### PR TITLE
fix(tenkz): draw unmatched port labels in final pass

### DIFF
--- a/tests/tenkz/kernel/regression/r_port_open_label_order.tex
+++ b/tests/tenkz/kernel/regression/r_port_open_label_order.tex
@@ -4,7 +4,43 @@
 \ExplSyntaxOn
 \file_input:n { tenkz-kernel.code.tex }
 \bool_new:N \g__tenkz_test_port_route_stroked_bool
+\bool_new:N \g__tenkz_test_late_hull_missing_bool
+\bool_new:N \g__tenkz_test_late_hull_live_bool
 \bool_new:N \l__tenkz_test_in_port_open_label_bool
+\bool_new:N \l__tenkz_test_in_port_open_stroke_bool
+\fp_new:N \g__tenkz_test_port_tip_x_fp
+\fp_new:N \g__tenkz_test_port_tip_y_fp
+\cs_new_eq:NN
+  \__tenkz_test_wire_port_open:n
+  \__tenkz_kernel_r_wire_port_open:n
+\cs_set_protected:Npn \__tenkz_kernel_r_wire_port_open:n #1
+  {
+    \__tenkz_model_get:nnN {#1} {host} \l_tmpa_tl
+    \prop_if_in:NeTF \l__tenkz_kernel_hull_live_prop {\l_tmpa_tl/xmin}
+      {\errmessage{wire-carried~port~host~was~measured~too~early}}
+      {\bool_gset_true:N \g__tenkz_test_late_hull_missing_bool}
+    \bool_set_true:N \l__tenkz_test_in_port_open_stroke_bool
+    \__tenkz_test_wire_port_open:n {#1}
+    \bool_set_false:N \l__tenkz_test_in_port_open_stroke_bool
+  }
+\cs_new_eq:NN
+  \__tenkz_test_wire_stroke:nn
+  \__tenkz_kernel_r_wire_stroke:nn
+\cs_set_protected:Npn \__tenkz_kernel_r_wire_stroke:nn #1#2
+  {
+    \bool_if:NT \l__tenkz_test_in_port_open_stroke_bool
+      {
+        \prop_if_in:NeTF \l__tenkz_kernel_hull_live_prop
+          {\l__tenkz_kernel_port_record_tl/xmin}
+          {\bool_gset_true:N \g__tenkz_test_late_hull_live_bool}
+          {\errmessage{port~geometry~did~not~materialize~its~late~host}}
+        \fp_gset_eq:NN \g__tenkz_test_port_tip_x_fp
+          \l__tenkz_kernel_r_port_tip_x_fp
+        \fp_gset_eq:NN \g__tenkz_test_port_tip_y_fp
+          \l__tenkz_kernel_r_port_tip_y_fp
+      }
+    \__tenkz_test_wire_stroke:nn {#1}{#2}
+  }
 \cs_new_eq:NN
   \__tenkz_test_index_route:n
   \__tenkz_kernel_r_index_route:n
@@ -40,14 +76,46 @@
           }
         \tl_if_eq:NNF \l_tmpa_tl \l_tmpb_tl
           {\errmessage{deferred~port-open~label~missed~its~tip}}
+        \fp_compare:nNnF
+          {
+            abs
+              (
+                \g__tenkz_test_port_tip_x_fp
+                - \l__tenkz_kernel_r_port_tip_x_fp
+              )
+          }
+          < {0.000001}
+          {\errmessage{deferred~port-open~label~left~its~stroked~tip~in~x}}
+        \fp_compare:nNnF
+          {
+            abs
+              (
+                \g__tenkz_test_port_tip_y_fp
+                - \l__tenkz_kernel_r_port_tip_y_fp
+              )
+          }
+          < {0.000001}
+          {\errmessage{deferred~port-open~label~left~its~stroked~tip~in~y}}
       }
     \__tenkz_test_port_labelnode:nnn {#1}{#2}{#3}
+  }
+\AtEndDocument
+  {
+    \bool_if:NF \g__tenkz_test_late_hull_missing_bool
+      {\errmessage{late-host~absence~probe~did~not~run}}
+    \bool_if:NF \g__tenkz_test_late_hull_live_bool
+      {\errmessage{late-host~materialization~probe~did~not~run}}
   }
 \ExplSyntaxOff
 \makeatother
 \begin{document}
 \tenkzkernel
-\begin{tenkz}[rows={wire}, cols=1, bonds=none]
-  \tn[ports={90:physical:$i$}]{}
+\begin{tenkz}[rows={wire}, cols=3, bonds=none]
+  \tn[at=(1,1), name=A]{A}
+  \tn[at=(1,3), name=B]{B}
+  \tnwire[kind=string, name=carrier]{A.0}{B.180}
+  \tn[at=on carrier 0.5, name=O, skin=box,
+      ports={0:physical:$i$}]{WIDELABEL123456789}
+  \tnmark[form=enclosure]{O}{}
 \end{tenkz}
 \end{document}

--- a/tests/tenkz/kernel/regression/r_unmatched_port_legs.tex
+++ b/tests/tenkz/kernel/regression/r_unmatched_port_legs.tex
@@ -26,6 +26,8 @@
 \bool_new:N \l__tenkz_test_in_port_label_bool
 \bool_new:N \l__tenkz_test_in_policy_label_bool
 \bool_new:N \l__tenkz_test_in_bonded_label_bool
+\bool_new:N \g__tenkz_test_atoms_done_bool
+\bool_new:N \g__tenkz_test_marks_done_bool
 \int_new:N \g__tenkz_test_bonded_slot_int
 \cs_new:Npn \TenkzPortLabelMode
   {
@@ -300,11 +302,27 @@
           {\errmessage{virtual~port~lost~its~semantic~stroke}}
       }
   }
