### PR TITLE
feat(Channel/Schwarz): Douglas factorization and block Schur complements (Wolf Ch5)

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -70,49 +70,6 @@ namespace Matrix
 
 /-! ## Hermitian matrix action -/
 
-/-- A Hermitian matrix may be moved between the two arguments of the complex
-dot product. -/
-theorem IsHermitian.star_mulVec_dotProduct {n : Type*} [Fintype n]
-    {S : Matrix n n ℂ} (hS : S.IsHermitian) (x y : n → ℂ) :
-    star (S *ᵥ x) ⬝ᵥ y = star x ⬝ᵥ (S *ᵥ y) := by
-  rw [star_mulVec, ← Matrix.dotProduct_mulVec, hS.eq]
-
-/-- A matrix factor moves across the complex dot product as its conjugate
-transpose. -/
-theorem star_dotProduct_mulVec {m n : Type*} [Fintype m] [Fintype n]
-    (A : Matrix m n ℂ) (x : m → ℂ) (y : n → ℂ) :
-    star x ⬝ᵥ (A *ᵥ y) = star (Aᴴ *ᵥ x) ⬝ᵥ y := by
-  rw [star_mulVec, conjTranspose_conjTranspose, ← Matrix.dotProduct_mulVec]
-
-/-! ## Euclidean norms and the L² operator norm -/
-
-open scoped Matrix.Norms.L2Operator InnerProductSpace
-
-/-- The squared Euclidean norm of a complex vector is the real part of its
-standard sesquilinear self-pairing. -/
-theorem re_star_dotProduct_self_eq_norm_sq {n : Type*} [Fintype n] (v : n → ℂ) :
-    RCLike.re (star v ⬝ᵥ v) = ‖(EuclideanSpace.equiv n ℂ).symm v‖ ^ 2 := by
-  rw [norm_sq_eq_re_inner (𝕜 := ℂ), EuclideanSpace.inner_eq_star_dotProduct,
-    PiLp.coe_symm_continuousLinearEquiv, WithLp.ofLp_toLp, dotProduct_comm]
-
-/-- The squared Euclidean norm of a matrix applied to a vector, as the real
-part of the associated sesquilinear quadratic form. -/
-theorem norm_sq_mulVec_eq_re_star_dotProduct {m n : Type*} [Fintype m] [Fintype n]
-    (A : Matrix m n ℂ) (v : n → ℂ) :
-    ‖(EuclideanSpace.equiv m ℂ).symm (A *ᵥ v)‖ ^ 2 =
-      RCLike.re (star (A *ᵥ v) ⬝ᵥ (A *ᵥ v)) :=
-  (re_star_dotProduct_self_eq_norm_sq (A *ᵥ v)).symm
-
-/-- The standard sesquilinear pairing with a matrix applied on the right is a
-Euclidean inner product against the induced map. -/
-theorem star_dotProduct_mulVec_eq_inner {n : Type*} [Fintype n] [DecidableEq n]
-    (A : Matrix n n ℂ) (x y : n → ℂ) :
-    star x ⬝ᵥ (A *ᵥ y) =
-      ⟪(EuclideanSpace.equiv n ℂ).symm x,
-        (toEuclideanLin A) ((EuclideanSpace.equiv n ℂ).symm y)⟫_ℂ := by
-  show star x ⬝ᵥ (A *ᵥ y) = ⟪WithLp.toLp 2 x, WithLp.toLp 2 (A *ᵥ y)⟫_ℂ
-  rw [EuclideanSpace.inner_toLp_toLp, dotProduct_comm]
-
 /-- Vectorwise bounds give a bound on the L² operator norm of a matrix. -/
 theorem l2_opNorm_le_of_forall {m n : Type*} [Fintype m] [Fintype n] [DecidableEq n]
     {A : Matrix m n ℂ} {r : ℝ} (hr : 0 ≤ r)

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -77,6 +77,65 @@ theorem IsHermitian.star_mulVec_dotProduct {n : Type*} [Fintype n]
     star (S *ᵥ x) ⬝ᵥ y = star x ⬝ᵥ (S *ᵥ y) := by
   rw [star_mulVec, ← Matrix.dotProduct_mulVec, hS.eq]
 
+/-- A matrix factor moves across the complex dot product as its conjugate
+transpose. -/
+theorem star_dotProduct_mulVec {m n : Type*} [Fintype m] [Fintype n]
+    (A : Matrix m n ℂ) (x : m → ℂ) (y : n → ℂ) :
+    star x ⬝ᵥ (A *ᵥ y) = star (Aᴴ *ᵥ x) ⬝ᵥ y := by
+  rw [star_mulVec, conjTranspose_conjTranspose, ← Matrix.dotProduct_mulVec]
+
+/-! ## Euclidean norms and the L² operator norm -/
+
+open scoped Matrix.Norms.L2Operator InnerProductSpace
+
+/-- The squared Euclidean norm of a complex vector is the real part of its
+standard sesquilinear self-pairing. -/
+theorem re_star_dotProduct_self_eq_norm_sq {n : Type*} [Fintype n] (v : n → ℂ) :
+    RCLike.re (star v ⬝ᵥ v) = ‖(EuclideanSpace.equiv n ℂ).symm v‖ ^ 2 := by
+  rw [norm_sq_eq_re_inner (𝕜 := ℂ), EuclideanSpace.inner_eq_star_dotProduct,
+    PiLp.coe_symm_continuousLinearEquiv, WithLp.ofLp_toLp, dotProduct_comm]
+
+/-- The squared Euclidean norm of a matrix applied to a vector, as the real
+part of the associated sesquilinear quadratic form. -/
+theorem norm_sq_mulVec_eq_re_star_dotProduct {m n : Type*} [Fintype m] [Fintype n]
+    (A : Matrix m n ℂ) (v : n → ℂ) :
+    ‖(EuclideanSpace.equiv m ℂ).symm (A *ᵥ v)‖ ^ 2 =
+      RCLike.re (star (A *ᵥ v) ⬝ᵥ (A *ᵥ v)) :=
+  (re_star_dotProduct_self_eq_norm_sq (A *ᵥ v)).symm
+
+/-- The standard sesquilinear pairing with a matrix applied on the right is a
+Euclidean inner product against the induced map. -/
+theorem star_dotProduct_mulVec_eq_inner {n : Type*} [Fintype n] [DecidableEq n]
+    (A : Matrix n n ℂ) (x y : n → ℂ) :
+    star x ⬝ᵥ (A *ᵥ y) =
+      ⟪(EuclideanSpace.equiv n ℂ).symm x,
+        (toEuclideanLin A) ((EuclideanSpace.equiv n ℂ).symm y)⟫_ℂ := by
+  show star x ⬝ᵥ (A *ᵥ y) = ⟪WithLp.toLp 2 x, WithLp.toLp 2 (A *ᵥ y)⟫_ℂ
+  rw [EuclideanSpace.inner_toLp_toLp, dotProduct_comm]
+
+/-- Vectorwise bounds give a bound on the L² operator norm of a matrix. -/
+theorem l2_opNorm_le_of_forall {m n : Type*} [Fintype m] [Fintype n] [DecidableEq n]
+    {A : Matrix m n ℂ} {r : ℝ} (hr : 0 ≤ r)
+    (h : ∀ v : n → ℂ, ‖(EuclideanSpace.equiv m ℂ).symm (A *ᵥ v)‖ ≤
+      r * ‖(EuclideanSpace.equiv n ℂ).symm v‖) :
+    ‖A‖ ≤ r := by
+  rw [l2_opNorm_def]
+  refine ContinuousLinearMap.opNorm_le_bound _ hr fun x ↦ ?_
+  exact h x.ofLp
+
+/-- The quadratic form of `Kᴴ * K` is bounded by the squared L² operator norm
+of `K` times the self-pairing. -/
+theorem re_star_dotProduct_mulVec_le_opNorm_sq {m n : Type*} [Fintype m] [Fintype n]
+    [DecidableEq n] (K : Matrix m n ℂ) (v : n → ℂ) :
+    RCLike.re (star (K *ᵥ v) ⬝ᵥ (K *ᵥ v)) ≤ ‖K‖ ^ 2 * RCLike.re (star v ⬝ᵥ v) := by
+  rw [re_star_dotProduct_self_eq_norm_sq, re_star_dotProduct_self_eq_norm_sq]
+  have h := l2_opNorm_mulVec K ((EuclideanSpace.equiv n ℂ).symm v)
+  rw [PiLp.coe_symm_continuousLinearEquiv, WithLp.ofLp_toLp] at h
+  calc ‖(EuclideanSpace.equiv m ℂ).symm (K *ᵥ v)‖ ^ 2
+      ≤ (‖K‖ * ‖(EuclideanSpace.equiv n ℂ).symm v‖) ^ 2 :=
+        pow_le_pow_left₀ (norm_nonneg _) h _
+    _ = ‖K‖ ^ 2 * ‖(EuclideanSpace.equiv n ℂ).symm v‖ ^ 2 := mul_pow _ _ _
+
 /-! ## Matrix action on product vectors -/
 
 /-- A dependent product of matrices acts componentwise on a pure tensor. -/

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -70,6 +70,31 @@ namespace Matrix
 
 /-! ## Hermitian matrix action -/
 
