### PR TITLE
feat(Channel/Peripheral): trivial Jordan blocks for peripheral spectrum (Wolf Prop 6.2)

### DIFF
--- a/TNLean/Channel/Peripheral.lean
+++ b/TNLean/Channel/Peripheral.lean
@@ -21,6 +21,7 @@ import TNLean.Channel.Peripheral.CyclicDecomposition.Primitivity
 import TNLean.Channel.Peripheral.CyclicGroup
 import TNLean.Channel.Peripheral.GroupStructure
 import TNLean.Channel.Peripheral.IrreducibleChannel
+import TNLean.Channel.Peripheral.JordanBlocks
 import TNLean.Channel.Peripheral.MultiCycleDecomposition
 import TNLean.Channel.Peripheral.PeriodicityRemoval
 import TNLean.Channel.Peripheral.Powers

--- a/TNLean/Channel/Peripheral/JordanBlocks.lean
+++ b/TNLean/Channel/Peripheral/JordanBlocks.lean
@@ -1,0 +1,280 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.MeanErgodicProjection
+import Mathlib.Analysis.Matrix.Normed
+
+/-!
+# Trivial Jordan blocks for peripheral eigenvalues — Wolf Proposition 6.2
+
+**Wolf Proposition 6.2**: Let $T: M_d(\mathbb{C}) \to M_d(\mathbb{C})$ be a
+trace-preserving (or unital) positive linear map. If $\lambda$ is an eigenvalue
+of $T$ with $|\lambda| = 1$, then its geometric multiplicity equals its algebraic
+multiplicity, i.e., all Jordan blocks for $\lambda$ are one-dimensional.
+
+The proof: if a Jordan block of size $\ge 2$ existed, the binomial expansion
+$T^n = (\lambda I + N)^n$ applied to a rank-$2$ generalized eigenvector
+would produce a term proportional to $n$, giving $\|T^n X\| \ge n\|Y\| - \|X\|$,
+which grows without bound. This contradicts the bounded-orbit theorem
+for positive trace-preserving maps.
+
+## Main results
+
+* `IsPositiveMap.no_rank_two_genEigenvector_of_tracePreserving`:
+  $\ker(T-\lambda)^2 = \ker(T-\lambda)$ when $|\lambda| = 1$.
+* `IsPositiveMap.peripheral_Jordan_trivial_of_tracePreserving`:
+  generalized eigenspace equals eigenspace for peripheral eigenvalues.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 6.2][Wolf2012QChannels]
+* Local source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 181--224.
+-/
+
+open scoped Matrix ComplexOrder Matrix.Norms.Frobenius
+open Matrix Filter
+
+variable {D : ℕ}
+
+namespace IsPositiveMap
+
+/-! ### Binomial expansion for rank-2 generalized eigenvectors -/
+
+/-- If $(T - \lambda)^2 X = 0$, then $T^n X = \lambda^n X + n \lambda^{n-1} (T-\lambda)X$.
+
+Proved by induction on $n$ using $T = \lambda I + N$ with $N = T - \lambda I$
+and $N^2 X = 0$.
+
+Source: Wolf, Proposition 6.2 proof, Eq. (6.10); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 181--224. -/
+private lemma pow_apply_rank_two_genEig
+    {V : Type*} [AddCommGroup V] [Module ℂ V]
+    (T : V →ₗ[ℂ] V) (μ : ℂ) (n : ℕ) (X : V)
+    (hN2 : ((T - μ • (1 : V →ₗ[ℂ] V)) ^ 2) X = 0) :
+    (T ^ n) X = (μ ^ n) • X + ((n : ℂ) * μ ^ (n - 1)) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    -- T^{n+1} X = T (T^n) X
+    rw [pow_succ', show (T * T ^ n) X = T ((T ^ n) X) from rfl, ih]
+    -- Now T (μ^n X + n μ^{n-1} (T-μ) X)
+    -- = μ^n T X + n μ^{n-1} T ((T-μ) X)
+    rw [map_add, map_smul, map_smul]
+    -- Compute T X = T X (trivial)
+    -- Compute T ((T-μ) X) = (T-μ+μ)(T-μ)X = (T-μ)^2 X + μ (T-μ) X = μ (T-μ) X
+    -- Because (T-μ)^2 X = 0
+    have h_TTX : T ((T - μ • (1 : V →ₗ[ℂ] V)) X) = μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
+      -- T = (T-μ) + μ, so T((T-μ)X) = (T-μ)^2 X + μ(T-μ)X = μ(T-μ)X (since (T-μ)^2 X = 0)
+      calc
+        T ((T - μ • (1 : V →ₗ[ℂ] V)) X)
+            = ((T - μ • (1 : V →ₗ[ℂ] V)) + μ • (1 : V →ₗ[ℂ] V)) ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by simp
+        _ = (T - μ • (1 : V →ₗ[ℂ] V)) ((T - μ • (1 : V →ₗ[ℂ] V)) X) +
+            (μ • (1 : V →ₗ[ℂ] V)) ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by rw [LinearMap.add_apply]
+        _ = ((T - μ • (1 : V →ₗ[ℂ] V)) ^ 2) X + μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
+          simp [pow_two, LinearMap.smul_apply]
+        _ = 0 + μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by rw [hN2]
+        _ = μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by simp
+    -- Substitute into the expression
+    rw [h_TTX]
+    -- Now we have: μ^n (T X) + n μ^{n-1} (μ (T-μ) X)
+    -- = μ^n (T X) + n μ^n (T-μ) X
+    -- But T X = μ X + (T-μ) X
+    have h_TX : T X = μ • X + (T - μ • (1 : V →ₗ[ℂ] V)) X := by
+      calc
+        T X = ((T - μ • (1 : V →ₗ[ℂ] V)) + μ • (1 : V →ₗ[ℂ] V)) X := by simp
+        _ = (T - μ • (1 : V →ₗ[ℂ] V)) X + (μ • (1 : V →ₗ[ℂ] V)) X := by rw [LinearMap.add_apply]
+        _ = (T - μ • (1 : V →ₗ[ℂ] V)) X + μ • X := by simp
+        _ = μ • X + (T - μ • (1 : V →ₗ[ℂ] V)) X := add_comm _ _
+    rw [h_TX]
+    -- = μ^n (μ X + (T-μ) X) + n μ^n (T-μ) X
+    -- = μ^{n+1} X + μ^n (T-μ) X + n μ^n (T-μ) X
+    -- = μ^{n+1} X + (n+1) μ^n (T-μ) X
+    -- After rw [h_TTX], the LHS has:
+    -- μ^n • (T X) + (n * μ^{n-1}) • μ • ((T-μ)X)
+    -- Replace T X by μ X + (T-μ)X
+    -- T X was already rewritten above
+    -- Goal: μ^n • (μ X + (T-μ)X) + (n*μ^(n-1)) • μ • ((T-μ)X) = RHS
+    -- Simplify smul: combine scalars
+    simp only [smul_add, smul_smul]
+    -- Goal: (μ^n * μ) • X + (μ^n + (μ * (↑n * μ^(n-1)))) • (T-μ)X = μ^(n+1) • X + (↑(n+1) * μ^(n+1-1)) • (T-μ)X
+    -- Simplify X-term: (μ^n * μ) = μ^(n+1) by ring
+    have hX : (μ ^ n : ℂ) * μ = μ ^ (n + 1) := by ring
+    -- Simplify (T-μ)X-term: μ^n + μ*n*μ^(n-1) = (n+1)*μ^n = ↑(n+1)*μ^{(n+1)-1}
+    have hV : (μ ^ n : ℂ) + (μ : ℂ) * ((n : ℂ) * (μ ^ (n - 1) : ℂ)) = (↑(n + 1) : ℂ) * (μ ^ (n + 1 - 1) : ℂ) := by
+      have h_pow : (μ : ℂ) ^ (n + 1 - 1) = (μ : ℂ) ^ n := by
+        rw [show (n : ℕ) + 1 - 1 = n by omega]
+      rw [h_pow]
+      push_cast
+      -- Goal: μ^n + μ * (n : ℂ) * μ^(n-1) = ((n : ℂ) + 1) * μ^n
+      -- Case split on n=0 vs n≥1
+      rcases Nat.eq_zero_or_pos n with (rfl | hn)
+      · simp
+      · -- n ≥ 1: then μ * μ^(n-1) = μ^n
+        have h_mul_pow : (μ : ℂ) * (μ : ℂ) ^ (n - 1) = (μ : ℂ) ^ n := by
+          rw [← pow_succ', Nat.sub_add_cancel hn]
+        -- Goal: μ^n + μ * (↑n * μ^(n-1)) = (↑n + 1) * μ^n
+        -- Rewrite μ * (↑n * μ^(n-1)) = ↑n * (μ * μ^(n-1)) = ↑n * μ^n
+        calc
+          (μ ^ n : ℂ) + (μ : ℂ) * ((n : ℂ) * (μ : ℂ) ^ (n - 1))
+              = (μ ^ n : ℂ) + ((n : ℂ) * ((μ : ℂ) * (μ : ℂ) ^ (n - 1))) := by ring
+          _ = (μ ^ n : ℂ) + ((n : ℂ) * (μ : ℂ) ^ n) := by rw [h_mul_pow]
+          _ = ((n : ℂ) + 1) * (μ ^ n : ℂ) := by ring
+    -- Goal: μ^(n+1) • X + μ^n • v + (n*μ^(n-1)*μ) • v = μ^(n+1) • X + ((n+1)*μ^(n+1-1)) • v
+    -- where v = (T-μ)X
+    -- Use add_smul to combine the v-terms
+    -- c₁ = μ^n, c₂ = n*μ^(n-1)*μ
+    -- c₁ + c₂ = μ^n + μ*n*μ^(n-1) = (n+1)*μ^n (by hV)
+    -- And μ^(n+1-1) = μ^n
+    -- So the RHS v-coefficient matches the sum
+    have h_v_coeff : (μ ^ n : ℂ) + ((n : ℂ) * (μ ^ (n - 1) : ℂ) * μ) = (↑(n + 1) : ℂ) * (μ ^ (n + 1 - 1) : ℂ) := by
+      -- hV LHS is μ^n + μ*(n*μ^(n-1)) which equals μ^n + n*μ^(n-1)*μ by commutativity
+      simpa [mul_comm, mul_left_comm, mul_assoc] using hV
+    -- The X-term matches by hX
+    rw [hX]
+    -- Now combine v-terms on LHS: μ^n • v + c • v = (μ^n + c) • v = d • v
+    -- Use add_smul in reverse, then h_v_coeff
+    have h_combine : (μ ^ n : ℂ) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) +
+        ((n : ℂ) * (μ ^ (n - 1) : ℂ) * μ) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) =
+        (↑(n + 1) * (μ ^ (n + 1 - 1) : ℂ)) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
+      rw [← add_smul, h_v_coeff]
+    -- Apply this in the larger expression
+    -- The LHS is: μ^{n+1} • X + (μ^n • v + c • v)
+    -- The parenthesization is (μ^{n+1} • X + μ^n • v) + c • v
+    -- We need to rewrite the last two terms
+    -- Use `rw` with `add_comm` and `add_assoc` to bring the v-terms together
+    -- The LHS is: μ^(n+1) • X + μ^n • v + c • v
+    -- where v = (T-μ)X, c = n*μ^(n-1)*μ
+    -- Regroup: μ^(n+1) • X + (μ^n • v + c • v)
+    -- Then apply h_combine to the parenthesized part
+    rw [add_assoc, h_combine]
+
+/-- **Wolf Proposition 6.2** (key step): For a positive trace-preserving map,
+no rank-2 generalized eigenvector exists at a peripheral eigenvalue.
+
+If $(T-\lambda)^2 X = 0$ with $|\lambda| = 1$, then $(T-\lambda)X = 0$.
+
+Source: Wolf, *Quantum Channels & Operations*, Proposition 6.2; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 181--224. -/
+theorem no_rank_two_genEigenvector_of_tracePreserving
+    [NeZero D] {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (μ : ℂ) (hμ_norm : ‖μ‖ = 1) (X : Matrix (Fin D) (Fin D) ℂ)
+    (hN2 : ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2) X = 0) :
+    (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) X = 0 := by
+  set N := T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+  by_contra h_not
+  have hNX_ne_zero : N X ≠ 0 := h_not
+  have hNX_norm_pos : 0 < ‖N X‖ := norm_pos_iff.mpr hNX_ne_zero
+  have hbounded : T.HasBoundedOrbits :=
+    hPos.hasBoundedOrbits_of_tracePreserving hTP
+  -- Binomial expansion: T^n X = μ^n X + n μ^{n-1} (N X)
+  have h_pow_formula (n : ℕ) : (T ^ n) X = (μ ^ n) • X + ((n : ℂ) * μ ^ (n - 1)) • (N X) :=
+    pow_apply_rank_two_genEig T μ n X hN2
+  -- Norm lower bound: ‖T^n X‖ ≥ n ‖N X‖ - ‖X‖
+  -- Uses: ‖a + b‖ ≥ ‖b‖ - ‖a‖, and ‖μ^k‖ = 1 for all k
+  have h_norm_μ_pow (k : ℕ) : ‖μ ^ k‖ = 1 := by
+    rw [norm_pow, hμ_norm, one_pow]
+  have h_norm_bound (n : ℕ) : (n : ℝ) * ‖N X‖ - ‖X‖ ≤ ‖(T ^ n) X‖ := by
+    rw [h_pow_formula n]
+    -- Let a = n μ^{n-1} (N X), b = μ^n X
+    -- ‖a + b‖ ≥ ‖a‖ - ‖b‖
+    have h_rev_triangle : ‖((n : ℂ) * μ ^ (n - 1)) • (N X)‖ ≤
+        ‖((n : ℂ) * μ ^ (n - 1)) • (N X) + (μ ^ n) • X‖ + ‖(μ ^ n) • X‖ := by
+      calc
+        ‖((n : ℂ) * μ ^ (n - 1)) • (N X)‖
+            = ‖(((n : ℂ) * μ ^ (n - 1)) • (N X) + (μ ^ n) • X) - (μ ^ n) • X‖ := by simp
+        _ ≤ ‖((n : ℂ) * μ ^ (n - 1)) • (N X) + (μ ^ n) • X‖ + ‖(μ ^ n) • X‖ :=
+          norm_sub_le _ _
+    -- Compute norms of the pieces
+    have h_norm_a : ‖((n : ℂ) * μ ^ (n - 1)) • (N X)‖ = (n : ℝ) * ‖N X‖ := by
+      rw [norm_smul, norm_mul, h_norm_μ_pow (n - 1), mul_one, Complex.norm_natCast]
+    have h_norm_b : ‖(μ ^ n) • X‖ = ‖X‖ := by
+      rw [norm_smul, h_norm_μ_pow n, one_mul]
+    rw [h_norm_a, h_norm_b] at h_rev_triangle
+    -- Rearranged: (n)*‖NX‖ - ‖X‖ ≤ ‖...‖
+    -- Using a - b ≤ c ↔ a ≤ c + b
+    have h_goal : (n : ℝ) * ‖N X‖ - ‖X‖ ≤ ‖(μ ^ n) • X + ((n : ℂ) * μ ^ (n - 1)) • (N X)‖ := by
+      rw [sub_le_iff_le_add]
+      simpa [add_comm] using h_rev_triangle
+    simpa [add_comm] using h_goal
+  -- For large n, n * ‖N X‖ exceeds any bound → contradicts bounded orbits
+  rcases isBounded_iff_forall_norm_le.mp (hbounded X) with ⟨C, hC⟩
+  -- hC : ∀ x ∈ Set.range (fun n => (T ^ n) X), ‖x‖ ≤ C
+  -- Pick n large enough so that n * ‖N X‖ - ‖X‖ > C
+  have hpos : 0 < ‖N X‖ := hNX_norm_pos
+  obtain ⟨n, hn⟩ : ∃ n : ℕ, C + ‖X‖ < (n : ℝ) * ‖N X‖ := by
+    have h_arch := exists_nat_gt ((C + ‖X‖) / ‖N X‖)
+    rcases h_arch with ⟨n, hn⟩
+    refine ⟨n, (div_lt_iff₀ hpos).mp hn⟩
+  have hC_n := hC ((T^[n]) X) ⟨n, rfl⟩
+  have h_bound_n := h_norm_bound n
+  -- h_bound_n: (n:ℝ)*‖NX‖ - ‖X‖ ≤ ‖(T^n)X‖ = ‖(T^[n])X‖
+  -- hC_n: ‖(T^[n])X‖ ≤ C
+  -- hn: C + ‖X‖ < (n:ℝ)*‖NX‖
+  -- Therefore C < (n:ℝ)*‖NX‖ - ‖X‖ ≤ C, contradiction
+  nlinarith
+
+/-- **Wolf Proposition 6.2** (full statement): For a positive trace-preserving map,
+the generalized eigenspace for any peripheral eigenvalue $\lambda$ equals
+the eigenspace: $\ker(T-\lambda)^k = \ker(T-\lambda)$ for all $k \ge 1$.
+
+In other words, peripheral eigenvalues have trivial Jordan blocks
+(algebraic multiplicity equals geometric multiplicity).
+
+Source: Wolf, *Quantum Channels & Operations*, Proposition 6.2; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 181--224. -/
+theorem peripheral_Jordan_trivial_of_tracePreserving
+    [NeZero D] {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (μ : ℂ) (hμ_norm : ‖μ‖ = 1) (k : ℕ) (X : Matrix (Fin D) (Fin D) ℂ)
+    (hNk : ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ k) X = 0) :
+    (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) X = 0 := by
+  -- Prove by induction on k that ((T-μ)^k) X = 0 implies (T-μ) X = 0
+  induction k with
+  | zero =>
+    have hX_zero : X = 0 := by simpa using hNk
+    simp [hX_zero]
+  | succ m ih =>
+    by_cases hm : m = 0
+    · subst hm; simpa using hNk
+    · -- m ≥ 1, rank-2 reduction
+      have hm_pos : 0 < m := Nat.pos_of_ne_zero hm
+      set Y := ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1)) X
+      have hN2_Y : ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2) Y = 0 := by
+        dsimp [Y]
+        -- (T-μ)^2 ((T-μ)^{m-1} X) = ((T-μ)^2 * (T-μ)^{m-1}) X = (T-μ)^{2+(m-1)} X = (T-μ)^{m+1} X
+        have : ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2) Y =
+            ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (2 + (m - 1))) X := by
+          dsimp [Y]
+          calc
+            ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2)
+                (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1)) X)
+                = (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2) *
+                   ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1))) X := rfl
+            _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (2 + (m - 1))) X := by
+              rw [pow_add]
+        rw [this, show (2 : ℕ) + (m - 1) = m + 1 by omega]
+        exact hNk
+      have hN1_Y : (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) Y = 0 :=
+        hPos.no_rank_two_genEigenvector_of_tracePreserving hTP μ hμ_norm Y hN2_Y
+      dsimp [Y] at hN1_Y
+      -- hN1_Y: (T - μ•1) ((T - μ•1)^(m-1) X) = 0
+      -- We need: ((T - μ•1)^m) X = 0
+      -- Since (T-μ•1) ∘ (T-μ•1)^(m-1) = (T-μ•1)^m when m ≥ 1
+      have hm_pos : 0 < m := Nat.pos_of_ne_zero hm
+      rw [show (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ))
+          ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1) X)
+          = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ m) X by
+        calc
+          _ = (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ))) *
+               ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1))) X := rfl
+          _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (1 + (m - 1))) X := by
+            rw [pow_add]
+          _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ m) X := by
+            rw [show (1 : ℕ) + (m - 1) = m by omega]
+      ] at hN1_Y
+      exact ih hN1_Y
+
+end IsPositiveMap

