### PR TITLE
feat(MPS/MPDO): prove CPSV canonical form, SAL, and the five-property capstone for the Kato p=1/2 tensor

### DIFF
--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -50,8 +50,6 @@ A completely positive coarse-graining map cannot send the former to the latter.
 
 open scoped Matrix BigOperators ComplexOrder
 
-set_option maxHeartbeats 400000
-
 namespace MPOTensor.KatoDeformedRFPObstruction
 
 /-- The Pauli $Z$ matrix on the physical two-dimensional space. -/
@@ -362,14 +360,10 @@ theorem tensor_not_isRFPViaTS : ¬ IsRFPViaTS tensor := by
 /-! ### CPSV canonical form of the doubled-index MPS tensor -/
 
 private lemma sqrt2_ne_zero : (Real.sqrt 2 : ℂ) ≠ 0 := by
-  intro h
-  have hpos := Real.sqrt_pos.mpr (by norm_num : (0 : ℝ) < 2)
-  apply hpos.ne'
-  exact_mod_cast h
+  intro h; have hpos := Real.sqrt_pos.mpr (by norm_num : (0 : ℝ) < 2); apply hpos.ne'; exact_mod_cast h
 
 private lemma sqrt2_sq_complex : ((Real.sqrt 2 : ℂ) ^ 2) = (2 : ℂ) := by
-  have hsq_real : (Real.sqrt 2 : ℝ) ^ 2 = (2 : ℝ) :=
-    Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num)
+  have hsq_real : (Real.sqrt 2 : ℝ) ^ 2 = (2 : ℝ) := Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num)
   calc
     ((Real.sqrt 2 : ℂ) ^ 2) = (((Real.sqrt 2 : ℝ) ^ 2 : ℝ) : ℂ) := by push_cast; ring
     _ = ((2 : ℝ) : ℂ) := by rw [hsq_real]
@@ -386,10 +380,7 @@ private lemma blockLetterAmplitude_sq : blockLetterAmplitude ^ 2 = (1 / 2 : ℂ)
 
 noncomputable def block0Weight : ℂ := (1 : ℂ) / Real.sqrt 2
 noncomputable def block1Weight : ℂ := (1 : ℂ) / (2 * Real.sqrt 2)
-
-noncomputable def katoCFWeights : Fin 2 → ℂ := fun k => match k with
-  | 0 => block0Weight
-  | 1 => block1Weight
+noncomputable def katoCFWeights : Fin 2 → ℂ := fun k => match k with | 0 => block0Weight | 1 => block1Weight
 
 private lemma block0Weight_times_amplitude : block0Weight * blockLetterAmplitude = (1 / 2 : ℂ) := by
   calc
@@ -409,275 +400,162 @@ noncomputable def katoCFBlock0 : MPSTensor 4 1 :=
   fun p => if p = 0 ∨ p = 3 then !![blockLetterAmplitude] else 0
 
 noncomputable def katoCFBlock1 : MPSTensor 4 1 :=
-  fun p => if p = 0 then !![blockLetterAmplitude]
-    else if p = 3 then !![-blockLetterAmplitude] else 0
+  fun p => if p = 0 then !![blockLetterAmplitude] else if p = 3 then !![-blockLetterAmplitude] else 0
 
-noncomputable def katoCFBlocks : Fin 2 → MPSTensor 4 1 := fun k => match k with
-  | 0 => katoCFBlock0
-  | 1 => katoCFBlock1
+noncomputable def katoCFBlocks : Fin 2 → MPSTensor 4 1 := fun k => match k with | 0 => katoCFBlock0 | 1 => katoCFBlock1
 
-/-- The transfer map of katoCFBlock0 is the identity on the bond-one space.
+private lemma oneByOne_mul_apply (A B : Matrix (Fin 1) (Fin 1) ℂ) : (A * B) 0 0 = (A 0 0) * (B 0 0) := by
+  rw [Matrix.mul_apply]
+  have huniv : (Finset.univ : Finset (Fin 1)) = {(0 : Fin 1)} := by decide
+  rw [huniv, Finset.sum_singleton]
 
-Both nonzero entries (physical indices 0 and 3) equal 1/√2, giving
-∑ |A_i|² = |1/√2|² + |1/√2|² = 1. -/
+private lemma oneByOne_mul_conj_apply (A X : Matrix (Fin 1) (Fin 1) ℂ) :
+    (A * X * Aᴴ) 0 0 = (A 0 0) * (X 0 0) * star (A 0 0) := by
+  calc
+    (A * X * Aᴴ) 0 0 = ((A * X) * Aᴴ) 0 0 := rfl
+    _ = (A * X) 0 0 * (Aᴴ) 0 0 := by rw [oneByOne_mul_apply]
+    _ = ((A 0 0) * (X 0 0)) * (Aᴴ) 0 0 := by rw [oneByOne_mul_apply]
+    _ = (A 0 0) * (X 0 0) * star (A 0 0) := by rw [Matrix.conjTranspose_apply]
+
 private lemma katoCFBlock0_transferMap_eq_id :
     MPSTensor.transferMap katoCFBlock0 = LinearMap.id := by
   apply LinearMap.ext; intro X
-  -- For Fin 1, all elements equal 0 by dec_trivial
-  have hi (i : Fin 1) : i = 0 := by fin_cases i; rfl
-  have hj (j : Fin 1) : j = 0 := by fin_cases j; rfl
-  ext i j; rw [hi i, hj j]
-  -- Goal: (∑ p, katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ) 0 0 = X 0 0
-  -- Only p=0 and p=3 contribute, each with value blockLetterAmplitude (real, so star=id)
+  ext i j
+  have hi : i = (0 : Fin 1) := Subsingleton.elim _ _
+  have hj : j = (0 : Fin 1) := Subsingleton.elim _ _
+  rw [hi, hj]
   rw [MPSTensor.transferMap_apply]
-  -- Enumerate the sum explicitly
-  -- For 1×1 matrices, (M * N) 0 0 = M 0 0 * N 0 0, so the sum reduces to a scalar sum
-  -- Only p=0 and p=3 contribute nonzero values, both equal to blockLetterAmplitude
-  -- Thus ∑ |A_p 0 0|² = 2 * blockLetterAmplitude² = 2 * (1/2) = 1
-  have hsum_scalar : (∑ p : Fin 4, (katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0)) = X 0 0 := by
-    calc
-      (∑ p : Fin 4, (katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0))
-          = (X 0 0) * (∑ p : Fin 4, (katoCFBlock0 p 0 0) * star (katoCFBlock0 p 0 0)) := by
-        simp_rw [Finset.mul_sum]; ring
-      _ = (X 0 0) * (blockLetterAmplitude * star blockLetterAmplitude * 2) := by
-        simp [katoCFBlock0, Fin.sum_univ_four]
-        ring
-      _ = (X 0 0) * (blockLetterAmplitude ^ 2 * 2) := by
-        have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
-          rw [blockLetterAmplitude]; simp
-        rw [hstar]; ring
-      _ = (X 0 0) * ((1/2 : ℂ) * 2) := by rw [blockLetterAmplitude_sq]
-      _ = X 0 0 := by ring
-  -- Connect the matrix sum entry to the scalar sum
   calc
     (∑ p : Fin 4, (katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ)) 0 0
         = ∑ p : Fin 4, ((katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ) 0 0) := rfl
     _ = ∑ p : Fin 4, ((katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0)) := by
       refine Finset.sum_congr rfl (fun p _ => ?_)
-      -- For 1×1 matrices, (M * N * P) 0 0 = M 0 0 * N 0 0 * P 0 0
-      -- This is true because there is only one index in the matrix multiplication sum
-      calc
-        ((katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ) 0 0) = 
-            ((katoCFBlock0 p * X) * (katoCFBlock0 p)ᴴ) 0 0 := rfl
-        _ = ∑ k : Fin 1, (katoCFBlock0 p * X) 0 k * ((katoCFBlock0 p)ᴴ) k 0 := rfl
-        _ = (katoCFBlock0 p * X) 0 0 * ((katoCFBlock0 p)ᴴ) 0 0 := by simp
-        _ = (∑ j : Fin 1, (katoCFBlock0 p) 0 j * X j 0) * ((katoCFBlock0 p)ᴴ) 0 0 := rfl
-        _ = ((katoCFBlock0 p) 0 0 * X 0 0) * ((katoCFBlock0 p)ᴴ) 0 0 := by simp
-        _ = (katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0) := by simp; ring
-    _ = X 0 0 := hsum_scalar
+      rw [oneByOne_mul_conj_apply (katoCFBlock0 p) X]
+    _ = (X 0 0) * (∑ p : Fin 4, (katoCFBlock0 p 0 0) * star (katoCFBlock0 p 0 0)) := by
+      rw [Finset.mul_sum]; refine Finset.sum_congr rfl (fun p _ => ?_); ring
+    _ = (X 0 0) * (1 : ℂ) := by
+      have hsum : (∑ p : Fin 4, (katoCFBlock0 p 0 0) * star (katoCFBlock0 p 0 0)) = (1 : ℂ) := by
+        have h0 : (katoCFBlock0 0) 0 0 = blockLetterAmplitude := by simp [katoCFBlock0]
+        have h1 : (katoCFBlock0 1) 0 0 = (0 : ℂ) := by simp [katoCFBlock0]
+        have h2 : (katoCFBlock0 2) 0 0 = (0 : ℂ) := by simp [katoCFBlock0]
+        have h3 : (katoCFBlock0 3) 0 0 = blockLetterAmplitude := by simp [katoCFBlock0]
+        rw [Fin.sum_univ_four, h0, h1, h2, h3]
+        have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
+          rw [blockLetterAmplitude]; simp
+        rw [hstar]
+        simp [hstar]
+        rw [← pow_two, blockLetterAmplitude_sq]
+        norm_num
+      rw [hsum]
+    _ = X 0 0 := by simp
 
-/-- The transfer map of katoCFBlock1 is the identity on the bond-one space.
-The two nonzero entries are 1/√2 and -1/√2, so ∑|A_i|² = 1 as well. -/
 private lemma katoCFBlock1_transferMap_eq_id :
     MPSTensor.transferMap katoCFBlock1 = LinearMap.id := by
   apply LinearMap.ext; intro X
-  -- For Fin 1, all elements equal 0 by dec_trivial
-  have hi (i : Fin 1) : i = 0 := by fin_cases i; rfl
-  have hj (j : Fin 1) : j = 0 := by fin_cases j; rfl
-  ext i j; rw [hi i, hj j]
+  ext i j
+  have hi : i = (0 : Fin 1) := Subsingleton.elim _ _
+  have hj : j = (0 : Fin 1) := Subsingleton.elim _ _
+  rw [hi, hj]
   rw [MPSTensor.transferMap_apply]
-  -- Similar scalar sum: only p=0 (+amplitude) and p=3 (-amplitude) contribute
-  -- |amplitude|² + |-amplitude|² = 2 * amplitude² = 1
-  have hsum_scalar : (∑ p : Fin 4, (katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0)) = X 0 0 := by
-    calc
-      (∑ p : Fin 4, (katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0))
-          = (X 0 0) * (∑ p : Fin 4, (katoCFBlock1 p 0 0) * star (katoCFBlock1 p 0 0)) := by
-        simp_rw [Finset.mul_sum]; ring
-      _ = (X 0 0) * (blockLetterAmplitude * star blockLetterAmplitude * 2) := by
-        simp [katoCFBlock1, Fin.sum_univ_four]
-        ring
-      _ = (X 0 0) * (blockLetterAmplitude ^ 2 * 2) := by
-        have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
-          rw [blockLetterAmplitude]; simp
-        rw [hstar]; ring
-      _ = (X 0 0) * ((1/2 : ℂ) * 2) := by rw [blockLetterAmplitude_sq]
-      _ = X 0 0 := by ring
   calc
     (∑ p : Fin 4, (katoCFBlock1 p * X * (katoCFBlock1 p)ᴴ)) 0 0
         = ∑ p : Fin 4, ((katoCFBlock1 p * X * (katoCFBlock1 p)ᴴ) 0 0) := rfl
     _ = ∑ p : Fin 4, ((katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0)) := by
       refine Finset.sum_congr rfl (fun p _ => ?_)
-      calc
-        ((katoCFBlock1 p * X * (katoCFBlock1 p)ᴴ) 0 0) = 
-            ((katoCFBlock1 p * X) * (katoCFBlock1 p)ᴴ) 0 0 := rfl
-        _ = ∑ k : Fin 1, (katoCFBlock1 p * X) 0 k * ((katoCFBlock1 p)ᴴ) k 0 := rfl
-        _ = (katoCFBlock1 p * X) 0 0 * ((katoCFBlock1 p)ᴴ) 0 0 := by simp
-        _ = (∑ j : Fin 1, (katoCFBlock1 p) 0 j * X j 0) * ((katoCFBlock1 p)ᴴ) 0 0 := rfl
-        _ = ((katoCFBlock1 p) 0 0 * X 0 0) * ((katoCFBlock1 p)ᴴ) 0 0 := by simp
-        _ = (katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0) := by simp; ring
-    _ = X 0 0 := hsum_scalar
+      rw [oneByOne_mul_conj_apply (katoCFBlock1 p) X]
+    _ = (X 0 0) * (∑ p : Fin 4, (katoCFBlock1 p 0 0) * star (katoCFBlock1 p 0 0)) := by
+      rw [Finset.mul_sum]; refine Finset.sum_congr rfl (fun p _ => ?_); ring
+    _ = (X 0 0) * (1 : ℂ) := by
+      have hsum : (∑ p : Fin 4, (katoCFBlock1 p 0 0) * star (katoCFBlock1 p 0 0)) = (1 : ℂ) := by
+        have h0 : (katoCFBlock1 0) 0 0 = blockLetterAmplitude := by simp [katoCFBlock1]
+        have h1 : (katoCFBlock1 1) 0 0 = (0 : ℂ) := by simp [katoCFBlock1]
+        have h2 : (katoCFBlock1 2) 0 0 = (0 : ℂ) := by simp [katoCFBlock1]
+        have h3 : (katoCFBlock1 3) 0 0 = -blockLetterAmplitude := by simp [katoCFBlock1]
+        rw [Fin.sum_univ_four, h0, h1, h2, h3]
+        have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
+          rw [blockLetterAmplitude]; simp
+        rw [hstar]
+        simp [hstar]
+        rw [← pow_two, blockLetterAmplitude_sq]
+        norm_num
+      rw [hsum]
+    _ = X 0 0 := by simp
 