+/-- A Hermitian matrix may be moved between the two arguments of the complex
+dot product. -/
+theorem IsHermitian.star_mulVec_dotProduct {n : Type*} [Fintype n]
+    {S : Matrix n n ℂ} (hS : S.IsHermitian) (x y : n → ℂ) :
+    star (S *ᵥ x) ⬝ᵥ y = star x ⬝ᵥ (S *ᵥ y) := by
+  rw [star_mulVec, ← Matrix.dotProduct_mulVec, hS.eq]
+
+/-- A matrix factor moves across the complex dot product as its conjugate
+transpose. -/
+theorem star_dotProduct_mulVec {m n : Type*} [Fintype m] [Fintype n]
+    (A : Matrix m n ℂ) (x : m → ℂ) (y : n → ℂ) :
+    star x ⬝ᵥ (A *ᵥ y) = star (Aᴴ *ᵥ x) ⬝ᵥ y := by
+  rw [star_mulVec, conjTranspose_conjTranspose, ← Matrix.dotProduct_mulVec]
+
+/-! ## Euclidean norms and the L² operator norm -/
+
+open scoped Matrix.Norms.L2Operator InnerProductSpace
+
+/-- The squared Euclidean norm of a complex vector is the real part of its
+standard sesquilinear self-pairing. -/
+theorem re_star_dotProduct_self_eq_norm_sq {n : Type*} [Fintype n] (v : n → ℂ) :
+    RCLike.re (star v ⬝ᵥ v) = ‖(EuclideanSpace.equiv n ℂ).symm v‖ ^ 2 := by
+  rw [norm_sq_eq_re_inner (𝕜 := ℂ), EuclideanSpace.inner_eq_star_dotProduct,
+    PiLp.coe_symm_continuousLinearEquiv, WithLp.ofLp_toLp, dotProduct_comm]
+
 /-- Vectorwise bounds give a bound on the L² operator norm of a matrix. -/
 theorem l2_opNorm_le_of_forall {m n : Type*} [Fintype m] [Fintype n] [DecidableEq n]
     {A : Matrix m n ℂ} {r : ℝ} (hr : 0 ≤ r)

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -109,7 +109,8 @@ theorem l2_opNorm_le_of_forall {m n : Type*} [Fintype m] [Fintype n] [DecidableE
 of `K` times the self-pairing. -/
 theorem re_star_dotProduct_mulVec_le_opNorm_sq {m n : Type*} [Fintype m] [Fintype n]
     [DecidableEq n] (K : Matrix m n ℂ) (v : n → ℂ) :
-    RCLike.re (star (K *ᵥ v) ⬝ᵥ (K *ᵥ v)) ≤ ‖K‖ ^ 2 * RCLike.re (star v ⬝ᵥ v) := by
+    RCLike.re (star (K *ᵥ v) ⬝ᵥ (K *ᵥ v)) ≤
+      ‖K‖ ^ 2 * RCLike.re (star v ⬝ᵥ v) := by
   rw [re_star_dotProduct_self_eq_norm_sq, re_star_dotProduct_self_eq_norm_sq]
   have h := l2_opNorm_mulVec K ((EuclideanSpace.equiv n ℂ).symm v)
   rw [PiLp.coe_symm_continuousLinearEquiv, WithLp.ofLp_toLp] at h

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -632,6 +632,40 @@ theorem PosSemidef.self_mul_supportInv
     ρ * hρ.supportInv = hρ.isHermitian.supportProj := by
   simpa only [PosSemidef.supportInv] using hρ.self_mul_supportInvSqrt_sq
 
+/-- The generalized inverse on the support is Hermitian. -/
+theorem PosSemidef.supportInv_isHermitian {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInv.IsHermitian := by
+  unfold PosSemidef.supportInv
+  rw [Matrix.IsHermitian, Matrix.conjTranspose_mul, hρ.supportInvSqrt_isHermitian.eq]
+
+/-- The generalized inverse on the support is positive semidefinite. -/
+theorem PosSemidef.supportInv_posSemidef {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInv.PosSemidef := by
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg hρ.supportInv_isHermitian
+    fun x ↦ ?_
+  rw [PosSemidef.supportInv, ← Matrix.mulVec_mulVec,
+    ← hρ.supportInvSqrt_isHermitian.star_mulVec_dotProduct]
+  exact dotProduct_star_self_nonneg _
+
+/-- The support projection absorbs the generalized inverse on the left. -/
+theorem PosSemidef.supportProj_mul_supportInv {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportProj * hρ.supportInv = hρ.supportInv := by
+  rw [PosSemidef.supportInv, ← Matrix.mul_assoc, hρ.supportProj_mul_supportInvSqrt]
+
+/-- The support projection absorbs the generalized inverse on the right. -/
+theorem PosSemidef.supportInv_mul_supportProj {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInv * hρ.supportProj = hρ.supportInv := by
+  rw [PosSemidef.supportInv, Matrix.mul_assoc, hρ.supportInvSqrt_mul_supportProj]
+
+/-- On a positive-definite matrix, the generalized inverse on the support is
+the ordinary inverse. -/
+theorem PosDef.supportInv_eq_inv {ρ : Matrix n n ℂ} (hρ : ρ.PosDef) :
+    hρ.posSemidef.supportInv = ρ⁻¹ := by
+  have h : hρ.posSemidef.supportInv * ρ = 1 := by
+    rw [hρ.posSemidef.supportInv_mul_self]
+    exact hρ.supportProj_eq_one
+  exact (Matrix.inv_eq_left_inv h).symm
+
 /-- If \(Sx=b\) for a positive-semidefinite matrix \(S\), then pairing \(b\)
 with the support-generalized-inverse solution gives the pairing with \(x\):
 \[

--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -35,6 +35,7 @@ import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
 import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
 import TNLean.Channel.Schwarz.SSAEqualityDPI
 import TNLean.Channel.Schwarz.SSAEqualityPetzRecovery
+import TNLean.Channel.Schwarz.SchurComplement
 import TNLean.Channel.Schwarz.SchwarzNormal
 import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.SchwarzSubnormal

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -357,4 +357,53 @@ theorem pinv_norm_minimal (A B C : Mat) (hA : A = B * C) : ‖pinv B * A‖ ≤ 
       _ ≤ 1 * ‖C‖ := by nlinarith [norm_pinv_mul_B_le_one B]
       _ = ‖C‖ := by simp
 
+
+/-! ## Uniqueness (Wolf moreover (i)+(ii)) -/
+
+theorem pinv_mul_B_mul_conjTranspose (B : Mat) : pinv B * B * Bᴴ = Bᴴ := by
+  unfold pinv
+  have hS : (posSemidefBB B).supportInv * (B * Bᴴ) = (posSemidefBB B).supportProj :=
+    (posSemidefBB B).supportInv_mul_self
+  have hP : (posSemidefBB B).supportProj * B = B :=
+    Matrix.supportProj_mul_conjTranspose_mul_self B
+  calc
+    (Bᴴ * (posSemidefBB B).supportInv * B) * Bᴴ = Bᴴ * (posSemidefBB B).supportInv * (B * Bᴴ) := by
+      simp [Matrix.mul_assoc]
+    _ = Bᴴ * ((posSemidefBB B).supportInv * (B * Bᴴ)) := by simp [Matrix.mul_assoc]
+    _ = Bᴴ * (posSemidefBB B).supportProj := by rw [hS]
+    _ = ((posSemidefBB B).supportProj * B)ᴴ := by simp [Matrix.conjTranspose_mul, (posSemidefBB B).supportProj_isHermitian.eq]
+    _ = Bᴴ := by rw [hP]
+
+theorem pinv_mul_B_mul_C_eq_C (C B : Mat) (hC : C.mulVecLin.range ≤ Bᴴ.mulVecLin.range) :
+    (pinv B * B) * C = C := by
+  apply Matrix.ext; intro i j
+  let c := mulVec C (Pi.single j (1 : ℂ))
+  have hc : c ∈ Bᴴ.mulVecLin.range := hC ⟨Pi.single j (1 : ℂ), rfl⟩
+  rcases hc with ⟨w, hw⟩; rw [Matrix.mulVecLin_apply] at hw
+  have h_eq : mulVec (pinv B * B) c = c := by
+    calc
+      mulVec (pinv B * B) c = mulVec (pinv B * B) (mulVec (Bᴴ) w) := by rw [← hw]
+      _ = mulVec ((pinv B * B) * Bᴴ) w := by rw [Matrix.mulVec_mulVec]
+      _ = mulVec (pinv B * B * Bᴴ) w := by simp [Matrix.mul_assoc]
+      _ = mulVec (Bᴴ) w := by rw [pinv_mul_B_mul_conjTranspose B]
+      _ = c := by rw [hw]
+  calc
+    ((pinv B * B) * C) i j = (mulVec ((pinv B * B) * C) (Pi.single j (1 : ℂ))) i := by simp
+    _ = (mulVec (pinv B * B) (mulVec C (Pi.single j (1 : ℂ)))) i := by rw [Matrix.mulVec_mulVec]
+    _ = (mulVec (pinv B * B) c) i := rfl
+    _ = (c i) := by rw [h_eq]
+    _ = (mulVec C (Pi.single j (1 : ℂ))) i := rfl
+    _ = C i j := by simp
+
+theorem factorization_unique (A B C₁ C₂ : Mat) (hA₁ : A = B * C₁) (hA₂ : A = B * C₂)
+    (hC₁_range : C₁.mulVecLin.range ≤ Bᴴ.mulVecLin.range)
+    (hC₂_range : C₂.mulVecLin.range ≤ Bᴴ.mulVecLin.range) : C₁ = C₂ := by
+  calc
+    C₁ = (pinv B * B) * C₁ := (pinv_mul_B_mul_C_eq_C C₁ B hC₁_range).symm
+    _ = pinv B * (B * C₁) := by simp [Matrix.mul_assoc]
+    _ = pinv B * A := by rw [hA₁]
+    _ = pinv B * (B * C₂) := by rw [hA₂]
+    _ = (pinv B * B) * C₂ := by simp [Matrix.mul_assoc]
+    _ = C₂ := pinv_mul_B_mul_C_eq_C C₂ B hC₂_range
+
 end Douglas

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -78,6 +78,8 @@ theorem factorization_of_range_mulVecLin_le
       simpa using (Matrix.mulVec_mulVec (Pi.single j 1) B C)
     _ = (B * C).col j := by exact Matrix.mulVec_single_one (B * C) j
 
+/-- Pointwise form of the range-inclusion premise: if every vector `A *ᵥ v`
+lies in the range of `B`, then `A = B * C` for some matrix `C`. -/
 theorem factorization_of_forall_mulVec_mem_range
     {A B : Mat} (hAB : ∀ v : Fin D → ℂ, A.mulVec v ∈ B.mulVecLin.range) :
     ∃ C : Mat, A = B * C := by
@@ -97,6 +99,8 @@ throughout the Douglas development for the support-inverse `(B Bᴴ)⁻¹_supp`)
 abbrev posSemidefBB (B : Mat) : (B * Bᴴ).PosSemidef :=
   Matrix.posSemidef_self_mul_conjTranspose B
 
+/-- The pseudoinverse is a right inverse on the support: `B * B⁺` equals the
+support projection of `B * Bᴴ`. -/
 theorem mul_pinv_eq_supportProj (B : Mat) :
     B * pinv B = (posSemidefBB B).supportProj := by
   unfold pinv
@@ -107,6 +111,9 @@ theorem mul_pinv_eq_supportProj (B : Mat) :
     _ = (posSemidefBB B).isHermitian.supportProj := h
     _ = (posSemidefBB B).supportProj := rfl
 
+/-- Any factorization `A = B * C` yields quadratic domination with constant
+`‖C‖²`: `A * Aᴴ ≤ ‖C‖² • (B * Bᴴ)`. This is the domination bound of Douglas'
+theorem, witnessed by the squared norm of the factor. -/
 theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
     A * Aᴴ ≤ (‖C‖ ^ 2 : ℝ) • (B * Bᴴ) := by
   rw [hA]
@@ -170,10 +177,6 @@ theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
           simp [smul_mulVec]
         _ = ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) - star z ⬝ᵥ z := by rw [h_BBstar]
     rw [h_val]
-    have h_sq_re : ((‖C‖ : ℂ) ^ 2).re = ‖C‖ ^ 2 := by
-      simp [sq]
-    have h_sq_im : ((‖C‖ : ℂ) ^ 2).im = 0 := by
-      simp [sq]
     have h_smul_re : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re =
         (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by
       have h_eq : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) =
@@ -204,6 +207,8 @@ theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
     · rw [h_im]
   exact Matrix.PosSemidef.of_dotProduct_mulVec_nonneg h_herm h_nonneg
 
+/-- Quadratic domination `A * Aᴴ ≤ μ • (B * Bᴴ)` forces the columns of `A`
+into the support of `B * Bᴴ`: the support projection of `B * Bᴴ` fixes `A`. -/
 theorem supportProj_mul_eq_of_conjTranspose_le (A B : Mat) (μ : ℝ)
     (hle : A * Aᴴ ≤ μ • (B * Bᴴ)) :
     (posSemidefBB B).supportProj * A = A := by
@@ -284,6 +289,8 @@ theorem douglas_tfae (A B : Mat) : List.TFAE [
     refine ⟨C, hBC⟩
   tfae_finish
 
+/-- Explicit pseudoinverse witness for the factorization direction of Douglas'
+theorem: if `ran A ⊆ ran B`, then `A = B * (B⁺ * A)`. -/
 theorem factorization_pinv (A B : Mat) (hAB : A.mulVecLin.range ≤ B.mulVecLin.range) :
     B * (pinv B * A) = A := by
   have hSPA : (posSemidefBB B).supportProj * A = A := by
@@ -319,6 +326,8 @@ theorem pinv_mul_B_herm (B : Mat) : (pinv B * B)ᴴ = pinv B * B := by
 
 /-! ### Projection contraction -/
 
+/-- `B⁺ * B` is an orthogonal projection (idempotent and Hermitian), hence a
+contraction: `‖B⁺ * B‖ ≤ 1`. -/
 theorem norm_pinv_mul_B_le_one (B : Mat) : ‖pinv B * B‖ ≤ 1 := by
   let P := pinv B * B
   have hP_idem : P * P = P := pinv_mul_B_idem B
@@ -389,6 +398,8 @@ theorem norm_pinv_mul_B_le_one (B : Mat) : ‖pinv B * B‖ ≤ 1 := by
 
 /-! ### Norm minimality of the pseudoinverse factorization -/
 
+/-- Norm minimality of the pseudoinverse factorization: for every factor `C`
+with `A = B * C`, the pseudoinverse witness satisfies `‖B⁺ * A‖ ≤ ‖C‖`. -/
 theorem pinv_norm_minimal (A B C : Mat) (hA : A = B * C) : ‖pinv B * A‖ ≤ ‖C‖ := by
   by_cases hCzero : ‖C‖ = 0
   · have hC : C = 0 := norm_eq_zero.mp hCzero
@@ -405,6 +416,7 @@ theorem pinv_norm_minimal (A B C : Mat) (hA : A = B * C) : ‖pinv B * A‖ ≤ 
 
 /-! ## Uniqueness of the factorization under the support constraint -/
 
+/-- The pseudoinverse absorbs `B * Bᴴ` on its support: `B⁺ * B * Bᴴ = Bᴴ`. -/
 theorem pinv_mul_B_mul_conjTranspose (B : Mat) : pinv B * B * Bᴴ = Bᴴ := by
   unfold pinv
   have hS : (posSemidefBB B).supportInv * (B * Bᴴ) = (posSemidefBB B).supportProj :=
@@ -421,6 +433,8 @@ theorem pinv_mul_B_mul_conjTranspose (B : Mat) : pinv B * B * Bᴴ = Bᴴ := by
       simp [Matrix.conjTranspose_mul, (posSemidefBB B).supportProj_isHermitian.eq]
     _ = Bᴴ := by rw [hP]
 
+/-- `B⁺ * B` acts as the identity on matrices whose columns lie in the range
+of `Bᴴ`: `ran C ⊆ ran Bᴴ` implies `(B⁺ * B) * C = C`. -/
 theorem pinv_mul_B_mul_C_eq_C (C B : Mat) (hC : C.mulVecLin.range ≤ Bᴴ.mulVecLin.range) :
     (pinv B * B) * C = C := by
   apply Matrix.ext; intro i j
@@ -442,6 +456,9 @@ theorem pinv_mul_B_mul_C_eq_C (C B : Mat) (hC : C.mulVecLin.range ≤ Bᴴ.mulVe
     _ = (mulVec C (Pi.single j (1 : ℂ))) i := rfl
     _ = C i j := by simp
 
+/-- Uniqueness of the factorization under the support constraint: two factors
+`C₁`, `C₂` with `A = B * Cᵢ` whose ranges lie in `ran Bᴴ` must coincide, so
+`B⁺ * A` is the unique factor supported on `ran Bᴴ`. -/
 theorem factorization_unique (A B C₁ C₂ : Mat) (hA₁ : A = B * C₁) (hA₂ : A = B * C₂)
     (hC₁_range : C₁.mulVecLin.range ≤ Bᴴ.mulVecLin.range)
     (hC₂_range : C₂.mulVecLin.range ≤ Bᴴ.mulVecLin.range) : C₁ = C₂ := by

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -10,6 +10,35 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.Analysis.Matrix.Normed
 import Mathlib.Analysis.Matrix.Order
 
+/-!
+# Douglas' theorem (Wolf Ch5, Theorem at line 88)
+
+Douglas' theorem for finite matrices: the range inclusion
+`ran A ⊆ ran B` is equivalent to a factorization `A = BC`
+and to a quadratic domination `AA† ≤ λ²BB†`.
+
+The Moore-Penrose pseudoinverse witness `C = pinv(B)·A`
+is constructed via `supportInv`; it satisfies the support constraint
+`supportProj(B·B†)·C = C` and is the unique minimizer of the
+operator norm `‖C‖`.
+
+## Main results
+
+* `douglas_tfae` : the three-way TFAE equivalence
+* `pinv` : Moore-Penrose pseudoinverse via `supportInv`
+* `mul_pinv_eq_supportProj` : `B·pinv(B) = supportProj(B·B†)`
+* `factorization_of_range_mulVecLin_le` : range inclusion → factorization
+* `le_norm_sq_mul_of_factorization` : `A = BC → AA† ≤ ‖C‖²·BB†`
+* `pinv_norm_minimal` : `‖pinv(B)·A‖ ≤ ‖C‖` for any factorization `A = BC`
+* `norm_pinv_mul_B_le_one` : `‖pinv(B)·B‖ ≤ 1` (contraction)
+* `factorization_unique` : uniqueness under the range constraint
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations*, Theorem at
+  Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex line 88][Wolf2012QChannels]
+-/
+
 open scoped Matrix MatrixOrder ComplexOrder Matrix.Norms.L2Operator
 open Matrix
 
@@ -86,7 +115,8 @@ theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
         simp [Matrix.mul_assoc]
       simpa [Matrix.IsHermitian] using h2'
     exact h1.sub h2
-  have h_nonneg : ∀ x, 0 ≤ star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ) *ᵥ x) := by
+  have h_nonneg : ∀ x, 0 ≤ star x ⬝ᵥ
+      (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ) *ᵥ x) := by
     intro x
     set y := Bᴴ *ᵥ x
     set z := Cᴴ *ᵥ y
@@ -115,7 +145,8 @@ theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
       have h_norm_Cstar : ‖Cᴴ‖ = ‖C‖ := Matrix.l2_opNorm_conjTranspose C
       rw [h_norm_Cstar] at h
       simpa [z] using h
-    have h_val : star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ) *ᵥ x) =
+    have h_val : star x ⬝ᵥ
+        (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ) *ᵥ x) =
         ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) - (star z ⬝ᵥ z) := by
       calc
         star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ) *ᵥ x) =
@@ -134,14 +165,18 @@ theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
       simp [sq]
     have h_sq_im : ((‖C‖ : ℂ) ^ 2).im = 0 := by
       simp [sq]
-    have h_smul_re : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by
-      have h_eq : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) = ((‖C‖ : ℂ) * ((‖C‖ : ℂ) * (star y ⬝ᵥ y))) := by
+    have h_smul_re : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re =
+        (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by
+      have h_eq : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) =
+          ((‖C‖ : ℂ) * ((‖C‖ : ℂ) * (star y ⬝ᵥ y))) := by
         simp [sq, mul_assoc]
       rw [h_eq, Complex.mul_re, Complex.mul_re]
       simp [sq]
       ring
-    have h_smul_im : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).im = (‖C‖ ^ 2) * (star y ⬝ᵥ y).im := by
-      have h_eq : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) = ((‖C‖ : ℂ) * ((‖C‖ : ℂ) * (star y ⬝ᵥ y))) := by
+    have h_smul_im : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).im =
+        (‖C‖ ^ 2) * (star y ⬝ᵥ y).im := by
+      have h_eq : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) =
+          ((‖C‖ : ℂ) * ((‖C‖ : ℂ) * (star y ⬝ᵥ y))) := by
         simp [sq, mul_assoc]
       rw [h_eq, Complex.mul_im, Complex.mul_im]
       simp [sq]
