### PR TITLE
refactor(tenkz): rehome the fusion-tree drawer out of the cd dialect

### DIFF
--- a/docs/tenkz/ARCHITECTURE.md
+++ b/docs/tenkz/ARCHITECTURE.md
@@ -103,7 +103,8 @@ geometry service:
 
 - grid layout for `tenkz`;
 - lattice layout, including the `tenkzplanes` preset;
-- map, polygon, and fusion-tree layout for `tenkzcd`;
+- map and polygon layout for `tenkzcd`;
+- fusion-tree layout for the standalone `\tntree` atom;
 - explicitly placed typed-graph layout for `tenkzfree`.
 
 Dialect layout owns only placement rules that are genuinely specific to that

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -372,9 +372,9 @@ and next-stage contract.
 
 These are normative ownership rules for new code and migration destinations,
 not a claim that every historical path has moved.  The live `tenkz-core`,
-`tenkz-grid`, `tenkz-cd`, `tenkz-lattice`, and `tenkz-free` files still combine
-some parsing, geometry, rendering, and event work; direct `\draw` or `\node`
-emission in those files remains migration debt.
+`tenkz-grid`, `tenkz-tree`, `tenkz-cd`, `tenkz-lattice`, and `tenkz-free` files
+still combine some parsing, geometry, rendering, and event work; direct `\draw`
+or `\node` emission in those files remains migration debt.
 
 - `tenkz-model.code.tex` owns normalized semantic records and freezes topology
   after validation.

--- a/tests/tenkz/render-census-baseline.json
+++ b/tests/tenkz/render-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "raw_ink": {
     "by_file": {
-      "tenkz-cd.code.tex": 21,
+      "tenkz-cd.code.tex": 7,
       "tenkz-core.code.tex": 8,
       "tenkz-frame.code.tex": 0,
       "tenkz-free.code.tex": 0,
@@ -13,7 +13,8 @@
       "tenkz-metric.code.tex": 0,
       "tenkz-model.code.tex": 0,
       "tenkz-render.code.tex": 0,
-      "tenkz-string.code.tex": 2
+      "tenkz-string.code.tex": 2,
+      "tenkz-tree.code.tex": 14
     },
     "total": 38
   },
@@ -31,7 +32,8 @@
       "tenkz-metric.code.tex": 0,
       "tenkz-model.code.tex": 0,
       "tenkz-render.code.tex": 0,
-      "tenkz-string.code.tex": 0
+      "tenkz-string.code.tex": 0,
+      "tenkz-tree.code.tex": 0
     },
     "total": 20
   }

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -1,13 +1,8 @@
-% Input: validated map, fusion-tree, and coherence-diagram declarations.
+% Input: validated map and coherence-diagram declarations.
 % Output: normalized typed connections and cd-specific layout ink.
-% Owned state: parsed trees, map matrices, polygon slots, and arrow declarations.
+% Owned state: map matrices, polygon slots, and arrow declarations.
 % Invariants: labels and topology validate before any measured layout pass.
 % Next stage: shared event services emit the resolved model used for rendering.
-%
-%   \tntree[keys]{(((a\,b)_x\,c)_y\,d)_e}
-%       a fusion tree from a parenthesization word: leaves on a top
-%       line, one junction per fused pair, internal charges on the
-%       downward edges, a short rooted leg carrying the total charge.
 %
 %   \begin{tenkzcd}[polygon=n, radius=..]
 %     cell & cell & ... \tnarrow[from=i, to=j]{label} ...
@@ -21,34 +16,13 @@
 %       may hold tenkz objects (\tntree, \tnpic) since those are
 %       self-contained boxes.
 %
