### PR TITLE
fix(tests/tenkz/rmp): name the marked braid site clear of its lattice dot

### DIFF
--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-three.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-three.tex
@@ -17,7 +17,7 @@
                 west=open, east=open, north=open, south=open]
     % the two-by-two lattice patch: the anyons stand on the right column
     \tn[at=(1,1), name=p]{}
-    \tn[at=(1,2), name=i, role=marked, label pos=sw]{i}
+    \tn[at=(1,2), name=i, role=marked, label pos=nw]{i}
     \tn[at=(2,1), name=q]{}
     \tn[at=(2,2), name=j, role=extra, label pos=sw]{j}
     % the resolver box stands east of the patch where the a-j crossing was

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -839,11 +839,11 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "4b921815dddebb9a7c3d74994edc8360928daa4654e714c627b176d9c91eed72"
+case_sha256 = "c195a96cdd5fcabb2da8adb4f903eda726ec6eb431dbe8e47a40847821bb1510"
 second_viewer = "braid-plane-remodel-second-pass-2026-08-06-400dpi"
 reviewed = "2026-08-06"
 renderer = "braid-plane-remodel-2026-08-06-200dpi"
-note = "the plane frame now carries the patch the source draws, so the lattice slant matches and every inter-site index is virtual while the four site legs end in air; the source-red strings still wind through their six bead stations into R_{j,a} with j and i at their corners, and a's fourth bead now sits where it laps the lattice line running north out of i; the resolver contour stands further east than the source parallelogram, which the source shears with the plane and uses to hide the a-b meeting"
+note = "The marked site names itself north-west, clear of the lattice dot its south-west station stood on. the plane frame now carries the patch the source draws, so the lattice slant matches and every inter-site index is virtual while the four site legs end in air; the source-red strings still wind through their six bead stations into R_{j,a} with j and i at their corners, and a's fourth bead now sits where it laps the lattice line running north out of i; the resolver contour stands further east than the source parallelogram, which the source shears with the plane and uses to hide the a-b meeting"
 
 [[verdict]]
 id = "rmp-iii-b-braid-four"


### PR DESCRIPTION
A follow-up to PR #5585. The plane re-model of `rmp-iii-b-braid-three` put a lattice dot exactly where the marked site's south-west label stood, and `tenkz_audit` caught it as a hard `label-overlap`: the label's bounding box intersects the circle glyph beneath it. The section run passed, so it surfaced only under `check --id` — which is how it reached main.

The site names itself north-west instead. I compared the two renders at 300 dpi: the label clears the dot and nothing else in the drawing moves. Of the four stations tried, `n` and `nw` both clear; `nw` keeps the label nearest its own site.

`case_sha256` re-pinned and the verdict note records the station.

## Test plan
- `tenkz_rmp.py check --id rmp-iii-b-braid-three` PASS.
- `tenkz_rmp.py check --section section-iii-b` PASS, 11 targets; verdicts unchanged at 90 faithful / 40 cosmetic-gap / 0 blocked.
- `test_tenkz_corpus_provenance.py` PASS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test corpus and verdict metadata only; no renderer or production code changes.
> 
> **Overview**
> Follow-up to the plane re-model of **`rmp-iii-b-braid-three`**: the marked site **`i`** used **`label pos=sw`**, which put its label on the same station as a lattice dot and triggered a hard **`label-overlap`** from **`tenkz_audit`** (section check passed; **`check --id`** caught it).
> 
> The case now uses **`label pos=nw`** so the label clears the dot without moving geometry or strings. **`verdicts.toml`** re-pins **`case_sha256`** and the verdict note records the station change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5790d8f88546496525172aa2d2045fb8a8941f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->