-
-/-- Each bond-one block is a normal tensor (NT) in the sense of
-arXiv:1606.00608, lines 233--235.
-
-Source: project derivation; bond-one tensors with identity transfer map are
-normal by `isNormalTensor_of_bondDim_one_of_transferMap_eq_id`. -/
-private lemma katoCFBlocks_normal (k : Fin 2) :
-    MPSTensor.IsNormalTensor (katoCFBlocks k) := by
+private lemma katoCFBlocks_normal (k : Fin 2) : MPSTensor.IsNormalTensor (katoCFBlocks k) := by
   fin_cases k
   · exact MPSTensor.isNormalTensor_of_bondDim_one_of_transferMap_eq_id
       katoCFBlock0 katoCFBlock0_transferMap_eq_id
   · exact MPSTensor.isNormalTensor_of_bondDim_one_of_transferMap_eq_id
       katoCFBlock1 katoCFBlock1_transferMap_eq_id
 
-/-- The doubled-index MPS tensor equals the weighted block-diagonal
-reconstruction from the two bond-one blocks.
-
-We prove this by direct computation on all 16 matrix entries. Both sides are
-nonzero only when the physical doubled index ($p \in \mathsf{Fin}\,4$) corresponds
-to a diagonal pair ($p = 0$ or $p = 3$) and the virtual indices match ($x = y$).
-
-Source: project derivation; the componentwise check uses the explicit forms of
-the Kato tensor letters (arXiv:2410.22696, lines 712--721) and the definition
-of the CPSV canonical form (arXiv:1606.00608, eq. `II_CF1`, lines 214--245). -/
 theorem toMPSTensor_eq_toTensorFromBlocks :
     MPOTensor.toMPSTensor tensor = MPSTensor.toTensorFromBlocks katoCFWeights katoCFBlocks := by
+  let e : (Σ _k : Fin 2, Fin 1) ≃ Fin 2 := finSigmaFinEquiv
+  have hflat (k : Fin 2) : e ⟨k, (0 : Fin 1)⟩ = k := by fin_cases k <;> rfl
+  have hflat_symm (k : Fin 2) : e.symm k = ⟨k, (0 : Fin 1)⟩ := by
+    apply e.injective; rw [e.apply_symm_apply, hflat]
   funext p; ext x y
-  rw [MPOTensor.toMPSTensor]
-  -- Goal: tensor (p.divNat) (p.modNat) x y = (toTensorFromBlocks ... p) x y
-  -- Both sides are zero except for 4 specific cases:
-  -- (p=0, x=y=0): 1/2 = block0Weight * blockLetterAmplitude
-  -- (p=0, x=y=1): 1/4 = block1Weight * blockLetterAmplitude
-  -- (p=3, x=y=0): 1/2 = block0Weight * blockLetterAmplitude
-  -- (p=3, x=y=1): -1/4 = block1Weight * (-blockLetterAmplitude)
-  -- All other 12 cases: both sides = 0
-  -- We handle the zero cases uniformly, then the 4 nonzero cases individually
-  -- First, expand the block diagonal definition into an explicit formula
-  -- For 2 blocks of dim 1, toTensorFromBlocks p x y = 
-  --   if x = y then (if x = 0 then block0Weight * katoCFBlock0 p 0 0
-  --                   else block1Weight * katoCFBlock1 p 0 0)
-  --   else 0
-  rw [MPSTensor.toTensorFromBlocks, Matrix.reindex_apply, Matrix.reindex_apply]
-  -- Now we have tensor (p.divNat) (p.modNat) x y =
-  --   (Matrix.blockDiagonal' (fun k => katoCFWeights k • katoCFBlocks k p))
-  --     (finSigmaFinEquiv.symm x) (finSigmaFinEquiv.symm y)
-  -- We need to evaluate blockDiagonal' at these sigma-type coordinates
-  -- Key lemma: finSigmaFinEquiv.symm x = ⟨x, 0⟩ for our 2×1 setup
-  have hsymm (z : Fin 2) : (finSigmaFinEquiv.symm z : Σ _ : Fin 2, Fin 1) = ⟨z, 0⟩ := by
-    apply finSigmaFinEquiv.injective
-    simp [finSigmaFinEquiv]
-  rw [hsymm x, hsymm y]
-  -- Now simplify the blockDiagonal' entry
-  -- blockDiagonal' f ⟨x,0⟩ ⟨y,0⟩ = 0 if x ≠ y, else = (f x) 0 0
-  by_cases hxy : x = y
+  simp only [MPOTensor.toMPSTensor, MPSTensor.toTensorFromBlocks,
+    Matrix.reindex_apply, katoCFWeights, katoCFBlocks]
+  change tensor (p.divNat) (p.modNat) x y =
+    (Matrix.blockDiagonal' (fun k : Fin 2 => (katoCFWeights k) • (katoCFBlocks k p)))
+      (e.symm x) (e.symm y)
+  rw [hflat_symm x, hflat_symm y]
+  by_cases h : x = y
   · subst y
-    -- Same block: the entry is katoCFWeights x • katoCFBlocks x p 0 0
-    simp [Matrix.blockDiagonal', katoCFWeights, katoCFBlocks]
-    -- Now goal: tensor (p.divNat) (p.modNat) x x = 
-    --   (if x=0 then block0Weight * katoCFBlock0 p 0 0
-    --    else block1Weight * katoCFBlock1 p 0 0)
-    -- We handle the two physical cases separately
-    by_cases hp_diag : p.divNat = p.modNat
-    · -- p = 0 or p = 3
-      have hp_val : p = 0 ∨ p = 3 := by
-        have h0 : (0 : Fin 4).divNat = (0 : Fin 4).modNat := by decide
-        have h1 : ¬ ((1 : Fin 4).divNat = (1 : Fin 4).modNat) := by decide
-        have h2 : ¬ ((2 : Fin 4).divNat = (2 : Fin 4).modNat) := by decide
-        have h3 : (3 : Fin 4).divNat = (3 : Fin 4).modNat := by decide
-        fin_cases p <;> simp [hp_diag, h0, h1, h2, h3]
-      rcases hp_val with rfl | rfl
-      · -- p = 0
-        fin_cases x
-        · simp [tensor, siteSign, pauliZ, katoCFBlock0, block0Weight_times_amplitude]
-        · simp [tensor, siteSign, pauliZ, katoCFBlock1, block1Weight_times_amplitude]
-      · -- p = 3
-        fin_cases x
-        · simp [tensor, siteSign, pauliZ, katoCFBlock0, block0Weight_times_amplitude]
-        · simp [tensor, siteSign, pauliZ, katoCFBlock1, block1Weight_times_amplitude]
-    · -- Off-diagonal physical index: tensor is 0, and katoCFBlock0/katoCFBlock1 are also 0 for p=1,2
-      simp [tensor, hp_diag, katoCFBlock0, katoCFBlock1]
-  · -- Different blocks: blockDiagonal' is 0
-    simp [Matrix.blockDiagonal'_apply_ne (fun i j _ => ?_) hxy]
-    -- tensor (p.divNat) (p.modNat) x y = 0 for x ≠ y (tensor is diagonal)
+    simp [Matrix.blockDiagonal', katoCFWeights, katoCFBlocks, katoCFBlock0, katoCFBlock1]
     by_cases hp_diag : p.divNat = p.modNat
     · have hp_val : p = 0 ∨ p = 3 := by
-        have h0 : (0 : Fin 4).divNat = (0 : Fin 4).modNat := by decide
-        have h1 : ¬ ((1 : Fin 4).divNat = (1 : Fin 4).modNat) := by decide
-        have h2 : ¬ ((2 : Fin 4).divNat = (2 : Fin 4).modNat) := by decide
-        have h3 : (3 : Fin 4).divNat = (3 : Fin 4).modNat := by decide
-        fin_cases p <;> simp [hp_diag, h0, h1, h2, h3]
+        fin_cases p
+        · left; rfl
+        · exfalso; apply (by decide : ¬ ((1 : Fin (2*2)).divNat = (1 : Fin (2*2)).modNat)); exact hp_diag
+        · exfalso; apply (by decide : ¬ ((2 : Fin (2*2)).divNat = (2 : Fin (2*2)).modNat)); exact hp_diag
+        · right; rfl
       rcases hp_val with rfl | rfl
-      · simp [tensor, siteSign, pauliZ, hxy]
-      · simp [tensor, siteSign, pauliZ, hxy]
-    · simp [tensor, hp_diag]
+      · fin_cases x
+        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, katoCFBlock0, block0Weight_times_amplitude]
+        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, katoCFBlock1, block1Weight_times_amplitude]
+      · fin_cases x
+        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, katoCFBlock0, block0Weight_times_amplitude]
+        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, katoCFBlock1, block1Weight_times_amplitude]
+    · -- p.divNat ≠ p.modNat means p is 1 or 2; tensor = 0 and blocks = 0
+      have hp12 : p = (1 : Fin (2*2)) ∨ p = (2 : Fin (2*2)) := by
+        fin_cases p
+        · exfalso; exact hp_diag (by decide : ((0 : Fin (2*2)).divNat = (0 : Fin (2*2)).modNat))
+        · left; rfl
+        · right; rfl
+        · exfalso; exact hp_diag (by decide : ((3 : Fin (2*2)).divNat = (3 : Fin (2*2)).modNat))
+      rcases hp12 with rfl | rfl
+      · -- p = (1 : Fin (2*2)); divNat ≠ modNat, so tensor=0 and blocks=0
+        have h1 : ¬ ((1 : Fin (2*2)).divNat = (1 : Fin (2*2)).modNat) := by decide
+        rw [tensor, if_neg h1]
+        fin_cases x <;> simp [katoCFBlock0, katoCFBlock1]
+      · -- p = (2 : Fin (2*2)); divNat ≠ modNat, so tensor=0 and blocks=0
+        have h2 : ¬ ((2 : Fin (2*2)).divNat = (2 : Fin (2*2)).modNat) := by decide
+        rw [tensor, if_neg h2]
+        fin_cases x <;> simp [katoCFBlock0, katoCFBlock1]
+  · rw [Matrix.blockDiagonal'_apply_ne (fun k : Fin 2 => (katoCFWeights k) • (katoCFBlocks k p))
+      (0 : Fin 1) (0 : Fin 1) h]
+    by_cases hp_diag : p.divNat = p.modNat
+    · have hp_val : p = 0 ∨ p = 3 := by
+        fin_cases p
+        · left; rfl
+        · exfalso; apply (by decide : ¬ ((1 : Fin (2*2)).divNat = (1 : Fin (2*2)).modNat)); exact hp_diag
+        · exfalso; apply (by decide : ¬ ((2 : Fin (2*2)).divNat = (2 : Fin (2*2)).modNat)); exact hp_diag
+        · right; rfl
+      rcases hp_val with rfl | rfl
+      · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, h]
+      · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, h]
+    · -- p.divNat ≠ p.modNat: tensor evaluates to 0 because off-diagonal physical letter
+      rw [tensor, if_neg hp_diag]
+      simp
 
-/-- The doubled-index MPS tensor of the Kato $p=1/2$ tensor is in literal CPSV
-canonical form (arXiv:1606.00608 eq. `II_CF1`, lines 214--245).
-
-The decomposition uses two bond-one blocks: one with amplitude $1/\sqrt{2}$ at both
-physical letters $(0,0)$ and $(1,1)$, and one with amplitudes $1/\sqrt{2}$ and
-$-1/\sqrt{2}$ respectively.  The weights $\mu_0 = 1/\sqrt{2}$ and
-$\mu_1 = 1/(2\sqrt{2})$ recover the original diagonal matrix entries.
-
-This is a project derivation: the sources do not state the canonical-form
-decomposition explicitly.  Kato proves the closed family in arXiv:2410.22696,
-lines 712--721; the CPSV canonical form is arXiv:1606.00608 eq. `II_CF1`,
-lines 214--245. -/
 theorem tensor_toMPSTensor_isCPSVCanonicalForm :
     MPSTensor.IsCPSVCanonicalForm (MPOTensor.toMPSTensor tensor) := by
   rw [toMPSTensor_eq_toTensorFromBlocks]
   exact (MPSTensor.CPSVCanonicalFormData.ofBlocks
     (fun _ => by norm_num) katoCFWeights katoCFBlocks
     katoCFBlocks_normal).isCPSVCanonicalForm
-
-/-! ### Saturation of the area law -/
-
-private lemma mpo_trace_ne_zero (N : ℕ) (hN : 0 < N) : (mpo tensor N).trace ≠ 0 := by
-  rw [trace_mpo_tensor N hN]; norm_num
-
-/-- The normalized MPO equals the unnormalized MPO because trace = 1. -/
-private lemma normalizedMPO_eq_mpo (N : ℕ) (hN : 0 < N) :
-    tensor.normalizedMPO N = mpo tensor N := by
-  have htr_one : (MPOTensor.mpo tensor N).trace = (1 : ℂ) := trace_mpo_tensor N hN
-  rw [MPOTensor.normalizedMPO, htr_one, inv_one, one_smul]
-
-/-- **Boundary lemma (proof incomplete):** The reduced block state is maximally mixed.
-The missing piece is the combinatorial identity that the sum of configurationSign
-over all complement words vanishes, because each site contributes factor (1 + (-1)) = 0. -/
-theorem reducedBlockState_eq_maximallyMixed {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N) :
-    tensor.reducedBlockState N L (Nat.le_of_lt hLN) =
-      ((2 : ℂ) ^ L)⁻¹ • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) := by
-  sorry
-
-/-- **Boundary lemma (proof incomplete):** Block entropy equals L log 2.
-The missing piece is the entropy formula for the maximally mixed state,
-which requires `vonNeumannEntropy_diagonal` and evaluating `Real.negMulLog (1/2^L)`. -/
-theorem blockEntropy_eq_L_log_two {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N)
-    (hM : (mpo tensor N).PosSemidef) :
-    tensor.blockEntropy N L (Nat.le_of_lt hLN) hM = (L : ℝ) * Real.log 2 := by
-  sorry
-
-/-- Kato's p=1/2 tensor generates MPDO that saturate the area law
-(arXiv:1606.00608 Definition 4.6, line 811): I_L = I_{L+1} for 1 ≤ L < ⌊N/2⌋.
-
-The proof is reduced to the two boundary lemmas above:
-- `reducedBlockState_eq_maximallyMixed` shows that reduced states are maximally mixed
-- `blockEntropy_eq_L_log_two` computes their entropy as L log 2
-
-Both lemmas are stated precisely but contain `sorry`. This is a project derivation:
-neither Kato arXiv:2410.22696 nor CPSV16 arXiv:1606.00608 discuss SAL for this tensor. -/
-theorem tensor_isSAL : IsSAL tensor := by
-  refine ⟨tensor_isMPDO, ?_, ?_⟩
-  · intro N hN; exact mpo_trace_ne_zero N hN
-  · -- The mutual information equality I_L = I_{L+1} follows from the fact that
-    -- S_L = L·log(2) for all L < N, so S_L + S_{N-L} = N·log(2) = S_{L+1} + S_{N-L-1}
-    -- and therefore I_L = S_L + S_{N-L} - S_N = N·log(2) - S_N = I_{L+1}
-    intro N L hL1 hL_lt_halfN; sorry
-
-/-! ### Capstone theorem -/
-
-/-- There exists an MPO tensor on 2 physical and 2 virtual dimensions that
-simultaneously satisfies CPSV canonical form, positivity (MPDO), idempotent
-physical-trace transfer, saturation of the area law, and fails the
-tensor-scaling renormalization-fixed-point condition of
-arXiv:1606.00608 Definition 4.1. -/
-theorem exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS :
-    ∃ K : MPOTensor 2 2, MPSTensor.IsCPSVCanonicalForm (MPOTensor.toMPSTensor K) ∧ IsMPDO K ∧
-      (physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) ∧
-      IsSAL K ∧ ¬ IsRFPViaTS K := by
-  refine ⟨tensor, tensor_toMPSTensor_isCPSVCanonicalForm, tensor_isMPDO,
-    physTraceTransfer_tensor_idempotent, tensor_isSAL, tensor_not_isRFPViaTS⟩
 
 
 end MPOTensor.KatoDeformedRFPObstruction

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -559,16 +559,16 @@ theorem tensor_toMPSTensor_isCPSVCanonicalForm :
 
 /-! ### Strong Area Law (SAL)
 
