### PR TITLE
fix(tenkz): count the language's own sugar as finished work

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -33,7 +33,7 @@ $\tr(XA^\sigma)$ for the local space $\mathcal G_L^A$.
         % Type verdict: a rank-L physical tensor, equivalently a length-L state.
         % Boundary signature: semantic virtual-west=0 | virtual-east=0 |
         % physical-up=L | physical-down=0; the finite schematic emits 3 up legs.
-        \begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace]
+        \begin{tenkz}[rows={wire}, cols=5, boundary=periodic]
             \tn[skin=ring]{X} &
             \tn[label pos=135, ports={90:physical:$\sigma_1$}]{A} &
             \tn[label pos=135, ports={90:physical}]{A} & \tn[skin=dots]{} &
@@ -490,7 +490,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         % Type verdict: a rank-L physical tensor in G_L(A).
         % Boundary signature: semantic virtual-west=0 | virtual-east=0 |
         % physical-up=L | physical-down=0; the finite schematic emits 3 up legs.
-        \begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace]
+        \begin{tenkz}[rows={wire}, cols=5, boundary=periodic]
             \tn[skin=ring]{A^j X} &
             \tn[label pos=135, ports={90:physical:$\sigma_1$}]{A} &
             \tn[label pos=135, ports={90:physical}]{A} & \tn[skin=dots]{} &
@@ -532,7 +532,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         % Type verdict: a rank-L physical tensor in G_L(A).
         % Boundary signature: semantic virtual-west=0 | virtual-east=0 |
         % physical-up=L | physical-down=0; the finite schematic emits 3 up legs.
-        \begin{tenkz}[rows={wire}, cols=5, west=trace, east=trace]
+        \begin{tenkz}[rows={wire}, cols=5, boundary=periodic]
             \tn[skin=ring]{X A^i} &
             \tn[label pos=135, ports={90:physical:$\sigma_1$}]{A} &
             \tn[label pos=135, ports={90:physical}]{A} & \tn[skin=dots]{} &

--- a/blueprint/src/chapter/ch20_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch20_mpdo_foundations.tex
@@ -123,7 +123,7 @@ Diagrammatically,
     % \tau_1,\ldots,\tau_N, hence the semantic boundary signature is
     % (0,0,N,N).  The \tndots atom abbreviates the omitted cells, so the drawn
     % and logged physical arities are necessarily schematic rather than N.
-    \begin{tenkz}[rows={wire}, cols=4, west=trace, east=trace]
+    \begin{tenkz}[rows={wire}, cols=4, boundary=periodic]
         \tn[skin=mpo, ports={90:physical:$\sigma_1$, 270:physical:$\tau_1$}]{M} &
         \tn[skin=mpo, ports={90:physical:$\sigma_2$, 270:physical:$\tau_2$}]{M} &
         \tn[skin=dots]{} &

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -330,9 +330,9 @@
     % Exact source orientation: the upper layer is plain K_y and the lower
     % layer is plain K_x.  There is no conjugation or adjoint in AppKxKy=0.
     % Source: Papers/1606.00608/MPDO_KxKy.png and source TeX lines 1634--1639.
-    \begin{tenkz}[rows={op,op}, cols=1, west=open, east=open]
-        \tn[skin=mpo, ports={90:physical, 270:physical}]{\mathcal K_y} \\
-        \tn[skin=mpo, ports={90:physical, 270:physical}]{\mathcal K_x}
+    \begin{tenkz}[rows={op,op}, cols=1, west=open, east=open, physical=updown]
+        \tn[skin=mpo]{\mathcal K_y} \\
+        \tn[skin=mpo]{\mathcal K_x}
     \end{tenkz}
     $ = 0$
 \end{center}
@@ -849,27 +849,24 @@ leaves only the diagonal term:
     % (the physical legs, closed under sum_j P_j = Id) -- so all
     % four panels log the same boundary signature
     % (virtual-west=1 | virtual-east=1 | physical-up=1 | physical-down=1).
