### PR TITLE
feat(tenkz): let an author restate a generated bond

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_peps.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_peps.tex
@@ -40,16 +40,39 @@ product states, and the square lattice.
         % indices, hence boundary type (V,P)=(28,0).
         % Source verdict: exact square-lattice specialization of the first
         % hypothesis in arXiv:1804.04964, paper_normal.tex:1475--1499.
-        \begin{tenkzlattice}[rows=7, cols=7, boundary legs]
-            \tnregion[slot=selected, label={$A_1$},
-                label at=center]{(4-6,2-3)}
-            \tnregion[slot=secondary, label={$A_2$},
-                label at=center]{(3-4,4-6)}
-            \tnregion[slot=complement, outline, label={$A_3$},
-                label at=north]
-                {(1-7,1-7) - (4-6,2-3) - (3-4,4-6)}
-            \tnedge[distinguished]{(4,3)-(4,4)}
-        \end{tenkzlattice}
+        \tenkzkernel
+        \tndeclare{species}{blocked-edge}{hue=source:red!65!black}
+        \begin{tenkz}[rows={wire,wire,wire,wire,wire,wire,wire}, cols=7,
+            west=open, east=open, north=open, south=open]
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{}
+            \tnwire[species=blocked-edge]{(4,3)}{(4,4)}
+            \tnmark[form=enclosure, slot=selected, tint]
+                {(4,2) .. (6,3)}{$A_1$}
+            \tnmark[form=enclosure, slot=secondary, tint]
+                {(3,4) .. (4,6)}{$A_2$}
+            \tnmark[form=enclosure, slot=complement, label pos=n]
+                {(1,1) .. (7,7) - (4,2) .. (6,3) - (3,4) .. (4,6)}{$A_3$}
+        \end{tenkz}
         $\qquad\text{edge blocking}$
     \end{tenkzequation}
     \begin{tenkzequation}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_square_translated_windows_and_comparison.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square_translated_windows_and_comparison.tex
@@ -377,16 +377,39 @@
         % indices, hence boundary type (V,P)=(28,0).
         % Source verdict: exact discrete translation of arXiv:1804.04964,
         % paper_normal.tex:1475--1499; A1 is red, A2 blue, and A3 the rest.
-        \begin{tenkzlattice}[rows=7, cols=7, boundary legs]
-            \tnregion[slot=selected, label={$A_1$},
-                label at=center]{(4-6,2-3)}
-            \tnregion[slot=secondary, label={$A_2$},
-                label at=center]{(3-4,4-6)}
-            \tnregion[slot=complement, outline, label={$A_3$},
-                label at=north]
-                {(1-7,1-7) - (4-6,2-3) - (3-4,4-6)}
-            \tnedge[distinguished]{(4,3)-(4,4)}
-        \end{tenkzlattice}
+        \tenkzkernel
+        \tndeclare{species}{blocked-edge}{hue=source:red!65!black}
+        \begin{tenkz}[rows={wire,wire,wire,wire,wire,wire,wire}, cols=7,
+            west=open, east=open, north=open, south=open]
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} \\
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} &
+            \tn[skin=dot]{}
+            \tnwire[species=blocked-edge]{(4,3)}{(4,4)}
+            \tnmark[form=enclosure, slot=selected, tint]
+                {(4,2) .. (6,3)}{$A_1$}
+            \tnmark[form=enclosure, slot=secondary, tint]
+                {(3,4) .. (4,6)}{$A_2$}
+            \tnmark[form=enclosure, slot=complement, label pos=n]
+                {(1,1) .. (7,7) - (4,2) .. (6,3) - (3,4) .. (4,6)}{$A_3$}
+        \end{tenkz}
     \end{tenkzequation}
 \end{definition}
 

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -102,11 +102,11 @@ separate public-surface occurrence and therefore appears separately.
 | `ch24_peps_ft_edge_kernel_gauges_kernel_descent_recovery.tex` | — | — | L174, 196, 218, 445, 467, 489 `tenkzfree` → `C-species+R-free+R-record` |
 | `ch24_peps_ft_edge_middle.tex` | — | L278 `tnpic` → `C-picture+C-policy` | L242 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_foundations.tex` | — | — | L48, 384 `tenkzfree` → `R-free+R-record` |
-| `ch24_peps_ft_normal_capstone_normal_peps.tex` | — | — | L43 `tenkzlattice` → `R-lattice+R-record`<br>L69, 85 `tenkz` → `R-record` |
+| `ch24_peps_ft_normal_capstone_normal_peps.tex` | — | — | L45, 92, 108 `tenkz` → `R-record` |
 | `ch24_peps_ft_normal_square_blocking_and_fundamental.tex` | — | — | L21, 28 `tenkzlattice` → `C-species+R-lattice+R-record`<br>L89, 95, 114, 150 `tenkzlattice` → `R-lattice+R-record`<br>L162, 229 `tenkzfree` → `C-species+R-free+R-record`<br>L212 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_normal_square_coordinate_regions.tex` | — | — | L99, 104, 121, 286 `tenkzlattice` → `R-lattice+R-record` |
 | `ch24_peps_ft_normal_square_rectangular_injectivity.tex` | — | — | L206, 229 `tenkz` → `R-record` |
