### PR TITLE
feat(tenkz): let a label stand on a generated open leg

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft.tex
+++ b/blueprint/src/chapter/ch24_peps_ft.tex
@@ -43,41 +43,34 @@ the five-vertex example graph this is
 % Formula: c_A(sigma)=sum_eta prod_{i=1}^5 A_i(eta_i,sigma_i), for the
 % source graph with cycle 1--2--3--4--5--1 and chord 2--5.
 % Ink-to-index: the six thin joins are precisely the six summed virtual edge
-% indices, while the five north legs are sigma_1,...,sigma_5.
+% indices, while the five outward legs are sigma_1,...,sigma_5.
 % Contraction and boundary signature: every virtual index is contracted and
 % the five physical indices remain visible, hence (V,P)=(0,5); fixing their
 % labels evaluates the displayed coefficient.
 % Source verdict: exact graph and contraction of
 % Papers/1804.04964/paper_normal.tex:961--979, redrawn in house notation.
 \begin{center}
-    \begin{tenkzfree}
-        \tnput[ports={0:virtual,110:virtual,north:physical}]
-            {stateAone}{(-10mm,-5mm)}{A_1}
-        \tnput[ports={180:virtual,55:virtual,141:virtual,north:physical}]
-            {stateAtwo}{(8mm,-5mm)}{A_2}
-        \tnput[ports={235:virtual,155:virtual,north:physical}]
-            {stateAthree}{(16mm,6mm)}{A_3}
-        \tnput[ports={-25:virtual,190:virtual,north:physical}]
-            {stateAfour}{(4mm,15mm)}{A_4}
-        \tnput[ports={10:virtual,-70:virtual,-39:virtual,north:physical}]
-            {stateAfive}{(-10mm,10mm)}{A_5}
-        \tnput[boundary, ports={south:physical}]{statePone}{(-10mm,3mm)}{}
-        \tnput[boundary, ports={south:physical}]{statePtwo}{(8mm,3mm)}{}
-        \tnput[boundary, ports={south:physical}]{statePthree}{(16mm,14mm)}{}
-        \tnput[boundary, ports={south:physical}]{statePfour}{(4mm,23mm)}{}
-        \tnput[boundary, ports={south:physical}]{statePfive}{(-10mm,18mm)}{}
-        \tnjoin{stateAone.0}{stateAtwo.180}
-        \tnjoin{stateAtwo.55}{stateAthree.235}
-        \tnjoin{stateAthree.155}{stateAfour.-25}
-        \tnjoin{stateAfour.190}{stateAfive.10}
-        \tnjoin{stateAfive.-70}{stateAone.110}
-        \tnjoin{stateAtwo.141}{stateAfive.-39}
-        \tnjoin{stateAone.north}{statePone.south}
-        \tnjoin{stateAtwo.north}{statePtwo.south}
-        \tnjoin{stateAthree.north}{statePthree.south}
-        \tnjoin{stateAfour.north}{statePfour.south}
-        \tnjoin{stateAfive.north}{statePfive.south}
-    \end{tenkzfree}
+    \tenkzkernel
+    % The five vertices sit at the stations of a circle frame, which realizes
+    % the cycle as the ring and leaves the chord as the one extra edge.
+    \begin{tenkz}[rows={wire}, cols=5, frame=circle, bonds=none]
+        \tn[at=(1,1), name=stateAone, label pos=145,
+            ports={0:virtual, 180:virtual, 90:physical}]{A_1}
+        \tn[at=(1,2), name=stateAtwo, label pos=145,
+            ports={0:virtual, 180:virtual, -72:virtual, 90:physical}]{A_2}
+        \tn[at=(1,3), name=stateAthree, label pos=145,
+            ports={0:virtual, 180:virtual, 90:physical}]{A_3}
+        \tn[at=(1,4), name=stateAfour, label pos=145,
+            ports={0:virtual, 180:virtual, 90:physical}]{A_4}
+        \tn[at=(1,5), name=stateAfive, label pos=145,
+            ports={0:virtual, 180:virtual, 252:virtual, 90:physical}]{A_5}
+        \tnwire{stateAone.0}{stateAtwo.180}
+        \tnwire{stateAtwo.0}{stateAthree.180}
+        \tnwire{stateAthree.0}{stateAfour.180}
+        \tnwire{stateAfour.0}{stateAfive.180}
+        \tnwire{stateAfive.0}{stateAone.180}
+        \tnwire{stateAtwo.-72}{stateAfive.252}
+    \end{tenkz}
 \end{center}
 
 A PEPS is \emph{injective} when at every vertex the physical vectors