+\cs_new_eq:NN \__tenkz_test_atoms: \__tenkz_kernel_r_atoms:
+\cs_set_protected:Npn \__tenkz_kernel_r_atoms:
+  {
+    \__tenkz_test_atoms:
+    \bool_gset_true:N \g__tenkz_test_atoms_done_bool
+  }
+\cs_new_eq:NN \__tenkz_test_marks: \__tenkz_kernel_r_marks:
+\cs_set_protected:Npn \__tenkz_kernel_r_marks:
+  {
+    \__tenkz_test_marks:
+    \bool_gset_true:N \g__tenkz_test_marks_done_bool
+  }
 \cs_new_eq:NN
   \__tenkz_test_port_open_label:n
   \__tenkz_kernel_r_port_open_label:n
 \cs_set_protected:Npn \__tenkz_kernel_r_port_open_label:n #1
   {
+    \bool_if:NF \g__tenkz_test_atoms_done_bool
+      {\errmessage{unmatched~port~label~preceded~atom~ink}}
+    \bool_if:NF \g__tenkz_test_marks_done_bool
+      {\errmessage{unmatched~port~label~preceded~mark~ink}}
     \bool_set_true:N \l__tenkz_test_in_port_label_bool
     \__tenkz_test_port_open_label:n {#1}
     \bool_set_false:N \l__tenkz_test_in_port_label_bool
@@ -318,7 +336,7 @@
       ports={0@01:virtual:$a$, 90:physical, 45:physical:$i$}]{A}
   \tn[at=(1,2), name=B, ports={180@001:virtual:$b$}]{B}
   \tnwire{A.0@01}{B.180@001}
-  \tn[skin=dot, at=on port-open-1 0.5]{}
+  \tn[skin=dot, at=on port-open-2 1]{}
 \end{tenkz}
 \begin{tenkz}[rows={wire}, cols=2, bonds=none, frame=plane]
   \tn[at=(1,1), name=P,

--- a/tests/tenkz/kernel/regression/r_unmatched_port_legs.tex
+++ b/tests/tenkz/kernel/regression/r_unmatched_port_legs.tex
@@ -314,6 +314,13 @@
     \__tenkz_test_marks:
     \bool_gset_true:N \g__tenkz_test_marks_done_bool
   }
+\cs_new_eq:NN \__tenkz_test_render: \__tenkz_kernel_render:
+\cs_set_protected:Npn \__tenkz_kernel_render:
+  {
+    \bool_gset_false:N \g__tenkz_test_atoms_done_bool
+    \bool_gset_false:N \g__tenkz_test_marks_done_bool
+    \__tenkz_test_render:
+  }
 \cs_new_eq:NN
   \__tenkz_test_port_open_label:n
   \__tenkz_kernel_r_port_open_label:n

--- a/tests/tenkz/kernel/regression/r_unmatched_port_legs.tex
+++ b/tests/tenkz/kernel/regression/r_unmatched_port_legs.tex
@@ -343,6 +343,7 @@
       ports={0@01:virtual:$a$, 90:physical, 45:physical:$i$}]{A}
   \tn[at=(1,2), name=B, ports={180@001:virtual:$b$}]{B}
   \tnwire{A.0@01}{B.180@001}
