### PR TITLE
feat(MPS/BNT): compare eventual MPV spans

### DIFF
--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -50,9 +50,9 @@ Theorem 4.4 of arXiv:2011.12127 (Cirac–Pérez-García–Schuch–Verstraete, R
   in a form suited to families with per-block bond dimension.
 
 * `MPSTensor.eventually_exists_invertible_changeBasis`: If two BNT-like families produce MPV
-  states that are eventually linearly independent and always span the same subspace, then for all
-  sufficiently large system sizes there is an invertible coefficient matrix `U_N` expressing one
-  family in terms of the other.
+  states that are eventually linearly independent and eventually span the same subspace, then
+  for all sufficiently large system sizes there is an invertible coefficient matrix `U_N`
+  expressing one family in terms of the other.
 
 ## Intended use in Theorem 4.4
 
@@ -383,14 +383,16 @@ lemma bntFamilies_eventually_linearIndependent
 **Eventually invertible change-of-basis matrix from equal spans.**
 
 Given two BNT-like families of MPS tensors whose pairwise overlaps converge to orthonormality
-(so both are eventually linearly independent), and whose MPV state spans agree for every system
-size `N`, there is—for all large enough `N`—an invertible `g × g` coefficient matrix `U_N`
+(so both are eventually linearly independent), and whose MPV state spans eventually agree,
+there is—for all large enough `N`—an invertible `g × g` coefficient matrix `U_N`
 satisfying
 
 `mpvState (B j) N = ∑ i, U_N i j • mpvState (A i) N`.
 
 This converts the equal-MPV-subspace condition into a matrix equation whose
 asymptotics can then be analysed in the permutation-matching step of Theorem 4.4.
+The eventual span hypothesis is the comparison used in CPSV16, arXiv:1606.00608,
+local source lines 522–525 and 1305–1307.
 -/
 lemma eventually_exists_invertible_changeBasis
     {d g : ℕ} {dimA dimB : Fin g → ℕ}
@@ -404,7 +406,7 @@ lemma eventually_exists_invertible_changeBasis
       Tendsto (fun N => mpvOverlap (d := d) (B j) (B j) N) atTop (nhds (1 : ℂ)))
     (hB_off : ∀ i j, i ≠ j →
       Tendsto (fun N => mpvOverlap (d := d) (B i) (B j) N) atTop (nhds (0 : ℂ)))
