### PR TITLE
feat(Channel): rectangular Choi–Jamiolkowski and Kraus representation (Wolf Ch2)

### DIFF
--- a/TNLean/Algebra/MatrixSpectralDecomp.lean
+++ b/TNLean/Algebra/MatrixSpectralDecomp.lean
@@ -27,7 +27,7 @@ open Matrix Finset BigOperators
 
 namespace Matrix
 
-/-- Conjugating the scaled matrix unit `(c · c̄) · E_{i,j}` by `K` and `Kᴴ`
+/-- Conjugating the scaled matrix unit `(c · star c) · E_{i,j}` by `K` and `Kᴴ`
 yields the rank-one outer product of the scaled columns of `K`:
 `K * ((c * star c) · E_{i,j}) * Kᴴ = (c · K_col(i)) (c · K_col(j))†`, where
 the second factor is the conjugate-scaled column. The operator `K` may be

--- a/TNLean/Algebra/MatrixSpectralDecomp.lean
+++ b/TNLean/Algebra/MatrixSpectralDecomp.lean
@@ -28,13 +28,14 @@ open Matrix Finset BigOperators
 namespace Matrix
 
 /-- `K * (c * c' · E_{i,j}) * K† = c · K_col(i) ⊗ c' · K_col(j)†` as an outer
-product. -/
+product. The operator `K` may be rectangular: the conjugated matrix unit acts
+on the column index type of `K`. -/
 theorem mul_single_mul_conjTranspose_eq_vecMulVec
-    {n : Type*} [Fintype n] [DecidableEq n]
-    (K : Matrix n n ℂ) (c : ℂ) (i₂ j₂ : n) :
+    {m n : Type*} [Fintype n] [DecidableEq n]
+    (K : Matrix m n ℂ) (c : ℂ) (i₂ j₂ : n) :
     K * Matrix.single i₂ j₂ (c * star c) * Kᴴ =
