### PR TITLE
refactor(tenkz): retire the inert conjugate key

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -101,7 +101,7 @@ contraction, the same boundary signature, whether the restatement carries ink
 of its own or none. A travelling string states an operator index rather than
 that contraction and retires nothing.
 
-### 2.3 Atom keys (13)
+### 2.3 Atom keys (12)
 
 | Key | Type | Values | Default | Diagnostic family |
 |---|---|---|---|---|
@@ -116,7 +116,6 @@ that contraction and retires nothing.
 | `pairing cross=` | indexed-crossing-list | `<pairing-number>: <crossing-declaration>, ...` | empty | `TKZ-SKIN-PAIRING-*` |
 | `size=` | small-enum | `s` `m` `l` | `m` | `TKZ-SIZE-*` |
 | `label pos=` | angle | a bearing in the record's own axes, or `auto` | `auto` | `TKZ-LABEL-*` |
-| `conjugate` | flag | — | false | `TKZ-ATOM-*` |
 | `void=` | small-enum | `open` `sealed` | unset | `TKZ-ATOM-*` |
 
 A face is an angle in the record's own axes (§3, §4), so the outward physical
@@ -875,6 +874,7 @@ is not the fixed two-axis atom contract of §7.
 | `slot=` | `species=`, which atoms and wires already carry |
 | `up=`, `down=` | `ports=`: the outward physical face is the row's own normal |
 | `check=` | nothing: the audit follows the joiner class (§7) |
+| `conjugate` flag | nothing: duality is the wire's `dir=` (§2.4), and a conjugate overline is label mathematics |
 | `form=cut`, `form=band`, `form=brace-below`, `form=prose`, `\tncut`, `\tnregion`, `\tnprose` | `form=enclosure`, `form=bracket`, or a term of unknown signature (§6, §7) |
 | `frame=vertical`, `frame=rotate=<deg>`, frame matrices | `flat`, `plane`, `circle`; orientation is a consequence of where a record sits (§4) |
 | `leg <face> of <cell>`, `<compass> outside` | a generated leg is a named record; an open end takes its place from the route (§5) |

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2267,3 +2267,41 @@ verdicts below.
 | flag:consumers:key:connection:to | dies with the `\tnarrow` declarations that addressed it, exactly as `from=` does; expiry 0.9 |
 | flag:consumers:key:connection:species | dies at the S4 swap with the 0.7 connection tier it belongs to; the kernel wire carries its own signed `species=` row, and the respelled arrows carry their type in the preamble style; expiry 0.9 |
 | flag:consumers:key:setup:species | dies as a name-list: `\tndeclare{species}{name}{hue=...}` is the one declaration door, the blueprint already declares every species through it, and the last bare name-list rode the retired `tenkzcd` opt-in; expiry 0.9 |
+
+### 2026-08-06 — the conjugate flag is sentenced
+
+`conjugate=` is installed on the kernel atom tier and read by nothing: not
+the ink passes, not the boundary-signature fold, not a checker.  A sweep of
+the whole tree (issue 5383) finds sixteen atoms across seven section-II
+benchmark cases carrying the flag, two kernel regression fixtures spelling
+it as a manufactured consumer, and no consumer of the answer anywhere.  The
+only trace it leaves is the `conjugate=true` field in those atoms' records.
+
+The issue reserved the row until the directed-signatures design decided who
+carries duality.  The contract has since decided: wire `dir=` is the one
+spelling for a space against its dual (`LANGUAGE-1.0` section 2.4), so a
+second semantic carrier would say the same thing twice.  The presentational
+reading fails on the corpus's own evidence: no author panel draws a
+conjugate glyph, and every benchmark atom that wants visible conjugation
+spells `\overline{...}` in its label — wiring the flag to ink would double
+the bar on the three labelled cases, grow a stub bar on the empty-labelled
+bra rows, and change renders no figure asked for.  What remains is a flag
+that looks semantic, claims to be presentational, and is neither; a stored
+answer nobody reads is a key that can silently lie.
+
+So the row is tombstoned.  Per the booking rule in force since session 0,
+the ledger status moves with the parser row and not before: the registry row
+stays `kernel` with its note reading the sentence, the row is struck from
+the contract's atom table into the section-10 tombstones today — as the nine
+amendments were at their sentencing — and the deletion itself — the parser
+row, the sixteen benchmark spellings, the two fixture spellings, and their
+re-pinned record streams — executes as the usual corpus rewrite at the 1.0
+freeze.
+
+No meter moves today.  M1 stays at 140 kernel rows and 201 total, M2 at 228
+parser paths with an unchanged identity, M4 untouched; the registry note and
+this sentence are the whole diff.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:kernel-atom:conjugate | tombstoned: read by nothing, duality already has its one spelling in wire `dir=`, and the conjugate overline is label mathematics already spelled in the corpus; the parser row, the sixteen benchmark spellings, and the two fixture spellings leave in the corpus rewrite at the 1.0 freeze, the status moving with the parser row as booked since session 0; expiry 0.9 |

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -213,7 +213,7 @@ kernel-\allowbreak{}atom & \texttt{label~pos} & angle & auto & Label \allowbreak
 kernel-\allowbreak{}atom & \texttt{nudge} & pair & zero & Quarter-\allowbreak{}pitch \allowbreak{}displacement. \\
 kernel-\allowbreak{}atom & \texttt{void} & void-\allowbreak{}policy & unset & Hole \allowbreak{}or \allowbreak{}removed \allowbreak{}site. \\
 kernel-\allowbreak{}atom & \texttt{physical} & physical-\allowbreak{}policy & unset & Site's \allowbreak{}own \allowbreak{}answer \allowbreak{}to \allowbreak{}the \allowbreak{}picture's \allowbreak{}physical \allowbreak{}policy. \\
