### PR TITLE
feat(tenkz): implement the stock pill as a measured rounded silhouette

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -207,7 +207,7 @@ overload census (§11, meter M6) never rises.
 |---|---|
 | side policy | `open` `none` `trace` `cup` |
 | routes | `straight` `orth` `arc` |
-| default skins | `dot` `box` `ring` `tri` `dots` `none` |
+| default skins | `dot` `box` `ring` `tri` `roundrect` `dots` `none` |
 | mark forms | `bracket` `enclosure` `label` |
 
 Two whole rows retired. The atom faces retired because a face is an angle in

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -247,5 +247,6 @@ kernel-\allowbreak{}declare & \texttt{pairings} & port-\allowbreak{}pair-\allowb
 \begin{longtable}{@{}>{\raggedright\arraybackslash}p{24mm}>{\raggedright\arraybackslash}p{24mm}>{\raggedright\arraybackslash}p{58mm}@{}}
 \toprule Prelude class & Name & Declaration \\ \midrule
 skin & \texttt{mpo} & \texttt{base=box} \\
+skin & \texttt{pill} & \texttt{base=roundrect} \\
 \bottomrule\end{longtable}
 }

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1035,13 +1035,59 @@ cmp -s "$WORK/r_mpo_skin_box.tnlog" \
     "$WORK/r_mpo_skin_prelude.normalized.tnlog" >&2 || true
   exit 1
 }
+pill_atoms=$(grep -Ec '^atom.*[|]skin=pill([|]|$)' \
+  "$WORK/r_pill_skin_prelude.tnlog" || true)
+[ "$pill_atoms" -eq 3 ] || {
+  echo "FAIL: the stock pill name did not remain in all three atom records" >&2
+  exit 1
+}
+pill_glyphs=$(grep -Ec '^ink-use\|.*\|class=glyph\|.*\|shape=roundrect' \
+  "$WORK/r_pill_skin_prelude.tnlog" || true)
+[ "$pill_glyphs" -eq 3 ] || {
+  echo "FAIL: the stock pill did not ink three rounded silhouettes" >&2
+  exit 1
+}
+pill_hulls=$(grep -Ec \
+  '^glyph-geometry\|.*\|shape=roundrect\|.*\|radius=[1-9][0-9]*\|' \
+  "$WORK/r_pill_skin_prelude.tnlog" || true)
+[ "$pill_hulls" -eq 3 ] || {
+  echo "FAIL: a pill hull lost the roundrect family or its cap radius" >&2
+  exit 1
+}
+sed 's/skin=pill/skin=roundrect/g' "$WORK/r_pill_skin_prelude.tnlog" \
+  >"$WORK/r_pill_skin_prelude.normalized.tnlog"
+cmp -s "$WORK/r_pill_skin_roundrect.tnlog" \
+  "$WORK/r_pill_skin_prelude.normalized.tnlog" || {
+  echo "FAIL: the stock pill declaration changed roundrect geometry or events" >&2
+  diff -u "$WORK/r_pill_skin_roundrect.tnlog" \
+    "$WORK/r_pill_skin_prelude.normalized.tnlog" >&2 || true
+  exit 1
+}
+cap_port_glyphs=$(grep -Ec \
+  '^glyph-geometry\|.*\|shape=roundrect\|.*\|radius=[1-9][0-9]*\|' \
+  "$WORK/r_pill_skin_cap_ports.tnlog" || true)
+[ "$cap_port_glyphs" -eq 2 ] || {
+  echo "FAIL: a near-cap ported pill fell back to a sharp hull family" >&2
+  exit 1
+}
+grep -Fq '|origin=port-open|port-face=168|port-slot=1|port-type=virtual' \
+  "$WORK/r_pill_skin_cap_ports.tnlog" || {
+  echo "FAIL: an unconsumed pill port did not materialize its open leg" >&2
+  exit 1
+}
+grep -Fq '|origin=port-open|port-face=230|port-slot=1|port-type=physical' \
+  "$WORK/r_pill_skin_cap_ports.tnlog" || {
+  echo "FAIL: a physical pill port lost its type on materialization" >&2
+  exit 1
+}
 command -v pdftoppm >/dev/null 2>&1 || {
   echo "FAIL: kernel pixel gate requires pdftoppm" >&2
   exit 1
 }
 for pixel_fixture in \
     k_plane k_skin_pairings r_hull_live r_ink_semantics r_label_turn \
-    r_mpo_skin_box r_mpo_skin_prelude r_parallel_lanes r_ring_closure; do
+    r_mpo_skin_box r_mpo_skin_prelude r_parallel_lanes \
+    r_pill_skin_prelude r_pill_skin_roundrect r_ring_closure; do
   if ! pdftoppm -singlefile -png -r 300 \
       "$WORK/$pixel_fixture.pdf" "$WORK/$pixel_fixture" >/dev/null 2>&1; then
     echo "FAIL: $pixel_fixture fixture could not be rasterized" >&2
