### PR TITLE
test(tenkz): pin comment-terminated control words in dimension scanning

### DIFF
--- a/scripts/test_tenkz_dimension_inventory.py
+++ b/scripts/test_tenkz_dimension_inventory.py
@@ -336,6 +336,71 @@ def test_owner_span_grouping() -> None:
     )
 
 
+def test_comment_terminated_control_word() -> None:
+    # A `%` comment terminates a control word mid-name even though its
+    # discarded endline leaves no space token in the input stream
+    # (`dimensions.py`, `_command_spans`).  TeX reads a backslash-name
+    # interrupted by a comment as the control word `\tn` followed by the
+    # letters p, u, t on the next line, never as the merged command
+    # `\tnput`; the scanner must reproduce that reading on raw,
+    # non-comment-stripped source.
+    comment_terminated = (
+        "\\begin{tenkzfree}[pitch=1mm]\n"
+        "  \\tn% mid-name comment\n"
+        "put{a}{(3mm,4mm)}{}\n"
+        "\\end{tenkzfree}\n"
+    )
+    space_terminated = (
+        "\\begin{tenkzfree}[pitch=1mm]\n"
+        "  \\tn put{a}{(3mm,4mm)}{}\n"
+        "\\end{tenkzfree}\n"
+    )
+    merged = (
+        "\\begin{tenkzfree}[pitch=1mm]\n"
+        "  \\tnput{a}{(3mm,4mm)}{}\n"
+        "\\end{tenkzfree}\n"
+    )
+
+    # The comment-terminated and space-terminated forms both leave the
+    # (3mm,4mm) dimensions unowned (no `\tnput` command is formed) ...
+    comment_message = _expect_error(
+        lambda: _build(comment_terminated),
+        "cannot inventory unowned case dimension",
+    )
+    space_message = _expect_error(
+        lambda: _build(space_terminated),
+        "cannot inventory unowned case dimension",
+    )
+    # ... and the comment form reports the dimensions at their true source
+    # line after the discarded comment endline, proving that offsets survive
+    # the comment rather than collapsing into the preceding line.
+    if ":3: 3mm" not in comment_message:
+        raise AssertionError(
+            f"comment-terminated control word lost its source line: {comment_message!r}"
+        )
+    if ":2: 3mm" not in space_message:
+        raise AssertionError(
+            f"space-terminated control word lost its source line: {space_message!r}"
+        )
+
+    # The merged control word is a genuinely different, dimension-bearing
+    # command: the comment form must not spuriously merge into it.
+    merged_inventory = _build(merged)
+    merged_sites = merged_inventory.cases[0].sites
+    if tuple(site.owner for site in merged_sites) != (
+        DimensionOwner.METRIC,
+        DimensionOwner.LAYOUT,
+    ):
+        raise AssertionError(f"merged control word lost its owners: {merged_sites!r}")
+    if not any(
+        site.site.endswith("tnput@1/command:\\tnput{a}{(<dimension>,<dimension>)}{}")
+        for site in merged_sites
+    ):
+        raise AssertionError(
+            f"merged control word lost its dimension owner identity: {merged_sites!r}"
+        )
+
+
 def test_construct_ordinals_are_semantic() -> None:
     base_source = r"""\begin{tenkzfree}
   \tnput{a}{(1mm,2mm)}{}
@@ -1545,6 +1610,7 @@ def main() -> int:
     test_repository_inventory()
     test_formatting_stability()
     test_owner_span_grouping()
+    test_comment_terminated_control_word()
     test_construct_ordinals_are_semantic()
     test_picture_scope_ancestry_is_semantic()
     test_balanced_changes_are_rejected()

--- a/scripts/test_tenkz_dimension_inventory.py
+++ b/scripts/test_tenkz_dimension_inventory.py
@@ -339,7 +339,9 @@ def test_owner_span_grouping() -> None:
 def test_comment_terminated_control_word() -> None:
     # A `%` comment terminates a control word mid-name even though its
     # discarded endline leaves no space token in the input stream
-    # (`dimensions.py`, `_command_spans`).  TeX reads a backslash-name
+    # (`dimensions.py`: `scan_case_dimensions` works on an offset-preserving
+    # comment-stripped view and `_active_fragment` inserts a space across
+    # comment gaps so control words cannot merge).  TeX reads a backslash-name
     # interrupted by a comment as the control word `\tn` followed by the
     # letters p, u, t on the next line, never as the merged command
     # `\tnput`; the scanner must reproduce that reading on raw,


### PR DESCRIPTION
Closes #5402. Follow-up to #5392 (exact RMP dimension ownership freeze).

`scripts/tenkzlib/dimensions.py`'s `_command_spans` handles a `%` comment terminating a control word mid-name (e.g. `\tn%...\nput`) on raw, non-comment-stripped source — a `%` eats the rest of the line and its endline, so TeX reads the control word `\tn` followed by the letters p, u, t, never the merged `\tnput`. The behavior was confirmed by review tracing in #5392 but had no explicit regression test.

New `test_comment_terminated_control_word` in `scripts/test_tenkz_dimension_inventory.py` asserts:
- the comment-terminated form fails with the same `cannot inventory unowned case dimension` error as the space-terminated form (no dimension-bearing `\tnput` command is formed),
- it reports the dimensions at their true source line after the discarded comment endline (`:3: 3mm`), proving offsets survive the comment,
- the merged `\tnput{a}{(3mm,4mm)}{}` form genuinely differs: it succeeds with the `METRIC` + `LAYOUT` owner sites including `tnput@1/command:\\tnput{a}{(<dimension>,<dimension>)}{}`.

Verified locally: `python3 scripts/test_tenkz_dimension_inventory.py` passes (whole suite).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications; low risk to runtime behavior.
> 
> **Overview**
> Adds **`test_comment_terminated_control_word`** to lock in TeX-correct parsing when a **`%`** comment cuts a control word mid-name (e.g. `\tn%…\nput` → `\tn` + `put`, not `\tnput`).
> 
> The test checks that comment-terminated and space-separated variants both fail inventory with **unowned case dimension** errors, that diagnostics use the right source lines (`:3:` vs `:2:`), and that real **`\tnput{…}`** still inventories with **METRIC** / **LAYOUT** owners. The new case is wired into the script **`main()`** suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8909cf05be36cf685996fc0f42d53c38ff97415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->