@@ -93,17 +86,14 @@ trivial kernel, $\ker A_v=\{0\}$:
 % Source verdict: exact arbitrary-degree map formulation of
 % Papers/1804.04964/paper_normal.tex:961--981, not a square-degree-four star.
 \begin{center}
-    \begin{tenkzfree}
-        \tnput[boundary, ports={east:virtual}, label pos=south]
-            {introInjectiveDomain}{(-18mm,0)}
-            {\bigotimes_{e\ni v}\C^{D_e}}
-        \tnput[box, ports={west:virtual,east:physical}]
-            {introInjectiveMap}{(0,0)}{A_v}
-        \tnput[boundary, ports={west:physical}, label pos=south]
-            {introInjectiveCodomain}{(18mm,0)}{\C^d}
-        \tnjoin{introInjectiveDomain.east}{introInjectiveMap.west}
-        \tnjoin{introInjectiveMap.east}{introInjectiveCodomain.west}
-    \end{tenkzfree}
+    \tenkzkernel
+    % The domain and the codomain name the two open ends of the map, so each
+    % is the tip label of the port whose type it belongs to.
+    \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+        \tn[at=(1,1), name=introInjectiveMap, skin=box,
+            ports={180:virtual:\bigotimes_{e\ni v}\C^{D_e},
+                   0:physical:\C^d}]{A_v}
+    \end{tenkz}
 \end{center}
 It is \emph{normal} when blocking the tensors over suitable regions makes the
 blocked tensors injective, following

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -95,7 +95,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L333, 852, 856, 862, 867 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
-| `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
+| `ch24_peps_ft.tex` | L56, 92 `tenkz` → `P-grid` | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | — | — | L83, 115, 329, 347, 365, 623, 647 `tenkzfree` → `C-species+R-free+R-record`<br>L316 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex` | L53, 60 `tenkz` → `P-grid` | — | — |
@@ -117,9 +117,9 @@ separate public-surface occurrence and therefore appears separately.
 
 | Raw construct | Occurrences |
 |---|---:|
-| `tenkz` | 118 |
+| `tenkz` | 120 |
 | `tenkzeq` | 0 |
-| `tenkzfree` | 36 |
+| `tenkzfree` | 34 |
 | `tenkzlattice` | 14 |
 | `tenkzcd` | 6 |
 | `tenkzplanes` | 0 |
@@ -129,9 +129,9 @@ separate public-surface occurrence and therefore appears separately.
 
 | Disposition | Occurrences |
 |---|---:|
-| preserve | 46 |
+| preserve | 48 |
 | codemod | 25 |
-| redraw | 136 |
+| redraw | 134 |
 | **Total** | **207** |
 
 The raw count is 174 environment openings plus 33 command occurrences,

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -554,7 +554,9 @@ cups, names are side-qualified (`cup-west-1-2`, `cup-east-1-2`) so every
 derived wire remains addressable as one named record. Generated legs take
 canonical names on the same rule and are named records like any other, which
 is why no address production is needed to reach one. Beads and labels attach
-to closures by the ordinary address grammar. A closed chain that renders open
+to closures by the ordinary address grammar. A leg has one model end and one
+free tip, so `on <leg> t` is read along the leg the picture draws, from the
+end the wire is written from to the end it is written to. A closed chain that renders open
 is impossible by construction: the closure IS a wire record, and every wire
 is drawn or errors.
 

--- a/docs/tenkz/chapters2/ch-worked.tex
+++ b/docs/tenkz/chapters2/ch-worked.tex
@@ -44,6 +44,46 @@ finite family whose members keep one hue across figures.  Labels distinguish
 objects of the same kind; color does not encode identity.  A role may change
 style, never topology.
 
