### PR TITLE
doc(tenkz): name the fragile frame where chaining is taught

### DIFF
--- a/docs/tenkz/chapters2/ch-tutorial.tex
+++ b/docs/tenkz/chapters2/ch-tutorial.tex
@@ -22,6 +22,12 @@ body declarations.  Each source is complete and uses canonical public syntax.
 The environment chooses a contraction grid.  \tnkey{physical=up} is picture
 policy.  Each \tncmd{tn} declares an atom; \verb|&| advances one site.
 
+Beamer reads a frame's body before typesetting it, under the catcodes in
+force when the frame opens, so a chained picture's \verb|&| is still an
+alignment tab and the frame stops with a misplaced-tab error.  Mark the frame
+\texttt{[fragile]}; beamer then defers that reading until the picture's own
+catcode for \verb|&| applies.
+
 \subsection{A channel sandwich}
 
 \begin{tnexample}[


### PR DESCRIPTION
## What

A chained kernel picture sets `&` active only once its environment begins.
Beamer reads a frame's body before typesetting it, under the catcode in
force when the frame opens, so an ordinary frame still sees `&` as an
alignment tab. This is architectural to beamer's frame-body capture, not
something tenkz's grammar controls, so the documentation route from the
issue is the one taken (a grammar change would need to abandon the
active-catcode chaining mechanism entirely, for one host).

## Reproduction

Minimal beamer document, `\tenkzkernel` active, a chained picture inside a
plain frame:

```tex
\documentclass{beamer}
\usepackage{tenkz}
\tenkzkernel
\begin{document}
\begin{frame}{Chained kernel picture}
\begin{tenkz}[rows={wire}, cols=3, size=s]
  \tn[label pos=s, ports={90:physical:$i_1$}]{A} &
  \tn[label pos=s, ports={90:physical:$i_2$}]{A} &
  \tn[label pos=s, ports={90:physical:$i_3$}]{A}
\end{tenkz}
\end{frame}
\end{document}
```

Plain frame (`timeout 120 env TEXINPUTS=<worktree>/tex/tenkz//: xelatex
-interaction=nonstopmode`):

```
! Misplaced alignment tab character &.
\beamer@doifinframe ...s={90:physical:$i_1$}]{A} &
...
! Package tenkz Error: [TKZ-LANG-OCCUPANCY] cell (1,1) belongs to record
(tenkz)                atom-1; record atom-3 cannot claim it.
```

`\begin{frame}[fragile]{...}` with the identical body: exit 0, no errors.

## Fix

Added two sentences to the chaining paragraph in
`docs/tenkz/chapters2/ch-tutorial.tex` (the manual's "An MPS word" example,
where `&` is first introduced), stating what beamer does and what the
author writes:

> Beamer reads a frame's body before typesetting it, under the catcodes in
> force when the frame opens, so a chained picture's `&` is still an
> alignment tab and the frame stops with a misplaced-tab error. Mark the
> frame `[fragile]`; beamer then defers that reading until the picture's own
> catcode for `&` applies.

The manual has no section on hosting tenkz inside other document classes, so
there was no second location to update.

## Diagnostic

Not added. The raw TeX "Misplaced alignment tab" error fires during
beamer's own argument-grabbing of the frame body, before `\begin{tenkz}`'s
catcode-setting code (`tex/tenkz/tenkz-kernel.code.tex`,
`\__tenkz_kernel_begin:n`) ever runs — there is no point in tenkz's own
code path to intercept it. The subsequent tenkz-native occupancy error is a
downstream symptom of the same mangled input, not a reliable signal on its
own (occupancy conflicts arise from unrelated authoring mistakes too), so
guessing "this must be an unfragile beamer frame" from it would be a false
lead in other cases. No clean hook.

## Validation

- `python3 scripts/tenkz_manual_doctest.py` — PASS
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — no violations
- `cd docs/tenkz && TEXINPUTS=<worktree>/tex/tenkz//: xelatex -interaction=nonstopmode -halt-on-error manual2.tex` (x2) — exit 0
- Compiled all three decks PR LionSR/TNLean#5522 migrated (`presentation20260207.tex`,
  `presentation20260222_technical.tex`,
  `presentation20260318_agentic_formalization.tex`) — exit 0, no errors

Closes LionSR/tenkz#159