### PR TITLE
feat(tenkz): draw the traced closure and let a site answer the physical policy

### DIFF
--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -142,8 +142,8 @@ top-level-source census so a shared input is not counted multiple times.
 | Disposition | Fixtures |
 |---|---:|
 | preserve | 10 |
-| codemod | 39 |
-| redraw | 215 |
+| codemod | 40 |
+| redraw | 214 |
 | **Total** | **264** |
 
 Of the 264 top-level fixtures, 246 directly or indirectly open a tenkz
@@ -155,16 +155,16 @@ consumers, and 5 contain no tenkz public-surface construct.
 - `P-grid`: `iso_h.tex` · `p3_probe_opop.tex` · `rv4061_flatonly.tex` · `trace_warn.tex` · `zz_wirescan.tex`
 - `P-none`: `geom.tex` · `plane_experiment.tex` · `zz_geomdag.tex` · `zz_geomframe.tex` · `zz_geomsupport.tex`
 
-### Codemod fixtures (39)
+### Codemod fixtures (40)
 
 - `C-declare`: `p_species.tex`
 - `C-policy`: `hdr.tex` · `iso_i.tex` · `iso_k.tex` · `p3_bisect_d.tex` · `rv4061_ketptrace.tex`
-- `C-policy+C-record`: `g06_stageB.tex` · `hard01_v2.tex` · `p3_bond_insertion.tex` · `p3_gauge.tex` · `p3_lemma1.tex` · `p3_trace_word.tex` · `p3_word.tex` · `p_newcup.tex` · `part_B3.tex` · `rv4061_cellset.tex` · `rv4061_cuporder.tex` · `t2_lassodef.tex` · `t2_lassodef_v2.tex`
+- `C-policy+C-record`: `g06_stageB.tex` · `hard01_v2.tex` · `p3_bond_insertion.tex` · `p3_gauge.tex` · `p3_lemma1.tex` · `p3_trace_word.tex` · `p3_word.tex` · `p_newcup.tex` · `part_B3.tex` · `rv4061_cellset.tex` · `rv4061_cuporder.tex` · `t2_lassodef.tex` · `t2_lassodef_v2.tex` · `t2_twoshift.tex`
 - `C-record`: `hard11_v3.tex` · `hard11_v4.tex` · `iso_a.tex` · `iso_b.tex` · `iso_d.tex` · `iso_e.tex` · `iso_f.tex` · `iso_g.tex` · `iso_t.tex` · `t2_staircase.tex`
 - `C-switch`: `fig21d_cubic.tex` · `fig21d_cubic_v2.tex`
 - `C-tree`: `gr_t2_fsymbol.tex` · `hard11_v2.tex` · `p3_eq5_fsymbol.tex` · `p3_eq5_v2.tex` · `p4067_braced.tex` · `t2_fusion.tex` · `t2_pentagon5.tex` · `tree_test.tex`
 
-### Redraw fixtures (215)
+### Redraw fixtures (214)
 
 - `C-declare+C-picture+C-policy+C-record+R-free+R-record`: `adv_leak.tex`
 - `C-declare+C-policy+C-record+C-species+R-free+R-lattice+R-record`: `g06_stageC.tex`
@@ -177,7 +177,7 @@ consumers, and 5 contain no tenkz public-surface construct.
 - `C-policy+C-record+R-free+R-lattice+R-plane+R-record`: `planes_keys_test.tex`
 - `C-policy+C-record+R-free+R-record`: `gr_t1_fusion.tex` · `hard01_ortho.tex` · `hard02_ALdef.tex` · `hard03_rdm.tex` · `hard05_OL.tex` · `hard06_gauge2layer.tex` · `hard12_zcl.tex` · `rv4061_ex_atoms-keys.tex` · `t2_mpo.tex` · `zz_frame_rotation.tex`
 - `C-policy+C-record+R-lattice+R-record`: `g06_stageA.tex`