-| `ch24_peps_ft_normal_square_translated_windows_and_comparison.tex` | — | — | L380 `tenkzlattice` → `R-lattice+R-record` |
+| `ch24_peps_ft_normal_square_translated_windows_and_comparison.tex` | — | — | L382 `tenkz` → `R-record` |
 | `ch24_peps_ft_normal_union.tex` | — | — | L213, 270, 301, 327, 358 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_region_transfer_covariance.tex` | L351, 355, 359, 363 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_torus_translation_and_reference_windows.tex` | — | — | L22 `tenkzlattice` → `C-species+R-lattice+R-record` |
@@ -117,10 +117,10 @@ separate public-surface occurrence and therefore appears separately.
 
 | Raw construct | Occurrences |
 |---|---:|
-| `tenkz` | 120 |
+| `tenkz` | 122 |
 | `tenkzeq` | 0 |
 | `tenkzfree` | 34 |
-| `tenkzlattice` | 14 |
+| `tenkzlattice` | 12 |
 | `tenkzcd` | 6 |
 | `tenkzplanes` | 0 |
 | `tnpic` | 22 |

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -92,6 +92,15 @@ A generated grid endpoint begins with the virtual default. Matching authored
 port declarations may refine both ends to physical; declaring only one end
 physical still conflicts with its implicit virtual peer.
 
+The frame populates and the body overrides, for bonds as for atoms (§4). An
+authored index wire joining two adjacent cells *is* that pair's bond, so the
+frame mints no second wire under it and the pair's ports have one consumer.
+The wire's species, stroke, and route are the bond's, which is how a figure
+distinguishes the one edge it is about. The topology is unmoved: the same
+contraction, the same boundary signature, whether the restatement carries ink
+of its own or none. A travelling string states an operator index rather than
+that contraction and retires nothing.
+
 ### 2.3 Atom keys (13)
 
 | Key | Type | Values | Default | Diagnostic family |

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2192,3 +2192,47 @@ already there.
 | flag:sugar-shaped:command:tnsite | dies at the language landing with every 0.7 lattice command; the wave that migrates the PEPS region figures retires two of its six blueprint consumers, and the narrowed option profile the flag reads is that retirement and not new uniformity; expiry 0.9 |
 
 Extension-gate: #5570
