### PR TITLE
fix(tenkz): default a void site's skin to none

### DIFF
--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -503,6 +503,12 @@ These mistakes have shipped bugs here.
     such a store with `\__tenkz_prop_new_indexed:N`, which answers a key in
     one step.  A pair-keyed store — one entry per pair of routes — is the
     worst case and must never be flat.
+11. Call sites may alias an argument to the result variable:
+    `\__tenkz_kernel_atom_skin_base:nN { \tl_use:N \l__tenkz_kernel_r_c_tl }
+    \l__tenkz_kernel_r_c_tl` reads and writes one token list.  Inside such a
+    function, read every input before the first write to the target: once
+    the target holds `\q_no_value`, re-expanding the argument is trap 1 and
+    loops forever.
 
 ## Geometry discipline
 

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -105,7 +105,7 @@ that contraction and retires nothing.
 
 | Key | Type | Values | Default | Diagnostic family |
 |---|---|---|---|---|
-| `skin=` | identifier | a declared skin; defaults §2.8 | theme default (`dot`) | `TKZ-SKIN-*` |
+| `skin=` | identifier | a declared skin; defaults §2.8 | theme default (`dot`; `none` on a void site) | `TKZ-SKIN-*` |
 | `wide=` | positive-integer | — | 1 | `TKZ-ATOM-*` |
 | `wires=` | positive-integer | — | 1 | `TKZ-ATOM-*` |
 | `at=` | address | — | next chain cell | `TKZ-ADDR-*` |
@@ -138,7 +138,10 @@ The label component is where the retired page-relative keys went: an index
 name belongs to the port it names, and a port already knows which way it
 points. A cluster carrier is a glyphless group and owns no authored `ports=`;
 attach wires to its addressable member atoms instead. `void=open` is a hole
-that preserves indices; `void=sealed` removes the site and its bonds.
+that preserves indices; `void=sealed` removes the site and its bonds. A void
+site's skin defaults to `none` rather than `dot`: a hole draws nothing
+unless the author declares a skin, while every record — the bonds bridging
+an open hole, its boundary entries — stands unchanged.
 
 ### 2.4 Wire keys (10)
 
@@ -1100,3 +1103,11 @@ confirmation at L1 acceptance:
    content (§13), so a side that exposes indices says so. The registry rows,
    the key table, and §3 now say that, and `none` is the explicit spelling of
    the kernel default rather than a seal.
+7. **A void site draws no glyph — corrected 2026-08-07.** The skin default
+   read `dot` for every atom, so `\tn[void=open]{}` drew a site
+   indistinguishable from a real one and a sealed void drew a free-floating
+   dot with no bonds. A hole means an absent site: both void words now
+   default the skin to `none`, and the record half of the contract — the
+   bonds bridging an open hole, its surviving physical index, the boundary
+   signature — is untouched. A declared `skin=` still draws, and the
+   `\tnskip` ledger row stays one key long and is glyph-faithful as printed.

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -139,9 +139,10 @@ name belongs to the port it names, and a port already knows which way it
 points. A cluster carrier is a glyphless group and owns no authored `ports=`;
 attach wires to its addressable member atoms instead. `void=open` is a hole
 that preserves indices; `void=sealed` removes the site and its bonds. A void
-site's skin defaults to `none` rather than `dot`: a hole draws nothing
-unless the author declares a skin, while every record — the bonds bridging
-an open hole, its boundary entries — stands unchanged.
+site's skin defaults to `none` rather than `dot`: a hole draws nothing —
+no glyph and, by the `skin=none` rule it inherits, no label — unless the
+author declares a skin, while every record — the bonds bridging an open
+hole, its boundary entries — stands unchanged.
 
 ### 2.4 Wire keys (10)
 
@@ -1111,3 +1112,6 @@ confirmation at L1 acceptance:
    bonds bridging an open hole, its surviving physical index, the boundary
    signature — is untouched. A declared `skin=` still draws, and the
    `\tnskip` ledger row stays one key long and is glyph-faithful as printed.