--- a/TNLean/Channel/Peripheral/JordanBlocks.lean
+++ b/TNLean/Channel/Peripheral/JordanBlocks.lean
@@ -53,20 +53,25 @@ lemma pow_apply_rank_two_genEig
     {V : Type*} [AddCommGroup V] [Module ℂ V]
     (T : V →ₗ[ℂ] V) (μ : ℂ) (n : ℕ) (X : V)
     (hN2 : ((T - μ • (1 : V →ₗ[ℂ] V)) ^ 2) X = 0) :
-    (T ^ n) X = (μ ^ n) • X + ((n : ℂ) * μ ^ (n - 1)) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
+    (T ^ n) X = (μ ^ n) • X +
+      ((n : ℂ) * μ ^ (n - 1)) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
   induction n with
   | zero => simp
   | succ n ih =>
     rw [pow_succ', show (T * T ^ n) X = T ((T ^ n) X) from rfl, ih]
     rw [map_add, map_smul, map_smul]
-    have h_TTX : T ((T - μ • (1 : V →ₗ[ℂ] V)) X) = μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
+    have h_TTX : T ((T - μ • (1 : V →ₗ[ℂ] V)) X) =
+        μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
       -- T = (T-μ) + μ, so T((T-μ)X) = (T-μ)^2 X + μ(T-μ)X = μ(T-μ)X (since (T-μ)^2 X = 0)
       calc
         T ((T - μ • (1 : V →ₗ[ℂ] V)) X)
-            = ((T - μ • (1 : V →ₗ[ℂ] V)) + μ • (1 : V →ₗ[ℂ] V)) ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by simp
+            = ((T - μ • (1 : V →ₗ[ℂ] V)) + μ • (1 : V →ₗ[ℂ] V))
+                ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by simp
         _ = (T - μ • (1 : V →ₗ[ℂ] V)) ((T - μ • (1 : V →ₗ[ℂ] V)) X) +
-            (μ • (1 : V →ₗ[ℂ] V)) ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by rw [LinearMap.add_apply]
-        _ = ((T - μ • (1 : V →ₗ[ℂ] V)) ^ 2) X + μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
+            (μ • (1 : V →ₗ[ℂ] V)) ((T - μ • (1 : V →ₗ[ℂ] V)) X) :=
+          by rw [LinearMap.add_apply]
+        _ = ((T - μ • (1 : V →ₗ[ℂ] V)) ^ 2) X +
+            μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
           simp [pow_two, LinearMap.smul_apply]
         _ = 0 + μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by rw [hN2]
         _ = μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by simp
@@ -76,7 +81,8 @@ lemma pow_apply_rank_two_genEig
     have h_TX : T X = μ • X + (T - μ • (1 : V →ₗ[ℂ] V)) X := by
       calc
         T X = ((T - μ • (1 : V →ₗ[ℂ] V)) + μ • (1 : V →ₗ[ℂ] V)) X := by simp
-        _ = (T - μ • (1 : V →ₗ[ℂ] V)) X + (μ • (1 : V →ₗ[ℂ] V)) X := by rw [LinearMap.add_apply]
+        _ = (T - μ • (1 : V →ₗ[ℂ] V)) X + (μ • (1 : V →ₗ[ℂ] V)) X :=
+          by rw [LinearMap.add_apply]
         _ = (T - μ • (1 : V →ₗ[ℂ] V)) X + μ • X := by simp
         _ = μ • X + (T - μ • (1 : V →ₗ[ℂ] V)) X := add_comm _ _
     rw [h_TX]
@@ -89,7 +95,8 @@ lemma pow_apply_rank_two_genEig
     simp only [smul_add, smul_smul]
     have hX : (μ ^ n : ℂ) * μ = μ ^ (n + 1) := by ring
     -- Simplify (T-μ)X-term: μ^n + μ*n*μ^(n-1) = (n+1)*μ^n = ↑(n+1)*μ^{(n+1)-1}
-    have hV : (μ ^ n : ℂ) + (μ : ℂ) * ((n : ℂ) * (μ ^ (n - 1) : ℂ)) = (↑(n + 1) : ℂ) * (μ ^ (n + 1 - 1) : ℂ) := by
+    have hV : (μ ^ n : ℂ) + (μ : ℂ) * ((n : ℂ) * (μ ^ (n - 1) : ℂ))
+        = (↑(n + 1) : ℂ) * (μ ^ (n + 1 - 1) : ℂ) := by
       have h_pow : (μ : ℂ) ^ (n + 1 - 1) = (μ : ℂ) ^ n := by
         rw [show (n : ℕ) + 1 - 1 = n by omega]
       rw [h_pow]
@@ -104,7 +111,8 @@ lemma pow_apply_rank_two_genEig
               = (μ ^ n : ℂ) + ((n : ℂ) * ((μ : ℂ) * (μ : ℂ) ^ (n - 1))) := by ring
           _ = (μ ^ n : ℂ) + ((n : ℂ) * (μ : ℂ) ^ n) := by rw [h_mul_pow]
           _ = ((n : ℂ) + 1) * (μ ^ n : ℂ) := by ring
-    have h_v_coeff : (μ ^ n : ℂ) + ((n : ℂ) * (μ ^ (n - 1) : ℂ) * μ) = (↑(n + 1) : ℂ) * (μ ^ (n + 1 - 1) : ℂ) := by
+    have h_v_coeff : (μ ^ n : ℂ) + ((n : ℂ) * (μ ^ (n - 1) : ℂ) * μ)
+        = (↑(n + 1) : ℂ) * (μ ^ (n + 1 - 1) : ℂ) := by
       -- hV LHS is μ^n + μ*(n*μ^(n-1)) which equals μ^n + n*μ^(n-1)*μ by commutativity
       simpa [mul_comm, mul_left_comm, mul_assoc] using hV
     rw [hX]
@@ -143,7 +151,8 @@ theorem no_rank_two_genEigenvector_of_tracePreserving
   have hbounded : T.HasBoundedOrbits :=
     hPos.hasBoundedOrbits_of_tracePreserving hTP
   -- Binomial expansion: T^n X = μ^n X + n μ^{n-1} (N X)
-  have h_pow_formula (n : ℕ) : (T ^ n) X = (μ ^ n) • X + ((n : ℂ) * μ ^ (n - 1)) • (N X) :=
+  have h_pow_formula (n : ℕ) :
+      (T ^ n) X = (μ ^ n) • X + ((n : ℂ) * μ ^ (n - 1)) • (N X) :=
     pow_apply_rank_two_genEig T μ n X hN2
   -- Norm lower bound: ‖T^n X‖ ≥ n ‖N X‖ - ‖X‖
   -- Uses: ‖a + b‖ ≥ ‖b‖ - ‖a‖, and ‖μ^k‖ = 1 for all k
@@ -168,7 +177,8 @@ theorem no_rank_two_genEigenvector_of_tracePreserving
     rw [h_norm_a, h_norm_b] at h_rev_triangle
     -- Rearranged: (n)*‖NX‖ - ‖X‖ ≤ ‖...‖
     -- Using a - b ≤ c ↔ a ≤ c + b
-    have h_goal : (n : ℝ) * ‖N X‖ - ‖X‖ ≤ ‖(μ ^ n) • X + ((n : ℂ) * μ ^ (n - 1)) • (N X)‖ := by
+    have h_goal : (n : ℝ) * ‖N X‖ - ‖X‖ ≤
+        ‖(μ ^ n) • X + ((n : ℂ) * μ ^ (n - 1)) • (N X)‖ := by
       rw [sub_le_iff_le_add]
       simpa [add_comm] using h_rev_triangle
     simpa [add_comm] using h_goal
@@ -190,7 +200,7 @@ theorem no_rank_two_genEigenvector_of_tracePreserving
   -- Now h_bound_n: (n:ℝ)*‖NX‖ - ‖X‖ ≤ ‖(T^[n])X‖
   -- hC_n: ‖(T^[n])X‖ ≤ C
   -- hn: C + ‖X‖ < (n:ℝ)*‖NX‖
-  -- Combine: C + ‖X‖ < (n:ℝ)*‖NX‖, so C < (n:ℝ)*‖NX‖ - ‖X‖ ≤ ‖(T^[n])X‖ ≤ C
+  -- Combine: C + ‖X‖ < n*‖NX‖, so C < n*‖NX‖ - ‖X‖ ≤ ‖(T^[n])X‖ ≤ C
   have h_ineq : C < (n : ℝ) * ‖N X‖ - ‖X‖ := by linarith
   have h_chain : (n : ℝ) * ‖N X‖ - ‖X‖ ≤ C := by
     -- from h_bound_n and hC_n
@@ -221,45 +231,47 @@ theorem peripheral_Jordan_trivial_of_tracePreserving
     have hX_zero : X = 0 := by simpa using hNk
     simp [hX_zero]
   | succ m ih =>
+    set N := T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+      with hN_def
     by_cases hm : m = 0
     · subst hm; simpa using hNk
     · -- m ≥ 1, rank-2 reduction
-      set Y := ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1)) X
-      have hN2_Y : ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2) Y = 0 := by
+      set Y := (N ^ (m - 1)) X
+      have hN2_Y : (N ^ 2) Y = 0 := by
         dsimp [Y]