-- `C-policy+C-record+R-record`: `atoms_test.tex` · `audit1.tex` · `audit3.tex` · `audit4.tex` · `audit_open.tex` · `boundary_test.tex` · `channel_test.tex` · `cups_edge.tex` · `cups_test.tex` · `gr_t5_zipper.tex` · `gr_t8_sum.tex` · `hard01_v3.tex` · `hard02_v2.tex` · `hard03_v3.tex` · `hard04_v3.tex` · `hard05_v2.tex` · `hard05_v4.tex` · `hard06_v2.tex` · `hard06_v3.tex` · `hard06_v4.tex` · `hard08_mpu.tex` · `hard08_v2.tex` · `hard08_v3.tex` · `hard10_v2.tex` · `hard12_v2.tex` · `hard12_v3.tex` · `iso_j.tex` · `lrbox_probe.tex` · `modes_dot_baseline.tex` · `modes_test.tex` · `p3_eq08.tex` · `p3_eq09.tex` · `p3_eq4_ortho.tex` · `p3_eq4_v2.tex` · `p3_multibond.tex` · `p3_multibond2.tex` · `part_B1.tex` · `part_B2.tex` · `part_B4.tex` · `regress_x_pbc.tex` · `rev4075_sig.tex` · `rv4061_ex_boundary-doctrine.tex` · `rv4061_ex_canonical-channel.tex` · `rv4061_ex_cups-channels.tex` · `rv4061_ex_grid-mpo-stress.tex` · `rv_probe.tex` · `stress.tex` · `t2_ared.tex` · `t2_ared_loop.tex` · `t2_mpublock.tex` · `t2_mpucond.tex` · `t2_mpuflow.tex` · `t2_olvert.tex` · `t2_purifyO.tex` · `t2_rhoR.tex` · `t2_sv17.tex` · `t2_twoshift.tex`
+- `C-policy+C-record+R-record`: `atoms_test.tex` · `audit1.tex` · `audit3.tex` · `audit4.tex` · `audit_open.tex` · `boundary_test.tex` · `channel_test.tex` · `cups_edge.tex` · `cups_test.tex` · `gr_t5_zipper.tex` · `gr_t8_sum.tex` · `hard01_v3.tex` · `hard02_v2.tex` · `hard03_v3.tex` · `hard04_v3.tex` · `hard05_v2.tex` · `hard05_v4.tex` · `hard06_v2.tex` · `hard06_v3.tex` · `hard06_v4.tex` · `hard08_mpu.tex` · `hard08_v2.tex` · `hard08_v3.tex` · `hard10_v2.tex` · `hard12_v2.tex` · `hard12_v3.tex` · `iso_j.tex` · `lrbox_probe.tex` · `modes_dot_baseline.tex` · `modes_test.tex` · `p3_eq08.tex` · `p3_eq09.tex` · `p3_eq4_ortho.tex` · `p3_eq4_v2.tex` · `p3_multibond.tex` · `p3_multibond2.tex` · `part_B1.tex` · `part_B2.tex` · `part_B4.tex` · `regress_x_pbc.tex` · `rev4075_sig.tex` · `rv4061_ex_boundary-doctrine.tex` · `rv4061_ex_canonical-channel.tex` · `rv4061_ex_cups-channels.tex` · `rv4061_ex_grid-mpo-stress.tex` · `rv_probe.tex` · `stress.tex` · `t2_ared.tex` · `t2_ared_loop.tex` · `t2_mpublock.tex` · `t2_mpucond.tex` · `t2_mpuflow.tex` · `t2_olvert.tex` · `t2_purifyO.tex` · `t2_rhoR.tex` · `t2_sv17.tex`
 - `C-policy+R-free+R-lattice+R-record`: `hard07_peps.tex`
 - `C-policy+R-free+R-record`: `gr_t6_leftinv.tex`
 - `C-policy+R-lattice+R-plane+R-record`: `plane_test.tex` · `rmpfig2_test.tex`

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -1891,3 +1891,37 @@ unchanged. M4 rises from 26.49 to 26.54 for the recovered typing. The
 physical-dimension census stays at zero.
 
 Census-correction: #5360
