### PR TITLE
fix(tenkz): draw a labelled cup as its documented expansion

### DIFF
--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -65,10 +65,9 @@ on decay rates.
         % instead feeds the adjoint and gives the same trace pairing with Y.
         % Boundary signature: (virtual-west=0 | virtual-east=0 |
         % physical-up=0 | physical-down=0).
-        \begin{tenkz}[rows={wire,wire}, cols=3, west=cup, east=cup]
+        \begin{tenkz}[rows={wire,wire}, cols=3,
+            west={cup=$Y$}, east={cup=$X\rho^R$}]
             \tn[at=(1,2), skin=ring, wires=2]{\E_A^n}
-            \tn[skin=ring, at=on cup-west-1-2 0.5]{Y}
-            \tn[skin=ring, at=on cup-east-1-2 0.5]{X\rho^R}
         \end{tenkz}
     \end{center}
 \end{definition}

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2401,14 +2401,14 @@ regression_count=$(find "$WORK" -maxdepth 1 -name 'r_*.tex' | wc -l | tr -d ' ')
 echo "PASS: $regression_count review regressions hold"
 
 fail=0
-for pair in s1 s2 s3 s4 s5 s6 s7 s8 s9; do
+for pair in s1 s2 s3 s4 s5 s6 s7 s8 s9 s10; do
   if ! cmp -s "$WORK/${pair}_sugar.tnlog" "$WORK/${pair}_kernel.tnlog"; then
     echo "FAIL: sugar pair $pair diverges from its kernel expansion" >&2
     diff "$WORK/${pair}_sugar.tnlog" "$WORK/${pair}_kernel.tnlog" >&2 || true
     fail=1
   fi
 done
-[ "$fail" -eq 0 ] && echo "PASS: 9 sugar spellings byte-identical to their expansions"
+[ "$fail" -eq 0 ] && echo "PASS: 10 sugar spellings byte-identical to their expansions"
 
 CURRENT="$WORK/current.sha256"
 ( cd "$WORK"

--- a/tests/tenkz/kernel/sugar/s10_kernel.tex
+++ b/tests/tenkz/kernel/sugar/s10_kernel.tex
@@ -1,0 +1,16 @@
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=3, west=cup, east=cup]
+  \tn[at=(1,2), skin=ring, wires=2]{T^n}
+  \tn[skin=ring, at=on cup-west-1-2 0.5]{Y}
+  \tn[skin=ring, at=on cup-east-1-2 0.5]{X\rho^R}
+\end{tenkz}
+\mbox{p}
+\end{document}

--- a/tests/tenkz/kernel/sugar/s10_sugar.tex
+++ b/tests/tenkz/kernel/sugar/s10_sugar.tex
@@ -1,0 +1,14 @@
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=3, west={cup=$Y$}, east={cup=$X\rho^R$}]
+  \tn[at=(1,2), skin=ring, wires=2]{T^n}
+\end{tenkz}
+\mbox{p}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -3005,21 +3005,32 @@
 % fixed point a side closes through is one matrix for the whole side.
 \tl_new:N \l__tenkz_kernel_cupbead_tl
 \tl_new:N \l__tenkz_kernel_cupnode_tl