-        -- (T-μ)^2 ((T-μ)^{m-1} X) = ((T-μ)^2 * (T-μ)^{m-1}) X = (T-μ)^{2+(m-1)} X = (T-μ)^{m+1} X
-        have : ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2) Y =
-            ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (2 + (m - 1))) X := by
+        -- (T-μ)^2((T-μ)^{m-1}X) = ((T-μ)^2*(T-μ)^{m-1})X = (T-μ)^{m+1}X
+        have : (N ^ 2) Y =
+            (N ^ (2 + (m - 1))) X := by
           dsimp [Y]
           calc
-            ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2)
-                (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1)) X)
-                = (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2) *
-                   ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1))) X := rfl
-            _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (2 + (m - 1))) X := by
+            (N ^ 2)
+                ((N ^ (m - 1)) X)
+                = ((N ^ 2) *
+                   (N ^ (m - 1))) X := rfl
+            _ = (N ^ (2 + (m - 1))) X := by
               rw [pow_add]
         rw [this, show (2 : ℕ) + (m - 1) = m + 1 by omega]
         exact hNk
-      have hN1_Y : (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) Y = 0 :=
+      have hN1_Y : N Y = 0 :=
         hPos.no_rank_two_genEigenvector_of_tracePreserving hTP μ hμ_norm Y hN2_Y
       -- hN1_Y: (T - μ•1) Y = 0  where Y = (T-μ•1)^(m-1) X
       -- We need: ((T-μ•1)^m) X = 0 for the induction hypothesis ih
       -- Compute: (T-μ•1) Y = (T-μ•1) ((T-μ•1)^(m-1) X) = ((T-μ•1)^m) X
       -- because (T-μ•1) ∘ (T-μ•1)^(m-1) = (T-μ•1)^m in the endomorphism ring
