### PR TITLE
fix(tests/tenkz/rmp): type three mistyped indices found by the contraction audit

### DIFF
--- a/docs/tenkz/COSMETIC-GAP-BAR.md
+++ b/docs/tenkz/COSMETIC-GAP-BAR.md
@@ -12,6 +12,9 @@ alike and no comparison of pictures catches a mistyped one. The record stream
 catches it, and the boundary signature catches it only when the mistyping moves
 an open end. Every verdict below was reached at the render, so typing is the
 one property a re-review must read out of the record rather than off the page.
+`scripts/tenkz_contracted_types.py --all` reads it out: it compiles each target
+and reports how many of its contracted indices are physical and how many
+virtual, in both picture languages. Run it after any migration wave.
 
 This distinction controls the verdict:
 

--- a/scripts/tenkz_contracted_types.py
+++ b/scripts/tenkz_contracted_types.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Report the type of every contracted index in the tenkz RMP corpus.
+
+The kernel strokes a connected wire the same way whether its two ends are
+physical or virtual ports, so a mistyped contracted index leaves the drawing
+untouched and no render comparison can find it.  The record stream does carry
+the type, and this script reads it: for each target it compiles the case and
+reports how many of its contracted indices are physical and how many virtual,
+with the origin of each contraction.
+
+Both picture languages are covered.  In the kernel a contracted index is a
+``wire`` record with both ``from`` and ``to`` resolved; it carries
+``port-type=physical`` when the kernel typed both of its ports physical, and
+carries no type field when the contraction is virtual.  In the older grid
+dialect the type is fixed by the grammar rather than declared, so the record
+kind names it: ``pairleg``, ``pairtrace`` and ``phtrace`` are site
+contractions, while ``bond``, ``cup`` and ``trace`` run along the network.
+
+Usage::
+
+    python3 scripts/tenkz_contracted_types.py --all
+    python3 scripts/tenkz_contracted_types.py --id rmp-ii-ortho-left
+    python3 scripts/tenkz_contracted_types.py --all --physical-only
+    python3 scripts/tenkz_contracted_types.py --all --build-dir DIR
+
+``--build-dir`` reuses (and populates) a directory of compiled targets instead
+of a temporary one, which makes a repeated audit cheap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import os
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tenkz_rmp import (  # noqa: E402
+    DEFAULT_MANIFEST,
+    RMPError,
+    load_manifest,
+    standalone_wrapper,
+    tex_environment,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Grid-dialect record kinds that are contractions.  The dialect has no declared
+# port type: a ket-bra site pairing and a physical trace are physical because
+# the grammar that emits them says so, and a bond, a cup and a virtual trace
+# run along the network.
+DIALECT_PHYSICAL = frozenset({"pairleg", "pairtrace", "phtrace"})
+DIALECT_VIRTUAL = frozenset({"bond", "cup", "trace"})
+
+
+@dataclass
+class Contraction:
+    """One contracted index, with the type and the construct that made it."""
+
+    picture: str
+    lang: str
+    kind: str
+    origin: str
+    type: str
+
+
+@dataclass
+class TargetReport:
+    id: str
+    languages: list[str] = field(default_factory=list)
+    contractions: list[Contraction] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def physical(self) -> list[Contraction]:
+        return [item for item in self.contractions if item.type == "physical"]
+
+    @property
+    def virtual(self) -> list[Contraction]:
+        return [item for item in self.contractions if item.type == "virtual"]
+
+
+def record_fields(line: str) -> tuple[str, dict[str, str]]:
+    parts = line.strip().split("|")
+    attrs: dict[str, str] = {}
+    for part in parts[1:]:
+        key, separator, value = part.partition("=")
+        if separator:
+            attrs[key] = value
+    return parts[0], attrs
+
+
+def read_stream(text: str) -> tuple[list[str], list[Contraction]]:
+    """Classify every contracted index in one event stream."""
+    languages: list[str] = []
+    picture = "?"
+    lang = "unknown"
+    contractions: list[Contraction] = []
+    for line in text.splitlines():
+        kind, attrs = record_fields(line)
+        if kind == "picture":
+            picture = attrs.get("id", "?")
+            lang = attrs.get("lang", "unknown").split("|")[0]
+            if lang not in languages:
+                languages.append(lang)
+            continue
+        if kind == "wire":
+            if "from" not in attrs or "to" not in attrs:
+                continue
+            contractions.append(
+                Contraction(
+                    picture=picture,
+                    lang=lang,
+                    kind="wire",
+                    origin=attrs.get("origin", "tnwire"),
+                    # The kernel stamps port-type only on a physical index;
+                    # an untyped contraction is virtual by default.
+                    type=attrs.get("port-type", "virtual"),
+                )
+            )
+            continue
+        if kind in DIALECT_PHYSICAL or kind in DIALECT_VIRTUAL:
+            contractions.append(
+                Contraction(
+                    picture=attrs.get("picture", picture),
+                    lang=lang,
+                    kind=kind,
+                    origin=kind,
+                    type="physical" if kind in DIALECT_PHYSICAL else "virtual",
+                )
+            )
+    return languages, contractions
+
+
+def compile_target(target, work_root: Path, env: dict[str, str]) -> TargetReport:
+    work = work_root / target.id
+    work.mkdir(parents=True, exist_ok=True)
+    wrapper = work / f"{target.id}-standalone.tex"
+    wrapper.write_text(standalone_wrapper(target), encoding="utf-8")
+    stream = wrapper.with_suffix(".tnlog")
+    if not (stream.is_file() and stream.stat().st_size):
+        try:
+            subprocess.run(
+                ["xelatex", "-interaction=nonstopmode", "-halt-on-error", wrapper.name],
+                cwd=work,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return TargetReport(id=target.id, error=str(exc))
+        if not (stream.is_file() and stream.stat().st_size):
+            return TargetReport(id=target.id, error="produced no nonempty .tnlog")
+    languages, contractions = read_stream(stream.read_text(encoding="utf-8"))
+    return TargetReport(id=target.id, languages=languages, contractions=contractions)
+
+
+def describe(report: TargetReport) -> str:
+    if report.error is not None:
+        return f"{report.id}\tERROR: {report.error}"
+    origins = Counter(item.origin for item in report.physical)
+    detail = ", ".join(f"{origin}={count}" for origin, count in sorted(origins.items()))
+    return (
+        f"{report.id}\t"
+        f"lang={'+'.join(report.languages) or 'none'}\t"
+        f"physical={len(report.physical)}\t"
+        f"virtual={len(report.virtual)}"
+        + (f"\tvia {detail}" if detail else "")
+    )
+
+
+def run(targets, work_root: Path, jobs: int) -> list[TargetReport]:
+    env = tex_environment(work_root)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        return list(pool.map(lambda t: compile_target(t, work_root, env), targets))
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    selection = result.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--all", action="store_true")
+    selection.add_argument("--id", dest="target_id", metavar="TARGET")
+    result.add_argument(
+        "--build-dir",
+        type=Path,
+        help="reuse this directory of compiled targets instead of a temporary one",
+    )
+    result.add_argument(
+        "--physical-only",
+        action="store_true",
+        help="list only the targets that record a contracted physical index",
+    )
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    manifest = Path(os.environ.get("TENKZ_RMP_MANIFEST", DEFAULT_MANIFEST))
+    try:
+        targets = load_manifest(manifest)
+    except RMPError as exc:
+        print(f"FAIL: {exc}")
+        return 1
+    if args.target_id is not None:
+        targets = [target for target in targets if target.id == args.target_id]
+        if not targets:
+            print(f"FAIL: unknown target id: {args.target_id}")
+            return 1
+    jobs = max(1, os.cpu_count() or 1)
+
+    if args.build_dir is not None:
+        args.build_dir.mkdir(parents=True, exist_ok=True)
+        reports = run(targets, args.build_dir.resolve(), jobs)
+    else:
+        with tempfile.TemporaryDirectory(prefix="tenkz-contracted-") as temporary:
+            reports = run(targets, Path(temporary), jobs)
+
+    failures = [report for report in reports if report.error is not None]
+    shown = [report for report in reports if not args.physical_only or report.physical]
+    for report in shown:
+        print(describe(report))
+
+    physical_targets = [report for report in reports if report.physical]
+    mixed = [report for report in physical_targets if report.virtual]
+    print(
+        f"\n{len(reports)} targets; "
+        f"{len(physical_targets)} record a contracted physical index, "
+        f"{len(mixed)} contract both types; "
+        f"{sum(len(report.physical) for report in reports)} physical and "
+        f"{sum(len(report.virtual) for report in reports)} virtual contractions."
+    )
+    if failures:
+        for report in failures:
+            print(f"FAIL: {report.id}: {report.error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-local-purification.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-local-purification.tex
@@ -24,9 +24,9 @@
       ports={180:virtual,0@1:virtual,0@2:virtual}]
       {X^{-1}}
     \tn[at=(1,2), name=A, skin=box,
-      ports={180:virtual,0:virtual,90:physical,270:virtual}]{A}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{A}
     \tn[at=(2,2), name=Ac, skin=box, conjugate,
-      ports={180:virtual,0:virtual,90:virtual,270:physical}]{\overline{A}}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{\overline{A}}
     \tn[at=(1,3), name=X, skin=ring, wires=2,
       ports={180@1:virtual,180@2:virtual,0:virtual}]{X}
     \tnwire{open w}{Xi.180}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-blocking.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-blocking.tex
@@ -12,13 +12,13 @@
   % LHS: the blocked two-column sandwich, everything open
   \begin{tenkz}[rows={op,op}, cols=2, bonds=none]
     \tn[at=(1,1), name=u1, skin=box,
-      ports={180:virtual,0:virtual,90:physical,270:virtual}]{U}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{U}
     \tn[at=(1,2), name=u2, skin=box,
-      ports={180:virtual,0:virtual,90:physical,270:virtual}]{U}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{U}
     \tn[at=(2,1), name=ub1, skin=box, conjugate,
-      ports={180:virtual,0:virtual,90:virtual,270:physical}]{\overline{U}}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{\overline{U}}
     \tn[at=(2,2), name=ub2, skin=box, conjugate,
-      ports={180:virtual,0:virtual,90:virtual,270:physical}]{\overline{U}}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{\overline{U}}
     \tnwire{open w}{u1.180} \tnwire{u1.0}{u2.180} \tnwire{u2.0}{open e}
     \tnwire{open w}{ub1.180} \tnwire{ub1.0}{ub2.180} \tnwire{ub2.0}{open e}
     \tnwire{u1.270}{ub1.90} \tnwire{u2.270}{ub2.90}
@@ -32,13 +32,13 @@
   % routed detour, so the closure currently draws along the column axis.
   \begin{tenkz}[rows={op,op}, cols=2, bonds=none]
     \tn[at=(1,1), name=u1, skin=box,
-      ports={180:virtual,0:virtual,90:physical,270:virtual}]{U}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{U}
     \tn[at=(2,1), name=ub1, skin=box, conjugate,
-      ports={180:virtual,0:virtual,90:virtual,270:physical}]{\overline{U}}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{\overline{U}}
     \tn[at=(1,2), name=u2, skin=box,
-      ports={180:virtual,0:virtual,90:physical,270:virtual}]{U}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{U}
     \tn[at=(2,2), name=ub2, skin=box, conjugate,
-      ports={180:virtual,0:virtual,90:virtual,270:physical}]{\overline{U}}
+      ports={180:virtual,0:virtual,90:physical,270:physical}]{\overline{U}}
     \tnwire{u1.270}{ub1.90} \tnwire{u2.270}{ub2.90}
     \tnwire{open w}{u1.180} \tnwire{open w}{ub1.180}
     \tnwire{u2.0}{open e} \tnwire{ub2.0}{open e}

--- a/tests/tenkz/rmp/section-iv-v-app/cases/rmp-iv-intersection-rhs-four.tex
+++ b/tests/tenkz/rmp/section-iv-v-app/cases/rmp-iv-intersection-rhs-four.tex
@@ -10,7 +10,7 @@
 \[
   \begin{tenkz}[rows={wire,wire,wire}, cols=7, bonds=none]
     \tn[at=(1,1), skin=box, wide=3, name=s,
-      ports={270@1:physical, 270@3:physical, 90@1:physical, 90@3:physical}]{S}
+      ports={270@1:physical, 270@3:physical, 90@1:virtual, 90@3:virtual}]{S}
     % R is the signed wide box atom; its word closes through drop junctions
     % into the top face, and the cut interior ends turn upward.
     \tn[at=(2,2), skin=none, name=jw, ports={0:virtual, 270:virtual}]{}

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -82,11 +82,11 @@ status = "faithful"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "3990374fae600d60455883f726f20186432d5f9130b169744b453f45a423a7ad"
+case_sha256 = "b3b1c10f97a58346de946c44d37b0ad0be40f3ed624061f7c477c2051907e13d"
 second_viewer = "fable-w1a-recheck-2026-08-05-400dpi"
-reviewed = "2026-08-05"
-renderer = "fable-w1a-vision-review-2026-08-05-200dpi"
-note = "X and X^-1 match at one reference width by the kernel size class. As in the source, each capsule absorbs the doubling: one virtual rail is open on each outer side, the doubled rail runs only between the capsules and the A pair, and the boundary matches O's four indices outright, so no tenkzeq check off is needed. The single outer rail leaves each capsule at the upper wire-row rather than mid-height (house port placement)."
+reviewed = "2026-08-06"
+renderer = "claude-issue-5577-typing-audit-2026-08-06-200dpi"
+note = "Issue #5577: the A-Abar bond retyped virtual to physical (A.270, Ac.90). In O = X^-1 (sum_k A^k tensor conj(A^k)) X the summed index k is the purifying site index the ket tensor shares with its conjugate, not a network bond: the author draws one continuous vertical from y=0.7 to y=-0.7 through A at y=0.3 and Abar at y=-0.3, cut into three visible segments by the two white tensor boxes, while A's and Abar's virtual legs are the horizontals running into the X^-1 and X capsules (ImagesReview Section II.tex lines 323-334). Typing the middle segment virtual made one stroke change type mid-line, since A.90 and Ac.270 were already physical. The workbench rendering of the same author block, rmp-workbench-ii-positive-mpo-old, already types this bond physical. Render at 200dpi is pixel-identical, since a connected physical leg strokes as a bond. Prior note: X and X^-1 match at one reference width by the kernel size class. As in the source, each capsule absorbs the doubling: one virtual rail is open on each outer side, the doubled rail runs only between the capsules and the A pair, and the boundary matches O's four indices outright, so no tenkzeq check off is needed. The single outer rail leaves each capsule at the upper wire-row rather than mid-height (house port placement)."
 
 [[verdict]]
 id = "rmp-ii-mpu-unitarity"
@@ -106,11 +106,11 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = ["placement-illegible"]
-case_sha256 = "afdac2f68d36447256f0af03c05dbd35d7f7e321494f96f549c7659ba6356301"
-reviewed = "2026-08-05"
-renderer = "fable-w1a-vision-review-2026-08-05-300dpi"
+case_sha256 = "e87a92370efda1d09990e047e84dbc0b55f0e011c7012c62b396f6fdd6efcb04"
+reviewed = "2026-08-06"
+renderer = "claude-issue-5577-typing-audit-2026-08-06-200dpi"
 second_viewer = "fable-w1a-recheck-2026-08-05-400dpi"
-note = "The model matches the author panel: the 2x2 blocked sandwich, two disjoint RHS factors, the a/b beads anchored to hull-routed side closures (route={e of ...}/{w of ...}), and the conjugate row's overline. The residue is K1: the renderer does not yet ink a hull route on an endpoint index wire, so each closure currently draws along its column axis over the U-Ubar bond instead of arcing off the east/west faces the contract names (LANGUAGE-1.0 s5, bend= retirement row); the grid-tier predecessor inked this closure correctly through its side-cup policy."
+note = "Issue #5577: the four U-Ubar column bonds retyped virtual to physical (u1.270, ub1.90, u2.270, ub2.90 on both panels). The author draws each column as one continuous vertical stroke from y=0.7 to y=-0.7 through U at y=0.3 and Ubar at y=-0.3, with the virtual rails as the horizontals at y=+/-0.3 (ImagesReview Section II.tex lines 405-412); the segment between the two tensors is therefore the summed site index, and typing it virtual while its two open ends were already physical made one stroke change type mid-line. The (a1) panel the figure factors sets the same sandwich equal to a bare vertical line, which only reads as the identity on the physical space. Sibling conventions: rmp-ii-mpu-unitarity pairs the same U-Ubar site index through the grid dialect's op/op rows, and rmp-ii-ortho-left/right type a contracted physical index 270:physical to 90:physical. Render at 200dpi is pixel-identical, since a connected physical leg strokes as a bond. Prior note: The model matches the author panel: the 2x2 blocked sandwich, two disjoint RHS factors, the a/b beads anchored to hull-routed side closures (route={e of ...}/{w of ...}), and the conjugate row's overline. The residue is K1: the renderer does not yet ink a hull route on an endpoint index wire, so each closure currently draws along its column axis over the U-Ubar bond instead of arcing off the east/west faces the contract names (LANGUAGE-1.0 s5, bend= retirement row); the grid-tier predecessor inked this closure correctly through its side-cup policy."
 
 [[verdict]]
 id = "rmp-ii-mpu-splitting"
@@ -978,11 +978,11 @@ status = "faithful"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "f408020089fbddfda5105f2f0f8b3edbf7c31e43441b0dfb4a65a14eeaa3caed"
-reviewed = "2026-08-05"
-renderer = "fable-w4-section-iv-migration-2026-08-05-200dpi"
+case_sha256 = "4430ce358248ab88a5bd924ed5b6054eddedaa19efa7d8b1ca6141bc5728046e"
+reviewed = "2026-08-06"
+renderer = "claude-issue-5577-typing-audit-2026-08-06-200dpi"
 second_viewer = "fable-w4-second-pass-2026-08-05-400dpi"
-note = "kernel migration: R is respelled from the 0.7 pill to the signed wide box atom (LANGUAGE-1.0 s14); S consumes R's escaped leg and B's leg through straight drops, the cut ends turn upward between B and C, and no spurious crossing appears. S's outputs sit at its top-face stations where the source raises them from the box corners (house form). Confirmed on a second 400dpi pass."
+note = "Issue #5577: S's two outputs retyped physical to virtual (90@1, 90@3). S inverts the jointly injective pair A, B, so it consumes two site indices and returns the two virtual bond ends; the author draws those ends as one open U raised from the box corners (ImagesReview Section IV.tex line 131), the same open U the equation's left panel draws as its free identity wire and types virtual on both ends (rmp-iv-intersection-lhs-four). The two panels' boundary signatures settle it: the left panel exposes open:n open:n open:n open:n phys:n, and the right panel matched that only after the retyping, having exposed open:n open:n phys:n phys:n phys:n before. Unlike a contracted index, an open port's leg reach follows its type, so the render moves: S's two upward stubs shorten from physical-leg to stub reach and nothing else changes. Prior note: kernel migration: R is respelled from the 0.7 pill to the signed wide box atom (LANGUAGE-1.0 s14); S consumes R's escaped leg and B's leg through straight drops, the cut ends turn upward between B and C, and no spurious crossing appears. S's outputs sit at its top-face stations where the source raises them from the box corners (house form). Confirmed on a second 400dpi pass."
 
 [[verdict]]
 id = "rmp-iv-intersection-lhs-five"


### PR DESCRIPTION
## Tally

All **130** targets compiled and their record streams read; the **43** targets LionSR/tenkz#175 names (28 recording a contracted physical index, 15 reverse candidates) were read case-by-case against their manifest formula, their boundary line, and the author source. **Zero remain unaudited.**

| | |
|---|---|
| Targets whose streams were read | 130 |
| Targets read against the author source | 43 |
| Contracted indices classified | 1389 (73 physical, 1316 virtual after the fixes) |
| Recorded physical contractions found correct | 60 of 63 |
| Corrections applied | 3 |
| Defects found but not correctable as a retyping | 3 targets, 30 wires, filed as follow-ups |
| Undecidable | 0 |

The surface is slightly larger than LionSR/tenkz#175 states. **29** targets record a contracted physical index, not 28: `rmp-ii-mpu-unitarity` records one too, as a grid-dialect `pairleg`, which a `port-type=` grep cannot see. And only **3** targets in the corpus carry a non-kernel picture, not 5 — see "The dialect gap" below.

## Corrections

### 1. `rmp-ii-mpu-blocking` — 4 contracted site indices, virtual to physical

`u1.270`/`ub1.90` and `u2.270`/`ub2.90`, on both panels.

The author draws each column of the blocked sandwich as **one continuous vertical stroke** from y=0.7 to y=-0.7, passing through `U` at y=+0.3 and `Ubar` at y=-0.3, with the virtual rails as the horizontals at y=+/-0.3 (`ImagesReview Section II.tex` lines 405-412). The two open ends of that stroke were already typed physical, so typing the middle segment virtual made one stroke change type mid-line. The (a1) panel this figure factors sets the same sandwich equal to a bare vertical line, which only reads as the identity on the *physical* space.

Sibling conventions: `rmp-ii-mpu-unitarity` contracts the same U-Ubar site index through the grid dialect's `op/op` pairing, and `rmp-ii-ortho-left`/`-right` type a contracted physical index `270:physical` to `90:physical`.

**Render at 200 dpi is pixel-identical** (sha256 `91a118d3...46375` before and after).

### 2. `rmp-ii-local-purification` — 1 contracted site index, virtual to physical

`A.270`/`Ac.90`.

In `O = X^-1 (sum_k A^k tensor conj(A^k)) X` the summed index `k` is the purifying site index the ket tensor shares with its conjugate, not a network bond. The author again draws one continuous vertical from y=0.7 to y=-0.7 through `A` and `Abar`, cut into three visible segments by the two white tensor boxes, while `A`'s and `Abar`'s virtual legs are the horizontals running into the `X^-1` and `X` capsules (`ImagesReview Section II.tex` lines 323-334). Same mid-line type change as above.

Decisive sibling: `rmp-workbench-ii-positive-mpo-old` renders the *same author block* and already types this bond physical.

**Render at 200 dpi is pixel-identical** (sha256 `0324f9ac...2479d` before and after).

### 3. `rmp-iv-intersection-rhs-four` — 2 open ports, physical to virtual

`S`'s `90@1` and `90@3`.

`S` inverts the jointly injective pair `A, B` (paper line 2069), so it *consumes* two site indices and *returns* the two recovered virtual bond ends. The author draws those ends as one open U raised from the box corners (`ImagesReview Section IV.tex` line 131) — the same open U the equation's left panel draws as its free identity wire and types virtual on both ends (`rmp-iv-intersection-lhs-four`).

The two panels' boundary signatures settle it:

```
lhs-four            open:n, open:n, open:n, open:n, phys:n
rhs-four (before)   open:n, open:n, phys:n, phys:n, phys:n
rhs-four (after)    open:n, open:n, open:n, open:n, phys:n
```

The two sides of one equation exposed different index types before the retyping.

This is the one correction on **open** ports rather than a contracted index, and an open port's leg reach follows its type, so the render does move: `S`'s two upward stubs shorten from physical-leg reach to stub reach. Nothing else in the drawing changes. Because the drawing moved, the verdict's `renderer` is re-stamped; the `second_viewer` entry is the earlier `fable-w4-second-pass` and should be refreshed on the next sweep.

## Defects found that a retyping cannot fix

Filed as follow-ups rather than patched here, because each needs a re-model or a kernel affordance, not a port edit.

**`rmp-iii-b-braid-one`, `rmp-iii-b-braid-three` — 4 wires.** Both declare `physical=updown` on a `rows={wire,wire}, cols=2` frame, which turns the grid's *vertical inter-row bonds* into contracted physical indices (`bond-1-1-2-1`, `bond-1-2-2-2`) while the horizontal ones stay virtual. The author draws all four lines of the 2x2 patch inside one lattice plane — `\begin{scope}[canvas is xz plane at y=0]` then two lines along x and two along z (`ImagesReview Section III.tex` lines 805-809 and 864-868) — so both families are PEPS virtual bonds; the physical legs are the four out-of-plane stubs `-- (x,0.2,z)` at lines 815-820 and 882-888, which the case does not draw at all. The author figure therefore has *zero* contracted physical indices.

There is no local fix: in the flat frame the vertical axis **is** the physical axis by language design, so a virtual inter-row link cannot be spelled there. Dropping `physical=updown` compiles for braid-three but deletes the four open lattice legs from the model, and fails outright for braid-one, whose string crossing is addressed as `leg n of (1,1)`. The right model is the plane frame with `lattice={2x2}`, the idiom `rmp-iii-b-anyon-pair` already uses — a re-model that moves the render and needs its own pairing sweep.

**`rmp-ii-peps-marginal` — 4 wires; `rmp-iii-b-condensation` — 24 wires.** Both close ket-bra site pairs across a plane bilayer with member-addressed wires, `\tnwire{(r,c,1)}{(r,c,2)}`. Those cannot be typed physical as written: the kernel types a wire physical only when both ends resolve to `kind=port` nodes, and the port address production requires a *named* record, so a bare `(r,c,k)` member address is unconditionally virtual. `rmp-iii-b-condensation`'s own manifest boundary already claims "all 24 inter-sheet physical pairs are contracted", and the author's `tm` pic draws the joining segment between the two sheet beads explicitly (`ImagesReview Section III.tex` lines 85-92). Closing this needs either names and port declarations on all 48 members or a transverse closure for the bilayer basis.

## The dialect gap is narrower than LionSR/tenkz#175 assumed

Only **3** targets in the corpus carry a non-kernel picture — `rmp-ii-mpu-unitarity`, `rmp-ii-tangent-projector`, `rmp-workbench-ii-projector-on-pta` — and all three are auditable today, so none was migrated and none is left unaudited.

The grid dialect does not declare a type per wire because it does not have one to declare: the type is fixed by the grammar, and the record kind names it. `pairleg`, `pairtrace` and `phtrace` are site contractions; `bond`, `cup` and `trace` run along the network. The author's choice is still visible — `rows={ket,bra}` pairs the facing site legs and emits `pairleg`, `rows={ket:nopair, bra}` suppresses it — and that is exactly what the audit reads:

- `rmp-ii-mpu-unitarity`: one `pairleg` at the `op/op` interface. Correct — the author's single vertical passes through `U` at y=+0.3 and `Ubar` at y=-0.3, so the segment between them is the site contraction and the segments to +/-0.7 are open (`ImagesReview Section II.tex` lines 395-404).
- `rmp-ii-tangent-projector`, `rmp-workbench-ii-projector-on-pta`: pairing suppressed at every interface. Correct — `P_T(A)` is an operator on the many-body Hilbert space, so the ket row's legs point up and the bra row's point down and nothing joins them; what closes ket to bra is the *thick* bracket on the auxiliary rails (`ImagesReview Section II.tex` line 220), a virtual cup.

Emitting `port-type=` from the dialect renderers would still be a tidy uniformity, but it is not needed to audit these three.

## Two counting artifacts worth knowing

Neither is a mistyping, but both inflate the recorded physical-contraction count and would mislead a census built on it:

- `rmp-iii-a-mpo-tensor` (2), `rmp-iii-a-peps-tensor` (3), `rmp-iii-a-pentagon-mixed` (6): these legs terminate at glyphless `skin=none` label markers, so the stream records them as contractions although the mathematics — and each manifest boundary line, and the empty `kernel-boundary` signature on the pentagon panels — calls them open. The typing itself is correct and follows the paper's C/D split, restored to physical in LionSR/tenkz#133.
- `rmp-ii-ortho-left` line 13 calls the west-cup-contracted index "beta"; the author labels it alpha (`ImagesReview Section II.tex` line 195), and the case's own RHS comment correctly names the open pair (beta, beta'). Comment-only, left alone to keep this change to typing.

