### PR TITLE
fix(tenkz): let a label carry phantom and accent spellings

### DIFF
--- a/tests/tenkz/kernel/regression/r_label_opaque_math.tex
+++ b/tests/tenkz/kernel/regression/r_label_opaque_math.tex
@@ -1,0 +1,24 @@
+% Regression: \hphantom, \vphantom, and \bar must reach the node as opaque
+% text.  The label completion fully expanded the field; \hphantom/\vphantom
+% carry an internal \iffalse..\fi that full expansion tears from its match
+% (Incomplete \iffalse), and \bar's math-accent expansion ran before the
+% node ever entered math mode.  Atom labels take the bare command -- the
+% kernel supplies its own math shift; mark labels take no auto-wrap, so the
+% author supplies theirs (issue 5481).
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=3, bonds=none]
+  \tn[at=(1,1)]{\hphantom{x}A}
+  \tn[at=(1,2)]{\vphantom{x}A}
+  \tn[at=(1,3)]{\bar A}
+\end{tenkz}
+\quad
+\begin{tenkz}[rows={wire}, cols=3, bonds=none]
+  \tn[at=(1,1), name=p]{A} \tn[at=(1,2), name=q]{A} \tn[at=(1,3), name=r]{A}
+  \tnmark[form=label, label pos=n]{p}{$\hphantom{x}A$}
+  \tnmark[form=label, label pos=n]{q}{$\vphantom{x}A$}
+  \tnmark[form=label, label pos=n]{r}{$\bar A$}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1757,8 +1757,13 @@
     \__tenkz_model_record_atom:n { kind = tn }
     \prop_clear:N \l__tenkz_kernel_stage_prop
     \__tenkz_kernel_keys:nn { tenkz-kernel-atom } {#1}
+    % A label is opaque text: \hphantom, \vphantom, and math accents like
+    % \bar embed their own conditional/box primitives, so a full expansion
+    % of the label content orphans an \iffalse from its \fi (issue 5481).
+    % The raw completion stores it unexpanded, as the model already does
+    % for the equally opaque `ports` field in \__tenkz_kernel_commit:.
     \tl_if_blank:nF {#2}
-      { \__tenkz_model_complete:nnn { \l__tenkz_model_last_tl } {label} {#2} }
+      { \__tenkz_model_complete_raw:nnn { \l__tenkz_model_last_tl } {label} {#2} }
     \prop_get:NnN \l__tenkz_kernel_stage_prop {at} \l__tenkz_kernel_scratch_tl
     \quark_if_no_value:NTF \l__tenkz_kernel_scratch_tl
       {
@@ -2260,8 +2265,9 @@
     \prop_clear:N \l__tenkz_kernel_stage_prop
     \__tenkz_kernel_keys:nn { tenkz-kernel-mark } {#1}
     \__tenkz_model_complete:nnn { \l__tenkz_model_last_tl } {target} {#2}
+    % Opaque text, per the \tn label above (issue 5481): raw completion.
     \tl_if_blank:nF {#3}
-      { \__tenkz_model_complete:nnn { \l__tenkz_model_last_tl } {label} {#3} }
+      { \__tenkz_model_complete_raw:nnn { \l__tenkz_model_last_tl } {label} {#3} }
     \__tenkz_kernel_commit:
     \ignorespaces
   }


### PR DESCRIPTION
## Reproduction

A minimal standalone (`\documentclass{standalone}` + `\usepackage{tenkz}` + `\tenkzkernel`) with:

```latex
\begin{tenkz}[rows={wire}, cols=1, bonds=none]
  \tn[at=(1,1)]{$\hphantom{x}A$}
\end{tenkz}
```

compiled with `TEXINPUTS=<worktree>/tex/tenkz//: xelatex -interaction=nonstopmode` fails with:

```
! Incomplete \iffalse; all text was ignored after line 6.
```

Same for `\vphantom`. `\bar` crashes differently (a cascade of "Missing $ inserted" / "Extra }" errors) when the label is fed through the same path.

## Cause

`\__tenkz_kernel_tn:nn` and `\__tenkz_kernel_tnmark:nnn` (`tex/tenkz/tenkz-kernel.code.tex`) completed the atom/mark `label` field through `\__tenkz_model_complete:nnn`, which fully expands the field via `\prop_put:Nee`. `\hphantom`/`\vphantom` expand to a body carrying an internal `\iffalse..\fi` (via `\DeclareRobustCommand`'s `\protect` indirection, which is not honored by e-TeX's `\expanded` primitive), so full expansion tears the `\iffalse` from its matching `\fi`. `\bar` fully-expands to `\mathaccent "7016\relax {A}` ahead of the math shift that gives it meaning, corrupting the node's mode nesting once the label is later typeset.

The fix routes both completions through the existing `\__tenkz_model_complete_raw:nnn` door — the same one the model already uses for the equally opaque `ports` field — so the label reaches the node unexpanded, as opaque text, per the audited-label doctrine.

## Validation

- Reproduced the crash on unpatched `origin/main`, confirmed the fix resolves it (all three spellings compile and render with the label visible and correctly placed, verified visually).
- Reverted the kernel fix with the new regression fixture in place: fixture failed as expected; restored the fix: fixture passes.
- `bash scripts/tenkz_kernel_probes.sh --check` — PASS: 109 review regressions hold; 9 sugar spellings byte-identical; 12 kernel record streams byte-identical; kernel pixels byte-identical (no snapshot needed — the new fixture sits outside the fixed golden set).
- `python3 scripts/test_tenkz_kernel_audit.py` — PASS.
- `python3 scripts/test_tenkz_shrink.py` — all PASS.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — PASS: census stable at 200 and all 146 flags carry verdicts.

## Regression

`tests/tenkz/kernel/regression/r_label_opaque_math.tex` covers `\hphantom`, `\vphantom`, and `\bar` in both an atom label (kernel auto-wraps in math) and a mark label (author supplies the math shift), per the wave-1B follow-up comment on the issue.

Closes LionSR/tenkz#143