### PR TITLE
doc(MPS/MPDO): synchronize Theorem 4.14 status

### DIFF
--- a/docs/audits/2026-04-21_issue612_algebra_structure_blocker.md
+++ b/docs/audits/2026-04-21_issue612_algebra_structure_blocker.md
@@ -4,6 +4,15 @@ Date: 2026-04-20
 Branch: `feat/612-algebra-structure-coeffs`
 Target issue: #612
 
+> **Superseded status (2026-08-03).** This report is retained as a historical
+> diagnosis of the then-vacuous support-algebra route. It is not the current
+> status of Theorem 4.14. The source-faithful tensor-attached BNT route was
+> completed in PR #5364; see
+> `TNLean/MPS/MPDO/CPSVBNTTheoremEquivalence.lean` and the maintained coverage
+> audit `docs/audits/2026-05-08-mps-ft-paper-coverage.md`. The weak
+> support-algebra route described below was not repaired into that theorem and
+> remains a distinct, historically useful obstruction.
+
 ## Outcome
 
 I did **not** change `TNLean/MPS/MPDO/AlgebraStructure.lean`.

--- a/docs/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
+++ b/docs/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
@@ -4,6 +4,14 @@ Date: 2026-04-23; rebased on current `main` on 2026-04-25
 Branch: `feat/826-algebra-to-fusion-v2`
 Target issue: #826
 
+> **Superseded status (2026-08-03).** This report is retained as a historical
+> analysis of the weak implication from adjoint fixed-point support algebras to
+> transfer retracts. Its counterexample boundary is still relevant, but it is
+> not the current status of Theorem 4.14. PR #5364 completed the distinct,
+> source-faithful tensor-attached BNT route; see
+> `TNLean/MPS/MPDO/CPSVBNTTheoremEquivalence.lean` and the maintained coverage
+> audit `docs/audits/2026-05-08-mps-ft-paper-coverage.md`.
+
 ## Scope
 
 Issue #826 asks for the converse direction of the MPDO §4.5 equivalence:

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -51,17 +51,16 @@ For MPDO renormalization fixed points:
   this restriction from the generic physical-coordinate transport identities,
   which make explicit a basis change that the source uses without stating the
   corresponding two-site and four-site congruences.
