### PR TITLE
feat(Channel): Wolf Ch6 positive and Schwarz map generality (wave 1)

### DIFF
--- a/TNLean/Channel/PerronFrobenius.lean
+++ b/TNLean/Channel/PerronFrobenius.lean
@@ -9,4 +9,5 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.Channel.PerronFrobenius
 
 import TNLean.Channel.PerronFrobenius.Existence
+import TNLean.Channel.PerronFrobenius.ExtremalQuantities
 import TNLean.Channel.PerronFrobenius.Normalization

--- a/TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean
+++ b/TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean
@@ -11,7 +11,6 @@ import TNLean.Channel.Schwarz.PositiveMapProperties
 
 Wolf Chapter 6, Eqs. (6.29)--(6.30).
 
-## TODO
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder

--- a/TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean
+++ b/TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.PerronFrobenius.Existence
+import TNLean.Channel.Schwarz.PositiveMapProperties
+
+/-!
+# Extremal quantities r(X) and r̃(X) for positive maps
+
+Wolf Chapter 6, Eqs. (6.29)--(6.30).
+
+## TODO (issue #3976 M3)
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+variable {D : ℕ}
+
+namespace PerronFrobeniusExtremal
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The set of real λ such that (T - λ)(X) ≥ 0. -/
+def rSet (T : Mat →ₗ[ℂ] Mat) (X : Mat) : Set ℝ :=
+  {t : ℝ | (T X - (t : ℂ) • X).PosSemidef}
+
+/-- r(X) = sup { t ∈ ℝ | (T - t)(X) ≥ 0 }.  Wolf Eq. (6.29). -/
+noncomputable def r (T : Mat →ₗ[ℂ] Mat) (X : Mat) : ℝ :=
+  sSup (rSet T X)
+
+/-- r̃(X) = inf { t ∈ ℝ | (T - t)(X) ≤ 0 }.  Wolf Eq. (6.30). -/
+noncomputable def rTilde (T : Mat →ₗ[ℂ] Mat) (X : Mat) : ℝ :=
+  sInf {t : ℝ | (T X - (t : ℂ) • X) ≤ 0}
+
+/-- r_max = sup_{X ≥ 0, X ≠ 0} r(X). -/
+noncomputable def rMax (T : Mat →ₗ[ℂ] Mat) : ℝ :=
+  sSup (r T '' {X | X.PosSemidef ∧ X ≠ 0})
+
+/-- r̃_max = sup_{X ≥ 0, X ≠ 0} r̃(X). -/
+noncomputable def rTildeMax (T : Mat →ₗ[ℂ] Mat) : ℝ :=
+  sSup (rTilde T '' {X | X.PosSemidef ∧ X ≠ 0})
+
+end PerronFrobeniusExtremal

--- a/TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean
+++ b/TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean
@@ -3,14 +3,50 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Channel.PerronFrobenius.Existence
-import TNLean.Channel.Schwarz.PositiveMapProperties
+import Mathlib.Analysis.Matrix.Order
 
 /-!
 # Extremal quantities r(X) and rTilde(X) for positive maps
 
-Wolf Chapter 6, Eqs. (6.29)--(6.30).
+For a positive map `T` on `M_D(ℂ)`, Wolf defines on the cone of positive
+semidefinite operators the functionals `r(X) := sup {λ ∈ ℝ | (T - λ id)(X) ≥ 0}`
+and `rTilde(X) := inf {λ ∈ ℝ | (T - λ id)(X) ≤ 0}` (Equations (6.29)--(6.30)),
+and then the maxima `r := sup_{X ≥ 0} r(X)` and `rTilde := sup_{X ≥ 0} rTilde(X)`
+in the text below those equations.
 