+
+### 2026-08-05 — the closure draws itself and a site answers the policy
+
+Two changes return the picture body to the size of the idea it draws.
+
+A flat row's traced sides now draw their closure. The rail leaves both
+ends, drops by the trace reach, and returns with the source's rounded
+corners, instead of running straight along the row it closes. Every
+figure that spelled that return by hand -- an invisible junction at each
+corner and four wires between them -- says `west=trace, east=trace`
+again, and `boundary=periodic`, which is those two words, draws a
+periodic chain as the papers draw it.
+
+A site may answer the picture's physical policy for itself. The policy
+legs a row's sites; a ring standing between tensors, or an elision,
+carries no physical index and now says `physical=none` once instead of
+forcing the picture to abandon its policy and list every port of every
+atom. `void=sealed` could not serve: a sealed site is a removed site and
+loses its bonds.
+
+The boundary-insertion word shows the size of the change: eleven lines of
+addresses and ports become three lines that name the row, its closure,
+and the two sites that carry no physical index. M4 falls from 26.54 to
+26.50 on that one case, and the corpus rewrite that follows will take it
+further. The parser gains one leaf, 226 to 227, and the kernel ledger one
+row.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:kernel-atom:physical | keep-because: the key lands with the closure fix and the first rewritten word; the rest of its consumers arrive as the corpus returns to the policy spelling it was forced to abandon; expiry 0.9 |
+
+Extension-gate: #5524
+
+Census-correction: #5492

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -212,6 +212,7 @@ kernel-\allowbreak{}atom & \texttt{size} & size-\allowbreak{}class & m & Per-\al
 kernel-\allowbreak{}atom & \texttt{label~pos} & angle & auto & Label \allowbreak{}quadrant. \\
 kernel-\allowbreak{}atom & \texttt{nudge} & pair & zero & Quarter-\allowbreak{}pitch \allowbreak{}displacement. \\
 kernel-\allowbreak{}atom & \texttt{void} & void-\allowbreak{}policy & unset & Hole \allowbreak{}or \allowbreak{}removed \allowbreak{}site. \\
+kernel-\allowbreak{}atom & \texttt{physical} & physical-\allowbreak{}policy & unset & Site's \allowbreak{}own \allowbreak{}answer \allowbreak{}to \allowbreak{}the \allowbreak{}picture's \allowbreak{}physical \allowbreak{}policy. \\
 kernel-\allowbreak{}atom & \texttt{conjugate} & flag & false & Reserved; \allowbreak{}currently \allowbreak{}inert \allowbreak{}(\allowbreak{}stored,\allowbreak{} \allowbreak{}unread). \\
 kernel-\allowbreak{}atom & \texttt{cluster} & pair & empty & Expander: \allowbreak{}RxC \allowbreak{}addressable \allowbreak{}sub-\allowbreak{}atom \allowbreak{}group. \\
 kernel-\allowbreak{}atom & \texttt{role} & semantic-\allowbreak{}role & empty & Prelude \allowbreak{}species \allowbreak{}spelling. \\

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -6,14 +6,14 @@
       "commands": 25,
       "environments": 6,
       "escape": 11,