+
+### 2026-08-06 — the body restates one generated bond
+
+A lattice draws its bonds from the row and column policy, and until now the
+body could not reach one of them. Three spellings were tried and none stated
+it: an authored wire over the same pair was recorded first and the generated
+bond inked on top of it, the typed-port spelling of that pair raised
+`TKZ-PORT-CONSUMED` because the generated bond had already claimed both ports,
+and writing out eighty-four wires to give one of them a different ink is not a
+spelling anyone will use. Two PEPS panels wanted exactly that sentence — this
+edge is the edge being blocked — and were the last two the region wave could
+not carry across.
+
+The kernel already held the rule and was not applying it to bonds. Section 4
+says the frame populates and the body overrides: an authored atom at a cell
+replaces the atom the frame put there, and every address of that cell resolves
+to the authored record rather than to coincident population underneath it. A
+grid bond is frame population of the same kind. So an authored index wire
+joining two adjacent cells IS that pair's bond, with its species, its stroke
+and its route, and the frame mints no second one under it. The pair's ports
+then have one consumer, which is why the typed-port spelling stops colliding.
+
+The rule costs nothing. M1 stays at 140 kernel rows and 201 total; M2 stays at
+228 parser paths with its identity unchanged, because no key, no value, and no
+address production was added — the change is a suppression in the generation
+loop, reading the wire records the body already left. M4 is unmoved at 25.94:
+the benchmark corpus is untouched. Only an index wire retires a bond; a
+travelling string carries an operator index, states a different claim, and
+retires nothing.
+
+The two panels move, and both lose their last `\tnedge`. The remaining
+blueprint consumer of the command and of its `distinguished` flag is the same
+one figure, so both rows fall below tenure a milestone before their own
+verdicts said they would. Neither verdict changes: both were already booked to
+die with the 0.7 lattice dialect, and each now has one blueprint consumer left
+to lose. The restated bond is thinner than the 0.7 emphasis stroke and that is
+the contract doing its work — the stroke follows the type the port carries and
+`weight=` is a tombstone, so emphasis rides the declared species and nothing
+else.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:command:tnedge | dies at the language landing with every 0.7 lattice command: an edge is an ordinary `\tnwire` of kind index, and a generated one is now restatable by the body; the two migrated PEPS panels retire all but one blueprint consumer, and the tenure it loses is the one this row already spent; expiry 0.9 |
+| flag:consumers:key:connection:distinguished | dies with `\tnedge` it rides: a distinguished edge is a restated bond carrying a declared `species=`, which is how the two migrated panels now say it; the single remaining blueprint consumer goes with the lattice dialect at S4; expiry 0.9 |

--- a/docs/tenkz/chapters2/ch-worked.tex
+++ b/docs/tenkz/chapters2/ch-worked.tex
@@ -65,6 +65,34 @@ glyph and one free tip, and fraction zero is the end the wire is written
 from, so a leg written from a port to \tnval{open e} runs outward while one
 written from \tnval{open w} to a port runs inward.
 
+\subsection{Say which bond is the one under discussion}
+
+A lattice draws its bonds from the row and column policy, and every one of
+them is the same black contraction.  A figure that distinguishes one edge --
+the edge being blocked, the bond being cut -- restates that bond in the body.
+An index wire between two adjacent cells is that pair's bond: the frame mints
+no second wire under it, and the wire's species, stroke, and route are the
+bond's.
+
+\begin{Verbatim}[fontsize=\small,frame=leftline]
+\tenkzkernel
+\tndeclare{species}{blocked-edge}{hue=source:red!65!black}
+\begin{tenkz}[rows={wire,wire}, cols=3]
+  \tn{} & \tn{} & \tn{}\\
+  \tn{} & \tn{} & \tn{}
+  \tnwire[species=blocked-edge]{(1,1)}{(1,2)}
+\end{tenkz}
+\end{Verbatim}
+
+The restatement is the same contraction, so the count of internal bonds and
+the exposed boundary do not move; only the ink does.  Either spelling of the
+pair reaches it -- the two cells, as above, or the two typed ports
+\tnval{a.0} and \tnval{b.180} on named atoms.  \tnkey{bonds=none} plus a
+hand-written wire for every pair states the same picture and is not a
+spelling anyone should use.  A travelling string is not a restatement: it
+carries an operator index, so it is drawn over the lattice and retires
+nothing.
+
 \subsection{Send a physical index sideways}
 
 An index type belongs to the port that carries it.  \tnkey{ports=} types each

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -121,6 +121,56 @@ grep -Fq '|name=bond-1-1-1-2|origin=grid|' "$WORK/k_blocking.tnlog" || {
   echo "FAIL: bonds=grid did not materialize the adjacent WIRE record" >&2
   exit 1
 }
