### PR TITLE
feat(MPS/Periodic): transport spectral sector overlaps

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -72,16 +72,6 @@ noncomputable def matched_p_basis {P Q : SectorDecomposition d}
   exact cast (congr_arg (MPSTensor d) (hDim (Q.flatIndexEquiv.symm s).1))
     (P.basis (β (Q.flatIndexEquiv.symm s).1))
 
-/-- Duplicate the per-basis gauge matrices over all copies in the flattened `Q` coordinates.
-
-This realizes the `𝟙_{r_k} ⊗ X_k` part of CPSV16 Appendix MPV proof,
-line 1191. -/
-noncomputable def matched_block_gauge {Q : SectorDecomposition d}
-    (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ) :
-    (s : Fin Q.totalCopies) → GL (Fin (Q.flatDim s)) ℂ := fun s => by
-  change GL (Fin (Q.basisDim (Q.flatIndexEquiv.symm s).1)) ℂ
-  exact Xblock (Q.flatIndexEquiv.symm s).1
-
 /-- **Global block gauge from matched sectors and copy weights.**
 
 Assume the sectors of two sector decompositions have already been matched, and

--- a/TNLean/MPS/Periodic.lean
+++ b/TNLean/MPS/Periodic.lean
@@ -42,6 +42,7 @@ import TNLean.MPS.Periodic.SectorIrreducibility.HLiftCore
 import TNLean.MPS.Periodic.SectorIrreducibility.OrbitSum
 import TNLean.MPS.Periodic.SectorIrreducibility.ProjectionOrtho
 import TNLean.MPS.Periodic.SectorLift
+import TNLean.MPS.Periodic.SectorNormalization
 import TNLean.MPS.Periodic.SectorUnitary
 import TNLean.MPS.Periodic.Symmetry
 import TNLean.MPS.Periodic.Symmetry.Corollary41

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -21,9 +21,11 @@ in its equal-case strengthening:
   if two non-repeated block families satisfy a supplied periodic-overlap
   hypothesis, their blocks match bijectively up to `RepeatedBlocks`. Source
   theorem `thm:bd` instead assumes proportionality of the assembled MPV
-  families. The deduction of the supplied hypothesis is proved for literal
-  multiplicity-bearing families of normalized periodic blocks; transport from
-  the source's unnormalized blocks remains incomplete.
+  families. The companion module `ProportionalOverlap` proves the deduction
+  for literal multiplicity-bearing families of spectrally periodic blocks,
+  including transport through their sectorwise Perron similarities. A
+  source-labelled matching theorem retaining equality of matched periods
+  remains to be stated.
 
 * **Supporting lemmas for the equal-case theorem `thm:bdequal`**: The equal-case
   strengthening produces per-block Z-gauge data (diagonal Z with Z^m = 1) from the
@@ -101,6 +103,17 @@ theorem HetRepeatedBlocks.of_repeatedBlocks {D : ℕ} {A B : MPSTensor d D}
     (h : RepeatedBlocks A B) : HetRepeatedBlocks A B :=
   ⟨rfl, h⟩
 
+/-- A pure bond-space similarity is a repeated-block relation with unit phase,
+also in the heterogeneous-dimension formulation.
+
+Source: arXiv:1708.00029, definition `def:repeated` and equation `eq:rep`,
+lines 276--284; the pure normalization similarities used here occur at
+lines 313--332. -/
+theorem GaugeEquiv.toHetRepeatedBlocks {D : ℕ} {A B : MPSTensor d D}
+    (h : GaugeEquiv A B) : HetRepeatedBlocks A B :=
+  HetRepeatedBlocks.of_repeatedBlocks
+    ((equivalentBlocks_iff_gaugeEquiv.mpr h).to_repeatedBlocks)
+
 /-! ## Periodic block matching witness -/
 
 /-- Witness for periodic block matching: equal block counts, a bijection, and per-block
@@ -143,6 +156,62 @@ structure PeriodicOverlapHypothesis
   hetRepeatedBlocks_of_nondecaying : ∀ j k,
     ¬ Filter.Tendsto (fun N => mpvOverlap (d := d) (A j) (B k) N) Filter.atTop (nhds 0) →
     HetRepeatedBlocks (A j) (B k)
