### PR TITLE
feat(Channel): unconditional two-variable operator Schwarz inequality and equality criterion (Wolf Ch5)

### DIFF
--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -50,6 +50,7 @@ import TNLean.Channel.Schwarz.SupportSourceBDefect
 import TNLean.Channel.Schwarz.SupportSourceDefect
 import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.TwoVariable
+import TNLean.Channel.Schwarz.TwoVariableUnconditional
 import TNLean.Channel.Schwarz.WeylRelativeEntropyIntegral
 import TNLean.Channel.Schwarz.WeylSupportPetzRecovery
 import TNLean.Channel.Schwarz.WeylSupportRelativeEntropyEquality

--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -50,6 +50,7 @@ import TNLean.Channel.Schwarz.SupportSourceBDefect
 import TNLean.Channel.Schwarz.SupportSourceDefect
 import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.TwoVariable
+import TNLean.Channel.Schwarz.TwoVariableEquality
 import TNLean.Channel.Schwarz.TwoVariableUnconditional
 import TNLean.Channel.Schwarz.WeylRelativeEntropyIntegral
 import TNLean.Channel.Schwarz.WeylSupportPetzRecovery

--- a/TNLean/Channel/Schwarz/AbstractMultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/AbstractMultiplicativeDomain.lean
@@ -24,6 +24,11 @@ representation or complete-positivity hypothesis is imposed.
 
 * `SchwarzMap.mem_rightMultiplicativeDomain_iff`: Wolf, Equation (5.13).
 * `SchwarzMap.mem_leftMultiplicativeDomain_iff`: Wolf, Equation (5.14).
+* `SchwarzMap.eq_zero_of_forall_quadratic_posSemidef`: a matrix-valued
+  quadratic in a real parameter, positive semidefinite for every value of
+  the parameter and with zero constant term, has zero linear coefficient;
+  the completing-the-square step reused by the Wolf Ch5 line-198 equality
+  criterion for the two-variable operator Schwarz inequality.
 
 ## References
 
@@ -98,7 +103,7 @@ theorem linear_eq_zero_of_quadratic_nonneg
 
 /-- A matrix-valued quadratic which is positive semidefinite for every real
 parameter and has zero constant term must have zero linear coefficient. -/
-private theorem eq_zero_of_forall_quadratic_posSemidef
+theorem eq_zero_of_forall_quadratic_posSemidef
     {m : Type*} [Finite m] {B D : Matrix m m ℂ}
     (h : ∀ t : ℝ,
       (((t : ℂ) • B) + ((t ^ 2 : ℝ) : ℂ) • D).PosSemidef) :

