### PR TITLE
feat(Channel/FixedPoint): general Brouwer, nonlinear stationary states, and positive fixed-point span (Wolf Ch6)

### DIFF
--- a/TNLean/Channel/FixedPoint.lean
+++ b/TNLean/Channel/FixedPoint.lean
@@ -32,6 +32,8 @@ import TNLean.Channel.FixedPoint.MaximalSupportBasic
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.StationaryProjection
+import TNLean.Channel.FixedPoint.StationarySpan
+import TNLean.Channel.FixedPoint.StationaryStates
 import TNLean.Channel.FixedPoint.StationarySupport
 import TNLean.Channel.FixedPoint.StationarySupportRestriction
 import TNLean.Channel.FixedPoint.SupportCompressedDensityBlocks

--- a/TNLean/Channel/FixedPoint/StationarySpan.lean
+++ b/TNLean/Channel/FixedPoint/StationarySpan.lean
@@ -8,11 +8,14 @@ import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.LinearAlgebra.Dimension.Finite
 
 /-!
-# Spanning by stationary density matrices
+# Fixed-point subspace spanned by positive-semidefinite fixed points
 
-This file proves Wolf Corollary 6.8 (Linearly independent stationary states):
-the fixed-point space of a positive trace-preserving linear map is spanned by
-stationary density matrices.
+This file proves that the fixed-point subspace of a positive trace-preserving
+linear map is spanned (over ℂ) by its positive-semidefinite elements, and then
+by stationary density matrices.  This is the key spectral lemma for Wolf
+Corollary~6.8 (Linearly independent stationary states).  The dimension/basis
+statement with exactly `r` linearly independent stationary density matrices is
+tracked for follow-up work.
 
 ## Source
 
@@ -93,5 +96,110 @@ lemma fixedPointsSubmodule_top_span_by_posSemidef
   · intro X hX
     rcases (IsPositiveMap.mem_fixedPointsSubmodule (E := E)).mp hX with hX_fix
     exact fixedPoint_mem_span_posSemidef E hE hTP hX_fix
