### PR TITLE
ci(tenkz): prove every sugar spelling renders as its kernel expansion

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Gate for the kernel language stage: the seven contract fixtures pin their
-# record streams, and every sugar spelling proves byte-identical events
-# against its kernel expansion.  Sources: tests/tenkz/kernel/.
+# record streams, and every sugar spelling proves byte-identical events and
+# pixels against its kernel expansion.  Sources: tests/tenkz/kernel/.
 set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 KERNEL="$REPO/tests/tenkz/kernel"
@@ -2643,8 +2643,25 @@ for pair in s1 s2 s3 s4 s5 s6 s7 s8 s9 s10; do
     diff "$WORK/${pair}_sugar.tnlog" "$WORK/${pair}_kernel.tnlog" >&2 || true
     fail=1
   fi
+  # Events do not carry a label's ink.  The labelled cup of issue 5563 left
+  # byte-identical records while its unpeeled `$...$` value set a superscript
+  # one math style larger than its expansion's \tn body.  Both halves of a
+  # pair compile in this same session, so their rasters compare byte for byte
+  # without an exact-toolchain pin.
+  for half in sugar kernel; do
+    if ! pdftoppm -singlefile -png -r 300 \
+        "$WORK/${pair}_${half}.pdf" "$WORK/${pair}_${half}" >/dev/null 2>&1; then
+      echo "FAIL: sugar pair fixture ${pair}_${half} could not be rasterized" >&2
+      exit 1
+    fi
+  done
+  if ! cmp -s "$WORK/${pair}_sugar.png" "$WORK/${pair}_kernel.png"; then
+    echo "FAIL: sugar pair $pair does not render as its kernel expansion" >&2
+    fail=1
+  fi
 done
-[ "$fail" -eq 0 ] && echo "PASS: 10 sugar spellings byte-identical to their expansions"
+[ "$fail" -eq 0 ] &&
+  echo "PASS: 10 sugar spellings byte-identical to their expansions in events and pixels"
 
 CURRENT="$WORK/current.sha256"
 ( cd "$WORK"


### PR DESCRIPTION
Closes LionSR/tenkz#168.

## What the measurement found

The mismatch LionSR/tenkz#168 describes no longer reproduces. Its root cause was the labelled cup's `$...$` value keeping its math delimiters: the bead label is typeset inside the kernel's own math shift as `$\tenkz@labelsize <label>$` (script style), and a value that keeps its delimiters needs a box, and a box holds text style inside a script-style label — so a superscript set one math style larger, 5 px wider at 200 dpi, confined to the east cup atom because only that label carried a superscript. The peel that removes the author's outer `$...$` landed with LionSR/tenkz#167 (`fix(tenkz): draw a labelled cup as its documented expansion`) and was promoted to the shared `\__tenkz_kernel_unmath:N` rule for every positional label by LionSR/tenkz#158's fix (`fix(tenkz): give every label one rule about the math shift`). LionSR/tenkz#168 was filed from the same LionSR/TNLean#5561 observation that produced LionSR/tenkz#167 and outlived its fix.

Measured now: `tests/tenkz/kernel/sugar/s10_sugar.tex` (the `west={cup=$Y$}, east={cup=$X\rho^R$}` spelling, mirroring `ch14_correlations.tex` L68) and `s10_kernel.tex` (its documented expansion) rasterize byte-identical at 200 dpi, and all ten sugar pairs rasterize byte-identical at 300 dpi.

## What was still missing

The sugar-pair probe compared event streams alone, and events do not carry a label's ink: before LionSR/tenkz#167 the sugar and its expansion left byte-identical records while rendering 5 px apart, which is exactly the divergence the ledger exists to forbid. The probe now also rasterizes each pair's two halves at 300 dpi and compares the rasters byte for byte. Both halves compile in the same session, so the comparison needs no exact-toolchain pin and adds nothing to `golden-pixels.sha256`.

No new fixture is added: the standalone regression pair for this exact case (`s10_sugar.tex`/`s10_kernel.tex`, superscripted cup label included) already exists under `tests/tenkz/kernel/sugar/`, added by LionSR/tenkz#167's fix. `blueprint/src/chapter/ch14_correlations.tex` is untouched.

## Evidence

- `scripts/tenkz_kernel_probes.sh --check`: 127 review regressions hold; **10 sugar spellings byte-identical to their expansions in events and pixels**; 12 kernel record streams byte-identical; kernel pixels byte-identical.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`: census stable at 201.
- No `tex/tenkz/` change: rendering and event contracts are untouched by construction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the kernel probe script; no `tex/tenkz` or rendering logic is modified.
> 
> **Overview**
> Extends the kernel sugar-pair gate in `tenkz_kernel_probes.sh` so equivalence is checked on **pixels** as well as event streams.
> 
> For each of the ten `s*_sugar` / `s*_kernel` fixtures, the script rasterizes both PDFs at 300 dpi with `pdftoppm` and compares the PNGs byte-for-byte. That closes the gap where label ink (e.g. labelled cup `$...$` vs peeled `\tn` from LionSR/tenkz#168) could match in `tnlog` but differ on the page. Sugar/kernel halves compile in one session, so this check does not add entries to `golden-pixels.sha256`. Header comments and the pass message now say **events and pixels**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 024a6aee504ff7f49d956e8b83b5aee7abdc3624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->