### PR TITLE
ci(tenkz): enforce append-only soak history

### DIFF
--- a/.github/workflows/tenkz-policy.yml
+++ b/.github/workflows/tenkz-policy.yml
@@ -1,0 +1,98 @@
+name: Tenkz Compatibility Policy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  policy:
+    name: Check append-only tenkz evidence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.event.after || github.sha }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Test and check exact Git evidence
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.event.after }}
+          ZERO_SHA: '0000000000000000000000000000000000000000'
+        run: |
+          set -euo pipefail
+
+          ensure_commit() {
+            local oid="$1"
+            if ! git cat-file -e "${oid}^{commit}" 2>/dev/null; then
+              git fetch --no-tags origin "$oid"
+            fi
+            test "$(git rev-parse "${oid}^{commit}")" = "$oid"
+          }
+
+          python3 scripts/test_check_tenkz_policy.py
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            ensure_commit "$PR_BASE_SHA"
+            ensure_commit "$PR_HEAD_SHA"
+            test "$(git rev-parse HEAD)" = "$PR_HEAD_SHA"
+            python3 scripts/check_tenkz_policy.py \
+              --target-ref "$PR_HEAD_SHA" \
+              --pull-request-base-ref "$PR_BASE_SHA" \
+              --main-ref "$PR_BASE_SHA"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            ensure_commit "$PUSH_AFTER"
+            test "$(git rev-parse HEAD)" = "$PUSH_AFTER"
+            if [ "$PUSH_BEFORE" = "$ZERO_SHA" ]; then
+              python3 scripts/check_tenkz_policy.py \
+                --target-ref "$PUSH_AFTER" \
+                --history-base-ref "$ZERO_SHA" \
+                --history-head-ref "$PUSH_AFTER" \
+                --main-ref "$PUSH_AFTER"
+            else
+              ensure_commit "$PUSH_BEFORE"
+              python3 scripts/check_tenkz_policy.py \
+                --target-ref "$PUSH_AFTER" \
+                --history-base-ref "$PUSH_BEFORE" \
+                --history-head-ref "$PUSH_AFTER" \
+                --main-ref "$PUSH_AFTER"
+            fi
+          else
+            TARGET="$(git rev-parse HEAD)"
+            read -r -a LINEAGE <<< "$(git rev-list --parents -n 1 "$TARGET")"
+            if [ "${#LINEAGE[@]}" -eq 1 ]; then
+              RANGE_BASE="$ZERO_SHA"
+              python3 scripts/check_tenkz_policy.py \
+                --target-ref "$TARGET" \
+                --history-base-ref "$RANGE_BASE" \
+                --history-head-ref "$TARGET" \
+                --main-ref "$TARGET"
+            else
+              RANGE_BASE="${LINEAGE[1]}"
+              python3 scripts/check_tenkz_policy.py \
+                --target-ref "$TARGET" \
+                --history-base-ref "$RANGE_BASE" \
+                --history-head-ref "$TARGET" \
+                --main-ref "$TARGET"
+            fi
+          fi

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -8,13 +8,22 @@ stacked integration layer resolves the external facts.
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import re
+import subprocess
+import sys
 import tomllib
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Callable, Collection
 
 
+ROOT = Path(__file__).resolve().parents[1]
+DESIGN_PATH = "docs/tenkz/DESIGN.md"
+SOAK_PATH = "docs/tenkz/SOAK-1.0.md"
+ZERO_SHA = "0" * 40
 SOAK_MARKER = "<!-- tenkz-soak-entries: append below only while enforcement=armed -->"
 FREEZE_TAG_RE = re.compile(r"tenkz-v0\.9\.(?:0|[1-9][0-9]*)")
 FINAL_TAG = "tenkz-v1.0.0"
@@ -4749,3 +4758,489 @@ def check_append_only(previous: str | None, current: str) -> None:
         current.startswith(previous),
         "SOAK-1.0.md changed existing bytes instead of appending",
     )
