### PR TITLE
doc(tenkz): the kernel side default is none, and the registry now says so

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -75,7 +75,7 @@ declared. The generated reference prints this test beside every row.
 | `rows=` | row-list | — | `{wire}` | picture | `TKZ-PIC-*` |
 | `cols=` | integer | — | 3 | picture | `TKZ-PIC-*` |
 | `frame=` | frame-spec | `flat` `plane` `circle`; a picture-level `flat` or `plane` may carry `basis=` | `flat` | picture, group, atom | `TKZ-FRAME-*` |
-| `west=` `east=` `north=` `south=` | small-enum | `open` `none` `trace` `cup` | `open` | picture | `TKZ-SIDE-*` |
+| `west=` `east=` `north=` `south=` | small-enum | `open` `none` `trace` `cup` | `none` | picture | `TKZ-SIDE-*` |
 | `trace=` | trace-spec | selector or `physical` | empty | picture | `TKZ-SELECT-*` |
 | `open=` | selector | — | empty | picture | `TKZ-SELECT-*` |
 | `bonds=` | small-enum | `grid` `none` | `grid` | picture | `TKZ-PIC-*` |
@@ -334,6 +334,18 @@ with `[TKZ-CIRCLE-OPEN-DIRECTION]` until a station-local or geodesic diagonal
 construction is part of the language. There are no placeholder atoms.
 <!-- Consumers of the open-end policy: every former tenkzfree body; e.g.
      rmp-ii-triangle-network, rmp-ii-mpo-sheet, rmp-iii-b-braid-one. -->
+
+A side that exposes indices says so. The four side words default to `none`,
+so a picture that states no policy draws no side leg and carries the empty
+boundary signature on those sides; `west=open`, or `boundary=open` for the
+pair, is what mints the legs and puts them in the signature. This follows
+from open ink being declared content (§13): the frame's grid is a coordinate
+system that places atoms, not a claim that every rim cell owns a dangling
+index, and a circuit or a single-atom picture would collect nonsense legs
+under any other reading. `none` is the explicit spelling of the default and
+changes nothing in a kernel picture; it seals in the grid dialect, whose
+pictures do draw their west and east stubs unbidden, and that difference is
+the one place the two languages disagree about a default.
 
 ## 4. Frames
 
@@ -1076,3 +1088,15 @@ confirmation at L1 acceptance:
    is one exchange of net zero, and it is spelled in §2.5 above. It costs no
    key either way, so the registry books it in the change that adds the
    parser row rather than in two halves.
+6. **The kernel side default is `none` — corrected 2026-08-06.** The key
+   table above and the four `kernel-picture` registry rows read `open`,
+   which was the 0.7 default copied into the kernel tier by hand: a grid
+   picture does draw its west and east stubs unbidden and seals them with
+   `boundary=none`, and neither is true under `\tenkzkernel`. Honouring the
+   printed `open` was measured across the 130 benchmark targets and rejected:
+   thirty stop compiling on a doubly consumed boundary port, forty-three grow
+   legs, and forty move their boundary signature. The reading the contract
+   supports is the one the kernel already implements — open ink is declared
+   content (§13), so a side that exposes indices says so. The registry rows,
+   the key table, and §3 now say that, and `none` is the explicit spelling of
+   the kernel default rather than a seal.

--- a/docs/tenkz/chapters2/ch-worked.tex
+++ b/docs/tenkz/chapters2/ch-worked.tex
@@ -6,12 +6,24 @@ example and add only the policy the mathematics requires.
 
 \subsection{Keep a map open; close a scalar}
 
