### PR TITLE
doc(MPDO/RFP): classify normalization-sensitive source routes

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -450,7 +450,7 @@
 % conditional blocking theorem thm:mpdo_blocked_original_tensor_is_rfp_via_ts
 % instead assumes a neighboring trace factorization.
 % Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[Blocking channels from SAL and ZCL (obstructed by Lemma C.5)]
+\begin{theorem}[Blocking channels from SAL and ZCL (rank-one obstruction)]
     \label{thm:mpdo_sal_zcl_blocking_channels}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl, def:is_rfp_via_ts,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -450,7 +450,7 @@
 % conditional blocking theorem thm:mpdo_blocked_original_tensor_is_rfp_via_ts
 % instead assumes a neighboring trace factorization.
 % Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[Blocking channels from SAL and ZCL (open)]
+\begin{theorem}[Blocking channels from SAL and ZCL (obstructed by Lemma C.5)]
     \label{thm:mpdo_sal_zcl_blocking_channels}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl, def:is_rfp_via_ts,
@@ -469,8 +469,8 @@
     The printed proof of implication (ii)$\Rightarrow$(v) refers back to the
     construction of Proposition~C.7 after projection to each local sector.
     That construction requires the rank-one neighboring-trace factorization
-    supplied in the printed argument by the refuted Lemma~C.5. No proof under
-    SAL and ZCL alone is presently known.
+    supplied in the printed argument by the refuted Lemma~C.5. Thus the printed
+    route is obstructed; no alternative proof under SAL and ZCL alone is known.
 \end{theorem}
 
 % Correct equation, not a figure: the cited source draws the two-to-three

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -134,7 +134,7 @@
 % given by thm:psd_trace_powers_rank_one_t and
 % thm:pairing_idempotent_rank_one_t. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{corollary}[Local sector structure from SAL and ZCL (open)]
+\begin{corollary}[Local sector structure from SAL and ZCL (obstructed by Lemma C.5)]
     \label{cor:mpdo_sal_zcl_local_sector_structure}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl, thm:sal_implies_eta_structure,
@@ -150,8 +150,8 @@
     \end{align}
     This is the structural corollary at
     \cite[Appendix~C.2, lines~1501--1505]{Cirac2016MPDO_arXiv}. Its printed
-    derivation combines Lemma~C.4 with the refuted Lemma~C.5, so the conclusion
-    remains open under the printed hypotheses.
+    derivation combines Lemma~C.4 with the refuted Lemma~C.5, so the printed
+    route is obstructed under the stated hypotheses.
 \end{corollary}
 
 \begin{theorem}[Positive neighboring sectors generate positive periodic operators]
@@ -762,7 +762,7 @@ This is the calculation in
 % thm:psd_trace_powers_rank_one_t and thm:pairing_idempotent_rank_one_t.
 % Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[BNT sector structure from SAL and ZCL]
+\begin{theorem}[BNT sector structure from SAL and ZCL (obstructed by Lemma C.5)]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -134,7 +134,7 @@
 % given by thm:psd_trace_powers_rank_one_t and
 % thm:pairing_idempotent_rank_one_t. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{corollary}[Local sector structure from SAL and ZCL (obstructed by Lemma C.5)]
+\begin{corollary}[Local sector structure from SAL and ZCL (rank-one obstruction)]
     \label{cor:mpdo_sal_zcl_local_sector_structure}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl, thm:sal_implies_eta_structure,
@@ -150,8 +150,9 @@
     \end{align}
     This is the structural corollary at
     \cite[Appendix~C.2, lines~1501--1505]{Cirac2016MPDO_arXiv}. Its printed
-    derivation combines Lemma~C.4 with the refuted Lemma~C.5, so the printed
-    route is obstructed under the stated hypotheses.
+    derivation combines Lemma~C.4 with the refuted rank-one conclusion of
+    Lemma~C.5. Thus the printed route is obstructed; no alternative proof of
+    this corollary from SAL and ZCL alone is known.
 \end{corollary}
 
 \begin{theorem}[Positive neighboring sectors generate positive periodic operators]
@@ -762,7 +763,7 @@ This is the calculation in
 % thm:psd_trace_powers_rank_one_t and thm:pairing_idempotent_rank_one_t.
 % Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[BNT sector structure from SAL and ZCL (obstructed by Lemma C.5)]
+\begin{theorem}[BNT sector structure from SAL and ZCL (rank-one obstruction)]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl,
@@ -785,4 +786,8 @@ This is the calculation in
     the positive neighboring operators in each sector factorization, and the
     unstarred layer identities. The remaining identities specify the local
     factorization and its rank-one normalization.
+    The printed proof obtains that normalization from the structural corollary
+    above, whose derivation invokes the refuted rank-one conclusion of
+    Lemma~C.5. Thus the printed route is obstructed; no alternative proof of the
+    complete sector structure from SAL and ZCL alone is known.
 \end{theorem}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -84,7 +84,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | — | L188 `tenkz` → `C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L213 `tenkz` → `C-record`<br>L731 `tenkz` → `C-policy+C-record` | L735, 741, 746 `tenkz` → `C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L214 `tenkz` → `C-record`<br>L732 `tenkz` → `C-policy+C-record` | L736, 742, 747 `tenkz` → `C-record+R-record` |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |


### PR DESCRIPTION
## Summary

- classify the three Lemma C.5-dependent CPSV16 blueprint statements as obstructed rather than merely open;
- retain `\notready` and distinguish obstruction of the printed proof route from refutation of the final implications;
- keep the exact source-line and paper-gap anchors.

## Retrospective normalization correction (2026-08-03)

This documentation change originally inherited the claim that Lemma C.5 itself had been refuted. PR #5389 later showed that the four-sector tensor is a raw-representative obstruction: it satisfies SAL and literal fixed-tensor ZCL but is not the normal unit-weight representative used in Case I. Its normal rescaling has unit weight but fails literal fixed-tensor ZCL.

The durable classification is therefore: Lemma C.5 and its dependent source statements are unresolved at the normalization boundary. The printed rank-one proof has an unclosed step, but neither the lemma nor the downstream implications are declared false.

Closes the historical documentation task #5385. Corrected source status: #5389.

## Historical validation

- `git diff --check origin/main...HEAD`;
- reader-facing prose and focused TeX checks;
- blueprint-to-Lean synchronization;
- no Lean files changed and no `lake` command was run.