+\subsection{Stand a label on an open leg}
+
+An open leg is a wire like any other and it carries a name.  A side policy
+names its legs after the side and the row or column they leave --
+\tnval{open-west-1}, \tnval{open-south-col-3} -- and an authored open end
+takes the name its \tncmd{tnwire} declares.  Address a fraction of that name
+to put a label or a bead on the leg:
+
+\begin{Verbatim}[fontsize=\small,frame=leftline]
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, west=open, east=open]
+  \tn{A} & \tn{B}
+  \tnmark[form=label, label pos=90]{on open-west-1 0.5}{$\alpha$}
+\end{tenkz}
+\end{Verbatim}
+
+The station is read along the leg the picture draws.  A leg has one end on a
+glyph and one free tip, and fraction zero is the end the wire is written
+from, so a leg written from a port to \tnval{open e} runs outward while one
+written from \tnval{open w} to a port runs inward.
+
+\subsection{Send a physical index sideways}
+
+An index type belongs to the port that carries it.  \tnkey{ports=} types each
+face on its own, so \tnval{0:physical} sends a physical index east exactly as
+\tnval{0:virtual} sends a virtual one, and a map drawn as a single atom types
+its two faces differently:
+
+\begin{Verbatim}[fontsize=\small,frame=leftline]
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=1, bonds=none]
+  \tn[at=(1,1), skin=box, ports={180:virtual:V, 0:physical:W}]{A}
+\end{tenkz}
+\end{Verbatim}
+
+\tnkey{physical=} is a picture policy, not the only source of a physical
+index: it gives every frame-cell atom one outward physical port on the
+frame's own outward face.  The two spellings stand side by side, and neither
+claims the other's face.
+
 \subsection{Keep a physical index out of a projected sheet}
 
 There are five directions at a PEPS tensor, but only four lie in the sheet.

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -208,6 +208,66 @@ awk -F'|' '
   echo "FAIL: the operator on the cup stands on the chord, not the arc" >&2
   exit 1
 }