--- a/TNLean/Channel/Schwarz/TwoVariableEquality.lean
+++ b/TNLean/Channel/Schwarz/TwoVariableEquality.lean
@@ -178,4 +178,15 @@ theorem schwarz_equality_criterion (E : Mat →ₗ[ℂ] Mat) (B : Mat) (_hE : Is
     simpa [QQ] using hLzero
   exact (sub_eq_zero.mp hLzero').symm
 
+/-- **Converse of the equality criterion.** If the Eq. (5.5) identity
+`E(A†B) · pinv(E(B†B)) · E(B†X) = E(A†X)` holds for every `X`, then in
+particular (at `X = A`) `A` is in the equality-attaining set
+`equalityAttaining E B`. The source states only the forward direction
+(`schwarz_equality_criterion`); this converse is immediate from it by
+specializing at `X = A`. -/
+theorem mem_equalityAttaining_of_forall_eq (E : Mat →ₗ[ℂ] Mat) (B A : Mat)
+    (hid : ∀ X, E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * X) = E (Aᴴ * X)) :
+    A ∈ equalityAttaining E B :=
+  hid A
+
 end SchwarzTwoVariable

--- a/TNLean/Channel/Schwarz/TwoVariableEquality.lean
+++ b/TNLean/Channel/Schwarz/TwoVariableEquality.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.TwoVariableUnconditional
+import TNLean.Channel.Schwarz.AbstractMultiplicativeDomain
+
+/-!
+# Equality in the two-variable operator Schwarz inequality
+
+This file proves Wolf's equality criterion for the two-variable operator
+Schwarz inequality (Eq. (5.4)): for a fixed `B` such that the inequality
+holds for every `A`, and for `A` at which equality is attained, the
+pseudoinverse sandwich `E(A†B) · pinv(E(B†B)) · E(B†X)` agrees with
+`E(A†X)` for *every* `X`, not only `X = A`.
+
+The proof is Wolf's `t A + X` quadratic-in-`t` completing-the-square
+argument: expanding the (matrix-valued) nonnegative quadratic form of the
+Schwarz inequality at `A + t X` for real `t`, the `t²`-coefficient vanishes
+at the equality point `A`, so the remaining linear-in-`t` term must vanish
+identically; applying this at `X` and at `i X` and combining isolates the
+one-sided identity Eq. (5.5).
+
+## Main definitions
+
+* `HasSchwarzInequalityFor`: Wolf's per-`B` hypothesis, Eq. (5.4) held for a
+  given `B` and every `A`.
+* `equalityAttaining`: the equality-attaining set `𝒜_B`.
+
+## Main results
+
+* `hasSchwarzInequalityFor_of_is2PositiveMap`: a 2-positive map satisfies
+  the per-`B` hypothesis for every `B` (Theorem 5.3).
+* `schwarz_equality_criterion`: Wolf's Eq. (5.5), the equality criterion.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5,
+  Theorem "Equality in the operator Schwarz inequality"][Wolf2012QChannels]
+* Local source: `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`,
+  line 198.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+namespace SchwarzTwoVariable
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- Wolf's per-`B` hypothesis for the equality theorem: the two-variable
+Schwarz inequality Eq. (5.4) holds for the given `B`, for every `A`.
+
+Source: Wolf, *Quantum Channels & Operations*, Chapter 5, Theorem "Equality
+in the operator Schwarz inequality", local source
+`Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, line 198. -/
+def HasSchwarzInequalityFor (E : Mat →ₗ[ℂ] Mat) (B : Mat) : Prop :=
+  ∀ A, E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A) ≤ E (Aᴴ * A)
+
+/-- The equality-attaining set `𝒜_B` for a given `B`: the `A`'s for which
+equality is attained in Eq. (5.4).
+
+Source: Wolf, Ch5, line 198. -/
+def equalityAttaining (E : Mat →ₗ[ℂ] Mat) (B : Mat) : Set Mat :=
+  {A | E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A) = E (Aᴴ * A)}
+
+/-- A 2-positive map satisfies Wolf's per-`B` hypothesis for every `B`
+(Theorem 5.3, Eq. (5.4) unconditionally). -/
+theorem hasSchwarzInequalityFor_of_is2PositiveMap
+    {E : Mat →ₗ[ℂ] Mat} (h2pos : Is2PositiveMap E) (B : Mat) :
+    HasSchwarzInequalityFor E B :=
+  fun A => schwarz_two_variable_unconditional E h2pos A B
+
+/-- The quadratic form of the two-variable Schwarz inequality:
+`QQ E B U V = E(U†V) - E(U†B) · pinv(E(B†B)) · E(B†V)`, the difference whose
+nonnegativity is Eq. (5.4) and whose vanishing at `U = V = A` is membership
+in the equality-attaining set.
+
+`E` and `B` are explicit (rather than section variables) throughout this
+file: unfolding `QQ` via `simp only [QQ]` against a `QQ` built from
+section-variable `E`, `B` was observed to desynchronize the unfolded
+occurrences from the ambient `E`, `B` in the goal. -/
+private noncomputable def QQ (E : Mat →ₗ[ℂ] Mat) (B U V : Mat) : Mat :=
+  E (Uᴴ * V) - E (Uᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * V)
+
+/-- `QQ E B U` is `ℂ`-linear in its second argument. -/
+private theorem QQ_add_right (E : Mat →ₗ[ℂ] Mat) (B U V1 V2 : Mat) (c : ℂ) :
+    QQ E B U (V1 + c • V2) = QQ E B U V1 + c • QQ E B U V2 := by
+  simp only [QQ, Matrix.mul_add, Matrix.mul_smul, map_add, map_smul]
+  module
+
+/-- `QQ E B` is conjugate-linear in its first argument. -/
+private theorem QQ_add_left (E : Mat →ₗ[ℂ] Mat) (B U1 U2 V : Mat) (c : ℂ) :
+    QQ E B (U1 + c • U2) V = QQ E B U1 V + (star c) • QQ E B U2 V := by
+  simp only [QQ, Matrix.conjTranspose_add, Matrix.conjTranspose_smul, Matrix.add_mul,
+    Matrix.smul_mul, map_add, map_smul]
+  module
+
+/-- `QQ E B U U` is positive semidefinite whenever Wolf's per-`B` hypothesis
+holds: this is exactly Eq. (5.4) rearranged as a difference. -/
+private theorem QQ_posSemidef {E : Mat →ₗ[ℂ] Mat} {B : Mat}
+    (hSchwarz : HasSchwarzInequalityFor E B) (U : Mat) :
+    (QQ E B U U).PosSemidef :=
+  Matrix.le_iff.mp (hSchwarz U)
+
+/-- The quadratic-in-`c` expansion of `QQ E B` at `A + c • X`, using
+bilinearity and the equality hypothesis `QQ E B A A = 0`. -/
+private theorem QQ_expand (E : Mat →ₗ[ℂ] Mat) (B : Mat) {A X : Mat}
+    (hAA : QQ E B A A = 0) (c : ℂ) :
+    QQ E B (A + c • X) (A + c • X) =
+      c • QQ E B A X + (star c) • QQ E B X A + (star c * c) • QQ E B X X := by
+  rw [QQ_add_left, QQ_add_right, QQ_add_right, hAA]
+  module
+
+/-- **Equality in the two-variable operator Schwarz inequality**
+(Wolf, Theorem "Equality in the operator Schwarz inequality", Eq. (5.5)).
+
+Let `E` be a positive linear map such that for a given `B` the two-variable
+Schwarz inequality holds for all `A` (`hSchwarz`). Then for every `A` in
+the equality-attaining set `equalityAttaining E B` and every `X`:
+
+`E(A†B) · pinv(E(B†B)) · E(B†X) = E(A†X)`.
+
+The `IsPositiveMap E` hypothesis matches Wolf's theorem statement; it is not
+needed by this proof, which only uses `hSchwarz` and the equality
+hypothesis `hA`. -/
+theorem schwarz_equality_criterion (E : Mat →ₗ[ℂ] Mat) (B : Mat) (_hE : IsPositiveMap E)
+    (hSchwarz : HasSchwarzInequalityFor E B) {A : Mat} (hA : A ∈ equalityAttaining E B)
+    (X : Mat) :
+    E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * X) = E (Aᴴ * X) := by
+  have hAA : QQ E B A A = 0 := sub_eq_zero.mpr hA.symm
+  set L : Mat := QQ E B A X with hL_def
+  set R : Mat := QQ E B X A with hR_def
+  set Q : Mat := QQ E B X X with hQ_def
+  have hQt (c : ℂ) : QQ E B (A + c • X) (A + c • X) =
+      c • L + (star c) • R + (star c * c) • Q :=
+    QQ_expand E B hAA c
+  have hreal (t : ℝ) :
+      (((t : ℂ) • (L + R)) + ((t ^ 2 : ℝ) : ℂ) • Q).PosSemidef := by
+    have h := QQ_posSemidef hSchwarz (A + (t : ℂ) • X)
+    rw [hQt (t : ℂ)] at h
+    have e1 : star (t : ℂ) = (t : ℂ) := by simp
+    have e2 : (t : ℂ) • L + (t : ℂ) • R + ((t : ℂ) * (t : ℂ)) • Q =
+        (t : ℂ) • (L + R) + ((t ^ 2 : ℝ) : ℂ) • Q := by push_cast; module
+    rw [e1, e2] at h
+    exact h
+  have hsum : L + R = 0 := SchwarzMap.eq_zero_of_forall_quadratic_posSemidef hreal
+  have himag (t : ℝ) :
+      (((t : ℂ) • ((Complex.I : ℂ) • L - (Complex.I : ℂ) • R)) +
+        ((t ^ 2 : ℝ) : ℂ) • Q).PosSemidef := by
+    have h := QQ_posSemidef hSchwarz (A + ((t : ℂ) * Complex.I) • X)
+    rw [hQt ((t : ℂ) * Complex.I)] at h
+    have e1 : star ((t : ℂ) * Complex.I) = -((t : ℂ) * Complex.I) := by simp
+    have hcoef : (-((t : ℂ) * Complex.I)) * ((t : ℂ) * Complex.I) = ((t ^ 2 : ℝ) : ℂ) := by
+      have hI2 : Complex.I * Complex.I = -1 := Complex.I_mul_I
+      calc (-((t : ℂ) * Complex.I)) * ((t : ℂ) * Complex.I)
+          = -((t : ℂ) * (t : ℂ)) * (Complex.I * Complex.I) := by ring
+        _ = -((t : ℂ) * (t : ℂ)) * (-1) := by rw [hI2]
+        _ = (t : ℂ) * (t : ℂ) := by ring
+        _ = ((t ^ 2 : ℝ) : ℂ) := by push_cast; ring
+    have e2 : ((t : ℂ) * Complex.I) • L + (-((t : ℂ) * Complex.I)) • R +
+        ((-((t : ℂ) * Complex.I)) * ((t : ℂ) * Complex.I)) • Q =
+        (t : ℂ) • ((Complex.I : ℂ) • L - (Complex.I : ℂ) • R) + ((t ^ 2 : ℝ) : ℂ) • Q := by
+      rw [hcoef]; module
+    rw [e1, e2] at h
+    exact h
+  have hdiff : (Complex.I : ℂ) • L - (Complex.I : ℂ) • R = 0 :=
+    SchwarzMap.eq_zero_of_forall_quadratic_posSemidef himag
+  have hR_eq : R = -L := eq_neg_of_add_eq_zero_right hsum
+  have hL : L = 0 := by
+    rw [hR_eq, smul_neg, sub_neg_eq_add, ← add_smul] at hdiff
+    exact (smul_eq_zero.mp hdiff).resolve_left (by norm_num)
+  have hLzero : QQ E B A X = 0 := hL_def ▸ hL
+  have hLzero' : E (Aᴴ * X) - E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * X) = 0 := by
+    simpa [QQ] using hLzero
+  exact (sub_eq_zero.mp hLzero').symm
+
+end SchwarzTwoVariable

--- a/TNLean/Channel/Schwarz/TwoVariableUnconditional.lean
+++ b/TNLean/Channel/Schwarz/TwoVariableUnconditional.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.TwoVariable
+import TNLean.Channel.Schwarz.SchurComplement
+
+/-!
+# The unconditional two-variable operator Schwarz inequality
+
+This file proves the unconditional form of Wolf's Theorem 5.3 (Eq. (5.4)):
+for a 2-positive map `E` and all `A, B`,
+`E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, with the inverse taken on the
+range via the Moore–Penrose pseudoinverse `Douglas.pinv`.
+
+This upgrades the conditional (witness-dependent) form
+`SchwarzTwoVariable.schwarz_two_variable` of `TwoVariable.lean` by
+constructing the witness `w = pinv(E(B†B)) · E(B†A) · v` explicitly for
+every `v`, using the kernel-inclusion clause of the Schur complement
+(`ker_inclusion_of_fromBlocks_posSemidef`) and the support-projection
+absorption lemma
+`Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le`, rather
+than the `EuclideanSpace`/`PiLp` range-ker duality route that caused
+`whnf` timeouts (documented in
+`docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`).
+
+## Main results
+
+* `ker_EBB_le_ker_EAB`: `ker(E(B†B)) ⊆ ker(E(A†B))`, the kernel-inclusion
+  clause of the ampliated block matrix.
+* `EBB_mul_pinv_mul_EBA_eq`: the pseudoinverse witness identity
+  `E(B†B) · (pinv(E(B†B)) · E(B†A)) = E(B†A)`, i.e. the range inclusion
+  `ran E(B†A) ⊆ ran E(B†B)` in pseudoinverse form.
+* `schwarz_two_variable_unconditional`: the unconditional inequality
+  `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`, Wolf's Eq. (5.4) literally, no
+  witness vector assumed to exist.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 5,
+  Theorem 5.3][Wolf2012QChannels]
+* Local source: `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`,
+  lines 180--190.
+* `docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex`.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+namespace SchwarzTwoVariable
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The conjugate-transpose identity `E(B†A) = E(A†B)†`, for a 2-positive
+(hence positive) map `E`. -/
+theorem map_EBA_eq_conjTranspose_EAB (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E)
+    (A B : Mat) : E (Bᴴ * A) = (E (Aᴴ * B))ᴴ := by
+  have hPos : IsPositiveMap E := h2pos.isPositiveMap
+  rw [← hPos.map_conjTranspose (Aᴴ * B)]
+  congr 1
+  rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+
+/-- The kernel of `E(B†B)` is contained in the kernel of `E(A†B)`: this is
+the Schur-complement kernel-absorption clause of Theorem 5.2 applied to the
+ampliated `2×2` block matrix `[[E(A†A), E(A†B)], [E(B†A), E(B†B)]]`. -/
+theorem ker_EBB_le_ker_EAB (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E) (A B : Mat)
+    (y : Fin D → ℂ) (hy : (E (Bᴴ * B)).mulVec y = 0) : (E (Aᴴ * B)).mulVec y = 0 := by
+  have h_psd := ampliated_block_matrix_posSemidef E h2pos A B
+  rw [map_EBA_eq_conjTranspose_EAB E h2pos A B] at h_psd
+  exact ker_inclusion_of_fromBlocks_posSemidef h_psd y hy
+
+/-- The pseudoinverse `Douglas.pinv (E(B†B))` is a genuine right-inverse
+witness for `E(B†A)` on the support of `E(B†B)`:
+`E(B†B) · (pinv(E(B†B)) · E(B†A)) = E(B†A)`.
+
+This is the range-inclusion step `ran E(B†A) ⊆ ran E(B†B)` of the
+unconditional Schwarz inequality, obtained from `ker_EBB_le_ker_EAB` via the
+support-projection absorption lemma
+`Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le` and the
+pseudoinverse identity `Douglas.pinv (E(B†B)) · E(B†B) = supportProj`. -/
+theorem EBB_mul_pinv_mul_EBA_eq (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E) (A B : Mat) :
+    (E (Bᴴ * B)) * (Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A)) = E (Bᴴ * A) := by
+  have hPos : IsPositiveMap E := h2pos.isPositiveMap
+  have hR : (E (Bᴴ * B)).PosSemidef := hPos _ (Matrix.posSemidef_conjTranspose_mul_self B)
+  have hker : ∀ y : Fin D → ℂ,
+      (E (Bᴴ * B)).mulVec y = 0 → (E (Aᴴ * B)).mulVec y = 0 :=
+    ker_EBB_le_ker_EAB E h2pos A B
+  have habsorb : (E (Aᴴ * B)) * hR.isHermitian.supportProj = E (Aᴴ * B) :=
+    hR.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker
+  have habsorb' : hR.isHermitian.supportProj * (E (Aᴴ * B))ᴴ = (E (Aᴴ * B))ᴴ := by
+    have h := congrArg Matrix.conjTranspose habsorb
+    rwa [Matrix.conjTranspose_mul, hR.isHermitian.supportProj_isHermitian.eq] at h
+  have hpinv_eq : (E (Bᴴ * B)) * Douglas.pinv (E (Bᴴ * B)) = hR.isHermitian.supportProj :=
+    SchurComplement.R_mul_pinv_eq_supportProj (E (Bᴴ * B)) hR
+  rw [map_EBA_eq_conjTranspose_EAB E h2pos A B]
+  calc
+    (E (Bᴴ * B)) * (Douglas.pinv (E (Bᴴ * B)) * (E (Aᴴ * B))ᴴ)
+        = ((E (Bᴴ * B)) * Douglas.pinv (E (Bᴴ * B))) * (E (Aᴴ * B))ᴴ := by
+          rw [Matrix.mul_assoc]
+      _ = hR.isHermitian.supportProj * (E (Aᴴ * B))ᴴ := by rw [hpinv_eq]
+      _ = (E (Aᴴ * B))ᴴ := habsorb'
+
+/-- **The unconditional two-variable operator Schwarz inequality**
+(Wolf, Theorem 5.3, Eq. (5.4)). For a 2-positive map `E` and all `A, B`:
+
+`E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)`,
+
+with the inverse taken on the range via the Moore–Penrose pseudoinverse
+`Douglas.pinv`. Unlike `SchwarzTwoVariable.schwarz_two_variable`, no
+witness vector `w` is assumed to exist: the pseudoinverse witness
+`w = pinv(E(B†B)) · E(B†A) · v` is constructed explicitly for every `v`. -/
+theorem schwarz_two_variable_unconditional (E : Mat →ₗ[ℂ] Mat) (h2pos : Is2PositiveMap E)
+    (A B : Mat) :
+    E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A) ≤ E (Aᴴ * A) := by
+  rw [Matrix.le_iff]
+  refine Matrix.posSemidef_of_forall_star_dotProduct_mulVec_nonneg (fun v => ?_)
+  set w : Fin D → ℂ := (Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A)).mulVec v with hw_def
+  have hw : (E (Bᴴ * B)).mulVec w = (E (Bᴴ * A)).mulVec v := by
+    rw [hw_def, Matrix.mulVec_mulVec, EBB_mul_pinv_mul_EBA_eq E h2pos A B]
+  have hineq := schwarz_two_variable E h2pos A B v w hw
+  have heq : (E (Aᴴ * B)).mulVec w =
+      (E (Aᴴ * B) * Douglas.pinv (E (Bᴴ * B)) * E (Bᴴ * A)).mulVec v := by
+    rw [hw_def, Matrix.mulVec_mulVec, Matrix.mul_assoc]
+  rw [heq] at hineq
+  rw [Matrix.sub_mulVec, dotProduct_sub]
+  exact sub_nonneg.mpr hineq
+
+end SchwarzTwoVariable

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -475,7 +475,7 @@ positivity.
     \lean{SchwarzTwoVariable.equalityAttaining}
     \leanok
     \uses{def:has_schwarz_inequality_for}