-The saturation of the area law (arXiv:1606.00608, Definition 4.6, line 811)
+The saturation of the area law (arXiv:1606.00608, Definition 4.6, line 811)
 requires the mutual information chain $I_1 = I_2 = \dots$ with
-$I_L = S_L + S_{N-L} - S_N$ (line 797).  For Kato's $p=1/2$ tensor
+$I_L = S_L + S_{N-L} - S_N$ (line 797).  For Kato's $p=1/2$ tensor
 the block reduced states are maximally mixed for non‑full blocks,
 which forces $S_L = L \log 2$ and cancels the $N$‑dependence.
 **All entropy computations in this section are project derivations,
 not stated by Kato or CPSV16.** -/
 
 /-- When the unnormalized MPO has unit trace the normalized MPO collapses
-to the bare MPO.  This relies on `trace_mpo_tensor` giving trace 1. -/
+to the bare MPO.  This relies on `trace_mpo_tensor` giving trace 1. -/
 private lemma normalizedMPO_tensor_eq_mpo (N : ℕ) (hN : 0 < N) :
     normalizedMPO tensor N = mpo tensor N := by
   rw [normalizedMPO, trace_mpo_tensor N hN, inv_one, one_smul]
@@ -798,7 +798,7 @@ private lemma blockEntropy_tensor_eq {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N)
   rw [Real.log_pow]
 
 /-- Kato's $p=1/2$ tensor saturates the area law (arXiv:1606.00608,
-Definition 4.6, line 811): the mutual information $I_L$ is constant
+Definition 4.6, line 811): the mutual information $I_L$ is constant
 in the block size $L$ for $1 \le L < \lfloor N/2\rfloor$.
 
 The proof: for a proper subsystem, the reduced state is maximally mixed,
@@ -843,7 +843,7 @@ theorem tensor_isSAL : IsSAL tensor := by
 The tensor is in CPSV canonical form, generates an MPDO, has an
 idempotent physical‑trace transfer, saturates the area law, yet
 admits no fixed‑scale renormalisation à la arXiv:1606.00608
-Definition 4.1. -/
+Definition 4.1. -/
 theorem exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS :
     ∃ K : MPOTensor 2 2,
       MPSTensor.IsCPSVCanonicalForm K.toMPSTensor ∧

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -557,5 +557,304 @@ theorem tensor_toMPSTensor_isCPSVCanonicalForm :
     (fun _ => by norm_num) katoCFWeights katoCFBlocks
     katoCFBlocks_normal).isCPSVCanonicalForm
 
+/-! ### Strong Area Law (SAL)
+
+The saturation of the area law (arXiv:1606.00608, Definition 4.6, line 811)
+requires the mutual information chain $I_1 = I_2 = \dots$ with
+$I_L = S_L + S_{N-L} - S_N$ (line 797).  For Kato's $p=1/2$ tensor
+the block reduced states are maximally mixed for non‑full blocks,
+which forces $S_L = L \log 2$ and cancels the $N$‑dependence.
+**All entropy computations in this section are project derivations,
+not stated by Kato or CPSV16.** -/
+
+/-- When the unnormalized MPO has unit trace the normalized MPO collapses
+to the bare MPO.  This relies on `trace_mpo_tensor` giving trace 1. -/
+private lemma normalizedMPO_tensor_eq_mpo (N : ℕ) (hN : 0 < N) :
+    normalizedMPO tensor N = mpo tensor N := by
+  rw [normalizedMPO, trace_mpo_tensor N hN, inv_one, one_smul]
+
+/-- The site-sum vanishes: $\sum_{a=0,1} \operatorname{siteSign} a = 1+(-1)=0$. -/
+private lemma sum_siteSign_eq_zero : (∑ a : Fin 2, siteSign a) = (0 : ℂ) := by
+  calc
+    (∑ a : Fin 2, siteSign a) = siteSign 0 + siteSign 1 := Fin.sum_univ_two _
+    _ = (1 : ℂ) + (-1 : ℂ) := by simp [siteSign, pauliZ]
+    _ = 0 := by ring
+
+/-- Sum of `configurationSign` over all functions `Fin n → Fin 2` vanishes
+when the domain is nonempty.  This is the distributive‑law identity
+$\sum_{w} \prod_k \operatorname{siteSign}(w_k)
+  = \prod_k \sum_{a} \operatorname{siteSign}(a) = 0^n$.
+(project derivation) -/
+private lemma sum_configurationSign_eq_zero {n : ℕ} (hn : 0 < n) :
+    ∑ w : Fin n → Fin 2, configurationSign w = 0 := by
+  have hcard : Fintype.card (Fin n) = n := Fintype.card_fin n
+  calc
+    ∑ w : Fin n → Fin 2, configurationSign w
+        = ∑ w : Fin n → Fin 2, (∏ k : Fin n, siteSign (w k)) := rfl
+    _ = ∑ w ∈ (Fintype.piFinset fun (_ : Fin n) => (Finset.univ : Finset (Fin 2))),
+        (∏ k : Fin n, siteSign (w k)) := by simp [Fintype.piFinset_univ]
+    _ = ∏ k : Fin n, (∑ a ∈ (Finset.univ : Finset (Fin 2)), siteSign a) := by
+      rw [← Finset.prod_univ_sum (fun (_ : Fin n) => (Finset.univ : Finset (Fin 2)))
+        (fun (_ : Fin n) a => siteSign a)]
+    _ = ∏ k : Fin n, (∑ a : Fin 2, siteSign a) := by simp
+    _ = ∏ k : Fin n, (0 : ℂ) := by rw [sum_siteSign_eq_zero]
+    _ = 0 := by
+      rw [Finset.prod_const, Finset.card_univ, hcard]
+      exact zero_pow hn.ne'
+
+/-- `configurationSign` factorises through `Fin.append`.
+For $u : \operatorname{Fin} L \to \operatorname{Fin} 2$ and
+$w : \operatorname{Fin} M \to \operatorname{Fin} 2$,
+$\operatorname{configurationSign}(u \mathbin{+\!\!+} w)
+  = \operatorname{configurationSign}(u) \cdot \operatorname{configurationSign}(w)$.
+(project derivation) -/
+private lemma configurationSign_append {L M : ℕ}
+    (u : Fin L → Fin 2) (w : Fin M → Fin 2) :
+    configurationSign (Fin.append u w) = configurationSign u * configurationSign w := by
+  rw [configurationSign, configurationSign, configurationSign]
+  rw [Fin.prod_univ_add]
+  simp [Fin.append_left, Fin.append_right]
+
+/-- `configurationSign` is conjugation‑invariant under the length‑cast:
+for $h_N : N = L + M$ we have
+$\operatorname{configurationSign}(u \mathbin{+\!\!+} w \circ \mathrm{cast}\,h_N)
+  = \operatorname{configurationSign}(u) \cdot \operatorname{configurationSign}(w)$.
+(project derivation) -/
+private lemma configurationSign_append_cast {L M N : ℕ} (hN : N = L + M)
+    (u : Fin L → Fin 2) (w : Fin M → Fin 2) :
+    configurationSign (Fin.append u w ∘ Fin.cast hN) =
+      configurationSign u * configurationSign w := by
+  subst hN
+  simp [configurationSign_append]
+
+/-- The $(u,v)$ entry of the reduced block state of the Kato tensor.
+
+When $u = v$ the entry is the constant $(1/2)^L$ plus the sign term
+(which vanishes when the complement is nonempty, i.e. $L < N$).
+When $u \neq v$ the entry is zero because the MPO is diagonal.
+
+(project derivation) -/
+private lemma reducedBlockState_tensor_apply_eq {N L : ℕ} (hL : L ≤ N) (hNpos : 0 < N)
+    (u v : Fin L → Fin 2) :
+    reducedBlockState tensor N L hL u v =
+      if u = v then ((1 / 2 : ℂ) ^ L)
+                   + ((1 / 4 : ℂ) ^ N) * (configurationSign u) *
+                       (∑ w : Fin (N - L) → Fin 2, configurationSign w)
+      else 0 := by
+  set M := N - L with hM
+  have hNM : N = L + M := by omega
+  have hcard_fun : Fintype.card (Fin M → Fin 2) = 2 ^ M := by
+    simp
+  rw [reducedBlockState_eq_sum tensor hL u v,
+    normalizedMPO_tensor_eq_mpo N hNpos,
+    mpo_tensor_eq_diagonal N]
+  by_cases huv : u = v
+  · subst huv
+    simp only [Matrix.diagonal_apply_eq]
+    -- ∑ w, ((1/2)^N + (1/4)^N * configurationSign (Fin.append u w ∘ Fin.cast hNM))
+    rw [Finset.sum_add_distrib]
+    congr 1
+    · -- ∑ w, (1/2)^N = (1/2)^L
+      rw [Finset.sum_const, Finset.card_univ, hcard_fun, hNM]
+      -- Goal: (2 ^ M : ℕ) • ((1 / 2 : ℂ) ^ (L + M)) = (1 / 2 : ℂ) ^ L
+      -- Convert ℕ-scalar multiplication to ℂ multiplication
+      simpa [nsmul_eq_mul] using calc
+        ((2 : ℂ) ^ M) * (((1 : ℂ) / 2) ^ (L + M))
+            = ((2 : ℂ) ^ M) * (((1 : ℂ) / 2) ^ L * ((1 : ℂ) / 2) ^ M) := by rw [pow_add]
+        _ = (((2 : ℂ) ^ M) * ((1 / 2 : ℂ) ^ M)) * ((1 / 2 : ℂ) ^ L) := by ring
+        _ = (((2 : ℂ) * (1 / 2 : ℂ)) ^ M) * ((1 / 2 : ℂ) ^ L) := by rw [mul_pow]
+        _ = (1 ^ M) * ((1 / 2 : ℂ) ^ L) := by ring
+        _ = (1 : ℂ) * ((1 / 2 : ℂ) ^ L) := by simp
+        _ = (1 / 2 : ℂ) ^ L := by simp
+    · -- ∑ w, (1/4)^N * configurationSign (Fin.append u w ∘ Fin.cast hNM)
+      -- = (1/4)^N * configurationSign u * (∑ w, configurationSign w)
+      calc
+        (∑ w : Fin M → Fin 2, ((1 / 4 : ℂ) ^ N * configurationSign (Fin.append u w ∘ Fin.cast hNM)))
+            = (∑ w : Fin M → Fin 2, ((1 / 4 : ℂ) ^ N * (configurationSign u * configurationSign w))) := by
+          refine Finset.sum_congr rfl (fun w _ => ?_)
+          rw [configurationSign_append_cast hNM u w]
+        _ = ((1 / 4 : ℂ) ^ N) * (configurationSign u) * (∑ w : Fin M → Fin 2, configurationSign w) := by
+          simp [Finset.mul_sum, mul_assoc]
+  · -- u ≠ v: each term in the sum is zero because the MPO is diagonal
+    have hterm_zero : ∀ w : Fin M → Fin 2,
+        (Matrix.diagonal fun σ : Fin N → Fin 2 =>
+          (1 / 2 : ℂ) ^ N + (1 / 4 : ℂ) ^ N * configurationSign σ)
+        (Fin.append u w ∘ Fin.cast hNM) (Fin.append v w ∘ Fin.cast hNM) = 0 := by
+      intro w
+      have hne : Fin.append u w ∘ Fin.cast hNM ≠ Fin.append v w ∘ Fin.cast hNM := by
+        intro heq
+        apply huv
+        -- Cancelling Fin.cast hNM (which is an Equiv, hence surjective)
+        have hcast_eq_fun : (Fin.cast hNM : Fin N → Fin (L + M)) = (finCongr hNM) := by
+          ext i; simp
+        have heq' : Fin.append u w = Fin.append v w := by
+          ext i
+          have h_eq_val : Fin.append u w i = Fin.append v w i := by
+            obtain ⟨j, hj⟩ := (finCongr hNM).surjective i
+            calc
+              Fin.append u w i = Fin.append u w ((finCongr hNM) j) := by rw [hj]
+              _ = Fin.append u w ((Fin.cast hNM) j) := by rw [hcast_eq_fun]
+              _ = (Fin.append u w ∘ Fin.cast hNM) j := rfl
+              _ = (Fin.append v w ∘ Fin.cast hNM) j := by rw [heq]
+              _ = Fin.append v w ((Fin.cast hNM) j) := rfl
+              _ = Fin.append v w ((finCongr hNM) j) := by rw [hcast_eq_fun]
+              _ = Fin.append v w i := by rw [hj]
+          exact congrArg Fin.val h_eq_val
+        funext i
+        have hi := congrArg (fun f : Fin (L + M) → Fin 2 => f (Fin.castAdd M i)) heq'
+        simpa [Fin.append_left] using hi
+      rw [Matrix.diagonal_apply_ne _ hne]
+    have hsum : (∑ w : Fin M → Fin 2,
+        (Matrix.diagonal fun σ : Fin N → Fin 2 =>
+          (1 / 2 : ℂ) ^ N + (1 / 4 : ℂ) ^ N * configurationSign σ)
+        (Fin.append u w ∘ Fin.cast hNM) (Fin.append v w ∘ Fin.cast hNM)) = 0 := by
+      apply Finset.sum_eq_zero
+      intro w _
+      rw [hterm_zero w]
+    rw [hsum]
+    simp [huv]
+
+/-- When $1 \le L < N$ the reduced block state of the Kato tensor on
+$L$ spins is maximally mixed:
+$\rho_L = 2^{-L} \cdot \mathbf{1}$.
+(project derivation) -/
+private lemma reducedBlockState_tensor_eq_scaled_one {N L : ℕ}
+    (hLpos : 1 ≤ L) (hLN : L < N) (hL : L ≤ N := Nat.le_of_lt hLN) :
+    reducedBlockState tensor N L hL = ((2 : ℂ)⁻¹ ^ L : ℂ) • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) := by
+  ext u v
+  rw [reducedBlockState_tensor_apply_eq hL (by omega) u v]
+  by_cases huv : u = v
+  · subst huv
+    have hsum_zero : (∑ w : Fin (N - L) → Fin 2, configurationSign w) = 0 :=
+      sum_configurationSign_eq_zero (Nat.sub_pos_of_lt hLN)
+    simp [hsum_zero, Matrix.one_apply_eq, smul_apply, show ((1 : ℂ) / 2) = (2 : ℂ)⁻¹ by norm_num]
+  · simp [huv, Matrix.one_apply_ne huv, smul_apply]
+
+/-- Scalar helper: $d \cdot \operatorname{negMulLog}(d^{-1}) = \log d$ for $d \neq 0$.
+(project derivation) -/
+private lemma negMulLog_pow_inv_mul (d : ℝ) (hd : d ≠ 0) : d * Real.negMulLog (d⁻¹) = Real.log d := by
+  rw [Real.negMulLog]
+  calc
+    d * (-(d⁻¹) * Real.log (d⁻¹)) = -(d * d⁻¹ * Real.log (d⁻¹)) := by ring
+    _ = -(1 * Real.log (d⁻¹)) := by
+      field_simp [hd]
+    _ = -Real.log (d⁻¹) := by simp
+    _ = Real.log d := by rw [Real.log_inv, neg_neg]
+
+/-- The block entropy $S_L$ for the Kato tensor equals $L \log 2$
+whenever $1 \le L < N$ (so the block is a proper subsystem).
+(project derivation; the maximally‑mixed computation above
+and the entropy of a scalar matrix are not in Kato or CPSV16.) -/
+private lemma blockEntropy_tensor_eq {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N)
+    (hL : L ≤ N) (hM : (mpo tensor N).PosSemidef) :
+    blockEntropy tensor N L hL hM = L * Real.log 2 := by
+  rw [blockEntropy]
+  have hrho_herm : (reducedBlockState tensor N L hL).IsHermitian :=
+    reducedBlockState_isHermitian tensor N L hL hM
+  have hrho_eq : reducedBlockState tensor N L hL =
+      ((2 : ℂ)⁻¹ ^ L : ℂ) • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) :=
+    reducedBlockState_tensor_eq_scaled_one hLpos hLN
+  -- Hermitian proof for the scaled identity
+  have hc_selfadj : IsSelfAdjoint ((2 : ℂ)⁻¹ ^ L : ℂ) := by
+    simp [IsSelfAdjoint]
+  have h_scaled_herm : (((2 : ℂ)⁻¹ ^ L : ℂ) • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ)).IsHermitian :=
+    (Matrix.isHermitian_one (n := Fin L → Fin 2) (α := ℂ)).smul hc_selfadj
+  rw [vonNeumannEntropy_congr hrho_eq hrho_herm h_scaled_herm]
+  -- Now compute von Neumann entropy of c • 1 via charpoly
+  rw [vonNeumannEntropy_eq_charpoly_roots _ h_scaled_herm]
+  have h_card : Fintype.card (Fin L → Fin 2) = 2 ^ L := by
+    simp [Fintype.card_fun, Fintype.card_fin]
+  have h_charpoly : (((2 : ℂ)⁻¹ ^ L : ℂ) • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ)).charpoly =
+      (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) ^ (Fintype.card (Fin L → Fin 2)) := by
+    calc
+      _ = (Matrix.diagonal fun _ : Fin L → Fin 2 => ((2 : ℂ)⁻¹ ^ L : ℂ)).charpoly := by
+        rw [Matrix.smul_one_eq_diagonal]
+      _ = ∏ _i : Fin L → Fin 2, (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) :=
+        Matrix.charpoly_diagonal (fun _ : Fin L → Fin 2 => ((2 : ℂ)⁻¹ ^ L : ℂ))
+      _ = (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) ^ (Fintype.card (Fin L → Fin 2)) := by
+        simp
+  rw [h_charpoly, Polynomial.roots_pow, Polynomial.roots_X_sub_C]
+  simp only [Multiset.map_nsmul, Multiset.sum_nsmul, Multiset.map_singleton,
+    Multiset.sum_singleton]
+  -- Now we have: (Fintype.card ... : ℝ) • Real.negMulLog (...) = ...
+  -- where • is nsmul; convert to multiplication
+  rw [nsmul_eq_mul]
+  rw [h_card]
+  have h_re : (((2 : ℂ)⁻¹ ^ L : ℂ).re : ℝ) = ((2⁻¹ : ℝ) ^ L) := by
+    calc
+      (((2 : ℂ)⁻¹ ^ L : ℂ).re : ℝ) = ((((2⁻¹ : ℝ) : ℂ) ^ L : ℂ).re : ℝ) := by norm_num
+      _ = ((((2⁻¹ : ℝ) ^ L : ℝ) : ℂ).re : ℝ) := by rw [Complex.ofReal_pow]
+      _ = ((2⁻¹ : ℝ) ^ L : ℝ) := by rw [Complex.ofReal_re]
+  rw [h_re]
+  -- Now: (2^L : ℝ) * Real.negMulLog (((2⁻¹ : ℝ) ^ L)) = L * Real.log 2
+  have h_inv : ((2⁻¹ : ℝ) ^ L) = ((2 ^ L : ℝ)⁻¹) := by
+    simp [inv_pow]
+  rw [h_inv]
+  -- Goal: ↑(2 ^ L) * Real.negMulLog ((2 ^ L : ℝ)⁻¹) = ↑L * Real.log 2
+  -- Push the Nat.cast through
+  push_cast
+  -- Goal: (2 ^ L : ℝ) * Real.negMulLog ((2 ^ L : ℝ)⁻¹) = (L : ℝ) * Real.log 2
+  rw [negMulLog_pow_inv_mul ((2 : ℝ) ^ L) (pow_ne_zero L (by norm_num : (2 : ℝ) ≠ 0))]
+  rw [Real.log_pow]
+
+/-- Kato's $p=1/2$ tensor saturates the area law (arXiv:1606.00608,
+Definition 4.6, line 811): the mutual information $I_L$ is constant
+in the block size $L$ for $1 \le L < \lfloor N/2\rfloor$.
+
+The proof: for a proper subsystem, the reduced state is maximally mixed,
+so $S_L = L \log 2$ (project derivation).  Therefore
+$I_L = L\log 2 + (N-L)\log 2 - c_N = N\log 2 - c_N$
+which is independent of $L$. -/
+theorem tensor_isSAL : IsSAL tensor := by
+  refine ⟨tensor_isMPDO, ?_, ?_⟩
+  · -- ∀ N, 0 < N → (mpo tensor N).trace ≠ 0
+    intro N hN
+    rw [trace_mpo_tensor N hN]
+    norm_num
+  · -- ∀ N L, 1 ≤ L → (hL : L < N / 2) → mutualInfoChain ... L ... = mutualInfoChain ... (L+1) ...
+    intro N L hLpos hL_lt_half
+    have hM : (mpo tensor N).PosSemidef := tensor_isMPDO N (by
+      have : 1 ≤ N := by
+        have := Nat.div_pos (by omega) (by norm_num)
+        omega
+      omega)
+    -- mutualInfoChain expands to blockEntropy with specific hL proofs.
+    -- We use `apply` with blockEntropy_tensor_eq so Lean unifies the proof terms.
+    simp only [mutualInfoChain]
+    have hL_val : blockEntropy tensor N L (Nat.le_of_lt (hL_lt_half.trans_le (Nat.div_le_self N 2))) hM = (L : ℝ) * Real.log 2 := by
+      apply blockEntropy_tensor_eq hLpos (by omega) _ hM
+    have hNL_val : blockEntropy tensor N (N - L) (Nat.sub_le N L) hM = ((N - L : ℕ) : ℝ) * Real.log 2 := by
+      apply blockEntropy_tensor_eq (by omega) (by omega) _ hM
+    have hLp1_val : blockEntropy tensor N (L + 1) (hL_lt_half.trans_le (Nat.div_le_self N 2)) hM = ((L + 1 : ℕ) : ℝ) * Real.log 2 := by
+      apply blockEntropy_tensor_eq (by omega) (by omega) _ hM
+    have hNLp1_val : blockEntropy tensor N (N - (L + 1)) (Nat.sub_le N (L + 1)) hM = ((N - (L + 1) : ℕ) : ℝ) * Real.log 2 := by
+      apply blockEntropy_tensor_eq (by omega) (by omega) _ hM
+    rw [hL_val, hNL_val, hLp1_val, hNLp1_val]
+    -- Cancel the S_N term (blockEntropy N N) from both sides
+    -- Then simplify L*log2 + (N-L)*log2 = (L+1)*log2 + (N-(L+1))*log2
+    -- Both sides equal N*log2
+    have hcast1 : ((N - L : ℕ) : ℝ) = (N : ℝ) - (L : ℝ) := Nat.cast_sub (by omega)
+    have hcast2 : ((N - (L + 1) : ℕ) : ℝ) = (N : ℝ) - (((L + 1 : ℕ) : ℝ)) := Nat.cast_sub (by omega)
+    have hcast3 : ((L + 1 : ℕ) : ℝ) = (L : ℝ) + 1 := by simp
+    rw [hcast1, hcast2, hcast3]
+    ring
+
+/-- **Kato's $p=1/2$ tensor as a five‑property capstone.**
+The tensor is in CPSV canonical form, generates an MPDO, has an
+idempotent physical‑trace transfer, saturates the area law, yet
+admits no fixed‑scale renormalisation à la arXiv:1606.00608
+Definition 4.1. -/
+theorem exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS :
+    ∃ K : MPOTensor 2 2,
+      MPSTensor.IsCPSVCanonicalForm K.toMPSTensor ∧
+      IsMPDO K ∧
+      (physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) ∧
+      IsSAL K ∧
+      ¬ IsRFPViaTS K := by
+  refine ⟨tensor, ?_, tensor_isMPDO, physTraceTransfer_tensor_idempotent, tensor_isSAL,
+    tensor_not_isRFPViaTS⟩
+  -- The canonical form is stated for the MPSTensor, not MPOTensor.toMPSTensor
+  -- But the theorem `tensor_toMPSTensor_isCPSVCanonicalForm` gives exactly this
+  exact tensor_toMPSTensor_isCPSVCanonicalForm
 
 end MPOTensor.KatoDeformedRFPObstruction

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -39,6 +39,13 @@ A completely positive coarse-graining map cannot send the former to the latter.
   $\operatorname{diag}(1,0)$ and is idempotent.
 * `tensor_not_isRFPViaTS`: no fixed-scale channels satisfy the two
   intertwining identities of Definition 4.1.
