### PR TITLE
feat(tenkz): nested region selection for the six-panel intersection windows

### DIFF
--- a/docs/tenkz/COSMETIC-GAP-BAR.md
+++ b/docs/tenkz/COSMETIC-GAP-BAR.md
@@ -97,8 +97,8 @@ hash-pinned visual check required before changing a verdict.
 | `rmp-iv-intersection-rhs-four` | — | Promoted to `faithful` 2026-08-04: five open ends match Rtensor4; no spurious crossing. |
 | `rmp-iv-intersection-lhs-five` | — | Promoted to `faithful` 2026-08-04: the restored three-index boundary matches; sideways stubs preserve it. |
 | `rmp-iv-intersection-rhs-five` | X | Re-audit the mirrored open C--X contraction before accepting it as equivalent routing. |
-| `rmp-iv-intersection-lhs-six` | X | Promoted to `blocked`: the missing `nested-regions` capability leaves an invented lattice and the wrong contraction. |
-| `rmp-iv-intersection-rhs-six` | X | Promoted to `blocked`: the missing `nested-regions` capability leaves an invented lattice and the wrong contraction. |
+| `rmp-iv-intersection-lhs-six` | K2 | Resolved to `cosmetic-gap` 2026-08-05: kernel nested regions replace the invented lattice; the A--B patch window nests inside the L window and the cut bonds end on it. Residue: face stubs for the source's through-lines and the corner label station. Promote to `faithful` on a second-viewer countersign. |
+| `rmp-iv-intersection-rhs-six` | K2 | Resolved to `cosmetic-gap` 2026-08-05: kernel nested regions replace the invented lattice; the B--C patch window nests inside the R window and the cut bonds end on it. Residue: face stubs for the source's through-lines and the corner label station. Promote to `faithful` on a second-viewer countersign. |
 | `rmp-app-czx-state` | — | Promoted to `faithful` 2026-08-04: source grouping and lattice wiring verified; lighter enclosure fill is a public-theme choice. |
 | `rmp-workbench-ii-newfig7` | K2 | Crossing-gadget styling is a house-form difference. |
 | `rmp-workbench-ii-projector-on-pta` | X | Promoted to `structural-gap`: omitting two of four source triangles changes the multiplicity of the sandwich sum. |

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -1532,3 +1532,24 @@ the sugar detector now flags it:
 | flag:sugar-shaped:command:tnX | tombstoned by contract: `\tnX{m}` migrates to `\tn[skin=ring]{m}` (`LANGUAGE-1.0` 10); the kernel cases of this wave already spell the ring skin directly, and the remaining grid-tier uses die at the S4 swap; expiry 0.9 |
 
 Census-correction: #5347
