### PR TITLE
feat(MPS/MPDO): identify wMat's eigenvalues with the oneLabelChi entries

### DIFF
--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
@@ -25,9 +25,10 @@ of the project example motivated by arXiv:1606.00608, Theorem 4.14 and lines
   for any $s > 0$;
 * `R_isMPDO` — the closed operator family `mpo R N` is positive
   semidefinite for every positive chain length `N` (`R` is an MPDO);
-* `wMat_eigenvalue_eq_oneLabelChi_entry` — the eigenvalues of the local
-  factor `wMat` of the `R_isMPDO` factorization are exactly the entries of
-  `oneLabelChi` (a scope-restricted spectral link; see *Remaining gap*).
+* `wMat_eigenvalue_eq_oneLabelChi_entry` — the two entries of `oneLabelChi`
+  are eigenvalues of the local factor `wMat` of the `R_isMPDO`
+  factorization, exhibited by a full eigenbasis (a scope-restricted
+  spectral link; see *Remaining gap*).
 
 ## Tensor definition
 
@@ -452,24 +453,26 @@ lemma wMat_posSemidef : wMat.PosSemidef := by
   · have h9 : (0 : ℂ) ≤ (9/25 : ℂ) := by positivity
     refine Matrix.PosSemidef.smul hJ h9
 
-/-- The Walsh–Hadamard eigenvectors of `wMat`: the uniform vector `![1, 1]`
-is a fixed point (eigenvalue `1`), and the alternating vector `![1, -1]` is
-scaled by `lambda = 7/25` (eigenvalue `lambda`). -/
+/-- The uniform Walsh–Hadamard vector `![1, 1]` is a fixed point of `wMat`
+(eigenvalue `1`). -/
 lemma wMat_mulVec_ones : wMat.mulVec ![1, 1] = (1 : ℂ) • ![1, 1] := by
   ext i
   fin_cases i <;> simp [Matrix.mulVec, dotProduct, wMat, Fin.sum_univ_two] <;> norm_num
 
+/-- The alternating Walsh–Hadamard vector `![1, -1]` is an eigenvector of
+`wMat` with eigenvalue `lambda = 7/25`. -/
 lemma wMat_mulVec_alt : wMat.mulVec ![1, -1] = (lambda : ℂ) • ![1, -1] := by
   ext i
   fin_cases i <;>
     simp [Matrix.mulVec, dotProduct, wMat, Fin.sum_univ_two, lambda] <;> norm_num
 
-/-- **`wMat`'s eigenvalues are exactly the entries of `oneLabelChi`.** For
-each `k : Fin 2`, `oneLabelChi.entry 0 0 0 k` (`1` at `k = 0`, `lambda` at
-`k = 1`) is an eigenvalue of `wMat`, witnessed by the Walsh–Hadamard
-eigenvectors `![1, 1]` and `![1, -1]`.  This identifies the local factor of
-the `R_isMPDO` factorization (`wMat`, via `coeff_sq_eq_wMat`) with the
-one-label `χ` block `oneLabelChi` declared independently in this file.
+/-- **The two entries of `oneLabelChi` are eigenvalues of `wMat`, exhibited
+by a full eigenbasis.** For each `k : Fin 2`, `oneLabelChi.entry 0 0 0 k`
+(`1` at `k = 0`, `lambda` at `k = 1`) is an eigenvalue of `wMat`, witnessed
+by the Walsh–Hadamard eigenvectors `![1, 1]` and `![1, -1]`.  This
+identifies the local factor of the `R_isMPDO` factorization (`wMat`, via
+`coeff_sq_eq_wMat`) with the one-label `χ` block `oneLabelChi` declared
+independently in this file.
 
 **Scope restriction (partial BNT-coefficient link):** this identifies the
 *spectral data* of `wMat` with `oneLabelChi`'s entries; it is not the

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
@@ -24,7 +24,10 @@ of the project example motivated by arXiv:1606.00608, Theorem 4.14 and lines
   $c_s^{(L)} = s^L(1 + (7/25)^L)$, which is not length-independent
   for any $s > 0$;
 * `R_isMPDO` — the closed operator family `mpo R N` is positive
-  semidefinite for every positive chain length `N` (`R` is an MPDO).
+  semidefinite for every positive chain length `N` (`R` is an MPDO);
+* `wMat_eigenvalue_eq_oneLabelChi_entry` — the eigenvalues of the local
+  factor `wMat` of the `R_isMPDO` factorization are exactly the entries of
+  `oneLabelChi` (a scope-restricted spectral link; see *Remaining gap*).
 
 ## Tensor definition
 
@@ -61,6 +64,14 @@ letters entangle bra- and ket-side labels, so no purification tensor exists.
 
 ## Remaining gap
 
+* The uniform BNT-label structure-coefficient statement of
+  arXiv:1606.00608, Theorem 4.14(ii) for `R` — that `oneLabelCoeffs`
+  literally arises from `R`'s same-length product algebra, not only that
+  its spectral data matches (`wMat_eigenvalue_eq_oneLabelChi_entry`) —
+  requires the `AlgebraStructureData` witness apparatus of
+  `TNLean/MPS/MPDO/BNTTheoremWitness.lean`, which in turn needs
+  `IsRFPViaTS R` (below).  Documented in
+  `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`.
 * The literal CPSV canonical form of `R.toMPSTensor` (single bond‑4 block
 with weight `μ = (25/32)² = 625/1024`, eq. II_CF1) and the Definition 4.1
 renormalization fixed‑point condition (`IsRFPViaTS`) are future work.
