### PR TITLE
ci(tenkz): separate replay and current policy evidence

### DIFF
--- a/.github/workflows/tenkz-policy.yml
+++ b/.github/workflows/tenkz-policy.yml
@@ -50,6 +50,7 @@ jobs:
             test "$(git rev-parse "${oid}^{commit}")" = "$oid"
           }
 
+          python3 scripts/test_tenkz_policy_evidence.py
           python3 scripts/test_check_tenkz_policy.py
 
           if [ "$EVENT_NAME" = "pull_request" ]; then

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -415,12 +415,14 @@ follows a released sign-off.
 Each attempt has exactly one opening freeze. The audit boundary is not an entry
 field, timestamp, or caller choice: it is the final live entry in the immutable
 ledger prefix at the start of a fail-closed validation against one complete
-current GitHub/Git snapshot and exact validation target. The resolver supplies
-a closed `AuditEvidence` value containing that `boundary_entry_id`, the
-ledger-ordered `invalid_entries` not already acknowledged as defined below,
-and true `snapshot_complete` and `validation_target_exact` flags. A caller
-cannot choose or weaken those fields. The boundary must equal the actual final
-live entry in that prefix; reusing an earlier boundary is invalid.
+current GitHub/Git snapshot and exact validation target. The evidence bundle
+supplies a closed `AuditEvidence` value containing that `boundary_entry_id`,
+the exact validation-target object ID, and true `snapshot_complete` and
+`validation_target_exact` flags. The validator itself derives the
+ledger-ordered invalid-entry queue from the current snapshot; no caller
+supplies that queue. A caller cannot choose or weaken the audit fields. The
+boundary must equal the actual final live entry in that prefix; reusing an
+earlier boundary is invalid.
 
 Historical reset placement and prospective drift use separate evidence
 channels. For every merged `record-invalid` reset at or before the boundary,
@@ -462,12 +464,13 @@ restored at the canonical path. This is not a caller-selected audit boundary.
 
 A historically valid reset acknowledges its target while that reset continues
 to pass its own current common, external, and kind-specific checks. The current
