### PR TITLE
doc(PEPS): drop issue number from RegionReconcile docstring per prose style

### DIFF
--- a/TNLean/PEPS/RegionBlock/RegionReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/RegionReconcile.lean
@@ -313,7 +313,7 @@ forward-transfer multiplicativity `hmul`. The hypothesis is discharged by the
 coherent-frame route: `exists_regionEdgeGauge_of_blockingData`
 (`TNLean.PEPS.CoherentFrameInstance2`) derives both coefficient transfers and the
 forward multiplicativity existentially from one-edge blocking data, with no
-single-vertex injectivity of the original tensors (this resolved issue #2470). The
+single-vertex injectivity of the original tensors. The
 block-endpoint inversions above (`coeffTransfer_of_endpointOp_eq`,
 `regionInsertedCoeff_eq_of_regionRow_eq`) supply the coefficient transfers
 `htransferAB`/`htransferBA` on the direct region route; the remaining Section-3


### PR DESCRIPTION
Follow-up to #5484 (issue #5463): the merged docstring text cited "issue #2470", which the reader-facing prose gate (`docs/prose_style.md`) bans in Lean docstrings. This removes the issue-number citation; the docstring still points at the coherent-frame theorem and the Section-3 route gap note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a Lean docstring; no logic or API impact.
> 
> **Overview**
> Aligns the **`regionInsertionTransfer_of_coeffTransfer`** docstring with the reader-facing prose style by dropping the parenthetical **"(this resolved issue #2470)"** after the coherent-frame route sentence. The surrounding explanation is unchanged: it still cites `exists_regionEdgeGauge_of_blockingData`, the block-endpoint inversions, and the Section-3 route gap doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7194033c4ad8602fa395a91c1228be267b9b1e87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->