-    For a fixed $B$, the set $\mcA_B\subseteq\MN{D}$ of $A$'s for which
+    For a fixed $B$, the set $\mc{A}_B\subseteq\MN{D}$ of $A$'s for which
     equality is attained in the two-variable operator Schwarz inequality:
     \begin{align}
         E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
@@ -492,7 +492,7 @@ positivity.
     Let $E:\MN{D}\to\MN{D}$ be a positive linear map such that, for a
     given $B\in\MN{D}$, the per-$B$ Schwarz hypothesis holds
     (Definition~\ref{def:has_schwarz_inequality_for}). Then for every
-    $A\in\mcA_B$ (Definition~\ref{def:equality_attaining}) and every
+    $A\in\mc{A}_B$ (Definition~\ref{def:equality_attaining}) and every
     $X\in\MN{D}$,
     \begin{align}
         E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger X)
@@ -506,7 +506,7 @@ positivity.
 \begin{proof}\leanok
     Write $Q(U,V) = E(U^\dagger V) - E(U^\dagger B)E(B^\dagger B)^+E(B^\dagger
     V)$; the per-$B$ hypothesis is $Q(U,U)\ge0$ for every $U$, and
-    $A\in\mcA_B$ means $Q(A,A)=0$. Applying the hypothesis to
+    $A\in\mc{A}_B$ means $Q(A,A)=0$. Applying the hypothesis to
     $A + cX$ for $c\in\mathbb C$ and expanding bilinearly gives
     \begin{align}
         Q(A+cX,A+cX)
