### PR TITLE
feat(MPS/MPDO): prove the Kato-family fixed-scale channel obstruction

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -163,6 +163,7 @@ import TNLean.MPS.MPDO.InverseMapActiveSectorRecurrence
 import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
 import TNLean.MPS.MPDO.InverseMapPhysicalSectorFactorization
 import TNLean.MPS.MPDO.IsometricAdjacentBondTransport
+import TNLean.MPS.MPDO.KatoDeformedRFPObstruction
 import TNLean.MPS.MPDO.LengthDependentRFPExample
 import TNLean.MPS.MPDO.LengthIndependentCoefficients
 import TNLean.MPS.MPDO.LinearMarkedTensor

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.SectorTrace
+
+/-!
+# A tensor-changing renormalization flow outside the fixed-scale condition
+
+Kato's example at parameter $p=1/2$, after conjugating each physical site by
+the Hadamard matrix, has only two nonzero physical letters:
+\[
+  K^{00}=\operatorname{diag}(1/2,1/4),\qquad
+  K^{11}=\operatorname{diag}(1/2,-1/4).
+\]
+It generates the positive, trace-one family
+\[
+  \rho_N=2^{-N}I+4^{-N}Z^{\otimes N}.
+\]
+Its physical-trace transfer is the projection $\operatorname{diag}(1,0)$.
+
+The exact renormalization in Kato's construction changes the tensor along the
+flow.  The last theorem below concerns instead the fixed tensor and the two
+intertwining channels in Definition 4.1 of arXiv:1606.00608.  For the virtual
+boundary $X=\operatorname{diag}(2,8)$, the two-site physical closure is positive
+semidefinite, whereas the one-site closure is $\operatorname{diag}(3,-1)$.
+A completely positive coarse-graining map cannot send the former to the latter.
+
+## Main results
+
+* `mpo_tensor_eq_diagonal`: the exact closed MPO at every positive length.
+* `tensor_isMPDO`: positivity of the complete positive-length family.
+* `trace_mpo_tensor`: unit trace at every positive length.
+* `physTraceTransfer_tensor`: the physical-trace transfer is
+  $\operatorname{diag}(1,0)$ and is idempotent.
+* `tensor_not_isRFPViaTS`: no fixed-scale channels satisfy the two
+  intertwining identities of Definition 4.1.
+
+## References
+
+* K. Kato, *Exact renormalization group flow for matrix product density
+  operators*, arXiv:2410.22696, lines 709--838, especially lines 712--721.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Definition 4.1,
+  lines 645--659.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.KatoDeformedRFPObstruction
+
+/-- The Pauli $Z$ matrix on the physical two-dimensional space. -/
+noncomputable def pauliZ : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![1, 0; 0, -1]
+
+/-- The sign carried by one physical letter in the second virtual sector. -/
+noncomputable def siteSign (i : Fin 2) : ℂ :=
+  pauliZ i i
+
+/-- Kato's $p=1/2$ tensor after a physical Hadamard conjugation.
+
+Thus $K^{00}=\operatorname{diag}(1/2,1/4)$,
+$K^{11}=\operatorname{diag}(1/2,-1/4)$, and the two off-diagonal physical
+letters vanish.  The physical conjugation turns the source tensor
+$\operatorname{diag}(I/2,X/4)$ into $\operatorname{diag}(I/2,Z/4)$.
+
+Source: arXiv:2410.22696, lines 712--721. -/
+noncomputable def tensor : MPOTensor 2 2 :=
+  fun i j => if i = j then
+    Matrix.diagonal ![(1 / 2 : ℂ), (1 / 4 : ℂ) * siteSign i]
+  else 0
+
+@[simp] private lemma tensor_zero_zero :
+    tensor 0 0 = !![(1 / 2 : ℂ), 0; 0, (1 / 4 : ℂ)] := by
+  ext a b
+  fin_cases a <;> fin_cases b <;> norm_num [tensor, siteSign, pauliZ]
+
+@[simp] private lemma tensor_one_one :
+    tensor 1 1 = !![(1 / 2 : ℂ), 0; 0, -(1 / 4 : ℂ)] := by
+  ext a b
+  fin_cases a <;> fin_cases b <;> norm_num [tensor, siteSign, pauliZ]
+
+@[simp] private lemma tensor_zero_one : tensor 0 1 = 0 := by
+  simp [tensor]
+
+@[simp] private lemma tensor_one_zero : tensor 1 0 = 0 := by
+  simp [tensor]
+
+/-! ### Closed operators at arbitrary length -/
+
+/-- The product of the $Z$ eigenvalues along a physical configuration. -/
+noncomputable def configurationSign {N : ℕ} (σ : Fin N → Fin 2) : ℂ :=
+  ∏ k, siteSign (σ k)
+
+private lemma siteSign_eq_one_or_neg_one (i : Fin 2) :
+    siteSign i = 1 ∨ siteSign i = -1 := by
+  fin_cases i <;> simp [siteSign, pauliZ]
+
+private lemma prod_tensor_diagonal :
+    ∀ {N : ℕ} (σ : Fin N → Fin 2),
+      (List.ofFn fun k => tensor (σ k) (σ k)).prod =
+        Matrix.diagonal ![(1 / 2 : ℂ) ^ N,
+          (1 / 4 : ℂ) ^ N * configurationSign σ] := by
+  intro N
+  induction N with
+  | zero =>
+      intro σ
+      ext a b
+      fin_cases a <;> fin_cases b <;>
+        simp [configurationSign]
+  | succ N ih =>
+      intro σ
+      rw [List.ofFn_succ, List.prod_cons, tensor, if_pos rfl,
+        ih (fun i => σ i.succ), Matrix.diagonal_mul_diagonal]
+      ext a b
+      fin_cases a <;> fin_cases b <;>
+        simp [configurationSign, Fin.prod_univ_succ, pow_succ] <;> ring
+
+private lemma prod_tensor_off_diagonal {N : ℕ} {σ τ : Fin N → Fin 2}
+    (hστ : σ ≠ τ) :
+    (List.ofFn fun k => tensor (σ k) (τ k)).prod = 0 := by
+  obtain ⟨k, hk⟩ := Function.ne_iff.mp hστ
+  apply List.prod_eq_zero
+  exact List.mem_ofFn.mpr ⟨k, by simp [tensor, hk]⟩
+
+/-- The exact closed MPO at every length is diagonal.  Its entry at a physical
+configuration $\sigma$ is
+$2^{-N}+4^{-N}\prod_k z_{\sigma_k}$, where $z_0=1$ and $z_1=-1$.
+
+Equivalently, the operator is $2^{-N}I+4^{-N}Z^{\otimes N}$. This is the
+$p=1/2$ specialization of Kato's family after physical Hadamard conjugation.
+
+Source: arXiv:2410.22696, lines 712--721 and 822--832. -/
+theorem mpo_tensor_eq_diagonal (N : ℕ) :
+    mpo tensor N = Matrix.diagonal fun σ =>
+      (1 / 2 : ℂ) ^ N + (1 / 4 : ℂ) ^ N * configurationSign σ := by
+  ext σ τ
+  by_cases hστ : σ = τ
+  · subst τ
+    rw [Matrix.diagonal_apply_eq, mpo_apply, mpoMatrixEntry, evalWord_ofFn,
+      prod_tensor_diagonal, Matrix.trace_diagonal]
+    simp [Fin.sum_univ_two]
+  · rw [Matrix.diagonal_apply_ne _ hστ, mpo_apply, mpoMatrixEntry,
+      evalWord_ofFn, prod_tensor_off_diagonal hστ, Matrix.trace_zero]
+
+private lemma configurationSign_eq_one_or_neg_one {N : ℕ} (σ : Fin N → Fin 2) :
+    configurationSign σ = 1 ∨ configurationSign σ = -1 := by
+  induction N with
+  | zero =>
+      left
+      simp [configurationSign]
+  | succ N ih =>
+      have hprod :
+          configurationSign σ =
+            siteSign (σ 0) * configurationSign (σ ∘ Fin.succ) := by
+        rw [configurationSign, Fin.prod_univ_succ]
+        rfl
+      rw [hprod]
+      rcases siteSign_eq_one_or_neg_one (σ 0) with hhead | hhead
+      · rcases ih (σ ∘ Fin.succ) with htail | htail
+        · left
+          rw [hhead, htail, one_mul]
+        · right
+          rw [hhead, htail, one_mul]
+      · rcases ih (σ ∘ Fin.succ) with htail | htail
+        · right
+          rw [hhead, htail, neg_one_mul]
+        · left
+          rw [hhead, htail]
+          norm_num
+
+/-- Kato's $p=1/2$ tensor generates a positive semidefinite operator at every
+positive chain length.
+
+Source: arXiv:2410.22696, lines 712--721 and 822--832. -/
+theorem tensor_isMPDO : IsMPDO tensor := by
+  intro N _hN
+  rw [mpo_tensor_eq_diagonal]
+  apply Matrix.PosSemidef.diagonal
+  intro σ
+  rcases configurationSign_eq_one_or_neg_one σ with hsign | hsign
+  · change (0 : ℂ) ≤
+      (1 / 2 : ℂ) ^ N + (1 / 4 : ℂ) ^ N * configurationSign σ
+    rw [hsign]
+    positivity
+  · change (0 : ℂ) ≤
+      (1 / 2 : ℂ) ^ N + (1 / 4 : ℂ) ^ N * configurationSign σ
+    rw [hsign]
+    have hhalf :
+        (1 / 2 : ℂ) ^ N = Complex.ofReal ((1 / 2 : ℝ) ^ N) := by
+      rw [show (1 / 2 : ℂ) = Complex.ofReal (1 / 2 : ℝ) by norm_num]
+      exact (Complex.ofReal_pow (1 / 2 : ℝ) N).symm
+    have hquarter :
+        (1 / 4 : ℂ) ^ N = Complex.ofReal ((1 / 4 : ℝ) ^ N) := by
+      rw [show (1 / 4 : ℂ) = Complex.ofReal (1 / 4 : ℝ) by norm_num]
+      exact (Complex.ofReal_pow (1 / 4 : ℝ) N).symm
+    rw [mul_neg_one, Complex.nonneg_iff]
+    constructor
+    · have hpow : (1 / 4 : ℝ) ^ N ≤ (1 / 2 : ℝ) ^ N :=
+        pow_le_pow_left₀ (by norm_num) (by norm_num) N
+      have hnonneg : 0 ≤ (1 / 2 : ℝ) ^ N - (1 / 4 : ℝ) ^ N :=
+        sub_nonneg.mpr hpow
+      simpa only [hhalf, hquarter, Complex.add_re, Complex.neg_re,
+        Complex.ofReal_re, sub_eq_add_neg] using hnonneg
+    · simp only [hhalf, hquarter, Complex.add_im, Complex.neg_im,
+        Complex.ofReal_im, neg_zero, add_zero]
+
+/-! ### Physical trace and normalization -/
+
+/-- The physical-trace transfer of the $p=1/2$ tensor is the rank-one
+projection $\operatorname{diag}(1,0)$.
+
+Source: the tensor is arXiv:2410.22696, lines 712--721; the physical-trace
+transfer is the contraction in arXiv:1606.00608, Definition 4.2,
+lines 735--741. -/
+theorem physTraceTransfer_tensor :
+    physTraceTransfer tensor = !![(1 : ℂ), 0; 0, 0] := by
+  ext a b
+  fin_cases a <;> fin_cases b <;>
+    norm_num [physTraceTransfer, tensor, siteSign, pauliZ, Fin.sum_univ_two]
+
+/-- The physical-trace transfer satisfies literal idempotence.
+
+This is the zero-correlation-length identity used by arXiv:1606.00608,
+Definition 4.2, lines 735--741. -/
+theorem physTraceTransfer_tensor_idempotent :
+    physTraceTransfer tensor * physTraceTransfer tensor =
+      physTraceTransfer tensor := by
+  rw [physTraceTransfer_tensor]
+  ext a b
+  fin_cases a <;> fin_cases b <;>
+    norm_num [Matrix.mul_apply, Fin.sum_univ_two]
+
+/-- Every positive-length closed operator generated by the tensor has trace
+one.
+
+Source: arXiv:2410.22696, lines 712--721 and 822--832. -/
+theorem trace_mpo_tensor (N : ℕ) (hN : 0 < N) :
+    Matrix.trace (mpo tensor N) = 1 := by
+  have hIdem : IsIdempotentElem (physTraceTransfer tensor) := by
+    rw [isIdempotentElem_iff]
+    exact physTraceTransfer_tensor_idempotent
+  rw [trace_mpo_eq_trace_verticalLoop_pow, verticalLoop_eq_physTraceTransfer,
+    hIdem.pow_eq hN.ne', physTraceTransfer_tensor]
+  norm_num [Matrix.trace, Fin.sum_univ_two]
+
+/-! ### One- and two-site physical closures -/
+
+/-- The one-site physical closure is
+$X_{00}I/2+X_{11}Z/4$.
+
+Source comparison: arXiv:2410.22696, lines 717--721 gives the tensor; the
+physical closure is the one-site contraction in arXiv:1606.00608,
+Definition 4.1, lines 645--659. -/
+theorem physClose1_tensor (X : Matrix (Fin 2) (Fin 2) ℂ) :
+    physClose1 tensor X =
+      (X 0 0 / 2) • (1 : Matrix (Fin 2) (Fin 2) ℂ) +
+        (X 1 1 / 4) • pauliZ := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [physClose1_apply, tensor, siteSign, pauliZ, Matrix.trace,
+      Matrix.mul_apply, Fin.sum_univ_two] <;> ring
+
+/-- The two-site physical closure is
+$X_{00}(I\otimes I)/4+X_{11}(Z\otimes Z)/16$.
+
+Source comparison: arXiv:2410.22696, lines 717--721 gives the tensor; the
+physical closure is the two-site contraction in arXiv:1606.00608,
+Definition 4.1, lines 645--659. -/
+theorem physClose2_tensor (X : Matrix (Fin 2) (Fin 2) ℂ) :
+    physClose2 tensor X =
+      (X 0 0 / 4) • (1 : Matrix (Fin 2 × Fin 2) (Fin 2 × Fin 2) ℂ) +
+        (X 1 1 / 16) • pauliZ.kronecker pauliZ := by
+  ext i j
+  rcases i with ⟨i₀, i₁⟩
+  rcases j with ⟨j₀, j₁⟩
+  fin_cases i₀ <;> fin_cases i₁ <;> fin_cases j₀ <;> fin_cases j₁ <;>
+    norm_num [physClose2_apply, tensor, siteSign, pauliZ, Matrix.trace,
+      Matrix.mul_apply, Fin.sum_univ_two, Matrix.kronecker_apply] <;> ring
+
+/-! ### Fixed-scale channel obstruction -/
+
+/-- The virtual boundary matrix which separates the positivity of the one- and
+two-site physical closures. -/
+noncomputable def obstructionBoundary : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![2, 0; 0, 8]
+
+/-- At the obstruction boundary, the one-site closure is
+$\operatorname{diag}(3,-1)$ and is therefore not positive semidefinite.
+
+This identity is not stated by Kato; it follows from the tensor at
+arXiv:2410.22696, lines 712--721, and the one-site closure of
+arXiv:1606.00608, Definition 4.1, lines 645--659. -/
+theorem physClose1_obstructionBoundary :
+    physClose1 tensor obstructionBoundary = !![(3 : ℂ), 0; 0, -1] := by
+  rw [physClose1_tensor]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    norm_num [obstructionBoundary, pauliZ]
+
+/-- At the obstruction boundary, the two-site closure is the projection onto
+the span of $\lvert 00\rangle$ and $\lvert 11\rangle$.
+
+This identity is not stated by Kato; it follows from the tensor at
+arXiv:2410.22696, lines 712--721, and the two-site closure of
+arXiv:1606.00608, Definition 4.1, lines 645--659. -/
+theorem physClose2_obstructionBoundary :
+    physClose2 tensor obstructionBoundary =
+      Matrix.diagonal fun p : Fin 2 × Fin 2 => if p.1 = p.2 then 1 else 0 := by
+  rw [physClose2_tensor]
+  ext p q
+  rcases p with ⟨p₀, p₁⟩
+  rcases q with ⟨q₀, q₁⟩
+  fin_cases p₀ <;> fin_cases p₁ <;> fin_cases q₀ <;> fin_cases q₁ <;>
+    norm_num [obstructionBoundary, pauliZ, Matrix.kronecker_apply]
+
+/-- The two-site closure at `obstructionBoundary` is positive semidefinite. -/
+theorem physClose2_obstructionBoundary_posSemidef :
+    (physClose2 tensor obstructionBoundary).PosSemidef := by
+  rw [physClose2_obstructionBoundary]
+  apply Matrix.PosSemidef.diagonal
+  intro p
+  change (0 : ℂ) ≤ if p.1 = p.2 then 1 else 0
+  split <;> norm_num
+
+/-- The one-site closure at `obstructionBoundary` is not positive
+semidefinite. -/
+theorem physClose1_obstructionBoundary_not_posSemidef :
+    ¬ (physClose1 tensor obstructionBoundary).PosSemidef := by
+  intro hpos
+  have hdiag := hpos.diag_nonneg (i := (1 : Fin 2))
+  rw [physClose1_obstructionBoundary] at hdiag
+  norm_num [Complex.nonneg_iff] at hdiag
+
+/-- Kato's $p=1/2$ tensor does not satisfy the fixed-tensor renormalization
+condition of arXiv:1606.00608, Definition 4.1.  Indeed, a coarse-graining
+channel would have to send the positive two-site closure at
+$X=\operatorname{diag}(2,8)$ to the non-positive one-site closure.  Complete
+positivity forbids this.
+
+The nonexistence of fixed-scale channels is not stated by Kato; it follows
+from the one- and two-site closure identities above.  Kato proves that the family has an
+exact renormalization flow in which the tensor changes; arXiv:2410.22696,
+lines 692--706 and 827--838 distinguishes that flow from its fixed points.
+No canonical-form, strong-area-law, or static-converse assertion is made here.
+-/
+theorem tensor_not_isRFPViaTS : ¬ IsRFPViaTS tensor := by
+  intro hRFP
+  obtain ⟨S, _T, hS, _hT, hSclose, _hTclose⟩ := hRFP
+  have hpos : (S (physClose2 tensor obstructionBoundary)).PosSemidef :=
+    hS.map_posSemidef physClose2_obstructionBoundary_posSemidef
+  rw [hSclose obstructionBoundary] at hpos
+  exact physClose1_obstructionBoundary_not_posSemidef hpos
+
+end MPOTensor.KatoDeformedRFPObstruction

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -192,6 +192,103 @@ Definition~\ref{def:mpo_source_zcl} permits the positive factor $\lambda$.
     $\mathcal T_M^2=\mathcal T_M$.
 \end{proof}
 
+\begin{theorem}[An idempotent physical-trace transfer without fixed-tensor
+    renormalization maps]
+    \label{thm:kato_deformed_mpdo_fixed_tensor_obstruction}
+    \lean{MPOTensor.KatoDeformedRFPObstruction.pauliZ,
+      MPOTensor.KatoDeformedRFPObstruction.siteSign,
+      MPOTensor.KatoDeformedRFPObstruction.tensor,
+      MPOTensor.KatoDeformedRFPObstruction.configurationSign,
+      MPOTensor.KatoDeformedRFPObstruction.mpo_tensor_eq_diagonal,
+      MPOTensor.KatoDeformedRFPObstruction.tensor_isMPDO,
+      MPOTensor.KatoDeformedRFPObstruction.trace_mpo_tensor,
+      MPOTensor.KatoDeformedRFPObstruction.physTraceTransfer_tensor,
+      MPOTensor.KatoDeformedRFPObstruction.%
+        physTraceTransfer_tensor_idempotent,
+      MPOTensor.KatoDeformedRFPObstruction.physClose1_tensor,
+      MPOTensor.KatoDeformedRFPObstruction.physClose2_tensor,
+      MPOTensor.KatoDeformedRFPObstruction.obstructionBoundary,
+      MPOTensor.KatoDeformedRFPObstruction.%
+        physClose1_obstructionBoundary,
+      MPOTensor.KatoDeformedRFPObstruction.%
+        physClose2_obstructionBoundary,
+      MPOTensor.KatoDeformedRFPObstruction.%
+        physClose2_obstructionBoundary_posSemidef,
+      MPOTensor.KatoDeformedRFPObstruction.%
+        physClose1_obstructionBoundary_not_posSemidef,
+      MPOTensor.KatoDeformedRFPObstruction.tensor_not_isRFPViaTS}
+    \leanok
+    \uses{def:mpdo, def:phys_close, def:mpo_physical_trace_transfer,
+      def:is_rfp_via_ts}
+    Let $Z=\operatorname{diag}(1,-1)$ and let $K$ be the bond-two MPO tensor
+    whose nonzero physical letters are
+    \begin{align}
+        K^{00}&=\operatorname{diag}(1/2,1/4), &
+        K^{11}&=\operatorname{diag}(1/2,-1/4).
+        \notag
+    \end{align}
+    For every $N\geq1$, its closed operator is
+    \begin{align}
+        \rho_N(K)&=2^{-N}I+4^{-N}Z^{\otimes N}\geq0, &
+        \tr\rho_N(K)&=1.
+        \notag
+    \end{align}
+    Its physical-trace transfer is
+    \begin{align}
+        \mathcal T_K&=\operatorname{diag}(1,0), &
+        \mathcal T_K^2&=\mathcal T_K.
+        \notag
+    \end{align}
+    For every virtual matrix $X$, the physical closures satisfy
+    \begin{align}
+        K_1(X)&=\frac{X_{00}}2I+\frac{X_{11}}4Z,
+        \notag\\
+        K_2(X)&=\frac{X_{00}}4I\otimes I
+          +\frac{X_{11}}{16}Z\otimes Z.
+        \notag
+    \end{align}
+    Nevertheless, $K$ is not a renormalization fixed point in the sense of
+    Definition~\ref{def:is_rfp_via_ts}.
+
+    The tensor is the $p=1/2$ example of
+    \cite[lines~709--838]{Kato2024Exact}, after conjugating every physical site
+    by the Hadamard matrix. Kato's exact renormalization changes the tensor
+    along the flow and the source explicitly states that this example is not a
+    fixed point. The fixed-tensor-channel obstruction follows directly from
+    the one- and two-site closure identities; it is not asserted as a theorem
+    in that source. No canonical-form or strong-area-law conclusion is part of
+    this statement.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:mpdo_trace_loop_chain, lem:is_kraus_cptp_map_pos}
+    Since the two virtual sectors are diagonal, set $z_0=1$ and $z_1=-1$.
+    A physical configuration $\sigma$ has weight
+    \begin{align}
+        2^{-N}+4^{-N}\prod_{k=0}^{N-1}z_{\sigma_k}.
+        \notag
+    \end{align}
+    This proves the closed-operator formula. Each diagonal entry is either
+    $2^{-N}+4^{-N}$ or $2^{-N}-4^{-N}$ and is nonnegative. Contracting the
+    physical indices gives $\mathcal T_K=\operatorname{diag}(1,0)$, whence
+    $\tr\rho_N(K)=\tr(\mathcal T_K^N)=1$ for $N\geq1$ and
+    $\mathcal T_K^2=\mathcal T_K$.
+
+    Direct contraction with a virtual matrix $X$ gives the two closure
+    formulas. Set $X_* = \operatorname{diag}(2,8)$. Then
+    \begin{align}
+        K_2(X_*)&=\frac12(I\otimes I+Z\otimes Z)\geq0,
+        \notag\\
+        K_1(X_*)&=I+2Z=\operatorname{diag}(3,-1)\not\geq0.
+        \notag
+    \end{align}
+    If the coarse-graining channel $\mathcal S$ of
+    Definition~\ref{def:is_rfp_via_ts} existed, complete positivity would give
+    $\mathcal S[K_2(X_*)]\geq0$, whereas its intertwining identity would give
+    $\mathcal S[K_2(X_*)]=K_1(X_*)$. This is a contradiction.
+\end{proof}
+
 \begin{theorem}[Renormalization fixed points satisfy the up-to-scalar
     physical-trace relation]
     \label{thm:rfp_via_ts_source_zcl}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -254,6 +254,15 @@
   note         = {Preprint; published version: Ann.\ Phys.\ \textbf{378} (2017) 100--149},
 }
 
