### PR TITLE
fix(tenkz): index the property stores that grow with the picture

### DIFF
--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -497,6 +497,12 @@ These mistakes have shipped bugs here.
 8. Expand integer registers explicitly in `\iow` event writes.
 9. Picture IDs nest: the global UID and group-local current ID have different
    ownership.  An inline `\tnpic` must not clobber its parent.
+10. `\prop_new:N` builds a flat store: `\prop_get`, `\prop_if_in` and
+    `\prop_item` all compare the wanted key against every other key, so a
+    store the picture fills costs the square of its size to read.  Declare
+    such a store with `\__tenkz_prop_new_indexed:N`, which answers a key in
+    one step.  A pair-keyed store — one entry per pair of routes — is the
+    worst case and must never be flat.
 
 ## Geometry discipline
 

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -40,7 +40,7 @@
 % for kind=affine, or fields n (stations), r (radius), start (degrees) for
 % kind=circle.  A projected plane additionally owns one page-space transverse
 % vector.  Frames are picture-local.
-\prop_new:N \l__tenkz_geom_frame_prop     % "name/field" -> fp literal
+\__tenkz_prop_new_indexed:N \l__tenkz_geom_frame_prop     % "name/field" -> fp literal
 \prop_new:N \l__tenkz_geom_framekind_prop % "name" -> affine | circle
 \fp_const:Nn \c__tenkz_geom_plane_transverse_x_fp {0}
 \fp_const:Nn \c__tenkz_geom_plane_transverse_y_fp {1}
@@ -916,10 +916,10 @@
 % ---------- the placement graph ---------------------------------------------
 % A request is stored unresolved and evaluated on demand; evaluation walks
 % dependencies depth-first, marks the path, and a revisit names the cycle.
-\prop_new:N \l__tenkz_geom_req_prop    % id -> {type}{arg}{arg}{arg}
-\prop_new:N \l__tenkz_geom_x_prop      % id -> fp literal (pitch units)
-\prop_new:N \l__tenkz_geom_y_prop
-\prop_new:N \l__tenkz_geom_state_prop  % id -> visiting
+\__tenkz_prop_new_indexed:N \l__tenkz_geom_req_prop    % id -> {type}{arg}{arg}{arg}
+\__tenkz_prop_new_indexed:N \l__tenkz_geom_x_prop      % id -> fp literal (pitch units)
+\__tenkz_prop_new_indexed:N \l__tenkz_geom_y_prop
+\__tenkz_prop_new_indexed:N \l__tenkz_geom_state_prop  % id -> visiting
 \seq_new:N  \l__tenkz_geom_trail_seq
 \tl_new:N \l__tenkz_geom_xa_tl \tl_new:N \l__tenkz_geom_ya_tl
 \bool_new:N \l__tenkz_geom_ok_bool

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -192,8 +192,8 @@
 \int_new:N  \l__tenkz_kernel_col_int
 \int_new:N  \l__tenkz_kernel_row_advance_int  % maximum implicit span on current row
 \int_new:N  \l__tenkz_kernel_node_int         % address node serial
-\prop_new:N \l__tenkz_kernel_node_prop        % "id/field" -> value
-\prop_new:N \l__tenkz_kernel_named_prop       % user name -> record id
+\__tenkz_prop_new_indexed:N \l__tenkz_kernel_node_prop        % "id/field" -> value
+\__tenkz_prop_new_indexed:N \l__tenkz_kernel_named_prop       % user name -> record id
 % Atoms whose labels need the silhouette / pairing / label render split.
 \prop_new:N \l__tenkz_kernel_skin_pairing_host_prop
 \prop_new:N \l__tenkz_kernel_skin_pairing_cross_prop
@@ -1471,6 +1471,7 @@
         \bool_if:NT \l__tenkz_kernel_ineq_bool
           { |scope=\int_use:N \g__tenkz_kernel_eq_scope_int }
       }
+    \__tenkz_kernel_emit_index:
     \clist_map_inline:nn { atom, wire, mark, frame }
       {
         \__tenkz_model_map_ids:nn {##1}
@@ -1483,23 +1484,36 @@
         |signature=\tl_use:N \l__tenkz_kernel_sig_tl
       }
   }