-    (hspan : ∀ N : ℕ,
+    (hspan : ∀ᶠ N : ℕ in atTop,
       Submodule.span ℂ (Set.range (fun j : Fin g => mpvState (d := d) (A j) N)) =
       Submodule.span ℂ (Set.range (fun j : Fin g => mpvState (d := d) (B j) N))) :
     ∀ᶠ N in atTop, ∃ U : Matrix (Fin g) (Fin g) ℂ,
@@ -416,11 +418,11 @@ lemma eventually_exists_invertible_changeBasis
   have hA_li := bntFamilies_eventually_linearIndependent A hA_diag hA_off
   have hB_li := bntFamilies_eventually_linearIndependent B hB_diag hB_off
   -- Combine the two "eventually" filters.
-  filter_upwards [hA_li, hB_li] with N hA_N hB_N
+  filter_upwards [hA_li, hB_li, hspan] with N hA_N hB_N hspanN
   -- Apply the pure linear-algebra change-of-basis lemma.
   exact exists_invertible_changeBasis
     (fun j => mpvState (d := d) (A j) N)
     (fun j => mpvState (d := d) (B j) N)
-    hA_N hB_N (hspan N)
+    hA_N hB_N hspanN
 
 end MPSTensor

--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -391,8 +391,13 @@ satisfying
 
 This converts the equal-MPV-subspace condition into a matrix equation whose
 asymptotics can then be analysed in the permutation-matching step of Theorem 4.4.
-The eventual span hypothesis is the comparison used in CPSV16, arXiv:1606.00608,
-local source lines 522–525 and 1305–1307.
+
+**Local fix (eventual span equality):** The source comparison holds only on a
+finite tail.  Accordingly, this result assumes eventual span equality rather
+than equality at every length.  See
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source context: CPSV16, arXiv:1606.00608, lines 522--525 and 1305--1307.
 -/
 lemma eventually_exists_invertible_changeBasis
     {d g : ℕ} {dimA dimB : Fin g → ℕ}

--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -417,7 +417,7 @@ lemma eventually_exists_invertible_changeBasis
   -- Both families are eventually LI.
   have hA_li := bntFamilies_eventually_linearIndependent A hA_diag hA_off
   have hB_li := bntFamilies_eventually_linearIndependent B hB_diag hB_off
-  -- Combine the two "eventually" filters.
+  -- Intersect the three eventual conditions.
   filter_upwards [hA_li, hB_li, hspan] with N hA_N hB_N hspanN
   -- Apply the pure linear-algebra change-of-basis lemma.
   exact exists_invertible_changeBasis

--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -450,7 +450,7 @@ lemma exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
   have hB_li :=
     eventually_linearIndependent_of_overlap_tendsto_orthonormal B hB_self hB_off
   -- ═══════════════════════════════════════════════════════════════════════════
-  -- Step 2: Pick N where both are linearly independent.
+  -- Step 2: Pick N where both are linearly independent and their spans agree.
   -- ═══════════════════════════════════════════════════════════════════════════
   have hBoth : ∀ᶠ N in atTop,
       LinearIndependent ℂ (fun j : Fin gA => mpvState (d := d) (A j) N) ∧

--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -69,8 +69,11 @@ private lemma tendsto_mpvInner_one_of_overlap_one
 **Permutation rigidity for basis-of-normal-tensors (BNT) decompositions, primitive branch.**
 
 Two finite families of primitive blocks whose MPV overlaps are asymptotically orthonormal
-and which span the same MPV subspace at each system size must agree blockwise up to a
-permutation, dimension equality, and gauge-phase equivalence.
+and which eventually span the same MPV subspace must agree blockwise up to a permutation,
+dimension equality, and gauge-phase equivalence.
+
+The eventual span hypothesis is the comparison used in CPSV16, arXiv:1606.00608,
+local source lines 522–525 and 1305–1307.
 -/
 theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
     {d g : ℕ}
@@ -86,7 +89,7 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
     (hA_off : ∀ i j, i ≠ j → Tendsto (fun N => mpvOverlap (d := d) (A i) (A j) N) atTop (nhds 0))
     (hB_self : ∀ j, Tendsto (fun N => mpvOverlap (d := d) (B j) (B j) N) atTop (nhds (1 : ℂ)))
     (hB_off : ∀ i j, i ≠ j → Tendsto (fun N => mpvOverlap (d := d) (B i) (B j) N) atTop (nhds 0))
-    (hspan : ∀ N,
+    (hspan : ∀ᶠ N : ℕ in atTop,
       Submodule.span ℂ (Set.range (fun j : Fin g => mpvState (d := d) (A j) N))
       =
       Submodule.span ℂ (Set.range (fun j : Fin g => mpvState (d := d) (B j) N))) :
@@ -386,7 +389,7 @@ The key new ingredient is a proof that the equal-span hypothesis forces
 * `MPSTensor.exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho`:
   If two BNT-like families with `gA` and `gB` blocks respectively are both
   injective, normalised, and have asymptotically orthonormal overlaps, and they
-  span the same MPV subspace at every system size, then
+  eventually span the same MPV subspace, then
   1. `gA = gB`,
   2. there is a permutation `perm : Fin gA ≃ Fin gB`, and
   3. each block `A j` is gauge-phase equivalent to `B (perm j)` (with matching
@@ -405,9 +408,12 @@ namespace MPSTensor
 **Primitive basis-of-normal-tensors permutation step, span-equality formulation.**
 
 Two BNT-like families with possibly different numbers of blocks `gA`, `gB`
-that are injective, normalised, asymptotically orthonormal, and span the same
-MPV subspace at every system size must have `gA = gB` and agree blockwise up to
-a permutation, dimension equality, and gauge-phase equivalence.
+that are injective, normalised, asymptotically orthonormal, and eventually span
+the same MPV subspace must have `gA = gB` and agree blockwise up to a
+permutation, dimension equality, and gauge-phase equivalence.
+
+The eventual span hypothesis is the comparison used in CPSV16, arXiv:1606.00608,
+local source lines 522–525 and 1305–1307.
 -/
 lemma exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
     {d gA gB : ℕ}
@@ -425,7 +431,7 @@ lemma exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
     (hB_self : ∀ j, Tendsto (fun N => mpvOverlap (d := d) (B j) (B j) N) atTop (nhds (1 : ℂ)))
     (hB_off : ∀ i j, i ≠ j →
       Tendsto (fun N => mpvOverlap (d := d) (B i) (B j) N) atTop (nhds 0))
-    (hspan : ∀ N,
+    (hspan : ∀ᶠ N : ℕ in atTop,
       Submodule.span ℂ (Set.range (fun j : Fin gA => mpvState (d := d) (A j) N))
         =
       Submodule.span ℂ (Set.range (fun j : Fin gB => mpvState (d := d) (B j) N))) :
@@ -448,10 +454,14 @@ lemma exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
   -- ═══════════════════════════════════════════════════════════════════════════
   have hBoth : ∀ᶠ N in atTop,
       LinearIndependent ℂ (fun j : Fin gA => mpvState (d := d) (A j) N) ∧
-      LinearIndependent ℂ (fun j : Fin gB => mpvState (d := d) (B j) N) := by
-    filter_upwards [hA_li, hB_li] with N hA hB
-    exact ⟨hA, hB⟩
-  obtain ⟨N, hA_N, hB_N⟩ := hBoth.exists
+      LinearIndependent ℂ (fun j : Fin gB => mpvState (d := d) (B j) N) ∧
+      Submodule.span ℂ
+          (Set.range (fun j : Fin gA => mpvState (d := d) (A j) N)) =
+        Submodule.span ℂ
+          (Set.range (fun j : Fin gB => mpvState (d := d) (B j) N)) := by
+    filter_upwards [hA_li, hB_li, hspan] with N hA hB hspanN
+    exact ⟨hA, hB, hspanN⟩
+  obtain ⟨N, hA_N, hB_N, hspanN⟩ := hBoth.exists
   -- ═══════════════════════════════════════════════════════════════════════════
   -- Step 3: Deduce gA = gB via finrank_span_eq_card.
   -- ═══════════════════════════════════════════════════════════════════════════
@@ -462,7 +472,7 @@ lemma exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
       (fun j : Fin gA => mpvState (d := d) (A j) N))) =
     Module.finrank ℂ ↥(Submodule.span ℂ (Set.range
       (fun j : Fin gB => mpvState (d := d) (B j) N))) := by
-    rw [hspan N]
+    rw [hspanN]
   have hcard : Fintype.card (Fin gA) = Fintype.card (Fin gB) := by
     rw [← hfA, hfAB, hfB]
   simp only [Fintype.card_fin] at hcard

--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -72,8 +72,12 @@ Two finite families of primitive blocks whose MPV overlaps are asymptotically or
 and which eventually span the same MPV subspace must agree blockwise up to a permutation,
 dimension equality, and gauge-phase equivalence.
 
-The eventual span hypothesis is the comparison used in CPSV16, arXiv:1606.00608,
-local source lines 522–525 and 1305–1307.
+**Local fix (eventual span equality):** The source comparison holds only on a
+finite tail.  Accordingly, this result assumes eventual span equality rather
+than equality at every length.  See
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source context: CPSV16, arXiv:1606.00608, lines 522--525 and 1305--1307.
 -/
 theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
     {d g : ℕ}
@@ -412,8 +416,12 @@ that are injective, normalised, asymptotically orthonormal, and eventually span
 the same MPV subspace must have `gA = gB` and agree blockwise up to a
 permutation, dimension equality, and gauge-phase equivalence.
 
-The eventual span hypothesis is the comparison used in CPSV16, arXiv:1606.00608,
-local source lines 522–525 and 1305–1307.
+**Local fix (eventual span equality):** The source comparison holds only on a
+finite tail.  Accordingly, this result assumes eventual span equality rather
+than equality at every length.  See
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source context: CPSV16, arXiv:1606.00608, lines 522--525 and 1305--1307.
 -/
 lemma exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho
     {d gA gB : ℕ}

--- a/blueprint/src/appendix/ft_mps/ch10_bnt_normal_and_gram_support.tex
+++ b/blueprint/src/appendix/ft_mps/ch10_bnt_normal_and_gram_support.tex
@@ -177,6 +177,7 @@ criterion and its coefficient-extraction corollary.
 \begin{lemma}[Eventual linear independence from overlap orthonormality]
     \label{lem:bnt_overlap_orthonormal_li}
     \lean{MPSTensor.eventually_linearIndependent_of_overlap_tendsto_orthonormal}
+    \lean{MPSTensor.bntFamilies_eventually_linearIndependent}
     \leanok
     \uses{def:mpv_overlap, lem:bnt_finite_index_overlap_orthonormal_li}
     Let $(A_j)_{j=1}^g$ be a finite family of tensors such that

--- a/blueprint/src/appendix/ft_mps/ch10_bnt_power_sums_and_sector_bookkeeping.tex
+++ b/blueprint/src/appendix/ft_mps/ch10_bnt_power_sums_and_sector_bookkeeping.tex
@@ -32,16 +32,18 @@ bond dimension $D_{\mathrm{tot}}=\sum_j r_jD_j$.
     \leanok
     \uses{lem:bnt_invertible_change_basis, def:mpv_overlap}
     If two finite families of blocks have asymptotically orthonormal overlaps
-    within each family and their MPV spans agree for every system size $N$,
-    then for all sufficiently large $N$ there exists an invertible matrix
-    $U_N$ expressing the MPV states of one family as linear combinations of
-    the MPV states of the other.
+    within each family, and if their MPV spans agree for all sufficiently large
+    system sizes $N$, then for all sufficiently large $N$ there exists an
+    invertible matrix $U_N$ expressing the MPV states of one family as linear
+    combinations of the MPV states of the other.
 \end{lemma}
 
 \begin{proof}\leanok\uses{lem:bnt_overlap_orthonormal_li, lem:bnt_invertible_change_basis}
     By Lemma~\ref{lem:bnt_overlap_orthonormal_li}, both families are
-    linearly independent for all sufficiently large $N$. At such an $N$, the
-    span equality lets us apply Lemma~\ref{lem:bnt_invertible_change_basis}.
+    linearly independent for all sufficiently large $N$. Hence, for all
+    sufficiently large $N$, both families are linearly independent and the
+    assumed span equality holds. Lemma~\ref{lem:bnt_invertible_change_basis}
+    applies at each such $N$.
 \end{proof}
 
 \begin{lemma}[Eventual vanishing of a finite geometric sum]

--- a/blueprint/src/chapter/ch10_bnt_permutation_and_power_sums.tex
+++ b/blueprint/src/chapter/ch10_bnt_permutation_and_power_sums.tex
@@ -1,9 +1,10 @@
 \section{Permutation rigidity for bases of normal tensors}
 
-When two bases of normal tensors generate the same MPV subspace at every positive length,
-the blocks must agree up to a permutation and per-block gauge phases. The
-argument turns the equality of spans into an invertible change-of-basis matrix,
-then analyses its asymptotics through the overlaps.
+When two bases of normal tensors generate the same MPV subspace for all
+sufficiently large positive lengths, the blocks must agree up to a permutation
+and per-block gauge phases. The argument turns the eventual equality of spans
+into an invertible change-of-basis matrix, then analyses its asymptotics through
+the overlaps.
 
 The change-of-basis matrix is now used to match the blocks. We first treat
 equal block counts, then remove that restriction.
@@ -13,12 +14,14 @@ equal block counts, then remove that restriction.
     \lean{MPSTensor.exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho}
     \leanok
     \uses{def:injective, def:mpv_overlap, def:gauge_phase_equiv}
+    % CPSV16 source boundary: arXiv:1606.00608, local source lines
+    % 522--525 and 1305--1307.
     Let $(A_j)_{j=1}^g$ and $(B_j)_{j=1}^g$ be injective families of positive
     bond dimension satisfying trace-preserving normalization, with self-overlaps tending to~$1$ and
     off-diagonal overlaps tending to~$0$ within each family. If the spans of
-    the MPV states agree for every system size $N$, then there is a permutation
-    $\pi$ of $\{1, \ldots, g\}$ such that $A_j$ and $B_{\pi(j)}$ have the
-    same bond dimension and are gauge-phase equivalent.
+    the MPV states agree for all sufficiently large system sizes $N$, then
+    there is a permutation $\pi$ of $\{1, \ldots, g\}$ such that $A_j$ and
+    $B_{\pi(j)}$ have the same bond dimension and are gauge-phase equivalent.
 \end{theorem}
 
 \begin{proof}\leanok\uses{lem:bnt_eventual_change_basis, thm:overlap_decay, thm:overlap_decay_rect}
@@ -60,7 +63,7 @@ equal block counts, then remove that restriction.
     $\sum_i (B_k^i)^\dagger B_k^i = \Id$, whose self-overlaps
     converge to~$1$ and whose cross-overlaps within each
     family converge to~$0$.
-    If for every system size~$N$,
+    If, for all sufficiently large system sizes~$N$,
     \begin{align}
         \spn_{\C}\{\ket{V^{(N)}(A_j)} : 1 \le j \le g_A\}
          & =
@@ -73,10 +76,12 @@ equal block counts, then remove that restriction.
 
 \begin{proof}\leanok\uses{lem:bnt_overlap_orthonormal_li, thm:bnt_perm_same_card}
     By Lemma~\ref{lem:bnt_overlap_orthonormal_li}, both families are
-    linearly independent for all sufficiently large $N$. At such an $N$, the
-    common span has the same dimension when computed from the $A$-family or
-    the $B$-family, so $g_A = g_B$. After identifying the two index sets,
-    Theorem~\ref{thm:bnt_perm_same_card} yields the permutation conclusion.
+    linearly independent for all sufficiently large $N$. Choose $N$ large
+    enough that both families are linearly independent and the assumed span
+    equality holds. The common span then has the same dimension when computed
+    from the $A$-family or the $B$-family, so $g_A = g_B$. After identifying
+    the two index sets, Theorem~\ref{thm:bnt_perm_same_card} yields the
+    permutation conclusion.
 \end{proof}
 
 The two preceding results obtain the block matching from the asymptotic

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -528,6 +528,17 @@ multiplicity-one, unit-weight representative, using Beigi's
 finite-degeneracy classification.  Neither statement establishes the
 unrestricted repeated-copy, raw-weight canonical-form theorem.
 
+The parent-ground-space identity in CPSV16 applies for $N>2$, whereas
+the permutation-rigidity lemmas previously required equality of the two
+matrix-product-vector spans at every length.  Only eventual span equality is
+used in their proofs: one chooses a sufficiently large length at which both
+families are linearly independent, and all subsequent overlap comparisons are
+asymptotic.  The comparison is therefore now stated under eventual span
+equality.  This gives exactly the $N>2$ boundary needed at CPSV16, source
+lines 522--525 together with lines 1305--1307; once normal representatives
+have been matched, the resulting gauge--phase relation determines their
+vectors at every positive length.
+
 The auxiliary declaration
 \leanid{MPSTensor.BeigiSectorGraphData.}
 \hspace{0pt}\leanid{mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -534,10 +534,15 @@ matrix-product-vector spans at every length.  Only eventual span equality is
 used in their proofs: one chooses a sufficiently large length at which both
 families are linearly independent, and all subsequent overlap comparisons are
 asymptotic.  The comparison is therefore now stated under eventual span
-equality.  This gives exactly the $N>2$ boundary needed at CPSV16, source
-lines 522--525 together with lines 1305--1307; once normal representatives
-have been matched, the resulting gauge--phase relation determines their
-vectors at every positive length.
+equality.  CPSV16 supplies this hypothesis on the concrete tail $N>2$, at
+source lines 522--525 together with lines 1305--1307.  The general comparison
+lemmas assert only the existence of a finite tail: the selected length must
+also lie beyond the independent linear-independence thresholds, so no common
+numerical threshold of $2$ is asserted.  This is a local correction, replacing
+an unnecessary all-length hypothesis by the finite-tail hypothesis used in the
+proof and supplied by CPSV16.  Once normal representatives have been matched,
+the resulting gauge--phase relation determines their vectors at every positive
+length.
 
 The auxiliary declaration
 \leanid{MPSTensor.BeigiSectorGraphData.}


### PR DESCRIPTION
## Motivation

CPSV16 identifies the relevant parent-Hamiltonian ground spaces only beyond a finite length: arXiv:1606.00608, local source lines 522–525, with the comparison invoked at lines 1305–1307. The primitive BNT comparison lemmas nevertheless required equality of MPV spans at every length, although their proofs use that equality only on a sufficiently large tail.

## Description

- Weakens the span hypothesis of `eventually_exists_invertible_changeBasis` and both primitive permutation-rigidity theorems from `∀ N` to `∀ᶠ N in atTop`.
- Intersects the span tail with the existing eventual linear-independence tails; no new mathematical premise or downstream caller change is required.
- Updates the live split Blueprint entries and records the exact source boundary in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
- Adds direct CPSV16 source anchors to all three revised Lean docstrings, as required for paper realignment.

No `sorry`, axiom, or proof bypass is introduced.

Closes #5410.

## Validation

- `lake exe cache get` followed by warm-cache seeding
- targeted checks for `TNLean.MPS.BNT.Basic`, `PrimitiveOverlap`, and `PermutationRigidityPrimitive`
- direct Lean checks of both changed BNT modules
- Blueprint–Lean synchronization and reverse declaration coverage
- reader-facing prose, proof-integrity, and diff checks

No fresh or broad build was run.

## Agent assistance

OpenAI Codex (GPT-5) assisted with rebasing the recovered local commit, adapting the split Blueprint, source comparison, and validation. A separate agent independently checked every use of the weakened hypothesis and the CPSV16 line ranges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hypothesis-only tightening aligned with how the proofs already work; no new axioms or proof shortcuts. Residual risk is low if a downstream caller still assumed span equality at every `N`.
> 
> **Overview**
> Aligns primitive BNT comparison lemmas with CPSV16 by replacing **all-length** MPV span equality with **eventual** span equality (`∀ᶠ N in atTop`) in `eventually_exists_invertible_changeBasis`, `exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho`, and `exists_eq_numBlocks_and_equiv_gaugePhase_of_overlapOrtho`.
> 
> Proofs now intersect the span tail with the existing eventual linear-independence filters (including picking one `N` with both LI and matching spans for the unequal-block-count step). Blueprint statements and proofs are updated in parallel, with CPSV16 source boundaries documented in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` and the revised Lean docstrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5408a425feb677944790d93b9bb7a93418efeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->