@@ -1054,6 +1100,10 @@ for pixel_fixture in \
 done
 cmp -s "$WORK/r_mpo_skin_box.png" "$WORK/r_mpo_skin_prelude.png" || {
   echo "FAIL: the stock MPO declaration changed box pixels" >&2
+  exit 1
+}
+cmp -s "$WORK/r_pill_skin_roundrect.png" "$WORK/r_pill_skin_prelude.png" || {
+  echo "FAIL: the stock pill declaration changed roundrect pixels" >&2
   exit 1
 }
 grep -Eq '^atom.*\|size=s\|.*\|species=warm($|\|)' \
@@ -1124,6 +1174,19 @@ if ( cd "$WORK" &&
 fi
 grep -Fq '[TKZ-FRAME-WORD]' "$WORK/n_frame_word.transcript" || {
   echo "FAIL: unknown frame word lacked TKZ-FRAME-WORD" >&2
+  exit 1
+}
+
+skin_negative="$KERNEL/negative/n_unknown_skin.tex"
+if ( cd "$WORK" &&
+     TEXINPUTS="$REPO/tex/tenkz//:" \
+       timeout 120 xelatex -interaction=nonstopmode -halt-on-error \
+       "$skin_negative" >"$WORK/n_unknown_skin.transcript" 2>&1 ); then
+  echo "FAIL: a skin word outside the primitive and declared sets was accepted" >&2
+  exit 1
+fi
+grep -Fq '[TKZ-KERNEL-SKIN]' "$WORK/n_unknown_skin.transcript" || {
+  echo "FAIL: unknown skin lacked TKZ-KERNEL-SKIN" >&2
   exit 1
 }
 

--- a/tests/tenkz/kernel/negative/n_unknown_skin.tex
+++ b/tests/tenkz/kernel/negative/n_unknown_skin.tex
@@ -1,0 +1,10 @@
+% Negative: a skin word that is neither primitive nor declared is rejected
+% with the coded skin diagnostic.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=3, bonds=none]
+  \tn[skin=capsule, at=(1,2), name=bad]{X}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_pill_skin_cap_ports.tex
+++ b/tests/tenkz/kernel/regression/r_pill_skin_cap_ports.tex
@@ -1,0 +1,24 @@
+% Regression: typed ports on the measured pill meet the rounded boundary on
+% both sides of a cap transition.  The bearings straddle the flat-to-cap
+% changeover of the medium pill, the labelled ports stand their labels on
+% the trimmed boundary points, and the unconsumed ports materialize
+% ordinary open legs.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none, size=m]
+  \tn[skin=pill, at=(2,2), name=flatcap,
+    ports={12:virtual:$a$, 28:virtual:$b$, 168:virtual, 192:virtual}]{P}
+  \tnwire{flatcap.12}{open e} \tnwire{flatcap.28}{open ne}
+  \tnwire{open w}{flatcap.192}
+\end{tenkz}
+\quad
+\begin{tenkz}[rows={wire,wire,wire}, cols=4, bonds=none, size=m]
+  \tn[skin=pill, at=(2,2), name=widecap, wide=2,
+    ports={50:virtual:$c$, 130:virtual, 230:physical, 310:virtual}]
+    {P_{\alpha\beta\gamma}}
+  \tnwire{widecap.50}{open ne} \tnwire{open nw}{widecap.130}
+  \tnwire{widecap.310}{open se}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_pill_skin_prelude.tex
+++ b/tests/tenkz/kernel/regression/r_pill_skin_prelude.tex
@@ -1,0 +1,25 @@
+% Regression: the registry-owned pill prelude name retains skin=pill in each
+% atom record while resolving through the measured rounded silhouette at
+% every size.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none, size=s]
+  \tn[skin=pill, at=(2,2), name=small,
+    ports={37:virtual,217:virtual}]{P}
+  \tnwire{small.37}{open ne} \tnwire{open sw}{small.217}
+\end{tenkz}
+\quad
+\begin{tenkz}[rows={wire,wire,wire}, cols=4, bonds=none, size=m]
+  \tn[skin=pill, at=(2,2), name=medium, wide=2,
+    ports={73:virtual,253:virtual}]{P_{\alpha\beta}}
+  \tnwire{medium.73}{open n} \tnwire{open s}{medium.253}
+\end{tenkz}
+\quad
+\begin{tenkz}[rows={wire,wire,wire}, cols=5, bonds=none, size=l]
+  \tn[skin=pill, at=(2,2), name=large, wide=3,
+    ports={143:virtual,323:virtual}]{P^{(L)}}
+  \tnwire{large.143}{open nw} \tnwire{open se}{large.323}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_pill_skin_roundrect.tex
+++ b/tests/tenkz/kernel/regression/r_pill_skin_roundrect.tex
@@ -1,0 +1,25 @@
+% Reference for the stock pill prelude regression: three measured rounded
+% silhouettes exercise every size class, wide spans, short and wide labels,
+% and arbitrary-angle ports.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none, size=s]
+  \tn[skin=roundrect, at=(2,2), name=small,
+    ports={37:virtual,217:virtual}]{P}
+  \tnwire{small.37}{open ne} \tnwire{open sw}{small.217}
+\end{tenkz}
+\quad
+\begin{tenkz}[rows={wire,wire,wire}, cols=4, bonds=none, size=m]
+  \tn[skin=roundrect, at=(2,2), name=medium, wide=2,
+    ports={73:virtual,253:virtual}]{P_{\alpha\beta}}
+  \tnwire{medium.73}{open n} \tnwire{open s}{medium.253}
+\end{tenkz}
+\quad
+\begin{tenkz}[rows={wire,wire,wire}, cols=5, bonds=none, size=l]
+  \tn[skin=roundrect, at=(2,2), name=large, wide=3,
+    ports={143:virtual,323:virtual}]{P^{(L)}}
+  \tnwire{large.143}{open nw} \tnwire{open se}{large.323}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -324,6 +324,22 @@
         \tenkz@r@glyphref\tenkz@pitch * 5 / 4\relax,
       minimum height=\dimexpr
         \tenkz@r@glyphref\tenkz@pitch * 5 / 4\relax},