+* `tensor_toMPSTensor_isCPSVCanonicalForm`: the doubled-index MPS tensor
+  is in literal CPSV canonical form (arXiv:1606.00608, eq. `II_CF1`).
+* `tensor_isSAL`: the tensor saturates the area law (Definition 4.6).
+* `exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS`:
+  the tensor simultaneously exhibits CPSV canonical form, MPDO positivity,
+  idempotent physical-trace transfer, strong area law, and absence of
+  fixed-scale renormalization.
 
 ## References
 
@@ -359,11 +366,9 @@ theorem tensor_not_isRFPViaTS : ¬ IsRFPViaTS tensor := by
 
 /-! ### CPSV canonical form of the doubled-index MPS tensor -/
 
-private lemma sqrt2_ne_zero : (Real.sqrt 2 : ℂ) ≠ 0 := by
-  intro h; have hpos := Real.sqrt_pos.mpr (by norm_num : (0 : ℝ) < 2); apply hpos.ne'; exact_mod_cast h
-
 private lemma sqrt2_sq_complex : ((Real.sqrt 2 : ℂ) ^ 2) = (2 : ℂ) := by
-  have hsq_real : (Real.sqrt 2 : ℝ) ^ 2 = (2 : ℝ) := Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num)
+  have hsq_real : (Real.sqrt 2 : ℝ) ^ 2 = (2 : ℝ) :=
+    Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num)
   calc
     ((Real.sqrt 2 : ℂ) ^ 2) = (((Real.sqrt 2 : ℝ) ^ 2 : ℝ) : ℂ) := by push_cast; ring
     _ = ((2 : ℝ) : ℂ) := by rw [hsq_real]
@@ -380,18 +385,23 @@ private lemma blockLetterAmplitude_sq : blockLetterAmplitude ^ 2 = (1 / 2 : ℂ)
 
 noncomputable def block0Weight : ℂ := (1 : ℂ) / Real.sqrt 2
 noncomputable def block1Weight : ℂ := (1 : ℂ) / (2 * Real.sqrt 2)
-noncomputable def katoCFWeights : Fin 2 → ℂ := fun k => match k with | 0 => block0Weight | 1 => block1Weight
+noncomputable def katoCFWeights : Fin 2 → ℂ :=
+  fun k => match k with | 0 => block0Weight | 1 => block1Weight
 
-private lemma block0Weight_times_amplitude : block0Weight * blockLetterAmplitude = (1 / 2 : ℂ) := by
+private lemma block0Weight_times_amplitude :
+    block0Weight * blockLetterAmplitude = (1 / 2 : ℂ) := by
   calc
-    block0Weight * blockLetterAmplitude = ((1 : ℂ) / Real.sqrt 2) * ((1 : ℂ) / Real.sqrt 2) := rfl
+    block0Weight * blockLetterAmplitude =
+        ((1 : ℂ) / Real.sqrt 2) * ((1 : ℂ) / Real.sqrt 2) := rfl
     _ = 1 / ((Real.sqrt 2 : ℂ) ^ 2) := by ring
     _ = 1 / (2 : ℂ) := by rw [sqrt2_sq_complex]
     _ = (1 / 2 : ℂ) := by norm_num
 
-private lemma block1Weight_times_amplitude : block1Weight * blockLetterAmplitude = (1 / 4 : ℂ) := by
+private lemma block1Weight_times_amplitude :
+    block1Weight * blockLetterAmplitude = (1 / 4 : ℂ) := by
   calc
-    block1Weight * blockLetterAmplitude = ((1 : ℂ) / (2 * Real.sqrt 2)) * ((1 : ℂ) / Real.sqrt 2) := rfl
+    block1Weight * blockLetterAmplitude =
+        ((1 : ℂ) / (2 * Real.sqrt 2)) * ((1 : ℂ) / Real.sqrt 2) := rfl
     _ = 1 / (2 * ((Real.sqrt 2 : ℂ) ^ 2)) := by ring
     _ = 1 / (2 * (2 : ℂ)) := by rw [sqrt2_sq_complex]
     _ = (1 / 4 : ℂ) := by ring
@@ -400,25 +410,37 @@ noncomputable def katoCFBlock0 : MPSTensor 4 1 :=
   fun p => if p = 0 ∨ p = 3 then !![blockLetterAmplitude] else 0
 
 noncomputable def katoCFBlock1 : MPSTensor 4 1 :=
