### PR TITLE
feat(MPS/Periodic): normalize spectral periodic blocks

### DIFF
--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -28,6 +28,8 @@ for irreducible completely positive maps on `M_D(ℂ)`.
   is `r`.
 * `spectralRadius_toReal_eq_of_posDef_eigenvector_of_irreducible_cp`:
   the same statement as a real-valued identity.
+* `peripheralEigenvalues_similarityMap_eq`: peripheral eigenvalues are
+  invariant under the positive-congruence similarity used for Perron gauges.
 * `IsPrimitive.similarityMap_iff`: primitivity is invariant under the
   positive-congruence similarity used for Perron gauges.
 
@@ -98,6 +100,27 @@ theorem spectralRadius_similarityMap_eq
     rw [hspec_left, hspec_alg, hspec_right]
   change spectralRadius ℂ (Φ (similarityMap (D := D) C E)) = spectralRadius ℂ (Φ E)
   rw [spectralRadius, spectralRadius, hspec]
+
+/-- Peripheral eigenvalues are invariant under the congruence similarity
+`X ↦ C⁻¹ * E (C * X * Cᴴ) * (Cᴴ)⁻¹`.
+
+Source context: the normalization in arXiv:1708.00029, lines 313--332 uses this bond-space
+similarity to pass from irreducible blocks to trace-preserving irreducible blocks without
+rescaling them. The spectral invariance is the finite-dimensional similarity step in M. Wolf,
+*Quantum Channels & Operations: Guided Tour*, Section 6.2, Theorem 6.3 [Wolf2012QChannels]. -/
+theorem peripheralEigenvalues_similarityMap_eq
+    (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0)
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    peripheralEigenvalues (similarityMap (D := D) C E) = peripheralEigenvalues E := by
+  have hsim :
+      similarityMap (D := D) C E =
+        (Matrix.congruenceLinearEquiv C hC).symm.conj E := by
+    apply LinearMap.ext
+    intro X
+    ext i j
+    simp [similarityMap, LinearEquiv.conj_apply, Matrix.mul_assoc]
+  rw [hsim]
+  exact peripheralEigenvalues_conj (Matrix.congruenceLinearEquiv C hC).symm E
 
 /-- Peripheral-spectrum primitivity is invariant under the positive-congruence
 similarity used to change Kraus gauges. -/

--- a/TNLean/Channel/Peripheral/Spectrum.lean
+++ b/TNLean/Channel/Peripheral/Spectrum.lean
@@ -26,6 +26,8 @@ the eigenvalues on the unit circle.
 
 ## Main results
 
+* `matrix_dim_ne_zero_of_spectralRadius_eq_one` — spectral radius one forces
+  positive matrix dimension
 * `one_mem_peripheralEigenvalues` — 1 is a peripheral eigenvalue
 * `peripheralEigenvalues_finite` — peripheral eigenvalues are finite
 * `isRootOfUnity_of_finite_powers` — pigeonhole for roots of unity
@@ -62,6 +64,19 @@ def peripheralEigenvalues {V : Type*} [AddCommGroup V] [Module ℂ V]
   {μ : ℂ | Module.End.HasEigenvalue f μ ∧ ‖μ‖ = 1}
 
 /-! ## Part 2: Basic properties -/
+
+/-- A continuous endomorphism of square matrices with spectral radius one has
+positive matrix dimension.
+
+If the matrix dimension were zero, then the endomorphism algebra would be
+subsingleton and every endomorphism would have spectral radius zero. -/
+theorem matrix_dim_ne_zero_of_spectralRadius_eq_one
+    (T : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hT : spectralRadius ℂ T = 1) : D ≠ 0 := by
+  intro hD
+  subst D
+  rw [spectrum.SpectralRadius.of_subsingleton] at hT
+  exact zero_ne_one hT
 
 section PeripheralBasic
 

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -121,16 +121,11 @@ endomorphism algebra, is subsingleton. The transfer operator is therefore zero
 and has spectral radius zero, contradicting the spectral-radius-one clause in
 arXiv:1606.00608, lines 233--235. -/
 theorem IsNormalTensor.bondDim_ne_zero {A : MPSTensor d D} (h : IsNormalTensor A) :
-    D ≠ 0 := by
-  intro hD
-  subst D
-  have hMap :
-      ((Module.End.toContinuousLinearMap (Matrix (Fin 0) (Fin 0) ℂ))
-        (transferMap (d := d) (D := 0) A)) = 0 :=
-    Subsingleton.elim _ _
-  have hspectral := h.spectral_radius_one
-  rw [hMap, spectrum.spectralRadius_zero] at hspectral
-  exact zero_ne_one hspectral
+    D ≠ 0 :=
+  matrix_dim_ne_zero_of_spectralRadius_eq_one
+    ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+      (transferMap (d := d) (D := D) A))
+    h.spectral_radius_one
 
 /-- Every tensor of bond dimension one is irreducible: the only orthogonal
 projections on its one-dimensional bond space are zero and the identity. -/

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -29,6 +29,8 @@ tensor.
 
 ## Main statements
 