+## Main definitions
+
+* `PerronFrobeniusExtremal.rSet`: the set `{λ ∈ ℝ | (T - λ id)(X) ≥ 0}`.
+* `PerronFrobeniusExtremal.r` and `PerronFrobeniusExtremal.rTilde`: the
+  extremal functionals of Wolf Equations (6.29) and (6.30).
+* `PerronFrobeniusExtremal.rMax` and `PerronFrobeniusExtremal.rTildeMax`: the
+  maxima `r` and `rTilde` over nonzero positive semidefinite `X`.
+
+## Implementation notes
+
+Wolf's functionals are defined only on the cone of positive semidefinite
+operators, and the defining sets carry no sign restriction on `λ`.  The Lean
+definitions are total, so on the degenerate input `X = 0` they return junk
+values: `rSet T 0 = Set.univ` (since `T 0 - λ • 0 = 0` is positive semidefinite
+for every `λ`), and Mathlib's totalized `sSup`/`sInf` of an unbounded set are
+`0`, hence `r T 0 = 0` and `rTilde T 0 = 0` rather than the extended-real
+`+∞`/`−∞` of the source formulas.  Meaningful use requires `X.PosSemidef` and
+`X ≠ 0`; for a positive map `T` the defining sets are then nonempty and
+bounded, so `r T X` and `rTilde T X` agree with the source supremum/infimum.
+The maxima `rMax`/`rTildeMax` range over nonzero PSD `X`, matching Wolf's
+remark that the sets "are compact or can be made so, e.g., by imposing
+`tr[X] = 1`".
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 6,
+  Equations (6.29)--(6.30) and the maxima defined in the text below them;
+  local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
+  lines 608--619 (definitions) and 635--637 (compactness remark).
+
+## Tags
+
+positive maps, Perron--Frobenius, spectral radius, extremal quantities
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -22,23 +58,41 @@ namespace PerronFrobeniusExtremal
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-- The set of real λ such that (T - λ)(X) ≥ 0. -/
+/-- The set `{λ ∈ ℝ | (T - λ id)(X) ≥ 0}` whose supremum is Wolf's `r(X)`,
+Equation (6.29).  Wolf's functional is defined on the cone of positive
+semidefinite operators; the set itself carries no sign restriction on `λ`.
+For `X = 0` the set is `Set.univ`, since `T 0 - λ • 0 = 0` is positive
+semidefinite for every `λ`. -/
 def rSet (T : Mat →ₗ[ℂ] Mat) (X : Mat) : Set ℝ :=
   {t : ℝ | (T X - (t : ℂ) • X).PosSemidef}
 
-/-- r(X) = sup { t ∈ ℝ | (T - t)(X) ≥ 0 }.  Wolf Eq. (6.29). -/
+/-- `r(X) = sup {λ ∈ ℝ | (T - λ id)(X) ≥ 0}`, Wolf Equation (6.29).
+The meaningful domain is nonzero positive semidefinite `X`: at `X = 0` the set
+`rSet T 0` is `Set.univ`, so `r T 0` is the junk value `sSup Set.univ = 0` of
+Mathlib's totalized `sSup`, not the extended-real `+∞` of the source formula. -/
 noncomputable def r (T : Mat →ₗ[ℂ] Mat) (X : Mat) : ℝ :=
   sSup (rSet T X)
 
-/-- rTilde(X) = inf { t ∈ ℝ | (T - t)(X) ≤ 0 }.  Wolf Eq. (6.30). -/
+/-- `rTilde(X) = inf {λ ∈ ℝ | (T - λ id)(X) ≤ 0}`, Wolf Equation (6.30).
+As for `r`, the meaningful domain is nonzero positive semidefinite `X`; at
+`X = 0` the defining set is `Set.univ`, so `rTilde T 0` is the junk value
+`sInf Set.univ = 0` of Mathlib's totalized `sInf`. -/
 noncomputable def rTilde (T : Mat →ₗ[ℂ] Mat) (X : Mat) : ℝ :=
   sInf {t : ℝ | (T X - (t : ℂ) • X) ≤ 0}
 
-/-- r_max = sup_{X ≥ 0, X ≠ 0} r(X). -/
+/-- The maximum `r := sup_{X ≥ 0} r(X)` of Wolf's extremal functional, defined
+in the text between Equations (6.29)--(6.30) and Theorem 6.3 (local source
+lines 617--619).  The range is restricted to nonzero `X`, matching Wolf's
+remark that the sets "can be made [compact], e.g., by imposing `tr[X] = 1`"
+(local source lines 635--637), and avoiding the junk value of `r` at `X = 0`. -/
 noncomputable def rMax (T : Mat →ₗ[ℂ] Mat) : ℝ :=
   sSup (r T '' {X | X.PosSemidef ∧ X ≠ 0})
 
