### PR TITLE
fix(tenkz): make final tag publication retryable

### DIFF
--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -304,11 +304,11 @@ The sole networked release step is the dedicated workflow's terminal publisher
 job. It has no checkout and runs no repository code. GitHub starts it only after
 the exact sign-off integration's network-disabled post-merge validator succeeds.
 
-The publisher makes one authenticated tag object that every retry can
-reconstruct. The pinned support tree supplies its SSH-Ed25519 public key and
-byte-level object schema; only the publisher receives the private key. The
-schema fixes the tagger identity and timezone to `+0000`. The validator converts
-the sign-off pull request's exact UTC `mergedAt` to one integer Unix second and
+The publisher reads the final ref before deciding whether it needs the private
+key. The pinned support tree supplies the SSH-Ed25519 public key and byte-level
+object schema; only the absent-ref path receives the private key. The schema
+fixes the tagger identity and timezone to `+0000`. The validator converts the
+sign-off pull request's exact UTC `mergedAt` to one integer Unix second and
 passes that `tagger_epoch_seconds` value; a fractional, non-UTC, ambiguous, or
 out-of-range value fails closed. The schema specifies the complete Git
 tag-object byte layout, the `git` SSH-signature namespace and embedding, and the
@@ -322,16 +322,16 @@ no caller-supplied replacement. It fetches those exact Git objects by OID
 through the GitHub control plane and verifies their identities and hashes before
 constructing `E`; it never reads a moving branch path.
 
-After validation, the publisher constructs that exact object `E`, verifies its
-raw signature against the pinned public key, checks every schema byte and its
-peel, and computes its object ID before any write. If the final ref is absent,
-it creates the already-verified object and ref without force. If an uncertain
-earlier write already left the ref at `E`, a retry repeats the raw verification
-and adopts it. Any other present object is an incident. The job exits
-successfully only after a final readback authenticates `E`; it emits no durable
-output receipt. Without the private key, another actor cannot forge an
-acceptable object; replaying the already-authorized `E` cannot change its name
-or target.
+After validation, the publisher first reads the final ref. If it is absent, the
+publisher constructs `E`, verifies its raw signature against the pinned public
+key, checks every schema byte and its peel, computes its object ID before any
+write, and creates the already-verified object and ref without force. If an
+uncertain earlier write already left the ref at `E`, a retry authenticates the
+stored raw object and adopts it without reading the private key. Any other
+present object is an incident. The job exits successfully only after a final
+readback authenticates `E`; it emits no durable output receipt. Without the
+private key, another actor cannot forge an acceptable object; replaying the
+already-authorized `E` cannot change its name or target.
 
 The evidence-campaign freeze tag matches `tenkz-v0.9.PATCH`. `PATCH` has the
 canonical grammar `0|[1-9][0-9]*`. When a new freeze is proposed, its patch must

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -274,9 +274,10 @@ also pins the complete Git tree at `release_publisher_workflow_root`. Until a
 validation declares `released`, the current tree must equal that pin and the
 dedicated environment must retain its protected-branch rule. Across that tree,
 the publisher is the only job that may name the environment or private-key
-secret; `secrets: inherit` is forbidden. The key exists only as that environment
-secret. An organization or repository secret with the same name and access to
-this repository fails closed.
+secret; `secrets: inherit` is forbidden. The configured secret name exists only
+in that environment. The same name in another environment in this repository,
+at repository scope, or at organization scope with access to this repository
+fails closed.
 
 After a successful publisher job, an administrator removes the environment
 secret. The validation that declares `released` requires its absence, and every

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -295,9 +295,11 @@ the exact sign-off integration's network-disabled post-merge validator succeeds.
 The publisher makes one authenticated tag object that every retry can
 reconstruct. The pinned support tree supplies its SSH-Ed25519 public key and
 byte-level object schema; only the publisher receives the private key. The
-schema fixes the tagger identity and uses the sign-off merge time rather than a
-runner clock. Its signed message binds the final name, sign-off integration,
-policy hash, and ledger prefix.
+schema fixes the tagger identity, fixes its timezone to `+0000`, and uses the
+sign-off merge time rather than a runner clock. It specifies the complete Git
+tag-object byte layout, the `git` SSH-signature namespace and embedding, and the
+repository object-format hash. Its signed message binds the final name,
+sign-off integration, policy hash, and ledger prefix.
 
 The successful validator passes one closed tuple to its dependent job: `I`, the
 normalized sign-off merge time, policy and prefix hashes, prefix boundary, and

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -76,6 +76,8 @@ release_tag_public_key = "tests/tenkz/release-support/final-tag-signing-key.pub"
 release_tag_object_schema = "tests/tenkz/release-support/final-tag-object-v1.schema.json"
 release_publisher_environment = "tenkz-release-publisher"
 release_publisher_secret = "TENKZ_FINAL_TAG_SIGNING_KEY"
+release_publisher_secret_scope = "environment-only-no-shadow"
+release_publisher_key_retirement = "required-before-released"
 release_publisher_workflow_root = ".github/workflows"
 release_test_dependency_contract = "pinned-harness-support-declared-subject-roles"
 release_test_protocol = "hermetic-repository-view-no-shell-or-network"
@@ -268,12 +270,21 @@ evidence-supervisor result is still required; a workflow status cannot replace
 it. A missing, renamed, non-blob, or changed workflow fails closed.
 
 Key isolation has a wider boundary than the one release workflow. Activation
-also pins the complete Git tree at `release_publisher_workflow_root`. Every
-later validation requires that same tree and rechecks the dedicated environment
-and its protected-branch rule. Across that tree, the publisher is the only job
-that may name the environment or private-key secret. Thus another workflow
-cannot borrow the key while an attempt is active. Environment administrators
-remain inside the explicit GitHub-administration trust boundary.
+also pins the complete Git tree at `release_publisher_workflow_root`. Until a
+validation declares `released`, the current tree must equal that pin and the
+dedicated environment must retain its protected-branch rule. Across that tree,
+the publisher is the only job that may name the environment or private-key
+secret; `secrets: inherit` is forbidden. The key exists only as that environment
+secret. An organization or repository secret with the same name and access to
+this repository fails closed.
+
+After a successful publisher job, an administrator removes the environment
+secret. The validation that declares `released` requires its absence, and every
+later replay rejects its reintroduction. Released replay checks the successful
+job against the historical workflow tree at the sign-off integration, which
+must equal the activation pin. It does not require unrelated current workflows
+to remain frozen after the key is gone. Environment administrators remain
+inside the explicit GitHub-administration trust boundary.
 
 The resolver also closes the dedicated workflow's executable dependency graph.
 A local action or reusable workflow is pinned by its activation Git object and
@@ -295,26 +306,31 @@ the exact sign-off integration's network-disabled post-merge validator succeeds.
 The publisher makes one authenticated tag object that every retry can
 reconstruct. The pinned support tree supplies its SSH-Ed25519 public key and
 byte-level object schema; only the publisher receives the private key. The
-schema fixes the tagger identity, fixes its timezone to `+0000`, and uses the
-sign-off merge time rather than a runner clock. It specifies the complete Git
+schema fixes the tagger identity and timezone to `+0000`. The validator converts
+the sign-off pull request's exact UTC `mergedAt` to one integer Unix second and
+passes that `tagger_epoch_seconds` value; a fractional, non-UTC, ambiguous, or
+out-of-range value fails closed. The schema specifies the complete Git
 tag-object byte layout, the `git` SSH-signature namespace and embedding, and the
 repository object-format hash. Its signed message binds the final name,
 sign-off integration, policy hash, and ledger prefix.
 