-      have h_pow_eq : (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) Y
-          = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ m) X := by
+      have h_pow_eq : N Y
+          = (N ^ m) X := by
         dsimp [Y]
         calc
-          (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ))
-              (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1)) X)
-              = (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ))) *
-                 ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1))) X := rfl
-          _ = (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (1 : ℕ)) *
-               ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1))) X := by
+          N
+              ((N ^ (m - 1)) X)
+              = ((N) *
+                 (N ^ (m - 1))) X := rfl
+          _ = ((N ^ (1 : ℕ)) *
+               (N ^ (m - 1))) X := by
             simp
-          _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ ((1 : ℕ) + (m - 1))) X := by
+          _ = (N ^ ((1 : ℕ) + (m - 1))) X := by
             rw [← pow_add]
-          _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ m) X := by
+          _ = (N ^ m) X := by
             rw [show (1 : ℕ) + (m - 1) = m by omega]
       -- Now rewrite hN1_Y using h_pow_eq
       rw [h_pow_eq] at hN1_Y

--- a/TNLean/Channel/Peripheral/JordanBlocks.lean
+++ b/TNLean/Channel/Peripheral/JordanBlocks.lean
@@ -210,11 +210,24 @@ theorem no_rank_two_genEigenvector_of_tracePreserving
     refine ⟨n, (div_lt_iff₀ hpos).mp hn⟩
   have hC_n := hC ((T^[n]) X) ⟨n, rfl⟩
   have h_bound_n := h_norm_bound n
