### PR TITLE
doc(PEPS): refresh stale multiplicativity docstring in RegionReconcile

### DIFF
--- a/TNLean/PEPS/RegionBlock/RegionReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/RegionReconcile.lean
@@ -308,15 +308,17 @@ injectivity. The datum feeds `exists_regionEdgeGauge_of_transfer`
 (`TNLean.PEPS.RegionBlock.Algebra`) to read off the per-edge gauge with no
 single-vertex injectivity.
 
-**Scope (multiplicativity hypothesis):** the forward-transfer multiplicativity `hmul`
-is the only field not yet derived region-injectively. The source derives it from the
-homomorphism property of the physical realization
-(`Papers/1804.04964/paper_normal.tex`, eq. `X->O`), whose region port reads the
-recovered matrix off the single-vertex virtual pullback and so currently needs the
-in-region endpoint spanning. The block-endpoint inversions above
-(`coeffTransfer_of_endpointOp_eq`, `regionInsertedCoeff_eq_of_regionRow_eq`) supply
-the coefficient transfers `htransferAB`/`htransferBA`; the residual single-vertex
-read-off is documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+**Scope (multiplicativity hypothesis):** the datum is parametric in the
+forward-transfer multiplicativity `hmul`. The hypothesis is discharged by the
+coherent-frame route: `exists_regionEdgeGauge_of_blockingData`
+(`TNLean.PEPS.CoherentFrameInstance2`) derives both coefficient transfers and the
+forward multiplicativity existentially from one-edge blocking data, with no
+single-vertex injectivity of the original tensors (this resolved issue #2470). The
+block-endpoint inversions above (`coeffTransfer_of_endpointOp_eq`,
+`regionInsertedCoeff_eq_of_regionRow_eq`) supply the coefficient transfers
+`htransferAB`/`htransferBA` on the direct region route; the remaining Section-3
+route hypotheses are tracked in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
 `Papers/1804.04964/paper_normal.tex`. -/


### PR DESCRIPTION
Docstring-only fix per issue #5463. The scope paragraph at `RegionReconcile.lean:310-318` still described `hmul` as the one field not yet derived region-injectively, referencing the pre-resolution state of #2470. It now records that the coherent-frame route (`exists_regionEdgeGauge_of_blockingData`, `TNLean/PEPS/CoherentFrameInstance2.lean`) discharges both coefficient transfers and the forward multiplicativity existentially, with no single-vertex injectivity, while the direct region route's remaining Section-3 hypotheses stay tracked in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.

Closes #5463

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no Lean proof or API impact.
> 
> **Overview**
> **Docstring-only** refresh of the **Scope (multiplicativity hypothesis)** paragraph on `regionInsertionTransfer_of_coeffTransfer` in `RegionReconcile.lean`.
> 
> The text no longer says `hmul` is the one field not yet derived region-injectively via single-vertex physical realization. It now states the datum stays parametric in `hmul`, that **`exists_regionEdgeGauge_of_blockingData`** (`CoherentFrameInstance2`) existentially supplies coefficient transfers and forward multiplicativity from one-edge blocking data without single-vertex injectivity (issue **#2470** resolved), and that the direct region route still gets `htransferAB`/`htransferBA` from the block-endpoint lemmas while other Section-3 hypotheses remain in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a3087e43fc58febc60be48fcd0d90fda1c69057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->