-The default open boundary is right for a matrix word or an unapplied transfer
-map.  Add \tnkey{boundary=none} only when the formula is a fully contracted
-scalar.  Use \tnkey{boundary=periodic} for a same-row trace.  Use
-\tnkey{west=cup} or \tnkey{east=cup} to connect adjacent layers.  These three
-closures can have the same count of open ends and still mean different
-operations.
+The two surfaces answer an unstated side differently, and the difference is
+worth knowing before the first picture.  In \tnenv{tenkz} and its relatives
+the open boundary is the default: a matrix word or an unapplied transfer map
+draws its west and east stubs unbidden, and \tnkey{boundary=none} is what
+seals them when the formula is a fully contracted scalar.  Under
+\tncmd{tenkzkernel} a side exposes indices only when it says so.  A kernel
+picture that states no side policy draws no side leg and carries the empty
+boundary signature on those sides, so a map keeps its ends by writing
+\tnkey{boundary=open} -- or \tnkey{west=open} for one side alone -- and
+\tnkey{boundary=none} is the explicit spelling of what the picture already
+does.  A kernel frame's grid places atoms; it does not claim that every rim
+cell owns a dangling index, which is why a circuit pyramid or a single
+four-legged junction collects no legs it did not ask for.
+
+Both surfaces agree on the rest of the alphabet.  Use
+\tnkey{boundary=periodic} for a same-row trace.  Use \tnkey{west=cup} or
+\tnkey{east=cup} to connect adjacent layers.  These closures can have the
+same count of open ends and still mean different operations.
 
 \subsection{Stack ket, operator, and bra}
 

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -183,10 +183,10 @@ kernel-\allowbreak{}picture & \texttt{rows} & row-\allowbreak{}list & {wire} & C
 kernel-\allowbreak{}picture & \texttt{cols} & positive-\allowbreak{}integer & 3 & Cells \allowbreak{}per \allowbreak{}row. \\
 kernel-\allowbreak{}picture & \texttt{frame} & frame-\allowbreak{}spec & flat & Closed \allowbreak{}flat,\allowbreak{} \allowbreak{}plane,\allowbreak{} \allowbreak{}or \allowbreak{}circle \allowbreak{}frame \allowbreak{}word. \\
 kernel-\allowbreak{}frame & \texttt{basis} & basis-\allowbreak{}spec & origin \allowbreak{}singleton & Ordered \allowbreak{}row-\allowbreak{}kind \allowbreak{}members \allowbreak{}at \allowbreak{}east/north \allowbreak{}quarter-\allowbreak{}pitch \allowbreak{}offsets. \\
-kernel-\allowbreak{}picture & \texttt{west} & side-\allowbreak{}policy & open & West \allowbreak{}side \allowbreak{}policy. \\
-kernel-\allowbreak{}picture & \texttt{east} & side-\allowbreak{}policy & open & East \allowbreak{}side \allowbreak{}policy. \\
-kernel-\allowbreak{}picture & \texttt{north} & side-\allowbreak{}policy & open & North \allowbreak{}side \allowbreak{}policy. \\
-kernel-\allowbreak{}picture & \texttt{south} & side-\allowbreak{}policy & open & South \allowbreak{}side \allowbreak{}policy. \\
+kernel-\allowbreak{}picture & \texttt{west} & side-\allowbreak{}policy & none & West \allowbreak{}side \allowbreak{}policy. \\
+kernel-\allowbreak{}picture & \texttt{east} & side-\allowbreak{}policy & none & East \allowbreak{}side \allowbreak{}policy. \\
+kernel-\allowbreak{}picture & \texttt{north} & side-\allowbreak{}policy & none & North \allowbreak{}side \allowbreak{}policy. \\
+kernel-\allowbreak{}picture & \texttt{south} & side-\allowbreak{}policy & none & South \allowbreak{}side \allowbreak{}policy. \\
 kernel-\allowbreak{}picture & \texttt{trace} & trace-\allowbreak{}spec & empty & Cells \allowbreak{}or \allowbreak{}physical \allowbreak{}ports \allowbreak{}closed \allowbreak{}to \allowbreak{}themselves. \\
 kernel-\allowbreak{}picture & \texttt{open} & cell-\allowbreak{}set & empty & Cells \allowbreak{}opened \allowbreak{}by \allowbreak{}declaration. \\
 kernel-\allowbreak{}picture & \texttt{bonds} & bond-\allowbreak{}policy & grid & Frame-\allowbreak{}generated \allowbreak{}adjacent \allowbreak{}contraction. \\
