### PR TITLE
doc(blueprint): respell the single-figure chapters and decks onto the tenkz kernel (wave B1)

### DIFF
--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -406,11 +406,39 @@ except ImportError:  # standalone harness use; see the section comment above
     pass
 else:
 
+    class tenkzkernel(Command):
+        r"""The kernel switch (spec §2).  It draws nothing; it stands in
+        the tree so a picture can read whether the switch reaches it."""
+
+        args = ""
+
     class tenkzequation(Environment):
         """A responsive text-mode row of independent SVG picture units."""
 
         blockType = True
         templateName = "TenkzEquation"
+
+    def _kernel_switch_reaches(node) -> bool:
+        r"""Whether \tenkzkernel is in force where this picture stands.
+
+        The switch is an ordinary TeX declaration, so a group ends it: a
+        switch inside one ``center`` block does not reach a picture in the
+        next.  Reading the preceding siblings at each level up from the
+        picture answers exactly that question, and it keeps a chapter that
+        has migrated one figure from claiming the ones it has not.
+        """
+        current = node
+        while current is not None:
+            parent = getattr(current, "parentNode", None)
+            if parent is None:
+                return False
+            for sibling in getattr(parent, "childNodes", []):
+                if sibling is current:
+                    break
+                if getattr(sibling, "nodeName", "") == "tenkzkernel":
+                    return True
+            current = parent
+        return False
 
     class _TenkzSvgMixin:
         """Shared rendering: compile the captured unit, emit one <img>."""
@@ -426,6 +454,8 @@ else:
         @property
         def tenkz_svg_html(self) -> str:
             unit_source = self.tenkzUnitSource()
+            if _kernel_switch_reaches(self):
+                unit_source = "\\tenkzkernel\n" + unit_source
             output_dir = _output_dir(self.ownerDocument)
             svg_path, _ = render_unit(unit_source, output_dir / _SVG_SUBDIR)
             if svg_path is None:

--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -248,16 +248,9 @@ nonvanishing of~$T$, which the final theorem combines into the gauge~$X$.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0.
         \tenkzkernel
-        \begin{tenkz}[rows={wire}, cols=3, bonds=none]
-            \tn[at=(1,1), skin=ring, name=x1, ports={180:virtual, 0:virtual}]{X}
-            \tn[at=(1,2), name=a, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$i$}]{A}
-            \tn[at=(1,3), skin=ring, name=x2,
-                ports={180:virtual, 0:virtual}]{X^{-1}}
-            \tnwire{x1.180}{open w}
-            \tnwire{x1.0}{a.180}
-            \tnwire{a.0}{x2.180}
-            \tnwire{x2.0}{open e}
+        \begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
+            \tn[skin=ring]{X} & \tn[label pos=s, ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{X^{-1}}
         \end{tenkz}
     \end{center}
 \end{theorem}

--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -247,8 +247,17 @@ nonvanishing of~$T$, which the final theorem combines into the gauge~$X$.
         % Type verdict: the picture is a rank-three local tensor.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0.
-        \begin{tenkz}[physical=up]
-            \tnX{X} & \tn[up=$i$]{A} & \tnX{X^{-1}}
+        \tenkzkernel
+        \begin{tenkz}[rows={wire}, cols=3, bonds=none]
+            \tn[at=(1,1), skin=ring, name=x1, ports={180:virtual, 0:virtual}]{X}
+            \tn[at=(1,2), name=a, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$i$}]{A}
+            \tn[at=(1,3), skin=ring, name=x2,
+                ports={180:virtual, 0:virtual}]{X^{-1}}
+            \tnwire{x1.180}{open w}
+            \tnwire{x1.0}{a.180}
+            \tnwire{a.0}{x2.180}
+            \tnwire{x2.0}{open e}
         \end{tenkz}
     \end{center}
 \end{theorem}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
@@ -38,12 +38,24 @@ for its sector-level conclusion.
         % index at each end and one physical leg, so the two sides carry
         % the same boundary signature
         % (virtual-west=1 | virtual-east=1 | physical-up=1).
-        \begin{tenkz}[physical=up]
-            \tn[up=$i$]{Q_k}
+        \tenkzkernel
+        \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+            \tn[at=(1,1), name=q, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$i$}]{Q_k}
+            \tnwire{q.180}{open w}
+            \tnwire{q.0}{open e}
         \end{tenkz}
         $ = \zeta_k$
-        \begin{tenkz}[physical=up]
-            \tnX{X_k} & \tn[up=$i$]{P_{\beta(k)}} & \tnX{X_k^{-1}}
+        \begin{tenkz}[rows={wire}, cols=3, bonds=none]
+            \tn[at=(1,1), skin=ring, name=x1, ports={180:virtual, 0:virtual}]{X_k}
+            \tn[at=(1,2), name=p, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$i$}]{P_{\beta(k)}}
+            \tn[at=(1,3), skin=ring, name=x2,
+                ports={180:virtual, 0:virtual}]{X_k^{-1}}
+            \tnwire{x1.180}{open w}
+            \tnwire{x1.0}{p.180}
+            \tnwire{p.0}{x2.180}
+            \tnwire{x2.0}{open e}
         \end{tenkz}
     \end{center}
     with every open virtual end a matrix index.

--- a/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
@@ -39,23 +39,14 @@ for its sector-level conclusion.
         % the same boundary signature
         % (virtual-west=1 | virtual-east=1 | physical-up=1).
         \tenkzkernel
-        \begin{tenkz}[rows={wire}, cols=1, bonds=none]
-            \tn[at=(1,1), name=q, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$i$}]{Q_k}
-            \tnwire{q.180}{open w}
-            \tnwire{q.0}{open e}
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+            \tn[label pos=s, ports={90:physical:$i$}]{Q_k}
         \end{tenkz}
         $ = \zeta_k$
-        \begin{tenkz}[rows={wire}, cols=3, bonds=none]
-            \tn[at=(1,1), skin=ring, name=x1, ports={180:virtual, 0:virtual}]{X_k}
-            \tn[at=(1,2), name=p, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$i$}]{P_{\beta(k)}}
-            \tn[at=(1,3), skin=ring, name=x2,
-                ports={180:virtual, 0:virtual}]{X_k^{-1}}
-            \tnwire{x1.180}{open w}
-            \tnwire{x1.0}{p.180}
-            \tnwire{p.0}{x2.180}
-            \tnwire{x2.0}{open e}
+        \begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
+            \tn[skin=ring]{X_k} &
+            \tn[label pos=s, ports={90:physical:$i$}]{P_{\beta(k)}} &
+            \tn[skin=ring]{X_k^{-1}}
         \end{tenkz}
     \end{center}
     with every open virtual end a matrix index.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -94,11 +94,29 @@
         % Semantic boundary signature: (virtual-west=0 | virtual-east=0 |
         % physical-up=L+1 | physical-down=0).  This finite schematic emits
         % (virtual-west=0 | virtual-east=0 | physical-up=3 | physical-down=0).
