### PR TITLE
fix(tests/tenkz/rmp): type the isometry's physical bond as physical

### DIFF
--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-rfp-isometry.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-rfp-isometry.tex
@@ -19,9 +19,9 @@
   % below it is the summed physical index j.
   \begin{tenkz}[rows={wire,wire}, cols=2, bonds=none]
     \tn[at=(1,1), skin=pill, wide=2, name=U,
-      ports={90@1:physical:$i_1$, 90@2:physical:$i_2$, 270:virtual}]{U}
+      ports={90@1:physical:$i_1$, 90@2:physical:$i_2$, 270:physical}]{U}
     \tn[at=(2,1), skin=box, wide=2, name=A,
-      ports={180:virtual, 0:virtual, 90:virtual}]{A}
+      ports={180:virtual, 0:virtual, 90:physical}]{A}
     \tnwire{U.270}{A.90}
   \end{tenkz}
 \]

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -359,11 +359,11 @@ status = "faithful"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "fc6fb70ed7a7f5ca5fa58660d8be231b3c145d280d29c8d2f56585dabcac53b6"
+case_sha256 = "744f5d11f8528f89f9526555ccd7976078fcda32903f7e45e5c7c785ae3162d0"
 reviewed = "2026-08-05"
 renderer = "claude-kernel-source-review-2026-08-05-200dpi"
-second_viewer = "fable-vision-countersign-2026-08-05-200dpi"
-note = "Kernel migration, Fable-countersigned against the author panel: two open-physical A boxes bonded on the left, and U's two labelled outputs over the single blocked bond into the wide pill on the right, matching the source's rounded U glyph (stock pill skin, PR #5480, issue #5363); the wide house A under U versus the source's site-sized A is house styling (the bar)."
+second_viewer = "claude-issue-5503-port-fix-countersign-2026-08-05-200dpi"
+note = "Issue #5503: U.270 and A.90 retyped virtual to physical -- the bond carries the summed physical index j (A^{i_1} A^{i_2} = sum_j U_{(i_1 i_2),j} A^j), matching the author source's identical vertical-stub style for that bond and the LHS's unambiguous physical legs (ImagesReview Section II.tex lines 693-699), and the sibling convention in rmp-ii-ortho-left/right (270:physical -> 90:physical for a contracted physical index). Render at 200dpi is pixel-identical to the pre-fix panel, since physical leg/.style={bond} in tenkz-core.code.tex aliases the two wire styles for a connected bond; the fix is a semantic-typing correction confirmed against the author panel fig2_fig2-pepe_AAeqUA.pdf, not a visual change. Prior note: Kernel migration, Fable-countersigned against the author panel: two open-physical A boxes bonded on the left, and U's two labelled outputs over the single blocked bond into the wide pill on the right, matching the source's rounded U glyph (stock pill skin, PR #5480, issue #5363); the wide house A under U versus the source's site-sized A is house styling (the bar)."
 
 [[verdict]]
 id = "rmp-ii-zcl-mpdo"


### PR DESCRIPTION
## Summary

Issue LionSR/tenkz#149: the U-A bond in `rmp-ii-rfp-isometry` represents the summed physical index `j` in `A^{i_1} A^{i_2} = sum_j U_{(i_1 i_2),j} A^j`, but both `U.270` and `A.90` were declared `virtual`. Retyped both ports to `physical`.

## Source evidence

- **Author source** (`tex/RMP_TIKZ_SOURCE_CODE/ImagesReview Section II/ImagesReview Section II.tex`, lines 685-701, "AA=UA" block): the U-A vertical bond (`\draw (1,0.2)-- (1,0.4);`) is drawn in the exact same short-vertical-stub style as the LHS's two open physical legs (`\draw (-1,0.2)-- (-1,0.4);` and `\draw (-0.5,0.2)-- (-0.5,0.4);`), which are unambiguously the physical outputs `i_1`, `i_2` of the two `A` tensors. The bond is not styled like the horizontal virtual chain bonds (`\draw (-1.4,0)-- (-0.1,0);` and `\draw (0.6,0)-- (1.4,0);`).
- **Author figure** `Papers/2011.12127/fig2_fig2-pepe_AAeqUA.pdf` confirms this visually: a single vertical bond from `A` up into `U`, matching the physical-leg stub geometry used elsewhere in the same panel.
- **Sibling convention**: `rmp-ii-ortho-left.tex` and `rmp-ii-ortho-right.tex` use the identical pattern (`270:physical -> 90:physical`) for a contracted physical index between two vertically stacked tensors.
- The case's own in-source comment already read "the single vertical U-A bond below it is the summed physical index j" -- the comment and the port types disagreed.

Mathematically, `j` indexes the site tensor `A^j` on the RHS -- it is a physical (site) degree of freedom, summed over, not a virtual chain bond -- matching this repo's stated rule ("An index that carries a physical (site) degree of freedom is physical").

## Render comparison

Rendered the case at 200dpi via a scratch standalone (`\documentclass[border=8pt,varwidth=270mm]{standalone}` + `amsmath,amssymb,mathtools` + `tenkz`) before and after the fix, and diffed against `fig2_fig2-pepe_AAeqUA.pdf` at the same resolution.

- Before and after renders are **pixel-identical** (confirmed with `PIL.ImageChops.difference` -> empty bbox). This is expected: `tex/tenkz/tenkz-core.code.tex:247` defines `physical leg/.style={bond}`, so a *connected* wire's stroke (drawn via `\tnwire`) is visually aliased to the ordinary bond style regardless of port type in the kernel tier. The fix corrects semantic port typing consumed by downstream diagnostics/semantic analysis, not the drawing itself.
- Both renders match the author panel's geometry: `U` above `A` joined by a single vertical bond, `U`'s two labelled outputs `i_1, i_2` open above, and the LHS pair of `A` boxes on a horizontal virtual bond with their own open physical legs.

## Verdict update

- `case_sha256` re-pinned to the post-fix hash (`744f5d11f8528f89f9526555ccd7976078fcda32903f7e45e5c7c785ae3162d0`).
- `note` records the retype, the source evidence, and that the render is unchanged.
- `second_viewer` tag added: `claude-issue-5503-port-fix-countersign-2026-08-05-200dpi`.

## Test plan

- [x] `python3 scripts/tenkz_rmp.py check --id rmp-ii-rfp-isometry` -> PASS
- [x] `python3 scripts/tenkz_rmp.py check --section section-ii` -> PASS (48 targets)
- [x] `python3 scripts/test_tenkz_corpus_provenance.py` -> PASS
- [x] `python3 scripts/test_tenkz_shrink.py` -> PASS
- [x] `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` -> PASS (census stable at 200, no meter moved, no `SHRINK.md`/`census-baseline.json` update needed)

Closes LionSR/tenkz#149