@@ -194,7 +194,7 @@ kernel-\allowbreak{}picture & \texttt{align} & row & midline & The \allowbreak{}
 kernel-\allowbreak{}picture & \texttt{size} & size-\allowbreak{}class & from \allowbreak{}math \allowbreak{}style & Size \allowbreak{}class \allowbreak{}of \allowbreak{}the \allowbreak{}metric \allowbreak{}context. \\
 kernel-\allowbreak{}picture & \texttt{check} & check-\allowbreak{}spec & signature & The \allowbreak{}tenkzeq \allowbreak{}audit \allowbreak{}specification. \\
 kernel-\allowbreak{}picture & \texttt{sandwich} & flag & false & Ket-\allowbreak{}over-\allowbreak{}bra \allowbreak{}row \allowbreak{}preset. \\
-kernel-\allowbreak{}picture & \texttt{boundary} & enum(\allowbreak{}open\textbar{}\allowbreak{}none\textbar{}\allowbreak{}periodic) & open & All-\allowbreak{}side \allowbreak{}boundary \allowbreak{}word. \\
+kernel-\allowbreak{}picture & \texttt{boundary} & enum(\allowbreak{}open\textbar{}\allowbreak{}none\textbar{}\allowbreak{}periodic) & none & All-\allowbreak{}side \allowbreak{}boundary \allowbreak{}word. \\
 kernel-\allowbreak{}picture & \texttt{lattice} & pair & empty & RxC \allowbreak{}wire-\allowbreak{}row \allowbreak{}lattice \allowbreak{}preset. \\
 kernel-\allowbreak{}picture & \texttt{ring} & integer & empty & Circle-\allowbreak{}frame \allowbreak{}ring \allowbreak{}preset. \\
 kernel-\allowbreak{}picture & \texttt{surface} & identifier & empty & Torus \allowbreak{}closure \allowbreak{}preset. \\

--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -87,8 +87,10 @@
   \qritem{setup}{tnset, species, themes, tndeclareatom}
 
   \qrsection{Boundary facts}
-  \qritem{open}{the default keeps matrix or map indices visible}
-  \qritem{boundary=none}{seals an object}
+  \qritem{boundary=open}{keeps matrix or map indices visible; it is the
+    default outside the kernel and the word a kernel picture writes}
+  \qritem{boundary=none}{seals an object outside the kernel, and spells the
+    kernel default}
   \qritem{boundary=periodic}{returns each row to itself}
   \qritem{west=cup / east=cup}{connects adjacent layers, and outranks
     boundary= on its own side}

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -211,6 +211,24 @@ if grep -Fq '|origin=port-open|' \
   echo "FAIL: explicit open sides left duplicate typed-port stubs" >&2
   exit 1
 fi