-      Matrix.vecMulVec (fun i₁ : n => c * K i₁ i₂)
-        (fun j₁ : n => star (c * K j₁ j₂)) := by
+      Matrix.vecMulVec (fun i₁ : m => c * K i₁ i₂)
+        (fun j₁ : m => star (c * K j₁ j₂)) := by
   rw [show Matrix.single i₂ j₂ (c * star c) =
       (c * star c) • Matrix.vecMulVec (Pi.single i₂ (1 : ℂ)) (Pi.single j₂ 1) by
     rw [← Matrix.single_eq_single_vecMulVec_single i₂ j₂]

--- a/TNLean/Algebra/MatrixSpectralDecomp.lean
+++ b/TNLean/Algebra/MatrixSpectralDecomp.lean
@@ -27,9 +27,12 @@ open Matrix Finset BigOperators
 
 namespace Matrix
 
-/-- `K * (c * c' · E_{i,j}) * K† = c · K_col(i) ⊗ c' · K_col(j)†` as an outer
-product. The operator `K` may be rectangular: the conjugated matrix unit acts
-on the column index type of `K`. -/
+/-- Conjugating the scaled matrix unit `(c · c̄) · E_{i,j}` by `K` and `Kᴴ`
+yields the rank-one outer product of the scaled columns of `K`:
+`K * ((c * star c) · E_{i,j}) * Kᴴ = (c · K_col(i)) (c · K_col(j))†`, where
+the second factor is the conjugate-scaled column. The operator `K` may be
+rectangular: the conjugated matrix unit acts on the column index type of
+`K`. -/
 theorem mul_single_mul_conjTranspose_eq_vecMulVec
     {m n : Type*} [Fintype n] [DecidableEq n]
     (K : Matrix m n ℂ) (c : ℂ) (i₂ j₂ : n) :

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.Channel.Basic
 import TNLean.Channel.BreuerHallMap
 import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.ChoiRectangular
 import TNLean.Channel.ChoiTypeMap
 import TNLean.Channel.CompletelyPositiveBridge
 import TNLean.Channel.DensityRetract
@@ -29,6 +30,7 @@ import TNLean.Channel.KoashiImoto
 import TNLean.Channel.KrausCPTP
 import TNLean.Channel.KrausFreedom
 import TNLean.Channel.KrausRank
+import TNLean.Channel.KrausRectangular
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.LocalizedKrausCPTP

--- a/TNLean/Channel/ChoiJamiolkowski.lean
+++ b/TNLean/Channel/ChoiJamiolkowski.lean
@@ -159,8 +159,9 @@ theorem omegaSlice_eq_single (i₂ j₂ : Fin D) :
   · subst hb; simp [ha, show ¬(i₂ = a) from Ne.symm ha]
   · simp [ha, hb, show ¬(i₂ = a) from Ne.symm ha, show ¬(j₂ = b) from Ne.symm hb]
 
-/-- The omega coefficient `(1/√D)·(1/√D) = 1/D`. -/
-private theorem omegaCoeff_eq_inv (hd : 0 < D) :
+/-- The omega coefficient `(1/√D)·(1/√D) = 1/D`: the squared modulus of the
+maximally-entangled normalization constant. -/
+theorem omegaCoeff_eq_inv (hd : 0 < D) :
     (((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) *
       star ((1 : ℂ) / ((D : ℝ).sqrt : ℂ))) =
       1 / (D : ℂ) := by

--- a/TNLean/Channel/ChoiRectangular.lean
+++ b/TNLean/Channel/ChoiRectangular.lean
@@ -156,21 +156,6 @@ noncomputable def mapOfChoiMatrix
 
 /-! ### The omega slice -/
 
-/-- The squared modulus of the maximally-entangled normalization constant:
-`(1/√d)·conj(1/√d) = 1/d`. -/
-theorem omegaCoeff_eq_inv (hd : 0 < d) :
-    (((1 : ℂ) / ((d : ℝ).sqrt : ℂ)) *
-      star ((1 : ℂ) / ((d : ℝ).sqrt : ℂ))) = 1 / (d : ℂ) := by
-  have hdr : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr hd
-  rw [show star ((1 : ℂ) / ((d : ℝ).sqrt : ℂ)) =
-      1 / ((d : ℝ).sqrt : ℂ) from by simp [Complex.conj_ofReal]]
-  rw [show (1 : ℂ) / ((d : ℝ).sqrt : ℂ) *
-      (1 / ((d : ℝ).sqrt : ℂ)) =
-      1 / (((d : ℝ).sqrt : ℂ) ^ 2) from by ring]
-  rw [show (((d : ℝ).sqrt : ℂ) ^ 2) = (((d : ℝ).sqrt ^ 2 : ℝ) : ℂ) from by push_cast; ring]
-  rw [Real.sq_sqrt hdr.le]
-  simp
-
 /-- The `(i₂, j₂)`-slice of `|Ω⟩⟨Ω|` is `(1/d) · E_{i₂,j₂}` for `d > 0`:
 the matrix unit scaled by `1/d`. This is the identity
 `d |Ω⟩⟨Ω| = F^{T_B}` of Wolf, Example 1.2, used in the proof of
@@ -178,8 +163,8 @@ Proposition 2.1. -/
 private theorem omegaSlice_eq_single (hd : 0 < d) (i₂ j₂ : Fin d) :
     Matrix.bipartiteSlice (Matrix.omegaProj d) i₂ j₂ =
       (1 / (d : ℂ)) • Matrix.single i₂ j₂ (1 : ℂ) := by
-  rw [ChoiJamiolkowski.omegaSlice_eq_single (D := d) i₂ j₂, omegaCoeff_eq_inv hd,
-    Matrix.smul_single, smul_eq_mul, mul_one]
+  rw [ChoiJamiolkowski.omegaSlice_eq_single (D := d) i₂ j₂,
+    ChoiJamiolkowski.omegaCoeff_eq_inv hd, Matrix.smul_single, smul_eq_mul, mul_one]
 
 /-! ### Mutual inverses -/
 
@@ -734,7 +719,7 @@ theorem doublyStochastic_iff_partialTraces_proportional
 
 end PartialTraceClauses
 
-/-! ### Bridge to the square development -/
+/-! ### Specialization to equal dimensions -/
 
 /-- The rectangular Choi matrix at `d = d' = D` is definitionally the square
 Choi matrix `ChoiJamiolkowski.choiMatrix`: the existing square development is

--- a/TNLean/Channel/ChoiRectangular.lean
+++ b/TNLean/Channel/ChoiRectangular.lean
@@ -1,0 +1,746 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixSpectralDecomp
+import TNLean.Algebra.TracePairing
+import TNLean.Channel.PartialTrace
+import TNLean.Channel.MaximallyEntangled
+import TNLean.Channel.TensorMap
+import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.Basic
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.InnerProductSpace.Positive
+
+/-!
+# Rectangular Choi–Jamiolkowski representation of maps
+
+This file defines the Choi matrix of a linear map `T : M_d(ℂ) → M_{d'}(ℂ)`
+between matrix algebras of possibly different dimensions and proves the full
+Choi–Jamiolkowski one-to-one correspondence with the characterization clauses
+of Wolf Chapter 2, Proposition 2.1 (Choi–Jamiolkowski representation of maps),
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 60–126.
+
+## Main definitions
+
+* `ChoiRectangular.choiMatrix T`: the Choi matrix
+  `τ = (T ⊗ id_d)(|Ω⟩⟨Ω|)` of `T : M_d(ℂ) → M_{d'}(ℂ)`, an operator on
+  `ℂ^{d'} ⊗ ℂ^d` (output factor first, input factor second, as in Wolf);
+  `|Ω⟩ = (1/√d) Σⱼ |j,j⟩` is the normalized maximally entangled vector on the
+  input factor.
+* `ChoiRectangular.mapOfChoiMatrix τ`: the inverse correspondence recovering
+  `T` from `τ` (Wolf Eq. (2.4)).
+
+## Main results (Wolf Proposition 2.1, Eq. (2.1))
+
+* `ChoiRectangular.mapOfChoiMatrix_choiMatrix` /
+  `ChoiRectangular.choiMatrix_mapOfChoiMatrix` — the two assignments are
+  mutual inverses
+* `ChoiRectangular.trace_pairing` — the trace-pairing formula
+  `tr[A T(B)] = d · tr[τ (A ⊗ Bᵀ)]`
+* `ChoiRectangular.choiMatrix_isHermitian_iff_hermiticityPreserving` —
+  Hermiticity clause: `τ = τ†` iff `T(B†) = T(B)†` for all `B`
+* `ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef` —
+  complete-positivity clause: `T` is completely positive iff `τ ≥ 0`
+* `ChoiRectangular.traceRight_choiMatrix` and
+  `ChoiRectangular.unital_iff_traceRight_choiMatrix` — unitality clause:
+  `T(𝟙) = 𝟙` iff `tr_B(τ) = 𝟙_{d'}/d`
+* `ChoiRectangular.traceLeft_choiMatrix` and
+  `ChoiRectangular.tracePreserving_iff_traceLeft_choiMatrix` —
+  trace-preservation clause: `tr_A(τ) = (T*(𝟙))ᵀ/d`, hence `T*(𝟙) = 𝟙` iff
+  `tr_A(τ) = 𝟙_d/d`
+* `ChoiRectangular.trace_choiMatrix` — normalization clause:
+  `tr(τ) = tr(T*(𝟙))/d`
+* `ChoiRectangular.doublyStochastic_iff_partialTraces_proportional` —
+  doubly-stochastic clause: `T(𝟙) ∝ 𝟙` and `T*(𝟙) ∝ 𝟙` iff `tr_A(τ) ∝ 𝟙`
+  and `tr_B(τ) ∝ 𝟙`
+
+## Design notes
+
+The TNLean predicate `IsKrausCP` (existence of a rectangular Kraus
+representation) is used as the complete-positivity notion, matching the
+Kraus-form characterization used in Wolf Theorem 2.1 (Kraus representation).
+The square development `ChoiJamiolkowski.choiMatrix` is the specialization
+`d = d'`; see `ChoiRectangular.choiMatrix_eq_choiJamiolkowski`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2,
+  Proposition 2.1][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix Finset BigOperators
+
+namespace ChoiRectangular
+
+variable {d d' : ℕ}
+
+/-! ### The rectangular Choi matrix and its inverse -/
+
+/-- The **Choi matrix** of a linear map `T : M_d(ℂ) → M_{d'}(ℂ)`:
+
+  `τ = (T ⊗ id_d)(|Ω⟩⟨Ω|)`
+
+where `|Ω⟩ = (1/√d) Σⱼ |j,j⟩` is the normalized maximally entangled vector on
+the input factor `ℂ^d ⊗ ℂ^d`. The result is an operator on `ℂ^{d'} ⊗ ℂ^d`,
+indexed by `Fin d' × Fin d` (output factor first, input factor second).
+
+Wolf, Chapter 2, Proposition 2.1, Equation (2.1);
+`Notes/WolfNoteTexSource/ch02_representations.tex`, line 66. -/
+noncomputable def choiMatrix
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ :=
+  Matrix.tensorMapId T (Matrix.omegaProj d)
+
+/-- Elementwise formula:
+`τ (i₁,i₂) (j₁,j₂) = (T (bipartiteSlice (|Ω⟩⟨Ω|) i₂ j₂)) i₁ j₁`. -/
+theorem choiMatrix_apply
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (i₁ j₁ : Fin d') (i₂ j₂ : Fin d) :
+    choiMatrix T (i₁, i₂) (j₁, j₂) =
+      (T (Matrix.bipartiteSlice (Matrix.omegaProj d) i₂ j₂)) i₁ j₁ := by
+  simp [choiMatrix, Matrix.tensorMapId_apply]
+
+/-- `choiMatrix` as a linear map in the superoperator argument. -/
+noncomputable def choiMatrixLinearMap :
+    (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) →ₗ[ℂ]
+      Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ where
+  toFun := choiMatrix
+  map_add' T S := by
+    ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+    simp [choiMatrix, Matrix.tensorMapId_apply]
+  map_smul' c T := by
+    ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+    simp [choiMatrix, Matrix.tensorMapId_apply]
+
+@[simp] theorem choiMatrix_add
+    (T S : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    choiMatrix (T + S) = choiMatrix T + choiMatrix S :=
+  (choiMatrixLinearMap (d := d) (d' := d')).map_add T S
+
+@[simp] theorem choiMatrix_smul
+    (c : ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    choiMatrix (c • T) = c • choiMatrix T :=
+  (choiMatrixLinearMap (d := d) (d' := d')).map_smul c T
+
+/-- The **inverse Choi assignment**: for an operator `τ` on `ℂ^{d'} ⊗ ℂ^d`,
+the linear map `T : M_d(ℂ) → M_{d'}(ℂ)` with entries
+
+  `T(B) i₁ j₁ = d · Σ_{i₂ j₂} τ (i₁,i₂) (j₁,j₂) · B i₂ j₂`.
+
+This is Wolf, Chapter 2, Equation (2.4), the `τ ↦ T` direction of
+Equation (2.1). -/
+noncomputable def mapOfChoiMatrix
+    (τ : Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ where
+  toFun B i₁ j₁ := (d : ℂ) * ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+    τ (i₁, i₂) (j₁, j₂) * B i₂ j₂
+  map_add' X Y := by
+    ext i₁ j₁
+    change (d : ℂ) * ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        τ (i₁, i₂) (j₁, j₂) * (X + Y) i₂ j₂ =
+      (d : ℂ) * ∑ i₂ : Fin d, ∑ j₂ : Fin d, τ (i₁, i₂) (j₁, j₂) * X i₂ j₂ +
+        (d : ℂ) * ∑ i₂ : Fin d, ∑ j₂ : Fin d, τ (i₁, i₂) (j₁, j₂) * Y i₂ j₂
+    simp only [Matrix.add_apply, mul_add, Finset.sum_add_distrib]
+  map_smul' c X := by
+    ext i₁ j₁
+    change (d : ℂ) * ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        τ (i₁, i₂) (j₁, j₂) * (c • X) i₂ j₂ =
+      c • ((d : ℂ) * ∑ i₂ : Fin d, ∑ j₂ : Fin d, τ (i₁, i₂) (j₁, j₂) * X i₂ j₂)
+    simp only [Matrix.smul_apply, smul_eq_mul, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun i₂ _ => Finset.sum_congr rfl fun j₂ _ => ?_
+    ring
+
+/-! ### The omega slice -/
+
+/-- The squared modulus of the maximally-entangled normalization constant:
+`(1/√d)·conj(1/√d) = 1/d`. -/
+theorem omegaCoeff_eq_inv (hd : 0 < d) :
+    (((1 : ℂ) / ((d : ℝ).sqrt : ℂ)) *
+      star ((1 : ℂ) / ((d : ℝ).sqrt : ℂ))) = 1 / (d : ℂ) := by
+  have hdr : (0 : ℝ) < (d : ℝ) := Nat.cast_pos.mpr hd
+  rw [show star ((1 : ℂ) / ((d : ℝ).sqrt : ℂ)) =
+      1 / ((d : ℝ).sqrt : ℂ) from by simp [Complex.conj_ofReal]]
+  rw [show (1 : ℂ) / ((d : ℝ).sqrt : ℂ) *
+      (1 / ((d : ℝ).sqrt : ℂ)) =
+      1 / (((d : ℝ).sqrt : ℂ) ^ 2) from by ring]
+  rw [show (((d : ℝ).sqrt : ℂ) ^ 2) = (((d : ℝ).sqrt ^ 2 : ℝ) : ℂ) from by push_cast; ring]
+  rw [Real.sq_sqrt hdr.le]
+  simp
+
+/-- The `(i₂, j₂)`-slice of `|Ω⟩⟨Ω|` is `(1/d) · E_{i₂,j₂}` for `d > 0`:
+the matrix unit scaled by `1/d`. This is the identity
+`d |Ω⟩⟨Ω| = F^{T_B}` of Wolf, Example 1.2, used in the proof of
+Proposition 2.1. -/
+private theorem omegaSlice_eq_single (hd : 0 < d) (i₂ j₂ : Fin d) :
+    Matrix.bipartiteSlice (Matrix.omegaProj d) i₂ j₂ =
+      (1 / (d : ℂ)) • Matrix.single i₂ j₂ (1 : ℂ) := by
+  rw [ChoiJamiolkowski.omegaSlice_eq_single (D := d) i₂ j₂, omegaCoeff_eq_inv hd,
+    Matrix.smul_single, smul_eq_mul, mul_one]
+
+/-! ### Mutual inverses -/
+
+section MutualInverse
+
+variable [NeZero d]
+
+/-- The forward-inverse composition `T ↦ τ ↦ T` is the identity: every linear
+map is recovered from its Choi matrix. This is the direction `T → τ → T` of
+Wolf, Proposition 2.1, proof (Equations (2.2)–(2.3)). -/
+theorem mapOfChoiMatrix_choiMatrix
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    mapOfChoiMatrix (choiMatrix T) = T := by
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  have hdne : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  ext B i₁ j₁
+  have hB : B = ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+      (B i₂ j₂) • Matrix.single i₂ j₂ (1 : ℂ) := by
+    conv_lhs => rw [matrix_eq_sum_single B]
+    refine Finset.sum_congr rfl fun i₂ _ => Finset.sum_congr rfl fun j₂ _ => ?_
+    rw [Matrix.smul_single, smul_eq_mul, mul_one]
+  have hsum2 : (∑ i₂ : Fin d, ∑ j₂ : Fin d,
+      (B i₂ j₂) • ((1 / (d : ℂ)) • Matrix.single i₂ j₂ (1 : ℂ))) =
+        (1 / (d : ℂ)) • B := by
+    conv_rhs => rw [hB]
+    rw [Finset.smul_sum]
+    refine Finset.sum_congr rfl fun i₂ _ => ?_
+    rw [Finset.smul_sum]
+    refine Finset.sum_congr rfl fun j₂ _ => ?_
+    rw [smul_comm]
+  have hstep : ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+      choiMatrix T (i₁, i₂) (j₁, j₂) * B i₂ j₂ =
+        T ((1 / (d : ℂ)) • B) i₁ j₁ := by
+    calc
+      ∑ i₂ : Fin d, ∑ j₂ : Fin d, choiMatrix T (i₁, i₂) (j₁, j₂) * B i₂ j₂
+          = ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+              (T ((B i₂ j₂) • ((1 / (d : ℂ)) • Matrix.single i₂ j₂ (1 : ℂ)))) i₁ j₁ := by
+            refine Finset.sum_congr rfl fun i₂ _ => Finset.sum_congr rfl fun j₂ _ => ?_
+            simp only [choiMatrix_apply, omegaSlice_eq_single hdpos, map_smul,
+              Matrix.smul_apply, smul_eq_mul]
+            ring
+      _ = (T (∑ i₂ : Fin d, ∑ j₂ : Fin d,
+          (B i₂ j₂) • ((1 / (d : ℂ)) • Matrix.single i₂ j₂ (1 : ℂ)))) i₁ j₁ := by
+            simp [map_sum, Matrix.sum_apply]
+      _ = T ((1 / (d : ℂ)) • B) i₁ j₁ := by
+            rw [hsum2]
+  change (d : ℂ) * ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+      choiMatrix T (i₁, i₂) (j₁, j₂) * B i₂ j₂ = T B i₁ j₁
+  rw [hstep, map_smul, Matrix.smul_apply, smul_eq_mul]
+  field_simp
+
+/-- The inverse-forward composition `τ ↦ T ↦ τ` is the identity: every operator
+on `ℂ^{d'} ⊗ ℂ^d` is the Choi matrix of the map it defines. This is the
+surjectivity of `T ↦ τ` in Wolf, Proposition 2.1, proof. -/
+theorem choiMatrix_mapOfChoiMatrix
+    (τ : Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ) :
+    choiMatrix (mapOfChoiMatrix τ) = τ := by
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  have hdne : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rw [choiMatrix_apply, omegaSlice_eq_single hdpos, map_smul, Matrix.smul_apply]
+  change (1 / (d : ℂ)) • ((d : ℂ) * ∑ a : Fin d, ∑ b : Fin d,
+      τ (i₁, a) (j₁, b) * (Matrix.single i₂ j₂ (1 : ℂ)) a b) = τ (i₁, i₂) (j₁, j₂)
+  have hsum : ∑ a : Fin d, ∑ b : Fin d,
+      τ (i₁, a) (j₁, b) * (Matrix.single i₂ j₂ (1 : ℂ)) a b =
+        τ (i₁, i₂) (j₁, j₂) := by
+    rw [Finset.sum_eq_single i₂]
+    · rw [Finset.sum_eq_single j₂]
+      · simp
+      · intro b _ hb
+        simp [hb.symm]
+      · simp
+    · intro a _ ha
+      rw [Finset.sum_eq_zero]
+      intro b _
+      simp [ha.symm]
+    · simp
+  rw [hsum, smul_eq_mul]
+  field_simp
+
+/-- The Choi assignment is injective: equal Choi matrices imply equal maps
+(Wolf, Proposition 2.1: the correspondence is one-to-one). -/
+theorem choiMatrix_injective :
+    Function.Injective (choiMatrix (d := d) (d' := d')) := by
+  intro T S hTS
+  have h := congrArg mapOfChoiMatrix hTS
+  simpa [mapOfChoiMatrix_choiMatrix] using h
+
+/-- Equality of Choi matrices implies equality of maps. -/
+theorem eq_of_choiMatrix_eq
+    {T S : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hTS : choiMatrix T = choiMatrix S) : T = S :=
+  choiMatrix_injective hTS
+
+end MutualInverse
+
+/-! ### The trace-pairing formula -/
+
+/-- **Trace-pairing formula** (Wolf, Proposition 2.1, Equation (2.1), second
+line): for all `A ∈ M_{d'}` and `B ∈ M_d`,
+
+  `tr[A T(B)] = d · tr[τ (A ⊗ Bᵀ)]`. -/
+theorem trace_pairing [NeZero d]
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (A : Matrix (Fin d') (Fin d') ℂ) (B : Matrix (Fin d) (Fin d) ℂ) :
+    (A * T B).trace = (d : ℂ) *
+      ((choiMatrix T) * kroneckerMap (· * ·) A B.transpose).trace := by
+  have hTB : ∀ i₁ j₁ : Fin d', (T B) j₁ i₁ = (d : ℂ) *
+      ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        choiMatrix T (j₁, i₂) (i₁, j₂) * B i₂ j₂ := by
+    intro i₁ j₁
+    have h := congrFun (congrArg DFunLike.coe
+      (mapOfChoiMatrix_choiMatrix (d := d) (d' := d') T)) B
+    change T B j₁ i₁ = (mapOfChoiMatrix (choiMatrix T) B) j₁ i₁
+    rw [h]
+  have hswap : (∑ i₁ : Fin d', ∑ j₁ : Fin d', ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+      A i₁ j₁ * (choiMatrix T (j₁, i₂) (i₁, j₂) * B i₂ j₂)) =
+    ∑ j₁ : Fin d', ∑ i₂ : Fin d, ∑ i₁ : Fin d', ∑ j₂ : Fin d,
+      A i₁ j₁ * (choiMatrix T (j₁, i₂) (i₁, j₂) * B i₂ j₂) := by
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun j₁ _ => ?_
+    rw [Finset.sum_comm]
+  calc
+    (A * T B).trace = ∑ i₁ : Fin d', ∑ j₁ : Fin d', A i₁ j₁ * (T B) j₁ i₁ := by
+      simp [Matrix.trace, Matrix.diag, Matrix.mul_apply]
+    _ = (d : ℂ) * ∑ i₁ : Fin d', ∑ j₁ : Fin d', ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+          A i₁ j₁ * (choiMatrix T (j₁, i₂) (i₁, j₂) * B i₂ j₂) := by
+          rw [Finset.mul_sum]
+          refine Finset.sum_congr rfl fun i₁ _ => ?_
+          rw [Finset.mul_sum]
+          refine Finset.sum_congr rfl fun j₁ _ => ?_
+          rw [hTB i₁ j₁]
+          simp only [Finset.mul_sum]
+          refine Finset.sum_congr rfl fun i₂ _ => Finset.sum_congr rfl fun j₂ _ => ?_
+          ring
+    _ = (d : ℂ) * ∑ j₁ : Fin d', ∑ i₂ : Fin d, ∑ i₁ : Fin d', ∑ j₂ : Fin d,
+          A i₁ j₁ * (choiMatrix T (j₁, i₂) (i₁, j₂) * B i₂ j₂) := by
+          rw [hswap]
+    _ = (d : ℂ) * ((choiMatrix T) *
+          kroneckerMap (· * ·) A B.transpose).trace := by
+          congr 1
+          simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply,
+            Fintype.sum_prod_type, Matrix.kroneckerMap_apply,
+            Matrix.transpose_apply]
+          refine Finset.sum_congr rfl fun j₁ _ => Finset.sum_congr rfl fun i₂ _ =>
+            Finset.sum_congr rfl fun i₁ _ => Finset.sum_congr rfl fun j₂ _ => ?_
+          ring
+
+/-! ### Complete positivity correspondence -/
+
+section CPCorrespondence
+
+/-- **Easy direction of the complete-positivity clause** (Wolf, Proposition
+2.1): the Choi matrix of a map in rectangular Kraus form
+`T(X) = Σⱼ Kⱼ X Kⱼ†` is a sum of rank-one outer products, hence positive
+semidefinite. -/
+theorem choiMatrix_of_kraus_posSemidef {r : ℕ}
+    (K : Fin r → Matrix (Fin d') (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (hT : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
+    (choiMatrix T).PosSemidef := by
+  classical
+  let c : ℂ := (1 : ℂ) / ((d : ℝ).sqrt : ℂ)
+  have hchoi : choiMatrix T = ∑ j : Fin r,
+      Matrix.vecMulVec (fun p : Fin d' × Fin d => c * K j p.1 p.2)
+        (star (fun p : Fin d' × Fin d => c * K j p.1 p.2)) := by
+    ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+    rw [choiMatrix_apply, hT, ChoiJamiolkowski.omegaSlice_eq_single (D := d) i₂ j₂,
+      Matrix.sum_apply i₁ j₁, Matrix.sum_apply (i₁, i₂) (j₁, j₂)]
+    change ∑ x : Fin r,
+        (K x * Matrix.single i₂ j₂ (c * star c) * (K x)ᴴ) i₁ j₁ =
+      ∑ x : Fin r,
+        Matrix.vecMulVec (fun p : Fin d' × Fin d => c * K x p.1 p.2)
+          (star (fun p : Fin d' × Fin d => c * K x p.1 p.2)) (i₁, i₂) (j₁, j₂)
+    refine Finset.sum_congr rfl ?_
+    intro x _
+    simpa [Matrix.vecMulVec_apply] using congrArg (fun M => M i₁ j₁)
+      (Matrix.mul_single_mul_conjTranspose_eq_vecMulVec (K := K x) (c := c) i₂ j₂)
+  rw [hchoi]
+  refine Matrix.posSemidef_sum (s := Finset.univ)
+    (x := fun i =>
+      Matrix.vecMulVec (fun p : Fin d' × Fin d => c * K i p.1 p.2)
+        (star (fun p : Fin d' × Fin d => c * K i p.1 p.2))) ?_
+  intro i _
+  simpa using Matrix.posSemidef_vecMulVec_self_star
+    (fun p : Fin d' × Fin d => c * K i p.1 p.2)
+
+/-- The Kraus family reconstructed from a Choi-matrix decomposition into
+rank-one outer products: writing `τ = Σₘ |ψₘ⟩⟨ψₘ|`, Wolf's Equation (1.13)
+`|ψ⟩ = (X ⊗ 𝟙)|Ω⟩` gives `Kₘ = reshape(ψₘ)/c` with `c = 1/√d` the
+maximally-entangled normalization constant. -/
+noncomputable def krausOfChoiDecomp {ι : Type*} [Fintype ι]
+    (v : ι → (Fin d' × Fin d) → ℂ) : ι → Matrix (Fin d') (Fin d) ℂ :=
+  fun m a b => v m (a, b) / ((1 : ℂ) / ((d : ℝ).sqrt : ℂ))
+
+/-- The reconstructed family `krausOfChoiDecomp` is a Kraus representation of
+the underlying map (Wolf, Proposition 2.1, proof: decompose `τ` into rank-one
+operators `|ψ⟩⟨ψ'|` and use `|ψ⟩ = (X ⊗ 𝟙)|Ω⟩` from Wolf, Equation (1.13)). -/
+theorem krausOfChoiDecomp_spec [NeZero d]
+    {ι : Type*} [Fintype ι]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (v : ι → (Fin d' × Fin d) → ℂ)
+    (hchoi : choiMatrix T = ∑ m : ι, Matrix.vecMulVec (v m) (star (v m))) :
+    ∀ X, T X = ∑ m : ι,
+      krausOfChoiDecomp (d := d) v m * X * (krausOfChoiDecomp (d := d) v m)ᴴ := by
+  classical
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  let c : ℂ := (1 : ℂ) / ((d : ℝ).sqrt : ℂ)
+  have hc : c ≠ 0 := by
+    dsimp [c]
+    have hsqrt : (((d : ℝ).sqrt : ℂ)) ≠ 0 :=
+      Complex.ofReal_ne_zero.mpr <| Real.sqrt_ne_zero'.2 (by exact_mod_cast hdpos)
+    simp [hsqrt]
+  have hstarc : star c = c := by simp [c]
+  have hαne : c * star c ≠ 0 := by
+    simpa [hstarc] using mul_ne_zero hc hc
+  let K : ι → Matrix (Fin d') (Fin d) ℂ := krausOfChoiDecomp (d := d) v
+  intro X
+  let S : Matrix (Fin d) (Fin d) ℂ → Matrix (Fin d') (Fin d') ℂ :=
+    fun Y => ∑ m : ι, K m * Y * (K m)ᴴ
+  let P : Matrix (Fin d) (Fin d) ℂ → Prop := fun Y => T Y = S Y
+  change P X
+  have hKeq : ∀ m a b, K m a b = v m (a, b) / c := fun m a b => rfl
+  refine Matrix.induction_on X ?_ ?_
+  · intro p q hp hq
+    dsimp [P, S] at *
+    simp [map_add, Matrix.add_mul, Matrix.mul_add, hp, hq, Finset.sum_add_distrib]
+  · intro i j z
+    dsimp [P, S]
+    have hbase : T (Matrix.single i j (1 : ℂ)) = S (Matrix.single i j (1 : ℂ)) := by
+      ext a b
+      have hentry : T (Matrix.single i j (c * star c)) a b =
+          (∑ m : ι, Matrix.vecMulVec (v m) (star (v m))) (a, i) (b, j) := by
+        have h := congrArg (fun M => M (a, i) (b, j)) hchoi
+        rwa [choiMatrix_apply, ChoiJamiolkowski.omegaSlice_eq_single (D := d) i j] at h
+      have hsmul : T (Matrix.single i j (c * star c)) a b =
+          (c * star c) * T (Matrix.single i j (1 : ℂ)) a b := by
+        simpa [Matrix.smul_single] using congrArg (fun M => M a b)
+          (T.map_smul (c * star c) (Matrix.single i j (1 : ℂ)))
+      have h1 : (c * star c) * T (Matrix.single i j (1 : ℂ)) a b =
+          ∑ m : ι, v m (a, i) * star (v m (b, j)) := by
+        exact hsmul.symm.trans <|
+          by simpa [Matrix.sum_apply, Matrix.vecMulVec_apply] using hentry
+      have h2 : (c * star c) * S (Matrix.single i j (1 : ℂ)) a b =
+          ∑ m : ι, v m (a, i) * star (v m (b, j)) := by
+        calc
+          (c * star c) * S (Matrix.single i j (1 : ℂ)) a b
+              = (c * star c) *
+                  ((∑ m : ι, K m * Matrix.single i j (1 : ℂ) * (K m)ᴴ) a b) := rfl
+          _ = (c * star c) *
+                ∑ m : ι, (K m * Matrix.single i j (1 : ℂ) * (K m)ᴴ) a b := by
+                rw [Matrix.sum_apply]
+          _ = ∑ m : ι,
+                (c * star c) * ((K m * Matrix.single i j (1 : ℂ) * (K m)ᴴ) a b) := by
+                rw [Finset.mul_sum]
+          _ = ∑ m : ι, v m (a, i) * star (v m (b, j)) := by
+                refine Finset.sum_congr rfl ?_
+                intro m _
+                have hterm : (K m * Matrix.single i j (1 : ℂ) * (K m)ᴴ) a b =
+                    (v m (a, i) / c) * star (v m (b, j) / c) := by
+                  have h := Matrix.mul_single_mul_conjTranspose_eq_vecMulVec
+                    (K := K m) (c := (1 : ℂ)) i j
+                  have h' := congrFun (congrFun h a) b
+                  simp only [Matrix.vecMulVec_apply] at h'
+                  simpa [hKeq] using h'
+                rw [hterm]
+                simp [div_eq_mul_inv, hstarc, hc, mul_assoc, mul_left_comm, mul_comm]
+      exact (mul_left_cancel₀ hαne) (h1.trans h2.symm)
+    have hSsmul (Y : Matrix (Fin d) (Fin d) ℂ) : S (z • Y) = z • S Y := by
+      dsimp [S]
+      simp [Finset.smul_sum]
+    calc
+      T (Matrix.single i j z) = z • T (Matrix.single i j (1 : ℂ)) := by
+        simpa [Matrix.smul_single] using T.map_smul z (Matrix.single i j (1 : ℂ))
+      _ = z • S (Matrix.single i j (1 : ℂ)) := by rw [hbase]
+      _ = S (z • Matrix.single i j (1 : ℂ)) := by rw [hSsmul]
+      _ = S (Matrix.single i j z) := by simp [Matrix.smul_single]
+
+variable [NeZero d]
+
+/-- A Choi-matrix decomposition into rank-one outer products yields a
+rectangular Kraus family indexed by the same finite type (existential form of
+`krausOfChoiDecomp_spec`). -/
+theorem exists_kraus_of_choiMatrix_eq_sum_vecMulVec
+    {ι : Type*} [Fintype ι]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (v : ι → (Fin d' × Fin d) → ℂ)
+    (hchoi : choiMatrix T = ∑ m : ι, Matrix.vecMulVec (v m) (star (v m))) :
+    ∃ K : ι → Matrix (Fin d') (Fin d) ℂ, ∀ X, T X = ∑ m : ι, K m * X * (K m)ᴴ :=
+  ⟨krausOfChoiDecomp (d := d) v, krausOfChoiDecomp_spec (T := T) v hchoi⟩
+
+/-- **Complete-positivity clause** (Wolf, Proposition 2.1): a linear map
+`T : M_d(ℂ) → M_{d'}(ℂ)` is completely positive — here in the rectangular
+Kraus form `IsKrausCP`, matching Wolf, Theorem 2.1 — if and only if its Choi
+matrix is positive semidefinite. -/
+theorem isKrausCP_iff_choiMatrix_posSemidef
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    IsKrausCP T ↔ (choiMatrix T).PosSemidef := by
+  constructor
+  · rintro ⟨r, K, hK⟩
+    exact choiMatrix_of_kraus_posSemidef K T hK
+  · intro hτ
+    classical
+    obtain ⟨r, v, hchoi⟩ := (Matrix.posSemidef_iff_eq_sum_vecMulVec).mp hτ
+    obtain ⟨K, hK⟩ :=
+      exists_kraus_of_choiMatrix_eq_sum_vecMulVec (T := T) (ι := Fin r) v hchoi
+    exact ⟨r, K, hK⟩
+
+/-- Surjectivity of the Choi assignment on positive semidefinite operators:
+every PSD `τ` on `ℂ^{d'} ⊗ ℂ^d` is the Choi matrix of a completely positive
+map (Wolf, Proposition 2.1, proof: surjectivity of `T ↦ τ`). -/
+theorem exists_isKrausCP_of_posSemidef
+    {τ : Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ}
+    (hτ : τ.PosSemidef) :
+    ∃ T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ,
+      IsKrausCP T ∧ choiMatrix T = τ := by
+  refine ⟨mapOfChoiMatrix τ, ?_, choiMatrix_mapOfChoiMatrix τ⟩
+  rw [isKrausCP_iff_choiMatrix_posSemidef, choiMatrix_mapOfChoiMatrix]
+  exact hτ
+
+end CPCorrespondence
+
+/-! ### Hermiticity correspondence -/
+
+/-- **Hermiticity clause** (Wolf, Proposition 2.1): the Choi matrix is
+Hermitian if and only if `T(B†) = T(B)†` for all `B ∈ M_d`. -/
+theorem choiMatrix_isHermitian_iff_hermiticityPreserving [NeZero d]
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    (choiMatrix T).IsHermitian ↔
+      (∀ B : Matrix (Fin d) (Fin d) ℂ, T (Bᴴ) = (T B)ᴴ) := by
+  classical
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  have hdne : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  have h1dne : (1 / (d : ℂ)) ≠ 0 := one_div_ne_zero hdne
+  have h1d : star (1 / (d : ℂ)) = 1 / (d : ℂ) := by
+    rw [show (1 / (d : ℂ)) = (((1 / d : ℝ)) : ℂ) by push_cast; ring]
+    simp
+  have hstar1d (y : ℂ) : star ((1 / (d : ℂ)) * y) = (1 / (d : ℂ)) * star y := by
+    rw [star_mul, h1d, mul_comm]
+  constructor
+  · intro hτ
+    have hsingle : ∀ i j : Fin d,
+        T (Matrix.single j i (1 : ℂ)) = (T (Matrix.single i j (1 : ℂ)))ᴴ := by
+      intro i j
+      ext a b
+      have hentry : (1 / (d : ℂ)) * T (Matrix.single j i (1 : ℂ)) a b =
+          star ((1 / (d : ℂ)) * T (Matrix.single i j (1 : ℂ)) b a) := by
+        have h := congrArg (fun M => M (a, j) (b, i)) hτ.eq
+        simp only [Matrix.conjTranspose_apply, choiMatrix_apply,
+          omegaSlice_eq_single hdpos j i, omegaSlice_eq_single hdpos i j,
+          map_smul, Matrix.smul_apply, smul_eq_mul] at h
+        exact h.symm
+      rw [hstar1d] at hentry
+      have h := mul_left_cancel₀ h1dne hentry
+      rwa [Matrix.conjTranspose_apply]
+    intro B
+    let P : Matrix (Fin d) (Fin d) ℂ → Prop := fun M => T (Mᴴ) = (T M)ᴴ
+    change P B
+    refine Matrix.induction_on B ?_ ?_
+    · intro p q hp hq; dsimp [P] at *; simp [map_add, hp, hq]
+    · intro i j z
+      dsimp [P]
+      calc
+        T ((Matrix.single i j z)ᴴ) = T (Matrix.single j i (star z)) := by
+          rw [Matrix.conjTranspose_single]
+        _ = (star z) • T (Matrix.single j i (1 : ℂ)) := by
+              simpa [Matrix.smul_single] using T.map_smul (star z) (Matrix.single j i (1 : ℂ))
+        _ = (star z) • (T (Matrix.single i j (1 : ℂ)))ᴴ := by rw [hsingle]
+        _ = (z • T (Matrix.single i j (1 : ℂ)))ᴴ := by simp [Matrix.conjTranspose_smul]
+        _ = (T (Matrix.single i j z))ᴴ := by
+              simpa [Matrix.smul_single] using
+                congrArg Matrix.conjTranspose (T.map_smul z (Matrix.single i j (1 : ℂ))).symm
+  · intro hT
+    ext ⟨a, i⟩ ⟨b, j⟩
+    have hsingle : T (Matrix.single j i (1 : ℂ)) =
+        (T (Matrix.single i j (1 : ℂ)))ᴴ := by
+      have h := hT (Matrix.single i j (1 : ℂ))
+      rwa [Matrix.conjTranspose_single, star_one] at h
+    have hentry : star ((1 / (d : ℂ)) * T (Matrix.single j i (1 : ℂ)) b a) =
+        (1 / (d : ℂ)) * T (Matrix.single i j (1 : ℂ)) a b := by
+      rw [hstar1d, hsingle, Matrix.conjTranspose_apply, star_star]
+    simp only [Matrix.conjTranspose_apply, choiMatrix_apply,
+      omegaSlice_eq_single hdpos i j, omegaSlice_eq_single hdpos j i,
+      map_smul, Matrix.smul_apply, smul_eq_mul]
+    exact hentry
+
+/-! ### Partial traces of the Choi matrix -/
+
+section PartialTraceClauses
+
+/-- The diagonal slices of `|Ω⟩⟨Ω|` sum to `(1/d) · 𝟙`. -/
+private theorem sum_omegaSlice_diag (hd : 0 < d) :
+    ∑ k : Fin d, Matrix.bipartiteSlice (Matrix.omegaProj d) k k =
+      (1 / (d : ℂ)) • (1 : Matrix (Fin d) (Fin d) ℂ) := by
+  have h1 : ∑ k : Fin d, Matrix.single k k (1 : ℂ) =
+      (1 : Matrix (Fin d) (Fin d) ℂ) := by
+    rw [Matrix.sum_single_eq_diagonal]
+    exact Matrix.diagonal_one
+  rw [← h1, Finset.smul_sum]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  rw [omegaSlice_eq_single hd]
+
+/-- The trace-pairing adjoint of `T` fixes the identity if and only if `T`
+preserves the trace. -/
+theorem traceAdjointMap_one_eq_one_iff_tracePreserving
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    Matrix.traceAdjointMap T 1 = 1 ↔
+      ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace := by
+  constructor
+  · intro h X
+    have h1 : (T X).trace = ((Matrix.traceAdjointMap T 1) * X).trace := by
+      rw [Matrix.trace_traceAdjointMap_mul, Matrix.one_mul]
+    rw [h1, h, Matrix.one_mul]
+  · intro h
+    apply (Matrix.ext_iff_trace_mul_right).2
+    intro N
+    rw [Matrix.trace_traceAdjointMap_mul, Matrix.one_mul, h N, Matrix.one_mul]
+
+/-- Cancellation of a nonzero scalar on a matrix equation. -/
+private theorem smul_cancel {ι : Type*}
+    {M N : Matrix ι ι ℂ} {c : ℂ} (hc : c ≠ 0) (h : c • M = c • N) : M = N := by
+  calc M = (1 : ℂ) • M := (one_smul _ _).symm
+    _ = (c⁻¹ * c) • M := by rw [inv_mul_cancel₀ hc]
+    _ = c⁻¹ • (c • M) := (smul_smul _ _ _).symm
+    _ = c⁻¹ • (c • N) := by rw [h]
+    _ = (c⁻¹ * c) • N := smul_smul _ _ _
+    _ = N := by rw [inv_mul_cancel₀ hc]; exact one_smul _ _
+
+variable [NeZero d]
+
+/-- **Right partial trace of the Choi matrix** (Wolf, Proposition 2.1,
+unitality clause): tracing the input factor gives
+
+  `tr_B(τ) = T(𝟙)/d`. -/
+theorem traceRight_choiMatrix
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    Matrix.traceRight (choiMatrix T) = (1 / (d : ℂ)) • T 1 := by
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  ext i j
+  calc
+    Matrix.traceRight (choiMatrix T) i j
+        = ∑ k : Fin d, choiMatrix T (i, k) (j, k) := Matrix.traceRight_apply _ _ _
+    _ = ∑ k : Fin d, (T (Matrix.bipartiteSlice (Matrix.omegaProj d) k k)) i j := by
+          refine Finset.sum_congr rfl fun k _ => ?_
+          rw [choiMatrix_apply]
+    _ = (T (∑ k : Fin d, Matrix.bipartiteSlice (Matrix.omegaProj d) k k)) i j := by
+          rw [map_sum, Matrix.sum_apply]
+    _ = (T ((1 / (d : ℂ)) • (1 : Matrix (Fin d) (Fin d) ℂ))) i j := by
+          rw [sum_omegaSlice_diag hdpos]
+    _ = ((1 / (d : ℂ)) • T 1) i j := by
+          rw [map_smul]
+
+/-- **Unitality clause** (Wolf, Proposition 2.1): `T(𝟙) = 𝟙` if and only if
+`tr_B(τ) = 𝟙_{d'}/d`. -/
+theorem unital_iff_traceRight_choiMatrix
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    T 1 = 1 ↔ Matrix.traceRight (choiMatrix T) =
+      (1 / (d : ℂ)) • (1 : Matrix (Fin d') (Fin d') ℂ) := by
+  have hdne : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  rw [traceRight_choiMatrix]
+  constructor
+  · intro h; rw [h]
+  · intro h
+    exact smul_cancel (one_div_ne_zero hdne) h
+
+/-- **Left partial trace of the Choi matrix** (Wolf, Proposition 2.1,
+trace-preservation clause): tracing the output factor gives
+
+  `tr_A(τ) = (T*(𝟙))ᵀ/d`
+
+where `T*` is the trace-pairing adjoint. -/
+theorem traceLeft_choiMatrix
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    Matrix.traceLeft (choiMatrix T) =
+      (1 / (d : ℂ)) • (Matrix.traceAdjointMap T 1).transpose := by
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  ext i j
+  calc
+    Matrix.traceLeft (choiMatrix T) i j
+        = ∑ k : Fin d', choiMatrix T (k, i) (k, j) := Matrix.traceLeft_apply _ _ _
+    _ = (T (Matrix.bipartiteSlice (Matrix.omegaProj d) i j)).trace := by
+          simp only [choiMatrix_apply]
+          simp [Matrix.trace, Matrix.diag]
+    _ = (1 / (d : ℂ)) * (T (Matrix.single i j (1 : ℂ))).trace := by
+          rw [omegaSlice_eq_single hdpos, map_smul, Matrix.trace_smul, smul_eq_mul]
+    _ = (1 / (d : ℂ)) * (Matrix.traceAdjointMap T 1) j i := by
+          have h : (Matrix.traceAdjointMap T 1) j i =
+              (T (Matrix.single i j (1 : ℂ))).trace := by
+            have h2 := Matrix.trace_traceAdjointMap_mul T 1 (Matrix.single i j (1 : ℂ))
+            rwa [Matrix.trace_mul_single, Matrix.one_mul, MulOpposite.op_one,
+              one_smul] at h2
+          rw [h]
+    _ = ((1 / (d : ℂ)) • (Matrix.traceAdjointMap T 1).transpose) i j := by
+          simp [Matrix.smul_apply, Matrix.transpose_apply, smul_eq_mul]
+
+/-- **Trace-preservation clause** (Wolf, Proposition 2.1): `T` preserves the
+trace — equivalently `T*(𝟙) = 𝟙` — if and only if `tr_A(τ) = 𝟙_d/d`. -/
+theorem tracePreserving_iff_traceLeft_choiMatrix
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    (∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) ↔
+      Matrix.traceLeft (choiMatrix T) =
+        (1 / (d : ℂ)) • (1 : Matrix (Fin d) (Fin d) ℂ) := by
+  have hdne : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  rw [traceLeft_choiMatrix, ← traceAdjointMap_one_eq_one_iff_tracePreserving]
+  constructor
+  · intro h
+    rw [h, Matrix.transpose_one]
+  · intro h
+    have hT := smul_cancel (one_div_ne_zero hdne) (N := (1 : Matrix (Fin d) (Fin d) ℂ)) h
+    calc Matrix.traceAdjointMap T 1
+        = ((1 : Matrix (Fin d) (Fin d) ℂ)).transpose := by
+          rw [← Matrix.transpose_transpose (Matrix.traceAdjointMap T 1), hT]
+      _ = 1 := Matrix.transpose_one
+
+/-- **Normalization clause** (Wolf, Proposition 2.1):
+`tr(τ) = tr(T*(𝟙))/d`. -/
+theorem trace_choiMatrix
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    (choiMatrix T).trace = (1 / (d : ℂ)) * (Matrix.traceAdjointMap T 1).trace := by
+  rw [Matrix.trace_eq_trace_traceLeft, traceLeft_choiMatrix, Matrix.trace_smul,
+    Matrix.trace_transpose, smul_eq_mul]
+
+/-- **Doubly-stochastic clause** (Wolf, Proposition 2.1): `T(𝟙) ∝ 𝟙` and
+`T*(𝟙) ∝ 𝟙` if and only if `tr_A(τ) ∝ 𝟙` and `tr_B(τ) ∝ 𝟙`. -/
+theorem doublyStochastic_iff_partialTraces_proportional
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    ((∃ c : ℂ, T 1 = c • (1 : Matrix (Fin d') (Fin d') ℂ)) ∧
+      (∃ c : ℂ, Matrix.traceAdjointMap T 1 =
+        c • (1 : Matrix (Fin d) (Fin d) ℂ))) ↔
+    ((∃ c : ℂ, Matrix.traceRight (choiMatrix T) =
+        c • (1 : Matrix (Fin d') (Fin d') ℂ)) ∧
+      (∃ c : ℂ, Matrix.traceLeft (choiMatrix T) =
+        c • (1 : Matrix (Fin d) (Fin d) ℂ))) := by
+  have hdne : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  have h1d : (1 / (d : ℂ)) ≠ 0 := one_div_ne_zero hdne
+  rw [traceRight_choiMatrix, traceLeft_choiMatrix]
+  constructor
+  · rintro ⟨⟨c, hc⟩, ⟨e, he⟩⟩
+    refine ⟨⟨(1 / (d : ℂ)) * c, ?_⟩, ⟨(1 / (d : ℂ)) * e, ?_⟩⟩
+    · rw [hc, smul_smul]
+    · rw [he, Matrix.transpose_smul, Matrix.transpose_one, smul_smul]
+  · rintro ⟨⟨c, hc⟩, ⟨e, he⟩⟩
+    refine ⟨⟨(d : ℂ) * c, smul_cancel h1d ?_⟩, ⟨(d : ℂ) * e, ?_⟩⟩
+    · rw [hc, smul_smul, show (1 / (d : ℂ)) * ((d : ℂ) * c) = c by field_simp]
+    · have hT : (Matrix.traceAdjointMap T 1).transpose = ((d : ℂ) * e) • 1 :=
+        smul_cancel h1d (by
+          rw [he, smul_smul, show (1 / (d : ℂ)) * ((d : ℂ) * e) = e by field_simp])
+      calc Matrix.traceAdjointMap T 1
+          = (((d : ℂ) * e) • (1 : Matrix (Fin d) (Fin d) ℂ)).transpose := by
+            rw [← Matrix.transpose_transpose (Matrix.traceAdjointMap T 1), hT]
+        _ = ((d : ℂ) * e) • 1 := by rw [Matrix.transpose_smul, Matrix.transpose_one]
+
+end PartialTraceClauses
+
+/-! ### Bridge to the square development -/
+
+/-- The rectangular Choi matrix at `d = d' = D` is definitionally the square
+Choi matrix `ChoiJamiolkowski.choiMatrix`: the existing square development is
+the specialization of the present one. -/
+theorem choiMatrix_eq_choiJamiolkowski {D : ℕ}
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    choiMatrix (d := D) (d' := D) T = ChoiJamiolkowski.choiMatrix T := rfl
+
+end ChoiRectangular

--- a/TNLean/Channel/KrausRectangular.lean
+++ b/TNLean/Channel/KrausRectangular.lean
@@ -1,0 +1,634 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.ChoiRectangular
+import TNLean.Channel.KrausRank
+import TNLean.Channel.KrausRepresentation
+import TNLean.Algebra.MatrixGramUnitary
+import TNLean.Algebra.FinSum
+
+/-!
+# Rectangular Kraus representation theorem
+
+This file proves the rectangular (different-dimension) form of Wolf Chapter 2,
+Theorem 2.1 (Kraus representation), `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 229–273: for a linear map `T : M_d(ℂ) → M_{d'}(ℂ)`,
+
+* **existence**: `T` is completely positive iff it admits a Kraus
+  representation `T(A) = Σⱼ Kⱼ A Kⱼ†` with `Kⱼ : d' × d` (this is the
+  complete-positivity clause `ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef`);
+* **normalization** (`kraus_tp_iff_sum_conjTranspose_mul`,
+  `kraus_unital_iff_sum_mul_conjTranspose`): `T` is trace preserving iff
+  `Σⱼ Kⱼ†Kⱼ = 𝟙`, and unital iff `Σⱼ KⱼKⱼ† = 𝟙`;
+* **Kraus rank** (`choiRank_isLeast_hasKrausCard_of_isKrausCP`,
+  `choiRank_le_mul`): the minimal number of Kraus operators is
+  `r = rank(τ) ≤ d·d'`, where `τ` is the Choi matrix;
+* **orthogonality** (`exists_kraus_orthogonal_of_isKrausCP`): there is a
+  representation with `r = rank(τ)` Hilbert–Schmidt orthogonal Kraus
+  operators (`tr[Kᵢ†Kⱼ] ∝ δᵢⱼ`);
+* **freedom** (`kraus_isometry_freedom_iff`, `kraus_unitary_freedom_iff`):
+  two Kraus families represent the same map iff they are related by a unitary
+  after padding the smaller family with zeros (isometric form), or by a
+  unitary of the same size (unitary form).
+
+## Main definitions
+
+* `ChoiRectangular.HasKrausCard T r` — `T` has an exact `r`-operator
+  rectangular Kraus representation.
+* `ChoiRectangular.HasKrausRankLE T r` — `T` has a rectangular Kraus
+  representation with at most `r` operators.
+* `ChoiRectangular.choiRank T` — the rank of the rectangular Choi matrix.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2,
+  Theorem 2.1][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix Finset BigOperators
+
+namespace ChoiRectangular
+
+variable {d d' : ℕ}
+
+/-! ### Kraus cardinality and the Choi rank -/
+
+/-- A linear map `T : M_d(ℂ) → M_{d'}(ℂ)` has an exact `r`-operator
+rectangular Kraus representation `T(X) = Σⱼ Kⱼ X Kⱼ†` with
+`Kⱼ : Matrix (Fin d') (Fin d) ℂ` (Wolf, Theorem 2.1, Equation (2.8)). -/
+def HasKrausCard
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) (r : ℕ) :
+    Prop :=
+  ∃ K : Fin r → Matrix (Fin d') (Fin d) ℂ,
+    ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ
+
+/-- A linear map `T : M_d(ℂ) → M_{d'}(ℂ)` admits a rectangular Kraus
+representation with at most `r` operators. -/
+def HasKrausRankLE
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) (r : ℕ) :
+    Prop :=
+  ∃ s : ℕ, s ≤ r ∧ HasKrausCard T s
+
+/-- The **Kraus rank** (Choi rank) of a linear map between matrix algebras is
+the rank of its Choi matrix (Wolf, Theorem 2.1, footnote: `r = rank(τ)`, to
+be distinguished from the rank of `T` as a linear map). -/
+noncomputable def choiRank
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) : ℕ :=
+  (choiMatrix T).rank
+
+/-- If `T` has `r` Kraus operators and `r ≤ s`, then it also has `s` Kraus
+operators obtained by zero-padding (Wolf, Theorem 2.1 item 4: "the smaller
+set is padded with zeros"). -/
+theorem hasKrausCard_mono {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+    Matrix (Fin d') (Fin d') ℂ} {r s : ℕ}
+    (hT : HasKrausCard T r) (hCard : r ≤ s) :
+    HasKrausCard T s := by
+  classical
+  rcases hT with ⟨K, hK⟩
+  refine ⟨fun α => if hlt : α.val < r then K ⟨α.val, hlt⟩ else 0, ?_⟩
+  intro X
+  rw [hK X, Fin.sum_castLE_extend_zero (f := fun j => K j * X * (K j)ᴴ) hCard]
+  refine Finset.sum_congr rfl ?_
+  intro α _
+  simp only
+  split_ifs with hlt
+  · rfl
+  · simp
+
+/-- The rectangular Choi matrix of a Kraus map is a sum of rank-one outer
+products (Wolf, Theorem 2.1, proof, Equation (2.9):
+`τ = Σⱼ |ψⱼ⟩⟨ψⱼ|` with `|ψⱼ⟩ = (Kⱼ ⊗ 𝟙)|Ω⟩`). -/
+theorem choiMatrix_eq_sum_vecMulVec_of_kraus {r : ℕ}
+    (K : Fin r → Matrix (Fin d') (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (hT : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
+    choiMatrix T =
+      ∑ j : Fin r,
+        Matrix.vecMulVec
+          (fun p : Fin d' × Fin d => ((1 : ℂ) / ((d : ℝ).sqrt : ℂ)) * K j p.1 p.2)
+          (star (fun p : Fin d' × Fin d => ((1 : ℂ) / ((d : ℝ).sqrt : ℂ)) * K j p.1 p.2)) := by
+  classical
+  let c : ℂ := (1 : ℂ) / ((d : ℝ).sqrt : ℂ)
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rw [choiMatrix_apply, hT,
+    ChoiJamiolkowski.omegaSlice_eq_single (D := d) i₂ j₂,
+    Matrix.sum_apply i₁ j₁, Matrix.sum_apply (i₁, i₂) (j₁, j₂)]
+  change ∑ x : Fin r,
+      (K x * Matrix.single i₂ j₂ (c * star c) * (K x)ᴴ) i₁ j₁ =
+    ∑ x : Fin r,
+      Matrix.vecMulVec (fun p : Fin d' × Fin d => c * K x p.1 p.2)
+        (star (fun p : Fin d' × Fin d => c * K x p.1 p.2)) (i₁, i₂) (j₁, j₂)
+  refine Finset.sum_congr rfl ?_
+  intro x _
+  simpa [Matrix.vecMulVec_apply] using
+    congrArg (fun M => M i₁ j₁)
+      (Matrix.mul_single_mul_conjTranspose_eq_vecMulVec (K := K x) (c := c) i₂ j₂)
+
+/-- Any `r`-operator rectangular Kraus representation bounds the Kraus rank
+by `r` (Wolf, Theorem 2.1, proof: `r ≥ rank(τ)`). -/
+theorem choiRank_le_of_hasKrausCard {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+    Matrix (Fin d') (Fin d') ℂ} {r : ℕ}
+    (hT : HasKrausCard T r) :
+    choiRank T ≤ r := by
+  rcases hT with ⟨K, hK⟩
+  exact Channel.rank_le_card_of_eq_sum_vecMulVec _ _
+    (choiMatrix_eq_sum_vecMulVec_of_kraus K T hK)
+
+/-- The Kraus rank is at most `d · d'` (Wolf, Theorem 2.1 item 2:
+`r = rank(τ) ≤ dd'`). -/
+theorem choiRank_le_mul
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    choiRank T ≤ d * d' := by
+  have h := Matrix.rank_le_card_width (choiMatrix T)
+  rw [Fintype.card_prod, Fintype.card_fin, Fintype.card_fin] at h
+  exact h.trans (Nat.mul_comm d' d).le
+
+/-- A completely positive map admits a rectangular Kraus representation whose
+cardinality is exactly the rank of its Choi matrix (Wolf, Theorem 2.1, proof:
+"equality can be achieved", using the spectral decomposition of `τ ≥ 0`). -/
+theorem hasKrausCard_choiRank_of_isKrausCP [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCP T) :
+    HasKrausCard T (choiRank T) := by
+  classical
+  have hτpsd : (choiMatrix T).PosSemidef :=
+    (isKrausCP_iff_choiMatrix_posSemidef (T := T)).mp hT
+  let hτ : (choiMatrix T).IsHermitian := hτpsd.1
+  let v : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0} → (Fin d' × Fin d) → ℂ :=
+    fun i p => ((Real.sqrt (hτ.eigenvalues i.1) : ℂ)) * hτ.eigenvectorUnitary p i.1
+  have hchoi' : choiMatrix T =
+      ∑ i : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
+        Matrix.vecMulVec (v i) (fun p => star (v i p)) := by
+    simpa [hτ, v] using
+      Matrix.PosSemidef.eq_sum_vecMulVec_nonzero_eigs (A := choiMatrix T) hτpsd
+  have hchoi : choiMatrix T =
+      ∑ i : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
+        Matrix.vecMulVec (v i) (star (v i)) := by
+    refine hchoi'.trans ?_
+    apply Finset.sum_congr rfl
+    intro i _
+    congr 1
+  have hcard : Fintype.card {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0} =
+      choiRank T := by
+    unfold choiRank
+    simpa [hτ] using (hτ.rank_eq_card_non_zero_eigs).symm
+  obtain ⟨K, hK⟩ := exists_kraus_of_choiMatrix_eq_sum_vecMulVec (T := T)
+    (ι := {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0}) v hchoi
+  have hK' : HasKrausCard T
+      (Fintype.card {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0}) := by
+    refine ⟨fun α => K ((Fintype.equivFin _).symm α), ?_⟩
+    intro X
+    calc
+      T X = ∑ m : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
+          K m * X * (K m)ᴴ := hK X
+      _ = ∑ α : Fin (Fintype.card {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0}),
+            K ((Fintype.equivFin _).symm α) * X *
+              (K ((Fintype.equivFin _).symm α))ᴴ := by
+              refine Fintype.sum_equiv (Fintype.equivFin _) _ _ ?_
+              intro m
+              simp
+  rwa [hcard] at hK'
+
+/-- **Kraus rank** (Wolf, Theorem 2.1 item 2): the minimal number of
+rectangular Kraus operators of a completely positive map is the rank of its
+Choi matrix, `r = rank(τ)`. -/
+theorem choiRank_isLeast_hasKrausCard_of_isKrausCP [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCP T) :
+    IsLeast {r : ℕ | HasKrausCard T r} (choiRank T) :=
+  ⟨hasKrausCard_choiRank_of_isKrausCP hT,
+   fun _r hr => choiRank_le_of_hasKrausCard hr⟩
+
+/-- **Orthogonal minimal Kraus family** (Wolf, Theorem 2.1 item 3): every
+completely positive map admits a representation with `r = rank(τ)`
+Hilbert–Schmidt orthogonal Kraus operators, `tr[Kᵢ†Kⱼ] ∝ δᵢⱼ`; the
+off-diagonal traces vanish and the diagonal traces are nonzero. -/
+theorem exists_kraus_orthogonal_of_isKrausCP [NeZero d]
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCP T) :
+    ∃ K : Fin (choiRank T) → Matrix (Fin d') (Fin d) ℂ,
+      (∀ X, T X = ∑ i : Fin (choiRank T), K i * X * (K i)ᴴ) ∧
+      (∀ i j : Fin (choiRank T), i ≠ j → ((K i)ᴴ * K j).trace = 0) ∧
+      (∀ i : Fin (choiRank T), ((K i)ᴴ * K i).trace ≠ 0) := by
+  classical
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  have hdne : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  have hτpsd : (choiMatrix T).PosSemidef :=
+    (isKrausCP_iff_choiMatrix_posSemidef (T := T)).mp hT
+  let hτ : (choiMatrix T).IsHermitian := hτpsd.1
+  let v : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0} → (Fin d' × Fin d) → ℂ :=
+    fun i p => ((Real.sqrt (hτ.eigenvalues i.1) : ℂ)) * hτ.eigenvectorUnitary p i.1
+  have hchoi' : choiMatrix T =
+      ∑ i : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
+        Matrix.vecMulVec (v i) (fun p => star (v i p)) := by
+    simpa [hτ, v] using
+      Matrix.PosSemidef.eq_sum_vecMulVec_nonzero_eigs (A := choiMatrix T) hτpsd
+  have hchoi : choiMatrix T =
+      ∑ i : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
+        Matrix.vecMulVec (v i) (star (v i)) := by
+    refine hchoi'.trans ?_
+    apply Finset.sum_congr rfl
+    intro i _
+    congr 1
+  have hcard : Fintype.card {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0} =
+      choiRank T := by
+    unfold choiRank
+    simpa [hτ] using (hτ.rank_eq_card_non_zero_eigs).symm
+  -- The Kraus family reconstructed from the spectral decomposition of `τ`.
+  let c : ℂ := (1 : ℂ) / ((d : ℝ).sqrt : ℂ)
+  have hstarc : star c = c := by simp [c]
+  have hcc : c * star c = 1 / (d : ℂ) := by
+    simpa [c, hstarc] using omegaCoeff_eq_inv (d := d) hdpos
+  have hcne : c ≠ 0 := by
+    dsimp [c]
+    have hsqrt : (((d : ℝ).sqrt : ℂ)) ≠ 0 :=
+      Complex.ofReal_ne_zero.mpr <| Real.sqrt_ne_zero'.2 (by exact_mod_cast hdpos)
+    simp [hsqrt]
+  let Ks : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0} →
+      Matrix (Fin d') (Fin d) ℂ :=
+    krausOfChoiDecomp (d := d) v
+  have hKs : ∀ X, T X = ∑ m : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
+      Ks m * X * (Ks m)ᴴ :=
+    krausOfChoiDecomp_spec (T := T) v hchoi
+  -- The eigenvector columns are orthonormal.
+  have hon : ∀ m n : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
+      ∑ p : Fin d' × Fin d,
+        star (hτ.eigenvectorUnitary p m.1) * hτ.eigenvectorUnitary p n.1 =
+          if n = m then 1 else 0 := by
+    intro m n
+    have hu : (hτ.eigenvectorUnitary :
+        Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ)ᴴ *
+          (hτ.eigenvectorUnitary :
+            Matrix (Fin d' × Fin d) (Fin d' × Fin d) ℂ) = 1 := by
+      simpa [Matrix.star_eq_conjTranspose] using
+        Matrix.UnitaryGroup.star_mul_self hτ.eigenvectorUnitary
+    have h := congrFun (congrFun hu m.1) n.1
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] at h
+    rw [h]
+    simp [Subtype.ext_iff, eq_comm]
+  -- The Hilbert–Schmidt Gram matrix of the reconstructed family.
+  have hgram : ∀ m n : {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0},
+      ((Ks m)ᴴ * Ks n).trace =
+        (d : ℂ) * ((Real.sqrt (hτ.eigenvalues m.1) : ℂ)) *
+          ((Real.sqrt (hτ.eigenvalues n.1) : ℂ)) * (if n = m then 1 else 0) := by
+    intro m n
+    have h1 : ((Ks m)ᴴ * Ks n).trace =
+        ∑ p : Fin d' × Fin d, star (Ks m p.1 p.2) * Ks n p.1 p.2 := by
+      simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.conjTranspose_apply]
+      rw [Finset.sum_comm]
+      exact (Fintype.sum_prod_type
+        (fun p : Fin d' × Fin d => star (Ks m p.1 p.2) * Ks n p.1 p.2)).symm
+    have h2 : ∀ p : Fin d' × Fin d,
+        star (Ks m p.1 p.2) * Ks n p.1 p.2 =
+          (1 / (c * star c)) *
+            (((Real.sqrt (hτ.eigenvalues m.1) : ℂ)) *
+              ((Real.sqrt (hτ.eigenvalues n.1) : ℂ))) *
+              (star (hτ.eigenvectorUnitary p m.1) *
+                hτ.eigenvectorUnitary p n.1) := by
+      intro p
+      have hsqrtm : star ((Real.sqrt (hτ.eigenvalues m.1) : ℂ)) =
+          ((Real.sqrt (hτ.eigenvalues m.1) : ℂ)) := by
+        simp
+      change star (v m p / c) * (v n p / c) = _
+      rw [star_div₀, hstarc, star_mul, hsqrtm]
+      simp only [v]
+      rw [div_eq_mul_inv, div_eq_mul_inv, one_div, mul_inv]
+      ring
+    calc
+      ((Ks m)ᴴ * Ks n).trace
+          = ∑ p : Fin d' × Fin d, star (Ks m p.1 p.2) * Ks n p.1 p.2 := h1
+      _ = ∑ p : Fin d' × Fin d,
+            (1 / (c * star c)) *
+              (((Real.sqrt (hτ.eigenvalues m.1) : ℂ)) *
+                ((Real.sqrt (hτ.eigenvalues n.1) : ℂ))) *
+                (star (hτ.eigenvectorUnitary p m.1) *
+                  hτ.eigenvectorUnitary p n.1) :=
+            Finset.sum_congr rfl fun p _ => h2 p
+      _ = (1 / (c * star c)) *
+            (((Real.sqrt (hτ.eigenvalues m.1) : ℂ)) *
+              ((Real.sqrt (hτ.eigenvalues n.1) : ℂ))) *
+              (∑ p : Fin d' × Fin d, star (hτ.eigenvectorUnitary p m.1) *
+                hτ.eigenvectorUnitary p n.1) := by
+            rw [Finset.mul_sum]
+      _ = (1 / (c * star c)) *
+            (((Real.sqrt (hτ.eigenvalues m.1) : ℂ)) *
+              ((Real.sqrt (hτ.eigenvalues n.1) : ℂ))) * (if n = m then 1 else 0) := by
+            rw [hon m n]
+      _ = (d : ℂ) * ((Real.sqrt (hτ.eigenvalues m.1) : ℂ)) *
+            ((Real.sqrt (hτ.eigenvalues n.1) : ℂ)) * (if n = m then 1 else 0) := by
+            rw [hcc, one_div_one_div]
+            ring
+  -- Reindex the subtype-indexed family to `Fin (choiRank T)`.
+  let e : Fin (choiRank T) ≃ {j : Fin d' × Fin d // hτ.eigenvalues j ≠ 0} :=
+    (finCongr hcard).symm.trans (Fintype.equivFin _).symm
+  refine ⟨fun α => Ks (e α), ?_, ?_, ?_⟩
+  · intro X
+    rw [hKs X]
+    exact (e.sum_comp (fun m => Ks m * X * (Ks m)ᴴ)).symm
+  · intro i j hij
+    have hne : e i ≠ e j := fun h => hij (e.injective h)
+    have hg := hgram (e i) (e j)
+    rw [if_neg (show e j ≠ e i from fun h => hne h.symm), mul_zero] at hg
+    exact hg
+  · intro i
+    have hg := hgram (e i) (e i)
+    rw [if_pos rfl, mul_one] at hg
+    rw [hg, mul_assoc]
+    have hlam : (Real.sqrt (hτ.eigenvalues (e i).1) : ℂ) *
+        (Real.sqrt (hτ.eigenvalues (e i).1) : ℂ) =
+          ((hτ.eigenvalues (e i).1 : ℝ) : ℂ) := by
+      rw [← Complex.ofReal_mul, Real.mul_self_sqrt (hτpsd.eigenvalues_nonneg _)]
+    rw [hlam]
+    exact mul_ne_zero hdne (Complex.ofReal_ne_zero.mpr (e i).2)
+
+/-! ### Normalization conditions (Wolf, Theorem 2.1 item 1) -/
+
+/-- **Trace-preserving normalization, necessary direction** (Wolf, Theorem
+2.1 item 1): if the rectangular Kraus map `T(X) = Σⱼ Kⱼ X Kⱼ†` preserves the
+trace, then `Σⱼ Kⱼ†Kⱼ = 𝟙`. -/
+theorem kraus_sum_conjTranspose_mul_of_tracePreserving
+    {r : ℕ} (K : Fin r → Matrix (Fin d') (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ)
+    (htp : ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :
+    ∑ i : Fin r, (K i)ᴴ * K i = 1 := by
+  apply (Matrix.ext_iff_trace_mul_right).2
+  intro N
+  rw [Matrix.one_mul]
+  rw [Finset.sum_mul, Matrix.trace_sum]
+  simp_rw [show ∀ i : Fin r,
+    ((K i)ᴴ * K i * N).trace = (K i * N * (K i)ᴴ).trace from
+    fun i => by rw [Matrix.mul_assoc ((K i)ᴴ), Matrix.trace_mul_comm, Matrix.mul_assoc]]
+  rw [← Matrix.trace_sum]
+  conv_lhs => rw [← hK N]
+  rw [htp N]
+
+/-- **Trace-preserving normalization** (Wolf, Theorem 2.1 item 1): the
+rectangular Kraus map `T(X) = Σⱼ Kⱼ X Kⱼ†` is trace preserving if and only
+if `Σⱼ Kⱼ†Kⱼ = 𝟙`. -/
+theorem kraus_tp_iff_sum_conjTranspose_mul
+    {r : ℕ} (K : Fin r → Matrix (Fin d') (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
+    (∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) ↔
+      ∑ i : Fin r, (K i)ᴴ * K i = 1 := by
+  constructor
+  · exact kraus_sum_conjTranspose_mul_of_tracePreserving K T hK
+  · intro h X
+    rw [hK X]
+    exact kraus_tp_of_sum_conjTranspose_mul K h X
+
+/-- **Unital normalization** (Wolf, Theorem 2.1 item 1): the rectangular
+Kraus map `T(X) = Σⱼ Kⱼ X Kⱼ†` is unital if and only if `Σⱼ KⱼKⱼ† = 𝟙`. -/
+theorem kraus_unital_iff_sum_mul_conjTranspose
+    {r : ℕ} (K : Fin r → Matrix (Fin d') (Fin d) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ) :
+    T 1 = 1 ↔ ∑ i : Fin r, K i * (K i)ᴴ = 1 := by
+  rw [hK 1]
+  simp [Matrix.mul_one]
+
+/-! ### Unitary freedom (Wolf, Theorem 2.1 item 4) -/
+
+/-- If two rectangular Kraus families define the same map, they also define
+the same Heisenberg dual: `Σ Bα† Y Bα = Σ Aj† Y Aj` for all `Y`. This is the
+uniqueness of the trace-pairing adjoint. -/
+theorem kraus_dual_eq_of_map_eq
+    {r₁ r₂ : ℕ}
+    (B : Fin r₁ → Matrix (Fin d') (Fin d) ℂ)
+    (A : Fin r₂ → Matrix (Fin d') (Fin d) ℂ)
+    (h : ∀ X : Matrix (Fin d) (Fin d) ℂ,
+      ∑ α : Fin r₁, B α * X * (B α)ᴴ =
+      ∑ j : Fin r₂, A j * X * (A j)ᴴ) :
+    ∀ Y : Matrix (Fin d') (Fin d') ℂ,
+      ∑ α : Fin r₁, (B α)ᴴ * Y * B α =
+      ∑ j : Fin r₂, (A j)ᴴ * Y * A j := by
+  intro Y
+  apply (Matrix.ext_iff_trace_mul_right).2
+  intro X
+  simp_rw [Finset.sum_mul, Matrix.trace_sum]
+  have trace_cycle : ∀ K : Matrix (Fin d') (Fin d) ℂ,
+      trace (Kᴴ * Y * K * X) = trace (K * X * Kᴴ * Y) := fun K => by
+    rw [Matrix.mul_assoc (Kᴴ * Y) K X, Matrix.trace_mul_comm,
+        ← Matrix.mul_assoc (K * X) Kᴴ Y]
+  simp_rw [trace_cycle]
+  rw [← Matrix.trace_sum, ← Matrix.trace_sum,
+      ← Finset.sum_mul, ← Finset.sum_mul]
+  rw [h X]
+
+/-- Map equality implies equal Stinespring Gramians:
+`Σ Bα†Bα = Σ Aj†Aj`. -/
+theorem kraus_conjTranspose_mul_eq_of_map_eq
+    {r₁ r₂ : ℕ}
+    (B : Fin r₁ → Matrix (Fin d') (Fin d) ℂ)
+    (A : Fin r₂ → Matrix (Fin d') (Fin d) ℂ)
+    (h : ∀ X : Matrix (Fin d) (Fin d) ℂ,
+      ∑ α : Fin r₁, B α * X * (B α)ᴴ =
+      ∑ j : Fin r₂, A j * X * (A j)ᴴ) :
+    ∑ α : Fin r₁, (B α)ᴴ * B α =
+    ∑ j : Fin r₂, (A j)ᴴ * A j := by
+  have hdual := kraus_dual_eq_of_map_eq B A h
+  simpa [Matrix.mul_one] using hdual 1
+
+/-- **Isometric mixing, sufficient direction** (Wolf, Theorem 2.1 item 4):
+if `W` is an isometry (`W†W = 𝟙`) and `Kⱼ = Σₗ Wⱼₗ K'ₗ`, then `{Kⱼ}` and
+`{K'ₗ}` define the same rectangular Kraus map. -/
+theorem kraus_same_map_of_isometry_combination
+    {ι₁ ι₂ : Type*} [Fintype ι₁] [Fintype ι₂] [DecidableEq ι₂]
+    (K : ι₁ → Matrix (Fin d') (Fin d) ℂ)
+    (K' : ι₂ → Matrix (Fin d') (Fin d) ℂ)
+    (W : Matrix ι₁ ι₂ ℂ)
+    (hW : Wᴴ * W = 1)
+    (hK : ∀ j, K j = ∑ l, W j l • K' l) :
+    ∀ X : Matrix (Fin d) (Fin d) ℂ,
+      ∑ j, K j * X * (K j)ᴴ =
+      ∑ l, K' l * X * (K' l)ᴴ := by
+  intro X
+  have hW_entry : ∀ l l' : ι₂,
+      ∑ j : ι₁, (starRingEnd ℂ) (W j l) * W j l' = if l = l' then 1 else 0 := by
+    intro l l'
+    have h := congrArg (fun M : Matrix ι₂ ι₂ ℂ => M l l') hW
+    simpa [Matrix.mul_apply, Matrix.one_apply] using h
+  calc
+    ∑ j, K j * X * (K j)ᴴ
+        = ∑ j : ι₁,
+            (∑ l, W j l • K' l) * X *
+            ((∑ l, W j l • K' l)ᴴ) := by simp only [hK]
+    _ = ∑ j : ι₁, ∑ l : ι₂, ∑ l' : ι₂,
+          (((starRingEnd ℂ) (W j l')) * W j l) • (K' l * X * (K' l')ᴴ) := by
+          refine Finset.sum_congr rfl fun j _ => ?_
+          rw [Matrix.sum_mul]
+          simp_rw [Matrix.conjTranspose_sum, Matrix.conjTranspose_smul]
+          rw [Matrix.mul_sum]
+          simp_rw [Matrix.sum_mul]
+          rw [Finset.sum_comm]
+          refine Finset.sum_congr rfl fun a _ => Finset.sum_congr rfl fun x _ => ?_
+          rw [Matrix.smul_mul, Matrix.mul_smul, Matrix.smul_mul, smul_smul,
+            starRingEnd_apply]
+    _ = ∑ l : ι₂, ∑ l' : ι₂,
+          (∑ j : ι₁, ((starRingEnd ℂ) (W j l')) * W j l) • (K' l * X * (K' l')ᴴ) := by
+          rw [Finset.sum_comm]
+          apply Finset.sum_congr rfl
+          intro l _
+          rw [Finset.sum_comm]
+          simp_rw [← Finset.sum_smul]
+    _ = ∑ l : ι₂, ∑ l' : ι₂,
+          (if l' = l then 1 else 0) • (K' l * X * (K' l')ᴴ) := by
+          simp_rw [hW_entry]; simp
+    _ = ∑ l, K' l * X * (K' l)ᴴ := by simp
+
+/-- **Padded isometric freedom, necessary direction** (Wolf, Theorem 2.1
+item 4): if two rectangular Kraus families of sizes `r₁` and `r₂` with
+`r₂ ≤ r₁` define the same completely positive map, then the larger family is
+an isometric linear combination of the smaller one: `Bα = Σⱼ Vαⱼ Aⱼ` with
+`V†V = 𝟙`.
+
+The proof follows Wolf via the subsequent "equivalence of ensembles"
+proposition: the map equality forces the vectorized Kraus operators
+`(Aⱼ)_{ab}` and `(Bα)_{ab}` to have equal Gram matrices, so they are related
+by an isometry. -/
+theorem kraus_isometry_freedom
+    {r₁ r₂ : ℕ}
+    (B : Fin r₁ → Matrix (Fin d') (Fin d) ℂ)
+    (A : Fin r₂ → Matrix (Fin d') (Fin d) ℂ)
+    (h : ∀ X : Matrix (Fin d) (Fin d) ℂ,
+      ∑ α : Fin r₁, B α * X * (B α)ᴴ =
+      ∑ j : Fin r₂, A j * X * (A j)ᴴ)
+    (hCard : r₂ ≤ r₁) :
+    ∃ V : Matrix (Fin r₁) (Fin r₂) ℂ,
+      V.conjTranspose * V = 1 ∧
+      ∀ α : Fin r₁, B α = ∑ j : Fin r₂, V α j • A j := by
+  -- Pad `A` with zeros to size `r₁`.
+  let A' : Fin r₁ → Matrix (Fin d') (Fin d) ℂ :=
+    fun α => if hlt : α.val < r₂ then A ⟨α.val, hlt⟩ else 0
+  have hBA' : ∀ X, ∑ α : Fin r₁, B α * X * (B α)ᴴ =
+      ∑ α : Fin r₁, A' α * X * (A' α)ᴴ := by
+    intro X; rw [h X]
+    rw [Fin.sum_castLE_extend_zero (fun j => A j * X * (A j)ᴴ) hCard]
+    apply Finset.sum_congr rfl; intro α _
+    simp only [A']; split_ifs <;> simp
+  have hdual := kraus_dual_eq_of_map_eq B A' hBA'
+  -- Equal Gram matrices of the vectorized families.
+  let MB : Matrix (Fin r₁) (Fin d' × Fin d) ℂ := fun α x => B α x.1 x.2
+  let MA' : Matrix (Fin r₁) (Fin d' × Fin d) ℂ := fun α x => A' α x.1 x.2
+  have hGram : MBᴴ * MB = MA'ᴴ * MA' := by
+    ext ⟨a, b⟩ ⟨c, e⟩
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, MB, MA']
+    have h_entry := congr_fun (congr_fun (hdual (Matrix.single a c 1)) b) e
+    simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.single_apply] at h_entry
+    have collapse : ∀ (K : Fin r₁ → Matrix (Fin d') (Fin d) ℂ),
+        (∑ α, ∑ x₁, (∑ x₂, star (K α x₂ b) *
+          (if a = x₂ ∧ c = x₁ then (1 : ℂ) else 0)) * K α x₁ e) =
+        ∑ α, star (K α a b) * K α c e := by
+      intro K
+      apply Finset.sum_congr rfl; intro α _
+      have step₁ : ∀ x₁, (∑ x₂, star (K α x₂ b) *
+          (if a = x₂ ∧ c = x₁ then (1 : ℂ) else 0)) * K α x₁ e =
+          if c = x₁ then star (K α a b) * K α x₁ e else 0 := by
+        intro x₁
+        have h_inner : (∑ x₂, star (K α x₂ b) *
+            (if a = x₂ ∧ c = x₁ then (1 : ℂ) else 0)) =
+            if c = x₁ then star (K α a b) else 0 := by
+          rw [Finset.sum_eq_single a (fun x _ hx => by simp [Ne.symm hx])
+              (fun h => absurd (Finset.mem_univ _) h)]
+          simp
+        rw [h_inner]; split_ifs <;> simp
+      simp_rw [step₁]; simp [Finset.sum_ite_eq, Finset.mem_univ]
+    rw [collapse, collapse] at h_entry
+    exact h_entry
+  obtain ⟨U, hU⟩ := Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq
+    (B := MB) (A := MA') hGram
+  have hU_unitary :
+      (U : Matrix (Fin r₁) (Fin r₁) ℂ)ᴴ * (U : Matrix (Fin r₁) (Fin r₁) ℂ) = 1 := by
+    simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
+  have hU_mat_eq : (U : Matrix (Fin r₁) (Fin r₁) ℂ) * MA' = MB := hU.symm
+  refine ⟨fun α j => (U : Matrix (Fin r₁) (Fin r₁) ℂ) α (Fin.castLE hCard j), ?_, ?_⟩
+  · ext j k
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
+    have h_uu := congr_fun (congr_fun hU_unitary (Fin.castLE hCard j)) (Fin.castLE hCard k)
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] at h_uu
+    rw [h_uu]; simp [(Fin.castLE_injective hCard).eq_iff]
+  · intro α; ext a b
+    have h_entry : (B α) a b =
+        ∑ β : Fin r₁, (U : Matrix (Fin r₁) (Fin r₁) ℂ) α β * (A' β) a b := by
+      have := congr_fun (congr_fun hU_mat_eq α) (a, b)
+      simpa [Matrix.mul_apply, MB, MA'] using this.symm
+    rw [h_entry]; simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+    rw [Fin.sum_castLE_extend_zero
+      (fun j => (U : Matrix (Fin r₁) (Fin r₁) ℂ) α (Fin.castLE hCard j) *
+        (A j) a b) hCard]
+    apply Finset.sum_congr rfl; intro β _
+    simp only [A']; split_ifs with hlt
+    · simp only [Fin.eta, Fin.castLE]
+    · simp only [Matrix.zero_apply, mul_zero]
+
+/-- **Padded unitary freedom** (Wolf, Theorem 2.1 item 4): two rectangular
+Kraus families define the same completely positive map if and only if, after
+padding the smaller family with zero operators, they are related by an
+isometric mixing matrix. -/
+theorem kraus_isometry_freedom_iff
+    {ι₁ ι₂ : Type*} [Fintype ι₁] [Fintype ι₂] [DecidableEq ι₂]
+    (B : ι₁ → Matrix (Fin d') (Fin d) ℂ)
+    (A : ι₂ → Matrix (Fin d') (Fin d) ℂ)
+    (hCard : Fintype.card ι₂ ≤ Fintype.card ι₁) :
+    (∀ X : Matrix (Fin d) (Fin d) ℂ,
+      ∑ α, B α * X * (B α)ᴴ = ∑ j, A j * X * (A j)ᴴ) ↔
+      ∃ V : Matrix ι₁ ι₂ ℂ,
+        Vᴴ * V = 1 ∧
+        ∀ α, B α = ∑ j, V α j • A j := by
+  classical
+  constructor
+  · intro h
+    -- Reindex to `Fin` and apply the necessary direction.
+    let e₁ : ι₁ ≃ Fin (Fintype.card ι₁) := Fintype.equivFin ι₁
+    let e₂ : ι₂ ≃ Fin (Fintype.card ι₂) := Fintype.equivFin ι₂
+    let B' : Fin (Fintype.card ι₁) → Matrix (Fin d') (Fin d) ℂ := B ∘ e₁.symm
+    let A' : Fin (Fintype.card ι₂) → Matrix (Fin d') (Fin d) ℂ := A ∘ e₂.symm
+    have h' : ∀ X : Matrix (Fin d) (Fin d) ℂ,
+        ∑ α : Fin (Fintype.card ι₁), B' α * X * (B' α)ᴴ =
+        ∑ j : Fin (Fintype.card ι₂), A' j * X * (A' j)ᴴ := by
+      intro X
+      change ∑ α, B (e₁.symm α) * X * (B (e₁.symm α))ᴴ =
+        ∑ j, A (e₂.symm j) * X * (A (e₂.symm j))ᴴ
+      rw [e₁.symm.sum_comp (fun i => B i * X * (B i)ᴴ),
+          e₂.symm.sum_comp (fun j => A j * X * (A j)ᴴ)]
+      exact h X
+    obtain ⟨V', hV'_iso, hV'_decomp⟩ := kraus_isometry_freedom B' A' h' hCard
+    refine ⟨fun α j => V' (e₁ α) (e₂ j), ?_, ?_⟩
+    · ext j k
+      simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
+      rw [show ∑ x : ι₁, star (V' (e₁ x) (e₂ j)) * V' (e₁ x) (e₂ k) =
+          ∑ β, star (V' β (e₂ j)) * V' β (e₂ k) from
+        e₁.sum_comp (fun β => star (V' β (e₂ j)) * V' β (e₂ k))]
+      have h_entry := congr_fun (congr_fun hV'_iso (e₂ j)) (e₂ k)
+      simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
+        e₂.injective.eq_iff] at h_entry
+      exact h_entry
+    · intro α
+      have := hV'_decomp (e₁ α)
+      simp only [B', A', Function.comp, Equiv.symm_apply_apply] at this
+      rw [this, ← e₂.sum_comp (fun β => V' (e₁ α) β • A (e₂.symm β))]
+      simp [Equiv.symm_apply_apply]
+  · rintro ⟨V, hV, hBA⟩
+    exact kraus_same_map_of_isometry_combination (K := B) (K' := A) (W := V) hV hBA
+
+/-- **Unitary freedom, same-size form** (Wolf, Theorem 2.1 item 4): two
+rectangular Kraus families with the same finite index type define the same
+completely positive map if and only if they are related by a unitary mixing
+matrix. -/
+theorem kraus_unitary_freedom_iff
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (B A : ι → Matrix (Fin d') (Fin d) ℂ) :
+    (∀ X : Matrix (Fin d) (Fin d) ℂ,
+      ∑ α, B α * X * (B α)ᴴ = ∑ j, A j * X * (A j)ᴴ) ↔
+      ∃ U : Matrix.unitaryGroup ι ℂ,
+        ∀ α, B α = ∑ j, (U : Matrix ι ι ℂ) α j • A j := by
+  rw [kraus_isometry_freedom_iff B A le_rfl]
+  refine ⟨fun ⟨V, hV, hBA⟩ => ⟨⟨V, Matrix.mem_unitaryGroup_iff'.2 hV⟩, hBA⟩,
+          fun ⟨U, hBA⟩ => ⟨(U : Matrix ι ι ℂ), Matrix.mem_unitaryGroup_iff'.mp U.prop, hBA⟩⟩
+
+end ChoiRectangular

--- a/TNLean/Channel/KrausRectangular.lean
+++ b/TNLean/Channel/KrausRectangular.lean
@@ -241,7 +241,7 @@ theorem exists_kraus_orthogonal_of_isKrausCP [NeZero d]
   let c : ℂ := (1 : ℂ) / ((d : ℝ).sqrt : ℂ)
   have hstarc : star c = c := by simp [c]
   have hcc : c * star c = 1 / (d : ℂ) := by
-    simpa [c, hstarc] using omegaCoeff_eq_inv (d := d) hdpos
+    simpa [c, hstarc] using ChoiJamiolkowski.omegaCoeff_eq_inv (D := d) hdpos
   have hcne : c ≠ 0 := by
     dsimp [c]
     have hsqrt : (((d : ℝ).sqrt : ℂ)) ≠ 0 :=

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -7,6 +7,8 @@ import TNLean.Channel.PartialTrace
 import TNLean.Channel.MaximallyEntangled
 import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.ChoiRectangular
+import TNLean.Channel.KrausRectangular
 import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
@@ -55,11 +57,24 @@ project import.
     `Channel.hasKrausRankLE_choiRank_of_cp` /
     `Channel.hasKrausRankLE_choiRank_of_cptp`
     — minimal Kraus constructions from the Choi spectral decomposition ✓
-  - The different-dimension Choi correspondence, general adjoint
-    partial-trace and trace-normalization identities, converse partial-trace
-    clauses, and doubly-stochastic clause are not yet formalized, so
-    Proposition 2.1 is not marked complete; see
-    `docs/paper-gaps/choi_rectangular_scope.tex`.
+  - **Rectangular (different-dimension) form** in
+    `TNLean/Channel/ChoiRectangular.lean` (namespace `ChoiRectangular`):
+    `choiMatrix` — `τ = (T ⊗ id_d)(|Ω⟩⟨Ω|)` on `ℂ^{d'} ⊗ ℂ^d` ✓
+    `mapOfChoiMatrix_choiMatrix` / `choiMatrix_mapOfChoiMatrix` — mutual
+    inverses ✓ `trace_pairing` — `tr[A T(B)] = d·tr[τ (A ⊗ Bᵀ)]` ✓
+    `choiMatrix_isHermitian_iff_hermiticityPreserving` — Hermiticity clause ✓
+    `isKrausCP_iff_choiMatrix_posSemidef` — CP clause ✓
+    `unital_iff_traceRight_choiMatrix` — unitality clause ✓
+    `traceLeft_choiMatrix` (`tr_A(τ) = (T*(𝟙))ᵀ/d`) and
+    `tracePreserving_iff_traceLeft_choiMatrix` — trace-preservation clause ✓
+    `trace_choiMatrix` (`tr(τ) = tr(T*(𝟙))/d`) — normalization clause ✓
+    `doublyStochastic_iff_partialTraces_proportional` — doubly-stochastic
+    clause ✓
+  - `ChoiRectangular.choiMatrix_eq_choiJamiolkowski` — the square development
+    is the specialization `d = d'` ✓
+  - Remaining square-only declarations (the `ChoiJamiolkowski.choiMatrix`
+    API, `IsTracePreservingMap`, `IsChannel`) are documented as specializations
+    in `docs/paper-gaps/choi_rectangular_scope.tex`.
 
 * **Theorem 2.1** (Kraus representation, square development):
   - `kraus_tp_of_sum_conjTranspose_mul` — `∑Kᵢ†Kᵢ = 𝟙` ⟹ TP ✓
@@ -78,9 +93,19 @@ project import.
     — Wolf Theorem 2.18 in isometric form, including zero-padding of the smaller family ✓
   - `kraus_unitary_freedom_iff`
     — Wolf Theorem 2.18 in same-size unitary form ✓
-  - The full rectangular existence, minimal-rank, orthogonal-family, and
-    padded-unitary statement is not yet formalized; see
-    `docs/paper-gaps/choi_rectangular_scope.tex`.
+  - **Rectangular form** in `TNLean/Channel/KrausRectangular.lean`
+    (namespace `ChoiRectangular`):
+    `kraus_tp_iff_sum_conjTranspose_mul` / `kraus_unital_iff_sum_mul_conjTranspose`
+    — normalization item 1 in both directions ✓
+    `choiRank` / `choiRank_le_of_hasKrausCard` /
+    `hasKrausCard_choiRank_of_isKrausCP` /
+    `choiRank_isLeast_hasKrausCard_of_isKrausCP` / `choiRank_le_mul`
+    — minimal Kraus number `r = rank(τ) ≤ d·d'` ✓
+    `exists_kraus_orthogonal_of_isKrausCP`
+    — Hilbert–Schmidt orthogonal minimal family (`tr[Kᵢ†Kⱼ] ∝ δᵢⱼ`) ✓
+    `kraus_isometry_freedom` / `kraus_isometry_freedom_iff` /
+    `kraus_unitary_freedom_iff`
+    — padded isometric/unitary freedom (item 4) ✓
 
 * **Theorem 2.2** (Stinespring dilation):
   - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✓
@@ -235,6 +260,8 @@ project import.
 | SWAP operator F | `MaximallyEntangled.lean` | `Matrix.swapMatrix` |
 | Tensor product of maps | `TensorMap.lean` | `Matrix.tensorMapId` |
 | Choi matrix | `ChoiJamiolkowski.lean` | `ChoiJamiolkowski.choiMatrix` |
+| Rectangular Choi matrix | `ChoiRectangular.lean` | `ChoiRectangular.choiMatrix` |
+| Rectangular Kraus rank | `KrausRectangular.lean` | `ChoiRectangular.choiRank` |
 | Stinespring isometry | `Stinespring.lean` | `stinespringV` |
 | POVM | `POVM.lean` | `POVM` |
 | Naimark isometry | `POVM.lean` | `POVM.naimarkIsometry` |

--- a/blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex
+++ b/blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex
@@ -144,3 +144,310 @@
     If $\mathcal S$ is trace-preserving completely positive and $X\geq0$, then
     $\mathcal S(X)\geq0$.
 \end{lemma}
+
+\section{The Choi--Jamiolkowski representation of maps between matrix algebras}
+
+Fix $d,d'\geq 1$. For a linear map $T:\MN{d}\to\MN{d'}$ between matrix
+algebras of possibly different dimensions, write $\Omega_d$ for the maximally
+entangled vector on the \emph{input} factor and $\tau$ for the associated
+operator on $\C^{d'}\otimes\C^{d}$, with the output factor first. The partial
+trace over the output factor is written $\tr_A$ and the partial trace over
+the input factor is written $\tr_B$.
+
+\begin{definition}[Choi matrix of a map between matrix algebras]
+    \label{def:choi_matrix_rect}
+    \lean{ChoiRectangular.choiMatrix, ChoiRectangular.mapOfChoiMatrix}
+    \leanok
+    \uses{def:maximally_entangled, def:tensor_map_id}
+    The \emph{Choi matrix} of a linear map $T:\MN{d}\to\MN{d'}$ is
+    \begin{align}
+        \tau &= (T\otimes\operatorname{id}_d)
+          \bigl(\ketbra{\Omega_d}{\Omega_d}\bigr),
+        \notag
+    \end{align}
+    an operator on $\C^{d'}\otimes\C^{d}$. This is the correspondence of
+    \cite[Proposition~2.1]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{theorem}[Mutual inverses of the Choi correspondence]
+    \label{thm:choi_rect_mutual_inverse}
+    \lean{ChoiRectangular.mapOfChoiMatrix_choiMatrix,
+        ChoiRectangular.choiMatrix_mapOfChoiMatrix,
+        ChoiRectangular.choiMatrix_injective}
+    \leanok
+    \uses{def:choi_matrix_rect}
+    The assignments $T\mapsto\tau$ and $\tau\mapsto T$, the latter defined
+    entrywise by
+    \begin{align}
+        T(B)_{i_1 j_1}
+          &= d\sum_{i_2,j_2=0}^{d-1}
+            \tau_{(i_1,i_2),(j_1,j_2)}\,B_{i_2 j_2},
+        \notag
+    \end{align}
+    are mutual inverses: every linear map is recovered from its Choi matrix,
+    and every operator on $\C^{d'}\otimes\C^{d}$ is the Choi matrix of the
+    map it defines. This is \cite[Proposition~2.1, Equation~(2.4)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The $(i_2,j_2)$-slice of $\ketbra{\Omega_d}{\Omega_d}$ is the matrix
+    unit $E_{i_2 j_2}$ scaled by $1/d$; substituting it into the defining
+    entries and using linearity gives both compositions.
+\end{proof}
+
+\begin{theorem}[Trace-pairing formula]
+    \label{thm:choi_rect_trace_pairing}
+    \lean{ChoiRectangular.trace_pairing}
+    \leanok
+    \uses{def:choi_matrix_rect, thm:choi_rect_mutual_inverse}
+    For every $A\in\MN{d'}$ and $B\in\MN{d}$,
+    \begin{align}
+        \tr\!\bigl(A\,T(B)\bigr)
+          &= d\,\tr\!\bigl(\tau\,(A\otimes B^{T})\bigr).
+        \notag
+    \end{align}
+    This is the second line of \cite[Proposition~2.1, Equation~(2.1)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Expand $\tr(A\,T(B))$ entrywise, insert the inverse assignment of
+    Theorem~\ref{thm:choi_rect_mutual_inverse}, and identify the resulting
+    four-fold sum with $d\,\tr(\tau\,(A\otimes B^{T}))$.
+\end{proof}
+
+\begin{theorem}[Hermiticity preservation]
+    \label{thm:choi_rect_hermiticity}
+    \lean{ChoiRectangular.choiMatrix_isHermitian_iff_hermiticityPreserving}
+    \leanok
+    \uses{def:choi_matrix_rect}
+    The Choi matrix is Hermitian, $\tau=\tau^\dagger$, if and only if
+    $T(B^\dagger)=T(B)^\dagger$ for every $B\in\MN{d}$. This is the
+    Hermiticity clause of \cite[Proposition~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The entries of $\tau$ along the diagonal slices are the entries of
+    $T(E_{i_2 j_2})$ scaled by $1/d$, so Hermiticity of $\tau$ is the
+    relation $T(E_{j_2 i_2})=T(E_{i_2 j_2})^\dagger$ on matrix units; both
+    directions then follow by linearity.
+\end{proof}
+
+\begin{theorem}[Complete positivity]
+    \label{thm:choi_rect_cp}
+    \lean{ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef,
+        ChoiRectangular.exists_isKrausCP_of_posSemidef,
+        ChoiRectangular.choiMatrix_of_kraus_posSemidef,
+        ChoiRectangular.krausOfChoiDecomp, ChoiRectangular.krausOfChoiDecomp_spec,
+        ChoiRectangular.exists_kraus_of_choiMatrix_eq_sum_vecMulVec}
+    \leanok
+    \uses{def:choi_matrix_rect, def:is_kraus_cp}
+    The map $T$ is completely positive, in the sense that it admits a Kraus
+    representation $T(X)=\sum_{j}K_jXK_j^\dagger$ with
+    $K_j\in M_{d'\times d}(\C)$, if and only if $\tau\geq0$. This is the
+    complete-positivity clause of \cite[Proposition~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    If $T(X)=\sum_j K_jXK_j^\dagger$, then
+    $\tau=\sum_j\ketbra{\psi_j}{\psi_j}$ with
+    $(\psi_j)_{(i_1,i_2)}=(K_j)_{i_1 i_2}/\sqrt{d}$, so $\tau\geq0$.
+    Conversely, a positive semidefinite $\tau$ decomposes into rank-one
+    outer products $\sum_j\ketbra{\psi_j}{\psi_j}$, and rescaling the
+    vectors $\psi_j$ by $\sqrt{d}$ gives Kraus operators via the inverse
+    assignment.
+\end{proof}
+
+\begin{theorem}[Unitality]
+    \label{thm:choi_rect_unital}
+    \lean{ChoiRectangular.traceRight_choiMatrix,
+        ChoiRectangular.unital_iff_traceRight_choiMatrix}
+    \leanok
+    \uses{def:choi_matrix_rect, def:partial_trace}
+    The input-factor partial trace of the Choi matrix is
+    $\tr_B(\tau)=T(\Id_d)/d$; hence $T(\Id_d)=\Id_{d'}$ if and only if
+    $\tr_B(\tau)=\Id_{d'}/d$. This is the unitality clause of
+    \cite[Proposition~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The diagonal slices of $\ketbra{\Omega_d}{\Omega_d}$ sum to $\Id_d/d$,
+    so linearity gives $\tr_B(\tau)=T(\Id_d)/d$; cancelling the factor
+    $1/d$ gives the equivalence.
+\end{proof}
+
+\begin{theorem}[Preservation of the trace]
+    \label{thm:choi_rect_tp}
+    \lean{ChoiRectangular.traceLeft_choiMatrix,
+        ChoiRectangular.traceAdjointMap_one_eq_one_iff_tracePreserving,
+        ChoiRectangular.tracePreserving_iff_traceLeft_choiMatrix}
+    \leanok
+    \uses{def:choi_matrix_rect, def:partial_trace, def:trace_pairing_adjoint}
+    The output-factor partial trace of the Choi matrix is
+    $\tr_A(\tau)=(T^*(\Id_{d'}))^{T}/d$, where $T^*$ is the trace-pairing
+    adjoint; hence $T^*(\Id_{d'})=\Id_d$, equivalently $T$ preserves the
+    trace, if and only if $\tr_A(\tau)=\Id_d/d$. This is the
+    trace-preservation clause of \cite[Proposition~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The output-factor partial trace has entries
+    $\tr(T(E_{i_2 j_2}))/d$, which are the entries of
+    $(T^*(\Id_{d'}))^{T}/d$ by the defining trace pairing of the adjoint.
+    The equivalence $\tr(T(X))=\tr(X)\Leftrightarrow T^*(\Id_{d'})=\Id_d$
+    is the nondegeneracy of the trace pairing, and transposition and the
+    factor $1/d$ cancel.
+\end{proof}
+
+\begin{theorem}[Trace normalization]
+    \label{thm:choi_rect_normalization}
+    \lean{ChoiRectangular.trace_choiMatrix}
+    \leanok
+    \uses{def:choi_matrix_rect, thm:choi_rect_tp}
+    The full trace of the Choi matrix is
+    $\tr(\tau)=\tr(T^*(\Id_{d'}))/d$. This is the normalization clause of
+    \cite[Proposition~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take the trace of the identity
+    $\tr_A(\tau)=(T^*(\Id_{d'}))^{T}/d$ of Theorem~\ref{thm:choi_rect_tp}.
+\end{proof}
+
+\begin{theorem}[Doubly-stochastic maps]
+    \label{thm:choi_rect_doubly_stochastic}
+    \lean{ChoiRectangular.doublyStochastic_iff_partialTraces_proportional}
+    \leanok
+    \uses{def:choi_matrix_rect, thm:choi_rect_unital, thm:choi_rect_tp}
+    The conditions $T(\Id_d)\propto\Id_{d'}$ and
+    $T^*(\Id_{d'})\propto\Id_d$ hold if and only if
+    $\tr_B(\tau)\propto\Id_{d'}$ and $\tr_A(\tau)\propto\Id_d$. This is the
+    doubly-stochastic clause of \cite[Proposition~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Immediate from the partial-trace identities
+    $\tr_B(\tau)=T(\Id_d)/d$ and $\tr_A(\tau)=(T^*(\Id_{d'}))^{T}/d$ of
+    Theorems~\ref{thm:choi_rect_unital} and~\ref{thm:choi_rect_tp}.
+\end{proof}
+
+\section{The Kraus representation theorem for rectangular matrix algebras}
+
+\begin{theorem}[Kraus normalization conditions]
+    \label{thm:kraus_rect_normalization}
+    \lean{ChoiRectangular.kraus_tp_iff_sum_conjTranspose_mul,
+        ChoiRectangular.kraus_unital_iff_sum_mul_conjTranspose,
+        ChoiRectangular.kraus_sum_conjTranspose_mul_of_tracePreserving}
+    \leanok
+    \uses{def:is_kraus_cp}
+    Let $T(X)=\sum_{j=1}^{r}K_jXK_j^\dagger$ with
+    $K_j\in M_{d'\times d}(\C)$. Then $T$ is trace preserving if and only
+    if $\sum_j K_j^\dagger K_j=\Id_d$, and unital if and only if
+    $\sum_j K_jK_j^\dagger=\Id_{d'}$. This is item~1 of
+    \cite[Theorem~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Cyclicity of the trace gives
+    $\tr\bigl(\bigl(\sum_j K_j^\dagger K_j\bigr)X\bigr)=\tr(T(X))$ for every
+    $X$, so the trace-preserving equivalence follows from nondegeneracy of
+    the trace pairing; the unital equivalence is the evaluation at $X=\Id_d$.
+\end{proof}
+
+\begin{definition}[Kraus cardinality and Kraus rank]
+    \label{def:kraus_rank_rect}
+    \lean{ChoiRectangular.HasKrausCard, ChoiRectangular.HasKrausRankLE,
+        ChoiRectangular.choiRank, ChoiRectangular.hasKrausCard_mono}
+    \leanok
+    \uses{def:is_kraus_cp, def:choi_matrix_rect}
+    A map $T:\MN{d}\to\MN{d'}$ has \emph{Kraus cardinality} $r$ if it has an
+    exact $r$-operator Kraus representation. Its \emph{Kraus rank} (Choi
+    rank) is the rank of its Choi matrix, $r=\operatorname{rank}(\tau)$;
+    following \cite[Theorem~2.1, footnote]{Wolf2012Quantum}, this is
+    distinguished from the rank of $T$ as a linear map.
+\end{definition}
+
+\begin{theorem}[Minimality of the Kraus rank]
+    \label{thm:kraus_rect_rank_minimal}
+    \lean{ChoiRectangular.hasKrausCard_choiRank_of_isKrausCP,
+        ChoiRectangular.choiRank_le_of_hasKrausCard,
+        ChoiRectangular.choiRank_isLeast_hasKrausCard_of_isKrausCP,
+        ChoiRectangular.choiRank_le_mul}
+    \leanok
+    \uses{def:kraus_rank_rect, thm:choi_rect_cp}
+    The minimal number of Kraus operators of a completely positive map
+    $T:\MN{d}\to\MN{d'}$ is $r=\operatorname{rank}(\tau)\leq dd'$. This is
+    item~2 of \cite[Theorem~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:choi_rect_cp}
+    Every $r$-operator Kraus family gives
+    $\tau=\sum_{j=1}^{r}\ketbra{\psi_j}{\psi_j}$, so
+    $\operatorname{rank}(\tau)\leq r$. Conversely, the spectral
+    decomposition of $\tau\geq0$ into $\operatorname{rank}(\tau)$ rank-one
+    outer products yields a Kraus family of exactly
+    $\operatorname{rank}(\tau)$ operators by
+    Theorem~\ref{thm:choi_rect_cp}, and
+    $\operatorname{rank}(\tau)\leq dd'$ since $\tau$ acts on a
+    $dd'$-dimensional space.
+\end{proof}
+
+\begin{theorem}[Orthogonal minimal Kraus family]
+    \label{thm:kraus_rect_orthogonal}
+    \lean{ChoiRectangular.exists_kraus_orthogonal_of_isKrausCP}
+    \leanok
+    \uses{def:kraus_rank_rect, thm:kraus_rect_rank_minimal}
+    Every completely positive map $T:\MN{d}\to\MN{d'}$ admits a Kraus
+    representation with $r=\operatorname{rank}(\tau)$ Hilbert--Schmidt
+    orthogonal Kraus operators, $\tr[K_i^\dagger K_j]\propto\delta_{ij}$;
+    the off-diagonal traces vanish and the diagonal traces are nonzero.
+    This is item~3 of \cite[Theorem~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kraus_rect_rank_minimal}
+    Choose the $\psi_j$ in the spectral decomposition of
+    Theorem~\ref{thm:kraus_rect_rank_minimal} to be orthogonal
+    eigenvectors; the corresponding Kraus operators then satisfy
+    $\tr[K_i^\dagger K_j]=d\,\lambda_i\,\delta_{ij}$, where $\lambda_i$ is
+    the $i$-th nonzero eigenvalue of $\tau$.
+\end{proof}
+
+\begin{theorem}[Unitary freedom of Kraus representations]
+    \label{thm:kraus_rect_freedom}
+    \lean{ChoiRectangular.kraus_isometry_freedom_iff,
+        ChoiRectangular.kraus_unitary_freedom_iff,
+        ChoiRectangular.kraus_isometry_freedom,
+        ChoiRectangular.kraus_same_map_of_isometry_combination,
+        ChoiRectangular.kraus_dual_eq_of_map_eq,
+        ChoiRectangular.kraus_conjTranspose_mul_eq_of_map_eq}
+    \leanok
+    \uses{def:is_kraus_cp}
+    Two sets of Kraus operators $\{K_j\}$ and $\{\widetilde{K}_\ell\}$
+    represent the same completely positive map if and only if there is a
+    unitary $U$ with $K_j=\sum_\ell U_{j\ell}\widetilde{K}_\ell$, where the
+    smaller set is padded with zero operators; equivalently, after padding,
+    the families are related by an isometry $V$ with $V^\dagger V=\Id$.
+    This is item~4 of \cite[Theorem~2.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    An isometric combination preserves the map by the orthogonality
+    relations of the mixing matrix. Conversely, equal maps have equal
+    trace-pairing adjoints, hence equal Gram matrices
+    for the vectorized Kraus operators $(K_j)_{ab}$; equal Gram matrices
+    are related by a unitary, whose rectangular submatrix is the claimed
+    isometry after zero-padding.
+\end{proof}

--- a/docs/paper-gaps/choi_rectangular_scope.tex
+++ b/docs/paper-gaps/choi_rectangular_scope.tex
@@ -7,9 +7,10 @@
 
 \input{command}
 
-\title{The Square-Dimensional Scope of the Choi--Jamiolkowski Correspondence}
+\title{The Rectangular Choi--Jamiolkowski Correspondence:\\
+Resolution of the Square-Dimensional Scope Restriction}
 \author{}
-\date{2026-07-30}
+\date{2026-08-04}
 
 \begin{document}
 \maketitle
@@ -53,73 +54,98 @@ More generally, without assuming trace preservation, the source gives
 It also gives the corresponding proportional-identity criterion for a
 doubly-stochastic map \cite[Proposition~2.1]{Wolf2012Quantum}.
 
-\section{The square specialization}
-
-The present Choi matrix takes a linear endomorphism
-$T:\MN{D}\to\MN{D}$ and produces an operator on
-$\C^D\otimes\C^D$.\footnote{Formal definition:
-\leanid{ChoiJamiolkowski.choiMatrix} in
-\doclink{TNLean/Channel/ChoiJamiolkowski}.}
-Within this specialization, the development proves the complete-positivity
-equivalence, the Hermiticity-preservation equivalence, and the implication
-from trace preservation to
-\begin{align}
-    \tr_A(\tau_T)&=\frac{\Id_D}{D}.
-\end{align}
-It consequently proves $\tr(\tau_T)=1$ for trace-preserving maps.  It does not
-yet prove the general adjoint partial-trace identity or the general trace
-normalization identity displayed above.
-Thus these results agree with Wolf Proposition~2.1 after imposing $d=d'$,
-but they do not constitute its different-dimension statement.
-
-\section{Missing clauses}
-
-For arbitrary $d$ and $d'$, the remaining work is to construct both directions
-of the correspondence, prove the trace-pairing formula, and derive the
-Hermiticity, complete-positivity, unitality, trace-preservation, and
-doubly-stochastic equivalences.  In particular, the converse partial-trace
-implications, the general adjoint partial-trace identity, the general trace
-normalization identity, and the proportional-identity clauses should be
-established rather than inferred from the square specialization.
-
-The natural complete-positivity predicate is the existence of rectangular
-Kraus operators $A_i\in M_{d'\times d}(\C)$ satisfying
-\begin{align}
-    T(X)&=\sum_i A_i X A_i^\dagger.
-\end{align}
-Using this predicate keeps the Choi correspondence compatible with the
-rectangular Kraus representation already used elsewhere in the development.
-
-\section{The related Kraus-representation restriction}
-
-Wolf Theorem~2.1 states that a map
-$T:\MN{d}\to\MN{d'}$ is completely positive if and only if it has a
-rectangular Kraus representation
+Wolf Theorem~2.1 states that $T$ is completely positive if and only if it
+has a rectangular Kraus representation
 \begin{align}
     T(X)&=\sum_{j=1}^{r}K_jXK_j^\dagger,
-    &K_j&\in M_{d'\times d}(\C).
+    &K_j&\in M_{d'\times d}(\C),
     \tag{Wolf 2.8}
 \end{align}
-It further identifies the trace-preserving and unital normalizations, the
-minimal value $r=\operatorname{rank}(\tau_T)\leq dd'$, an orthogonal minimal
-family, and the unitary freedom after padding the smaller family with zero
+and identifies the trace-preserving and unital normalizations, the minimal
+value $r=\operatorname{rank}(\tau_T)\leq dd'$, an orthogonal minimal family,
+and the unitary freedom after padding the smaller family with zero
 operators \cite[Theorem~2.1]{Wolf2012Quantum}.
 
-The present development contains rectangular Kraus predicates and several
-normalization and freedom results, but not this full arbitrary-dimensional
-package.  The missing work is the rectangular existence equivalence together
-with the minimal-rank and orthogonal-family conclusions, followed by the
-padded-unitary classification in the source's stated generality.
+\section{Resolution}
+
+The different-dimension statements are now formalized.  The rectangular
+Choi development\footnote{Formal module:
+\doclink{TNLean/Channel/ChoiRectangular}; namespace
+\leanid{ChoiRectangular}.} defines the Choi matrix
+\leanid{choiMatrix} on $\C^{d'}\otimes\C^{d}$ and proves
+\begin{itemize}
+    \item the mutual-inverse pair \leanid{mapOfChoiMatrix_choiMatrix} and
+        \leanid{choiMatrix_mapOfChoiMatrix};
+    \item the trace-pairing formula \leanid{trace_pairing};
+    \item the Hermiticity clause
+        \leanid{choiMatrix_isHermitian_iff_hermiticityPreserving};
+    \item the complete-positivity clause
+        \leanid{isKrausCP_iff_choiMatrix_posSemidef};
+    \item the unitality clause
+        \leanid{unital_iff_traceRight_choiMatrix}, from the identity
+        \leanid{traceRight_choiMatrix} ($\tr_B(\tau_T)=T(\Id)/d$);
+    \item the trace-preservation clause
+        \leanid{tracePreserving_iff_traceLeft_choiMatrix}, from the identity
+        \leanid{traceLeft_choiMatrix}
+        ($\tr_A(\tau_T)=(T^*(\Id))^{T}/d$);
+    \item the normalization clause \leanid{trace_choiMatrix}
+        ($\tr(\tau_T)=\tr(T^*(\Id))/d$);
+    \item the doubly-stochastic clause
+        \leanid{doublyStochastic_iff_partialTraces_proportional}.
+\end{itemize}
+The rectangular Kraus development\footnote{Formal module:
+\doclink{TNLean/Channel/KrausRectangular}; same namespace.} proves the
+normalization equivalences \leanid{kraus_tp_iff_sum_conjTranspose_mul} and
+\leanid{kraus_unital_iff_sum_mul_conjTranspose}, the minimality of the
+Kraus rank \leanid{choiRank_isLeast_hasKrausCard_of_isKrausCP} with bound
+\leanid{choiRank_le_mul} ($r=\operatorname{rank}(\tau_T)\leq dd'$), the
+orthogonal minimal family \leanid{exists_kraus_orthogonal_of_isKrausCP},
+and the padded unitary freedom \leanid{kraus_isometry_freedom_iff} and
+\leanid{kraus_unitary_freedom_iff}.
+
+The complete-positivity predicate is \leanid{IsKrausCP}, the existence of
+rectangular Kraus operators, which is the notion used elsewhere in the
+development; the Choi correspondence is phrased relative to it.
+
+\section{Surviving square-only declarations}
+
+The following declarations remain square-only.  Each is the $d=d'$
+specialization of a rectangular result proved above, not an independent
+scope gap; they are retained because existing callers use them.
+
+\begin{itemize}
+    \item \leanid{ChoiJamiolkowski.choiMatrix} and its correspondence
+        clauses.  The square Choi matrix is definitionally the rectangular
+        one at $d=d'$ (\leanid{ChoiRectangular.choiMatrix_eq_choiJamiolkowski}),
+        and each square clause is the specialization of the rectangular
+        clause with the same name.
+    \item \leanid{IsTracePreservingMap} and \leanid{IsChannel}.  These
+        predicates are stated for endomorphisms of a single matrix algebra.
+        The rectangular development states trace preservation pointwise,
+        $\tr(T(X))=\tr(X)$; the channel structure (complete positivity
+        plus trace preservation) is covered for rectangular maps by
+        \leanid{IsKrausCPTP}.
+    \item \leanid{Channel.HasKrausCard}, \leanid{Channel.HasKrausRankLE},
+        and \leanid{Channel.choiRank}.  The square cardinality and rank
+        predicates specialize \leanid{ChoiRectangular.HasKrausCard},
+        \leanid{ChoiRectangular.HasKrausRankLE}, and
+        \leanid{ChoiRectangular.choiRank}.
+    \item The square Kraus-freedom theorems
+        \leanid{kraus_isometry_freedom_iff} and
+        \leanid{kraus_unitary_freedom_iff} in
+        \doclink{TNLean/Channel/KrausUnitaryFreedom}.  The rectangular
+        namespace carries the general-dimension forms
+        \leanid{ChoiRectangular.kraus_isometry_freedom_iff} and
+        \leanid{ChoiRectangular.kraus_unitary_freedom_iff}.
+\end{itemize}
 
 \section{Verdict}
 
-These are \emph{scope restrictions}: the proved Choi and Kraus results are
-mathematically correct in their stated settings, while Wolf Proposition~2.1
-and Theorem~2.1 allow independent input and output dimensions and include the
-additional clauses above.  The source-labelled blueprint entries therefore
-state the restrictions explicitly.  The restrictions can be removed once the
-different-dimension statements have been proved.\footnote{Formal follow-up:
-\ghissue{3987}.}
+The scope restriction recorded here on 2026-07-30 is \emph{lifted}: Wolf
+Proposition~2.1 and Theorem~2.1 are formalized at the source's generality,
+with independent input and output dimensions and all displayed clauses.
+No hypothesis strengthening remains, and no source-level gap survives in
+this area.  Resolved in \ghissue{3987}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Formalizes Wolf *Quantum Channels & Operations*, Chapter 2, **Proposition 2.1**
(Choi–Jamiolkowski representation of maps, `Notes/WolfNoteTexSource/ch02_representations.tex`
lines 60–126) and **Theorem 2.1** (Kraus representation, lines 229–273) for linear
maps `T : M_d(ℂ) → M_{d'}(ℂ)` between matrix algebras of **possibly different
dimensions** — closing the square-only scope restriction previously recorded in
`docs/paper-gaps/choi_rectangular_scope.tex`.

Closes LionSR/QICLean#208

## Main declarations

**New module `TNLean/Channel/ChoiRectangular.lean`** (namespace `ChoiRectangular`):
- `choiMatrix` — the rectangular Choi matrix `τ = (T ⊗ id_d)(|Ω⟩⟨Ω|)` on `ℂ^{d'} ⊗ ℂ^d`,
  with the normalized maximally entangled vector on the **input** factor
- `mapOfChoiMatrix`, `mapOfChoiMatrix_choiMatrix`, `choiMatrix_mapOfChoiMatrix`,
  `choiMatrix_injective` — the mutual-inverse pair of Eq. (2.1)/(2.4)
- `trace_pairing` — `tr[A T(B)] = d·tr[τ (A ⊗ Bᵀ)]`
- `choiMatrix_isHermitian_iff_hermiticityPreserving` — Hermiticity clause
- `isKrausCP_iff_choiMatrix_posSemidef`, `exists_isKrausCP_of_posSemidef` — CP clause
  (against the existing `IsKrausCP` predicate)
- `traceRight_choiMatrix`, `unital_iff_traceRight_choiMatrix` — unitality clause
- `traceLeft_choiMatrix` (`tr_A(τ) = (T*(𝟙))ᵀ/d`),
  `traceAdjointMap_one_eq_one_iff_tracePreserving`,
  `tracePreserving_iff_traceLeft_choiMatrix` — trace-preservation clause
- `trace_choiMatrix` (`tr(τ) = tr(T*(𝟙))/d`) — normalization clause
- `doublyStochastic_iff_partialTraces_proportional` — doubly-stochastic clause
- `choiMatrix_eq_choiJamiolkowski` — the square development is the `d = d'` specialization (defeq)

**New module `TNLean/Channel/KrausRectangular.lean`** (same namespace):
- `HasKrausCard`, `HasKrausRankLE`, `choiRank`, `hasKrausCard_mono`
- `kraus_tp_iff_sum_conjTranspose_mul`, `kraus_unital_iff_sum_mul_conjTranspose` — normalization (item 1)
- `hasKrausCard_choiRank_of_isKrausCP`, `choiRank_le_of_hasKrausCard`,
  `choiRank_isLeast_hasKrausCard_of_isKrausCP`, `choiRank_le_mul` — minimal number `r = rank(τ) ≤ d·d'` (item 2)
- `exists_kraus_orthogonal_of_isKrausCP` — Hilbert–Schmidt orthogonal minimal family,
  `tr[Kᵢ†Kⱼ] ∝ δᵢⱼ` (item 3)
- `kraus_isometry_freedom`, `kraus_isometry_freedom_iff`, `kraus_unitary_freedom_iff`,
  `kraus_same_map_of_isometry_combination`, `kraus_dual_eq_of_map_eq`,
  `kraus_conjTranspose_mul_eq_of_map_eq` — padded unitary freedom (item 4)

**Adjusted:** `Matrix.mul_single_mul_conjTranspose_eq_vecMulVec` generalized to
rectangular `K` (square callers unchanged; verified `ChoiJamiolkowski.lean` and
`KrausRank.lean` still compile).

## Proof integrity

- No `sorry`/`admit`/`native_decide`/`axiom`/kernel bypasses in changed files.
- `#print axioms` on all 31 main theorems: every one reports exactly
  `[propext, Classical.choice, Quot.sound]`.
- `lake env lean` clean (no warnings) on both new modules;
  `lake build TNLean.Channel` green.

## Blueprint

- `blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex`: new sections
  *The Choi–Jamiolkowski representation of maps between matrix algebras* and
  *The Kraus representation theorem for rectangular matrix algebras*, with
  `\lean`/`\leanok` on the new rectangular declarations only (no square-specialization
  `\leanok` for source-level items). Labels: `def:choi_matrix_rect`,
  `thm:choi_rect_mutual_inverse`, `thm:choi_rect_trace_pairing`,
  `thm:choi_rect_hermiticity`, `thm:choi_rect_cp`, `thm:choi_rect_unital`,
  `thm:choi_rect_tp`, `thm:choi_rect_normalization`, `thm:choi_rect_doubly_stochastic`,
  `thm:kraus_rect_normalization`, `def:kraus_rank_rect`,
  `thm:kraus_rect_rank_minimal`, `thm:kraus_rect_orthogonal`, `thm:kraus_rect_freedom`.
- `python3 scripts/blueprint_lean_sync.py --ci`: 6429/6429 in sync.
- `lake exe checkdecls blueprint/lean_decls`: 0 missing.
- Full blueprint PDF compiles (853 pages, no undefined references).
- `TNLean/Channel/WolfChapter2Index.lean` coverage summary updated.

## Paper-gap notes

`docs/paper-gaps/choi_rectangular_scope.tex` rewritten: the scope restriction is
**lifted**; surviving square-only declarations (`ChoiJamiolkowski.choiMatrix` API,
`IsTracePreservingMap`, `IsChannel`, `Channel.HasKrausCard`/`choiRank`, square
freedom theorems) are documented as `d = d'` specializations retained for existing
callers. No source-level gap survives; no proof follows a route absent from the
source (mutual inverses via the slice identity `d|Ω⟩⟨Ω| = F^{T_B}`; CP via the
spectral decomposition of `τ ≥ 0`; freedom via equal Gram matrices of the
vectorized Kraus operators, matching the "equivalence of ensembles" proposition).

## Salvage notes (branch `claude/issue-3987-wolf-ch2-rectangular-choi-and`)

- **Adopted:** the source-faithful design of the deleted
  `TNLean/Channel/ChoiRectangular.lean` (commit `604dba5ec`, later removed in
  `cfcb2acb0` "narrow to compiled scope"): the Choi matrix as
  `tensorMapId T (omegaProj d)` with output factor first, the entrywise inverse
  assignment, and the omega-slice approach. Also adopted the branch's paper-gap
  note `docs/paper-gaps/choi_rectangular_scope.tex` (rewritten here as a
  resolution note).
- **Rewrote:** all proofs (the salvaged module did not compile); replaced the
  duplicate `IsCPMapRect` predicate with the existing `IsKrausCP`.
- **Added beyond the salvage:** the general adjoint partial-trace identity
  `tr_A(τ) = (T*(𝟙))ᵀ/d`, the TP/unital converse directions, the doubly-stochastic
  clause, Wolf's exact normalization form `tr(τ) = tr(T*(𝟙))/d`, and the entire
  rectangular Kraus theorem (rank minimality, orthogonal family, padded freedom).
- The branch tip's scope-restriction comments in
  `ch04_channels_choi_foundations.tex` / `ch16_channel_representations_choi_and_kraus.tex`
  (already on main) remain accurate — those entries present the square theorems as
  specializations — and are untouched.

## Test plan

- [x] `lake env lean TNLean/Channel/ChoiRectangular.lean` / `KrausRectangular.lean` clean
- [x] `lake build TNLean.Channel` green
- [x] `rg "sorry|admit|native_decide|axiom"` clean on changed files
- [x] `#print axioms` standard-only on all main theorems
- [x] blueprint sync 100%, checkdecls 0 missing, blueprint PDF compiles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new proof surface (~1.4k lines) in core channel theory with no axioms/sorry claimed, but mistakes in Choi–Kraus equivalences would affect downstream formalizations that import `TNLean.Channel`.
> 
> **Overview**
> Formalizes Wolf Chapter 2 **Proposition 2.1** and **Theorem 2.1** for linear maps `T : M_d(ℂ) → M_{d'}(ℂ)` with independent input and output dimensions, closing the square-only scope noted in `docs/paper-gaps/choi_rectangular_scope.tex`.
> 
> **`TNLean/Channel/ChoiRectangular.lean`** introduces `choiMatrix` / `mapOfChoiMatrix` on `ℂ^{d'} ⊗ ℂ^d`, mutual inverses, trace pairing, and the Hermiticity, complete positivity (`IsKrausCP` ↔ PSD Choi), unitality, trace preservation via `traceAdjointMap`, trace normalization, and doubly-stochastic partial-trace clauses. **`TNLean/Channel/KrausRectangular.lean`** adds rectangular Kraus cardinality/`choiRank`, TP/unital sum identities, minimal rank `r = rank(τ) ≤ d·d'`, an orthogonal minimal Kraus family, and padded isometric/unitary freedom.
> 
> Supporting edits: **`Matrix.mul_single_mul_conjTranspose_eq_vecMulVec`** allows rectangular `K`; **`ChoiJamiolkowski.omegaCoeff_eq_inv`** is public; channel aggregator and **`WolfChapter2Index`** document coverage; blueprint **`ch04_channels_rectangular_kraus_maps.tex`** gains linked sections; the paper-gap doc is rewritten as a **resolution** (issue LionSR/QICLean#208).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75c190f8b3428305630b2bbc8055390de719619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->