### PR TITLE
fix(tenkz/kernel): type an intra-cell layer pairing from the pairing

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -421,6 +421,19 @@ not identify a member. A bilayer is consequently one frame with two basis
 members and explicit intra-cell pairing wires; nesting cannot collapse it
 into two unrelated frames.
 
+An intra-cell pairing wire carries a type neither of its ends can state. A
+member address names a lattice place, and a place is not a port. The type
+belongs to the pairing, and the frame already knows which direction is
+physical: on a plane, a wire joining two different members of one cell, both
+of them declared `ket`, `op`, or `bra`, is that site's physical index — the
+ket-bra pairing that a partial trace or a double-layer expectation value sums
+over. It is recorded physical and strokes as the bond it already was. A `wire`
+member carries a virtual index beside the bond and pairs with nothing, and the
+same closure on a flat frame stays virtual, because only a plane declares the
+transverse physical axis such a pairing follows. The rule reads a closed
+pairing off the frame and the two row kinds exactly as `open up|down` reads an
+open transverse leg off its direction word.
+
 An authored atom at `(r,c,k)` replaces that member. An authored atom at
 `(r,c)` replaces the whole populated cell, so every member address in that
 cell resolves to the authored record rather than creating coincident
@@ -451,6 +464,8 @@ Consumers, circle pitch: `rmp-ii-triangle-network`, `rmp-iii-a-ground-space-1d`,
 `rmp-ii-idempotent`, `rmp-workbench-iii-eq51`.
 Consumers, basis: `rmp-workbench-iii-cluster-state`, `rmp-app-czx-state`,
 `rmp-iii-a-ghz-state`, `rmp-iii-b-condensation`.
+Consumers, transverse pairing: `rmp-ii-peps-marginal`,
+`rmp-iii-b-condensation`.
 
 ## 5. Wires
 
@@ -465,7 +480,9 @@ stroke. Those two strokes are one ink once both ends are consumed: a contracted
 index carries its type in the record and not in its line, so no render tells a
 physical contraction from a virtual one. Type reaches the page only on an open
 leg, whose stub answers to it, and reaches a reviewer only through the record
-stream and the boundary signature.
+stream and the boundary signature. Two ends that state no type still leave one
+contraction typed: the pairing between two layers of one stacked site, which
+Section 4 types from the frame and the two row kinds rather than from its ends.
 `kind=pairing` is a declared skin's curved own-port route: it belongs to one
 host, remains addressable by arclength, and its declared list order controls
 the over-glyph ink and supplies the crossing order between pairings of that

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -709,6 +709,21 @@ grep -Eq '^mark.*[|]members=atom-[0-9]+([|]|$)' \
   echo "FAIL: a three-coordinate address did not select one basis member" >&2
   exit 1
 }
