### PR TITLE
fix(scripts): derive the corrupted total instead of hard-coding it

### DIFF
--- a/scripts/test_check_tenkz_dispositions.py
+++ b/scripts/test_check_tenkz_dispositions.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -272,11 +273,24 @@ def main() -> int:
     _, _, blueprint_inventory, _ = guard.documented_blueprint(
         guard.DOCUMENT.read_text()
     )
-    assert blueprint_inventory[("ch02_mps.tex", 54, "tenkz")] == "redraw"
-
-    broken_total = guard.DOCUMENT.read_text().replace(
-        "| **Total** | **207** |", "| **Total** | **999** |", 1
+    # Structural checks only: naming a live row's disposition here would
+    # break this test whenever a migration legitimately discharges it.
+    assert blueprint_inventory
+    assert all(
+        disposition in guard.DISPOSITIONS
+        for disposition in blueprint_inventory.values()
     )
+
+    # Corrupt the first reconciliation total, whatever its current value:
+    # hard-coding the live number would make this probe a silent no-op the
+    # next time a migration legitimately moves the total.
+    broken_total, replacements = re.subn(
+        r"\| \*\*Total\*\* \| \*\*\d+\*\* \|",
+        "| **Total** | **999** |",
+        guard.DOCUMENT.read_text(),
+        count=1,
+    )
+    assert replacements == 1, "no reconciliation total row found to corrupt"
     try:
         guard.parse_counter_table(
             broken_total, "| Raw construct | Occurrences |"


### PR DESCRIPTION
## Problem

The demolition guard fails on main: `test_check_tenkz_dispositions.py` raises `stale reconciliation total was not rejected`, which blocks every open PR (#5597, #5599, #5602, #5607, #5608 all inherit it).

Root cause: the self-test corrupts the reconciliation total by replacing the literal string `| **Total** | **207** |`. #5601 legitimately moved the total to 201, so the replacement silently no-ops, the document stays valid, `parse_counter_table` correctly raises nothing, and the probe's own assertion fires. The test hard-coded the very number it exists to guard.

## Fix

- The probe now corrupts whatever total the document currently carries (`re.subn` on the row pattern) and asserts the substitution actually happened, so it can never no-op silently again.
- The sibling assertion pinning a live blueprint row's disposition (`ch02_mps.tex` L54 = redraw) had the same failure ahead of it — #5607, in flight, discharges exactly that row. Replaced by structural checks (non-empty inventory, every disposition in the checker's vocabulary) that survive legitimate migrations.

## Verification

`python3 scripts/test_check_tenkz_dispositions.py` → PASS on current main (fails without this change); `python3 scripts/check_tenkz_dispositions.py` → PASS, 201 blueprint occurrences and 264 fixtures reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in `scripts/test_check_tenkz_dispositions.py`; no production or checker logic modified.
> 
> **Overview**
> Fixes **failing demolition-guard self-tests** on main by removing hard-coded migration numbers that go stale when `DISPOSITIONS.md` totals or blueprint rows legitimately change.
> 
> The reconciliation-total probe now uses **`re.subn`** on the `| **Total** | **\d+** |` row pattern and **asserts one substitution occurred**, so corrupting the document cannot silently no-op when the live total moves (e.g. 207 → 201).
> 
> Blueprint inventory coverage drops the pin on a specific live row (`ch02_mps.tex` L54 = redraw) and instead checks that the inventory is non-empty and every disposition is in **`guard.DISPOSITIONS`** (`preserve`, `codemod`, `redraw`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaddf21b8d034255d52ee04ece6f21bc06282a90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->