### PR TITLE
doc(blueprint): respell the ch21 commutative diagrams onto tikz-cd

### DIFF
--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -2,8 +2,9 @@ r"""plasTeX renderers for tenkz tensor-network pictures (spec §1.5, §5.1).
 
 The tenkz environments (``tenkz``, ``tenkzcd``, ``tenkzlattice``,
 ``tenkzplanes``, ``tenkzfree`` — the spec's four sub-languages plus the
-Phase-1 bra-ket double-layer environment that lives in the lattice layer)
-and the bridge command ``\tnpic`` are registered here as
+Phase-1 bra-ket double-layer environment that lives in the lattice layer),
+the plain ``tikzcd`` environment that carries the blueprint's commutative
+diagrams, and the bridge command ``\tnpic`` are registered here as
 **verbatim-captured units**: plasTeX never tokenizes a picture body.  Each
 captured unit is compiled **standalone** against ``TEXINPUTS=tex/tenkz//``
 and converted to one SVG, cached by a per-body content hash, so editing one
@@ -91,6 +92,7 @@ MISSING_SVG_SENTINEL = "tenkz SVG unavailable"
 # every picture, editing one picture body re-renders exactly one SVG.
 _RENDER_SOURCE_FILES = (
     _SRC_DIR / "macros/common.tex",
+    _SRC_DIR / "macros/diagrams.tex",
     *sorted(_TENKZ_DIR.glob("*.sty")),
     *sorted(_TENKZ_DIR.glob("*.code.tex")),
 )
@@ -104,6 +106,7 @@ _ENVIRONMENT_LANGS = {
     "tenkzlattice": "lattice",
     "tenkzplanes": "planes",
     "tenkzfree": "free",
+    "tikzcd": "cd",
     "tnpic": "grid",
 }
 
@@ -129,6 +132,7 @@ def _latex_document(unit_source: str) -> str:
 \newcounter{{chapter}}
 \input{{macros/common}}
 \usepackage{{tenkz}}
+\input{{macros/diagrams}}
 \begin{{document}}
 {unit_source}
 \end{{document}}
@@ -512,6 +516,9 @@ else:
         pass
 
     class tenkzfree(_TenkzVerbatimEnvironment):
+        pass
+
+    class tikzcd(_TenkzVerbatimEnvironment):
         pass
 
     class tnpic(_TenkzSvgMixin, Command):

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex
@@ -284,22 +284,19 @@
 
 \begin{figure}[ht]
     \centering
-    % Clockwise slots are M, R, P, L, LI.  The three unstarred arrows are
-    % the upper route L -> LI -> M -> R; the starred arrows are the lower
-    % route L -> P -> R.  Tree subscripts are precisely the intermediate
-    % fusion charges carried by the corresponding internal edges.
-    \begin{tenkzcd}[polygon=5, radius=34mm]
-      \tntree{(a\,((b\,c)_h\,d)_i)_e} &
-      \tntree{(a\,(b\,(c\,d)_j)_i)_e} &
-      \tntree{((a\,b)_f\,(c\,d)_j)_e} &
-      \tntree{(((a\,b)_f\,c)_g\,d)_e} &
-      \tntree{((a\,(b\,c)_h)_g\,d)_e}
-      \tnarrow[from=4, to=5]{F^{abc}_{g}}
-      \tnarrow[from=5, to=1]{F^{ahd}_{e}}
-      \tnarrow[from=1, to=2]{F^{bcd}_{i}}
-      \tnarrow*[from=4, to=3]{F^{fcd}_{e}}
-      \tnarrow*[from=3, to=2]{F^{abj}_{e}}
-    \end{tenkzcd}
+    % M sits on top, LI and R in the middle row, L and P on the bottom.
+    % The upper route L -> LI -> M -> R climbs the left flank; the lower
+    % route L -> P -> R crosses the bottom, its labels swapped outward.
+    % Tree subscripts are precisely the intermediate fusion charges
+    % carried by the corresponding internal edges.
+    \begin{tikzcd}[column sep=tiny]
+      & \tntree{(a\,((b\,c)_h\,d)_i)_e} \arrow[dr, "F^{bcd}_{i}"] & \\
+      \tntree{((a\,(b\,c)_h)_g\,d)_e} \arrow[ur, "F^{ahd}_{e}"] & &
+        \tntree{(a\,(b\,(c\,d)_j)_i)_e} \\
+      \tntree{(((a\,b)_f\,c)_g\,d)_e} \arrow[u, "F^{abc}_{g}"]
+          \arrow[rr, "F^{fcd}_{e}"'] & &
+        \tntree{((a\,b)_f\,(c\,d)_j)_e} \arrow[u, "F^{abj}_{e}"']
+    \end{tikzcd}
     \caption{The five complete zipper fusion trees of
         \cite[Section~3.4, equation~(33)]{Bultinck2017Anyons}. Each arrow is
         a printed $F$-move, with right-tree coordinates indexing rows and
@@ -404,21 +401,17 @@
 
 \begin{figure}[ht]
     \centering
-    % Clockwise slots are M, R, P, L, LI.  Hence r_1,r_2,r_3 trace the
-    % three-edge route L -> LI -> M -> R, while s_1,s_2 trace L -> P -> R.
-    % The vertices are Cartesian parenthesizations, not fusion trees.
-    \begin{tenkzcd}[polygon=5, radius=38mm]
-      \ensuremath{(A\times((B\times C)\times D))} &
-      \ensuremath{(A\times(B\times(C\times D)))} &
-      \ensuremath{((A\times B)\times(C\times D))} &
-      \ensuremath{(((A\times B)\times C)\times D)} &
-      \ensuremath{((A\times(B\times C))\times D)}
-      \tnarrow[from=4, to=5]{r_1}
-      \tnarrow[from=5, to=1]{r_2}
-      \tnarrow[from=1, to=2]{r_3}
-      \tnarrow*[from=4, to=3]{s_1}
-      \tnarrow*[from=3, to=2]{s_2}
-    \end{tenkzcd}
+    % M sits on top, LI and R in the middle row, L and P on the bottom;
+    % r_1,r_2,r_3 trace the three-edge route L -> LI -> M -> R, while
+    % s_1,s_2 trace L -> P -> R.  The vertices are Cartesian
+    % parenthesizations, not fusion trees.
+    \begin{tikzcd}[column sep=small]
+      & (A\times((B\times C)\times D)) \arrow[dr, "r_3"] & \\
+      ((A\times(B\times C))\times D) \arrow[ur, "r_2"] & &
+        (A\times(B\times(C\times D))) \\
+      (((A\times B)\times C)\times D) \arrow[u, "r_1"] \arrow[rr, "s_1"'] & &
+        ((A\times B)\times(C\times D)) \arrow[u, "s_2"']
+    \end{tikzcd}
     \caption{The five parenthesizations of four bond-coordinate factors.
         The upper path is the three-edge composite
         $r_3\circ r_2\circ r_1$, and the lower path is the two-edge composite

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -626,23 +626,21 @@ the remaining sites unchanged.
     % the contracted virtual index \gamma.  Each blue stroke is a typed map
     % between the complete objects at its endpoints, never a tensor contraction.
     \par\noindent\hfil
-    \begin{tenkzcd}[maps, species={channel},
+    \begin{tikzcd}[channel, ampersand replacement=\&,
         column sep=10mm, row sep=8mm]
       \tnpic[inline, physical=updown]{
         \tn[mpo]{M}
-      } &
+      } \arrow[r, "\mathcal T"] \&
       \tnpic[inline, physical=updown]{
         \tn[mpo]{M} & \tn[mpo]{M}
       } \\
       \tnpic[inline, physical=updown]{
         \tn[mpo]{M} & \tn[mpo]{M}
-      } &
+      } \arrow[r, "\mathcal S"] \&
       \tnpic[inline, physical=updown]{
         \tn[mpo]{M}
       }
-      \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
-      \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S}
-    \end{tenkzcd}
+    \end{tikzcd}
     \hfil\par
 \end{definition}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex
@@ -424,18 +424,14 @@ the global controlled map $\mathcal S_0$. The four fiberwise types are
 % matrix-algebra domains and codomains. Ink: every blue stroke denotes a
 % trace-preserving completely positive map, and its label specifies the map.
 \par\noindent\hfil
-  \begin{tenkzcd}[maps, species={channel}, row sep=6mm]
-    \mathcal A_2^{k,h} & \mathcal A_{\partial}^{k,h} \\
-    \mathcal A_{\eta}^{k,h} & \mathcal A_2^{k,h} \\
-    \mathcal A_3^{k,l,h} & \mathcal A_{\partial}^{k,h} \\
-    \mathcal A_{\Omega}^{k,h} & \mathcal A_3^{k,\bullet,h}
-    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]
-      {\mathcal T_0^{(k,h)}}
-    \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]
-      {\mathcal S_2^{(k,h)}}
-    \tnarrow[from={(3,1)}, to={(3,2)}, species=channel]
-      {\mathcal S_0^{(k,l,h)}}
-    \tnarrow[from={(4,1)}, to={(4,2)}, species=channel]
-      {\mathcal T_2^{(k,h)}}
-  \end{tenkzcd}
+  \begin{tikzcd}[channel, column sep=16mm, row sep=6mm]
+    \mathcal A_2^{k,h} \arrow[r, "\mathcal T_0^{(k,h)}"] &
+      \mathcal A_{\partial}^{k,h} \\
+    \mathcal A_{\eta}^{k,h} \arrow[r, "\mathcal S_2^{(k,h)}"] &
+      \mathcal A_2^{k,h} \\
+    \mathcal A_3^{k,l,h} \arrow[r, "\mathcal S_0^{(k,l,h)}"] &
+      \mathcal A_{\partial}^{k,h} \\
+    \mathcal A_{\Omega}^{k,h} \arrow[r, "\mathcal T_2^{(k,h)}"] &
+      \mathcal A_3^{k,\bullet,h}
+  \end{tikzcd}
 \hfil\par

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex
@@ -157,25 +157,21 @@ With the matrix algebras introduced above, the refinement stages have type
 % T_2 : A_Omega -> A_3. Ink: each blue stroke denotes a channel, its label
 % names the stage, and the fixed left-to-right axis records composition.
 \par\noindent\hfil
-  \begin{tenkzcd}[maps, species={channel}]
-    \mathcal A_2 &
-    \mathcal A_{\partial} &
-    \mathcal A_{\Omega} &
+  \begin{tikzcd}[channel, column sep=large]
+    \mathcal A_2 \arrow[r, "\mathcal T_0"] &
+    \mathcal A_{\partial} \arrow[r, "\mathcal T_1"] &
+    \mathcal A_{\Omega} \arrow[r, "\mathcal T_2"] &
     \mathcal A_3
-    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T_0}
-    \tnarrow[from={(1,2)}, to={(1,3)}, species=channel]{\mathcal T_1}
-    \tnarrow[from={(1,3)}, to={(1,4)}, species=channel]{\mathcal T_2}
-  \end{tenkzcd}
+  \end{tikzcd}
 \hfil\par
 Here $\mathcal T_1$ adjoins $\overline\Omega_{k,h}$ on each diagonal
 outer-sector summand. The composite channel has type
 % Formula: T = T_2 T_1 T_0 : A_2 -> A_3. Ink: the blue stroke denotes the
 % composite channel T; its endpoints are matrix algebras, not matrices.
 \par\noindent\hfil
-  \begin{tenkzcd}[maps, species={channel}]
-    \mathcal A_2 & \mathcal A_3
-    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
-  \end{tenkzcd}
+  \begin{tikzcd}[channel, column sep=large]
+    \mathcal A_2 \arrow[r, "\mathcal T"] & \mathcal A_3
+  \end{tikzcd}
 \hfil\par
 
 \begin{definition}[The neighboring-state preparation $\mathcal S_1$]

--- a/blueprint/src/macros/diagrams.tex
+++ b/blueprint/src/macros/diagrams.tex
@@ -1,0 +1,12 @@
+% Commutative diagrams are tikz-cd material, outside the tenkz language.
+% The channel style keeps the ink these arrows carried as tenkz typed
+% maps: a headless stroke of wire weight in the marked hue, its label
+% seated on the stroke over paper.  Both the print preamble and the
+% standalone web picture units read this file after loading tenkz, which
+% supplies tikz-cd and the hue.
+\tikzcdset{
+  channel/.style={
+    every arrow/.append style={draw=tenkzMarked, line width=0.55pt,
+      no head},
+    every label/.append style={description}},
+}

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -11,6 +11,7 @@
 \input{macros/common}
 \input{macros/print}
 \usepackage{tenkz}
+\input{macros/diagrams}
 
 \providecommand{\blueprinttitle}{Tensor Network Theory:\\
   \large A formalization blueprint}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -81,18 +81,16 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_foundations.tex` | L87, 92 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 293, 294, 295, 296, 298 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L581, 583 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L444 `tenkzfree` → `R-free+R-record` |
-| `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
+| `ch21_mpdo_rfp_renormalization.tex` | — | — | L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | L282, 288 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L793, 806, 814, 821, 895, 902 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex` | — | — | L427 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L333, 852, 856, 862, 867 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | L56, 92 `tenkz` → `P-grid` | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record` |
@@ -121,23 +119,25 @@ separate public-surface occurrence and therefore appears separately.
 | `tenkzeq` | 0 |
 | `tenkzfree` | 34 |
 | `tenkzlattice` | 12 |
-| `tenkzcd` | 6 |
+| `tenkzcd` | 0 |
 | `tenkzplanes` | 0 |
 | `tnpic` | 22 |
 | `tntree` | 11 |
-| **Total** | **207** |
+| **Total** | **201** |
 
 | Disposition | Occurrences |
 |---|---:|
 | preserve | 48 |
 | codemod | 25 |
-| redraw | 134 |
-| **Total** | **207** |
+| redraw | 128 |
+| **Total** | **201** |
 
-The raw count is 174 environment openings plus 33 command occurrences,
-which reconciles to 207. This reproduces the issue baseline: 106 `tenkz`,
+The raw count is 168 environment openings plus 33 command occurrences,
+which reconciles to 201. The issue baseline counted 106 `tenkz`,
 36 `tenkzfree`, 18 `tenkzlattice`, 6 `tenkzcd`, 0 `tenkzeq`,
-0 `tenkzplanes`, and 41 `\tnpic`/`\tntree` lines.
+0 `tenkzplanes`, and 41 `\tnpic`/`\tntree` lines; the six `tenkzcd`
+pictures have since been respelled onto plain tikz-cd, discharging every
+blueprint `R-cd` row.
 
 ## Standalone fixture inventory
 

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2236,3 +2236,34 @@ else.
 |---|---|
 | flag:consumers:command:tnedge | dies at the language landing with every 0.7 lattice command: an edge is an ordinary `\tnwire` of kind index, and a generated one is now restatable by the body; the two migrated PEPS panels retire all but one blueprint consumer, and the tenure it loses is the one this row already spent; expiry 0.9 |
 | flag:consumers:key:connection:distinguished | dies with `\tnedge` it rides: a distinguished edge is a restated bond carrying a declared `species=`, which is how the two migrated panels now say it; the single remaining blueprint consumer goes with the lattice dialect at S4; expiry 0.9 |
+
+### 2026-08-06 — the commutative diagrams leave the language
+
+The six blueprint `tenkzcd` pictures are respelled onto plain tikz-cd,
+which is where the signed contract sends them: commutative diagrams
+belong to tikz-cd, outside this language (`LANGUAGE-1.0` §10). The four
+typed-map figures keep their ink through one preamble style — a channel
+arrow is a headless stroke of wire weight in the marked hue, its label
+seated on the stroke — and the two coherence pentagons take the ordinary
+category-theorist's spelling, a matrix with blank cells, their `\tntree`
+bodies unchanged. Every blueprint `R-cd` row in `DISPOSITIONS.md` is
+discharged; the environment's remaining consumers are standalone
+fixtures awaiting their own redraws.
+
+M3 falls from 29 to 24: the two `radius=`, one `column sep=`, and two
+`row sep=` occurrences that rode the retired pictures were the metered
+escapes #5085 left open until this migration. M1 stays at 140 kernel
+rows and 201 total, M2 at 228 parser paths, and M4 at 25.94 — the
+registry and the benchmark corpus are untouched. Seven rows lose their
+last demand-corpus consumers with the respelling and take their
+verdicts below.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:environment:tenkzcd | tombstoned by contract: commutative diagrams belong to tikz-cd, outside this language (`LANGUAGE-1.0` §10); the blueprint respelling leaves only fixture consumers, which go with their own `R-cd` redraws; deleted at the S4 swap; expiry 0.9 |
+| flag:consumers:command:tnarrow | tombstoned by contract: `\tnarrow` migrates to `\tnwire[dir=to]` (`LANGUAGE-1.0` §10), and a commutative-diagram arrow is tikz-cd's own `\arrow`, outside the language; the respelling retired its last demand-corpus uses; expiry 0.9 |
+| flag:consumers:key:picture:maps | tombstoned by contract: `maps` died with `tenkzcd` (`LANGUAGE-1.0` §10); its only demand-corpus consumers were the respelled typed-map figures; expiry 0.9 |
+| flag:consumers:key:connection:from | dies with the `\tnarrow` declarations that addressed it: a tikz-cd arrow names its target cell directly, and a kernel wire names both endpoints as arguments; expiry 0.9 |
+| flag:consumers:key:connection:to | dies with the `\tnarrow` declarations that addressed it, exactly as `from=` does; expiry 0.9 |
+| flag:consumers:key:connection:species | dies at the S4 swap with the 0.7 connection tier it belongs to; the kernel wire carries its own signed `species=` row, and the respelled arrows carry their type in the preamble style; expiry 0.9 |
+| flag:consumers:key:setup:species | dies as a name-list: `\tndeclare{species}{name}{hue=...}` is the one declaration door, the blueprint already declares every species through it, and the last bare name-list rode the retired `tenkzcd` opt-in; expiry 0.9 |

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -17,7 +17,7 @@
   },
   "m3_escape_usage": {
     "definition": "occurrences of escape-ledger spellings in the demand corpus; every occurrence names a core-grammar gap",
-    "value": 29
+    "value": 24
   },
   "m4_lines_per_case": {
     "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",


### PR DESCRIPTION
Part of retiring the `tenkzcd` dialect (#4699; checklist item 6.2 on LionSR/tenkz#13). `LANGUAGE-1.0.md` §10 records the signed decision: commutative diagrams belong to tikz-cd, outside this language, and `maps`, `polygon=`, `radius=` died with `tenkzcd`. This PR respells all six blueprint `tenkzcd` pictures onto plain `tikzcd` and discharges every blueprint `R-cd` disposition row.

## The six pictures

| Figure | Old | New |
|---|---:|---:|
| `ch21_..._refinement_channels_sector_coordinates.tex` — three-stage refinement row | 9 | 6 |
| `ch21_..._refinement_channels_sector_coordinates.tex` — composite channel | 4 | 3 |
| `ch21_..._normalized_preparations_controlled_partial_traces.tex` — four fiberwise types | 14 | 10 |
| `ch21_mpdo_rfp_renormalization.tex` — coarse-graining/refining pair (`\tnpic` cells) | 17 | 15 |
| `ch21_..._fusion_isometries_complete_zipper_coherence.tex` — fusion-tree pentagon | 12 | 8 |
| `ch21_..._fusion_isometries_complete_zipper_coherence.tex` — parenthesization pentagon | 12 | 7 |

68 picture lines become 49. The pentagons take the ordinary category-theorist's spelling — a matrix with blank cells — with their `\tntree` bodies byte-unchanged; the starred `\tnarrow*` label swaps become tikz-cd's `"label"'`. The renormalization figure keeps its kernel `\tnpic` cells inside `tikzcd` cells; `ampersand replacement=\&` guards the `&` those cell bodies carry, which is tikz-cd's documented spelling for nested alignment characters.

## Shared preamble style

`blueprint/src/macros/diagrams.tex` defines one `tikzcd` style, `channel`, reproducing exactly what `species={channel}` bought in the retired dialect: a headless stroke of tenkz wire weight (0.55pt) in the marked hue (`tenkzMarked`), label seated on the stroke over paper (`description`). The print preamble (`print.tex`) and the standalone web picture units (`Packages/tenkz_pic.py`) both read the file after loading tenkz; `tenkz_pic.py` also registers `tikzcd` as a verbatim-captured unit and folds `macros/diagrams.tex` into the render digest, so both pipelines compile byte-identical picture sources.

## Render evidence

Standalone rasters of every figure at **200 dpi** (`pdftocairo -png -r 200`), old spelling vs new, inspected pairwise: `fig1-refine-three.png`, `fig2-refine-comp.png`, `fig3-prep-four.png`, `fig4-renorm.png`, `fig5-pent-trees.png`, `fig6-pent-prod.png` (scratchpad `old/` and `final/` sets). Checked: blue stroke color and weight, label seated on the stroke, MPO cells and their physical legs, tree topology and charge labels, arrow directions, label sides (swapped labels sit outside the pentagon's lower route), no clipping. The old dialect measured label widths to grow the map gap; tikz-cd does not, so the wide-label figures carry explicit `column sep` (large/16mm) — verified the stroke stays visible on both sides of every label.

- `leanblueprint pdf` builds; book pages 550, 683–684, 699, 799, 800 inspected at 100 dpi (fiberwise strokes re-checked at 300 dpi — all four blue).
- `leanblueprint web` builds (exit 0); the six `tenkz-pic-cd` SVGs render through the xelatex→dvisvgm route with the correct `rgb(0%,0%,65%)` channel strokes; two rasterized and inspected.
- `scripts/tenkz_kernel_probes.sh`: all probes pass, kernel pixels byte-identical.
- `python3 scripts/check_tenkz_dispositions.py`: 201 blueprint occurrences reconcile exactly.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`: passes; M3 falls 29 → 24 (the `radius=` ×2, `column sep=`, `row sep=` ×2 escapes leave the demand corpus), M1/M2/M4 unchanged; the seven rows that lost their last demand-corpus consumers carry verdicts in the new `SHRINK.md` session.

## What still blocks deleting `tenkz-cd.code.tex`

- 14 standalone fixtures under `tests/tenkz/*.tex` still open `tenkzcd`. `docs/tenkz/FIXTURE-RETIREMENT.md` (#5600) classifies their typed-map behaviours as **dies** — no replacement coverage owed — so deletion now waits on the legacy fixture-corpus retirement (checklist 6.3–6.4 on LionSR/tenkz#13), not on redraw work.
- LionSR/TNLean#5598 already moved `\tntree` out into `tenkz-tree.code.tex`, so the tree survivor no longer blocks.
- With this PR the blueprint is `tenkzcd`-free; deleting the file is the final step of LionSR/TNLean#4699 once the fixture corpus goes.
