### PR TITLE
feat(Channel/FixedPoint): stationary-state basis of the fixed-point space (Wolf Cor 6.8)

### DIFF
--- a/TNLean/Channel/FixedPoint/StationarySpan.lean
+++ b/TNLean/Channel/FixedPoint/StationarySpan.lean
@@ -10,12 +10,11 @@ import Mathlib.LinearAlgebra.Dimension.Finite
 /-!
 # Fixed-point subspace spanned by positive-semidefinite fixed points
 
-This file proves that the fixed-point subspace of a positive trace-preserving
-linear map is spanned (over ℂ) by its positive-semidefinite elements, and then
-by stationary density matrices.  This is the key spectral lemma for Wolf
-Corollary~6.8 (Linearly independent stationary states).  The dimension/basis
-statement with exactly `r` linearly independent stationary density matrices is
-tracked for follow-up work.
+This file proves Wolf Corollary 6.8 (Linearly independent stationary states)
+in full: the fixed-point subspace of a positive trace-preserving linear map is
+spanned (over ℂ) by stationary density matrices, and when the subspace has
+dimension `r`, there exist `r` linearly independent stationary density matrices
+that span it.
 
 ## Source
 
@@ -53,7 +52,8 @@ lemma mem_fixedPointsSubmodule {X : Matrix (Fin D) (Fin D) ℂ} :
   simp [fixedPointsSubmodule, LinearMap.mem_ker, sub_eq_zero]
 
 /-- The set of PSD fixed points. -/