-  fun p => if p = 0 then !![blockLetterAmplitude] else if p = 3 then !![-blockLetterAmplitude] else 0
+  fun p =>
+    if p = 0 then !![blockLetterAmplitude]
+    else if p = 3 then !![-blockLetterAmplitude]
+    else 0
 
-noncomputable def katoCFBlocks : Fin 2 → MPSTensor 4 1 := fun k => match k with | 0 => katoCFBlock0 | 1 => katoCFBlock1
+noncomputable def katoCFBlocks : Fin 2 → MPSTensor 4 1 :=
+  fun k => match k with | 0 => katoCFBlock0 | 1 => katoCFBlock1
 
-private lemma oneByOne_mul_apply (A B : Matrix (Fin 1) (Fin 1) ℂ) : (A * B) 0 0 = (A 0 0) * (B 0 0) := by
+private lemma one_by_one_mul_apply (A B : Matrix (Fin 1) (Fin 1) ℂ) :
+    (A * B) 0 0 = (A 0 0) * (B 0 0) := by
   rw [Matrix.mul_apply]
   have huniv : (Finset.univ : Finset (Fin 1)) = {(0 : Fin 1)} := by decide
   rw [huniv, Finset.sum_singleton]
 
-private lemma oneByOne_mul_conj_apply (A X : Matrix (Fin 1) (Fin 1) ℂ) :
+private lemma one_by_one_mul_conj_apply (A X : Matrix (Fin 1) (Fin 1) ℂ) :
     (A * X * Aᴴ) 0 0 = (A 0 0) * (X 0 0) * star (A 0 0) := by
   calc
     (A * X * Aᴴ) 0 0 = ((A * X) * Aᴴ) 0 0 := rfl
-    _ = (A * X) 0 0 * (Aᴴ) 0 0 := by rw [oneByOne_mul_apply]
-    _ = ((A 0 0) * (X 0 0)) * (Aᴴ) 0 0 := by rw [oneByOne_mul_apply]
+    _ = (A * X) 0 0 * (Aᴴ) 0 0 := by rw [one_by_one_mul_apply]
+    _ = ((A 0 0) * (X 0 0)) * (Aᴴ) 0 0 := by rw [one_by_one_mul_apply]
     _ = (A 0 0) * (X 0 0) * star (A 0 0) := by rw [Matrix.conjTranspose_apply]
 
-private lemma katoCFBlock0_transferMap_eq_id :
-    MPSTensor.transferMap katoCFBlock0 = LinearMap.id := by
+/-- Both Kato CF blocks have transfer map equal to the identity.
+The common computation is factored through this helper, parameterized
+by the two nonzero entries of the block (entries 1 and 2 are zero). -/
+private lemma katoCFBlock_transferMap_eq_id_aux (s : ℂ) (B : MPSTensor 4 1)
+    (hB0 : (B 0) 0 0 = blockLetterAmplitude) (hB1 : (B 1) 0 0 = 0)
+    (hB2 : (B 2) 0 0 = 0) (hB3 : (B 3) 0 0 = s)
+    (hs_sum : blockLetterAmplitude * star blockLetterAmplitude +
+              s * star s = 1) :
+    MPSTensor.transferMap B = LinearMap.id := by
   apply LinearMap.ext; intro X
   ext i j
   have hi : i = (0 : Fin 1) := Subsingleton.elim _ _
@@ -426,60 +448,46 @@ private lemma katoCFBlock0_transferMap_eq_id :
   rw [hi, hj]
   rw [MPSTensor.transferMap_apply]
   calc
-    (∑ p : Fin 4, (katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ)) 0 0
-        = ∑ p : Fin 4, ((katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ) 0 0) := rfl
-    _ = ∑ p : Fin 4, ((katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0)) := by
+    (∑ p : Fin 4, (B p * X * (B p)ᴴ)) 0 0
+        = ∑ p : Fin 4, ((B p * X * (B p)ᴴ) 0 0) := rfl
+    _ = ∑ p : Fin 4, ((B p 0 0) * (X 0 0) * star (B p 0 0)) := by
       refine Finset.sum_congr rfl (fun p _ => ?_)
-      rw [oneByOne_mul_conj_apply (katoCFBlock0 p) X]
-    _ = (X 0 0) * (∑ p : Fin 4, (katoCFBlock0 p 0 0) * star (katoCFBlock0 p 0 0)) := by
+      rw [one_by_one_mul_conj_apply (B p) X]
+    _ = (X 0 0) * (∑ p : Fin 4, (B p 0 0) * star (B p 0 0)) := by
       rw [Finset.mul_sum]; refine Finset.sum_congr rfl (fun p _ => ?_); ring
     _ = (X 0 0) * (1 : ℂ) := by
-      have hsum : (∑ p : Fin 4, (katoCFBlock0 p 0 0) * star (katoCFBlock0 p 0 0)) = (1 : ℂ) := by
-        have h0 : (katoCFBlock0 0) 0 0 = blockLetterAmplitude := by simp [katoCFBlock0]
-        have h1 : (katoCFBlock0 1) 0 0 = (0 : ℂ) := by simp [katoCFBlock0]
-        have h2 : (katoCFBlock0 2) 0 0 = (0 : ℂ) := by simp [katoCFBlock0]
-        have h3 : (katoCFBlock0 3) 0 0 = blockLetterAmplitude := by simp [katoCFBlock0]
-        rw [Fin.sum_univ_four, h0, h1, h2, h3]
-        have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
-          rw [blockLetterAmplitude]; simp
-        rw [hstar]
-        simp [hstar]
-        rw [← pow_two, blockLetterAmplitude_sq]
-        norm_num
+      have hsum : (∑ p : Fin 4, (B p 0 0) * star (B p 0 0)) = (1 : ℂ) := by
+        rw [Fin.sum_univ_four, hB0, hB1, hB2, hB3]
+        simp
+        simpa using hs_sum
       rw [hsum]
     _ = X 0 0 := by simp
 
+private lemma katoCFBlock0_transferMap_eq_id :
+    MPSTensor.transferMap katoCFBlock0 = LinearMap.id :=
+  katoCFBlock_transferMap_eq_id_aux blockLetterAmplitude katoCFBlock0
+    (by simp [katoCFBlock0]) (by simp [katoCFBlock0])
+    (by simp [katoCFBlock0]) (by simp [katoCFBlock0])
+    (by
+      have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
+        rw [blockLetterAmplitude]; simp
+      rw [hstar, ← pow_two, blockLetterAmplitude_sq]
+      norm_num)
+
 private lemma katoCFBlock1_transferMap_eq_id :
-    MPSTensor.transferMap katoCFBlock1 = LinearMap.id := by
-  apply LinearMap.ext; intro X
-  ext i j
-  have hi : i = (0 : Fin 1) := Subsingleton.elim _ _
-  have hj : j = (0 : Fin 1) := Subsingleton.elim _ _
-  rw [hi, hj]
-  rw [MPSTensor.transferMap_apply]
-  calc
-    (∑ p : Fin 4, (katoCFBlock1 p * X * (katoCFBlock1 p)ᴴ)) 0 0
-        = ∑ p : Fin 4, ((katoCFBlock1 p * X * (katoCFBlock1 p)ᴴ) 0 0) := rfl
-    _ = ∑ p : Fin 4, ((katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0)) := by
-      refine Finset.sum_congr rfl (fun p _ => ?_)
-      rw [oneByOne_mul_conj_apply (katoCFBlock1 p) X]
-    _ = (X 0 0) * (∑ p : Fin 4, (katoCFBlock1 p 0 0) * star (katoCFBlock1 p 0 0)) := by
-      rw [Finset.mul_sum]; refine Finset.sum_congr rfl (fun p _ => ?_); ring
-    _ = (X 0 0) * (1 : ℂ) := by
-      have hsum : (∑ p : Fin 4, (katoCFBlock1 p 0 0) * star (katoCFBlock1 p 0 0)) = (1 : ℂ) := by
-        have h0 : (katoCFBlock1 0) 0 0 = blockLetterAmplitude := by simp [katoCFBlock1]
-        have h1 : (katoCFBlock1 1) 0 0 = (0 : ℂ) := by simp [katoCFBlock1]
-        have h2 : (katoCFBlock1 2) 0 0 = (0 : ℂ) := by simp [katoCFBlock1]
-        have h3 : (katoCFBlock1 3) 0 0 = -blockLetterAmplitude := by simp [katoCFBlock1]
-        rw [Fin.sum_univ_four, h0, h1, h2, h3]
-        have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
-          rw [blockLetterAmplitude]; simp
-        rw [hstar]
-        simp [hstar]
-        rw [← pow_two, blockLetterAmplitude_sq]
-        norm_num
-      rw [hsum]
-    _ = X 0 0 := by simp
+    MPSTensor.transferMap katoCFBlock1 = LinearMap.id :=
+  katoCFBlock_transferMap_eq_id_aux (-blockLetterAmplitude) katoCFBlock1
+    (by simp [katoCFBlock1]) (by simp [katoCFBlock1])
+    (by simp [katoCFBlock1]) (by simp [katoCFBlock1])
+    (by
+      have hstar_amp : star blockLetterAmplitude = blockLetterAmplitude := by
+        rw [blockLetterAmplitude]; simp
+      have hstar_neg : star (-blockLetterAmplitude) = -blockLetterAmplitude := by
+        simp [hstar_amp]
+      rw [hstar_amp, hstar_neg]
+      ring_nf
+      rw [blockLetterAmplitude_sq]
+      norm_num)
 
 private lemma katoCFBlocks_normal (k : Fin 2) : MPSTensor.IsNormalTensor (katoCFBlocks k) := by
   fin_cases k
@@ -488,7 +496,7 @@ private lemma katoCFBlocks_normal (k : Fin 2) : MPSTensor.IsNormalTensor (katoCF
   · exact MPSTensor.isNormalTensor_of_bondDim_one_of_transferMap_eq_id
       katoCFBlock1 katoCFBlock1_transferMap_eq_id
 
-theorem toMPSTensor_eq_toTensorFromBlocks :
+private theorem toMPSTensor_eq_toTensorFromBlocks :
     MPOTensor.toMPSTensor tensor = MPSTensor.toTensorFromBlocks katoCFWeights katoCFBlocks := by
   let e : (Σ _k : Fin 2, Fin 1) ≃ Fin 2 := finSigmaFinEquiv
   have hflat (k : Fin 2) : e ⟨k, (0 : Fin 1)⟩ = k := by fin_cases k <;> rfl
@@ -508,16 +516,24 @@ theorem toMPSTensor_eq_toTensorFromBlocks :
     · have hp_val : p = 0 ∨ p = 3 := by
         fin_cases p
         · left; rfl
-        · exfalso; apply (by decide : ¬ ((1 : Fin (2*2)).divNat = (1 : Fin (2*2)).modNat)); exact hp_diag
-        · exfalso; apply (by decide : ¬ ((2 : Fin (2*2)).divNat = (2 : Fin (2*2)).modNat)); exact hp_diag
+        · exfalso
+          apply (by decide : ¬ ((1 : Fin (2*2)).divNat = (1 : Fin (2*2)).modNat))
+          exact hp_diag
+        · exfalso
+          apply (by decide : ¬ ((2 : Fin (2*2)).divNat = (2 : Fin (2*2)).modNat))
+          exact hp_diag
         · right; rfl
       rcases hp_val with rfl | rfl
       · fin_cases x
-        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, katoCFBlock0, block0Weight_times_amplitude]
-        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, katoCFBlock1, block1Weight_times_amplitude]
+        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat,
+            katoCFBlock0, block0Weight_times_amplitude]
+        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat,
+            katoCFBlock1, block1Weight_times_amplitude]
       · fin_cases x
-        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, katoCFBlock0, block0Weight_times_amplitude]
-        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, katoCFBlock1, block1Weight_times_amplitude]
+        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat,
+            katoCFBlock0, block0Weight_times_amplitude]
+        · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat,
+            katoCFBlock1, block1Weight_times_amplitude]
     · -- p.divNat ≠ p.modNat means p is 1 or 2; tensor = 0 and blocks = 0
       have hp12 : p = (1 : Fin (2*2)) ∨ p = (2 : Fin (2*2)) := by
         fin_cases p
@@ -540,8 +556,12 @@ theorem toMPSTensor_eq_toTensorFromBlocks :
     · have hp_val : p = 0 ∨ p = 3 := by
         fin_cases p
         · left; rfl
-        · exfalso; apply (by decide : ¬ ((1 : Fin (2*2)).divNat = (1 : Fin (2*2)).modNat)); exact hp_diag
-        · exfalso; apply (by decide : ¬ ((2 : Fin (2*2)).divNat = (2 : Fin (2*2)).modNat)); exact hp_diag
+        · exfalso
+          apply (by decide : ¬ ((1 : Fin (2*2)).divNat = (1 : Fin (2*2)).modNat))
+          exact hp_diag
+        · exfalso
+          apply (by decide : ¬ ((2 : Fin (2*2)).divNat = (2 : Fin (2*2)).modNat))
+          exact hp_diag
         · right; rfl
       rcases hp_val with rfl | rfl
       · simp [tensor, siteSign, pauliZ, Fin.divNat, Fin.modNat, h]
@@ -550,6 +570,12 @@ theorem toMPSTensor_eq_toTensorFromBlocks :
       rw [tensor, if_neg hp_diag]
       simp
 
+/-- The doubled-index MPS tensor of Kato's $p=1/2$ tensor is in literal CPSV
+canonical form (arXiv:1606.00608, Section 2.3, eq. `II_CF1`, lines 214–245):
+a weighted direct sum of two normal bond-one tensors.
+
+Source: the tensor is arXiv:2410.22696 lines 712–721; the canonical form
+verification follows the construction in arXiv:1606.00608 Section 2.3. -/
 theorem tensor_toMPSTensor_isCPSVCanonicalForm :
     MPSTensor.IsCPSVCanonicalForm (MPOTensor.toMPSTensor tensor) := by
   rw [toMPSTensor_eq_toTensorFromBlocks]
@@ -562,8 +588,8 @@ theorem tensor_toMPSTensor_isCPSVCanonicalForm :
 The saturation of the area law (arXiv:1606.00608, Definition 4.6, line 811)
 requires the mutual information chain $I_1 = I_2 = \dots$ with
 $I_L = S_L + S_{N-L} - S_N$ (line 797).  For Kato's $p=1/2$ tensor
-the block reduced states are maximally mixed for non‑full blocks,
-which forces $S_L = L \log 2$ and cancels the $N$‑dependence.
+the block reduced states are maximally mixed for non-full blocks,
+which forces $S_L = L \log 2$ and cancels the $N$-dependence.
 **All entropy computations in this section are project derivations,
 not stated by Kato or CPSV16.** -/
 
@@ -580,8 +606,8 @@ private lemma sum_siteSign_eq_zero : (∑ a : Fin 2, siteSign a) = (0 : ℂ) := 
     _ = (1 : ℂ) + (-1 : ℂ) := by simp [siteSign, pauliZ]
     _ = 0 := by ring
 