+# A leg with a free end has one model end, so it answers along the route it
+# inks.  Each address below was refused outright before issue 5566.
+for station in 'open-west-1|t=0.5' 'open-east-1|t=0.5' 'eastleg|t=0.75'; do
+  grep -Fq "stringbead|id=$station|x=" "$WORK/r_onwire_open_leg.tnlog" || {
+    echo "FAIL: no place was answered on the open leg $station" >&2
+    exit 1
+  }
+done
+# Each station lies on the side its leg leaves by, and the station on the
+# authored east leg lies beyond the silhouette the leg springs from.
+awk -F'|' '
+  /^picture\|id=k2\|/ { pic = 2 }
+  /^glyph-geometry\|/ {
+    for (i = 1; i <= NF; i++) {
+      split($i, kv, "=")
+      if (kv[1] == "xmax" && pic == 2 && !box) box = kv[2] / 65536
+    }
+  }
+  /^stringbead\|/ {
+    id = ""; x = ""
+    for (i = 1; i <= NF; i++) {
+      split($i, kv, "=")
+      if (kv[1] == "id") id = kv[2]
+      if (kv[1] == "x") { x = kv[2]; sub(/pt$/, "", x); x += 0 }
+    }
+    if (id == "open-west-1" && x < 0) west = 1
+    if (id == "open-east-1" && x > 0) east = 1
+    if (id == "eastleg" && x > box) beyond = 1
+  }
+  END { exit !(west && east && beyond) }
+' "$WORK/r_onwire_open_leg.tnlog" || {
+  echo "FAIL: a place on an open leg did not land on the leg" >&2
+  exit 1
+}
+# The dot standing on the north physical leg is the second picture's own atom.
+[ "$(grep -c '^atom|.*|skin=dot$' "$WORK/r_onwire_open_leg.tnlog" || true)" \
+    -eq 2 ] || {
+  echo "FAIL: an atom addressed to an open leg was not placed" >&2
+  exit 1
+}
+# An index type belongs to the port, not to the frame: a side face carries a
+# physical index, and the frame's own physical policy stands beside it.
+for signature in \
+  'kernel-boundary|signature=open:w, phys:e' \
+  'kernel-boundary|signature=open:w, phys:e, phys:n, phys:n, phys:n'; do
+  grep -Fxq "$signature" "$WORK/r_port_physical_side_face.tnlog" || {
+    echo "FAIL: a side-face physical index lost its boundary entry" >&2
+    exit 1
+  }
+done
+[ "$(grep -c '|port-face=0|.*|port-type=physical$' \
+      "$WORK/r_port_physical_side_face.tnlog" || true)" -eq 3 ] || {
+  echo "FAIL: the east face did not carry a physical index in every picture" >&2
+  exit 1
+}
+grep -Fq '|port-face=0|port-label=W|port-slot=1|port-type=physical' \
+    "$WORK/r_port_physical_side_face.tnlog" || {
+  echo "FAIL: a side-face physical port lost its tip label" >&2
+  exit 1
+}
 chain_ports=$(awk '/^picture\|id=k2\|/ { exit } /^wire\|.*origin=port-open/' \
   "$WORK/r_ports_chain_placed.tnlog" | sed 's/|from=addr-[0-9]*//')
 at_ports=$(awk '/^picture\|id=k2\|/ { seen = 1 }

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -22,8 +22,8 @@ SPEC.loader.exec_module(DOCTEST)
 def main() -> int:
     manual = DOCTEST.displayed_examples()
     reference = DOCTEST.reference_examples()
-    if len(manual) != 10:
-        raise AssertionError(f"expected 10 displayed TeX examples, found {len(manual)}")
+    if len(manual) != 12:
+        raise AssertionError(f"expected 12 displayed TeX examples, found {len(manual)}")
     if len(reference) != 25:
         raise AssertionError(f"expected 25 reference examples, found {len(reference)}")
     if any(r"\begin{document}" not in example.document for example in manual):

--- a/tests/tenkz/kernel/regression/r_onwire_open_leg.tex
+++ b/tests/tenkz/kernel/regression/r_onwire_open_leg.tex
@@ -1,0 +1,27 @@
+% Regression: a place on a generated open leg is read off the leg the kernel
+% draws.  A leg with a free end has only one model end, so the arithmetic that
+% divides a run between two ends could not answer for it and the address was
+% refused outright (issue 5566).  The leg saves the route it inks like every
+% other index wire, and the address is answered along that route: a label and
+% a bead now take a station on a side-policy leg, on an authored open end, and
+% on an open physical leg alike.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+% the side policy's own legs: one leaving west, one leaving east
+\begin{tenkz}[rows={wire}, cols=2, west=open, east=open]
+  \tn{A} & \tn{B}
+  \tnmark[form=label, label pos=90]{on open-west-1 0.5}{$\alpha$}
+  \tn[skin=dot, at=on open-east-1 0.5]{}
+\end{tenkz}
+\qquad
+% an authored open end, and an open physical leg on a side face
+\begin{tenkz}[rows={wire}, cols=1, bonds=none]
+  \tn[at=(1,1), skin=box, name=X,
+    ports={180:virtual, 90:physical}]{X}
+  \tnwire[name=eastleg]{X.0}{open e}
+  \tnmark[form=label, label pos=270]{on eastleg 0.75}{$t$}
+  \tn[skin=dot, at=on port-open-2 0.5]{}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_port_physical_side_face.tex
+++ b/tests/tenkz/kernel/regression/r_port_physical_side_face.tex
@@ -1,0 +1,28 @@
+% Regression: an index type belongs to the port that carries it, not to the
+% frame.  A physical index on a side face is therefore an ordinary typed port:
+% the east face of a chained atom is physical while its west face is virtual,
+% and the frame-owned `physical=` policy keeps its own outward face beside
+% them without either claiming the other (issue 5566).  A wire joining two
+% physical ports strokes as a physical leg; joining a physical port to a
+% virtual one stays the coded type error it always was.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+% west virtual, east physical, on the last atom of a bonded chain
+\begin{tenkz}[rows={wire}, cols=3]
+  \tn[ports={180:virtual}]{A} & \tn{B} & \tn[ports={0:physical}]{C}
+\end{tenkz}
+\qquad
+% the same side-face physical index beside the frame's own physical policy
+\begin{tenkz}[rows={wire}, cols=3, physical=up]
+  \tn[ports={180:virtual}]{A} & \tn{B} & \tn[ports={0:physical}]{C}
+\end{tenkz}
+\qquad
+% the map picture: a physical index carried east, a virtual one carried west,
+% each naming the space it leaves for
+\begin{tenkz}[rows={wire}, cols=1, bonds=none]
+  \tn[at=(1,1), skin=box, name=map,
+    ports={180:virtual:V, 0:physical:W}]{A}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -6266,12 +6266,26 @@
                 % An index wire saves the path it inks under its own id, so a
                 % generated cup or a trace closure answers along the arc the
                 % reader sees rather than along the chord between its ends.
+                % A leg with a free end has no second model end to divide, and
+                % answers along its route for the same reason.
+                \__tenkz_model_get:nnN
+                  { \tl_use:N \l__tenkz_kernel_ow_a_tl } {from}
+                  \l__tenkz_kernel_ow_b_tl
+                \__tenkz_model_get:nnN
+                  { \tl_use:N \l__tenkz_kernel_ow_a_tl } {to}
+                  \l__tenkz_kernel_ow_c_tl
                 \__tenkz_kernel_r_sid:nN
                   { \tl_use:N \l__tenkz_kernel_ow_a_tl }
                   \l__tenkz_kernel_ow_sid_tl
-                \__tenkz_string_bends:VTF \l__tenkz_kernel_ow_sid_tl
-                  { \__tenkz_kernel_r_onwire_curve:n {#1} }
-                  { \__tenkz_kernel_r_onwire_run:n {#1} }
+                \bool_lazy_and:nnTF
+                  { ! \quark_if_no_value_p:N \l__tenkz_kernel_ow_b_tl }
+                  { ! \quark_if_no_value_p:N \l__tenkz_kernel_ow_c_tl }
+                  {
+                    \__tenkz_string_bends:VTF \l__tenkz_kernel_ow_sid_tl
+                      { \__tenkz_kernel_r_onwire_route:n {#1} }
+                      { \__tenkz_kernel_r_onwire_run:n {#1} }
+                  }
+                  { \__tenkz_kernel_r_onwire_route:n {#1} }
               }
           }
       }
@@ -6304,6 +6318,19 @@
       \l__tenkz_kernel_ow_t_tl
     \seq_pop_right:NN \l__tenkz_kernel_ow_run_stack_seq
       \l__tenkz_kernel_ow_a_tl
+  }
+% The point of a wire that its two model ends do not divide: a bending route,
+% or a leg one of whose ends is a free tip the renderer chose.  Both are read
+% off the route the wire inked.  A wire that inked no route at all keeps the
+% engine's own diagnostic, which names the address the author wrote.
+\cs_new_protected:Npn \__tenkz_kernel_r_onwire_route:n #1
+  {
+    \__tenkz_string_inked:VTF \l__tenkz_kernel_ow_sid_tl
+      { \__tenkz_kernel_r_onwire_curve:n {#1} }
+      {
+        \msg_error:nnee {tenkz}{kernel-render-todo}
+          { \__tenkz_kernel_r_item:nn {#1} {text} } {#1}
+      }
   }
 % the arclength point of a curve, converted once at the coordinate boundary
 \cs_new_protected:Npn \__tenkz_kernel_r_onwire_curve:n #1

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -1357,6 +1357,16 @@
   }
 \prg_generate_conditional_variant:Nnn \__tenkz_string_bends:n {V} {T,F,TF}
 
+% Whether a route was ever saved under #1.  A caller that means to measure a
+% route asks this first, so an id that names no ink is refused by the caller's
+% own diagnostic rather than by the bead's.
+\prg_new_protected_conditional:Npnn \__tenkz_string_inked:n #1 {T,F,TF}
+  {
+    \prop_if_in:NnTF \l__tenkz_string_kind_prop {#1}
+      { \prg_return_true: } { \prg_return_false: }
+  }
+\prg_generate_conditional_variant:Nnn \__tenkz_string_inked:n {V} {T,F,TF}
+
 % The point at arclength fraction #2 along string #1, exposed as TikZ
 % coordinate #3 and reported as an event.  PGF's markings decoration advances
 % by actual path distance, unlike spath's segment-count coordinate system.


### PR DESCRIPTION
A leg has one model end and one free tip the renderer chooses. The on-wire
arithmetic divides a run between two model ends, so it could not answer for a
leg at all: `on open-west-1 0.5`, `on eastleg 0.75` on a wire written to
`open e`, and every other address on an open end were refused with
`[TKZ-KERNEL-RENDER-TODO]`. A leg saves the route it inks like every other
index wire, so the route was there to be asked.

## What changed

**`tenkz-kernel.code.tex`** — the on-wire dispatch now states the doctrine the
comment above it already carried. A wire that runs straight between two model
ends divides that run; everything else — a bending closure, or a leg whose
second end is a free tip — is read along the route it inked. The two branches
meet in `\__tenkz_kernel_r_onwire_route:n`, which measures the saved route and,
when a wire inked none, keeps the engine's own diagnostic naming the address the
author wrote rather than letting the bead fail on an unknown id.

**`tenkz-string.code.tex`** — `\__tenkz_string_inked:nTF` reports whether a route
was ever saved under an id, the question the new branch has to put before it
measures. It is the sibling of `\__tenkz_string_bends:nTF` and reads the same
store.

No address production was added. A generated leg already carries a canonical
name — `open-west-1`, `open-east-1`, `open-south-col-3`, `open-physical-1`,
`port-open-2` — exactly as `LANGUAGE-1.0.md` §5 says it does; what it lacked was
an answer, not an address. §5 now records how the answer is read, and the manual
gains the recipe.

## The physical-index decision

**An atom carries a physical index on a side face. The type is a property of the
port.** The issue's second half does not reproduce: `ports={0:physical}` is
already legal on a chained atom, on an `at=`-placed atom, and beside the
frame-owned `physical=` policy, and it types the port without either claiming the
other's face.

Evidence, all three pictures from
`tests/tenkz/kernel/regression/r_port_physical_side_face.tex`:

| picture | records |
|---|---|
| `cols=3`, east face physical | `kernel-boundary\|signature=open:w, phys:e` |
| the same beside `physical=up` | `kernel-boundary\|signature=open:w, phys:e, phys:n, phys:n, phys:n` |
| one box atom, both faces typed | `port-face=0\|port-label=W\|port-type=physical` |

Rendered at 900 dpi: the east stub inks visibly heavier than the west one, so
the typing reads off the page and not only out of the stream. `TKZ-PORT-TYPE`
still fires where it should — a wire joining a virtual port to a physical one is
the coded error the negative fixtures already pin.

The contract supports this reading. §4 already distinguishes the two statements
in as many words: "`physical=up` leaves a site along that third axis, whereas
`ports={90:physical}` still means the in-plane north face. The two statements are
deliberately different." `physical=` is a bulk policy over frame cells; a typed
port is the per-face statement. The manual now says both, in a new recipe beside
the plane recipe that says where `physical=` belongs.

## Regressions

- `r_onwire_open_leg.tex` — a label on the side policy's west leg, a bead on its
  east leg, a label on an authored `open e` end, and a bead on an open physical
  leg. Each address was refused before this change. The probe asserts all three
  stations exist, that the west station lies west of the frame and the east one
  east of it, and that the station on the authored leg lies beyond the silhouette
  the leg springs from.
- `r_port_physical_side_face.tex` — the three pictures above.

Both compiled standalone and looked at at 250–900 dpi.

## Consumer verdicts

`blueprint/src/chapter/ch24_peps_ft.tex` L53 and L96 both migrate; the file's
`tenkzfree` occurrences are gone.

**L53, the five-vertex state graph — migrated.** It does not need absolute
placement. The figure's own comment names the graph: "cycle 1--2--3--4--5--1 and
chord 2--5", and the millimetre coordinates draw a pentagon with the 2--5
diagonal. A circle frame gives the pentagon its stations, so the ring is the
cycle and the chord is the one extra `\tnwire`; each vertex keeps its physical
index as an outward `90:physical` port. Rendered before and after at 200 dpi side
by side: same six virtual edges, same five open physical legs, same triangle
closed by the chord on vertices 1, 2 and 5. The legs run outward on the radius
rather than north, which is what a circle frame's own axes mean; the
ink-to-index comment now says "outward legs" where it said "north legs".

**L96, the injectivity map — migrated.** One box atom whose west face is virtual
and whose east face is physical, each port carrying the space it leaves for as
its tip label. Rendered before and after at 200 dpi: the 0.7 figure inked both
wires at the same weight and dropped the two space labels below the line; the
kernel figure inks the physical leg heavier than the virtual one and sets each
label inline at its own tip. The port typing the issue reported lost is in the
stream: `signature=open:w, phys:e`.

`docs/tenkz/DISPOSITIONS.md` moves both occurrences from redraw to preserve
(L56, L92 `tenkz` → `P-grid`); the blueprint reconciliation reads 120 `tenkz`,
34 `tenkzfree`, preserve 48, redraw 134, total unchanged at 207.

## What is left

A `physical=` policy leg still owns no wire record: the policy writes a field on
each atom and the leg pass inks the leg under the path id `leg-n-1-1`, which is
not a name, so `on leg-n-1-1 0.5` fails with `[TKZ-KERNEL-RENDER-ONWIRE]`. The
per-atom spelling `ports={90:physical:$\sigma$}` reaches the same leg with a
label and an address, so the capability exists; the bulk policy has no
equivalent. Making the policy leg a record adds one wire event per site to every
`physical=` picture and moves every golden stream, which does not belong in this
change. Filed as LionSR/tenkz#174.

`leg <face> of <cell>` stays what it is: a wire operand for `crossing of`, which
`rmp-iii-b-braid-one` uses, and a tombstone as a place. §14.3 of the contract
reversed the production on 2026-07-25 on the grounds that a generated leg is a
named record and no production is needed to reach one — which this change makes
true of every leg that is a record. Resurrecting it as a place would name a wire
where a point is wanted.

## Validation

```
bash scripts/tenkz_kernel_probes.sh
  PASS: 123 review regressions hold
  PASS: 10 sugar spellings byte-identical to their expansions
  PASS: 12 kernel record streams byte-identical
  PASS: kernel pixels byte-identical
bash scripts/tenkz_golden.sh --check
  PASS: 264 event streams byte-identical to the golden baseline
python3 scripts/test_tenkz_kernel_audit.py
  tenkz-kernel-audit: parser, crossings, boundaries, and geometry passed
python3 scripts/check_tenkz_dispositions.py
  PASS: 207 blueprint occurrences and 264 standalone fixtures reconcile exactly
python3 scripts/test_tenkz_pic.py
  all tenkz pipeline checks passed
python3 scripts/tenkz_manual_doctest.py
  PASS: 12 displayed manual examples and 25 reference examples
python3 scripts/tenkz_rmp.py check --section section-ii
  PASS: validated, compiled, linted, and audited 48 RMP target(s)
  Verdicts: unreviewed 0 | faithful 90 | cosmetic-gap 40 | structural-gap 0 | unfaithful 0 | blocked 0
python3 scripts/tenkz_shrink.py gate --base-ref origin/main
  tenkz-shrink: PASS: census stable at 201 and all 149 flag(s) carry verdicts
```

`docs/tenkz/manual2.tex` and `blueprint/src/print.tex` both compile clean. The
streams and pixels are byte-identical throughout — the only additions are the two
new regression fixtures, which the goldens do not cover. No RMP case file
changed, so no `case_sha256` moves.

Closes LionSR/tenkz#170