-The successful validator passes one closed tuple to its dependent job: `I`, the
-normalized sign-off merge time, policy and prefix hashes, prefix boundary, and
-the pinned support-tree, schema-blob, and public-key-blob OIDs. The publisher
-accepts no caller-supplied replacement. It fetches those exact Git objects by
-OID through the GitHub control plane and verifies their identities and hashes
-before constructing `E`; it never reads a moving branch path.
+The successful validator passes one closed tuple to its dependent job: `I`,
+`tagger_epoch_seconds`, policy and prefix hashes, prefix boundary, and the
+pinned support-tree, schema-blob, and public-key-blob OIDs. The publisher accepts
+no caller-supplied replacement. It fetches those exact Git objects by OID
+through the GitHub control plane and verifies their identities and hashes before
+constructing `E`; it never reads a moving branch path.
 
-After validation, the publisher constructs that exact object `E`. If the final
-ref is absent, it creates `E` and the ref without force. If an uncertain earlier
-write already left the ref at `E`, a retry verifies the raw signature, payload,
-and peel and adopts it. Any other present object is an incident. A successful
-publisher job records `E`'s OID after readback. Without the private key, another
-actor cannot forge an acceptable object; replaying the already-authorized `E`
-cannot change its name or target.
+After validation, the publisher constructs that exact object `E`, verifies its
+raw signature against the pinned public key, checks every schema byte and its
+peel, and computes its object ID before any write. If the final ref is absent,
+it creates the already-verified object and ref without force. If an uncertain
+earlier write already left the ref at `E`, a retry repeats the raw verification
+and adopts it. Any other present object is an incident. The job exits
+successfully only after a final readback authenticates `E`; it emits no durable
+output receipt. Without the private key, another actor cannot forge an
+acceptable object; replaying the already-authorized `E` cannot change its name
+or target.
 
 The evidence-campaign freeze tag matches `tenkz-v0.9.PATCH`. `PATCH` has the
 canonical grammar `0|[1-9][0-9]*`. When a new freeze is proposed, its patch must
@@ -487,21 +503,24 @@ and before sign-off merge. The sign-off head and integration must descend from
 all three integrations. The sign-off may proceed immediately once those ordered
 facts hold. It also requires one qualifying work entry in each class, no
 unresolved `fix-compatible` friction in the active attempt, and no condition
-requiring reset. A
-validated sign-off first enters `signed-off-awaiting-tag`; mutable evidence
-remains live until a full replay succeeds. If the exact signed object appears
-but its publisher job stopped before recording success, the intermediate state
-is `signed-off-awaiting-publisher-receipt`; a retry authenticates it. A
-successful publisher job plus that exact object on the sign-off integration
-under the required no-update, no-delete, no-bypass protection enters terminal
-`released` state, and no entry follows it. Every later validation still replays
-all current mutable facts. Before the final tag exists, drift follows the
-ordered reset process; after the tag exists, the same drift is a hard release
-incident and never reopens the ledger. Ruleset administrators and the GitHub
-control plane are trusted: the validator does not claim to detect drift or a
-protection gap that an administrator restores before its snapshot. A wrong,
-moved, or replaced present tag is never repaired by moving or reusing the name.
-An absent final-tag ref remains `signed-off-awaiting-tag` unless a successful
-publisher job previously read it back; later absence in that case is an
-incident. The exact entry grammar, state transitions, external-fact rules, and
-reset rules live in `SOAK-1.0.md`.
+requiring reset. A validated sign-off first enters
+`signed-off-awaiting-tag`; mutable evidence remains live until a full replay
+succeeds. If the exact signed object appears but no publisher job has completed
+successfully, the intermediate state is
+`signed-off-awaiting-publisher-success`; a retry authenticates it. Once the job
+succeeds, the campaign is `signed-off-awaiting-key-retirement` until the
+environment key is removed. A later validation, not the publisher job, declares
+terminal `released` state after observing the exact object, the successful
+historical job, and the retired key; no entry follows it. There is no publisher
+output receipt or compatibility state alias.
+
+Every later validation still replays all current mutable facts. Before the
+final tag exists, drift follows the ordered reset process; after the tag exists,
+the same drift is a hard release incident and never reopens the ledger. Ruleset
+administrators and the GitHub control plane are trusted: the validator does not
+claim to detect drift or a protection gap that an administrator restores before
+its snapshot. A wrong, moved, or replaced present tag is never repaired by
+moving or reusing the name. An absent final-tag ref remains
+`signed-off-awaiting-tag` unless a successful publisher job previously read it
+back; later absence in that case is an incident. The exact entry grammar, state
+transitions, external-fact rules, and reset rules live in `SOAK-1.0.md`.

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -276,8 +276,8 @@ dedicated environment must retain its protected-branch rule. Across that tree,
 the publisher is the only job that may name the environment or private-key
 secret; `secrets: inherit` is forbidden. The configured secret name exists only
 in that environment. The same name in another environment in this repository,
-at repository scope, or at organization scope with access to this repository
-fails closed.
+at repository scope, or at organization scope fails closed, regardless of the
+organization secret's current repository access.
 
 After a successful publisher job, an administrator removes the environment
 secret. The validation that declares `released` requires its absence, and every
@@ -319,8 +319,9 @@ The successful validator passes one closed tuple to its dependent job: `I`,
 `tagger_epoch_seconds`, policy and prefix hashes, prefix boundary, and the
 pinned support-tree, schema-blob, and public-key-blob OIDs. The publisher accepts
 no caller-supplied replacement. It fetches those exact Git objects by OID
-through the GitHub control plane and verifies their identities and hashes before
-constructing `E`; it never reads a moving branch path.
+through the GitHub control plane and verifies their identities and hashes. When
+construction is required, those checks precede it; the publisher never reads a
+moving branch path.
 
 After validation, the publisher first reads the final ref. If it is absent, the
 publisher constructs `E`, verifies its raw signature against the pinned public

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -71,6 +71,9 @@ release_enforcement_workflows = [".github/workflows/tenkz-release-policy.yml"]
 release_workflow_dependencies = "transitive-content-addressed-no-runtime-downloads"
 release_enforcement_network = "disabled-before-repository-code"
 release_reset_replay_schema = "tests/tenkz/release-support/reset-replay-v1.schema.json"
+release_tag_signature = "ssh-ed25519"
+release_tag_public_key = "tests/tenkz/release-support/final-tag-signing-key.pub"
+release_tag_object_schema = "tests/tenkz/release-support/final-tag-object-v1.schema.json"
 release_test_dependency_contract = "pinned-harness-support-declared-subject-roles"
 release_test_protocol = "hermetic-repository-view-no-shell-or-network"
 
@@ -276,10 +279,22 @@ content does not.
 
 The sole networked release step is the dedicated workflow's terminal publisher
 job. It has no checkout and runs no repository code. GitHub starts it only after