+* `exists_tpGauge_of_irreducible_spectralRadius_one`: an irreducible
+  spectral-radius-one tensor admits a pure trace-preserving Perron gauge.
 * `IsNormalTensor.exists_tpGauge`: a normal tensor admits a pure
   trace-preserving Perron gauge.
 * `IsNormalTensor.isNormal`: spectral normality implies eventual block
@@ -57,37 +59,47 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- A normal tensor admits a trace-preserving gauge with no scalar rescaling.
+/-- An irreducible tensor of spectral radius one admits a trace-preserving Perron gauge with no
+scalar rescaling.
 
-The tensor is normal in the sense of arXiv:1606.00608, lines 231--235: its
-transfer map has spectral radius one and unique peripheral eigenvalue one.
-The spectral-radius normalization forces positive bond dimension. The
-positive-definite left Perron eigenvector consequently has eigenvalue one, so
-the usual Perron gauge is a pure similarity of the original tensor. -/
-theorem IsNormalTensor.exists_tpGauge
-    {A : MPSTensor d D} (h : IsNormalTensor A) :
+The positive-definite right and left Perron eigenvectors have the same positive eigenvalue.  The
+spectral-radius-one hypothesis forces this eigenvalue to be one, so the left Perron eigenvector is
+an adjoint fixed point of the original transfer map.  Gauging by its positive square root is
+therefore a pure similarity, is left-canonical, and preserves irreducibility.
+
+Source: arXiv:1708.00029, lines 313--332; Wolf, *Quantum Channels & Operations*, Theorem 6.3. -/
+theorem exists_tpGauge_of_irreducible_spectralRadius_one
+    {A : MPSTensor d D}
+    (hIrr : IsIrreducibleTensor A)
+    (hRadius :
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (transferMap (d := d) (D := D) A)) = 1) :
     ∃ σ : Matrix (Fin D) (Fin D) ℂ,
       σ.PosDef ∧
       transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = σ ∧
       IsLeftCanonical (tpGauge (d := d) (D := D) A σ) ∧
       GaugeEquiv A (tpGauge (d := d) (D := D) A σ) ∧
-      _root_.IsPrimitive
-        (transferMap (d := d) (D := D) (tpGauge (d := d) (D := D) A σ)) ∧
       IsIrreducibleTensor (tpGauge (d := d) (D := D) A σ) := by
-  letI : NeZero D := ⟨h.bondDim_ne_zero⟩
+  have hD : D ≠ 0 :=
+    matrix_dim_ne_zero_of_spectralRadius_eq_one
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+        (transferMap (d := d) (D := D) A))
+      hRadius
+  letI : NeZero D := ⟨hD⟩
   have hA : ∃ i, A i ≠ 0 := by
     by_contra hzero
     push Not at hzero
     have hmap : transferMap (d := d) (D := D) A = 0 := by
       ext X a b
       simp [transferMap_apply, hzero]
-    have hspectral := h.spectral_radius_one
+    have hspectral := hRadius
     rw [hmap] at hspectral
     simp at hspectral
   have hIrrMap : IsIrreducibleMap (transferMap (d := d) (D := D) A) :=
-    isIrreducibleCP_transferMap_of_isIrreducibleTensor A h.no_invariant_proj
+    isIrreducibleCP_transferMap_of_isIrreducibleTensor A hIrr
   obtain ⟨ρ, r, hρ, hr, hρeig⟩ :=
-    exists_posDef_transferMap_eigenvector_of_irreducible A h.no_invariant_proj hA
+    exists_posDef_transferMap_eigenvector_of_irreducible A hIrr hA
   have hradius :
       (spectralRadius ℂ
         ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
@@ -99,11 +111,11 @@ theorem IsNormalTensor.exists_tpGauge
       (spectralRadius ℂ
         ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
           (transferMap (d := d) (D := D) A))).toReal = 1 := by
-    rw [h.spectral_radius_one]
+    rw [hRadius]
     simp
   have hr_one : r = 1 := hradius.symm.trans hradius_one
   obtain ⟨σ, t, hσ, ht, hσeig⟩ :=
-    exists_posDef_adjoint_eigenvector A h.no_invariant_proj hA
+    exists_posDef_adjoint_eigenvector A hIrr hA
   have htrace : Matrix.trace (σ * transferMap (d := d) (D := D) A ρ) =
       Matrix.trace
         (transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ * ρ) :=
@@ -135,11 +147,33 @@ theorem IsNormalTensor.exists_tpGauge
     tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint A σ hσ hσfix
   have hGauge : GaugeEquiv A (tpGauge (d := d) (D := D) A σ) :=
     gaugeEquiv_tpGauge A σ hσ