@@ -520,3 +520,15 @@ positivity.
     vanishes. Combining the two gives $Q(A,X)=0$, which is the displayed
     identity.
 \end{proof}
+
+\begin{corollary}[Converse of the equality criterion]
+    \label{cor:two_variable_schwarz_equality_converse}
+    \lean{SchwarzTwoVariable.mem_equalityAttaining_of_forall_eq}
+    \leanok
+    \uses{def:equality_attaining}
+    If the identity of
+    Theorem~\ref{thm:two_variable_schwarz_equality} holds for every
+    $X\in\MN{D}$, then $A\in\mc{A}_B$. This is immediate from the
+    theorem by specializing at $X=A$; the source states only the forward
+    direction.
+\end{corollary}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -425,6 +425,69 @@ positivity.
     $v^\dagger E(A^\dagger A)v - v^\dagger E(A^\dagger B)w \ge 0$.
 \end{proof}
 
+\begin{lemma}[Conjugate-transpose identity]
+    \label{lem:map_EBA_eq_conjTranspose_EAB}
+    \lean{SchwarzTwoVariable.map_EBA_eq_conjTranspose_EAB}
+    \leanok
+    \uses{def:2positive_map}
+    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
+    $A,B\in\MN{D}$,
+    \begin{align}
+        E(B^\dagger A) & = E(A^\dagger B)^\dagger.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    A $2$-positive map is positive, and positive maps preserve adjoints.
+    Applying this to $A^\dagger B$ and using
+    $(A^\dagger B)^\dagger = B^\dagger A$ gives the identity.
+\end{proof}
+
+\begin{lemma}[Kernel inclusion for the two-variable Schwarz inequality]
+    \label{lem:ker_EBB_le_ker_EAB}
+    \lean{SchwarzTwoVariable.ker_EBB_le_ker_EAB}
+    \leanok
+    \uses{def:2positive_map, lem:map_EBA_eq_conjTranspose_EAB}
+    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
+    $A,B\in\MN{D}$, $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:map_EBA_eq_conjTranspose_EAB, lem:two_variable_operator_schwarz_conditional}
+    Rewrite $E(B^\dagger A)$ as $E(A^\dagger B)^\dagger$
+    (Lemma~\ref{lem:map_EBA_eq_conjTranspose_EAB}) in the ampliated PSD
+    block matrix $\bigl[\begin{smallmatrix}
+        E(A^\dagger A) & E(A^\dagger B)\\
+        E(B^\dagger A) & E(B^\dagger B)
+    \end{smallmatrix}\bigr]$ from the proof of
+    Lemma~\ref{lem:two_variable_operator_schwarz_conditional}: if
+    $E(B^\dagger B)y=0$ then testing the PSD quadratic form on $(0,y)$
+    forces $E(A^\dagger B)y=0$.
+\end{proof}
+
+\begin{lemma}[Pseudoinverse range-inclusion witness]
+    \label{lem:EBB_mul_pinv_mul_EBA_eq}
+    \lean{SchwarzTwoVariable.EBB_mul_pinv_mul_EBA_eq}
+    \leanok
+    \uses{def:2positive_map, def:pinv, lem:ker_EBB_le_ker_EAB}
+    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
+    $A,B\in\MN{D}$,
+    \begin{align}
+        E(B^\dagger B)\bigl(E(B^\dagger B)^{+}E(B^\dagger A)\bigr)
+         & = E(B^\dagger A).
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    The kernel inclusion $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$
+    (Lemma~\ref{lem:ker_EBB_le_ker_EAB}) gives, after taking adjoints, that
+    the support projection of $E(B^\dagger B)$ absorbs $E(B^\dagger A)$ on
+    the left. Since $E(B^\dagger B)E(B^\dagger B)^{+}$ is exactly that
+    support projection, the displayed identity follows.
+\end{proof}
+
 \begin{theorem}[Two-variable operator Schwarz inequality]
     \label{thm:two_variable_operator_schwarz}
     \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional}
