### PR TITLE
fix(tenkz): harden RMP dimension ownership

### DIFF
--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -717,7 +717,13 @@ def _option_spans(
     """Find public option containers without joining split control words."""
     spans: list[_OwnerSpan] = []
     for container in _environment_tokens(source, owner_source):
-        if container.kind != "begin" or container.name not in _OPTION_ENVIRONMENT_KEYS:
+        if (
+            container.kind != "begin"
+            or (
+                container.name is not None
+                and container.name not in _PUBLIC_ENVIRONMENTS
+            )
+        ):
             continue
         position = _skip_space(owner_source, container.end)
         if owner_source[position : position + 1] != "[":
@@ -725,6 +731,8 @@ def _option_spans(
         closed = match_group(owner_source, position, "[", "]")
         if closed < 0:
             spans.append(_OwnerSpan(container.start, len(source), None, True))
+            continue
+        if container.name not in _OPTION_ENVIRONMENT_KEYS:
             continue
         spans.extend(
             _option_group_spans(

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -212,11 +212,19 @@ class _EnvironmentToken:
 
 
 _PUBLIC_ENVIRONMENTS = frozenset((*_OPTION_ENVIRONMENT_KEYS, "tenkzeq"))
-_TEX_CONTROL_WORD_END = r"(?![A-Za-z])"
+# A source-only scan cannot recover arbitrary catcode changes.  Treat Unicode
+# letters plus LaTeX/expl3's conventional ``@``, ``:``, and ``_`` letters as
+# one conservative control-word alphabet: refusing to split an ambiguous
+# spelling is safer than assigning dimensions to a shorter public command.
+_STATIC_CONTROL_WORD_NAME_RE = re.compile(r"(?:[^\W\d_]|[@:_])+")
+_TEX_CONTROL_WORD_END = r"(?![^\W\d_]|[@:_])"
 _ENVIRONMENT_CONTROL_RE = re.compile(
     r"\\(begin|end)" + _TEX_CONTROL_WORD_END
 )
 _ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z@:_][A-Za-z0-9@:_*.-]*")
+_CSNAME_SPACE_RE = re.compile(r"\\space" + _TEX_CONTROL_WORD_END)
+
+
 @dataclass(frozen=True)
 class _OptionCommandGrammar:
     """Physical keys accepted by one bracket-option command."""
@@ -340,6 +348,36 @@ def _is_control_word_start(source: str, position: int) -> bool:
     return run_length % 2 == 1
 
 
+def _is_static_control_word_letter(character: str) -> bool:
+    """Recognize a conservative letter across common LaTeX catcode modes."""
+    return _STATIC_CONTROL_WORD_NAME_RE.fullmatch(character) is not None
+
+
+def _control_sequence_name(source: str) -> str | None:
+    """Return one literal control-sequence token, if ``source`` is exactly one."""
+    if len(source) < 2 or source[0] != "\\":
+        return None
+    name = source[1:]
+    if _is_static_control_word_letter(name[0]):
+        if all(_is_static_control_word_letter(character) for character in name):
+            return name
+        return None
+    return name if len(name) == 1 else None
+
+
+def _csname_spelling(source: str, *, expand_space: bool) -> str:
+    """Normalize the statically reproducible part of a ``\\csname`` spelling.
+
+    Environment dispatch expands its token-list argument, so canonical
+    ``\\space`` tokens become ordinary spaces before ``\\csname`` ignores
+    them.  Kernel declaration names are first stringified with
+    ``\\tl_to_str:n`` and therefore request whitespace removal only.
+    """
+    if expand_space:
+        source = _CSNAME_SPACE_RE.sub(" ", source)
+    return re.sub(r"\s+", "", _active_source(source).text)
+
+
 def _following_mandatory_arguments(
     source: str, position: int, count: int
 ) -> list[_MandatoryArgument] | None:
@@ -360,8 +398,10 @@ def _following_mandatory_arguments(
             if position + 1 >= len(source):
                 return None
             token_end = position + 2
-            if source[position + 1].isalpha():
-                while token_end < len(source) and source[token_end].isalpha():
+            if _is_static_control_word_letter(source[position + 1]):
+                while token_end < len(source) and _is_static_control_word_letter(
+                    source[token_end]
+                ):
                     token_end += 1
             argument = _MandatoryArgument(position, token_end, token_end)
         else:
@@ -435,9 +475,9 @@ def _declared_atom_commands(
         name_source = owner_source[
             arguments[0].content_start : arguments[0].content_end
         ].strip()
-        name_match = re.fullmatch(r"\\([A-Za-z]+)", name_source)
-        if name_match is not None:
-            names.add(name_match.group(1))
+        name = _control_sequence_name(name_source)
+        if name is not None:
+            names.add(name)
     for declaration in _KERNEL_DECLARE_RE.finditer(owner_source):
         if not _is_control_word_start(owner_source, declaration.start()):
             continue
@@ -453,14 +493,18 @@ def _declared_atom_commands(
         ).text.strip()
         if class_name != "atom":
             continue
-        command_name = _active_source(
+        command_name = _csname_spelling(
             source[
                 arguments[1].content_start : arguments[1].content_end
-            ]
-        ).text.strip()
+            ],
+            expand_space=False,
+        ).strip()
         if command_name.startswith("\\"):
             command_name = command_name[1:]
-        if re.fullmatch(r"[A-Za-z]+", command_name) is not None:
+        if (
+            _STATIC_CONTROL_WORD_NAME_RE.fullmatch(command_name) is not None
+            or len(command_name) == 1
+        ):
             names.add(command_name)
     return frozenset(names)
 
@@ -480,32 +524,47 @@ def _command_spans(
         )
     pattern = re.compile(
         r"\\("
-        + "|".join(sorted(grammars, key=len, reverse=True))
+        + "|".join(
+            re.escape(name)
+            + (
+                _TEX_CONTROL_WORD_END
+                if _STATIC_CONTROL_WORD_NAME_RE.fullmatch(name) is not None
+                else ""
+            )
+            for name in sorted(grammars, key=len, reverse=True)
+        )
         + r")"
-        + _TEX_CONTROL_WORD_END
     )
     for command in pattern.finditer(source):
         if not _is_control_word_start(source, command.start()):
             continue
-        grammar = grammars[command.group(1)]
+        name = command.group(1)
+        grammar = grammars[name]
         position = _skip_space(source, command.end())
-        if grammar.accepts_star and source[position : position + 1] == "*":
-            position = _skip_space(source, position + 1)
-        if grammar.accepts_options and source[position : position + 1] == "[":
-            closed = match_group(source, position, "[", "]")
-            if closed < 0:
-                continue
-            position = _skip_space(source, closed)
-        if command.group(1) in dynamic_names:
+        if name in dynamic_names:
             # The declaration may have collided with a command of unknown
-            # arity.  Quarantine every adjacent braced argument rather than
-            # guessing the successful atom command's one-argument grammar.
-            while source[position : position + 1] == "{":
-                closed = match_group(source, position, "{", "}")
+            # signature.  Quarantine every adjacent syntactic argument rather
+            # than guessing how many stars, options, or groups it accepts.
+            while position < len(source):
+                character = source[position : position + 1]
+                if character == "*":
+                    position = _skip_space(source, position + 1)
+                    continue
+                if character not in "[{":
+                    break
+                closer = "]" if character == "[" else "}"
+                closed = match_group(source, position, character, closer)
                 if closed < 0:
                     break
                 position = _skip_space(source, closed)
         else:
+            if grammar.accepts_star and source[position : position + 1] == "*":
+                position = _skip_space(source, position + 1)
+            if grammar.accepts_options and source[position : position + 1] == "[":
+                closed = match_group(source, position, "[", "]")
+                if closed < 0:
+                    continue
+                position = _skip_space(source, closed)
             for _ in range(max(grammar.positional_group_counts)):
                 if source[position : position + 1] != "{":
                     break
@@ -596,10 +655,11 @@ def _environment_tokens(
         closed = match_group(owner_source, position, "{", "}")
         if closed < 0:
             continue
-        active_name = _active_source(source[position + 1 : closed - 1]).text
-        # LaTeX dispatches environments through ``\csname``, which ignores
-        # ordinary spaces while constructing the control-sequence name.
-        name = re.sub(r"\s+", "", active_name)
+        # LaTeX dispatch expands the name in ``\csname``; model the canonical
+        # expandable space token as well as ordinary ignored whitespace.
+        name = _csname_spelling(
+            source[position + 1 : closed - 1], expand_space=True
+        )
         if _ENVIRONMENT_NAME_RE.fullmatch(name) is None:
             continue
         tokens.append(

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -545,6 +545,7 @@ def _command_spans(
             continue
         name = command.group(1)
         grammar = grammars[name]
+        span_owner = grammar.owner
         position = _skip_space(source, command.end())
         if name in dynamic_names:
             # The declaration may have collided with a command of unknown
@@ -560,6 +561,11 @@ def _command_spans(
                 closer = "]" if character == "[" else "}"
                 closed = match_group(source, position, character, closer)
                 if closed < 0:
+                    # A malformed adjacent argument has no trustworthy end.
+                    # Quarantine the remainder rather than exposing it to an
+                    # enclosing owner through a guessed command boundary.
+                    position = len(source)
+                    span_owner = None
                     break
                 position = _skip_space(source, closed)
         else:
@@ -568,18 +574,22 @@ def _command_spans(
             if grammar.accepts_options and source[position : position + 1] == "[":
                 closed = match_group(source, position, "[", "]")
                 if closed < 0:
-                    continue
-                position = _skip_space(source, closed)
+                    position = len(source)
+                    span_owner = None
+                else:
+                    position = _skip_space(source, closed)
             for _ in range(max(grammar.positional_group_counts)):
                 if source[position : position + 1] != "{":
                     break
                 closed = match_group(source, position, "{", "}")
                 if closed < 0:
+                    position = len(source)
+                    span_owner = None
                     break
                 position = _skip_space(source, closed)
         spans.append(
             _OwnerSpan(
-                command.start(), position, grammar.owner
+                command.start(), position, span_owner
             )
         )
     return spans

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -217,11 +217,6 @@ _ENVIRONMENT_CONTROL_RE = re.compile(
     r"\\(begin|end)" + _TEX_CONTROL_WORD_END
 )
 _ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z@:_][A-Za-z0-9@:_*.-]*")
-_EXPLICIT_GROUP_RE = re.compile(
-    r"\\(begingroup|endgroup|bgroup|egroup)" + _TEX_CONTROL_WORD_END
-)
-
-
 @dataclass(frozen=True)
 class _OptionCommandGrammar:
     """Physical keys accepted by one bracket-option command."""
@@ -254,16 +249,6 @@ _OPTION_BRACE_COMMAND_RE = re.compile(r"\\tnset" + _TEX_CONTROL_WORD_END)
 _SETUP_PHYSICAL_KEYS = frozenset({"pitch"})
 _DECLARE_ATOM_RE = re.compile(r"\\tndeclareatom" + _TEX_CONTROL_WORD_END)
 _KERNEL_DECLARE_RE = re.compile(r"\\tndeclare" + _TEX_CONTROL_WORD_END)
-_DECLARE_ATOM_SKINS = frozenset({"dot", "box", "pill", "mpo"})
-_DECLARE_ATOM_PHYSICAL_KEYS = frozenset({"label shift"})
-# A static source scan cannot reproduce TeX's complete ``\cs_if_exist`` state.
-# Activate only the tenkz extension namespace; arbitrary spellings remain
-# neutral barriers, so a collision with a format or package command cannot
-# acquire physical ownership.  The public examples use this namespace.
-_DYNAMIC_ATOM_NAME_RE = re.compile(r"tn[A-Za-z]+")
-_DECLARE_ATOM_PORT_RE = re.compile(
-    r"(?:west|east):virtual|(?:up|down):physical"
-)
 
 
 def _validate_physical_option_key_sets() -> None:
@@ -272,7 +257,6 @@ def _validate_physical_option_key_sets() -> None:
         *_OPTION_ENVIRONMENT_KEYS.values(),
         *(grammar.physical_keys for grammar in _OPTION_BRACKET_COMMANDS.values()),
         _SETUP_PHYSICAL_KEYS,
-        _DECLARE_ATOM_PHYSICAL_KEYS,
     ]
     unknown = set().union(*key_sets).difference(_PHYSICAL_OPTION_KEY_OWNERS)
     if unknown:
@@ -290,34 +274,6 @@ class _OwnerSpan:
     start: int
     end: int
     owner: DimensionOwner | None
-
-
-@dataclass(frozen=True)
-class _DeclaredCommand:
-    """One valid dynamic atom binding over its TeX lexical scope."""
-
-    name: str
-    start: int
-    end: int
-    physical_keys: frozenset[str]
-
-
-@dataclass(frozen=True)
-class _DeclarationCandidate:
-    """A parsed declaration before collision and duplicate checks."""
-
-    name: str
-    declaration_start: int
-    binding_start: int
-    physical_keys: frozenset[str]
-
-
-@dataclass(frozen=True)
-class _DynamicCommands:
-    """Known dynamic spellings and the declarations that actually bind them."""
-
-    names: frozenset[str]
-    bindings: tuple[_DeclaredCommand, ...]
 
 
 @dataclass(frozen=True)
@@ -438,63 +394,6 @@ def _top_level_comma_segments(source: str) -> list[tuple[int, int]]:
     return segments
 
 
-def _literal_option_value(value: str) -> str | None:
-    """Remove one complete outer brace group from a literal PGF value."""
-    value = value.strip()
-    if not value.startswith("{"):
-        return value
-    closed = match_group(value, 0, "{", "}")
-    if closed != len(value):
-        return None
-    return value[1:-1].strip()
-
-
-def _valid_compatibility_atom_descriptor(source: str) -> bool:
-    """Whether a literal descriptor creates a public compatibility atom."""
-    for start, end in _top_level_comma_segments(source):
-        segment = source[start:end].strip()
-        if not segment:
-            continue
-        key, separator, raw_value = segment.partition("=")
-        if not separator:
-            return False
-        value = _literal_option_value(raw_value)
-        if value is None:
-            return False
-        key = key.strip()
-        if key == "skin":
-            if value not in _DECLARE_ATOM_SKINS:
-                return False
-        elif key == "ports":
-            if value and any(
-                _DECLARE_ATOM_PORT_RE.fullmatch(port.strip()) is None
-                for port in value.split(",")
-            ):
-                return False
-        else:
-            return False
-    return True
-
-
-def _brace_scope_spans(source: str) -> list[tuple[int, int]]:
-    """Return conservative lexical scopes delimited by unescaped braces."""
-    openings: list[int] = []
-    spans: list[tuple[int, int]] = []
-    index = 0
-    while index < len(source):
-        character = source[index]
-        if character == "\\":
-            index += 2
-            continue
-        if character == "{":
-            openings.append(index)
-        elif character == "}" and openings:
-            spans.append((openings.pop(), index + 1))
-        index += 1
-    spans.extend((opening, len(source)) for opening in openings)
-    return spans
-
-
 def _environment_scope_spans(
     tokens: Iterable[_EnvironmentToken],
     names: frozenset[str] | None = None,
@@ -515,46 +414,15 @@ def _environment_scope_spans(
     return spans
 
 
-def _explicit_group_scope_spans(source: str) -> list[tuple[int, int]]:
-    """Return scopes made with TeX's word and control-symbol group aliases."""
-    openings: dict[str, list[int]] = {"word": [], "alias": []}
-    spans: list[tuple[int, int]] = []
-    group_kinds = {
-        "begingroup": ("word", True),
-        "endgroup": ("word", False),
-        "bgroup": ("alias", True),
-        "egroup": ("alias", False),
-    }
-    for token in _EXPLICIT_GROUP_RE.finditer(source):
-        if not _is_control_word_start(source, token.start()):
-            continue
-        group_kind, is_opening = group_kinds[token.group(1)]
-        if is_opening:
-            openings[group_kind].append(token.start())
-        elif openings[group_kind]:
-            spans.append((openings[group_kind].pop(), token.end()))
-    for stack in openings.values():
-        spans.extend((opening, len(source)) for opening in stack)
-    return spans
-
-
-def _scope_end(position: int, spans: Iterable[tuple[int, int]], length: int) -> int:
-    """Return the end of the innermost lexical scope containing ``position``."""
-    return min(
-        (
-            length if end < 0 else end
-            for start, end in spans
-            if start < position < (length if end < 0 else end)
-        ),
-        default=length,
-    )
-
-
 def _declared_atom_commands(
     source: str, owner_source: str
-) -> _DynamicCommands:
-    """Return non-colliding dynamic atoms with position- and scope-bound keys."""
-    candidates: list[_DeclarationCandidate] = []
+) -> frozenset[str]:
+    """Return dynamic spellings as neutral, source-wide barriers.
+
+    Whether ``NewDocumentCommand`` succeeds depends on TeX's ambient control
+    sequence table, which a source-only scanner cannot reconstruct.  Dynamic
+    declarations therefore never grant dimension ownership here.
+    """
     names: set[str] = set()
     for declaration in _DECLARE_ATOM_RE.finditer(owner_source):
         if not _is_control_word_start(owner_source, declaration.start()):
@@ -569,25 +437,7 @@ def _declared_atom_commands(
         ].strip()
         name_match = re.fullmatch(r"\\([A-Za-z]+)", name_source)
         if name_match is not None:
-            name = name_match.group(1)
-            names.add(name)
-            if _DYNAMIC_ATOM_NAME_RE.fullmatch(name) is None:
-                continue
-            descriptor = _active_source(
-                source[
-                    arguments[1].content_start : arguments[1].content_end
-                ]
-            ).text
-            if not _valid_compatibility_atom_descriptor(descriptor):
-                continue
-            candidates.append(
-                _DeclarationCandidate(
-                    name,
-                    declaration.start(),
-                    arguments[-1].end,
-                    _DECLARE_ATOM_PHYSICAL_KEYS,
-                )
-            )
+            names.add(name_match.group(1))
     for declaration in _KERNEL_DECLARE_RE.finditer(owner_source):
         if not _is_control_word_start(owner_source, declaration.start()):
             continue
@@ -612,74 +462,22 @@ def _declared_atom_commands(
             command_name = command_name[1:]
         if re.fullmatch(r"[A-Za-z]+", command_name) is not None:
             names.add(command_name)
-            if _DYNAMIC_ATOM_NAME_RE.fullmatch(command_name) is None:
-                continue
-            candidates.append(
-                _DeclarationCandidate(
-                    command_name,
-                    declaration.start(),
-                    arguments[-1].end,
-                    frozenset(),
-                )
-            )
-
-    environment_tokens = _environment_tokens(source, owner_source)
-    scope_spans = (
-        _brace_scope_spans(owner_source)
-        + _environment_scope_spans(environment_tokens)
-        + _explicit_group_scope_spans(owner_source)
-    )
-    commands: list[_DeclaredCommand] = []
-    for candidate in sorted(candidates, key=lambda item: item.declaration_start):
-        # Both declaration mechanisms use NewDocumentCommand.  A fixed public
-        # command or an already-active dynamic binding therefore makes the
-        # declaration invalid; in particular it must not alter option owners.
-        if candidate.name in _COMMAND_GRAMMARS or any(
-            command.name == candidate.name
-            and command.start <= candidate.declaration_start < command.end
-            for command in commands
-        ):
-            continue
-        end = _scope_end(
-            candidate.declaration_start, scope_spans, len(owner_source)
-        )
-        if candidate.binding_start <= end:
-            commands.append(
-                _DeclaredCommand(
-                    candidate.name,
-                    candidate.binding_start,
-                    end,
-                    candidate.physical_keys,
-                )
-            )
-    return _DynamicCommands(frozenset(names), tuple(commands))
-
-
-def _active_declaration(
-    declarations: Iterable[_DeclaredCommand], name: str, position: int
-) -> _DeclaredCommand | None:
-    """Return the dynamic binding active at one invocation position."""
-    return next(
-        (
-            declaration
-            for declaration in declarations
-            if declaration.name == name
-            and declaration.start <= position < declaration.end
-        ),
-        None,
-    )
+    return frozenset(names)
 
 
 def _command_spans(
-    source: str, declared_commands: _DynamicCommands
+    source: str, declared_commands: Iterable[str]
 ) -> list[_OwnerSpan]:
     spans: list[_OwnerSpan] = []
     grammars = dict(_COMMAND_GRAMMARS)
-    # Known dynamic names are neutral even before or outside their valid
-    # binding.  This is a fail-closed quarantine, not retroactive activation:
-    # no physical option key is accepted without an active declaration.
-    for name in declared_commands.names:
-        grammars.setdefault(name, _CommandGrammar(None, (1,)))
+    # Dynamic spellings are source-wide neutral barriers.  This deliberately
+    # sacrifices ownership inference rather than guessing whether TeX's
+    # ambient control-sequence collision check accepted a declaration.
+    dynamic_names = frozenset(declared_commands).difference(grammars)
+    for name in dynamic_names:
+        grammars[name] = _CommandGrammar(
+            None, (0,), accepts_star=True
+        )
     pattern = re.compile(
         r"\\("
         + "|".join(sorted(grammars, key=len, reverse=True))
@@ -698,13 +496,23 @@ def _command_spans(
             if closed < 0:
                 continue
             position = _skip_space(source, closed)
-        for _ in range(max(grammar.positional_group_counts)):
-            if source[position : position + 1] != "{":
-                break
-            closed = match_group(source, position, "{", "}")
-            if closed < 0:
-                break
-            position = _skip_space(source, closed)
+        if command.group(1) in dynamic_names:
+            # The declaration may have collided with a command of unknown
+            # arity.  Quarantine every adjacent braced argument rather than
+            # guessing the successful atom command's one-argument grammar.
+            while source[position : position + 1] == "{":
+                closed = match_group(source, position, "{", "}")
+                if closed < 0:
+                    break
+                position = _skip_space(source, closed)
+        else:
+            for _ in range(max(grammar.positional_group_counts)):
+                if source[position : position + 1] != "{":
+                    break
+                closed = match_group(source, position, "{", "}")
+                if closed < 0:
+                    break
+                position = _skip_space(source, closed)
         spans.append(
             _OwnerSpan(
                 command.start(), position, grammar.owner
@@ -788,7 +596,10 @@ def _environment_tokens(
         closed = match_group(owner_source, position, "{", "}")
         if closed < 0:
             continue
-        name = _active_source(source[position + 1 : closed - 1]).text
+        active_name = _active_source(source[position + 1 : closed - 1]).text
+        # LaTeX dispatches environments through ``\csname``, which ignores
+        # ordinary spaces while constructing the control-sequence name.
+        name = re.sub(r"\s+", "", active_name)
         if _ENVIRONMENT_NAME_RE.fullmatch(name) is None:
             continue
         tokens.append(
@@ -814,7 +625,6 @@ def _environment_spans(
 def _option_spans(
     source: str,
     owner_source: str,
-    declared_commands: _DynamicCommands,
 ) -> list[_OwnerSpan]:
     """Find public option containers without joining split control words."""
     spans: list[_OwnerSpan] = []
@@ -863,37 +673,6 @@ def _option_spans(
             spans.extend(
                 _option_group_spans(
                     source, position + 1, closed - 1, allowed_keys
-                )
-            )
-    declared_bindings = declared_commands.bindings
-    declared_names = declared_commands.names
-    if declared_names:
-        declared_pattern = re.compile(
-            r"\\("
-            + "|".join(sorted(declared_names, key=len, reverse=True))
-            + r")"
-            + _TEX_CONTROL_WORD_END
-        )
-        for container in declared_pattern.finditer(owner_source):
-            if not _is_control_word_start(owner_source, container.start()):
-                continue
-            declaration = _active_declaration(
-                declared_bindings, container.group(1), container.start()
-            )
-            if declaration is None:
-                continue
-            position = _skip_space(owner_source, container.end())
-            if owner_source[position : position + 1] != "[":
-                continue
-            closed = match_group(owner_source, position, "[", "]")
-            if closed < 0:
-                continue
-            spans.extend(
-                _option_group_spans(
-                    source,
-                    position + 1,
-                    closed - 1,
-                    declaration.physical_keys,
                 )
             )
     return spans
@@ -997,7 +776,7 @@ def scan_case_dimensions(path: Path, source: str) -> tuple[DimensionOccurrence, 
     owner_source = strip_comments(source)
     declared_commands = _declared_atom_commands(source, owner_source)
     owner_spans = (
-        _option_spans(source, owner_source, declared_commands)
+        _option_spans(source, owner_source)
         + _command_spans(owner_source, declared_commands)
         + _environment_spans(source, owner_source)
     )

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -685,7 +685,7 @@ def _environment_tokens(
         if _ENVIRONMENT_NAME_RE.fullmatch(spelling) is not None:
             name: str | None = spelling
             match_name = f"static:{spelling}"
-        elif "\\" in spelling:
+        elif "\\" in spelling or "#" in spelling:
             name = None
             match_name = f"unresolved:{spelling}"
         else:
@@ -704,7 +704,12 @@ def _environment_spans(
     """Return neutral barriers for public environments and malformed controls."""
     tokens = _environment_tokens(source, owner_source)
     spans = [
-        _OwnerSpan(start, len(source) if end < 0 else end, None)
+        _OwnerSpan(
+            start,
+            len(source) if end < 0 else end,
+            None,
+            end < 0,
+        )
         for start, end in _environment_scope_spans(
             tokens, _PUBLIC_ENVIRONMENTS
         )

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -283,6 +283,7 @@ class _OwnerSpan:
     start: int
     end: int
     owner: DimensionOwner | None
+    is_quarantine: bool = False
 
 
 @dataclass(frozen=True)
@@ -546,6 +547,7 @@ def _command_spans(
         name = command.group(1)
         grammar = grammars[name]
         span_owner = grammar.owner
+        is_quarantine = False
         position = _skip_space(source, command.end())
         if name in dynamic_names:
             # The declaration may have collided with a command of unknown
@@ -566,6 +568,7 @@ def _command_spans(
                     # enclosing owner through a guessed command boundary.
                     position = len(source)
                     span_owner = None
+                    is_quarantine = True
                     break
                 position = _skip_space(source, closed)
         else:
@@ -576,6 +579,7 @@ def _command_spans(
                 if closed < 0:
                     position = len(source)
                     span_owner = None
+                    is_quarantine = True
                 else:
                     position = _skip_space(source, closed)
             for _ in range(max(grammar.positional_group_counts)):
@@ -585,11 +589,12 @@ def _command_spans(
                 if closed < 0:
                     position = len(source)
                     span_owner = None
+                    is_quarantine = True
                     break
                 position = _skip_space(source, closed)
         spans.append(
             _OwnerSpan(
-                command.start(), position, span_owner
+                command.start(), position, span_owner, is_quarantine
             )
         )
     return spans
@@ -719,6 +724,7 @@ def _option_spans(
             continue
         closed = match_group(owner_source, position, "[", "]")
         if closed < 0:
+            spans.append(_OwnerSpan(container.start, len(source), None, True))
             continue
         spans.extend(
             _option_group_spans(
@@ -788,13 +794,17 @@ def _comment_owner(comment: str) -> DimensionOwner | None:
     ):
         return DimensionOwner.FRAME
     if re.search(
-        r"\\tn(?:join|wire|edge|arrow)(?![a-z])|\b(?:route|string)\b",
+        r"\\tn(?:join|wire|edge|arrow)"
+        + _TEX_CONTROL_WORD_END
+        + r"|\b(?:route|string)\b",
         lowered,
     ):
         return DimensionOwner.ROUTE
     if re.search(
-        r"\\tnput(?![a-z])|\b(?:composition|layout|width|height|length|radius|"
-        r"diameter|wide|tall|long|thick)\b",
+        r"\\tnput"
+        + _TEX_CONTROL_WORD_END
+        + r"|\b(?:composition|layout|width|height|length|radius|diameter|wide|"
+        r"tall|long|thick)\b",
         lowered,
     ):
         return DimensionOwner.LAYOUT
@@ -864,7 +874,14 @@ def scan_case_dimensions(path: Path, source: str) -> tuple[DimensionOccurrence, 
         + _environment_spans(source, owner_source)
     )
     # A semantic option value is more specific than its containing command.
-    owner_spans.sort(key=lambda span: span.end - span.start)
+    # A malformed remainder has no trustworthy nested grammar, however, so
+    # its neutral quarantine must win over every shorter span inside it.
+    owner_spans.sort(
+        key=lambda span: (
+            0 if span.is_quarantine else 1,
+            span.end - span.start,
+        )
+    )
     comments = _comment_ranges(source)
     occurrences: list[DimensionOccurrence] = []
     for match in DIMENSION_RE.finditer(active.text):

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -256,6 +256,11 @@ _DECLARE_ATOM_RE = re.compile(r"\\tndeclareatom" + _TEX_CONTROL_WORD_END)
 _KERNEL_DECLARE_RE = re.compile(r"\\tndeclare" + _TEX_CONTROL_WORD_END)
 _DECLARE_ATOM_SKINS = frozenset({"dot", "box", "pill", "mpo"})
 _DECLARE_ATOM_PHYSICAL_KEYS = frozenset({"label shift"})
+# A static source scan cannot reproduce TeX's complete ``\cs_if_exist`` state.
+# Activate only the tenkz extension namespace; arbitrary spellings remain
+# neutral barriers, so a collision with a format or package command cannot
+# acquire physical ownership.  The public examples use this namespace.
+_DYNAMIC_ATOM_NAME_RE = re.compile(r"tn[A-Za-z]+")
 _DECLARE_ATOM_PORT_RE = re.compile(
     r"(?:west|east):virtual|(?:up|down):physical"
 )
@@ -323,6 +328,15 @@ class _ActiveSource:
     offsets: tuple[int, ...]
 
 
+@dataclass(frozen=True)
+class _MandatoryArgument:
+    """One xparse ``m`` argument and its complete source extent."""
+
+    content_start: int
+    content_end: int
+    end: int
+
+
 def _active_source(source: str) -> _ActiveSource:
     """Remove TeX comments as token splices while retaining source locations."""
     characters: list[str] = []
@@ -370,21 +384,35 @@ def _is_control_word_start(source: str, position: int) -> bool:
     return run_length % 2 == 1
 
 
-def _following_brace_groups(
+def _following_mandatory_arguments(
     source: str, position: int, count: int
-) -> list[tuple[int, int]] | None:
-    """Return the next exact number of mandatory brace-group spans."""
-    groups: list[tuple[int, int]] = []
+) -> list[_MandatoryArgument] | None:
+    """Return following xparse ``m`` arguments, braced or one-token."""
+    arguments: list[_MandatoryArgument] = []
     for _ in range(count):
         position = _skip_space(source, position)
-        if source[position : position + 1] != "{":
+        if position >= len(source):
             return None
-        closed = match_group(source, position, "{", "}")
-        if closed < 0:
-            return None
-        groups.append((position + 1, closed - 1))
-        position = closed
-    return groups
+        if source[position] == "{":
+            closed = match_group(source, position, "{", "}")
+            if closed < 0:
+                return None
+            argument = _MandatoryArgument(
+                position + 1, closed - 1, closed
+            )
+        elif source[position] == "\\":
+            if position + 1 >= len(source):
+                return None
+            token_end = position + 2
+            if source[position + 1].isalpha():
+                while token_end < len(source) and source[token_end].isalpha():
+                    token_end += 1
+            argument = _MandatoryArgument(position, token_end, token_end)
+        else:
+            argument = _MandatoryArgument(position, position + 1, position + 1)
+        arguments.append(argument)
+        position = argument.end
+    return arguments
 
 
 def _top_level_comma_segments(source: str) -> list[tuple[int, int]]:
@@ -531,16 +559,24 @@ def _declared_atom_commands(
     for declaration in _DECLARE_ATOM_RE.finditer(owner_source):
         if not _is_control_word_start(owner_source, declaration.start()):
             continue
-        groups = _following_brace_groups(owner_source, declaration.end(), 2)
-        if groups is None:
+        arguments = _following_mandatory_arguments(
+            owner_source, declaration.end(), 2
+        )
+        if arguments is None:
             continue
-        name_source = owner_source[groups[0][0] : groups[0][1]].strip()
+        name_source = owner_source[
+            arguments[0].content_start : arguments[0].content_end
+        ].strip()
         name_match = re.fullmatch(r"\\([A-Za-z]+)", name_source)
         if name_match is not None:
             name = name_match.group(1)
             names.add(name)
+            if _DYNAMIC_ATOM_NAME_RE.fullmatch(name) is None:
+                continue
             descriptor = _active_source(
-                source[groups[1][0] : groups[1][1]]
+                source[
+                    arguments[1].content_start : arguments[1].content_end
+                ]
             ).text
             if not _valid_compatibility_atom_descriptor(descriptor):
                 continue
@@ -548,33 +584,41 @@ def _declared_atom_commands(
                 _DeclarationCandidate(
                     name,
                     declaration.start(),
-                    groups[-1][1] + 1,
+                    arguments[-1].end,
                     _DECLARE_ATOM_PHYSICAL_KEYS,
                 )
             )
     for declaration in _KERNEL_DECLARE_RE.finditer(owner_source):
         if not _is_control_word_start(owner_source, declaration.start()):
             continue
-        groups = _following_brace_groups(owner_source, declaration.end(), 3)
-        if groups is None:
+        arguments = _following_mandatory_arguments(
+            owner_source, declaration.end(), 3
+        )
+        if arguments is None:
             continue
         class_name = _active_source(
-            source[groups[0][0] : groups[0][1]]
+            source[
+                arguments[0].content_start : arguments[0].content_end
+            ]
         ).text.strip()
         if class_name != "atom":
             continue
         command_name = _active_source(
-            source[groups[1][0] : groups[1][1]]
+            source[
+                arguments[1].content_start : arguments[1].content_end
+            ]
         ).text.strip()
         if command_name.startswith("\\"):
             command_name = command_name[1:]
         if re.fullmatch(r"[A-Za-z]+", command_name) is not None:
             names.add(command_name)
+            if _DYNAMIC_ATOM_NAME_RE.fullmatch(command_name) is None:
+                continue
             candidates.append(
                 _DeclarationCandidate(
                     command_name,
                     declaration.start(),
-                    groups[-1][1] + 1,
+                    arguments[-1].end,
                     frozenset(),
                 )
             )
@@ -744,8 +788,7 @@ def _environment_tokens(
         closed = match_group(owner_source, position, "{", "}")
         if closed < 0:
             continue
-        active_name = _active_source(source[position + 1 : closed - 1]).text
-        name = re.sub(r"\s+", "", active_name)
+        name = _active_source(source[position + 1 : closed - 1]).text
         if _ENVIRONMENT_NAME_RE.fullmatch(name) is None:
             continue
         tokens.append(

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -203,10 +203,11 @@ _OPTION_ENVIRONMENT_KEYS: Mapping[str, frozenset[str]] = {
 
 @dataclass(frozen=True)
 class _EnvironmentToken:
-    """One active, simple ``\\begin`` or ``\\end`` token."""
+    """One active ``\\begin`` or ``\\end`` token and its pairing key."""
 
     kind: str
-    name: str
+    name: str | None
+    match_name: str
     start: int
     end: int
 
@@ -442,12 +443,16 @@ def _environment_scope_spans(
     openings: dict[str, list[_EnvironmentToken]] = {}
     spans: list[tuple[int, int]] = []
     for token in tokens:
-        if names is not None and token.name not in names:
+        if (
+            names is not None
+            and token.name is not None
+            and token.name not in names
+        ):
             continue
         if token.kind == "begin":
-            openings.setdefault(token.name, []).append(token)
-        elif openings.get(token.name):
-            opening = openings[token.name].pop()
+            openings.setdefault(token.match_name, []).append(token)
+        elif openings.get(token.match_name):
+            opening = openings[token.match_name].pop()
             spans.append((opening.start, token.end))
     for stack in openings.values():
         spans.extend((opening.start, -1) for opening in stack)
@@ -655,16 +660,24 @@ def _environment_tokens(
         closed = match_group(owner_source, position, "{", "}")
         if closed < 0:
             continue
-        # LaTeX dispatch expands the name in ``\csname``; model the canonical
-        # expandable space token as well as ordinary ignored whitespace.
-        name = _csname_spelling(
+        # LaTeX dispatch expands the name in ``\csname``.  Model canonical
+        # spaces exactly; unresolved control sequences cannot safely grant a
+        # public option owner, but matching spellings still form a neutral
+        # quarantine so their bodies cannot inherit an enclosing owner.
+        spelling = _csname_spelling(
             source[position + 1 : closed - 1], expand_space=True
         )
-        if _ENVIRONMENT_NAME_RE.fullmatch(name) is None:
+        if _ENVIRONMENT_NAME_RE.fullmatch(spelling) is not None:
+            name: str | None = spelling
+            match_name = f"static:{spelling}"
+        elif "\\" in spelling:
+            name = None
+            match_name = f"unresolved:{spelling}"
+        else:
             continue
         tokens.append(
             _EnvironmentToken(
-                control.group(1), name, control.start(), closed
+                control.group(1), name, match_name, control.start(), closed
             )
         )
     return tokens

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -701,22 +701,28 @@ def _environment_tokens(
 def _environment_spans(
     source: str, owner_source: str
 ) -> list[_OwnerSpan]:
-    """Return neutral, depth-matched spans for every public environment."""
-    return [
+    """Return neutral barriers for public environments and malformed controls."""
+    tokens = _environment_tokens(source, owner_source)
+    spans = [
         _OwnerSpan(start, len(source) if end < 0 else end, None)
         for start, end in _environment_scope_spans(
-            _environment_tokens(source, owner_source), _PUBLIC_ENVIRONMENTS
+            tokens, _PUBLIC_ENVIRONMENTS
         )
     ]
-
-
-def _option_spans(
-    source: str,
-    owner_source: str,
-) -> list[_OwnerSpan]:
-    """Find public option containers without joining split control words."""
-    spans: list[_OwnerSpan] = []
-    for container in _environment_tokens(source, owner_source):
+    # An unclosed environment-name argument cannot be resolved to a public
+    # name, but it still consumes the remainder as one malformed control.
+    for control in _ENVIRONMENT_CONTROL_RE.finditer(owner_source):
+        if not _is_control_word_start(owner_source, control.start()):
+            continue
+        position = _skip_space(owner_source, control.end())
+        if owner_source[position : position + 1] != "{":
+            continue
+        if match_group(owner_source, position, "{", "}") < 0:
+            spans.append(_OwnerSpan(control.start(), len(source), None, True))
+    # Every environment that already participates in the barrier contract
+    # needs the same fail-closed option boundary, even when its options have
+    # no physical keys or its expandable name remains unresolved.
+    for container in tokens:
         if (
             container.kind != "begin"
             or (
@@ -728,11 +734,28 @@ def _option_spans(
         position = _skip_space(owner_source, container.end)
         if owner_source[position : position + 1] != "[":
             continue
+        if match_group(owner_source, position, "[", "]") < 0:
+            spans.append(_OwnerSpan(container.start, len(source), None, True))
+    return spans
+
+
+def _option_spans(
+    source: str,
+    owner_source: str,
+) -> list[_OwnerSpan]:
+    """Find public option containers without joining split control words."""
+    spans: list[_OwnerSpan] = []
+    for container in _environment_tokens(source, owner_source):
+        if (
+            container.kind != "begin"
+            or container.name not in _OPTION_ENVIRONMENT_KEYS
+        ):
+            continue
+        position = _skip_space(owner_source, container.end)
+        if owner_source[position : position + 1] != "[":
+            continue
         closed = match_group(owner_source, position, "[", "]")
         if closed < 0:
-            spans.append(_OwnerSpan(container.start, len(source), None, True))
-            continue
-        if container.name not in _OPTION_ENVIRONMENT_KEYS:
             continue
         spans.extend(
             _option_group_spans(

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -97,7 +97,7 @@ BOOK_LAYOUT_ALLOWLIST: Mapping[Path, int] = {
 class _CommandGrammar:
     """The public xparse shape relevant to dimension ownership."""
 
-    owner: DimensionOwner
+    owner: DimensionOwner | None
     positional_group_counts: tuple[int, ...]
     accepts_star: bool = False
     accepts_options: bool = True
@@ -115,25 +115,166 @@ _COMMAND_GRAMMARS: Mapping[str, _CommandGrammar] = {
     "tnarrow": _CommandGrammar(                                 # s O{} m
         DimensionOwner.ROUTE, (1,), accepts_star=True
     ),
+    # Typed containers below are ownership barriers, not blanket LAYOUT
+    # owners.  Their recognized physical option values receive narrower
+    # spans; arbitrary dimensions in an object label/body remain unowned and
+    # cannot inherit an enclosing route owner.
+    "tnpic": _CommandGrammar(None, (1,)),                        # O{} m
+    "tntree": _CommandGrammar(None, (1,)),                       # O{} m
+    "tn": _CommandGrammar(None, (1,), accepts_star=True),        # s O{} m
+    "tnX": _CommandGrammar(None, (1,)),                          # O{} m
+    "tnfuse": _CommandGrammar(None, (1,)),                       # O{} m
+    "tnsite": _CommandGrammar(None, (1,)),                       # O{} m
+    "tndots": _CommandGrammar(None, (0,)),                       # O{}
+    "tnghost": _CommandGrammar(                                 # m
+        None, (1,), accepts_options=False
+    ),
+    "tnskip": _CommandGrammar(                                  # no arguments
+        None, (0,), accepts_options=False
+    ),
+    "tnspan": _CommandGrammar(None, (2,)),                       # O{} m m
+    "tncut": _CommandGrammar(None, (1,)),                        # O{} m
+    "tnregion": _CommandGrammar(None, (1,)),                     # O{} m
+    "tnset": _CommandGrammar(                                   # m
+        None, (1,), accepts_options=False
+    ),
+    "tndeclareatom": _CommandGrammar(                           # m m
+        None, (2,), accepts_options=False
+    ),
+    "tnmark": _CommandGrammar(None, (2,)),                       # O{} m m
+    "tngroup": _CommandGrammar(None, (1,)),                      # O{} m
+    "tndeclare": _CommandGrammar(                               # m m m
+        None, (3,), accepts_options=False
+    ),
+    # Kernel sugar has no sanctioned physical value.  Keep it neutral rather
+    # than letting its endpoints inherit an enclosing composition owner.
+    "tnbond": _CommandGrammar(None, (2,)),                       # O{} m m
+    "tnprose": _CommandGrammar(                                 # m
+        None, (1,), accepts_options=False
+    ),
+    "tenkzkernel": _CommandGrammar(                             # no arguments
+        None, (0,), accepts_options=False
+    ),
 }
-_COMMAND_RE = re.compile(r"\\(" + "|".join(_COMMAND_GRAMMARS) + r")\b")
+# This is the physical subset of the public option registry, not the current
+# corpus vocabulary.  Plane rise/slant and sheet sep are dimensionless ratios;
+# out/in are angles.  Keeping key spelling and owner in one table prevents a
+# future public length from being recognized lexically but assigned by a
+# second, drifting owner list.
+_PHYSICAL_OPTION_KEY_OWNERS: Mapping[str, DimensionOwner] = {
+    "pitch": DimensionOwner.METRIC,
+    "radius": DimensionOwner.METRIC,
+    "column sep": DimensionOwner.METRIC,
+    "row sep": DimensionOwner.METRIC,
+    "col vector": DimensionOwner.FRAME,
+    "row vector": DimensionOwner.FRAME,
+    "sheet vector": DimensionOwner.FRAME,
+    "label shift": DimensionOwner.LAYOUT,
+}
+
+
+def _option_key_pattern(key: str) -> str:
+    """Return a regex spelling of one space-normalized public option key."""
+    return r"\s+".join(re.escape(word) for word in key.split())
+
+
 _OPTION_OWNER_RE = re.compile(
-    r"\s*(?P<key>sheet\s+vector|row\s+vector|col\s+vector|pitch)\s*=",
-    flags=re.IGNORECASE,
+    r"\s*(?P<key>"
+    + "|".join(
+        _option_key_pattern(key)
+        for key in sorted(_PHYSICAL_OPTION_KEY_OWNERS, key=len, reverse=True)
+    )
+    + r")\s*=",
 )
-_OPTION_ENVIRONMENT_RE = re.compile(
-    r"\\begin\s*\{\s*tenkz(?:cd|eq|free|lattice|planes)?\s*\}"
+_OPTION_ENVIRONMENT_KEYS: Mapping[str, frozenset[str]] = {
+    "tenkz": frozenset({"pitch"}),
+    "tenkzcd": frozenset({"pitch", "radius", "column sep", "row sep"}),
+    "tenkzfree": frozenset({"pitch"}),
+    "tenkzlattice": frozenset(
+        {"pitch", "col vector", "row vector", "sheet vector"}
+    ),
+    "tenkzplanes": frozenset(
+        {"pitch", "col vector", "row vector", "sheet vector"}
+    ),
+}
+
+
+@dataclass(frozen=True)
+class _EnvironmentToken:
+    """One active, simple ``\\begin`` or ``\\end`` token."""
+
+    kind: str
+    name: str
+    start: int
+    end: int
+
+
+_PUBLIC_ENVIRONMENTS = frozenset((*_OPTION_ENVIRONMENT_KEYS, "tenkzeq"))
+_ENVIRONMENT_CONTROL_RE = re.compile(r"\\(begin|end)\b")
+_ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z@:_][A-Za-z0-9@:_*.-]*")
+_EXPLICIT_GROUP_RE = re.compile(
+    r"\\(begingroup|endgroup|bgroup|egroup)\b"
 )
-_OPTION_BRACKET_COMMAND_RE = re.compile(r"\\(?:tnpic|tntree)\b")
+
+
+@dataclass(frozen=True)
+class _OptionCommandGrammar:
+    """Physical keys accepted by one bracket-option command."""
+
+    accepts_star: bool
+    physical_keys: frozenset[str]
+
+
+_OPTION_BRACKET_COMMANDS: Mapping[str, _OptionCommandGrammar] = {
+    # Picture/tree explicitly forward pitch; the three cell commands consume
+    # label shift through /tenkz/cell.  Do not infer option families from the
+    # registry's broad object scope: /tenkz/site rejects label shift today,
+    # while tndots has no option slot in the public grammar.  Leaving both out
+    # keeps malformed or undocumented dimensions unowned.
+    "tnpic": _OptionCommandGrammar(False, frozenset({"pitch"})),
+    "tntree": _OptionCommandGrammar(False, frozenset({"pitch"})),
+    "tn": _OptionCommandGrammar(True, frozenset({"label shift"})),
+    "tnX": _OptionCommandGrammar(False, frozenset({"label shift"})),
+    "tnfuse": _OptionCommandGrammar(False, frozenset({"label shift"})),
+}
+_OPTION_BRACKET_COMMAND_RE = re.compile(
+    r"\\("
+    + "|".join(
+        sorted(_OPTION_BRACKET_COMMANDS, key=len, reverse=True)
+    )
+    + r")\b"
+)
 _OPTION_BRACE_COMMAND_RE = re.compile(r"\\tnset\b")
-_FRAME_KEYS = {"sheet vector", "row vector", "col vector"}
+_SETUP_PHYSICAL_KEYS = frozenset({"pitch"})
+_DECLARE_ATOM_RE = re.compile(r"\\tndeclareatom\b")
+_KERNEL_DECLARE_RE = re.compile(r"\\tndeclare\b")
 
 
 @dataclass(frozen=True)
 class _OwnerSpan:
     start: int
     end: int
-    owner: DimensionOwner
+    owner: DimensionOwner | None
+
+
+@dataclass(frozen=True)
+class _DeclaredCommand:
+    """One valid dynamic atom binding over its TeX lexical scope."""
+
+    name: str
+    start: int
+    end: int
+    physical_keys: frozenset[str]
+
+
+@dataclass(frozen=True)
+class _DeclarationCandidate:
+    """A parsed declaration before collision and duplicate checks."""
+
+    name: str
+    declaration_start: int
+    binding_start: int
+    physical_keys: frozenset[str]
 
 
 @dataclass(frozen=True)
@@ -191,12 +332,211 @@ def _is_control_word_start(source: str, position: int) -> bool:
     return run_length % 2 == 1
 
 
-def _command_spans(source: str) -> list[_OwnerSpan]:
+def _following_brace_groups(
+    source: str, position: int, count: int
+) -> list[tuple[int, int]] | None:
+    """Return the next exact number of mandatory brace-group spans."""
+    groups: list[tuple[int, int]] = []
+    for _ in range(count):
+        position = _skip_space(source, position)
+        if source[position : position + 1] != "{":
+            return None
+        closed = match_group(source, position, "{", "}")
+        if closed < 0:
+            return None
+        groups.append((position + 1, closed - 1))
+        position = closed
+    return groups
+
+
+def _brace_scope_spans(source: str) -> list[tuple[int, int]]:
+    """Return conservative lexical scopes delimited by unescaped braces."""
+    openings: list[int] = []
+    spans: list[tuple[int, int]] = []
+    index = 0
+    while index < len(source):
+        character = source[index]
+        if character == "\\":
+            index += 2
+            continue
+        if character == "{":
+            openings.append(index)
+        elif character == "}" and openings:
+            spans.append((openings.pop(), index + 1))
+        index += 1
+    spans.extend((opening, len(source)) for opening in openings)
+    return spans
+
+
+def _environment_scope_spans(
+    tokens: Iterable[_EnvironmentToken],
+    names: frozenset[str] | None = None,
+) -> list[tuple[int, int]]:
+    """Depth-match selected environment tokens into lexical scopes."""
+    openings: dict[str, list[_EnvironmentToken]] = {}
+    spans: list[tuple[int, int]] = []
+    for token in tokens:
+        if names is not None and token.name not in names:
+            continue
+        if token.kind == "begin":
+            openings.setdefault(token.name, []).append(token)
+        elif openings.get(token.name):
+            opening = openings[token.name].pop()
+            spans.append((opening.start, token.end))
+    for stack in openings.values():
+        spans.extend((opening.start, -1) for opening in stack)
+    return spans
+
+
+def _explicit_group_scope_spans(source: str) -> list[tuple[int, int]]:
+    """Return scopes made with TeX's word and control-symbol group aliases."""
+    openings: dict[str, list[int]] = {"word": [], "alias": []}
+    spans: list[tuple[int, int]] = []
+    group_kinds = {
+        "begingroup": ("word", True),
+        "endgroup": ("word", False),
+        "bgroup": ("alias", True),
+        "egroup": ("alias", False),
+    }
+    for token in _EXPLICIT_GROUP_RE.finditer(source):
+        if not _is_control_word_start(source, token.start()):
+            continue
+        group_kind, is_opening = group_kinds[token.group(1)]
+        if is_opening:
+            openings[group_kind].append(token.start())
+        elif openings[group_kind]:
+            spans.append((openings[group_kind].pop(), token.end()))
+    for stack in openings.values():
+        spans.extend((opening, len(source)) for opening in stack)
+    return spans
+
+
+def _scope_end(position: int, spans: Iterable[tuple[int, int]], length: int) -> int:
+    """Return the end of the innermost lexical scope containing ``position``."""
+    return min(
+        (
+            length if end < 0 else end
+            for start, end in spans
+            if start < position < (length if end < 0 else end)
+        ),
+        default=length,
+    )
+
+
+def _declared_atom_commands(
+    source: str, owner_source: str
+) -> tuple[_DeclaredCommand, ...]:
+    """Return non-colliding dynamic atoms with position- and scope-bound keys."""
+    candidates: list[_DeclarationCandidate] = []
+    for declaration in _DECLARE_ATOM_RE.finditer(owner_source):
+        if not _is_control_word_start(owner_source, declaration.start()):
+            continue
+        groups = _following_brace_groups(owner_source, declaration.end(), 2)
+        if groups is None:
+            continue
+        name_source = owner_source[groups[0][0] : groups[0][1]].strip()
+        name_match = re.fullmatch(r"\\([A-Za-z]+)", name_source)
+        if name_match is not None:
+            candidates.append(
+                _DeclarationCandidate(
+                    name_match.group(1),
+                    declaration.start(),
+                    groups[-1][1] + 1,
+                    frozenset({"label shift"}),
+                )
+            )
+    for declaration in _KERNEL_DECLARE_RE.finditer(owner_source):
+        if not _is_control_word_start(owner_source, declaration.start()):
+            continue
+        groups = _following_brace_groups(owner_source, declaration.end(), 3)
+        if groups is None:
+            continue
+        class_name = _active_source(
+            source[groups[0][0] : groups[0][1]]
+        ).text.strip()
+        if class_name != "atom":
+            continue
+        command_name = _active_source(
+            source[groups[1][0] : groups[1][1]]
+        ).text.strip()
+        if command_name.startswith("\\"):
+            command_name = command_name[1:]
+        if re.fullmatch(r"[A-Za-z]+", command_name) is not None:
+            candidates.append(
+                _DeclarationCandidate(
+                    command_name,
+                    declaration.start(),
+                    groups[-1][1] + 1,
+                    frozenset(),
+                )
+            )
+
+    environment_tokens = _environment_tokens(source, owner_source)
+    scope_spans = (
+        _brace_scope_spans(owner_source)
+        + _environment_scope_spans(environment_tokens)
+        + _explicit_group_scope_spans(owner_source)
+    )
+    commands: list[_DeclaredCommand] = []
+    for candidate in sorted(candidates, key=lambda item: item.declaration_start):
+        # Both declaration mechanisms use NewDocumentCommand.  A fixed public
+        # command or an already-active dynamic binding therefore makes the
+        # declaration invalid; in particular it must not alter option owners.
+        if candidate.name in _COMMAND_GRAMMARS or any(
+            command.name == candidate.name
+            and command.start <= candidate.declaration_start < command.end
+            for command in commands
+        ):
+            continue
+        end = _scope_end(
+            candidate.declaration_start, scope_spans, len(owner_source)
+        )
+        if candidate.binding_start <= end:
+            commands.append(
+                _DeclaredCommand(
+                    candidate.name,
+                    candidate.binding_start,
+                    end,
+                    candidate.physical_keys,
+                )
+            )
+    return tuple(commands)
+
+
+def _active_declaration(
+    declarations: Iterable[_DeclaredCommand], name: str, position: int
+) -> _DeclaredCommand | None:
+    """Return the dynamic binding active at one invocation position."""
+    return next(
+        (
+            declaration
+            for declaration in declarations
+            if declaration.name == name
+            and declaration.start <= position < declaration.end
+        ),
+        None,
+    )
+
+
+def _command_spans(
+    source: str, declared_commands: Iterable[_DeclaredCommand]
+) -> list[_OwnerSpan]:
     spans: list[_OwnerSpan] = []
-    for command in _COMMAND_RE.finditer(source):
+    grammars = dict(_COMMAND_GRAMMARS)
+    # Known dynamic names are neutral even before or outside their valid
+    # binding.  This is a fail-closed quarantine, not retroactive activation:
+    # no physical option key is accepted without an active declaration.
+    for declaration in declared_commands:
+        grammars.setdefault(declaration.name, _CommandGrammar(None, (1,)))
+    pattern = re.compile(
+        r"\\("
+        + "|".join(sorted(grammars, key=len, reverse=True))
+        + r")\b"
+    )
+    for command in pattern.finditer(source):
         if not _is_control_word_start(source, command.start()):
             continue
-        grammar = _COMMAND_GRAMMARS[command.group(1)]
+        grammar = grammars[command.group(1)]
         position = _skip_space(source, command.end())
         if grammar.accepts_star and source[position : position + 1] == "*":
             position = _skip_space(source, position + 1)
@@ -225,82 +565,202 @@ def _option_value_end(source: str, position: int) -> int:
     if source[position : position + 1] == "{":
         closed = match_group(source, position, "{", "}")
         return len(source) if closed < 0 else closed
-    depths = {"{": 0, "[": 0, "(": 0}
-    closing = {"}": "{", "]": "[", ")": "("}
+    brace_depth = 0
     index = position
     while index < len(source):
         character = source[index]
         if character == "\\":
             index += 2
             continue
-        if character in depths:
-            depths[character] += 1
-        elif character in closing:
-            opener = closing[character]
-            if depths[opener] == 0:
+        if character == "{":
+            brace_depth += 1
+        elif character == "}":
+            if brace_depth == 0:
                 return index
-            depths[opener] -= 1
-        elif character == "," and not any(depths.values()):
+            brace_depth -= 1
+        elif character == "," and brace_depth == 0:
             return index
         index += 1
     return index
 
 
 def _option_group_spans(
-    source: str, start: int, end: int
+    source: str,
+    start: int,
+    end: int,
+    allowed_keys: frozenset[str] | None = None,
 ) -> list[_OwnerSpan]:
+    """Classify one option group using TeX-spliced tokens and source offsets."""
     spans: list[_OwnerSpan] = []
-    segment_start = start
-    depths = {"{": 0, "[": 0, "(": 0}
-    closing = {"}": "{", "]": "[", ")": "("}
+    active = _active_source(source[start:end])
+    option_source = active.text
+    brace_depth = 0
     segments: list[tuple[int, int]] = []
-    index = start
-    while index < end:
-        character = source[index]
+    segment_start = 0
+    index = 0
+    while index < len(option_source):
+        character = option_source[index]
         if character == "\\":
             index += 2
             continue
-        if character in depths:
-            depths[character] += 1
-        elif character in closing:
-            opener = closing[character]
-            depths[opener] = max(0, depths[opener] - 1)
-        elif character == "," and not any(depths.values()):
+        if character == "{":
+            brace_depth += 1
+        elif character == "}":
+            brace_depth = max(0, brace_depth - 1)
+        elif character == "," and brace_depth == 0:
             segments.append((segment_start, index))
             segment_start = index + 1
         index += 1
-    segments.append((segment_start, end))
+    segments.append((segment_start, len(option_source)))
     for segment_start, segment_end in segments:
-        option = _OPTION_OWNER_RE.match(source, segment_start, segment_end)
+        option = _OPTION_OWNER_RE.match(
+            option_source, segment_start, segment_end
+        )
         if option is None:
             continue
-        key = re.sub(r"\s+", " ", option.group("key").lower())
-        owner = (
-            DimensionOwner.FRAME if key in _FRAME_KEYS else DimensionOwner.METRIC
+        key = re.sub(r"\s+", " ", option.group("key")).strip()
+        if allowed_keys is not None and key not in allowed_keys:
+            continue
+        owner = _PHYSICAL_OPTION_KEY_OWNERS[key]
+        value_end = min(
+            segment_end, _option_value_end(option_source, option.end())
         )
-        value_end = min(segment_end, _option_value_end(source, option.end()))
-        spans.append(_OwnerSpan(option.end(), value_end, owner))
+        if option.end() >= len(active.offsets):
+            source_start = end
+        else:
+            source_start = start + active.offsets[option.end()]
+        if value_end <= option.end():
+            source_end = source_start
+        elif value_end > len(active.offsets):
+            source_end = end
+        else:
+            source_end = start + active.offsets[value_end - 1] + 1
+        spans.append(_OwnerSpan(source_start, source_end, owner))
     return spans
 
 
-def _option_spans(source: str) -> list[_OwnerSpan]:
+def _environment_tokens(
+    source: str, owner_source: str
+) -> list[_EnvironmentToken]:
+    """Parse simple environment names without joining split control words."""
+    tokens: list[_EnvironmentToken] = []
+    for control in _ENVIRONMENT_CONTROL_RE.finditer(owner_source):
+        if not _is_control_word_start(owner_source, control.start()):
+            continue
+        position = _skip_space(owner_source, control.end())
+        if owner_source[position : position + 1] != "{":
+            continue
+        closed = match_group(owner_source, position, "{", "}")
+        if closed < 0:
+            continue
+        active_name = _active_source(source[position + 1 : closed - 1]).text
+        name = re.sub(r"\s+", "", active_name)
+        if _ENVIRONMENT_NAME_RE.fullmatch(name) is None:
+            continue
+        tokens.append(
+            _EnvironmentToken(
+                control.group(1), name, control.start(), closed
+            )
+        )
+    return tokens
+
+
+def _environment_spans(
+    source: str, owner_source: str
+) -> list[_OwnerSpan]:
+    """Return neutral, depth-matched spans for every public environment."""
+    return [
+        _OwnerSpan(start, len(source) if end < 0 else end, None)
+        for start, end in _environment_scope_spans(
+            _environment_tokens(source, owner_source), _PUBLIC_ENVIRONMENTS
+        )
+    ]
+
+
+def _option_spans(
+    source: str,
+    owner_source: str,
+    declared_commands: Iterable[_DeclaredCommand],
+) -> list[_OwnerSpan]:
+    """Find public option containers without joining split control words."""
     spans: list[_OwnerSpan] = []
+    for container in _environment_tokens(source, owner_source):
+        if container.kind != "begin" or container.name not in _OPTION_ENVIRONMENT_KEYS:
+            continue
+        position = _skip_space(owner_source, container.end)
+        if owner_source[position : position + 1] != "[":
+            continue
+        closed = match_group(owner_source, position, "[", "]")
+        if closed < 0:
+            continue
+        spans.extend(
+            _option_group_spans(
+                source,
+                position + 1,
+                closed - 1,
+                _OPTION_ENVIRONMENT_KEYS[container.name],
+            )
+        )
     containers = (
-        (_OPTION_ENVIRONMENT_RE, "[", "]"),
         (_OPTION_BRACKET_COMMAND_RE, "[", "]"),
         (_OPTION_BRACE_COMMAND_RE, "{", "}"),
     )
     for pattern, opener, closer in containers:
-        for container in pattern.finditer(source):
-            if not _is_control_word_start(source, container.start()):
+        for container in pattern.finditer(owner_source):
+            if not _is_control_word_start(owner_source, container.start()):
                 continue
-            position = _skip_space(source, container.end())
-            if source[position : position + 1] != opener:
+            position = _skip_space(owner_source, container.end())
+            allowed_keys: frozenset[str] | None = None
+            if pattern is _OPTION_BRACKET_COMMAND_RE:
+                grammar = _OPTION_BRACKET_COMMANDS[container.group(1)]
+                allowed_keys = grammar.physical_keys
+                if (
+                    grammar.accepts_star
+                    and owner_source[position : position + 1] == "*"
+                ):
+                    position = _skip_space(owner_source, position + 1)
+            elif pattern is _OPTION_BRACE_COMMAND_RE:
+                allowed_keys = _SETUP_PHYSICAL_KEYS
+            if owner_source[position : position + 1] != opener:
                 continue
-            closed = match_group(source, position, opener, closer)
+            closed = match_group(owner_source, position, opener, closer)
             if closed < 0:
                 continue
-            spans.extend(_option_group_spans(source, position + 1, closed - 1))
+            spans.extend(
+                _option_group_spans(
+                    source, position + 1, closed - 1, allowed_keys
+                )
+            )
+    declared_commands = tuple(declared_commands)
+    declared_names = {declaration.name for declaration in declared_commands}
+    if declared_names:
+        declared_pattern = re.compile(
+            r"\\("
+            + "|".join(sorted(declared_names, key=len, reverse=True))
+            + r")\b"
+        )
+        for container in declared_pattern.finditer(owner_source):
+            if not _is_control_word_start(owner_source, container.start()):
+                continue
+            declaration = _active_declaration(
+                declared_commands, container.group(1), container.start()
+            )
+            if declaration is None:
+                continue
+            position = _skip_space(owner_source, container.end())
+            if owner_source[position : position + 1] != "[":
+                continue
+            closed = match_group(owner_source, position, "[", "]")
+            if closed < 0:
+                continue
+            spans.extend(
+                _option_group_spans(
+                    source,
+                    position + 1,
+                    closed - 1,
+                    declaration.physical_keys,
+                )
+            )
     return spans
 
 
@@ -397,7 +857,12 @@ def scan_case_dimensions(path: Path, source: str) -> tuple[DimensionOccurrence, 
     # ``\tn%...\nput``.  Keep ownership on an offset-preserving blanked view
     # while the numeric/unit recognizer uses the collapsed mapped view above.
     owner_source = strip_comments(source)
-    owner_spans = _option_spans(owner_source) + _command_spans(owner_source)
+    declared_commands = _declared_atom_commands(source, owner_source)
+    owner_spans = (
+        _option_spans(source, owner_source, declared_commands)
+        + _command_spans(owner_source, declared_commands)
+        + _environment_spans(source, owner_source)
+    )
     # A semantic option value is more specific than its containing command.
     owner_spans.sort(key=lambda span: span.end - span.start)
     comments = _comment_ranges(source)

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -160,7 +160,9 @@ _COMMAND_GRAMMARS: Mapping[str, _CommandGrammar] = {
 # corpus vocabulary.  Plane rise/slant and sheet sep are dimensionless ratios;
 # out/in are angles.  Keeping key spelling and owner in one table prevents a
 # future public length from being recognized lexically but assigned by a
-# second, drifting owner list.
+# second, drifting owner list.  Every physical-key allowlist below must be a
+# subset of this mapping; ``_validate_physical_option_key_sets`` enforces that
+# invariant at import time.
 _PHYSICAL_OPTION_KEY_OWNERS: Mapping[str, DimensionOwner] = {
     "pitch": DimensionOwner.METRIC,
     "radius": DimensionOwner.METRIC,
@@ -210,10 +212,13 @@ class _EnvironmentToken:
 
 
 _PUBLIC_ENVIRONMENTS = frozenset((*_OPTION_ENVIRONMENT_KEYS, "tenkzeq"))
-_ENVIRONMENT_CONTROL_RE = re.compile(r"\\(begin|end)\b")
+_TEX_CONTROL_WORD_END = r"(?![A-Za-z])"
+_ENVIRONMENT_CONTROL_RE = re.compile(
+    r"\\(begin|end)" + _TEX_CONTROL_WORD_END
+)
 _ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z@:_][A-Za-z0-9@:_*.-]*")
 _EXPLICIT_GROUP_RE = re.compile(
-    r"\\(begingroup|endgroup|bgroup|egroup)\b"
+    r"\\(begingroup|endgroup|bgroup|egroup)" + _TEX_CONTROL_WORD_END
 )
 
 
@@ -242,12 +247,37 @@ _OPTION_BRACKET_COMMAND_RE = re.compile(
     + "|".join(
         sorted(_OPTION_BRACKET_COMMANDS, key=len, reverse=True)
     )
-    + r")\b"
+    + r")"
+    + _TEX_CONTROL_WORD_END
 )
-_OPTION_BRACE_COMMAND_RE = re.compile(r"\\tnset\b")
+_OPTION_BRACE_COMMAND_RE = re.compile(r"\\tnset" + _TEX_CONTROL_WORD_END)
 _SETUP_PHYSICAL_KEYS = frozenset({"pitch"})
-_DECLARE_ATOM_RE = re.compile(r"\\tndeclareatom\b")
-_KERNEL_DECLARE_RE = re.compile(r"\\tndeclare\b")
+_DECLARE_ATOM_RE = re.compile(r"\\tndeclareatom" + _TEX_CONTROL_WORD_END)
+_KERNEL_DECLARE_RE = re.compile(r"\\tndeclare" + _TEX_CONTROL_WORD_END)
+_DECLARE_ATOM_SKINS = frozenset({"dot", "box", "pill", "mpo"})
+_DECLARE_ATOM_PHYSICAL_KEYS = frozenset({"label shift"})
+_DECLARE_ATOM_PORT_RE = re.compile(
+    r"(?:west|east):virtual|(?:up|down):physical"
+)
+
+
+def _validate_physical_option_key_sets() -> None:
+    """Reject allowlists that lack a corresponding physical-key owner."""
+    key_sets = [
+        *_OPTION_ENVIRONMENT_KEYS.values(),
+        *(grammar.physical_keys for grammar in _OPTION_BRACKET_COMMANDS.values()),
+        _SETUP_PHYSICAL_KEYS,
+        _DECLARE_ATOM_PHYSICAL_KEYS,
+    ]
+    unknown = set().union(*key_sets).difference(_PHYSICAL_OPTION_KEY_OWNERS)
+    if unknown:
+        raise RuntimeError(
+            "physical option keys lack dimension owners: "
+            f"{sorted(unknown)!r}"
+        )
+
+
+_validate_physical_option_key_sets()
 
 
 @dataclass(frozen=True)
@@ -275,6 +305,14 @@ class _DeclarationCandidate:
     declaration_start: int
     binding_start: int
     physical_keys: frozenset[str]
+
+
+@dataclass(frozen=True)
+class _DynamicCommands:
+    """Known dynamic spellings and the declarations that actually bind them."""
+
+    names: frozenset[str]
+    bindings: tuple[_DeclaredCommand, ...]
 
 
 @dataclass(frozen=True)
@@ -347,6 +385,67 @@ def _following_brace_groups(
         groups.append((position + 1, closed - 1))
         position = closed
     return groups
+
+
+def _top_level_comma_segments(source: str) -> list[tuple[int, int]]:
+    """Split a PGF list where only braces protect commas."""
+    brace_depth = 0
+    segments: list[tuple[int, int]] = []
+    segment_start = 0
+    index = 0
+    while index < len(source):
+        character = source[index]
+        if character == "\\":
+            index += 2
+            continue
+        if character == "{":
+            brace_depth += 1
+        elif character == "}":
+            brace_depth = max(0, brace_depth - 1)
+        elif character == "," and brace_depth == 0:
+            segments.append((segment_start, index))
+            segment_start = index + 1
+        index += 1
+    segments.append((segment_start, len(source)))
+    return segments
+
+
+def _literal_option_value(value: str) -> str | None:
+    """Remove one complete outer brace group from a literal PGF value."""
+    value = value.strip()
+    if not value.startswith("{"):
+        return value
+    closed = match_group(value, 0, "{", "}")
+    if closed != len(value):
+        return None
+    return value[1:-1].strip()
+
+
+def _valid_compatibility_atom_descriptor(source: str) -> bool:
+    """Whether a literal descriptor creates a public compatibility atom."""
+    for start, end in _top_level_comma_segments(source):
+        segment = source[start:end].strip()
+        if not segment:
+            continue
+        key, separator, raw_value = segment.partition("=")
+        if not separator:
+            return False
+        value = _literal_option_value(raw_value)
+        if value is None:
+            return False
+        key = key.strip()
+        if key == "skin":
+            if value not in _DECLARE_ATOM_SKINS:
+                return False
+        elif key == "ports":
+            if value and any(
+                _DECLARE_ATOM_PORT_RE.fullmatch(port.strip()) is None
+                for port in value.split(",")
+            ):
+                return False
+        else:
+            return False
+    return True
 
 
 def _brace_scope_spans(source: str) -> list[tuple[int, int]]:
@@ -425,9 +524,10 @@ def _scope_end(position: int, spans: Iterable[tuple[int, int]], length: int) -> 
 
 def _declared_atom_commands(
     source: str, owner_source: str
-) -> tuple[_DeclaredCommand, ...]:
+) -> _DynamicCommands:
     """Return non-colliding dynamic atoms with position- and scope-bound keys."""
     candidates: list[_DeclarationCandidate] = []
+    names: set[str] = set()
     for declaration in _DECLARE_ATOM_RE.finditer(owner_source):
         if not _is_control_word_start(owner_source, declaration.start()):
             continue
@@ -437,12 +537,19 @@ def _declared_atom_commands(
         name_source = owner_source[groups[0][0] : groups[0][1]].strip()
         name_match = re.fullmatch(r"\\([A-Za-z]+)", name_source)
         if name_match is not None:
+            name = name_match.group(1)
+            names.add(name)
+            descriptor = _active_source(
+                source[groups[1][0] : groups[1][1]]
+            ).text
+            if not _valid_compatibility_atom_descriptor(descriptor):
+                continue
             candidates.append(
                 _DeclarationCandidate(
-                    name_match.group(1),
+                    name,
                     declaration.start(),
                     groups[-1][1] + 1,
-                    frozenset({"label shift"}),
+                    _DECLARE_ATOM_PHYSICAL_KEYS,
                 )
             )
     for declaration in _KERNEL_DECLARE_RE.finditer(owner_source):
@@ -462,6 +569,7 @@ def _declared_atom_commands(
         if command_name.startswith("\\"):
             command_name = command_name[1:]
         if re.fullmatch(r"[A-Za-z]+", command_name) is not None:
+            names.add(command_name)
             candidates.append(
                 _DeclarationCandidate(
                     command_name,
@@ -500,7 +608,7 @@ def _declared_atom_commands(
                     candidate.physical_keys,
                 )
             )
-    return tuple(commands)
+    return _DynamicCommands(frozenset(names), tuple(commands))
 
 
 def _active_declaration(
@@ -519,19 +627,20 @@ def _active_declaration(
 
 
 def _command_spans(
-    source: str, declared_commands: Iterable[_DeclaredCommand]
+    source: str, declared_commands: _DynamicCommands
 ) -> list[_OwnerSpan]:
     spans: list[_OwnerSpan] = []
     grammars = dict(_COMMAND_GRAMMARS)
     # Known dynamic names are neutral even before or outside their valid
     # binding.  This is a fail-closed quarantine, not retroactive activation:
     # no physical option key is accepted without an active declaration.
-    for declaration in declared_commands:
-        grammars.setdefault(declaration.name, _CommandGrammar(None, (1,)))
+    for name in declared_commands.names:
+        grammars.setdefault(name, _CommandGrammar(None, (1,)))
     pattern = re.compile(
         r"\\("
         + "|".join(sorted(grammars, key=len, reverse=True))
-        + r")\b"
+        + r")"
+        + _TEX_CONTROL_WORD_END
     )
     for command in pattern.finditer(source):
         if not _is_control_word_start(source, command.start()):
@@ -594,25 +703,7 @@ def _option_group_spans(
     spans: list[_OwnerSpan] = []
     active = _active_source(source[start:end])
     option_source = active.text
-    brace_depth = 0
-    segments: list[tuple[int, int]] = []
-    segment_start = 0
-    index = 0
-    while index < len(option_source):
-        character = option_source[index]
-        if character == "\\":
-            index += 2
-            continue
-        if character == "{":
-            brace_depth += 1
-        elif character == "}":
-            brace_depth = max(0, brace_depth - 1)
-        elif character == "," and brace_depth == 0:
-            segments.append((segment_start, index))
-            segment_start = index + 1
-        index += 1
-    segments.append((segment_start, len(option_source)))
-    for segment_start, segment_end in segments:
+    for segment_start, segment_end in _top_level_comma_segments(option_source):
         option = _OPTION_OWNER_RE.match(
             option_source, segment_start, segment_end
         )
@@ -680,7 +771,7 @@ def _environment_spans(
 def _option_spans(
     source: str,
     owner_source: str,
-    declared_commands: Iterable[_DeclaredCommand],
+    declared_commands: _DynamicCommands,
 ) -> list[_OwnerSpan]:
     """Find public option containers without joining split control words."""
     spans: list[_OwnerSpan] = []
@@ -731,19 +822,20 @@ def _option_spans(
                     source, position + 1, closed - 1, allowed_keys
                 )
             )
-    declared_commands = tuple(declared_commands)
-    declared_names = {declaration.name for declaration in declared_commands}
+    declared_bindings = declared_commands.bindings
+    declared_names = declared_commands.names
     if declared_names:
         declared_pattern = re.compile(
             r"\\("
             + "|".join(sorted(declared_names, key=len, reverse=True))
-            + r")\b"
+            + r")"
+            + _TEX_CONTROL_WORD_END
         )
         for container in declared_pattern.finditer(owner_source):
             if not _is_control_word_start(owner_source, container.start()):
                 continue
             declaration = _active_declaration(
-                declared_commands, container.group(1), container.start()
+                declared_bindings, container.group(1), container.start()
             )
             if declaration is None:
                 continue
@@ -790,10 +882,13 @@ def _comment_owner(comment: str) -> DimensionOwner | None:
         lowered,
     ):
         return DimensionOwner.FRAME
-    if re.search(r"\\tn(?:join|wire|edge|arrow)\b|\b(?:route|string)\b", lowered):
+    if re.search(
+        r"\\tn(?:join|wire|edge|arrow)(?![a-z])|\b(?:route|string)\b",
+        lowered,
+    ):
         return DimensionOwner.ROUTE
     if re.search(
-        r"\\tnput\b|\b(?:composition|layout|width|height|length|radius|"
+        r"\\tnput(?![a-z])|\b(?:composition|layout|width|height|length|radius|"
         r"diameter|wide|tall|long|thick)\b",
         lowered,
     ):

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -647,6 +647,26 @@ def test_rmp_dimension_ownership() -> None:
             "an unbraced xparse declaration escaped quarantine: "
             f"{unbraced_compatibility_atom!r}"
         )
+    for catcode_prelude, atom_name in (
+        (r"\makeatletter", "tn@atom"),
+        (r"\ExplSyntaxOn", "tn:atom"),
+        (r"\ExplSyntaxOn", "tn_atom"),
+        ("", "tnλatom"),
+        ("", "?"),
+    ):
+        catcode_atom = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"{catcode_prelude}\tndeclareatom{{\{atom_name}}}{{skin=dot}}"
+            rf"\tnarrow{{\{atom_name}[label shift={{99mm,100mm}}]"
+            r"{101mm}{102mm}}",
+        )
+        if len(catcode_atom) != 4 or any(
+            occurrence.owner is not None for occurrence in catcode_atom
+        ):
+            raise AssertionError(
+                "a control-sequence atom name escaped dynamic quarantine: "
+                f"name={atom_name!r}, occurrences={catcode_atom!r}"
+            )
     declared_kernel_atom = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tndeclare{atom}{tnkernelatom}{skin=dot}"
@@ -755,6 +775,32 @@ def test_rmp_dimension_ownership() -> None:
             "a source-local command collision activated dynamic ownership: "
             f"{source_local_collision!r}"
         )
+    repeated_optional_collision = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\NewDocumentCommand{\tnoccupied}{O{} O{} m}{}"
+        r"\tnarrow{\tndeclareatom{\tnoccupied}{skin=dot}"
+        r"\tnoccupied[][103mm]{104mm}}",
+    )
+    if len(repeated_optional_collision) != 2 or any(
+        occurrence.owner is not None
+        for occurrence in repeated_optional_collision
+    ):
+        raise AssertionError(
+            "a repeated optional argument escaped unknown-arity quarantine: "
+            f"{repeated_optional_collision!r}"
+        )
+    colliding_parbox = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{\tndeclareatom{\parbox}{skin=dot}"
+        r"\parbox[c][105mm][c]{106mm}{x}}",
+    )
+    if len(colliding_parbox) != 2 or any(
+        occurrence.owner is not None for occurrence in colliding_parbox
+    ):
+        raise AssertionError(
+            "a real multi-option command escaped unknown-arity quarantine: "
+            f"{colliding_parbox!r}"
+        )
     scoped_atom_declaration = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tnarrow{{\tndeclareatom{\tnlocalatom}{skin=dot}"
@@ -840,6 +886,19 @@ def test_rmp_dimension_ownership() -> None:
             "an environment-local atom escaped source-wide quarantine: "
             f"{environment_scoped_atom!r}"
         )
+    for kernel_name in ("tn spaced", "tn\nspaced"):
+        csname_declared_atom = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"\tndeclare{{atom}}{{{kernel_name}}}{{skin=dot}}"
+            r"\tnarrow{\tnspaced[label shift={107mm,108mm}]{A}}",
+        )
+        if len(csname_declared_atom) != 2 or any(
+            occurrence.owner is not None for occurrence in csname_declared_atom
+        ):
+            raise AssertionError(
+                "a csname-normalized kernel atom escaped quarantine: "
+                f"name={kernel_name!r}, occurrences={csname_declared_atom!r}"
+            )
     for environment in (
         "tenkz",
         "tenkzcd",
@@ -928,6 +987,29 @@ kz}}
             raise AssertionError(
                 "a csname-spaced environment lost its public boundary: "
                 f"name={spaced_name!r}, occurrences={spaced_environment!r}"
+            )
+    for expanded_space_name in (
+        r"ten\space kz",
+        r"ten\space\space kz",
+        "ten\\space% preserve the control-word boundary\nkz",
+    ):
+        expanded_space_environment = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"\tnarrow{{\begin{{{expanded_space_name}}}[pitch=109mm]"
+            rf"\rule{{110mm}}{{111mm}}\end{{{expanded_space_name}}}}}",
+        )
+        if [
+            (occurrence.literal, occurrence.owner)
+            for occurrence in expanded_space_environment
+        ] != [
+            ("109mm", DimensionOwner.METRIC),
+            ("110mm", None),
+            ("111mm", None),
+        ]:
+            raise AssertionError(
+                "an expanded-space environment lost its public boundary: "
+                f"name={expanded_space_name!r}, "
+                f"occurrences={expanded_space_environment!r}"
             )
     nested_label_shift = scan_case_dimensions(
         Path("synthetic.tex"),

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -1011,6 +1011,19 @@ kz}}
                 f"name={expanded_space_name!r}, "
                 f"occurrences={expanded_space_environment!r}"
             )
+    macro_environment = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\def\tenname{tenkz}"
+        r"\tnarrow{\begin{\tenname}[pitch=112mm]"
+        r"\rule{113mm}{114mm}\end{\tenname}}",
+    )
+    if len(macro_environment) != 3 or any(
+        occurrence.owner is not None for occurrence in macro_environment
+    ):
+        raise AssertionError(
+            "an unresolved expandable environment escaped neutral quarantine: "
+            f"{macro_environment!r}"
+        )
     nested_label_shift = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tnarrow[from=1,to=2]{\tnpic[inline]{"

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -617,8 +617,8 @@ def test_rmp_dimension_ownership() -> None:
             )
     declared_compatibility_atom = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"\tndeclareatom{\myatom}{skin=dot}"
-        r"\tnarrow{\myatom[label shift={52mm,53mm}]"
+        r"\tndeclareatom{\tnmyatom}{skin=dot}"
+        r"\tnarrow{\tnmyatom[label shift={52mm,53mm}]"
         r"{\rule{54mm}{55mm}}}",
     )
     if [
@@ -634,10 +634,23 @@ def test_rmp_dimension_ownership() -> None:
             "a declared compatibility atom lost its typed boundary: "
             f"{declared_compatibility_atom!r}"
         )
+    unbraced_compatibility_atom = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{\tndeclareatom\tnbareatom{skin=dot}"
+        r"\tnbareatom[label shift={86mm,87mm}]{A}}",
+    )
+    if len(unbraced_compatibility_atom) != 2 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in unbraced_compatibility_atom
+    ):
+        raise AssertionError(
+            "an unbraced xparse declaration argument lost its binding: "
+            f"{unbraced_compatibility_atom!r}"
+        )
     declared_kernel_atom = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"\tndeclare{atom}{kernelatom}{skin=dot}"
-        r"\tnarrow{\kernelatom[label shift={56mm,57mm}]"
+        r"\tndeclare{atom}{tnkernelatom}{skin=dot}"
+        r"\tnarrow{\tnkernelatom[label shift={56mm,57mm}]"
         r"{\rule{58mm}{59mm}}}",
     )
     if len(declared_kernel_atom) != 4 or any(
@@ -655,9 +668,9 @@ def test_rmp_dimension_ownership() -> None:
     ):
         rejected_compatibility_atom = scan_case_dimensions(
             Path("synthetic.tex"),
-            rf"\tnarrow{{\tndeclareatom{{\invalidatom}}"
+            rf"\tnarrow{{\tndeclareatom{{\tninvalidatom}}"
             rf"{{{invalid_descriptor}}}"
-            r"\invalidatom[label shift={80mm,81mm}]{A}}",
+            r"\tninvalidatom[label shift={80mm,81mm}]{A}}",
         )
         if len(rejected_compatibility_atom) != 2 or any(
             occurrence.owner is not None
@@ -674,9 +687,9 @@ def test_rmp_dimension_ownership() -> None:
     ):
         digit_delimited_group = scan_case_dimensions(
             Path("synthetic.tex"),
-            rf"\{opener}1\tndeclareatom{{\groupatom}}{{skin=dot}}"
-            rf"\groupatom[label shift={{82mm,83mm}}]{{A}}\{closer}2"
-            r"\tnarrow{\groupatom[label shift={84mm,85mm}]{B}}",
+            rf"\{opener}1\tndeclareatom{{\tngroupatom}}{{skin=dot}}"
+            rf"\tngroupatom[label shift={{82mm,83mm}}]{{A}}\{closer}2"
+            r"\tnarrow{\tngroupatom[label shift={84mm,85mm}]{B}}",
         )
         if [
             (occurrence.literal, occurrence.owner)
@@ -693,8 +706,8 @@ def test_rmp_dimension_ownership() -> None:
             )
     atom_before_declaration = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"\tnarrow{\lateatom[label shift={60mm,61mm}]{A}}"
-        r"\tndeclareatom{\lateatom}{skin=dot}",
+        r"\tnarrow{\tnlateatom[label shift={60mm,61mm}]{A}}"
+        r"\tndeclareatom{\tnlateatom}{skin=dot}",
     )
     if len(atom_before_declaration) != 2 or any(
         occurrence.owner is not None for occurrence in atom_before_declaration
@@ -716,11 +729,24 @@ def test_rmp_dimension_ownership() -> None:
             "a rejected declaration changed a fixed public command owner: "
             f"{colliding_atom_declaration!r}"
         )
+    colliding_latex_declaration = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{\tndeclareatom\rule{skin=dot}"
+        r"\rule[label shift={88mm,89mm}]{A}}",
+    )
+    if len(colliding_latex_declaration) != 2 or any(
+        occurrence.owner is not None
+        for occurrence in colliding_latex_declaration
+    ):
+        raise AssertionError(
+            "a format command collision activated dynamic ownership: "
+            f"{colliding_latex_declaration!r}"
+        )
     scoped_atom_declaration = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"\tnarrow{{\tndeclareatom{\localatom}{skin=dot}"
-        r"\localatom[label shift={64mm,65mm}]{A}}"
-        r"\localatom[label shift={66mm,67mm}]{B}}",
+        r"\tnarrow{{\tndeclareatom{\tnlocalatom}{skin=dot}"
+        r"\tnlocalatom[label shift={64mm,65mm}]{A}}"
+        r"\tnlocalatom[label shift={66mm,67mm}]{B}}",
     )
     if [
         (occurrence.literal, occurrence.owner)
@@ -737,9 +763,9 @@ def test_rmp_dimension_ownership() -> None:
         )
     compatibility_then_duplicate = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"\tndeclareatom{\duplicateatom}{skin=dot}"
-        r"\tndeclare{atom}{duplicateatom}{skin=dot}"
-        r"\duplicateatom[label shift={68mm,69mm}]{A}",
+        r"\tndeclareatom{\tnduplicateatom}{skin=dot}"
+        r"\tndeclare{atom}{tnduplicateatom}{skin=dot}"
+        r"\tnduplicateatom[label shift={68mm,69mm}]{A}",
     )
     if len(compatibility_then_duplicate) != 2 or any(
         occurrence.owner is not DimensionOwner.LAYOUT
@@ -751,9 +777,9 @@ def test_rmp_dimension_ownership() -> None:
         )
     kernel_then_duplicate = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"\tndeclare{atom}{otherduplicate}{skin=dot}"
-        r"\tndeclareatom{\otherduplicate}{skin=dot}"
-        r"\otherduplicate[label shift={70mm,71mm}]{A}",
+        r"\tndeclare{atom}{tnotherduplicate}{skin=dot}"
+        r"\tndeclareatom{\tnotherduplicate}{skin=dot}"
+        r"\tnotherduplicate[label shift={70mm,71mm}]{A}",
     )
     if len(kernel_then_duplicate) != 2 or any(
         occurrence.owner is not None for occurrence in kernel_then_duplicate
@@ -764,10 +790,10 @@ def test_rmp_dimension_ownership() -> None:
         )
     reused_atom_declaration = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"{\tndeclareatom{\reusedatom}{skin=dot}"
-        r"\reusedatom[label shift={72mm,73mm}]{A}}"
-        r"{\tndeclare{atom}{reusedatom}{skin=dot}"
-        r"\reusedatom[label shift={74mm,75mm}]{B}}",
+        r"{\tndeclareatom{\tnreusedatom}{skin=dot}"
+        r"\tnreusedatom[label shift={72mm,73mm}]{A}}"
+        r"{\tndeclare{atom}{tnreusedatom}{skin=dot}"
+        r"\tnreusedatom[label shift={74mm,75mm}]{B}}",
     )
     if [
         (occurrence.literal, occurrence.owner)
@@ -784,9 +810,9 @@ def test_rmp_dimension_ownership() -> None:
         )
     environment_scoped_atom = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"\begin{tenkzeq}\tndeclareatom{\envatom}{skin=dot}"
-        r"\envatom[label shift={76mm,77mm}]{A}\end{tenkzeq}"
-        r"\tnarrow{\envatom[label shift={78mm,79mm}]{B}}",
+        r"\begin{tenkzeq}\tndeclareatom{\tnenvatom}{skin=dot}"
+        r"\tnenvatom[label shift={76mm,77mm}]{A}\end{tenkzeq}"
+        r"\tnarrow{\tnenvatom[label shift={78mm,79mm}]{B}}",
     )
     if [
         (occurrence.literal, occurrence.owner)
@@ -872,6 +898,20 @@ kz}}
             "a comment-spliced environment lost its neutral boundary: "
             f"{spliced_environment!r}"
         )
+    for spaced_name in ("ten kz", "tenkz cd", " tenkz"):
+        spaced_environment = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"\begin{{{spaced_name}}}[pitch=90mm]"
+            rf"\rule{{91mm}}{{92mm}}\end{{{spaced_name}}}",
+        )
+        if len(spaced_environment) != 3 or any(
+            occurrence.owner is not None
+            for occurrence in spaced_environment
+        ):
+            raise AssertionError(
+                "whitespace inside an environment name was collapsed: "
+                f"name={spaced_name!r}, occurrences={spaced_environment!r}"
+            )
     nested_label_shift = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tnarrow[from=1,to=2]{\tnpic[inline]{"

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -41,6 +41,7 @@ from tenkzlib.dimensions import (
     scan_case_dimensions,
     validate_dimension_report,
 )
+from tenkzlib.texcase import strip_comments
 from tenkzlib.tnlog import parse_log
 
 
@@ -207,9 +208,16 @@ def _expect_dimension_failure(report: DimensionReport, phrase: str) -> None:
 
 
 def test_rmp_dimension_ownership() -> None:
-    registry = (
+    registry_source = (
         ROOT / "tex" / "tenkz" / "tenkz-language-registry.tex"
     ).read_text(encoding="utf-8")
+    registry = strip_comments(
+        registry_source
+        + "\n% \\__tenkz_language_registry_command:nnnnn "
+        "{commentedcommand}\n"
+        + "% \\__tenkz_language_registry_environment:nnnn "
+        "{commentedenvironment}\n"
+    )
     registered_commands = set(
         re.findall(
             r"__tenkz_language_registry_command:nnnnn \{([^}]+)\}",
@@ -639,6 +647,50 @@ def test_rmp_dimension_ownership() -> None:
             "a declared kernel atom inherited route or compatibility keys: "
             f"{declared_kernel_atom!r}"
         )
+    for invalid_descriptor in (
+        "bogus=x",
+        "skin=triangle",
+        "ports={west:physical}",
+        "skin=dot,ports={up:virtual}",
+    ):
+        rejected_compatibility_atom = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"\tnarrow{{\tndeclareatom{{\invalidatom}}"
+            rf"{{{invalid_descriptor}}}"
+            r"\invalidatom[label shift={80mm,81mm}]{A}}",
+        )
+        if len(rejected_compatibility_atom) != 2 or any(
+            occurrence.owner is not None
+            for occurrence in rejected_compatibility_atom
+        ):
+            raise AssertionError(
+                "an invalid compatibility descriptor activated an atom: "
+                f"descriptor={invalid_descriptor!r}, "
+                f"occurrences={rejected_compatibility_atom!r}"
+            )
+    for opener, closer in (
+        ("begingroup", "endgroup"),
+        ("bgroup", "egroup"),
+    ):
+        digit_delimited_group = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"\{opener}1\tndeclareatom{{\groupatom}}{{skin=dot}}"
+            rf"\groupatom[label shift={{82mm,83mm}}]{{A}}\{closer}2"
+            r"\tnarrow{\groupatom[label shift={84mm,85mm}]{B}}",
+        )
+        if [
+            (occurrence.literal, occurrence.owner)
+            for occurrence in digit_delimited_group
+        ] != [
+            ("82mm", DimensionOwner.LAYOUT),
+            ("83mm", DimensionOwner.LAYOUT),
+            ("84mm", None),
+            ("85mm", None),
+        ]:
+            raise AssertionError(
+                "a digit-delimited TeX group primitive lost its scope: "
+                f"opener={opener!r}, occurrences={digit_delimited_group!r}"
+            )
     atom_before_declaration = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tnarrow{\lateatom[label shift={60mm,61mm}]{A}}"

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -550,6 +550,17 @@ def test_rmp_dimension_ownership() -> None:
                 "a non-public physical option gained ownership: "
                 f"source={malformed_source!r}, occurrences={malformed_options!r}"
             )
+    unclosed_public_argument = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{x \tnpic[pitch=41mm \rule{42mm}{43mm}}",
+    )
+    if len(unclosed_public_argument) != 3 or any(
+        occurrence.owner is not None for occurrence in unclosed_public_argument
+    ):
+        raise AssertionError(
+            "an unclosed public argument exposed dimensions to an enclosing owner: "
+            f"{unclosed_public_argument!r}"
+        )
     for case_variant in (
         r"\tnarrow{x \tnpic[PITCH=34mm]{y}}",
         r"\tnarrow{x \tn[Label Shift={35mm,36mm}]{A}}",

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -599,6 +599,22 @@ def test_rmp_dimension_ownership() -> None:
                 f"source={unclosed_environment_source!r}, "
                 f"occurrences={unclosed_environment_option!r}"
             )
+    for malformed_environment_name in (
+        r"\begin{tenkz \tnput{x}{(59mm,0)}{}",
+        r"\end{tenkz \tnput{x}{(60mm,0)}{}",
+    ):
+        malformed_name_dimensions = scan_case_dimensions(
+            Path("synthetic.tex"), malformed_environment_name
+        )
+        if (
+            len(malformed_name_dimensions) != 1
+            or malformed_name_dimensions[0].owner is not None
+        ):
+            raise AssertionError(
+                "an unclosed environment name exposed nested ownership: "
+                f"source={malformed_environment_name!r}, "
+                f"occurrences={malformed_name_dimensions!r}"
+            )
     for case_variant in (
         r"\tnarrow{x \tnpic[PITCH=34mm]{y}}",
         r"\tnarrow{x \tn[Label Shift={35mm,36mm}]{A}}",

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -625,13 +625,13 @@ def test_rmp_dimension_ownership() -> None:
         (occurrence.literal, occurrence.owner)
         for occurrence in declared_compatibility_atom
     ] != [
-        ("52mm", DimensionOwner.LAYOUT),
-        ("53mm", DimensionOwner.LAYOUT),
+        ("52mm", None),
+        ("53mm", None),
         ("54mm", None),
         ("55mm", None),
     ]:
         raise AssertionError(
-            "a declared compatibility atom lost its typed boundary: "
+            "a source-only compatibility declaration granted ownership: "
             f"{declared_compatibility_atom!r}"
         )
     unbraced_compatibility_atom = scan_case_dimensions(
@@ -640,11 +640,11 @@ def test_rmp_dimension_ownership() -> None:
         r"\tnbareatom[label shift={86mm,87mm}]{A}}",
     )
     if len(unbraced_compatibility_atom) != 2 or any(
-        occurrence.owner is not DimensionOwner.LAYOUT
+        occurrence.owner is not None
         for occurrence in unbraced_compatibility_atom
     ):
         raise AssertionError(
-            "an unbraced xparse declaration argument lost its binding: "
+            "an unbraced xparse declaration escaped quarantine: "
             f"{unbraced_compatibility_atom!r}"
         )
     declared_kernel_atom = scan_case_dimensions(
@@ -695,13 +695,13 @@ def test_rmp_dimension_ownership() -> None:
             (occurrence.literal, occurrence.owner)
             for occurrence in digit_delimited_group
         ] != [
-            ("82mm", DimensionOwner.LAYOUT),
-            ("83mm", DimensionOwner.LAYOUT),
+            ("82mm", None),
+            ("83mm", None),
             ("84mm", None),
             ("85mm", None),
         ]:
             raise AssertionError(
-                "a digit-delimited TeX group primitive lost its scope: "
+                "a grouped dynamic declaration escaped quarantine: "
                 f"opener={opener!r}, occurrences={digit_delimited_group!r}"
             )
     atom_before_declaration = scan_case_dimensions(
@@ -732,15 +732,28 @@ def test_rmp_dimension_ownership() -> None:
     colliding_latex_declaration = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tnarrow{\tndeclareatom\rule{skin=dot}"
-        r"\rule[label shift={88mm,89mm}]{A}}",
+        r"\rule[label shift={88mm,89mm}]{95mm}{96mm}}",
     )
-    if len(colliding_latex_declaration) != 2 or any(
+    if len(colliding_latex_declaration) != 4 or any(
         occurrence.owner is not None
         for occurrence in colliding_latex_declaration
     ):
         raise AssertionError(
             "a format command collision activated dynamic ownership: "
             f"{colliding_latex_declaration!r}"
+        )
+    source_local_collision = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\newcommand{\tnoccupied}[2][]{A}"
+        r"\tnarrow{\tndeclareatom{\tnoccupied}{skin=dot}"
+        r"\tnoccupied[label shift={93mm,94mm}]{97mm}{98mm}}",
+    )
+    if len(source_local_collision) != 4 or any(
+        occurrence.owner is not None for occurrence in source_local_collision
+    ):
+        raise AssertionError(
+            "a source-local command collision activated dynamic ownership: "
+            f"{source_local_collision!r}"
         )
     scoped_atom_declaration = scan_case_dimensions(
         Path("synthetic.tex"),
@@ -752,13 +765,13 @@ def test_rmp_dimension_ownership() -> None:
         (occurrence.literal, occurrence.owner)
         for occurrence in scoped_atom_declaration
     ] != [
-        ("64mm", DimensionOwner.LAYOUT),
-        ("65mm", DimensionOwner.LAYOUT),
+        ("64mm", None),
+        ("65mm", None),
         ("66mm", None),
         ("67mm", None),
     ]:
         raise AssertionError(
-            "a local dynamic atom escaped its brace scope: "
+            "a local dynamic atom escaped source-wide quarantine: "
             f"{scoped_atom_declaration!r}"
         )
     compatibility_then_duplicate = scan_case_dimensions(
@@ -768,11 +781,11 @@ def test_rmp_dimension_ownership() -> None:
         r"\tnduplicateatom[label shift={68mm,69mm}]{A}",
     )
     if len(compatibility_then_duplicate) != 2 or any(
-        occurrence.owner is not DimensionOwner.LAYOUT
+        occurrence.owner is not None
         for occurrence in compatibility_then_duplicate
     ):
         raise AssertionError(
-            "a rejected duplicate replaced an active compatibility atom: "
+            "duplicate declarations escaped dynamic quarantine: "
             f"{compatibility_then_duplicate!r}"
         )
     kernel_then_duplicate = scan_case_dimensions(
@@ -799,13 +812,13 @@ def test_rmp_dimension_ownership() -> None:
         (occurrence.literal, occurrence.owner)
         for occurrence in reused_atom_declaration
     ] != [
-        ("72mm", DimensionOwner.LAYOUT),
-        ("73mm", DimensionOwner.LAYOUT),
+        ("72mm", None),
+        ("73mm", None),
         ("74mm", None),
         ("75mm", None),
     ]:
         raise AssertionError(
-            "a later scope could not safely reuse a dynamic atom name: "
+            "a reused dynamic name escaped source-wide quarantine: "
             f"{reused_atom_declaration!r}"
         )
     environment_scoped_atom = scan_case_dimensions(
@@ -818,13 +831,13 @@ def test_rmp_dimension_ownership() -> None:
         (occurrence.literal, occurrence.owner)
         for occurrence in environment_scoped_atom
     ] != [
-        ("76mm", DimensionOwner.LAYOUT),
-        ("77mm", DimensionOwner.LAYOUT),
+        ("76mm", None),
+        ("77mm", None),
         ("78mm", None),
         ("79mm", None),
     ]:
         raise AssertionError(
-            "a dynamic atom escaped its environment scope: "
+            "an environment-local atom escaped source-wide quarantine: "
             f"{environment_scoped_atom!r}"
         )
     for environment in (
@@ -898,18 +911,22 @@ kz}}
             "a comment-spliced environment lost its neutral boundary: "
             f"{spliced_environment!r}"
         )
-    for spaced_name in ("ten kz", "tenkz cd", " tenkz"):
+    for spaced_name in ("ten kz", "tenkz cd", " tenkz", "ten\nkz"):
         spaced_environment = scan_case_dimensions(
             Path("synthetic.tex"),
-            rf"\begin{{{spaced_name}}}[pitch=90mm]"
-            rf"\rule{{91mm}}{{92mm}}\end{{{spaced_name}}}",
+            rf"\tnarrow{{\begin{{{spaced_name}}}[pitch=90mm]"
+            rf"\rule{{91mm}}{{92mm}}\end{{{spaced_name}}}}}",
         )
-        if len(spaced_environment) != 3 or any(
-            occurrence.owner is not None
+        if [
+            (occurrence.literal, occurrence.owner)
             for occurrence in spaced_environment
-        ):
+        ] != [
+            ("90mm", DimensionOwner.METRIC),
+            ("91mm", None),
+            ("92mm", None),
+        ]:
             raise AssertionError(
-                "whitespace inside an environment name was collapsed: "
+                "a csname-spaced environment lost its public boundary: "
                 f"name={spaced_name!r}, occurrences={spaced_environment!r}"
             )
     nested_label_shift = scan_case_dimensions(

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -552,14 +552,43 @@ def test_rmp_dimension_ownership() -> None:
             )
     unclosed_public_argument = scan_case_dimensions(
         Path("synthetic.tex"),
-        r"\tnarrow{x \tnpic[pitch=41mm \rule{42mm}{43mm}}",
+        r"\tnarrow{x \tnpic[pitch=41mm \tnput{x}{(42mm,0)}{} "
+        r"\rule{43mm}{44mm}}",
     )
-    if len(unclosed_public_argument) != 3 or any(
+    if len(unclosed_public_argument) != 4 or any(
         occurrence.owner is not None for occurrence in unclosed_public_argument
     ):
         raise AssertionError(
             "an unclosed public argument exposed dimensions to an enclosing owner: "
             f"{unclosed_public_argument!r}"
+        )
+    for malformed_nested_source in (
+        r"\tnpic{51mm \tnput{x}{(52mm,0)}{}",
+        r"\tndeclareatom{\tnmalformed}{skin=dot}"
+        r"\tnmalformed[label shift=53mm \tnput{x}{(54mm,0)}{}",
+    ):
+        malformed_nested = scan_case_dimensions(
+            Path("synthetic.tex"), malformed_nested_source
+        )
+        if len(malformed_nested) != 2 or any(
+            occurrence.owner is not None for occurrence in malformed_nested
+        ):
+            raise AssertionError(
+                "a malformed static or dynamic argument exposed nested ownership: "
+                f"source={malformed_nested_source!r}, "
+                f"occurrences={malformed_nested!r}"
+            )
+    unclosed_environment_option = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{x \begin{tenkz}[pitch=45mm \tnput{x}{(46mm,0)}{} "
+        r"\end{tenkz}}",
+    )
+    if len(unclosed_environment_option) != 2 or any(
+        occurrence.owner is not None for occurrence in unclosed_environment_option
+    ):
+        raise AssertionError(
+            "an unclosed environment option exposed nested ownership: "
+            f"{unclosed_environment_option!r}"
         )
     for case_variant in (
         r"\tnarrow{x \tnpic[PITCH=34mm]{y}}",
@@ -1115,6 +1144,25 @@ ch=21mm,inline]{\\tn{A}}}
         raise AssertionError(
             f"a comment-split control word gained dimension ownership: {split_owner!r}"
         )
+    for extended_comment_command in (
+        "% \\tnput_extra 47mm\n",
+        "% \\tnjoin@extra 48mm\n",
+        "% \\tnwire:extra 49mm\n",
+        "% \\tnedgeλ 50mm\n",
+    ):
+        comment_dimensions = scan_case_dimensions(
+            Path("synthetic.tex"), extended_comment_command
+        )
+        if (
+            len(comment_dimensions) != 1
+            or comment_dimensions[0].owner is not None
+            or not comment_dimensions[0].in_comment
+        ):
+            raise AssertionError(
+                "an extended comment control word matched a public-command prefix: "
+                f"source={extended_comment_command!r}, "
+                f"occurrences={comment_dimensions!r}"
+            )
     book_spliced_source = "\\setlength\\textwidth{1m% join the unit\n m}\n"
     book_spliced = scan_book_dimensions(Path("book.tex"), book_spliced_source)
     if (

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -36,6 +36,7 @@ from tenkzlib.dimensions import (
     DimensionReport,
     _COMMAND_GRAMMARS,
     _PUBLIC_ENVIRONMENTS,
+    _environment_spans,
     collect_dimension_report,
     scan_book_dimensions,
     scan_case_dimensions,
@@ -578,43 +579,79 @@ def test_rmp_dimension_ownership() -> None:
                 f"source={malformed_nested_source!r}, "
                 f"occurrences={malformed_nested!r}"
             )
-    for unclosed_environment_source in (
-        r"\tnarrow{x \begin{tenkz}[pitch=45mm \tnput{x}{(46mm,0)}{} "
-        r"\end{tenkz}}",
-        r"\tnarrow{x \begin{tenkzeq}[check=55mm \tnput{x}{(56mm,0)}{} "
-        r"\end{tenkzeq}}",
-        r"\def\tenname{tenkz}"
-        r"\tnarrow{x \begin{\tenname}[pitch=57mm \tnput{x}{(58mm,0)}{} "
-        r"\end{\tenname}}",
-    ):
-        unclosed_environment_option = scan_case_dimensions(
-            Path("synthetic.tex"), unclosed_environment_source
+    environment_names = (
+        ("static", "tenkz", ""),
+        ("unresolved", r"\tenname", r"\def\tenname{tenkz}"),
+        ("parameterized", "#1", ""),
+    )
+    owner_contexts = (
+        (
+            "route",
+            r"\tnarrow{",
+            "}",
+            r"\tnput{x}{(DIM,0)}{}",
+        ),
+        (
+            "layout",
+            r"\tnput{x}{(0,0)}{",
+            "}",
+            r"\tnarrow{DIM}",
+        ),
+    )
+    malformed_kinds = ("unclosed name", "unclosed option", "missing end")
+    literal_index = 61
+    for name_kind, environment_name, prelude in environment_names:
+        for malformed_kind in malformed_kinds:
+            for owner_kind, outer_open, outer_close, inner_template in owner_contexts:
+                literal = f"{literal_index}mm"
+                literal_index += 1
+                inner_command = inner_template.replace("DIM", literal)
+                if malformed_kind == "unclosed name":
+                    environment = rf"\begin{{{environment_name} " + inner_command
+                    # Keep the name group genuinely unclosed; the outer owner
+                    # is intentionally opened but cannot close across it.
+                    suffix = ""
+                elif malformed_kind == "unclosed option":
+                    environment = (
+                        rf"\begin{{{environment_name}}}[malformed "
+                        + inner_command
+                        + rf"\end{{{environment_name}}}"
+                    )
+                    suffix = outer_close
+                else:
+                    environment = rf"\begin{{{environment_name}}}" + inner_command
+                    suffix = outer_close
+                source = prelude + outer_open + environment + suffix
+                owner_source = strip_comments(source)
+                literal_offset = source.index(literal)
+                environment_barriers = _environment_spans(source, owner_source)
+                if not any(
+                    span.is_quarantine
+                    and span.start <= literal_offset < span.end
+                    for span in environment_barriers
+                ):
+                    raise AssertionError(
+                        "a malformed environment remainder lacked a quarantine: "
+                        f"name={name_kind}, malformed={malformed_kind}, "
+                        f"outer={owner_kind}, source={source!r}, "
+                        f"spans={environment_barriers!r}"
+                    )
+                occurrences = scan_case_dimensions(Path("synthetic.tex"), source)
+                if len(occurrences) != 1 or occurrences[0].owner is not None:
+                    raise AssertionError(
+                        "a malformed environment remainder exposed an owner: "
+                        f"name={name_kind}, malformed={malformed_kind}, "
+                        f"outer={owner_kind}, source={source!r}, "
+                        f"occurrences={occurrences!r}"
+                    )
+    unclosed_environment_end = scan_case_dimensions(
+        Path("synthetic.tex"), r"\end{tenkz \tnput{x}{(79mm,0)}{}"
+    )
+    if len(unclosed_environment_end) != 1 or unclosed_environment_end[0].owner is not None:
+        raise AssertionError(
+            "an unclosed environment end name exposed nested ownership: "
+            f"{unclosed_environment_end!r}"
         )
-        if len(unclosed_environment_option) != 2 or any(
-            occurrence.owner is not None
-            for occurrence in unclosed_environment_option
-        ):
-            raise AssertionError(
-                "an unclosed environment option exposed nested ownership: "
-                f"source={unclosed_environment_source!r}, "
-                f"occurrences={unclosed_environment_option!r}"
-            )
-    for malformed_environment_name in (
-        r"\begin{tenkz \tnput{x}{(59mm,0)}{}",
-        r"\end{tenkz \tnput{x}{(60mm,0)}{}",
-    ):
-        malformed_name_dimensions = scan_case_dimensions(
-            Path("synthetic.tex"), malformed_environment_name
-        )
-        if (
-            len(malformed_name_dimensions) != 1
-            or malformed_name_dimensions[0].owner is not None
-        ):
-            raise AssertionError(
-                "an unclosed environment name exposed nested ownership: "
-                f"source={malformed_environment_name!r}, "
-                f"occurrences={malformed_name_dimensions!r}"
-            )
     for case_variant in (
         r"\tnarrow{x \tnpic[PITCH=34mm]{y}}",
         r"\tnarrow{x \tn[Label Shift={35mm,36mm}]{A}}",

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -34,6 +34,8 @@ from tenkzlib.dimensions import (
     DimensionOwner,
     DimensionOwnershipError,
     DimensionReport,
+    _COMMAND_GRAMMARS,
+    _PUBLIC_ENVIRONMENTS,
     collect_dimension_report,
     scan_book_dimensions,
     scan_case_dimensions,
@@ -205,6 +207,35 @@ def _expect_dimension_failure(report: DimensionReport, phrase: str) -> None:
 
 
 def test_rmp_dimension_ownership() -> None:
+    registry = (
+        ROOT / "tex" / "tenkz" / "tenkz-language-registry.tex"
+    ).read_text(encoding="utf-8")
+    registered_commands = set(
+        re.findall(
+            r"__tenkz_language_registry_command:nnnnn \{([^}]+)\}",
+            registry,
+        )
+    )
+    if registered_commands != set(_COMMAND_GRAMMARS):
+        raise AssertionError(
+            "dimension barriers disagree with the public command registry: "
+            f"registry-only={sorted(registered_commands - set(_COMMAND_GRAMMARS))!r}, "
+            f"scanner-only={sorted(set(_COMMAND_GRAMMARS) - registered_commands)!r}"
+        )
+    registered_environments = set(
+        re.findall(
+            r"__tenkz_language_registry_environment:nnnn \{([^}]+)\}",
+            registry,
+        )
+    )
+    if registered_environments != set(_PUBLIC_ENVIRONMENTS):
+        raise AssertionError(
+            "dimension barriers disagree with the public environment registry: "
+            f"registry-only="
+            f"{sorted(registered_environments - set(_PUBLIC_ENVIRONMENTS))!r}, "
+            f"scanner-only="
+            f"{sorted(set(_PUBLIC_ENVIRONMENTS) - registered_environments)!r}"
+        )
     targets = load_manifest(DEFAULT_MANIFEST)
     report = collect_dimension_report(ROOT, (target.case for target in targets))
     expected = Counter(
@@ -229,11 +260,11 @@ def test_rmp_dimension_ownership() -> None:
     validate_dimension_report(report)
 
     synthetic = r"""% pitch=14mm remains visible to the comment audit
-\begin{tenkz}[pitch=11mm,
-  sheet vector={0mm,2.5mm}]
+\begin{tenkz}[pitch=11mm]
   \tnput{a}{(1mm,2mm)}{}
   \tnjoin[via={(3mm,4mm)}]{a}{5mm,6mm}
 \end{tenkz}
+\begin{tenkzlattice}[sheet vector={0mm,2.5mm}]\end{tenkzlattice}
 """
     occurrences = scan_case_dimensions(Path("synthetic.tex"), synthetic)
     synthetic_counts = Counter(
@@ -334,6 +365,18 @@ def test_rmp_dimension_ownership() -> None:
             ("51pt", "52pt"),
             "53mm",
         ),
+        (
+            r"\tnpic{\rule{61pt}{62pt}}{\hspace{63mm}}",
+            None,
+            ("61pt", "62pt"),
+            "63mm",
+        ),
+        (
+            r"\tntree{{\rule{71pt}{72pt}}}{\hspace{73mm}}",
+            None,
+            ("71pt", "72pt"),
+            "73mm",
+        ),
     )
     for source, owner, owned_literals, independent_literal in command_arity_cases:
         occurrences = scan_case_dimensions(Path("synthetic.tex"), source)
@@ -410,6 +453,417 @@ def test_rmp_dimension_ownership() -> None:
     )
     if len(tree_option) != 1 or tree_option[0].owner is not DimensionOwner.METRIC:
         raise AssertionError(f"a tntree metric option lost ownership: {tree_option!r}")
+    public_example = ROOT / "tex" / "tenkz" / "examples" / "api" / "tnarrow.tex"
+    public_example_dimensions = scan_case_dimensions(
+        public_example.relative_to(ROOT), public_example.read_text(encoding="utf-8")
+    )
+    if (
+        len(public_example_dimensions) != 1
+        or public_example_dimensions[0].literal != "18mm"
+        or public_example_dimensions[0].owner is not DimensionOwner.METRIC
+    ):
+        raise AssertionError(
+            "the public tenkzcd polygon radius lost metric ownership: "
+            f"{public_example_dimensions!r}"
+        )
+    physical_picture_options = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\begin{tenkzcd}[column sep=7mm,row sep=8mm]\end{tenkzcd}"
+        r"\begin{tenkzlattice}[col vector={9mm,10mm},"
+        r"row vector={11mm,12mm},sheet vector={13mm,14mm}]"
+        r"\end{tenkzlattice}",
+    )
+    expected_picture_owners = (
+        *((literal, DimensionOwner.METRIC) for literal in ("7mm", "8mm")),
+        *((literal, DimensionOwner.FRAME) for literal in (
+            "9mm", "10mm", "11mm", "12mm", "13mm", "14mm"
+        )),
+    )
+    if tuple(
+        (occurrence.literal, occurrence.owner)
+        for occurrence in physical_picture_options
+    ) != expected_picture_owners:
+        raise AssertionError(
+            "public physical picture keys lost their semantic owners: "
+            f"{physical_picture_options!r}"
+        )
+    ratio_keys = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\begin{tenkzlattice}[plane rise=15mm,plane slant=16mm]"
+        r"\end{tenkzlattice}",
+    )
+    if len(ratio_keys) != 2 or any(
+        occurrence.owner is not None for occurrence in ratio_keys
+    ):
+        raise AssertionError(
+            "dimensionless plane-ratio keys gained physical ownership: "
+            f"{ratio_keys!r}"
+        )
+    direct_label_shift = scan_case_dimensions(
+        Path("synthetic.tex"), r"\tn*[label shift={17mm,18mm}]{A}"
+    )
+    if len(direct_label_shift) != 2 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in direct_label_shift
+    ):
+        raise AssertionError(
+            "a public object label shift lost layout ownership: "
+            f"{direct_label_shift!r}"
+        )
+    for command in ("tnX", "tnfuse"):
+        object_label_shift = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"\{command}[label shift={{17mm,18mm}}]{{A}}",
+        )
+        if len(object_label_shift) != 2 or any(
+            occurrence.owner is not DimensionOwner.LAYOUT
+            for occurrence in object_label_shift
+        ):
+            raise AssertionError(
+                f"{command} label shift lost layout ownership: "
+                f"{object_label_shift!r}"
+            )
+    for malformed_source, expected_count in (
+        (r"\tnsite[label shift={23mm,24mm}]{(1,1)}", 2),
+        (r"\tndots[label shift={25mm,26mm}]", 2),
+        (r"\tnarrow[from=1,to=2]{\tn[pitch=27mm]{A}}", 1),
+        (r"\tnpic[label shift={28mm,29mm}]{\tn{A}}", 2),
+        (r"\tnset{radius=30mm}", 1),
+        (r"\begin{tenkz}[radius=31mm]\end{tenkz}", 1),
+        (r"\begin{tenkzcd}[col vector={32mm,33mm}]\end{tenkzcd}", 2),
+    ):
+        malformed_options = scan_case_dimensions(
+            Path("synthetic.tex"), malformed_source
+        )
+        if len(malformed_options) != expected_count or any(
+            occurrence.owner is not None for occurrence in malformed_options
+        ):
+            raise AssertionError(
+                "a non-public physical option gained ownership: "
+                f"source={malformed_source!r}, occurrences={malformed_options!r}"
+            )
+    for case_variant in (
+        r"\tnarrow{x \tnpic[PITCH=34mm]{y}}",
+        r"\tnarrow{x \tn[Label Shift={35mm,36mm}]{A}}",
+        r"\tnarrow{x \begin{tenkzlattice}[COL VECTOR={37mm,38mm}]"
+        r"\end{tenkzlattice}}",
+    ):
+        case_sensitive_options = scan_case_dimensions(
+            Path("synthetic.tex"), case_variant
+        )
+        if not case_sensitive_options or any(
+            occurrence.owner is not None
+            for occurrence in case_sensitive_options
+        ):
+            raise AssertionError(
+                "a case-mismatched PGF key gained ownership: "
+                f"source={case_variant!r}, "
+                f"occurrences={case_sensitive_options!r}"
+            )
+    nested_setup = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{x \tnset{pitch=39mm,radius=40mm}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in nested_setup
+    ] != [
+        ("39mm", DimensionOwner.METRIC),
+        ("40mm", None),
+    ]:
+        raise AssertionError(
+            "a nested setup command leaked its enclosing owner: "
+            f"{nested_setup!r}"
+        )
+    neutral_command_containers = (
+        ("tn", r"\tn{\rule{41mm}{42mm}}"),
+        ("tnX", r"\tnX{\rule{41mm}{42mm}}"),
+        ("tnfuse", r"\tnfuse{\rule{41mm}{42mm}}"),
+        ("tndots", r"\tndots[label shift={41mm,42mm}]"),
+        ("tnghost", r"\tnghost{41mm}"),
+        ("tnspan", r"\tnspan{2}{\rule{41mm}{42mm}}"),
+        ("tncut", r"\tncut{\rule{41mm}{42mm}}"),
+        ("tnregion", r"\tnregion[label={\rule{41mm}{42mm}}]{x}"),
+        ("tnsite", r"\tnsite[label={\rule{41mm}{42mm}}]{(1,1)}"),
+        ("tntree", r"\tntree{{\rule{41mm}{42mm}}}"),
+        ("tnpic", r"\tnpic{\rule{41mm}{42mm}}"),
+        ("tnset", r"\tnset{radius=41mm}"),
+        ("tndeclareatom", r"\tndeclareatom{\foo}{bogus=41mm}"),
+        ("tnmark", r"\tnmark[form=label]{x}{\rule{41mm}{42mm}}"),
+        ("tngroup", r"\tngroup{\rule{41mm}{42mm}}"),
+        ("tndeclare", r"\tndeclare{skin}{x}{bogus=41mm}"),
+        ("tnbond", r"\tnbond{41mm}{x}"),
+        ("tnprose", r"\tnprose{\rule{41mm}{42mm}}"),
+    )
+    for command, container in neutral_command_containers:
+        nested_container = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"\tnarrow[from=1,to=2]{{{container}}}",
+        )
+        if not nested_container or any(
+            occurrence.owner is not None for occurrence in nested_container
+        ):
+            raise AssertionError(
+                f"a nested {command} container inherited route ownership: "
+                f"{nested_container!r}"
+            )
+    declared_compatibility_atom = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\myatom}{skin=dot}"
+        r"\tnarrow{\myatom[label shift={52mm,53mm}]"
+        r"{\rule{54mm}{55mm}}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in declared_compatibility_atom
+    ] != [
+        ("52mm", DimensionOwner.LAYOUT),
+        ("53mm", DimensionOwner.LAYOUT),
+        ("54mm", None),
+        ("55mm", None),
+    ]:
+        raise AssertionError(
+            "a declared compatibility atom lost its typed boundary: "
+            f"{declared_compatibility_atom!r}"
+        )
+    declared_kernel_atom = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclare{atom}{kernelatom}{skin=dot}"
+        r"\tnarrow{\kernelatom[label shift={56mm,57mm}]"
+        r"{\rule{58mm}{59mm}}}",
+    )
+    if len(declared_kernel_atom) != 4 or any(
+        occurrence.owner is not None for occurrence in declared_kernel_atom
+    ):
+        raise AssertionError(
+            "a declared kernel atom inherited route or compatibility keys: "
+            f"{declared_kernel_atom!r}"
+        )
+    atom_before_declaration = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{\lateatom[label shift={60mm,61mm}]{A}}"
+        r"\tndeclareatom{\lateatom}{skin=dot}",
+    )
+    if len(atom_before_declaration) != 2 or any(
+        occurrence.owner is not None for occurrence in atom_before_declaration
+    ):
+        raise AssertionError(
+            "a dynamic atom gained ownership before its declaration: "
+            f"{atom_before_declaration!r}"
+        )
+    colliding_atom_declaration = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnjoin}{skin=dot}"
+        r"\tnjoin[label shift={62mm,63mm}]{a}{b}",
+    )
+    if len(colliding_atom_declaration) != 2 or any(
+        occurrence.owner is not DimensionOwner.ROUTE
+        for occurrence in colliding_atom_declaration
+    ):
+        raise AssertionError(
+            "a rejected declaration changed a fixed public command owner: "
+            f"{colliding_atom_declaration!r}"
+        )
+    scoped_atom_declaration = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{{\tndeclareatom{\localatom}{skin=dot}"
+        r"\localatom[label shift={64mm,65mm}]{A}}"
+        r"\localatom[label shift={66mm,67mm}]{B}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in scoped_atom_declaration
+    ] != [
+        ("64mm", DimensionOwner.LAYOUT),
+        ("65mm", DimensionOwner.LAYOUT),
+        ("66mm", None),
+        ("67mm", None),
+    ]:
+        raise AssertionError(
+            "a local dynamic atom escaped its brace scope: "
+            f"{scoped_atom_declaration!r}"
+        )
+    compatibility_then_duplicate = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\duplicateatom}{skin=dot}"
+        r"\tndeclare{atom}{duplicateatom}{skin=dot}"
+        r"\duplicateatom[label shift={68mm,69mm}]{A}",
+    )
+    if len(compatibility_then_duplicate) != 2 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in compatibility_then_duplicate
+    ):
+        raise AssertionError(
+            "a rejected duplicate replaced an active compatibility atom: "
+            f"{compatibility_then_duplicate!r}"
+        )
+    kernel_then_duplicate = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclare{atom}{otherduplicate}{skin=dot}"
+        r"\tndeclareatom{\otherduplicate}{skin=dot}"
+        r"\otherduplicate[label shift={70mm,71mm}]{A}",
+    )
+    if len(kernel_then_duplicate) != 2 or any(
+        occurrence.owner is not None for occurrence in kernel_then_duplicate
+    ):
+        raise AssertionError(
+            "a rejected duplicate replaced an active kernel atom: "
+            f"{kernel_then_duplicate!r}"
+        )
+    reused_atom_declaration = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"{\tndeclareatom{\reusedatom}{skin=dot}"
+        r"\reusedatom[label shift={72mm,73mm}]{A}}"
+        r"{\tndeclare{atom}{reusedatom}{skin=dot}"
+        r"\reusedatom[label shift={74mm,75mm}]{B}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in reused_atom_declaration
+    ] != [
+        ("72mm", DimensionOwner.LAYOUT),
+        ("73mm", DimensionOwner.LAYOUT),
+        ("74mm", None),
+        ("75mm", None),
+    ]:
+        raise AssertionError(
+            "a later scope could not safely reuse a dynamic atom name: "
+            f"{reused_atom_declaration!r}"
+        )
+    environment_scoped_atom = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\begin{tenkzeq}\tndeclareatom{\envatom}{skin=dot}"
+        r"\envatom[label shift={76mm,77mm}]{A}\end{tenkzeq}"
+        r"\tnarrow{\envatom[label shift={78mm,79mm}]{B}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in environment_scoped_atom
+    ] != [
+        ("76mm", DimensionOwner.LAYOUT),
+        ("77mm", DimensionOwner.LAYOUT),
+        ("78mm", None),
+        ("79mm", None),
+    ]:
+        raise AssertionError(
+            "a dynamic atom escaped its environment scope: "
+            f"{environment_scoped_atom!r}"
+        )
+    for environment in (
+        "tenkz",
+        "tenkzcd",
+        "tenkzfree",
+        "tenkzlattice",
+        "tenkzplanes",
+        "tenkzeq",
+    ):
+        nested_environment = scan_case_dimensions(
+            Path("synthetic.tex"),
+            rf"\tnarrow{{\begin{{{environment}}}"
+            rf"\rule{{43mm}}{{44mm}}\end{{{environment}}}}}",
+        )
+        if len(nested_environment) != 2 or any(
+            occurrence.owner is not None for occurrence in nested_environment
+        ):
+            raise AssertionError(
+                f"a nested {environment} environment inherited route ownership: "
+                f"{nested_environment!r}"
+            )
+    unbraced_pgf_pair = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{\begin{tenkzlattice}[col vector=(45mm,46mm)]"
+        r"\end{tenkzlattice}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in unbraced_pgf_pair
+    ] != [
+        ("45mm", DimensionOwner.FRAME),
+        ("46mm", None),
+    ]:
+        raise AssertionError(
+            "parentheses incorrectly protected a PGF option comma: "
+            f"{unbraced_pgf_pair!r}"
+        )
+    unbraced_pgf_brackets = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow{\tn[label shift=[47mm,48mm]]{A}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in unbraced_pgf_brackets
+    ] != [
+        ("47mm", DimensionOwner.LAYOUT),
+        ("48mm", None),
+    ]:
+        raise AssertionError(
+            "brackets incorrectly protected a PGF option comma: "
+            f"{unbraced_pgf_brackets!r}"
+        )
+    spliced_environment_source = r"""\tnarrow{
+  \begin{ten% splice an environment name
+kz}[pitch=49mm]\rule{50mm}{51mm}\end{ten% splice the closing name
+kz}}
+"""
+    spliced_environment = scan_case_dimensions(
+        Path("synthetic.tex"), spliced_environment_source
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in spliced_environment
+    ] != [
+        ("49mm", DimensionOwner.METRIC),
+        ("50mm", None),
+        ("51mm", None),
+    ]:
+        raise AssertionError(
+            "a comment-spliced environment lost its neutral boundary: "
+            f"{spliced_environment!r}"
+        )
+    nested_label_shift = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tnarrow[from=1,to=2]{\tnpic[inline]{"
+        r"\tn*[label shift={19mm,20mm}]{A}}}",
+    )
+    if len(nested_label_shift) != 2 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in nested_label_shift
+    ):
+        raise AssertionError(
+            "a nested object label shift inherited route ownership: "
+            f"{nested_label_shift!r}"
+        )
+    spliced_picture_key_source = """\\tnarrow[from=1,to=2]{
+  \\tnpic[pit% splice the public option key
+ch=21mm,inline]{\\tn{A}}}
+"""
+    spliced_picture_key = scan_case_dimensions(
+        Path("synthetic.tex"), spliced_picture_key_source
+    )
+    if (
+        len(spliced_picture_key) != 1
+        or spliced_picture_key[0].owner is not DimensionOwner.METRIC
+        or spliced_picture_key[0].line != 3
+        or spliced_picture_key[0].offset
+        != spliced_picture_key_source.index("21mm")
+    ):
+        raise AssertionError(
+            "a comment-spliced picture key inherited route ownership: "
+            f"{spliced_picture_key!r}"
+        )
+    split_picture_source = "\\tn% terminate the control word\npic[pitch=22mm]{x}\n"
+    split_picture = scan_case_dimensions(
+        Path("synthetic.tex"), split_picture_source
+    )
+    if (
+        len(split_picture) != 1
+        or split_picture[0].owner is not None
+        or split_picture[0].line != 2
+    ):
+        raise AssertionError(
+            "a comment-split picture control word gained option ownership: "
+            f"{split_picture!r}"
+        )
     comment_spliced_source = """\\tnput{x}{(1% join the number and unit
  mm,2m% join the unit letters
  m,3tr% join the true prefix
@@ -599,7 +1053,8 @@ def test_rmp_dimension_ownership() -> None:
     for source, phrase in (
         (r"\begin{tenkz}[pitch=1mm]\end{tenkz}", "metric dimensions increased"),
         (
-            r"\begin{tenkz}[sheet vector={0mm,1mm}]\end{tenkz}",
+            r"\begin{tenkzlattice}[sheet vector={0mm,1mm}]"
+            r"\end{tenkzlattice}",
             "projection/frame dimensions increased",
         ),
         (r"\tnjoin{a}{1mm}", "route/string dimensions increased to 397"),

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -578,18 +578,27 @@ def test_rmp_dimension_ownership() -> None:
                 f"source={malformed_nested_source!r}, "
                 f"occurrences={malformed_nested!r}"
             )
-    unclosed_environment_option = scan_case_dimensions(
-        Path("synthetic.tex"),
+    for unclosed_environment_source in (
         r"\tnarrow{x \begin{tenkz}[pitch=45mm \tnput{x}{(46mm,0)}{} "
         r"\end{tenkz}}",
-    )
-    if len(unclosed_environment_option) != 2 or any(
-        occurrence.owner is not None for occurrence in unclosed_environment_option
+        r"\tnarrow{x \begin{tenkzeq}[check=55mm \tnput{x}{(56mm,0)}{} "
+        r"\end{tenkzeq}}",
+        r"\def\tenname{tenkz}"
+        r"\tnarrow{x \begin{\tenname}[pitch=57mm \tnput{x}{(58mm,0)}{} "
+        r"\end{\tenname}}",
     ):
-        raise AssertionError(
-            "an unclosed environment option exposed nested ownership: "
-            f"{unclosed_environment_option!r}"
+        unclosed_environment_option = scan_case_dimensions(
+            Path("synthetic.tex"), unclosed_environment_source
         )
+        if len(unclosed_environment_option) != 2 or any(
+            occurrence.owner is not None
+            for occurrence in unclosed_environment_option
+        ):
+            raise AssertionError(
+                "an unclosed environment option exposed nested ownership: "
+                f"source={unclosed_environment_source!r}, "
+                f"occurrences={unclosed_environment_option!r}"
+            )
     for case_variant in (
         r"\tnarrow{x \tnpic[PITCH=34mm]{y}}",
         r"\tnarrow{x \tn[Label Shift={35mm,36mm}]{A}}",


### PR DESCRIPTION
### Motivation

- PR #5380 has already merged the RMP dimension-ownership contract. A post-merge audit found lexical paths that could still assign a semantic owner too broadly: case-insensitive PGF keys, comma grouping beyond braces, nested public containers inheriting an outer owner, and source-declared atom commands taking effect retroactively or colliding with fixed commands.
- This follow-up hardens only the ownership scanner and its regression tests. It does not alter RMP cases, verdicts, drawings, or generated PDFs.

### Description

- Recognize TeX absolute dimensions across supported units and comment splices, while keeping authored source offsets and comment measurements auditable.
- Match physical PGF keys case-sensitively and only in the public command or environment that accepts each key; split option lists using PGF's brace-protected comma rule.
- Keep every registered public command and environment as a neutral ownership barrier unless its grammar explicitly grants metric, frame, route, or layout ownership.
- Treat every source-declared atom spelling as a source-wide neutral barrier. The source-only scanner cannot reconstruct TeX ambient control-sequence state, so dynamic declarations never grant physical ownership; common LaTeX/expl3/Unicode control words and control symbols are quarantined with conservative token boundaries.
- Normalize kernel declaration and environment names according to their distinct `c`/`\\csname` paths, including ordinary ignored whitespace and canonical expandable `\\space`; unresolved expandable environment spellings are depth-matched as neutral barriers and never grant option ownership. Unknown collided commands quarantine repeated stars, option groups, and braced groups without guessing arity.
- Add registry-equality and adversarial regressions for malformed options, nested containers, comment splices, catcode-letter names, `\\csname` spacing, repeated optional arguments, declaration order, local scope, duplicate order, and fixed-command collisions.

### Testing

- `python3 -Werror -m py_compile scripts/tenkzlib/dimensions.py scripts/test_tenkz_corpus_provenance.py`
- `git diff --check origin/main...HEAD`
- `python3 scripts/test_tenkz_corpus_provenance.py`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/test_tenkz_language.py`
- `TENKZ_RMP_JOBS=2 python3 scripts/tenkz_rmp.py check --all` — immediate parent `7026459` validated, compiled, linted, and audited all 130 targets; the latest scanner-only delta passes its focused provenance, macro-environment, pycompile, and cleanliness gates, and exact-head Actions must pass before merge. The dimension baseline remains 926 case dimensions (396 route, 530 layout), with 0 metric, frame, or comment dimensions and 28 benchmark-book layout dimensions.

---
Follow-up to #5380.

### Agent assistance

- OpenAI Codex (GPT-5) assisted with the scanner implementation, adversarial regression design, and exact-head validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, security-adjacent static-analysis change to RMP audit gates; behavior is intentionally stricter but limited to scanner/tests with frozen dimension baselines.
> 
> **Overview**
> Hardens the **source-only RMP dimension-ownership scanner** in `scripts/tenkzlib/dimensions.py` so physical dimensions are classified more narrowly and fail closed; corpus cases and ratchet ceilings are unchanged.
> 
> **Physical PGF keys** are matched **case-sensitively** from a single `_PHYSICAL_OPTION_KEY_OWNERS` table, with per-environment and per-command allowlists validated at import. Option lists split on commas only when **braces** protect them (PGF-style), not parentheses/brackets.
> 
> **Public commands** beyond route/layout primitives are mostly **neutral barriers** (`owner=None`); only whitelisted option values get metric/frame/layout spans. **Environments** (`tenkz*`, `tenkzeq`) add neutral scope barriers, `\csname`/`\space` name normalization, and **quarantine** spans for malformed names/options or unclosed groups.
> 
> **Dynamic atom declarations** (`\tndeclareatom`, kernel `\tndeclare{atom}{…}`) register **source-wide neutral** command spellings with conservative quarantine on collisions and unknown arity—no retroactive ownership. Span resolution prefers **quarantine** over shorter enclosing owners.
> 
> **Tests** in `test_tenkz_corpus_provenance.py` assert registry parity with `tenkz-language-registry.tex` and add broad adversarial coverage (nested containers, comment splices, catcodes, macro environments, invalid options).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae1485436f6c3170de70a3c4dd4868cffa749d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