-/-- rTildeMax = sup_{X ≥ 0, X ≠ 0} rTilde(X). -/
+/-- The maximum `rTilde := sup_{X ≥ 0} rTilde(X)` of Wolf's second extremal
+functional, defined in the same source passage as `rMax` (Wolf Chapter 6, text
+between Equations (6.29)--(6.30) and Theorem 6.3; local source lines 617--619).
+As for `rMax`, the range excludes `X = 0`, where `rTilde` takes its junk
+value. -/
 noncomputable def rTildeMax (T : Mat →ₗ[ℂ] Mat) : ℝ :=
   sSup (rTilde T '' {X | X.PosSemidef ∧ X ≠ 0})
 

--- a/TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean
+++ b/TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean
@@ -7,11 +7,11 @@ import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.Channel.Schwarz.PositiveMapProperties
 
 /-!
-# Extremal quantities r(X) and r̃(X) for positive maps
+# Extremal quantities r(X) and rTilde(X) for positive maps
 
 Wolf Chapter 6, Eqs. (6.29)--(6.30).
 
-## TODO (issue #3976 M3)
+## TODO
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -31,7 +31,7 @@ def rSet (T : Mat →ₗ[ℂ] Mat) (X : Mat) : Set ℝ :=
 noncomputable def r (T : Mat →ₗ[ℂ] Mat) (X : Mat) : ℝ :=
   sSup (rSet T X)
 
-/-- r̃(X) = inf { t ∈ ℝ | (T - t)(X) ≤ 0 }.  Wolf Eq. (6.30). -/
+/-- rTilde(X) = inf { t ∈ ℝ | (T - t)(X) ≤ 0 }.  Wolf Eq. (6.30). -/
 noncomputable def rTilde (T : Mat →ₗ[ℂ] Mat) (X : Mat) : ℝ :=
   sInf {t : ℝ | (T X - (t : ℂ) • X) ≤ 0}
 
@@ -39,7 +39,7 @@ noncomputable def rTilde (T : Mat →ₗ[ℂ] Mat) (X : Mat) : ℝ :=
 noncomputable def rMax (T : Mat →ₗ[ℂ] Mat) : ℝ :=
   sSup (r T '' {X | X.PosSemidef ∧ X ≠ 0})
 
-/-- r̃_max = sup_{X ≥ 0, X ≠ 0} r̃(X). -/
+/-- rTildeMax = sup_{X ≥ 0, X ≠ 0} rTilde(X). -/
 noncomputable def rTildeMax (T : Mat →ₗ[ℂ] Mat) : ℝ :=
   sSup (rTilde T '' {X | X.PosSemidef ∧ X ≠ 0})
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -159,9 +159,12 @@ In `TNLean.Channel.Irreducible.FromSpectral`:
   TP gauge reduction + channel fixed-point contradiction.
 * `isIrreducibleMap_iff_spectral_properties` — the final iff statement.
 
-### Wolf Theorem 6.5 (Spectral radius and positive eigenvectors) — FORMALIZED
+### Wolf Theorem 6.5 (Spectral radius and positive eigenvectors) — PARTIAL
 
 * `exists_posSemidef_eigenvector` — `TNLean.Channel.PerronFrobenius.Existence`
+* `exists_posSemidef_eigenvector_general` — gives SOME nonnegative eigenvalue with
+  PSD eigenvector, but does NOT identify it with the spectral radius.
+* Paper-gap: `docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex`
 
 Uses Brouwer's fixed-point theorem on density matrices (proved in
 `TNLean.Axioms.BrouwerFixedPoint`).

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -159,7 +159,7 @@ In `TNLean.Channel.Irreducible.FromSpectral`:
   TP gauge reduction + channel fixed-point contradiction.
 * `isIrreducibleMap_iff_spectral_properties` — the final iff statement.
 
-### Wolf Theorem 6.5 (Spectral radius and positive eigenvectors) — PARTIAL
+### Wolf Theorem 6.5 (Spectral radius and positive eigenvectors) — PARTIALLY FORMALIZED
 
 * `exists_posSemidef_eigenvector` — `TNLean.Channel.PerronFrobenius.Existence`
 * `exists_posSemidef_eigenvector_general` — gives SOME nonnegative eigenvalue with

--- a/docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex
+++ b/docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex
@@ -1,55 +1,110 @@
-\documentclass[11pt]{article}
+\documentclass{article}
+
 \usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Spectral-Radius Identification in Wolf Theorem 6.5}