-  -- h_bound_n: (n:ℝ)*‖NX‖ - ‖X‖ ≤ ‖(T^n)X‖ = ‖(T^[n])X‖
+  -- h_bound_n gives bound on ‖(T^n)X‖, but hC_n is about ‖(T^[n])X‖
+  -- Use Module.End.pow_apply to connect them: (T^n)X = (T^[n])X
+  have h_pow_eq : (T ^ n) X = (T^[n]) X := by simpa using Module.End.pow_apply T n X
+  rw [h_pow_eq] at h_bound_n
+  -- Now h_bound_n: (n:ℝ)*‖NX‖ - ‖X‖ ≤ ‖(T^[n])X‖
   -- hC_n: ‖(T^[n])X‖ ≤ C
   -- hn: C + ‖X‖ < (n:ℝ)*‖NX‖
-  -- Therefore C < (n:ℝ)*‖NX‖ - ‖X‖ ≤ C, contradiction
-  nlinarith
+  -- Combine: C + ‖X‖ < (n:ℝ)*‖NX‖, so C < (n:ℝ)*‖NX‖ - ‖X‖ ≤ ‖(T^[n])X‖ ≤ C
+  have h_ineq : C < (n : ℝ) * ‖N X‖ - ‖X‖ := by linarith
+  have h_chain : (n : ℝ) * ‖N X‖ - ‖X‖ ≤ C := by
+    -- from h_bound_n and hC_n
+    -- Actually: h_bound_n: A ≤ B, hC_n: B ≤ C → A ≤ C
+    -- Wait: h_bound_n: A - ‖X‖ ≤ B where A = n*‖NX‖, B = ‖(T^[n])X‖
+    -- hC_n: B ≤ C
+    -- So A - ‖X‖ ≤ B ≤ C → A - ‖X‖ ≤ C
+    -- But we need A - ‖X‖ ≤ C which follows from h_bound_n and hC_n
+    linarith
+  linarith
 
 /-- **Wolf Proposition 6.2** (full statement): For a positive trace-preserving map,
 the generalized eigenspace for any peripheral eigenvalue $\lambda$ equals
@@ -259,22 +272,28 @@ theorem peripheral_Jordan_trivial_of_tracePreserving
         exact hNk
       have hN1_Y : (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) Y = 0 :=
         hPos.no_rank_two_genEigenvector_of_tracePreserving hTP μ hμ_norm Y hN2_Y
