### PR TITLE
feat(MPDO): prove the Lemma C.5 Case-I overlap formula

### DIFF
--- a/TNLean/Algebra/TraceReindex.lean
+++ b/TNLean/Algebra/TraceReindex.lean
@@ -23,4 +23,17 @@ theorem trace_reindex {R m n : Type*} [AddCommMonoid R] [Fintype m] [Fintype n]
   simpa [trace, reindex_apply] using
     Fintype.sum_equiv e.symm _ _ (by intro; simp)
 
+/-- The trace of `Y * Y` equals the trace of `X * X` whenever `Y` is obtained from `X`
+by simultaneously reindexing the rows and columns. Combines `trace_reindex` with the
+multiplicativity of `reindex e e` (as `reindexRingEquiv`). -/
+theorem trace_mul_self_eq_of_reindex_eq {R m n : Type*} [NonAssocSemiring R] [Fintype m]
+    [Fintype n] (e : m ≃ n) (X : Matrix m m R)
+    (Y : Matrix n n R) (hXY : Matrix.reindex e e X = Y) :
+    Matrix.trace (Y * Y) = Matrix.trace (X * X) := by
+  classical
+  rw [← hXY, ← Matrix.trace_reindex e (X * X)]
+  congr 1
+  rw [← Matrix.coe_reindexRingEquiv R e]
+  exact (map_mul (Matrix.reindexRingEquiv R e) X X).symm
+
 end Matrix

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -44,7 +44,7 @@ proved:
 * the overlap formula `mpvOverlap = Complex.ofReal(tr(S^N))`
   (`mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow`).
 
-The overlap formula assembles the doubled-index self-overlap identity
+The overlap formula combines the doubled-index self-overlap identity
 (`Purity`) with the physical-sector product realization
 (`PhysicalSectorProductRealization`) via a physical basis change with
 `Uᴴ * U = 1` (`trace_mpo_conjugatePhysical_mul_self`), the cyclic trace factorization

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -654,8 +654,9 @@ theorem sum_prod_traceSq_eq_sum_active
 /-- **The overlap formula.** The doubled-index MPS self-overlap equals the real cast of
 `tr(S^N)`, where `S` is the active-sector trace-squared matrix.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499; self-overlap