-kernel-\allowbreak{}atom & \texttt{conjugate} & flag & false & Reserved; \allowbreak{}currently \allowbreak{}inert \allowbreak{}(\allowbreak{}stored,\allowbreak{} \allowbreak{}unread). \\
+kernel-\allowbreak{}atom & \texttt{conjugate} & flag & false & Tombstoned; \allowbreak{}stored,\allowbreak{} \allowbreak{}read \allowbreak{}by \allowbreak{}nothing. \allowbreak{}Sunset \allowbreak{}1.0. \\
 kernel-\allowbreak{}atom & \texttt{cluster} & pair & empty & Expander: \allowbreak{}RxC \allowbreak{}addressable \allowbreak{}sub-\allowbreak{}atom \allowbreak{}group. \\
 kernel-\allowbreak{}atom & \texttt{role} & semantic-\allowbreak{}role & empty & Prelude \allowbreak{}species \allowbreak{}spelling. \\
 kernel-\allowbreak{}wire & \texttt{kind} & enum(\allowbreak{}index\textbar{}\allowbreak{}string\textbar{}\allowbreak{}pairing) & index & Bond,\allowbreak{} \allowbreak{}travelling \allowbreak{}string,\allowbreak{} \allowbreak{}or \allowbreak{}generated \allowbreak{}skin \allowbreak{}pairing. \\

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -310,9 +310,13 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{void}{void-policy}{unset}{kernel}{Hole or removed site.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{physical}{physical-policy}{unset}{kernel}{Site's own answer to the picture's physical policy.}
 % Issue 5383: stored but never read by ink passes or the signature fold.
-% Marked reserved until the directed-signatures design (issue 4162)
-% decides whether duality rides dir= or a real glyph flip is implemented.
-\__tenkz_language_registry_key:nnnnnn {kernel-atom}{conjugate}{flag}{false}{kernel}{Reserved; currently inert (stored, unread).}
+% The directed-signatures question the reservation waited on is answered:
+% wire dir= is the contract's one spelling for a space against its dual, and
+% no source panel draws a conjugate glyph -- the overline the corpus wants
+% is label mathematics, already spelled there.  Sentenced in the shrink
+% ledger (2026-08-06); the status moves with the parser row at the 1.0
+% freeze, and the corpus rewrite executes with it.
+\__tenkz_language_registry_key:nnnnnn {kernel-atom}{conjugate}{flag}{false}{kernel}{Tombstoned; stored, read by nothing. Sunset 1.0.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{cluster}{pair}{empty}{sugar(name=, skin=)}{Expander: RxC addressable sub-atom group.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{role}{semantic-role}{empty}{sugar(species=)}{Prelude species spelling.}
 \__tenkz_language_registry_key:nnnnnn {kernel-wire}{kind}{enum(index|string|pairing)}{index}{kernel}{Bond, travelling string, or generated skin pairing.}


### PR DESCRIPTION
Closes LionSR/tenkz#138. Disposition 3, tombstone.

## The sweep

A fresh whole-tree sweep confirms the issue's finding and sharpens it. The key now installs on the kernel tier only (`tex/tenkz/tenkz-kernel.code.tex:1180`); the grid and lattice installers named in the issue are already gone. No ink pass, no boundary-signature fold, and no checker reads the stored flag; its only trace is the `conjugate=true` field in atom records. Consumers of the spelling: sixteen atoms across seven section-II RMP cases (`rmp-ii-mpu-blocking`, `rmp-ii-sv17`, `rmp-workbench-ii-v-tensor-definition`, `rmp-ii-spectrum-transfer`, `rmp-ii-spectrum-rho`, `rmp-ii-local-purification`, `rmp-ii-reduced-density`) and two kernel regression fixtures (`r_cup_label`, `r_false_flags` — manufactured consumers). Zero blueprint occurrences.

## Why tombstone and not the glyph

- **Not semantic (option 1):** wire `dir=` is the contract's one spelling for a space against its dual (`LANGUAGE-1.0` §2.4); a second duality carrier says the same thing twice, which one-concept-one-spelling forbids.
- **Not presentational (option 2):** no author panel draws a conjugate glyph, and the corpus's own verdicts show the demand is for the overline as *label mathematics*: every conjugate-flagged atom that wants visible conjugation already spells `\overline{...}` in its label (`rmp-ii-mpu-blocking`, `rmp-ii-local-purification`, `rmp-workbench-ii-v-tensor-definition`), and the `verdicts.toml` notes record that spelling as the accepted form. Wiring the flag to ink would double the bar on the three labelled cases and grow a stub bar on the empty-labelled bra rows — a rendering change no figure asked for, staling verdicts to draw something the sources do not draw.

What remains is a flag that looks semantic, claims to be presentational, and is neither — exactly the silently-lying key the audit doctrine exists to prevent.

## How the tombstone is booked

Per the booking rule in force since session 0 (the nine amendments' comment block in the registry): the sentence lands now, and the ledger status moves with the parser row, not before.

- `docs/tenkz/SHRINK.md`: new final session (2026-08-06) with the machine-readable verdict row `tombstoned ...; expiry 0.9`; the entire pre-change file is retained byte-for-byte as a prefix.
- `docs/tenkz/LANGUAGE-1.0.md`: `conjugate` struck from the §2.3 atom table (13 → 12) and entered in the §10 tombstone table with its migration — the same treatment the nine sentenced amendments received while their registry rows stay `kernel`.
- `tex/tenkz/tenkz-language-registry.tex`: the row stays `kernel` (the alias ledger is closed — M5 growth is rejected unconditionally, and `conjugate` abbreviates nothing); its note now reads `Tombstoned; stored, read by nothing. Sunset 1.0.` with the sentencing comment above it.
- `docs/tenkz/chapters2/generated-language-reference.tex`: regenerated from the registry.

The parser row, the sixteen benchmark spellings, the two fixture spellings, and their re-pinned record streams leave in the usual corpus rewrite at the 1.0 freeze. Nothing changes today for the six in-flight chapter-migration PRs: no parser, event, or rendering change.

## Evidence

- `scripts/tenkz_kernel_probes.sh --check`: 127 review regressions hold; 10 sugar pairs byte-identical; 12 kernel record streams byte-identical; kernel pixels byte-identical.
- `scripts/tenkz_golden.sh --check`: 264 event streams byte-identical to the golden baseline.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`: census stable at 201, all 150 flags carry verdicts; meters byte-identical to `tests/tenkz/census-baseline.json` (M1 140 kernel / 201 total, M2 228 with unchanged identity, M4 25.94).
- `python3 scripts/tenkz_language.py check`: registry valid (229 records); `python3 scripts/check_tenkz_policy.py` and `check_tenkz_dispositions.py` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and registry bookkeeping only; executable parser and corpus edits are explicitly deferred, with CI census unchanged.
> 
> **Overview**
> **Tombstones the kernel atom `conjugate` flag** (#5383): it is parsed and stored but never read by ink, signatures, or checkers, so the PR books retirement now and deletes parser/corpus spellings at the 1.0 freeze.
> 
> **Contract and shrink ledger:** `LANGUAGE-1.0` shrinks the §2.3 atom key table (13→12), adds a §10 tombstone pointing duality to wire `dir=` and visible conjugation to label `\overline{...}`. `SHRINK.md` records the 2026-08-06 verdict; registry and generated reference rows stay `kernel` until the parser row moves, with notes marked tombstoned/sunset 1.0.
> 
> **No runtime change in this diff** — meters and parsers unchanged; sixteen benchmark and two fixture uses leave in the planned corpus rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e9eeeb04b3aabb4aa30a248bae798b12c4783e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->