### PR TITLE
fix(tenkz): let a declared-skin row be chained

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -181,6 +181,21 @@ at_ports=$(awk '/^picture\|id=k2\|/ { seen = 1 }
   echo "FAIL: the two placements reached different open physical boundaries" >&2
   exit 1
 }
+chain_pairing=$(awk '/^picture\|id=k2\|/ { exit } /^wire\|/' \
+  "$WORK/r_skin_pairing_chain_placed.tnlog" | sed 's/addr-[0-9]*/addr/g')
+at_pairing=$(awk '/^picture\|id=k2\|/ { seen = 1 }
+  seen && /^wire\|/' \
+  "$WORK/r_skin_pairing_chain_placed.tnlog" | sed 's/addr-[0-9]*/addr/g')
+[ -n "$chain_pairing" ] && [ "$chain_pairing" = "$at_pairing" ] || {
+  echo "FAIL: a declared skin's pairings differ between the two placements" >&2
+  exit 1
+}
+[ "$(grep -Fc \
+      'kernel-boundary|signature=open:e, open:w, phys:n, phys:n, phys:s, phys:s' \
+      "$WORK/r_skin_pairing_chain_placed.tnlog" || true)" -eq 2 ] || {
+  echo "FAIL: a chained pairing carrier reached a different boundary" >&2
+  exit 1
+}
 grep -Fq 'kernel-boundary|signature=phys:n' \
     "$WORK/r_port_physical_open.tnlog" || {
   echo "FAIL: physical port type did not reach its explicit open boundary" >&2

--- a/tests/tenkz/kernel/regression/r_skin_pairing_chain_placed.tex
+++ b/tests/tenkz/kernel/regression/r_skin_pairing_chain_placed.tex
@@ -1,0 +1,26 @@
+% Regression: a declared skin's own pairings are placement-agnostic.  The
+% same row of carriers is stated twice, once with the chain cursor and once
+% with explicit addresses, and must record the same typed ports and the same
+% boundary.  Reading a carrier's cell through its address node alone left the
+% chained spelling with no cell at all and spun the compiler (issue 5528).
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\tndeclare{species}{right}{hue=source:blue}
+\tndeclare{species}{left}{hue=source:red}
+\tndeclare{skin}{shift-right}{
+  base=box,
+  pairings={n@1 > e@1 : right, s@1 > w@1 : left}
+}
+\begin{tenkz}[rows={wire}, cols=2, bonds=none, physical=updown]
+  \tn[skin=shift-right]{} & \tn[skin=shift-right]{}
+  \tnwire{open w}{(1,1)} \tnwire{(1,1)}{(1,2)} \tnwire{(1,2)}{open e}
+\end{tenkz}
+\qquad
+\begin{tenkz}[rows={wire}, cols=2, bonds=none, physical=updown]
+  \tn[at=(1,1), skin=shift-right]{}
+  \tn[at=(1,2), skin=shift-right]{}
+  \tnwire{open w}{(1,1)} \tnwire{(1,1)}{(1,2)} \tnwire{(1,2)}{open e}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-two-shift.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-two-shift.tex
@@ -22,10 +22,10 @@
   \begin{tenkz}[rows={wire,wire}, cols=4, bonds=none, physical=updown]
     % The upper row turns right (blue) and its lower legs turn left (red);
     % the lower row reverses both, as in the published panel.
-    \tn[at=(1,1), skin=shift-right]{} \tn[at=(1,2), skin=shift-right]{}
-    \tn[at=(1,3), skin=shift-right]{} \tn[at=(1,4), skin=shift-right]{}
-    \tn[at=(2,1), skin=shift-left]{} \tn[at=(2,2), skin=shift-left]{}
-    \tn[at=(2,3), skin=shift-left]{} \tn[at=(2,4), skin=shift-left]{}
+    \tn[skin=shift-right]{} & \tn[skin=shift-right]{} &
+    \tn[skin=shift-right]{} & \tn[skin=shift-right]{} \\
+    \tn[skin=shift-left]{} & \tn[skin=shift-left]{} &
+    \tn[skin=shift-left]{} & \tn[skin=shift-left]{}
     \tnwire{open w}{(1,1)} \tnwire{(1,1)}{(1,2)}
     \tnwire{(1,2)}{(1,3)} \tnwire{(1,3)}{(1,4)}
     \tnwire{(1,4)}{open e}

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -154,10 +154,11 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "ec201c6800c6f9dffe49d2b7d06a63d6d6434afb8529f3bc49e6a795c1f3ec8b"
-reviewed = "2026-08-04"
-renderer = "kimi-kernel-pairings-source-review-2026-08-04-200dpi"
-note = "The X row is resolved: the case now records the source pairing boxes and open legs through the mpu-wrap-second skin-pairings model, with the right mover source-blue and the left mover source-red. Residue: the row channels keep house ink where the published panel colours the movers."
+case_sha256 = "8ed99f9b371ff8e0a8408398a72a154f01c19401e762270768e397dc9f15475a"
+reviewed = "2026-08-05"
+renderer = "claude-5528-chain-placed-pairings-2026-08-05-200dpi"
+second_viewer = "claude-5528-countersign-sec2fig7c-b-2026-08-05-200dpi"
+note = "The X row is resolved: the case now records the source pairing boxes and open legs through the mpu-wrap-second skin-pairings model, with the right mover source-blue and the left mover source-red. The eight carriers now stand on the chain cursor rather than on eight written addresses, and the 200 dpi raster is byte-identical to the addressed spelling it replaces. Residue: the row channels keep house ink where the published panel colours the movers."
 
 [[verdict]]
 id = "rmp-ii-mpu-normal-form"

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -4589,6 +4589,9 @@
 \tl_new:N   \l__tenkz_kernel_r_touch_b_tl
 \tl_new:N   \l__tenkz_kernel_r_touch_c_tl
 \tl_new:N   \l__tenkz_kernel_r_touch_d_tl
+\tl_new:N   \l__tenkz_kernel_r_touch_row_tl
+\tl_new:N   \l__tenkz_kernel_r_touch_col_tl
+\bool_new:N \l__tenkz_kernel_r_touch_cell_bool
 \tl_new:N   \l__tenkz_kernel_r_hue_tl
 \tl_new:N   \l__tenkz_kernel_r_species_tl
 \tl_new:N   \l__tenkz_kernel_r_species_descriptor_tl
@@ -12723,13 +12726,18 @@
     \bool_set_false:N \l_tmpa_bool
     % An ordinary index ending on the pairing's carrier is attached to that
     % carrier, even when grid sugar represented the end by its occupied cell
-    % rather than by an explicit port node.
+    % rather than by an explicit port node.  The carrier's cell is asked for
+    % by the one question both placements answer: an "at=" carrier keeps its
+    % address as a node, a chained carrier as address text, and reading the
+    % node alone leaves a chained carrier with no cell at all (issue 5528).
     \__tenkz_model_get:nnN {#2} {host} \l__tenkz_kernel_r_touch_c_tl
     \quark_if_no_value:NF \l__tenkz_kernel_r_touch_c_tl
       {
-        \__tenkz_model_get:nnN
-          { \l__tenkz_kernel_r_touch_c_tl } {node}
-          \l__tenkz_kernel_r_touch_d_tl
+        \exp_args:NV \__tenkz_kernel_atom_rc:nNNN
+          \l__tenkz_kernel_r_touch_c_tl
+          \l__tenkz_kernel_r_touch_row_tl
+          \l__tenkz_kernel_r_touch_col_tl
+          \l__tenkz_kernel_r_touch_cell_bool
         \clist_map_inline:nn {from,to}
           {
             \__tenkz_model_get:nnN {#1} {##1}
@@ -12754,28 +12762,25 @@
                       }
                     {cell}
                       {
-                        \bool_lazy_and:nnT
+                        \bool_lazy_all:nT
                           {
-                            \str_if_eq_p:ee
-                              {
-                                \__tenkz_kernel_r_item:nn
-                                  { \l__tenkz_kernel_r_touch_a_tl } {row}
-                              }
-                              {
-                                \__tenkz_kernel_r_item:nn
-                                  { \l__tenkz_kernel_r_touch_d_tl } {row}
-                              }
-                          }
-                          {
-                            \str_if_eq_p:ee
-                              {
-                                \__tenkz_kernel_r_item:nn
-                                  { \l__tenkz_kernel_r_touch_a_tl } {col}
-                              }
-                              {
-                                \__tenkz_kernel_r_item:nn
-                                  { \l__tenkz_kernel_r_touch_d_tl } {col}
-                              }
+                            { \l__tenkz_kernel_r_touch_cell_bool }
+                            {
+                              \str_if_eq_p:ee
+                                {
+                                  \__tenkz_kernel_r_item:nn
+                                    { \l__tenkz_kernel_r_touch_a_tl } {row}
+                                }
+                                { \l__tenkz_kernel_r_touch_row_tl }
+                            }
+                            {
+                              \str_if_eq_p:ee
+                                {
+                                  \__tenkz_kernel_r_item:nn
+                                    { \l__tenkz_kernel_r_touch_a_tl } {col}
+                                }
+                                { \l__tenkz_kernel_r_touch_col_tl }
+                            }
                           }
                           { \bool_set_true:N \l_tmpa_bool }
                       }


### PR DESCRIPTION
## The minimal input that hung

One atom. One wire.

```tex
\tenkzkernel
\tndeclare{species}{right}{hue=source:blue}
\tndeclare{skin}{shift-right}{ base=box, pairings={n@1 > e@1 : right} }
\begin{tenkz}[rows={wire}, cols=1]
  \tn[skin=shift-right]{}
  \tnwire{open w}{(1,1)}
\end{tenkz}
```

`timeout 60 xelatex` never returns. Writing the same atom as
`\tn[at=(1,1), skin=shift-right]{}` compiles in a second. Neither the row
break nor a second column is needed: the chain cursor, a declared skin
carrying its own pairings, and one index that touches the carrier are the
whole recipe. Dropping the pairings, or dropping the wire, or writing the
address makes it compile.

## The cause

An atom placed by `at=` records its address as a NODE; an atom placed by the
chain cursor records it as address TEXT. `\__tenkz_kernel_r_wires_share_port:nn`
asked for the pairing carrier's cell by reading the node alone, so for a
chained carrier it got `\q_no_value` and then handed that quark to
`\prop_item:Ne`. A quark expands to itself, and this one was inside an
e-expansion: the compiler spun on `\q_no_value ->\q_no_value` with nothing
written to the log.

The kernel already owns the question both placements answer —
`\__tenkz_kernel_atom_rc:nNNN`, "the grid cell an atom occupies, whichever
way the author placed it". The pairing test now asks it, and honours the
boolean it returns for placements that have no cell at all.

## What moved

- `tex/tenkz/tenkz-kernel.code.tex` — the carrier's cell comes from the
  placement-agnostic accessor.
- `tests/tenkz/kernel/regression/r_skin_pairing_chain_placed.tex` — a
  declared-skin-with-pairings row stated twice, chained and addressed.
- `scripts/tenkz_kernel_probes.sh` — the two spellings must record the same
  wires (address ids normalized) and the same boundary signature. They do.
- `tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-two-shift.tex` — the consumer
  returns to the chained spelling PR LionSR/TNLean#5527 had to revert. Its 200 dpi raster
  is byte-identical to the addressed spelling's
  (`3a4fb0d02dd5ce6bfdd117660c9f05cd895e1801b8d8b257e1766c5a5c72a0c3`), and it
  still carries the same residue against `sec2fig7c (b).pdf`: two rows of four
  boxes, four up and four down legs per row, two open virtual endpoints, turn
  orientation reversed between rows; the row channels keep house ink where the
  published panel colours the movers.
- `tests/tenkz/rmp/verdicts.toml` — `case_sha256` re-pinned with a
  `second_viewer` countersignature.

## Validation

- `bash scripts/tenkz_kernel_probes.sh` — PASS: 117 review regressions hold;
  9 sugar spellings byte-identical; 12 kernel record streams byte-identical;
  kernel pixels byte-identical.
- `python3 scripts/test_tenkz_kernel_audit.py` — PASS: parser, crossings,
  boundaries, and geometry.
- `python3 scripts/tenkz_rmp.py check --section section-ii` — PASS: 48 targets.
- `python3 scripts/test_tenkz_corpus_provenance.py` — PASS.
- `python3 scripts/test_tenkz_shrink.py` — 32 PASS.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — PASS: census
  stable at 201, all 147 flags carry verdicts.

No meter moves: the consumer's rewrite is line-neutral (four addressed atom
lines become four chained ones), so M4 stands at 25.94 and SHRINK.md gains no
session entry.

Closes LionSR/tenkz#154