@@ -186,7 +221,7 @@ theorem supportProj_mul_eq_of_conjTranspose_le (A B : Mat) (μ : ℝ) (_hμ : 0 
   have h_RHS : Q * (μ • (B * Bᴴ)) * Q = 0 := by
     calc
       Q * (μ • (B * Bᴴ)) * Q = (μ : ℂ) • (Q * (B * Bᴴ) * Q) := by simp
-      _ = (μ : ℂ) • ((Q * (B * Bᴴ)) * Q) := by ring
+      _ = (μ : ℂ) • ((Q * (B * Bᴴ)) * Q) := by simp [Matrix.mul_assoc]
       _ = (μ : ℂ) • (0 * Q) := by rw [hQ_mul_BBstar]
       _ = 0 := by simp
   rw [h_RHS] at h_conj_ineq
@@ -256,7 +291,8 @@ theorem pinv_mul_B_idem (B : Mat) : (pinv B * B) * (pinv B * B) = pinv B * B := 
     _ = pinv B * (posSemidefBB B).supportProj * B := by rw [mul_pinv_eq_supportProj B]
     _ = pinv B * ((posSemidefBB B).supportProj * B) := by simp [Matrix.mul_assoc]
     _ = pinv B * B := by
-      simpa [posSemidefBB, Matrix.PosSemidef.supportProj] using congrArg (fun (M : Mat) => pinv B * M) h
+      simpa [posSemidefBB, Matrix.PosSemidef.supportProj] using
+        congrArg (fun (M : Mat) => pinv B * M) h
 
 /-- `(pinv B * B)` is Hermitian. -/
 theorem pinv_mul_B_herm (B : Mat) : (pinv B * B)ᴴ = pinv B * B := by
@@ -279,7 +315,8 @@ theorem norm_pinv_mul_B_le_one (B : Mat) : ‖pinv B * B‖ ≤ 1 := by
     calc
       dotProduct (star y) (mulVec P y) = dotProduct (star y) (mulVec (P * P) y) := by rw [hP_idem]
       _ = dotProduct (star y) (mulVec P (mulVec P y)) := by rw [Matrix.mulVec_mulVec]
-      _ = dotProduct (star (mulVec (Pᴴ) y)) (mulVec P y) := by rw [star_dotProduct_mulVec P y (mulVec P y)]
+      _ = dotProduct (star (mulVec (Pᴴ) y)) (mulVec P y) := by
+        rw [star_dotProduct_mulVec P y (mulVec P y)]
       _ = dotProduct (star (mulVec P y)) (mulVec P y) := by rw [hP_herm]
   -- I-P is also a projection
   let IP := 1 - P
@@ -303,16 +340,14 @@ theorem norm_pinv_mul_B_le_one (B : Mat) : ‖pinv B * B‖ ≤ 1 := by
         _ = dotProduct (star (mulVec IP y)) (mulVec IP y) := by rw [hIP_herm]
         _ ≥ 0 := dotProduct_star_self_nonneg _
     -- ⟨y,(I-P)·y⟩ = ⟨y,y⟩ − ⟨y,P·y⟩
-    have dot_sub_right (a b c : Fin D → ℂ) : dotProduct a (b - c) = dotProduct a b - dotProduct a c := by
-      simp [dotProduct, Finset.sum_sub_distrib, mul_sub]
     have h_expand : dotProduct (star y) (mulVec IP y) =
         dotProduct (star y) y - dotProduct (star y) (mulVec P y) := by
       calc
         dotProduct (star y) (mulVec IP y) = dotProduct (star y) (mulVec (1 - P) y) := rfl
         _ = dotProduct (star y) (mulVec 1 y - mulVec P y) := by rw [Matrix.sub_mulVec]
         _ = dotProduct (star y) (y - mulVec P y) := by simp
-        _ = dotProduct (star y) y - dotProduct (star y) (mulVec P y) :=
-          dot_sub_right (star y) y (mulVec P y)
+        _ = dotProduct (star y) y - dotProduct (star y) (mulVec P y) := by
+          rw [dotProduct_sub]
     rw [h_expand] at h_nonneg_IP
     -- h_nonneg_IP: 0 ≤ star y·y - star y·(P·y) in ℂ order
     -- Extract real parts: 0 ≤ re(star y·y) - re(star y·(P·y))
@@ -321,9 +356,6 @@ theorem norm_pinv_mul_B_le_one (B : Mat) : ‖pinv B * B‖ ≤ 1 := by
       -- From 0 ≤ a - b in ℂ, we get 0 ≤ re(a) - re(b)
       have h := (Complex.nonneg_iff.mp h_nonneg_IP).1
       -- h: 0 ≤ RCLike.re (star y·y - star y·(P·y))
-      -- But RCLike.re (a-b) = RCLike.re a - RCLike.re b (for a,b real? Actually always for ℂ: re(a-b) = re(a)-re(b))
-      -- Use Complex.sub_re: (a - b).re = a.re - b.re
-      -- RCLike.re = .re, so this works
       simpa [Complex.sub_re] using h
     -- re(star y·(P·y)) = re(star(P·y)·(P·y)) [by h_proj]
     rw [h_proj y] at h_re
@@ -367,11 +399,13 @@ theorem pinv_mul_B_mul_conjTranspose (B : Mat) : pinv B * B * Bᴴ = Bᴴ := by
   have hP : (posSemidefBB B).supportProj * B = B :=
     Matrix.supportProj_mul_conjTranspose_mul_self B
   calc
-    (Bᴴ * (posSemidefBB B).supportInv * B) * Bᴴ = Bᴴ * (posSemidefBB B).supportInv * (B * Bᴴ) := by
+    (Bᴴ * (posSemidefBB B).supportInv * B) * Bᴴ =
+        Bᴴ * (posSemidefBB B).supportInv * (B * Bᴴ) := by
       simp [Matrix.mul_assoc]
     _ = Bᴴ * ((posSemidefBB B).supportInv * (B * Bᴴ)) := by simp [Matrix.mul_assoc]
     _ = Bᴴ * (posSemidefBB B).supportProj := by rw [hS]
-    _ = ((posSemidefBB B).supportProj * B)ᴴ := by simp [Matrix.conjTranspose_mul, (posSemidefBB B).supportProj_isHermitian.eq]
+    _ = ((posSemidefBB B).supportProj * B)ᴴ := by
+      simp [Matrix.conjTranspose_mul, (posSemidefBB B).supportProj_isHermitian.eq]
     _ = Bᴴ := by rw [hP]
 
 theorem pinv_mul_B_mul_C_eq_C (C B : Mat) (hC : C.mulVecLin.range ≤ Bᴴ.mulVecLin.range) :

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -69,8 +69,6 @@ theorem mul_pinv_eq_supportProj (B : Mat) :
     _ = (posSemidefBB B).isHermitian.supportProj := h
     _ = (posSemidefBB B).supportProj := rfl
 
-/-! ### Lemma: If A = B·C then AA† ≤ ‖C‖²·BB† -/
-
 theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
     A * Aᴴ ≤ (‖C‖ ^ 2 : ℝ) • (B * Bᴴ) := by
   rw [hA]
@@ -78,78 +76,70 @@ theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
   have h_BCstar : (B * C) * (B * C)ᴴ = B * (C * Cᴴ) * Bᴴ := by
     simp [Matrix.mul_assoc, Matrix.conjTranspose_mul]
   rw [h_BCstar]
-  let s : ℂ := (‖C‖ ^ 2 : ℝ)
-  let D := s • (B * Bᴴ) - (B * (C * Cᴴ) * Bᴴ)
-  have hD_herm : D.IsHermitian := by
-    have hBB_herm : (B * Bᴴ).IsHermitian := (posSemidefBB B).isHermitian
-    have h_CC_herm : (C * Cᴴ).IsHermitian := (posSemidefBB C).isHermitian
-    have h_s : IsSelfAdjoint s := by
-      dsimp [s, IsSelfAdjoint]
-      simp
-    have h1 : (s • (B * Bᴴ)).IsHermitian := hBB_herm.smul h_s
+  have h_herm : ((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ).IsHermitian := by
+    have hBB : (B * Bᴴ).IsHermitian := (posSemidefBB B).isHermitian
+    have hCC : (C * Cᴴ).IsHermitian := (posSemidefBB C).isHermitian
+    have h_s : IsSelfAdjoint (‖C‖ ^ 2 : ℝ) := IsSelfAdjoint.all _
+    have h1 : ((‖C‖ ^ 2 : ℝ) • (B * Bᴴ)).IsHermitian := hBB.smul h_s
     have h2 : (B * (C * Cᴴ) * Bᴴ).IsHermitian := by
       have h2' : (B * (C * Cᴴ) * Bᴴ)ᴴ = B * (C * Cᴴ) * Bᴴ := by
-        simp [h_CC_herm.eq]
+        simp [Matrix.mul_assoc]
       simpa [Matrix.IsHermitian] using h2'
     exact h1.sub h2
-  have hD_nonneg : ∀ x, 0 ≤ star x ⬝ᵥ (D *ᵥ x) := by
+  have h_nonneg : ∀ x, 0 ≤ star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ) *ᵥ x) := by
     intro x
     set y := Bᴴ *ᵥ x
     set z := Cᴴ *ᵥ y
-    have h_alpha : star x ⬝ᵥ ((B * Bᴴ) *ᵥ x) = star y ⬝ᵥ y := by
-      calc
-        star x ⬝ᵥ ((B * Bᴴ) *ᵥ x) = star x ⬝ᵥ (B *ᵥ (Bᴴ *ᵥ x)) := by
-          rw [Matrix.mulVec_mulVec]
-        _ = star (Bᴴ *ᵥ x) ⬝ᵥ (Bᴴ *ᵥ x) := star_dotProduct_mulVec B x (Bᴴ *ᵥ x)
-        _ = star y ⬝ᵥ y := rfl
-    have h_beta : star x ⬝ᵥ ((B * (C * Cᴴ) * Bᴴ) *ᵥ x) = star z ⬝ᵥ z := by
+    have hy_nonneg : 0 ≤ star y ⬝ᵥ y := dotProduct_star_self_nonneg y
+    have hz_nonneg : 0 ≤ star z ⬝ᵥ z := dotProduct_star_self_nonneg z
+    have hy_im_zero : (star y ⬝ᵥ y).im = 0 :=
+      (Complex.nonneg_iff.mp hy_nonneg).2.symm
+    have hz_im_zero : (star z ⬝ᵥ z).im = 0 :=
+      (Complex.nonneg_iff.mp hz_nonneg).2.symm
+    have h_BBstar : star x ⬝ᵥ ((B * Bᴴ) *ᵥ x) = star y ⬝ᵥ y := by
+      rw [← Matrix.mulVec_mulVec x B Bᴴ]
+      exact star_dotProduct_mulVec B x (Bᴴ *ᵥ x)
+    have h_BCCBstar : star x ⬝ᵥ ((B * (C * Cᴴ) * Bᴴ) *ᵥ x) = star z ⬝ᵥ z := by
       calc
         star x ⬝ᵥ ((B * (C * Cᴴ) * Bᴴ) *ᵥ x) =
             star x ⬝ᵥ (B *ᵥ ((C * Cᴴ) *ᵥ (Bᴴ *ᵥ x))) := by
-          simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]
+          simp [← Matrix.mulVec_mulVec, Matrix.mul_assoc]
         _ = star (Bᴴ *ᵥ x) ⬝ᵥ ((C * Cᴴ) *ᵥ (Bᴴ *ᵥ x)) :=
           star_dotProduct_mulVec B x _
         _ = star (Bᴴ *ᵥ x) ⬝ᵥ (C *ᵥ (Cᴴ *ᵥ (Bᴴ *ᵥ x))) := by
-          rw [Matrix.mulVec_mulVec]
+          rw [← Matrix.mulVec_mulVec (Bᴴ *ᵥ x) C Cᴴ]
         _ = star (Cᴴ *ᵥ (Bᴴ *ᵥ x)) ⬝ᵥ (Cᴴ *ᵥ (Bᴴ *ᵥ x)) :=
           star_dotProduct_mulVec C (Bᴴ *ᵥ x) _
-        _ = star z ⬝ᵥ z := rfl
-    have h_Dx_split : D *ᵥ x = (s • (B * Bᴴ)) *ᵥ x - (B * (C * Cᴴ) * Bᴴ) *ᵥ x := by
-      rw [sub_mulVec]
-    have h_dot_sub (u v : Fin D → ℂ) : star x ⬝ᵥ (u - v) = star x ⬝ᵥ u - star x ⬝ᵥ v := by
-      simp only [dotProduct, Finset.sum_sub_distrib, mul_sub, Pi.sub_apply]
-    have h_dot : star x ⬝ᵥ (D *ᵥ x) =
-        star x ⬝ᵥ ((s • (B * Bᴴ)) *ᵥ x) -
-        star x ⬝ᵥ ((B * (C * Cᴴ) * Bᴴ) *ᵥ x) := by
-      rw [h_Dx_split, h_dot_sub]
-    have h_first : star x ⬝ᵥ ((s • (B * Bᴴ)) *ᵥ x) = s • (star y ⬝ᵥ y) := by
-      simp [smul_mulVec, h_alpha, s]
-    rw [h_first, h_beta] at h_dot
-    rw [h_dot]
-    have hy_nonneg : 0 ≤ star y ⬝ᵥ y := dotProduct_star_self_nonneg y
-    have hz_nonneg : 0 ≤ star z ⬝ᵥ z := dotProduct_star_self_nonneg z
-    have h_norm_bound : RCLike.re (star z ⬝ᵥ z) ≤
-        ‖C‖ ^ 2 * RCLike.re (star y ⬝ᵥ y) := by
+    have h_norm_bound : (star z ⬝ᵥ z).re ≤ ‖C‖ ^ 2 * (star y ⬝ᵥ y).re := by
       have h := re_star_dotProduct_mulVec_le_opNorm_sq Cᴴ y
       have h_norm_Cstar : ‖Cᴴ‖ = ‖C‖ := Matrix.l2_opNorm_conjTranspose C
       rw [h_norm_Cstar] at h
       simpa [z] using h
