### PR TITLE
doc(blueprint): respell the MPS and symmetry chapters onto the tenkz kernel

### DIFF
--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -422,6 +422,24 @@ else:
         blockType = True
         templateName = "TenkzEquation"
 
+    def _holds_kernel_switch(node) -> bool:
+        r"""Whether this preceding sibling carries \tenkzkernel in force.
+
+        A paragraph break is not a TeX group, so a switch inside a
+        preceding ``par`` wrapper still governs what follows; the search
+        descends through ``par`` nodes and nothing else, since every
+        other container opens a group that ends the declaration.
+        """
+        name = getattr(node, "nodeName", "")
+        if name == "tenkzkernel":
+            return True
+        if name != "par":
+            return False
+        return any(
+            _holds_kernel_switch(child)
+            for child in getattr(node, "childNodes", [])
+        )
+
     def _kernel_switch_reaches(node) -> bool:
         r"""Whether \tenkzkernel is in force where this picture stands.
 
@@ -439,7 +457,7 @@ else:
             for sibling in getattr(parent, "childNodes", []):
                 if sibling is current:
                     break
-                if getattr(sibling, "nodeName", "") == "tenkzkernel":
+                if _holds_kernel_switch(sibling):
                     return True
             current = parent
         return False

--- a/blueprint/src/appendix/ft_mps/ch12_symmetry_algebra.tex
+++ b/blueprint/src/appendix/ft_mps/ch12_symmetry_algebra.tex
@@ -44,16 +44,16 @@ reordering basis states rather than by a general linear map. % The statements of
     % Contractions: none.
     % Paired boundary: boundary|virtual-west=1|virtual-east=1|
     % physical-up=1|physical-down=0.
-    \begin{align}
-        \begin{tenkz}[physical=up]
-            \tn[up=$i$]{A}
+    \begin{tenkzequation}
+        \tenkzkernel
+        \begin{tenkz}[cols=1, boundary=open]
+            \tn[ports={90:physical:$i$}]{A}
         \end{tenkz}
-         & \qquad \xrightarrow{\sigma_g} \qquad
-        \begin{tenkz}[physical=up]
-            \tn[up=$\sigma(g)(i)$]{A}
+        \(\qquad \xrightarrow{\sigma_g} \qquad\)
+        \begin{tenkz}[cols=1, boundary=open]
+            \tn[ports={90:physical:$\sigma(g)(i)$}]{A}
         \end{tenkz}.
-        \notag
-    \end{align}
+    \end{tenkzequation}
 \end{definition}
 
 \begin{lemma}[Identity permutation twist]\label{lem:perm_twisted_one}
@@ -105,14 +105,20 @@ $\sigma(h)$ acts first on the index.
     % Contractions: none in any panel.
     % Common boundary: boundary|virtual-west=1|virtual-east=1|
     % physical-up=1|physical-down=0.
-    \begin{align}
-        \tnpic[physical=up]{\tn[up=$i$]{A}}
-         & \qquad \xrightarrow{\sigma_h} \qquad
-        \tnpic[physical=up]{\tn[up=$\sigma(h)(i)$]{A}}
-        \qquad \xrightarrow{\sigma_g} \qquad
-        \tnpic[physical=up]{\tn[up=$\sigma(g)(\sigma(h)(i))$]{A}}.
-        \notag
-    \end{align}
+    \begin{tenkzequation}
+        \tenkzkernel
+        \begin{tenkz}[cols=1, boundary=open]
+            \tn[ports={90:physical:$i$}]{A}
+        \end{tenkz}
+        \(\qquad \xrightarrow{\sigma_h} \qquad\)
+        \begin{tenkz}[cols=1, boundary=open]
+            \tn[ports={90:physical:$\sigma(h)(i)$}]{A}
+        \end{tenkz}
+        \(\qquad \xrightarrow{\sigma_g} \qquad\)
+        \begin{tenkz}[cols=1, boundary=open]
+            \tn[ports={90:physical:$\sigma(g)(\sigma(h)(i))$}]{A}
+        \end{tenkz}.
+    \end{tenkzequation}
 \end{proof}
 
 
@@ -193,15 +199,17 @@ scalar factor.
     \uses{def:gauge_equiv}
     Diagrammatically, the hypothesis is that the two local gauges
     \begin{center}
+        \tenkzkernel
         % B^i = X A^i X^{-1}: the red capsules act on the west and east
         % virtual indices of A^i; the upper leg is the free index i.
         % Both sides have boundary signature (1,1,1,0).
-        \begin{tenkz}[physical=up]
-            \tn[up=$i$]{B}
+        \begin{tenkz}[cols=1, boundary=open]
+            \tn[ports={90:physical:$i$}]{B}
         \end{tenkz}
         $ = $
-        \begin{tenkz}[physical=up]
-            \tnX{X} & \tn[up=$i$]{A} & \tnX{X^{-1}}
+        \begin{tenkz}[boundary=open]
+            \tn[skin=ring]{X} & \tn[ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{X^{-1}}
         \end{tenkz}
 
         \qquad\text{and}\qquad
@@ -209,12 +217,13 @@ scalar factor.
         % B^i = Y A^i Y^{-1}: this second gauge has the same source,
         % target, and free physical index as the X-gauge above.  Both
         % sides again have boundary signature (1,1,1,0).
-        \begin{tenkz}[physical=up]
-            \tn[up=$i$]{B}
+        \begin{tenkz}[cols=1, boundary=open]
+            \tn[ports={90:physical:$i$}]{B}
         \end{tenkz}
         $ = $
-        \begin{tenkz}[physical=up]
-            \tnX{Y} & \tn[up=$i$]{A} & \tnX{Y^{-1}}
+        \begin{tenkz}[boundary=open]
+            \tn[skin=ring]{Y} & \tn[ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{Y^{-1}}
         \end{tenkz}
     \end{center}
     produce the same target tensor $B^i$ from the same source tensor
@@ -264,17 +273,19 @@ scalar factor.
     $c(g,h) \in \C^{\times}$. Diagrammatically, the two candidate gauges
     are competing local replacements for the same twisted tensor:
     \begin{center}
+        \tenkzkernel
         % (X(h)X(g)) A^i (X(h)X(g))^{-1}
         %   = X(gh) A^i X(gh)^{-1}: the two candidate gauges act on
         % the same virtual indices of A^i and produce the same twisted
         % tensor.  The upper leg is i; both terms have signature (1,1,1,0).
-        \begin{tenkz}[physical=up]
-            \tnX{X(h)X(g)} & \tn[up=$i$]{A} &
-            \tnX{(X(h)X(g))^{-1}}
+        \begin{tenkz}[boundary=open]
+            \tn[skin=ring]{X(h)X(g)} & \tn[ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{(X(h)X(g))^{-1}}
         \end{tenkz}
         $ = $
-        \begin{tenkz}[physical=up]
-            \tnX{X(gh)} & \tn[up=$i$]{A} & \tnX{X(gh)^{-1}}
+        \begin{tenkz}[boundary=open]
+            \tn[skin=ring]{X(gh)} & \tn[ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{X(gh)^{-1}}
         \end{tenkz}
     \end{center}
     and both sides conjugate $A^i$ to the same twisted tensor

--- a/blueprint/src/appendix/ft_mps/ch12_symmetry_algebra.tex
+++ b/blueprint/src/appendix/ft_mps/ch12_symmetry_algebra.tex
@@ -214,9 +214,6 @@ scalar factor.
 
         \qquad\text{and}\qquad
 
-        % The paragraph break above ends the declaration's scope in the
-        % standalone web renderer, so the switch is restated.
-        \tenkzkernel
         % B^i = Y A^i Y^{-1}: this second gauge has the same source,
         % target, and free physical index as the X-gauge above.  Both
         % sides again have boundary signature (1,1,1,0).

--- a/blueprint/src/appendix/ft_mps/ch12_symmetry_algebra.tex
+++ b/blueprint/src/appendix/ft_mps/ch12_symmetry_algebra.tex
@@ -214,6 +214,9 @@ scalar factor.
 
         \qquad\text{and}\qquad
 
+        % The paragraph break above ends the declaration's scope in the
+        % standalone web renderer, so the switch is restated.
+        \tenkzkernel
         % B^i = Y A^i Y^{-1}: this second gauge has the same source,
         % target, and free physical index as the X-gauge above.  Both
         % sides again have boundary signature (1,1,1,0).

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -21,8 +21,9 @@ boundary conditions (PBC).
         % index i, and the open west/east legs are the two virtual
         % matrix indices. Boundary signature: (virtual-west=1 |
         % virtual-east=1 | physical-up=1 | physical-down=0).
-        \begin{tenkz}[physical=up]
-            \tn[up=$i$]{A}
+        \tenkzkernel
+        \begin{tenkz}[cols=1, boundary=open]
+            \tn[ports={90:physical:$i$}]{A}
         \end{tenkz}
     \end{center}
     The black node denotes the tensor $A$, the horizontal legs are virtual,
@@ -51,9 +52,12 @@ boundary conditions (PBC).
         % the remaining L-3 factors. Emitted boundary signature of this
         % finite schematic: (virtual-west=1 | virtual-east=1 |
         % physical-up=3 | physical-down=0).
-        \begin{tenkz}[physical=up]
-            \tn[up=$i_1$]{A}\tnspan[brace below]{4}{$L\text{ copies}$} &
-            \tn{A} & \tndots & \tn[up=$i_L$]{A}
+        \tenkzkernel
+        \begin{tenkz}[cols=4, boundary=open, physical=up]
+            \tn[label pos=135, ports={90:physical:$i_1$}]{A} &
+            \tn[label pos=135]{A} & \tn[skin=dots]{} &
+            \tn[label pos=135, ports={90:physical:$i_L$}]{A}
+            \tnmark[form=bracket]{(1,1) .. (1,4)}{$L\text{ copies}$}
         \end{tenkz}
     \end{center}
     in which each black node denotes the same local tensor $A$, the virtual
@@ -168,9 +172,12 @@ boundary conditions (PBC).
         % the remaining N-3 factors. Emitted boundary signature of this
         % finite schematic: (virtual-west=0 | virtual-east=0 |
         % physical-up=3 | physical-down=0).
-        \begin{tenkz}[periodic, physical=up]
-            \tn[up=$i_1$]{A}\tnspan[brace below]{4}{$N\text{ copies}$} &
-            \tn{A} & \tndots & \tn[up=$i_N$]{A}
+        \tenkzkernel
+        \begin{tenkz}[cols=4, boundary=periodic, physical=up]
+            \tn[label pos=135, ports={90:physical:$i_1$}]{A} &
+            \tn[label pos=135]{A} & \tn[skin=dots]{} &
+            \tn[label pos=135, ports={90:physical:$i_N$}]{A}
+            \tnmark[form=bracket]{(1,1) .. (1,4)}{$N\text{ copies}$}
         \end{tenkz}
     \end{center}
     of $N$ copies of the local tensor $A$, with the outer virtual legs closed
@@ -190,16 +197,17 @@ boundary conditions (PBC).
     \end{align}
     Diagrammatically, the transfer map is the double-layer contraction
     \begin{center}
-        % \E_A(X) = \sum_i A^i X (A^i)^\dagger: the upper and starred
+        % \E_A(X) = \sum_i A^i X (A^i)^\dagger: the upper and conjugate
         % lower nodes are A and its conjugate, their paired physical
         % legs sum i, and X rides the east cup (the input). Traversing
         % the lower wire in the opposite direction supplies the transpose
         % in the adjoint. The west pair remains open as the matrix output.
         % Boundary signature: (virtual-west=2 | virtual-east=0 |
         % physical-up=0 | physical-down=0).
-        \begin{tenkz}[sandwich, east={cup=$X$}]
-            \tn{A} \\
-            \tn*{A}
+        \tenkzkernel
+        \begin{tenkz}[rows={ket,bra}, cols=1, west=open, east={cup=$X$}]
+            \tn[label pos=n]{A} \\
+            \tn[label pos=s, conjugate]{\overline{A}}
         \end{tenkz}
     \end{center}
     in which the upper node denotes $A$, the lower node denotes $A^\dagger$,
@@ -269,8 +277,10 @@ boundary conditions (PBC).
         % Type verdict: both sides are rank-three local MPS tensors.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0.
-        \begin{tenkz}[physical=up]
-            \tnX{X} & \tn[up=$i$]{A} & \tnX{X^{-1}}
+        \tenkzkernel
+        \begin{tenkz}[boundary=open]
+            \tn[skin=ring]{X} & \tn[ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{X^{-1}}
         \end{tenkz}
     \end{center}
     where the black node denotes the tensor $A$, the upper leg is the physical
@@ -837,9 +847,11 @@ $A^{-1}A=\Id$. This is the identity used in
         % tensor after combining the L physical indices.
         % Boundary signature: semantic virtual-west=1 | virtual-east=1 |
         % physical-up=L | physical-down=0; the finite schematic emits 3 up legs.
-        \begin{tenkz}[physical=up, tensor style=box]
-            \tn[up=$i_1$]{A}\tnspan[box, label pos=west]{4}{A^{[L]}} &
-            \tn{A} & \tndots & \tn[up=$i_L$]{A}
+        \tenkzkernel
+        \begin{tenkz}[cols=4, boundary=open, physical=up]
+            \tn[skin=box, ports={90:physical:$i_1$}]{A} & \tn[skin=box]{A} &
+            \tn[skin=dots]{} & \tn[skin=box, ports={90:physical:$i_L$}]{A}
+            \tnmark[form=enclosure, label pos=w]{(1,1) .. (1,4)}{$A^{[L]}$}
         \end{tenkz}
     \end{center}
 \end{definition}
@@ -963,6 +975,11 @@ $A^{-1}A=\Id$. This is the identity used in
         % scalar. The brace makes the N-site contraction schematic.
         % Boundary signature: (virtual-west=0 | virtual-east=0 |
         % physical-up=0 | physical-down=0).
+        % Blocked on the 0.7 grid tier: the kernel draws each row's trace
+        % return one clearance below its own row, so the upper ring's return
+        % would run through the ladder and cross the physical pairings.  The
+        % picture migrates once a per-row closure can clear the whole
+        % two-row selection it closes.
         \begin{tenkz}[rows={ket, bra}, periodic]
             \tn{A} & \tndots & \tn{A} \\
             \tn*{B}\tnspan[brace below]{3}{$N\text{ sites}$} & \tndots & \tn*{B}

--- a/blueprint/src/chapter/ch12_symmetry_string_order.tex
+++ b/blueprint/src/chapter/ch12_symmetry_string_order.tex
@@ -27,22 +27,23 @@ physical state symmetry requires additional hypotheses.
     % A_n\otimes\overline{A_{n'}}.
     % Source verdict: Papers/0802.0447/StringOrder-v10.tex, equation EU,
     % lines 164--174, gives this exact algebraic identity but no dedicated
-    % figure.  The lower \tn* supplies entrywise conjugation; reading order
-    % supplies the transpose that yields A_{n'}^\dagger in the applied map.
-    % Pairing/index map: the top-to-middle pairleg contracts n and the
-    % middle-to-bottom pairleg contracts n'.  These are the only physical
-    % pairings.  The middle u row has no virtual boundary, while both
-    % virtual legs of A_n and both virtual legs of \overline{A_{n'}} remain
-    % free because the map has not consumed X.
+    % figure.  The conjugate lower node supplies entrywise conjugation;
+    % reading order supplies the transpose that yields A_{n'}^\dagger in the
+    % applied map.
+    % Pairing/index map: u rides the single ket-bra rung; the segment above
+    % it contracts n and the segment below it contracts n'.  These are the
+    % only physical pairings.  Both virtual legs of A_n and both virtual
+    % legs of \overline{A_{n'}} remain free because the map has not
+    % consumed X.
     % boundary|virtual-west=2|virtual-east=2|physical-up=0|physical-down=0.
-    \begin{align}
-         & \begin{tenkz}[rows={ket,op:none,bra}]
-               \tn{A_n} \\
-               \tn[role=operator]{u} \\
-               \tn*{A_{n'}}
-           \end{tenkz}.
-        \notag
-    \end{align}
+    \begin{center}
+        \tenkzkernel
+        \begin{tenkz}[rows={ket,bra}, cols=1, boundary=open]
+            \tn[label pos=n]{A_n} \\
+            \tn[label pos=s, conjugate]{\overline{A_{n'}}}
+            \tn[species=operator, label pos=w, at=on bond-1-1-2-1 0.5]{u}
+        \end{tenkz}.
+    \end{center}
     The upper and lower black nodes denote $A_n$ and $A_{n'}^\dagger$, and the
     red node labelled $u$ couples the physical legs.
 \end{definition}
@@ -69,17 +70,22 @@ physical state symmetry requires additional hypotheses.
     % Type verdict: a scalar after every physical and virtual index is contracted.
     % Boundary signature: virtual-west=0 | virtual-east=0 |
     % physical-up=0 | physical-down=0.
-    \begin{align}
-         & \begin{tenkz}[rows={ket,op:none,bra},
-                   west={cup=$\Lambda$}, east=cup]
-               \tn{A} & \tn{A} & \tndots & \tn{A} \\
-               \tn[role=operator]{u} & \tn[role=operator]{u} & \tndots &
-               \tn[role=operator]{u} \\
-               \tn*{A}\tnspan[brace below]{4}{$L\text{ sites}$} &
-               \tn*{A} & \tndots & \tn*{A}
-           \end{tenkz}.
-        \notag
-    \end{align}
+    % The site count stands as a label below the chain: a brace under the
+    % conjugate row would run through that row's labels.
+    \begin{center}
+        \tenkzkernel
+        \begin{tenkz}[rows={ket,bra}, cols=4, west={cup=$\Lambda$}, east=cup]
+            \tn[label pos=n]{A} & \tn[label pos=n]{A} & \tn[skin=dots]{} &
+            \tn[label pos=n]{A} \\
+            \tn[label pos=s, conjugate]{\overline{A}} &
+            \tn[label pos=s, conjugate]{\overline{A}} & \tn[skin=dots]{} &
+            \tn[label pos=s, conjugate]{\overline{A}}
+            \tn[species=operator, label pos=w, at=on bond-1-1-2-1 0.5]{u}
+            \tn[species=operator, label pos=w, at=on bond-1-2-2-2 0.5]{u}
+            \tn[species=operator, label pos=w, at=on bond-1-4-2-4 0.5]{u}
+            \tnmark[form=label]{2 s of midway (2,2) and (2,3)}{$L\text{ sites}$}
+        \end{tenkz}.
+    \end{center}
     The boundary matrix $\Lambda$ is contracted into the virtual boundary, the
     red nodes labelled $u$ sit on the physical rungs, and the right boundary
     is traced.
@@ -339,6 +345,7 @@ physical state symmetry requires additional hypotheses.
     Locally, the physical action of $u$ can therefore be pushed to the virtual
     legs:
     \begin{tenkzequation}
+        \tenkzkernel
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
         % Condition C1, lines 328--334, states
         % sum_j u_{ij} A^j = V A^i V^\dagger.
@@ -349,23 +356,14 @@ physical state symmetry requires additional hypotheses.
         % Type verdict: both sides are rank-three local tensors.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0 on both sides.
-        \begin{tenkz}[rows={op:none,ket}]
-            \tn[role=operator,up=$i$]{u} \\
-            \tn{A}
+        \begin{tenkz}[rows={op,ket}, cols=1]
+            \tn[species=operator, label pos=w, ports={90:physical:$i$}]{u} \\
+            \tn[label pos=s, ports={180:virtual, 0:virtual}]{A}
         \end{tenkz}
         =
-        % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
-        % Condition C1, lines 328--334, states
-        % sum_j u_{ij} A^j = V A^i V^\dagger.
-        % Ink-to-index map: i is free above u; j is the sole physical
-        % contraction between u and A; west/east virtual indices remain free.
-        % Contraction set: one physical u--A bond on the left and two
-        % virtual gauge bonds on the right.
-        % Type verdict: both sides are rank-three local tensors.
-        % Boundary signature: virtual-west=1 | virtual-east=1 |
-        % physical-up=1 | physical-down=0 on both sides.
-        \begin{tenkz}[physical=up]
-            \tnX{V} & \tn[up=$i$]{A} & \tnX{V^\dagger}
+        \begin{tenkz}[boundary=open]
+            \tn[skin=ring]{V} & \tn[ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{V^\dagger}
         \end{tenkz}.
     \end{tenkzequation}
 \end{definition}
@@ -384,6 +382,7 @@ physical state symmetry requires additional hypotheses.
     In doubled-layer notation, the virtual operators slide through the local
     transfer cell:
     \begin{tenkzequation}
+        \tenkzkernel
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
         % Condition C2, lines 335--340, states E(VXV^\dagger)=V E(X)V^\dagger.
         % Ink-to-index map: the ket row carries V and A, the bra row carries
@@ -393,23 +392,16 @@ physical state symmetry requires additional hypotheses.
         % Type verdict: equality of endomorphisms on the doubled virtual space.
         % Boundary signature: virtual-west=2 | virtual-east=2 |
         % physical-up=0 | physical-down=0 on both sides.
-        \begin{tenkz}[sandwich]
-            \tnX{V} & \tn{A} \\
-            \tnX{\overline V} & \tn*{A}
+        \begin{tenkz}[rows={ket,bra}, cols=2, bonds=none, boundary=open]
+            \tn[skin=ring]{V} & \tn[label pos=n]{A} \\
+            \tn[skin=ring]{\overline V} & \tn[label pos=s, conjugate]{\overline{A}}
+            \tnwire{(1,1)}{(1,2)} \tnwire{(2,1)}{(2,2)} \tnwire{(1,2)}{(2,2)}
         \end{tenkz}
         =
-        % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
-        % Condition C2, lines 335--340, states E(VXV^\dagger)=V E(X)V^\dagger.
-        % Ink-to-index map: the ket row carries V and A, the bra row carries
-        % their complex conjugates; each column of A and bar(A) shares one index.
-        % Contraction set: one physical ket--bra pairing per transfer cell and
-        % the internal horizontal bonds on each row; all four outer wires are free.
-        % Type verdict: equality of endomorphisms on the doubled virtual space.
-        % Boundary signature: virtual-west=2 | virtual-east=2 |
-        % physical-up=0 | physical-down=0 on both sides.
-        \begin{tenkz}[sandwich]
-            \tn{A} & \tnX{V} \\
-            \tn*{A} & \tnX{\overline V}
+        \begin{tenkz}[rows={ket,bra}, cols=2, bonds=none, boundary=open]
+            \tn[label pos=n]{A} & \tn[skin=ring]{V} \\
+            \tn[label pos=s, conjugate]{\overline{A}} & \tn[skin=ring]{\overline V}
+            \tnwire{(1,1)}{(1,2)} \tnwire{(2,1)}{(2,2)} \tnwire{(1,1)}{(2,1)}
         \end{tenkz}.
     \end{tenkzequation}
 \end{definition}
@@ -440,6 +432,7 @@ physical state symmetry requires additional hypotheses.
     \leanok
     Both sides express the same local picture with opposite orientation:
     \begin{tenkzequation}
+        \tenkzkernel
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
         % Conditions C2--C3, lines 335--347, identify covariance with
         % commutation by V\otimes\overline V in the doubled picture.
@@ -450,24 +443,16 @@ physical state symmetry requires additional hypotheses.
         % Type verdict: equality of two doubled-space endomorphisms.
         % Boundary signature: virtual-west=2 | virtual-east=2 |
         % physical-up=0 | physical-down=0 on both sides.
-        \begin{tenkz}[sandwich]
-            \tnX{V} & \tn{A} \\
-            \tnX{\overline V} & \tn*{A}
+        \begin{tenkz}[rows={ket,bra}, cols=2, bonds=none, boundary=open]
+            \tn[skin=ring]{V} & \tn[label pos=n]{A} \\
+            \tn[skin=ring]{\overline V} & \tn[label pos=s, conjugate]{\overline{A}}
+            \tnwire{(1,1)}{(1,2)} \tnwire{(2,1)}{(2,2)} \tnwire{(1,2)}{(2,2)}
         \end{tenkz}
         =
-        % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
-        % Conditions C2--C3, lines 335--347, identify covariance with
-        % commutation by V\otimes\overline V in the doubled picture.
-        % Ink-to-index map: the upper/lower rows carry the ket/bra virtual
-        % indices; the A--bar(A) pair contracts the physical Kraus index.
-        % Contraction set: the transfer-cell physical pairing and each internal
-        % horizontal row bond are summed; the four outer virtual indices are free.
-        % Type verdict: equality of two doubled-space endomorphisms.
-        % Boundary signature: virtual-west=2 | virtual-east=2 |
-        % physical-up=0 | physical-down=0 on both sides.
-        \begin{tenkz}[sandwich]
-            \tn{A} & \tnX{V} \\
-            \tn*{A} & \tnX{\overline V}
+        \begin{tenkz}[rows={ket,bra}, cols=2, bonds=none, boundary=open]
+            \tn[label pos=n]{A} & \tn[skin=ring]{V} \\
+            \tn[label pos=s, conjugate]{\overline{A}} & \tn[skin=ring]{\overline V}
+            \tnwire{(1,1)}{(1,2)} \tnwire{(2,1)}{(2,2)} \tnwire{(1,1)}{(2,1)}
         \end{tenkz}.
     \end{tenkzequation}
     The two formulas are the same identity read from opposite sides.
@@ -487,6 +472,7 @@ physical state symmetry requires additional hypotheses.
     \uses{lem:unitary_kraus_mixing}
     Starting from
     \begin{tenkzequation}
+        \tenkzkernel
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
         % Condition C1, lines 328--334, is the displayed intertwining relation.
         % Ink-to-index map: i stays free, j contracts vertically between u and A,
@@ -496,22 +482,14 @@ physical state symmetry requires additional hypotheses.
         % Type verdict: equality of rank-three local tensors.
         % Boundary signature: virtual-west=1 | virtual-east=1 |
         % physical-up=1 | physical-down=0 on both sides.
-        \begin{tenkz}[rows={op:none,ket}]
-            \tn[role=operator,up=$i$]{u} \\
-            \tn{A}
+        \begin{tenkz}[rows={op,ket}, cols=1]
+            \tn[species=operator, label pos=w, ports={90:physical:$i$}]{u} \\
+            \tn[label pos=s, ports={180:virtual, 0:virtual}]{A}
         \end{tenkz}
         =
-        % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
-        % Condition C1, lines 328--334, is the displayed intertwining relation.
-        % Ink-to-index map: i stays free, j contracts vertically between u and A,
-        % and the west/east virtual indices stay free on both sides.
-        % Contraction set: one physical bond on the left; two virtual gauge
-        % bonds on the right.
-        % Type verdict: equality of rank-three local tensors.
-        % Boundary signature: virtual-west=1 | virtual-east=1 |
-        % physical-up=1 | physical-down=0 on both sides.
-        \begin{tenkz}[physical=up]
-            \tnX{V} & \tn[up=$i$]{A} & \tnX{V^\dagger}
+        \begin{tenkz}[boundary=open]
+            \tn[skin=ring]{V} & \tn[ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{V^\dagger}
         \end{tenkz},
     \end{tenkzequation}
     one inserts $V^\dagger V = \Id$ so that each local transfer cell is
@@ -537,6 +515,7 @@ physical state symmetry requires additional hypotheses.
     \uses{thm:kraus_rectangular_freedom}
     Set $B^i := V\, A^i\, V^\dagger$. The transfer-map covariance relation
     \begin{tenkzequation}
+        \tenkzkernel
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
         % Condition C2, lines 335--340, is E\circ Ad_V=Ad_V\circ E.
         % Ink-to-index map: V and bar(V) act on the ket/bra virtual rows;
@@ -546,23 +525,16 @@ physical state symmetry requires additional hypotheses.
         % Type verdict: equality of doubled-space endomorphisms.
         % Boundary signature: virtual-west=2 | virtual-east=2 |
         % physical-up=0 | physical-down=0 on both sides.
-        \begin{tenkz}[sandwich]
-            \tnX{V} & \tn{A} \\
-            \tnX{\overline V} & \tn*{A}
+        \begin{tenkz}[rows={ket,bra}, cols=2, bonds=none, boundary=open]
+            \tn[skin=ring]{V} & \tn[label pos=n]{A} \\
+            \tn[skin=ring]{\overline V} & \tn[label pos=s, conjugate]{\overline{A}}
+            \tnwire{(1,1)}{(1,2)} \tnwire{(2,1)}{(2,2)} \tnwire{(1,2)}{(2,2)}
         \end{tenkz}
         =
-        % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
-        % Condition C2, lines 335--340, is E\circ Ad_V=Ad_V\circ E.
-        % Ink-to-index map: V and bar(V) act on the ket/bra virtual rows;
-        % A and bar(A) share the summed physical Kraus index.
-        % Contraction set: one transfer-cell physical pairing and both internal
-        % horizontal row bonds; the four boundary wires remain free.
-        % Type verdict: equality of doubled-space endomorphisms.
-        % Boundary signature: virtual-west=2 | virtual-east=2 |
-        % physical-up=0 | physical-down=0 on both sides.
-        \begin{tenkz}[sandwich]
-            \tn{A} & \tnX{V} \\
-            \tn*{A} & \tnX{\overline V}
+        \begin{tenkz}[rows={ket,bra}, cols=2, bonds=none, boundary=open]
+            \tn[label pos=n]{A} & \tn[skin=ring]{V} \\
+            \tn[label pos=s, conjugate]{\overline{A}} & \tn[skin=ring]{\overline V}
+            \tnwire{(1,1)}{(1,2)} \tnwire{(2,1)}{(2,2)} \tnwire{(1,1)}{(2,1)}
         \end{tenkz}
     \end{tenkzequation}
     implies that the two $d$-element Kraus families $B$ and $A$ define the
@@ -863,13 +835,15 @@ physical state symmetry requires additional hypotheses.
     % Boundary signature: virtual-west=1 | virtual-east=1 |
     % physical-up=1 | physical-down=0 on both sides.
     \begin{tenkzequation}
-        \begin{tenkz}[rows={op:none,ket}]
-            \tn[role=operator,up=$i$]{u} \\
-            \tn{A}
+        \tenkzkernel
+        \begin{tenkz}[rows={op,ket}, cols=1]
+            \tn[species=operator, label pos=w, ports={90:physical:$i$}]{u} \\
+            \tn[label pos=s, ports={180:virtual, 0:virtual}]{A}
         \end{tenkz}
         $\;=\;\mu\,$
-        \begin{tenkz}[physical=up]
-            \tnX{V} & \tn[up=$i$]{A} & \tnX{V^\dagger}
+        \begin{tenkz}[boundary=open]
+            \tn[skin=ring]{V} & \tn[ports={90:physical:$i$}]{A} &
+            \tn[skin=ring]{V^\dagger}
         \end{tenkz}.
     \end{tenkzequation}
 \end{theorem}

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -652,34 +652,29 @@ The next three corollaries support channel decompositions and correspond to
 A Kraus representation writes the channel as
 $T(\rho)=\sum_i K_i\rho K_i^\dagger$. In tensor-network form the Kraus index $i$
 is summed between the $K_i$ layer and the $K_i^\dagger$ layer:
-\begin{center}
+\begin{tenkzequation}
+    \tenkzkernel
     % Formula: T(\rho)=\sum_i K_i\rho K_i^\dagger.
     % Source verdict: Wolf, Theorem 2.1 and Equation (2.8), gives the Kraus
     %   formula but no dedicated figure; that formula is authoritative here.
     % In indices, T(\rho)_{ab}
     %   =\sum_{i,c,d}(K_i)_{ac}\rho_{cd}\overline{(K_i)_{bd}}.
-    % The sandwich pairleg contracts the unique Kraus index i.  Its upper
+    % The ket-bra pairing contracts the unique Kraus index i.  Its upper
     %   node is K_i and its lower node is the conjugate \overline{K_i}; reading
     %   the lower wire from the east input toward the west output supplies the
     %   transpose, hence K_i^\dagger in the matrix product.
-    % The east cup contracts the input indices c,d against \rho.  The west
-    %   pair carries the free output indices a,b, so reversing the picture
-    %   would instead feed the adjoint channel.
+    % The east cup contracts the input indices c,d against \rho, which rides
+    %   the cup's bend.  The west pair carries the free output indices a,b --
+    %   the two open matrix indices of T(\rho) named on the left of the
+    %   equation -- so reversing the picture would instead feed the adjoint.
     % Boundary signature: (virtual-west=2 | virtual-east=0 |
     % physical-up=0 | physical-down=0).
-    % The state rides the closing cup.  The kernel's on-wire anchor divides the
-    % record chord rather than the drawn arc (#5482 neighbourhood), so a tensor
-    % placed there would read as sitting on the physical contraction; this
-    % picture keeps its 0.7 spelling until a station on a generated cup exists.
-    \begin{tenkz}[
-        sandwich,
-        east={cup=$\rho$},
-        west label=$T(\rho)$
-    ]
-        \tn{K_i} \\
-        \tn*{K_i}
+    $T(\rho) \;=\;$
+    \begin{tenkz}[rows={ket,bra}, cols=1, west=open, east={cup=$\rho$}]
+        \tn[label pos=n]{K_i} \\
+        \tn[label pos=s, conjugate]{\overline{K_i}}
     \end{tenkz}
-\end{center}
+\end{tenkzequation}
 
 \begin{theorem}[Trace preservation implies Kraus normalization]\label{thm:kraus_sum_conjTranspose_mul_of_tp}
     \lean{kraus_sum_conjTranspose_mul_of_tp}

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -6,30 +6,25 @@ For a normalized Kraus family, the Stinespring construction realizes the
 channel through an isometry $V$ into a larger space,
 $T(\rho)=\tr_E[V\rho V^\dagger]$; tracing out the environment $E$ returns the
 channel:
-\begin{center}
+\begin{tenkzequation}
+    \tenkzkernel
     % Formula/source: Wolf, Sec. 2.2, proof of Thm. 2.5, gives the
     % Schrödinger-picture identity
     % T(\rho)=\tr_{\mathbb C^r}(V\rho V^\dagger).
-    % Indices: \rho contracts the east system-index pair; the west system
-    % pair consists of the free indices of T(\rho), while the unique vertical
-    % pairleg contracts the repeated dilation-space index e.
-    % Orientation: the starred lower V is the conjugate bra layer; together
+    % Indices: \rho rides the east cup and contracts the east system-index
+    % pair; the west system pair consists of the free indices of T(\rho),
+    % named on the left of the equation, while the unique ket-bra pairing
+    % contracts the repeated dilation-space index e.
+    % Orientation: the conjugate lower V is the bra layer; together
     % with the return path it represents V^\dagger in the operator formula.
     % Boundary signature: (virtual-west=2 | virtual-east=0 |
     % physical-up=0 | physical-down=0).
-    % The state rides the closing cup.  The kernel's on-wire anchor divides the
-    % record chord rather than the drawn arc (#5482 neighbourhood), so a tensor
-    % placed there would read as sitting on the physical contraction; this
-    % picture keeps its 0.7 spelling until a station on a generated cup exists.
-    \begin{tenkz}[
-        sandwich,
-        east={cup=$\rho$},
-        west label=$T(\rho)$
-    ]
-        \tn{V} \\
-        \tn*{V}
+    $T(\rho) \;=\;$
+    \begin{tenkz}[rows={ket,bra}, cols=1, west=open, east={cup=$\rho$}]
+        \tn[label pos=n]{V} \\
+        \tn[label pos=s, conjugate]{\overline{V}}
     \end{tenkz}
-\end{center}
+\end{tenkzequation}
 
 \begin{definition}[Stinespring matrix]\label{def:stinespring_v}
     \lean{stinespringV}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -61,19 +61,19 @@ separate public-surface occurrence and therefore appears separately.
 
 | Source | Preserve | Codemod | Redraw |
 |---|---|---|---|
-| `ch02_mps.tex` | — | L200 `tenkz` → `C-policy+C-record` | L24, 54, 171, 272, 840, 966 `tenkz` → `C-policy+C-record+R-record` |
+| `ch02_mps.tex` | L25, 56, 176, 208, 281, 851 `tenkz` → `P-grid` | — | L983 `tenkz` → `C-policy+C-record+R-record` |
 | `ch03_single.tex` | L251 `tenkz` → `P-grid` | — | — |
 | `ch04_channels_choi_foundations.tex` | L87 `tenkz` → `P-grid` | — | — |
 | `ch11_fundamental_theorem_core.tex` | L42, 46 `tenkz` → `P-grid` | — | — |
-| `ch12_symmetry_string_order.tex` | — | L396, 410, 453, 468, 549, 563 `tenkz` → `C-policy+C-record` | L39, 352, 499, 866 `tenkz` → `C-record+C-species+R-record`<br>L73 `tenkz` → `C-policy+C-record+C-species+R-record`<br>L367, 513, 871 `tenkz` → `C-policy+C-record+R-record` |
+| `ch12_symmetry_string_order.tex` | L41, 77, 359, 364, 395, 401, 446, 452, 485, 490, 528, 534, 839, 844 `tenkz` → `P-grid` | — | — |
 | `ch12_symmetry_virtual_and_cohomology.tex` | L181, 196, 330, 459, 473 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | — | — | L54 `tenkzfree` → `R-free+R-record` |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | — | — | L275 `tenkzfree` → `R-free+R-record` |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 493, 535 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
-| `ch16_channel_representations_choi_and_kraus.tex` | — | L674 `tenkz` → `C-policy+C-record` | — |
-| `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L24 `tenkz` → `C-policy+C-record` | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | L673 `tenkz` → `P-grid` | — | — |
+| `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L234, 240 `tenkz` → `C-policy+C-record` | L154, 160, 338, 435 `tenkz` → `C-policy+C-record+R-record`<br>L178, 183 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |
 | `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 644 `tenkz` → `P-grid` | — | — |
@@ -127,9 +127,9 @@ separate public-surface occurrence and therefore appears separately.
 
 | Disposition | Occurrences |
 |---|---:|
-| preserve | 48 |
-| codemod | 25 |
-| redraw | 128 |
+| preserve | 70 |
+| codemod | 16 |
+| redraw | 115 |
 | **Total** | **201** |
 
 The raw count is 168 environment openings plus 33 command occurrences,

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2305,3 +2305,29 @@ this sentence are the whole diff.
 | flag | verdict |
 |---|---|
 | flag:consumers:key:kernel-atom:conjugate | tombstoned: read by nothing, duality already has its one spelling in wire `dir=`, and the conjugate overline is label mathematics already spelled in the corpus; the parser row, the sixteen benchmark spellings, and the two fixture spellings leave in the corpus rewrite at the 1.0 freeze, the status moving with the parser row as booked since session 0; expiry 0.9 |
+
+### 2026-08-06 — the MPS and symmetry chapters leave the grid tier
+
+Thirty-three blueprint pictures across the matrix-product-vector chapter, the
+string-order chapter, the symmetry appendix, and the two channel-representation
+chapters now carry `\tenkzkernel`. The wave retires the chapters' 0.7
+spellings — `sandwich` two-row presets, `periodic` flags, `up=` shorthands,
+`role=`, `tensor style=`, `west label=`, `\tnX`, `\tn*`, `\tndots`, and
+`\tnspan` — for signed kernel rows: `rows={ket,bra}` ladders with bead
+operators on the pairing bonds, typed `ports=` with port labels, `boundary=`
+side policy, labelled side cups, and `\tnmark` bracket and enclosure ranges.
+One picture stays on the grid tier with its blocker named in the source: the
+MPV-overlap ladder needs a per-row trace return that clears the two-row
+selection it closes, and the kernel still drops every flat-row return one
+clearance below its own row.
+
+All six meters are unchanged: M1 stays at 140 kernel rows, M2 keeps its parser
+identity, M3 gains no escape, M4 is untouched at its frozen denominator, and
+no alias or overload moves. What moves is demand: three 0.7 rows lose their
+last blueprint consumers a milestone before the S4 swap would have taken them.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:annotation:brace below | dies at the S4 swap with the 0.7 annotation tier: the kernel bracket mark speaks from the south by itself, and the two remaining demand-corpus consumers are the blocked MPV-overlap ladder and a fixture booked to the grid dialect's own retirement; expiry 0.9 |
+| flag:consumers:key:picture:sandwich | dies at the S4 swap: the 0.7 two-row preset has no consumer left, and the kernel's own `sandwich` row is the three-row preset the sugar ledger signs, so nothing remains for the grid reading to serve; expiry 0.9 |
+| flag:cooccur:picture:east label+west label | dies with the 0.7 boundary-label keys they are: the kernel tier carries no side-label row, a boundary pair is named by the mathematics beside the panel or by a port label, and the five shared invocations all ride grid-tier fixtures booked to the dialect's retirement; expiry 0.9 |

--- a/scripts/test_tenkz_pic.py
+++ b/scripts/test_tenkz_pic.py
@@ -129,7 +129,37 @@ def _assert_contract_rejects(core_source: str, theme_source: str, defect: str) -
     raise AssertionError(f"slide theme contract accepted {defect}")
 
 
+class _Node:
+    """A bare document node for exercising the kernel-switch walk."""
+
+    def __init__(self, name, children=()):
+        self.nodeName = name
+        self.parentNode = None
+        self.childNodes = list(children)
+        for child in self.childNodes:
+            child.parentNode = self
+
+
+def _assert_switch_scope() -> None:
+    reaches = tenkz_pic._kernel_switch_reaches
+    # A paragraph break is not a group: a switch inside a preceding par
+    # wrapper still governs a picture in a later par of the same center.
+    switch_par = _Node("par", [_Node("tenkzkernel"), _Node("tenkz")])
+    later_pic = _Node("tenkz")
+    center = _Node("center", [switch_par, _Node("par", [later_pic])])
+    _Node("document", [center])
+    assert reaches(switch_par.childNodes[1]), "same-par picture unreached"
+    assert reaches(later_pic), "picture after a par break unreached"
+    # A center is a group: the switch must not leak into the next one.
+    outside = _Node("tenkz")
+    _Node("document", [center, _Node("center", [_Node("par", [outside])])])
+    assert not reaches(outside), "switch leaked past its group"
+
+
 def main() -> int:
+    _assert_switch_scope()
+    print("PASS switch scope: par-transparent kernel-switch walk")
+
     missing_html = tenkz_pic._missing_tools_html(r"\tnpic{\tn{A}}")
     sentinel = tenkz_pic.MISSING_SVG_SENTINEL
     assert sentinel in missing_html, "missing-tool HTML lost its stable sentinel"


### PR DESCRIPTION
Migrates five blueprint chapters off the 0.7 grid tier onto the 1.0 kernel.
Checklist item 6 on tracker LionSR/tenkz#13; part of LionSR/TNLean#4699.

## Per-file picture counts

| File | tenkz units | On kernel |
|---|---:|---:|
| `blueprint/src/chapter/ch02_mps.tex` | 7 | 6 (1 blocked, see below) |
| `blueprint/src/appendix/ft_mps/ch12_symmetry_algebra.tex` | 11 | 11 |
| `blueprint/src/chapter/ch12_symmetry_string_order.tex` | 14 | 14 |
| `blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex` | 1 | 1 |
| `blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex` | 1 | 1 |

33 units now carry `\tenkzkernel`. The retired 0.7 spellings are `sandwich`
presets, `periodic` flags, `up=`, `role=`, `tensor style=`, `west label=`,
`\tnX`, `\tn*`, `\tndots`, and `\tnspan`, replaced by `rows={ket,bra}`
ladders with bead operators on the pairing bonds, typed `ports=`,
`boundary=` side policies, labelled side cups, and `\tnmark` bracket,
enclosure, and label ranges.

**Blocked picture (stays on the grid tier, blocker named in the source):**
the MPV-overlap ladder at `ch02_mps.tex` L983 needs a per-row trace return
that clears the two-row selection it closes; the kernel draws each flat-row
return one clearance below its own row, which would run the upper ring's
return through the ladder and cross the physical pairings.

## Line delta

Blueprint sources: **+181 / −186** across the five files (net −5).
With the `DISPOSITIONS.md` reclassification and the appended `SHRINK.md`
entry: +214 / −193 total.

## Ledgers and gates

- `DISPOSITIONS.md`: the five files' rows discharge from Codemod/Redraw to
  Preserve `P-grid`; ch02 L983 keeps its `C-policy+C-record+R-record` row.
  Occurrence totals move to preserve 70 / codemod 16 / redraw 115 (201).
- `SHRINK.md`: one appended entry; all six meters unchanged; three 0.7 rows
  (`annotation:brace below`, `picture:sandwich`, `east label+west label`)
  lose their last blueprint consumers ahead of the S4 swap.
- `scripts/check_tenkz_dispositions.py` — PASS (201 blueprint occurrences,
  264 fixtures reconcile exactly).
- `scripts/tenkz_kernel_probes.sh` — PASS (127 review regressions, sugar and
  record streams byte-identical, kernel pixels byte-identical).
- `python3 scripts/test_tenkz_pic.py` — PASS (cold/warm/edit invalidation).
- `python3 scripts/tenkz_shrink.py gate` — PASS (census stable at 201, all
  159 flags carry verdicts).

## Render evidence

All 34 units (33 kernel + the blocked grid ladder) were extracted with their
in-force `\tenkzkernel` scope, compiled through the plasTeX pipeline's own
standalone document wrapper, and rendered to PNG at 200 dpi (two cup
pictures re-rendered at 500 dpi to resolve the pairing rung); every image
was inspected against the boundary signature stated in the adjacent source
comment. Units by source line:

- ch02: L25, L56, L176, L208, L281, L851, L983
- ch12_symmetry_algebra: L49, L53, L110, L114, L118, L206, L210, L223,
  L227, L284, L289
- ch12_symmetry_string_order: L41, L77, L359, L364, L395, L401, L446,
  L452, L485, L490, L528, L534, L839, L844
- ch16 choi_and_kraus: L673; ch16 dilations_and_ordered_cp: L23

**Boundary-leg judgments** (the expected failure mode: the grid dialect
opened sides by default, the kernel does not):

- Every `boundary=open` picture shows both outer virtual legs in ink:
  the one-site tensors (1,1,1,0), the gauge sandwiches
  `X A X^{-1}` / `Y A Y^{-1}` / `X(h)X(g)` with legs outboard of the
  rings, and the word/blocking schematics (1,1,3,0) with the brace and
  enclosure marks adding no contraction.
- The four `bonds=none` C2/C3 transfer-cell equations keep all four outer
  wires free on both sides (2,2,0,0); the explicit `\tnwire` sets draw
  exactly the two row bonds plus the single physical rung, on the correct
  column of each side.
- The cup pictures (`west=open, east={cup=...}`) close exactly the east
  pair through the ρ/X bead and leave the west output pair open (2,0,0,0),
  with the ket-bra rung contracting the Kraus/dilation index — matching
  `T(ρ)=Σ K_i ρ K_i†` and `T(ρ)=tr_E[VρV†]`.
- The fully-closed string-order chain (west cup Λ, east cup) emits no open
  leg, as its scalar formula requires.
- The `rows={op,ket}` C1 panels keep i free above u and restate A's side
  ports (`ports={180:virtual, 0:virtual}`) so the virtual legs stay open.

No silently-lost leg was found in any of the 34 renders.

## Kernel idioms found missing

- **Per-row trace return that clears a multi-row selection**: the one
  blocker keeping ch02 L983 on the grid tier; the kernel's flat-row return
  drops one clearance below its own row and would cross the ladder.
- **Declaration scope ends at a paragraph break**: a `center` block whose
  panels are separated by a blank line needs the `\tenkzkernel` switch
  restated after the break (done at ch12_symmetry_algebra L219, with an
  explanatory comment); the switch cannot be hoisted once per block.
- **`rows={op,ket}` closes side ports by default**: the C1 panels must
  restate `ports={180:virtual, 0:virtual}` on the ket-row tensor to keep
  its virtual legs open — the grid tier's open-sides default covered this.

Refs LionSR/TNLean#4699, LionSR/tenkz#13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect blueprint figure sources and plasTeX SVG compilation scope for `\tenkzkernel`; a wrong switch walk could render migrated pictures with the wrong dialect, though the new tests target that path specifically.
> 
> **Overview**
> Moves **33 blueprint tensor-network figures** from the 0.7 grid dialect onto the **1.0 kernel** across `ch02_mps`, symmetry appendix/algebra, `ch12_symmetry_string_order`, and two `ch16` channel chapters. Each migrated unit now uses `\tenkzkernel` plus kernel spellings (`rows={ket,bra}`, typed `ports=`, `boundary=`, ring skins, `\tnmark` brackets/enclosures, bead operators on pairing bonds) instead of retired grid shortcuts (`sandwich`, `up=`, `\tnX`, `\tn*`, `\tndots`, `\tnspan`, etc.).
> 
> **plasTeX** gains `_holds_kernel_switch` so `\tenkzkernel` scope is **transparent across `par` wrappers** (paragraph breaks inside a `center` block still activate the switch) while **TeX groups still end** the declaration; standalone SVG compile prepends `\tenkzkernel` when the walk finds an in-force switch. **`scripts/test_tenkz_pic.py`** adds regression tests for that scope behavior.
> 
> One **MPV overlap ladder** in `ch02_mps` **stays on the grid tier** until per-row trace returns can clear multi-row selections without crossing physical pairings. **`DISPOSITIONS.md`** and **`SHRINK.md`** reclassify the migrated rows to Preserve `P-grid` and record three 0.7 consumer flags losing their last blueprint users ahead of the S4 swap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02baa5c0b93fd8e7ac172dda8fab769a4eaa750a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->