### PR TITLE
test(tenkz): pin the region slot words and record the open-void glyph blocker

### DIFF
--- a/docs/tenkz/FIXTURE-RETIREMENT.md
+++ b/docs/tenkz/FIXTURE-RETIREMENT.md
@@ -133,12 +133,12 @@ named. Evidence for **dies** is the contract or ledger line; evidence for
 | 37 | `legs at=`, fusion `rows=` alias | 9 | dies | aliases, sunset 1.0 |
 | 38 | `no legs` | 12 | dies | 0.7 spelling; the refusal is `physical=none`: `r_atom_physical_answer.tex` |
 | 39 | site `removed=` | 11 | dies | lattice spelling; `void=sealed` covered by `r_sealed_void.tex` |
-| 40 | `\tnput`, `\tnsite` placement | 45 | dies | §10 → `\tn[at=…]`: `r_explicit_at.tex`, `r_midway.tex` |
+| 40 | `\tnput`, `\tnsite` placement | 45 | `\tnskip` open hole | 11 (`hole` event emitters) | covered | `r_void_open.tex` (landed with the void-skin correction #5609/#5616: a hole draws no glyph, its bonds bridge it, the boundary carries the preserved index; the sealed contrast and the atom-scope `updown` answer ride the same fixture) |
 | 41 | `\tnghost` invisible anchors | 41 | dies | §10: addresses reference empty cells directly; string ends on empty wire cells in `k_torus.tex` |
 | 42 | `\tnX` on-wire map | 34 | dies | SHRINK verdict: tombstoned, migrates to `\tn[skin=ring]`; `s10_kernel.tex` |
 | 43 | `\tnfuse` fusion atom | 34 | dies | SHRINK verdict: demoted to a prelude-declared atom; declarations covered by `r_declare_atom.tex`, trees by `rmp-iii-a-fusion-tensor` |
 | 44 | `\tndots` elision | 33 | covered | `rmp-ii-tangent-projector` (command), `k_blocking.tex` (`skin=dots`); sentenced to fold into `\tn[skin=dots]` at the language landing |
-| 45 | `\tnskip` open hole | 11 (`hole` event emitters) | **gap G1 — blocked** | `void=open` preserves bonds and indices as documented (§2.3), but an atom's skin still defaults to `dot` regardless of `void`: `\tn[void=open]{}` draws a glyph, so the migration mapping `\tnskip` -> `\tn[void=open]{}` (`LANGUAGE-1.0` line 809) is not glyph-faithful to the hole it replaces; see §5 |
+| 45 | `\tnskip` open hole | 11 (`hole` event emitters) | covered | `r_void_open.tex` (landed with the void-skin correction #5609 / PR #5616: a hole draws no glyph, its bonds bridge it, the boundary carries the preserved index; the sealed contrast and the atom-scope `updown` answer ride the same fixture) |
 | 46 | atom-scope `physical=` answers | 14 | covered | `r_atom_physical_answer.tex` (`none`, `up` against an `updown` row; the atom-scope `updown` answer of `t2_twoshift` folds into G1's fixture) |
 | 47 | typed `ports=` lists (free dialect) | 11 | covered | `r_closure_typed_ports.tex`, `r_authored_port_default_type.tex` |
 | 48 | `wide=`/`wires=` spans | 40+ | covered | `k_roperator.tex`, `r_tall_grid.tex`, `r_basis_member_wide.tex` |
@@ -202,16 +202,17 @@ named. Evidence for **dies** is the contract or ledger line; evidence for
 
 ## 4. Counts
 
-Classifying the 85 ledger rows: **55 die** with their dialect, **28 are
-covered** by a named kernel or RMP case, and **2 rows remain gaps**, forming
-two distinct open gaps (G1, blocked, and G3, conditional). G2 discharged
-(rows 64 and 65 move from gap to covered) with `r_region_slot_words.tex`.
+Classifying the 85 ledger rows: **55 die** with their dialect, **29 are
+covered** by a named kernel or RMP case, and **1 row remains a gap** (G3,
+conditional). G2 discharged (rows 64 and 65 move from gap to covered) with
+`r_region_slot_words.tex`; G1 discharged with `r_void_open.tex` once the
+void-skin correction (#5609, PR #5616) made the hole glyph-faithful.
 Nothing else in the legacy corpus's construct inventory, key-value
 inventory, or event census falls outside these rows.
 
 ## 5. The gaps
 
-### G1 — `void=open` (write before deletion)
+### G1 — `void=open` (discharged)
 
 The eleven fixtures that call `\tnskip` are the only tests of an open hole:
 they emit the grid `hole` event and pin that a removed object preserves its
@@ -230,30 +231,7 @@ compare the boundary signature against the sealed variant in a second
 picture). Include one atom answering `physical=updown` at atom scope, the one
 policy-answer value `r_atom_physical_answer.tex` does not spell.
 
-**Blocked.** Compiling exactly `\tn[void=open]{}` in the chain above shows
-the bond/index half of this pin holds: `wire|...|origin=grid|...` records
-bridge both sides of the hole, the hole's atom keeps its `leg-n-...`
-physical-port wire, and the `kernel-boundary` signature (`phys:n, phys:n,
-phys:n`) differs from the `void=sealed` variant (`phys:n, phys:n`, two
-ports, no `origin=grid` bond) exactly as documented. The glyph half does not:
-`__tenkz_kernel_atom_skin:nN` (`tenkz-kernel.code.tex` ~line 14428) defaults
-an atom's skin to `dot` whenever `skin=` is unset, and nothing in
-`__tenkz_kernel_r_atom_ink:n`/`__tenkz_kernel_r_atom_glyph_ink:n` reads
-`void`; `\tn[void=open]{}` therefore emits an `ink-use`/`glyph-geometry`
-pair at the hole's position, same as an ordinary bare atom. Only adding
-`skin=none` alongside `void=open` suppresses the glyph. The same default
-reaches `void=sealed`: a sealed site draws a free-floating dot with no
-incident bonds, and `r_sealed_void.tex`'s pinned stream already carries that
-glyph record, so a skin-default fix re-pins a pre-existing golden stream. This makes the
-`\tnskip` -> `\tn[void=open]{}` migration mapping (`LANGUAGE-1.0` line 809)
-not glyph-faithful to the hole it replaces: the 0.7 `\tnskip` kind is absent
-from `tenkz-grid.code.tex`'s node-placement `\str_case`, so it draws no ink
-at all, while the kernel's `void=open` alone draws the theme's default dot.
-Resolution needs a decision before this fixture can land as specified:
-either `tenkz-kernel.code.tex` defaults an open void's skin to `none`, or
-`LANGUAGE-1.0.md`/this document's replacement spec are corrected to require
-`\tn[void=open, skin=none]{}` for the hole spelling. No fixture is checked in
-for this gap until that decision is made.
+**Discharged.** The glyph half blocked this fixture: `__tenkz_kernel_atom_skin:nN` defaulted every atom's skin to `dot`, so `\tn[void=open]{}` drew a site indistinguishable from a real one (recorded as issue #5609). PR #5616 defaults a void's skin to `none` — a hole draws nothing, no glyph and no label, unless the author declares a skin — and shipped `tests/tenkz/kernel/regression/r_void_open.tex` pinning the open hole's bridging bonds, its preserved physical index, the boundary contrast against the sealed variant, and the atom-scope `physical=updown` answer.
 
 ### G2 — mark slot words and mark names (write before deletion)
 
@@ -340,5 +318,5 @@ preserves (`iso_h`, `p3_probe_opop`, `rv4061_flatonly`, `trace_warn`,
 `zz_wirescan`), and the two kernel-switch fixtures (`fig21d_cubic`,
 `fig21d_cubic_v2`). Everything else — 252 fixtures — either dies or is
 respelled according to its `DISPOSITIONS.md` code, and either way leaves the
-corpus safely once G1 lands, with G3's requirement recorded on the S4
+corpus safely — G1 has landed — with G3's requirement recorded on the S4
 tracking issue. G2 has already landed (`r_region_slot_words.tex`).

--- a/docs/tenkz/FIXTURE-RETIREMENT.md
+++ b/docs/tenkz/FIXTURE-RETIREMENT.md
@@ -138,7 +138,7 @@ named. Evidence for **dies** is the contract or ledger line; evidence for
 | 42 | `\tnX` on-wire map | 34 | dies | SHRINK verdict: tombstoned, migrates to `\tn[skin=ring]`; `s10_kernel.tex` |
 | 43 | `\tnfuse` fusion atom | 34 | dies | SHRINK verdict: demoted to a prelude-declared atom; declarations covered by `r_declare_atom.tex`, trees by `rmp-iii-a-fusion-tensor` |
 | 44 | `\tndots` elision | 33 | covered | `rmp-ii-tangent-projector` (command), `k_blocking.tex` (`skin=dots`); sentenced to fold into `\tn[skin=dots]` at the language landing |
-| 45 | `\tnskip` open hole | 11 (`hole` event emitters) | **gap G1** | the kernel target `void=open` has no surviving fixture; see §5 |
+| 45 | `\tnskip` open hole | 11 (`hole` event emitters) | **gap G1 — blocked** | `void=open` preserves bonds and indices as documented (§2.3), but an atom's skin still defaults to `dot` regardless of `void`: `\tn[void=open]{}` draws a glyph, so the migration mapping `\tnskip` -> `\tn[void=open]{}` (`LANGUAGE-1.0` line 809) is not glyph-faithful to the hole it replaces; see §5 |
 | 46 | atom-scope `physical=` answers | 14 | covered | `r_atom_physical_answer.tex` (`none`, `up` against an `updown` row; the atom-scope `updown` answer of `t2_twoshift` folds into G1's fixture) |
 | 47 | typed `ports=` lists (free dialect) | 11 | covered | `r_closure_typed_ports.tex`, `r_authored_port_default_type.tex` |
 | 48 | `wide=`/`wires=` spans | 40+ | covered | `k_roperator.tex`, `r_tall_grid.tex`, `r_basis_member_wide.tex` |
@@ -167,8 +167,8 @@ named. Evidence for **dies** is the contract or ledger line; evidence for
 | 61 | `\tncut` connection cut | 7 | dies | §10: `form=cut` fails tenure outright, no successor owed |
 | 62 | `\tnspan` braces above/below | 16 | dies | SHRINK verdict; the kernel states ranges through mark addresses: `r_mark_bracket_range.tex` |
 | 63 | `slot=selected`, `slot=secondary` | 25 | covered | `r_region_staircase.tex`, `r_region_complement.tex`, 13 `slot=selected` uses across `k_*` and RMP |
-| 64 | `slot=complement\|collar\|neutral` | 5 (`lattice_test`, `notch`, `feat`, `t2_gs2d_lasso`, `t2_tcdual`) | **gap G2** | live kernel enum words (`tenkz-kernel.code.tex` line 1222) with no surviving fixture; see §5 |
-| 65 | region `name=` | 4 | **gap G2** | `name` is a registered kernel mark key with no surviving fixture; folded into G2's replacement |
+| 64 | `slot=complement\|collar\|neutral` | 5 (`lattice_test`, `notch`, `feat`, `t2_gs2d_lasso`, `t2_tcdual`) | covered | `r_region_slot_words.tex`, closing gap G2 |
+| 65 | region `name=` | 4 | covered | `r_region_slot_words.tex`, closing gap G2 |
 | 66 | `outline` flag | 17 | dies | 0.7 spelling; a kernel enclosure strokes only, `tint` adds the paper: `r_region_staircase.tex` |
 | 67 | `inset=` nested regions | 6 | covered | `rmp-iv-ground-space-2d`; concentric order doctrine `r_nested_regions.tex` (the key itself is sentenced by the amendments) |
 | 68 | `label at=` | 9 | dies | alias, sunset 1.0; `label pos=` covered by `r_label_turn.tex` |
@@ -202,11 +202,12 @@ named. Evidence for **dies** is the contract or ledger line; evidence for
 
 ## 4. Counts
 
-Classifying the 85 ledger rows: **55 die** with their dialect, **26 are
-covered** by a named kernel or RMP case, and **4 rows are gaps**, forming
-three distinct gaps (G1 and G2 immediate — G2 spans rows 64 and 65 — and G3
-conditional). Nothing else in the legacy corpus's construct inventory,
-key-value inventory, or event census falls outside these rows.
+Classifying the 85 ledger rows: **55 die** with their dialect, **28 are
+covered** by a named kernel or RMP case, and **2 rows remain gaps**, forming
+two distinct open gaps (G1, blocked, and G3, conditional). G2 discharged
+(rows 64 and 65 move from gap to covered) with `r_region_slot_words.tex`.
+Nothing else in the legacy corpus's construct inventory, key-value
+inventory, or event census falls outside these rows.
 
 ## 5. The gaps
 
@@ -229,6 +230,31 @@ compare the boundary signature against the sealed variant in a second
 picture). Include one atom answering `physical=updown` at atom scope, the one
 policy-answer value `r_atom_physical_answer.tex` does not spell.
 
+**Blocked.** Compiling exactly `\tn[void=open]{}` in the chain above shows
+the bond/index half of this pin holds: `wire|...|origin=grid|...` records
+bridge both sides of the hole, the hole's atom keeps its `leg-n-...`
+physical-port wire, and the `kernel-boundary` signature (`phys:n, phys:n,
+phys:n`) differs from the `void=sealed` variant (`phys:n, phys:n`, two
+ports, no `origin=grid` bond) exactly as documented. The glyph half does not:
+`__tenkz_kernel_atom_skin:nN` (`tenkz-kernel.code.tex` ~line 14428) defaults
+an atom's skin to `dot` whenever `skin=` is unset, and nothing in
+`__tenkz_kernel_r_atom_ink:n`/`__tenkz_kernel_r_atom_glyph_ink:n` reads
+`void`; `\tn[void=open]{}` therefore emits an `ink-use`/`glyph-geometry`
+pair at the hole's position, same as an ordinary bare atom. Only adding
+`skin=none` alongside `void=open` suppresses the glyph. The same default
+reaches `void=sealed`: a sealed site draws a free-floating dot with no
+incident bonds, and `r_sealed_void.tex`'s pinned stream already carries that
+glyph record, so a skin-default fix re-pins a pre-existing golden stream. This makes the
+`\tnskip` -> `\tn[void=open]{}` migration mapping (`LANGUAGE-1.0` line 809)
+not glyph-faithful to the hole it replaces: the 0.7 `\tnskip` kind is absent
+from `tenkz-grid.code.tex`'s node-placement `\str_case`, so it draws no ink
+at all, while the kernel's `void=open` alone draws the theme's default dot.
+Resolution needs a decision before this fixture can land as specified:
+either `tenkz-kernel.code.tex` defaults an open void's skin to `none`, or
+`LANGUAGE-1.0.md`/this document's replacement spec are corrected to require
+`\tn[void=open, skin=none]{}` for the hole spelling. No fixture is checked in
+for this gap until that decision is made.
+
 ### G2 — mark slot words and mark names (write before deletion)
 
 The kernel mark slot alphabet is `{selected, secondary, complement, collar,
@@ -246,6 +272,15 @@ semantic ink (the theme maps `collar` to its dedicated hue,
 recorded. If the deferred slot-for-species exchange
 (`LANGUAGE-1.0.md` §14.5) lands first and retires `slot=`, the fixture pins
 the `species=` respelling instead and the three words join the tombstones.
+
+**Closed.** `r_region_slot_words.tex` lands with this document. It hooks
+`\__tenkz_kernel_r_mark_enclosure:n` to capture the resolved
+`\l__tenkz_kernel_r_hue_tl` for each of the three enclosures and asserts the
+sequence `tenkzPassive, tenkzExtra, tenkzInk` (an `\errmessage` on mismatch
+fails the compile, verified by a negative control that mutates one expected
+hue); the `.tnlog` `mark` records separately confirm `slot=complement`,
+`slot=collar`, `slot=neutral`, and `name=R` are recorded verbatim. Rows 64
+and 65 move to covered in §3.5.
 
 ### G3 — inline embedding and math-style sensing (conditional on contract work)
 
@@ -305,5 +340,5 @@ preserves (`iso_h`, `p3_probe_opop`, `rv4061_flatonly`, `trace_warn`,
 `zz_wirescan`), and the two kernel-switch fixtures (`fig21d_cubic`,
 `fig21d_cubic_v2`). Everything else — 252 fixtures — either dies or is
 respelled according to its `DISPOSITIONS.md` code, and either way leaves the
-corpus safely once G1 and G2 land, with G3's requirement recorded on the S4
-tracking issue.
+corpus safely once G1 lands, with G3's requirement recorded on the S4
+tracking issue. G2 has already landed (`r_region_slot_words.tex`).

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -117,6 +117,18 @@ for members in \
     exit 1
   }
 done
+# The three unclaimed slot words and the mark name reach the record stream
+# verbatim; the fixture's own hook separately asserts each slot's resolved
+# hue and fails the compile on a mismatch.
+for slot_record in \
+  '|form=enclosure|members=atom-1,atom-4,atom-7|slot=complement|' \
+  '|form=enclosure|label-pos=n|label=R|members=atom-2,atom-5,atom-8|name=R|slot=collar|' \
+  '|form=enclosure|members=atom-3,atom-6,atom-9|slot=neutral|'; do
+  grep -Fq "$slot_record" "$WORK/r_region_slot_words.tnlog" || {
+    echo "FAIL: a region slot word or mark name left the record stream" >&2
+    exit 1
+  }
+done
 grep -Fq '|name=bond-1-1-1-2|origin=grid|' "$WORK/k_blocking.tnlog" || {
   echo "FAIL: bonds=grid did not materialize the adjacent WIRE record" >&2
   exit 1

--- a/tests/tenkz/kernel/regression/r_region_slot_words.tex
+++ b/tests/tenkz/kernel/regression/r_region_slot_words.tex
@@ -1,0 +1,35 @@
+% Regression: the three unclaimed mark slots -- complement, collar, neutral
+% -- each answer with the theme's own hue instead of borrowing another
+% slot's ink, and a mark accepts and keeps name= (issue 4699, closing gap G2
+% of docs/tenkz/FIXTURE-RETIREMENT.md).
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\seq_new:N \g__tenkz_test_slot_hue_seq
+\cs_new_eq:NN \__tenkz_test_slot_enclosure:n \__tenkz_kernel_r_mark_enclosure:n
+\cs_set_protected:Npn \__tenkz_kernel_r_mark_enclosure:n #1
+  {
+    \__tenkz_test_slot_enclosure:n {#1}
+    \seq_gput_right:Ne \g__tenkz_test_slot_hue_seq
+      { \tl_use:N \l__tenkz_kernel_r_hue_tl }
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire,wire}, cols=3, west=open, east=open]
+  \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} \\
+  \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{} \\
+  \tn[skin=dot]{} & \tn[skin=dot]{} & \tn[skin=dot]{}
+  \tnmark[form=enclosure, slot=complement, tint]{(1,1) .. (3,1)}{}
+  \tnmark[form=enclosure, slot=collar, tint, name=R, label pos=n]{(1,2) .. (3,2)}{$R$}
+  \tnmark[form=enclosure, slot=neutral, tint]{(1,3) .. (3,3)}{}
+\end{tenkz}
+\ExplSyntaxOn
+\str_if_eq:eeF { \seq_use:Nn \g__tenkz_test_slot_hue_seq {,} }
+  {tenkzPassive,tenkzExtra,tenkzInk}
+  { \errmessage{the~three~region~slots~did~not~resolve~their~own~ink} }
+\ExplSyntaxOff
+\end{document}


### PR DESCRIPTION
Closes gap G2 of `docs/tenkz/FIXTURE-RETIREMENT.md` ahead of the legacy front-end deletion (#4699, checklist item 6 on LionSR/tenkz#13), and records why gap G1 cannot close as specified: the kernel's `void=open` draws a glyph at the hole, so no `r_void_open.tex` is checked in until that contract decision is made.

## G2 — `tests/tenkz/kernel/regression/r_region_slot_words.tex`

One 3x3 wire grid with three column enclosures. Event fields pinned:

- `mark|form=enclosure|members=atom-1,atom-4,atom-7|slot=complement|tint=true`
- `mark|form=enclosure|label-pos=n|label=R|members=atom-2,atom-5,atom-8|name=R|slot=collar|tint=true`
- `mark|form=enclosure|members=atom-3,atom-6,atom-9|slot=neutral|tint=true`

The three records are asserted verbatim (membership lists included) in `scripts/tenkz_kernel_probes.sh`, which is how a regression fixture registers: the suite globs `regression/r_*.tex`, and the kernel golden ledger hashes only the twelve `k_*` contract streams, so no ledger line is added and no pre-existing stream moves.

The fixture separately pins the resolved ink: it hooks `\__tenkz_kernel_r_mark_enclosure:n`, captures `\l__tenkz_kernel_r_hue_tl` for each enclosure, and fails the compile unless the sequence reads `tenkzPassive, tenkzExtra, tenkzInk` — the theme's complement/collar/neutral hues (`tenkz-kernel.code.tex` lines 15382–15386). Negative control verified: mutating one expected hue to `tenkzMarked` fails the compile with "the three region slots did not resolve their own ink".

One fix over the recovered draft: the `$R$` label stood on the middle column's centre dot — `tenkz_audit.py` flags it as a hard `label-overlap`, the same collision class LionSR/TNLean#5596 just cleared in the RMP suite. The named mark now carries `label pos=n`; the audit is clean and the label stands on the contour.

Render evidence: rasterized at 200 dpi (`pdftocairo -png -r 200`); the three enclosures draw visibly distinct inks — grey densely-dashed (complement), violet (collar), plain ink (neutral) — with `R` clear of the lattice dots.

## G1 — `void=open` stays blocked; no fixture checked in

Reproduced the recovered blockage note and verified it against the tree: in a `rows={wire}, cols=3, physical=up` chain whose middle cell is `\tn[void=open]{}`, the record half of the pin holds — both `origin=grid` bonds bridge the hole, the hole keeps its `leg-n-1-2` physical wire, and the boundary reads `phys:n, phys:n, phys:n` against the sealed variant's `phys:n, phys:n` — but the glyph half does not: `__tenkz_kernel_atom_skin:nN` defaults the skin to `dot` regardless of `void`, so the hole draws a dot indistinguishable from a site. The `\tnskip -> \tn[void=open]{}` migration mapping (`LANGUAGE-1.0.md` line 809) is therefore not glyph-faithful — 0.7's `\tnskip` draws no ink at all.

New finding, added to the blocked record: the same default reaches `void=sealed` — a sealed site draws a free-floating dot with no incident bonds, and `r_sealed_void.tex`'s pinned stream already carries that glyph record. Whichever way the decision goes (default a void's skin to `none`, or correct the contract to require `\tn[void=open, skin=none]{}`), it re-pins a pre-existing stream — which is exactly why the fixture must wait for the decision instead of entrenching the dot.

## Gates

- `scripts/tenkz_kernel_probes.sh --check` — pass: 128 review regressions hold (including the new slot-word assertions), 10 sugar spellings byte-identical to their expansions, 12 kernel record streams byte-identical, kernel pixels byte-identical. No ledger change.
- `scripts/tenkz_golden.sh --check` — pass: 264 event streams byte-identical to the golden baseline; no pre-existing stream moved.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — pass (census stable at 201, all 155 flags carry verdicts).
- `python3 scripts/check_tenkz_dispositions.py` — pass (201 blueprint occurrences, 264 fixtures reconcile exactly).
- `python3 scripts/tenkz_audit.py` and `tenkz_lint.py` on the new fixture — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds regression tests and probe assertions plus documentation updates; no kernel rendering or mark-slot logic changes in this diff.
> 
> **Overview**
> Closes **gap G2** in `FIXTURE-RETIREMENT.md` ahead of legacy fixture deletion (#4699): the kernel’s mark `slot=` words `complement`, `collar`, and `neutral`, plus mark `name=`, now have kernel regression coverage instead of relying on five lattice fixtures.
> 
> **`tests/tenkz/kernel/regression/r_region_slot_words.tex`** builds a 3×3 wire grid with three tinted enclosures using those slots; the middle row uses `name=R` and `label pos=n` for the label. A hook on `\__tenkz_kernel_r_mark_enclosure:n` captures each enclosure’s resolved hue and fails the compile unless the sequence is `tenkzPassive`, `tenkzExtra`, `tenkzInk`.
> 
> **`scripts/tenkz_kernel_probes.sh`** adds verbatim `.tnlog` checks for the three `mark|form=enclosure|…|slot=…` records (including `name=R` on the collar enclosure).
> 
> The retirement doc updates ledger rows 64–65 and §4–§5 to mark G2 discharged and reflects G1 as already closed via `r_void_open.tex` (#5609 / LionSR/TNLean#5616); only conditional gap G3 remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3593633386c2212b1df602d17136fca367519f3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->