+% The record store is one flat table keyed "id/field", while the stream is
+% written one record at a time.  Asking the whole table for each record's
+% fields reads every field of the picture once per record.  One pass files
+% each field under the record that owns it, and a record reads only its own.
+\__tenkz_prop_new_indexed:N \l__tenkz_kernel_emit_field_prop
+\tl_new:N \l__tenkz_kernel_emit_field_tl
+\cs_new_protected:Npn \__tenkz_kernel_emit_index:
+  {
+    \prop_clear:N \l__tenkz_kernel_emit_field_prop
+    \prop_map_inline:Nn \l__tenkz_model_record_prop
+      { \__tenkz_kernel_emit_index_entry:wn ##1 \q_stop {##2} }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_emit_index_entry:wn #1 / #2 \q_stop #3
+  {
+    \prop_get:NnNF \l__tenkz_kernel_emit_field_prop {#1}
+      \l__tenkz_kernel_emit_field_tl
+      { \tl_clear:N \l__tenkz_kernel_emit_field_tl }
+    \tl_put_right:Ne \l__tenkz_kernel_emit_field_tl
+      { { \tl_to_str:n {#2} = \tl_to_str:n {#3} } }
+    \prop_put:NnV \l__tenkz_kernel_emit_field_prop {#1}
+      \l__tenkz_kernel_emit_field_tl
+  }
 \cs_new_protected:Npn \__tenkz_kernel_emit_record:n #1
   {
     \seq_clear:N \l__tenkz_kernel_emit_seq
-    \prop_map_inline:Nn \l__tenkz_model_record_prop
+    \prop_get:NnNT \l__tenkz_kernel_emit_field_prop {#1}
+      \l__tenkz_kernel_emit_field_tl
       {
-        \str_if_eq:eeT
-          { \str_range:nnn {##1} {1} { \str_count:n { #1 / } } }
-          { #1 / }
-          {
-            \seq_put_right:Ne \l__tenkz_kernel_emit_seq
-              {
-                \str_range:nnn {##1}
-                  { \int_eval:n { \str_count:n { #1 / } + 1 } }
-                  { \str_count:n {##1} }
-                = \tl_to_str:n {##2}
-              }
-          }
+        \tl_map_inline:Nn \l__tenkz_kernel_emit_field_tl
+          { \seq_put_right:Nn \l__tenkz_kernel_emit_seq {##1} }
       }
     \seq_sort:Nn \l__tenkz_kernel_emit_seq
       {

--- a/tex/tenkz/tenkz-model.code.tex
+++ b/tex/tenkz/tenkz-model.code.tex
@@ -17,8 +17,8 @@
 \seq_new:N \l__tenkz_model_mark_seq
 \seq_new:N \l__tenkz_model_frame_seq
 \seq_new:N \l__tenkz_model_record_seq
-\prop_new:N \l__tenkz_model_record_prop   % "id/field" -> normalized value
-\prop_new:N \l__tenkz_model_class_prop    % "id" -> class word
+\__tenkz_prop_new_indexed:N \l__tenkz_model_record_prop   % "id/field" -> normalized value
+\__tenkz_prop_new_indexed:N \l__tenkz_model_class_prop    % "id" -> class word
 \prop_new:N \l__tenkz_model_picture_prop  % picture-level fields
 \int_new:N  \l__tenkz_model_next_int
 \bool_new:N \l__tenkz_model_validated_bool

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -70,15 +70,15 @@
 
 % ---------- state ------------------------------------------------------------
 \seq_new:N \l__tenkz_string_ids_seq          % declaration order
-\prop_new:N \l__tenkz_string_kind_prop       % id -> open|closed|wind|around
+\__tenkz_prop_new_indexed:N \l__tenkz_string_kind_prop       % id -> open|closed|wind|around
 \prop_new:N \l__tenkz_string_source_prop     % id -> caller|generated
 \seq_new:N \l__tenkz_string_cross_seq        % {under}{over} pairs
-\prop_new:N \l__tenkz_string_cross_prop      % unordered pair -> declarations
-\prop_new:N \l__tenkz_string_join_prop       % unordered pair -> endpoint joins
-\prop_new:N \l__tenkz_string_touch_prop      % shared semantic wire ports
-\prop_new:N \l__tenkz_string_touch_all_prop  % topology-owned overlap route
-\prop_new:N \l__tenkz_string_touch_all_exempt_prop % route still checked
-\prop_new:N \l__tenkz_string_disjoint_prop   % model-proven disjoint pairs
+\__tenkz_prop_new_indexed:N \l__tenkz_string_cross_prop      % unordered pair -> declarations
+\__tenkz_prop_new_indexed:N \l__tenkz_string_join_prop       % unordered pair -> endpoint joins
+\__tenkz_prop_new_indexed:N \l__tenkz_string_touch_prop      % shared semantic wire ports
+\__tenkz_prop_new_indexed:N \l__tenkz_string_touch_all_prop  % topology-owned overlap route
+\__tenkz_prop_new_indexed:N \l__tenkz_string_touch_all_exempt_prop % route still checked
+\__tenkz_prop_new_indexed:N \l__tenkz_string_disjoint_prop   % model-proven disjoint pairs
 \seq_new:N \l__tenkz_string_gap_ids_seq      % under paths awaiting one gap pass
 \seq_new:N \l__tenkz_string_self_gap_ids_seq % self paths awaiting branch gap
 \seq_new:N \l__tenkz_string_processed_seq    % directed crossing pairs split

--- a/tex/tenkz/tenkz.sty
+++ b/tex/tenkz/tenkz.sty
@@ -1,6 +1,6 @@
 % Input: public tenkz syntax and the package's staged implementation files.
 % Output: picture environments, composition wrappers, and setup declarations.
-% Owned state: none; this file is a logic-free dependency and stage load map.
+% Owned state: none; this file is the dependency probe and stage load map.
 % Invariants: language loads before model, shared services, and dialect renderers.
 % Next stage: tenkz-language.code.tex validates and registers public syntax.
 %
@@ -17,6 +17,17 @@
 \RequirePackage{tikz-cd}
 \usetikzlibrary{calc,arrows.meta,backgrounds,decorations.pathreplacing,
   decorations.markings,fit,shapes.geometric,hobby,spath3,intersections}
+
+% A store whose key count grows with the picture is declared through this
+% door.  expl3's default property list is a flat token list, so every lookup
+% compares the wanted key against all the others: a picture with n keys pays
+% n^2 to read itself.  The indexed representation answers a key in one step.
+% Where it is absent the flat store still answers correctly, only slowly.
+\ExplSyntaxOn
+\cs_if_exist:NTF \prop_new_linked:N
+  { \cs_new_eq:NN \__tenkz_prop_new_indexed:N \prop_new_linked:N }
+  { \cs_new_eq:NN \__tenkz_prop_new_indexed:N \prop_new:N }
+\ExplSyntaxOff
 
 \input{tenkz-language.code.tex}
 \input{tenkz-model.code.tex}


### PR DESCRIPTION
## Which case it turned out to be

The kernel. The two GHZ targets are not unusually large; they were paying a
quadratic fold, and so was every other picture in proportion to its size.

## The measurement

Same machine (10 cores, XeTeX 0.999997 / TeX Live 2025), one case at a time on
an idle machine, `origin/main`:

| target | before | after |
|---|---|---|
| `rmp-iii-a-ghz-state` | 53.5 s | 7.3 s |
| `rmp-workbench-iii-ghz-state-workbench` | 52.9 s | — (same figure) |
| `rmp-iii-a-torus-three` (largest source in the section) | 16.4 s | — |

Cost against picture size, on a synthetic copy of the GHZ lattice with the
same declarations at r rows by 8 columns:

| rows | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| seconds | 2.16 | 4.90 | 10.38 | 20.70 | 39.75 | 63.53 |

Doubling per added row while the member count rises by a fixed eight: about
`n^2.5` in the members. That is not the honest cost of a bigger picture.

Instrumenting the kernel's stage entry points with `\elapsedtime`, at 6x8
(62.0 s total):

| stage | before | after |
|---|---|---|
| string crossing police, 8385 route pairs | 49.3 s | 0.21 s |
| record-stream emitter, 240 records | 5.4 s | 0.18 s |
| everything else | ~7 s | ~7 s |
| **total** | **62.0 s** | **7.2 s** |

`\__tenkz_string_count:nnN` was never called — no PGF intersection was
computed at all. The whole 49.3 s was `\prop_if_in:` on the disjoint-pair
store.

## Why

`\prop_new:N` builds expl3's flat property list, where `\prop_get`,
`\prop_if_in`, `\prop_item` and `\prop_put` all compare the wanted key
against every stored key. `\__tenkz_string_police_pair:nn` asks
`\l__tenkz_string_disjoint_prop` whether a pair is already known disjoint —
once per pair — and that store holds one entry per disjoint pair. P routes
therefore cost P^2 lookups into a store of P^2 entries.

The bounding-box broad phase in `\__tenkz_kernel_r_port_box_compare:nnnnn`
that fills the store was already correct: the pairs are rejected cheaply and
geometrically, exactly as they should be. Only the store's representation was
wrong.

The record emitter had the same shape one order lower: it read the whole
`id/field` table once per record to find that record's fields.

## The fix

`\__tenkz_prop_new_indexed:N` in `tenkz.sty` — expl3's linked representation
where it exists, the flat one otherwise, so an older expl3 still answers
correctly, only slowly. The stores whose key count grows with the picture are
declared through it: model records and classes, the geometry placement graph
and frames, the kernel node and name tables, and the string kind, cross, join,
touch and disjoint tables. Stores of fixed size (species, skins, document
setup) stay flat.

`\__tenkz_kernel_emit_index:` files each field under its record in one pass,
and a record reads only its own.

I did not touch the runner's 120-second cap. The cap was never the problem
here: the heaviest case now finishes in 7 seconds, and the diagnosis the issue
asked for came back "kernel", not "budget".

## Validation

- `check --section section-iii-a`: **PASS, 54 targets, 80 s wall** (the acceptance)
- `check --section section-ii`: PASS, 48 targets, 59 s wall
- `check --section section-iii-b`: PASS, 11 targets, 19 s wall
- `tenkz_kernel_probes.sh`: 118 regressions hold, 10 sugar spellings
  byte-identical, 12 kernel record streams byte-identical, kernel pixels
  byte-identical
- `tenkz_golden.sh --check`: 264 event streams byte-identical
- `test_tenkz_corpus_provenance.py`, `test_tenkz_shrink.py`: PASS
- `tenkz_shrink.py gate --base-ref origin/main`: census stable at 201; no
  meter moved, so no SHRINK.md session entry

`rmp-iii-a-ghz-state`'s `.tnlog` and PDF are byte-identical before and after.

Closes LionSR/tenkz#163
