### PR TITLE
refactor(tenkz): emit the cup cubic once instead of four times

### DIFF
--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -10681,6 +10681,31 @@
 
 % Cup records already own the paired row or column indices.  Rendering only
 % turns those resolved endpoints into an outboard half-ellipse.
+% All four sides stroke the same cubic between the resolved endpoints: both
+% control points sit the stub distance outboard along the side's outward
+% axis.  The side branch supplies that offset term for each axis; the other
+% axis receives the empty term.
+\cs_new_protected:Npn \__tenkz_kernel_r_wire_cup_stroke:nn #1#2
+  {
+    \__tenkz_kernel_r_wire_stroke:nn { bond }
+      {
+        \__tenkz_kernel_r_pair:nn
+          { \l__tenkz_kernel_r_x_fp }
+          { \l__tenkz_kernel_r_y_fp }
+        .. controls
+          \__tenkz_kernel_r_pair:nn
+            { \l__tenkz_kernel_r_x_fp #1 }
+            { \l__tenkz_kernel_r_y_fp #2 }
+          and
+          \__tenkz_kernel_r_pair:nn
+            { \l__tenkz_kernel_r_xb_fp #1 }
+            { \l__tenkz_kernel_r_yb_fp #2 }
+        ..
+        \__tenkz_kernel_r_pair:nn
+          { \l__tenkz_kernel_r_xb_fp }
+          { \l__tenkz_kernel_r_yb_fp }
+      }
+  }
 \cs_new_protected:Npn \__tenkz_kernel_r_wire_cup:n #1
   {
     \__tenkz_model_get:nnN {#1} {side} \l__tenkz_kernel_r_tl
@@ -10698,30 +10723,8 @@
             \__tenkz_kernel_r_frame_xy:nnNN
               { \l__tenkz_kernel_r_col_tl } {1}
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_kernel_r_wire_stroke:nn { bond }
-              {
-                \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_x_fp }
-                  { \l__tenkz_kernel_r_y_fp }
-                .. controls
-                  \__tenkz_kernel_r_pair:nn
-                    {
-                      \l__tenkz_kernel_r_x_fp
-                      - \__tenkz_metric_ratio:n {stub}
-                    }
-                    { \l__tenkz_kernel_r_y_fp }
-                  and
-                  \__tenkz_kernel_r_pair:nn
-                    {
-                      \l__tenkz_kernel_r_xb_fp
-                      - \__tenkz_metric_ratio:n {stub}
-                    }
-                    { \l__tenkz_kernel_r_yb_fp }
-                ..
-                \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_xb_fp }
-                  { \l__tenkz_kernel_r_yb_fp }
-              }
+            \__tenkz_kernel_r_wire_cup_stroke:nn
+              { - \__tenkz_metric_ratio:n {stub} } { }
           }
         {east}
           {
@@ -10737,30 +10740,8 @@
               { \l__tenkz_kernel_r_col_tl }
               { \l__tenkz_kernel_r_cols_int }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_kernel_r_wire_stroke:nn { bond }
-              {
-                \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_x_fp }
-                  { \l__tenkz_kernel_r_y_fp }
-                .. controls
-                  \__tenkz_kernel_r_pair:nn
-                    {
-                      \l__tenkz_kernel_r_x_fp
-                      + \__tenkz_metric_ratio:n {stub}
-                    }
-                    { \l__tenkz_kernel_r_y_fp }
-                  and
-                  \__tenkz_kernel_r_pair:nn
-                    {
-                      \l__tenkz_kernel_r_xb_fp
-                      + \__tenkz_metric_ratio:n {stub}
-                    }
-                    { \l__tenkz_kernel_r_yb_fp }
-                ..
-                \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_xb_fp }
-                  { \l__tenkz_kernel_r_yb_fp }
-              }
+            \__tenkz_kernel_r_wire_cup_stroke:nn
+              { + \__tenkz_metric_ratio:n {stub} } { }
           }
         {north}
           {
@@ -10774,30 +10755,8 @@
             \__tenkz_kernel_r_frame_xy:nnNN
               {1} { \l__tenkz_kernel_r_col_tl }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_kernel_r_wire_stroke:nn { bond }
-              {
-                \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_x_fp }
-                  { \l__tenkz_kernel_r_y_fp }
-                .. controls
-                  \__tenkz_kernel_r_pair:nn
-                    { \l__tenkz_kernel_r_x_fp }
-                    {
-                      \l__tenkz_kernel_r_y_fp
-                      + \__tenkz_metric_ratio:n {stub}
-                    }
-                  and
-                  \__tenkz_kernel_r_pair:nn
-                    { \l__tenkz_kernel_r_xb_fp }
-                    {
-                      \l__tenkz_kernel_r_yb_fp
-                      + \__tenkz_metric_ratio:n {stub}
-                    }
-                ..
-                \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_xb_fp }
-                  { \l__tenkz_kernel_r_yb_fp }
-              }
+            \__tenkz_kernel_r_wire_cup_stroke:nn
+              { } { + \__tenkz_metric_ratio:n {stub} }
           }
         {south}
           {
@@ -10813,30 +10772,8 @@
               { \l__tenkz_kernel_r_rows_int }
               { \l__tenkz_kernel_r_col_tl }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_kernel_r_wire_stroke:nn { bond }
-              {
-                \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_x_fp }
-                  { \l__tenkz_kernel_r_y_fp }
-                .. controls
-                  \__tenkz_kernel_r_pair:nn
-                    { \l__tenkz_kernel_r_x_fp }
-                    {
-                      \l__tenkz_kernel_r_y_fp
-                      - \__tenkz_metric_ratio:n {stub}
-                    }
-                  and
-                  \__tenkz_kernel_r_pair:nn
-                    { \l__tenkz_kernel_r_xb_fp }
-                    {
-                      \l__tenkz_kernel_r_yb_fp
-                      - \__tenkz_metric_ratio:n {stub}
-                    }
-                ..
-                \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_xb_fp }
-                  { \l__tenkz_kernel_r_yb_fp }
-              }
+            \__tenkz_kernel_r_wire_cup_stroke:nn
+              { } { - \__tenkz_metric_ratio:n {stub} }
           }
       }
       {


### PR DESCRIPTION
Closes LionSR/tenkz#165.

The four side branches of `\__tenkz_kernel_r_wire_cup:n` wrote the same cubic Bezier path out verbatim, differing only in the outboard control-point offset: `-stub` on x for west, `+stub` on x for east, `+stub` on y for north, `-stub` on y for south. A single helper `\__tenkz_kernel_r_wire_cup_stroke:nn` now owns the path; each side passes its offset term for the outward axis and the empty term for the other axis. The substituted token streams are identical to the previous inline copies, so the saved routes and emitted events are unchanged. The four copies were confirmed identical apart from that offset — no hidden sign, anchor, or control-point-ordering differences.

## Evidence

- `scripts/tenkz_kernel_probes.sh --check`: 127 review regressions hold; 10 sugar spellings byte-identical to their expansions; 12 kernel record streams byte-identical; **kernel pixels byte-identical**.
- `scripts/tenkz_golden.sh --check`: 264 event streams byte-identical to the golden baseline.
- `scripts/tenkz_pixelpair.sh origin/main`: 6 pages byte-identical at 300 dpi against origin/main.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`: census stable at 201; meters byte-identical to `tests/tenkz/census-baseline.json`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Render-path refactor with no intended geometry change; risk is limited to accidental token-order differences in the shared helper, which the PR’s golden/pixel checks are meant to catch.
> 
> **Overview**
> **Cup wire rendering** in `tenkz-kernel.code.tex` no longer duplicates the same cubic Bezier bond stroke in each of the west/east/north/south branches of `\__tenkz_kernel_r_wire_cup:n`.
> 
> A new `\__tenkz_kernel_r_wire_cup_stroke:nn` builds the shared path (endpoints plus outboard control points at stub distance). Each side branch still resolves frame anchors as before, then calls the helper with two offset fragments: the outward-axis stub term (`± \__tenkz_metric_ratio:n {stub}` on x or y) and an empty term on the other axis. Inline comments document that shared geometry.
> 
> This is a structural deduplication only; emitted paths and pixels are intended to match the prior four inline copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e2a966102e30923096dde3e82ae667afb2fca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->