### PR TITLE
doc(blueprint): respell the moderate chapters onto the tenkz kernel (wave B2)

### DIFF
--- a/blueprint/src/chapter/ch04_channels_choi_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_choi_foundations.tex
@@ -72,6 +72,7 @@ The Choi--Jamio\l{}kowski isomorphism bends the input legs of the channel $T$
 around the maximally entangled pair $\ket{\Omega}$, presenting the map as the
 matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space:
 \begin{center}
+    \tenkzkernel
     % Formula: \tau=(T\otimes\id)(\ketbra{\Omega}{\Omega}).
     % Source verdict: Wolf, Proposition 2.1 and Equation (2.1), applies the
     %   two-wire map T\otimes\id to the maximally entangled projector.
@@ -83,13 +84,10 @@ matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space:
     %   the other; the two west rails are the output indices of \tau.
     % Boundary signature: (virtual-west=2 | virtual-east=0 |
     % physical-up=0 | physical-down=0).
-    \begin{tenkz}[
-        rows={wire,wire},
-        east={cup=$\ketbra{\Omega}{\Omega}$},
-        west label=$\tau$
-    ]
-        \tnghost{} & \tnX[wires=2]{T\otimes\id} & \tnghost{} \\
-        \tnghost{} & & \tnghost{}
+    \begin{tenkz}[rows={wire,wire}, cols=2, west=open, east=cup]
+        \tn[skin=ring, wires=2,
+            ports={180@1:virtual:$\tau$, 180@2:virtual}]{T\otimes\id}
+        \tn[skin=ring, at=on cup-1-2 0.5]{\ketbra{\Omega}{\Omega}}
     \end{tenkz}
 \end{center}
 

--- a/blueprint/src/chapter/ch12_symmetry_virtual_and_cohomology.tex
+++ b/blueprint/src/chapter/ch12_symmetry_virtual_and_cohomology.tex
@@ -177,9 +177,10 @@ on the bond space.
     % Boundary: virtual-west=1 | virtual-east=1 | physical-up=1 |
     % physical-down=0.
     \begin{tenkzequation}
-        \begin{tenkz}[rows={op:none,ket}]
-            \tn[role=operator,up=$i$]{U(g)} \\
-            \tn{A}
+        \tenkzkernel
+        \begin{tenkz}[rows={op,ket}, cols=1, west=none, east=none]
+            \tn[species=operator, label pos=w, ports={90:physical:$i$}]{U(g)} \\
+            \tn[label pos=s, ports={180:virtual, 0:virtual}]{A}
         \end{tenkz}
         \(\qquad \leadsto \qquad\)
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
@@ -192,8 +193,9 @@ on the bond space.
         % Type verdict: a rank-three twisted local tensor.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0.