+  have hGaugeIrr : IsIrreducibleTensor (tpGauge (d := d) (D := D) A σ) :=
+    isIrreducibleTensor_tpGauge_of_isIrreducibleMap A σ hσ hIrrMap
+  exact ⟨σ, hσ, hσfix, hTP, hGauge, hGaugeIrr⟩
+
+/-- A normal tensor admits a trace-preserving gauge with no scalar rescaling.
+
+The tensor is normal in the sense of arXiv:1606.00608, lines 231--235: its
+transfer map has spectral radius one and unique peripheral eigenvalue one.
+The spectral-radius normalization forces positive bond dimension. The
+positive-definite left Perron eigenvector consequently has eigenvalue one, so
+the usual Perron gauge is a pure similarity of the original tensor. -/
+theorem IsNormalTensor.exists_tpGauge
+    {A : MPSTensor d D} (h : IsNormalTensor A) :
+    ∃ σ : Matrix (Fin D) (Fin D) ℂ,
+      σ.PosDef ∧
+      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) σ = σ ∧
+      IsLeftCanonical (tpGauge (d := d) (D := D) A σ) ∧
+      GaugeEquiv A (tpGauge (d := d) (D := D) A σ) ∧
+      _root_.IsPrimitive
+        (transferMap (d := d) (D := D) (tpGauge (d := d) (D := D) A σ)) ∧
+      IsIrreducibleTensor (tpGauge (d := d) (D := D) A σ) := by
+  obtain ⟨σ, hσ, hσfix, hTP, hGauge, hIrr⟩ :=
+    exists_tpGauge_of_irreducible_spectralRadius_one
+      h.no_invariant_proj h.spectral_radius_one
   have hPrim : _root_.IsPrimitive
       (transferMap (d := d) (D := D) (tpGauge (d := d) (D := D) A σ)) :=
     (isPrimitive_transferMap_tpGauge_iff A σ hσ).2 h.primitive_transfer
-  have hIrr : IsIrreducibleTensor (tpGauge (d := d) (D := D) A σ) :=
-    isIrreducibleTensor_tpGauge_of_isIrreducibleMap A σ hσ hIrrMap
   exact ⟨σ, hσ, hσfix, hTP, hGauge, hPrim, hIrr⟩
 
 /-- A normal tensor in the spectral sense of arXiv:1606.00608 is eventually

--- a/TNLean/MPS/Periodic.lean
+++ b/TNLean/MPS/Periodic.lean
@@ -15,6 +15,7 @@ import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.GlobalGauge
 import TNLean.MPS.Periodic.NormalCanonicalPeriodOne
+import TNLean.MPS.Periodic.Normalization
 import TNLean.MPS.Periodic.NormalizedSelfOverlap
 import TNLean.MPS.Periodic.Overlap
 import TNLean.MPS.Periodic.Overlap.Dichotomy

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -18,8 +18,12 @@ import Mathlib.RingTheory.RootsOfUnity.Complex
 
 This file introduces the basic periodic MPS predicates and equivalence relations
 used by the periodic form theory (arXiv:1708.00029, Section 2.1).
+
+The predicate `IsSpectrallyPeriodic` describes irreducible spectral-radius-one
+blocks before trace-preserving normalization, whereas `IsPeriodic` also includes
+left-canonical normalization.
 -/
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators Matrix.Norms.Operator
 
 namespace MPSTensor
 
@@ -65,6 +69,45 @@ theorem instEquivalenceGaugeEquiv :
   trans := MPSChainTensor.GaugeEquiv.trans
 
 end PeriodicMPSTensor
+
+/-- `IsSpectrallyPeriodic m A` records a periodic irreducible block before
+trace-preserving normalization: its transfer map is irreducible, has spectral
+radius one, and has unit-circle eigenvalues exactly the `m`-th roots of unity.
+
+Unlike `IsPeriodic`, this predicate does not assume that `A` is left-canonical.
+The source passes from this spectral form to trace-preserving form by a pure
+similarity transformation.
+
+Source: arXiv:1708.00029, lines 248--261 and 313--332. -/
+structure IsSpectrallyPeriodic (m : ℕ) (A : MPSTensor d D) : Prop where
+  /-- The transfer map has no nontrivial invariant projection, as required for
+  each irreducible-form block in arXiv:1708.00029, lines 248--261. -/
+  irreducible : IsIrreducibleTensor A
+  /-- The transfer map has spectral radius one, following the rescaling in
+  arXiv:1708.00029, lines 248--255 and the definition at lines 260--261. -/
+  spectral_radius_one :
+    spectralRadius ℂ
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+        (transferMap (d := d) (D := D) A)) = 1
+  /-- The period is positive, as in the periodic-block description of
+  arXiv:1708.00029, lines 257--258. -/
+  period_pos : 0 < m
+  /-- The unit-circle eigenvalues are exactly the `m`-th roots of unity, as in
+  arXiv:1708.00029, lines 257--258. -/
+  peripheral_eq :
+    peripheralEigenvalues (transferMap (d := d) (D := D) A) = {μ : ℂ | μ ^ m = 1}
+
+/-- A spectrally periodic block has nonzero bond dimension.
+
+At bond dimension zero its transfer operator acts on the zero-dimensional
+matrix space and therefore has spectral radius zero, contradicting the
+spectral-radius-one normalization of arXiv:1708.00029, lines 248--261. -/
+theorem IsSpectrallyPeriodic.bondDim_ne_zero {m : ℕ} {A : MPSTensor d D}
+    (hA : IsSpectrallyPeriodic m A) : D ≠ 0 :=
+  matrix_dim_ne_zero_of_spectralRadius_eq_one
+    ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+      (transferMap (d := d) (D := D) A))
+    hA.spectral_radius_one
 
 /-- `IsPeriodic m A` bundles irreducibility, left-canonical normalization,
 peripheral spectrum equal to the `m`-th roots of unity, and positivity of `m`.