-the exact sign-off integration's network-disabled post-merge validator succeeds;
-it uses the GitHub control plane to create the absent annotated
-`tenkz-v1.0.0` tag at that integration. The pinned workflow and job dependency,
-not a tagger timestamp or a manual push, establish this order.
+the exact sign-off integration's network-disabled post-merge validator succeeds.
+
+The publisher makes one authenticated tag object that every retry can
+reconstruct. The pinned support tree supplies its SSH-Ed25519 public key and
+byte-level object schema; only the publisher receives the private key. The
+schema fixes the tagger identity and uses the sign-off merge time rather than a
+runner clock. Its signed message binds the final name, sign-off integration,
+policy hash, and ledger prefix.
+
+After validation, the publisher constructs that exact object `E`. If the final
+ref is absent, it creates `E` and the ref without force. If an uncertain earlier
+write already left the ref at `E`, a retry verifies the raw signature, payload,
+and peel and adopts it. Any other present object is an incident. A successful
+publisher job records `E`'s OID after readback. Without the private key, another
+actor cannot forge an acceptable object; replaying the already-authorized `E`
+cannot change its name or target.
 
 The evidence-campaign freeze tag matches `tenkz-v0.9.PATCH`. `PATCH` has the
 canonical grammar `0|[1-9][0-9]*`. When a new freeze is proposed, its patch must
@@ -373,7 +388,8 @@ The dependency chain is ordered:
    independently exact-head-approved release-preparation pull request descending
    from both work integrations and all resolution records;
 9. merge the independently approved sign-off record; its pinned post-merge
-   workflow validates it and then creates `tenkz-v1.0.0` on its integration.
+   workflow validates it, records the exact tag object, and then creates
+   `tenkz-v1.0.0` on its integration.
 
 Closing #5086 in step 2 means that its plane-basis capability has landed for
 0.8. The `expiry 1.0` values on related SHRINK entries bound the later removal
@@ -453,9 +469,10 @@ facts hold. It also requires one qualifying work entry in each class, no
 unresolved `fix-compatible` friction in the active attempt, and no condition
 requiring reset. A
 validated sign-off first enters `signed-off-awaiting-tag`; mutable evidence
-remains live until a full replay succeeds and the exact annotated final tag is
-currently observed on its integration under the required no-update, no-delete,
-no-bypass protection. That current-state observation enters terminal
+remains live until a full replay succeeds, a successful publisher job has
+created or authenticated the exact signed final-tag object, and that object is
+observed on its integration under the required no-update, no-delete, no-bypass
+protection. That combined observation enters terminal
 `released` state, and no entry follows it. Every later validation still replays
 all current mutable facts. Before the final tag exists, drift follows the
 ordered reset process; after the tag exists, the same drift is a hard release

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -48,7 +48,7 @@ frozen_twin_scope = "library-entry-point-in-same-package"
 frozen_twin_lifetime = "permanent"
 frozen_twin_precedent = "quantikz/quantikz2"
 maintainer_identity = "github:lionsr"
-signer_identity_scheme = "github:lowercase-login"
+github_identity_scheme = "github:lowercase-login"
 reviewer_repository_permissions = ["write", "admin"]
 release_manifest_pattern = "docs/tenkz/releases/TAG.toml"
 release_package_metadata = "tex/tenkz/tenkz.sty"
@@ -74,6 +74,9 @@ release_reset_replay_schema = "tests/tenkz/release-support/reset-replay-v1.schem
 release_tag_signature = "ssh-ed25519"
 release_tag_public_key = "tests/tenkz/release-support/final-tag-signing-key.pub"
 release_tag_object_schema = "tests/tenkz/release-support/final-tag-object-v1.schema.json"
+release_publisher_environment = "tenkz-release-publisher"
+release_publisher_secret = "TENKZ_FINAL_TAG_SIGNING_KEY"
+release_publisher_workflow_root = ".github/workflows"
 release_test_dependency_contract = "pinned-harness-support-declared-subject-roles"
 release_test_protocol = "hermetic-repository-view-no-shell-or-network"
 
@@ -264,6 +267,14 @@ head and executed workflow resolve to those pinned bytes. The independent
 evidence-supervisor result is still required; a workflow status cannot replace
 it. A missing, renamed, non-blob, or changed workflow fails closed.
 
+Key isolation has a wider boundary than the one release workflow. Activation
+also pins the complete Git tree at `release_publisher_workflow_root`. Every
+later validation requires that same tree and rechecks the dedicated environment
+and its protected-branch rule. Across that tree, the publisher is the only job
+that may name the environment or private-key secret. Thus another workflow
+cannot borrow the key while an attempt is active. Environment administrators
+remain inside the explicit GitHub-administration trust boundary.
+
 The resolver also closes the dedicated workflow's executable dependency graph.
 A local action or reusable workflow is pinned by its activation Git object and
 included in later byte-and-mode checks. Every external action or reusable
@@ -287,6 +298,13 @@ byte-level object schema; only the publisher receives the private key. The
 schema fixes the tagger identity and uses the sign-off merge time rather than a
 runner clock. Its signed message binds the final name, sign-off integration,
 policy hash, and ledger prefix.
+
+The successful validator passes one closed tuple to its dependent job: `I`, the
+normalized sign-off merge time, policy and prefix hashes, prefix boundary, and
+the pinned support-tree, schema-blob, and public-key-blob OIDs. The publisher
+accepts no caller-supplied replacement. It fetches those exact Git objects by
+OID through the GitHub control plane and verifies their identities and hashes
+before constructing `E`; it never reads a moving branch path.
 
 After validation, the publisher constructs that exact object `E`. If the final
 ref is absent, it creates `E` and the ref without force. If an uncertain earlier
@@ -469,10 +487,11 @@ facts hold. It also requires one qualifying work entry in each class, no
 unresolved `fix-compatible` friction in the active attempt, and no condition
 requiring reset. A
 validated sign-off first enters `signed-off-awaiting-tag`; mutable evidence
-remains live until a full replay succeeds, a successful publisher job has
-created or authenticated the exact signed final-tag object, and that object is
-observed on its integration under the required no-update, no-delete, no-bypass
-protection. That combined observation enters terminal
+remains live until a full replay succeeds. If the exact signed object appears
+but its publisher job stopped before recording success, the intermediate state
+is `signed-off-awaiting-publisher-receipt`; a retry authenticates it. A
+successful publisher job plus that exact object on the sign-off integration
+under the required no-update, no-delete, no-bypass protection enters terminal
 `released` state, and no entry follows it. Every later validation still replays
 all current mutable facts. Before the final tag exists, drift follows the
 ordered reset process; after the tag exists, the same drift is a hard release
@@ -480,6 +499,7 @@ incident and never reopens the ledger. Ruleset administrators and the GitHub
 control plane are trusted: the validator does not claim to detect drift or a
 protection gap that an administrator restores before its snapshot. A wrong,
 moved, or replaced present tag is never repaired by moving or reusing the name.
-An absent final-tag ref remains `signed-off-awaiting-tag`; this state-based
-contract stores no prior-observation witness. The exact entry grammar, state
-transitions, external-fact rules, and reset rules live in `SOAK-1.0.md`.
+An absent final-tag ref remains `signed-off-awaiting-tag` unless a successful
+publisher job previously read it back; later absence in that case is an
+incident. The exact entry grammar, state transitions, external-fact rules, and
+reset rules live in `SOAK-1.0.md`.

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -206,9 +206,9 @@ lifetime.  The alternative execution form must begin exactly
 `executes at the <milestone> freeze`.  Prose outside such a row is not a
 machine-readable verdict.
 
