### PR TITLE
ci(tenkz): validate compatibility evidence state

### DIFF
--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -1,22 +1,30 @@
 #!/usr/bin/env python3
-"""Pure validation for the tenkz compatibility policy and 1.0 soak log."""
+"""Pure validation for the tenkz compatibility policy and 1.0 evidence log.
+
+Repository and GitHub access are deliberately injected.  This module owns the
+closed grammar, immutable-evidence contracts, and attempt state machine; a
+stacked integration layer resolves the external facts.
+"""
 
 from __future__ import annotations
 
 import re
 import tomllib
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
-from typing import Callable
+from datetime import datetime, timezone
+from typing import Callable, Collection
 
 
-SOAK_MARKER = "<!-- tenkz-soak-entries: append below; do not edit preceding bytes -->"
-PREREQUISITES = ["#5086", "#4699", "#4162", "#4703", "#4708", "#4163"]
+SOAK_MARKER = "<!-- tenkz-soak-entries: append below only while enforcement=armed -->"
 FREEZE_TAG_RE = re.compile(r"tenkz-v0\.9\.(?:0|[1-9][0-9]*)")
+FINAL_TAG = "tenkz-v1.0.0"
 SHA_RE = re.compile(r"[0-9a-f]{40}")
 ENTRY_ID_RE = re.compile(r"S1-[0-9]{4}")
+PR_REF_RE = re.compile(r"#[1-9][0-9]*")
+ISSUE_REF_RE = PR_REF_RE
 IDENTITY_RE = re.compile(r"github:[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?")
-UTC_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
+LOGIN_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?")
+
 ENTRY_KINDS = {
     "freeze",
     "work",
@@ -26,44 +34,65 @@ ENTRY_KINDS = {
     "correction",
     "sign-off",
 }
+WORK_CLASSES = ("formalization-or-blueprint", "rmp-benchmark")
 TRIAGE = {"fix-compatible", "defer-to-2.0", "breaking-required"}
 SURFACES = {"tex-api", "tnlog"}
+RESET_CAUSES = {"breaking-required", "record-invalid"}
 
 EXPECTED_POLICY = {
     "policy": {
         "schema": 1,
+        "enforcement": "pending",
+        "enforcement_transition": "pending-to-armed",
         "tag_namespace": "tenkz-v*",
         "repository_tag_namespace": "v*",
         "freeze_tag_pattern": "tenkz-v0.9.PATCH",
         "freeze_tag_kind": "annotated",
-        "soak_days": 28,
-        "event_format_implementation": "pending",
+        "required_distinct_work_prs": 2,
+        "work_classes": list(WORK_CLASSES),
+        "one_class_per_work_pr": True,
+        "work_excluded_paths": ["TNLean/Archive/**"],
         "event_format_owners": ["#4162", "#4703"],
         "soak_blocker_chain": [
             ["#5086", "#4699", "#4162"],
             ["#4703", "#4708", "#4163"],
         ],
-        "deprecation_removal": "next-major",
+        "deprecation_removal": "not-before-next-major",
         "tombstone_reuse": False,
-        "frozen_twin_scope": "library-or-package-entry-point",
+        "frozen_twin_scope": "library-entry-point-in-same-package",
         "frozen_twin_lifetime": "permanent",
         "frozen_twin_precedent": "quantikz/quantikz2",
         "maintainer_identity": "github:lionsr",
         "signer_identity_scheme": "github:lowercase-login",
+        "tag_immutability": "github-ruleset-no-update-delete-or-bypass",
+        "release_manifest_pattern": "docs/tenkz/releases/TAG.toml",
+        "release_package_metadata": "tex/tenkz/tenkz.sty",
+        "release_manual": "docs/tenkz/manual2.tex",
+        "release_change_record": "docs/tenkz/CHANGES.md",
+        "release_event_format": "docs/tenkz/TNLOG.md",
+        "release_test_inventory": "tests/tenkz/release-tests.toml",
+        "release_test_inventory_sha256": "pending",
+        "release_test_code_root": "scripts",
+        "release_test_code_tree": "pending",
+        "release_test_support_root": "tests/tenkz/release-support",
+        "release_test_support_tree": "pending",
+        "release_test_data_roots": ["tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"],
+        "release_test_dependency_contract": "pinned-code-support-declared-subject-data",
+        "release_test_protocol": "hermetic-repository-view-no-shell-or-network",
+    },
+    "event_format": {
+        "reader_accepts": "same-major-any-minor",
+        "unknown_optional_fields": "ignore",
+        "unknown_event_kinds": "explicitly-ignorable-only",
+        "non_ignorable_change": "major",
     },
     "compatibility": {
-        "patch": {
-            "tex_api": "backward-compatible-fix",
-            "tnlog": "byte-stable",
-        },
+        "patch": {"tex_api": "backward-compatible-fix", "tnlog": "byte-stable"},
         "minor": {
             "tex_api": "backward-compatible-addition",
             "tnlog": "additive-versioned",
         },
-        "major": {
-            "tex_api": "breaking-change",
-            "tnlog": "breaking-versioned",
-        },
+        "major": {"tex_api": "breaking-change", "tnlog": "breaking-versioned"},
     },
 }
 
@@ -71,41 +100,43 @@ EXPECTED_SOAK = {
     "soak": {
         "schema": 1,
         "policy": "docs/tenkz/DESIGN.md",
+        "enforcement": "pending",
+        "enforcement_transition": "pending-to-armed",
+        "policy_sha256": "pending",
+        "armed_by_pr": "pending",
         "append_only": True,
-        "minimum_days": 28,
-        "normal_work_windows": 4,
-        "required_prerequisites": PREREQUISITES,
+        "append_only_from": "armed",
+        "ordering_anchor": "freeze-record-pr-merged-at",
+        "ancestry_anchor": "freeze-record-pr-merge-commit",
+        "work_anchor": "work-pr-merged-at",
         "freeze_tag_pattern": "tenkz-v0.9.PATCH",
         "freeze_tag_kind": "annotated",
         "release_tag": "tenkz-v1.0.0",
-        "maintainer_identity": "github:lionsr",
-        "signer_identity_scheme": "github:lowercase-login",
     }
 }
 
-COMMON_FIELDS = {"id", "kind", "date", "author", "attempt"}
+COMMON_FIELDS = {"id", "kind", "record_pr", "attempt"}
 FIELDS_BY_KIND = {
     "freeze": COMMON_FIELDS
     | {
-        "freeze_sha",
+        "source_pr",
+        "source_sha",
         "freeze_tag_object",
         "freeze_tag",
-        "freeze_tagger_utc",
         "prerequisites",
         "evidence",
     },
-    "work": COMMON_FIELDS
-    | {"work_sha", "work_committed_utc", "summary", "evidence"},
+    "work": COMMON_FIELDS | {"work_pr", "class", "summary", "evidence"},
     "friction": COMMON_FIELDS | {"surface", "triage", "summary", "evidence"},
     "resolution": COMMON_FIELDS | {"friction", "summary", "evidence"},
-    "reset": COMMON_FIELDS | {"friction", "reason", "evidence"},
+    "reset": COMMON_FIELDS | {"cause", "target", "reason", "evidence"},
     "correction": COMMON_FIELDS | {"target", "summary", "evidence"},
     "sign-off": COMMON_FIELDS
     | {
         "freeze",
-        "freeze_sha",
+        "source_sha",
+        "release_prep_pr",
         "release_tag",
-        "maintainer",
         "reviewer",
         "work_evidence",
         "decision",
@@ -114,24 +145,267 @@ FIELDS_BY_KIND = {
 
 
 class PolicyError(ValueError):
-    """A compatibility policy or soak record is invalid."""
+    """A compatibility policy or evidence record is invalid."""
+
+
+@dataclass(frozen=True)
+class ReviewEvidence:
+    """One review from complete changed-review history."""
+
+    login: str | None
+    state: str | None
+    submitted_at: datetime | None
+    commit_oid: str | None
+    dismissed: bool | None = False
+
+
+@dataclass(frozen=True)
+class PullRequestEvidence:
+    """GitHub facts plus Git checks for one PR relative to the requested anchor."""
+
+    in_repository: bool | None
+    base_ref_name: str | None
+    author_login: str | None
+    head_oid: str | None
+    merged: bool | None
+    merged_at: datetime | None = None
+    merged_by_login: str | None = None
+    merge_commit_oid: str | None = None
+    reviews: tuple[ReviewEvidence, ...] | None = None
+    reviews_complete: bool | None = None
+    integration_reachable_from_main: bool | None = None
+    integration_tree_matches_head: bool | None = None
+    integration_strict_descendant_of_anchor: bool | None = None
+
+
+@dataclass(frozen=True)
+class RecordDiffEvidence:
+    """Immutable ledger and release-payload facts for an entry record PR."""
+
+    validated_pr_ref: str | None
+    validated_head_oid: str | None
+    complete: bool | None
+    unique_merge_base: bool | None
+    integration_parent_count: int | None
+    base_lacks_entry: bool | None
+    appends_exact_entry: bool | None
+    pinned_prefix_unchanged: bool | None
+    other_entries_unchanged: bool | None
+    no_other_path_changes: bool | None
+    candidate_main_is_ancestor_of_head: bool | None
+    integration_parent_is_ancestor_of_head: bool | None
+    integration_second_parent_matches_head: bool | None
+    source_to_head_is_exact_freeze_append: bool | None = None
+    candidate_main_tip_is_source: bool | None = None
+    integration_parent_is_source: bool | None = None
+    candidate_main_tip_is_release_integration: bool | None = None
+    integration_parent_is_release_integration: bool | None = None
+    validated_release_integration: str | None = None
+    validated_work_integrations: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class WorkDiffEvidence:
+    """Facts derived from the complete immutable merge-base-to-head work diff."""
+
+    complete: bool | None
+    integration_parent_count: int | None
+    unique_merge_base: bool | None
+    integration_parent_is_ancestor_of_head: bool | None
+    integration_second_parent_matches_head: bool | None
+    policy_paths_untouched: bool | None
+    excluded_paths_applied: bool | None
+    semantic_add_or_modify_classes: tuple[str, ...] | None
+    semantic_lean_changed: bool | None
+    semantic_blueprint_changed: bool | None
+    semantic_rmp_changed: bool | None
+    lean_modules_build: bool | None
+    proof_integrity_clean: bool | None
+    blueprint_checkdecls_passed: bool | None
+    blueprint_build_passed: bool | None
+    rmp_targets_resolved: bool | None
+    rmp_stages_complete: bool | None
+    rmp_checks_passed: bool | None
+
+
+@dataclass(frozen=True)
+class ReleaseContract:
+    """Policy-owned paths, inventory digest, and execution protocol."""
+
+    manifest_pattern: str
+    package_metadata: str
+    manual: str
+    change_record: str
+    event_format: str
+    test_inventory: str
+    test_inventory_sha256: str
+    test_code_root: str
+    test_code_tree: str
+    test_support_root: str
+    test_support_tree: str
+    test_data_roots: tuple[str, ...]
+    test_dependency_contract: str
+    test_protocol: str
+
+    def manifest_path(self, tag: str) -> str:
+        return self.manifest_pattern.replace("TAG", tag)
+
+    def release_varying_paths(self, tag: str) -> tuple[str, ...]:
+        return (
+            self.manifest_path(tag),
+            self.package_metadata,
+            self.manual,
+            self.change_record,
+            self.event_format,
+        )
+
+
+@dataclass(frozen=True)
+class ReleasePayloadEvidence:
+    """Complete policy-owned payload and deterministic test facts for one tree."""
+
+    validated_tree_oid: str | None
+    validated_tag: str | None
+    validated_contract: ReleaseContract | None
+    complete: bool | None
+    manifest_path: str | None
+    regular_distinct_paths: bool | None
+    manifest_contract_valid: bool | None
+    artifact_declarations_agree: bool | None
+    inventory_digest_matches: bool | None
+    inventory_contract_valid: bool | None
+    test_code_tree_matches: bool | None
+    test_support_tree_matches: bool | None
+    inventory_data_paths_within_mutable_roots: bool | None
+    executable_dependencies_within_code_tree: bool | None
+    acceptance_dependencies_within_support_tree: bool | None
+    subject_data_cannot_reduce_coverage: bool | None
+    hermetic_execution_contract_valid: bool | None
+    payload_execution_receipts_complete_and_matching: bool | None
+    test_execution_complete: bool | None
+    compatibility_tests_passed: bool | None
+    payload_blob_oids: tuple[str, ...] | None
+
+
+@dataclass(frozen=True)
+class ReleasePrepEvidence:
+    """Exact-head, complete-diff, manifest, and payload facts for release prep."""
+
+    validated_pr_ref: str | None
+    validated_head_oid: str | None
+    validated_manifest_path: str | None
+    validated_changed_paths: tuple[str, ...] | None
+    validated_work_integrations: tuple[str, ...] | None
+    complete: bool | None
+    integration_parent_count: int | None
+    unique_merge_base: bool | None
+    integration_parent_is_ancestor_of_head: bool | None
+    integration_second_parent_matches_head: bool | None
+    integration_descends_from_work_integrations: bool | None
+    exact_release_varying_path_diff: bool | None
 
 
 @dataclass(frozen=True)
 class TagEvidence:
-    object_id: str
-    object_type: str
-    commit: str
-    tagger_utc: datetime | None
-    reachable_from_main: bool
+    object_id: str | None
+    object_type: str | None
+    commit: str | None
+    patch_is_fresh_for_attempt: bool | None = None
+    exists: bool | None = True
+    validated_entry_id: str | None = None
+    validated_record_pr: str | None = None
+    commit_is_validated_record_integration: bool | None = None
 
 
 @dataclass(frozen=True)
-class CommitEvidence:
-    object_type: str
-    committed_utc: datetime | None
-    reachable_from_main: bool
-    descends_from_freeze: bool
+class AuditEvidence:
+    """Complete current-validity result and its immutable-ledger boundary.
+
+    Replay callbacks reconstruct integration-time history (or the exact final
+    unmerged candidate).  This separate channel records every entry that fails
+    the current snapshot, so later drift is queued only after the fixed audit
+    boundary and cannot block intervening history.
+    """
+
+    boundary_entry_id: str | None
+    invalid_entries: tuple[str, ...] | None
+    snapshot_complete: bool | None
+    validation_target_exact: bool | None
+
+
+@dataclass(frozen=True)
+class ActivationDiffEvidence:
+    """Exact candidate diff and pinned-value checks for the arming PR."""
+
+    validated_pr_ref: str | None
+    validated_head_oid: str | None
+    complete: bool | None
+    candidate_main_is_ancestor_of_head: bool | None
+    unique_merge_base: bool | None
+    exact_seven_scalar_replacements: bool | None
+    inventory_digest_matches: bool | None
+    test_code_tree_matches: bool | None
+    test_support_tree_matches: bool | None
+    inventory_data_paths_within_mutable_roots: bool | None
+    executable_dependencies_within_code_tree: bool | None
+    acceptance_dependencies_within_support_tree: bool | None
+    subject_data_cannot_reduce_coverage: bool | None
+    hermetic_execution_contract_valid: bool | None
+    supervisor_self_test_receipt_valid: bool | None
+    policy_digest_matches: bool | None
+    ledger_prefix_matches: bool | None
+
+
+@dataclass(frozen=True)
+class TagProtectionEvidence:
+    """Complete current repository and organization tag-ruleset state.
+
+    Ruleset administrators and the GitHub control plane are the policy's
+    trusted boundary; these fields describe only the observable current
+    snapshot and make no historical-protection claim.
+    """
+
+    repository_rulesets_complete: bool | None
+    organization_rulesets_complete: bool | None
+    credential_has_write_visibility: bool | None
+    details_unredacted: bool | None
+    namespace_fully_covered: bool | None
+    applicable_rulesets_active: bool | None
+    updates_forbidden: bool | None
+    deletions_forbidden: bool | None
+    bypass_actors: tuple[str, ...] | None
+    unambiguous: bool | None
+
+
+@dataclass(frozen=True)
+class IssueEvidence:
+    in_repository: bool | None
+    closed: bool | None
+    closed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class RecordInspection:
+    """Common record state after candidate or post-merge provenance checks."""
+
+    author: str
+    pending: bool
+    merged_at: datetime | None
+    integration: str | None
+    invalid_reasons: tuple[str, ...]
+
+
+ResolveReplayPullRequest = Callable[[str, str | None], PullRequestEvidence]
+ResolveReplayActivationDiff = Callable[[str], ActivationDiffEvidence]
+ResolveReplayRecordDiff = Callable[[str, str, str | None], RecordDiffEvidence]
+ResolveReplayWorkDiff = Callable[[str], WorkDiffEvidence]
+ResolveReplayReleasePrep = Callable[
+    [str, tuple[str, ...], tuple[str, ...]], ReleasePrepEvidence
+]
+ResolveReplayReleasePayload = Callable[[str, str, ReleaseContract], ReleasePayloadEvidence]
+ResolveReplayFreezeTag = Callable[[str], TagEvidence]
+ResolveCurrentFinalTag = Callable[[str], TagEvidence]
+ResolveReplayIssue = Callable[[str], IssueEvidence]
 
 
 def require(condition: bool, message: str) -> None:
@@ -158,19 +432,52 @@ def parse_toml_block(text: str, label: str) -> dict:
     return parsed
 
 
+def validate_policy_mapping(policy: dict) -> dict:
+    """Validate the closed pending policy or its four-field armed form."""
+
+    root = policy.get("policy")
+    require(isinstance(root, dict), "tenkz-policy-v1 lacks [policy]")
+    enforcement = root.get("enforcement")
+    require(enforcement in {"pending", "armed"}, "policy enforcement state is invalid")
+    normalized = {**policy, "policy": {**root}}
+    if enforcement == "armed":
+        inventory_digest = root.get("release_test_inventory_sha256")
+        test_code_tree = root.get("release_test_code_tree")
+        test_support_tree = root.get("release_test_support_tree")
+        require(
+            isinstance(inventory_digest, str)
+            and re.fullmatch(r"[0-9a-f]{64}", inventory_digest) is not None,
+            "armed policy inventory digest is invalid",
+        )
+        require(
+            isinstance(test_code_tree, str) and SHA_RE.fullmatch(test_code_tree) is not None,
+            "armed policy test-code tree is invalid",
+        )
+        require(
+            isinstance(test_support_tree, str)
+            and SHA_RE.fullmatch(test_support_tree) is not None,
+            "armed policy test-support tree is invalid",
+        )
+        normalized["policy"]["enforcement"] = "pending"
+        normalized["policy"]["release_test_inventory_sha256"] = "pending"
+        normalized["policy"]["release_test_code_tree"] = "pending"
+        normalized["policy"]["release_test_support_tree"] = "pending"
+    require(normalized == EXPECTED_POLICY, "tenkz-policy-v1 differs from the signed policy")
+    return policy
+
+
 def validate_policy_text(text: str) -> dict:
     required_headings = {
         "## Compatibility ownership",
         "## Package versions",
         "## Deprecations, tombstones, and frozen twins",
         "## Release tags",
-        "## The 1.0 freeze and soak",
+        "## The 1.0 freeze and evidence gate",
     }
     missing = sorted(heading for heading in required_headings if heading not in text)
     require(not missing, f"DESIGN.md lacks required section(s): {', '.join(missing)}")
     policy = parse_toml_block(text, "tenkz-policy-v1")
-    require(policy == EXPECTED_POLICY, "tenkz-policy-v1 differs from the signed policy")
-    return policy
+    return validate_policy_mapping(policy)
 
 
 def parse_entry_block(block: str, index: int) -> dict:
@@ -184,14 +491,40 @@ def parse_entry_block(block: str, index: int) -> dict:
     return entry
 
 
+def validate_soak_mapping(soak: dict) -> dict:
+    """Validate the closed pending schema or its three-field armed form."""
+
+    root = soak.get("soak")
+    require(isinstance(root, dict), "tenkz-soak-v1 lacks [soak]")
+    enforcement = root.get("enforcement")
+    require(enforcement in {"pending", "armed"}, "soak enforcement state is invalid")
+    normalized = {**soak, "soak": {**root}}
+    if enforcement == "armed":
+        policy_digest = root.get("policy_sha256")
+        armed_by_pr = root.get("armed_by_pr")
+        require(
+            isinstance(policy_digest, str)
+            and re.fullmatch(r"[0-9a-f]{64}", policy_digest) is not None,
+            "armed soak policy digest is invalid",
+        )
+        require(
+            isinstance(armed_by_pr, str) and PR_REF_RE.fullmatch(armed_by_pr) is not None,
+            "armed soak activation PR is invalid",
+        )
+        normalized["soak"]["enforcement"] = "pending"
+        normalized["soak"]["policy_sha256"] = "pending"
+        normalized["soak"]["armed_by_pr"] = "pending"
+    require(normalized == EXPECTED_SOAK, "tenkz-soak-v1 differs from the signed schema")
+    return soak
+
+
 def parse_soak_text(text: str) -> tuple[dict, list[dict]]:
-    soak = parse_toml_block(text, "tenkz-soak-v1")
-    require(soak == EXPECTED_SOAK, "tenkz-soak-v1 differs from the signed schema")
+    soak = validate_soak_mapping(parse_toml_block(text, "tenkz-soak-v1"))
     require(text.count(SOAK_MARKER) == 1, "SOAK-1.0.md must contain one append marker")
     prefix, tail = text.split(SOAK_MARKER, 1)
     require(
         not fenced_blocks(prefix, "tenkz-soak-entry-v1"),
-        "soak entries must appear after the append marker",
+        "evidence entries must appear after the append marker",
     )
 
     pattern = re.compile(
@@ -203,11 +536,14 @@ def parse_soak_text(text: str) -> tuple[dict, list[dict]]:
     for index, match in enumerate(pattern.finditer(tail), start=1):
         require(
             not tail[cursor : match.start()].strip(),
-            "only soak entry blocks may follow the append marker",
+            "only evidence entry blocks may follow the append marker",
         )
         entries.append(parse_entry_block(match.group(1), index))
         cursor = match.end()
-    require(not tail[cursor:].strip(), "only soak entry blocks may follow the append marker")
+    require(
+        not tail[cursor:].strip(),
+        "only evidence entry blocks may follow the append marker",
+    )
     return soak, entries
 
 
@@ -219,373 +555,1567 @@ def nonempty_string(value: object, field: str, entry_id: str) -> str:
     return value
 
 
-def string_list(value: object, field: str, entry_id: str) -> list[str]:
+def closed_string_list(value: object, field: str, entry_id: str) -> list[str]:
     require(
         isinstance(value, list)
         and all(isinstance(item, str) and item.strip() for item in value),
         f"{entry_id} field {field} must be a list of nonempty strings",
     )
+    require(len(value) == len(set(value)), f"{entry_id} field {field} has duplicates")
     return value
 
 
-def iso_date(value: object, entry_id: str) -> date:
-    text = nonempty_string(value, "date", entry_id)
-    try:
-        parsed = date.fromisoformat(text)
-    except ValueError as error:
-        raise PolicyError(f"{entry_id} date must use YYYY-MM-DD") from error
-    require(parsed.isoformat() == text, f"{entry_id} date must use YYYY-MM-DD")
-    return parsed
+def sha(value: object, field: str, entry_id: str) -> str:
+    result = nonempty_string(value, field, entry_id)
+    require(SHA_RE.fullmatch(result) is not None, f"{entry_id} has invalid {field}")
+    return result
 
 
-def iso_utc(value: object, field: str, entry_id: str) -> datetime:
-    text = nonempty_string(value, field, entry_id)
-    require(UTC_RE.fullmatch(text) is not None, f"{entry_id} {field} must use UTC seconds")
-    try:
-        return datetime.strptime(text, "%Y-%m-%dT%H:%M:%SZ").replace(
-            tzinfo=timezone.utc
-        )
-    except ValueError as error:
-        raise PolicyError(f"{entry_id} {field} is not a real UTC timestamp") from error
+def pr_ref(value: object, field: str, entry_id: str) -> str:
+    result = nonempty_string(value, field, entry_id)
+    require(PR_REF_RE.fullmatch(result) is not None, f"{entry_id} has invalid {field}")
+    return result
 
 
-def normalized_identity(value: object, field: str, entry_id: str) -> str:
-    identity = nonempty_string(value, field, entry_id)
+def issue_ref(value: object, field: str, entry_id: str) -> str:
+    result = nonempty_string(value, field, entry_id)
+    require(ISSUE_REF_RE.fullmatch(result) is not None, f"{entry_id} has invalid {field}")
+    return result
+
+
+def identity(value: object, field: str, entry_id: str) -> str:
+    result = nonempty_string(value, field, entry_id)
     require(
-        IDENTITY_RE.fullmatch(identity) is not None,
+        IDENTITY_RE.fullmatch(result) is not None,
         f"{entry_id} {field} must use github:lowercase-login",
     )
-    return identity
+    return result
 
 
-def validate_entry_shape(entry: dict, index: int) -> tuple[str, str, date, int]:
+def normalized_login(value: object, field: str) -> str:
+    require(isinstance(value, str) and bool(value), f"{field} is missing")
+    result = value.lower()
+    require(LOGIN_RE.fullmatch(result) is not None, f"{field} is malformed")
+    return result
+
+
+def utc_instant(value: object, field: str) -> datetime:
+    require(isinstance(value, datetime), f"{field} is missing or malformed")
+    require(
+        value.tzinfo is not None and value.utcoffset() is not None,
+        f"{field} must be timezone-aware",
+    )
+    return value.astimezone(timezone.utc)
+
+
+def policy_rules(
+    policy: dict,
+) -> tuple[int, tuple[str, ...], tuple[str, ...], list[str], ReleaseContract, str]:
+    validate_policy_mapping(policy)
+    root = policy.get("policy")
+    require(isinstance(root, dict), "policy evidence lacks [policy]")
+    count = root.get("required_distinct_work_prs")
+    classes = root.get("work_classes")
+    require(count == 2, "policy must require exactly two distinct work PRs")
+    require(classes == list(WORK_CLASSES), "policy has the wrong work classes")
+    require(root.get("one_class_per_work_pr") is True, "policy must assign one class per PR")
+    excluded_paths = root.get("work_excluded_paths")
+    require(
+        excluded_paths == ["TNLean/Archive/**"],
+        "policy has the wrong work-excluded paths",
+    )
+    chain = root.get("soak_blocker_chain")
+    require(
+        isinstance(chain, list)
+        and all(isinstance(row, list) for row in chain)
+        and all(isinstance(item, str) for row in chain for item in row),
+        "policy has a malformed blocker chain",
+    )
+    prerequisites = [item for row in chain for item in row]
+    maintainer_identity = identity(
+        root.get("maintainer_identity"),
+        "maintainer_identity",
+        "policy",
+    )
+    require(
+        root.get("signer_identity_scheme") == "github:lowercase-login",
+        "policy has the wrong signer identity scheme",
+    )
+    require(
+        root.get("tag_immutability") == "github-ruleset-no-update-delete-or-bypass",
+        "policy has the wrong tag-immutability model",
+    )
+    contract = ReleaseContract(
+        manifest_pattern=str(root.get("release_manifest_pattern", "")),
+        package_metadata=str(root.get("release_package_metadata", "")),
+        manual=str(root.get("release_manual", "")),
+        change_record=str(root.get("release_change_record", "")),
+        event_format=str(root.get("release_event_format", "")),
+        test_inventory=str(root.get("release_test_inventory", "")),
+        test_inventory_sha256=str(root.get("release_test_inventory_sha256", "")),
+        test_code_root=str(root.get("release_test_code_root", "")),
+        test_code_tree=str(root.get("release_test_code_tree", "")),
+        test_support_root=str(root.get("release_test_support_root", "")),
+        test_support_tree=str(root.get("release_test_support_tree", "")),
+        test_data_roots=tuple(root.get("release_test_data_roots", ())),
+        test_dependency_contract=str(root.get("release_test_dependency_contract", "")),
+        test_protocol=str(root.get("release_test_protocol", "")),
+    )
+    require(
+        (
+            contract.manifest_pattern,
+            contract.package_metadata,
+            contract.manual,
+            contract.change_record,
+            contract.event_format,
+            contract.test_inventory,
+            contract.test_code_root,
+            contract.test_support_root,
+            contract.test_data_roots,
+            contract.test_dependency_contract,
+            contract.test_protocol,
+        )
+        == (
+            "docs/tenkz/releases/TAG.toml",
+            "tex/tenkz/tenkz.sty",
+            "docs/tenkz/manual2.tex",
+            "docs/tenkz/CHANGES.md",
+            "docs/tenkz/TNLOG.md",
+            "tests/tenkz/release-tests.toml",
+            "scripts",
+            "tests/tenkz/release-support",
+            ("tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"),
+            "pinned-code-support-declared-subject-data",
+            "hermetic-repository-view-no-shell-or-network",
+        ),
+        "policy has the wrong release-payload contract",
+    )
+    enforcement = root.get("enforcement")
+    require(enforcement in {"pending", "armed"}, "policy enforcement state is invalid")
+    if enforcement == "pending":
+        require(
+            contract.test_inventory_sha256 == "pending"
+            and contract.test_code_tree == "pending"
+            and contract.test_support_tree == "pending",
+            "pending policy has activated release-test pins",
+        )
+    else:
+        require(
+            re.fullmatch(r"[0-9a-f]{64}", contract.test_inventory_sha256) is not None,
+            "armed policy inventory digest is invalid",
+        )
+        require(
+            SHA_RE.fullmatch(contract.test_code_tree) is not None,
+            "armed policy test-code tree is invalid",
+        )
+        require(
+            SHA_RE.fullmatch(contract.test_support_tree) is not None,
+            "armed policy test-support tree is invalid",
+        )
+    return (
+        count,
+        tuple(classes),
+        tuple(excluded_paths),
+        prerequisites,
+        contract,
+        maintainer_identity.removeprefix("github:"),
+    )
+
+
+def validate_entry_shape(entry: dict, index: int) -> tuple[str, str, int, str]:
     expected_id = f"S1-{index:04d}"
     entry_id = nonempty_string(entry.get("id"), "id", expected_id)
     require(ENTRY_ID_RE.fullmatch(entry_id) is not None, f"invalid entry id {entry_id}")
     require(entry_id == expected_id, f"expected entry id {expected_id}, found {entry_id}")
     kind = nonempty_string(entry.get("kind"), "kind", entry_id)
     require(kind in ENTRY_KINDS, f"{entry_id} has unknown kind {kind}")
-    require(
-        set(entry) == FIELDS_BY_KIND[kind],
-        f"{entry_id} {kind} fields differ from the schema",
-    )
-    entry_date = iso_date(entry["date"], entry_id)
-    normalized_identity(entry["author"], "author", entry_id)
+    require(set(entry) == FIELDS_BY_KIND[kind], f"{entry_id} {kind} fields differ from schema")
+    record_pr = pr_ref(entry["record_pr"], "record_pr", entry_id)
     attempt = entry["attempt"]
     require(
         isinstance(attempt, int) and not isinstance(attempt, bool) and attempt > 0,
         f"{entry_id} attempt must be a positive integer",
     )
-    return entry_id, kind, entry_date, attempt
+    return entry_id, kind, attempt, record_pr
+
+
+def validate_pr_core(pr: PullRequestEvidence, pr_name: str) -> tuple[str, str]:
+    require(pr.in_repository is True, f"{pr_name} is not in this repository")
+    require(pr.base_ref_name == "main", f"{pr_name} does not target main")
+    author = normalized_login(pr.author_login, f"{pr_name} author")
+    head = pr.head_oid
+    require(
+        isinstance(head, str) and SHA_RE.fullmatch(head) is not None,
+        f"{pr_name} head is invalid",
+    )
+    require(isinstance(pr.merged, bool), f"{pr_name} merged state is missing")
+    return author, head
+
+
+def validate_merged_pr(
+    pr: PullRequestEvidence,
+    pr_name: str,
+    *,
+    require_descendant: bool,
+    require_tree: bool,
+) -> tuple[datetime, str]:
+    require(pr.merged is True, f"{pr_name} is not merged")
+    merged_at = utc_instant(pr.merged_at, f"{pr_name} mergedAt")
+    integration = pr.merge_commit_oid
+    require(
+        isinstance(integration, str) and SHA_RE.fullmatch(integration) is not None,
+        f"{pr_name} merge commit is invalid",
+    )
+    require(
+        pr.integration_reachable_from_main is True,
+        f"{pr_name} integration is not reachable from main",
+    )
+    if require_tree:
+        require(
+            pr.integration_tree_matches_head is True,
+            f"{pr_name} integration tree differs from head",
+        )
+    if require_descendant:
+        require(
+            pr.integration_strict_descendant_of_anchor is True,
+            f"{pr_name} integration is not a strict descendant of its anchor",
+        )
+    return merged_at, integration
+
+
+def require_candidate_pr(pr: PullRequestEvidence, pr_name: str) -> None:
+    require(pr.merged is False, f"{pr_name} candidate state is inconsistent")
+    require(pr.merged_at is None, f"{pr_name} unmerged candidate has mergedAt")
+    require(pr.merge_commit_oid is None, f"{pr_name} unmerged candidate has a merge commit")
+    require(pr.merged_by_login is None, f"{pr_name} unmerged candidate has mergedBy")
+
+
+def inspect_record_pr(
+    pr: PullRequestEvidence,
+    diff: RecordDiffEvidence,
+    *,
+    entry_id: str,
+    record_ref: str,
+    require_descendant: bool,
+) -> RecordInspection:
+    """Check common self-reference facts, classifying merged failures for reset.
+
+    Candidate failures are ordinary validation errors: a not-yet-merged block
+    must actually be under validation on its declared PR and exact head.
+    Once GitHub reports the declared PR merged, a failed common identity,
+    reachability, tree, or provenance predicate becomes ``record-invalid``
+    state so that the next non-correction record can be the required reset.
+    """
+
+    require(isinstance(pr.merged, bool), f"{record_ref} merged state is missing")
+    pending = pr.merged is False
+    errors: list[str] = []
+
+    def check(condition: bool, message: str) -> None:
+        if condition:
+            return
+        if pending:
+            raise PolicyError(message)
+        errors.append(message)
+
+    check(pr.in_repository is True, f"{record_ref} is not in this repository")
+    check(pr.base_ref_name == "main", f"{record_ref} does not target main")
+    try:
+        author = normalized_login(pr.author_login, f"{record_ref} author")
+    except PolicyError as error:
+        if pending:
+            raise
+        errors.append(str(error))
+        author = ""
+    head = pr.head_oid
+    head_valid = isinstance(head, str) and SHA_RE.fullmatch(head) is not None
+    check(head_valid, f"{record_ref} head is invalid")
+
+    check(diff.complete is True, f"{entry_id} record diff is incomplete")
+    check(diff.unique_merge_base is True, f"{entry_id} record merge base is ambiguous")
+    check(diff.validated_pr_ref == record_ref, f"{entry_id} was validated on another PR")
+    check(
+        head_valid and diff.validated_head_oid == head,
+        f"{entry_id} was not validated at the declared exact head",
+    )
+    check(diff.base_lacks_entry is True, f"{entry_id} record base already has the entry")
+    check(diff.appends_exact_entry is True, f"{entry_id} record does not append exactly itself")
+    check(diff.pinned_prefix_unchanged is True, f"{entry_id} record changes pinned bytes")
+    check(diff.other_entries_unchanged is True, f"{entry_id} record changes another entry")
+    check(diff.no_other_path_changes is True, f"{entry_id} record changes another path")
+
+    if pending:
+        check(
+            diff.candidate_main_is_ancestor_of_head is True,
+            f"{entry_id} candidate main is not an ancestor of the record head",
+        )
+        require_candidate_pr(pr, record_ref)
+        return RecordInspection(author, True, None, None, ())
+
+    try:
+        merged_at = utc_instant(pr.merged_at, f"{record_ref} mergedAt")
+    except PolicyError as error:
+        errors.append(str(error))
+        merged_at = None
+    integration = pr.merge_commit_oid
+    integration_valid = isinstance(integration, str) and SHA_RE.fullmatch(integration) is not None
+    check(integration_valid, f"{record_ref} merge commit is invalid")
+    check(
+        diff.integration_parent_count in {1, 2},
+        f"{record_ref} integration has an invalid parent count",
+    )
+    check(
+        diff.integration_parent_is_ancestor_of_head is True,
+        f"{record_ref} integration parent is not an ancestor of the record head",
+    )
+    if diff.integration_parent_count == 2:
+        check(
+            diff.integration_second_parent_matches_head is True,
+            f"{record_ref} integration second parent differs from the record head",
+        )
+    check(
+        pr.integration_reachable_from_main is True,
+        f"{record_ref} integration is not reachable from main",
+    )
+    check(
+        pr.integration_tree_matches_head is True,
+        f"{record_ref} integration tree differs from head",
+    )
+    if require_descendant:
+        check(
+            pr.integration_strict_descendant_of_anchor is True,
+            f"{record_ref} integration is not a strict descendant of its anchor",
+        )
+    return RecordInspection(
+        author,
+        False,
+        merged_at,
+        integration if integration_valid else None,
+        tuple(errors),
+    )
+
+
+def latest_effective_reviews(
+    pr: PullRequestEvidence,
+    pr_name: str,
+) -> dict[str, ReviewEvidence]:
+    require(pr.reviews_complete is True, f"{pr_name} review pagination is incomplete")
+    require(isinstance(pr.reviews, tuple), f"{pr_name} review history is missing")
+    latest: dict[str, ReviewEvidence] = {}
+    for review in pr.reviews:
+        require(isinstance(review.dismissed, bool), f"{pr_name} review dismissal is missing")
+        reviewer = normalized_login(review.login, f"{pr_name} reviewer")
+        state = review.state
+        require(isinstance(state, str) and bool(state), f"{pr_name} review state is missing")
+        submitted = utc_instant(review.submitted_at, f"{pr_name} review submittedAt")
+        commit_oid = review.commit_oid
+        require(
+            isinstance(commit_oid, str) and SHA_RE.fullmatch(commit_oid) is not None,
+            f"{pr_name} review commit is invalid",
+        )
+        if review.dismissed or state not in {"APPROVED", "CHANGES_REQUESTED"}:
+            continue
+        prior = latest.get(reviewer)
+        if prior is not None:
+            prior_time = utc_instant(prior.submitted_at, f"{pr_name} review submittedAt")
+            require(submitted != prior_time, f"{pr_name} has ambiguous review ordering")
+            if submitted < prior_time:
+                continue
+        latest[reviewer] = review
+    return latest
+
+
+def require_independent_approval(
+    pr: PullRequestEvidence,
+    pr_name: str,
+    *,
+    author: str,
+    after: datetime | None = None,
+    before: datetime | None = None,
+    named_reviewer: str | None = None,
+    distinct_from: Collection[str] = (),
+) -> tuple[str, datetime]:
+    latest = latest_effective_reviews(pr, pr_name)
+    candidates = latest.items()
+    if named_reviewer is not None:
+        candidates = [(named_reviewer, latest.get(named_reviewer))]
+    for reviewer, review in candidates:
+        if review is None or reviewer == author or reviewer in distinct_from:
+            continue
+        submitted = utc_instant(review.submitted_at, f"{pr_name} review submittedAt")
+        if review.state != "APPROVED" or review.commit_oid != pr.head_oid:
+            continue
+        if after is not None and submitted <= after:
+            continue
+        if before is not None and submitted >= before:
+            continue
+        return reviewer, submitted
+    qualifier = f" by {named_reviewer}" if named_reviewer is not None else ""
+    raise PolicyError(f"{pr_name} lacks an independent exact-head approval{qualifier}")
+
+
+def validate_release_payload(
+    evidence: ReleasePayloadEvidence,
+    *,
+    tree_oid: str,
+    tag: str,
+    contract: ReleaseContract,
+    subject: str,
+) -> tuple[str, ...]:
+    """Validate one exact-tree payload and return its ordered blob identity."""
+
+    require(evidence.validated_tree_oid == tree_oid, f"{subject} used another payload tree")
+    require(evidence.validated_tag == tag, f"{subject} used another payload tag")
+    require(
+        evidence.validated_contract == contract,
+        f"{subject} used another release-payload contract",
+    )
+    require(evidence.complete is True, f"{subject} payload evidence is incomplete")
+    require(
+        evidence.manifest_path == contract.manifest_path(tag),
+        f"{subject} used another release manifest",
+    )
+    require(
+        evidence.regular_distinct_paths is True,
+        f"{subject} payload paths are not regular and distinct",
+    )
+    require(evidence.manifest_contract_valid is True, f"{subject} manifest is invalid")
+    require(
+        evidence.artifact_declarations_agree is True,
+        f"{subject} release artifacts disagree",
+    )
+    require(
+        evidence.inventory_digest_matches is True,
+        f"{subject} test-inventory digest differs from policy",
+    )
+    require(
+        evidence.inventory_contract_valid is True,
+        f"{subject} test inventory is invalid",
+    )
+    require(
+        evidence.test_code_tree_matches is True,
+        f"{subject} release-test code tree differs from policy",
+    )
+    require(
+        evidence.test_support_tree_matches is True,
+        f"{subject} release-test support tree differs from policy",
+    )
+    require(
+        evidence.inventory_data_paths_within_mutable_roots is True,
+        f"{subject} inventory data paths escape the mutable subject roots",
+    )
+    require(
+        evidence.executable_dependencies_within_code_tree is True,
+        f"{subject} executable dependency escapes the pinned code tree",
+    )
+    require(
+        evidence.acceptance_dependencies_within_support_tree is True,
+        f"{subject} acceptance dependency escapes the pinned support tree",
+    )
+    require(
+        evidence.subject_data_cannot_reduce_coverage is True,
+        f"{subject} subject data can reduce release-test coverage",
+    )
+    require(
+        evidence.hermetic_execution_contract_valid is True,
+        f"{subject} hermetic execution contract is invalid",
+    )
+    require(
+        evidence.payload_execution_receipts_complete_and_matching is True,
+        f"{subject} payload execution receipts are incomplete or mismatched",
+    )
+    require(
+        evidence.test_execution_complete is True,
+        f"{subject} release-test execution is incomplete",
+    )
+    require(
+        evidence.compatibility_tests_passed is True,
+        f"{subject} release compatibility tests did not pass",
+    )
+    blob_oids = evidence.payload_blob_oids
+    require(
+        isinstance(blob_oids, tuple)
+        and len(blob_oids) == 6
+        and all(isinstance(item, str) and SHA_RE.fullmatch(item) for item in blob_oids),
+        f"{subject} payload blob identity is missing",
+    )
+    return blob_oids
+
+
+def validate_tag_protection(evidence: TagProtectionEvidence) -> None:
+    """Require complete, unredacted, active protection with no bypass actor."""
+
+    require(
+        evidence.repository_rulesets_complete is True,
+        "repository ruleset pagination is incomplete",
+    )
+    require(
+        evidence.organization_rulesets_complete is True,
+        "organization ruleset pagination is incomplete",
+    )
+    require(
+        evidence.credential_has_write_visibility is True,
+        "ruleset credential lacks write-level visibility",
+    )
+    require(evidence.details_unredacted is True, "ruleset details are omitted or redacted")
+    require(
+        evidence.namespace_fully_covered is True,
+        "rulesets do not cover the complete tenkz tag namespace",
+    )
+    require(
+        evidence.applicable_rulesets_active is True,
+        "applicable tag rulesets are not active",
+    )
+    require(evidence.updates_forbidden is True, "tenkz tag updates are not forbidden")
+    require(evidence.deletions_forbidden is True, "tenkz tag deletions are not forbidden")
+    require(isinstance(evidence.bypass_actors, tuple), "ruleset bypass actors are unavailable")
+    require(not evidence.bypass_actors, "tenkz tag protection has a bypass actor")
+    require(evidence.unambiguous is True, "applicable tag protection is ambiguous")
 
 
 def validate_entries(
     entries: list[dict],
     *,
-    resolve_tag: Callable[[str], TagEvidence] | None = None,
-    resolve_commit: Callable[[str, str], CommitEvidence] | None = None,
-    now: datetime | None = None,
+    policy: dict = EXPECTED_POLICY,
+    soak: dict = EXPECTED_SOAK,
+    resolve_replay_pr: ResolveReplayPullRequest | None = None,
+    resolve_replay_activation_diff: ResolveReplayActivationDiff | None = None,
+    resolve_replay_record_diff: ResolveReplayRecordDiff | None = None,
+    resolve_replay_work_diff: ResolveReplayWorkDiff | None = None,
+    resolve_replay_release_prep: ResolveReplayReleasePrep | None = None,
+    resolve_replay_release_payload: ResolveReplayReleasePayload | None = None,
+    resolve_replay_freeze_tag: ResolveReplayFreezeTag | None = None,
+    resolve_current_final_tag: ResolveCurrentFinalTag | None = None,
+    resolve_replay_issue: ResolveReplayIssue | None = None,
+    audit: AuditEvidence | None = None,
+    tag_protection: TagProtectionEvidence | None = None,
 ) -> str:
-    current = now or datetime.now(timezone.utc)
-    require(current.tzinfo is not None, "current time must be timezone-aware")
-    current = current.astimezone(timezone.utc)
-    seen: dict[str, tuple[dict, date]] = {}
+    """Validate entry grammar, injected immutable facts, and attempt state.
+
+    Every ``resolve_replay_*`` callback supplies integration-time evidence, or
+    exact candidate evidence for the final unmerged record.  ``audit`` is the
+    separate complete current-validity snapshot, including the final entry in
+    the immutable prefix that existed when it started.  Current drift is never
+    substituted into replay callbacks; its ordered targets enter the state only
+    after that boundary.
+    """
+
+    (
+        required_work_count,
+        work_classes,
+        excluded_paths,
+        prerequisites,
+        release_contract,
+        maintainer_login,
+    ) = policy_rules(policy)
+    validate_soak_mapping(soak)
+    enforcement = policy["policy"]["enforcement"]
+    soak_root = soak["soak"]
+    require(
+        soak_root["enforcement"] == enforcement,
+        "policy and soak enforcement states disagree",
+    )
+    if enforcement == "pending":
+        require(not entries, "evidence entries require armed policy enforcement")
+        require(audit is None, "audit evidence has no entries")
+        return "not-started"
+    require(
+        resolve_current_final_tag is not None,
+        "entry validation requires current final-tag evidence",
+    )
+    require(
+        resolve_replay_freeze_tag is not None,
+        "entry validation requires replay freeze-tag evidence",
+    )
+    require(tag_protection is not None, "tag-protection evidence is missing")
+    require(audit is not None, "entry validation requires complete audit evidence")
+    require(audit.snapshot_complete is True, "audit snapshot is incomplete")
+    require(audit.validation_target_exact is True, "audit validation target is not exact")
+    activation_ref = pr_ref(soak_root["armed_by_pr"], "armed_by_pr", "soak")
+
+    shaped = [validate_entry_shape(entry, index) for index, entry in enumerate(entries, 1)]
+    record_refs = [shape[3] for shape in shaped]
+    require(len(record_refs) == len(set(record_refs)), "record_pr values must be distinct")
+    record_ref_set = set(record_refs)
+    final_tag = resolve_current_final_tag(FINAL_TAG)
+    require(isinstance(final_tag.exists, bool), "final-tag existence is unavailable")
+
+    def validate_absent_final_tag() -> None:
+        require(final_tag.exists is False, "final tag exists before successful sign-off")
+        require(
+            final_tag.object_id is None
+            and final_tag.object_type is None
+            and final_tag.commit is None
+            and final_tag.patch_is_fresh_for_attempt is None
+            and final_tag.validated_entry_id is None
+            and final_tag.validated_record_pr is None
+            and final_tag.commit_is_validated_record_integration is None,
+            "absent final-tag evidence is inconsistent",
+        )
+
+    def finish_pending(state: str) -> str:
+        assert tag_protection is not None
+        validate_tag_protection(tag_protection)
+        validate_absent_final_tag()
+        return state
+
+    terminal_tag_present = final_tag.exists is True
+
+    require(resolve_replay_pr is not None, "entry validation requires replay PR evidence")
+    require(
+        resolve_replay_activation_diff is not None,
+        "entry validation requires replay activation-diff evidence",
+    )
+    require(
+        resolve_replay_record_diff is not None,
+        "entry validation requires replay record-diff evidence",
+    )
+    require(
+        resolve_replay_work_diff is not None,
+        "entry validation requires replay work-diff evidence",
+    )
+    require(
+        resolve_replay_release_payload is not None,
+        "entry validation requires replay release-payload evidence",
+    )
+    require(
+        resolve_replay_issue is not None,
+        "entry validation requires replay issue evidence",
+    )
+    if any(shape[1] == "sign-off" for shape in shaped):
+        require(
+            resolve_replay_release_prep is not None,
+            "sign-off validation requires replay release-preparation evidence",
+        )
+
+    require(
+        isinstance(audit.invalid_entries, tuple)
+        and all(isinstance(item, str) for item in audit.invalid_entries),
+        "audit invalid-entry inventory is missing",
+    )
+    invalid_list = list(audit.invalid_entries)
+    invalid_set = set(invalid_list)
+    require(len(invalid_list) == len(invalid_set), "audit invalid entries contain duplicates")
+    entry_ids = {shape[0] for shape in shaped}
+    require(invalid_set <= entry_ids, "record-invalid evidence names an unknown entry")
+    entry_positions = {shape[0]: index for index, shape in enumerate(shaped, start=1)}
+    require(
+        invalid_list == sorted(invalid_list, key=entry_positions.__getitem__),
+        "audit invalid entries are not in ledger order",
+    )
+    if audit.boundary_entry_id is None:
+        require(not invalid_list, "audit with an empty prefix names invalid entries")
+        drift_boundary = 0
+    else:
+        require(
+            audit.boundary_entry_id in entry_ids,
+            "audit boundary is not a live entry",
+        )
+        drift_boundary = entry_positions[audit.boundary_entry_id]
+        require(
+            all(entry_positions[target] <= drift_boundary for target in invalid_set),
+            "audit boundary precedes an invalid target",
+        )
+    # The audit channel has replayed every current mutable fact.  Before tag
+    # creation, its classified drift enters the ordered reset queue.  Once any
+    # final-tag ref exists, the same drift is a hard release incident and never
+    # reopens the append-only ledger reconstructed above.
+    drift_targets = invalid_list.copy()
+
+    source_ref_set = {
+        pr_ref(entry["source_pr"], "source_pr", shape[0])
+        for entry, shape in zip(entries, shaped)
+        if shape[1] == "freeze"
+    }
+    all_work_refs = [
+        pr_ref(entry["work_pr"], "work_pr", shape[0])
+        for entry, shape in zip(entries, shaped)
+        if shape[1] == "work"
+    ]
+    release_prep_refs = [
+        pr_ref(entry["release_prep_pr"], "release_prep_pr", shape[0])
+        for entry, shape in zip(entries, shaped)
+        if shape[1] == "sign-off"
+    ]
+    require(
+        len(release_prep_refs) == len(set(release_prep_refs)),
+        "release_prep_pr values must be distinct",
+    )
+    require(len(all_work_refs) == len(set(all_work_refs)), "work_pr values must be distinct")
+    for work_ref in all_work_refs:
+        require(work_ref != activation_ref, f"work PR {work_ref} is the activation PR")
+        require(work_ref not in source_ref_set, f"work PR {work_ref} is a source PR")
+        require(work_ref not in record_ref_set, f"work PR {work_ref} is an entry record PR")
+        require(
+            work_ref not in release_prep_refs,
+            f"work PR {work_ref} is a release-preparation PR",
+        )
+    for release_ref in release_prep_refs:
+        require(
+            release_ref != activation_ref,
+            f"release-preparation PR {release_ref} is the activation PR",
+        )
+        require(
+            release_ref not in source_ref_set,
+            f"release-preparation PR {release_ref} is a source PR",
+        )
+        require(
+            release_ref not in record_ref_set,
+            f"release-preparation PR {release_ref} is an entry record PR",
+        )
+
+    activation = resolve_replay_pr(activation_ref, None)
+    activation_author, activation_head = validate_pr_core(activation, activation_ref)
+    activation_diff = resolve_replay_activation_diff(activation_ref)
+    require(
+        activation_diff.validated_pr_ref == activation_ref,
+        "activation diff was validated on another PR",
+    )
+    require(
+        activation_diff.validated_head_oid == activation_head,
+        "activation diff was not validated at the exact head",
+    )
+    require(activation_diff.complete is True, "activation diff is incomplete")
+    require(
+        activation_diff.candidate_main_is_ancestor_of_head is True,
+        "activation main target is not an ancestor of its head",
+    )
+    require(
+        activation_diff.unique_merge_base is True,
+        "activation merge base is ambiguous",
+    )
+    require(
+        activation_diff.exact_seven_scalar_replacements is True,
+        "activation diff is not exactly the seven permitted scalar replacements",
+    )
+    require(
+        activation_diff.inventory_digest_matches is True,
+        "activation inventory digest is wrong",
+    )
+    require(
+        activation_diff.test_code_tree_matches is True,
+        "activation test-code tree is wrong",
+    )
+    require(
+        activation_diff.test_support_tree_matches is True,
+        "activation test-support tree is wrong",
+    )
+    require(
+        activation_diff.inventory_data_paths_within_mutable_roots is True,
+        "activation inventory data paths escape the mutable subject roots",
+    )
+    require(
+        activation_diff.executable_dependencies_within_code_tree is True,
+        "activation executable dependency escapes the pinned code tree",
+    )
+    require(
+        activation_diff.acceptance_dependencies_within_support_tree is True,
+        "activation acceptance dependency escapes the pinned support tree",
+    )
+    require(
+        activation_diff.subject_data_cannot_reduce_coverage is True,
+        "activation subject data can reduce release-test coverage",
+    )
+    require(
+        activation_diff.hermetic_execution_contract_valid is True,
+        "activation hermetic execution contract is invalid",
+    )
+    require(
+        activation_diff.supervisor_self_test_receipt_valid is True,
+        "activation supervisor self-test receipt is invalid",
+    )
+    require(
+        activation_diff.policy_digest_matches is True,
+        "activation policy digest is wrong",
+    )
+    require(
+        activation_diff.ledger_prefix_matches is True,
+        "activation ledger prefix is wrong",
+    )
+    activation_merged_at, activation_integration = validate_merged_pr(
+        activation,
+        activation_ref,
+        require_descendant=False,
+        require_tree=True,
+    )
+    del activation_merged_at
+    activation_merger = normalized_login(activation.merged_by_login, f"{activation_ref} mergedBy")
+    require(
+        activation_merger == maintainer_login,
+        f"{activation_ref} was not merged by github:{maintainer_login}",
+    )
+    require_independent_approval(
+        activation,
+        activation_ref,
+        author=activation_author,
+        before=utc_instant(activation.merged_at, f"{activation_ref} mergedAt"),
+        distinct_from={maintainer_login},
+    )
+
+    seen: dict[str, dict] = {}
+    seen_attempts: dict[str, int] = {}
     active: dict | None = None
-    last_date: date | None = None
     last_attempt = 0
-    pending_break: str | None = None
+    last_record_integration: str | None = activation_integration
+    last_reset_integration: str | None = None
+    prior_patch = -1
+    pending_reset: tuple[str, str] | None = None
     signed = False
-    prior_freeze_sha: str | None = None
-    prior_freeze_utc: datetime | None = None
-    used_freeze_tags: set[str] = set()
-    used_freeze_objects: set[str] = set()
-    used_freeze_shas: set[str] = set()
+    successful_signoff: tuple[str, str, str] | None = None
+    used_source_refs: set[str] = set()
+    used_source_shas: set[str] = set()
+    used_tag_names: set[str] = set()
+    used_tag_objects: set[str] = set()
 
-    for index, entry in enumerate(entries, start=1):
-        entry_id, kind, entry_date, attempt = validate_entry_shape(entry, index)
+    for index, (entry, shape) in enumerate(zip(entries, shaped), start=1):
+        entry_id, kind, attempt, record_ref = shape
+        if index > drift_boundary and drift_targets and pending_reset is None:
+            pending_reset = ("record-invalid", drift_targets[0])
+            signed = False
         require(not signed, f"{entry_id} appears after final sign-off")
-        require(entry_date <= current.date(), f"{entry_id} date is in the future")
-        if last_date is not None:
-            require(entry_date >= last_date, f"{entry_id} date precedes the prior entry")
-        last_date = entry_date
-
-        if pending_break is not None:
-            require(
-                kind == "reset" and entry["friction"] == pending_break,
-                f"{pending_break} breaking need must be followed immediately by its reset",
-            )
+        if pending_reset is not None and kind != "correction":
+            require(kind == "reset", f"{pending_reset[1]} must be followed by its reset")
 
         if kind == "freeze":
             require(active is None, f"{entry_id} starts a freeze while an attempt is active")
+            require(pending_reset is None, f"{entry_id} starts before the required reset")
             require(attempt == last_attempt + 1, f"{entry_id} has the wrong attempt number")
-            freeze_sha = nonempty_string(entry["freeze_sha"], "freeze_sha", entry_id)
-            tag_object = nonempty_string(
-                entry["freeze_tag_object"], "freeze_tag_object", entry_id
-            )
-            freeze_tag = nonempty_string(entry["freeze_tag"], "freeze_tag", entry_id)
-            tagger_utc = iso_utc(
-                entry["freeze_tagger_utc"], "freeze_tagger_utc", entry_id
-            )
-            require(SHA_RE.fullmatch(freeze_sha) is not None, f"{entry_id} has invalid freeze_sha")
-            require(
-                SHA_RE.fullmatch(tag_object) is not None,
-                f"{entry_id} has invalid freeze_tag_object",
-            )
-            require(
-                FREEZE_TAG_RE.fullmatch(freeze_tag) is not None,
-                f"{entry_id} freeze tag must use tenkz-v0.9.PATCH",
-            )
-            require(
-                freeze_tag not in used_freeze_tags,
-                f"{entry_id} reuses a prior freeze tag",
-            )
-            require(
-                tag_object not in used_freeze_objects,
-                f"{entry_id} reuses a prior freeze tag object",
-            )
-            require(
-                freeze_sha not in used_freeze_shas,
-                f"{entry_id} reuses a prior freeze commit",
-            )
-            require(
-                entry_date == tagger_utc.date(),
-                f"{entry_id} date differs from the tagger UTC date",
-            )
-            require(tagger_utc <= current, f"{entry_id} tagger timestamp is in the future")
-            require(
-                entry["prerequisites"] == PREREQUISITES,
-                f"{entry_id} lacks the full blocker chain",
-            )
-            nonempty_string(entry["evidence"], "evidence", entry_id)
-            require(resolve_tag is not None, f"{entry_id} requires Git tag resolution")
-            require(resolve_commit is not None, f"{entry_id} requires Git commit resolution")
-            tag = resolve_tag(freeze_tag)
-            require(tag.object_type == "tag", f"{entry_id} freeze tag is not annotated")
-            require(tag.object_id == tag_object, f"{entry_id} freeze tag object was replaced")
-            require(tag.commit == freeze_sha, f"{entry_id} freeze tag peels to another commit")
-            require(tag.tagger_utc is not None, f"{entry_id} annotated tag lacks a tagger date")
-            require(
-                tag.tagger_utc.tzinfo is not None
-                and tag.tagger_utc.utcoffset() is not None,
-                f"{entry_id} tagger timestamp must be timezone-aware",
-            )
-            require(
-                tag.tagger_utc.astimezone(timezone.utc) == tagger_utc,
-                f"{entry_id} tagger timestamp differs from the tag object",
-            )
-            if prior_freeze_utc is not None:
-                require(
-                    tagger_utc > prior_freeze_utc,
-                    f"{entry_id} tagger timestamp must follow the prior freeze",
-                )
-            require(
-                tag.reachable_from_main,
-                f"{entry_id} freeze commit is not reachable from main",
-            )
-            freeze_commit = resolve_commit(
-                freeze_sha,
-                prior_freeze_sha if prior_freeze_sha is not None else freeze_sha,
-            )
-            require(
-                freeze_commit.object_type == "commit",
-                f"{entry_id} freeze_sha is not a commit",
-            )
-            require(
-                freeze_commit.committed_utc is not None,
-                f"{entry_id} freeze commit lacks a committer date",
-            )
-            require(
-                freeze_commit.committed_utc.tzinfo is not None,
-                f"{entry_id} freeze commit timestamp must be timezone-aware",
-            )
-            require(
-                freeze_commit.committed_utc.astimezone(timezone.utc) <= tagger_utc,
-                f"{entry_id} freeze commit postdates the annotated tag",
-            )
-            if prior_freeze_sha is not None:
-                require(
-                    freeze_commit.descends_from_freeze,
-                    f"{entry_id} freeze commit does not descend from the prior freeze",
-                )
-            active = {
-                "attempt": attempt,
-                "freeze_id": entry_id,
-                "freeze_utc": tagger_utc,
-                "freeze_sha": freeze_sha,
-                "work": {},
-                "friction": {},
-            }
-            prior_freeze_sha = freeze_sha
-            prior_freeze_utc = tagger_utc
-            used_freeze_tags.add(freeze_tag)
-            used_freeze_objects.add(tag_object)
-            used_freeze_shas.add(freeze_sha)
-            last_attempt = attempt
         elif kind == "correction":
             target = nonempty_string(entry["target"], "target", entry_id)
             require(target in seen, f"{entry_id} correction target is not an earlier entry")
             require(
-                attempt == seen[target][0]["attempt"],
-                f"{entry_id} correction attempt differs from its target",
+                attempt == seen_attempts[target],
+                f"{entry_id} correction attempt differs from target",
             )
-            nonempty_string(entry["summary"], "summary", entry_id)
-            nonempty_string(entry["evidence"], "evidence", entry_id)
+        elif kind == "reset":
+            reset_cause = nonempty_string(entry["cause"], "cause", entry_id)
+            require(reset_cause in RESET_CAUSES, f"{entry_id} has invalid reset cause")
+            if reset_cause == "breaking-required":
+                require(active is not None, f"{entry_id} breaking reset has no active attempt")
+                require(attempt == active["attempt"], f"{entry_id} has the wrong active attempt")
+            else:
+                require(last_attempt > 0, f"{entry_id} record-invalid reset has no prior attempt")
+                reset_attempt = active["attempt"] if active is not None else last_attempt
+                require(attempt == reset_attempt, f"{entry_id} has the wrong reset attempt")
         else:
             require(active is not None, f"{entry_id} {kind} appears without an active freeze")
             require(attempt == active["attempt"], f"{entry_id} has the wrong active attempt")
 
-            if kind == "work":
-                work_sha = nonempty_string(entry["work_sha"], "work_sha", entry_id)
-                work_utc = iso_utc(
-                    entry["work_committed_utc"], "work_committed_utc", entry_id
+        record_anchor = last_record_integration
+        source_sha_for_record: str | None = None
+        if kind == "freeze":
+            source_sha_for_record = sha(entry["source_sha"], "source_sha", entry_id)
+            record_anchor = source_sha_for_record
+        record = resolve_replay_pr(record_ref, record_anchor)
+        diff = resolve_replay_record_diff(entry_id, record_ref, source_sha_for_record)
+        inspection = inspect_record_pr(
+            record,
+            diff,
+            entry_id=entry_id,
+            record_ref=record_ref,
+            require_descendant=True,
+        )
+        record_author = inspection.author
+        record_pending = inspection.pending
+        record_merged_at = inspection.merged_at
+        record_integration = inspection.integration
+        record_invalid_reasons = list(inspection.invalid_reasons)
+
+        def check_kind_record_fact(condition: bool, message: str) -> None:
+            if condition:
+                return
+            if record_pending:
+                raise PolicyError(message)
+            record_invalid_reasons.append(message)
+
+        if kind == "freeze":
+            check_kind_record_fact(
+                diff.source_to_head_is_exact_freeze_append is True,
+                f"{entry_id} source-to-head diff is not exactly the freeze append",
+            )
+            check_kind_record_fact(
+                diff.candidate_main_tip_is_source is True,
+                f"{entry_id} candidate main tip differs from source_sha",
+            )
+            if not record_pending:
+                check_kind_record_fact(
+                    diff.integration_parent_is_source is True,
+                    f"{entry_id} integration parent differs from source_sha",
                 )
-                require(SHA_RE.fullmatch(work_sha) is not None, f"{entry_id} has invalid work_sha")
+        if kind == "sign-off":
+            check_kind_record_fact(
+                diff.candidate_main_tip_is_release_integration is True,
+                f"{entry_id} candidate main tip differs from release integration",
+            )
+            if not record_pending:
+                check_kind_record_fact(
+                    diff.integration_parent_is_release_integration is True,
+                    f"{entry_id} integration parent differs from release integration",
+                )
+        if record_pending:
+            require(index == len(entries), f"{entry_id} unmerged record is not the final entry")
+
+        def entry_is_invalid() -> bool:
+            # Resolver failures are current mutable drift or intrinsic
+            # immutable-fact failures.  The audit inventory independently
+            # schedules them in ledger order at its immutable boundary.
+            return bool(record_invalid_reasons)
+
+        def check_external(action: Callable[[], object]) -> object | None:
+            """Turn a merged entry's drifted external fact into reset state."""
+
+            try:
+                return action()
+            except PolicyError as error:
+                if record_pending:
+                    raise
+                record_invalid_reasons.append(str(error))
+                return None
+
+        if kind == "freeze":
+            source_ref = pr_ref(entry["source_pr"], "source_pr", entry_id)
+            source_sha = source_sha_for_record
+            assert source_sha is not None
+            require(source_ref != record_ref, f"{entry_id} source and record PRs must differ")
+            require(source_ref not in used_source_refs, f"{entry_id} reuses a source PR")
+            require(source_sha not in used_source_shas, f"{entry_id} reuses a source SHA")
+            source_anchor = activation_integration if last_attempt == 0 else last_reset_integration
+            require(source_anchor is not None, f"{entry_id} lacks the preceding reset anchor")
+            tag_object = sha(entry["freeze_tag_object"], "freeze_tag_object", entry_id)
+            tag_name = nonempty_string(entry["freeze_tag"], "freeze_tag", entry_id)
+            require(
+                FREEZE_TAG_RE.fullmatch(tag_name) is not None,
+                f"{entry_id} has invalid freeze tag",
+            )
+            patch = int(tag_name.rsplit(".", 1)[1])
+            require(patch > prior_patch, f"{entry_id} freeze PATCH must increase")
+            require(tag_name not in used_tag_names, f"{entry_id} reuses a freeze tag")
+            require(tag_object not in used_tag_objects, f"{entry_id} reuses a freeze tag object")
+            listed = closed_string_list(entry["prerequisites"], "prerequisites", entry_id)
+            require(listed == prerequisites, f"{entry_id} lacks the derived blocker chain")
+            for item in listed:
+                issue_ref(item, "prerequisites", entry_id)
+            nonempty_string(entry["evidence"], "evidence", entry_id)
+
+            def freeze_external_facts() -> tuple[list[IssueEvidence], tuple[str, ...]]:
+                source = resolve_replay_pr(source_ref, source_anchor)
+                source_author, _source_head = validate_pr_core(source, source_ref)
+                source_time, source_integration = validate_merged_pr(
+                    source,
+                    source_ref,
+                    require_descendant=True,
+                    require_tree=True,
+                )
+                require_independent_approval(
+                    source,
+                    source_ref,
+                    author=source_author,
+                    before=source_time,
+                )
                 require(
-                    work_sha != active["freeze_sha"],
-                    f"{entry_id} reuses the freeze commit as work evidence",
+                    source_integration == source_sha,
+                    f"{entry_id} source SHA differs from source PR",
+                )
+                tag = resolve_replay_freeze_tag(tag_name)
+                require(tag.exists is True, f"{entry_id} freeze tag is missing")
+                require(tag.object_type == "tag", f"{entry_id} freeze tag is not annotated")
+                require(
+                    tag.object_id == tag_object,
+                    f"{entry_id} freeze tag object was replaced",
                 )
                 require(
-                    entry_date == work_utc.date(),
-                    f"{entry_id} date differs from the work commit UTC date",
-                )
-                require(work_utc <= current, f"{entry_id} work commit is in the future")
-                require(
-                    work_utc > active["freeze_utc"],
-                    f"{entry_id} work commit must postdate the freeze tag",
-                )
-                require(resolve_commit is not None, f"{entry_id} requires Git commit resolution")
-                commit = resolve_commit(work_sha, active["freeze_sha"])
-                require(commit.object_type == "commit", f"{entry_id} work_sha is not a commit")
-                require(
-                    commit.committed_utc is not None,
-                    f"{entry_id} work commit lacks a committer date",
+                    tag.commit == source_sha,
+                    f"{entry_id} freeze tag peels to another commit",
                 )
                 require(
-                    commit.committed_utc.tzinfo is not None
-                    and commit.committed_utc.utcoffset() is not None,
-                    f"{entry_id} work commit timestamp must be timezone-aware",
+                    tag.patch_is_fresh_for_attempt is True,
+                    f"{entry_id} freeze PATCH does not exceed abandoned tags",
                 )
-                require(
-                    commit.committed_utc.astimezone(timezone.utc) == work_utc,
-                    f"{entry_id} timestamp differs from the commit object",
+                payload_blobs = validate_release_payload(
+                    resolve_replay_release_payload(source_sha, tag_name, release_contract),
+                    tree_oid=source_sha,
+                    tag=tag_name,
+                    contract=release_contract,
+                    subject=f"{entry_id} freeze",
                 )
-                require(
-                    commit.reachable_from_main,
-                    f"{entry_id} work commit is not reachable from main",
-                )
-                require(
-                    commit.descends_from_freeze,
-                    f"{entry_id} work commit does not descend from the freeze",
-                )
-                require(
-                    all(record["sha"] != work_sha for record in active["work"].values()),
-                    f"{entry_id} repeats a work commit",
-                )
-                nonempty_string(entry["summary"], "summary", entry_id)
-                nonempty_string(entry["evidence"], "evidence", entry_id)
-                active["work"][entry_id] = {"sha": work_sha, "when": work_utc}
-            elif kind == "friction":
-                surface = nonempty_string(entry["surface"], "surface", entry_id)
-                triage = nonempty_string(entry["triage"], "triage", entry_id)
-                require(surface in SURFACES, f"{entry_id} has invalid friction surface")
-                require(triage in TRIAGE, f"{entry_id} has invalid friction triage")
-                nonempty_string(entry["summary"], "summary", entry_id)
-                nonempty_string(entry["evidence"], "evidence", entry_id)
-                active["friction"][entry_id] = {
-                    "triage": triage,
-                    "resolved": False,
-                }
-                if triage == "breaking-required":
-                    pending_break = entry_id
-            elif kind == "resolution":
-                friction = nonempty_string(entry["friction"], "friction", entry_id)
-                record = active["friction"].get(friction)
-                require(record is not None, f"{entry_id} names no friction in this attempt")
-                require(
-                    record["triage"] == "fix-compatible",
-                    f"{entry_id} may resolve only fix-compatible friction",
-                )
-                require(not record["resolved"], f"{entry_id} resolves friction twice")
-                nonempty_string(entry["summary"], "summary", entry_id)
-                nonempty_string(entry["evidence"], "evidence", entry_id)
-                record["resolved"] = True
-            elif kind == "reset":
-                friction = nonempty_string(entry["friction"], "friction", entry_id)
-                record = active["friction"].get(friction)
-                require(record is not None, f"{entry_id} names no friction in this attempt")
-                require(
-                    record["triage"] == "breaking-required",
-                    f"{entry_id} reset needs a breaking-required friction",
-                )
-                nonempty_string(entry["reason"], "reason", entry_id)
-                nonempty_string(entry["evidence"], "evidence", entry_id)
-                pending_break = None
-                active = None
-            elif kind == "sign-off":
-                freeze = nonempty_string(entry["freeze"], "freeze", entry_id)
-                freeze_sha = nonempty_string(entry["freeze_sha"], "freeze_sha", entry_id)
-                release_tag = nonempty_string(entry["release_tag"], "release_tag", entry_id)
-                decision = nonempty_string(entry["decision"], "decision", entry_id)
-                maintainer = normalized_identity(entry["maintainer"], "maintainer", entry_id)
-                reviewer = normalized_identity(entry["reviewer"], "reviewer", entry_id)
-                work_evidence = string_list(entry["work_evidence"], "work_evidence", entry_id)
-                require(freeze == active["freeze_id"], f"{entry_id} names the wrong freeze entry")
-                require(
-                    freeze_sha == active["freeze_sha"],
-                    f"{entry_id} names the wrong freeze SHA",
-                )
-                require(release_tag == "tenkz-v1.0.0", f"{entry_id} has the wrong release tag")
-                require(decision == "release", f"{entry_id} decision must be release")
-                require(maintainer == "github:lionsr", f"{entry_id} has the wrong maintainer")
-                require(reviewer != maintainer, f"{entry_id} reviewer must be independent")
-                require(
-                    len(work_evidence) == len(set(work_evidence)),
-                    f"{entry_id} repeats work evidence",
-                )
-                eligible_at = active["freeze_utc"] + timedelta(days=28)
-                require(current >= eligible_at, f"{entry_id} current UTC is before 28 full days")
-                require(
-                    entry_date >= eligible_at.date(),
-                    f"{entry_id} sign-off date is backdated",
-                )
-                windows: set[int] = set()
-                for work_id in work_evidence:
+                facts: list[IssueEvidence] = []
+                for item in listed:
+                    fact = resolve_replay_issue(item)
                     require(
-                        work_id in active["work"],
-                        f"{entry_id} names missing work entry {work_id}",
+                        fact.in_repository is True,
+                        f"{entry_id} prerequisite {item} is external",
                     )
-                    offset = active["work"][work_id]["when"] - active["freeze_utc"]
-                    if timedelta(0) <= offset < timedelta(days=28):
-                        windows.add(offset.days // 7)
+                    require(
+                        fact.closed is True,
+                        f"{entry_id} prerequisite {item} is not closed",
+                    )
+                    utc_instant(fact.closed_at, f"{entry_id} prerequisite {item} closedAt")
+                    facts.append(fact)
+                return facts, payload_blobs
+
+            freeze_result = check_external(freeze_external_facts)
+            prerequisite_facts = (
+                freeze_result[0]
+                if isinstance(freeze_result, tuple)
+                else []
+            )
+            freeze_payload_blobs = (
+                freeze_result[1]
+                if isinstance(freeze_result, tuple)
+                else ()
+            )
+
+            if record_pending:
+                return finish_pending("freeze-pending")
+            if not entry_is_invalid():
+                assert record_merged_at is not None and record_integration is not None
+
+                def check_prerequisite_times() -> None:
+                    for item, fact in zip(listed, prerequisite_facts):
+                        closed_at = utc_instant(
+                            fact.closed_at,
+                            f"{entry_id} prerequisite {item} closedAt",
+                        )
+                        require(
+                            closed_at <= record_merged_at,
+                            f"{entry_id} prerequisite {item} closed after T",
+                        )
+
+                check_external(check_prerequisite_times)
+            active = {
+                "attempt": attempt,
+                "freeze_id": entry_id,
+                "source_sha": source_sha,
+                "freeze_tag": tag_name,
+                "freeze_time": record_merged_at,
+                "freeze_integration": record_integration or source_sha,
+                "freeze_payload_blobs": freeze_payload_blobs,
+                "work": {},
+                "friction": {},
+            }
+            last_attempt = attempt
+            prior_patch = patch
+            used_source_refs.add(source_ref)
+            used_source_shas.add(source_sha)
+            used_tag_names.add(tag_name)
+            used_tag_objects.add(tag_object)
+
+        elif kind == "work":
+            assert active is not None
+            work_ref = pr_ref(entry["work_pr"], "work_pr", entry_id)
+            work_class = nonempty_string(entry["class"], "class", entry_id)
+            require(work_class in work_classes, f"{entry_id} has invalid work class")
+            require(len(active["work"]) < required_work_count, f"{entry_id} is a third work entry")
+            require(work_class not in active["work"], f"{entry_id} repeats work class {work_class}")
+            nonempty_string(entry["summary"], "summary", entry_id)
+            nonempty_string(entry["evidence"], "evidence", entry_id)
+
+            def work_external_facts() -> tuple[datetime, str]:
+                work_pr = resolve_replay_pr(work_ref, active["freeze_integration"])
+                work_author, _work_head = validate_pr_core(work_pr, work_ref)
+                work_merged_at, work_integration = validate_merged_pr(
+                    work_pr,
+                    work_ref,
+                    require_descendant=True,
+                    require_tree=True,
+                )
                 require(
-                    windows == {0, 1, 2, 3},
-                    f"{entry_id} lacks normal-work evidence in all four windows",
+                    work_merged_at > active["freeze_time"],
+                    f"{entry_id} work PR did not merge after T",
                 )
-                unresolved = sorted(
-                    friction
-                    for friction, record in active["friction"].items()
-                    if record["triage"] == "fix-compatible" and not record["resolved"]
+                require_independent_approval(
+                    work_pr,
+                    work_ref,
+                    author=work_author,
+                    before=work_merged_at,
+                )
+                work_diff = resolve_replay_work_diff(work_ref)
+                require(work_diff.complete is True, f"{entry_id} work diff is incomplete")
+                require(
+                    work_diff.integration_parent_count in {1, 2},
+                    f"{entry_id} work integration has an invalid parent count",
                 )
                 require(
-                    not unresolved,
-                    f"{entry_id} has unresolved friction: {', '.join(unresolved)}",
+                    work_diff.unique_merge_base is True,
+                    f"{entry_id} work merge base is ambiguous",
                 )
+                require(
+                    work_diff.integration_parent_is_ancestor_of_head is True,
+                    f"{entry_id} work integration parent is not an ancestor of its head",
+                )
+                if work_diff.integration_parent_count == 2:
+                    require(
+                        work_diff.integration_second_parent_matches_head is True,
+                        f"{entry_id} work integration second parent differs from its head",
+                    )
+                require(
+                    work_diff.policy_paths_untouched is True,
+                    f"{entry_id} work diff changes policy",
+                )
+                require(
+                    excluded_paths == ("TNLean/Archive/**",)
+                    and work_diff.excluded_paths_applied is True,
+                    f"{entry_id} work diff did not apply excluded paths",
+                )
+                semantic_classes = work_diff.semantic_add_or_modify_classes
+                require(
+                    isinstance(semantic_classes, tuple)
+                    and all(isinstance(item, str) for item in semantic_classes),
+                    f"{entry_id} semantic work-class evidence is missing",
+                )
+                semantic_flags = (
+                    work_diff.semantic_lean_changed,
+                    work_diff.semantic_blueprint_changed,
+                    work_diff.semantic_rmp_changed,
+                )
+                require(
+                    all(isinstance(flag, bool) for flag in semantic_flags),
+                    f"{entry_id} semantic path evidence is incomplete",
+                )
+                require(
+                    set(semantic_classes) <= set(work_classes),
+                    f"{entry_id} semantic work evidence has an unknown class",
+                )
+                derived_classes = tuple(
+                    candidate
+                    for candidate, changed in (
+                        (
+                            "formalization-or-blueprint",
+                            work_diff.semantic_lean_changed
+                            or work_diff.semantic_blueprint_changed,
+                        ),
+                        ("rmp-benchmark", work_diff.semantic_rmp_changed),
+                    )
+                    if changed
+                )
+                require(
+                    semantic_classes == derived_classes,
+                    f"{entry_id} semantic work-class evidence is inconsistent",
+                )
+                require(
+                    work_class in semantic_classes,
+                    f"{entry_id} work diff is comment, whitespace, or deletion only",
+                )
+                if work_diff.semantic_lean_changed is True:
+                    require(
+                        work_diff.lean_modules_build is True,
+                        f"{entry_id} changed Lean modules do not build",
+                    )
+                    require(
+                        work_diff.proof_integrity_clean is True,
+                        f"{entry_id} work diff introduces a proof-integrity blocker",
+                    )
+                if work_diff.semantic_blueprint_changed is True:
+                    require(
+                        work_diff.blueprint_checkdecls_passed is True,
+                        f"{entry_id} blueprint declarations do not check",
+                    )
+                    require(
+                        work_diff.blueprint_build_passed is True,
+                        f"{entry_id} relevant blueprint build did not pass",
+                    )
+                if work_diff.semantic_rmp_changed is True:
+                    require(
+                        work_diff.rmp_targets_resolved is True,
+                        f"{entry_id} RMP cases do not resolve through the manifest",
+                    )
+                    require(
+                        work_diff.rmp_stages_complete is True,
+                        f"{entry_id} RMP validation stages are incomplete",
+                    )
+                    require(
+                        work_diff.rmp_checks_passed is True,
+                        f"{entry_id} RMP case checks did not pass",
+                    )
+                return work_merged_at, work_integration
+
+            work_result = check_external(work_external_facts)
+            if record_pending:
+                return finish_pending("work-pending")
+            if not entry_is_invalid():
+                assert isinstance(work_result, tuple)
+                work_merged_at, work_integration = work_result
+                active["work"][work_class] = {
+                    "entry_id": entry_id,
+                    "pr": work_ref,
+                    "merged_at": work_merged_at,
+                    "integration": work_integration,
+                }
+
+        elif kind == "friction":
+            assert active is not None
+            surface = nonempty_string(entry["surface"], "surface", entry_id)
+            triage = nonempty_string(entry["triage"], "triage", entry_id)
+            require(surface in SURFACES, f"{entry_id} has invalid friction surface")
+            require(triage in TRIAGE, f"{entry_id} has invalid friction triage")
+            nonempty_string(entry["summary"], "summary", entry_id)
+            nonempty_string(entry["evidence"], "evidence", entry_id)
+            if record_pending:
+                return finish_pending("friction-pending")
+            if not entry_is_invalid():
+                active["friction"][entry_id] = {"triage": triage, "resolved": False}
+                if triage == "breaking-required":
+                    pending_reset = ("breaking-required", entry_id)
+
+        elif kind == "resolution":
+            assert active is not None
+            friction = nonempty_string(entry["friction"], "friction", entry_id)
+            fact = active["friction"].get(friction)
+            require(fact is not None, f"{entry_id} names no friction in this attempt")
+            require(fact["triage"] == "fix-compatible", f"{entry_id} resolves incompatible triage")
+            require(fact["resolved"] is False, f"{entry_id} resolves friction twice")
+            nonempty_string(entry["summary"], "summary", entry_id)
+            nonempty_string(entry["evidence"], "evidence", entry_id)
+            if record_pending:
+                return finish_pending("resolution-pending")
+            if not entry_is_invalid():
+                fact["resolved"] = True
+
+        elif kind == "reset":
+            cause = nonempty_string(entry["cause"], "cause", entry_id)
+            target = nonempty_string(entry["target"], "target", entry_id)
+            require(cause in RESET_CAUSES, f"{entry_id} has invalid reset cause")
+            require(target in seen, f"{entry_id} reset target is not earlier")
+            if cause == "breaking-required":
+                require(
+                    seen_attempts[target] == attempt,
+                    f"{entry_id} breaking reset target is in another attempt",
+                )
+            require(
+                pending_reset == (cause, target),
+                f"{entry_id} does not match the required reset",
+            )
+            nonempty_string(entry["reason"], "reason", entry_id)
+            nonempty_string(entry["evidence"], "evidence", entry_id)
+            if record_pending:
+                return finish_pending("reset-pending")
+            if not entry_is_invalid():
+                if cause == "record-invalid" and drift_targets:
+                    require(
+                        target == drift_targets[0],
+                        f"{entry_id} does not reset the earliest drifted record",
+                    )
+                    drift_targets.pop(0)
+                pending_reset = None
+                last_reset_integration = record_integration
                 active = None
-                signed = True
 
-        seen[entry_id] = (entry, entry_date)
+        elif kind == "correction":
+            nonempty_string(entry["summary"], "summary", entry_id)
+            nonempty_string(entry["evidence"], "evidence", entry_id)
+            if record_pending:
+                return finish_pending("correction-pending")
 
-    require(pending_break is None, f"{pending_break} breaking need lacks an immediate reset")
+        elif kind == "sign-off":
+            assert active is not None
+            freeze = nonempty_string(entry["freeze"], "freeze", entry_id)
+            source_sha = sha(entry["source_sha"], "source_sha", entry_id)
+            release_tag = nonempty_string(entry["release_tag"], "release_tag", entry_id)
+            reviewer_identity = identity(entry["reviewer"], "reviewer", entry_id)
+            reviewer = reviewer_identity.removeprefix("github:")
+            work_ids = closed_string_list(entry["work_evidence"], "work_evidence", entry_id)
+            decision = nonempty_string(entry["decision"], "decision", entry_id)
+            require(freeze == active["freeze_id"], f"{entry_id} names the wrong freeze")
+            require(source_sha == active["source_sha"], f"{entry_id} names the wrong source SHA")
+            require(release_tag == "tenkz-v1.0.0", f"{entry_id} has the wrong release tag")
+            require(decision == "release", f"{entry_id} decision must be release")
+            require(
+                len(active["work"]) == required_work_count
+                and set(active["work"]) == set(work_classes),
+                f"{entry_id} lacks one work class",
+            )
+            expected_ids = {fact["entry_id"] for fact in active["work"].values()}
+            require(
+                len(work_ids) == required_work_count,
+                f"{entry_id} must name exactly two work entries",
+            )
+            require(
+                set(work_ids) == expected_ids,
+                f"{entry_id} does not name exactly the active work entries",
+            )
+            latest_work_merge = max(fact["merged_at"] for fact in active["work"].values())
+            work_integrations = tuple(
+                active["work"][work_class]["integration"] for work_class in work_classes
+            )
+            release_ref = pr_ref(
+                entry["release_prep_pr"],
+                "release_prep_pr",
+                entry_id,
+            )
+            assert resolve_replay_release_prep is not None
+
+            release_paths = release_contract.release_varying_paths(FINAL_TAG)
+
+            def release_external_facts() -> tuple[datetime, str, tuple[str, ...]]:
+                release_pr = resolve_replay_pr(release_ref, active["freeze_integration"])
+                release_author, release_head = validate_pr_core(release_pr, release_ref)
+                release_merged_at, release_integration = validate_merged_pr(
+                    release_pr,
+                    release_ref,
+                    require_descendant=True,
+                    require_tree=True,
+                )
+                require(
+                    release_merged_at > latest_work_merge,
+                    f"{entry_id} release preparation did not merge after both work PRs",
+                )
+                require_independent_approval(
+                    release_pr,
+                    release_ref,
+                    author=release_author,
+                    before=release_merged_at,
+                )
+                release = resolve_replay_release_prep(
+                    release_ref,
+                    release_paths,
+                    work_integrations,
+                )
+                require(
+                    release.validated_pr_ref == release_ref,
+                    f"{entry_id} release preparation was validated on another PR",
+                )
+                require(
+                    release.validated_head_oid == release_head,
+                    f"{entry_id} release preparation was not validated at its exact head",
+                )
+                require(
+                    release.validated_manifest_path == release_contract.manifest_path(FINAL_TAG),
+                    f"{entry_id} release preparation used another manifest",
+                )
+                require(
+                    release.validated_changed_paths == release_paths,
+                    f"{entry_id} release preparation used another changed-path set",
+                )
+                require(
+                    release.validated_work_integrations == work_integrations,
+                    f"{entry_id} release preparation used other work integrations",
+                )
+                require(release.complete is True, f"{entry_id} release diff is incomplete")
+                require(
+                    release.integration_parent_count in {1, 2},
+                    f"{entry_id} release integration has an invalid parent count",
+                )
+                require(
+                    release.unique_merge_base is True,
+                    f"{entry_id} release merge base is ambiguous",
+                )
+                require(
+                    release.integration_parent_is_ancestor_of_head is True,
+                    f"{entry_id} release parent is not an ancestor of its head",
+                )
+                if release.integration_parent_count == 2:
+                    require(
+                        release.integration_second_parent_matches_head is True,
+                        f"{entry_id} release second parent differs from its head",
+                    )
+                require(
+                    release.integration_descends_from_work_integrations is True,
+                    f"{entry_id} release does not descend from both work integrations",
+                )
+                require(
+                    release.exact_release_varying_path_diff is True,
+                    f"{entry_id} release diff is not exactly the policy-owned payload",
+                )
+                payload_blobs = validate_release_payload(
+                    resolve_replay_release_payload(release_head, FINAL_TAG, release_contract),
+                    tree_oid=release_head,
+                    tag=FINAL_TAG,
+                    contract=release_contract,
+                    subject=f"{entry_id} release preparation",
+                )
+                return release_merged_at, release_integration, payload_blobs
+
+            release_result = check_external(release_external_facts)
+            release_merged_at: datetime | None = None
+            release_integration: str | None = None
+            release_payload_blobs: tuple[str, ...] = ()
+            if isinstance(release_result, tuple):
+                release_merged_at, release_integration, release_payload_blobs = release_result
+                check_kind_record_fact(
+                    diff.validated_release_integration == release_integration,
+                    f"{entry_id} ancestry used another release integration",
+                )
+                check_kind_record_fact(
+                    diff.validated_work_integrations == work_integrations,
+                    f"{entry_id} ancestry used other work integrations",
+                )
+
+                def signoff_payload_facts() -> None:
+                    assert isinstance(record.head_oid, str)
+                    head_blobs = validate_release_payload(
+                        resolve_replay_release_payload(
+                            record.head_oid,
+                            FINAL_TAG,
+                            release_contract,
+                        ),
+                        tree_oid=record.head_oid,
+                        tag=FINAL_TAG,
+                        contract=release_contract,
+                        subject=f"{entry_id} sign-off head",
+                    )
+                    require(
+                        head_blobs == release_payload_blobs,
+                        f"{entry_id} sign-off head changed the prepared payload blobs",
+                    )
+                    freeze_blobs = validate_release_payload(
+                        resolve_replay_release_payload(
+                            source_sha,
+                            active["freeze_tag"],
+                            release_contract,
+                        ),
+                        tree_oid=source_sha,
+                        tag=active["freeze_tag"],
+                        contract=release_contract,
+                        subject=f"{entry_id} active freeze",
+                    )
+                    require(
+                        freeze_blobs == active["freeze_payload_blobs"],
+                        f"{entry_id} active freeze payload blobs changed",
+                    )
+
+                check_external(signoff_payload_facts)
+            require(
+                reviewer != maintainer_login,
+                f"{entry_id} reviewer must differ from maintainer",
+            )
+            if record_author:
+                require(
+                    reviewer != record_author,
+                    f"{entry_id} reviewer must differ from record author",
+                )
+            if not entry_is_invalid():
+                assert release_merged_at is not None
+                before = record_merged_at if not record_pending else None
+                check_external(
+                    lambda: require_independent_approval(
+                        record,
+                        record_ref,
+                        author=record_author,
+                        after=max(latest_work_merge, release_merged_at),
+                        before=before,
+                        named_reviewer=reviewer,
+                        distinct_from={maintainer_login},
+                    )
+                )
+            unresolved = sorted(
+                friction
+                for friction, fact in active["friction"].items()
+                if fact["triage"] == "fix-compatible" and fact["resolved"] is False
+            )
+            require(not unresolved, f"{entry_id} has unresolved friction: {', '.join(unresolved)}")
+            require(pending_reset is None, f"{entry_id} cannot sign off before reset")
+            if record_pending:
+                return finish_pending("sign-off-pending")
+            if not entry_is_invalid():
+                def signoff_postmerge_facts() -> None:
+                    assert (
+                        record_merged_at is not None
+                        and record_integration is not None
+                        and release_merged_at is not None
+                    )
+                    require(
+                        record_merged_at > max(latest_work_merge, release_merged_at),
+                        f"{entry_id} did not merge after work and release preparation",
+                    )
+                    merger = normalized_login(
+                        record.merged_by_login,
+                        f"{record_ref} mergedBy",
+                    )
+                    require(
+                        merger == maintainer_login,
+                        f"{entry_id} was not merged by github:{maintainer_login}",
+                    )
+                    integration_blobs = validate_release_payload(
+                        resolve_replay_release_payload(
+                            record_integration,
+                            FINAL_TAG,
+                            release_contract,
+                        ),
+                        tree_oid=record_integration,
+                        tag=FINAL_TAG,
+                        contract=release_contract,
+                        subject=f"{entry_id} sign-off integration",
+                    )
+                    require(
+                        integration_blobs == release_payload_blobs,
+                        f"{entry_id} integration changed the prepared payload blobs",
+                    )
+
+                check_external(signoff_postmerge_facts)
+                if not entry_is_invalid():
+                    assert record_integration is not None and release_integration is not None
+                    active = None
+                    signed = True
+                    successful_signoff = (entry_id, record_ref, record_integration)
+
+        if record_integration is not None and not entry_is_invalid():
+            last_record_integration = record_integration
+        seen[entry_id] = entry
+        seen_attempts[entry_id] = attempt
+        if entry_is_invalid():
+            require(not record_pending, f"{entry_id} cannot be invalid before merge")
+            pending_reset = ("record-invalid", entry_id)
+
+    if drift_targets and pending_reset is None:
+        pending_reset = ("record-invalid", drift_targets[0])
+        signed = False
+    assert tag_protection is not None
+    validate_tag_protection(tag_protection)
+    if terminal_tag_present and pending_reset is not None:
+        raise PolicyError("final tag exists while release evidence requires reset")
+    if terminal_tag_present and not signed:
+        raise PolicyError("final tag exists without a successfully validated sign-off")
+    if pending_reset is not None:
+        validate_absent_final_tag()
+        return f"reset-required:{pending_reset[1]}"
     if signed:
-        return "signed-off"
+        assert successful_signoff is not None
+        if terminal_tag_present:
+            require(shaped[-1][1] == "sign-off", "final tag exists without a final sign-off")
+            require(
+                entries[-1]["release_tag"] == FINAL_TAG,
+                "released sign-off names another tag",
+            )
+            require(final_tag.object_type == "tag", "final release tag is not annotated")
+            require(
+                isinstance(final_tag.object_id, str)
+                and SHA_RE.fullmatch(final_tag.object_id) is not None,
+                "final release tag object is invalid",
+            )
+            require(
+                isinstance(final_tag.commit, str)
+                and SHA_RE.fullmatch(final_tag.commit) is not None,
+                "final release tag target is invalid",
+            )
+            signoff_entry, signoff_record, signoff_integration = successful_signoff
+            require(
+                final_tag.validated_entry_id == signoff_entry,
+                "final tag was bound to another sign-off entry",
+            )
+            require(
+                final_tag.validated_record_pr == signoff_record,
+                "final tag was bound to another sign-off record PR",
+            )
+            require(
+                final_tag.commit == signoff_integration
+                and final_tag.commit_is_validated_record_integration is True,
+                "final tag does not target the validated sign-off integration",
+            )
+            return "released"
+        validate_absent_final_tag()
+        return "signed-off-awaiting-tag"
+    validate_absent_final_tag()
     if active is not None:
         return f"attempt-{active['attempt']}-active"
-    if entries:
-        return "reset"
-    return "not-started"
+    if last_attempt == 0:
+        return "not-started"
+    return "reset"
 
 
 def check_append_only(previous: str | None, current: str) -> None:
     if previous is None:
         return
-    require(current.startswith(previous), "SOAK-1.0.md changed existing bytes instead of appending")
+    require(
+        current.startswith(previous),
+        "SOAK-1.0.md changed existing bytes instead of appending",
+    )

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -1967,7 +1967,7 @@ def validate_entries(
     pending_reset: tuple[str, str] | None = None
     deferred_invalid_targets: list[str] = []
     signed = False
-    successful_signoff: tuple[str, str, str] | None = None
+    successful_signoff: tuple[str, str, str, str] | None = None
     used_source_refs: set[str] = set()
     used_source_shas: set[str] = set()
     used_tag_names: set[str] = set()
@@ -2273,6 +2273,7 @@ def validate_entries(
                 "source_sha": source_sha,
                 "freeze_tag": tag_name,
                 "freeze_time": record_merged_at,
+                "freeze_valid": not entry_is_invalid(),
                 "freeze_integration": record_integration or source_sha,
                 "freeze_payload_blobs": freeze_payload_blobs,
                 "work": {},
@@ -2304,10 +2305,16 @@ def validate_entries(
                     require_descendant=True,
                     require_tree=True,
                 )
-                require(
-                    work_merged_at > active["freeze_time"],
-                    f"{entry_id} work PR did not merge after T",
-                )
+                if active["freeze_valid"]:
+                    freeze_time = active["freeze_time"]
+                    require(
+                        isinstance(freeze_time, datetime),
+                        f"{entry_id} active freeze merge time is unavailable",
+                    )
+                    require(
+                        work_merged_at > freeze_time,
+                        f"{entry_id} work PR did not merge after T",
+                    )
                 require_independent_approval(
                     work_pr,
                     work_ref,
@@ -3186,7 +3193,12 @@ def validate_entries(
                     assert record_integration is not None and release_integration is not None
                     active = None
                     signed = True
-                    successful_signoff = (entry_id, record_ref, record_integration)
+                    successful_signoff = (
+                        entry_id,
+                        record_ref,
+                        record_integration,
+                        release_tag,
+                    )
 
         if record_integration is not None and not entry_is_invalid():
             last_record_integration = record_integration
@@ -3221,11 +3233,6 @@ def validate_entries(
     if signed:
         assert successful_signoff is not None
         if terminal_tag_present:
-            require(shaped[-1][1] == "sign-off", "final tag exists without a final sign-off")
-            require(
-                entries[-1]["release_tag"] == FINAL_TAG,
-                "released sign-off names another tag",
-            )
             require(final_tag.object_type == "tag", "final release tag is not annotated")
             require(
                 isinstance(final_tag.object_id, str)
@@ -3237,7 +3244,10 @@ def validate_entries(
                 and SHA_RE.fullmatch(final_tag.commit) is not None,
                 "final release tag target is invalid",
             )
-            signoff_entry, signoff_record, signoff_integration = successful_signoff
+            signoff_entry, signoff_record, signoff_integration, signoff_tag = (
+                successful_signoff
+            )
+            require(signoff_tag == FINAL_TAG, "released sign-off names another tag")
             require(
                 final_tag.validated_entry_id == signoff_entry,
                 "final tag was bound to another sign-off entry",

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -71,7 +71,7 @@ EXPECTED_POLICY = {
         "frozen_twin_lifetime": "permanent",
         "frozen_twin_precedent": "quantikz/quantikz2",
         "maintainer_identity": "github:lionsr",
-        "signer_identity_scheme": "github:lowercase-login",
+        "github_identity_scheme": "github:lowercase-login",
         "reviewer_repository_permissions": ["write", "admin"],
         "tag_immutability": "github-ruleset-no-update-delete-or-bypass",
         "release_manifest_pattern": "docs/tenkz/releases/TAG.toml",
@@ -101,6 +101,18 @@ EXPECTED_POLICY = {
         "release_reset_replay_schema": (
             "tests/tenkz/release-support/reset-replay-v1.schema.json"
         ),
+        "release_tag_signature": "ssh-ed25519",
+        "release_tag_public_key": (
+            "tests/tenkz/release-support/final-tag-signing-key.pub"
+        ),
+        "release_tag_object_schema": (
+            "tests/tenkz/release-support/final-tag-object-v1.schema.json"
+        ),
+        "release_publisher_environment": "tenkz-release-publisher",
+        "release_publisher_secret": "TENKZ_FINAL_TAG_SIGNING_KEY",
+        "release_publisher_secret_scope": "environment-only-no-shadow",
+        "release_publisher_key_retirement": "required-before-released",
+        "release_publisher_workflow_root": ".github/workflows",
         "release_test_dependency_contract": (
             "pinned-harness-support-declared-subject-roles"
         ),
@@ -335,6 +347,14 @@ class ReleaseContract:
     workflow_dependency_contract: str
     enforcement_network_contract: str
     reset_replay_schema: str
+    tag_signature: str
+    tag_public_key: str
+    tag_object_schema: str
+    publisher_environment: str
+    publisher_secret: str
+    publisher_secret_scope: str
+    publisher_key_retirement: str
+    publisher_workflow_root: str
     test_dependency_contract: str
     test_protocol: str
 
@@ -475,15 +495,49 @@ class TagEvidence:
     historical_current_namespace_complete: bool | None = None
     historical_current_matching_tag_names: tuple[str, ...] | None = None
     exists: bool | None = True
+    final_lookup_before_fetch_object_id: str | None = None
+    final_fetched_object_id: str | None = None
+    final_lookup_after_fetch_object_id: str | None = None
+    final_network_disabled_before_object_read: bool | None = None
+    final_raw_object_bytes_complete: bool | None = None
+    final_object_schema_valid: bool | None = None
+    final_recomputed_object_id: str | None = None
+    final_signature_algorithm: str | None = None
+    final_signature_namespace: str | None = None
+    final_raw_signature_valid: bool | None = None
+    final_public_key_blob_oid: str | None = None
+    final_public_key_from_pinned_support_tree: bool | None = None
+    final_schema_blob_oid: str | None = None
+    final_schema_from_pinned_support_tree: bool | None = None
+    final_tagger_identity_matches_schema: bool | None = None
+    final_tagger_epoch_seconds: int | None = None
+    final_tagger_timezone: str | None = None
+    final_message_tag: str | None = None
+    final_message_integration_oid: str | None = None
+    final_message_policy_sha256: str | None = None
+    final_message_prefix_sha256: str | None = None
+    final_message_prefix_boundary: str | None = None
+    final_commit_reachable_from_main: bool | None = None
 
 
 @dataclass(frozen=True)
 class FinalTagPublisherEvidence:
-    """Pinned post-merge validation and final-tag publisher job evidence."""
+    """Complete pinned publisher and terminal release-validation history."""
 
     validated_integration_oid: str | None
+    validated_tagger_epoch_seconds: int | None
+    validated_policy_sha256: str | None
+    validated_prefix_sha256: str | None
+    validated_prefix_boundary: str | None
+    validated_support_tree_oid: str | None
+    validated_schema_blob_oid: str | None
+    validated_public_key_blob_oid: str | None
     complete: bool | None
-    pinned_workflow_run_exact: bool | None
+    workflow_runs_complete_and_paginated: bool | None
+    workflow_jobs_complete_and_paginated: bool | None
+    release_validation_runs_complete_and_paginated: bool | None
+    prior_released_validation_exact_and_successful: bool | None
+    pinned_workflow_runs_exact: bool | None
     postmerge_validation_succeeded: bool | None
     postmerge_validation_network_disabled: bool | None
     publisher_status: str | None
@@ -492,15 +546,50 @@ class FinalTagPublisherEvidence:
     validation_jobs_lack_contents_write: bool | None
     publisher_has_only_contents_write: bool | None
     publisher_has_no_checkout_or_repository_execution: bool | None
-    publisher_uses_version_fingerprinted_hosted_gh: bool | None
+    publisher_has_no_uses_or_inherited_secrets: bool | None
+    publisher_uses_only_version_fingerprinted_hosted_gh_git_ssh_keygen: bool | None
     publisher_command_and_inputs_closed: bool | None
     publisher_uses_only_github_control_plane: bool | None
     other_networked_steps_absent: bool | None
-    final_ref_absent_before_create: bool | None
-    annotated_tag_object_targets_integration: bool | None
-    ref_created_without_force: bool | None
-    readback_complete_and_matching: bool | None
-    reported_tag_object_oid: str | None
+    closed_needs_tuple_complete_and_matching: bool | None
+    closed_needs_has_no_caller_substitute: bool | None
+    github_metadata_matches_closed_needs: bool | None
+    caller_controlled_inputs_absent: bool | None
+    exact_git_objects_fetched_by_oid_and_verified: bool | None
+    publisher_environment_and_secret_exact: bool | None
+    publisher_is_only_private_key_consumer: bool | None
+    deterministic_signed_tag_object_contract: bool | None
+    signature_algorithm_and_namespace_exact: bool | None
+    tagger_epoch_exact_canonical_and_in_range: bool | None
+    publisher_reads_ref_before_private_key_access: bool | None
+    private_key_available_only_to_absent_ref_path: bool | None
+    existing_ref_path_cannot_access_private_key: bool | None
+    absent_ref_candidate_authenticated_before_write: bool | None
+    existing_ref_object_authenticated_without_mutation: bool | None
+    publisher_success_requires_authenticated_final_readback: bool | None
+    publisher_emits_no_durable_output_receipt: bool | None
+    successful_job_head_matches_integration: bool | None
+    successful_job_historical_workflow_tree_matches_activation: bool | None
+    successful_job_follows_successful_postmerge_validation: bool | None
+    successful_job_conclusion_api_visible: bool | None
+
+
+@dataclass(frozen=True)
+class PublisherSecretEvidence:
+    """Exhaustive current locations for the publisher signing-key name."""
+
+    validated_environment: str | None
+    validated_secret_name: str | None
+    validated_secret_scope: str | None
+    validated_key_retirement: str | None
+    complete: bool | None
+    repository_environments_complete_and_paginated: bool | None
+    all_environment_secret_names_complete_and_paginated: bool | None
+    repository_secret_names_complete_and_paginated: bool | None
+    organization_secret_names_and_access_complete_and_paginated: bool | None
+    configured_secret_locations: tuple[str, ...] | None
+    dedicated_environment_configuration_complete: bool | None
+    dedicated_environment_restricts_protected_release_branch: bool | None
 
 
 @dataclass(frozen=True)
@@ -558,6 +647,7 @@ class WorkflowEvidence:
     validated_activation_integration: str | None
     validated_target_oid: str | None
     validated_paths: tuple[str, ...] | None
+    validated_publisher_workflow_root: str | None
     complete: bool | None
     activation_paths_are_regular_blobs: bool | None
     target_blobs_and_modes_match_activation: bool | None
@@ -573,6 +663,12 @@ class WorkflowEvidence:
     candidate_diff_untouched: bool | None
     github_checks_bind_exact_head_and_workflows: bool | None
     supervisor_receipt_complete_and_matching: bool | None
+    activation_publisher_workflow_tree_complete: bool | None
+    target_publisher_workflow_tree_matches_activation: bool | None
+    workflow_jobs_complete_and_paginated: bool | None
+    publisher_is_sole_environment_consumer: bool | None
+    publisher_is_sole_secret_consumer: bool | None
+    workflow_secret_inheritance_absent: bool | None
 
 
 @dataclass(frozen=True)
@@ -603,6 +699,18 @@ class ActivationDiffEvidence:
     hermetic_execution_contract_valid: bool | None
     supervisor_self_test_receipt_valid: bool | None
     enforcement_workflows_pinned: bool | None
+    publisher_workflow_tree_pinned: bool | None
+    publisher_workflow_jobs_complete_and_paginated: bool | None
+    publisher_is_sole_environment_consumer: bool | None
+    publisher_is_sole_secret_consumer: bool | None
+    workflow_secret_inheritance_absent: bool | None
+    publisher_environment_configuration_complete: bool | None
+    publisher_environment_restricts_protected_release_branch: bool | None
+    repository_environments_complete_and_paginated: bool | None
+    all_environment_secret_names_complete_and_paginated: bool | None
+    repository_secret_names_complete_and_paginated: bool | None
+    organization_secret_names_and_access_complete_and_paginated: bool | None
+    configured_secret_only_in_dedicated_environment: bool | None
     policy_digest_matches: bool | None
     ledger_prefix_matches: bool | None
 
@@ -661,11 +769,18 @@ ResolveReplayReleaseTestObservation = Callable[
 ResolveReplayFreezeTag = Callable[[str], TagEvidence]
 ResolveCurrentFinalTag = Callable[[str], TagEvidence]
 ResolveFinalTagPublisher = Callable[[str], FinalTagPublisherEvidence]
+ResolveCurrentPublisherSecret = Callable[
+    [str, str, str, str],
+    PublisherSecretEvidence,
+]
 ResolveReplayIssue = Callable[[str], IssueEvidence]
 ResolveReplayRecordInvalidReset = Callable[
     [str, str, str, str, str], RecordInvalidResetReplayEvidence
 ]
-ResolveCurrentWorkflow = Callable[[str, str, tuple[str, ...]], WorkflowEvidence]
+ResolveCurrentWorkflow = Callable[
+    [str, str, tuple[str, ...], str],
+    WorkflowEvidence,
+]
 
 
 def require(condition: bool, message: str) -> None:
@@ -954,6 +1069,25 @@ def utc_instant(value: object, field: str) -> datetime:
     return value.astimezone(timezone.utc)
 
 
+def canonical_tagger_epoch_seconds(value: object, field: str) -> int:
+    """Convert one exact integral UTC instant to the closed tagger scalar."""
+
+    require(isinstance(value, datetime), f"{field} is missing or malformed")
+    require(
+        value.tzinfo is not None
+        and value.utcoffset() == timezone.utc.utcoffset(value)
+        and value.microsecond == 0,
+        f"{field} is not an unambiguous integral UTC instant",
+    )
+    seconds = int(value.timestamp())
+    require(0 <= seconds < 2**63, f"{field} is outside the tagger epoch range")
+    require(
+        datetime.fromtimestamp(seconds, timezone.utc) == value.astimezone(timezone.utc),
+        f"{field} does not have a canonical tagger epoch",
+    )
+    return seconds
+
+
 def policy_rules(
     policy: dict,
 ) -> tuple[
@@ -992,8 +1126,8 @@ def policy_rules(
         "policy",
     )
     require(
-        root.get("signer_identity_scheme") == "github:lowercase-login",
-        "policy has the wrong signer identity scheme",
+        root.get("github_identity_scheme") == "github:lowercase-login",
+        "policy has the wrong GitHub identity scheme",
     )
     reviewer_permissions = root.get("reviewer_repository_permissions")
     require(
@@ -1023,6 +1157,14 @@ def policy_rules(
         workflow_dependency_contract=str(root.get("release_workflow_dependencies", "")),
         enforcement_network_contract=str(root.get("release_enforcement_network", "")),
         reset_replay_schema=str(root.get("release_reset_replay_schema", "")),
+        tag_signature=str(root.get("release_tag_signature", "")),
+        tag_public_key=str(root.get("release_tag_public_key", "")),
+        tag_object_schema=str(root.get("release_tag_object_schema", "")),
+        publisher_environment=str(root.get("release_publisher_environment", "")),
+        publisher_secret=str(root.get("release_publisher_secret", "")),
+        publisher_secret_scope=str(root.get("release_publisher_secret_scope", "")),
+        publisher_key_retirement=str(root.get("release_publisher_key_retirement", "")),
+        publisher_workflow_root=str(root.get("release_publisher_workflow_root", "")),
         test_dependency_contract=str(root.get("release_test_dependency_contract", "")),
         test_protocol=str(root.get("release_test_protocol", "")),
     )
@@ -1043,6 +1185,14 @@ def policy_rules(
             contract.workflow_dependency_contract,
             contract.enforcement_network_contract,
             contract.reset_replay_schema,
+            contract.tag_signature,
+            contract.tag_public_key,
+            contract.tag_object_schema,
+            contract.publisher_environment,
+            contract.publisher_secret,
+            contract.publisher_secret_scope,
+            contract.publisher_key_retirement,
+            contract.publisher_workflow_root,
             contract.test_dependency_contract,
             contract.test_protocol,
         )
@@ -1071,6 +1221,14 @@ def policy_rules(
             "transitive-content-addressed-no-runtime-downloads",
             "disabled-before-repository-code",
             "tests/tenkz/release-support/reset-replay-v1.schema.json",
+            "ssh-ed25519",
+            "tests/tenkz/release-support/final-tag-signing-key.pub",
+            "tests/tenkz/release-support/final-tag-object-v1.schema.json",
+            "tenkz-release-publisher",
+            "TENKZ_FINAL_TAG_SIGNING_KEY",
+            "environment-only-no-shadow",
+            "required-before-released",
+            ".github/workflows",
             "pinned-harness-support-declared-subject-roles",
             "hermetic-repository-view-no-shell-or-network",
         ),
@@ -1738,6 +1896,7 @@ def validate_workflow_evidence(
     activation_integration: str,
     target_oid: str,
     workflow_paths: tuple[str, ...],
+    publisher_workflow_root: str,
 ) -> None:
     """Bind enforcement results to pinned workflow bytes and dependencies."""
 
@@ -1747,6 +1906,10 @@ def validate_workflow_evidence(
     )
     require(evidence.validated_target_oid == target_oid, "workflow evidence used another target")
     require(evidence.validated_paths == workflow_paths, "workflow evidence used another path set")
+    require(
+        evidence.validated_publisher_workflow_root == publisher_workflow_root,
+        "workflow evidence used another publisher workflow root",
+    )
     require(evidence.complete is True, "workflow evidence is incomplete")
     require(
         evidence.activation_paths_are_regular_blobs is True,
@@ -1801,23 +1964,168 @@ def validate_workflow_evidence(
         evidence.supervisor_receipt_complete_and_matching is True,
         "independent evidence-supervisor receipt is incomplete or mismatched",
     )
+    require(
+        evidence.activation_publisher_workflow_tree_complete is True,
+        "activation publisher workflow tree is incomplete",
+    )
+    require(
+        evidence.target_publisher_workflow_tree_matches_activation is True,
+        "publisher workflow tree differs from activation",
+    )
+    require(
+        evidence.workflow_jobs_complete_and_paginated is True,
+        "publisher workflow job enumeration is incomplete",
+    )
+    require(
+        evidence.publisher_is_sole_environment_consumer is True,
+        "another workflow job names the publisher environment",
+    )
+    require(
+        evidence.publisher_is_sole_secret_consumer is True,
+        "another workflow job names the publisher secret",
+    )
+    require(
+        evidence.workflow_secret_inheritance_absent is True,
+        "publisher workflow permits inherited secrets",
+    )
+
+
+def validate_publisher_secret(
+    evidence: PublisherSecretEvidence,
+    *,
+    contract: ReleaseContract,
+    retired: bool,
+    require_environment_configuration: bool,
+) -> None:
+    """Require exhaustive secret-name visibility and the exact lifecycle state."""
+
+    require(
+        evidence.validated_environment == contract.publisher_environment,
+        "publisher secret evidence used another environment",
+    )
+    require(
+        evidence.validated_secret_name == contract.publisher_secret,
+        "publisher secret evidence used another secret name",
+    )
+    require(
+        evidence.validated_secret_scope == contract.publisher_secret_scope,
+        "publisher secret evidence used another scope contract",
+    )
+    require(
+        evidence.validated_key_retirement == contract.publisher_key_retirement,
+        "publisher secret evidence used another retirement contract",
+    )
+    require(evidence.complete is True, "publisher secret evidence is incomplete")
+    require(
+        evidence.repository_environments_complete_and_paginated is True,
+        "repository environment pagination is incomplete",
+    )
+    require(
+        evidence.all_environment_secret_names_complete_and_paginated is True,
+        "environment secret-name pagination is incomplete",
+    )
+    require(
+        evidence.repository_secret_names_complete_and_paginated is True,
+        "repository secret-name pagination is incomplete",
+    )
+    require(
+        evidence.organization_secret_names_and_access_complete_and_paginated is True,
+        "organization secret-name or access pagination is incomplete",
+    )
+    locations = evidence.configured_secret_locations
+    require(
+        isinstance(locations, tuple)
+        and all(isinstance(location, str) and location for location in locations)
+        and len(locations) == len(set(locations)),
+        "publisher secret locations are incomplete or malformed",
+    )
+    if retired:
+        require(
+            not locations,
+            "publisher signing-key name was reintroduced after retirement",
+        )
+    else:
+        require(
+            locations == (f"environment:{contract.publisher_environment}",),
+            "publisher signing-key name is missing, shadowed, or outside its environment",
+        )
+    if require_environment_configuration:
+        require(
+            evidence.dedicated_environment_configuration_complete is True,
+            "publisher environment configuration is incomplete",
+        )
+        require(
+            evidence.dedicated_environment_restricts_protected_release_branch is True,
+            "publisher environment does not restrict the protected release branch",
+        )
 
 
 def validate_final_tag_publisher(
     evidence: FinalTagPublisherEvidence,
     *,
     integration_oid: str,
-) -> tuple[str, str | None]:
-    """Validate the pinned publisher state for one sign-off integration."""
+    tagger_epoch_seconds: int,
+    policy_sha256: str,
+    prefix_boundary: str,
+    support_tree_oid: str,
+) -> str:
+    """Validate the complete pinned publisher retry history for one sign-off."""
 
     require(
         evidence.validated_integration_oid == integration_oid,
         "final-tag publisher evidence used another sign-off integration",
     )
+    require(
+        evidence.validated_tagger_epoch_seconds == tagger_epoch_seconds,
+        "final-tag publisher evidence used another tagger epoch",
+    )
+    require(
+        evidence.validated_policy_sha256 == policy_sha256,
+        "final-tag publisher evidence used another policy hash",
+    )
+    require(
+        isinstance(evidence.validated_prefix_sha256, str)
+        and SHA256_RE.fullmatch(evidence.validated_prefix_sha256) is not None,
+        "final-tag publisher evidence has an invalid ledger-prefix hash",
+    )
+    require(
+        evidence.validated_prefix_boundary == prefix_boundary,
+        "final-tag publisher evidence used another ledger-prefix boundary",
+    )
+    require(
+        evidence.validated_support_tree_oid == support_tree_oid,
+        "final-tag publisher evidence used another support tree",
+    )
+    require(
+        isinstance(evidence.validated_schema_blob_oid, str)
+        and SHA_RE.fullmatch(evidence.validated_schema_blob_oid) is not None,
+        "final-tag publisher evidence has an invalid object-schema blob OID",
+    )
+    require(
+        isinstance(evidence.validated_public_key_blob_oid, str)
+        and SHA_RE.fullmatch(evidence.validated_public_key_blob_oid) is not None,
+        "final-tag publisher evidence has an invalid public-key blob OID",
+    )
     require(evidence.complete is True, "final-tag publisher evidence is incomplete")
     require(
-        evidence.pinned_workflow_run_exact is True,
-        "final-tag publisher run is not bound to the pinned exact workflow",
+        evidence.workflow_runs_complete_and_paginated is True,
+        "final-tag publisher run pagination is incomplete",
+    )
+    require(
+        evidence.workflow_jobs_complete_and_paginated is True,
+        "final-tag publisher job pagination is incomplete",
+    )
+    require(
+        evidence.release_validation_runs_complete_and_paginated is True,
+        "release-validation run pagination is incomplete",
+    )
+    require(
+        isinstance(evidence.prior_released_validation_exact_and_successful, bool),
+        "prior released-validation history is unavailable",
+    )
+    require(
+        evidence.pinned_workflow_runs_exact is True,
+        "final-tag publisher runs are not bound to the pinned exact workflow",
     )
     require(
         evidence.postmerge_validation_succeeded is True,
@@ -1844,8 +2152,12 @@ def validate_final_tag_publisher(
         "final-tag publisher checks out or executes repository content",
     )
     require(
-        evidence.publisher_uses_version_fingerprinted_hosted_gh is True,
-        "final-tag publisher uses another executable",
+        evidence.publisher_has_no_uses_or_inherited_secrets is True,
+        "final-tag publisher uses an action, called workflow, or inherited secret",
+    )
+    require(
+        evidence.publisher_uses_only_version_fingerprinted_hosted_gh_git_ssh_keygen is True,
+        "final-tag publisher uses an unpinned or unapproved executable",
     )
     require(
         evidence.publisher_command_and_inputs_closed is True,
@@ -1859,50 +2171,222 @@ def validate_final_tag_publisher(
         evidence.other_networked_steps_absent is True,
         "release workflow has another networked step",
     )
+    require(
+        evidence.closed_needs_tuple_complete_and_matching is True,
+        "final-tag publisher closed needs tuple is incomplete or mismatched",
+    )
+    require(
+        evidence.closed_needs_has_no_caller_substitute is True,
+        "final-tag publisher accepts a caller substitute for closed needs",
+    )
+    require(
+        evidence.github_metadata_matches_closed_needs is True,
+        "trusted GitHub metadata differs from the closed needs tuple",
+    )
+    require(
+        evidence.caller_controlled_inputs_absent is True,
+        "final-tag publisher accepts a caller-controlled input",
+    )
+    require(
+        evidence.exact_git_objects_fetched_by_oid_and_verified is True,
+        "final-tag publisher did not fetch and verify the exact Git objects by OID",
+    )
+    require(
+        evidence.publisher_environment_and_secret_exact is True,
+        "final-tag publisher uses another environment or secret",
+    )
+    require(
+        evidence.publisher_is_only_private_key_consumer is True,
+        "another job can consume the final-tag private key",
+    )
+    require(
+        evidence.deterministic_signed_tag_object_contract is True,
+        "final-tag publisher does not construct the deterministic signed object",
+    )
+    require(
+        evidence.signature_algorithm_and_namespace_exact is True,
+        "final-tag publisher uses another signature algorithm or namespace",
+    )
+    require(
+        evidence.tagger_epoch_exact_canonical_and_in_range is True,
+        "final-tag publisher tagger epoch is not canonical or in range",
+    )
+    require(
+        evidence.publisher_reads_ref_before_private_key_access is True,
+        "final-tag publisher accesses the private key before reading the ref",
+    )
+    require(
+        evidence.private_key_available_only_to_absent_ref_path is True,
+        "final-tag private key is available outside absent-ref construction",
+    )
+    require(
+        evidence.existing_ref_path_cannot_access_private_key is True,
+        "existing-ref retry can access the private key",
+    )
+    require(
+        evidence.absent_ref_candidate_authenticated_before_write is True,
+        "publisher does not authenticate the candidate object before its first write",
+    )
+    require(
+        evidence.existing_ref_object_authenticated_without_mutation is True,
+        "publisher does not authenticate an existing exact object without mutation",
+    )
+    require(
+        evidence.publisher_success_requires_authenticated_final_readback is True,
+        "publisher can succeed without an authenticated final readback",
+    )
+    require(
+        evidence.publisher_emits_no_durable_output_receipt is True,
+        "final-tag publisher relies on a durable job-output receipt",
+    )
     status = evidence.publisher_status
     require(
-        status in {"not-run", "success", "failure"},
+        status in {"not-run", "incomplete", "failure", "success"},
         "final-tag publisher has an invalid status",
+    )
+    if status != "success":
+        require(
+            evidence.prior_released_validation_exact_and_successful is False,
+            "prior released validation lacks a successful publisher job",
+        )
+    successful_job_evidence = (
+        evidence.successful_job_head_matches_integration,
+        evidence.successful_job_historical_workflow_tree_matches_activation,
+        evidence.successful_job_follows_successful_postmerge_validation,
+        evidence.successful_job_conclusion_api_visible,
     )
     if status == "not-run":
         require(
             evidence.publisher_started_after_validation_success is None
-            and evidence.final_ref_absent_before_create is None
-            and evidence.annotated_tag_object_targets_integration is None
-            and evidence.ref_created_without_force is None
-            and evidence.readback_complete_and_matching is None
-            and evidence.reported_tag_object_oid is None,
-            "publisher that did not run carries creation evidence",
+            and successful_job_evidence == (None, None, None, None),
+            "publisher that did not run carries successful-job evidence",
         )
-        return status, None
+        return status
     require(
         evidence.publisher_started_after_validation_success is True,
         "final-tag publisher did not start after validation success",
     )
-    if status == "failure":
-        raise PolicyError("final-tag publisher failed; hard release incident")
+    if status in {"incomplete", "failure"}:
+        require(
+            successful_job_evidence == (None, None, None, None),
+            "unsuccessful publisher history carries successful-job evidence",
+        )
+        return status
     require(
-        evidence.final_ref_absent_before_create is True,
-        "final tag existed before the publisher create operation",
+        evidence.successful_job_head_matches_integration is True,
+        "successful publisher job used another head",
     )
     require(
-        evidence.annotated_tag_object_targets_integration is True,
-        "publisher did not create an annotated tag object for the integration",
+        evidence.successful_job_historical_workflow_tree_matches_activation is True,
+        "successful publisher job used another historical workflow tree",
     )
     require(
-        evidence.ref_created_without_force is True,
-        "publisher did not create the absent final ref without force",
+        evidence.successful_job_follows_successful_postmerge_validation is True,
+        "successful publisher job did not follow its successful validation job",
     )
     require(
-        evidence.readback_complete_and_matching is True,
-        "publisher final-tag readback is incomplete or mismatched",
+        evidence.successful_job_conclusion_api_visible is True,
+        "successful publisher job conclusion is not API-visible",
     )
-    object_oid = evidence.reported_tag_object_oid
+    return status
+
+
+def validate_authenticated_final_tag(
+    evidence: TagEvidence,
+    *,
+    integration_oid: str,
+    tagger_epoch_seconds: int,
+    policy_sha256: str,
+    prefix_boundary: str,
+    publisher: FinalTagPublisherEvidence,
+    contract: ReleaseContract,
+) -> str:
+    """Authenticate the exact current annotated object after a stable double lookup."""
+
+    require(evidence.exists is True, "final tag is absent")
+    require(evidence.object_type == "tag", "final release tag is not annotated")
+    object_id = evidence.object_id
     require(
-        isinstance(object_oid, str) and SHA_RE.fullmatch(object_oid) is not None,
-        "publisher did not report a valid final tag-object OID",
+        isinstance(object_id, str) and SHA_RE.fullmatch(object_id) is not None,
+        "final release tag object is invalid",
     )
-    return status, object_oid
+    require(
+        evidence.final_lookup_before_fetch_object_id
+        == evidence.final_fetched_object_id
+        == evidence.final_lookup_after_fetch_object_id
+        == object_id,
+        "final tag changed across exact-object fetch and double resolution",
+    )
+    require(
+        evidence.final_network_disabled_before_object_read is True,
+        "final tag object was read before network removal",
+    )
+    require(
+        evidence.final_raw_object_bytes_complete is True,
+        "final tag raw object bytes are incomplete",
+    )
+    require(
+        evidence.final_object_schema_valid is True,
+        "final tag object does not satisfy the pinned byte schema",
+    )
+    require(
+        evidence.final_recomputed_object_id == object_id,
+        "final tag raw object hash does not match its OID",
+    )
+    require(
+        evidence.final_signature_algorithm == contract.tag_signature,
+        "final tag uses another signature algorithm",
+    )
+    require(
+        evidence.final_signature_namespace == "git",
+        "final tag SSH signature uses another namespace",
+    )
+    require(evidence.final_raw_signature_valid is True, "final tag raw signature is invalid")
+    require(
+        evidence.final_public_key_blob_oid == publisher.validated_public_key_blob_oid
+        and evidence.final_public_key_from_pinned_support_tree is True,
+        "final tag verification used another public key",
+    )
+    require(
+        evidence.final_schema_blob_oid == publisher.validated_schema_blob_oid
+        and evidence.final_schema_from_pinned_support_tree is True,
+        "final tag verification used another object schema",
+    )
+    require(
+        evidence.final_tagger_identity_matches_schema is True,
+        "final tag tagger identity differs from the pinned schema",
+    )
+    require(
+        evidence.final_tagger_epoch_seconds == tagger_epoch_seconds,
+        "final tag tagger epoch differs from the closed publisher tuple",
+    )
+    require(evidence.final_tagger_timezone == "+0000", "final tag timezone is not +0000")
+    require(evidence.final_message_tag == FINAL_TAG, "final tag payload names another tag")
+    require(
+        evidence.final_message_integration_oid == integration_oid,
+        "final tag payload names another sign-off integration",
+    )
+    require(
+        evidence.final_message_policy_sha256 == policy_sha256,
+        "final tag payload names another policy hash",
+    )
+    require(
+        evidence.final_message_prefix_sha256 == publisher.validated_prefix_sha256,
+        "final tag payload names another ledger-prefix hash",
+    )
+    require(
+        evidence.final_message_prefix_boundary == prefix_boundary,
+        "final tag payload names another ledger-prefix boundary",
+    )
+    require(
+        evidence.commit == integration_oid,
+        "final tag does not peel to the validated sign-off integration",
+    )
+    require(
+        evidence.final_commit_reachable_from_main is True,
+        "final tag integration is not reachable from current main",
+    )
+    return object_id
 
 
 def validate_entries(
@@ -1923,6 +2407,7 @@ def validate_entries(
     resolve_replay_freeze_tag: ResolveReplayFreezeTag | None = None,
     resolve_current_final_tag: ResolveCurrentFinalTag | None = None,
     resolve_final_tag_publisher: ResolveFinalTagPublisher | None = None,
+    resolve_current_publisher_secret: ResolveCurrentPublisherSecret | None = None,
     resolve_replay_issue: ResolveReplayIssue | None = None,
     resolve_replay_record_invalid_reset: ResolveReplayRecordInvalidReset | None = None,
     resolve_current_workflow: ResolveCurrentWorkflow | None = None,
@@ -1966,6 +2451,10 @@ def validate_entries(
     require(
         resolve_final_tag_publisher is not None,
         "entry validation requires final-tag publisher evidence",
+    )
+    require(
+        resolve_current_publisher_secret is not None,
+        "entry validation requires publisher secret evidence",
     )
     require(
         resolve_replay_freeze_tag is not None,
@@ -2275,6 +2764,54 @@ def validate_entries(
         "activation enforcement workflows or dependencies are not pinned",
     )
     require(
+        activation_diff.publisher_workflow_tree_pinned is True,
+        "activation publisher workflow tree is not pinned",
+    )
+    require(
+        activation_diff.publisher_workflow_jobs_complete_and_paginated is True,
+        "activation publisher workflow job enumeration is incomplete",
+    )
+    require(
+        activation_diff.publisher_is_sole_environment_consumer is True,
+        "another activation workflow job names the publisher environment",
+    )
+    require(
+        activation_diff.publisher_is_sole_secret_consumer is True,
+        "another activation workflow job names the publisher secret",
+    )
+    require(
+        activation_diff.workflow_secret_inheritance_absent is True,
+        "activation publisher workflow permits inherited secrets",
+    )
+    require(
+        activation_diff.publisher_environment_configuration_complete is True,
+        "activation publisher environment configuration is incomplete",
+    )
+    require(
+        activation_diff.publisher_environment_restricts_protected_release_branch is True,
+        "activation publisher environment does not restrict the protected release branch",
+    )
+    require(
+        activation_diff.repository_environments_complete_and_paginated is True,
+        "activation repository environment pagination is incomplete",
+    )
+    require(
+        activation_diff.all_environment_secret_names_complete_and_paginated is True,
+        "activation environment secret-name pagination is incomplete",
+    )
+    require(
+        activation_diff.repository_secret_names_complete_and_paginated is True,
+        "activation repository secret-name pagination is incomplete",
+    )
+    require(
+        activation_diff.organization_secret_names_and_access_complete_and_paginated is True,
+        "activation organization secret-name or access pagination is incomplete",
+    )
+    require(
+        activation_diff.configured_secret_only_in_dedicated_environment is True,
+        "activation publisher secret is missing, shadowed, or outside its environment",
+    )
+    require(
         activation_diff.policy_digest_matches is True,
         "activation policy digest is wrong",
     )
@@ -2303,6 +2840,7 @@ def validate_entries(
     )
 
     final_tag_cache: TagEvidence | None = None
+    publisher_secret_cache: PublisherSecretEvidence | None = None
 
     def current_final_tag() -> TagEvidence:
         nonlocal final_tag_cache
@@ -2314,19 +2852,64 @@ def validate_entries(
             )
         return final_tag_cache
 
-    def validate_current_controls() -> None:
-        assert tag_protection is not None and resolve_current_workflow is not None
+    def current_publisher_secret() -> PublisherSecretEvidence:
+        nonlocal publisher_secret_cache
+        assert resolve_current_publisher_secret is not None
+        if publisher_secret_cache is None:
+            publisher_secret_cache = resolve_current_publisher_secret(
+                release_contract.publisher_environment,
+                release_contract.publisher_secret,
+                release_contract.publisher_secret_scope,
+                release_contract.publisher_key_retirement,
+            )
+        return publisher_secret_cache
+
+    def validate_pinned_current_workflow() -> None:
+        assert resolve_current_workflow is not None
         validate_workflow_evidence(
             resolve_current_workflow(
                 activation_integration,
                 validation_target_oid,
                 release_contract.enforcement_workflows,
+                release_contract.publisher_workflow_root,
             ),
             activation_integration=activation_integration,
             target_oid=validation_target_oid,
             workflow_paths=release_contract.enforcement_workflows,
+            publisher_workflow_root=release_contract.publisher_workflow_root,
         )
+
+    def validate_pre_release_controls() -> None:
+        assert tag_protection is not None
+        validate_pinned_current_workflow()
         validate_tag_protection(tag_protection)
+        validate_publisher_secret(
+            current_publisher_secret(),
+            contract=release_contract,
+            retired=False,
+            require_environment_configuration=True,
+        )
+
+    def validate_release_transition_controls() -> None:
+        assert tag_protection is not None
+        validate_pinned_current_workflow()
+        validate_tag_protection(tag_protection)
+        validate_publisher_secret(
+            current_publisher_secret(),
+            contract=release_contract,
+            retired=True,
+            require_environment_configuration=True,
+        )
+
+    def validate_released_controls() -> None:
+        assert tag_protection is not None
+        validate_tag_protection(tag_protection)
+        validate_publisher_secret(
+            current_publisher_secret(),
+            contract=release_contract,
+            retired=True,
+            require_environment_configuration=False,
+        )
 
     def validate_absent_final_tag() -> None:
         final_tag = current_final_tag()
@@ -2339,12 +2922,35 @@ def validate_entries(
             and final_tag.candidate_matching_tag_names is None
             and final_tag.historical_candidate_check_exact_and_successful is None
             and final_tag.historical_current_namespace_complete is None
-            and final_tag.historical_current_matching_tag_names is None,
+            and final_tag.historical_current_matching_tag_names is None
+            and final_tag.final_lookup_before_fetch_object_id is None
+            and final_tag.final_fetched_object_id is None
+            and final_tag.final_lookup_after_fetch_object_id is None
+            and final_tag.final_network_disabled_before_object_read is None
+            and final_tag.final_raw_object_bytes_complete is None
+            and final_tag.final_object_schema_valid is None
+            and final_tag.final_recomputed_object_id is None
+            and final_tag.final_signature_algorithm is None
+            and final_tag.final_signature_namespace is None
+            and final_tag.final_raw_signature_valid is None
+            and final_tag.final_public_key_blob_oid is None
+            and final_tag.final_public_key_from_pinned_support_tree is None
+            and final_tag.final_schema_blob_oid is None
+            and final_tag.final_schema_from_pinned_support_tree is None
+            and final_tag.final_tagger_identity_matches_schema is None
+            and final_tag.final_tagger_epoch_seconds is None
+            and final_tag.final_tagger_timezone is None
+            and final_tag.final_message_tag is None
+            and final_tag.final_message_integration_oid is None
+            and final_tag.final_message_policy_sha256 is None
+            and final_tag.final_message_prefix_sha256 is None
+            and final_tag.final_message_prefix_boundary is None
+            and final_tag.final_commit_reachable_from_main is None,
             "absent final-tag evidence is inconsistent",
         )
 
     def finish_pending(state: str) -> str:
-        validate_current_controls()
+        validate_pre_release_controls()
         validate_absent_final_tag()
         return state
 
@@ -2359,8 +2965,8 @@ def validate_entries(
     pending_reset: tuple[str, str] | None = None
     deferred_invalid_targets: list[str] = []
     signed = False
-    successful_signoff: tuple[str, str, str, str] | None = None
-    observed_signoff: tuple[str, str, str, str] | None = None
+    successful_signoff: tuple[str, str, str, str, int] | None = None
+    observed_signoff: tuple[str, str, str, str, int] | None = None
     used_source_refs: set[str] = set()
     used_source_shas: set[str] = set()
     used_tag_names: set[str] = set()
@@ -3533,13 +4139,23 @@ def validate_entries(
             require(source_sha == active["source_sha"], f"{entry_id} names the wrong source SHA")
             require(release_tag == "tenkz-v1.0.0", f"{entry_id} has the wrong release tag")
             require(decision == "release", f"{entry_id} decision must be release")
+            tagger_epoch_seconds: int | None = None
             if not record_pending and record_integration is not None:
-                observed_signoff = (
-                    entry_id,
-                    record_ref,
-                    record_integration,
-                    release_tag,
+                tagger_epoch_result = check_external(
+                    lambda: canonical_tagger_epoch_seconds(
+                        record.merged_at,
+                        f"{record_ref} mergedAt",
+                    )
                 )
+                if isinstance(tagger_epoch_result, int):
+                    tagger_epoch_seconds = tagger_epoch_result
+                    observed_signoff = (
+                        entry_id,
+                        record_ref,
+                        record_integration,
+                        release_tag,
+                        tagger_epoch_seconds,
+                    )
             require(
                 len(active["work"]) == required_work_count
                 and set(active["work"]) == set(work_classes),
@@ -3776,7 +4392,12 @@ def validate_entries(
 
                 check_external(signoff_postmerge_facts)
                 if not entry_is_invalid():
-                    assert record_integration is not None and release_integration is not None
+                    assert (
+                        record_integration is not None
+                        and release_integration is not None
+                        and record_merged_at is not None
+                        and tagger_epoch_seconds is not None
+                    )
                     active = None
                     signed = True
                     successful_signoff = (
@@ -3784,6 +4405,7 @@ def validate_entries(
                         record_ref,
                         record_integration,
                         release_tag,
+                        tagger_epoch_seconds,
                     )
 
         if record_integration is not None and not entry_is_invalid():
@@ -3806,16 +4428,27 @@ def validate_entries(
             deferred_invalid_targets.sort(key=entry_positions.__getitem__)
 
     activate_current_record_queue()
-    validate_current_controls()
     final_tag = current_final_tag()
     terminal_tag_present = final_tag.exists is True
     publisher_status: str | None = None
-    published_tag_object: str | None = None
+    publisher_evidence: FinalTagPublisherEvidence | None = None
     if observed_signoff is not None:
         assert resolve_final_tag_publisher is not None
-        publisher_status, published_tag_object = validate_final_tag_publisher(
-            resolve_final_tag_publisher(observed_signoff[2]),
-            integration_oid=observed_signoff[2],
+        (
+            signoff_entry_id,
+            _signoff_record_ref,
+            observed_signoff_integration,
+            _observed_release_tag,
+            observed_tagger_epoch_seconds,
+        ) = observed_signoff
+        publisher_evidence = resolve_final_tag_publisher(observed_signoff_integration)
+        publisher_status = validate_final_tag_publisher(
+            publisher_evidence,
+            integration_oid=observed_signoff_integration,
+            tagger_epoch_seconds=observed_tagger_epoch_seconds,
+            policy_sha256=soak_root["policy_sha256"],
+            prefix_boundary=signoff_entry_id,
+            support_tree_oid=release_contract.test_support_tree,
         )
     if terminal_tag_present and pending_reset is not None:
         raise PolicyError("final tag exists while release evidence requires reset")
@@ -3824,49 +4457,56 @@ def validate_entries(
     if terminal_tag_present and not signed:
         raise PolicyError("final tag exists without a successfully validated sign-off")
     if pending_reset is not None:
+        validate_pre_release_controls()
         validate_absent_final_tag()
         return f"reset-required:{pending_reset[1]}"
     if signed:
         assert successful_signoff is not None
-        _signoff_entry, _signoff_record, signoff_integration, signoff_tag = (
-            successful_signoff
-        )
+        (
+            signoff_entry,
+            _signoff_record,
+            signoff_integration,
+            signoff_tag,
+            tagger_epoch_seconds,
+        ) = successful_signoff
         require(signoff_tag == FINAL_TAG, "released sign-off names another tag")
         require(
-            publisher_status in {"not-run", "success"},
+            publisher_status in {"not-run", "incomplete", "failure", "success"},
             "final-tag publisher evidence is unavailable after sign-off",
         )
-        if publisher_status == "not-run":
-            require(
-                not terminal_tag_present,
-                "final tag exists without the successful pinned publisher",
-            )
+        assert publisher_evidence is not None
+        if not terminal_tag_present:
+            if publisher_status == "success":
+                raise PolicyError(
+                    "final-tag publisher succeeded but the final ref is absent; "
+                    "hard release incident"
+                )
+            validate_pre_release_controls()
             validate_absent_final_tag()
             return "signed-off-awaiting-tag"
-        require(
-            terminal_tag_present,
-            "final-tag publisher succeeded but the final ref is absent; hard release incident",
+        validate_authenticated_final_tag(
+            final_tag,
+            integration_oid=signoff_integration,
+            tagger_epoch_seconds=tagger_epoch_seconds,
+            policy_sha256=soak_root["policy_sha256"],
+            prefix_boundary=signoff_entry,
+            publisher=publisher_evidence,
+            contract=release_contract,
         )
-        require(final_tag.object_type == "tag", "final release tag is not annotated")
-        require(
-            isinstance(final_tag.object_id, str)
-            and SHA_RE.fullmatch(final_tag.object_id) is not None,
-            "final release tag object is invalid",
-        )
-        require(
-            isinstance(final_tag.commit, str)
-            and SHA_RE.fullmatch(final_tag.commit) is not None,
-            "final release tag target is invalid",
-        )
-        require(
-            final_tag.object_id == published_tag_object,
-            "current final tag object differs from the publisher output",
-        )
-        require(
-            final_tag.commit == signoff_integration,
-            "final tag does not target the validated sign-off integration",
-        )
+        if publisher_status != "success":
+            validate_pre_release_controls()
+            return "signed-off-awaiting-publisher-success"
+        publisher_secret = current_publisher_secret()
+        if publisher_evidence.prior_released_validation_exact_and_successful is True:
+            validate_released_controls()
+            return "released"
+        secret_locations = publisher_secret.configured_secret_locations
+        if secret_locations:
+            validate_pre_release_controls()
+            return "signed-off-awaiting-key-retirement"
+        validate_release_transition_controls()
         return "released"
+    validate_pre_release_controls()
     validate_absent_final_tag()
     if active is not None:
         return f"attempt-{active['attempt']}-active"

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -149,6 +149,7 @@ FIELDS_BY_KIND = {
         "source_sha",
         "freeze_tag_object",
         "freeze_tag",
+        "freeze_tag_snapshot",
         "prerequisites",
         "evidence",
     },
@@ -469,13 +470,37 @@ class TagEvidence:
     object_type: str | None
     commit: str | None
     candidate_namespace_complete: bool | None = None
-    candidate_patch_exceeds_current_namespace: bool | None = None
+    candidate_matching_tag_names: tuple[str, ...] | None = None
     historical_candidate_check_exact_and_successful: bool | None = None
-    historical_compares_only_earlier_freezes: bool | None = None
+    historical_current_namespace_complete: bool | None = None
+    historical_current_matching_tag_names: tuple[str, ...] | None = None
     exists: bool | None = True
-    validated_entry_id: str | None = None
-    validated_record_pr: str | None = None
-    commit_is_validated_record_integration: bool | None = None
+
+
+@dataclass(frozen=True)
+class FinalTagPublisherEvidence:
+    """Pinned post-merge validation and final-tag publisher job evidence."""
+
+    validated_integration_oid: str | None
+    complete: bool | None
+    pinned_workflow_run_exact: bool | None
+    postmerge_validation_succeeded: bool | None
+    postmerge_validation_network_disabled: bool | None
+    publisher_status: str | None
+    publisher_needs_exact_postmerge_validation: bool | None
+    publisher_started_after_validation_success: bool | None
+    validation_jobs_lack_contents_write: bool | None
+    publisher_has_only_contents_write: bool | None
+    publisher_has_no_checkout_or_repository_execution: bool | None
+    publisher_uses_version_fingerprinted_hosted_gh: bool | None
+    publisher_command_and_inputs_closed: bool | None
+    publisher_uses_only_github_control_plane: bool | None
+    other_networked_steps_absent: bool | None
+    final_ref_absent_before_create: bool | None
+    annotated_tag_object_targets_integration: bool | None
+    ref_created_without_force: bool | None
+    readback_complete_and_matching: bool | None
+    reported_tag_object_oid: str | None
 
 
 @dataclass(frozen=True)
@@ -635,6 +660,7 @@ ResolveReplayReleaseTestObservation = Callable[
 ]
 ResolveReplayFreezeTag = Callable[[str], TagEvidence]
 ResolveCurrentFinalTag = Callable[[str], TagEvidence]
+ResolveFinalTagPublisher = Callable[[str], FinalTagPublisherEvidence]
 ResolveReplayIssue = Callable[[str], IssueEvidence]
 ResolveReplayRecordInvalidReset = Callable[
     [str, str, str, str, str], RecordInvalidResetReplayEvidence
@@ -829,6 +855,27 @@ def closed_string_list(value: object, field: str, entry_id: str) -> list[str]:
     )
     require(len(value) == len(set(value)), f"{entry_id} field {field} has duplicates")
     return value
+
+
+def ordered_freeze_tag_names(value: object, subject: str) -> tuple[str, ...]:
+    """Validate a complete freeze-tag namespace snapshot in numeric order."""
+
+    require(
+        isinstance(value, (list, tuple))
+        and bool(value)
+        and all(
+            isinstance(item, str) and FREEZE_TAG_RE.fullmatch(item) is not None
+            for item in value
+        ),
+        f"{subject} is missing or contains an invalid freeze tag name",
+    )
+    names = tuple(value)
+    require(len(names) == len(set(names)), f"{subject} contains duplicate tag names")
+    require(
+        names == tuple(sorted(names, key=lambda name: int(name.rsplit(".", 1)[1]))),
+        f"{subject} is not in ascending numeric PATCH order",
+    )
+    return names
 
 
 def normalized_repository_path(value: object) -> str | None:
@@ -1756,6 +1803,108 @@ def validate_workflow_evidence(
     )
 
 
+def validate_final_tag_publisher(
+    evidence: FinalTagPublisherEvidence,
+    *,
+    integration_oid: str,
+) -> tuple[str, str | None]:
+    """Validate the pinned publisher state for one sign-off integration."""
+
+    require(
+        evidence.validated_integration_oid == integration_oid,
+        "final-tag publisher evidence used another sign-off integration",
+    )
+    require(evidence.complete is True, "final-tag publisher evidence is incomplete")
+    require(
+        evidence.pinned_workflow_run_exact is True,
+        "final-tag publisher run is not bound to the pinned exact workflow",
+    )
+    require(
+        evidence.postmerge_validation_succeeded is True,
+        "final-tag publisher lacks successful exact post-merge validation",
+    )
+    require(
+        evidence.postmerge_validation_network_disabled is True,
+        "final-tag publisher validation was not network-disabled",
+    )
+    require(
+        evidence.publisher_needs_exact_postmerge_validation is True,
+        "final-tag publisher does not depend on the exact validation job",
+    )
+    require(
+        evidence.validation_jobs_lack_contents_write is True,
+        "a validation job has contents write permission",
+    )
+    require(
+        evidence.publisher_has_only_contents_write is True,
+        "final-tag publisher has missing or excess permissions",
+    )
+    require(
+        evidence.publisher_has_no_checkout_or_repository_execution is True,
+        "final-tag publisher checks out or executes repository content",
+    )
+    require(
+        evidence.publisher_uses_version_fingerprinted_hosted_gh is True,
+        "final-tag publisher uses another executable",
+    )
+    require(
+        evidence.publisher_command_and_inputs_closed is True,
+        "final-tag publisher command or inputs are not closed",
+    )
+    require(
+        evidence.publisher_uses_only_github_control_plane is True,
+        "final-tag publisher uses a non-GitHub network service",
+    )
+    require(
+        evidence.other_networked_steps_absent is True,
+        "release workflow has another networked step",
+    )
+    status = evidence.publisher_status
+    require(
+        status in {"not-run", "success", "failure"},
+        "final-tag publisher has an invalid status",
+    )
+    if status == "not-run":
+        require(
+            evidence.publisher_started_after_validation_success is None
+            and evidence.final_ref_absent_before_create is None
+            and evidence.annotated_tag_object_targets_integration is None
+            and evidence.ref_created_without_force is None
+            and evidence.readback_complete_and_matching is None
+            and evidence.reported_tag_object_oid is None,
+            "publisher that did not run carries creation evidence",
+        )
+        return status, None
+    require(
+        evidence.publisher_started_after_validation_success is True,
+        "final-tag publisher did not start after validation success",
+    )
+    if status == "failure":
+        raise PolicyError("final-tag publisher failed; hard release incident")
+    require(
+        evidence.final_ref_absent_before_create is True,
+        "final tag existed before the publisher create operation",
+    )
+    require(
+        evidence.annotated_tag_object_targets_integration is True,
+        "publisher did not create an annotated tag object for the integration",
+    )
+    require(
+        evidence.ref_created_without_force is True,
+        "publisher did not create the absent final ref without force",
+    )
+    require(
+        evidence.readback_complete_and_matching is True,
+        "publisher final-tag readback is incomplete or mismatched",
+    )
+    object_oid = evidence.reported_tag_object_oid
+    require(
+        isinstance(object_oid, str) and SHA_RE.fullmatch(object_oid) is not None,
+        "publisher did not report a valid final tag-object OID",
+    )
+    return status, object_oid
+
+
 def validate_entries(
     entries: list[dict],
     *,
@@ -1773,6 +1922,7 @@ def validate_entries(
     ) = None,
     resolve_replay_freeze_tag: ResolveReplayFreezeTag | None = None,
     resolve_current_final_tag: ResolveCurrentFinalTag | None = None,
+    resolve_final_tag_publisher: ResolveFinalTagPublisher | None = None,
     resolve_replay_issue: ResolveReplayIssue | None = None,
     resolve_replay_record_invalid_reset: ResolveReplayRecordInvalidReset | None = None,
     resolve_current_workflow: ResolveCurrentWorkflow | None = None,
@@ -1812,6 +1962,10 @@ def validate_entries(
     require(
         resolve_current_final_tag is not None,
         "entry validation requires current final-tag evidence",
+    )
+    require(
+        resolve_final_tag_publisher is not None,
+        "entry validation requires final-tag publisher evidence",
     )
     require(
         resolve_replay_freeze_tag is not None,
@@ -2182,12 +2336,10 @@ def validate_entries(
             and final_tag.object_type is None
             and final_tag.commit is None
             and final_tag.candidate_namespace_complete is None
-            and final_tag.candidate_patch_exceeds_current_namespace is None
+            and final_tag.candidate_matching_tag_names is None
             and final_tag.historical_candidate_check_exact_and_successful is None
-            and final_tag.historical_compares_only_earlier_freezes is None
-            and final_tag.validated_entry_id is None
-            and final_tag.validated_record_pr is None
-            and final_tag.commit_is_validated_record_integration is None,
+            and final_tag.historical_current_namespace_complete is None
+            and final_tag.historical_current_matching_tag_names is None,
             "absent final-tag evidence is inconsistent",
         )
 
@@ -2208,6 +2360,7 @@ def validate_entries(
     deferred_invalid_targets: list[str] = []
     signed = False
     successful_signoff: tuple[str, str, str, str] | None = None
+    observed_signoff: tuple[str, str, str, str] | None = None
     used_source_refs: set[str] = set()
     used_source_shas: set[str] = set()
     used_tag_names: set[str] = set()
@@ -2404,6 +2557,23 @@ def validate_entries(
             )
             patch = int(tag_name.rsplit(".", 1)[1])
             require(patch > prior_patch, f"{entry_id} freeze PATCH must increase")
+            tag_snapshot = ordered_freeze_tag_names(
+                entry["freeze_tag_snapshot"],
+                f"{entry_id} freeze_tag_snapshot",
+            )
+            require(
+                tag_name in tag_snapshot,
+                f"{entry_id} freeze_tag_snapshot omits its freeze tag",
+            )
+            other_snapshot_patches = tuple(
+                int(name.rsplit(".", 1)[1])
+                for name in tag_snapshot
+                if name != tag_name
+            )
+            require(
+                patch > max(other_snapshot_patches, default=-1),
+                f"{entry_id} freeze PATCH is not maximal in its retained snapshot",
+            )
             require(tag_name not in used_tag_names, f"{entry_id} reuses a freeze tag")
             require(tag_object not in used_tag_objects, f"{entry_id} reuses a freeze tag object")
             listed = closed_string_list(entry["prerequisites"], "prerequisites", entry_id)
@@ -2449,8 +2619,12 @@ def validate_entries(
                         f"{entry_id} candidate tag namespace is incompletely paginated",
                     )
                     require(
-                        tag.candidate_patch_exceeds_current_namespace is True,
-                        f"{entry_id} candidate PATCH does not exceed the current namespace",
+                        ordered_freeze_tag_names(
+                            tag.candidate_matching_tag_names,
+                            f"{entry_id} candidate tag namespace",
+                        )
+                        == tag_snapshot,
+                        f"{entry_id} retained snapshot differs from the candidate namespace",
                     )
                 else:
                     require(
@@ -2458,8 +2632,16 @@ def validate_entries(
                         f"{entry_id} lacks its exact successful candidate PATCH check",
                     )
                     require(
-                        tag.historical_compares_only_earlier_freezes is True,
-                        f"{entry_id} historical PATCH check includes a later tag",
+                        tag.historical_current_namespace_complete is True,
+                        f"{entry_id} current tag namespace is incompletely paginated",
+                    )
+                    current_tag_names = ordered_freeze_tag_names(
+                        tag.historical_current_matching_tag_names,
+                        f"{entry_id} current tag namespace",
+                    )
+                    require(
+                        set(tag_snapshot).issubset(current_tag_names),
+                        f"{entry_id} current tag namespace lost a retained name",
                     )
                 payload_blobs = validate_release_payload(
                     resolve_replay_release_payload(source_sha, tag_name, release_contract),
@@ -3351,6 +3533,13 @@ def validate_entries(
             require(source_sha == active["source_sha"], f"{entry_id} names the wrong source SHA")
             require(release_tag == "tenkz-v1.0.0", f"{entry_id} has the wrong release tag")
             require(decision == "release", f"{entry_id} decision must be release")
+            if not record_pending and record_integration is not None:
+                observed_signoff = (
+                    entry_id,
+                    record_ref,
+                    record_integration,
+                    release_tag,
+                )
             require(
                 len(active["work"]) == required_work_count
                 and set(active["work"]) == set(work_classes),
@@ -3620,8 +3809,18 @@ def validate_entries(
     validate_current_controls()
     final_tag = current_final_tag()
     terminal_tag_present = final_tag.exists is True
+    publisher_status: str | None = None
+    published_tag_object: str | None = None
+    if observed_signoff is not None:
+        assert resolve_final_tag_publisher is not None
+        publisher_status, published_tag_object = validate_final_tag_publisher(
+            resolve_final_tag_publisher(observed_signoff[2]),
+            integration_oid=observed_signoff[2],
+        )
     if terminal_tag_present and pending_reset is not None:
         raise PolicyError("final tag exists while release evidence requires reset")
+    if publisher_status == "success" and pending_reset is not None:
+        raise PolicyError("final-tag publisher succeeded while release evidence requires reset")
     if terminal_tag_present and not signed:
         raise PolicyError("final tag exists without a successfully validated sign-off")
     if pending_reset is not None:
@@ -3629,38 +3828,45 @@ def validate_entries(
         return f"reset-required:{pending_reset[1]}"
     if signed:
         assert successful_signoff is not None
-        if terminal_tag_present:
-            require(final_tag.object_type == "tag", "final release tag is not annotated")
+        _signoff_entry, _signoff_record, signoff_integration, signoff_tag = (
+            successful_signoff
+        )
+        require(signoff_tag == FINAL_TAG, "released sign-off names another tag")
+        require(
+            publisher_status in {"not-run", "success"},
+            "final-tag publisher evidence is unavailable after sign-off",
+        )
+        if publisher_status == "not-run":
             require(
-                isinstance(final_tag.object_id, str)
-                and SHA_RE.fullmatch(final_tag.object_id) is not None,
-                "final release tag object is invalid",
+                not terminal_tag_present,
+                "final tag exists without the successful pinned publisher",
             )
-            require(
-                isinstance(final_tag.commit, str)
-                and SHA_RE.fullmatch(final_tag.commit) is not None,
-                "final release tag target is invalid",
-            )
-            signoff_entry, signoff_record, signoff_integration, signoff_tag = (
-                successful_signoff
-            )
-            require(signoff_tag == FINAL_TAG, "released sign-off names another tag")
-            require(
-                final_tag.validated_entry_id == signoff_entry,
-                "final tag was bound to another sign-off entry",
-            )
-            require(
-                final_tag.validated_record_pr == signoff_record,
-                "final tag was bound to another sign-off record PR",
-            )
-            require(
-                final_tag.commit == signoff_integration
-                and final_tag.commit_is_validated_record_integration is True,
-                "final tag does not target the validated sign-off integration",
-            )
-            return "released"
-        validate_absent_final_tag()
-        return "signed-off-awaiting-tag"
+            validate_absent_final_tag()
+            return "signed-off-awaiting-tag"
+        require(
+            terminal_tag_present,
+            "final-tag publisher succeeded but the final ref is absent; hard release incident",
+        )
+        require(final_tag.object_type == "tag", "final release tag is not annotated")
+        require(
+            isinstance(final_tag.object_id, str)
+            and SHA_RE.fullmatch(final_tag.object_id) is not None,
+            "final release tag object is invalid",
+        )
+        require(
+            isinstance(final_tag.commit, str)
+            and SHA_RE.fullmatch(final_tag.commit) is not None,
+            "final release tag target is invalid",
+        )
+        require(
+            final_tag.object_id == published_tag_object,
+            "current final tag object differs from the publisher output",
+        )
+        require(
+            final_tag.commit == signoff_integration,
+            "final tag does not target the validated sign-off integration",
+        )
+        return "released"
     validate_absent_final_tag()
     if active is not None:
         return f"attempt-{active['attempt']}-active"

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -296,6 +296,7 @@ def validate_entries(
     pending_break: str | None = None
     signed = False
     prior_freeze_sha: str | None = None
+    prior_freeze_utc: datetime | None = None
     used_freeze_tags: set[str] = set()
     used_freeze_objects: set[str] = set()
     used_freeze_shas: set[str] = set()
@@ -364,9 +365,19 @@ def validate_entries(
             require(tag.commit == freeze_sha, f"{entry_id} freeze tag peels to another commit")
             require(tag.tagger_utc is not None, f"{entry_id} annotated tag lacks a tagger date")
             require(
+                tag.tagger_utc.tzinfo is not None
+                and tag.tagger_utc.utcoffset() is not None,
+                f"{entry_id} tagger timestamp must be timezone-aware",
+            )
+            require(
                 tag.tagger_utc.astimezone(timezone.utc) == tagger_utc,
                 f"{entry_id} tagger timestamp differs from the tag object",
             )
+            if prior_freeze_utc is not None:
+                require(
+                    tagger_utc > prior_freeze_utc,
+                    f"{entry_id} tagger timestamp must follow the prior freeze",
+                )
             require(
                 tag.reachable_from_main,
                 f"{entry_id} freeze commit is not reachable from main",
@@ -405,6 +416,7 @@ def validate_entries(
                 "friction": {},
             }
             prior_freeze_sha = freeze_sha
+            prior_freeze_utc = tagger_utc
             used_freeze_tags.add(freeze_tag)
             used_freeze_objects.add(tag_object)
             used_freeze_shas.add(freeze_sha)
@@ -429,13 +441,17 @@ def validate_entries(
                 )
                 require(SHA_RE.fullmatch(work_sha) is not None, f"{entry_id} has invalid work_sha")
                 require(
+                    work_sha != active["freeze_sha"],
+                    f"{entry_id} reuses the freeze commit as work evidence",
+                )
+                require(
                     entry_date == work_utc.date(),
                     f"{entry_id} date differs from the work commit UTC date",
                 )
                 require(work_utc <= current, f"{entry_id} work commit is in the future")
                 require(
-                    work_utc >= active["freeze_utc"],
-                    f"{entry_id} work commit predates the freeze tag",
+                    work_utc > active["freeze_utc"],
+                    f"{entry_id} work commit must postdate the freeze tag",
                 )
                 require(resolve_commit is not None, f"{entry_id} requires Git commit resolution")
                 commit = resolve_commit(work_sha, active["freeze_sha"])
@@ -443,6 +459,11 @@ def validate_entries(
                 require(
                     commit.committed_utc is not None,
                     f"{entry_id} work commit lacks a committer date",
+                )
+                require(
+                    commit.committed_utc.tzinfo is not None
+                    and commit.committed_utc.utcoffset() is not None,
+                    f"{entry_id} work commit timestamp must be timezone-aware",
                 )
                 require(
                     commit.committed_utc.astimezone(timezone.utc) == work_utc,

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -537,6 +537,9 @@ class FinalTagPublisherEvidence:
     workflow_jobs_complete_and_paginated: bool | None
     release_validation_runs_complete_and_paginated: bool | None
     prior_released_validation_exact_and_successful: bool | None
+    prior_released_validation_prefix_boundary: str | None
+    prior_released_validation_target_oid: str | None
+    prior_released_validation_target_contains_exact_prefix: bool | None
     pinned_workflow_runs_exact: bool | None
     postmerge_validation_succeeded: bool | None
     postmerge_validation_network_disabled: bool | None
@@ -2067,6 +2070,7 @@ def validate_final_tag_publisher(
     tagger_epoch_seconds: int,
     policy_sha256: str,
     prefix_boundary: str,
+    current_prefix_boundary: str,
     support_tree_oid: str,
 ) -> str:
     """Validate the complete pinned publisher retry history for one sign-off."""
@@ -2123,6 +2127,29 @@ def validate_final_tag_publisher(
         isinstance(evidence.prior_released_validation_exact_and_successful, bool),
         "prior released-validation history is unavailable",
     )
+    if evidence.prior_released_validation_exact_and_successful:
+        require(
+            evidence.prior_released_validation_prefix_boundary
+            == current_prefix_boundary,
+            "prior released validation used another ledger prefix",
+        )
+        require(
+            isinstance(evidence.prior_released_validation_target_oid, str)
+            and SHA_RE.fullmatch(evidence.prior_released_validation_target_oid)
+            is not None,
+            "prior released validation target is missing or malformed",
+        )
+        require(
+            evidence.prior_released_validation_target_contains_exact_prefix is True,
+            "prior released validation target did not contain the exact ledger prefix",
+        )
+    else:
+        require(
+            evidence.prior_released_validation_prefix_boundary is None
+            and evidence.prior_released_validation_target_oid is None
+            and evidence.prior_released_validation_target_contains_exact_prefix is None,
+            "non-released history carries a released-validation binding",
+        )
     require(
         evidence.pinned_workflow_runs_exact is True,
         "final-tag publisher runs are not bound to the pinned exact workflow",
@@ -2966,7 +2993,6 @@ def validate_entries(
     deferred_invalid_targets: list[str] = []
     signed = False
     successful_signoff: tuple[str, str, str, str, int] | None = None
-    observed_signoff: tuple[str, str, str, str, int] | None = None
     used_source_refs: set[str] = set()
     used_source_shas: set[str] = set()
     used_tag_names: set[str] = set()
@@ -3820,23 +3846,46 @@ def validate_entries(
                         subject=f"{entry_id} fix-head test {test_ref}",
                     )
                     )
+                    integration_fingerprint, integration_programs, integration_fixtures = (
+                        validate_release_test_observation(
+                            resolve_replay_release_test_observation(
+                                fix_integration,
+                                active["freeze_tag"],
+                                test_ref,
+                                release_contract,
+                            ),
+                            tree_oid=fix_integration,
+                            tag=active["freeze_tag"],
+                            test_ref=test_ref,
+                            surface=fact["surface"],
+                            expected_result="passed",
+                            expected_failure_fingerprint=fingerprint,
+                            contract=release_contract,
+                            subject=f"{entry_id} fix-integration test {test_ref}",
+                        )
+                    )
                     require(
-                        base_fingerprint == head_fingerprint == fingerprint,
+                        base_fingerprint
+                        == head_fingerprint
+                        == integration_fingerprint
+                        == fingerprint,
                         f"{entry_id} test {test_ref} changed its pinned fingerprint",
                     )
                     require(
                         base_programs
                         == head_programs
+                        == integration_programs
                         == inventory_fact["program_paths"],
                         f"{entry_id} test {test_ref} changed its declared program roles",
                     )
                     require(
                         base_fixtures
                         == head_fixtures
+                        == integration_fixtures
                         == inventory_fact["fixture_paths"],
                         f"{entry_id} test {test_ref} changed its declared fixture roles",
                     )
-                validate_release_payload(
+                head_payload_blobs = validate_release_payload(
                     resolve_replay_release_payload(
                         fix_head,
                         active["freeze_tag"],
@@ -3846,6 +3895,21 @@ def validate_entries(
                     tag=active["freeze_tag"],
                     contract=release_contract,
                     subject=f"{entry_id} fix head",
+                )
+                integration_payload_blobs = validate_release_payload(
+                    resolve_replay_release_payload(
+                        fix_integration,
+                        active["freeze_tag"],
+                        release_contract,
+                    ),
+                    tree_oid=fix_integration,
+                    tag=active["freeze_tag"],
+                    contract=release_contract,
+                    subject=f"{entry_id} fix integration",
+                )
+                require(
+                    integration_payload_blobs == head_payload_blobs,
+                    f"{entry_id} fix integration changed the validated payload blobs",
                 )
                 return fix_merged_at, fix_integration
 
@@ -4149,13 +4213,6 @@ def validate_entries(
                 )
                 if isinstance(tagger_epoch_result, int):
                     tagger_epoch_seconds = tagger_epoch_result
-                    observed_signoff = (
-                        entry_id,
-                        record_ref,
-                        record_integration,
-                        release_tag,
-                        tagger_epoch_seconds,
-                    )
             require(
                 len(active["work"]) == required_work_count
                 and set(active["work"]) == set(work_classes),
@@ -4432,26 +4489,32 @@ def validate_entries(
     terminal_tag_present = final_tag.exists is True
     publisher_status: str | None = None
     publisher_evidence: FinalTagPublisherEvidence | None = None
-    if observed_signoff is not None:
+    if terminal_tag_present and pending_reset is not None:
+        raise PolicyError("final tag exists while release evidence requires reset")
+    if successful_signoff is not None:
         assert resolve_final_tag_publisher is not None
         (
             signoff_entry_id,
             _signoff_record_ref,
-            observed_signoff_integration,
+            successful_signoff_integration,
             _observed_release_tag,
-            observed_tagger_epoch_seconds,
-        ) = observed_signoff
-        publisher_evidence = resolve_final_tag_publisher(observed_signoff_integration)
+            successful_tagger_epoch_seconds,
+        ) = successful_signoff
+        publisher_evidence = resolve_final_tag_publisher(successful_signoff_integration)
+        current_prefix_boundary = audit.boundary_entry_id
+        require(
+            isinstance(current_prefix_boundary, str),
+            "released-validation history requires a nonempty ledger prefix",
+        )
         publisher_status = validate_final_tag_publisher(
             publisher_evidence,
-            integration_oid=observed_signoff_integration,
-            tagger_epoch_seconds=observed_tagger_epoch_seconds,
+            integration_oid=successful_signoff_integration,
+            tagger_epoch_seconds=successful_tagger_epoch_seconds,
             policy_sha256=soak_root["policy_sha256"],
             prefix_boundary=signoff_entry_id,
+            current_prefix_boundary=current_prefix_boundary,
             support_tree_oid=release_contract.test_support_tree,
         )
-    if terminal_tag_present and pending_reset is not None:
-        raise PolicyError("final tag exists while release evidence requires reset")
     if publisher_status == "success" and pending_reset is not None:
         raise PolicyError("final-tag publisher succeeded while release evidence requires reset")
     if terminal_tag_present and not signed:

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -25,6 +25,7 @@ PR_REF_RE = re.compile(r"#[1-9][0-9]*")
 ISSUE_REF_RE = PR_REF_RE
 IDENTITY_RE = re.compile(r"github:[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?")
 LOGIN_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?")
+TEST_REF_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
 
 ENTRY_KINDS = {
     "freeze",
@@ -53,6 +54,8 @@ EXPECTED_POLICY = {
         "work_classes": list(WORK_CLASSES),
         "one_class_per_work_pr": True,
         "work_excluded_paths": ["TNLean/Archive/**"],
+        "tex_api_fix_paths": ["tex/tenkz/**/*.tex", "tex/tenkz/**/*.sty"],
+        "tnlog_fix_paths": ["tex/tenkz/**/*.tex", "tex/tenkz/**/*.sty"],
         "event_format_owners": ["#4162", "#4703"],
         "soak_blocker_chain": [
             ["#5086", "#4699", "#4162"],
@@ -275,13 +278,13 @@ class ResolutionDiffEvidence:
     integration_strict_descendant_of_freeze: bool | None
     integration_strict_descendant_of_friction: bool | None
     policy_paths_untouched: bool | None
-    has_added_or_modified_regular_nonledger_blob: bool | None
-    normalized_token_stream_changed: bool | None
-    semantic_witness_is_same_regular_nonledger_blob: bool | None
-    validated_contract: ReleaseContract | None
-    inventory_commands_complete: bool | None
-    inventory_commands_passed: bool | None
-    execution_receipts_exact_and_matching: bool | None
+    validated_base_oid: str | None
+    validated_surface: str | None
+    validated_fix_path_patterns: tuple[str, ...] | None
+    semantic_witness_path: str | None
+    surface_matching_added_or_modified_regular_blob: bool | None
+    tex_comment_stripped_token_stream_changed: bool | None
+    semantic_witness_is_same_surface_regular_blob: bool | None
 
 
 @dataclass(frozen=True)
@@ -300,6 +303,8 @@ class ReleaseContract:
     test_support_root: str
     test_support_tree: str
     test_data_roots: tuple[str, ...]
+    tex_api_fix_paths: tuple[str, ...]
+    tnlog_fix_paths: tuple[str, ...]
     enforcement_workflows: tuple[str, ...]
     workflow_dependency_contract: str
     enforcement_network_contract: str
@@ -318,6 +323,12 @@ class ReleaseContract:
             self.change_record,
             self.event_format,
         )
+
+    def fix_paths(self, surface: str) -> tuple[str, ...]:
+        """Return the closed policy path set for one compatibility surface."""
+
+        require(surface in SURFACES, f"unknown compatibility surface {surface}")
+        return self.tex_api_fix_paths if surface == "tex-api" else self.tnlog_fix_paths
 
 
 @dataclass(frozen=True)
@@ -345,6 +356,45 @@ class ReleasePayloadEvidence:
     test_execution_complete: bool | None
     compatibility_tests_passed: bool | None
     payload_blob_oids: tuple[str, ...] | None
+    inventory_test_surfaces_valid: bool | None
+
+
+@dataclass(frozen=True)
+class ReleaseTestObservationEvidence:
+    """Exact single-test receipt for friction regression observation."""
+
+    validated_tree_oid: str | None
+    validated_tag: str | None
+    validated_test_ref: str | None
+    validated_contract: ReleaseContract | None
+    complete: bool | None
+    manifest_path: str | None
+    regular_distinct_paths: bool | None
+    manifest_contract_valid: bool | None
+    artifact_declarations_agree: bool | None
+    inventory_digest_matches: bool | None
+    inventory_contract_valid: bool | None
+    inventory_test_surfaces_valid: bool | None
+    inventory_test_exists: bool | None
+    inventory_command_exact_and_matching: bool | None
+    test_code_tree_matches: bool | None
+    test_support_tree_matches: bool | None
+    inventory_data_paths_within_mutable_roots: bool | None
+    executable_dependencies_within_code_tree: bool | None
+    acceptance_dependencies_within_support_tree: bool | None
+    subject_data_cannot_reduce_coverage: bool | None
+    hermetic_execution_contract_valid: bool | None
+    tool_fingerprints_match: bool | None
+    inventory_test_surfaces: tuple[str, ...] | None
+    exactly_one_inventory_test_run: bool | None
+    setup_complete_and_matching: bool | None
+    isolation_valid: bool | None
+    execution_receipt_exact_and_matching: bool | None
+    execution_complete: bool | None
+    timed_out: bool | None
+    terminated_by_signal: bool | None
+    clean_process_exit: bool | None
+    exit_code: int | None
 
 
 @dataclass(frozen=True)
@@ -473,6 +523,7 @@ class ActivationDiffEvidence:
     enforcement_workflows_pinned: bool | None
     policy_digest_matches: bool | None
     ledger_prefix_matches: bool | None
+    inventory_test_surfaces_valid: bool | None
 
 
 @dataclass(frozen=True)
@@ -523,6 +574,9 @@ ResolveReplayReleasePrep = Callable[
     [str, tuple[str, ...], tuple[str, ...]], ReleasePrepEvidence
 ]
 ResolveReplayReleasePayload = Callable[[str, str, ReleaseContract], ReleasePayloadEvidence]
+ResolveReplayReleaseTestObservation = Callable[
+    [str, str, str, ReleaseContract], ReleaseTestObservationEvidence
+]
 ResolveReplayFreezeTag = Callable[[str], TagEvidence]
 ResolveCurrentFinalTag = Callable[[str], TagEvidence]
 ResolveReplayIssue = Callable[[str], IssueEvidence]
@@ -721,6 +775,27 @@ def closed_string_list(value: object, field: str, entry_id: str) -> list[str]:
     return value
 
 
+def normalized_repository_path(value: object) -> str | None:
+    """Return a normalized repository-relative path, or ``None``."""
+
+    if not isinstance(value, str) or not value or value.startswith("/") or "\\" in value:
+        return None
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return value
+
+
+def policy_glob_matches(path: str, pattern: str) -> bool:
+    """Match the policy's normalized ``*``/``**`` repository path grammar."""
+
+    expression = re.escape(pattern)
+    expression = expression.replace(r"\*\*/", r"(?:[^/]+/)*")
+    expression = expression.replace(r"\*", r"[^/]*")
+    expression = expression.replace(r"\?", r"[^/]")
+    return re.fullmatch(expression, path) is not None
+
+
 def sha(value: object, field: str, entry_id: str) -> str:
     result = nonempty_string(value, field, entry_id)
     require(SHA_RE.fullmatch(result) is not None, f"{entry_id} has invalid {field}")
@@ -833,6 +908,8 @@ def policy_rules(
         test_support_root=str(root.get("release_test_support_root", "")),
         test_support_tree=str(root.get("release_test_support_tree", "")),
         test_data_roots=tuple(root.get("release_test_data_roots", ())),
+        tex_api_fix_paths=tuple(root.get("tex_api_fix_paths", ())),
+        tnlog_fix_paths=tuple(root.get("tnlog_fix_paths", ())),
         enforcement_workflows=tuple(root.get("release_enforcement_workflows", ())),
         workflow_dependency_contract=str(root.get("release_workflow_dependencies", "")),
         enforcement_network_contract=str(root.get("release_enforcement_network", "")),
@@ -851,6 +928,8 @@ def policy_rules(
             contract.test_code_root,
             contract.test_support_root,
             contract.test_data_roots,
+            contract.tex_api_fix_paths,
+            contract.tnlog_fix_paths,
             contract.enforcement_workflows,
             contract.workflow_dependency_contract,
             contract.enforcement_network_contract,
@@ -868,6 +947,8 @@ def policy_rules(
             "scripts",
             "tests/tenkz/release-support",
             ("tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"),
+            ("tex/tenkz/**/*.tex", "tex/tenkz/**/*.sty"),
+            ("tex/tenkz/**/*.tex", "tex/tenkz/**/*.sty"),
             (".github/workflows/tenkz-release-policy.yml",),
             "transitive-content-addressed-no-runtime-downloads",
             "disabled-before-repository-code",
@@ -918,6 +999,8 @@ def validate_entry_shape(entry: dict, index: int) -> tuple[str, str, int, str]:
     kind = nonempty_string(entry.get("kind"), "kind", entry_id)
     require(kind in ENTRY_KINDS, f"{entry_id} has unknown kind {kind}")
     expected_fields = FIELDS_BY_KIND[kind]
+    if kind == "friction" and entry.get("triage") == "fix-compatible":
+        expected_fields = expected_fields | {"regression_tests"}
     if kind == "reset" and entry.get("cause") == "record-invalid":
         expected_fields = expected_fields | {"replay_receipt_pr", "replay_receipt_sha256"}
     require(set(entry) == expected_fields, f"{entry_id} {kind} fields differ from schema")
@@ -1193,6 +1276,10 @@ def validate_release_payload(
         f"{subject} test inventory is invalid",
     )
     require(
+        evidence.inventory_test_surfaces_valid is True,
+        f"{subject} test inventory has invalid surface declarations",
+    )
+    require(
         evidence.test_code_tree_matches is True,
         f"{subject} release-test code tree differs from policy",
     )
@@ -1240,6 +1327,120 @@ def validate_release_payload(
         f"{subject} payload blob identity is missing",
     )
     return blob_oids
+
+
+def validate_release_test_observation(
+    evidence: ReleaseTestObservationEvidence,
+    *,
+    tree_oid: str,
+    tag: str,
+    test_ref: str,
+    surface: str,
+    expect_exit_zero: bool,
+    contract: ReleaseContract,
+    subject: str,
+) -> None:
+    """Validate one exact test observation, including a clean process exit."""
+
+    require(evidence.validated_tree_oid == tree_oid, f"{subject} used another tree")
+    require(evidence.validated_tag == tag, f"{subject} used another freeze tag")
+    require(evidence.validated_test_ref == test_ref, f"{subject} ran another test")
+    require(evidence.validated_contract == contract, f"{subject} used another contract")
+    require(evidence.complete is True, f"{subject} observation is incomplete")
+    require(
+        evidence.manifest_path == contract.manifest_path(tag),
+        f"{subject} used another release manifest",
+    )
+    require(
+        evidence.regular_distinct_paths is True,
+        f"{subject} release paths are not regular and distinct",
+    )
+    require(evidence.manifest_contract_valid is True, f"{subject} manifest is invalid")
+    require(
+        evidence.artifact_declarations_agree is True,
+        f"{subject} release artifacts disagree",
+    )
+    require(
+        evidence.inventory_digest_matches is True,
+        f"{subject} test-inventory digest differs from policy",
+    )
+    require(evidence.inventory_contract_valid is True, f"{subject} inventory is invalid")
+    require(
+        evidence.inventory_test_surfaces_valid is True,
+        f"{subject} inventory has invalid surface declarations",
+    )
+    require(evidence.inventory_test_exists is True, f"{subject} test is absent from inventory")
+    require(
+        evidence.inventory_command_exact_and_matching is True,
+        f"{subject} command differs from the pinned inventory test",
+    )
+    require(
+        evidence.test_code_tree_matches is True,
+        f"{subject} test-code tree differs from policy",
+    )
+    require(
+        evidence.test_support_tree_matches is True,
+        f"{subject} test-support tree differs from policy",
+    )
+    require(
+        evidence.inventory_data_paths_within_mutable_roots is True,
+        f"{subject} data paths escape the mutable subject roots",
+    )
+    require(
+        evidence.executable_dependencies_within_code_tree is True,
+        f"{subject} executable dependency escapes the pinned code tree",
+    )
+    require(
+        evidence.acceptance_dependencies_within_support_tree is True,
+        f"{subject} acceptance dependency escapes the pinned support tree",
+    )
+    require(
+        evidence.subject_data_cannot_reduce_coverage is True,
+        f"{subject} subject data can reduce test coverage",
+    )
+    require(
+        evidence.hermetic_execution_contract_valid is True,
+        f"{subject} hermetic execution contract is invalid",
+    )
+    require(evidence.tool_fingerprints_match is True, f"{subject} tool identity differs")
+    surfaces = evidence.inventory_test_surfaces
+    require(
+        isinstance(surfaces, tuple)
+        and bool(surfaces)
+        and all(isinstance(item, str) for item in surfaces),
+        f"{subject} inventory test surfaces are missing",
+    )
+    require(len(surfaces) == len(set(surfaces)), f"{subject} test surfaces have duplicates")
+    require(set(surfaces) <= SURFACES, f"{subject} test has an unknown surface")
+    require(surface in surfaces, f"{subject} test does not cover surface {surface}")
+    require(
+        evidence.exactly_one_inventory_test_run is True,
+        f"{subject} did not run exactly one inventory test",
+    )
+    require(
+        evidence.setup_complete_and_matching is True,
+        f"{subject} setup is incomplete or mismatched",
+    )
+    require(evidence.isolation_valid is True, f"{subject} isolation failed")
+    require(
+        evidence.execution_receipt_exact_and_matching is True,
+        f"{subject} execution receipt is incomplete or mismatched",
+    )
+    require(evidence.execution_complete is True, f"{subject} execution is incomplete")
+    require(evidence.timed_out is False, f"{subject} timed out")
+    require(evidence.terminated_by_signal is False, f"{subject} ended by signal")
+    require(evidence.clean_process_exit is True, f"{subject} did not exit cleanly")
+    exit_code = evidence.exit_code
+    require(
+        isinstance(exit_code, int)
+        and not isinstance(exit_code, bool)
+        and 0 <= exit_code <= 255,
+        f"{subject} has an invalid process exit code",
+    )
+    if expect_exit_zero:
+        require(exit_code == 0, f"{subject} regression test did not pass")
+    else:
+        require(exit_code != 0, f"{subject} regression test did not reproduce friction")
 
 
 def validate_tag_protection(evidence: TagProtectionEvidence) -> None:
@@ -1356,6 +1557,9 @@ def validate_entries(
     resolve_replay_resolution_diff: ResolveReplayResolutionDiff | None = None,
     resolve_replay_release_prep: ResolveReplayReleasePrep | None = None,
     resolve_replay_release_payload: ResolveReplayReleasePayload | None = None,
+    resolve_replay_release_test_observation: (
+        ResolveReplayReleaseTestObservation | None
+    ) = None,
     resolve_replay_freeze_tag: ResolveReplayFreezeTag | None = None,
     resolve_current_final_tag: ResolveCurrentFinalTag | None = None,
     resolve_replay_issue: ResolveReplayIssue | None = None,
@@ -1436,6 +1640,16 @@ def validate_entries(
         require(
             resolve_replay_resolution_diff is not None,
             "resolution validation requires replay fix-diff evidence",
+        )
+    if any(
+        shape[1] == "friction"
+        and entry.get("triage") == "fix-compatible"
+        and bool(entry.get("regression_tests"))
+        for entry, shape in zip(entries, shaped)
+    ):
+        require(
+            resolve_replay_release_test_observation is not None,
+            "friction validation requires replay single-test evidence",
         )
     require(
         resolve_replay_release_payload is not None,
@@ -1626,6 +1840,10 @@ def validate_entries(
     require(
         activation_diff.inventory_digest_matches is True,
         "activation inventory digest is wrong",
+    )
+    require(
+        activation_diff.inventory_test_surfaces_valid is True,
+        "activation inventory test surfaces are invalid",
     )
     require(
         activation_diff.test_code_tree_matches is True,
@@ -2240,14 +2458,59 @@ def validate_entries(
             triage = nonempty_string(entry["triage"], "triage", entry_id)
             require(surface in SURFACES, f"{entry_id} has invalid friction surface")
             require(triage in TRIAGE, f"{entry_id} has invalid friction triage")
+            regression_tests: tuple[str, ...] = ()
+            if triage == "fix-compatible":
+                listed_tests = closed_string_list(
+                    entry["regression_tests"],
+                    "regression_tests",
+                    entry_id,
+                )
+                for test_ref in listed_tests:
+                    require(
+                        TEST_REF_RE.fullmatch(test_ref) is not None,
+                        f"{entry_id} has invalid regression test {test_ref}",
+                    )
+                regression_tests = tuple(listed_tests)
             nonempty_string(entry["summary"], "summary", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
+
+            def friction_observation_facts() -> None:
+                if not regression_tests:
+                    return
+                assert resolve_replay_release_test_observation is not None
+                record_head = record.head_oid
+                assert isinstance(record_head, str)
+                trees = [("head", record_head)]
+                if not record_pending:
+                    assert record_integration is not None
+                    trees.append(("integration", record_integration))
+                for stage, tree_oid in trees:
+                    for test_ref in regression_tests:
+                        validate_release_test_observation(
+                            resolve_replay_release_test_observation(
+                                tree_oid,
+                                active["freeze_tag"],
+                                test_ref,
+                                release_contract,
+                            ),
+                            tree_oid=tree_oid,
+                            tag=active["freeze_tag"],
+                            test_ref=test_ref,
+                            surface=surface,
+                            expect_exit_zero=False,
+                            contract=release_contract,
+                            subject=f"{entry_id} friction {stage} test {test_ref}",
+                        )
+
+            check_external(friction_observation_facts)
             if record_pending:
                 return finish_pending("friction-pending")
             if not entry_is_invalid():
                 assert record_merged_at is not None and record_integration is not None
                 active["friction"][entry_id] = {
+                    "surface": surface,
                     "triage": triage,
+                    "regression_tests": regression_tests,
                     "resolved": False,
                     "merged_at": record_merged_at,
                     "integration": record_integration,
@@ -2263,6 +2526,10 @@ def validate_entries(
             require(fact is not None, f"{entry_id} names no friction in this attempt")
             require(fact["triage"] == "fix-compatible", f"{entry_id} resolves incompatible triage")
             require(fact["resolved"] is False, f"{entry_id} resolves friction twice")
+            require(
+                bool(fact["regression_tests"]),
+                f"{entry_id} cannot resolve an empty regression-test evidence gap",
+            )
             nonempty_string(entry["summary"], "summary", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
 
@@ -2338,33 +2605,84 @@ def validate_entries(
                     fix_diff.policy_paths_untouched is True,
                     f"{entry_id} fix diff changes policy or the soak ledger",
                 )
+                fix_base = fix_diff.validated_base_oid
                 require(
-                    fix_diff.has_added_or_modified_regular_nonledger_blob is True,
-                    f"{entry_id} fix diff has no added or modified regular non-ledger blob",
+                    isinstance(fix_base, str) and SHA_RE.fullmatch(fix_base) is not None,
+                    f"{entry_id} fix merge base is missing or malformed",
                 )
                 require(
-                    fix_diff.normalized_token_stream_changed is True,
-                    f"{entry_id} fix diff has no semantic normalized-token change",
+                    fix_diff.validated_surface == fact["surface"],
+                    f"{entry_id} fix diff used another compatibility surface",
                 )
                 require(
-                    fix_diff.semantic_witness_is_same_regular_nonledger_blob is True,
-                    f"{entry_id} fix semantic witness is not one qualifying blob",
+                    fix_diff.validated_fix_path_patterns
+                    == release_contract.fix_paths(fact["surface"]),
+                    f"{entry_id} fix diff used another surface path set",
+                )
+                witness_path = fix_diff.semantic_witness_path
+                normalized_witness = normalized_repository_path(witness_path)
+                require(
+                    normalized_witness is not None
+                    and any(
+                        policy_glob_matches(normalized_witness, pattern)
+                        for pattern in release_contract.fix_paths(fact["surface"])
+                    ),
+                    f"{entry_id} fix semantic witness path is not surface-owned TeX",
                 )
                 require(
-                    fix_diff.validated_contract == release_contract,
-                    f"{entry_id} fix tests used another release-test contract",
+                    fix_diff.surface_matching_added_or_modified_regular_blob is True,
+                    f"{entry_id} fix has no added or modified surface-owned TeX blob",
                 )
                 require(
-                    fix_diff.inventory_commands_complete is True,
-                    f"{entry_id} fix did not run every pinned inventory command",
+                    fix_diff.tex_comment_stripped_token_stream_changed is True,
+                    f"{entry_id} fix has no TeX-comment-stripped token change",
                 )
                 require(
-                    fix_diff.inventory_commands_passed is True,
-                    f"{entry_id} fix failed a pinned inventory command",
+                    fix_diff.semantic_witness_is_same_surface_regular_blob is True,
+                    f"{entry_id} fix semantic witness is not one surface-owned TeX blob",
                 )
-                require(
-                    fix_diff.execution_receipts_exact_and_matching is True,
-                    f"{entry_id} fix execution receipts are incomplete or mismatched",
+                assert resolve_replay_release_test_observation is not None
+                for test_ref in fact["regression_tests"]:
+                    validate_release_test_observation(
+                        resolve_replay_release_test_observation(
+                            fix_base,
+                            active["freeze_tag"],
+                            test_ref,
+                            release_contract,
+                        ),
+                        tree_oid=fix_base,
+                        tag=active["freeze_tag"],
+                        test_ref=test_ref,
+                        surface=fact["surface"],
+                        expect_exit_zero=False,
+                        contract=release_contract,
+                        subject=f"{entry_id} fix-base test {test_ref}",
+                    )
+                    validate_release_test_observation(
+                        resolve_replay_release_test_observation(
+                            fix_head,
+                            active["freeze_tag"],
+                            test_ref,
+                            release_contract,
+                        ),
+                        tree_oid=fix_head,
+                        tag=active["freeze_tag"],
+                        test_ref=test_ref,
+                        surface=fact["surface"],
+                        expect_exit_zero=True,
+                        contract=release_contract,
+                        subject=f"{entry_id} fix-head test {test_ref}",
+                    )
+                validate_release_payload(
+                    resolve_replay_release_payload(
+                        fix_head,
+                        active["freeze_tag"],
+                        release_contract,
+                    ),
+                    tree_oid=fix_head,
+                    tag=active["freeze_tag"],
+                    contract=release_contract,
+                    subject=f"{entry_id} fix head",
                 )
                 return fix_merged_at, fix_integration
 

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -135,7 +135,7 @@ FIELDS_BY_KIND = {
     },
     "work": COMMON_FIELDS | {"work_pr", "class", "summary", "evidence"},
     "friction": COMMON_FIELDS | {"surface", "triage", "summary", "evidence"},
-    "resolution": COMMON_FIELDS | {"friction", "summary", "evidence"},
+    "resolution": COMMON_FIELDS | {"friction", "fix_pr", "summary", "evidence"},
     "reset": COMMON_FIELDS | {"cause", "target", "reason", "evidence"},
     "correction": COMMON_FIELDS | {"target", "summary", "evidence"},
     "sign-off": COMMON_FIELDS
@@ -213,6 +213,9 @@ class RecordDiffEvidence:
     candidate_main_tip_is_receipt_integration: bool | None = None
     integration_parent_is_receipt_integration: bool | None = None
     validated_receipt_integration: str | None = None
+    candidate_main_tip_descends_from_fix_integration: bool | None = None
+    integration_parent_descends_from_fix_integration: bool | None = None
+    validated_fix_integration: str | None = None
 
 
 @dataclass(frozen=True)
@@ -241,6 +244,32 @@ class WorkDiffEvidence:
     rmp_targets_resolved: bool | None
     rmp_stages_complete: bool | None
     rmp_checks_passed: bool | None
+
+
+@dataclass(frozen=True)
+class ResolutionDiffEvidence:
+    """Complete exact-head evidence for one compatible fix pull request."""
+
+    validated_pr_ref: str | None
+    validated_head_oid: str | None
+    validated_integration_oid: str | None
+    validated_freeze_integration: str | None
+    validated_friction_integration: str | None
+    complete: bool | None
+    integration_parent_count: int | None
+    unique_merge_base: bool | None
+    integration_parent_is_ancestor_of_head: bool | None
+    integration_second_parent_matches_head: bool | None
+    integration_strict_descendant_of_freeze: bool | None
+    integration_strict_descendant_of_friction: bool | None
+    policy_paths_untouched: bool | None
+    has_added_or_modified_regular_nonledger_blob: bool | None
+    normalized_token_stream_changed: bool | None
+    semantic_witness_is_same_regular_nonledger_blob: bool | None
+    validated_contract: ReleaseContract | None
+    inventory_commands_complete: bool | None
+    inventory_commands_passed: bool | None
+    execution_receipts_exact_and_matching: bool | None
 
 
 @dataclass(frozen=True)
@@ -469,6 +498,7 @@ ResolveReplayPullRequest = Callable[[str, str | None], PullRequestEvidence]
 ResolveReplayActivationDiff = Callable[[str], ActivationDiffEvidence]
 ResolveReplayRecordDiff = Callable[[str, str, str | None], RecordDiffEvidence]
 ResolveReplayWorkDiff = Callable[[str], WorkDiffEvidence]
+ResolveReplayResolutionDiff = Callable[[str], ResolutionDiffEvidence]
 ResolveReplayReleasePrep = Callable[
     [str, tuple[str, ...], tuple[str, ...]], ReleasePrepEvidence
 ]
@@ -1281,6 +1311,7 @@ def validate_entries(
     resolve_replay_activation_diff: ResolveReplayActivationDiff | None = None,
     resolve_replay_record_diff: ResolveReplayRecordDiff | None = None,
     resolve_replay_work_diff: ResolveReplayWorkDiff | None = None,
+    resolve_replay_resolution_diff: ResolveReplayResolutionDiff | None = None,
     resolve_replay_release_prep: ResolveReplayReleasePrep | None = None,
     resolve_replay_release_payload: ResolveReplayReleasePayload | None = None,
     resolve_replay_freeze_tag: ResolveReplayFreezeTag | None = None,
@@ -1359,6 +1390,11 @@ def validate_entries(
         resolve_replay_work_diff is not None,
         "entry validation requires replay work-diff evidence",
     )
+    if any(shape[1] == "resolution" for shape in shaped):
+        require(
+            resolve_replay_resolution_diff is not None,
+            "resolution validation requires replay fix-diff evidence",
+        )
     require(
         resolve_replay_release_payload is not None,
         "entry validation requires replay release-payload evidence",
@@ -2126,19 +2162,150 @@ def validate_entries(
             if record_pending:
                 return finish_pending("friction-pending")
             if not entry_is_invalid():
-                active["friction"][entry_id] = {"triage": triage, "resolved": False}
+                assert record_merged_at is not None and record_integration is not None
+                active["friction"][entry_id] = {
+                    "triage": triage,
+                    "resolved": False,
+                    "merged_at": record_merged_at,
+                    "integration": record_integration,
+                }
                 if triage == "breaking-required":
                     pending_reset = ("breaking-required", entry_id)
 
         elif kind == "resolution":
             assert active is not None
             friction = nonempty_string(entry["friction"], "friction", entry_id)
+            fix_ref = pr_ref(entry["fix_pr"], "fix_pr", entry_id)
             fact = active["friction"].get(friction)
             require(fact is not None, f"{entry_id} names no friction in this attempt")
             require(fact["triage"] == "fix-compatible", f"{entry_id} resolves incompatible triage")
             require(fact["resolved"] is False, f"{entry_id} resolves friction twice")
             nonempty_string(entry["summary"], "summary", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
+
+            def resolution_external_facts() -> tuple[datetime, str]:
+                assert resolve_replay_resolution_diff is not None
+                fix_pr = resolve_replay_pr(fix_ref, active["freeze_integration"])
+                fix_author, fix_head = validate_pr_core(fix_pr, fix_ref)
+                fix_merged_at, fix_integration = validate_merged_pr(
+                    fix_pr,
+                    fix_ref,
+                    require_descendant=True,
+                    require_tree=True,
+                )
+                require(
+                    fix_merged_at > fact["merged_at"],
+                    f"{entry_id} fix PR did not merge after its friction record",
+                )
+                require_independent_approval(
+                    fix_pr,
+                    fix_ref,
+                    author=fix_author,
+                    before=fix_merged_at,
+                    authorized_permissions=reviewer_permissions,
+                )
+                fix_diff = resolve_replay_resolution_diff(fix_ref)
+                require(
+                    fix_diff.validated_pr_ref == fix_ref,
+                    f"{entry_id} fix diff was validated on another PR",
+                )
+                require(
+                    fix_diff.validated_head_oid == fix_head,
+                    f"{entry_id} fix diff was not validated at its exact head",
+                )
+                require(
+                    fix_diff.validated_integration_oid == fix_integration,
+                    f"{entry_id} fix diff used another integration",
+                )
+                require(
+                    fix_diff.validated_freeze_integration == active["freeze_integration"],
+                    f"{entry_id} fix diff used another freeze integration",
+                )
+                require(
+                    fix_diff.validated_friction_integration == fact["integration"],
+                    f"{entry_id} fix diff used another friction integration",
+                )
+                require(fix_diff.complete is True, f"{entry_id} fix diff is incomplete")
+                fix_parent_count = integration_parent_count(
+                    fix_diff.integration_parent_count,
+                    f"{entry_id} fix integration",
+                )
+                require(
+                    fix_diff.unique_merge_base is True,
+                    f"{entry_id} fix merge base is ambiguous",
+                )
+                require(
+                    fix_diff.integration_parent_is_ancestor_of_head is True,
+                    f"{entry_id} fix integration parent is not an ancestor of its head",
+                )
+                if fix_parent_count == 2:
+                    require(
+                        fix_diff.integration_second_parent_matches_head is True,
+                        f"{entry_id} fix integration second parent differs from its head",
+                    )
+                require(
+                    fix_diff.integration_strict_descendant_of_freeze is True,
+                    f"{entry_id} fix integration does not descend from the active freeze",
+                )
+                require(
+                    fix_diff.integration_strict_descendant_of_friction is True,
+                    f"{entry_id} fix integration does not descend from its friction record",
+                )
+                require(
+                    fix_diff.policy_paths_untouched is True,
+                    f"{entry_id} fix diff changes policy or the soak ledger",
+                )
+                require(
+                    fix_diff.has_added_or_modified_regular_nonledger_blob is True,
+                    f"{entry_id} fix diff has no added or modified regular non-ledger blob",
+                )
+                require(
+                    fix_diff.normalized_token_stream_changed is True,
+                    f"{entry_id} fix diff has no semantic normalized-token change",
+                )
+                require(
+                    fix_diff.semantic_witness_is_same_regular_nonledger_blob is True,
+                    f"{entry_id} fix semantic witness is not one qualifying blob",
+                )
+                require(
+                    fix_diff.validated_contract == release_contract,
+                    f"{entry_id} fix tests used another release-test contract",
+                )
+                require(
+                    fix_diff.inventory_commands_complete is True,
+                    f"{entry_id} fix did not run every pinned inventory command",
+                )
+                require(
+                    fix_diff.inventory_commands_passed is True,
+                    f"{entry_id} fix failed a pinned inventory command",
+                )
+                require(
+                    fix_diff.execution_receipts_exact_and_matching is True,
+                    f"{entry_id} fix execution receipts are incomplete or mismatched",
+                )
+                return fix_merged_at, fix_integration
+
+            resolution_result = check_external(resolution_external_facts)
+            if isinstance(resolution_result, tuple):
+                fix_merged_at, fix_integration = resolution_result
+                check_kind_record_fact(
+                    diff.validated_fix_integration == fix_integration,
+                    f"{entry_id} resolution record used another fix integration",
+                )
+                check_kind_record_fact(
+                    diff.candidate_main_tip_descends_from_fix_integration is True,
+                    f"{entry_id} resolution candidate does not descend from its fix",
+                )
+                if not record_pending:
+                    check_kind_record_fact(
+                        diff.integration_parent_descends_from_fix_integration is True,
+                        f"{entry_id} resolution integration parent does not descend from its fix",
+                    )
+                    assert record_merged_at is not None
+                    check_kind_record_fact(
+                        record_merged_at > fix_merged_at,
+                        f"{entry_id} resolution record did not merge after its fix PR",
+                    )
             if record_pending:
                 return finish_pending("resolution-pending")
             if not entry_is_invalid():

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -19,6 +19,7 @@ SOAK_MARKER = "<!-- tenkz-soak-entries: append below only while enforcement=arme
 FREEZE_TAG_RE = re.compile(r"tenkz-v0\.9\.(?:0|[1-9][0-9]*)")
 FINAL_TAG = "tenkz-v1.0.0"
 SHA_RE = re.compile(r"[0-9a-f]{40}")
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
 ENTRY_ID_RE = re.compile(r"S1-[0-9]{4}")
 PR_REF_RE = re.compile(r"#[1-9][0-9]*")
 ISSUE_REF_RE = PR_REF_RE
@@ -64,6 +65,7 @@ EXPECTED_POLICY = {
         "frozen_twin_precedent": "quantikz/quantikz2",
         "maintainer_identity": "github:lionsr",
         "signer_identity_scheme": "github:lowercase-login",
+        "reviewer_repository_permissions": ["push", "maintain", "admin"],
         "tag_immutability": "github-ruleset-no-update-delete-or-bypass",
         "release_manifest_pattern": "docs/tenkz/releases/TAG.toml",
         "release_package_metadata": "tex/tenkz/tenkz.sty",
@@ -77,6 +79,11 @@ EXPECTED_POLICY = {
         "release_test_support_root": "tests/tenkz/release-support",
         "release_test_support_tree": "pending",
         "release_test_data_roots": ["tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"],
+        "release_enforcement_workflows": [".github/workflows/pr-ci.yml"],
+        "release_workflow_dependencies": "transitive-immutable-git-sha-or-content-digest",
+        "release_reset_replay_schema": (
+            "tests/tenkz/release-support/reset-replay-v1.schema.json"
+        ),
         "release_test_dependency_contract": "pinned-code-support-declared-subject-data",
         "release_test_protocol": "hermetic-repository-view-no-shell-or-network",
     },
@@ -157,6 +164,7 @@ class ReviewEvidence:
     submitted_at: datetime | None
     commit_oid: str | None
     dismissed: bool | None = False
+    repository_permission: str | None = None
 
 
 @dataclass(frozen=True)
@@ -202,12 +210,19 @@ class RecordDiffEvidence:
     integration_parent_is_release_integration: bool | None = None
     validated_release_integration: str | None = None
     validated_work_integrations: tuple[str, ...] | None = None
+    candidate_main_tip_is_receipt_integration: bool | None = None
+    integration_parent_is_receipt_integration: bool | None = None
+    validated_receipt_integration: str | None = None
 
 
 @dataclass(frozen=True)
 class WorkDiffEvidence:
     """Facts derived from the complete immutable merge-base-to-head work diff."""
 
+    validated_pr_ref: str | None
+    validated_head_oid: str | None
+    validated_integration_oid: str | None
+    validated_freeze_integration: str | None
     complete: bool | None
     integration_parent_count: int | None
     unique_merge_base: bool | None
@@ -244,6 +259,9 @@ class ReleaseContract:
     test_support_root: str
     test_support_tree: str
     test_data_roots: tuple[str, ...]
+    enforcement_workflows: tuple[str, ...]
+    workflow_dependency_contract: str
+    reset_replay_schema: str
     test_dependency_contract: str
     test_protocol: str
 
@@ -311,6 +329,8 @@ class TagEvidence:
     object_type: str | None
     commit: str | None
     patch_is_fresh_for_attempt: bool | None = None
+    namespace_complete: bool | None = None
+    patch_exceeds_other_namespace_tags: bool | None = None
     exists: bool | None = True
     validated_entry_id: str | None = None
     validated_record_pr: str | None = None
@@ -331,6 +351,55 @@ class AuditEvidence:
     invalid_entries: tuple[str, ...] | None
     snapshot_complete: bool | None
     validation_target_exact: bool | None
+    validation_target_oid: str | None
+
+
+@dataclass(frozen=True)
+class RecordInvalidResetReplayEvidence:
+    """Durable receipt-blob evidence for one ``record-invalid`` reset."""
+
+    validated_entry_id: str | None
+    validated_target_entry_id: str | None
+    validated_receipt_pr: str | None
+    validated_receipt_head_oid: str | None
+    validated_receipt_integration_oid: str | None
+    complete: bool | None
+    receipt_candidate_main_tip_exact: bool | None
+    changes_exactly_one_new_regular_blob: bool | None
+    receipt_path: str | None
+    raw_blob_sha256: str | None
+    raw_blob_read_from_receipt_integration: bool | None
+    schema_path: str | None
+    schema_support_tree_oid: str | None
+    schema_from_pinned_support_tree: bool | None
+    schema_closed_and_valid: bool | None
+    boundary_entry_id: str | None
+    validation_target_oid: str | None
+    raw_invalid_entries: tuple[str, ...] | None
+    pending_breaking_target: str | None
+    normalized_resolver_inputs_complete_and_matching: bool | None
+    workflow_dependency_closure_pinned: bool | None
+    supervisor_receipts_complete_and_matching: bool | None
+    current_candidate_snapshot_reproduces_receipt: bool | None
+
+
+@dataclass(frozen=True)
+class WorkflowEvidence:
+    """Pinned enforcement-workflow facts for one exact validation target."""
+
+    validated_activation_integration: str | None
+    validated_target_oid: str | None
+    validated_paths: tuple[str, ...] | None
+    complete: bool | None
+    activation_paths_are_regular_blobs: bool | None
+    target_blobs_and_modes_match_activation: bool | None
+    local_dependencies_pinned_and_matching: bool | None
+    external_dependencies_use_full_commit_shas: bool | None
+    containers_use_content_digests: bool | None
+    dependency_graph_complete_and_acyclic: bool | None
+    candidate_diff_untouched: bool | None
+    github_checks_bind_exact_head_and_workflows: bool | None
+    supervisor_receipt_complete_and_matching: bool | None
 
 
 @dataclass(frozen=True)
@@ -352,6 +421,7 @@ class ActivationDiffEvidence:
     subject_data_cannot_reduce_coverage: bool | None
     hermetic_execution_contract_valid: bool | None
     supervisor_self_test_receipt_valid: bool | None
+    enforcement_workflows_pinned: bool | None
     policy_digest_matches: bool | None
     ledger_prefix_matches: bool | None
 
@@ -406,11 +476,41 @@ ResolveReplayReleasePayload = Callable[[str, str, ReleaseContract], ReleasePaylo
 ResolveReplayFreezeTag = Callable[[str], TagEvidence]
 ResolveCurrentFinalTag = Callable[[str], TagEvidence]
 ResolveReplayIssue = Callable[[str], IssueEvidence]
+ResolveReplayRecordInvalidReset = Callable[
+    [str, str, str, str], RecordInvalidResetReplayEvidence
+]
+ResolveCurrentWorkflow = Callable[[str, str, tuple[str, ...]], WorkflowEvidence]
 
 
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise PolicyError(message)
+
+
+def closed_value_matches(actual: object, expected: object) -> bool:
+    """Compare a closed schema without Python's bool/int numeric coercions."""
+
+    if type(actual) is not type(expected):
+        return False
+    if isinstance(expected, dict):
+        return set(actual) == set(expected) and all(  # type: ignore[arg-type]
+            closed_value_matches(actual[key], value)  # type: ignore[index]
+            for key, value in expected.items()
+        )
+    if isinstance(expected, list):
+        return len(actual) == len(expected) and all(  # type: ignore[arg-type]
+            closed_value_matches(item, wanted)
+            for item, wanted in zip(actual, expected, strict=True)  # type: ignore[arg-type]
+        )
+    return actual == expected
+
+
+def integration_parent_count(value: object, subject: str) -> int:
+    require(
+        isinstance(value, int) and not isinstance(value, bool) and value in {1, 2},
+        f"{subject} has an invalid parent count",
+    )
+    return value
 
 
 def fenced_blocks(text: str, label: str) -> list[str]:
@@ -462,7 +562,10 @@ def validate_policy_mapping(policy: dict) -> dict:
         normalized["policy"]["release_test_inventory_sha256"] = "pending"
         normalized["policy"]["release_test_code_tree"] = "pending"
         normalized["policy"]["release_test_support_tree"] = "pending"
-    require(normalized == EXPECTED_POLICY, "tenkz-policy-v1 differs from the signed policy")
+    require(
+        closed_value_matches(normalized, EXPECTED_POLICY),
+        "tenkz-policy-v1 differs from the signed policy",
+    )
     return policy
 
 
@@ -514,7 +617,10 @@ def validate_soak_mapping(soak: dict) -> dict:
         normalized["soak"]["enforcement"] = "pending"
         normalized["soak"]["policy_sha256"] = "pending"
         normalized["soak"]["armed_by_pr"] = "pending"
-    require(normalized == EXPECTED_SOAK, "tenkz-soak-v1 differs from the signed schema")
+    require(
+        closed_value_matches(normalized, EXPECTED_SOAK),
+        "tenkz-soak-v1 differs from the signed schema",
+    )
     return soak
 
 
@@ -571,6 +677,12 @@ def sha(value: object, field: str, entry_id: str) -> str:
     return result
 
 
+def sha256(value: object, field: str, entry_id: str) -> str:
+    result = nonempty_string(value, field, entry_id)
+    require(SHA256_RE.fullmatch(result) is not None, f"{entry_id} has invalid {field}")
+    return result
+
+
 def pr_ref(value: object, field: str, entry_id: str) -> str:
     result = nonempty_string(value, field, entry_id)
     require(PR_REF_RE.fullmatch(result) is not None, f"{entry_id} has invalid {field}")
@@ -610,7 +722,15 @@ def utc_instant(value: object, field: str) -> datetime:
 
 def policy_rules(
     policy: dict,
-) -> tuple[int, tuple[str, ...], tuple[str, ...], list[str], ReleaseContract, str]:
+) -> tuple[
+    int,
+    tuple[str, ...],
+    tuple[str, ...],
+    list[str],
+    ReleaseContract,
+    str,
+    tuple[str, ...],
+]:
     validate_policy_mapping(policy)
     root = policy.get("policy")
     require(isinstance(root, dict), "policy evidence lacks [policy]")
@@ -641,6 +761,11 @@ def policy_rules(
         root.get("signer_identity_scheme") == "github:lowercase-login",
         "policy has the wrong signer identity scheme",
     )
+    reviewer_permissions = root.get("reviewer_repository_permissions")
+    require(
+        reviewer_permissions == ["push", "maintain", "admin"],
+        "policy has the wrong reviewer permission set",
+    )
     require(
         root.get("tag_immutability") == "github-ruleset-no-update-delete-or-bypass",
         "policy has the wrong tag-immutability model",
@@ -658,6 +783,9 @@ def policy_rules(
         test_support_root=str(root.get("release_test_support_root", "")),
         test_support_tree=str(root.get("release_test_support_tree", "")),
         test_data_roots=tuple(root.get("release_test_data_roots", ())),
+        enforcement_workflows=tuple(root.get("release_enforcement_workflows", ())),
+        workflow_dependency_contract=str(root.get("release_workflow_dependencies", "")),
+        reset_replay_schema=str(root.get("release_reset_replay_schema", "")),
         test_dependency_contract=str(root.get("release_test_dependency_contract", "")),
         test_protocol=str(root.get("release_test_protocol", "")),
     )
@@ -672,6 +800,9 @@ def policy_rules(
             contract.test_code_root,
             contract.test_support_root,
             contract.test_data_roots,
+            contract.enforcement_workflows,
+            contract.workflow_dependency_contract,
+            contract.reset_replay_schema,
             contract.test_dependency_contract,
             contract.test_protocol,
         )
@@ -685,6 +816,9 @@ def policy_rules(
             "scripts",
             "tests/tenkz/release-support",
             ("tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"),
+            (".github/workflows/pr-ci.yml",),
+            "transitive-immutable-git-sha-or-content-digest",
+            "tests/tenkz/release-support/reset-replay-v1.schema.json",
             "pinned-code-support-declared-subject-data",
             "hermetic-repository-view-no-shell-or-network",
         ),
@@ -719,6 +853,7 @@ def policy_rules(
         prerequisites,
         contract,
         maintainer_identity.removeprefix("github:"),
+        tuple(reviewer_permissions),
     )
 
 
@@ -729,7 +864,10 @@ def validate_entry_shape(entry: dict, index: int) -> tuple[str, str, int, str]:
     require(entry_id == expected_id, f"expected entry id {expected_id}, found {entry_id}")
     kind = nonempty_string(entry.get("kind"), "kind", entry_id)
     require(kind in ENTRY_KINDS, f"{entry_id} has unknown kind {kind}")
-    require(set(entry) == FIELDS_BY_KIND[kind], f"{entry_id} {kind} fields differ from schema")
+    expected_fields = FIELDS_BY_KIND[kind]
+    if kind == "reset" and entry.get("cause") == "record-invalid":
+        expected_fields = expected_fields | {"replay_receipt_pr", "replay_receipt_sha256"}
+    require(set(entry) == expected_fields, f"{entry_id} {kind} fields differ from schema")
     record_pr = pr_ref(entry["record_pr"], "record_pr", entry_id)
     attempt = entry["attempt"]
     require(
@@ -860,15 +998,17 @@ def inspect_record_pr(
     integration = pr.merge_commit_oid
     integration_valid = isinstance(integration, str) and SHA_RE.fullmatch(integration) is not None
     check(integration_valid, f"{record_ref} merge commit is invalid")
-    check(
-        diff.integration_parent_count in {1, 2},
-        f"{record_ref} integration has an invalid parent count",
+    parent_count_valid = (
+        isinstance(diff.integration_parent_count, int)
+        and not isinstance(diff.integration_parent_count, bool)
+        and diff.integration_parent_count in {1, 2}
     )
+    check(parent_count_valid, f"{record_ref} integration has an invalid parent count")
     check(
         diff.integration_parent_is_ancestor_of_head is True,
         f"{record_ref} integration parent is not an ancestor of the record head",
     )
-    if diff.integration_parent_count == 2:
+    if parent_count_valid and diff.integration_parent_count == 2:
         check(
             diff.integration_second_parent_matches_head is True,
             f"{record_ref} integration second parent differs from the record head",
@@ -934,6 +1074,7 @@ def require_independent_approval(
     before: datetime | None = None,
     named_reviewer: str | None = None,
     distinct_from: Collection[str] = (),
+    authorized_permissions: Collection[str],
 ) -> tuple[str, datetime]:
     latest = latest_effective_reviews(pr, pr_name)
     candidates = latest.items()
@@ -945,13 +1086,17 @@ def require_independent_approval(
         submitted = utc_instant(review.submitted_at, f"{pr_name} review submittedAt")
         if review.state != "APPROVED" or review.commit_oid != pr.head_oid:
             continue
+        if review.repository_permission not in authorized_permissions:
+            continue
         if after is not None and submitted <= after:
             continue
         if before is not None and submitted >= before:
             continue
         return reviewer, submitted
     qualifier = f" by {named_reviewer}" if named_reviewer is not None else ""
-    raise PolicyError(f"{pr_name} lacks an independent exact-head approval{qualifier}")
+    raise PolicyError(
+        f"{pr_name} lacks a repository-authorized independent exact-head approval{qualifier}"
+    )
 
 
 def validate_release_payload(
@@ -1073,6 +1218,60 @@ def validate_tag_protection(evidence: TagProtectionEvidence) -> None:
     require(evidence.unambiguous is True, "applicable tag protection is ambiguous")
 
 
+def validate_workflow_evidence(
+    evidence: WorkflowEvidence,
+    *,
+    activation_integration: str,
+    target_oid: str,
+    workflow_paths: tuple[str, ...],
+) -> None:
+    """Bind enforcement results to pinned workflow bytes and dependencies."""
+
+    require(
+        evidence.validated_activation_integration == activation_integration,
+        "workflow evidence used another activation integration",
+    )
+    require(evidence.validated_target_oid == target_oid, "workflow evidence used another target")
+    require(evidence.validated_paths == workflow_paths, "workflow evidence used another path set")
+    require(evidence.complete is True, "workflow evidence is incomplete")
+    require(
+        evidence.activation_paths_are_regular_blobs is True,
+        "activation enforcement workflow is not a regular blob",
+    )
+    require(
+        evidence.target_blobs_and_modes_match_activation is True,
+        "enforcement workflow bytes or modes differ from activation",
+    )
+    require(
+        evidence.local_dependencies_pinned_and_matching is True,
+        "local workflow dependency differs from its activation object",
+    )
+    require(
+        evidence.external_dependencies_use_full_commit_shas is True,
+        "external workflow dependency uses a mutable ref",
+    )
+    require(
+        evidence.containers_use_content_digests is True,
+        "workflow container dependency is not content-addressed",
+    )
+    require(
+        evidence.dependency_graph_complete_and_acyclic is True,
+        "workflow dependency graph is incomplete or cyclic",
+    )
+    require(
+        evidence.candidate_diff_untouched is True,
+        "candidate diff changes a pinned enforcement workflow",
+    )
+    require(
+        evidence.github_checks_bind_exact_head_and_workflows is True,
+        "GitHub checks are not bound to the exact head and pinned workflows",
+    )
+    require(
+        evidence.supervisor_receipt_complete_and_matching is True,
+        "independent evidence-supervisor receipt is incomplete or mismatched",
+    )
+
+
 def validate_entries(
     entries: list[dict],
     *,
@@ -1087,6 +1286,8 @@ def validate_entries(
     resolve_replay_freeze_tag: ResolveReplayFreezeTag | None = None,
     resolve_current_final_tag: ResolveCurrentFinalTag | None = None,
     resolve_replay_issue: ResolveReplayIssue | None = None,
+    resolve_replay_record_invalid_reset: ResolveReplayRecordInvalidReset | None = None,
+    resolve_current_workflow: ResolveCurrentWorkflow | None = None,
     audit: AuditEvidence | None = None,
     tag_protection: TagProtectionEvidence | None = None,
 ) -> str:
@@ -1107,6 +1308,7 @@ def validate_entries(
         prerequisites,
         release_contract,
         maintainer_login,
+        reviewer_permissions,
     ) = policy_rules(policy)
     validate_soak_mapping(soak)
     enforcement = policy["policy"]["enforcement"]
@@ -1131,35 +1333,18 @@ def validate_entries(
     require(audit is not None, "entry validation requires complete audit evidence")
     require(audit.snapshot_complete is True, "audit snapshot is incomplete")
     require(audit.validation_target_exact is True, "audit validation target is not exact")
+    validation_target_oid = audit.validation_target_oid
+    require(
+        isinstance(validation_target_oid, str)
+        and SHA_RE.fullmatch(validation_target_oid) is not None,
+        "audit validation target OID is missing or malformed",
+    )
     activation_ref = pr_ref(soak_root["armed_by_pr"], "armed_by_pr", "soak")
 
     shaped = [validate_entry_shape(entry, index) for index, entry in enumerate(entries, 1)]
     record_refs = [shape[3] for shape in shaped]
     require(len(record_refs) == len(set(record_refs)), "record_pr values must be distinct")
     record_ref_set = set(record_refs)
-    final_tag = resolve_current_final_tag(FINAL_TAG)
-    require(isinstance(final_tag.exists, bool), "final-tag existence is unavailable")
-
-    def validate_absent_final_tag() -> None:
-        require(final_tag.exists is False, "final tag exists before successful sign-off")
-        require(
-            final_tag.object_id is None
-            and final_tag.object_type is None
-            and final_tag.commit is None
-            and final_tag.patch_is_fresh_for_attempt is None
-            and final_tag.validated_entry_id is None
-            and final_tag.validated_record_pr is None
-            and final_tag.commit_is_validated_record_integration is None,
-            "absent final-tag evidence is inconsistent",
-        )
-
-    def finish_pending(state: str) -> str:
-        assert tag_protection is not None
-        validate_tag_protection(tag_protection)
-        validate_absent_final_tag()
-        return state
-
-    terminal_tag_present = final_tag.exists is True
 
     require(resolve_replay_pr is not None, "entry validation requires replay PR evidence")
     require(
@@ -1182,6 +1367,18 @@ def validate_entries(
         resolve_replay_issue is not None,
         "entry validation requires replay issue evidence",
     )
+    require(
+        resolve_current_workflow is not None,
+        "entry validation requires current workflow evidence",
+    )
+    if any(
+        shape[1] == "reset" and entry.get("cause") == "record-invalid"
+        for entry, shape in zip(entries, shaped)
+    ):
+        require(
+            resolve_replay_record_invalid_reset is not None,
+            "record-invalid reset validation requires historical placement evidence",
+        )
     if any(shape[1] == "sign-off" for shape in shaped):
         require(
             resolve_replay_release_prep is not None,
@@ -1216,6 +1413,31 @@ def validate_entries(
             all(entry_positions[target] <= drift_boundary for target in invalid_set),
             "audit boundary precedes an invalid target",
         )
+    require(
+        drift_boundary in {len(shaped), max(0, len(shaped) - 1)},
+        "audit boundary is stale rather than the actual final live prefix",
+    )
+    for reset_index, (entry, shape) in enumerate(zip(entries, shaped)):
+        entry_id, kind, _attempt, _record_ref = shape
+        if kind != "reset" or entry.get("cause") != "record-invalid":
+            continue
+        if entry_id not in invalid_set:
+            continue
+        target = nonempty_string(entry.get("target"), "target", entry_id)
+        later_valid_acknowledgement = any(
+            later_shape[1] == "reset"
+            and later_entry.get("cause") == "record-invalid"
+            and later_entry.get("target") == target
+            and later_shape[0] not in invalid_set
+            for later_entry, later_shape in zip(
+                entries[reset_index + 1 :],
+                shaped[reset_index + 1 :],
+            )
+        )
+        require(
+            later_valid_acknowledgement or target in invalid_set,
+            f"{entry_id} invalid acknowledgement does not uncover {target}",
+        )
     # The audit channel has replayed every current mutable fact.  Before tag
     # creation, its classified drift enters the ordered reset queue.  Once any
     # final-tag ref exists, the same drift is a hard release incident and never
@@ -1237,11 +1459,38 @@ def validate_entries(
         for entry, shape in zip(entries, shaped)
         if shape[1] == "sign-off"
     ]
+    replay_receipt_refs = [
+        pr_ref(entry["replay_receipt_pr"], "replay_receipt_pr", shape[0])
+        for entry, shape in zip(entries, shaped)
+        if shape[1] == "reset" and entry.get("cause") == "record-invalid"
+    ]
     require(
         len(release_prep_refs) == len(set(release_prep_refs)),
         "release_prep_pr values must be distinct",
     )
     require(len(all_work_refs) == len(set(all_work_refs)), "work_pr values must be distinct")
+    require(
+        len(replay_receipt_refs) == len(set(replay_receipt_refs)),
+        "replay_receipt_pr values must be distinct",
+    )
+    replay_receipt_ref_set = set(replay_receipt_refs)
+    for receipt_ref in replay_receipt_refs:
+        require(
+            receipt_ref != activation_ref,
+            f"replay receipt PR {receipt_ref} is the activation PR",
+        )
+        require(
+            receipt_ref not in source_ref_set,
+            f"replay receipt PR {receipt_ref} is a source PR",
+        )
+        require(
+            receipt_ref not in record_ref_set,
+            f"replay receipt PR {receipt_ref} is an entry record PR",
+        )
+        require(
+            receipt_ref not in release_prep_refs,
+            f"replay receipt PR {receipt_ref} is a release-preparation PR",
+        )
     for work_ref in all_work_refs:
         require(work_ref != activation_ref, f"work PR {work_ref} is the activation PR")
         require(work_ref not in source_ref_set, f"work PR {work_ref} is a source PR")
@@ -1249,6 +1498,10 @@ def validate_entries(
         require(
             work_ref not in release_prep_refs,
             f"work PR {work_ref} is a release-preparation PR",
+        )
+        require(
+            work_ref not in replay_receipt_ref_set,
+            f"work PR {work_ref} is a replay receipt PR",
         )
     for release_ref in release_prep_refs:
         require(
@@ -1262,6 +1515,10 @@ def validate_entries(
         require(
             release_ref not in record_ref_set,
             f"release-preparation PR {release_ref} is an entry record PR",
+        )
+        require(
+            release_ref not in replay_receipt_ref_set,
+            f"release-preparation PR {release_ref} is a replay receipt PR",
         )
 
     activation = resolve_replay_pr(activation_ref, None)
@@ -1325,6 +1582,10 @@ def validate_entries(
         "activation supervisor self-test receipt is invalid",
     )
     require(
+        activation_diff.enforcement_workflows_pinned is True,
+        "activation enforcement workflows or dependencies are not pinned",
+    )
+    require(
         activation_diff.policy_digest_matches is True,
         "activation policy digest is wrong",
     )
@@ -1338,7 +1599,6 @@ def validate_entries(
         require_descendant=False,
         require_tree=True,
     )
-    del activation_merged_at
     activation_merger = normalized_login(activation.merged_by_login, f"{activation_ref} mergedBy")
     require(
         activation_merger == maintainer_login,
@@ -1350,16 +1610,66 @@ def validate_entries(
         author=activation_author,
         before=utc_instant(activation.merged_at, f"{activation_ref} mergedAt"),
         distinct_from={maintainer_login},
+        authorized_permissions=reviewer_permissions,
     )
+
+    final_tag_cache: TagEvidence | None = None
+
+    def current_final_tag() -> TagEvidence:
+        nonlocal final_tag_cache
+        if final_tag_cache is None:
+            final_tag_cache = resolve_current_final_tag(FINAL_TAG)
+            require(
+                isinstance(final_tag_cache.exists, bool),
+                "final-tag existence is unavailable",
+            )
+        return final_tag_cache
+
+    def validate_current_controls() -> None:
+        assert tag_protection is not None and resolve_current_workflow is not None
+        validate_workflow_evidence(
+            resolve_current_workflow(
+                activation_integration,
+                validation_target_oid,
+                release_contract.enforcement_workflows,
+            ),
+            activation_integration=activation_integration,
+            target_oid=validation_target_oid,
+            workflow_paths=release_contract.enforcement_workflows,
+        )
+        validate_tag_protection(tag_protection)
+
+    def validate_absent_final_tag() -> None:
+        final_tag = current_final_tag()
+        require(final_tag.exists is False, "final tag exists before successful sign-off")
+        require(
+            final_tag.object_id is None
+            and final_tag.object_type is None
+            and final_tag.commit is None
+            and final_tag.patch_is_fresh_for_attempt is None
+            and final_tag.namespace_complete is None
+            and final_tag.patch_exceeds_other_namespace_tags is None
+            and final_tag.validated_entry_id is None
+            and final_tag.validated_record_pr is None
+            and final_tag.commit_is_validated_record_integration is None,
+            "absent final-tag evidence is inconsistent",
+        )
+
+    def finish_pending(state: str) -> str:
+        validate_current_controls()
+        validate_absent_final_tag()
+        return state
 
     seen: dict[str, dict] = {}
     seen_attempts: dict[str, int] = {}
     active: dict | None = None
     last_attempt = 0
     last_record_integration: str | None = activation_integration
+    last_ledger_record_merged_at: datetime | None = activation_merged_at
     last_reset_integration: str | None = None
     prior_patch = -1
     pending_reset: tuple[str, str] | None = None
+    deferred_invalid_targets: list[str] = []
     signed = False
     successful_signoff: tuple[str, str, str] | None = None
     used_source_refs: set[str] = set()
@@ -1367,12 +1677,29 @@ def validate_entries(
     used_tag_names: set[str] = set()
     used_tag_objects: set[str] = set()
 
+    def activate_current_record_queue() -> None:
+        nonlocal pending_reset, signed
+        if pending_reset is not None:
+            return
+        if drift_targets:
+            pending_reset = ("record-invalid", drift_targets[0])
+        elif deferred_invalid_targets:
+            pending_reset = ("record-invalid", deferred_invalid_targets[0])
+        if pending_reset is not None:
+            signed = False
+
     for index, (entry, shape) in enumerate(zip(entries, shaped), start=1):
         entry_id, kind, attempt, record_ref = shape
-        if index > drift_boundary and drift_targets and pending_reset is None:
-            pending_reset = ("record-invalid", drift_targets[0])
-            signed = False
-        require(not signed, f"{entry_id} appears after final sign-off")
+        if index > drift_boundary:
+            activate_current_record_queue()
+        if signed:
+            require(
+                kind == "correction"
+                or (kind == "reset" and entry.get("cause") == "record-invalid"),
+                f"{entry_id} appears after final sign-off",
+            )
+            if kind == "reset":
+                signed = False
         if pending_reset is not None and kind != "correction":
             require(kind == "reset", f"{pending_reset[1]} must be followed by its reset")
 
@@ -1420,6 +1747,17 @@ def validate_entries(
         record_merged_at = inspection.merged_at
         record_integration = inspection.integration
         record_invalid_reasons = list(inspection.invalid_reasons)
+        if index == len(entries):
+            expected_boundary = index - 1 if record_pending else index
+            require(
+                drift_boundary == expected_boundary,
+                "audit boundary is stale rather than the actual final live prefix",
+            )
+            if record_pending:
+                require(
+                    validation_target_oid == record.head_oid,
+                    f"{entry_id} candidate audit targets another head",
+                )
 
         def check_kind_record_fact(condition: bool, message: str) -> None:
             if condition:
@@ -1511,6 +1849,7 @@ def validate_entries(
                     source_ref,
                     author=source_author,
                     before=source_time,
+                    authorized_permissions=reviewer_permissions,
                 )
                 require(
                     source_integration == source_sha,
@@ -1529,7 +1868,16 @@ def validate_entries(
                 )
                 require(
                     tag.patch_is_fresh_for_attempt is True,
-                    f"{entry_id} freeze PATCH does not exceed abandoned tags",
+                    f"{entry_id} freeze PATCH does not exceed earlier freeze entries",
+                )
+                require(
+                    tag.namespace_complete is True,
+                    f"{entry_id} freeze tag namespace is incompletely paginated",
+                )
+                require(
+                    tag.patch_exceeds_other_namespace_tags is True,
+                    f"{entry_id} freeze PATCH does not exceed abandoned tags "
+                    "or other namespace tags",
                 )
                 payload_blobs = validate_release_payload(
                     resolve_replay_release_payload(source_sha, tag_name, release_contract),
@@ -1612,7 +1960,7 @@ def validate_entries(
 
             def work_external_facts() -> tuple[datetime, str]:
                 work_pr = resolve_replay_pr(work_ref, active["freeze_integration"])
-                work_author, _work_head = validate_pr_core(work_pr, work_ref)
+                work_author, work_head = validate_pr_core(work_pr, work_ref)
                 work_merged_at, work_integration = validate_merged_pr(
                     work_pr,
                     work_ref,
@@ -1628,12 +1976,29 @@ def validate_entries(
                     work_ref,
                     author=work_author,
                     before=work_merged_at,
+                    authorized_permissions=reviewer_permissions,
                 )
                 work_diff = resolve_replay_work_diff(work_ref)
-                require(work_diff.complete is True, f"{entry_id} work diff is incomplete")
                 require(
-                    work_diff.integration_parent_count in {1, 2},
-                    f"{entry_id} work integration has an invalid parent count",
+                    work_diff.validated_pr_ref == work_ref,
+                    f"{entry_id} work diff was validated on another PR",
+                )
+                require(
+                    work_diff.validated_head_oid == work_head,
+                    f"{entry_id} work diff was not validated at its exact head",
+                )
+                require(
+                    work_diff.validated_integration_oid == work_integration,
+                    f"{entry_id} work diff used another integration",
+                )
+                require(
+                    work_diff.validated_freeze_integration == active["freeze_integration"],
+                    f"{entry_id} work diff used another freeze integration",
+                )
+                require(work_diff.complete is True, f"{entry_id} work diff is incomplete")
+                work_parent_count = integration_parent_count(
+                    work_diff.integration_parent_count,
+                    f"{entry_id} work integration",
                 )
                 require(
                     work_diff.unique_merge_base is True,
@@ -1643,7 +2008,7 @@ def validate_entries(
                     work_diff.integration_parent_is_ancestor_of_head is True,
                     f"{entry_id} work integration parent is not an ancestor of its head",
                 )
-                if work_diff.integration_parent_count == 2:
+                if work_parent_count == 2:
                     require(
                         work_diff.integration_second_parent_matches_head is True,
                         f"{entry_id} work integration second parent differs from its head",
@@ -1735,6 +2100,14 @@ def validate_entries(
             if not entry_is_invalid():
                 assert isinstance(work_result, tuple)
                 work_merged_at, work_integration = work_result
+                assert record_merged_at is not None
+                check_kind_record_fact(
+                    record_merged_at > work_merged_at,
+                    f"{entry_id} evidence record did not merge after its work PR",
+                )
+            if not entry_is_invalid():
+                assert isinstance(work_result, tuple)
+                work_merged_at, work_integration = work_result
                 active["work"][work_class] = {
                     "entry_id": entry_id,
                     "pr": work_ref,
@@ -1781,21 +2154,215 @@ def validate_entries(
                     seen_attempts[target] == attempt,
                     f"{entry_id} breaking reset target is in another attempt",
                 )
-            require(
-                pending_reset == (cause, target),
-                f"{entry_id} does not match the required reset",
-            )
+            historical_record_reset = cause == "record-invalid" and index <= drift_boundary
+            if cause == "record-invalid":
+                assert resolve_replay_record_invalid_reset is not None
+                receipt_ref = pr_ref(entry["replay_receipt_pr"], "replay_receipt_pr", entry_id)
+                receipt_digest = sha256(
+                    entry["replay_receipt_sha256"],
+                    "replay_receipt_sha256",
+                    entry_id,
+                )
+
+                def replay_receipt_facts() -> tuple[list[str], str | None, str]:
+                    receipt_pr = resolve_replay_pr(receipt_ref, last_record_integration)
+                    receipt_author, receipt_head = validate_pr_core(receipt_pr, receipt_ref)
+                    receipt_time, receipt_integration = validate_merged_pr(
+                        receipt_pr,
+                        receipt_ref,
+                        require_descendant=False,
+                        require_tree=True,
+                    )
+                    require(
+                        normalized_login(receipt_pr.merged_by_login, f"{receipt_ref} mergedBy")
+                        == maintainer_login,
+                        f"{receipt_ref} was not merged by github:{maintainer_login}",
+                    )
+                    require_independent_approval(
+                        receipt_pr,
+                        receipt_ref,
+                        author=receipt_author,
+                        before=receipt_time,
+                        distinct_from={maintainer_login},
+                        authorized_permissions=reviewer_permissions,
+                    )
+                    if record_merged_at is not None:
+                        require(
+                            record_merged_at > receipt_time,
+                            f"{entry_id} reset record did not merge after its receipt PR",
+                        )
+                    require(
+                        last_ledger_record_merged_at is not None
+                        and receipt_time > last_ledger_record_merged_at,
+                        f"{entry_id} receipt PR did not merge after its ledger boundary",
+                    )
+                    replay = resolve_replay_record_invalid_reset(
+                        entry_id,
+                        target,
+                        receipt_ref,
+                        receipt_digest,
+                    )
+                    require(
+                        replay.validated_entry_id == entry_id,
+                        f"{entry_id} reset receipt used another entry",
+                    )
+                    require(
+                        replay.validated_target_entry_id == target,
+                        f"{entry_id} reset receipt used another target",
+                    )
+                    require(
+                        replay.validated_receipt_pr == receipt_ref,
+                        f"{entry_id} reset receipt used another PR",
+                    )
+                    require(
+                        replay.validated_receipt_head_oid == receipt_head,
+                        f"{entry_id} reset receipt used another exact head",
+                    )
+                    require(
+                        replay.validated_receipt_integration_oid == receipt_integration,
+                        f"{entry_id} reset receipt used another integration",
+                    )
+                    require(replay.complete is True, f"{entry_id} reset receipt is incomplete")
+                    require(
+                        replay.receipt_candidate_main_tip_exact is True,
+                        f"{entry_id} receipt PR did not target the exact current main tip",
+                    )
+                    require(
+                        replay.changes_exactly_one_new_regular_blob is True,
+                        f"{entry_id} receipt PR changes more than its new regular blob",
+                    )
+                    expected_path = f"docs/tenkz/soak-replay/{receipt_ref[1:]}.json"
+                    require(
+                        replay.receipt_path == expected_path,
+                        f"{entry_id} reset receipt has the wrong path",
+                    )
+                    require(
+                        replay.raw_blob_sha256 == receipt_digest,
+                        f"{entry_id} reset receipt blob digest differs from the entry",
+                    )
+                    require(
+                        replay.raw_blob_read_from_receipt_integration is True,
+                        f"{entry_id} reset receipt was not read from its reachable integration",
+                    )
+                    require(
+                        replay.schema_path == release_contract.reset_replay_schema,
+                        f"{entry_id} reset receipt used another schema",
+                    )
+                    require(
+                        replay.schema_support_tree_oid == release_contract.test_support_tree,
+                        f"{entry_id} reset receipt used another support tree",
+                    )
+                    require(
+                        replay.schema_from_pinned_support_tree is True,
+                        f"{entry_id} reset receipt schema is not from the pinned support tree",
+                    )
+                    require(
+                        replay.schema_closed_and_valid is True,
+                        f"{entry_id} reset receipt does not satisfy the closed schema",
+                    )
+                    expected_boundary = shaped[index - 2][0]
+                    require(
+                        replay.boundary_entry_id == expected_boundary,
+                        f"{entry_id} reset receipt used another pre-reset prefix",
+                    )
+                    require(
+                        replay.validation_target_oid == receipt_head,
+                        f"{entry_id} reset receipt used an inexact validation target",
+                    )
+                    replay_invalid = replay.raw_invalid_entries
+                    require(
+                        isinstance(replay_invalid, tuple)
+                        and all(isinstance(item, str) for item in replay_invalid),
+                        f"{entry_id} reset receipt raw-invalid queue is missing",
+                    )
+                    replay_list = list(replay_invalid)
+                    require(
+                        len(replay_list) == len(set(replay_list)),
+                        f"{entry_id} reset receipt raw-invalid queue has duplicates",
+                    )
+                    require(
+                        all(item in seen for item in replay_list),
+                        f"{entry_id} reset receipt names a non-prefix entry",
+                    )
+                    require(
+                        replay_list == sorted(replay_list, key=entry_positions.__getitem__),
+                        f"{entry_id} reset receipt queue is not in ledger order",
+                    )
+                    breaking_target = replay.pending_breaking_target
+                    actual_breaking_target = (
+                        pending_reset[1]
+                        if pending_reset is not None
+                        and pending_reset[0] == "breaking-required"
+                        else None
+                    )
+                    require(
+                        breaking_target == actual_breaking_target,
+                        f"{entry_id} reset receipt has the wrong pending breaking target",
+                    )
+                    require(
+                        replay.normalized_resolver_inputs_complete_and_matching is True,
+                        f"{entry_id} reset receipt resolver inputs are incomplete or mismatched",
+                    )
+                    require(
+                        replay.workflow_dependency_closure_pinned is True,
+                        f"{entry_id} reset receipt workflow closure is not pinned",
+                    )
+                    require(
+                        replay.supervisor_receipts_complete_and_matching is True,
+                        f"{entry_id} reset receipt supervisor results are incomplete or mismatched",
+                    )
+                    require(
+                        replay.current_candidate_snapshot_reproduces_receipt is True,
+                        f"{entry_id} reset candidate no longer reproduces its receipt",
+                    )
+                    return replay_list, breaking_target, receipt_integration
+
+                receipt_result = check_external(replay_receipt_facts)
+                if isinstance(receipt_result, tuple):
+                    replay_list, breaking_target, receipt_integration = receipt_result
+                    check_kind_record_fact(
+                        diff.validated_receipt_integration == receipt_integration,
+                        f"{entry_id} record diff used another receipt integration",
+                    )
+                    check_kind_record_fact(
+                        diff.candidate_main_tip_is_receipt_integration is True,
+                        f"{entry_id} candidate base differs from receipt integration",
+                    )
+                    if not record_pending:
+                        check_kind_record_fact(
+                            diff.integration_parent_is_receipt_integration is True,
+                            f"{entry_id} integration parent differs from receipt integration",
+                        )
+                    receipt_required = (
+                        ("breaking-required", breaking_target)
+                        if breaking_target is not None
+                        else (("record-invalid", replay_list[0]) if replay_list else None)
+                    )
+                    if historical_record_reset:
+                        require(
+                            receipt_required == (cause, target),
+                            f"{entry_id} does not match its durable historical reset receipt",
+                        )
+                    else:
+                        require(
+                            pending_reset == (cause, target) == receipt_required,
+                            f"{entry_id} does not match its current reset receipt",
+                        )
+            else:
+                require(
+                    pending_reset == (cause, target),
+                    f"{entry_id} does not match the required reset",
+                )
             nonempty_string(entry["reason"], "reason", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
             if record_pending:
                 return finish_pending("reset-pending")
             if not entry_is_invalid():
-                if cause == "record-invalid" and drift_targets:
-                    require(
-                        target == drift_targets[0],
-                        f"{entry_id} does not reset the earliest drifted record",
-                    )
-                    drift_targets.pop(0)
+                if cause == "record-invalid":
+                    if drift_targets and target == drift_targets[0]:
+                        drift_targets.pop(0)
+                    if target in deferred_invalid_targets:
+                        deferred_invalid_targets.remove(target)
                 pending_reset = None
                 last_reset_integration = record_integration
                 active = None
@@ -1864,6 +2431,7 @@ def validate_entries(
                     release_ref,
                     author=release_author,
                     before=release_merged_at,
+                    authorized_permissions=reviewer_permissions,
                 )
                 release = resolve_replay_release_prep(
                     release_ref,
@@ -1891,9 +2459,9 @@ def validate_entries(
                     f"{entry_id} release preparation used other work integrations",
                 )
                 require(release.complete is True, f"{entry_id} release diff is incomplete")
-                require(
-                    release.integration_parent_count in {1, 2},
-                    f"{entry_id} release integration has an invalid parent count",
+                release_parent_count = integration_parent_count(
+                    release.integration_parent_count,
+                    f"{entry_id} release integration",
                 )
                 require(
                     release.unique_merge_base is True,
@@ -1903,7 +2471,7 @@ def validate_entries(
                     release.integration_parent_is_ancestor_of_head is True,
                     f"{entry_id} release parent is not an ancestor of its head",
                 )
-                if release.integration_parent_count == 2:
+                if release_parent_count == 2:
                     require(
                         release.integration_second_parent_matches_head is True,
                         f"{entry_id} release second parent differs from its head",
@@ -1957,21 +2525,6 @@ def validate_entries(
                         head_blobs == release_payload_blobs,
                         f"{entry_id} sign-off head changed the prepared payload blobs",
                     )
-                    freeze_blobs = validate_release_payload(
-                        resolve_replay_release_payload(
-                            source_sha,
-                            active["freeze_tag"],
-                            release_contract,
-                        ),
-                        tree_oid=source_sha,
-                        tag=active["freeze_tag"],
-                        contract=release_contract,
-                        subject=f"{entry_id} active freeze",
-                    )
-                    require(
-                        freeze_blobs == active["freeze_payload_blobs"],
-                        f"{entry_id} active freeze payload blobs changed",
-                    )
 
                 check_external(signoff_payload_facts)
             require(
@@ -1995,6 +2548,7 @@ def validate_entries(
                         before=before,
                         named_reviewer=reviewer,
                         distinct_from={maintainer_login},
+                        authorized_permissions=reviewer_permissions,
                     )
                 )
             unresolved = sorted(
@@ -2050,17 +2604,19 @@ def validate_entries(
 
         if record_integration is not None and not entry_is_invalid():
             last_record_integration = record_integration
+        if record_merged_at is not None:
+            last_ledger_record_merged_at = record_merged_at
         seen[entry_id] = entry
         seen_attempts[entry_id] = attempt
         if entry_is_invalid():
             require(not record_pending, f"{entry_id} cannot be invalid before merge")
-            pending_reset = ("record-invalid", entry_id)
+            if entry_id not in deferred_invalid_targets:
+                deferred_invalid_targets.append(entry_id)
 
-    if drift_targets and pending_reset is None:
-        pending_reset = ("record-invalid", drift_targets[0])
-        signed = False
-    assert tag_protection is not None
-    validate_tag_protection(tag_protection)
+    activate_current_record_queue()
+    validate_current_controls()
+    final_tag = current_final_tag()
+    terminal_tag_present = final_tag.exists is True
     if terminal_tag_present and pending_reset is not None:
         raise PolicyError("final tag exists while release evidence requires reset")
     if terminal_tag_present and not signed:

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -470,6 +470,7 @@ class ReleasePrepEvidence:
 
     validated_pr_ref: str | None
     validated_head_oid: str | None
+    validated_integration_oid: str | None
     validated_manifest_path: str | None
     validated_changed_paths: tuple[str, ...] | None
     validated_work_integrations: tuple[str, ...] | None
@@ -763,7 +764,8 @@ ResolveReplayRecordDiff = Callable[[str, str, str | None], RecordDiffEvidence]
 ResolveReplayWorkDiff = Callable[[str], WorkDiffEvidence]
 ResolveReplayResolutionDiff = Callable[[str], ResolutionDiffEvidence]
 ResolveReplayReleasePrep = Callable[
-    [str, tuple[str, ...], tuple[str, ...], tuple[str, ...]], ReleasePrepEvidence
+    [str, str, tuple[str, ...], tuple[str, ...], tuple[str, ...]],
+    ReleasePrepEvidence,
 ]
 ResolveReplayReleasePayload = Callable[[str, str, ReleaseContract], ReleasePayloadEvidence]
 ResolveReplayReleaseTestObservation = Callable[
@@ -4284,6 +4286,7 @@ def validate_entries(
                 )
                 release = resolve_replay_release_prep(
                     release_ref,
+                    release_integration,
                     release_paths,
                     work_integrations,
                     resolution_integrations,
@@ -4295,6 +4298,10 @@ def validate_entries(
                 require(
                     release.validated_head_oid == release_head,
                     f"{entry_id} release preparation was not validated at its exact head",
+                )
+                require(
+                    release.validated_integration_oid == release_integration,
+                    f"{entry_id} release preparation used another integration",
                 )
                 require(
                     release.validated_manifest_path == release_contract.manifest_path(FINAL_TAG),

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""Pure validation for the tenkz compatibility policy and 1.0 soak log."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Callable
+
+
+SOAK_MARKER = "<!-- tenkz-soak-entries: append below; do not edit preceding bytes -->"
+PREREQUISITES = ["#5086", "#4699", "#4162", "#4703", "#4708", "#4163"]
+FREEZE_TAG_RE = re.compile(r"tenkz-v0\.9\.(?:0|[1-9][0-9]*)")
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+ENTRY_ID_RE = re.compile(r"S1-[0-9]{4}")
+IDENTITY_RE = re.compile(r"github:[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?")
+UTC_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
+ENTRY_KINDS = {
+    "freeze",
+    "work",
+    "friction",
+    "resolution",
+    "reset",
+    "correction",
+    "sign-off",
+}
+TRIAGE = {"fix-compatible", "defer-to-2.0", "breaking-required"}
+SURFACES = {"tex-api", "tnlog"}
+
+EXPECTED_POLICY = {
+    "policy": {
+        "schema": 1,
+        "tag_namespace": "tenkz-v*",
+        "repository_tag_namespace": "v*",
+        "freeze_tag_pattern": "tenkz-v0.9.PATCH",
+        "freeze_tag_kind": "annotated",
+        "soak_days": 28,
+        "event_format_implementation": "pending",
+        "event_format_owners": ["#4162", "#4703"],
+        "soak_blocker_chain": [
+            ["#5086", "#4699", "#4162"],
+            ["#4703", "#4708", "#4163"],
+        ],
+        "deprecation_removal": "next-major",
+        "tombstone_reuse": False,
+        "frozen_twin_scope": "library-or-package-entry-point",
+        "frozen_twin_lifetime": "permanent",
+        "frozen_twin_precedent": "quantikz/quantikz2",
+        "maintainer_identity": "github:lionsr",
+        "signer_identity_scheme": "github:lowercase-login",
+    },
+    "compatibility": {
+        "patch": {
+            "tex_api": "backward-compatible-fix",
+            "tnlog": "byte-stable",
+        },
+        "minor": {
+            "tex_api": "backward-compatible-addition",
+            "tnlog": "additive-versioned",
+        },
+        "major": {
+            "tex_api": "breaking-change",
+            "tnlog": "breaking-versioned",
+        },
+    },
+}
+
+EXPECTED_SOAK = {
+    "soak": {
+        "schema": 1,
+        "policy": "docs/tenkz/DESIGN.md",
+        "append_only": True,
+        "minimum_days": 28,
+        "normal_work_windows": 4,
+        "required_prerequisites": PREREQUISITES,
+        "freeze_tag_pattern": "tenkz-v0.9.PATCH",
+        "freeze_tag_kind": "annotated",
+        "release_tag": "tenkz-v1.0.0",
+        "maintainer_identity": "github:lionsr",
+        "signer_identity_scheme": "github:lowercase-login",
+    }
+}
+
+COMMON_FIELDS = {"id", "kind", "date", "author", "attempt"}
+FIELDS_BY_KIND = {
+    "freeze": COMMON_FIELDS
+    | {
+        "freeze_sha",
+        "freeze_tag_object",
+        "freeze_tag",
+        "freeze_tagger_utc",
+        "prerequisites",
+        "evidence",
+    },
+    "work": COMMON_FIELDS
+    | {"work_sha", "work_committed_utc", "summary", "evidence"},
+    "friction": COMMON_FIELDS | {"surface", "triage", "summary", "evidence"},
+    "resolution": COMMON_FIELDS | {"friction", "summary", "evidence"},
+    "reset": COMMON_FIELDS | {"friction", "reason", "evidence"},
+    "correction": COMMON_FIELDS | {"target", "summary", "evidence"},
+    "sign-off": COMMON_FIELDS
+    | {
+        "freeze",
+        "freeze_sha",
+        "release_tag",
+        "maintainer",
+        "reviewer",
+        "work_evidence",
+        "decision",
+    },
+}
+
+
+class PolicyError(ValueError):
+    """A compatibility policy or soak record is invalid."""
+
+
+@dataclass(frozen=True)
+class TagEvidence:
+    object_id: str
+    object_type: str
+    commit: str
+    tagger_utc: datetime | None
+    reachable_from_main: bool
+
+
+@dataclass(frozen=True)
+class CommitEvidence:
+    object_type: str
+    committed_utc: datetime | None
+    reachable_from_main: bool
+    descends_from_freeze: bool
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise PolicyError(message)
+
+
+def fenced_blocks(text: str, label: str) -> list[str]:
+    pattern = re.compile(
+        rf"^```toml[ \t]+{re.escape(label)}[ \t]*\n(.*?)^```[ \t]*$",
+        re.MULTILINE | re.DOTALL,
+    )
+    return [match.group(1) for match in pattern.finditer(text)]
+
+
+def parse_toml_block(text: str, label: str) -> dict:
+    blocks = fenced_blocks(text, label)
+    require(len(blocks) == 1, f"expected exactly one {label} block, found {len(blocks)}")
+    try:
+        parsed = tomllib.loads(blocks[0])
+    except tomllib.TOMLDecodeError as error:
+        raise PolicyError(f"invalid TOML in {label}: {error}") from error
+    require(isinstance(parsed, dict), f"{label} must decode to a table")
+    return parsed
+
+
+def validate_policy_text(text: str) -> dict:
+    required_headings = {
+        "## Compatibility ownership",
+        "## Package versions",
+        "## Deprecations, tombstones, and frozen twins",
+        "## Release tags",
+        "## The 1.0 freeze and soak",
+    }
+    missing = sorted(heading for heading in required_headings if heading not in text)
+    require(not missing, f"DESIGN.md lacks required section(s): {', '.join(missing)}")
+    policy = parse_toml_block(text, "tenkz-policy-v1")
+    require(policy == EXPECTED_POLICY, "tenkz-policy-v1 differs from the signed policy")
+    return policy
+
+
+def parse_entry_block(block: str, index: int) -> dict:
+    try:
+        parsed = tomllib.loads(block)
+    except tomllib.TOMLDecodeError as error:
+        raise PolicyError(f"entry {index} contains invalid TOML: {error}") from error
+    require(set(parsed) == {"entry"}, f"entry {index} must contain only [entry]")
+    entry = parsed["entry"]
+    require(isinstance(entry, dict), f"entry {index} [entry] must be a table")
+    return entry
+
+
+def parse_soak_text(text: str) -> tuple[dict, list[dict]]:
+    soak = parse_toml_block(text, "tenkz-soak-v1")
+    require(soak == EXPECTED_SOAK, "tenkz-soak-v1 differs from the signed schema")
+    require(text.count(SOAK_MARKER) == 1, "SOAK-1.0.md must contain one append marker")
+    prefix, tail = text.split(SOAK_MARKER, 1)
+    require(
+        not fenced_blocks(prefix, "tenkz-soak-entry-v1"),
+        "soak entries must appear after the append marker",
+    )
+
+    pattern = re.compile(
+        r"^```toml[ \t]+tenkz-soak-entry-v1[ \t]*\n(.*?)^```[ \t]*$",
+        re.MULTILINE | re.DOTALL,
+    )
+    entries: list[dict] = []
+    cursor = 0
+    for index, match in enumerate(pattern.finditer(tail), start=1):
+        require(
+            not tail[cursor : match.start()].strip(),
+            "only soak entry blocks may follow the append marker",
+        )
+        entries.append(parse_entry_block(match.group(1), index))
+        cursor = match.end()
+    require(not tail[cursor:].strip(), "only soak entry blocks may follow the append marker")
+    return soak, entries
+
+
+def nonempty_string(value: object, field: str, entry_id: str) -> str:
+    require(
+        isinstance(value, str) and bool(value.strip()),
+        f"{entry_id} field {field} must be a nonempty string",
+    )
+    return value
+
+
+def string_list(value: object, field: str, entry_id: str) -> list[str]:
+    require(
+        isinstance(value, list)
+        and all(isinstance(item, str) and item.strip() for item in value),
+        f"{entry_id} field {field} must be a list of nonempty strings",
+    )
+    return value
+
+
+def iso_date(value: object, entry_id: str) -> date:
+    text = nonempty_string(value, "date", entry_id)
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as error:
+        raise PolicyError(f"{entry_id} date must use YYYY-MM-DD") from error
+    require(parsed.isoformat() == text, f"{entry_id} date must use YYYY-MM-DD")
+    return parsed
+
+
+def iso_utc(value: object, field: str, entry_id: str) -> datetime:
+    text = nonempty_string(value, field, entry_id)
+    require(UTC_RE.fullmatch(text) is not None, f"{entry_id} {field} must use UTC seconds")
+    try:
+        return datetime.strptime(text, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError as error:
+        raise PolicyError(f"{entry_id} {field} is not a real UTC timestamp") from error
+
+
+def normalized_identity(value: object, field: str, entry_id: str) -> str:
+    identity = nonempty_string(value, field, entry_id)
+    require(
+        IDENTITY_RE.fullmatch(identity) is not None,
+        f"{entry_id} {field} must use github:lowercase-login",
+    )
+    return identity
+
+
+def validate_entry_shape(entry: dict, index: int) -> tuple[str, str, date, int]:
+    expected_id = f"S1-{index:04d}"
+    entry_id = nonempty_string(entry.get("id"), "id", expected_id)
+    require(ENTRY_ID_RE.fullmatch(entry_id) is not None, f"invalid entry id {entry_id}")
+    require(entry_id == expected_id, f"expected entry id {expected_id}, found {entry_id}")
+    kind = nonempty_string(entry.get("kind"), "kind", entry_id)
+    require(kind in ENTRY_KINDS, f"{entry_id} has unknown kind {kind}")
+    require(
+        set(entry) == FIELDS_BY_KIND[kind],
+        f"{entry_id} {kind} fields differ from the schema",
+    )
+    entry_date = iso_date(entry["date"], entry_id)
+    normalized_identity(entry["author"], "author", entry_id)
+    attempt = entry["attempt"]
+    require(
+        isinstance(attempt, int) and not isinstance(attempt, bool) and attempt > 0,
+        f"{entry_id} attempt must be a positive integer",
+    )
+    return entry_id, kind, entry_date, attempt
+
+
+def validate_entries(
+    entries: list[dict],
+    *,
+    resolve_tag: Callable[[str], TagEvidence] | None = None,
+    resolve_commit: Callable[[str, str], CommitEvidence] | None = None,
+    now: datetime | None = None,
+) -> str:
+    current = now or datetime.now(timezone.utc)
+    require(current.tzinfo is not None, "current time must be timezone-aware")
+    current = current.astimezone(timezone.utc)
+    seen: dict[str, tuple[dict, date]] = {}
+    active: dict | None = None
+    last_date: date | None = None
+    last_attempt = 0
+    pending_break: str | None = None
+    signed = False
+    prior_freeze_sha: str | None = None
+    used_freeze_tags: set[str] = set()
+    used_freeze_objects: set[str] = set()
+    used_freeze_shas: set[str] = set()
+
+    for index, entry in enumerate(entries, start=1):
+        entry_id, kind, entry_date, attempt = validate_entry_shape(entry, index)
+        require(not signed, f"{entry_id} appears after final sign-off")
+        require(entry_date <= current.date(), f"{entry_id} date is in the future")
+        if last_date is not None:
+            require(entry_date >= last_date, f"{entry_id} date precedes the prior entry")
+        last_date = entry_date
+
+        if pending_break is not None:
+            require(
+                kind == "reset" and entry["friction"] == pending_break,
+                f"{pending_break} breaking need must be followed immediately by its reset",
+            )
+
+        if kind == "freeze":
+            require(active is None, f"{entry_id} starts a freeze while an attempt is active")
+            require(attempt == last_attempt + 1, f"{entry_id} has the wrong attempt number")
+            freeze_sha = nonempty_string(entry["freeze_sha"], "freeze_sha", entry_id)
+            tag_object = nonempty_string(
+                entry["freeze_tag_object"], "freeze_tag_object", entry_id
+            )
+            freeze_tag = nonempty_string(entry["freeze_tag"], "freeze_tag", entry_id)
+            tagger_utc = iso_utc(
+                entry["freeze_tagger_utc"], "freeze_tagger_utc", entry_id
+            )
+            require(SHA_RE.fullmatch(freeze_sha) is not None, f"{entry_id} has invalid freeze_sha")
+            require(
+                SHA_RE.fullmatch(tag_object) is not None,
+                f"{entry_id} has invalid freeze_tag_object",
+            )
+            require(
+                FREEZE_TAG_RE.fullmatch(freeze_tag) is not None,
+                f"{entry_id} freeze tag must use tenkz-v0.9.PATCH",
+            )
+            require(
+                freeze_tag not in used_freeze_tags,
+                f"{entry_id} reuses a prior freeze tag",
+            )
+            require(
+                tag_object not in used_freeze_objects,
+                f"{entry_id} reuses a prior freeze tag object",
+            )
+            require(
+                freeze_sha not in used_freeze_shas,
+                f"{entry_id} reuses a prior freeze commit",
+            )
+            require(
+                entry_date == tagger_utc.date(),
+                f"{entry_id} date differs from the tagger UTC date",
+            )
+            require(tagger_utc <= current, f"{entry_id} tagger timestamp is in the future")
+            require(
+                entry["prerequisites"] == PREREQUISITES,
+                f"{entry_id} lacks the full blocker chain",
+            )
+            nonempty_string(entry["evidence"], "evidence", entry_id)
+            require(resolve_tag is not None, f"{entry_id} requires Git tag resolution")
+            require(resolve_commit is not None, f"{entry_id} requires Git commit resolution")
+            tag = resolve_tag(freeze_tag)
+            require(tag.object_type == "tag", f"{entry_id} freeze tag is not annotated")
+            require(tag.object_id == tag_object, f"{entry_id} freeze tag object was replaced")
+            require(tag.commit == freeze_sha, f"{entry_id} freeze tag peels to another commit")
+            require(tag.tagger_utc is not None, f"{entry_id} annotated tag lacks a tagger date")
+            require(
+                tag.tagger_utc.astimezone(timezone.utc) == tagger_utc,
+                f"{entry_id} tagger timestamp differs from the tag object",
+            )
+            require(
+                tag.reachable_from_main,
+                f"{entry_id} freeze commit is not reachable from main",
+            )
+            freeze_commit = resolve_commit(
+                freeze_sha,
+                prior_freeze_sha if prior_freeze_sha is not None else freeze_sha,
+            )
+            require(
+                freeze_commit.object_type == "commit",
+                f"{entry_id} freeze_sha is not a commit",
+            )
+            require(
+                freeze_commit.committed_utc is not None,
+                f"{entry_id} freeze commit lacks a committer date",
+            )
+            require(
+                freeze_commit.committed_utc.tzinfo is not None,
+                f"{entry_id} freeze commit timestamp must be timezone-aware",
+            )
+            require(
+                freeze_commit.committed_utc.astimezone(timezone.utc) <= tagger_utc,
+                f"{entry_id} freeze commit postdates the annotated tag",
+            )
+            if prior_freeze_sha is not None:
+                require(
+                    freeze_commit.descends_from_freeze,
+                    f"{entry_id} freeze commit does not descend from the prior freeze",
+                )
+            active = {
+                "attempt": attempt,
+                "freeze_id": entry_id,
+                "freeze_utc": tagger_utc,
+                "freeze_sha": freeze_sha,
+                "work": {},
+                "friction": {},
+            }
+            prior_freeze_sha = freeze_sha
+            used_freeze_tags.add(freeze_tag)
+            used_freeze_objects.add(tag_object)
+            used_freeze_shas.add(freeze_sha)
+            last_attempt = attempt
+        elif kind == "correction":
+            target = nonempty_string(entry["target"], "target", entry_id)
+            require(target in seen, f"{entry_id} correction target is not an earlier entry")
+            require(
+                attempt == seen[target][0]["attempt"],
+                f"{entry_id} correction attempt differs from its target",
+            )
+            nonempty_string(entry["summary"], "summary", entry_id)
+            nonempty_string(entry["evidence"], "evidence", entry_id)
+        else:
+            require(active is not None, f"{entry_id} {kind} appears without an active freeze")
+            require(attempt == active["attempt"], f"{entry_id} has the wrong active attempt")
+
+            if kind == "work":
+                work_sha = nonempty_string(entry["work_sha"], "work_sha", entry_id)
+                work_utc = iso_utc(
+                    entry["work_committed_utc"], "work_committed_utc", entry_id
+                )
+                require(SHA_RE.fullmatch(work_sha) is not None, f"{entry_id} has invalid work_sha")
+                require(
+                    entry_date == work_utc.date(),
+                    f"{entry_id} date differs from the work commit UTC date",
+                )
+                require(work_utc <= current, f"{entry_id} work commit is in the future")
+                require(
+                    work_utc >= active["freeze_utc"],
+                    f"{entry_id} work commit predates the freeze tag",
+                )
+                require(resolve_commit is not None, f"{entry_id} requires Git commit resolution")
+                commit = resolve_commit(work_sha, active["freeze_sha"])
+                require(commit.object_type == "commit", f"{entry_id} work_sha is not a commit")
+                require(
+                    commit.committed_utc is not None,
+                    f"{entry_id} work commit lacks a committer date",
+                )
+                require(
+                    commit.committed_utc.astimezone(timezone.utc) == work_utc,
+                    f"{entry_id} timestamp differs from the commit object",
+                )
+                require(
+                    commit.reachable_from_main,
+                    f"{entry_id} work commit is not reachable from main",
+                )
+                require(
+                    commit.descends_from_freeze,
+                    f"{entry_id} work commit does not descend from the freeze",
+                )
+                require(
+                    all(record["sha"] != work_sha for record in active["work"].values()),
+                    f"{entry_id} repeats a work commit",
+                )
+                nonempty_string(entry["summary"], "summary", entry_id)
+                nonempty_string(entry["evidence"], "evidence", entry_id)
+                active["work"][entry_id] = {"sha": work_sha, "when": work_utc}
+            elif kind == "friction":
+                surface = nonempty_string(entry["surface"], "surface", entry_id)
+                triage = nonempty_string(entry["triage"], "triage", entry_id)
+                require(surface in SURFACES, f"{entry_id} has invalid friction surface")
+                require(triage in TRIAGE, f"{entry_id} has invalid friction triage")
+                nonempty_string(entry["summary"], "summary", entry_id)
+                nonempty_string(entry["evidence"], "evidence", entry_id)
+                active["friction"][entry_id] = {
+                    "triage": triage,
+                    "resolved": False,
+                }
+                if triage == "breaking-required":
+                    pending_break = entry_id
+            elif kind == "resolution":
+                friction = nonempty_string(entry["friction"], "friction", entry_id)
+                record = active["friction"].get(friction)
+                require(record is not None, f"{entry_id} names no friction in this attempt")
+                require(
+                    record["triage"] == "fix-compatible",
+                    f"{entry_id} may resolve only fix-compatible friction",
+                )
+                require(not record["resolved"], f"{entry_id} resolves friction twice")
+                nonempty_string(entry["summary"], "summary", entry_id)
+                nonempty_string(entry["evidence"], "evidence", entry_id)
+                record["resolved"] = True
+            elif kind == "reset":
+                friction = nonempty_string(entry["friction"], "friction", entry_id)
+                record = active["friction"].get(friction)
+                require(record is not None, f"{entry_id} names no friction in this attempt")
+                require(
+                    record["triage"] == "breaking-required",
+                    f"{entry_id} reset needs a breaking-required friction",
+                )
+                nonempty_string(entry["reason"], "reason", entry_id)
+                nonempty_string(entry["evidence"], "evidence", entry_id)
+                pending_break = None
+                active = None
+            elif kind == "sign-off":
+                freeze = nonempty_string(entry["freeze"], "freeze", entry_id)
+                freeze_sha = nonempty_string(entry["freeze_sha"], "freeze_sha", entry_id)
+                release_tag = nonempty_string(entry["release_tag"], "release_tag", entry_id)
+                decision = nonempty_string(entry["decision"], "decision", entry_id)
+                maintainer = normalized_identity(entry["maintainer"], "maintainer", entry_id)
+                reviewer = normalized_identity(entry["reviewer"], "reviewer", entry_id)
+                work_evidence = string_list(entry["work_evidence"], "work_evidence", entry_id)
+                require(freeze == active["freeze_id"], f"{entry_id} names the wrong freeze entry")
+                require(
+                    freeze_sha == active["freeze_sha"],
+                    f"{entry_id} names the wrong freeze SHA",
+                )
+                require(release_tag == "tenkz-v1.0.0", f"{entry_id} has the wrong release tag")
+                require(decision == "release", f"{entry_id} decision must be release")
+                require(maintainer == "github:lionsr", f"{entry_id} has the wrong maintainer")
+                require(reviewer != maintainer, f"{entry_id} reviewer must be independent")
+                require(
+                    len(work_evidence) == len(set(work_evidence)),
+                    f"{entry_id} repeats work evidence",
+                )
+                eligible_at = active["freeze_utc"] + timedelta(days=28)
+                require(current >= eligible_at, f"{entry_id} current UTC is before 28 full days")
+                require(
+                    entry_date >= eligible_at.date(),
+                    f"{entry_id} sign-off date is backdated",
+                )
+                windows: set[int] = set()
+                for work_id in work_evidence:
+                    require(
+                        work_id in active["work"],
+                        f"{entry_id} names missing work entry {work_id}",
+                    )
+                    offset = active["work"][work_id]["when"] - active["freeze_utc"]
+                    if timedelta(0) <= offset < timedelta(days=28):
+                        windows.add(offset.days // 7)
+                require(
+                    windows == {0, 1, 2, 3},
+                    f"{entry_id} lacks normal-work evidence in all four windows",
+                )
+                unresolved = sorted(
+                    friction
+                    for friction, record in active["friction"].items()
+                    if record["triage"] == "fix-compatible" and not record["resolved"]
+                )
+                require(
+                    not unresolved,
+                    f"{entry_id} has unresolved friction: {', '.join(unresolved)}",
+                )
+                active = None
+                signed = True
+
+        seen[entry_id] = (entry, entry_date)
+
+    require(pending_break is None, f"{pending_break} breaking need lacks an immediate reset")
+    if signed:
+        return "signed-off"
+    if active is not None:
+        return f"attempt-{active['attempt']}-active"
+    if entries:
+        return "reset"
+    return "not-started"
+
+
+def check_append_only(previous: str | None, current: str) -> None:
+    if previous is None:
+        return
+    require(current.startswith(previous), "SOAK-1.0.md changed existing bytes instead of appending")

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -65,7 +65,7 @@ EXPECTED_POLICY = {
         "frozen_twin_precedent": "quantikz/quantikz2",
         "maintainer_identity": "github:lionsr",
         "signer_identity_scheme": "github:lowercase-login",
-        "reviewer_repository_permissions": ["push", "maintain", "admin"],
+        "reviewer_repository_permissions": ["write", "admin"],
         "tag_immutability": "github-ruleset-no-update-delete-or-bypass",
         "release_manifest_pattern": "docs/tenkz/releases/TAG.toml",
         "release_package_metadata": "tex/tenkz/tenkz.sty",
@@ -79,8 +79,13 @@ EXPECTED_POLICY = {
         "release_test_support_root": "tests/tenkz/release-support",
         "release_test_support_tree": "pending",
         "release_test_data_roots": ["tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"],
-        "release_enforcement_workflows": [".github/workflows/pr-ci.yml"],
-        "release_workflow_dependencies": "transitive-immutable-git-sha-or-content-digest",
+        "release_enforcement_workflows": [
+            ".github/workflows/tenkz-release-policy.yml"
+        ],
+        "release_workflow_dependencies": (
+            "transitive-content-addressed-no-runtime-downloads"
+        ),
+        "release_enforcement_network": "disabled-before-repository-code",
         "release_reset_replay_schema": (
             "tests/tenkz/release-support/reset-replay-v1.schema.json"
         ),
@@ -164,7 +169,7 @@ class ReviewEvidence:
     submitted_at: datetime | None
     commit_oid: str | None
     dismissed: bool | None = False
-    repository_permission: str | None = None
+    repository_top_level_permission: str | None = None
 
 
 @dataclass(frozen=True)
@@ -216,6 +221,13 @@ class RecordDiffEvidence:
     candidate_main_tip_descends_from_fix_integration: bool | None = None
     integration_parent_descends_from_fix_integration: bool | None = None
     validated_fix_integration: str | None = None
+    validated_prior_receipts: tuple[tuple[str, str], ...] | None = None
+    candidate_target_preserves_prior_receipts: bool | None = None
+    head_preserves_prior_receipts: bool | None = None
+    integration_preserves_prior_receipts: bool | None = None
+    entry_diff_untouched_prior_receipts: bool | None = None
+    receipt_blob_preserved_from_candidate_base_to_head: bool | None = None
+    receipt_blob_preserved_in_integration: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -290,6 +302,7 @@ class ReleaseContract:
     test_data_roots: tuple[str, ...]
     enforcement_workflows: tuple[str, ...]
     workflow_dependency_contract: str
+    enforcement_network_contract: str
     reset_replay_schema: str
     test_dependency_contract: str
     test_protocol: str
@@ -397,7 +410,9 @@ class RecordInvalidResetReplayEvidence:
     changes_exactly_one_new_regular_blob: bool | None
     receipt_path: str | None
     raw_blob_sha256: str | None
-    raw_blob_read_from_receipt_integration: bool | None
+    validated_current_tree_oid: str | None
+    raw_blob_read_from_current_validation_tree: bool | None
+    current_tree_blob_has_exact_path_mode_bytes_and_digest: bool | None
     schema_path: str | None
     schema_support_tree_oid: str | None
     schema_from_pinned_support_tree: bool | None
@@ -426,6 +441,11 @@ class WorkflowEvidence:
     external_dependencies_use_full_commit_shas: bool | None
     containers_use_content_digests: bool | None
     dependency_graph_complete_and_acyclic: bool | None
+    package_managers_absent: bool | None
+    downloaders_absent: bool | None
+    unhashed_runtime_dependencies_absent: bool | None
+    runtime_fetched_executables_absent: bool | None
+    network_disabled_before_repository_code: bool | None
     candidate_diff_untouched: bool | None
     github_checks_bind_exact_head_and_workflows: bool | None
     supervisor_receipt_complete_and_matching: bool | None
@@ -507,7 +527,7 @@ ResolveReplayFreezeTag = Callable[[str], TagEvidence]
 ResolveCurrentFinalTag = Callable[[str], TagEvidence]
 ResolveReplayIssue = Callable[[str], IssueEvidence]
 ResolveReplayRecordInvalidReset = Callable[
-    [str, str, str, str], RecordInvalidResetReplayEvidence
+    [str, str, str, str, str], RecordInvalidResetReplayEvidence
 ]
 ResolveCurrentWorkflow = Callable[[str, str, tuple[str, ...]], WorkflowEvidence]
 
@@ -793,7 +813,7 @@ def policy_rules(
     )
     reviewer_permissions = root.get("reviewer_repository_permissions")
     require(
-        reviewer_permissions == ["push", "maintain", "admin"],
+        reviewer_permissions == ["write", "admin"],
         "policy has the wrong reviewer permission set",
     )
     require(
@@ -815,6 +835,7 @@ def policy_rules(
         test_data_roots=tuple(root.get("release_test_data_roots", ())),
         enforcement_workflows=tuple(root.get("release_enforcement_workflows", ())),
         workflow_dependency_contract=str(root.get("release_workflow_dependencies", "")),
+        enforcement_network_contract=str(root.get("release_enforcement_network", "")),
         reset_replay_schema=str(root.get("release_reset_replay_schema", "")),
         test_dependency_contract=str(root.get("release_test_dependency_contract", "")),
         test_protocol=str(root.get("release_test_protocol", "")),
@@ -832,6 +853,7 @@ def policy_rules(
             contract.test_data_roots,
             contract.enforcement_workflows,
             contract.workflow_dependency_contract,
+            contract.enforcement_network_contract,
             contract.reset_replay_schema,
             contract.test_dependency_contract,
             contract.test_protocol,
@@ -846,8 +868,9 @@ def policy_rules(
             "scripts",
             "tests/tenkz/release-support",
             ("tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"),
-            (".github/workflows/pr-ci.yml",),
-            "transitive-immutable-git-sha-or-content-digest",
+            (".github/workflows/tenkz-release-policy.yml",),
+            "transitive-content-addressed-no-runtime-downloads",
+            "disabled-before-repository-code",
             "tests/tenkz/release-support/reset-replay-v1.schema.json",
             "pinned-code-support-declared-subject-data",
             "hermetic-repository-view-no-shell-or-network",
@@ -926,6 +949,7 @@ def validate_merged_pr(
     *,
     require_descendant: bool,
     require_tree: bool,
+    require_reachable: bool = True,
 ) -> tuple[datetime, str]:
     require(pr.merged is True, f"{pr_name} is not merged")
     merged_at = utc_instant(pr.merged_at, f"{pr_name} mergedAt")
@@ -934,10 +958,11 @@ def validate_merged_pr(
         isinstance(integration, str) and SHA_RE.fullmatch(integration) is not None,
         f"{pr_name} merge commit is invalid",
     )
-    require(
-        pr.integration_reachable_from_main is True,
-        f"{pr_name} integration is not reachable from main",
-    )
+    if require_reachable:
+        require(
+            pr.integration_reachable_from_main is True,
+            f"{pr_name} integration is not reachable from main",
+        )
     if require_tree:
         require(
             pr.integration_tree_matches_head is True,
@@ -1116,7 +1141,7 @@ def require_independent_approval(
         submitted = utc_instant(review.submitted_at, f"{pr_name} review submittedAt")
         if review.state != "APPROVED" or review.commit_oid != pr.head_oid:
             continue
-        if review.repository_permission not in authorized_permissions:
+        if review.repository_top_level_permission not in authorized_permissions:
             continue
         if after is not None and submitted <= after:
             continue
@@ -1287,6 +1312,23 @@ def validate_workflow_evidence(
     require(
         evidence.dependency_graph_complete_and_acyclic is True,
         "workflow dependency graph is incomplete or cyclic",
+    )
+    require(
+        evidence.package_managers_absent is True,
+        "release workflow invokes a package manager",
+    )
+    require(evidence.downloaders_absent is True, "release workflow invokes a downloader")
+    require(
+        evidence.unhashed_runtime_dependencies_absent is True,
+        "release workflow has an unhashed runtime dependency",
+    )
+    require(
+        evidence.runtime_fetched_executables_absent is True,
+        "release workflow fetches executable content at runtime",
+    )
+    require(
+        evidence.network_disabled_before_repository_code is True,
+        "release workflow does not disable network before repository code",
     )
     require(
         evidence.candidate_diff_untouched is True,
@@ -1801,6 +1843,47 @@ def validate_entries(
             if record_pending:
                 raise PolicyError(message)
             record_invalid_reasons.append(message)
+
+        prior_receipts = tuple(
+            (
+                "docs/tenkz/soak-replay/"
+                + pr_ref(
+                    prior_entry["replay_receipt_pr"],
+                    "replay_receipt_pr",
+                    prior_shape[0],
+                )[1:]
+                + ".json",
+                sha256(
+                    prior_entry["replay_receipt_sha256"],
+                    "replay_receipt_sha256",
+                    prior_shape[0],
+                ),
+            )
+            for prior_entry, prior_shape in zip(entries[: index - 1], shaped[: index - 1])
+            if prior_shape[1] == "reset" and prior_entry.get("cause") == "record-invalid"
+        )
+        if prior_receipts:
+            check_kind_record_fact(
+                diff.validated_prior_receipts == prior_receipts,
+                f"{entry_id} retention evidence used another prior-receipt set",
+            )
+            check_kind_record_fact(
+                diff.candidate_target_preserves_prior_receipts is True,
+                f"{entry_id} candidate target does not retain every prior receipt",
+            )
+            check_kind_record_fact(
+                diff.head_preserves_prior_receipts is True,
+                f"{entry_id} exact head does not retain every prior receipt",
+            )
+            check_kind_record_fact(
+                diff.entry_diff_untouched_prior_receipts is True,
+                f"{entry_id} diff changes a prior receipt path",
+            )
+            if not record_pending:
+                check_kind_record_fact(
+                    diff.integration_preserves_prior_receipts is True,
+                    f"{entry_id} integration does not retain every prior receipt",
+                )
 
         if kind == "freeze":
             check_kind_record_fact(
@@ -2339,6 +2422,7 @@ def validate_entries(
                         receipt_ref,
                         require_descendant=False,
                         require_tree=True,
+                        require_reachable=not historical_record_reset,
                     )
                     require(
                         normalized_login(receipt_pr.merged_by_login, f"{receipt_ref} mergedBy")
@@ -2368,6 +2452,7 @@ def validate_entries(
                         target,
                         receipt_ref,
                         receipt_digest,
+                        validation_target_oid,
                     )
                     require(
                         replay.validated_entry_id == entry_id,
@@ -2408,8 +2493,16 @@ def validate_entries(
                         f"{entry_id} reset receipt blob digest differs from the entry",
                     )
                     require(
-                        replay.raw_blob_read_from_receipt_integration is True,
-                        f"{entry_id} reset receipt was not read from its reachable integration",
+                        replay.validated_current_tree_oid == validation_target_oid,
+                        f"{entry_id} reset receipt was read from another validation tree",
+                    )
+                    require(
+                        replay.raw_blob_read_from_current_validation_tree is True,
+                        f"{entry_id} reset receipt was not read from the current validation tree",
+                    )
+                    require(
+                        replay.current_tree_blob_has_exact_path_mode_bytes_and_digest is True,
+                        f"{entry_id} current tree does not retain the exact receipt blob",
                     )
                     require(
                         replay.schema_path == release_contract.reset_replay_schema,
@@ -2495,10 +2588,18 @@ def validate_entries(
                         diff.candidate_main_tip_is_receipt_integration is True,
                         f"{entry_id} candidate base differs from receipt integration",
                     )
+                    check_kind_record_fact(
+                        diff.receipt_blob_preserved_from_candidate_base_to_head is True,
+                        f"{entry_id} reset head does not preserve its receipt blob",
+                    )
                     if not record_pending:
                         check_kind_record_fact(
                             diff.integration_parent_is_receipt_integration is True,
                             f"{entry_id} integration parent differs from receipt integration",
+                        )
+                        check_kind_record_fact(
+                            diff.receipt_blob_preserved_in_integration is True,
+                            f"{entry_id} reset integration does not preserve its receipt blob",
                         )
                     receipt_required = (
                         ("breaking-required", breaking_target)
@@ -2777,8 +2878,16 @@ def validate_entries(
         seen_attempts[entry_id] = attempt
         if entry_is_invalid():
             require(not record_pending, f"{entry_id} cannot be invalid before merge")
+            if kind == "reset" and entry.get("cause") == "record-invalid":
+                uncovered_target = nonempty_string(entry["target"], "target", entry_id)
+                if (
+                    uncovered_target not in drift_targets
+                    and uncovered_target not in deferred_invalid_targets
+                ):
+                    deferred_invalid_targets.append(uncovered_target)
             if entry_id not in deferred_invalid_targets:
                 deferred_invalid_targets.append(entry_id)
+            deferred_invalid_targets.sort(key=entry_positions.__getitem__)
 
     activate_current_record_queue()
     validate_current_controls()

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -2868,18 +2868,12 @@ def validate_entries(
         authorized_permissions=reviewer_permissions,
     )
 
-    final_tag_cache: TagEvidence | None = None
     publisher_secret_cache: PublisherSecretEvidence | None = None
 
-    def current_final_tag() -> TagEvidence:
-        nonlocal final_tag_cache
-        if final_tag_cache is None:
-            final_tag_cache = resolve_current_final_tag(FINAL_TAG)
-            require(
-                isinstance(final_tag_cache.exists, bool),
-                "final-tag existence is unavailable",
-            )
-        return final_tag_cache
+    def resolve_terminal_final_tag() -> TagEvidence:
+        final_tag = resolve_current_final_tag(FINAL_TAG)
+        require(isinstance(final_tag.exists, bool), "final-tag existence is unavailable")
+        return final_tag
 
     def current_publisher_secret() -> PublisherSecretEvidence:
         nonlocal publisher_secret_cache
@@ -2940,8 +2934,7 @@ def validate_entries(
             require_environment_configuration=False,
         )
 
-    def validate_absent_final_tag() -> None:
-        final_tag = current_final_tag()
+    def validate_absent_final_tag(final_tag: TagEvidence) -> None:
         require(final_tag.exists is False, "final tag exists before successful sign-off")
         require(
             final_tag.object_id is None
@@ -2978,11 +2971,6 @@ def validate_entries(
             "absent final-tag evidence is inconsistent",
         )
 
-    def finish_pending(state: str) -> str:
-        validate_pre_release_controls()
-        validate_absent_final_tag()
-        return state
-
     seen: dict[str, dict] = {}
     seen_attempts: dict[str, int] = {}
     active: dict | None = None
@@ -2992,9 +2980,10 @@ def validate_entries(
     last_reset_integration: str | None = None
     prior_patch = -1
     pending_reset: tuple[str, str] | None = None
+    pending_state: str | None = None
     deferred_invalid_targets: list[str] = []
     signed = False
-    successful_signoff: tuple[str, str, str, str, int] | None = None
+    successful_signoffs: list[tuple[str, str, str, str, int]] = []
     used_source_refs: set[str] = set()
     used_source_shas: set[str] = set()
     used_tag_names: set[str] = set()
@@ -3312,7 +3301,8 @@ def validate_entries(
             )
 
             if record_pending:
-                return finish_pending("freeze-pending")
+                pending_state = "freeze-pending"
+                break
             if not entry_is_invalid():
                 assert record_merged_at is not None and record_integration is not None
 
@@ -3501,7 +3491,8 @@ def validate_entries(
 
             work_result = check_external(work_external_facts)
             if record_pending:
-                return finish_pending("work-pending")
+                pending_state = "work-pending"
+                break
             if not entry_is_invalid():
                 assert isinstance(work_result, tuple)
                 work_merged_at, work_integration = work_result
@@ -3608,7 +3599,8 @@ def validate_entries(
 
             friction_result = check_external(friction_observation_facts)
             if record_pending:
-                return finish_pending("friction-pending")
+                pending_state = "friction-pending"
+                break
             if not entry_is_invalid():
                 assert record_merged_at is not None and record_integration is not None
                 active["friction"][entry_id] = {
@@ -3937,7 +3929,8 @@ def validate_entries(
                         f"{entry_id} resolution record did not merge after its fix PR",
                     )
             if record_pending:
-                return finish_pending("resolution-pending")
+                pending_state = "resolution-pending"
+                break
             if not entry_is_invalid():
                 assert record_integration is not None
                 assert record_merged_at is not None
@@ -4175,7 +4168,8 @@ def validate_entries(
             nonempty_string(entry["reason"], "reason", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
             if record_pending:
-                return finish_pending("reset-pending")
+                pending_state = "reset-pending"
+                break
             if not entry_is_invalid():
                 if cause == "record-invalid":
                     if drift_targets and target == drift_targets[0]:
@@ -4190,7 +4184,8 @@ def validate_entries(
             nonempty_string(entry["summary"], "summary", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
             if record_pending:
-                return finish_pending("correction-pending")
+                pending_state = "correction-pending"
+                break
 
         elif kind == "sign-off":
             assert active is not None
@@ -4418,7 +4413,8 @@ def validate_entries(
                 )
             require(pending_reset is None, f"{entry_id} cannot sign off before reset")
             if record_pending:
-                return finish_pending("sign-off-pending")
+                pending_state = "sign-off-pending"
+                break
             if not entry_is_invalid():
                 def signoff_postmerge_facts() -> None:
                     assert (
@@ -4464,12 +4460,14 @@ def validate_entries(
                     )
                     active = None
                     signed = True
-                    successful_signoff = (
-                        entry_id,
-                        record_ref,
-                        record_integration,
-                        release_tag,
-                        tagger_epoch_seconds,
+                    successful_signoffs.append(
+                        (
+                            entry_id,
+                            record_ref,
+                            record_integration,
+                            release_tag,
+                            tagger_epoch_seconds,
+                        )
                     )
 
         if record_integration is not None and not entry_is_invalid():
@@ -4491,14 +4489,16 @@ def validate_entries(
                 deferred_invalid_targets.append(entry_id)
             deferred_invalid_targets.sort(key=entry_positions.__getitem__)
 
-    activate_current_record_queue()
-    final_tag = current_final_tag()
-    terminal_tag_present = final_tag.exists is True
-    publisher_status: str | None = None
-    publisher_evidence: FinalTagPublisherEvidence | None = None
-    if terminal_tag_present and pending_reset is not None:
-        raise PolicyError("final tag exists while release evidence requires reset")
-    if successful_signoff is not None:
+    if pending_state is None:
+        activate_current_record_queue()
+    publisher_history: list[
+        tuple[
+            tuple[str, str, str, str, int],
+            FinalTagPublisherEvidence,
+            str,
+        ]
+    ] = []
+    for successful_signoff in successful_signoffs:
         assert resolve_final_tag_publisher is not None
         (
             signoff_entry_id,
@@ -4522,21 +4522,31 @@ def validate_entries(
             current_prefix_boundary=current_prefix_boundary,
             support_tree_oid=release_contract.test_support_tree,
         )
-    if publisher_status == "success" and pending_reset is not None:
-        raise PolicyError("final-tag publisher succeeded while release evidence requires reset")
-    if publisher_status == "success" and not terminal_tag_present:
+        publisher_history.append(
+            (successful_signoff, publisher_evidence, publisher_status)
+        )
+
+    # Resolve the current ref only after every historical publisher status.
+    # Thus an absent snapshot combined with publisher success is necessarily a
+    # post-success observation, never a pre-publication race.
+    final_tag = resolve_terminal_final_tag()
+    terminal_tag_present = final_tag.exists is True
+    any_publisher_succeeded = any(
+        publisher_status == "success"
+        for _signoff, _evidence, publisher_status in publisher_history
+    )
+    if any_publisher_succeeded and not terminal_tag_present:
         raise PolicyError(
             "final-tag publisher succeeded but the final ref is absent; "
             "hard release incident"
         )
+    if terminal_tag_present and pending_reset is not None:
+        raise PolicyError("final tag exists while release evidence requires reset")
     if terminal_tag_present and not signed:
         raise PolicyError("final tag exists without a successfully validated sign-off")
-    if pending_reset is not None:
-        validate_pre_release_controls()
-        validate_absent_final_tag()
-        return f"reset-required:{pending_reset[1]}"
-    if signed:
-        assert successful_signoff is not None
+    for successful_signoff, publisher_evidence, publisher_status in publisher_history:
+        if publisher_status != "success":
+            continue
         (
             signoff_entry,
             _signoff_record,
@@ -4545,15 +4555,6 @@ def validate_entries(
             tagger_epoch_seconds,
         ) = successful_signoff
         require(signoff_tag == FINAL_TAG, "released sign-off names another tag")
-        require(
-            publisher_status in {"not-run", "incomplete", "failure", "success"},
-            "final-tag publisher evidence is unavailable after sign-off",
-        )
-        assert publisher_evidence is not None
-        if not terminal_tag_present:
-            validate_pre_release_controls()
-            validate_absent_final_tag()
-            return "signed-off-awaiting-tag"
         validate_authenticated_final_tag(
             final_tag,
             integration_oid=signoff_integration,
@@ -4563,7 +4564,47 @@ def validate_entries(
             publisher=publisher_evidence,
             contract=release_contract,
         )
+    if pending_state is not None:
+        validate_pre_release_controls()
+        validate_absent_final_tag(final_tag)
+        return pending_state
+    if pending_reset is not None:
+        validate_pre_release_controls()
+        validate_absent_final_tag(final_tag)
+        return f"reset-required:{pending_reset[1]}"
+    if signed:
+        assert publisher_history
+        (
+            (
+                signoff_entry,
+                _signoff_record,
+                signoff_integration,
+                signoff_tag,
+                tagger_epoch_seconds,
+            ),
+            publisher_evidence,
+            publisher_status,
+        ) = publisher_history[-1]
+        require(signoff_tag == FINAL_TAG, "released sign-off names another tag")
+        require(
+            publisher_status in {"not-run", "incomplete", "failure", "success"},
+            "final-tag publisher evidence is unavailable after sign-off",
+        )
+        assert publisher_evidence is not None
+        if not terminal_tag_present:
+            validate_pre_release_controls()
+            validate_absent_final_tag(final_tag)
+            return "signed-off-awaiting-tag"
         if publisher_status != "success":
+            validate_authenticated_final_tag(
+                final_tag,
+                integration_oid=signoff_integration,
+                tagger_epoch_seconds=tagger_epoch_seconds,
+                policy_sha256=soak_root["policy_sha256"],
+                prefix_boundary=signoff_entry,
+                publisher=publisher_evidence,
+                contract=release_contract,
+            )
             validate_pre_release_controls()
             return "signed-off-awaiting-publisher-success"
         publisher_secret = current_publisher_secret()
@@ -4577,7 +4618,7 @@ def validate_entries(
         validate_release_transition_controls()
         return "released"
     validate_pre_release_controls()
-    validate_absent_final_tag()
+    validate_absent_final_tag(final_tag)
     if active is not None:
         return f"attempt-{active['attempt']}-active"
     if last_attempt == 0:

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import re
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Callable, Collection
 
@@ -576,6 +576,29 @@ class FinalTagPublisherEvidence:
     successful_job_historical_workflow_tree_matches_activation: bool | None
     successful_job_follows_successful_postmerge_validation: bool | None
     successful_job_conclusion_api_visible: bool | None
+
+
+@dataclass(frozen=True)
+class ReleaseSignoff:
+    """One validated sign-off and the immutable tuple owned by its publisher."""
+
+    entry_id: str
+    integration_oid: str
+    release_tag: str
+    tagger_epoch_seconds: int
+
+
+@dataclass(frozen=True)
+class ReleaseAttempt:
+    """One release epoch with attempt-local publisher and final-ref evidence."""
+
+    epoch_entry_id: str
+    signoff: ReleaseSignoff | None = None
+    pending_state: str | None = None
+    predecessor_signoff: ReleaseSignoff | None = None
+    publisher_evidence: FinalTagPublisherEvidence | None = None
+    publisher_status: str | None = None
+    final_ref_observation: TagEvidence | None = None
 
 
 @dataclass(frozen=True)
@@ -2980,17 +3003,16 @@ def validate_entries(
     last_reset_integration: str | None = None
     prior_patch = -1
     pending_reset: tuple[str, str] | None = None
-    pending_state: str | None = None
     deferred_invalid_targets: list[str] = []
-    signed = False
-    successful_signoffs: list[tuple[str, str, str, str, int]] = []
+    release_attempts: list[ReleaseAttempt] = []
+    current_release_attempt: ReleaseAttempt | None = None
     used_source_refs: set[str] = set()
     used_source_shas: set[str] = set()
     used_tag_names: set[str] = set()
     used_tag_objects: set[str] = set()
 
     def activate_current_record_queue() -> None:
-        nonlocal pending_reset, signed
+        nonlocal pending_reset, current_release_attempt
         if pending_reset is not None:
             return
         if drift_targets:
@@ -2998,20 +3020,39 @@ def validate_entries(
         elif deferred_invalid_targets:
             pending_reset = ("record-invalid", deferred_invalid_targets[0])
         if pending_reset is not None:
-            signed = False
+            current_release_attempt = None
+
+    def open_pending_release_attempt(*, entry_id: str, state: str) -> None:
+        """Open the current candidate epoch without mutating prior release evidence."""
+
+        nonlocal current_release_attempt
+        predecessor_signoff = (
+            current_release_attempt.signoff
+            if current_release_attempt is not None
+            else None
+        )
+        current_release_attempt = ReleaseAttempt(
+            epoch_entry_id=entry_id,
+            pending_state=state,
+            predecessor_signoff=predecessor_signoff,
+        )
+        release_attempts.append(current_release_attempt)
 
     for index, (entry, shape) in enumerate(zip(entries, shaped), start=1):
         entry_id, kind, attempt, record_ref = shape
         if index > drift_boundary:
             activate_current_record_queue()
-        if signed:
+        if (
+            current_release_attempt is not None
+            and current_release_attempt.signoff is not None
+        ):
             require(
                 kind == "correction"
                 or (kind == "reset" and entry.get("cause") == "record-invalid"),
                 f"{entry_id} appears after final sign-off",
             )
             if kind == "reset":
-                signed = False
+                current_release_attempt = None
         if pending_reset is not None and kind != "correction":
             require(kind == "reset", f"{pending_reset[1]} must be followed by its reset")
 
@@ -3301,7 +3342,10 @@ def validate_entries(
             )
 
             if record_pending:
-                pending_state = "freeze-pending"
+                open_pending_release_attempt(
+                    entry_id=entry_id,
+                    state="freeze-pending",
+                )
                 break
             if not entry_is_invalid():
                 assert record_merged_at is not None and record_integration is not None
@@ -3491,7 +3535,10 @@ def validate_entries(
 
             work_result = check_external(work_external_facts)
             if record_pending:
-                pending_state = "work-pending"
+                open_pending_release_attempt(
+                    entry_id=entry_id,
+                    state="work-pending",
+                )
                 break
             if not entry_is_invalid():
                 assert isinstance(work_result, tuple)
@@ -3599,7 +3646,10 @@ def validate_entries(
 
             friction_result = check_external(friction_observation_facts)
             if record_pending:
-                pending_state = "friction-pending"
+                open_pending_release_attempt(
+                    entry_id=entry_id,
+                    state="friction-pending",
+                )
                 break
             if not entry_is_invalid():
                 assert record_merged_at is not None and record_integration is not None
@@ -3929,7 +3979,10 @@ def validate_entries(
                         f"{entry_id} resolution record did not merge after its fix PR",
                     )
             if record_pending:
-                pending_state = "resolution-pending"
+                open_pending_release_attempt(
+                    entry_id=entry_id,
+                    state="resolution-pending",
+                )
                 break
             if not entry_is_invalid():
                 assert record_integration is not None
@@ -4168,7 +4221,10 @@ def validate_entries(
             nonempty_string(entry["reason"], "reason", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
             if record_pending:
-                pending_state = "reset-pending"
+                open_pending_release_attempt(
+                    entry_id=entry_id,
+                    state="reset-pending",
+                )
                 break
             if not entry_is_invalid():
                 if cause == "record-invalid":
@@ -4184,7 +4240,10 @@ def validate_entries(
             nonempty_string(entry["summary"], "summary", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
             if record_pending:
-                pending_state = "correction-pending"
+                open_pending_release_attempt(
+                    entry_id=entry_id,
+                    state="correction-pending",
+                )
                 break
 
         elif kind == "sign-off":
@@ -4413,7 +4472,10 @@ def validate_entries(
                 )
             require(pending_reset is None, f"{entry_id} cannot sign off before reset")
             if record_pending:
-                pending_state = "sign-off-pending"
+                open_pending_release_attempt(
+                    entry_id=entry_id,
+                    state="sign-off-pending",
+                )
                 break
             if not entry_is_invalid():
                 def signoff_postmerge_facts() -> None:
@@ -4459,16 +4521,17 @@ def validate_entries(
                         and tagger_epoch_seconds is not None
                     )
                     active = None
-                    signed = True
-                    successful_signoffs.append(
-                        (
-                            entry_id,
-                            record_ref,
-                            record_integration,
-                            release_tag,
-                            tagger_epoch_seconds,
-                        )
+                    signoff = ReleaseSignoff(
+                        entry_id=entry_id,
+                        integration_oid=record_integration,
+                        release_tag=release_tag,
+                        tagger_epoch_seconds=tagger_epoch_seconds,
                     )
+                    current_release_attempt = ReleaseAttempt(
+                        epoch_entry_id=entry_id,
+                        signoff=signoff,
+                    )
+                    release_attempts.append(current_release_attempt)
 
         if record_integration is not None and not entry_is_invalid():
             last_record_integration = record_integration
@@ -4489,25 +4552,25 @@ def validate_entries(
                 deferred_invalid_targets.append(entry_id)
             deferred_invalid_targets.sort(key=entry_positions.__getitem__)
 
-    if pending_state is None:
+    if (
+        current_release_attempt is None
+        or current_release_attempt.pending_state is None
+    ):
         activate_current_record_queue()
-    publisher_history: list[
-        tuple[
-            tuple[str, str, str, str, int],
-            FinalTagPublisherEvidence,
-            str,
-        ]
-    ] = []
-    for successful_signoff in successful_signoffs:
+
+    current_epoch_entry_id = (
+        current_release_attempt.epoch_entry_id
+        if current_release_attempt is not None
+        else None
+    )
+    audited_release_attempts: list[ReleaseAttempt] = []
+    for release_attempt in release_attempts:
+        signoff = release_attempt.signoff
+        if signoff is None:
+            audited_release_attempts.append(release_attempt)
+            continue
         assert resolve_final_tag_publisher is not None
-        (
-            signoff_entry_id,
-            _signoff_record_ref,
-            successful_signoff_integration,
-            _observed_release_tag,
-            successful_tagger_epoch_seconds,
-        ) = successful_signoff
-        publisher_evidence = resolve_final_tag_publisher(successful_signoff_integration)
+        publisher_evidence = resolve_final_tag_publisher(signoff.integration_oid)
         current_prefix_boundary = audit.boundary_entry_id
         require(
             isinstance(current_prefix_boundary, str),
@@ -4515,77 +4578,138 @@ def validate_entries(
         )
         publisher_status = validate_final_tag_publisher(
             publisher_evidence,
-            integration_oid=successful_signoff_integration,
-            tagger_epoch_seconds=successful_tagger_epoch_seconds,
+            integration_oid=signoff.integration_oid,
+            tagger_epoch_seconds=signoff.tagger_epoch_seconds,
             policy_sha256=soak_root["policy_sha256"],
-            prefix_boundary=signoff_entry_id,
+            prefix_boundary=signoff.entry_id,
             current_prefix_boundary=current_prefix_boundary,
             support_tree_oid=release_contract.test_support_tree,
         )
-        publisher_history.append(
-            (successful_signoff, publisher_evidence, publisher_status)
+        audited_release_attempts.append(
+            replace(
+                release_attempt,
+                publisher_evidence=publisher_evidence,
+                publisher_status=publisher_status,
+            )
         )
 
-    # Resolve the current ref only after every historical publisher status.
+    # Resolve the current ref only after every attempt-local publisher status.
     # Thus an absent snapshot combined with publisher success is necessarily a
     # post-success observation, never a pre-publication race.
     final_tag = resolve_terminal_final_tag()
     terminal_tag_present = final_tag.exists is True
-    any_publisher_succeeded = any(
-        publisher_status == "success"
-        for _signoff, _evidence, publisher_status in publisher_history
-    )
-    if any_publisher_succeeded and not terminal_tag_present:
-        raise PolicyError(
-            "final-tag publisher succeeded but the final ref is absent; "
-            "hard release incident"
-        )
+    for release_attempt in audited_release_attempts:
+        if release_attempt.publisher_status == "success" and not terminal_tag_present:
+            assert release_attempt.signoff is not None
+            raise PolicyError(
+                "final-tag publisher succeeded but the final ref is absent; "
+                "hard release incident for "
+                f"{release_attempt.signoff.entry_id} at "
+                f"{release_attempt.signoff.integration_oid}"
+            )
     if terminal_tag_present and pending_reset is not None:
         raise PolicyError("final tag exists while release evidence requires reset")
-    if terminal_tag_present and not signed:
-        raise PolicyError("final tag exists without a successfully validated sign-off")
-    for successful_signoff, publisher_evidence, publisher_status in publisher_history:
-        if publisher_status != "success":
-            continue
+
+    current_attempt = next(
         (
-            signoff_entry,
-            _signoff_record,
-            signoff_integration,
-            signoff_tag,
-            tagger_epoch_seconds,
-        ) = successful_signoff
-        require(signoff_tag == FINAL_TAG, "released sign-off names another tag")
-        validate_authenticated_final_tag(
-            final_tag,
-            integration_oid=signoff_integration,
-            tagger_epoch_seconds=tagger_epoch_seconds,
-            policy_sha256=soak_root["policy_sha256"],
-            prefix_boundary=signoff_entry,
-            publisher=publisher_evidence,
-            contract=release_contract,
+            release_attempt
+            for release_attempt in audited_release_attempts
+            if release_attempt.epoch_entry_id == current_epoch_entry_id
+        ),
+        None,
+    )
+    current_ref_signoff = (
+        current_attempt.signoff
+        if current_attempt is not None and current_attempt.signoff is not None
+        else (
+            current_attempt.predecessor_signoff
+            if current_attempt is not None
+            and current_attempt.pending_state == "correction-pending"
+            else None
         )
-    if pending_state is not None:
+    )
+    claimed_signoff_entries = {
+        release_attempt.signoff.entry_id
+        for release_attempt in audited_release_attempts
+        if release_attempt.signoff is not None
+        and release_attempt.publisher_status == "success"
+    }
+    # Ref authentication is independent of whether publication has reported success.
+    if terminal_tag_present and current_ref_signoff is not None:
+        claimed_signoff_entries.add(current_ref_signoff.entry_id)
+    if terminal_tag_present and not claimed_signoff_entries:
+        raise PolicyError(
+            "final tag exists without a successfully validated sign-off claim"
+        )
+
+    if terminal_tag_present:
+        authenticated_attempts: list[ReleaseAttempt] = []
+        for release_attempt in audited_release_attempts:
+            signoff = release_attempt.signoff
+            if signoff is None or signoff.entry_id not in claimed_signoff_entries:
+                authenticated_attempts.append(release_attempt)
+                continue
+            publisher_evidence = release_attempt.publisher_evidence
+            assert publisher_evidence is not None
+            require(
+                signoff.release_tag == FINAL_TAG,
+                "released sign-off names another tag",
+            )
+            validate_authenticated_final_tag(
+                final_tag,
+                integration_oid=signoff.integration_oid,
+                tagger_epoch_seconds=signoff.tagger_epoch_seconds,
+                policy_sha256=soak_root["policy_sha256"],
+                prefix_boundary=signoff.entry_id,
+                publisher=publisher_evidence,
+                contract=release_contract,
+            )
+            authenticated_attempts.append(
+                replace(release_attempt, final_ref_observation=final_tag)
+            )
+        audited_release_attempts = authenticated_attempts
+        current_attempt = next(
+            (
+                release_attempt
+                for release_attempt in audited_release_attempts
+                if release_attempt.epoch_entry_id == current_epoch_entry_id
+            ),
+            None,
+        )
+
+    if terminal_tag_present and current_ref_signoff is None:
+        raise PolicyError(
+            "final tag exists without a successfully validated sign-off "
+            "for the current release attempt"
+        )
+
+    if current_attempt is not None and current_attempt.pending_state is not None:
+        prior_release_exists = any(
+            release_attempt.publisher_evidence is not None
+            and (
+                release_attempt.publisher_evidence
+                .prior_released_validation_exact_and_successful
+                is True
+            )
+            for release_attempt in audited_release_attempts
+        )
+        require(
+            not prior_release_exists,
+            f"{current_attempt.epoch_entry_id} appears after a prior released validation",
+        )
         validate_pre_release_controls()
-        validate_absent_final_tag(final_tag)
-        return pending_state
+        if not terminal_tag_present:
+            validate_absent_final_tag(final_tag)
+        return current_attempt.pending_state
     if pending_reset is not None:
         validate_pre_release_controls()
         validate_absent_final_tag(final_tag)
         return f"reset-required:{pending_reset[1]}"
-    if signed:
-        assert publisher_history
-        (
-            (
-                signoff_entry,
-                _signoff_record,
-                signoff_integration,
-                signoff_tag,
-                tagger_epoch_seconds,
-            ),
-            publisher_evidence,
-            publisher_status,
-        ) = publisher_history[-1]
-        require(signoff_tag == FINAL_TAG, "released sign-off names another tag")
+    if current_attempt is not None and current_attempt.signoff is not None:
+        signoff = current_attempt.signoff
+        publisher_evidence = current_attempt.publisher_evidence
+        publisher_status = current_attempt.publisher_status
+        require(signoff.release_tag == FINAL_TAG, "released sign-off names another tag")
         require(
             publisher_status in {"not-run", "incomplete", "failure", "success"},
             "final-tag publisher evidence is unavailable after sign-off",
@@ -4596,15 +4720,7 @@ def validate_entries(
             validate_absent_final_tag(final_tag)
             return "signed-off-awaiting-tag"
         if publisher_status != "success":
-            validate_authenticated_final_tag(
-                final_tag,
-                integration_oid=signoff_integration,
-                tagger_epoch_seconds=tagger_epoch_seconds,
-                policy_sha256=soak_root["policy_sha256"],
-                prefix_boundary=signoff_entry,
-                publisher=publisher_evidence,
-                contract=release_contract,
-            )
+            assert current_attempt.final_ref_observation is not None
             validate_pre_release_controls()
             return "signed-off-awaiting-publisher-success"
         publisher_secret = current_publisher_secret()

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -4524,6 +4524,11 @@ def validate_entries(
         )
     if publisher_status == "success" and pending_reset is not None:
         raise PolicyError("final-tag publisher succeeded while release evidence requires reset")
+    if publisher_status == "success" and not terminal_tag_present:
+        raise PolicyError(
+            "final-tag publisher succeeded but the final ref is absent; "
+            "hard release incident"
+        )
     if terminal_tag_present and not signed:
         raise PolicyError("final tag exists without a successfully validated sign-off")
     if pending_reset is not None:
@@ -4546,11 +4551,6 @@ def validate_entries(
         )
         assert publisher_evidence is not None
         if not terminal_tag_present:
-            if publisher_status == "success":
-                raise PolicyError(
-                    "final-tag publisher succeeded but the final ref is absent; "
-                    "hard release incident"
-                )
             validate_pre_release_controls()
             validate_absent_final_tag()
             return "signed-off-awaiting-tag"

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -37,9 +37,9 @@ ENTRY_KINDS = {
     "sign-off",
 }
 WORK_CLASSES = ("formalization-or-blueprint", "rmp-benchmark")
-TRIAGE = {"fix-compatible", "defer-to-2.0", "breaking-required"}
+TRIAGE = {"fix-compatible", "defer-to-2.0", "restart-required"}
 SURFACES = {"tex-api", "tnlog"}
-RESET_CAUSES = {"breaking-required", "record-invalid"}
+RESET_CAUSES = {"restart-required", "record-invalid"}
 
 EXPECTED_POLICY = {
     "policy": {
@@ -54,8 +54,12 @@ EXPECTED_POLICY = {
         "work_classes": list(WORK_CLASSES),
         "one_class_per_work_pr": True,
         "work_excluded_paths": ["TNLean/Archive/**"],
-        "tex_api_fix_paths": ["tex/tenkz/**/*.tex", "tex/tenkz/**/*.sty"],
-        "tnlog_fix_paths": ["tex/tenkz/**/*.tex", "tex/tenkz/**/*.sty"],
+        "tex_api_fix_paths": ["tex/tenkz/*.tex", "tex/tenkz/*.sty"],
+        "tnlog_fix_paths": [
+            "tex/tenkz/*.tex",
+            "tex/tenkz/*.sty",
+            "scripts/tenkzlib/tnlog.py",
+        ],
         "event_format_owners": ["#4162", "#4703"],
         "soak_blocker_chain": [
             ["#5086", "#4699", "#4162"],
@@ -77,11 +81,16 @@ EXPECTED_POLICY = {
         "release_event_format": "docs/tenkz/TNLOG.md",
         "release_test_inventory": "tests/tenkz/release-tests.toml",
         "release_test_inventory_sha256": "pending",
-        "release_test_code_root": "scripts",
+        "release_test_code_root": "tests/tenkz/release-harness",
         "release_test_code_tree": "pending",
         "release_test_support_root": "tests/tenkz/release-support",
         "release_test_support_tree": "pending",
-        "release_test_data_roots": ["tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"],
+        "release_test_subject_roots": [
+            "tex/tenkz",
+            "scripts/tenkzlib/tnlog.py",
+            "docs/tenkz",
+            "tests/tenkz/rmp",
+        ],
         "release_enforcement_workflows": [
             ".github/workflows/tenkz-release-policy.yml"
         ],
@@ -92,7 +101,9 @@ EXPECTED_POLICY = {
         "release_reset_replay_schema": (
             "tests/tenkz/release-support/reset-replay-v1.schema.json"
         ),
-        "release_test_dependency_contract": "pinned-code-support-declared-subject-data",
+        "release_test_dependency_contract": (
+            "pinned-harness-support-declared-subject-roles"
+        ),
         "release_test_protocol": "hermetic-repository-view-no-shell-or-network",
     },
     "event_format": {
@@ -262,6 +273,21 @@ class WorkDiffEvidence:
 
 
 @dataclass(frozen=True)
+class RegressionFixEvidence:
+    """One test-specific semantic program witness in a compatible fix diff."""
+
+    test_ref: str | None
+    validated_surface: str | None
+    declared_program_paths: tuple[str, ...] | None
+    changed_program_path: str | None
+    program_blob_modified: bool | None
+    semantic_stream_kind: str | None
+    semantic_stream_changed: bool | None
+    python_reader_parses: bool | None
+    baseline_failure_fingerprint: str | None
+
+
+@dataclass(frozen=True)
 class ResolutionDiffEvidence:
     """Complete exact-head evidence for one compatible fix pull request."""
 
@@ -279,12 +305,11 @@ class ResolutionDiffEvidence:
     integration_strict_descendant_of_friction: bool | None
     policy_paths_untouched: bool | None
     validated_base_oid: str | None
-    validated_surface: str | None
-    validated_fix_path_patterns: tuple[str, ...] | None
-    semantic_witness_path: str | None
-    surface_matching_added_or_modified_regular_blob: bool | None
-    tex_comment_stripped_token_stream_changed: bool | None
-    semantic_witness_is_same_surface_regular_blob: bool | None
+    validated_regression_tests: tuple[str, ...] | None
+    regression_fixes: tuple[RegressionFixEvidence, ...] | None
+    validated_identity_trees: tuple[str, str, str, str, str] | None
+    fixture_blobs_modes_and_trees_identical: bool | None
+    freeze_manifest_blob_identical: bool | None
 
 
 @dataclass(frozen=True)
@@ -302,7 +327,7 @@ class ReleaseContract:
     test_code_tree: str
     test_support_root: str
     test_support_tree: str
-    test_data_roots: tuple[str, ...]
+    test_subject_roots: tuple[str, ...]
     tex_api_fix_paths: tuple[str, ...]
     tnlog_fix_paths: tuple[str, ...]
     enforcement_workflows: tuple[str, ...]
@@ -344,19 +369,25 @@ class ReleasePayloadEvidence:
     manifest_contract_valid: bool | None
     artifact_declarations_agree: bool | None
     inventory_digest_matches: bool | None
-    inventory_contract_valid: bool | None
+    inventory_exact_schema_valid: bool | None
+    inventory_ids_and_failure_fingerprints_unique: bool | None
+    inventory_test_surface_valid: bool | None
+    inventory_atomic_assertions_one_per_test: bool | None
     test_code_tree_matches: bool | None
     test_support_tree_matches: bool | None
-    inventory_data_paths_within_mutable_roots: bool | None
-    executable_dependencies_within_code_tree: bool | None
+    inventory_subject_paths_within_subject_roots: bool | None
+    inventory_program_paths_regular_and_surface_owned: bool | None
+    inventory_fixture_paths_regular_or_trees: bool | None
+    inventory_subject_roles_disjoint: bool | None
+    inventory_fixtures_nonexecutable: bool | None
+    executable_dependencies_within_harness_tree: bool | None
     acceptance_dependencies_within_support_tree: bool | None
-    subject_data_cannot_reduce_coverage: bool | None
+    subjects_cannot_supply_evidence_logic: bool | None
     hermetic_execution_contract_valid: bool | None
     payload_execution_receipts_complete_and_matching: bool | None
     test_execution_complete: bool | None
     compatibility_tests_passed: bool | None
     payload_blob_oids: tuple[str, ...] | None
-    inventory_test_surfaces_valid: bool | None
 
 
 @dataclass(frozen=True)
@@ -373,19 +404,29 @@ class ReleaseTestObservationEvidence:
     manifest_contract_valid: bool | None
     artifact_declarations_agree: bool | None
     inventory_digest_matches: bool | None
-    inventory_contract_valid: bool | None
-    inventory_test_surfaces_valid: bool | None
+    inventory_exact_schema_valid: bool | None
+    inventory_ids_and_failure_fingerprints_unique: bool | None
+    inventory_test_surface_valid: bool | None
+    inventory_atomic_assertions_one_per_test: bool | None
     inventory_test_exists: bool | None
     inventory_command_exact_and_matching: bool | None
     test_code_tree_matches: bool | None
     test_support_tree_matches: bool | None
-    inventory_data_paths_within_mutable_roots: bool | None
-    executable_dependencies_within_code_tree: bool | None
+    inventory_subject_paths_within_subject_roots: bool | None
+    executable_dependencies_within_harness_tree: bool | None
     acceptance_dependencies_within_support_tree: bool | None
-    subject_data_cannot_reduce_coverage: bool | None
+    subjects_cannot_supply_evidence_logic: bool | None
     hermetic_execution_contract_valid: bool | None
     tool_fingerprints_match: bool | None
-    inventory_test_surfaces: tuple[str, ...] | None
+    inventory_test_surface: str | None
+    inventory_test_failure_fingerprint: str | None
+    inventory_test_program_paths: tuple[str, ...] | None
+    inventory_test_fixture_paths: tuple[str, ...] | None
+    inventory_test_program_paths_regular_blobs: bool | None
+    inventory_test_fixture_paths_regular_blobs_or_trees: bool | None
+    inventory_test_fixture_trees_exclude_program_paths: bool | None
+    inventory_test_fixtures_nonexecutable: bool | None
+    atomic_assertion_count: int | None
     exactly_one_inventory_test_run: bool | None
     setup_complete_and_matching: bool | None
     isolation_valid: bool | None
@@ -393,8 +434,13 @@ class ReleaseTestObservationEvidence:
     execution_complete: bool | None
     timed_out: bool | None
     terminated_by_signal: bool | None
-    clean_process_exit: bool | None
+    result: str | None
     exit_code: int | None
+    assertion_failure_receipt_path: str | None
+    observed_failure_fingerprint: str | None
+    assertion_failure_receipt_exact_and_matching: bool | None
+    assertion_failure_receipt_atomically_written: bool | None
+    single_failure_cause: bool | None
 
 
 @dataclass(frozen=True)
@@ -406,12 +452,14 @@ class ReleasePrepEvidence:
     validated_manifest_path: str | None
     validated_changed_paths: tuple[str, ...] | None
     validated_work_integrations: tuple[str, ...] | None
+    validated_resolution_integrations: tuple[str, ...] | None
     complete: bool | None
     integration_parent_count: int | None
     unique_merge_base: bool | None
     integration_parent_is_ancestor_of_head: bool | None
     integration_second_parent_matches_head: bool | None
     integration_descends_from_work_integrations: bool | None
+    integration_descends_from_resolution_integrations: bool | None
     exact_release_varying_path_diff: bool | None
 
 
@@ -420,9 +468,10 @@ class TagEvidence:
     object_id: str | None
     object_type: str | None
     commit: str | None
-    patch_is_fresh_for_attempt: bool | None = None
-    namespace_complete: bool | None = None
-    patch_exceeds_other_namespace_tags: bool | None = None
+    candidate_namespace_complete: bool | None = None
+    candidate_patch_exceeds_current_namespace: bool | None = None
+    historical_candidate_check_exact_and_successful: bool | None = None
+    historical_compares_only_earlier_freezes: bool | None = None
     exists: bool | None = True
     validated_entry_id: str | None = None
     validated_record_pr: str | None = None
@@ -470,7 +519,7 @@ class RecordInvalidResetReplayEvidence:
     boundary_entry_id: str | None
     validation_target_oid: str | None
     raw_invalid_entries: tuple[str, ...] | None
-    pending_breaking_target: str | None
+    pending_restart_target: str | None
     normalized_resolver_inputs_complete_and_matching: bool | None
     workflow_dependency_closure_pinned: bool | None
     supervisor_receipts_complete_and_matching: bool | None
@@ -512,18 +561,25 @@ class ActivationDiffEvidence:
     unique_merge_base: bool | None
     exact_seven_scalar_replacements: bool | None
     inventory_digest_matches: bool | None
+    inventory_exact_schema_valid: bool | None
+    inventory_ids_and_failure_fingerprints_unique: bool | None
+    inventory_test_surface_valid: bool | None
+    inventory_atomic_assertions_one_per_test: bool | None
     test_code_tree_matches: bool | None
     test_support_tree_matches: bool | None
-    inventory_data_paths_within_mutable_roots: bool | None
-    executable_dependencies_within_code_tree: bool | None
+    inventory_subject_paths_within_subject_roots: bool | None
+    inventory_program_paths_regular_and_surface_owned: bool | None
+    inventory_fixture_paths_regular_or_trees: bool | None
+    inventory_subject_roles_disjoint: bool | None
+    inventory_fixtures_nonexecutable: bool | None
+    executable_dependencies_within_harness_tree: bool | None
     acceptance_dependencies_within_support_tree: bool | None
-    subject_data_cannot_reduce_coverage: bool | None
+    subjects_cannot_supply_evidence_logic: bool | None
     hermetic_execution_contract_valid: bool | None
     supervisor_self_test_receipt_valid: bool | None
     enforcement_workflows_pinned: bool | None
     policy_digest_matches: bool | None
     ledger_prefix_matches: bool | None
-    inventory_test_surfaces_valid: bool | None
 
 
 @dataclass(frozen=True)
@@ -571,7 +627,7 @@ ResolveReplayRecordDiff = Callable[[str, str, str | None], RecordDiffEvidence]
 ResolveReplayWorkDiff = Callable[[str], WorkDiffEvidence]
 ResolveReplayResolutionDiff = Callable[[str], ResolutionDiffEvidence]
 ResolveReplayReleasePrep = Callable[
-    [str, tuple[str, ...], tuple[str, ...]], ReleasePrepEvidence
+    [str, tuple[str, ...], tuple[str, ...], tuple[str, ...]], ReleasePrepEvidence
 ]
 ResolveReplayReleasePayload = Callable[[str, str, ReleaseContract], ReleasePayloadEvidence]
 ResolveReplayReleaseTestObservation = Callable[
@@ -796,6 +852,12 @@ def policy_glob_matches(path: str, pattern: str) -> bool:
     return re.fullmatch(expression, path) is not None
 
 
+def path_within_subject_roots(path: str, roots: tuple[str, ...]) -> bool:
+    """Check a normalized subject path against closed file-or-tree roots."""
+
+    return any(path == root or path.startswith(f"{root}/") for root in roots)
+
+
 def sha(value: object, field: str, entry_id: str) -> str:
     result = nonempty_string(value, field, entry_id)
     require(SHA_RE.fullmatch(result) is not None, f"{entry_id} has invalid {field}")
@@ -907,7 +969,7 @@ def policy_rules(
         test_code_tree=str(root.get("release_test_code_tree", "")),
         test_support_root=str(root.get("release_test_support_root", "")),
         test_support_tree=str(root.get("release_test_support_tree", "")),
-        test_data_roots=tuple(root.get("release_test_data_roots", ())),
+        test_subject_roots=tuple(root.get("release_test_subject_roots", ())),
         tex_api_fix_paths=tuple(root.get("tex_api_fix_paths", ())),
         tnlog_fix_paths=tuple(root.get("tnlog_fix_paths", ())),
         enforcement_workflows=tuple(root.get("release_enforcement_workflows", ())),
@@ -927,7 +989,7 @@ def policy_rules(
             contract.test_inventory,
             contract.test_code_root,
             contract.test_support_root,
-            contract.test_data_roots,
+            contract.test_subject_roots,
             contract.tex_api_fix_paths,
             contract.tnlog_fix_paths,
             contract.enforcement_workflows,
@@ -944,16 +1006,25 @@ def policy_rules(
             "docs/tenkz/CHANGES.md",
             "docs/tenkz/TNLOG.md",
             "tests/tenkz/release-tests.toml",
-            "scripts",
+            "tests/tenkz/release-harness",
             "tests/tenkz/release-support",
-            ("tex/tenkz", "docs/tenkz", "tests/tenkz/rmp"),
-            ("tex/tenkz/**/*.tex", "tex/tenkz/**/*.sty"),
-            ("tex/tenkz/**/*.tex", "tex/tenkz/**/*.sty"),
+            (
+                "tex/tenkz",
+                "scripts/tenkzlib/tnlog.py",
+                "docs/tenkz",
+                "tests/tenkz/rmp",
+            ),
+            ("tex/tenkz/*.tex", "tex/tenkz/*.sty"),
+            (
+                "tex/tenkz/*.tex",
+                "tex/tenkz/*.sty",
+                "scripts/tenkzlib/tnlog.py",
+            ),
             (".github/workflows/tenkz-release-policy.yml",),
             "transitive-content-addressed-no-runtime-downloads",
             "disabled-before-repository-code",
             "tests/tenkz/release-support/reset-replay-v1.schema.json",
-            "pinned-code-support-declared-subject-data",
+            "pinned-harness-support-declared-subject-roles",
             "hermetic-repository-view-no-shell-or-network",
         ),
         "policy has the wrong release-payload contract",
@@ -1271,13 +1342,18 @@ def validate_release_payload(
         evidence.inventory_digest_matches is True,
         f"{subject} test-inventory digest differs from policy",
     )
+    require(evidence.inventory_exact_schema_valid is True, f"{subject} inventory schema is invalid")
     require(
-        evidence.inventory_contract_valid is True,
-        f"{subject} test inventory is invalid",
+        evidence.inventory_ids_and_failure_fingerprints_unique is True,
+        f"{subject} inventory IDs or failure fingerprints are not unique",
     )
     require(
-        evidence.inventory_test_surfaces_valid is True,
-        f"{subject} test inventory has invalid surface declarations",
+        evidence.inventory_test_surface_valid is True,
+        f"{subject} test inventory has an invalid surface declaration",
+    )
+    require(
+        evidence.inventory_atomic_assertions_one_per_test is True,
+        f"{subject} inventory contains a non-atomic compatibility test",
     )
     require(
         evidence.test_code_tree_matches is True,
@@ -1288,20 +1364,36 @@ def validate_release_payload(
         f"{subject} release-test support tree differs from policy",
     )
     require(
-        evidence.inventory_data_paths_within_mutable_roots is True,
-        f"{subject} inventory data paths escape the mutable subject roots",
+        evidence.inventory_subject_paths_within_subject_roots is True,
+        f"{subject} inventory subject paths escape the pinned subject roots",
     )
     require(
-        evidence.executable_dependencies_within_code_tree is True,
-        f"{subject} executable dependency escapes the pinned code tree",
+        evidence.inventory_program_paths_regular_and_surface_owned is True,
+        f"{subject} inventory program paths are not regular surface-owned blobs",
+    )
+    require(
+        evidence.inventory_fixture_paths_regular_or_trees is True,
+        f"{subject} inventory fixture paths are not regular blobs or trees",
+    )
+    require(
+        evidence.inventory_subject_roles_disjoint is True,
+        f"{subject} inventory program and fixture roles overlap",
+    )
+    require(
+        evidence.inventory_fixtures_nonexecutable is True,
+        f"{subject} inventory permits an executable fixture",
+    )
+    require(
+        evidence.executable_dependencies_within_harness_tree is True,
+        f"{subject} executable dependency escapes the pinned harness tree",
     )
     require(
         evidence.acceptance_dependencies_within_support_tree is True,
         f"{subject} acceptance dependency escapes the pinned support tree",
     )
     require(
-        evidence.subject_data_cannot_reduce_coverage is True,
-        f"{subject} subject data can reduce release-test coverage",
+        evidence.subjects_cannot_supply_evidence_logic is True,
+        f"{subject} subject paths can supply evidence or coverage logic",
     )
     require(
         evidence.hermetic_execution_contract_valid is True,
@@ -1336,11 +1428,12 @@ def validate_release_test_observation(
     tag: str,
     test_ref: str,
     surface: str,
-    expect_exit_zero: bool,
+    expected_result: str,
+    expected_failure_fingerprint: str | None,
     contract: ReleaseContract,
     subject: str,
-) -> None:
-    """Validate one exact test observation, including a clean process exit."""
+) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    """Validate one atomic test observation and return its pinned inventory facts."""
 
     require(evidence.validated_tree_oid == tree_oid, f"{subject} used another tree")
     require(evidence.validated_tag == tag, f"{subject} used another freeze tag")
@@ -1364,10 +1457,21 @@ def validate_release_test_observation(
         evidence.inventory_digest_matches is True,
         f"{subject} test-inventory digest differs from policy",
     )
-    require(evidence.inventory_contract_valid is True, f"{subject} inventory is invalid")
     require(
-        evidence.inventory_test_surfaces_valid is True,
-        f"{subject} inventory has invalid surface declarations",
+        evidence.inventory_exact_schema_valid is True,
+        f"{subject} inventory schema is invalid",
+    )
+    require(
+        evidence.inventory_ids_and_failure_fingerprints_unique is True,
+        f"{subject} inventory IDs or failure fingerprints are not unique",
+    )
+    require(
+        evidence.inventory_test_surface_valid is True,
+        f"{subject} inventory has an invalid surface declaration",
+    )
+    require(
+        evidence.inventory_atomic_assertions_one_per_test is True,
+        f"{subject} inventory contains a non-atomic compatibility test",
     )
     require(evidence.inventory_test_exists is True, f"{subject} test is absent from inventory")
     require(
@@ -1383,36 +1487,112 @@ def validate_release_test_observation(
         f"{subject} test-support tree differs from policy",
     )
     require(
-        evidence.inventory_data_paths_within_mutable_roots is True,
-        f"{subject} data paths escape the mutable subject roots",
+        evidence.inventory_subject_paths_within_subject_roots is True,
+        f"{subject} subject paths escape the pinned subject roots",
     )
     require(
-        evidence.executable_dependencies_within_code_tree is True,
-        f"{subject} executable dependency escapes the pinned code tree",
+        evidence.executable_dependencies_within_harness_tree is True,
+        f"{subject} executable dependency escapes the pinned harness tree",
     )
     require(
         evidence.acceptance_dependencies_within_support_tree is True,
         f"{subject} acceptance dependency escapes the pinned support tree",
     )
     require(
-        evidence.subject_data_cannot_reduce_coverage is True,
-        f"{subject} subject data can reduce test coverage",
+        evidence.subjects_cannot_supply_evidence_logic is True,
+        f"{subject} subjects can supply evidence or coverage logic",
     )
     require(
         evidence.hermetic_execution_contract_valid is True,
         f"{subject} hermetic execution contract is invalid",
     )
     require(evidence.tool_fingerprints_match is True, f"{subject} tool identity differs")
-    surfaces = evidence.inventory_test_surfaces
+    test_surface = evidence.inventory_test_surface
     require(
-        isinstance(surfaces, tuple)
-        and bool(surfaces)
-        and all(isinstance(item, str) for item in surfaces),
-        f"{subject} inventory test surfaces are missing",
+        isinstance(test_surface, str) and test_surface in SURFACES,
+        f"{subject} inventory test surface is missing or invalid",
     )
-    require(len(surfaces) == len(set(surfaces)), f"{subject} test surfaces have duplicates")
-    require(set(surfaces) <= SURFACES, f"{subject} test has an unknown surface")
-    require(surface in surfaces, f"{subject} test does not cover surface {surface}")
+    require(test_surface == surface, f"{subject} test covers another surface")
+    fingerprint = evidence.inventory_test_failure_fingerprint
+    require(
+        isinstance(fingerprint, str) and SHA256_RE.fullmatch(fingerprint) is not None,
+        f"{subject} has an invalid pinned failure fingerprint",
+    )
+    if expected_failure_fingerprint is not None:
+        require(
+            fingerprint == expected_failure_fingerprint,
+            f"{subject} used another pinned failure fingerprint",
+        )
+    program_paths = evidence.inventory_test_program_paths
+    fixture_paths = evidence.inventory_test_fixture_paths
+    require(
+        isinstance(program_paths, tuple)
+        and bool(program_paths)
+        and all(normalized_repository_path(path) == path for path in program_paths),
+        f"{subject} program paths are missing or malformed",
+    )
+    require(
+        isinstance(fixture_paths, tuple)
+        and all(normalized_repository_path(path) == path for path in fixture_paths),
+        f"{subject} fixture paths are malformed",
+    )
+    require(
+        len(program_paths) == len(set(program_paths)),
+        f"{subject} program paths contain duplicates",
+    )
+    require(
+        len(fixture_paths) == len(set(fixture_paths)),
+        f"{subject} fixture paths contain duplicates",
+    )
+    require(
+        all(path_within_subject_roots(path, contract.test_subject_roots) for path in program_paths),
+        f"{subject} program path escapes the pinned subject roots",
+    )
+    require(
+        all(path_within_subject_roots(path, contract.test_subject_roots) for path in fixture_paths),
+        f"{subject} fixture path escapes the pinned subject roots",
+    )
+    require(
+        set(program_paths).isdisjoint(fixture_paths)
+        and all(
+            not program.startswith(f"{fixture}/")
+            for program in program_paths
+            for fixture in fixture_paths
+        ),
+        f"{subject} program and fixture roles overlap",
+    )
+    require(
+        all(
+            any(
+                policy_glob_matches(program, pattern)
+                for pattern in contract.fix_paths(test_surface)
+            )
+            for program in program_paths
+        ),
+        f"{subject} program path does not match its declared surface",
+    )
+    require(
+        evidence.inventory_test_program_paths_regular_blobs is True,
+        f"{subject} program path is not a regular blob",
+    )
+    require(
+        evidence.inventory_test_fixture_paths_regular_blobs_or_trees is True,
+        f"{subject} fixture path is not a regular blob or tree",
+    )
+    require(
+        evidence.inventory_test_fixture_trees_exclude_program_paths is True,
+        f"{subject} fixture tree contains a program path",
+    )
+    require(
+        evidence.inventory_test_fixtures_nonexecutable is True,
+        f"{subject} fixture is executable",
+    )
+    require(
+        isinstance(evidence.atomic_assertion_count, int)
+        and not isinstance(evidence.atomic_assertion_count, bool)
+        and evidence.atomic_assertion_count == 1,
+        f"{subject} does not contain exactly one atomic assertion",
+    )
     require(
         evidence.exactly_one_inventory_test_run is True,
         f"{subject} did not run exactly one inventory test",
@@ -1429,7 +1609,8 @@ def validate_release_test_observation(
     require(evidence.execution_complete is True, f"{subject} execution is incomplete")
     require(evidence.timed_out is False, f"{subject} timed out")
     require(evidence.terminated_by_signal is False, f"{subject} ended by signal")
-    require(evidence.clean_process_exit is True, f"{subject} did not exit cleanly")
+    require(expected_result in {"passed", "assertion-failed"}, "invalid expected result")
+    require(evidence.result == expected_result, f"{subject} returned another result")
     exit_code = evidence.exit_code
     require(
         isinstance(exit_code, int)
@@ -1437,10 +1618,40 @@ def validate_release_test_observation(
         and 0 <= exit_code <= 255,
         f"{subject} has an invalid process exit code",
     )
-    if expect_exit_zero:
-        require(exit_code == 0, f"{subject} regression test did not pass")
+    if expected_result == "passed":
+        require(exit_code == 0, f"{subject} passed result did not exit zero")
+        require(
+            evidence.assertion_failure_receipt_path is None
+            and evidence.observed_failure_fingerprint is None
+            and evidence.assertion_failure_receipt_exact_and_matching is None
+            and evidence.assertion_failure_receipt_atomically_written is None
+            and evidence.single_failure_cause is None,
+            f"{subject} passed result carries assertion-failure evidence",
+        )
     else:
-        require(exit_code != 0, f"{subject} regression test did not reproduce friction")
+        require(exit_code == 10, f"{subject} assertion failure did not exit exactly 10")
+        require(
+            evidence.assertion_failure_receipt_path
+            == "/tenkz-output/assertion-failure-v1.json",
+            f"{subject} used another assertion-failure receipt path",
+        )
+        require(
+            evidence.observed_failure_fingerprint == fingerprint,
+            f"{subject} observed another failure fingerprint",
+        )
+        require(
+            evidence.assertion_failure_receipt_exact_and_matching is True,
+            f"{subject} assertion-failure receipt is incomplete or mismatched",
+        )
+        require(
+            evidence.assertion_failure_receipt_atomically_written is True,
+            f"{subject} assertion-failure receipt was not written atomically",
+        )
+        require(
+            evidence.single_failure_cause is True,
+            f"{subject} reported a coarse or multiple-cause failure",
+        )
+    return fingerprint, program_paths, fixture_paths
 
 
 def validate_tag_protection(evidence: TagProtectionEvidence) -> None:
@@ -1842,8 +2053,20 @@ def validate_entries(
         "activation inventory digest is wrong",
     )
     require(
-        activation_diff.inventory_test_surfaces_valid is True,
-        "activation inventory test surfaces are invalid",
+        activation_diff.inventory_exact_schema_valid is True,
+        "activation inventory schema is invalid",
+    )
+    require(
+        activation_diff.inventory_ids_and_failure_fingerprints_unique is True,
+        "activation inventory IDs or failure fingerprints are not unique",
+    )
+    require(
+        activation_diff.inventory_test_surface_valid is True,
+        "activation inventory test surface is invalid",
+    )
+    require(
+        activation_diff.inventory_atomic_assertions_one_per_test is True,
+        "activation inventory contains a non-atomic compatibility test",
     )
     require(
         activation_diff.test_code_tree_matches is True,
@@ -1854,20 +2077,36 @@ def validate_entries(
         "activation test-support tree is wrong",
     )
     require(
-        activation_diff.inventory_data_paths_within_mutable_roots is True,
-        "activation inventory data paths escape the mutable subject roots",
+        activation_diff.inventory_subject_paths_within_subject_roots is True,
+        "activation inventory subject paths escape the pinned subject roots",
     )
     require(
-        activation_diff.executable_dependencies_within_code_tree is True,
-        "activation executable dependency escapes the pinned code tree",
+        activation_diff.inventory_program_paths_regular_and_surface_owned is True,
+        "activation inventory program paths are not regular surface-owned blobs",
+    )
+    require(
+        activation_diff.inventory_fixture_paths_regular_or_trees is True,
+        "activation inventory fixture paths are not regular blobs or trees",
+    )
+    require(
+        activation_diff.inventory_subject_roles_disjoint is True,
+        "activation inventory subject roles overlap",
+    )
+    require(
+        activation_diff.inventory_fixtures_nonexecutable is True,
+        "activation inventory permits an executable fixture",
+    )
+    require(
+        activation_diff.executable_dependencies_within_harness_tree is True,
+        "activation executable dependency escapes the pinned harness tree",
     )
     require(
         activation_diff.acceptance_dependencies_within_support_tree is True,
         "activation acceptance dependency escapes the pinned support tree",
     )
     require(
-        activation_diff.subject_data_cannot_reduce_coverage is True,
-        "activation subject data can reduce release-test coverage",
+        activation_diff.subjects_cannot_supply_evidence_logic is True,
+        "activation subjects can supply evidence or coverage logic",
     )
     require(
         activation_diff.hermetic_execution_contract_valid is True,
@@ -1942,9 +2181,10 @@ def validate_entries(
             final_tag.object_id is None
             and final_tag.object_type is None
             and final_tag.commit is None
-            and final_tag.patch_is_fresh_for_attempt is None
-            and final_tag.namespace_complete is None
-            and final_tag.patch_exceeds_other_namespace_tags is None
+            and final_tag.candidate_namespace_complete is None
+            and final_tag.candidate_patch_exceeds_current_namespace is None
+            and final_tag.historical_candidate_check_exact_and_successful is None
+            and final_tag.historical_compares_only_earlier_freezes is None
             and final_tag.validated_entry_id is None
             and final_tag.validated_record_pr is None
             and final_tag.commit_is_validated_record_integration is None,
@@ -2013,8 +2253,8 @@ def validate_entries(
         elif kind == "reset":
             reset_cause = nonempty_string(entry["cause"], "cause", entry_id)
             require(reset_cause in RESET_CAUSES, f"{entry_id} has invalid reset cause")
-            if reset_cause == "breaking-required":
-                require(active is not None, f"{entry_id} breaking reset has no active attempt")
+            if reset_cause == "restart-required":
+                require(active is not None, f"{entry_id} restart reset has no active attempt")
                 require(attempt == active["attempt"], f"{entry_id} has the wrong active attempt")
             else:
                 require(last_attempt > 0, f"{entry_id} record-invalid reset has no prior attempt")
@@ -2203,19 +2443,24 @@ def validate_entries(
                     tag.commit == source_sha,
                     f"{entry_id} freeze tag peels to another commit",
                 )
-                require(
-                    tag.patch_is_fresh_for_attempt is True,
-                    f"{entry_id} freeze PATCH does not exceed earlier freeze entries",
-                )
-                require(
-                    tag.namespace_complete is True,
-                    f"{entry_id} freeze tag namespace is incompletely paginated",
-                )
-                require(
-                    tag.patch_exceeds_other_namespace_tags is True,
-                    f"{entry_id} freeze PATCH does not exceed abandoned tags "
-                    "or other namespace tags",
-                )
+                if record_pending:
+                    require(
+                        tag.candidate_namespace_complete is True,
+                        f"{entry_id} candidate tag namespace is incompletely paginated",
+                    )
+                    require(
+                        tag.candidate_patch_exceeds_current_namespace is True,
+                        f"{entry_id} candidate PATCH does not exceed the current namespace",
+                    )
+                else:
+                    require(
+                        tag.historical_candidate_check_exact_and_successful is True,
+                        f"{entry_id} lacks its exact successful candidate PATCH check",
+                    )
+                    require(
+                        tag.historical_compares_only_earlier_freezes is True,
+                        f"{entry_id} historical PATCH check includes a later tag",
+                    )
                 payload_blobs = validate_release_payload(
                     resolve_replay_release_payload(source_sha, tag_name, release_contract),
                     tree_oid=source_sha,
@@ -2472,6 +2717,10 @@ def validate_entries(
                     "regression_tests",
                     entry_id,
                 )
+                require(
+                    bool(listed_tests),
+                    f"{entry_id} regression_tests must be nonempty",
+                )
                 for test_ref in listed_tests:
                     require(
                         TEST_REF_RE.fullmatch(test_ref) is not None,
@@ -2481,19 +2730,24 @@ def validate_entries(
             nonempty_string(entry["summary"], "summary", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
 
-            def friction_observation_facts() -> None:
+            def friction_observation_facts() -> dict[str, dict[str, object]]:
                 if not regression_tests:
-                    return
+                    return {}
                 assert resolve_replay_release_test_observation is not None
                 record_head = record.head_oid
                 assert isinstance(record_head, str)
-                trees = [("head", record_head)]
-                if not record_pending:
-                    assert record_integration is not None
-                    trees.append(("integration", record_integration))
-                for stage, tree_oid in trees:
+                observations: dict[str, dict[str, object]] = {}
+
+                def observe_tree(
+                    stage: str,
+                    tree_oid: str,
+                    expected: dict[str, dict[str, object]] | None,
+                ) -> dict[str, dict[str, object]]:
+                    result: dict[str, dict[str, object]] = {}
                     for test_ref in regression_tests:
-                        validate_release_test_observation(
+                        expected_test = expected.get(test_ref) if expected is not None else None
+                        fingerprint, program_paths, fixture_paths = (
+                            validate_release_test_observation(
                             resolve_replay_release_test_observation(
                                 tree_oid,
                                 active["freeze_tag"],
@@ -2504,12 +2758,39 @@ def validate_entries(
                             tag=active["freeze_tag"],
                             test_ref=test_ref,
                             surface=surface,
-                            expect_exit_zero=False,
+                            expected_result="assertion-failed",
+                            expected_failure_fingerprint=(
+                                str(expected_test["fingerprint"])
+                                if expected_test is not None
+                                else None
+                            ),
                             contract=release_contract,
                             subject=f"{entry_id} friction {stage} test {test_ref}",
                         )
+                        )
+                        if expected_test is not None:
+                            require(
+                                program_paths == expected_test["program_paths"],
+                                f"{entry_id} friction test {test_ref} changed program roles",
+                            )
+                            require(
+                                fixture_paths == expected_test["fixture_paths"],
+                                f"{entry_id} friction test {test_ref} changed fixture roles",
+                            )
+                        result[test_ref] = {
+                            "fingerprint": fingerprint,
+                            "program_paths": program_paths,
+                            "fixture_paths": fixture_paths,
+                        }
+                    return result
 
-            check_external(friction_observation_facts)
+                observations = observe_tree("head", record_head, None)
+                if not record_pending:
+                    assert record_integration is not None
+                    observe_tree("integration", record_integration, observations)
+                return observations
+
+            friction_result = check_external(friction_observation_facts)
             if record_pending:
                 return finish_pending("friction-pending")
             if not entry_is_invalid():
@@ -2518,12 +2799,14 @@ def validate_entries(
                     "surface": surface,
                     "triage": triage,
                     "regression_tests": regression_tests,
+                    "test_facts": friction_result,
+                    "head": record.head_oid,
                     "resolved": False,
                     "merged_at": record_merged_at,
                     "integration": record_integration,
                 }
-                if triage == "breaking-required":
-                    pending_reset = ("breaking-required", entry_id)
+                if triage == "restart-required":
+                    pending_reset = ("restart-required", entry_id)
 
         elif kind == "resolution":
             assert active is not None
@@ -2533,10 +2816,6 @@ def validate_entries(
             require(fact is not None, f"{entry_id} names no friction in this attempt")
             require(fact["triage"] == "fix-compatible", f"{entry_id} resolves incompatible triage")
             require(fact["resolved"] is False, f"{entry_id} resolves friction twice")
-            require(
-                bool(fact["regression_tests"]),
-                f"{entry_id} cannot resolve an empty regression-test evidence gap",
-            )
             nonempty_string(entry["summary"], "summary", entry_id)
             nonempty_string(entry["evidence"], "evidence", entry_id)
 
@@ -2617,40 +2896,108 @@ def validate_entries(
                     isinstance(fix_base, str) and SHA_RE.fullmatch(fix_base) is not None,
                     f"{entry_id} fix merge base is missing or malformed",
                 )
+                regression_tests = fact["regression_tests"]
                 require(
-                    fix_diff.validated_surface == fact["surface"],
-                    f"{entry_id} fix diff used another compatibility surface",
+                    fix_diff.validated_regression_tests == regression_tests,
+                    f"{entry_id} fix diff used another regression-test set",
+                )
+                regression_fixes = fix_diff.regression_fixes
+                require(
+                    isinstance(regression_fixes, tuple)
+                    and len(regression_fixes) == len(regression_tests),
+                    f"{entry_id} fix lacks one semantic witness per regression test",
+                )
+                fixes_by_test: dict[str, RegressionFixEvidence] = {}
+                for fix_evidence in regression_fixes:
+                    test_ref = fix_evidence.test_ref
+                    require(
+                        isinstance(test_ref, str)
+                        and test_ref in regression_tests
+                        and test_ref not in fixes_by_test,
+                        f"{entry_id} fix semantic witnesses do not match its tests",
+                    )
+                    fixes_by_test[test_ref] = fix_evidence
+                test_facts = fact["test_facts"]
+                assert isinstance(test_facts, dict)
+                for test_ref in regression_tests:
+                    fix_evidence = fixes_by_test[test_ref]
+                    inventory_fact = test_facts[test_ref]
+                    assert isinstance(inventory_fact, dict)
+                    declared_program_paths = inventory_fact["program_paths"]
+                    fingerprint = inventory_fact["fingerprint"]
+                    require(
+                        fix_evidence.validated_surface == fact["surface"],
+                        f"{entry_id} test {test_ref} used another compatibility surface",
+                    )
+                    require(
+                        fix_evidence.declared_program_paths == declared_program_paths,
+                        f"{entry_id} test {test_ref} used another declared program set",
+                    )
+                    changed_path = normalized_repository_path(
+                        fix_evidence.changed_program_path
+                    )
+                    require(
+                        changed_path is not None
+                        and changed_path in declared_program_paths
+                        and any(
+                            policy_glob_matches(changed_path, pattern)
+                            for pattern in release_contract.fix_paths(fact["surface"])
+                        ),
+                        f"{entry_id} test {test_ref} changed no eligible declared program",
+                    )
+                    require(
+                        fix_evidence.program_blob_modified is True,
+                        f"{entry_id} test {test_ref} program blob was not modified",
+                    )
+                    require(
+                        fix_evidence.semantic_stream_changed is True,
+                        f"{entry_id} test {test_ref} program changed only nonsemantic text",
+                    )
+                    if changed_path == "scripts/tenkzlib/tnlog.py":
+                        require(
+                            fact["surface"] == "tnlog"
+                            and fix_evidence.semantic_stream_kind
+                            == "python-location-free-ast"
+                            and fix_evidence.python_reader_parses is True,
+                            f"{entry_id} test {test_ref} reader semantic stream is invalid",
+                        )
+                    else:
+                        require(
+                            fix_evidence.semantic_stream_kind
+                            == "tex-comment-stripped-tokens"
+                            and fix_evidence.python_reader_parses is None,
+                            f"{entry_id} test {test_ref} TeX semantic stream is invalid",
+                        )
+                    require(
+                        fix_evidence.baseline_failure_fingerprint == fingerprint,
+                        f"{entry_id} test {test_ref} used another baseline fingerprint",
+                    )
+                identity_trees = (
+                    fact["head"],
+                    fact["integration"],
+                    fix_base,
+                    fix_head,
+                    fix_integration,
                 )
                 require(
-                    fix_diff.validated_fix_path_patterns
-                    == release_contract.fix_paths(fact["surface"]),
-                    f"{entry_id} fix diff used another surface path set",
-                )
-                witness_path = fix_diff.semantic_witness_path
-                normalized_witness = normalized_repository_path(witness_path)
-                require(
-                    normalized_witness is not None
-                    and any(
-                        policy_glob_matches(normalized_witness, pattern)
-                        for pattern in release_contract.fix_paths(fact["surface"])
-                    ),
-                    f"{entry_id} fix semantic witness path is not surface-owned TeX",
+                    fix_diff.validated_identity_trees == identity_trees,
+                    f"{entry_id} fix identity check used another five-tree boundary",
                 )
                 require(
-                    fix_diff.surface_matching_added_or_modified_regular_blob is True,
-                    f"{entry_id} fix has no added or modified surface-owned TeX blob",
+                    fix_diff.fixture_blobs_modes_and_trees_identical is True,
+                    f"{entry_id} fix changes a regression fixture identity",
                 )
                 require(
-                    fix_diff.tex_comment_stripped_token_stream_changed is True,
-                    f"{entry_id} fix has no TeX-comment-stripped token change",
-                )
-                require(
-                    fix_diff.semantic_witness_is_same_surface_regular_blob is True,
-                    f"{entry_id} fix semantic witness is not one surface-owned TeX blob",
+                    fix_diff.freeze_manifest_blob_identical is True,
+                    f"{entry_id} fix changes the active-freeze manifest identity",
                 )
                 assert resolve_replay_release_test_observation is not None
-                for test_ref in fact["regression_tests"]:
-                    validate_release_test_observation(
+                for test_ref in regression_tests:
+                    inventory_fact = test_facts[test_ref]
+                    assert isinstance(inventory_fact, dict)
+                    fingerprint = str(inventory_fact["fingerprint"])
+                    base_fingerprint, base_programs, base_fixtures = (
+                        validate_release_test_observation(
                         resolve_replay_release_test_observation(
                             fix_base,
                             active["freeze_tag"],
@@ -2661,11 +3008,14 @@ def validate_entries(
                         tag=active["freeze_tag"],
                         test_ref=test_ref,
                         surface=fact["surface"],
-                        expect_exit_zero=False,
+                        expected_result="assertion-failed",
+                        expected_failure_fingerprint=fingerprint,
                         contract=release_contract,
                         subject=f"{entry_id} fix-base test {test_ref}",
                     )
-                    validate_release_test_observation(
+                    )
+                    head_fingerprint, head_programs, head_fixtures = (
+                        validate_release_test_observation(
                         resolve_replay_release_test_observation(
                             fix_head,
                             active["freeze_tag"],
@@ -2676,9 +3026,27 @@ def validate_entries(
                         tag=active["freeze_tag"],
                         test_ref=test_ref,
                         surface=fact["surface"],
-                        expect_exit_zero=True,
+                        expected_result="passed",
+                        expected_failure_fingerprint=fingerprint,
                         contract=release_contract,
                         subject=f"{entry_id} fix-head test {test_ref}",
+                    )
+                    )
+                    require(
+                        base_fingerprint == head_fingerprint == fingerprint,
+                        f"{entry_id} test {test_ref} changed its pinned fingerprint",
+                    )
+                    require(
+                        base_programs
+                        == head_programs
+                        == inventory_fact["program_paths"],
+                        f"{entry_id} test {test_ref} changed its declared program roles",
+                    )
+                    require(
+                        base_fixtures
+                        == head_fixtures
+                        == inventory_fact["fixture_paths"],
+                        f"{entry_id} test {test_ref} changed its declared fixture roles",
                     )
                 validate_release_payload(
                     resolve_replay_release_payload(
@@ -2717,17 +3085,21 @@ def validate_entries(
             if record_pending:
                 return finish_pending("resolution-pending")
             if not entry_is_invalid():
+                assert record_integration is not None
+                assert record_merged_at is not None
                 fact["resolved"] = True
+                fact["resolution_integration"] = record_integration
+                fact["resolution_merged_at"] = record_merged_at
 
         elif kind == "reset":
             cause = nonempty_string(entry["cause"], "cause", entry_id)
             target = nonempty_string(entry["target"], "target", entry_id)
             require(cause in RESET_CAUSES, f"{entry_id} has invalid reset cause")
             require(target in seen, f"{entry_id} reset target is not earlier")
-            if cause == "breaking-required":
+            if cause == "restart-required":
                 require(
                     seen_attempts[target] == attempt,
-                    f"{entry_id} breaking reset target is in another attempt",
+                    f"{entry_id} restart reset target is in another attempt",
                 )
             historical_record_reset = cause == "record-invalid" and index <= drift_boundary
             if cause == "record-invalid":
@@ -2873,16 +3245,16 @@ def validate_entries(
                         replay_list == sorted(replay_list, key=entry_positions.__getitem__),
                         f"{entry_id} reset receipt queue is not in ledger order",
                     )
-                    breaking_target = replay.pending_breaking_target
-                    actual_breaking_target = (
+                    restart_target = replay.pending_restart_target
+                    actual_restart_target = (
                         pending_reset[1]
                         if pending_reset is not None
-                        and pending_reset[0] == "breaking-required"
+                        and pending_reset[0] == "restart-required"
                         else None
                     )
                     require(
-                        breaking_target == actual_breaking_target,
-                        f"{entry_id} reset receipt has the wrong pending breaking target",
+                        restart_target == actual_restart_target,
+                        f"{entry_id} reset receipt has the wrong pending restart target",
                     )
                     require(
                         replay.normalized_resolver_inputs_complete_and_matching is True,
@@ -2900,11 +3272,11 @@ def validate_entries(
                         replay.current_candidate_snapshot_reproduces_receipt is True,
                         f"{entry_id} reset candidate no longer reproduces its receipt",
                     )
-                    return replay_list, breaking_target, receipt_integration
+                    return replay_list, restart_target, receipt_integration
 
                 receipt_result = check_external(replay_receipt_facts)
                 if isinstance(receipt_result, tuple):
-                    replay_list, breaking_target, receipt_integration = receipt_result
+                    replay_list, restart_target, receipt_integration = receipt_result
                     check_kind_record_fact(
                         diff.validated_receipt_integration == receipt_integration,
                         f"{entry_id} record diff used another receipt integration",
@@ -2927,8 +3299,8 @@ def validate_entries(
                             f"{entry_id} reset integration does not preserve its receipt blob",
                         )
                     receipt_required = (
-                        ("breaking-required", breaking_target)
-                        if breaking_target is not None
+                        ("restart-required", restart_target)
+                        if restart_target is not None
                         else (("record-invalid", replay_list[0]) if replay_list else None)
                     )
                     if historical_record_reset:
@@ -2997,6 +3369,28 @@ def validate_entries(
             work_integrations = tuple(
                 active["work"][work_class]["integration"] for work_class in work_classes
             )
+            compatible_frictions = [
+                (friction_id, fact)
+                for friction_id, fact in active["friction"].items()
+                if fact["triage"] == "fix-compatible"
+            ]
+            unresolved = [
+                friction_id
+                for friction_id, fact in compatible_frictions
+                if fact["resolved"] is False
+            ]
+            require(
+                not unresolved,
+                f"{entry_id} has unresolved friction: {', '.join(unresolved)}",
+            )
+            require(pending_reset is None, f"{entry_id} cannot prepare before reset")
+            resolution_integrations = tuple(
+                fact["resolution_integration"] for _friction_id, fact in compatible_frictions
+            )
+            latest_resolution_merge = max(
+                (fact["resolution_merged_at"] for _friction_id, fact in compatible_frictions),
+                default=latest_work_merge,
+            )
             release_ref = pr_ref(
                 entry["release_prep_pr"],
                 "release_prep_pr",
@@ -3016,8 +3410,8 @@ def validate_entries(
                     require_tree=True,
                 )
                 require(
-                    release_merged_at > latest_work_merge,
-                    f"{entry_id} release preparation did not merge after both work PRs",
+                    release_merged_at > max(latest_work_merge, latest_resolution_merge),
+                    f"{entry_id} release preparation merged before work or resolution evidence",
                 )
                 require_independent_approval(
                     release_pr,
@@ -3030,6 +3424,7 @@ def validate_entries(
                     release_ref,
                     release_paths,
                     work_integrations,
+                    resolution_integrations,
                 )
                 require(
                     release.validated_pr_ref == release_ref,
@@ -3050,6 +3445,10 @@ def validate_entries(
                 require(
                     release.validated_work_integrations == work_integrations,
                     f"{entry_id} release preparation used other work integrations",
+                )
+                require(
+                    release.validated_resolution_integrations == resolution_integrations,
+                    f"{entry_id} release preparation used other resolution integrations",
                 )
                 require(release.complete is True, f"{entry_id} release diff is incomplete")
                 release_parent_count = integration_parent_count(
@@ -3072,6 +3471,10 @@ def validate_entries(
                 require(
                     release.integration_descends_from_work_integrations is True,
                     f"{entry_id} release does not descend from both work integrations",
+                )
+                require(
+                    release.integration_descends_from_resolution_integrations is True,
+                    f"{entry_id} release does not descend from every resolution integration",
                 )
                 require(
                     release.exact_release_varying_path_diff is True,
@@ -3144,12 +3547,6 @@ def validate_entries(
                         authorized_permissions=reviewer_permissions,
                     )
                 )
-            unresolved = sorted(
-                friction
-                for friction, fact in active["friction"].items()
-                if fact["triage"] == "fix-compatible" and fact["resolved"] is False
-            )
-            require(not unresolved, f"{entry_id} has unresolved friction: {', '.join(unresolved)}")
             require(pending_reset is None, f"{entry_id} cannot sign off before reset")
             if record_pending:
                 return finish_pending("sign-off-pending")

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -108,8 +108,13 @@ def freeze(
     source_sha: str = SHA,
     tag_object: str = TAG_OBJECT,
     tag: str = "tenkz-v0.9.0",
+    tag_snapshot: tuple[str, ...] | None = None,
     prerequisites: str = PREREQUISITES,
 ) -> str:
+    if tag_snapshot is None:
+        patch = int(tag.rsplit(".", 1)[1])
+        tag_snapshot = tuple(f"tenkz-v0.9.{index}" for index in range(patch + 1))
+    rendered_snapshot = ", ".join(f'"{item}"' for item in tag_snapshot)
     return block(
         f'''id = "{entry_id}"
 kind = "freeze"
@@ -119,6 +124,7 @@ source_pr = "{source_pr}"
 source_sha = "{source_sha}"
 freeze_tag_object = "{tag_object}"
 freeze_tag = "{tag}"
+freeze_tag_snapshot = [{rendered_snapshot}]
 prerequisites = {prerequisites}
 evidence = "source, tag, and issue evidence"'''
     )
@@ -324,6 +330,38 @@ def candidate_pr(
     )
 
 
+def publisher_evidence(
+    integration_oid: str,
+    *,
+    status: str = "not-run",
+    object_oid: str = FINAL_TAG_OBJECT,
+) -> policy.FinalTagPublisherEvidence:
+    ran = status in {"success", "failure"}
+    succeeded = status == "success"
+    return policy.FinalTagPublisherEvidence(
+        validated_integration_oid=integration_oid,
+        complete=True,
+        pinned_workflow_run_exact=True,
+        postmerge_validation_succeeded=True,
+        postmerge_validation_network_disabled=True,
+        publisher_status=status,
+        publisher_needs_exact_postmerge_validation=True,
+        publisher_started_after_validation_success=True if ran else None,
+        validation_jobs_lack_contents_write=True,
+        publisher_has_only_contents_write=True,
+        publisher_has_no_checkout_or_repository_execution=True,
+        publisher_uses_version_fingerprinted_hosted_gh=True,
+        publisher_command_and_inputs_closed=True,
+        publisher_uses_only_github_control_plane=True,
+        other_networked_steps_absent=True,
+        final_ref_absent_before_create=True if succeeded else None,
+        annotated_tag_object_targets_integration=True if succeeded else None,
+        ref_created_without_force=True if succeeded else None,
+        readback_complete_and_matching=True if succeeded else None,
+        reported_tag_object_oid=object_oid if succeeded else None,
+    )
+
+
 @dataclass
 class Context:
     prs: dict[str, policy.PullRequestEvidence]
@@ -335,6 +373,7 @@ class Context:
     payloads: dict[tuple[str, str], policy.ReleasePayloadEvidence]
     tags: dict[str, policy.TagEvidence]
     issues: dict[str, policy.IssueEvidence]
+    publishers: dict[str, policy.FinalTagPublisherEvidence] = field(default_factory=dict)
     observations: dict[
         tuple[str, str, str], policy.ReleaseTestObservationEvidence
     ] = field(default_factory=dict)
@@ -396,6 +435,15 @@ class Context:
     def resolve_current_final_tag(self, tag: str) -> policy.TagEvidence:
         assert tag == policy.FINAL_TAG
         return self.tags[tag]
+
+    def resolve_final_tag_publisher(
+        self,
+        integration_oid: str,
+    ) -> policy.FinalTagPublisherEvidence:
+        return self.publishers.get(
+            integration_oid,
+            publisher_evidence(integration_oid),
+        )
 
     def resolve_replay_issue(self, issue: str) -> policy.IssueEvidence:
         return self.issues[issue]
@@ -856,7 +904,8 @@ def context() -> Context:
                 "tag",
                 SHA,
                 historical_candidate_check_exact_and_successful=True,
-                historical_compares_only_earlier_freezes=True,
+                historical_current_namespace_complete=True,
+                historical_current_matching_tag_names=("tenkz-v0.9.0",),
             ),
             policy.FINAL_TAG: policy.TagEvidence(None, None, None, exists=False),
         },
@@ -1240,10 +1289,10 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
                 if tag.candidate_namespace_complete is None
                 else tag.candidate_namespace_complete
             ),
-            candidate_patch_exceeds_current_namespace=(
-                True
-                if tag.candidate_patch_exceeds_current_namespace is None
-                else tag.candidate_patch_exceeds_current_namespace
+            candidate_matching_tag_names=(
+                tuple(entry["freeze_tag_snapshot"])
+                if tag.candidate_matching_tag_names is None
+                else tag.candidate_matching_tag_names
             ),
         )
     prepare_reset_receipts(entries, facts)
@@ -1279,6 +1328,7 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
         ),
         "resolve_replay_freeze_tag": facts.resolve_replay_freeze_tag,
         "resolve_current_final_tag": facts.resolve_current_final_tag,
+        "resolve_final_tag_publisher": facts.resolve_final_tag_publisher,
         "resolve_replay_issue": facts.resolve_replay_issue,
         "resolve_replay_record_invalid_reset": facts.resolve_replay_record_invalid_reset,
         "resolve_current_workflow": facts.resolve_current_workflow,
@@ -1390,8 +1440,20 @@ def add_freeze_facts(
         "tag",
         source_sha,
         historical_candidate_check_exact_and_successful=True,
-        historical_compares_only_earlier_freezes=True,
+        historical_current_namespace_complete=True,
     )
+    current_names = tuple(
+        sorted(
+            (name for name in facts.tags if policy.FREEZE_TAG_RE.fullmatch(name)),
+            key=lambda name: int(name.rsplit(".", 1)[1]),
+        )
+    )
+    for name in current_names:
+        facts.tags[name] = replace(
+            facts.tags[name],
+            historical_current_namespace_complete=True,
+            historical_current_matching_tag_names=current_names,
+        )
     facts.payloads[(source_sha, tag)] = payload_evidence(
         source_sha,
         tag,
@@ -1579,6 +1641,64 @@ def main() -> int:
         lambda: validate([freeze(tag="tenkz-v0.9.00")], context()),
         "invalid freeze tag",
     )
+
+    missing_snapshot = freeze().replace(
+        '\nfreeze_tag_snapshot = ["tenkz-v0.9.0"]',
+        "",
+    )
+    expect_failure(
+        lambda: policy.validate_entry_shape(parsed_entries(missing_snapshot)[0], 1),
+        "fields differ from schema",
+    )
+    expect_failure(
+        lambda: validate([freeze(tag_snapshot=())], context()),
+        "freeze_tag_snapshot is missing",
+    )
+    expect_failure(
+        lambda: validate(
+            [
+                freeze(
+                    tag="tenkz-v0.9.2",
+                    tag_snapshot=(
+                        "tenkz-v0.9.1",
+                        "tenkz-v0.9.0",
+                        "tenkz-v0.9.2",
+                    ),
+                )
+            ],
+            context(),
+        ),
+        "not in ascending numeric PATCH order",
+    )
+    expect_failure(
+        lambda: validate(
+            [
+                freeze(
+                    tag="tenkz-v0.9.1",
+                    tag_snapshot=("tenkz-v0.9.1", "tenkz-v0.9.2"),
+                )
+            ],
+            context(),
+        ),
+        "freeze PATCH is not maximal in its retained snapshot",
+    )
+
+    later_reservation = context()
+    later_reservation.tags["tenkz-v0.9.0"] = replace(
+        later_reservation.tags["tenkz-v0.9.0"],
+        historical_current_matching_tag_names=(
+            "tenkz-v0.9.0",
+            "tenkz-v0.9.1",
+        ),
+    )
+    assert validate([freeze()], later_reservation) == "attempt-1-active"
+
+    lost_retained_name = context()
+    lost_retained_name.tags["tenkz-v0.9.0"] = replace(
+        lost_retained_name.tags["tenkz-v0.9.0"],
+        historical_current_matching_tag_names=("tenkz-v0.9.1",),
+    )
+    assert validate([freeze()], lost_retained_name) == "reset-required:S1-0001"
 
     missing_receipt_field = reset(
         "S1-0002", "#908", "record-invalid", "S1-0001"
@@ -2719,11 +2839,158 @@ def main() -> int:
         "tag",
         oid(9071),
         exists=True,
-        validated_entry_id="S1-0004",
-        validated_record_pr=SIGNOFF_RECORD,
-        commit_is_validated_record_integration=True,
+    )
+    released.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
     )
     assert validate(complete_log(), released) == "released"
+
+    manual_final = context()
+    manual_final.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    expect_failure(
+        lambda: validate(complete_log(), manual_final),
+        "without the successful pinned publisher",
+    )
+
+    failed_publisher = context()
+    failed_publisher.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="failure",
+    )
+    expect_failure(
+        lambda: validate(complete_log(), failed_publisher),
+        "publisher failed; hard release incident",
+    )
+
+    lost_published_ref = context()
+    lost_published_ref.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    expect_failure(
+        lambda: validate(complete_log(), lost_published_ref),
+        "publisher succeeded but the final ref is absent",
+    )
+
+    published_then_drifted = context()
+    published_then_drifted.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    expect_failure(
+        lambda: validate(
+            complete_log(),
+            published_then_drifted,
+            audit=audit_evidence("S1-0004", ("S1-0002",)),
+        ),
+        "publisher succeeded while release evidence requires reset",
+    )
+
+    replaced_published_object = context()
+    replaced_published_object.tags[policy.FINAL_TAG] = policy.TagEvidence(
+        "d" * 40,
+        "tag",
+        oid(9071),
+        exists=True,
+    )
+    replaced_published_object.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    expect_failure(
+        lambda: validate(complete_log(), replaced_published_object),
+        "current final tag object differs from the publisher output",
+    )
+
+    publisher_contract_failures = (
+        (
+            "postmerge_validation_network_disabled",
+            False,
+            "validation was not network-disabled",
+        ),
+        (
+            "publisher_needs_exact_postmerge_validation",
+            False,
+            "does not depend on the exact validation job",
+        ),
+        (
+            "validation_jobs_lack_contents_write",
+            False,
+            "validation job has contents write permission",
+        ),
+        (
+            "publisher_has_only_contents_write",
+            False,
+            "missing or excess permissions",
+        ),
+        (
+            "publisher_has_no_checkout_or_repository_execution",
+            False,
+            "checks out or executes repository content",
+        ),
+        (
+            "publisher_uses_version_fingerprinted_hosted_gh",
+            False,
+            "uses another executable",
+        ),
+        (
+            "publisher_command_and_inputs_closed",
+            False,
+            "command or inputs are not closed",
+        ),
+        (
+            "publisher_uses_only_github_control_plane",
+            False,
+            "uses a non-GitHub network service",
+        ),
+        ("other_networked_steps_absent", False, "another networked step"),
+        (
+            "publisher_started_after_validation_success",
+            False,
+            "did not start after validation success",
+        ),
+        ("final_ref_absent_before_create", False, "existed before the publisher"),
+        (
+            "annotated_tag_object_targets_integration",
+            False,
+            "annotated tag object for the integration",
+        ),
+        ("ref_created_without_force", False, "without force"),
+        ("readback_complete_and_matching", False, "readback is incomplete"),
+    )
+    for field_name, bad_value, error_fragment in publisher_contract_failures:
+        bad_publisher = context()
+        bad_publisher.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+        bad_publisher.publishers[oid(9071)] = replace(
+            publisher_evidence(oid(9071), status="success"),
+            **{field_name: bad_value},
+        )
+        expect_failure(
+            lambda facts=bad_publisher: validate(complete_log(), facts),
+            error_fragment,
+        )
+
+    wrong_publisher_integration = context()
+    wrong_publisher_integration.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    wrong_publisher_integration.publishers[oid(9071)] = replace(
+        publisher_evidence(oid(9071), status="success"),
+        validated_integration_oid=oid(9991),
+    )
+    expect_failure(
+        lambda: validate(complete_log(), wrong_publisher_integration),
+        "used another sign-off integration",
+    )
+
+    premature_publisher_output = context()
+    premature_publisher_output.publishers[oid(9071)] = replace(
+        publisher_evidence(oid(9071)),
+        reported_tag_object_oid=FINAL_TAG_OBJECT,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), premature_publisher_output),
+        "publisher that did not run carries creation evidence",
+    )
 
     trailing_correction = context()
     add_record(
@@ -2734,6 +3001,7 @@ def main() -> int:
         SIGNOFF_MERGE + timedelta(seconds=1),
     )
     trailing_correction.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    trailing_correction.publishers.update(released.publishers)
     assert validate(
         complete_log() + [correction("S1-0005", "#908", "S1-0002")],
         trailing_correction,
@@ -2809,6 +3077,10 @@ def main() -> int:
         oid(9071),
         exists=True,
     )
+    lightweight_final.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
     expect_failure(
         lambda: validate(complete_log(), lightweight_final),
         "final release tag is not annotated",
@@ -2830,9 +3102,10 @@ def main() -> int:
         "tag",
         oid(9991),
         exists=True,
-        validated_entry_id="S1-0004",
-        validated_record_pr=SIGNOFF_RECORD,
-        commit_is_validated_record_integration=False,
+    )
+    wrong_final_target.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
     )
     expect_failure(
         lambda: validate(complete_log(), wrong_final_target),
@@ -2845,9 +3118,6 @@ def main() -> int:
         "tag",
         oid(9071),
         exists=True,
-        validated_entry_id="S1-0004",
-        validated_record_pr=SIGNOFF_RECORD,
-        commit_is_validated_record_integration=True,
     )
     expect_failure(
         lambda: validate(complete_log()[:3], premature_final),
@@ -2857,7 +3127,7 @@ def main() -> int:
     inconsistent_absent = context()
     inconsistent_absent.tags[policy.FINAL_TAG] = replace(
         inconsistent_absent.tags[policy.FINAL_TAG],
-        validated_entry_id="S1-0004",
+        object_id=FINAL_TAG_OBJECT,
     )
     expect_failure(
         lambda: validate(complete_log(), inconsistent_absent),
@@ -2869,10 +3139,6 @@ def main() -> int:
         forged_release.records["S1-0004"],
         validated_pr_ref=SIGNOFF_RECORD,
         validated_head_oid=forged_release.prs[SIGNOFF_RECORD].head_oid,
-    )
-    forged_release.tags[policy.FINAL_TAG] = replace(
-        released.tags[policy.FINAL_TAG],
-        validated_entry_id="S1-0003",
     )
     forged_log = [
         freeze(),
@@ -3961,9 +4227,9 @@ def main() -> int:
         "9" * 40,
         "tag",
         SHA,
-        True,
-        True,
-        True,
+        historical_candidate_check_exact_and_successful=True,
+        historical_current_namespace_complete=True,
+        historical_current_matching_tag_names=("tenkz-v0.9.0",),
     )
     add_record(
         moved_tag,
@@ -3985,9 +4251,8 @@ def main() -> int:
         "9" * 40,
         "tag",
         SHA,
-        True,
-        True,
-        True,
+        candidate_namespace_complete=True,
+        candidate_matching_tag_names=("tenkz-v0.9.0",),
     )
     expect_failure(
         lambda: validate([freeze()], moved_tag_candidate),
@@ -4028,11 +4293,11 @@ def main() -> int:
     stale_patch.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
     stale_patch.tags["tenkz-v0.9.0"] = replace(
         stale_patch.tags["tenkz-v0.9.0"],
-        candidate_patch_exceeds_current_namespace=False,
+        candidate_matching_tag_names=("tenkz-v0.9.0", "tenkz-v0.9.1"),
     )
     expect_failure(
         lambda: validate([freeze()], stale_patch),
-        "candidate PATCH does not exceed the current namespace",
+        "retained snapshot differs from the candidate namespace",
     )
 
     mixed_record = context()

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -167,13 +167,17 @@ def resolution(
     target: str,
     *,
     attempt: int = 1,
+    fix_pr: str | None = None,
 ) -> str:
+    entry_number = int(entry_id.removeprefix("S1-"))
+    fix_ref = fix_pr or f"#{18_000 + entry_number}"
     return block(
         f'''id = "{entry_id}"
 kind = "resolution"
 record_pr = "{record_pr}"
 attempt = {attempt}
 friction = "{target}"
+fix_pr = "{fix_ref}"
 summary = "compatible repair"
 evidence = "merged repair evidence"'''
     )
@@ -315,6 +319,7 @@ class Context:
     activation_diff: policy.ActivationDiffEvidence
     records: dict[str, policy.RecordDiffEvidence]
     work_diffs: dict[str, policy.WorkDiffEvidence]
+    resolution_diffs: dict[str, policy.ResolutionDiffEvidence]
     release_preps: dict[str, policy.ReleasePrepEvidence]
     payloads: dict[tuple[str, str], policy.ReleasePayloadEvidence]
     tags: dict[str, policy.TagEvidence]
@@ -340,6 +345,9 @@ class Context:
 
     def resolve_replay_work_diff(self, ref: str) -> policy.WorkDiffEvidence:
         return self.work_diffs[ref]
+
+    def resolve_replay_resolution_diff(self, ref: str) -> policy.ResolutionDiffEvidence:
+        return self.resolution_diffs[ref]
 
     def resolve_replay_release_prep(
         self,
@@ -718,6 +726,7 @@ def context() -> Context:
         activation_diff,
         records,
         work_diffs,
+        {},
         release_preps,
         payloads,
         {
@@ -815,6 +824,96 @@ def prepare_reset_receipts(entries: list[dict], facts: Context) -> None:
         )
 
 
+def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
+    """Populate exact fix-PR evidence for scenarios not testing resolutions."""
+
+    by_id = {entry["id"]: entry for entry in entries}
+    for entry in entries:
+        if entry["kind"] != "resolution":
+            continue
+        entry_id = entry["id"]
+        friction_entry = by_id[entry["friction"]]
+        friction_pr = facts.prs[friction_entry["record_pr"]]
+        friction_time = friction_pr.merged_at
+        friction_integration = friction_pr.merge_commit_oid
+        assert friction_time is not None and friction_integration is not None
+        freeze_entry = next(
+            candidate
+            for candidate in reversed(entries[: entries.index(entry)])
+            if candidate["kind"] == "freeze" and candidate["attempt"] == entry["attempt"]
+        )
+        freeze_integration = facts.prs[freeze_entry["record_pr"]].merge_commit_oid
+        assert freeze_integration is not None
+        resolution_record = facts.prs[entry["record_pr"]]
+        fix_ref = entry["fix_pr"]
+        fix_number = int(fix_ref[1:])
+        if fix_ref not in facts.prs:
+            resolution_time = resolution_record.merged_at
+            fix_time = (
+                friction_time + (resolution_time - friction_time) / 2
+                if resolution_time is not None
+                else friction_time + timedelta(seconds=1)
+            )
+            fix_head = oid(fix_number * 10)
+            facts.prs[fix_ref] = merged_pr(
+                fix_number,
+                fix_time,
+                author=f"fix-author-{fix_number}",
+                reviews=(
+                    review(
+                        f"fix-reviewer-{fix_number}",
+                        fix_time - timedelta(microseconds=1),
+                        fix_head,
+                    ),
+                ),
+            )
+        fix_pr = facts.prs[fix_ref]
+        fix_integration = fix_pr.merge_commit_oid
+        assert fix_integration is not None
+        if fix_ref not in facts.resolution_diffs:
+            facts.resolution_diffs[fix_ref] = policy.ResolutionDiffEvidence(
+                validated_pr_ref=fix_ref,
+                validated_head_oid=fix_pr.head_oid,
+                validated_integration_oid=fix_integration,
+                validated_freeze_integration=freeze_integration,
+                validated_friction_integration=friction_integration,
+                complete=True,
+                integration_parent_count=1,
+                unique_merge_base=True,
+                integration_parent_is_ancestor_of_head=True,
+                integration_second_parent_matches_head=True,
+                integration_strict_descendant_of_freeze=True,
+                integration_strict_descendant_of_friction=True,
+                policy_paths_untouched=True,
+                has_added_or_modified_regular_nonledger_blob=True,
+                normalized_token_stream_changed=True,
+                semantic_witness_is_same_regular_nonledger_blob=True,
+                validated_contract=policy.policy_rules(ARMED_POLICY)[4],
+                inventory_commands_complete=True,
+                inventory_commands_passed=True,
+                execution_receipts_exact_and_matching=True,
+            )
+        record_diff = facts.records[entry_id]
+        facts.records[entry_id] = replace(
+            record_diff,
+            candidate_main_tip_descends_from_fix_integration=(
+                True
+                if record_diff.candidate_main_tip_descends_from_fix_integration is None
+                else record_diff.candidate_main_tip_descends_from_fix_integration
+            ),
+            integration_parent_descends_from_fix_integration=(
+                True
+                if record_diff.integration_parent_descends_from_fix_integration is None
+                else record_diff.integration_parent_descends_from_fix_integration
+            ),
+            validated_fix_integration=(
+                fix_integration
+                if record_diff.validated_fix_integration is None
+                else record_diff.validated_fix_integration
+            ),
+        )
+
+
 def set_review_permission(facts: Context, ref: str, permission: str | None) -> None:
     pull_request = facts.prs[ref]
     assert pull_request.reviews is not None
@@ -830,6 +929,7 @@ def set_review_permission(facts: Context, ref: str, permission: str | None) -> N
 def validate(blocks: list[str], facts: Context, **overrides) -> str:
     entries = parsed_entries(*blocks)
     prepare_reset_receipts(entries, facts)
+    prepare_resolution_facts(entries, facts)
     if "audit" not in overrides:
         boundary: str | None = None
         target_oid = facts.prs[ACTIVATION].merge_commit_oid
@@ -851,6 +951,7 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
         "resolve_replay_activation_diff": facts.resolve_replay_activation_diff,
         "resolve_replay_record_diff": facts.resolve_replay_record_diff,
         "resolve_replay_work_diff": facts.resolve_replay_work_diff,
+        "resolve_replay_resolution_diff": facts.resolve_replay_resolution_diff,
         "resolve_replay_release_prep": facts.resolve_replay_release_prep,
         "resolve_replay_release_payload": facts.resolve_replay_release_payload,
         "resolve_replay_freeze_tag": facts.resolve_replay_freeze_tag,
@@ -1361,6 +1462,115 @@ def main() -> int:
     )
     assert validate(complete_log()[:2], cross_bound_work) == (
         "reset-required:S1-0002"
+    )
+
+    missing_fix_pr = resolution("S1-0003", RMP_RECORD, "S1-0002").replace(
+        '\nfix_pr = "#18003"',
+        "",
+    )
+    expect_failure(
+        lambda: policy.validate_entry_shape(
+            parsed_entries(
+                freeze(),
+                friction("S1-0002", FORMAL_RECORD, "fix-compatible"),
+                missing_fix_pr,
+            )[2],
+            3,
+        ),
+        "fields differ from schema",
+    )
+
+    def resolution_case(candidate_record: bool) -> tuple[list[str], Context, str]:
+        blocks = [
+            freeze(),
+            friction("S1-0002", FORMAL_RECORD, "fix-compatible"),
+            resolution("S1-0003", RMP_RECORD, "S1-0002"),
+        ]
+        facts = context()
+        if candidate_record:
+            facts.prs[RMP_RECORD] = candidate_pr(906, author="record-author")
+        entries = parsed_entries(*blocks)
+        prepare_resolution_facts(entries, facts)
+        return blocks, facts, entries[-1]["fix_pr"]
+
+    valid_resolution, valid_resolution_facts, _fix_ref = resolution_case(False)
+    assert validate(valid_resolution, valid_resolution_facts) == "attempt-1-active"
+    pending_resolution, pending_resolution_facts, _fix_ref = resolution_case(True)
+    assert validate(pending_resolution, pending_resolution_facts) == "resolution-pending"
+
+    resolution_diff_failures = (
+        (
+            "has_added_or_modified_regular_nonledger_blob",
+            False,
+            "no added or modified regular non-ledger blob",
+        ),
+        (
+            "normalized_token_stream_changed",
+            False,
+            "no semantic normalized-token change",
+        ),
+        (
+            "semantic_witness_is_same_regular_nonledger_blob",
+            False,
+            "not one qualifying blob",
+        ),
+        ("validated_head_oid", oid(99_980), "not validated at its exact head"),
+        (
+            "integration_strict_descendant_of_friction",
+            False,
+            "does not descend from its friction record",
+        ),
+        ("policy_paths_untouched", False, "changes policy or the soak ledger"),
+        ("inventory_commands_complete", False, "every pinned inventory command"),
+        ("inventory_commands_passed", False, "failed a pinned inventory command"),
+        (
+            "execution_receipts_exact_and_matching",
+            False,
+            "execution receipts are incomplete",
+        ),
+    )
+    for field_name, bad_value, error_fragment in resolution_diff_failures:
+        blocks, facts, fix_ref = resolution_case(True)
+        facts.resolution_diffs[fix_ref] = replace(
+            facts.resolution_diffs[fix_ref],
+            **{field_name: bad_value},
+        )
+        expect_failure(
+            lambda blocks=blocks, facts=facts: validate(blocks, facts),
+            error_fragment,
+        )
+
+    unreviewed_resolution, unreviewed_facts, fix_ref = resolution_case(True)
+    unreviewed_facts.prs[fix_ref] = replace(unreviewed_facts.prs[fix_ref], reviews=())
+    expect_failure(
+        lambda: validate(unreviewed_resolution, unreviewed_facts),
+        "repository-authorized independent exact-head approval",
+    )
+
+    unauthorized_resolution, unauthorized_facts, fix_ref = resolution_case(True)
+    set_review_permission(unauthorized_facts, fix_ref, "pull")
+    expect_failure(
+        lambda: validate(unauthorized_resolution, unauthorized_facts),
+        "repository-authorized independent exact-head approval",
+    )
+
+    stale_resolution_base, stale_resolution_facts, _fix_ref = resolution_case(True)
+    stale_resolution_facts.records["S1-0003"] = replace(
+        stale_resolution_facts.records["S1-0003"],
+        candidate_main_tip_descends_from_fix_integration=False,
+    )
+    expect_failure(
+        lambda: validate(stale_resolution_base, stale_resolution_facts),
+        "resolution candidate does not descend from its fix",
+    )
+
+    wrong_postmerge_ancestry, wrong_postmerge_facts, _fix_ref = resolution_case(False)
+    wrong_postmerge_facts.records["S1-0003"] = replace(
+        wrong_postmerge_facts.records["S1-0003"],
+        integration_parent_descends_from_fix_integration=False,
+    )
+    assert validate(wrong_postmerge_ancestry, wrong_postmerge_facts) == (
+        "reset-required:S1-0003"
     )
 
     candidate = context()

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -3570,6 +3570,72 @@ def main() -> int:
         "publisher succeeded but the final ref is absent",
     )
 
+    # A permitted candidate correction is a new current release epoch.  The
+    # predecessor sign-off keeps ownership of its authenticated published ref
+    # while the candidate reports its own pending state.
+    pending_published_correction = context()
+    add_record(
+        pending_published_correction,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    pending_published_correction.prs["#908"] = candidate_pr(
+        908,
+        author="record-author",
+    )
+    pending_published_correction.tags[policy.FINAL_TAG] = authenticated_final_tag(
+        oid(9071)
+    )
+    pending_published_correction.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    pending_published_correction_log = complete_log() + [
+        correction("S1-0005", "#908", "S1-0002")
+    ]
+    assert validate(
+        pending_published_correction_log,
+        pending_published_correction,
+    ) == "correction-pending"
+
+    pending_tag_without_publisher_success = context()
+    add_record(
+        pending_tag_without_publisher_success,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    pending_tag_without_publisher_success.prs["#908"] = candidate_pr(
+        908,
+        author="record-author",
+    )
+    pending_tag_without_publisher_success.tags[policy.FINAL_TAG] = (
+        authenticated_final_tag(oid(9071))
+    )
+    pending_tag_without_publisher_success.publishers[oid(9071)] = (
+        publisher_evidence(oid(9071), status="failure")
+    )
+    assert validate(
+        pending_published_correction_log,
+        pending_tag_without_publisher_success,
+    ) == "correction-pending"
+
+    pending_published_correction.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+        prior_released=True,
+    )
+    expect_failure(
+        lambda: validate(
+            pending_published_correction_log,
+            pending_published_correction,
+        ),
+        "appears after a prior released validation",
+    )
+
     # A ref created by the publisher during validation is observed after the
     # successful job, rather than misclassified from an earlier absent read.
     ref_created_during_validation = context()
@@ -3818,14 +3884,33 @@ def main() -> int:
     )
     assert publisher_lookups == [oid(9071), second_signoff_integration]
     publisher_lookups.clear()
+    # A forged current-attempt object cannot erase an older attempt's
+    # successful publisher claim, even when every current-attempt field is
+    # otherwise exact.
+    second_tagger_epoch = policy.canonical_tagger_epoch_seconds(
+        second_signoff_merge,
+        "second sign-off mergedAt",
+    )
     replacement_signoff.tags[policy.FINAL_TAG] = authenticated_final_tag(
         second_signoff_integration,
-        tagger_epoch_seconds=SIGNOFF_TAGGER_EPOCH,
-        prefix_boundary="S1-0004",
+        tagger_epoch_seconds=second_tagger_epoch,
+        prefix_boundary="S1-0010",
     )
     expect_failure(
         lambda: validate(replacement_signoff_log, replacement_signoff),
-        "final tag payload names another sign-off integration",
+        "final tag tagger epoch differs from the closed publisher tuple",
+    )
+    assert publisher_lookups == [oid(9071), second_signoff_integration]
+
+    # Conversely, a stale object authenticated for the old attempt cannot be
+    # adopted by the replacement attempt merely because the old publisher did
+    # not succeed.
+    publisher_lookups.clear()
+    replacement_signoff.publishers[oid(9071)] = publisher_evidence(oid(9071))
+    replacement_signoff.tags[policy.FINAL_TAG] = authenticated_final_tag(oid(9071))
+    expect_failure(
+        lambda: validate(replacement_signoff_log, replacement_signoff),
+        "final tag tagger epoch differs from the closed publisher tuple",
     )
     assert publisher_lookups == [oid(9071), second_signoff_integration]
 
@@ -4990,6 +5075,40 @@ def main() -> int:
     assert (
         validate(complete_log()[:2], comment_only_work)
         == "reset-required:S1-0002"
+    )
+
+    # A mixed eligible diff still fills only the class recorded by its entry.
+    # The separate RMP work entry remains necessary and completes the two-PR
+    # evidence set.
+    mixed_class_work = context()
+    mixed_class_work.work_diffs[FORMAL_WORK] = replace(
+        mixed_class_work.work_diffs[FORMAL_WORK],
+        semantic_add_or_modify_classes=(
+            "formalization-or-blueprint",
+            "rmp-benchmark",
+        ),
+        semantic_rmp_changed=True,
+    )
+    assert validate(complete_log()[:2], mixed_class_work) == "attempt-1-active"
+    assert validate(complete_log(), mixed_class_work) == "signed-off-awaiting-tag"
+
+    inconsistent_mixed_class_work = context()
+    inconsistent_mixed_class_work.work_diffs[RMP_WORK] = replace(
+        inconsistent_mixed_class_work.work_diffs[RMP_WORK],
+        semantic_add_or_modify_classes=(
+            "formalization-or-blueprint",
+            "rmp-benchmark",
+        ),
+        semantic_lean_changed=True,
+        semantic_rmp_changed=False,
+    )
+    inconsistent_mixed_class_work.prs[RMP_RECORD] = candidate_pr(
+        906,
+        author="record-author",
+    )
+    expect_failure(
+        lambda: validate(complete_log()[:3], inconsistent_mixed_class_work),
+        "semantic work-class evidence is inconsistent",
     )
 
     failing_lean_work = context()

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -3545,6 +3545,290 @@ def main() -> int:
         "publisher succeeded but the final ref is absent",
     )
 
+    # Pending ledger records do not bypass a historical publisher incident.
+    pending_after_signoff = context()
+    add_record(
+        pending_after_signoff,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    pending_after_signoff.prs["#908"] = candidate_pr(
+        908,
+        author="record-author",
+    )
+    pending_after_signoff.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    expect_failure(
+        lambda: validate(
+            complete_log() + [correction("S1-0005", "#908", "S1-0002")],
+            pending_after_signoff,
+        ),
+        "publisher succeeded but the final ref is absent",
+    )
+
+    # A ref created by the publisher during validation is observed after the
+    # successful job, rather than misclassified from an earlier absent read.
+    ref_created_during_validation = context()
+    lookup_order: list[str] = []
+
+    def resolve_successful_publisher(
+        integration_oid: str,
+    ) -> policy.FinalTagPublisherEvidence:
+        lookup_order.append(f"publisher:{integration_oid}")
+        return publisher_evidence(integration_oid, status="success")
+
+    def resolve_ref_after_publisher(tag: str) -> policy.TagEvidence:
+        assert tag == policy.FINAL_TAG
+        publisher_already_observed = bool(lookup_order)
+        lookup_order.append(f"ref:{tag}")
+        if not publisher_already_observed:
+            return policy.TagEvidence(None, None, None, exists=False)
+        return authenticated_final_tag(oid(9071))
+
+    ref_created_during_validation.resolve_final_tag_publisher = (
+        resolve_successful_publisher
+    )
+    ref_created_during_validation.resolve_current_final_tag = resolve_ref_after_publisher
+    assert validate(complete_log(), ref_created_during_validation) == (
+        "signed-off-awaiting-key-retirement"
+    )
+    assert lookup_order == [
+        f"publisher:{oid(9071)}",
+        f"ref:{policy.FINAL_TAG}",
+    ]
+
+    # A replacement sign-off cannot overwrite an older publisher whose
+    # delayed success makes the now-absent final ref a hard incident.
+    replacement_signoff = context()
+    add_record(
+        replacement_signoff,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+        invalid_tree=True,
+    )
+    add_record(
+        replacement_signoff,
+        "S1-0006",
+        "#909",
+        909,
+        SIGNOFF_MERGE + timedelta(seconds=3),
+    )
+    second_source_sha = "6" * 40
+    second_freeze_tag = "tenkz-v0.9.1"
+    add_freeze_facts(
+        replacement_signoff,
+        "S1-0007",
+        source_ref="#910",
+        source_number=910,
+        source_sha=second_source_sha,
+        record_ref="#911",
+        record_number=911,
+        tag=second_freeze_tag,
+        tag_object="7" * 40,
+        merged_at=SIGNOFF_MERGE + timedelta(seconds=5),
+    )
+    second_freeze_integration = replacement_signoff.prs["#911"].merge_commit_oid
+    assert isinstance(second_freeze_integration, str)
+
+    second_formal_merge = SIGNOFF_MERGE + timedelta(seconds=6)
+    replacement_signoff.prs["#912"] = merged_pr(
+        912,
+        second_formal_merge,
+        author="second-formal-author",
+        reviews=(
+            review(
+                "second-formal-reviewer",
+                second_formal_merge - timedelta(microseconds=1),
+                oid(9120),
+            ),
+        ),
+    )
+    second_formal_integration = replacement_signoff.prs["#912"].merge_commit_oid
+    assert isinstance(second_formal_integration, str)
+    replacement_signoff.work_diffs["#912"] = replace(
+        replacement_signoff.work_diffs[FORMAL_WORK],
+        validated_pr_ref="#912",
+        validated_head_oid=oid(9120),
+        validated_integration_oid=second_formal_integration,
+        validated_freeze_integration=second_freeze_integration,
+    )
+    add_record(
+        replacement_signoff,
+        "S1-0008",
+        "#913",
+        913,
+        SIGNOFF_MERGE + timedelta(seconds=7),
+    )
+
+    second_rmp_merge = SIGNOFF_MERGE + timedelta(seconds=8)
+    replacement_signoff.prs["#914"] = merged_pr(
+        914,
+        second_rmp_merge,
+        author="second-rmp-author",
+        reviews=(
+            review(
+                "second-rmp-reviewer",
+                second_rmp_merge - timedelta(microseconds=1),
+                oid(9140),
+            ),
+        ),
+    )
+    second_rmp_integration = replacement_signoff.prs["#914"].merge_commit_oid
+    assert isinstance(second_rmp_integration, str)
+    replacement_signoff.work_diffs["#914"] = replace(
+        replacement_signoff.work_diffs[RMP_WORK],
+        validated_pr_ref="#914",
+        validated_head_oid=oid(9140),
+        validated_integration_oid=second_rmp_integration,
+        validated_freeze_integration=second_freeze_integration,
+    )
+    add_record(
+        replacement_signoff,
+        "S1-0009",
+        "#915",
+        915,
+        SIGNOFF_MERGE + timedelta(seconds=9),
+    )
+
+    second_work_integrations = (
+        second_formal_integration,
+        second_rmp_integration,
+    )
+    second_release_merge = SIGNOFF_MERGE + timedelta(
+        seconds=9,
+        microseconds=500_000,
+    )
+    replacement_signoff.prs["#916"] = merged_pr(
+        916,
+        second_release_merge,
+        author="second-release-prep-author",
+        reviews=(
+            review(
+                "second-release-prep-reviewer",
+                second_release_merge - timedelta(microseconds=1),
+                oid(9160),
+            ),
+        ),
+    )
+    second_release_integration = replacement_signoff.prs["#916"].merge_commit_oid
+    assert isinstance(second_release_integration, str)
+    replacement_signoff.release_preps["#916"] = replace(
+        replacement_signoff.release_preps[RELEASE_PREP],
+        validated_pr_ref="#916",
+        validated_head_oid=oid(9160),
+        validated_integration_oid=second_release_integration,
+        validated_work_integrations=second_work_integrations,
+    )
+    second_payload_blobs = tuple(oid(40_000 + index) for index in range(6))
+    replacement_signoff.payloads[(oid(9160), policy.FINAL_TAG)] = payload_evidence(
+        oid(9160),
+        policy.FINAL_TAG,
+        second_payload_blobs,
+    )
+
+    second_signoff_merge = SIGNOFF_MERGE + timedelta(seconds=11)
+    add_record(
+        replacement_signoff,
+        "S1-0010",
+        "#917",
+        917,
+        second_signoff_merge,
+    )
+    replacement_signoff.prs["#917"] = replace(
+        replacement_signoff.prs["#917"],
+        author_login="second-release-author",
+        reviews=(
+            review(
+                "second-release-reviewer",
+                SIGNOFF_MERGE + timedelta(seconds=10),
+                oid(9170),
+            ),
+        ),
+    )
+    second_signoff_integration = replacement_signoff.prs["#917"].merge_commit_oid
+    assert isinstance(second_signoff_integration, str)
+    replacement_signoff.records["S1-0010"] = replace(
+        replacement_signoff.records["S1-0010"],
+        candidate_main_tip_is_release_integration=True,
+        integration_parent_is_release_integration=True,
+        validated_release_integration=second_release_integration,
+        validated_work_integrations=second_work_integrations,
+    )
+    for tree_oid in (oid(9170), second_signoff_integration):
+        replacement_signoff.payloads[(tree_oid, policy.FINAL_TAG)] = payload_evidence(
+            tree_oid,
+            policy.FINAL_TAG,
+            second_payload_blobs,
+        )
+
+    replacement_signoff_log = complete_log() + [
+        correction("S1-0005", "#908", "S1-0002"),
+        reset("S1-0006", "#909", "record-invalid", "S1-0005"),
+        freeze(
+            "S1-0007",
+            record_pr="#911",
+            attempt=2,
+            source_pr="#910",
+            source_sha=second_source_sha,
+            tag_object="7" * 40,
+            tag=second_freeze_tag,
+        ),
+        work(
+            "S1-0008",
+            "#913",
+            "#912",
+            "formalization-or-blueprint",
+            attempt=2,
+        ),
+        work("S1-0009", "#915", "#914", "rmp-benchmark", attempt=2),
+        sign_off(
+            "S1-0010",
+            "#917",
+            ["S1-0008", "S1-0009"],
+            attempt=2,
+            freeze_id="S1-0007",
+            source_sha=second_source_sha,
+            release_prep_pr="#916",
+            reviewer="github:second-release-reviewer",
+        ),
+    ]
+    replacement_signoff.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    publisher_lookups: list[str] = []
+    resolve_replacement_publisher = replacement_signoff.resolve_final_tag_publisher
+
+    def resolve_all_publishers(
+        integration_oid: str,
+    ) -> policy.FinalTagPublisherEvidence:
+        publisher_lookups.append(integration_oid)
+        return resolve_replacement_publisher(integration_oid)
+
+    replacement_signoff.resolve_final_tag_publisher = resolve_all_publishers
+    expect_failure(
+        lambda: validate(replacement_signoff_log, replacement_signoff),
+        "publisher succeeded but the final ref is absent",
+    )
+    assert publisher_lookups == [oid(9071), second_signoff_integration]
+    publisher_lookups.clear()
+    replacement_signoff.tags[policy.FINAL_TAG] = authenticated_final_tag(
+        second_signoff_integration,
+        tagger_epoch_seconds=SIGNOFF_TAGGER_EPOCH,
+        prefix_boundary="S1-0004",
+    )
+    expect_failure(
+        lambda: validate(replacement_signoff_log, replacement_signoff),
+        "final tag payload names another sign-off integration",
+    )
+    assert publisher_lookups == [oid(9071), second_signoff_integration]
+
     published_then_drifted = context()
     published_then_drifted.publishers[oid(9071)] = publisher_evidence(
         oid(9071),
@@ -3556,7 +3840,7 @@ def main() -> int:
             published_then_drifted,
             audit=audit_evidence("S1-0004", ("S1-0002",)),
         ),
-        "publisher succeeded while release evidence requires reset",
+        "publisher succeeded but the final ref is absent",
     )
 
     independently_authenticated_object = context()

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -1902,6 +1902,15 @@ def main() -> int:
         "reset-required:S1-0002"
     )
 
+    missing_freeze_merge_time = context()
+    missing_freeze_merge_time.prs[FREEZE_RECORD] = replace(
+        missing_freeze_merge_time.prs[FREEZE_RECORD],
+        merged_at=None,
+    )
+    assert validate(complete_log(), missing_freeze_merge_time) == (
+        "reset-required:S1-0001"
+    )
+
     work_after_record = context()
     work_after_record.prs[FORMAL_RECORD] = replace(
         work_after_record.prs[FORMAL_RECORD],
@@ -2320,6 +2329,20 @@ def main() -> int:
         commit_is_validated_record_integration=True,
     )
     assert validate(complete_log(), released) == "released"
+
+    trailing_correction = context()
+    add_record(
+        trailing_correction,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    trailing_correction.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    assert validate(
+        complete_log() + [correction("S1-0005", "#908", "S1-0002")],
+        trailing_correction,
+    ) == "released"
 
     # The current-validity audit runs forever while replay callbacks retain the
     # integration-time history.  Before the tag, drift enters the reset queue;

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -341,9 +341,16 @@ def publisher_evidence(
     tagger_epoch_seconds: int = SIGNOFF_TAGGER_EPOCH,
     prefix_boundary: str = "S1-0004",
     prior_released: bool = False,
+    prior_released_prefix_boundary: str | None = None,
+    prior_released_target_oid: str | None = None,
 ) -> policy.FinalTagPublisherEvidence:
     ran = status in {"incomplete", "failure", "success"}
     succeeded = status == "success"
+    if prior_released:
+        prior_released_prefix_boundary = (
+            prior_released_prefix_boundary or prefix_boundary
+        )
+        prior_released_target_oid = prior_released_target_oid or integration_oid
     return policy.FinalTagPublisherEvidence(
         validated_integration_oid=integration_oid,
         validated_tagger_epoch_seconds=tagger_epoch_seconds,
@@ -358,6 +365,11 @@ def publisher_evidence(
         workflow_jobs_complete_and_paginated=True,
         release_validation_runs_complete_and_paginated=True,
         prior_released_validation_exact_and_successful=prior_released,
+        prior_released_validation_prefix_boundary=prior_released_prefix_boundary,
+        prior_released_validation_target_oid=prior_released_target_oid,
+        prior_released_validation_target_contains_exact_prefix=(
+            True if prior_released else None
+        ),
         pinned_workflow_runs_exact=True,
         postmerge_validation_succeeded=True,
         postmerge_validation_network_disabled=True,
@@ -1359,10 +1371,29 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
                         program_paths=(program_path,),
                     ),
                 )
+                facts.observations.setdefault(
+                    (fix_integration, freeze_entry["freeze_tag"], test_ref),
+                    observation_evidence(
+                        fix_integration,
+                        freeze_entry["freeze_tag"],
+                        test_ref,
+                        surface=surface,
+                        result="passed",
+                        program_paths=(program_path,),
+                    ),
+                )
         facts.payloads.setdefault(
             (fix_head, freeze_entry["freeze_tag"]),
             payload_evidence(
                 fix_head,
+                freeze_entry["freeze_tag"],
+                FREEZE_PAYLOAD_BLOBS,
+            ),
+        )
+        facts.payloads.setdefault(
+            (fix_integration, freeze_entry["freeze_tag"]),
+            payload_evidence(
+                fix_integration,
                 freeze_entry["freeze_tag"],
                 FREEZE_PAYLOAD_BLOBS,
             ),
@@ -2898,18 +2929,31 @@ def main() -> int:
     def fix_observation_keys(
         facts: Context,
         fix_ref: str,
-    ) -> tuple[tuple[str, str, str], tuple[str, str, str]]:
+    ) -> tuple[
+        tuple[str, str, str],
+        tuple[str, str, str],
+        tuple[str, str, str],
+    ]:
         fix_base = facts.resolution_diffs[fix_ref].validated_base_oid
         fix_head = facts.prs[fix_ref].head_oid
-        assert isinstance(fix_base, str) and isinstance(fix_head, str)
+        fix_integration = facts.prs[fix_ref].merge_commit_oid
+        assert (
+            isinstance(fix_base, str)
+            and isinstance(fix_head, str)
+            and isinstance(fix_integration, str)
+        )
         tag = "tenkz-v0.9.0"
         return (
             (fix_base, tag, REGRESSION_TEST),
             (fix_head, tag, REGRESSION_TEST),
+            (fix_integration, tag, REGRESSION_TEST),
         )
 
     base_passes, base_passes_facts, fix_ref = resolution_case(True)
-    base_key, _head_key = fix_observation_keys(base_passes_facts, fix_ref)
+    base_key, _head_key, _integration_key = fix_observation_keys(
+        base_passes_facts,
+        fix_ref,
+    )
     base_passes_facts.observations[base_key] = replace(
         base_passes_facts.observations[base_key],
         exit_code=0,
@@ -2920,7 +2964,10 @@ def main() -> int:
     )
 
     head_fails, head_fails_facts, fix_ref = resolution_case(True)
-    _base_key, head_key = fix_observation_keys(head_fails_facts, fix_ref)
+    _base_key, head_key, _integration_key = fix_observation_keys(
+        head_fails_facts,
+        fix_ref,
+    )
     head_fails_facts.observations[head_key] = replace(
         head_fails_facts.observations[head_key],
         exit_code=9,
@@ -2931,7 +2978,10 @@ def main() -> int:
     )
 
     wrong_fix_tag, wrong_fix_tag_facts, fix_ref = resolution_case(True)
-    _base_key, head_key = fix_observation_keys(wrong_fix_tag_facts, fix_ref)
+    _base_key, head_key, _integration_key = fix_observation_keys(
+        wrong_fix_tag_facts,
+        fix_ref,
+    )
     wrong_fix_tag_facts.observations[head_key] = replace(
         wrong_fix_tag_facts.observations[head_key],
         validated_tag="tenkz-v0.9.1",
@@ -2939,6 +2989,20 @@ def main() -> int:
     expect_failure(
         lambda: validate(wrong_fix_tag, wrong_fix_tag_facts),
         "fix-head test tex-api-regression used another freeze tag",
+    )
+
+    integration_fails, integration_fails_facts, fix_ref = resolution_case(True)
+    _base_key, _head_key, integration_key = fix_observation_keys(
+        integration_fails_facts,
+        fix_ref,
+    )
+    integration_fails_facts.observations[integration_key] = replace(
+        integration_fails_facts.observations[integration_key],
+        exit_code=9,
+    )
+    expect_failure(
+        lambda: validate(integration_fails, integration_fails_facts),
+        "fix-integration test tex-api-regression passed result did not exit zero",
     )
 
     incomplete_fix_payload, incomplete_fix_payload_facts, fix_ref = resolution_case(True)
@@ -2952,6 +3016,19 @@ def main() -> int:
     expect_failure(
         lambda: validate(incomplete_fix_payload, incomplete_fix_payload_facts),
         "fix head release compatibility tests did not pass",
+    )
+
+    incomplete_integration_payload, integration_payload_facts, fix_ref = resolution_case(True)
+    fix_integration = integration_payload_facts.prs[fix_ref].merge_commit_oid
+    assert isinstance(fix_integration, str)
+    integration_payload_key = (fix_integration, "tenkz-v0.9.0")
+    integration_payload_facts.payloads[integration_payload_key] = replace(
+        integration_payload_facts.payloads[integration_payload_key],
+        compatibility_tests_passed=False,
+    )
+    expect_failure(
+        lambda: validate(incomplete_integration_payload, integration_payload_facts),
+        "fix integration release compatibility tests did not pass",
     )
 
     invalid_inventory_surfaces, invalid_inventory_facts, fix_ref = resolution_case(True)
@@ -2968,12 +3045,30 @@ def main() -> int:
     )
 
     postmerge_recheck, postmerge_recheck_facts, fix_ref = resolution_case(False)
-    _base_key, head_key = fix_observation_keys(postmerge_recheck_facts, fix_ref)
+    _base_key, head_key, _integration_key = fix_observation_keys(
+        postmerge_recheck_facts,
+        fix_ref,
+    )
     postmerge_recheck_facts.observations[head_key] = replace(
         postmerge_recheck_facts.observations[head_key],
         exit_code=2,
     )
     assert validate(postmerge_recheck, postmerge_recheck_facts) == (
+        "reset-required:S1-0003"
+    )
+
+    integration_postmerge_recheck, integration_postmerge_facts, fix_ref = (
+        resolution_case(False)
+    )
+    _base_key, _head_key, integration_key = fix_observation_keys(
+        integration_postmerge_facts,
+        fix_ref,
+    )
+    integration_postmerge_facts.observations[integration_key] = replace(
+        integration_postmerge_facts.observations[integration_key],
+        exit_code=2,
+    )
+    assert validate(integration_postmerge_recheck, integration_postmerge_facts) == (
         "reset-required:S1-0003"
     )
 
@@ -3215,6 +3310,42 @@ def main() -> int:
     )
     released.publisher_secret_override = publisher_secret_evidence(retired=True)
     assert validate(complete_log(), released) == "released"
+
+    prior_release_binding_failures = (
+        (
+            "prior_released_validation_prefix_boundary",
+            "S1-9999",
+            "prior released validation used another ledger prefix",
+        ),
+        (
+            "prior_released_validation_target_oid",
+            None,
+            "prior released validation target is missing or malformed",
+        ),
+        (
+            "prior_released_validation_target_contains_exact_prefix",
+            False,
+            "did not contain the exact ledger prefix",
+        ),
+    )
+    for field_name, bad_value, error_fragment in prior_release_binding_failures:
+        bad_prior_release = context()
+        bad_prior_release.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+        bad_prior_release.publishers[oid(9071)] = replace(
+            publisher_evidence(
+                oid(9071),
+                status="success",
+                prior_released=True,
+            ),
+            **{field_name: bad_value},
+        )
+        bad_prior_release.publisher_secret_override = publisher_secret_evidence(
+            retired=True
+        )
+        expect_failure(
+            lambda facts=bad_prior_release: validate(complete_log(), facts),
+            error_fragment,
+        )
 
     first_release_declaration = context()
     first_release_declaration.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
@@ -3669,6 +3800,16 @@ def main() -> int:
         "prior released validation lacks a successful publisher job",
     )
 
+    nonreleased_with_prior_binding = context()
+    nonreleased_with_prior_binding.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        prior_released_target_oid=oid(9071),
+    )
+    expect_failure(
+        lambda: validate(complete_log(), nonreleased_with_prior_binding),
+        "non-released history carries a released-validation binding",
+    )
+
     trailing_correction = context()
     add_record(
         trailing_correction,
@@ -3678,12 +3819,54 @@ def main() -> int:
         SIGNOFF_MERGE + timedelta(seconds=1),
     )
     trailing_correction.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
-    trailing_correction.publishers.update(released.publishers)
+    trailing_correction.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
     trailing_correction.publisher_secret_override = publisher_secret_evidence(retired=True)
-    assert validate(
-        complete_log() + [correction("S1-0005", "#908", "S1-0002")],
-        trailing_correction,
-    ) == "released"
+    trailing_correction_log = complete_log() + [
+        correction("S1-0005", "#908", "S1-0002")
+    ]
+    assert validate(trailing_correction_log, trailing_correction) == "released"
+
+    trailing_correction_replay = context()
+    add_record(
+        trailing_correction_replay,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    trailing_correction_replay.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    trailing_correction_replay.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+        prior_released=True,
+        prior_released_prefix_boundary="S1-0005",
+        prior_released_target_oid=oid(9081),
+    )
+    trailing_correction_replay.publisher_secret_override = publisher_secret_evidence(
+        retired=True
+    )
+    assert validate(trailing_correction_log, trailing_correction_replay) == "released"
+
+    appended_after_release = context()
+    add_record(
+        appended_after_release,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    appended_after_release.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    appended_after_release.publishers.update(released.publishers)
+    appended_after_release.publisher_secret_override = publisher_secret_evidence(
+        retired=True
+    )
+    expect_failure(
+        lambda: validate(trailing_correction_log, appended_after_release),
+        "prior released validation used another ledger prefix",
+    )
 
     # The current-validity audit runs forever while replay callbacks retain the
     # integration-time history.  Before the tag, drift enters the reset queue;
@@ -5012,9 +5195,13 @@ def main() -> int:
     )
 
     signoff_common = context()
-    signoff_common.prs[SIGNOFF_RECORD] = replace(
-        signoff_common.prs[SIGNOFF_RECORD],
-        integration_tree_matches_head=False,
+    signoff_common.payloads[(oid(9071), policy.FINAL_TAG)] = replace(
+        signoff_common.payloads[(oid(9071), policy.FINAL_TAG)],
+        test_execution_complete=False,
+    )
+    signoff_common.publishers[oid(9071)] = replace(
+        publisher_evidence(oid(9071)),
+        postmerge_validation_succeeded=False,
     )
     add_record(
         signoff_common,

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Perturbation tests for the tenkz compatibility and soak policy."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_tenkz_policy as policy
+
+
+DESIGN_TEXT = (ROOT / "docs/tenkz/DESIGN.md").read_text(encoding="utf-8")
+SOAK_TEXT = (ROOT / "docs/tenkz/SOAK-1.0.md").read_text(encoding="utf-8")
+SHA = "a" * 40
+TAG_OBJECT = "c" * 40
+SECOND_SHA = "b" * 40
+SECOND_TAG_OBJECT = "d" * 40
+FREEZE_UTC = datetime(2026, 9, 1, tzinfo=timezone.utc)
+SECOND_FREEZE_UTC = datetime(2026, 9, 4, tzinfo=timezone.utc)
+NOW = datetime(2026, 9, 30, 12, tzinfo=timezone.utc)
+PREREQUISITES = '["#5086", "#4699", "#4162", "#4703", "#4708", "#4163"]'
+WORK_COMMITS = {
+    "S1-0002": ("2" * 40, datetime(2026, 9, 2, 12, tzinfo=timezone.utc)),
+    "S1-0003": ("3" * 40, datetime(2026, 9, 8, 12, tzinfo=timezone.utc)),
+    "S1-0005": ("5" * 40, datetime(2026, 9, 15, 12, tzinfo=timezone.utc)),
+    "S1-0006": ("6" * 40, datetime(2026, 9, 22, 12, tzinfo=timezone.utc)),
+    "S1-0007": ("7" * 40, datetime(2026, 9, 15, 12, tzinfo=timezone.utc)),
+    "S1-0008": ("8" * 40, datetime(2026, 9, 22, 12, tzinfo=timezone.utc)),
+}
+
+
+def block(contents: str) -> str:
+    return f"\n```toml tenkz-soak-entry-v1\n[entry]\n{contents.strip()}\n```\n"
+
+
+def utc_text(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def freeze(
+    entry_id: str = "S1-0001",
+    *,
+    when: str = "2026-09-01",
+    attempt: int = 1,
+    sha: str = SHA,
+    tag_object: str = TAG_OBJECT,
+    tag: str = "tenkz-v0.9.0",
+    tagger_utc: str = "2026-09-01T00:00:00Z",
+    prerequisites: str = PREREQUISITES,
+) -> str:
+    return block(
+        f'''id = "{entry_id}"
+kind = "freeze"
+date = "{when}"
+author = "github:lionsr"
+attempt = {attempt}
+freeze_sha = "{sha}"
+freeze_tag_object = "{tag_object}"
+freeze_tag = "{tag}"
+freeze_tagger_utc = "{tagger_utc}"
+prerequisites = {prerequisites}
+evidence = "https://example.test/freeze"'''
+    )
+
+
+def work(
+    entry_id: str,
+    *,
+    attempt: int = 1,
+    sha: str | None = None,
+    committed_utc: datetime | None = None,
+    when: str | None = None,
+) -> str:
+    default_sha, default_time = WORK_COMMITS[entry_id]
+    work_sha = sha or default_sha
+    work_time = committed_utc or default_time
+    entry_date = when or work_time.date().isoformat()
+    return block(
+        f'''id = "{entry_id}"
+kind = "work"
+date = "{entry_date}"
+author = "github:blueprint-author"
+attempt = {attempt}
+work_sha = "{work_sha}"
+work_committed_utc = "{utc_text(work_time)}"
+summary = "ordinary blueprint diagram work"
+evidence = "https://example.test/{entry_id}"'''
+    )
+
+
+def friction(
+    entry_id: str,
+    when: str,
+    triage: str,
+    *,
+    attempt: int = 1,
+) -> str:
+    return block(
+        f'''id = "{entry_id}"
+kind = "friction"
+date = "{when}"
+author = "github:blueprint-author"
+attempt = {attempt}
+surface = "tex-api"
+triage = "{triage}"
+summary = "recorded interface friction"
+evidence = "https://example.test/{entry_id}"'''
+    )
+
+
+def resolution(entry_id: str, when: str, target: str, *, attempt: int = 1) -> str:
+    return block(
+        f'''id = "{entry_id}"
+kind = "resolution"
+date = "{when}"
+author = "github:lionsr"
+attempt = {attempt}
+friction = "{target}"
+summary = "compatible repair"
+evidence = "https://example.test/{entry_id}"'''
+    )
+
+
+def reset(entry_id: str, when: str, target: str, *, attempt: int = 1) -> str:
+    return block(
+        f'''id = "{entry_id}"
+kind = "reset"
+date = "{when}"
+author = "github:lionsr"
+attempt = {attempt}
+friction = "{target}"
+reason = "the documented surface needs a breaking change"
+evidence = "https://example.test/{entry_id}"'''
+    )
+
+
+def correction(entry_id: str, when: str, target: str, *, attempt: int = 1) -> str:
+    return block(
+        f'''id = "{entry_id}"
+kind = "correction"
+date = "{when}"
+author = "github:lionsr"
+attempt = {attempt}
+target = "{target}"
+summary = "additional explanatory evidence"
+evidence = "https://example.test/{entry_id}"'''
+    )
+
+
+def sign_off(
+    entry_id: str,
+    when: str,
+    work_ids: list[str],
+    *,
+    attempt: int = 1,
+    freeze_id: str = "S1-0001",
+    sha: str = SHA,
+    maintainer: str = "github:lionsr",
+    reviewer: str = "github:independent-reviewer",
+) -> str:
+    work_array = ", ".join(f'"{item}"' for item in work_ids)
+    return block(
+        f'''id = "{entry_id}"
+kind = "sign-off"
+date = "{when}"
+author = "github:lionsr"
+attempt = {attempt}
+freeze = "{freeze_id}"
+freeze_sha = "{sha}"
+release_tag = "tenkz-v1.0.0"
+maintainer = "{maintainer}"
+reviewer = "{reviewer}"
+work_evidence = [{work_array}]
+decision = "release"'''
+    )
+
+
+def parsed_entries(*blocks: str) -> list[dict]:
+    _schema, entries = policy.parse_soak_text(SOAK_TEXT + "".join(blocks))
+    return entries
+
+
+def expect_failure(action, fragment: str) -> None:
+    try:
+        action()
+    except policy.PolicyError as error:
+        assert fragment in str(error), (fragment, str(error))
+    else:
+        raise AssertionError(f"expected PolicyError containing {fragment!r}")
+
+
+def resolve_tag(tag: str) -> policy.TagEvidence:
+    return {
+        "tenkz-v0.9.0": policy.TagEvidence(
+            TAG_OBJECT, "tag", SHA, FREEZE_UTC, True
+        ),
+        "tenkz-v0.9.1": policy.TagEvidence(
+            SECOND_TAG_OBJECT, "tag", SECOND_SHA, SECOND_FREEZE_UTC, True
+        ),
+    }[tag]
+
+
+def resolve_commit(sha: str, _freeze_sha: str) -> policy.CommitEvidence:
+    if sha == SHA:
+        return policy.CommitEvidence("commit", FREEZE_UTC, True, True)
+    if sha == SECOND_SHA:
+        return policy.CommitEvidence("commit", SECOND_FREEZE_UTC, True, True)
+    committed = next(time for work_sha, time in WORK_COMMITS.values() if work_sha == sha)
+    return policy.CommitEvidence("commit", committed, True, True)
+
+
+def validate(entries: list[dict], **overrides) -> str:
+    arguments = {
+        "resolve_tag": resolve_tag,
+        "resolve_commit": resolve_commit,
+        "now": NOW,
+    }
+    arguments.update(overrides)
+    return policy.validate_entries(entries, **arguments)
+
+
+def complete_log() -> list[str]:
+    return [
+        freeze(),
+        work("S1-0002"),
+        work("S1-0003"),
+        friction("S1-0004", "2026-09-10", "fix-compatible"),
+        resolution("S1-0005", "2026-09-11", "S1-0004"),
+        friction("S1-0006", "2026-09-12", "defer-to-2.0"),
+        work("S1-0007"),
+        work("S1-0008"),
+        sign_off(
+            "S1-0009",
+            "2026-09-29",
+            ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
+        ),
+    ]
+
+
+def main() -> int:
+    assert policy.validate_policy_text(DESIGN_TEXT) == policy.EXPECTED_POLICY
+    _schema, empty_entries = policy.parse_soak_text(SOAK_TEXT)
+    assert policy.validate_entries(empty_entries) == "not-started"
+
+    signed_entries = parsed_entries(*complete_log())
+    assert validate(signed_entries) == "signed-off"
+
+    reset_entries = parsed_entries(
+        freeze(),
+        friction("S1-0002", "2026-09-02", "breaking-required"),
+        reset("S1-0003", "2026-09-02", "S1-0002"),
+        correction("S1-0004", "2026-09-03", "S1-0002"),
+        freeze(
+            "S1-0005",
+            when="2026-09-04",
+            attempt=2,
+            sha=SECOND_SHA,
+            tag_object=SECOND_TAG_OBJECT,
+            tag="tenkz-v0.9.1",
+            tagger_utc="2026-09-04T00:00:00Z",
+        ),
+    )
+    assert validate(reset_entries) == "attempt-2-active"
+
+    reused_freeze = parsed_entries(
+        freeze(),
+        friction("S1-0002", "2026-09-01", "breaking-required"),
+        reset("S1-0003", "2026-09-01", "S1-0002"),
+        freeze("S1-0004", when="2026-09-01", attempt=2),
+    )
+    expect_failure(lambda: validate(reused_freeze), "reuses a prior freeze tag")
+
+    reused_object = parsed_entries(
+        freeze(),
+        friction("S1-0002", "2026-09-01", "breaking-required"),
+        reset("S1-0003", "2026-09-01", "S1-0002"),
+        freeze(
+            "S1-0004",
+            when="2026-09-04",
+            attempt=2,
+            sha=SECOND_SHA,
+            tag_object=TAG_OBJECT,
+            tag="tenkz-v0.9.1",
+            tagger_utc="2026-09-04T00:00:00Z",
+        ),
+    )
+    expect_failure(lambda: validate(reused_object), "reuses a prior freeze tag object")
+
+    reused_commit = parsed_entries(
+        freeze(),
+        friction("S1-0002", "2026-09-01", "breaking-required"),
+        reset("S1-0003", "2026-09-01", "S1-0002"),
+        freeze(
+            "S1-0004",
+            when="2026-09-04",
+            attempt=2,
+            sha=SHA,
+            tag_object=SECOND_TAG_OBJECT,
+            tag="tenkz-v0.9.1",
+            tagger_utc="2026-09-04T00:00:00Z",
+        ),
+    )
+    expect_failure(lambda: validate(reused_commit), "reuses a prior freeze commit")
+
+    non_descending_freeze = lambda sha, _prior: policy.CommitEvidence(
+        "commit", SECOND_FREEZE_UTC if sha == SECOND_SHA else FREEZE_UTC, True, False
+    )
+    expect_failure(
+        lambda: validate(reset_entries, resolve_commit=non_descending_freeze),
+        "does not descend from the prior freeze",
+    )
+
+    expect_failure(
+        lambda: policy.validate_policy_text(
+            DESIGN_TEXT.replace('tag_namespace = "tenkz-v*"', 'tag_namespace = "v*"')
+        ),
+        "signed policy",
+    )
+    expect_failure(
+        lambda: policy.validate_policy_text(
+            DESIGN_TEXT.replace(
+                'frozen_twin_scope = "library-or-package-entry-point"',
+                'frozen_twin_scope = "spelling-level"',
+            )
+        ),
+        "signed policy",
+    )
+    expect_failure(
+        lambda: policy.validate_policy_text(
+            DESIGN_TEXT.replace('tnlog = "byte-stable"', 'tnlog = "best-effort"')
+        ),
+        "signed policy",
+    )
+    expect_failure(
+        lambda: policy.parse_soak_text(
+            SOAK_TEXT.replace("minimum_days = 28", "minimum_days = 27")
+        ),
+        "signed schema",
+    )
+    expect_failure(
+        lambda: policy.parse_soak_text(SOAK_TEXT + "free-form tail\n"),
+        "only soak entry blocks",
+    )
+
+    bad_prerequisites = parsed_entries(
+        freeze(prerequisites='["#5086", "#4699", "#4162", "#4703", "#4708"]')
+    )
+    expect_failure(lambda: validate(bad_prerequisites), "full blocker chain")
+    expect_failure(lambda: validate(parsed_entries(freeze(sha="abc"))), "invalid freeze_sha")
+    expect_failure(
+        lambda: validate(parsed_entries(freeze(tag="tenkz-v1.0.0"))),
+        "tenkz-v0.9.PATCH",
+    )
+
+    lightweight = lambda _tag: policy.TagEvidence(
+        SHA, "commit", SHA, None, True
+    )
+    expect_failure(
+        lambda: validate(parsed_entries(freeze()), resolve_tag=lightweight),
+        "not annotated",
+    )
+    replaced = lambda _tag: policy.TagEvidence(
+        SECOND_TAG_OBJECT, "tag", SHA, FREEZE_UTC, True
+    )
+    expect_failure(
+        lambda: validate(parsed_entries(freeze()), resolve_tag=replaced),
+        "object was replaced",
+    )
+    wrong_peeled_commit = lambda _tag: policy.TagEvidence(
+        TAG_OBJECT, "tag", SECOND_SHA, FREEZE_UTC, True
+    )
+    expect_failure(
+        lambda: validate(
+            parsed_entries(freeze()),
+            resolve_tag=wrong_peeled_commit,
+        ),
+        "peels to another commit",
+    )
+    unreachable_freeze = lambda _tag: policy.TagEvidence(
+        TAG_OBJECT, "tag", SHA, FREEZE_UTC, False
+    )
+    expect_failure(
+        lambda: validate(
+            parsed_entries(freeze()),
+            resolve_tag=unreachable_freeze,
+        ),
+        "freeze commit is not reachable from main",
+    )
+    expect_failure(
+        lambda: validate(parsed_entries(freeze(when="2026-08-31"))),
+        "differs from the tagger UTC date",
+    )
+    missing_freeze_time = lambda _sha, _prior: policy.CommitEvidence(
+        "commit", None, True, True
+    )
+    expect_failure(
+        lambda: validate(
+            parsed_entries(freeze()),
+            resolve_commit=missing_freeze_time,
+        ),
+        "freeze commit lacks a committer date",
+    )
+    postdated_freeze_commit = lambda _sha, _prior: policy.CommitEvidence(
+        "commit", datetime(2026, 9, 1, 0, 0, 1, tzinfo=timezone.utc), True, True
+    )
+    expect_failure(
+        lambda: validate(
+            parsed_entries(freeze()),
+            resolve_commit=postdated_freeze_commit,
+        ),
+        "freeze commit postdates the annotated tag",
+    )
+    future_utc = datetime(2026, 10, 1, tzinfo=timezone.utc)
+    future_tag = lambda _tag: policy.TagEvidence(
+        TAG_OBJECT, "tag", SHA, future_utc, True
+    )
+    expect_failure(
+        lambda: validate(
+            parsed_entries(
+                freeze(when="2026-10-01", tagger_utc="2026-10-01T00:00:00Z")
+            ),
+            resolve_tag=future_tag,
+        ),
+        "future",
+    )
+
+    fake_work_entries = parsed_entries(freeze(), work("S1-0002"))
+    fake_work = lambda sha, freeze_sha: (
+        resolve_commit(sha, freeze_sha)
+        if sha == SHA
+        else policy.CommitEvidence("missing", None, False, False)
+    )
+    expect_failure(
+        lambda: validate(fake_work_entries, resolve_commit=fake_work),
+        "not a commit",
+    )
+    non_main = lambda sha, freeze_sha: (
+        resolve_commit(sha, freeze_sha)
+        if sha == SHA
+        else policy.CommitEvidence(
+            "commit", resolve_commit(sha, freeze_sha).committed_utc, False, True
+        )
+    )
+    expect_failure(
+        lambda: validate(fake_work_entries, resolve_commit=non_main),
+        "not reachable from main",
+    )
+    not_descendant = lambda sha, freeze_sha: (
+        resolve_commit(sha, freeze_sha)
+        if sha == SHA
+        else policy.CommitEvidence(
+            "commit", resolve_commit(sha, freeze_sha).committed_utc, True, False
+        )
+    )
+    expect_failure(
+        lambda: validate(fake_work_entries, resolve_commit=not_descendant),
+        "does not descend from the freeze",
+    )
+    wrong_time = lambda sha, freeze_sha: (
+        resolve_commit(sha, freeze_sha)
+        if sha == SHA
+        else policy.CommitEvidence(
+            "commit", datetime(2026, 9, 3, tzinfo=timezone.utc), True, True
+        )
+    )
+    expect_failure(
+        lambda: validate(fake_work_entries, resolve_commit=wrong_time),
+        "differs from the commit object",
+    )
+
+    too_early = complete_log()
+    too_early[-1] = sign_off(
+        "S1-0009",
+        "2026-09-28",
+        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
+    )
+    expect_failure(
+        lambda: validate(
+            parsed_entries(*too_early),
+            now=datetime(2026, 9, 28, 12, tzinfo=timezone.utc),
+        ),
+        "current UTC is before 28 full days",
+    )
+    backdated_signoff = complete_log()
+    backdated_signoff[-1] = sign_off(
+        "S1-0009",
+        "2026-09-28",
+        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
+    )
+    expect_failure(
+        lambda: validate(parsed_entries(*backdated_signoff)),
+        "sign-off date is backdated",
+    )
+
+    missing_window = complete_log()
+    missing_window[-1] = sign_off(
+        "S1-0009",
+        "2026-09-29",
+        ["S1-0002", "S1-0003", "S1-0007"],
+    )
+    expect_failure(lambda: validate(parsed_entries(*missing_window)), "all four windows")
+
+    bad_maintainer = complete_log()
+    bad_maintainer[-1] = sign_off(
+        "S1-0009",
+        "2026-09-29",
+        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
+        maintainer="LionSR",
+    )
+    expect_failure(
+        lambda: validate(parsed_entries(*bad_maintainer)),
+        "github:lowercase-login",
+    )
+    bad_reviewer = complete_log()
+    bad_reviewer[-1] = sign_off(
+        "S1-0009",
+        "2026-09-29",
+        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
+        reviewer="github:Independent-Reviewer",
+    )
+    expect_failure(
+        lambda: validate(parsed_entries(*bad_reviewer)),
+        "github:lowercase-login",
+    )
+    same_signer = complete_log()
+    same_signer[-1] = sign_off(
+        "S1-0009",
+        "2026-09-29",
+        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
+        reviewer="github:lionsr",
+    )
+    expect_failure(lambda: validate(parsed_entries(*same_signer)), "independent")
+
+    breaking_without_reset = parsed_entries(
+        freeze(),
+        friction("S1-0002", "2026-09-02", "breaking-required"),
+        work("S1-0003"),
+    )
+    expect_failure(lambda: validate(breaking_without_reset), "followed immediately")
+
+    unresolved = parsed_entries(
+        freeze(),
+        work("S1-0002"),
+        work("S1-0003"),
+        friction("S1-0004", "2026-09-10", "fix-compatible"),
+        work("S1-0005"),
+        work("S1-0006"),
+        sign_off(
+            "S1-0007",
+            "2026-09-29",
+            ["S1-0002", "S1-0003", "S1-0005", "S1-0006"],
+        ),
+    )
+    expect_failure(lambda: validate(unresolved), "unresolved friction")
+
+    policy.check_append_only(SOAK_TEXT, SOAK_TEXT + freeze())
+    expect_failure(
+        lambda: policy.check_append_only(
+            SOAK_TEXT,
+            SOAK_TEXT.replace("append-only evidence", "rewritten evidence") + freeze(),
+        ),
+        "changed existing bytes",
+    )
+
+    invented_field = freeze().replace(
+        'evidence = "https://example.test/freeze"',
+        'evidence = "https://example.test/freeze"\ninvented = true',
+    )
+    expect_failure(
+        lambda: validate(parsed_entries(invented_field)),
+        "fields differ",
+    )
+
+    print("PASS: tenkz policy anchors tags, work, identities, and soak resets")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Perturbation tests for the tenkz compatibility and soak policy."""
+"""Perturbation tests for the pure tenkz release-evidence state machine."""
 
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timezone
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -16,86 +17,134 @@ import check_tenkz_policy as policy
 
 DESIGN_TEXT = (ROOT / "docs/tenkz/DESIGN.md").read_text(encoding="utf-8")
 SOAK_TEXT = (ROOT / "docs/tenkz/SOAK-1.0.md").read_text(encoding="utf-8")
+ACTIVATION = "#900"
+SOURCE = "#901"
+FREEZE_RECORD = "#902"
+FORMAL_WORK = "#903"
+FORMAL_RECORD = "#904"
+RMP_WORK = "#905"
+RMP_RECORD = "#906"
+SIGNOFF_RECORD = "#907"
+RELEASE_PREP = "#920"
 SHA = "a" * 40
-TAG_OBJECT = "c" * 40
-SECOND_SHA = "b" * 40
-SECOND_TAG_OBJECT = "d" * 40
-FREEZE_UTC = datetime(2026, 9, 1, tzinfo=timezone.utc)
-SECOND_FREEZE_UTC = datetime(2026, 9, 4, tzinfo=timezone.utc)
-NOW = datetime(2026, 9, 30, 12, tzinfo=timezone.utc)
+TAG_OBJECT = "b" * 40
+FINAL_TAG_OBJECT = "c" * 40
+FREEZE_TIME = datetime(2026, 9, 1, 12, 0, 10, tzinfo=timezone.utc)
+FORMAL_MERGE = FREEZE_TIME + timedelta(seconds=1)
+RMP_MERGE = FREEZE_TIME + timedelta(seconds=2)
+RELEASE_MERGE = FREEZE_TIME + timedelta(seconds=2, microseconds=500_000)
+SIGNOFF_REVIEW = FREEZE_TIME + timedelta(seconds=3)
+SIGNOFF_MERGE = FREEZE_TIME + timedelta(seconds=11)
 PREREQUISITES = '["#5086", "#4699", "#4162", "#4703", "#4708", "#4163"]'
-WORK_COMMITS = {
-    "S1-0002": ("2" * 40, datetime(2026, 9, 2, 12, tzinfo=timezone.utc)),
-    "S1-0003": ("3" * 40, datetime(2026, 9, 8, 12, tzinfo=timezone.utc)),
-    "S1-0005": ("5" * 40, datetime(2026, 9, 15, 12, tzinfo=timezone.utc)),
-    "S1-0006": ("6" * 40, datetime(2026, 9, 22, 12, tzinfo=timezone.utc)),
-    "S1-0007": ("7" * 40, datetime(2026, 9, 15, 12, tzinfo=timezone.utc)),
-    "S1-0008": ("8" * 40, datetime(2026, 9, 22, 12, tzinfo=timezone.utc)),
+INVENTORY_DIGEST = "d" * 64
+TEST_CODE_TREE = "e" * 40
+TEST_SUPPORT_TREE = "1" * 40
+POLICY_DIGEST = "f" * 64
+
+ARMED_POLICY = {
+    **policy.EXPECTED_POLICY,
+    "policy": {
+        **policy.EXPECTED_POLICY["policy"],
+        "enforcement": "armed",
+        "release_test_inventory_sha256": INVENTORY_DIGEST,
+        "release_test_code_tree": TEST_CODE_TREE,
+        "release_test_support_tree": TEST_SUPPORT_TREE,
+    },
 }
+ARMED_SOAK = {
+    **policy.EXPECTED_SOAK,
+    "soak": {
+        **policy.EXPECTED_SOAK["soak"],
+        "enforcement": "armed",
+        "policy_sha256": POLICY_DIGEST,
+        "armed_by_pr": ACTIVATION,
+    },
+}
+ARMED_DESIGN_TEXT = (
+    DESIGN_TEXT.replace('enforcement = "pending"', 'enforcement = "armed"', 1)
+    .replace(
+        'release_test_inventory_sha256 = "pending"',
+        f'release_test_inventory_sha256 = "{INVENTORY_DIGEST}"',
+        1,
+    )
+    .replace(
+        'release_test_code_tree = "pending"',
+        f'release_test_code_tree = "{TEST_CODE_TREE}"',
+        1,
+    )
+    .replace(
+        'release_test_support_tree = "pending"',
+        f'release_test_support_tree = "{TEST_SUPPORT_TREE}"',
+        1,
+    )
+)
+ARMED_SOAK_TEXT = (
+    SOAK_TEXT.replace('enforcement = "pending"', 'enforcement = "armed"', 1)
+    .replace('policy_sha256 = "pending"', f'policy_sha256 = "{POLICY_DIGEST}"', 1)
+    .replace('armed_by_pr = "pending"', f'armed_by_pr = "{ACTIVATION}"', 1)
+)
+
+
+def oid(number: int) -> str:
+    return f"{number:040x}"
+
+
+FREEZE_PAYLOAD_BLOBS = tuple(oid(10_000 + index) for index in range(6))
+FINAL_PAYLOAD_BLOBS = tuple(oid(20_000 + index) for index in range(6))
 
 
 def block(contents: str) -> str:
     return f"\n```toml tenkz-soak-entry-v1\n[entry]\n{contents.strip()}\n```\n"
 
 
-def utc_text(value: datetime) -> str:
-    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
 def freeze(
     entry_id: str = "S1-0001",
     *,
-    when: str = "2026-09-01",
+    record_pr: str = FREEZE_RECORD,
     attempt: int = 1,
-    sha: str = SHA,
+    source_pr: str = SOURCE,
+    source_sha: str = SHA,
     tag_object: str = TAG_OBJECT,
     tag: str = "tenkz-v0.9.0",
-    tagger_utc: str = "2026-09-01T00:00:00Z",
     prerequisites: str = PREREQUISITES,
 ) -> str:
     return block(
         f'''id = "{entry_id}"
 kind = "freeze"
-date = "{when}"
-author = "github:lionsr"
+record_pr = "{record_pr}"
 attempt = {attempt}
-freeze_sha = "{sha}"
+source_pr = "{source_pr}"
+source_sha = "{source_sha}"
 freeze_tag_object = "{tag_object}"
 freeze_tag = "{tag}"
-freeze_tagger_utc = "{tagger_utc}"
 prerequisites = {prerequisites}
-evidence = "https://example.test/freeze"'''
+evidence = "source, tag, and issue evidence"'''
     )
 
 
 def work(
     entry_id: str,
+    record_pr: str,
+    work_pr: str,
+    work_class: str,
     *,
     attempt: int = 1,
-    sha: str | None = None,
-    committed_utc: datetime | None = None,
-    when: str | None = None,
 ) -> str:
-    default_sha, default_time = WORK_COMMITS[entry_id]
-    work_sha = sha or default_sha
-    work_time = committed_utc or default_time
-    entry_date = when or work_time.date().isoformat()
     return block(
         f'''id = "{entry_id}"
 kind = "work"
-date = "{entry_date}"
-author = "github:blueprint-author"
+record_pr = "{record_pr}"
 attempt = {attempt}
-work_sha = "{work_sha}"
-work_committed_utc = "{utc_text(work_time)}"
-summary = "ordinary blueprint diagram work"
-evidence = "https://example.test/{entry_id}"'''
+work_pr = "{work_pr}"
+class = "{work_class}"
+summary = "ordinary qualifying work"
+evidence = "immutable PR evidence"'''
     )
 
 
 def friction(
     entry_id: str,
-    when: str,
+    record_pr: str,
     triage: str,
     *,
     attempt: int = 1,
@@ -103,86 +152,566 @@ def friction(
     return block(
         f'''id = "{entry_id}"
 kind = "friction"
-date = "{when}"
-author = "github:blueprint-author"
+record_pr = "{record_pr}"
 attempt = {attempt}
 surface = "tex-api"
 triage = "{triage}"
-summary = "recorded interface friction"
-evidence = "https://example.test/{entry_id}"'''
+summary = "observed interface friction"
+evidence = "reproducer and triage"'''
     )
 
 
-def resolution(entry_id: str, when: str, target: str, *, attempt: int = 1) -> str:
+def resolution(
+    entry_id: str,
+    record_pr: str,
+    target: str,
+    *,
+    attempt: int = 1,
+) -> str:
     return block(
         f'''id = "{entry_id}"
 kind = "resolution"
-date = "{when}"
-author = "github:lionsr"
+record_pr = "{record_pr}"
 attempt = {attempt}
 friction = "{target}"
 summary = "compatible repair"
-evidence = "https://example.test/{entry_id}"'''
+evidence = "merged repair evidence"'''
     )
 
 
-def reset(entry_id: str, when: str, target: str, *, attempt: int = 1) -> str:
+def reset(
+    entry_id: str,
+    record_pr: str,
+    cause: str,
+    target: str,
+    *,
+    attempt: int = 1,
+) -> str:
     return block(
         f'''id = "{entry_id}"
 kind = "reset"
-date = "{when}"
-author = "github:lionsr"
+record_pr = "{record_pr}"
 attempt = {attempt}
-friction = "{target}"
-reason = "the documented surface needs a breaking change"
-evidence = "https://example.test/{entry_id}"'''
+cause = "{cause}"
+target = "{target}"
+reason = "attempt evidence requires a new freeze"
+evidence = "verified reset cause"'''
     )
 
 
-def correction(entry_id: str, when: str, target: str, *, attempt: int = 1) -> str:
+def correction(
+    entry_id: str,
+    record_pr: str,
+    target: str,
+    *,
+    attempt: int = 1,
+) -> str:
     return block(
         f'''id = "{entry_id}"
 kind = "correction"
-date = "{when}"
-author = "github:lionsr"
+record_pr = "{record_pr}"
 attempt = {attempt}
 target = "{target}"
-summary = "additional explanatory evidence"
-evidence = "https://example.test/{entry_id}"'''
+summary = "additional explanation"
+evidence = "historical clarification"'''
     )
 
 
 def sign_off(
     entry_id: str,
-    when: str,
+    record_pr: str,
     work_ids: list[str],
     *,
     attempt: int = 1,
     freeze_id: str = "S1-0001",
-    sha: str = SHA,
-    maintainer: str = "github:lionsr",
-    reviewer: str = "github:independent-reviewer",
+    source_sha: str = SHA,
+    release_prep_pr: str = RELEASE_PREP,
+    reviewer: str = "github:release-reviewer",
 ) -> str:
     work_array = ", ".join(f'"{item}"' for item in work_ids)
     return block(
         f'''id = "{entry_id}"
 kind = "sign-off"
-date = "{when}"
-author = "github:lionsr"
+record_pr = "{record_pr}"
 attempt = {attempt}
 freeze = "{freeze_id}"
-freeze_sha = "{sha}"
+source_sha = "{source_sha}"
+release_prep_pr = "{release_prep_pr}"
 release_tag = "tenkz-v1.0.0"
-maintainer = "{maintainer}"
 reviewer = "{reviewer}"
 work_evidence = [{work_array}]
 decision = "release"'''
     )
 
 
+def review(
+    login: str,
+    submitted_at: datetime,
+    head: str,
+    *,
+    state: str = "APPROVED",
+    dismissed: bool = False,
+) -> policy.ReviewEvidence:
+    return policy.ReviewEvidence(login, state, submitted_at, head, dismissed)
+
+
+def merged_pr(
+    number: int,
+    merged_at: datetime,
+    *,
+    author: str = "author",
+    merger: str = "lionsr",
+    reviews: tuple[policy.ReviewEvidence, ...] = (),
+) -> policy.PullRequestEvidence:
+    return policy.PullRequestEvidence(
+        in_repository=True,
+        base_ref_name="main",
+        author_login=author,
+        head_oid=oid(number * 10),
+        merged=True,
+        merged_at=merged_at,
+        merged_by_login=merger,
+        merge_commit_oid=oid(number * 10 + 1),
+        reviews=reviews,
+        reviews_complete=True,
+        integration_reachable_from_main=True,
+        integration_tree_matches_head=True,
+        integration_strict_descendant_of_anchor=True,
+    )
+
+
+def candidate_pr(
+    number: int,
+    *,
+    author: str = "author",
+    reviews: tuple[policy.ReviewEvidence, ...] = (),
+) -> policy.PullRequestEvidence:
+    return policy.PullRequestEvidence(
+        in_repository=True,
+        base_ref_name="main",
+        author_login=author,
+        head_oid=oid(number * 10),
+        merged=False,
+        reviews=reviews,
+        reviews_complete=True,
+    )
+
+
+@dataclass
+class Context:
+    prs: dict[str, policy.PullRequestEvidence]
+    activation_diff: policy.ActivationDiffEvidence
+    records: dict[str, policy.RecordDiffEvidence]
+    work_diffs: dict[str, policy.WorkDiffEvidence]
+    release_preps: dict[str, policy.ReleasePrepEvidence]
+    payloads: dict[tuple[str, str], policy.ReleasePayloadEvidence]
+    tags: dict[str, policy.TagEvidence]
+    issues: dict[str, policy.IssueEvidence]
+
+    def resolve_replay_activation_diff(self, _ref: str) -> policy.ActivationDiffEvidence:
+        return self.activation_diff
+
+    def resolve_replay_pr(self, ref: str, _anchor: str | None) -> policy.PullRequestEvidence:
+        return self.prs[ref]
+
+    def resolve_replay_record_diff(
+        self,
+        entry_id: str,
+        _record_pr: str,
+        _source_sha: str | None,
+    ) -> policy.RecordDiffEvidence:
+        return self.records[entry_id]
+
+    def resolve_replay_work_diff(self, ref: str) -> policy.WorkDiffEvidence:
+        return self.work_diffs[ref]
+
+    def resolve_replay_release_prep(
+        self,
+        ref: str,
+        _paths: tuple[str, ...],
+        _work_integrations: tuple[str, ...],
+    ) -> policy.ReleasePrepEvidence:
+        return self.release_preps[ref]
+
+    def resolve_replay_release_payload(
+        self,
+        tree_oid: str,
+        tag: str,
+        _contract: policy.ReleaseContract,
+    ) -> policy.ReleasePayloadEvidence:
+        return self.payloads[(tree_oid, tag)]
+
+    def resolve_replay_freeze_tag(self, tag: str) -> policy.TagEvidence:
+        assert tag != policy.FINAL_TAG
+        return self.tags[tag]
+
+    def resolve_current_final_tag(self, tag: str) -> policy.TagEvidence:
+        assert tag == policy.FINAL_TAG
+        return self.tags[tag]
+
+    def resolve_replay_issue(self, issue: str) -> policy.IssueEvidence:
+        return self.issues[issue]
+
+
+def payload_evidence(
+    tree_oid: str,
+    tag: str,
+    blob_oids: tuple[str, ...],
+) -> policy.ReleasePayloadEvidence:
+    contract = policy.policy_rules(ARMED_POLICY)[4]
+    return policy.ReleasePayloadEvidence(
+        validated_tree_oid=tree_oid,
+        validated_tag=tag,
+        validated_contract=contract,
+        complete=True,
+        manifest_path=contract.manifest_path(tag),
+        regular_distinct_paths=True,
+        manifest_contract_valid=True,
+        artifact_declarations_agree=True,
+        inventory_digest_matches=True,
+        inventory_contract_valid=True,
+        test_code_tree_matches=True,
+        test_support_tree_matches=True,
+        inventory_data_paths_within_mutable_roots=True,
+        executable_dependencies_within_code_tree=True,
+        acceptance_dependencies_within_support_tree=True,
+        subject_data_cannot_reduce_coverage=True,
+        hermetic_execution_contract_valid=True,
+        payload_execution_receipts_complete_and_matching=True,
+        test_execution_complete=True,
+        compatibility_tests_passed=True,
+        payload_blob_oids=blob_oids,
+    )
+
+
+def context() -> Context:
+    activation_head = oid(9000)
+    formal_head = oid(9030)
+    rmp_head = oid(9050)
+    signoff_head = oid(9070)
+    release_head = oid(9200)
+    prs = {
+        ACTIVATION: merged_pr(
+            900,
+            FREEZE_TIME - timedelta(seconds=70),
+            author="policy-author",
+            reviews=(
+                review(
+                    "policy-reviewer",
+                    FREEZE_TIME - timedelta(seconds=80),
+                    activation_head,
+                ),
+            ),
+        ),
+        SOURCE: replace(
+            merged_pr(
+                901,
+                FREEZE_TIME - timedelta(seconds=20),
+                author="source-author",
+                reviews=(
+                    review(
+                        "source-reviewer",
+                        FREEZE_TIME - timedelta(seconds=21),
+                        oid(9010),
+                    ),
+                ),
+            ),
+            merge_commit_oid=SHA,
+        ),
+        FREEZE_RECORD: merged_pr(902, FREEZE_TIME, author="record-author"),
+        FORMAL_WORK: merged_pr(
+            903,
+            FORMAL_MERGE,
+            author="formal-author",
+            reviews=(
+                review(
+                    "formal-reviewer",
+                    FORMAL_MERGE - timedelta(microseconds=1),
+                    formal_head,
+                ),
+            ),
+        ),
+        FORMAL_RECORD: merged_pr(
+            904,
+            FREEZE_TIME + timedelta(seconds=5),
+            author="record-author",
+        ),
+        RMP_WORK: merged_pr(
+            905,
+            RMP_MERGE,
+            author="rmp-author",
+            reviews=(
+                review(
+                    "rmp-reviewer",
+                    RMP_MERGE - timedelta(microseconds=1),
+                    rmp_head,
+                ),
+            ),
+        ),
+        RMP_RECORD: merged_pr(
+            906,
+            FREEZE_TIME + timedelta(seconds=7),
+            author="record-author",
+        ),
+        RELEASE_PREP: merged_pr(
+            920,
+            RELEASE_MERGE,
+            author="release-prep-author",
+            reviews=(
+                review(
+                    "release-prep-reviewer",
+                    RELEASE_MERGE - timedelta(microseconds=1),
+                    release_head,
+                ),
+            ),
+        ),
+        SIGNOFF_RECORD: merged_pr(
+            907,
+            SIGNOFF_MERGE,
+            author="release-author",
+            reviews=(review("release-reviewer", SIGNOFF_REVIEW, signoff_head),),
+        ),
+    }
+    entry_records = {
+        "S1-0001": FREEZE_RECORD,
+        "S1-0002": FORMAL_RECORD,
+        "S1-0003": RMP_RECORD,
+        "S1-0004": SIGNOFF_RECORD,
+    }
+    activation_diff = policy.ActivationDiffEvidence(
+        validated_pr_ref=ACTIVATION,
+        validated_head_oid=activation_head,
+        complete=True,
+        candidate_main_is_ancestor_of_head=True,
+        unique_merge_base=True,
+        exact_seven_scalar_replacements=True,
+        inventory_digest_matches=True,
+        test_code_tree_matches=True,
+        test_support_tree_matches=True,
+        inventory_data_paths_within_mutable_roots=True,
+        executable_dependencies_within_code_tree=True,
+        acceptance_dependencies_within_support_tree=True,
+        subject_data_cannot_reduce_coverage=True,
+        hermetic_execution_contract_valid=True,
+        supervisor_self_test_receipt_valid=True,
+        policy_digest_matches=True,
+        ledger_prefix_matches=True,
+    )
+    records = {
+        entry_id: policy.RecordDiffEvidence(
+            validated_pr_ref=record_ref,
+            validated_head_oid=prs[record_ref].head_oid,
+            complete=True,
+            unique_merge_base=True,
+            integration_parent_count=1,
+            base_lacks_entry=True,
+            appends_exact_entry=True,
+            pinned_prefix_unchanged=True,
+            other_entries_unchanged=True,
+            no_other_path_changes=True,
+            candidate_main_is_ancestor_of_head=True,
+            integration_parent_is_ancestor_of_head=True,
+            integration_second_parent_matches_head=True,
+            source_to_head_is_exact_freeze_append=entry_id == "S1-0001",
+            candidate_main_tip_is_source=entry_id == "S1-0001",
+            integration_parent_is_source=entry_id == "S1-0001",
+            candidate_main_tip_is_release_integration=entry_id == "S1-0004",
+            integration_parent_is_release_integration=entry_id == "S1-0004",
+            validated_release_integration=(
+                prs[RELEASE_PREP].merge_commit_oid if entry_id == "S1-0004" else None
+            ),
+            validated_work_integrations=(
+                (
+                    prs[FORMAL_WORK].merge_commit_oid,
+                    prs[RMP_WORK].merge_commit_oid,
+                )
+                if entry_id == "S1-0004"
+                else None
+            ),
+        )
+        for entry_id, record_ref in entry_records.items()
+    }
+    work_diffs = {
+        FORMAL_WORK: policy.WorkDiffEvidence(
+            complete=True,
+            integration_parent_count=1,
+            unique_merge_base=True,
+            integration_parent_is_ancestor_of_head=True,
+            integration_second_parent_matches_head=True,
+            policy_paths_untouched=True,
+            excluded_paths_applied=True,
+            semantic_add_or_modify_classes=("formalization-or-blueprint",),
+            semantic_lean_changed=True,
+            semantic_blueprint_changed=False,
+            semantic_rmp_changed=False,
+            lean_modules_build=True,
+            proof_integrity_clean=True,
+            blueprint_checkdecls_passed=True,
+            blueprint_build_passed=True,
+            rmp_targets_resolved=True,
+            rmp_stages_complete=True,
+            rmp_checks_passed=True,
+        ),
+        RMP_WORK: policy.WorkDiffEvidence(
+            complete=True,
+            integration_parent_count=2,
+            unique_merge_base=True,
+            integration_parent_is_ancestor_of_head=True,
+            integration_second_parent_matches_head=True,
+            policy_paths_untouched=True,
+            excluded_paths_applied=True,
+            semantic_add_or_modify_classes=("rmp-benchmark",),
+            semantic_lean_changed=False,
+            semantic_blueprint_changed=False,
+            semantic_rmp_changed=True,
+            lean_modules_build=True,
+            proof_integrity_clean=True,
+            blueprint_checkdecls_passed=True,
+            blueprint_build_passed=True,
+            rmp_targets_resolved=True,
+            rmp_stages_complete=True,
+            rmp_checks_passed=True,
+        ),
+    }
+    work_integrations = (
+        prs[FORMAL_WORK].merge_commit_oid,
+        prs[RMP_WORK].merge_commit_oid,
+    )
+    assert all(isinstance(item, str) for item in work_integrations)
+    release_preps = {
+        RELEASE_PREP: policy.ReleasePrepEvidence(
+            validated_pr_ref=RELEASE_PREP,
+            validated_head_oid=release_head,
+            validated_manifest_path="docs/tenkz/releases/tenkz-v1.0.0.toml",
+            validated_changed_paths=policy.policy_rules(ARMED_POLICY)[4].release_varying_paths(
+                policy.FINAL_TAG
+            ),
+            validated_work_integrations=work_integrations,
+            complete=True,
+            integration_parent_count=1,
+            unique_merge_base=True,
+            integration_parent_is_ancestor_of_head=True,
+            integration_second_parent_matches_head=True,
+            integration_descends_from_work_integrations=True,
+            exact_release_varying_path_diff=True,
+        )
+    }
+    payloads = {
+        (SHA, "tenkz-v0.9.0"): payload_evidence(
+            SHA,
+            "tenkz-v0.9.0",
+            FREEZE_PAYLOAD_BLOBS,
+        ),
+        (release_head, policy.FINAL_TAG): payload_evidence(
+            release_head,
+            policy.FINAL_TAG,
+            FINAL_PAYLOAD_BLOBS,
+        ),
+        (signoff_head, policy.FINAL_TAG): payload_evidence(
+            signoff_head,
+            policy.FINAL_TAG,
+            FINAL_PAYLOAD_BLOBS,
+        ),
+        (oid(9071), policy.FINAL_TAG): payload_evidence(
+            oid(9071),
+            policy.FINAL_TAG,
+            FINAL_PAYLOAD_BLOBS,
+        ),
+    }
+    issues = {
+        issue: policy.IssueEvidence(
+            True,
+            True,
+            FREEZE_TIME - timedelta(seconds=100),
+        )
+        for issue in ("#5086", "#4699", "#4162", "#4703", "#4708", "#4163")
+    }
+    return Context(
+        prs,
+        activation_diff,
+        records,
+        work_diffs,
+        release_preps,
+        payloads,
+        {
+            "tenkz-v0.9.0": policy.TagEvidence(TAG_OBJECT, "tag", SHA, True),
+            policy.FINAL_TAG: policy.TagEvidence(None, None, None, exists=False),
+        },
+        issues,
+    )
+
+
 def parsed_entries(*blocks: str) -> list[dict]:
-    _schema, entries = policy.parse_soak_text(SOAK_TEXT + "".join(blocks))
+    _schema, entries = policy.parse_soak_text(ARMED_SOAK_TEXT + "".join(blocks))
     return entries
+
+
+def audit_evidence(
+    boundary: str | None,
+    invalid_entries: tuple[str, ...] = (),
+) -> policy.AuditEvidence:
+    return policy.AuditEvidence(boundary, invalid_entries, True, True)
+
+
+def protected_tags() -> policy.TagProtectionEvidence:
+    return policy.TagProtectionEvidence(
+        repository_rulesets_complete=True,
+        organization_rulesets_complete=True,
+        credential_has_write_visibility=True,
+        details_unredacted=True,
+        namespace_fully_covered=True,
+        applicable_rulesets_active=True,
+        updates_forbidden=True,
+        deletions_forbidden=True,
+        bypass_actors=(),
+        unambiguous=True,
+    )
+
+
+def validate(blocks: list[str], facts: Context, **overrides) -> str:
+    entries = parsed_entries(*blocks)
+    if "audit" not in overrides:
+        boundary: str | None = None
+        for entry in entries:
+            record = facts.prs.get(entry["record_pr"])
+            if record is None or record.merged is not True:
+                break
+            boundary = entry["id"]
+        overrides["audit"] = audit_evidence(boundary)
+    arguments = {
+        "policy": ARMED_POLICY,
+        "soak": ARMED_SOAK,
+        "resolve_replay_pr": facts.resolve_replay_pr,
+        "resolve_replay_activation_diff": facts.resolve_replay_activation_diff,
+        "resolve_replay_record_diff": facts.resolve_replay_record_diff,
+        "resolve_replay_work_diff": facts.resolve_replay_work_diff,
+        "resolve_replay_release_prep": facts.resolve_replay_release_prep,
+        "resolve_replay_release_payload": facts.resolve_replay_release_payload,
+        "resolve_replay_freeze_tag": facts.resolve_replay_freeze_tag,
+        "resolve_current_final_tag": facts.resolve_current_final_tag,
+        "resolve_replay_issue": facts.resolve_replay_issue,
+        "tag_protection": protected_tags(),
+    }
+    arguments.update(overrides)
+    return policy.validate_entries(entries, **arguments)
+
+
+def complete_log() -> list[str]:
+    return [
+        freeze(),
+        work(
+            "S1-0002",
+            FORMAL_RECORD,
+            FORMAL_WORK,
+            "formalization-or-blueprint",
+        ),
+        work("S1-0003", RMP_RECORD, RMP_WORK, "rmp-benchmark"),
+        sign_off(
+            "S1-0004",
+            SIGNOFF_RECORD,
+            ["S1-0002", "S1-0003"],
+        ),
+    ]
 
 
 def expect_failure(action, fragment: str) -> None:
@@ -194,461 +723,1648 @@ def expect_failure(action, fragment: str) -> None:
         raise AssertionError(f"expected PolicyError containing {fragment!r}")
 
 
-def resolve_tag(tag: str) -> policy.TagEvidence:
-    return {
-        "tenkz-v0.9.0": policy.TagEvidence(
-            TAG_OBJECT, "tag", SHA, FREEZE_UTC, True
+def add_record(
+    facts: Context,
+    entry_id: str,
+    record_ref: str,
+    number: int,
+    merged_at: datetime,
+    *,
+    invalid_tree: bool = False,
+    freeze_entry: bool = False,
+) -> None:
+    facts.prs[record_ref] = replace(
+        merged_pr(number, merged_at, author="record-author"),
+        integration_tree_matches_head=not invalid_tree,
+    )
+    facts.records[entry_id] = policy.RecordDiffEvidence(
+        validated_pr_ref=record_ref,
+        validated_head_oid=facts.prs[record_ref].head_oid,
+        complete=True,
+        unique_merge_base=True,
+        integration_parent_count=1,
+        base_lacks_entry=True,
+        appends_exact_entry=True,
+        pinned_prefix_unchanged=True,
+        other_entries_unchanged=True,
+        no_other_path_changes=True,
+        candidate_main_is_ancestor_of_head=True,
+        integration_parent_is_ancestor_of_head=True,
+        integration_second_parent_matches_head=True,
+        source_to_head_is_exact_freeze_append=freeze_entry,
+        candidate_main_tip_is_source=freeze_entry,
+        integration_parent_is_source=freeze_entry,
+    )
+
+
+def add_freeze_facts(
+    facts: Context,
+    entry_id: str,
+    *,
+    source_ref: str,
+    source_number: int,
+    source_sha: str,
+    record_ref: str,
+    record_number: int,
+    tag: str,
+    tag_object: str,
+    merged_at: datetime,
+) -> None:
+    source_time = merged_at - timedelta(seconds=1)
+    facts.prs[source_ref] = replace(
+        merged_pr(
+            source_number,
+            source_time,
+            reviews=(
+                review(
+                    f"source-reviewer-{source_number}",
+                    source_time - timedelta(microseconds=1),
+                    oid(source_number * 10),
+                ),
+            ),
         ),
-        "tenkz-v0.9.1": policy.TagEvidence(
-            SECOND_TAG_OBJECT, "tag", SECOND_SHA, SECOND_FREEZE_UTC, True
-        ),
-    }[tag]
-
-
-def resolve_commit(sha: str, _freeze_sha: str) -> policy.CommitEvidence:
-    if sha == SHA:
-        return policy.CommitEvidence("commit", FREEZE_UTC, True, True)
-    if sha == SECOND_SHA:
-        return policy.CommitEvidence("commit", SECOND_FREEZE_UTC, True, True)
-    committed = next(time for work_sha, time in WORK_COMMITS.values() if work_sha == sha)
-    return policy.CommitEvidence("commit", committed, True, True)
-
-
-def validate(entries: list[dict], **overrides) -> str:
-    arguments = {
-        "resolve_tag": resolve_tag,
-        "resolve_commit": resolve_commit,
-        "now": NOW,
-    }
-    arguments.update(overrides)
-    return policy.validate_entries(entries, **arguments)
-
-
-def complete_log() -> list[str]:
-    return [
-        freeze(),
-        work("S1-0002"),
-        work("S1-0003"),
-        friction("S1-0004", "2026-09-10", "fix-compatible"),
-        resolution("S1-0005", "2026-09-11", "S1-0004"),
-        friction("S1-0006", "2026-09-12", "defer-to-2.0"),
-        work("S1-0007"),
-        work("S1-0008"),
-        sign_off(
-            "S1-0009",
-            "2026-09-29",
-            ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
-        ),
-    ]
+        merge_commit_oid=source_sha,
+    )
+    add_record(
+        facts,
+        entry_id,
+        record_ref,
+        record_number,
+        merged_at,
+        freeze_entry=True,
+    )
+    facts.tags[tag] = policy.TagEvidence(tag_object, "tag", source_sha, True)
+    facts.payloads[(source_sha, tag)] = payload_evidence(
+        source_sha,
+        tag,
+        tuple(oid(30_000 + source_number * 10 + index) for index in range(6)),
+    )
 
 
 def main() -> int:
     assert policy.validate_policy_text(DESIGN_TEXT) == policy.EXPECTED_POLICY
-    _schema, empty_entries = policy.parse_soak_text(SOAK_TEXT)
+    schema, empty_entries = policy.parse_soak_text(SOAK_TEXT)
+    assert schema == policy.EXPECTED_SOAK
     assert policy.validate_entries(empty_entries) == "not-started"
-
-    signed_entries = parsed_entries(*complete_log())
-    assert validate(signed_entries) == "signed-off"
-
-    reset_entries = parsed_entries(
-        freeze(),
-        friction("S1-0002", "2026-09-02", "breaking-required"),
-        reset("S1-0003", "2026-09-02", "S1-0002"),
-        correction("S1-0004", "2026-09-03", "S1-0002"),
-        freeze(
-            "S1-0005",
-            when="2026-09-04",
-            attempt=2,
-            sha=SECOND_SHA,
-            tag_object=SECOND_TAG_OBJECT,
-            tag="tenkz-v0.9.1",
-            tagger_utc="2026-09-04T00:00:00Z",
-        ),
-    )
-    assert validate(reset_entries) == "attempt-2-active"
-
-    reused_freeze = parsed_entries(
-        freeze(),
-        friction("S1-0002", "2026-09-01", "breaking-required"),
-        reset("S1-0003", "2026-09-01", "S1-0002"),
-        freeze("S1-0004", when="2026-09-01", attempt=2),
-    )
-    expect_failure(lambda: validate(reused_freeze), "reuses a prior freeze tag")
-
-    reused_object = parsed_entries(
-        freeze(),
-        friction("S1-0002", "2026-09-01", "breaking-required"),
-        reset("S1-0003", "2026-09-01", "S1-0002"),
-        freeze(
-            "S1-0004",
-            when="2026-09-04",
-            attempt=2,
-            sha=SECOND_SHA,
-            tag_object=TAG_OBJECT,
-            tag="tenkz-v0.9.1",
-            tagger_utc="2026-09-04T00:00:00Z",
-        ),
-    )
-    expect_failure(lambda: validate(reused_object), "reuses a prior freeze tag object")
-
-    reused_commit = parsed_entries(
-        freeze(),
-        friction("S1-0002", "2026-09-01", "breaking-required"),
-        reset("S1-0003", "2026-09-01", "S1-0002"),
-        freeze(
-            "S1-0004",
-            when="2026-09-04",
-            attempt=2,
-            sha=SHA,
-            tag_object=SECOND_TAG_OBJECT,
-            tag="tenkz-v0.9.1",
-            tagger_utc="2026-09-04T00:00:00Z",
-        ),
-    )
-    expect_failure(lambda: validate(reused_commit), "reuses a prior freeze commit")
-
-    non_descending_freeze = lambda sha, _prior: policy.CommitEvidence(
-        "commit", SECOND_FREEZE_UTC if sha == SECOND_SHA else FREEZE_UTC, True, False
+    assert policy.validate_policy_text(ARMED_DESIGN_TEXT) == ARMED_POLICY
+    armed_schema, armed_empty_entries = policy.parse_soak_text(ARMED_SOAK_TEXT)
+    assert armed_schema["soak"]["enforcement"] == "armed"
+    assert armed_schema["soak"]["policy_sha256"] == POLICY_DIGEST
+    assert armed_schema["soak"]["armed_by_pr"] == ACTIVATION
+    assert armed_schema == ARMED_SOAK
+    assert armed_empty_entries == []
+    assert validate([], context()) == "not-started"
+    empty_mixed_activation = context()
+    empty_mixed_activation.activation_diff = replace(
+        empty_mixed_activation.activation_diff,
+        exact_seven_scalar_replacements=False,
     )
     expect_failure(
-        lambda: validate(reset_entries, resolve_commit=non_descending_freeze),
-        "does not descend from the prior freeze",
+        lambda: validate([], empty_mixed_activation),
+        "not exactly the seven permitted scalar replacements",
+    )
+    expect_failure(
+        lambda: validate(
+            [freeze()],
+            context(),
+            policy=policy.EXPECTED_POLICY,
+            soak=policy.EXPECTED_SOAK,
+        ),
+        "entries require armed policy enforcement",
+    )
+    assert "minimum_days" not in schema["soak"]
+    assert "work_classes" not in schema["soak"]
+    assert "work_excluded_paths" not in schema["soak"]
+    assert policy.EXPECTED_POLICY["policy"]["work_excluded_paths"] == [
+        "TNLean/Archive/**"
+    ]
+    assert "event_format_implementation" not in policy.EXPECTED_POLICY["policy"]
+
+    # Both qualifying merges, the sign-off review, and sign-off merge occur in
+    # one minute.  Strict event ordering, not elapsed calendar time, is enough.
+    assert validate(complete_log(), context()) == "signed-off-awaiting-tag"
+
+    candidate = context()
+    candidate_head = candidate.prs[SIGNOFF_RECORD].head_oid
+    assert candidate_head is not None
+    candidate.prs[SIGNOFF_RECORD] = candidate_pr(
+        907,
+        author="release-author",
+        reviews=(
+            review(
+                "release-reviewer",
+                SIGNOFF_REVIEW,
+                candidate_head,
+            ),
+        ),
+    )
+    assert validate(complete_log(), candidate) == "sign-off-pending"
+
+    released = context()
+    released.tags[policy.FINAL_TAG] = policy.TagEvidence(
+        FINAL_TAG_OBJECT,
+        "tag",
+        oid(9071),
+        exists=True,
+        validated_entry_id="S1-0004",
+        validated_record_pr=SIGNOFF_RECORD,
+        commit_is_validated_record_integration=True,
+    )
+    assert validate(complete_log(), released) == "released"
+
+    # The current-validity audit runs forever while replay callbacks retain the
+    # integration-time history.  Before the tag, drift enters the reset queue;
+    # once a final-tag ref exists it is a hard incident and never reopens it.
+    expect_failure(
+        lambda: validate(
+            complete_log(),
+            released,
+            audit=audit_evidence("S1-0004", ("S1-0004",)),
+        ),
+        "final tag exists while release evidence requires reset",
+    )
+    expect_failure(
+        lambda: validate(
+            complete_log(),
+            released,
+            tag_protection=replace(protected_tags(), updates_forbidden=False),
+        ),
+        "tag updates are not forbidden",
+    )
+    expect_failure(
+        lambda: validate(
+            complete_log(),
+            released,
+            tag_protection=replace(protected_tags(), details_unredacted=False),
+        ),
+        "omitted or redacted",
+    )
+    expect_failure(
+        lambda: validate(
+            complete_log(),
+            released,
+            tag_protection=replace(protected_tags(), bypass_actors=("admin",)),
+        ),
+        "has a bypass actor",
+    )
+    expect_failure(
+        lambda: validate(
+            complete_log(),
+            released,
+            tag_protection=replace(protected_tags(), bypass_actors=None),
+        ),
+        "bypass actors are unavailable",
+    )
+    expect_failure(
+        lambda: validate(
+            complete_log(),
+            released,
+            tag_protection=replace(protected_tags(), organization_rulesets_complete=False),
+        ),
+        "organization ruleset pagination is incomplete",
     )
 
-    first_reset_freeze_utc = datetime(2026, 9, 1, 12, tzinfo=timezone.utc)
-    for second_reset_freeze_utc in (
-        datetime(2026, 9, 1, 11, tzinfo=timezone.utc),
-        first_reset_freeze_utc,
-    ):
-        nonincreasing_reset_entries = parsed_entries(
-            freeze(tagger_utc=utc_text(first_reset_freeze_utc)),
-            friction("S1-0002", "2026-09-01", "breaking-required"),
-            reset("S1-0003", "2026-09-01", "S1-0002"),
-            freeze(
-                "S1-0004",
-                when="2026-09-01",
-                attempt=2,
-                sha=SECOND_SHA,
-                tag_object=SECOND_TAG_OBJECT,
-                tag="tenkz-v0.9.1",
-                tagger_utc=utc_text(second_reset_freeze_utc),
-            ),
+    unclassified_released_drift = context()
+    unclassified_released_drift.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    unclassified_released_drift.prs[SIGNOFF_RECORD] = replace(
+        unclassified_released_drift.prs[SIGNOFF_RECORD],
+        reviews_complete=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), unclassified_released_drift),
+        "final tag exists while release evidence requires reset",
+    )
+
+    lightweight_final = context()
+    lightweight_final.tags[policy.FINAL_TAG] = policy.TagEvidence(
+        FINAL_TAG_OBJECT,
+        "commit",
+        oid(9071),
+        exists=True,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), lightweight_final),
+        "final release tag is not annotated",
+    )
+    replay_before_tag_check = context()
+    replay_before_tag_check.tags[policy.FINAL_TAG] = lightweight_final.tags[policy.FINAL_TAG]
+    replay_before_tag_check.activation_diff = replace(
+        replay_before_tag_check.activation_diff,
+        exact_seven_scalar_replacements=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), replay_before_tag_check),
+        "not exactly the seven permitted scalar replacements",
+    )
+
+    wrong_final_target = context()
+    wrong_final_target.tags[policy.FINAL_TAG] = policy.TagEvidence(
+        FINAL_TAG_OBJECT,
+        "tag",
+        oid(9991),
+        exists=True,
+        validated_entry_id="S1-0004",
+        validated_record_pr=SIGNOFF_RECORD,
+        commit_is_validated_record_integration=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), wrong_final_target),
+        "does not target the validated sign-off integration",
+    )
+
+    premature_final = context()
+    premature_final.tags[policy.FINAL_TAG] = policy.TagEvidence(
+        FINAL_TAG_OBJECT,
+        "tag",
+        oid(9071),
+        exists=True,
+        validated_entry_id="S1-0004",
+        validated_record_pr=SIGNOFF_RECORD,
+        commit_is_validated_record_integration=True,
+    )
+    expect_failure(
+        lambda: validate(complete_log()[:3], premature_final),
+        "without a successfully validated sign-off",
+    )
+
+    inconsistent_absent = context()
+    inconsistent_absent.tags[policy.FINAL_TAG] = replace(
+        inconsistent_absent.tags[policy.FINAL_TAG],
+        validated_entry_id="S1-0004",
+    )
+    expect_failure(
+        lambda: validate(complete_log(), inconsistent_absent),
+        "absent final-tag evidence is inconsistent",
+    )
+
+    forged_release = context()
+    forged_release.records["S1-0003"] = replace(
+        forged_release.records["S1-0004"],
+        validated_pr_ref=SIGNOFF_RECORD,
+        validated_head_oid=forged_release.prs[SIGNOFF_RECORD].head_oid,
+    )
+    forged_release.tags[policy.FINAL_TAG] = replace(
+        released.tags[policy.FINAL_TAG],
+        validated_entry_id="S1-0003",
+    )
+    forged_log = [
+        freeze(),
+        work(
+            "S1-0002",
+            FORMAL_RECORD,
+            FORMAL_WORK,
+            "formalization-or-blueprint",
+        ),
+        sign_off("S1-0003", SIGNOFF_RECORD, ["S1-0002"]),
+    ]
+    expect_failure(
+        lambda: validate(forged_log, forged_release),
+        "lacks one work class",
+    )
+
+    incomplete_audit = policy.AuditEvidence("S1-0004", (), False, True)
+    expect_failure(
+        lambda: validate(complete_log(), context(), audit=incomplete_audit),
+        "audit snapshot is incomplete",
+    )
+    inexact_target_audit = policy.AuditEvidence("S1-0004", (), True, False)
+    expect_failure(
+        lambda: validate(complete_log(), context(), audit=inexact_target_audit),
+        "audit validation target is not exact",
+    )
+
+    mixed_activation = context()
+    mixed_activation.activation_diff = replace(
+        mixed_activation.activation_diff,
+        exact_seven_scalar_replacements=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], mixed_activation),
+        "not exactly the seven permitted scalar replacements",
+    )
+
+    wrong_activation_code_tree = context()
+    wrong_activation_code_tree.activation_diff = replace(
+        wrong_activation_code_tree.activation_diff,
+        test_code_tree_matches=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], wrong_activation_code_tree),
+        "activation test-code tree is wrong",
+    )
+    wrong_activation_support_tree = context()
+    wrong_activation_support_tree.activation_diff = replace(
+        wrong_activation_support_tree.activation_diff,
+        test_support_tree_matches=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], wrong_activation_support_tree),
+        "activation test-support tree is wrong",
+    )
+    activation_subject_controls_coverage = context()
+    activation_subject_controls_coverage.activation_diff = replace(
+        activation_subject_controls_coverage.activation_diff,
+        subject_data_cannot_reduce_coverage=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], activation_subject_controls_coverage),
+        "subject data can reduce release-test coverage",
+    )
+    activation_unhermetic = context()
+    activation_unhermetic.activation_diff = replace(
+        activation_unhermetic.activation_diff,
+        hermetic_execution_contract_valid=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], activation_unhermetic),
+        "hermetic execution contract is invalid",
+    )
+    invalid_supervisor_receipt = context()
+    invalid_supervisor_receipt.activation_diff = replace(
+        invalid_supervisor_receipt.activation_diff,
+        supervisor_self_test_receipt_valid=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], invalid_supervisor_receipt),
+        "supervisor self-test receipt is invalid",
+    )
+
+    unapproved_source = context()
+    unapproved_source.prs[SOURCE] = replace(
+        unapproved_source.prs[SOURCE],
+        reviews=(),
+    )
+    assert validate([freeze()], unapproved_source) == "reset-required:S1-0001"
+
+    source_tree_mismatch = context()
+    source_tree_mismatch.prs[SOURCE] = replace(
+        source_tree_mismatch.prs[SOURCE],
+        integration_tree_matches_head=False,
+    )
+    assert validate([freeze()], source_tree_mismatch) == "reset-required:S1-0001"
+
+    bad_freeze_payload = context()
+    bad_freeze_payload.payloads[(SHA, "tenkz-v0.9.0")] = replace(
+        bad_freeze_payload.payloads[(SHA, "tenkz-v0.9.0")],
+        compatibility_tests_passed=False,
+    )
+    assert validate([freeze()], bad_freeze_payload) == "reset-required:S1-0001"
+
+    bad_release_payload = context()
+    bad_release_payload.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
+        bad_release_payload.payloads[(oid(9200), policy.FINAL_TAG)],
+        inventory_contract_valid=False,
+    )
+    assert (
+        validate(complete_log(), bad_release_payload)
+        == "reset-required:S1-0004"
+    )
+
+    changed_test_code = context()
+    changed_test_code.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
+        changed_test_code.payloads[(oid(9200), policy.FINAL_TAG)],
+        test_code_tree_matches=False,
+    )
+    assert (
+        validate(complete_log(), changed_test_code)
+        == "reset-required:S1-0004"
+    )
+
+    changed_test_support = context()
+    changed_test_support.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
+        changed_test_support.payloads[(oid(9200), policy.FINAL_TAG)],
+        test_support_tree_matches=False,
+    )
+    assert (
+        validate(complete_log(), changed_test_support)
+        == "reset-required:S1-0004"
+    )
+
+    undeclared_subject_data = context()
+    undeclared_subject_data.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
+        undeclared_subject_data.payloads[(oid(9200), policy.FINAL_TAG)],
+        inventory_data_paths_within_mutable_roots=False,
+    )
+    assert (
+        validate(complete_log(), undeclared_subject_data)
+        == "reset-required:S1-0004"
+    )
+
+    acceptance_from_subject = context()
+    acceptance_from_subject.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
+        acceptance_from_subject.payloads[(oid(9200), policy.FINAL_TAG)],
+        acceptance_dependencies_within_support_tree=False,
+    )
+    assert (
+        validate(complete_log(), acceptance_from_subject)
+        == "reset-required:S1-0004"
+    )
+
+    executable_from_subject = context()
+    executable_from_subject.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
+        executable_from_subject.payloads[(oid(9200), policy.FINAL_TAG)],
+        executable_dependencies_within_code_tree=False,
+    )
+    assert (
+        validate(complete_log(), executable_from_subject)
+        == "reset-required:S1-0004"
+    )
+
+    subject_reduces_coverage = context()
+    subject_reduces_coverage.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
+        subject_reduces_coverage.payloads[(oid(9200), policy.FINAL_TAG)],
+        subject_data_cannot_reduce_coverage=False,
+    )
+    assert (
+        validate(complete_log(), subject_reduces_coverage)
+        == "reset-required:S1-0004"
+    )
+
+    mismatched_receipt = context()
+    mismatched_receipt.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
+        mismatched_receipt.payloads[(oid(9200), policy.FINAL_TAG)],
+        payload_execution_receipts_complete_and_matching=False,
+    )
+    assert (
+        validate(complete_log(), mismatched_receipt)
+        == "reset-required:S1-0004"
+    )
+
+    changed_signoff_payload = context()
+    changed_signoff_payload.payloads[(oid(9070), policy.FINAL_TAG)] = replace(
+        changed_signoff_payload.payloads[(oid(9070), policy.FINAL_TAG)],
+        payload_blob_oids=tuple(oid(21_000 + index) for index in range(6)),
+    )
+    assert (
+        validate(complete_log(), changed_signoff_payload)
+        == "reset-required:S1-0004"
+    )
+
+    failing_integration_payload = context()
+    failing_integration_payload.payloads[(oid(9071), policy.FINAL_TAG)] = replace(
+        failing_integration_payload.payloads[(oid(9071), policy.FINAL_TAG)],
+        test_execution_complete=False,
+    )
+    assert (
+        validate(complete_log(), failing_integration_payload)
+        == "reset-required:S1-0004"
+    )
+
+    unprepared = context()
+    unprepared.release_preps[RELEASE_PREP] = replace(
+        unprepared.release_preps[RELEASE_PREP],
+        exact_release_varying_path_diff=False,
+    )
+    assert validate(complete_log(), unprepared) == "reset-required:S1-0004"
+
+    unprepared_candidate = context()
+    signoff = unprepared_candidate.prs[SIGNOFF_RECORD]
+    assert signoff.head_oid is not None
+    unprepared_candidate.prs[SIGNOFF_RECORD] = candidate_pr(
+        907,
+        author="release-author",
+        reviews=(review("release-reviewer", SIGNOFF_REVIEW, signoff.head_oid),),
+    )
+    unprepared_candidate.release_preps[RELEASE_PREP] = replace(
+        unprepared_candidate.release_preps[RELEASE_PREP],
+        exact_release_varying_path_diff=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), unprepared_candidate),
+        "release diff is not exactly the policy-owned payload",
+    )
+
+    non_atomic_candidate = context()
+    non_atomic_candidate.records["S1-0004"] = replace(
+        non_atomic_candidate.records["S1-0004"],
+        candidate_main_tip_is_release_integration=False,
+    )
+    assert (
+        validate(complete_log(), non_atomic_candidate)
+        == "reset-required:S1-0004"
+    )
+
+    non_atomic_pending = context()
+    pending_head = non_atomic_pending.prs[SIGNOFF_RECORD].head_oid
+    assert pending_head is not None
+    non_atomic_pending.prs[SIGNOFF_RECORD] = candidate_pr(
+        907,
+        author="release-author",
+        reviews=(review("release-reviewer", SIGNOFF_REVIEW, pending_head),),
+    )
+    non_atomic_pending.records["S1-0004"] = replace(
+        non_atomic_pending.records["S1-0004"],
+        candidate_main_tip_is_release_integration=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), non_atomic_pending),
+        "candidate main tip differs from release integration",
+    )
+
+    non_atomic_merge = context()
+    non_atomic_merge.records["S1-0004"] = replace(
+        non_atomic_merge.records["S1-0004"],
+        integration_parent_is_release_integration=False,
+    )
+    assert validate(complete_log(), non_atomic_merge) == "reset-required:S1-0004"
+
+    release_wrong_ancestry = context()
+    release_wrong_ancestry.release_preps[RELEASE_PREP] = replace(
+        release_wrong_ancestry.release_preps[RELEASE_PREP],
+        integration_descends_from_work_integrations=False,
+    )
+    assert (
+        validate(complete_log(), release_wrong_ancestry)
+        == "reset-required:S1-0004"
+    )
+
+    release_wrong_paths = context()
+    release_wrong_paths.release_preps[RELEASE_PREP] = replace(
+        release_wrong_paths.release_preps[RELEASE_PREP],
+        validated_changed_paths=("docs/tenkz/releases/tenkz-v1.0.0.toml",),
+    )
+    assert (
+        validate(complete_log(), release_wrong_paths)
+        == "reset-required:S1-0004"
+    )
+
+    for submitted in (RMP_MERGE, RMP_MERGE - timedelta(microseconds=1)):
+        too_early = context()
+        signoff_pr = too_early.prs[SIGNOFF_RECORD]
+        assert signoff_pr.head_oid is not None
+        too_early.prs[SIGNOFF_RECORD] = replace(
+            signoff_pr,
+            reviews=(review("release-reviewer", submitted, signoff_pr.head_oid),),
         )
-        reset_tags = lambda tag, second=second_reset_freeze_utc: {
-            "tenkz-v0.9.0": policy.TagEvidence(
-                TAG_OBJECT, "tag", SHA, first_reset_freeze_utc, True
-            ),
-            "tenkz-v0.9.1": policy.TagEvidence(
-                SECOND_TAG_OBJECT, "tag", SECOND_SHA, second, True
-            ),
-        }[tag]
-        reset_commits = lambda sha, _prior, second=second_reset_freeze_utc: (
-            policy.CommitEvidence(
-                "commit",
-                first_reset_freeze_utc if sha == SHA else second,
-                True,
-                True,
-            )
+        assert validate(complete_log(), too_early) == "reset-required:S1-0004"
+
+        candidate_too_early = context()
+        candidate_head = candidate_too_early.prs[SIGNOFF_RECORD].head_oid
+        assert candidate_head is not None
+        candidate_too_early.prs[SIGNOFF_RECORD] = candidate_pr(
+            907,
+            author="release-author",
+            reviews=(review("release-reviewer", submitted, candidate_head),),
         )
         expect_failure(
-            lambda: validate(
-                nonincreasing_reset_entries,
-                resolve_tag=reset_tags,
-                resolve_commit=reset_commits,
-            ),
-            "must follow the prior freeze",
+            lambda facts=candidate_too_early: validate(complete_log(), facts),
+            "independent exact-head approval",
         )
+
+    at_freeze = context()
+    formal = at_freeze.prs[FORMAL_WORK]
+    assert formal.head_oid is not None
+    at_freeze.prs[FORMAL_WORK] = replace(
+        formal,
+        merged_at=FREEZE_TIME,
+        reviews=(
+            review(
+                "formal-reviewer",
+                FREEZE_TIME - timedelta(microseconds=1),
+                formal.head_oid,
+            ),
+        ),
+    )
+    assert validate(complete_log()[:2], at_freeze) == "reset-required:S1-0002"
+
+    duplicated_class = complete_log()
+    duplicated_class[2] = work(
+        "S1-0003",
+        RMP_RECORD,
+        RMP_WORK,
+        "formalization-or-blueprint",
+    )
+    duplicated_facts = context()
+    duplicated_facts.work_diffs[RMP_WORK] = replace(
+        duplicated_facts.work_diffs[RMP_WORK],
+    )
+    expect_failure(
+        lambda: validate(duplicated_class, duplicated_facts),
+        "repeats work class",
+    )
+
+    repeated_pr = complete_log()
+    repeated_pr[2] = work("S1-0003", RMP_RECORD, FORMAL_WORK, "rmp-benchmark")
+    expect_failure(
+        lambda: validate(repeated_pr, context()),
+        "work_pr values must be distinct",
+    )
+
+    missing_class = [
+        freeze(),
+        work(
+            "S1-0002",
+            FORMAL_RECORD,
+            FORMAL_WORK,
+            "formalization-or-blueprint",
+        ),
+        sign_off("S1-0003", SIGNOFF_RECORD, ["S1-0002"]),
+    ]
+    missing_facts = context()
+    missing_facts.records["S1-0003"] = missing_facts.records.pop("S1-0004")
+    expect_failure(
+        lambda: validate(missing_class, missing_facts),
+        "lacks one work class",
+    )
+
+    invalid_class = complete_log()
+    invalid_class[1] = work("S1-0002", FORMAL_RECORD, FORMAL_WORK, "documentation")
+    expect_failure(
+        lambda: validate(invalid_class, context()),
+        "invalid work class",
+    )
+
+    wrong_signoff_set = complete_log()
+    wrong_signoff_set[-1] = sign_off(
+        "S1-0004",
+        SIGNOFF_RECORD,
+        ["S1-0001", "S1-0002"],
+    )
+    expect_failure(
+        lambda: validate(wrong_signoff_set, context()),
+        "exactly the active work entries",
+    )
+
+    third_facts = context()
+    third_facts.prs["#908"] = merged_pr(
+        908,
+        FREEZE_TIME + timedelta(seconds=4),
+        reviews=(
+            review(
+                "third-reviewer",
+                FREEZE_TIME + timedelta(seconds=3),
+                oid(9080),
+            ),
+        ),
+    )
+    third_facts.prs["#909"] = merged_pr(909, FREEZE_TIME + timedelta(seconds=8))
+    third_facts.work_diffs["#908"] = policy.WorkDiffEvidence(
+        complete=True,
+        integration_parent_count=1,
+        unique_merge_base=True,
+        integration_parent_is_ancestor_of_head=True,
+        integration_second_parent_matches_head=True,
+        policy_paths_untouched=True,
+        excluded_paths_applied=True,
+        semantic_add_or_modify_classes=("formalization-or-blueprint",),
+        semantic_lean_changed=True,
+        semantic_blueprint_changed=False,
+        semantic_rmp_changed=False,
+        lean_modules_build=True,
+        proof_integrity_clean=True,
+        blueprint_checkdecls_passed=True,
+        blueprint_build_passed=True,
+        rmp_targets_resolved=True,
+        rmp_stages_complete=True,
+        rmp_checks_passed=True,
+    )
+    third_log = complete_log()[:3] + [
+        work("S1-0004", "#909", "#908", "formalization-or-blueprint")
+    ]
+    expect_failure(
+        lambda: validate(third_log, third_facts),
+        "third work entry",
+    )
+
+    no_exact_approval = context()
+    formal = no_exact_approval.prs[FORMAL_WORK]
+    no_exact_approval.prs[FORMAL_WORK] = replace(
+        formal,
+        reviews=(
+            review(
+                "formal-reviewer",
+                FORMAL_MERGE - timedelta(microseconds=2),
+                formal.head_oid or oid(0),
+            ),
+            review(
+                "formal-reviewer",
+                FORMAL_MERGE - timedelta(microseconds=1),
+                formal.head_oid or oid(0),
+                state="CHANGES_REQUESTED",
+            ),
+        ),
+    )
+    assert (
+        validate(complete_log()[:2], no_exact_approval)
+        == "reset-required:S1-0002"
+    )
+
+    incomplete_reviews = context()
+    incomplete_reviews.prs[RMP_WORK] = replace(
+        incomplete_reviews.prs[RMP_WORK],
+        reviews_complete=False,
+    )
+    assert (
+        validate(complete_log()[:3], incomplete_reviews)
+        == "reset-required:S1-0003"
+    )
+
+    changed_policy = context()
+    changed_policy.work_diffs[FORMAL_WORK] = replace(
+        changed_policy.work_diffs[FORMAL_WORK],
+        policy_paths_untouched=False,
+    )
+    assert validate(complete_log()[:2], changed_policy) == "reset-required:S1-0002"
+
+    comment_only_work = context()
+    comment_only_work.work_diffs[FORMAL_WORK] = replace(
+        comment_only_work.work_diffs[FORMAL_WORK],
+        semantic_add_or_modify_classes=(),
+        semantic_lean_changed=False,
+    )
+    assert (
+        validate(complete_log()[:2], comment_only_work)
+        == "reset-required:S1-0002"
+    )
+
+    failing_lean_work = context()
+    failing_lean_work.work_diffs[FORMAL_WORK] = replace(
+        failing_lean_work.work_diffs[FORMAL_WORK],
+        lean_modules_build=False,
+    )
+    assert (
+        validate(complete_log()[:2], failing_lean_work)
+        == "reset-required:S1-0002"
+    )
+
+    incomplete_rmp_work = context()
+    incomplete_rmp_work.work_diffs[RMP_WORK] = replace(
+        incomplete_rmp_work.work_diffs[RMP_WORK],
+        rmp_stages_complete=False,
+    )
+    assert (
+        validate(complete_log()[:3], incomplete_rmp_work)
+        == "reset-required:S1-0003"
+    )
+
+    bad_tree = context()
+    bad_tree.prs[RMP_WORK] = replace(
+        bad_tree.prs[RMP_WORK],
+        integration_tree_matches_head=False,
+    )
+    assert validate(complete_log()[:3], bad_tree) == "reset-required:S1-0003"
+
+    bad_work_parent = context()
+    bad_work_parent.work_diffs[FORMAL_WORK] = replace(
+        bad_work_parent.work_diffs[FORMAL_WORK],
+        integration_parent_is_ancestor_of_head=False,
+    )
+    assert (
+        validate(complete_log()[:2], bad_work_parent)
+        == "reset-required:S1-0002"
+    )
+
+    bad_work_second_parent = context()
+    bad_work_second_parent.work_diffs[RMP_WORK] = replace(
+        bad_work_second_parent.work_diffs[RMP_WORK],
+        integration_second_parent_matches_head=False,
+    )
+    assert (
+        validate(complete_log()[:3], bad_work_second_parent)
+        == "reset-required:S1-0003"
+    )
+
+    bad_record = context()
+    bad_record.records["S1-0002"] = replace(
+        bad_record.records["S1-0002"],
+        pinned_prefix_unchanged=False,
+    )
+    assert (
+        validate(complete_log()[:2], bad_record)
+        == "reset-required:S1-0002"
+    )
+
+    bad_record_parent = context()
+    bad_record_parent.records["S1-0002"] = replace(
+        bad_record_parent.records["S1-0002"],
+        integration_parent_is_ancestor_of_head=False,
+    )
+    assert (
+        validate(complete_log()[:2], bad_record_parent)
+        == "reset-required:S1-0002"
+    )
+
+    bad_record_second_parent = context()
+    bad_record_second_parent.records["S1-0002"] = replace(
+        bad_record_second_parent.records["S1-0002"],
+        integration_parent_count=2,
+        integration_second_parent_matches_head=False,
+    )
+    assert (
+        validate(complete_log()[:2], bad_record_second_parent)
+        == "reset-required:S1-0002"
+    )
+
+    candidate_freeze = context()
+    candidate_freeze.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
+    assert validate([freeze()], candidate_freeze) == "freeze-pending"
+
+    bad_candidate_parent = context()
+    bad_candidate_parent.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
+    bad_candidate_parent.records["S1-0001"] = replace(
+        bad_candidate_parent.records["S1-0001"],
+        candidate_main_is_ancestor_of_head=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], bad_candidate_parent),
+        "candidate main is not an ancestor",
+    )
+
+    reset_facts = context()
+    reset_facts.prs["#908"] = merged_pr(908, FREEZE_TIME + timedelta(seconds=4))
+    reset_facts.prs["#909"] = merged_pr(909, FREEZE_TIME + timedelta(seconds=5))
+    reset_facts.prs["#910"] = merged_pr(910, FREEZE_TIME + timedelta(seconds=6))
+    for entry_id in ("S1-0002", "S1-0003", "S1-0004"):
+        reset_facts.records[entry_id] = policy.RecordDiffEvidence(
+            validated_pr_ref={
+                "S1-0002": "#908",
+                "S1-0003": "#909",
+                "S1-0004": "#910",
+            }[entry_id],
+            validated_head_oid=reset_facts.prs[
+                {
+                    "S1-0002": "#908",
+                    "S1-0003": "#909",
+                    "S1-0004": "#910",
+                }[entry_id]
+            ].head_oid,
+            complete=True,
+            unique_merge_base=True,
+            integration_parent_count=1,
+            base_lacks_entry=True,
+            appends_exact_entry=True,
+            pinned_prefix_unchanged=True,
+            other_entries_unchanged=True,
+            no_other_path_changes=True,
+            candidate_main_is_ancestor_of_head=True,
+            integration_parent_is_ancestor_of_head=True,
+            integration_second_parent_matches_head=True,
+        )
+    reset_log = [
+        freeze(),
+        friction("S1-0002", "#908", "breaking-required"),
+        correction("S1-0003", "#909", "S1-0002"),
+        reset("S1-0004", "#910", "breaking-required", "S1-0002"),
+    ]
+    assert validate(reset_log, reset_facts) == "reset"
+
+    missing_reset = reset_log[:2] + [
+        work("S1-0003", FORMAL_RECORD, FORMAL_WORK, "formalization-or-blueprint")
+    ]
+    expect_failure(
+        lambda: validate(missing_reset, reset_facts),
+        "must be followed by its reset",
+    )
+
+    invalid_facts = context()
+    invalid_facts.prs["#908"] = merged_pr(908, FREEZE_TIME + timedelta(seconds=6))
+    invalid_facts.records["S1-0003"] = policy.RecordDiffEvidence(
+        validated_pr_ref="#908",
+        validated_head_oid=invalid_facts.prs["#908"].head_oid,
+        complete=True,
+        unique_merge_base=True,
+        integration_parent_count=1,
+        base_lacks_entry=True,
+        appends_exact_entry=True,
+        pinned_prefix_unchanged=True,
+        other_entries_unchanged=True,
+        no_other_path_changes=True,
+        candidate_main_is_ancestor_of_head=True,
+        integration_parent_is_ancestor_of_head=True,
+        integration_second_parent_matches_head=True,
+    )
+    invalid_log = complete_log()[:2]
+    assert (
+        validate(
+            invalid_log,
+            invalid_facts,
+            audit=audit_evidence("S1-0002", ("S1-0002",)),
+        )
+        == "reset-required:S1-0002"
+    )
+    recovered = invalid_log + [
+        reset("S1-0003", "#908", "record-invalid", "S1-0002")
+    ]
+    assert (
+        validate(
+            recovered,
+            invalid_facts,
+            audit=audit_evidence("S1-0002", ("S1-0002",)),
+        )
+        == "reset"
+    )
+    expect_failure(
+        lambda: validate(
+            invalid_log,
+            invalid_facts,
+            audit=audit_evidence(None, ("S1-0002",)),
+        ),
+        "audit with an empty prefix names invalid entries",
+    )
+    expect_failure(
+        lambda: validate(
+            invalid_log,
+            invalid_facts,
+            audit=audit_evidence("S1-0001", ("S1-0002",)),
+        ),
+        "audit boundary precedes an invalid target",
+    )
+
+    # Drift is discovered against the current repository, not at the old
+    # entry's integration point.  Replay every later historical entry with its
+    # immutable integration facts, then require the first new non-correction
+    # entry to reset the earliest drifted record.
+    replayed_drift = context()
+    add_record(
+        replayed_drift,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    assert (
+        validate(
+            complete_log(),
+            replayed_drift,
+            audit=audit_evidence("S1-0004", ("S1-0002",)),
+        )
+        == "reset-required:S1-0002"
+    )
+    assert (
+        validate(
+            complete_log()
+            + [reset("S1-0005", "#908", "record-invalid", "S1-0002")],
+            replayed_drift,
+            audit=audit_evidence("S1-0004", ("S1-0002",)),
+        )
+        == "reset"
+    )
+
+    replayed_freeze_drift = context()
+    add_record(
+        replayed_freeze_drift,
+        "S1-0004",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=8),
+    )
+    assert (
+        validate(
+            complete_log()[:3]
+            + [reset("S1-0004", "#908", "record-invalid", "S1-0001")],
+            replayed_freeze_drift,
+            audit=audit_evidence("S1-0003", ("S1-0001",)),
+        )
+        == "reset"
+    )
+
+    corrected_drift = context()
+    add_record(
+        corrected_drift,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    add_record(
+        corrected_drift,
+        "S1-0006",
+        "#909",
+        909,
+        SIGNOFF_MERGE + timedelta(seconds=2),
+    )
+    assert (
+        validate(
+            complete_log()
+            + [
+                correction("S1-0005", "#908", "S1-0001"),
+                reset("S1-0006", "#909", "record-invalid", "S1-0002"),
+            ],
+            corrected_drift,
+            audit=audit_evidence("S1-0004", ("S1-0002",)),
+        )
+        == "reset"
+    )
+
+    # An already-pending breaking-required reset has priority at the drift
+    # boundary; the administrative drift reset follows immediately after it.
+    ordered_resets = context()
+    add_record(
+        ordered_resets,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=3),
+    )
+    add_record(
+        ordered_resets,
+        "S1-0003",
+        "#909",
+        909,
+        FREEZE_TIME + timedelta(seconds=4),
+    )
+    add_record(
+        ordered_resets,
+        "S1-0004",
+        "#910",
+        910,
+        FREEZE_TIME + timedelta(seconds=5),
+    )
+    breaking_then_drift = [
+        freeze(),
+        friction("S1-0002", "#908", "breaking-required"),
+        reset("S1-0003", "#909", "breaking-required", "S1-0002"),
+        reset("S1-0004", "#910", "record-invalid", "S1-0001"),
+    ]
+    assert (
+        validate(
+            breaking_then_drift[:3],
+            ordered_resets,
+            audit=audit_evidence("S1-0002", ("S1-0001",)),
+        )
+        == "reset-required:S1-0001"
+    )
+    assert (
+        validate(
+            breaking_then_drift,
+            ordered_resets,
+            audit=audit_evidence("S1-0002", ("S1-0001",)),
+        )
+        == "reset"
+    )
+
+    batched_drift = context()
+    add_record(
+        batched_drift,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    add_record(
+        batched_drift,
+        "S1-0006",
+        "#909",
+        909,
+        SIGNOFF_MERGE + timedelta(seconds=2),
+    )
+    unsorted_audit = policy.AuditEvidence(
+        "S1-0004",
+        ("S1-0002", "S1-0001"),
+        True,
+        True,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), batched_drift, audit=unsorted_audit),
+        "invalid entries are not in ledger order",
+    )
+    ordered_audit = policy.AuditEvidence(
+        "S1-0004",
+        ("S1-0001", "S1-0002"),
+        True,
+        True,
+    )
+    batched_log = complete_log() + [
+        reset("S1-0005", "#908", "record-invalid", "S1-0001"),
+        reset("S1-0006", "#909", "record-invalid", "S1-0002"),
+    ]
+    assert validate(batched_log[:-1], batched_drift, audit=ordered_audit) == (
+        "reset-required:S1-0002"
+    )
+    assert validate(batched_log, batched_drift, audit=ordered_audit) == "reset"
+
+    # The self-referential record rule is common to every entry kind.  A
+    # copied or tree-mismatched merged record never supplies usable evidence;
+    # the next non-correction entry must reset that exact record.
+    common_cases: list[tuple[str, list[str], str, str, str]] = []
+
+    freeze_common = context()
+    freeze_common.prs[FREEZE_RECORD] = replace(
+        freeze_common.prs[FREEZE_RECORD],
+        integration_tree_matches_head=False,
+    )
+    add_record(
+        freeze_common,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    common_cases.append(
+        (
+            "freeze",
+            [
+                freeze(),
+                reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+            ],
+            "S1-0001",
+            "S1-0002",
+            "#908",
+        )
+    )
+
+    work_common = context()
+    work_common.prs[FORMAL_RECORD] = replace(
+        work_common.prs[FORMAL_RECORD],
+        integration_tree_matches_head=False,
+    )
+    add_record(
+        work_common,
+        "S1-0003",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=6),
+    )
+    common_cases.append(
+        (
+            "work",
+            [
+                freeze(),
+                work(
+                    "S1-0002",
+                    FORMAL_RECORD,
+                    FORMAL_WORK,
+                    "formalization-or-blueprint",
+                ),
+                reset("S1-0003", "#908", "record-invalid", "S1-0002"),
+            ],
+            "S1-0002",
+            "S1-0003",
+            "#908",
+        )
+    )
+
+    friction_common = context()
+    add_record(
+        friction_common,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=3),
+        invalid_tree=True,
+    )
+    add_record(
+        friction_common,
+        "S1-0003",
+        "#909",
+        909,
+        FREEZE_TIME + timedelta(seconds=4),
+    )
+    common_cases.append(
+        (
+            "friction",
+            [
+                freeze(),
+                friction("S1-0002", "#908", "defer-to-2.0"),
+                reset("S1-0003", "#909", "record-invalid", "S1-0002"),
+            ],
+            "S1-0002",
+            "S1-0003",
+            "#909",
+        )
+    )
+
+    resolution_common = context()
+    add_record(
+        resolution_common,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=3),
+    )
+    add_record(
+        resolution_common,
+        "S1-0003",
+        "#909",
+        909,
+        FREEZE_TIME + timedelta(seconds=4),
+        invalid_tree=True,
+    )
+    add_record(
+        resolution_common,
+        "S1-0004",
+        "#910",
+        910,
+        FREEZE_TIME + timedelta(seconds=5),
+    )
+    common_cases.append(
+        (
+            "resolution",
+            [
+                freeze(),
+                friction("S1-0002", "#908", "fix-compatible"),
+                resolution("S1-0003", "#909", "S1-0002"),
+                reset("S1-0004", "#910", "record-invalid", "S1-0003"),
+            ],
+            "S1-0003",
+            "S1-0004",
+            "#910",
+        )
+    )
+
+    correction_common = context()
+    add_record(
+        correction_common,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=3),
+        invalid_tree=True,
+    )
+    add_record(
+        correction_common,
+        "S1-0003",
+        "#909",
+        909,
+        FREEZE_TIME + timedelta(seconds=4),
+    )
+    common_cases.append(
+        (
+            "correction",
+            [
+                freeze(),
+                correction("S1-0002", "#908", "S1-0001"),
+                reset("S1-0003", "#909", "record-invalid", "S1-0002"),
+            ],
+            "S1-0002",
+            "S1-0003",
+            "#909",
+        )
+    )
+
+    reset_common = context()
+    add_record(
+        reset_common,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=3),
+    )
+    add_record(
+        reset_common,
+        "S1-0003",
+        "#909",
+        909,
+        FREEZE_TIME + timedelta(seconds=4),
+        invalid_tree=True,
+    )
+    add_record(
+        reset_common,
+        "S1-0004",
+        "#910",
+        910,
+        FREEZE_TIME + timedelta(seconds=5),
+    )
+    common_cases.append(
+        (
+            "reset",
+            [
+                freeze(),
+                friction("S1-0002", "#908", "breaking-required"),
+                reset("S1-0003", "#909", "breaking-required", "S1-0002"),
+                reset("S1-0004", "#910", "record-invalid", "S1-0003"),
+            ],
+            "S1-0003",
+            "S1-0004",
+            "#910",
+        )
+    )
+
+    signoff_common = context()
+    signoff_common.prs[SIGNOFF_RECORD] = replace(
+        signoff_common.prs[SIGNOFF_RECORD],
+        integration_tree_matches_head=False,
+    )
+    add_record(
+        signoff_common,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+    )
+    common_cases.append(
+        (
+            "sign-off",
+            complete_log()
+            + [reset("S1-0005", "#908", "record-invalid", "S1-0004")],
+            "S1-0004",
+            "S1-0005",
+            "#908",
+        )
+    )
+
+    case_facts = {
+        "freeze": freeze_common,
+        "work": work_common,
+        "friction": friction_common,
+        "resolution": resolution_common,
+        "correction": correction_common,
+        "reset": reset_common,
+        "sign-off": signoff_common,
+    }
+    for name, log, invalid_id, reset_id, _reset_pr in common_cases:
+        facts = case_facts[name]
+        assert validate(log[:-1], facts) == f"reset-required:{invalid_id}"
+        assert log[-1].find(f'id = "{reset_id}"') >= 0
+        assert validate(log, facts) == "reset"
+
+    copied_candidate = context()
+    copied_candidate.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
+    copied_candidate.records["S1-0001"] = replace(
+        copied_candidate.records["S1-0001"],
+        validated_pr_ref="#999",
+    )
+    expect_failure(
+        lambda: validate([freeze()], copied_candidate),
+        "validated on another PR",
+    )
+
+    copied_merged = context()
+    copied_merged.records["S1-0001"] = replace(
+        copied_merged.records["S1-0001"],
+        validated_pr_ref="#999",
+    )
+    add_record(
+        copied_merged,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    copied_log = [
+        freeze(),
+        reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+    ]
+    assert validate(copied_log[:-1], copied_merged) == "reset-required:S1-0001"
+    assert validate(copied_log, copied_merged) == "reset"
+
+    moved_tag = context()
+    moved_tag.tags["tenkz-v0.9.0"] = policy.TagEvidence("9" * 40, "tag", SHA, True)
+    add_record(
+        moved_tag,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    moved_tag_log = [
+        freeze(),
+        reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+    ]
+    assert validate(moved_tag_log[:-1], moved_tag) == "reset-required:S1-0001"
+    assert validate(moved_tag_log, moved_tag) == "reset"
+
+    moved_tag_candidate = context()
+    moved_tag_candidate.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
+    moved_tag_candidate.tags["tenkz-v0.9.0"] = policy.TagEvidence(
+        "9" * 40,
+        "tag",
+        SHA,
+        True,
+    )
+    expect_failure(
+        lambda: validate([freeze()], moved_tag_candidate),
+        "tag object was replaced",
+    )
+
+    advanced_candidate = context()
+    advanced_candidate.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
+    advanced_candidate.records["S1-0001"] = replace(
+        advanced_candidate.records["S1-0001"],
+        candidate_main_tip_is_source=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], advanced_candidate),
+        "candidate main tip differs from source_sha",
+    )
+
+    wrong_parent = context()
+    wrong_parent.records["S1-0001"] = replace(
+        wrong_parent.records["S1-0001"],
+        integration_parent_is_source=False,
+    )
+    add_record(
+        wrong_parent,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    wrong_parent_log = [
+        freeze(),
+        reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+    ]
+    assert validate(wrong_parent_log[:-1], wrong_parent) == "reset-required:S1-0001"
+    assert validate(wrong_parent_log, wrong_parent) == "reset"
+
+    stale_patch = context()
+    stale_patch.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
+    stale_patch.tags["tenkz-v0.9.0"] = replace(
+        stale_patch.tags["tenkz-v0.9.0"],
+        patch_is_fresh_for_attempt=False,
+    )
+    expect_failure(
+        lambda: validate([freeze()], stale_patch),
+        "PATCH does not exceed abandoned tags",
+    )
+
+    mixed_record = context()
+    mixed_record.records["S1-0002"] = replace(
+        mixed_record.records["S1-0002"],
+        no_other_path_changes=False,
+    )
+    assert (
+        validate(complete_log()[:2], mixed_record)
+        == "reset-required:S1-0002"
+    )
+
+    archived_work = context()
+    archived_work.work_diffs[FORMAL_WORK] = replace(
+        archived_work.work_diffs[FORMAL_WORK],
+        excluded_paths_applied=False,
+    )
+    assert (
+        validate(complete_log()[:2], archived_work)
+        == "reset-required:S1-0002"
+    )
+    archive_only = context()
+    archive_only.work_diffs[FORMAL_WORK] = replace(
+        archive_only.work_diffs[FORMAL_WORK],
+        semantic_add_or_modify_classes=(),
+        semantic_lean_changed=False,
+    )
+    assert (
+        validate(complete_log()[:2], archive_only)
+        == "reset-required:S1-0002"
+    )
+
+    # A historical correction retains its target attempt, but an invalid
+    # record is repaired administratively.  With no active attempt, that
+    # reset uses the most recently opened number and leaves the state inactive.
+    historical = context()
+    add_record(
+        historical,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    add_record(
+        historical,
+        "S1-0003",
+        "#909",
+        909,
+        FREEZE_TIME + timedelta(seconds=2),
+    )
+    add_record(
+        historical,
+        "S1-0004",
+        "#910",
+        910,
+        FREEZE_TIME + timedelta(seconds=3),
+        invalid_tree=True,
+    )
+    add_record(
+        historical,
+        "S1-0005",
+        "#911",
+        911,
+        FREEZE_TIME + timedelta(seconds=4),
+    )
+    second_sha = "c" * 40
+    second_tag_object = "d" * 40
+    add_freeze_facts(
+        historical,
+        "S1-0006",
+        source_ref="#912",
+        source_number=912,
+        source_sha=second_sha,
+        record_ref="#913",
+        record_number=913,
+        tag="tenkz-v0.9.1",
+        tag_object=second_tag_object,
+        merged_at=FREEZE_TIME + timedelta(seconds=6),
+    )
+    add_record(
+        historical,
+        "S1-0007",
+        "#914",
+        914,
+        FREEZE_TIME + timedelta(seconds=7),
+        invalid_tree=True,
+    )
+    add_record(
+        historical,
+        "S1-0008",
+        "#915",
+        915,
+        FREEZE_TIME + timedelta(seconds=8),
+    )
+    third_sha = "e" * 40
+    third_tag_object = "f" * 40
+    add_freeze_facts(
+        historical,
+        "S1-0009",
+        source_ref="#916",
+        source_number=916,
+        source_sha=third_sha,
+        record_ref="#917",
+        record_number=917,
+        tag="tenkz-v0.9.2",
+        tag_object=third_tag_object,
+        merged_at=FREEZE_TIME + timedelta(seconds=10),
+    )
+    historical_log = [
+        freeze(),
+        friction("S1-0002", "#908", "breaking-required"),
+        reset("S1-0003", "#909", "breaking-required", "S1-0002"),
+        correction("S1-0004", "#910", "S1-0001", attempt=1),
+        reset("S1-0005", "#911", "record-invalid", "S1-0004", attempt=1),
+        freeze(
+            "S1-0006",
+            record_pr="#913",
+            attempt=2,
+            source_pr="#912",
+            source_sha=second_sha,
+            tag_object=second_tag_object,
+            tag="tenkz-v0.9.1",
+        ),
+        correction("S1-0007", "#914", "S1-0001", attempt=1),
+        reset("S1-0008", "#915", "record-invalid", "S1-0007", attempt=2),
+        freeze(
+            "S1-0009",
+            record_pr="#917",
+            attempt=3,
+            source_pr="#916",
+            source_sha=third_sha,
+            tag_object=third_tag_object,
+            tag="tenkz-v0.9.2",
+        ),
+    ]
+    assert (
+        validate(historical_log[:4], historical)
+        == "reset-required:S1-0004"
+    )
+    assert validate(historical_log[:5], historical) == "reset"
+    assert validate(historical_log[:6], historical) == "attempt-2-active"
+    assert (
+        validate(historical_log[:7], historical)
+        == "reset-required:S1-0007"
+    )
+    assert validate(historical_log[:8], historical) == "reset"
+    assert validate(historical_log, historical) == "attempt-3-active"
 
     expect_failure(
         lambda: policy.validate_policy_text(
-            DESIGN_TEXT.replace('tag_namespace = "tenkz-v*"', 'tag_namespace = "v*"')
+            DESIGN_TEXT.replace(
+                "required_distinct_work_prs = 2",
+                "required_distinct_work_prs = 3",
+            )
         ),
         "signed policy",
     )
     expect_failure(
         lambda: policy.validate_policy_text(
             DESIGN_TEXT.replace(
-                'frozen_twin_scope = "library-or-package-entry-point"',
-                'frozen_twin_scope = "spelling-level"',
+                'work_classes = ["formalization-or-blueprint", "rmp-benchmark"]',
+                'work_classes = ["rmp-benchmark", "formalization-or-blueprint"]',
             )
         ),
         "signed policy",
     )
     expect_failure(
-        lambda: policy.validate_policy_text(
-            DESIGN_TEXT.replace('tnlog = "byte-stable"', 'tnlog = "best-effort"')
-        ),
-        "signed policy",
-    )
-    expect_failure(
         lambda: policy.parse_soak_text(
-            SOAK_TEXT.replace("minimum_days = 28", "minimum_days = 27")
+            SOAK_TEXT.replace(
+                "append_only = true",
+                'minimum_elapsed = "forbidden"\nappend_only = true',
+            )
         ),
         "signed schema",
     )
     expect_failure(
         lambda: policy.parse_soak_text(SOAK_TEXT + "free-form tail\n"),
-        "only soak entry blocks",
+        "only evidence entry blocks",
     )
 
-    bad_prerequisites = parsed_entries(
-        freeze(prerequisites='["#5086", "#4699", "#4162", "#4703", "#4708"]')
-    )
-    expect_failure(lambda: validate(bad_prerequisites), "full blocker chain")
-    expect_failure(lambda: validate(parsed_entries(freeze(sha="abc"))), "invalid freeze_sha")
-    expect_failure(
-        lambda: validate(parsed_entries(freeze(tag="tenkz-v1.0.0"))),
-        "tenkz-v0.9.PATCH",
-    )
-
-    lightweight = lambda _tag: policy.TagEvidence(
-        SHA, "commit", SHA, None, True
+    invented = freeze().replace(
+        'evidence = "source, tag, and issue evidence"',
+        'evidence = "source, tag, and issue evidence"\ninvented = true',
     )
     expect_failure(
-        lambda: validate(parsed_entries(freeze()), resolve_tag=lightweight),
-        "not annotated",
+        lambda: validate([invented], context()),
+        "fields differ from schema",
     )
-    replaced = lambda _tag: policy.TagEvidence(
-        SECOND_TAG_OBJECT, "tag", SHA, FREEZE_UTC, True
-    )
-    expect_failure(
-        lambda: validate(parsed_entries(freeze()), resolve_tag=replaced),
-        "object was replaced",
-    )
-    wrong_peeled_commit = lambda _tag: policy.TagEvidence(
-        TAG_OBJECT, "tag", SECOND_SHA, FREEZE_UTC, True
-    )
-    expect_failure(
-        lambda: validate(
-            parsed_entries(freeze()),
-            resolve_tag=wrong_peeled_commit,
-        ),
-        "peels to another commit",
-    )
-    unreachable_freeze = lambda _tag: policy.TagEvidence(
-        TAG_OBJECT, "tag", SHA, FREEZE_UTC, False
-    )
-    expect_failure(
-        lambda: validate(
-            parsed_entries(freeze()),
-            resolve_tag=unreachable_freeze,
-        ),
-        "freeze commit is not reachable from main",
-    )
-    expect_failure(
-        lambda: validate(parsed_entries(freeze(when="2026-08-31"))),
-        "differs from the tagger UTC date",
-    )
-    naive_tag_time = lambda _tag: policy.TagEvidence(
-        TAG_OBJECT, "tag", SHA, datetime(2026, 9, 1), True
-    )
-    expect_failure(
-        lambda: validate(parsed_entries(freeze()), resolve_tag=naive_tag_time),
-        "tagger timestamp must be timezone-aware",
-    )
-    missing_freeze_time = lambda _sha, _prior: policy.CommitEvidence(
-        "commit", None, True, True
-    )
-    expect_failure(
-        lambda: validate(
-            parsed_entries(freeze()),
-            resolve_commit=missing_freeze_time,
-        ),
-        "freeze commit lacks a committer date",
-    )
-    postdated_freeze_commit = lambda _sha, _prior: policy.CommitEvidence(
-        "commit", datetime(2026, 9, 1, 0, 0, 1, tzinfo=timezone.utc), True, True
-    )
-    expect_failure(
-        lambda: validate(
-            parsed_entries(freeze()),
-            resolve_commit=postdated_freeze_commit,
-        ),
-        "freeze commit postdates the annotated tag",
-    )
-    future_utc = datetime(2026, 10, 1, tzinfo=timezone.utc)
-    future_tag = lambda _tag: policy.TagEvidence(
-        TAG_OBJECT, "tag", SHA, future_utc, True
-    )
-    expect_failure(
-        lambda: validate(
-            parsed_entries(
-                freeze(when="2026-10-01", tagger_utc="2026-10-01T00:00:00Z")
-            ),
-            resolve_tag=future_tag,
-        ),
-        "future",
-    )
-
-    fake_work_entries = parsed_entries(freeze(), work("S1-0002"))
-    freeze_as_work = parsed_entries(
-        freeze(),
-        work("S1-0002", sha=SHA, committed_utc=FREEZE_UTC),
-    )
-    expect_failure(lambda: validate(freeze_as_work), "reuses the freeze commit")
-    simultaneous_work = parsed_entries(
-        freeze(),
-        work("S1-0002", committed_utc=FREEZE_UTC),
-    )
-    expect_failure(lambda: validate(simultaneous_work), "must postdate the freeze tag")
-    fake_work = lambda sha, freeze_sha: (
-        resolve_commit(sha, freeze_sha)
-        if sha == SHA
-        else policy.CommitEvidence("missing", None, False, False)
-    )
-    expect_failure(
-        lambda: validate(fake_work_entries, resolve_commit=fake_work),
-        "not a commit",
-    )
-    non_main = lambda sha, freeze_sha: (
-        resolve_commit(sha, freeze_sha)
-        if sha == SHA
-        else policy.CommitEvidence(
-            "commit", resolve_commit(sha, freeze_sha).committed_utc, False, True
-        )
-    )
-    expect_failure(
-        lambda: validate(fake_work_entries, resolve_commit=non_main),
-        "not reachable from main",
-    )
-    not_descendant = lambda sha, freeze_sha: (
-        resolve_commit(sha, freeze_sha)
-        if sha == SHA
-        else policy.CommitEvidence(
-            "commit", resolve_commit(sha, freeze_sha).committed_utc, True, False
-        )
-    )
-    expect_failure(
-        lambda: validate(fake_work_entries, resolve_commit=not_descendant),
-        "does not descend from the freeze",
-    )
-    wrong_time = lambda sha, freeze_sha: (
-        resolve_commit(sha, freeze_sha)
-        if sha == SHA
-        else policy.CommitEvidence(
-            "commit", datetime(2026, 9, 3, tzinfo=timezone.utc), True, True
-        )
-    )
-    expect_failure(
-        lambda: validate(fake_work_entries, resolve_commit=wrong_time),
-        "differs from the commit object",
-    )
-    naive_work_time = lambda sha, freeze_sha: (
-        resolve_commit(sha, freeze_sha)
-        if sha == SHA
-        else policy.CommitEvidence(
-            "commit", datetime(2026, 9, 2, 12), True, True
-        )
-    )
-    expect_failure(
-        lambda: validate(fake_work_entries, resolve_commit=naive_work_time),
-        "work commit timestamp must be timezone-aware",
-    )
-
-    too_early = complete_log()
-    too_early[-1] = sign_off(
-        "S1-0009",
-        "2026-09-28",
-        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
-    )
-    expect_failure(
-        lambda: validate(
-            parsed_entries(*too_early),
-            now=datetime(2026, 9, 28, 12, tzinfo=timezone.utc),
-        ),
-        "current UTC is before 28 full days",
-    )
-    backdated_signoff = complete_log()
-    backdated_signoff[-1] = sign_off(
-        "S1-0009",
-        "2026-09-28",
-        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
-    )
-    expect_failure(
-        lambda: validate(parsed_entries(*backdated_signoff)),
-        "sign-off date is backdated",
-    )
-
-    missing_window = complete_log()
-    missing_window[-1] = sign_off(
-        "S1-0009",
-        "2026-09-29",
-        ["S1-0002", "S1-0003", "S1-0007"],
-    )
-    expect_failure(lambda: validate(parsed_entries(*missing_window)), "all four windows")
-
-    bad_maintainer = complete_log()
-    bad_maintainer[-1] = sign_off(
-        "S1-0009",
-        "2026-09-29",
-        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
-        maintainer="LionSR",
-    )
-    expect_failure(
-        lambda: validate(parsed_entries(*bad_maintainer)),
-        "github:lowercase-login",
-    )
-    bad_reviewer = complete_log()
-    bad_reviewer[-1] = sign_off(
-        "S1-0009",
-        "2026-09-29",
-        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
-        reviewer="github:Independent-Reviewer",
-    )
-    expect_failure(
-        lambda: validate(parsed_entries(*bad_reviewer)),
-        "github:lowercase-login",
-    )
-    same_signer = complete_log()
-    same_signer[-1] = sign_off(
-        "S1-0009",
-        "2026-09-29",
-        ["S1-0002", "S1-0003", "S1-0007", "S1-0008"],
-        reviewer="github:lionsr",
-    )
-    expect_failure(lambda: validate(parsed_entries(*same_signer)), "independent")
-
-    breaking_without_reset = parsed_entries(
-        freeze(),
-        friction("S1-0002", "2026-09-02", "breaking-required"),
-        work("S1-0003"),
-    )
-    expect_failure(lambda: validate(breaking_without_reset), "followed immediately")
-
-    unresolved = parsed_entries(
-        freeze(),
-        work("S1-0002"),
-        work("S1-0003"),
-        friction("S1-0004", "2026-09-10", "fix-compatible"),
-        work("S1-0005"),
-        work("S1-0006"),
-        sign_off(
-            "S1-0007",
-            "2026-09-29",
-            ["S1-0002", "S1-0003", "S1-0005", "S1-0006"],
-        ),
-    )
-    expect_failure(lambda: validate(unresolved), "unresolved friction")
 
     policy.check_append_only(SOAK_TEXT, SOAK_TEXT + freeze())
     expect_failure(
         lambda: policy.check_append_only(
             SOAK_TEXT,
-            SOAK_TEXT.replace("append-only evidence", "rewritten evidence") + freeze(),
+            SOAK_TEXT.replace("release-evidence log", "rewritten log") + freeze(),
         ),
         "changed existing bytes",
     )
 
-    invented_field = freeze().replace(
-        'evidence = "https://example.test/freeze"',
-        'evidence = "https://example.test/freeze"\ninvented = true',
-    )
-    expect_failure(
-        lambda: validate(parsed_entries(invented_field)),
-        "fields differ",
-    )
-
-    print("PASS: tenkz policy anchors tags, work, identities, and soak resets")
+    print("PASS: tenkz evidence gate enforces two exact classes without calendar delay")
     return 0
 
 

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -315,6 +315,50 @@ def main() -> int:
         "does not descend from the prior freeze",
     )
 
+    first_reset_freeze_utc = datetime(2026, 9, 1, 12, tzinfo=timezone.utc)
+    for second_reset_freeze_utc in (
+        datetime(2026, 9, 1, 11, tzinfo=timezone.utc),
+        first_reset_freeze_utc,
+    ):
+        nonincreasing_reset_entries = parsed_entries(
+            freeze(tagger_utc=utc_text(first_reset_freeze_utc)),
+            friction("S1-0002", "2026-09-01", "breaking-required"),
+            reset("S1-0003", "2026-09-01", "S1-0002"),
+            freeze(
+                "S1-0004",
+                when="2026-09-01",
+                attempt=2,
+                sha=SECOND_SHA,
+                tag_object=SECOND_TAG_OBJECT,
+                tag="tenkz-v0.9.1",
+                tagger_utc=utc_text(second_reset_freeze_utc),
+            ),
+        )
+        reset_tags = lambda tag, second=second_reset_freeze_utc: {
+            "tenkz-v0.9.0": policy.TagEvidence(
+                TAG_OBJECT, "tag", SHA, first_reset_freeze_utc, True
+            ),
+            "tenkz-v0.9.1": policy.TagEvidence(
+                SECOND_TAG_OBJECT, "tag", SECOND_SHA, second, True
+            ),
+        }[tag]
+        reset_commits = lambda sha, _prior, second=second_reset_freeze_utc: (
+            policy.CommitEvidence(
+                "commit",
+                first_reset_freeze_utc if sha == SHA else second,
+                True,
+                True,
+            )
+        )
+        expect_failure(
+            lambda: validate(
+                nonincreasing_reset_entries,
+                resolve_tag=reset_tags,
+                resolve_commit=reset_commits,
+            ),
+            "must follow the prior freeze",
+        )
+
     expect_failure(
         lambda: policy.validate_policy_text(
             DESIGN_TEXT.replace('tag_namespace = "tenkz-v*"', 'tag_namespace = "v*"')
@@ -395,6 +439,13 @@ def main() -> int:
         lambda: validate(parsed_entries(freeze(when="2026-08-31"))),
         "differs from the tagger UTC date",
     )
+    naive_tag_time = lambda _tag: policy.TagEvidence(
+        TAG_OBJECT, "tag", SHA, datetime(2026, 9, 1), True
+    )
+    expect_failure(
+        lambda: validate(parsed_entries(freeze()), resolve_tag=naive_tag_time),
+        "tagger timestamp must be timezone-aware",
+    )
     missing_freeze_time = lambda _sha, _prior: policy.CommitEvidence(
         "commit", None, True, True
     )
@@ -430,6 +481,16 @@ def main() -> int:
     )
 
     fake_work_entries = parsed_entries(freeze(), work("S1-0002"))
+    freeze_as_work = parsed_entries(
+        freeze(),
+        work("S1-0002", sha=SHA, committed_utc=FREEZE_UTC),
+    )
+    expect_failure(lambda: validate(freeze_as_work), "reuses the freeze commit")
+    simultaneous_work = parsed_entries(
+        freeze(),
+        work("S1-0002", committed_utc=FREEZE_UTC),
+    )
+    expect_failure(lambda: validate(simultaneous_work), "must postdate the freeze tag")
     fake_work = lambda sha, freeze_sha: (
         resolve_commit(sha, freeze_sha)
         if sha == SHA
@@ -471,6 +532,17 @@ def main() -> int:
     expect_failure(
         lambda: validate(fake_work_entries, resolve_commit=wrong_time),
         "differs from the commit object",
+    )
+    naive_work_time = lambda sha, freeze_sha: (
+        resolve_commit(sha, freeze_sha)
+        if sha == SHA
+        else policy.CommitEvidence(
+            "commit", datetime(2026, 9, 2, 12), True, True
+        )
+    )
+    expect_failure(
+        lambda: validate(fake_work_entries, resolve_commit=naive_work_time),
+        "work commit timestamp must be timezone-aware",
     )
 
     too_early = complete_log()

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -517,6 +517,7 @@ class Context:
     def resolve_replay_release_prep(
         self,
         ref: str,
+        _integration_oid: str,
         _paths: tuple[str, ...],
         _work_integrations: tuple[str, ...],
         _resolution_integrations: tuple[str, ...],
@@ -1000,6 +1001,7 @@ def context() -> Context:
         RELEASE_PREP: policy.ReleasePrepEvidence(
             validated_pr_ref=RELEASE_PREP,
             validated_head_oid=release_head,
+            validated_integration_oid=prs[RELEASE_PREP].merge_commit_oid,
             validated_manifest_path="docs/tenkz/releases/tenkz-v1.0.0.toml",
             validated_changed_paths=policy.policy_rules(ARMED_POLICY)[4].release_varying_paths(
                 policy.FINAL_TAG
@@ -4335,6 +4337,53 @@ def main() -> int:
     assert (
         validate(complete_log(), failing_integration_payload)
         == "reset-required:S1-0004"
+    )
+
+    release_binding_call = context()
+    observed_release_integrations: list[str] = []
+
+    def resolve_bound_release_prep(
+        ref: str,
+        integration_oid: str,
+        _paths: tuple[str, ...],
+        _work_integrations: tuple[str, ...],
+        _resolution_integrations: tuple[str, ...],
+    ) -> policy.ReleasePrepEvidence:
+        observed_release_integrations.append(integration_oid)
+        return release_binding_call.release_preps[ref]
+
+    assert validate(
+        complete_log(),
+        release_binding_call,
+        resolve_replay_release_prep=resolve_bound_release_prep,
+    ) == "signed-off-awaiting-tag"
+    assert observed_release_integrations == [oid(9201)]
+
+    for invalid_integration in (None, oid(9991)):
+        release_other_integration = context()
+        release_other_integration.release_preps[RELEASE_PREP] = replace(
+            release_other_integration.release_preps[RELEASE_PREP],
+            validated_integration_oid=invalid_integration,
+        )
+        assert validate(complete_log(), release_other_integration) == (
+            "reset-required:S1-0004"
+        )
+
+    release_other_integration_candidate = context()
+    signoff = release_other_integration_candidate.prs[SIGNOFF_RECORD]
+    assert signoff.head_oid is not None
+    release_other_integration_candidate.prs[SIGNOFF_RECORD] = candidate_pr(
+        907,
+        author="release-author",
+        reviews=(review("release-reviewer", SIGNOFF_REVIEW, signoff.head_oid),),
+    )
+    release_other_integration_candidate.release_preps[RELEASE_PREP] = replace(
+        release_other_integration_candidate.release_preps[RELEASE_PREP],
+        validated_integration_oid=oid(9991),
+    )
+    expect_failure(
+        lambda: validate(complete_log(), release_other_integration_candidate),
+        "release preparation used another integration",
     )
 
     unprepared = context()

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -266,7 +266,7 @@ def review(
     *,
     state: str = "APPROVED",
     dismissed: bool = False,
-    permission: str | None = "push",
+    permission: str | None = "write",
 ) -> policy.ReviewEvidence:
     return policy.ReviewEvidence(login, state, submitted_at, head, dismissed, permission)
 
@@ -382,6 +382,7 @@ class Context:
         target: str,
         receipt_ref: str,
         receipt_digest: str,
+        current_tree_oid: str,
     ) -> policy.RecordInvalidResetReplayEvidence:
         override = self.reset_replays.get(entry_id)
         if override is not None:
@@ -399,7 +400,9 @@ class Context:
             changes_exactly_one_new_regular_blob=True,
             receipt_path=f"docs/tenkz/soak-replay/{receipt_ref[1:]}.json",
             raw_blob_sha256=receipt_digest,
-            raw_blob_read_from_receipt_integration=True,
+            validated_current_tree_oid=current_tree_oid,
+            raw_blob_read_from_current_validation_tree=True,
+            current_tree_blob_has_exact_path_mode_bytes_and_digest=True,
             schema_path=policy.policy_rules(ARMED_POLICY)[4].reset_replay_schema,
             schema_support_tree_oid=TEST_SUPPORT_TREE,
             schema_from_pinned_support_tree=True,
@@ -433,6 +436,11 @@ class Context:
             external_dependencies_use_full_commit_shas=True,
             containers_use_content_digests=True,
             dependency_graph_complete_and_acyclic=True,
+            package_managers_absent=True,
+            downloaders_absent=True,
+            unhashed_runtime_dependencies_absent=True,
+            runtime_fetched_executables_absent=True,
+            network_disabled_before_repository_code=True,
             candidate_diff_untouched=True,
             github_checks_bind_exact_head_and_workflows=True,
             supervisor_receipt_complete_and_matching=True,
@@ -821,7 +829,62 @@ def prepare_reset_receipts(entries: list[dict], facts: Context) -> None:
                 if record_diff.validated_receipt_integration is None
                 else record_diff.validated_receipt_integration
             ),
+            receipt_blob_preserved_from_candidate_base_to_head=(
+                True
+                if record_diff.receipt_blob_preserved_from_candidate_base_to_head is None
+                else record_diff.receipt_blob_preserved_from_candidate_base_to_head
+            ),
+            receipt_blob_preserved_in_integration=(
+                True
+                if record_diff.receipt_blob_preserved_in_integration is None
+                else record_diff.receipt_blob_preserved_in_integration
+            ),
         )
+
+
+def prepare_receipt_retention(entries: list[dict], facts: Context) -> None:
+    """Bind every later record tree to all earlier durable receipt blobs."""
+
+    prior_receipts: list[tuple[str, str]] = []
+    for entry in entries:
+        if prior_receipts:
+            record_diff = facts.records[entry["id"]]
+            facts.records[entry["id"]] = replace(
+                record_diff,
+                validated_prior_receipts=(
+                    tuple(prior_receipts)
+                    if record_diff.validated_prior_receipts is None
+                    else record_diff.validated_prior_receipts
+                ),
+                candidate_target_preserves_prior_receipts=(
+                    True
+                    if record_diff.candidate_target_preserves_prior_receipts is None
+                    else record_diff.candidate_target_preserves_prior_receipts
+                ),
+                head_preserves_prior_receipts=(
+                    True
+                    if record_diff.head_preserves_prior_receipts is None
+                    else record_diff.head_preserves_prior_receipts
+                ),
+                integration_preserves_prior_receipts=(
+                    True
+                    if record_diff.integration_preserves_prior_receipts is None
+                    else record_diff.integration_preserves_prior_receipts
+                ),
+                entry_diff_untouched_prior_receipts=(
+                    True
+                    if record_diff.entry_diff_untouched_prior_receipts is None
+                    else record_diff.entry_diff_untouched_prior_receipts
+                ),
+            )
+        if entry["kind"] == "reset" and entry["cause"] == "record-invalid":
+            receipt_ref = entry["replay_receipt_pr"]
+            prior_receipts.append(
+                (
+                    f"docs/tenkz/soak-replay/{receipt_ref[1:]}.json",
+                    entry["replay_receipt_sha256"],
+                )
+            )
 
 
 def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
@@ -920,7 +983,7 @@ def set_review_permission(facts: Context, ref: str, permission: str | None) -> N
     facts.prs[ref] = replace(
         pull_request,
         reviews=tuple(
-            replace(item, repository_permission=permission)
+            replace(item, repository_top_level_permission=permission)
             for item in pull_request.reviews
         ),
     )
@@ -930,6 +993,7 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
     entries = parsed_entries(*blocks)
     prepare_reset_receipts(entries, facts)
     prepare_resolution_facts(entries, facts)
+    prepare_receipt_retention(entries, facts)
     if "audit" not in overrides:
         boundary: str | None = None
         target_oid = facts.prs[ACTIVATION].merge_commit_oid
@@ -1121,16 +1185,19 @@ def main() -> int:
     assert validate(complete_log(), context()) == "signed-off-awaiting-tag"
 
     # Every approval path uses the policy's closed collaborator-permission set.
-    for denied_permission in (None, "pull", "triage"):
+    for denied_permission in (None, "none", "read", "maintain", "push", "triage"):
         denied_activation = context()
         set_review_permission(denied_activation, ACTIVATION, denied_permission)
         expect_failure(
             lambda facts=denied_activation: validate([], facts),
             "repository-authorized independent exact-head approval",
         )
+    admin_reviewer = context()
+    set_review_permission(admin_reviewer, ACTIVATION, "admin")
+    assert validate([], admin_reviewer) == "not-started"
 
     denied_source = context()
-    set_review_permission(denied_source, SOURCE, "pull")
+    set_review_permission(denied_source, SOURCE, "read")
     denied_source.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
     expect_failure(
         lambda: validate([freeze()], denied_source),
@@ -1138,7 +1205,7 @@ def main() -> int:
     )
 
     denied_work = context()
-    set_review_permission(denied_work, FORMAL_WORK, "triage")
+    set_review_permission(denied_work, FORMAL_WORK, "read")
     denied_work.prs[FORMAL_RECORD] = candidate_pr(904, author="record-author")
     expect_failure(
         lambda: validate(complete_log()[:2], denied_work),
@@ -1146,7 +1213,7 @@ def main() -> int:
     )
 
     denied_release = context()
-    set_review_permission(denied_release, RELEASE_PREP, "pull")
+    set_review_permission(denied_release, RELEASE_PREP, "read")
     signoff_head = denied_release.prs[SIGNOFF_RECORD].head_oid
     assert signoff_head is not None
     denied_release.prs[SIGNOFF_RECORD] = candidate_pr(
@@ -1170,7 +1237,7 @@ def main() -> int:
                 "release-reviewer",
                 SIGNOFF_REVIEW,
                 signoff_head,
-                permission="pull",
+                permission="read",
             ),
         ),
     )
@@ -1195,7 +1262,7 @@ def main() -> int:
     receipt_entries = parsed_entries(*receipt_log)
     prepare_reset_receipts(receipt_entries, denied_receipt)
     receipt_ref = receipt_entries[-1]["replay_receipt_pr"]
-    set_review_permission(denied_receipt, receipt_ref, "triage")
+    set_review_permission(denied_receipt, receipt_ref, "read")
     expect_failure(
         lambda: validate(
             receipt_log,
@@ -1262,14 +1329,15 @@ def main() -> int:
         prepare_reset_receipts(entries, facts)
         receipt_ref = entries[-1]["replay_receipt_pr"]
         receipt_digest = entries[-1]["replay_receipt_sha256"]
+        candidate_head = facts.prs["#908"].head_oid
+        assert candidate_head is not None
         replay = facts.resolve_replay_record_invalid_reset(
             "S1-0002",
             "S1-0001",
             receipt_ref,
             receipt_digest,
+            candidate_head,
         )
-        candidate_head = facts.prs["#908"].head_oid
-        assert candidate_head is not None
         audit = audit_evidence(
             "S1-0001",
             ("S1-0001",),
@@ -1290,7 +1358,16 @@ def main() -> int:
         ("receipt_candidate_main_tip_exact", False, "exact current main tip"),
         ("changes_exactly_one_new_regular_blob", False, "new regular blob"),
         ("receipt_path", "docs/tenkz/soak-replay/wrong.json", "wrong path"),
-        ("raw_blob_read_from_receipt_integration", False, "reachable integration"),
+        (
+            "raw_blob_read_from_current_validation_tree",
+            False,
+            "current validation tree",
+        ),
+        (
+            "current_tree_blob_has_exact_path_mode_bytes_and_digest",
+            False,
+            "does not retain the exact receipt blob",
+        ),
         ("schema_path", "schema.json", "used another schema"),
         ("schema_support_tree_oid", oid(99_993), "used another support tree"),
         ("schema_from_pinned_support_tree", False, "pinned support tree"),
@@ -1367,6 +1444,22 @@ def main() -> int:
         "candidate base differs from receipt integration",
     )
 
+    missing_receipt_in_head_blocks, missing_receipt_in_head, head_audit, _replay = (
+        reset_candidate_case()
+    )
+    missing_receipt_in_head.records["S1-0002"] = replace(
+        missing_receipt_in_head.records["S1-0002"],
+        receipt_blob_preserved_from_candidate_base_to_head=False,
+    )
+    expect_failure(
+        lambda: validate(
+            missing_receipt_in_head_blocks,
+            missing_receipt_in_head,
+            audit=head_audit,
+        ),
+        "reset head does not preserve its receipt blob",
+    )
+
     invalid_acknowledgement = context()
     add_record(
         invalid_acknowledgement,
@@ -1390,6 +1483,153 @@ def main() -> int:
             "S1-0002",
             ("S1-0001", "S1-0002"),
             target_oid=invalid_acknowledgement.prs["#908"].merge_commit_oid,
+        ),
+    ) == "reset-required:S1-0001"
+
+    def retained_receipt_case(candidate_record: bool) -> tuple[list[str], Context, str]:
+        blocks = [
+            freeze(),
+            reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+            correction("S1-0003", "#909", "S1-0001"),
+        ]
+        facts = context()
+        add_record(
+            facts,
+            "S1-0002",
+            "#908",
+            908,
+            FREEZE_TIME + timedelta(seconds=1),
+        )
+        add_record(
+            facts,
+            "S1-0003",
+            "#909",
+            909,
+            FREEZE_TIME + timedelta(seconds=2),
+        )
+        if candidate_record:
+            facts.prs["#909"] = candidate_pr(909, author="record-author")
+        entries = parsed_entries(*blocks)
+        prepare_reset_receipts(entries, facts)
+        prepare_receipt_retention(entries, facts)
+        return blocks, facts, entries[1]["replay_receipt_pr"]
+
+    retained_candidate, retained_candidate_facts, receipt_ref = retained_receipt_case(True)
+    retained_candidate_facts.prs[receipt_ref] = replace(
+        retained_candidate_facts.prs[receipt_ref],
+        integration_reachable_from_main=False,
+    )
+    assert validate(retained_candidate, retained_candidate_facts) == "correction-pending"
+
+    missing_current_blob, missing_current_blob_facts, receipt_ref = retained_receipt_case(
+        False
+    )
+    missing_current_blob = missing_current_blob[:2]
+    current_tree_oid = missing_current_blob_facts.prs["#908"].merge_commit_oid
+    assert current_tree_oid is not None
+    receipt_entry = parsed_entries(*missing_current_blob)[1]
+    replay = missing_current_blob_facts.resolve_replay_record_invalid_reset(
+        "S1-0002",
+        "S1-0001",
+        receipt_ref,
+        receipt_entry["replay_receipt_sha256"],
+        current_tree_oid,
+    )
+    missing_current_blob_facts.reset_replays["S1-0002"] = replace(
+        replay,
+        current_tree_blob_has_exact_path_mode_bytes_and_digest=False,
+    )
+    assert validate(
+        missing_current_blob,
+        missing_current_blob_facts,
+        audit=audit_evidence(
+            "S1-0002",
+            (),
+            target_oid=current_tree_oid,
+        ),
+    ) == "reset-required:S1-0001"
+
+    unreachable_creation_blocks, unreachable_creation, creation_audit, _replay = (
+        reset_candidate_case()
+    )
+    receipt_ref = parsed_entries(*unreachable_creation_blocks)[1]["replay_receipt_pr"]
+    unreachable_creation.prs[receipt_ref] = replace(
+        unreachable_creation.prs[receipt_ref],
+        integration_reachable_from_main=False,
+    )
+    expect_failure(
+        lambda: validate(
+            unreachable_creation_blocks,
+            unreachable_creation,
+            audit=creation_audit,
+        ),
+        "integration is not reachable from main",
+    )
+
+    retention_candidate_failures = (
+        (
+            "candidate_target_preserves_prior_receipts",
+            False,
+            "candidate target does not retain every prior receipt",
+        ),
+        (
+            "head_preserves_prior_receipts",
+            False,
+            "exact head does not retain every prior receipt",
+        ),
+        (
+            "entry_diff_untouched_prior_receipts",
+            False,
+            "diff changes a prior receipt path",
+        ),
+        (
+            "validated_prior_receipts",
+            (("docs/tenkz/soak-replay/wrong.json", "0" * 64),),
+            "another prior-receipt set",
+        ),
+    )
+    for field_name, bad_value, error_fragment in retention_candidate_failures:
+        blocks, facts, _receipt_ref = retained_receipt_case(True)
+        facts.records["S1-0003"] = replace(
+            facts.records["S1-0003"],
+            **{field_name: bad_value},
+        )
+        expect_failure(
+            lambda blocks=blocks, facts=facts: validate(blocks, facts),
+            error_fragment,
+        )
+
+    retained_postmerge, retained_postmerge_facts, _receipt_ref = retained_receipt_case(False)
+    retained_postmerge_facts.records["S1-0003"] = replace(
+        retained_postmerge_facts.records["S1-0003"],
+        integration_preserves_prior_receipts=False,
+    )
+    assert validate(retained_postmerge, retained_postmerge_facts) == (
+        "reset-required:S1-0003"
+    )
+
+    missing_reset_integration = context()
+    add_record(
+        missing_reset_integration,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    missing_reset_integration.records["S1-0002"] = replace(
+        missing_reset_integration.records["S1-0002"],
+        receipt_blob_preserved_in_integration=False,
+    )
+    assert validate(
+        [
+            freeze(),
+            reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+        ],
+        missing_reset_integration,
+        audit=audit_evidence(
+            "S1-0002",
+            ("S1-0001", "S1-0002"),
+            target_oid=missing_reset_integration.prs["#908"].merge_commit_oid,
         ),
     ) == "reset-required:S1-0001"
 
@@ -1419,7 +1659,7 @@ def main() -> int:
     workflow = mutable_workflow.resolve_current_workflow(
         activation_integration,
         target_oid,
-        (".github/workflows/pr-ci.yml",),
+        (".github/workflows/tenkz-release-policy.yml",),
     )
     mutable_workflow.workflow_override = replace(
         workflow,
@@ -1429,6 +1669,43 @@ def main() -> int:
         lambda: validate(complete_log(), mutable_workflow),
         "external workflow dependency uses a mutable ref",
     )
+    workflow_failures = (
+        ("package_managers_absent", False, "invokes a package manager"),
+        ("downloaders_absent", False, "invokes a downloader"),
+        (
+            "unhashed_runtime_dependencies_absent",
+            False,
+            "unhashed runtime dependency",
+        ),
+        (
+            "runtime_fetched_executables_absent",
+            False,
+            "fetches executable content at runtime",
+        ),
+        (
+            "network_disabled_before_repository_code",
+            False,
+            "does not disable network before repository code",
+        ),
+    )
+    for field_name, bad_value, error_fragment in workflow_failures:
+        workflow_facts = context()
+        activation_integration = workflow_facts.prs[ACTIVATION].merge_commit_oid
+        target_oid = workflow_facts.prs[SIGNOFF_RECORD].merge_commit_oid
+        assert activation_integration is not None and target_oid is not None
+        workflow = workflow_facts.resolve_current_workflow(
+            activation_integration,
+            target_oid,
+            (".github/workflows/tenkz-release-policy.yml",),
+        )
+        workflow_facts.workflow_override = replace(
+            workflow,
+            **{field_name: bad_value},
+        )
+        expect_failure(
+            lambda facts=workflow_facts: validate(complete_log(), facts),
+            error_fragment,
+        )
 
     boolean_record_parent = context()
     boolean_record_parent.records["S1-0001"] = replace(
@@ -1548,7 +1825,7 @@ def main() -> int:
     )
 
     unauthorized_resolution, unauthorized_facts, fix_ref = resolution_case(True)
-    set_review_permission(unauthorized_facts, fix_ref, "pull")
+    set_review_permission(unauthorized_facts, fix_ref, "read")
     expect_failure(
         lambda: validate(unauthorized_resolution, unauthorized_facts),
         "repository-authorized independent exact-head approval",

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -3507,6 +3507,44 @@ def main() -> int:
         "publisher succeeded but the final ref is absent",
     )
 
+    # A later record-invalid reset supersedes the live sign-off state, but it
+    # cannot erase the publisher's authenticated success history.  Delayed
+    # success with no final ref remains a hard release incident after reset.
+    post_signoff_reset = context()
+    add_record(
+        post_signoff_reset,
+        "S1-0005",
+        "#908",
+        908,
+        SIGNOFF_MERGE + timedelta(seconds=1),
+        invalid_tree=True,
+    )
+    add_record(
+        post_signoff_reset,
+        "S1-0006",
+        "#909",
+        909,
+        SIGNOFF_MERGE + timedelta(seconds=3),
+    )
+    post_signoff_reset_log = complete_log() + [
+        correction("S1-0005", "#908", "S1-0002"),
+        reset("S1-0006", "#909", "record-invalid", "S1-0005"),
+    ]
+    assert validate(post_signoff_reset_log, post_signoff_reset) == "reset"
+    post_signoff_reset.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="failure",
+    )
+    assert validate(post_signoff_reset_log, post_signoff_reset) == "reset"
+    post_signoff_reset.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    expect_failure(
+        lambda: validate(post_signoff_reset_log, post_signoff_reset),
+        "publisher succeeded but the final ref is absent",
+    )
+
     published_then_drifted = context()
     published_then_drifted.publishers[oid(9071)] = publisher_evidence(
         oid(9071),

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -40,6 +40,7 @@ INVENTORY_DIGEST = "d" * 64
 TEST_CODE_TREE = "e" * 40
 TEST_SUPPORT_TREE = "1" * 40
 POLICY_DIGEST = "f" * 64
+REGRESSION_TEST = "tex-api-regression"
 
 ARMED_POLICY = {
     **policy.EXPECTED_POLICY,
@@ -148,16 +149,25 @@ def friction(
     triage: str,
     *,
     attempt: int = 1,
+    surface: str = "tex-api",
+    regression_tests: tuple[str, ...] | None = None,
 ) -> str:
+    selected_tests = regression_tests
+    if selected_tests is None and triage == "fix-compatible":
+        selected_tests = (REGRESSION_TEST,)
+    regression_line = ""
+    if selected_tests is not None:
+        rendered_tests = ", ".join(f'"{item}"' for item in selected_tests)
+        regression_line = f"\nregression_tests = [{rendered_tests}]"
     return block(
         f'''id = "{entry_id}"
 kind = "friction"
 record_pr = "{record_pr}"
 attempt = {attempt}
-surface = "tex-api"
+surface = "{surface}"
 triage = "{triage}"
 summary = "observed interface friction"
-evidence = "reproducer and triage"'''
+evidence = "reproducer and triage"{regression_line}'''
     )
 
 
@@ -324,6 +334,9 @@ class Context:
     payloads: dict[tuple[str, str], policy.ReleasePayloadEvidence]
     tags: dict[str, policy.TagEvidence]
     issues: dict[str, policy.IssueEvidence]
+    observations: dict[
+        tuple[str, str, str], policy.ReleaseTestObservationEvidence
+    ] = field(default_factory=dict)
     reset_replays: dict[str, policy.RecordInvalidResetReplayEvidence] = field(
         default_factory=dict
     )
@@ -364,6 +377,15 @@ class Context:
         _contract: policy.ReleaseContract,
     ) -> policy.ReleasePayloadEvidence:
         return self.payloads[(tree_oid, tag)]
+
+    def resolve_replay_release_test_observation(
+        self,
+        tree_oid: str,
+        tag: str,
+        test_ref: str,
+        _contract: policy.ReleaseContract,
+    ) -> policy.ReleaseTestObservationEvidence:
+        return self.observations[(tree_oid, tag, test_ref)]
 
     def resolve_replay_freeze_tag(self, tag: str) -> policy.TagEvidence:
         assert tag != policy.FINAL_TAG
@@ -475,6 +497,52 @@ def payload_evidence(
         test_execution_complete=True,
         compatibility_tests_passed=True,
         payload_blob_oids=blob_oids,
+        inventory_test_surfaces_valid=True,
+    )
+
+
+def observation_evidence(
+    tree_oid: str,
+    tag: str,
+    test_ref: str,
+    *,
+    surfaces: tuple[str, ...] = ("tex-api",),
+    exit_code: int = 1,
+) -> policy.ReleaseTestObservationEvidence:
+    contract = policy.policy_rules(ARMED_POLICY)[4]
+    return policy.ReleaseTestObservationEvidence(
+        validated_tree_oid=tree_oid,
+        validated_tag=tag,
+        validated_test_ref=test_ref,
+        validated_contract=contract,
+        complete=True,
+        manifest_path=contract.manifest_path(tag),
+        regular_distinct_paths=True,
+        manifest_contract_valid=True,
+        artifact_declarations_agree=True,
+        inventory_digest_matches=True,
+        inventory_contract_valid=True,
+        inventory_test_surfaces_valid=True,
+        inventory_test_exists=True,
+        inventory_command_exact_and_matching=True,
+        test_code_tree_matches=True,
+        test_support_tree_matches=True,
+        inventory_data_paths_within_mutable_roots=True,
+        executable_dependencies_within_code_tree=True,
+        acceptance_dependencies_within_support_tree=True,
+        subject_data_cannot_reduce_coverage=True,
+        hermetic_execution_contract_valid=True,
+        tool_fingerprints_match=True,
+        inventory_test_surfaces=surfaces,
+        exactly_one_inventory_test_run=True,
+        setup_complete_and_matching=True,
+        isolation_valid=True,
+        execution_receipt_exact_and_matching=True,
+        execution_complete=True,
+        timed_out=False,
+        terminated_by_signal=False,
+        clean_process_exit=True,
+        exit_code=exit_code,
     )
 
 
@@ -591,6 +659,7 @@ def context() -> Context:
         enforcement_workflows_pinned=True,
         policy_digest_matches=True,
         ledger_prefix_matches=True,
+        inventory_test_surfaces_valid=True,
     )
     records = {
         entry_id: policy.RecordDiffEvidence(
@@ -887,6 +956,37 @@ def prepare_receipt_retention(entries: list[dict], facts: Context) -> None:
             )
 
 
+def prepare_friction_observations(entries: list[dict], facts: Context) -> None:
+    """Populate exact head/integration failure receipts for named regressions."""
+
+    freeze_tags = {
+        entry["attempt"]: entry["freeze_tag"]
+        for entry in entries
+        if entry["kind"] == "freeze"
+    }
+    for entry in entries:
+        if entry["kind"] != "friction" or entry["triage"] != "fix-compatible":
+            continue
+        tag = freeze_tags[entry["attempt"]]
+        record = facts.prs[entry["record_pr"]]
+        trees = [record.head_oid]
+        if record.merged is True:
+            trees.append(record.merge_commit_oid)
+        for tree_oid in trees:
+            assert isinstance(tree_oid, str)
+            for test_ref in entry["regression_tests"]:
+                facts.observations.setdefault(
+                    (tree_oid, tag, test_ref),
+                    observation_evidence(
+                        tree_oid,
+                        tag,
+                        test_ref,
+                        surfaces=(entry["surface"],),
+                        exit_code=1,
+                    ),
+                )
+
+
 def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
     """Populate exact fix-PR evidence for scenarios not testing resolutions."""
 
@@ -933,10 +1033,13 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
         fix_pr = facts.prs[fix_ref]
         fix_integration = fix_pr.merge_commit_oid
         assert fix_integration is not None
+        fix_head = fix_pr.head_oid
+        assert fix_head is not None
+        fix_base = oid(fix_number * 10 - 1)
         if fix_ref not in facts.resolution_diffs:
             facts.resolution_diffs[fix_ref] = policy.ResolutionDiffEvidence(
                 validated_pr_ref=fix_ref,
-                validated_head_oid=fix_pr.head_oid,
+                validated_head_oid=fix_head,
                 validated_integration_oid=fix_integration,
                 validated_freeze_integration=freeze_integration,
                 validated_friction_integration=friction_integration,
@@ -948,14 +1051,48 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
                 integration_strict_descendant_of_freeze=True,
                 integration_strict_descendant_of_friction=True,
                 policy_paths_untouched=True,
-                has_added_or_modified_regular_nonledger_blob=True,
-                normalized_token_stream_changed=True,
-                semantic_witness_is_same_regular_nonledger_blob=True,
-                validated_contract=policy.policy_rules(ARMED_POLICY)[4],
-                inventory_commands_complete=True,
-                inventory_commands_passed=True,
-                execution_receipts_exact_and_matching=True,
+                validated_base_oid=fix_base,
+                validated_surface=friction_entry["surface"],
+                validated_fix_path_patterns=policy.policy_rules(ARMED_POLICY)[
+                    4
+                ].fix_paths(friction_entry["surface"]),
+                semantic_witness_path="tex/tenkz/tenkz.sty",
+                surface_matching_added_or_modified_regular_blob=True,
+                tex_comment_stripped_token_stream_changed=True,
+                semantic_witness_is_same_surface_regular_blob=True,
             )
+        fix_diff = facts.resolution_diffs[fix_ref]
+        observation_base = fix_diff.validated_base_oid
+        if isinstance(observation_base, str):
+            for test_ref in friction_entry["regression_tests"]:
+                facts.observations.setdefault(
+                    (observation_base, freeze_entry["freeze_tag"], test_ref),
+                    observation_evidence(
+                        observation_base,
+                        freeze_entry["freeze_tag"],
+                        test_ref,
+                        surfaces=(friction_entry["surface"],),
+                        exit_code=1,
+                    ),
+                )
+                facts.observations.setdefault(
+                    (fix_head, freeze_entry["freeze_tag"], test_ref),
+                    observation_evidence(
+                        fix_head,
+                        freeze_entry["freeze_tag"],
+                        test_ref,
+                        surfaces=(friction_entry["surface"],),
+                        exit_code=0,
+                    ),
+                )
+        facts.payloads.setdefault(
+            (fix_head, freeze_entry["freeze_tag"]),
+            payload_evidence(
+                fix_head,
+                freeze_entry["freeze_tag"],
+                FREEZE_PAYLOAD_BLOBS,
+            ),
+        )
         record_diff = facts.records[entry_id]
         facts.records[entry_id] = replace(
             record_diff,
@@ -992,6 +1129,7 @@ def set_review_permission(facts: Context, ref: str, permission: str | None) -> N
 def validate(blocks: list[str], facts: Context, **overrides) -> str:
     entries = parsed_entries(*blocks)
     prepare_reset_receipts(entries, facts)
+    prepare_friction_observations(entries, facts)
     prepare_resolution_facts(entries, facts)
     prepare_receipt_retention(entries, facts)
     if "audit" not in overrides:
@@ -1018,6 +1156,9 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
         "resolve_replay_resolution_diff": facts.resolve_replay_resolution_diff,
         "resolve_replay_release_prep": facts.resolve_replay_release_prep,
         "resolve_replay_release_payload": facts.resolve_replay_release_payload,
+        "resolve_replay_release_test_observation": (
+            facts.resolve_replay_release_test_observation
+        ),
         "resolve_replay_freeze_tag": facts.resolve_replay_freeze_tag,
         "resolve_current_final_tag": facts.resolve_current_final_tag,
         "resolve_replay_issue": facts.resolve_replay_issue,
@@ -1163,6 +1304,15 @@ def main() -> int:
         lambda: validate([], empty_mixed_activation),
         "not exactly the seven permitted scalar replacements",
     )
+    invalid_activation_surfaces = context()
+    invalid_activation_surfaces.activation_diff = replace(
+        invalid_activation_surfaces.activation_diff,
+        inventory_test_surfaces_valid=False,
+    )
+    expect_failure(
+        lambda: validate([], invalid_activation_surfaces),
+        "activation inventory test surfaces are invalid",
+    )
     expect_failure(
         lambda: validate(
             [freeze()],
@@ -1178,6 +1328,35 @@ def main() -> int:
     assert policy.EXPECTED_POLICY["policy"]["work_excluded_paths"] == [
         "TNLean/Archive/**"
     ]
+    contract = policy.policy_rules(ARMED_POLICY)[4]
+    assert contract.fix_paths("tex-api") == (
+        "tex/tenkz/**/*.tex",
+        "tex/tenkz/**/*.sty",
+    )
+    assert contract.fix_paths("tnlog") == contract.fix_paths("tex-api")
+    assert policy.policy_glob_matches(
+        "tex/tenkz/tenkz.sty",
+        contract.fix_paths("tex-api")[1],
+    )
+    assert policy.policy_glob_matches(
+        "tex/tenkz/internal/parser.tex",
+        contract.fix_paths("tex-api")[0],
+    )
+    assert not policy.policy_glob_matches(
+        "TNLean/Fix.lean",
+        contract.fix_paths("tex-api")[0],
+    )
+    wrong_fix_paths = {
+        **ARMED_POLICY,
+        "policy": {
+            **ARMED_POLICY["policy"],
+            "tex_api_fix_paths": ["TNLean/**/*.lean"],
+        },
+    }
+    expect_failure(
+        lambda: policy.policy_rules(wrong_fix_paths),
+        "differs from the signed policy",
+    )
     assert "event_format_implementation" not in policy.EXPECTED_POLICY["policy"]
 
     # Both qualifying merges, the sign-off review, and sign-off merge occur in
@@ -1741,6 +1920,104 @@ def main() -> int:
         "reset-required:S1-0002"
     )
 
+    missing_regression_tests = friction(
+        "S1-0002",
+        FORMAL_RECORD,
+        "fix-compatible",
+    ).replace(f'\nregression_tests = ["{REGRESSION_TEST}"]', "")
+    expect_failure(
+        lambda: policy.validate_entry_shape(
+            parsed_entries(freeze(), missing_regression_tests)[1],
+            2,
+        ),
+        "fields differ from schema",
+    )
+
+    forbidden_regression_tests = friction(
+        "S1-0002",
+        FORMAL_RECORD,
+        "defer-to-2.0",
+        regression_tests=(REGRESSION_TEST,),
+    )
+    expect_failure(
+        lambda: policy.validate_entry_shape(
+            parsed_entries(freeze(), forbidden_regression_tests)[1],
+            2,
+        ),
+        "fields differ from schema",
+    )
+
+    for bad_tests, error_fragment in (
+        (("Bad_Test",), "invalid regression test"),
+        ((REGRESSION_TEST, REGRESSION_TEST), "has duplicates"),
+    ):
+        expect_failure(
+            lambda tests=bad_tests: validate(
+                [
+                    freeze(),
+                    friction(
+                        "S1-0002",
+                        FORMAL_RECORD,
+                        "fix-compatible",
+                        regression_tests=tests,
+                    ),
+                ],
+                context(),
+            ),
+            error_fragment,
+        )
+
+    def friction_case(candidate_record: bool) -> tuple[list[str], Context, tuple[str, str, str]]:
+        blocks = [
+            freeze(),
+            friction("S1-0002", FORMAL_RECORD, "fix-compatible"),
+        ]
+        facts = context()
+        if candidate_record:
+            facts.prs[FORMAL_RECORD] = candidate_pr(904, author="record-author")
+        entries = parsed_entries(*blocks)
+        prepare_friction_observations(entries, facts)
+        record = facts.prs[FORMAL_RECORD]
+        tree_oid = record.head_oid if candidate_record else record.merge_commit_oid
+        assert isinstance(tree_oid, str)
+        return blocks, facts, (tree_oid, "tenkz-v0.9.0", REGRESSION_TEST)
+
+    friction_observation_failures = (
+        ("inventory_test_surfaces", ("tnlog",), "does not cover surface tex-api"),
+        ("inventory_test_surfaces", (), "test surfaces are missing"),
+        ("inventory_test_surfaces", ("tex-api", "tex-api"), "surfaces have duplicates"),
+        ("inventory_test_exists", False, "test is absent from inventory"),
+        ("inventory_command_exact_and_matching", False, "command differs from the pinned"),
+        ("timed_out", True, "timed out"),
+        ("terminated_by_signal", True, "ended by signal"),
+        ("setup_complete_and_matching", False, "setup is incomplete"),
+        ("isolation_valid", False, "isolation failed"),
+        ("execution_complete", False, "execution is incomplete"),
+        ("clean_process_exit", False, "did not exit cleanly"),
+        ("exit_code", 0, "did not reproduce friction"),
+        ("exit_code", True, "invalid process exit code"),
+        ("validated_tag", "tenkz-v0.9.1", "used another freeze tag"),
+    )
+    for field_name, bad_value, error_fragment in friction_observation_failures:
+        blocks, facts, observation_key = friction_case(True)
+        facts.observations[observation_key] = replace(
+            facts.observations[observation_key],
+            **{field_name: bad_value},
+        )
+        expect_failure(
+            lambda blocks=blocks, facts=facts: validate(blocks, facts),
+            error_fragment,
+        )
+
+    postmerge_friction, postmerge_friction_facts, integration_key = friction_case(False)
+    postmerge_friction_facts.observations[integration_key] = replace(
+        postmerge_friction_facts.observations[integration_key],
+        exit_code=0,
+    )
+    assert validate(postmerge_friction, postmerge_friction_facts) == (
+        "reset-required:S1-0002"
+    )
+
     missing_fix_pr = resolution("S1-0003", RMP_RECORD, "S1-0002").replace(
         '\nfix_pr = "#18003"',
         "",
@@ -1755,6 +2032,80 @@ def main() -> int:
             3,
         ),
         "fields differ from schema",
+    )
+
+    empty_regression_resolution = [
+        freeze(),
+        friction(
+            "S1-0002",
+            FORMAL_RECORD,
+            "fix-compatible",
+            regression_tests=(),
+        ),
+        resolution("S1-0003", RMP_RECORD, "S1-0002"),
+    ]
+    expect_failure(
+        lambda: validate(empty_regression_resolution, context()),
+        "cannot resolve an empty regression-test evidence gap",
+    )
+
+    empty_gap_signoff = [
+        freeze(),
+        friction(
+            "S1-0002",
+            FORMAL_RECORD,
+            "fix-compatible",
+            regression_tests=(),
+        ),
+        work(
+            "S1-0003",
+            RMP_RECORD,
+            FORMAL_WORK,
+            "formalization-or-blueprint",
+        ),
+        work("S1-0004", "#930", RMP_WORK, "rmp-benchmark"),
+        sign_off("S1-0005", "#931", ["S1-0003", "S1-0004"]),
+    ]
+    empty_gap_facts = context()
+    add_record(
+        empty_gap_facts,
+        "S1-0004",
+        "#930",
+        930,
+        FREEZE_TIME + timedelta(seconds=8),
+    )
+    add_record(
+        empty_gap_facts,
+        "S1-0005",
+        "#931",
+        931,
+        SIGNOFF_MERGE,
+    )
+    empty_gap_head = empty_gap_facts.prs["#931"].head_oid
+    assert isinstance(empty_gap_head, str)
+    empty_gap_facts.prs["#931"] = replace(
+        empty_gap_facts.prs["#931"],
+        author_login="release-author",
+        reviews=(review("release-reviewer", SIGNOFF_REVIEW, empty_gap_head),),
+    )
+    empty_gap_facts.records["S1-0005"] = replace(
+        empty_gap_facts.records["S1-0005"],
+        candidate_main_tip_is_release_integration=True,
+        integration_parent_is_release_integration=True,
+        validated_release_integration=empty_gap_facts.prs[RELEASE_PREP].merge_commit_oid,
+        validated_work_integrations=(
+            empty_gap_facts.prs[FORMAL_WORK].merge_commit_oid,
+            empty_gap_facts.prs[RMP_WORK].merge_commit_oid,
+        ),
+    )
+    empty_gap_facts.payloads[(empty_gap_head, policy.FINAL_TAG)] = payload_evidence(
+        empty_gap_head,
+        policy.FINAL_TAG,
+        FINAL_PAYLOAD_BLOBS,
+    )
+    expect_failure(
+        lambda: validate(empty_gap_signoff, empty_gap_facts),
+        "unresolved friction: S1-0002",
     )
 
     def resolution_case(candidate_record: bool) -> tuple[list[str], Context, str]:
@@ -1777,20 +2128,24 @@ def main() -> int:
 
     resolution_diff_failures = (
         (
-            "has_added_or_modified_regular_nonledger_blob",
+            "surface_matching_added_or_modified_regular_blob",
             False,
-            "no added or modified regular non-ledger blob",
+            "no added or modified surface-owned TeX blob",
         ),
         (
-            "normalized_token_stream_changed",
+            "tex_comment_stripped_token_stream_changed",
             False,
-            "no semantic normalized-token change",
+            "no TeX-comment-stripped token change",
         ),
         (
-            "semantic_witness_is_same_regular_nonledger_blob",
+            "semantic_witness_is_same_surface_regular_blob",
             False,
-            "not one qualifying blob",
+            "not one surface-owned TeX blob",
         ),
+        ("validated_base_oid", "bad", "merge base is missing or malformed"),
+        ("validated_surface", "tnlog", "used another compatibility surface"),
+        ("validated_fix_path_patterns", ("TNLean/**/*.lean",), "another surface path set"),
+        ("semantic_witness_path", "TNLean/Fix.lean", "not surface-owned TeX"),
         ("validated_head_oid", oid(99_980), "not validated at its exact head"),
         (
             "integration_strict_descendant_of_friction",
@@ -1798,13 +2153,6 @@ def main() -> int:
             "does not descend from its friction record",
         ),
         ("policy_paths_untouched", False, "changes policy or the soak ledger"),
-        ("inventory_commands_complete", False, "every pinned inventory command"),
-        ("inventory_commands_passed", False, "failed a pinned inventory command"),
-        (
-            "execution_receipts_exact_and_matching",
-            False,
-            "execution receipts are incomplete",
-        ),
     )
     for field_name, bad_value, error_fragment in resolution_diff_failures:
         blocks, facts, fix_ref = resolution_case(True)
@@ -1816,6 +2164,101 @@ def main() -> int:
             lambda blocks=blocks, facts=facts: validate(blocks, facts),
             error_fragment,
         )
+
+    # Neither an unrelated Lean-only change nor a test-only change supplies
+    # the required surface-owned TeX implementation witness.
+    for rejected_path in ("TNLean/Fix.lean", "tests/tenkz/test_fix.py"):
+        blocks, facts, fix_ref = resolution_case(True)
+        facts.resolution_diffs[fix_ref] = replace(
+            facts.resolution_diffs[fix_ref],
+            semantic_witness_path=rejected_path,
+        )
+        expect_failure(
+            lambda blocks=blocks, facts=facts: validate(blocks, facts),
+            "semantic witness path is not surface-owned TeX",
+        )
+
+    def fix_observation_keys(
+        facts: Context,
+        fix_ref: str,
+    ) -> tuple[tuple[str, str, str], tuple[str, str, str]]:
+        fix_base = facts.resolution_diffs[fix_ref].validated_base_oid
+        fix_head = facts.prs[fix_ref].head_oid
+        assert isinstance(fix_base, str) and isinstance(fix_head, str)
+        tag = "tenkz-v0.9.0"
+        return (
+            (fix_base, tag, REGRESSION_TEST),
+            (fix_head, tag, REGRESSION_TEST),
+        )
+
+    base_passes, base_passes_facts, fix_ref = resolution_case(True)
+    base_key, _head_key = fix_observation_keys(base_passes_facts, fix_ref)
+    base_passes_facts.observations[base_key] = replace(
+        base_passes_facts.observations[base_key],
+        exit_code=0,
+    )
+    expect_failure(
+        lambda: validate(base_passes, base_passes_facts),
+        "fix-base test tex-api-regression regression test did not reproduce friction",
+    )
+
+    head_fails, head_fails_facts, fix_ref = resolution_case(True)
+    _base_key, head_key = fix_observation_keys(head_fails_facts, fix_ref)
+    head_fails_facts.observations[head_key] = replace(
+        head_fails_facts.observations[head_key],
+        exit_code=9,
+    )
+    expect_failure(
+        lambda: validate(head_fails, head_fails_facts),
+        "fix-head test tex-api-regression regression test did not pass",
+    )
+
+    wrong_fix_tag, wrong_fix_tag_facts, fix_ref = resolution_case(True)
+    _base_key, head_key = fix_observation_keys(wrong_fix_tag_facts, fix_ref)
+    wrong_fix_tag_facts.observations[head_key] = replace(
+        wrong_fix_tag_facts.observations[head_key],
+        validated_tag="tenkz-v0.9.1",
+    )
+    expect_failure(
+        lambda: validate(wrong_fix_tag, wrong_fix_tag_facts),
+        "fix-head test tex-api-regression used another freeze tag",
+    )
+
+    incomplete_fix_payload, incomplete_fix_payload_facts, fix_ref = resolution_case(True)
+    fix_head = incomplete_fix_payload_facts.prs[fix_ref].head_oid
+    assert isinstance(fix_head, str)
+    payload_key = (fix_head, "tenkz-v0.9.0")
+    incomplete_fix_payload_facts.payloads[payload_key] = replace(
+        incomplete_fix_payload_facts.payloads[payload_key],
+        compatibility_tests_passed=False,
+    )
+    expect_failure(
+        lambda: validate(incomplete_fix_payload, incomplete_fix_payload_facts),
+        "fix head release compatibility tests did not pass",
+    )
+
+    invalid_inventory_surfaces, invalid_inventory_facts, fix_ref = resolution_case(True)
+    fix_head = invalid_inventory_facts.prs[fix_ref].head_oid
+    assert isinstance(fix_head, str)
+    payload_key = (fix_head, "tenkz-v0.9.0")
+    invalid_inventory_facts.payloads[payload_key] = replace(
+        invalid_inventory_facts.payloads[payload_key],
+        inventory_test_surfaces_valid=False,
+    )
+    expect_failure(
+        lambda: validate(invalid_inventory_surfaces, invalid_inventory_facts),
+        "fix head test inventory has invalid surface declarations",
+    )
+
+    postmerge_recheck, postmerge_recheck_facts, fix_ref = resolution_case(False)
+    _base_key, head_key = fix_observation_keys(postmerge_recheck_facts, fix_ref)
+    postmerge_recheck_facts.observations[head_key] = replace(
+        postmerge_recheck_facts.observations[head_key],
+        exit_code=2,
+    )
+    assert validate(postmerge_recheck, postmerge_recheck_facts) == (
+        "reset-required:S1-0003"
+    )
 
     unreviewed_resolution, unreviewed_facts, fix_ref = resolution_case(True)
     unreviewed_facts.prs[fix_ref] = replace(unreviewed_facts.prs[fix_ref], reviews=())

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -35,11 +35,15 @@ RMP_MERGE = FREEZE_TIME + timedelta(seconds=2)
 RELEASE_MERGE = FREEZE_TIME + timedelta(seconds=2, microseconds=500_000)
 SIGNOFF_REVIEW = FREEZE_TIME + timedelta(seconds=3)
 SIGNOFF_MERGE = FREEZE_TIME + timedelta(seconds=11)
+SIGNOFF_TAGGER_EPOCH = int(SIGNOFF_MERGE.timestamp())
 PREREQUISITES = '["#5086", "#4699", "#4162", "#4703", "#4708", "#4163"]'
 INVENTORY_DIGEST = "d" * 64
 TEST_CODE_TREE = "e" * 40
 TEST_SUPPORT_TREE = "1" * 40
 POLICY_DIGEST = "f" * 64
+PREFIX_DIGEST = "3" * 64
+FINAL_TAG_SCHEMA_BLOB = "4" * 40
+FINAL_TAG_PUBLIC_KEY_BLOB = "5" * 40
 REGRESSION_TEST = "tex-api-regression"
 FAILURE_FINGERPRINT = "2" * 64
 
@@ -334,14 +338,27 @@ def publisher_evidence(
     integration_oid: str,
     *,
     status: str = "not-run",
-    object_oid: str = FINAL_TAG_OBJECT,
+    tagger_epoch_seconds: int = SIGNOFF_TAGGER_EPOCH,
+    prefix_boundary: str = "S1-0004",
+    prior_released: bool = False,
 ) -> policy.FinalTagPublisherEvidence:
-    ran = status in {"success", "failure"}
+    ran = status in {"incomplete", "failure", "success"}
     succeeded = status == "success"
     return policy.FinalTagPublisherEvidence(
         validated_integration_oid=integration_oid,
+        validated_tagger_epoch_seconds=tagger_epoch_seconds,
+        validated_policy_sha256=POLICY_DIGEST,
+        validated_prefix_sha256=PREFIX_DIGEST,
+        validated_prefix_boundary=prefix_boundary,
+        validated_support_tree_oid=TEST_SUPPORT_TREE,
+        validated_schema_blob_oid=FINAL_TAG_SCHEMA_BLOB,
+        validated_public_key_blob_oid=FINAL_TAG_PUBLIC_KEY_BLOB,
         complete=True,
-        pinned_workflow_run_exact=True,
+        workflow_runs_complete_and_paginated=True,
+        workflow_jobs_complete_and_paginated=True,
+        release_validation_runs_complete_and_paginated=True,
+        prior_released_validation_exact_and_successful=prior_released,
+        pinned_workflow_runs_exact=True,
         postmerge_validation_succeeded=True,
         postmerge_validation_network_disabled=True,
         publisher_status=status,
@@ -350,15 +367,97 @@ def publisher_evidence(
         validation_jobs_lack_contents_write=True,
         publisher_has_only_contents_write=True,
         publisher_has_no_checkout_or_repository_execution=True,
-        publisher_uses_version_fingerprinted_hosted_gh=True,
+        publisher_has_no_uses_or_inherited_secrets=True,
+        publisher_uses_only_version_fingerprinted_hosted_gh_git_ssh_keygen=True,
         publisher_command_and_inputs_closed=True,
         publisher_uses_only_github_control_plane=True,
         other_networked_steps_absent=True,
-        final_ref_absent_before_create=True if succeeded else None,
-        annotated_tag_object_targets_integration=True if succeeded else None,
-        ref_created_without_force=True if succeeded else None,
-        readback_complete_and_matching=True if succeeded else None,
-        reported_tag_object_oid=object_oid if succeeded else None,
+        closed_needs_tuple_complete_and_matching=True,
+        closed_needs_has_no_caller_substitute=True,
+        github_metadata_matches_closed_needs=True,
+        caller_controlled_inputs_absent=True,
+        exact_git_objects_fetched_by_oid_and_verified=True,
+        publisher_environment_and_secret_exact=True,
+        publisher_is_only_private_key_consumer=True,
+        deterministic_signed_tag_object_contract=True,
+        signature_algorithm_and_namespace_exact=True,
+        tagger_epoch_exact_canonical_and_in_range=True,
+        publisher_reads_ref_before_private_key_access=True,
+        private_key_available_only_to_absent_ref_path=True,
+        existing_ref_path_cannot_access_private_key=True,
+        absent_ref_candidate_authenticated_before_write=True,
+        existing_ref_object_authenticated_without_mutation=True,
+        publisher_success_requires_authenticated_final_readback=True,
+        publisher_emits_no_durable_output_receipt=True,
+        successful_job_head_matches_integration=True if succeeded else None,
+        successful_job_historical_workflow_tree_matches_activation=(
+            True if succeeded else None
+        ),
+        successful_job_follows_successful_postmerge_validation=(
+            True if succeeded else None
+        ),
+        successful_job_conclusion_api_visible=True if succeeded else None,
+    )
+
+
+def authenticated_final_tag(
+    integration_oid: str,
+    *,
+    object_oid: str = FINAL_TAG_OBJECT,
+    tagger_epoch_seconds: int = SIGNOFF_TAGGER_EPOCH,
+    prefix_boundary: str = "S1-0004",
+) -> policy.TagEvidence:
+    return policy.TagEvidence(
+        object_oid,
+        "tag",
+        integration_oid,
+        exists=True,
+        final_lookup_before_fetch_object_id=object_oid,
+        final_fetched_object_id=object_oid,
+        final_lookup_after_fetch_object_id=object_oid,
+        final_network_disabled_before_object_read=True,
+        final_raw_object_bytes_complete=True,
+        final_object_schema_valid=True,
+        final_recomputed_object_id=object_oid,
+        final_signature_algorithm="ssh-ed25519",
+        final_signature_namespace="git",
+        final_raw_signature_valid=True,
+        final_public_key_blob_oid=FINAL_TAG_PUBLIC_KEY_BLOB,
+        final_public_key_from_pinned_support_tree=True,
+        final_schema_blob_oid=FINAL_TAG_SCHEMA_BLOB,
+        final_schema_from_pinned_support_tree=True,
+        final_tagger_identity_matches_schema=True,
+        final_tagger_epoch_seconds=tagger_epoch_seconds,
+        final_tagger_timezone="+0000",
+        final_message_tag=policy.FINAL_TAG,
+        final_message_integration_oid=integration_oid,
+        final_message_policy_sha256=POLICY_DIGEST,
+        final_message_prefix_sha256=PREFIX_DIGEST,
+        final_message_prefix_boundary=prefix_boundary,
+        final_commit_reachable_from_main=True,
+    )
+
+
+def publisher_secret_evidence(
+    *,
+    retired: bool = False,
+    locations: tuple[str, ...] | None = None,
+) -> policy.PublisherSecretEvidence:
+    if locations is None:
+        locations = () if retired else ("environment:tenkz-release-publisher",)
+    return policy.PublisherSecretEvidence(
+        validated_environment="tenkz-release-publisher",
+        validated_secret_name="TENKZ_FINAL_TAG_SIGNING_KEY",
+        validated_secret_scope="environment-only-no-shadow",
+        validated_key_retirement="required-before-released",
+        complete=True,
+        repository_environments_complete_and_paginated=True,
+        all_environment_secret_names_complete_and_paginated=True,
+        repository_secret_names_complete_and_paginated=True,
+        organization_secret_names_and_access_complete_and_paginated=True,
+        configured_secret_locations=locations,
+        dedicated_environment_configuration_complete=True,
+        dedicated_environment_restricts_protected_release_branch=True,
     )
 
 
@@ -381,6 +480,7 @@ class Context:
         default_factory=dict
     )
     workflow_override: policy.WorkflowEvidence | None = None
+    publisher_secret_override: policy.PublisherSecretEvidence | None = None
 
     def resolve_replay_activation_diff(self, _ref: str) -> policy.ActivationDiffEvidence:
         return self.activation_diff
@@ -440,10 +540,34 @@ class Context:
         self,
         integration_oid: str,
     ) -> policy.FinalTagPublisherEvidence:
-        return self.publishers.get(
-            integration_oid,
-            publisher_evidence(integration_oid),
-        )
+        override = self.publishers.get(integration_oid)
+        if override is not None:
+            return override
+        for entry_id, record_diff in self.records.items():
+            record_ref = record_diff.validated_pr_ref
+            if record_ref is None:
+                continue
+            record = self.prs.get(record_ref)
+            if record is not None and record.merge_commit_oid == integration_oid:
+                assert record.merged_at is not None
+                return publisher_evidence(
+                    integration_oid,
+                    tagger_epoch_seconds=policy.canonical_tagger_epoch_seconds(
+                        record.merged_at,
+                        f"{record_ref} mergedAt",
+                    ),
+                    prefix_boundary=entry_id,
+                )
+        raise AssertionError(f"no sign-off record resolves to {integration_oid}")
+
+    def resolve_current_publisher_secret(
+        self,
+        _environment: str,
+        _secret_name: str,
+        _secret_scope: str,
+        _key_retirement: str,
+    ) -> policy.PublisherSecretEvidence:
+        return self.publisher_secret_override or publisher_secret_evidence()
 
     def resolve_replay_issue(self, issue: str) -> policy.IssueEvidence:
         return self.issues[issue]
@@ -494,6 +618,7 @@ class Context:
         activation_integration: str,
         target_oid: str,
         paths: tuple[str, ...],
+        publisher_workflow_root: str,
     ) -> policy.WorkflowEvidence:
         if self.workflow_override is not None:
             return self.workflow_override
@@ -501,6 +626,7 @@ class Context:
             validated_activation_integration=activation_integration,
             validated_target_oid=target_oid,
             validated_paths=paths,
+            validated_publisher_workflow_root=publisher_workflow_root,
             complete=True,
             activation_paths_are_regular_blobs=True,
             target_blobs_and_modes_match_activation=True,
@@ -516,6 +642,12 @@ class Context:
             candidate_diff_untouched=True,
             github_checks_bind_exact_head_and_workflows=True,
             supervisor_receipt_complete_and_matching=True,
+            activation_publisher_workflow_tree_complete=True,
+            target_publisher_workflow_tree_matches_activation=True,
+            workflow_jobs_complete_and_paginated=True,
+            publisher_is_sole_environment_consumer=True,
+            publisher_is_sole_secret_consumer=True,
+            workflow_secret_inheritance_absent=True,
         )
 
 
@@ -748,6 +880,18 @@ def context() -> Context:
         hermetic_execution_contract_valid=True,
         supervisor_self_test_receipt_valid=True,
         enforcement_workflows_pinned=True,
+        publisher_workflow_tree_pinned=True,
+        publisher_workflow_jobs_complete_and_paginated=True,
+        publisher_is_sole_environment_consumer=True,
+        publisher_is_sole_secret_consumer=True,
+        workflow_secret_inheritance_absent=True,
+        publisher_environment_configuration_complete=True,
+        publisher_environment_restricts_protected_release_branch=True,
+        repository_environments_complete_and_paginated=True,
+        all_environment_secret_names_complete_and_paginated=True,
+        repository_secret_names_complete_and_paginated=True,
+        organization_secret_names_and_access_complete_and_paginated=True,
+        configured_secret_only_in_dedicated_environment=True,
         policy_digest_matches=True,
         ledger_prefix_matches=True,
     )
@@ -1329,6 +1473,7 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
         "resolve_replay_freeze_tag": facts.resolve_replay_freeze_tag,
         "resolve_current_final_tag": facts.resolve_current_final_tag,
         "resolve_final_tag_publisher": facts.resolve_final_tag_publisher,
+        "resolve_current_publisher_secret": facts.resolve_current_publisher_secret,
         "resolve_replay_issue": facts.resolve_replay_issue,
         "resolve_replay_record_invalid_reset": facts.resolve_replay_record_invalid_reset,
         "resolve_current_workflow": facts.resolve_current_workflow,
@@ -1528,6 +1673,41 @@ def main() -> int:
         "TNLean/Fix.lean",
         contract.fix_paths("tex-api")[0],
     )
+    assert contract.tag_signature == "ssh-ed25519"
+    assert contract.tag_public_key.endswith("final-tag-signing-key.pub")
+    assert contract.tag_object_schema.endswith("final-tag-object-v1.schema.json")
+    assert contract.publisher_environment == "tenkz-release-publisher"
+    assert contract.publisher_secret == "TENKZ_FINAL_TAG_SIGNING_KEY"
+    assert contract.publisher_secret_scope == "environment-only-no-shadow"
+    assert contract.publisher_key_retirement == "required-before-released"
+    assert contract.publisher_workflow_root == ".github/workflows"
+    assert {
+        "validated_signoff_merged_at",
+        "successful_publisher_object_oids",
+        "publisher_operation",
+        "reported_tag_object_oid",
+        "ref_created_without_force",
+        "readback_complete_and_matching",
+    }.isdisjoint(policy.FinalTagPublisherEvidence.__dataclass_fields__)
+    assert "final_tagger_merged_at" not in policy.TagEvidence.__dataclass_fields__
+    assert (
+        policy.canonical_tagger_epoch_seconds(SIGNOFF_MERGE, "sign-off mergedAt")
+        == SIGNOFF_TAGGER_EPOCH
+    )
+    expect_failure(
+        lambda: policy.canonical_tagger_epoch_seconds(
+            SIGNOFF_MERGE + timedelta(microseconds=1),
+            "sign-off mergedAt",
+        ),
+        "not an unambiguous integral UTC instant",
+    )
+    expect_failure(
+        lambda: policy.canonical_tagger_epoch_seconds(
+            SIGNOFF_MERGE.astimezone(timezone(timedelta(hours=1))),
+            "sign-off mergedAt",
+        ),
+        "not an unambiguous integral UTC instant",
+    )
     wrong_fix_paths = {
         **ARMED_POLICY,
         "policy": {
@@ -1539,6 +1719,21 @@ def main() -> int:
         lambda: policy.policy_rules(wrong_fix_paths),
         "differs from the signed policy",
     )
+    legacy_identity_root = {
+        key: value
+        for key, value in ARMED_POLICY["policy"].items()
+        if key != "github_identity_scheme"
+    }
+    legacy_identity_root["signer_identity_scheme"] = "github:lowercase-login"
+    legacy_identity_policy = {
+        **ARMED_POLICY,
+        "policy": legacy_identity_root,
+    }
+    expect_failure(
+        lambda: policy.policy_rules(legacy_identity_policy),
+        "differs from the signed policy",
+    )
+    assert "signer_identity_scheme" not in policy.EXPECTED_POLICY["policy"]
     assert "event_format_implementation" not in policy.EXPECTED_POLICY["policy"]
 
     # Both qualifying merges, the sign-off review, and sign-off merge occur in
@@ -2079,6 +2274,7 @@ def main() -> int:
         activation_integration,
         target_oid,
         (".github/workflows/tenkz-release-policy.yml",),
+        ".github/workflows",
     )
     mutable_workflow.workflow_override = replace(
         workflow,
@@ -2089,6 +2285,11 @@ def main() -> int:
         "external workflow dependency uses a mutable ref",
     )
     workflow_failures = (
+        (
+            "validated_publisher_workflow_root",
+            ".github/other-workflows",
+            "another publisher workflow root",
+        ),
         ("package_managers_absent", False, "invokes a package manager"),
         ("downloaders_absent", False, "invokes a downloader"),
         (
@@ -2106,6 +2307,36 @@ def main() -> int:
             False,
             "does not disable network before repository code",
         ),
+        (
+            "activation_publisher_workflow_tree_complete",
+            False,
+            "activation publisher workflow tree is incomplete",
+        ),
+        (
+            "target_publisher_workflow_tree_matches_activation",
+            False,
+            "publisher workflow tree differs from activation",
+        ),
+        (
+            "workflow_jobs_complete_and_paginated",
+            False,
+            "workflow job enumeration is incomplete",
+        ),
+        (
+            "publisher_is_sole_environment_consumer",
+            False,
+            "another workflow job names the publisher environment",
+        ),
+        (
+            "publisher_is_sole_secret_consumer",
+            False,
+            "another workflow job names the publisher secret",
+        ),
+        (
+            "workflow_secret_inheritance_absent",
+            False,
+            "permits inherited secrets",
+        ),
     )
     for field_name, bad_value, error_fragment in workflow_failures:
         workflow_facts = context()
@@ -2116,6 +2347,7 @@ def main() -> int:
             activation_integration,
             target_oid,
             (".github/workflows/tenkz-release-policy.yml",),
+            ".github/workflows",
         )
         workflow_facts.workflow_override = replace(
             workflow,
@@ -2125,6 +2357,86 @@ def main() -> int:
             lambda facts=workflow_facts: validate(complete_log(), facts),
             error_fragment,
         )
+
+    publisher_secret_failures = (
+        ("validated_environment", "another-environment", "another environment"),
+        ("validated_secret_name", "ANOTHER_KEY", "another secret name"),
+        ("validated_secret_scope", "repository", "another scope contract"),
+        ("validated_key_retirement", "optional", "another retirement contract"),
+        ("complete", False, "publisher secret evidence is incomplete"),
+        (
+            "repository_environments_complete_and_paginated",
+            False,
+            "repository environment pagination is incomplete",
+        ),
+        (
+            "all_environment_secret_names_complete_and_paginated",
+            False,
+            "environment secret-name pagination is incomplete",
+        ),
+        (
+            "repository_secret_names_complete_and_paginated",
+            False,
+            "repository secret-name pagination is incomplete",
+        ),
+        (
+            "organization_secret_names_and_access_complete_and_paginated",
+            False,
+            "organization secret-name or access pagination is incomplete",
+        ),
+        (
+            "dedicated_environment_configuration_complete",
+            False,
+            "publisher environment configuration is incomplete",
+        ),
+        (
+            "dedicated_environment_restricts_protected_release_branch",
+            False,
+            "does not restrict the protected release branch",
+        ),
+    )
+    for field_name, bad_value, error_fragment in publisher_secret_failures:
+        secret_facts = context()
+        secret_facts.publisher_secret_override = replace(
+            publisher_secret_evidence(),
+            **{field_name: bad_value},
+        )
+        expect_failure(
+            lambda facts=secret_facts: validate([], facts),
+            error_fragment,
+        )
+
+    for locations in (
+        (),
+        ("environment:another-environment",),
+        ("repository:TENKZ_FINAL_TAG_SIGNING_KEY",),
+        ("organization:TNLean-org:access-none",),
+        ("organization:TNLean-org:access-selected",),
+        (
+            "environment:tenkz-release-publisher",
+            "repository:TENKZ_FINAL_TAG_SIGNING_KEY",
+        ),
+    ):
+        shadowed_secret = context()
+        shadowed_secret.publisher_secret_override = publisher_secret_evidence(
+            locations=locations,
+        )
+        expect_failure(
+            lambda facts=shadowed_secret: validate([], facts),
+            "publisher signing-key name is missing, shadowed, or outside its environment",
+        )
+
+    malformed_secret_locations = context()
+    malformed_secret_locations.publisher_secret_override = publisher_secret_evidence(
+        locations=(
+            "environment:tenkz-release-publisher",
+            "environment:tenkz-release-publisher",
+        ),
+    )
+    expect_failure(
+        lambda: validate([], malformed_secret_locations),
+        "publisher secret locations are incomplete or malformed",
+    )
 
     boolean_record_parent = context()
     boolean_record_parent.records["S1-0001"] = replace(
@@ -2895,23 +3207,124 @@ def main() -> int:
     assert validate(complete_log(), candidate) == "sign-off-pending"
 
     released = context()
-    released.tags[policy.FINAL_TAG] = policy.TagEvidence(
-        FINAL_TAG_OBJECT,
-        "tag",
-        oid(9071),
-        exists=True,
-    )
+    released.tags[policy.FINAL_TAG] = authenticated_final_tag(oid(9071))
     released.publishers[oid(9071)] = publisher_evidence(
         oid(9071),
         status="success",
+        prior_released=True,
     )
+    released.publisher_secret_override = publisher_secret_evidence(retired=True)
     assert validate(complete_log(), released) == "released"
+
+    first_release_declaration = context()
+    first_release_declaration.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    first_release_declaration.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    first_release_declaration.publisher_secret_override = publisher_secret_evidence(
+        retired=True,
+    )
+    assert validate(complete_log(), first_release_declaration) == "released"
+
+    first_release_with_workflow_drift = context()
+    first_release_with_workflow_drift.tags[policy.FINAL_TAG] = released.tags[
+        policy.FINAL_TAG
+    ]
+    first_release_with_workflow_drift.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    first_release_with_workflow_drift.publisher_secret_override = (
+        publisher_secret_evidence(retired=True)
+    )
+    activation_integration = first_release_with_workflow_drift.prs[
+        ACTIVATION
+    ].merge_commit_oid
+    target_oid = first_release_with_workflow_drift.prs[
+        SIGNOFF_RECORD
+    ].merge_commit_oid
+    assert isinstance(activation_integration, str) and isinstance(target_oid, str)
+    transition_workflow = first_release_with_workflow_drift.resolve_current_workflow(
+        activation_integration,
+        target_oid,
+        (".github/workflows/tenkz-release-policy.yml",),
+        ".github/workflows",
+    )
+    first_release_with_workflow_drift.workflow_override = replace(
+        transition_workflow,
+        target_publisher_workflow_tree_matches_activation=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), first_release_with_workflow_drift),
+        "publisher workflow tree differs from activation",
+    )
+
+    first_release_with_environment_drift = context()
+    first_release_with_environment_drift.tags[policy.FINAL_TAG] = released.tags[
+        policy.FINAL_TAG
+    ]
+    first_release_with_environment_drift.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    first_release_with_environment_drift.publisher_secret_override = replace(
+        publisher_secret_evidence(retired=True),
+        dedicated_environment_configuration_complete=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), first_release_with_environment_drift),
+        "publisher environment configuration is incomplete",
+    )
+
+    released_with_current_workflow_drift = context()
+    released_with_current_workflow_drift.tags[policy.FINAL_TAG] = released.tags[
+        policy.FINAL_TAG
+    ]
+    released_with_current_workflow_drift.publishers.update(released.publishers)
+    released_with_current_workflow_drift.publisher_secret_override = (
+        replace(
+            publisher_secret_evidence(retired=True),
+            dedicated_environment_configuration_complete=False,
+            dedicated_environment_restricts_protected_release_branch=False,
+        )
+    )
+    activation_integration = released_with_current_workflow_drift.prs[
+        ACTIVATION
+    ].merge_commit_oid
+    target_oid = released_with_current_workflow_drift.prs[
+        SIGNOFF_RECORD
+    ].merge_commit_oid
+    assert isinstance(activation_integration, str) and isinstance(target_oid, str)
+    released_workflow = released_with_current_workflow_drift.resolve_current_workflow(
+        activation_integration,
+        target_oid,
+        (".github/workflows/tenkz-release-policy.yml",),
+        ".github/workflows",
+    )
+    released_with_current_workflow_drift.workflow_override = replace(
+        released_workflow,
+        target_publisher_workflow_tree_matches_activation=False,
+    )
+    assert validate(complete_log(), released_with_current_workflow_drift) == "released"
+
+    reintroduced_after_release = context()
+    reintroduced_after_release.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    reintroduced_after_release.publishers.update(released.publishers)
+    reintroduced_after_release.publisher_secret_override = publisher_secret_evidence()
+    reintroduced_after_release.workflow_override = replace(
+        released_workflow,
+        target_publisher_workflow_tree_matches_activation=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), reintroduced_after_release),
+        "publisher signing-key name was reintroduced after retirement",
+    )
 
     manual_final = context()
     manual_final.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
-    expect_failure(
-        lambda: validate(complete_log(), manual_final),
-        "without the successful pinned publisher",
+    assert validate(complete_log(), manual_final) == (
+        "signed-off-awaiting-publisher-success"
     )
 
     failed_publisher = context()
@@ -2919,9 +3332,36 @@ def main() -> int:
         oid(9071),
         status="failure",
     )
-    expect_failure(
-        lambda: validate(complete_log(), failed_publisher),
-        "publisher failed; hard release incident",
+    assert validate(complete_log(), failed_publisher) == "signed-off-awaiting-tag"
+
+    failed_after_write = context()
+    failed_after_write.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    failed_after_write.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="failure",
+    )
+    assert validate(complete_log(), failed_after_write) == (
+        "signed-off-awaiting-publisher-success"
+    )
+
+    incomplete_after_write = context()
+    incomplete_after_write.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    incomplete_after_write.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="incomplete",
+    )
+    assert validate(complete_log(), incomplete_after_write) == (
+        "signed-off-awaiting-publisher-success"
+    )
+
+    key_retirement_pending = context()
+    key_retirement_pending.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+    key_retirement_pending.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="success",
+    )
+    assert validate(complete_log(), key_retirement_pending) == (
+        "signed-off-awaiting-key-retirement"
     )
 
     lost_published_ref = context()
@@ -2948,23 +3388,51 @@ def main() -> int:
         "publisher succeeded while release evidence requires reset",
     )
 
-    replaced_published_object = context()
-    replaced_published_object.tags[policy.FINAL_TAG] = policy.TagEvidence(
-        "d" * 40,
-        "tag",
+    independently_authenticated_object = context()
+    independently_authenticated_object.tags[policy.FINAL_TAG] = authenticated_final_tag(
         oid(9071),
-        exists=True,
+        object_oid="d" * 40,
     )
-    replaced_published_object.publishers[oid(9071)] = publisher_evidence(
+    independently_authenticated_object.publishers[oid(9071)] = publisher_evidence(
         oid(9071),
         status="success",
     )
-    expect_failure(
-        lambda: validate(complete_log(), replaced_published_object),
-        "current final tag object differs from the publisher output",
+    independently_authenticated_object.publisher_secret_override = (
+        publisher_secret_evidence(retired=True)
     )
+    assert validate(complete_log(), independently_authenticated_object) == "released"
 
     publisher_contract_failures = (
+        (
+            "workflow_runs_complete_and_paginated",
+            False,
+            "run pagination is incomplete",
+        ),
+        (
+            "workflow_jobs_complete_and_paginated",
+            False,
+            "job pagination is incomplete",
+        ),
+        (
+            "release_validation_runs_complete_and_paginated",
+            False,
+            "release-validation run pagination is incomplete",
+        ),
+        (
+            "prior_released_validation_exact_and_successful",
+            None,
+            "prior released-validation history is unavailable",
+        ),
+        (
+            "pinned_workflow_runs_exact",
+            False,
+            "not bound to the pinned exact workflow",
+        ),
+        (
+            "postmerge_validation_succeeded",
+            False,
+            "lacks successful exact post-merge validation",
+        ),
         (
             "postmerge_validation_network_disabled",
             False,
@@ -2991,9 +3459,14 @@ def main() -> int:
             "checks out or executes repository content",
         ),
         (
-            "publisher_uses_version_fingerprinted_hosted_gh",
+            "publisher_has_no_uses_or_inherited_secrets",
             False,
-            "uses another executable",
+            "uses an action, called workflow, or inherited secret",
+        ),
+        (
+            "publisher_uses_only_version_fingerprinted_hosted_gh_git_ssh_keygen",
+            False,
+            "unpinned or unapproved executable",
         ),
         (
             "publisher_command_and_inputs_closed",
@@ -3007,18 +3480,115 @@ def main() -> int:
         ),
         ("other_networked_steps_absent", False, "another networked step"),
         (
+            "closed_needs_tuple_complete_and_matching",
+            False,
+            "closed needs tuple is incomplete or mismatched",
+        ),
+        (
+            "closed_needs_has_no_caller_substitute",
+            False,
+            "accepts a caller substitute",
+        ),
+        (
+            "github_metadata_matches_closed_needs",
+            False,
+            "GitHub metadata differs",
+        ),
+        (
+            "caller_controlled_inputs_absent",
+            False,
+            "caller-controlled input",
+        ),
+        (
+            "exact_git_objects_fetched_by_oid_and_verified",
+            False,
+            "exact Git objects by OID",
+        ),
+        (
+            "publisher_environment_and_secret_exact",
+            False,
+            "another environment or secret",
+        ),
+        (
+            "publisher_is_only_private_key_consumer",
+            False,
+            "another job can consume",
+        ),
+        (
+            "deterministic_signed_tag_object_contract",
+            False,
+            "deterministic signed object",
+        ),
+        (
+            "signature_algorithm_and_namespace_exact",
+            False,
+            "another signature algorithm or namespace",
+        ),
+        (
+            "tagger_epoch_exact_canonical_and_in_range",
+            False,
+            "tagger epoch is not canonical or in range",
+        ),
+        (
+            "publisher_reads_ref_before_private_key_access",
+            False,
+            "accesses the private key before reading the ref",
+        ),
+        (
+            "private_key_available_only_to_absent_ref_path",
+            False,
+            "private key is available outside absent-ref construction",
+        ),
+        (
+            "existing_ref_path_cannot_access_private_key",
+            False,
+            "existing-ref retry can access the private key",
+        ),
+        (
+            "absent_ref_candidate_authenticated_before_write",
+            False,
+            "does not authenticate the candidate object before its first write",
+        ),
+        (
+            "existing_ref_object_authenticated_without_mutation",
+            False,
+            "does not authenticate an existing exact object without mutation",
+        ),
+        (
+            "publisher_success_requires_authenticated_final_readback",
+            False,
+            "can succeed without an authenticated final readback",
+        ),
+        (
+            "publisher_emits_no_durable_output_receipt",
+            False,
+            "relies on a durable job-output receipt",
+        ),
+        (
             "publisher_started_after_validation_success",
             False,
             "did not start after validation success",
         ),
-        ("final_ref_absent_before_create", False, "existed before the publisher"),
         (
-            "annotated_tag_object_targets_integration",
+            "successful_job_head_matches_integration",
             False,
-            "annotated tag object for the integration",
+            "used another head",
         ),
-        ("ref_created_without_force", False, "without force"),
-        ("readback_complete_and_matching", False, "readback is incomplete"),
+        (
+            "successful_job_historical_workflow_tree_matches_activation",
+            False,
+            "used another historical workflow tree",
+        ),
+        (
+            "successful_job_follows_successful_postmerge_validation",
+            False,
+            "did not follow its successful validation job",
+        ),
+        (
+            "successful_job_conclusion_api_visible",
+            False,
+            "conclusion is not API-visible",
+        ),
     )
     for field_name, bad_value, error_fragment in publisher_contract_failures:
         bad_publisher = context()
@@ -3043,14 +3613,60 @@ def main() -> int:
         "used another sign-off integration",
     )
 
-    premature_publisher_output = context()
-    premature_publisher_output.publishers[oid(9071)] = replace(
+    publisher_binding_failures = (
+        (
+            "validated_tagger_epoch_seconds",
+            SIGNOFF_TAGGER_EPOCH + 1,
+            "another tagger epoch",
+        ),
+        ("validated_policy_sha256", "0" * 64, "another policy hash"),
+        ("validated_prefix_sha256", "invalid", "invalid ledger-prefix hash"),
+        ("validated_prefix_boundary", "S1-9999", "another ledger-prefix boundary"),
+        ("validated_support_tree_oid", oid(9992), "another support tree"),
+        ("validated_schema_blob_oid", None, "invalid object-schema blob OID"),
+        ("validated_public_key_blob_oid", None, "invalid public-key blob OID"),
+    )
+    for field_name, bad_value, error_fragment in publisher_binding_failures:
+        bad_publisher = context()
+        bad_publisher.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
+        bad_publisher.publishers[oid(9071)] = replace(
+            publisher_evidence(oid(9071), status="success"),
+            **{field_name: bad_value},
+        )
+        expect_failure(
+            lambda facts=bad_publisher: validate(complete_log(), facts),
+            error_fragment,
+        )
+
+    premature_successful_job_evidence = context()
+    premature_successful_job_evidence.publishers[oid(9071)] = replace(
         publisher_evidence(oid(9071)),
-        reported_tag_object_oid=FINAL_TAG_OBJECT,
+        successful_job_conclusion_api_visible=True,
     )
     expect_failure(
-        lambda: validate(complete_log(), premature_publisher_output),
-        "publisher that did not run carries creation evidence",
+        lambda: validate(complete_log(), premature_successful_job_evidence),
+        "publisher that did not run carries successful-job evidence",
+    )
+
+    failed_with_successful_job_evidence = context()
+    failed_with_successful_job_evidence.publishers[oid(9071)] = replace(
+        publisher_evidence(oid(9071), status="failure"),
+        successful_job_head_matches_integration=True,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), failed_with_successful_job_evidence),
+        "unsuccessful publisher history carries successful-job evidence",
+    )
+
+    failed_with_prior_release = context()
+    failed_with_prior_release.publishers[oid(9071)] = publisher_evidence(
+        oid(9071),
+        status="failure",
+        prior_released=True,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), failed_with_prior_release),
+        "prior released validation lacks a successful publisher job",
     )
 
     trailing_correction = context()
@@ -3063,6 +3679,7 @@ def main() -> int:
     )
     trailing_correction.tags[policy.FINAL_TAG] = released.tags[policy.FINAL_TAG]
     trailing_correction.publishers.update(released.publishers)
+    trailing_correction.publisher_secret_override = publisher_secret_evidence(retired=True)
     assert validate(
         complete_log() + [correction("S1-0005", "#908", "S1-0002")],
         trailing_correction,
@@ -3132,11 +3749,9 @@ def main() -> int:
     )
 
     lightweight_final = context()
-    lightweight_final.tags[policy.FINAL_TAG] = policy.TagEvidence(
-        FINAL_TAG_OBJECT,
-        "commit",
-        oid(9071),
-        exists=True,
+    lightweight_final.tags[policy.FINAL_TAG] = replace(
+        authenticated_final_tag(oid(9071)),
+        object_type="commit",
     )
     lightweight_final.publishers[oid(9071)] = publisher_evidence(
         oid(9071),
@@ -3158,11 +3773,9 @@ def main() -> int:
     )
 
     wrong_final_target = context()
-    wrong_final_target.tags[policy.FINAL_TAG] = policy.TagEvidence(
-        FINAL_TAG_OBJECT,
-        "tag",
-        oid(9991),
-        exists=True,
+    wrong_final_target.tags[policy.FINAL_TAG] = replace(
+        authenticated_final_tag(oid(9071)),
+        commit=oid(9991),
     )
     wrong_final_target.publishers[oid(9071)] = publisher_evidence(
         oid(9071),
@@ -3170,16 +3783,93 @@ def main() -> int:
     )
     expect_failure(
         lambda: validate(complete_log(), wrong_final_target),
-        "does not target the validated sign-off integration",
+        "does not peel to the validated sign-off integration",
     )
 
-    premature_final = context()
-    premature_final.tags[policy.FINAL_TAG] = policy.TagEvidence(
-        FINAL_TAG_OBJECT,
-        "tag",
-        oid(9071),
-        exists=True,
+    final_tag_authentication_failures = (
+        (
+            "final_lookup_after_fetch_object_id",
+            "d" * 40,
+            "changed across exact-object fetch and double resolution",
+        ),
+        (
+            "final_network_disabled_before_object_read",
+            False,
+            "read before network removal",
+        ),
+        ("final_raw_object_bytes_complete", False, "raw object bytes are incomplete"),
+        ("final_object_schema_valid", False, "pinned byte schema"),
+        ("final_recomputed_object_id", "d" * 40, "raw object hash"),
+        ("final_signature_algorithm", "rsa", "another signature algorithm"),
+        ("final_signature_namespace", "file", "another namespace"),
+        ("final_raw_signature_valid", False, "raw signature is invalid"),
+        ("final_public_key_blob_oid", "d" * 40, "another public key"),
+        (
+            "final_public_key_from_pinned_support_tree",
+            False,
+            "another public key",
+        ),
+        ("final_schema_blob_oid", "d" * 40, "another object schema"),
+        (
+            "final_schema_from_pinned_support_tree",
+            False,
+            "another object schema",
+        ),
+        (
+            "final_tagger_identity_matches_schema",
+            False,
+            "tagger identity differs",
+        ),
+        (
+            "final_tagger_epoch_seconds",
+            SIGNOFF_TAGGER_EPOCH + 1,
+            "tagger epoch differs",
+        ),
+        ("final_tagger_timezone", "+0100", "timezone is not +0000"),
+        ("final_message_tag", "tenkz-v1.0.1", "payload names another tag"),
+        (
+            "final_message_integration_oid",
+            oid(9991),
+            "payload names another sign-off integration",
+        ),
+        (
+            "final_message_policy_sha256",
+            "0" * 64,
+            "payload names another policy hash",
+        ),
+        (
+            "final_message_prefix_sha256",
+            "0" * 64,
+            "payload names another ledger-prefix hash",
+        ),
+        (
+            "final_message_prefix_boundary",
+            "S1-0003",
+            "payload names another ledger-prefix boundary",
+        ),
+        (
+            "final_commit_reachable_from_main",
+            False,
+            "not reachable from current main",
+        ),
     )
+    for field_name, bad_value, error_fragment in final_tag_authentication_failures:
+        bad_tag = context()
+        bad_tag.tags[policy.FINAL_TAG] = replace(
+            authenticated_final_tag(oid(9071)),
+            **{field_name: bad_value},
+        )
+        bad_tag.publishers[oid(9071)] = publisher_evidence(
+            oid(9071),
+            status="success",
+        )
+        expect_failure(
+            lambda facts=bad_tag: validate(complete_log(), facts),
+            error_fragment,
+        )
+
+    premature_final = context()
+    premature_final.tags[policy.FINAL_TAG] = authenticated_final_tag(oid(9071))
     expect_failure(
         lambda: validate(complete_log()[:3], premature_final),
         "without a successfully validated sign-off",
@@ -3282,6 +3972,66 @@ def main() -> int:
         lambda: validate([freeze()], invalid_supervisor_receipt),
         "supervisor self-test receipt is invalid",
     )
+    activation_publisher_failures = (
+        (
+            "publisher_workflow_tree_pinned",
+            "activation publisher workflow tree is not pinned",
+        ),
+        (
+            "publisher_workflow_jobs_complete_and_paginated",
+            "activation publisher workflow job enumeration is incomplete",
+        ),
+        (
+            "publisher_is_sole_environment_consumer",
+            "another activation workflow job names the publisher environment",
+        ),
+        (
+            "publisher_is_sole_secret_consumer",
+            "another activation workflow job names the publisher secret",
+        ),
+        (
+            "workflow_secret_inheritance_absent",
+            "activation publisher workflow permits inherited secrets",
+        ),
+        (
+            "publisher_environment_configuration_complete",
+            "activation publisher environment configuration is incomplete",
+        ),
+        (
+            "publisher_environment_restricts_protected_release_branch",
+            "does not restrict the protected release branch",
+        ),
+        (
+            "repository_environments_complete_and_paginated",
+            "activation repository environment pagination is incomplete",
+        ),
+        (
+            "all_environment_secret_names_complete_and_paginated",
+            "activation environment secret-name pagination is incomplete",
+        ),
+        (
+            "repository_secret_names_complete_and_paginated",
+            "activation repository secret-name pagination is incomplete",
+        ),
+        (
+            "organization_secret_names_and_access_complete_and_paginated",
+            "activation organization secret-name or access pagination is incomplete",
+        ),
+        (
+            "configured_secret_only_in_dedicated_environment",
+            "activation publisher secret is missing, shadowed, or outside its environment",
+        ),
+    )
+    for field_name, error_fragment in activation_publisher_failures:
+        bad_activation = context()
+        bad_activation.activation_diff = replace(
+            bad_activation.activation_diff,
+            **{field_name: False},
+        )
+        expect_failure(
+            lambda facts=bad_activation: validate([freeze()], facts),
+            error_fragment,
+        )
 
     unapproved_source = context()
     unapproved_source.prs[SOURCE] = replace(
@@ -3481,6 +4231,19 @@ def main() -> int:
         validate(complete_log(), release_wrong_paths)
         == "reset-required:S1-0004"
     )
+
+    for noncanonical_merge_time in (
+        SIGNOFF_MERGE + timedelta(microseconds=1),
+        SIGNOFF_MERGE.astimezone(timezone(timedelta(hours=1))),
+    ):
+        noncanonical_tagger_epoch = context()
+        noncanonical_tagger_epoch.prs[SIGNOFF_RECORD] = replace(
+            noncanonical_tagger_epoch.prs[SIGNOFF_RECORD],
+            merged_at=noncanonical_merge_time,
+        )
+        assert validate(complete_log(), noncanonical_tagger_epoch) == (
+            "reset-required:S1-0004"
+        )
 
     for submitted in (RMP_MERGE, RMP_MERGE - timedelta(microseconds=1)):
         too_early = context()
@@ -3805,6 +4568,41 @@ def main() -> int:
         reset("S1-0004", "#910", "restart-required", "S1-0002"),
     ]
     assert validate(reset_log, reset_facts) == "reset"
+
+    invalid_correction_behind_restart = context()
+    for entry_id, record_ref, number, merged_at, invalid_tree in (
+        ("S1-0002", "#908", 908, FREEZE_TIME + timedelta(seconds=3), False),
+        ("S1-0003", "#909", 909, FREEZE_TIME + timedelta(seconds=4), True),
+        ("S1-0004", "#910", 910, FREEZE_TIME + timedelta(seconds=5), False),
+        ("S1-0005", "#911", 911, FREEZE_TIME + timedelta(seconds=6), False),
+    ):
+        add_record(
+            invalid_correction_behind_restart,
+            entry_id,
+            record_ref,
+            number,
+            merged_at,
+            invalid_tree=invalid_tree,
+        )
+    restart_then_invalid_correction = [
+        freeze(),
+        friction("S1-0002", "#908", "restart-required"),
+        correction("S1-0003", "#909", "S1-0002"),
+        reset("S1-0004", "#910", "restart-required", "S1-0002"),
+        reset("S1-0005", "#911", "record-invalid", "S1-0003"),
+    ]
+    assert validate(
+        restart_then_invalid_correction[:3],
+        invalid_correction_behind_restart,
+    ) == "reset-required:S1-0002"
+    assert validate(
+        restart_then_invalid_correction[:4],
+        invalid_correction_behind_restart,
+    ) == "reset-required:S1-0003"
+    assert validate(
+        restart_then_invalid_correction,
+        invalid_correction_behind_restart,
+    ) == "reset"
 
     missing_reset = reset_log[:2] + [
         work("S1-0003", FORMAL_RECORD, FORMAL_WORK, "formalization-or-blueprint")

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -12,7 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-import check_tenkz_policy as policy
+import check_tenkz_policy as policy  # noqa: E402
 
 
 DESIGN_TEXT = (ROOT / "docs/tenkz/DESIGN.md").read_text(encoding="utf-8")
@@ -186,7 +186,18 @@ def reset(
     target: str,
     *,
     attempt: int = 1,
+    replay_receipt_pr: str | None = None,
+    replay_receipt_sha256: str | None = None,
 ) -> str:
+    replay_fields = ""
+    if cause == "record-invalid":
+        entry_number = int(entry_id.removeprefix("S1-"))
+        receipt_ref = replay_receipt_pr or f"#{19_000 + entry_number}"
+        receipt_digest = replay_receipt_sha256 or f"{entry_number:064x}"
+        replay_fields = (
+            f'\nreplay_receipt_pr = "{receipt_ref}"'
+            f'\nreplay_receipt_sha256 = "{receipt_digest}"'
+        )
     return block(
         f'''id = "{entry_id}"
 kind = "reset"
@@ -195,7 +206,7 @@ attempt = {attempt}
 cause = "{cause}"
 target = "{target}"
 reason = "attempt evidence requires a new freeze"
-evidence = "verified reset cause"'''
+evidence = "verified reset cause"{replay_fields}'''
     )
 
 
@@ -251,8 +262,9 @@ def review(
     *,
     state: str = "APPROVED",
     dismissed: bool = False,
+    permission: str | None = "push",
 ) -> policy.ReviewEvidence:
-    return policy.ReviewEvidence(login, state, submitted_at, head, dismissed)
+    return policy.ReviewEvidence(login, state, submitted_at, head, dismissed, permission)
 
 
 def merged_pr(
@@ -307,6 +319,10 @@ class Context:
     payloads: dict[tuple[str, str], policy.ReleasePayloadEvidence]
     tags: dict[str, policy.TagEvidence]
     issues: dict[str, policy.IssueEvidence]
+    reset_replays: dict[str, policy.RecordInvalidResetReplayEvidence] = field(
+        default_factory=dict
+    )
+    workflow_override: policy.WorkflowEvidence | None = None
 
     def resolve_replay_activation_diff(self, _ref: str) -> policy.ActivationDiffEvidence:
         return self.activation_diff
@@ -351,6 +367,68 @@ class Context:
 
     def resolve_replay_issue(self, issue: str) -> policy.IssueEvidence:
         return self.issues[issue]
+
+    def resolve_replay_record_invalid_reset(
+        self,
+        entry_id: str,
+        target: str,
+        receipt_ref: str,
+        receipt_digest: str,
+    ) -> policy.RecordInvalidResetReplayEvidence:
+        override = self.reset_replays.get(entry_id)
+        if override is not None:
+            return override
+        receipt = self.prs[receipt_ref]
+        index = int(entry_id.removeprefix("S1-"))
+        return policy.RecordInvalidResetReplayEvidence(
+            validated_entry_id=entry_id,
+            validated_target_entry_id=target,
+            validated_receipt_pr=receipt_ref,
+            validated_receipt_head_oid=receipt.head_oid,
+            validated_receipt_integration_oid=receipt.merge_commit_oid,
+            complete=True,
+            receipt_candidate_main_tip_exact=True,
+            changes_exactly_one_new_regular_blob=True,
+            receipt_path=f"docs/tenkz/soak-replay/{receipt_ref[1:]}.json",
+            raw_blob_sha256=receipt_digest,
+            raw_blob_read_from_receipt_integration=True,
+            schema_path=policy.policy_rules(ARMED_POLICY)[4].reset_replay_schema,
+            schema_support_tree_oid=TEST_SUPPORT_TREE,
+            schema_from_pinned_support_tree=True,
+            schema_closed_and_valid=True,
+            boundary_entry_id=f"S1-{index - 1:04d}",
+            validation_target_oid=receipt.head_oid,
+            raw_invalid_entries=(target,),
+            pending_breaking_target=None,
+            normalized_resolver_inputs_complete_and_matching=True,
+            workflow_dependency_closure_pinned=True,
+            supervisor_receipts_complete_and_matching=True,
+            current_candidate_snapshot_reproduces_receipt=True,
+        )
+
+    def resolve_current_workflow(
+        self,
+        activation_integration: str,
+        target_oid: str,
+        paths: tuple[str, ...],
+    ) -> policy.WorkflowEvidence:
+        if self.workflow_override is not None:
+            return self.workflow_override
+        return policy.WorkflowEvidence(
+            validated_activation_integration=activation_integration,
+            validated_target_oid=target_oid,
+            validated_paths=paths,
+            complete=True,
+            activation_paths_are_regular_blobs=True,
+            target_blobs_and_modes_match_activation=True,
+            local_dependencies_pinned_and_matching=True,
+            external_dependencies_use_full_commit_shas=True,
+            containers_use_content_digests=True,
+            dependency_graph_complete_and_acyclic=True,
+            candidate_diff_untouched=True,
+            github_checks_bind_exact_head_and_workflows=True,
+            supervisor_receipt_complete_and_matching=True,
+        )
 
 
 def payload_evidence(
@@ -494,6 +572,7 @@ def context() -> Context:
         subject_data_cannot_reduce_coverage=True,
         hermetic_execution_contract_valid=True,
         supervisor_self_test_receipt_valid=True,
+        enforcement_workflows_pinned=True,
         policy_digest_matches=True,
         ledger_prefix_matches=True,
     )
@@ -533,6 +612,10 @@ def context() -> Context:
     }
     work_diffs = {
         FORMAL_WORK: policy.WorkDiffEvidence(
+            validated_pr_ref=FORMAL_WORK,
+            validated_head_oid=prs[FORMAL_WORK].head_oid,
+            validated_integration_oid=prs[FORMAL_WORK].merge_commit_oid,
+            validated_freeze_integration=prs[FREEZE_RECORD].merge_commit_oid,
             complete=True,
             integration_parent_count=1,
             unique_merge_base=True,
@@ -553,6 +636,10 @@ def context() -> Context:
             rmp_checks_passed=True,
         ),
         RMP_WORK: policy.WorkDiffEvidence(
+            validated_pr_ref=RMP_WORK,
+            validated_head_oid=prs[RMP_WORK].head_oid,
+            validated_integration_oid=prs[RMP_WORK].merge_commit_oid,
+            validated_freeze_integration=prs[FREEZE_RECORD].merge_commit_oid,
             complete=True,
             integration_parent_count=2,
             unique_merge_base=True,
@@ -634,7 +721,14 @@ def context() -> Context:
         release_preps,
         payloads,
         {
-            "tenkz-v0.9.0": policy.TagEvidence(TAG_OBJECT, "tag", SHA, True),
+            "tenkz-v0.9.0": policy.TagEvidence(
+                TAG_OBJECT,
+                "tag",
+                SHA,
+                True,
+                True,
+                True,
+            ),
             policy.FINAL_TAG: policy.TagEvidence(None, None, None, exists=False),
         },
         issues,
@@ -649,8 +743,9 @@ def parsed_entries(*blocks: str) -> list[dict]:
 def audit_evidence(
     boundary: str | None,
     invalid_entries: tuple[str, ...] = (),
+    target_oid: str = oid(99_999),
 ) -> policy.AuditEvidence:
-    return policy.AuditEvidence(boundary, invalid_entries, True, True)
+    return policy.AuditEvidence(boundary, invalid_entries, True, True, target_oid)
 
 
 def protected_tags() -> policy.TagProtectionEvidence:
@@ -668,16 +763,87 @@ def protected_tags() -> policy.TagProtectionEvidence:
     )
 
 
+def prepare_reset_receipts(entries: list[dict], facts: Context) -> None:
+    """Populate the default durable receipt facts used by unrelated scenarios."""
+
+    for entry in entries:
+        if entry["kind"] != "reset" or entry["cause"] != "record-invalid":
+            continue
+        entry_id = entry["id"]
+        record = facts.prs[entry["record_pr"]]
+        receipt_ref = entry["replay_receipt_pr"]
+        receipt_number = int(receipt_ref[1:])
+        if receipt_ref not in facts.prs:
+            record_time = record.merged_at
+            receipt_time = (
+                record_time - timedelta(microseconds=1)
+                if record_time is not None
+                else SIGNOFF_MERGE + timedelta(seconds=100 + receipt_number)
+            )
+            receipt_head = oid(receipt_number * 10)
+            facts.prs[receipt_ref] = merged_pr(
+                receipt_number,
+                receipt_time,
+                author=f"receipt-author-{receipt_number}",
+                reviews=(
+                    review(
+                        f"receipt-reviewer-{receipt_number}",
+                        receipt_time - timedelta(microseconds=1),
+                        receipt_head,
+                    ),
+                ),
+            )
+        receipt_integration = facts.prs[receipt_ref].merge_commit_oid
+        record_diff = facts.records[entry_id]
+        facts.records[entry_id] = replace(
+            record_diff,
+            candidate_main_tip_is_receipt_integration=(
+                True
+                if record_diff.candidate_main_tip_is_receipt_integration is None
+                else record_diff.candidate_main_tip_is_receipt_integration
+            ),
+            integration_parent_is_receipt_integration=(
+                True
+                if record_diff.integration_parent_is_receipt_integration is None
+                else record_diff.integration_parent_is_receipt_integration
+            ),
+            validated_receipt_integration=(
+                receipt_integration
+                if record_diff.validated_receipt_integration is None
+                else record_diff.validated_receipt_integration
+            ),
+        )
+
+
+def set_review_permission(facts: Context, ref: str, permission: str | None) -> None:
+    pull_request = facts.prs[ref]
+    assert pull_request.reviews is not None
+    facts.prs[ref] = replace(
+        pull_request,
+        reviews=tuple(
+            replace(item, repository_permission=permission)
+            for item in pull_request.reviews
+        ),
+    )
+
+
 def validate(blocks: list[str], facts: Context, **overrides) -> str:
     entries = parsed_entries(*blocks)
+    prepare_reset_receipts(entries, facts)
     if "audit" not in overrides:
         boundary: str | None = None
+        target_oid = facts.prs[ACTIVATION].merge_commit_oid
         for entry in entries:
             record = facts.prs.get(entry["record_pr"])
-            if record is None or record.merged is not True:
+            if record is None:
+                break
+            target_oid = record.head_oid
+            if record.merged is not True:
                 break
             boundary = entry["id"]
-        overrides["audit"] = audit_evidence(boundary)
+            target_oid = record.merge_commit_oid
+        assert isinstance(target_oid, str)
+        overrides["audit"] = audit_evidence(boundary, target_oid=target_oid)
     arguments = {
         "policy": ARMED_POLICY,
         "soak": ARMED_SOAK,
@@ -690,6 +856,8 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
         "resolve_replay_freeze_tag": facts.resolve_replay_freeze_tag,
         "resolve_current_final_tag": facts.resolve_current_final_tag,
         "resolve_replay_issue": facts.resolve_replay_issue,
+        "resolve_replay_record_invalid_reset": facts.resolve_replay_record_invalid_reset,
+        "resolve_current_workflow": facts.resolve_current_workflow,
         "tag_protection": protected_tags(),
     }
     arguments.update(overrides)
@@ -793,7 +961,14 @@ def add_freeze_facts(
         merged_at,
         freeze_entry=True,
     )
-    facts.tags[tag] = policy.TagEvidence(tag_object, "tag", source_sha, True)
+    facts.tags[tag] = policy.TagEvidence(
+        tag_object,
+        "tag",
+        source_sha,
+        True,
+        True,
+        True,
+    )
     facts.payloads[(source_sha, tag)] = payload_evidence(
         source_sha,
         tag,
@@ -843,6 +1018,350 @@ def main() -> int:
     # Both qualifying merges, the sign-off review, and sign-off merge occur in
     # one minute.  Strict event ordering, not elapsed calendar time, is enough.
     assert validate(complete_log(), context()) == "signed-off-awaiting-tag"
+
+    # Every approval path uses the policy's closed collaborator-permission set.
+    for denied_permission in (None, "pull", "triage"):
+        denied_activation = context()
+        set_review_permission(denied_activation, ACTIVATION, denied_permission)
+        expect_failure(
+            lambda facts=denied_activation: validate([], facts),
+            "repository-authorized independent exact-head approval",
+        )
+
+    denied_source = context()
+    set_review_permission(denied_source, SOURCE, "pull")
+    denied_source.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
+    expect_failure(
+        lambda: validate([freeze()], denied_source),
+        "repository-authorized independent exact-head approval",
+    )
+
+    denied_work = context()
+    set_review_permission(denied_work, FORMAL_WORK, "triage")
+    denied_work.prs[FORMAL_RECORD] = candidate_pr(904, author="record-author")
+    expect_failure(
+        lambda: validate(complete_log()[:2], denied_work),
+        "repository-authorized independent exact-head approval",
+    )
+
+    denied_release = context()
+    set_review_permission(denied_release, RELEASE_PREP, "pull")
+    signoff_head = denied_release.prs[SIGNOFF_RECORD].head_oid
+    assert signoff_head is not None
+    denied_release.prs[SIGNOFF_RECORD] = candidate_pr(
+        907,
+        author="release-author",
+        reviews=(review("release-reviewer", SIGNOFF_REVIEW, signoff_head),),
+    )
+    expect_failure(
+        lambda: validate(complete_log(), denied_release),
+        "repository-authorized independent exact-head approval",
+    )
+
+    denied_signoff = context()
+    signoff_head = denied_signoff.prs[SIGNOFF_RECORD].head_oid
+    assert signoff_head is not None
+    denied_signoff.prs[SIGNOFF_RECORD] = candidate_pr(
+        907,
+        author="release-author",
+        reviews=(
+            review(
+                "release-reviewer",
+                SIGNOFF_REVIEW,
+                signoff_head,
+                permission="pull",
+            ),
+        ),
+    )
+    expect_failure(
+        lambda: validate(complete_log(), denied_signoff),
+        "repository-authorized independent exact-head approval",
+    )
+
+    receipt_log = [
+        freeze(),
+        reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+    ]
+    denied_receipt = context()
+    add_record(
+        denied_receipt,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    denied_receipt.prs["#908"] = candidate_pr(908, author="record-author")
+    receipt_entries = parsed_entries(*receipt_log)
+    prepare_reset_receipts(receipt_entries, denied_receipt)
+    receipt_ref = receipt_entries[-1]["replay_receipt_pr"]
+    set_review_permission(denied_receipt, receipt_ref, "triage")
+    expect_failure(
+        lambda: validate(
+            receipt_log,
+            denied_receipt,
+            audit=audit_evidence(
+                "S1-0001",
+                ("S1-0001",),
+                target_oid=denied_receipt.prs["#908"].head_oid,
+            ),
+        ),
+        "repository-authorized independent exact-head approval",
+    )
+
+    expect_failure(
+        lambda: validate([freeze(tag="tenkz-v0.9.00")], context()),
+        "invalid freeze tag",
+    )
+
+    missing_receipt_field = reset(
+        "S1-0002", "#908", "record-invalid", "S1-0001"
+    ).replace('\nreplay_receipt_pr = "#19002"', "")
+    expect_failure(
+        lambda: policy.validate_entry_shape(
+            parsed_entries(freeze(), missing_receipt_field)[1],
+            2,
+        ),
+        "fields differ from schema",
+    )
+    breaking_with_receipt = reset(
+        "S1-0002", "#908", "breaking-required", "S1-0001"
+    ).replace(
+        'evidence = "verified reset cause"',
+        'evidence = "verified reset cause"\nreplay_receipt_pr = "#19002"\n'
+        f'replay_receipt_sha256 = "{"2" * 64}"',
+    )
+    expect_failure(
+        lambda: policy.validate_entry_shape(
+            parsed_entries(freeze(), breaking_with_receipt)[1],
+            2,
+        ),
+        "fields differ from schema",
+    )
+
+    def reset_candidate_case() -> tuple[
+        list[str],
+        Context,
+        policy.AuditEvidence,
+        policy.RecordInvalidResetReplayEvidence,
+    ]:
+        blocks = [
+            freeze(),
+            reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+        ]
+        facts = context()
+        add_record(
+            facts,
+            "S1-0002",
+            "#908",
+            908,
+            FREEZE_TIME + timedelta(seconds=1),
+        )
+        facts.prs["#908"] = candidate_pr(908, author="record-author")
+        entries = parsed_entries(*blocks)
+        prepare_reset_receipts(entries, facts)
+        receipt_ref = entries[-1]["replay_receipt_pr"]
+        receipt_digest = entries[-1]["replay_receipt_sha256"]
+        replay = facts.resolve_replay_record_invalid_reset(
+            "S1-0002",
+            "S1-0001",
+            receipt_ref,
+            receipt_digest,
+        )
+        candidate_head = facts.prs["#908"].head_oid
+        assert candidate_head is not None
+        audit = audit_evidence(
+            "S1-0001",
+            ("S1-0001",),
+            target_oid=candidate_head,
+        )
+        return blocks, facts, audit, replay
+
+    receipt_perturbations = (
+        ("validated_target_entry_id", "S1-9999", "used another target"),
+        ("validated_receipt_pr", "#9999", "used another PR"),
+        ("validated_receipt_head_oid", oid(99_991), "used another exact head"),
+        (
+            "validated_receipt_integration_oid",
+            oid(99_992),
+            "used another integration",
+        ),
+        ("complete", False, "reset receipt is incomplete"),
+        ("receipt_candidate_main_tip_exact", False, "exact current main tip"),
+        ("changes_exactly_one_new_regular_blob", False, "new regular blob"),
+        ("receipt_path", "docs/tenkz/soak-replay/wrong.json", "wrong path"),
+        ("raw_blob_read_from_receipt_integration", False, "reachable integration"),
+        ("schema_path", "schema.json", "used another schema"),
+        ("schema_support_tree_oid", oid(99_993), "used another support tree"),
+        ("schema_from_pinned_support_tree", False, "pinned support tree"),
+        ("schema_closed_and_valid", False, "closed schema"),
+        ("boundary_entry_id", "S1-9999", "another pre-reset prefix"),
+        ("validation_target_oid", oid(99_994), "inexact validation target"),
+        ("raw_invalid_entries", (), "does not match its current reset receipt"),
+        (
+            "pending_breaking_target",
+            "S1-0001",
+            "wrong pending breaking target",
+        ),
+        (
+            "normalized_resolver_inputs_complete_and_matching",
+            False,
+            "resolver inputs are incomplete",
+        ),
+        ("workflow_dependency_closure_pinned", False, "workflow closure is not pinned"),
+        (
+            "supervisor_receipts_complete_and_matching",
+            False,
+            "supervisor results are incomplete",
+        ),
+        (
+            "current_candidate_snapshot_reproduces_receipt",
+            False,
+            "no longer reproduces its receipt",
+        ),
+    )
+    for field_name, bad_value, error_fragment in receipt_perturbations:
+        receipt_blocks, receipt_facts, receipt_audit, replay = reset_candidate_case()
+        receipt_facts.reset_replays["S1-0002"] = replace(
+            replay,
+            **{field_name: bad_value},
+        )
+        expect_failure(
+            lambda blocks=receipt_blocks, facts=receipt_facts, audit=receipt_audit: validate(
+                blocks,
+                facts,
+                audit=audit,
+            ),
+            error_fragment,
+        )
+
+    wrong_receipt_digest_blocks, wrong_receipt_digest, digest_audit, replay = (
+        reset_candidate_case()
+    )
+    wrong_receipt_digest.reset_replays["S1-0002"] = replace(
+        replay,
+        raw_blob_sha256="f" * 64,
+    )
+    expect_failure(
+        lambda: validate(
+            wrong_receipt_digest_blocks,
+            wrong_receipt_digest,
+            audit=digest_audit,
+        ),
+        "blob digest differs from the entry",
+    )
+
+    wrong_receipt_base_blocks, wrong_receipt_base, base_audit, _replay = (
+        reset_candidate_case()
+    )
+    wrong_receipt_base.records["S1-0002"] = replace(
+        wrong_receipt_base.records["S1-0002"],
+        candidate_main_tip_is_receipt_integration=False,
+    )
+    expect_failure(
+        lambda: validate(
+            wrong_receipt_base_blocks,
+            wrong_receipt_base,
+            audit=base_audit,
+        ),
+        "candidate base differs from receipt integration",
+    )
+
+    invalid_acknowledgement = context()
+    add_record(
+        invalid_acknowledgement,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    invalid_acknowledgement.records["S1-0002"] = replace(
+        invalid_acknowledgement.records["S1-0002"],
+        integration_parent_is_receipt_integration=False,
+    )
+    invalid_ack_log = [
+        freeze(),
+        reset("S1-0002", "#908", "record-invalid", "S1-0001"),
+    ]
+    assert validate(
+        invalid_ack_log,
+        invalid_acknowledgement,
+        audit=audit_evidence(
+            "S1-0002",
+            ("S1-0001", "S1-0002"),
+            target_oid=invalid_acknowledgement.prs["#908"].merge_commit_oid,
+        ),
+    ) == "reset-required:S1-0001"
+
+    receipt_collision_blocks, receipt_collision, collision_audit, _replay = (
+        reset_candidate_case()
+    )
+    receipt_collision_blocks[-1] = reset(
+        "S1-0002",
+        "#908",
+        "record-invalid",
+        "S1-0001",
+        replay_receipt_pr=ACTIVATION,
+    )
+    expect_failure(
+        lambda: validate(
+            receipt_collision_blocks,
+            receipt_collision,
+            audit=collision_audit,
+        ),
+        "replay receipt PR #900 is the activation PR",
+    )
+
+    mutable_workflow = context()
+    activation_integration = mutable_workflow.prs[ACTIVATION].merge_commit_oid
+    target_oid = mutable_workflow.prs[SIGNOFF_RECORD].merge_commit_oid
+    assert activation_integration is not None and target_oid is not None
+    workflow = mutable_workflow.resolve_current_workflow(
+        activation_integration,
+        target_oid,
+        (".github/workflows/pr-ci.yml",),
+    )
+    mutable_workflow.workflow_override = replace(
+        workflow,
+        external_dependencies_use_full_commit_shas=False,
+    )
+    expect_failure(
+        lambda: validate(complete_log(), mutable_workflow),
+        "external workflow dependency uses a mutable ref",
+    )
+
+    boolean_record_parent = context()
+    boolean_record_parent.records["S1-0001"] = replace(
+        boolean_record_parent.records["S1-0001"],
+        integration_parent_count=True,
+    )
+    assert validate([freeze()], boolean_record_parent) == "reset-required:S1-0001"
+
+    boolean_work_parent = context()
+    boolean_work_parent.work_diffs[FORMAL_WORK] = replace(
+        boolean_work_parent.work_diffs[FORMAL_WORK],
+        integration_parent_count=True,
+    )
+    assert validate(complete_log()[:2], boolean_work_parent) == (
+        "reset-required:S1-0002"
+    )
+
+    work_after_record = context()
+    work_after_record.prs[FORMAL_RECORD] = replace(
+        work_after_record.prs[FORMAL_RECORD],
+        merged_at=FORMAL_MERGE - timedelta(microseconds=1),
+    )
+    assert validate(complete_log()[:2], work_after_record) == (
+        "reset-required:S1-0002"
+    )
+
+    cross_bound_work = context()
+    cross_bound_work.work_diffs[FORMAL_WORK] = replace(
+        cross_bound_work.work_diffs[FORMAL_WORK],
+        validated_head_oid=oid(99_995),
+    )
+    assert validate(complete_log()[:2], cross_bound_work) == (
+        "reset-required:S1-0002"
+    )
 
     candidate = context()
     candidate_head = candidate.prs[SIGNOFF_RECORD].head_oid
@@ -1022,12 +1541,12 @@ def main() -> int:
         "lacks one work class",
     )
 
-    incomplete_audit = policy.AuditEvidence("S1-0004", (), False, True)
+    incomplete_audit = policy.AuditEvidence("S1-0004", (), False, True, oid(99_999))
     expect_failure(
         lambda: validate(complete_log(), context(), audit=incomplete_audit),
         "audit snapshot is incomplete",
     )
-    inexact_target_audit = policy.AuditEvidence("S1-0004", (), True, False)
+    inexact_target_audit = policy.AuditEvidence("S1-0004", (), True, False, oid(99_999))
     expect_failure(
         lambda: validate(complete_log(), context(), audit=inexact_target_audit),
         "audit validation target is not exact",
@@ -1399,6 +1918,10 @@ def main() -> int:
     )
     third_facts.prs["#909"] = merged_pr(909, FREEZE_TIME + timedelta(seconds=8))
     third_facts.work_diffs["#908"] = policy.WorkDiffEvidence(
+        validated_pr_ref="#908",
+        validated_head_oid=third_facts.prs["#908"].head_oid,
+        validated_integration_oid=third_facts.prs["#908"].merge_commit_oid,
+        validated_freeze_integration=third_facts.prs[FREEZE_RECORD].merge_commit_oid,
         complete=True,
         integration_parent_count=1,
         unique_merge_base=True,
@@ -1645,14 +2168,7 @@ def main() -> int:
     recovered = invalid_log + [
         reset("S1-0003", "#908", "record-invalid", "S1-0002")
     ]
-    assert (
-        validate(
-            recovered,
-            invalid_facts,
-            audit=audit_evidence("S1-0002", ("S1-0002",)),
-        )
-        == "reset"
-    )
+    assert validate(recovered, invalid_facts) == "reset"
     expect_failure(
         lambda: validate(
             invalid_log,
@@ -1690,15 +2206,10 @@ def main() -> int:
         )
         == "reset-required:S1-0002"
     )
-    assert (
-        validate(
-            complete_log()
-            + [reset("S1-0005", "#908", "record-invalid", "S1-0002")],
-            replayed_drift,
-            audit=audit_evidence("S1-0004", ("S1-0002",)),
-        )
-        == "reset"
-    )
+    assert validate(
+        complete_log() + [reset("S1-0005", "#908", "record-invalid", "S1-0002")],
+        replayed_drift,
+    ) == "reset"
 
     replayed_freeze_drift = context()
     add_record(
@@ -1708,15 +2219,11 @@ def main() -> int:
         908,
         FREEZE_TIME + timedelta(seconds=8),
     )
-    assert (
-        validate(
-            complete_log()[:3]
-            + [reset("S1-0004", "#908", "record-invalid", "S1-0001")],
-            replayed_freeze_drift,
-            audit=audit_evidence("S1-0003", ("S1-0001",)),
-        )
-        == "reset"
-    )
+    assert validate(
+        complete_log()[:3]
+        + [reset("S1-0004", "#908", "record-invalid", "S1-0001")],
+        replayed_freeze_drift,
+    ) == "reset"
 
     corrected_drift = context()
     add_record(
@@ -1733,18 +2240,14 @@ def main() -> int:
         909,
         SIGNOFF_MERGE + timedelta(seconds=2),
     )
-    assert (
-        validate(
-            complete_log()
-            + [
-                correction("S1-0005", "#908", "S1-0001"),
-                reset("S1-0006", "#909", "record-invalid", "S1-0002"),
-            ],
-            corrected_drift,
-            audit=audit_evidence("S1-0004", ("S1-0002",)),
-        )
-        == "reset"
-    )
+    assert validate(
+        complete_log()
+        + [
+            correction("S1-0005", "#908", "S1-0001"),
+            reset("S1-0006", "#909", "record-invalid", "S1-0002"),
+        ],
+        corrected_drift,
+    ) == "reset"
 
     # An already-pending breaking-required reset has priority at the drift
     # boundary; the administrative drift reset follows immediately after it.
@@ -1780,18 +2283,15 @@ def main() -> int:
         validate(
             breaking_then_drift[:3],
             ordered_resets,
-            audit=audit_evidence("S1-0002", ("S1-0001",)),
+            audit=audit_evidence(
+                "S1-0003",
+                ("S1-0001",),
+                target_oid=ordered_resets.prs["#909"].merge_commit_oid,
+            ),
         )
         == "reset-required:S1-0001"
     )
-    assert (
-        validate(
-            breaking_then_drift,
-            ordered_resets,
-            audit=audit_evidence("S1-0002", ("S1-0001",)),
-        )
-        == "reset"
-    )
+    assert validate(breaking_then_drift, ordered_resets) == "reset"
 
     batched_drift = context()
     add_record(
@@ -1813,25 +2313,25 @@ def main() -> int:
         ("S1-0002", "S1-0001"),
         True,
         True,
+        oid(99_999),
     )
     expect_failure(
         lambda: validate(complete_log(), batched_drift, audit=unsorted_audit),
         "invalid entries are not in ledger order",
     )
-    ordered_audit = policy.AuditEvidence(
-        "S1-0004",
-        ("S1-0001", "S1-0002"),
-        True,
-        True,
-    )
     batched_log = complete_log() + [
         reset("S1-0005", "#908", "record-invalid", "S1-0001"),
         reset("S1-0006", "#909", "record-invalid", "S1-0002"),
     ]
-    assert validate(batched_log[:-1], batched_drift, audit=ordered_audit) == (
+    first_reset_audit = audit_evidence(
+        "S1-0005",
+        ("S1-0002",),
+        target_oid=batched_drift.prs["#908"].merge_commit_oid,
+    )
+    assert validate(batched_log[:-1], batched_drift, audit=first_reset_audit) == (
         "reset-required:S1-0002"
     )
-    assert validate(batched_log, batched_drift, audit=ordered_audit) == "reset"
+    assert validate(batched_log, batched_drift) == "reset"
 
     # The self-referential record rule is common to every entry kind.  A
     # copied or tree-mismatched merged record never supplies usable evidence;
@@ -2015,6 +2515,13 @@ def main() -> int:
         910,
         FREEZE_TIME + timedelta(seconds=5),
     )
+    add_record(
+        reset_common,
+        "S1-0005",
+        "#911",
+        911,
+        FREEZE_TIME + timedelta(seconds=6),
+    )
     common_cases.append(
         (
             "reset",
@@ -2022,11 +2529,12 @@ def main() -> int:
                 freeze(),
                 friction("S1-0002", "#908", "breaking-required"),
                 reset("S1-0003", "#909", "breaking-required", "S1-0002"),
-                reset("S1-0004", "#910", "record-invalid", "S1-0003"),
+                reset("S1-0004", "#910", "breaking-required", "S1-0002"),
+                reset("S1-0005", "#911", "record-invalid", "S1-0003"),
             ],
             "S1-0003",
-            "S1-0004",
-            "#910",
+            "S1-0005",
+            "#911",
         )
     )
 
@@ -2064,9 +2572,11 @@ def main() -> int:
     }
     for name, log, invalid_id, reset_id, _reset_pr in common_cases:
         facts = case_facts[name]
-        assert validate(log[:-1], facts) == f"reset-required:{invalid_id}"
+        actual = validate(log[:-1], facts)
+        assert actual == f"reset-required:{invalid_id}", (name, actual)
         assert log[-1].find(f'id = "{reset_id}"') >= 0
-        assert validate(log, facts) == "reset"
+        final_actual = validate(log, facts)
+        assert final_actual == "reset", (name, final_actual)
 
     copied_candidate = context()
     copied_candidate.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
@@ -2099,7 +2609,14 @@ def main() -> int:
     assert validate(copied_log, copied_merged) == "reset"
 
     moved_tag = context()
-    moved_tag.tags["tenkz-v0.9.0"] = policy.TagEvidence("9" * 40, "tag", SHA, True)
+    moved_tag.tags["tenkz-v0.9.0"] = policy.TagEvidence(
+        "9" * 40,
+        "tag",
+        SHA,
+        True,
+        True,
+        True,
+    )
     add_record(
         moved_tag,
         "S1-0002",
@@ -2120,6 +2637,8 @@ def main() -> int:
         "9" * 40,
         "tag",
         SHA,
+        True,
+        True,
         True,
     )
     expect_failure(
@@ -2161,7 +2680,7 @@ def main() -> int:
     stale_patch.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
     stale_patch.tags["tenkz-v0.9.0"] = replace(
         stale_patch.tags["tenkz-v0.9.0"],
-        patch_is_fresh_for_attempt=False,
+        patch_exceeds_other_namespace_tags=False,
     )
     expect_failure(
         lambda: validate([freeze()], stale_patch),
@@ -2325,6 +2844,12 @@ def main() -> int:
     )
     expect_failure(
         lambda: policy.validate_policy_text(
+            DESIGN_TEXT.replace("schema = 1", "schema = true", 1)
+        ),
+        "signed policy",
+    )
+    expect_failure(
+        lambda: policy.validate_policy_text(
             DESIGN_TEXT.replace(
                 'work_classes = ["formalization-or-blueprint", "rmp-benchmark"]',
                 'work_classes = ["rmp-benchmark", "formalization-or-blueprint"]',
@@ -2338,6 +2863,12 @@ def main() -> int:
                 "append_only = true",
                 'minimum_elapsed = "forbidden"\nappend_only = true',
             )
+        ),
+        "signed schema",
+    )
+    expect_failure(
+        lambda: policy.parse_soak_text(
+            SOAK_TEXT.replace("append_only = true", "append_only = 1", 1)
         ),
         "signed schema",
     )

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -41,6 +41,7 @@ TEST_CODE_TREE = "e" * 40
 TEST_SUPPORT_TREE = "1" * 40
 POLICY_DIGEST = "f" * 64
 REGRESSION_TEST = "tex-api-regression"
+FAILURE_FINGERPRINT = "2" * 64
 
 ARMED_POLICY = {
     **policy.EXPECTED_POLICY,
@@ -367,6 +368,7 @@ class Context:
         ref: str,
         _paths: tuple[str, ...],
         _work_integrations: tuple[str, ...],
+        _resolution_integrations: tuple[str, ...],
     ) -> policy.ReleasePrepEvidence:
         return self.release_preps[ref]
 
@@ -432,7 +434,7 @@ class Context:
             boundary_entry_id=f"S1-{index - 1:04d}",
             validation_target_oid=receipt.head_oid,
             raw_invalid_entries=(target,),
-            pending_breaking_target=None,
+            pending_restart_target=None,
             normalized_resolver_inputs_complete_and_matching=True,
             workflow_dependency_closure_pinned=True,
             supervisor_receipts_complete_and_matching=True,
@@ -485,19 +487,25 @@ def payload_evidence(
         manifest_contract_valid=True,
         artifact_declarations_agree=True,
         inventory_digest_matches=True,
-        inventory_contract_valid=True,
+        inventory_exact_schema_valid=True,
+        inventory_ids_and_failure_fingerprints_unique=True,
+        inventory_test_surface_valid=True,
+        inventory_atomic_assertions_one_per_test=True,
         test_code_tree_matches=True,
         test_support_tree_matches=True,
-        inventory_data_paths_within_mutable_roots=True,
-        executable_dependencies_within_code_tree=True,
+        inventory_subject_paths_within_subject_roots=True,
+        inventory_program_paths_regular_and_surface_owned=True,
+        inventory_fixture_paths_regular_or_trees=True,
+        inventory_subject_roles_disjoint=True,
+        inventory_fixtures_nonexecutable=True,
+        executable_dependencies_within_harness_tree=True,
         acceptance_dependencies_within_support_tree=True,
-        subject_data_cannot_reduce_coverage=True,
+        subjects_cannot_supply_evidence_logic=True,
         hermetic_execution_contract_valid=True,
         payload_execution_receipts_complete_and_matching=True,
         test_execution_complete=True,
         compatibility_tests_passed=True,
         payload_blob_oids=blob_oids,
-        inventory_test_surfaces_valid=True,
     )
 
 
@@ -506,10 +514,14 @@ def observation_evidence(
     tag: str,
     test_ref: str,
     *,
-    surfaces: tuple[str, ...] = ("tex-api",),
-    exit_code: int = 1,
+    surface: str = "tex-api",
+    result: str = "assertion-failed",
+    failure_fingerprint: str = FAILURE_FINGERPRINT,
+    program_paths: tuple[str, ...] = ("tex/tenkz/tenkz.sty",),
+    fixture_paths: tuple[str, ...] = ("tests/tenkz/rmp/fixtures/baseline.tex",),
 ) -> policy.ReleaseTestObservationEvidence:
     contract = policy.policy_rules(ARMED_POLICY)[4]
+    assertion_failed = result == "assertion-failed"
     return policy.ReleaseTestObservationEvidence(
         validated_tree_oid=tree_oid,
         validated_tag=tag,
@@ -521,19 +533,29 @@ def observation_evidence(
         manifest_contract_valid=True,
         artifact_declarations_agree=True,
         inventory_digest_matches=True,
-        inventory_contract_valid=True,
-        inventory_test_surfaces_valid=True,
+        inventory_exact_schema_valid=True,
+        inventory_ids_and_failure_fingerprints_unique=True,
+        inventory_test_surface_valid=True,
+        inventory_atomic_assertions_one_per_test=True,
         inventory_test_exists=True,
         inventory_command_exact_and_matching=True,
         test_code_tree_matches=True,
         test_support_tree_matches=True,
-        inventory_data_paths_within_mutable_roots=True,
-        executable_dependencies_within_code_tree=True,
+        inventory_subject_paths_within_subject_roots=True,
+        executable_dependencies_within_harness_tree=True,
         acceptance_dependencies_within_support_tree=True,
-        subject_data_cannot_reduce_coverage=True,
+        subjects_cannot_supply_evidence_logic=True,
         hermetic_execution_contract_valid=True,
         tool_fingerprints_match=True,
-        inventory_test_surfaces=surfaces,
+        inventory_test_surface=surface,
+        inventory_test_failure_fingerprint=failure_fingerprint,
+        inventory_test_program_paths=program_paths,
+        inventory_test_fixture_paths=fixture_paths,
+        inventory_test_program_paths_regular_blobs=True,
+        inventory_test_fixture_paths_regular_blobs_or_trees=True,
+        inventory_test_fixture_trees_exclude_program_paths=True,
+        inventory_test_fixtures_nonexecutable=True,
+        atomic_assertion_count=1,
         exactly_one_inventory_test_run=True,
         setup_complete_and_matching=True,
         isolation_valid=True,
@@ -541,8 +563,21 @@ def observation_evidence(
         execution_complete=True,
         timed_out=False,
         terminated_by_signal=False,
-        clean_process_exit=True,
-        exit_code=exit_code,
+        result=result,
+        exit_code=10 if assertion_failed else 0,
+        assertion_failure_receipt_path=(
+            "/tenkz-output/assertion-failure-v1.json" if assertion_failed else None
+        ),
+        observed_failure_fingerprint=(
+            failure_fingerprint if assertion_failed else None
+        ),
+        assertion_failure_receipt_exact_and_matching=(
+            True if assertion_failed else None
+        ),
+        assertion_failure_receipt_atomically_written=(
+            True if assertion_failed else None
+        ),
+        single_failure_cause=True if assertion_failed else None,
     )
 
 
@@ -648,18 +683,25 @@ def context() -> Context:
         unique_merge_base=True,
         exact_seven_scalar_replacements=True,
         inventory_digest_matches=True,
+        inventory_exact_schema_valid=True,
+        inventory_ids_and_failure_fingerprints_unique=True,
+        inventory_test_surface_valid=True,
+        inventory_atomic_assertions_one_per_test=True,
         test_code_tree_matches=True,
         test_support_tree_matches=True,
-        inventory_data_paths_within_mutable_roots=True,
-        executable_dependencies_within_code_tree=True,
+        inventory_subject_paths_within_subject_roots=True,
+        inventory_program_paths_regular_and_surface_owned=True,
+        inventory_fixture_paths_regular_or_trees=True,
+        inventory_subject_roles_disjoint=True,
+        inventory_fixtures_nonexecutable=True,
+        executable_dependencies_within_harness_tree=True,
         acceptance_dependencies_within_support_tree=True,
-        subject_data_cannot_reduce_coverage=True,
+        subjects_cannot_supply_evidence_logic=True,
         hermetic_execution_contract_valid=True,
         supervisor_self_test_receipt_valid=True,
         enforcement_workflows_pinned=True,
         policy_digest_matches=True,
         ledger_prefix_matches=True,
-        inventory_test_surfaces_valid=True,
     )
     records = {
         entry_id: policy.RecordDiffEvidence(
@@ -759,12 +801,14 @@ def context() -> Context:
                 policy.FINAL_TAG
             ),
             validated_work_integrations=work_integrations,
+            validated_resolution_integrations=(),
             complete=True,
             integration_parent_count=1,
             unique_merge_base=True,
             integration_parent_is_ancestor_of_head=True,
             integration_second_parent_matches_head=True,
             integration_descends_from_work_integrations=True,
+            integration_descends_from_resolution_integrations=True,
             exact_release_varying_path_diff=True,
         )
     }
@@ -811,9 +855,8 @@ def context() -> Context:
                 TAG_OBJECT,
                 "tag",
                 SHA,
-                True,
-                True,
-                True,
+                historical_candidate_check_exact_and_successful=True,
+                historical_compares_only_earlier_freezes=True,
             ),
             policy.FINAL_TAG: policy.TagEvidence(None, None, None, exists=False),
         },
@@ -972,6 +1015,11 @@ def prepare_friction_observations(entries: list[dict], facts: Context) -> None:
         trees = [record.head_oid]
         if record.merged is True:
             trees.append(record.merge_commit_oid)
+        program_path = (
+            "scripts/tenkzlib/tnlog.py"
+            if entry["surface"] == "tnlog"
+            else "tex/tenkz/tenkz.sty"
+        )
         for tree_oid in trees:
             assert isinstance(tree_oid, str)
             for test_ref in entry["regression_tests"]:
@@ -981,8 +1029,9 @@ def prepare_friction_observations(entries: list[dict], facts: Context) -> None:
                         tree_oid,
                         tag,
                         test_ref,
-                        surfaces=(entry["surface"],),
-                        exit_code=1,
+                        surface=entry["surface"],
+                        result="assertion-failed",
+                        program_paths=(program_path,),
                     ),
                 )
 
@@ -996,6 +1045,8 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
             continue
         entry_id = entry["id"]
         friction_entry = by_id[entry["friction"]]
+        if friction_entry["triage"] != "fix-compatible":
+            continue
         friction_pr = facts.prs[friction_entry["record_pr"]]
         friction_time = friction_pr.merged_at
         friction_integration = friction_pr.merge_commit_oid
@@ -1036,6 +1087,31 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
         fix_head = fix_pr.head_oid
         assert fix_head is not None
         fix_base = oid(fix_number * 10 - 1)
+        surface = friction_entry["surface"]
+        program_path = (
+            "scripts/tenkzlib/tnlog.py"
+            if surface == "tnlog"
+            else "tex/tenkz/tenkz.sty"
+        )
+        stream_kind = (
+            "python-location-free-ast"
+            if surface == "tnlog"
+            else "tex-comment-stripped-tokens"
+        )
+        regression_fixes = tuple(
+            policy.RegressionFixEvidence(
+                test_ref=test_ref,
+                validated_surface=surface,
+                declared_program_paths=(program_path,),
+                changed_program_path=program_path,
+                program_blob_modified=True,
+                semantic_stream_kind=stream_kind,
+                semantic_stream_changed=True,
+                python_reader_parses=True if surface == "tnlog" else None,
+                baseline_failure_fingerprint=FAILURE_FINGERPRINT,
+            )
+            for test_ref in friction_entry["regression_tests"]
+        )
         if fix_ref not in facts.resolution_diffs:
             facts.resolution_diffs[fix_ref] = policy.ResolutionDiffEvidence(
                 validated_pr_ref=fix_ref,
@@ -1052,14 +1128,17 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
                 integration_strict_descendant_of_friction=True,
                 policy_paths_untouched=True,
                 validated_base_oid=fix_base,
-                validated_surface=friction_entry["surface"],
-                validated_fix_path_patterns=policy.policy_rules(ARMED_POLICY)[
-                    4
-                ].fix_paths(friction_entry["surface"]),
-                semantic_witness_path="tex/tenkz/tenkz.sty",
-                surface_matching_added_or_modified_regular_blob=True,
-                tex_comment_stripped_token_stream_changed=True,
-                semantic_witness_is_same_surface_regular_blob=True,
+                validated_regression_tests=tuple(friction_entry["regression_tests"]),
+                regression_fixes=regression_fixes,
+                validated_identity_trees=(
+                    friction_pr.head_oid,
+                    friction_integration,
+                    fix_base,
+                    fix_head,
+                    fix_integration,
+                ),
+                fixture_blobs_modes_and_trees_identical=True,
+                freeze_manifest_blob_identical=True,
             )
         fix_diff = facts.resolution_diffs[fix_ref]
         observation_base = fix_diff.validated_base_oid
@@ -1071,8 +1150,9 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
                         observation_base,
                         freeze_entry["freeze_tag"],
                         test_ref,
-                        surfaces=(friction_entry["surface"],),
-                        exit_code=1,
+                        surface=surface,
+                        result="assertion-failed",
+                        program_paths=(program_path,),
                     ),
                 )
                 facts.observations.setdefault(
@@ -1081,8 +1161,9 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
                         fix_head,
                         freeze_entry["freeze_tag"],
                         test_ref,
-                        surfaces=(friction_entry["surface"],),
-                        exit_code=0,
+                        surface=surface,
+                        result="passed",
+                        program_paths=(program_path,),
                     ),
                 )
         facts.payloads.setdefault(
@@ -1113,6 +1194,23 @@ def prepare_resolution_facts(entries: list[dict], facts: Context) -> None:
             ),
         )
 
+    resolution_integrations = tuple(
+        facts.prs[entry["record_pr"]].merge_commit_oid
+        for entry in entries
+        if entry["kind"] == "resolution"
+        and entry["fix_pr"] in facts.resolution_diffs
+        and isinstance(facts.prs[entry["record_pr"]].merge_commit_oid, str)
+    )
+    assert all(isinstance(item, str) for item in resolution_integrations)
+    if resolution_integrations:
+        for ref, evidence in tuple(facts.release_preps.items()):
+            if evidence.validated_resolution_integrations == ():
+                facts.release_preps[ref] = replace(
+                    evidence,
+                    validated_resolution_integrations=resolution_integrations,
+                    integration_descends_from_resolution_integrations=True,
+                )
+
 
 def set_review_permission(facts: Context, ref: str, permission: str | None) -> None:
     pull_request = facts.prs[ref]
@@ -1128,6 +1226,26 @@ def set_review_permission(facts: Context, ref: str, permission: str | None) -> N
 
 def validate(blocks: list[str], facts: Context, **overrides) -> str:
     entries = parsed_entries(*blocks)
+    for entry in entries:
+        if entry["kind"] != "freeze":
+            continue
+        record = facts.prs.get(entry["record_pr"])
+        if record is None or record.merged is not False:
+            continue
+        tag = facts.tags[entry["freeze_tag"]]
+        facts.tags[entry["freeze_tag"]] = replace(
+            tag,
+            candidate_namespace_complete=(
+                True
+                if tag.candidate_namespace_complete is None
+                else tag.candidate_namespace_complete
+            ),
+            candidate_patch_exceeds_current_namespace=(
+                True
+                if tag.candidate_patch_exceeds_current_namespace is None
+                else tag.candidate_patch_exceeds_current_namespace
+            ),
+        )
     prepare_reset_receipts(entries, facts)
     prepare_friction_observations(entries, facts)
     prepare_resolution_facts(entries, facts)
@@ -1271,9 +1389,8 @@ def add_freeze_facts(
         tag_object,
         "tag",
         source_sha,
-        True,
-        True,
-        True,
+        historical_candidate_check_exact_and_successful=True,
+        historical_compares_only_earlier_freezes=True,
     )
     facts.payloads[(source_sha, tag)] = payload_evidence(
         source_sha,
@@ -1307,11 +1424,11 @@ def main() -> int:
     invalid_activation_surfaces = context()
     invalid_activation_surfaces.activation_diff = replace(
         invalid_activation_surfaces.activation_diff,
-        inventory_test_surfaces_valid=False,
+        inventory_test_surface_valid=False,
     )
     expect_failure(
         lambda: validate([], invalid_activation_surfaces),
-        "activation inventory test surfaces are invalid",
+        "activation inventory test surface is invalid",
     )
     expect_failure(
         lambda: validate(
@@ -1330,15 +1447,18 @@ def main() -> int:
     ]
     contract = policy.policy_rules(ARMED_POLICY)[4]
     assert contract.fix_paths("tex-api") == (
-        "tex/tenkz/**/*.tex",
-        "tex/tenkz/**/*.sty",
+        "tex/tenkz/*.tex",
+        "tex/tenkz/*.sty",
     )
-    assert contract.fix_paths("tnlog") == contract.fix_paths("tex-api")
+    assert contract.fix_paths("tnlog") == (
+        *contract.fix_paths("tex-api"),
+        "scripts/tenkzlib/tnlog.py",
+    )
     assert policy.policy_glob_matches(
         "tex/tenkz/tenkz.sty",
         contract.fix_paths("tex-api")[1],
     )
-    assert policy.policy_glob_matches(
+    assert not policy.policy_glob_matches(
         "tex/tenkz/internal/parser.tex",
         contract.fix_paths("tex-api")[0],
     )
@@ -1470,8 +1590,8 @@ def main() -> int:
         ),
         "fields differ from schema",
     )
-    breaking_with_receipt = reset(
-        "S1-0002", "#908", "breaking-required", "S1-0001"
+    restart_with_receipt = reset(
+        "S1-0002", "#908", "restart-required", "S1-0001"
     ).replace(
         'evidence = "verified reset cause"',
         'evidence = "verified reset cause"\nreplay_receipt_pr = "#19002"\n'
@@ -1479,7 +1599,7 @@ def main() -> int:
     )
     expect_failure(
         lambda: policy.validate_entry_shape(
-            parsed_entries(freeze(), breaking_with_receipt)[1],
+            parsed_entries(freeze(), restart_with_receipt)[1],
             2,
         ),
         "fields differ from schema",
@@ -1555,9 +1675,9 @@ def main() -> int:
         ("validation_target_oid", oid(99_994), "inexact validation target"),
         ("raw_invalid_entries", (), "does not match its current reset receipt"),
         (
-            "pending_breaking_target",
+            "pending_restart_target",
             "S1-0001",
-            "wrong pending breaking target",
+            "wrong pending restart target",
         ),
         (
             "normalized_resolver_inputs_complete_and_matching",
@@ -1992,19 +2112,31 @@ def main() -> int:
         return blocks, facts, (tree_oid, "tenkz-v0.9.0", REGRESSION_TEST)
 
     friction_observation_failures = (
-        ("inventory_test_surfaces", ("tnlog",), "does not cover surface tex-api"),
-        ("inventory_test_surfaces", (), "test surfaces are missing"),
-        ("inventory_test_surfaces", ("tex-api", "tex-api"), "surfaces have duplicates"),
+        ("inventory_test_surface", "tnlog", "test covers another surface"),
+        ("inventory_test_surface", None, "test surface is missing or invalid"),
         ("inventory_test_exists", False, "test is absent from inventory"),
         ("inventory_command_exact_and_matching", False, "command differs from the pinned"),
+        (
+            "inventory_test_fixture_trees_exclude_program_paths",
+            False,
+            "fixture tree contains a program path",
+        ),
+        ("inventory_test_fixtures_nonexecutable", False, "fixture is executable"),
+        ("atomic_assertion_count", 2, "does not contain exactly one atomic assertion"),
         ("timed_out", True, "timed out"),
         ("terminated_by_signal", True, "ended by signal"),
         ("setup_complete_and_matching", False, "setup is incomplete"),
         ("isolation_valid", False, "isolation failed"),
         ("execution_complete", False, "execution is incomplete"),
-        ("clean_process_exit", False, "did not exit cleanly"),
-        ("exit_code", 0, "did not reproduce friction"),
+        ("result", "setup-failed", "returned another result"),
+        ("exit_code", 9, "assertion failure did not exit exactly 10"),
         ("exit_code", True, "invalid process exit code"),
+        (
+            "observed_failure_fingerprint",
+            "3" * 64,
+            "observed another failure fingerprint",
+        ),
+        ("single_failure_cause", False, "coarse or multiple-cause failure"),
         ("validated_tag", "tenkz-v0.9.1", "used another freeze tag"),
     )
     for field_name, bad_value, error_fragment in friction_observation_failures:
@@ -2017,6 +2149,17 @@ def main() -> int:
             lambda blocks=blocks, facts=facts: validate(blocks, facts),
             error_fragment,
         )
+
+    fixture_gaming, fixture_gaming_facts, observation_key = friction_case(True)
+    observation = fixture_gaming_facts.observations[observation_key]
+    fixture_gaming_facts.observations[observation_key] = replace(
+        observation,
+        inventory_test_fixture_paths=observation.inventory_test_program_paths,
+    )
+    expect_failure(
+        lambda: validate(fixture_gaming, fixture_gaming_facts),
+        "program and fixture roles overlap",
+    )
 
     postmerge_friction, postmerge_friction_facts, integration_key = friction_case(False)
     postmerge_friction_facts.observations[integration_key] = replace(
@@ -2055,7 +2198,7 @@ def main() -> int:
     ]
     expect_failure(
         lambda: validate(empty_regression_resolution, context()),
-        "cannot resolve an empty regression-test evidence gap",
+        "regression_tests must be nonempty",
     )
 
     empty_gap_signoff = [
@@ -2114,13 +2257,24 @@ def main() -> int:
     )
     expect_failure(
         lambda: validate(empty_gap_signoff, empty_gap_facts),
-        "unresolved friction: S1-0002",
+        "regression_tests must be nonempty",
     )
 
-    def resolution_case(candidate_record: bool) -> tuple[list[str], Context, str]:
+    def resolution_case(
+        candidate_record: bool,
+        *,
+        surface: str = "tex-api",
+        test_ref: str = REGRESSION_TEST,
+    ) -> tuple[list[str], Context, str]:
         blocks = [
             freeze(),
-            friction("S1-0002", FORMAL_RECORD, "fix-compatible"),
+            friction(
+                "S1-0002",
+                FORMAL_RECORD,
+                "fix-compatible",
+                surface=surface,
+                regression_tests=(test_ref,),
+            ),
             resolution("S1-0003", RMP_RECORD, "S1-0002"),
         ]
         facts = context()
@@ -2135,26 +2289,44 @@ def main() -> int:
     pending_resolution, pending_resolution_facts, _fix_ref = resolution_case(True)
     assert validate(pending_resolution, pending_resolution_facts) == "resolution-pending"
 
+    reader_resolution, reader_resolution_facts, reader_fix_ref = resolution_case(
+        True,
+        surface="tnlog",
+        test_ref="tnlog-reader-regression",
+    )
+    assert validate(reader_resolution, reader_resolution_facts) == "resolution-pending"
+    reader_diff = reader_resolution_facts.resolution_diffs[reader_fix_ref]
+    assert reader_diff.regression_fixes is not None
+    reader_resolution_facts.resolution_diffs[reader_fix_ref] = replace(
+        reader_diff,
+        regression_fixes=(
+            replace(reader_diff.regression_fixes[0], python_reader_parses=False),
+        ),
+    )
+    expect_failure(
+        lambda: validate(reader_resolution, reader_resolution_facts),
+        "reader semantic stream is invalid",
+    )
+
     resolution_diff_failures = (
-        (
-            "surface_matching_added_or_modified_regular_blob",
-            False,
-            "no added or modified surface-owned TeX blob",
-        ),
-        (
-            "tex_comment_stripped_token_stream_changed",
-            False,
-            "no TeX-comment-stripped token change",
-        ),
-        (
-            "semantic_witness_is_same_surface_regular_blob",
-            False,
-            "not one surface-owned TeX blob",
-        ),
         ("validated_base_oid", "bad", "merge base is missing or malformed"),
-        ("validated_surface", "tnlog", "used another compatibility surface"),
-        ("validated_fix_path_patterns", ("TNLean/**/*.lean",), "another surface path set"),
-        ("semantic_witness_path", "TNLean/Fix.lean", "not surface-owned TeX"),
+        ("validated_regression_tests", (), "used another regression-test set"),
+        ("regression_fixes", (), "lacks one semantic witness per regression test"),
+        (
+            "validated_identity_trees",
+            (SHA, SHA, SHA, SHA, SHA),
+            "identity check used another five-tree boundary",
+        ),
+        (
+            "fixture_blobs_modes_and_trees_identical",
+            False,
+            "changes a regression fixture identity",
+        ),
+        (
+            "freeze_manifest_blob_identical",
+            False,
+            "changes the active-freeze manifest identity",
+        ),
         ("validated_head_oid", oid(99_980), "not validated at its exact head"),
         (
             "integration_strict_descendant_of_friction",
@@ -2174,17 +2346,60 @@ def main() -> int:
             error_fragment,
         )
 
-    # Neither an unrelated Lean-only change nor a test-only change supplies
-    # the required surface-owned TeX implementation witness.
-    for rejected_path in ("TNLean/Fix.lean", "tests/tenkz/test_fix.py"):
+    regression_fix_failures = (
+        ("validated_surface", "tnlog", "used another compatibility surface"),
+        (
+            "declared_program_paths",
+            ("tex/tenkz/other.sty",),
+            "used another declared program set",
+        ),
+        ("program_blob_modified", False, "program blob was not modified"),
+        ("semantic_stream_changed", False, "changed only nonsemantic text"),
+        ("semantic_stream_kind", "raw-bytes", "TeX semantic stream is invalid"),
+        ("python_reader_parses", True, "TeX semantic stream is invalid"),
+        (
+            "baseline_failure_fingerprint",
+            "3" * 64,
+            "used another baseline fingerprint",
+        ),
+    )
+    for field_name, bad_value, error_fragment in regression_fix_failures:
         blocks, facts, fix_ref = resolution_case(True)
+        fix_diff = facts.resolution_diffs[fix_ref]
+        assert fix_diff.regression_fixes is not None
         facts.resolution_diffs[fix_ref] = replace(
-            facts.resolution_diffs[fix_ref],
-            semantic_witness_path=rejected_path,
+            fix_diff,
+            regression_fixes=(
+                replace(fix_diff.regression_fixes[0], **{field_name: bad_value}),
+            ),
         )
         expect_failure(
             lambda blocks=blocks, facts=facts: validate(blocks, facts),
-            "semantic witness path is not surface-owned TeX",
+            error_fragment,
+        )
+
+    # Neither a Lean-only change, a harness-only change, nor a fixture change
+    # can stand in for the declared compatibility program.
+    for rejected_path in (
+        "TNLean/Fix.lean",
+        "tests/tenkz/release-harness/test_fix.py",
+        "tests/tenkz/rmp/fixtures/baseline.tex",
+    ):
+        blocks, facts, fix_ref = resolution_case(True)
+        fix_diff = facts.resolution_diffs[fix_ref]
+        assert fix_diff.regression_fixes is not None
+        facts.resolution_diffs[fix_ref] = replace(
+            fix_diff,
+            regression_fixes=(
+                replace(
+                    fix_diff.regression_fixes[0],
+                    changed_program_path=rejected_path,
+                ),
+            ),
+        )
+        expect_failure(
+            lambda blocks=blocks, facts=facts: validate(blocks, facts),
+            "changed no eligible declared program",
         )
 
     def fix_observation_keys(
@@ -2208,7 +2423,7 @@ def main() -> int:
     )
     expect_failure(
         lambda: validate(base_passes, base_passes_facts),
-        "fix-base test tex-api-regression regression test did not reproduce friction",
+        "fix-base test tex-api-regression assertion failure did not exit exactly 10",
     )
 
     head_fails, head_fails_facts, fix_ref = resolution_case(True)
@@ -2219,7 +2434,7 @@ def main() -> int:
     )
     expect_failure(
         lambda: validate(head_fails, head_fails_facts),
-        "fix-head test tex-api-regression regression test did not pass",
+        "fix-head test tex-api-regression passed result did not exit zero",
     )
 
     wrong_fix_tag, wrong_fix_tag_facts, fix_ref = resolution_case(True)
@@ -2252,11 +2467,11 @@ def main() -> int:
     payload_key = (fix_head, "tenkz-v0.9.0")
     invalid_inventory_facts.payloads[payload_key] = replace(
         invalid_inventory_facts.payloads[payload_key],
-        inventory_test_surfaces_valid=False,
+        inventory_test_surface_valid=False,
     )
     expect_failure(
         lambda: validate(invalid_inventory_surfaces, invalid_inventory_facts),
-        "fix head test inventory has invalid surface declarations",
+        "fix head test inventory has an invalid surface declaration",
     )
 
     postmerge_recheck, postmerge_recheck_facts, fix_ref = resolution_case(False)
@@ -2300,6 +2515,186 @@ def main() -> int:
     )
     assert validate(wrong_postmerge_ancestry, wrong_postmerge_facts) == (
         "reset-required:S1-0003"
+    )
+
+    old_attempt_facts = context()
+    add_record(
+        old_attempt_facts,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    add_record(
+        old_attempt_facts,
+        "S1-0003",
+        "#909",
+        909,
+        FREEZE_TIME + timedelta(seconds=2),
+    )
+    second_source_sha = "4" * 40
+    add_freeze_facts(
+        old_attempt_facts,
+        "S1-0004",
+        source_ref="#910",
+        source_number=910,
+        source_sha=second_source_sha,
+        record_ref="#911",
+        record_number=911,
+        tag="tenkz-v0.9.1",
+        tag_object="5" * 40,
+        merged_at=FREEZE_TIME + timedelta(seconds=4),
+    )
+    add_record(
+        old_attempt_facts,
+        "S1-0005",
+        "#912",
+        912,
+        FREEZE_TIME + timedelta(seconds=6),
+    )
+    old_attempt_resolution = [
+        freeze(),
+        friction("S1-0002", "#908", "restart-required"),
+        reset("S1-0003", "#909", "restart-required", "S1-0002"),
+        freeze(
+            "S1-0004",
+            record_pr="#911",
+            attempt=2,
+            source_pr="#910",
+            source_sha=second_source_sha,
+            tag_object="5" * 40,
+            tag="tenkz-v0.9.1",
+        ),
+        resolution(
+            "S1-0005",
+            "#912",
+            "S1-0002",
+            attempt=2,
+        ),
+    ]
+    expect_failure(
+        lambda: validate(old_attempt_resolution, old_attempt_facts),
+        "names no friction in this attempt",
+    )
+
+    def resolution_signoff_case(
+        *,
+        release_merge: datetime,
+        candidate_signoff: bool,
+    ) -> tuple[list[str], Context]:
+        facts = context()
+        record_specs = (
+            ("S1-0002", "#908", 908, 3),
+            ("S1-0003", "#909", 909, 5),
+            ("S1-0004", "#910", 910, 6),
+            ("S1-0005", "#911", 911, 7),
+            ("S1-0006", "#912", 912, 11),
+        )
+        for entry_id, ref, number, seconds in record_specs:
+            add_record(
+                facts,
+                entry_id,
+                ref,
+                number,
+                FREEZE_TIME + timedelta(seconds=seconds),
+            )
+        release_head = facts.prs[RELEASE_PREP].head_oid
+        assert isinstance(release_head, str)
+        facts.prs[RELEASE_PREP] = replace(
+            facts.prs[RELEASE_PREP],
+            merged_at=release_merge,
+            reviews=(
+                review(
+                    "release-prep-reviewer",
+                    release_merge - timedelta(microseconds=1),
+                    release_head,
+                ),
+            ),
+        )
+        signoff_head = facts.prs["#912"].head_oid
+        assert isinstance(signoff_head, str)
+        if candidate_signoff:
+            facts.prs["#912"] = candidate_pr(
+                912,
+                author="release-author",
+                reviews=(
+                    review(
+                        "release-reviewer",
+                        FREEZE_TIME + timedelta(seconds=10),
+                        signoff_head,
+                    ),
+                ),
+            )
+        else:
+            facts.prs["#912"] = replace(
+                facts.prs["#912"],
+                author_login="release-author",
+                reviews=(
+                    review(
+                        "release-reviewer",
+                        FREEZE_TIME + timedelta(seconds=10),
+                        signoff_head,
+                    ),
+                ),
+            )
+        work_integrations = (
+            facts.prs[FORMAL_WORK].merge_commit_oid,
+            facts.prs[RMP_WORK].merge_commit_oid,
+        )
+        facts.records["S1-0006"] = replace(
+            facts.records["S1-0006"],
+            candidate_main_tip_is_release_integration=True,
+            integration_parent_is_release_integration=True,
+            validated_release_integration=facts.prs[RELEASE_PREP].merge_commit_oid,
+            validated_work_integrations=work_integrations,
+        )
+        facts.payloads[(signoff_head, policy.FINAL_TAG)] = payload_evidence(
+            signoff_head,
+            policy.FINAL_TAG,
+            FINAL_PAYLOAD_BLOBS,
+        )
+        signoff_integration = facts.prs["#912"].merge_commit_oid
+        if isinstance(signoff_integration, str):
+            facts.payloads[(signoff_integration, policy.FINAL_TAG)] = payload_evidence(
+                signoff_integration,
+                policy.FINAL_TAG,
+                FINAL_PAYLOAD_BLOBS,
+            )
+        blocks = [
+            freeze(),
+            friction("S1-0002", "#908", "fix-compatible"),
+            resolution("S1-0003", "#909", "S1-0002"),
+            work(
+                "S1-0004",
+                "#910",
+                FORMAL_WORK,
+                "formalization-or-blueprint",
+            ),
+            work("S1-0005", "#911", RMP_WORK, "rmp-benchmark"),
+            sign_off(
+                "S1-0006",
+                "#912",
+                ["S1-0004", "S1-0005"],
+            ),
+        ]
+        prepared_entries = parsed_entries(*blocks)
+        prepare_friction_observations(prepared_entries, facts)
+        prepare_resolution_facts(prepared_entries, facts)
+        return blocks, facts
+
+    resolution_signoff, resolution_signoff_facts = resolution_signoff_case(
+        release_merge=FREEZE_TIME + timedelta(seconds=8),
+        candidate_signoff=True,
+    )
+    resolution_signoff_status = validate(resolution_signoff, resolution_signoff_facts)
+    assert resolution_signoff_status == "sign-off-pending", resolution_signoff_status
+    prep_before_resolution, prep_before_resolution_facts = resolution_signoff_case(
+        release_merge=FREEZE_TIME + timedelta(seconds=3, microseconds=500_000),
+        candidate_signoff=True,
+    )
+    expect_failure(
+        lambda: validate(prep_before_resolution, prep_before_resolution_facts),
+        "release preparation merged before work or resolution evidence",
     )
 
     candidate = context()
@@ -2536,11 +2931,11 @@ def main() -> int:
     activation_subject_controls_coverage = context()
     activation_subject_controls_coverage.activation_diff = replace(
         activation_subject_controls_coverage.activation_diff,
-        subject_data_cannot_reduce_coverage=False,
+        subjects_cannot_supply_evidence_logic=False,
     )
     expect_failure(
         lambda: validate([freeze()], activation_subject_controls_coverage),
-        "subject data can reduce release-test coverage",
+        "activation subjects can supply evidence or coverage logic",
     )
     activation_unhermetic = context()
     activation_unhermetic.activation_diff = replace(
@@ -2585,7 +2980,7 @@ def main() -> int:
     bad_release_payload = context()
     bad_release_payload.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
         bad_release_payload.payloads[(oid(9200), policy.FINAL_TAG)],
-        inventory_contract_valid=False,
+        inventory_exact_schema_valid=False,
     )
     assert (
         validate(complete_log(), bad_release_payload)
@@ -2615,7 +3010,7 @@ def main() -> int:
     undeclared_subject_data = context()
     undeclared_subject_data.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
         undeclared_subject_data.payloads[(oid(9200), policy.FINAL_TAG)],
-        inventory_data_paths_within_mutable_roots=False,
+        inventory_subject_paths_within_subject_roots=False,
     )
     assert (
         validate(complete_log(), undeclared_subject_data)
@@ -2635,7 +3030,7 @@ def main() -> int:
     executable_from_subject = context()
     executable_from_subject.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
         executable_from_subject.payloads[(oid(9200), policy.FINAL_TAG)],
-        executable_dependencies_within_code_tree=False,
+        executable_dependencies_within_harness_tree=False,
     )
     assert (
         validate(complete_log(), executable_from_subject)
@@ -2645,7 +3040,7 @@ def main() -> int:
     subject_reduces_coverage = context()
     subject_reduces_coverage.payloads[(oid(9200), policy.FINAL_TAG)] = replace(
         subject_reduces_coverage.payloads[(oid(9200), policy.FINAL_TAG)],
-        subject_data_cannot_reduce_coverage=False,
+        subjects_cannot_supply_evidence_logic=False,
     )
     assert (
         validate(complete_log(), subject_reduces_coverage)
@@ -3078,9 +3473,9 @@ def main() -> int:
         )
     reset_log = [
         freeze(),
-        friction("S1-0002", "#908", "breaking-required"),
+        friction("S1-0002", "#908", "restart-required"),
         correction("S1-0003", "#909", "S1-0002"),
-        reset("S1-0004", "#910", "breaking-required", "S1-0002"),
+        reset("S1-0004", "#910", "restart-required", "S1-0002"),
     ]
     assert validate(reset_log, reset_facts) == "reset"
 
@@ -3202,7 +3597,7 @@ def main() -> int:
         corrected_drift,
     ) == "reset"
 
-    # An already-pending breaking-required reset has priority at the drift
+    # An already-pending restart-required reset has priority at the drift
     # boundary; the administrative drift reset follows immediately after it.
     ordered_resets = context()
     add_record(
@@ -3226,15 +3621,15 @@ def main() -> int:
         910,
         FREEZE_TIME + timedelta(seconds=5),
     )
-    breaking_then_drift = [
+    restart_then_drift = [
         freeze(),
-        friction("S1-0002", "#908", "breaking-required"),
-        reset("S1-0003", "#909", "breaking-required", "S1-0002"),
+        friction("S1-0002", "#908", "restart-required"),
+        reset("S1-0003", "#909", "restart-required", "S1-0002"),
         reset("S1-0004", "#910", "record-invalid", "S1-0001"),
     ]
     assert (
         validate(
-            breaking_then_drift[:3],
+            restart_then_drift[:3],
             ordered_resets,
             audit=audit_evidence(
                 "S1-0003",
@@ -3244,7 +3639,7 @@ def main() -> int:
         )
         == "reset-required:S1-0001"
     )
-    assert validate(breaking_then_drift, ordered_resets) == "reset"
+    assert validate(restart_then_drift, ordered_resets) == "reset"
 
     batched_drift = context()
     add_record(
@@ -3480,9 +3875,9 @@ def main() -> int:
             "reset",
             [
                 freeze(),
-                friction("S1-0002", "#908", "breaking-required"),
-                reset("S1-0003", "#909", "breaking-required", "S1-0002"),
-                reset("S1-0004", "#910", "breaking-required", "S1-0002"),
+                friction("S1-0002", "#908", "restart-required"),
+                reset("S1-0003", "#909", "restart-required", "S1-0002"),
+                reset("S1-0004", "#910", "restart-required", "S1-0002"),
                 reset("S1-0005", "#911", "record-invalid", "S1-0003"),
             ],
             "S1-0003",
@@ -3633,11 +4028,11 @@ def main() -> int:
     stale_patch.prs[FREEZE_RECORD] = candidate_pr(902, author="record-author")
     stale_patch.tags["tenkz-v0.9.0"] = replace(
         stale_patch.tags["tenkz-v0.9.0"],
-        patch_exceeds_other_namespace_tags=False,
+        candidate_patch_exceeds_current_namespace=False,
     )
     expect_failure(
         lambda: validate([freeze()], stale_patch),
-        "PATCH does not exceed abandoned tags",
+        "candidate PATCH does not exceed the current namespace",
     )
 
     mixed_record = context()
@@ -3748,8 +4143,8 @@ def main() -> int:
     )
     historical_log = [
         freeze(),
-        friction("S1-0002", "#908", "breaking-required"),
-        reset("S1-0003", "#909", "breaking-required", "S1-0002"),
+        friction("S1-0002", "#908", "restart-required"),
+        reset("S1-0003", "#909", "restart-required", "S1-0002"),
         correction("S1-0004", "#910", "S1-0001", attempt=1),
         reset("S1-0005", "#911", "record-invalid", "S1-0004", attempt=1),
         freeze(

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -2196,6 +2196,67 @@ def main() -> int:
         "fields differ from schema",
     )
 
+    deferred_friction_facts = context()
+    formal_record_diff = deferred_friction_facts.records["S1-0002"]
+    rmp_record_diff = deferred_friction_facts.records["S1-0003"]
+    signoff_record_diff = deferred_friction_facts.records["S1-0004"]
+    add_record(
+        deferred_friction_facts,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(microseconds=500_000),
+    )
+    deferred_friction_facts.records["S1-0003"] = formal_record_diff
+    deferred_friction_facts.records["S1-0004"] = rmp_record_diff
+    deferred_friction_facts.records["S1-0005"] = signoff_record_diff
+    deferred_friction_log = [
+        freeze(),
+        friction("S1-0002", "#908", "defer-to-2.0"),
+        work(
+            "S1-0003",
+            FORMAL_RECORD,
+            FORMAL_WORK,
+            "formalization-or-blueprint",
+        ),
+        work("S1-0004", RMP_RECORD, RMP_WORK, "rmp-benchmark"),
+        sign_off(
+            "S1-0005",
+            SIGNOFF_RECORD,
+            ["S1-0003", "S1-0004"],
+        ),
+    ]
+    assert validate(deferred_friction_log, deferred_friction_facts) == (
+        "signed-off-awaiting-tag"
+    )
+
+    deferred_resolution_facts = context()
+    add_record(
+        deferred_resolution_facts,
+        "S1-0002",
+        "#908",
+        908,
+        FREEZE_TIME + timedelta(seconds=1),
+    )
+    add_record(
+        deferred_resolution_facts,
+        "S1-0003",
+        "#909",
+        909,
+        FREEZE_TIME + timedelta(seconds=2),
+    )
+    expect_failure(
+        lambda: validate(
+            [
+                freeze(),
+                friction("S1-0002", "#908", "defer-to-2.0"),
+                resolution("S1-0003", "#909", "S1-0002"),
+            ],
+            deferred_resolution_facts,
+        ),
+        "resolves incompatible triage",
+    )
+
     for bad_tests, error_fragment in (
         (("Bad_Test",), "invalid regression test"),
         ((REGRESSION_TEST, REGRESSION_TEST), "has duplicates"),


### PR DESCRIPTION
## Summary

- Validate the closed pending/armed compatibility-policy and soak-ledger schemas through a pure, callback-driven state machine.
- Enforce the fast 1.0 gate by exact event ordering, with no calendar-delay requirement: activation, independently approved freeze, one semantic work PR per required class, release preparation, and exact-head sign-off.
- Bind deterministic SSH-Ed25519 final-tag authentication to the exact sign-off integration, canonical integral UTC tagger epoch, policy hash, ledger-prefix hash/boundary, pinned schema, and pinned public key.
- Make publication retry-safe and structurally keyless when the final ref already exists; trust an API-visible exact successful publisher job rather than a durable job-output receipt.
- Exhaustively validate environment, repository, and organization secret-name scope. Release requires key retirement, rejects later reintroduction, and replays the successful historical publisher workflow while allowing unrelated current workflows to evolve afterward.
- Replace the provisional receipt state cleanly with `signed-off-awaiting-publisher-success` and `signed-off-awaiting-key-retirement`; no compatibility aliases or dual schemas remain.

## Stack

- Rebased directly on `main` after LionSR/TNLean#5391 merged as `4aa52ff0265c56d056bb1d0e73e7eb400b929cf9`.
- This PR contains the pure parser/state machine and perturbation tests. Repository/GitHub evidence resolution and dedicated CI wiring remain in LionSR/TNLean#5377.
- Enforcement remains `pending`; this PR creates no live entry, package version, release secret, or tag.

## Validation

- `python3 -m py_compile scripts/check_tenkz_policy.py scripts/test_check_tenkz_policy.py`
- `python3 scripts/test_check_tenkz_policy.py`
- `ruff check scripts/check_tenkz_policy.py scripts/test_check_tenkz_policy.py`
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py --base-ref origin/main gate`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check origin/main...HEAD`

Refs LionSR/tenkz#128

## Work-class assignment

`one_class_per_work_pr = true` governs evidence assignment, not exclusive diff contents. Under `docs/tenkz/SOAK-1.0.md` lines 625-631, one PR fills only its recorded class even when its immutable diff contains eligible changes from both classes. `docs/tenkz/DESIGN.md` lines 442-444 separately requires distinct PRs for the two class assignments. The validator therefore requires recorded-class membership plus distinct work PRs; a positive perturbation covers a mixed diff followed by the separate RMP work PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new release-governance validator with intricate state around tags, signing keys, and ledger resets; logic-only with injected dependencies and no armed enforcement in this PR, but mistakes would affect future 1.0 gate behavior.
> 
> **Overview**
> Introduces **`scripts/check_tenkz_policy.py`**, a self-contained validator for the tenkz 1.0 compatibility gate. Git and GitHub facts are **injected via callbacks**; the module owns closed TOML grammars (`tenkz-policy-v1`, `tenkz-soak-v1`, soak entries), immutable-evidence contracts, and the full attempt lifecycle.
> 
> **Parsing and policy shape:** Validates `DESIGN.md` / `SOAK-1.0.md` fenced blocks against fixed `EXPECTED_POLICY` / `EXPECTED_SOAK` (pending vs armed normalization), parses append-only soak entries after a marker, and exposes `check_append_only` for ledger byte stability.
> 
> **State machine (`validate_entries`):** Walks ordered soak entries (`freeze`, `work`, `friction`, `resolution`, `reset`, `correction`, `sign-off`) with attempt numbering, mandatory resets (`restart-required`, `record-invalid` + replay receipts), and an **audit channel** that queues drifted merged records without rewriting replay history. Enforces activation arming, two distinct work classes, fix-compatible friction/resolution with hermetic release-test witnesses, release prep, maintainer/reviewer rules, tag rulesets, pinned workflows, and publisher-secret scope/retirement.
> 
> **Release terminal:** Binds SSH-Ed25519 `tenkz-v1.0.0` to sign-off integration, canonical tagger epoch, policy/prefix hashes, and pinned support artifacts; distinguishes outcomes such as `attempt-*-active`, `reset-required:*`, `signed-off-awaiting-tag`, `signed-off-awaiting-publisher-success`, `signed-off-awaiting-key-retirement`, and `released`. A present final tag after publisher success without a ref is treated as a hard incident; post-tag drift blocks ledger resets.
> 
> Enforcement remains **pending** in policy until armed elsewhere (#5377); this PR adds logic only, not live CI wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440b2284735235d94226d09fefbc640e599c3486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->