-resolver forms `AuditEvidence.invalid_entries` from current raw-invalid entries
-after subtracting those acknowledged targets. If an acknowledging reset later
-fails a current check, its target is uncovered and both the target and reset
-are independently included when invalid. Historical replay never substitutes
-an earlier prefix for the current boundary, and the final `invalid_entries`
-value is not fed back into its own derivation.
+resolver supplies the facts for every live entry, and the validator forms its
+internal queue from current raw-invalid entries after subtracting those
+acknowledged targets. If an acknowledging reset later fails a current check,
+its target is uncovered and both the target and reset are independently
+included when invalid. Historical replay never substitutes an earlier prefix
+for the current boundary, and the derived queue is not fed back into its own
+derivation.
 
 When the reset queue is nonempty, the first new non-correction entry after the
 boundary is its head. If a `restart-required` reset was already pending at the

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -3156,17 +3156,23 @@ def validate_entries(
                 finally:
                     resolver = previous
 
+            replay_result: object | None = None
+            replay_error: PolicyError | None = None
             try:
                 replay_result = run(replay_resolver)
             except PolicyError as error:
-                if record_pending:
-                    raise
-                classify_replay_failure(str(error))
-                return None
+                replay_error = error
+            current_error: PolicyError | None = None
             try:
                 run(current_resolver)
             except PolicyError as error:
-                classify_snapshot_failure(str(error))
+                current_error = error
+            if replay_error is not None:
+                if record_pending:
+                    raise replay_error
+                classify_replay_failure(str(replay_error))
+            if current_error is not None:
+                classify_snapshot_failure(str(current_error))
             return replay_result
 
         if kind == "freeze":

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -2,8 +2,8 @@
 """Pure validation for the tenkz compatibility policy and 1.0 evidence log.
 
 Repository and GitHub access are deliberately injected.  This module owns the
-closed grammar, immutable-evidence contracts, and attempt state machine; a
-stacked integration layer resolves the external facts.
+closed grammar, immutable-evidence contracts, and attempt state machine; the
+evidence bundle supplies external facts.
 """
 
 from __future__ import annotations
@@ -18,6 +18,8 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Collection
+
+from tenkz_policy_evidence import PolicyEvidenceBundle, PolicyEvidenceResolver
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -630,16 +632,14 @@ class PublisherSecretEvidence:
 
 @dataclass(frozen=True)
 class AuditEvidence:
-    """Complete current-validity result and its immutable-ledger boundary.
+    """Exact current-validity snapshot and its immutable-ledger boundary.
 
-    Replay callbacks reconstruct integration-time history (or the exact final
-    unmerged candidate).  This separate channel records every entry that fails
-    the current snapshot, so later drift is queued only after the fixed audit
-    boundary and cannot block intervening history.
+    Replay derives the invalid-entry inventory from the resolver.  The boundary
+    places that ordered inventory after the immutable prefix, so current drift
+    cannot block intervening history.
     """
 
     boundary_entry_id: str | None
-    invalid_entries: tuple[str, ...] | None
     snapshot_complete: bool | None
     validation_target_exact: bool | None
     validation_target_oid: str | None
@@ -788,36 +788,6 @@ class RecordInspection:
     merged_at: datetime | None
     integration: str | None
     invalid_reasons: tuple[str, ...]
-
-
-ResolveReplayPullRequest = Callable[[str, str | None], PullRequestEvidence]
-ResolveReplayActivationDiff = Callable[[str], ActivationDiffEvidence]
-ResolveReplayRecordDiff = Callable[[str, str, str | None], RecordDiffEvidence]
-ResolveReplayWorkDiff = Callable[[str], WorkDiffEvidence]
-ResolveReplayResolutionDiff = Callable[[str], ResolutionDiffEvidence]
-ResolveReplayReleasePrep = Callable[
-    [str, str, tuple[str, ...], tuple[str, ...], tuple[str, ...]],
-    ReleasePrepEvidence,
-]
-ResolveReplayReleasePayload = Callable[[str, str, ReleaseContract], ReleasePayloadEvidence]
-ResolveReplayReleaseTestObservation = Callable[
-    [str, str, str, ReleaseContract], ReleaseTestObservationEvidence
-]
-ResolveReplayFreezeTag = Callable[[str], TagEvidence]
-ResolveCurrentFinalTag = Callable[[str], TagEvidence]
-ResolveFinalTagPublisher = Callable[[str], FinalTagPublisherEvidence]
-ResolveCurrentPublisherSecret = Callable[
-    [str, str, str, str],
-    PublisherSecretEvidence,
-]
-ResolveReplayIssue = Callable[[str], IssueEvidence]
-ResolveReplayRecordInvalidReset = Callable[
-    [str, str, str, str, str], RecordInvalidResetReplayEvidence
-]
-ResolveCurrentWorkflow = Callable[
-    [str, str, tuple[str, ...], str],
-    WorkflowEvidence,
-]
 
 
 def require(condition: bool, message: str) -> None:
@@ -2455,34 +2425,14 @@ def validate_entries(
     *,
     policy: dict = EXPECTED_POLICY,
     soak: dict = EXPECTED_SOAK,
-    resolve_replay_pr: ResolveReplayPullRequest | None = None,
-    resolve_replay_activation_diff: ResolveReplayActivationDiff | None = None,
-    resolve_replay_record_diff: ResolveReplayRecordDiff | None = None,
-    resolve_replay_work_diff: ResolveReplayWorkDiff | None = None,
-    resolve_replay_resolution_diff: ResolveReplayResolutionDiff | None = None,
-    resolve_replay_release_prep: ResolveReplayReleasePrep | None = None,
-    resolve_replay_release_payload: ResolveReplayReleasePayload | None = None,
-    resolve_replay_release_test_observation: (
-        ResolveReplayReleaseTestObservation | None
-    ) = None,
-    resolve_replay_freeze_tag: ResolveReplayFreezeTag | None = None,
-    resolve_current_final_tag: ResolveCurrentFinalTag | None = None,
-    resolve_final_tag_publisher: ResolveFinalTagPublisher | None = None,
-    resolve_current_publisher_secret: ResolveCurrentPublisherSecret | None = None,
-    resolve_replay_issue: ResolveReplayIssue | None = None,
-    resolve_replay_record_invalid_reset: ResolveReplayRecordInvalidReset | None = None,
-    resolve_current_workflow: ResolveCurrentWorkflow | None = None,
-    audit: AuditEvidence | None = None,
-    tag_protection: TagProtectionEvidence | None = None,
+    evidence: PolicyEvidenceBundle | None = None,
 ) -> str:
-    """Validate entry grammar, injected immutable facts, and attempt state.
+    """Validate entry grammar, one exact evidence snapshot, and attempt state.
 
-    Every ``resolve_replay_*`` callback supplies integration-time evidence, or
-    exact candidate evidence for the final unmerged record.  ``audit`` is the
-    separate complete current-validity snapshot, including the final entry in
-    the immutable prefix that existed when it started.  Current drift is never
-    substituted into replay callbacks; its ordered targets enter the state only
-    after that boundary.
+    The immutable resolver supplies integration-time evidence, or exact
+    candidate evidence for the final unmerged record.  The current resolver
+    derives drift from the exact snapshot and queues affected entries only
+    after that snapshot's immutable boundary.
     """
 
     (
@@ -2503,26 +2453,14 @@ def validate_entries(
     )
     if enforcement == "pending":
         require(not entries, "evidence entries require armed policy enforcement")
-        require(audit is None, "audit evidence has no entries")
+        require(evidence is None, "policy evidence has no pending entries")
         return "not-started"
-    require(
-        resolve_current_final_tag is not None,
-        "entry validation requires current final-tag evidence",
-    )
-    require(
-        resolve_final_tag_publisher is not None,
-        "entry validation requires final-tag publisher evidence",
-    )
-    require(
-        resolve_current_publisher_secret is not None,
-        "entry validation requires publisher secret evidence",
-    )
-    require(
-        resolve_replay_freeze_tag is not None,
-        "entry validation requires replay freeze-tag evidence",
-    )
-    require(tag_protection is not None, "tag-protection evidence is missing")
-    require(audit is not None, "entry validation requires complete audit evidence")
+    require(evidence is not None, "armed entry validation requires policy evidence")
+    replay_resolver = evidence.replay.resolver
+    current_resolver = evidence.current.resolver
+    resolver = replay_resolver
+    audit = evidence.current.audit
+    tag_protection = evidence.current.tag_protection
     require(audit.snapshot_complete is True, "audit snapshot is incomplete")
     require(audit.validation_target_exact is True, "audit validation target is not exact")
     validation_target_oid = audit.validation_target_oid
@@ -2538,77 +2476,9 @@ def validate_entries(
     require(len(record_refs) == len(set(record_refs)), "record_pr values must be distinct")
     record_ref_set = set(record_refs)
 
-    require(resolve_replay_pr is not None, "entry validation requires replay PR evidence")
-    require(
-        resolve_replay_activation_diff is not None,
-        "entry validation requires replay activation-diff evidence",
-    )
-    require(
-        resolve_replay_record_diff is not None,
-        "entry validation requires replay record-diff evidence",
-    )
-    require(
-        resolve_replay_work_diff is not None,
-        "entry validation requires replay work-diff evidence",
-    )
-    if any(shape[1] == "resolution" for shape in shaped):
-        require(
-            resolve_replay_resolution_diff is not None,
-            "resolution validation requires replay fix-diff evidence",
-        )
-    if any(
-        shape[1] == "friction"
-        and entry.get("triage") == "fix-compatible"
-        and bool(entry.get("regression_tests"))
-        for entry, shape in zip(entries, shaped)
-    ):
-        require(
-            resolve_replay_release_test_observation is not None,
-            "friction validation requires replay single-test evidence",
-        )
-    require(
-        resolve_replay_release_payload is not None,
-        "entry validation requires replay release-payload evidence",
-    )
-    require(
-        resolve_replay_issue is not None,
-        "entry validation requires replay issue evidence",
-    )
-    require(
-        resolve_current_workflow is not None,
-        "entry validation requires current workflow evidence",
-    )
-    if any(
-        shape[1] == "reset" and entry.get("cause") == "record-invalid"
-        for entry, shape in zip(entries, shaped)
-    ):
-        require(
-            resolve_replay_record_invalid_reset is not None,
-            "record-invalid reset validation requires historical placement evidence",
-        )
-    if any(shape[1] == "sign-off" for shape in shaped):
-        require(
-            resolve_replay_release_prep is not None,
-            "sign-off validation requires replay release-preparation evidence",
-        )
-
-    require(
-        isinstance(audit.invalid_entries, tuple)
-        and all(isinstance(item, str) for item in audit.invalid_entries),
-        "audit invalid-entry inventory is missing",
-    )
-    invalid_list = list(audit.invalid_entries)
-    invalid_set = set(invalid_list)
-    require(len(invalid_list) == len(invalid_set), "audit invalid entries contain duplicates")
     entry_ids = {shape[0] for shape in shaped}
-    require(invalid_set <= entry_ids, "record-invalid evidence names an unknown entry")
     entry_positions = {shape[0]: index for index, shape in enumerate(shaped, start=1)}
-    require(
-        invalid_list == sorted(invalid_list, key=entry_positions.__getitem__),
-        "audit invalid entries are not in ledger order",
-    )
     if audit.boundary_entry_id is None:
-        require(not invalid_list, "audit with an empty prefix names invalid entries")
         drift_boundary = 0
     else:
         require(
@@ -2616,40 +2486,10 @@ def validate_entries(
             "audit boundary is not a live entry",
         )
         drift_boundary = entry_positions[audit.boundary_entry_id]
-        require(
-            all(entry_positions[target] <= drift_boundary for target in invalid_set),
-            "audit boundary precedes an invalid target",
-        )
     require(
         drift_boundary in {len(shaped), max(0, len(shaped) - 1)},
         "audit boundary is stale rather than the actual final live prefix",
     )
-    for reset_index, (entry, shape) in enumerate(zip(entries, shaped)):
-        entry_id, kind, _attempt, _record_ref = shape
-        if kind != "reset" or entry.get("cause") != "record-invalid":
-            continue
-        if entry_id not in invalid_set:
-            continue
-        target = nonempty_string(entry.get("target"), "target", entry_id)
-        later_valid_acknowledgement = any(
-            later_shape[1] == "reset"
-            and later_entry.get("cause") == "record-invalid"
-            and later_entry.get("target") == target
-            and later_shape[0] not in invalid_set
-            for later_entry, later_shape in zip(
-                entries[reset_index + 1 :],
-                shaped[reset_index + 1 :],
-            )
-        )
-        require(
-            later_valid_acknowledgement or target in invalid_set,
-            f"{entry_id} invalid acknowledgement does not uncover {target}",
-        )
-    # The audit channel has replayed every current mutable fact.  Before tag
-    # creation, its classified drift enters the ordered reset queue.  Once any
-    # final-tag ref exists, the same drift is a hard release incident and never
-    # reopens the append-only ledger reconstructed above.
-    drift_targets = invalid_list.copy()
 
     source_ref_set = {
         pr_ref(entry["source_pr"], "source_pr", shape[0])
@@ -2728,9 +2568,9 @@ def validate_entries(
             f"release-preparation PR {release_ref} is a replay receipt PR",
         )
 
-    activation = resolve_replay_pr(activation_ref, None)
+    activation = resolver.resolve_replay_pr(activation_ref, None)
     activation_author, activation_head = validate_pr_core(activation, activation_ref)
-    activation_diff = resolve_replay_activation_diff(activation_ref)
+    activation_diff = current_resolver.resolve_replay_activation_diff(activation_ref)
     require(
         activation_diff.validated_pr_ref == activation_ref,
         "activation diff was validated on another PR",
@@ -2899,19 +2739,44 @@ def validate_entries(
         distinct_from={maintainer_login},
         authorized_permissions=reviewer_permissions,
     )
+    if current_resolver is not replay_resolver:
+        snapshot_activation = current_resolver.resolve_replay_pr(activation_ref, None)
+        snapshot_author, snapshot_head = validate_pr_core(
+            snapshot_activation,
+            activation_ref,
+        )
+        snapshot_merged_at, snapshot_integration = validate_merged_pr(
+            snapshot_activation,
+            activation_ref,
+            require_descendant=False,
+            require_tree=True,
+        )
+        require(
+            snapshot_head == activation_head
+            and snapshot_integration == activation_integration
+            and snapshot_merged_at == activation_merged_at,
+            "current activation identity differs from immutable replay",
+        )
+        require_independent_approval(
+            snapshot_activation,
+            activation_ref,
+            author=snapshot_author,
+            before=snapshot_merged_at,
+            distinct_from={maintainer_login},
+            authorized_permissions=reviewer_permissions,
+        )
 
     publisher_secret_cache: PublisherSecretEvidence | None = None
 
     def resolve_terminal_final_tag() -> TagEvidence:
-        final_tag = resolve_current_final_tag(FINAL_TAG)
+        final_tag = current_resolver.resolve_current_final_tag(FINAL_TAG)
         require(isinstance(final_tag.exists, bool), "final-tag existence is unavailable")
         return final_tag
 
     def current_publisher_secret() -> PublisherSecretEvidence:
         nonlocal publisher_secret_cache
-        assert resolve_current_publisher_secret is not None
         if publisher_secret_cache is None:
-            publisher_secret_cache = resolve_current_publisher_secret(
+            publisher_secret_cache = current_resolver.resolve_current_publisher_secret(
                 release_contract.publisher_environment,
                 release_contract.publisher_secret,
                 release_contract.publisher_secret_scope,
@@ -2920,9 +2785,8 @@ def validate_entries(
         return publisher_secret_cache
 
     def validate_pinned_current_workflow() -> None:
-        assert resolve_current_workflow is not None
         validate_workflow_evidence(
-            resolve_current_workflow(
+            current_resolver.resolve_current_workflow(
                 activation_integration,
                 validation_target_oid,
                 release_contract.enforcement_workflows,
@@ -3024,9 +2888,7 @@ def validate_entries(
         nonlocal pending_reset, current_release_attempt
         if pending_reset is not None:
             return
-        if drift_targets:
-            pending_reset = ("record-invalid", drift_targets[0])
-        elif deferred_invalid_targets:
+        if deferred_invalid_targets:
             pending_reset = ("record-invalid", deferred_invalid_targets[0])
         if pending_reset is not None:
             current_release_attempt = None
@@ -3095,8 +2957,12 @@ def validate_entries(
         if kind == "freeze":
             source_sha_for_record = sha(entry["source_sha"], "source_sha", entry_id)
             record_anchor = source_sha_for_record
-        record = resolve_replay_pr(record_ref, record_anchor)
-        diff = resolve_replay_record_diff(entry_id, record_ref, source_sha_for_record)
+        record = resolver.resolve_replay_pr(record_ref, record_anchor)
+        diff = resolver.resolve_replay_record_diff(
+            entry_id,
+            record_ref,
+            source_sha_for_record,
+        )
         inspection = inspect_record_pr(
             record,
             diff,
@@ -3108,7 +2974,68 @@ def validate_entries(
         record_pending = inspection.pending
         record_merged_at = inspection.merged_at
         record_integration = inspection.integration
-        record_invalid_reasons = list(inspection.invalid_reasons)
+        replay_invalid_reasons = list(inspection.invalid_reasons)
+        record_invalid_reasons = replay_invalid_reasons.copy()
+        snapshot_record = record
+        snapshot_diff = diff
+        snapshot_record_merged_at = record_merged_at
+
+        def classify_snapshot_failure(message: str) -> None:
+            if record_pending:
+                raise PolicyError(message)
+            if message not in record_invalid_reasons:
+                record_invalid_reasons.append(message)
+
+        def classify_replay_failure(message: str) -> None:
+            if message not in replay_invalid_reasons:
+                replay_invalid_reasons.append(message)
+            if message not in record_invalid_reasons:
+                record_invalid_reasons.append(message)
+
+        if current_resolver is not replay_resolver:
+            snapshot_record = current_resolver.resolve_replay_pr(
+                record_ref,
+                record_anchor,
+            )
+            snapshot_diff = current_resolver.resolve_replay_record_diff(
+                entry_id,
+                record_ref,
+                source_sha_for_record,
+            )
+            snapshot_inspection = inspect_record_pr(
+                snapshot_record,
+                snapshot_diff,
+                entry_id=entry_id,
+                record_ref=record_ref,
+                require_descendant=True,
+            )
+            snapshot_record_merged_at = snapshot_inspection.merged_at
+            for reason in snapshot_inspection.invalid_reasons:
+                classify_snapshot_failure(reason)
+            replay_identity = (
+                record.in_repository,
+                record.base_ref_name,
+                record.author_login,
+                record.head_oid,
+                record.merged,
+                record.merged_at,
+                record.merged_by_login,
+                record.merge_commit_oid,
+            )
+            snapshot_identity = (
+                snapshot_record.in_repository,
+                snapshot_record.base_ref_name,
+                snapshot_record.author_login,
+                snapshot_record.head_oid,
+                snapshot_record.merged,
+                snapshot_record.merged_at,
+                snapshot_record.merged_by_login,
+                snapshot_record.merge_commit_oid,
+            )
+            if snapshot_identity != replay_identity:
+                classify_snapshot_failure(
+                    f"{entry_id} current record identity differs from immutable replay"
+                )
         if index == len(entries):
             expected_boundary = index - 1 if record_pending else index
             require(
@@ -3121,12 +3048,18 @@ def validate_entries(
                     f"{entry_id} candidate audit targets another head",
                 )
 
-        def check_kind_record_fact(condition: bool, message: str) -> None:
-            if condition:
-                return
-            if record_pending:
-                raise PolicyError(message)
-            record_invalid_reasons.append(message)
+        def check_kind_record_fact(
+            condition: bool,
+            message: str,
+            snapshot_condition: bool | None = None,
+        ) -> None:
+            if not condition:
+                if record_pending:
+                    raise PolicyError(message)
+                classify_replay_failure(message)
+            current_condition = condition if snapshot_condition is None else snapshot_condition
+            if current_resolver is not replay_resolver and current_condition is not True:
+                classify_snapshot_failure(message)
 
         prior_receipts = tuple(
             (
@@ -3150,68 +3083,98 @@ def validate_entries(
             check_kind_record_fact(
                 diff.validated_prior_receipts == prior_receipts,
                 f"{entry_id} retention evidence used another prior-receipt set",
+                snapshot_diff.validated_prior_receipts == prior_receipts,
             )
             check_kind_record_fact(
                 diff.candidate_target_preserves_prior_receipts is True,
                 f"{entry_id} candidate target does not retain every prior receipt",
+                snapshot_diff.candidate_target_preserves_prior_receipts is True,
             )
             check_kind_record_fact(
                 diff.head_preserves_prior_receipts is True,
                 f"{entry_id} exact head does not retain every prior receipt",
+                snapshot_diff.head_preserves_prior_receipts is True,
             )
             check_kind_record_fact(
                 diff.entry_diff_untouched_prior_receipts is True,
                 f"{entry_id} diff changes a prior receipt path",
+                snapshot_diff.entry_diff_untouched_prior_receipts is True,
             )
             if not record_pending:
                 check_kind_record_fact(
                     diff.integration_preserves_prior_receipts is True,
                     f"{entry_id} integration does not retain every prior receipt",
+                    snapshot_diff.integration_preserves_prior_receipts is True,
                 )
 
         if kind == "freeze":
             check_kind_record_fact(
                 diff.source_to_head_is_exact_freeze_append is True,
                 f"{entry_id} source-to-head diff is not exactly the freeze append",
+                snapshot_diff.source_to_head_is_exact_freeze_append is True,
             )
             check_kind_record_fact(
                 diff.candidate_main_tip_is_source is True,
                 f"{entry_id} candidate main tip differs from source_sha",
+                snapshot_diff.candidate_main_tip_is_source is True,
             )
             if not record_pending:
                 check_kind_record_fact(
                     diff.integration_parent_is_source is True,
                     f"{entry_id} integration parent differs from source_sha",
+                    snapshot_diff.integration_parent_is_source is True,
                 )
         if kind == "sign-off":
             check_kind_record_fact(
                 diff.candidate_main_tip_is_release_integration is True,
                 f"{entry_id} candidate main tip differs from release integration",
+                snapshot_diff.candidate_main_tip_is_release_integration is True,
             )
             if not record_pending:
                 check_kind_record_fact(
                     diff.integration_parent_is_release_integration is True,
                     f"{entry_id} integration parent differs from release integration",
+                    snapshot_diff.integration_parent_is_release_integration is True,
                 )
         if record_pending:
             require(index == len(entries), f"{entry_id} unmerged record is not the final entry")
 
         def entry_is_invalid() -> bool:
             # Resolver failures are current mutable drift or intrinsic
-            # immutable-fact failures.  The audit inventory independently
-            # schedules them in ledger order at its immutable boundary.
+            # immutable-fact failures.  Replay schedules them in ledger order
+            # after the audit boundary.
             return bool(record_invalid_reasons)
 
+        def replay_entry_is_invalid() -> bool:
+            return bool(replay_invalid_reasons)
+
         def check_external(action: Callable[[], object]) -> object | None:
-            """Turn a merged entry's drifted external fact into reset state."""
+            """Replay immutable facts, then classify the exact current snapshot."""
+
+            nonlocal resolver
+
+            def run(selected: PolicyEvidenceResolver) -> object:
+                nonlocal resolver
+                previous = resolver
+                resolver = selected
+                try:
+                    return action()
+                finally:
+                    resolver = previous
 
             try:
-                return action()
+                replay_result = run(replay_resolver)
             except PolicyError as error:
                 if record_pending:
                     raise
-                record_invalid_reasons.append(str(error))
+                classify_replay_failure(str(error))
                 return None
+            if current_resolver is not replay_resolver:
+                try:
+                    run(current_resolver)
+                except PolicyError as error:
+                    classify_snapshot_failure(str(error))
+            return replay_result
 
         if kind == "freeze":
             source_ref = pr_ref(entry["source_pr"], "source_pr", entry_id)
@@ -3256,7 +3219,7 @@ def validate_entries(
             nonempty_string(entry["evidence"], "evidence", entry_id)
 
             def freeze_external_facts() -> tuple[list[IssueEvidence], tuple[str, ...]]:
-                source = resolve_replay_pr(source_ref, source_anchor)
+                source = resolver.resolve_replay_pr(source_ref, source_anchor)
                 source_author, _source_head = validate_pr_core(source, source_ref)
                 source_time, source_integration = validate_merged_pr(
                     source,
@@ -3275,7 +3238,7 @@ def validate_entries(
                     source_integration == source_sha,
                     f"{entry_id} source SHA differs from source PR",
                 )
-                tag = resolve_replay_freeze_tag(tag_name)
+                tag = resolver.resolve_replay_freeze_tag(tag_name)
                 require(tag.exists is True, f"{entry_id} freeze tag is missing")
                 require(tag.object_type == "tag", f"{entry_id} freeze tag is not annotated")
                 require(
@@ -3317,7 +3280,11 @@ def validate_entries(
                         f"{entry_id} current tag namespace lost a retained name",
                     )
                 payload_blobs = validate_release_payload(
-                    resolve_replay_release_payload(source_sha, tag_name, release_contract),
+                    resolver.resolve_replay_release_payload(
+                        source_sha,
+                        tag_name,
+                        release_contract,
+                    ),
                     tree_oid=source_sha,
                     tag=tag_name,
                     contract=release_contract,
@@ -3325,7 +3292,7 @@ def validate_entries(
                 )
                 facts: list[IssueEvidence] = []
                 for item in listed:
-                    fact = resolve_replay_issue(item)
+                    fact = resolver.resolve_replay_issue(item)
                     require(
                         fact.in_repository is True,
                         f"{entry_id} prerequisite {item} is external",
@@ -3356,7 +3323,7 @@ def validate_entries(
                     state="freeze-pending",
                 )
                 break
-            if not entry_is_invalid():
+            if not replay_entry_is_invalid():
                 assert record_merged_at is not None and record_integration is not None
 
                 def check_prerequisite_times() -> None:
@@ -3377,7 +3344,7 @@ def validate_entries(
                 "source_sha": source_sha,
                 "freeze_tag": tag_name,
                 "freeze_time": record_merged_at,
-                "freeze_valid": not entry_is_invalid(),
+                "freeze_valid": not replay_entry_is_invalid(),
                 "freeze_integration": record_integration or source_sha,
                 "freeze_payload_blobs": freeze_payload_blobs,
                 "work": {},
@@ -3401,7 +3368,10 @@ def validate_entries(
             nonempty_string(entry["evidence"], "evidence", entry_id)
 
             def work_external_facts() -> tuple[datetime, str]:
-                work_pr = resolve_replay_pr(work_ref, active["freeze_integration"])
+                work_pr = resolver.resolve_replay_pr(
+                    work_ref,
+                    active["freeze_integration"],
+                )
                 work_author, work_head = validate_pr_core(work_pr, work_ref)
                 work_merged_at, work_integration = validate_merged_pr(
                     work_pr,
@@ -3426,7 +3396,7 @@ def validate_entries(
                     before=work_merged_at,
                     authorized_permissions=reviewer_permissions,
                 )
-                work_diff = resolve_replay_work_diff(work_ref)
+                work_diff = resolver.resolve_replay_work_diff(work_ref)
                 require(
                     work_diff.validated_pr_ref == work_ref,
                     f"{entry_id} work diff was validated on another PR",
@@ -3549,16 +3519,16 @@ def validate_entries(
                     state="work-pending",
                 )
                 break
-            if not entry_is_invalid():
-                assert isinstance(work_result, tuple)
+            if isinstance(work_result, tuple) and not replay_entry_is_invalid():
                 work_merged_at, work_integration = work_result
                 assert record_merged_at is not None
                 check_kind_record_fact(
                     record_merged_at > work_merged_at,
                     f"{entry_id} evidence record did not merge after its work PR",
+                    snapshot_record_merged_at is not None
+                    and snapshot_record_merged_at > work_merged_at,
                 )
-            if not entry_is_invalid():
-                assert isinstance(work_result, tuple)
+            if isinstance(work_result, tuple) and not replay_entry_is_invalid():
                 work_merged_at, work_integration = work_result
                 active["work"][work_class] = {
                     "entry_id": entry_id,
@@ -3596,7 +3566,6 @@ def validate_entries(
             def friction_observation_facts() -> dict[str, dict[str, object]]:
                 if not regression_tests:
                     return {}
-                assert resolve_replay_release_test_observation is not None
                 record_head = record.head_oid
                 assert isinstance(record_head, str)
                 observations: dict[str, dict[str, object]] = {}
@@ -3611,7 +3580,7 @@ def validate_entries(
                         expected_test = expected.get(test_ref) if expected is not None else None
                         fingerprint, program_paths, fixture_paths = (
                             validate_release_test_observation(
-                            resolve_replay_release_test_observation(
+                            resolver.resolve_replay_release_test_observation(
                                 tree_oid,
                                 active["freeze_tag"],
                                 test_ref,
@@ -3660,8 +3629,12 @@ def validate_entries(
                     state="friction-pending",
                 )
                 break
-            if not entry_is_invalid():
-                assert record_merged_at is not None and record_integration is not None
+            if (
+                isinstance(friction_result, dict)
+                and not replay_entry_is_invalid()
+                and record_merged_at is not None
+                and record_integration is not None
+            ):
                 active["friction"][entry_id] = {
                     "surface": surface,
                     "triage": triage,
@@ -3687,8 +3660,10 @@ def validate_entries(
             nonempty_string(entry["evidence"], "evidence", entry_id)
 
             def resolution_external_facts() -> tuple[datetime, str]:
-                assert resolve_replay_resolution_diff is not None
-                fix_pr = resolve_replay_pr(fix_ref, active["freeze_integration"])
+                fix_pr = resolver.resolve_replay_pr(
+                    fix_ref,
+                    active["freeze_integration"],
+                )
                 fix_author, fix_head = validate_pr_core(fix_pr, fix_ref)
                 fix_merged_at, fix_integration = validate_merged_pr(
                     fix_pr,
@@ -3707,7 +3682,7 @@ def validate_entries(
                     before=fix_merged_at,
                     authorized_permissions=reviewer_permissions,
                 )
-                fix_diff = resolve_replay_resolution_diff(fix_ref)
+                fix_diff = resolver.resolve_replay_resolution_diff(fix_ref)
                 require(
                     fix_diff.validated_pr_ref == fix_ref,
                     f"{entry_id} fix diff was validated on another PR",
@@ -3858,14 +3833,13 @@ def validate_entries(
                     fix_diff.freeze_manifest_blob_identical is True,
                     f"{entry_id} fix changes the active-freeze manifest identity",
                 )
-                assert resolve_replay_release_test_observation is not None
                 for test_ref in regression_tests:
                     inventory_fact = test_facts[test_ref]
                     assert isinstance(inventory_fact, dict)
                     fingerprint = str(inventory_fact["fingerprint"])
                     base_fingerprint, base_programs, base_fixtures = (
                         validate_release_test_observation(
-                        resolve_replay_release_test_observation(
+                        resolver.resolve_replay_release_test_observation(
                             fix_base,
                             active["freeze_tag"],
                             test_ref,
@@ -3883,7 +3857,7 @@ def validate_entries(
                     )
                     head_fingerprint, head_programs, head_fixtures = (
                         validate_release_test_observation(
-                        resolve_replay_release_test_observation(
+                        resolver.resolve_replay_release_test_observation(
                             fix_head,
                             active["freeze_tag"],
                             test_ref,
@@ -3901,7 +3875,7 @@ def validate_entries(
                     )
                     integration_fingerprint, integration_programs, integration_fixtures = (
                         validate_release_test_observation(
-                            resolve_replay_release_test_observation(
+                            resolver.resolve_replay_release_test_observation(
                                 fix_integration,
                                 active["freeze_tag"],
                                 test_ref,
@@ -3939,7 +3913,7 @@ def validate_entries(
                         f"{entry_id} test {test_ref} changed its declared fixture roles",
                     )
                 head_payload_blobs = validate_release_payload(
-                    resolve_replay_release_payload(
+                    resolver.resolve_replay_release_payload(
                         fix_head,
                         active["freeze_tag"],
                         release_contract,
@@ -3950,7 +3924,7 @@ def validate_entries(
                     subject=f"{entry_id} fix head",
                 )
                 integration_payload_blobs = validate_release_payload(
-                    resolve_replay_release_payload(
+                    resolver.resolve_replay_release_payload(
                         fix_integration,
                         active["freeze_tag"],
                         release_contract,
@@ -3972,20 +3946,25 @@ def validate_entries(
                 check_kind_record_fact(
                     diff.validated_fix_integration == fix_integration,
                     f"{entry_id} resolution record used another fix integration",
+                    snapshot_diff.validated_fix_integration == fix_integration,
                 )
                 check_kind_record_fact(
                     diff.candidate_main_tip_descends_from_fix_integration is True,
                     f"{entry_id} resolution candidate does not descend from its fix",
+                    snapshot_diff.candidate_main_tip_descends_from_fix_integration is True,
                 )
                 if not record_pending:
                     check_kind_record_fact(
                         diff.integration_parent_descends_from_fix_integration is True,
                         f"{entry_id} resolution integration parent does not descend from its fix",
+                        snapshot_diff.integration_parent_descends_from_fix_integration is True,
                     )
                     assert record_merged_at is not None
                     check_kind_record_fact(
                         record_merged_at > fix_merged_at,
                         f"{entry_id} resolution record did not merge after its fix PR",
+                        snapshot_record_merged_at is not None
+                        and snapshot_record_merged_at > fix_merged_at,
                     )
             if record_pending:
                 open_pending_release_attempt(
@@ -3993,9 +3972,12 @@ def validate_entries(
                     state="resolution-pending",
                 )
                 break
-            if not entry_is_invalid():
-                assert record_integration is not None
-                assert record_merged_at is not None
+            if (
+                isinstance(resolution_result, tuple)
+                and not replay_entry_is_invalid()
+                and record_integration is not None
+                and record_merged_at is not None
+            ):
                 fact["resolved"] = True
                 fact["resolution_integration"] = record_integration
                 fact["resolution_merged_at"] = record_merged_at
@@ -4012,7 +3994,6 @@ def validate_entries(
                 )
             historical_record_reset = cause == "record-invalid" and index <= drift_boundary
             if cause == "record-invalid":
-                assert resolve_replay_record_invalid_reset is not None
                 receipt_ref = pr_ref(entry["replay_receipt_pr"], "replay_receipt_pr", entry_id)
                 receipt_digest = sha256(
                     entry["replay_receipt_sha256"],
@@ -4021,7 +4002,10 @@ def validate_entries(
                 )
 
                 def replay_receipt_facts() -> tuple[list[str], str | None, str]:
-                    receipt_pr = resolve_replay_pr(receipt_ref, last_record_integration)
+                    receipt_pr = resolver.resolve_replay_pr(
+                        receipt_ref,
+                        last_record_integration,
+                    )
                     receipt_author, receipt_head = validate_pr_core(receipt_pr, receipt_ref)
                     receipt_time, receipt_integration = validate_merged_pr(
                         receipt_pr,
@@ -4053,7 +4037,7 @@ def validate_entries(
                         and receipt_time > last_ledger_record_merged_at,
                         f"{entry_id} receipt PR did not merge after its ledger boundary",
                     )
-                    replay = resolve_replay_record_invalid_reset(
+                    replay = resolver.resolve_replay_record_invalid_reset(
                         entry_id,
                         target,
                         receipt_ref,
@@ -4189,23 +4173,29 @@ def validate_entries(
                     check_kind_record_fact(
                         diff.validated_receipt_integration == receipt_integration,
                         f"{entry_id} record diff used another receipt integration",
+                        snapshot_diff.validated_receipt_integration == receipt_integration,
                     )
                     check_kind_record_fact(
                         diff.candidate_main_tip_is_receipt_integration is True,
                         f"{entry_id} candidate base differs from receipt integration",
+                        snapshot_diff.candidate_main_tip_is_receipt_integration is True,
                     )
                     check_kind_record_fact(
                         diff.receipt_blob_preserved_from_candidate_base_to_head is True,
                         f"{entry_id} reset head does not preserve its receipt blob",
+                        snapshot_diff.receipt_blob_preserved_from_candidate_base_to_head
+                        is True,
                     )
                     if not record_pending:
                         check_kind_record_fact(
                             diff.integration_parent_is_receipt_integration is True,
                             f"{entry_id} integration parent differs from receipt integration",
+                            snapshot_diff.integration_parent_is_receipt_integration is True,
                         )
                         check_kind_record_fact(
                             diff.receipt_blob_preserved_in_integration is True,
                             f"{entry_id} reset integration does not preserve its receipt blob",
+                            snapshot_diff.receipt_blob_preserved_in_integration is True,
                         )
                     receipt_required = (
                         ("restart-required", restart_target)
@@ -4235,10 +4225,8 @@ def validate_entries(
                     state="reset-pending",
                 )
                 break
-            if not entry_is_invalid():
+            if not replay_entry_is_invalid():
                 if cause == "record-invalid":
-                    if drift_targets and target == drift_targets[0]:
-                        drift_targets.pop(0)
                     if target in deferred_invalid_targets:
                         deferred_invalid_targets.remove(target)
                 pending_reset = None
@@ -4323,12 +4311,13 @@ def validate_entries(
                 "release_prep_pr",
                 entry_id,
             )
-            assert resolve_replay_release_prep is not None
-
             release_paths = release_contract.release_varying_paths(FINAL_TAG)
 
             def release_external_facts() -> tuple[datetime, str, tuple[str, ...]]:
-                release_pr = resolve_replay_pr(release_ref, active["freeze_integration"])
+                release_pr = resolver.resolve_replay_pr(
+                    release_ref,
+                    active["freeze_integration"],
+                )
                 release_author, release_head = validate_pr_core(release_pr, release_ref)
                 release_merged_at, release_integration = validate_merged_pr(
                     release_pr,
@@ -4347,7 +4336,7 @@ def validate_entries(
                     before=release_merged_at,
                     authorized_permissions=reviewer_permissions,
                 )
-                release = resolve_replay_release_prep(
+                release = resolver.resolve_replay_release_prep(
                     release_ref,
                     release_integration,
                     release_paths,
@@ -4413,7 +4402,11 @@ def validate_entries(
                     f"{entry_id} release diff is not exactly the policy-owned payload",
                 )
                 payload_blobs = validate_release_payload(
-                    resolve_replay_release_payload(release_head, FINAL_TAG, release_contract),
+                    resolver.resolve_replay_release_payload(
+                        release_head,
+                        FINAL_TAG,
+                        release_contract,
+                    ),
                     tree_oid=release_head,
                     tag=FINAL_TAG,
                     contract=release_contract,
@@ -4430,16 +4423,18 @@ def validate_entries(
                 check_kind_record_fact(
                     diff.validated_release_integration == release_integration,
                     f"{entry_id} ancestry used another release integration",
+                    snapshot_diff.validated_release_integration == release_integration,
                 )
                 check_kind_record_fact(
                     diff.validated_work_integrations == work_integrations,
                     f"{entry_id} ancestry used other work integrations",
+                    snapshot_diff.validated_work_integrations == work_integrations,
                 )
 
                 def signoff_payload_facts() -> None:
                     assert isinstance(record.head_oid, str)
                     head_blobs = validate_release_payload(
-                        resolve_replay_release_payload(
+                        resolver.resolve_replay_release_payload(
                             record.head_oid,
                             FINAL_TAG,
                             release_contract,
@@ -4464,7 +4459,7 @@ def validate_entries(
                     reviewer != record_author,
                     f"{entry_id} reviewer must differ from record author",
                 )
-            if not entry_is_invalid():
+            if not replay_entry_is_invalid():
                 assert release_merged_at is not None
                 before = record_merged_at if not record_pending else None
                 check_external(
@@ -4486,7 +4481,7 @@ def validate_entries(
                     state="sign-off-pending",
                 )
                 break
-            if not entry_is_invalid():
+            if not replay_entry_is_invalid():
                 def signoff_postmerge_facts() -> None:
                     assert (
                         record_merged_at is not None
@@ -4506,7 +4501,7 @@ def validate_entries(
                         f"{entry_id} was not merged by github:{maintainer_login}",
                     )
                     integration_blobs = validate_release_payload(
-                        resolve_replay_release_payload(
+                        resolver.resolve_replay_release_payload(
                             record_integration,
                             FINAL_TAG,
                             release_contract,
@@ -4522,7 +4517,7 @@ def validate_entries(
                     )
 
                 check_external(signoff_postmerge_facts)
-                if not entry_is_invalid():
+                if not replay_entry_is_invalid():
                     assert (
                         record_integration is not None
                         and release_integration is not None
@@ -4542,7 +4537,7 @@ def validate_entries(
                     )
                     release_attempts.append(current_release_attempt)
 
-        if record_integration is not None and not entry_is_invalid():
+        if record_integration is not None and not replay_entry_is_invalid():
             last_record_integration = record_integration
         if record_merged_at is not None:
             last_ledger_record_merged_at = record_merged_at
@@ -4552,10 +4547,7 @@ def validate_entries(
             require(not record_pending, f"{entry_id} cannot be invalid before merge")
             if kind == "reset" and entry.get("cause") == "record-invalid":
                 uncovered_target = nonempty_string(entry["target"], "target", entry_id)
-                if (
-                    uncovered_target not in drift_targets
-                    and uncovered_target not in deferred_invalid_targets
-                ):
+                if uncovered_target not in deferred_invalid_targets:
                     deferred_invalid_targets.append(uncovered_target)
             if entry_id not in deferred_invalid_targets:
                 deferred_invalid_targets.append(entry_id)
@@ -4578,8 +4570,9 @@ def validate_entries(
         if signoff is None:
             audited_release_attempts.append(release_attempt)
             continue
-        assert resolve_final_tag_publisher is not None
-        publisher_evidence = resolve_final_tag_publisher(signoff.integration_oid)
+        publisher_evidence = current_resolver.resolve_final_tag_publisher(
+            signoff.integration_oid
+        )
         current_prefix_boundary = audit.boundary_entry_id
         require(
             isinstance(current_prefix_boundary, str),

--- a/scripts/check_tenkz_policy.py
+++ b/scripts/check_tenkz_policy.py
@@ -2568,7 +2568,7 @@ def validate_entries(
             f"release-preparation PR {release_ref} is a replay receipt PR",
         )
 
-    activation = resolver.resolve_replay_pr(activation_ref, None)
+    activation = replay_resolver.resolve_replay_pr(activation_ref, None)
     activation_author, activation_head = validate_pr_core(activation, activation_ref)
     activation_diff = current_resolver.resolve_replay_activation_diff(activation_ref)
     require(
@@ -2739,32 +2739,31 @@ def validate_entries(
         distinct_from={maintainer_login},
         authorized_permissions=reviewer_permissions,
     )
-    if current_resolver is not replay_resolver:
-        snapshot_activation = current_resolver.resolve_replay_pr(activation_ref, None)
-        snapshot_author, snapshot_head = validate_pr_core(
-            snapshot_activation,
-            activation_ref,
-        )
-        snapshot_merged_at, snapshot_integration = validate_merged_pr(
-            snapshot_activation,
-            activation_ref,
-            require_descendant=False,
-            require_tree=True,
-        )
-        require(
-            snapshot_head == activation_head
-            and snapshot_integration == activation_integration
-            and snapshot_merged_at == activation_merged_at,
-            "current activation identity differs from immutable replay",
-        )
-        require_independent_approval(
-            snapshot_activation,
-            activation_ref,
-            author=snapshot_author,
-            before=snapshot_merged_at,
-            distinct_from={maintainer_login},
-            authorized_permissions=reviewer_permissions,
-        )
+    snapshot_activation = current_resolver.resolve_replay_pr(activation_ref, None)
+    snapshot_author, snapshot_head = validate_pr_core(
+        snapshot_activation,
+        activation_ref,
+    )
+    snapshot_merged_at, snapshot_integration = validate_merged_pr(
+        snapshot_activation,
+        activation_ref,
+        require_descendant=False,
+        require_tree=True,
+    )
+    require(
+        snapshot_head == activation_head
+        and snapshot_integration == activation_integration
+        and snapshot_merged_at == activation_merged_at,
+        "current activation identity differs from immutable replay",
+    )
+    require_independent_approval(
+        snapshot_activation,
+        activation_ref,
+        author=snapshot_author,
+        before=snapshot_merged_at,
+        distinct_from={maintainer_login},
+        authorized_permissions=reviewer_permissions,
+    )
 
     publisher_secret_cache: PublisherSecretEvidence | None = None
 
@@ -2957,8 +2956,8 @@ def validate_entries(
         if kind == "freeze":
             source_sha_for_record = sha(entry["source_sha"], "source_sha", entry_id)
             record_anchor = source_sha_for_record
-        record = resolver.resolve_replay_pr(record_ref, record_anchor)
-        diff = resolver.resolve_replay_record_diff(
+        record = replay_resolver.resolve_replay_pr(record_ref, record_anchor)
+        diff = replay_resolver.resolve_replay_record_diff(
             entry_id,
             record_ref,
             source_sha_for_record,
@@ -2976,10 +2975,6 @@ def validate_entries(
         record_integration = inspection.integration
         replay_invalid_reasons = list(inspection.invalid_reasons)
         record_invalid_reasons = replay_invalid_reasons.copy()
-        snapshot_record = record
-        snapshot_diff = diff
-        snapshot_record_merged_at = record_merged_at
-
         def classify_snapshot_failure(message: str) -> None:
             if record_pending:
                 raise PolicyError(message)
@@ -2992,50 +2987,49 @@ def validate_entries(
             if message not in record_invalid_reasons:
                 record_invalid_reasons.append(message)
 
-        if current_resolver is not replay_resolver:
-            snapshot_record = current_resolver.resolve_replay_pr(
-                record_ref,
-                record_anchor,
+        snapshot_record = current_resolver.resolve_replay_pr(
+            record_ref,
+            record_anchor,
+        )
+        snapshot_diff = current_resolver.resolve_replay_record_diff(
+            entry_id,
+            record_ref,
+            source_sha_for_record,
+        )
+        snapshot_inspection = inspect_record_pr(
+            snapshot_record,
+            snapshot_diff,
+            entry_id=entry_id,
+            record_ref=record_ref,
+            require_descendant=True,
+        )
+        snapshot_record_merged_at = snapshot_inspection.merged_at
+        for reason in snapshot_inspection.invalid_reasons:
+            classify_snapshot_failure(reason)
+        replay_identity = (
+            record.in_repository,
+            record.base_ref_name,
+            record.author_login,
+            record.head_oid,
+            record.merged,
+            record.merged_at,
+            record.merged_by_login,
+            record.merge_commit_oid,
+        )
+        snapshot_identity = (
+            snapshot_record.in_repository,
+            snapshot_record.base_ref_name,
+            snapshot_record.author_login,
+            snapshot_record.head_oid,
+            snapshot_record.merged,
+            snapshot_record.merged_at,
+            snapshot_record.merged_by_login,
+            snapshot_record.merge_commit_oid,
+        )
+        if snapshot_identity != replay_identity:
+            classify_snapshot_failure(
+                f"{entry_id} current record identity differs from immutable replay"
             )
-            snapshot_diff = current_resolver.resolve_replay_record_diff(
-                entry_id,
-                record_ref,
-                source_sha_for_record,
-            )
-            snapshot_inspection = inspect_record_pr(
-                snapshot_record,
-                snapshot_diff,
-                entry_id=entry_id,
-                record_ref=record_ref,
-                require_descendant=True,
-            )
-            snapshot_record_merged_at = snapshot_inspection.merged_at
-            for reason in snapshot_inspection.invalid_reasons:
-                classify_snapshot_failure(reason)
-            replay_identity = (
-                record.in_repository,
-                record.base_ref_name,
-                record.author_login,
-                record.head_oid,
-                record.merged,
-                record.merged_at,
-                record.merged_by_login,
-                record.merge_commit_oid,
-            )
-            snapshot_identity = (
-                snapshot_record.in_repository,
-                snapshot_record.base_ref_name,
-                snapshot_record.author_login,
-                snapshot_record.head_oid,
-                snapshot_record.merged,
-                snapshot_record.merged_at,
-                snapshot_record.merged_by_login,
-                snapshot_record.merge_commit_oid,
-            )
-            if snapshot_identity != replay_identity:
-                classify_snapshot_failure(
-                    f"{entry_id} current record identity differs from immutable replay"
-                )
         if index == len(entries):
             expected_boundary = index - 1 if record_pending else index
             require(
@@ -3058,7 +3052,7 @@ def validate_entries(
                     raise PolicyError(message)
                 classify_replay_failure(message)
             current_condition = condition if snapshot_condition is None else snapshot_condition
-            if current_resolver is not replay_resolver and current_condition is not True:
+            if current_condition is not True:
                 classify_snapshot_failure(message)
 
         prior_receipts = tuple(
@@ -3169,11 +3163,10 @@ def validate_entries(
                     raise
                 classify_replay_failure(str(error))
                 return None
-            if current_resolver is not replay_resolver:
-                try:
-                    run(current_resolver)
-                except PolicyError as error:
-                    classify_snapshot_failure(str(error))
+            try:
+                run(current_resolver)
+            except PolicyError as error:
+                classify_snapshot_failure(str(error))
             return replay_result
 
         if kind == "freeze":
@@ -3301,16 +3294,19 @@ def validate_entries(
                         fact.closed is True,
                         f"{entry_id} prerequisite {item} is not closed",
                     )
-                    utc_instant(fact.closed_at, f"{entry_id} prerequisite {item} closedAt")
+                    closed_at = utc_instant(
+                        fact.closed_at,
+                        f"{entry_id} prerequisite {item} closedAt",
+                    )
+                    if record_merged_at is not None:
+                        require(
+                            closed_at <= record_merged_at,
+                            f"{entry_id} prerequisite {item} closed after T",
+                        )
                     facts.append(fact)
                 return facts, payload_blobs
 
             freeze_result = check_external(freeze_external_facts)
-            prerequisite_facts = (
-                freeze_result[0]
-                if isinstance(freeze_result, tuple)
-                else []
-            )
             freeze_payload_blobs = (
                 freeze_result[1]
                 if isinstance(freeze_result, tuple)
@@ -3325,19 +3321,6 @@ def validate_entries(
                 break
             if not replay_entry_is_invalid():
                 assert record_merged_at is not None and record_integration is not None
-
-                def check_prerequisite_times() -> None:
-                    for item, fact in zip(listed, prerequisite_facts):
-                        closed_at = utc_instant(
-                            fact.closed_at,
-                            f"{entry_id} prerequisite {item} closedAt",
-                        )
-                        require(
-                            closed_at <= record_merged_at,
-                            f"{entry_id} prerequisite {item} closed after T",
-                        )
-
-                check_external(check_prerequisite_times)
             active = {
                 "attempt": attempt,
                 "freeze_id": entry_id,
@@ -4462,18 +4445,27 @@ def validate_entries(
             if not replay_entry_is_invalid():
                 assert release_merged_at is not None
                 before = record_merged_at if not record_pending else None
-                check_external(
-                    lambda: require_independent_approval(
-                        record,
+                def signoff_approval_facts() -> None:
+                    approval_record = resolver.resolve_replay_pr(
                         record_ref,
-                        author=record_author,
+                        record_anchor,
+                    )
+                    approval_author, _approval_head = validate_pr_core(
+                        approval_record,
+                        record_ref,
+                    )
+                    require_independent_approval(
+                        approval_record,
+                        record_ref,
+                        author=approval_author,
                         after=max(latest_work_merge, release_merged_at),
                         before=before,
                         named_reviewer=reviewer,
                         distinct_from={maintainer_login},
                         authorized_permissions=reviewer_permissions,
                     )
-                )
+
+                check_external(signoff_approval_facts)
             require(pending_reset is None, f"{entry_id} cannot sign off before reset")
             if record_pending:
                 open_pending_release_attempt(

--- a/scripts/tenkz_policy_evidence.py
+++ b/scripts/tenkz_policy_evidence.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Typed inputs and raw REST transport for tenkz policy evidence.
+
+The policy checker consumes one :class:`PolicyEvidenceBundle`.  One resolver
+reconstructs immutable history; a second resolver is bound to the exact current
+snapshot.  Either resolver may report that a fact is unavailable, but neither
+may replace that fact with a default.
+
+This module also fixes the raw GitHub transport contract used by later live
+resolvers: REST responses only, 100 records per page, and complete ``Link``
+pagination.  It deliberately does not interpret release or supervisor facts.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Literal,
+    Mapping,
+    Protocol,
+    runtime_checkable,
+)
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+if TYPE_CHECKING:
+    from check_tenkz_policy import (
+        ActivationDiffEvidence,
+        AuditEvidence,
+        FinalTagPublisherEvidence,
+        IssueEvidence,
+        PublisherSecretEvidence,
+        PullRequestEvidence,
+        RecordDiffEvidence,
+        RecordInvalidResetReplayEvidence,
+        ReleaseContract,
+        ReleasePayloadEvidence,
+        ReleasePrepEvidence,
+        ReleaseTestObservationEvidence,
+        ResolutionDiffEvidence,
+        TagEvidence,
+        TagProtectionEvidence,
+        WorkflowEvidence,
+        WorkDiffEvidence,
+    )
+
+
+EVIDENCE_API_VERSION = 1
+GITHUB_REST_API_VERSION = "2022-11-28"
+GITHUB_JSON_MEDIA_TYPE = "application/vnd.github+json"
+REST_PAGE_SIZE = 100
+
+
+class EvidenceContractError(ValueError):
+    """The raw response or in-memory evidence contract is malformed."""
+
+
+class EvidenceUnavailable(ValueError):
+    """A required fact was not collected by this resolver."""
+
+
+@dataclass(frozen=True)
+class RestResponse:
+    """One raw REST response before policy-specific interpretation."""
+
+    status: int
+    headers: Mapping[str, str]
+    body: bytes
+
+
+RestRequest = Callable[[str, Mapping[str, str]], RestResponse]
+
+
+def _with_page_size(url: str) -> str:
+    """Set the closed REST page size without changing the other query fields."""
+
+    split = urlsplit(url)
+    query = [
+        (key, value)
+        for key, value in parse_qsl(split.query, keep_blank_values=True)
+        if key != "per_page"
+    ]
+    query.append(("per_page", str(REST_PAGE_SIZE)))
+    return urlunsplit(
+        (split.scheme, split.netloc, split.path, urlencode(query), split.fragment)
+    )
+
+
+def _next_link(headers: Mapping[str, str]) -> str | None:
+    """Read the unique ``rel=next`` target from a GitHub ``Link`` header."""
+
+    raw = next((value for key, value in headers.items() if key.lower() == "link"), None)
+    if raw is None:
+        return None
+    targets: list[str] = []
+    for item in raw.split(","):
+        parts = [part.strip() for part in item.split(";")]
+        if not parts or not (parts[0].startswith("<") and parts[0].endswith(">")):
+            raise EvidenceContractError(
+                "GitHub Link header contains a malformed target"
+            )
+        relations = {
+            relation
+            for part in parts[1:]
+            if part.startswith('rel="') and part.endswith('"')
+            for relation in part.removeprefix("rel=").strip('"').split()
+        }
+        if "next" in relations:
+            targets.append(parts[0][1:-1])
+    if len(targets) > 1:
+        raise EvidenceContractError("GitHub Link header contains multiple next targets")
+    return targets[0] if targets else None
+
+
+class GitHubRestApiV1:
+    """Strict raw GitHub REST reader with complete fixed-size pagination."""
+
+    def __init__(self, request: RestRequest) -> None:
+        self._request = request
+
+    @staticmethod
+    def headers() -> Mapping[str, str]:
+        return {
+            "Accept": GITHUB_JSON_MEDIA_TYPE,
+            "X-GitHub-Api-Version": GITHUB_REST_API_VERSION,
+        }
+
+    def object(self, url: str) -> Mapping[str, object]:
+        """Return one JSON object, rejecting partial or differently shaped replies."""
+
+        response = self._request(url, self.headers())
+        value = self._decode_success(response)
+        if not isinstance(value, dict) or not all(
+            isinstance(key, str) for key in value
+        ):
+            raise EvidenceContractError("GitHub REST object response is not an object")
+        return value
+
+    def pages(self, url: str) -> tuple[Mapping[str, object], ...]:
+        """Read every page of a list endpoint in server order."""
+
+        current = _with_page_size(url)
+        seen: set[str] = set()
+        records: list[Mapping[str, object]] = []
+        while current is not None:
+            if current in seen:
+                raise EvidenceContractError("GitHub REST pagination contains a cycle")
+            seen.add(current)
+            response = self._request(current, self.headers())
+            value = self._decode_success(response)
+            if not isinstance(value, list):
+                raise EvidenceContractError(
+                    "GitHub REST paginated response is not a list"
+                )
+            for item in value:
+                if not isinstance(item, dict) or not all(
+                    isinstance(key, str) for key in item
+                ):
+                    raise EvidenceContractError(
+                        "GitHub REST paginated response contains a non-object"
+                    )
+                records.append(item)
+            next_url = _next_link(response.headers)
+            current = _with_page_size(next_url) if next_url is not None else None
+        return tuple(records)
+
+    @staticmethod
+    def _decode_success(response: RestResponse) -> object:
+        if (
+            not isinstance(response.status, int)
+            or isinstance(response.status, bool)
+            or not 200 <= response.status < 300
+        ):
+            raise EvidenceUnavailable(
+                f"GitHub REST evidence is unavailable (HTTP {response.status!r})"
+            )
+        try:
+            return json.loads(response.body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise EvidenceContractError(
+                "GitHub REST response is not valid JSON"
+            ) from error
+
+
+@runtime_checkable
+class PolicyEvidenceResolver(Protocol):
+    """Every evidence query used by the policy replay, with no optional methods."""
+
+    def resolve_replay_pr(
+        self,
+        ref: str,
+        anchor: str | None,
+    ) -> PullRequestEvidence:
+        ...
+
+    def resolve_replay_activation_diff(self, ref: str) -> ActivationDiffEvidence:
+        ...
+
+    def resolve_replay_record_diff(
+        self,
+        entry_id: str,
+        record_pr: str,
+        source_sha: str | None,
+    ) -> RecordDiffEvidence:
+        ...
+
+    def resolve_replay_work_diff(self, ref: str) -> WorkDiffEvidence:
+        ...
+
+    def resolve_replay_resolution_diff(self, ref: str) -> ResolutionDiffEvidence:
+        ...
+
+    def resolve_replay_release_prep(
+        self,
+        ref: str,
+        integration_oid: str,
+        paths: tuple[str, ...],
+        work_integrations: tuple[str, ...],
+        resolution_integrations: tuple[str, ...],
+    ) -> ReleasePrepEvidence:
+        ...
+
+    def resolve_replay_release_payload(
+        self,
+        tree_oid: str,
+        tag: str,
+        contract: ReleaseContract,
+    ) -> ReleasePayloadEvidence:
+        ...
+
+    def resolve_replay_release_test_observation(
+        self,
+        tree_oid: str,
+        tag: str,
+        test_ref: str,
+        contract: ReleaseContract,
+    ) -> ReleaseTestObservationEvidence:
+        ...
+
+    def resolve_replay_freeze_tag(self, tag: str) -> TagEvidence:
+        ...
+
+    def resolve_current_final_tag(self, tag: str) -> TagEvidence:
+        ...
+
+    def resolve_final_tag_publisher(
+        self,
+        integration_oid: str,
+    ) -> FinalTagPublisherEvidence:
+        ...
+
+    def resolve_current_publisher_secret(
+        self,
+        environment: str,
+        secret_name: str,
+        secret_scope: str,
+        key_retirement: str,
+    ) -> PublisherSecretEvidence:
+        ...
+
+    def resolve_replay_issue(self, ref: str) -> IssueEvidence:
+        ...
+
+    def resolve_replay_record_invalid_reset(
+        self,
+        entry_id: str,
+        target: str,
+        receipt_ref: str,
+        receipt_digest: str,
+        current_tree_oid: str,
+    ) -> RecordInvalidResetReplayEvidence:
+        ...
+
+    def resolve_current_workflow(
+        self,
+        activation_integration: str,
+        target_oid: str,
+        paths: tuple[str, ...],
+        publisher_workflow_root: str,
+    ) -> WorkflowEvidence:
+        ...
+
+
+def _require_complete_resolver(resolver: object, subject: str) -> None:
+    if not isinstance(resolver, PolicyEvidenceResolver):
+        raise EvidenceContractError(f"{subject} policy evidence resolver is incomplete")
+
+
+@dataclass(frozen=True)
+class ImmutableReplayEvidence:
+    """Evidence fixed at each historical integration or candidate head."""
+
+    resolver: PolicyEvidenceResolver
+
+    def __post_init__(self) -> None:
+        _require_complete_resolver(self.resolver, "immutable replay")
+
+
+@dataclass(frozen=True)
+class CurrentEvidenceSnapshot:
+    """Current facts bound to one exact repository validation target."""
+
+    resolver: PolicyEvidenceResolver
+    audit: AuditEvidence
+    tag_protection: TagProtectionEvidence
+
+    def __post_init__(self) -> None:
+        _require_complete_resolver(self.resolver, "current snapshot")
+
+
+@dataclass(frozen=True)
+class PolicyEvidenceBundle:
+    """Separate immutable replay from current drift in one checker input."""
+
+    replay: ImmutableReplayEvidence
+    current: CurrentEvidenceSnapshot
+    api_version: Literal[1] = EVIDENCE_API_VERSION
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.api_version, int)
+            or isinstance(self.api_version, bool)
+            or self.api_version != EVIDENCE_API_VERSION
+        ):
+            raise EvidenceContractError(
+                f"unsupported tenkz policy evidence API version {self.api_version!r}"
+            )
+        if not isinstance(self.replay, ImmutableReplayEvidence):
+            raise EvidenceContractError("immutable replay evidence is malformed")
+        if not isinstance(self.current, CurrentEvidenceSnapshot):
+            raise EvidenceContractError("current policy evidence snapshot is malformed")

--- a/scripts/tenkz_policy_evidence.py
+++ b/scripts/tenkz_policy_evidence.py
@@ -172,7 +172,7 @@ class GitHubRestApiV1:
         if (
             not isinstance(response.status, int)
             or isinstance(response.status, bool)
-            or not 200 <= response.status < 300
+            or response.status != 200
         ):
             raise EvidenceUnavailable(
                 f"GitHub REST evidence is unavailable (HTTP {response.status!r})"
@@ -332,3 +332,7 @@ class PolicyEvidenceBundle:
             raise EvidenceContractError("immutable replay evidence is malformed")
         if not isinstance(self.current, CurrentEvidenceSnapshot):
             raise EvidenceContractError("current policy evidence snapshot is malformed")
+        if self.replay.resolver is self.current.resolver:
+            raise EvidenceContractError(
+                "immutable replay and current snapshot resolvers must be distinct"
+            )

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -1466,8 +1466,11 @@ def set_review_permission(facts: Context, ref: str, permission: str | None) -> N
 
 def validate(blocks: list[str], facts: Context, **overrides) -> str:
     entries = parsed_entries(*blocks)
-    current_resolver = overrides.pop("current_resolver", facts)
+    current_resolver = overrides.pop("current_resolver", None)
+    if current_resolver is None:
+        current_resolver = deepcopy(facts)
     assert isinstance(current_resolver, Context)
+    assert current_resolver is not facts
 
     def prepare_context(context: Context) -> None:
         for entry in entries:
@@ -1496,8 +1499,7 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
         prepare_receipt_retention(entries, context)
 
     prepare_context(facts)
-    if current_resolver is not facts:
-        prepare_context(current_resolver)
+    prepare_context(current_resolver)
     audit = overrides.pop("audit", None)
     tag_protection = overrides.pop("tag_protection", None)
     if audit is None:
@@ -5201,7 +5203,7 @@ def main() -> int:
 
     release_binding_call.resolve_replay_release_prep = resolve_bound_release_prep
     assert validate(complete_log(), release_binding_call) == "signed-off-awaiting-tag"
-    assert observed_release_integrations == [oid(9201)]
+    assert observed_release_integrations == [oid(9201), oid(9201)]
 
     for invalid_integration in (None, oid(9991)):
         release_other_integration = context()
@@ -5817,6 +5819,42 @@ def main() -> int:
         immutable_approval,
         current_resolver=current_dismissal,
     ) == "reset-required:S1-0002"
+
+    # Sign-off approval is also mutable.  The current channel must inspect the
+    # current record rather than reusing the approved immutable record.
+    immutable_signoff = context()
+    current_signoff_dismissal = context()
+    signoff_pr = current_signoff_dismissal.prs[SIGNOFF_RECORD]
+    assert signoff_pr.reviews is not None
+    current_signoff_dismissal.prs[SIGNOFF_RECORD] = replace(
+        signoff_pr,
+        reviews=tuple(
+            replace(item, state="DISMISSED", dismissed=True)
+            for item in signoff_pr.reviews
+        ),
+    )
+    assert validate(
+        complete_log(),
+        immutable_signoff,
+        current_resolver=current_signoff_dismissal,
+    ) == "reset-required:S1-0004"
+
+    # Re-closing a prerequisite after the freeze time invalidates the current
+    # freeze without changing its immutable integration-time issue receipt.
+    immutable_prerequisites = context()
+    current_reclosed_prerequisite = context()
+    freeze_record = current_reclosed_prerequisite.prs[FREEZE_RECORD]
+    assert freeze_record.merged_at is not None
+    prerequisite = current_reclosed_prerequisite.issues["#5086"]
+    current_reclosed_prerequisite.issues["#5086"] = replace(
+        prerequisite,
+        closed_at=freeze_record.merged_at + timedelta(seconds=1),
+    )
+    assert validate(
+        [freeze()],
+        immutable_prerequisites,
+        current_resolver=current_reclosed_prerequisite,
+    ) == "reset-required:S1-0001"
 
     replayed_freeze_drift = context()
     add_record(

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -5856,6 +5856,36 @@ def main() -> int:
         current_resolver=current_reclosed_prerequisite,
     ) == "reset-required:S1-0001"
 
+    # Replay drift cannot hide an unavailable current fact.  Both channels
+    # must run before the merged record is classified for reset.
+    immutable_late_prerequisite = context()
+    immutable_freeze_record = immutable_late_prerequisite.prs[FREEZE_RECORD]
+    assert immutable_freeze_record.merged_at is not None
+    immutable_issue = immutable_late_prerequisite.issues["#5086"]
+    immutable_late_prerequisite.issues["#5086"] = replace(
+        immutable_issue,
+        closed_at=immutable_freeze_record.merged_at + timedelta(seconds=1),
+    )
+    unavailable_current_prerequisite = context()
+    current_issue_calls: list[str] = []
+
+    def unavailable_current_issue(ref: str) -> policy.IssueEvidence:
+        current_issue_calls.append(ref)
+        raise policy_evidence.EvidenceUnavailable(
+            "current prerequisite evidence is unavailable"
+        )
+
+    unavailable_current_prerequisite.resolve_replay_issue = unavailable_current_issue
+    expect_failure(
+        lambda: validate(
+            [freeze()],
+            immutable_late_prerequisite,
+            current_resolver=unavailable_current_prerequisite,
+        ),
+        "current prerequisite evidence is unavailable",
+    )
+    assert current_issue_calls == ["#5086"]
+
     replayed_freeze_drift = context()
     add_record(
         replayed_freeze_drift,

--- a/scripts/test_check_tenkz_policy.py
+++ b/scripts/test_check_tenkz_policy.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -16,6 +17,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 import check_tenkz_policy as policy  # noqa: E402
+import tenkz_policy_evidence as policy_evidence  # noqa: E402
 
 
 DESIGN_TEXT = (ROOT / "docs/tenkz/DESIGN.md").read_text(encoding="utf-8")
@@ -1081,10 +1083,19 @@ def parsed_entries(*blocks: str) -> list[dict]:
 
 def audit_evidence(
     boundary: str | None,
-    invalid_entries: tuple[str, ...] = (),
     target_oid: str = oid(99_999),
 ) -> policy.AuditEvidence:
-    return policy.AuditEvidence(boundary, invalid_entries, True, True, target_oid)
+    return policy.AuditEvidence(boundary, True, True, target_oid)
+
+
+def invalidate_records(facts: Context, *entry_ids: str) -> None:
+    """Make current replay derive the selected records as invalid."""
+
+    for entry_id in entry_ids:
+        facts.records[entry_id] = replace(
+            facts.records[entry_id],
+            no_other_path_changes=False,
+        )
 
 
 def protected_tags() -> policy.TagProtectionEvidence:
@@ -1455,35 +1466,45 @@ def set_review_permission(facts: Context, ref: str, permission: str | None) -> N
 
 def validate(blocks: list[str], facts: Context, **overrides) -> str:
     entries = parsed_entries(*blocks)
-    for entry in entries:
-        if entry["kind"] != "freeze":
-            continue
-        record = facts.prs.get(entry["record_pr"])
-        if record is None or record.merged is not False:
-            continue
-        tag = facts.tags[entry["freeze_tag"]]
-        facts.tags[entry["freeze_tag"]] = replace(
-            tag,
-            candidate_namespace_complete=(
-                True
-                if tag.candidate_namespace_complete is None
-                else tag.candidate_namespace_complete
-            ),
-            candidate_matching_tag_names=(
-                tuple(entry["freeze_tag_snapshot"])
-                if tag.candidate_matching_tag_names is None
-                else tag.candidate_matching_tag_names
-            ),
-        )
-    prepare_reset_receipts(entries, facts)
-    prepare_friction_observations(entries, facts)
-    prepare_resolution_facts(entries, facts)
-    prepare_receipt_retention(entries, facts)
-    if "audit" not in overrides:
-        boundary: str | None = None
-        target_oid = facts.prs[ACTIVATION].merge_commit_oid
+    current_resolver = overrides.pop("current_resolver", facts)
+    assert isinstance(current_resolver, Context)
+
+    def prepare_context(context: Context) -> None:
         for entry in entries:
-            record = facts.prs.get(entry["record_pr"])
+            if entry["kind"] != "freeze":
+                continue
+            record = context.prs.get(entry["record_pr"])
+            if record is None or record.merged is not False:
+                continue
+            tag = context.tags[entry["freeze_tag"]]
+            context.tags[entry["freeze_tag"]] = replace(
+                tag,
+                candidate_namespace_complete=(
+                    True
+                    if tag.candidate_namespace_complete is None
+                    else tag.candidate_namespace_complete
+                ),
+                candidate_matching_tag_names=(
+                    tuple(entry["freeze_tag_snapshot"])
+                    if tag.candidate_matching_tag_names is None
+                    else tag.candidate_matching_tag_names
+                ),
+            )
+        prepare_reset_receipts(entries, context)
+        prepare_friction_observations(entries, context)
+        prepare_resolution_facts(entries, context)
+        prepare_receipt_retention(entries, context)
+
+    prepare_context(facts)
+    if current_resolver is not facts:
+        prepare_context(current_resolver)
+    audit = overrides.pop("audit", None)
+    tag_protection = overrides.pop("tag_protection", None)
+    if audit is None:
+        boundary: str | None = None
+        target_oid = current_resolver.prs[ACTIVATION].merge_commit_oid
+        for entry in entries:
+            record = current_resolver.prs.get(entry["record_pr"])
             if record is None:
                 break
             target_oid = record.head_oid
@@ -1492,28 +1513,20 @@ def validate(blocks: list[str], facts: Context, **overrides) -> str:
             boundary = entry["id"]
             target_oid = record.merge_commit_oid
         assert isinstance(target_oid, str)
-        overrides["audit"] = audit_evidence(boundary, target_oid=target_oid)
+        audit = audit_evidence(boundary, target_oid=target_oid)
+    if tag_protection is None:
+        tag_protection = protected_tags()
     arguments = {
         "policy": ARMED_POLICY,
         "soak": ARMED_SOAK,
-        "resolve_replay_pr": facts.resolve_replay_pr,
-        "resolve_replay_activation_diff": facts.resolve_replay_activation_diff,
-        "resolve_replay_record_diff": facts.resolve_replay_record_diff,
-        "resolve_replay_work_diff": facts.resolve_replay_work_diff,
-        "resolve_replay_resolution_diff": facts.resolve_replay_resolution_diff,
-        "resolve_replay_release_prep": facts.resolve_replay_release_prep,
-        "resolve_replay_release_payload": facts.resolve_replay_release_payload,
-        "resolve_replay_release_test_observation": (
-            facts.resolve_replay_release_test_observation
+        "evidence": policy_evidence.PolicyEvidenceBundle(
+            replay=policy_evidence.ImmutableReplayEvidence(facts),
+            current=policy_evidence.CurrentEvidenceSnapshot(
+                resolver=current_resolver,
+                audit=audit,
+                tag_protection=tag_protection,
+            ),
         ),
-        "resolve_replay_freeze_tag": facts.resolve_replay_freeze_tag,
-        "resolve_current_final_tag": facts.resolve_current_final_tag,
-        "resolve_final_tag_publisher": facts.resolve_final_tag_publisher,
-        "resolve_current_publisher_secret": facts.resolve_current_publisher_secret,
-        "resolve_replay_issue": facts.resolve_replay_issue,
-        "resolve_replay_record_invalid_reset": facts.resolve_replay_record_invalid_reset,
-        "resolve_current_workflow": facts.resolve_current_workflow,
-        "tag_protection": protected_tags(),
     }
     arguments.update(overrides)
     return policy.validate_entries(entries, **arguments)
@@ -1540,10 +1553,10 @@ def complete_log() -> list[str]:
 def expect_failure(action, fragment: str) -> None:
     try:
         action()
-    except policy.PolicyError as error:
+    except (policy.PolicyError, policy_evidence.EvidenceUnavailable) as error:
         assert fragment in str(error), (fragment, str(error))
     else:
-        raise AssertionError(f"expected PolicyError containing {fragment!r}")
+        raise AssertionError(f"expected evidence failure containing {fragment!r}")
 
 
 def add_record(
@@ -2051,7 +2064,27 @@ def main() -> int:
     assert armed_schema["soak"]["armed_by_pr"] == ACTIVATION
     assert armed_schema == ARMED_SOAK
     assert armed_empty_entries == []
+    expect_failure(
+        lambda: policy.validate_entries(
+            armed_empty_entries,
+            policy=ARMED_POLICY,
+            soak=ARMED_SOAK,
+        ),
+        "armed entry validation requires policy evidence",
+    )
     assert validate([], context()) == "not-started"
+    unavailable_supervisor = context()
+
+    def unavailable_activation(_ref: str) -> policy.ActivationDiffEvidence:
+        raise policy_evidence.EvidenceUnavailable(
+            "activation supervisor evidence is unavailable"
+        )
+
+    unavailable_supervisor.resolve_replay_activation_diff = unavailable_activation
+    expect_failure(
+        lambda: validate([], unavailable_supervisor),
+        "activation supervisor evidence is unavailable",
+    )
     empty_mixed_activation = context()
     empty_mixed_activation.activation_diff = replace(
         empty_mixed_activation.activation_diff,
@@ -2252,13 +2285,13 @@ def main() -> int:
     prepare_reset_receipts(receipt_entries, denied_receipt)
     receipt_ref = receipt_entries[-1]["replay_receipt_pr"]
     set_review_permission(denied_receipt, receipt_ref, "read")
+    invalidate_records(denied_receipt, "S1-0001")
     expect_failure(
         lambda: validate(
             receipt_log,
             denied_receipt,
             audit=audit_evidence(
                 "S1-0001",
-                ("S1-0001",),
                 target_oid=denied_receipt.prs["#908"].head_oid,
             ),
         ),
@@ -2385,9 +2418,9 @@ def main() -> int:
             receipt_digest,
             candidate_head,
         )
+        invalidate_records(facts, "S1-0001")
         audit = audit_evidence(
             "S1-0001",
-            ("S1-0001",),
             target_oid=candidate_head,
         )
         return blocks, facts, audit, replay
@@ -2523,12 +2556,12 @@ def main() -> int:
         freeze(),
         reset("S1-0002", "#908", "record-invalid", "S1-0001"),
     ]
+    invalidate_records(invalid_acknowledgement, "S1-0001")
     assert validate(
         invalid_ack_log,
         invalid_acknowledgement,
         audit=audit_evidence(
             "S1-0002",
-            ("S1-0001", "S1-0002"),
             target_oid=invalid_acknowledgement.prs["#908"].merge_commit_oid,
         ),
     ) == "reset-required:S1-0001"
@@ -2586,12 +2619,12 @@ def main() -> int:
         replay,
         current_tree_blob_has_exact_path_mode_bytes_and_digest=False,
     )
+    invalidate_records(missing_current_blob_facts, "S1-0001")
     assert validate(
         missing_current_blob,
         missing_current_blob_facts,
         audit=audit_evidence(
             "S1-0002",
-            (),
             target_oid=current_tree_oid,
         ),
     ) == "reset-required:S1-0001"
@@ -2667,6 +2700,7 @@ def main() -> int:
         missing_reset_integration.records["S1-0002"],
         receipt_blob_preserved_in_integration=False,
     )
+    invalidate_records(missing_reset_integration, "S1-0001")
     assert validate(
         [
             freeze(),
@@ -2675,7 +2709,6 @@ def main() -> int:
         missing_reset_integration,
         audit=audit_evidence(
             "S1-0002",
-            ("S1-0001", "S1-0002"),
             target_oid=missing_reset_integration.prs["#908"].merge_commit_oid,
         ),
     ) == "reset-required:S1-0001"
@@ -4319,11 +4352,14 @@ def main() -> int:
         oid(9071),
         status="success",
     )
+    published_replay = deepcopy(published_then_drifted)
+    invalidate_records(published_then_drifted, "S1-0002")
     expect_failure(
         lambda: validate(
             complete_log(),
-            published_then_drifted,
-            audit=audit_evidence("S1-0004", ("S1-0002",)),
+            published_replay,
+            audit=audit_evidence("S1-0004"),
+            current_resolver=published_then_drifted,
         ),
         "publisher succeeded but the final ref is absent",
     )
@@ -4677,17 +4713,21 @@ def main() -> int:
         "prior released validation used another ledger prefix",
     )
 
-    # The current-validity audit runs forever while replay callbacks retain the
-    # integration-time history.  Before the tag, drift enters the reset queue;
-    # once a final-tag ref exists it is a hard incident and never reopens it.
+    # Current replay derives drift in ledger order.  Before the tag it enters
+    # the reset queue; once a final-tag ref exists it is a hard incident.
+    released_replay = deepcopy(released)
+    released_signoff_record = released.records["S1-0004"]
+    invalidate_records(released, "S1-0004")
     expect_failure(
         lambda: validate(
             complete_log(),
-            released,
-            audit=audit_evidence("S1-0004", ("S1-0004",)),
+            released_replay,
+            audit=audit_evidence("S1-0004"),
+            current_resolver=released,
         ),
         "final tag exists while release evidence requires reset",
     )
+    released.records["S1-0004"] = released_signoff_record
     expect_failure(
         lambda: validate(
             complete_log(),
@@ -4898,12 +4938,12 @@ def main() -> int:
         "lacks one work class",
     )
 
-    incomplete_audit = policy.AuditEvidence("S1-0004", (), False, True, oid(99_999))
+    incomplete_audit = policy.AuditEvidence("S1-0004", False, True, oid(99_999))
     expect_failure(
         lambda: validate(complete_log(), context(), audit=incomplete_audit),
         "audit snapshot is incomplete",
     )
-    inexact_target_audit = policy.AuditEvidence("S1-0004", (), True, False, oid(99_999))
+    inexact_target_audit = policy.AuditEvidence("S1-0004", True, False, oid(99_999))
     expect_failure(
         lambda: validate(complete_log(), context(), audit=inexact_target_audit),
         "audit validation target is not exact",
@@ -5159,11 +5199,8 @@ def main() -> int:
         observed_release_integrations.append(integration_oid)
         return release_binding_call.release_preps[ref]
 
-    assert validate(
-        complete_log(),
-        release_binding_call,
-        resolve_replay_release_prep=resolve_bound_release_prep,
-    ) == "signed-off-awaiting-tag"
+    release_binding_call.resolve_replay_release_prep = resolve_bound_release_prep
+    assert validate(complete_log(), release_binding_call) == "signed-off-awaiting-tag"
     assert observed_release_integrations == [oid(9201)]
 
     for invalid_integration in (None, oid(9991)):
@@ -5703,11 +5740,12 @@ def main() -> int:
         integration_second_parent_matches_head=True,
     )
     invalid_log = complete_log()[:2]
+    invalidate_records(invalid_facts, "S1-0002")
     assert (
         validate(
             invalid_log,
             invalid_facts,
-            audit=audit_evidence("S1-0002", ("S1-0002",)),
+            audit=audit_evidence("S1-0002"),
         )
         == "reset-required:S1-0002"
     )
@@ -5719,17 +5757,17 @@ def main() -> int:
         lambda: validate(
             invalid_log,
             invalid_facts,
-            audit=audit_evidence(None, ("S1-0002",)),
+            audit=audit_evidence(None),
         ),
-        "audit with an empty prefix names invalid entries",
+        "audit boundary is stale",
     )
     expect_failure(
         lambda: validate(
             invalid_log,
             invalid_facts,
-            audit=audit_evidence("S1-0001", ("S1-0002",)),
+            audit=audit_evidence("S1-0001"),
         ),
-        "audit boundary precedes an invalid target",
+        "audit boundary is stale",
     )
 
     # Drift is discovered against the current repository, not at the old
@@ -5744,18 +5782,41 @@ def main() -> int:
         908,
         SIGNOFF_MERGE + timedelta(seconds=1),
     )
+    replayed_history = deepcopy(replayed_drift)
+    invalidate_records(replayed_drift, "S1-0002")
     assert (
         validate(
             complete_log(),
-            replayed_drift,
-            audit=audit_evidence("S1-0004", ("S1-0002",)),
+            replayed_history,
+            audit=audit_evidence("S1-0004"),
+            current_resolver=replayed_drift,
         )
         == "reset-required:S1-0002"
     )
     assert validate(
         complete_log() + [reset("S1-0005", "#908", "record-invalid", "S1-0002")],
-        replayed_drift,
+        replayed_history,
+        current_resolver=replayed_drift,
     ) == "reset"
+
+    # A current dismissal schedules a reset of the work record, but immutable
+    # replay still reconstructs the approved work and the later sign-off.
+    immutable_approval = context()
+    current_dismissal = context()
+    formal_pr = current_dismissal.prs[FORMAL_WORK]
+    assert formal_pr.reviews is not None
+    current_dismissal.prs[FORMAL_WORK] = replace(
+        formal_pr,
+        reviews=tuple(
+            replace(item, state="DISMISSED", dismissed=True)
+            for item in formal_pr.reviews
+        ),
+    )
+    assert validate(
+        complete_log(),
+        immutable_approval,
+        current_resolver=current_dismissal,
+    ) == "reset-required:S1-0002"
 
     replayed_freeze_drift = context()
     add_record(
@@ -5825,13 +5886,13 @@ def main() -> int:
         reset("S1-0003", "#909", "restart-required", "S1-0002"),
         reset("S1-0004", "#910", "record-invalid", "S1-0001"),
     ]
+    invalidate_records(ordered_resets, "S1-0001")
     assert (
         validate(
             restart_then_drift[:3],
             ordered_resets,
             audit=audit_evidence(
                 "S1-0003",
-                ("S1-0001",),
                 target_oid=ordered_resets.prs["#909"].merge_commit_oid,
             ),
         )
@@ -5854,30 +5915,29 @@ def main() -> int:
         909,
         SIGNOFF_MERGE + timedelta(seconds=2),
     )
-    unsorted_audit = policy.AuditEvidence(
-        "S1-0004",
-        ("S1-0002", "S1-0001"),
-        True,
-        True,
-        oid(99_999),
-    )
-    expect_failure(
-        lambda: validate(complete_log(), batched_drift, audit=unsorted_audit),
-        "invalid entries are not in ledger order",
-    )
+    batched_history = deepcopy(batched_drift)
+    invalidate_records(batched_drift, "S1-0002", "S1-0001")
+    assert validate(
+        complete_log(),
+        batched_history,
+        current_resolver=batched_drift,
+    ) == "reset-required:S1-0001"
     batched_log = complete_log() + [
         reset("S1-0005", "#908", "record-invalid", "S1-0001"),
         reset("S1-0006", "#909", "record-invalid", "S1-0002"),
     ]
-    first_reset_audit = audit_evidence(
-        "S1-0005",
-        ("S1-0002",),
-        target_oid=batched_drift.prs["#908"].merge_commit_oid,
-    )
-    assert validate(batched_log[:-1], batched_drift, audit=first_reset_audit) == (
+    assert validate(
+        batched_log[:-1],
+        batched_history,
+        current_resolver=batched_drift,
+    ) == (
         "reset-required:S1-0002"
     )
-    assert validate(batched_log, batched_drift) == "reset"
+    assert validate(
+        batched_log,
+        batched_history,
+        current_resolver=batched_drift,
+    ) == "reset"
 
     # The self-referential record rule is common to every entry kind.  A
     # copied or tree-mismatched merged record never supplies usable evidence;

--- a/scripts/test_tenkz_policy_evidence.py
+++ b/scripts/test_tenkz_policy_evidence.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Focused checks for the raw tenkz policy-evidence contract."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import tenkz_policy_evidence as evidence  # noqa: E402
+
+
+FIXTURES = ROOT / "tests/tenkz/policy-evidence/api-v1"
+
+
+def fixture(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+class FrozenRequest:
+    def __init__(self, responses: dict[str, evidence.RestResponse]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, dict[str, str]]] = []
+
+    def __call__(
+        self,
+        url: str,
+        headers: Mapping[str, str],
+    ) -> evidence.RestResponse:
+        self.calls.append((url, dict(headers)))
+        return self.responses[url]
+
+
+def expect_failure(action: Callable[[], object], fragment: str) -> None:
+    try:
+        action()
+    except (evidence.EvidenceContractError, evidence.EvidenceUnavailable) as error:
+        assert fragment in str(error), (fragment, str(error))
+        return
+    raise AssertionError(f"expected evidence failure containing {fragment!r}")
+
+
+def main() -> int:
+    pull_url = "https://api.github.test/repos/LionSR/TNLean/pulls/42"
+    reviews_url = pull_url + "/reviews?direction=asc"
+    first_page = reviews_url + "&per_page=100"
+    second_page = pull_url + "/reviews?page=2&per_page=100"
+    request = FrozenRequest(
+        {
+            pull_url: evidence.RestResponse(200, {}, fixture("pull-request.json")),
+            first_page: evidence.RestResponse(
+                200,
+                {
+                    "Link": (
+                        f'<{pull_url}/reviews?page=2&per_page=1>; rel="next", '
+                        f'<{pull_url}/reviews?page=2&per_page=1>; rel="last"'
+                    )
+                },
+                fixture("reviews-page-1.json"),
+            ),
+            second_page: evidence.RestResponse(
+                200,
+                {},
+                fixture("reviews-page-2.json"),
+            ),
+        }
+    )
+    api = evidence.GitHubRestApiV1(request)
+    assert api.object(pull_url)["number"] == 42
+    assert [item["id"] for item in api.pages(reviews_url)] == [1001, 1002]
+    expected_headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    assert request.calls == [
+        (pull_url, expected_headers),
+        (first_page, expected_headers),
+        (second_page, expected_headers),
+    ]
+
+    issue_url = "https://api.github.test/repos/LionSR/TNLean/issues/5352"
+    issue_request = FrozenRequest(
+        {issue_url: evidence.RestResponse(200, {}, fixture("issue.json"))}
+    )
+    assert evidence.GitHubRestApiV1(issue_request).object(issue_url)["number"] == 5352
+
+    denied = FrozenRequest(
+        {pull_url: evidence.RestResponse(403, {}, b'{"message":"forbidden"}')}
+    )
+    expect_failure(
+        lambda: evidence.GitHubRestApiV1(denied).object(pull_url),
+        "HTTP 403",
+    )
+    malformed = FrozenRequest(
+        {first_page: evidence.RestResponse(200, {}, b'{"not":"a page"}')}
+    )
+    expect_failure(
+        lambda: evidence.GitHubRestApiV1(malformed).pages(reviews_url),
+        "not a list",
+    )
+    cyclic = FrozenRequest(
+        {
+            first_page: evidence.RestResponse(
+                200,
+                {"link": f'<{first_page}>; rel="next"'},
+                b"[]",
+            )
+        }
+    )
+    expect_failure(
+        lambda: evidence.GitHubRestApiV1(cyclic).pages(reviews_url),
+        "pagination contains a cycle",
+    )
+
+    expect_failure(
+        lambda: evidence.ImmutableReplayEvidence(resolver=object()),
+        "immutable replay policy evidence resolver is incomplete",
+    )
+    expect_failure(
+        lambda: evidence.CurrentEvidenceSnapshot(
+            resolver=object(),
+            audit=object(),
+            tag_protection=object(),
+        ),
+        "current snapshot policy evidence resolver is incomplete",
+    )
+    expect_failure(
+        lambda: evidence.PolicyEvidenceBundle(
+            replay=object(),
+            current=object(),
+            api_version=2,
+        ),
+        "unsupported tenkz policy evidence API version",
+    )
+    print("PASS: tenkz policy evidence uses one strict API-v1 REST contract")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_tenkz_policy_evidence.py
+++ b/scripts/test_tenkz_policy_evidence.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Callable, Mapping
 from pathlib import Path
+from unittest.mock import Mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -95,6 +96,13 @@ def main() -> int:
         lambda: evidence.GitHubRestApiV1(denied).object(pull_url),
         "HTTP 403",
     )
+    partial = FrozenRequest(
+        {pull_url: evidence.RestResponse(206, {}, fixture("pull-request.json"))}
+    )
+    expect_failure(
+        lambda: evidence.GitHubRestApiV1(partial).object(pull_url),
+        "HTTP 206",
+    )
     malformed = FrozenRequest(
         {first_page: evidence.RestResponse(200, {}, b'{"not":"a page"}')}
     )
@@ -135,6 +143,18 @@ def main() -> int:
             api_version=2,
         ),
         "unsupported tenkz policy evidence API version",
+    )
+    shared_resolver = Mock(spec=evidence.PolicyEvidenceResolver)
+    expect_failure(
+        lambda: evidence.PolicyEvidenceBundle(
+            replay=evidence.ImmutableReplayEvidence(shared_resolver),
+            current=evidence.CurrentEvidenceSnapshot(
+                shared_resolver,
+                audit=object(),
+                tag_protection=object(),
+            ),
+        ),
+        "resolvers must be distinct",
     )
     print("PASS: tenkz policy evidence uses one strict API-v1 REST contract")
     return 0

--- a/tests/tenkz/policy-evidence/api-v1/issue.json
+++ b/tests/tenkz/policy-evidence/api-v1/issue.json
@@ -1,0 +1,6 @@
+{
+  "number": 5352,
+  "state": "open",
+  "closed_at": null,
+  "repository_url": "https://api.github.com/repos/LionSR/TNLean"
+}

--- a/tests/tenkz/policy-evidence/api-v1/pull-request.json
+++ b/tests/tenkz/policy-evidence/api-v1/pull-request.json
@@ -1,0 +1,11 @@
+{
+  "number": 42,
+  "state": "closed",
+  "merged": true,
+  "base": {"ref": "main"},
+  "head": {"sha": "1111111111111111111111111111111111111111"},
+  "user": {"login": "author"},
+  "merged_by": {"login": "maintainer"},
+  "merge_commit_sha": "2222222222222222222222222222222222222222",
+  "merged_at": "2026-08-03T10:00:00Z"
+}

--- a/tests/tenkz/policy-evidence/api-v1/reviews-page-1.json
+++ b/tests/tenkz/policy-evidence/api-v1/reviews-page-1.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 1001,
+    "state": "APPROVED",
+    "commit_id": "1111111111111111111111111111111111111111",
+    "submitted_at": "2026-08-03T09:58:00Z",
+    "user": {"login": "reviewer-one"}
+  }
+]

--- a/tests/tenkz/policy-evidence/api-v1/reviews-page-2.json
+++ b/tests/tenkz/policy-evidence/api-v1/reviews-page-2.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 1002,
+    "state": "DISMISSED",
+    "commit_id": "0000000000000000000000000000000000000000",
+    "submitted_at": "2026-08-03T09:40:00Z",
+    "user": {"login": "reviewer-two"}
+  }
+]


### PR DESCRIPTION
### Motivation

Issue LionSR/tenkz#128's checker accepted fifteen independent optional callbacks and a caller-classified invalid-entry inventory. Those inputs could mix immutable replay facts with mutable current state. The 1.0 evidence gate needs that boundary to be explicit before a live collector is connected.

### Description

- Replace the optional callbacks with one API-v1 `PolicyEvidenceBundle` containing separate `ImmutableReplayEvidence` and `CurrentEvidenceSnapshot` values; aliased resolver objects are rejected.
- Remove `AuditEvidence.invalid_entries`; derive invalid entries inside validation in ledger order, and align the normative soak text with that ownership.
- Reconstruct historical state only from immutable replay evidence, then always exercise the distinct current channel without back-projecting drift into history.
- Recheck current sign-off approval and prerequisite closure time, including dismissal and re-closure regressions.
- Fail closed when armed validation lacks either complete resolver or an exact current snapshot.
- Add a strict raw GitHub REST reader that accepts only complete HTTP 200 responses, uses `per_page=100` and complete `Link` pagination, and is covered by frozen API-v1 fixtures; there is no GraphQL or `gh` fallback.

There is no compatibility adapter. This slice does not add the live semantic collector, activate the policy, create tags or release artifacts, change the version, or implement workflow, secret, and tag-protection collection. Armed repository validation therefore remains fail-closed until the later collector slice supplies the bundle.

### Testing

- `python3 scripts/test_tenkz_policy_evidence.py`
- `python3 scripts/test_check_tenkz_policy.py`
- `python3 scripts/check_tenkz_policy.py --target-ref HEAD --pull-request-base-ref 9673110416911b71266f8b149da37e3f53fbe594 --main-ref 9673110416911b71266f8b149da37e3f53fbe594`
- `python3 scripts/check_tenkz_policy.py --target-ref HEAD --history-base-ref 5a9f90d288f8d642c8d423fcd2a2468349a4d9a1 --history-head-ref HEAD --main-ref HEAD`
- `python3 scripts/test_check_tenkz_demolition.py`
- `python3 scripts/check_tenkz_demolition.py`
- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 9673110416911b71266f8b149da37e3f53fbe594`
- `ruff format --check scripts/tenkz_policy_evidence.py scripts/test_tenkz_policy_evidence.py`
- `ruff check scripts/tenkz_policy_evidence.py scripts/test_tenkz_policy_evidence.py scripts/check_tenkz_policy.py scripts/test_check_tenkz_policy.py`
- `actionlint .github/workflows/tenkz-policy.yml`
- `git diff --check`

The soak policy remains `pending`, so the normative correction is permitted before the policy hash is armed. Both the exact PR-range and exact one-commit history gates passed without changing `policy_sha256 = "pending"`.

Part of LionSR/tenkz#128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release-evidence state machine and audit boundary for LionSR/tenkz#128, but behavior is heavily regression-tested and armed checks remain fail-closed until a live collector supplies the bundle.
> 
> **Overview**
> Replaces fifteen optional `resolve_*` callbacks and caller-supplied `AuditEvidence.invalid_entries` with a single API-v1 **`PolicyEvidenceBundle`**: distinct **`ImmutableReplayEvidence`** and **`CurrentEvidenceSnapshot`** resolvers (aliasing the same resolver object is rejected). Armed validation now **derives the ledger-ordered invalid-entry queue** from current snapshot facts instead of trusting an external inventory.
> 
> **`validate_entries`** runs immutable replay for history, then always exercises the **current** resolver—classifying drift via paired replay vs snapshot checks (record identity, diffs, approvals, prerequisite closure) without back-projecting current failures into replay state. **`AuditEvidence`** shrinks to boundary, target OID, and completeness flags; soak normative text matches that ownership.
> 
> Adds **`scripts/tenkz_policy_evidence.py`** with the resolver protocol, bundle types, and a **strict GitHub REST v1** reader (HTTP 200 only, `per_page=100`, full `Link` pagination), plus fixtures and **`test_tenkz_policy_evidence.py`** wired into the tenkz-policy workflow. Perturbation tests move to the bundle model and add regressions for dismissed reviews and late prerequisite closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3222edca76939083d8024deec5021b2e2e984cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->