+   The default inherits the whole `skin=none` reading: a void's authored
+   label is suppressed with its glyph, so a labelled anchor that must stay
+   visible declares a skin.

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1183,6 +1183,61 @@ if grep -Fq '|origin=grid|' "$WORK/r_sealed_void.tnlog"; then
   echo "FAIL: a sealed void retained an incident generated grid bond" >&2
   exit 1
 fi
+# A void site draws no glyph by default; its records decide open against
+# sealed.  The two chains of r_void_open share one shape: the open hole
+# keeps both bridging grid bonds, its own physical leg, and its boundary
+# entry, while the sealed variant loses the site's bonds and leg.  Neither
+# void draws a site glyph, so each picture inks exactly its two real sites.
+void_pane() {
+  awk -v pane="$1" -v pattern="$2" '
+    /^picture\|/ { seen++ }
+    $0 ~ pattern { if (seen == pane) print }
+  ' "$WORK/r_void_open.tnlog"
+}
+grep -Fq '|name=H|physical=up|void=open' "$WORK/r_void_open.tnlog" || {
+  echo "FAIL: the open hole lost its record or its physical policy answer" >&2
+  exit 1
+}
+[ "$(void_pane 1 '[|]origin=grid[|]' | wc -l | tr -d ' ')" -eq 2 ] || {
+  echo "FAIL: an open hole did not keep both bridging grid bonds" >&2
+  exit 1
+}
+grep -Fq '|host=atom-2|kind=index|name=leg-n-1-2|origin=policy-leg|port-type=physical' \
+    "$WORK/r_void_open.tnlog" || {
+  echo "FAIL: the open hole lost its physical leg" >&2
+  exit 1
+}
+[ "$(void_pane 2 '[|]origin=grid[|]' | wc -l | tr -d ' ')" -eq 0 ] || {
+  echo "FAIL: the sealed contrast retained a generated grid bond" >&2
+  exit 1
+}
+[ "$(void_pane 1 '^kernel-boundary[|]')" = \
+  'kernel-boundary|signature=phys:n, phys:n, phys:n, phys:s' ] || {
+  echo "FAIL: the open chain's boundary lost the hole's index or the updown answer" >&2
+  exit 1
+}
+[ "$(void_pane 2 '^kernel-boundary[|]')" = \
+  'kernel-boundary|signature=phys:n, phys:n' ] || {
+  echo "FAIL: the sealed chain's boundary kept a removed index" >&2
+  exit 1
+}
+for pane in 1 2; do
+  [ "$(void_pane "$pane" '^ink-use[|].*[|]class=glyph[|]' | wc -l | tr -d ' ')" \
+      -eq 2 ] || {
+    echo "FAIL: a void site in pane $pane drew a site glyph" >&2
+    exit 1
+  }
+done
+grep -Fq '|name=C|physical=updown' "$WORK/r_void_open.tnlog" || {
+  echo "FAIL: the atom-scope updown answer did not reach the site" >&2
+  exit 1
+}
+for leg in leg-n-1-3 leg-s-1-3; do
+  void_pane 1 '[|]origin=policy-leg[|]' | grep -Fq "|name=$leg|" || {
+    echo "FAIL: the atom-scope updown answer lost its $leg" >&2
+    exit 1
+  }
+done
 if grep -Fq '|physical=none|' "$WORK/r_physical_policy.tnlog"; then
   echo "FAIL: physical=none materialized a physical port" >&2
   exit 1

