### PR TITLE
feat(MPDO): complete the S-map half of IsRFPViaTS R

### DIFF
--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
@@ -349,10 +349,6 @@ lemma eq_of_bit1_bit2 (p q : Fin 4) (h1 : bit1 p = bit1 q) (h2 : bit2 p = bit2 q
     · rw [← bit2_eq_bondEquiv_symm_snd, ← bit2_eq_bondEquiv_symm_snd, h2]
   exact bondEquiv.symm.injective h
 
-/-- The off-diagonal cancellation between `S`'s two gated Kraus operators. -/
-lemma eigVecs_orthogonal : eigVecs 0 0 * eigVecs 0 1 + eigVecs 1 0 * eigVecs 1 1 = 0 := by
-  norm_num [eigVecs]
-
 /-- `Σ_s eigVecs s b ^ 2 = 2` for a fixed bit `b`, summing over the eigenbasis label. -/
 lemma eigVecs_sq_sum' (b : Fin 2) : (eigVecs 0 b) ^ 2 + (eigVecs 1 b) ^ 2 = 2 := by
   fin_cases b <;> norm_num [eigVecs]
@@ -403,7 +399,8 @@ lemma bit2_ne_of_gate_combine_eq {pq pq' : Fin 4 × Fin 4} (hg : gate pq.1 pq.2)
   exact Prod.ext hp1 (eq_of_bit1_bit2 _ _ h2 h3)
 
 /-- The off-diagonal cancellation between the eigenbasis rows for distinct
-bits, generalizing `eigVecs_orthogonal` to either order. -/
+bits: the two gated Kraus operators of `S` are orthogonal on any pair of
+physical indices whose shared bond bits differ. -/
 lemma eigVecs_orthogonal' {b b' : Fin 2} (h : b ≠ b') :
     eigVecs 0 b * eigVecs 0 b' + eigVecs 1 b * eigVecs 1 b' = 0 := by
   fin_cases b <;> fin_cases b' <;> simp_all [eigVecs]
@@ -603,6 +600,9 @@ lemma coarseKraus_resolution :
 theorem coarseMap_isKrausCPTP : IsKrausCPTP coarseMap :=
   Matrix.rectangularKrausMap_isKrausCPTP _ coarseKraus_resolution
 
+/-- **`coarseMap` sends the two-site physical operator of `R` back to the
+one-site physical operator.** Together with `coarseMap_isKrausCPTP`, this
+supplies the `S`-map equation of Definition 4.1 for `R`. -/
 theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
     coarseMap (physClose2 R X) = physClose1 R X := by
   ext i j

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
@@ -9,10 +9,10 @@ import TNLean.MPS.MPDO.RFPViaTS
 /-!
 # The renormalization fixed-point maps for the rescaling-stable example
 
-**Scope: partial formalization.** This file continues
-`TNLean.MPS.MPDO.RescalingStableLengthDependentRFP`, constructing the two
-trace-preserving completely positive maps of Definition 4.1
-(`MPOTensor.IsRFPViaTS`) for the explicit MPO tensor `R` of that file.
+This file continues `TNLean.MPS.MPDO.RescalingStableLengthDependentRFP`,
+constructing the two trace-preserving completely positive maps of
+Definition 4.1 (`MPOTensor.IsRFPViaTS`) for the explicit MPO tensor `R` of
+that file, and concludes that `R` satisfies `IsRFPViaTS`.
 
 `IsRFPViaTS M` (`TNLean/MPS/MPDO/RFPViaTS.lean`) does not presuppose the
 source's canonical-form hypothesis: it is the bare existence of
@@ -32,20 +32,15 @@ M X` for all virtual operators `X`.
 * `refineMap_isKrausCPTP` — `T` is trace-preserving completely positive.
 * `refineMap_physClose1` — `T[physClose1 R X] = physClose2 R X` for all `X`
   (the `eq:Tmap` equation of Definition 4.1).
-
-## Remaining gap
-
-The coarse-graining map `S` (`coarseMap`) is defined with four Kraus
-operators — two gated (`coarseKrausGated`, sharing `T`'s Walsh–Hadamard
-amplitude `coarseAmp = 1/√2`) and two ungated (`coarseKrausUngated`, a
-deterministic assignment resolving the identity on bond-mismatched pairs)
-— but its trace-preserving completely positive property
-(`Σ (Kraus)ᴴ Kraus = 1` on the full two-site domain, including the
-off-diagonal cancellation `Σ_s eigVecs s 0 · eigVecs s 1 = 0` between the
-two gated Kraus operators) and the `eq:Smap` equation
-`S[physClose2 R X] = physClose1 R X` are not yet proved.  Completing these
-two lemmas and combining with `refineMap_isKrausCPTP`/`refineMap_physClose1`
-yields `IsRFPViaTS R` directly.
+* `coarseMap` (`S`) — four Kraus operators: two gated (`coarseKrausGated`,
+  sharing `T`'s Walsh–Hadamard amplitude `coarseAmp = 1/√2`) and two
+  ungated (`coarseKrausUngated`, a deterministic assignment resolving the
+  identity on bond-mismatched pairs).
+* `coarseMap_isKrausCPTP` — `S` is trace-preserving completely positive.
+* `coarseMap_physClose2` — `S[physClose2 R X] = physClose1 R X` for all `X`
+  (the `eq:Smap` equation of Definition 4.1).
+* `isRFPViaTS_R` — `R` satisfies `IsRFPViaTS`, witnessed by `S := coarseMap`
+  and `T := refineMap`.
 
 ## References
 
@@ -620,8 +615,8 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
   -- vanishes whenever `p` fails the bond-matching condition, which is exactly
   -- the domain of `coarseKrausUngated`.
   have hungated_zero : ∀ t : Fin 2,
-      (∑ q : Fin 4 × Fin 4, (∑ p : Fin 4 × Fin 4,
-          coarseKrausUngated t i p * physClose2 R X p q) * star (coarseKrausUngated t j q)) = 0 := by
+      (∑ q : Fin 4 × Fin 4, (∑ p : Fin 4 × Fin 4, coarseKrausUngated t i p * physClose2 R X p q) *
+          star (coarseKrausUngated t j q)) = 0 := by
     intro t
     apply Finset.sum_eq_zero
     intro q _
@@ -640,7 +635,8 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
     rw [hinner]; simp
   have hungated_sum_zero :
       (∑ t : Fin 2, ∑ q : Fin 4 × Fin 4, (∑ p : Fin 4 × Fin 4,
-          coarseKrausUngated t i p * physClose2 R X p q) * star (coarseKrausUngated t j q)) = 0 := by
+          coarseKrausUngated t i p * physClose2 R X p q) *
+        star (coarseKrausUngated t j q)) = 0 := by
     rw [Fin.sum_univ_two, hungated_zero 0, hungated_zero 1, add_zero]
   rw [hungated_sum_zero, add_zero]
   -- The gated contribution: on the fiber of `i`, `physClose2 R X p q` rescales
@@ -742,5 +738,12 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
   have hev11 : eigVecs 1 1 = (-1 : ℂ) := by simp [eigVecs]
   rw [hamp, hw00, hw01, hw10, hw11, hev00, hev01, hev10, hev11]
   ring
+
+/-- **`R` satisfies the source's renormalization fixed-point condition
+of Definition 4.1.** `coarseMap` and `refineMap` are the trace-preserving
+completely positive maps `S` and `T` witnessing `IsRFPViaTS R`. -/
+theorem isRFPViaTS_R : IsRFPViaTS R :=
+  ⟨coarseMap, refineMap, coarseMap_isKrausCPTP, refineMap_isKrausCPTP,
+    coarseMap_physClose2, refineMap_physClose1⟩
 
 end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
@@ -608,4 +608,139 @@ lemma coarseKraus_resolution :
 theorem coarseMap_isKrausCPTP : IsKrausCPTP coarseMap :=
   Matrix.rectangularKrausMap_isKrausCPTP _ coarseKraus_resolution
 
+theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
+    coarseMap (physClose2 R X) = physClose1 R X := by
+  ext i j
+  change (∑ α : Fin 2 ⊕ Fin 2,
+      Sum.elim coarseKrausGated coarseKrausUngated α * physClose2 R X *
+        (Sum.elim coarseKrausGated coarseKrausUngated α)ᴴ) i j = physClose1 R X i j
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_sum_type,
+    Sum.elim_inl, Sum.elim_inr]
+  -- The ungated Kraus operators annihilate every entry: `physClose2 R X p q`
+  -- vanishes whenever `p` fails the bond-matching condition, which is exactly
+  -- the domain of `coarseKrausUngated`.
+  have hungated_zero : ∀ t : Fin 2,
+      (∑ q : Fin 4 × Fin 4, (∑ p : Fin 4 × Fin 4,
+          coarseKrausUngated t i p * physClose2 R X p q) * star (coarseKrausUngated t j q)) = 0 := by
+    intro t
+    apply Finset.sum_eq_zero
+    intro q _
+    have hinner : (∑ p : Fin 4 × Fin 4, coarseKrausUngated t i p * physClose2 R X p q) = 0 := by
+      apply Finset.sum_eq_zero
+      intro p _
+      by_cases hp : ¬ gate p.1 p.2 ∧ combine p.1 p.2 = i ∧ bit2 p.1 = t
+      · have hz : physClose2 R X p q = 0 := by
+          rw [physClose2_R_entry, if_neg (fun hcon : gate p.1 p.2 ∧ gate q.1 q.2 => hp.1 hcon.1)]
+          ring
+        rw [hz, mul_zero]
+      · have e : coarseKrausUngated t i p = 0 := by
+          simp only [coarseKrausUngated, Matrix.of_apply]
+          exact if_neg hp
+        rw [e, zero_mul]
+    rw [hinner]; simp
+  have hungated_sum_zero :
+      (∑ t : Fin 2, ∑ q : Fin 4 × Fin 4, (∑ p : Fin 4 × Fin 4,
+          coarseKrausUngated t i p * physClose2 R X p q) * star (coarseKrausUngated t j q)) = 0 := by
+    rw [Fin.sum_univ_two, hungated_zero 0, hungated_zero 1, add_zero]
+  rw [hungated_sum_zero, add_zero]
+  -- The gated contribution: on the fiber of `i`, `physClose2 R X p q` rescales
+  -- and restricts `physClose1 R X` along `combine`; the two-level fiber sum
+  -- (over the shared bond bits of `p` and of `q`) reassembles the `wMat`
+  -- eigendecomposition and collapses to `physClose1 R X i j` exactly.
+  have hinner : ∀ s : Fin 2, ∀ q : Fin 4 × Fin 4,
+      (∑ p : Fin 4 × Fin 4, coarseKrausGated s i p * physClose2 R X p q) =
+        (if gate q.1 q.2 then
+            (coarseAmp : ℂ) * (25 / 32 : ℂ) * physClose1 R X i (combine q.1 q.2) *
+              (eigVecs s 0 * wMat 0 (bit2 q.1) + eigVecs s 1 * wMat 1 (bit2 q.1))
+          else 0) := by
+    intro s q
+    by_cases hq : gate q.1 q.2
+    · rw [if_pos hq]
+      have hcongr : (∑ p : Fin 4 × Fin 4, coarseKrausGated s i p * physClose2 R X p q) =
+          ∑ p : Fin 4 × Fin 4, if gate p.1 p.2 ∧ combine p.1 p.2 = i then
+              (coarseAmp : ℂ) * (25 / 32 : ℂ) * physClose1 R X i (combine q.1 q.2) *
+                (eigVecs s (bit2 p.1) * wMat (bit2 p.1) (bit2 q.1))
+            else 0 := by
+        apply Finset.sum_congr rfl
+        intro p _
+        by_cases hp : gate p.1 p.2 ∧ combine p.1 p.2 = i
+        · rw [if_pos hp]
+          have e : coarseKrausGated s i p = (coarseAmp : ℂ) * eigVecs s (bit2 p.1) := by
+            simp only [coarseKrausGated, Matrix.of_apply]
+            exact if_pos hp
+          have c1 : (if gate p.1 p.2 ∧ gate q.1 q.2 then wMat (bit2 p.1) (bit2 q.1) else 0) =
+              wMat (bit2 p.1) (bit2 q.1) := if_pos ⟨hp.1, hq⟩
+          rw [e, physClose2_R_entry, hp.2, c1]; ring
+        · rw [if_neg hp]
+          have e : coarseKrausGated s i p = 0 := by
+            simp only [coarseKrausGated, Matrix.of_apply]
+            exact if_neg hp
+          rw [e, zero_mul]
+      rw [hcongr, gated_combine_fiber_sum i (fun b => (coarseAmp : ℂ) * (25 / 32 : ℂ) *
+          physClose1 R X i (combine q.1 q.2) * (eigVecs s b * wMat b (bit2 q.1)))]
+      ring
+    · rw [if_neg hq]
+      apply Finset.sum_eq_zero
+      intro p _
+      by_cases hp : gate p.1 p.2 ∧ combine p.1 p.2 = i
+      · have e : coarseKrausGated s i p = (coarseAmp : ℂ) * eigVecs s (bit2 p.1) := by
+          simp only [coarseKrausGated, Matrix.of_apply]
+          exact if_pos hp
+        have c1 : (if gate p.1 p.2 ∧ gate q.1 q.2 then wMat (bit2 p.1) (bit2 q.1) else 0) = 0 :=
+          if_neg (fun hcon => hq hcon.2)
+        rw [e, physClose2_R_entry, c1]; ring
+      · have e : coarseKrausGated s i p = 0 := by
+          simp only [coarseKrausGated, Matrix.of_apply]
+          exact if_neg hp
+        rw [e, zero_mul]
+  have houter : ∀ s : Fin 2,
+      (∑ q : Fin 4 × Fin 4, (∑ p : Fin 4 × Fin 4,
+          coarseKrausGated s i p * physClose2 R X p q) * star (coarseKrausGated s j q)) =
+        (coarseAmp : ℂ) ^ 2 * (25 / 32 : ℂ) * physClose1 R X i j *
+          (eigVecs s 0 * wMat 0 0 * eigVecs s 0 + eigVecs s 1 * wMat 1 0 * eigVecs s 0 +
+            (eigVecs s 0 * wMat 0 1 * eigVecs s 1 + eigVecs s 1 * wMat 1 1 * eigVecs s 1)) := by
+    intro s
+    have hcongr : (∑ q : Fin 4 × Fin 4, (∑ p : Fin 4 × Fin 4,
+        coarseKrausGated s i p * physClose2 R X p q) * star (coarseKrausGated s j q)) =
+        ∑ q : Fin 4 × Fin 4, if gate q.1 q.2 ∧ combine q.1 q.2 = j then
+            (coarseAmp : ℂ) ^ 2 * (25 / 32 : ℂ) * physClose1 R X i j *
+              (eigVecs s 0 * wMat 0 (bit2 q.1) + eigVecs s 1 * wMat 1 (bit2 q.1)) *
+              eigVecs s (bit2 q.1)
+          else 0 := by
+      apply Finset.sum_congr rfl
+      intro q _
+      rw [hinner]
+      by_cases hqj : gate q.1 q.2 ∧ combine q.1 q.2 = j
+      · rw [if_pos hqj.1, if_pos hqj, hqj.2]
+        have e : coarseKrausGated s j q = (coarseAmp : ℂ) * eigVecs s (bit2 q.1) := by
+          simp only [coarseKrausGated, Matrix.of_apply]
+          exact if_pos hqj
+        rw [e, star_mul', eigVecs_star, coarseAmp_star]
+        ring
+      · by_cases hq : gate q.1 q.2
+        · have hqne : combine q.1 q.2 ≠ j := fun hcon => hqj ⟨hq, hcon⟩
+          rw [if_pos hq, if_neg hqj]
+          have e : coarseKrausGated s j q = 0 := by
+            simp only [coarseKrausGated, Matrix.of_apply]
+            exact if_neg (fun hcon => hqne hcon.2)
+          rw [e]; simp
+        · rw [if_neg hq, if_neg hqj]; simp
+    rw [hcongr, gated_combine_fiber_sum j (fun b => (coarseAmp : ℂ) ^ 2 * (25 / 32 : ℂ) *
+        physClose1 R X i j * (eigVecs s 0 * wMat 0 b + eigVecs s 1 * wMat 1 b) * eigVecs s b)]
+    ring
+  rw [Fin.sum_univ_two, houter, houter]
+  have hamp : (coarseAmp : ℂ) ^ 2 = (1 / 2 : ℂ) := by
+    have hcast : ((coarseAmp : ℝ) : ℂ) ^ 2 = ((coarseAmp ^ 2 : ℝ) : ℂ) := by push_cast; ring
+    rw [hcast, coarseAmp_sq]; norm_num
+  have hw00 : wMat 0 0 = (16 / 25 : ℂ) := by simp [wMat]; norm_num
+  have hw01 : wMat 0 1 = (9 / 25 : ℂ) := by simp [wMat]; norm_num
+  have hw10 : wMat 1 0 = (9 / 25 : ℂ) := by simp [wMat]; norm_num
+  have hw11 : wMat 1 1 = (16 / 25 : ℂ) := by simp [wMat]; norm_num
+  have hev00 : eigVecs 0 0 = (1 : ℂ) := by simp [eigVecs]
+  have hev01 : eigVecs 0 1 = (1 : ℂ) := by simp [eigVecs]
+  have hev10 : eigVecs 1 0 = (1 : ℂ) := by simp [eigVecs]
+  have hev11 : eigVecs 1 1 = (-1 : ℂ) := by simp [eigVecs]
+  rw [hamp, hw00, hw01, hw10, hw11, hev00, hev01, hev10, hev11]
+  ring
+
 end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
@@ -389,6 +389,30 @@ lemma eq_of_ungated_combine_bit2 {pq pq' : Fin 4 × Fin 4} (h1 : ¬ gate pq.1 pq
 lemma coarseAmp_star : star ((coarseAmp : ℝ) : ℂ) = (coarseAmp : ℂ) :=
   Complex.conj_ofReal _
 
+/-- Two `gate`-satisfying pairs sharing a `combine` value and distinct from
+each other cannot share their first site's second bit: if they did,
+`eq_of_bit1_bit2` would force the pairs to coincide. -/
+lemma bit2_ne_of_gate_combine_eq {pq pq' : Fin 4 × Fin 4} (hg : gate pq.1 pq.2)
+    (hg' : gate pq'.1 pq'.2) (hc : combine pq.1 pq.2 = combine pq'.1 pq'.2) (hne : pq ≠ pq') :
+    bit2 pq.1 ≠ bit2 pq'.1 := by
+  intro hb
+  apply hne
+  have h1 : bit1 pq.1 = bit1 pq'.1 := by
+    have := congrArg bit1 hc
+    rwa [bit1_combine, bit1_combine] at this
+  have hp1 : pq.1 = pq'.1 := eq_of_bit1_bit2 _ _ h1 hb
+  have h2 : bit1 pq.2 = bit1 pq'.2 := hg.symm.trans (hb.trans hg')
+  have h3 : bit2 pq.2 = bit2 pq'.2 := by
+    have := congrArg bit2 hc
+    rwa [bit2_combine, bit2_combine] at this
+  exact Prod.ext hp1 (eq_of_bit1_bit2 _ _ h2 h3)
+
+/-- The off-diagonal cancellation between the eigenbasis rows for distinct
+bits, generalizing `eigVecs_orthogonal` to either order. -/
+lemma eigVecs_orthogonal' {b b' : Fin 2} (h : b ≠ b') :
+    eigVecs 0 b * eigVecs 0 b' + eigVecs 1 b * eigVecs 1 b' = 0 := by
+  fin_cases b <;> fin_cases b' <;> simp_all [eigVecs]
+
 /-- **The coarse-graining Kraus family resolves the identity.** -/
 lemma coarseKraus_resolution :
     ∑ α : Fin 2 ⊕ Fin 2,
@@ -408,34 +432,45 @@ lemma coarseKraus_resolution :
     intro s
     by_cases h : gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2
     · rw [if_pos h]
-      rw [Finset.sum_eq_single (combine pq.1 pq.2)]
-      · simp only [coarseKrausGated, Matrix.of_apply, if_pos ⟨h.1, rfl⟩, if_pos ⟨h.2.1, h.2.2.symm⟩,
-          star_mul', coarseAmp_star]
-        ring
-      · intro k _ hk
+      have e1 : coarseKrausGated s (combine pq.1 pq.2) pq =
+          (coarseAmp : ℂ) * eigVecs s (bit2 pq.1) := by
+        simp [coarseKrausGated, Matrix.of_apply, h.1]
+      have e2 : coarseKrausGated s (combine pq.1 pq.2) pq' =
+          (coarseAmp : ℂ) * eigVecs s (bit2 pq'.1) := by
         simp only [coarseKrausGated, Matrix.of_apply]
-        rw [if_neg (fun hc => hk hc.2.symm), star_zero, zero_mul]
+        exact if_pos ⟨h.2.1, h.2.2.symm⟩
+      rw [Finset.sum_eq_single (combine pq.1 pq.2)]
+      · rw [e1, e2, star_mul', eigVecs_star, coarseAmp_star]; ring
+      · intro k _ hk
+        have e : coarseKrausGated s k pq = 0 := by
+          simp only [coarseKrausGated, Matrix.of_apply]
+          exact if_neg (fun hcond => hk hcond.2.symm)
+        rw [e]; simp
       · simp
     · rw [if_neg h]
+      apply Finset.sum_eq_zero
+      intro k _
       rw [not_and_or, not_and_or] at h
       rcases h with h1 | h1 | h1
-      · apply Finset.sum_eq_zero; intro k _
-        simp only [coarseKrausGated, Matrix.of_apply]
-        rw [if_neg (fun hc => h1 hc.1), star_zero, zero_mul]
-      · apply Finset.sum_eq_zero; intro k _
-        simp only [coarseKrausGated, Matrix.of_apply]
-        rw [if_neg (fun hc => h1 hc.1)]
-        by_cases h' : gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k
-        · simp [h']
-        · rw [if_neg h', star_zero, zero_mul]
-      · apply Finset.sum_eq_zero; intro k _
-        by_cases hpk : gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k
+      · have e : coarseKrausGated s k pq = 0 := by
+          simp only [coarseKrausGated, Matrix.of_apply]
+          exact if_neg (fun hcond => h1 hcond.1)
+        rw [e]; simp
+      · have e : coarseKrausGated s k pq' = 0 := by
+          simp only [coarseKrausGated, Matrix.of_apply]
+          exact if_neg (fun hcond => h1 hcond.1)
+        rw [e]; simp
+      · by_cases hpk : gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k
         · have hpk' : ¬ (gate pq'.1 pq'.2 ∧ combine pq'.1 pq'.2 = k) := by
-            rintro ⟨_, hc⟩
-            exact h1 (hpk.2.symm.trans hc)
-          simp only [coarseKrausGated, Matrix.of_apply, if_pos hpk, if_neg hpk', star_mul',
-            coarseAmp_star, mul_zero]
-        · simp only [coarseKrausGated, Matrix.of_apply, if_neg hpk, star_zero, zero_mul]
+            rintro ⟨_, hc⟩; exact h1 (hpk.2.trans hc.symm)
+          have e : coarseKrausGated s k pq' = 0 := by
+            simp only [coarseKrausGated, Matrix.of_apply]
+            exact if_neg hpk'
+          rw [e]; simp
+        · have e : coarseKrausGated s k pq = 0 := by
+            simp only [coarseKrausGated, Matrix.of_apply]
+            exact if_neg hpk
+          rw [e]; simp
   -- The ungated contribution at a fixed label `t`, as a sum over the domain `Fin 4`.
   have hungated_term : ∀ t : Fin 2,
       (∑ k : Fin 4, star (coarseKrausUngated t k pq) * coarseKrausUngated t k pq') =
@@ -445,12 +480,20 @@ lemma coarseKraus_resolution :
     by_cases h : ¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = t ∧ bit2 pq'.1 = t ∧
         combine pq.1 pq.2 = combine pq'.1 pq'.2
     · rw [if_pos h]
-      rw [Finset.sum_eq_single (combine pq.1 pq.2)]
-      · simp only [coarseKrausUngated, Matrix.of_apply, if_pos ⟨h.1, rfl, h.2.2.1⟩,
-          if_pos ⟨h.2.1, h.2.2.2.2.symm, h.2.2.2.1⟩, star_one, one_mul]
-      · intro k _ hk
+      obtain ⟨hg1, hg2, hb1, hb2, hc⟩ := h
+      have e1 : coarseKrausUngated t (combine pq.1 pq.2) pq = 1 := by
         simp only [coarseKrausUngated, Matrix.of_apply]
-        rw [if_neg (fun hc => hk hc.2.1.symm), star_zero, zero_mul]
+        exact if_pos ⟨hg1, trivial, hb1⟩
+      have e2 : coarseKrausUngated t (combine pq.1 pq.2) pq' = 1 := by
+        simp only [coarseKrausUngated, Matrix.of_apply]
+        exact if_pos ⟨hg2, hc.symm, hb2⟩
+      rw [Finset.sum_eq_single (combine pq.1 pq.2)]
+      · rw [e1, e2]; simp
+      · intro k _ hk
+        have e : coarseKrausUngated t k pq = 0 := by
+          simp only [coarseKrausUngated, Matrix.of_apply]
+          exact if_neg (fun hcond => hk hcond.2.1.symm)
+        rw [e]; simp
       · simp
     · rw [if_neg h]
       apply Finset.sum_eq_zero
@@ -459,39 +502,110 @@ lemma coarseKraus_resolution :
       · have hpk' : ¬ (¬ gate pq'.1 pq'.2 ∧ combine pq'.1 pq'.2 = k ∧ bit2 pq'.1 = t) := by
           rintro ⟨hg', hc', hb'⟩
           exact h ⟨hpk.1, hg', hpk.2.2, hb', hpk.2.1.trans hc'.symm⟩
-        simp only [coarseKrausUngated, Matrix.of_apply, if_pos hpk, if_neg hpk', star_one, mul_zero]
-      · simp only [coarseKrausUngated, Matrix.of_apply, if_neg hpk, star_zero, zero_mul]
-  simp_rw [hgated_term, hungated_term]
+        have e : coarseKrausUngated t k pq' = 0 := by
+          simp only [coarseKrausUngated, Matrix.of_apply]
+          exact if_neg hpk'
+        rw [e]; simp
+      · have e : coarseKrausUngated t k pq = 0 := by
+          simp only [coarseKrausUngated, Matrix.of_apply]
+          exact if_neg hpk
+        rw [e]; simp
+  simp only [hgated_term, hungated_term, Fin.sum_univ_two]
   by_cases heq : pq = pq'
   · subst heq
     rw [if_pos rfl]
     by_cases hg : gate pq.1 pq.2
-    · rw [if_pos ⟨hg, hg, rfl⟩, if_neg (fun hc => (hc.1 hg))]
-      rw [Fin.sum_univ_two]
-      have h0 : (coarseAmp : ℂ) ^ 2 * eigVecs 0 (bit2 pq.1) * eigVecs 0 (bit2 pq.1) +
-          (coarseAmp : ℂ) ^ 2 * eigVecs 1 (bit2 pq.1) * eigVecs 1 (bit2 pq.1) =
+    · have hCg : gate pq.1 pq.2 ∧ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = combine pq.1 pq.2 :=
+        ⟨hg, hg, rfl⟩
+      have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
+          bit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := fun hc => hc.1 hg
+      have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
+          bit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := fun hc => hc.1 hg
+      rw [if_pos hCg, if_pos hCg, if_neg hCu0, if_neg hCu1]
+      have hsum : (eigVecs 0 (bit2 pq.1)) ^ 2 + (eigVecs 1 (bit2 pq.1)) ^ 2 = (2 : ℂ) := by
+        exact_mod_cast eigVecs_sq_sum' (bit2 pq.1)
+      have hamp : (coarseAmp : ℂ) ^ 2 = (1 / 2 : ℂ) := by
+        have hcast : ((coarseAmp : ℝ) : ℂ) ^ 2 = ((coarseAmp ^ 2 : ℝ) : ℂ) := by push_cast; ring
+        rw [hcast, coarseAmp_sq]; norm_num
+      have step : (coarseAmp : ℂ) ^ 2 * eigVecs 0 (bit2 pq.1) * eigVecs 0 (bit2 pq.1) +
+          (coarseAmp : ℂ) ^ 2 * eigVecs 1 (bit2 pq.1) * eigVecs 1 (bit2 pq.1) + (0 + 0) =
           (coarseAmp : ℂ) ^ 2 * ((eigVecs 0 (bit2 pq.1)) ^ 2 + (eigVecs 1 (bit2 pq.1)) ^ 2) := by
         ring
-      rw [h0]
-      have hsum : ((eigVecs 0 (bit2 pq.1)) ^ 2 + (eigVecs 1 (bit2 pq.1)) ^ 2 : ℂ) = 2 := by
-        exact_mod_cast eigVecs_sq_sum' (bit2 pq.1)
-      rw [hsum]
-      have hamp2 : (coarseAmp : ℂ) ^ 2 = ((coarseAmp ^ 2 : ℝ) : ℂ) := by push_cast; ring
-      rw [hamp2, coarseAmp_sq]
-      norm_num
-    · rw [if_neg (fun hc => hg hc.1), if_pos ⟨hg, hg, rfl, rfl, rfl⟩]
-      simp
+      rw [step, hsum, hamp]; norm_num
+    · have hCg : ¬ (gate pq.1 pq.2 ∧ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = combine pq.1 pq.2) :=
+        fun hc => hg hc.1
+      rw [if_neg hCg, if_neg hCg]
+      by_cases hb : bit2 pq.1 = (0 : Fin 2)
+      · have hCu0 : ¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
+            bit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2 :=
+          ⟨hg, hg, hb, hb, rfl⟩
+        have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
+            bit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := by
+          rintro ⟨_, _, hb1, _, _⟩
+          rw [hb] at hb1; exact absurd hb1 (by decide)
+        rw [if_pos hCu0, if_neg hCu1]; norm_num
+      · have hb1 : bit2 pq.1 = (1 : Fin 2) := by omega
+        have hCu1 : ¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
+            bit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2 :=
+          ⟨hg, hg, hb1, hb1, rfl⟩
+        have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
+            bit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := by
+          rintro ⟨_, _, hb0, _, _⟩
+          exact hb hb0
+        rw [if_neg hCu0, if_pos hCu1]; norm_num
   · rw [if_neg heq]
     by_cases hg : gate pq.1 pq.2
     · by_cases hg' : gate pq'.1 pq'.2
       · by_cases hc : combine pq.1 pq.2 = combine pq'.1 pq'.2
-        · rw [if_pos ⟨hg, hg', hc⟩, if_neg (fun hcon => hg (False.elim (hcon.2.2.1 ▸ hg')).elim)]
-          sorry
-        · rw [if_neg (fun hcon => hc hcon.2.2), if_neg (fun hcon => hc hcon.2.2.2.2)]
-          simp
-      · rw [if_neg (fun hcon => hg' hcon.2.1), if_neg (fun hcon => hg' hcon.2.1)]
-        simp
-    · rw [if_neg (fun hcon => hg hcon.1), if_neg (fun hcon => hg hcon.1)]
-      simp
+        · have hCg : gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2 :=
+            ⟨hg, hg', hc⟩
+          have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
+              bit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+            fun hcon => hcon.1 hg
+          have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
+              bit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+            fun hcon => hcon.1 hg
+          rw [if_pos hCg, if_pos hCg, if_neg hCu0, if_neg hCu1]
+          have hbne : bit2 pq.1 ≠ bit2 pq'.1 := bit2_ne_of_gate_combine_eq hg hg' hc heq
+          have step : (coarseAmp : ℂ) ^ 2 * eigVecs 0 (bit2 pq.1) * eigVecs 0 (bit2 pq'.1) +
+              (coarseAmp : ℂ) ^ 2 * eigVecs 1 (bit2 pq.1) * eigVecs 1 (bit2 pq'.1) + (0 + 0) =
+              (coarseAmp : ℂ) ^ 2 *
+                (eigVecs 0 (bit2 pq.1) * eigVecs 0 (bit2 pq'.1) +
+                  eigVecs 1 (bit2 pq.1) * eigVecs 1 (bit2 pq'.1)) := by
+            ring
+          rw [step, eigVecs_orthogonal' hbne, mul_zero]
+        · have hCg : ¬ (gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧
+              combine pq.1 pq.2 = combine pq'.1 pq'.2) := fun hcon => hc hcon.2.2
+          have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
+              bit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+            fun hcon => hcon.1 hg
+          have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
+              bit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+            fun hcon => hcon.1 hg
+          rw [if_neg hCg, if_neg hCg, if_neg hCu0, if_neg hCu1]; norm_num
+      · have hCg : ¬ (gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧
+            combine pq.1 pq.2 = combine pq'.1 pq'.2) := fun hcon => hg' hcon.2.1
+        have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
+            bit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+          fun hcon => hcon.1 hg
+        have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
+            bit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+          fun hcon => hcon.1 hg
+        rw [if_neg hCg, if_neg hCg, if_neg hCu0, if_neg hCu1]; norm_num
+    · have hCg : ¬ (gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧
+          combine pq.1 pq.2 = combine pq'.1 pq'.2) := fun hcon => hg hcon.1
+      have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
+          bit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) := by
+        rintro ⟨hg1, hg1', hb1, hb1', hceq⟩
+        exact heq (eq_of_ungated_combine_bit2 hg1 hg1' hceq (hb1.trans hb1'.symm))
+      have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
+          bit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) := by
+        rintro ⟨hg1, hg1', hb1, hb1', hceq⟩
+        exact heq (eq_of_ungated_combine_bit2 hg1 hg1' hceq (hb1.trans hb1'.symm))
+      rw [if_neg hCg, if_neg hCg, if_neg hCu0, if_neg hCu1]; norm_num
+
+/-- **`coarseMap` is trace-preserving completely positive.** -/
+theorem coarseMap_isKrausCPTP : IsKrausCPTP coarseMap :=
+  Matrix.rectangularKrausMap_isKrausCPTP _ coarseKraus_resolution
 
 end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
@@ -346,4 +346,44 @@ noncomputable def coarseMap :
     (Sum.elim coarseKrausGated coarseKrausUngated :
       Fin 2 ⊕ Fin 2 → Matrix (Fin 4) (Fin 4 × Fin 4) ℂ)
 
+/-- A physical index is determined by its two bits. -/
+lemma eq_of_bit1_bit2 (p q : Fin 4) (h1 : bit1 p = bit1 q) (h2 : bit2 p = bit2 q) : p = q := by
+  have h : bondEquiv.symm p = bondEquiv.symm q := by
+    apply Prod.ext
+    · rw [← bit1_eq_bondEquiv_symm_fst, ← bit1_eq_bondEquiv_symm_fst, h1]
+    · rw [← bit2_eq_bondEquiv_symm_snd, ← bit2_eq_bondEquiv_symm_snd, h2]
+  exact bondEquiv.symm.injective h
+
+/-- The off-diagonal cancellation between `S`'s two gated Kraus operators. -/
+lemma eigVecs_orthogonal : eigVecs 0 0 * eigVecs 0 1 + eigVecs 1 0 * eigVecs 1 1 = 0 := by
+  norm_num [eigVecs]
+
+/-- `Σ_s eigVecs s b ^ 2 = 2` for a fixed bit `b`, summing over the eigenbasis label. -/
+lemma eigVecs_sq_sum' (b : Fin 2) : (eigVecs 0 b) ^ 2 + (eigVecs 1 b) ^ 2 = 2 := by
+  fin_cases b <;> norm_num [eigVecs]
+
+/-- Two elements of `Fin 2` that both differ from a common third element agree. -/
+lemma fin2_eq_of_ne_ne {a b c : Fin 2} (hac : a ≠ c) (hbc : b ≠ c) : a = b := by
+  fin_cases a <;> fin_cases b <;> fin_cases c <;> simp_all
+
+/-- An ungated pair is determined by its `combine` value and the first
+site's second bit. -/
+lemma eq_of_ungated_combine_bit2 {pq pq' : Fin 4 × Fin 4} (h1 : ¬ gate pq.1 pq.2)
+    (h1' : ¬ gate pq'.1 pq'.2) (hc : combine pq.1 pq.2 = combine pq'.1 pq'.2)
+    (hb : bit2 pq.1 = bit2 pq'.1) : pq = pq' := by
+  have e1 : bit1 pq.1 = bit1 pq'.1 := by
+    have h := congrArg bit1 hc
+    rwa [bit1_combine, bit1_combine] at h
+  have e2 : bit2 pq.2 = bit2 pq'.2 := by
+    have h := congrArg bit2 hc
+    rwa [bit2_combine, bit2_combine] at h
+  have e3 : bit1 pq.2 = bit1 pq'.2 := by
+    have h1b : bit1 pq.2 ≠ bit2 pq.1 := fun h => h1 h.symm
+    have h1'b : bit1 pq'.2 ≠ bit2 pq.1 := by
+      rw [hb]; exact fun h => h1' h.symm
+    exact fin2_eq_of_ne_ne h1b h1'b
+  apply Prod.ext
+  · exact eq_of_bit1_bit2 _ _ e1 hb
+  · exact eq_of_bit1_bit2 _ _ e3 e2
+
 end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
@@ -386,4 +386,112 @@ lemma eq_of_ungated_combine_bit2 {pq pq' : Fin 4 × Fin 4} (h1 : ¬ gate pq.1 pq
   · exact eq_of_bit1_bit2 _ _ e1 hb
   · exact eq_of_bit1_bit2 _ _ e3 e2
 
+lemma coarseAmp_star : star ((coarseAmp : ℝ) : ℂ) = (coarseAmp : ℂ) :=
+  Complex.conj_ofReal _
+
+/-- **The coarse-graining Kraus family resolves the identity.** -/
+lemma coarseKraus_resolution :
+    ∑ α : Fin 2 ⊕ Fin 2,
+        (Sum.elim coarseKrausGated coarseKrausUngated α)ᴴ *
+          Sum.elim coarseKrausGated coarseKrausUngated α =
+      (1 : Matrix (Fin 4 × Fin 4) (Fin 4 × Fin 4) ℂ) := by
+  ext pq pq'
+  rw [Matrix.one_apply]
+  simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_sum_type,
+    Sum.elim_inl, Sum.elim_inr]
+  -- The gated contribution at a fixed label `s`, as a sum over the domain `Fin 4`.
+  have hgated_term : ∀ s : Fin 2,
+      (∑ k : Fin 4, star (coarseKrausGated s k pq) * coarseKrausGated s k pq') =
+        if gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2 then
+          (coarseAmp : ℂ) ^ 2 * eigVecs s (bit2 pq.1) * eigVecs s (bit2 pq'.1)
+        else 0 := by
+    intro s
+    by_cases h : gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2
+    · rw [if_pos h]
+      rw [Finset.sum_eq_single (combine pq.1 pq.2)]
+      · simp only [coarseKrausGated, Matrix.of_apply, if_pos ⟨h.1, rfl⟩, if_pos ⟨h.2.1, h.2.2.symm⟩,
+          star_mul', coarseAmp_star]
+        ring
+      · intro k _ hk
+        simp only [coarseKrausGated, Matrix.of_apply]
+        rw [if_neg (fun hc => hk hc.2.symm), star_zero, zero_mul]
+      · simp
+    · rw [if_neg h]
+      rw [not_and_or, not_and_or] at h
+      rcases h with h1 | h1 | h1
+      · apply Finset.sum_eq_zero; intro k _
+        simp only [coarseKrausGated, Matrix.of_apply]
+        rw [if_neg (fun hc => h1 hc.1), star_zero, zero_mul]
+      · apply Finset.sum_eq_zero; intro k _
+        simp only [coarseKrausGated, Matrix.of_apply]
+        rw [if_neg (fun hc => h1 hc.1)]
+        by_cases h' : gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k
+        · simp [h']
+        · rw [if_neg h', star_zero, zero_mul]
+      · apply Finset.sum_eq_zero; intro k _
+        by_cases hpk : gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k
+        · have hpk' : ¬ (gate pq'.1 pq'.2 ∧ combine pq'.1 pq'.2 = k) := by
+            rintro ⟨_, hc⟩
+            exact h1 (hpk.2.symm.trans hc)
+          simp only [coarseKrausGated, Matrix.of_apply, if_pos hpk, if_neg hpk', star_mul',
+            coarseAmp_star, mul_zero]
+        · simp only [coarseKrausGated, Matrix.of_apply, if_neg hpk, star_zero, zero_mul]
+  -- The ungated contribution at a fixed label `t`, as a sum over the domain `Fin 4`.
+  have hungated_term : ∀ t : Fin 2,
+      (∑ k : Fin 4, star (coarseKrausUngated t k pq) * coarseKrausUngated t k pq') =
+        if ¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = t ∧ bit2 pq'.1 = t ∧
+            combine pq.1 pq.2 = combine pq'.1 pq'.2 then 1 else 0 := by
+    intro t
+    by_cases h : ¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = t ∧ bit2 pq'.1 = t ∧
+        combine pq.1 pq.2 = combine pq'.1 pq'.2
+    · rw [if_pos h]
+      rw [Finset.sum_eq_single (combine pq.1 pq.2)]
+      · simp only [coarseKrausUngated, Matrix.of_apply, if_pos ⟨h.1, rfl, h.2.2.1⟩,
+          if_pos ⟨h.2.1, h.2.2.2.2.symm, h.2.2.2.1⟩, star_one, one_mul]
+      · intro k _ hk
+        simp only [coarseKrausUngated, Matrix.of_apply]
+        rw [if_neg (fun hc => hk hc.2.1.symm), star_zero, zero_mul]
+      · simp
+    · rw [if_neg h]
+      apply Finset.sum_eq_zero
+      intro k _
+      by_cases hpk : ¬ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k ∧ bit2 pq.1 = t
+      · have hpk' : ¬ (¬ gate pq'.1 pq'.2 ∧ combine pq'.1 pq'.2 = k ∧ bit2 pq'.1 = t) := by
+          rintro ⟨hg', hc', hb'⟩
+          exact h ⟨hpk.1, hg', hpk.2.2, hb', hpk.2.1.trans hc'.symm⟩
+        simp only [coarseKrausUngated, Matrix.of_apply, if_pos hpk, if_neg hpk', star_one, mul_zero]
+      · simp only [coarseKrausUngated, Matrix.of_apply, if_neg hpk, star_zero, zero_mul]
+  simp_rw [hgated_term, hungated_term]
+  by_cases heq : pq = pq'
+  · subst heq
+    rw [if_pos rfl]
+    by_cases hg : gate pq.1 pq.2
+    · rw [if_pos ⟨hg, hg, rfl⟩, if_neg (fun hc => (hc.1 hg))]
+      rw [Fin.sum_univ_two]
+      have h0 : (coarseAmp : ℂ) ^ 2 * eigVecs 0 (bit2 pq.1) * eigVecs 0 (bit2 pq.1) +
+          (coarseAmp : ℂ) ^ 2 * eigVecs 1 (bit2 pq.1) * eigVecs 1 (bit2 pq.1) =
+          (coarseAmp : ℂ) ^ 2 * ((eigVecs 0 (bit2 pq.1)) ^ 2 + (eigVecs 1 (bit2 pq.1)) ^ 2) := by
+        ring
+      rw [h0]
+      have hsum : ((eigVecs 0 (bit2 pq.1)) ^ 2 + (eigVecs 1 (bit2 pq.1)) ^ 2 : ℂ) = 2 := by
+        exact_mod_cast eigVecs_sq_sum' (bit2 pq.1)
+      rw [hsum]
+      have hamp2 : (coarseAmp : ℂ) ^ 2 = ((coarseAmp ^ 2 : ℝ) : ℂ) := by push_cast; ring
+      rw [hamp2, coarseAmp_sq]
+      norm_num
+    · rw [if_neg (fun hc => hg hc.1), if_pos ⟨hg, hg, rfl, rfl, rfl⟩]
+      simp
+  · rw [if_neg heq]
+    by_cases hg : gate pq.1 pq.2
+    · by_cases hg' : gate pq'.1 pq'.2
+      · by_cases hc : combine pq.1 pq.2 = combine pq'.1 pq'.2
+        · rw [if_pos ⟨hg, hg', hc⟩, if_neg (fun hcon => hg (False.elim (hcon.2.2.1 ▸ hg')).elim)]
+          sorry
+        · rw [if_neg (fun hcon => hc hcon.2.2), if_neg (fun hcon => hc hcon.2.2.2.2)]
+          simp
+      · rw [if_neg (fun hcon => hg' hcon.2.1), if_neg (fun hcon => hg' hcon.2.1)]
+        simp
+    · rw [if_neg (fun hcon => hg hcon.1), if_neg (fun hcon => hg hcon.1)]
+      simp
+
 end MPOTensor.RescalingStableLengthDependentRFP

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -840,16 +840,47 @@
     Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_spectral}.
 \end{theorem}
 \begin{proof}\leanok
-    On the physical-index pairs satisfying the bond-matching condition,
-    the two-site physical operator is the one-site physical operator
-    rescaled by $25/32$ and by the corresponding entry of $W$; on every
-    other pair it vanishes. The refinement map reassembles $W$ from its
-    eigendecomposition against the one-site physical operator. The
-    coarse-graining map's gated Kraus operators reassemble $W$ in the
-    opposite direction, and its ungated Kraus operators annihilate the
-    vanishing entries; each of the two families resolves the identity, the
-    second using orthogonality of the eigenvectors of $W$ on distinct bond
-    bits.
+    Identify each physical index $p\in\{0,1,2,3\}$ with a pair of bits
+    $(p',p'')\in\{0,1\}^2$ as above, and write $i_1\ast i_2:=(i_1',i_2'')$
+    for the physical index gluing the first bit of $i_1$ to the second bit
+    of $i_2$. The two-site physical operator is a gate-restricted, rescaled
+    pullback of the one-site physical operator along $\ast$:
+    \begin{align}
+        M_2(X)_{(i_1,i_2)(j_1,j_2)}
+            &=\frac{25}{32}\,\mathbb 1[i_1''=i_2']\,\mathbb 1[j_1''=j_2']\,
+              W(i_1'',j_1'')\,M_1(X)_{i_1\ast i_2,\,j_1\ast j_2},
+        \notag
+    \end{align}
+    vanishing whenever either indicator fails. Write $e_0=(1,1)$,
+    $e_1=(1,-1)$ for the eigenvectors of $W$ and $\lambda_0=1$,
+    $\lambda_1=7/25$ for the matching eigenvalues
+    (Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_spectral}). The
+    refinement map's two Kraus operators carry the amplitudes
+    $\sqrt{25\lambda_s/64}$ on $e_s$, and reassemble the rescaled local
+    factor from the eigendecomposition of $W$,
+    \begin{align}
+        \sum_{s\in\{0,1\}}\frac{25}{64}\lambda_s\,e_s(b)\,e_s(b')
+            &=\frac{25}{32}\,W(b,b'), &
+        b,b'&\in\{0,1\},
+        \notag
+    \end{align}
+    which is exactly the coefficient displayed above. The coarse-graining
+    map's two gated Kraus operators carry the shared amplitude $1/\sqrt2$
+    on $e_0,e_1$, and their resolution of the identity on the
+    bond-matching pairs is the single identity
+    \begin{align}
+        \frac12\sum_{s\in\{0,1\}}e_s(b)\,e_s(b')
+            &=\begin{cases}1,&b=b',\\0,&b\ne b',\end{cases} &
+        b,b'&\in\{0,1\}:
+        \notag
+    \end{align}
+    the case $b=b'$ is the trace-preserving normalization and the case
+    $b\ne b'$ the off-diagonal cancellation between the two gated Kraus
+    operators. The coarse-graining map's two ungated Kraus operators supply
+    a deterministic assignment on the bond-mismatched pairs, where the
+    two-site physical operator already vanishes by the displayed formula
+    above; together the four Kraus operators resolve the identity on the
+    full two-site domain.
 \end{proof}
 
 \begin{definition}[Linearly independent operator family]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -790,10 +790,10 @@
     spectral data of $W$ and of $\varphi$ with $\chi$.
     % Scope note: this is not the uniform BNT-label structure-coefficient
     % statement of Theorem 4.14(ii) (Cirac2016MPDO_arXiv) for R itself, nor
-    % the literal CPSV canonical form or the renormalization fixed-point
-    % property of Definition is_rfp_via_ts: those require the
-    % tensor-attached BNT algebra-structure witness for R, which is future
-    % work.
+    % the literal CPSV canonical form: those require the tensor-attached
+    % BNT algebra-structure witness for R, which is future work. The
+    % renormalization fixed-point property of Definition is_rfp_via_ts is
+    % established directly below, without that witness.
 \end{theorem}
 \begin{proof}\leanok
     The uniform and alternating vectors are eigenvectors of the explicit
@@ -815,6 +815,41 @@
         \varphi(E_{01})&=\varphi(E_{10})=0.
         \notag
     \end{align}
+\end{proof}
+
+\begin{theorem}[The rescaling-stable tensor is a renormalization fixed
+    point]%
+    \label{thm:mpdo_bnt_label_rescaling_stable_is_rfp_via_ts}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.isRFPViaTS_R}
+    \leanok
+    \uses{def:is_rfp_via_ts,
+        thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    The tensor $R$ of
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_length_dependence} is a
+    renormalization fixed point in the sense of
+    Definition~\ref{def:is_rfp_via_ts}. The refinement map $\mathcal T$ has
+    two Kraus operators built from the eigenvectors of $W$, with amplitude
+    $5/8$ on the uniform eigenvector and $\sqrt7/8$ on the alternating
+    eigenvector. The coarse-graining map $\mathcal S$ has four Kraus
+    operators: two share the amplitude $1/\sqrt2$ and the eigenvectors of
+    $W$ on the physical-index pairs satisfying the bond-matching condition,
+    and two are a deterministic assignment on the pairs that fail it,
+    chosen so the family resolves the identity. This exhibits $R$ as a
+    full renormalization fixed-point example, without the tensor-attached
+    BNT algebra-structure witness anticipated in
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_spectral}.
+\end{theorem}
+\begin{proof}\leanok
+    On the physical-index pairs satisfying the bond-matching condition,
+    the two-site physical operator is the one-site physical operator
+    rescaled by $25/32$ and by the corresponding entry of $W$; on every
+    other pair it vanishes. The refinement map reassembles $W$ from its
+    eigendecomposition against the one-site physical operator. The
+    coarse-graining map's gated Kraus operators reassemble $W$ in the
+    opposite direction, and its ungated Kraus operators annihilate the
+    vanishing entries; each of the two families resolves the identity, the
+    second using orthogonality of the eigenvectors of $W$ on distinct bond
+    bits.
 \end{proof}
 
 \begin{definition}[Linearly independent operator family]%


### PR DESCRIPTION
## Summary

Completes the S-map (coarse-graining) half of Definition 4.1 (`IsRFPViaTS`) for the rescaling-stable length-dependent MPO tensor `R` (`TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean`), building on the T-map half delivered previously. `R` now has a full, faithful `IsRFPViaTS` witness.

## Changes

- `coarseKraus_resolution` — the four-Kraus family of the coarse-graining map `coarseMap` (two gated, sharing `T`'s Walsh–Hadamard structure; two ungated, a deterministic assignment on bond-mismatched pairs) resolves the identity, using the off-diagonal cancellation between the gated Kraus operators' eigenvectors.
- `coarseMap_isKrausCPTP` — `coarseMap` is trace-preserving completely positive.
- `coarseMap_physClose2` — `coarseMap (physClose2 R X) = physClose1 R X` for all `X` (the `eq:Smap` equation of Definition 4.1). The ungated Kraus operators annihilate `physClose2 R X` entirely (it vanishes on any bond-mismatched pair); the gated Kraus operators implement a two-level fiber sum over the shared bond bits that reassembles the local Walsh–Hadamard factor's eigendecomposition and exactly cancels the `25/32` rescaling.
- `isRFPViaTS_R` — the capstone: `R` satisfies `IsRFPViaTS`, witnessed by `S := coarseMap` and `T := refineMap`.
- Blueprint (ch21): adds the corresponding theorem citing `isRFPViaTS_R`, and updates a now-stale scope note that had anticipated needing the tensor-attached BNT algebra-structure witness for this property — the direct Kraus-map construction establishes it without that witness.

No `sorry`, no new axioms (`#print axioms isRFPViaTS_R` shows only `propext`, `Classical.choice`, `Quot.sound`).

Closes #5474

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal proofs and blueprint documentation for an already-motivated example; no changes to core auth, APIs, or runtime behavior.
> 
> **Overview**
> Completes the **coarse-graining (`S`) half** of Definition 4.1 for the explicit MPO tensor `R`, closing the gap left after the refinement map `T` was already proved. The file now proves that the four-Kraus `coarseMap` is trace-preserving completely positive (`coarseKraus_resolution` / `coarseMap_isKrausCPTP`) and satisfies **`S[physClose2 R X] = physClose1 R X`** (`coarseMap_physClose2`), then packages **`isRFPViaTS_R`**.
> 
> Supporting lemmas cover Walsh–Hadamard eigenvector orthogonality (off-diagonal cancellation between gated Kraus operators), uniqueness of gated vs ungated pairs under `combine` and bond bits, and case splits for identity resolution on the full two-site domain.
> 
> The module doc drops the “remaining gap” section and lists the new main results. **Blueprint ch21** adds Theorem `mpdo_bnt_label_rescaling_stable_is_rfp_via_ts` citing `isRFPViaTS_R`, and revises the spectral theorem scope note so **IsRFPViaTS is established without** the tensor-attached BNT algebra-structure witness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807f83b76f25e8b6b733bf6656b464da5ce95995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->