+\tl_new:N \l__tenkz_kernel_cupname_tl
+\tl_new:N \l__tenkz_kernel_cupother_tl
+\tl_new:N \l__tenkz_kernel_cuppol_tl
+% The documented spelling writes the matrix with its own math delimiters,
+% while the atom slot opens math around a label of its own accord.  Peel the
+% author's pair off, so the matrix reaches the label exactly as a `\tn` body
+% does and is typeset in the same math style.  Keeping the delimiters needs a
+% box, and a box holds text style inside a script-style label -- the label
+% then draws wider than the expansion it stands for.
+\cs_new_protected:Npn \__tenkz_kernel_cup_unmath:w $#1$ \q_stop
+  { \tl_set:Nn \l__tenkz_kernel_cupbead_tl {#1} }
+\cs_new_protected:Npn \__tenkz_kernel_cup_unmath:
+  {
+    \exp_args:NV \tl_if_head_eq_catcode:nNT \l__tenkz_kernel_cupbead_tl $
+      {
+        \exp_last_unbraced:NV \__tenkz_kernel_cup_unmath:w
+          \l__tenkz_kernel_cupbead_tl \q_stop
+      }
+  }
 \cs_new_protected:Npn \__tenkz_kernel_cup_bead:nn #1#2
   {
     \prop_get:NnN \l__tenkz_kernel_policy_prop {cup-#1}
       \l__tenkz_kernel_cupbead_tl
     \quark_if_no_value:NF \l__tenkz_kernel_cupbead_tl
       {
-        % A positional label argument is mathematics and the atom slot opens
-        % math around it; a KEY value is typeset as the author wrote it, and
-        % the documented spelling of this one carries its own delimiters.
-        % The box keeps the author's copy inside the slot's math.
-        \tl_set:Ne \l__tenkz_kernel_cupbead_tl
-          {
-            \exp_not:N \mbox
-              { \exp_not:V \l__tenkz_kernel_cupbead_tl }
-          }
+        \__tenkz_kernel_cup_unmath:
         \__tenkz_model_record_atom:n { kind = tn , skin = ring }
         \__tenkz_model_complete_raw:nnV { \l__tenkz_model_last_tl } {label}
           \l__tenkz_kernel_cupbead_tl
@@ -3034,72 +3045,78 @@
   }
 \cs_generate_variant:Nn \__tenkz_kernel_cup_bead:nn { nV }
 
+% The name a bend takes: `cup-<i>-<i+1>` for a row pair, `cup-col-<i>-<i+1>`
+% for a column pair, qualified by the side it leaves from when the opposite
+% side bends too, so two arcs over the same pair stay separately addressable.
+\cs_new_protected:Npn \__tenkz_kernel_cup_name:nnnN #1#2#3#4
+  {
+    \str_case:nn {#1}
+      {
+        {west}  { \tl_set:Nn \l__tenkz_kernel_cupother_tl {east}  }
+        {east}  { \tl_set:Nn \l__tenkz_kernel_cupother_tl {west}  }
+        {north} { \tl_set:Nn \l__tenkz_kernel_cupother_tl {south} }
+        {south} { \tl_set:Nn \l__tenkz_kernel_cupother_tl {north} }
+      }
+    \prop_get:NVN \l__tenkz_kernel_policy_prop \l__tenkz_kernel_cupother_tl
+      \l__tenkz_kernel_cuppol_tl
+    \str_if_eq:VnTF \l__tenkz_kernel_cuppol_tl {cup}
+      { \tl_set:Ne #4 { cup-#1-#2#3-\int_eval:n {#3 + 1} } }
+      { \tl_set:Ne #4 { cup-#2#3-\int_eval:n {#3 + 1} } }
+  }
 \cs_new_protected:Npn \__tenkz_kernel_row_cups:n #1
   {
     \int_step_inline:nnnn {1}{2}{\__tenkz_kernel_rows: - 1}
       {
-        \tl_set:Ne \l_tmpa_tl
-          {cup-##1-\int_eval:n {##1 + 1}}
-        \str_case:nn {#1}
-          {
-            {west}
-              {
-                \prop_get:NnN \l__tenkz_kernel_policy_prop {east} \l_tmpb_tl
-                \str_if_eq:VnT \l_tmpb_tl {cup}
-                  {
-                    \tl_set:Ne \l_tmpa_tl
-                      {cup-west-##1-\int_eval:n {##1 + 1}}
-                  }
-              }
-            {east}
-              {
-                \prop_get:NnN \l__tenkz_kernel_policy_prop {west} \l_tmpb_tl
-                \str_if_eq:VnT \l_tmpb_tl {cup}
-                  {
-                    \tl_set:Ne \l_tmpa_tl
-                      {cup-east-##1-\int_eval:n {##1 + 1}}
-                  }
-              }
-          }
+        \__tenkz_kernel_cup_name:nnnN {#1}{}{##1} \l__tenkz_kernel_cupname_tl
         \__tenkz_kernel_closure_wire:nnnn
           {cup}{#1}
           {top = ##1 , bottom = \int_eval:n {##1 + 1}}
-          {\tl_use:N \l_tmpa_tl}
-        \__tenkz_kernel_cup_bead:nV {#1} \l_tmpa_tl
+          {\tl_use:N \l__tenkz_kernel_cupname_tl}
       }
   }
 \cs_new_protected:Npn \__tenkz_kernel_col_cups:n #1
   {
     \int_step_inline:nnnn {1}{2}{\__tenkz_kernel_cols: - 1}
       {
-        \tl_set:Ne \l_tmpa_tl
-          {cup-col-##1-\int_eval:n {##1 + 1}}
-        \str_case:nn {#1}
-          {
-            {north}
-              {
-                \prop_get:NnN \l__tenkz_kernel_policy_prop {south} \l_tmpb_tl
-                \str_if_eq:VnT \l_tmpb_tl {cup}
-                  {
-                    \tl_set:Ne \l_tmpa_tl
-                      {cup-north-col-##1-\int_eval:n {##1 + 1}}
-                  }
-              }
-            {south}
-              {
-                \prop_get:NnN \l__tenkz_kernel_policy_prop {north} \l_tmpb_tl
-                \str_if_eq:VnT \l_tmpb_tl {cup}
-                  {
-                    \tl_set:Ne \l_tmpa_tl
-                      {cup-south-col-##1-\int_eval:n {##1 + 1}}
-                  }
-              }
-          }
+        \__tenkz_kernel_cup_name:nnnN {#1}{col-}{##1} \l__tenkz_kernel_cupname_tl
         \__tenkz_kernel_closure_wire:nnnn
           {cup}{#1}
           {left = ##1 , right = \int_eval:n {##1 + 1}}
-          {\tl_use:N \l_tmpa_tl}
-        \__tenkz_kernel_cup_bead:nV {#1} \l_tmpa_tl
+          {\tl_use:N \l__tenkz_kernel_cupname_tl}
+      }
+  }
+% A labelled side's bead is the body atom of the documented expansion, so it
+% is minted where an author would have written it: after the body, before the
+% derived wires.  Minting it beside its bend instead would number it after
+% the grid bonds, and the sugar would record a different stream from the
+% spelling it stands for.
+\cs_new_protected:Npn \__tenkz_kernel_side_cup_beads:nnn #1#2#3
+  {
+    \int_step_inline:nnnn {1}{2}{#3 - 1}
+      {
+        \__tenkz_kernel_cup_name:nnnN {#1}{#2}{##1} \l__tenkz_kernel_cupname_tl
+        \__tenkz_kernel_cup_bead:nV {#1} \l__tenkz_kernel_cupname_tl
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_cup_beads:
+  {
+    \clist_map_inline:nn {west,east}
+      {
+        \prop_get:NnN \l__tenkz_kernel_policy_prop {##1} \l_tmpa_tl
+        \str_if_eq:VnT \l_tmpa_tl {cup}
+          {
+            \__tenkz_kernel_side_cup_beads:nnn {##1}{}
+              { \__tenkz_kernel_rows: }
+          }
+      }
+    \clist_map_inline:nn {north,south}
+      {
+        \prop_get:NnN \l__tenkz_kernel_policy_prop {##1} \l_tmpa_tl
+        \str_if_eq:VnT \l_tmpa_tl {cup}
+          {
+            \__tenkz_kernel_side_cup_beads:nnn {##1}{col-}
+              { \__tenkz_kernel_cols: }
+          }
       }
   }
 
@@ -15212,6 +15229,7 @@
 \cs_new_protected:Npn \__tenkz_kernel_end:
   {
     \__tenkz_kernel_basis_policy_validate:
+    \__tenkz_kernel_cup_beads:
     \__tenkz_kernel_populate:
     \__tenkz_kernel_skin_pairings:
     \__tenkz_kernel_prepare_cell_policies:


### PR DESCRIPTION
## Reproduction

One picture, two spellings, rendered at 200 dpi: the `ch14_correlations.tex`
correlator with `west={cup=$Y$}, east={cup=$X\rho^R$}` against the explicit
expansion LANGUAGE-1.0 §9 gives for it. Before this change the sugar drew
289x147 against the expansion's 283x147, `compare -metric AE` 1780, and the
record streams already differed:

```
< atom|id=atom-9|kind=tn|label=\mbox {$Y$}|node=addr-14|skin=ring
< atom|id=atom-11|kind=tn|label=\mbox {$X\rho ^R$}|node=addr-15|skin=ring
---
> atom|id=atom-2|kind=tn|label=Y|node=addr-2|skin=ring
> atom|id=atom-3|kind=tn|label=X\rho ^R|node=addr-3|skin=ring
```

So the divergence was not typesetting-time only: the sugar minted a different
bead, and the pixels followed.

## Cause

Two seams, both in how the sugar mints that bead. The label reached the atom
wrapped in `\mbox`, because the documented value carries its own `$…$` while
the atom slot opens math around a label of its own accord; a box holds text
style inside a script-style label, so the label drew larger than the body it
stands for, and the whole five pixels sat in the east cup whose label carries
a superscript. And the bead was minted beside its bend, at closure, which
numbered it after the grid bonds, while the expansion declares it in the body.

The fix peels the author's delimiters, so the matrix reaches the label exactly
as a `\tn` body does, and mints the bead where an author would have written
it: after the body, before the derived wires. The cup naming rule, which the
bead pass and the wire pass both need, is now one function instead of the two
copies it had. LANGUAGE-1.0 §9's row is unchanged and is now literally true;
the general atom-label shift contract stays open as LionSR/tenkz#158.

## Probe

`s10_sugar.tex` / `s10_kernel.tex` join the sugar-expansion pair set, written
like the existing nine: the labelled cup against `west=cup, east=cup` plus two
`\tn[skin=ring, at=on cup-<side>-1-2 0.5]` beads, with a superscript in the
east label. The count in `scripts/tenkz_kernel_probes.sh` rises to 10.

`ch14_correlations.tex` returns to the sugar spelling. Rendered against main's
explicit spelling under main's kernel: 283x147 both, `compare -metric AE` 0 —
the drawing is unchanged.

## Validation

```
bash scripts/tenkz_kernel_probes.sh
  PASS: 117 review regressions hold
  PASS: 10 sugar spellings byte-identical to their expansions
  PASS: 12 kernel record streams byte-identical
  PASS: kernel pixels byte-identical
python3 scripts/test_tenkz_kernel_audit.py
  tenkz-kernel-audit: parser, crossings, boundaries, and geometry passed
python3 scripts/tenkz_rmp.py check --section section-ii
  PASS: validated, compiled, linted, and audited 48 RMP target(s)
  Verdicts: unreviewed 0 | faithful 90 | cosmetic-gap 40 | structural-gap 0 |
    unfaithful 0 | blocked 0
python3 scripts/check_tenkz_dispositions.py
  PASS: 207 blueprint occurrences and 264 standalone fixtures reconcile exactly
python3 scripts/test_tenkz_pic.py
  all tenkz pipeline checks passed
TENKZ_CORPUS_JOBS=8 scripts/tenkz_golden.sh --check
  PASS: 264 event streams byte-identical to the golden baseline
python3 scripts/tenkz_manual_doctest.py
  PASS: 10 displayed manual examples and 25 reference examples
python3 scripts/test_tenkz_language.py
  PASS: registry, typed atom diagnostic, and alias event equivalence
python3 scripts/check_tenkz_policy.py
  PASS: tenkz compatibility policy valid; evidence not-started (0 entries)
xelatex docs/tenkz/manual2.tex
  20 pages, no errors
python3 scripts/tenkz_shrink.py gate --base-ref origin/main
  tenkz-shrink: PASS: census stable at 201 and all 148 flag(s) carry verdicts
```

No meter moved, so SHRINK.md and `tests/tenkz/census-baseline.json` are
untouched. The legacy grid path draws a labelled cup's matrix beside the bend
from its own wire record and never wrapped the value, which is why the corpus
event streams stay byte-identical.

Closes LionSR/tenkz#167