+# A restated bond is the same bond.  The three panels of r_bond_restated are
+# one 3x3 lattice: the policy's own twelve bonds, the same figure with two of
+# them restated by the body and carrying nothing, and the same two carrying a
+# species and a stroke.  The frame retires the pair the body claimed instead
+# of minting a second wire under it, so the bond count, the silhouettes, and
+# the exposed boundary hold across all three.
+restated_pane() {
+  awk -v pane="$1" -v pattern="$2" '
+    /^picture\|/ { seen++ }
+    $0 ~ pattern { if (seen == pane) print }
+  ' "$WORK/r_bond_restated.tnlog"
+}
+for pane in 1 2 3; do
+  [ "$(restated_pane "$pane" '^kernel-boundary[|]')" = \
+    'kernel-boundary|signature=open:e, open:e, open:e, open:n, open:n, open:n, open:s, open:s, open:s, open:w, open:w, open:w' ] || {
+    echo "FAIL: restating a bond moved panel $pane's exposed boundary" >&2
+    exit 1
+  }
+done
+for pane in 2 3; do
+  [ "$(restated_pane "$pane" '[|]origin=grid[|]' | wc -l | tr -d ' ')" -eq 10 ] || {
+    echo "FAIL: panel $pane did not retire the two bonds its body restated" >&2
+    exit 1
+  }
+  for retired in bond-1-1-1-2 bond-2-3-3-3; do
+    if restated_pane "$pane" '[|]origin=grid[|]' | grep -Fq "|name=$retired|"; then
+      echo "FAIL: the frame minted $retired under the body's own wire" >&2
+      exit 1
+    fi
+  done
+done
+[ "$(restated_pane 1 '[|]origin=grid[|]' | wc -l | tr -d ' ')" -eq 12 ] || {
+  echo "FAIL: the unrestated control lost a policy bond" >&2
+  exit 1
+}
+[ "$(restated_pane 3 '^wire[|].*[|]species=blocked' | wc -l | tr -d ' ')" -eq 2 ] || {
+  echo "FAIL: the species did not reach the two restated bonds" >&2
+  exit 1
+}
+restated_glyphs() {
+  restated_pane "$1" '^glyph-geometry[|]' | sed 's/picture=k[0-9]*|//; s/owner=[0-9]*|//'
+}
+control_glyphs=$(restated_glyphs 1)
+keyless_glyphs=$(restated_glyphs 2)
+[ -n "$control_glyphs" ] && [ "$control_glyphs" = "$keyless_glyphs" ] || {
+  echo "FAIL: a keyless restatement moved the silhouettes it stands between" >&2
+  diff <(printf '%s\n' "$control_glyphs") <(printf '%s\n' "$keyless_glyphs") >&2 \
+    || true
+  exit 1
+}
 [ "$(grep -c '|origin=open|' \
       "$WORK/r_plane_open_perimeter.tnlog" || true)" -eq 12 ] || {
   echo "FAIL: four open plane sides did not materialize 12 perimeter wires" >&2

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -22,8 +22,8 @@ SPEC.loader.exec_module(DOCTEST)
 def main() -> int:
     manual = DOCTEST.displayed_examples()
     reference = DOCTEST.reference_examples()
-    if len(manual) != 12:
-        raise AssertionError(f"expected 12 displayed TeX examples, found {len(manual)}")
+    if len(manual) != 13:
+        raise AssertionError(f"expected 13 displayed TeX examples, found {len(manual)}")
     if len(reference) != 25:
         raise AssertionError(f"expected 25 reference examples, found {len(reference)}")
     if any(r"\begin{document}" not in example.document for example in manual):

--- a/tests/tenkz/kernel/regression/r_bond_restated.tex
+++ b/tests/tenkz/kernel/regression/r_bond_restated.tex
@@ -1,0 +1,45 @@
+% Regression: the body restates one generated bond among many.  A lattice
+% draws its bonds from the row and column policy, and before issue 5571 the
+% body could not reach one of them: an authored wire over the same pair was
+% recorded first and the generated bond inked on top of it, while the
+% typed-port spelling of that pair raised TKZ-PORT-CONSUMED because the
+% generated bond had already claimed both ports.  The frame populates and the
+% body overrides -- the rule section 4 states for atoms -- so an authored
+% index wire joining two adjacent cells IS that pair's bond, and the frame
+% mints no second one under it.  The topology is stated once either way: the
+% same contraction count, the same silhouettes, and the same exposed
+% boundary, whether the restatement carries ink of its own or none.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\tndeclare{species}{blocked}{hue=source:red}
+% the control: every bond comes from the policy
+\begin{tenkz}[rows={wire,wire,wire}, cols=3,
+  west=open, east=open, north=open, south=open]
+  \tn{} & \tn{} & \tn{}\\
+  \tn{} & \tn{} & \tn{}\\
+  \tn{} & \tn{} & \tn{}
+\end{tenkz}
+\qquad
+% two of the twelve restated with nothing of their own: the same figure,
+% one by its cells and one through its typed ports
+\begin{tenkz}[rows={wire,wire,wire}, cols=3,
+  west=open, east=open, north=open, south=open]
+  \tn{} & \tn{} & \tn{}\\
+  \tn{} & \tn{} & \tn[name=c]{}\\
+  \tn{} & \tn{} & \tn[name=d]{}
+  \tnwire{(1,1)}{(1,2)}
+  \tnwire{c.270}{d.90}
+\end{tenkz}
+\qquad
+% the same two carrying a species and a stroke: the edge under discussion
+\begin{tenkz}[rows={wire,wire,wire}, cols=3,
+  west=open, east=open, north=open, south=open]
+  \tn{} & \tn{} & \tn{}\\
+  \tn{} & \tn{} & \tn[name=e]{}\\
+  \tn{} & \tn{} & \tn[name=f]{}
+  \tnwire[species=blocked]{(1,1)}{(1,2)}
+  \tnwire[species=blocked, stroke=dashed]{e.270}{f.90}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2955,8 +2955,169 @@
           }
       }
   }
