### PR TITLE
fix(tenkz): require closure probe records

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -59,6 +59,14 @@ grep -Fq '|name=wrap-1|origin=trace|row=1|' "$WORK/k_twoshift.tnlog" || {
   echo "FAIL: trace policy did not derive the per-row wrap-1 record" >&2
   exit 1
 }
+grep -Fq '|origin=trace|' "$WORK/r_closure_typed_ports.tnlog" || {
+  echo "FAIL: typed-port trace closure emitted no trace record" >&2
+  exit 1
+}
+grep -Fq '|origin=cup|' "$WORK/r_closure_typed_ports.tnlog" || {
+  echo "FAIL: typed-port cup closure emitted no cup record" >&2
+  exit 1
+}
 if grep -Fq '|origin=port-open|' "$WORK/r_closure_typed_ports.tnlog"; then
   echo "FAIL: trace/cup closure left duplicate typed-port stubs" >&2
   exit 1


### PR DESCRIPTION
## Summary

- Require the typed-port closure fixture to emit both trace and cup records.
- Keep the existing assertion that those closures leave no duplicate open-port stubs.

## Why

The old negative-only check passed vacuously if closure creation and open-stub materialization both disappeared. This closes the late test-integrity finding on merged PR #5191 without changing kernel output or public syntax.

Review thread: https://github.com/LionSR/TNLean/pull/5191#discussion_r3693170873

## Validation

- `bash -n scripts/tenkz_kernel_probes.sh`
- `shellcheck scripts/tenkz_kernel_probes.sh`
- `scripts/tenkz_kernel_probes.sh --check`
  - 95 review regressions
  - 9 sugar equivalences
  - 12 kernel record streams
  - kernel pixel goldens
- `git diff --check`

Follow-up to #5191.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to `tenkz_kernel_probes.sh` with no kernel or API impact.
> 
> **Overview**
> Strengthens the **typed-port closure** regression in `scripts/tenkz_kernel_probes.sh` so the gate no longer relies only on the absence of duplicate `port-open` stubs.
> 
> After the existing wrap/trace checks, it now **requires** `r_closure_typed_ports.tnlog` to contain at least one record with `origin=trace` and one with `origin=cup`. That way the probe fails if closure materialization disappears entirely, instead of passing vacuously when both closures and open stubs are missing.
> 
> Kernel output and public syntax are unchanged; this is test-integrity only (follow-up to merged closure work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b92be83717f7ced9c43e91f60310fe7c0c4cf19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->