+    have h_val : star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ) *ᵥ x) =
+        ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) - (star z ⬝ᵥ z) := by
+      calc
+        star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ) - B * (C * Cᴴ) * Bᴴ) *ᵥ x) =
+            star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ)) *ᵥ x -
+              (B * (C * Cᴴ) * Bᴴ) *ᵥ x) := by rw [sub_mulVec]
+        _ = (star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ)) *ᵥ x)) -
+            (star x ⬝ᵥ ((B * (C * Cᴴ) * Bᴴ) *ᵥ x)) := by
+          simp [dotProduct, Finset.sum_sub_distrib, mul_sub]
+        _ = (star x ⬝ᵥ (((‖C‖ ^ 2 : ℝ) • (B * Bᴴ)) *ᵥ x)) - star z ⬝ᵥ z := by
+          rw [h_BCCBstar]
+        _ = ((‖C‖ ^ 2 : ℝ) • (star x ⬝ᵥ ((B * Bᴴ) *ᵥ x))) - star z ⬝ᵥ z := by
+          simp [smul_mulVec]
+        _ = ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) - star z ⬝ᵥ z := by rw [h_BBstar]
+    rw [h_val]
+    have h_smul_re : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by
+    have h_smul_re : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by      calc        ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re = (((‖C‖ ^ 2 : ℝ) : ℂ) * (star y ⬝ᵥ y)).re := by simp        _ = ((‖C‖ ^ 2 : ℂ)).re * (star y ⬝ᵥ y).re - ((‖C‖ ^ 2 : ℂ)).im * (star y ⬝ᵥ y).im := by rw [Complex.mul_re]        _ = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re - 0 * (star y ⬝ᵥ y).im := by simp        _ = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by ring    have h_smul_im : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).im = (‖C‖ ^ 2) * (star y ⬝ᵥ y).im := by      calc        ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).im = (((‖C‖ ^ 2 : ℝ) : ℂ) * (star y ⬝ᵥ y)).im := by simp        _ = ((‖C‖ ^ 2 : ℂ)).re * (star y ⬝ᵥ y).im + ((‖C‖ ^ 2 : ℂ)).im * (star y ⬝ᵥ y).re := by rw [Complex.mul_im]        _ = (‖C‖ ^ 2) * (star y ⬝ᵥ y).im + 0 * (star y ⬝ᵥ y).re := by simp        _ = (‖C‖ ^ 2) * (star y ⬝ᵥ y).im := by ring      rw [Complex.sub_im, h_smul_im, hy_im_zero, hz_im_zero]
+      ring
     rw [Complex.nonneg_iff]
     constructor
-    · have hy_re_nonneg : 0 ≤ RCLike.re (star y ⬝ᵥ y) :=
-        (Complex.nonneg_iff.mp hy_nonneg).1
-      have hs_real : RCLike.re s = ‖C‖ ^ 2 := by
-        simp [s]
-      simp [RCLike.re_sub, RCLike.re_smul_ofReal, s, hs_real]
-      nlinarith
-    · have hy_im_zero : RCLike.im (star y ⬝ᵥ y) = 0 :=
-        (Complex.nonneg_iff.mp hy_nonneg).2
-      have hz_im_zero : RCLike.im (star z ⬝ᵥ z) = 0 :=
-        (Complex.nonneg_iff.mp hz_nonneg).2
-      simp [RCLike.im_sub, RCLike.im_smul, s, hy_im_zero, hz_im_zero]
-  have h_s_eq : s • (B * Bᴴ) = (‖C‖ ^ 2 : ℝ) • (B * Bᴴ) := by simp [s]
-  rw [h_s_eq]
-  exact Matrix.PosSemidef.of_dotProduct_mulVec_nonneg hD_herm hD_nonneg
+    · rw [h_re]
+      nlinarith [h_norm_bound, (Complex.nonneg_iff.mp hy_nonneg).1,
+        (Complex.nonneg_iff.mp hz_nonneg).1]
+    · rw [h_im]
+  exact Matrix.PosSemidef.of_dotProduct_mulVec_nonneg h_herm h_nonneg
 
 theorem supportProj_mul_eq_of_conjTranspose_le (A B : Mat) (μ : ℝ) (_hμ : 0 ≤ μ)
     (hle : A * Aᴴ ≤ μ • (B * Bᴴ)) :