@@ -443,12 +506,15 @@ positivity.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:two_variable_operator_schwarz_conditional, lem:EBB_mul_pinv_mul_EBA_eq}
     For every $v$, the vector $w = E(B^\dagger B)^{+}E(B^\dagger A)\,v$
     satisfies the side condition $E(B^\dagger B)\,w = E(B^\dagger A)\,v$ of
     the conditional lemma
-    (Lemma~\ref{lem:two_variable_operator_schwarz_conditional}): the kernel
-    inclusion $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$, obtained
-    from the ampliated PSD block matrix of the conditional lemma's proof,
+    (Lemma~\ref{lem:two_variable_operator_schwarz_conditional}): this is
+    exactly Lemma~\ref{lem:EBB_mul_pinv_mul_EBA_eq} evaluated at $v$. The
+    kernel inclusion $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$,
+    obtained from the ampliated PSD block matrix of the conditional
+    lemma's proof,
     gives $\operatorname{ran}(E(B^\dagger A))\subseteq
     \operatorname{ran}(E(B^\dagger B))$, so the pseudoinverse is a genuine
     right-inverse witness for $E(B^\dagger A)$ on the support of
@@ -484,6 +550,26 @@ positivity.
     \end{align}
 \end{definition}
 
+\begin{lemma}[Vanishing linear coefficient of a nonnegative matrix quadratic]
+    \label{lem:eq_zero_of_forall_quadratic_posSemidef}
+    \lean{SchwarzMap.eq_zero_of_forall_quadratic_posSemidef}
+    \leanok
+    Let $m$ be finite and $B,D\in\MN{m}$. If
+    $tB+t^2D$ is positive semidefinite for every $t\in\mathbb R$, then
+    $B=0$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Testing the quadratic form on a vector $x$ reduces to the scalar
+    statement: if $tb+t^2d\ge0$ for every real $t$, where
+    $b=x^\dagger Bx$ and $d=x^\dagger Dx\ge0$, then $b=0$. Evaluating at
+    $t=\pm1$ forces $d\ge0$; evaluating at $t=-\operatorname{Re}(b)/(d+1)$
+    and completing the square forces $\operatorname{Re}(b)=0$, and
+    comparing the imaginary parts at $t=\pm1$ forces
+    $\operatorname{Im}(b)=0$. Since this holds for every $x$, $B=0$ by
+    polarization.
+\end{proof}
+
 \begin{theorem}[Equality in the operator Schwarz inequality]
     \label{thm:two_variable_schwarz_equality}
     \lean{SchwarzTwoVariable.schwarz_equality_criterion}
@@ -504,6 +590,7 @@ positivity.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:eq_zero_of_forall_quadratic_posSemidef}
     Write $Q(U,V) = E(U^\dagger V) - E(U^\dagger B)E(B^\dagger B)^+E(B^\dagger
     V)$; the per-$B$ hypothesis is $Q(U,U)\ge0$ for every $U$, and
     $A\in\mc{A}_B$ means $Q(A,A)=0$. Applying the hypothesis to
@@ -514,9 +601,11 @@ positivity.
         \ge 0.
         \notag
     \end{align}
-    Taking $c=t\in\mathbb R$ shows the linear-in-$t$ coefficient
-    $Q(A,X)+Q(X,A)$ vanishes (the quadratic coefficient $Q(X,X)$ is fixed
-    and nonnegative); taking $c=tI$ shows $I\,Q(A,X) - I\,Q(X,A)$
+    Taking $c=t\in\mathbb R$ and applying
+    Lemma~\ref{lem:eq_zero_of_forall_quadratic_posSemidef} to the linear
+    coefficient $Q(A,X)+Q(X,A)$ and the fixed nonnegative quadratic
+    coefficient $Q(X,X)$ shows $Q(A,X)+Q(X,A)$ vanishes; taking $c=tI$ and
+    applying the same lemma to $I\,Q(A,X) - I\,Q(X,A)$ shows this also
     vanishes. Combining the two gives $Q(A,X)=0$, which is the displayed
     identity.
 \end{proof}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -427,25 +427,96 @@ positivity.
 
 \begin{theorem}[Two-variable operator Schwarz inequality]
     \label{thm:two_variable_operator_schwarz}