-- `cpsv16_vertical_sector_invertibility.tex` separates the proved fixed
-  contraction families and product-generation theorem from the remaining
-  density-weighted fixed-point argument in Appendix C.4. Wolf's full
-  fixed-point theorem, including maximal-support reduction and the
-  complementary zero summand, and its full-support direct-sum consequence are
-  now formalized.  The two transported square composites are proved trace
-  preserving on the full sector algebras by a maximal-support argument, and a
-  trace sandwich gives the same conclusion for each transported map; the
-  complete-positivity and adjoint Schwarz hypotheses remain.  The note also
-  records that sector relabelling follows from mutually inverse positive
-  trace-preserving maps, not from a bare linear equivalence.
+- `cpsv16_vertical_sector_invertibility.tex` records the fixed contraction
+  families and product-generation theorem used in Appendix C.4. The later
+  mixed one-site/two-site comparison and zero-sector completion close the
+  density-weighted argument: Theorem 4.14(i)--(ii) is formalized under the
+  source's literal canonical-form and MPDO hypotheses, and the corresponding
+  (i)--(iii) equivalence is formalized for the documented active-support
+  correction of the printed fusion clause. See
+  `cpsv16_two_site_sector_unitary_gauge_gap.tex` and
+  `TNLean/MPS/MPDO/CPSVBNTTheoremEquivalence.lean`. The unrestricted printed
+  statement (iii), including inactive product sectors, is not claimed.
 - `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT
   elements with nilpotent physical-trace transfer matrices and records the
   positive physical blocking and chosen-BNT interpretation of the

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -242,20 +242,22 @@ the geometric-sequence extrapolation already used in the BNT Fundamental
 Theorem with the unequal-cardinality power-sum identity, and therefore proves
 the power-sum step used at lines~2053--2058.
 
-What remains before this constructor can be applied is the tensor-level BNT
-comparison at lines~2048--2058.  The predicate
+The tensor-level BNT comparison at lines~2048--2058 is now supplied by the
+literal two-site spectrum comparison and exact sector-gauge construction
+documented in
+\path{cpsv16_two_site_sector_unitary_gauge_gap.tex}.  The predicate
 \leanid{MPOTensor.BNTAlgebraTensorClause} now chooses the one-site vertical
 canonical decomposition and identifies the operators and trace scalars in the
 abstract BNT algebra clause with
 $O_L(M_\alpha)$ and $m_\alpha=\sum_q\omega_{\alpha,q}$, respectively.  It does
-not choose a vertical canonical decomposition of the two-site blocked tensor,
-nor does it assert the relabelling and unitary identifications of the one-site
-products with the two-site BNT sectors.  These identifications must yield the
-displayed eventual power-sum equality from the same-length algebra law; the
-constructor above then supplies the spectrum comparison without any further
-mathematical hypothesis.
+not itself contain a second vertical canonical decomposition.  Instead, the
+mixed-prefix argument constructs the required relabelling and simultaneous
+unitary identifications from the tensor-attached clause.  The resulting
+positive multiset equality supplies the spectrum comparison without an
+additional mathematical hypothesis; the completion is used by
+\leanid{MPOTensor.BNTAlgebraTensorClause.isRFPViaTS}.
 
-\section{BNT-label coefficient objects and remaining elimination plan}
+\section{BNT-label coefficient objects}
 
 The same-length coefficient family $c^{(L)}_{\alpha,\beta,\gamma}$, indexed
 by fixed BNT labels, is represented separately from the blocked-basis
@@ -306,15 +308,14 @@ without also assuming the comparison formula.\footnote{%
 \leanid{MPOTensor.BNTBlockedBasisLabelAssignment},
 \leanid{MPOTensor.BNTBlockedBasisLabelAssignment.blockedLabel},
 \leanid{MPOTensor.BNTBlockedBasisCoefficientComparison}.}  This predicate
-inherits the second scope restriction above: its left hand side is expanded in a
-basis of $\mathcal A_{2n}$, while the source theorem's BNT product law is
-same-length. It therefore records the formal blocked-basis comparison
-predicate; constructing the source label maps from an MPDO tensor is still part
-of the Appendix C.3--C.4 witness construction. The predicate is not itself the
-same-length product statement of Theorem~4.14(ii).
-These declarations specify the BNT-label coefficient objects and the comparison
-statement, but they do not yet construct the operators, trace scalars,
-coefficients, comparison maps, or $\chi$-matrices from an MPDO tensor.
+inherits the second scope restriction above: its left hand side is expanded in
+a basis of $\mathcal A_{2n}$, while the source theorem's BNT product law is
+same-length.  It therefore records the formal blocked-basis comparison
+predicate and is not itself the same-length product statement of
+Theorem~4.14(ii).  The generic declarations in this section do not construct
+the tensor-attached objects by themselves.  That construction is now supplied
+by \leanid{MPOTensor.BNTAlgebraTensorClause} and the reflected-target argument
+in \path{TNLean/MPS/MPDO/BNTAlgebraTensorClauseReflectedTarget.lean}.
 Once both the same-length BNT product form and a positive BNT-label
 $\chi$-witness are available, the same-length product expansion with
 coefficients written as $\tr(\chi_{\alpha,\beta,\gamma}^L)$
@@ -729,10 +730,11 @@ printed $F$-matrix and pentagon theorem apply to the length-independent source
 BNT fusion family without an additional injectivity, selector, inverse, or
 coisometry hypothesis.
 
-The remaining upstream construction is different: one must obtain the
-labelled fusion-isometry family and its identification with the BNT of the
-vertical canonical form from the RFP tensor itself.  That Appendix
-C.3--C.4 obligation is not supplied by the complete-zipper assembly above.
+The labelled fusion-isometry family and its identification with the BNT of the
+vertical canonical form are now obtained from the RFP tensor by
+\leanid{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS}.  This closes the
+corrected active-support form of the Appendix C.3--C.4 implication.  It is
+logically separate from the complete-zipper construction below.
 
 Independently of this positive-diagonal specialization, the source-faithful
 complete zipper fusion structure is now formalized by
@@ -814,31 +816,27 @@ $F$-matrix.  The forward edge matrices in the formalization follow
 forward identity and this inverse, literally indexed form are stated by the
 two matrix equalities and the entrywise theorem above.
 
-To eliminate the source-theorem gap, the formalization should instead:
-\begin{enumerate}
-    \item use the source-faithful predicate
-        \leanid{MPOTensor.BNTAlgebraTensorClause} for Theorem~4.14(ii), which
-        chooses the vertical canonical-form decomposition from
-        Proposition~4.13 and fixes the BNT operators
-        $O_L(M_\alpha)$ and weights $m_\alpha=\tr(\mu_\alpha)$ appearing in the
-        positive chi trace-power law, same-length product law, and length-one
-        idempotent identity;
-    \item relate this predicate to the one-site and two-site vertical
-        decompositions used in Appendix~C.4, lines~2048--2058, and prove the
-        unitary relabelling and the positive multiset identity for the
-        $\nu_{\gamma,k}$;
-    \item deduce $\tr(\nu_\gamma)=m_\gamma$ and construct the retained-sector
-        composites $T_0=\widetilde R_2\widetilde T R_1$ and
-        $S_0=\widetilde R_1\widetilde S R_2$ from lines~2065--2085, then add a
-        trace-preserving completely positive completion on the orthogonal
-        complements as recorded in
-        \path{cpgsv17_vertical_isometry_zero_sector.tex};
-    \item conclude the paper's renormalization fixed-point predicate, namely
-        the existence of the two trace-preserving completely positive maps in
-        Definition~4.1.  Any comparison with the transfer-retract predicate
-        must then be stated separately, because the latter is presently
-        equivalent to transfer-map idempotence rather than Definition~4.1.
-\end{enumerate}
+\section{Completion status for Theorem 4.14}
+
+The tensor-attached BNT route described above is complete.  The mixed
+one-site/two-site prefix argument gives the unitary relabelling and positive
+multiset identity for the $\nu_{\gamma,k}$.  The retained-sector composites
+$T_0=\widetilde R_2\widetilde T R_1$ and
+$S_0=\widetilde R_1\widetilde S R_2$, together with the zero-sector
+measure-and-prepare completion, give the two trace-preserving completely
+positive maps of Definition~4.1.  This implication is
+\leanid{MPOTensor.BNTAlgebraTensorClause.isRFPViaTS}.
+
+Under the literal CPSV canonical-form and MPDO hypotheses, the two directions
+are combined in
+\leanid{MPOTensor.isRFPViaTS_iff_hasBNTAlgebraTensorClause}.  The corresponding
+equivalence
+\leanid{MPOTensor.isRFPViaTS_iff_hasBNTFusionTensorClause} uses the documented
+active-support correction of Theorem~4.14(iii), not its unrestricted printed
+form.  These results do not identify the positive-diagonal family with a
+complete zipper fusion family and do not supply the stronger categorical
+$F$-matrix data discussed above.  The transfer-retract predicate also remains
+separate: it expresses transfer-map idempotence rather than Definition~4.1.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -292,10 +292,16 @@ finite products in Appendix~C.4; the support conditions
 does not determine a preferred action on the discarded physical complements.
 For the converse implication, the measure-and-prepare terms in
 \eqref{eq:converse-completed-channels} give global physical channels with the
-same action on the source-generated family.  This conclusion remains
-conditional on the unitary sector conjugacies used in
-\eqref{eq:converse-active-composites}; it does not prove their unconditional
-existence in Theorem~4.14.
+same action on the source-generated family.  Within this note, that construction
+is conditional on the unitary sector conjugacies used in
+\eqref{eq:converse-active-composites}.  The later mixed one-site/two-site prefix
+argument proves those conjugacies from the tensor-attached BNT clause, as
+documented in
+\path{cpsv16_two_site_sector_unitary_gauge_gap.tex}.  Consequently the
+zero-sector completion is used unconditionally by
+\leanid{MPOTensor.BNTAlgebraTensorClause.isRFPViaTS}, closing
+Theorem~4.14(ii)$\Rightarrow$(i) under the source's standing canonical-form and
+MPDO hypotheses.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Closes #5394.

## What changed

- replaces obsolete open-plan prose in the MPDO/RFP paper-gap index and blocked-chi note with the completed tensor-attached BNT route;
- records the downstream discharge of the unitary-sector condition in the zero-sector completion note;
- marks the issue #612 and #826 audits as historical snapshots without rewriting their weak-support-algebra obstruction;
- keeps the complete-zipper and categorical F-matrix construction explicitly separate.

## Mathematical boundary

Theorem 4.14(i) if and only if (ii) is complete under the literal CPSV canonical-form and MPDO hypotheses. The fusion equivalence is complete only for the documented active-support correction of statement (iii); this PR does not claim the unrestricted printed statement. It also does not claim that Theorem 4.14 supplies complete-zipper data.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- obsolete-current-status phrase scan across the five changed files
- declaration and path reference audit
- standalone `latexmk` builds of both changed paper-gap notes with the repository `command.tex` forced through `TEXINPUTS=.:`
- independent read-only source-faithfulness review

No Lean declaration, import, Blueprint graph, or tenkz file changes. No local Lake build was run for this documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and LaTeX documentation only; no code or proof changes, so risk is limited to prose accuracy and cross-references.
> 
> **Overview**
> **Documentation-only** update (closes #5394): MPDO/RFP paper-gap prose is aligned with the **completed tensor-attached BNT route** (PR #5364), without changing Lean, Blueprint, or builds.
> 
> The **paper-gaps index** (`docs/paper-gaps/README.md`) and **`cpgsv17_vertical_sector_invertibility`** entry now state that Theorem **4.14(i)–(ii)** is formalized under literal CPSV canonical-form and MPDO hypotheses, and **(i)–(iii)** only for the **documented active-support correction** of fusion clause (iii)—not the unrestricted printed statement including inactive product sectors.
> 
> **`cpgsv17_blocked_chi_uniformity.tex`** drops open “remaining elimination” language: the two-site spectrum comparison, `BNTAlgebraTensorClause.isRFPViaTS`, `HasBNTFusionTensorClause.of_isRFPViaTS`, and a new **“Completion status for Theorem 4.14”** section point at `CPSVBNTTheoremEquivalence.lean` and still separate complete-zipper / categorical **F**-matrix data from the positive-diagonal route.
> 
> **`cpgsv17_vertical_isometry_zero_sector.tex`** records that unitary sector conjugacies for the converse are no longer only conditional in isolation—they are proved by the mixed one-site/two-site prefix argument, so zero-sector completion feeds **`isRFPViaTS`** unconditionally for **(ii)⇒(i)**.
> 
> Issues **#612** and **#826** audit reports get **superseded** banners: historical weak support-algebra obstruction, with pointers to the tensor-attached equivalence—not a rewrite of those analyses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f4a5ebcd7db524a45a8b75c2c03bf6c10ab0b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->