## The repeatable check

`scripts/tenkz_contracted_types.py` compiles each target and reports its contracted indices by type and by the construct that made each one:

```
$ python3 scripts/tenkz_contracted_types.py --all --physical-only
rmp-ii-mps-marginal        lang=kernel       physical=2  virtual=12  via tnwire=2
rmp-ii-mpu-unitarity       lang=grid+kernel  physical=1  virtual=2   via pairleg=1
rmp-ii-zcl-mpdo            lang=kernel       physical=3  virtual=1   via trace=3
rmp-iii-b-braid-one        lang=kernel       physical=2  virtual=2   via grid=2
...
130 targets; 31 record a contracted physical index, 29 contract both types;
73 physical and 1316 virtual contractions.
```

It covers both picture languages and takes `--build-dir` to reuse a compiled tree, so re-running it after a migration wave is cheap. `docs/tenkz/COSMETIC-GAP-BAR.md` now names it where it states the house rule.

## Validation

- `python3 scripts/tenkz_rmp.py check --all` — PASS, 130 targets; faithful 90, cosmetic-gap 40, structural-gap 0, unfaithful 0, blocked 0
- `python3 scripts/test_tenkz_corpus_provenance.py` — PASS
- `python3 scripts/test_tenkz_shrink.py` — 32 PASS
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — PASS, census stable at 201

No meter moved, so no `SHRINK.md` session entry and no `tests/tenkz/census-baseline.json` regeneration.

Closes LionSR/tenkz#175
