### PR TITLE
doc(MPS/MPDO): point Purity.lean gap citations at cpgsv17_pf_rank_one

### DIFF
--- a/TNLean/MPS/MPDO/Purity.lean
+++ b/TNLean/MPS/MPDO/Purity.lean
@@ -31,7 +31,7 @@ entry formula `MPSTensor.mpv_toMPSTensor_pairConfig`.
 stated in trace form and in the Frobenius-norm vocabulary of
 `TNLean.Algebra.MatrixAux`.  Following the convention of the eta-local
 structure paper-gap note
-(`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`), the
+(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`), the
 unnormalized quantity `Matrix.trace (mpo K N * (mpo K N)ᴴ)` is called the
 *raw squared Hilbert--Schmidt norm* of the MPO family; it is not a
 normalized-state purity, which would require the trace normalization that has
@@ -52,7 +52,7 @@ not been established here.
 
 These identities are project infrastructure preparing the Lemma C.5 route of
 the eta-local structure paper-gap note
-(`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`)
+(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`)
 (arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines
 1473--1499; Case-I assumptions at lines 1374--1381; cyclic direct-sum form at
 lines 1580--1593).  They are not statements from CPSV16, and no Lemma C.5
@@ -95,7 +95,7 @@ summands along `pairCfgEquiv`.
 
 This is a project derivation preparing the Lemma C.5 route of the eta-local
 structure paper-gap note
-(`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`)
+(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`)
 (arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1473--1499); it is not
 a claim from CPSV16.  Before trace normalization is established, the right
 side is the raw squared Hilbert--Schmidt norm of the MPO family, not a
@@ -132,7 +132,7 @@ MPSTensor.mpvOverlap K.toMPSTensor K.toMPSTensor N
 
 This is a project derivation preparing the Lemma C.5 route of the eta-local
 structure paper-gap note
-(`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`)
+(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`)
 (arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1473--1499); it is not
 a claim from CPSV16. -/
 theorem mpvOverlap_toMPSTensor_self_eq_trace_sq (K : MPOTensor d D) (hK : IsMPDO K)
@@ -147,7 +147,7 @@ Hilbert--Schmidt norm in the vocabulary of `TNLean.Algebra.MatrixAux`.
 
 This is a project derivation preparing the Lemma C.5 route of the eta-local
 structure paper-gap note
-(`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`); it
+(`docs/paper-gaps/cpgsv17_pf_rank_one.tex`); it
 is not a claim from CPSV16. -/
 theorem mpvOverlap_toMPSTensor_self_re_eq_frobenius_norm_sq (K : MPOTensor d D) (N : ℕ) :
     (MPSTensor.mpvOverlap K.toMPSTensor K.toMPSTensor N).re = ‖mpo K N‖ ^ 2 := by


### PR DESCRIPTION
Docstring-only fix per issue #5420: all five paper-gap citations in `TNLean/MPS/MPDO/Purity.lean` pointed at `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` (SAL→η-local-structure), which does not mention purity, Hilbert–Schmidt norms, or the Lemma C.5 route. They now point at `cpgsv17_pf_rank_one.tex`, the note the rest of the codebase cites for the Lemma C.5 / SALZCL route.

Closes #5420

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only path swaps with no executable or proof changes.
> 
> **Overview**
> **Documentation-only** update in `TNLean/MPS/MPDO/Purity.lean`: every docstring that cited `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` for the Lemma C.5 / SALZCL route now cites `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, matching how the rest of the codebase (e.g. `Algebra/PerronFrobenius/RankOne.lean`) documents that route.
> 
> No Lean proofs or APIs change—only module-level and theorem docstrings (naming convention, source fidelity, and the three overlap/trace/Frobenius theorems).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d31d0908a7b1de100751752b4c31aba9dbe2884a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->