### PR TITLE
fix(MPDO/RFP): audit the simple blocking normalization boundary

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.MPS.MPDO
 
+import TNLean.MPS.MPDO.ActiveSectorBlockingBoundary
 import TNLean.MPS.MPDO.ActiveSectorInverseMapProvenance
 import TNLean.MPS.MPDO.ActiveSectorSpanningAreaLaw
 import TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample

--- a/TNLean/MPS/MPDO/ActiveSectorBlockingBoundary.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorBlockingBoundary.lean
@@ -1,0 +1,494 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.FundamentalTheorem.SectorBNT.SingleSector
+import TNLean.MPS.MPDO.ActiveSectorSpanningAreaLaw
+import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.BiCFDerivation.Core
+import TNLean.MPS.MPDO.NormalizedMPOProportionality
+import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPDO.SimpleTensor
+import TNLean.MPS.SharedInfra.Scaling
+
+/-!
+# The four-sector tensor at the blocking-channel boundary
+
+This file puts the four-sector tensor of
+`ActiveSectorSpanningCounterexample` in the scalar normalization required by
+the horizontal canonical form of arXiv:1606.00608.  The normalized tensor
+still has strong area law and source zero correlation length, but its
+two-site block cannot be a renormalization fixed point in the sense of
+Definition 4.1: its physical-trace transfer is a nonunit scalar multiple of
+an idempotent.
+
+## Reference
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.9 and Appendix C.2, lines 1484--1499 and 1810--1825
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.ActiveSectorSpanningCounterexample
+
+/-- The positive scalar which normalizes the horizontal transfer radius of
+the four-sector tensor to one.
+
+This implements the horizontal canonical normalization required in
+arXiv:1606.00608, Definition 2.4 and Theorem 4.9, lines 217--226 and
+849--856. -/
+def canonicalScale : ℝ := 4 / Real.sqrt 5
+
+/-- The horizontally normalized representative of the four-sector tensor.
+
+Source boundary: arXiv:1606.00608, Theorem 4.9, lines 849--856. -/
+def canonicalTensor : MPOTensor 4 2 :=
+  (canonicalScale : ℂ) • tensor
+
+lemma canonicalScale_pos : 0 < canonicalScale := by
+  unfold canonicalScale
+  positivity
+
+lemma canonicalScale_ne_zero : (canonicalScale : ℂ) ≠ 0 := by
+  exact_mod_cast canonicalScale_pos.ne'
+
+lemma canonicalScale_sq : canonicalScale ^ 2 = 16 / 5 := by
+  rw [canonicalScale, div_pow, Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 5)]
+  norm_num
+
+lemma coe_canonicalScale_sq : (canonicalScale : ℂ) ^ 2 = 16 / 5 := by
+  rw [← Complex.ofReal_pow, canonicalScale_sq, Complex.ofReal_div]
+  norm_num
+
+@[simp] lemma star_canonicalScale :
+    star (canonicalScale : ℂ) = (canonicalScale : ℂ) :=
+  Complex.conj_ofReal canonicalScale
+
+/-- The diagonal bond gauge which puts the canonical representative in
+left-canonical form.
+
+The gauge realizes the canonical-form normalization of arXiv:1606.00608,
+Definition 2.4, lines 217--226, for this explicit tensor. -/
+def canonicalGaugeMatrix : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![8, 0; 0, 1]
+
+private lemma canonicalGaugeMatrix_det_ne_zero : canonicalGaugeMatrix.det ≠ 0 := by
+  norm_num [canonicalGaugeMatrix, Matrix.det_fin_two]
+
+/-- The canonical gauge as an invertible matrix.
+
+Source boundary: arXiv:1606.00608, Definition 2.4, lines 217--226. -/
+def canonicalGauge : GL (Fin 2) ℂ :=
+  Matrix.GeneralLinearGroup.mkOfDetNeZero canonicalGaugeMatrix
+    canonicalGaugeMatrix_det_ne_zero
+
+@[simp] lemma canonicalGauge_val :
+    (canonicalGauge : Matrix (Fin 2) (Fin 2) ℂ) = canonicalGaugeMatrix :=
+  Matrix.GeneralLinearGroup.val_mkOfDetNeZero _ _
+
+@[simp] lemma canonicalGauge_inv_val :
+    ((canonicalGauge⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) =
+      !![1 / 8, 0; 0, 1] := by
+  have h : canonicalGauge * Matrix.GeneralLinearGroup.mkOfDetNeZero
+      (!![1 / 8, 0; 0, 1] : Matrix (Fin 2) (Fin 2) ℂ)
+      (by norm_num [Matrix.det_fin_two]) = 1 := by
+    apply Units.ext
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      norm_num [canonicalGaugeMatrix, Matrix.mul_apply, Fin.sum_univ_two]
+  rw [show canonicalGauge⁻¹ = Matrix.GeneralLinearGroup.mkOfDetNeZero
+      (!![1 / 8, 0; 0, 1] : Matrix (Fin 2) (Fin 2) ℂ)
+      (by norm_num [Matrix.det_fin_two]) from inv_eq_of_mul_eq_one_right h]
+  exact Matrix.GeneralLinearGroup.val_mkOfDetNeZero _ _
+
+/-- The gauge-equivalent left-canonical normal block used in the one-sector
+BNT presentation.
+
+Source boundary: arXiv:1606.00608, Definition 2.4 and the BNT decomposition,
+lines 217--301. -/
+def canonicalBlock : MPSTensor (4 * 4) 2 :=
+  fun i ↦
+    (canonicalGauge : Matrix (Fin 2) (Fin 2) ℂ) *
+      canonicalTensor.toMPSTensor i *
+        ((canonicalGauge⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ)
+
+lemma canonicalTensor_toMPSTensor_pair (i j : Fin 4) :
+    canonicalTensor.toMPSTensor (finProdFinEquiv (i, j)) =
+      if i = j then (canonicalScale : ℂ) • sectorMatrix i else 0 := by
+  unfold MPOTensor.toMPSTensor
+  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+  simp [canonicalTensor, tensor]
+
+/-- The four nonzero physical slices after the canonical bond gauge, before
+the common scalar normalization.
+
+These are the explicit slices used to test the canonical-form hypotheses of
+arXiv:1606.00608, Theorem 4.9, lines 849--856. -/
+def canonicalSectorMatrix : Fin 4 → Matrix (Fin 2) (Fin 2) ℂ := ![
+  !![1 / 4, 1 / 4; 1 / 8, 1 / 8],
+  !![1 / 4, 1 / 4; -1 / 8, -1 / 8],
+  !![1 / 4, -1 / 4; 1 / 8, -1 / 8],
+  !![1 / 4, -1 / 4; -1 / 8, 1 / 8]]
+
+private def sectorMatrixInCoordinates : Fin 4 → Matrix (Fin 2) (Fin 2) ℂ := ![
+  !![1 / 4, 1 / 32; 1, 1 / 8],
+  !![1 / 4, 1 / 32; -1, -1 / 8],
+  !![1 / 4, -1 / 32; 1, -1 / 8],
+  !![1 / 4, -1 / 32; -1, 1 / 8]]
+
+private lemma sectorMatrix_eq_inCoordinates (i : Fin 4) :
+    sectorMatrix i = sectorMatrixInCoordinates i := by
+  ext x y
+  fin_cases i <;> fin_cases x <;> fin_cases y <;>
+    norm_num [sectorMatrixInCoordinates, sectorMatrix, leftPairing, rightPairing]
+
+lemma canonicalBlock_pair (i j : Fin 4) :
+    canonicalBlock (finProdFinEquiv (i, j)) =
+      if i = j then (canonicalScale : ℂ) • canonicalSectorMatrix i else 0 := by
+  simp only [canonicalBlock, canonicalGauge_val, canonicalGauge_inv_val,
+    canonicalTensor_toMPSTensor_pair]
+  by_cases hij : i = j
+  · subst j
+    rw [if_pos rfl, Matrix.mul_smul, Matrix.smul_mul]
+    rw [sectorMatrix_eq_inCoordinates]
+    ext x y
+    fin_cases i <;> fin_cases x <;> fin_cases y <;>
+      norm_num [canonicalSectorMatrix, sectorMatrixInCoordinates,
+        canonicalGaugeMatrix, Matrix.mul_apply, Fin.sum_univ_two]
+  · rw [if_neg hij, if_neg hij, Matrix.mul_zero, Matrix.zero_mul]
+
+/-- The literal CPSV canonical representative obtained by separating the
+doubled physical index of the left-canonical normal block.
+
+Source boundary: arXiv:1606.00608, BNT canonical form, lines 217--301, and
+Theorem 4.9, lines 849--856. -/
+def canonicalRepresentative : MPOTensor 4 2 :=
+  verticalBNTMPO canonicalBlock
+
+@[simp] lemma canonicalRepresentative_toMPSTensor :
+    canonicalRepresentative.toMPSTensor = canonicalBlock :=
+  verticalBNTMPO_toMPSTensor canonicalBlock
+
+lemma canonicalTensor_gaugeEquiv_canonicalBlock :
+    MPSTensor.GaugeEquiv canonicalTensor.toMPSTensor canonicalBlock :=
+  ⟨canonicalGauge, fun _ ↦ rfl⟩
+
+/-- The explicit bond gauge satisfies the left-canonical normalization of
+arXiv:1606.00608, Definition 2.4, lines 217--226. -/
+lemma canonicalBlock_isLeftCanonical :
+    MPSTensor.IsLeftCanonical canonicalBlock := by
+  unfold MPSTensor.IsLeftCanonical
+  rw [← finProdFinEquiv.sum_comp, Fintype.sum_prod_type]
+  simp_rw [canonicalBlock_pair]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [canonicalSectorMatrix, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Fin.sum_univ_four, Fin.sum_univ_two] <;>
+    norm_num [starRingEnd_apply] <;>
+    ring_nf <;>
+    norm_num [coe_canonicalScale_sq]
+
+lemma canonicalTensor_isInjective : canonicalTensor.IsInjective := by
+  change MPSTensor.IsInjective
+    (fun i ↦ (canonicalScale : ℂ) • tensor.toMPSTensor i)
+  exact tensor_isInjective.smul canonicalScale_ne_zero
+
+lemma canonicalBlock_isInjective : canonicalBlock.IsInjective :=
+  MPSTensor.isInjective_of_gaugeEquiv canonicalTensor_isInjective
+    canonicalTensor_gaugeEquiv_canonicalBlock
+
+lemma canonicalBlock_isNormalTensor :
+    MPSTensor.IsNormalTensor canonicalBlock :=
+  MPSTensor.isNormalTensor_of_isNormal_leftCanonical canonicalBlock
+    canonicalBlock_isInjective.isNormal canonicalBlock_isLeftCanonical
+
+/-- The one-block decomposition satisfies the BNT hypotheses of
+arXiv:1606.00608, Section 2.3, lines 217--301. -/
+lemma canonicalBlock_isBNTCanonicalForm :
+    MPSTensor.IsBNTCanonicalForm
+      (MPSTensor.singleSectorDecomposition canonicalBlock) := by
+  apply MPSTensor.isBNTCanonicalForm_singleSectorDecomposition
+    canonicalBlock_isNormalTensor.no_invariant_proj
+    canonicalBlock_isLeftCanonical
+  exact MPSTensor.overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+    canonicalBlock canonicalBlock_isNormalTensor.no_invariant_proj
+      canonicalBlock_isLeftCanonical canonicalBlock_isNormalTensor.primitive_transfer
+
+/-- The literal representative is in the canonical form assumed by
+arXiv:1606.00608, Theorem 4.9, lines 849--856. -/
+lemma canonicalRepresentative_isCPSVCanonicalForm :
+    MPSTensor.IsCPSVCanonicalForm canonicalRepresentative.toMPSTensor := by
+  rw [canonicalRepresentative_toMPSTensor,
+    ← MPSTensor.toTensorFromBlocks_fin_one canonicalBlock]
+  exact (MPSTensor.CPSVCanonicalFormData.ofBlocks
+    (fun _ : Fin 1 ↦ by simp) (fun _ : Fin 1 ↦ (1 : ℂ))
+      (fun _ : Fin 1 ↦ canonicalBlock)
+      (fun _ ↦ canonicalBlock_isNormalTensor)).isCPSVCanonicalForm
+
+/-- The single normal block is block-injective already at word length one,
+meeting the biCF hypothesis used in arXiv:1606.00608, Appendix C.2,
+lines 1628--1658. -/
+lemma canonicalBlock_hasBiCF :
+    MPSTensor.HasBiCF (fun _ : Fin 1 ↦ canonicalBlock) :=
+  canonicalBlock_isInjective.hasBiCF_fin_one
+
+lemma canonicalBlock_singleSector_hasBiCF :
+    MPSTensor.HasBiCF
+      (MPSTensor.singleSectorDecomposition canonicalBlock).basis := by
+  simpa [MPSTensor.singleSectorDecomposition] using canonicalBlock_hasBiCF
+
+lemma mpo_canonicalTensor (N : ℕ) :
+    mpo canonicalTensor N = ((canonicalScale : ℂ) ^ N) • mpo tensor N := by
+  ext σ τ
+  simp only [Matrix.smul_apply, smul_eq_mul]
+  rw [← MPSTensor.mpv_toMPSTensor_pairConfig,
+    ← MPSTensor.mpv_toMPSTensor_pairConfig]
+  change MPSTensor.mpv
+    (fun i ↦ (canonicalScale : ℂ) • tensor.toMPSTensor i)
+      (fun n ↦ finProdFinEquiv (σ n, τ n)) =
+    (canonicalScale : ℂ) ^ N *
+      MPSTensor.mpv tensor.toMPSTensor
+        (fun n ↦ finProdFinEquiv (σ n, τ n))
+  rw [MPSTensor.mpv_smul]
+
+lemma mpo_canonicalRepresentative (N : ℕ) :
+    mpo canonicalRepresentative N = mpo canonicalTensor N := by
+  ext σ τ
+  rw [← MPSTensor.mpv_toMPSTensor_pairConfig,
+    ← MPSTensor.mpv_toMPSTensor_pairConfig,
+    canonicalRepresentative_toMPSTensor]
+  exact (canonicalTensor_gaugeEquiv_canonicalBlock.sameMPV N _).symm
+
+/-- The normalized tensor generates positive operators, as required in
+arXiv:1606.00608, Theorem 4.9, lines 849--856. -/
+lemma canonicalTensor_isMPDO : IsMPDO canonicalTensor := by
+  intro N hN
+  rw [mpo_canonicalTensor]
+  apply (Classical.choose tensor_isSAL N hN).smul
+  exact_mod_cast pow_nonneg canonicalScale_pos.le N
+
+/-- The literal canonical representative generates the same positive operator
+family and hence satisfies the MPDO hypothesis of arXiv:1606.00608,
+Theorem 4.9, lines 849--856. -/
+lemma canonicalRepresentative_isMPDO : IsMPDO canonicalRepresentative := by
+  intro N hN
+  rw [mpo_canonicalRepresentative]
+  exact canonicalTensor_isMPDO N hN
+
+lemma normalizedMPO_canonicalTensor (N : ℕ) :
+    normalizedMPO canonicalTensor N = normalizedMPO tensor N := by
+  apply normalizedMPO_eq_of_nonzeroProportionalMPV₂_at
+  refine ⟨(canonicalScale : ℂ) ^ N, pow_ne_zero N canonicalScale_ne_zero, ?_⟩
+  intro ρ
+  change MPSTensor.mpv (fun i ↦ (canonicalScale : ℂ) • tensor.toMPSTensor i) ρ = _
+  rw [MPSTensor.mpv_smul]
+
+lemma normalizedMPO_canonicalRepresentative (N : ℕ) :
+    normalizedMPO canonicalRepresentative N = normalizedMPO tensor N := by
+  rw [normalizedMPO, mpo_canonicalRepresentative,
+    ← normalizedMPO, normalizedMPO_canonicalTensor]
+
+/-- Scalar normalization preserves the strong area law appearing in
+arXiv:1606.00608, Theorem 4.9(ii), lines 851--856. -/
+lemma canonicalTensor_isSAL : IsSAL canonicalTensor := by
+  rcases tensor_isSAL with ⟨_, hTrace, hStep⟩
+  refine ⟨canonicalTensor_isMPDO, ?_, ?_⟩
+  · intro N hN
+    rw [mpo_canonicalTensor, Matrix.trace_smul]
+    exact mul_ne_zero (pow_ne_zero N canonicalScale_ne_zero) (hTrace N hN)
+  · intro N L hL hLN
+    simpa only [mutualInfoChain, blockEntropy, reducedBlockState,
+      normalizedMPO_canonicalTensor] using hStep N L hL hLN
+
+/-- Gauge transport preserves the strong area law of
+arXiv:1606.00608, Theorem 4.9(ii), lines 851--856. -/
+lemma canonicalRepresentative_isSAL : IsSAL canonicalRepresentative := by
+  rcases canonicalTensor_isSAL with ⟨_, hTrace, hStep⟩
+  refine ⟨canonicalRepresentative_isMPDO, ?_, ?_⟩
+  · intro N hN
+    rw [mpo_canonicalRepresentative]
+    exact hTrace N hN
+  · intro N L hL hLN
+    simpa only [mutualInfoChain, blockEntropy, reducedBlockState,
+      normalizedMPO_canonicalRepresentative, normalizedMPO_canonicalTensor] using
+        hStep N L hL hLN
+
+/-- The physical-trace transfer of the canonical representative is the same
+rank-one projection as for `tensor`, multiplied by the canonical scalar. -/
+lemma physTraceTransfer_canonicalTensor :
+    physTraceTransfer canonicalTensor =
+      (canonicalScale : ℂ) • !![1, 0; 0, 0] := by
+  rw [canonicalTensor]
+  change ∑ i : Fin 4, (canonicalScale : ℂ) • tensor i i = _
+  rw [← Finset.smul_sum, ← physTraceTransfer]
+  rw [physTraceTransfer_tensor, leftPairing_mul_rightPairing]
+
+/-- The normalized tensor satisfies the scale-invariant zero-correlation
+condition of arXiv:1606.00608, Theorem 4.9(ii), lines 851--856. -/
+lemma canonicalTensor_isSourceZCL : IsSourceZCL canonicalTensor := by
+  refine ⟨?_, canonicalScale, canonicalScale_pos, ?_⟩
+  · rw [physTraceTransfer_canonicalTensor]
+    intro hzero
+    have h00 := congrFun (congrFun hzero (0 : Fin 2)) (0 : Fin 2)
+    simp at h00
+    exact canonicalScale_pos.ne' h00
+  · rw [physTraceTransfer_canonicalTensor,
+      smul_mul_smul_comm]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp
+
+lemma physTraceTransfer_canonicalRepresentative :
+    physTraceTransfer canonicalRepresentative =
+      (canonicalScale : ℂ) • !![1, 0; 0, 0] := by
+  rw [physTraceTransfer]
+  simp only [canonicalRepresentative, verticalBNTMPO_apply]
+  simp_rw [canonicalBlock_pair]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [canonicalSectorMatrix, Fin.sum_univ_four] <;> ring
+
+/-- The literal canonical representative satisfies the source ZCL condition
+of arXiv:1606.00608, Theorem 4.9(ii), lines 851--856. -/
+lemma canonicalRepresentative_isSourceZCL :
+    IsSourceZCL canonicalRepresentative := by
+  refine ⟨?_, canonicalScale, canonicalScale_pos, ?_⟩
+  · rw [physTraceTransfer_canonicalRepresentative]
+    intro hzero
+    have h00 := congrFun (congrFun hzero (0 : Fin 2)) (0 : Fin 2)
+    simp at h00
+    exact canonicalScale_pos.ne' h00
+  · rw [physTraceTransfer_canonicalRepresentative,
+      smul_mul_smul_comm]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp
+
+lemma doubledPhysTraceTransfer_canonicalBlock :
+    doubledPhysTraceTransfer 4 canonicalBlock =
+      (canonicalScale : ℂ) • !![1, 0; 0, 0] := by
+  rw [doubledPhysTraceTransfer]
+  simp_rw [canonicalBlock_pair]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [canonicalSectorMatrix, Fin.sum_univ_four] <;> ring
+
+lemma doubledPhysTraceTransfer_canonicalBlock_not_isNilpotent :
+    ¬ IsNilpotent (doubledPhysTraceTransfer 4 canonicalBlock) := by
+  intro hnil
+  have htrace := (Matrix.isNilpotent_trace_of_isNilpotent hnil).eq_zero
+  rw [doubledPhysTraceTransfer_canonicalBlock] at htrace
+  simp [Matrix.trace, Fin.sum_univ_two] at htrace
+  exact canonicalScale_pos.ne' htrace
+
+/-- The canonical representative is simple in the one-sector BNT canonical
+form used in the standing hypotheses of arXiv:1606.00608, Theorem 4.9,
+lines 815--856. -/
+lemma canonicalRepresentative_isSimpleCanonicalForm :
+    IsSimpleCanonicalForm canonicalRepresentative := by
+  let S := MPSTensor.singleSectorDecomposition canonicalBlock
+  refine ⟨canonicalRepresentative_isMPDO, S,
+    canonicalBlock_isBNTCanonicalForm, ?_, ?_⟩
+  · intro j
+    fin_cases j
+    simpa [S, MPSTensor.singleSectorDecomposition] using
+      doubledPhysTraceTransfer_canonicalBlock_not_isNilpotent
+  · have hTotal : S.totalDim = 2 := by
+      rfl
+    refine ⟨hTotal, fun _ ↦ 1, ?_⟩
+    intro i
+    rw [canonicalRepresentative_toMPSTensor]
+    have hGaugeOne :
+        MPSTensor.globalGaugeOfBlocks (dim := S.flatDim) (fun _ ↦ 1) = 1 := by
+      exact MPSTensor.globalGaugeOfBlocks_one
+    rw [hGaugeOne]
+    simp only [Units.val_one, inv_one, one_mul, mul_one]
+    change canonicalBlock i = S.toTensor i
+    change canonicalBlock i = MPSTensor.toTensorFromBlocks
+      (fun _ : Fin 1 ↦ (1 : ℂ)) (fun _ : Fin 1 ↦ canonicalBlock) i
+    exact congrFun (MPSTensor.toTensorFromBlocks_fin_one canonicalBlock) i |>.symm
+
+/-- Blocking two sites squares the canonical scalar and leaves the idempotent
+physical-trace transfer of the unscaled tensor unchanged. -/
+lemma physTraceTransfer_blockTwo_canonicalTensor :
+    physTraceTransfer (blockTwo canonicalTensor) =
+      ((canonicalScale : ℂ) ^ 2) • !![1, 0; 0, 0] := by
+  rw [physTraceTransfer_blockTwo, physTraceTransfer_canonicalTensor,
+    smul_mul_smul_comm]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pow_two]
+
+/-- The two-site block of the horizontally normalized four-sector tensor is
+not a renormalization fixed point via the trace-preserving completely positive
+maps of Definition 4.1.
+
+The obstruction is normalization-sensitive and does not use the invalid
+rank-one inference of Lemma C.5: trace preservation would make the blocked
+physical-trace transfer idempotent, whereas its nonzero eigenvalue is
+`canonicalScale ^ 2 = 16 / 5`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Theorem 4.9,
+direction (ii) implies (v), lines 851--893. -/
+theorem blockTwo_canonicalTensor_not_isRFPViaTS :
+    ¬ IsRFPViaTS (blockTwo canonicalTensor) := by
+  intro hRFP
+  have hidem := physTraceTransfer_sq_of_isRFPViaTS _ hRFP
+  rw [physTraceTransfer_blockTwo_canonicalTensor] at hidem
+  have h00 := congrFun (congrFun hidem (0 : Fin 2)) (0 : Fin 2)
+  norm_num [coe_canonicalScale_sq, Matrix.mul_apply, Fin.sum_univ_two] at h00
+
+lemma physTraceTransfer_blockTwo_canonicalRepresentative :
+    physTraceTransfer (blockTwo canonicalRepresentative) =
+      ((canonicalScale : ℂ) ^ 2) • !![1, 0; 0, 0] := by
+  rw [physTraceTransfer_blockTwo, physTraceTransfer_canonicalRepresentative,
+    smul_mul_smul_comm]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [pow_two]
+
+/-- The two-site block of the literal CPSV canonical representative is not a
+renormalization fixed point via the trace-preserving completely positive maps
+of Definition 4.1. -/
+theorem blockTwo_canonicalRepresentative_not_isRFPViaTS :
+    ¬ IsRFPViaTS (blockTwo canonicalRepresentative) := by
+  intro hRFP
+  have hidem := physTraceTransfer_sq_of_isRFPViaTS _ hRFP
+  rw [physTraceTransfer_blockTwo_canonicalRepresentative] at hidem
+  have h00 := congrFun (congrFun hidem (0 : Fin 2)) (0 : Fin 2)
+  norm_num [coe_canonicalScale_sq, Matrix.mul_apply, Fin.sum_univ_two] at h00
+
+/-- The literal one-sector CPSV representative satisfies the standing simple,
+BNT, and biCF conditions of Theorem 4.9 together with SAL and source ZCL, but
+its two-site block is not an RFP via the two channels of Definition 4.1.
+
+Thus the printed implication (ii) to (v) is false, rather than merely missing
+the rank-one proof supplied through Lemma C.5.  The obstruction and the
+normalization-sensitive representative are documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+
+Source: arXiv:1606.00608, Theorem 4.9, lines 849--893; Appendix C.2,
+Lemma C.5, lines 1484--1499; and `prop2to5`, lines 1810--1825. -/
+theorem canonicalRepresentative_refutes_theorem4_9_ii_to_v :
+    MPSTensor.IsCPSVCanonicalForm canonicalRepresentative.toMPSTensor ∧
+      IsSimpleCanonicalForm canonicalRepresentative ∧
+      MPSTensor.IsBNTCanonicalForm
+        (MPSTensor.singleSectorDecomposition canonicalBlock) ∧
+      MPSTensor.HasBiCF
+        (MPSTensor.singleSectorDecomposition canonicalBlock).basis ∧
+      IsSAL canonicalRepresentative ∧
+      IsSourceZCL canonicalRepresentative ∧
+      ¬ IsRFPViaTS (blockTwo canonicalRepresentative) :=
+  ⟨canonicalRepresentative_isCPSVCanonicalForm,
+    canonicalRepresentative_isSimpleCanonicalForm,
+    canonicalBlock_isBNTCanonicalForm,
+    canonicalBlock_singleSector_hasBiCF,
+    canonicalRepresentative_isSAL,
+    canonicalRepresentative_isSourceZCL,
+    blockTwo_canonicalRepresentative_not_isRFPViaTS⟩
+
+end MPOTensor.ActiveSectorSpanningCounterexample

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -251,6 +251,29 @@ def HasBiCF
         (∑ k : Fin r, Matrix.trace (Δ k * evalWord (A k) (List.ofFn w))) = 0) →
     ∀ k, Δ k = 0
 
