### PR TITLE
feat(MPDO): Perron eigenvector + Lemma C.5 Case-I singleton-sector assembly

### DIFF
--- a/TNLean/Algebra/PerronFrobenius.lean
+++ b/TNLean/Algebra/PerronFrobenius.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.Algebra.PerronFrobenius
 
 import TNLean.Algebra.PerronFrobenius.Idempotent
+import TNLean.Algebra.PerronFrobenius.PerronVector
 import TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic
 import TNLean.Algebra.PerronFrobenius.RankOne
 import TNLean.Algebra.PerronFrobenius.Substochastic

--- a/TNLean/Algebra/PerronFrobenius/PerronVector.lean
+++ b/TNLean/Algebra/PerronFrobenius/PerronVector.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.PerronFrobenius.Idempotent
+import TNLean.Algebra.PerronFrobenius.Substochastic
+
+/-!
+# Perron eigenvector for a primitive matrix with `T² = T³`
+
+This file constructs a strictly positive eigenvector, with eigenvalue exactly `1`, for a
+primitive real matrix `T` satisfying `T² = T³`, and the induced diagonal conjugation of
+`T` into a row-stochastic primitive matrix. This is the ingredient needed by the Lemma C.5
+Case-I singleton-sector route (see issue tracker `#5548`, prerequisite for `#5436`):
+the paper's own citation-based step from primitivity and constant positive-power traces to
+a rank-one factorization is not valid in general (a counterexample is recorded in
+`TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean` and
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`); this file supplies the correct Perron-vector
+ingredient consumed by `trace_pow_similarity_diagonal`
+(`TNLean/MPS/MPDO/LemmaC5CaseI.lean`) for the corrected, source-faithful replacement
+argument (issue `#5404`'s "source-faithful route").
+
+The construction is elementary: `T² = T³` and primitivity already give (via
+`IsPrimitive.exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three`) a positive rank-one
+factorization `T² = a bᵀ` with `a ⬝ᵥ b = 1`. Since `T² a = a`, the vector `v = a + T a` is a
+strictly positive eigenvector of `T` itself with eigenvalue `1`: `T v = T a + T² a = T a + a
+= v`. No general Perron-Frobenius existence theorem (e.g. via Brouwer's fixed-point theorem
+on the probability simplex) is needed for this specialized case.
+
+## Main declarations
+
+* `Matrix.IsPrimitive.exists_pos_eigenvector_one_of_pow_two_eq_pow_three`: existence of the
+  positive eigenvalue-`1` eigenvector.
+* `Matrix.IsPrimitive.exists_rowStochastic_diagonal_conj_of_pow_two_eq_pow_three`: the
+  diagonal conjugate of `T` by this eigenvector is row-stochastic and primitive.
+-/
+
+open scoped Matrix
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+
+/-- A primitive matrix `T` with `T² = T³` has a strictly positive eigenvector with
+eigenvalue exactly `1`.
+
+The vector is `v = a + T a`, where `T² = vecMulVec a b` is the positive rank-one
+factorization of `T²` given by
+`IsPrimitive.exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three`. -/
+theorem IsPrimitive.exists_pos_eigenvector_one_of_pow_two_eq_pow_three
+    {T : Matrix n n ℝ} (hT : T.IsPrimitive) (hTsq : T ^ 2 = T ^ 3) :
+    ∃ v : n → ℝ, (∀ i, 0 < v i) ∧ T.mulVec v = v := by
+  obtain ⟨a, b, ha, hb, hT2, hab⟩ :=
+    hT.exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three hTsq
+  have hT2a : (T ^ 2).mulVec a = a := by
+    rw [hT2]
+    ext i
+    simp only [Matrix.mulVec, Matrix.vecMulVec_apply, dotProduct]
+    have hfactor : (∑ x, a i * b x * a x) = a i * ∑ x, b x * a x := by
+      rw [Finset.mul_sum]
+      exact Finset.sum_congr rfl (fun x _ => by ring)
+    rw [hfactor, show (∑ x, b x * a x) = b ⬝ᵥ a from rfl, dotProduct_comm b a, hab, mul_one]
+  set u : n → ℝ := T.mulVec a with hu
+  have hu_pos : ∀ i, 0 < u i := by
+    intro i
+    have hrow_nonzero : ∃ j, 0 < T i j := by
+      by_contra hcon
+      push Not at hcon
+      have hrow_zero : ∀ j, T i j = 0 := fun j => le_antisymm (hcon j) (hT.nonneg i j)
+      have : (T * T) i i = 0 := by
+        simp only [Matrix.mul_apply]
+        apply Finset.sum_eq_zero
+        intro j _
+        rw [hrow_zero j, zero_mul]
+      have hT2ii : (T ^ 2) i i = 0 := by rw [sq]; exact this
+      rw [hT2] at hT2ii
+      simp only [Matrix.vecMulVec_apply] at hT2ii
+      have : a i * b i = 0 := hT2ii
+      rcases mul_eq_zero.mp this with h | h
+      · exact absurd h (ha i).ne'
+      · exact absurd h (hb i).ne'
+    obtain ⟨j, hj⟩ := hrow_nonzero
+    calc (0 : ℝ) < T i j * a j := mul_pos hj (ha j)
+      _ ≤ u i := by
+        rw [hu]
+        change T i j * a j ≤ ∑ k, T i k * a k
+        exact Finset.single_le_sum (f := fun k => T i k * a k)
+          (fun k _ => mul_nonneg (hT.nonneg i k) (ha k).le) (Finset.mem_univ j)
+  have hTu : T.mulVec u = a := by
+    rw [hu, Matrix.mulVec_mulVec, ← sq, hT2a]
+  refine ⟨a + u, fun i => add_pos (ha i) (hu_pos i), ?_⟩
+  rw [Matrix.mulVec_add, hTu, ← hu]
+  ext i
+  simp only [Pi.add_apply]
+  ring
+
+/-- For a primitive matrix `T` with `T² = T³`, conjugating by the diagonal of the positive
+eigenvalue-`1` eigenvector `v` gives a row-stochastic, primitive matrix `D⁻¹ T D`. -/
+theorem IsPrimitive.exists_rowStochastic_diagonal_conj_of_pow_two_eq_pow_three
+    {T : Matrix n n ℝ} (hT : T.IsPrimitive) (hTsq : T ^ 2 = T ^ 3) :
+    ∃ v : n → ℝ, (∀ i, 0 < v i) ∧
+      ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v) ∈ Matrix.rowStochastic ℝ n ∧
+      ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v).IsPrimitive := by
+  obtain ⟨v, hv, hTv⟩ := hT.exists_pos_eigenvector_one_of_pow_two_eq_pow_three hTsq
+  have hdet : IsUnit ((Matrix.diagonal v).det) := by
+    rw [Matrix.det_diagonal]
+    exact IsUnit.prod_univ_iff.mpr fun i => (hv i).ne'.isUnit
+  have hinv : (Matrix.diagonal v)⁻¹ = Matrix.diagonal (fun i => (v i)⁻¹) := by
+    apply Matrix.inv_eq_right_inv
+    simp [Matrix.diagonal_mul_diagonal, fun i => (hv i).ne']
+  have hPapply : ∀ i j, ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v) i j =
+      (v i)⁻¹ * T i j * v j := by
+    intro i j
+    rw [hinv, Matrix.mul_diagonal, Matrix.diagonal_mul]
+  have hPnn : ∀ i j, 0 ≤ ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v) i j := by
+    intro i j
+    rw [hPapply]
+    exact mul_nonneg (mul_nonneg (inv_pos.mpr (hv i)).le (hT.nonneg i j)) (hv j).le
+  refine ⟨v, hv, ?_, ?_⟩
+  · rw [Matrix.mem_rowStochastic]
+    refine ⟨hPnn, ?_⟩
+    ext i
+    simp only [Matrix.mulVec, dotProduct, Pi.one_apply, mul_one, hPapply]
+    have hfactor : (∑ j, (v i)⁻¹ * T i j * v j) = (v i)⁻¹ * ∑ j, T i j * v j := by
+      rw [Finset.mul_sum]
+      exact Finset.sum_congr rfl (fun j _ => by ring)
+    rw [hfactor, show (∑ j, T i j * v j) = T.mulVec v i from rfl, hTv,
+      inv_mul_cancel₀ (hv i).ne']
+  · have hPpow : ∀ k, ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v) ^ k =
+        (Matrix.diagonal v)⁻¹ * T ^ k * Matrix.diagonal v := by
+      intro k
+      induction k with
+      | zero => simp [Matrix.nonsing_inv_mul _ hdet]
+      | succ k ih =>
+        rw [pow_succ, pow_succ, ih]
+        calc
+          (Matrix.diagonal v)⁻¹ * T ^ k * Matrix.diagonal v *
+              ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v) =
+            (Matrix.diagonal v)⁻¹ * T ^ k *
+              (Matrix.diagonal v * (Matrix.diagonal v)⁻¹) * T * Matrix.diagonal v := by
+            simp [Matrix.mul_assoc]
+          _ = (Matrix.diagonal v)⁻¹ * T ^ k * 1 * T * Matrix.diagonal v := by
+            rw [Matrix.mul_nonsing_inv _ hdet]
+          _ = (Matrix.diagonal v)⁻¹ * T ^ (k + 1) * Matrix.diagonal v := by
+            simp [pow_succ, Matrix.mul_assoc]
+    obtain ⟨k, hk_pos, hk⟩ := hT.exists_pos_pow
+    refine ⟨fun i j => hPnn i j, k, hk_pos, fun i j => ?_⟩
+    rw [hPpow, hinv, Matrix.mul_diagonal, Matrix.diagonal_mul]
+    exact mul_pos (mul_pos (inv_pos.mpr (hv i)) (hk i j)) (hv j)
+
+end Matrix