-## Compatibility policy and 1.0 evidence gate
+## Pre-1.0 contract and 1.0 evidence gate
 
-`DESIGN.md` owns package and event-stream compatibility.  `SOAK-1.0.md` is an
+`DESIGN.md` owns the package and event-stream contract.  `SOAK-1.0.md` is an
 inactive ledger while its normative block says `enforcement = "pending"`.
 During that state, no campaign entry is valid and reviewed follow-up PRs may still
 correct the prefix.
@@ -218,6 +218,8 @@ exists today.  Move its callers to the clean 1.0 form in the same change, then
 delete it.  Do not add an alias, compatibility reader, dual writer, or temporary
 bridge.  If one pull request is too large, stack small pull requests whose
 integration order keeps every merged tree on the single new contract.
+The shrink ledger's `alias(...)` verdict records debt already present; it is not
+permission to introduce another alias.
 
 The activation slice under #5352 will add the validation commands here only
 after their scripts, repository-evidence checks, tests, and CI wiring exist on

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -215,8 +215,9 @@ correct the prefix.
 
 Before the 0.9 freeze, do not preserve an obsolete spelling merely because it
 exists today.  Move its callers to the clean 1.0 form in the same change, then
-delete it.  Add a temporary bridge only when a staged migration cannot land
-atomically, and give that bridge an explicit SHRINK expiry.
+delete it.  Do not add an alias, compatibility reader, dual writer, or temporary
+bridge.  If one pull request is too large, stack small pull requests whose
+integration order keeps every merged tree on the single new contract.
 
 The activation slice under #5352 will add the validation commands here only
 after their scripts, repository-evidence checks, tests, and CI wiring exist on
@@ -299,6 +300,13 @@ publisher then constructs the one signed tag object fixed by the release policy
 and creates the final ref.  A stopped runner can retry by authenticating that
 same object; it never invents a second one.  Do not push the tag by hand: an
 object other than the exact authenticated one is an incident, not a release.
+Before its first write, the publisher verifies the candidate object's signature,
+schema bytes, object ID, and peel.  A successful job is itself the API-visible
+publication fact; there is no inaccessible job-output receipt.  Remove the
+environment key after that success.  A later validation declares release only
+after it sees the exact object, the historical pinned publisher job, and the
+retired key.  Unrelated workflow files may then evolve without changing that
+historical evidence.
 Current mutable facts are replayed forever: drift before the final-tag ref uses
 the reset process, while drift after that ref exists is a hard incident and
 never reopens the ledger.

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -333,7 +333,9 @@ close and reopen activity; and pushes to `main` and the `tenkz-v*` tag
 namespace.  It performs only read requests.  Its credential principal needs
 read access to repository contents, pull requests, reviews, and issues, plus
 the write-level ruleset visibility GitHub requires to return unredacted rule
-and bypass details.  Missing or redacted details fail closed.  Ruleset
+and bypass details.  It also needs complete name-and-access visibility for
+repository, organization, and environment Actions secrets; secret values are
+never read.  Missing or redacted details fail closed.  Ruleset
 administrators and the GitHub control plane are trusted; this current-state
 check does not claim to detect an administrative protection gap restored before
 the snapshot.  No live-entry or release command is available while enforcement

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -294,11 +294,11 @@ compatible friction in the active attempt is resolved and both work merges have
 landed; its exact diff changes only the tag-derived 1.0 manifest and four
 canonical release artifacts.  Exact-head sign-off review follows immediately
 on that integration; if `main` advances, repeat preparation on the new tip.  A
-validated sign-off remains live until a full replay succeeds and
-the pinned post-merge workflow's dependent publisher job creates and reads back
-the exact annotated final tag under current required protection.  Do not push
-that tag by hand: a pre-existing or externally created ref is an incident, not
-a release.
+validated sign-off remains live until a full replay succeeds.  The dependent
+publisher then constructs the one signed tag object fixed by the release policy
+and creates the final ref.  A stopped runner can retry by authenticating that
+same object; it never invents a second one.  Do not push the tag by hand: an
+object other than the exact authenticated one is an incident, not a release.
 Current mutable facts are replayed forever: drift before the final-tag ref uses
 the reset process, while drift after that ref exists is a hard incident and
 never reopens the ledger.

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -296,10 +296,11 @@ landed; its exact diff changes only the tag-derived 1.0 manifest and four
 canonical release artifacts.  Exact-head sign-off review follows immediately
 on that integration; if `main` advances, repeat preparation on the new tip.  A
 validated sign-off remains live until a full replay succeeds.  The dependent
-publisher then constructs the one signed tag object fixed by the release policy
-and creates the final ref.  A stopped runner can retry by authenticating that
-same object; it never invents a second one.  Do not push the tag by hand: an
-object other than the exact authenticated one is an incident, not a release.
+publisher first reads the final ref.  It either constructs the one signed tag
+object fixed by the release policy and creates an absent ref, or authenticates
+that already-present object without reading the private key.  A retry never
+invents a second object.  Do not push the tag by hand: any other object is an
+incident, not a release.
 Before its first write, the publisher verifies the candidate object's signature,
 schema bytes, object ID, and peel.  A successful job is itself the API-visible
 publication fact; there is no inaccessible job-output receipt.  Remove the

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -101,8 +101,9 @@ normalized sign-off `mergedAt`, policy and prefix hashes, prefix boundary, and
 the pinned support-tree, object-schema-blob, and public-key-blob OIDs. The
 publisher accepts no caller-provided substitute. Through `gh`, it fetches those
 exact Git objects by OID and verifies their identities and hashes. A branch
-name, moving path, environment value other than the private key, or unbound
-`workflow_dispatch` input fails closed.
+name, moving path, caller-controlled variable or secret other than the private
+key, or unbound `workflow_dispatch` input fails closed. Trusted `GITHUB_*`
+runner metadata must agree with the closed tuple.
 
 The publisher constructs one byte-deterministic annotated tag object `E`. The
 pinned object schema fixes its tagger identity, normalizes the tagger time to

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -80,14 +80,29 @@ trusted; downloaded mutable executable content does not.
 The dedicated workflow has one terminal publisher job with job-level
 `contents: write`; validation jobs have no write permission. The publisher has
 no checkout, local action, container, package download, or repository command.