+
+/-- Pure bond-space similarities transport a periodic overlap hypothesis back to the
+original block families.
+
+Every closed-chain matrix-product coefficient is invariant under similarity, so each
+mixed overlap agrees exactly before and after the two gauges. Hence decay, and therefore
+non-decay, is unchanged. The repeated-block conclusion is transported by composing the
+pure-gauge repeated-block relations on its two sides.
+
+Source: arXiv:1708.00029, lines 313--332 (blockwise pure normalization similarities),
+and proposition `equal-or-orthogonal-generalized`, lines 589--609. -/
+theorem PeriodicOverlapHypothesis.of_gaugeEquiv
+    {rA rB : ℕ}
+    {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
+    {A A' : (j : Fin rA) → MPSTensor d (dimA j)}
+    {B B' : (k : Fin rB) → MPSTensor d (dimB k)}
+    (hGaugeA : ∀ j, GaugeEquiv (A j) (A' j))
+    (hGaugeB : ∀ k, GaugeEquiv (B k) (B' k))
+    (hOverlap : PeriodicOverlapHypothesis A' B') :
+    PeriodicOverlapHypothesis A B := by
+  classical
+  have hRepA : ∀ j, HetRepeatedBlocks (A j) (A' j) := fun j =>
+    (hGaugeA j).toHetRepeatedBlocks
+  have hRepB : ∀ k, HetRepeatedBlocks (B k) (B' k) := fun k =>
+    (hGaugeB k).toHetRepeatedBlocks
+  have hOverlapEq : ∀ j k N,
+      mpvOverlap (d := d) (A j) (B k) N = mpvOverlap (d := d) (A' j) (B' k) N := by
+    intro j k N
+    apply Finset.sum_congr rfl
+    intro σ _
+    rw [(hGaugeA j).sameMPV N σ, (hGaugeB k).sameMPV N σ]
+  refine
+    { exists_nondecaying_A := ?_
+      exists_nondecaying_B := ?_
+      hetRepeatedBlocks_of_nondecaying := ?_ }
+  · intro j
+    obtain ⟨k, hNondecay⟩ := hOverlap.exists_nondecaying_A j
+    refine ⟨k, ?_⟩
+    intro hDecay
+    apply hNondecay
+    exact hDecay.congr' (Filter.Eventually.of_forall fun N ↦ hOverlapEq j k N)
+  · intro k
+    obtain ⟨j, hNondecay⟩ := hOverlap.exists_nondecaying_B k
+    refine ⟨j, ?_⟩
+    intro hDecay
+    apply hNondecay
+    exact hDecay.congr' (Filter.Eventually.of_forall fun N ↦ hOverlapEq j k N)
+  · intro j k hNondecay
+    have hNondecay' : ¬ Filter.Tendsto
+        (fun N ↦ mpvOverlap (d := d) (A' j) (B' k) N) Filter.atTop (nhds 0) := by
+      intro hDecay
+      apply hNondecay
+      exact hDecay.congr'
+        (Filter.Eventually.of_forall fun N ↦ (hOverlapEq j k N).symm)
+    exact (hRepA j).trans
+      ((hOverlap.hetRepeatedBlocks_of_nondecaying j k hNondecay').trans (hRepB k).symm)
 
 /-- **Build `PeriodicOverlapHypothesis` from `IsPeriodic` data via the overlap dichotomy.**
 
@@ -316,8 +385,12 @@ conclusion for different bond dimensions. The companion module
 `ProportionalOverlap` supplies the multi-block non-decaying cross-overlap
 hypotheses for literal multiplicity-bearing normalized periodic forms, with
 `PeriodicOverlapHypothesis.ofIsIrreducibleForm` as a scalar-weight
-specialization. Transport from the source's unnormalized blocks remains
-separate, as recorded in
+specialization. Its theorem
+`PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions` performs
+the sectorwise Perron normalization and transports the hypothesis back to the
+original spectral-radius-one blocks. The remaining source-faithfulness gap is
+to package the matching conclusion while retaining equality of matched
+periods, as recorded in
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.
 
 The `PeriodicOverlapHypothesis` parameter can be supplied via

--- a/TNLean/MPS/Periodic/ProportionalOverlap.lean
+++ b/TNLean/MPS/Periodic/ProportionalOverlap.lean
@@ -7,6 +7,7 @@ import TNLean.Algebra.FinSum
 import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
 import TNLean.MPS.Periodic.FundamentalTheorem
 import TNLean.MPS.Periodic.Overlap.Dichotomy
+import TNLean.MPS.Periodic.SectorNormalization
 
 /-!
 # Non-decaying periodic overlaps from proportional matrix-product vectors
@@ -23,6 +24,9 @@ the nonzero complex multiplicity weights.
 * `PeriodicOverlapHypothesis.ofSectorDecompositions`: literal normalized
   multiplicity-bearing tensors with proportional MPVs satisfy the periodic
   overlap hypothesis.
+* `PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions`:
+  spectral-radius-one multiplicity-bearing tensors satisfy the same hypothesis
+  after a pure block-diagonal Perron gauge.
 * `PeriodicOverlapHypothesis.ofIsIrreducibleForm`: the scalar-weight
   irreducible-form specialization.
 
@@ -270,15 +274,15 @@ may depend freely on the positive chain length.
 Source: arXiv:1708.00029, equations `eq:bdnr` and `eq:Bbdnr`, lines 286--305
 and 575--585; proof of theorem `thm:bd`, lines 630--631.
 
-**Scope restriction (normalization):** The source first assumes irreducible
-blocks of spectral radius one and then obtains trace-preserving blocks by a
-block-diagonal similarity at lines 313--332. Here each basis block is already
-`IsPeriodic`, hence left-canonical. The literal multiplicity-bearing
-presentation and positive-length proportionality agree with the source, but
-the pure Perron normalization must still be applied sectorwise and the result
-transported back to the original blocks. The normalization of each individual
-block is supplied by the individual pure Perron normalization theorem. This
-theorem constructs the three fields of
+**Scope restriction (normalization boundary):** The source first assumes
+irreducible blocks of spectral radius one and then obtains trace-preserving
+blocks by a block-diagonal similarity at lines 313--332. This theorem instead
+takes each basis block to be `IsPeriodic`, hence left-canonical. The companion
+theorem `ofSpectrallyPeriodicSectorDecompositions` below applies the individual
+pure Perron normalizations sectorwise, assembles the global block-diagonal
+similarities, and transports the conclusion back. The literal
+multiplicity-bearing presentation and positive-length proportionality agree
+with the source. This theorem constructs the three fields of
 `PeriodicOverlapHypothesis`; it does not assert the unique basis matching in
 source theorem `thm:bd`. This restriction is recorded in
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
@@ -321,6 +325,68 @@ theorem PeriodicOverlapHypothesis.ofSectorDecompositions
     exact tendsto_mpvOverlap_zero_swap (P.basis j₀) (Q.basis k₀) hDecay
   exact PeriodicOverlapHypothesis.ofIsPeriodic
     P.basis Q.basis periodP periodQ hPerP hPerQ hExP hExQ
+
+/-- Spectrally periodic multiplicity-bearing decompositions with proportional
+matrix-product vectors satisfy the periodic overlap hypothesis.
+
+Each representative block is put in left-canonical form by its positive Perron
+gauge.  Repeating the representative gauge over all copies gives the global
+block-diagonal similarity
+\(\bigoplus_j (I_{r_j} \otimes X_j)\).  The multiplicities and their weights are
+unchanged, so the normalized overlap theorem applies with the original grouped
+coefficients.  Pure-gauge invariance then returns its conclusion to the
+original representatives.
+
+Source: arXiv:1708.00029, equations `eq:bdnr` and `eq:Bbdnr`, lines 286--305
+and 575--585; normalization by block-diagonal similarity, lines 313--332; and
+theorem `thm:bd`, lines 613--632. -/
+theorem PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions
+    (P Q : SectorDecomposition d)
+    (periodP : Fin P.basisCount → ℕ)
+    (periodQ : Fin Q.basisCount → ℕ)
+    (hPerP : ∀ j, IsSpectrallyPeriodic (periodP j) (P.basis j))
+    (hPerQ : ∀ k, IsSpectrallyPeriodic (periodQ k) (Q.basis k))
+    (hNonRepP : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (P.basis i) (P.basis j))
+    (hNonRepQ : ∀ i j, i ≠ j → ¬ HetRepeatedBlocks (Q.basis i) (Q.basis j))
+    (hProp : NonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
+    PeriodicOverlapHypothesis P.basis Q.basis := by
+  classical
+  obtain ⟨basisP, hGaugeP, hPeriodicP, hGlobalP⟩ :=
+    P.exists_isPeriodic_replaceBasis periodP hPerP
+  obtain ⟨basisQ, hGaugeQ, hPeriodicQ, hGlobalQ⟩ :=
+    Q.exists_isPeriodic_replaceBasis periodQ hPerQ
+  have hRepeatedP : ∀ j, HetRepeatedBlocks (P.basis j) (basisP j) := fun j =>
+    (hGaugeP j).toHetRepeatedBlocks
+  have hRepeatedQ : ∀ k, HetRepeatedBlocks (Q.basis k) (basisQ k) := fun k =>
+    (hGaugeQ k).toHetRepeatedBlocks
+  have hNonRepP' : ∀ i j, i ≠ j →
+      ¬ HetRepeatedBlocks ((P.replaceBasis basisP).basis i)
+        ((P.replaceBasis basisP).basis j) := by
+    intro i j hij hRepeated
+    apply hNonRepP i j hij
+    exact (hRepeatedP i).trans (hRepeated.trans (hRepeatedP j).symm)
+  have hNonRepQ' : ∀ i j, i ≠ j →
+      ¬ HetRepeatedBlocks ((Q.replaceBasis basisQ).basis i)
+        ((Q.replaceBasis basisQ).basis j) := by
+    intro i j hij hRepeated
+    apply hNonRepQ i j hij
+    exact (hRepeatedQ i).trans (hRepeated.trans (hRepeatedQ j).symm)
+  have hProp' : NonzeroProportionalMPV₂
+      (P.replaceBasis basisP).toTensor (Q.replaceBasis basisQ).toTensor := by
+    intro N hN
+    obtain ⟨c, hc, hEq⟩ := hProp N hN
+    refine ⟨c, hc, fun σ ↦ ?_⟩
+    calc
+      mpv (P.replaceBasis basisP).toTensor σ = mpv P.toTensor σ :=
+        (GaugeEquiv.sameMPV hGlobalP N σ).symm
+      _ = c * mpv Q.toTensor σ := hEq σ
+      _ = c * mpv (Q.replaceBasis basisQ).toTensor σ :=
+        congrArg (fun z : ℂ ↦ c * z) (GaugeEquiv.sameMPV hGlobalQ N σ)
+  have hNormalized :=
+    PeriodicOverlapHypothesis.ofSectorDecompositions
+      (P.replaceBasis basisP) (Q.replaceBasis basisQ) periodP periodQ
+      hPeriodicP hPeriodicQ hNonRepP' hNonRepQ' hProp'
+  exact PeriodicOverlapHypothesis.of_gaugeEquiv hGaugeP hGaugeQ hNormalized
 
 /-- Proportional, normalized scalar-weight MPV representations have
 non-decaying overlap partners in both directions.

--- a/TNLean/MPS/Periodic/SectorNormalization.lean
+++ b/TNLean/MPS/Periodic/SectorNormalization.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Periodic.Normalization
+import TNLean.MPS.SharedInfra.BlockGauge
+import TNLean.MPS.SharedInfra.SectorDecomposition
+
+/-!
+# Sectorwise Perron normalization of periodic blocks
+
+This file applies the pure Perron normalization to every representative of a
+sector decomposition.  The replacement leaves the multiplicities and their
+weights unchanged.  Repeating each representative gauge over all its copies
+then gives a block-diagonal similarity of the assembled tensors.
+
+## Main results
+
+* `SectorDecomposition.gaugeEquiv_toTensor_replaceBasis`: representativewise
+  pure gauges assemble to a gauge of the full multiplicity-bearing tensor.
+* `SectorDecomposition.exists_isPeriodic_replaceBasis`: every spectrally
+  periodic representative family has a left-canonical periodic replacement
+  with the same multiplicity data.
+
+## Reference
+
+De las Cuevas--Cirac--Schuch--Pérez-García, arXiv:1708.00029,
+equation `eq:bdnr` and lines 286--332.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+namespace SectorDecomposition
+
+/-- Replace the representative tensors of a sector decomposition without
+changing their bond dimensions, multiplicities, or weights.
+
+The source normalizes each representative in
+$A^i = \bigoplus_j (R_j \otimes A_j^i)$ by a pure similarity, leaving every
+diagonal entry of $R_j$ unchanged.
+
+Source: arXiv:1708.00029, equation `eq:bdnr`, lines 286--305, and the
+blockwise similarities at lines 313--332. -/
+def replaceBasis (P : SectorDecomposition d)
+    (B : (j : Fin P.basisCount) → MPSTensor d (P.basisDim j)) :
+    SectorDecomposition d where
+  basisCount := P.basisCount
+  basisDim := P.basisDim
+  basis := B
+  sectors := P.sectors
+
+/-- The representative indexed by $j$ in the replaced family is $B_j$.
+
+Source context: arXiv:1708.00029, equation `eq:bdnr`, lines 286--305,
+with the representativewise similarities at lines 313--332. -/
+@[simp]
+theorem replaceBasis_basis (P : SectorDecomposition d)
+    (B : (j : Fin P.basisCount) → MPSTensor d (P.basisDim j))
+    (j : Fin P.basisCount) :
+    (P.replaceBasis B).basis j = B j :=
+  rfl
+
+/-- Replacing the representatives leaves every multiplicity coefficient
+$\sum_q \mu_{j,q}^N$ unchanged.
+
+Source: arXiv:1708.00029, equation `eq:bdnr`, lines 286--305, and the pure
+blockwise similarities at lines 313--332. -/
+@[simp]
+theorem replaceBasis_coeff (P : SectorDecomposition d)
+    (B : (j : Fin P.basisCount) → MPSTensor d (P.basisDim j))
+    (N : ℕ) (j : Fin P.basisCount) :
+    (P.replaceBasis B).coeff N j = P.coeff N j :=
+  rfl
+
+/-- Duplicate a representative gauge over every copy of that representative
+in the flattened sector coordinates.
+
+For gauges $X_j$, this is the family whose direct sum is
+$\bigoplus_j (I_{r_j} \otimes X_j)$.
+
+Source: arXiv:1708.00029, equation `eq:bdnr`, lines 286--305, and the
+block-diagonal similarity described at lines 313--332. -/
+private noncomputable def flatGaugeOfBasis (P : SectorDecomposition d)
+    (X : (j : Fin P.basisCount) → GL (Fin (P.basisDim j)) ℂ) :
+    (s : Fin P.totalCopies) → GL (Fin (P.flatDim s)) ℂ :=
+  fun s ↦ by
+    change GL (Fin (P.basisDim (P.flatIndexEquiv.symm s).1)) ℂ
+    exact X (P.flatIndexEquiv.symm s).1
+
+/-- Pure gauges of all representatives assemble to a pure gauge of the full
+multiplicity-bearing tensor, with every multiplicity weight unchanged.
+
+The global gauge is the flattened block diagonal
+$\bigoplus_j (I_{r_j} \otimes X_j)$.  Thus no scalar power is introduced into
+the coefficients $\sum_q \mu_{j,q}^N$.
+
+Source: arXiv:1708.00029, equation `eq:bdnr`, lines 286--305, and the
+block-diagonal similarity at lines 313--332. -/
+theorem gaugeEquiv_toTensor_replaceBasis (P : SectorDecomposition d)
+    (B : (j : Fin P.basisCount) → MPSTensor d (P.basisDim j))
+    (hGauge : ∀ j, GaugeEquiv (P.basis j) (B j)) :
+    GaugeEquiv P.toTensor (P.replaceBasis B).toTensor := by
+  classical
+  choose X hX using hGauge
+  let Xflat := P.flatGaugeOfBasis X
+  have hXflat : ∀ (s : Fin P.totalCopies) (i : Fin d),
+      (P.replaceBasis B).flatBasis s i =
+        (Xflat s : Matrix (Fin (P.flatDim s)) (Fin (P.flatDim s)) ℂ) *
+          P.flatBasis s i *
+          (((Xflat s)⁻¹ : GL (Fin (P.flatDim s)) ℂ) :
+            Matrix (Fin (P.flatDim s)) (Fin (P.flatDim s)) ℂ) := by
+    intro s i
+    change B (P.flatIndexEquiv.symm s).1 i =
+      (X (P.flatIndexEquiv.symm s).1 : Matrix _ _ ℂ) *
+        P.basis (P.flatIndexEquiv.symm s).1 i *
+        (((X (P.flatIndexEquiv.symm s).1)⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)
+    exact hX (P.flatIndexEquiv.symm s).1 i
+  refine ⟨globalGaugeOfBlocks Xflat, ?_⟩
+  change ∀ i : Fin d,
+    toTensorFromBlocks (d := d) (P.flatWeight)
+        (P.replaceBasis B).flatBasis i =
+      (globalGaugeOfBlocks Xflat : Matrix _ _ ℂ) *
+        toTensorFromBlocks (d := d) (P.flatWeight) P.flatBasis i *
+        (((globalGaugeOfBlocks Xflat)⁻¹ : GL _ ℂ) : Matrix _ _ ℂ)
+  exact toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
+    (P.flatWeight) P.flatBasis (P.replaceBasis B).flatBasis Xflat hXflat
+
+/-- A spectrally periodic representative family has a left-canonical periodic
+replacement with the same multiplicities and weights, and the resulting full
+tensor is gauge-equivalent to the original one.
+
+Each representative is normalized by its positive-definite adjoint Perron
+fixed point.  Since its spectral radius is already one, this is a pure
+similarity rather than a scalar rescaling.  Consequently all diagonal entries
+of the multiplicity matrices, and hence all their power-sum coefficients, are
+unchanged.
+
+Source: arXiv:1708.00029, lines 313--332, applied to the multiplicity-bearing
+form `eq:bdnr` at lines 286--305. -/
+theorem exists_isPeriodic_replaceBasis (P : SectorDecomposition d)
+    (period : Fin P.basisCount → ℕ)
+    (hP : ∀ j, IsSpectrallyPeriodic (period j) (P.basis j)) :
+    ∃ B : (j : Fin P.basisCount) → MPSTensor d (P.basisDim j),
+      (∀ j, GaugeEquiv (P.basis j) (B j)) ∧
+      (∀ j, IsPeriodic (period j) (B j)) ∧
+      GaugeEquiv P.toTensor (P.replaceBasis B).toTensor := by
+  classical
+  choose sigma _hsigma _hfixed hGauge hPeriodic using
+    fun j ↦ (hP j).exists_isPeriodic_tpGauge
+  let B : (j : Fin P.basisCount) → MPSTensor d (P.basisDim j) :=
+    fun j ↦ tpGauge (P.basis j) (sigma j)
+  have hGaugeB : ∀ j, GaugeEquiv (P.basis j) (B j) := by
+    intro j
+    simpa [B] using hGauge j
+  have hPeriodicB : ∀ j, IsPeriodic (period j) (B j) := by
+    intro j
+    simpa [B] using hPeriodic j
+  exact ⟨B, hGaugeB, hPeriodicB,
+    P.gaugeEquiv_toTensor_replaceBasis B hGaugeB⟩
+
+end SectorDecomposition
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/SectorNormalization.lean
+++ b/TNLean/MPS/Periodic/SectorNormalization.lean
@@ -77,21 +77,6 @@ theorem replaceBasis_coeff (P : SectorDecomposition d)
     (P.replaceBasis B).coeff N j = P.coeff N j :=
   rfl
 
-/-- Duplicate a representative gauge over every copy of that representative
-in the flattened sector coordinates.
-
-For gauges $X_j$, this is the family whose direct sum is
-$\bigoplus_j (I_{r_j} \otimes X_j)$.
-
-Source: arXiv:1708.00029, equation `eq:bdnr`, lines 286--305, and the
-block-diagonal similarity described at lines 313--332. -/
-private noncomputable def flatGaugeOfBasis (P : SectorDecomposition d)
-    (X : (j : Fin P.basisCount) → GL (Fin (P.basisDim j)) ℂ) :
-    (s : Fin P.totalCopies) → GL (Fin (P.flatDim s)) ℂ :=
-  fun s ↦ by
-    change GL (Fin (P.basisDim (P.flatIndexEquiv.symm s).1)) ℂ
-    exact X (P.flatIndexEquiv.symm s).1
-
 /-- Pure gauges of all representatives assemble to a pure gauge of the full
 multiplicity-bearing tensor, with every multiplicity weight unchanged.
 
@@ -107,7 +92,7 @@ theorem gaugeEquiv_toTensor_replaceBasis (P : SectorDecomposition d)
     GaugeEquiv P.toTensor (P.replaceBasis B).toTensor := by
   classical
   choose X hX using hGauge
-  let Xflat := P.flatGaugeOfBasis X
+  let Xflat := matched_block_gauge (Q := P) X
   have hXflat : ∀ (s : Fin P.totalCopies) (i : Fin d),
       (P.replaceBasis B).flatBasis s i =
         (Xflat s : Matrix (Fin (P.flatDim s)) (Fin (P.flatDim s)) ℂ) *

--- a/TNLean/MPS/SharedInfra/BlockGauge.lean
+++ b/TNLean/MPS/SharedInfra/BlockGauge.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.SharedInfra.BlockAssembly
+import TNLean.MPS.SharedInfra.SectorDecomposition
 
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.Group.Pi.Units
@@ -12,27 +12,31 @@ import Mathlib.LinearAlgebra.UnitaryGroup
 /-!
 # Shared block-diagonal gauge infrastructure
 
-This file factors out the pure-linear-algebra block-diagonal gauge machinery
-used by the block-gauge constructions in the multi-block and BNT fundamental
-theorem arguments.
+This file factors out the shared block-diagonal and sector-coordinate gauge
+machinery used by the multi-block and BNT fundamental theorem arguments and by
+periodic sector normalization.
 
 Exports:
 
 * `blockDiagonalGL` — block-diagonal `GL`-element from a family of invertible
   blocks.
+* `matched_block_gauge` — repetition of a representative gauge over every
+  multiplicity copy in flattened sector coordinates.
 * `globalGaugeOfBlocks` — the reindexed block-diagonal gauge on the flattened
   bond `Fin (∑ k, dim k)` used by `toTensorFromBlocks`.
 * `toTensorFromBlocks_eq_globalGaugeOfBlocks_conj` — direct-sum conjugation
   identity: per-block conjugation lifts to a `globalGaugeOfBlocks`-conjugation
   of `toTensorFromBlocks`.
 
-These declarations are pure linear-algebra intermediate constructions rather
-than statements of the fundamental theorem itself.
+These declarations are shared intermediate constructions rather than
+statements of the fundamental theorem itself.
 
 ## Reference
 
 * arXiv:1606.00608, Corollary II.2 (`eq:II_auxcor`, lines 1172--1178)
   and its block-diagonal gauge construction in lines 1189--1192.
+* arXiv:1708.00029, equation `eq:bdnr`, lines 286--305, and the sectorwise
+  normalization similarities at lines 313--332.
 -/
 
 open scoped Matrix BigOperators
@@ -40,6 +44,23 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d : ℕ}
+
+/-! ## Repetition over sector copies -/
+
+/-- Duplicate each representative gauge over all its multiplicity copies in
+flattened sector coordinates.
+
+For gauges $X_j$, applying `globalGaugeOfBlocks` to this family gives
+$\bigoplus_j (I_{r_j} \otimes X_j)$.
+
+Sources: arXiv:1606.00608, Appendix MPV proof, line 1191; arXiv:1708.00029,
+equation `eq:bdnr`, lines 286--305, and the blockwise similarities at
+lines 313--332. -/
+noncomputable def matched_block_gauge {Q : SectorDecomposition d}
+    (Xblock : (k : Fin Q.basisCount) → GL (Fin (Q.basisDim k)) ℂ) :
+    (s : Fin Q.totalCopies) → GL (Fin (Q.flatDim s)) ℂ := fun s => by
+  change GL (Fin (Q.basisDim (Q.flatIndexEquiv.symm s).1)) ℂ
+  exact Xblock (Q.flatIndexEquiv.symm s).1
 
 /-! ## Block-diagonal invertible matrices -/
 

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -116,6 +116,80 @@
     preserves the prescribed set of $m$-th roots of unity.
 \end{proof}
 
+\begin{definition}[Replacement of the representative family]
+    \label{def:periodic_sector_basis_replacement}
+    \lean{MPSTensor.SectorDecomposition.replaceBasis}
+    \lean{MPSTensor.SectorDecomposition.replaceBasis_basis}
+    \lean{MPSTensor.SectorDecomposition.replaceBasis_coeff}
+    \leanok
+    Let
+    \begin{align}
+        A^i&=\bigoplus_{j\in J}(R_j\otimes A_j^i)
+        \notag
+    \end{align}
+    be a multiplicity-bearing sector decomposition.  For tensors $B_j$ with
+    the same bond dimension as $A_j$, its representative replacement is
+    \begin{align}
+        A_B^i&=\bigoplus_{j\in J}(R_j\otimes B_j^i).
+        \notag
+    \end{align}
+    Thus the index set, bond dimensions, multiplicities, and every entry of
+    the diagonal matrices $R_j$ remain unchanged.  In particular, for every
+    length $N$ and every representative $j$, the grouped coefficient remains
+    \begin{align}
+        \operatorname{tr}(R_j^N)&=\sum_q\mu_{j,q}^N.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Assembly of representative similarities]
+    \label{thm:periodic_sector_basis_replacement_gauge}
+    \lean{MPSTensor.SectorDecomposition.gaugeEquiv_toTensor_replaceBasis}
+    \leanok
+    \uses{def:periodic_sector_basis_replacement}
+    Suppose that, for every $j\in J$, there is an invertible matrix $X_j$
+    such that
+    \begin{align}
+        B_j^i&=X_jA_j^iX_j^{-1}.
+        \notag
+    \end{align}
+    Then the two multiplicity-bearing tensors are related by the pure
+    similarity
+    \begin{align}
+        A_B^i&=XA^iX^{-1},&
+        X&=\bigoplus_{j\in J}(I_{r_j}\otimes X_j).
+        \notag
+    \end{align}
+\end{theorem}
+\begin{proof}
+    \uses{lem:tensor_from_blocks_globalGauge_conj}
+    \leanok
+    Repeat $X_j$ on every copy indexed by a diagonal entry of $R_j$, and take
+    their block-diagonal direct sum.  On the $(j,q)$ block, conjugation by
+    this matrix sends $\mu_{j,q}A_j^i$ to $\mu_{j,q}B_j^i$.
+\end{proof}
+
+\begin{theorem}[Sectorwise Perron normalization]
+    \label{thm:spectral_periodic_sector_normalization}
+    \lean{MPSTensor.SectorDecomposition.exists_isPeriodic_replaceBasis}
+    \leanok
+    \uses{def:spectral_periodic_tensor, def:periodic_sector_basis_replacement,
+        def:periodic_tensor}
+    Suppose every representative $A_j$ is spectrally $m_j$-periodic.  There
+    are left-canonical $m_j$-periodic representatives $B_j$, each purely
+    similar to $A_j$, such that the two full multiplicity-bearing tensors are
+    purely similar.  Every multiplicity matrix $R_j$ is unchanged.
+\end{theorem}
+\begin{proof}
+    \uses{thm:spectral_periodic_normalization,
+        thm:periodic_sector_basis_replacement_gauge}
+    \leanok
+    Apply the positive Perron gauge separately to every representative and
+    assemble these gauges with
+    Theorem~\ref{thm:periodic_sector_basis_replacement_gauge}.  Since every
+    spectral radius is already one, no representative is rescaled.
+\end{proof}
+
 \begin{theorem}[A periodic tensor has positive bond dimension]
     \label{thm:periodic_bond_dimension_pos}
     \lean{MPSTensor.IsPeriodic.bondDim_ne_zero}

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -162,7 +162,8 @@
     \end{align}
 \end{theorem}
 \begin{proof}
-    \uses{lem:tensor_from_blocks_globalGauge_conj}
+    \uses{def:ft_matched_flat_data,
+        lem:tensor_from_blocks_globalGauge_conj}
     \leanok
     Repeat $X_j$ on every copy indexed by a diagonal entry of $R_j$, and take
     their block-diagonal direct sum.  On the $(j,q)$ block, conjugation by

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -426,6 +426,37 @@
     repeated blocks, and transitivity gives the claim.
 \end{proof}
 
+\begin{lemma}[A pure similarity is a repeated-block relation]
+    \label{lem:pure_gauge_het_repeated_blocks}
+    \lean{MPSTensor.GaugeEquiv.toHetRepeatedBlocks}
+    \leanok
+    If $B^i=XA^iX^{-1}$ for an invertible matrix $X$, then $A$ and $B$ are
+    repeated blocks with equal bond dimension and unit phase.
+\end{lemma}
+\begin{proof}\leanok
+    Invert the pure gauge and take the repeated-block phase to be one.
+\end{proof}
+
+\begin{lemma}[Pure similarities preserve periodic overlap hypotheses]
+    \label{lem:periodic_overlap_hypothesis_gauge_transport}
+    \lean{MPSTensor.PeriodicOverlapHypothesis.of_gaugeEquiv}
+    \leanok
+    Let $\{A_j\}_{j\in J}$ and $\{B_k\}_{k\in K}$ be finite tensor
+    families, and suppose that $A_j'$ is purely similar to $A_j$ and $B_k'$ is
+    purely similar to $B_k$ for every $j,k$.  Assume that every tensor in each
+    primed family has a non-decaying mixed-overlap partner in the other primed
+    family, and that every non-decaying primed pair is a repeated pair.  Then
+    the same three assertions hold for the two original families.
+\end{lemma}
+\begin{proof}
+    \uses{lem:pure_gauge_het_repeated_blocks, thm:gauge_invariance}
+    \leanok
+    Cyclicity of the trace makes every closed-chain coefficient, and hence
+    every mixed overlap, invariant under the two similarities.  Thus decay and
+    non-decay are unchanged.  For a non-decaying pair, compose its primed
+    repeated-block relation with the two pure similarities.
+\end{proof}
+
 \begin{theorem}[Non-decaying mixed overlaps for normalized bases of periodic
     tensors]
     \label{thm:periodic_multiplicity_nondecaying_overlap}
@@ -465,7 +496,7 @@
         \notag
     \end{align}
 
-    \emph{Scope restriction.} The source initially assumes that the transfer
+    \emph{Normalization boundary.} The source initially assumes that the transfer
     maps of the basis tensors are irreducible and have spectral radius one,
     and then obtains the trace-preserving normalization by a block-diagonal
     similarity
@@ -474,11 +505,11 @@
     otherwise arbitrary diagonal matrices with nonzero complex entries, the
     displayed direct sums are literal, and proportionality is assumed only at
     positive lengths.  Theorem~\ref{thm:spectral_periodic_normalization}
-    constructs each normalizing similarity.  Applying these similarities to
-    the whole sector decomposition and transporting the conclusion back remain
-    to be proved before this result applies to the unnormalized source
-    statement.  This remaining distinction is recorded in
-    \path{docs/paper-gaps/1708_periodic_overlap_route_alignment.tex}.
+    constructs each normalizing similarity, while
+    Theorem~\ref{thm:spectral_periodic_sector_normalization} assembles them
+    without changing the multiplicity matrices.  Theorem~\ref{thm:%
+        periodic_spectral_multiplicity_nondecaying_overlap} below applies the
+    present result and returns its conclusion to the unnormalized blocks.
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:finite_coefficient_isolation,
@@ -523,6 +554,49 @@
     conjugate symmetry of the mixed overlap gives the converse assertion. For
     any non-decaying pair, the periodic overlap dichotomy excludes its decay
     alternative and supplies the repeated-block relation.
+\end{proof}
+
+\begin{theorem}[Non-decaying mixed overlaps for spectrally periodic bases]
+    \label{thm:periodic_spectral_multiplicity_nondecaying_overlap}
+    \lean{MPSTensor.PeriodicOverlapHypothesis.%
+        ofSpectrallyPeriodicSectorDecompositions}
+    \leanok
+    \uses{def:nonzero_proportional_mpv, def:spectral_periodic_tensor}
+    Let
+    \begin{align}
+        A^i&=\bigoplus_{j\in J}(R_j\otimes A_j^i),&
+        B^i&=\bigoplus_{k\in K}(S_k\otimes B_k^i),
+        \notag
+    \end{align}
+    where the diagonal entries of every $R_j$ and $S_k$ are nonzero.  Suppose
+    that the two representative families are pairwise non-repeated.  Assign
+    positive integers $m_j$ and $n_k$ to their representatives, and suppose
+    that every transfer map is irreducible, has spectral radius one, and has
+    peripheral spectrum respectively
+    $\{z\in\C:z^{m_j}=1\}$ or $\{z\in\C:z^{n_k}=1\}$.  If, for every positive
+    $N$, there is a scalar $c_N\ne0$ such that
+    \begin{align}
+        \ket{V^{(N)}(A)}&=c_N\ket{V^{(N)}(B)},
+        \notag
+    \end{align}
+    then every representative in either family has a representative in the
+    other family whose mixed overlap does not tend to zero.  Every such pair
+    has equal bond dimension and differs by an invertible similarity and a
+    unit-modulus scalar.
+\end{theorem}
+\begin{proof}
+    \uses{lem:periodic_overlap_hypothesis_gauge_transport,
+        lem:pure_gauge_het_repeated_blocks, thm:gauge_invariance,
+        thm:periodic_multiplicity_nondecaying_overlap,
+        thm:spectral_periodic_sector_normalization}
+    \leanok
+    Normalize all representatives by their pure Perron gauges and assemble
+    the gauges block diagonally.  The multiplicity matrices and their grouped
+    coefficients remain unchanged.  Pure similarity preserves the total
+    positive-length proportionality and pairwise non-repetition, so
+    Theorem~\ref{thm:periodic_multiplicity_nondecaying_overlap} applies to the
+    normalized families.  Finally apply
+    Lemma~\ref{lem:periodic_overlap_hypothesis_gauge_transport}.
 \end{proof}
 
 \begin{theorem}[Scalar-weight specialization of the mixed-overlap theorem]
@@ -588,8 +662,10 @@
 
     The theorem relates the two bases of periodic tensors but makes no
     assertion relating their multiplicity matrices.
-    % Formalization status: the normalized multiplicity-bearing theorem above
-    % proves the overlap step after the source's Perron similarity. Applying
-    % these similarities sectorwise and transporting back remains tracked in
-    % issue #5342.
+    % Formalization status: the spectrally periodic multiplicity-bearing
+    % theorem above proves the complete overlap-hypothesis step for literal
+    % irreducible forms.  A source-labelled theorem retaining equality of the
+    % matched periods is still required before this exact statement can be
+    % marked ready.  Extension from arbitrary tensors through Proposition 2.1
+    % is a separate positive-length representative question.
 \end{theorem}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -94,7 +94,11 @@ is deliberately source-faithful.
 - **Sanctioned bridge:**
   `MPSTensor.IsSpectrallyPeriodic.exists_isPeriodic_tpGauge` in
   `TNLean/MPS/Periodic/Normalization.lean` gives a pure-similarity
-  trace-preserving representative.
+  trace-preserving representative. For a multiplicity-bearing sector
+  decomposition, `MPSTensor.SectorDecomposition.exists_isPeriodic_replaceBasis`
+  applies these gauges simultaneously and leaves all multiplicities and weights
+  unchanged; `PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions`
+  is the corresponding overlap-hypothesis bridge.
 - **Caveat:** general invertible similarities do not preserve
   left-canonicality. The bridge is therefore one-way into `IsPeriodic`, not an
   equivalence between the two predicates.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -97,7 +97,8 @@ is deliberately source-faithful.
   trace-preserving representative. For a multiplicity-bearing sector
   decomposition, `MPSTensor.SectorDecomposition.exists_isPeriodic_replaceBasis`
   applies these gauges simultaneously and leaves all multiplicities and weights
-  unchanged; `PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions`
+  unchanged;
+  `MPSTensor.PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions`
   is the corresponding overlap-hypothesis bridge.
 - **Caveat:** general invertible similarities do not preserve
   left-canonicality. The bridge is therefore one-way into `IsPeriodic`, not an

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -288,7 +288,7 @@ lemma is not used. Restoring the spanning clause and routing through
 half is formalized; no unrestricted spanning assertion is presently attributed
 to the source consequence.
 
-\section{Normalized multiplicity theorem and remaining transport restriction}
+\section{Multiplicity-bearing overlap theorem and Perron transport}
 
 \textbf{Source.}\footnote{\cite{DeLasCuevas2017Irreducible}, equations
 \emph{bdnr} and \emph{Bbdnr}, lines 286--305 and 575--585; the normalization
@@ -350,33 +350,53 @@ is preserved by similarity.  Thus this normalization leaves every
 matrix-product vector unchanged and introduces no extra power into the
 multiplicity coefficients.
 
-\textbf{Remaining sectorwise transport restriction.} The normalized overlap
-theorem still takes a literal sector decomposition whose basis blocks already
-satisfy \path{IsPeriodic}.  The formal development does not yet replace every
-basis block by its Perron representative inside a new sector decomposition,
-assemble the individual similarities into a block-diagonal gauge, or transport
-the overlap hypothesis back to the original basis.  Applying the theorem to an
-arbitrary original tensor through a lower-dimensional representative also
-requires a positive-length transport statement of the kind allowed at
-lines~266--271.
+\textbf{Sectorwise normalization and return to the original blocks.} The
+declaration \path{SectorDecomposition.replaceBasis} changes only the
+representative tensors, keeping their index set, bond dimensions,
+multiplicities, and weights fixed.  If $X_j$ is the pure Perron gauge of the
+$j$th representative, then
+\path{SectorDecomposition.gaugeEquiv_toTensor_replaceBasis} assembles the
+global gauge
+\begin{align}
+  X&=\bigoplus_j(I_{r_j}\otimes X_j).
+\end{align}
+Consequently each block $\mu_{j,q}A_j^i$ is sent to
+$\mu_{j,q}X_jA_j^iX_j^{-1}$, with no change to $\mu_{j,q}$.
+The declaration \path{SectorDecomposition.exists_isPeriodic_replaceBasis}
+applies this construction simultaneously to every spectrally periodic
+representative.
+
+Pure similarities preserve all closed-chain coefficients, so they preserve
+every mixed overlap exactly.  The declaration
+\path{PeriodicOverlapHypothesis.of_gaugeEquiv} uses this equality to preserve
+decay and non-decay, and composes the pure gauges with any repeated-block
+relation obtained after normalization.  Pairwise non-repetition is preserved
+by the same transitivity argument.  Finally,
+\path{PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions}
+normalizes both literal multiplicity-bearing decompositions, transports their
+positive-length proportionality to the normalized tensors, applies the
+normalized multiplicity theorem, and returns the complete periodic-overlap
+hypothesis to the original spectral-radius-one blocks.  This completes the
+overlap-hypothesis step tracked by issue~\#5342.
 
 The declarations \leanid{fundamentalTheorem_periodic_proportional} and
 \leanid{fundamentalTheorem_periodic_proportional_of_isPeriodic} begin after
 this step: they accept the periodic-overlap hypothesis, or its non-decaying
 partner fields, as premises and prove the resulting finite block matching.
-Together with the new normalized overlap theorem they give the block matching for
-literal normalized irreducible forms.  The source theorem itself remains
-unformalized until the preceding sectorwise transport step is proved;
-the exact source-labelled blueprint statement must therefore remain
-\emph{not ready}.
+Together with the spectrally periodic multiplicity theorem they give the block
+matching for literal irreducible forms.  The exact source-labelled theorem
+remains \emph{not ready}, however, because the existing matching conclusion
+does not explicitly retain equality of the matched periods.  This is the
+remaining gap intrinsic to Theorem~3.4 at lines~613--632.  Separately,
+extending the irreducible-form theorem to arbitrary input tensors through
+Proposition~2.1 requires the positive-length, possibly lower-dimensional
+comparison at lines~266--271; that extension is not part of Theorem~3.4.
 
-\textbf{Elimination plan.} Apply the pure Perron normalization to every basis
-block and assemble the block gauges while leaving all multiplicity entries
-unchanged.  Prove invariance of proportional positive-length MPVs, overlap
-decay, pairwise non-repetition, and the final repeated-block relation under
-these similarities.  A separate positive-length representative
-transport then covers the source-allowed lower-dimensional representative.
-The remaining sectorwise transport work is tracked by
+\textbf{Remaining elimination plan.} Combine the spectrally periodic overlap
+theorem with the finite matching argument in a source-labelled statement that
+retains equality of matched periods.  For the separate extension beyond
+Theorem~3.4, prove the positive-length comparison with the representative from
+Proposition~2.1.  The completed overlap-hypothesis step is tracked by
 \href{https://github.com/LionSR/TNLean/issues/5342}{issue \#5342}; the subsequent
 multiplicity-power extraction is tracked by
 \href{https://github.com/LionSR/TNLean/issues/5344}{issue \#5344}.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,21 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### pure gauge to heterogeneous repeated blocks — promoted
+- **Pattern:** convert `GaugeEquiv A B` to `HetRepeatedBlocks A B` by passing
+  through `EquivalentBlocks`, choosing unit phase, and embedding the
+  equal-dimension repeated-block relation.
+- **Seen:** four occurrences across
+  `TNLean/MPS/Periodic/FundamentalTheorem.lean` and
+  `TNLean/MPS/Periodic/ProportionalOverlap.lean` in the sectorwise-normalization
+  draft (2026-08-02).
+- **Abstraction:** `MPSTensor.GaugeEquiv.toHetRepeatedBlocks` in
+  `TNLean/MPS/Periodic/FundamentalTheorem.lean`.
+- **Notes:** the lemma fixes the otherwise easy-to-reverse orientation between
+  pure gauges and `RepeatedBlocks`, while `HetRepeatedBlocks.trans` absorbs all
+  bond-dimension casts. It replaces four explicit conversion chains with
+  one-line calls; the source delta is four added lines after documentation.
+
 ### spectral-radius-one matrix dimension — promoted
 - **Pattern:** exclude zero matrix dimension by observing that every
   endomorphism of the zero-dimensional square-matrix space has spectral radius


### PR DESCRIPTION
## Summary

- add representative replacement for a multiplicity-bearing sector decomposition,
  leaving bond dimensions, multiplicities, weights, and grouped coefficients unchanged;
- repeat each representative Perron gauge over all multiplicity copies and assemble the
  pure global similarity
  \(\bigoplus_j (I_{r_j}\otimes X_j)\);
- prove that pure similarities transport the complete periodic overlap hypothesis,
  preserving every mixed overlap exactly and composing the resulting repeated-block
  relations;
- derive `PeriodicOverlapHypothesis` directly from source-shaped
  `NonzeroProportionalMPV₂` for literal spectrally periodic decompositions; and
- update the Blueprint, glossary, paper-gap account, and promoted proof-pattern ledger.

## Source-faithfulness boundary

The new spectral wrapper performs the sectorwise Perron normalization prescribed in
arXiv:1708.00029, lines 313--332, applies the normalized multiplicity-bearing overlap
theorem, and transports the conclusion back to the original spectral-radius-one
representatives. Since every gauge is a pure similarity, no scalar power is introduced
into \(\operatorname{tr}(R_j^N)\) or \(\operatorname{tr}(S_k^N)\).

This completes the overlap-hypothesis target of issue #5342. It does not mark the exact
source Theorem 3.4 as formalized: a combined source-labelled matching theorem must still
retain equality of matched periods. The lower-dimensional representative extension from
arbitrary tensors belongs separately to Proposition 2.1.

## Validation

- `lake build TNLean.MPS.Periodic.ProportionalOverlap`
- `lake build TNLean` using the existing warm incremental build artifacts
- `lake exe lint_style`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- changed-declaration reverse Blueprint coverage
- `leanblueprint checkdecls`
- proof-integrity scan for prohibited declarations and kernel bypasses
- `git diff --check`

Closes #5342

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core periodic FT overlap and gauge transport on sector decompositions; proofs are largely compositional, but mistakes in MPV or overlap invariance would undermine downstream matching toward Theorem 3.4.
> 
> **Overview**
> Adds **sectorwise Perron normalization** for multiplicity-bearing decompositions: `SectorDecomposition.replaceBasis` swaps representatives while keeping multiplicities and grouped coefficients fixed; per-block pure gauges assemble to a global similarity ⊕_j (I_{r_j} ⊗ X_j) via `gaugeEquiv_toTensor_replaceBasis` and `exists_isPeriodic_replaceBasis`. `matched_block_gauge` moves to shared `BlockGauge.lean` for BNT and periodic use.
> 
> **Overlap transport:** `GaugeEquiv.toHetRepeatedBlocks` and `PeriodicOverlapHypothesis.of_gaugeEquiv` show pure similarities preserve mixed overlaps and repeated-block conclusions. `PeriodicOverlapHypothesis.ofSpectrallyPeriodicSectorDecompositions` normalizes spectrally periodic blocks, applies the existing normalized overlap theorem, and pulls the hypothesis back to the original representatives—closing the overlap-hypothesis step for issue #5342.
> 
> Blueprint, glossary, paper-gap notes, and tactic-pattern ledger are updated; a source-labelled theorem that also matches periods remains outstanding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f20d7981d6972f54de7b225df172841f249c46d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->