-      "kernel": 138,
+      "kernel": 139,
       "sugar": 13
     }
   },
   "m2_parser_paths": {
     "definition": "public leaf keys installed by the TeX parsers; identity changes require an Extension-gate citation",
-    "identity_sha256": "cf87f98fe9af37edd780303541fa1b5cdc35a6a2332c8975678e24bf9fb8f22c",
-    "value": 226
+    "identity_sha256": "0fdd463b1353a358c53a6acdaa177ec7907413b4b77efb577ad2e2a6a303167d",
+    "value": 227
   },
   "m3_escape_usage": {
     "definition": "occurrences of escape-ledger spellings in the demand corpus; every occurrence names a core-grammar gap",
@@ -21,7 +21,7 @@
   },
   "m4_lines_per_case": {
     "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",
-    "value": 26.54
+    "value": 26.5
   },
   "m5_aliases": {
     "definition": "key and value alias rows plus sunset compliance; near zero at the 1.0 freeze",

--- a/tests/tenkz/kernel/regression/r_atom_physical_answer.tex
+++ b/tests/tenkz/kernel/regression/r_atom_physical_answer.tex
@@ -1,0 +1,15 @@
+% Regression: a site answers the picture's physical policy for itself.
+% The row states physical=updown; the ring and the elision carry no
+% physical index and say so once, keeping their bonds, while the third
+% site overrides the direction instead of refusing it (issue 5524).
+% The traced sides draw their returning rail (issue 5492).
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace, physical=updown]
+  \tn[skin=ring, physical=none]{X} & \tn[skin=mpo]{} &
+  \tn[skin=mpo, physical=up]{} & \tn[skin=dots, physical=none]{} &
+  \tn[skin=mpo]{}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-eq51.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-eq51.tex
@@ -8,14 +8,9 @@
 % Capabilities: kernel, boundary-insertion, closure
 \[
   \tenkzkernel
-  \begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace]
-    \tn[at=(1,1), skin=ring]{X}
-    \tn[at=(1,2), skin=mpo, ports={0:virtual, 90:physical, 180:virtual,
-      270:physical}]{}
-    \tn[at=(1,3), skin=mpo, ports={0:virtual, 90:physical, 180:virtual,
-      270:physical}]{}
-    \tn[at=(1,4), skin=dots]{}
-    \tn[at=(1,5), skin=mpo, ports={0:virtual, 90:physical, 180:virtual,
-      270:physical}]{}
+  \begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace,
+      physical=updown]
+    \tn[skin=ring, physical=none]{X} & \tn[skin=mpo]{} & \tn[skin=mpo]{} &
+    \tn[skin=dots, physical=none]{} & \tn[skin=mpo]{}
   \end{tenkz}
 \]

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -1217,25 +1217,27 @@ note = "kernel respell verified against Eq50.pdf: the one mpo atom keeps all fou
 
 [[verdict]]
 id = "rmp-workbench-iii-eq51"
-status = "cosmetic-gap"
+status = "faithful"
 pairing = "verified"
 pairing_by = "codex-pairing-sweep-2026-07-24"
 defects = []
-case_sha256 = "54a74ec6791def2aa3a12d87bc83351903ceee37b4c4978709c0b392c08c3e34"
+case_sha256 = "49eaf495e8684ff948350a6947d39cc101ba04252bb9cb46b397e0a83db2053e"
 reviewed = "2026-08-05"
-renderer = "fable-kernel-migration-2026-08-05-200dpi"
-note = "kernel respell verified against Eq51.pdf: the X ring, three mpo atoms with both physical legs, and the elision dots all match. Residue: west/east=trace renders as identified extended rail ends; the recorded closure's long return (the source's drawn racetrack) is not inked yet."
+renderer = "fable-closure-ink-2026-08-05-150dpi-was:fable-kernel-migration-2026-08-05-200dpi"
+second_viewer = "fable-closure-ink-countersign-2026-08-05-400dpi"
+note = "kernel respell verified against Eq51.pdf: the X ring, three mpo atoms with both physical legs, and the elision dots all match, and the traced sides now draw the source's returning rail below the word. The row states its physical policy once and the ring and elision answer it with physical=none, so the case says what the picture is in three lines."
 
 [[verdict]]
 id = "rmp-workbench-iii-eq52"
-status = "cosmetic-gap"
+status = "faithful"
 pairing = "verified"
 pairing_by = "codex-pairing-sweep-2026-07-24"
 defects = []
 case_sha256 = "e4e66c8de80547dbc86c05ed1ed0194a3ca75459847de16ea73157399a9cf83e"
 reviewed = "2026-08-05"