-Its only executable is the hosted runner's version-fingerprinted `gh` client,
-invoked by the pinned workflow's closed inline command. Its `needs` dependency
-names the exact post-merge validation job, so GitHub can start it only after that
-job succeeds for the sign-off integration `I`. It then uses only GitHub's
-control plane to require the final ref absent, create an
-annotated `tenkz-v1.0.0` tag object targeting `I`, create the ref without force,
-and read it back. Its closed check output records the returned tag-object OID.
-Any other networked step or publisher input fails closed.
+It uses only the hosted runner's version-fingerprinted `gh`, `git`, and
+`ssh-keygen` clients and the pinned workflow's closed inline command. Its
+`needs` dependency names the exact post-merge validation job, so GitHub can
+start it only after that job succeeds for the sign-off integration `I`. The
+publisher alone receives the private half of the policy's dedicated signing
+key. Any other networked step, executable, key user, or publisher input fails
+closed.
+
+The publisher constructs one byte-deterministic annotated tag object `E`. The
+pinned object schema fixes its tagger identity, normalizes the tagger time to
+the sign-off pull request's exact `mergedAt`, and fixes the signed-message
+serialization. That message binds `tenkz-v1.0.0`, `I`, the armed policy hash,
+and the validated ledger prefix. `E` carries an SSH-Ed25519 signature under the
+public key in the pinned support tree. The validator checks the raw signature
+and payload itself; GitHub's displayed `verified` value is not a substitute.
+
+The publisher reads the final ref before and after every uncertain write. If it
+is absent, the job creates or re-creates content-addressed object `E`, creates
+the ref without force, and reads it back. If the ref already names `E`, the job
+authenticates its exact bytes, signature, and peel to `I` and succeeds without
+another mutation. An absent ref remains retryable. Any present non-`E` object,
+bad signature, wrong payload, or wrong peel is a hard release incident. A
+successful publisher job records `E`'s OID after the final readback.
 
 While validly armed, later changes preserve the pinned policy and prefix and
 append live entry blocks after the marker. A correction is an appended entry;
@@ -756,34 +771,37 @@ source fact, invalid 0.9 payload, or pinned-byte mismatch requires a
 sign-off-specific external-fact, or
 `validate-release-payload(I, tenkz-v1.0.0)` mismatch requires that reset
 targeting the sign-off. Neither case is a validated sign-off. After post-merge
-validation succeeds, the campaign is `signed-off-awaiting-tag` and only the
-pinned workflow's dependent publisher job may create the annotated
-`tenkz-v1.0.0` tag on `I`. An absent ref leaves the campaign awaiting that job
-or a full-workflow retry. A ref present before the publisher runs, a failed
-create-if-absent operation, or a ref created by another path is a hard release
-incident, not a release. All mutable external facts remain subject to
-revalidation, and drift while the ref is absent requires the ordered reset
-process above.
+validation succeeds, the campaign is `signed-off-awaiting-tag`. The pinned
+workflow's dependent publisher job may create the exact authenticated object
+`E` and the `tenkz-v1.0.0` ref on `I`. An absent ref leaves the campaign awaiting
+that job or a full-workflow retry. If `E` is present but the job stopped before
+recording success, the campaign is `signed-off-awaiting-publisher-receipt`; a
+retry authenticates and adopts `E`. A different present object or failed
+authentication is a hard release incident, not a release. All mutable external
+facts remain subject to revalidation, and drift while the ref is absent requires
+the ordered reset process above.
 
 Every validation, including one whose snapshot already contains the final tag,
 first replays the complete pinned policy, ledger, payload, Git, and GitHub
 evidence through the validated sign-off. A tag lookup may not short-circuit
 that replay. GitHub must report a successful publisher job in the pinned
 workflow run for `I`, ordered after its successful post-merge validation job.
-The current object named `tenkz-v1.0.0` must equal the object that job created,
-be annotated, and peel to `I` under the required current no-update, no-delete,
-no-bypass protection. Only that combined observation changes the campaign to
-terminal `released` state. No later ledger entry or new sign-off is valid. Every
-later validation still replays every current mutable fact. A
+Its closed output names `E`'s OID and reports that the final readback either
+created or authenticated that same object. The current object named
+`tenkz-v1.0.0` must equal `E`, carry the valid raw signature and exact payload,
+and peel to `I` under the required current no-update, no-delete, no-bypass
+protection. Only that combined observation changes the campaign to terminal
+`released` state. No later ledger entry or new sign-off is valid. Every later
+validation still replays every current mutable fact. A
 mismatch that requires the ordered reset process while the final-tag ref is
 absent becomes a hard release incident once that ref exists; it never reopens
 the ledger. Creating the protected name with the wrong kind or target is also a
 hard release incident. Weaker current protection, or a moved or replaced
 present tag, is likewise a hard release incident. An absent final-tag ref
-remains `signed-off-awaiting-tag` only while no successful publisher job exists.
-After that job records the created object, an absent ref is a hard incident.
-No incident is repaired by deleting, moving, or reusing the name, and none
-starts another 1.0 attempt.
+remains `signed-off-awaiting-tag` while no successful publisher job exists. A
+successful job with an absent ref is a hard incident because the job's required
+readback could not have succeeded. No incident is repaired by deleting, moving,
+or reusing the name, and none starts another 1.0 attempt.
 
 No entry may be appended while `enforcement = "pending"`. The activation slice
 under #5352 will add validation commands only after their scripts,

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -69,12 +69,13 @@ Activation also derives and pins the complete Git tree at the policy's
 current tree must equal that pin. The resolver completely enumerates its
 workflow jobs and requires the terminal publisher to be the sole job naming
 `release_publisher_environment` or `release_publisher_secret`. Workflow-level
-secret inheritance is forbidden. The current environment configuration must restrict
-deployment to the protected release branch. The private key must exist only as
-that environment secret. The resolver exhaustively checks repository and
-organization secret names and access, and rejects any same-named secret that
-can reach the repository. Missing, wider, changed, shadowed, or incompletely
-paginated configuration fails closed.
+secret inheritance is forbidden. The current environment configuration must
+restrict deployment to the protected release branch. The configured private-key
+secret name must exist only in that environment. The resolver exhaustively lists
+every repository environment and its secret names, the repository secret names,
+and the organization secret names and repository access. It rejects the same
+name in any other scope that can reach the repository. Missing, wider, changed,
+shadowed, or incompletely paginated configuration fails closed.
 
 After a successful publisher job, an administrator removes the environment
 secret. The validation that declares `released` requires its absence, and every
@@ -847,9 +848,10 @@ against the same deterministic object.
 
 The current object named `tenkz-v1.0.0` must equal `E`, carry the valid raw
 signature and exact payload, and peel to `I` under the required current
-no-update, no-delete, no-bypass protection. The environment key and any
-same-named repository or organization secret must be absent. Only a validation
-that observes this complete conjunction changes the campaign to terminal
+no-update, no-delete, no-bypass protection. The configured secret name must be
+absent from every repository environment and from repository and organization
+scope. Only a validation that observes this complete conjunction changes the
+campaign to terminal
 `released` state; the publisher job never declares release itself. No later
 ledger entry or new sign-off is valid. Released replay continues to check the
 historical publisher tree, but unrelated current workflows may change after the

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -74,8 +74,9 @@ restrict deployment to the protected release branch. The configured private-key
 secret name must exist only in that environment. The resolver exhaustively lists
 every repository environment and its secret names, the repository secret names,
 and the organization secret names and repository access. It rejects the same
-name in any other scope that can reach the repository. Missing, wider, changed,
-shadowed, or incompletely paginated configuration fails closed.
+name in every other environment and at repository or organization scope,
+regardless of the organization secret's current repository access. Missing,
+wider, changed, shadowed, or incompletely paginated configuration fails closed.
 
 After a successful publisher job, an administrator removes the environment
 secret. The validation that declares `released` requires its absence, and every

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -64,6 +64,15 @@ workflow resolve to the pinned bytes. It cannot replace the independent
 evidence-supervisor result. A missing, renamed, non-blob, or changed workflow
 fails closed.
 