-    % (lean target: schwarz_two_variable_unconditional — not yet defined)
-    \uses{def:2positive_map}
-    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map.
-    For every $A,B\in\MN{D}$ and every vector $v$,
+    \lean{SchwarzTwoVariable.schwarz_two_variable_unconditional}
+    \leanok
+    \uses{def:2positive_map, def:pinv}
+    Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
+    $A,B\in\MN{D}$,
     \begin{align}
-        v^\dagger\,E(A^\dagger A)\,v
-         & \ge \sup_{w\,:\,E(B^\dagger B)w=E(B^\dagger A)v}
-            v^\dagger\,E(A^\dagger B)\,w,
+        E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
+         & \le E(A^\dagger A),
         \notag
     \end{align}
-    where the supremum is taken over all $w$ satisfying the side condition.
-    Equivalently, for every $v$ there exists a vector $w$ with
-    $E(B^\dagger B)w = E(B^\dagger A)v$ such that
-    $v^\dagger E(A^\dagger A)v \ge v^\dagger E(A^\dagger B)w$,
-    and the value $v^\dagger E(A^\dagger B)w$ is independent of the choice
-    of such $w$.
-    This is \cite[Eq.~(5.4)]{Wolf2012Quantum}.
-    \notready
-    % Missing: existence of w via ran(E(B†B)) = ker(E(B†B))⊥.
-    % The conditional form (Lemma~\ref{lem:two_variable_operator_schwarz_conditional})
-    % is formalized; the unconditional form needs EuclideanSpace range/ker duality.
+    where $(\cdot)^+$ is the Moore--Penrose pseudoinverse, i.e.\ the
+    inverse taken on the range. This is \cite[Eq.~(5.4)]{Wolf2012Quantum},
+    unconditional: no vector is assumed to exist.
 \end{theorem}
+
+\begin{proof}\leanok
+    For every $v$, the vector $w = E(B^\dagger B)^{+}E(B^\dagger A)\,v$
+    satisfies the side condition $E(B^\dagger B)\,w = E(B^\dagger A)\,v$ of
+    the conditional lemma
+    (Lemma~\ref{lem:two_variable_operator_schwarz_conditional}): the kernel
+    inclusion $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$, obtained
+    from the ampliated PSD block matrix of the conditional lemma's proof,
+    gives $\operatorname{ran}(E(B^\dagger A))\subseteq
+    \operatorname{ran}(E(B^\dagger B))$, so the pseudoinverse is a genuine
+    right-inverse witness for $E(B^\dagger A)$ on the support of
+    $E(B^\dagger B)$. Applying the conditional lemma with this $w$ for
+    every $v$ gives the displayed matrix inequality.
+\end{proof}
+
+\begin{definition}[Per-$B$ Schwarz hypothesis]\label{def:has_schwarz_inequality_for}
+    \lean{SchwarzTwoVariable.HasSchwarzInequalityFor}
+    \leanok
+    \uses{def:pinv}
+    A complex-linear map $E:\MN{D}\to\MN{D}$ and a fixed $B\in\MN{D}$
+    satisfy the per-$B$ Schwarz hypothesis when
+    \begin{align}
+        E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
+         & \le E(A^\dagger A)
+        \notag
+    \end{align}
+    for every $A\in\MN{D}$. A $2$-positive map satisfies this for every
+    $B$ (Theorem~\ref{thm:two_variable_operator_schwarz}).
+\end{definition}
+
+\begin{definition}[Equality-attaining set]\label{def:equality_attaining}
+    \lean{SchwarzTwoVariable.equalityAttaining}
+    \leanok
+    \uses{def:has_schwarz_inequality_for}
+    For a fixed $B$, the set $\mcA_B\subseteq\MN{D}$ of $A$'s for which
+    equality is attained in the two-variable operator Schwarz inequality:
+    \begin{align}
+        E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger A)
+         & = E(A^\dagger A).
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Equality in the operator Schwarz inequality]
+    \label{thm:two_variable_schwarz_equality}
+    \lean{SchwarzTwoVariable.schwarz_equality_criterion}
+    \leanok
+    \uses{def:has_schwarz_inequality_for, def:equality_attaining}
+    Let $E:\MN{D}\to\MN{D}$ be a positive linear map such that, for a
+    given $B\in\MN{D}$, the per-$B$ Schwarz hypothesis holds
+    (Definition~\ref{def:has_schwarz_inequality_for}). Then for every
+    $A\in\mcA_B$ (Definition~\ref{def:equality_attaining}) and every
+    $X\in\MN{D}$,
+    \begin{align}
+        E(A^\dagger B)\,E(B^\dagger B)^{+}\,E(B^\dagger X)
+         & = E(A^\dagger X).
+        \notag
+    \end{align}
+    This is the source's equality theorem, local source
+    \path{Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex}, line 198.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write $Q(U,V) = E(U^\dagger V) - E(U^\dagger B)E(B^\dagger B)^+E(B^\dagger
+    V)$; the per-$B$ hypothesis is $Q(U,U)\ge0$ for every $U$, and
+    $A\in\mcA_B$ means $Q(A,A)=0$. Applying the hypothesis to
+    $A + cX$ for $c\in\mathbb C$ and expanding bilinearly gives
+    \begin{align}
+        Q(A+cX,A+cX)
+         & = c\,Q(A,X) + \overline{c}\,Q(X,A) + \overline{c}c\,Q(X,X)
+        \ge 0.
+        \notag
+    \end{align}
+    Taking $c=t\in\mathbb R$ shows the linear-in-$t$ coefficient
+    $Q(A,X)+Q(X,A)$ vanishes (the quadratic coefficient $Q(X,X)$ is fixed
+    and nonnegative); taking $c=tI$ shows $I\,Q(A,X) - I\,Q(X,A)$
+    vanishes. Combining the two gives $Q(A,X)=0$, which is the displayed
+    identity.
+\end{proof}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -425,8 +425,8 @@ positivity.
     $v^\dagger E(A^\dagger A)v - v^\dagger E(A^\dagger B)w \ge 0$.
 \end{proof}
 