--- a/TNLean/MPS/Periodic/Normalization.lean
+++ b/TNLean/MPS/Periodic/Normalization.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Irreducible.SpectralRadius
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.Periodic.Defs
+
+/-!
+# Perron normalization of spectral periodic blocks
+
+This file passes from an irreducible periodic block of spectral radius one to a
+left-canonical periodic block by a pure Perron similarity.  No scalar rescales
+the tensor, so the similarity preserves every matrix-product vector and leaves
+the multiplicity matrices of a block-diagonal irreducible form unchanged.
+
+## Main result
+
+* `IsSpectrallyPeriodic.exists_isPeriodic_tpGauge`: a spectrally periodic block
+  has a gauge-equivalent trace-preserving representative with the same period.
+
+## Reference
+
+De las Cuevas--Cirac--Schuch--Pérez-García, arXiv:1708.00029, lines 313--332.
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder Matrix.Norms.Operator
+
+namespace MPSTensor
+
+variable {d D m : ℕ}
+
+/-- A spectrally periodic block has a gauge-equivalent left-canonical periodic
+representative obtained without scalar rescaling.
+
+The positive-definite adjoint Perron fixed point gives the trace-preserving
+gauge.  The transfer map changes by similarity, so irreducibility and the
+prescribed roots-of-unity peripheral spectrum are unchanged.
+
+Source: arXiv:1708.00029, lines 313--332. -/
+theorem IsSpectrallyPeriodic.exists_isPeriodic_tpGauge
+    {A : MPSTensor d D} (hA : IsSpectrallyPeriodic m A) :
+    ∃ σ : Matrix (Fin D) (Fin D) ℂ,
+      σ.PosDef ∧
+      transferMap (d := d) (D := D) (fun i ↦ (A i)ᴴ) σ = σ ∧
+      GaugeEquiv A (tpGauge (d := d) (D := D) A σ) ∧
+      IsPeriodic m (tpGauge (d := d) (D := D) A σ) := by
+  obtain ⟨σ, hσ, hσfix, hLeft, hGauge, hIrr⟩ :=
+    exists_tpGauge_of_irreducible_spectralRadius_one
+      hA.irreducible hA.spectral_radius_one
+  have hSdet : (CFC.sqrt σ).det ≠ 0 :=
+    (isUnit_det_cfc_sqrt_of_posDef σ hσ).ne_zero
+  have hSinvDet : ((CFC.sqrt σ)⁻¹).det ≠ 0 := by
+    simpa [Matrix.det_nonsing_inv] using inv_ne_zero hSdet
+  have hPeripheral :
+      peripheralEigenvalues
+          (transferMap (d := d) (D := D) (tpGauge (d := d) (D := D) A σ)) =
+        peripheralEigenvalues (transferMap (d := d) (D := D) A) := by
+    rw [transferMap_tpGauge_eq_similarityMap A σ hσ]
+    exact peripheralEigenvalues_similarityMap_eq
+      (CFC.sqrt σ)⁻¹ hSinvDet (transferMap (d := d) (D := D) A)
+  refine ⟨σ, hσ, hσfix, hGauge, ?_⟩
+  exact ⟨hIrr, hLeft, hA.period_pos, hPeripheral.trans hA.peripheral_eq⟩
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/ProportionalOverlap.lean
+++ b/TNLean/MPS/Periodic/ProportionalOverlap.lean
@@ -275,8 +275,10 @@ blocks of spectral radius one and then obtains trace-preserving blocks by a
 block-diagonal similarity at lines 313--332. Here each basis block is already
 `IsPeriodic`, hence left-canonical. The literal multiplicity-bearing
 presentation and positive-length proportionality agree with the source, but
-normalization by similarity and transport back to the original blocks remain
-to be formalized. This theorem constructs the three fields of
+the pure Perron normalization must still be applied sectorwise and the result
+transported back to the original blocks. The normalization of each individual
+block is supplied by the individual pure Perron normalization theorem. This
+theorem constructs the three fields of
 `PeriodicOverlapHypothesis`; it does not assert the unique basis matching in
 source theorem `thm:bd`. This restriction is recorded in
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/

--- a/blueprint/src/chapter/ch04_channels_peripheral_spectrum_and_primitivity.tex
+++ b/blueprint/src/chapter/ch04_channels_peripheral_spectrum_and_primitivity.tex
@@ -25,6 +25,18 @@
     $|\lambda| = r$.
 \end{definition}
 