-        \begin{tenkz}[periodic, physical=up]
-            \tnX{X'} &
-            \tn[up=$\sigma_1$]{A}%
-            \tnspan[brace below]{4}{$L+1\text{ sites}$} &
-            \tn{A} & \tndots & \tn[up=$\sigma_{L+1}$]{A}
+        % The periodic return is spelled through the two corner junctions;
+        % the site-count brace does not draw in the kernel yet (#5482), so
+        % its mathematics stays as the south label under the return.
+        \tenkzkernel
+        \begin{tenkz}[rows={wire,wire}, cols=7, bonds=none, align=1]
+            \tn[at=(1,2), skin=ring, name=x, ports={180:virtual, 0:virtual}]{X'}
+            \tn[at=(1,3), name=a1, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$\sigma_1$}]{A}
+            \tn[at=(1,4), name=a2, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical}]{A}
+            \tn[at=(1,5), skin=dots, name=d, ports={180:virtual, 0:virtual}]{}
+            \tn[at=(1,6), name=a3, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$\sigma_{L+1}$}]{A}
+            \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
+            \tn[at=(2,7), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
+            \tnwire{x.0}{a1.180}
+            \tnwire{a1.0}{a2.180}
+            \tnwire{a2.0}{d.180}
+            \tnwire{d.0}{a3.180}
+            \tnwire[route=arc]{a3.0}{je.90}
+            \tnwire{je.180}{jw.0}
+            \tnwire[route=arc]{jw.90}{x.180}
+            \tnmark[form=label, label pos=s]{midway jw and je}{$L+1\text{ sites}$}
         \end{tenkz}
     \end{center}
     \begin{enumerate}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -94,29 +94,16 @@
         % Semantic boundary signature: (virtual-west=0 | virtual-east=0 |
         % physical-up=L+1 | physical-down=0).  This finite schematic emits
         % (virtual-west=0 | virtual-east=0 | physical-up=3 | physical-down=0).
-        % The periodic return is spelled through the two corner junctions;
-        % the site-count brace does not draw in the kernel yet (#5482), so
-        % its mathematics stays as the south label under the return.
+        % The traced sides draw the periodic return; the site-count brace does
+        % not draw in the kernel yet (#5482), so its mathematics stays as the
+        % south label under the return.
         \tenkzkernel
-        \begin{tenkz}[rows={wire,wire}, cols=7, bonds=none, align=1]
-            \tn[at=(1,2), skin=ring, name=x, ports={180:virtual, 0:virtual}]{X'}
-            \tn[at=(1,3), name=a1, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$\sigma_1$}]{A}
-            \tn[at=(1,4), name=a2, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical}]{A}
-            \tn[at=(1,5), skin=dots, name=d, ports={180:virtual, 0:virtual}]{}
-            \tn[at=(1,6), name=a3, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$\sigma_{L+1}$}]{A}
-            \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
-            \tn[at=(2,7), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
-            \tnwire{x.0}{a1.180}
-            \tnwire{a1.0}{a2.180}
-            \tnwire{a2.0}{d.180}
-            \tnwire{d.0}{a3.180}
-            \tnwire[route=arc]{a3.0}{je.90}
-            \tnwire{je.180}{jw.0}
-            \tnwire[route=arc]{jw.90}{x.180}
-            \tnmark[form=label, label pos=s]{midway jw and je}{$L+1\text{ sites}$}
+        \begin{tenkz}[rows={wire}, cols=5, boundary=periodic]
+            \tn[skin=ring]{X'} &
+            \tn[label pos=s, ports={90:physical:$\sigma_1$}]{A} &
+            \tn[label pos=s, ports={90:physical}]{A} & \tn[skin=dots]{} &
+            \tn[label pos=s, ports={90:physical:$\sigma_{L+1}$}]{A}
+            \tnmark[form=label, label pos=s]{s outside}{$L+1\text{ sites}$}
         \end{tenkz}
     \end{center}
     \begin{enumerate}

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -667,20 +667,17 @@ is summed between the $K_i$ layer and the $K_i^\dagger$ layer:
     %   would instead feed the adjoint channel.
     % Boundary signature: (virtual-west=2 | virtual-east=0 |
     % physical-up=0 | physical-down=0).
-    \tenkzkernel
-    $T(\rho)$
-    \begin{tenkz}[rows={wire,wire,wire}, cols=2, bonds=none]
-        \tn[at=(1,1), name=ket, label pos=n,
-            ports={180:virtual, 0:virtual, 270:physical}]{K_i}
-        \tn[at=(3,1), name=bra, label pos=s,
-            ports={180:virtual, 0:virtual, 90:physical}]{\overline{K_i}}
-        \tnwire{ket.180}{open w}
-        \tnwire{bra.180}{open w}
-        \tnwire{ket.270}{bra.90}
-        \tn[at=(2,2), name=rho, label pos=e,
-            ports={90:virtual, 270:virtual}]{\rho}
-        \tnwire[route=arc]{ket.0}{rho.90}
-        \tnwire[route=arc]{rho.270}{bra.0}
+    % The state rides the closing cup.  The kernel's on-wire anchor divides the
+    % record chord rather than the drawn arc (#5482 neighbourhood), so a tensor
+    % placed there would read as sitting on the physical contraction; this
+    % picture keeps its 0.7 spelling until a station on a generated cup exists.
+    \begin{tenkz}[
+        sandwich,
+        east={cup=$\rho$},
+        west label=$T(\rho)$
+    ]
+        \tn{K_i} \\
+        \tn*{K_i}
     \end{tenkz}
 \end{center}
 

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -667,13 +667,20 @@ is summed between the $K_i$ layer and the $K_i^\dagger$ layer:
     %   would instead feed the adjoint channel.
     % Boundary signature: (virtual-west=2 | virtual-east=0 |
     % physical-up=0 | physical-down=0).
-    \begin{tenkz}[
-        sandwich,
-        east={cup=$\rho$},
-        west label=$T(\rho)$
-    ]
-        \tn{K_i} \\
-        \tn*{K_i}
+    \tenkzkernel
+    $T(\rho)$
+    \begin{tenkz}[rows={wire,wire,wire}, cols=2, bonds=none]
+        \tn[at=(1,1), name=ket, label pos=n,
+            ports={180:virtual, 0:virtual, 270:physical}]{K_i}
+        \tn[at=(3,1), name=bra, label pos=s,
+            ports={180:virtual, 0:virtual, 90:physical}]{\overline{K_i}}
+        \tnwire{ket.180}{open w}
+        \tnwire{bra.180}{open w}
+        \tnwire{ket.270}{bra.90}
+        \tn[at=(2,2), name=rho, label pos=e,
+            ports={90:virtual, 270:virtual}]{\rho}
+        \tnwire[route=arc]{ket.0}{rho.90}
+        \tnwire[route=arc]{rho.270}{bra.0}
     \end{tenkz}
 \end{center}
 

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -17,20 +17,17 @@ channel:
     % with the return path it represents V^\dagger in the operator formula.
     % Boundary signature: (virtual-west=2 | virtual-east=0 |
     % physical-up=0 | physical-down=0).
-    \tenkzkernel
-    $T(\rho)$
-    \begin{tenkz}[rows={wire,wire,wire}, cols=2, bonds=none]
-        \tn[at=(1,1), name=ket, label pos=n,
-            ports={180:virtual, 0:virtual, 270:physical}]{V}
-        \tn[at=(3,1), name=bra, label pos=s,
-            ports={180:virtual, 0:virtual, 90:physical}]{\overline{V}}
-        \tnwire{ket.180}{open w}
-        \tnwire{bra.180}{open w}
-        \tnwire{ket.270}{bra.90}
-        \tn[at=(2,2), name=rho, label pos=e,
-            ports={90:virtual, 270:virtual}]{\rho}
-        \tnwire[route=arc]{ket.0}{rho.90}
-        \tnwire[route=arc]{rho.270}{bra.0}
+    % The state rides the closing cup.  The kernel's on-wire anchor divides the
+    % record chord rather than the drawn arc (#5482 neighbourhood), so a tensor
+    % placed there would read as sitting on the physical contraction; this
+    % picture keeps its 0.7 spelling until a station on a generated cup exists.
+    \begin{tenkz}[
+        sandwich,
+        east={cup=$\rho$},
+        west label=$T(\rho)$
+    ]
+        \tn{V} \\
+        \tn*{V}
     \end{tenkz}
 \end{center}
 

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -17,13 +17,20 @@ channel:
     % with the return path it represents V^\dagger in the operator formula.
     % Boundary signature: (virtual-west=2 | virtual-east=0 |
     % physical-up=0 | physical-down=0).
-    \begin{tenkz}[
-        sandwich,
-        east={cup=$\rho$},
-        west label=$T(\rho)$
-    ]
-        \tn{V} \\
-        \tn*{V}
+    \tenkzkernel
+    $T(\rho)$
+    \begin{tenkz}[rows={wire,wire,wire}, cols=2, bonds=none]
+        \tn[at=(1,1), name=ket, label pos=n,
+            ports={180:virtual, 0:virtual, 270:physical}]{V}
+        \tn[at=(3,1), name=bra, label pos=s,
+            ports={180:virtual, 0:virtual, 90:physical}]{\overline{V}}
+        \tnwire{ket.180}{open w}
+        \tnwire{bra.180}{open w}
+        \tnwire{ket.270}{bra.90}
+        \tn[at=(2,2), name=rho, label pos=e,
+            ports={90:virtual, 270:virtual}]{\rho}
+        \tnwire[route=arc]{ket.0}{rho.90}
+        \tnwire[route=arc]{rho.270}{bra.0}
     \end{tenkz}
 \end{center}
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -634,14 +634,43 @@
         % matrices on the wire and carry no legs.  Both sides carry the
         % same boundary signature
         % (virtual-west=1 | virtual-east=1 | physical-up=1 | physical-down=1).
-        \begin{tenkz}[physical=updown, compact]
-            \tnX{X_\alpha^{\dagger}} & \tnX{X_\alpha} & \tn{M_\alpha} &
-            \tnX{X_\alpha^{-1}} & \tnX{X_\alpha^{-1\dagger}}
+        \tenkzkernel
+        \begin{tenkz}[rows={wire}, cols=5, bonds=none, size=s]
+            \tn[at=(1,1), skin=ring, name=g1,
+                ports={180:virtual, 0:virtual}]{X_\alpha^{\dagger}}
+            \tn[at=(1,2), skin=ring, name=g2,
+                ports={180:virtual, 0:virtual}]{X_\alpha}
+            \tn[at=(1,3), name=m, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M_\alpha}
+            \tn[at=(1,4), skin=ring, name=g3,
+                ports={180:virtual, 0:virtual}]{X_\alpha^{-1}}
+            \tn[at=(1,5), skin=ring, name=g4,
+                ports={180:virtual, 0:virtual}]{X_\alpha^{-1\dagger}}
+            \tnwire{g1.180}{open w}
+            \tnwire{g1.0}{g2.180}
+            \tnwire{g2.0}{m.180}
+            \tnwire{m.0}{g3.180}
+            \tnwire{g3.0}{g4.180}
+            \tnwire{g4.0}{open e}
         \end{tenkz}
         $ = $
-        \begin{tenkz}[physical=updown, compact]
-            \tnX{Y_\alpha^{\dagger}} & \tnX{Y_\alpha} & \tn{M_\alpha} &
-            \tnX{Y_\alpha^{-1}} & \tnX{Y_\alpha^{-1\dagger}}
+        \begin{tenkz}[rows={wire}, cols=5, bonds=none, size=s]
+            \tn[at=(1,1), skin=ring, name=g1,
+                ports={180:virtual, 0:virtual}]{Y_\alpha^{\dagger}}
+            \tn[at=(1,2), skin=ring, name=g2,
+                ports={180:virtual, 0:virtual}]{Y_\alpha}
+            \tn[at=(1,3), name=m, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M_\alpha}
+            \tn[at=(1,4), skin=ring, name=g3,
+                ports={180:virtual, 0:virtual}]{Y_\alpha^{-1}}
+            \tn[at=(1,5), skin=ring, name=g4,
+                ports={180:virtual, 0:virtual}]{Y_\alpha^{-1\dagger}}
+            \tnwire{g1.180}{open w}
+            \tnwire{g1.0}{g2.180}
+            \tnwire{g2.0}{m.180}
+            \tnwire{m.0}{g3.180}
+            \tnwire{g3.0}{g4.180}
+            \tnwire{g4.0}{open e}
         \end{tenkz}
     \end{center}
     \caption{Equality of the Gram conjugations for two copies of the same

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -635,42 +635,16 @@
         % same boundary signature
         % (virtual-west=1 | virtual-east=1 | physical-up=1 | physical-down=1).
         \tenkzkernel
-        \begin{tenkz}[rows={wire}, cols=5, bonds=none, size=s]
-            \tn[at=(1,1), skin=ring, name=g1,
-                ports={180:virtual, 0:virtual}]{X_\alpha^{\dagger}}
-            \tn[at=(1,2), skin=ring, name=g2,
-                ports={180:virtual, 0:virtual}]{X_\alpha}
-            \tn[at=(1,3), name=m, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M_\alpha}
-            \tn[at=(1,4), skin=ring, name=g3,
-                ports={180:virtual, 0:virtual}]{X_\alpha^{-1}}
-            \tn[at=(1,5), skin=ring, name=g4,
-                ports={180:virtual, 0:virtual}]{X_\alpha^{-1\dagger}}
-            \tnwire{g1.180}{open w}
-            \tnwire{g1.0}{g2.180}
-            \tnwire{g2.0}{m.180}
-            \tnwire{m.0}{g3.180}
-            \tnwire{g3.0}{g4.180}
-            \tnwire{g4.0}{open e}
+        \begin{tenkz}[rows={wire}, cols=5, west=open, east=open, size=s]
+            \tn[skin=ring]{X_\alpha^{\dagger}} & \tn[skin=ring]{X_\alpha} &
+            \tn[label pos=s, ports={90:physical, 270:physical}]{M_\alpha} &
+            \tn[skin=ring]{X_\alpha^{-1}} & \tn[skin=ring]{X_\alpha^{-1\dagger}}
         \end{tenkz}
         $ = $
-        \begin{tenkz}[rows={wire}, cols=5, bonds=none, size=s]
-            \tn[at=(1,1), skin=ring, name=g1,
-                ports={180:virtual, 0:virtual}]{Y_\alpha^{\dagger}}
-            \tn[at=(1,2), skin=ring, name=g2,
-                ports={180:virtual, 0:virtual}]{Y_\alpha}
-            \tn[at=(1,3), name=m, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M_\alpha}
-            \tn[at=(1,4), skin=ring, name=g3,
-                ports={180:virtual, 0:virtual}]{Y_\alpha^{-1}}
-            \tn[at=(1,5), skin=ring, name=g4,
-                ports={180:virtual, 0:virtual}]{Y_\alpha^{-1\dagger}}
-            \tnwire{g1.180}{open w}
-            \tnwire{g1.0}{g2.180}
-            \tnwire{g2.0}{m.180}
-            \tnwire{m.0}{g3.180}
-            \tnwire{g3.0}{g4.180}
-            \tnwire{g4.0}{open e}
+        \begin{tenkz}[rows={wire}, cols=5, west=open, east=open, size=s]
+            \tn[skin=ring]{Y_\alpha^{\dagger}} & \tn[skin=ring]{Y_\alpha} &
+            \tn[label pos=s, ports={90:physical, 270:physical}]{M_\alpha} &
+            \tn[skin=ring]{Y_\alpha^{-1}} & \tn[skin=ring]{Y_\alpha^{-1\dagger}}
         \end{tenkz}
     \end{center}
     \caption{Equality of the Gram conjugations for two copies of the same

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -76,16 +76,9 @@ The two closure maps have the same local form:
     % Paired signature (formula and network):
     % boundary|virtual-west=0|virtual-east=0|physical-up=1|physical-down=1.
     $M_\alpha(X)=$
-    \begin{tenkz}[rows={wire,wire}, cols=4, bonds=none, align=1]
-        \tn[at=(1,2), skin=box, name=x, ports={180:virtual, 0:virtual}]{X}
-        \tn[at=(1,3), skin=mpo, name=m,
-            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M_\alpha}
-        \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
-        \tn[at=(2,4), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
-        \tnwire{x.0}{m.180}
-        \tnwire[route=arc]{m.0}{je.90}
-        \tnwire{je.180}{jw.0}
-        \tnwire[route=arc]{jw.90}{x.180}
+    \begin{tenkz}[rows={wire}, cols=2, boundary=periodic]
+        \tn[skin=box]{X} &
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{M_\alpha}
     \end{tenkz}
     \qquad
     % Formula: A_\alpha(X)_{ij}
@@ -99,16 +92,9 @@ The two closure maps have the same local form:
     % Paired signature (formula and network):
     % boundary|virtual-west=0|virtual-east=0|physical-up=1|physical-down=1.
     $A_\alpha(X)=$
-    \begin{tenkz}[rows={wire,wire}, cols=4, bonds=none, align=1]
-        \tn[at=(1,2), skin=box, name=x, ports={180:virtual, 0:virtual}]{X}
-        \tn[at=(1,3), skin=mpo, name=m,
-            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{A_\alpha}
-        \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
-        \tn[at=(2,4), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
-        \tnwire{x.0}{m.180}
-        \tnwire[route=arc]{m.0}{je.90}
-        \tnwire{je.180}{jw.0}
-        \tnwire[route=arc]{jw.90}{x.180}
+    \begin{tenkz}[rows={wire}, cols=2, boundary=periodic]
+        \tn[skin=box]{X} &
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{A_\alpha}
     \end{tenkz}
 \end{center}
 In each cell, $X$ is inserted on the virtual bond and the virtual indices are

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -64,6 +64,7 @@
 
 The two closure maps have the same local form:
 \begin{center}
+    \tenkzkernel
     % Formula: M_\alpha(X)_{ij}
     % = \sum_{a,b}(M_\alpha^{ij})_{ab}X_{ba}
     % = \tr(M_\alpha^{ij}X).
@@ -75,8 +76,16 @@ The two closure maps have the same local form:
     % Paired signature (formula and network):
     % boundary|virtual-west=0|virtual-east=0|physical-up=1|physical-down=1.
     $M_\alpha(X)=$
-    \begin{tenkz}[periodic, physical=updown, tensor style=box]
-        \tn[box, no legs]{X} & \tn[mpo]{M_\alpha}
+    \begin{tenkz}[rows={wire,wire}, cols=4, bonds=none, align=1]
+        \tn[at=(1,2), skin=box, name=x, ports={180:virtual, 0:virtual}]{X}
+        \tn[at=(1,3), skin=mpo, name=m,
+            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M_\alpha}
+        \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
+        \tn[at=(2,4), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
+        \tnwire{x.0}{m.180}
+        \tnwire[route=arc]{m.0}{je.90}
+        \tnwire{je.180}{jw.0}
+        \tnwire[route=arc]{jw.90}{x.180}
     \end{tenkz}
     \qquad
     % Formula: A_\alpha(X)_{ij}
@@ -90,8 +99,16 @@ The two closure maps have the same local form:
     % Paired signature (formula and network):
     % boundary|virtual-west=0|virtual-east=0|physical-up=1|physical-down=1.
     $A_\alpha(X)=$
-    \begin{tenkz}[periodic, physical=updown, tensor style=box]
-        \tn[box, no legs]{X} & \tn[mpo]{A_\alpha}
+    \begin{tenkz}[rows={wire,wire}, cols=4, bonds=none, align=1]
+        \tn[at=(1,2), skin=box, name=x, ports={180:virtual, 0:virtual}]{X}
+        \tn[at=(1,3), skin=mpo, name=m,
+            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{A_\alpha}
+        \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
+        \tn[at=(2,4), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
+        \tnwire{x.0}{m.180}
+        \tnwire[route=arc]{m.0}{je.90}
+        \tnwire{je.180}{jw.0}
+        \tnwire[route=arc]{jw.90}{x.180}
     \end{tenkz}
 \end{center}
 In each cell, $X$ is inserted on the virtual bond and the virtual indices are

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -15,12 +15,26 @@ The two-site block is the virtual contraction of two copies of $K$:
 % Source verdict: exact house-style reproduction of MPDO_K=MM.png from
 % Theorem 4.9, lines 851--856.  The source has no blocking enclosure.
 \begin{tenkzequation}
-    \tnpic[physical=updown, tensor style=box]{%
-        \tn[mpo, up={$(i_1,i_2)$}, down={$(j_1,j_2)$}]{M}}
+    \tenkzkernel
+    \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+        \tn[at=(1,1), skin=mpo, name=m,
+            ports={180:virtual, 0:virtual,
+                   90:physical:{$(i_1,i_2)$}, 270:physical:{$(j_1,j_2)$}}]{M}
+        \tnwire{m.180}{open w}
+        \tnwire{m.0}{open e}
+    \end{tenkz}
     \qquad$=$\qquad
-    \tnpic[physical=updown, tensor style=box]{%
-        \tn[mpo, up=$i_1$, down=$j_1$]{K} &
-        \tn[mpo, up=$i_2$, down=$j_2$]{K}}
+    \begin{tenkz}[rows={wire}, cols=2, bonds=none]
+        \tn[at=(1,1), skin=mpo, name=k1,
+            ports={180:virtual, 0:virtual, 90:physical:$i_1$,
+                   270:physical:$j_1$}]{K}
+        \tn[at=(1,2), skin=mpo, name=k2,
+            ports={180:virtual, 0:virtual, 90:physical:$i_2$,
+                   270:physical:$j_2$}]{K}
+        \tnwire{k1.180}{open w}
+        \tnwire{k1.0}{k2.180}
+        \tnwire{k2.0}{open e}
+    \end{tenkz}
 \end{tenkzequation}
 The two ket indices and the two bra indices are grouped into the blocked
 physical indices, as in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -16,24 +16,14 @@ The two-site block is the virtual contraction of two copies of $K$:
 % Theorem 4.9, lines 851--856.  The source has no blocking enclosure.
 \begin{tenkzequation}
     \tenkzkernel
-    \begin{tenkz}[rows={wire}, cols=1, bonds=none]
-        \tn[at=(1,1), skin=mpo, name=m,
-            ports={180:virtual, 0:virtual,
-                   90:physical:{$(i_1,i_2)$}, 270:physical:{$(j_1,j_2)$}}]{M}
-        \tnwire{m.180}{open w}
-        \tnwire{m.0}{open e}
+    \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+        \tn[skin=mpo, ports={90:physical:{$(i_1,i_2)$},
+            270:physical:{$(j_1,j_2)$}}]{M}
     \end{tenkz}
     \qquad$=$\qquad
-    \begin{tenkz}[rows={wire}, cols=2, bonds=none]
-        \tn[at=(1,1), skin=mpo, name=k1,
-            ports={180:virtual, 0:virtual, 90:physical:$i_1$,
-                   270:physical:$j_1$}]{K}
-        \tn[at=(1,2), skin=mpo, name=k2,
-            ports={180:virtual, 0:virtual, 90:physical:$i_2$,
-                   270:physical:$j_2$}]{K}
-        \tnwire{k1.180}{open w}
-        \tnwire{k1.0}{k2.180}
-        \tnwire{k2.0}{open e}
+    \begin{tenkz}[rows={wire}, cols=2, west=open, east=open]
+        \tn[skin=mpo, ports={90:physical:$i_1$, 270:physical:$j_1$}]{K} &
+        \tn[skin=mpo, ports={90:physical:$i_2$, 270:physical:$j_2$}]{K}
     \end{tenkz}
 \end{tenkzequation}
 The two ket indices and the two bra indices are grouped into the blocked

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -83,12 +83,22 @@
     % the product T_M T_M.  Traced physical legs are closed indices,
     % so both sides carry the same boundary signature
     % (virtual-west=1 | virtual-east=1 | physical-up=0 | physical-down=0).
-    \begin{tenkz}[physical=updown, trace=physical]
-        \tn[mpo]{M}
+    \tenkzkernel
+    \begin{tenkz}[rows={wire}, cols=1, bonds=none, trace=physical]
+        \tn[at=(1,1), skin=mpo, name=m1,
+            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M}
+        \tnwire{m1.180}{open w}
+        \tnwire{m1.0}{open e}
     \end{tenkz}
     $ = $
-    \begin{tenkz}[physical=updown, trace=physical]
-        \tn[mpo]{M} & \tn[mpo]{M}
+    \begin{tenkz}[rows={wire}, cols=2, bonds=none, trace=physical]
+        \tn[at=(1,1), skin=mpo, name=m1,
+            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M}
+        \tn[at=(1,2), skin=mpo, name=m2,
+            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M}
+        \tnwire{m1.180}{open w}
+        \tnwire{m1.0}{m2.180}
+        \tnwire{m2.0}{open e}
     \end{tenkz}
 \end{center}
 This is the literal identity in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -84,21 +84,14 @@
     % so both sides carry the same boundary signature
     % (virtual-west=1 | virtual-east=1 | physical-up=0 | physical-down=0).
     \tenkzkernel
-    \begin{tenkz}[rows={wire}, cols=1, bonds=none, trace=physical]
-        \tn[at=(1,1), skin=mpo, name=m1,
-            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M}
-        \tnwire{m1.180}{open w}
-        \tnwire{m1.0}{open e}
+    \begin{tenkz}[rows={wire}, cols=1, west=open, east=open, trace=physical,
+        physical=updown]
+        \tn[skin=mpo]{M}
     \end{tenkz}
     $ = $
-    \begin{tenkz}[rows={wire}, cols=2, bonds=none, trace=physical]
-        \tn[at=(1,1), skin=mpo, name=m1,
-            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M}
-        \tn[at=(1,2), skin=mpo, name=m2,
-            ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M}
-        \tnwire{m1.180}{open w}
-        \tnwire{m1.0}{m2.180}
-        \tnwire{m2.0}{open e}
+    \begin{tenkz}[rows={wire}, cols=2, west=open, east=open, trace=physical,
+        physical=updown]
+        \tn[skin=mpo]{M} & \tn[skin=mpo]{M}
     \end{tenkz}
 \end{center}
 This is the literal identity in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex
@@ -278,14 +278,20 @@ $\eta_{k,h}=r_k l_h$:
     % further horizontal index.  Both sides carry the same boundary
     % signature
     % (virtual-west=0 | virtual-east=0 | physical-up=2 | physical-down=2).
-    \begin{tenkz}[physical=updown, boundary=none]
-        \tn[pill, wide=2, legs at={1,2},
-            up={{$x_R$},{$x_L$}}, down={{$y_R$},{$y_L$}}]{\eta_{k,h}}
+    \tenkzkernel
+    \begin{tenkz}[rows={wire}, cols=2, bonds=none, west=none, east=none]
+        \tn[at=(1,1), skin=pill, wide=2, name=eta,
+            ports={90@1:physical:$x_R$, 90@2:physical:$x_L$,
+                   270@1:physical:$y_R$, 270@2:physical:$y_L$}]{\eta_{k,h}}
     \end{tenkz}
     $ = $
-    \begin{tenkz}[physical=updown, boundary=none,
-                  bond label={$a$ at 1-2}]
-        \tn[up=$x_R$, down=$y_R$]{r_k} & \tn[up=$x_L$, down=$y_L$]{l_h}
+    \begin{tenkz}[rows={wire}, cols=2, bonds=none, west=none, east=none]
+        \tn[at=(1,1), name=rk, label pos=w,
+            ports={0:virtual, 90:physical:$x_R$, 270:physical:$y_R$}]{r_k}
+        \tn[at=(1,2), name=lh, label pos=e,
+            ports={180:virtual, 90:physical:$x_L$, 270:physical:$y_L$}]{l_h}
+        \tnwire[name=ab]{rk.0}{lh.180}
+        \tnmark[form=label, label pos=n]{on ab 0.5}{$a$}
     \end{tenkz}
 \end{center}
 This is the contraction in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex
@@ -279,19 +279,16 @@ $\eta_{k,h}=r_k l_h$:
     % signature
     % (virtual-west=0 | virtual-east=0 | physical-up=2 | physical-down=2).
     \tenkzkernel
-    \begin{tenkz}[rows={wire}, cols=2, bonds=none, west=none, east=none]
-        \tn[at=(1,1), skin=pill, wide=2, name=eta,
+    \begin{tenkz}[rows={wire}, cols=2, west=none, east=none]
+        \tn[skin=pill, wide=2,
             ports={90@1:physical:$x_R$, 90@2:physical:$x_L$,
                    270@1:physical:$y_R$, 270@2:physical:$y_L$}]{\eta_{k,h}}
     \end{tenkz}
     $ = $
-    \begin{tenkz}[rows={wire}, cols=2, bonds=none, west=none, east=none]
-        \tn[at=(1,1), name=rk, label pos=w,
-            ports={0:virtual, 90:physical:$x_R$, 270:physical:$y_R$}]{r_k}
-        \tn[at=(1,2), name=lh, label pos=e,
-            ports={180:virtual, 90:physical:$x_L$, 270:physical:$y_L$}]{l_h}
-        \tnwire[name=ab]{rk.0}{lh.180}
-        \tnmark[form=label, label pos=n]{on ab 0.5}{$a$}
+    \begin{tenkz}[rows={wire}, cols=2, west=none, east=none]
+        \tn[label pos=w, ports={90:physical:$x_R$, 270:physical:$y_R$}]{r_k} &
+        \tn[label pos=e, ports={90:physical:$x_L$, 270:physical:$y_L$}]{l_h}
+        \tnmark[form=label, label pos=n]{midway (1,1) and (1,2)}{$a$}
     \end{tenkz}
 \end{center}
 This is the contraction in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -186,18 +186,11 @@
         % the right-hand side 0 is the zero element of the same matrix space,
         % written as plain text since it carries no ink of its own.
         \tenkzkernel
-        \begin{tenkz}[rows={op,op,op}, cols=1, bonds=none]
-            \tn[at=(1,1), skin=mpo, name=p1,
-                ports={90:physical, 270:physical}]{P_j}
-            \tn[at=(2,1), skin=mpo, name=k,
-                ports={180:virtual, 0:virtual,
-                       90:physical, 270:physical}]{\noexpand\mathcal K_i}
-            \tn[at=(3,1), skin=mpo, name=p2,
-                ports={90:physical, 270:physical}]{P_{j^\prime}}
-            \tnwire{p1.270}{k.90}
-            \tnwire{k.270}{p2.90}
-            \tnwire{k.180}{open w}
-            \tnwire{k.0}{open e}
+        \begin{tenkz}[rows={op,op,op}, cols=1, physical=updown]
+            \tn[skin=mpo]{P_j} \\
+            \tn[skin=mpo,
+                ports={180:virtual, 0:virtual}]{\noexpand\mathcal K_i} \\
+            \tn[skin=mpo]{P_{j^\prime}}
         \end{tenkz}
         $ = 0\quad\text{unless }i=j=j^\prime$
     \end{center}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -185,10 +185,19 @@
         % (virtual-west=1 | virtual-east=1 | physical-up=1 | physical-down=1);
         % the right-hand side 0 is the zero element of the same matrix space,
         % written as plain text since it carries no ink of its own.
-        \begin{tenkz}[rows={op:none, op, op:none}]
-            \tn[mpo]{P_j} \\
-            \tn[mpo]{\mathcal K_i} \\
-            \tn[mpo]{P_{j^\prime}}
+        \tenkzkernel
+        \begin{tenkz}[rows={op,op,op}, cols=1, bonds=none]
+            \tn[at=(1,1), skin=mpo, name=p1,
+                ports={90:physical, 270:physical}]{P_j}
+            \tn[at=(2,1), skin=mpo, name=k,
+                ports={180:virtual, 0:virtual,
+                       90:physical, 270:physical}]{\noexpand\mathcal K_i}
+            \tn[at=(3,1), skin=mpo, name=p2,
+                ports={90:physical, 270:physical}]{P_{j^\prime}}
+            \tnwire{p1.270}{k.90}
+            \tnwire{k.270}{p2.90}
+            \tnwire{k.180}{open w}
+            \tnwire{k.0}{open e}
         \end{tenkz}
         $ = 0\quad\text{unless }i=j=j^\prime$
     \end{center}

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex
@@ -49,13 +49,42 @@
     % Boundary signature: both panels have (V,P)=(0,3).  Source verdict: exact
     % reproduction of paper_normal.tex:255--274 and 565--580 in house style.
     \begin{center}
-        \tnpic[periodic, physical=up]{%
-            \tn[up=$\sigma_1$]{A_1} & \tnX{X} &
-            \tn[up=$\sigma_2$]{A_2} & \tn[up=$\sigma_3$]{A_3}}
+        \tenkzkernel
+        \begin{tenkz}[rows={wire,wire}, cols=6, bonds=none, align=1]
+            \tn[at=(1,2), name=a1, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$\sigma_1$}]{A_1}
+            \tn[at=(1,3), skin=ring, name=x, ports={180:virtual, 0:virtual}]{X}
+            \tn[at=(1,4), name=a2, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$\sigma_2$}]{A_2}
+            \tn[at=(1,5), name=a3, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$\sigma_3$}]{A_3}
+            \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
+            \tn[at=(2,6), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
+            \tnwire{a1.0}{x.180}
+            \tnwire{x.0}{a2.180}
+            \tnwire{a2.0}{a3.180}
+            \tnwire[route=arc]{a3.0}{je.90}
+            \tnwire{je.180}{jw.0}
+            \tnwire[route=arc]{jw.90}{a1.180}
+        \end{tenkz}
         $=$
-        \tnpic[periodic, physical=up]{%
-            \tn[up=$\sigma_1$]{B_1} & \tnX{Y} &
-            \tn[up=$\sigma_2$]{B_2} & \tn[up=$\sigma_3$]{B_3}}
+        \begin{tenkz}[rows={wire,wire}, cols=6, bonds=none, align=1]
+            \tn[at=(1,2), name=b1, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$\sigma_1$}]{B_1}
+            \tn[at=(1,3), skin=ring, name=y, ports={180:virtual, 0:virtual}]{Y}
+            \tn[at=(1,4), name=b2, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$\sigma_2$}]{B_2}
+            \tn[at=(1,5), name=b3, label pos=s,
+                ports={180:virtual, 0:virtual, 90:physical:$\sigma_3$}]{B_3}
+            \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
+            \tn[at=(2,6), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
+            \tnwire{b1.0}{y.180}
+            \tnwire{y.0}{b2.180}
+            \tnwire{b2.0}{b3.180}
+            \tnwire[route=arc]{b3.0}{je.90}
+            \tnwire{je.180}{jw.0}
+            \tnwire[route=arc]{jw.90}{b1.180}
+        \end{tenkz}
     \end{center}
 \end{theorem}
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex
@@ -50,40 +50,18 @@
     % reproduction of paper_normal.tex:255--274 and 565--580 in house style.
     \begin{center}
         \tenkzkernel
-        \begin{tenkz}[rows={wire,wire}, cols=6, bonds=none, align=1]
-            \tn[at=(1,2), name=a1, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$\sigma_1$}]{A_1}
-            \tn[at=(1,3), skin=ring, name=x, ports={180:virtual, 0:virtual}]{X}
-            \tn[at=(1,4), name=a2, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$\sigma_2$}]{A_2}
-            \tn[at=(1,5), name=a3, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$\sigma_3$}]{A_3}
-            \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
-            \tn[at=(2,6), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
-            \tnwire{a1.0}{x.180}
-            \tnwire{x.0}{a2.180}
-            \tnwire{a2.0}{a3.180}
-            \tnwire[route=arc]{a3.0}{je.90}
-            \tnwire{je.180}{jw.0}
-            \tnwire[route=arc]{jw.90}{a1.180}
+        \begin{tenkz}[rows={wire}, cols=4, boundary=periodic]
+            \tn[label pos=s, ports={90:physical:$\sigma_1$}]{A_1} &
+            \tn[skin=ring]{X} &
+            \tn[label pos=s, ports={90:physical:$\sigma_2$}]{A_2} &
+            \tn[label pos=s, ports={90:physical:$\sigma_3$}]{A_3}
         \end{tenkz}
         $=$
-        \begin{tenkz}[rows={wire,wire}, cols=6, bonds=none, align=1]
-            \tn[at=(1,2), name=b1, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$\sigma_1$}]{B_1}
-            \tn[at=(1,3), skin=ring, name=y, ports={180:virtual, 0:virtual}]{Y}
-            \tn[at=(1,4), name=b2, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$\sigma_2$}]{B_2}
-            \tn[at=(1,5), name=b3, label pos=s,
-                ports={180:virtual, 0:virtual, 90:physical:$\sigma_3$}]{B_3}
-            \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
-            \tn[at=(2,6), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
-            \tnwire{b1.0}{y.180}
-            \tnwire{y.0}{b2.180}
-            \tnwire{b2.0}{b3.180}
-            \tnwire[route=arc]{b3.0}{je.90}
-            \tnwire{je.180}{jw.0}
-            \tnwire[route=arc]{jw.90}{b1.180}
+        \begin{tenkz}[rows={wire}, cols=4, boundary=periodic]
+            \tn[label pos=s, ports={90:physical:$\sigma_1$}]{B_1} &
+            \tn[skin=ring]{Y} &
+            \tn[label pos=s, ports={90:physical:$\sigma_2$}]{B_2} &
+            \tn[label pos=s, ports={90:physical:$\sigma_3$}]{B_3}
         \end{tenkz}
     \end{center}
 \end{theorem}

--- a/docs/slides/presentation20260207.tex
+++ b/docs/slides/presentation20260207.tex
@@ -55,9 +55,26 @@ B^i = X A^i X^{-1}
 % Boundary: the emitted four-site schematic has (virtual, physical) = (0, 4);
 % the symbolic N-site word has (0, N), with no virtual index open.
 % Source: arXiv:1606.00608, Fig. I and lines 135--170.
-\begin{tenkz}[compact, periodic, physical=up]
-  \tn[up=$i_1$]{A} & \tn[up=$i_2$]{A} & \tndots &
-  \tn[up=$i_{N-1}$]{A} & \tn[up=$i_N$]{A}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=7, bonds=none, align=1, size=s]
+  \tn[at=(1,2), name=a1, label pos=s,
+      ports={180:virtual, 0:virtual, 90:physical:$i_1$}]{A}
+  \tn[at=(1,3), name=a2, label pos=s,
+      ports={180:virtual, 0:virtual, 90:physical:$i_2$}]{A}
+  \tn[at=(1,4), skin=dots, name=d, ports={180:virtual, 0:virtual}]{}
+  \tn[at=(1,5), name=a3, label pos=s,
+      ports={180:virtual, 0:virtual, 90:physical:$i_{N-1}$}]{A}
+  \tn[at=(1,6), name=a4, label pos=s,
+      ports={180:virtual, 0:virtual, 90:physical:$i_N$}]{A}
+  \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
+  \tn[at=(2,7), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
+  \tnwire{a1.0}{a2.180}
+  \tnwire{a2.0}{d.180}
+  \tnwire{d.0}{a3.180}
+  \tnwire{a3.0}{a4.180}
+  \tnwire[route=arc]{a4.0}{je.90}
+  \tnwire{je.180}{jw.0}
+  \tnwire[route=arc]{jw.90}{a1.180}
 \end{tenkz}
 
 \vspace{1.5em}

--- a/docs/slides/presentation20260207.tex
+++ b/docs/slides/presentation20260207.tex
@@ -26,7 +26,7 @@
 \end{center}
 \end{frame}
 
-\begin{frame}{The Challenge}
+\begin{frame}[fragile]{The Challenge}
 \textbf{\LARGE When do $A$ and $B$ describe the same quantum physics?}
 
 \vspace{0.5em}
@@ -56,25 +56,11 @@ B^i = X A^i X^{-1}
 % the symbolic N-site word has (0, N), with no virtual index open.
 % Source: arXiv:1606.00608, Fig. I and lines 135--170.
 \tenkzkernel
-\begin{tenkz}[rows={wire,wire}, cols=7, bonds=none, align=1, size=s]
-  \tn[at=(1,2), name=a1, label pos=s,
-      ports={180:virtual, 0:virtual, 90:physical:$i_1$}]{A}
-  \tn[at=(1,3), name=a2, label pos=s,
-      ports={180:virtual, 0:virtual, 90:physical:$i_2$}]{A}
-  \tn[at=(1,4), skin=dots, name=d, ports={180:virtual, 0:virtual}]{}
-  \tn[at=(1,5), name=a3, label pos=s,
-      ports={180:virtual, 0:virtual, 90:physical:$i_{N-1}$}]{A}
-  \tn[at=(1,6), name=a4, label pos=s,
-      ports={180:virtual, 0:virtual, 90:physical:$i_N$}]{A}
-  \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
-  \tn[at=(2,7), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
-  \tnwire{a1.0}{a2.180}
-  \tnwire{a2.0}{d.180}
-  \tnwire{d.0}{a3.180}
-  \tnwire{a3.0}{a4.180}
-  \tnwire[route=arc]{a4.0}{je.90}
-  \tnwire{je.180}{jw.0}
-  \tnwire[route=arc]{jw.90}{a1.180}
+\begin{tenkz}[rows={wire}, cols=5, boundary=periodic, size=s]
+  \tn[label pos=s, ports={90:physical:$i_1$}]{A} &
+  \tn[label pos=s, ports={90:physical:$i_2$}]{A} & \tn[skin=dots]{} &
+  \tn[label pos=s, ports={90:physical:$i_{N-1}$}]{A} &
+  \tn[label pos=s, ports={90:physical:$i_N$}]{A}
 \end{tenkz}
 
 \vspace{1.5em}

--- a/docs/slides/presentation20260207.tnlog
+++ b/docs/slides/presentation20260207.tnlog
@@ -1,46 +1,42 @@
 picture|id=k1|lang=kernel
-atom|id=atom-1|kind=tn|label-pos=s|label=A|name=a1|node=addr-1|ports=180:virtual, 0:virtual, 90:physical:$i_1$
-atom|id=atom-2|kind=tn|label-pos=s|label=A|name=a2|node=addr-2|ports=180:virtual, 0:virtual, 90:physical:$i_2$
-atom|id=atom-3|kind=tn|name=d|node=addr-3|ports=180:virtual, 0:virtual|skin=dots
-atom|id=atom-4|kind=tn|label-pos=s|label=A|name=a3|node=addr-4|ports=180:virtual, 0:virtual, 90:physical:$i_{N-1}$
-atom|id=atom-5|kind=tn|label-pos=s|label=A|name=a4|node=addr-5|ports=180:virtual, 0:virtual, 90:physical:$i_N$
-atom|id=atom-6|kind=tn|name=jw|node=addr-6|ports=0:virtual, 90:virtual|skin=none
-atom|id=atom-7|kind=tn|name=je|node=addr-7|ports=90:virtual, 180:virtual|skin=none
-wire|id=wire-8|from=addr-8|kind=index|to=addr-9
-wire|id=wire-9|from=addr-10|kind=index|to=addr-11
-wire|id=wire-10|from=addr-12|kind=index|to=addr-13
-wire|id=wire-11|from=addr-14|kind=index|to=addr-15
-wire|id=wire-12|from=addr-16|kind=index|route=arc|to=addr-17
-wire|id=wire-13|from=addr-18|kind=index|to=addr-19
-wire|id=wire-14|from=addr-20|kind=index|route=arc|to=addr-21
-wire|id=wire-15|from=addr-22|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
-wire|id=wire-16|from=addr-23|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
-wire|id=wire-17|from=addr-24|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
-wire|id=wire-18|from=addr-25|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+atom|id=atom-1|addr=(1,1)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_1$
+atom|id=atom-2|addr=(1,2)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_2$
+atom|id=atom-3|addr=(1,3)|kind=tn|skin=dots
+atom|id=atom-4|addr=(1,4)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_{N-1}$
+atom|id=atom-5|addr=(1,5)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_N$
+wire|id=wire-6|from=addr-1|kind=index|name=bond-1-1-1-2|origin=grid|to=addr-2
+wire|id=wire-7|from=addr-3|kind=index|name=bond-1-2-1-3|origin=grid|to=addr-4
+wire|id=wire-8|from=addr-5|kind=index|name=bond-1-3-1-4|origin=grid|to=addr-6
+wire|id=wire-9|from=addr-7|kind=index|name=bond-1-4-1-5|origin=grid|to=addr-8
+wire|id=wire-10|from=addr-9|kind=index|name=wrap-1|origin=trace|row=1|side=west-east|to=addr-10
+wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
+wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
+wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
+wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
 kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
 ink-use|picture=k1|class=glyph|id=1|shape=circle
-glyph-geometry|picture=k1|owner=1|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=1|shape=circle|xmin=-182117|xmax=182117|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=1|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=1|owner=0|xmin=-162398|xmax=162398|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=2|shape=circle
-glyph-geometry|picture=k1|owner=2|shape=circle|xmin=3920177|xmax=4284411|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=2|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=2|owner=0|xmin=3939896|xmax=4264692|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=2|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=3|owner=0|xmin=5470411|xmax=6836471|ymin=-391762|ymax=391762|shape=rect|radius=0
+bbox|picture=k1|class=label|id=3|owner=0|xmin=3419264|xmax=4785324|ymin=-391762|ymax=391762|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=3|shape=circle
-glyph-geometry|picture=k1|owner=3|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=3|shape=circle|xmin=5971324|xmax=6335558|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=4|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=4|owner=0|xmin=5991043|xmax=6315839|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=4|shape=circle
-glyph-geometry|picture=k1|owner=4|shape=circle|xmin=10073618|xmax=10437852|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=4|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=5|owner=0|xmin=10093337|xmax=10418133|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=5|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=6|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=6|owner=0|xmin=-216498|xmax=216498|ymin=1038670|ymax=1566234|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=7|owner=0|xmin=3885796|xmax=4318792|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=7|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=8|owner=0|xmin=7611258|xmax=8797919|ymin=1038670|ymax=1620848|shape=rect|radius=0
+bbox|picture=k1|class=label|id=8|owner=0|xmin=5560111|xmax=6746772|ymin=1038670|ymax=1620848|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=9|owner=0|xmin=9989004|xmax=10522467|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=9|owner=0|xmin=7937857|xmax=8471320|ymin=1038670|ymax=1566234|shape=rect|radius=0

--- a/docs/slides/presentation20260207.tnlog
+++ b/docs/slides/presentation20260207.tnlog
@@ -1,0 +1,46 @@
+picture|id=k1|lang=kernel
+atom|id=atom-1|kind=tn|label-pos=s|label=A|name=a1|node=addr-1|ports=180:virtual, 0:virtual, 90:physical:$i_1$
+atom|id=atom-2|kind=tn|label-pos=s|label=A|name=a2|node=addr-2|ports=180:virtual, 0:virtual, 90:physical:$i_2$
+atom|id=atom-3|kind=tn|name=d|node=addr-3|ports=180:virtual, 0:virtual|skin=dots
+atom|id=atom-4|kind=tn|label-pos=s|label=A|name=a3|node=addr-4|ports=180:virtual, 0:virtual, 90:physical:$i_{N-1}$
+atom|id=atom-5|kind=tn|label-pos=s|label=A|name=a4|node=addr-5|ports=180:virtual, 0:virtual, 90:physical:$i_N$
+atom|id=atom-6|kind=tn|name=jw|node=addr-6|ports=0:virtual, 90:virtual|skin=none
+atom|id=atom-7|kind=tn|name=je|node=addr-7|ports=90:virtual, 180:virtual|skin=none
+wire|id=wire-8|from=addr-8|kind=index|to=addr-9
+wire|id=wire-9|from=addr-10|kind=index|to=addr-11
+wire|id=wire-10|from=addr-12|kind=index|to=addr-13
+wire|id=wire-11|from=addr-14|kind=index|to=addr-15
+wire|id=wire-12|from=addr-16|kind=index|route=arc|to=addr-17
+wire|id=wire-13|from=addr-18|kind=index|to=addr-19
+wire|id=wire-14|from=addr-20|kind=index|route=arc|to=addr-21
+wire|id=wire-15|from=addr-22|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
+wire|id=wire-16|from=addr-23|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
+wire|id=wire-17|from=addr-24|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
+wire|id=wire-18|from=addr-25|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
+ink-use|picture=k1|class=glyph|id=1|shape=circle
+glyph-geometry|picture=k1|owner=1|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=1|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=2|shape=circle
+glyph-geometry|picture=k1|owner=2|shape=circle|xmin=3920177|xmax=4284411|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=2|owner=0|xmin=3939896|xmax=4264692|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=3|owner=0|xmin=5470411|xmax=6836471|ymin=-391762|ymax=391762|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=3|shape=circle
+glyph-geometry|picture=k1|owner=3|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=4|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=4|shape=circle
+glyph-geometry|picture=k1|owner=4|shape=circle|xmin=10073618|xmax=10437852|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=5|owner=0|xmin=10093337|xmax=10418133|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=6|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=7|owner=0|xmin=3885796|xmax=4318792|ymin=1038670|ymax=1566234|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=8|owner=0|xmin=7611258|xmax=8797919|ymin=1038670|ymax=1620848|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=9|owner=0|xmin=9989004|xmax=10522467|ymin=1038670|ymax=1566234|shape=rect|radius=0

--- a/docs/slides/presentation20260222_technical.tex
+++ b/docs/slides/presentation20260222_technical.tex
@@ -66,7 +66,7 @@
 \section{Background: Matrix Product States}
 %======================================================================
 
-\begin{frame}{Matrix Product Vectors (MPV)}
+\begin{frame}[fragile]{Matrix Product Vectors (MPV)}
     \begin{columns}[T]
         \column{0.55\textwidth}
         \textbf{Definition:}
@@ -94,25 +94,12 @@
             % the symbolic N-site word has (0, N), with no virtual index open.
             % Source: arXiv:1606.00608, Fig. I and lines 135--170.
             \tenkzkernel
-            \begin{tenkz}[rows={wire,wire}, cols=7, bonds=none, align=1, size=s]
-              \tn[at=(1,2), name=a1, label pos=s,
-                  ports={180:virtual, 0:virtual, 90:physical:$i_1$}]{A}
-              \tn[at=(1,3), name=a2, label pos=s,
-                  ports={180:virtual, 0:virtual, 90:physical:$i_2$}]{A}
-              \tn[at=(1,4), skin=dots, name=d, ports={180:virtual, 0:virtual}]{}
-              \tn[at=(1,5), name=a3, label pos=s,
-                  ports={180:virtual, 0:virtual, 90:physical:$i_{N-1}$}]{A}
-              \tn[at=(1,6), name=a4, label pos=s,
-                  ports={180:virtual, 0:virtual, 90:physical:$i_N$}]{A}
-              \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
-              \tn[at=(2,7), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
-              \tnwire{a1.0}{a2.180}
-              \tnwire{a2.0}{d.180}
-              \tnwire{d.0}{a3.180}
-              \tnwire{a3.0}{a4.180}
-              \tnwire[route=arc]{a4.0}{je.90}
-              \tnwire{je.180}{jw.0}
-              \tnwire[route=arc]{jw.90}{a1.180}
+            \begin{tenkz}[rows={wire}, cols=5, boundary=periodic, size=s]
+              \tn[label pos=s, ports={90:physical:$i_1$}]{A} &
+              \tn[label pos=s, ports={90:physical:$i_2$}]{A} &
+              \tn[skin=dots]{} &
+              \tn[label pos=s, ports={90:physical:$i_{N-1}$}]{A} &
+              \tn[label pos=s, ports={90:physical:$i_N$}]{A}
             \end{tenkz}
             \\ \vspace{0.5em}
             {\footnotesize Periodic Boundary Conditions (Trace)}

--- a/docs/slides/presentation20260222_technical.tex
+++ b/docs/slides/presentation20260222_technical.tex
@@ -93,9 +93,26 @@
             % Boundary: the emitted four-site schematic has (virtual, physical) = (0, 4);
             % the symbolic N-site word has (0, N), with no virtual index open.
             % Source: arXiv:1606.00608, Fig. I and lines 135--170.
-            \begin{tenkz}[compact, periodic, physical=up]
-              \tn[up=$i_1$]{A} & \tn[up=$i_2$]{A} & \tndots &
-              \tn[up=$i_{N-1}$]{A} & \tn[up=$i_N$]{A}
+            \tenkzkernel
+            \begin{tenkz}[rows={wire,wire}, cols=7, bonds=none, align=1, size=s]
+              \tn[at=(1,2), name=a1, label pos=s,
+                  ports={180:virtual, 0:virtual, 90:physical:$i_1$}]{A}
+              \tn[at=(1,3), name=a2, label pos=s,
+                  ports={180:virtual, 0:virtual, 90:physical:$i_2$}]{A}
+              \tn[at=(1,4), skin=dots, name=d, ports={180:virtual, 0:virtual}]{}
+              \tn[at=(1,5), name=a3, label pos=s,
+                  ports={180:virtual, 0:virtual, 90:physical:$i_{N-1}$}]{A}
+              \tn[at=(1,6), name=a4, label pos=s,
+                  ports={180:virtual, 0:virtual, 90:physical:$i_N$}]{A}
+              \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
+              \tn[at=(2,7), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
+              \tnwire{a1.0}{a2.180}
+              \tnwire{a2.0}{d.180}
+              \tnwire{d.0}{a3.180}
+              \tnwire{a3.0}{a4.180}
+              \tnwire[route=arc]{a4.0}{je.90}
+              \tnwire{je.180}{jw.0}
+              \tnwire[route=arc]{jw.90}{a1.180}
             \end{tenkz}
             \\ \vspace{0.5em}
             {\footnotesize Periodic Boundary Conditions (Trace)}

--- a/docs/slides/presentation20260222_technical.tnlog
+++ b/docs/slides/presentation20260222_technical.tnlog
@@ -1,46 +1,42 @@
 picture|id=k1|lang=kernel
-atom|id=atom-1|kind=tn|label-pos=s|label=A|name=a1|node=addr-1|ports=180:virtual, 0:virtual, 90:physical:$i_1$
-atom|id=atom-2|kind=tn|label-pos=s|label=A|name=a2|node=addr-2|ports=180:virtual, 0:virtual, 90:physical:$i_2$
-atom|id=atom-3|kind=tn|name=d|node=addr-3|ports=180:virtual, 0:virtual|skin=dots
-atom|id=atom-4|kind=tn|label-pos=s|label=A|name=a3|node=addr-4|ports=180:virtual, 0:virtual, 90:physical:$i_{N-1}$
-atom|id=atom-5|kind=tn|label-pos=s|label=A|name=a4|node=addr-5|ports=180:virtual, 0:virtual, 90:physical:$i_N$
-atom|id=atom-6|kind=tn|name=jw|node=addr-6|ports=0:virtual, 90:virtual|skin=none
-atom|id=atom-7|kind=tn|name=je|node=addr-7|ports=90:virtual, 180:virtual|skin=none
-wire|id=wire-8|from=addr-8|kind=index|to=addr-9
-wire|id=wire-9|from=addr-10|kind=index|to=addr-11
-wire|id=wire-10|from=addr-12|kind=index|to=addr-13
-wire|id=wire-11|from=addr-14|kind=index|to=addr-15
-wire|id=wire-12|from=addr-16|kind=index|route=arc|to=addr-17
-wire|id=wire-13|from=addr-18|kind=index|to=addr-19
-wire|id=wire-14|from=addr-20|kind=index|route=arc|to=addr-21
-wire|id=wire-15|from=addr-22|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
-wire|id=wire-16|from=addr-23|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
-wire|id=wire-17|from=addr-24|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
-wire|id=wire-18|from=addr-25|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+atom|id=atom-1|addr=(1,1)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_1$
+atom|id=atom-2|addr=(1,2)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_2$
+atom|id=atom-3|addr=(1,3)|kind=tn|skin=dots
+atom|id=atom-4|addr=(1,4)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_{N-1}$
+atom|id=atom-5|addr=(1,5)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_N$
+wire|id=wire-6|from=addr-1|kind=index|name=bond-1-1-1-2|origin=grid|to=addr-2
+wire|id=wire-7|from=addr-3|kind=index|name=bond-1-2-1-3|origin=grid|to=addr-4
+wire|id=wire-8|from=addr-5|kind=index|name=bond-1-3-1-4|origin=grid|to=addr-6
+wire|id=wire-9|from=addr-7|kind=index|name=bond-1-4-1-5|origin=grid|to=addr-8
+wire|id=wire-10|from=addr-9|kind=index|name=wrap-1|origin=trace|row=1|side=west-east|to=addr-10
+wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
+wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
+wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
+wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
 kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
 ink-use|picture=k1|class=glyph|id=1|shape=circle
-glyph-geometry|picture=k1|owner=1|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=1|shape=circle|xmin=-182117|xmax=182117|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=1|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=1|owner=0|xmin=-162398|xmax=162398|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=2|shape=circle
-glyph-geometry|picture=k1|owner=2|shape=circle|xmin=3920177|xmax=4284411|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=2|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=2|owner=0|xmin=3939896|xmax=4264692|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=2|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=3|owner=0|xmin=5470411|xmax=6836471|ymin=-391762|ymax=391762|shape=rect|radius=0
+bbox|picture=k1|class=label|id=3|owner=0|xmin=3419264|xmax=4785324|ymin=-391762|ymax=391762|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=3|shape=circle
-glyph-geometry|picture=k1|owner=3|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=3|shape=circle|xmin=5971324|xmax=6335558|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=4|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=4|owner=0|xmin=5991043|xmax=6315839|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=4|shape=circle
-glyph-geometry|picture=k1|owner=4|shape=circle|xmin=10073618|xmax=10437852|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=4|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=5|owner=0|xmin=10093337|xmax=10418133|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=5|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=6|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=6|owner=0|xmin=-216498|xmax=216498|ymin=1038670|ymax=1566234|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=7|owner=0|xmin=3885796|xmax=4318792|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=7|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=8|owner=0|xmin=7611258|xmax=8797919|ymin=1038670|ymax=1620848|shape=rect|radius=0
+bbox|picture=k1|class=label|id=8|owner=0|xmin=5560111|xmax=6746772|ymin=1038670|ymax=1620848|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=9|owner=0|xmin=9989004|xmax=10522467|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=9|owner=0|xmin=7937857|xmax=8471320|ymin=1038670|ymax=1566234|shape=rect|radius=0

--- a/docs/slides/presentation20260222_technical.tnlog
+++ b/docs/slides/presentation20260222_technical.tnlog
@@ -1,0 +1,46 @@
+picture|id=k1|lang=kernel
+atom|id=atom-1|kind=tn|label-pos=s|label=A|name=a1|node=addr-1|ports=180:virtual, 0:virtual, 90:physical:$i_1$
+atom|id=atom-2|kind=tn|label-pos=s|label=A|name=a2|node=addr-2|ports=180:virtual, 0:virtual, 90:physical:$i_2$
+atom|id=atom-3|kind=tn|name=d|node=addr-3|ports=180:virtual, 0:virtual|skin=dots
+atom|id=atom-4|kind=tn|label-pos=s|label=A|name=a3|node=addr-4|ports=180:virtual, 0:virtual, 90:physical:$i_{N-1}$
+atom|id=atom-5|kind=tn|label-pos=s|label=A|name=a4|node=addr-5|ports=180:virtual, 0:virtual, 90:physical:$i_N$
+atom|id=atom-6|kind=tn|name=jw|node=addr-6|ports=0:virtual, 90:virtual|skin=none
+atom|id=atom-7|kind=tn|name=je|node=addr-7|ports=90:virtual, 180:virtual|skin=none
+wire|id=wire-8|from=addr-8|kind=index|to=addr-9
+wire|id=wire-9|from=addr-10|kind=index|to=addr-11
+wire|id=wire-10|from=addr-12|kind=index|to=addr-13
+wire|id=wire-11|from=addr-14|kind=index|to=addr-15
+wire|id=wire-12|from=addr-16|kind=index|route=arc|to=addr-17
+wire|id=wire-13|from=addr-18|kind=index|to=addr-19
+wire|id=wire-14|from=addr-20|kind=index|route=arc|to=addr-21
+wire|id=wire-15|from=addr-22|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
+wire|id=wire-16|from=addr-23|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
+wire|id=wire-17|from=addr-24|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
+wire|id=wire-18|from=addr-25|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
+ink-use|picture=k1|class=glyph|id=1|shape=circle
+glyph-geometry|picture=k1|owner=1|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=1|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=2|shape=circle
+glyph-geometry|picture=k1|owner=2|shape=circle|xmin=3920177|xmax=4284411|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=2|owner=0|xmin=3939896|xmax=4264692|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=3|owner=0|xmin=5470411|xmax=6836471|ymin=-391762|ymax=391762|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=3|shape=circle
+glyph-geometry|picture=k1|owner=3|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=4|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=4|shape=circle
+glyph-geometry|picture=k1|owner=4|shape=circle|xmin=10073618|xmax=10437852|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=5|owner=0|xmin=10093337|xmax=10418133|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=6|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=7|owner=0|xmin=3885796|xmax=4318792|ymin=1038670|ymax=1566234|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=8|owner=0|xmin=7611258|xmax=8797919|ymin=1038670|ymax=1620848|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=9|owner=0|xmin=9989004|xmax=10522467|ymin=1038670|ymax=1566234|shape=rect|radius=0

--- a/docs/slides/presentation20260318_agentic_formalization.tex
+++ b/docs/slides/presentation20260318_agentic_formalization.tex
@@ -137,9 +137,26 @@
         % Boundary: the emitted four-site schematic has (virtual, physical) = (0, 4);
         % the symbolic N-site word has (0, N), with no virtual index open.
         % Source: arXiv:1606.00608, Fig. I and lines 135--170.
-        \begin{tenkz}[compact, periodic, physical=up]
-          \tn[up=$i_1$]{A} & \tn[up=$i_2$]{A} & \tndots &
-          \tn[up=$i_{N-1}$]{A} & \tn[up=$i_N$]{A}
+        \tenkzkernel
+        \begin{tenkz}[rows={wire,wire}, cols=7, bonds=none, align=1, size=s]
+          \tn[at=(1,2), name=a1, label pos=s,
+              ports={180:virtual, 0:virtual, 90:physical:$i_1$}]{A}
+          \tn[at=(1,3), name=a2, label pos=s,
+              ports={180:virtual, 0:virtual, 90:physical:$i_2$}]{A}
+          \tn[at=(1,4), skin=dots, name=d, ports={180:virtual, 0:virtual}]{}
+          \tn[at=(1,5), name=a3, label pos=s,
+              ports={180:virtual, 0:virtual, 90:physical:$i_{N-1}$}]{A}
+          \tn[at=(1,6), name=a4, label pos=s,
+              ports={180:virtual, 0:virtual, 90:physical:$i_N$}]{A}
+          \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
+          \tn[at=(2,7), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
+          \tnwire{a1.0}{a2.180}
+          \tnwire{a2.0}{d.180}
+          \tnwire{d.0}{a3.180}
+          \tnwire{a3.0}{a4.180}
+          \tnwire[route=arc]{a4.0}{je.90}
+          \tnwire{je.180}{jw.0}
+          \tnwire[route=arc]{jw.90}{a1.180}
         \end{tenkz}
         \end{center}
         \vspace{0.6em}

--- a/docs/slides/presentation20260318_agentic_formalization.tex
+++ b/docs/slides/presentation20260318_agentic_formalization.tex
@@ -113,7 +113,7 @@
     \end{columns}
 \end{frame}
 
-\begin{frame}{Matrix Product States in one slide}
+\begin{frame}[fragile]{Matrix Product States in one slide}
     \begin{columns}[T]
         \column{0.52\textwidth}
         \begin{block}{Definition (MPS tensor)~[1]}
@@ -138,25 +138,12 @@
         % the symbolic N-site word has (0, N), with no virtual index open.
         % Source: arXiv:1606.00608, Fig. I and lines 135--170.
         \tenkzkernel
-        \begin{tenkz}[rows={wire,wire}, cols=7, bonds=none, align=1, size=s]
-          \tn[at=(1,2), name=a1, label pos=s,
-              ports={180:virtual, 0:virtual, 90:physical:$i_1$}]{A}
-          \tn[at=(1,3), name=a2, label pos=s,
-              ports={180:virtual, 0:virtual, 90:physical:$i_2$}]{A}
-          \tn[at=(1,4), skin=dots, name=d, ports={180:virtual, 0:virtual}]{}
-          \tn[at=(1,5), name=a3, label pos=s,
-              ports={180:virtual, 0:virtual, 90:physical:$i_{N-1}$}]{A}
-          \tn[at=(1,6), name=a4, label pos=s,
-              ports={180:virtual, 0:virtual, 90:physical:$i_N$}]{A}
-          \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
-          \tn[at=(2,7), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
-          \tnwire{a1.0}{a2.180}
-          \tnwire{a2.0}{d.180}
-          \tnwire{d.0}{a3.180}
-          \tnwire{a3.0}{a4.180}
-          \tnwire[route=arc]{a4.0}{je.90}
-          \tnwire{je.180}{jw.0}
-          \tnwire[route=arc]{jw.90}{a1.180}
+        \begin{tenkz}[rows={wire}, cols=5, boundary=periodic, size=s]
+          \tn[label pos=s, ports={90:physical:$i_1$}]{A} &
+          \tn[label pos=s, ports={90:physical:$i_2$}]{A} &
+          \tn[skin=dots]{} &
+          \tn[label pos=s, ports={90:physical:$i_{N-1}$}]{A} &
+          \tn[label pos=s, ports={90:physical:$i_N$}]{A}
         \end{tenkz}
         \end{center}
         \vspace{0.6em}

--- a/docs/slides/presentation20260318_agentic_formalization.tnlog
+++ b/docs/slides/presentation20260318_agentic_formalization.tnlog
@@ -1,46 +1,42 @@
 picture|id=k1|lang=kernel
-atom|id=atom-1|kind=tn|label-pos=s|label=A|name=a1|node=addr-1|ports=180:virtual, 0:virtual, 90:physical:$i_1$
-atom|id=atom-2|kind=tn|label-pos=s|label=A|name=a2|node=addr-2|ports=180:virtual, 0:virtual, 90:physical:$i_2$
-atom|id=atom-3|kind=tn|name=d|node=addr-3|ports=180:virtual, 0:virtual|skin=dots
-atom|id=atom-4|kind=tn|label-pos=s|label=A|name=a3|node=addr-4|ports=180:virtual, 0:virtual, 90:physical:$i_{N-1}$
-atom|id=atom-5|kind=tn|label-pos=s|label=A|name=a4|node=addr-5|ports=180:virtual, 0:virtual, 90:physical:$i_N$
-atom|id=atom-6|kind=tn|name=jw|node=addr-6|ports=0:virtual, 90:virtual|skin=none
-atom|id=atom-7|kind=tn|name=je|node=addr-7|ports=90:virtual, 180:virtual|skin=none
-wire|id=wire-8|from=addr-8|kind=index|to=addr-9
-wire|id=wire-9|from=addr-10|kind=index|to=addr-11
-wire|id=wire-10|from=addr-12|kind=index|to=addr-13
-wire|id=wire-11|from=addr-14|kind=index|to=addr-15
-wire|id=wire-12|from=addr-16|kind=index|route=arc|to=addr-17
-wire|id=wire-13|from=addr-18|kind=index|to=addr-19
-wire|id=wire-14|from=addr-20|kind=index|route=arc|to=addr-21
-wire|id=wire-15|from=addr-22|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
-wire|id=wire-16|from=addr-23|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
-wire|id=wire-17|from=addr-24|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
-wire|id=wire-18|from=addr-25|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+atom|id=atom-1|addr=(1,1)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_1$
+atom|id=atom-2|addr=(1,2)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_2$
+atom|id=atom-3|addr=(1,3)|kind=tn|skin=dots
+atom|id=atom-4|addr=(1,4)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_{N-1}$
+atom|id=atom-5|addr=(1,5)|kind=tn|label-pos=s|label=A|ports=90:physical:$i_N$
+wire|id=wire-6|from=addr-1|kind=index|name=bond-1-1-1-2|origin=grid|to=addr-2
+wire|id=wire-7|from=addr-3|kind=index|name=bond-1-2-1-3|origin=grid|to=addr-4
+wire|id=wire-8|from=addr-5|kind=index|name=bond-1-3-1-4|origin=grid|to=addr-6
+wire|id=wire-9|from=addr-7|kind=index|name=bond-1-4-1-5|origin=grid|to=addr-8
+wire|id=wire-10|from=addr-9|kind=index|name=wrap-1|origin=trace|row=1|side=west-east|to=addr-10
+wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
+wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
+wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
+wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
 kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
 ink-use|picture=k1|class=glyph|id=1|shape=circle
-glyph-geometry|picture=k1|owner=1|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=1|shape=circle|xmin=-182117|xmax=182117|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=1|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=1|owner=0|xmin=-162398|xmax=162398|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=2|shape=circle
-glyph-geometry|picture=k1|owner=2|shape=circle|xmin=3920177|xmax=4284411|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=2|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=2|owner=0|xmin=3939896|xmax=4264692|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=2|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=3|owner=0|xmin=5470411|xmax=6836471|ymin=-391762|ymax=391762|shape=rect|radius=0
+bbox|picture=k1|class=label|id=3|owner=0|xmin=3419264|xmax=4785324|ymin=-391762|ymax=391762|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=3|shape=circle
-glyph-geometry|picture=k1|owner=3|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=3|shape=circle|xmin=5971324|xmax=6335558|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=4|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=4|owner=0|xmin=5991043|xmax=6315839|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 ink-use|picture=k1|class=glyph|id=4|shape=circle
-glyph-geometry|picture=k1|owner=4|shape=circle|xmin=10073618|xmax=10437852|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+glyph-geometry|picture=k1|owner=4|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=5|owner=0|xmin=10093337|xmax=10418133|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+bbox|picture=k1|class=label|id=5|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=6|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=6|owner=0|xmin=-216498|xmax=216498|ymin=1038670|ymax=1566234|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=7|owner=0|xmin=3885796|xmax=4318792|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=7|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=8|owner=0|xmin=7611258|xmax=8797919|ymin=1038670|ymax=1620848|shape=rect|radius=0
+bbox|picture=k1|class=label|id=8|owner=0|xmin=5560111|xmax=6746772|ymin=1038670|ymax=1620848|shape=rect|radius=0
 label-use|picture=k1
-bbox|picture=k1|class=label|id=9|owner=0|xmin=9989004|xmax=10522467|ymin=1038670|ymax=1566234|shape=rect|radius=0
+bbox|picture=k1|class=label|id=9|owner=0|xmin=7937857|xmax=8471320|ymin=1038670|ymax=1566234|shape=rect|radius=0

--- a/docs/slides/presentation20260318_agentic_formalization.tnlog
+++ b/docs/slides/presentation20260318_agentic_formalization.tnlog
@@ -1,0 +1,46 @@
+picture|id=k1|lang=kernel
+atom|id=atom-1|kind=tn|label-pos=s|label=A|name=a1|node=addr-1|ports=180:virtual, 0:virtual, 90:physical:$i_1$
+atom|id=atom-2|kind=tn|label-pos=s|label=A|name=a2|node=addr-2|ports=180:virtual, 0:virtual, 90:physical:$i_2$
+atom|id=atom-3|kind=tn|name=d|node=addr-3|ports=180:virtual, 0:virtual|skin=dots
+atom|id=atom-4|kind=tn|label-pos=s|label=A|name=a3|node=addr-4|ports=180:virtual, 0:virtual, 90:physical:$i_{N-1}$
+atom|id=atom-5|kind=tn|label-pos=s|label=A|name=a4|node=addr-5|ports=180:virtual, 0:virtual, 90:physical:$i_N$
+atom|id=atom-6|kind=tn|name=jw|node=addr-6|ports=0:virtual, 90:virtual|skin=none
+atom|id=atom-7|kind=tn|name=je|node=addr-7|ports=90:virtual, 180:virtual|skin=none
+wire|id=wire-8|from=addr-8|kind=index|to=addr-9
+wire|id=wire-9|from=addr-10|kind=index|to=addr-11
+wire|id=wire-10|from=addr-12|kind=index|to=addr-13
+wire|id=wire-11|from=addr-14|kind=index|to=addr-15
+wire|id=wire-12|from=addr-16|kind=index|route=arc|to=addr-17
+wire|id=wire-13|from=addr-18|kind=index|to=addr-19
+wire|id=wire-14|from=addr-20|kind=index|route=arc|to=addr-21
+wire|id=wire-15|from=addr-22|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
+wire|id=wire-16|from=addr-23|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
+wire|id=wire-17|from=addr-24|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
+wire|id=wire-18|from=addr-25|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
+ink-use|picture=k1|class=glyph|id=1|shape=circle
+glyph-geometry|picture=k1|owner=1|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=1|owner=0|xmin=1888749|xmax=2213545|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=2|shape=circle
+glyph-geometry|picture=k1|owner=2|shape=circle|xmin=3920177|xmax=4284411|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=2|owner=0|xmin=3939896|xmax=4264692|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=3|owner=0|xmin=5470411|xmax=6836471|ymin=-391762|ymax=391762|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=3|shape=circle
+glyph-geometry|picture=k1|owner=3|shape=circle|xmin=8022471|xmax=8386705|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=4|owner=0|xmin=8042190|xmax=8366986|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=4|shape=circle
+glyph-geometry|picture=k1|owner=4|shape=circle|xmin=10073618|xmax=10437852|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=5|owner=0|xmin=10093337|xmax=10418133|ymin=-1192952|ymax=-874578|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=6|owner=0|xmin=1834649|xmax=2267645|ymin=1038670|ymax=1566234|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=7|owner=0|xmin=3885796|xmax=4318792|ymin=1038670|ymax=1566234|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=8|owner=0|xmin=7611258|xmax=8797919|ymin=1038670|ymax=1620848|shape=rect|radius=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=9|owner=0|xmin=9989004|xmax=10522467|ymin=1038670|ymax=1566234|shape=rect|radius=0

--- a/docs/slides/presentation20260522_gap_analysis.tex
+++ b/docs/slides/presentation20260522_gap_analysis.tex
@@ -696,20 +696,16 @@ Pi-tensors don't span product algebra \\
 % Contraction: the physical pair is summed; the east cup inserts rho.
 % Boundary: (virtual, physical) = (2, 0), the west pair is E_A(rho).
 % Source: arXiv:1606.00608, lines 219--223; blueprint Definition 2.1.8.
-\tenkzkernel
-$\mathcal E_A(\rho)$
-\begin{tenkz}[rows={wire,wire,wire}, cols=2, bonds=none]
-  \tn[at=(1,1), name=ket, label pos=n,
-      ports={180:virtual, 0:virtual, 270:physical}]{A}
-  \tn[at=(3,1), name=bra, label pos=s,
-      ports={180:virtual, 0:virtual, 90:physical}]{\overline{A}}
-  \tnwire{ket.180}{open w}
-  \tnwire{bra.180}{open w}
-  \tnwire{ket.270}{bra.90}
-  \tn[at=(2,2), name=rho, label pos=e,
-      ports={90:virtual, 270:virtual}]{\rho}
-  \tnwire[route=arc]{ket.0}{rho.90}
-  \tnwire[route=arc]{rho.270}{bra.0}
+% The state rides the closing cup.  The kernel's on-wire anchor divides the
+% record chord rather than the drawn arc, so a tensor placed there would read
+% as sitting on the physical contraction; this picture keeps its 0.7 spelling
+% until a station on a generated cup exists.
+\begin{tenkz}[
+    sandwich,
+    east={cup=$\rho$},
+    west label=$\mathcal E_A(\rho)$]
+  \tn{A} \\
+  \tn*{A}
 \end{tenkz}
 \end{center}
 \end{columns}

--- a/docs/slides/presentation20260522_gap_analysis.tex
+++ b/docs/slides/presentation20260522_gap_analysis.tex
@@ -696,12 +696,20 @@ Pi-tensors don't span product algebra \\
 % Contraction: the physical pair is summed; the east cup inserts rho.
 % Boundary: (virtual, physical) = (2, 0), the west pair is E_A(rho).
 % Source: arXiv:1606.00608, lines 219--223; blueprint Definition 2.1.8.
-\begin{tenkz}[
-    sandwich,
-    east={cup=$\rho$},
-    west label=$\mathcal E_A(\rho)$]
-  \tn{A} \\
-  \tn*{A}
+\tenkzkernel
+$\mathcal E_A(\rho)$
+\begin{tenkz}[rows={wire,wire,wire}, cols=2, bonds=none]
+  \tn[at=(1,1), name=ket, label pos=n,
+      ports={180:virtual, 0:virtual, 270:physical}]{A}
+  \tn[at=(3,1), name=bra, label pos=s,
+      ports={180:virtual, 0:virtual, 90:physical}]{\overline{A}}
+  \tnwire{ket.180}{open w}
+  \tnwire{bra.180}{open w}
+  \tnwire{ket.270}{bra.90}
+  \tn[at=(2,2), name=rho, label pos=e,
+      ports={90:virtual, 270:virtual}]{\rho}
+  \tnwire[route=arc]{ket.0}{rho.90}
+  \tnwire[route=arc]{rho.270}{bra.0}
 \end{tenkz}
 \end{center}
 \end{columns}

--- a/docs/slides/presentation20260522_gap_analysis.tnlog
+++ b/docs/slides/presentation20260522_gap_analysis.tnlog
@@ -1,0 +1,22 @@
+picture|id=k1|lang=kernel
+atom|id=atom-1|kind=tn|label-pos=n|label=A|name=ket|node=addr-1|ports=180:virtual, 0:virtual, 270:physical
+atom|id=atom-2|kind=tn|label-pos=s|label=\protect \@@overline {A}|name=bra|node=addr-2|ports=180:virtual, 0:virtual, 90:physical
+atom|id=atom-6|kind=tn|label-pos=e|label=\rho |name=rho|node=addr-7|ports=90:virtual, 270:virtual
+wire|id=wire-3|from=addr-3|kind=index|to-open=w
+wire|id=wire-4|from=addr-4|kind=index|to-open=w
+wire|id=wire-5|from=addr-5|kind=index|port-type=physical|to=addr-6
+wire|id=wire-7|from=addr-8|kind=index|route=arc|to=addr-9
+wire|id=wire-8|from=addr-10|kind=index|route=arc|to=addr-11
+kernel-boundary|signature=open:w, open:w
+ink-use|picture=k1|class=glyph|id=1|shape=circle
+glyph-geometry|picture=k1|owner=1|shape=circle|xmin=-182117|xmax=182117|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=1|owner=0|xmin=-162398|xmax=162398|ymin=874578|ymax=1192952|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=2|shape=circle
+glyph-geometry|picture=k1|owner=2|shape=circle|xmin=-182117|xmax=182117|ymin=-4284411|ymax=-3920177|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=2|owner=0|xmin=-162398|xmax=162398|ymin=-5406650|ymax=-4976871|shape=rect|radius=0
+ink-use|picture=k1|class=glyph|id=3|shape=circle
+glyph-geometry|picture=k1|owner=3|shape=circle|xmin=1869030|xmax=2233264|ymin=-2233264|ymax=-1869030|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=k1
+bbox|picture=k1|class=label|id=3|owner=0|xmin=2925725|xmax=3197633|ymin=-2194507|ymax=-1907788|shape=rect|radius=0

--- a/docs/slides/presentation20260522_gap_analysis.tnlog
+++ b/docs/slides/presentation20260522_gap_analysis.tnlog
@@ -1,22 +1,20 @@
-picture|id=k1|lang=kernel
-atom|id=atom-1|kind=tn|label-pos=n|label=A|name=ket|node=addr-1|ports=180:virtual, 0:virtual, 270:physical
-atom|id=atom-2|kind=tn|label-pos=s|label=\protect \@@overline {A}|name=bra|node=addr-2|ports=180:virtual, 0:virtual, 90:physical
-atom|id=atom-6|kind=tn|label-pos=e|label=\rho |name=rho|node=addr-7|ports=90:virtual, 270:virtual
-wire|id=wire-3|from=addr-3|kind=index|to-open=w
-wire|id=wire-4|from=addr-4|kind=index|to-open=w
-wire|id=wire-5|from=addr-5|kind=index|port-type=physical|to=addr-6
-wire|id=wire-7|from=addr-8|kind=index|route=arc|to=addr-9
-wire|id=wire-8|from=addr-10|kind=index|route=arc|to=addr-11
-kernel-boundary|signature=open:w, open:w
-ink-use|picture=k1|class=glyph|id=1|shape=circle
-glyph-geometry|picture=k1|owner=1|shape=circle|xmin=-182117|xmax=182117|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
-label-use|picture=k1
-bbox|picture=k1|class=label|id=1|owner=0|xmin=-162398|xmax=162398|ymin=874578|ymax=1192952|shape=rect|radius=0
-ink-use|picture=k1|class=glyph|id=2|shape=circle
-glyph-geometry|picture=k1|owner=2|shape=circle|xmin=-182117|xmax=182117|ymin=-4284411|ymax=-3920177|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
-label-use|picture=k1
-bbox|picture=k1|class=label|id=2|owner=0|xmin=-162398|xmax=162398|ymin=-5406650|ymax=-4976871|shape=rect|radius=0
-ink-use|picture=k1|class=glyph|id=3|shape=circle
-glyph-geometry|picture=k1|owner=3|shape=circle|xmin=1869030|xmax=2233264|ymin=-2233264|ymax=-1869030|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
-label-use|picture=k1
-bbox|picture=k1|class=label|id=3|owner=0|xmin=2925725|xmax=3197633|ymin=-2194507|ymax=-1907788|shape=rect|radius=0
+picture|id=1|lang=grid
+ink-use|picture=1|class=glyph|id=1|shape=circle
+glyph-geometry|picture=1|owner=1|shape=circle|xmin=1869030|xmax=2233264|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+atom|picture=1|cell=1-1|kind=dot|role=none|species=none
+ink-use|picture=1|class=glyph|id=2|shape=circle
+glyph-geometry|picture=1|owner=2|shape=circle|xmin=1869030|xmax=2233264|ymin=-1823040|ymax=-1458806|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+atom|picture=1|cell=2-1|kind=dot|role=none|species=none
+label-use|picture=1
+bbox|picture=1|class=label|id=1|owner=0|xmin=-577161|xmax=621251|ymin=-229376|ymax=229376|shape=rect|radius=0
+ink-use|picture=1|class=glyph|id=3|shape=circle
+glyph-geometry|picture=1|owner=3|shape=circle|xmin=2974156|xmax=3338390|ymin=-1002579|ymax=-638345|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0
+label-use|picture=1
+bbox|picture=1|class=label|id=2|owner=0|xmin=3663160|xmax=3935068|ymin=-963822|ymax=-677103|shape=rect|radius=0
+cup|picture=1|side=east|top=1|bottom=2|matrix=1
+pairleg|picture=1|upper=1-1|lower=2-1|upper-port=center|column=1
+label-use|picture=1
+bbox|picture=1|class=label|id=3|owner=0|xmin=1935149|xmax=2167146|ymin=506887|ymax=734297|shape=rect|radius=0
+label-use|picture=1
+bbox|picture=1|class=label|id=4|owner=0|xmin=1935149|xmax=2167146|ymin=-2454794|ymax=-2147809|shape=rect|radius=0
+boundary|picture=1|virtual-west=2|virtual-east=0|physical-up=0|physical-down=0

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -55,23 +55,23 @@ separate public-surface occurrence and therefore appears separately.
 | `ch02_mps.tex` | — | L200 `tenkz` → `C-policy+C-record` | L24, 54, 171, 272, 840, 966 `tenkz` → `C-policy+C-record+R-record` |
 | `ch03_single.tex` | L251 `tenkz` → `P-grid` | — | — |
 | `ch04_channels_choi_foundations.tex` | — | — | L86 `tenkz` → `C-policy+C-record+R-record` |
-| `ch11_fundamental_theorem_core.tex` | L42, 49 `tenkz` → `P-grid` | — | — |
+| `ch11_fundamental_theorem_core.tex` | L42, 46 `tenkz` → `P-grid` | — | — |
 | `ch12_symmetry_string_order.tex` | — | L396, 410, 453, 468, 549, 563 `tenkz` → `C-policy+C-record` | L39, 352, 499, 866 `tenkz` → `C-record+C-species+R-record`<br>L73 `tenkz` → `C-policy+C-record+C-species+R-record`<br>L367, 513, 871 `tenkz` → `C-policy+C-record+R-record` |
 | `ch12_symmetry_virtual_and_cohomology.tex` | — | — | L180 `tenkz` → `C-record+C-species+R-record`<br>L195, 328, 456, 469 `tenkz` → `C-policy+C-record+R-record` |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | — | — | L54 `tenkzfree` → `R-free+R-record` |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | — | — | L275 `tenkzfree` → `R-free+R-record` |
-| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | L101 `tenkz` → `C-policy` | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | — | — | L35, 489, 528 `tenkz` → `C-policy+C-record+R-record` |
 | `ch14_correlations.tex` | — | — | L67 `tenkz` → `C-policy+C-record+R-record` |
-| `ch16_channel_representations_choi_and_kraus.tex` | L672 `tenkz` → `P-grid` | — | — |
-| `ch16_channel_representations_dilations_and_ordered_cp.tex` | L22 `tenkz` → `P-grid` | — | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | — | L674 `tenkz` → `C-policy+C-record` | — |
+| `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L24 `tenkz` → `C-policy+C-record` | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L234, 240 `tenkz` → `C-policy+C-record` | L154, 160, 338, 435 `tenkz` → `C-policy+C-record+R-record`<br>L178, 183 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |
-| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 657 `tenkz` → `P-grid` | — | — |
+| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 644 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | — | — | L16, 124, 370 `tenkz` → `C-policy+C-record+R-record`<br>L374 `tenkz` → `C-record+R-record` |
-| `ch21_mpdo_rfp_algebra_tower.tex` | L79, 102 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 27 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_foundations.tex` | L87, 94 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_algebra_tower.tex` | — | L79, 95 `tenkz` → `C-policy` | — |
+| `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_foundations.tex` | — | L87, 92 `tenkz` → `C-policy` | — |
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
@@ -81,7 +81,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | — | — | L792, 801, 808, 815, 888, 894 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex` | — | — | L427 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | L189 `tenkz` → `C-policy` | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L332 `tenkz` → `C-record`<br>L850 `tenkz` → `C-policy+C-record` | L854, 860, 865 `tenkz` → `C-record+R-record` |
@@ -89,7 +89,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | — | — | L83, 115, 329, 347, 365, 623, 647 `tenkzfree` → `C-species+R-free+R-record`<br>L316 `tenkzfree` → `R-free+R-record` |
-| `ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex` | L53, 71 `tenkz` → `P-grid` | — | — |
+| `ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex` | — | L53, 60 `tenkz` → `C-policy` | — |
 | `ch24_peps_ft_edge_kernel_gauges_kernel_descent_recovery.tex` | — | — | L174, 196, 218, 445, 467, 489 `tenkzfree` → `C-species+R-free+R-record` |
 | `ch24_peps_ft_edge_middle.tex` | — | L278 `tnpic` → `C-picture+C-policy` | L242 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_foundations.tex` | — | — | L48, 384 `tenkzfree` → `R-free+R-record` |
@@ -120,8 +120,8 @@ separate public-surface occurrence and therefore appears separately.
 
 | Disposition | Occurrences |
 |---|---:|
-| preserve | 19 |
-| codemod | 29 |
+| preserve | 9 |
+| codemod | 39 |
 | redraw | 159 |
 | **Total** | **207** |
 

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -53,35 +53,35 @@ separate public-surface occurrence and therefore appears separately.
 | Source | Preserve | Codemod | Redraw |
 |---|---|---|---|
 | `ch02_mps.tex` | — | L200 `tenkz` → `C-policy+C-record` | L24, 54, 171, 272, 840, 966 `tenkz` → `C-policy+C-record+R-record` |
-| `ch03_single.tex` | — | — | L250 `tenkz` → `C-policy+C-record+R-record` |
+| `ch03_single.tex` | L251 `tenkz` → `P-grid` | — | — |
 | `ch04_channels_choi_foundations.tex` | — | — | L86 `tenkz` → `C-policy+C-record+R-record` |
-| `ch11_fundamental_theorem_core.tex` | — | — | L41, 45 `tenkz` → `C-policy+C-record+R-record` |
+| `ch11_fundamental_theorem_core.tex` | L42, 49 `tenkz` → `P-grid` | — | — |
 | `ch12_symmetry_string_order.tex` | — | L396, 410, 453, 468, 549, 563 `tenkz` → `C-policy+C-record` | L39, 352, 499, 866 `tenkz` → `C-record+C-species+R-record`<br>L73 `tenkz` → `C-policy+C-record+C-species+R-record`<br>L367, 513, 871 `tenkz` → `C-policy+C-record+R-record` |
 | `ch12_symmetry_virtual_and_cohomology.tex` | — | — | L180 `tenkz` → `C-record+C-species+R-record`<br>L195, 328, 456, 469 `tenkz` → `C-policy+C-record+R-record` |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | — | — | L54 `tenkzfree` → `R-free+R-record` |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | — | — | L275 `tenkzfree` → `R-free+R-record` |
-| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | — | L97 `tenkz` → `C-policy+C-record+R-record` |
+| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | — | — | L35, 489, 528 `tenkz` → `C-policy+C-record+R-record` |
 | `ch14_correlations.tex` | — | — | L67 `tenkz` → `C-policy+C-record+R-record` |
-| `ch16_channel_representations_choi_and_kraus.tex` | — | L670 `tenkz` → `C-policy+C-record` | — |
-| `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L20 `tenkz` → `C-policy+C-record` | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | L672 `tenkz` → `P-grid` | — | — |
+| `ch16_channel_representations_dilations_and_ordered_cp.tex` | L22 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L234, 240 `tenkz` → `C-policy+C-record` | L154, 160, 338, 435 `tenkz` → `C-policy+C-record+R-record`<br>L178, 183 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |
-| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | — | — | L637, 642 `tenkz` → `C-policy+C-record+R-record` |
+| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 657 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | — | — | L16, 124, 370 `tenkz` → `C-policy+C-record+R-record`<br>L374 `tenkz` → `C-record+R-record` |
-| `ch21_mpdo_rfp_algebra_tower.tex` | — | — | L78, 93 `tenkz` → `C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | — | — | L18, 21 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_foundations.tex` | — | L86, 90 `tenkz` → `C-policy+C-record` | — |
+| `ch21_mpdo_rfp_algebra_tower.tex` | L79, 102 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 27 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_foundations.tex` | L87, 94 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L581, 583 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L444 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L281, 286 `tenkz` → `C-policy+C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | L282, 288 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | — | — | L792, 801, 808, 815, 888, 894 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex` | — | — | L427 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | — | L188 `tenkz` → `C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L332 `tenkz` → `C-record`<br>L850 `tenkz` → `C-policy+C-record` | L854, 860, 865 `tenkz` → `C-record+R-record` |
@@ -89,7 +89,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | — | — | L83, 115, 329, 347, 365, 623, 647 `tenkzfree` → `C-species+R-free+R-record`<br>L316 `tenkzfree` → `R-free+R-record` |
-| `ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex` | — | — | L52, 56 `tnpic` → `C-picture+C-policy+C-record+R-record` |
+| `ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex` | L53, 71 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_edge_kernel_gauges_kernel_descent_recovery.tex` | — | — | L174, 196, 218, 445, 467, 489 `tenkzfree` → `C-species+R-free+R-record` |
 | `ch24_peps_ft_edge_middle.tex` | — | L278 `tnpic` → `C-picture+C-policy` | L242 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_foundations.tex` | — | — | L48, 384 `tenkzfree` → `R-free+R-record` |
@@ -108,21 +108,21 @@ separate public-surface occurrence and therefore appears separately.
 
 | Raw construct | Occurrences |
 |---|---:|
-| `tenkz` | 106 |
+| `tenkz` | 110 |
 | `tenkzeq` | 0 |
 | `tenkzfree` | 36 |
 | `tenkzlattice` | 18 |
 | `tenkzcd` | 6 |
 | `tenkzplanes` | 0 |
-| `tnpic` | 30 |
+| `tnpic` | 26 |
 | `tntree` | 11 |
 | **Total** | **207** |
 
 | Disposition | Occurrences |
 |---|---:|
-| preserve | 0 |
-| codemod | 33 |
-| redraw | 174 |
+| preserve | 19 |
+| codemod | 29 |
+| redraw | 159 |
 | **Total** | **207** |
 
 The raw count is 166 environment openings plus 41 command occurrences,

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -1967,3 +1967,25 @@ draw a red trapezoid or a sharp rectangle. Those returns are ink, not
 ceremony.
 
 Census-correction: #5524
+
+### 2026-08-05 — the first blueprint chapters take the kernel
+
+Seventeen blueprint chapters, slide decks, and manual pages respell their
+figures on the kernel: declared frames, canonical addresses, typed ports,
+and stock skins replace the row-and-column spellings, periodic closures
+become explicit returns through invisible junctions, and the channel
+sandwiches route their closing cup through the operator standing on it.
+The benchmark corpus is untouched, so every meter but the consumer census
+stands; the demand corpus loses the retired grid spellings.
+
+Two figures keep their 0.7 spelling and are named in the disposition
+ledger: the operators of the maximally entangled state and the
+correlation window ride a generated cup between operator rows, where the
+on-wire anchor divides the record chord rather than the drawn arc, so a
+tensor placed there would read as sitting on the physical contraction.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:picture:west label | keep-because: this wave retires the grid consumers it touched; the two that remain are the entangled-state and inverse-map chapters, which respell with the blueprint's later waves; expiry 0.9 |
+
+Census-correction: #4709

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -1971,21 +1971,31 @@ Census-correction: #5524
 ### 2026-08-05 — the first blueprint chapters take the kernel
 
 Seventeen blueprint chapters, slide decks, and manual pages respell their
-figures on the kernel: declared frames, canonical addresses, typed ports,
-and stock skins replace the row-and-column spellings, periodic closures
-become explicit returns through invisible junctions, and the channel
-sandwiches route their closing cup through the operator standing on it.
-The benchmark corpus is untouched, so every meter but the consumer census
-stands; the demand corpus loses the retired grid spellings.
+figures on the kernel. Each picture states its row and its column count and
+then names its atoms in reading order: the chain runs on the alignment
+character, a stacked picture breaks its rows, and the grid bonds the
+neighbours it just placed. A word closed on itself says `boundary=periodic`
+and lets the closure draw itself; a word open at both ends says
+`west=open, east=open`. An address, a name, and a port list survive only
+where a later line reads them. The benchmark corpus is untouched, so every
+meter but the consumer census stands; the demand corpus loses the retired
+grid spellings.
 
-Two figures keep their 0.7 spelling and are named in the disposition
-ledger: the operators of the maximally entangled state and the
-correlation window ride a generated cup between operator rows, where the
-on-wire anchor divides the record chord rather than the drawn arc, so a
-tensor placed there would read as sitting on the physical contraction.
+Five figures keep their 0.7 spelling and are named in the disposition
+ledger: the operators of the maximally entangled state, the correlation
+window, the two channel sandwiches, and the transfer-map slide ride a
+generated cup between operator rows, where the on-wire anchor divides the
+record chord rather than the drawn arc, so a tensor placed there would read
+as sitting on the physical contraction.
+
+The physical policy is a real trade and not a free win. It pays where two or
+more sites take an unlabelled leg -- the operator stack, the traced word --
+and costs where a single site among many carries the index, because every
+other site then has to refuse it. Those pictures keep their port list, which
+also keeps them out of the codemod column.
 
 | flag | verdict |
 |---|---|
-| flag:consumers:key:picture:west label | keep-because: this wave retires the grid consumers it touched; the two that remain are the entangled-state and inverse-map chapters, which respell with the blueprint's later waves; expiry 0.9 |
+| flag:consumers:key:picture:west label | keep-because: this wave retires the grid consumers it touched; the five that remain all stand a tensor on a generated cup, and they respell when the kernel gains a station on that arc; expiry 0.9 |
 
 Census-correction: #4709

--- a/docs/tenkz/chapters2/ch-house.tex
+++ b/docs/tenkz/chapters2/ch-house.tex
@@ -16,11 +16,12 @@ recurring mathematical kind:
 \hspace*{2em}ports=\{\meta{face:type},\ldots\}\}}
 
 \begin{Verbatim}[fontsize=\small,frame=leftline]
-\tndeclareatom{\tnprojector}{
+\tenkzkernel
+\tndeclare{atom}{\tnprojector}{
   skin=box,
-  ports={west:virtual,east:virtual,up:physical}
+  ports={180:virtual, 0:virtual, 90:physical}
 }
-\begin{tenkz}[physical=up] \tnprojector{P} \end{tenkz}
+\begin{tenkz}[physical=up, cols=1] \tnprojector{P} \end{tenkz}
 \end{Verbatim}
 
 Faces are \tnval{west}, \tnval{east}, \tnval{up}, and \tnval{down}; types

--- a/docs/tenkz/chapters2/ch-house.tex
+++ b/docs/tenkz/chapters2/ch-house.tex
@@ -8,10 +8,10 @@ typed ports, and visual skin are separate data.
 
 \subsection{Declare one typed atom}
 
-Use \tncmd{tndeclareatom} only when the stock atom vocabulary cannot express a
+Use \tncmd{tndeclare} only when the stock atom vocabulary cannot express a
 recurring mathematical kind:
 
-\cmdsig{\textbackslash tndeclareatom\{\meta{command}\}\\
+\cmdsig{\textbackslash tndeclare\{atom\}\{\meta{command}\}\\
 \{skin=\meta{dot|box|pill|mpo},\\
 \hspace*{2em}ports=\{\meta{face:type},\ldots\}\}}
 
@@ -21,11 +21,12 @@ recurring mathematical kind:
   skin=box,
   ports={180:virtual, 0:virtual, 90:physical}
 }
-\begin{tenkz}[physical=up, cols=1] \tnprojector{P} \end{tenkz}
+\begin{tenkz}[cols=1] \tnprojector{P} \end{tenkz}
 \end{Verbatim}
 
-Faces are \tnval{west}, \tnval{east}, \tnval{up}, and \tnval{down}; types
-are \tnval{virtual} and \tnval{physical}.  The declaration creates a
+A face is an angle in the atom's own axes: \tnval{180} and \tnval{0} are the
+two ends of the wire, \tnval{90} is above and \tnval{270} below.  Types are
+\tnval{virtual} and \tnval{physical}.  The declaration creates a
 one-label atom command with optional per-use cell keys.  Its port list is
 complete: an anchor without a type is not an extension contract.
 

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -86,7 +86,7 @@ def _assert_source_linked_groups(repo_root: Path) -> None:
     )
     blocked_bodies = _tenkzequation_bodies(blocked)
     assert len(blocked_bodies) == 1, len(blocked_bodies)
-    assert blocked_bodies[0].count(r"\tnpic") == 2
+    assert blocked_bodies[0].count(r"\begin{tenkz}") == 2
     assert r"\qquad$=$\qquad" in blocked_bodies[0]
 
     channels = _read_tex_tree(


### PR DESCRIPTION
Seventeen blueprint chapters, slide decks, and manual pages say their figures
in the kernel. The picture bodies:

| | 0.7 original | first push | now |
|---|---:|---:|---:|
| lines of picture body | 95 | 311 | **137** |

The first push was rejected as far too verbose. The two design fixes that
have since landed on main — a flat row's traced sides draw their closure
(#5492), and a site answers the picture's physical policy for itself (#5524)
— removed the reasons for most of it.

## Two side-by-side spellings

The gauge relation, `ch03_single.tex`:

```tex
% before
\begin{tenkz}[rows={wire}, cols=3, bonds=none]
    \tn[at=(1,1), skin=ring, name=x1, ports={180:virtual, 0:virtual}]{X}
    \tn[at=(1,2), name=a, label pos=s,
        ports={180:virtual, 0:virtual, 90:physical:$i$}]{A}
    \tn[at=(1,3), skin=ring, name=x2,
        ports={180:virtual, 0:virtual}]{X^{-1}}
    \tnwire{x1.180}{open w}
    \tnwire{x1.0}{a.180}
    \tnwire{a.0}{x2.180}
    \tnwire{x2.0}{open e}
\end{tenkz}

% now
\begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
    \tn[skin=ring]{X} & \tn[label pos=s, ports={90:physical:$i$}]{A} &
    \tn[skin=ring]{X^{-1}}
\end{tenkz}
```

The closure map, `ch21_mpdo_rfp_algebra_tower.tex`:

```tex
% before
\begin{tenkz}[rows={wire,wire}, cols=4, bonds=none, align=1]
    \tn[at=(1,2), skin=box, name=x, ports={180:virtual, 0:virtual}]{X}
    \tn[at=(1,3), skin=mpo, name=m,
        ports={180:virtual, 0:virtual, 90:physical, 270:physical}]{M_\alpha}
    \tn[at=(2,1), skin=none, name=jw, ports={0:virtual, 90:virtual}]{}
    \tn[at=(2,4), skin=none, name=je, ports={90:virtual, 180:virtual}]{}
    \tnwire{x.0}{m.180}
    \tnwire[route=arc]{m.0}{je.90}
    \tnwire{je.180}{jw.0}
    \tnwire[route=arc]{jw.90}{x.180}
\end{tenkz}

% now
\begin{tenkz}[rows={wire}, cols=2, boundary=periodic]
    \tn[skin=box]{X} &
    \tn[skin=mpo, ports={90:physical, 270:physical}]{M_\alpha}
\end{tenkz}
```

## Per-figure line counts

| file | 0.7 | first push | now |
|---|---:|---:|---:|
| `ch03_single.tex` | 3 | 12 | 5 |
| `ch11_fundamental_theorem_core.tex` | 6 | 18 | 9 |
| `ch13_..._intersection_property.tex` | 6 | 21 | 8 |
| `ch16_..._choi_and_kraus.tex` | 8 | 13 | 8 (reverted to 0.7) |
| `ch16_..._dilations_and_ordered_cp.tex` | 8 | 13 | 8 (reverted to 0.7) |
| `ch20_..._positivity_gram_normalization.tex` | 8 | 37 | 11 |
| `ch21_mpdo_rfp_algebra_tower.tex` | 6 | 22 | 8 |
| `ch21_..._blocked_rfp_positive_blocking....tex` | 5 | 19 | 9 |
| `ch21_mpdo_rfp_foundations.tex` | 6 | 16 | 9 |
| `ch21_..._closed_sector_contractions.tex` | 8 | 14 | 11 |
| `ch21_..._primitivity_active_trace_matrix.tex` | 5 | 14 | 7 |
| `ch24_..._insertion_algebra_local_gauges.tex` | 6 | 35 | 13 |
| `presentation20260207.tex` | 4 | 21 | 7 |
| `presentation20260222_technical.tex` | 4 | 21 | 8 |
| `presentation20260318_agentic_formalization.tex` | 4 | 21 | 8 |
| `presentation20260522_gap_analysis.tex` | 7 | 13 | 7 (reverted to 0.7) |
| `ch-house.tex` | 1 | 1 | 1 |
| **total** | **95** | **311** | **137** |

## What changed in the spelling

- The `at=(r,c)` address goes: atoms chain on `&` and break rows on `\\`, and
  the grid bonds the neighbours it just placed. A `name=` survives only where
  a later line reads it, and no figure here needed one.
- A word closed on itself says `boundary=periodic` and lets the closure draw
  itself. Eleven lines of invisible junctions and hand-routed arcs go.
- A word open at both ends says `west=open, east=open`. The documented
  default does not currently draw side legs (#5529), so it is written out.
- The picture-level `physical=` policy is used where two or more sites take
  an unlabelled leg — the operator stack, the traced word. Where a single
  site among many carries the index, every other site would have to refuse
  it with `physical=none`, so those pictures keep their port list instead.
  That also keeps them out of the codemod column of the disposition ledger.

## Renders

Every figure was rendered before and after and compared.

- Eight flat pictures are **pixel-identical** (`compare -metric AE` = 0):
  ch03, ch11, ch20, ch21blocked, ch21found, ch21closed, ch21prim, and the
  blocked-RFP equation.
- Five periodic pictures change exactly as the closure fix intends: the
  hand-spelled trapezoid becomes the rounded return the sources draw. Each
  was checked against the 0.7 render it replaced and matches it: ch13, ch24,
  ch21tower, and the three chained decks.

## Three sandwiches return to 0.7

`ch16_..._choi_and_kraus`, `ch16_..._dilations_and_ordered_cp`, and the
transfer-map slide in `presentation20260522_gap_analysis` stand ρ on the
closing cup. The kernel's on-wire anchor divides the record chord rather
than the drawn arc, so the kernel spelling drew the cup as two straight
chords through a free-standing tensor — a visibly different picture. They
join the two figures already named in the ledger for the same reason and
render pixel-identically to the pre-wave drawing.

## Beamer

Beamer re-reads a frame body, which loses the alignment character the kernel
binds; a chained picture inside a plain frame raises *Misplaced alignment tab
character &* and then an occupancy error. The three decks holding a chained
picture mark that one frame `fragile`, which restores it. Worth an issue
against the kernel's `&` binding.

## Checks

- `scripts/test_tenkz_pic.py` — pass
- `scripts/check_tenkz_dispositions.py` — pass (line pins moved, and seven
  figures move from the preserve column to codemod because they now ride the
  `boundary=`/`physical=` sugar)
- `scripts/check_tenkz_policy.py` — pass
- `scripts/tenkz_shrink.py gate --base-ref origin/main` — pass, census stable
  at 200
- `docs/tenkz/manual2.tex` compiles (20 pages); all four decks compile