-      dsimp [Y] at hN1_Y
-      -- hN1_Y: (T - μ•1) ((T - μ•1)^(m-1) X) = 0
-      -- We need: ((T - μ•1)^m) X = 0
-      -- Since (T-μ•1) ∘ (T-μ•1)^(m-1) = (T-μ•1)^m when m ≥ 1
-      have hm_pos : 0 < m := Nat.pos_of_ne_zero hm
-      rw [show (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ))
-          ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1) X)
-          = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ m) X by
+      -- hN1_Y: (T - μ•1) Y = 0  where Y = (T-μ•1)^(m-1) X
+      -- We need: ((T-μ•1)^m) X = 0 for the induction hypothesis ih
+      -- Compute: (T-μ•1) Y = (T-μ•1) ((T-μ•1)^(m-1) X) = ((T-μ•1)^m) X
+      -- because (T-μ•1) ∘ (T-μ•1)^(m-1) = (T-μ•1)^m in the endomorphism ring
+      have h_pow_eq : (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) Y
+          = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ m) X := by
+        dsimp [Y]
         calc
-          _ = (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ))) *
-               ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1))) X := rfl
-          _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (1 + (m - 1))) X := by
-            rw [pow_add]
+          (T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ))
+              (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1)) X)
+              = (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ))) *
+                 ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1))) X := rfl
+          _ = (((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (1 : ℕ)) *
+               ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1))) X := by
+            simp
+          _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ ((1 : ℕ) + (m - 1))) X := by
+            rw [← pow_add]
           _ = ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ m) X := by
             rw [show (1 : ℕ) + (m - 1) = m by omega]
-      ] at hN1_Y
+      -- Now rewrite hN1_Y using h_pow_eq
+      rw [h_pow_eq] at hN1_Y
       exact ih hN1_Y
+
 
 end IsPositiveMap

--- a/TNLean/Channel/Peripheral/JordanBlocks.lean
+++ b/TNLean/Channel/Peripheral/JordanBlocks.lean
@@ -34,7 +34,7 @@ for positive trace-preserving maps.
 -/
 
 open scoped Matrix ComplexOrder Matrix.Norms.Frobenius
-open Matrix Filter
+open Matrix
 
 variable {D : ℕ}
 
@@ -232,7 +232,7 @@ theorem peripheral_Jordan_trivial_of_tracePreserving
     simp [hX_zero]
   | succ m ih =>
     set N := T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-      with hN_def
+
     by_cases hm : m = 0
     · subst hm; simpa using hNk
     · -- m ≥ 1, rank-2 reduction

--- a/TNLean/Channel/Peripheral/JordanBlocks.lean
+++ b/TNLean/Channel/Peripheral/JordanBlocks.lean
@@ -49,7 +49,7 @@ and $N^2 X = 0$.
 
 Source: Wolf, Proposition 6.2 proof, Eq. (6.10); local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 181--224. -/
-private lemma pow_apply_rank_two_genEig
+lemma pow_apply_rank_two_genEig
     {V : Type*} [AddCommGroup V] [Module ℂ V]
     (T : V →ₗ[ℂ] V) (μ : ℂ) (n : ℕ) (X : V)
     (hN2 : ((T - μ • (1 : V →ₗ[ℂ] V)) ^ 2) X = 0) :
@@ -57,14 +57,8 @@ private lemma pow_apply_rank_two_genEig
   induction n with
   | zero => simp
   | succ n ih =>
-    -- T^{n+1} X = T (T^n) X
     rw [pow_succ', show (T * T ^ n) X = T ((T ^ n) X) from rfl, ih]
-    -- Now T (μ^n X + n μ^{n-1} (T-μ) X)
-    -- = μ^n T X + n μ^{n-1} T ((T-μ) X)
     rw [map_add, map_smul, map_smul]
-    -- Compute T X = T X (trivial)
-    -- Compute T ((T-μ) X) = (T-μ+μ)(T-μ)X = (T-μ)^2 X + μ (T-μ) X = μ (T-μ) X
-    -- Because (T-μ)^2 X = 0
     have h_TTX : T ((T - μ • (1 : V →ₗ[ℂ] V)) X) = μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by
       -- T = (T-μ) + μ, so T((T-μ)X) = (T-μ)^2 X + μ(T-μ)X = μ(T-μ)X (since (T-μ)^2 X = 0)
       calc
@@ -78,9 +72,7 @@ private lemma pow_apply_rank_two_genEig
         _ = μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by simp
     -- Substitute into the expression
     rw [h_TTX]
-    -- Now we have: μ^n (T X) + n μ^{n-1} (μ (T-μ) X)
-    -- = μ^n (T X) + n μ^n (T-μ) X
-    -- But T X = μ X + (T-μ) X
+
     have h_TX : T X = μ • X + (T - μ • (1 : V →ₗ[ℂ] V)) X := by
       calc
         T X = ((T - μ • (1 : V →ₗ[ℂ] V)) + μ • (1 : V →ₗ[ℂ] V)) X := by simp
@@ -91,15 +83,10 @@ private lemma pow_apply_rank_two_genEig
     -- = μ^n (μ X + (T-μ) X) + n μ^n (T-μ) X
     -- = μ^{n+1} X + μ^n (T-μ) X + n μ^n (T-μ) X
     -- = μ^{n+1} X + (n+1) μ^n (T-μ) X
-    -- After rw [h_TTX], the LHS has:
-    -- μ^n • (T X) + (n * μ^{n-1}) • μ • ((T-μ)X)
+
     -- Replace T X by μ X + (T-μ)X
     -- T X was already rewritten above
-    -- Goal: μ^n • (μ X + (T-μ)X) + (n*μ^(n-1)) • μ • ((T-μ)X) = RHS
-    -- Simplify smul: combine scalars
     simp only [smul_add, smul_smul]
-    -- Goal: (μ^n * μ) • X + (μ^n + (μ * (↑n * μ^(n-1)))) • (T-μ)X = μ^(n+1) • X + (↑(n+1) * μ^(n+1-1)) • (T-μ)X
-    -- Simplify X-term: (μ^n * μ) = μ^(n+1) by ring
     have hX : (μ ^ n : ℂ) * μ = μ ^ (n + 1) := by ring
     -- Simplify (T-μ)X-term: μ^n + μ*n*μ^(n-1) = (n+1)*μ^n = ↑(n+1)*μ^{(n+1)-1}
     have hV : (μ ^ n : ℂ) + (μ : ℂ) * ((n : ℂ) * (μ ^ (n - 1) : ℂ)) = (↑(n + 1) : ℂ) * (μ ^ (n + 1 - 1) : ℂ) := by
@@ -107,34 +94,20 @@ private lemma pow_apply_rank_two_genEig
         rw [show (n : ℕ) + 1 - 1 = n by omega]
       rw [h_pow]
       push_cast
-      -- Goal: μ^n + μ * (n : ℂ) * μ^(n-1) = ((n : ℂ) + 1) * μ^n
-      -- Case split on n=0 vs n≥1
       rcases Nat.eq_zero_or_pos n with (rfl | hn)
       · simp
       · -- n ≥ 1: then μ * μ^(n-1) = μ^n
         have h_mul_pow : (μ : ℂ) * (μ : ℂ) ^ (n - 1) = (μ : ℂ) ^ n := by
           rw [← pow_succ', Nat.sub_add_cancel hn]
-        -- Goal: μ^n + μ * (↑n * μ^(n-1)) = (↑n + 1) * μ^n
-        -- Rewrite μ * (↑n * μ^(n-1)) = ↑n * (μ * μ^(n-1)) = ↑n * μ^n
         calc
           (μ ^ n : ℂ) + (μ : ℂ) * ((n : ℂ) * (μ : ℂ) ^ (n - 1))
               = (μ ^ n : ℂ) + ((n : ℂ) * ((μ : ℂ) * (μ : ℂ) ^ (n - 1))) := by ring
           _ = (μ ^ n : ℂ) + ((n : ℂ) * (μ : ℂ) ^ n) := by rw [h_mul_pow]
           _ = ((n : ℂ) + 1) * (μ ^ n : ℂ) := by ring
-    -- Goal: μ^(n+1) • X + μ^n • v + (n*μ^(n-1)*μ) • v = μ^(n+1) • X + ((n+1)*μ^(n+1-1)) • v
-    -- where v = (T-μ)X
-    -- Use add_smul to combine the v-terms
-    -- c₁ = μ^n, c₂ = n*μ^(n-1)*μ
-    -- c₁ + c₂ = μ^n + μ*n*μ^(n-1) = (n+1)*μ^n (by hV)
-    -- And μ^(n+1-1) = μ^n
-    -- So the RHS v-coefficient matches the sum
     have h_v_coeff : (μ ^ n : ℂ) + ((n : ℂ) * (μ ^ (n - 1) : ℂ) * μ) = (↑(n + 1) : ℂ) * (μ ^ (n + 1 - 1) : ℂ) := by
       -- hV LHS is μ^n + μ*(n*μ^(n-1)) which equals μ^n + n*μ^(n-1)*μ by commutativity
       simpa [mul_comm, mul_left_comm, mul_assoc] using hV
-    -- The X-term matches by hX
     rw [hX]
-    -- Now combine v-terms on LHS: μ^n • v + c • v = (μ^n + c) • v = d • v
-    -- Use add_smul in reverse, then h_v_coeff
     have h_combine : (μ ^ n : ℂ) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) +
         ((n : ℂ) * (μ ^ (n - 1) : ℂ) * μ) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) =
         (↑(n + 1) * (μ ^ (n + 1 - 1) : ℂ)) • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by