+Activation also derives and pins the complete Git tree at the policy's
+`release_publisher_workflow_root`. Every later validation requires that exact
+tree. It completely enumerates its workflow jobs and requires the terminal
+publisher to be the sole job naming `release_publisher_environment` or
+`release_publisher_secret`. The current environment configuration must restrict
+deployment to the protected release branch. Missing, wider, changed, or
+incompletely paginated configuration fails closed. A transient administrative
+change restored before the snapshot remains inside the stated trust boundary.
+
 The resolver closes the dedicated workflow's transitive executable dependency
 graph. Each local action or reusable workflow is pinned by its activation Git
 object and joins every later byte-and-mode check. Each external action or
@@ -79,14 +88,21 @@ trusted; downloaded mutable executable content does not.
 
 The dedicated workflow has one terminal publisher job with job-level
 `contents: write`; validation jobs have no write permission. The publisher has
-no checkout, local action, container, package download, or repository command.
-It uses only the hosted runner's version-fingerprinted `gh`, `git`, and
-`ssh-keygen` clients and the pinned workflow's closed inline command. Its
+no checkout, local action, container, package download, or repository-supplied
+executable. It uses only the hosted runner's version-fingerprinted `gh`, `git`,
+and `ssh-keygen` clients and the pinned workflow's closed inline command. Its
 `needs` dependency names the exact post-merge validation job, so GitHub can
-start it only after that job succeeds for the sign-off integration `I`. The
-publisher alone receives the private half of the policy's dedicated signing
-key. Any other networked step, executable, key user, or publisher input fails
-closed.
+start it only after that job succeeds for the sign-off integration `I`. The job
+runs in the dedicated environment and receives its private-key secret there.
+Any other networked step, executable, key user, or publisher input fails closed.
+
+The successful validator emits one closed `needs` tuple containing `I`, the
+normalized sign-off `mergedAt`, policy and prefix hashes, prefix boundary, and
+the pinned support-tree, object-schema-blob, and public-key-blob OIDs. The
+publisher accepts no caller-provided substitute. Through `gh`, it fetches those
+exact Git objects by OID and verifies their identities and hashes. A branch
+name, moving path, environment value other than the private key, or unbound
+`workflow_dispatch` input fails closed.
 
 The publisher constructs one byte-deterministic annotated tag object `E`. The
 pinned object schema fixes its tagger identity, normalizes the tagger time to
@@ -134,8 +150,9 @@ are read from the exact `docs/tenkz/DESIGN.md` policy pinned by
 `policy_sha256`; this ledger schema does not duplicate them. Tag immutability
 and the release manifest, canonical-artifact, inventory, runner, and enforcement-workflow
 configuration are likewise read only from that pinned policy, as are the
-maintainer identity, signer identity scheme, and authorized reviewer permission
-set.
+maintainer identity, GitHub identity scheme, and authorized reviewer permission
+set. The GitHub identity scheme normalizes people and bots in repository
+evidence; it is unrelated to the final tag's cryptographic signing key.
 
 Once armed, the normative blocks in `docs/tenkz/DESIGN.md` and this file have
 closed tables and field sets. Unknown tables or fields are rejected. Changing
@@ -799,9 +816,10 @@ the ledger. Creating the protected name with the wrong kind or target is also a
 hard release incident. Weaker current protection, or a moved or replaced
 present tag, is likewise a hard release incident. An absent final-tag ref
 remains `signed-off-awaiting-tag` while no successful publisher job exists. A
-successful job with an absent ref is a hard incident because the job's required
-readback could not have succeeded. No incident is repaired by deleting, moving,
-or reusing the name, and none starts another 1.0 attempt.
+successful job with a later absent ref is a hard incident: the required
+readback succeeded, so the protected ref was subsequently deleted or hidden.
+No incident is repaired by deleting, moving, or reusing the name, and none
+starts another 1.0 attempt.
 
 No entry may be appended while `enforcement = "pending"`. The activation slice
 under #5352 will add validation commands only after their scripts,

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -123,14 +123,14 @@ name, moving path, caller-controlled variable or secret other than the private
 key, or unbound `workflow_dispatch` input fails closed. Trusted `GITHUB_*`
 runner metadata must agree with the closed tuple.
 
-The publisher constructs one byte-deterministic annotated tag object `E`. The
-pinned object schema fixes its tagger identity, the `+0000` timezone, and the
-tagger time from the tuple's `tagger_epoch_seconds`. It fixes every byte from
-the `object` header through the message, the Git SSH-signature embedding, and
-the repository object-format hash. The publisher signs the exact unsigned tag
-payload with SSH-Ed25519 under namespace `git`; the deterministic signature
-completes `E`. The message binds `tenkz-v1.0.0`, `I`, the armed policy hash, and
-the validated ledger prefix.
+On the absent-ref path, the publisher constructs one byte-deterministic
+annotated tag object `E`. The pinned object schema fixes its tagger identity,
+the `+0000` timezone, and the tagger time from the tuple's
+`tagger_epoch_seconds`. It fixes every byte from the `object` header through the
+message, the Git SSH-signature embedding, and the repository object-format
+hash. The publisher signs the exact unsigned tag payload with SSH-Ed25519 under
+namespace `git`; the deterministic signature completes `E`. The message binds
+`tenkz-v1.0.0`, `I`, the armed policy hash, and the validated ledger prefix.
 
 The publisher reads the final ref before and after every uncertain write. If it
 is absent, the job constructs `E`, verifies its raw signature against the pinned

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -106,12 +106,15 @@ key, or unbound `workflow_dispatch` input fails closed. Trusted `GITHUB_*`
 runner metadata must agree with the closed tuple.
 
 The publisher constructs one byte-deterministic annotated tag object `E`. The
-pinned object schema fixes its tagger identity, normalizes the tagger time to
-the sign-off pull request's exact `mergedAt`, and fixes the signed-message
-serialization. That message binds `tenkz-v1.0.0`, `I`, the armed policy hash,
-and the validated ledger prefix. `E` carries an SSH-Ed25519 signature under the
-public key in the pinned support tree. The validator checks the raw signature
-and payload itself; GitHub's displayed `verified` value is not a substitute.
+pinned object schema fixes its tagger identity, the `+0000` timezone, and the
+tagger time obtained from the sign-off pull request's exact `mergedAt`. It fixes
+every byte from the `object` header through the message, the Git SSH-signature
+embedding, and the repository object-format hash. The publisher signs the exact
+unsigned tag payload with SSH-Ed25519 under namespace `git`; the deterministic
+signature completes `E`. The message binds `tenkz-v1.0.0`, `I`, the armed policy
+hash, and the validated ledger prefix. The validator checks the raw signature
+and payload against the pinned public key; GitHub's displayed `verified` value
+is not a substitute.
 
 The publisher reads the final ref before and after every uncertain write. If it
 is absent, the job creates or re-creates content-addressed object `E`, creates
@@ -120,6 +123,13 @@ authenticates its exact bytes, signature, and peel to `I` and succeeds without
 another mutation. An absent ref remains retryable. Any present non-`E` object,
 bad signature, wrong payload, or wrong peel is a hard release incident. A
 successful publisher job records `E`'s OID after the final readback.
+
+When the final ref exists, the trusted evidence-collection phase resolves it,
+fetches that exact annotated object into an isolated Git object database, and
+resolves the ref again; a changed lookup fails closed. Network access is then
+removed. The validator reads the stored object bytes with the
+version-fingerprinted Git client, recomputes their OID, and verifies the payload
+and signature. Parsed REST fields alone are insufficient evidence.
 
 While validly armed, later changes preserve the pinned policy and prefix and
 append live entry blocks after the marker. A correction is an appended entry;