-renderer = "fable-kernel-migration-2026-08-05-200dpi"
-note = "kernel respell verified against Eq52.pdf: the X ring plus one mpo atom with both physical indices open and the map named beside. Residue: the traced sides render as identified extended ends, not the source's drawn trace rectangle (same closure-ink gap as eq51)."
+renderer = "fable-closure-ink-2026-08-05-150dpi-was:fable-kernel-migration-2026-08-05-200dpi"
+second_viewer = "fable-closure-ink-countersign-2026-08-05-400dpi"
+note = "kernel respell verified against Eq52.pdf: the X ring plus one mpo atom with both physical indices open and the map named beside, with the traced sides drawing the source's returning rail."
 
 [[verdict]]
 id = "rmp-workbench-iii-diagram-one"

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1138,6 +1138,11 @@
 \__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { nudge } { nudge }
 \__tenkz_kernel_choice:nnnn { tenkz-kernel-atom } { void }
   { open, sealed } { void }
+% A site may answer the picture's physical policy for itself: the policy
+% states what a row's sites expose, and an atom that carries no physical
+% index says so once instead of listing the ports it does carry.
+\__tenkz_kernel_choice:nnnn { tenkz-kernel-atom } { physical }
+  { up, down, updown, none } { physical }
 \__tenkz_kernel_flag:nnn    { tenkz-kernel-atom } { conjugate } { conjugate }
 \__tenkz_kernel_unknown:nn  { tenkz-kernel-atom } { atom }
 \keys_define:nn { tenkz-kernel-atom }
@@ -1335,6 +1340,10 @@
           {surface} {#1} {torus} {picture}
       }
   }