@@ -440,6 +451,41 @@ lemma wMat_posSemidef : wMat.PosSemidef := by
     refine Matrix.PosSemidef.smul hI h7
   · have h9 : (0 : ℂ) ≤ (9/25 : ℂ) := by positivity
     refine Matrix.PosSemidef.smul hJ h9
+
+/-- The Walsh–Hadamard eigenvectors of `wMat`: the uniform vector `![1, 1]`
+is a fixed point (eigenvalue `1`), and the alternating vector `![1, -1]` is
+scaled by `lambda = 7/25` (eigenvalue `lambda`). -/
+lemma wMat_mulVec_ones : wMat.mulVec ![1, 1] = (1 : ℂ) • ![1, 1] := by
+  ext i
+  fin_cases i <;> simp [Matrix.mulVec, dotProduct, wMat, Fin.sum_univ_two] <;> norm_num
+
+lemma wMat_mulVec_alt : wMat.mulVec ![1, -1] = (lambda : ℂ) • ![1, -1] := by
+  ext i
+  fin_cases i <;>
+    simp [Matrix.mulVec, dotProduct, wMat, Fin.sum_univ_two, lambda] <;> norm_num
+
+/-- **`wMat`'s eigenvalues are exactly the entries of `oneLabelChi`.** For
+each `k : Fin 2`, `oneLabelChi.entry 0 0 0 k` (`1` at `k = 0`, `lambda` at
+`k = 1`) is an eigenvalue of `wMat`, witnessed by the Walsh–Hadamard
+eigenvectors `![1, 1]` and `![1, -1]`.  This identifies the local factor of
+the `R_isMPDO` factorization (`wMat`, via `coeff_sq_eq_wMat`) with the
+one-label `χ` block `oneLabelChi` declared independently in this file.
+
+**Scope restriction (partial BNT-coefficient link):** this identifies the
+*spectral data* of `wMat` with `oneLabelChi`'s entries; it is not the
+uniform BNT-label structure-coefficient statement of arXiv:1606.00608,
+Theorem 4.14(ii) (which requires the `AlgebraStructureData` witness that
+`R`'s same-length product algebra realizes `oneLabelCoeffs`).  That
+construction needs `IsRFPViaTS R`, itself future work (module docstring,
+*Remaining gap*).  Documented in
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
+theorem wMat_eigenvalue_eq_oneLabelChi_entry (k : Fin 2) :
+    ∃ v : Fin 2 → ℂ, v ≠ 0 ∧
+      wMat.mulVec v = (oneLabelChi.entry 0 0 0 k) • v := by
+  fin_cases k
+  · exact ⟨![1, 1], by simp, by simpa [oneLabelChi] using wMat_mulVec_ones⟩
+  · refine ⟨![1, -1], by simp, ?_⟩
+    simpa [oneLabelChi] using wMat_mulVec_alt
 
 /-- The Kronecker power `wN N` is positive semidefinite: by induction on
 `N`, `wN (N + 1)` is a submatrix of the Kronecker product `wN N ⊗ wMat`


### PR DESCRIPTION
## Summary

Progress on #5452. Stacked on #5514 (issue #5472) — base branch is
`agent/issue-5472-rfp-ismpdo`, not `main`; retarget to `main` once #5514
merges.

`wMat_eigenvalue_eq_oneLabelChi_entry` proves that `wMat`'s Walsh-Hadamard
eigenvalues (witnessed by the eigenvectors `![1, 1]` and `![1, -1]`) equal
`oneLabelChi`'s two entries `1` and `lambda = 7/25` — replacing the module
docstring's numerical-verification comment (N = 1, 2, 3) with a genuine
spectral proof.

**Scope note:** this is *not* a full closure of #5452. The issue's title
asks that "the BNT structure coefficients of R equal χ"; the full statement
of arXiv:1606.00608, Theorem 4.14(ii) requires an `AlgebraStructureData`
witness that `R`'s same-length product algebra literally realizes
`oneLabelCoeffs`, using the `BNTTheoremWitness`/`BNTAlgebraTensorClause`
apparatus. That apparatus itself requires `IsRFPViaTS R`, which is issue
#5474 and not yet started. I scoped this PR to the narrower, still-faithful
spectral identification (`wMat`'s eigenvalues = `oneLabelChi`'s entries),
marked `**Scope restriction (partial BNT-coefficient link):**` in the
docstring and citing the existing `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`
note, and left #5452 open for the full closure once #5474 lands.

## Test plan

- [x] `lake env lean TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean` — clean, no errors
- [x] `rg -n "sorry|axiom"` on the touched file — no results
- [x] `lake build TNLean.MPS.MPDO` — 9406/9406, green
- [x] `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci` — passes
- [x] `git diff --check` — clean
- [ ] CI full build