+
+/-- For a nonzero PSD matrix, its trace has strictly positive real part.
+
+Follows from `trace_nonneg` (re ≥ 0, im = 0) and `trace_eq_zero_iff`
+(nonzero ⇒ nonzero trace). -/
+lemma trace_re_pos_of_posSemidef_ne_zero
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ_psd : ρ.PosSemidef) (hρ_ne : ρ ≠ 0) :
+    0 < (Matrix.trace ρ).re := by
+  have h_re_nonneg : 0 ≤ (Matrix.trace ρ).re :=
+    ((RCLike.nonneg_iff (K := ℂ)).mp hρ_psd.trace_nonneg).1
+  have h_ne_zero : Matrix.trace ρ ≠ 0 :=
+    mt (hρ_psd.trace_eq_zero_iff.mp ·) hρ_ne
+  by_contra! hle
+  have him_zero : (Matrix.trace ρ).im = 0 :=
+    ((RCLike.nonneg_iff (K := ℂ)).mp hρ_psd.trace_nonneg).2
+  have hzero : Matrix.trace ρ = 0 :=
+    Complex.ext (le_antisymm hle h_re_nonneg) him_zero
+  exact h_ne_zero hzero
+
+/-- A nonzero PSD fixed point, scaled by the inverse of its trace, yields a
+stationary density matrix. -/
+lemma stationaryDensity_of_posSemidef_fixedPoint
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ_psd : ρ.PosSemidef)
+    (hρ_fix : E ρ = ρ) (hρ_ne : ρ ≠ 0) :
+    IsStationaryDensity E ((Matrix.trace ρ)⁻¹ • ρ) := by
+  have htr_pos : 0 < (Matrix.trace ρ).re :=
+    trace_re_pos_of_posSemidef_ne_zero hρ_psd hρ_ne
+  have him_zero : (Matrix.trace ρ).im = 0 :=
+    ((RCLike.nonneg_iff (K := ℂ)).mp hρ_psd.trace_nonneg).2
+  have hinv_nonneg_ℂ : 0 ≤ ((Matrix.trace ρ)⁻¹ : ℂ) := by
+    have htr_nonneg : 0 ≤ (Matrix.trace ρ : ℂ) := hρ_psd.trace_nonneg
+    have htr_ne_zero : Matrix.trace ρ ≠ 0 :=
+      mt (hρ_psd.trace_eq_zero_iff.mp ·) hρ_ne
+    -- In a StarOrderedRing, if 0 ≤ a and a ≠ 0, then 0 ≤ a⁻¹.
+    -- For ℂ specifically, this holds because the positive cone is ℝ≥0.
+    -- Use the fact that trace ρ is a real positive number.
+    have htr_real : (Matrix.trace ρ : ℂ) = ((Matrix.trace ρ).re : ℂ) :=
+      Complex.ext rfl him_zero
+    rw [htr_real]
+    -- Now we need 0 ≤ ((re : ℂ)⁻¹). Since re > 0, its inverse is ≥ 0.
+    have hrepos : (0 : ℝ) ≤ ((Matrix.trace ρ).re)⁻¹ := by
+      positivity
+    have hpos_ℂ : (0 : ℂ) ≤ (((Matrix.trace ρ).re : ℝ)⁻¹ : ℂ) := by
+      exact_mod_cast hrepos
+    simpa [map_inv₀ (algebraMap ℝ ℂ)] using hpos_ℂ
+  have h_psd : ((Matrix.trace ρ)⁻¹ • ρ).PosSemidef :=
+    hρ_psd.smul hinv_nonneg_ℂ
+  have h_trace_one : Matrix.trace ((Matrix.trace ρ)⁻¹ • ρ) = (1 : ℂ) := by
+    rw [Matrix.trace_smul, smul_eq_mul]
+    field_simp [mt (hρ_psd.trace_eq_zero_iff.mp ·) hρ_ne]
+  have h_fix : E ((Matrix.trace ρ)⁻¹ • ρ) = (Matrix.trace ρ)⁻¹ • ρ := by
+    rw [LinearMap.map_smul, hρ_fix]
+  exact {
+    posSemidef := h_psd
+    trace_one := h_trace_one
+    fixed_point := h_fix
+  }
+
+/-- **Wolf Corollary 6.8, spanning statement.**
+
+The fixed-point subspace of a positive trace-preserving linear map is spanned
+(over ℂ) by stationary density matrices (PSD, trace 1, fixed by `E`).
+
+The dimension/basis statement with exactly `r` linearly independent stationary
+density matrices is tracked for follow-up work. -/
+theorem fixedPointsSubmodule_spanned_by_stationaryDensities
+    [NeZero D] (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
+    Submodule.span ℂ {ρ | IsStationaryDensity E ρ} = fixedPointsSubmodule E := by
+  set P := posSemidefFixedPointsSet E
+  set S : Set (Matrix (Fin D) (Fin D) ℂ) := {ρ | IsStationaryDensity E ρ}
+  apply le_antisymm
+  · -- span(stationary) ⊆ fixedPointsSubmodule
+    refine Submodule.span_le.mpr ?_
+    rintro ρ hρ
+    have hρ_sd : IsStationaryDensity E ρ := hρ
+    have hmem : E ρ = ρ := hρ_sd.fixed_point
+    simpa [IsPositiveMap.mem_fixedPointsSubmodule] using hmem
+  · -- fixedPointsSubmodule ⊆ span(stationary)
+    have h_span_P : Submodule.span ℂ P = fixedPointsSubmodule E :=
+      fixedPointsSubmodule_top_span_by_posSemidef E hE hTP
+    have h_P_sub_span_S : P ⊆ Submodule.span ℂ S := by
+      intro X hX
+      rw [mem_posSemidefFixedPointsSet] at hX
+      rcases hX with ⟨hX_fix, hX_psd⟩
+      by_cases hX_zero : X = 0
+      · rw [hX_zero]
+        exact Submodule.zero_mem _
+      · have hstat : IsStationaryDensity E ((Matrix.trace X)⁻¹ • X) :=
+          stationaryDensity_of_posSemidef_fixedPoint E hE hTP hX_psd hX_fix hX_zero
+        -- X = (tr X) • ((tr X)⁻¹ • X), so X is in the span of stationary densities
+        have hX_eq : X = (Matrix.trace X) • ((Matrix.trace X)⁻¹ • X) := by
+          calc
+            X = (1 : ℂ) • X := by simp
+            _ = ((Matrix.trace X) * (Matrix.trace X)⁻¹) • X := by
+              field_simp [mt (hX_psd.trace_eq_zero_iff.mp ·) hX_zero]
+            _ = (Matrix.trace X) • ((Matrix.trace X)⁻¹ • X) := by simp [mul_smul]
+        rw [hX_eq]
+        have hmem : ((Matrix.trace X)⁻¹ • X) ∈ Submodule.span ℂ S :=
+          Submodule.subset_span (show ((Matrix.trace X)⁻¹ • X) ∈ S from hstat)
+        exact Submodule.smul_mem _ (Matrix.trace X) hmem
+    have h_span_le : Submodule.span ℂ P ≤ Submodule.span ℂ S :=
+      Submodule.span_le.mpr h_P_sub_span_S
+    rw [h_span_P] at h_span_le
+    exact h_span_le
 
 end IsPositiveMap

--- a/TNLean/Channel/FixedPoint/StationarySpan.lean
+++ b/TNLean/Channel/FixedPoint/StationarySpan.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.Cesaro
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.LinearAlgebra.Dimension.Finite
+
+/-!
+# Spanning by stationary density matrices
+
+This file proves Wolf Corollary 6.8 (Linearly independent stationary states):
+the fixed-point space of a positive trace-preserving linear map is spanned by
+stationary density matrices.
+
+## Source
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.8; local
+  source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1204--1218.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+variable {D : ℕ}
+
+/-- A stationary density matrix for a linear map `E`. -/
+structure IsStationaryDensity
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) : Prop where
+  posSemidef : ρ.PosSemidef
+  trace_one : Matrix.trace ρ = (1 : ℂ)
+  fixed_point : E ρ = ρ
+
+namespace IsPositiveMap
+
+variable (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+
+/-- The fixed-point subspace of `E`. -/
+def fixedPointsSubmodule (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) where
+  carrier := {X | E X = X}
+  add_mem' {a b} ha hb := by
+    simp at ha hb
+    show E (a + b) = a + b
+    rw [LinearMap.map_add, ha, hb]
+  zero_mem' := by simp
+  smul_mem' c {a} ha := by
+    simp at ha
+    show E (c • a) = c • a
+    rw [LinearMap.map_smul, ha]
+
+lemma mem_fixedPointsSubmodule {X : Matrix (Fin D) (Fin D) ℂ} :
+    X ∈ fixedPointsSubmodule E ↔ E X = X := Iff.rfl
+
+/-- The set of PSD fixed points. -/
+def posSemidefFixedPointsSet (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    Set (Matrix (Fin D) (Fin D) ℂ) :=
+  {X | X ∈ fixedPointsSubmodule E ∧ X.PosSemidef}
+
+lemma mem_posSemidefFixedPointsSet {X : Matrix (Fin D) (Fin D) ℂ} :
+    X ∈ posSemidefFixedPointsSet E ↔ E X = X ∧ X.PosSemidef := by
+  simp [posSemidefFixedPointsSet, IsPositiveMap.mem_fixedPointsSubmodule]
+
+/-- Every fixed point is a ℂ-linear combination of PSD fixed points
+(by Wolf Proposition 6.8). -/
+lemma fixedPoint_mem_span_posSemidef
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX_fix : E X = X) :
+    X ∈ Submodule.span ℂ (posSemidefFixedPointsSet E) := by
+  obtain ⟨P₁, P₂, P₃, P₄, hP₁, hP₂, hP₃, hP₄, hFP₁, hFP₂, hFP₃, hFP₄, h_decomp⟩ :=
+    IsPositiveMap.exists_posSemidef_fixedPoints_decomposition E hE hTP hX_fix
+  have mem (P : Matrix (Fin D) (Fin D) ℂ) (hPf : E P = P) (hPp : P.PosSemidef) :
+      P ∈ Submodule.span ℂ (posSemidefFixedPointsSet E) :=
+    Submodule.subset_span (by
+      rw [IsPositiveMap.mem_posSemidefFixedPointsSet]
+      exact ⟨hPf, hPp⟩)
+  rw [h_decomp]
+  refine Submodule.sub_mem _ (Submodule.smul_mem _ _ (Submodule.sub_mem _
+    (mem P₁ hFP₁ hP₁) (mem P₂ hFP₂ hP₂)))
+    (Submodule.smul_mem _ _ (Submodule.sub_mem _
+      (mem P₃ hFP₃ hP₃) (mem P₄ hFP₄ hP₄)))
+
+/-- The fixed-point subspace is spanned by its PSD elements. -/
+lemma fixedPointsSubmodule_top_span_by_posSemidef
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
+    Submodule.span ℂ (posSemidefFixedPointsSet E) = fixedPointsSubmodule E := by
+  apply le_antisymm
+  · refine Submodule.span_le.mpr ?_
+    rintro X ⟨hX_mem, -⟩
+    exact hX_mem
+  · intro X hX
+    rcases (IsPositiveMap.mem_fixedPointsSubmodule (E := E)).mp hX with hX_fix
+    exact fixedPoint_mem_span_posSemidef E hE hTP hX_fix
+
+end IsPositiveMap

--- a/TNLean/Channel/FixedPoint/StationarySpan.lean
+++ b/TNLean/Channel/FixedPoint/StationarySpan.lean
@@ -40,22 +40,17 @@ namespace IsPositiveMap
 
 variable (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
 
-/-- The fixed-point subspace of `E`. -/
+/-- The fixed-point subspace of `E`, realized as the kernel of `E - 1`.
+
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Equation (6.48);
+local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, line 1197. -/
 def fixedPointsSubmodule (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
-    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) where
-  carrier := {X | E X = X}
-  add_mem' {a b} ha hb := by
-    simp at ha hb
-    show E (a + b) = a + b
-    rw [LinearMap.map_add, ha, hb]
-  zero_mem' := by simp
-  smul_mem' c {a} ha := by
-    simp at ha
-    show E (c • a) = c • a
-    rw [LinearMap.map_smul, ha]
+    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+  LinearMap.ker (E - 1)
 
 lemma mem_fixedPointsSubmodule {X : Matrix (Fin D) (Fin D) ℂ} :
-    X ∈ fixedPointsSubmodule E ↔ E X = X := Iff.rfl
+    X ∈ fixedPointsSubmodule E ↔ E X = X := by
+  simp [fixedPointsSubmodule, LinearMap.mem_ker, sub_eq_zero]
 
 /-- The set of PSD fixed points. -/
 def posSemidefFixedPointsSet (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
@@ -64,7 +59,7 @@ def posSemidefFixedPointsSet (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix 
 
 lemma mem_posSemidefFixedPointsSet {X : Matrix (Fin D) (Fin D) ℂ} :
     X ∈ posSemidefFixedPointsSet E ↔ E X = X ∧ X.PosSemidef := by
-  simp [posSemidefFixedPointsSet, IsPositiveMap.mem_fixedPointsSubmodule]
+  simp [posSemidefFixedPointsSet, mem_fixedPointsSubmodule]
 
 /-- Every fixed point is a ℂ-linear combination of PSD fixed points
 (by Wolf Proposition 6.8). -/
@@ -77,7 +72,7 @@ lemma fixedPoint_mem_span_posSemidef
   have mem (P : Matrix (Fin D) (Fin D) ℂ) (hPf : E P = P) (hPp : P.PosSemidef) :
       P ∈ Submodule.span ℂ (posSemidefFixedPointsSet E) :=
     Submodule.subset_span (by
-      rw [IsPositiveMap.mem_posSemidefFixedPointsSet]
+      rw [mem_posSemidefFixedPointsSet]
       exact ⟨hPf, hPp⟩)
   rw [h_decomp]
   refine Submodule.sub_mem _ (Submodule.smul_mem _ _ (Submodule.sub_mem _
@@ -86,7 +81,7 @@ lemma fixedPoint_mem_span_posSemidef
       (mem P₃ hFP₃ hP₃) (mem P₄ hFP₄ hP₄)))
 
 /-- The fixed-point subspace is spanned by its PSD elements. -/
-lemma fixedPointsSubmodule_top_span_by_posSemidef
+lemma span_posSemidefFixedPointsSet_eq_fixedPointsSubmodule
     (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
     Submodule.span ℂ (posSemidefFixedPointsSet E) = fixedPointsSubmodule E := by
   apply le_antisymm
@@ -94,7 +89,7 @@ lemma fixedPointsSubmodule_top_span_by_posSemidef
     rintro X ⟨hX_mem, -⟩
     exact hX_mem
   · intro X hX
-    rcases (IsPositiveMap.mem_fixedPointsSubmodule (E := E)).mp hX with hX_fix
+    have hX_fix : E X = X := (mem_fixedPointsSubmodule (E := E)).mp hX
     exact fixedPoint_mem_span_posSemidef E hE hTP hX_fix
 
 /-- For a nonzero PSD matrix, its trace has strictly positive real part.
@@ -127,21 +122,12 @@ lemma stationaryDensity_of_posSemidef_fixedPoint
   have him_zero : (Matrix.trace ρ).im = 0 :=
     ((RCLike.nonneg_iff (K := ℂ)).mp hρ_psd.trace_nonneg).2
   have hinv_nonneg_ℂ : 0 ≤ ((Matrix.trace ρ)⁻¹ : ℂ) := by
-    have htr_nonneg : 0 ≤ (Matrix.trace ρ : ℂ) := hρ_psd.trace_nonneg
-    have htr_ne_zero : Matrix.trace ρ ≠ 0 :=
-      mt (hρ_psd.trace_eq_zero_iff.mp ·) hρ_ne
-    -- In a StarOrderedRing, if 0 ≤ a and a ≠ 0, then 0 ≤ a⁻¹.
-    -- For ℂ specifically, this holds because the positive cone is ℝ≥0.
-    -- Use the fact that trace ρ is a real positive number.
-    have htr_real : (Matrix.trace ρ : ℂ) = ((Matrix.trace ρ).re : ℂ) :=
+    have htrace_eq : (Matrix.trace ρ : ℂ) = ((Matrix.trace ρ).re : ℂ) :=
       Complex.ext rfl him_zero
-    rw [htr_real]
-    -- Now we need 0 ≤ ((re : ℂ)⁻¹). Since re > 0, its inverse is ≥ 0.
-    have hrepos : (0 : ℝ) ≤ ((Matrix.trace ρ).re)⁻¹ := by
+    rw [htrace_eq]
+    have hre_inv_nonneg : (0 : ℝ) ≤ ((Matrix.trace ρ).re)⁻¹ := by
       positivity
-    have hpos_ℂ : (0 : ℂ) ≤ (((Matrix.trace ρ).re : ℝ)⁻¹ : ℂ) := by
-      exact_mod_cast hrepos
-    simpa [map_inv₀ (algebraMap ℝ ℂ)] using hpos_ℂ
+    exact mod_cast hre_inv_nonneg
   have h_psd : ((Matrix.trace ρ)⁻¹ • ρ).PosSemidef :=
     hρ_psd.smul hinv_nonneg_ℂ
   have h_trace_one : Matrix.trace ((Matrix.trace ρ)⁻¹ • ρ) = (1 : ℂ) := by
@@ -163,7 +149,7 @@ The fixed-point subspace of a positive trace-preserving linear map is spanned
 The dimension/basis statement with exactly `r` linearly independent stationary
 density matrices is tracked for follow-up work. -/
 theorem fixedPointsSubmodule_spanned_by_stationaryDensities
-    [NeZero D] (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
     Submodule.span ℂ {ρ | IsStationaryDensity E ρ} = fixedPointsSubmodule E := by
   set P := posSemidefFixedPointsSet E
   set S : Set (Matrix (Fin D) (Fin D) ℂ) := {ρ | IsStationaryDensity E ρ}
@@ -173,10 +159,10 @@ theorem fixedPointsSubmodule_spanned_by_stationaryDensities
     rintro ρ hρ
     have hρ_sd : IsStationaryDensity E ρ := hρ
     have hmem : E ρ = ρ := hρ_sd.fixed_point
-    simpa [IsPositiveMap.mem_fixedPointsSubmodule] using hmem
+    simpa [mem_fixedPointsSubmodule] using hmem
   · -- fixedPointsSubmodule ⊆ span(stationary)
     have h_span_P : Submodule.span ℂ P = fixedPointsSubmodule E :=
-      fixedPointsSubmodule_top_span_by_posSemidef E hE hTP
+      span_posSemidefFixedPointsSet_eq_fixedPointsSubmodule E hE hTP
     have h_P_sub_span_S : P ⊆ Submodule.span ℂ S := by
       intro X hX
       rw [mem_posSemidefFixedPointsSet] at hX

--- a/TNLean/Channel/FixedPoint/StationarySpan.lean
+++ b/TNLean/Channel/FixedPoint/StationarySpan.lean
@@ -113,7 +113,6 @@ lemma trace_re_pos_of_posSemidef_ne_zero
 /-- A nonzero PSD fixed point, scaled by the inverse of its trace, yields a
 stationary density matrix. -/
 lemma stationaryDensity_of_posSemidef_fixedPoint
-    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ_psd : ρ.PosSemidef)
     (hρ_fix : E ρ = ρ) (hρ_ne : ρ ≠ 0) :
     IsStationaryDensity E ((Matrix.trace ρ)⁻¹ • ρ) := by
@@ -171,7 +170,7 @@ theorem fixedPointsSubmodule_spanned_by_stationaryDensities
       · rw [hX_zero]
         exact Submodule.zero_mem _
       · have hstat : IsStationaryDensity E ((Matrix.trace X)⁻¹ • X) :=
-          stationaryDensity_of_posSemidef_fixedPoint E hE hTP hX_psd hX_fix hX_zero
+          stationaryDensity_of_posSemidef_fixedPoint E hX_psd hX_fix hX_zero
         -- X = (tr X) • ((tr X)⁻¹ • X), so X is in the span of stationary densities
         have hX_eq : X = (Matrix.trace X) • ((Matrix.trace X)⁻¹ • X) := by
           calc

--- a/TNLean/Channel/FixedPoint/StationaryStates.lean
+++ b/TNLean/Channel/FixedPoint/StationaryStates.lean
@@ -15,9 +15,12 @@ Wolf Theorem 6.11 (Stationary states).
 
 ## Main definitions
 
-* `IsPositive` — a map (not necessarily linear) that sends PSD matrices to PSD matrices.
-* `IsTracePreserving` — a map (not necessarily linear) that preserves the trace.
-* `IsStationaryMap` — the conjunction of continuity, positivity, and trace preservation.
+* `IsStationaryMap.IsPositive` — a map (not necessarily linear) that sends
+  PSD matrices to PSD matrices.
+* `IsStationaryMap.IsTracePreserving` — a map (not necessarily linear) that
+  preserves the trace.
+* `IsStationaryMap` — the conjunction of continuity, positivity, and trace
+  preservation.
 
 ## Main results
 
@@ -39,6 +42,8 @@ open Matrix
 
 variable {D : ℕ}
 
+namespace IsStationaryMap
+
 /-- A map `T : M_D(ℂ) → M_D(ℂ)` is **positive** if it sends positive semidefinite
 matrices to positive semidefinite matrices.  This predicate is independent of
 linearity. -/
@@ -50,6 +55,8 @@ trace of every matrix.  This predicate is independent of linearity. -/
 def IsTracePreserving (T : Matrix (Fin D) (Fin D) ℂ → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   ∀ X : Matrix (Fin D) (Fin D) ℂ, Matrix.trace (T X) = Matrix.trace X
 
+end IsStationaryMap
+
 /-- A map is a **stationary map** (terminology of Wolf Theorem 6.11) if it is
 continuous, positive, and trace-preserving.  Linearity is not required; this
 matches the source statement that T is ``continuous, trace-preserving, positive
@@ -60,8 +67,8 @@ source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1152--1159.
 structure IsStationaryMap
     (T : Matrix (Fin D) (Fin D) ℂ → Matrix (Fin D) (Fin D) ℂ) : Prop where
   continuous : Continuous T
-  positive : IsPositive T
-  trace_preserving : IsTracePreserving T
+  positive : IsStationaryMap.IsPositive T
+  trace_preserving : IsStationaryMap.IsTracePreserving T
 
 namespace IsStationaryMap
 
@@ -117,9 +124,7 @@ lemma of_linear (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin 
     (hPos : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
     IsStationaryMap (fun X => E X) := by
   refine
-    { continuous := by
-        -- Linear maps on finite-dimensional spaces are continuous
-        exact LinearMap.continuous_of_finiteDimensional E
+    { continuous := LinearMap.continuous_of_finiteDimensional E
       positive := hPos
       trace_preserving := hTP }
 
@@ -142,17 +147,17 @@ theorem exists_stationaryState_of_channel [NeZero D]
 
 end IsStationaryMap
 
-/-! ### Compatibility bridges with the existing linear-map definitions
+/-! ### Compatibility with the existing linear-map definitions
 
 The predicates defined above for arbitrary functions coincide with the existing
 linear-map predicates when applied to linear maps. -/
 
-theorem IsPositive.eq_of_linear
+theorem IsStationaryMap.isPositive_eq_of_linear
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
-    IsPositive (fun X => E X) ↔ IsPositiveMap E := by
-  simp [IsPositive, IsPositiveMap]
+    IsStationaryMap.IsPositive (fun X => E X) ↔ IsPositiveMap E := by
+  simp [IsStationaryMap.IsPositive, IsPositiveMap]
 
-theorem IsTracePreserving.eq_of_linear
+theorem IsStationaryMap.isTracePreserving_eq_of_linear
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
-    IsTracePreserving (fun X => E X) ↔ IsTracePreservingMap E := by
-  simp [IsTracePreserving, IsTracePreservingMap]
+    IsStationaryMap.IsTracePreserving (fun X => E X) ↔ IsTracePreservingMap E := by
+  simp [IsStationaryMap.IsTracePreserving, IsTracePreservingMap]

--- a/TNLean/Channel/FixedPoint/StationaryStates.lean
+++ b/TNLean/Channel/FixedPoint/StationaryStates.lean
@@ -99,21 +99,8 @@ proved for density matrices) yields a fixed point.
 Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.11; local
 source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1152--1159. -/
 theorem exists_stationaryState [NeZero D] (hT : IsStationaryMap T) :
-    ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ ∈ densityMatrices D ∧ T ρ = ρ := by
-  have h_nonempty : (densityMatrices D).Nonempty :=
-    densityMatrices_nonempty (NeZero.pos D)
-  have h_compact : IsCompact (densityMatrices D) :=
-    densityMatrices_isCompact
-  have h_convex : Convex ℝ (densityMatrices D) :=
-    densityMatrices_isConvex
-  have h_maps : Set.MapsTo T (densityMatrices D) (densityMatrices D) :=
-    hT.maps_densityMatrices
-  have h_cont : ContinuousOn T (densityMatrices D) :=
-    hT.continuousOn_densityMatrices
-  have h_exists : ∃ ρ ∈ densityMatrices D, T ρ = ρ :=
-    brouwer_fixedPoint_densityMatrices h_cont h_maps
-  obtain ⟨ρ, hρ, hTx⟩ := h_exists
-  exact ⟨ρ, hρ, hTx⟩
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ ∈ densityMatrices D ∧ T ρ = ρ :=
+  brouwer_fixedPoint_densityMatrices (hT.continuousOn_densityMatrices) (hT.maps_densityMatrices)
 
 /-- **Wolf Theorem 6.11**, alternative formulation: the fixed point is a
 density matrix (PSD, trace 1) satisfying `T ρ = ρ`. -/

--- a/TNLean/Channel/FixedPoint/StationaryStates.lean
+++ b/TNLean/Channel/FixedPoint/StationaryStates.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Axioms.BrouwerFixedPoint
+import TNLean.Channel.Basic
+
+/-!
+# Stationary states for continuous positive trace-preserving maps
+
+This file proves the existence of stationary states for continuous (not
+necessarily linear) positive trace-preserving maps on `M_D(ℂ)`, following
+Wolf Theorem 6.11 (Stationary states).
+
+## Main definitions
+
+* `IsPositive` — a map (not necessarily linear) that sends PSD matrices to PSD matrices.
+* `IsTracePreserving` — a map (not necessarily linear) that preserves the trace.
+* `IsStationaryMap` — the conjunction of continuity, positivity, and trace preservation.
+
+## Main results
+
+* `IsStationaryMap.maps_densityMatrices` — a stationary map sends density matrices
+  to density matrices, so it restricts to a continuous self-map of the compact
+  convex set of density matrices.
+* `IsStationaryMap.exists_stationaryState` — existence of a density-matrix fixed
+  point (Wolf Theorem 6.11).
+
+## Source
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.11; local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1152--1159.
+
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+variable {D : ℕ}
+
+/-- A map `T : M_D(ℂ) → M_D(ℂ)` is **positive** if it sends positive semidefinite
+matrices to positive semidefinite matrices.  This predicate is independent of
+linearity. -/
+def IsPositive (T : Matrix (Fin D) (Fin D) ℂ → Matrix (Fin D) (Fin D) ℂ) : Prop :=
+  ∀ X : Matrix (Fin D) (Fin D) ℂ, X.PosSemidef → (T X).PosSemidef
+
+/-- A map `T : M_D(ℂ) → M_D(ℂ)` is **trace-preserving** if it preserves the
+trace of every matrix.  This predicate is independent of linearity. -/
+def IsTracePreserving (T : Matrix (Fin D) (Fin D) ℂ → Matrix (Fin D) (Fin D) ℂ) : Prop :=
+  ∀ X : Matrix (Fin D) (Fin D) ℂ, Matrix.trace (T X) = Matrix.trace X
+
+/-- A map is a **stationary map** (terminology of Wolf Theorem 6.11) if it is
+continuous, positive, and trace-preserving.  Linearity is not required; this
+matches the source statement that T is ``continuous, trace-preserving, positive
+(not necessarily linear)''.
+
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.11; local
+source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1152--1159. -/
+structure IsStationaryMap
+    (T : Matrix (Fin D) (Fin D) ℂ → Matrix (Fin D) (Fin D) ℂ) : Prop where
+  continuous : Continuous T
+  positive : IsPositive T
+  trace_preserving : IsTracePreserving T
+
+namespace IsStationaryMap
+
+variable (T : Matrix (Fin D) (Fin D) ℂ → Matrix (Fin D) (Fin D) ℂ)
+
+/-- A stationary map sends density matrices to density matrices.
+
+If `ρ` is PSD with trace 1, then so is `T(ρ)` — positivity gives PSD, and trace
+preservation gives trace 1. -/
+lemma maps_densityMatrices (hT : IsStationaryMap T) :
+    Set.MapsTo T (densityMatrices D) (densityMatrices D) := by
+  intro ρ hρ
+  rcases hρ with ⟨hρ_psd, hρ_tr⟩
+  refine ⟨hT.positive ρ hρ_psd, ?_⟩
+  rw [hT.trace_preserving ρ, hρ_tr]
+
+/-- A stationary map is continuous on the set of density matrices.
+
+This follows from global continuity. -/
+lemma continuousOn_densityMatrices (hT : IsStationaryMap T) :
+    ContinuousOn T (densityMatrices D) :=
+  hT.continuous.continuousOn
+
+/-- **Wolf Theorem 6.11 (Stationary states).**
+
+Every continuous, trace-preserving, positive (not necessarily linear) map
+`T : M_D(ℂ) → M_D(ℂ)` has at least one stationary state: a density matrix `ρ`
+such that `T(ρ) = ρ`.
+
+The proof is the one given by Wolf: the density matrices form a nonempty compact
+convex set, positivity + trace preservation implies `T` restricts to a
+continuous self-map of this set, and Brouwer's fixed point theorem (already
+proved for density matrices) yields a fixed point.
+
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.11; local
+source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1152--1159. -/
+theorem exists_stationaryState [NeZero D] (hT : IsStationaryMap T) :
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ ∈ densityMatrices D ∧ T ρ = ρ := by
+  have h_nonempty : (densityMatrices D).Nonempty :=
+    densityMatrices_nonempty (NeZero.pos D)
+  have h_compact : IsCompact (densityMatrices D) :=
+    densityMatrices_isCompact
+  have h_convex : Convex ℝ (densityMatrices D) :=
+    densityMatrices_isConvex
+  have h_maps : Set.MapsTo T (densityMatrices D) (densityMatrices D) :=
+    hT.maps_densityMatrices
+  have h_cont : ContinuousOn T (densityMatrices D) :=
+    hT.continuousOn_densityMatrices
+  have h_exists : ∃ ρ ∈ densityMatrices D, T ρ = ρ :=
+    brouwer_fixedPoint_densityMatrices h_cont h_maps
+  obtain ⟨ρ, hρ, hTx⟩ := h_exists
+  exact ⟨ρ, hρ, hTx⟩
+
+/-- **Wolf Theorem 6.11**, alternative formulation: the fixed point is a
+density matrix (PSD, trace 1) satisfying `T ρ = ρ`. -/
+theorem exists_stationaryState' [NeZero D] (hT : IsStationaryMap T) :
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ,
+      ρ.PosSemidef ∧ Matrix.trace ρ = 1 ∧ T ρ = ρ := by
+  obtain ⟨ρ, hρ, hTx⟩ := hT.exists_stationaryState
+  exact ⟨ρ, hρ.1, hρ.2, hTx⟩
+
+/-- Compatibility lemma: a linear positive trace-preserving map (in the sense of
+`IsPositiveMap` / `IsTracePreservingMap`) is a stationary map, because linear maps
+on finite-dimensional spaces are automatically continuous. -/
+lemma of_linear (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hPos : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
+    IsStationaryMap (fun X => E X) := by
+  refine
+    { continuous := by
+        -- Linear maps on finite-dimensional spaces are continuous
+        exact LinearMap.continuous_of_finiteDimensional E
+      positive := hPos
+      trace_preserving := hTP }
+
+/-- Wolf Theorem 6.11 for a linear positive trace-preserving map (the linear
+case that is the setting for Proposition 6.8 and the later fixed-point theory). -/
+theorem exists_stationaryState_of_linear [NeZero D]
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hPos : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ ∈ densityMatrices D ∧ E ρ = ρ :=
+  exists_stationaryState (fun X => E X) (of_linear E hPos hTP)
+
+/-- Wolf Theorem 6.11 for a quantum channel (linear CPTP map).  This recovers
+the existence result already proved by Cesàro means in `Cesaro.lean`, but now via
+Brouwer's fixed point theorem (the route taken by Wolf). -/
+theorem exists_stationaryState_of_channel [NeZero D]
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hE : IsChannel E) :
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ ∈ densityMatrices D ∧ E ρ = ρ :=
+  exists_stationaryState_of_linear E hE.pos hE.tp
+
+end IsStationaryMap
+
+/-! ### Compatibility bridges with the existing linear-map definitions
+
+The predicates defined above for arbitrary functions coincide with the existing
+linear-map predicates when applied to linear maps. -/
+
+theorem IsPositive.eq_of_linear
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    IsPositive (fun X => E X) ↔ IsPositiveMap E := by
+  simp [IsPositive, IsPositiveMap]
+
+theorem IsTracePreserving.eq_of_linear
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    IsTracePreserving (fun X => E X) ↔ IsTracePreservingMap E := by
+  simp [IsTracePreserving, IsTracePreservingMap]

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -271,13 +271,44 @@ In `TNLean.Channel.FixedPoint.Algebra`:
 ### Wolf Theorem 6.10 (Brouwer's fixed point theorem)
 
 * `brouwer_fixedPoint_densityMatrices` — `TNLean.Axioms.BrouwerFixedPoint`
+  (density-matrix specialization; kernel-checked).
+* `Gametheory.Brouwer.Brouwer` — exact import citation: Brouwer for the
+  standard simplex (LionSR/Brouwer library).
+* `exists_fixedPoint_closedCube` — `TNLean.Topology.BrouwerProduct`;
+  extends Brouwer to closed cubes.
+* `fixedPoint_of_compact_retract` — `TNLean.Topology.CompactRetractFixedPoint`;
+  extends Brouwer to compact retracts of finite-dimensional real normed spaces.
+* The general compact-convex statement (Wolf's formulation) is not yet proved;
+  see `docs/paper-gaps/brouwer_general_compact_convex.tex`.
 
-### Wolf Theorem 6.11 (Stationary states)
+### Wolf Theorem 6.11 (Stationary states) — FORMALIZED
 
-* Via Brouwer: `exists_posSemidef_eigenvector` (for general positive maps)
-* Via Cesàro: `IsChannel.exists_posSemidef_fixedPoint` — `TNLean.Channel.FixedPoint.Cesaro`
+The theorem is formalized for continuous (not necessarily linear) maps, exactly
+matching Wolf's statement ("continuous, trace-preserving, positive (not
+necessarily linear)").  The linear specializations are also provided.
 
-### Wolf Proposition 6.8 (Positive fixed-points)
+In `TNLean.Channel.FixedPoint.StationaryStates`:
+
+* `IsPositive` — positivity predicate for arbitrary (nonlinear) maps.
+* `IsTracePreserving` — trace-preservation predicate for arbitrary maps.
+* `IsStationaryMap` — conjunction of continuity, positivity, trace preservation.
+* `IsStationaryMap.exists_stationaryState` — Wolf Theorem 6.11: existence of a
+  density-matrix fixed point for a stationary map.  The proof uses
+  `brouwer_fixedPoint_densityMatrices`.
+* `IsStationaryMap.exists_stationaryState_of_linear` — specialization to linear
+  positive trace-preserving maps.
+* `IsStationaryMap.exists_stationaryState_of_channel` — specialization to
+  quantum channels (linear CPTP maps).  This recovers the existence result
+  already proved by Cesàro means in `Cesaro.lean`, but now via Brouwer.
+
+Additionally:
+
+* Via Cesàro: `IsChannel.exists_posSemidef_fixedPoint` —
+  `TNLean.Channel.FixedPoint.Cesaro`.
+* Via Brouwer (linear): `exists_posSemidef_eigenvector` —
+  `TNLean.Channel.PerronFrobenius.Existence`.
+
+### Wolf Proposition 6.8 (Positive fixed-points) — FORMALIZED
 
 * `IsPositiveMap.posPart_negPart_fixed_of_fixedPoint` — the source-faithful positive
   trace-preserving statement for the four canonical positive parts in
@@ -289,6 +320,20 @@ In `TNLean.Channel.FixedPoint.Algebra`:
 * `IsChannel.posSemidef_parts_of_hermitian_fixedPoint` — the channel specialization.
 * Numbered theorem: `IsPositiveMap.wolf_prop_6_8` —
   `TNLean.Channel.WolfChapter6Wrappers`.
+
+### Wolf Corollary 6.8 (Linearly independent stationary states) — FORMALIZED
+
+In `TNLean.Channel.FixedPoint.StationarySpan`:
+
+* `IsStationaryDensity` — predicate for a stationary density matrix (PSD,
+  trace 1, fixed by the map).
+* `IsPositiveMap.fixedPointsSubmodule` — the fixed-point subspace as a
+  `Submodule ℂ M_D(ℂ)`.
+* `IsPositiveMap.fixedPointsSubmodule_top_span_by_posSemidef` — the fixed-point
+  subspace is spanned (over ℂ) by its positive semidefinite elements (this is
+  the key lemma for the corollary).
+* The corollary's full statement with basis and dimension (Wolf's form) remains
+  to be proved; the spanning lemma is the load-bearing step.
 
 ### Wolf Corollary 6.6 (projected support corner) — FORMALIZED (Kraus case)
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -321,7 +321,7 @@ Additionally:
 * Numbered theorem: `IsPositiveMap.wolf_prop_6_8` —
   `TNLean.Channel.WolfChapter6Wrappers`.
 
-### Wolf Corollary 6.8 (Linearly independent stationary states) — FORMALIZED
+### Wolf Corollary 6.8 (Linearly independent stationary states) — KEY LEMMA FORMALIZED (basis/dimension statement open)
 
 In `TNLean.Channel.FixedPoint.StationarySpan`:
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -272,7 +272,7 @@ In `TNLean.Channel.FixedPoint.Algebra`:
 
 * `brouwer_fixedPoint_densityMatrices` — `TNLean.Axioms.BrouwerFixedPoint`
   (density-matrix specialization; kernel-checked).
-* `Gametheory.Brouwer.Brouwer` — exact import citation: Brouwer for the
+* `Brouwer (vendored Gametheory library)` — exact import citation: Brouwer for the
   standard simplex (LionSR/Brouwer library).
 * `exists_fixedPoint_closedCube` — `TNLean.Topology.BrouwerProduct`;
   extends Brouwer to closed cubes.
@@ -329,7 +329,7 @@ In `TNLean.Channel.FixedPoint.StationarySpan`:
   trace 1, fixed by the map).
 * `IsPositiveMap.fixedPointsSubmodule` — the fixed-point subspace as a
   `Submodule ℂ M_D(ℂ)`.
-* `IsPositiveMap.fixedPointsSubmodule_top_span_by_posSemidef` — the fixed-point
+* `IsPositiveMap.span_posSemidefFixedPointsSet_eq_fixedPointsSubmodule` — the fixed-point
   subspace is spanned (over ℂ) by its positive semidefinite elements (this is
   the key lemma for the corollary).
 * The corollary's full statement with basis and dimension (Wolf's form) remains

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -289,8 +289,8 @@ necessarily linear)").  The linear specializations are also provided.
 
 In `TNLean.Channel.FixedPoint.StationaryStates`:
 
-* `IsPositive` — positivity predicate for arbitrary (nonlinear) maps.
-* `IsTracePreserving` — trace-preservation predicate for arbitrary maps.
+* `IsStationaryMap.IsPositive` — positivity predicate for arbitrary (nonlinear) maps.
+* `IsStationaryMap.IsTracePreserving` — trace-preservation predicate for arbitrary maps.
 * `IsStationaryMap` — conjunction of continuity, positivity, trace preservation.
 * `IsStationaryMap.exists_stationaryState` — Wolf Theorem 6.11: existence of a
   density-matrix fixed point for a stationary map.  The proof uses

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -809,11 +809,11 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{theorem}[Stationary states --- nonlinear]\label{thm:stationary_states}
     \lean{IsStationaryMap.exists_stationaryState}
-    \lean{IsStationaryMap, IsPositive, IsTracePreserving}
+    \lean{IsStationaryMap, IsStationaryMap.IsPositive, IsStationaryMap.IsTracePreserving}
     \leanok
     \uses{def:density_matrices, thm:brouwer_density_matrices}
-    Let $T\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a continuous,
-    trace-preserving, positive (not necessarily linear) map.
+    Let $D\ge 1$ and let $T\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a
+    continuous, trace-preserving, positive (not necessarily linear) map.
     Then $T$ has at least one stationary state: a density matrix $\rho$
     such that $T(\rho)=\rho$.
 
@@ -867,24 +867,24 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \lean{IsPositiveMap.fixedPointsSubmodule_top_span_by_posSemidef}
     \lean{IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities}
     \lean{IsStationaryDensity}
+    \leanok
     \uses{thm:positive_fixedpoint_decomp}
     Let $E\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a positive,
     trace-preserving linear map with $D>0$.  The fixed-point subspace
     $\mathcal F_E=\{X\mid E(X)=X\}$ is spanned (over $\mathbb C$) by
     stationary density matrices (positive semidefinite, trace~1, fixed by~$E$).
+    \lean{IsPositiveMap.stationaryDensity_of_posSemidef_fixedPoint}
     Each nonzero positive-semidefinite fixed point can be scaled to a stationary
     density matrix.
 \end{corollary}
 
-\begin{proof}
-    \uses{thm:positive_fixedpoint_decomp,
-    thm:positive_fixedpoint_decomp}
+\begin{proof}\leanok
+    \uses{thm:positive_fixedpoint_decomp}
     By Theorem~\ref{thm:positive_fixedpoint_decomp}, every fixed point is a
     $\mathbb C$-linear combination of four positive-semidefinite fixed points.
-    For each nonzero positive-semidefinite fixed point $\rho$, the trace of a
-    positive-semidefinite matrix is zero only for the zero matrix
-    (Theorem~\ref{thm:positive_fixedpoint_decomp}), so $\tr(\rho)$ is a positive
-    real number.  Hence $\rho/\tr(\rho)$ is a stationary density matrix, and
+    For each nonzero positive-semidefinite fixed point $\rho$, a
+    positive-semidefinite matrix has zero trace only if it is the zero matrix,
+    so $\tr(\rho)$ is a positive real number.  Hence $\rho/\tr(\rho)$ is a stationary density matrix, and
     $\rho = \tr(\rho) \cdot (\rho/\tr(\rho))$ is in the span of the stationary
     density matrices.  The span of all positive-semidefinite fixed points
     therefore equals the span of the stationary density matrices, which

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -838,7 +838,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \lean{IsPositiveMap.posPart_negPart_fixed_of_fixedPoint}
     \lean{IsPositiveMap.exists_posSemidef_fixedPoints_decomposition}
     \leanok
-    \uses{def:positive_map, thm:stationary_states}
+    \uses{def:positive_map}
     Let $E\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a positive,
     trace-preserving linear map and $X=E(X)$ a fixed point.
     Decompose $X$ into Hermitian and anti-Hermitian parts and then each into

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -794,7 +794,6 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{theorem}[Brouwer's fixed point theorem (simplex)]
     \label{thm:brouwer_simplex}
-    \lean{Gametheory.Brouwer.Brouwer}
     Let $f\colon\Delta^n\to\Delta^n$ be a continuous map from the standard
     $n$-simplex to itself. Then there exists $x\in\Delta^n$ such that
     $f(x)=x$.

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -798,13 +798,10 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     $n$-simplex to itself. Then there exists $x\in\Delta^n$ such that
     $f(x)=x$.
 
-    The general compact-convex form stated by \cite[Theorem~6.10]{Wolf2012Quantum}
-    (continuous self-map of a nonempty compact convex subset of~$\mathbb{R}^n$
-    has a fixed point) is not yet proved.
-    The simplex version, its extension to products of simplices, closed cubes,
-    compact retracts, and the density-matrix specialization
-    (Theorem~\ref{thm:brouwer_density_matrices}) are formalized and suffice for
-    all current applications.
+    % The general compact-convex form stated by \cite[Theorem~6.10]{Wolf2012Quantum}
+    % is not yet proved.  The simplex version and its extensions (products of
+    % simplices, closed cubes, compact retracts, density-matrix specialization)
+    % are formalized and suffice for all current applications.
 \end{theorem}
 
 \begin{theorem}[Stationary states --- nonlinear]\label{thm:stationary_states}
@@ -864,7 +861,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{corollary}[Spanning by stationary density matrices]\label{cor:stationary_density_span}
     \lean{IsPositiveMap.fixedPointsSubmodule}
-    \lean{IsPositiveMap.fixedPointsSubmodule_top_span_by_posSemidef}
+    \lean{IsPositiveMap.span_posSemidefFixedPointsSet_eq_fixedPointsSubmodule}
     \lean{IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities}
     \lean{IsStationaryDensity}
     \leanok
@@ -890,8 +887,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     therefore equals the span of the stationary density matrices, which
     equals~$\mathcal F_E$.
 
-    The dimension statement of Wolf Corollary~6.8 (a basis of exactly~$r$
-    linearly independent stationary density matrices, where~$r$ is the dimension
-    of~$\mathcal F_E$) follows from the spanning result and finite dimensionality
-    but is not yet formalized.
+    % The dimension statement of Wolf Corollary~6.8 (a basis of exactly~r
+    % linearly independent stationary density matrices) follows from the spanning
+    % result and finite dimensionality but is not yet formalized.
 \end{proof}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -789,3 +789,104 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{proof}
 
 
+
+\section{General Brouwer and stationary states}
+
+\begin{theorem}[Brouwer's fixed point theorem (simplex)]
+    \label{thm:brouwer_simplex}
+    \lean{Gametheory.Brouwer.Brouwer}
+    \leanok
+    Let $f\colon\Delta^n\to\Delta^n$ be a continuous map from the standard
+    $n$-simplex to itself. Then there exists $x\in\Delta^n$ such that
+    $f(x)=x$.
+
+    This theorem is proved in the vendored Gametheory library
+    (LionSR/Brouwer).  Its extensions to products of simplices, closed cubes,
+    and compact retracts are available in
+    \texttt{TNLean.Topology.BrouwerProduct} and
+    \texttt{TNLean.Topology.CompactRetractFixedPoint}.  The density-matrix
+    specialization is Theorem~\ref{thm:brouwer_density_matrices}.
+    The general compact-convex form stated by Wolf is not yet proved; see
+    \texttt{docs/paper-gaps/brouwer\_general\_compact\_convex.tex}.
+\end{theorem}
+
+\begin{theorem}[Stationary states --- nonlinear]\label{thm:stationary_states}
+    \lean{IsStationaryMap.exists_stationaryState}
+    \lean{IsStationaryMap, IsPositive, IsTracePreserving}
+    \leanok
+    \uses{def:density_matrices, thm:brouwer_density_matrices}
+    Let $T\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a continuous,
+    trace-preserving, positive (not necessarily linear) map.
+    Then $T$ has at least one stationary state: a density matrix $\rho$
+    such that $T(\rho)=\rho$.
+
+    This matches Wolf Theorem~6.11 exactly: the hypotheses are continuity,
+    positivity ($X\geq0\Rightarrow T(X)\geq0$), and trace preservation
+    ($\tr(T(X))=\tr(X)$).  Linearity is not assumed.
+
+    The proof is Wolf's argument: positivity and trace preservation imply that
+    $T$ restricts to a continuous self-map of the compact convex set of
+    density matrices; the density-matrix version of Brouwer
+    (Theorem~\ref{thm:brouwer_density_matrices}) then yields a fixed point.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:brouwer_density_matrices}
+    Positivity and trace preservation give $T(\rho)\in\mathcal D_D$ for every
+    $\rho\in\mathcal D_D$; continuity of $T$ gives continuity on $\mathcal D_D$.
+    Theorem~\ref{thm:brouwer_density_matrices} applied to the restriction
+    $T|_{\mathcal D_D}$ yields $\rho\in\mathcal D_D$ with $T(\rho)=\rho$.
+\end{proof}
+
+\section{Fixed-point decomposition and span}
+
+\begin{theorem}[Positive fixed-point decomposition]\label{thm:positive_fixedpoint_decomp}
+    \lean{IsPositiveMap.posPart_negPart_fixed_of_fixedPoint}
+    \lean{IsPositiveMap.exists_posSemidef_fixedPoints_decomposition}
+    \leanok
+    \uses{def:positive_map, thm:stationary_states}
+    Let $E\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a positive,
+    trace-preserving linear map and $X=E(X)$ a fixed point.
+    Decompose $X$ into Hermitian and anti-Hermitian parts and then each into
+    orthogonal positive and negative parts, yielding four positive
+    semidefinite operators $P_1,\dots,P_4$.
+    Then $E(P_j)=P_j$ for $j=1,\dots,4$;
+    in other words, every fixed point is a $\mathbb C$-linear combination
+    of four positive-semidefinite fixed points.
+
+    This is Wolf Proposition~6.8.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:positive_map}
+    The proof follows Wolf: first handle Hermitian fixed points by the
+    orthogonality argument using the support projection (equation~(6.46)--(6.47)
+    in the source), then decompose an arbitrary fixed point into Hermitian
+    and skew-Hermitian parts and apply the Hermitian case to each.
+\end{proof}
+
+\begin{corollary}[Spanning by stationary density matrices]\label{cor:stationary_density_span}
+    \lean{IsPositiveMap.fixedPointsSubmodule}
+    \lean{IsPositiveMap.fixedPointsSubmodule_top_span_by_posSemidef}
+    \lean{IsStationaryDensity}
+    \uses{thm:positive_fixedpoint_decomp}
+    Let $E\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a positive,
+    trace-preserving linear map.  The fixed-point subspace
+    $\mathcal F_E=\{X\mid E(X)=X\}$ is spanned (over $\mathbb C$) by its
+    positive-semidefinite elements.  Each nonzero positive-semidefinite fixed
+    point can be scaled to a stationary density matrix (positive semidefinite,
+    trace~1, fixed by~$E$).
+
+    This is the key lemma for Wolf Corollary~6.8.
+\end{corollary}
+
+\begin{proof}
+    \uses{thm:positive_fixedpoint_decomp}
+    By Theorem~\ref{thm:positive_fixedpoint_decomp}, every fixed point is a
+    $\mathbb C$-linear combination of four positive-semidefinite fixed points,
+    hence lies in the span of the set of all positive-semidefinite fixed
+    points.  Thus the span of the positive-semidefinite fixed points equals the
+    whole fixed-point subspace.  For the scaling: if $\rho$ is a nonzero
+    positive-semidefinite fixed point, its trace is a positive real number, and
+    $\rho/\tr(\rho)$ is a stationary density matrix.
+\end{proof}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -795,7 +795,6 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \begin{theorem}[Brouwer's fixed point theorem (simplex)]
     \label{thm:brouwer_simplex}
     \lean{Gametheory.Brouwer.Brouwer}
-    \leanok
     Let $f\colon\Delta^n\to\Delta^n$ be a continuous map from the standard
     $n$-simplex to itself. Then there exists $x\in\Delta^n$ such that
     $f(x)=x$.

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -798,14 +798,13 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     $n$-simplex to itself. Then there exists $x\in\Delta^n$ such that
     $f(x)=x$.
 
-    This theorem is proved in the vendored Gametheory library
-    (LionSR/Brouwer).  Its extensions to products of simplices, closed cubes,
-    and compact retracts are available in
-    \texttt{TNLean.Topology.BrouwerProduct} and
-    \texttt{TNLean.Topology.CompactRetractFixedPoint}.  The density-matrix
-    specialization is Theorem~\ref{thm:brouwer_density_matrices}.
-    The general compact-convex form stated by Wolf is not yet proved; see
-    \texttt{docs/paper-gaps/brouwer\_general\_compact\_convex.tex}.
+    The general compact-convex form stated by \cite[Theorem~6.10]{Wolf2012Quantum}
+    (continuous self-map of a nonempty compact convex subset of~$\mathbb{R}^n$
+    has a fixed point) is not yet proved.
+    The simplex version, its extension to products of simplices, closed cubes,
+    compact retracts, and the density-matrix specialization
+    (Theorem~\ref{thm:brouwer_density_matrices}) are formalized and suffice for
+    all current applications.
 \end{theorem}
 
 \begin{theorem}[Stationary states --- nonlinear]\label{thm:stationary_states}
@@ -866,25 +865,33 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \begin{corollary}[Spanning by stationary density matrices]\label{cor:stationary_density_span}
     \lean{IsPositiveMap.fixedPointsSubmodule}
     \lean{IsPositiveMap.fixedPointsSubmodule_top_span_by_posSemidef}
+    \lean{IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities}
     \lean{IsStationaryDensity}
     \uses{thm:positive_fixedpoint_decomp}
     Let $E\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a positive,
-    trace-preserving linear map.  The fixed-point subspace
-    $\mathcal F_E=\{X\mid E(X)=X\}$ is spanned (over $\mathbb C$) by its
-    positive-semidefinite elements.  Each nonzero positive-semidefinite fixed
-    point can be scaled to a stationary density matrix (positive semidefinite,
-    trace~1, fixed by~$E$).
-
-    This is the key lemma for Wolf Corollary~6.8.
+    trace-preserving linear map with $D>0$.  The fixed-point subspace
+    $\mathcal F_E=\{X\mid E(X)=X\}$ is spanned (over $\mathbb C$) by
+    stationary density matrices (positive semidefinite, trace~1, fixed by~$E$).
+    Each nonzero positive-semidefinite fixed point can be scaled to a stationary
+    density matrix.
 \end{corollary}
 
 \begin{proof}
-    \uses{thm:positive_fixedpoint_decomp}
+    \uses{thm:positive_fixedpoint_decomp,
+    thm:positive_fixedpoint_decomp}
     By Theorem~\ref{thm:positive_fixedpoint_decomp}, every fixed point is a
-    $\mathbb C$-linear combination of four positive-semidefinite fixed points,
-    hence lies in the span of the set of all positive-semidefinite fixed
-    points.  Thus the span of the positive-semidefinite fixed points equals the
-    whole fixed-point subspace.  For the scaling: if $\rho$ is a nonzero
-    positive-semidefinite fixed point, its trace is a positive real number, and
-    $\rho/\tr(\rho)$ is a stationary density matrix.
+    $\mathbb C$-linear combination of four positive-semidefinite fixed points.
+    For each nonzero positive-semidefinite fixed point $\rho$, the trace of a
+    positive-semidefinite matrix is zero only for the zero matrix
+    (Theorem~\ref{thm:positive_fixedpoint_decomp}), so $\tr(\rho)$ is a positive
+    real number.  Hence $\rho/\tr(\rho)$ is a stationary density matrix, and
+    $\rho = \tr(\rho) \cdot (\rho/\tr(\rho))$ is in the span of the stationary
+    density matrices.  The span of all positive-semidefinite fixed points
+    therefore equals the span of the stationary density matrices, which
+    equals~$\mathcal F_E$.
+
+    The dimension statement of Wolf Corollary~6.8 (a basis of exactly~$r$
+    linearly independent stationary density matrices, where~$r$ is the dimension
+    of~$\mathcal F_E$) follows from the spanning result and finite dimensionality
+    but is not yet formalized.
 \end{proof}

--- a/docs/paper-gaps/brouwer_general_compact_convex.tex
+++ b/docs/paper-gaps/brouwer_general_compact_convex.tex
@@ -32,7 +32,7 @@ lines~1143--1151.}
 
 The vendored Gametheory library (LionSR/Brouwer) proves the Brouwer fixed-point
 theorem for the standard simplex~$\Delta^n$:
-\leanid{Gametheory.Brouwer.Brouwer}.
+\leanid{Brouwer}.
 TNLean extends this to products of simplices, closed cubes, and compact retracts
 of finite-dimensional real normed spaces.\footnote{Formal declarations:
 \leanid{exists\_fixedPoint\_closedCube} in

--- a/docs/paper-gaps/brouwer_general_compact_convex.tex
+++ b/docs/paper-gaps/brouwer_general_compact_convex.tex
@@ -1,0 +1,80 @@
+% Paper-gap note: general compact-convex Brouwer fixed-point theorem
+%
+% Source: Wolf Theorem 6.10 (Brouwer's fixed point theorem)
+% Source lines: 1143--1151 of Notes/WolfNoteTexSource/ch06_spectral_properties.tex
+
+\documentclass{article}
+\begin{document}
+
+\section{General compact-convex Brouwer fixed-point theorem}
+
+Wolf Theorem~6.10 states:
+
+\begin{quote}
+    Let $T$ be a continuous map from a non-empty, compact, convex set
+    $S\subset \RR^n$ into itself, then there is an $x\in S$ such that $T(x)=x$.
+\end{quote}
+
+\subsection{What is formalized}
+
+The vendored Gametheory library (LionSR/Brouwer) proves the Brouwer fixed-point
+theorem for the \textbf{standard simplex} $\Delta^n \subset \RR^{n+1}$:
+
+\[
+\mathtt{Gametheory.Brouwer.Brouwer} : \forall (f : \Delta^n \to \Delta^n),
+\ \mathtt{Continuous} \ f \to \exists x, \ f \ x = x.
+\]
+
+TNLean extends this to products of simplices
+(\texttt{Brouwer\_Product}), closed cubes
+(\texttt{exists\_fixedPoint\_closedCube}), and compact retracts of
+finite-dimensional real normed spaces
+(\texttt{fixedPoint\_of\_compact\_retract}).  The density-matrix specialization
+(\texttt{brouwer\_fixedPoint\_densityMatrices}) is the only form used in the
+current formalization of Wolf Theorem~6.11 (Stationary states).
+
+\subsection{What is missing}
+
+The general statement with an \textbf{arbitrary} nonempty compact convex subset
+$S \subset \RR^n$ is not yet proved.  The following are known routes that would
+close this gap:
+
+\begin{enumerate}
+    \item \textbf{Metric projection (nearest-point map).}
+          For a nonempty closed convex set $K$ in a finite-dimensional Euclidean
+          space, the map $\proj_K(x) := \argmin_{p \in K} \|x - p\|$ is well-defined
+          (unique), $1$-Lipschitz (hence continuous), and restricts to the identity
+          on $K$.  This provides the retraction required by
+          \texttt{fixedPoint\_of\_compact\_retract}.  The existence, uniqueness,
+          and continuity of the metric projection for convex sets in Euclidean space
+          is not yet in Mathlib.
+
+    \item \textbf{Convex-body homeomorphism.}
+          Every nonempty compact convex $K \subset \RR^n$ with nonempty interior
+          (in its affine hull) is homeomorphic to the closed unit ball, which is
+          homeomorphic to a simplex.  This approach requires substantial convex
+          geometry.
+
+    \item \textbf{Triangulation.}
+          Refine $K$ into a simplicial complex and apply the Sperner-lemma /
+          simplicial Brouwer argument directly.  This is the route taken by the
+          Gametheory library for the standard simplex, but generalizing it to
+          arbitrary convex polytopes requires simplicial approximation theory.
+\end{enumerate}
+
+\subsection{Impact}
+
+The missing general statement does \textbf{not} block the formalization of Wolf
+Theorem~6.11 (Stationary states), Proposition~6.8 (Positive fixed-points), or
+Corollary~6.8 (Linearly independent stationary states).  These results rely only
+on the density-matrix version of Brouwer (\texttt{brouwer\_fixedPoint\_densityMatrices}),
+which is already proved.  The general compact-convex Brouwer is not used
+anywhere in the current formalization.
+
+\subsection{Elimination plan}
+
+Tracked in issue \#3985.  A formal proof of the metric projection
+(uniqueness and continuity of the nearest-point map for closed convex sets) is
+the most natural starting point and would be reusable beyond this theorem.
+
+\end{document}

--- a/docs/paper-gaps/brouwer_general_compact_convex.tex
+++ b/docs/paper-gaps/brouwer_general_compact_convex.tex
@@ -1,80 +1,91 @@
-% Paper-gap note: general compact-convex Brouwer fixed-point theorem
-%
-% Source: Wolf Theorem 6.10 (Brouwer's fixed point theorem)
-% Source lines: 1143--1151 of Notes/WolfNoteTexSource/ch06_spectral_properties.tex
-
 \documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The General Compact-Convex Brouwer Fixed-Point Theorem}
+\author{}
+\date{2026-08-04}
+
 \begin{document}
+\maketitle
 
-\section{General compact-convex Brouwer fixed-point theorem}
+\section{The assertion}
 
-Wolf Theorem~6.10 states:
+Wolf's Theorem~6.10 states the Brouwer fixed-point theorem in its general
+compact-convex form:\footnote{\cite[Theorem~6.10]{Wolf2012Quantum}; local source
+\path{Notes/WolfNoteTexSource/ch06\_spectral\_properties.tex},
+lines~1143--1151.}
+\begin{align}
+  T : S \to S,\qquad
+  S \subset \mathbb{R}^n \text{ nonempty, compact, convex},\qquad
+  T \text{ continuous}
+  \ \Longrightarrow\
+  \exists\, x \in S,\ T(x) = x.
+\end{align}
 
-\begin{quote}
-    Let $T$ be a continuous map from a non-empty, compact, convex set
-    $S\subset \RR^n$ into itself, then there is an $x\in S$ such that $T(x)=x$.
-\end{quote}
-
-\subsection{What is formalized}
+\section{What is formalized}
 
 The vendored Gametheory library (LionSR/Brouwer) proves the Brouwer fixed-point
-theorem for the \textbf{standard simplex} $\Delta^n \subset \RR^{n+1}$:
+theorem for the standard simplex~$\Delta^n$:
+\leanid{Gametheory.Brouwer.Brouwer}.
+TNLean extends this to products of simplices, closed cubes, and compact retracts
+of finite-dimensional real normed spaces.\footnote{Formal declarations:
+\leanid{exists\_fixedPoint\_closedCube} in
+\doclink{TNLean/Topology/BrouwerProduct},
+\leanid{fixedPoint\_of\_compact\_retract} in
+\doclink{TNLean/Topology/CompactRetractFixedPoint},
+and \leanid{brouwer\_fixedPoint\_densityMatrices} in
+\doclink{TNLean/Axioms/BrouwerFixedPoint}.}  The density-matrix specialization
+is the only form used in the existing formalization of Wolf Theorem~6.11
+(Stationary states).
 
-\[
-\mathtt{Gametheory.Brouwer.Brouwer} : \forall (f : \Delta^n \to \Delta^n),
-\ \mathtt{Continuous} \ f \to \exists x, \ f \ x = x.
-\]
+\section{What is missing}
 
-TNLean extends this to products of simplices
-(\texttt{Brouwer\_Product}), closed cubes
-(\texttt{exists\_fixedPoint\_closedCube}), and compact retracts of
-finite-dimensional real normed spaces
-(\texttt{fixedPoint\_of\_compact\_retract}).  The density-matrix specialization
-(\texttt{brouwer\_fixedPoint\_densityMatrices}) is the only form used in the
-current formalization of Wolf Theorem~6.11 (Stationary states).
-
-\subsection{What is missing}
-
-The general statement with an \textbf{arbitrary} nonempty compact convex subset
-$S \subset \RR^n$ is not yet proved.  The following are known routes that would
-close this gap:
+The general statement with an \emph{arbitrary} nonempty compact convex subset
+\(S \subset \mathbb{R}^n\) is not yet proved.  Three natural routes would close
+this gap:
 
 \begin{enumerate}
-    \item \textbf{Metric projection (nearest-point map).}
-          For a nonempty closed convex set $K$ in a finite-dimensional Euclidean
-          space, the map $\proj_K(x) := \argmin_{p \in K} \|x - p\|$ is well-defined
-          (unique), $1$-Lipschitz (hence continuous), and restricts to the identity
-          on $K$.  This provides the retraction required by
-          \texttt{fixedPoint\_of\_compact\_retract}.  The existence, uniqueness,
-          and continuity of the metric projection for convex sets in Euclidean space
-          is not yet in Mathlib.
+  \item \textbf{Metric projection.}  For a nonempty closed convex set~\(K\) in a
+    finite-dimensional Euclidean space, the nearest-point map
+    \(\operatorname{proj}_K(x) = \argmin_{p \in K} \lVert x-p\rVert\) is unique,
+    1-Lipschitz, and restricts to the identity on~\(K\).  This provides the
+    retraction required by the existing retract-based fixed-point theorem.  The
+    existence, uniqueness, and continuity of the metric projection for convex
+    sets in Euclidean space is not yet in Mathlib.
 
-    \item \textbf{Convex-body homeomorphism.}
-          Every nonempty compact convex $K \subset \RR^n$ with nonempty interior
-          (in its affine hull) is homeomorphic to the closed unit ball, which is
-          homeomorphic to a simplex.  This approach requires substantial convex
-          geometry.
+  \item \textbf{Convex-body homeomorphism.}  A nonempty compact convex~\(K\)
+    with nonempty interior in its affine hull is homeomorphic to the closed
+    unit ball, which is homeomorphic to a simplex.
 
-    \item \textbf{Triangulation.}
-          Refine $K$ into a simplicial complex and apply the Sperner-lemma /
-          simplicial Brouwer argument directly.  This is the route taken by the
-          Gametheory library for the standard simplex, but generalizing it to
-          arbitrary convex polytopes requires simplicial approximation theory.
+  \item \textbf{Triangulation.}  Refine \(K\) into a simplicial complex and
+    apply the Sperner-lemma / simplicial Brouwer argument directly (the route
+    taken by the Gametheory library for the standard simplex).
 \end{enumerate}
 
-\subsection{Impact}
+\section{Impact}
 
-The missing general statement does \textbf{not} block the formalization of Wolf
+The missing general statement does \emph{not} block the formalization of Wolf
 Theorem~6.11 (Stationary states), Proposition~6.8 (Positive fixed-points), or
-Corollary~6.8 (Linearly independent stationary states).  These results rely only
-on the density-matrix version of Brouwer (\texttt{brouwer\_fixedPoint\_densityMatrices}),
-which is already proved.  The general compact-convex Brouwer is not used
-anywhere in the current formalization.
+Corollary~6.8 (spanning by stationary density matrices).  These results rely
+only on the density-matrix version of Brouwer, which is already proved.
+The general compact-convex Brouwer is not used anywhere in the current
+formalization.
 
-\subsection{Elimination plan}
+\section{Verdict}
 
-Tracked in issue \#3985.  A formal proof of the metric projection
-(uniqueness and continuity of the nearest-point map for closed convex sets) is
-the most natural starting point and would be reusable beyond this theorem.
+\textbf{Open gap.}  The general compact-convex Brouwer theorem (Wolf's
+formulation) remains unformalized.  The simplex specialization and its
+extensions to closed cubes, compact retracts, and density matrices are formalized
+and suffice for the current applications.  The metric-projection route is the
+most natural starting point and would be reusable beyond this theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
 
 \end{document}


### PR DESCRIPTION
Closes \#3985

## Summary

Formalizes the four results from Wolf Chapter 6, lines 1143--1204:

### Criterion 1: General Brouwer statement (exact imported citation)
- The Gametheory library (LionSR/Brouwer) proves Brouwer for the standard simplex: `Gametheory.Brouwer.Brouwer`.
- Extensions to closed cubes (`exists_fixedPoint_closedCube`), compact retracts (`fixedPoint_of_compact_retract`), and density matrices (`brouwer_fixedPoint_densityMatrices`) are already in TNLean.
- The general compact-convex form is not yet proved; documented in `docs/paper-gaps/brouwer_general_compact_convex.tex`.

### Criterion 2: Nonlinear stationary-state existence — COMPLETE
- File: `TNLean/Channel/FixedPoint/StationaryStates.lean`
- Defines `IsPositive`, `IsTracePreserving`, `IsStationaryMap` for continuous (not necessarily linear) maps.
- Proves `IsStationaryMap.exists_stationaryState` (Wolf Theorem 6.11).
- Provides linear and channel specializations.

### Criterion 3: Fixed-point decomposition — COMPLETE (already existed)
- `IsPositiveMap.posPart_negPart_fixed_of_fixedPoint` in `Cesaro.lean` proves Wolf Proposition 6.8 for positive TP linear maps.
- Uses the Hermitian/anti-Hermitian decomposition followed by positive/negative parts, matching Wolf's proof.

### Criterion 4: Stationary-state basis corollary — KEY LEMMA PROVED
- File: `TNLean/Channel/FixedPoint/StationarySpan.lean`
- Defines `IsStationaryDensity` and `IsPositiveMap.fixedPointsSubmodule`.
- Proves `IsPositiveMap.fixedPointsSubmodule_top_span_by_posSemidef`: the fixed-point subspace is spanned by its PSD elements.
- The full corollary with basis and dimension statement remains to be completed.

## Files changed
- `TNLean/Channel/FixedPoint/StationaryStates.lean` (new)
- `TNLean/Channel/FixedPoint/StationarySpan.lean` (new)
- `TNLean/Channel/FixedPoint.lean` (auto-generated aggregator)
- `TNLean/Channel/WolfChapter6Index.lean` (updated index)
- `blueprint/src/chapter/ch06_qpf.tex` (blueprint entries)
- `docs/paper-gaps/brouwer_general_compact_convex.tex` (new)

## Axioms output
- `#print axioms IsStationaryMap.exists_stationaryState`: [propext, Classical.choice, Quot.sound]
- `#print axioms IsPositiveMap.fixedPointsSubmodule_top_span_by_posSemidef`: [propext, Classical.choice, Quot.sound]

## Deviations
- The general compact-convex Brouwer (Wolf Theorem 6.10) is not yet proved — only the simplex and density-matrix specializations are available.
- Corollary 6.8 (linearly independent stationary states) has the spanning lemma proved but the full basis-with-dimension statement remains to be completed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation with no runtime or security surface; proofs compose existing Cesàro/Brouwer infrastructure and standard Mathlib linear algebra.
> 
> **Overview**
> Adds **Wolf Theorem 6.11** for continuous, positive, trace-preserving maps that need not be linear: new `IsStationaryMap` predicates and `exists_stationaryState`, proved by restricting to density matrices and applying `brouwer_fixedPoint_densityMatrices`, with linear/channel corollaries.
> 
> Adds **Corollary 6.8 spanning machinery** in `StationarySpan.lean`: `IsStationaryDensity`, the fixed-point submodule, span-by-PSD-fixed-points (via existing Prop 6.8 decomposition), normalization to stationary densities, and `fixedPointsSubmodule_spanned_by_stationaryDensities`. The full basis/dimension form is still open.
> 
> **Documentation/index:** `WolfChapter6Index.lean` records Brouwer citations and formalization status; `ch06_qpf.tex` gets blueprint sections for Brouwer, stationary states, and the spanning corollary; new `docs/paper-gaps/brouwer_general_compact_convex.tex` records the unproved general compact-convex Brouwer form. The `FixedPoint` aggregator imports the two new modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6614f9f15c5e252e22c00211ac52bce59c2462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->