### PR TITLE
doc(tenkz): say when the physical policy pays

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -744,6 +744,13 @@ crossing are geometric constructions rather than further cells, so the
 picture policy gives them no physical index. Such an atom may still declare
 an independent physical port with `ports=` when the mathematics requires one.
 
+The policy pays on a uniform row, where two or more sites share the leg: one
+declaration replaces a port on every eligible atom, and a rare exception
+refuses it with `physical=none`. It costs on a sparse row, where a single
+site among many carries the index: every other site must then refuse the
+policy, and the refusals outrun the port list they replaced. Write the
+policy for the shared leg; write the ports for the lone one.
+
 | Sugar | Expands to |
 |---|---|
 | `sandwich` | `rows={ket,op,bra}` |

--- a/docs/tenkz/chapters2/ch-worked.tex
+++ b/docs/tenkz/chapters2/ch-worked.tex
@@ -112,6 +112,21 @@ index: it gives every frame-cell atom one outward physical port on the
 frame's own outward face.  The two spellings stand side by side, and neither
 claims the other's face.
 
+The policy earns its place on a uniform row: state it once and every site
+takes the leg, with the rare exception refusing it by
+\tnkey{physical=none}.  It costs on a sparse row, where a single site among
+many carries the index -- every other site must then refuse it, and the
+refusals outrun the port list they replaced.  Reach for the policy when two
+or more sites share the leg; write the ports when only one does:
+
+\begin{Verbatim}[fontsize=\small,frame=leftline]
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=5]
+  \tn{} & \tn{} & \tn[ports={180:virtual, 0:virtual, 90:physical:$i$}]{} &
+  \tn{} & \tn{}
+\end{tenkz}
+\end{Verbatim}
+
 \subsection{Keep a physical index out of a projected sheet}
 
 There are five directions at a PEPS tensor, but only four lie in the sheet.

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -22,8 +22,8 @@ SPEC.loader.exec_module(DOCTEST)
 def main() -> int:
     manual = DOCTEST.displayed_examples()
     reference = DOCTEST.reference_examples()
-    if len(manual) != 13:
-        raise AssertionError(f"expected 13 displayed TeX examples, found {len(manual)}")
+    if len(manual) != 14:
+        raise AssertionError(f"expected 14 displayed TeX examples, found {len(manual)}")
     if len(reference) != 25:
         raise AssertionError(f"expected 25 reference examples, found {len(reference)}")
     if any(r"\begin{document}" not in example.document for example in manual):


### PR DESCRIPTION
## Summary

Closes the acceptance tail of LionSR/tenkz#153. The key itself landed in LionSR/TNLean#5525; what remained was writing down the boundary that Wave B2's report and the LionSR/tenkz#153 comment thread both independently found: the picture-level `physical=` policy pays on a uniform row and costs on a sparse one.

## Measurement

Took a real five-site row both ways, compiled all four spellings under `\tenkzkernel` (`TEXINPUTS=<worktree>/tex/tenkz//:`), and confirmed each pair renders pixel-identical (`compare -metric AE` = 0):

**Uniform row** — four sites carry an unlabelled physical leg, one refuses:
- policy (`physical=updown` + one `physical=none`): **4 lines**
- restated ports on all four MPO sites: **7 lines**

**Sparse row** — one site among five carries a labelled index:
- policy (`physical=up` + four `physical=none` refusals): **5 lines**
- port list (four bare atoms + one `ports={90:physical:$i$}`): **4 lines**

The policy wins by 3 lines on the uniform row; the port list wins by 1 line on the sparse row — the same boundary LionSR/TNLean#5522's comment described, now with a number attached.

## Text added

`docs/tenkz/chapters2/ch-worked.tex`, end of "Send a physical index sideways":

> The policy earns its place on a uniform row: state it once and every site takes the leg, with the rare exception refusing it by `physical=none`. It costs on a sparse row, where a single site among many carries the index -- every other site must then refuse it, and the refusals outrun the port list they replaced. Reach for the policy when two or more sites share the leg; write the ports when only one does:

followed by a worked example of the sparse case (a five-site row, one site labelled via `ports=`, none via the policy).

`docs/tenkz/LANGUAGE-1.0.md` §9 (registry-adjacent clause after the eligibility paragraph):

> The policy pays on a uniform row, where two or more sites share the leg: one declaration replaces a port on every eligible atom, and a rare exception refuses it with `physical=none`. It costs on a sparse row, where a single site among many carries the index: every other site must then refuse the policy, and the refusals outrun the port list they replaced. Write the policy for the shared leg; write the ports for the lone one.

`scripts/test_tenkz_manual_doctest.py`: bumped the pinned displayed-example count 13 -> 14 for the new worked example.

## Validation

- `python3 scripts/tenkz_manual_doctest.py` -- PASS: 14 displayed manual examples and 25 reference examples (all compile)
- `python3 scripts/test_tenkz_manual_doctest.py` -- PASS
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` -- no newly added violations
- `docs/tenkz/manual2.tex` compiles clean (xelatex, two passes, 22 pages, no errors/warnings)
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` -- PASS: census stable at 201 and all 150 flags carry verdicts

Closes LionSR/tenkz#153