+# The transverse pairing rule types a closure between two layers of one
+# stacked site, and types nothing else: not an inter-cell bond, not the same
+# closure on a frame with no transverse axis, and not a `wire' carrier.
+grep -Fq '|name=pair|port-type=physical|' \
+    "$WORK/r_transverse_pairing.tnlog" || {
+  echo "FAIL: the ket-bra pairing of one plane cell was not typed physical" >&2
+  exit 1
+}
+for wire in inter flatpair carrier; do
+  if grep -F "|name=$wire|" "$WORK/r_transverse_pairing.tnlog" \
+      | grep -Fq 'port-type=physical'; then
+    echo "FAIL: wire '$wire' is not a transverse pairing but was typed physical" >&2
+    exit 1
+  fi
+done
 basis_override_atoms=$(grep -c '^atom|' "$WORK/r_basis_override.tnlog" || true)
 [ "$basis_override_atoms" -eq 2 ] || {
   echo "FAIL: an authored basis member did not override population" >&2

--- a/tests/tenkz/kernel/regression/r_transverse_pairing.tex
+++ b/tests/tenkz/kernel/regression/r_transverse_pairing.tex
@@ -1,0 +1,27 @@
+%% Regression: a wire joining two layers of one stacked site is that site's
+%% physical index, typed from the pairing because a member address is a
+%% lattice place and a place is not a port.  The rule holds only where the
+%% frame declares a transverse physical axis and only between the layer row
+%% kinds; an inter-cell wire, a flat frame, and a `wire' carrier stay virtual.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+% ket-bra pairing on a plane: physical.  The east neighbour on one sheet is
+% an ordinary bond, so the rule reads the cell and not merely the members.
+\begin{tenkz}[lattice={1x2}, planes, bonds=none]
+  \tnwire[name=pair]{(1,1,1)}{(1,1,2)}
+  \tnwire[name=inter]{(1,1,1)}{(1,2,1)}
+\end{tenkz}
+% the same closure on a flat frame: no transverse axis, so virtual
+\begin{tenkz}[lattice={1x1}, bonds=none,
+    frame={flat, basis={ket at (0,0), bra at (2,2)}}]
+  \tnwire[name=flatpair]{(1,1,1)}{(1,1,2)}
+\end{tenkz}
+% a `wire' member carries a virtual index beside the bond and stacks with
+% nothing, so its closure to the ket layer stays virtual
+\begin{tenkz}[lattice={1x1}, bonds=none,
+    frame={plane, basis={ket at (0,0), wire at (2,2)}}]
+  \tnwire[name=carrier]{(1,1,1)}{(1,1,2)}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -51,7 +51,7 @@ case_sha256 = "71ab001a3b8d2bfeb7a8f9aa02fdcc8002d048a6627faf0d1517a94917ad6517"
 reviewed = "2026-08-05"
 renderer = "fable-w5-vision-2026-08-05-200dpi"
 second_viewer = "fable-w5-second-pass-2026-08-05-400dpi"
-note = "Kernel migration under #5507: the doubled sheet is the contract bilayer basis, the kept sites keep their open transverse ket-bra legs, and the traced fourth column closes site by site, matching the author panel index for index; the recorded trace-loop overshoot is gone. Residue: the contract bilayer offset overlaps the ket and bra sheets where the source separates them vertically, so the closing loops read as compact east wraps rather than the source long connectors."
+note = "Kernel migration under #5507: the doubled sheet is the contract bilayer basis, the kept sites keep their open transverse ket-bra legs, and the traced fourth column closes site by site, matching the author panel index for index; the recorded trace-loop overshoot is gone. Residue: the contract bilayer offset overlaps the ket and bra sheets where the source separates them vertically, so the closing loops read as compact east wraps rather than the source long connectors. Under #5582 the four traced ket-bra closures are recorded physical by the transverse pairing rule; the case bytes and the boundary signature are unchanged and the 200 dpi raster is byte-identical to the pre-retyping build."
 
 [[verdict]]
 id = "rmp-ii-mpo-sheet"
@@ -864,7 +864,7 @@ defects = []
 case_sha256 = "1344b6356d4b7a8d4b26860e68d7286603d24429c7de64beca30f819a94f0a10"
 reviewed = "2026-08-05"
 renderer = "fable-doubled-plane-migration-review-2026-08-05-200dpi"
-note = "the kernel plane bilayer keeps both 6x4 sheets, all 40 perimeter openings, all 24 inter-sheet contractions, and both marked strings, whose six interior marks are now portless affine beads dressing the crossed bonds; residues: the string bows between beads where the source runs taut, and the contract bilayer basis ties each sheet pair along the in-plane diagonal rather than the source's vertical drop"
+note = "the kernel plane bilayer keeps both 6x4 sheets, all 40 perimeter openings, all 24 inter-sheet contractions, and both marked strings, whose six interior marks are now portless affine beads dressing the crossed bonds; residues: the string bows between beads where the source runs taut, and the contract bilayer basis ties each sheet pair along the in-plane diagonal rather than the source's vertical drop. Under #5582 the 24 inter-sheet pairs are recorded physical by the transverse pairing rule, matching the author's tm pic, which joins the two sheet beads at every site; the case bytes and the boundary signature are unchanged and the 200 dpi raster is byte-identical to the pre-retyping build"
 
 [[verdict]]
 id = "rmp-iv-ground-space-1d"

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -4669,6 +4669,88 @@
       }
   }
 