+  % Keep the visual delta on the labelled unmatched port itself.
   \tn[skin=dot, at=on port-open-2 1]{}
 \end{tenkz}
 \begin{tenkz}[rows={wire}, cols=2, bonds=none, frame=plane]

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -11451,8 +11451,6 @@
           \l__tenkz_kernel_r_sid_tl
           \l__tenkz_kernel_r_wire_ink_tl
       }
-    \seq_map_inline:Nn \l__tenkz_kernel_r_port_label_routes_seq
-      { \__tenkz_kernel_r_port_open_label:n {##1} }
   }
 
 \cs_new_protected:Npn \__tenkz_kernel_r_index_joins:
@@ -13413,6 +13411,8 @@
     % annotated owner only after every wire, pairing, atom, closure, and mark.
     \__tenkz_model_map_ids:nn {wire}
       { \__tenkz_kernel_r_wire_port_labels:n {##1} }
+    \seq_map_inline:Nn \l__tenkz_kernel_r_port_label_routes_seq
+      { \__tenkz_kernel_r_port_open_label:n {##1} }
     \endtikzpicture
   }
 


### PR DESCRIPTION
## Summary\n\n- render unmatched typed-port labels in the final label pass\n- place them after wire labels, atoms, closures, and marks\n- add a regression that fails if unmatched labels render before atom or mark ink\n\nThis is the focused follow-up to the unresolved final-pass review thread on #5191:\nhttps://github.com/LionSR/TNLean/pull/5191#discussion_r3693119788\n\n## Validation\n\n- focused XeLaTeX fixture compilation\n- visual baseline comparison: all six labels remain; the intended delta is confined to the labelled endpoint\n- scripts/tenkz_kernel_probes.sh --check\n- git diff --check\n- changed-line 100-column audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tenkz kernel render ordering for all unmatched port labels; mistakes could misplace labels or break hull-dependent geometry, but scope is localized to the final label pass with dedicated regressions.
> 
> **Overview**
> **Unmatched typed-port labels** are no longer drawn during the wire/string ink stage. The kernel still queues routes on `l__tenkz_kernel_r_port_label_routes_seq` when open legs are stroked, but **`__tenkz_kernel_r_port_open_label:n` runs only at the end of the picture**—after wire port labels on bonded wires, atoms, physical traces, and marks—so open-port label ink cannot sit under atom or mark geometry.
> 
> Regression coverage is tightened: **`r_unmatched_port_legs.tex`** hooks `__tenkz_kernel_render:` to fail if an open-port label runs before atom or mark ink; **`r_port_open_label_order.tex`** exercises a wire-carried port with a wide label and checks late hull timing, that labels use the stroked tip coordinates, and that routing happened before labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0837573c072126cb2d3a9327ca6c4cb89a2abf91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->