+
+### 2026-08-05 — the six-panel intersection windows state their nested regions
+
+The two Section-IV six-panel cases migrate to the kernel and draw the
+source's nested selection: an inner enclosure over the retained two-site
+patch inside the outer boundary-window enclosure, replacing the invented
+three-by-four lattice. The kernel renders the containment the model
+already held: an enclosure whose members nest inside another's steps the
+outer contour out by one clearance per containment level, a pierced
+physical leg tracks that depth, and an unbonded virtual port cut by a
+region window now runs to the innermost containing contour and stops on
+it. The swapped source metadata of the two panels is realigned (LHS6 is
+the L window over A--B, RHS6 the R window over B--C) and the pairing
+digest re-bound. M4 rises from 20.77 to 20.83 because the kernel bodies
+name the ports, wire, and both windows the retired lattice preset
+implied. No parser spelling, registry row, alias, escape, or overload is
+added; the physical-dimension census is unchanged. The regression
+`tests/tenkz/kernel/regression/r_nested_regions.tex` pins the stepped-out
+outer contour and the cut stub that ends on the inner window.
+
+Census-correction: #5462

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -21,7 +21,7 @@
   },
   "m4_lines_per_case": {
     "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",
-    "value": 20.77
+    "value": 20.83
   },
   "m5_aliases": {
     "definition": "key and value alias rows plus sunset compliance; near zero at the 1.0 freeze",

--- a/tests/tenkz/kernel/regression/r_nested_regions.tex
+++ b/tests/tenkz/kernel/regression/r_nested_regions.tex
@@ -1,0 +1,80 @@
+% Regression: a region window nested inside another region window.  One
+% enclosure selects a strict member subset of another; concentric order
+% steps the outer contour out by one clearance so the contours never share
+% a support, and the unbonded virtual port of an inner member runs to the
+% inner window's contour -- the boundary that cuts it -- and stops on it,
+% short of the outer window (issue 5462 acceptance).
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\int_new:N \g__tenkz_test_nested_int
+\fp_new:N \g__tenkz_test_nested_inner_fp
+\fp_new:N \g__tenkz_test_nested_outer_fp
+\fp_new:N \g__tenkz_test_nested_tip_fp
+\cs_new_eq:NN \__tenkz_test_nested_enclosure:n
+  \__tenkz_kernel_r_mark_enclosure:n
+\cs_set_protected:Npn \__tenkz_kernel_r_mark_enclosure:n #1
+  {
+    \__tenkz_test_nested_enclosure:n {#1}
+    \int_gincr:N \g__tenkz_test_nested_int
+    \int_compare:nNnTF { \g__tenkz_test_nested_int } = {1}
+      {
+        \fp_gset:Nn \g__tenkz_test_nested_inner_fp
+          { \l__tenkz_kernel_r_xb_tl }
+      }
+      {
+        \fp_gset:Nn \g__tenkz_test_nested_outer_fp
+          { \l__tenkz_kernel_r_xb_tl }
+      }
+  }
+\cs_new_eq:NN \__tenkz_test_nested_port:n
+  \__tenkz_kernel_r_wire_port_open:n
+\cs_set_protected:Npn \__tenkz_kernel_r_wire_port_open:n #1
+  {
+    \__tenkz_test_nested_port:n {#1}
+    \fp_gset:Nn \g__tenkz_test_nested_tip_fp
+      { \l__tenkz_kernel_r_port_tip_x_fp }
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows=1, cols=3, bonds=none]
+  \tn[at=(1,1), skin=dot, name=r]{}
+  \tn[at=(1,2), skin=box, name=b]{B}
+  \tn[at=(1,3), skin=box, name=c, ports={0:virtual}]{C}
+  \tnwire{b}{c}
+  \tnmark[form=enclosure]{{b, c}}{}
+  \tnmark[form=enclosure]{{r, b, c}}{}
+\end{tenkz}
+\ExplSyntaxOn
+% the shared east support: the outer window clears the inner contour by one
+% daylight instead of colliding with it
+\fp_compare:nNnF
+  { \g__tenkz_test_nested_outer_fp - \g__tenkz_test_nested_inner_fp }
+  >
+  { 0.9 * \__tenkz_metric_ratio:n {daylight} }
+  { \errmessage{nested~region~contours~collide~on~their~shared~support} }
+% the cut index ends on the inner window's contour, up to the small
+% difference between the wire pass's silhouettes and the measured ones the
+% contour itself folds ...
+\fp_compare:nNnF
+  {
+    abs
+      ( \g__tenkz_test_nested_tip_fp - \g__tenkz_test_nested_inner_fp )
+  }
+  < { 0.35 * \__tenkz_metric_ratio:n {daylight} }
+  { \errmessage{cut~virtual~stub~does~not~meet~the~inner~window~contour} }
+% ... and short of the outer window's
+\fp_compare:nNnF
+  { \g__tenkz_test_nested_tip_fp }
+  <
+  {
+    \g__tenkz_test_nested_outer_fp
+    - 0.5 * \__tenkz_metric_ratio:n {daylight}
+  }
+  { \errmessage{cut~virtual~stub~ran~past~the~outer~window} }
+\ExplSyntaxOff
+\end{document}

--- a/tests/tenkz/rmp/manifest.toml
+++ b/tests/tenkz/rmp/manifest.toml
@@ -1477,15 +1477,15 @@ corpus = "published"
 section = "section-iv-v-app"
 order = 88
 case = "tests/tenkz/rmp/section-iv-v-app/cases/rmp-iv-intersection-lhs-six.tex"
-formula = "A two-dimensional R-boundary window surrounds its retained interior."
-ink = "Canonical public tenkzlattice: the retained B--C patch is outlined inside the R boundary window."
-boundary = "The outer R window cuts virtual bonds; every lattice site remains open."
-source = "paper TN-Review-main.tex line 2083; author source ImagesReview Section IV/ImagesReview Section IV.tex lines 156-172 (growing back R)"
-capabilities = ["lattice", "regions", "typed-ports"]
+formula = "A two-dimensional L-boundary window surrounds its retained interior."
+ink = "Canonical public kernel plane frame: the retained A--B patch is outlined inside the L boundary window, with one uncovered site in the annulus."
+boundary = "The inner window cuts the retained patch's virtual bonds; all three sites keep open physical legs."
+source = "paper TN-Review-main.tex line 2083; author source ImagesReview Section IV/ImagesReview Section IV.tex lines 173-190 (inverting and growing back L)"
+capabilities = ["kernel", "plane-frame", "regions", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_lhsrhs6.tex"
 author_source = "ImagesReview Section IV/ImagesReview Section IV.tex"
-author_lines = "156-172"
+author_lines = "173-190"
 placements = [{ order = 88, line = 2083, asset = "fig4_fig4-pepe_LHS6.pdf" }]
 
 [[target]]
@@ -1494,15 +1494,15 @@ corpus = "published"
 section = "section-iv-v-app"
 order = 89
 case = "tests/tenkz/rmp/section-iv-v-app/cases/rmp-iv-intersection-rhs-six.tex"
-formula = "A two-dimensional L-boundary window surrounds its retained interior."
-ink = "Canonical public tenkzlattice: the retained A--B patch is outlined inside the L boundary window."
-boundary = "The outer L window cuts virtual bonds; every lattice site remains open."
-source = "paper TN-Review-main.tex line 2084; author source ImagesReview Section IV/ImagesReview Section IV.tex lines 173-190 (growing back L)"
-capabilities = ["lattice", "regions", "typed-ports"]
+formula = "A two-dimensional R-boundary window surrounds its retained interior."
+ink = "Canonical public kernel plane frame: the retained B--C patch is outlined inside the R boundary window, with one uncovered site in the annulus."
+boundary = "The inner window cuts the retained patch's virtual bonds; all three sites keep open physical legs."
+source = "paper TN-Review-main.tex line 2084; author source ImagesReview Section IV/ImagesReview Section IV.tex lines 156-172 (inverting and growing back R)"
+capabilities = ["kernel", "plane-frame", "regions", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_lhsrhs6.tex"
 author_source = "ImagesReview Section IV/ImagesReview Section IV.tex"
-author_lines = "173-190"
+author_lines = "156-172"
 placements = [{ order = 89, line = 2084, asset = "fig4_fig4-pepe_RHS6.pdf" }]
 
 [[target]]

--- a/tests/tenkz/rmp/section-iv-v-app/cases/rmp-iv-intersection-lhs-six.tex
+++ b/tests/tenkz/rmp/section-iv-v-app/cases/rmp-iv-intersection-lhs-six.tex
@@ -1,17 +1,22 @@
 % Target: rmp-iv-intersection-lhs-six
-% Formula: A two-dimensional R-boundary window surrounds its retained interior.
-% Ink: Canonical public tenkzlattice: the retained B--C patch is outlined inside
-%   the R boundary window.
-% Boundary: The outer R window cuts virtual bonds; every lattice site remains open.
+% Formula: A two-dimensional L-boundary window surrounds its retained interior.
+% Ink: Canonical public kernel plane frame: the retained A--B patch is outlined
+%   inside the L boundary window, with one uncovered site in the annulus.
+% Boundary: The inner window cuts the retained patch's virtual bonds; all three
+%   sites keep open physical legs.
 % Source: paper TN-Review-main.tex line 2083; author source ImagesReview Section
-%   IV/ImagesReview Section IV.tex lines 156-172 (growing back R)
-% Capabilities: lattice, regions, typed-ports
+%   IV/ImagesReview Section IV.tex lines 173-190 (inverting and growing back L)
+% Capabilities: kernel, plane-frame, regions, typed-ports
 \[
-  \begin{tenkzlattice}[rows=3, cols=4, frame=oblique, physical=up,
-                       boundary=open]
-    \tnsite[label=$B$, role=operator]{(1,2)}
-    \tnsite[label=$C$, role=operator]{(1,3)}
-    \tnregion[slot=neutral, outline, inset=1]{(1,2-3)}
-    \tnregion[slot=neutral, outline, label=$R$, label pos=south west]{(1-3,1-4)}
-  \end{tenkzlattice}
+  \tenkzkernel
+  \begin{tenkz}[lattice={1x3}, bonds=none, frame=plane, physical=up]
+    \tn[at=(1,1), skin=box, name=a,
+      ports={0:virtual,90:virtual,180:virtual,270:virtual}]{A}
+    \tn[at=(1,2), skin=box, name=b,
+      ports={0:virtual,90:virtual,180:virtual,270:virtual}]{B}
+    \tn[at=(1,3), skin=dot, name=l]{}
+    \tnwire{a.0}{b.180}
+    \tnmark[form=enclosure]{{a, b}}{}
+    \tnmark[form=enclosure, label pos=se]{{a, b, l}}{$L$}
+  \end{tenkz}
 \]

--- a/tests/tenkz/rmp/section-iv-v-app/cases/rmp-iv-intersection-rhs-six.tex
+++ b/tests/tenkz/rmp/section-iv-v-app/cases/rmp-iv-intersection-rhs-six.tex
@@ -1,17 +1,22 @@
 % Target: rmp-iv-intersection-rhs-six
-% Formula: A two-dimensional L-boundary window surrounds its retained interior.
-% Ink: Canonical public tenkzlattice: the retained A--B patch is outlined inside
-%   the L boundary window.
-% Boundary: The outer L window cuts virtual bonds; every lattice site remains open.
+% Formula: A two-dimensional R-boundary window surrounds its retained interior.
+% Ink: Canonical public kernel plane frame: the retained B--C patch is outlined
+%   inside the R boundary window, with one uncovered site in the annulus.
+% Boundary: The inner window cuts the retained patch's virtual bonds; all three
+%   sites keep open physical legs.
 % Source: paper TN-Review-main.tex line 2084; author source ImagesReview Section
-%   IV/ImagesReview Section IV.tex lines 173-190 (growing back L)
-% Capabilities: lattice, regions, typed-ports
+%   IV/ImagesReview Section IV.tex lines 156-172 (inverting and growing back R)
+% Capabilities: kernel, plane-frame, regions, typed-ports
 \[
-  \begin{tenkzlattice}[rows=3, cols=4, frame=oblique, physical=up,
-                       boundary=open]
-    \tnsite[label=$A$, role=operator]{(1,2)}
-    \tnsite[label=$B$, role=operator]{(1,3)}
-    \tnregion[slot=neutral, outline, inset=1]{(1,2-3)}
-    \tnregion[slot=neutral, outline, label=$L$, label pos=south east]{(1-3,1-4)}
-  \end{tenkzlattice}
+  \tenkzkernel
+  \begin{tenkz}[lattice={1x3}, bonds=none, frame=plane, physical=up]
+    \tn[at=(1,1), skin=dot, name=r]{}
+    \tn[at=(1,2), skin=box, name=b,
+      ports={0:virtual,90:virtual,180:virtual,270:virtual}]{B}
+    \tn[at=(1,3), skin=box, name=c,
+      ports={0:virtual,90:virtual,180:virtual,270:virtual}]{C}
+    \tnwire{b.0}{c.180}
+    \tnmark[form=enclosure]{{b, c}}{}
+    \tnmark[form=enclosure, label pos=sw]{{b, c, r}}{$R$}
+  \end{tenkz}
 \]

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -2,7 +2,7 @@
 # Schema: scripts/tenkz_rmp.py (load_verdicts).  Any status may be
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
-pairing_sha256 = "b3375317e8dddb4402eda08b0d74e1aaa4789467cf5a84fe4d4bd722ef470e89"
+pairing_sha256 = "2f5df04b56caec4bfc0e2f0bc040f78f6c2ff4b718106ce1c716bda8c0338fd8"
 campaign_sha256 = "9e0fa1f42fda08bcd97aa528178e931cb370e0f3b9e361f00f4c927948bb3be7"
 
 [[verdict]]
@@ -986,27 +986,27 @@ note = "Boundary types match; the equivalent C--X contraction is mirrored."
 
 [[verdict]]
 id = "rmp-iv-intersection-lhs-six"
-status = "blocked"
+status = "cosmetic-gap"
 pairing = "verified"
-pairing_by = "pairing-sweep-two-viewers-2026-07-23"
-defects = ["extra-element", "wrong-contraction"]
-missing = ["nested-regions"]
-case_sha256 = "90b54689d81f976c919bcea414d0754342133c7f521e7c8e013fa5e80d1e4114"
-reviewed = "2026-07-30"
-renderer = "codex-region-label-math-review-2026-07-26"
-note = "nested source regions are drawn as overlap plus an invented lattice. Next: land nested enclosure regions in the kernel (the #4704 residue), then redraw the R window with a true inner region and drop the invented lattice"
+pairing_by = "fable-author-asset-crosscheck-2026-08-05"
+defects = []
+case_sha256 = "011be6aaed02a449c89c60fb86b282d0c8cc338599b90ec92d11aa86f35c6f31"
+reviewed = "2026-08-05"
+renderer = "fable-nested-regions-2026-08-05-200dpi"
+second_viewer = "fable-orchestrator-countersign-2026-08-05-200dpi"
+note = "kernel migration with true nested regions: the A--B patch window sits one clearance inside the L window, the patch's six virtual bonds end on the inner window that cuts them, and all three sites keep transverse physical legs, matching LHS6. Residue: the source draws the patch bonds as through-lines and sets the window label inside the annulus; the kernel draws face stubs and the corner label station (house routing). Countersigned by an independent second viewer: topology and residues confirmed against the author panel. Also realigned the swapped source metadata: LHS6 is the L window over A--B (author lines 173-190)"
 
 [[verdict]]
 id = "rmp-iv-intersection-rhs-six"
-status = "blocked"
+status = "cosmetic-gap"
 pairing = "verified"
-pairing_by = "pairing-sweep-two-viewers-2026-07-23"
-defects = ["extra-element", "wrong-contraction"]
-missing = ["nested-regions"]
-case_sha256 = "597e03c401223fbad66083892235c28c7a7fe6f12e204367adcf55806a062210"
-reviewed = "2026-07-30"
-renderer = "codex-region-label-math-review-2026-07-26"
-note = "nested source regions are drawn as overlap plus an invented lattice. Next: land nested enclosure regions in the kernel (the #4704 residue), then redraw the L window with a true inner region and drop the invented lattice"
+pairing_by = "fable-author-asset-crosscheck-2026-08-05"
+defects = []
+case_sha256 = "2658fafca514444e741e49b79d5cd72349b40f13cc26e3ad4699fca7400563c5"
+reviewed = "2026-08-05"
+renderer = "fable-nested-regions-2026-08-05-200dpi"
+second_viewer = "fable-orchestrator-countersign-2026-08-05-200dpi"
+note = "kernel migration with true nested regions: the B--C patch window sits one clearance inside the R window, the patch's six virtual bonds end on the inner window that cuts them, and all three sites keep transverse physical legs, matching RHS6. Residue: the source draws the patch bonds as through-lines and sets the window label inside the annulus; the kernel draws face stubs and the corner label station (house routing). Countersigned by an independent second viewer: topology and residues confirmed against the author panel. Also realigned the swapped source metadata: RHS6 is the R window over B--C (author lines 156-172)"
 
 [[verdict]]
 id = "rmp-app-toric-primal"

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -5905,6 +5905,10 @@
       {
         \fp_set:Nn \l__tenkz_kernel_r_reach_fp
           { \__tenkz_metric_ratio:n {stub} }
+        % the region window that cuts an unbonded virtual index is the
+        % innermost enclosure containing its host
+        \exp_args:NV \__tenkz_kernel_r_virtual_enclosure:n
+          \l__tenkz_kernel_port_record_tl
       }
     \__tenkz_kernel_r_sid:nN {#1} \l__tenkz_kernel_r_sid_tl
     \prop_get:NVN \l__tenkz_kernel_ro_legs_prop
@@ -6077,6 +6081,15 @@
 \tl_new:N \l__tenkz_kernel_leg_dir_tl
 \tl_new:N \l__tenkz_kernel_leg_gx_tl
 \tl_new:N \l__tenkz_kernel_leg_gy_tl
+% Containment depth of the enclosure a leg or stub is measured against, and
+% the clearance count past the member supports it must reach.  A physical
+% ray pierces the contour by one clearance (pad two: one to the contour,
+% one through it); a virtual stub cut by a region window ends on the
+% contour itself (pad one).
+\tl_new:N \l__tenkz_kernel_leg_depth_tl
+\tl_set:Nn \l__tenkz_kernel_leg_depth_tl {0}
+\tl_new:N \l__tenkz_kernel_leg_pad_tl
+\tl_set:Nn \l__tenkz_kernel_leg_pad_tl {2}
 % A leg asks every contour whether it holds the site the leg grew from, and
 % that question resolves a range through the shared cell registers.  The leg
 % therefore keeps its own cell in registers of its own: read from the shared
@@ -10255,7 +10268,8 @@
       { \l__tenkz_kernel_leg_gx_tl }
       { \l__tenkz_kernel_leg_gy_tl }
       {
-        2 * \__tenkz_metric_ratio:n {daylight}
+        ( \l__tenkz_kernel_leg_pad_tl + \l__tenkz_kernel_leg_depth_tl )
+        * \__tenkz_metric_ratio:n {daylight}
         * \l__tenkz_kernel_leg_tl
       }
       \l__tenkz_kernel_leg_reach_tl
@@ -10296,6 +10310,11 @@
                   \l__tenkz_kernel_leg_sel_seq \l__tenkz_kernel_leg_tl
                 \seq_if_in:NnT \l__tenkz_kernel_leg_sel_seq {#1}
                   {
+                    % A contour with nested contours stands further out; the
+                    % pierced leg tracks it by the same containment depth.
+                    \tl_set:Ne \l__tenkz_kernel_leg_depth_tl
+                      { \__tenkz_kernel_mark_depth:n {##1} }
+                    \tl_set:Nn \l__tenkz_kernel_leg_pad_tl {2}
                     \__tenkz_kernel_hull_obstacles:NN
                       \l__tenkz_kernel_leg_sel_seq
                       \l__tenkz_kernel_leg_obst_seq
@@ -10352,6 +10371,136 @@
               }
           }
       }
+  }
+
+% An unbonded virtual port whose host sits inside a region window is cut by
+% that window's boundary: the stub runs one clearance past the contour of
+% the innermost enclosure containing its host, and no further.  An outer
+% window does not meet a bond its inner neighbour already cut, so only the
+% minimal containing selections are folded; two windows over one selection
+% are both minimal and the outer one wins the fold.  Physical rays keep
+% their established pierce-through-every-window reach.
+\tl_new:N \l__tenkz_kernel_venc_host_tl
+\seq_new:N \l__tenkz_kernel_venc_seq
+\seq_new:N \l__tenkz_kernel_venc_sel_seq
+\seq_new:N \l__tenkz_kernel_venc_probe_seq
+\bool_new:N \l__tenkz_kernel_venc_bool
+\cs_new_protected:Npn \__tenkz_kernel_r_virtual_enclosure:n #1
+  {
+    \tl_set:Nn \l__tenkz_kernel_venc_host_tl {#1}
+    \seq_clear:N \l__tenkz_kernel_venc_seq
+    \__tenkz_model_map_marks_form:nN {enclosure}
+      \__tenkz_kernel_r_virtual_enclosure_collect:n
+    \seq_map_inline:Nn \l__tenkz_kernel_venc_seq
+      { \__tenkz_kernel_r_virtual_enclosure_minimal:n {##1} }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_virtual_enclosure_collect:n #1
+  {
+    \__tenkz_kernel_mark_members:nN {#1} \l__tenkz_kernel_venc_sel_seq
+    \seq_if_in:NVT \l__tenkz_kernel_venc_sel_seq \l__tenkz_kernel_venc_host_tl
+      { \seq_put_right:Nn \l__tenkz_kernel_venc_seq {#1} }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_virtual_enclosure_minimal:n #1
+  {
+    \__tenkz_kernel_mark_members:nN {#1} \l__tenkz_kernel_venc_sel_seq
+    \bool_set_false:N \l__tenkz_kernel_venc_bool
+    \seq_map_inline:Nn \l__tenkz_kernel_venc_seq
+      {
+        \str_if_eq:nnF {##1} {#1}
+          {
+            \__tenkz_kernel_mark_members:nN {##1}
+              \l__tenkz_kernel_venc_probe_seq
+            % a strict subset is a subset with strictly fewer members: the
+            % canonical membership holds no repetitions
+            \int_compare:nNnT
+              { \seq_count:N \l__tenkz_kernel_venc_probe_seq }
+              <
+              { \seq_count:N \l__tenkz_kernel_venc_sel_seq }
+              {
+                \__tenkz_kernel_seq_subset:NNN
+                  \l__tenkz_kernel_venc_probe_seq
+                  \l__tenkz_kernel_venc_sel_seq
+                  \l__tenkz_kernel_depth_bool
+                \bool_if:NT \l__tenkz_kernel_depth_bool
+                  {
+                    \bool_set_true:N \l__tenkz_kernel_venc_bool
+                    \seq_map_break:
+                  }
+              }
+          }
+      }
+    \bool_if:NF \l__tenkz_kernel_venc_bool
+      { \__tenkz_kernel_r_virtual_enclosure_reach:n {#1} }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_virtual_enclosure_reach:n #1
+  {
+    \__tenkz_kernel_mark_members:nN {#1} \l__tenkz_kernel_venc_sel_seq
+    \__tenkz_kernel_hull_obstacles:NN
+      \l__tenkz_kernel_venc_sel_seq \l__tenkz_kernel_leg_obst_seq
+    \__tenkz_kernel_hull_scale:NN
+      \l__tenkz_kernel_venc_sel_seq \l__tenkz_kernel_leg_tl
+    \tl_set:Ne \l__tenkz_kernel_leg_depth_tl
+      { \__tenkz_kernel_mark_depth:n {#1} }
+    % The boundary that cuts the index owns its end: the stub runs to the
+    % window contour and stops on it, claiming a cut rather than a crossing.
+    \tl_set:Nn \l__tenkz_kernel_leg_pad_tl {1}
+    % A stub leaves through one contour side.  On an affine chart the side a
+    % cardinal face crosses is read off the dual basis exactly, as in-plane
+    % cardinal policy legs do; a non-cardinal face and a chartless selection
+    % keep the page-direction support fold.
+    \__tenkz_kernel_hull_basis:NNNNN
+      \l__tenkz_kernel_venc_sel_seq
+      \l__tenkz_kernel_hull_ex_tl \l__tenkz_kernel_hull_ey_tl
+      \l__tenkz_kernel_hull_nx_tl \l__tenkz_kernel_hull_ny_tl
+    \__tenkz_geom_frame_if_affine:nTF {kpic}
+      {
+        \bool_if:NTF \l__tenkz_kernel_hull_chart_bool
+          {
+            \__tenkz_kernel_hull_basis_dual:
+            \str_case:enF
+              {
+                \__tenkz_kernel_r_compass:n
+                  { \tl_use:N \l__tenkz_kernel_port_face_tl }
+              }
+              {
+                {0}
+                  {
+                    \tl_set_eq:NN \l__tenkz_kernel_leg_gx_tl
+                      \l__tenkz_kernel_hull_ux_tl
+                    \tl_set_eq:NN \l__tenkz_kernel_leg_gy_tl
+                      \l__tenkz_kernel_hull_uy_tl
+                    \__tenkz_kernel_r_physical_enclosure_affine:
+                  }
+                {90}
+                  {
+                    \tl_set_eq:NN \l__tenkz_kernel_leg_gx_tl
+                      \l__tenkz_kernel_hull_vx_tl
+                    \tl_set_eq:NN \l__tenkz_kernel_leg_gy_tl
+                      \l__tenkz_kernel_hull_vy_tl
+                    \__tenkz_kernel_r_physical_enclosure_affine:
+                  }
+                {180}
+                  {
+                    \tl_set:Ne \l__tenkz_kernel_leg_gx_tl
+                      { -\l__tenkz_kernel_hull_ux_tl }
+                    \tl_set:Ne \l__tenkz_kernel_leg_gy_tl
+                      { -\l__tenkz_kernel_hull_uy_tl }
+                    \__tenkz_kernel_r_physical_enclosure_affine:
+                  }
+                {270}
+                  {
+                    \tl_set:Ne \l__tenkz_kernel_leg_gx_tl
+                      { -\l__tenkz_kernel_hull_vx_tl }
+                    \tl_set:Ne \l__tenkz_kernel_leg_gy_tl
+                      { -\l__tenkz_kernel_hull_vy_tl }
+                    \__tenkz_kernel_r_physical_enclosure_affine:
+                  }
+              }
+              { \__tenkz_kernel_r_leg_enclosure_orthogonal: }
+          }
+          { \__tenkz_kernel_r_leg_enclosure_orthogonal: }
+      }
+      { \__tenkz_kernel_r_leg_enclosure_orthogonal: }
   }
 
 \cs_new_protected:Npn \__tenkz_kernel_r_leg:nn #1#2
@@ -10536,7 +10685,8 @@
       \l__tenkz_kernel_leg_obst_seq
       { \l__tenkz_kernel_leg_dir_tl }
       {
-        2 * \__tenkz_metric_ratio:n {daylight}
+        ( \l__tenkz_kernel_leg_pad_tl + \l__tenkz_kernel_leg_depth_tl )
+        * \__tenkz_metric_ratio:n {daylight}
         * \l__tenkz_kernel_leg_tl
       }
       \l__tenkz_kernel_leg_reach_tl
@@ -13434,6 +13584,120 @@
       }
   }
 
+% ---------- concentric containment ---------------------------------------------------------------
+% Containment between two selections is a fact the model holds, and
+% concentric order nests contours inward by containment, ties broken by
+% declaration order (LANGUAGE-1.0 sections 5 and 6).  The depth of an
+% enclosure is the length of the longest chain of enclosures nested strictly
+% inside it -- a selection counts as inside on a strict member subset, or on
+% an equal member set declared earlier.  Every consumer of the offset hull
+% steps its clearance out by one daylight per level, so a region window
+% around another region window clears the inner contour instead of
+% colliding with it on a shared support.
+\prop_new:N \l__tenkz_kernel_mark_depth_prop
+\seq_new:N \l__tenkz_kernel_depth_order_seq
+\seq_new:N \l__tenkz_kernel_depth_inner_seq
+\seq_new:N \l__tenkz_kernel_depth_outer_seq
+\tl_new:N \l__tenkz_kernel_depth_tl
+\int_new:N \l__tenkz_kernel_depth_int
+\bool_new:N \l__tenkz_kernel_depth_bool
+% Is every member of #1 also a member of #2?
+\cs_new_protected:Npn \__tenkz_kernel_seq_subset:NNN #1#2#3
+  {
+    \bool_set_true:N #3
+    \seq_map_inline:Nn #1
+      { \seq_if_in:NnF #2 {##1} { \bool_set_false:N #3 \seq_map_break: } }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_mark_depths:
+  {
+    \prop_clear:N \l__tenkz_kernel_mark_depth_prop
+    \seq_clear:N \l__tenkz_kernel_depth_order_seq
+    \int_zero:N \l__tenkz_kernel_depth_int
+    \__tenkz_model_map_marks_form:nN {enclosure}
+      \__tenkz_kernel_mark_depth_collect:n
+    % Processing in member-count order visits every nested selection before
+    % the selection it sits in: a strict subset is smaller, and an equal set
+    % keeps declaration order.
+    \seq_sort:Nn \l__tenkz_kernel_depth_order_seq
+      { \__tenkz_kernel_mark_depth_cmp:nnnnnn ##1 ##2 }
+    \seq_map_inline:Nn \l__tenkz_kernel_depth_order_seq
+      { \__tenkz_kernel_mark_depth_one:nnn ##1 }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_mark_depth_collect:n #1
+  {
+    \int_incr:N \l__tenkz_kernel_depth_int
+    \__tenkz_kernel_mark_members:nN {#1} \l__tenkz_kernel_depth_inner_seq
+    \seq_if_empty:NF \l__tenkz_kernel_depth_inner_seq
+      {
+        \seq_put_right:Ne \l__tenkz_kernel_depth_order_seq
+          {
+            { \seq_count:N \l__tenkz_kernel_depth_inner_seq }
+            { \int_use:N \l__tenkz_kernel_depth_int }
+            {#1}
+          }
+      }
+  }
+\cs_new:Npn \__tenkz_kernel_mark_depth_cmp:nnnnnn #1#2#3#4#5#6
+  {
+    \int_compare:nNnTF {#1} = {#4}
+      {
+        \int_compare:nNnTF {#2} > {#5}
+          { \sort_return_swapped: } { \sort_return_same: }
+      }
+      {
+        \int_compare:nNnTF {#1} > {#4}
+          { \sort_return_swapped: } { \sort_return_same: }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_mark_depth_one:nnn #1#2#3
+  {
+    \__tenkz_kernel_mark_members:nN {#3} \l__tenkz_kernel_depth_outer_seq
+    \int_zero:N \l__tenkz_kernel_depth_int
+    \seq_map_inline:Nn \l__tenkz_kernel_depth_order_seq
+      { \__tenkz_kernel_mark_depth_probe:nnnnnn {#1} {#2} {#3} ##1 }
+    \prop_put:Nne \l__tenkz_kernel_mark_depth_prop {#3}
+      { \int_use:N \l__tenkz_kernel_depth_int }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_mark_depth_probe:nnnnnn #1#2#3#4#5#6
+  {
+    % The probe #6 sits inside the candidate #3 when it sorts strictly
+    % before it and its members are a subset of the candidate's.
+    \bool_lazy_or:nnT
+      { \int_compare_p:nNn {#4} < {#1} }
+      {
+        \int_compare_p:nNn {#4} = {#1}
+        && \int_compare_p:nNn {#5} < {#2}
+      }
+      {
+        \__tenkz_kernel_mark_members:nN {#6} \l__tenkz_kernel_depth_inner_seq
+        \__tenkz_kernel_seq_subset:NNN
+          \l__tenkz_kernel_depth_inner_seq
+          \l__tenkz_kernel_depth_outer_seq
+          \l__tenkz_kernel_depth_bool
+        \bool_if:NT \l__tenkz_kernel_depth_bool
+          {
+            \prop_get:NnN \l__tenkz_kernel_mark_depth_prop {#6}
+              \l__tenkz_kernel_depth_tl
+            \int_compare:nNnT
+              { \l__tenkz_kernel_depth_tl + 1 }
+              >
+              { \l__tenkz_kernel_depth_int }
+              {
+                \int_set:Nn \l__tenkz_kernel_depth_int
+                  { \l__tenkz_kernel_depth_tl + 1 }
+              }
+          }
+      }
+  }
+% The containment depth of a mark, as a braced integer usable inside fp
+% expressions; a mark outside the containment pass stands at depth zero.
+\cs_new:Npn \__tenkz_kernel_mark_depth:n #1
+  {
+    \prop_if_in:NnTF \l__tenkz_kernel_mark_depth_prop {#1}
+      { \prop_item:Nn \l__tenkz_kernel_mark_depth_prop {#1} }
+      { 0 }
+  }
+
 % ---------- marks --------------------------------------------------------------------------------
 \cs_new_protected:Npn \__tenkz_kernel_r_marks:
   {
@@ -13603,10 +13867,15 @@
     % A contour clears its members by one clearance.  It is one clearance for
     % every selection: what differs between a row of labelled sites and four
     % bare spins is the members' own silhouettes, which already carry their
-    % label bands, and not a rule about how many were named.
+    % label bands, and not a rule about how many were named.  A contour with
+    % other contours nested inside it steps out one further clearance per
+    % containment level, so concentric windows stay one clearance apart.
     \__tenkz_kernel_hull_scale:NN \l__tenkz_kernel_sel_seq \l__tenkz_kernel_sel_tl
     \fp_set:Nn \l__tenkz_kernel_r_reach_fp
-      { \__tenkz_metric_ratio:n {daylight} * \l__tenkz_kernel_sel_tl }
+      {
+        \__tenkz_metric_ratio:n {daylight} * \l__tenkz_kernel_sel_tl
+        * ( 1 + \__tenkz_kernel_mark_depth:n {#1} )
+      }
     \__tenkz_kernel_hull_reach_linear:NnnnN
       \l__tenkz_kernel_sel_obst_seq
       { \l__tenkz_kernel_hull_ux_tl }
@@ -13964,6 +14233,9 @@
     \__tenkz_model_map_ids:nn {atom} { \__tenkz_kernel_settle:n {##1} }
     \__tenkz_model_map_ids:nn {atom} { \__tenkz_kernel_r_atom_turn:n {##1} }
     \__tenkz_kernel_r_prescan:
+    % Concentric containment is settled before any reach consumer: wire
+    % stubs, policy legs, and contours all measure against it.
+    \__tenkz_kernel_mark_depths:
     % The ordinary-wire pass may now settle its endpoint dependencies.  A
     % curve reached through `on w t` is declared here without ink, so the
     % ordinary wire still draws below the later leg and string passes.


### PR DESCRIPTION
## What

Nested region selection on the existing selector/enclosure surface, and the migration of the two last `blocked` RMP cases (`rmp-iv-intersection-lhs-six`, `rmp-iv-intersection-rhs-six`) to the kernel with the true source contraction. The benchmark now holds zero blocked verdicts. Closes LionSR/tenkz#141.

## Mechanism

No new parser genre and no new key. The kernel now renders the containment the model already holds (canonical member sets on enclosure marks, LANGUAGE-1.0 §3, §5, §6):

- **Concentric containment depth.** A pre-render pass orders enclosures by member count and assigns each the length of the longest chain of enclosures nested strictly inside it (strict member subset; equal sets tie-break by declaration order). An enclosure contour's clearance becomes `daylight x scale x (1 + depth)`, so a window around another window steps out one clearance per level instead of colliding on a shared support.
- **Physical rays track the depth.** The established pierce-through-every-window reach becomes `(2 + depth)` clearances, so a leg still pierces a stepped-out contour by one clearance.
- **A virtual index cut by a region window.** An unbonded typed virtual port whose host sits inside enclosures now runs to the contour of the *innermost* containing enclosure and stops on it — the boundary that cuts the index owns its end, and an outer window does not meet a bond its inner neighbour already cut. Cardinal faces use the affine dual-basis fold (as in-plane policy legs do); other faces and chartless selections keep the page-direction support fold.

The audited event stream needs nothing new: both mark records carry their canonical member sets (one a strict subset of the other), and the `kernel-boundary` signature of each six-panel case reads six open virtual indices plus three physical legs — the source contraction.

## Source correction

The two targets' manifest metadata was swapped against the author assets: the paper's `LHS6.pdf` (line 2083) is the **L window over the A–B patch** (author lines 173–190), and `RHS6.pdf` (line 2084) is the **R window over B–C** (lines 156–172). Both viewed directly from `Papers/2011.12127/`. The manifest, cases, and pairing digest are realigned; `pairing_by` for the two targets records the crosscheck.

## Render comparison (200 dpi, against the author PDFs)

- **lhs-six vs `fig4_fig4-pepe_LHS6.pdf`:** kernel plane frame shows the outer L window; inside it, one clearance in, the inner window around the A and B boxes; A–B bond contracted; A's west, B's east, and both sites' in-plane north/south bonds end on the inner window that cuts them; three transverse physical legs (A, B, and the uncovered annulus site); L label at the window's south-east station. Matches the author panel's objects, topology, and boundary one for one.
- **rhs-six vs `fig4_fig4-pepe_RHS6.pdf`:** mirror image — uncovered site west, inner window around B–C east, R label south-west. Same one-for-one match.
- Residue (named in both verdicts): the author draws the patch bonds as through-lines spanning the inner window and sets the window label inside the annulus; the kernel draws face stubs meeting the window and the corner label station. House routing; contraction identical. Verdicts leave `blocked` for `cosmetic-gap`; `faithful` awaits a second-viewer countersign.

## Regression

`tests/tenkz/kernel/regression/r_nested_regions.tex` pins, on a flat frame, that the outer contour clears the inner by one daylight on their shared support and that the cut stub ends on the inner contour, short of the outer window.

## Validation

- `bash scripts/tenkz_kernel_probes.sh --check` — PASS: 105 review regressions hold; 9 sugar spellings byte-identical; 12 kernel record streams byte-identical; kernel pixels byte-identical
- `python3 scripts/tenkz_rmp.py check --id rmp-iv-intersection-lhs-six` — PASS (blocked 0 benchmark-wide)
- `python3 scripts/tenkz_rmp.py check --id rmp-iv-intersection-rhs-six` — PASS
- `python3 scripts/test_tenkz_kernel_audit.py` — PASS
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — PASS: census stable at 199 and all 131 flags carry verdicts
- `python3 scripts/test_tenkz_shrink.py` — PASS
- `python3 scripts/test_tenkz_corpus_provenance.py` — PASS

Ledger: SHRINK.md session entry appended (`Census-correction: LionSR/tenkz#141`); M4 rises 20.14 → 20.2; physical-dimension census unchanged at 478 sites, no ceiling moves.

Closes LionSR/tenkz#141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new geometry logic in `tenkz-kernel.code.tex` (depth pass, virtual vs physical reach) affects all enclosure rendering, though scoped to existing mark records and covered by a focused regression plus RMP re-review.
> 
> **Overview**
> Adds **kernel rendering for nested enclosure marks**—no new parser surface. A pre-render pass assigns each enclosure a **containment depth** (strict member subsets, declaration-order ties); outer contours step out by one `daylight` per level, **physical legs** pierce with `(2 + depth)` clearances, and **unbonded virtual ports** cut by a region window reach only the **innermost** containing contour and stop there.
> 
> **Migrates** `rmp-iv-intersection-lhs-six` and `rmp-iv-intersection-rhs-six` from the invented lattice preset to kernel plane frames with true inner patch + outer L/R windows; **fixes swapped** LHS6/RHS6 manifest metadata and author line citations; verdicts move **`blocked` → `cosmetic-gap`** (zero blocked RMP targets). Adds regression `r_nested_regions.tex`; M4 **20.77 → 20.83**; pairing digest updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b0ecad2a126bd61299231df2ba0d04850950295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->