### PR TITLE
fix(tenkz): close scanner execution-boundary gaps

### DIFF
--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -1886,10 +1886,10 @@ def main() -> int:
     try:
         manifest = Path(os.environ.get("TENKZ_RMP_MANIFEST", DEFAULT_MANIFEST))
         targets = load_manifest(manifest)
-        dimension_report = collect_dimension_report(
-            REPO, (target.case for target in targets)
-        )
         try:
+            dimension_report = collect_dimension_report(
+                REPO, (target.case for target in targets)
+            )
             validate_dimension_report(dimension_report)
         except DimensionOwnershipError as exc:
             fail(f"RMP dimension ownership failed:\n{exc}")

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -229,8 +229,16 @@ _LATEX_COMMAND_DEFINITION_RE = re.compile(
     r"\\(?:newcommand|renewcommand|providecommand|DeclareRobustCommand)"
     + _TEX_CONTROL_WORD_END
 )
+_LATEX_ENVIRONMENT_DEFINITION_RE = re.compile(
+    r"\\(?:newenvironment|renewenvironment|provideenvironment)"
+    + _TEX_CONTROL_WORD_END
+)
 _DOCUMENT_COMMAND_DEFINITION_RE = re.compile(
     r"\\(?:New|Renew|Provide|Declare)(?:Expandable)?DocumentCommand"
+    + _TEX_CONTROL_WORD_END
+)
+_DOCUMENT_ENVIRONMENT_DEFINITION_RE = re.compile(
+    r"\\(?:New|Renew|Provide|Declare)DocumentEnvironment"
     + _TEX_CONTROL_WORD_END
 )
 _ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z@:_][A-Za-z0-9@:_*.-]*")
@@ -703,12 +711,24 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                 for definition in _PRIMITIVE_DEFINITION_RE.finditer(source)
             ),
             *(
-                (definition.start(), "latex", definition)
+                (definition.start(), "latex command", definition)
                 for definition in _LATEX_COMMAND_DEFINITION_RE.finditer(source)
             ),
             *(
-                (definition.start(), "xparse", definition)
+                (definition.start(), "latex environment", definition)
+                for definition in _LATEX_ENVIRONMENT_DEFINITION_RE.finditer(
+                    source
+                )
+            ),
+            *(
+                (definition.start(), "xparse command", definition)
                 for definition in _DOCUMENT_COMMAND_DEFINITION_RE.finditer(source)
+            ),
+            *(
+                (definition.start(), "xparse environment", definition)
+                for definition in _DOCUMENT_ENVIRONMENT_DEFINITION_RE.finditer(
+                    source
+                )
             ),
         ),
         key=lambda candidate: candidate[0],
@@ -769,7 +789,7 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                     )
                 )
                 break
-        elif definition_kind == "latex":
+        elif definition_kind.startswith("latex"):
             position = _skip_space(source, definition.end())
             if source[position : position + 1] == "*":
                 position = _skip_space(source, position + 1)
@@ -790,20 +810,29 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                 position = _skip_space(source, closed)
             if malformed_option:
                 continue
-            replacements = _following_mandatory_arguments(
-                source, position, 1
-            )
-            if replacements is None:
-                quarantine_unclosed_mandatory(position, definition.start())
-                continue
-            replacement = replacements[0]
-            spans.append(
-                (definition.start(), replacement.end)
-            )
+            body_count = 2 if definition_kind.endswith("environment") else 1
+            bodies: list[_MandatoryArgument] = []
+            for _ in range(body_count):
+                following = _following_mandatory_arguments(
+                    source, position, 1
+                )
+                if following is None:
+                    quarantine_unclosed_mandatory(
+                        position, definition.start()
+                    )
+                    break
+                body = following[0]
+                bodies.append(body)
+                position = body.end
+            if len(bodies) == body_count:
+                spans.append((definition.start(), bodies[-1].end))
         else:
             position = definition.end()
             arguments: list[_MandatoryArgument] = []
-            for _ in range(3):
+            argument_count = (
+                4 if definition_kind.endswith("environment") else 3
+            )
+            for _ in range(argument_count):
                 following = _following_mandatory_arguments(
                     source, position, 1
                 )
@@ -815,11 +844,8 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                 argument = following[0]
                 arguments.append(argument)
                 position = argument.end
-            if len(arguments) == 3:
-                replacement = arguments[2]
-                spans.append(
-                    (definition.start(), replacement.end)
-                )
+            if len(arguments) == argument_count:
+                spans.append((definition.start(), arguments[-1].end))
     return spans
 
 

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -1068,7 +1068,7 @@ class _ExecutionContext:
 
 
 def _execution_context(source: str, owner_source: str) -> _ExecutionContext:
-    """Resolve mutually dependent declaration and replacement masks."""
+    """Resolve mutually dependent masks by finite-state convergence."""
     declared_commands = _declared_atom_commands(source, owner_source)
     state = (declared_commands, (), ())
     seen = {state}
@@ -1096,11 +1096,11 @@ def _execution_context(source: str, owner_source: str) -> _ExecutionContext:
             owner_source,
             next_replacement_spans + command_quarantines,
         )
-        # Begin with the raw source-wide superset and only remove declarations
-        # proven inert; an ambiguous self-reference therefore fails closed.
-        next_declared_commands = declared_commands.intersection(
-            visible_declared_commands
-        )
+        # Recompute exactly: a declaration hidden by a transient replacement
+        # span can become visible after the command quarantine that caused that
+        # span stabilizes. Repeated full states below make genuine cycles fail
+        # closed instead of silently retaining either side of the ambiguity.
+        next_declared_commands = visible_declared_commands
         next_state = (
             next_declared_commands,
             next_replacement_spans,

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -230,7 +230,7 @@ _LATEX_COMMAND_DEFINITION_RE = re.compile(
     + _TEX_CONTROL_WORD_END
 )
 _DOCUMENT_COMMAND_DEFINITION_RE = re.compile(
-    r"\\(?:New|Renew|Provide|Declare)DocumentCommand"
+    r"\\(?:New|Renew|Provide|Declare)(?:Expandable)?DocumentCommand"
     + _TEX_CONTROL_WORD_END
 )
 _ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z@:_][A-Za-z0-9@:_*.-]*")
@@ -713,6 +713,15 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
         ),
         key=lambda candidate: candidate[0],
     )