+\tl_new:N \l__tenkz_kernel_atom_phys_tl
+\cs_new_protected:Npn \__tenkz_kernel_atom_physical:nN #1#2
+  { \__tenkz_model_get:nnN {#1} {physical} #2 }
+
 \cs_new_protected:Npn \__tenkz_kernel_desugar_physical:n #1
   {
     \__tenkz_kernel_sugar:n {physical}
@@ -3332,6 +3341,7 @@
       { \__tenkz_model_complete:nnn {#1} {physical} {#2} }
   }
 
+\cs_generate_variant:Nn \__tenkz_kernel_set_atom_physical:nn { ne }
 \cs_new_protected:Npn \__tenkz_kernel_closures:
   {
     \__tenkz_kernel_cell_closures:
@@ -3393,8 +3403,21 @@
             \tl_set_eq:NN \l_tmpa_tl \l__tenkz_kernel_scratch_tl
             \__tenkz_model_map_ids:nn {atom}
               {
-                \__tenkz_kernel_set_atom_physical:nn
-                  {##1} { \tl_use:N \l_tmpa_tl }
+                \__tenkz_kernel_atom_physical:nN
+                  {##1} \l__tenkz_kernel_atom_phys_tl
+                \quark_if_no_value:NTF \l__tenkz_kernel_atom_phys_tl
+                  {
+                    \__tenkz_kernel_set_atom_physical:nn
+                      {##1} { \tl_use:N \l_tmpa_tl }
+                  }
+                  {
+                    \str_if_eq:VnF \l__tenkz_kernel_atom_phys_tl {none}
+                      {
+                        \__tenkz_kernel_set_atom_physical:ne
+                          {##1}
+                          { \tl_use:N \l__tenkz_kernel_atom_phys_tl }
+                      }
+                  }
               }
           }
       }
@@ -10176,11 +10199,48 @@
                   }
               }
               {
+                % A flat row closes the way the sources draw it: the rail
+                % leaves both ends, drops below the row by the trace reach,
+                % and runs back.  Joining the two reach points directly
+                % would lay the closure along the row it closes.
+                \fp_set:Nn \l__tenkz_kernel_r_reach_fp
+                  { \__tenkz_metric_ratio:n {pairtracereach} }
                 \__tenkz_kernel_r_wire_stroke:nn { bond }
                   {
                     \__tenkz_kernel_r_pair:nn
                       { \l__tenkz_kernel_r_x_fp }
                       { \l__tenkz_kernel_r_y_fp }
+                    --
+                    \__tenkz_kernel_r_pair:nn
+                      { \l__tenkz_kernel_r_x_fp }
+                      {
+                        \l__tenkz_kernel_r_y_fp
+                        - \l__tenkz_kernel_r_reach_fp / 2
+                      }
+                    arc
+                      [
+                        start~angle = 180 , end~angle = 270 ,
+                        radius =
+                          \__tenkz_kernel_r_pt:n
+                            { \l__tenkz_kernel_r_reach_fp / 2 }
+                      ]
+                    --
+                    \__tenkz_kernel_r_pair:nn
+                      {
+                        \l__tenkz_kernel_r_xb_fp
+                        - \l__tenkz_kernel_r_reach_fp / 2
+                      }
+                      {
+                        \l__tenkz_kernel_r_yb_fp
+                        - \l__tenkz_kernel_r_reach_fp
+                      }
+                    arc
+                      [
+                        start~angle = 270 , end~angle = 360 ,
+                        radius =
+                          \__tenkz_kernel_r_pt:n
+                            { \l__tenkz_kernel_r_reach_fp / 2 }
+                      ]
                     --
                     \__tenkz_kernel_r_pair:nn
                       { \l__tenkz_kernel_r_xb_fp }

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -302,6 +302,7 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{label~pos}{angle}{auto}{kernel}{Label quadrant.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{nudge}{pair}{zero}{kernel}{Quarter-pitch displacement.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{void}{void-policy}{unset}{kernel}{Hole or removed site.}
+\__tenkz_language_registry_key:nnnnnn {kernel-atom}{physical}{physical-policy}{unset}{kernel}{Site's own answer to the picture's physical policy.}
 % Issue 5383: stored but never read by ink passes or the signature fold.
 % Marked reserved until the directed-signatures design (issue 4162)
 % decides whether duality rides dir= or a real glyph flip is implemented.


### PR DESCRIPTION
Two design fixes that return a picture body to the size of the idea it draws. Together they are why the migrated figures read long.

## The closure draws itself

A flat row's traced sides drew a straight rail *along* the row they close, so a periodic word looked like an open word with longer ends. Every such figure in the corpus therefore spelled its return by hand: an invisible junction at each corner and four wires between them, fifteen-odd lines for one idea. The closure now leaves both ends, drops by the existing trace reach, and returns with the rounded corners the sources draw. `boundary=periodic` is exactly `west=trace, east=trace`, so a periodic chain now draws correctly with no other words at all. Closes LionSR/tenkz#146.

## A site answers the policy

A picture's `physical=` policy legged every site in the row, so a row holding a gauge ring or an elision had to abandon the policy entirely and list every port of every atom. A site now answers for itself — `physical=none` to carry no physical index while keeping its bonds, or a direction to override. `void=sealed` could not serve: a sealed site is a *removed* site and loses its bonds, which breaks the row. One new leaf (226 → 227) under Extension-gate LionSR/tenkz#153.

## What it buys

`rmp-workbench-iii-eq51`, the boundary-insertion word, stated five atoms in eleven lines of addresses and ports. It now reads:

```latex
\begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace, physical=updown]
  \tn[skin=ring, physical=none]{X} & \tn[skin=mpo]{} & \tn[skin=mpo]{} &
  \tn[skin=dots, physical=none]{} & \tn[skin=mpo]{}
\end{tenkz}
```

Rendered at 400 dpi beside `Eq51.pdf`: the same drawing, now including the returning rail the previous verdict recorded as missing. eq51 and eq52 rise from `cosmetic-gap` to `faithful` with a countersign; the closure residue they recorded is gone.

## Test plan

- `tenkz_kernel_probes.sh`: 108 review regressions hold, record streams and pixels byte-identical; new fixture `r_atom_physical_answer` exercises inherit, `none`, and override with the traced closure.
- `tenkz_rmp.py check --id` passes for all five trace-using cases and the rewritten eq51.
- kernel audit, language registry (228 records), shrink suite, and `gate --base-ref origin/main` pass; ledger entry carries the Extension-gate and census citations.

Follow-up: the rest of the corpus returns to the policy spelling, and the two blueprint figures held back in LionSR/TNLean#5522 unblock once the on-wire anchor (#5493) lands.