--- a/TNLean/Algebra/PerronFrobenius/PerronVector.lean
+++ b/TNLean/Algebra/PerronFrobenius/PerronVector.lean
@@ -12,14 +12,15 @@ import TNLean.Algebra.PerronFrobenius.Substochastic
 This file constructs a strictly positive eigenvector, with eigenvalue exactly `1`, for a
 primitive real matrix `T` satisfying `T² = T³`, and the induced diagonal conjugation of
 `T` into a row-stochastic primitive matrix. This is the ingredient needed by the Lemma C.5
-Case-I singleton-sector route (see issue tracker `#5548`, prerequisite for `#5436`):
+Case-I singleton-sector route:
 the paper's own citation-based step from primitivity and constant positive-power traces to
 a rank-one factorization is not valid in general (a counterexample is recorded in
 `TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean` and
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`); this file supplies the correct Perron-vector
 ingredient consumed by `trace_pow_similarity_diagonal`
 (`TNLean/MPS/MPDO/LemmaC5CaseI.lean`) for the corrected, source-faithful replacement
-argument (issue `#5404`'s "source-faithful route").
+argument, which instead exploits the tensor's normality hypothesis through the
+asymptotic overlap route.
 
 The construction is elementary: `T² = T³` and primitivity already give (via
 `IsPrimitive.exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three`) a positive rank-one
@@ -95,6 +96,17 @@ theorem IsPrimitive.exists_pos_eigenvector_one_of_pow_two_eq_pow_three
   simp only [Pi.add_apply]
   ring
 
+omit [Nonempty n] in
+/-- The entrywise formula for a diagonal similarity conjugate: `(D⁻¹ M D) i j = (d i)⁻¹ M i j
+d j`, where `D = diagonal d`. -/
+theorem diagonal_inv_mul_mul_diagonal_apply {d : n → ℝ} (hd : ∀ i, d i ≠ 0)
+    (M : Matrix n n ℝ) (i j : n) :
+    ((Matrix.diagonal d)⁻¹ * M * Matrix.diagonal d) i j = (d i)⁻¹ * M i j * d j := by
+  have hinv : (Matrix.diagonal d)⁻¹ = Matrix.diagonal (fun i => (d i)⁻¹) := by
+    apply Matrix.inv_eq_right_inv
+    simp [Matrix.diagonal_mul_diagonal, hd]
+  rw [hinv, Matrix.mul_diagonal, Matrix.diagonal_mul]
+
 /-- For a primitive matrix `T` with `T² = T³`, conjugating by the diagonal of the positive
 eigenvalue-`1` eigenvector `v` gives a row-stochastic, primitive matrix `D⁻¹ T D`. -/
 theorem IsPrimitive.exists_rowStochastic_diagonal_conj_of_pow_two_eq_pow_three
@@ -110,9 +122,8 @@ theorem IsPrimitive.exists_rowStochastic_diagonal_conj_of_pow_two_eq_pow_three
     apply Matrix.inv_eq_right_inv
     simp [Matrix.diagonal_mul_diagonal, fun i => (hv i).ne']
   have hPapply : ∀ i j, ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v) i j =
-      (v i)⁻¹ * T i j * v j := by
-    intro i j
-    rw [hinv, Matrix.mul_diagonal, Matrix.diagonal_mul]
+      (v i)⁻¹ * T i j * v j :=
+    fun i j => diagonal_inv_mul_mul_diagonal_apply (fun i => (hv i).ne') T i j
   have hPnn : ∀ i j, 0 ≤ ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v) i j := by
     intro i j
     rw [hPapply]

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -55,11 +55,11 @@ The overlap formula combines the doubled-index self-overlap identity
 index to the active sector (`sum_prod_traceSq_eq_sum_active`), and the
 cyclic-product expansion of `tr(S^N)` (`trace_pow_eq_sum_cyclic_product`).
 
-The singleton-sector argument is a proof by contradiction (issue `#5404`'s
-source-faithful route): the overlap formula and normality
+The singleton-sector argument is a proof by contradiction (the source-faithful
+route recorded in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`): the overlap formula and normality
 (`MPSTensor.IsNormalTensor.selfOverlap_tendsto_one`, the `equalMPS`
 self-overlap limit) give `tr(S^N) → 1`; conjugating the primitive `T` by
-its Perron vector (`Algebra.PerronFrobenius.PerronVector`, issue `#5548`)
+its Perron vector (`TNLean/Algebra/PerronFrobenius/PerronVector.lean`)
 to a stochastic matrix `P` bounds `S`, after the matching squared
 conjugation, entrywise by `P ⊙ P`; if more than one sector were active,
 `P` would be irreducible substochastic on a nontrivial index set, forcing
@@ -735,11 +735,13 @@ positive semidefinite, the active-sector trace matrix is primitive, and the tens
 normal (in the paper's spectral-radius-one sense), then the active sector set has exactly
 one element.
 
-The proof is by contradiction from the source-faithful route of issue `#5404`: the overlap
+The proof is by contradiction from the source-faithful route recorded in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`: the overlap
 formula and normality give `tr(S^N) → 1`; positivity bounds `S` entrywise by the Hadamard
 square of the primitive stochastic conjugate `P` of `T`; if there were more than one active
 sector, `P` would be irreducible substochastic on a nontrivial index set, forcing
-`tr(S^N) → 0`, a contradiction. Prerequisite Perron-vector infrastructure: issue `#5548`.
+`tr(S^N) → 0`, a contradiction. Prerequisite Perron-vector infrastructure:
+`TNLean/Algebra/PerronFrobenius/PerronVector.lean`.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499; normal-tensor
 self-overlap limit (`equalMPS`) at lines 1080--1100. -/

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -15,6 +15,7 @@ import TNLean.MPS.MPDO.SectorEtaPositivity
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.Analysis.MatrixTraceInequalities
 import TNLean.Algebra.PerronFrobenius.Idempotent
+import TNLean.Algebra.PerronFrobenius.PerronVector
 import TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic
 import TNLean.Algebra.PerronFrobenius.RankOne
 import TNLean.Algebra.PerronFrobenius.Substochastic
@@ -31,18 +32,20 @@ Case-I content carried here is the C.4–C.5 argument that the active-sector
 trace matrix `T` satisfies `T² = T³`, is primitive, and every entry of `T²`
 is positive.
 
-One further piece remains to complete the Case-I argument that the
-active sector set reduces to a singleton (`card(ActiveSector p) = 1`), from
-which the Case-I relations `T² = T` and `Q(1−LQ)L = 0` follow; these
-relations are the Case-I input to the proof of Lemma `SALZCL`
-(arXiv:1606.00608, Appendix C.2, lines 1473--1499), not the lemma's
-headline statement.  Two pieces feeding that singleton assembly are now
-proved:
+The Case-I argument that the active sector set reduces to a singleton
+(`card(ActiveSector p) = 1`), from which the Case-I relation `T² = T`
+follows, is now proved.  These are the Case-I input to the proof of Lemma
+`SALZCL` (arXiv:1606.00608, Appendix C.2, lines 1473--1499), not the
+lemma's headline statement.
 
 * trace similarity `tr(S_hat^N) = tr(S^N)` under diagonal scaling
   (`trace_pow_similarity_diagonal`),
 * the overlap formula `mpvOverlap = Complex.ofReal(tr(S^N))`
-  (`mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow`).
+  (`mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow`),
+* the active sector is unique
+  (`card_activeSector_eq_one_of_literal_ZCL`),
+* the Case-I relation `T² = T`
+  (`activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL`).
 
 The overlap formula combines the doubled-index self-overlap identity
 (`Purity`) with the physical-sector product realization
@@ -52,9 +55,22 @@ The overlap formula combines the doubled-index self-overlap identity
 index to the active sector (`sum_prod_traceSq_eq_sum_active`), and the
 cyclic-product expansion of `tr(S^N)` (`trace_pow_eq_sum_cyclic_product`).
 
-Only the singleton-sector assembly itself remains open.  The route is
-sketched in the paper-gap note
-`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+The singleton-sector argument is a proof by contradiction (issue `#5404`'s
+source-faithful route): the overlap formula and normality
+(`MPSTensor.IsNormalTensor.selfOverlap_tendsto_one`, the `equalMPS`
+self-overlap limit) give `tr(S^N) → 1`; conjugating the primitive `T` by
+its Perron vector (`Algebra.PerronFrobenius.PerronVector`, issue `#5548`)
+to a stochastic matrix `P` bounds `S`, after the matching squared
+conjugation, entrywise by `P ⊙ P`; if more than one sector were active,
+`P` would be irreducible substochastic on a nontrivial index set, forcing
+`tr(S^N) → 0` (`Matrix.trace_pow_tendsto_zero_of_nonneg_le_hadamard_self`),
+a contradiction.
+
+The remaining Case-I relation `Q(1−LQ)L = 0` is the same fact as
+`T² = T` under the rectangular decomposition `T = QL` already used in
+`activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL`'s proof;
+restating it in that form is not yet formalized.  The route is sketched in
+the paper-gap note `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 ## Main declarations
 
@@ -74,6 +90,10 @@ sketched in the paper-gap note
   reduces to the active-sector sum
 * `mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow`:
   **the overlap formula** `mpvOverlap = Complex.ofReal(tr(S^N))`
+* `card_activeSector_eq_one_of_literal_ZCL`:
+  **the active sector is unique**
+* `activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL`:
+  **the Case-I relation** `T² = T`
 
 ## Source fidelity
 
@@ -707,6 +727,133 @@ theorem mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_po
     simp [sq]
 
 end overlapFormula
+
+section singletonSector
+
+/-- **The active sector is unique.** Under literal ZCL, if the neighboring operators are
+positive semidefinite, the active-sector trace matrix is primitive, and the tensor is
+normal (in the paper's spectral-radius-one sense), then the active sector set has exactly
+one element.
+
+The proof is by contradiction from the source-faithful route of issue `#5404`: the overlap
+formula and normality give `tr(S^N) → 1`; positivity bounds `S` entrywise by the Hadamard
+square of the primitive stochastic conjugate `P` of `T`; if there were more than one active
+sector, `P` would be irreducible substochastic on a nontrivial index set, forcing
+`tr(S^N) → 0`, a contradiction. Prerequisite Perron-vector infrastructure: issue `#5548`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499; normal-tensor
+self-overlap limit (`equalMPS`) at lines 1080--1100. -/
+theorem card_activeSector_eq_one_of_literal_ZCL
+    [NeZero D] (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hspan : Submodule.span ℂ (Set.range (F.activeSectorOneSiteMatrixFamily p)) = ⊤)
+    (hnonzero : ∀ k : F.ActiveSector p,
+      ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0)
+    (htriangle : ∀ {k h : F.ActiveSector p}, F.neighboringOperator k h ≠ 0 →
+      ∃ j : F.ActiveSector p, F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0)
+    (hZCL_sq : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    (hK_normal : MPSTensor.IsNormalTensor K.toMPSTensor)
+    [hne : Nonempty (F.ActiveSector p)] :
+    Fintype.card (F.ActiveSector p) = 1 := by
+  by_contra hcard
+  have hcard1 : 1 < Fintype.card (F.ActiveSector p) := by
+    have h1 : 1 ≤ Fintype.card (F.ActiveSector p) := Fintype.card_pos
+    omega
+  haveI : Nontrivial (F.ActiveSector p) := Fintype.one_lt_card_iff_nontrivial.mp hcard1
+  set T := F.activeSectorTraceMatrix p with hTdef
+  have hTsq : T ^ 2 = T ^ 3 :=
+    activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL K F p hZCL_sq hinactive hpos
+  have hTprim : T.IsPrimitive :=
+    F.activeSectorTraceMatrix_isPrimitive p hpos hspan hnonzero htriangle
+  obtain ⟨v, hv, hPstoch, hPprim⟩ :=
+    hTprim.exists_rowStochastic_diagonal_conj_of_pow_two_eq_pow_three hTsq
+  set P := (Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v with hPdef
+  set S := activeSectorTraceSqMatrix K F p with hSdef
+  have hPapply : ∀ i j, P i j = (v i)⁻¹ * T i j * v j :=
+    fun i j => Matrix.diagonal_inv_mul_mul_diagonal_apply (fun i => (hv i).ne') T i j
+  have hSnn : ∀ k h, 0 ≤ S k h := fun k h => activeSectorTraceSqMatrix_nonneg K F p hpos k h
+  have hSbound : ∀ k h, S k h ≤ (T k h) ^ 2 :=
+    fun k h => activeSectorTraceSqMatrix_le_activeSectorTraceMatrix_sq K F p hpos k h
+  set Shat := (Matrix.diagonal (fun i => (v i) ^ 2))⁻¹ * S *
+    Matrix.diagonal (fun i => (v i) ^ 2) with hShatdef
+  have hShat_trace : ∀ N, Matrix.trace (Shat ^ N) = Matrix.trace (S ^ N) :=
+    fun N => trace_pow_similarity_squared_diagonal S v hv N
+  have hShatapply : ∀ i j, Shat i j = ((v i) ^ 2)⁻¹ * S i j * (v j) ^ 2 :=
+    fun i j => Matrix.diagonal_inv_mul_mul_diagonal_apply (fun i => (pow_pos (hv i) 2).ne') S i j
+  have hShat_nn : ∀ i j, 0 ≤ Shat i j := by
+    intro i j
+    rw [hShatapply]
+    exact mul_nonneg (mul_nonneg (inv_pos.mpr (pow_pos (hv i) 2)).le (hSnn i j))
+      (pow_pos (hv j) 2).le
+  have hShat_le : ∀ i j, Shat i j ≤ (P ⊙ P) i j := by
+    intro i j
+    rw [hShatapply, Matrix.hadamard_apply, hPapply]
+    have : ((v i) ^ 2)⁻¹ * S i j * (v j) ^ 2 ≤ ((v i) ^ 2)⁻¹ * (T i j) ^ 2 * (v j) ^ 2 := by
+      gcongr
+      exact hSbound i j
+    calc ((v i) ^ 2)⁻¹ * S i j * (v j) ^ 2 ≤ ((v i) ^ 2)⁻¹ * (T i j) ^ 2 * (v j) ^ 2 := this
+      _ = ((v i)⁻¹ * T i j * v j) * ((v i)⁻¹ * T i j * v j) := by ring
+  have htendsto_zero : Filter.Tendsto (fun N => Matrix.trace (S ^ N)) Filter.atTop (nhds 0) := by
+    have := Matrix.trace_pow_tendsto_zero_of_nonneg_le_hadamard_self hPstoch hPprim hShat_nn
+      hShat_le
+    simpa only [hShat_trace] using this
+  have htendsto_one : Filter.Tendsto (fun N => Matrix.trace (S ^ N)) Filter.atTop (nhds 1) := by
+    have hoverlap : Filter.Tendsto (fun N => MPSTensor.mpvOverlap K.toMPSTensor K.toMPSTensor N)
+        Filter.atTop (nhds (1 : ℂ)) := hK_normal.selfOverlap_tendsto_one
+    have hcongr : Filter.Tendsto (fun N => ((Matrix.trace (S ^ N) : ℝ) : ℂ))
+        Filter.atTop (nhds (1 : ℂ)) := by
+      apply hoverlap.congr'
+      filter_upwards [Filter.eventually_gt_atTop 0] with N hN
+      haveI : NeZero N := ⟨hN.ne'⟩
+      exact mpvOverlap_toMPSTensor_self_eq_ofReal_trace_activeSectorTraceSqMatrix_pow
+        K F p hpos hinactive
+    exact Filter.tendsto_ofReal_iff.mp hcongr
+  have := tendsto_nhds_unique htendsto_zero htendsto_one
+  norm_num at this
+
+/-- **The Case-I relation `T² = T`.** A direct corollary of the active sector being unique
+(`card_activeSector_eq_one_of_literal_ZCL`): on a singleton active-sector set the primitive
+matrix `T` collapses to a scalar `t` with `t² = t³` and `t² > 0`, forcing `t = 1`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1473--1499. -/
+theorem activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL
+    [NeZero D] (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hspan : Submodule.span ℂ (Set.range (F.activeSectorOneSiteMatrixFamily p)) = ⊤)
+    (hnonzero : ∀ k : F.ActiveSector p,
+      ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0)
+    (htriangle : ∀ {k h : F.ActiveSector p}, F.neighboringOperator k h ≠ 0 →
+      ∃ j : F.ActiveSector p, F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0)
+    (hZCL_sq : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    (hK_normal : MPSTensor.IsNormalTensor K.toMPSTensor)
+    [hne : Nonempty (F.ActiveSector p)] :
+    (F.activeSectorTraceMatrix p) ^ 2 = F.activeSectorTraceMatrix p := by
+  have hcard := card_activeSector_eq_one_of_literal_ZCL K F p hpos hspan hnonzero htriangle
+    hZCL_sq hinactive hK_normal
+  haveI : Subsingleton (F.ActiveSector p) := Fintype.card_le_one_iff_subsingleton.mp hcard.le
+  set T := F.activeSectorTraceMatrix p with hTdef
+  have hTsq3 : T ^ 2 = T ^ 3 :=
+    activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL K F p hZCL_sq hinactive hpos
+  have hTsqpos := activeSectorTraceMatrix_pow_two_pos K F p hpos hspan hnonzero htriangle
+    hZCL_sq hinactive
+  ext i j
+  have hij : i = j := Subsingleton.elim i j
+  subst hij
+  have hcollapse2 : (T ^ 2) i i = T i i * T i i := by
+    rw [sq, Matrix.mul_apply, Fintype.sum_eq_single i]
+    intro k hk
+    exact absurd (Subsingleton.elim k i) hk
+  have hcollapse3 : (T ^ 3) i i = (T ^ 2) i i * T i i := by
+    rw [pow_succ, Matrix.mul_apply, Fintype.sum_eq_single i]
+    intro k hk
+    exact absurd (Subsingleton.elim k i) hk
+  have heq : (T ^ 2) i i = (T ^ 2) i i * T i i := by rw [← hcollapse3, ← hTsq3]
+  have hTii : T i i = 1 := (mul_left_cancel₀ (hTsqpos i i).ne' (by rw [mul_one]; exact heq)).symm
+  rw [hcollapse2, hTii, mul_one]
+
+end singletonSector
 
 end caseI
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -977,3 +977,65 @@
     identify its complex trace-square with the real entry
     $S^*_{k,h}=\re\tr(\eta_{k,h}^2)$.
 \end{proof}
+
+\begin{theorem}[The active sector is unique]
+    \label{thm:mpdo_active_sector_singleton}
+    \lean{MPOTensor.card_activeSector_eq_one_of_literal_ZCL}
+    \leanok
+    \uses{def:mpdo_active_sector_trace_matrix, def:nt_cpsv,
+      thm:mpdo_active_trace_matrix_literal_zcl_powers,
+      thm:mpdo_overlap_formula}
+    Let ${\cal K}$ be an MPO tensor with a physical-sector factorization
+    and sector weights $p_k$, such that every neighboring operator is
+    positive semidefinite, the left tensor of every zero-weight sector
+    vanishes, and the underlying tensor is normal in the sense of
+    Definition~\ref{def:nt_cpsv}. Then the active sector set has exactly
+    one element:
+    \begin{align}
+        \left|I_*\right|&=1.
+        \notag
+    \end{align}
+    This is a project derivation completing the Case-I route toward
+    \cite[Appendix~C.2, Lemma~C.5, lines~1473--1499]{Cirac2016MPDO_arXiv};
+    it is not a statement of that source.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_active_sector_trace_matrix, thm:mpdo_overlap_formula}
+    By contradiction: suppose $|I_*|\geq2$. The overlap formula and the
+    normal self-overlap limit
+    (\cite[lines~1080--1100]{Cirac2016MPDO_arXiv}) give
+    $\tr((S^*)^N)\to1$. Conjugating the primitive trace matrix $T^*$ by
+    its positive Perron eigenvector (with eigenvalue $1$, obtained from
+    the positive rank-one factorization of $(T^*)^2$ under $(T^*)^2=(T^*)^3$)
+    yields a row-stochastic primitive matrix $P$; the matching squared
+    conjugation of $S^*$ is bounded entrywise by $P\odot P$. Since
+    $|I_*|\geq2$, $P$ is an irreducible substochastic matrix on a
+    nontrivial index set, so $\tr((S^*)^N)\to0$, contradicting the limit
+    of $1$.
+\end{proof}
+
+\begin{theorem}[The Case-I relation $(T^*)^2=T^*$]
+    \label{thm:mpdo_active_trace_matrix_pow_two_eq}
+    \lean{MPOTensor.activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL}
+    \leanok
+    \uses{thm:mpdo_active_sector_singleton,
+      thm:mpdo_active_trace_matrix_literal_zcl_powers}
+    Under the hypotheses of Theorem~\ref{thm:mpdo_active_sector_singleton},
+    \begin{align}
+        \left(T^*\right)^2&=T^*.
+        \notag
+    \end{align}
+    This is the Case-I input to the proof of Lemma~C.5
+    (\cite[Appendix~C.2, lines~1473--1499]{Cirac2016MPDO_arXiv}), not the
+    lemma's headline statement.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_active_sector_singleton}
+    On the singleton active sector set, $T^*$ is a scalar $t$. Stabilization
+    gives $t^2=t^3$, and positivity of $(T^*)^2$ gives $t^2>0$, hence
+    $t=1$ and $t^2=t$.
+\end{proof}


### PR DESCRIPTION
Closes #5548 (Perron eigenvector prerequisite). Closes #5436 (Case-I singleton-sector assembly).

## Slice 1: Perron eigenvector (`Algebra/PerronFrobenius/PerronVector.lean`)

- `Matrix.IsPrimitive.exists_pos_eigenvector_one_of_pow_two_eq_pow_three`: for a primitive matrix `T` with `T² = T³`, a strictly positive eigenvector with eigenvalue exactly `1`.
- `Matrix.IsPrimitive.exists_rowStochastic_diagonal_conj_of_pow_two_eq_pow_three`: the diagonal conjugate `D⁻¹ T D` of `T` by this eigenvector is row-stochastic and primitive.
- `Matrix.diagonal_inv_mul_mul_diagonal_apply`: the entrywise formula for a diagonal similarity conjugate, extracted as reusable infrastructure and consumed by both slice-1 and slice-2 proofs.

**Why this is simpler than a general Perron-Frobenius existence theorem**: the existing rank-one factorization `T² = vecMulVec a b` (`a, b > 0`, `a ⬝ᵥ b = 1`, from `IsPrimitive.exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three`) already gives `T² a = a`. Hence `v := a + T a` is a strictly positive eigenvector of `T` itself with eigenvalue exactly `1`. No Brouwer-fixed-point argument on the probability simplex is needed for this specialized `T² = T³` case (checked: Mathlib has no applicable eigenvector existence theorem for primitive nonnegative matrices).

## Slice 2: the Case-I singleton-sector assembly (`MPS/MPDO/LemmaC5CaseI.lean`)

- `card_activeSector_eq_one_of_literal_ZCL`: under literal ZCL, positive neighboring operators, primitivity, and normality (in the paper's spectral-radius-one sense), the active sector set is a singleton.
- `activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL`: the Case-I relation `T² = T`, a direct corollary.

The singleton-sector proof is by contradiction, following the source-faithful route from issue #5404: the overlap formula (#5539) and normality (`MPSTensor.IsNormalTensor.selfOverlap_tendsto_one`, the `equalMPS` self-overlap limit) give `tr(S^N) → 1`; conjugating the primitive `T` by its Perron vector (slice 1) to a stochastic matrix `P` bounds `S`, after the matching squared conjugation, entrywise by `P ⊙ P`; if more than one sector were active, `P` would be irreducible substochastic on a nontrivial index set, forcing `tr(S^N) → 0` (`Matrix.trace_pow_tendsto_zero_of_nonneg_le_hadamard_self`, #5408/#5411), a contradiction.

**Remaining gap**: `Q(1-LQ)L = 0` is the same fact as `T² = T` under the rectangular decomposition `T = QL` already used in `activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL`'s proof; restating it in that form is not yet formalized (documented in the module docstring, tracked toward the source's Lemma `SALZCL` conclusion).

**Validation**: `lake build TNLean.MPS.MPDO.LemmaC5CaseI` and a full `lake build TNLean` (9922 jobs) both pass. `lake exe lint_style --github` clean. No `sorry`/`axiom`. `git diff --check` clean. Lines ≤100 chars.