+
+    def quarantine_unclosed_mandatory(position: int) -> None:
+        position = _skip_space(source, position)
+        if (
+            source[position : position + 1] == "{"
+            and match_group(source, position, "{", "}") < 0
+        ):
+            spans.append((position, len(source)))
+
     for _, definition_kind, definition in definitions:
         if (
             not _is_control_word_start(source, definition.start())
@@ -761,29 +770,45 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                 position = _skip_space(source, position + 1)
             names = _following_mandatory_arguments(source, position, 1)
             if names is None:
+                quarantine_unclosed_mandatory(position)
                 continue
             position = _skip_space(source, names[0].end)
+            malformed_option = False
             for _ in range(2):
                 if source[position : position + 1] != "[":
                     break
                 closed = match_group(source, position, "[", "]")
                 if closed < 0:
-                    position = len(source)
+                    spans.append((position, len(source)))
+                    malformed_option = True
                     break
                 position = _skip_space(source, closed)
+            if malformed_option:
+                continue
             replacements = _following_mandatory_arguments(
                 source, position, 1
             )
-            if replacements is not None:
-                replacement = replacements[0]
-                spans.append(
-                    (replacement.content_start, replacement.content_end)
-                )
-        else:
-            arguments = _following_mandatory_arguments(
-                source, definition.end(), 3
+            if replacements is None:
+                quarantine_unclosed_mandatory(position)
+                continue
+            replacement = replacements[0]
+            spans.append(
+                (replacement.content_start, replacement.content_end)
             )
-            if arguments is not None:
+        else:
+            position = definition.end()
+            arguments: list[_MandatoryArgument] = []
+            for _ in range(3):
+                following = _following_mandatory_arguments(
+                    source, position, 1
+                )
+                if following is None:
+                    quarantine_unclosed_mandatory(position)
+                    break
+                argument = following[0]
+                arguments.append(argument)
+                position = argument.end
+            if len(arguments) == 3:
                 replacement = arguments[2]
                 spans.append(
                     (replacement.content_start, replacement.content_end)

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -805,6 +805,10 @@ def _macro_replacement_spans(
                 if character == "#":
                     position += 1
                     continue
+                if character == "}":
+                    spans.append((definition.start(), len(source)))
+                    body_found = True
+                    break
                 if character != "{":
                     position += 1
                     continue

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -780,6 +780,7 @@ def _macro_replacement_spans(
             continue
         if definition_kind == "primitive":
             position = definition.end()
+            body_found = False
             while position < len(source):
                 character = source[position]
                 if character == "\\":
@@ -814,7 +815,10 @@ def _macro_replacement_spans(
                         len(source) if closed < 0 else closed,
                     )
                 )
+                body_found = True
                 break
+            if not body_found:
+                spans.append((definition.start(), len(source)))
         elif definition_kind.startswith("latex"):
             position = _skip_space(source, definition.end())
             if source[position : position + 1] == "*":

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -489,17 +489,26 @@ def _environment_scope_spans(
 
 
 def _declared_atom_commands(
-    source: str, owner_source: str
+    source: str,
+    owner_source: str,
+    execution_mask_spans: Iterable[tuple[int, int]] = (),
 ) -> frozenset[str]:
     """Return dynamic spellings as neutral, source-wide barriers.
 
     Whether ``NewDocumentCommand`` succeeds depends on TeX's ambient control
     sequence table, which a source-only scanner cannot reconstruct.  Dynamic
-    declarations therefore never grant dimension ownership here.
+    declarations therefore never grant dimension ownership here. Declarations
+    stored inside known execution-mask spans are not executed and are excluded.
     """
+    execution_mask_spans = tuple(execution_mask_spans)
     names: set[str] = set()
     for declaration in _DECLARE_ATOM_RE.finditer(owner_source):
-        if not _is_control_word_start(owner_source, declaration.start()):
+        if (
+            not _is_control_word_start(owner_source, declaration.start())
+            or _position_in_spans(
+                declaration.start(), execution_mask_spans
+            )
+        ):
             continue
         arguments = _following_mandatory_arguments(
             owner_source, declaration.end(), 2
@@ -513,7 +522,12 @@ def _declared_atom_commands(
         if name is not None:
             names.add(name)
     for declaration in _KERNEL_DECLARE_RE.finditer(owner_source):
-        if not _is_control_word_start(owner_source, declaration.start()):
+        if (
+            not _is_control_word_start(owner_source, declaration.start())
+            or _position_in_spans(
+                declaration.start(), execution_mask_spans
+            )
+        ):
             continue
         arguments = _following_mandatory_arguments(
             owner_source, declaration.end(), 3
@@ -1044,6 +1058,67 @@ def _option_spans(
     return spans
 
 
+@dataclass(frozen=True)
+class _ExecutionContext:
+    """Stable definition, command, and shared execution-mask spans."""
+
+    replacement_spans: tuple[tuple[int, int], ...]
+    command_spans: tuple[_OwnerSpan, ...]
+    mask_spans: tuple[tuple[int, int], ...]
+
+
+def _execution_context(source: str, owner_source: str) -> _ExecutionContext:
+    """Resolve mutually dependent declaration and replacement masks."""
+    declared_commands = _declared_atom_commands(source, owner_source)
+    state = (declared_commands, (), ())
+    seen = {state}
+    # Every span boundary is a source offset.  The cycle check normally reaches
+    # the fixed point in two or three rounds; this finite bound is a final guard.
+    for _ in range(len(owner_source) + 2):
+        declared_commands, replacement_spans, _ = state
+        command_spans = tuple(
+            _command_spans(
+                owner_source, declared_commands, replacement_spans
+            )
+        )
+        command_quarantines = tuple(
+            (span.start, span.end)
+            for span in command_spans
+            if span.is_quarantine
+        )
+        next_replacement_spans = tuple(
+            _macro_replacement_spans(
+                owner_source, command_quarantines
+            )
+        )
+        visible_declared_commands = _declared_atom_commands(
+            source,
+            owner_source,
+            next_replacement_spans + command_quarantines,
+        )
+        # Begin with the raw source-wide superset and only remove declarations
+        # proven inert; an ambiguous self-reference therefore fails closed.
+        next_declared_commands = declared_commands.intersection(
+            visible_declared_commands
+        )
+        next_state = (
+            next_declared_commands,
+            next_replacement_spans,
+            command_quarantines,
+        )
+        if next_state == state:
+            return _ExecutionContext(
+                next_replacement_spans,
+                command_spans,
+                next_replacement_spans + command_quarantines,
+            )
+        if next_state in seen:
+            raise RuntimeError("tenkz execution masks did not converge")
+        seen.add(next_state)
+        state = next_state
+    raise RuntimeError("tenkz execution masks exceeded their source bound")
+
+
 def _comment_ranges(source: str) -> list[tuple[int, int]]:
     ranges: list[tuple[int, int]] = []
     line_start = 0
@@ -1144,38 +1219,16 @@ def scan_case_dimensions(path: Path, source: str) -> tuple[DimensionOccurrence, 
     # ``\tn%...\nput``.  Keep ownership on an offset-preserving blanked view
     # while the numeric/unit recognizer uses the collapsed mapped view above.
     owner_source = strip_comments(source)
-    declared_commands = _declared_atom_commands(source, owner_source)
-    # Definition-shaped tokens consumed by a dynamic label are inert. Discover
-    # command quarantines first so such a token cannot claim a later sibling as
-    # its replacement body; then recompute commands against the resulting mask.
-    command_prepass = _command_spans(owner_source, declared_commands)
-    command_quarantines = tuple(
-        (span.start, span.end)
-        for span in command_prepass
-        if span.is_quarantine
-    )
-    replacement_spans = _macro_replacement_spans(
-        owner_source, command_quarantines
-    )
-    command_spans = _command_spans(
-        owner_source, declared_commands, replacement_spans
-    )
-    # A quarantined command consumes any control token in its parsed extent.
-    # Keep independent option and environment scans from reactivating it.
-    execution_mask_spans = tuple(replacement_spans) + tuple(
-        (span.start, span.end)
-        for span in command_spans
-        if span.is_quarantine
-    )
+    context = _execution_context(source, owner_source)
     owner_spans = (
-        _option_spans(source, owner_source, execution_mask_spans)
-        + command_spans
+        _option_spans(source, owner_source, context.mask_spans)
+        + list(context.command_spans)
         + _environment_spans(
-            source, owner_source, execution_mask_spans
+            source, owner_source, context.mask_spans
         )
         + [
             _OwnerSpan(start, end, None, True)
-            for start, end in replacement_spans
+            for start, end in context.replacement_spans
         ]
     )
     # A semantic option value is more specific than its containing command.

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -222,6 +222,17 @@ _TEX_CONTROL_WORD_END = r"(?![^\W\d_]|[@:_])"
 _ENVIRONMENT_CONTROL_RE = re.compile(
     r"\\(begin|end)" + _TEX_CONTROL_WORD_END
 )
+_PRIMITIVE_DEFINITION_RE = re.compile(
+    r"\\(?:def|gdef|edef|xdef)" + _TEX_CONTROL_WORD_END
+)
+_LATEX_COMMAND_DEFINITION_RE = re.compile(
+    r"\\(?:newcommand|renewcommand|providecommand|DeclareRobustCommand)"
+    + _TEX_CONTROL_WORD_END
+)
+_DOCUMENT_COMMAND_DEFINITION_RE = re.compile(
+    r"\\(?:New|Renew|Provide|Declare)DocumentCommand"
+    + _TEX_CONTROL_WORD_END
+)
 _ENVIRONMENT_NAME_RE = re.compile(r"[A-Za-z@:_][A-Za-z0-9@:_*.-]*")
 _CSNAME_SPACE_RE = re.compile(r"\\space" + _TEX_CONTROL_WORD_END)
 
@@ -406,6 +417,15 @@ def _following_mandatory_arguments(
                 ):
                     token_end += 1
             argument = _MandatoryArgument(position, token_end, token_end)
+        elif (
+            source[position] == "#"
+            and position + 1 < len(source)
+            and source[position + 1].isdigit()
+        ):
+            # Inside a macro replacement, ``#1`` denotes the substituted
+            # parameter token list. Keep the marker and parameter number
+            # together so an unbraced expandable argument is fail-closed.
+            argument = _MandatoryArgument(position, position + 2, position + 2)
         else:
             argument = _MandatoryArgument(position, position + 1, position + 1)
         arguments.append(argument)
@@ -547,12 +567,13 @@ def _command_spans(
         name = command.group(1)
         grammar = grammars[name]
         span_owner = grammar.owner
-        is_quarantine = False
+        is_quarantine = name in dynamic_names
         position = _skip_space(source, command.end())
         if name in dynamic_names:
             # The declaration may have collided with a command of unknown
             # signature.  Quarantine every adjacent syntactic argument rather
             # than guessing how many stars, options, or groups it accepts.
+            consumed_brace_group = False
             while position < len(source):
                 character = source[position : position + 1]
                 if character == "*":
@@ -570,7 +591,35 @@ def _command_spans(
                     span_owner = None
                     is_quarantine = True
                     break
+                consumed_brace_group = consumed_brace_group or character == "{"
                 position = _skip_space(source, closed)
+            if not consumed_brace_group and position < len(source):
+                arguments = _following_mandatory_arguments(source, position, 1)
+                if arguments is not None:
+                    argument = arguments[0]
+                    argument_source = source[
+                        argument.content_start : argument.content_end
+                    ]
+                    position = _skip_space(source, argument.end)
+                    # A control sequence consumed as the atom label is inert.
+                    # Conservatively quarantine its adjacent syntax too, so
+                    # the same token cannot be rescanned as a public command.
+                    if argument_source.startswith("\\"):
+                        while position < len(source):
+                            character = source[position : position + 1]
+                            if character == "*":
+                                position = _skip_space(source, position + 1)
+                                continue
+                            if character not in "[{":
+                                break
+                            closer = "]" if character == "[" else "}"
+                            closed = match_group(
+                                source, position, character, closer
+                            )
+                            if closed < 0:
+                                position = len(source)
+                                break
+                            position = _skip_space(source, closed)
         else:
             if grammar.accepts_star and source[position : position + 1] == "*":
                 position = _skip_space(source, position + 1)
@@ -661,26 +710,107 @@ def _option_group_spans(
     return spans
 
 
+def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
+    """Return inert bodies of primitive, LaTeX, and xparse macro definitions."""
+    spans: list[tuple[int, int]] = []
+    for definition in _PRIMITIVE_DEFINITION_RE.finditer(source):
+        if not _is_control_word_start(source, definition.start()):
+            continue
+        position = definition.end()
+        while position < len(source):
+            character = source[position]
+            if character == "\\":
+                arguments = _following_mandatory_arguments(source, position, 1)
+                if arguments is None:
+                    break
+                position = arguments[0].end
+                continue
+            if (
+                character == "#"
+                and position + 1 < len(source)
+                and (
+                    source[position + 1].isdigit()
+                    or source[position + 1] == "#"
+                )
+            ):
+                # Parameter markers belong to the definition header.
+                position += 2
+                continue
+            if character == "#":
+                position += 1
+                continue
+            if character != "{":
+                position += 1
+                continue
+            closed = match_group(source, position, "{", "}")
+            spans.append((position, len(source) if closed < 0 else closed))
+            break
+    for definition in _LATEX_COMMAND_DEFINITION_RE.finditer(source):
+        if not _is_control_word_start(source, definition.start()):
+            continue
+        position = _skip_space(source, definition.end())
+        if source[position : position + 1] == "*":
+            position = _skip_space(source, position + 1)
+        names = _following_mandatory_arguments(source, position, 1)
+        if names is None:
+            continue
+        position = _skip_space(source, names[0].end)
+        for _ in range(2):
+            if source[position : position + 1] != "[":
+                break
+            closed = match_group(source, position, "[", "]")
+            if closed < 0:
+                position = len(source)
+                break
+            position = _skip_space(source, closed)
+        replacements = _following_mandatory_arguments(source, position, 1)
+        if replacements is not None:
+            replacement = replacements[0]
+            spans.append((replacement.content_start, replacement.content_end))
+    for definition in _DOCUMENT_COMMAND_DEFINITION_RE.finditer(source):
+        if not _is_control_word_start(source, definition.start()):
+            continue
+        arguments = _following_mandatory_arguments(
+            source, definition.end(), 3
+        )
+        if arguments is not None:
+            replacement = arguments[2]
+            spans.append((replacement.content_start, replacement.content_end))
+    return spans
+
+
+def _position_in_spans(
+    position: int, spans: Iterable[tuple[int, int]]
+) -> bool:
+    """Whether a source position lies inside any half-open span."""
+    return any(start <= position < end for start, end in spans)
+
+
 def _environment_tokens(
     source: str, owner_source: str
 ) -> list[_EnvironmentToken]:
     """Parse simple environment names without joining split control words."""
     tokens: list[_EnvironmentToken] = []
+    replacement_spans = _macro_replacement_spans(owner_source)
     for control in _ENVIRONMENT_CONTROL_RE.finditer(owner_source):
-        if not _is_control_word_start(owner_source, control.start()):
+        if (
+            not _is_control_word_start(owner_source, control.start())
+            or _position_in_spans(control.start(), replacement_spans)
+        ):
             continue
-        position = _skip_space(owner_source, control.end())
-        if owner_source[position : position + 1] != "{":
+        arguments = _following_mandatory_arguments(
+            owner_source, control.end(), 1
+        )
+        if arguments is None:
             continue
-        closed = match_group(owner_source, position, "{", "}")
-        if closed < 0:
-            continue
+        argument = arguments[0]
         # LaTeX dispatch expands the name in ``\csname``.  Model canonical
         # spaces exactly; unresolved control sequences cannot safely grant a
         # public option owner, but matching spellings still form a neutral
         # quarantine so their bodies cannot inherit an enclosing owner.
         spelling = _csname_spelling(
-            source[position + 1 : closed - 1], expand_space=True
+            source[argument.content_start : argument.content_end],
+            expand_space=True,
         )
         if _ENVIRONMENT_NAME_RE.fullmatch(spelling) is not None:
             name: str | None = spelling
@@ -692,7 +822,11 @@ def _environment_tokens(
             continue
         tokens.append(
             _EnvironmentToken(
-                control.group(1), name, match_name, control.start(), closed
+                control.group(1),
+                name,
+                match_name,
+                control.start(),
+                argument.end,
             )
         )
     return tokens
@@ -714,10 +848,14 @@ def _environment_spans(
             tokens, _PUBLIC_ENVIRONMENTS
         )
     ]
+    replacement_spans = _macro_replacement_spans(owner_source)
     # An unclosed environment-name argument cannot be resolved to a public
     # name, but it still consumes the remainder as one malformed control.
     for control in _ENVIRONMENT_CONTROL_RE.finditer(owner_source):
-        if not _is_control_word_start(owner_source, control.start()):
+        if (
+            not _is_control_word_start(owner_source, control.start())
+            or _position_in_spans(control.start(), replacement_spans)
+        ):
             continue
         position = _skip_space(owner_source, control.end())
         if owner_source[position : position + 1] != "{":

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -694,7 +694,7 @@ def _option_group_spans(
 
 
 def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
-    """Return inert bodies of primitive, LaTeX, and xparse macro definitions."""
+    """Return definition extents whose tokens are inert until invocation."""
     spans: list[tuple[int, int]] = []
     definitions = sorted(
         (
@@ -714,13 +714,15 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
         key=lambda candidate: candidate[0],
     )
 
-    def quarantine_unclosed_mandatory(position: int) -> None:
+    def quarantine_unclosed_mandatory(
+        position: int, definition_start: int
+    ) -> None:
         position = _skip_space(source, position)
         if (
             source[position : position + 1] == "{"
             and match_group(source, position, "{", "}") < 0
         ):
-            spans.append((position, len(source)))
+            spans.append((definition_start, len(source)))
 
     for _, definition_kind, definition in definitions:
         if (
@@ -761,7 +763,10 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                     continue
                 closed = match_group(source, position, "{", "}")
                 spans.append(
-                    (position, len(source) if closed < 0 else closed)
+                    (
+                        definition.start(),
+                        len(source) if closed < 0 else closed,
+                    )
                 )
                 break
         elif definition_kind == "latex":
@@ -770,7 +775,7 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                 position = _skip_space(source, position + 1)
             names = _following_mandatory_arguments(source, position, 1)
             if names is None:
-                quarantine_unclosed_mandatory(position)
+                quarantine_unclosed_mandatory(position, definition.start())
                 continue
             position = _skip_space(source, names[0].end)
             malformed_option = False
@@ -779,7 +784,7 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                     break
                 closed = match_group(source, position, "[", "]")
                 if closed < 0:
-                    spans.append((position, len(source)))
+                    spans.append((definition.start(), len(source)))
                     malformed_option = True
                     break
                 position = _skip_space(source, closed)
@@ -789,11 +794,11 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                 source, position, 1
             )
             if replacements is None:
-                quarantine_unclosed_mandatory(position)
+                quarantine_unclosed_mandatory(position, definition.start())
                 continue
             replacement = replacements[0]
             spans.append(
-                (replacement.content_start, replacement.content_end)
+                (definition.start(), replacement.end)
             )
         else:
             position = definition.end()
@@ -803,7 +808,9 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
                     source, position, 1
                 )
                 if following is None:
-                    quarantine_unclosed_mandatory(position)
+                    quarantine_unclosed_mandatory(
+                        position, definition.start()
+                    )
                     break
                 argument = following[0]
                 arguments.append(argument)
@@ -811,7 +818,7 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
             if len(arguments) == 3:
                 replacement = arguments[2]
                 spans.append(
-                    (replacement.content_start, replacement.content_end)
+                    (definition.start(), replacement.end)
                 )
     return spans
 

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -538,16 +538,13 @@ def _declared_atom_commands(
 def _command_spans(
     source: str, declared_commands: Iterable[str]
 ) -> list[_OwnerSpan]:
-    spans: list[_OwnerSpan] = []
     grammars = dict(_COMMAND_GRAMMARS)
-    # Dynamic spellings are source-wide neutral barriers.  This deliberately
-    # sacrifices ownership inference rather than guessing whether TeX's
-    # ambient control-sequence collision check accepted a declaration.
+    # Dynamic spellings are source-wide neutral barriers even though a source
+    # scan cannot know whether an ambient-name collision rejected a declaration.
+    # Their invocation extent still follows the declared public ``O{} m`` grammar.
     dynamic_names = frozenset(declared_commands).difference(grammars)
     for name in dynamic_names:
-        grammars[name] = _CommandGrammar(
-            None, (0,), accepts_star=True
-        )
+        grammars[name] = _CommandGrammar(None, (1,))
     pattern = re.compile(
         r"\\("
         + "|".join(
@@ -561,86 +558,72 @@ def _command_spans(
         )
         + r")"
     )
-    for command in pattern.finditer(source):
-        if not _is_control_word_start(source, command.start()):
-            continue
+    commands = [
+        command
+        for command in pattern.finditer(source)
+        if _is_control_word_start(source, command.start())
+    ]
+    # Parse dynamic atoms first. Their exact public grammar is ``O{} m``;
+    # command tokens consumed by the one label must not be rescanned, while a
+    # later brace-delimited sibling remains active input.
+    dynamic_spans: list[_OwnerSpan] = []
+    for command in commands:
         name = command.group(1)
+        if name not in dynamic_names or any(
+            span.start <= command.start() < span.end
+            for span in dynamic_spans
+        ):
+            continue
+        position = _skip_space(source, command.end())
+        if source[position : position + 1] == "[":
+            closed = match_group(source, position, "[", "]")
+            if closed < 0:
+                position = len(source)
+            else:
+                position = _skip_space(source, closed)
+        if position < len(source):
+            arguments = _following_mandatory_arguments(source, position, 1)
+            position = (
+                len(source)
+                if arguments is None
+                else _skip_space(source, arguments[0].end)
+            )
+        dynamic_spans.append(
+            _OwnerSpan(command.start(), position, None, True)
+        )
+
+    spans = list(dynamic_spans)
+    for command in commands:
+        name = command.group(1)
+        if name in dynamic_names or any(
+            span.start <= command.start() < span.end
+            for span in dynamic_spans
+        ):
+            continue
         grammar = grammars[name]
         span_owner = grammar.owner
-        is_quarantine = name in dynamic_names
+        is_quarantine = False
         position = _skip_space(source, command.end())
-        if name in dynamic_names:
-            # The declaration may have collided with a command of unknown
-            # signature.  Quarantine every adjacent syntactic argument rather
-            # than guessing how many stars, options, or groups it accepts.
-            consumed_brace_group = False
-            while position < len(source):
-                character = source[position : position + 1]
-                if character == "*":
-                    position = _skip_space(source, position + 1)
-                    continue
-                if character not in "[{":
-                    break
-                closer = "]" if character == "[" else "}"
-                closed = match_group(source, position, character, closer)
-                if closed < 0:
-                    # A malformed adjacent argument has no trustworthy end.
-                    # Quarantine the remainder rather than exposing it to an
-                    # enclosing owner through a guessed command boundary.
-                    position = len(source)
-                    span_owner = None
-                    is_quarantine = True
-                    break
-                consumed_brace_group = consumed_brace_group or character == "{"
+        if grammar.accepts_star and source[position : position + 1] == "*":
+            position = _skip_space(source, position + 1)
+        if grammar.accepts_options and source[position : position + 1] == "[":
+            closed = match_group(source, position, "[", "]")
+            if closed < 0:
+                position = len(source)
+                span_owner = None
+                is_quarantine = True
+            else:
                 position = _skip_space(source, closed)
-            if not consumed_brace_group and position < len(source):
-                arguments = _following_mandatory_arguments(source, position, 1)
-                if arguments is not None:
-                    argument = arguments[0]
-                    argument_source = source[
-                        argument.content_start : argument.content_end
-                    ]
-                    position = _skip_space(source, argument.end)
-                    # A control sequence consumed as the atom label is inert.
-                    # Conservatively quarantine its adjacent syntax too, so
-                    # the same token cannot be rescanned as a public command.
-                    if argument_source.startswith("\\"):
-                        while position < len(source):
-                            character = source[position : position + 1]
-                            if character == "*":
-                                position = _skip_space(source, position + 1)
-                                continue
-                            if character not in "[{":
-                                break
-                            closer = "]" if character == "[" else "}"
-                            closed = match_group(
-                                source, position, character, closer
-                            )
-                            if closed < 0:
-                                position = len(source)
-                                break
-                            position = _skip_space(source, closed)
-        else:
-            if grammar.accepts_star and source[position : position + 1] == "*":
-                position = _skip_space(source, position + 1)
-            if grammar.accepts_options and source[position : position + 1] == "[":
-                closed = match_group(source, position, "[", "]")
-                if closed < 0:
-                    position = len(source)
-                    span_owner = None
-                    is_quarantine = True
-                else:
-                    position = _skip_space(source, closed)
-            for _ in range(max(grammar.positional_group_counts)):
-                if source[position : position + 1] != "{":
-                    break
-                closed = match_group(source, position, "{", "}")
-                if closed < 0:
-                    position = len(source)
-                    span_owner = None
-                    is_quarantine = True
-                    break
-                position = _skip_space(source, closed)
+        for _ in range(max(grammar.positional_group_counts)):
+            if source[position : position + 1] != "{":
+                break
+            closed = match_group(source, position, "{", "}")
+            if closed < 0:
+                position = len(source)
+                span_owner = None
+                is_quarantine = True
+                break
+            position = _skip_space(source, closed)
         spans.append(
             _OwnerSpan(
                 command.start(), position, span_owner, is_quarantine
@@ -713,69 +696,98 @@ def _option_group_spans(
 def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
     """Return inert bodies of primitive, LaTeX, and xparse macro definitions."""
     spans: list[tuple[int, int]] = []
-    for definition in _PRIMITIVE_DEFINITION_RE.finditer(source):
-        if not _is_control_word_start(source, definition.start()):
+    definitions = sorted(
+        (
+            *(
+                (definition.start(), "primitive", definition)
+                for definition in _PRIMITIVE_DEFINITION_RE.finditer(source)
+            ),
+            *(
+                (definition.start(), "latex", definition)
+                for definition in _LATEX_COMMAND_DEFINITION_RE.finditer(source)
+            ),
+            *(
+                (definition.start(), "xparse", definition)
+                for definition in _DOCUMENT_COMMAND_DEFINITION_RE.finditer(source)
+            ),
+        ),
+        key=lambda candidate: candidate[0],
+    )
+    for _, definition_kind, definition in definitions:
+        if (
+            not _is_control_word_start(source, definition.start())
+            or any(
+                start <= definition.start() < end for start, end in spans
+            )
+        ):
             continue
-        position = definition.end()
-        while position < len(source):
-            character = source[position]
-            if character == "\\":
-                arguments = _following_mandatory_arguments(source, position, 1)
-                if arguments is None:
-                    break
-                position = arguments[0].end
-                continue
-            if (
-                character == "#"
-                and position + 1 < len(source)
-                and (
-                    source[position + 1].isdigit()
-                    or source[position + 1] == "#"
+        if definition_kind == "primitive":
+            position = definition.end()
+            while position < len(source):
+                character = source[position]
+                if character == "\\":
+                    arguments = _following_mandatory_arguments(
+                        source, position, 1
+                    )
+                    if arguments is None:
+                        break
+                    position = arguments[0].end
+                    continue
+                if (
+                    character == "#"
+                    and position + 1 < len(source)
+                    and (
+                        source[position + 1].isdigit()
+                        or source[position + 1] == "#"
+                    )
+                ):
+                    # Parameter markers belong to the definition header.
+                    position += 2
+                    continue
+                if character == "#":
+                    position += 1
+                    continue
+                if character != "{":
+                    position += 1
+                    continue
+                closed = match_group(source, position, "{", "}")
+                spans.append(
+                    (position, len(source) if closed < 0 else closed)
                 )
-            ):
-                # Parameter markers belong to the definition header.
-                position += 2
-                continue
-            if character == "#":
-                position += 1
-                continue
-            if character != "{":
-                position += 1
-                continue
-            closed = match_group(source, position, "{", "}")
-            spans.append((position, len(source) if closed < 0 else closed))
-            break
-    for definition in _LATEX_COMMAND_DEFINITION_RE.finditer(source):
-        if not _is_control_word_start(source, definition.start()):
-            continue
-        position = _skip_space(source, definition.end())
-        if source[position : position + 1] == "*":
-            position = _skip_space(source, position + 1)
-        names = _following_mandatory_arguments(source, position, 1)
-        if names is None:
-            continue
-        position = _skip_space(source, names[0].end)
-        for _ in range(2):
-            if source[position : position + 1] != "[":
                 break
-            closed = match_group(source, position, "[", "]")
-            if closed < 0:
-                position = len(source)
-                break
-            position = _skip_space(source, closed)
-        replacements = _following_mandatory_arguments(source, position, 1)
-        if replacements is not None:
-            replacement = replacements[0]
-            spans.append((replacement.content_start, replacement.content_end))
-    for definition in _DOCUMENT_COMMAND_DEFINITION_RE.finditer(source):
-        if not _is_control_word_start(source, definition.start()):
-            continue
-        arguments = _following_mandatory_arguments(
-            source, definition.end(), 3
-        )
-        if arguments is not None:
-            replacement = arguments[2]
-            spans.append((replacement.content_start, replacement.content_end))
+        elif definition_kind == "latex":
+            position = _skip_space(source, definition.end())
+            if source[position : position + 1] == "*":
+                position = _skip_space(source, position + 1)
+            names = _following_mandatory_arguments(source, position, 1)
+            if names is None:
+                continue
+            position = _skip_space(source, names[0].end)
+            for _ in range(2):
+                if source[position : position + 1] != "[":
+                    break
+                closed = match_group(source, position, "[", "]")
+                if closed < 0:
+                    position = len(source)
+                    break
+                position = _skip_space(source, closed)
+            replacements = _following_mandatory_arguments(
+                source, position, 1
+            )
+            if replacements is not None:
+                replacement = replacements[0]
+                spans.append(
+                    (replacement.content_start, replacement.content_end)
+                )
+        else:
+            arguments = _following_mandatory_arguments(
+                source, definition.end(), 3
+            )
+            if arguments is not None:
+                replacement = arguments[2]
+                spans.append(
+                    (replacement.content_start, replacement.content_end)
+                )
     return spans
 
 

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -1113,10 +1113,14 @@ def _execution_context(source: str, owner_source: str) -> _ExecutionContext:
                 next_replacement_spans + command_quarantines,
             )
         if next_state in seen:
-            raise RuntimeError("tenkz execution masks did not converge")
+            raise DimensionOwnershipError(
+                "tenkz execution masks did not converge"
+            )
         seen.add(next_state)
         state = next_state
-    raise RuntimeError("tenkz execution masks exceeded their source bound")
+    raise DimensionOwnershipError(
+        "tenkz execution masks exceeded their source bound"
+    )
 
 
 def _comment_ranges(source: str) -> list[tuple[int, int]]:

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -489,9 +489,7 @@ def _environment_scope_spans(
 
 
 def _declared_atom_commands(
-    source: str,
-    owner_source: str,
-    ignored_control_spans: Iterable[tuple[int, int]] = (),
+    source: str, owner_source: str
 ) -> frozenset[str]:
     """Return dynamic spellings as neutral, source-wide barriers.
 
@@ -499,15 +497,9 @@ def _declared_atom_commands(
     sequence table, which a source-only scanner cannot reconstruct.  Dynamic
     declarations therefore never grant dimension ownership here.
     """
-    ignored_control_spans = tuple(ignored_control_spans)
     names: set[str] = set()
     for declaration in _DECLARE_ATOM_RE.finditer(owner_source):
-        if (
-            not _is_control_word_start(owner_source, declaration.start())
-            or _position_in_spans(
-                declaration.start(), ignored_control_spans
-            )
-        ):
+        if not _is_control_word_start(owner_source, declaration.start()):
             continue
         arguments = _following_mandatory_arguments(
             owner_source, declaration.end(), 2
@@ -521,12 +513,7 @@ def _declared_atom_commands(
         if name is not None:
             names.add(name)
     for declaration in _KERNEL_DECLARE_RE.finditer(owner_source):
-        if (
-            not _is_control_word_start(owner_source, declaration.start())
-            or _position_in_spans(
-                declaration.start(), ignored_control_spans
-            )
-        ):
+        if not _is_control_word_start(owner_source, declaration.start()):
             continue
         arguments = _following_mandatory_arguments(
             owner_source, declaration.end(), 3
@@ -567,8 +554,7 @@ def _command_spans(
     # scan cannot know whether an ambient-name collision rejected a declaration.
     # Their invocation extent still follows the declared public ``O{} m`` grammar.
     dynamic_names = frozenset(declared_commands).difference(grammars)
-    for name in dynamic_names:
-        grammars[name] = _CommandGrammar(None, (1,))
+    command_names = frozenset(grammars).union(dynamic_names)
     pattern = re.compile(
         r"\\("
         + "|".join(
@@ -578,7 +564,7 @@ def _command_spans(
                 if _STATIC_CONTROL_WORD_NAME_RE.fullmatch(name) is not None
                 else ""
             )
-            for name in sorted(grammars, key=len, reverse=True)
+            for name in sorted(command_names, key=len, reverse=True)
         )
         + r")"
     )
@@ -720,8 +706,12 @@ def _option_group_spans(
     return spans
 
 
-def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
+def _macro_replacement_spans(
+    source: str,
+    ignored_control_spans: Iterable[tuple[int, int]] = (),
+) -> list[tuple[int, int]]:
     """Return definition extents whose tokens are inert until invocation."""
+    ignored_control_spans = tuple(ignored_control_spans)
     spans: list[tuple[int, int]] = []
     definitions = sorted(
         (
@@ -766,6 +756,9 @@ def _macro_replacement_spans(source: str) -> list[tuple[int, int]]:
     for _, definition_kind, definition in definitions:
         if (
             not _is_control_word_start(source, definition.start())
+            or _position_in_spans(
+                definition.start(), ignored_control_spans
+            )
             or any(
                 start <= definition.start() < end for start, end in spans
             )
@@ -878,17 +871,17 @@ def _position_in_spans(
 def _environment_tokens(
     source: str,
     owner_source: str,
-    ignored_control_spans: Iterable[tuple[int, int]] = (),
+    execution_mask_spans: Iterable[tuple[int, int]] | None = None,
 ) -> list[_EnvironmentToken]:
     """Parse simple environment names without joining split control words."""
     tokens: list[_EnvironmentToken] = []
-    replacement_spans = _macro_replacement_spans(owner_source)
-    ignored_control_spans = tuple(ignored_control_spans)
+    if execution_mask_spans is None:
+        execution_mask_spans = _macro_replacement_spans(owner_source)
+    execution_mask_spans = tuple(execution_mask_spans)
     for control in _ENVIRONMENT_CONTROL_RE.finditer(owner_source):
         if (
             not _is_control_word_start(owner_source, control.start())
-            or _position_in_spans(control.start(), replacement_spans)
-            or _position_in_spans(control.start(), ignored_control_spans)
+            or _position_in_spans(control.start(), execution_mask_spans)
         ):
             continue
         arguments = _following_mandatory_arguments(
@@ -928,12 +921,14 @@ def _environment_tokens(
 def _environment_spans(
     source: str,
     owner_source: str,
-    ignored_control_spans: Iterable[tuple[int, int]] = (),
+    execution_mask_spans: Iterable[tuple[int, int]] | None = None,
 ) -> list[_OwnerSpan]:
     """Return neutral barriers for public environments and malformed controls."""
-    ignored_control_spans = tuple(ignored_control_spans)
+    if execution_mask_spans is None:
+        execution_mask_spans = _macro_replacement_spans(owner_source)
+    execution_mask_spans = tuple(execution_mask_spans)
     tokens = _environment_tokens(
-        source, owner_source, ignored_control_spans
+        source, owner_source, execution_mask_spans
     )
     spans = [
         _OwnerSpan(
@@ -946,14 +941,12 @@ def _environment_spans(
             tokens, _PUBLIC_ENVIRONMENTS
         )
     ]
-    replacement_spans = _macro_replacement_spans(owner_source)
     # An unclosed environment-name argument cannot be resolved to a public
     # name, but it still consumes the remainder as one malformed control.
     for control in _ENVIRONMENT_CONTROL_RE.finditer(owner_source):
         if (
             not _is_control_word_start(owner_source, control.start())
-            or _position_in_spans(control.start(), replacement_spans)
-            or _position_in_spans(control.start(), ignored_control_spans)
+            or _position_in_spans(control.start(), execution_mask_spans)
         ):
             continue
         position = _skip_space(owner_source, control.end())
@@ -984,13 +977,15 @@ def _environment_spans(
 def _option_spans(
     source: str,
     owner_source: str,
-    ignored_control_spans: Iterable[tuple[int, int]] = (),
+    execution_mask_spans: Iterable[tuple[int, int]] | None = None,
 ) -> list[_OwnerSpan]:
     """Find public option containers without joining split control words."""
-    ignored_control_spans = tuple(ignored_control_spans)
+    if execution_mask_spans is None:
+        execution_mask_spans = _macro_replacement_spans(owner_source)
+    execution_mask_spans = tuple(execution_mask_spans)
     spans: list[_OwnerSpan] = []
     for container in _environment_tokens(
-        source, owner_source, ignored_control_spans
+        source, owner_source, execution_mask_spans
     ):
         if (
             container.kind != "begin"
@@ -1020,7 +1015,7 @@ def _option_spans(
             if (
                 not _is_control_word_start(owner_source, container.start())
                 or _position_in_spans(
-                    container.start(), ignored_control_spans
+                    container.start(), execution_mask_spans
                 )
             ):
                 continue
@@ -1149,25 +1144,34 @@ def scan_case_dimensions(path: Path, source: str) -> tuple[DimensionOccurrence, 
     # ``\tn%...\nput``.  Keep ownership on an offset-preserving blanked view
     # while the numeric/unit recognizer uses the collapsed mapped view above.
     owner_source = strip_comments(source)
-    replacement_spans = _macro_replacement_spans(owner_source)
-    declared_commands = _declared_atom_commands(
-        source, owner_source, replacement_spans
+    declared_commands = _declared_atom_commands(source, owner_source)
+    # Definition-shaped tokens consumed by a dynamic label are inert. Discover
+    # command quarantines first so such a token cannot claim a later sibling as
+    # its replacement body; then recompute commands against the resulting mask.
+    command_prepass = _command_spans(owner_source, declared_commands)
+    command_quarantines = tuple(
+        (span.start, span.end)
+        for span in command_prepass
+        if span.is_quarantine
+    )
+    replacement_spans = _macro_replacement_spans(
+        owner_source, command_quarantines
     )
     command_spans = _command_spans(
         owner_source, declared_commands, replacement_spans
     )
     # A quarantined command consumes any control token in its parsed extent.
     # Keep independent option and environment scans from reactivating it.
-    ignored_control_spans = tuple(replacement_spans) + tuple(
+    execution_mask_spans = tuple(replacement_spans) + tuple(
         (span.start, span.end)
         for span in command_spans
         if span.is_quarantine
     )
     owner_spans = (
-        _option_spans(source, owner_source, ignored_control_spans)
+        _option_spans(source, owner_source, execution_mask_spans)
         + command_spans
         + _environment_spans(
-            source, owner_source, ignored_control_spans
+            source, owner_source, execution_mask_spans
         )
         + [
             _OwnerSpan(start, end, None, True)

--- a/scripts/tenkzlib/dimensions.py
+++ b/scripts/tenkzlib/dimensions.py
@@ -489,7 +489,9 @@ def _environment_scope_spans(
 
 
 def _declared_atom_commands(
-    source: str, owner_source: str
+    source: str,
+    owner_source: str,
+    ignored_control_spans: Iterable[tuple[int, int]] = (),
 ) -> frozenset[str]:
     """Return dynamic spellings as neutral, source-wide barriers.
 
@@ -497,9 +499,15 @@ def _declared_atom_commands(
     sequence table, which a source-only scanner cannot reconstruct.  Dynamic
     declarations therefore never grant dimension ownership here.
     """
+    ignored_control_spans = tuple(ignored_control_spans)
     names: set[str] = set()
     for declaration in _DECLARE_ATOM_RE.finditer(owner_source):
-        if not _is_control_word_start(owner_source, declaration.start()):
+        if (
+            not _is_control_word_start(owner_source, declaration.start())
+            or _position_in_spans(
+                declaration.start(), ignored_control_spans
+            )
+        ):
             continue
         arguments = _following_mandatory_arguments(
             owner_source, declaration.end(), 2
@@ -513,7 +521,12 @@ def _declared_atom_commands(
         if name is not None:
             names.add(name)
     for declaration in _KERNEL_DECLARE_RE.finditer(owner_source):
-        if not _is_control_word_start(owner_source, declaration.start()):
+        if (
+            not _is_control_word_start(owner_source, declaration.start())
+            or _position_in_spans(
+                declaration.start(), ignored_control_spans
+            )
+        ):
             continue
         arguments = _following_mandatory_arguments(
             owner_source, declaration.end(), 3
@@ -544,8 +557,11 @@ def _declared_atom_commands(
 
 
 def _command_spans(
-    source: str, declared_commands: Iterable[str]
+    source: str,
+    declared_commands: Iterable[str],
+    ignored_control_spans: Iterable[tuple[int, int]] = (),
 ) -> list[_OwnerSpan]:
+    ignored_control_spans = tuple(ignored_control_spans)
     grammars = dict(_COMMAND_GRAMMARS)
     # Dynamic spellings are source-wide neutral barriers even though a source
     # scan cannot know whether an ambient-name collision rejected a declaration.
@@ -570,6 +586,9 @@ def _command_spans(
         command
         for command in pattern.finditer(source)
         if _is_control_word_start(source, command.start())
+        and not _position_in_spans(
+            command.start(), ignored_control_spans
+        )
     ]
     # Parse dynamic atoms first. Their exact public grammar is ``O{} m``;
     # command tokens consumed by the one label must not be rescanned, while a
@@ -857,15 +876,19 @@ def _position_in_spans(
 
 
 def _environment_tokens(
-    source: str, owner_source: str
+    source: str,
+    owner_source: str,
+    ignored_control_spans: Iterable[tuple[int, int]] = (),
 ) -> list[_EnvironmentToken]:
     """Parse simple environment names without joining split control words."""
     tokens: list[_EnvironmentToken] = []
     replacement_spans = _macro_replacement_spans(owner_source)
+    ignored_control_spans = tuple(ignored_control_spans)
     for control in _ENVIRONMENT_CONTROL_RE.finditer(owner_source):
         if (
             not _is_control_word_start(owner_source, control.start())
             or _position_in_spans(control.start(), replacement_spans)
+            or _position_in_spans(control.start(), ignored_control_spans)
         ):
             continue
         arguments = _following_mandatory_arguments(
@@ -903,10 +926,15 @@ def _environment_tokens(
 
 
 def _environment_spans(
-    source: str, owner_source: str
+    source: str,
+    owner_source: str,
+    ignored_control_spans: Iterable[tuple[int, int]] = (),
 ) -> list[_OwnerSpan]:
     """Return neutral barriers for public environments and malformed controls."""
-    tokens = _environment_tokens(source, owner_source)
+    ignored_control_spans = tuple(ignored_control_spans)
+    tokens = _environment_tokens(
+        source, owner_source, ignored_control_spans
+    )
     spans = [
         _OwnerSpan(
             start,
@@ -925,6 +953,7 @@ def _environment_spans(
         if (
             not _is_control_word_start(owner_source, control.start())
             or _position_in_spans(control.start(), replacement_spans)
+            or _position_in_spans(control.start(), ignored_control_spans)
         ):
             continue
         position = _skip_space(owner_source, control.end())
@@ -955,10 +984,14 @@ def _environment_spans(
 def _option_spans(
     source: str,
     owner_source: str,
+    ignored_control_spans: Iterable[tuple[int, int]] = (),
 ) -> list[_OwnerSpan]:
     """Find public option containers without joining split control words."""
+    ignored_control_spans = tuple(ignored_control_spans)
     spans: list[_OwnerSpan] = []
-    for container in _environment_tokens(source, owner_source):
+    for container in _environment_tokens(
+        source, owner_source, ignored_control_spans
+    ):
         if (
             container.kind != "begin"
             or container.name not in _OPTION_ENVIRONMENT_KEYS
@@ -984,7 +1017,12 @@ def _option_spans(
     )
     for pattern, opener, closer in containers:
         for container in pattern.finditer(owner_source):
-            if not _is_control_word_start(owner_source, container.start()):
+            if (
+                not _is_control_word_start(owner_source, container.start())
+                or _position_in_spans(
+                    container.start(), ignored_control_spans
+                )
+            ):
                 continue
             position = _skip_space(owner_source, container.end())
             allowed_keys: frozenset[str] | None = None
@@ -1111,11 +1149,30 @@ def scan_case_dimensions(path: Path, source: str) -> tuple[DimensionOccurrence, 
     # ``\tn%...\nput``.  Keep ownership on an offset-preserving blanked view
     # while the numeric/unit recognizer uses the collapsed mapped view above.
     owner_source = strip_comments(source)
-    declared_commands = _declared_atom_commands(source, owner_source)
+    replacement_spans = _macro_replacement_spans(owner_source)
+    declared_commands = _declared_atom_commands(
+        source, owner_source, replacement_spans
+    )
+    command_spans = _command_spans(
+        owner_source, declared_commands, replacement_spans
+    )
+    # A quarantined command consumes any control token in its parsed extent.
+    # Keep independent option and environment scans from reactivating it.
+    ignored_control_spans = tuple(replacement_spans) + tuple(
+        (span.start, span.end)
+        for span in command_spans
+        if span.is_quarantine
+    )
     owner_spans = (
-        _option_spans(source, owner_source)
-        + _command_spans(owner_source, declared_commands)
-        + _environment_spans(source, owner_source)
+        _option_spans(source, owner_source, ignored_control_spans)
+        + command_spans
+        + _environment_spans(
+            source, owner_source, ignored_control_spans
+        )
+        + [
+            _OwnerSpan(start, end, None, True)
+            for start, end in replacement_spans
+        ]
     )
     # A semantic option value is more specific than its containing command.
     # A malformed remainder has no trustworthy nested grammar, however, so

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -674,6 +674,10 @@ def test_rmp_dimension_ownership() -> None:
         ("primitive", r"\def\x{TOKEN}"),
         ("latex", r"\newcommand{\x}{TOKEN}"),
         ("xparse", r"\NewDocumentCommand{\x}{}{TOKEN}"),
+        (
+            "xparse expandable",
+            r"\NewExpandableDocumentCommand{\x}{}{TOKEN}",
+        ),
     )
     for definition_kind, definition_template in replacement_templates:
         inert_end = definition_template.replace("TOKEN", r"\end{tenkz}")
@@ -713,6 +717,10 @@ def test_rmp_dimension_ownership() -> None:
         ("primitive", r"\def\fake"),
         ("latex", r"\newcommand{\fake}{stored}"),
         ("xparse", r"\NewDocumentCommand{\fake}{}{stored}"),
+        (
+            "xparse expandable",
+            r"\NewExpandableDocumentCommand{\fake}{}{stored}",
+        ),
     )
     for outer_kind, outer_template in replacement_templates:
         for inner_kind, inner_definition in nested_definition_tokens:
@@ -739,6 +747,43 @@ def test_rmp_dimension_ownership() -> None:
                     f"outer={outer_kind}, inner={inner_kind}, "
                     f"occurrences={occurrences!r}"
                 )
+    unclosed_definition_prefixes = (
+        ("latex option", r"\newcommand{\x}[1 "),
+        ("latex body", r"\newcommand{\x}{"),
+        ("xparse specification", r"\NewDocumentCommand{\x}{m "),
+        ("xparse body", r"\NewDocumentCommand{\x}{}{"),
+        (
+            "expandable xparse body",
+            r"\NewExpandableDocumentCommand{\x}{}{",
+        ),
+    )
+    for definition_kind, definition_prefix in unclosed_definition_prefixes:
+        source = (
+            r"\begin{tenkz}"
+            + definition_prefix
+            + r"\end{tenkz}\rule{87mm}{88mm}"
+        )
+        replacement_spans = _macro_replacement_spans(strip_comments(source))
+        inert_end = source.index(r"\end{tenkz}")
+        if len(replacement_spans) != 1 or not any(
+            start <= inert_end < end == len(source)
+            for start, end in replacement_spans
+        ):
+            raise AssertionError(
+                "an unclosed definition body lacked an EOF replacement mask: "
+                f"definition={definition_kind}, spans={replacement_spans!r}"
+            )
+        literal_offset = source.index("87mm")
+        environment_spans = _environment_spans(source, strip_comments(source))
+        if not any(
+            span.is_quarantine
+            and span.start <= literal_offset < span.end
+            for span in environment_spans
+        ):
+            raise AssertionError(
+                "an unclosed definition body exposed an inert environment end: "
+                f"definition={definition_kind}, spans={environment_spans!r}"
+            )
     unclosed_environment_end = scan_case_dimensions(
         Path("synthetic.tex"), r"\end{tenkz \tnput{x}{(79mm,0)}{}"
     )

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -37,6 +37,7 @@ from tenkzlib.dimensions import (
     _COMMAND_GRAMMARS,
     _PUBLIC_ENVIRONMENTS,
     _environment_spans,
+    _macro_replacement_spans,
     collect_dimension_report,
     scan_book_dimensions,
     scan_case_dimensions,
@@ -708,6 +709,36 @@ def test_rmp_dimension_ownership() -> None:
                 "an inert replacement begin token opened an environment: "
                 f"definition={definition_kind}, occurrences={occurrences!r}"
             )
+    nested_definition_tokens = (
+        ("primitive", r"\def\fake"),
+        ("latex", r"\newcommand{\fake}{stored}"),
+        ("xparse", r"\NewDocumentCommand{\fake}{}{stored}"),
+    )
+    for outer_kind, outer_template in replacement_templates:
+        for inner_kind, inner_definition in nested_definition_tokens:
+            source = outer_template.replace("TOKEN", inner_definition) + (
+                r"\tnarrow{\begin{tenkz}\rule{85mm}{86mm}\end{tenkz}}"
+            )
+            replacement_spans = _macro_replacement_spans(strip_comments(source))
+            active_environment = source.index(r"\begin{tenkz}")
+            if len(replacement_spans) != 1 or any(
+                start <= active_environment < end
+                for start, end in replacement_spans
+            ):
+                raise AssertionError(
+                    "an inert nested definition masked active input: "
+                    f"outer={outer_kind}, inner={inner_kind}, "
+                    f"spans={replacement_spans!r}"
+                )
+            occurrences = scan_case_dimensions(Path("synthetic.tex"), source)
+            if len(occurrences) != 2 or any(
+                occurrence.owner is not None for occurrence in occurrences
+            ):
+                raise AssertionError(
+                    "an inert nested definition hid an active environment: "
+                    f"outer={outer_kind}, inner={inner_kind}, "
+                    f"occurrences={occurrences!r}"
+                )
     unclosed_environment_end = scan_case_dimensions(
         Path("synthetic.tex"), r"\end{tenkz \tnput{x}{(79mm,0)}{}"
     )
@@ -819,11 +850,25 @@ def test_rmp_dimension_ownership() -> None:
         r"\tnarrow{\tnfoo\tnput{x}{(121mm,0)}{}}",
     )
     if len(unbraced_dynamic_label) != 1 or any(
-        occurrence.owner is not None for occurrence in unbraced_dynamic_label
+        occurrence.owner is not DimensionOwner.ROUTE
+        for occurrence in unbraced_dynamic_label
     ):
         raise AssertionError(
             "an unbraced dynamic label reactivated a public command: "
             f"{unbraced_dynamic_label!r}"
+        )
+    braced_dynamic_sibling = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo{A}{\tnput{x}{(124mm,0)}{}}}",
+    )
+    if len(braced_dynamic_sibling) != 1 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in braced_dynamic_sibling
+    ):
+        raise AssertionError(
+            "a dynamic braced label consumed its sibling command: "
+            f"{braced_dynamic_sibling!r}"
         )
     later_dynamic_sibling = scan_case_dimensions(
         Path("synthetic.tex"),
@@ -863,11 +908,11 @@ def test_rmp_dimension_ownership() -> None:
             rf"\tnarrow{{\{atom_name}[label shift={{99mm,100mm}}]"
             r"{101mm}{102mm}}",
         )
-        if len(catcode_atom) != 4 or any(
-            occurrence.owner is not None for occurrence in catcode_atom
-        ):
+        if [
+            occurrence.owner for occurrence in catcode_atom
+        ] != [None, None, None, DimensionOwner.ROUTE]:
             raise AssertionError(
-                "a control-sequence atom name escaped dynamic quarantine: "
+                "a control-sequence atom exceeded its O{} m quarantine: "
                 f"name={atom_name!r}, occurrences={catcode_atom!r}"
             )
     declared_kernel_atom = scan_case_dimensions(
@@ -957,12 +1002,11 @@ def test_rmp_dimension_ownership() -> None:
         r"\tnarrow{\tndeclareatom\rule{skin=dot}"
         r"\rule[label shift={88mm,89mm}]{95mm}{96mm}}",
     )
-    if len(colliding_latex_declaration) != 4 or any(
-        occurrence.owner is not None
-        for occurrence in colliding_latex_declaration
-    ):
+    if [
+        occurrence.owner for occurrence in colliding_latex_declaration
+    ] != [None, None, None, DimensionOwner.ROUTE]:
         raise AssertionError(
-            "a format command collision activated dynamic ownership: "
+            "a format collision exceeded the declared O{} m barrier: "
             f"{colliding_latex_declaration!r}"
         )
     source_local_collision = scan_case_dimensions(
@@ -971,11 +1015,11 @@ def test_rmp_dimension_ownership() -> None:
         r"\tnarrow{\tndeclareatom{\tnoccupied}{skin=dot}"
         r"\tnoccupied[label shift={93mm,94mm}]{97mm}{98mm}}",
     )
-    if len(source_local_collision) != 4 or any(
-        occurrence.owner is not None for occurrence in source_local_collision
-    ):
+    if [
+        occurrence.owner for occurrence in source_local_collision
+    ] != [None, None, None, DimensionOwner.ROUTE]:
         raise AssertionError(
-            "a source-local command collision activated dynamic ownership: "
+            "a source-local collision exceeded the declared O{} m barrier: "
             f"{source_local_collision!r}"
         )
     repeated_optional_collision = scan_case_dimensions(
@@ -985,11 +1029,11 @@ def test_rmp_dimension_ownership() -> None:
         r"\tnoccupied[][103mm]{104mm}}",
     )
     if len(repeated_optional_collision) != 2 or any(
-        occurrence.owner is not None
+        occurrence.owner is not DimensionOwner.ROUTE
         for occurrence in repeated_optional_collision
     ):
         raise AssertionError(
-            "a repeated optional argument escaped unknown-arity quarantine: "
+            "a repeated optional collision exceeded the O{} m barrier: "
             f"{repeated_optional_collision!r}"
         )
     colliding_parbox = scan_case_dimensions(
@@ -998,10 +1042,11 @@ def test_rmp_dimension_ownership() -> None:
         r"\parbox[c][105mm][c]{106mm}{x}}",
     )
     if len(colliding_parbox) != 2 or any(
-        occurrence.owner is not None for occurrence in colliding_parbox
+        occurrence.owner is not DimensionOwner.ROUTE
+        for occurrence in colliding_parbox
     ):
         raise AssertionError(
-            "a real multi-option command escaped unknown-arity quarantine: "
+            "a real multi-option collision exceeded the O{} m barrier: "
             f"{colliding_parbox!r}"
         )
     scoped_atom_declaration = scan_case_dimensions(

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -1171,7 +1171,7 @@ def test_rmp_dimension_ownership() -> None:
             r"\bar\tndeclareatom{\foo}{skin=dot}"
             r"\foo\tndeclareatom{\bar}{skin=dot}",
         )
-    except RuntimeError as error:
+    except DimensionOwnershipError as error:
         if str(error) != "tenkz execution masks did not converge":
             raise AssertionError(
                 "a cyclic execution mask raised the wrong error: "

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -713,6 +713,36 @@ def test_rmp_dimension_ownership() -> None:
                 "an inert replacement begin token opened an environment: "
                 f"definition={definition_kind}, occurrences={occurrences!r}"
             )
+    stored_syntax_templates = (
+        ("latex default", r"\newcommand{\x}[1][TOKEN]{body}"),
+        (
+            "xparse processor",
+            r"\NewDocumentCommand{\x}{>{TOKEN}m}{body}",
+        ),
+        (
+            "expandable xparse processor",
+            r"\NewExpandableDocumentCommand{\x}{>{TOKEN}m}{body}",
+        ),
+    )
+    for definition_kind, definition_template in stored_syntax_templates:
+        definition = definition_template.replace("TOKEN", r"\end{tenkz}")
+        for owner_kind, outer_open, outer_close, _ in owner_contexts:
+            source = (
+                outer_open
+                + r"\begin{tenkz}"
+                + definition
+                + r"\rule{201mm}{202mm}\end{tenkz}"
+                + outer_close
+            )
+            occurrences = scan_case_dimensions(Path("synthetic.tex"), source)
+            if len(occurrences) != 2 or any(
+                occurrence.owner is not None for occurrence in occurrences
+            ):
+                raise AssertionError(
+                    "stored definition syntax closed an active environment: "
+                    f"definition={definition_kind}, outer={owner_kind}, "
+                    f"occurrences={occurrences!r}"
+                )
     nested_definition_tokens = (
         ("primitive", r"\def\fake"),
         ("latex", r"\newcommand{\fake}{stored}"),

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -919,6 +919,26 @@ def test_rmp_dimension_ownership() -> None:
                 "an unclosed definition body exposed an inert environment end: "
                 f"definition={definition_kind}, spans={environment_spans!r}"
             )
+    for primitive in ("def", "gdef", "edef", "xdef"):
+        source = rf"\tnarrow{{\{primitive}\x 206mm}}"
+        definition_start = source.index(rf"\{primitive}")
+        replacement_spans = _macro_replacement_spans(strip_comments(source))
+        if replacement_spans != [(definition_start, len(source))]:
+            raise AssertionError(
+                "a brace-less primitive definition lacked an EOF mask: "
+                f"primitive={primitive}, spans={replacement_spans!r}"
+            )
+        brace_less_primitive = scan_case_dimensions(
+            Path("synthetic.tex"), source
+        )
+        if len(brace_less_primitive) != 1 or any(
+            occurrence.owner is not None
+            for occurrence in brace_less_primitive
+        ):
+            raise AssertionError(
+                "a brace-less primitive definition exposed enclosing ownership: "
+                f"primitive={primitive}, occurrences={brace_less_primitive!r}"
+            )
     unclosed_environment_end = scan_case_dimensions(
         Path("synthetic.tex"), r"\end{tenkz \tnput{x}{(79mm,0)}{}"
     )

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -1066,6 +1066,36 @@ def test_rmp_dimension_ownership() -> None:
             "a dynamic label masked a later environment sibling: "
             f"{active_dynamic_environment_sibling!r}"
         )
+    definition_in_dynamic_label = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo{\def\x}\tnput{x}{(131mm,0)}{}}",
+    )
+    if len(definition_in_dynamic_label) != 1 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in definition_in_dynamic_label
+    ):
+        raise AssertionError(
+            "definition discovery crossed a dynamic label into its sibling: "
+            f"{definition_in_dynamic_label!r}"
+        )
+    active_definition_sibling = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo A\def\x{\tnput{x}{(132mm,0)}{}}"
+        r"\tnput{x}{(133mm,0)}{}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in active_definition_sibling
+    ] != [
+        ("132mm", None),
+        ("133mm", DimensionOwner.LAYOUT),
+    ]:
+        raise AssertionError(
+            "a dynamic label masked a later active definition or command: "
+            f"{active_definition_sibling!r}"
+        )
     braced_dynamic_sibling = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tndeclareatom{\tnfoo}{skin=dot}"

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -1096,6 +1096,60 @@ def test_rmp_dimension_ownership() -> None:
             "a dynamic label masked a later active definition or command: "
             f"{active_definition_sibling!r}"
         )
+    inert_dynamic_declaration = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\def\x{\tndeclareatom{\tnfoo}{skin=dot}}"
+        r"\tnarrow{\tnfoo{\tnput{x}{(201mm,0)}{}}}",
+    )
+    if len(inert_dynamic_declaration) != 1 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in inert_dynamic_declaration
+    ):
+        raise AssertionError(
+            "an inert atom declaration created a source-wide quarantine: "
+            f"{inert_dynamic_declaration!r}"
+        )
+    active_dynamic_declaration = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo{\tnput{x}{(202mm,0)}{}}}",
+    )
+    if len(active_dynamic_declaration) != 1 or any(
+        occurrence.owner is not None
+        for occurrence in active_dynamic_declaration
+    ):
+        raise AssertionError(
+            "an active atom declaration lost its dynamic quarantine: "
+            f"{active_dynamic_declaration!r}"
+        )
+    declaration_in_dynamic_label = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo{\tndeclareatom{\tnbar}{skin=dot}}"
+        r"\tnbar{\tnput{x}{(203mm,0)}{}}}",
+    )
+    if len(declaration_in_dynamic_label) != 1 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in declaration_in_dynamic_label
+    ):
+        raise AssertionError(
+            "a declaration consumed by a dynamic label escaped its mask: "
+            f"{declaration_in_dynamic_label!r}"
+        )
+    active_declaration_sibling = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo A\tndeclareatom{\tnbar}{skin=dot}"
+        r"\tnbar{\tnput{x}{(204mm,0)}{}}}",
+    )
+    if len(active_declaration_sibling) != 1 or any(
+        occurrence.owner is not None
+        for occurrence in active_declaration_sibling
+    ):
+        raise AssertionError(
+            "an active sibling declaration lost its dynamic quarantine: "
+            f"{active_declaration_sibling!r}"
+        )
     braced_dynamic_sibling = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tndeclareatom{\tnfoo}{skin=dot}"

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -939,6 +939,30 @@ def test_rmp_dimension_ownership() -> None:
                 "a brace-less primitive definition exposed enclosing ownership: "
                 f"primitive={primitive}, occurrences={brace_less_primitive!r}"
             )
+        unmatched_source = (
+            rf"\tnarrow{{{{\{primitive}\x}}"
+            r"\tnput{x}{(207mm,0)}{}}}"
+        )
+        definition_start = unmatched_source.index(rf"\{primitive}")
+        replacement_spans = _macro_replacement_spans(
+            strip_comments(unmatched_source)
+        )
+        if replacement_spans != [(definition_start, len(unmatched_source))]:
+            raise AssertionError(
+                "an unmatched primitive parameter brace lacked an EOF mask: "
+                f"primitive={primitive}, spans={replacement_spans!r}"
+            )
+        unmatched_primitive = scan_case_dimensions(
+            Path("synthetic.tex"), unmatched_source
+        )
+        if len(unmatched_primitive) != 1 or any(
+            occurrence.owner is not None
+            for occurrence in unmatched_primitive
+        ):
+            raise AssertionError(
+                "an unmatched primitive parameter brace stole a sibling body: "
+                f"primitive={primitive}, occurrences={unmatched_primitive!r}"
+            )
     unclosed_environment_end = scan_case_dimensions(
         Path("synthetic.tex"), r"\end{tenkz \tnput{x}{(79mm,0)}{}"
     )

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -1150,6 +1150,35 @@ def test_rmp_dimension_ownership() -> None:
             "an active sibling declaration lost its dynamic quarantine: "
             f"{active_declaration_sibling!r}"
         )
+    revived_dynamic_declaration = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\def\holder{\tndeclareatom{\foo}{skin=dot}}"
+        r"\tndeclareatom{\bar}{skin=dot}"
+        r"\foo\bar{\def\x}\tndeclareatom{\baz}{skin=dot}"
+        r"\tnarrow{\baz\tnput{x}{(205mm,0)}{}}",
+    )
+    if [
+        (occurrence.literal, occurrence.owner)
+        for occurrence in revived_dynamic_declaration
+    ] != [("205mm", DimensionOwner.ROUTE)]:
+        raise AssertionError(
+            "a transient definition mask permanently removed a declaration: "
+            f"{revived_dynamic_declaration!r}"
+        )
+    try:
+        scan_case_dimensions(
+            Path("synthetic.tex"),
+            r"\bar\tndeclareatom{\foo}{skin=dot}"
+            r"\foo\tndeclareatom{\bar}{skin=dot}",
+        )
+    except RuntimeError as error:
+        if str(error) != "tenkz execution masks did not converge":
+            raise AssertionError(
+                "a cyclic execution mask raised the wrong error: "
+                f"{error!r}"
+            ) from error
+    else:
+        raise AssertionError("a cyclic execution mask did not fail closed")
     braced_dynamic_sibling = scan_case_dimensions(
         Path("synthetic.tex"),
         r"\tndeclareatom{\tnfoo}{skin=dot}"

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -718,6 +718,44 @@ def test_rmp_dimension_ownership() -> None:
                 "an inert replacement begin token opened an environment: "
                 f"definition={definition_kind}, occurrences={occurrences!r}"
             )
+        inert_owners = definition_template.replace(
+            "TOKEN",
+            r"\tnset{pitch=203mm}\tnput{x}{(204mm,0)}{}",
+        )
+        occurrences = scan_case_dimensions(
+            Path("synthetic.tex"),
+            inert_owners + r"\tnarrow{\tnput{x}{(205mm,0)}{}}",
+        )
+        if [
+            (occurrence.literal, occurrence.owner)
+            for occurrence in occurrences
+        ] != [
+            ("203mm", None),
+            ("204mm", None),
+            ("205mm", DimensionOwner.LAYOUT),
+        ]:
+            raise AssertionError(
+                "stored public syntax gained ownership or masked active input: "
+                f"definition={definition_kind}, occurrences={occurrences!r}"
+            )
+        inert_unclosed_option = definition_template.replace(
+            "TOKEN", r"\tn[label shift=206mm"
+        )
+        occurrences = scan_case_dimensions(
+            Path("synthetic.tex"),
+            inert_unclosed_option + r"\tnarrow{207mm]}",
+        )
+        if [
+            (occurrence.literal, occurrence.owner)
+            for occurrence in occurrences
+        ] != [
+            ("206mm", None),
+            ("207mm", DimensionOwner.ROUTE),
+        ]:
+            raise AssertionError(
+                "stored malformed syntax crossed into active input: "
+                f"definition={definition_kind}, occurrences={occurrences!r}"
+            )
     stored_syntax_templates = (
         ("latex default", r"\newcommand{\x}[1][TOKEN]{body}"),
         (
@@ -965,6 +1003,68 @@ def test_rmp_dimension_ownership() -> None:
         raise AssertionError(
             "an unbraced dynamic label reactivated a public command: "
             f"{unbraced_dynamic_label!r}"
+        )
+    for consumed_label in (
+        r"\tn[label shift=125mm]{A}",
+        r"\tnset{pitch=126mm}",
+    ):
+        consumed_dynamic_option = scan_case_dimensions(
+            Path("synthetic.tex"),
+            r"\tndeclareatom{\tnfoo}{skin=dot}"
+            rf"\tnarrow{{\tnfoo{consumed_label}}}",
+        )
+        if len(consumed_dynamic_option) != 1 or any(
+            occurrence.owner is not DimensionOwner.ROUTE
+            for occurrence in consumed_dynamic_option
+        ):
+            raise AssertionError(
+                "a consumed dynamic label reactivated its option grammar: "
+                f"label={consumed_label!r}, "
+                f"occurrences={consumed_dynamic_option!r}"
+            )
+    for active_sibling, expected_owner in (
+        (r"\tn[label shift=127mm]{A}", DimensionOwner.LAYOUT),
+        (r"\tnset{pitch=128mm}", DimensionOwner.METRIC),
+    ):
+        active_dynamic_option_sibling = scan_case_dimensions(
+            Path("synthetic.tex"),
+            r"\tndeclareatom{\tnfoo}{skin=dot}"
+            rf"\tnarrow{{\tnfoo A{active_sibling}}}",
+        )
+        if len(active_dynamic_option_sibling) != 1 or any(
+            occurrence.owner is not expected_owner
+            for occurrence in active_dynamic_option_sibling
+        ):
+            raise AssertionError(
+                "a dynamic label masked a later option-bearing sibling: "
+                f"sibling={active_sibling!r}, "
+                f"occurrences={active_dynamic_option_sibling!r}"
+            )
+    consumed_dynamic_environment = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo\begin{tenkz}129mm\end{tenkz}}",
+    )
+    if len(consumed_dynamic_environment) != 1 or any(
+        occurrence.owner is not DimensionOwner.ROUTE
+        for occurrence in consumed_dynamic_environment
+    ):
+        raise AssertionError(
+            "a consumed dynamic label reactivated an environment control: "
+            f"{consumed_dynamic_environment!r}"
+        )
+    active_dynamic_environment_sibling = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo A\begin{tenkz}130mm\end{tenkz}}",
+    )
+    if len(active_dynamic_environment_sibling) != 1 or any(
+        occurrence.owner is not None
+        for occurrence in active_dynamic_environment_sibling
+    ):
+        raise AssertionError(
+            "a dynamic label masked a later environment sibling: "
+            f"{active_dynamic_environment_sibling!r}"
         )
     braced_dynamic_sibling = scan_case_dimensions(
         Path("synthetic.tex"),

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -580,9 +580,23 @@ def test_rmp_dimension_ownership() -> None:
                 f"occurrences={malformed_nested!r}"
             )
     environment_names = (
-        ("static", "tenkz", ""),
-        ("unresolved", r"\tenname", r"\def\tenname{tenkz}"),
-        ("parameterized", "#1", ""),
+        ("static", "{tenkz}", "{tenkz}", "{tenkz ", ""),
+        (
+            "unresolved",
+            r"{\tenname}",
+            r"{\tenname}",
+            r"{\tenname ",
+            r"\def\tenname{tenkz}",
+        ),
+        ("parameterized", "{#1}", "{#1}", "{#1 ", ""),
+        (
+            "unresolved unbraced",
+            r"\tenname",
+            r"\tenname",
+            None,
+            r"\def\tenname{tenkz}",
+        ),
+        ("parameterized unbraced", "#1", "#1", None, ""),
     )
     owner_contexts = (
         (
@@ -600,26 +614,37 @@ def test_rmp_dimension_ownership() -> None:
     )
     malformed_kinds = ("unclosed name", "unclosed option", "missing end")
     literal_index = 61
-    for name_kind, environment_name, prelude in environment_names:
+    for (
+        name_kind,
+        begin_argument,
+        end_argument,
+        unclosed_argument,
+        prelude,
+    ) in environment_names:
         for malformed_kind in malformed_kinds:
+            if malformed_kind == "unclosed name" and unclosed_argument is None:
+                continue
             for owner_kind, outer_open, outer_close, inner_template in owner_contexts:
                 literal = f"{literal_index}mm"
                 literal_index += 1
                 inner_command = inner_template.replace("DIM", literal)
                 if malformed_kind == "unclosed name":
-                    environment = rf"\begin{{{environment_name} " + inner_command
+                    environment = r"\begin" + unclosed_argument + inner_command
                     # Keep the name group genuinely unclosed; the outer owner
                     # is intentionally opened but cannot close across it.
                     suffix = ""
                 elif malformed_kind == "unclosed option":
                     environment = (
-                        rf"\begin{{{environment_name}}}[malformed "
+                        r"\begin"
+                        + begin_argument
+                        + "[malformed "
                         + inner_command
-                        + rf"\end{{{environment_name}}}"
+                        + r"\end"
+                        + end_argument
                     )
                     suffix = outer_close
                 else:
-                    environment = rf"\begin{{{environment_name}}}" + inner_command
+                    environment = r"\begin" + begin_argument + inner_command
                     suffix = outer_close
                 source = prelude + outer_open + environment + suffix
                 owner_source = strip_comments(source)
@@ -644,6 +669,45 @@ def test_rmp_dimension_ownership() -> None:
                         f"outer={owner_kind}, source={source!r}, "
                         f"occurrences={occurrences!r}"
                     )
+    replacement_templates = (
+        ("primitive", r"\def\x{TOKEN}"),
+        ("latex", r"\newcommand{\x}{TOKEN}"),
+        ("xparse", r"\NewDocumentCommand{\x}{}{TOKEN}"),
+    )
+    for definition_kind, definition_template in replacement_templates:
+        inert_end = definition_template.replace("TOKEN", r"\end{tenkz}")
+        for owner_kind, outer_open, outer_close, _ in owner_contexts:
+            source = (
+                outer_open
+                + r"\begin{tenkz}"
+                + inert_end
+                + r"\rule{81mm}{82mm}\end{tenkz}"
+                + outer_close
+            )
+            occurrences = scan_case_dimensions(Path("synthetic.tex"), source)
+            if len(occurrences) != 2 or any(
+                occurrence.owner is not None for occurrence in occurrences
+            ):
+                raise AssertionError(
+                    "an inert replacement end token closed an environment: "
+                    f"definition={definition_kind}, outer={owner_kind}, "
+                    f"occurrences={occurrences!r}"
+                )
+        inert_begin = definition_template.replace("TOKEN", r"\begin{tenkz}")
+        source = (
+            r"\tnarrow{\begin{tenkz}\end{tenkz}"
+            + inert_begin
+            + r"\rule{83mm}{84mm}}"
+        )
+        occurrences = scan_case_dimensions(Path("synthetic.tex"), source)
+        if len(occurrences) != 2 or any(
+            occurrence.owner is not DimensionOwner.ROUTE
+            for occurrence in occurrences
+        ):
+            raise AssertionError(
+                "an inert replacement begin token opened an environment: "
+                f"definition={definition_kind}, occurrences={occurrences!r}"
+            )
     unclosed_environment_end = scan_case_dimensions(
         Path("synthetic.tex"), r"\end{tenkz \tnput{x}{(79mm,0)}{}"
     )
@@ -748,6 +812,43 @@ def test_rmp_dimension_ownership() -> None:
         raise AssertionError(
             "an unbraced xparse declaration escaped quarantine: "
             f"{unbraced_compatibility_atom!r}"
+        )
+    unbraced_dynamic_label = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo\tnput{x}{(121mm,0)}{}}",
+    )
+    if len(unbraced_dynamic_label) != 1 or any(
+        occurrence.owner is not None for occurrence in unbraced_dynamic_label
+    ):
+        raise AssertionError(
+            "an unbraced dynamic label reactivated a public command: "
+            f"{unbraced_dynamic_label!r}"
+        )
+    later_dynamic_sibling = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo A\tnput{x}{(122mm,0)}{}}",
+    )
+    if len(later_dynamic_sibling) != 1 or any(
+        occurrence.owner is not DimensionOwner.LAYOUT
+        for occurrence in later_dynamic_sibling
+    ):
+        raise AssertionError(
+            "a dynamic one-token label consumed a later sibling command: "
+            f"{later_dynamic_sibling!r}"
+        )
+    grouped_dynamic_label = scan_case_dimensions(
+        Path("synthetic.tex"),
+        r"\tndeclareatom{\tnfoo}{skin=dot}"
+        r"\tnarrow{\tnfoo{\tnput{x}{(123mm,0)}{}}}",
+    )
+    if len(grouped_dynamic_label) != 1 or any(
+        occurrence.owner is not None for occurrence in grouped_dynamic_label
+    ):
+        raise AssertionError(
+            "a grouped dynamic label reactivated a public command: "
+            f"{grouped_dynamic_label!r}"
         )
     for catcode_prelude, atom_name in (
         (r"\makeatletter", "tn@atom"),

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import contextlib
 import csv
 import dataclasses
+import io
 import os
 import re
 import subprocess
+import sys
 import tempfile
 from collections import Counter
 from pathlib import Path
@@ -207,6 +210,36 @@ def _expect_dimension_failure(report: DimensionReport, phrase: str) -> None:
             ) from exc
     else:
         raise AssertionError(f"dimension mutation escaped the {phrase!r} ratchet")
+
+
+def test_rmp_dimension_cli_failure() -> None:
+    """Collection-time ownership failures use the concise CLI diagnostic."""
+    original_collect = tenkz_rmp.collect_dimension_report
+    original_argv = sys.argv
+
+    def raise_cycle(*_args: object, **_kwargs: object) -> DimensionReport:
+        raise DimensionOwnershipError(
+            "tenkz execution masks did not converge"
+        )
+
+    tenkz_rmp.collect_dimension_report = raise_cycle
+    sys.argv = [str(ROOT / "scripts" / "tenkz_rmp.py"), "check", "--all"]
+    stderr = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(stderr):
+            status = tenkz_rmp.main()
+    finally:
+        tenkz_rmp.collect_dimension_report = original_collect
+        sys.argv = original_argv
+    expected = (
+        "FAIL: RMP dimension ownership failed:\n"
+        "tenkz execution masks did not converge\n"
+    )
+    if status != 1 or stderr.getvalue() != expected:
+        raise AssertionError(
+            "a collection-time ownership cycle escaped the CLI handler: "
+            f"status={status}, stderr={stderr.getvalue()!r}"
+        )
 
 
 def test_rmp_dimension_ownership() -> None:
@@ -2003,6 +2036,7 @@ def test_rmp_pairing_identity() -> None:
 def main() -> int:
     test_kernel_capability_owner()
     test_ink_environment_owner()
+    test_rmp_dimension_cli_failure()
     test_rmp_dimension_ownership()
     test_rmp_author_source_identity()
     test_rmp_pairing_identity()

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -678,6 +678,11 @@ def test_rmp_dimension_ownership() -> None:
             "xparse expandable",
             r"\NewExpandableDocumentCommand{\x}{}{TOKEN}",
         ),
+        ("latex environment", r"\newenvironment{x}{TOKEN}{}"),
+        (
+            "xparse environment",
+            r"\NewDocumentEnvironment{x}{}{TOKEN}{}",
+        ),
     )
     for definition_kind, definition_template in replacement_templates:
         inert_end = definition_template.replace("TOKEN", r"\end{tenkz}")
@@ -723,6 +728,14 @@ def test_rmp_dimension_ownership() -> None:
             "expandable xparse processor",
             r"\NewExpandableDocumentCommand{\x}{>{TOKEN}m}{body}",
         ),
+        (
+            "latex environment default",
+            r"\newenvironment{x}[1][TOKEN]{begin}{end}",
+        ),
+        (
+            "xparse environment processor",
+            r"\NewDocumentEnvironment{x}{>{TOKEN}m}{begin}{end}",
+        ),
     )
     for definition_kind, definition_template in stored_syntax_templates:
         definition = definition_template.replace("TOKEN", r"\end{tenkz}")
@@ -750,6 +763,14 @@ def test_rmp_dimension_ownership() -> None:
         (
             "xparse expandable",
             r"\NewExpandableDocumentCommand{\fake}{}{stored}",
+        ),
+        (
+            "latex environment",
+            r"\newenvironment{fake}{stored}{}",
+        ),
+        (
+            "xparse environment",
+            r"\NewDocumentEnvironment{fake}{}{stored}{}",
         ),
     )
     for outer_kind, outer_template in replacement_templates:
@@ -785,6 +806,19 @@ def test_rmp_dimension_ownership() -> None:
         (
             "expandable xparse body",
             r"\NewExpandableDocumentCommand{\x}{}{",
+        ),
+        ("latex environment begin body", r"\newenvironment{x}{"),
+        (
+            "latex environment end body",
+            r"\newenvironment{x}{begin}{",
+        ),
+        (
+            "xparse environment begin body",
+            r"\NewDocumentEnvironment{x}{}{",
+        ),
+        (
+            "xparse environment end body",
+            r"\NewDocumentEnvironment{x}{}{begin}{",
         ),
     )
     for definition_kind, definition_prefix in unclosed_definition_prefixes:


### PR DESCRIPTION
Follow-up to #5384. Closes the six late exact-head review threads that arrived as #5384 merged.

- parse braced and one-token environment-name arguments through the shared mandatory-argument tokenizer, including parameter markers
- exclude inert primitive, LaTeX, and xparse macro replacement bodies from environment pairing
- make source-declared dynamic atoms precedence-winning neutral barriers for braced and one-token labels
- extend the adversarial matrix across ROUTE/LAYOUT contexts and add positive non-overconsumption checks

Validation:
- `python3 scripts/test_tenkz_corpus_provenance.py`
- `python3 -Werror -m py_compile scripts/tenkzlib/dimensions.py scripts/test_tenkz_corpus_provenance.py`
- `git diff --check origin/main...HEAD`
- changed-file 100-column check

Inventory compatibility was independently preflighted on the same corrective diff with zero conflicts and all inventory/provenance/texcase/production-RMP gates passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core static analysis for RMP dimension ownership across many TeX edge cases; mistakes could mis-classify dimensions or false-positive on valid corpus, though behavior is heavily regression-tested.
> 
> **Overview**
> Tightens the **RMP dimension ownership scanner** so TeX that is not executed at scan time cannot skew route/layout/metric classification.
> 
> **Execution masks and convergence:** Adds `_macro_replacement_spans` for primitive, LaTeX, and xparse definitions, plus `_execution_context` to iterate replacement spans, command quarantines, and visible `\tndeclareatom` names until stable (cycles raise `DimensionOwnershipError`). `scan_case_dimensions` unions those masks with option/command/environment spans.
> 
> **Parsing and dynamic atoms:** `\begin`/`\end` names go through the shared mandatory-argument tokenizer (including `#1` in macro bodies). Dynamic declared atoms use a fixed **O{} m** quarantine instead of open-ended argument guessing; tokens inside masks are skipped.
> 
> **RMP CLI and tests:** `tenkz_rmp.py` wraps dimension collection in try/except so ownership failures surface before builds. `test_tenkz_corpus_provenance.py` adds a large adversarial matrix (inert `\begin`/`\end` in definitions, unclosed bodies, dynamic-label siblings, mask cycles) and a CLI failure test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d5c320c2b97bbba0ec298d85488a24b3a11fb86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->