+\begin{lemma}[Unit spectral radius forces positive matrix size]
+    \label{lem:spectral_radius_one_matrix_dim_pos}
+    \lean{matrix_dim_ne_zero_of_spectralRadius_eq_one}
+    \leanok
+    Let $T:\MN D\to\MN D$ be a bounded linear map. If its spectral radius is
+    one, then $D\geq1$.
+\end{lemma}
+\begin{proof}\leanok
+    If $D=0$, then the matrix space and its endomorphism algebra contain only
+    zero, so every endomorphism has spectral radius zero.
+\end{proof}
+
 \begin{remark}[Peripheral conventions for channels]%
     \label{rem:peripheral_conventions_channels}
     \leanok

--- a/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
+++ b/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
@@ -12,7 +12,9 @@ matching between normal blocks.
     Every normal tensor has positive bond dimension.
 \end{theorem}
 
-\begin{proof}\leanok
+\begin{proof}
+    \uses{lem:spectral_radius_one_matrix_dim_pos}
+    \leanok
     If the bond dimension were zero, the bond-matrix space and its endomorphism
     algebra would each contain only zero. The transfer operator would therefore
     have spectral radius zero, contradicting the spectral-radius-one clause in

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -1,3 +1,85 @@
+\begin{definition}[Spectrally periodic irreducible tensor]
+    \label{def:spectral_periodic_tensor}
+    \lean{MPSTensor.IsSpectrallyPeriodic}
+    \leanok
+    An irreducible MPS tensor $A$ is \emph{spectrally $m$-periodic} if
+    $m\geq1$, the spectral radius of its transfer map is one, and
+    \begin{align}
+        \operatorname{Spec}_{\mathrm{per}}(\E_A)
+          &=\{\mu\in\C:\mu^m=1\}.
+        \notag
+    \end{align}
+    No trace-preserving normalization is imposed.  This is the form of the
+    periodic blocks before the similarity transformation in
+    \cite[lines~248--261 and 313--332]{DeLasCuevas2017Irreducible}.
+\end{definition}
+
+\begin{theorem}[A spectrally periodic tensor has positive bond dimension]
+    \label{thm:spectral_periodic_bond_dimension_pos}
+    \lean{MPSTensor.IsSpectrallyPeriodic.bondDim_ne_zero}
+    \leanok
+    \uses{def:spectral_periodic_tensor}
+    If $A$ is spectrally periodic, then its bond dimension satisfies $D\geq1$.
+\end{theorem}
+\begin{proof}
+    \uses{lem:spectral_radius_one_matrix_dim_pos}
+    \leanok
+    In bond dimension zero the matrix space and its endomorphism algebra are
+    zero-dimensional, so the transfer map has spectral radius zero.  This
+    contradicts the spectral-radius-one hypothesis.
+\end{proof}
+
+\begin{lemma}[Peripheral spectrum is invariant under bond-space similarity]
+    \label{lem:peripheral_spectrum_similarity}
+    \lean{peripheralEigenvalues_similarityMap_eq}
+    \leanok
+    Let $C\in\MN D$ be invertible and let $E$ be a linear map on $\MN D$.  If
+    \begin{align}
+        E_C(X)&=C^{-1}E(CXC^\dagger)(C^\dagger)^{-1},
+        \notag
+    \end{align}
+    then $E_C$ and $E$ have the same peripheral spectrum.
+\end{lemma}
+\begin{proof}\leanok
+    Conjugation by $X\mapsto CXC^\dagger$ gives a linear equivalence of the
+    matrix space.  Transporting eigenvectors through this equivalence preserves
+    every eigenvalue and hence the unit-circle eigenvalue set.
+\end{proof}
+
+\begin{theorem}[Pure Perron normalization at spectral radius one]
+    \label{thm:pure_perron_tp_gauge}
+    \lean{MPSTensor.exists_tpGauge_of_irreducible_spectralRadius_one}
+    \leanok
+    Let $A$ be irreducible and suppose that the spectral radius of $\E_A$ is
+    one.  There is a positive definite matrix $\sigma$ satisfying
+    \begin{align}
+        \sum_i(A^i)^\dagger\sigma A^i&=\sigma.
+        \notag
+    \end{align}
+    The tensor
+    \begin{align}
+        B^i&=\sigma^{1/2}A^i\sigma^{-1/2}
+        \notag
+    \end{align}
+    is left-canonical and irreducible, and $A$ and $B$ are related by a pure
+    invertible similarity.
+\end{theorem}
+\begin{proof}
+    \uses{lem:irreducible_transfer_perron_pair,
+        lem:spectral_radius_one_matrix_dim_pos,
+        thm:posDef_adjoint_eigenvector,
+        thm:spectral_radius_real_pf_irred,
+        thm:tp_gauge_from_adjoint_fixed,
+        lem:tp_gauge_equiv,
+        lem:similarity_irred_iff}
+    \leanok
+    Positive-definite right and left Perron eigenvectors have the same positive
+    eigenvalue by the trace pairing.  The spectral-radius identity makes this
+    eigenvalue equal to one.  Thus the left Perron eigenvector is an adjoint
+    fixed point, so its square-root gauge is trace-preserving.  Similarity
+    preserves irreducibility.
+\end{proof}
+
 \begin{definition}[Left-canonical periodic tensor]
     \label{def:periodic_tensor}
     \lean{MPSTensor.IsPeriodic}