+% The frame populates and the body overrides.  Section 4 states that rule for
+% atoms: an authored atom at a cell replaces the atom the frame put there,
+% and every address of that cell then resolves to the authored record rather
+% than creating coincident population underneath it.  A grid bond is frame
+% population of the same kind -- `bonds=grid` mints one wire per adjacent
+% pair, and the body never sees it -- so an authored index wire joining two
+% adjacent cells IS that pair's bond, with its species, its stroke and its
+% route, and the frame mints no second one under it.  Without the rule the
+% generated bond inks over the author's, and the typed-port spelling of the
+% same pair collides with the generated bond on the ports both claim.
+%
+% Only an index wire retires a bond: a string travels over the lattice and
+% carries an operator, which is a different index type and a different claim.
+\prop_new:N \l__tenkz_kernel_authored_bond_prop
+\tl_new:N \l__tenkz_kernel_bond_host_tl
+\tl_new:N \l__tenkz_kernel_bond_node_tl
+\tl_new:N \l__tenkz_kernel_bond_a_row_tl
+\tl_new:N \l__tenkz_kernel_bond_a_col_tl
+\tl_new:N \l__tenkz_kernel_bond_b_row_tl
+\tl_new:N \l__tenkz_kernel_bond_b_col_tl
+\bool_new:N \l__tenkz_kernel_bond_a_bool
+\bool_new:N \l__tenkz_kernel_bond_b_bool
+% The cell a wire end stands at, when it stands at one.  A cell or member
+% address names it outright; a typed port and a bare name reach it through
+% the record they belong to.  Every other production is a geometric
+% construction rather than a further cell, and answers false.
+\cs_new_protected:Npn \__tenkz_kernel_bond_end_cell:nNNN #1#2#3#4
+  {
+    \bool_set_false:N #4
+    \str_case:en { \__tenkz_kernel_node_item:nn {#1} {kind} }
+      {
+        {cell}
+          {
+            \tl_set:Ne #2 { \__tenkz_kernel_node_item:nn {#1} {row} }
+            \tl_set:Ne #3 { \__tenkz_kernel_node_item:nn {#1} {col} }
+            \bool_set_true:N #4
+          }
+        {member}
+          {
+            \tl_set:Ne #2 { \__tenkz_kernel_node_item:nn {#1} {row} }
+            \tl_set:Ne #3 { \__tenkz_kernel_node_item:nn {#1} {col} }
+            \bool_set_true:N #4
+          }
+        {port}
+          {
+            \__tenkz_kernel_port_node_record:nN {#1}
+              \l__tenkz_kernel_bond_host_tl
+            \quark_if_no_value:NF \l__tenkz_kernel_bond_host_tl
+              {
+                \exp_args:NV \__tenkz_kernel_atom_rc:nNNN
+                  \l__tenkz_kernel_bond_host_tl #2 #3 #4
+              }
+          }
+        {record}
+          {
+            \prop_get:NeN \l__tenkz_kernel_named_prop
+              { \__tenkz_kernel_node_item:nn {#1} {name} }
+              \l__tenkz_kernel_bond_host_tl
+            \quark_if_no_value:NF \l__tenkz_kernel_bond_host_tl
+              {
+                \exp_args:NV \__tenkz_kernel_atom_rc:nNNN
+                  \l__tenkz_kernel_bond_host_tl #2 #3 #4
+              }
+          }
+      }
+  }
+% Record the pair under the name the frame would have minted for it, so the
+% generation loop reads one key and the model keeps one canonical spelling.
+\cs_new_protected:Npn \__tenkz_kernel_authored_bond_register:nnnn #1#2#3#4
+  {
+    \bool_lazy_and:nnTF
+      { \int_compare_p:nNn {#1} = {#3} }
+      {
+        \bool_lazy_or_p:nn
+          { \int_compare_p:nNn {#2} = { #4 - 1 } }
+          { \int_compare_p:nNn {#4} = { #2 - 1 } }
+      }
+      {
+        \int_compare:nNnTF {#2} < {#4}
+          {
+            \prop_put:Nnn \l__tenkz_kernel_authored_bond_prop
+              {#1-#2-#3-#4} {authored}
+          }
+          {
+            \prop_put:Nnn \l__tenkz_kernel_authored_bond_prop
+              {#3-#4-#1-#2} {authored}
+          }
+      }
+      {
+        \bool_lazy_and:nnT
+          { \int_compare_p:nNn {#2} = {#4} }
+          {
+            \bool_lazy_or_p:nn
+              { \int_compare_p:nNn {#1} = { #3 - 1 } }
+              { \int_compare_p:nNn {#3} = { #1 - 1 } }
+          }
+          {
+            \int_compare:nNnTF {#1} < {#3}
+              {
+                \prop_put:Nnn \l__tenkz_kernel_authored_bond_prop
+                  {#1-#2-#3-#4} {authored}
+              }
+              {
+                \prop_put:Nnn \l__tenkz_kernel_authored_bond_prop
+                  {#3-#4-#1-#2} {authored}
+              }
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_authored_bond:n #1
+  {
+    \bool_set_false:N \l__tenkz_kernel_bond_a_bool
+    \bool_set_false:N \l__tenkz_kernel_bond_b_bool
+    \__tenkz_model_get:nnN {#1} {from} \l__tenkz_kernel_bond_node_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_bond_node_tl
+      {
+        \exp_args:NV \__tenkz_kernel_bond_end_cell:nNNN
+          \l__tenkz_kernel_bond_node_tl
+          \l__tenkz_kernel_bond_a_row_tl \l__tenkz_kernel_bond_a_col_tl
+          \l__tenkz_kernel_bond_a_bool
+      }
+    \bool_if:NT \l__tenkz_kernel_bond_a_bool
+      {
+        \__tenkz_model_get:nnN {#1} {to} \l__tenkz_kernel_bond_node_tl
+        \quark_if_no_value:NF \l__tenkz_kernel_bond_node_tl
+          {
+            \exp_args:NV \__tenkz_kernel_bond_end_cell:nNNN
+              \l__tenkz_kernel_bond_node_tl
+              \l__tenkz_kernel_bond_b_row_tl \l__tenkz_kernel_bond_b_col_tl
+              \l__tenkz_kernel_bond_b_bool
+          }
+      }
+    \bool_lazy_and:nnT
+      { \l__tenkz_kernel_bond_a_bool }
+      { \l__tenkz_kernel_bond_b_bool }
+      {
+        \use:e
+          {
+            \exp_not:N \__tenkz_kernel_authored_bond_register:nnnn
+              { \int_eval:n { \l__tenkz_kernel_bond_a_row_tl } }
+              { \int_eval:n { \l__tenkz_kernel_bond_a_col_tl } }
+              { \int_eval:n { \l__tenkz_kernel_bond_b_row_tl } }
+              { \int_eval:n { \l__tenkz_kernel_bond_b_col_tl } }
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_authored_bonds:
+  {
+    \prop_clear:N \l__tenkz_kernel_authored_bond_prop
+    \__tenkz_model_map_ids:nn {wire}
+      {
+        \__tenkz_model_get:nnN {##1} {origin} \l__tenkz_kernel_bond_host_tl
+        \quark_if_no_value:NT \l__tenkz_kernel_bond_host_tl
+          {
+            \__tenkz_model_get:nnN {##1} {kind} \l__tenkz_kernel_bond_host_tl
+            \str_if_eq:VnT \l__tenkz_kernel_bond_host_tl {index}
+              { \__tenkz_kernel_authored_bond:n {##1} }
+          }
+      }
+  }
 \cs_new_protected:Npn \__tenkz_kernel_bonds:
   {
+    \__tenkz_kernel_authored_bonds:
     \prop_get:NnN \l__tenkz_kernel_policy_prop {bonds}
       \l__tenkz_kernel_scratch_tl
     \quark_if_no_value:NT \l__tenkz_kernel_scratch_tl
@@ -2970,6 +3131,9 @@
             \int_step_inline:nn { \__tenkz_kernel_cols: - 1 }
               {
                 \bool_set_false:N \l_tmpa_bool
+                \prop_if_in:NeT \l__tenkz_kernel_authored_bond_prop
+                  { ##1-####1-##1-\int_eval:n {####1 + 1} }
+                  { \bool_set_true:N \l_tmpa_bool }
                 \__tenkz_kernel_cell_sealed:nnT {##1}{####1}
                   { \bool_set_true:N \l_tmpa_bool }
                 \__tenkz_kernel_cell_sealed:nnT
@@ -2990,6 +3154,9 @@
             \int_step_inline:nn { \__tenkz_kernel_cols: }
               {
                 \bool_set_false:N \l_tmpa_bool
+                \prop_if_in:NeT \l__tenkz_kernel_authored_bond_prop
+                  { ##1-####1-\int_eval:n {##1 + 1}-####1 }
+                  { \bool_set_true:N \l_tmpa_bool }
                 \prop_if_in:NeT \l__tenkz_kernel_trace_cell_prop
                   {##1-####1}
                   { \bool_set_true:N \l_tmpa_bool }


### PR DESCRIPTION
## The mechanism

An authored index wire joining two adjacent cells **is** that pair's bond. The
frame's generation loop reads the wire records the body already left, and
mints no bond for a pair the body claimed. The wire's `species=`, `stroke=`
and `route=` are the bond's, and the pair's typed ports have one consumer, so
`TKZ-PORT-CONSUMED` no longer fires on the port spelling.

Both spellings of the pair reach it — the two cells `{(4,3)}{(4,4)}`, or the
two typed ports `{a.0}{b.180}` on named atoms — because the endpoint resolver
answers with the cell a wire end stands at whether the address names the cell,
a basis member, a typed port, or a named record. Only `kind=index` retires a
bond: a travelling string carries an operator index and states a different
claim, so it is drawn over the lattice and retires nothing.

## The contract reading

Section 4 already states the rule, for atoms: *the frame populates and the
body overrides* — an authored atom at `(r,c)` replaces the whole populated
cell, and every address of that cell resolves to the authored record "rather
than creating coincident population underneath it". A grid bond is frame
population of the same kind: `bonds=grid` mints one wire per adjacent pair and
the body never sees it. This change applies the rule the kernel already
carries to the records generation actually creates. Section 2.2 gains the
paragraph that says so.

The reading was preferred over a restatement key or a selector reach because
it costs nothing. **M1** stays at 140 kernel rows and 201 total; **M2** stays
at 228 parser paths with `identity_sha256` unchanged; **M4** is unmoved at
25.94. No key, no value, no address production — hence no Extension-gate
issue, no registry row, and no baseline bump.

Emphasis rides the declared species and nothing else. Section 5 says the
stroke follows the type the port carries, and `weight=` is a §10 tombstone, so
a restated bond is inked, never thickened.

## The regression

`tests/tenkz/kernel/regression/r_bond_restated.tex` is one 3×3 lattice with
all four sides open, in three panels: the policy's own twelve bonds, the same
figure with two of them restated carrying nothing (one by its cells, one
through its typed ports), and the same two carrying a species and a dashed
stroke. `scripts/tenkz_kernel_probes.sh` asserts that all three expose the
same twelve-index boundary signature, that the two restated panels retain
exactly ten policy bonds and never mint `bond-1-1-1-2` or `bond-2-3-3-3`, that
the species reaches both restated bonds, and that the keyless restatement
leaves the glyph geometry of the control panel byte-identical. Compiled
standalone and looked at; a keyless restatement of a whole figure renders
pixel-identical to the control.

## Consumer verdicts

Both panels are the same 7×7 edge-blocking figure. Both migrate to
`\begin{tenkz}[rows={wire,...×7}, cols=7, west=open, east=open, north=open,
south=open]`, three `\tnmark[form=enclosure]` regions, and
`\tnwire[species=blocked-edge]{(4,3)}{(4,4)}` with
`\tndeclare{species}{blocked-edge}{hue=source:red!65!black}`.

Rendered before and after at 200 dpi and compared by eye, plus the figure in
its blueprint page at 130 dpi.

**`ch24_peps_ft_normal_capstone_normal_peps.tex` L43 → L45.** The distinguished
edge is the same edge, the same hue as the 0.7 `distinguished edge` style
(`tenkzAction` = `red!65!black`), running from the `(4,3)` dot through $A_2$'s
contour to the `(4,4)` dot. The three regions keep their palette: $A_1$ red
fill, $A_2$ blue fill, $A_3$ the grey dashed traced complement. 83 policy
bonds + 1 restated = 84 internal contractions, 28 boundary entries — exactly
the panel's stated `(V,P)=(28,0)`. Differences from the 0.7 render: the bond
carries the bond stroke rather than the emphasis width (contract, above), the
dots are the kernel's larger silhouette as in every migrated panel, and $A_2$'s
label sits at its own station rather than dead centre. Verdict: faithful.

**`ch24_peps_ft_normal_square_translated_windows_and_comparison.tex` L380 →
L382.** Identical figure and identical verdict.

`docs/tenkz/DISPOSITIONS.md`: both occurrences move from
`tenkzlattice → R-lattice+R-record` to `tenkz → R-record`, line pins follow
(capstone L43,69,85 → L45,92,108; windows L380 → L382), raw counts move
`tenkz` 120→122 and `tenkzlattice` 14→12, totals hold at 207.

`docs/tenkz/SHRINK.md` books the session: `\tnedge` and its `distinguished`
flag both fall to one blueprint consumer — the same remaining figure — and
each carries its verdict.

## Validation

```
bash scripts/tenkz_kernel_probes.sh      PASS: 124 review regressions hold
                                         PASS: 10 sugar spellings byte-identical
                                         PASS: 12 kernel record streams byte-identical
                                         PASS: kernel pixels byte-identical
bash scripts/tenkz_golden.sh --check     PASS: 264 event streams byte-identical
python3 scripts/test_tenkz_kernel_audit.py   parser, crossings, boundaries, geometry passed
python3 scripts/check_tenkz_dispositions.py  PASS: 207 blueprint occurrences and 264 fixtures reconcile
python3 scripts/test_tenkz_pic.py            all tenkz pipeline checks passed
python3 scripts/test_tenkz_manual_doctest.py PASS (13 displayed, 25 reference)
python3 scripts/tenkz_manual_doctest.py      PASS: 13 displayed and 25 reference examples compile
python3 scripts/test_tenkz_language.py       PASS: registry, typed atom diagnostic, alias event equivalence
python3 scripts/test_tenkz_shrink.py         PASS
python3 scripts/check_tenkz_policy.py        PASS
python3 scripts/check_tenkz_demolition.py    PASS
xelatex docs/tenkz/manual2.tex               clean
xelatex blueprint/src/print.tex              clean, 858 pages, 140 overfull hboxes (153 on base)
python3 scripts/tenkz_shrink.py gate --base-ref origin/main
                                         PASS: census stable at 201, all 150 flags carry verdicts
```

`blueprint/src/content.tex` has chapter 24 commented out, so the two consumer
panels were additionally compiled through a scratch wrapper that inputs
`chapter/ch24_peps_ft` — clean, and both figures were read off its pages. No
RMP case changed, so no `case_sha256` needed re-pinning. The manual gains one
recipe, which is why the doctest count moves from 12 to 13.

Closes LionSR/tenkz#172