@@ -802,10 +812,12 @@ the ordered reset process above.
 Every validation, including one whose snapshot already contains the final tag,
 first replays the complete pinned policy, ledger, payload, Git, and GitHub
 evidence through the validated sign-off. A tag lookup may not short-circuit
-that replay. GitHub must report a successful publisher job in the pinned
-workflow run for `I`, ordered after its successful post-merge validation job.
-Its closed output names `E`'s OID and reports that the final readback either
-created or authenticated that same object. The current object named
+that replay. The resolver completely paginates workflow runs and jobs for `I`.
+It accepts any successful publisher job using the exact pinned workflow bytes
+and ordered after that run's successful post-merge validation job. Its closed
+output names `E`'s OID and reports that the final readback either created or
+authenticated that same object. Distinct successful OIDs fail closed. The
+current object named
 `tenkz-v1.0.0` must equal `E`, carry the valid raw signature and exact payload,
 and peel to `I` under the required current no-update, no-delete, no-bypass
 protection. Only that combined observation changes the campaign to terminal
@@ -819,6 +831,9 @@ present tag, is likewise a hard release incident. An absent final-tag ref
 remains `signed-off-awaiting-tag` while no successful publisher job exists. A
 successful job with a later absent ref is a hard incident: the required
 readback succeeded, so the protected ref was subsequently deleted or hidden.
+If history rewriting makes `I` unreachable from current `main`, the ordinary
+replay fails; once the final ref exists, that failure is likewise a hard
+incident.
 No incident is repaired by deleting, moving, or reusing the name, and none
 starts another 1.0 attempt.
 

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -65,13 +65,24 @@ evidence-supervisor result. A missing, renamed, non-blob, or changed workflow
 fails closed.
 
 Activation also derives and pins the complete Git tree at the policy's
-`release_publisher_workflow_root`. Every later validation requires that exact
-tree. It completely enumerates its workflow jobs and requires the terminal
-publisher to be the sole job naming `release_publisher_environment` or
-`release_publisher_secret`. The current environment configuration must restrict
-deployment to the protected release branch. Missing, wider, changed, or
-incompletely paginated configuration fails closed. A transient administrative
-change restored before the snapshot remains inside the stated trust boundary.
+`release_publisher_workflow_root`. Until a validation declares `released`, the
+current tree must equal that pin. The resolver completely enumerates its
+workflow jobs and requires the terminal publisher to be the sole job naming
+`release_publisher_environment` or `release_publisher_secret`. Workflow-level
+secret inheritance is forbidden. The current environment configuration must restrict
+deployment to the protected release branch. The private key must exist only as
+that environment secret. The resolver exhaustively checks repository and
+organization secret names and access, and rejects any same-named secret that
+can reach the repository. Missing, wider, changed, shadowed, or incompletely
+paginated configuration fails closed.
+
+After a successful publisher job, an administrator removes the environment
+secret. The validation that declares `released` requires its absence, and every
+later replay rejects its reintroduction. Released replay resolves the successful
+job's historical workflow tree at `I` and requires that tree to equal the
+activation pin; unrelated current workflows need not retain those old bytes
+after the key is gone. A transient administrative change restored before a
+snapshot remains inside the stated trust boundary.
 
 The resolver closes the dedicated workflow's transitive executable dependency
 graph. Each local action or reusable workflow is pinned by its activation Git
@@ -90,14 +101,19 @@ The dedicated workflow has one terminal publisher job with job-level
 `contents: write`; validation jobs have no write permission. The publisher has
 no checkout, local action, container, package download, or repository-supplied
 executable. It uses only the hosted runner's version-fingerprinted `gh`, `git`,
-and `ssh-keygen` clients and the pinned workflow's closed inline command. Its
-`needs` dependency names the exact post-merge validation job, so GitHub can
+and `ssh-keygen` clients through the pinned workflow's closed inline command.
+It has no `uses` step, called workflow, composite action, or inherited secret.
+Its `needs` dependency names the exact post-merge validation job, so GitHub can
 start it only after that job succeeds for the sign-off integration `I`. The job
-runs in the dedicated environment and receives its private-key secret there.
-Any other networked step, executable, key user, or publisher input fails closed.
+runs in the dedicated environment; only the absent-ref construction path reads
+the private-key secret. Any other networked step, executable, key user, or
+publisher input fails closed.
 
-The successful validator emits one closed `needs` tuple containing `I`, the
-normalized sign-off `mergedAt`, policy and prefix hashes, prefix boundary, and
+The successful validator requires the sign-off pull request's exact `mergedAt`
+to be an unambiguous UTC instant with integral seconds. It converts that instant
+once to an integer Unix second; a fractional, non-UTC, ambiguous, or out-of-range
+value fails closed. Its closed `needs` tuple contains `I`, that
+`tagger_epoch_seconds` integer, policy and prefix hashes, prefix boundary, and
 the pinned support-tree, object-schema-blob, and public-key-blob OIDs. The
 publisher accepts no caller-provided substitute. Through `gh`, it fetches those
 exact Git objects by OID and verifies their identities and hashes. A branch
@@ -107,29 +123,34 @@ runner metadata must agree with the closed tuple.
 
 The publisher constructs one byte-deterministic annotated tag object `E`. The
 pinned object schema fixes its tagger identity, the `+0000` timezone, and the
-tagger time obtained from the sign-off pull request's exact `mergedAt`. It fixes
-every byte from the `object` header through the message, the Git SSH-signature
-embedding, and the repository object-format hash. The publisher signs the exact
-unsigned tag payload with SSH-Ed25519 under namespace `git`; the deterministic
-signature completes `E`. The message binds `tenkz-v1.0.0`, `I`, the armed policy
-hash, and the validated ledger prefix. The validator checks the raw signature
-and payload against the pinned public key; GitHub's displayed `verified` value
-is not a substitute.
+tagger time from the tuple's `tagger_epoch_seconds`. It fixes every byte from
+the `object` header through the message, the Git SSH-signature embedding, and
+the repository object-format hash. The publisher signs the exact unsigned tag
+payload with SSH-Ed25519 under namespace `git`; the deterministic signature
+completes `E`. The message binds `tenkz-v1.0.0`, `I`, the armed policy hash, and
+the validated ledger prefix.
 
 The publisher reads the final ref before and after every uncertain write. If it
-is absent, the job creates or re-creates content-addressed object `E`, creates
-the ref without force, and reads it back. If the ref already names `E`, the job
-authenticates its exact bytes, signature, and peel to `I` and succeeds without
-another mutation. An absent ref remains retryable. Any present non-`E` object,
-bad signature, wrong payload, or wrong peel is a hard release incident. A
-successful publisher job records `E`'s OID after the final readback.
+is absent, the job constructs `E`, verifies its raw signature against the pinned
+public key, checks every schema byte and its peel to `I`, and recomputes its
+object ID before the first mutation. It then writes that already-verified object,
+creates the ref without force, and reads it back. If the ref already names `E`,
+the job repeats the same raw authentication and succeeds without another
+mutation or private-key read. An absent ref remains retryable. Any present
+non-`E` object, bad signature, wrong payload, or wrong peel is a hard release
+incident. The job exits successfully only after the final readback authenticates
+`E`. It emits no durable output receipt; GitHub's API-visible successful job
+conclusion and the independently fetched current object are the evidence.
 
 When the final ref exists, the trusted evidence-collection phase resolves it,
 fetches that exact annotated object into an isolated Git object database, and
 resolves the ref again; a changed lookup fails closed. Network access is then
 removed. The validator reads the stored object bytes with the
 version-fingerprinted Git client, recomputes their OID, and verifies the payload