+\author{}
+\date{2026-08-04}
+
 \begin{document}
-\section{Wolf Theorem 6.5 --- spectral radius as eigenvalue with PSD eigenvector}
-\label{sec:gap_ch6_thm65}
+\maketitle
 
-\subsection{Source}
-M.~Wolf, \emph{Quantum Channels \& Operations: Guided Tour}, Chapter~6,
-Theorem~6.5, local source
-\verb|Notes/WolfNoteTexSource/ch06_spectral_properties.tex|, lines~743--745.
+\section{Source statement}
 
-\subsection{Statement}
-Let $T:\mathcal{M}_d(\mathbb{C})\to\mathcal{M}_d(\mathbb{C})$ be a positive map
-with spectral radius $\varrho$. Then $\varrho$ is an eigenvalue and there is a
-positive semidefinite $X\in\mathcal{M}_d(\mathbb{C})$ such that $T(X)=\varrho X$.
+Wolf's Theorem~6.5 asserts that the spectral radius of a positive map is
+itself an eigenvalue, attained on a positive semidefinite eigenvector. We
+write $X\succeq0$ for positive semidefinite, $X\succ0$ for positive definite,
+and $\varrho(T)$ for the spectral radius. The theorem states: for every
+positive linear map $T:\MN{d}\to\MN{d}$,
+\begin{align}
+  T(X)&=\varrho(T)\,X
+  \qquad\text{for some }X\succeq0,\ X\neq0.
+  \tag{Wolf Thm.~6.5}
+\end{align}
+The local source is
+\path{Notes/WolfNoteTexSource/ch06_spectral_properties.tex}, lines~743--747
+\cite{Wolf2012Quantum}.
 
-\subsection{What is formalized}
-\begin{itemize}
-\item \texttt{exists\_posSemidef\_eigenvector\_general} (in
-  \texttt{TNLean/Channel/PerronFrobenius/Existence.lean}) proves that every
-  positive map has SOME nonnegative eigenvalue $r\ge 0$ with PSD eigenvector.
-\item \texttt{spectralRadius\_eq\_of\_posDef\_eigenvector\_of\_irreducible\_cp}
-  (in \texttt{TNLean/Channel/Irreducible/SpectralRadius.lean}) proves that for
-  \emph{irreducible CP} maps, a positive eigenvalue with PosDef eigenvector equals
-  the spectral radius. This is Wolf Theorem~6.3(4) but restricted to CP maps.
-\end{itemize}
+\section{What is formalized}
 
-\subsection{What is missing}
-\texttt{exists\_posSemidef\_eigenvector\_general} does not identify its eigenvalue
-with the spectral radius (it may return a suboptimal eigenvalue, e.g.\ $r=0$ when
-the map has a nontrivial kernel). The existing spectral-radius identity is
-restricted to irreducible CP maps.
+Two formal statements cover separate parts of the assertion. First, every
+positive linear map $E:\MN{D}\to\MN{D}$ has some nonnegative eigenvalue with
+a positive semidefinite eigenvector:
+\begin{align}
+  E(\rho)&=r\rho,
+  \qquad \rho\succeq0,\ \rho\neq0,\ r\ge0.
+  \tag{formal existence}
+\end{align}
+\footnote{Formal declaration:
+  \leanid{exists_posSemidef_eigenvector_general} in
+  \doclink{TNLean/Channel/PerronFrobenius/Existence}. The stronger variant
+  \leanid{exists_posSemidef_eigenvector} assumes that $E$ does not annihilate
+  any nonzero positive semidefinite matrix and returns $r>0$.}
+Second, for an irreducible completely positive map, any positive eigenvalue
+with a positive definite eigenvector equals the spectral radius:
+\begin{align}
+  E(\rho)=r\rho,\quad \rho\succ0,\ r>0
+  \quad\Longrightarrow\quad
+  \varrho(E)=r,
+  \tag{formal identification}
+\end{align}
+provided $E$ is irreducible and completely positive.\footnote{Formal
+  declaration:
+  \leanid{spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp} in
+  \doclink{TNLean/Channel/Irreducible/SpectralRadius}. This is the
+  irreducible-map statement of Wolf Theorem~6.3(4), formalized in the
+  completely positive case.}
 