+/-- An injective tensor gives a one-block `HasBiCF` family at word length one. -/
+theorem IsInjective.hasBiCF_fin_one {D : ℕ} {A : MPSTensor d D}
+    (hA : IsInjective A) : HasBiCF (fun _ : Fin 1 ↦ A) := by
+  refine ⟨1, ?_⟩
+  intro Δ hΔ k
+  fin_cases k
+  have hletters : ∀ i, Matrix.trace (Δ 0 * A i) = 0 := by
+    intro i
+    let w : Fin 1 → Fin d := fun _ ↦ i
+    simpa [w, List.ofFn_succ, List.ofFn_zero, evalWord] using hΔ w
+  apply (Matrix.trace_mul_right_eq_zero_iff (Δ 0)).mp
+  intro N
+  have hN : N ∈ Submodule.span ℂ (Set.range A) := by
+    rw [hA]
+    exact Submodule.mem_top
+  induction hN using Submodule.span_induction with
+  | mem N hN =>
+      obtain ⟨i, rfl⟩ := hN
+      exact hletters i
+  | zero => simp
+  | add M N _ _ hM hN => simp [Matrix.mul_add, Matrix.trace_add, hM, hN]
+  | smul c M _ hM => simp [Matrix.trace_smul, hM]
+
 /-- If simultaneous word evaluations span the product algebra, then a block
 matrix family whose trace pairing vanishes on those word evaluations is zero. -/
 theorem block_matrices_eq_zero_of_wordTupleSpanTop_trace

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -193,6 +193,15 @@ noncomputable def blockTwo (M : MPOTensor d D) : MPOTensor (d * d) D :=
     M (finProdFinEquiv.symm i).1 (finProdFinEquiv.symm j).1 *
       M (finProdFinEquiv.symm i).2 (finProdFinEquiv.symm j).2
 