-\begin{lemma}[Conjugate-transpose identity]
-    \label{lem:map_EBA_eq_conjTranspose_EAB}
+\begin{theorem}[Conjugate-transpose identity]
+    \label{thm:map_EBA_eq_conjTranspose_EAB}
     \lean{SchwarzTwoVariable.map_EBA_eq_conjTranspose_EAB}
     \leanok
     \uses{def:2positive_map}
@@ -436,7 +436,7 @@ positivity.
         E(B^\dagger A) & = E(A^\dagger B)^\dagger.
         \notag
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     A $2$-positive map is positive, and positive maps preserve adjoints.
@@ -444,19 +444,19 @@ positivity.
     $(A^\dagger B)^\dagger = B^\dagger A$ gives the identity.
 \end{proof}
 
-\begin{lemma}[Kernel inclusion for the two-variable Schwarz inequality]
-    \label{lem:ker_EBB_le_ker_EAB}
+\begin{theorem}[Kernel inclusion for the two-variable Schwarz inequality]
+    \label{thm:ker_EBB_le_ker_EAB}
     \lean{SchwarzTwoVariable.ker_EBB_le_ker_EAB}
     \leanok
-    \uses{def:2positive_map, lem:map_EBA_eq_conjTranspose_EAB}
+    \uses{def:2positive_map, thm:map_EBA_eq_conjTranspose_EAB}
     Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
     $A,B\in\MN{D}$, $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:map_EBA_eq_conjTranspose_EAB, lem:two_variable_operator_schwarz_conditional}
+    \uses{thm:map_EBA_eq_conjTranspose_EAB, lem:two_variable_operator_schwarz_conditional}
     Rewrite $E(B^\dagger A)$ as $E(A^\dagger B)^\dagger$
-    (Lemma~\ref{lem:map_EBA_eq_conjTranspose_EAB}) in the ampliated PSD
+    (Lemma~\ref{thm:map_EBA_eq_conjTranspose_EAB}) in the ampliated PSD
     block matrix $\bigl[\begin{smallmatrix}
         E(A^\dagger A) & E(A^\dagger B)\\
         E(B^\dagger A) & E(B^\dagger B)
@@ -466,11 +466,11 @@ positivity.
     forces $E(A^\dagger B)y=0$.
 \end{proof}
 
-\begin{lemma}[Pseudoinverse range-inclusion witness]
-    \label{lem:EBB_mul_pinv_mul_EBA_eq}
+\begin{theorem}[Pseudoinverse range-inclusion witness]
+    \label{thm:EBB_mul_pinv_mul_EBA_eq}
     \lean{SchwarzTwoVariable.EBB_mul_pinv_mul_EBA_eq}
     \leanok
-    \uses{def:2positive_map, def:pinv, lem:ker_EBB_le_ker_EAB}
+    \uses{def:2positive_map, def:pinv, thm:ker_EBB_le_ker_EAB}
     Let $E:\MN{D}\to\MN{D}$ be a $2$-positive complex-linear map. For every
     $A,B\in\MN{D}$,
     \begin{align}
@@ -478,11 +478,11 @@ positivity.
          & = E(B^\dagger A).
         \notag
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     The kernel inclusion $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$
-    (Lemma~\ref{lem:ker_EBB_le_ker_EAB}) gives, after taking adjoints, that
+    (Lemma~\ref{thm:ker_EBB_le_ker_EAB}) gives, after taking adjoints, that
     the support projection of $E(B^\dagger B)$ absorbs $E(B^\dagger A)$ on
     the left. Since $E(B^\dagger B)E(B^\dagger B)^{+}$ is exactly that
     support projection, the displayed identity follows.
@@ -506,12 +506,12 @@ positivity.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:two_variable_operator_schwarz_conditional, lem:EBB_mul_pinv_mul_EBA_eq}
+    \uses{lem:two_variable_operator_schwarz_conditional, thm:EBB_mul_pinv_mul_EBA_eq}
     For every $v$, the vector $w = E(B^\dagger B)^{+}E(B^\dagger A)\,v$
     satisfies the side condition $E(B^\dagger B)\,w = E(B^\dagger A)\,v$ of
     the conditional lemma
     (Lemma~\ref{lem:two_variable_operator_schwarz_conditional}): this is
-    exactly Lemma~\ref{lem:EBB_mul_pinv_mul_EBA_eq} evaluated at $v$. The
+    exactly Lemma~\ref{thm:EBB_mul_pinv_mul_EBA_eq} evaluated at $v$. The
     kernel inclusion $\ker(E(B^\dagger B))\subseteq\ker(E(A^\dagger B))$,
     obtained from the ampliated PSD block matrix of the conditional
     lemma's proof,
@@ -550,14 +550,14 @@ positivity.
     \end{align}
 \end{definition}
 
-\begin{lemma}[Vanishing linear coefficient of a nonnegative matrix quadratic]
-    \label{lem:eq_zero_of_forall_quadratic_posSemidef}
+\begin{theorem}[Vanishing linear coefficient of a nonnegative matrix quadratic]
+    \label{thm:eq_zero_of_forall_quadratic_posSemidef}
     \lean{SchwarzMap.eq_zero_of_forall_quadratic_posSemidef}
     \leanok
     Let $m$ be finite and $B,D\in\MN{m}$. If
     $tB+t^2D$ is positive semidefinite for every $t\in\mathbb R$, then
     $B=0$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Testing the quadratic form on a vector $x$ reduces to the scalar
@@ -590,7 +590,7 @@ positivity.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:eq_zero_of_forall_quadratic_posSemidef}
+    \uses{thm:eq_zero_of_forall_quadratic_posSemidef}
     Write $Q(U,V) = E(U^\dagger V) - E(U^\dagger B)E(B^\dagger B)^+E(B^\dagger
     V)$; the per-$B$ hypothesis is $Q(U,U)\ge0$ for every $U$, and
     $A\in\mc{A}_B$ means $Q(A,A)=0$. Applying the hypothesis to
@@ -602,7 +602,7 @@ positivity.
         \notag
     \end{align}
     Taking $c=t\in\mathbb R$ and applying
-    Lemma~\ref{lem:eq_zero_of_forall_quadratic_posSemidef} to the linear
+    Lemma~\ref{thm:eq_zero_of_forall_quadratic_posSemidef} to the linear
     coefficient $Q(A,X)+Q(X,A)$ and the fixed nonnegative quadratic
     coefficient $Q(X,X)$ shows $Q(A,X)+Q(X,A)$ vanishes; taking $c=tI$ and
     applying the same lemma to $I\,Q(A,X) - I\,Q(X,A)$ shows this also


