### PR TITLE
doc(MPS/MPDO): correct rescaling-question attribution in RFP example docstrings

### DIFF
--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
@@ -199,8 +199,10 @@ theorem oneLabelCoeffs_not_lengthIndependent :
 /-- The uniform positive rescaling of the displayed one-label $\chi$ block:
 the roots $\{1, 7/25\}$ become $\{s, 7s/25\}$.
 
-Source: arXiv:1606.00608, lines 995--1010 (the rescaling question after
-Theorem 4.14; the tensor is a project example). -/
+Source: arXiv:1606.00608, lines 995--1010 pose the length-dependence
+question after Theorem 4.14; the rescaling-stability strengthening is a
+project-internal follow-up motivated by that question (the tensor is a
+project example). -/
 def oneLabelChiScaled (s : ℝ) : DiagonalChiFamily (Fin 1) where
   dim _ _ _ := 2
   entry _ _ _ k :=
@@ -237,8 +239,9 @@ rescaled roots $\{s, 7s/25\}$ cannot both equal one, and the rescaled
 family $s^L(1 + (7/25)^L)$ is not length-independent.
 
 Source: arXiv:1606.00608, Theorem 4.14 and lines 995--1010 (the
-rescaling-stability question; the tensor is a project example, not a
-tensor stated in CPSV16). -/
+length-dependence question); the rescaling-stability strengthening is a
+project-internal follow-up motivated by that question (the tensor is a
+project example, not a tensor stated in CPSV16). -/
 theorem oneLabelCoeffs_rescaling_stable_not_lengthIndependent (s : ℝ)
     (hs : 0 < s) : ¬ (rescaledCoeffs s).LengthIndependent := by
   intro hLI


### PR DESCRIPTION
Per issue #5449: the docstrings of `oneLabelChiScaled` and `oneLabelCoeffs_rescaling_stable_not_lengthIndependent` cited arXiv:1606.00608 lines 995-1010 as posing a "rescaling question". That passage poses only the length-dependence open question ($c^{(L)}$ depending on $L$); a repo-wide grep finds no occurrence of "rescal" in the paper source. The docstrings now state that the rescaling-stability strengthening is a project-internal follow-up motivated by the paper's length-dependence question.

Docstring-only change.

Closes #5449

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only attribution fixes in one Lean file; no executable or proof logic changes.
> 
> **Overview**
> Updates **Source** docstrings on `oneLabelChiScaled` and `oneLabelCoeffs_rescaling_stable_not_lengthIndependent` so arXiv:1606.00608 lines 995–1010 are credited with the **length-dependence** open question after Theorem 4.14, not a paper “rescaling question.”
> 
> The **rescaling-stability** result is described as a **project-internal** follow-up motivated by that passage (project example tensor, not stated in CPSV16). No Lean proofs or definitions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a51b0812559accef5e7f9221acd2c20ed4a28872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->