+@unpublished{Kato2024Exact,
+  author       = {Kato, Kohtaro},
+  title        = {Exact Renormalization Group Flow for Matrix Product Density Operators},
+  year         = {2024},
+  eprint       = {2410.22696},
+  eprinttype   = {arxiv},
+  note         = {Preprint},
+}
+
 @article{Cirac2017MPDO_AnnPhys,
   title        = {Matrix Product Density Operators: {Renormalization} Fixed Points and Boundary Theories},
   author       = {Cirac, J. I. and P{\'e}rez-Garc{\'i}a, D. and Schuch, N. and Verstraete, F.},


### PR DESCRIPTION
## Motivation

CPSV16 Definition 4.1 makes physical-trace idempotence a necessary condition for a fixed-scale renormalization fixed point, but it is not sufficient for a bare tensor. The Hadamard-conjugated p = 1/2 member of Kato's deformed family gives a compact normalized test case.

## Description

- Defines the Hadamard-conjugated Kato tensor and computes its MPDO exactly at every positive length.
- Proves positivity, trace-one normalization, and idempotence of the physical trace transfer.
- Computes the one- and two-site closures and uses X = diag(2, 8) to derive a positivity contradiction for any proposed coarse-graining channel.
- Adds a grouped Blueprint theorem and the Kato reference.
- Separates the source claim from the new consequence: Kato proves a tensor-changing renormalization flow, whereas the fixed-tensor channel obstruction is derived here. No canonical-form, strong-area-law, or full-converse assertion is made.

Closes #5407.

## Validation

- `lake env lean TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean`
- generated-import consistency
- Blueprint–Lean synchronization, including reverse coverage
- reader-facing prose, proof-integrity, and diff checks
- Blueprint PDF and bibliography validation

`leanblueprint checkdecls` was not run locally because the warm cache lacks an unrelated compiled module. No broad build was started to reconstruct it; CI provides the complete declaration check.

## Agent assistance

OpenAI Codex (GPT-5) assisted with the Lean proof, source comparison, Blueprint text, and validation. A separate agent independently reviewed the mathematical argument and source boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and blueprint documentation only; no changes to core RFP definitions or existing theorem statements.
> 
> **Overview**
> Adds a formal **Kato $p=1/2$** (Hadamard-conjugated) MPO tensor and shows it is a normalized, positive MPDO with **idempotent** physical-trace transfer $\mathcal T_K=\operatorname{diag}(1,0)$, yet **fails** `IsRFPViaTS` (CPSV Definition 4.1 fixed-tensor channels).
> 
> The Lean development closes the MPO as $2^{-N}I+4^{-N}Z^{\otimes N}$, derives one- and two-site physical closures, and at virtual boundary $X=\operatorname{diag}(2,8)$ exhibits **PSD** $K_2(X_*)$ versus **non-PSD** $K_1(X_*)=\operatorname{diag}(3,-1)$; any hypothesized coarse-graining channel would contradict complete positivity.
> 
> Blueprint **ch21** gains a grouped theorem with proof sketch, the module is wired into the MPDO aggregator, and **Kato (arXiv:2410.22696)** is added to the bibliography. The text distinguishes Kato’s tensor-changing flow from this new fixed-tensor obstruction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef39a456626c664afac440f972d76b8af8454071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->