### PR DESCRIPTION
## Summary

Closes LionSR/QICLean#266.
Closes LionSR/QICLean#268.

Formalizes the two remaining pieces of Wolf, *Quantum Channels & Operations*, Chapter 5, Theorem 5.3 (Eq. 5.4) and its equality criterion (Eq. 5.5), local source `Notes/WolfNoteTexSource/ch05_schwarz_inequalities.tex`, lines 180–215.

### LionSR/QICLean#266 — unconditional two-variable operator Schwarz inequality

`TNLean/Channel/Schwarz/TwoVariableUnconditional.lean`:

- `ker_EBB_le_ker_EAB`: `ker(E(B†B)) ⊆ ker(E(A†B))`, the kernel-inclusion clause of the ampliated PSD block matrix (the "range inclusion" step of the issue).
- `EBB_mul_pinv_mul_EBA_eq`: `E(B†B) · (pinv(E(B†B)) · E(B†A)) = E(B†A)`, the range-inclusion witness identity.
- `schwarz_two_variable_unconditional`: `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)` unconditionally — no witness vector is assumed to exist — using `Douglas.pinv` (the pseudoinverse packaging form the issue asked for, since PR LionSR/QICLean#205/#5433's pinv API is on `main`).

This avoids the `EuclideanSpace`/`PiLp` range-ker duality route documented in `docs/paper-gaps/wolf_ch5_two_variable_unconditional.tex` as causing `whnf` timeouts: instead it uses `Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le` and the existing `Douglas.pinv`/`SchurComplement.R_mul_pinv_eq_supportProj` API, pure matrix algebra with no inner-product-space typeclass machinery.

The blueprint's `thm:two_variable_operator_schwarz` (`ch05_schwarz_abstract_domains_and_order_auxiliary.tex`) is rewritten to state Eq. (5.4) literally in this pseudoinverse form (matching the Lean statement exactly) and `\leanok` is restored (was `\notready`).

Note: the issue's suggested proof route also lists a separate "well-definedness" lemma (any two witnesses `w` give the same value). This wasn't needed as a standalone step here — the unconditional theorem is proved directly by constructing the canonical pseudoinverse witness and never comparing it against another; the end result is the same.

### LionSR/QICLean#268 — equality criterion

`TNLean/Channel/Schwarz/TwoVariableEquality.lean`:

- `HasSchwarzInequalityFor E B`: Wolf's per-`B` hypothesis (Eq. 5.4 holding for a fixed `B`, every `A`) — this is the exact hypothesis of the source's equality theorem (positive `T*`, not necessarily 2-positive).
- `equalityAttaining E B`: the equality-attaining set `𝒜_B`.
- `hasSchwarzInequalityFor_of_is2PositiveMap`: a 2-positive map satisfies the per-`B` hypothesis for every `B`, connecting to LionSR/QICLean#266's theorem.
- `schwarz_equality_criterion`: Wolf's Eq. (5.5) — for `A ∈ 𝒜_B` and every `X`, `E(A†B) · pinv(E(B†B)) · E(B†X) = E(A†X)`. Proved by Wolf's `tA + X` quadratic-in-`t` completing-the-square argument (matrix-valued quadratic form expanded bilinearly, `t²`-coefficient vanishes at the equality point, the linear-in-`t` term forced to vanish by applying at `X` and `iX`).
- `mem_equalityAttaining_of_forall_eq`: the converse, immediate by specializing the Eq. (5.5) identity at `X = A` (the source states only the forward direction).

New blueprint entries `def:has_schwarz_inequality_for`, `def:equality_attaining`, `thm:two_variable_schwarz_equality`, `cor:two_variable_schwarz_equality_converse`.

Also made `SchwarzMap.eq_zero_of_forall_quadratic_posSemidef` in `AbstractMultiplicativeDomain.lean` non-private (was already proving exactly the completing-the-square step this file needed) and reused it directly instead of duplicating it.

## Validation

- `lake build TNLean.Channel.Schwarz` (whole module tree) — succeeds.
- `#print axioms` on all new top-level theorems — only `propext`, `Classical.choice`, `Quot.sound`.
- `rg -n "sorry|axiom"` on all changed files — no matches.
- `lake exe lint_style` on all changed files — clean.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci` — clean.
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls` — 100% in sync.
- `python3 scripts/generate_import_aggregators.py` — regenerated, committed.

## Remaining gaps

None for the formalized statements. Wolf's full Theorem 5.3 proof route via Stinespring dilation (Eq. 5.2–5.3) remains a separate, unformalized alternative proof of the same inequality — not needed since the ampliated-block-matrix route already proves it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs in the Schwarz channel module with no changes to runtime behavior, auth, or data paths; risk is mainly proof-maintenance and API surface (public `eq_zero_of_forall_quadratic_posSemidef`).
> 
> **Overview**
> Formalizes Wolf Ch5 **Eq. (5.4)** unconditionally and the **equality criterion Eq. (5.5)** for the two-variable operator Schwarz inequality, with matching blueprint updates.
> 
> **Unconditional inequality** (`TwoVariableUnconditional.lean`): proves `E(A†B) · pinv(E(B†B)) · E(B†A) ≤ E(A†A)` for 2-positive maps via kernel inclusion from the ampliated PSD block matrix, support-projection absorption, and the explicit pseudoinverse witness `w = pinv(E(B†B)) · E(B†A) · v` plugged into the existing conditional `schwarz_two_variable` lemma—avoiding the EuclideanSpace/`whnf` route noted in the paper-gap doc.
> 
> **Equality criterion** (`TwoVariableEquality.lean`): introduces `HasSchwarzInequalityFor`, `equalityAttaining`, and `schwarz_equality_criterion` (Wolf’s completing-the-square on the matrix quadratic `QQ`), plus a converse by specializing at `X = A`.
> 
> **Shared infrastructure**: `SchwarzMap.eq_zero_of_forall_quadratic_posSemidef` in `AbstractMultiplicativeDomain.lean` is promoted from private to public for reuse; aggregator imports and blueprint entries (`thm:two_variable_operator_schwarz` marked `\leanok`, new defs/theorems for equality) are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf5d7e13dec1a0f331fb5cce6b9378551c113b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->