-% Both environments and the standalone tree are math atoms: the baseline
-% is the vertical middle of the picture lowered by the math axis, so a
-% diagram centers on the axis of the surrounding formula.
+% Both environments are math atoms: the baseline is the vertical middle
+% of the picture lowered by the math axis, so a diagram centers on the
+% axis of the surrounding formula.  The axis reader and baseline style
+% live in tenkz-tree.code.tex, which outlives this dialect (#4699).
 
 \ExplSyntaxOn
 
-% ---------- tree metrics (ratios of pitch) ----------
-% Sibling pitch of the leaf row and the depth of one fusion level share
-% one ratio, so every edge of a balanced pair meets its junction at 45
-% degrees; the root leg is shorter than a level so the tree reads as
-% rooted, not as one more leaf.
-\def\tenkz@r@treestep{0.55}
-\def\tenkz@r@treeleg{0.35}
-% One ribbon is a band, not a fused wire: 0.13 pitch gives its two
-% wire-weight boundary curves visible daylight at compact scale.  The
-% vertex-patch reach exceeds the half-width so its three sector arcs
-% remain distinct at the most acute junctions in a four-leaf tree; 0.72
-% measures how far each cubic control travels from its mouth toward the
-% vertex, leaving a rounded nonzero waist between the three sectors.
-\def\tenkz@r@treeribbonhalf{0.065}
-\def\tenkz@r@treepatchreach{0.16}
-\def\tenkz@r@treepatchcontrol{0.72}
-% TikZ's rotated calc-coordinate delimiter must have the ordinary colon
-% catcode, so keep this tiny coordinate primitive outside expl3 syntax.
-\ExplSyntaxOff
-\def\tenkz@ribbonoffset#1#2#3#4#5{%
-  \coordinate (#1) at ($(#2)!#4!#5:(#3)$);}
-\ExplSyntaxOn
 % Typed-map rows are mathematical objects joined by named maps.  One
 % third-pitch column air is the floor for an unlabelled or sub-floor band;
 % measured names grow it before placement.  Half a pitch separates family
@@ -57,46 +31,6 @@
 \def\tenkz@r@maprowsep{0.50}
 
 % ---------- state ----------
-\seq_new:N \l__tenkzcd_items_seq     % parenthesization word, one item each
-\seq_new:N \l__tenkzcd_stack_seq     % {x}{level}{charge}{node}{topology}
-\seq_new:N \l__tenkzcd_vertices_seq  % postorder {node}{left}{right}
-\prop_new:N \l__tenkzcd_parent_prop  % node id -> parent node id or root
-\prop_new:N \l__tenkzcd_internal_prop % node id -> marker
-\tl_new:N  \l__tenkzcd_word_tl
-\tl_new:N  \l__tenkzcd_item_tl
-\tl_new:N  \l__tenkzcd_charge_tl
-\tl_new:N  \l__tenkzcd_ca_tl
-\tl_new:N  \l__tenkzcd_cb_tl
-\tl_new:N  \l__tenkzcd_cha_tl
-\tl_new:N  \l__tenkzcd_chb_tl
-\tl_new:N  \l__tenkzcd_anchor_tl
-\tl_new:N  \l__tenkzcd_tree_skin_tl
-\tl_new:N  \l__tenkzcd_tree_role_tl
-\tl_new:N  \l__tenkzcd_tree_species_tl
-\tl_new:N  \l__tenkzcd_tree_path_tl
-\tl_new:N  \l__tenkzcd_tree_fill_tl
-\tl_new:N  \l__tenkzcd_tree_junction_tl
-\tl_new:N  \l__tenkzcd_parent_tl
-\tl_new:N  \l__tenkzcd_topoa_tl
-\tl_new:N  \l__tenkzcd_topob_tl
-\tl_new:N  \l__tenkzcd_topop_tl
-\int_new:N \l__tenkzcd_leaf_int
-\int_new:N \l__tenkzcd_node_int
-\int_new:N \l__tenkzcd_nodea_int
-\int_new:N \l__tenkzcd_nodeb_int
-\int_new:N \l__tenkzcd_nodep_int
-% Picture ids cannot distinguish several standalone trees, so tree ids
-% are document-global and also keep every TikZ coordinate name unique.
-\int_new:N \g__tenkzcd_tree_int
-\int_new:N \l__tenkzcd_la_int
-\int_new:N \l__tenkzcd_lb_int
-\int_new:N \l__tenkzcd_lp_int
-\dim_new:N \l__tenkzcd_xa_dim
-\dim_new:N \l__tenkzcd_xb_dim
-\dim_new:N \l__tenkzcd_xp_dim
-\dim_new:N \l__tenkzcd_off_dim
-\dim_new:N \l__tenkzcd_axis_dim
-% tenkzcd
 \int_new:N \l__tenkzcd_ngon_int
 \int_new:N \l__tenkzcd_i_int
 \tl_new:N  \l__tenkzcd_radius_tl
@@ -194,26 +128,6 @@
 % scope family (GOAL.md "one universal language").
 \tenkz_install_core_forwards:nn {cd} {pitch,compact,inline,tensor~style,species}
 \pgfkeys{
-  /tenkz/tree/.is~family,
-  /tenkz/tree/tree~style/.is~choice,
-  /tenkz/tree/tree~style/wire/.code={\tl_set:Nn \l__tenkzcd_tree_skin_tl {wire}},
-  /tenkz/tree/tree~style/ribbon/.code={\tl_set:Nn \l__tenkzcd_tree_skin_tl {ribbon}},
-  /tenkz/tree/role/.is~choice,
-  /tenkz/tree/role/operator/.code={\tl_set:Nn \l__tenkzcd_tree_role_tl {operator}},
-  /tenkz/tree/role/marked/.code={\tl_set:Nn \l__tenkzcd_tree_role_tl {marked}},
-  /tenkz/tree/role/extra/.code={\tl_set:Nn \l__tenkzcd_tree_role_tl {extra}},
-  /tenkz/tree/role/passive/.code={\tl_set:Nn \l__tenkzcd_tree_role_tl {passive}},
-  /tenkz/tree/species/.code={
-    \tenkz_species_check:n {#1}
-    \tl_set:Nn \l__tenkzcd_tree_species_tl {#1}
-  },
-}
-% pitch=/compact=/inline= forward to the shared /tenkz key space
-% (tenkz-core.code.tex); tree is command-scope like /tenkz/cell, so it
-% keeps its own role=/species= above (per-vertex, validated) instead of
-% the picture-scope forwarding species= the other three families use.
-\tenkz_install_core_forwards:nn {tree} {pitch,compact,inline}
-\pgfkeys{
   /tenkz/arrow/.is~family,
   /tenkz/arrow/from/.store~in=\l__tenkzcd_afrom_tl,
   /tenkz/arrow/to/.store~in=\l__tenkzcd_ato_tl,
@@ -228,461 +142,6 @@
     \tl_set:Nn \l__tenkzcd_aspecies_tl {#1}
   },
 }
-
-% ---------- the fusion tree ----------
-% Grammar of the parenthesization word:
-%   node   :=  leaf  |  ( node node ) [ _ charge ]
-%   leaf, charge  :=  one character or one braced group
-% Separators (\, and spaces) are stripped before parsing.  The word is
-% flattened into a sequence of items and consumed left to right by a
-% recursive-descent parser; every finished subtree pushes its root
-% {x}{level}{charge} onto a value stack, so a fused pair pops its two
-% children, joins them, and pushes the joint.
-%
-% Layout: leaves sit on the line y = 0, spaced by one tree step; an
-% internal vertex sits at the x-midpoint of its children's roots, one
-% level below the deeper child (level = 1 + max of the child levels,
-% y = -level steps).  Charges are typeset only when the vertex's
-% downward edge is known, so they can be set clear of the ink.
-
-% y-coordinate of a fusion level (integer factor on the right)
-\cs_new:Npn \tenkz_cd_levely:n #1
-  { \dim_eval:n { -\tenkz@r@treestep\tenkz@pitch * (#1) } }
-
-% ---------- picture framing ----------
-% Every cd picture is a math atom sharing one baseline.  Read the axis
-% height (NFSS sets math fonts up lazily, so force them first), then lower
-% the picture's bounding-box centre by it so the diagram centres on the
-% surrounding formula's axis.
-\cs_new_protected:Npn \tenkz_cd_read_axis:
-  { \check@mathfonts
-    \dim_set:Nn \l__tenkzcd_axis_dim { \fontdimen22\textfont2 } }
-\tikzset{
-  tenkz~cd~baseline/.style={
-    baseline={([yshift=-\dim_use:N \l__tenkzcd_axis_dim]
-               current~bounding~box.center)} } }
-
-\cs_new_protected:Npn \tenkz_cd_tree_node:
-  {
-    \seq_pop_left:NNTF \l__tenkzcd_items_seq \l__tenkzcd_item_tl
-      {
-        \str_if_eq:VnTF \l__tenkzcd_item_tl { ( }
-          { \tenkz_cd_tree_internal: }
-          { \tenkz_cd_tree_leaf: }
-      }
-      { \PackageError{tenkz}{Malformed~tree:~unexpected~end~of~word}{} }
-  }
-
-% a leaf: a wire endpoint on the top line, its label above the tip.
-% Grammar guard: `_` and `)` can only reach the leaf position through a
-% malformed word -- `(a_u\,b)_x` tries to charge a leaf (the grammar
-% attaches charges to fused pairs only), `(a)` fuses a single node --
-% and typesetting them as leaves dies later with a raw TeX error, so
-% both stop here with the grammar rule spelled out.
-\cs_new_protected:Npn \tenkz_cd_tree_leaf:
-  {
-    \str_if_eq:VnT \l__tenkzcd_item_tl { _ }
-      { \PackageError{tenkz}{Malformed~tree:~a~charge~(_)~may~only~
-          follow~a~fused~pair's~closing~parenthesis}{} }
-    \str_if_eq:VnT \l__tenkzcd_item_tl { ) }
-      { \PackageError{tenkz}{Malformed~tree:~unexpected~')'~--~a~fused~
-          pair~takes~exactly~two~nodes}{} }
-    \dim_set:Nn \l__tenkzcd_xa_dim
-      { \tenkz@r@treestep\tenkz@pitch * \l__tenkzcd_leaf_int }
-    \int_incr:N \l__tenkzcd_leaf_int
-    \int_incr:N \l__tenkzcd_node_int
-    \coordinate
-      (tenkztree-\int_use:N\g__tenkzcd_tree_int-
-       \int_use:N\l__tenkzcd_node_int) at
-      (\dim_use:N \l__tenkzcd_xa_dim, 0pt);
-    \node[tn~label, anchor=south] at
-      (\dim_use:N \l__tenkzcd_xa_dim, \tenkz@dim{\tenkz@r@labelclear})
-      { $\tenkz@labelsize \tl_use:N \l__tenkzcd_item_tl$ };
-    \seq_put_right:Ne \l__tenkzcd_stack_seq
-      { { \dim_use:N \l__tenkzcd_xa_dim }{ 0 }{ }
-        { \int_use:N \l__tenkzcd_node_int }
-        { \int_use:N \l__tenkzcd_leaf_int } }
-  }
-
-% ( node node ) [_ charge]
-\cs_new_protected:Npn \tenkz_cd_tree_internal:
-  {
-    \tenkz_cd_tree_node:
-    \tenkz_cd_tree_node:
-    % the closing parenthesis
-    \seq_pop_left:NNTF \l__tenkzcd_items_seq \l__tenkzcd_item_tl
-      {
-        \str_if_eq:VnF \l__tenkzcd_item_tl { ) }
-          { \PackageError{tenkz}
-              {Malformed~tree:~expected~a~closing~parenthesis}{} }
-      }
-      { \PackageError{tenkz}{Malformed~tree:~unexpected~end~of~word}{} }
-    % the optional charge (parsed after the recursion, so the local
-    % charge register belongs to this vertex).  Peek at the next item: a
-    % leading `_` consumes the charge; anything else is the next node and
-    % is left in place for the parser to pick up.
-    \tl_clear:N \l__tenkzcd_charge_tl
-    \seq_get_left:NNT \l__tenkzcd_items_seq \l__tenkzcd_item_tl
-      {
-        \str_if_eq:VnT \l__tenkzcd_item_tl { _ }
-          {
-            \seq_pop_left:NN \l__tenkzcd_items_seq \l__tenkzcd_item_tl
-            \seq_pop_left:NNF \l__tenkzcd_items_seq \l__tenkzcd_charge_tl
-              { \PackageError{tenkz}{Malformed~tree:~dangling~charge}{} }
-          }
-      }
-    % pop the two children and fuse them
-    \seq_pop_right:NN \l__tenkzcd_stack_seq \l__tenkzcd_cb_tl
-    \seq_pop_right:NN \l__tenkzcd_stack_seq \l__tenkzcd_ca_tl
-    \exp_last_unbraced:NNV \tenkz_cd_unpack:Nnnnnn a \l__tenkzcd_ca_tl
-    \exp_last_unbraced:NNV \tenkz_cd_unpack:Nnnnnn b \l__tenkzcd_cb_tl
-    \tenkz_cd_tree_fuse:
-  }
-
-% A fusion vertex always has exactly two children, so the two popped
-% stack tuples are unpacked by the same five assignments; #1 (bare `a`
-% or `b`) selects which child's register family receives them, via the
-% `x#1_dim`/`l#1_int`/`ch#1_tl`/`node#1_int`/`topo#1_tl` naming already
-% shared by both families -- one function body instead of two.
-\cs_new_protected:Npn \tenkz_cd_unpack:Nnnnnn #1#2#3#4#5#6
-  {
-    \dim_set:cn { l__tenkzcd_x #1 _dim }     {#2}
-    \int_set:cn { l__tenkzcd_l #1 _int }     {#3}
-    \tl_set:cn  { l__tenkzcd_ch #1 _tl }     {#4}
-    \int_set:cn { l__tenkzcd_node #1 _int }  {#5}
-    \tl_set:cn  { l__tenkzcd_topo #1 _tl }   {#6}
-  }
-
-% Join the two children on the stack.  Parsing records one abstract
-% trivalent vertex; the selected skin draws that same record only after
-% the full word has been parsed, when the third (parent) direction is
-% known.  This separation is what lets the ribbon skin draw a regular
-% ribbon neighbourhood instead of guessing a vertical output at
-% every vertex.
-\cs_new_protected:Npn \tenkz_cd_tree_fuse:
-  {
-    \int_set:Nn \l__tenkzcd_lp_int
-      { 1 + \int_max:nn { \l__tenkzcd_la_int } { \l__tenkzcd_lb_int } }
-    \dim_set:Nn \l__tenkzcd_xp_dim
-      { ( \l__tenkzcd_xa_dim + \l__tenkzcd_xb_dim ) / 2 }
-    \int_incr:N \l__tenkzcd_node_int
-    \int_set_eq:NN \l__tenkzcd_nodep_int \l__tenkzcd_node_int
-    \coordinate
-      (tenkztree-\int_use:N\g__tenkzcd_tree_int-
-       \int_use:N\l__tenkzcd_nodep_int) at
-      (\dim_use:N \l__tenkzcd_xp_dim,
-       \tenkz_cd_levely:n {\l__tenkzcd_lp_int});
-    \prop_put:Nee \l__tenkzcd_parent_prop
-      { \int_use:N \l__tenkzcd_nodea_int }
-      { \int_use:N \l__tenkzcd_nodep_int }
-    \prop_put:Nee \l__tenkzcd_parent_prop
-      { \int_use:N \l__tenkzcd_nodeb_int }
-      { \int_use:N \l__tenkzcd_nodep_int }
-    \prop_put:Nee \l__tenkzcd_internal_prop
-      { \int_use:N \l__tenkzcd_nodep_int } {1}
-    \tl_if_blank:VF \l__tenkzcd_cha_tl
-      { \tenkz_cd_edge_charge:NnN \l__tenkzcd_xa_dim
-          {\l__tenkzcd_la_int} \l__tenkzcd_cha_tl }
-    \tl_if_blank:VF \l__tenkzcd_chb_tl
-      { \tenkz_cd_edge_charge:NnN \l__tenkzcd_xb_dim
-          {\l__tenkzcd_lb_int} \l__tenkzcd_chb_tl }
-    \seq_put_right:Ne \l__tenkzcd_vertices_seq
-      { { \int_use:N \l__tenkzcd_nodep_int }
-        { \int_use:N \l__tenkzcd_nodea_int }
-        { \int_use:N \l__tenkzcd_nodeb_int } }
-    \seq_put_right:Ne \l__tenkzcd_stack_seq
-      { { \dim_use:N \l__tenkzcd_xp_dim }{ \int_use:N \l__tenkzcd_lp_int }
-        { \exp_not:V \l__tenkzcd_charge_tl }
-        { \int_use:N \l__tenkzcd_nodep_int }
-        { (\exp_not:V\l__tenkzcd_topoa_tl,
-           \exp_not:V\l__tenkzcd_topob_tl) } }
-  }
-
-% A charge labels its vertex's downward edge, half a fusion level below
-% the vertex, on the side of the edge away from the parent.  Both child
-% edges of the vertex lie above it and every other edge lies beyond the
-% downward edge on the parent's side, so that quadrant is ink-free by
-% construction.  #1 = x register of the vertex, #2 = its level, #3 =
-% charge register; the parent's x register is still live.
-\cs_new_protected:Npn \tenkz_cd_edge_charge:NnN #1#2#3
-  {
-    % rightward-descending edge (xp right of the vertex): label the free
-    % LEFT side, anchor east, clearance subtracted; leftward or straight:
-    % label the RIGHT side, anchor west, clearance added
-    \dim_compare:nNnTF { \l__tenkzcd_xp_dim } > { #1 }
-      { \tl_set:Nn \l__tenkzcd_anchor_tl {east}
-        \dim_set:Nn \l__tenkzcd_off_dim { -\tenkz@dim{\tenkz@r@labelclear} } }
-      { \tl_set:Nn \l__tenkzcd_anchor_tl {west}
-        \dim_set:Nn \l__tenkzcd_off_dim { \tenkz@dim{\tenkz@r@labelclear} } }
-    \node[tn~label, anchor=\l__tenkzcd_anchor_tl] at
-      (\dim_eval:n{ #1 + \l__tenkzcd_off_dim },
-       \dim_eval:n{ \tenkz_cd_levely:n {#2}
-                    - \tenkz@r@treestep\tenkz@pitch / 2 })
-      { $\tenkz@labelsize \tl_use:N #3$ };
-  }
-
-% Resolve the semantic ink once per tree.  Species is the first
-% indirection and role wins, matching every other tenkz element.
-\cs_new_protected:Npn \tenkz_cd_tree_resolve_style:
-  {
-    \tl_set:Nn \l__tenkzcd_tree_path_tl {bond}
-    \tl_set:Nn \l__tenkzcd_tree_fill_tl {tree~ribbon~fill}
-    \tl_set:Nn \l__tenkzcd_tree_junction_tl {tree~junction}
-    \tl_if_blank:VF \l__tenkzcd_tree_species_tl
-      {
-        \tl_set:Ne \l__tenkzcd_tree_path_tl
-          {species~\tl_use:N\l__tenkzcd_tree_species_tl\c_space_tl bond}
-        \tl_set:Ne \l__tenkzcd_tree_fill_tl
-          {species~\tl_use:N\l__tenkzcd_tree_species_tl\c_space_tl ribbon~fill}
-        \tl_set:Ne \l__tenkzcd_tree_junction_tl
-          {species~\tl_use:N\l__tenkzcd_tree_species_tl
-            \c_space_tl tree~junction}
-      }
-    \tl_if_blank:VF \l__tenkzcd_tree_role_tl
-      {
-        \tl_set:Ne \l__tenkzcd_tree_path_tl
-          {\tl_use:N\l__tenkzcd_tree_role_tl\c_space_tl bond}
-        \tl_set:Ne \l__tenkzcd_tree_fill_tl
-          {\tl_use:N\l__tenkzcd_tree_role_tl\c_space_tl ribbon~fill}
-        \tl_set:Ne \l__tenkzcd_tree_junction_tl
-          {\tl_use:N\l__tenkzcd_tree_role_tl\c_space_tl tree~junction}
-      }
-    \str_if_eq:VnT \l__tenkzcd_tree_skin_tl {ribbon}
-      {
-        \tl_if_blank:VTF \l__tenkzcd_tree_role_tl
-          {
-            \tl_if_blank:VTF \l__tenkzcd_tree_species_tl
-              { \tl_set:Nn \l__tenkzcd_tree_path_tl {tree~ribbon} }
-              { \tl_set:Ne \l__tenkzcd_tree_path_tl
-                  {species~\tl_use:N\l__tenkzcd_tree_species_tl
-                    \c_space_tl ribbon} }
-          }
-          { \tl_set:Ne \l__tenkzcd_tree_path_tl
-              {\tl_use:N\l__tenkzcd_tree_role_tl\c_space_tl ribbon} }
-      }
-  }
-
-\cs_new:Npn \tenkz_cd_tree_name:n #1
-  { tenkztree-\int_use:N\g__tenkzcd_tree_int-#1 }
-
-\cs_new_protected:Npn \tenkz_cd_wire_vertex:nnn #1#2#3
-  {
-    \draw[\l__tenkzcd_tree_path_tl]
-      (\tenkz_cd_tree_name:n {#2}) -- (\tenkz_cd_tree_name:n {#1});
-    \draw[\l__tenkzcd_tree_path_tl]
-      (\tenkz_cd_tree_name:n {#3}) -- (\tenkz_cd_tree_name:n {#1});
-    \node[\l__tenkzcd_tree_junction_tl] at
-      (\tenkz_cd_tree_name:n {#1}) {};
-  }
-
-% One band owns the filled strip and its two boundaries between leaf/root
-% endpoints or vertex-patch mouths.  It is deliberately not TikZ's
-% `double' stroke: the two curves bound a surface, while the disjoint
-% vertex patch owns all ink inside each trivalent neighbourhood.
-\cs_new_protected:Npn \tenkz_cd_ribbon_band:nn #1#2
-  {
-    % Each internal endpoint is trimmed to its patch mouth.  The patch,
-    % not a center-to-center contour hidden underneath it, owns every
-    % junction.  Leaves and the root remain untrimmed.
-    \coordinate (tenkzearaw) at (\tenkz_cd_tree_name:n {#1});
-    \coordinate (tenkzebraw) at (\tenkz_cd_tree_name:n {#2});
-    \prop_if_in:NnTF \l__tenkzcd_internal_prop {#1}
-      { \coordinate (tenkzea) at
-          ($(tenkzearaw)!\tenkz@r@treepatchreach\tenkz@pitch!
-            (tenkzebraw)$); }
-      { \coordinate (tenkzea) at (tenkzearaw); }
-    \prop_if_in:NnTF \l__tenkzcd_internal_prop {#2}
-      { \coordinate (tenkzeb) at
-          ($(tenkzebraw)!\tenkz@r@treepatchreach\tenkz@pitch!
-            (tenkzearaw)$); }
-      { \coordinate (tenkzeb) at (tenkzebraw); }
-    \draw[\l__tenkzcd_tree_fill_tl, line~cap=butt,
-      line~width=\dim_eval:n {2\tenkz@dim{\tenkz@r@treeribbonhalf}}]
-      (tenkzea) -- (tenkzeb);
-    % Calc's rotated-coordinate scanner is deliberately fed plain names;
-    % expl3 function tokens inside the rotated target are not scan-safe.
-    \tenkz@ribbonoffset{tenkzeaL}{tenkzea}{tenkzeb}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
-    \tenkz@ribbonoffset{tenkzeaR}{tenkzea}{tenkzeb}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
-    \tenkz@ribbonoffset{tenkzebL}{tenkzeb}{tenkzea}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
-    \tenkz@ribbonoffset{tenkzebR}{tenkzeb}{tenkzea}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
-    \draw[\l__tenkzcd_tree_path_tl]
-      (tenkzeaL) -- (tenkzebR);
-    \draw[\l__tenkzcd_tree_path_tl]
-      (tenkzeaR) -- (tenkzebL);
-  }
-\cs_new_protected:Npn \tenkz_cd_ribbon_vertex_bands:nnn #1#2#3
-  {
-    \tenkz_cd_ribbon_band:nn {#1}{#2}
-    \tenkz_cd_ribbon_band:nn {#1}{#3}
-  }
-
-% The central patch is the regular ribbon neighbourhood of a trivalent
-% vertex: a disc with three attached bands.  Each sector arc has two
-% distinct controls, so the patch retains a nonzero waist and its boundary
-% never pinches or crosses.  No tensor bead or fused-bond glyph is inserted.
-\cs_new_protected:Npn \tenkz_cd_ribbon_patch:nnnn #1#2#3#4
-  {
-    \coordinate (tenkzvc) at (\tenkz_cd_tree_name:n {#1});
-    \coordinate (tenkzva) at (\tenkz_cd_tree_name:n {#2});
-    \coordinate (tenkzvb) at (\tenkz_cd_tree_name:n {#3});
-    \coordinate (tenkzvp) at (#4);
-    \coordinate (tenkzpa) at
-      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzva)$);
-    \coordinate (tenkzpb) at
-      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzvb)$);
-    \coordinate (tenkzpp) at
-      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzvp)$);
-    \tenkz@ribbonoffset{tenkzpaL}{tenkzpa}{tenkzva}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
-    \tenkz@ribbonoffset{tenkzpaR}{tenkzpa}{tenkzva}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
-    \tenkz@ribbonoffset{tenkzpbL}{tenkzpb}{tenkzvb}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
-    \tenkz@ribbonoffset{tenkzpbR}{tenkzpb}{tenkzvb}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
-    \tenkz@ribbonoffset{tenkzppL}{tenkzpp}{tenkzvp}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
-    \tenkz@ribbonoffset{tenkzppR}{tenkzpp}{tenkzvp}
-      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
-    \path[\l__tenkzcd_tree_fill_tl, draw=none]
-      (tenkzpbL)
-        .. controls ($(tenkzpbL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        and ($(tenkzpaR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        .. (tenkzpaR) --
-      (tenkzpaL)
-        .. controls ($(tenkzpaL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        and ($(tenkzppR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        .. (tenkzppR) --
-      (tenkzppL)
-        .. controls ($(tenkzppL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        and ($(tenkzpbR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        .. (tenkzpbR) -- cycle;
-    \draw[\l__tenkzcd_tree_path_tl]
-      (tenkzpbL)
-        .. controls ($(tenkzpbL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        and ($(tenkzpaR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        .. (tenkzpaR);
-    \draw[\l__tenkzcd_tree_path_tl]
-      (tenkzpaL)
-        .. controls ($(tenkzpaL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        and ($(tenkzppR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        .. (tenkzppR);
-    \draw[\l__tenkzcd_tree_path_tl]
-      (tenkzppL)
-        .. controls ($(tenkzppL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        and ($(tenkzpbR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
-        .. (tenkzpbR);
-  }
-
-\cs_new_protected:Npn \tenkz_cd_ribbon_vertex_patch:nnn #1#2#3
-  {
-    \prop_get:NnNTF \l__tenkzcd_parent_prop {#1} \l__tenkzcd_parent_tl
-      {
-        \str_if_eq:VnTF \l__tenkzcd_parent_tl {root}
-          { \tenkz_cd_ribbon_patch:nnnn {#1}{#2}{#3}
-              {tenkztree-\int_use:N\g__tenkzcd_tree_int-root} }
-          { \tenkz_cd_ribbon_patch:nnnn {#1}{#2}{#3}
-              {\tenkz_cd_tree_name:n {\l__tenkzcd_parent_tl}} }
-      }
-      { \PackageError{tenkz}{Internal~tree~vertex~#1~has~no~parent}{} }
-  }
-
-\cs_new_protected:Npn \tenkz_cd_tree_geometry:n #1
-  {
-    \begin{pgfonlayer}{background}
-      \str_if_eq:VnTF \l__tenkzcd_tree_skin_tl {wire}
-        {
-          \seq_map_inline:Nn \l__tenkzcd_vertices_seq
-            { \tenkz_cd_wire_vertex:nnn ##1 }
-          \draw[\l__tenkzcd_tree_path_tl]
-            (\tenkz_cd_tree_name:n {#1}) --
-            (tenkztree-\int_use:N\g__tenkzcd_tree_int-root);
-        }
-        {
-          \seq_map_inline:Nn \l__tenkzcd_vertices_seq
-            { \tenkz_cd_ribbon_vertex_bands:nnn ##1 }
-          \tenkz_cd_ribbon_band:nn {#1}{root}
-          \seq_map_inline:Nn \l__tenkzcd_vertices_seq
-            { \tenkz_cd_ribbon_vertex_patch:nnn ##1 }
-        }
-    \end{pgfonlayer}
-  }
-
-% The root creates the third direction of its vertex, renders the selected
-% skin from the recorded topology, and finally places the total charge.
-\cs_new_protected:Npn \tenkz_cd_tree_root:nnnnn #1#2#3#4#5
-  {
-    \tl_set:Nn \l__tenkzcd_topop_tl {#5}
-    \coordinate (tenkztree-\int_use:N\g__tenkzcd_tree_int-root) at
-      (#1, \dim_eval:n{ \tenkz_cd_levely:n {#2}
-                        - \tenkz@r@treeleg\tenkz@pitch });
-    \prop_put:Nnn \l__tenkzcd_parent_prop {#4} {root}
-    \tenkz_cd_tree_geometry:n {#4}
-    \tl_if_blank:nF {#3}
-      {
-        \node[tn~label, anchor=west] at
-          (\dim_eval:n{ #1 + \tenkz@dim{\tenkz@r@labelclear} },
-           \dim_eval:n{ \tenkz_cd_levely:n {#2}
-                        - \tenkz@r@treeleg\tenkz@pitch / 2 })
-          { $\tenkz@labelsize #3$ };
-      }
-  }
-
-\NewDocumentCommand \tntree { O{} m }
-  { \tenkz_cd_tree:nn {#1} {#2} }
-
-\cs_new_protected:Npn \tenkz_cd_tree:nn #1#2
-  {
-    \group_begin:
-    \tl_set:Nn \l__tenkzcd_tree_skin_tl {wire}
-    \tl_clear:N \l__tenkzcd_tree_role_tl
-    \tl_clear:N \l__tenkzcd_tree_species_tl
-    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/tree}{#1} }
-    \tenkz_cd_tree_resolve_style:
-    \int_gincr:N \g__tenkzcd_tree_int
-    % \, and spaces are separators, not syntax; flatten to items
-    % (spaces never form items, so only \, needs stripping)
-    \tl_set:Nn \l__tenkzcd_word_tl {#2}
-    \tl_remove_all:Nn \l__tenkzcd_word_tl { \, }
-    \seq_clear:N \l__tenkzcd_items_seq
-    \tl_map_inline:Nn \l__tenkzcd_word_tl
-      { \seq_put_right:Nn \l__tenkzcd_items_seq {##1} }
-    \seq_clear:N \l__tenkzcd_stack_seq
-    \seq_clear:N \l__tenkzcd_vertices_seq
-    \prop_clear:N \l__tenkzcd_parent_prop
-    \prop_clear:N \l__tenkzcd_internal_prop
-    \int_zero:N \l__tenkzcd_leaf_int
-    \int_zero:N \l__tenkzcd_node_int
-    \tenkz_cd_read_axis:
-    \begin{tikzpicture}[ tenkz~every~picture, tenkz~cd~baseline ]
-      \tenkz_cd_tree_node:
-      % exactly one tree per word: leftover items after the root parse
-      % would otherwise vanish, rendering a plausible tree of the WRONG
-      % parenthesization word (`a\,b` would draw the one-leaf tree `a`)
-      \seq_if_empty:NF \l__tenkzcd_items_seq
-        { \PackageError{tenkz}{Malformed~tree:~trailing~material~after~
-            the~root~--~a~word~denotes~exactly~one~tree}{} }
-      \seq_pop_right:NNT \l__tenkzcd_stack_seq \l__tenkzcd_ca_tl
-        { \exp_last_unbraced:NV \tenkz_cd_tree_root:nnnnn \l__tenkzcd_ca_tl }
-      % The canonical numeric bracketing reconstructs the rooted binary
-      % tree without writing arbitrary TeX labels into structural fields.
-      \tenkz@event{tree|picture=\the\tenkz@pictureid|
-        id=\int_use:N\g__tenkzcd_tree_int|
-        style=\tl_use:N\l__tenkzcd_tree_skin_tl|
-        leaves=\int_use:N\l__tenkzcd_leaf_int|
-        vertices=\int_eval:n{\seq_count:N\l__tenkzcd_vertices_seq}|
-        topology=\tl_use:N\l__tenkzcd_topop_tl|
-        role=\tl_if_blank:VTF\l__tenkzcd_tree_role_tl{none}
-          {\tl_use:N\l__tenkzcd_tree_role_tl}|
-        species=\tl_if_blank:VTF\l__tenkzcd_tree_species_tl{none}
-          {\tl_use:N\l__tenkzcd_tree_species_tl}}
-    \end{tikzpicture}
-    \group_end:
-  }
 
 % ---------- annotation arrows ----------
 % \tnarrow[from=i, to=j]{label} records an arrow; the polygon renderer
@@ -1459,7 +918,7 @@
         \tl_put_right:Nn \l__tenkzcd_body_tl { \\ }
         \int_gzero:N \g__tenkzcd_mapordinal_int
         \bool_gset_true:N \g__tenkzcd_inmaps_bool
-        \begin{tikzpicture}[tenkz~every~picture, tenkz~cd~baseline]
+        \begin{tikzpicture}[tenkz~every~picture, tenkz~tree~baseline]
           % Passthrough keys belong to the matrix and its cells.  Their scope
           % ends before deferred house-label nodes are drawn.
           \begin{scope}
@@ -1519,7 +978,7 @@
     \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/cd}{#1} }
     \seq_gclear:N \g__tenkzcd_arrows_seq
     \tenkz@beginpicture{cd}
-    \tenkz_cd_read_axis:
+    \tenkz_tree_read_axis:
     \bool_if:NTF \l__tenkzcd_maps_bool
       {
         \int_compare:nNnTF { \l__tenkzcd_ngon_int } > {0}
@@ -1549,7 +1008,7 @@
     \dim_set:Nn \l__tenkzcd_r_dim { \l__tenkzcd_radius_tl }
     \seq_set_split:Nnn \l__tenkzcd_cells_seq { & } {#2}
     \bool_gset_true:N \g__tenkzcd_inpoly_bool
-    \begin{tikzpicture}[ tenkz~every~picture, tenkz~cd~baseline, #1 ]
+    \begin{tikzpicture}[ tenkz~every~picture, tenkz~tree~baseline, #1 ]
       \int_zero:N \l__tenkzcd_i_int
       \seq_map_inline:Nn \l__tenkzcd_cells_seq
         {
@@ -1607,10 +1066,10 @@
 \cs_new_protected:Npn \tenkz_cd_grid_aux:nn #1#2
   {
     % tikzcd forwards unrecognized keys to /tikz/.cd, so the shared
-    % `tenkz cd baseline` style applies here exactly as it does for the
+    % `tenkz tree baseline` style applies here exactly as it does for the
     % tree, maps and polygon renderers
     \begin{tikzcd}
-      [ tenkz~cd~baseline, #1 ]
+      [ tenkz~tree~baseline, #1 ]
       #2
     \end{tikzcd}
   }

--- a/tex/tenkz/tenkz-tree.code.tex
+++ b/tex/tenkz/tenkz-tree.code.tex
@@ -1,0 +1,562 @@
+% Input: a validated fusion-tree parenthesization word and tree keys.
+% Output: fusion-tree layout ink and the tree's structural event record.
+% Owned state: the parse stack, vertex topology, skin choice, and tree ids.
+% Invariants: the word parses to exactly one rooted tree before any ink.
+% Next stage: shared event services emit the resolved model used for rendering.
+%
+%   \tntree[keys]{(((a\,b)_x\,c)_y\,d)_e}
+%       a fusion tree from a parenthesization word: leaves on a top
+%       line, one junction per fused pair, internal charges on the
+%       downward edges, a short rooted leg carrying the total charge.
+%
+% The standalone tree is a math atom: the baseline is the vertical middle
+% of the picture lowered by the math axis, so a tree centers on the axis
+% of the surrounding formula.
+
+\ExplSyntaxOn
+
+% ---------- tree metrics (ratios of pitch) ----------
+% Sibling pitch of the leaf row and the depth of one fusion level share
+% one ratio, so every edge of a balanced pair meets its junction at 45
+% degrees; the root leg is shorter than a level so the tree reads as
+% rooted, not as one more leaf.
+\def\tenkz@r@treestep{0.55}
+\def\tenkz@r@treeleg{0.35}
+% One ribbon is a band, not a fused wire: 0.13 pitch gives its two
+% wire-weight boundary curves visible daylight at compact scale.  The
+% vertex-patch reach exceeds the half-width so its three sector arcs
+% remain distinct at the most acute junctions in a four-leaf tree; 0.72
+% measures how far each cubic control travels from its mouth toward the
+% vertex, leaving a rounded nonzero waist between the three sectors.
+\def\tenkz@r@treeribbonhalf{0.065}
+\def\tenkz@r@treepatchreach{0.16}
+\def\tenkz@r@treepatchcontrol{0.72}
+% TikZ's rotated calc-coordinate delimiter must have the ordinary colon
+% catcode, so keep this tiny coordinate primitive outside expl3 syntax.
+\ExplSyntaxOff
+\def\tenkz@ribbonoffset#1#2#3#4#5{%
+  \coordinate (#1) at ($(#2)!#4!#5:(#3)$);}
+\ExplSyntaxOn
+
+% ---------- state ----------
+\seq_new:N \l__tenkztree_items_seq     % parenthesization word, one item each
+\seq_new:N \l__tenkztree_stack_seq     % {x}{level}{charge}{node}{topology}
+\seq_new:N \l__tenkztree_vertices_seq  % postorder {node}{left}{right}
+\prop_new:N \l__tenkztree_parent_prop  % node id -> parent node id or root
+\prop_new:N \l__tenkztree_internal_prop % node id -> marker
+\tl_new:N  \l__tenkztree_word_tl
+\tl_new:N  \l__tenkztree_item_tl
+\tl_new:N  \l__tenkztree_charge_tl
+\tl_new:N  \l__tenkztree_ca_tl
+\tl_new:N  \l__tenkztree_cb_tl
+\tl_new:N  \l__tenkztree_cha_tl
+\tl_new:N  \l__tenkztree_chb_tl
+\tl_new:N  \l__tenkztree_anchor_tl
+\tl_new:N  \l__tenkztree_skin_tl
+\tl_new:N  \l__tenkztree_role_tl
+\tl_new:N  \l__tenkztree_species_tl
+\tl_new:N  \l__tenkztree_path_tl
+\tl_new:N  \l__tenkztree_fill_tl
+\tl_new:N  \l__tenkztree_junction_tl
+\tl_new:N  \l__tenkztree_parent_tl
+\tl_new:N  \l__tenkztree_topoa_tl
+\tl_new:N  \l__tenkztree_topob_tl
+\tl_new:N  \l__tenkztree_topop_tl
+\int_new:N \l__tenkztree_leaf_int
+\int_new:N \l__tenkztree_node_int
+\int_new:N \l__tenkztree_nodea_int
+\int_new:N \l__tenkztree_nodeb_int
+\int_new:N \l__tenkztree_nodep_int
+% Picture ids cannot distinguish several standalone trees, so tree ids
+% are document-global and also keep every TikZ coordinate name unique.
+\int_new:N \g__tenkztree_id_int
+\int_new:N \l__tenkztree_la_int
+\int_new:N \l__tenkztree_lb_int
+\int_new:N \l__tenkztree_lp_int
+\dim_new:N \l__tenkztree_xa_dim
+\dim_new:N \l__tenkztree_xb_dim
+\dim_new:N \l__tenkztree_xp_dim
+\dim_new:N \l__tenkztree_off_dim
+\dim_new:N \l__tenkztree_axis_dim
+
+% ---------- keys ----------
+\pgfkeys{
+  /tenkz/tree/.is~family,
+  /tenkz/tree/tree~style/.is~choice,
+  /tenkz/tree/tree~style/wire/.code={\tl_set:Nn \l__tenkztree_skin_tl {wire}},
+  /tenkz/tree/tree~style/ribbon/.code={\tl_set:Nn \l__tenkztree_skin_tl {ribbon}},
+  /tenkz/tree/role/.is~choice,
+  /tenkz/tree/role/operator/.code={\tl_set:Nn \l__tenkztree_role_tl {operator}},
+  /tenkz/tree/role/marked/.code={\tl_set:Nn \l__tenkztree_role_tl {marked}},
+  /tenkz/tree/role/extra/.code={\tl_set:Nn \l__tenkztree_role_tl {extra}},
+  /tenkz/tree/role/passive/.code={\tl_set:Nn \l__tenkztree_role_tl {passive}},
+  /tenkz/tree/species/.code={
+    \tenkz_species_check:n {#1}
+    \tl_set:Nn \l__tenkztree_species_tl {#1}
+  },
+}
+% pitch=/compact=/inline= forward to the shared /tenkz key space
+% (tenkz-core.code.tex); tree is command-scope like /tenkz/cell, so it
+% keeps its own role=/species= above (per-vertex, validated) instead of
+% the picture-scope forwarding species= the other three families use.
+\tenkz_install_core_forwards:nn {tree} {pitch,compact,inline}
+
+% ---------- the fusion tree ----------
+% Grammar of the parenthesization word:
+%   node   :=  leaf  |  ( node node ) [ _ charge ]
+%   leaf, charge  :=  one character or one braced group
+% Separators (\, and spaces) are stripped before parsing.  The word is
+% flattened into a sequence of items and consumed left to right by a
+% recursive-descent parser; every finished subtree pushes its root
+% {x}{level}{charge} onto a value stack, so a fused pair pops its two
+% children, joins them, and pushes the joint.
+%
+% Layout: leaves sit on the line y = 0, spaced by one tree step; an
+% internal vertex sits at the x-midpoint of its children's roots, one
+% level below the deeper child (level = 1 + max of the child levels,
+% y = -level steps).  Charges are typeset only when the vertex's
+% downward edge is known, so they can be set clear of the ink.
+
+% y-coordinate of a fusion level (integer factor on the right)
+\cs_new:Npn \tenkz_tree_levely:n #1
+  { \dim_eval:n { -\tenkz@r@treestep\tenkz@pitch * (#1) } }
+
+% ---------- picture framing ----------
+% Every tree picture is a math atom sharing one baseline; the cd
+% dialect draws the same kind of atom and shares this reader and
+% style until its retirement (#4699).  Read the axis
+% height (NFSS sets math fonts up lazily, so force them first), then lower
+% the picture's bounding-box centre by it so the diagram centres on the
+% surrounding formula's axis.
+\cs_new_protected:Npn \tenkz_tree_read_axis:
+  { \check@mathfonts
+    \dim_set:Nn \l__tenkztree_axis_dim { \fontdimen22\textfont2 } }
+\tikzset{
+  tenkz~tree~baseline/.style={
+    baseline={([yshift=-\dim_use:N \l__tenkztree_axis_dim]
+               current~bounding~box.center)} } }
+
+\cs_new_protected:Npn \tenkz_tree_node:
+  {
+    \seq_pop_left:NNTF \l__tenkztree_items_seq \l__tenkztree_item_tl
+      {
+        \str_if_eq:VnTF \l__tenkztree_item_tl { ( }
+          { \tenkz_tree_internal: }
+          { \tenkz_tree_leaf: }
+      }
+      { \PackageError{tenkz}{Malformed~tree:~unexpected~end~of~word}{} }
+  }
+
+% a leaf: a wire endpoint on the top line, its label above the tip.
+% Grammar guard: `_` and `)` can only reach the leaf position through a
+% malformed word -- `(a_u\,b)_x` tries to charge a leaf (the grammar
+% attaches charges to fused pairs only), `(a)` fuses a single node --
+% and typesetting them as leaves dies later with a raw TeX error, so
+% both stop here with the grammar rule spelled out.
+\cs_new_protected:Npn \tenkz_tree_leaf:
+  {
+    \str_if_eq:VnT \l__tenkztree_item_tl { _ }
+      { \PackageError{tenkz}{Malformed~tree:~a~charge~(_)~may~only~
+          follow~a~fused~pair's~closing~parenthesis}{} }
+    \str_if_eq:VnT \l__tenkztree_item_tl { ) }
+      { \PackageError{tenkz}{Malformed~tree:~unexpected~')'~--~a~fused~
+          pair~takes~exactly~two~nodes}{} }
+    \dim_set:Nn \l__tenkztree_xa_dim
+      { \tenkz@r@treestep\tenkz@pitch * \l__tenkztree_leaf_int }
+    \int_incr:N \l__tenkztree_leaf_int
+    \int_incr:N \l__tenkztree_node_int
+    \coordinate
+      (tenkztree-\int_use:N\g__tenkztree_id_int-
+       \int_use:N\l__tenkztree_node_int) at
+      (\dim_use:N \l__tenkztree_xa_dim, 0pt);
+    \node[tn~label, anchor=south] at
+      (\dim_use:N \l__tenkztree_xa_dim, \tenkz@dim{\tenkz@r@labelclear})
+      { $\tenkz@labelsize \tl_use:N \l__tenkztree_item_tl$ };
+    \seq_put_right:Ne \l__tenkztree_stack_seq
+      { { \dim_use:N \l__tenkztree_xa_dim }{ 0 }{ }
+        { \int_use:N \l__tenkztree_node_int }
+        { \int_use:N \l__tenkztree_leaf_int } }
+  }
+
+% ( node node ) [_ charge]
+\cs_new_protected:Npn \tenkz_tree_internal:
+  {
+    \tenkz_tree_node:
+    \tenkz_tree_node:
+    % the closing parenthesis
+    \seq_pop_left:NNTF \l__tenkztree_items_seq \l__tenkztree_item_tl
+      {
+        \str_if_eq:VnF \l__tenkztree_item_tl { ) }
+          { \PackageError{tenkz}
+              {Malformed~tree:~expected~a~closing~parenthesis}{} }
+      }
+      { \PackageError{tenkz}{Malformed~tree:~unexpected~end~of~word}{} }
+    % the optional charge (parsed after the recursion, so the local
+    % charge register belongs to this vertex).  Peek at the next item: a
+    % leading `_` consumes the charge; anything else is the next node and
+    % is left in place for the parser to pick up.
+    \tl_clear:N \l__tenkztree_charge_tl
+    \seq_get_left:NNT \l__tenkztree_items_seq \l__tenkztree_item_tl
+      {
+        \str_if_eq:VnT \l__tenkztree_item_tl { _ }
+          {
+            \seq_pop_left:NN \l__tenkztree_items_seq \l__tenkztree_item_tl
+            \seq_pop_left:NNF \l__tenkztree_items_seq \l__tenkztree_charge_tl
+              { \PackageError{tenkz}{Malformed~tree:~dangling~charge}{} }
+          }
+      }
+    % pop the two children and fuse them
+    \seq_pop_right:NN \l__tenkztree_stack_seq \l__tenkztree_cb_tl
+    \seq_pop_right:NN \l__tenkztree_stack_seq \l__tenkztree_ca_tl
+    \exp_last_unbraced:NNV \tenkz_tree_unpack:Nnnnnn a \l__tenkztree_ca_tl
+    \exp_last_unbraced:NNV \tenkz_tree_unpack:Nnnnnn b \l__tenkztree_cb_tl
+    \tenkz_tree_fuse:
+  }
+
+% A fusion vertex always has exactly two children, so the two popped
+% stack tuples are unpacked by the same five assignments; #1 (bare `a`
+% or `b`) selects which child's register family receives them, via the
+% `x#1_dim`/`l#1_int`/`ch#1_tl`/`node#1_int`/`topo#1_tl` naming already
+% shared by both families -- one function body instead of two.
+\cs_new_protected:Npn \tenkz_tree_unpack:Nnnnnn #1#2#3#4#5#6
+  {
+    \dim_set:cn { l__tenkztree_x #1 _dim }     {#2}
+    \int_set:cn { l__tenkztree_l #1 _int }     {#3}
+    \tl_set:cn  { l__tenkztree_ch #1 _tl }     {#4}
+    \int_set:cn { l__tenkztree_node #1 _int }  {#5}
+    \tl_set:cn  { l__tenkztree_topo #1 _tl }   {#6}
+  }
+
+% Join the two children on the stack.  Parsing records one abstract
+% trivalent vertex; the selected skin draws that same record only after
+% the full word has been parsed, when the third (parent) direction is
+% known.  This separation is what lets the ribbon skin draw a regular
+% ribbon neighbourhood instead of guessing a vertical output at
+% every vertex.
+\cs_new_protected:Npn \tenkz_tree_fuse:
+  {
+    \int_set:Nn \l__tenkztree_lp_int
+      { 1 + \int_max:nn { \l__tenkztree_la_int } { \l__tenkztree_lb_int } }
+    \dim_set:Nn \l__tenkztree_xp_dim
+      { ( \l__tenkztree_xa_dim + \l__tenkztree_xb_dim ) / 2 }
+    \int_incr:N \l__tenkztree_node_int
+    \int_set_eq:NN \l__tenkztree_nodep_int \l__tenkztree_node_int
+    \coordinate
+      (tenkztree-\int_use:N\g__tenkztree_id_int-
+       \int_use:N\l__tenkztree_nodep_int) at
+      (\dim_use:N \l__tenkztree_xp_dim,
+       \tenkz_tree_levely:n {\l__tenkztree_lp_int});
+    \prop_put:Nee \l__tenkztree_parent_prop
+      { \int_use:N \l__tenkztree_nodea_int }
+      { \int_use:N \l__tenkztree_nodep_int }
+    \prop_put:Nee \l__tenkztree_parent_prop
+      { \int_use:N \l__tenkztree_nodeb_int }
+      { \int_use:N \l__tenkztree_nodep_int }
+    \prop_put:Nee \l__tenkztree_internal_prop
+      { \int_use:N \l__tenkztree_nodep_int } {1}
+    \tl_if_blank:VF \l__tenkztree_cha_tl
+      { \tenkz_tree_edge_charge:NnN \l__tenkztree_xa_dim
+          {\l__tenkztree_la_int} \l__tenkztree_cha_tl }
+    \tl_if_blank:VF \l__tenkztree_chb_tl
+      { \tenkz_tree_edge_charge:NnN \l__tenkztree_xb_dim
+          {\l__tenkztree_lb_int} \l__tenkztree_chb_tl }
+    \seq_put_right:Ne \l__tenkztree_vertices_seq
+      { { \int_use:N \l__tenkztree_nodep_int }
+        { \int_use:N \l__tenkztree_nodea_int }
+        { \int_use:N \l__tenkztree_nodeb_int } }
+    \seq_put_right:Ne \l__tenkztree_stack_seq
+      { { \dim_use:N \l__tenkztree_xp_dim }{ \int_use:N \l__tenkztree_lp_int }
+        { \exp_not:V \l__tenkztree_charge_tl }
+        { \int_use:N \l__tenkztree_nodep_int }
+        { (\exp_not:V\l__tenkztree_topoa_tl,
+           \exp_not:V\l__tenkztree_topob_tl) } }
+  }
+
+% A charge labels its vertex's downward edge, half a fusion level below
+% the vertex, on the side of the edge away from the parent.  Both child
+% edges of the vertex lie above it and every other edge lies beyond the
+% downward edge on the parent's side, so that quadrant is ink-free by
+% construction.  #1 = x register of the vertex, #2 = its level, #3 =
+% charge register; the parent's x register is still live.
+\cs_new_protected:Npn \tenkz_tree_edge_charge:NnN #1#2#3
+  {
+    % rightward-descending edge (xp right of the vertex): label the free
+    % LEFT side, anchor east, clearance subtracted; leftward or straight:
+    % label the RIGHT side, anchor west, clearance added
+    \dim_compare:nNnTF { \l__tenkztree_xp_dim } > { #1 }
+      { \tl_set:Nn \l__tenkztree_anchor_tl {east}
+        \dim_set:Nn \l__tenkztree_off_dim { -\tenkz@dim{\tenkz@r@labelclear} } }
+      { \tl_set:Nn \l__tenkztree_anchor_tl {west}
+        \dim_set:Nn \l__tenkztree_off_dim { \tenkz@dim{\tenkz@r@labelclear} } }
+    \node[tn~label, anchor=\l__tenkztree_anchor_tl] at
+      (\dim_eval:n{ #1 + \l__tenkztree_off_dim },
+       \dim_eval:n{ \tenkz_tree_levely:n {#2}
+                    - \tenkz@r@treestep\tenkz@pitch / 2 })
+      { $\tenkz@labelsize \tl_use:N #3$ };
+  }
+
+% Resolve the semantic ink once per tree.  Species is the first
+% indirection and role wins, matching every other tenkz element.
+\cs_new_protected:Npn \tenkz_tree_resolve_style:
+  {
+    \tl_set:Nn \l__tenkztree_path_tl {bond}
+    \tl_set:Nn \l__tenkztree_fill_tl {tree~ribbon~fill}
+    \tl_set:Nn \l__tenkztree_junction_tl {tree~junction}
+    \tl_if_blank:VF \l__tenkztree_species_tl
+      {
+        \tl_set:Ne \l__tenkztree_path_tl
+          {species~\tl_use:N\l__tenkztree_species_tl\c_space_tl bond}
+        \tl_set:Ne \l__tenkztree_fill_tl
+          {species~\tl_use:N\l__tenkztree_species_tl\c_space_tl ribbon~fill}
+        \tl_set:Ne \l__tenkztree_junction_tl
+          {species~\tl_use:N\l__tenkztree_species_tl
+            \c_space_tl tree~junction}
+      }
+    \tl_if_blank:VF \l__tenkztree_role_tl
+      {
+        \tl_set:Ne \l__tenkztree_path_tl
+          {\tl_use:N\l__tenkztree_role_tl\c_space_tl bond}
+        \tl_set:Ne \l__tenkztree_fill_tl
+          {\tl_use:N\l__tenkztree_role_tl\c_space_tl ribbon~fill}
+        \tl_set:Ne \l__tenkztree_junction_tl
+          {\tl_use:N\l__tenkztree_role_tl\c_space_tl tree~junction}
+      }
+    \str_if_eq:VnT \l__tenkztree_skin_tl {ribbon}
+      {
+        \tl_if_blank:VTF \l__tenkztree_role_tl
+          {
+            \tl_if_blank:VTF \l__tenkztree_species_tl
+              { \tl_set:Nn \l__tenkztree_path_tl {tree~ribbon} }
+              { \tl_set:Ne \l__tenkztree_path_tl
+                  {species~\tl_use:N\l__tenkztree_species_tl
+                    \c_space_tl ribbon} }
+          }
+          { \tl_set:Ne \l__tenkztree_path_tl
+              {\tl_use:N\l__tenkztree_role_tl\c_space_tl ribbon} }
+      }
+  }
+
+\cs_new:Npn \tenkz_tree_name:n #1
+  { tenkztree-\int_use:N\g__tenkztree_id_int-#1 }
+
+\cs_new_protected:Npn \tenkz_tree_wire_vertex:nnn #1#2#3
+  {
+    \draw[\l__tenkztree_path_tl]
+      (\tenkz_tree_name:n {#2}) -- (\tenkz_tree_name:n {#1});
+    \draw[\l__tenkztree_path_tl]
+      (\tenkz_tree_name:n {#3}) -- (\tenkz_tree_name:n {#1});
+    \node[\l__tenkztree_junction_tl] at
+      (\tenkz_tree_name:n {#1}) {};
+  }
+
+% One band owns the filled strip and its two boundaries between leaf/root
+% endpoints or vertex-patch mouths.  It is deliberately not TikZ's
+% `double' stroke: the two curves bound a surface, while the disjoint
+% vertex patch owns all ink inside each trivalent neighbourhood.
+\cs_new_protected:Npn \tenkz_tree_ribbon_band:nn #1#2
+  {
+    % Each internal endpoint is trimmed to its patch mouth.  The patch,
+    % not a center-to-center contour hidden underneath it, owns every
+    % junction.  Leaves and the root remain untrimmed.
+    \coordinate (tenkzearaw) at (\tenkz_tree_name:n {#1});
+    \coordinate (tenkzebraw) at (\tenkz_tree_name:n {#2});
+    \prop_if_in:NnTF \l__tenkztree_internal_prop {#1}
+      { \coordinate (tenkzea) at
+          ($(tenkzearaw)!\tenkz@r@treepatchreach\tenkz@pitch!
+            (tenkzebraw)$); }
+      { \coordinate (tenkzea) at (tenkzearaw); }
+    \prop_if_in:NnTF \l__tenkztree_internal_prop {#2}
+      { \coordinate (tenkzeb) at
+          ($(tenkzebraw)!\tenkz@r@treepatchreach\tenkz@pitch!
+            (tenkzearaw)$); }
+      { \coordinate (tenkzeb) at (tenkzebraw); }
+    \draw[\l__tenkztree_fill_tl, line~cap=butt,
+      line~width=\dim_eval:n {2\tenkz@dim{\tenkz@r@treeribbonhalf}}]
+      (tenkzea) -- (tenkzeb);
+    % Calc's rotated-coordinate scanner is deliberately fed plain names;
+    % expl3 function tokens inside the rotated target are not scan-safe.
+    \tenkz@ribbonoffset{tenkzeaL}{tenkzea}{tenkzeb}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzeaR}{tenkzea}{tenkzeb}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \tenkz@ribbonoffset{tenkzebL}{tenkzeb}{tenkzea}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzebR}{tenkzeb}{tenkzea}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \draw[\l__tenkztree_path_tl]
+      (tenkzeaL) -- (tenkzebR);
+    \draw[\l__tenkztree_path_tl]
+      (tenkzeaR) -- (tenkzebL);
+  }
+\cs_new_protected:Npn \tenkz_tree_ribbon_vertex_bands:nnn #1#2#3
+  {
+    \tenkz_tree_ribbon_band:nn {#1}{#2}
+    \tenkz_tree_ribbon_band:nn {#1}{#3}
+  }
+
+% The central patch is the regular ribbon neighbourhood of a trivalent
+% vertex: a disc with three attached bands.  Each sector arc has two
+% distinct controls, so the patch retains a nonzero waist and its boundary
+% never pinches or crosses.  No tensor bead or fused-bond glyph is inserted.
+\cs_new_protected:Npn \tenkz_tree_ribbon_patch:nnnn #1#2#3#4
+  {
+    \coordinate (tenkzvc) at (\tenkz_tree_name:n {#1});
+    \coordinate (tenkzva) at (\tenkz_tree_name:n {#2});
+    \coordinate (tenkzvb) at (\tenkz_tree_name:n {#3});
+    \coordinate (tenkzvp) at (#4);
+    \coordinate (tenkzpa) at
+      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzva)$);
+    \coordinate (tenkzpb) at
+      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzvb)$);
+    \coordinate (tenkzpp) at
+      ($(tenkzvc)!\tenkz@r@treepatchreach\tenkz@pitch!(tenkzvp)$);
+    \tenkz@ribbonoffset{tenkzpaL}{tenkzpa}{tenkzva}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzpaR}{tenkzpa}{tenkzva}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \tenkz@ribbonoffset{tenkzpbL}{tenkzpb}{tenkzvb}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzpbR}{tenkzpb}{tenkzvb}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \tenkz@ribbonoffset{tenkzppL}{tenkzpp}{tenkzvp}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{90}
+    \tenkz@ribbonoffset{tenkzppR}{tenkzpp}{tenkzvp}
+      {\tenkz@r@treeribbonhalf\tenkz@pitch}{-90}
+    \path[\l__tenkztree_fill_tl, draw=none]
+      (tenkzpbL)
+        .. controls ($(tenkzpbL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzpaR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzpaR) --
+      (tenkzpaL)
+        .. controls ($(tenkzpaL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzppR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzppR) --
+      (tenkzppL)
+        .. controls ($(tenkzppL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzpbR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzpbR) -- cycle;
+    \draw[\l__tenkztree_path_tl]
+      (tenkzpbL)
+        .. controls ($(tenkzpbL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzpaR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzpaR);
+    \draw[\l__tenkztree_path_tl]
+      (tenkzpaL)
+        .. controls ($(tenkzpaL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzppR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzppR);
+    \draw[\l__tenkztree_path_tl]
+      (tenkzppL)
+        .. controls ($(tenkzppL)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        and ($(tenkzpbR)!\tenkz@r@treepatchcontrol!(tenkzvc)$)
+        .. (tenkzpbR);
+  }
+
+\cs_new_protected:Npn \tenkz_tree_ribbon_vertex_patch:nnn #1#2#3
+  {
+    \prop_get:NnNTF \l__tenkztree_parent_prop {#1} \l__tenkztree_parent_tl
+      {
+        \str_if_eq:VnTF \l__tenkztree_parent_tl {root}
+          { \tenkz_tree_ribbon_patch:nnnn {#1}{#2}{#3}
+              {tenkztree-\int_use:N\g__tenkztree_id_int-root} }
+          { \tenkz_tree_ribbon_patch:nnnn {#1}{#2}{#3}
+              {\tenkz_tree_name:n {\l__tenkztree_parent_tl}} }
+      }
+      { \PackageError{tenkz}{Internal~tree~vertex~#1~has~no~parent}{} }
+  }
+
+\cs_new_protected:Npn \tenkz_tree_geometry:n #1
+  {
+    \begin{pgfonlayer}{background}
+      \str_if_eq:VnTF \l__tenkztree_skin_tl {wire}
+        {
+          \seq_map_inline:Nn \l__tenkztree_vertices_seq
+            { \tenkz_tree_wire_vertex:nnn ##1 }
+          \draw[\l__tenkztree_path_tl]
+            (\tenkz_tree_name:n {#1}) --
+            (tenkztree-\int_use:N\g__tenkztree_id_int-root);
+        }
+        {
+          \seq_map_inline:Nn \l__tenkztree_vertices_seq
+            { \tenkz_tree_ribbon_vertex_bands:nnn ##1 }
+          \tenkz_tree_ribbon_band:nn {#1}{root}
+          \seq_map_inline:Nn \l__tenkztree_vertices_seq
+            { \tenkz_tree_ribbon_vertex_patch:nnn ##1 }
+        }
+    \end{pgfonlayer}
+  }
+
+% The root creates the third direction of its vertex, renders the selected
+% skin from the recorded topology, and finally places the total charge.
+\cs_new_protected:Npn \tenkz_tree_root:nnnnn #1#2#3#4#5
+  {
+    \tl_set:Nn \l__tenkztree_topop_tl {#5}
+    \coordinate (tenkztree-\int_use:N\g__tenkztree_id_int-root) at
+      (#1, \dim_eval:n{ \tenkz_tree_levely:n {#2}
+                        - \tenkz@r@treeleg\tenkz@pitch });
+    \prop_put:Nnn \l__tenkztree_parent_prop {#4} {root}
+    \tenkz_tree_geometry:n {#4}
+    \tl_if_blank:nF {#3}
+      {
+        \node[tn~label, anchor=west] at
+          (\dim_eval:n{ #1 + \tenkz@dim{\tenkz@r@labelclear} },
+           \dim_eval:n{ \tenkz_tree_levely:n {#2}
+                        - \tenkz@r@treeleg\tenkz@pitch / 2 })
+          { $\tenkz@labelsize #3$ };
+      }
+  }
+
+\NewDocumentCommand \tntree { O{} m }
+  { \tenkz_tree:nn {#1} {#2} }
+
+\cs_new_protected:Npn \tenkz_tree:nn #1#2
+  {
+    \group_begin:
+    \tl_set:Nn \l__tenkztree_skin_tl {wire}
+    \tl_clear:N \l__tenkztree_role_tl
+    \tl_clear:N \l__tenkztree_species_tl
+    \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/tree}{#1} }
+    \tenkz_tree_resolve_style:
+    \int_gincr:N \g__tenkztree_id_int
+    % \, and spaces are separators, not syntax; flatten to items
+    % (spaces never form items, so only \, needs stripping)
+    \tl_set:Nn \l__tenkztree_word_tl {#2}
+    \tl_remove_all:Nn \l__tenkztree_word_tl { \, }
+    \seq_clear:N \l__tenkztree_items_seq
+    \tl_map_inline:Nn \l__tenkztree_word_tl
+      { \seq_put_right:Nn \l__tenkztree_items_seq {##1} }
+    \seq_clear:N \l__tenkztree_stack_seq
+    \seq_clear:N \l__tenkztree_vertices_seq
+    \prop_clear:N \l__tenkztree_parent_prop
+    \prop_clear:N \l__tenkztree_internal_prop
+    \int_zero:N \l__tenkztree_leaf_int
+    \int_zero:N \l__tenkztree_node_int
+    \tenkz_tree_read_axis:
+    \begin{tikzpicture}[ tenkz~every~picture, tenkz~tree~baseline ]
+      \tenkz_tree_node:
+      % exactly one tree per word: leftover items after the root parse
+      % would otherwise vanish, rendering a plausible tree of the WRONG
+      % parenthesization word (`a\,b` would draw the one-leaf tree `a`)
+      \seq_if_empty:NF \l__tenkztree_items_seq
+        { \PackageError{tenkz}{Malformed~tree:~trailing~material~after~
+            the~root~--~a~word~denotes~exactly~one~tree}{} }
+      \seq_pop_right:NNT \l__tenkztree_stack_seq \l__tenkztree_ca_tl
+        { \exp_last_unbraced:NV \tenkz_tree_root:nnnnn \l__tenkztree_ca_tl }
+      % The canonical numeric bracketing reconstructs the rooted binary
+      % tree without writing arbitrary TeX labels into structural fields.
+      \tenkz@event{tree|picture=\the\tenkz@pictureid|
+        id=\int_use:N\g__tenkztree_id_int|
+        style=\tl_use:N\l__tenkztree_skin_tl|
+        leaves=\int_use:N\l__tenkztree_leaf_int|
+        vertices=\int_eval:n{\seq_count:N\l__tenkztree_vertices_seq}|
+        topology=\tl_use:N\l__tenkztree_topop_tl|
+        role=\tl_if_blank:VTF\l__tenkztree_role_tl{none}
+          {\tl_use:N\l__tenkztree_role_tl}|
+        species=\tl_if_blank:VTF\l__tenkztree_species_tl{none}
+          {\tl_use:N\l__tenkztree_species_tl}}
+    \end{tikzpicture}
+    \group_end:
+  }
+
+\ExplSyntaxOff
+\endinput

--- a/tex/tenkz/tenkz.sty
+++ b/tex/tenkz/tenkz.sty
@@ -5,9 +5,10 @@
 % Next stage: tenkz-language.code.tex validates and registers public syntax.
 %
 % The four sub-languages: the contraction grid (tenkz, \tnpic),
-% commutative diagrams (tenkzcd: polygon mode and \tntree),
-% lattice-region schematics (tenkzlattice, with the tenkzplanes
-% double-layer preset), and free placement (tenkzfree).  0.6 speaks
+% commutative diagrams (tenkzcd: polygon mode), lattice-region
+% schematics (tenkzlattice, with the tenkzplanes double-layer preset),
+% and free placement (tenkzfree).  Fusion trees (\tntree) are
+% standalone structured atoms drawn by tenkz-tree.code.tex.  0.6 speaks
 % one key vocabulary across the tiers: frame=, the side-policy
 % alphabet (west=/east=), and the contraction cell-sets (open=/trace=).
 \NeedsTeXFormat{LaTeX2e}
@@ -37,6 +38,9 @@
 \input{tenkz-string.code.tex}
 \input{tenkz-frame.code.tex}
 \input{tenkz-grid.code.tex}
+% The tree file precedes the cd dialect: tenkz-cd borrows the tree's
+% math-atom axis reader and baseline style until its retirement (#4699).
+\input{tenkz-tree.code.tex}
 \input{tenkz-cd.code.tex}
 \input{tenkz-lattice.code.tex}
 \input{tenkz-free.code.tex}


### PR DESCRIPTION
Step 1 of retiring the `tenkzcd` dialect (#4699, checklist item 6 on LionSR/tenkz#13): the fusion-tree drawer moves out of the dialect that is about to be deleted. `LANGUAGE-1.0.md` §10 tombstones `tenkzcd` while §9 keeps `\tntree` as a kernel-era expander, so the tree cannot keep living in `tenkz-cd.code.tex`.

## What moved

`tex/tenkz/tenkz-tree.code.tex` (new, 562 lines) now owns everything `\tntree` needs: the tree metrics (`\tenkz@r@treestep`, `\tenkz@r@treeleg`, the ribbon ratios), `\tenkz@ribbonoffset`, the parse/layout state, the `/tenkz/tree` key family with its core forwards, the word parser (`\tenkz_tree_node:`/`_leaf:`/`_internal:`/`_fuse:`), the wire and ribbon skins, the vertex-patch geometry, the root/event emitter, and `\tntree` itself. Internal prefixes are renamed `tenkz_cd_`/`l__tenkzcd_` to `tenkz_tree_`/`l__tenkztree_`; doubled names were collapsed (`l__tenkzcd_tree_skin_tl` is now `l__tenkztree_skin_tl`, the global tree counter is `g__tenkztree_id_int`). The public spelling `\tntree`, its keys, its `tenkztree-<id>-<node>` coordinate names, and its event fields are untouched.

`tex/tenkz/tenkz-cd.code.tex` (1619 to 1078 lines) keeps the annotation arrows, typed-map rows, and the polygon/maps/grid environments — the half that dies with the dialect.

## What stayed, and the shared-helper decisions

- **Math-atom axis reader and baseline style** (`\tenkz_cd_read_axis:`, `tenkz cd baseline`, the axis register) were the one genuinely shared piece: the tree and all three cd modes use them. They move to the tree file as `\tenkz_tree_read_axis:`/`tenkz tree baseline` because `\tntree` outlives `tenkzcd`; the cd file now calls the tree spellings at its four sites. Nothing is duplicated. `tenkz.sty` loads the tree file immediately before the cd file and says why.
- **`\tenkz@r@mapgap`/`\tenkz@r@maprowsep`** are typed-map metrics; they stay in cd and die with it.
- **`\tenkz@ribbonoffset`** is used only by the ribbon skin; it moves.
- The `/tenkz/arrow` family, `\l__tenkzcd_body_tl`, and every map register are cd-only and stay; `scripts/test_tenkz_cd_map_labels.py` monkeypatches only map internals, so it needed no change.

No script changes were needed: `test_tenkz_tree.py` compiles fixtures rather than grepping sources, `tenkz_language.py` and `tenkz_shrink.py` glob `tex/tenkz/*.code.tex` and fingerprint parser leaves as a set (unchanged), and the dimension/disposition checkers key on the public `\tntree` spelling. `LANGUAGE-1.0.md` names no file for `\tntree`, so it is untouched. `docs/tenkz/ARCHITECTURE.md` §5 and the `HACKING.md` migration-debt file list get one-line factual updates, and `tests/tenkz/render-census-baseline.json` redistributes the moved ink (cd 21 → 7, tree 14; decimals cd 1, tree 0; totals unchanged at 38/20).

## Verification

- `scripts/tenkz_golden.sh --check` — **PASS: 264 event streams byte-identical** to the golden baseline.
- `scripts/tenkz_kernel_probes.sh` — PASS: 127 review regressions, 10 sugar spellings byte-identical to their expansions, 12 kernel record streams byte-identical, kernel pixels byte-identical.
- `scripts/tenkz_pixelpair.sh origin/main` — **PASS: 6 pages byte-identical at 300 dpi** (manifest includes `gallery.tex`, which draws four `\tntree` words and the B5 fusion-tree pentagon).
- Dedicated 200 dpi pair, same session, true-legacy detached worktree at `origin/main` vs this branch, fixtures `tex/tenkz/examples/api/tntree.tex` and `tex/tenkz/examples/cd-pentagon.tex`: both `tntree-200dpi.png` and `cd-pentagon-200dpi.png` byte-identical (`cmp`) between `scratchpad/pix200/base/` and `scratchpad/pix200/new/`.
- `python3 scripts/test_tenkz_tree.py` — PASS; `python3 scripts/test_tenkz_cd_map_labels.py` — PASS.
- `python3 scripts/tenkz_shrink.py meters` — byte-identical to `tests/tenkz/census-baseline.json`; `gate --base-ref origin/main` — PASS (census stable at 201, all 150 flags carry verdicts). No SHRINK.md session is required: no meter moved and no new flag was raised.
- `python3 scripts/tenkz_lint.py --census` — PASS against the updated baseline; `python3 scripts/tenkz_language.py check` — PASS (229 records); dispositions and demolition checkers — PASS.

## Notes for the deletion PR (#4699)

- The cd file still owns `tenkz tree baseline` call sites; deleting the dialect removes them without touching the tree file.
- `scripts/test_tenkz_cd_map_labels.py` reaches into `\tenkz_cd_map_path:nnn` and the map registers; it dies with the dialect.
- `tests/tenkz/render-census-baseline.json` will need `tenkz-cd.code.tex` dropped (7 ink, 1 decimal) when the file is deleted, and `tenkz.sty` line 8 still names `tenkzcd`.

Refs LionSR/TNLean#4699, LionSR/tenkz#13.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large internal move of fusion-tree rendering and shared baseline helpers, but behavior is pinned by golden events and pixel parity; risk is mainly regression in tree/cd math-axis layout or missed call-site updates when cd is removed later.
> 
> **Overview**
> Moves **fusion-tree drawing** out of the retiring `tenkzcd` dialect into a new **`tenkz-tree.code.tex`** stage, ahead of deleting `tenkz-cd` (#4699).
> 
> **`\tntree`** and its parser, wire/ribbon skins, `/tenkz/tree` keys, metrics, and events now live in the tree file with `tenkz_tree_*` / `l__tenkztree_*` internals. Public spellings (`\tntree`, coordinate names, event fields) stay the same.
> 
> **`tenkz-cd.code.tex`** keeps only maps, polygon/grid `tenkzcd`, and `\tnarrow`; it calls **`tenkz_tree_read_axis:`** and **`tenkz tree baseline`** for math-axis alignment instead of duplicating that logic.
> 
> **`tenkz.sty`** loads the tree file before cd; docs and **`render-census-baseline.json`** reflect the ink split (totals unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fecb54a89ca7ba0738c2e7e18f6646f0dfde58a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->