--- a/TNLean/Channel/Peripheral/JordanBlocks.lean
+++ b/TNLean/Channel/Peripheral/JordanBlocks.lean
@@ -194,8 +194,6 @@ theorem no_rank_two_genEigenvector_of_tracePreserving
   have h_ineq : C < (n : ℝ) * ‖N X‖ - ‖X‖ := by linarith
   have h_chain : (n : ℝ) * ‖N X‖ - ‖X‖ ≤ C := by
     -- from h_bound_n and hC_n
-    -- Actually: h_bound_n: A ≤ B, hC_n: B ≤ C → A ≤ C
-    -- Wait: h_bound_n: A - ‖X‖ ≤ B where A = n*‖NX‖, B = ‖(T^[n])X‖
     -- hC_n: B ≤ C
     -- So A - ‖X‖ ≤ B ≤ C → A - ‖X‖ ≤ C
     -- But we need A - ‖X‖ ≤ C which follows from h_bound_n and hC_n
@@ -226,7 +224,6 @@ theorem peripheral_Jordan_trivial_of_tracePreserving
     by_cases hm : m = 0
     · subst hm; simpa using hNk
     · -- m ≥ 1, rank-2 reduction
-      have hm_pos : 0 < m := Nat.pos_of_ne_zero hm
       set Y := ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ (m - 1)) X
       have hN2_Y : ((T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)) ^ 2) Y = 0 := by
         dsimp [Y]

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -7,6 +7,7 @@ import TNLean.Analysis.MeanErgodic
 import TNLean.Analysis.Dirichlet
 import TNLean.Channel.Determinant.Bound
 import TNLean.Channel.FixedPoint.Algebra
+import TNLean.Channel.Peripheral.JordanBlocks
 import TNLean.Channel.Peripheral.SpectralRadius
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
@@ -74,12 +75,19 @@ elimination plan.  Documented in
   approximation $1\le n\le q^m$ with $|x_k n-p_k|\le 1/q$ for all $k$, in
   `TNLean.Analysis.Dirichlet`.
 
-### Wolf Proposition 6.2 (Trivial Jordan blocks for peripheral spectrum) — NOT FORMALIZED
+### Wolf Proposition 6.2 (Trivial Jordan blocks for peripheral spectrum) — TRACE-PRESERVING CASE FORMALIZED
 
-Documented in `docs/paper-gaps/wolf_prop62_jordan_blocks.tex`.
-The bounded-orbit lemma (`IsPositiveMap.hasBoundedOrbits_of_tracePreserving`)
-is already formalized; the binomial-expansion growth argument for nontrivial
-Jordan blocks remains to be formalized.
+* `IsPositiveMap.no_rank_two_genEigenvector_of_tracePreserving` — rank-2
+  generalized eigenvectors do not exist at peripheral eigenvalues, in
+  `TNLean.Channel.Peripheral.JordanBlocks`.
+* `IsPositiveMap.peripheral_Jordan_trivial_of_tracePreserving` —
+  $\ker(T-\lambda)^k = \ker(T-\lambda)$ for all $k$ when $|\lambda| = 1$, in
+  `TNLean.Channel.Peripheral.JordanBlocks`.
+* `IsPositiveMap.pow_apply_rank_two_genEig` — binomial expansion:
+  $T^n X = \lambda^n X + n \lambda^{n-1} (T-\lambda)X$ when $(T-\lambda)^2 X = 0$.
+
+The unital case follows by duality (adjoint is trace-preserving) but is not
+yet formally wired. Documented in `docs/paper-gaps/wolf_prop62_jordan_blocks.tex`.
 
 ## Section 6.2 Irreducible maps and Perron–Frobenius theory
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -87,7 +87,7 @@ elimination plan.  Documented in
   $T^n X = \lambda^n X + n \lambda^{n-1} (T-\lambda)X$ when $(T-\lambda)^2 X = 0$.
 
 The unital case follows by duality (adjoint is trace-preserving) but is not
-yet formally wired. Documented in `docs/paper-gaps/wolf_prop62_jordan_blocks.tex`.
+yet proved via this dual route. Documented in `docs/paper-gaps/wolf_prop62_jordan_blocks.tex`.
 
 ## Section 6.2 Irreducible maps and Perron–Frobenius theory
 

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -760,7 +760,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:bounded_orbit_tp, lem:binom_exp_rank_two}
+    \uses{}
     If a rank-$2$ generalized eigenvector existed, the binomial expansion
     $T^n X=\lambda^n X+n\lambda^{n-1}(T-\lambda)X$ (when
     $(T-\lambda)^2X=0$) would make $\|T^nX\|$ grow linearly with $n$,

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -760,7 +760,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:bounded_orbit_tp}
+    \uses{thm:positive_trace_nonincreasing_bounded_orbits}
     If a rank-$2$ generalized eigenvector existed, the binomial expansion
     $T^n X=\lambda^n X+n\lambda^{n-1}(T-\lambda)X$ (when
     $(T-\lambda)^2X=0$) would make $\|T^nX\|$ grow linearly with $n$,

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -760,7 +760,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{}
+    \uses{thm:bounded_orbit_tp}
     If a rank-$2$ generalized eigenvector existed, the binomial expansion
     $T^n X=\lambda^n X+n\lambda^{n-1}(T-\lambda)X$ (when
     $(T-\lambda)^2X=0$) would make $\|T^nX\|$ grow linearly with $n$,

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -746,6 +746,28 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     gives gauge equivalence to $r^{-1/2}A$.
 \end{proof}
 