+# A kernel side exposes indices only when it says so.  The three chains are
+# the same picture under no side policy, under the explicit spelling of the
+# default, and under the open word; the boundary signatures read in that
+# order and the legs belong to the third alone.
+side_default_signatures=$(grep -F 'kernel-boundary|' \
+  "$WORK/r_side_default_none.tnlog")
+[ "$side_default_signatures" = 'kernel-boundary|signature=
+kernel-boundary|signature=
+kernel-boundary|signature=open:e, open:w' ] || {
+  echo "FAIL: an unstated kernel side stopped agreeing with boundary=none" >&2
+  printf '%s\n' "$side_default_signatures" >&2
+  exit 1
+}
+[ "$(grep -c '|origin=open|' "$WORK/r_side_default_none.tnlog" || true)" \
+    -eq 2 ] || {
+  echo "FAIL: the side default minted policy legs no picture asked for" >&2
+  exit 1
+}
 grep -Fq '|name=wrap-1|origin=trace|row=1|' "$WORK/k_twoshift.tnlog" || {
   echo "FAIL: trace policy did not derive the per-row wrap-1 record" >&2
   exit 1

--- a/tests/tenkz/kernel/regression/r_side_default_none.tex
+++ b/tests/tenkz/kernel/regression/r_side_default_none.tex
@@ -1,0 +1,23 @@
+% Regression: a kernel side exposes indices only when it says so.  The three
+% pictures are the same chain under no side policy, under the explicit
+% spelling of the default, and under the open word.  The first two carry the
+% empty boundary signature and mint no policy leg; only the third mints them.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2]
+  \tn{A} & \tn{B}
+\end{tenkz}
+\begin{tenkz}[rows={wire}, cols=2, boundary=none]
+  \tn{A} & \tn{B}
+\end{tenkz}
+\begin{tenkz}[rows={wire}, cols=2, boundary=open]
+  \tn{A} & \tn{B}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -271,10 +271,16 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{cols}{positive-integer}{3}{kernel}{Cells per row.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{frame}{frame-spec}{flat}{kernel}{Closed flat, plane, or circle frame word.}
 \__tenkz_language_registry_key:nnnnnn {kernel-frame}{basis}{basis-spec}{origin singleton}{kernel}{Ordered row-kind members at east/north quarter-pitch offsets.}
-\__tenkz_language_registry_key:nnnnnn {kernel-picture}{west}{side-policy}{open}{kernel}{West side policy.}
-\__tenkz_language_registry_key:nnnnnn {kernel-picture}{east}{side-policy}{open}{kernel}{East side policy.}
-\__tenkz_language_registry_key:nnnnnn {kernel-picture}{north}{side-policy}{open}{kernel}{North side policy.}
-\__tenkz_language_registry_key:nnnnnn {kernel-picture}{south}{side-policy}{open}{kernel}{South side policy.}
+% A kernel picture grows by declaration: a side exposes indices only when it
+% says so, and the frame's grid is a coordinate system rather than a claim
+% about which indices exist.  `none' is therefore the default word on every
+% side and the explicit spelling of that default.  The grid dialect's
+% {picture} rows above keep their own `open' default, which is where the
+% doctrine differs between the two languages.
+\__tenkz_language_registry_key:nnnnnn {kernel-picture}{west}{side-policy}{none}{kernel}{West side policy.}
+\__tenkz_language_registry_key:nnnnnn {kernel-picture}{east}{side-policy}{none}{kernel}{East side policy.}
+\__tenkz_language_registry_key:nnnnnn {kernel-picture}{north}{side-policy}{none}{kernel}{North side policy.}
+\__tenkz_language_registry_key:nnnnnn {kernel-picture}{south}{side-policy}{none}{kernel}{South side policy.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{trace}{trace-spec}{empty}{kernel}{Cells or physical ports closed to themselves.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{open}{cell-set}{empty}{kernel}{Cells opened by declaration.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{bonds}{bond-policy}{grid}{kernel}{Frame-generated adjacent contraction.}
@@ -282,7 +288,7 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{size}{size-class}{from math style}{kernel}{Size class of the metric context.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{check}{check-spec}{signature}{kernel}{The tenkzeq audit specification.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{sandwich}{flag}{false}{sugar(rows={ket,op,bra})}{Ket-over-bra row preset.}
-\__tenkz_language_registry_key:nnnnnn {kernel-picture}{boundary}{enum(open|none|periodic)}{open}{sugar(west, east)}{All-side boundary word.}
+\__tenkz_language_registry_key:nnnnnn {kernel-picture}{boundary}{enum(open|none|periodic)}{none}{sugar(west, east)}{All-side boundary word.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{lattice}{pair}{empty}{sugar(rows=, cols=)}{RxC wire-row lattice preset.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{ring}{integer}{empty}{sugar(rows=, cols=, frame=circle, west=trace, east=trace)}{Circle-frame ring preset.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{surface}{identifier}{empty}{sugar(west=trace, east=trace, north=trace, south=trace)}{Torus closure preset.}


### PR DESCRIPTION
## The contract reading

The contract supports **"the sides are not closed"**, not "open legs are
materialized". The kernel is right and the documentation was loose.

Three pieces of wording decide it:

- §13.5: **"Open ink is declared content: the boundary signature is computed
  from port and wire records."** and §1: **"The language grows by
  declaration, never by drawing."** A leg that appears because nobody spoke
  is drawn, not declared.
- §3: **"Open legs are policy, not objects. An unbonded typed port renders as
  a stub in the direction of its face."** Legs come from declared ports and
  authored `open` endpoints. The side policy is a third source that *mints*
  ports; it does not describe ports a frame cell already owns.
- The frame's grid is a coordinate system that places atoms. `cols=7` is not
  a claim that seven cells sit in a row each with a dangling end.
  `rmp-ii-circuit` is a doubling-tree pyramid on a 4x7 grid whose documented
  boundary is eight measured output legs and no virtual ends;
  `rmp-iii-a-ghz-tensor` is one atom on `cols=1` with four declared ports.
  Under a materializing default both collect legs no author asked for.

Where the printed `open` came from: the **0.7 grid dialect really does** open
by default -- `tenkz-grid.code.tex` initializes `\l__tenkz_boundary_tl` to
`open`, every grid picture draws its west and east stubs unbidden, and
`boundary=none` seals them. That default was copied by hand into the
`kernel-picture` registry rows and into the LANGUAGE-1.0 key table. The
`{picture}`-scope rows, which describe the grid dialect, were correct all
along.

Confirming the kernel: an unstated side and `boundary=none` produce
**byte-identical event streams** (`kernel-boundary|signature=`, no
`origin=open` wire), and every kernel read of the side policy compares
against `open`, `trace`, or `cup` -- `none` is structurally inert.

## Blast radius

Measured by making the default real (`west`/`east` fall back to `open` when
unset, guarded by the basis-aligned condition), compiling all 130 targets, and
diffing the record streams against `origin/main`:

| | count |
|---|---|
| targets that stop compiling (`TKZ-PORT-CONSUMED`: a policy leg and an authored end claiming one port) | **30** |
| of the 100 that survive: gain open-leg wires | **43** |
| of the 100 that survive: boundary signature moves | **40** |
| unchanged | 52 |

78 of 130 targets move, and the signature moves are the serious ones --
`rmp-ii-mpu-splitting` and `rmp-ii-mpu-two-shift` double their exposed
boundary, which is exactly the pictured-equation breakage the issue warned
about.

## The branch taken

Documentation, per the issue's second option.

- The four `kernel-picture` side rows and the kernel `boundary` row read
  `none`; the `{picture}` grid-dialect rows keep `open`, with a comment
  saying why the two tiers differ.
- LANGUAGE-1.0's key table follows, §3 states the doctrine and names the one
  place the two languages disagree about a default, and §14 books the
  correction as a dated decision with these numbers.
- The recipe "Keep a map open; close a scalar" and the quick reference now
  say which surface each default belongs to. A kernel map keeps its ends by
  writing `boundary=open`; `boundary=none` is the explicit spelling of what a
  kernel picture already does.
- `rmp-workbench-iii-eq50` and `rmp-ii-zcl-mpdo` keep their `west=open,
  east=open` -- now the contract's requirement rather than a workaround. No
  case source changes, so no `case_sha256` re-pin.
- `tests/tenkz/kernel/regression/r_side_default_none.tex` pins the three
  chains -- no policy, `boundary=none`, `boundary=open` -- by their boundary
  signatures and their policy-leg count, so the default cannot drift back.

No behaviour changed: the registry is a pure data table whose default field
is documentation, and no stream moved.

## Validation

```
python3 scripts/tenkz_rmp.py check --all         1 pre-existing hard error
                                                 (rmp-iii-b-braid-three label
                                                 overlap, reproduced on
                                                 origin/main); 130 targets
bash scripts/tenkz_golden.sh --check             PASS: 264 event streams byte-identical
bash scripts/tenkz_kernel_probes.sh              PASS: 127 review regressions hold
                                                 PASS: 10 sugar spellings byte-identical
                                                 PASS: 12 kernel record streams byte-identical
                                                 PASS: kernel pixels byte-identical
python3 scripts/tenkz_contracted_types.py --all  130 targets; 97 physical and
                                                 1292 virtual contractions
python3 scripts/test_tenkz_corpus_provenance.py  PASS
python3 scripts/test_tenkz_shrink.py             PASS
python3 scripts/tenkz_language.py check          PASS: 229 records
python3 scripts/tenkz_manual_doctest.py          PASS: 14 displayed + 25 reference examples
xelatex docs/tenkz/manual2.tex                   PASS (two passes)
python3 scripts/tenkz_shrink.py gate --base-ref origin/main
                                                 PASS: census stable at 201,
                                                 150 flags carry verdicts
```

No stream moved and no meter moved, so nothing was re-frozen and
`tests/tenkz/census-baseline.json` is untouched.

Closes LionSR/tenkz#155