-formulation at lines 1080--1100. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499; the self-overlap
+formulation `<V_alpha|V_alpha> = tr(E_alpha^N)` is in Appendix A, proof of Lemma
+`equalMPS`, line 1099. -/
 theorem mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow
     (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -521,8 +521,8 @@ end cyclicTrace
 section overlapFormula
 
 /-- The **sitewise product matrix** `W σ σ' = ∏ n, U (σ n) (σ' n)` used to
-congruence-conjugate the MPO family in `mpo_conjugatePhysical_eq` is unitary whenever
-`U` is.
+congruence-conjugate the MPO family in `mpo_conjugatePhysical_eq` satisfies `Wᴴ * W = 1`
+whenever `Uᴴ * U = 1`.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1434--1448 (the basis change defining
 `σ_tilde`). -/
@@ -557,7 +557,8 @@ theorem sitewise_prod_conjTranspose_mul_self {N : ℕ} (U : Matrix (Fin d) (Fin 
       (fun n x => star (U x (σ n)) * U x (τ n))]
     simp only [Fintype.piFinset_univ]
 
-/-- The trace of the doubled MPO is invariant under a physical unitary basis change.
+/-- The trace of the doubled MPO is invariant under a physical basis change `U` with
+`Uᴴ * U = 1` (an isometry; a unitary in the square case, e.g. `F.physicalIsometry`).
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1434--1448. -/
 theorem trace_mpo_conjugatePhysical_mul_self

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -46,8 +46,8 @@ proved:
 
 The overlap formula assembles the doubled-index self-overlap identity
 (`Purity`) with the physical-sector product realization
-(`PhysicalSectorProductRealization`) via a physical unitary basis change
-(`trace_mpo_conjugatePhysical_mul_self`), the cyclic trace factorization
+(`PhysicalSectorProductRealization`) via a physical basis change with
+`Uᴴ * U = 1` (`trace_mpo_conjugatePhysical_mul_self`), the cyclic trace factorization
 (`CyclicActiveTraceProductIdentities`), the reduction from the full sector
 index to the active sector (`sum_prod_traceSq_eq_sum_active`), and the
 cyclic-product expansion of `tr(S^N)` (`trace_pow_eq_sum_cyclic_product`).

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -31,33 +31,29 @@ Case-I content carried here is the C.4–C.5 argument that the active-sector
 trace matrix `T` satisfies `T² = T³`, is primitive, and every entry of `T²`
 is positive.
 
-Two further pieces remain to complete the Case-I argument that the
+One further piece remains to complete the Case-I argument that the
 active sector set reduces to a singleton (`card(ActiveSector p) = 1`), from
 which the Case-I relations `T² = T` and `Q(1−LQ)L = 0` follow; these
 relations are the Case-I input to the proof of Lemma `SALZCL`
 (arXiv:1606.00608, Appendix C.2, lines 1473--1499), not the lemma's
-headline statement.  The deferred pieces are documented at the end of the
-file:
+headline statement.  Two pieces feeding that singleton assembly are now
+proved:
 
 * trace similarity `tr(S_hat^N) = tr(S^N)` under diagonal scaling
-  (proved: `trace_pow_similarity_diagonal`),
-* the overlap formula `mpvOverlap = Complex.ofReal(tr(S^N))`.
+  (`trace_pow_similarity_diagonal`),
+* the overlap formula `mpvOverlap = Complex.ofReal(tr(S^N))`
+  (`mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow`).
 
-For the overlap formula, the elementary combinatorial machinery is now
-available (`pow_apply_eq_sum_path_indicator`,
-`trace_pow_eq_sum_cyclic_product`), turning `tr(S^N)` into a sum over
-cyclic labelings `k : Fin N → ActiveSector p`, in the shape needed to match
-`trace_cyclicNeighboringProduct_sq_eq_prod_trace_sq`
-(`CyclicActiveTraceProductIdentities`).  Assembling the full formula still
-requires reconciling the active-sector-restricted index type
-`F.ActiveSector p` used by `activeSectorTraceSqMatrix` with the
-full-sector index type `Fin F.sectorCount` that
-`PhysicalSectorFactorization.cyclicNeighboringProduct` and
-`reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal` range over; this
-reconciliation (via `hinactive`, which forces the contribution of any
-non-active sector to vanish) is not yet formalized.
+The overlap formula assembles the doubled-index self-overlap identity
+(`Purity`) with the physical-sector product realization
+(`PhysicalSectorProductRealization`) via a physical unitary basis change
+(`trace_mpo_conjugatePhysical_mul_self`), the cyclic trace factorization
+(`CyclicActiveTraceProductIdentities`), the reduction from the full sector
+index to the active sector (`sum_prod_traceSq_eq_sum_active`), and the
+cyclic-product expansion of `tr(S^N)` (`trace_pow_eq_sum_cyclic_product`).
 
-The route to assemble them is sketched in the paper-gap note
+Only the singleton-sector assembly itself remains open.  The route is
+sketched in the paper-gap note
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 ## Main declarations
@@ -74,6 +70,10 @@ The route to assemble them is sketched in the paper-gap note
   sum over indicator-weighted length-`N` walks from `a` to `b`
 * `trace_pow_eq_sum_cyclic_product`: `tr(S^N)` as a sum over cyclic
   products indexed by labelings `k : Fin N → n`
+* `sum_prod_traceSq_eq_sum_active`: the full-sector cyclic-product sum
+  reduces to the active-sector sum
+* `mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow`:
+  **the overlap formula** `mpvOverlap = Complex.ofReal(tr(S^N))`
 
 ## Source fidelity
 
@@ -517,6 +517,194 @@ theorem trace_pow_eq_sum_cyclic_product (S : Matrix n n R) {N : ℕ} [NeZero N] 
       exact congrArg v (Fin.castSucc_succ j).symm
 
 end cyclicTrace
+
+section overlapFormula
+
+/-- The **sitewise product matrix** `W σ σ' = ∏ n, U (σ n) (σ' n)` used to
+congruence-conjugate the MPO family in `mpo_conjugatePhysical_eq` is unitary whenever
+`U` is.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1434--1448 (the basis change defining
+`σ_tilde`). -/
+theorem sitewise_prod_conjTranspose_mul_self {N : ℕ} (U : Matrix (Fin d) (Fin d) ℂ)
+    (hU : Uᴴ * U = 1) :
+    (Matrix.of (fun σ σ' : Fin N → Fin d => ∏ n, U (σ n) (σ' n)))ᴴ *
+      (Matrix.of (fun σ σ' : Fin N → Fin d => ∏ n, U (σ n) (σ' n))) = 1 := by
+  ext σ τ
+  change (∑ σ' : Fin N → Fin d,
+      star (∏ n, U (σ' n) (σ n)) * (∏ n, U (σ' n) (τ n))) = (1 : Matrix _ _ ℂ) σ τ
+  have hstep1 : ∀ σ' : Fin N → Fin d,
+      star (∏ n, U (σ' n) (σ n)) * (∏ n, U (σ' n) (τ n)) =
+        ∏ n, (star (U (σ' n) (σ n)) * U (σ' n) (τ n)) := by
+    intro σ'
+    rw [star_prod, Finset.prod_mul_distrib]
+  simp_rw [hstep1]
+  rw [show (∑ σ' : Fin N → Fin d, ∏ n : Fin N,
+      (star (U (σ' n) (σ n)) * U (σ' n) (τ n))) =
+    ∏ n : Fin N, ∑ x : Fin d, (star (U x (σ n)) * U x (τ n)) from ?_]
+  · have hinner : ∀ n : Fin N, (∑ x : Fin d, star (U x (σ n)) * U x (τ n)) =
+        if σ n = τ n then (1 : ℂ) else 0 := by
+      intro n
+      have : (∑ x : Fin d, star (U x (σ n)) * U x (τ n)) = (Uᴴ * U) (σ n) (τ n) := by
+        simp only [Matrix.mul_apply, Matrix.conjTranspose_apply]
+      rw [this, hU, Matrix.one_apply]
+    simp_rw [hinner]
+    by_cases hστ : σ = τ
+    · simp [hστ, Matrix.one_apply]
+    · obtain ⟨n, hn⟩ := Function.ne_iff.mp hστ
+      rw [Finset.prod_eq_zero (Finset.mem_univ n) (if_neg hn), Matrix.one_apply, if_neg hστ]
+  · rw [Finset.prod_univ_sum (fun _ : Fin N => (Finset.univ : Finset (Fin d)))
+      (fun n x => star (U x (σ n)) * U x (τ n))]
+    simp only [Fintype.piFinset_univ]
+
+/-- The trace of the doubled MPO is invariant under a physical unitary basis change.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1434--1448. -/
+theorem trace_mpo_conjugatePhysical_mul_self
+    (U : Matrix (Fin d) (Fin d) ℂ) (hU : Uᴴ * U = 1) {N : ℕ} [NeZero N] :
+    Matrix.trace (mpo (conjugatePhysical K U) N * mpo (conjugatePhysical K U) N) =
+      Matrix.trace (mpo K N * mpo K N) := by
+  set W : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ :=
+    Matrix.of (fun σ σ' : Fin N → Fin d => ∏ n, U (σ n) (σ' n)) with hWdef
+  have hW : Wᴴ * W = 1 := sitewise_prod_conjTranspose_mul_self U hU
+  rw [mpo_conjugatePhysical_eq]
+  rw [← hWdef]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc Wᴴ W (mpo K N * Wᴴ), hW, Matrix.one_mul]
+  rw [Matrix.trace_mul_comm]
+  simp only [Matrix.mul_assoc]
+  rw [hW, Matrix.mul_one]
+
+/-- A neighboring operator vanishes whenever its target sector is inactive, since the
+left sector tensor of an inactive sector vanishes identically.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499. -/
+theorem neighboringOperator_eq_zero_of_inactive_right
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    (k h : Fin F.sectorCount) (hh : p h = 0) :
+    F.neighboringOperator k h = 0 := by
+  ext x y
+  simp [PhysicalSectorFactorization.neighboringOperator, hinactive h hh]
+
+/-- The cyclic product of neighboring-operator trace-squares vanishes as soon as one
+sector along the cycle is inactive: that sector is the target of some edge in the cycle,
+whose neighboring operator (and hence trace-square) vanishes by
+`neighboringOperator_eq_zero_of_inactive_right`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499. -/
+theorem prod_traceSq_eq_zero_of_not_forall_active
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    {N : ℕ} [NeZero N] (k : Fin N → Fin F.sectorCount)
+    (hk : ¬ ∀ i, p (k i) ≠ 0) :
+    ∏ i : Fin N, Matrix.trace ((F.neighboringOperator (k i) (k (i + 1))) ^ 2) = 0 := by
+  rw [not_forall] at hk
+  obtain ⟨j, hj⟩ := hk
+  rw [not_ne_iff] at hj
+  apply Finset.prod_eq_zero (Finset.mem_univ (j - 1))
+  rw [sub_add_cancel j 1,
+    neighboringOperator_eq_zero_of_inactive_right K F p hinactive (k (j - 1)) (k j) hj]
+  simp
+
+/-- **Reduction to the active sector.** The full-sector sum of cyclic trace-square
+products equals the sum restricted to cyclic labelings by the active sector, since every
+term with an inactive label vanishes.
+
+This is the reconciliation between the active-sector-restricted index type
+`F.ActiveSector p` and the full-sector index type `Fin F.sectorCount` needed to
+assemble the overlap formula.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499. -/
+theorem sum_prod_traceSq_eq_sum_active
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    {N : ℕ} [NeZero N] :
+    (∑ k : Fin N → Fin F.sectorCount, ∏ i : Fin N,
+        Matrix.trace ((F.neighboringOperator (k i) (k (i + 1))) ^ 2)) =
+      ∑ k : Fin N → F.ActiveSector p, ∏ i : Fin N,
+        Matrix.trace ((F.neighboringOperator (k i : Fin F.sectorCount)
+          (k (i + 1) : Fin F.sectorCount)) ^ 2) := by
+  rw [show (∑ k : Fin N → Fin F.sectorCount, ∏ i : Fin N,
+      Matrix.trace ((F.neighboringOperator (k i) (k (i + 1))) ^ 2)) =
+    ∑ k ∈ Finset.univ.filter (fun k : Fin N → Fin F.sectorCount => ∀ i, p (k i) ≠ 0),
+      ∏ i : Fin N, Matrix.trace ((F.neighboringOperator (k i) (k (i + 1))) ^ 2) from ?_]
+  · refine Finset.sum_bij'
+      (fun k hk i => (⟨k i, by
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hk
+        exact hk i⟩ : F.ActiveSector p))
+      (fun k' _ i => (k' i : Fin F.sectorCount))
+      ?hi ?hj ?left_inv ?right_inv ?h
+    case hi => intro k _; exact Finset.mem_univ _
+    case hj =>
+      intro k' _
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      exact fun i => (k' i).2
+    case left_inv => intro k _; rfl
+    case right_inv => intro k' _; rfl
+    case h => intro k _; rfl
+  · rw [Finset.sum_filter]
+    apply Finset.sum_congr rfl
+    intro k _
+    by_cases hk : ∀ i, p (k i) ≠ 0
+    · simp [hk]
+    · rw [if_neg hk, prod_traceSq_eq_zero_of_not_forall_active K F p hinactive k hk]
+
+/-- **The overlap formula.** The doubled-index MPS self-overlap equals the real cast of
+`tr(S^N)`, where `S` is the active-sector trace-squared matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499; self-overlap
+formulation at lines 1080--1100. -/
+theorem mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    {N : ℕ} [NeZero N] :
+    MPSTensor.mpvOverlap K.toMPSTensor K.toMPSTensor N =
+      Complex.ofReal (Matrix.trace ((activeSectorTraceSqMatrix K F p) ^ N)) := by
+  have hK : IsMPDO K := F.isMPDO_of_neighboringOperator_pos hpos
+  rw [mpvOverlap_toMPSTensor_self_eq_trace_sq K hK (NeZero.pos N)]
+  rw [← trace_mpo_conjugatePhysical_mul_self K F.physicalIsometry
+    F.physicalIsometry_isometry (N := N)]
+  rw [← Matrix.trace_mul_self_eq_of_reindex_eq (F.physicalConfigEquiv N) _ _
+    (F.mpo_sectorCoordinateTensor_eq_reindex_conjugatePhysical N).symm]
+  rw [← Matrix.trace_mul_self_eq_of_reindex_eq (F.sectorCoordinateChainEquiv N) _ _
+    (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal (N := N))]
+  rw [show Matrix.blockDiagonal' (fun k => F.cyclicNeighboringProduct k) *
+      Matrix.blockDiagonal' (fun k => F.cyclicNeighboringProduct k) =
+      Matrix.blockDiagonal' (fun k => (F.cyclicNeighboringProduct k) ^ 2) from ?_]
+  · rw [Matrix.trace_blockDiagonal']
+    simp_rw [F.trace_cyclicNeighboringProduct_sq_eq_prod_trace_sq]
+    rw [sum_prod_traceSq_eq_sum_active K F p hinactive]
+    have hcast : ∀ k : Fin N → F.ActiveSector p, (∏ i : Fin N,
+        Matrix.trace ((F.neighboringOperator (k i : Fin F.sectorCount)
+          (k (i + 1) : Fin F.sectorCount)) ^ 2)) =
+        ((∏ i : Fin N, activeSectorTraceSqMatrix K F p (k i) (k (i + 1)) : ℝ) : ℂ) := by
+      intro k
+      rw [Complex.ofReal_prod]
+      apply Finset.prod_congr rfl
+      intro i _
+      have hsq : ((F.neighboringOperator (k i : Fin F.sectorCount)
+          (k (i + 1) : Fin F.sectorCount)) ^ 2).PosSemidef := by
+        have hherm := (hpos (k i) (k (i + 1))).isHermitian
+        have h_sq_eq : (F.neighboringOperator (k i : Fin F.sectorCount)
+            (k (i + 1) : Fin F.sectorCount)) ^ 2 =
+            (F.neighboringOperator (k i : Fin F.sectorCount) (k (i + 1) : Fin F.sectorCount)) *
+              (F.neighboringOperator (k i : Fin F.sectorCount)
+                (k (i + 1) : Fin F.sectorCount))ᴴ := by
+          rw [sq, hherm.eq]
+        rw [h_sq_eq]
+        exact Matrix.posSemidef_self_mul_conjTranspose _
+      rw [hsq.isHermitian.trace_eq_ofReal_re]
+      rfl
+    simp_rw [hcast]
+    rw [← Complex.ofReal_sum]
+    congr 1
+    exact (trace_pow_eq_sum_cyclic_product (activeSectorTraceSqMatrix K F p)).symm
+  · rw [← Matrix.blockDiagonal'_mul]
+    simp [sq]
+
+end overlapFormula
 
 end caseI
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -639,10 +639,9 @@
     entries of $\eta_{k_n,k_{n+1}}^2$.
 \end{proof}
 
-% Proved Case-I components; the singleton-sector assembly (trace
-% similarity, the overlap formula, and the Case-I relations) is not yet
-% formalized.  The route is sketched in
-% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+% Proved Case-I components; the singleton-sector assembly (the Case-I
+% relations $(T^*)^2=T^*$ and $Q(1-LQ)L=0$) is not yet formalized.  The
+% route is sketched in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{lemma}[Trace-squared matrix of the neighboring operators]
     \label{lem:mpdo_active_sector_trace_sq_matrix}
     \lean{MPOTensor.activeSectorTraceSqMatrix,
@@ -683,9 +682,7 @@
 \end{proof}
 
 % Proved Case-I components.  The remaining singleton-sector assembly
-% is not yet formalized: the overlap formula
-% $O_{{\cal K}^{\mathrm{MPS}}{\cal K}^{\mathrm{MPS}}}(N)
-% =\tr((S^*)^N)$, and the Case-I relations $(T^*)^2=T^*$ and
+% is not yet formalized: the Case-I relations $(T^*)^2=T^*$ and
 % $Q(1-LQ)L=0$ in the rectangular decomposition
 % $\mathcal T_{\cal K}=LQ$.  The virtual-spanning counterexample above
 % shows that the last relation does not follow from virtual spanning
@@ -838,4 +835,115 @@
     closed length-$N$ walks $v$ (with $v_0=v_N$) as cyclic labelings
     $k:\{0,\ldots,N-1\}\to I$ by dropping the repeated final
     coordinate.
+\end{proof}
+
+\begin{lemma}[Trace invariance under the physical basis change]
+    \label{lem:mpdo_trace_conjugate_physical_invariant}
+    \lean{MPOTensor.sitewise_prod_conjTranspose_mul_self,
+      MPOTensor.trace_mpo_conjugatePhysical_mul_self}
+    \leanok
+    \uses{def:mpo_family}
+    Let $K$ be an MPO tensor and $U$ a unitary on the physical space. Then
+    \begin{align}
+        \tr\!\left(\rho^{(N)}(\widetilde K)\,\rho^{(N)}(\widetilde K)\right)
+        &=\tr\!\left(\rho^{(N)}(K)\,\rho^{(N)}(K)\right),
+        \notag
+    \end{align}
+    where $\widetilde K$ is $K$ conjugated by $U$ at every physical site.
+    This is a project derivation preparing the Case-I route of
+    \cite[Appendix~C.2, lines~1434--1448]{Cirac2016MPDO_arXiv} (the basis
+    change defining $\sigma_{\mathrm{tilde}}$); it is not a claim from that
+    source.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The sitewise product matrix $W_{\sigma,\sigma'}=\prod_n U(\sigma_n,\sigma'_n)$
+    is unitary because $U$ is: expanding $W^\dagger W$ as a sum over
+    intermediate configurations and using $\sum_x\overline{U(x,a)}\,U(x,b)
+    =\delta_{a,b}$ site by site gives the identity. Since
+    $\rho^{(N)}(\widetilde K)=W\,\rho^{(N)}(K)\,W^\dagger$, cyclicity of the
+    trace and unitarity of $W$ cancel the $W$'s from
+    $\tr\!\left(W\rho^{(N)}(K)\rho^{(N)}(K)W^\dagger\right)$.
+\end{proof}
+
+\begin{lemma}[Reduction to the active sector]
+    \label{lem:mpdo_sum_prod_traceSq_active}
+    \lean{MPOTensor.neighboringOperator_eq_zero_of_inactive_right,
+      MPOTensor.prod_traceSq_eq_zero_of_not_forall_active,
+      MPOTensor.sum_prod_traceSq_eq_sum_active}
+    \leanok
+    \uses{def:mpdo_active_sector_trace_matrix,
+      thm:mpdo_cyclic_neighboring_trace_products}
+    Let ${\cal K}$ be an MPO tensor with a physical-sector factorization
+    and sector weights $p_k$, such that the left tensor of every
+    zero-weight sector vanishes. Then, for $N\geq1$, the sum over all
+    sector labelings of the cyclic trace-square product reduces to the
+    sum over active-sector labelings:
+    \begin{align}
+        \sum_{k:\{0,\ldots,N-1\}\to I}\ \prod_{i=0}^{N-1}
+          \tr\!\left(\eta_{k_i,k_{i+1}}^2\right)
+        &=\sum_{k:\{0,\ldots,N-1\}\to I_*}\ \prod_{i=0}^{N-1}
+          \tr\!\left(\eta_{k_i,k_{i+1}}^2\right).
+        \notag
+    \end{align}
+    This is the reconciliation, flagged as an open reconciliation gap when
+    Lemma~\ref{lem:mpdo_pow_apply_path_indicator} and
+    Theorem~\ref{thm:mpdo_trace_pow_cyclic_product} were added, between
+    the full sector index set $I$ and the active sector set $I_*$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_active_sector_trace_matrix}
+    A neighboring operator with an inactive target sector vanishes,
+    because the left tensor of that sector vanishes identically. Hence any
+    cyclic labeling touching an inactive sector has a vanishing factor
+    (that sector is the target of some edge in the cycle), so its product
+    is zero. The active-sector sum is therefore exactly the full-sector
+    sum, restricted to a labeling-by-labeling bijection with the inactive
+    terms discarded.
+\end{proof}
+
+\begin{theorem}[The overlap formula]
+    \label{thm:mpdo_overlap_formula}
+    \lean{MPOTensor.mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow}
+    \leanok
+    \uses{lem:mpdo_active_sector_trace_sq_matrix,
+      thm:mpdo_doubled_overlap_hilbert_schmidt,
+      thm:mpdo_trace_pow_cyclic_product,
+      lem:mpdo_trace_conjugate_physical_invariant,
+      lem:mpdo_sum_prod_traceSq_active}
+    Let ${\cal K}$ be an MPO tensor with a physical-sector factorization
+    and sector weights $p_k$, such that every neighboring operator is
+    positive semidefinite and the left tensor of every zero-weight sector
+    vanishes. Then, for $N\geq1$,
+    \begin{align}
+        O_{{\cal K}^{\mathrm{MPS}}{\cal K}^{\mathrm{MPS}}}(N)
+        &=\tr\!\left((S^*)^N\right).
+        \notag
+    \end{align}
+    This is a project derivation completing the first step of the Case-I
+    route toward
+    \cite[Appendix~C.2, Lemma~C.5, lines~1473--1499]{Cirac2016MPDO_arXiv};
+    it is not a statement of that source.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:mpdo_active_sector_trace_sq_matrix,
+      thm:mpdo_doubled_overlap_hilbert_schmidt,
+      thm:mpdo_trace_pow_cyclic_product,
+      lem:mpdo_trace_conjugate_physical_invariant,
+      lem:mpdo_sum_prod_traceSq_active}
+    Combine Theorem~\ref{thm:mpdo_doubled_overlap_hilbert_schmidt} with
+    Lemma~\ref{lem:mpdo_trace_conjugate_physical_invariant} (conjugating by
+    the physical isometry of the factorization) and the block-diagonal
+    product realization to identify the doubled-index trace with the
+    full-sector cyclic trace-square sum. Lemma
+    \ref{lem:mpdo_sum_prod_traceSq_active} restricts this sum to the
+    active sector, and Hermiticity identifies each complex trace-square
+    with its real trace-squared matrix entry. Theorem
+    \ref{thm:mpdo_trace_pow_cyclic_product} collapses the resulting
+    cyclic-labeling sum into $\tr((S^*)^N)$.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -843,7 +843,8 @@
       MPOTensor.trace_mpo_conjugatePhysical_mul_self}
     \leanok
     \uses{def:mpo_family}
-    Let $K$ be an MPO tensor and $U$ a unitary on the physical space. Then
+    Let $K$ be an MPO tensor and $U$ an isometry on the physical space,
+    $U^\dagger U=1$. Then
     \begin{align}
         \tr\!\left(\rho^{(N)}(\widetilde K)\,\rho^{(N)}(\widetilde K)\right)
         &=\tr\!\left(\rho^{(N)}(K)\,\rho^{(N)}(K)\right),
@@ -859,11 +860,11 @@
 \begin{proof}
     \leanok
     The sitewise product matrix $W_{\sigma,\sigma'}=\prod_n U(\sigma_n,\sigma'_n)$
-    is unitary because $U$ is: expanding $W^\dagger W$ as a sum over
-    intermediate configurations and using $\sum_x\overline{U(x,a)}\,U(x,b)
+    satisfies $W^\dagger W=1$ because $U$ does: expanding $W^\dagger W$ as a sum
+    over intermediate configurations and using $\sum_x\overline{U(x,a)}\,U(x,b)
     =\delta_{a,b}$ site by site gives the identity. Since
     $\rho^{(N)}(\widetilde K)=W\,\rho^{(N)}(K)\,W^\dagger$, cyclicity of the
-    trace and unitarity of $W$ cancel the $W$'s from
+    trace and $W^\dagger W=1$ cancel the $W$'s from
     $\tr\!\left(W\rho^{(N)}(K)\rho^{(N)}(K)W^\dagger\right)$.
 \end{proof}
 
@@ -934,16 +935,45 @@
     \uses{lem:mpdo_active_sector_trace_sq_matrix,
       thm:mpdo_doubled_overlap_hilbert_schmidt,
       thm:mpdo_trace_pow_cyclic_product,
+      thm:mpdo_cyclic_neighboring_trace_products,
       lem:mpdo_trace_conjugate_physical_invariant,
       lem:mpdo_sum_prod_traceSq_active}
-    Combine Theorem~\ref{thm:mpdo_doubled_overlap_hilbert_schmidt} with
-    Lemma~\ref{lem:mpdo_trace_conjugate_physical_invariant} (conjugating by
-    the physical isometry of the factorization) and the block-diagonal
-    product realization to identify the doubled-index trace with the
-    full-sector cyclic trace-square sum. Lemma
-    \ref{lem:mpdo_sum_prod_traceSq_active} restricts this sum to the
-    active sector, and Hermiticity identifies each complex trace-square
-    with its real trace-squared matrix entry. Theorem
-    \ref{thm:mpdo_trace_pow_cyclic_product} collapses the resulting
-    cyclic-labeling sum into $\tr((S^*)^N)$.
+    Write $\rho=\rho^{(N)}({\cal K})$, $\widetilde\rho=\rho^{(N)}(\widetilde{\cal K})$
+    for the physically conjugated MPO, and $\Omega_k$ for the cyclic
+    neighboring product of Theorem~\ref{thm:mpdo_cyclic_neighboring_trace_products}.
+    The overlap unwinds into a chain of trace identities:
+    \begin{align}
+        O_{{\cal K}^{\mathrm{MPS}}{\cal K}^{\mathrm{MPS}}}(N)
+        &=\tr(\rho\,\rho)
+        &&\text{Theorem~\ref{thm:mpdo_doubled_overlap_hilbert_schmidt}}
+        \notag\\
+        &=\tr(\widetilde\rho\,\widetilde\rho)
+        &&\text{Lemma~\ref{lem:mpdo_trace_conjugate_physical_invariant}}
+        \notag\\
+        &=\tr\!\left(\Bigl(\bigoplus_{k}\Omega_k\Bigr)^{\!2}\right)
+        &&\text{block-diagonal product realization}
+        \notag\\
+        &=\sum_{k:\{0,\ldots,N-1\}\to I}\tr\!\left(\Omega_k^2\right)
+        &&\text{trace of a block-diagonal matrix}
+        \notag\\
+        &=\sum_{k:\{0,\ldots,N-1\}\to I}\ \prod_{i=0}^{N-1}
+          \tr\!\left(\eta_{k_i,k_{i+1}}^2\right)
+        &&\text{Theorem~\ref{thm:mpdo_cyclic_neighboring_trace_products}}
+        \notag\\
+        &=\sum_{k:\{0,\ldots,N-1\}\to I_*}\ \prod_{i=0}^{N-1}
+          \tr\!\left(\eta_{k_i,k_{i+1}}^2\right)
+        &&\text{Lemma~\ref{lem:mpdo_sum_prod_traceSq_active}}
+        \notag\\
+        &=\sum_{k:\{0,\ldots,N-1\}\to I_*}\ \prod_{i=0}^{N-1}S^*_{k_i,k_{i+1}}
+        &&\text{Hermiticity, }\tr(A)=\re\tr(A)\text{ for }A=A^\dagger
+        \notag\\
+        &=\tr\!\left((S^*)^N\right)
+        &&\text{Theorem~\ref{thm:mpdo_trace_pow_cyclic_product}}
+        \notag
+    \end{align}
+    The third step combines the block-diagonal product realization of
+    the sector-coordinate MPO with the reindexing invariance of
+    trace-of-square. The sixth step uses Hermiticity of $\eta_{k,h}$ to
+    identify its complex trace-square with the real entry
+    $S^*_{k,h}=\re\tr(\eta_{k,h}^2)$.
 \end{proof}


### PR DESCRIPTION
Proves the headline statement of #5435: the doubled-index MPS self-overlap equals `Complex.ofReal(tr(S^N))`, where `S` is the active-sector trace-squared matrix (arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499).

```lean
theorem mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow
    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
    {N : ℕ} [NeZero N] :
    MPSTensor.mpvOverlap K.toMPSTensor K.toMPSTensor N =
      Complex.ofReal (Matrix.trace ((activeSectorTraceSqMatrix K F p) ^ N))
```

`hpos`/`hinactive` are the same Case-I hypothesis pair already used throughout this file (e.g. `activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL`); no additional hypothesis is introduced beyond that established route, and `IsMPDO K` is derived internally from `hpos` (via `isMPDO_of_neighboringOperator_pos`) rather than added as a separate hypothesis.

**Proof route**, assembling existing project infrastructure plus new lemmas:

- `mpvOverlap_toMPSTensor_self_eq_trace_sq` (`Purity.lean`): `mpvOverlap = tr(mpo K N * mpo K N)`.
- `trace_mpo_conjugatePhysical_mul_self` (new) + `sitewise_prod_conjTranspose_mul_self` (new): trace invariance under the physical unitary basis change `conjugatePhysical`, proved via unitarity of the sitewise product matrix `W = U^{⊗N}` built from `F.physicalIsometry`.
- `mpo_sectorCoordinateTensor_eq_reindex_conjugatePhysical` and `reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal` (`PhysicalSectorProductRealization.lean`), combined with `Matrix.trace_mul_self_eq_of_reindex_eq` (new, in `TraceReindex.lean`, generalized to any `NonAssocSemiring`): moves the trace through both reindexing steps down to the block-diagonal cyclic-neighboring-product form.
- `trace_cyclicNeighboringProduct_sq_eq_prod_trace_sq` (`CyclicActiveTraceProductIdentities.lean`): expands each block's trace-square as a product over the cycle.
- `sum_prod_traceSq_eq_sum_active` (new, with `neighboringOperator_eq_zero_of_inactive_right` and `prod_traceSq_eq_zero_of_not_forall_active`): reduces the full-sector index type `Fin F.sectorCount` down to the active-sector index type `F.ActiveSector p`, using `hinactive` to show every cyclic labeling touching an inactive sector contributes zero. This is the reconciliation gap flagged in the module docstring by the prior PR (#5519).
- `Matrix.IsHermitian.trace_eq_ofReal_re` + `trace_pow_eq_sum_cyclic_product` (already on main): identifies the complex trace-squares with `activeSectorTraceSqMatrix` and collapses the cyclic-labeling sum back into `tr(S^N)`.

**Validation**: `lake build TNLean.MPS.MPDO.LemmaC5CaseI TNLean.Algebra.TraceReindex` and a full `lake build` both pass. No `sorry`/`axiom`. `git diff --check` clean. Lines ≤100 chars.

Closes #5435.