+
+\begin{theorem}[Trivial Jordan blocks for peripheral eigenvalues]
+    \label{thm:peripheral_jordan_trivial}
+    \lean{IsPositiveMap.peripheral_Jordan_trivial_of_tracePreserving}
+    \leanok
+    \uses{def:positive_map, def:trace_preserving}
+    Let $T:\MN{D}\to\MN{D}$ be a positive trace-preserving linear map
+    with $D>0$.  If $\lambda$ is an eigenvalue of $T$ with $|\lambda|=1$,
+    then $\ker(T-\lambda)^k=\ker(T-\lambda)$ for all $k\ge1$.
+    This is the trace-preserving case of
+    \cite[Proposition~6.2]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:bounded_orbit_tp, lem:binom_exp_rank_two}
+    If a rank-$2$ generalized eigenvector existed, the binomial expansion
+    $T^n X=\lambda^n X+n\lambda^{n-1}(T-\lambda)X$ (when
+    $(T-\lambda)^2X=0$) would make $\|T^nX\|$ grow linearly with $n$,
+    contradicting the bounded-orbit theorem for positive trace-preserving
+    maps.  The rank-$k$ case reduces to rank~$2$ by induction.
+\end{proof}
+
 \section{Spectral radius at the Perron eigenvalue}
 
 \begin{theorem}[Spectral radius is the Perron eigenvalue]

--- a/docs/paper-gaps/wolf_prop62_jordan_blocks.tex
+++ b/docs/paper-gaps/wolf_prop62_jordan_blocks.tex
@@ -67,7 +67,7 @@ The unital case remains as a \emph{scope restriction}: the source
 Proposition~6.2 is stated for trace-preserving \emph{or} unital positive maps.
 The unital case follows by duality (the trace adjoint $T^*$ is trace-preserving
 and positive, and the generalized-eigenspace structure transfers), but the
-formal dual-transport proof is not yet wired.
+formal dual-transport proof is not yet formalized.
 See \ghissue{3984}.\footnote{Tracking: \ghissue{3984}.}
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/wolf_prop62_jordan_blocks.tex
+++ b/docs/paper-gaps/wolf_prop62_jordan_blocks.tex
@@ -55,11 +55,20 @@ binomial term $\binom{n}{k-1}$ growing like $n^{k-1}$.
 
 \section{Verdict}
 
-This is an \emph{open gap}.  The bounded-orbit lemma supplies the analytic
-hypothesis; the algebraic step (binomial expansion for the power of a linear
-endomorphism with nilpotent perturbation) is mathematically clear but not
-yet formalized.  The rank-$2$ case suffices for the peripheral-spectrum
-applications in Theorem~6.6 of the source.\footnote{Tracking: \ghissue{3984}.}
+The trace-preserving case is \emph{closed}.  The rank-2 binomial expansion
+(\leanid{IsPositiveMap.pow\_apply\_rank\_two\_genEig}),
+the rank-2 generalized-eigenvector prohibition
+(\leanid{IsPositiveMap.no\_rank\_two\_genEigenvector\_of\_tracePreserving}),
+and the full $k$-step reduction
+(\leanid{IsPositiveMap.peripheral\_Jordan\_trivial\_of\_tracePreserving})
+are all formalized in \doclink{TNLean/Channel/Peripheral/JordanBlocks}.
+
+The unital case remains as a \emph{scope restriction}: the source
+Proposition~6.2 is stated for trace-preserving \emph{or} unital positive maps.
+The unital case follows by duality (the trace adjoint $T^*$ is trace-preserving
+and positive, and the generalized-eigenspace structure transfers), but the
+formal dual-transport proof is not yet wired.
+See \ghissue{3984}.\footnote{Tracking: \ghissue{3984}.}
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Addresses LionSR/QICLean#36

## Summary
Formalizes Wolf Proposition 6.2: trivial Jordan blocks for peripheral eigenvalues of positive trace-preserving maps.

### Complete
- `IsPositiveMap.pow_apply_rank_two_genEig` — binomial expansion: $T^nX = \lambda^n X + n\lambda^{n-1}(T-\lambda)X$ when $(T-\lambda)^2 X = 0$
- `IsPositiveMap.no_rank_two_genEigenvector_of_tracePreserving` — no rank-2 generalized eigenvectors at $|\lambda|=1$
- `IsPositiveMap.peripheral_Jordan_trivial_of_tracePreserving` — $\ker(T-\lambda)^k = \ker(T-\lambda)$ for all $k\ge1$

### Scope restriction
The unital case follows by duality (adjoint is trace-preserving) but the formal dual-transport is not yet wired. Documented in `docs/paper-gaps/wolf_prop62_jordan_blocks.tex`.

### #print axioms output
```
no_rank_two_genEigenvector_of_tracePreserving depends on axioms: [propext, Classical.choice, Quot.sound]
peripheral_Jordan_trivial_of_tracePreserving depends on axioms: [propext, Classical.choice, Quot.sound]
```

### Files changed
- New: `TNLean/Channel/Peripheral/JordanBlocks.lean`
- Modified: `TNLean/Channel/WolfChapter6Index.lean`, `TNLean/Channel/Peripheral.lean`
- Updated: `blueprint/src/chapter/ch06_qpf.tex`, `docs/paper-gaps/wolf_prop62_jordan_blocks.tex`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and documentation with no runtime or API surface; remaining scope is explicitly the unital dual proof, not half-wired production logic.
> 
> **Overview**
> Formalizes **Wolf Proposition 6.2** for **positive trace-preserving** maps on matrix algebras: eigenvalues with \(|\lambda|=1\) have no nontrivial Jordan blocks (\(\ker(T-\lambda)^k=\ker(T-\lambda)\)).
> 
> New module `TNLean/Channel/Peripheral/JordanBlocks.lean` proves the rank-2 binomial identity `pow_apply_rank_two_genEig`, rules out rank-2 generalized eigenvectors via linear orbit growth against `hasBoundedOrbits_of_tracePreserving`, and extends to all \(k\) by induction in `peripheral_Jordan_trivial_of_tracePreserving`. The peripheral aggregator and `WolfChapter6Index` now import and list these results; the blueprint chapter adds theorem `peripheral_jordan_trivial` with `\leanok`; `docs/paper-gaps/wolf_prop62_jordan_blocks.tex` marks the trace-preserving gap **closed** and notes the **unital** case is still only sketched via adjoint duality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c73f762882df4ac6a91aa86a41017733c78d61e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->