-/-- Sum of `configurationSign` over all functions `Fin n → Fin 2` vanishes
-when the domain is nonempty.  This is the distributive‑law identity
+/-- Sum of `configurationSign` over all binary words of length $n$
+vanishes when $n > 0$.  This is the distributive-law identity
 $\sum_{w} \prod_k \operatorname{siteSign}(w_k)
   = \prod_k \sum_{a} \operatorname{siteSign}(a) = 0^n$.
 (project derivation) -/
@@ -615,9 +641,11 @@ private lemma configurationSign_append {L M : ℕ}
   rw [Fin.prod_univ_add]
   simp [Fin.append_left, Fin.append_right]
 
-/-- `configurationSign` is conjugation‑invariant under the length‑cast:
-for $h_N : N = L + M$ we have
-$\operatorname{configurationSign}(u \mathbin{+\!\!+} w \circ \mathrm{cast}\,h_N)
+/-- `configurationSign` is invariant under the canonical bijection
+$\operatorname{Fin} N \simeq \operatorname{Fin}(L+M)$ given by $h_N : N = L + M$:
+for $u : \operatorname{Fin} L \to \operatorname{Fin} 2$ and
+$w : \operatorname{Fin} M \to \operatorname{Fin} 2$,
+$\operatorname{configurationSign}(u \mathbin{+\!\!+} w \circ e_{h_N})
   = \operatorname{configurationSign}(u) \cdot \operatorname{configurationSign}(w)$.
 (project derivation) -/
 private lemma configurationSign_append_cast {L M N : ℕ} (hN : N = L + M)
@@ -669,11 +697,16 @@ private lemma reducedBlockState_tensor_apply_eq {N L : ℕ} (hL : L ≤ N) (hNpo
     · -- ∑ w, (1/4)^N * configurationSign (Fin.append u w ∘ Fin.cast hNM)
       -- = (1/4)^N * configurationSign u * (∑ w, configurationSign w)
       calc
-        (∑ w : Fin M → Fin 2, ((1 / 4 : ℂ) ^ N * configurationSign (Fin.append u w ∘ Fin.cast hNM)))
-            = (∑ w : Fin M → Fin 2, ((1 / 4 : ℂ) ^ N * (configurationSign u * configurationSign w))) := by
+        (∑ w : Fin M → Fin 2,
+            ((1 / 4 : ℂ) ^ N *
+              configurationSign (Fin.append u w ∘ Fin.cast hNM)))
+            = (∑ w : Fin M → Fin 2,
+                ((1 / 4 : ℂ) ^ N *
+                  (configurationSign u * configurationSign w))) := by
           refine Finset.sum_congr rfl (fun w _ => ?_)
           rw [configurationSign_append_cast hNM u w]
-        _ = ((1 / 4 : ℂ) ^ N) * (configurationSign u) * (∑ w : Fin M → Fin 2, configurationSign w) := by
+        _ = ((1 / 4 : ℂ) ^ N) * (configurationSign u) *
+            (∑ w : Fin M → Fin 2, configurationSign w) := by
           simp [Finset.mul_sum, mul_assoc]
   · -- u ≠ v: each term in the sum is zero because the MPO is diagonal
     have hterm_zero : ∀ w : Fin M → Fin 2,
@@ -720,19 +753,23 @@ $\rho_L = 2^{-L} \cdot \mathbf{1}$.
 (project derivation) -/
 private lemma reducedBlockState_tensor_eq_scaled_one {N L : ℕ}
     (hLpos : 1 ≤ L) (hLN : L < N) (hL : L ≤ N := Nat.le_of_lt hLN) :
-    reducedBlockState tensor N L hL = ((2 : ℂ)⁻¹ ^ L : ℂ) • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) := by
+    reducedBlockState tensor N L hL =
+      ((2 : ℂ)⁻¹ ^ L : ℂ) •
+      (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) := by
   ext u v
   rw [reducedBlockState_tensor_apply_eq hL (by omega) u v]
   by_cases huv : u = v
   · subst huv
     have hsum_zero : (∑ w : Fin (N - L) → Fin 2, configurationSign w) = 0 :=
       sum_configurationSign_eq_zero (Nat.sub_pos_of_lt hLN)
-    simp [hsum_zero, Matrix.one_apply_eq, smul_apply, show ((1 : ℂ) / 2) = (2 : ℂ)⁻¹ by norm_num]
+    simp [hsum_zero, Matrix.one_apply_eq,
+      show ((1 : ℂ) / 2) = (2 : ℂ)⁻¹ by norm_num]
   · simp [huv, Matrix.one_apply_ne huv, smul_apply]
 
-/-- Scalar helper: $d \cdot \operatorname{negMulLog}(d^{-1}) = \log d$ for $d \neq 0$.
-(project derivation) -/
-private lemma negMulLog_pow_inv_mul (d : ℝ) (hd : d ≠ 0) : d * Real.negMulLog (d⁻¹) = Real.log d := by
+/-- For $d \neq 0$, $d \cdot \operatorname{negMulLog}(d^{-1}) = \log d$
+(project derivation). -/
+private lemma negMulLog_pow_inv_mul (d : ℝ) (hd : d ≠ 0) :
+    d * Real.negMulLog (d⁻¹) = Real.log d := by
   rw [Real.negMulLog]
   calc
     d * (-(d⁻¹) * Real.log (d⁻¹)) = -(d * d⁻¹ * Real.log (d⁻¹)) := by ring
@@ -743,7 +780,7 @@ private lemma negMulLog_pow_inv_mul (d : ℝ) (hd : d ≠ 0) : d * Real.negMulLo
 
 /-- The block entropy $S_L$ for the Kato tensor equals $L \log 2$
 whenever $1 \le L < N$ (so the block is a proper subsystem).
-(project derivation; the maximally‑mixed computation above
+(project derivation; the maximally-mixed computation above
 and the entropy of a scalar matrix are not in Kato or CPSV16.) -/
 private lemma blockEntropy_tensor_eq {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N)
     (hL : L ≤ N) (hM : (mpo tensor N).PosSemidef) :
@@ -757,21 +794,27 @@ private lemma blockEntropy_tensor_eq {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N)
   -- Hermitian proof for the scaled identity
   have hc_selfadj : IsSelfAdjoint ((2 : ℂ)⁻¹ ^ L : ℂ) := by
     simp [IsSelfAdjoint]
-  have h_scaled_herm : (((2 : ℂ)⁻¹ ^ L : ℂ) • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ)).IsHermitian :=
+  have h_scaled_herm : (((2 : ℂ)⁻¹ ^ L : ℂ) •
+      (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ)).IsHermitian :=
     (Matrix.isHermitian_one (n := Fin L → Fin 2) (α := ℂ)).smul hc_selfadj
   rw [vonNeumannEntropy_congr hrho_eq hrho_herm h_scaled_herm]
   -- Now compute von Neumann entropy of c • 1 via charpoly
   rw [vonNeumannEntropy_eq_charpoly_roots _ h_scaled_herm]
   have h_card : Fintype.card (Fin L → Fin 2) = 2 ^ L := by
     simp [Fintype.card_fun, Fintype.card_fin]
-  have h_charpoly : (((2 : ℂ)⁻¹ ^ L : ℂ) • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ)).charpoly =
-      (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) ^ (Fintype.card (Fin L → Fin 2)) := by
+  have h_charpoly : (((2 : ℂ)⁻¹ ^ L : ℂ) •
+      (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ)).charpoly =
+      (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) ^
+        (Fintype.card (Fin L → Fin 2)) := by
     calc
       _ = (Matrix.diagonal fun _ : Fin L → Fin 2 => ((2 : ℂ)⁻¹ ^ L : ℂ)).charpoly := by
         rw [Matrix.smul_one_eq_diagonal]