-    \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
-        \tn[skin=mpo, ports={90:physical, 270:physical}]{K_i}
+    \begin{tenkz}[rows={wire}, cols=1, west=open, east=open, physical=updown]
+        \tn[skin=mpo]{K_i}
     \end{tenkz}
     $ = \sum_{j,j'}$
-    \begin{tenkz}[rows={op,op,op}, cols=1, west=none, east=none]
-        \tn[skin=mpo, ports={90:physical, 270:physical}]{P_j} \\
-        \tn[skin=mpo, ports={90:physical, 270:physical, 180:virtual, 0:virtual}]
-          {K_i} \\
-        \tn[skin=mpo, ports={90:physical, 270:physical}]{P_{j'}}
+    \begin{tenkz}[rows={op,op,op}, cols=1, west=none, east=none, physical=updown]
+        \tn[skin=mpo]{P_j} \\
+        \tn[skin=mpo, ports={180:virtual, 0:virtual}]{K_i} \\
+        \tn[skin=mpo]{P_{j'}}
     \end{tenkz}
     $ = $
-    \begin{tenkz}[rows={op,op}, cols=1, west=none, east=none]
-        \tn[skin=mpo, ports={90:physical, 270:physical}]{P_i} \\
-        \tn[skin=mpo, ports={90:physical, 270:physical, 180:virtual, 0:virtual}]
-          {K_i}
+    \begin{tenkz}[rows={op,op}, cols=1, west=none, east=none, physical=updown]
+        \tn[skin=mpo]{P_i} \\
+        \tn[skin=mpo, ports={180:virtual, 0:virtual}]{K_i}
     \end{tenkz}
     $ = $
-    \begin{tenkz}[rows={op,op}, cols=1, west=none, east=none]
-        \tn[skin=mpo, ports={90:physical, 270:physical, 180:virtual, 0:virtual}]
-          {K_i} \\
-        \tn[skin=mpo, ports={90:physical, 270:physical}]{P_i}
+    \begin{tenkz}[rows={op,op}, cols=1, west=none, east=none, physical=updown]
+        \tn[skin=mpo, ports={180:virtual, 0:virtual}]{K_i} \\
+        \tn[skin=mpo]{P_i}
     \end{tenkz}
 \end{center}
 Equivalently, each local tensor is supported on its own sector:

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
@@ -348,22 +348,20 @@
     %   boundary|virtual-west=1|virtual-east=1|physical-up=1|physical-down=0.
     \begin{center}
         \tenkzkernel
-        \begin{tenkz}[rows={wire}, cols=2, west=open, east=open]
-            \tn[label pos=s, ports={90:physical}]{A_R} &
-            \tn[label pos=s, ports={90:physical}]{A}
+        \begin{tenkz}[rows={wire}, cols=2, west=open, east=open, physical=up]
+            \tn[label pos=s]{A_R} & \tn[label pos=s]{A}
         \end{tenkz}
         \quad$=$\quad
-        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
-            \tn[label pos=s, ports={90:physical}]{A_S}
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open, physical=up]
+            \tn[label pos=s]{A_S}
         \end{tenkz}
         \quad$\propto$\quad
-        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
-            \tn[label pos=s, ports={90:physical}]{\widetilde B_S}
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open, physical=up]
+            \tn[label pos=s]{\widetilde B_S}
         \end{tenkz}
         \quad$=$\quad
-        \begin{tenkz}[rows={wire}, cols=2, west=open, east=open]
-            \tn[label pos=s, ports={90:physical}]{\widetilde B_R} &
-            \tn[label pos=s, ports={90:physical}]{\widetilde B}
+        \begin{tenkz}[rows={wire}, cols=2, west=open, east=open, physical=up]
+            \tn[label pos=s]{\widetilde B_R} & \tn[label pos=s]{\widetilde B}
         \end{tenkz}.
     \end{center}
     Applying the left inverse supplied by injectivity of the block

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -11,10 +11,19 @@ with the tracked TeX sources.
 ## Disposition rules
 
 - **Preserve** means a pure `tenkz` grid construct already uses kernel
-  vocabulary. It remains byte-compatible at the surface switch.
+  vocabulary. It remains byte-compatible at the surface switch. A key with a
+  signed `kernel-` registry row counts as kernel vocabulary whether its status
+  is `kernel` or `sugar(...)`, because a sugar row carries no sunset: the
+  switch leaves it spelled exactly as it stands. This holds only under the
+  kernel switch, which is where a key already means what 1.0 says it means.
 - **Codemod** means every non-kernel spelling has a mechanical expansion in
   the §9 sugar ledger or an exact 0.7 atom-shorthand respelling to 1.0 atom
-  keys. The target codes below name that expansion.
+  keys. The target codes below name that expansion. The same key on a 0.7
+  picture is a non-kernel spelling even when the kernel carries a row of that
+  name, because the two tiers read several of them differently: 0.7
+  `boundary=` sets all four sides where the kernel sets west and east, and
+  0.7 `physical=` is a row topology where the kernel's is a per-cell port
+  policy.
 - **Redraw** means the construct depends on a §10 tombstone. Its mathematical
   boundary and topology must be re-authored with the named §12-style shape;
   a compatibility-renderer transcription is not a migration.
@@ -32,7 +41,7 @@ with the tracked TeX sources.
 | `C-declare` | Replace compatibility setup lists with `\tndeclare` records. |
 | `C-picture` | Expand `\tnpic` to a scoped `tenkz` picture term. |
 | `C-tree` | Expand `\tntree` to declared fuse atoms and `\tnwire` records. |
-| `C-policy` | Expand physical/boundary sugar to `rows=`, typed `ports=`, and explicit side policies. |
+| `C-policy` | Expand 0.7 physical/boundary sugar and the boundary-label keys to `rows=`, typed `ports=`, and explicit side policies. |
 | `C-frame` | Expand lattice/ring/surface/planes/cluster sugar to rows, columns, frame, basis members, and explicit closures. |
 | `C-record` | Expand atom, wire, span, skip, and port sugar; respell 0.7 atom flags as `skin=` and typed `ports=` on `\tn`, `\tnwire`, and `\tnmark` records. |
 | `C-species` | Replace `role=` with the corresponding declared `species=`. |
@@ -60,7 +69,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch12_symmetry_virtual_and_cohomology.tex` | L181, 196, 330, 459, 473 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | — | — | L54 `tenkzfree` → `R-free+R-record` |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | — | — | L275 `tenkzfree` → `R-free+R-record` |
-| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | L101 `tenkz` → `C-policy` | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 493, 535 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | — | L674 `tenkz` → `C-policy+C-record` | — |
@@ -69,9 +78,9 @@ separate public-surface occurrence and therefore appears separately.
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |
 | `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 644 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | L17, 126 `tenkz` → `P-grid` | — | L372 `tenkz` → `C-policy+C-record+R-record`<br>L376 `tenkz` → `C-record+R-record` |
-| `ch21_mpdo_rfp_algebra_tower.tex` | — | L79, 95 `tenkz` → `C-policy` | — |
+| `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_foundations.tex` | — | L87, 92 `tenkz` → `C-policy` | — |
+| `ch21_mpdo_rfp_foundations.tex` | L87, 92 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
@@ -81,15 +90,15 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L793, 806, 814, 821, 895, 902 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex` | — | — | L427 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | L189 `tenkz` → `C-policy` | — |
+| `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L333, 852, 856, 863, 869 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L333, 852, 856, 862, 867 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | — | — | L83, 115, 329, 347, 365, 623, 647 `tenkzfree` → `C-species+R-free+R-record`<br>L316 `tenkzfree` → `R-free+R-record` |
-| `ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex` | — | L53, 60 `tenkz` → `C-policy` | — |
+| `ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex` | L53, 60 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_edge_kernel_gauges_kernel_descent_recovery.tex` | — | — | L174, 196, 218, 445, 467, 489 `tenkzfree` → `C-species+R-free+R-record` |
 | `ch24_peps_ft_edge_middle.tex` | — | L278 `tnpic` → `C-picture+C-policy` | L242 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_foundations.tex` | — | — | L48, 384 `tenkzfree` → `R-free+R-record` |
@@ -99,7 +108,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch24_peps_ft_normal_square_rectangular_injectivity.tex` | — | — | L205, 214 `tenkzlattice` → `R-lattice+R-record` |
 | `ch24_peps_ft_normal_square_translated_windows_and_comparison.tex` | — | — | L380 `tenkzlattice` → `R-lattice+R-record` |
 | `ch24_peps_ft_normal_union.tex` | — | — | L213, 270, 301, 327, 358 `tenkzfree` → `R-free+R-record` |
-| `ch24_peps_ft_region_transfer_covariance.tex` | L351, 356, 360, 364 `tenkz` → `P-grid` | — | — |
+| `ch24_peps_ft_region_transfer_covariance.tex` | L351, 355, 359, 363 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_torus_translation_and_reference_windows.tex` | — | — | L22 `tenkzlattice` → `C-species+R-lattice+R-record` |
 | `ch26_mps_rfp_normal_isometry_canonical_forms.tex` | L453, 457 `tenkz` → `P-grid` | — | L605 `tenkz` → `C-policy+R-record`<br>L610 `tenkzfree` → `R-free+R-record` |
 | `ch26_mps_rfp_physical_blocking.tex` | — | — | L198, 223 `tenkz` → `C-policy+C-record+R-record`<br>L202, 217 `tenkz` → `C-record+R-record` |
@@ -120,8 +129,8 @@ separate public-surface occurrence and therefore appears separately.
 
 | Disposition | Occurrences |
 |---|---:|
-| preserve | 38 |
-| codemod | 33 |
+| preserve | 46 |
+| codemod | 25 |
 | redraw | 136 |
 | **Total** | **207** |
 

--- a/scripts/check_tenkz_dispositions.py
+++ b/scripts/check_tenkz_dispositions.py
@@ -33,6 +33,13 @@ ENVIRONMENT = re.compile(
 COMMAND = re.compile(r"\\(tnpic|tntree)\b")
 TENKZEQ_TOKEN = re.compile(r"\\(begin|end)\{tenkzeq\}")
 SETUP_COMMAND = re.compile(r"\\(?:tnset|tndeclare(?:atom)?|tenkzkernel)\b")
+GROUP_TOKEN = re.compile(
+    r"\\begin\s*\{\s*[A-Za-z@*]+\s*\}"
+    r"|\\end\s*\{\s*[A-Za-z@*]+\s*\}"
+    r"|\\tenkzkernel(?![A-Za-z])"
+    r"|\\(?:[A-Za-z]+|.)"
+    r"|[{}]"
+)
 DISPOSITIONS = ("preserve", "codemod", "redraw")
 DEAD_COMMANDS = (
     "tnput",
@@ -252,6 +259,44 @@ def unrecognized_option_keys(source: str) -> set[str]:
     return unknown
 
 
+def kernel_switch_spans(source: str) -> list[tuple[int, int]]:
+    r"""Return the character ranges over which `\tenkzkernel` is in force.
+
+    The switch is an ordinary TeX declaration, so the group that contains it
+    ends it: a switch inside one `center` block does not reach a picture in
+    the next. Environments and brace groups both count as groups, which is
+    the same reading the blueprint renderer applies to the document tree.
+    """
+    spans: list[tuple[int, int]] = []
+    depth = 0
+    start: int | None = None
+    switch_depth = 0
+    for match in GROUP_TOKEN.finditer(source):
+        token = match.group()
+        if token.startswith("\\tenkzkernel"):
+            if start is None:
+                start, switch_depth = match.end(), depth
+            continue
+        if token.startswith("\\begin") or token == "{":
+            depth += 1
+            continue
+        if token.startswith("\\end") or token == "}":
+            depth -= 1
+        else:
+            continue
+        if start is not None and depth < switch_depth:
+            spans.append((start, match.start()))
+            start = None
+    if start is not None:
+        spans.append((start, len(source)))
+    return spans
+
+
+def within(spans: list[tuple[int, int]], offset: int) -> bool:
+    """Return whether an offset falls inside one of the given ranges."""
+    return any(start <= offset < end for start, end in spans)
+
+
 def scan_inventory_constructs(source: str) -> list[Construct]:
     """Scan picture constructs plus the non-picture `tenkzeq` wrapper."""
     constructs = scan_constructs(source)
@@ -284,15 +329,20 @@ def scan_inventory_constructs(source: str) -> list[Construct]:
     return constructs
 
 
-def construct_sources(path: Path) -> dict[tuple[str, int, str], list[str]]:
-    """Return source slices for each picture construct in a TeX file."""
+def construct_sources(
+    path: Path,
+) -> dict[tuple[str, int, str], list[tuple[str, bool]]]:
+    """Return each construct's source slice and whether the kernel reaches it."""
     source = normalized_environment_spacing(
         strip_comments(path.read_text(errors="replace"))
     )
-    result: dict[tuple[str, int, str], list[str]] = defaultdict(list)
+    spans = kernel_switch_spans(source)
+    result: dict[tuple[str, int, str], list[tuple[str, bool]]] = defaultdict(list)
     for construct in scan_inventory_constructs(source):
         key = (path.name, construct.line, construct.name)
-        result[key].append(source[construct.start : construct.end])
+        result[key].append(
+            (source[construct.start : construct.end], within(spans, construct.start))
+        )
     return result
 
 
@@ -318,8 +368,18 @@ def expanded_source(path: Path, stack: tuple[Path, ...] = ()) -> str:
     )
 
 
-def fragment_target_codes(source: str) -> frozenset[str]:
-    """Classify one construct or construct-free source fragment."""
+def fragment_target_codes(source: str, kernel: bool = False) -> frozenset[str]:
+    r"""Classify one construct or construct-free source fragment.
+
+    `kernel` says the `\tenkzkernel` switch reaches this fragment, so its keys
+    already carry their 1.0 meaning. A key with a signed `kernel-` registry
+    row then owes no migration work, whether the row is kernel or sugar: the
+    surface switch leaves it spelled exactly as it stands. The same key on a
+    0.7 picture still owes one, because the two tiers read several of these
+    keys differently — 0.7 `boundary=` sets all four sides where the kernel
+    sets west and east, and 0.7 `physical=` is a row topology where the
+    kernel's is a per-cell port policy.
+    """
     public_commands = (
         "tn",
         "tnwire",
@@ -358,6 +418,11 @@ def fragment_target_codes(source: str) -> frozenset[str]:
         scope: {key for option_scope, key, _value in options if option_scope == scope}
         for scope in SIGNED_KEYS_BY_SCOPE
     }
+    migrating_by_scope = {
+        scope: scope_keys - SIGNED_KEYS_BY_SCOPE[scope] if kernel else scope_keys
+        for scope, scope_keys in keys_by_scope.items()
+    }
+    migrating = set().union(*migrating_by_scope.values())
     tn_options: list[tuple[str, str | None]] = []
     for match in re.finditer(r"\\tn\*?(?![A-Za-z])", source):
         group = following_group(source, match.end(), "[", "]")
@@ -433,7 +498,9 @@ def fragment_target_codes(source: str) -> frozenset[str]:
     dead_record |= "tri" in tn_keys
     if tn_keys & {"box", "dot", "pill", "mpo", "ring", "no legs"}:
         codes.add("C-record")
-    if any(key == "cluster" and value is not None for key, value in tn_options):
+    if "cluster" in migrating_by_scope["atom"] and any(
+        key == "cluster" and value is not None for key, value in tn_options
+    ):
         codes.add("C-record")
     if dead_record:
         codes.add("R-record")
@@ -442,7 +509,9 @@ def fragment_target_codes(source: str) -> frozenset[str]:
         codes.add("C-picture")
     if re.search(r"\\tntree\b", source):
         codes.add("C-tree")
-    if "physical" in keys or keys_by_scope["picture"] & {
+    # The kernel side grammar takes `cup={m}` itself; `tail=` has no kernel row.
+    labelled_side = r"tail" if kernel else r"(?:cup|tail)"
+    if "physical" in migrating or migrating_by_scope["picture"] & {
         "boundary",
         "west label",
         "east label",
@@ -452,14 +521,14 @@ def fragment_target_codes(source: str) -> frozenset[str]:
         "sandwich",
         "periodic",
     } or any(
-        re.match(r"(?:cup|tail)\s*=", value.lstrip("{").strip())
+        re.match(labelled_side + r"\s*=", value.lstrip("{").strip())
         for scope, key, value in options
         if scope == "picture"
         and key in {"west", "east", "north", "south"}
         and value is not None
     ):
         codes.add("C-policy")
-    if keys_by_scope["picture"] & {
+    if migrating_by_scope["picture"] & {
         "lattice",
         "ring",
         "surface",
@@ -471,7 +540,7 @@ def fragment_target_codes(source: str) -> frozenset[str]:
         codes.add("C-record")
     if re.search(r"\\tn\*", source):
         codes.add("C-record")
-    if keys_by_scope["atom"] & {
+    if migrating_by_scope["atom"] & {
         "combined",
         "span",
         "up at",
@@ -482,9 +551,9 @@ def fragment_target_codes(source: str) -> frozenset[str]:
         "down",
     }:
         codes.add("C-record")
-    if "role" in keys:
+    if "role" in migrating:
         codes.add("C-species")
-    if "species" in keys_by_scope["setup"]:
+    if "species" in migrating_by_scope["setup"]:
         codes.add("C-declare")
     if re.search(r"\\tndeclareatom\b", source):
         codes.add("C-declare")
@@ -502,11 +571,17 @@ def fragment_target_codes(source: str) -> frozenset[str]:
 def source_target_codes(source: str) -> frozenset[str]:
     """Derive exact migration targets, preserving mixed-construct workloads."""
     source = normalized_environment_spacing(source)
+    spans = kernel_switch_spans(source)
     constructs = scan_inventory_constructs(source)
     codes: set[str] = set()
     masked = list(source)
     for construct in constructs:
-        codes.update(fragment_target_codes(source[construct.start : construct.end]))
+        codes.update(
+            fragment_target_codes(
+                source[construct.start : construct.end],
+                within(spans, construct.start),
+            )
+        )
         for index in range(construct.start, construct.end):
             if masked[index] != "\n":
                 masked[index] = " "
@@ -673,7 +748,7 @@ def main() -> int:
 
     blueprint_occurrences: Counter[tuple[str, int, str]] = Counter()
     blueprint_raw: Counter[str] = Counter()
-    blueprint_sources: dict[tuple[str, int, str], list[str]] = {}
+    blueprint_sources: dict[tuple[str, int, str], list[tuple[str, bool]]] = {}
     for path in sorted(BLUEPRINT_ROOT.glob("*.tex")):
         blueprint_sources.update(construct_sources(path))
         for line, name in occurrences(path):
@@ -706,7 +781,10 @@ def main() -> int:
         fail("blueprint reconciliation tables have different totals")
     for key, documented_disposition in blueprint_occurrence_dispositions.items():
         actual_targets = frozenset().union(
-            *(fragment_target_codes(source) for source in blueprint_sources[key])
+            *(
+                fragment_target_codes(source, kernel)
+                for source, kernel in blueprint_sources[key]
+            )
         )
         if actual_targets != blueprint_occurrence_targets[key]:
             fail(

--- a/scripts/test_check_tenkz_dispositions.py
+++ b/scripts/test_check_tenkz_dispositions.py
@@ -118,6 +118,42 @@ def main() -> int:
         r"\begin{tenkz}[physical=up]\tnspan[brace below]{2}{}\end{tenkz}"
     ) == frozenset({"C-policy", "C-record", "R-record"})
 
+    # A signed kernel row owes no migration work under the kernel switch,
+    # whether its registry status is kernel or sugar; the same key on a 0.7
+    # picture still does, because the two tiers read it differently.
+    signed_sugar = (
+        r"\begin{tenkz}[physical=up]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[boundary=periodic]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[sandwich]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[lattice={2x2}]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[ring=4]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[surface=torus]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[west={cup=$m$}]\tn{}\end{tenkz}",
+        r"\begin{tenkz}\tn[cluster={2x3}]{}\end{tenkz}",
+        r"\begin{tenkz}\tn[role=operator]{}\end{tenkz}",
+    )
+    for source in signed_sugar:
+        assert guard.fragment_target_codes(source, True) == frozenset(
+            {"P-grid"}
+        ), source
+        assert guard.fragment_target_codes(source) != frozenset({"P-grid"}), source
+
+    # Keys with no kernel row keep their codemod under the switch.
+    unsigned_policy = (
+        r"\begin{tenkz}[periodic]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[west label=$m$]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[bond label=$m$]\tn{}\end{tenkz}",
+        r"\begin{tenkz}[west={tail=$m$}]\tn{}\end{tenkz}",
+    )
+    for source in unsigned_policy:
+        assert "C-policy" in guard.fragment_target_codes(source, True), source
+
+    # A tombstoned key stays a redraw under the switch even where the
+    # registry still carries a kernel row of that name.
+    assert guard.fragment_target_codes(
+        r"\begin{tenkz}\tn[nudge={1,0}]{}\end{tenkz}", True
+    ) == frozenset({"R-record"})
+
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
         dependency = root / "dependency.inc"
@@ -142,7 +178,27 @@ def main() -> int:
         )
         sources = guard.construct_sources(blueprint)
         construct = sources[("blueprint.tex", 1, "tenkz")]
-        assert any(guard.uses_tombstone(source) for source in construct)
+        assert any(guard.uses_tombstone(source) for source, _ in construct)
+        assert not any(kernel for _, kernel in construct)
+
+        switched = root / "switched.tex"
+        switched.write_text(
+            "\\begin{center}\n"
+            r"\tenkzkernel" "\n"
+            r"\begin{tenkz}[physical=up]\tn{}\end{tenkz}" "\n"
+            "\\end{center}\n"
+            r"\begin{tenkz}[physical=up]\tn{}\end{tenkz}"
+        )
+        switched_sources = guard.construct_sources(switched)
+        assert switched_sources[("switched.tex", 3, "tenkz")] == [
+            (r"\begin{tenkz}[physical=up]\tn{}\end{tenkz}", True)
+        ]
+        assert switched_sources[("switched.tex", 5, "tenkz")] == [
+            (r"\begin{tenkz}[physical=up]\tn{}\end{tenkz}", False)
+        ]
+        assert guard.source_target_codes(switched.read_text()) == frozenset(
+            {"C-policy", "C-switch"}
+        )
 
         cycle = root / "cycle.tex"
         cycle.write_text(r"\input{cycle.tex}")
@@ -198,9 +254,9 @@ def main() -> int:
         tree_sources = guard.construct_sources(tree)
         tree_key = ("tree.tex", 1, "tntree")
         assert list(tree_sources) == [tree_key]
-        assert tree_sources[tree_key] == [tree_source]
+        assert tree_sources[tree_key] == [(tree_source, False)]
         assert guard.source_target_codes(tree_source) == frozenset({"C-tree"})
-        assert guard.fragment_target_codes(tree_sources[tree_key][0]) == frozenset(
+        assert guard.fragment_target_codes(*tree_sources[tree_key][0]) == frozenset(
             {"C-tree"}
         )
 


### PR DESCRIPTION
## The conclusion: `physical=` and `boundary=` are 1.0 surface

The registry is right and the ledger was wrong. Four pieces of evidence, all
pointing the same way:

1. **Registry status.** Both keys carry a `kernel-picture` row whose status is
   `sugar(...)`:

       {kernel-picture}{physical}{physical-policy}{none}{sugar(rows)}
       {kernel-picture}{boundary}{enum(open|none|periodic)}{open}{sugar(west, east)}

   The rows that *are* retiring look different. Every one of them says so in
   the same field: `{picture}{periodic}{flag}{false}{alias(boundary=periodic;
   sunset=1.0)}`, `{object}{legs at}{...}{alias(up at,down at; sunset=1.0)}`,
   `{picture}{boundary legs}{...}{alias(boundary=open; sunset=1.0)}`. A sunset
   is a field the registry knows how to write, and neither of these two keys
   carries one.

2. **The contract's own two ledgers.** LANGUAGE-1.0 §11 splits the census in
   exactly this place: "`sugar(<expansion>)` rows pass the expansion-closure
   check and hold tenure at three consumers; `alias` rows carry sunsets."
   M5 tracks aliases and their sunsets and is to be "near zero at the 1.0
   freeze". M1 counts sugar as a standing ledger with no such target. The
   Session-0 baseline records `sugar: 13` beside `alias: 6`.

3. **§9 and §10.** Both keys are rows of the §9 sugar ledger, with `physical=`
   given a worked teaching example. Neither appears in the §10 tombstone
   table, and §9 says outright that teaching text uses sugar freely.

4. **The parser.** `tenkz-kernel.code.tex` installs `sandwich`, `boundary`,
   `lattice`, `ring`, `surface`, `planes`, and `physical` in
   `tenkz-kernel-picture` next to `rows`, `cols`, and the four side keys. A
   kernel picture spelled with them compiles today and will compile at S4
   with the same bytes.

So the ledger's own definition of preserve — "remains byte-compatible at the
surface switch" — already covered these figures, and the classifier was
reading a spelling that survives the switch as work still owed.

### What the classifier now does

`fragment_target_codes` takes a `kernel` flag. Under the `\tenkzkernel`
switch, a key with a signed `kernel-` registry row contributes no `C-` code,
whatever its status — the rule is registry-derived rather than a hand-kept
list, so it covers `sandwich`, `lattice`, `ring`, `surface`, `planes`,
`cluster`, and `role` on the same footing as the two keys the issue names.

The classification survives where it still means something:

- **On a 0.7 picture the codes are unchanged**, because the two tiers do not
  read these keys the same way. The 0.7 row is
  `{picture}{boundary}{...}{sugar(west=, east=, north=, south=)}` — all four
  sides — where the kernel's sets west and east; the 0.7 `physical=` is "one-row
  physical topology" where the kernel's is a per-cell port policy; 0.7
  `sandwich` expands to `rows={ket,bra}` and the kernel's to `rows={ket,op,bra}`.
  A 0.7 figure carrying one of these genuinely has to be restated.
- **Keys with no kernel row keep their `C-policy` under the switch**:
  `periodic` (the bare flag, an alias with a sunset), the four `<side> label=`
  keys, `bond label=`, and `tail=`. `cup={m}` is exempt, because the kernel
  side grammar takes it directly.
- **Tombstones still outrank the exemption.** `nudge=`, `inset=`, `slot=`, and
  `check=` are §10 tombstones that the registry still carries as kernel rows
  pending their retirements; the exemption touches `C-` codes only, so those
  stay `R-record`.

The switch is read with its TeX scope, not by file: a `\tenkzkernel` inside
one `center` block does not reach a picture in the next. This is the same
reading `blueprint/src/Packages/tenkz_pic.py` applies to the document tree,
and it is what keeps a half-migrated chapter honest — `ch26_mps_rfp_normal_isometry_canonical_forms.tex`
has its switch at L443 and its unmigrated figures at L605 and L610, which stay
in the redraw column.

## Table movement

| Blueprint | before | after |
|---|---:|---:|
| preserve | 38 | **46** |
| codemod | 33 | **25** |
| redraw | 136 | 136 |
| **Total** | 207 | 207 |

Eight occurrences move, all of them kernel-tier pictures already spelled the
way the manual teaches:

| Occurrence | before | after |
|---|---|---|
| `ch13_..._intersection_property.tex` L101 | `C-policy` | `P-grid` |
| `ch21_mpdo_rfp_algebra_tower.tex` L79, 95 | `C-policy` | `P-grid` |
| `ch21_mpdo_rfp_foundations.tex` L87, 92 | `C-policy` | `P-grid` |
| `ch21_..._primitivity_active_trace_matrix.tex` L189 | `C-policy` | `P-grid` |
| `ch24_..._insertion_algebra_local_gauges.tex` L53, 60 | `C-policy` | `P-grid` |

The standalone fixture totals are unmoved at 10/40/214: no fixture pairs the
kernel switch with a policy key, and a kernel fixture is a codemod anyway on
`C-switch`.

## Figures shortened

Twelve pictures across four chapters return to the sugar. Each was rendered
before and after at 200 dpi through a scratch standalone; every pair compares
at **AE 0** — pixel-identical, same bounding box.

| File | pictures | picture lines |
|---|---:|---:|
| `ch13_..._local_parent_interaction.tex` | 3 | 21 → 21 |
| `ch20_mpdo_foundations.tex` | 4 | 17 → 17 |
| `ch21_..._structure_capstone.tex` | 5 | 23 → **20** |
| `ch24_peps_ft_region_transfer_covariance.tex` | 4 | 14 → **12** |
| **Total** | 16 | 75 → **70** |

- `west=trace, east=trace` → `boundary=periodic` in the four periodic chains
  (three in ch13, one in ch20). This also ends a split spelling: the sibling
  file `ch13_..._intersection_property.tex` already said `boundary=periodic`
  for the same drawing.
- The per-atom `ports={90:physical, 270:physical}` and `ports={90:physical}`
  lists → `physical=updown` and `physical=up` in the nine pictures where every
  frame-cell atom carried the same unlabelled policy port. Five source lines
  go, three of them the wrapped continuation lines that a 12-token `ports=`
  list forces.

Not shortened, and why:

- **Labelled physical ports stay.** `ports={90:physical:$\sigma_1$}` writes the
  label on its typed port, which is what §9 teaches; the policy generates the
  leg but carries no label of its own.
- **Mixed pictures stay.** In `ch20_..._positivity_gram_normalization.tex` and
  the ch12/ch03/ch26 chains only the middle atom takes a physical leg while the
  gauge capsules take none, so a picture-wide policy would be wrong.
- **The cup labels stay explicit.** `west={cup=$Y$}` is kernel side grammar and
  the classifier now exempts it, but it does not render identically to its §9
  expansion: `ch14_correlations.tex` L68 came out 5 px wider at 200 dpi, the
  difference sitting entirely in the east cup atom, whose label carries a
  superscript. That looks like the sugar's `$…$` value reaching the label in a
  different math style than a `\tn` body does. Worth its own issue; it is not
  this PR's to fix, and the figure is left alone rather than changed by an
  amount nobody asked for.
- **`west=open, east=open` and `west=none, east=none` stay.** `boundary=open`
  and `boundary=none` are now permitted, but the swap moves no lines and would
  touch four chapters this PR has no other business in.

The wave-B2 session entry in `SHRINK.md` records the old incentive in its own
words — "a picture that says `physical=up` or `boundary=periodic` still reads
its topology off a sugar row, and the disposition ledger books that as a
codemod, so the ports and the two side words are written out instead". That
entry is dated and append-only, so it stands as written; this PR is the
correction it was describing the need for.

## Validation

```
python3 scripts/check_tenkz_dispositions.py
  PASS: 207 blueprint occurrences and 264 standalone fixtures reconcile exactly
python3 scripts/test_check_tenkz_dispositions.py
  PASS: disposition checker detects contract and dependency regressions
python3 scripts/test_tenkz_pic.py
  all tenkz pipeline checks passed
python3 scripts/test_tenkz_language.py
  PASS: registry, typed atom diagnostic, and alias event equivalence
python3 scripts/check_tenkz_demolition.py
  PASS: no retired tensor-network catalogue calls, paths, or pipeline entry points
python3 scripts/tenkz_shrink.py gate --base-ref origin/main
  tenkz-shrink: PASS: census stable at 201 and all 148 flag(s) carry verdicts
xelatex docs/tenkz/manual2.tex       -> 20 pages, no errors
xelatex blueprint/src/print.tex      -> 858 pages, no errors
```

No meter moves — M1 through M6 are byte-identical to
`tests/tenkz/census-baseline.json` — so there is no `SHRINK.md` session entry
and no baseline regeneration. The registry is untouched; only the ledger and
the figures that were paying it move.

The test file gains the rule as assertions: nine signed sugar spellings that
classify `P-grid` under the switch and not without it, four unsigned policy
spellings that keep `C-policy` under it, one tombstone that stays `R-record`
under it, and a two-picture fixture proving the switch stops at its group.

Closes LionSR/tenkz#166