--- a/tests/tenkz/kernel/regression/r_void_open.tex
+++ b/tests/tenkz/kernel/regression/r_void_open.tex
@@ -1,0 +1,25 @@
+% Regression: an open hole keeps its indices and draws nothing.
+% The first chain's middle cell is a hole: both generated grid bonds
+% bridge it, its physical leg survives in the boundary signature, and no
+% glyph stands in the cell (issue 5609).  The sealed chain below it is
+% the contrast: the site and its bonds are gone.  The third site answers
+% the row's physical=up policy with updown at atom scope, the one policy
+% answer r_atom_physical_answer.tex does not spell.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=3, physical=up]
+  \tn[name=A]{A} & \tn[void=open, name=H]{} &
+  \tn[name=C, physical=updown]{C}
+\end{tenkz}
+\begin{tenkz}[rows={wire}, cols=3, physical=up]
+  \tn[name=A]{A} & \tn[void=sealed, name=V]{} & \tn[name=C]{C}
+\end{tenkz}
+\mbox{parsed}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -14362,10 +14362,22 @@
 \seq_new:N \l__tenkz_kernel_skin_base_seq
 
 % The skin an atom declares, defaulting to the dot an unadorned site draws.
+% A void site — open or sealed — defaults to none instead: a hole keeps its
+% records (bonds bridging it, its boundary entries) but draws no glyph unless
+% the author declares one (issue 5609).  The void field is read before the
+% skin field: a caller may pass a result variable that its own #1 expansion
+% reads, so #1 must not be expanded again once #2 holds \q_no_value.
+\tl_new:N \l__tenkz_kernel_atom_skin_void_tl
 \cs_new_protected:Npn \__tenkz_kernel_atom_skin:nN #1#2
   {
+    \__tenkz_model_get:nnN {#1} {void} \l__tenkz_kernel_atom_skin_void_tl
     \__tenkz_model_get:nnN {#1} {skin} #2
-    \quark_if_no_value:NT #2 { \tl_set:Nn #2 {dot} }
+    \quark_if_no_value:NT #2
+      {
+        \quark_if_no_value:NTF \l__tenkz_kernel_atom_skin_void_tl
+          { \tl_set:Nn #2 {dot} }
+          { \tl_set:Nn #2 {none} }
+      }
   }
 % That skin resolved to its primitive.  Measurement, silhouette folding and
 % ink all ask this one question, so no consumer can default or resolve a skin


### PR DESCRIPTION
Closes LionSR/TNLean#5609. Part of the fixture-retirement campaign: LionSR/tenkz#13, checklist 6.3–6.4 on LionSR/TNLean#4699.

## The rule chosen

Issue LionSR/TNLean#5609 offered two spellings: default a void's skin to `none`, or respell the `\tnskip` ledger row with an explicit `skin=none`. This takes the first. A hole means an absent site, so a hole draws nothing unless the author declares a skin; the `\tnskip` → `\tn[void=open]{}` row stays one key long and is now glyph-faithful as printed. Both `void=open` and `void=sealed` stop drawing the site dot, and the record half of the contract — the bonds bridging an open hole, the surviving physical index, the boundary signature — is byte-for-byte what it was.

The change sits in the one skin accessor, `\__tenkz_kernel_atom_skin:nN`, so measurement, silhouette folding, and ink keep agreeing on the resolved skin. `LANGUAGE-1.0.md` records the rule in §2.3, in the atom key table, and as sign-off decision 7.

## A quark loop found on the way

The first draft read the `void` field inside the skin-defaulting branch, and every kernel picture with grid bonds stopped terminating. The cause is now trap 11 in `HACKING.md`: one call site aliases the result variable into the argument — `\__tenkz_kernel_atom_skin_base:nN { \tl_use:N \l__tenkz_kernel_r_c_tl } \l__tenkz_kernel_r_c_tl` in the ellipsis trim — so once the target held `\q_no_value`, re-expanding the argument expanded the quark forever (trap 1). The accessor therefore reads `void` before it writes the target; no call site changes.

## G1 retirement fixture

`tests/tenkz/kernel/regression/r_void_open.tex` is the §5 G1 replacement from `FIXTURE-RETIREMENT.md`: one `physical=up` chain whose middle cell is `\tn[void=open]{}`, over a sealed contrast chain. The probe assertions pin that the open hole keeps both bridging `origin=grid` bonds, its own physical leg, and its boundary entry (`phys:n, phys:n, phys:n, phys:s`) while the sealed variant loses the site's bonds and leg (`phys:n, phys:n`); that neither void inks a glyph — each picture draws exactly its two real sites; and that the third site answers the row's `physical=up` policy with `updown` at atom scope, the one policy-answer value `r_atom_physical_answer.tex` does not spell.

PR LionSR/TNLean#5608 has not merged, so `FIXTURE-RETIREMENT.md` is untouched here; marking G1 discharged with this fixture's name belongs to whichever change lands after both are in.

## The re-pin, argued loudly

The issue anticipated re-pinning `r_sealed_void.tex`'s stored stream. No stored ledger pins it: `tests/tenkz/kernel/golden.sha256` freezes the twelve `k_*` contract fixtures only, and none of them draws a bare void (`k_skin_pairings.tex` spells `skin=none` explicitly), so both kernel ledgers are byte-identical after this change and no baseline file moves. The streams that do change belong to two regression fixtures whose behaviour the probe assertions validate, and both changes are the intended contract:

- `r_sealed_void.tex` — the free-floating dot's glyph events leave the stream; the atom record, the empty boundary signature, and the absence of grid bonds hold exactly as asserted.
- `r_physical_policy.tex` — its five sealed voids are string anchors and policy contrasts; they stop inking dots, and every one of its record assertions still holds.

## Gates

- `scripts/tenkz_kernel_probes.sh --check` — PASS: 128 review regressions hold (including the new `r_void_open` block), 10 sugar pairs byte-identical in events and pixels, 12 kernel record streams byte-identical, kernel pixels byte-identical.
- `scripts/tenkz_golden.sh --check` — PASS: 264 event streams byte-identical to the golden baseline; the legacy surface never consults the kernel skin accessor.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — PASS: census stable at 201, all 159 flags carry verdicts. No census movement, so no `SHRINK.md` append and no baseline regeneration.
- `python3 scripts/check_tenkz_dispositions.py` — PASS: 201 blueprint occurrences and 264 standalone fixtures reconcile exactly.
- `python3 scripts/tenkz_audit.py r_void_open.tnlog` — no hard errors; `scripts/tenkz_lint.py` on the fixture source: 0 findings.
- `scripts/tenkz_pixelpair.sh origin/main` — PASS: 6 pages byte-identical at 300 dpi against origin/main.

## Render evidence

- `r_void_open.pdf` at 200 dpi and 400 dpi (`r_void_open_200dpi.png`, `r_void_open_400dpi.png`): the open hole draws no glyph while its two grid bonds bridge it as one unbroken bond line; the hole's physical leg rises from the empty cell; the third site carries north and south legs for its atom-scope `updown` answer; the sealed contrast shows two detached sites with north legs only.
- `r_sealed_void.pdf` at 200 dpi (`r_sealed_void_200dpi.png`): the sealed void's free-floating dot is gone; the two real sites stand alone with their labels.
- `r_physical_policy.pdf` at 200 dpi (`r_physical_policy_200dpi.png`): the five sealed-void anchors no longer ink dots; the string crossing keeps only its own crossing atom, and every label stays in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized default in one skin accessor with regression probes; record topology and boundaries are explicitly preserved and tested.
> 
> **Overview**
> **Void sites no longer ink a default dot.** In `\__tenkz_kernel_atom_skin:nN`, atoms with `void=open` or `void=sealed` default to `skin=none` instead of `dot`, so holes stay glyph-free (and inherit `none` label suppression) unless the author sets `skin=`. Topology and records—grid bonds across an open hole, policy legs, boundary signatures—are unchanged.
> 
> The accessor reads `void` before writing the skin result so call sites that alias the argument and result token list (trap 11 in `HACKING.md`) do not loop on `\q_no_value`.
> 
> **Contract and gates:** `LANGUAGE-1.0.md` and sign-off decision 7 document the rule; `r_void_open.tex` plus probe checks pin open vs sealed contrast and per-picture glyph counts (two real sites only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2319c94303b8160204e8d1085a6f39f883ed0c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->