-Proving the general positive-map case requires one of:
+\section{Comparison}
+
+The existence statement does not identify its eigenvalue with the spectral
+radius, and no such conclusion is possible for an arbitrary nonnegative
+eigenvalue of a positive map. On $\MN{2}$, the completely positive map
+\begin{align}
+  E(X)&=X_{11} \one
+\end{align}
+satisfies $E(\one)=\one$, so $\varrho(E)=1$; yet the nonzero positive
+semidefinite matrix $X=\ketbra{2}{2}$ lies in the kernel of $E$, so an
+existence theorem may return $r=0<\varrho(E)$. Conversely, the
+identification statement assumes irreducibility and complete positivity, both
+absent from Wolf Theorem~6.5, and requires a positive definite eigenvector.
+
+Closing the general positive-map case requires one of the following:
 \begin{enumerate}
-\item A direct resolvent/pole argument: for $\lambda>\varrho$, the resolvent
-  $R(\lambda)=(\lambda-T)^{-1}$ preserves positivity; as $\lambda\downarrow\varrho$,
-  the residue gives a PSD eigenvector for $\varrho$. Formalizing this needs
-  holomorphic functional calculus and spectral projections.
-\item Lifting from the irreducible case: decompose the PSD cone into invariant
-  faces, apply the Perron--Frobenius theorem to each irreducible component, and
-  select the component with maximal spectral radius. Requires formalizing the
-  invariant-face decomposition of positive maps.
+\item a resolvent argument: for $\lambda>\varrho(T)$ the resolvent
+  $(\lambda-T)^{-1}$ preserves positivity, and the pole at
+  $\lambda=\varrho(T)$ produces a positive semidefinite eigenvector; this
+  route needs holomorphic functional calculus and spectral projections;
+\item lifting from the irreducible case through the invariant-face
+  decomposition of the positive cone: apply the Perron--Frobenius theorem to
+  each irreducible component and select the component of maximal spectral
+  radius; this route needs the invariant-face decomposition of positive maps.
 \end{enumerate}
 