@@ -10,6 +92,29 @@
     A $1$-periodic tensor is exactly an irreducible tensor with
     primitive transfer map (Definition~\ref{def:primitive_channel}).
 \end{definition}
+
+\begin{theorem}[Perron normalization of spectrally periodic tensors]
+    \label{thm:spectral_periodic_normalization}
+    \lean{MPSTensor.IsSpectrallyPeriodic.exists_isPeriodic_tpGauge}
+    \leanok
+    \uses{def:spectral_periodic_tensor, def:periodic_tensor}
+    Let $A$ be spectrally $m$-periodic.  There is a positive definite matrix
+    $\sigma$ such that
+    \begin{align}
+        B^i&=\sigma^{1/2}A^i\sigma^{-1/2}
+        \notag
+    \end{align}
+    is a left-canonical $m$-periodic tensor.  The similarity is pure, so it
+    leaves every matrix-product vector unchanged and introduces no scalar
+    weight into the normalization.
+\end{theorem}
+\begin{proof}
+    \uses{lem:peripheral_spectrum_similarity, thm:pure_perron_tp_gauge}
+    \leanok
+    Apply Theorem~\ref{thm:pure_perron_tp_gauge}.  The transfer map of $B$ is
+    similar to that of $A$, so Lemma~\ref{lem:peripheral_spectrum_similarity}
+    preserves the prescribed set of $m$-th roots of unity.
+\end{proof}
 
 \begin{theorem}[A periodic tensor has positive bond dimension]
     \label{thm:periodic_bond_dimension_pos}

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -473,9 +473,11 @@
     starts with the normalized basis tensors.  The multiplicity matrices are
     otherwise arbitrary diagonal matrices with nonzero complex entries, the
     displayed direct sums are literal, and proportionality is assumed only at
-    positive lengths.  Transport through the normalizing similarities remains
-    to be proved before applying this result to the unnormalized source
-    statement.  This distinction is recorded in
+    positive lengths.  Theorem~\ref{thm:spectral_periodic_normalization}
+    constructs each normalizing similarity.  Applying these similarities to
+    the whole sector decomposition and transporting the conclusion back remain
+    to be proved before this result applies to the unnormalized source
+    statement.  This remaining distinction is recorded in
     \path{docs/paper-gaps/1708_periodic_overlap_route_alignment.tex}.
 \end{theorem}
 \begin{proof}\leanok
@@ -587,6 +589,7 @@
     The theorem relates the two bases of periodic tensors but makes no
     assertion relating their multiplicity matrices.
     % Formalization status: the normalized multiplicity-bearing theorem above
-    % proves the overlap step after the source's Perron similarity. Constructing
-    % and transporting through that similarity remains tracked in issue #5342.
+    % proves the overlap step after the source's Perron similarity. Applying
+    % these similarities sectorwise and transporting back remains tracked in
+    % issue #5342.
 \end{theorem}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -79,6 +79,38 @@ is deliberately source-faithful.
   eventual block injectivity does not recover spectral-radius-one normalization
   or peripheral-spectrum data. Do not treat the predicates as aliases.
 
+## Periodic irreducible blocks
+
+### `MPSTensor.IsSpectrallyPeriodic`
+
+- **Declaration:**
+  `MPSTensor.IsSpectrallyPeriodic (m : ℕ) (A : MPSTensor d D) : Prop`.
+- **Defined in:** `TNLean/MPS/Periodic/Defs.lean`.
+- **Meaning:** the transfer map is irreducible, has spectral radius one, and has
+  unit-circle eigenvalues exactly the `m`-th roots of unity, with `m > 0`.
+  No trace-preserving normalization is assumed.
+- **Source:** de las Cuevas--Cirac--Schuch--Pérez-García, arXiv:1708.00029,
+  lines 248--261.
+- **Sanctioned bridge:**
+  `MPSTensor.IsSpectrallyPeriodic.exists_isPeriodic_tpGauge` in
+  `TNLean/MPS/Periodic/Normalization.lean` gives a pure-similarity
+  trace-preserving representative.
+- **Caveat:** general invertible similarities do not preserve
+  left-canonicality. The bridge is therefore one-way into `IsPeriodic`, not an
+  equivalence between the two predicates.
+
+### `MPSTensor.IsPeriodic`
+
+- **Declaration:** `MPSTensor.IsPeriodic (m : ℕ) (A : MPSTensor d D) : Prop`.
+- **Defined in:** `TNLean/MPS/Periodic/Defs.lean`.
+- **Meaning:** the tensor is irreducible and left-canonical, `m > 0`, and the
+  peripheral eigenvalues are exactly the `m`-th roots of unity.
+- **Source:** the trace-preserving form obtained in arXiv:1708.00029,
+  lines 313--332.
+- **Caveat:** this predicate is the normalized input to the periodic overlap
+  theory. It must not be substituted for the unnormalized source assumptions
+  without applying the pure Perron normalization theorem.
+
 ## Primitivity
 
 The unqualified canonical predicate is the generic transfer-map predicate

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -288,7 +288,7 @@ lemma is not used. Restoring the spanning clause and routing through
 half is formalized; no unrestricted spanning assertion is presently attributed
 to the source consequence.
 