-      _ = ∏ _i : Fin L → Fin 2, (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) :=
-        Matrix.charpoly_diagonal (fun _ : Fin L → Fin 2 => ((2 : ℂ)⁻¹ ^ L : ℂ))
-      _ = (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) ^ (Fintype.card (Fin L → Fin 2)) := by
+      _ = ∏ _i : Fin L → Fin 2,
+          (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) :=
+        Matrix.charpoly_diagonal
+          (fun _ : Fin L → Fin 2 => ((2 : ℂ)⁻¹ ^ L : ℂ))
+      _ = (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) ^
+          (Fintype.card (Fin L → Fin 2)) := by
         simp
   rw [h_charpoly, Polynomial.roots_pow, Polynomial.roots_X_sub_C]
   simp only [Multiset.map_nsmul, Multiset.sum_nsmul, Multiset.map_singleton,
@@ -782,7 +825,8 @@ private lemma blockEntropy_tensor_eq {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N)
   rw [h_card]
   have h_re : (((2 : ℂ)⁻¹ ^ L : ℂ).re : ℝ) = ((2⁻¹ : ℝ) ^ L) := by
     calc
-      (((2 : ℂ)⁻¹ ^ L : ℂ).re : ℝ) = ((((2⁻¹ : ℝ) : ℂ) ^ L : ℂ).re : ℝ) := by norm_num
+      (((2 : ℂ)⁻¹ ^ L : ℂ).re : ℝ) =
+          ((((2⁻¹ : ℝ) : ℂ) ^ L : ℂ).re : ℝ) := by norm_num
       _ = ((((2⁻¹ : ℝ) ^ L : ℝ) : ℂ).re : ℝ) := by rw [Complex.ofReal_pow]
       _ = ((2⁻¹ : ℝ) ^ L : ℝ) := by rw [Complex.ofReal_re]
   rw [h_re]
@@ -811,38 +855,43 @@ theorem tensor_isSAL : IsSAL tensor := by
     intro N hN
     rw [trace_mpo_tensor N hN]
     norm_num
-  · -- ∀ N L, 1 ≤ L → (hL : L < N / 2) → mutualInfoChain ... L ... = mutualInfoChain ... (L+1) ...
+  · -- ∀ N L, 1 ≤ L → (hL : L < N / 2) →
+    --   mutualInfoChain ... L ... = mutualInfoChain ... (L+1) ...
     intro N L hLpos hL_lt_half
-    have hM : (mpo tensor N).PosSemidef := tensor_isMPDO N (by
-      have : 1 ≤ N := by
-        have := Nat.div_pos (by omega) (by norm_num)
-        omega
-      omega)
+    have hM : (mpo tensor N).PosSemidef :=
+      tensor_isMPDO N (by omega)
     -- mutualInfoChain expands to blockEntropy with specific hL proofs.
     -- We use `apply` with blockEntropy_tensor_eq so Lean unifies the proof terms.
     simp only [mutualInfoChain]
-    have hL_val : blockEntropy tensor N L (Nat.le_of_lt (hL_lt_half.trans_le (Nat.div_le_self N 2))) hM = (L : ℝ) * Real.log 2 := by
+    have hL_val : blockEntropy tensor N L
+        (Nat.le_of_lt (hL_lt_half.trans_le (Nat.div_le_self N 2))) hM =
+        (L : ℝ) * Real.log 2 := by
       apply blockEntropy_tensor_eq hLpos (by omega) _ hM
-    have hNL_val : blockEntropy tensor N (N - L) (Nat.sub_le N L) hM = ((N - L : ℕ) : ℝ) * Real.log 2 := by
+    have hNL_val : blockEntropy tensor N (N - L) (Nat.sub_le N L) hM =
+        ((N - L : ℕ) : ℝ) * Real.log 2 := by
       apply blockEntropy_tensor_eq (by omega) (by omega) _ hM
-    have hLp1_val : blockEntropy tensor N (L + 1) (hL_lt_half.trans_le (Nat.div_le_self N 2)) hM = ((L + 1 : ℕ) : ℝ) * Real.log 2 := by
+    have hLp1_val : blockEntropy tensor N (L + 1)
+        (hL_lt_half.trans_le (Nat.div_le_self N 2)) hM =
+        ((L + 1 : ℕ) : ℝ) * Real.log 2 := by
       apply blockEntropy_tensor_eq (by omega) (by omega) _ hM
-    have hNLp1_val : blockEntropy tensor N (N - (L + 1)) (Nat.sub_le N (L + 1)) hM = ((N - (L + 1) : ℕ) : ℝ) * Real.log 2 := by
+    have hNLp1_val : blockEntropy tensor N (N - (L + 1))
+        (Nat.sub_le N (L + 1)) hM =
+        ((N - (L + 1) : ℕ) : ℝ) * Real.log 2 := by
       apply blockEntropy_tensor_eq (by omega) (by omega) _ hM
     rw [hL_val, hNL_val, hLp1_val, hNLp1_val]
     -- Cancel the S_N term (blockEntropy N N) from both sides
     -- Then simplify L*log2 + (N-L)*log2 = (L+1)*log2 + (N-(L+1))*log2
     -- Both sides equal N*log2
     have hcast1 : ((N - L : ℕ) : ℝ) = (N : ℝ) - (L : ℝ) := Nat.cast_sub (by omega)
-    have hcast2 : ((N - (L + 1) : ℕ) : ℝ) = (N : ℝ) - (((L + 1 : ℕ) : ℝ)) := Nat.cast_sub (by omega)
+    have hcast2 : ((N - (L + 1) : ℕ) : ℝ) = (N : ℝ) - ((L + 1 : ℕ) : ℝ) :=
+      Nat.cast_sub (by omega)
     have hcast3 : ((L + 1 : ℕ) : ℝ) = (L : ℝ) + 1 := by simp
     rw [hcast1, hcast2, hcast3]
     ring
 
-/-- **Kato's $p=1/2$ tensor as a five‑property capstone.**
-The tensor is in CPSV canonical form, generates an MPDO, has an
-idempotent physical‑trace transfer, saturates the area law, yet
-admits no fixed‑scale renormalisation à la arXiv:1606.00608
+/-- Kato's $p=1/2$ tensor is in CPSV canonical form, generates MPDO,
+has idempotent physical-trace transfer, saturates the area law, but
+admits no fixed-scale renormalization a la arXiv:1606.00608
 Definition 4.1. -/
 theorem exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS :
     ∃ K : MPOTensor 2 2,

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -374,7 +374,7 @@ private lemma sqrt2_sq_complex : ((Real.sqrt 2 : ℂ) ^ 2) = (2 : ℂ) := by
     _ = ((2 : ℝ) : ℂ) := by rw [hsq_real]
     _ = (2 : ℂ) := rfl
 
-noncomputable def blockLetterAmplitude : ℂ := (1 : ℂ) / Real.sqrt 2
+private noncomputable def blockLetterAmplitude : ℂ := (1 : ℂ) / Real.sqrt 2
 
 private lemma blockLetterAmplitude_sq : blockLetterAmplitude ^ 2 = (1 / 2 : ℂ) := by
   calc
@@ -383,9 +383,9 @@ private lemma blockLetterAmplitude_sq : blockLetterAmplitude ^ 2 = (1 / 2 : ℂ)
     _ = 1 / (2 : ℂ) := by rw [sqrt2_sq_complex]
     _ = (1 / 2 : ℂ) := by norm_num
 
-noncomputable def block0Weight : ℂ := (1 : ℂ) / Real.sqrt 2
-noncomputable def block1Weight : ℂ := (1 : ℂ) / (2 * Real.sqrt 2)
-noncomputable def katoCFWeights : Fin 2 → ℂ :=
+private noncomputable def block0Weight : ℂ := (1 : ℂ) / Real.sqrt 2
+private noncomputable def block1Weight : ℂ := (1 : ℂ) / (2 * Real.sqrt 2)
+private noncomputable def katoCFWeights : Fin 2 → ℂ :=
   fun k => match k with | 0 => block0Weight | 1 => block1Weight
 
 private lemma block0Weight_times_amplitude :
@@ -406,16 +406,16 @@ private lemma block1Weight_times_amplitude :
     _ = 1 / (2 * (2 : ℂ)) := by rw [sqrt2_sq_complex]
     _ = (1 / 4 : ℂ) := by ring
 
-noncomputable def katoCFBlock0 : MPSTensor 4 1 :=
+private noncomputable def katoCFBlock0 : MPSTensor 4 1 :=
   fun p => if p = 0 ∨ p = 3 then !![blockLetterAmplitude] else 0
 
-noncomputable def katoCFBlock1 : MPSTensor 4 1 :=
+private noncomputable def katoCFBlock1 : MPSTensor 4 1 :=
   fun p =>
     if p = 0 then !![blockLetterAmplitude]
     else if p = 3 then !![-blockLetterAmplitude]
     else 0
 
-noncomputable def katoCFBlocks : Fin 2 → MPSTensor 4 1 :=
+private noncomputable def katoCFBlocks : Fin 2 → MPSTensor 4 1 :=
   fun k => match k with | 0 => katoCFBlock0 | 1 => katoCFBlock1
 
 private lemma one_by_one_mul_apply (A B : Matrix (Fin 1) (Fin 1) ℂ) :

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -5,6 +5,8 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.SectorTrace
+import TNLean.MPS.MPDO.AreaLaw
+import TNLean.MPS.CanonicalForm.Definitions
 
 /-!
 # A tensor-changing renormalization flow outside the fixed-scale condition
@@ -47,6 +49,8 @@ A completely positive coarse-graining map cannot send the former to the latter.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
+
+set_option maxHeartbeats 400000
 
 namespace MPOTensor.KatoDeformedRFPObstruction
 
@@ -352,5 +356,328 @@ theorem tensor_not_isRFPViaTS : ¬ IsRFPViaTS tensor := by
     hS.map_posSemidef physClose2_obstructionBoundary_posSemidef
   rw [hSclose obstructionBoundary] at hpos
   exact physClose1_obstructionBoundary_not_posSemidef hpos
+
+
+
+/-! ### CPSV canonical form of the doubled-index MPS tensor -/
+
+private lemma sqrt2_ne_zero : (Real.sqrt 2 : ℂ) ≠ 0 := by
+  intro h
+  have hpos := Real.sqrt_pos.mpr (by norm_num : (0 : ℝ) < 2)
+  apply hpos.ne'
+  exact_mod_cast h
+
+private lemma sqrt2_sq_complex : ((Real.sqrt 2 : ℂ) ^ 2) = (2 : ℂ) := by
+  have hsq_real : (Real.sqrt 2 : ℝ) ^ 2 = (2 : ℝ) :=
+    Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num)
+  calc
+    ((Real.sqrt 2 : ℂ) ^ 2) = (((Real.sqrt 2 : ℝ) ^ 2 : ℝ) : ℂ) := by push_cast; ring
+    _ = ((2 : ℝ) : ℂ) := by rw [hsq_real]
+    _ = (2 : ℂ) := rfl
+
+noncomputable def blockLetterAmplitude : ℂ := (1 : ℂ) / Real.sqrt 2
+
+private lemma blockLetterAmplitude_sq : blockLetterAmplitude ^ 2 = (1 / 2 : ℂ) := by
+  calc
+    blockLetterAmplitude ^ 2 = ((1 : ℂ) / Real.sqrt 2) ^ 2 := rfl
+    _ = 1 / ((Real.sqrt 2 : ℂ) ^ 2) := by ring
+    _ = 1 / (2 : ℂ) := by rw [sqrt2_sq_complex]
+    _ = (1 / 2 : ℂ) := by norm_num
+
+noncomputable def block0Weight : ℂ := (1 : ℂ) / Real.sqrt 2
+noncomputable def block1Weight : ℂ := (1 : ℂ) / (2 * Real.sqrt 2)
+
+noncomputable def katoCFWeights : Fin 2 → ℂ := fun k => match k with
+  | 0 => block0Weight
+  | 1 => block1Weight
+
+private lemma block0Weight_times_amplitude : block0Weight * blockLetterAmplitude = (1 / 2 : ℂ) := by
+  calc
+    block0Weight * blockLetterAmplitude = ((1 : ℂ) / Real.sqrt 2) * ((1 : ℂ) / Real.sqrt 2) := rfl
+    _ = 1 / ((Real.sqrt 2 : ℂ) ^ 2) := by ring
+    _ = 1 / (2 : ℂ) := by rw [sqrt2_sq_complex]
+    _ = (1 / 2 : ℂ) := by norm_num
+
+private lemma block1Weight_times_amplitude : block1Weight * blockLetterAmplitude = (1 / 4 : ℂ) := by
+  calc
+    block1Weight * blockLetterAmplitude = ((1 : ℂ) / (2 * Real.sqrt 2)) * ((1 : ℂ) / Real.sqrt 2) := rfl
+    _ = 1 / (2 * ((Real.sqrt 2 : ℂ) ^ 2)) := by ring
+    _ = 1 / (2 * (2 : ℂ)) := by rw [sqrt2_sq_complex]
+    _ = (1 / 4 : ℂ) := by ring
+
+noncomputable def katoCFBlock0 : MPSTensor 4 1 :=
+  fun p => if p = 0 ∨ p = 3 then !![blockLetterAmplitude] else 0
+
+noncomputable def katoCFBlock1 : MPSTensor 4 1 :=
+  fun p => if p = 0 then !![blockLetterAmplitude]
+    else if p = 3 then !![-blockLetterAmplitude] else 0
+
+noncomputable def katoCFBlocks : Fin 2 → MPSTensor 4 1 := fun k => match k with
+  | 0 => katoCFBlock0
+  | 1 => katoCFBlock1
+
+/-- The transfer map of katoCFBlock0 is the identity on the bond-one space.
+
+Both nonzero entries (physical indices 0 and 3) equal 1/√2, giving
+∑ |A_i|² = |1/√2|² + |1/√2|² = 1. -/
+private lemma katoCFBlock0_transferMap_eq_id :
+    MPSTensor.transferMap katoCFBlock0 = LinearMap.id := by
+  apply LinearMap.ext; intro X
+  -- For Fin 1, all elements equal 0 by dec_trivial
+  have hi (i : Fin 1) : i = 0 := by fin_cases i; rfl
+  have hj (j : Fin 1) : j = 0 := by fin_cases j; rfl
+  ext i j; rw [hi i, hj j]
+  -- Goal: (∑ p, katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ) 0 0 = X 0 0
+  -- Only p=0 and p=3 contribute, each with value blockLetterAmplitude (real, so star=id)
+  rw [MPSTensor.transferMap_apply]
+  -- Enumerate the sum explicitly
+  -- For 1×1 matrices, (M * N) 0 0 = M 0 0 * N 0 0, so the sum reduces to a scalar sum
+  -- Only p=0 and p=3 contribute nonzero values, both equal to blockLetterAmplitude
+  -- Thus ∑ |A_p 0 0|² = 2 * blockLetterAmplitude² = 2 * (1/2) = 1
+  have hsum_scalar : (∑ p : Fin 4, (katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0)) = X 0 0 := by
+    calc
+      (∑ p : Fin 4, (katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0))
+          = (X 0 0) * (∑ p : Fin 4, (katoCFBlock0 p 0 0) * star (katoCFBlock0 p 0 0)) := by
+        simp_rw [Finset.mul_sum]; ring
+      _ = (X 0 0) * (blockLetterAmplitude * star blockLetterAmplitude * 2) := by
+        simp [katoCFBlock0, Fin.sum_univ_four]
+        ring
+      _ = (X 0 0) * (blockLetterAmplitude ^ 2 * 2) := by
+        have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
+          rw [blockLetterAmplitude]; simp
+        rw [hstar]; ring
+      _ = (X 0 0) * ((1/2 : ℂ) * 2) := by rw [blockLetterAmplitude_sq]
+      _ = X 0 0 := by ring
+  -- Connect the matrix sum entry to the scalar sum
+  calc
+    (∑ p : Fin 4, (katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ)) 0 0
+        = ∑ p : Fin 4, ((katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ) 0 0) := rfl
+    _ = ∑ p : Fin 4, ((katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0)) := by
+      refine Finset.sum_congr rfl (fun p _ => ?_)
+      -- For 1×1 matrices, (M * N * P) 0 0 = M 0 0 * N 0 0 * P 0 0
+      -- This is true because there is only one index in the matrix multiplication sum
+      calc
+        ((katoCFBlock0 p * X * (katoCFBlock0 p)ᴴ) 0 0) = 
+            ((katoCFBlock0 p * X) * (katoCFBlock0 p)ᴴ) 0 0 := rfl
+        _ = ∑ k : Fin 1, (katoCFBlock0 p * X) 0 k * ((katoCFBlock0 p)ᴴ) k 0 := rfl
+        _ = (katoCFBlock0 p * X) 0 0 * ((katoCFBlock0 p)ᴴ) 0 0 := by simp
+        _ = (∑ j : Fin 1, (katoCFBlock0 p) 0 j * X j 0) * ((katoCFBlock0 p)ᴴ) 0 0 := rfl
+        _ = ((katoCFBlock0 p) 0 0 * X 0 0) * ((katoCFBlock0 p)ᴴ) 0 0 := by simp
+        _ = (katoCFBlock0 p 0 0) * (X 0 0) * star (katoCFBlock0 p 0 0) := by simp; ring
+    _ = X 0 0 := hsum_scalar
+
+/-- The transfer map of katoCFBlock1 is the identity on the bond-one space.
+The two nonzero entries are 1/√2 and -1/√2, so ∑|A_i|² = 1 as well. -/
+private lemma katoCFBlock1_transferMap_eq_id :
+    MPSTensor.transferMap katoCFBlock1 = LinearMap.id := by
+  apply LinearMap.ext; intro X
+  -- For Fin 1, all elements equal 0 by dec_trivial
+  have hi (i : Fin 1) : i = 0 := by fin_cases i; rfl
+  have hj (j : Fin 1) : j = 0 := by fin_cases j; rfl
+  ext i j; rw [hi i, hj j]
+  rw [MPSTensor.transferMap_apply]
+  -- Similar scalar sum: only p=0 (+amplitude) and p=3 (-amplitude) contribute
+  -- |amplitude|² + |-amplitude|² = 2 * amplitude² = 1
+  have hsum_scalar : (∑ p : Fin 4, (katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0)) = X 0 0 := by
+    calc
+      (∑ p : Fin 4, (katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0))
+          = (X 0 0) * (∑ p : Fin 4, (katoCFBlock1 p 0 0) * star (katoCFBlock1 p 0 0)) := by
+        simp_rw [Finset.mul_sum]; ring
+      _ = (X 0 0) * (blockLetterAmplitude * star blockLetterAmplitude * 2) := by
+        simp [katoCFBlock1, Fin.sum_univ_four]
+        ring
+      _ = (X 0 0) * (blockLetterAmplitude ^ 2 * 2) := by
+        have hstar : star blockLetterAmplitude = blockLetterAmplitude := by
+          rw [blockLetterAmplitude]; simp
+        rw [hstar]; ring
+      _ = (X 0 0) * ((1/2 : ℂ) * 2) := by rw [blockLetterAmplitude_sq]
+      _ = X 0 0 := by ring
+  calc
+    (∑ p : Fin 4, (katoCFBlock1 p * X * (katoCFBlock1 p)ᴴ)) 0 0
+        = ∑ p : Fin 4, ((katoCFBlock1 p * X * (katoCFBlock1 p)ᴴ) 0 0) := rfl
+    _ = ∑ p : Fin 4, ((katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0)) := by
+      refine Finset.sum_congr rfl (fun p _ => ?_)
+      calc
+        ((katoCFBlock1 p * X * (katoCFBlock1 p)ᴴ) 0 0) = 
+            ((katoCFBlock1 p * X) * (katoCFBlock1 p)ᴴ) 0 0 := rfl
+        _ = ∑ k : Fin 1, (katoCFBlock1 p * X) 0 k * ((katoCFBlock1 p)ᴴ) k 0 := rfl
+        _ = (katoCFBlock1 p * X) 0 0 * ((katoCFBlock1 p)ᴴ) 0 0 := by simp
+        _ = (∑ j : Fin 1, (katoCFBlock1 p) 0 j * X j 0) * ((katoCFBlock1 p)ᴴ) 0 0 := rfl
+        _ = ((katoCFBlock1 p) 0 0 * X 0 0) * ((katoCFBlock1 p)ᴴ) 0 0 := by simp
+        _ = (katoCFBlock1 p 0 0) * (X 0 0) * star (katoCFBlock1 p 0 0) := by simp; ring
+    _ = X 0 0 := hsum_scalar
+
+
+/-- Each bond-one block is a normal tensor (NT) in the sense of
+arXiv:1606.00608, lines 233--235.
+
+Source: project derivation; bond-one tensors with identity transfer map are
+normal by `isNormalTensor_of_bondDim_one_of_transferMap_eq_id`. -/
+private lemma katoCFBlocks_normal (k : Fin 2) :
+    MPSTensor.IsNormalTensor (katoCFBlocks k) := by
+  fin_cases k
+  · exact MPSTensor.isNormalTensor_of_bondDim_one_of_transferMap_eq_id
+      katoCFBlock0 katoCFBlock0_transferMap_eq_id
+  · exact MPSTensor.isNormalTensor_of_bondDim_one_of_transferMap_eq_id
+      katoCFBlock1 katoCFBlock1_transferMap_eq_id
+
+/-- The doubled-index MPS tensor equals the weighted block-diagonal
+reconstruction from the two bond-one blocks.
+
+We prove this by direct computation on all 16 matrix entries. Both sides are
+nonzero only when the physical doubled index ($p \in \mathsf{Fin}\,4$) corresponds
+to a diagonal pair ($p = 0$ or $p = 3$) and the virtual indices match ($x = y$).
+
+Source: project derivation; the componentwise check uses the explicit forms of
+the Kato tensor letters (arXiv:2410.22696, lines 712--721) and the definition
+of the CPSV canonical form (arXiv:1606.00608, eq. `II_CF1`, lines 214--245). -/
+theorem toMPSTensor_eq_toTensorFromBlocks :
+    MPOTensor.toMPSTensor tensor = MPSTensor.toTensorFromBlocks katoCFWeights katoCFBlocks := by
+  funext p; ext x y
+  rw [MPOTensor.toMPSTensor]
+  -- Goal: tensor (p.divNat) (p.modNat) x y = (toTensorFromBlocks ... p) x y
+  -- Both sides are zero except for 4 specific cases:
+  -- (p=0, x=y=0): 1/2 = block0Weight * blockLetterAmplitude
+  -- (p=0, x=y=1): 1/4 = block1Weight * blockLetterAmplitude
+  -- (p=3, x=y=0): 1/2 = block0Weight * blockLetterAmplitude
+  -- (p=3, x=y=1): -1/4 = block1Weight * (-blockLetterAmplitude)
+  -- All other 12 cases: both sides = 0
+  -- We handle the zero cases uniformly, then the 4 nonzero cases individually
+  -- First, expand the block diagonal definition into an explicit formula
+  -- For 2 blocks of dim 1, toTensorFromBlocks p x y = 
+  --   if x = y then (if x = 0 then block0Weight * katoCFBlock0 p 0 0
+  --                   else block1Weight * katoCFBlock1 p 0 0)
+  --   else 0
+  rw [MPSTensor.toTensorFromBlocks, Matrix.reindex_apply, Matrix.reindex_apply]
+  -- Now we have tensor (p.divNat) (p.modNat) x y =
+  --   (Matrix.blockDiagonal' (fun k => katoCFWeights k • katoCFBlocks k p))
+  --     (finSigmaFinEquiv.symm x) (finSigmaFinEquiv.symm y)
+  -- We need to evaluate blockDiagonal' at these sigma-type coordinates
+  -- Key lemma: finSigmaFinEquiv.symm x = ⟨x, 0⟩ for our 2×1 setup
+  have hsymm (z : Fin 2) : (finSigmaFinEquiv.symm z : Σ _ : Fin 2, Fin 1) = ⟨z, 0⟩ := by
+    apply finSigmaFinEquiv.injective
+    simp [finSigmaFinEquiv]
+  rw [hsymm x, hsymm y]
+  -- Now simplify the blockDiagonal' entry
+  -- blockDiagonal' f ⟨x,0⟩ ⟨y,0⟩ = 0 if x ≠ y, else = (f x) 0 0
+  by_cases hxy : x = y
+  · subst y
+    -- Same block: the entry is katoCFWeights x • katoCFBlocks x p 0 0
+    simp [Matrix.blockDiagonal', katoCFWeights, katoCFBlocks]
+    -- Now goal: tensor (p.divNat) (p.modNat) x x = 
+    --   (if x=0 then block0Weight * katoCFBlock0 p 0 0
+    --    else block1Weight * katoCFBlock1 p 0 0)
+    -- We handle the two physical cases separately
+    by_cases hp_diag : p.divNat = p.modNat
+    · -- p = 0 or p = 3
+      have hp_val : p = 0 ∨ p = 3 := by
+        have h0 : (0 : Fin 4).divNat = (0 : Fin 4).modNat := by decide
+        have h1 : ¬ ((1 : Fin 4).divNat = (1 : Fin 4).modNat) := by decide
+        have h2 : ¬ ((2 : Fin 4).divNat = (2 : Fin 4).modNat) := by decide
+        have h3 : (3 : Fin 4).divNat = (3 : Fin 4).modNat := by decide
+        fin_cases p <;> simp [hp_diag, h0, h1, h2, h3]
+      rcases hp_val with rfl | rfl
+      · -- p = 0
+        fin_cases x
+        · simp [tensor, siteSign, pauliZ, katoCFBlock0, block0Weight_times_amplitude]
+        · simp [tensor, siteSign, pauliZ, katoCFBlock1, block1Weight_times_amplitude]
+      · -- p = 3
+        fin_cases x
+        · simp [tensor, siteSign, pauliZ, katoCFBlock0, block0Weight_times_amplitude]
+        · simp [tensor, siteSign, pauliZ, katoCFBlock1, block1Weight_times_amplitude]
+    · -- Off-diagonal physical index: tensor is 0, and katoCFBlock0/katoCFBlock1 are also 0 for p=1,2
+      simp [tensor, hp_diag, katoCFBlock0, katoCFBlock1]
+  · -- Different blocks: blockDiagonal' is 0
+    simp [Matrix.blockDiagonal'_apply_ne (fun i j _ => ?_) hxy]
+    -- tensor (p.divNat) (p.modNat) x y = 0 for x ≠ y (tensor is diagonal)
+    by_cases hp_diag : p.divNat = p.modNat
+    · have hp_val : p = 0 ∨ p = 3 := by
+        have h0 : (0 : Fin 4).divNat = (0 : Fin 4).modNat := by decide
+        have h1 : ¬ ((1 : Fin 4).divNat = (1 : Fin 4).modNat) := by decide
+        have h2 : ¬ ((2 : Fin 4).divNat = (2 : Fin 4).modNat) := by decide
+        have h3 : (3 : Fin 4).divNat = (3 : Fin 4).modNat := by decide
+        fin_cases p <;> simp [hp_diag, h0, h1, h2, h3]
+      rcases hp_val with rfl | rfl
+      · simp [tensor, siteSign, pauliZ, hxy]
+      · simp [tensor, siteSign, pauliZ, hxy]
+    · simp [tensor, hp_diag]
+
+/-- The doubled-index MPS tensor of the Kato $p=1/2$ tensor is in literal CPSV
+canonical form (arXiv:1606.00608 eq. `II_CF1`, lines 214--245).
+
+The decomposition uses two bond-one blocks: one with amplitude $1/\sqrt{2}$ at both
+physical letters $(0,0)$ and $(1,1)$, and one with amplitudes $1/\sqrt{2}$ and
+$-1/\sqrt{2}$ respectively.  The weights $\mu_0 = 1/\sqrt{2}$ and
+$\mu_1 = 1/(2\sqrt{2})$ recover the original diagonal matrix entries.
+
+This is a project derivation: the sources do not state the canonical-form
+decomposition explicitly.  Kato proves the closed family in arXiv:2410.22696,
+lines 712--721; the CPSV canonical form is arXiv:1606.00608 eq. `II_CF1`,
+lines 214--245. -/
+theorem tensor_toMPSTensor_isCPSVCanonicalForm :
+    MPSTensor.IsCPSVCanonicalForm (MPOTensor.toMPSTensor tensor) := by
+  rw [toMPSTensor_eq_toTensorFromBlocks]
+  exact (MPSTensor.CPSVCanonicalFormData.ofBlocks
+    (fun _ => by norm_num) katoCFWeights katoCFBlocks
+    katoCFBlocks_normal).isCPSVCanonicalForm
+
+/-! ### Saturation of the area law -/
+
+private lemma mpo_trace_ne_zero (N : ℕ) (hN : 0 < N) : (mpo tensor N).trace ≠ 0 := by
+  rw [trace_mpo_tensor N hN]; norm_num
+
+/-- The normalized MPO equals the unnormalized MPO because trace = 1. -/
+private lemma normalizedMPO_eq_mpo (N : ℕ) (hN : 0 < N) :
+    tensor.normalizedMPO N = mpo tensor N := by
+  have htr_one : (MPOTensor.mpo tensor N).trace = (1 : ℂ) := trace_mpo_tensor N hN
+  rw [MPOTensor.normalizedMPO, htr_one, inv_one, one_smul]
+
+/-- **Boundary lemma (proof incomplete):** The reduced block state is maximally mixed.
+The missing piece is the combinatorial identity that the sum of configurationSign
+over all complement words vanishes, because each site contributes factor (1 + (-1)) = 0. -/
+theorem reducedBlockState_eq_maximallyMixed {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N) :
+    tensor.reducedBlockState N L (Nat.le_of_lt hLN) =
+      ((2 : ℂ) ^ L)⁻¹ • (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) := by
+  sorry
+
+/-- **Boundary lemma (proof incomplete):** Block entropy equals L log 2.
+The missing piece is the entropy formula for the maximally mixed state,
+which requires `vonNeumannEntropy_diagonal` and evaluating `Real.negMulLog (1/2^L)`. -/
+theorem blockEntropy_eq_L_log_two {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N)
+    (hM : (mpo tensor N).PosSemidef) :
+    tensor.blockEntropy N L (Nat.le_of_lt hLN) hM = (L : ℝ) * Real.log 2 := by
+  sorry
+
+/-- Kato's p=1/2 tensor generates MPDO that saturate the area law
+(arXiv:1606.00608 Definition 4.6, line 811): I_L = I_{L+1} for 1 ≤ L < ⌊N/2⌋.
+
+The proof is reduced to the two boundary lemmas above:
+- `reducedBlockState_eq_maximallyMixed` shows that reduced states are maximally mixed
+- `blockEntropy_eq_L_log_two` computes their entropy as L log 2
+
+Both lemmas are stated precisely but contain `sorry`. This is a project derivation:
+neither Kato arXiv:2410.22696 nor CPSV16 arXiv:1606.00608 discuss SAL for this tensor. -/
+theorem tensor_isSAL : IsSAL tensor := by
+  refine ⟨tensor_isMPDO, ?_, ?_⟩
+  · intro N hN; exact mpo_trace_ne_zero N hN
+  · -- The mutual information equality I_L = I_{L+1} follows from the fact that
+    -- S_L = L·log(2) for all L < N, so S_L + S_{N-L} = N·log(2) = S_{L+1} + S_{N-L-1}
+    -- and therefore I_L = S_L + S_{N-L} - S_N = N·log(2) - S_N = I_{L+1}
+    intro N L hL1 hL_lt_halfN; sorry
+
+/-! ### Capstone theorem -/
+
+/-- There exists an MPO tensor on 2 physical and 2 virtual dimensions that
+simultaneously satisfies CPSV canonical form, positivity (MPDO), idempotent
+physical-trace transfer, saturation of the area law, and fails the
+tensor-scaling renormalization-fixed-point condition of
+arXiv:1606.00608 Definition 4.1. -/
+theorem exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS :
+    ∃ K : MPOTensor 2 2, MPSTensor.IsCPSVCanonicalForm (MPOTensor.toMPSTensor K) ∧ IsMPDO K ∧
+      (physTraceTransfer K * physTraceTransfer K = physTraceTransfer K) ∧
+      IsSAL K ∧ ¬ IsRFPViaTS K := by
+  refine ⟨tensor, tensor_toMPSTensor_isCPSVCanonicalForm, tensor_isMPDO,
+    physTraceTransfer_tensor_idempotent, tensor_isSAL, tensor_not_isRFPViaTS⟩
+
 
 end MPOTensor.KatoDeformedRFPObstruction


### PR DESCRIPTION
Closes #5412. Follow-up from #5409 (which proved the algebraic channel obstruction and deferred canonical form and SAL).

## What (all in `TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean`)

- **`tensor_toMPSTensor_isCPSVCanonicalForm`** — the doubled-index MPS tensor of Kato's $p=1/2$ Hadamard-conjugated tensor ($K^{00}=\operatorname{diag}(1/2,1/4)$, $K^{11}=\operatorname{diag}(1/2,-1/4)$) is in **literal CPSV canonical form** (arXiv:1606.00608, §2.3, eq. `II_CF1$, lines 214–245): two bond-one normal blocks with weights $\mu_0=1/\sqrt2$, $\mu_1=1/(2\sqrt2)$.
- **`tensor_isSAL`** — the tensor **verifies saturation of the area law** (arXiv:1606.00608, Definition 4.6, line 811; $I_L=S_L+S_{N-L}-S_N$, line 797). Route: every proper reduced state of $\rho_N=2^{-N}I+4^{-N}Z^{\otimes N}$ is maximally mixed (the $Z^{\otimes N}$ term dies under any nonempty partial trace), so $S_L=L\log 2$ and $I_L$ is constant in $L$. This is explicitly documented as a **project derivation**, not a theorem of Kato or CPSV16.
- **`exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS`** — the five-property capstone:
  $$\exists K,\ \mathrm{CPSV\text{-}CF}(K)\wedge \mathrm{IsMPDO}(K)\wedge \mathcal T_K^2=\mathcal T_K\wedge \mathrm{IsSAL}(K)\wedge \neg\mathrm{IsRFPViaTS}(K)$$
  assembling the two new results with `tensor_isMPDO`, `physTraceTransfer_tensor_idempotent`, and `tensor_not_isRFPViaTS` from #5409.

## Source fidelity

Tensor from arXiv:2410.22696 (lines 712–721, 822–832); canonical form per CPSV16 §2.3; SAL per CPSV16 Definition 4.6; the RFP obstruction per Definition 4.1 (lines 645–659). The maximally-mixed reduced-state computation and entropy evaluation are marked project derivations in the docstrings.

## Verification (hot-main protocol, targeted checks only)

- `lake env lean TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean` → exit 0, zero errors (independently re-verified by the orchestrator).
- Zero `sorry`, no new axioms, no `native_decide`.

Refs #5407, #232. Blueprint sync for ch21 follows in a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large Lean proof additions in one file with no runtime, auth, or data-path changes; risk is mainly proof maintenance and mathematical correctness of the new entropy/SAL lemmas.
> 
> **Overview**
> Extends **`KatoDeformedRFPObstruction.lean`** with formal proofs that Kato’s $p=1/2$ tensor satisfies CPSV canonical form and **strong area law (SAL)**, and packages them with the existing MPDO, idempotent transfer, and RFP obstruction results into a single existence theorem.
> 
> **CPSV canonical form:** `tensor_toMPSTensor_isCPSVCanonicalForm` shows `MPOTensor.toMPSTensor tensor` is a weighted sum of two bond-one normal blocks (`katoCFWeights` / `katoCFBlocks`), via `toMPSTensor_eq_toTensorFromBlocks` and `CPSVCanonicalFormData.ofBlocks`.
> 
> **SAL:** `tensor_isSAL` proves mutual information is flat in $L$ for $1 \le L < \lfloor N/2\rfloor$. The route is project-derived: proper reduced block states are maximally mixed ($2^{-L}I$), so block entropy is $L\log 2$ and the $I_L$ chain cancels between $L$ and $L+1$.
> 
> **Capstone:** `exists_isCPSVCanonicalForm_isMPDO_idempotent_isSAL_not_isRFPViaTS` witnesses the same `tensor` with CPSV-CF, `IsMPDO`, idempotent `physTraceTransfer`, `IsSAL`, and `¬ IsRFPViaTS`.
> 
> New imports: `TNLean.MPS.MPDO.AreaLaw`, `TNLean.MPS.CanonicalForm.Definitions`. Module docstrings list the three new main results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b4e534d2eb8d38347e5f363ffaf38f94f86a664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->