+% A doubled or sandwiched site stacks its layers as basis members of one
+% cell, and the index joining two of those layers is that site's own physical
+% index: the ket-bra pairing a partial trace or a double-layer expectation
+% value sums over.  That type belongs to the pairing rather than to either
+% end -- a member address names a lattice place, and a place is not a port --
+% so the kernel reads it off the two members' declared row kinds, exactly as
+% `open up|down' reads a transverse open leg off its direction word.  Only a
+% plane frame declares the transverse physical axis such a pairing follows;
+% only the layer kinds ket, op and bra stack along that axis, a `wire' member
+% carrying a virtual index beside the bond instead.
+\bool_new:N \l__tenkz_kernel_transverse_pair_bool
+\int_new:N  \l__tenkz_kernel_transverse_layer_int
+\tl_new:N   \l__tenkz_kernel_transverse_from_tl
+\tl_new:N   \l__tenkz_kernel_transverse_to_tl
+\tl_new:N   \l__tenkz_kernel_transverse_kind_tl
+\cs_new:Npn \__tenkz_kernel_transverse_cell:n #1
+  {
+    \__tenkz_kernel_node_item:nn {#1} {kind} /
+    \__tenkz_kernel_node_item:nn {#1} {row} /
+    \__tenkz_kernel_node_item:nn {#1} {col}
+  }
+\cs_new_protected:Npn \__tenkz_kernel_transverse_layer:n #1
+  {
+    \prop_get:NeN \l__tenkz_kernel_basis_kind_prop {#1}
+      \l__tenkz_kernel_transverse_kind_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_transverse_kind_tl
+      {
+        \clist_if_in:nVT {ket,op,bra}
+          \l__tenkz_kernel_transverse_kind_tl
+          { \int_incr:N \l__tenkz_kernel_transverse_layer_int }
+      }
+  }
+\cs_generate_variant:Nn \__tenkz_kernel_transverse_layer:n { e }
+\cs_new_protected:Npn \__tenkz_kernel_transverse_pair_test:nn #1#2
+  {
+    \str_if_eq:eeT
+      { \__tenkz_kernel_node_item:nn {#1} {kind} } {member}
+      {
+        \str_if_eq:eeT
+          { \__tenkz_kernel_transverse_cell:n {#1} }
+          { \__tenkz_kernel_transverse_cell:n {#2} }
+          {
+            \str_if_eq:eeF
+              { \__tenkz_kernel_node_item:nn {#1} {member} }
+              { \__tenkz_kernel_node_item:nn {#2} {member} }
+              {
+                \int_zero:N \l__tenkz_kernel_transverse_layer_int
+                \__tenkz_kernel_transverse_layer:e
+                  { \__tenkz_kernel_node_item:nn {#1} {member} }
+                \__tenkz_kernel_transverse_layer:e
+                  { \__tenkz_kernel_node_item:nn {#2} {member} }
+                \int_compare:nNnT
+                  { \l__tenkz_kernel_transverse_layer_int } = {2}
+                  { \bool_set_true:N \l__tenkz_kernel_transverse_pair_bool }
+              }
+          }
+      }
+  }
+\cs_generate_variant:Nn \__tenkz_kernel_transverse_pair_test:nn { VV }
+\cs_new_protected:Npn \__tenkz_kernel_transverse_pair_type:n #1
+  {
+    \bool_set_false:N \l__tenkz_kernel_transverse_pair_bool
+    \str_if_eq:eeT { \__tenkz_kernel_r_frame_word: } {plane}
+      {
+        \__tenkz_model_get:nnN {#1} {from}
+          \l__tenkz_kernel_transverse_from_tl
+        \__tenkz_model_get:nnN {#1} {to}
+          \l__tenkz_kernel_transverse_to_tl
+        \quark_if_no_value:NF \l__tenkz_kernel_transverse_from_tl
+          {
+            \quark_if_no_value:NF \l__tenkz_kernel_transverse_to_tl
+              {
+                \__tenkz_kernel_transverse_pair_test:VV
+                  \l__tenkz_kernel_transverse_from_tl
+                  \l__tenkz_kernel_transverse_to_tl
+              }
+          }
+      }
+    \bool_if:NT \l__tenkz_kernel_transverse_pair_bool
+      { \__tenkz_kernel_port_wire_physical:n {#1} }
+  }
+
 \cs_new_protected:Npn \__tenkz_kernel_port_wire_type_validate:n #1
   {
     \__tenkz_model_get:nnN {#1} {kind} \l__tenkz_kernel_port_type_tl
@@ -4748,8 +4830,13 @@
     \int_zero:N \l__tenkz_kernel_port_open_int
     \__tenkz_model_map_ids:nn {atom}
       { \__tenkz_kernel_port_open_atom:n {##1} }
+    % Port typing first, then the one closure ports cannot speak for: the
+    % transverse pairing between two layers of one stacked site.
     \__tenkz_model_map_ids:nn {wire}
-      { \__tenkz_kernel_port_wire_type_validate:n {##1} }
+      {
+        \__tenkz_kernel_port_wire_type_validate:n {##1}
+        \__tenkz_kernel_transverse_pair_type:n {##1}
+      }
   }
 
 % ---------- render: records make ink ---------------------------------------------------------


### PR DESCRIPTION
## Mechanism

The kernel typed a wire physical only when both ends resolved to a node of
`kind=port`, and the port address production requires a named record. A member
address `(r,c,k)` is `kind=member`, so a member-to-member wire was virtual
unconditionally — the mathematics could not reach the record.

The type does not belong to either end. A member address names a lattice place,
and a place is not a port. It belongs to the **pairing**, and the frame already
knows which direction is physical. On a plane frame, a wire joining two
different members of one cell, both declared `ket`, `op`, or `bra`, is that
site's own physical index: the ket-bra pairing that a partial trace or a
double-layer expectation value sums over. `\__tenkz_kernel_transverse_pair_type:n`
reads that off the frame word and the two declared row kinds, and runs after
port typing in the same wire pass — exactly as `open up|down` reads an open
transverse leg off its direction word.

The rule types nothing else. An inter-cell wire is an ordinary bond; a `wire`
basis member carries a virtual index beside the bond and stacks with nothing;
and the same closure on a flat frame stays virtual, because only a plane
declares the transverse physical axis such a pairing follows. All four cases
are pinned by the new regression
`tests/tenkz/kernel/regression/r_transverse_pairing.tex`.

The author sources confirm the mathematics rather than contradict it:
`ImagesReview Section III.tex` lines 85-92 define the `tm` pic as two sheet
beads joined by a segment, and lines 925-953 place that pic at every one of the
24 sites of the condensation bilayer. `rmp-iii-b-condensation`'s own manifest
boundary line already read "all 24 inter-sheet physical pairs are contracted".

`physical leg` is an alias of `bond` in `tenkz-core.code.tex`, so a contracted
physical index strokes as the bond it already was. The boundary signature reads
only open ends and port-open origins, so it does not move either.

## Consumer verdicts

Both survive with no re-pin: the case bytes are unchanged, so `case_sha256`
stands. Each note now records the retyping and its evidence.

| target | verdict | 200 dpi raster vs `origin/main` | stream diff |
|---|---|---|---|
| `rmp-ii-peps-marginal` | `cosmetic-gap`, pairing verified — unchanged | byte-identical | 4 lines, each gaining `port-type=physical` |
| `rmp-iii-b-condensation` | `cosmetic-gap`, pairing verified — unchanged | byte-identical | 24 lines, each gaining `port-type=physical` |

Both sides rendered in one session from a detached worktree at `origin/main`;
the only stream change on either target is the added `port-type=physical` field
on exactly those 28 wires.

## Audit counts (`scripts/tenkz_contracted_types.py`)

| | before | after |
|---|---|---|
| `rmp-ii-peps-marginal` | physical 0, virtual 76 | **physical 4**, virtual 72 |
| `rmp-iii-b-condensation` | physical 0, virtual 102 | **physical 24**, virtual 78 |
| corpus totals | 73 physical, 1316 virtual; 31 targets record a physical contraction | **101 physical**, 1288 virtual; **33 targets** |

The 28 closures the audit of LionSR/tenkz#175 could not verify now read physical.

## Validation

```
bash scripts/tenkz_kernel_probes.sh
  PASS: 125 review regressions hold          (124 + the one intentional addition)
  PASS: 10 sugar spellings byte-identical to their expansions
  PASS: 12 kernel record streams byte-identical
  PASS: kernel pixels byte-identical
bash scripts/tenkz_golden.sh --check
  PASS: 264 event streams byte-identical to the golden baseline
python3 scripts/test_tenkz_kernel_audit.py
  tenkz-kernel-audit: parser, crossings, boundaries, and geometry passed
python3 scripts/tenkz_rmp.py check --all
  PASS: validated, compiled, linted, and audited 130 RMP target(s)
  Verdicts: unreviewed 0 | faithful 90 | cosmetic-gap 40 | structural-gap 0 | unfaithful 0 | blocked 0
  Pairing:  verified 120 | context-only 10
python3 scripts/tenkz_contracted_types.py --all
  130 targets; 33 record a contracted physical index, 31 contract both types;
  101 physical and 1288 virtual contractions.
python3 scripts/test_tenkz_corpus_provenance.py
  PASS: tenkz provenance source-name invariant
python3 scripts/test_tenkz_shrink.py
  33 PASS
python3 scripts/test_tenkz_language.py
  PASS: registry, typed atom diagnostic, and alias event equivalence
python3 scripts/tenkz_manual_doctest.py
  PASS: 14 displayed manual examples and 25 reference examples
python3 scripts/tenkz_shrink.py gate --base-ref origin/main
  tenkz-shrink: PASS: census stable at 201 and all 150 flag(s) carry verdicts
```

No production and no key were added, so the parser census does not move: the
meters are byte-identical to `tests/tenkz/census-baseline.json`. No
Extension-gate issue, no registry row, no SHRINK.md entry, no baseline bump.

The contract records the rule in `docs/tenkz/LANGUAGE-1.0.md` §4 (the bilayer
paragraph, with its consumers) and cross-references it from §5's typing
paragraph.

Closes LionSR/tenkz#177