-        \begin{tenkz}[physical=up]
-            \tnX{X(g)} & \tn[up=$i$]{A} & \tnX{X(g)^{-1}}
+        \begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
+            \tn[skin=ring]{X(g)} & \tn[label pos=s, ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{X(g)^{-1}}
         \end{tenkz}.
     \end{tenkzequation}
     Apply Lemma~\ref{lem:gauge_equiv_twisted} to obtain $X(g)$, then
@@ -313,8 +315,8 @@ on the bond space.
     \end{align}
     In tensor-network notation, for each fixed~$g$ this is the local gauge
     relation
-    \begin{align}
-         &
+    \begin{center}
+        \tenkzkernel
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
         % lines 328--349, gives the unitary u,V specialization
         % (V^\dagger = V^{-1}); the surrounding fundamental theorem supplies
@@ -325,11 +327,11 @@ on the bond space.
         % Type verdict: a rank-three local tensor for each fixed g.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0.
-        \begin{tenkz}[physical=up]
-            \tnX{X(g)} & \tn[up=$i$]{A} & \tnX{X(g)^{-1}}
+        \begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
+            \tn[skin=ring]{X(g)} & \tn[label pos=s, ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{X(g)^{-1}}
         \end{tenkz}
-        \notag
-    \end{align}
+    \end{center}
     with the black node denoting the tensor named in the surrounding
     formula and the two red side nodes acting on the virtual legs.
     In particular, $\rho$ is a projective representation of $G$ on the
@@ -443,6 +445,7 @@ make this precise and establish the quotient $H^2(G,\C^{\times})$.
     $\rho_2(g)=f(g^{-1})\rho_1(g)$.
     Equivalently, for each fixed $g$ the two local gauges
     \begin{tenkzequation}
+        \tenkzkernel
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
         % lines 328--349, gives the unitary u,V specialization
         % (V^\dagger = V^{-1}); the surrounding fundamental theorem supplies
@@ -453,9 +456,10 @@ make this precise and establish the quotient $H^2(G,\C^{\times})$.
         % Type verdict: a rank-three local tensor.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0.
-        \begin{tenkz}[physical=up]
-            \tnX{X_1(g^{-1})} & \tn[up=$i$]{A} &
-            \tnX{X_1(g^{-1})^{-1}}
+        \begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
+            \tn[skin=ring]{X_1(g^{-1})} &
+            \tn[label pos=s, ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{X_1(g^{-1})^{-1}}
         \end{tenkz}
         \qquad \text{and} \qquad
         % Formula/source: the same source passage, with the second virtual
@@ -466,9 +470,10 @@ make this precise and establish the quotient $H^2(G,\C^{\times})$.
         % Type verdict: a rank-three local tensor, comparable to the left picture.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0.
-        \begin{tenkz}[physical=up]
-            \tnX{X_2(g^{-1})} & \tn[up=$i$]{A} &
-            \tnX{X_2(g^{-1})^{-1}}
+        \begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
+            \tn[skin=ring]{X_2(g^{-1})} &
+            \tn[label pos=s, ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{X_2(g^{-1})^{-1}}
         \end{tenkz}
     \end{tenkzequation}
     describe the same twisted tensor, so they differ by a scalar. Set

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -23,6 +23,7 @@ $\tr(XA^\sigma)$ for the local space $\mathcal G_L^A$.
     The map $\Gamma_L$ in (\ref{eq:parent_gamma}) is a $\C$-linear map from
     $\MN{D}$ to $(\Fin{d}^{L}\to\C)$. In tensor-network notation,
     \begin{center}
+        \tenkzkernel
         % Formula/source: Papers/quant-ph_0608197/MPSarchive.tex,
         % lines 889--898, defines Gamma_L(X) with coefficients
         % tr(X A_{i_1}\cdots A_{i_L}).
@@ -32,10 +33,12 @@ $\tr(XA^\sigma)$ for the local space $\mathcal G_L^A$.
         % Type verdict: a rank-L physical tensor, equivalently a length-L state.
         % Boundary signature: semantic virtual-west=0 | virtual-east=0 |
         % physical-up=L | physical-down=0; the finite schematic emits 3 up legs.
-        \begin{tenkz}[periodic, physical=up]
-            \tnX{X} &
-            \tn[up=$\sigma_1$]{A}\tnspan[brace below]{4}{L} &
-            \tn{A} & \tndots & \tn[up=$\sigma_L$]{A}
+        \begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace]
+            \tn[skin=ring]{X} &
+            \tn[label pos=135, ports={90:physical:$\sigma_1$}]{A} &
+            \tn[label pos=135, ports={90:physical}]{A} & \tn[skin=dots]{} &
+            \tn[label pos=135, ports={90:physical:$\sigma_L$}]{A}
+            \tnmark[form=bracket]{(1,2) .. (1,5)}{$L$}
         \end{tenkz}
     \end{center}
     The chain denotes the word tensor $A^\sigma$ with open physical indices
@@ -478,6 +481,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \leanok
     The restriction simply absorbs the last tensor into the boundary matrix:
     \begin{center}
+        \tenkzkernel
         % Formula/source: Papers/quant-ph_0608197/MPSarchive.tex,
         % lines 889--898, with boundary argument A^j X in Gamma_L.
         % Ink-to-index map: sigma_1,...,sigma_L remain free; j is absorbed into
@@ -486,10 +490,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         % Type verdict: a rank-L physical tensor in G_L(A).
         % Boundary signature: semantic virtual-west=0 | virtual-east=0 |
         % physical-up=L | physical-down=0; the finite schematic emits 3 up legs.
-        \begin{tenkz}[periodic, physical=up]
-            \tnX{A^j X} &
-            \tn[up=$\sigma_1$]{A}\tnspan[brace below]{4}{L} &
-            \tn{A} & \tndots & \tn[up=$\sigma_L$]{A}
+        \begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace]
+            \tn[skin=ring]{A^j X} &
+            \tn[label pos=135, ports={90:physical:$\sigma_1$}]{A} &
+            \tn[label pos=135, ports={90:physical}]{A} & \tn[skin=dots]{} &
+            \tn[label pos=135, ports={90:physical:$\sigma_L$}]{A}
+            \tnmark[form=bracket]{(1,2) .. (1,5)}{$L$}
         \end{tenkz}
     \end{center}
     Direct computation gives
@@ -517,6 +523,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     On the right restriction, one first rotates the trace and then reads the
     resulting boundary matrix on the shortened window:
     \begin{center}
+        \tenkzkernel
         % Formula/source: Papers/quant-ph_0608197/MPSarchive.tex,
         % lines 889--898, with the cyclically rotated boundary argument X A^i.
         % Ink-to-index map: sigma_1,...,sigma_L remain free; i has been absorbed
@@ -525,10 +532,12 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         % Type verdict: a rank-L physical tensor in G_L(A).
         % Boundary signature: semantic virtual-west=0 | virtual-east=0 |
         % physical-up=L | physical-down=0; the finite schematic emits 3 up legs.
-        \begin{tenkz}[periodic, physical=up]
-            \tnX{X A^i} &
-            \tn[up=$\sigma_1$]{A}\tnspan[brace below]{4}{L} &
-            \tn{A} & \tndots & \tn[up=$\sigma_L$]{A}
+        \begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace]
+            \tn[skin=ring]{X A^i} &
+            \tn[label pos=135, ports={90:physical:$\sigma_1$}]{A} &
+            \tn[label pos=135, ports={90:physical}]{A} & \tn[skin=dots]{} &
+            \tn[label pos=135, ports={90:physical:$\sigma_L$}]{A}
+            \tnmark[form=bracket]{(1,2) .. (1,5)}{$L$}
         \end{tenkz}
     \end{center}
     By trace cyclicity,

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -51,6 +51,7 @@ on decay rates.
     Equivalently, insert $X$ at site $0$, propagate by $\E_A^n$, then insert
     $Y$ and take the trace.
     \begin{center}
+        \tenkzkernel
         % Formula: \langle X_0Y_n\rangle
         %   = \tr\!\left(Y\,\E_A^n(X\rho^R)\right).
         % Source verdict: Cirac2021Matrix, Section II.B.3, supports the
@@ -64,13 +65,10 @@ on decay rates.
         % instead feeds the adjoint and gives the same trace pairing with Y.
         % Boundary signature: (virtual-west=0 | virtual-east=0 |
         % physical-up=0 | physical-down=0).
-        \begin{tenkz}[
-            sandwich,
-            west={cup=$Y$},
-            east={cup=$X\rho^R$}
-        ]
-            \tnghost{} & \tnX[wires=2]{\E_A^n} & \tnghost{} \\
-            \tnghost{} & & \tnghost{}
+        \begin{tenkz}[rows={wire,wire}, cols=3, west=cup, east=cup]
+            \tn[at=(1,2), skin=ring, wires=2]{\E_A^n}
+            \tn[skin=ring, at=on cup-west-1-2 0.5]{Y}
+            \tn[skin=ring, at=on cup-east-1-2 0.5]{X\rho^R}
         \end{tenkz}
     \end{center}
 \end{definition}

--- a/blueprint/src/chapter/ch20_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch20_mpdo_foundations.tex
@@ -7,14 +7,15 @@
     $\{M^{ij}\}_{i,j=0}^{d-1}$ with $M^{ij} \in \MN{D}$, indexed by a ket
     index $i$ and a bra index $j$. Diagrammatically,
     \begin{center}
+        \tenkzkernel
         % Formula: (M^{ij})_{\alpha\beta}, with M^{ij}\in\operatorname{Mat}_D.
         % Ink/index correspondence: the west and east legs carry the free
         % virtual indices \alpha and \beta; the upper and lower legs carry the
         % free physical indices i and j.  Nothing is contracted, so the
         % boundary signature (virtual-west,virtual-east,physical-up,physical-down)
         % is (1,1,1,1).
-        \begin{tenkz}[physical=updown]
-            \tn[mpo, up=$i$, down=$j$]{M}
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+            \tn[skin=mpo, ports={90:physical:$i$, 270:physical:$j$}]{M}
         \end{tenkz}
     \end{center}
 \end{definition}
@@ -109,6 +110,7 @@
 
 Diagrammatically,
 \begin{center}
+    \tenkzkernel
     % Formula: \rho^{(N)}(M)_{\sigma,\tau}
     % = \tr(M^{\sigma_1\tau_1}\cdots
     % M^{\sigma_N\tau_N})
@@ -121,11 +123,11 @@ Diagrammatically,
     % \tau_1,\ldots,\tau_N, hence the semantic boundary signature is
     % (0,0,N,N).  The \tndots atom abbreviates the omitted cells, so the drawn
     % and logged physical arities are necessarily schematic rather than N.
-    \begin{tenkz}[physical=updown, periodic]
-        \tn[mpo, up=$\sigma_1$, down=$\tau_1$]{M} &
-        \tn[mpo, up=$\sigma_2$, down=$\tau_2$]{M} &
-        \tndots &
-        \tn[mpo, up=$\sigma_N$, down=$\tau_N$]{M}
+    \begin{tenkz}[rows={wire}, cols=4, west=trace, east=trace]
+        \tn[skin=mpo, ports={90:physical:$\sigma_1$, 270:physical:$\tau_1$}]{M} &
+        \tn[skin=mpo, ports={90:physical:$\sigma_2$, 270:physical:$\tau_2$}]{M} &
+        \tn[skin=dots]{} &
+        \tn[skin=mpo, ports={90:physical:$\sigma_N$, 270:physical:$\tau_N$}]{M}
     \end{tenkz}
 \end{center}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -773,6 +773,7 @@
         \notag
     \end{align}
     \begin{center}
+        \tenkzkernel
         % K_{3;k,l,h}(X) = B_{k,h}(X) (x) eta_{k,l} (x) eta_{l,h}: the
         % three-site closure of the sector-restricted MPO chain, after
         % regrouping its six bond-space legs (L_k,R_k,L_l,R_l,L_h,R_h),
@@ -789,32 +790,37 @@
         % Definition~\ref{def:mpdo_three_site_sector_closure}
         % (virtual-west=0 | virtual-east=0 | physical-up=6 |
         % physical-down=6 on both sides).
-        \begin{tenkz}[physical=updown, boundary=none, compact]
-            \tn[pill, wide=6, legs at={1,2,3,4,5,6},
-                up={$L_k$,$R_h$,$R_k$,$L_l$,$R_l$,$L_h$},
-                down={$L_k$,$R_h$,$R_k$,$L_l$,$R_l$,$L_h$}]
+        \begin{tenkz}[rows={wire}, cols=6, west=none, east=none]
+            \tn[skin=pill, wide=6,
+                ports={90@1:physical:$L_k$, 90@2:physical:$R_h$,
+                  90@3:physical:$R_k$, 90@4:physical:$L_l$,
+                  90@5:physical:$R_l$, 90@6:physical:$L_h$,
+                  270@1:physical:$L_k$, 270@2:physical:$R_h$,
+                  270@3:physical:$R_k$, 270@4:physical:$L_l$,
+                  270@5:physical:$R_l$, 270@6:physical:$L_h$}]
               {{\cal K}_{3;k,l,h}(X)}
         \end{tenkz}
         $\;=\;$
         % B_{k,h}(X): l_k and r_h flank the virtual matrix X on the
         % wire; their open legs are L_k and R_h.
-        \begin{tenkz}[physical=updown, boundary=none, compact]
-            \tn[up=$L_k$, down=$L_k$]{l_k} & \tnX{X} &
-            \tn[up=$R_h$, down=$R_h$]{r_h}
+        \begin{tenkz}[rows={wire}, cols=3, west=none, east=none]
+            \tn[label pos=225, ports={90:physical:$L_k$, 270:physical:$L_k$}]{l_k} &
+            \tn[skin=ring]{X} &
+            \tn[label pos=225, ports={90:physical:$R_h$, 270:physical:$R_h$}]{r_h}
         \end{tenkz}
         $\;\otimes\;$
         % eta_{k,l}: r_k and l_l share the contracted virtual bond
         % between sites k and l; their open legs are R_k and L_l.
-        \begin{tenkz}[physical=updown, boundary=none, compact]
-            \tn[up=$R_k$, down=$R_k$]{r_k} &
-            \tn[up=$L_l$, down=$L_l$]{l_l}
+        \begin{tenkz}[rows={wire}, cols=2, west=none, east=none]
+            \tn[label pos=225, ports={90:physical:$R_k$, 270:physical:$R_k$}]{r_k} &
+            \tn[label pos=225, ports={90:physical:$L_l$, 270:physical:$L_l$}]{l_l}
         \end{tenkz}
         $\;\otimes\;$
         % eta_{l,h}: r_l and l_h share the contracted virtual bond
         % between sites l and h; their open legs are R_l and L_h.
-        \begin{tenkz}[physical=updown, boundary=none, compact]
-            \tn[up=$R_l$, down=$R_l$]{r_l} &
-            \tn[up=$L_h$, down=$L_h$]{l_h}
+        \begin{tenkz}[rows={wire}, cols=2, west=none, east=none]
+            \tn[label pos=225, ports={90:physical:$R_l$, 270:physical:$R_l$}]{r_l} &
+            \tn[label pos=225, ports={90:physical:$L_h$, 270:physical:$L_h$}]{l_h}
         \end{tenkz}
     \end{center}
 \end{theorem}
@@ -870,6 +876,7 @@
           \notag
       \end{align}
       \begin{center}
+          \tenkzkernel
           % R_2(K_2(X))_{k,h} = a_kb_h B_{k,h}(X): the two-site
           % closure, restricted to sector pair (k,h) and traced over
           % its inner bond space R_k (x) L_h, factors into the scalar
@@ -885,15 +892,17 @@
           % no further horizontal index survives. Both sides carry
           % the same boundary signature (virtual-west=0 |
           % virtual-east=0 | physical-up=2 | physical-down=2).
-          \begin{tenkz}[physical=updown, boundary=none, compact]
-              \tn[pill, wide=2, legs at={1,2},
-                  up={{$L_k$},{$R_h$}}, down={{$L_k$},{$R_h$}}]
+          \begin{tenkz}[rows={wire}, cols=2, west=none, east=none]
+              \tn[skin=pill, wide=2,
+                  ports={90@1:physical:$L_k$, 90@2:physical:$R_h$,
+                    270@1:physical:$L_k$, 270@2:physical:$R_h$}]
                 {\mathfrak R_2({\cal K}_2(X))_{k,h}}
           \end{tenkz}
           $\;=\;a_kb_h\;$
-          \begin{tenkz}[physical=updown, boundary=none, compact]
-              \tn[up=$L_k$, down=$L_k$]{l_k} & \tnX{X} &
-              \tn[up=$R_h$, down=$R_h$]{r_h}
+          \begin{tenkz}[rows={wire}, cols=3, west=none, east=none]
+              \tn[label pos=225, ports={90:physical:$L_k$, 270:physical:$L_k$}]{l_k} &
+              \tn[skin=ring]{X} &
+              \tn[label pos=225, ports={90:physical:$R_h$, 270:physical:$R_h$}]{r_h}
           \end{tenkz}
       \end{center}
     \end{minipage}\hfill

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -326,12 +326,13 @@
 \end{definition}
 
 \begin{center}
+    \tenkzkernel
     % Exact source orientation: the upper layer is plain K_y and the lower
     % layer is plain K_x.  There is no conjugation or adjoint in AppKxKy=0.
     % Source: Papers/1606.00608/MPDO_KxKy.png and source TeX lines 1634--1639.
-    \begin{tenkz}[rows={op,op}]
-        \tn[mpo]{\mathcal K_y} \\
-        \tn[mpo]{\mathcal K_x}
+    \begin{tenkz}[rows={op,op}, cols=1, west=open, east=open]
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{\mathcal K_y} \\
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{\mathcal K_x}
     \end{tenkz}
     $ = 0$
 \end{center}
@@ -840,6 +841,7 @@ leaves only the diagonal term:
       =\mathcal K_i\,P_i. \notag
 \end{align}
 \begin{center}
+    \tenkzkernel
     % K_i = sum_{j,j'} P_j K_i P_{j'} = P_i K_i = K_i P_i: each
     % sector tensor absorbs its own projector.  All four terms
     % expose the same open indices -- one west stub, one east
@@ -847,24 +849,27 @@ leaves only the diagonal term:
     % (the physical legs, closed under sum_j P_j = Id) -- so all
     % four panels log the same boundary signature
     % (virtual-west=1 | virtual-east=1 | physical-up=1 | physical-down=1).
-    \begin{tenkz}[physical=updown]
-        \tn[mpo]{K_i}
+    \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{K_i}
     \end{tenkz}
     $ = \sum_{j,j'}$
-    \begin{tenkz}[rows={op:none, op, op:none}]
-        \tn[mpo]{P_j} \\
-        \tn[mpo]{K_i} \\
-        \tn[mpo]{P_{j'}}
+    \begin{tenkz}[rows={op,op,op}, cols=1, west=none, east=none]
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{P_j} \\
+        \tn[skin=mpo, ports={90:physical, 270:physical, 180:virtual, 0:virtual}]
+          {K_i} \\
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{P_{j'}}
     \end{tenkz}
     $ = $
-    \begin{tenkz}[rows={op:none, op}]
-        \tn[mpo]{P_i} \\
-        \tn[mpo]{K_i}
+    \begin{tenkz}[rows={op,op}, cols=1, west=none, east=none]
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{P_i} \\
+        \tn[skin=mpo, ports={90:physical, 270:physical, 180:virtual, 0:virtual}]
+          {K_i}
     \end{tenkz}
     $ = $
-    \begin{tenkz}[rows={op, op:none}]
-        \tn[mpo]{K_i} \\
-        \tn[mpo]{P_i}
+    \begin{tenkz}[rows={op,op}, cols=1, west=none, east=none]
+        \tn[skin=mpo, ports={90:physical, 270:physical, 180:virtual, 0:virtual}]
+          {K_i} \\
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{P_i}
     \end{tenkz}
 \end{center}
 Equivalently, each local tensor is supported on its own sector:

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
@@ -347,22 +347,24 @@
     % One-tensor boundary signature:
     %   boundary|virtual-west=1|virtual-east=1|physical-up=1|physical-down=0.
     \begin{center}
-        \tnpic[physical=up]{
-            \tn[label pos=south]{A_R} & \tn[label pos=south]{A}
-        }
+        \tenkzkernel
+        \begin{tenkz}[rows={wire}, cols=2, west=open, east=open]
+            \tn[label pos=s, ports={90:physical}]{A_R} &
+            \tn[label pos=s, ports={90:physical}]{A}
+        \end{tenkz}
         \quad$=$\quad
-        \tnpic[physical=up]{
-            \tn[label pos=south]{A_S}
-        }
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+            \tn[label pos=s, ports={90:physical}]{A_S}
+        \end{tenkz}
         \quad$\propto$\quad
-        \tnpic[physical=up]{
-            \tn[label pos=south]{\widetilde B_S}
-        }
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+            \tn[label pos=s, ports={90:physical}]{\widetilde B_S}
+        \end{tenkz}
         \quad$=$\quad
-        \tnpic[physical=up]{
-            \tn[label pos=south]{\widetilde B_R} &
-            \tn[label pos=south]{\widetilde B}
-        }.
+        \begin{tenkz}[rows={wire}, cols=2, west=open, east=open]
+            \tn[label pos=s, ports={90:physical}]{\widetilde B_R} &
+            \tn[label pos=s, ports={90:physical}]{\widetilde B}
+        \end{tenkz}.
     \end{center}
     Applying the left inverse supplied by injectivity of the block
     $A_R=\lambda_R\widetilde B_R$ gives

--- a/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
@@ -440,6 +440,7 @@ ambient bond space.
     \centering
     $A=X\sqrt\rho\,U\,X^{-1}$
     \begin{center}
+        \tenkzkernel
         % A^i = X sqrt(rho) U^i X^{-1} (the corrected local packaging of
         % eq_III_NT_RFP, CPSV16 Lemma lem:charact-NT-pure-RFP, lines
         % 1275-1289; docs/paper-gaps/cpsv16_rfp_isometry_scope.tex):
@@ -449,12 +450,13 @@ ambient bond space.
         % (west, into sqrt(rho)) and beta (east, into X^{-1}).  Both
         % sides carry the same boundary signature
         % (virtual-west=1 | virtual-east=1 | physical-up=1).
-        \begin{tenkz}[physical=up]
-            \tn[up=$i$]{A}
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+            \tn[label pos=s, ports={90:physical:$i$}]{A}
         \end{tenkz}
         $ = $
-        \begin{tenkz}[physical=up]
-            \tnX{X} & \tnX{\sqrt\rho} & \tn[up=$i$]{U} & \tnX{X^{-1}}
+        \begin{tenkz}[rows={wire}, cols=4, west=open, east=open]
+            \tn[skin=ring]{X} & \tn[skin=ring]{\sqrt\rho} &
+            \tn[label pos=s, ports={90:physical:$i$}]{U} & \tn[skin=ring]{X^{-1}}
         \end{tenkz}
     \end{center}
     \caption{The square-root form of a normal renormalization fixed point:

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -54,21 +54,21 @@ separate public-surface occurrence and therefore appears separately.
 |---|---|---|---|
 | `ch02_mps.tex` | — | L200 `tenkz` → `C-policy+C-record` | L24, 54, 171, 272, 840, 966 `tenkz` → `C-policy+C-record+R-record` |
 | `ch03_single.tex` | L251 `tenkz` → `P-grid` | — | — |
-| `ch04_channels_choi_foundations.tex` | — | — | L86 `tenkz` → `C-policy+C-record+R-record` |
+| `ch04_channels_choi_foundations.tex` | L87 `tenkz` → `P-grid` | — | — |
 | `ch11_fundamental_theorem_core.tex` | L42, 46 `tenkz` → `P-grid` | — | — |
 | `ch12_symmetry_string_order.tex` | — | L396, 410, 453, 468, 549, 563 `tenkz` → `C-policy+C-record` | L39, 352, 499, 866 `tenkz` → `C-record+C-species+R-record`<br>L73 `tenkz` → `C-policy+C-record+C-species+R-record`<br>L367, 513, 871 `tenkz` → `C-policy+C-record+R-record` |
-| `ch12_symmetry_virtual_and_cohomology.tex` | — | — | L180 `tenkz` → `C-record+C-species+R-record`<br>L195, 328, 456, 469 `tenkz` → `C-policy+C-record+R-record` |
+| `ch12_symmetry_virtual_and_cohomology.tex` | L181, 196, 330, 459, 473 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | — | — | L54 `tenkzfree` → `R-free+R-record` |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | — | — | L275 `tenkzfree` → `R-free+R-record` |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | L101 `tenkz` → `C-policy` | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | — | — | L35, 489, 528 `tenkz` → `C-policy+C-record+R-record` |
-| `ch14_correlations.tex` | — | — | L67 `tenkz` → `C-policy+C-record+R-record` |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 493, 535 `tenkz` → `P-grid` | — | — |
+| `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | — | L674 `tenkz` → `C-policy+C-record` | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L24 `tenkz` → `C-policy+C-record` | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L234, 240 `tenkz` → `C-policy+C-record` | L154, 160, 338, 435 `tenkz` → `C-policy+C-record+R-record`<br>L178, 183 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |
 | `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 644 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_foundations.tex` | — | — | L16, 124, 370 `tenkz` → `C-policy+C-record+R-record`<br>L374 `tenkz` → `C-record+R-record` |
+| `ch20_mpdo_foundations.tex` | L17, 126 `tenkz` → `P-grid` | — | L372 `tenkz` → `C-policy+C-record+R-record`<br>L376 `tenkz` → `C-record+R-record` |
 | `ch21_mpdo_rfp_algebra_tower.tex` | — | L79, 95 `tenkz` → `C-policy` | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_foundations.tex` | — | L87, 92 `tenkz` → `C-policy` | — |
@@ -79,12 +79,12 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | L282, 288 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |
-| `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | — | — | L792, 801, 808, 815, 888, 894 `tenkz` → `C-policy+C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L793, 806, 814, 821, 895, 902 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex` | — | — | L427 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | L189 `tenkz` → `C-policy` | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L332 `tenkz` → `C-record`<br>L850 `tenkz` → `C-policy+C-record` | L854, 860, 865 `tenkz` → `C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L333, 852, 856, 863, 869 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |
@@ -99,33 +99,33 @@ separate public-surface occurrence and therefore appears separately.
 | `ch24_peps_ft_normal_square_rectangular_injectivity.tex` | — | — | L205, 214 `tenkzlattice` → `R-lattice+R-record` |
 | `ch24_peps_ft_normal_square_translated_windows_and_comparison.tex` | — | — | L380 `tenkzlattice` → `R-lattice+R-record` |
 | `ch24_peps_ft_normal_union.tex` | — | — | L213, 270, 301, 327, 358 `tenkzfree` → `R-free+R-record` |
-| `ch24_peps_ft_region_transfer_covariance.tex` | — | L350, 354, 358, 362 `tnpic` → `C-picture+C-policy` | — |
+| `ch24_peps_ft_region_transfer_covariance.tex` | L351, 356, 360, 364 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_torus_translation_and_reference_windows.tex` | — | — | L22 `tenkzlattice` → `C-species+R-lattice+R-record` |
-| `ch26_mps_rfp_normal_isometry_canonical_forms.tex` | — | — | L452, 456 `tenkz` → `C-policy+C-record+R-record`<br>L603 `tenkz` → `C-policy+R-record`<br>L608 `tenkzfree` → `R-free+R-record` |
+| `ch26_mps_rfp_normal_isometry_canonical_forms.tex` | L453, 457 `tenkz` → `P-grid` | — | L605 `tenkz` → `C-policy+R-record`<br>L610 `tenkzfree` → `R-free+R-record` |
 | `ch26_mps_rfp_physical_blocking.tex` | — | — | L198, 223 `tenkz` → `C-policy+C-record+R-record`<br>L202, 217 `tenkz` → `C-record+R-record` |
 
 ### Blueprint reconciliation
 
 | Raw construct | Occurrences |
 |---|---:|
-| `tenkz` | 110 |
+| `tenkz` | 114 |
 | `tenkzeq` | 0 |
 | `tenkzfree` | 36 |
 | `tenkzlattice` | 18 |
 | `tenkzcd` | 6 |
 | `tenkzplanes` | 0 |
-| `tnpic` | 26 |
+| `tnpic` | 22 |
 | `tntree` | 11 |
 | **Total** | **207** |
 
 | Disposition | Occurrences |
 |---|---:|
-| preserve | 9 |
-| codemod | 39 |
-| redraw | 159 |
+| preserve | 38 |
+| codemod | 33 |
+| redraw | 136 |
 | **Total** | **207** |
 
-The raw count is 166 environment openings plus 41 command occurrences,
+The raw count is 174 environment openings plus 33 command occurrences,
 which reconciles to 207. This reproduces the issue baseline: 106 `tenkz`,
 36 `tenkzfree`, 18 `tenkzlattice`, 6 `tenkzcd`, 0 `tenkzeq`,
 0 `tenkzplanes`, and 41 `\tnpic`/`\tntree` lines.

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2099,3 +2099,44 @@ The new leaf is the one census move: M1 kernel 139 to 140, M2 parser paths
 | flag:consumers:key:kernel-wire:stroke | keep-because: kernel-scope rows count no demand-corpus consumers before the S4 surface swap, as every other kernel-wire row records; the leaf already carries its first benchmark consumer in rmp-app-toric-dual and its Extension-gate in #5543; expiry 0.8 |
 
 Extension-gate: #5543
+
+### 2026-08-05 — the moderate chapters, and the last ghost but one
+
+Nine more blueprint chapters respell onto the kernel. Twenty-nine pictures
+move to pure kernel spelling, which is what puts every one of them in the
+preserve column: a picture that says `physical=up` or `boundary=periodic`
+still reads its topology off a sugar row, and the disposition ledger books
+that as a codemod, so the ports and the two side words are written out
+instead. The trade is visible in the source: the pictures cost sixteen more
+lines than their 0.7 originals and none of that goes on scaffolding, because
+the chain still runs on the alignment character and only two atoms in the
+whole wave need an address.
+
+Three of the nine chapters carry the figures the previous wave had to leave
+behind. A tensor now stands on a generated cup, so the Choi projector, the
+correlator window, and their side words are ordinary records: the side takes
+`cup`, and the matrix it closes through rides half way along the bend. Those
+two figures also lose the ghost atoms that stood in for the empty cells the
+cup needed, because a wire row populates nothing and an address reaches an
+empty cell directly.
+
+That retirement is what moves the consumer census. Four ghost calls remain in
+the blueprint and they are all in one figure, so the command falls below
+tenure a milestone before its own verdict said it would. Nothing about the
+verdict changes: the command was already booked to die at the language
+landing, and it now has one blueprint consumer left to lose.
+
+Four grid figures keep their 0.7 spelling and are named in the disposition
+ledger. Two want an even-width centre port, which lies between numbered slots
+by construction, and a wide dot whose silhouette grows with its span; one
+wants a row separation the kernel does not name; one is a commutative diagram,
+which is not this language's to draw. The free graphs, the fusion trees, and
+the conjugated layer belong to the redraw waves and are untouched here. The
+mean lines per benchmark case is unmoved at 25.94, because the benchmark
+corpus is untouched.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:command:tnghost | dies at the language landing because addresses name empty cells directly; the wave retires all but one blueprint consumer and the tenure it loses is the one this row already spent; expiry 0.9 |
+
+Census-correction: #4709

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -66,8 +66,8 @@ def _assert_source_linked_groups(repo_root: Path) -> None:
     ).read_text(encoding="utf-8")
     symmetry_bodies = _tenkzequation_bodies(symmetry)
     symmetry_anchors = (
-        r"\tn[role=operator,up=$i$]{U(g)}",
-        r"\tnX{X_1(g^{-1})}",
+        r"\tn[species=operator, label pos=w, ports={90:physical:$i$}]{U(g)}",
+        r"\tn[skin=ring]{X_1(g^{-1})}",
         "Condition C1, lines 328--334, states",
         "Condition C2, lines 335--340, states",
         "Conditions C2--C3, lines 335--347",


### PR DESCRIPTION
Twenty-nine pictures across nine chapters take the 1.0 kernel. Every one of
them lands in the preserve column of the disposition ledger as `P-grid`, which
is what fixes the register: a picture that keeps `physical=up` or
`boundary=periodic` still reads its topology off a sugar row, and the ledger
books that as a codemod, so the ports and the two side words are written out.

## Lines per file (0.7 original → now)

Counted over the picture sources themselves — every construct from its
`\begin` to its `\end`, comments stripped — and over the whole file.

| Chapter | pictures 0.7 | pictures 1.0 | file 0.7 | file 1.0 |
|---|---:|---:|---:|---:|
| `ch04_channels_choi_foundations.tex` | 8 | 5 | 230 | 228 |
| `ch12_symmetry_virtual_and_cohomology.tex` | 18 | 22 | 633 | 638 |
| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | 15 | 21 | 545 | 554 |
| `ch14_correlations.tex` | 8 | 5 | 402 | 400 |
| `ch20_mpdo_foundations.tex` | 17 | 17 | 425 | 427 |
| `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | 27 | 34 | 1014 | 1023 |
| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | 20 | 23 | 914 | 919 |
| `ch24_peps_ft_region_transfer_covariance.tex` | 13 | 14 | 417 | 419 |
| `ch26_mps_rfp_normal_isometry_canonical_forms.tex` | 87 | 88 | 703 | 705 |
| **Total** | **213** | **229** | **5283** | **5313** |

The sixteen lines are all port declarations. None of them is scaffolding: the
chain still runs on the alignment character, the grid still bonds the
neighbours it places, and two atoms in the whole wave carry an address. The
sugar spelling would have been shorter and would have put every one of those
pictures in the codemod column instead.

## Two spellings

A gauge relation, `ch12_symmetry_virtual_and_cohomology.tex`:

```tex
% 0.7
\begin{tenkz}[physical=up]
    \tnX{X(g)} & \tn[up=$i$]{A} & \tnX{X(g)^{-1}}
\end{tenkz}

% 1.0
\begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
    \tn[skin=ring]{X(g)} & \tn[label pos=s, ports={90:physical:$i$}]{A} &
    \tn[skin=ring]{X(g)^{-1}}
\end{tenkz}
```

The correlator window, `ch14_correlations.tex` — the figure the last wave had
to leave on 0.7 because a bead could not stand on a cup:

```tex
% 0.7
\begin{tenkz}[
    sandwich,
    west={cup=$Y$},
    east={cup=$X\rho^R$}
]
    \tnghost{} & \tnX[wires=2]{\E_A^n} & \tnghost{} \\
    \tnghost{} & & \tnghost{}
\end{tenkz}

% 1.0
\begin{tenkz}[rows={wire,wire}, cols=3, west=cup, east=cup]
    \tn[at=(1,2), skin=ring, wires=2]{\E_A^n}
    \tn[skin=ring, at=on cup-west-1-2 0.5]{Y}
    \tn[skin=ring, at=on cup-east-1-2 0.5]{X\rho^R}
\end{tenkz}
```

The ghosts go because a wire row populates nothing and an address reaches an
empty cell directly. The same move frees `ch04_channels_choi_foundations.tex`,
whose Choi projector rides the east cup on the same rule.

## What is drawn

Every figure was rendered before and after against the blueprint's own
standalone document and compared by eye. The drawn mathematics is unchanged
in all twenty-nine: same atoms, same skins, same contractions, same open ends,
same index names at the same ports. The kernel's own ink differs, as it does
in every migrated chapter already on main — the ring silhouette is a rounded
pill rather than a rounded square, and a physical leg is stroked heavier than
a virtual bond because the stroke follows the type the port carries.

Two label stations moved rather than collide:

- `ch13`, the three ground-space words: the `A` labels take `label pos=135`.
  At their 0.7 station they now sit on the arc of the bracket, which the
  kernel draws one clearance under the atoms it spans rather than under the
  trace return.
- `ch12`, the physical action: `U(g)` takes `label pos=w`, its 0.7 station.
  The kernel tints the label with the species, so it reads red where 0.7 set
  it black.

## Not migrated

Four grid figures keep their 0.7 spelling; all are named in the ledger.

- `ch26_mps_rfp_physical_blocking.tex`, both displayed equations. The blocking
  isometry is an even-width pill whose summed index leaves the centre of its
  span, and an even-width centre lies between numbered slots by construction,
  so no authored port reaches it; grid bonding then draws one vertical per
  spanned column instead of the single contraction the source draws. The
  blocked tensor underneath is a `wide=` dot, whose silhouette does not grow
  with its span, so its side legs render detached from the glyph.
- `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` L38/L50. The right panel
  sets `layer sep=2` to make the absent multiplicity pairleg unmistakable at
  print size; the kernel names no row separation.
- `ch21_mpdo_rfp_renormalization.tex` L629. A commutative diagram, owned by
  wave B3.

The free graphs, the fusion trees, and the conjugated layer in
`ch20_mpdo_foundations.tex` L372/376 belong to the redraw waves and are
untouched.

## Checks

- `python3 scripts/test_tenkz_pic.py` — all pipeline checks pass.
- `python3 scripts/check_tenkz_dispositions.py` — 207 blueprint occurrences and
  264 fixtures reconcile. The ledger moves the twenty-nine to preserve, clears
  their redraw and codemod cells, re-pins every line, follows the four
  `\tnpic` → `tenkz` conversions in the raw-count table (`tenkz` 110→114,
  `tnpic` 26→22), and recomputes the totals (preserve 9→38, codemod 39→33,
  redraw 159→136).
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — passes. The
  ghost retirement drops `\tnghost` below tenure a milestone early, so
  `docs/tenkz/SHRINK.md` gains a session entry with the flag verdict and
  `Census-correction: LionSR/tenkz#13`. `tests/tenkz/census-baseline.json` recomputes
  identical and is unchanged.
- `blueprint/src/print.tex` and `docs/tenkz/manual2.tex` both compile clean
  under xelatex. No deck changed.
- `tests/tenkz/rmp/**` untouched.

Advances LionSR/tenkz#13; precondition work for LionSR/tenkz#132