+/-- The physical-trace transfer of a two-site block is the square of the
+original physical-trace transfer. -/
+theorem physTraceTransfer_blockTwo (M : MPOTensor d D) :
+    physTraceTransfer (blockTwo M) =
+      physTraceTransfer M * physTraceTransfer M := by
+  rw [physTraceTransfer, ← finProdFinEquiv.sum_comp, Fintype.sum_prod_type,
+    physTraceTransfer, Finset.sum_mul_sum]
+  simp [blockTwo]
+
 /-- Identify the standard two-site index `Fin (d * d)` with the general
 length-two blocked alphabet.
 

--- a/TNLean/MPS/SharedInfra/BlockAssembly.lean
+++ b/TNLean/MPS/SharedInfra/BlockAssembly.lean
@@ -29,7 +29,24 @@ noncomputable def toTensorFromBlocks {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k)) :
     MPSTensor d (∑ k : Fin r, dim k) := fun i =>
   (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
-    (Matrix.blockDiagonal' fun k => (μ k) • (A k i))
+  (Matrix.blockDiagonal' fun k => (μ k) • (A k i))
+
+/-- A `Fin 1` block sum with unit weight is the original tensor. -/
+@[simp]
+theorem toTensorFromBlocks_fin_one {D : ℕ} (A : MPSTensor d D) :
+    toTensorFromBlocks (fun _ : Fin 1 ↦ (1 : ℂ)) (fun _ : Fin 1 ↦ A) = A := by
+  let e : (Σ _k : Fin 1, Fin D) ≃ Fin D := finSigmaFinEquiv
+  have hsymm (i : Fin D) : e.symm i = ⟨0, i⟩ := by
+    apply e.injective
+    rw [e.apply_symm_apply]
+    ext
+    exact (@finSigmaFinEquiv_one (fun _ : Fin 1 ↦ D) ⟨(0 : Fin 1), i⟩).symm
+  funext i
+  ext x y
+  simp only [toTensorFromBlocks, Matrix.reindex_apply]
+  change (Matrix.reindex e e
+    (Matrix.blockDiagonal' (fun _k : Fin 1 ↦ (1 : ℂ) • A i))) x y = A i x y
+  simp [Matrix.reindex_apply, hsymm]
 
 /-- Flatten the dependent block coordinates after reindexing the block family by an
 equivalence. -/

--- a/TNLean/MPS/SharedInfra/BlockGauge.lean
+++ b/TNLean/MPS/SharedInfra/BlockGauge.lean
@@ -106,6 +106,13 @@ noncomputable def globalGaugeOfBlocks (X : (k : Fin r) → GL (Fin (dim k)) ℂ)
     (Matrix.reindexAlgEquiv ℂ ℂ (finSigmaFinEquiv (n := dim))).toRingEquiv.toMonoidHom
     (blockDiagonalGL X)
 
+/-- The block-diagonal gauge assembled from identity blocks is the identity. -/
+@[simp]
+theorem globalGaugeOfBlocks_one :
+    globalGaugeOfBlocks (dim := dim) (fun _ ↦ 1) = 1 := by
+  change Units.map _ (Units.map _ ((MulEquiv.piUnits).symm 1)) = 1
+  rw [map_one, map_one, map_one]
+
 /-- A block-diagonal gauge assembled from unitary blocks is unitary. -/
 theorem globalGaugeOfBlocks_unitaryGL_mem
     (U : (k : Fin r) → Matrix.unitaryGroup (Fin (dim k)) ℂ) :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -413,8 +413,8 @@
 % **Scope restriction (SAL and ZCL):** the theorem starts from a neighboring
 % trace factorization, including the rank-one identity
 % tr(eta_{k,h}) = a_k b_h. It proves the conditional implication (iv) => (v),
-% not Proposition prop2to5 from SAL and ZCL alone. The missing rank-one step is
-% documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
+% not Proposition prop2to5 from SAL and ZCL alone. The refuted rank-one
+% inference is documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[Conditional two-site blocking theorem from neighboring trace factorization]
     \label{thm:mpdo_blocked_original_tensor_is_rfp_via_ts}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_isRFPViaTS}
@@ -440,38 +440,57 @@
     $\mathcal K^{[2]}$.
 \end{proof}
 
-% **Refuted prerequisite (Lemma C.5):**
-% rem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
-% SAL and ZCL hypotheses by thm:mpdo_sal_zcl_rank_one_counterexample. Hence the
-% printed proof through prop2to3 does not establish implication (ii) => (v),
-% which remains unformalized rather than refuted. Corrected rank-one criteria
-% under positive semidefiniteness or linear independence are given by
-% thm:psd_trace_powers_rank_one_t and thm:pairing_idempotent_rank_one_t. The
-% conditional blocking theorem thm:mpdo_blocked_original_tensor_is_rfp_via_ts
-% instead assumes a neighboring trace factorization.
+% **Refuted:** the source-selected four-sector tensor from
+% thm:mpdo_sal_zcl_rank_one_counterexample, after the scalar normalization and
+% bond gauge required by the printed canonical-form hypotheses, satisfies the
+% standing simple, biCF, BNT, SAL, and ZCL assumptions but its two-site block
+% is not RFP via trace-preserving maps.  Thus Theorem 4.9 (ii) => (v) is false
+% under the printed hypotheses, not merely unsupported by the refuted Lemma
+% C.5.  The conditional blocking theorem
+% thm:mpdo_blocked_original_tensor_is_rfp_via_ts remains valid when a rank-one
+% neighboring trace factorization is supplied separately.
 % Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[Blocking channels from SAL and ZCL (rank-one obstruction)]
+\begin{theorem}[Counterexample to blocking from strong area law and zero correlation length]
     \label{thm:mpdo_sal_zcl_blocking_channels}
-    \notready
+    \lean{MPOTensor.ActiveSectorSpanningCounterexample.%
+      canonicalRepresentative_refutes_theorem4_9_ii_to_v}
+    \leanok
     \uses{def:is_sal, def:mpo_source_zcl, def:is_rfp_via_ts,
-        def:mpdo_two_site_blocking}
-    Let $K$ be a simple tensor in block-injective canonical form (biCF),
-    equipped with a basis-of-normal-tensors decomposition and satisfying the
-    strong area law and zero correlation length. Let $M=K^{[2]}$ be its
-    two-site blocking. Then
-    there are trace-preserving completely positive maps in both directions
-    between the one-site and two-site closures of $M$. Equivalently, $M$ is a
-    renormalization fixed point via these two maps. This is implication
-    (ii)$\Rightarrow$(v) of
+        def:mpdo_two_site_blocking,
+        thm:mpdo_sal_zcl_rank_one_counterexample}
+    Let $l_i$ be the columns of
+    $L=\left(\begin{smallmatrix}1/4&1/4&1/4&1/4\\
+    1&-1&1&-1\end{smallmatrix}\right)$ and let $r_i$ be the rows of
+    $Q=\left(\begin{smallmatrix}1&1/8\\1&1/8\\1&-1/8\\1&-1/8
+    \end{smallmatrix}\right)$. Put $c=4/\sqrt5$, $G=\operatorname{diag}(8,1)$,
+    and
+    $K^{ij}=\delta_{ij}cG(l_ir_i)G^{-1}$. Then $K$ is a simple matrix product
+    density operator tensor in canonical form; its one-sector
+    basis-of-normal-tensors presentation is in block-injective canonical form.
+    It satisfies the strong area law and source zero correlation length, but
+    $K^{[2]}$ is not a renormalization fixed point via trace-preserving
+    completely positive maps. Hence implication (ii)$\Rightarrow$(v) of
     \cite[Theorem~4.9 and Appendix~C.2, lines~1810--1825]
-      {Cirac2016MPDO_arXiv}. The separate standing biCF and BNT hypotheses are
-    imposed at lines~849--850 and restated at line~1628 of the same source.
-    The printed proof of implication (ii)$\Rightarrow$(v) refers back to the
-    construction of Proposition~C.7 after projection to each local sector.
-    That construction requires the rank-one neighboring-trace factorization
-    supplied in the printed argument by the refuted Lemma~C.5. Thus the printed
-    route is obstructed; no alternative proof under SAL and ZCL alone is known.
+      {Cirac2016MPDO_arXiv} is false under its printed hypotheses.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:rfp_via_ts_physical_trace_idempotent}
+    The gauge $G$ makes the unique normal block left canonical, and its four
+    nonzero physical slices span $\MN{2}$. The one-sector presentation is
+    therefore both a basis-of-normal-tensors canonical form and block-injective
+    at length one. Scalar normalization and bond conjugation preserve the
+    normalized periodic states of the four-sector tensor in
+    Theorem~\ref{thm:mpdo_sal_zcl_rank_one_counterexample}; consequently $K$
+    satisfies the strong area law. Since
+    $LQ=\operatorname{diag}(1,0)=P$, its physical-trace transfer and that of its
+    two-site block are
+    $\mathcal T_K=cP$ and $\mathcal T_{K^{[2]}}=c^2P=(16/5)P$, respectively.
+    If $K^{[2]}$ were a renormalization fixed point via trace-preserving maps,
+    Theorem~\ref{thm:rfp_via_ts_physical_trace_idempotent} would give
+    $(c^2P)^2=c^2P$, contrary to $c^2=16/5$ and $P\ne0$.
+\end{proof}
 
 % Correct equation, not a figure: the cited source draws the two-to-three
 % channel MPDO_TSKKK.png after explicitly suppressing U, but it does not draw

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -84,13 +84,21 @@ For MPDO renormalization fixed points:
   multiplicity. This chainwise proof requires no copy independence. The note
   also records that the printed invocation of `lemmus` is invalid because its
   source-ZCL hypothesis is absent from the proposition.
-- `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` records the missing
-  coherent positive choice for the inverse-map neighboring operators in
-  Appendix C.2. The comparison with the conjugated Hayashi decomposition,
-  the tensors $l_k,r_k$, the resulting physical-sector factorization,
-  and the exact finite-chain bond product are formalized. Deriving recurrence
-  from injectivity and choosing positive representatives coherently across
-  the sector graph remain open.
+- `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` is the closure record for the
+  coherent positive choice in Appendix C.2. Recurrence is derived from
+  injectivity after zero-weight sectors are normalized, the inverse-map
+  tensors are coherently rephased, and the active-sector trace matrix is
+  primitive. The resulting positive commuting bond and its exact finite-chain
+  product now give the eta-local structure from the printed SAL hypotheses.
+- `cpgsv17_pf_rank_one.tex` records that Lemma C.5's primitive-matrix
+  rank-one inference is false, and realizes its nilpotent obstruction in an
+  injective four-sector MPDO satisfying the printed SAL and source-ZCL
+  hypotheses. Canonical normalization gives the simple, biCF, and BNT
+  standing hypotheses of Theorem 4.9 while the two-site block fails the
+  trace-preserving RFP condition, refuting implication
+  $\mathrm{(ii)}\Rightarrow\mathrm{(v)}$. The structural implication
+  $\mathrm{(ii)}\Rightarrow\mathrm{(iv)}$ remains unresolved rather than
+  formalized by the invalid rank-one step.
 - `cpsv16_purification_rfp_definition.tex` records why the former
   local-purification PRFP predicate was removed: it required a generic
   pure-state RFP witness, but did not enforce the source's positive-length
@@ -130,7 +138,11 @@ For MPDO renormalization fixed points:
   Definition 4.1 local renormalization equations. Positivity alone admits the
   zero tensor. The horizontal-form theorems are stronger specializations that
   derive the required nonvanishing. This closes only implication
-  $\mathrm{(i)}\Rightarrow\mathrm{(ii)}$; Theorem 4.9 remains partial.
+  $\mathrm{(i)}\Rightarrow\mathrm{(ii)}$. Theorem 4.9 is not an equivalence
+  as printed: implication $\mathrm{(ii)}\Rightarrow\mathrm{(v)}$ is refuted
+  by the canonical four-sector example recorded in
+  `cpgsv17_pf_rank_one.tex`, while
+  $\mathrm{(ii)}\Rightarrow\mathrm{(iv)}$ remains unresolved.
 - `hjpw04_ssa_product_marginal_reference.tex` records the singular
   product-marginal evaluation in the relative-entropy form of strong
   subadditivity. The support-compressed tensor logarithm, the bipartite entropy

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -519,6 +519,62 @@ is a formal counterexample to the rank-one conclusion of the printed
 Lemma~C.5, not merely to an intermediate matrix argument.  This closes the
 verification tracked in \ghissue{4270}.
 
+\section{Canonical normalization refutes the blocking implication}
+
+The same four-sector tensor decides the downstream implication
+(ii)$\Rightarrow$(v) of Theorem~4.9.  The printed theorem assumes that the
+simple tensor has already been put in block-injective canonical form and in a
+basis-of-normal-tensors presentation.  For the matrices $L,Q$ above, set
+\[
+  c=\frac4{\sqrt5},
+  \qquad
+  G=\begin{pmatrix}8&0\\0&1\end{pmatrix},
+  \qquad
+  K^{ij}=\delta_{ij}\,cG(l_ir_i)G^{-1}.
+\]
+The scalar $c$ normalizes the horizontal transfer radius, and the bond gauge
+$G$ makes the unique normal block left canonical.  The four nonzero physical
+slices span $\MN{2}$, so this one-sector presentation is a literal canonical
+representative, is block-injective at length one, and satisfies the standing
+simple, biCF, and BNT hypotheses of Theorem~4.9.  Scalar multiplication by the
+positive number $c$ and bond conjugation leave every normalized periodic state
+unchanged.  Thus the strong area law proved for the original tensor also holds
+for $K$.  Its physical-trace transfer is a nonzero scalar multiple of the same
+rank-one projection,
+\[
+  \mathcal T_K=cP,
+  \qquad
+  P=LQ=\begin{pmatrix}1&0\\0&0\end{pmatrix},
+\]
+and therefore $K$ satisfies source zero correlation length.
+
+Physical blocking squares this transfer:
+\[
+  \mathcal T_{K^{[2]}}=\mathcal T_K^2
+    =c^2P=\frac{16}{5}P.
+\]
+Definition~4.1 implies that the physical-trace transfer of every
+renormalization fixed point via trace-preserving maps is idempotent.  Here
+\[
+  \mathcal T_{K^{[2]}}^2
+    =\left(\frac{16}{5}\right)^2P
+    \ne\frac{16}{5}P
+    =\mathcal T_{K^{[2]}}.
+\]
+Consequently $K^{[2]}$ is not a renormalization fixed point in the sense of
+Definition~4.1.  The tensor $K$ satisfies every printed standing hypothesis
+and condition~(ii), while condition~(v) fails.  Thus Theorem~4.9
+(ii)$\Rightarrow$(v) is false under its printed hypotheses, rather than merely
+unsupported by the proof through Lemma~C.5.
+
+The canonical representative, its simple, biCF, BNT, SAL, and ZCL properties,
+and the non-RFP conclusion are formalized in
+\path{TNLean/MPS/MPDO/ActiveSectorBlockingBoundary.lean}.  The combined
+declaration is
+\leanid{MPOTensor.ActiveSectorSpanningCounterexample.%
+canonicalRepresentative_refutes_theorem4_9_ii_to_v}.  This classification is
+tracked in \ghissue{5388}.
+
 \section{A positive-semidefinite route}
 
 The formal development proves a corrected sufficient matrix theorem. Let $T$
@@ -577,21 +633,25 @@ has not been identified with the inverse-map family constructed in lines
 1413--1455, and the trace of its all-ones matrix is the number of sectors, not
 one unless there is a single sector.
 
-The positive-semidefinite route must therefore use more of the matrix product
-density operator construction than the separate inequalities
-$\eta_{k,h}\geq 0$. One possible completion is to derive an adjoint or Gram
-relation from the inverse-map tensors. Positive semidefiniteness of the source
-trace matrix is not presently established by the cited passage.
+The positive-semidefinite route is therefore a corrected strengthening, not a
+consequence of the printed hypotheses.  It must assume an adjoint or Gram
+relation beyond the separate inequalities $\eta_{k,h}\geq 0$.  In fact, the
+source-selected trace matrix of the four-sector example above is non-Hermitian:
+its $(0,2)$ entry is $3/8$, whereas its $(2,0)$ entry is $1/8$.  Thus SAL and
+ZCL do not force the Hermitian, and hence do not force the positive
+semidefinite, matrix hypothesis used by the corrected theorem.
 
-This corrected theorem does not refute the intended matrix product density
-operator result; it supplies one sufficient matrix-level hypothesis. For this
-route, the open question is whether the trace matrix
-$T_{k,h}=\operatorname{tr}(\eta_{k,h})$ is Hermitian or positive semidefinite.
-The pairing-idempotence route of Section~3.1 avoids that hypothesis, but instead
-requires the concrete sector pairing, the zero-correlation-length operator
-identity, and linear independence. Positivity of each $\eta_{k,h}$ gives only
-$T_{k,h}\geq 0$ entry by entry, which implies neither matrix-level positive
-semidefiniteness nor Hermitian symmetry.
+This corrected theorem supplies one sufficient matrix-level hypothesis; by
+itself it neither proves nor refutes a tensor-level statement.  The canonical
+four-sector representative above independently refutes the printed blocking
+implication.  The positive-semidefinite route remains valid when Hermitian
+positive semidefiniteness of
+$T_{k,h}=\operatorname{tr}(\eta_{k,h})$ is supplied as an additional
+hypothesis. The pairing-idempotence route of Section~3.1 avoids that hypothesis,
+but instead requires the concrete sector pairing, the zero-correlation-length
+operator identity, and linear independence. Positivity of each $\eta_{k,h}$
+gives only $T_{k,h}\geq 0$ entry by entry, which implies neither matrix-level
+positive semidefiniteness nor Hermitian symmetry.
 \footnote{The entrywise nonnegativity result is
 {\scriptsize\leanid{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}}. The
 positive-semidefinite reformulation for the rank-one conclusion is
@@ -657,10 +717,13 @@ This obstruction propagates to every source statement whose proof invokes the
 rank-one factorization from Lemma~C.5.  In particular, the structural
 corollary at lines~1501--1505, the proposition proving Theorem~4.9
 (ii)$\Rightarrow$(iv) at lines~1740--1788, and the proposition proving
-Theorem~4.9 (ii)$\Rightarrow$(v) at lines~1810--1825 are not formalized from
-their stated SAL and ZCL hypotheses.  The constructions from an explicitly
-supplied rank-one neighboring trace factorization remain valid restricted
-results, but they do not establish these three source statements.
+Theorem~4.9 (ii)$\Rightarrow$(v) at lines~1810--1825 are not established by
+the printed argument.  The canonical normalization above goes further for the
+last implication: it supplies a counterexample satisfying the theorem's
+standing hypotheses.  The constructions from an explicitly supplied rank-one
+neighboring trace factorization remain valid restricted results, but they do
+not establish the structural corollary or implication (ii)$\Rightarrow$(iv)
+from SAL and ZCL alone.
 
 \section{Conclusion}
 
@@ -680,15 +743,19 @@ Markov witness with an independently supplied trace matrix has been retired:
 it imposed no relation between the state, the matrix, and an MPO tensor, and
 therefore added no consequence to either criterion.
 
-The all-cut Markov proof and the source-selected inverse-map calculation now
-show that Lemma~C.5 is false as printed: its injective four-sector witness
+The all-cut Markov proof and the source-selected inverse-map calculation show
+that Lemma~C.5 is false as printed: its injective four-sector witness
 satisfies SAL and source ZCL, while the asserted factorization
 $T_{k,h}=a_kb_h$ does not exist.  Consequently its structural corollary and
-the source implications (ii)$\Rightarrow$(iv) and (ii)$\Rightarrow$(v) of
-Theorem~4.9 cannot be obtained by the printed argument.  The direct matrix
-conclusions remain available under positive semidefiniteness or the appropriate
-linear-independence hypothesis, but those additional conditions do not supply
-the source's structural corollary and must not be attributed to it.
+the source implication (ii)$\Rightarrow$(iv) of Theorem~4.9 cannot be obtained
+by the printed argument.  After canonical normalization and gauge fixing, the
+same witness also satisfies the theorem's standing simple, biCF, and BNT
+hypotheses while its two-site block is not an RFP via trace-preserving maps.
+It therefore refutes implication (ii)$\Rightarrow$(v) itself.  The direct
+matrix conclusions remain available under positive semidefiniteness or the
+appropriate linear-independence hypothesis, but those additional conditions
+do not supply the source's structural corollary and must not be attributed to
+it.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Status: superseded without merge

This draft attempted to turn the normalized four-sector tensor into a counterexample to Theorem 4.9, implication (ii) to (v). It was closed without merge after the source-hypothesis audit exposed a normalization error. PR #5389 contains the corrected result.

## Mathematical defect in the proposed conclusion

The draft used the repository predicate `MPOTensor.IsSourceZCL`, which is invariant under a positive scalar, as though it were the paper's literal fixed-tensor ZCL identity. For the normal unit-weight representative
[
A=(4/sqrt5)K,
]
the physical-trace transfer satisfies only the up-to-scalar relation; it does not satisfy the literal ZCL diagram. Its two-site block indeed fails `IsRFPViaTS`, but (A) therefore does not satisfy the exact antecedent used in the proposed source counterexample.

Conversely, the raw tensor (K) satisfies the literal ZCL identity and the bare RFP equations, but it is not the globally unit-weight normal representative assumed in Appendix C.2, Case I.

Thus neither representative simultaneously satisfies both standing source conventions. The proposed declaration `canonicalRepresentative_refutes_theorem4_9_ii_to_v` did not establish a source-faithful refutation and was not merged.

## Durable result

PR #5389 retains the valid calculations:

- two-site blocking preserves the bare trace-preserving-channel RFP equations;
- (K) and `blockTwo K` satisfy those equations;
- the normalized representative has two-site physical-trace eigenvalue (16/5) and its block fails `IsRFPViaTS`;
- the exact source implication remains unsettled at the normalization boundary.

Issue #5388 and `docs/paper-gaps/cpgsv17_pf_rank_one.tex` record the corrected classification.