+
+
+def git_output(root: Path, arguments: list[str]) -> str:
+    """Run a read-only Git query or fail the repository check closed."""
+
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as error:
+        raise PolicyError(f"could not execute git: {error}") from error
+    if result.returncode != 0:
+        raise PolicyError(result.stderr.strip() or f"git {' '.join(arguments)} failed")
+    return result.stdout.strip()
+
+
+def git_bytes(root: Path, arguments: list[str]) -> bytes:
+    """Run a read-only Git query whose exact stdout bytes are evidence."""
+
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=root,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as error:
+        raise PolicyError(f"could not execute git: {error}") from error
+    if result.returncode != 0:
+        message = result.stderr.decode("utf-8", errors="replace").strip()
+        raise PolicyError(message or f"git {' '.join(arguments)} failed")
+    return result.stdout
+
+
+def resolve_commit_oid(root: Path, ref: str, subject: str) -> str:
+    """Resolve one ref to an immutable commit OID."""
+
+    require(isinstance(ref, str) and bool(ref), f"{subject} is missing")
+    oid = git_output(
+        root,
+        ["rev-parse", "--verify", "--end-of-options", f"{ref}^{{commit}}"],
+    )
+    require(SHA_RE.fullmatch(oid) is not None, f"{subject} did not resolve to a SHA-1 OID")
+    require(
+        git_output(root, ["cat-file", "-t", oid]) == "commit",
+        f"{subject} did not resolve to a commit",
+    )
+    return oid
+
+
+def require_exact_commit_oid(root: Path, oid: str | None, subject: str) -> str:
+    """Require an immutable commit OID rather than accepting a mutable ref."""
+
+    require(
+        isinstance(oid, str) and SHA_RE.fullmatch(oid) is not None,
+        f"{subject} is not an exact commit OID",
+    )
+    require(
+        git_output(root, ["cat-file", "-t", oid]) == "commit",
+        f"{subject} is not a commit",
+    )
+    return oid
+
+
+def git_is_ancestor(root: Path, ancestor: str, descendant: str) -> bool:
+    """Check ancestry while distinguishing false from an unavailable query."""
+
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as error:
+        raise PolicyError(f"could not execute git: {error}") from error
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise PolicyError(result.stderr.strip() or "git ancestry check failed")
+
+
+def verified_git_object_bytes(
+    root: Path,
+    object_id: str,
+    object_type: str,
+) -> bytes:
+    """Read exact object bytes and bind them back to their SHA-1 object ID."""
+
+    require(SHA_RE.fullmatch(object_id) is not None, "Git object ID is invalid")
+    require(
+        git_output(root, ["rev-parse", "--show-object-format"]) == "sha1",
+        "repository object format is not SHA-1",
+    )
+    require(
+        git_output(root, ["cat-file", "-t", object_id]) == object_type,
+        f"Git object {object_id} is not a {object_type}",
+    )
+    raw = git_bytes(root, ["cat-file", object_type, object_id])
+    size = git_output(root, ["cat-file", "-s", object_id])
+    require(size.isdigit() and int(size) == len(raw), "Git object size is inconsistent")
+    framed = f"{object_type} {len(raw)}\0".encode() + raw
+    recomputed = hashlib.sha1(framed, usedforsecurity=False).hexdigest()
+    require(recomputed == object_id, "Git object bytes do not match their object ID")
+    return raw
+
+
+def freeze_tag_git_evidence(root: Path, tag: str, main_ref: str) -> TagEvidence:
+    """Resolve Git-only freeze-tag facts without claiming signature verification.
+
+    The final-tag signature, pinned public key, object schema, and historical
+    GitHub check are separate evidence boundaries.  This resolver deliberately
+    leaves all of those fields unset.
+    """
+
+    require(FREEZE_TAG_RE.fullmatch(tag) is not None, f"freeze tag {tag} is invalid")
+    output = git_output(
+        root,
+        [
+            "for-each-ref",
+            "--format=%(objectname)%09%(objecttype)%09END",
+            f"refs/tags/{tag}",
+        ],
+    )
+    lines = output.splitlines()
+    require(len(lines) == 1, f"freeze tag {tag} does not exist uniquely")
+    fields = lines[0].split("\t")
+    require(len(fields) == 3 and fields[-1] == "END", f"could not inspect {tag}")
+    object_id, object_type, _sentinel = fields
+    require(SHA_RE.fullmatch(object_id) is not None, f"freeze tag {tag} has an invalid OID")
+    require(object_type in {"tag", "commit"}, f"freeze tag {tag} has an invalid object kind")
+    if object_type == "tag":
+        verified_git_object_bytes(root, object_id, "tag")
+    else:
+        require_exact_commit_oid(root, object_id, f"freeze tag {tag} object")
+
+    commit = resolve_commit_oid(root, f"refs/tags/{tag}", f"freeze tag {tag}")
+    main_oid = resolve_commit_oid(root, main_ref, "main ref")
+    require(
+        git_is_ancestor(root, commit, main_oid),
+        f"freeze tag {tag} commit is not reachable from main",
+    )
+    namespace = tuple(
+        sorted(
+            (
+                name
+                for name in git_output(
+                    root,
+                    ["for-each-ref", "--format=%(refname:strip=2)", "refs/tags"],
+                ).splitlines()
+                if FREEZE_TAG_RE.fullmatch(name) is not None
+            ),
+            key=lambda name: int(name.rsplit(".", 1)[1]),
+        )
+    )
+    return TagEvidence(
+        object_id=object_id,
+        object_type=object_type,
+        commit=commit,
+        candidate_namespace_complete=True,
+        candidate_matching_tag_names=namespace,
+        historical_current_namespace_complete=True,
+        historical_current_matching_tag_names=namespace,
+    )
+
+
+def bind_merged_pull_request_git_evidence(
+    root: Path,
+    evidence: PullRequestEvidence,
+    *,
+    anchor_oid: str,
+    main_ref: str,
+) -> PullRequestEvidence:
+    """Bind GitHub PR identity to exact local integration-tree facts."""
+
+    require(evidence.merged is True, "Git integration evidence requires a merged PR")
+    head_oid = require_exact_commit_oid(root, evidence.head_oid, "PR head")
+    integration_oid = require_exact_commit_oid(
+        root,
+        evidence.merge_commit_oid,
+        "PR integration",
+    )
+    anchor = require_exact_commit_oid(root, anchor_oid, "PR ancestry anchor")
+    main_oid = resolve_commit_oid(root, main_ref, "main ref")
+    integration_tree = git_output(root, ["rev-parse", f"{integration_oid}^{{tree}}"])
+    head_tree = git_output(root, ["rev-parse", f"{head_oid}^{{tree}}"])
+    return replace(
+        evidence,
+        integration_reachable_from_main=git_is_ancestor(
+            root,
+            integration_oid,
+            main_oid,
+        ),
+        integration_tree_matches_head=integration_tree == head_tree,
+        integration_strict_descendant_of_anchor=(
+            integration_oid != anchor
+            and git_is_ancestor(root, anchor, integration_oid)
+        ),
+    )
+
+
+def file_bytes_at_ref(root: Path, ref: str, path: str) -> bytes | None:
+    """Read one regular non-executable blob at a commit, preserving exact bytes."""
+
+    commit = resolve_commit_oid(root, ref, f"ref {ref}")
+    output = git_output(
+        root,
+        [
+            "ls-tree",
+            "--format=%(objectmode)%x09%(objecttype)%x09%(objectname)%x09%(path)%x09END",
+            commit,
+            "--",
+            path,
+        ],
+    )
+    if not output:
+        return None
+    lines = output.splitlines()
+    require(len(lines) == 1, f"could not locate {path} uniquely at {ref}")
+    fields = lines[0].split("\t")
+    require(
+        len(fields) == 5 and fields[-1] == "END" and fields[3] == path,
+        f"could not inspect {path} at {ref}",
+    )
+    mode, object_type, object_id, _path, _sentinel = fields
+    require(
+        mode == "100644" and object_type == "blob",
+        f"{path} is not a regular non-executable blob at {ref}",
+    )
+    return verified_git_object_bytes(root, object_id, "blob")
+
+
+def required_text_at_ref(root: Path, ref: str, path: str) -> str:
+    raw = file_bytes_at_ref(root, ref, path)
+    require(raw is not None, f"{path} is absent at {ref}")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PolicyError(f"{path} is not UTF-8 at {ref}") from error
+
+
+def soak_bytes_at_ref(root: Path, ref: str) -> bytes | None:
+    return file_bytes_at_ref(root, ref, SOAK_PATH)
+
+
+def soak_enforcement(raw: bytes, subject: str) -> str:
+    """Parse one exact ledger revision and return its enforcement state."""
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PolicyError(f"{SOAK_PATH} is not UTF-8 at {subject}") from error
+    try:
+        soak, _entries = parse_soak_text(text)
+    except PolicyError as error:
+        raise PolicyError(f"{SOAK_PATH} is invalid at {subject}: {error}") from error
+    enforcement = soak["soak"]["enforcement"]
+    assert enforcement in {"pending", "armed"}
+    return enforcement
+
+
+def check_soak_transition(
+    previous: bytes | None,
+    current: bytes | None,
+    *,
+    previous_subject: str,
+    current_subject: str,
+) -> None:
+    """Validate one ledger edge using the predecessor's enforcement state."""
+
+    if previous is None:
+        if current is not None:
+            soak_enforcement(current, current_subject)
+        return
+
+    previous_enforcement = soak_enforcement(previous, previous_subject)
+    require(current is not None, f"{SOAK_PATH} was removed at {current_subject}")
+    current_enforcement = soak_enforcement(current, current_subject)
+    if previous_enforcement == "pending":
+        return
+    require(
+        current_enforcement == "armed",
+        f"{SOAK_PATH} returned to pending after being armed at {previous_subject}",
+    )
+    require(
+        current.startswith(previous),
+        "SOAK-1.0.md changed existing armed bytes instead of appending",
+    )
+
+
+def first_parent_range_base(root: Path, base_oid: str, head_oid: str) -> str:
+    """Find the PR fork boundary on the head's first-parent lineage."""
+
+    base = require_exact_commit_oid(root, base_oid, "pull-request base")
+    head = require_exact_commit_oid(root, head_oid, "pull-request head")
+    exclusive = git_output(
+        root,
+        ["rev-list", "--first-parent", "--reverse", head, f"^{base}"],
+    ).splitlines()
+    if not exclusive:
+        require(
+            git_is_ancestor(root, head, base),
+            "pull-request head has no shared first-parent boundary with its base",
+        )
+        return head
+
+    first = exclusive[0]
+    parents = git_output(root, ["show", "-s", "--format=%P", first]).split()
+    require(
+        bool(parents) and git_is_ancestor(root, parents[0], base),
+        "pull-request head has no shared first-parent boundary with its base",
+    )
+    return parents[0]
+
+
+def check_append_only_history(root: Path, base_ref: str, head_ref: str) -> None:
+    """Check every first-parent ledger transition in one exact Git range."""
+
+    head = resolve_commit_oid(root, head_ref, "history head")
+    lineage = git_output(
+        root,
+        ["rev-list", "--first-parent", "--reverse", head],
+    ).splitlines()
+    require(bool(lineage) and lineage[-1] == head, f"could not inspect history to {head}")
+
+    if base_ref == ZERO_SHA:
+        commits = lineage
+        previous_commit: str | None = None
+        previous_bytes: bytes | None = None
+    else:
+        base = resolve_commit_oid(root, base_ref, "history base")
+        require(base in lineage, f"{base} is not on the first-parent path to {head}")
+        base_index = lineage.index(base)
+        commits = lineage[base_index + 1 :]
+        previous_commit = base
+        previous_bytes = soak_bytes_at_ref(root, base)
+
+    for commit in commits:
+        parents = git_output(root, ["show", "-s", "--format=%P", commit]).split()
+        if previous_commit is None:
+            require(not parents, f"push history does not begin at root commit {commit}")
+        else:
+            require(
+                bool(parents) and parents[0] == previous_commit,
+                f"{previous_commit} is not the first parent of {commit}",
+            )
+        current_bytes = soak_bytes_at_ref(root, commit)
+        check_soak_transition(
+            previous_bytes,
+            current_bytes,
+            previous_subject=previous_commit or "history start",
+            current_subject=commit,
+        )
+        previous_commit = commit
+        previous_bytes = current_bytes
+
+    require(previous_commit == head, f"{base_ref} is not on the first-parent path to {head}")
+
+
+def validate_repository(
+    root: Path = ROOT,
+    *,
+    target_ref: str = "HEAD",
+    base_ref: str | None = None,
+    pull_request_base_ref: str | None = None,
+    history_base_ref: str | None = None,
+    history_head_ref: str | None = None,
+    main_ref: str = "origin/main",
+) -> tuple[int, str]:
+    """Validate the exact target and fail closed if armed evidence lacks resolvers."""
+
+    range_modes = sum(
+        (
+            base_ref is not None,
+            pull_request_base_ref is not None,
+            history_base_ref is not None or history_head_ref is not None,
+        )
+    )
+    require(range_modes <= 1, "repository range modes are mutually exclusive")
+    require(
+        history_head_ref is None or history_base_ref is not None,
+        "history head requires a history base",
+    )
+    target_oid = resolve_commit_oid(root, target_ref, "validation target")
+    resolve_commit_oid(root, main_ref, "main ref")
+    design_text = required_text_at_ref(root, target_oid, DESIGN_PATH)
+    soak_raw = soak_bytes_at_ref(root, target_oid)
+    require(soak_raw is not None, f"{SOAK_PATH} is absent at {target_ref}")
+    try:
+        soak_text = soak_raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PolicyError(f"{SOAK_PATH} is not UTF-8 at {target_ref}") from error
+
+    policy_mapping = validate_policy_text(design_text)
+    soak_mapping, entries = parse_soak_text(soak_text)
+    if base_ref is not None:
+        base_oid = resolve_commit_oid(root, base_ref, "comparison base")
+        check_soak_transition(
+            soak_bytes_at_ref(root, base_oid),
+            soak_raw,
+            previous_subject=base_oid,
+            current_subject=target_oid,
+        )
+    if pull_request_base_ref is not None:
+        pr_base = require_exact_commit_oid(
+            root,
+            pull_request_base_ref,
+            "pull-request base",
+        )
+        check_soak_transition(
+            soak_bytes_at_ref(root, pr_base),
+            soak_raw,
+            previous_subject=pr_base,
+            current_subject=target_oid,
+        )
+        range_base = first_parent_range_base(root, pr_base, target_oid)
+        check_append_only_history(root, range_base, target_oid)
+    if history_base_ref is not None:
+        history_head = history_head_ref or target_oid
+        require(
+            resolve_commit_oid(root, history_head, "history head") == target_oid,
+            "history head differs from the exact validation target",
+        )
+        check_append_only_history(root, history_base_ref, history_head)
+
+    state = validate_entries(entries, policy=policy_mapping, soak=soak_mapping)
+    return len(entries), state
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate exact tenkz policy and append-only Git evidence",
+    )
+    parser.add_argument("--root", type=Path, default=ROOT, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--target-ref",
+        default="HEAD",
+        help="exact commit whose policy and ledger are validated",
+    )
+    parser.add_argument(
+        "--base-ref",
+        help="Git ref whose ledger transition to the target is validated",
+    )
+    parser.add_argument(
+        "--pull-request-base-ref",
+        help="exact PR base OID used to derive and validate its first-parent range",
+    )
+    parser.add_argument(
+        "--history-base-ref",
+        help="pre-change Git ref whose first-parent range must be append-only",
+    )
+    parser.add_argument(
+        "--history-head-ref",
+        help="post-change Git ref; defaults to --target-ref",
+    )
+    parser.add_argument(
+        "--main-ref",
+        default="origin/main",
+        help="current main ref used by repository evidence",
+    )
+    args = parser.parse_args()
+    try:
+        count, state = validate_repository(
+            args.root.resolve(),
+            target_ref=args.target_ref,
+            base_ref=args.base_ref,
+            pull_request_base_ref=args.pull_request_base_ref,
+            history_base_ref=args.history_base_ref,
+            history_head_ref=args.history_head_ref,
+            main_ref=args.main_ref,
+        )
+    except (OSError, PolicyError, UnicodeError, ValueError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+    print(f"PASS: tenkz compatibility policy valid; evidence {state} ({count} entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1639,11 +1642,408 @@ def add_freeze_facts(
     )
 
 
+def git(root: Path, *arguments: str, env: dict[str, str] | None = None) -> str:
+    process_env = os.environ.copy()
+    if env is not None:
+        process_env.update(env)
+    return subprocess.check_output(
+        ["git", *arguments],
+        cwd=root,
+        env=process_env,
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+def initialize_repository(root: Path) -> None:
+    git(root, "init", "-q", "--initial-branch=main")
+    git(root, "config", "user.name", "Policy Test")
+    git(root, "config", "user.email", "policy@example.test")
+    git(root, "config", "commit.gpgsign", "false")
+    git(root, "config", "tag.gpgsign", "false")
+
+
+def git_pr_evidence(head_oid: str, integration_oid: str) -> policy.PullRequestEvidence:
+    return policy.PullRequestEvidence(
+        in_repository=True,
+        base_ref_name="main",
+        author_login="author",
+        head_oid=head_oid,
+        merged=True,
+        merge_commit_oid=integration_oid,
+    )
+
+
+def test_git_evidence_resolvers() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        initialize_repository(root)
+        (root / "surface.txt").write_text("freeze\n", encoding="utf-8")
+        git(root, "add", "surface.txt")
+        freeze_env = {
+            "GIT_AUTHOR_DATE": "2026-09-01T00:00:00Z",
+            "GIT_COMMITTER_DATE": "2026-09-01T00:00:00Z",
+        }
+        git(root, "commit", "-q", "-m", "freeze", env=freeze_env)
+        freeze_sha = git(root, "rev-parse", "HEAD")
+        tag_env = {"GIT_COMMITTER_DATE": "2026-09-01T01:00:00Z"}
+        git(root, "tag", "-a", "tenkz-v0.9.0", "-m", "freeze", env=tag_env)
+
+        annotated = policy.freeze_tag_git_evidence(root, "tenkz-v0.9.0", "main")
+        assert annotated.object_type == "tag"
+        assert annotated.commit == freeze_sha
+        assert annotated.candidate_matching_tag_names == ("tenkz-v0.9.0",)
+        assert annotated.historical_current_matching_tag_names == ("tenkz-v0.9.0",)
+        assert annotated.historical_candidate_check_exact_and_successful is None
+        assert annotated.final_raw_signature_valid is None
+        assert annotated.final_public_key_blob_oid is None
+        assert annotated.final_schema_blob_oid is None
+
+        recorded_object = annotated.object_id
+        assert isinstance(recorded_object, str)
+        raw_tag = policy.verified_git_object_bytes(root, recorded_object, "tag")
+        assert raw_tag.startswith(b"object " + freeze_sha.encode() + b"\n")
+
+        git(root, "tag", "-d", "tenkz-v0.9.0")
+        git(root, "tag", "tenkz-v0.9.0")
+        lightweight = policy.freeze_tag_git_evidence(root, "tenkz-v0.9.0", "main")
+        assert lightweight.object_type == "commit"
+        assert lightweight.object_id == freeze_sha
+
+        git(root, "tag", "-d", "tenkz-v0.9.0")
+        replacement_env = {"GIT_COMMITTER_DATE": "2026-09-01T02:00:00Z"}
+        git(
+            root,
+            "tag",
+            "-a",
+            "tenkz-v0.9.0",
+            "-m",
+            "replacement",
+            env=replacement_env,
+        )
+        replacement = policy.freeze_tag_git_evidence(root, "tenkz-v0.9.0", "main")
+        assert replacement.object_id != recorded_object
+
+        git(root, "switch", "-q", "-c", "work")
+        (root / "surface.txt").write_text("freeze\nwork\n", encoding="utf-8")
+        git(root, "add", "surface.txt")
+        git(root, "commit", "-q", "-m", "work")
+        work_head = git(root, "rev-parse", "HEAD")
+        git(root, "switch", "-q", "main")
+        git(root, "merge", "-q", "--no-ff", "work", "-m", "integrate work")
+        integration = git(root, "rev-parse", "HEAD")
+        bound = policy.bind_merged_pull_request_git_evidence(
+            root,
+            git_pr_evidence(work_head, integration),
+            anchor_oid=freeze_sha,
+            main_ref="main",
+        )
+        assert bound.integration_reachable_from_main
+        assert bound.integration_tree_matches_head
+        assert bound.integration_strict_descendant_of_anchor
+
+        mutable_integration = replace(
+            git_pr_evidence(work_head, integration),
+            merge_commit_oid="main",
+        )
+        expect_failure(
+            lambda: policy.bind_merged_pull_request_git_evidence(
+                root,
+                mutable_integration,
+                anchor_oid=freeze_sha,
+                main_ref="main",
+            ),
+            "is not an exact commit OID",
+        )
+
+        git(root, "switch", "-q", "-c", "unmerged", integration)
+        (root / "unmerged.txt").write_text("not on main\n", encoding="utf-8")
+        git(root, "add", "unmerged.txt")
+        git(root, "commit", "-q", "-m", "unmerged work")
+        unmerged = git(root, "rev-parse", "HEAD")
+        git(root, "tag", "-a", "tenkz-v0.9.1", "-m", "unreachable")
+        git(root, "switch", "-q", "main")
+        unmerged_bound = policy.bind_merged_pull_request_git_evidence(
+            root,
+            git_pr_evidence(unmerged, unmerged),
+            anchor_oid=integration,
+            main_ref="main",
+        )
+        assert not unmerged_bound.integration_reachable_from_main
+        assert unmerged_bound.integration_tree_matches_head
+        assert unmerged_bound.integration_strict_descendant_of_anchor
+        expect_failure(
+            lambda: policy.freeze_tag_git_evidence(root, "tenkz-v0.9.1", "main"),
+            "is not reachable from main",
+        )
+
+
+def run_policy_cli(
+    root: Path,
+    *arguments: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    process_env = os.environ.copy()
+    if env is not None:
+        process_env.update(env)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/check_tenkz_policy.py"),
+            "--root",
+            str(root),
+            *arguments,
+        ],
+        cwd=root,
+        env=process_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_append_only_git_ranges_and_cli() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        initialize_repository(root)
+        design = root / policy.DESIGN_PATH
+        soak = root / policy.SOAK_PATH
+
+        def commit_soak(text: str, message: str) -> str:
+            soak.write_text(text, encoding="utf-8")
+            git(root, "add", policy.SOAK_PATH)
+            git(root, "commit", "-q", "-m", message)
+            return git(root, "rev-parse", "HEAD")
+
+        soak.parent.mkdir(parents=True)
+        design.write_text(DESIGN_TEXT, encoding="utf-8")
+        soak.write_text(SOAK_TEXT, encoding="utf-8")
+        git(root, "add", policy.DESIGN_PATH, policy.SOAK_PATH)
+        git(root, "commit", "-q", "-m", "land append-only policy")
+        before = git(root, "rev-parse", "HEAD")
+        assert policy.validate_repository(
+            root,
+            target_ref=before,
+            main_ref=before,
+        ) == (0, "not-started")
+        policy.check_append_only_history(root, policy.ZERO_SHA, before)
+
+        pending_text = SOAK_TEXT.replace("release-evidence log", "corrected evidence log")
+        assert pending_text != SOAK_TEXT
+        pending_rewrite = commit_soak(pending_text, "correct pending ledger prose")
+        policy.check_append_only_history(root, before, pending_rewrite)
+        policy.check_append_only_history(root, policy.ZERO_SHA, pending_rewrite)
+        assert policy.validate_repository(
+            root,
+            target_ref=pending_rewrite,
+            base_ref=before,
+            main_ref=pending_rewrite,
+        ) == (0, "not-started")
+        assert policy.validate_repository(
+            root,
+            target_ref=pending_rewrite,
+            history_base_ref=before,
+            history_head_ref=pending_rewrite,
+            main_ref=pending_rewrite,
+        ) == (0, "not-started")
+        expect_failure(
+            lambda: policy.validate_repository(
+                root,
+                target_ref=pending_rewrite,
+                base_ref=before,
+                history_base_ref=before,
+                main_ref=pending_rewrite,
+            ),
+            "range modes are mutually exclusive",
+        )
+
+        successful_cli = run_policy_cli(
+            root,
+            "--target-ref",
+            pending_rewrite,
+            "--history-base-ref",
+            before,
+            "--history-head-ref",
+            pending_rewrite,
+            "--main-ref",
+            pending_rewrite,
+        )
+        assert successful_cli.returncode == 0, successful_cli.stderr
+        assert successful_cli.stdout.startswith("PASS:")
+
+        git(root, "switch", "-q", "-c", "malformed", pending_rewrite)
+        malformed_text = pending_text.replace(
+            'enforcement = "pending"',
+            'enforcement = "invalid"',
+            1,
+        )
+        malformed = commit_soak(malformed_text, "malform pending ledger state")
+        malformed_restored = commit_soak(pending_text, "restore pending ledger state")
+        assert git(root, "rev-parse", f"{malformed_restored}^{{tree}}") == git(
+            root,
+            "rev-parse",
+            f"{pending_rewrite}^{{tree}}",
+        )
+        expect_failure(
+            lambda: policy.check_append_only_history(
+                root,
+                pending_rewrite,
+                malformed_restored,
+            ),
+            f"is invalid at {malformed}",
+        )
+
+        git(root, "switch", "-q", "main")
+        git(root, "switch", "-q", "-c", "updated-branch", before)
+        git(root, "commit", "-q", "--allow-empty", "-m", "pull-request work")
+        git(root, "switch", "-q", "main")
+        git(root, "commit", "-q", "--allow-empty", "-m", "advance pull-request base")
+        advanced_base = git(root, "rev-parse", "HEAD")
+        git(root, "switch", "-q", "updated-branch")
+        git(root, "merge", "-q", "--no-ff", "main", "-m", "update pull-request branch")
+        updated_head = git(root, "rev-parse", "HEAD")
+        ordinary_merge_base = git(root, "merge-base", advanced_base, updated_head)
+        assert ordinary_merge_base == advanced_base
+        expect_failure(
+            lambda: policy.check_append_only_history(
+                root,
+                ordinary_merge_base,
+                updated_head,
+            ),
+            "not on the first-parent path",
+        )
+        derived_base = policy.first_parent_range_base(root, advanced_base, updated_head)
+        assert derived_base == before
+        policy.check_append_only_history(root, derived_base, updated_head)
+        assert policy.validate_repository(
+            root,
+            target_ref=updated_head,
+            pull_request_base_ref=advanced_base,
+            main_ref=advanced_base,
+        ) == (0, "not-started")
+        updated_cli = run_policy_cli(
+            root,
+            "--target-ref",
+            updated_head,
+            "--pull-request-base-ref",
+            advanced_base,
+            "--main-ref",
+            advanced_base,
+        )
+        assert updated_cli.returncode == 0, updated_cli.stderr
+        assert updated_cli.stdout.startswith("PASS:")
+
+        expect_failure(
+            lambda: policy.check_append_only_history(root, malformed_restored, advanced_base),
+            "not on the first-parent path",
+        )
+
+        git(root, "switch", "-q", "main")
+        activation_text = ARMED_SOAK_TEXT.replace(
+            "release-evidence log",
+            "activation evidence log",
+        )
+        assert activation_text != pending_text
+        activation = commit_soak(activation_text, "activate append-only ledger")
+        policy.check_append_only_history(root, advanced_base, activation)
+        policy.check_soak_transition(
+            policy.soak_bytes_at_ref(root, advanced_base),
+            policy.soak_bytes_at_ref(root, activation),
+            previous_subject=advanced_base,
+            current_subject=activation,
+        )
+
+        armed_text = activation_text + "\n"
+        armed_append = commit_soak(armed_text, "append armed ledger bytes")
+        policy.check_append_only_history(root, activation, armed_append)
+        policy.check_append_only_history(root, policy.ZERO_SHA, armed_append)
+
+        git(root, "switch", "-q", "-c", "downgrade", armed_append)
+        downgrade = commit_soak(pending_text, "attempt armed downgrade")
+        expect_failure(
+            lambda: policy.check_append_only_history(root, armed_append, downgrade),
+            "returned to pending after being armed",
+        )
+
+        git(root, "switch", "-q", "main")
+        armed_rewrite = armed_text.replace(
+            "activation evidence log",
+            "rewritten evidence log",
+        )
+        assert armed_rewrite != armed_text
+        commit_soak(armed_rewrite, "rewrite immutable armed prefix")
+        bad_head = commit_soak(armed_text, "restore final armed ledger bytes")
+
+        assert git(root, "rev-parse", f"{bad_head}^{{tree}}") == git(
+            root,
+            "rev-parse",
+            f"{armed_append}^{{tree}}",
+        )
+        assert policy.soak_bytes_at_ref(root, bad_head) == policy.soak_bytes_at_ref(
+            root,
+            armed_append,
+        )
+        policy.check_soak_transition(
+            policy.soak_bytes_at_ref(root, armed_append),
+            policy.soak_bytes_at_ref(root, bad_head),
+            previous_subject=armed_append,
+            current_subject=bad_head,
+        )
+        expect_failure(
+            lambda: policy.check_append_only_history(root, armed_append, bad_head),
+            "changed existing armed bytes",
+        )
+        expect_failure(
+            lambda: policy.check_append_only_history(root, policy.ZERO_SHA, bad_head),
+            "changed existing armed bytes",
+        )
+        expect_failure(
+            lambda: policy.validate_repository(
+                root,
+                target_ref=armed_append,
+                history_base_ref=before,
+                history_head_ref=bad_head,
+                main_ref=armed_append,
+            ),
+            "history head differs from the exact validation target",
+        )
+
+        failed_cli = run_policy_cli(
+            root,
+            "--target-ref",
+            bad_head,
+            "--history-base-ref",
+            armed_append,
+            "--history-head-ref",
+            bad_head,
+            "--main-ref",
+            bad_head,
+        )
+        assert failed_cli.returncode == 1
+        assert failed_cli.stderr.startswith("FAIL:")
+        assert "Traceback" not in failed_cli.stderr
+
+        missing_git_cli = run_policy_cli(
+            root,
+            "--target-ref",
+            pending_rewrite,
+            "--main-ref",
+            pending_rewrite,
+            env={"PATH": ""},
+        )
+        assert missing_git_cli.returncode == 1
+        assert missing_git_cli.stderr.startswith("FAIL: could not execute git:")
+        assert "Traceback" not in missing_git_cli.stderr
+
+
 def main() -> int:
     assert policy.validate_policy_text(DESIGN_TEXT) == policy.EXPECTED_POLICY
     schema, empty_entries = policy.parse_soak_text(SOAK_TEXT)
     assert schema == policy.EXPECTED_SOAK
     assert policy.validate_entries(empty_entries) == "not-started"
+    assert policy.validate_repository(ROOT) == (0, "not-started")
+    test_git_evidence_resolvers()
+    test_append_only_git_ranges_and_cli()
     assert policy.validate_policy_text(ARMED_DESIGN_TEXT) == ARMED_POLICY
     armed_schema, armed_empty_entries = policy.parse_soak_text(ARMED_SOAK_TEXT)
     assert armed_schema["soak"]["enforcement"] == "armed"


### PR DESCRIPTION
## Summary

- resolve exact local Git object, tree, reachability, and ancestry evidence without accepting mutable refs as immutable evidence
- bind freeze tags to verified SHA-1 object bytes while leaving signature, pinned-key, schema, and hosted-check claims to their separate evidence boundary
- parse every ledger revision fail-closed and enforce append-only transitions from the first armed predecessor, while allowing valid pending corrections and the pending-to-armed activation rewrite
- derive PR history from the head first-parent lineage so Update-branch merges are scanned without treating a second-parent merge base as the range boundary
- run the checker and its real-Git perturbation suite in a dedicated lightweight workflow that has no path filter, uses exact event OIDs, has read-only contents permission, persists no credential, and receives no secrets

## Scope boundary

This is the local Git and CI layer only. It does not add the live GitHub, Actions, payload, or publisher resolvers. A nonempty armed ledger therefore fails closed until those callbacks are supplied by the follow-up layer.

This PR does not change the tenkz package version, create a release tag, configure a signing secret, or append a live soak entry.

Part of LionSR/tenkz#128.

## Validation

All local checks below pass on `60fa2705336932aabaf67ca82b21a6f1063b43d0`.

- `python3 -m py_compile scripts/check_tenkz_policy.py scripts/test_check_tenkz_policy.py`
- `python3 scripts/test_check_tenkz_policy.py`
- exact PR-mode and push-mode invocations of `scripts/check_tenkz_policy.py`
- `ruff check scripts/check_tenkz_policy.py scripts/test_check_tenkz_policy.py`
- `actionlint .github/workflows/tenkz-policy.yml`
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py --base-ref origin/main gate`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New mandatory CI on all PRs and main pushes with non-trivial first-parent and append-only ledger rules; mistakes could block merges, but checks are read-only Git with no secrets and fail closed on armed evidence gaps.
> 
> **Overview**
> **Adds CI and local Git enforcement** so `docs/tenkz/SOAK-1.0.md` cannot be rewritten once the ledger is **armed**, while still allowing **pending** corrections and the pending→armed activation.
> 
> `scripts/check_tenkz_policy.py` gains a **CLI** and repository validation that reads **exact commit OIDs** (not mutable refs), verifies **SHA-1 object bytes**, resolves **freeze tags** and **merged PR** tree/reachability facts, and walks **first-parent** history—using a PR-specific fork boundary so “update branch” merges are scanned correctly. `scripts/test_check_tenkz_policy.py` adds **real Git** perturbation tests for those paths.
> 
> A new **`.github/workflows/tenkz-policy.yml`** runs on every PR and `main` push (no path filter): full history checkout, `test_check_tenkz_policy.py`, then `check_tenkz_policy.py` with event-specific base/head SHAs. **Read-only** `contents` permission, no persisted credentials or secrets.
> 
> **Scope note:** this layer does not wire live GitHub/publisher resolvers; a nonempty **armed** ledger still **fails closed** until follow-up work supplies them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60fa2705336932aabaf67ca82b21a6f1063b43d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->