-\section{Normalized multiplicity theorem and remaining normalization restriction}
+\section{Normalized multiplicity theorem and remaining transport restriction}
 
 \textbf{Source.}\footnote{\cite{DeLasCuevas2017Irreducible}, equations
 \emph{bdnr} and \emph{Bbdnr}, lines 286--305 and 575--585; the normalization
@@ -337,18 +337,28 @@ matrix-product-vector equality at the empty word and may describe an ambient
 tensor only through such an equality.  These are restrictions of that older
 formulation, not of the new literal multiplicity-bearing theorem.
 
-\textbf{Remaining normalization restriction.} The basis blocks in the new
-theorem satisfy the local predicate \path{IsPeriodic}, which includes
-left-canonical normalization.  The source initially assumes only that each
-transfer map is irreducible with spectral radius one, then uses the positive
-adjoint Perron eigenmatrix to obtain a trace-preserving block by pure
-similarity \cite[lines~313--332]{DeLasCuevas2017Irreducible}.  The formal
-development does not yet provide this normalization simultaneously for all
-sectors while preserving the displayed multiplicity weights, nor does it yet
-transport the resulting overlap hypothesis back through those blockwise
-similarities.  Applying the theorem to an arbitrary original tensor through a
-lower-dimensional representative also requires a positive-length transport
-statement of the kind allowed at lines~266--271.
+\textbf{Pure normalization theorem.} The predicate
+\path{IsSpectrallyPeriodic} records the source assumptions on a basis block:
+irreducibility, spectral radius one, positive period, and the prescribed
+roots-of-unity peripheral spectrum.  The declaration
+\path{IsSpectrallyPeriodic.exists_isPeriodic_tpGauge} applies the positive
+adjoint Perron eigenmatrix to obtain a left-canonical periodic block by pure
+similarity, exactly as in
+\cite[lines~313--332]{DeLasCuevas2017Irreducible}.  The Perron eigenvalue is
+forced to equal one, so no scalar rescales the block.  The peripheral spectrum
+is preserved by similarity.  Thus this normalization leaves every
+matrix-product vector unchanged and introduces no extra power into the
+multiplicity coefficients.
+
+\textbf{Remaining sectorwise transport restriction.} The normalized overlap
+theorem still takes a literal sector decomposition whose basis blocks already
+satisfy \path{IsPeriodic}.  The formal development does not yet replace every
+basis block by its Perron representative inside a new sector decomposition,
+assemble the individual similarities into a block-diagonal gauge, or transport
+the overlap hypothesis back to the original basis.  Applying the theorem to an
+arbitrary original tensor through a lower-dimensional representative also
+requires a positive-length transport statement of the kind allowed at
+lines~266--271.
 
 The declarations \leanid{fundamentalTheorem_periodic_proportional} and
 \leanid{fundamentalTheorem_periodic_proportional_of_isPeriodic} begin after
@@ -356,20 +366,17 @@ this step: they accept the periodic-overlap hypothesis, or its non-decaying
 partner fields, as premises and prove the resulting finite block matching.
 Together with the new normalized overlap theorem they give the block matching for
 literal normalized irreducible forms.  The source theorem itself remains
-unformalized until the preceding normalization and transport step is proved;
+unformalized until the preceding sectorwise transport step is proved;
 the exact source-labelled blueprint statement must therefore remain
 \emph{not ready}.
 
-\textbf{Elimination plan.} Introduce the source predicate consisting of
-irreducibility, spectral radius one, positive period, and the prescribed
-peripheral spectrum.  Extract the pure Perron similarity argument from the
-existing primitive special case, apply it to every basis block without scalar
-rescaling, and assemble the block gauges while leaving all multiplicity
-entries unchanged.  Prove invariance of proportional positive-length MPVs,
-overlap decay, pairwise non-repetition, and the final repeated-block relation
-under these similarities.  A separate positive-length representative
+\textbf{Elimination plan.} Apply the pure Perron normalization to every basis
+block and assemble the block gauges while leaving all multiplicity entries
+unchanged.  Prove invariance of proportional positive-length MPVs, overlap
+decay, pairwise non-repetition, and the final repeated-block relation under
+these similarities.  A separate positive-length representative
 transport then covers the source-allowed lower-dimensional representative.
-The mixed-overlap and normalization work remains tracked by
+The remaining sectorwise transport work is tracked by
 \href{https://github.com/LionSR/TNLean/issues/5342}{issue \#5342}; the subsequent
 multiplicity-power extraction is tracked by
 \href{https://github.com/LionSR/TNLean/issues/5344}{issue \#5344}.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,19 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### spectral-radius-one matrix dimension — promoted
+- **Pattern:** exclude zero matrix dimension by observing that every
+  endomorphism of the zero-dimensional square-matrix space has spectral radius
+  zero.
+- **Seen:** three occurrences across `CanonicalForm/Definitions.lean`,
+  `CanonicalForm/NormalTensorGauge.lean`, and `Periodic/Defs.lean` before
+  promotion.
+- **Abstraction:** `matrix_dim_ne_zero_of_spectralRadius_eq_one` in
+  `TNLean/Channel/Peripheral/Spectrum.lean`.
+- **Notes:** the shared lemma is independent of positivity and transfer-map
+  structure; callers supply only the spectral-radius-one identity. Net source
+  delta: 0 lines relative to the unabstracted draft (14 removed, 14 added).
+
 ### positive-semidefinite support congruence — promoted
 - **Pattern:** transport the support projection across an equality of positive
   semidefinite matrices while identifying the two positivity proofs by proof


### PR DESCRIPTION
## Summary

- introduce the source-level predicate for irreducible periodic blocks before trace-preserving normalization
- extract a Perron gauge theorem for every irreducible tensor of spectral radius one, without scalar rescaling
- prove that the prescribed peripheral spectrum is preserved by the gauge similarity and hence obtain a left-canonical periodic representative
- align the Blueprint, glossary, proof-pattern ledger, and periodic-overlap gap account with the proved normalization step

## Mathematical scope

Let `A` be an irreducible tensor whose transfer map has spectral radius one. The positive right and adjoint Perron eigenmatrices have the same positive eigenvalue by the trace pairing, and the spectral-radius identity forces that eigenvalue to be one. If `σ` is the positive-definite adjoint fixed point, then

`Bⁱ = σ¹ᐟ² Aⁱ σ⁻¹ᐟ²`

is left-canonical and irreducible. This is a pure similarity: it changes neither the matrix-product vectors nor the multiplicity weights. The transfer maps are similar through positive congruence, so their peripheral eigenvalue sets agree.

The new predicate `IsSpectrallyPeriodic m A` records exactly the source assumptions on one periodic basis block: irreducibility, spectral radius one, positive period, and peripheral eigenvalues equal to the `m`-th roots of unity. The normalization theorem sends this predicate to `IsPeriodic m B` by the pure Perron gauge.

The repeated zero-dimensional spectral-radius argument is also factored into a general lemma and reused by the normal and periodic predicates.

## Source faithfulness and remaining work

The construction follows arXiv:1708.00029, lines 248–261 and 313–332. Left-canonicality is deliberately absent from the source predicate and appears only after the proved similarity transformation.

The exact source-labelled Theorem 3.4 remains marked not ready. Its remaining step is sectorwise: replace every basis block by its Perron representative inside the full decomposition, assemble the individual similarities, and transport positive-length proportionality, overlap decay, non-repetition, and the repeated-block conclusion back to the original basis. Issue #5342 therefore remains open.

## Validation

- `lake build TNLean.MPS.Periodic.Normalization`
- `lake build TNLean`
- `lake exe lint_style`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- changed-declaration reverse Blueprint coverage against `origin/main`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- proof-integrity scan of all changed Lean files
- independent mathematical/source-faithfulness and code-review audits

Refs #5342

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation refactor with no auth, runtime, or data-path changes; remaining risk is mathematical correctness of the new Lean theorems, which is localized to MPS/channel formalization.
> 
> **Overview**
> This PR formalizes **irreducible periodic blocks before trace-preserving normalization** (arXiv:1708.00029) and the **pure Perron similarity** that passes them to left-canonical `IsPeriodic` form without rescaling MPVs or multiplicity weights.
> 
> **Shared infrastructure:** `matrix_dim_ne_zero_of_spectralRadius_eq_one` replaces three duplicated zero-dimension arguments; `peripheralEigenvalues_similarityMap_eq` shows unit-circle eigenvalues are unchanged under the bond-space congruence used in Perron gauges.
> 
> **Gauge layer:** `exists_tpGauge_of_irreducible_spectralRadius_one` is extracted from `IsNormalTensor.exists_tpGauge` (irreducibility + spectral radius one only); normal tensors call it and then recover primitivity.
> 
> **Periodic pipeline:** New `IsSpectrallyPeriodic` (irreducible, ρ=1, prescribed roots-of-unity peripheral spectrum) and `IsSpectrallyPeriodic.exists_isPeriodic_tpGauge` in `TNLean/MPS/Periodic/Normalization.lean`. Blueprint ch04/ch22, glossary, tactic-pattern ledger, and the periodic-overlap gap doc are updated; sectorwise assembly and transport back to the original basis remain open (#5342).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1043e817edbd73218b5df22cfde6499bfeb053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->