-and signature. Parsed REST fields alone are insufficient evidence.
+and raw signature against the pinned public key. GitHub's displayed `verified`
+value and parsed REST fields are insufficient evidence. This collection occurs
+in a validation run after the publisher run that first created or adopted the
+object.
 
 While validly armed, later changes preserve the pinned policy and prefix and
 append live entry blocks after the marker. A correction is an appended entry;
@@ -802,27 +823,38 @@ targeting the sign-off. Neither case is a validated sign-off. After post-merge
 validation succeeds, the campaign is `signed-off-awaiting-tag`. The pinned
 workflow's dependent publisher job may create the exact authenticated object
 `E` and the `tenkz-v1.0.0` ref on `I`. An absent ref leaves the campaign awaiting
-that job or a full-workflow retry. If `E` is present but the job stopped before
-recording success, the campaign is `signed-off-awaiting-publisher-receipt`; a
-retry authenticates and adopts `E`. A different present object or failed
-authentication is a hard release incident, not a release. All mutable external
-facts remain subject to revalidation, and drift while the ref is absent requires
-the ordered reset process above.
+that job or a full-workflow retry. If `E` is present but no publisher job has
+completed successfully, the campaign is
+`signed-off-awaiting-publisher-success`; a retry authenticates and adopts `E`
+without reading the private key. After a successful job, the campaign is
+`signed-off-awaiting-key-retirement` until an administrator removes the
+environment secret. These names replace the provisional receipt state; there
+is no compatibility alias. A different present object or failed authentication
+is a hard release incident, not a release. All mutable external facts remain
+subject to revalidation, and drift while the ref is absent requires the ordered
+reset process above.
 
 Every validation, including one whose snapshot already contains the final tag,
 first replays the complete pinned policy, ledger, payload, Git, and GitHub
 evidence through the validated sign-off. A tag lookup may not short-circuit
 that replay. The resolver completely paginates workflow runs and jobs for `I`.
-It accepts any successful publisher job using the exact pinned workflow bytes
-and ordered after that run's successful post-merge validation job. Its closed
-output names `E`'s OID and reports that the final readback either created or
-authenticated that same object. Distinct successful OIDs fail closed. The
-current object named
-`tenkz-v1.0.0` must equal `E`, carry the valid raw signature and exact payload,
-and peel to `I` under the required current no-update, no-delete, no-bypass
-protection. Only that combined observation changes the campaign to terminal
-`released` state. No later ledger entry or new sign-off is valid. Every later
-validation still replays every current mutable fact. A
+It accepts any successful publisher job whose head is `I`, whose historical
+workflow tree equals the activation pin, and which follows that run's successful
+post-merge validation job. The resolver does not read job outputs: by contract,
+that exact job can succeed only after authenticating the final readback of `E`.
+Several successful retries are harmless because each ran the same pinned bytes
+against the same deterministic object.
+
+The current object named `tenkz-v1.0.0` must equal `E`, carry the valid raw
+signature and exact payload, and peel to `I` under the required current
+no-update, no-delete, no-bypass protection. The environment key and any
+same-named repository or organization secret must be absent. Only a validation
+that observes this complete conjunction changes the campaign to terminal
+`released` state; the publisher job never declares release itself. No later
+ledger entry or new sign-off is valid. Released replay continues to check the
+historical publisher tree, but unrelated current workflows may change after the
+key is retired. Every later validation still replays every current mutable fact.
+A
 mismatch that requires the ordered reset process while the final-tag ref is
 absent becomes a hard release incident once that ref exists; it never reopens
 the ledger. Creating the protected name with the wrong kind or target is also a


### PR DESCRIPTION
## Summary

- Define one byte-deterministic SSH-Ed25519 annotated tag object `E`.
- Pass one canonical `tagger_epoch_seconds` scalar and pinned support-object OIDs.
- Verify `E` completely before the first ref write and authenticate it on every retry.
- Keep the signing key environment-only, reject shadows in every repository
  environment and at repository or organization scope, and retire the key before
  terminal release.
- Derive publication from an exact successful job plus independently authenticated
  current `E`; do not rely on inaccessible job outputs.
- Verify the historical pinned publisher workflow after release, so unrelated current
  workflows may evolve once the key is gone.
- Replace the provisional receipt state with awaiting-publisher-success and
  awaiting-key-retirement states, without aliases.
- Require clean pre-1.0 replacement: no compatibility readers, dual writers, or
  temporary bridges.

## Why

PR LionSR/TNLean#5373 left an irrecoverable window if GitHub created the final ref and the runner
stopped before a successful job conclusion. A retry can now adopt only the exact
authenticated object authorized by the sign-off. Exact review also found that job
outputs are not available through the workflow-run API, that a permanent complete
workflow-tree pin would freeze unrelated CI, and that a shadow secret or wrong private
key could bypass the intended failure boundary. This revision closes those gaps at the
shared contract.

## Scope

Documentation-only correction to the pending LionSR/tenkz#128 contract. The key, object schema,
state implementation, and workflow still belong to later enforcement slices; nothing is
armed here.

## Validation

- Both normative TOML blocks parse with `tomllib`.
- All edited lines are at most 100 characters.
- Reader-facing prose, language tests, shrink gate, and `git diff --check` pass.
- Exact head: `0c3eb785edcd8b4f85c35ee1717f7dc427fab8ee`.

Follow-up to LionSR/TNLean#5373. Refs LionSR/tenkz#128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Normative documentation for not-yet-armed enforcement; no executable release or auth code changes in this diff.
> 
> **Overview**
> **Documentation-only** revision to the pending LionSR/tenkz#128 tenkz 1.0 release contract in `DESIGN.md`, `SOAK-1.0.md`, and `HACKING.md`—no checker, workflow, or keys are armed in this PR.
> 
> The final `tenkz-v1.0.0` tag is now defined as one **byte-deterministic SSH-Ed25519 annotated object `E`**, with `tagger_epoch_seconds` derived from the sign-off PR’s UTC `mergedAt` and support paths pinned in policy. The publisher **reads the ref first**: on absence it builds and fully verifies `E` before any write; on retry it **authenticates the same `E`** without the private key. Publication evidence is the **successful pinned publisher job** plus independently verified current `E`—**not** inaccessible workflow job outputs.
> 
> **Key isolation** expands to pin the whole `release_publisher_workflow_root` tree until `released`, forbid `secrets: inherit` and **shadow secrets** at repo/org scope, and require **environment key removal** before terminal release; post-release replay checks the **historical** publisher workflow tree only.
> 
> Campaign states add **`signed-off-awaiting-publisher-success`** and **`signed-off-awaiting-key-retirement`** (no receipt/alias); only a later validation may enter **`released`**. `HACKING.md` tightens **pre-1.0** rules: no compatibility readers, dual writers, or temporary bridges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3eb785edcd8b4f85c35ee1717f7dc427fab8ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->