+  % A pill scales BOTH of its named floors by the class factor, so every
+  % size keeps the pill's flat proportion; the canonical square styles
+  % above would swallow it into a box.
+  tenkz pill size s/.style={
+      minimum width=\dimexpr
+        \tenkz@r@glyphref\tenkz@pitch * 3 / 4\relax,
+      minimum height=\dimexpr
+        \tenkz@r@glyphbox\tenkz@pitch * 3 / 4\relax},
+  tenkz pill size m/.style={
+      minimum width=\tenkz@dim{\tenkz@r@glyphref},
+      minimum height=\tenkz@dim{\tenkz@r@glyphbox}},
+  tenkz pill size l/.style={
+      minimum width=\dimexpr
+        \tenkz@r@glyphref\tenkz@pitch * 5 / 4\relax,
+      minimum height=\dimexpr
+        \tenkz@r@glyphbox\tenkz@pitch * 5 / 4\relax},
   tenkz dot size s/.style={
       minimum size=\tenkz@dim{\tenkz@r@clusterdot}},
   tenkz dot size m/.style={

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -1119,6 +1119,61 @@
 \cs_new:Npn \__tenkz_geom_rr:nnn #1#2#3
   { min( (#1) , (#2) , (#3) ) }
 
+% Radial reach of a rounded rectangle from its centre along bearing #4: the
+% distance at which the outgoing ray meets the boundary.  This is the
+% port-trim query, distinct from the support fold above -- a support in a
+% direction is attained off-ray at a corner, while a wire endpoint stands ON
+% the ray.  A flat-side hit divides the half-extent by its direction cosine;
+% a cap hit solves the ray's quadratic against the corner disc.  Half-extents
+% #1, #2 and corner radius #3 share one unit; the reach lands in #5 in that
+% unit.  The side tests keep every division away from a vanishing cosine: a
+% ray parallel to a side can only leave through the other pair of sides or a
+% cap.
+\fp_new:N \l__tenkz_geom_ray_u_fp
+\fp_new:N \l__tenkz_geom_ray_v_fp
+\fp_new:N \l__tenkz_geom_ray_r_fp
+\fp_new:N \l__tenkz_geom_ray_cx_fp
+\fp_new:N \l__tenkz_geom_ray_cy_fp
+\fp_new:N \l__tenkz_geom_ray_b_fp
+\cs_new_protected:Npn \__tenkz_geom_roundrect_ray:nnnnN #1#2#3#4#5
+  {
+    \fp_set:Nn \l__tenkz_geom_ray_u_fp { abs( cosd(#4) ) }
+    \fp_set:Nn \l__tenkz_geom_ray_v_fp { abs( sind(#4) ) }
+    \fp_set:Nn \l__tenkz_geom_ray_r_fp { \__tenkz_geom_rr:nnn {#3}{#1}{#2} }
+    \fp_set:Nn \l__tenkz_geom_ray_cx_fp
+      { (#1) - \l__tenkz_geom_ray_r_fp }
+    \fp_set:Nn \l__tenkz_geom_ray_cy_fp
+      { (#2) - \l__tenkz_geom_ray_r_fp }
+    \fp_compare:nNnTF
+      { (#1) * \l__tenkz_geom_ray_v_fp }
+      >
+      { \l__tenkz_geom_ray_cy_fp * \l__tenkz_geom_ray_u_fp }
+      {
+        \fp_compare:nNnTF
+          { (#2) * \l__tenkz_geom_ray_u_fp }
+          >
+          { \l__tenkz_geom_ray_cx_fp * \l__tenkz_geom_ray_v_fp }
+          {
+            \fp_set:Nn \l__tenkz_geom_ray_b_fp
+              {
+                \l__tenkz_geom_ray_cx_fp * \l__tenkz_geom_ray_u_fp
+                + \l__tenkz_geom_ray_cy_fp * \l__tenkz_geom_ray_v_fp
+              }
+            \fp_set:Nn #5
+              {
+                \l__tenkz_geom_ray_b_fp
+                + sqrt( max( 0 ,
+                    \l__tenkz_geom_ray_b_fp ^ 2
+                    - \l__tenkz_geom_ray_cx_fp ^ 2
+                    - \l__tenkz_geom_ray_cy_fp ^ 2
+                    + \l__tenkz_geom_ray_r_fp ^ 2 ) )
+              }
+          }
+          { \fp_set:Nn #5 { (#2) / \l__tenkz_geom_ray_v_fp } }
+      }
+      { \fp_set:Nn #5 { (#1) / \l__tenkz_geom_ray_u_fp } }
+  }
+
 % Support of one primitive transported through a complete east/north basis.
 % This is a distinct contract from the scalar-turn function above: an affine
 % support record is

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -4319,6 +4319,8 @@
 
 \msg_new:nnn {tenkz}{kernel-render-todo}
   { [TKZ-KERNEL-RENDER-TODO]~'#1'~does~not~draw~yet~(record~#2) }
+\msg_new:nnn {tenkz}{kernel-skin}
+  { [TKZ-KERNEL-SKIN]~no~skin~named~'#1'~is~primitive~or~declared }
 \msg_new:nnn {tenkz}{kernel-render-unplaced}
   { [TKZ-KERNEL-RENDER-UNPLACED]~record~'#1'~has~no~address,~node,~or~
     cluster~parent~to~resolve }
@@ -6489,7 +6491,7 @@
         \prop_if_in:NnF \l__tenkz_kernel_glyph_face_probe_prop {#1}
           {
             \__tenkz_kernel_hull_measure_glyph:n {#1}
-            \clist_map_inline:nn {box,family,xmin,xmax,ymin,ymax}
+            \clist_map_inline:nn {box,family,radius,xmin,xmax,ymin,ymax}
               {
                 \prop_remove:Nn \l__tenkz_kernel_hull_live_prop
                   {#1/##1}
@@ -6734,7 +6736,28 @@
           }
       }
       {
-        \prop_put:Nnn \l__tenkz_kernel_hull_live_prop {#1/family} {rect}
+        % The measured pill publishes the roundrect family with the live
+        % named pill-cap radius, in the anchors' outer envelope: the path
+        % radius plus the half-stroke the border anchors already include.
+        % No box-shaped record may stand in for pill ink.
+        \str_if_eq:VnTF \l__tenkz_kernel_hull_skin_tl {roundrect}
+          {
+            \prop_put:Nnn \l__tenkz_kernel_hull_live_prop {#1/family}
+              {roundrect}
+            \prop_put:Nne \l__tenkz_kernel_hull_live_prop {#1/radius}
+              {
+                \fp_eval:n
+                  {
+                    ( \dim_to_fp:n { \__tenkz_dim:n {pillcap} }
+                      + \dim_to_fp:n { \__tenkz_dim:n {wirewidth} } / 2 )
+                    / \dim_to_fp:n { \use:c {tenkz@pitch} }
+                  }
+              }
+          }
+          {
+            \prop_put:Nnn \l__tenkz_kernel_hull_live_prop {#1/family}
+              {rect}
+          }
         \pgfextractx \l__tenkz_kernel_hull_west_dim
           {
             \pgfpointanchor
@@ -6810,6 +6833,12 @@
               \l__tenkz_kernel_hull_shape_tl
             \quark_if_no_value:NT \l__tenkz_kernel_hull_shape_tl
               { \tl_set:Nn \l__tenkz_kernel_hull_shape_tl {rect} }
+            % Only the roundrect family publishes a corner radius; every
+            % other measured family folds with a sharp record.
+            \prop_get:NnN \l__tenkz_kernel_hull_live_prop {##1/radius}
+              \l__tenkz_kernel_hull_radius_tl
+            \quark_if_no_value:NT \l__tenkz_kernel_hull_radius_tl
+              { \tl_set:Nn \l__tenkz_kernel_hull_radius_tl {0} }
             \fp_set:Nn \l__tenkz_kernel_hull_xoff_fp
               {
                 ( \l__tenkz_kernel_hull_xmin_tl
@@ -6839,7 +6868,7 @@
                         - \l__tenkz_kernel_hull_xmin_tl ) / 2 } }
                     { \fp_eval:n { ( \l__tenkz_kernel_hull_ymax_tl
                         - \l__tenkz_kernel_hull_ymin_tl ) / 2 } }
-                    {0}
+                    { \tl_use:N \l__tenkz_kernel_hull_radius_tl }
                     { \l__tenkz_kernel_r_basis_ex_tl }
                     { \l__tenkz_kernel_r_basis_ey_tl }
                     { \l__tenkz_kernel_r_basis_nx_tl }
@@ -6874,7 +6903,7 @@
                         - \l__tenkz_kernel_hull_xmin_tl ) / 2 } }
                     { \fp_eval:n { ( \l__tenkz_kernel_hull_ymax_tl
                         - \l__tenkz_kernel_hull_ymin_tl ) / 2 } }
-                    {0}
+                    { \tl_use:N \l__tenkz_kernel_hull_radius_tl }
                     { \tl_use:N \l__tenkz_kernel_hull_turn_tl }
                     { \fp_eval:n { \l__tenkz_kernel_hull_x_fp
                         + \l__tenkz_kernel_hull_xrot_fp } }
@@ -6973,6 +7002,31 @@
           }
         {dots}  { \tl_set:Nn #2 { {circle}{0}{0}{0}{0} } }
         {none}  { \tl_set:Nn #2 { {circle}{0}{0}{0}{0} } }
+        {roundrect}
+          {
+            % An unmeasured pill folds like the generic spanned glyph below,
+            % but under its own family: the caps subtract the live named
+            % pill-cap radius from the sharp corners.
+            \__tenkz_kernel_hull_half:nnN {#1} {wide}
+              \l__tenkz_kernel_hull_a_tl
+            \__tenkz_kernel_hull_half:nnN {#1} {wires}
+              \l__tenkz_kernel_hull_b_tl
+            \__tenkz_kernel_r_turn:nN {#1} \l__tenkz_kernel_hull_turn_tl
+            \tl_set:Ne #2
+              {
+                {roundrect}
+                { \tl_use:N \l__tenkz_kernel_hull_a_tl }
+                { \tl_use:N \l__tenkz_kernel_hull_b_tl }
+                {
+                  \fp_eval:n
+                    {
+                      \dim_to_fp:n { \__tenkz_dim:n {pillcap} }
+                      / \dim_to_fp:n { \use:c {tenkz@pitch} }
+                    }
+                }
+                { \tl_use:N \l__tenkz_kernel_hull_turn_tl }
+              }
+          }
         {tri}
           {
             \__tenkz_kernel_r_turn:nN {#1} \l__tenkz_kernel_hull_turn_tl
@@ -8394,6 +8448,100 @@
       }
   }
 
+% pgf border anchors answer on the measurement node's sharp rectangle, so a
+% numeric-bearing anchor on a measured pill overshoots the caps.  Re-meet the
+% rounded silhouette at the same bearing: the measurement node's own anchors
+% supply the centre and half-extents, the live named pill-cap radius plus the
+% half-stroke those anchors already include supplies the caps, and the shared
+% roundrect ray query supplies the reach.  Named anchors (north, east, ...)
+% stand on the flat sides, which the caps never touch, and pass unchanged.
+% The two dim registers below are the readers' anchor outputs, adjusted in
+% place after every measurement-node read.
+\fp_new:N \l__tenkz_kernel_pill_hx_fp
+\fp_new:N \l__tenkz_kernel_pill_hy_fp
+\fp_new:N \l__tenkz_kernel_pill_cx_fp
+\fp_new:N \l__tenkz_kernel_pill_cy_fp
+\fp_new:N \l__tenkz_kernel_pill_t_fp
+\cs_new_protected:Npn \__tenkz_kernel_r_pill_trim_anchor:nn #1#2
+  {
+    \__tenkz_kernel_hull_resolve_skin:n {#1}
+    \str_if_eq:VnT \l__tenkz_kernel_hull_skin_tl {roundrect}
+      {
+        \regex_match:nnT { \A \-? [0-9]+ ( \. [0-9]* )? \Z } {#2}
+          { \__tenkz_kernel_r_pill_trim_anchor_aux:nn {#1} {#2} }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_pill_trim_anchor_aux:nn #1#2
+  {
+    \tl_set:Ne \l__tenkz_kernel_hull_measure_name_tl
+      { tenkz_hull_\int_use:N \g__tenkz_kernel_picture_int _#1 }
+    \pgfextractx \l__tenkz_kernel_hull_west_dim
+      {
+        \pgfpointanchor
+          {\tl_use:N \l__tenkz_kernel_hull_measure_name_tl}{west}
+      }
+    \pgfextractx \l__tenkz_kernel_hull_east_dim
+      {
+        \pgfpointanchor
+          {\tl_use:N \l__tenkz_kernel_hull_measure_name_tl}{east}
+      }
+    \pgfextracty \l__tenkz_kernel_hull_south_dim
+      {
+        \pgfpointanchor
+          {\tl_use:N \l__tenkz_kernel_hull_measure_name_tl}{south}
+      }
+    \pgfextracty \l__tenkz_kernel_hull_north_dim
+      {
+        \pgfpointanchor
+          {\tl_use:N \l__tenkz_kernel_hull_measure_name_tl}{north}
+      }
+    \fp_set:Nn \l__tenkz_kernel_pill_hx_fp
+      {
+        ( \dim_to_fp:n { \l__tenkz_kernel_hull_east_dim }
+          - \dim_to_fp:n { \l__tenkz_kernel_hull_west_dim } ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_pill_hy_fp
+      {
+        ( \dim_to_fp:n { \l__tenkz_kernel_hull_north_dim }
+          - \dim_to_fp:n { \l__tenkz_kernel_hull_south_dim } ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_pill_cx_fp
+      {
+        ( \dim_to_fp:n { \l__tenkz_kernel_hull_east_dim }
+          + \dim_to_fp:n { \l__tenkz_kernel_hull_west_dim } ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_pill_cy_fp
+      {
+        ( \dim_to_fp:n { \l__tenkz_kernel_hull_north_dim }
+          + \dim_to_fp:n { \l__tenkz_kernel_hull_south_dim } ) / 2
+      }
+    \__tenkz_geom_roundrect_ray:nnnnN
+      { \l__tenkz_kernel_pill_hx_fp }
+      { \l__tenkz_kernel_pill_hy_fp }
+      {
+        \dim_to_fp:n { \__tenkz_dim:n {pillcap} }
+        + \dim_to_fp:n { \__tenkz_dim:n {wirewidth} } / 2
+      }
+      {#2}
+      \l__tenkz_kernel_pill_t_fp
+    \dim_set:Nn \l__tenkz_kernel_r_north_x_dim
+      {
+        \fp_to_dim:n
+          {
+            \l__tenkz_kernel_pill_cx_fp
+            + \l__tenkz_kernel_pill_t_fp * cosd(#2)
+          }
+      }
+    \dim_set:Nn \l__tenkz_kernel_r_north_y_dim
+      {
+        \fp_to_dim:n
+          {
+            \l__tenkz_kernel_pill_cy_fp
+            + \l__tenkz_kernel_pill_t_fp * sind(#2)
+          }
+      }
+  }
+
 % Read one measurement-node anchor in the glyph's own east/north axes.  A live
 % hull measurement is reused when present; an unscheduled ordinary dot instead
 % gets a private face node so the query cannot replace its label-aware fallback
@@ -8456,6 +8604,7 @@
         \pgfpointanchor
           {\tl_use:N \l__tenkz_kernel_hull_measure_name_tl}{#2}
       }
+    \__tenkz_kernel_r_pill_trim_anchor:nn {#1} {#2}
     \fp_set:Nn #3
       {
         \dim_to_fp:n { \l__tenkz_kernel_r_north_x_dim }
@@ -8963,6 +9112,8 @@
           {\tl_use:N \l__tenkz_kernel_hull_measure_name_tl}
           {\tl_use:N \l__tenkz_kernel_r_b_tl}
       }
+    \exp_args:NnV \__tenkz_kernel_r_pill_trim_anchor:nn {#2}
+      \l__tenkz_kernel_r_b_tl
     \fp_set:Nn \l__tenkz_kernel_r_xc_fp
       {
         \dim_to_fp:n { \l__tenkz_kernel_r_north_x_dim }
@@ -12591,6 +12742,7 @@
         {box}  { \tl_set:Nn #3 { box~tensor } }
         {ring} { \tl_set:Nn #3 { on-wire~matrix } }
         {tri}  { \tl_set:Nn #3 { left~canonical~tensor } }
+        {roundrect} { \tl_set:Nn #3 { pill~tensor } }
         {dots}
           {
             \tl_set:Nn #3
@@ -12633,15 +12785,28 @@
     \__tenkz_model_get:nnN {#1} {size} \l__tenkz_kernel_r_x_tl
     % An absent size keeps the established per-skin geometry.  Dot sizing
     % precedes the span minima below, so a multi-slot pairing host retains its
-    % support.  Other canonical skins use their shared reference on both axes.
+    % support.  A pill scales both of its own named floors, keeping its flat
+    % proportion; other canonical skins use their shared reference on both
+    % axes.
     \quark_if_no_value:NF \l__tenkz_kernel_r_x_tl
       {
-        \str_if_eq:VnTF \l__tenkz_kernel_r_skin_base_tl {dot}
+        \str_case:VnF \l__tenkz_kernel_r_skin_base_tl
           {
-            \tl_put_right:Ne #2
+            {dot}
               {
-                , tenkz~dot~size~
-                    \tl_use:N \l__tenkz_kernel_r_x_tl
+                \tl_put_right:Ne #2
+                  {
+                    , tenkz~dot~size~
+                        \tl_use:N \l__tenkz_kernel_r_x_tl
+                  }
+              }
+            {roundrect}
+              {
+                \tl_put_right:Ne #2
+                  {
+                    , tenkz~pill~size~
+                        \tl_use:N \l__tenkz_kernel_r_x_tl
+                  }
               }
           }
           {
@@ -12696,7 +12861,7 @@
 \int_new:N \l__tenkz_kernel_r_skin_crossings_int
 \seq_new:N \l__tenkz_kernel_skin_base_seq
 
-% Resolve a declaration chain to one of the six primitive skins.  Resolution
+% Resolve a declaration chain to one of the seven primitive skins.  Resolution
 % is shared by hull measurement and ink, so a declared alias cannot acquire
 % the geometry of one primitive and the rendering of another.
 \cs_new_protected:Npn \__tenkz_kernel_skin_base:nN #1#2
@@ -12712,6 +12877,7 @@
         {box}  { \tl_set:Nn #2 {box} }
         {ring} { \tl_set:Nn #2 {ring} }
         {tri}  { \tl_set:Nn #2 {tri} }
+        {roundrect} { \tl_set:Nn #2 {roundrect} }
         {dots} { \tl_set:Nn #2 {dots} }
         {none} { \tl_set:Nn #2 {none} }
       }
@@ -12745,8 +12911,7 @@
                   }
               }
               {
-                \msg_error:nnee {tenkz}{kernel-render-todo}
-                  { unknown~skin~'#1' } {skin}
+                \msg_error:nnn {tenkz}{kernel-skin} {#1}
                 \tl_set:Nn #2 {box}
               }
           }
@@ -12914,6 +13079,8 @@
           {\tl_use:N \l__tenkz_kernel_hull_measure_name_tl}
           {\tl_use:N #3}
       }
+    \exp_args:NVV \__tenkz_kernel_r_pill_trim_anchor:nn
+      \l__tenkz_kernel_r_skin_wire_host_tl #3
     \fp_set:Nn \l__tenkz_kernel_r_xc_fp
       {
         \dim_to_fp:n { \l__tenkz_kernel_r_north_x_dim }

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -265,6 +265,7 @@
 
 % class, name, declaration descriptor
 \__tenkz_language_registry_prelude:nnn {skin}{mpo}{base=box}
+\__tenkz_language_registry_prelude:nnn {skin}{pill}{base=roundrect}
 
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{rows}{row-list}{{wire}}{kernel}{Chain row topology; non-wire rows populate.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{cols}{positive-integer}{3}{kernel}{Cells per row.}

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -87,7 +87,7 @@
   }
 
 % ---------- skins ------------------------------------------------------------
-% The six kernel base skins resolve to the calibrated styles of tenkz-core.
+% The seven kernel base skins resolve to the calibrated styles of tenkz-core.
 % A declared skin adds only the own-port pairing primitive below.
 \cs_new:Npn \__tenkz_render_skin_style:n #1
   {
@@ -97,6 +97,7 @@
         {box}  { box~tensor }
         {ring} { on-wire~matrix }
         {tri}  { left~canonical~tensor }
+        {roundrect} { pill~tensor }
         {dots} { draw = none , fill = none }
         {none} { draw = none , fill = none , inner~sep = 0pt , minimum~size = 0pt }
       }


### PR DESCRIPTION
Advances LionSR/tenkz#135 (does not close it): this PR delivers the measured pill silhouette in the kernel; the sixteen consumer-case migrations named in the issue follow in the wave PRs, and the issue's acceptance closes only on those source-facing renders.

## Mechanism

The kernel resolver gains a seventh measured base skin, `roundrect`, whose ink style is the legacy `pill tensor` of `tenkz-core` (the named `\tenkz@pillcap` radius, the pill insets, the common glyph-reference width, the ordinary glyph-box height). The standard prelude declares `pill` over it — `{skin}{pill}{base=roundrect}` in the executable registry — exactly the `mpo -> box` mechanism of LionSR/TNLean#5369, keeping the LANGUAGE-1.0 sentence "the standard prelude declares pill" true as written. No new public parser key, no client metric, no case-specific renderer branch, and `pill` is not aliased to `box`.

## Acceptance evidence (kernel-side bullets)

- **`\tn[skin=pill]` compiles under `\tenkzkernel` with no client declaration** — `tests/tenkz/kernel/regression/r_pill_skin_prelude.tex` compiles standalone; its three atom records keep `skin=pill` (probe stanza asserts the count).
- **One shared rounded-rectangle geometry, `shape=roundrect`, live named radius** — hull measurement and ink resolve through the same `\__tenkz_kernel_skin_base:nN` chain to the same `pill tensor` style; the audit emits `ink-use|...|shape=roundrect` and `glyph-geometry|...|shape=roundrect|...|radius=162201` (2.2pt pill cap plus the half-stroke the border envelope carries) for every pill. The hull's live support record publishes the `roundrect` family with that radius, so contours and route folds consume the rounded support the geometry stage already knew (`\__tenkz_geom_support:nnnnnn`), not a box record. No box-shaped measurement drives pill ink.
- **Arbitrary-angle typed ports trim to the measured rounded boundary, including near a cap** — pgf border anchors answer on the sharp measurement rectangle, so every numeric-bearing anchor read on a pill is re-met on the rounded silhouette by a new radial boundary query (`\__tenkz_geom_roundrect_ray:nnnnN`, unit-checked against hand-computed flat, cap, transition-continuity, and clamped-radius values). The three measurement-node anchor readers (glyph anchors, hull port points, pairing cell ends) share one trim function. Port type checking, consumption, and open-leg materialization are untouched index behavior — `r_pill_skin_cap_ports` asserts the unconsumed virtual and physical ports still materialize ordinary `origin=port-open` legs with their types.
- **`size=s|m|l`, short and wide labels, `wide=` spans keep the named pill proportions** — new `tenkz pill size s|m|l` styles scale both named pill floors (`\tenkz@r@glyphref` width, `\tenkz@r@glyphbox` height) by the class factor instead of the canonical square styles; no raw client dimension appears anywhere. Exercised across all three sizes, `wide=2`/`wide=3`, and short/subscripted labels in the regression pair.
- **Focused regressions, registry/reference coverage, coded negative** — `r_pill_skin_roundrect` / `r_pill_skin_prelude` (a normalized-event and pixel-identical pair, mirroring the mpo pair), `r_pill_skin_cap_ports` (bearings 12/28 straddle the flat-to-cap changeover of the medium pill; 50/130/230/310 on a wide pill), `negative/n_unknown_skin` rejected with the new coded `[TKZ-KERNEL-SKIN]` diagnostic, registry prelude row plus regenerated language reference.
- **Existing baselines unchanged** — the kernel record streams and pixel pins are byte-identical (`scripts/tenkz_kernel_probes.sh` passes with the pill additions as new stanzas only); the golden lists gain nothing, and the only intentional inventory additions are the new pill fixtures and the prelude row.

## Out of scope (wave follow-ups)

- Migrating `rmp-ii-blocking`, `rmp-iii-a-proof-one`, the Section-IV pill carriers, and the rest of the sixteen census targets; the RMP focused checks and full gates for those cases run in the migration wave. `tests/tenkz/rmp/` is untouched here.

## Validation

- `python3 scripts/test_tenkz_kernel_audit.py` — pass
- `bash scripts/tenkz_kernel_probes.sh` — pass (baselines byte-identical)
- `python3 scripts/tenkz_language.py check` / `generate-reference` — pass (227 records)
- `python3 scripts/test_tenkz_language.py` — pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hull measurement, port anchor resolution, and geometry folding used by routes and pairings; changes are gated by byte-identical baselines plus new pill-specific probes rather than broad corpus migrations.
> 
> **Overview**
> Adds a seventh kernel primitive skin **`roundrect`** (ink via legacy `pill tensor`) and a standard prelude **`pill`** with `base=roundrect`, mirroring the existing `mpo` → `box` pattern. **`roundrect`** joins the default-skins alphabet in LANGUAGE-1.0 and the generated language reference.
> 
> **Sizing and geometry:** New **`tenkz pill size s|m|l`** styles scale both named pill width and height floors by size class so pills keep their flat aspect ratio. Hull measurement publishes a **`roundrect`** support family with the live **`pillcap`** radius (plus half-stroke); unmeasured pills fold through the same family instead of a box record. A shared **`__tenkz_geom_roundrect_ray`** query trims numeric-bearing port anchors onto the rounded boundary because pgf border anchors sit on the sharp measurement rectangle.
> 
> **Resolver and diagnostics:** Skin resolution now recognizes seven primitives; unknown skins emit **`[TKZ-KERNEL-SKIN]`** instead of a generic render-todo error.
> 
> **Tests:** Regression fixtures for prelude vs `roundrect` (event and pixel parity), cap-transition ports, kernel probe stanzas, and **`n_unknown_skin`** negative test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92eef536ec72cfd3b560e4d84240dfac26b03e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->