### PR TITLE
fix(tenkz): measure an arc-routed index wire along the path it draws

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -115,6 +115,47 @@ if grep -Fq '|origin=port-open|' "$WORK/r_closure_implicit_virtual.tnlog"; then
   echo "FAIL: implicit closure endpoints grew open-port stubs" >&2
   exit 1
 fi
+grep -Fq 'stringbead|id=cup-1-2|t=0.5' "$WORK/r_onwire_cup_arc.tnlog" || {
+  echo "FAIL: a place on a generated cup was not measured along the cup" >&2
+  exit 1
+}
+if grep -Fq 'stringbead|id=run|' "$WORK/r_onwire_cup_arc.tnlog"; then
+  echo "FAIL: a straight run stopped dividing its own run" >&2
+  exit 1
+fi
+awk -F'|' '
+  /^picture\|id=k2\|/ { exit }
+  /^glyph-geometry\|/ {
+    for (i = 1; i <= NF; i++) {
+      split($i, kv, "=")
+      if (kv[1] == "xmin") lo = kv[2] + 0
+      if (kv[1] == "xmax") hi = kv[2] + 0
+    }
+    if (n == 1) east = prev
+    else if (n > 1 && prev > east) east = prev
+    prev = hi
+    centre = (lo + hi) / 2
+    n++
+  }
+  END { exit !(n > 1 && centre > east) }
+' "$WORK/r_onwire_cup_arc.tnlog" || {
+  echo "FAIL: the operator on the cup stands on the chord, not the arc" >&2
+  exit 1
+}
+chain_ports=$(awk '/^picture\|id=k2\|/ { exit } /^wire\|.*origin=port-open/' \
+  "$WORK/r_ports_chain_placed.tnlog" | sed 's/|from=addr-[0-9]*//')
+at_ports=$(awk '/^picture\|id=k2\|/ { seen = 1 }
+  seen && /^wire\|.*origin=port-open/' \
+  "$WORK/r_ports_chain_placed.tnlog" | sed 's/|from=addr-[0-9]*//')
+[ -n "$chain_ports" ] && [ "$chain_ports" = "$at_ports" ] || {
+  echo "FAIL: chain-placed and at-placed atoms declared different ports" >&2
+  exit 1
+}
+[ "$(grep -Fc 'kernel-boundary|signature=phys:n, phys:n, phys:s, phys:s' \
+      "$WORK/r_ports_chain_placed.tnlog" || true)" -eq 2 ] || {
+  echo "FAIL: the two placements reached different open physical boundaries" >&2
+  exit 1
+}
 grep -Fq 'kernel-boundary|signature=phys:n' \
     "$WORK/r_port_physical_open.tnlog" || {
   echo "FAIL: physical port type did not reach its explicit open boundary" >&2

--- a/tests/tenkz/kernel/regression/r_onwire_cup_arc.tex
+++ b/tests/tenkz/kernel/regression/r_onwire_cup_arc.tex
@@ -1,0 +1,24 @@
+% Regression: a place on a generated cup is read off the arc the cup draws.
+% The cup policy pairs the two rows with a curve that leaves the frame to the
+% east; an operator at a fraction of that wire stands on the ink rather than on
+% the chord between the two ends (issue 5493), and a mark reaches the same
+% place through the same address.  The second picture pins the other half of
+% the contract: a wire that runs straight between two ends divides that run.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=2, bonds=none, east=cup]
+  \tn[at=(1,1), skin=mpo, name=a]{} \tn[at=(1,2), skin=mpo, name=b]{}
+  \tn[at=(2,1), skin=mpo, name=c]{} \tn[at=(2,2), skin=mpo, name=d]{}
+  \tnwire{a}{b} \tnwire{c}{d}
+  \tn[skin=box, at=on cup-1-2 0.5]{$O$}
+  \tnmark[form=label, label pos=0]{on cup-1-2 0.8}{$t$}
+\end{tenkz}
+\qquad
+\begin{tenkz}[rows={wire,wire}, cols=1, bonds=none]
+  \tn[at=(1,1), skin=mpo, name=p]{} \tn[at=(2,1), skin=mpo, name=q]{}
+  \tnwire[name=run]{p}{q}
+  \tn[skin=box, at=on run 0.5]{$Q$}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_ports_chain_placed.tex
+++ b/tests/tenkz/kernel/regression/r_ports_chain_placed.tex
@@ -1,0 +1,22 @@
+% Regression: a typed-port declaration is placement-agnostic.  The two
+% pictures state the same traced word twice, once with the chain cursor and
+% once with explicit addresses, and must record the same ports, the same
+% closure, and the same open physical indices (issue 5493).
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=3, west=trace, east=trace]
+  \tn[skin=ring]{X} &
+  \tn[skin=mpo, ports={0:virtual, 90:physical, 180:virtual, 270:physical}]{} &
+  \tn[skin=mpo, ports={0:virtual, 90:physical, 180:virtual, 270:physical}]{}
+\end{tenkz}
+\qquad
+\begin{tenkz}[rows={wire}, cols=3, west=trace, east=trace]
+  \tn[at=(1,1), skin=ring]{X}
+  \tn[at=(1,2), skin=mpo,
+    ports={0:virtual, 90:physical, 180:virtual, 270:physical}]{}
+  \tn[at=(1,3), skin=mpo,
+    ports={0:virtual, 90:physical, 180:virtual, 270:physical}]{}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -5827,9 +5827,17 @@
                   \l__tenkz_kernel_ow_b_tl
                 \__tenkz_model_get:nnN {#1} {to}
                   \l__tenkz_kernel_ow_c_tl
-                \bool_lazy_and:nnTF
-                  { ! \quark_if_no_value_p:N \l__tenkz_kernel_ow_b_tl }
-                  { ! \quark_if_no_value_p:N \l__tenkz_kernel_ow_c_tl }
+                \__tenkz_model_get:nnN {#1} {origin}
+                  \l__tenkz_kernel_dep_look_tl
+                \bool_lazy_all:nTF
+                  {
+                    { ! \quark_if_no_value_p:N \l__tenkz_kernel_ow_b_tl }
+                    { ! \quark_if_no_value_p:N \l__tenkz_kernel_ow_c_tl }
+                    % A closure owns its route: the renderer chooses the shape
+                    % that leaves the frame, so two ends do not describe it.
+                    { ! \str_if_eq_p:Vn \l__tenkz_kernel_dep_look_tl {cup} }
+                    { ! \str_if_eq_p:Vn \l__tenkz_kernel_dep_look_tl {trace} }
+                  }
                   {
                     % A closed straight index wire has no staged curve; its
                     % endpoints already determine every `on wire t` point.
@@ -5987,9 +5995,11 @@
 
 % `on w t` is the point at fraction t of wire w.  A curve is measured along
 % itself, so the engine answers the arclength question on the route it saved
-% before any crossing cut it; a wire that is a straight run between two ends
-% divides that run instead.  The tensor placed there is not a junction: the
-% wire keeps its whole route and the place is read off it.
+% before any crossing cut it; that route is the one the wire inks, whether the
+% author declared it or a closure policy generated it.  Only a wire that runs
+% straight between two ends divides that run instead.  The tensor placed there
+% is not a junction: the wire keeps its whole route and the place is read off
+% it.
 \cs_new_protected:Npn \__tenkz_kernel_r_port_open_geometry:n #1
   {
     \__tenkz_model_get:nnN {#1} {from} \l__tenkz_kernel_r_end_tl
@@ -6099,7 +6109,17 @@
                 {string}  { \__tenkz_kernel_r_onwire_curve:n {#1} }
                 {pairing} { \__tenkz_kernel_r_onwire_curve:n {#1} }
               }
-              { \__tenkz_kernel_r_onwire_run:n {#1} }
+              {
+                % An index wire saves the path it inks under its own id, so a
+                % generated cup or a trace closure answers along the arc the
+                % reader sees rather than along the chord between its ends.
+                \__tenkz_kernel_r_sid:nN
+                  { \tl_use:N \l__tenkz_kernel_ow_a_tl }
+                  \l__tenkz_kernel_ow_sid_tl
+                \__tenkz_string_bends:VTF \l__tenkz_kernel_ow_sid_tl
+                  { \__tenkz_kernel_r_onwire_curve:n {#1} }
+                  { \__tenkz_kernel_r_onwire_run:n {#1} }
+              }
           }
       }
   }

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -1342,6 +1342,21 @@
   }
 
 % ---------- beads ---------------------------------------------------------------
+% Whether the saved route #1 bends.  The answer is read off the stored path,
+% not off the spelling that produced it: a path assembled from straight
+% segments is divided by its ends, while a bending one is only answered for
+% along itself.  An id no route was saved under does not bend.
+\prg_new_protected_conditional:Npnn \__tenkz_string_bends:n #1 {T,F,TF}
+  {
+    \prop_if_in:NnTF \l__tenkz_string_kind_prop {#1}
+      {
+        \tl_if_in:cVTF { \l__tikzspath_prefix_tl #1 } \c_spath_curveto_tl
+          { \prg_return_true: } { \prg_return_false: }
+      }
+      { \prg_return_false: }
+  }
+\prg_generate_conditional_variant:Nnn \__tenkz_string_bends:n {V} {T,F,TF}
+
 % The point at arclength fraction #2 along string #1, exposed as TikZ
 % coordinate #3 and reported as an event.  PGF's markings decoration advances
 % by actual path distance, unlike spath's segment-count coordinate system.


### PR DESCRIPTION
A place named `on w t` is the point at fraction `t` of wire `w`. The kernel's
own doctrine says a curve is measured along itself and only a wire that runs
straight between two ends divides that run. The dispatch did not say that: it
sent `kind=string` and `kind=pairing` to the arclength path and everything else
to the chord. A generated cup inks a Bezier, so an operator addressed
`on cup-1-2 0.5` was answered on the straight line between the cup's two ends —
inside the frame, on top of whatever else crosses there — and a cup with no
recorded ends refused to answer at all with `TKZ-KERNEL-RENDER-TODO`.

Advances LionSR/tenkz#147. The on-wire half is fixed, including the issue's second
acceptance clause; the `ports=` half does not reproduce (see below).

## What changed

`\__tenkz_kernel_r_wire_stroke:nn` already saves every index wire's stroked
path as an spath under the wire's own id, so no new geometry was needed — the
inked route was there to be asked.

- **`tenkz-string.code.tex`** gains `\__tenkz_string_bends:nTF`, which reads the
  saved path and answers whether it contains a curveto segment. The question is
  put to the stored path, not to the spelling that produced it, so a wire is
  classified by what it draws.
- **`tenkz-kernel.code.tex`**: the on-wire dispatch asks that question of an
  index wire and takes the arclength path when the answer is yes. A straight run
  keeps the exact segment arithmetic it always had, so no existing placement
  moves.
- **`tenkz-kernel.code.tex`**: a closure record (`origin=cup`, `origin=trace`)
  no longer settles on its two ends alone. The renderer owns the shape a closure
  leaves the frame with, so two ends do not describe it; the record now waits for
  the wire stage that inks it, exactly as an open or generated index path already
  did. Without this the cup's route did not yet exist when an atom addressed it.

The doctrine comment above `\__tenkz_kernel_r_port_open_geometry:n` now states
the rule the code follows: the measured route is the one the wire inks, whether
the author declared it or a closure policy generated it.

## Evidence

`tests/tenkz/kernel/regression/r_onwire_cup_arc.tex` — an operator at the
midpoint of a generated cup, a mark at 0.8 of the same cup, and an atom at the
midpoint of a straight run. Before: `TKZ-KERNEL-RENDER-TODO` when the cup had no
recorded ends, and the chord when it had them. After: the operator's glyph centre
lies at 2743406sp, east of every other glyph in the picture (maximum 2581955sp),
which only the arc reaches; the chord midpoint is 2051147sp. The probe script now
asserts that inequality, asserts the bead events for the cup, and asserts that
the straight run still emits none.

The mark target `on <index-wire> t` — the other half of the issue's acceptance
clause — draws in both shapes, so the workaround LionSR/TNLean#5491 used (a label at a
fractional east offset) is no longer needed.

Rendered and looked at at 300dpi: the operator sits on the bend with the cup
passing behind it, and the marked label stands beside the lower part of the arc.

**Corpus effect.** All 130 RMP targets were compiled against `origin/main` and
against this branch and their event streams diffed. Three differ, all of them
cases that hand-place a bead on a canonical cup wire because the labelled-cup
sugar does not expand yet (#5482): `rmp-ii-reduced-density`,
`rmp-ii-spectrum-rho`, `rmp-ii-sv17`. In all three the ring moves from floating
inside the racetrack onto the bend — which is what those cases' own comments say
they draw ("the on-bend fixed points", "the west rho^R / east rho^L cup beads",
"the virtual ends closed on unlabelled cup beads"). Renders compared side by side
at 200dpi. `rmp-ii-mpu-blocking`, whose beads sit on hull-routed wires, is
untouched: those routes ink straight segments and keep the run path. No case file
changes, so no verdict hash moves.

## The `ports=` half

I could not reproduce it, and I will not guess at a fix for a defect I cannot see
fail. Against `origin/main` and against the base commit of LionSR/TNLean#5491 I compiled about
forty spellings: chain rewrites of the exact `eq51`, `eq52`, `diagram-two`, and
`eq50-reduced` cases that were forced onto explicit `at=` addresses; eighteen
atom options crossed with five closure policies; compass-word and degree faces;
slotted ports; `wires=`, `wide=`, `cluster=`, `void=`, `physical=`; west/east,
north/south, and cup closures. Every one compiled. The likeliest reading is that
one of the kernel commits landing between the wave-2A worktree's base and today
fixed it — `0bd3f9270` (physical policy made ports-only) and `59783d1d8`
(physical policy kept on frame atoms) are the plausible candidates.

So instead of a speculative fix,
`tests/tenkz/kernel/regression/r_ports_chain_placed.tex` pins the property the
issue asks for: the same traced word stated twice, once with the chain cursor and
once with explicit addresses. The probe script asserts that the two placements
record identical typed ports and reach the same open physical boundary. If the
defect returns, that fixture catches it.

## Blueprint figures

`ch04_channels_choi_foundations` and `ch14_correlations` both write
`west={cup=...}` / `east={cup=...}`. That sugar still does not expand (#5482),
but its kernel workaround — a hand-placed bead on the canonical cup wire, the
spelling `rmp-ii-spectrum-rho` already uses — now lands on the bend instead of in
the middle of the picture. That was the blocker; the migration can proceed on
`agent/blueprint-figures-w1`, which this branch does not touch.

## Validation

- `bash scripts/tenkz_kernel_probes.sh` — PASS: 111 review regressions hold (109
  before, plus the two added here and one that landed on main during this work);
  9 sugar spellings byte-identical; 12 kernel record streams byte-identical;
  kernel pixels byte-identical. No snapshot taken: the goldens cover the twelve
  `k_*` streams and eight pinned rasters, none of which moved.
- `python3 scripts/test_tenkz_kernel_audit.py` — PASS
- `python3 scripts/tenkz_rmp.py check --all` — three hard failures, all
  pre-existing on `origin/main` and unrelated to this branch:
  `rmp-iii-a-spt-intertwiner`, `rmp-iii-b-idempotent`, and
  `rmp-workbench-iii-diagram-four`, each `eq-boundary-mismatch`. Verified by
  stashing this branch's `tex/` and `scripts/` changes and reproducing every
  failure on a clean tree. `check --section section-ii`, which covers all three
  targets this branch moves, passes: 48 targets, 86 faithful / 44 cosmetic-gap.
- `python3 scripts/test_tenkz_shrink.py` — PASS (32 checks)
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — PASS: census
  stable at 200, all 146 flags carry verdicts. No meter moved, so no `SHRINK.md`
  entry and no census baseline regeneration.