-\subsection{Elimination plan}
-The extremal-quantity approach (issue \#3976 M3) will first prove Theorem~6.3
-for irreducible positive maps directly (without CP/Kraus assumptions). Then the
-invariant-face decomposition (a separate project) will lift to the general case.
-If the resolvent argument is more tractable, it may be used as a shortcut.
+The planned first step is Wolf Theorem~6.3 for irreducible positive maps
+without complete-positivity hypotheses, via the extremal functionals of Wolf
+Equations~(6.29)--(6.30).\footnote{Formal declarations:
+  \leanid{PerronFrobeniusExtremal.r},
+  \leanid{PerronFrobeniusExtremal.rTilde},
+  \leanid{PerronFrobeniusExtremal.rMax}, and
+  \leanid{PerronFrobeniusExtremal.rTildeMax} in
+  \doclink{TNLean/Channel/PerronFrobenius/ExtremalQuantities}; tracked in
+  \ghissue{3976} (milestone M3).}
 
-\subsection{Verdict}
-Wolf Theorem~6.5 is partially formalized: existence of a nonnegative PSD
-eigenvalue is proved, but the identification with the spectral radius is missing.
+\section{Verdict}
+
+Wolf Theorem~6.5 is an \emph{open gap}: the existence of a nonnegative
+eigenvalue with a positive semidefinite eigenvector is formalized for every
+positive map, but the identification of that eigenvalue with the spectral
+radius is available only as a \emph{scope restriction} to irreducible
+completely positive maps with a positive definite eigenvector.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
 \end{document}

--- a/docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex
+++ b/docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex
@@ -1,0 +1,55 @@
+\documentclass[11pt]{article}
+\usepackage{amsmath,amssymb}
+\begin{document}
+\section{Wolf Theorem 6.5 --- spectral radius as eigenvalue with PSD eigenvector}
+\label{sec:gap_ch6_thm65}
+
+\subsection{Source}
+M.~Wolf, \emph{Quantum Channels \& Operations: Guided Tour}, Chapter~6,
+Theorem~6.5, local source
+\verb|Notes/WolfNoteTexSource/ch06_spectral_properties.tex|, lines~743--745.
+
+\subsection{Statement}
+Let $T:\mathcal{M}_d(\mathbb{C})\to\mathcal{M}_d(\mathbb{C})$ be a positive map
+with spectral radius $\varrho$. Then $\varrho$ is an eigenvalue and there is a
+positive semidefinite $X\in\mathcal{M}_d(\mathbb{C})$ such that $T(X)=\varrho X$.
+
+\subsection{What is formalized}
+\begin{itemize}
+\item \texttt{exists\_posSemidef\_eigenvector\_general} (in
+  \texttt{TNLean/Channel/PerronFrobenius/Existence.lean}) proves that every
+  positive map has SOME nonnegative eigenvalue $r\ge 0$ with PSD eigenvector.
+\item \texttt{spectralRadius\_eq\_of\_posDef\_eigenvector\_of\_irreducible\_cp}
+  (in \texttt{TNLean/Channel/Irreducible/SpectralRadius.lean}) proves that for
+  \emph{irreducible CP} maps, a positive eigenvalue with PosDef eigenvector equals
+  the spectral radius. This is Wolf Theorem~6.3(4) but restricted to CP maps.
+\end{itemize}
+
+\subsection{What is missing}
+\texttt{exists\_posSemidef\_eigenvector\_general} does not identify its eigenvalue
+with the spectral radius (it may return a suboptimal eigenvalue, e.g.\ $r=0$ when
+the map has a nontrivial kernel). The existing spectral-radius identity is
+restricted to irreducible CP maps.
+
+Proving the general positive-map case requires one of:
+\begin{enumerate}
+\item A direct resolvent/pole argument: for $\lambda>\varrho$, the resolvent
+  $R(\lambda)=(\lambda-T)^{-1}$ preserves positivity; as $\lambda\downarrow\varrho$,
+  the residue gives a PSD eigenvector for $\varrho$. Formalizing this needs
+  holomorphic functional calculus and spectral projections.
+\item Lifting from the irreducible case: decompose the PSD cone into invariant
+  faces, apply the Perron--Frobenius theorem to each irreducible component, and
+  select the component with maximal spectral radius. Requires formalizing the
+  invariant-face decomposition of positive maps.
+\end{enumerate}
+
+\subsection{Elimination plan}
+The extremal-quantity approach (issue \#3976 M3) will first prove Theorem~6.3
+for irreducible positive maps directly (without CP/Kraus assumptions). Then the
+invariant-face decomposition (a separate project) will lift to the general case.
+If the resolvent argument is more tractable, it may be used as a shortcut.
+
+\subsection{Verdict}
+Wolf Theorem~6.5 is partially formalized: existence of a nonnegative PSD
+eigenvalue is proved, but the identification with the spectral radius is missing.
+\end{document}


### PR DESCRIPTION
Addresses LionSR/QICLean#37.

## M3: Extremal quantities (definitions committed)
- `TNLean/Channel/PerronFrobenius/ExtremalQuantities.lean`: r(X), r̃(X), rMax, rTildeMax

## M1: Spectral radius as eigenvalue (paper-gap)
- Updated WolfChapter6Index: Theorem 6.5 marked as PARTIAL
- Paper-gap note: `docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex`
- `exists_posSemidef_eigenvector_general` gives SOME PSD eigenvalue but doesn't
  identify it with the spectral radius.
- Gap requires: (1) resolvent/pole argument needing holomorphic functional
  calculus, or (2) invariant-face decomposition + M3 extremal quantities.

## Next
- Prove r = r̃ for irreducible positive maps (M3)
- Then either prove the resolvent lemma or the invariant-face decomposition
  to complete M1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New definitions and documentation only; no changes to existing proofs or security-sensitive code.
> 
> **Overview**
> Adds **Lean definitions** for Wolf’s Perron–Frobenius extremal functionals (Eqs. 6.29–6.30): `PerronFrobeniusExtremal.r`, `rTilde`, and cone maxima `rMax` / `rTildeMax` over nonzero PSD `X`, with notes on junk behavior at `X = 0`. The new module is exported via `TNLean.Channel.PerronFrobenius`.
> 
> **Documentation** reclassifies Wolf Theorem 6.5 as **partially formalized** in `WolfChapter6Index` (existence via `exists_posSemidef_eigenvector_general` does not identify the eigenvalue with spectral radius). A new paper-gap note `docs/paper-gaps/wolf_ch6_spectral_radius_eigenvalue.tex` records the open gap and points to the extremal quantities as the planned route toward irreducible Theorem 6.3 without CP hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 160eb5e86af9857a5b30a944c6aab76fe50d58a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->