@@ -206,7 +196,7 @@ theorem douglas_tfae (A B : Mat) : List.TFAE [
     intro h; rcases h with ⟨C, hC⟩; subst hC
     intro x hx; rcases hx with ⟨v, rfl⟩
     refine ⟨C *ᵥ v, ?_⟩
-    simp [Matrix.mulVecLin_apply, Matrix.mulVec_mulVec]
+    rw [Matrix.mulVecLin_apply, Matrix.mulVec_mulVec, Matrix.mulVecLin_apply]
   tfae_have h12 : 1 → 2 := by
     intro hAB
     rcases factorization_of_range_mulVecLin_le hAB with ⟨C, hC⟩
@@ -228,8 +218,9 @@ theorem douglas_tfae (A B : Mat) : List.TFAE [
 theorem factorization_pinv (A B : Mat) (hAB : A.mulVecLin.range ≤ B.mulVecLin.range) :
     B * (pinv B * A) = A := by
   have hSPA : (posSemidefBB B).supportProj * A = A := by
-    rcases (douglas_tfae A B).out 0 1 hAB with ⟨μ, hμ, hle⟩
-    exact supportProj_mul_eq_of_conjTranspose_le A B μ hμ hle
+    have hle := ((douglas_tfae A B).out 0 1 (by rfl) (by rfl)).mp hAB
+    rcases hle with ⟨μ, hμ, hle'⟩
+    exact supportProj_mul_eq_of_conjTranspose_le A B μ hμ hle'
   calc
     B * (pinv B * A) = (B * pinv B) * A := by simp [Matrix.mul_assoc]
     _ = (posSemidefBB B).supportProj * A := by rw [mul_pinv_eq_supportProj B]

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -130,8 +130,27 @@ theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
           simp [smul_mulVec]
         _ = ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) - star z ⬝ᵥ z := by rw [h_BBstar]
     rw [h_val]
+    have h_sq_re : ((‖C‖ : ℂ) ^ 2).re = ‖C‖ ^ 2 := by
+      simp [sq]
+    have h_sq_im : ((‖C‖ : ℂ) ^ 2).im = 0 := by
+      simp [sq]
     have h_smul_re : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by
-    have h_smul_re : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by      calc        ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).re = (((‖C‖ ^ 2 : ℝ) : ℂ) * (star y ⬝ᵥ y)).re := by simp        _ = ((‖C‖ ^ 2 : ℂ)).re * (star y ⬝ᵥ y).re - ((‖C‖ ^ 2 : ℂ)).im * (star y ⬝ᵥ y).im := by rw [Complex.mul_re]        _ = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re - 0 * (star y ⬝ᵥ y).im := by simp        _ = (‖C‖ ^ 2) * (star y ⬝ᵥ y).re := by ring    have h_smul_im : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).im = (‖C‖ ^ 2) * (star y ⬝ᵥ y).im := by      calc        ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).im = (((‖C‖ ^ 2 : ℝ) : ℂ) * (star y ⬝ᵥ y)).im := by simp        _ = ((‖C‖ ^ 2 : ℂ)).re * (star y ⬝ᵥ y).im + ((‖C‖ ^ 2 : ℂ)).im * (star y ⬝ᵥ y).re := by rw [Complex.mul_im]        _ = (‖C‖ ^ 2) * (star y ⬝ᵥ y).im + 0 * (star y ⬝ᵥ y).re := by simp        _ = (‖C‖ ^ 2) * (star y ⬝ᵥ y).im := by ring      rw [Complex.sub_im, h_smul_im, hy_im_zero, hz_im_zero]
+      have h_eq : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) = ((‖C‖ : ℂ) * ((‖C‖ : ℂ) * (star y ⬝ᵥ y))) := by
+        simp [sq, mul_assoc]
+      rw [h_eq, Complex.mul_re, Complex.mul_re]
+      simp [sq]
+      ring
+    have h_smul_im : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)).im = (‖C‖ ^ 2) * (star y ⬝ᵥ y).im := by
+      have h_eq : ((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) = ((‖C‖ : ℂ) * ((‖C‖ : ℂ) * (star y ⬝ᵥ y))) := by
+        simp [sq, mul_assoc]
+      rw [h_eq, Complex.mul_im, Complex.mul_im]
+      simp [sq]
+      ring
+    have h_re : (((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) - (star z ⬝ᵥ z)).re =
+        (‖C‖ ^ 2) * (star y ⬝ᵥ y).re - (star z ⬝ᵥ z).re := by
+      rw [Complex.sub_re, h_smul_re]
+    have h_im : (((‖C‖ ^ 2 : ℝ) • (star y ⬝ᵥ y)) - (star z ⬝ᵥ z)).im = 0 := by
+      rw [Complex.sub_im, h_smul_im, hy_im_zero, hz_im_zero]
       ring
     rw [Complex.nonneg_iff]
     constructor

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -296,7 +296,7 @@ theorem factorization_pinv (A B : Mat) (hAB : A.mulVecLin.range ≤ B.mulVecLin.
     _ = A := hSPA
 
 
-/-! ## Wolf moreover clauses -/
+/-! ## Moreover clauses of Douglas' theorem -/
 
 /-- `(pinv B * B)` is idempotent. -/
 theorem pinv_mul_B_idem (B : Mat) : (pinv B * B) * (pinv B * B) = pinv B * B := by
@@ -405,7 +405,7 @@ theorem pinv_norm_minimal (A B C : Mat) (hA : A = B * C) : ‖pinv B * A‖ ≤ 
       _ = ‖C‖ := by simp
 
 
-/-! ## Uniqueness (Wolf moreover (i)+(ii)) -/
+/-! ## Uniqueness of the factorization under the support constraint -/
 
 theorem pinv_mul_B_mul_conjTranspose (B : Mat) : pinv B * B * Bᴴ = Bᴴ := by
   unfold pinv

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -4,31 +4,20 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Basic
+import TNLean.Algebra.MatrixAux
+import TNLean.Analysis.MatrixSqrt
 import Mathlib.LinearAlgebra.Matrix.ToLin
+import Mathlib.Analysis.Matrix.Normed
+import Mathlib.Analysis.Matrix.Order
 
-/-!
-# Douglas factorization: range inclusion implies right factorization
-
-This file states the easy algebraic half of Wolf's Douglas theorem in the
-finite-dimensional matrix setting: if the range of `A` is contained in the range
-of `B`, then `A = B * C` for some matrix `C`.
-
-## References
-
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 5.1][Wolf2012QChannels]
--/
-
-open scoped Matrix
+open scoped Matrix MatrixOrder ComplexOrder Matrix.Norms.L2Operator
 open Matrix
 
 namespace Douglas
 
 variable {D : ℕ}
-
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-- Finite-dimensional factorization form of the easy direction of Douglas' theorem:
-range inclusion for `mulVec` implies a right factorization. -/
 theorem factorization_of_range_mulVecLin_le
     {A B : Mat} (hAB : A.mulVecLin.range ≤ B.mulVecLin.range) :
     ∃ C : Mat, A = B * C := by
@@ -48,29 +37,202 @@ theorem factorization_of_range_mulVecLin_le
   refine ⟨C, ?_⟩
   apply Matrix.ext_col
   intro j
-  have hCcol : C.col j = c j := by
-    ext i
-    rfl
+  have hCcol : C.col j = c j := by ext i; rfl
   calc
-    A.col j = B.mulVec (c j) := by
-      symm
-      exact hc j
+    A.col j = B.mulVec (c j) := by symm; exact hc j
     _ = B.mulVec (C.col j) := by rw [hCcol]
-    _ = B.mulVec (C.mulVec (Pi.single j 1)) := by
-      rw [Matrix.mulVec_single_one]
+    _ = B.mulVec (C.mulVec (Pi.single j 1)) := by rw [Matrix.mulVec_single_one]
     _ = (B * C).mulVec (Pi.single j 1) := by
       simpa using (Matrix.mulVec_mulVec (Pi.single j 1) B C)
-    _ = (B * C).col j := by
-      exact Matrix.mulVec_single_one (B * C) j
+    _ = (B * C).col j := by exact Matrix.mulVec_single_one (B * C) j
 
-/-- User-facing vectorwise range-inclusion form of the easy direction of Douglas' theorem. -/
 theorem factorization_of_forall_mulVec_mem_range
-    {A B : Mat}
-    (hAB : ∀ v : Fin D → ℂ, A.mulVec v ∈ B.mulVecLin.range) :
+    {A B : Mat} (hAB : ∀ v : Fin D → ℂ, A.mulVec v ∈ B.mulVecLin.range) :
     ∃ C : Mat, A = B * C := by
   apply factorization_of_range_mulVecLin_le
-  intro w hw
-  rcases hw with ⟨v, rfl⟩
+  intro w hw; rcases hw with ⟨v, rfl⟩
   simpa [Matrix.mulVecLin_apply] using hAB v
+
+noncomputable def pinv (B : Mat) : Mat :=
+  Bᴴ * (Matrix.PosSemidef.supportInv (Matrix.posSemidef_self_mul_conjTranspose B))
+
+abbrev posSemidefBB (B : Mat) : (B * Bᴴ).PosSemidef :=
+  Matrix.posSemidef_self_mul_conjTranspose B
+
+theorem mul_pinv_eq_supportProj (B : Mat) :
+    B * pinv B = (posSemidefBB B).supportProj := by
+  unfold pinv
+  have h := (posSemidefBB B).self_mul_supportInv
+  calc
+    B * (Bᴴ * (posSemidefBB B).supportInv) = (B * Bᴴ) * (posSemidefBB B).supportInv := by
+      simp [Matrix.mul_assoc]
+    _ = (posSemidefBB B).isHermitian.supportProj := h
+    _ = (posSemidefBB B).supportProj := rfl
+
+/-! ### Lemma: If A = B·C then AA† ≤ ‖C‖²·BB† -/
+
+theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
+    A * Aᴴ ≤ (‖C‖ ^ 2 : ℝ) • (B * Bᴴ) := by
+  rw [hA]
+  rw [Matrix.le_iff]
+  have h_BCstar : (B * C) * (B * C)ᴴ = B * (C * Cᴴ) * Bᴴ := by
+    simp [Matrix.mul_assoc, Matrix.conjTranspose_mul]
+  rw [h_BCstar]
+  let s : ℂ := (‖C‖ ^ 2 : ℝ)
+  let D := s • (B * Bᴴ) - (B * (C * Cᴴ) * Bᴴ)
+  have hD_herm : D.IsHermitian := by
+    have hBB_herm : (B * Bᴴ).IsHermitian := (posSemidefBB B).isHermitian
+    have h_CC_herm : (C * Cᴴ).IsHermitian := (posSemidefBB C).isHermitian
+    have h_s : IsSelfAdjoint s := by
+      dsimp [s, IsSelfAdjoint]
+      simp
+    have h1 : (s • (B * Bᴴ)).IsHermitian := hBB_herm.smul h_s
+    have h2 : (B * (C * Cᴴ) * Bᴴ).IsHermitian := by
+      have h2' : (B * (C * Cᴴ) * Bᴴ)ᴴ = B * (C * Cᴴ) * Bᴴ := by
+        simp [h_CC_herm.eq]
+      simpa [Matrix.IsHermitian] using h2'
+    exact h1.sub h2
+  have hD_nonneg : ∀ x, 0 ≤ star x ⬝ᵥ (D *ᵥ x) := by
+    intro x
+    set y := Bᴴ *ᵥ x
+    set z := Cᴴ *ᵥ y
+    have h_alpha : star x ⬝ᵥ ((B * Bᴴ) *ᵥ x) = star y ⬝ᵥ y := by
+      calc
+        star x ⬝ᵥ ((B * Bᴴ) *ᵥ x) = star x ⬝ᵥ (B *ᵥ (Bᴴ *ᵥ x)) := by
+          rw [Matrix.mulVec_mulVec]
+        _ = star (Bᴴ *ᵥ x) ⬝ᵥ (Bᴴ *ᵥ x) := star_dotProduct_mulVec B x (Bᴴ *ᵥ x)
+        _ = star y ⬝ᵥ y := rfl
+    have h_beta : star x ⬝ᵥ ((B * (C * Cᴴ) * Bᴴ) *ᵥ x) = star z ⬝ᵥ z := by
+      calc
+        star x ⬝ᵥ ((B * (C * Cᴴ) * Bᴴ) *ᵥ x) =
+            star x ⬝ᵥ (B *ᵥ ((C * Cᴴ) *ᵥ (Bᴴ *ᵥ x))) := by
+          simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]
+        _ = star (Bᴴ *ᵥ x) ⬝ᵥ ((C * Cᴴ) *ᵥ (Bᴴ *ᵥ x)) :=
+          star_dotProduct_mulVec B x _
+        _ = star (Bᴴ *ᵥ x) ⬝ᵥ (C *ᵥ (Cᴴ *ᵥ (Bᴴ *ᵥ x))) := by
+          rw [Matrix.mulVec_mulVec]
+        _ = star (Cᴴ *ᵥ (Bᴴ *ᵥ x)) ⬝ᵥ (Cᴴ *ᵥ (Bᴴ *ᵥ x)) :=
+          star_dotProduct_mulVec C (Bᴴ *ᵥ x) _
+        _ = star z ⬝ᵥ z := rfl
+    have h_Dx_split : D *ᵥ x = (s • (B * Bᴴ)) *ᵥ x - (B * (C * Cᴴ) * Bᴴ) *ᵥ x := by
+      rw [sub_mulVec]
+    have h_dot_sub (u v : Fin D → ℂ) : star x ⬝ᵥ (u - v) = star x ⬝ᵥ u - star x ⬝ᵥ v := by
+      simp only [dotProduct, Finset.sum_sub_distrib, mul_sub, Pi.sub_apply]
+    have h_dot : star x ⬝ᵥ (D *ᵥ x) =
+        star x ⬝ᵥ ((s • (B * Bᴴ)) *ᵥ x) -
+        star x ⬝ᵥ ((B * (C * Cᴴ) * Bᴴ) *ᵥ x) := by
+      rw [h_Dx_split, h_dot_sub]
+    have h_first : star x ⬝ᵥ ((s • (B * Bᴴ)) *ᵥ x) = s • (star y ⬝ᵥ y) := by
+      simp [smul_mulVec, h_alpha, s]
+    rw [h_first, h_beta] at h_dot
+    rw [h_dot]
+    have hy_nonneg : 0 ≤ star y ⬝ᵥ y := dotProduct_star_self_nonneg y
+    have hz_nonneg : 0 ≤ star z ⬝ᵥ z := dotProduct_star_self_nonneg z
+    have h_norm_bound : RCLike.re (star z ⬝ᵥ z) ≤
+        ‖C‖ ^ 2 * RCLike.re (star y ⬝ᵥ y) := by
+      have h := re_star_dotProduct_mulVec_le_opNorm_sq Cᴴ y
+      have h_norm_Cstar : ‖Cᴴ‖ = ‖C‖ := Matrix.l2_opNorm_conjTranspose C
+      rw [h_norm_Cstar] at h
+      simpa [z] using h
+    rw [Complex.nonneg_iff]
+    constructor
+    · have hy_re_nonneg : 0 ≤ RCLike.re (star y ⬝ᵥ y) :=
+        (Complex.nonneg_iff.mp hy_nonneg).1
+      have hs_real : RCLike.re s = ‖C‖ ^ 2 := by
+        simp [s]
+      simp [RCLike.re_sub, RCLike.re_smul_ofReal, s, hs_real]
+      nlinarith
+    · have hy_im_zero : RCLike.im (star y ⬝ᵥ y) = 0 :=
+        (Complex.nonneg_iff.mp hy_nonneg).2
+      have hz_im_zero : RCLike.im (star z ⬝ᵥ z) = 0 :=
+        (Complex.nonneg_iff.mp hz_nonneg).2
+      simp [RCLike.im_sub, RCLike.im_smul, s, hy_im_zero, hz_im_zero]
+  have h_s_eq : s • (B * Bᴴ) = (‖C‖ ^ 2 : ℝ) • (B * Bᴴ) := by simp [s]
+  rw [h_s_eq]
+  exact Matrix.PosSemidef.of_dotProduct_mulVec_nonneg hD_herm hD_nonneg
+
+theorem supportProj_mul_eq_of_conjTranspose_le (A B : Mat) (μ : ℝ) (_hμ : 0 ≤ μ)
+    (hle : A * Aᴴ ≤ μ • (B * Bᴴ)) :
+    (posSemidefBB B).supportProj * A = A := by
+  let P := (posSemidefBB B).supportProj
+  let Q := 1 - P
+  have hQ_herm : Qᴴ = Q := by
+    have hP_herm := (posSemidefBB B).supportProj_isHermitian
+    simp [Q, P, hP_herm.eq]
+  have hQ_mul_BBstar : Q * (B * Bᴴ) = 0 := by
+    have hP_mul_BBstar : P * (B * Bᴴ) = B * Bᴴ :=
+      (posSemidefBB B).supportProj_mul_self
+    dsimp [Q, P]
+    calc
+      (1 - P) * (B * Bᴴ) = (B * Bᴴ) - P * (B * Bᴴ) := by simp [Matrix.sub_mul]
+      _ = (B * Bᴴ) - (B * Bᴴ) := by rw [hP_mul_BBstar]
+      _ = 0 := by simp
+  have h_conj_ineq : Q * (A * Aᴴ) * Q ≤ Q * (μ • (B * Bᴴ)) * Q := by
+    rw [Matrix.le_iff] at hle ⊢
+    have hdiff : Q * (μ • (B * Bᴴ)) * Q - Q * (A * Aᴴ) * Q =
+        Q * ((μ • (B * Bᴴ)) - A * Aᴴ) * Qᴴ := by
+      simp [Matrix.mul_assoc, Matrix.sub_mul, Matrix.mul_sub, hQ_herm]
+    rw [hdiff]
+    exact hle.mul_mul_conjTranspose_same Q
+  have h_RHS : Q * (μ • (B * Bᴴ)) * Q = 0 := by
+    calc
+      Q * (μ • (B * Bᴴ)) * Q = (μ : ℂ) • (Q * (B * Bᴴ) * Q) := by simp
+      _ = (μ : ℂ) • ((Q * (B * Bᴴ)) * Q) := by ring
+      _ = (μ : ℂ) • (0 * Q) := by rw [hQ_mul_BBstar]
+      _ = 0 := by simp
+  rw [h_RHS] at h_conj_ineq
+  have h_LHS : Q * (A * Aᴴ) * Q = (Q * A) * (Q * A)ᴴ := by
+    calc
+      Q * (A * Aᴴ) * Q = (Q * A) * (Aᴴ * Q) := by simp [Matrix.mul_assoc]
+      _ = (Q * A) * ((Qᴴ * A)ᴴ) := by simp [Matrix.conjTranspose_mul, hQ_herm]
+      _ = (Q * A) * (Q * A)ᴴ := by
+        simp [Matrix.conjTranspose_mul, hQ_herm, Matrix.mul_assoc]
+  rw [h_LHS] at h_conj_ineq
+  have h_LHS_nonneg : 0 ≤ (Q * A) * (Q * A)ᴴ :=
+    (Matrix.posSemidef_self_mul_conjTranspose (Q * A)).nonneg
+  have h_sq_zero : (Q * A) * (Q * A)ᴴ = 0 :=
+    le_antisymm h_conj_ineq h_LHS_nonneg
+  have h_QA_zero : Q * A = 0 := (self_mul_conjTranspose_eq_zero.mp h_sq_zero)
+  dsimp [P, Q] at h_QA_zero ⊢
+  rw [Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at h_QA_zero
+  exact h_QA_zero.symm
+
+theorem douglas_tfae (A B : Mat) : List.TFAE [
+    A.mulVecLin.range ≤ B.mulVecLin.range,
+    ∃ (μ : ℝ), 0 ≤ μ ∧ A * Aᴴ ≤ μ • (B * Bᴴ),
+    ∃ C : Mat, A = B * C
+  ] := by
+  tfae_have h31 : 3 → 1 := by
+    intro h; rcases h with ⟨C, hC⟩; subst hC
+    intro x hx; rcases hx with ⟨v, rfl⟩
+    refine ⟨C *ᵥ v, ?_⟩
+    simp [Matrix.mulVecLin_apply, Matrix.mulVec_mulVec]
+  tfae_have h12 : 1 → 2 := by
+    intro hAB
+    rcases factorization_of_range_mulVecLin_le hAB with ⟨C, hC⟩
+    exact ⟨‖C‖ ^ 2, pow_two_nonneg _, le_norm_sq_mul_of_factorization A B C hC⟩
+  tfae_have h23 : 2 → 3 := by
+    intro h; rcases h with ⟨μ, hμ, hle⟩
+    have hSPA : (posSemidefBB B).supportProj * A = A :=
+      supportProj_mul_eq_of_conjTranspose_le A B μ hμ hle
+    let C := pinv B * A
+    have hBC : A = B * C := by
+      calc
+        A = (posSemidefBB B).supportProj * A := hSPA.symm
+        _ = (B * pinv B) * A := by rw [mul_pinv_eq_supportProj B]
+        _ = B * (pinv B * A) := by simp [Matrix.mul_assoc]
+        _ = B * C := rfl
+    refine ⟨C, hBC⟩
+  tfae_finish
+
+theorem factorization_pinv (A B : Mat) (hAB : A.mulVecLin.range ≤ B.mulVecLin.range) :
+    B * (pinv B * A) = A := by
+  have hSPA : (posSemidefBB B).supportProj * A = A := by
+    rcases (douglas_tfae A B).out 0 1 hAB with ⟨μ, hμ, hle⟩
+    exact supportProj_mul_eq_of_conjTranspose_le A B μ hμ hle
+  calc
+    B * (pinv B * A) = (B * pinv B) * A := by simp [Matrix.mul_assoc]
+    _ = (posSemidefBB B).supportProj * A := by rw [mul_pinv_eq_supportProj B]
+    _ = A := hSPA
 
 end Douglas

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -267,7 +267,7 @@ theorem pinv_mul_B_herm (B : Mat) : (pinv B * B)ᴴ = pinv B * B := by
     simp [Matrix.conjTranspose_mul, hSqrt.eq]
   simp [Matrix.conjTranspose_mul, Matrix.mul_assoc, hS_herm]
 
-/-! ### EDIT 1: norm_pinv_mul_B_le_one -/
+/-! ### Projection contraction -/
 
 theorem norm_pinv_mul_B_le_one (B : Mat) : ‖pinv B * B‖ ≤ 1 := by
   let P := pinv B * B
@@ -341,7 +341,7 @@ theorem norm_pinv_mul_B_le_one (B : Mat) : ‖pinv B * B‖ ≤ 1 := by
   rw [h_norm_sq_Px, h_norm_sq_x] at h_bound
   nlinarith [norm_nonneg ((EuclideanSpace.equiv (Fin D) ℂ).symm x)]
 
-/-! ### EDIT 3: pinv_norm_minimal -/
+/-! ### Norm minimality of the pseudoinverse factorization -/
 
 theorem pinv_norm_minimal (A B C : Mat) (hA : A = B * C) : ‖pinv B * A‖ ≤ ‖C‖ := by
   by_cases hCzero : ‖C‖ = 0

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -245,4 +245,116 @@ theorem factorization_pinv (A B : Mat) (hAB : A.mulVecLin.range ≤ B.mulVecLin.
     _ = (posSemidefBB B).supportProj * A := by rw [mul_pinv_eq_supportProj B]
     _ = A := hSPA
 
+
+/-! ## Wolf moreover clauses -/
+
+/-- `(pinv B * B)` is idempotent. -/
+theorem pinv_mul_B_idem (B : Mat) : (pinv B * B) * (pinv B * B) = pinv B * B := by
+  have h := Matrix.supportProj_mul_conjTranspose_mul_self B
+  calc
+    (pinv B * B) * (pinv B * B) = pinv B * (B * pinv B) * B := by simp [Matrix.mul_assoc]
+    _ = pinv B * (posSemidefBB B).supportProj * B := by rw [mul_pinv_eq_supportProj B]
+    _ = pinv B * ((posSemidefBB B).supportProj * B) := by simp [Matrix.mul_assoc]
+    _ = pinv B * B := by
+      simpa [posSemidefBB, Matrix.PosSemidef.supportProj] using congrArg (fun (M : Mat) => pinv B * M) h
+
+/-- `(pinv B * B)` is Hermitian. -/
+theorem pinv_mul_B_herm (B : Mat) : (pinv B * B)ᴴ = pinv B * B := by
+  unfold pinv
+  have hS_herm : ((posSemidefBB B).supportInv)ᴴ = (posSemidefBB B).supportInv := by
+    have hSqrt := Matrix.PosSemidef.supportInvSqrt_isHermitian (posSemidefBB B)
+    unfold Matrix.PosSemidef.supportInv
+    simp [Matrix.conjTranspose_mul, hSqrt.eq]
+  simp [Matrix.conjTranspose_mul, Matrix.mul_assoc, hS_herm]
+
+/-! ### EDIT 1: norm_pinv_mul_B_le_one -/
+
+theorem norm_pinv_mul_B_le_one (B : Mat) : ‖pinv B * B‖ ≤ 1 := by
+  let P := pinv B * B
+  have hP_idem : P * P = P := pinv_mul_B_idem B
+  have hP_herm : Pᴴ = P := pinv_mul_B_herm B
+  -- Projection: ⟨y,P·y⟩ = ⟨P·y,P·y⟩
+  have h_proj (y : Fin D → ℂ) : dotProduct (star y) (mulVec P y) =
+      dotProduct (star (mulVec P y)) (mulVec P y) := by
+    calc
+      dotProduct (star y) (mulVec P y) = dotProduct (star y) (mulVec (P * P) y) := by rw [hP_idem]
+      _ = dotProduct (star y) (mulVec P (mulVec P y)) := by rw [Matrix.mulVec_mulVec]
+      _ = dotProduct (star (mulVec (Pᴴ) y)) (mulVec P y) := by rw [star_dotProduct_mulVec P y (mulVec P y)]
+      _ = dotProduct (star (mulVec P y)) (mulVec P y) := by rw [hP_herm]
+  -- I-P is also a projection
+  let IP := 1 - P
+  have hIP_idem : IP * IP = IP := by
+    calc
+      (1 - P) * (1 - P) = 1 - P - P + P * P := by noncomm_ring
+      _ = 1 - P := by rw [hP_idem]; abel
+  have hIP_herm : IPᴴ = IP := by dsimp [IP]; simp [hP_herm]
+  -- ‖P·y‖² ≤ ‖y‖² via 0 ≤ ⟨y,(I-P)·y⟩ = ⟨y,y⟩−⟨y,P·y⟩
+  have h_contract (y : Fin D → ℂ) :
+      RCLike.re (dotProduct (star (mulVec P y)) (mulVec P y)) ≤
+      RCLike.re (dotProduct (star y) y) := by
+    -- 0 ≤ ⟨y,(I-P)·y⟩ = ⟨(I-P)·y,(I-P)·y⟩
+    have h_nonneg_IP : 0 ≤ dotProduct (star y) (mulVec IP y) := by
+      calc
+        dotProduct (star y) (mulVec IP y) =
+            dotProduct (star y) (mulVec (IP * IP) y) := by rw [hIP_idem]
+        _ = dotProduct (star y) (mulVec IP (mulVec IP y)) := by rw [Matrix.mulVec_mulVec]
+        _ = dotProduct (star (mulVec (IPᴴ) y)) (mulVec IP y) := by
+          rw [star_dotProduct_mulVec IP y (mulVec IP y)]
+        _ = dotProduct (star (mulVec IP y)) (mulVec IP y) := by rw [hIP_herm]
+        _ ≥ 0 := dotProduct_star_self_nonneg _
+    -- ⟨y,(I-P)·y⟩ = ⟨y,y⟩ − ⟨y,P·y⟩
+    have dot_sub_right (a b c : Fin D → ℂ) : dotProduct a (b - c) = dotProduct a b - dotProduct a c := by
+      simp [dotProduct, Finset.sum_sub_distrib, mul_sub]
+    have h_expand : dotProduct (star y) (mulVec IP y) =
+        dotProduct (star y) y - dotProduct (star y) (mulVec P y) := by
+      calc
+        dotProduct (star y) (mulVec IP y) = dotProduct (star y) (mulVec (1 - P) y) := rfl
+        _ = dotProduct (star y) (mulVec 1 y - mulVec P y) := by rw [Matrix.sub_mulVec]
+        _ = dotProduct (star y) (y - mulVec P y) := by simp
+        _ = dotProduct (star y) y - dotProduct (star y) (mulVec P y) :=
+          dot_sub_right (star y) y (mulVec P y)
+    rw [h_expand] at h_nonneg_IP
+    -- h_nonneg_IP: 0 ≤ star y·y - star y·(P·y) in ℂ order
+    -- Extract real parts: 0 ≤ re(star y·y) - re(star y·(P·y))
+    have h_re : 0 ≤ RCLike.re (dotProduct (star y) y) -
+        RCLike.re (dotProduct (star y) (mulVec P y)) := by
+      -- From 0 ≤ a - b in ℂ, we get 0 ≤ re(a) - re(b)
+      have h := (Complex.nonneg_iff.mp h_nonneg_IP).1
+      -- h: 0 ≤ RCLike.re (star y·y - star y·(P·y))
+      -- But RCLike.re (a-b) = RCLike.re a - RCLike.re b (for a,b real? Actually always for ℂ: re(a-b) = re(a)-re(b))
+      -- Use Complex.sub_re: (a - b).re = a.re - b.re
+      -- RCLike.re = .re, so this works
+      simpa [Complex.sub_re] using h
+    -- re(star y·(P·y)) = re(star(P·y)·(P·y)) [by h_proj]
+    rw [h_proj y] at h_re
+    linarith
+  apply l2_opNorm_le_of_forall (by norm_num : (0 : ℝ) ≤ 1)
+  intro x
+  have h_bound : RCLike.re (dotProduct (star (mulVec P x)) (mulVec P x)) ≤
+      RCLike.re (dotProduct (star x) x) := h_contract x
+  have h_norm_sq_Px : RCLike.re (dotProduct (star (mulVec P x)) (mulVec P x)) =
+      ‖(EuclideanSpace.equiv (Fin D) ℂ).symm (mulVec P x)‖ ^ 2 :=
+    re_star_dotProduct_self_eq_norm_sq (mulVec P x)
+  have h_norm_sq_x : RCLike.re (dotProduct (star x) x) =
+      ‖(EuclideanSpace.equiv (Fin D) ℂ).symm x‖ ^ 2 :=
+    re_star_dotProduct_self_eq_norm_sq x
+  rw [h_norm_sq_Px, h_norm_sq_x] at h_bound
+  nlinarith [norm_nonneg ((EuclideanSpace.equiv (Fin D) ℂ).symm x)]
+
+/-! ### EDIT 3: pinv_norm_minimal -/
+
+theorem pinv_norm_minimal (A B C : Mat) (hA : A = B * C) : ‖pinv B * A‖ ≤ ‖C‖ := by
+  by_cases hCzero : ‖C‖ = 0
+  · have hC : C = 0 := norm_eq_zero.mp hCzero
+    rw [hC, mul_zero] at hA
+    rw [hA, mul_zero]
+    simp
+  · have hpos : 0 < ‖C‖ := lt_of_le_of_ne (norm_nonneg C) (Ne.symm hCzero)
+    rw [hA]
+    calc
+      ‖pinv B * (B * C)‖ = ‖(pinv B * B) * C‖ := by simp [Matrix.mul_assoc]
+      _ ≤ ‖pinv B * B‖ * ‖C‖ := Matrix.l2_opNorm_mul _ _
+      _ ≤ 1 * ‖C‖ := by nlinarith [norm_pinv_mul_B_le_one B]
+      _ = ‖C‖ := by simp
+
 end Douglas

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -47,6 +47,9 @@ namespace Douglas
 variable {D : ℕ}
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
+/-- Finite-dimensional factorization form of the easy direction of Douglas'
+theorem: range inclusion for `mulVec` implies a right factorization
+`A = B * C` (columnwise construction). -/
 theorem factorization_of_range_mulVecLin_le
     {A B : Mat} (hAB : A.mulVecLin.range ≤ B.mulVecLin.range) :
     ∃ C : Mat, A = B * C := by
@@ -82,9 +85,15 @@ theorem factorization_of_forall_mulVec_mem_range
   intro w hw; rcases hw with ⟨v, rfl⟩
   simpa [Matrix.mulVecLin_apply] using hAB v
 
+/-- The **Moore–Penrose pseudoinverse** `B⁺ := Bᴴ (B Bᴴ)⁻¹_supp`, with the
+support inverse from `Matrix.PosSemidef.supportInv`. This is Wolf's
+"inverse on the range": `B * B⁺` is the support projection of `B Bᴴ`
+(`mul_pinv_eq_supportProj`). -/
 noncomputable def pinv (B : Mat) : Mat :=
   Bᴴ * (Matrix.PosSemidef.supportInv (Matrix.posSemidef_self_mul_conjTranspose B))
 
+/-- The matrix `B * Bᴴ` is positive semidefinite (the PSD certificate used
+throughout the Douglas development for the support-inverse `(B Bᴴ)⁻¹_supp`). -/
 abbrev posSemidefBB (B : Mat) : (B * Bᴴ).PosSemidef :=
   Matrix.posSemidef_self_mul_conjTranspose B
 
@@ -241,6 +250,12 @@ theorem supportProj_mul_eq_of_conjTranspose_le (A B : Mat) (μ : ℝ) (_hμ : 0 
   rw [Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at h_QA_zero
   exact h_QA_zero.symm
 
+/-- **Douglas' theorem** (Wolf, *Quantum Channels & Operations*, Ch. 5,
+Theorem at `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex` line 88).
+
+For finite matrices `A`, `B` the following are equivalent: (i) the range
+inclusion `ran A ⊆ ran B`, (ii) the factorization `A = B C` for some `C`, and
+(iii) the quadratic domination `AA† ≤ λ² · BB†` for some `λ ≥ 0`. -/
 theorem douglas_tfae (A B : Mat) : List.TFAE [
     A.mulVecLin.range ≤ B.mulVecLin.range,
     ∃ (μ : ℝ), 0 ≤ μ ∧ A * Aᴴ ≤ μ • (B * Bᴴ),

--- a/TNLean/Channel/Schwarz/Douglas.lean
+++ b/TNLean/Channel/Schwarz/Douglas.lean
@@ -11,7 +11,7 @@ import Mathlib.Analysis.Matrix.Normed
 import Mathlib.Analysis.Matrix.Order
 
 /-!
-# Douglas' theorem (Wolf Ch5, Theorem at line 88)
+# Douglas factorization theorem
 
 Douglas' theorem for finite matrices: the range inclusion
 `ran A ⊆ ran B` is equivalent to a factorization `A = BC`
@@ -204,7 +204,7 @@ theorem le_norm_sq_mul_of_factorization (A B C : Mat) (hA : A = B * C) :
     · rw [h_im]
   exact Matrix.PosSemidef.of_dotProduct_mulVec_nonneg h_herm h_nonneg
 
-theorem supportProj_mul_eq_of_conjTranspose_le (A B : Mat) (μ : ℝ) (_hμ : 0 ≤ μ)
+theorem supportProj_mul_eq_of_conjTranspose_le (A B : Mat) (μ : ℝ)
     (hle : A * Aᴴ ≤ μ • (B * Bᴴ)) :
     (posSemidefBB B).supportProj * A = A := by
   let P := (posSemidefBB B).supportProj
@@ -271,9 +271,9 @@ theorem douglas_tfae (A B : Mat) : List.TFAE [
     rcases factorization_of_range_mulVecLin_le hAB with ⟨C, hC⟩
     exact ⟨‖C‖ ^ 2, pow_two_nonneg _, le_norm_sq_mul_of_factorization A B C hC⟩
   tfae_have h23 : 2 → 3 := by
-    intro h; rcases h with ⟨μ, hμ, hle⟩
+    intro h; rcases h with ⟨μ, _hμ, hle⟩
     have hSPA : (posSemidefBB B).supportProj * A = A :=
-      supportProj_mul_eq_of_conjTranspose_le A B μ hμ hle
+      supportProj_mul_eq_of_conjTranspose_le A B μ hle
     let C := pinv B * A
     have hBC : A = B * C := by
       calc
@@ -288,13 +288,12 @@ theorem factorization_pinv (A B : Mat) (hAB : A.mulVecLin.range ≤ B.mulVecLin.
     B * (pinv B * A) = A := by
   have hSPA : (posSemidefBB B).supportProj * A = A := by
     have hle := ((douglas_tfae A B).out 0 1 (by rfl) (by rfl)).mp hAB
-    rcases hle with ⟨μ, hμ, hle'⟩
-    exact supportProj_mul_eq_of_conjTranspose_le A B μ hμ hle'
+    rcases hle with ⟨μ, _hμ, hle'⟩
+    exact supportProj_mul_eq_of_conjTranspose_le A B μ hle'
   calc
     B * (pinv B * A) = (B * pinv B) * A := by simp [Matrix.mul_assoc]
     _ = (posSemidefBB B).supportProj * A := by rw [mul_pinv_eq_supportProj B]
     _ = A := hSPA
-
 
 /-! ## Moreover clauses of Douglas' theorem -/
 
@@ -403,7 +402,6 @@ theorem pinv_norm_minimal (A B C : Mat) (hA : A = B * C) : ‖pinv B * A‖ ≤ 
       _ ≤ ‖pinv B * B‖ * ‖C‖ := Matrix.l2_opNorm_mul _ _
       _ ≤ 1 * ‖C‖ := by nlinarith [norm_pinv_mul_B_le_one B]
       _ = ‖C‖ := by simp
-
 
 /-! ## Uniqueness of the factorization under the support constraint -/
 

--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.Douglas
+import TNLean.Analysis.MatrixSqrt
+import Mathlib.Data.Matrix.Block
+
+/-!
+# Block Schur complements (Wolf §5.1, Theorem 5.2)
+
+For a self-adjoint 2×2 block matrix `M = [[P, Q], [Q†, R]]`
+with `P, R` PSD, the following are equivalent:
+
+1. `M` is PSD
+2. `ker(R) ⊆ ker(Q)` and the pseudoinverse Schur complement `P − Q·R⁺·Q†` is PSD
+3. `ker(R) ⊆ ker(Q)` and `‖P^{-1/2}·Q·R^{-1/2}‖ ≤ 1` (contraction form)
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations*, Theorem 5.2][Wolf2012QChannels]
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder Matrix.Norms.L2Operator
+open Matrix
+
+namespace SchurComplement
+
+variable {D₁ D₂ : ℕ}
+
+/-- A 2×2 block matrix: [[P, Q], [Q†, R]]. -/
+def blockMatrix (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) : Matrix ((Fin D₁) ⊕ (Fin D₂)) ((Fin D₁) ⊕ (Fin D₂)) ℂ :=
+  Matrix.fromBlocks P Q (Qᴴ) R
+
+theorem blockMatrix_isHermitian (P : Matrix (Fin D₁) (Fin D₁) ℂ)
+    (Q : Matrix (Fin D₁) (Fin D₂) ℂ) (R : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hP : P.IsHermitian) (hR : R.IsHermitian) : (blockMatrix P Q R).IsHermitian := by
+  rw [Matrix.IsHermitian, blockMatrix]
+  simp [Matrix.fromBlocks_conjTranspose, hP.eq, hR.eq]
+
+/-- Pseudoinverse Schur complement: `P − Q·R⁺·Q†`. -/
+noncomputable def schurComplement (P : Matrix (Fin D₁) (Fin D₁) ℂ)
+    (Q : Matrix (Fin D₁) (Fin D₂) ℂ) (R : Matrix (Fin D₂) (Fin D₂) ℂ) :
+    Matrix (Fin D₁) (Fin D₁) ℂ :=
+  P - Q * (Douglas.pinv R) * (Qᴴ)
+
+/-- **Schur complement theorem** (Wolf Theorem 5.2).
+For PSD blocks P and R, the following are equivalent:
+1. The block matrix [[P, Q], [Q†, R]] is PSD
+2. ker(R) ⊆ ker(Q) and the pseudoinverse Schur complement P − Q·R⁺·Q† is PSD
+3. ker(R) ⊆ ker(Q) and ‖P^{-1/2}·Q·R^{-1/2}‖ ≤ 1 (contraction)
+
+Proof follows Wolf: (1)→(2) via quadratic-form minimization,
+(2)→(3) via algebraic manipulation with P^{1/2} and R^{1/2},
+(3)→(1) via the representation with contraction K. -/
+theorem schur_tfae (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef) :
+    List.TFAE [
+      (blockMatrix P Q R).PosSemidef,
+      (∀ (y : Fin D₂ → ℂ), mulVec R y = 0 → mulVec Q y = 0) ∧
+        (schurComplement P Q R).PosSemidef,
+      (∀ (y : Fin D₂ → ℂ), mulVec R y = 0 → mulVec Q y = 0) ∧
+        (‖(CFC.sqrt P)⁻¹ * Q * (CFC.sqrt R)⁻¹‖ ≤ 1)
+    ] := by
+  sorry
+
+end SchurComplement

--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -34,6 +34,8 @@ def blockMatrix (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (F
     (R : Matrix (Fin D₂) (Fin D₂) ℂ) : Matrix ((Fin D₁) ⊕ (Fin D₂)) ((Fin D₁) ⊕ (Fin D₂)) ℂ :=
   Matrix.fromBlocks P Q (Qᴴ) R
 
+/-- The block matrix `[[P, Q], [Q†, R]]` is Hermitian when its diagonal
+blocks `P` and `R` are Hermitian. -/
 theorem blockMatrix_isHermitian (P : Matrix (Fin D₁) (Fin D₁) ℂ)
     (Q : Matrix (Fin D₁) (Fin D₂) ℂ) (R : Matrix (Fin D₂) (Fin D₂) ℂ)
     (hP : P.IsHermitian) (hR : R.IsHermitian) : (blockMatrix P Q R).IsHermitian := by
@@ -45,7 +47,5 @@ noncomputable def schurComplement (P : Matrix (Fin D₁) (Fin D₁) ℂ)
     (Q : Matrix (Fin D₁) (Fin D₂) ℂ) (R : Matrix (Fin D₂) (Fin D₂) ℂ) :
     Matrix (Fin D₁) (Fin D₁) ℂ :=
   P - Q * (Douglas.pinv R) * (Qᴴ)
-
-
 
 end SchurComplement

--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -8,7 +8,7 @@ import TNLean.Analysis.MatrixSqrt
 import Mathlib.Data.Matrix.Block
 
 /-!
-# Block Schur complements (Wolf Theorem 5.2)
+# Block Schur complements
 
 For a self-adjoint 2×2 block matrix `M = [[P, Q], [Q†, R]]`
 with `P, R` PSD, the following are equivalent:
@@ -31,7 +31,8 @@ variable {D₁ D₂ : ℕ}
 
 /-- A 2×2 block matrix: [[P, Q], [Q†, R]]. -/
 def blockMatrix (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
-    (R : Matrix (Fin D₂) (Fin D₂) ℂ) : Matrix ((Fin D₁) ⊕ (Fin D₂)) ((Fin D₁) ⊕ (Fin D₂)) ℂ :=
+    (R : Matrix (Fin D₂) (Fin D₂) ℂ) :
+    Matrix ((Fin D₁) ⊕ (Fin D₂)) ((Fin D₁) ⊕ (Fin D₂)) ℂ :=
   Matrix.fromBlocks P Q (Qᴴ) R
 
 /-- The block matrix `[[P, Q], [Q†, R]]` is Hermitian when its diagonal

--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -46,24 +46,6 @@ noncomputable def schurComplement (P : Matrix (Fin D₁) (Fin D₁) ℂ)
     Matrix (Fin D₁) (Fin D₁) ℂ :=
   P - Q * (Douglas.pinv R) * (Qᴴ)
 
-/-- **Schur complement theorem** (Wolf Theorem 5.2).
-For PSD blocks P and R, the following are equivalent:
-1. The block matrix [[P, Q], [Q†, R]] is PSD
-2. ker(R) ⊆ ker(Q) and the pseudoinverse Schur complement P − Q·R⁺·Q† is PSD
-3. ker(R) ⊆ ker(Q) and ‖P^{-1/2}·Q·R^{-1/2}‖ ≤ 1 (contraction)
 
-Proof follows Wolf: (1)→(2) via quadratic-form minimization,
-(2)→(3) via algebraic manipulation with P^{1/2} and R^{1/2},
-(3)→(1) via the representation with contraction K. -/
-theorem schur_tfae (P : Matrix (Fin D₁) (Fin D₁) ℂ) (Q : Matrix (Fin D₁) (Fin D₂) ℂ)
-    (R : Matrix (Fin D₂) (Fin D₂) ℂ) (hP : P.PosSemidef) (hR : R.PosSemidef) :
-    List.TFAE [
-      (blockMatrix P Q R).PosSemidef,
-      (∀ (y : Fin D₂ → ℂ), mulVec R y = 0 → mulVec Q y = 0) ∧
-        (schurComplement P Q R).PosSemidef,
-      (∀ (y : Fin D₂ → ℂ), mulVec R y = 0 → mulVec Q y = 0) ∧
-        (‖(CFC.sqrt P)⁻¹ * Q * (CFC.sqrt R)⁻¹‖ ≤ 1)
-    ] := by
-  sorry
 
 end SchurComplement

--- a/TNLean/Channel/Schwarz/SchurComplement.lean
+++ b/TNLean/Channel/Schwarz/SchurComplement.lean
@@ -8,7 +8,7 @@ import TNLean.Analysis.MatrixSqrt
 import Mathlib.Data.Matrix.Block
 
 /-!
-# Block Schur complements (Wolf §5.1, Theorem 5.2)
+# Block Schur complements (Wolf Theorem 5.2)
 
 For a self-adjoint 2×2 block matrix `M = [[P, Q], [Q†, R]]`
 with `P, R` PSD, the following are equivalent:

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -16,3 +16,6 @@ later in the full blueprint.
 % of the Fundamental Theorem proof chain. They are developed in the auxiliary
 % channel-theory chapter after the FT sequence.
 % \input{chapter/ch05_schwarz_abstract_domains_and_order_auxiliary}
+
+\input{chapter/ch05_schwarz_douglas}
+\input{chapter/ch05_schwarz_schur_complement}

--- a/blueprint/src/chapter/ch05_schwarz_douglas.tex
+++ b/blueprint/src/chapter/ch05_schwarz_douglas.tex
@@ -14,7 +14,6 @@
 \begin{definition}[Pseudoinverse]\label{def:pinv}
   \lean{Douglas.pinv}
   \leanok
-  \uses{def:posSemidefBB}
   The \emph{Moore-Penrose pseudoinverse} $B^+$ is defined via the support-generalised
   inverse of $B B^\dagger$:
   $B^+ := B^\dagger \cdot (B B^\dagger)^{-1}_{\mathrm{supp}}$.
@@ -23,7 +22,7 @@
 \begin{lemma}[Pseudoinverse-factorization identity]\label{lem:mul_pinv_eq_supportProj}
   \lean{Douglas.mul_pinv_eq_supportProj}
   \leanok
-  \uses{def:pinv, def:posSemidefBB}
+  \uses{def:pinv}
   $B \cdot B^+ = \operatorname{supportProj}(B B^\dagger)$.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch05_schwarz_douglas.tex
+++ b/blueprint/src/chapter/ch05_schwarz_douglas.tex
@@ -37,7 +37,7 @@
 \begin{theorem}[Uniqueness of the pseudoinverse factorization]\label{thm:factorization_unique}
   \lean{Douglas.factorization_unique}
   \leanok
-  \uses{def:pinv, lem:mul_pinv_eq_supportProj}
+  \uses{def:pinv}
   If $A = B C_1 = B C_2$ and $\range(C_1), \range(C_2) \subseteq \range(B^\dagger)$,
   then $C_1 = C_2$. In particular, $C = B^+ A$ is the unique such factor.
 \end{theorem}

--- a/blueprint/src/chapter/ch05_schwarz_douglas.tex
+++ b/blueprint/src/chapter/ch05_schwarz_douglas.tex
@@ -2,6 +2,7 @@
 
 \begin{theorem}[Douglas factorisation]\label{thm:douglas_tfae}
   \lean{Douglas.douglas_tfae}
+  \uses{def:pinv, lem:mul_pinv_eq_supportProj}
   \leanok
   Let $A, B \in \MN{D}$. The following are equivalent:
   \begin{enumerate}
@@ -29,14 +30,14 @@
 \begin{theorem}[Explicit factorization via pseudoinverse]\label{thm:factorization_pinv}
   \lean{Douglas.factorization_pinv}
   \leanok
-  \uses{def:pinv, thm:douglas_tfae}
+  \uses{def:pinv, lem:mul_pinv_eq_supportProj}
   If $\range(A) \subseteq \range(B)$, then $A = B \cdot (B^+ A)$.
 \end{theorem}
 
 \begin{theorem}[Uniqueness of the pseudoinverse factorization]\label{thm:factorization_unique}
   \lean{Douglas.factorization_unique}
   \leanok
-  \uses{def:pinv, thm:douglas_tfae}
+  \uses{def:pinv, lem:mul_pinv_eq_supportProj}
   If $A = B C_1 = B C_2$ and $\range(C_1), \range(C_2) \subseteq \range(B^\dagger)$,
   then $C_1 = C_2$. In particular, $C = B^+ A$ is the unique such factor.
 \end{theorem}

--- a/blueprint/src/chapter/ch05_schwarz_douglas.tex
+++ b/blueprint/src/chapter/ch05_schwarz_douglas.tex
@@ -1,0 +1,51 @@
+\section{Douglas Factorization}\label{sec:douglas}
+
+\begin{theorem}[Douglas factorisation]\label{thm:douglas_tfae}
+  \lean{Douglas.douglas_tfae}
+  \leanok
+  Let $A, B \in \MN{D}$. The following are equivalent:
+  \begin{enumerate}
+    \item $\range(A) \subseteq \range(B)$,
+    \item $A A^\dagger \le \mu B B^\dagger$ for some $\mu \ge 0$,
+    \item $A = B C$ for some $C \in \MN{D}$.
+  \end{enumerate}
+\end{theorem}
+
+\begin{definition}[Pseudoinverse]\label{def:pinv}
+  \lean{Douglas.pinv}
+  \leanok
+  \uses{def:posSemidefBB}
+  The \emph{Moore-Penrose pseudoinverse} $B^+$ is defined via the support-generalised
+  inverse of $B B^\dagger$:
+  $B^+ := B^\dagger \cdot (B B^\dagger)^{-1}_{\mathrm{supp}}$.
+\end{definition}
+
+\begin{lemma}[Pseudoinverse-factorization identity]\label{lem:mul_pinv_eq_supportProj}
+  \lean{Douglas.mul_pinv_eq_supportProj}
+  \leanok
+  \uses{def:pinv, def:posSemidefBB}
+  $B \cdot B^+ = \operatorname{supportProj}(B B^\dagger)$.
+\end{lemma}
+
+\begin{theorem}[Explicit factorization via pseudoinverse]\label{thm:factorization_pinv}
+  \lean{Douglas.factorization_pinv}
+  \leanok
+  \uses{def:pinv, thm:douglas_tfae}
+  If $\range(A) \subseteq \range(B)$, then $A = B \cdot (B^+ A)$.
+\end{theorem}
+
+\begin{theorem}[Uniqueness of the pseudoinverse factorization]\label{thm:factorization_unique}
+  \lean{Douglas.factorization_unique}
+  \leanok
+  \uses{def:pinv, thm:douglas_tfae}
+  If $A = B C_1 = B C_2$ and $\range(C_1), \range(C_2) \subseteq \range(B^\dagger)$,
+  then $C_1 = C_2$. In particular, $C = B^+ A$ is the unique such factor.
+\end{theorem}
+
+\begin{theorem}[Norm-minimal factorization]\label{thm:pinv_norm_minimal}
+  \lean{Douglas.pinv_norm_minimal}
+  \leanok
+  \uses{def:pinv}
+  For every factorisation $A = B C$, the pseudoinverse witness attains the minimal operator norm:
+  $\|B^+ A\| \le \|C\|$.
+\end{theorem}

--- a/blueprint/src/chapter/ch05_schwarz_douglas.tex
+++ b/blueprint/src/chapter/ch05_schwarz_douglas.tex
@@ -24,13 +24,15 @@
   \lean{Douglas.mul_pinv_eq_supportProj}
   \leanok
   \uses{def:pinv}
-  $B \cdot B^+ = \operatorname{supportProj}(B B^\dagger)$.
+  $B \cdot B^+ = P_{\mathrm{supp}}(B B^\dagger)$,
+  where $P_{\mathrm{supp}}(X)$ denotes the support projection of $X$
+  (the orthogonal projection onto the range of $X$).
 \end{lemma}
 
 \begin{theorem}[Explicit factorization via pseudoinverse]\label{thm:factorization_pinv}
   \lean{Douglas.factorization_pinv}
   \leanok
-  \uses{def:pinv, lem:mul_pinv_eq_supportProj}
+  \uses{thm:douglas_tfae, def:pinv, lem:mul_pinv_eq_supportProj}
   If $\range(A) \subseteq \range(B)$, then $A = B \cdot (B^+ A)$.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -12,9 +12,9 @@
     \item $Q = P^{1/2} K R^{1/2}$ for a contraction $K$ with $\|K\|_\infty \le 1$.
   \end{enumerate}
   Here $R^+$ denotes the pseudoinverse (inverse on the support) and the
-  square roots $P^{1/2}, R^{1/2}$ are the positive semidefinite square roots
-  compensated on the kernel. The proof is deferred (paper-gap
-  \texttt{schur\_complement\_tfae}).
+  square roots $P^{1/2}, R^{1/2}$ are the positive semidefinite square roots,
+  with their inverses extended by zero on the kernel.
+% The proof is deferred (paper-gap schur_complement_tfae).
 \end{theorem}
 
 \begin{definition}[Block matrix]\label{def:blockMatrix}
@@ -23,6 +23,14 @@
   A $2 \times 2$ block matrix $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$
   indexed by $\Fin{D_1} \oplus \Fin{D_2}$.
 \end{definition}
+
+\begin{lemma}[Hermiticity of the block matrix]\label{lem:blockMatrix_isHermitian}
+  \lean{SchurComplement.blockMatrix_isHermitian}
+  \leanok
+  \uses{def:blockMatrix}
+  If $P$ and $R$ are Hermitian, then the block matrix
+  $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$ is Hermitian.
+\end{lemma}
 
 \begin{definition}[Schur complement]\label{def:schurComplement}
   \lean{SchurComplement.schurComplement}

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -1,20 +1,20 @@
 \section{Block Schur Complements}\label{sec:schur_complement}
 
 \begin{theorem}[Block Schur complement]\label{thm:schur_tfae}
-  \lean{SchurComplement.schur_tfae}
+  \notready
   \uses{def:schurComplement, def:blockMatrix}
   Let $P \in \MN{D_1}$, $R \in \MN{D_2}$ be positive semi-definite
-  and $Q \in \MN{D_1,D_2}$. The following are equivalent:
+  and $Q \in \MN{D_1,D_2}$ such that $\ker(R) \subseteq \ker(Q)$.
+  Wolf's Theorem~5.2 states that the following are equivalent:
   \begin{enumerate}
     \item The block matrix $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$ is PSD,
-    \item $\ker(R) \subseteq \ker(Q)$ and $P \ge Q R^+ Q^\dagger$,
-    \item $\ker(R) \subseteq \ker(Q)$ and $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$.
+    \item $P \ge Q R^+ Q^\dagger$ (pseudoinverse Schur complement),
+    \item $Q = P^{1/2} K R^{1/2}$ for a contraction $K$ with $\|K\|_\infty \le 1$.
   \end{enumerate}
-  Here $R^+$ denotes the pseudoinverse (inverse on the support).
-  The equivalence (1)$\Leftrightarrow$(2) is the pseudoinverse Schur complement;
-  (1)$\Leftrightarrow$(3) is the contraction characterisation.
-  The full TFAE is stated but the proof uses quadratic-form expansions
-  deferred to a follow-up PR (paper-gap \texttt{schur\_complement\_tfae}).
+  Here $R^+$ denotes the pseudoinverse (inverse on the support) and the
+  square roots $P^{1/2}, R^{1/2}$ are the positive semidefinite square roots
+  compensated on the kernel. The proof is deferred (paper-gap
+  \texttt{schur\_complement\_tfae}).
 \end{theorem}
 
 \begin{definition}[Block matrix]\label{def:blockMatrix}

--- a/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
+++ b/blueprint/src/chapter/ch05_schwarz_schur_complement.tex
@@ -1,0 +1,32 @@
+\section{Block Schur Complements}\label{sec:schur_complement}
+
+\begin{theorem}[Block Schur complement]\label{thm:schur_tfae}
+  \lean{SchurComplement.schur_tfae}
+  \uses{def:schurComplement, def:blockMatrix}
+  Let $P \in \MN{D_1}$, $R \in \MN{D_2}$ be positive semi-definite
+  and $Q \in \MN{D_1,D_2}$. The following are equivalent:
+  \begin{enumerate}
+    \item The block matrix $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$ is PSD,
+    \item $\ker(R) \subseteq \ker(Q)$ and $P \ge Q R^+ Q^\dagger$,
+    \item $\ker(R) \subseteq \ker(Q)$ and $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$.
+  \end{enumerate}
+  Here $R^+$ denotes the pseudoinverse (inverse on the support).
+  The equivalence (1)$\Leftrightarrow$(2) is the pseudoinverse Schur complement;
+  (1)$\Leftrightarrow$(3) is the contraction characterisation.
+  The full TFAE is stated but the proof uses quadratic-form expansions
+  deferred to a follow-up PR (paper-gap \texttt{schur\_complement\_tfae}).
+\end{theorem}
+
+\begin{definition}[Block matrix]\label{def:blockMatrix}
+  \lean{SchurComplement.blockMatrix}
+  \leanok
+  A $2 \times 2$ block matrix $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$
+  indexed by $\Fin{D_1} \oplus \Fin{D_2}$.
+\end{definition}
+
+\begin{definition}[Schur complement]\label{def:schurComplement}
+  \lean{SchurComplement.schurComplement}
+  \leanok
+  \uses{def:pinv}
+  The pseudoinverse Schur complement $P - Q R^+ Q^\dagger$.
+\end{definition}

--- a/docs/paper-gaps/schur_complement_tfae.tex
+++ b/docs/paper-gaps/schur_complement_tfae.tex
@@ -1,0 +1,43 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Schur Complement TFAE — Partial Proof}
+\author{}
+\date{2026-08-04}
+
+\begin{document}
+\maketitle
+
+\section{Source}
+Wolf, \textit{Quantum Channels \& Operations}, Theorem~5.2 (Block matrices and Schur complements).
+
+\section{Gap}
+The TFAE equivalence for the block Schur complement (\lean{SchurComplement.schur_tfae})
+is stated but the three-way proof is not yet completely formalised.
+The remaining subgoals are:
+
+\begin{enumerate}
+  \item[(1)$\Rightarrow$(2)] Quadratic-form minimisation: for the block matrix
+    $\bigl[\begin{smallmatrix} P & Q \\ Q^\dagger & R \end{smallmatrix}\bigr]$,
+    the optimal choice $y = -R^+ Q^\dagger x$ gives
+    $x^\dagger(P - Q R^+ Q^\dagger)x \ge 0$ for all~$x$.
+
+  \item[(2)$\Rightarrow$(3)] Algebraic manipulation with $P^{1/2}$ and $R^{1/2}$
+    to rewrite $P \ge Q R^+ Q^\dagger$ as
+    $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$.
+
+  \item[(3)$\Rightarrow$(1)] The contraction form gives the block PSD decomposition
+    via $K = P^{-1/2} Q R^{-1/2}$ with $\|K\| \le 1$.
+\end{enumerate}
+
+\section{Verdict}
+\textbf{Partial}. The theorem statement, block-matrix definition, and pseudoinverse
+Schur complement are formalised. The TFAE proof is deferred to a future PR.
+
+\end{document}

--- a/docs/paper-gaps/schur_complement_tfae.tex
+++ b/docs/paper-gaps/schur_complement_tfae.tex
@@ -7,49 +7,57 @@
 
 \input{command}
 
-\title{Schur Complement TFAE — Open Gap}
+\title{Schur Complement TFAE --- Open Gap}
 \author{}
 \date{2026-08-04}
 
 \begin{document}
 \maketitle
 
-\section{Source}
-Wolf, \textit{Quantum Channels \& Operations}, Theorem~5.2 (Block matrices and Schur complements).
+\section{Source statement}
+Wolf, \textit{Quantum Channels \& Operations}, Theorem~5.2 (Block matrices and
+Schur complements). Let $P$, $R$ be positive semi-definite complex matrices
+and $Q$ a complex matrix of compatible dimensions. Then the following are
+equivalent:
+\begin{enumerate}
+  \item the block matrix
+    $\begin{pmatrix} P & Q \\ Q^\dagger & R \end{pmatrix}$
+    is positive semi-definite;
+  \item $\ker(R) \subseteq \ker(Q)$ and
+    \begin{align}
+      P \ge Q R^{+} Q^\dagger,
+      \tag{Wolf, Theorem 5.2 (2)}
+    \end{align}
+    where $R^{+}$ is the pseudo-inverse (the inverse on the support);
+  \item $\ker(R) \subseteq \ker(Q)$ and
+    $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$.
+\end{enumerate}
 
 \section{Gap}
-The TFAE equivalence for the block Schur complement is not yet formalised in
-this branch: the definitions \leanid{SchurComplement.blockMatrix},
+Only the objects entering the statement are formalised: the block matrix
+itself, its self-adjointness for Hermitian diagonal blocks, and the
+pseudoinverse Schur complement $P - Q R^{+} Q^\dagger$.\footnote{Formal
+declarations: \leanid{SchurComplement.blockMatrix},
 \leanid{SchurComplement.blockMatrix_isHermitian}, and
-\leanid{SchurComplement.schurComplement} are present, but no direction of the
-equivalence has a Lean statement or proof here. The proof is under development
-on the stacked follow-up branch for PR \#5442. The remaining subgoals are:
-
+\leanid{SchurComplement.schurComplement} in
+\doclink{TNLean/Channel/Schwarz/SchurComplement}.}
+No direction of the equivalence has a formal statement yet. The standard
+argument has three steps:
 \begin{enumerate}
   \item[(1)$\Rightarrow$(2)] Quadratic-form minimisation: for the block matrix
     $\bigl[\begin{smallmatrix} P & Q \\ Q^\dagger & R \end{smallmatrix}\bigr]$,
-    the optimal choice $y = -R^+ Q^\dagger x$ gives
-    $x^\dagger(P - Q R^+ Q^\dagger)x \ge 0$ for all~$x$.
-
-  \item[(2)$\Rightarrow$(3)] Algebraic manipulation with $P^{1/2}$ and $R^{1/2}$
-    to rewrite $P \ge Q R^+ Q^\dagger$ as
+    the optimal choice $y = -R^{+} Q^\dagger x$ gives
+    $x^\dagger (P - Q R^{+} Q^\dagger) x \ge 0$ for all~$x$.
+  \item[(2)$\Rightarrow$(3)] Algebraic manipulation with $P^{1/2}$ and
+    $R^{1/2}$ rewrites $P \ge Q R^{+} Q^\dagger$ as
     $\|P^{-1/2} Q R^{-1/2}\|_\infty \le 1$.
-
-  \item[(3)$\Rightarrow$(1)] The contraction form gives the block PSD decomposition
-    via $K = P^{-1/2} Q R^{-1/2}$ with $\|K\| \le 1$.
+  \item[(3)$\Rightarrow$(1)] The contraction form gives the block PSD
+    decomposition via $K = P^{-1/2} Q R^{-1/2}$ with $\|K\| \le 1$, using the
+    operator-norm characterisation $\|L\| \le 1 \iff L L^\dagger \le I$.
 \end{enumerate}
 
 \section{Verdict}
-\textbf{Open gap}. Only \leanid{SchurComplement.blockMatrix},
-\leanid{SchurComplement.blockMatrix_isHermitian}, and
-\leanid{SchurComplement.schurComplement} are formalised (and carry \texttt{\textbackslash leanok}
-in the blueprint); the TFAE theorem itself is an open gap with no Lean
-statement on this branch, tracked by a \texttt{\textbackslash notready} blueprint entry.
-The proof in progress on the stacked branch currently has: the block quadratic
-form expansion, kernel inclusion (1)$\Rightarrow$(2) part one, and
-pseudoinverse-support algebra; the Schur-complement minimisation, the converse
-direction, and the contraction characterisation (2)$\Longleftrightarrow$(3)
-(including the operator-norm lemma $\|L\|\le 1 \iff L L^\dagger \le I$)
-remain to be integrated.
+\textbf{Open gap}. The cited equivalence has no formal statement; only the
+block-matrix definitions it involves are formalised.
 
 \end{document}

--- a/docs/paper-gaps/schur_complement_tfae.tex
+++ b/docs/paper-gaps/schur_complement_tfae.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{Schur Complement TFAE — Partial Proof}
+\title{Schur Complement TFAE — Open Gap}
 \author{}
 \date{2026-08-04}
 
@@ -18,9 +18,12 @@
 Wolf, \textit{Quantum Channels \& Operations}, Theorem~5.2 (Block matrices and Schur complements).
 
 \section{Gap}
-The TFAE equivalence for the block Schur complement (\lean{SchurComplement.schur_tfae})
-is stated but the three-way proof is not yet completely formalised.
-The remaining subgoals are:
+The TFAE equivalence for the block Schur complement is not yet formalised in
+this branch: the definitions \leanid{SchurComplement.blockMatrix},
+\leanid{SchurComplement.blockMatrix_isHermitian}, and
+\leanid{SchurComplement.schurComplement} are present, but no direction of the
+equivalence has a Lean statement or proof here. The proof is under development
+on the stacked follow-up branch for PR \#5442. The remaining subgoals are:
 
 \begin{enumerate}
   \item[(1)$\Rightarrow$(2)] Quadratic-form minimisation: for the block matrix
@@ -37,14 +40,16 @@ The remaining subgoals are:
 \end{enumerate}
 
 \section{Verdict}
-\textbf{Partially resolved}. The core equivalence (1)$\Longleftrightarrow$(2) is proved:
-\begin{itemize}
-  \item (1)$\Longrightarrow$(2): kernel inclusion via \texttt{dotProduct\_mulVec\_zero\_iff}
-    and Schur complement PSD via quadratic-form minimisation;
-  \item (2)$\Longrightarrow$(1): completing the square using the algebraic identity
-    $R^+ = \operatorname{supportInv}(R)$.
-\end{itemize}
-The contraction characterisation (2)$\Longleftrightarrow$(3) (including the operator-norm
-lemma $\|L\|\le 1 \iff L L^\dagger \le I$) is deferred to a follow-up PR.
+\textbf{Open gap}. Only \leanid{SchurComplement.blockMatrix},
+\leanid{SchurComplement.blockMatrix_isHermitian}, and
+\leanid{SchurComplement.schurComplement} are formalised (and carry \texttt{\textbackslash leanok}
+in the blueprint); the TFAE theorem itself is an open gap with no Lean
+statement on this branch, tracked by a \texttt{\textbackslash notready} blueprint entry.
+The proof in progress on the stacked branch currently has: the block quadratic
+form expansion, kernel inclusion (1)$\Rightarrow$(2) part one, and
+pseudoinverse-support algebra; the Schur-complement minimisation, the converse
+direction, and the contraction characterisation (2)$\Longleftrightarrow$(3)
+(including the operator-norm lemma $\|L\|\le 1 \iff L L^\dagger \le I$)
+remain to be integrated.
 
 \end{document}

--- a/docs/paper-gaps/schur_complement_tfae.tex
+++ b/docs/paper-gaps/schur_complement_tfae.tex
@@ -37,7 +37,14 @@ The remaining subgoals are:
 \end{enumerate}
 
 \section{Verdict}
-\textbf{Partial}. The theorem statement, block-matrix definition, and pseudoinverse
-Schur complement are formalised. The TFAE proof is deferred to a future PR.
+\textbf{Partially resolved}. The core equivalence (1)$\Longleftrightarrow$(2) is proved:
+\begin{itemize}
+  \item (1)$\Longrightarrow$(2): kernel inclusion via \texttt{dotProduct\_mulVec\_zero\_iff}
+    and Schur complement PSD via quadratic-form minimisation;
+  \item (2)$\Longrightarrow$(1): completing the square using the algebraic identity
+    $R^+ = \operatorname{supportInv}(R)$.
+\end{itemize}
+The contraction characterisation (2)$\Longleftrightarrow$(3) (including the operator-norm
+lemma $\|L\|\le 1 \iff L L^\dagger \le I$) is deferred to a follow-up PR.
 
 \end{document}


### PR DESCRIPTION
## Summary

Implements Wolf Chapter 5 theorems for Douglas factorization (Theorem 5.1) and block Schur complements (Theorem 5.2).

### Douglas Theorem (COMPLETE)
- TFAE equivalence (range inclusion, Löwner inequality, factorization)
- Pseudoinverse construction via support-generalized inverse
- Uniqueness on range: `Douglas.factorization_unique`
- Norm minimum: `Douglas.pinv_norm_minimal`
- Projection contraction lemma: `Douglas.norm_pinv_mul_B_le_one`

### Block Schur Complements (PARTIAL)
- Block matrix definition: `SchurComplement.blockMatrix`
- Pseudoinverse Schur complement: `SchurComplement.schurComplement`
- TFAE theorem excised (0 sorries); blueprint marked `\notready`
- Proof deferred (paper-gap: `schur_complement_tfae`)

Addresses LionSR/QICLean#205 (does not close — Schur TFAE proof remains).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new proof surface in operator-norm and PSD order theory (`Douglas.le_norm_sq_mul_of_factorization`, contraction bounds); Schur TFAE remains unproved so downstream proofs must not assume it yet.
> 
> **Overview**
> **Douglas factorization (Wolf Thm. 5.1)** is formalized end-to-end in `Douglas.lean`: Moore–Penrose `pinv` via `supportInv`, the three-way `douglas_tfae` (range inclusion ↔ Löwner bound ↔ `A = BC`), explicit witness `factorization_pinv`, domination `le_norm_sq_mul_of_factorization`, and “moreover” results (uniqueness on `ran B†`, `pinv_norm_minimal`, `norm_pinv_mul_B_le_one`).
> 
> Supporting infrastructure is added in **`MatrixAux`** (dot-product / L² operator-norm lemmas) and **`MatrixSqrt`** (algebra of `supportInv`: Hermitian, PSD, projection identities, `PosDef.supportInv_eq_inv`).
> 
> **Block Schur complements (Wolf Thm. 5.2)** get definitions only in new `SchurComplement.lean` (`blockMatrix`, `schurComplement` using `Douglas.pinv`, Hermiticity); the TFAE PSD equivalence is **not** proved—blueprint marked `\notready` and documented in `docs/paper-gaps/schur_complement_tfae.tex`. Blueprint chapters and the Schwarz import tree are wired accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c4a5b973b01cccb5672a0f49f66e03853625c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->