-def posSemidefFixedPointsSet (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+def posSemidefFixedPointsSet
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     Set (Matrix (Fin D) (Fin D) ℂ) :=
   {X | X ∈ fixedPointsSubmodule E ∧ X.PosSemidef}
 
@@ -67,7 +67,8 @@ lemma fixedPoint_mem_span_posSemidef
     (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
     {X : Matrix (Fin D) (Fin D) ℂ} (hX_fix : E X = X) :
     X ∈ Submodule.span ℂ (posSemidefFixedPointsSet E) := by
-  obtain ⟨P₁, P₂, P₃, P₄, hP₁, hP₂, hP₃, hP₄, hFP₁, hFP₂, hFP₃, hFP₄, h_decomp⟩ :=
+  obtain ⟨P₁, P₂, P₃, P₄, hP₁, hP₂, hP₃, hP₄, hFP₁, hFP₂, hFP₃, hFP₄,
+    h_decomp⟩ :=
     IsPositiveMap.exists_posSemidef_fixedPoints_decomposition E hE hTP hX_fix
   have mem (P : Matrix (Fin D) (Fin D) ℂ) (hPf : E P = P) (hPp : P.PosSemidef) :
       P ∈ Submodule.span ℂ (posSemidefFixedPointsSet E) :=
@@ -145,8 +146,9 @@ lemma stationaryDensity_of_posSemidef_fixedPoint
 The fixed-point subspace of a positive trace-preserving linear map is spanned
 (over ℂ) by stationary density matrices (PSD, trace 1, fixed by `E`).
 
-The dimension/basis statement with exactly `r` linearly independent stationary
-density matrices is tracked for follow-up work. -/
+The basis statement (Theorem `exists_stationaryDensity_basis_of_fixedPointsSubmodule`)
+yields `r` linearly independent stationary density matrices spanning the space,
+where `r` is the dimension of the fixed-point subspace. -/
 theorem fixedPointsSubmodule_spanned_by_stationaryDensities
     (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
     Submodule.span ℂ {ρ | IsStationaryDensity E ρ} = fixedPointsSubmodule E := by
@@ -186,5 +188,49 @@ theorem fixedPointsSubmodule_spanned_by_stationaryDensities
       Submodule.span_le.mpr h_P_sub_span_S
     rw [h_span_P] at h_span_le
     exact h_span_le
+
+
+/-- **Wolf Corollary 6.8 (Linearly independent stationary states).**
+
+Let `E` be a positive trace-preserving linear map on `M_D(ℂ)`.  The fixed-point
+subspace `F_E = {X | E X = X}` is finite-dimensional.  Let `r = dim_ℂ F_E`.
+Then there exist `r` linearly independent stationary density matrices
+`ρ₁, …, ρᵣ` (positive semidefinite, trace 1, fixed by `E`) whose ℂ-linear
+span equals `F_E`.
+
+Equivalently, the fixed-point space has a basis consisting entirely of
+stationary density matrices.
+
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.8;
+local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
+lines 1204--1215. -/
+theorem exists_stationaryDensity_basis_of_fixedPointsSubmodule
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
+    ∃ (r : ℕ) (ρ : Fin r → Matrix (Fin D) (Fin D) ℂ),
+      (∀ i, IsStationaryDensity E (ρ i)) ∧
+      LinearIndependent ℂ ρ ∧
+      Submodule.span ℂ (Set.range ρ) = fixedPointsSubmodule E := by
+  set S : Set (Matrix (Fin D) (Fin D) ℂ) := {ρ | IsStationaryDensity E ρ}
+    with hS
+  set V := fixedPointsSubmodule E with hV
+  have h_span : Submodule.span ℂ S = V :=
+    fixedPointsSubmodule_spanned_by_stationaryDensities E hE hTP
+  -- V is a submodule of a finite-dimensional space, so span ℂ S is finite
+  have h_fin : Module.Finite ℂ (Submodule.span ℂ S) := by
+    rw [h_span]
+    infer_instance
+  -- Extract a basis from the spanning set
+  rcases Submodule.exists_fun_fin_finrank_span_eq ℂ S with ⟨f, hf_mem, hf_span, hf_indep⟩
+  -- f is indexed by Fin r where r = Module.finrank ℂ (span ℂ S).
+  -- Since span ℂ S = V, this r equals the finrank of V.
+  have h_stationary : ∀ i, IsStationaryDensity E (f i) := by
+    intro i
+    have : f i ∈ S := hf_mem i
+    rw [hS, Set.mem_setOf_eq] at this
+    exact this
+  have h_finrank_eq : Module.finrank ℂ (Submodule.span ℂ S) =
+      Module.finrank ℂ V := by rw [h_span]
+  refine ⟨Module.finrank ℂ (Submodule.span ℂ S), f, h_stationary, hf_indep, ?_⟩
+  rw [hf_span, h_span]
 
 end IsPositiveMap

--- a/TNLean/Channel/FixedPoint/StationarySpan.lean
+++ b/TNLean/Channel/FixedPoint/StationarySpan.lean
@@ -189,7 +189,6 @@ theorem fixedPointsSubmodule_spanned_by_stationaryDensities
     rw [h_span_P] at h_span_le
     exact h_span_le
 
-
 /-- **Wolf Corollary 6.8 (Linearly independent stationary states).**
 
 Let `E` be a positive trace-preserving linear map on `M_D(ℂ)`.  The fixed-point
@@ -203,34 +202,30 @@ stationary density matrices.
 
 Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.8;
 local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
-lines 1204--1215. -/
+lines 1204--1212. -/
 theorem exists_stationaryDensity_basis_of_fixedPointsSubmodule
     (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E) :
-    ∃ (r : ℕ) (ρ : Fin r → Matrix (Fin D) (Fin D) ℂ),
+    ∃ ρ : Fin (Module.finrank ℂ (fixedPointsSubmodule E)) →
+      Matrix (Fin D) (Fin D) ℂ,
       (∀ i, IsStationaryDensity E (ρ i)) ∧
       LinearIndependent ℂ ρ ∧
       Submodule.span ℂ (Set.range ρ) = fixedPointsSubmodule E := by
   set S : Set (Matrix (Fin D) (Fin D) ℂ) := {ρ | IsStationaryDensity E ρ}
     with hS
-  set V := fixedPointsSubmodule E with hV
-  have h_span : Submodule.span ℂ S = V :=
+  have h_span : Submodule.span ℂ S = fixedPointsSubmodule E :=
     fixedPointsSubmodule_spanned_by_stationaryDensities E hE hTP
-  -- V is a submodule of a finite-dimensional space, so span ℂ S is finite
-  have h_fin : Module.Finite ℂ (Submodule.span ℂ S) := by
-    rw [h_span]
-    infer_instance
   -- Extract a basis from the spanning set
+  -- Rewrite the goal's index type using h_span so it matches f's type
+  rw [show Module.finrank ℂ (fixedPointsSubmodule E) =
+    Module.finrank ℂ (Submodule.span ℂ S) from by rw [h_span]]
   rcases Submodule.exists_fun_fin_finrank_span_eq ℂ S with ⟨f, hf_mem, hf_span, hf_indep⟩
-  -- f is indexed by Fin r where r = Module.finrank ℂ (span ℂ S).
-  -- Since span ℂ S = V, this r equals the finrank of V.
   have h_stationary : ∀ i, IsStationaryDensity E (f i) := by
     intro i
     have : f i ∈ S := hf_mem i
     rw [hS, Set.mem_setOf_eq] at this
     exact this
-  have h_finrank_eq : Module.finrank ℂ (Submodule.span ℂ S) =
-      Module.finrank ℂ V := by rw [h_span]
-  refine ⟨Module.finrank ℂ (Submodule.span ℂ S), f, h_stationary, hf_indep, ?_⟩
-  rw [hf_span, h_span]
+  -- Also rewrite the span goal using h_span
+  rw [← h_span]
+  exact ⟨f, h_stationary, hf_indep, hf_span⟩
 
 end IsPositiveMap

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -342,7 +342,7 @@ Additionally:
 * Numbered theorem: `IsPositiveMap.wolf_prop_6_8` —
   `TNLean.Channel.WolfChapter6Wrappers`.
 
-### Wolf Corollary 6.8 (Linearly independent stationary states) — KEY LEMMA FORMALIZED (basis/dimension statement open)
+### Wolf Corollary 6.8 (Linearly independent stationary states) — FORMALIZED
 
 In `TNLean.Channel.FixedPoint.StationarySpan`:
 
@@ -350,11 +350,15 @@ In `TNLean.Channel.FixedPoint.StationarySpan`:
   trace 1, fixed by the map).
 * `IsPositiveMap.fixedPointsSubmodule` — the fixed-point subspace as a
   `Submodule ℂ M_D(ℂ)`.
-* `IsPositiveMap.span_posSemidefFixedPointsSet_eq_fixedPointsSubmodule` — the fixed-point
-  subspace is spanned (over ℂ) by its positive semidefinite elements (this is
-  the key lemma for the corollary).
-* The corollary's full statement with basis and dimension (Wolf's form) remains
-  to be proved; the spanning lemma is the load-bearing step.
+* `IsPositiveMap.span_posSemidefFixedPointsSet_eq_fixedPointsSubmodule` —
+  the fixed-point subspace is spanned (over ℂ) by its positive semidefinite
+  elements.
+* `IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities` —
+  the fixed-point subspace is spanned (over ℂ) by stationary density matrices
+  (PSD, trace 1, fixed by `E`).
+* `IsPositiveMap.exists_stationaryDensity_basis_of_fixedPointsSubmodule` —
+  Wolf Corollary 6.8: when the fixed-point subspace has dimension `r`, there
+  exist `r` linearly independent stationary density matrices spanning it.
 
 ### Wolf Corollary 6.6 (projected support corner) — FORMALIZED (Kraus case)
 

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -878,35 +878,32 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     and skew-Hermitian parts and apply the Hermitian case to each.
 \end{proof}
 
-\begin{corollary}[Spanning by stationary density matrices]\label{cor:stationary_density_span}
+\begin{corollary}[Linearly independent stationary states]\label{cor:stationary_density_span}
     \lean{IsPositiveMap.fixedPointsSubmodule}
     \lean{IsPositiveMap.span_posSemidefFixedPointsSet_eq_fixedPointsSubmodule}
     \lean{IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities}
+    \lean{IsPositiveMap.exists_stationaryDensity_basis_of_fixedPointsSubmodule}
     \lean{IsStationaryDensity}
+    \lean{IsPositiveMap.stationaryDensity_of_posSemidef_fixedPoint}
     \leanok
     \uses{thm:positive_fixedpoint_decomp}
     Let $E\colon M_D(\mathbb C)\to M_D(\mathbb C)$ be a positive,
-    trace-preserving linear map with $D>0$.  The fixed-point subspace
-    $\mathcal F_E=\{X\mid E(X)=X\}$ is spanned (over $\mathbb C$) by
-    stationary density matrices (positive semidefinite, trace~1, fixed by~$E$).
-    \lean{IsPositiveMap.stationaryDensity_of_posSemidef_fixedPoint}
-    Each nonzero positive-semidefinite fixed point can be scaled to a stationary
-    density matrix.
+    trace-preserving linear map.  Let $\mathcal F_E=\{X\mid E(X)=X\}$ be the
+    fixed-point subspace and $r = \dim_{\mathbb C} \mathcal F_E$.
+    Then there exist $r$ linearly independent stationary density matrices
+    $\rho_1,\dots,\rho_r$ (positive semidefinite, trace~1, fixed by~$E$)
+    whose $\mathbb C$-linear span equals $\mathcal F_E$.
+
+    This is Wolf Corollary~6.8 (Linearly independent stationary states).
 \end{corollary}
 
 \begin{proof}\leanok
     \uses{thm:positive_fixedpoint_decomp}
     By Theorem~\ref{thm:positive_fixedpoint_decomp}, every fixed point is a
     $\mathbb C$-linear combination of four positive-semidefinite fixed points.
-    For each nonzero positive-semidefinite fixed point $\rho$, a
-    positive-semidefinite matrix has zero trace only if it is the zero matrix,
-    so $\tr(\rho)$ is a positive real number.  Hence $\rho/\tr(\rho)$ is a stationary density matrix, and
-    $\rho = \tr(\rho) \cdot (\rho/\tr(\rho))$ is in the span of the stationary
-    density matrices.  The span of all positive-semidefinite fixed points
-    therefore equals the span of the stationary density matrices, which
-    equals~$\mathcal F_E$.
-
-    % The dimension statement of Wolf Corollary~6.8 (a basis of exactly~r
-    % linearly independent stationary density matrices) follows from the spanning
-    % result and finite dimensionality but is not yet formalized.
+    Each nonzero positive-semidefinite fixed point can be scaled to a stationary
+    density matrix, so the stationary density matrices span~$\mathcal F_E$.
+    Since $\mathcal F_E$ is finite-dimensional, the spanning set contains a
+    basis; extracting one yields $r$ linearly independent stationary density
+    matrices.
 \end{proof}


### PR DESCRIPTION
Addresses \#3985

## Summary

Completes Wolf Corollary 6.8 (Linearly independent stationary states). The spanning half was already merged in \#5416; this PR completes the dimension-exact basis statement.

### New theorem

`IsPositiveMap.exists_stationaryDensity_basis_of_fixedPointsSubmodule` — when the fixed-point subspace of a positive trace-preserving linear map `E` has dimension `r`, there exist `r` linearly independent stationary density matrices (PSD, trace 1, fixed by `E`) whose ℂ-linear span equals the fixed-point subspace.

### Proof

From the spanning result (`fixedPointsSubmodule_spanned_by_stationaryDensities`), we know the set of stationary density matrices spans the fixed-point subspace. Since the subspace is finite-dimensional, `Submodule.exists_fun_fin_finrank_span_eq` extracts a basis from this spanning set, yielding exactly `Module.finrank` many vectors.

### Changes

- `TNLean/Channel/FixedPoint/StationarySpan.lean`: add theorem, update docstrings
- `TNLean/Channel/WolfChapter6Index.lean`: update Corollary 6.8 heading to FORMALIZED
- `blueprint/src/chapter/ch06_qpf.tex`: update corollary to full basis statement with `\lean{}` tags
- Line-length fixes

### Axioms

Only `propext`, `Classical.choice`, `Quot.sound`.

### Note

The general compact-convex Brouwer statement (criterion 1 of \#3985) remains tracked in `docs/paper-gaps/brouwer_general_compact_convex.tex` and is not addressed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib linear-algebra packaging on top of merged spanning lemmas; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Completes Wolf Corollary 6.8** by proving that the fixed-point subspace of a positive trace-preserving map has a ℂ-basis of exactly `r = dim F_E` **stationary density matrices**, where the spanning half was already in the codebase.
> 
> Adds `IsPositiveMap.exists_stationaryDensity_basis_of_fixedPointsSubmodule` in `StationarySpan.lean`: after `fixedPointsSubmodule_spanned_by_stationaryDensities`, it applies `Submodule.exists_fun_fin_finrank_span_eq` to pull a linearly independent family of size `finrank` from the spanning set of stationary densities. Module and blueprint docs are updated so Corollary 6.8 is marked **FORMALIZED** with the full dimension-exact statement (not “basis open”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7a117cad798790bc9949e804fe82cfa06ba0af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->