### PR TITLE
fix(tenkz): compile a chained kernel picture inside a plain beamer frame

### DIFF
--- a/docs/slides/presentation20260207.tex
+++ b/docs/slides/presentation20260207.tex
@@ -26,7 +26,7 @@
 \end{center}
 \end{frame}
 
-\begin{frame}[fragile]{The Challenge}
+\begin{frame}{The Challenge}
 \textbf{\LARGE When do $A$ and $B$ describe the same quantum physics?}
 
 \vspace{0.5em}

--- a/docs/slides/presentation20260207.tnlog
+++ b/docs/slides/presentation20260207.tnlog
@@ -9,10 +9,10 @@ wire|id=wire-7|from=addr-3|kind=index|name=bond-1-2-1-3|origin=grid|to=addr-4
 wire|id=wire-8|from=addr-5|kind=index|name=bond-1-3-1-4|origin=grid|to=addr-6
 wire|id=wire-9|from=addr-7|kind=index|name=bond-1-4-1-5|origin=grid|to=addr-8
 wire|id=wire-10|from=addr-9|kind=index|name=wrap-1|origin=trace|row=1|side=west-east|to=addr-10
-wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
-wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
-wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
-wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=i_1|port-slot=1|port-type=physical
+wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=i_2|port-slot=1|port-type=physical
+wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=i_{N-1}|port-slot=1|port-type=physical
+wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=i_N|port-slot=1|port-type=physical
 kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
 ink-use|picture=k1|class=glyph|id=1|shape=circle
 glyph-geometry|picture=k1|owner=1|shape=circle|xmin=-182117|xmax=182117|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0

--- a/docs/slides/presentation20260222_technical.tex
+++ b/docs/slides/presentation20260222_technical.tex
@@ -66,7 +66,7 @@
 \section{Background: Matrix Product States}
 %======================================================================
 
-\begin{frame}[fragile]{Matrix Product Vectors (MPV)}
+\begin{frame}{Matrix Product Vectors (MPV)}
     \begin{columns}[T]
         \column{0.55\textwidth}
         \textbf{Definition:}

--- a/docs/slides/presentation20260222_technical.tnlog
+++ b/docs/slides/presentation20260222_technical.tnlog
@@ -9,10 +9,10 @@ wire|id=wire-7|from=addr-3|kind=index|name=bond-1-2-1-3|origin=grid|to=addr-4
 wire|id=wire-8|from=addr-5|kind=index|name=bond-1-3-1-4|origin=grid|to=addr-6
 wire|id=wire-9|from=addr-7|kind=index|name=bond-1-4-1-5|origin=grid|to=addr-8
 wire|id=wire-10|from=addr-9|kind=index|name=wrap-1|origin=trace|row=1|side=west-east|to=addr-10
-wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
-wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
-wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
-wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=i_1|port-slot=1|port-type=physical
+wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=i_2|port-slot=1|port-type=physical
+wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=i_{N-1}|port-slot=1|port-type=physical
+wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=i_N|port-slot=1|port-type=physical
 kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
 ink-use|picture=k1|class=glyph|id=1|shape=circle
 glyph-geometry|picture=k1|owner=1|shape=circle|xmin=-182117|xmax=182117|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0

--- a/docs/slides/presentation20260318_agentic_formalization.tex
+++ b/docs/slides/presentation20260318_agentic_formalization.tex
@@ -113,7 +113,7 @@
     \end{columns}
 \end{frame}
 
-\begin{frame}[fragile]{Matrix Product States in one slide}
+\begin{frame}{Matrix Product States in one slide}
     \begin{columns}[T]
         \column{0.52\textwidth}
         \begin{block}{Definition (MPS tensor)~[1]}

--- a/docs/slides/presentation20260318_agentic_formalization.tnlog
+++ b/docs/slides/presentation20260318_agentic_formalization.tnlog
@@ -9,10 +9,10 @@ wire|id=wire-7|from=addr-3|kind=index|name=bond-1-2-1-3|origin=grid|to=addr-4
 wire|id=wire-8|from=addr-5|kind=index|name=bond-1-3-1-4|origin=grid|to=addr-6
 wire|id=wire-9|from=addr-7|kind=index|name=bond-1-4-1-5|origin=grid|to=addr-8
 wire|id=wire-10|from=addr-9|kind=index|name=wrap-1|origin=trace|row=1|side=west-east|to=addr-10
-wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=$i_1$|port-slot=1|port-type=physical
-wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=$i_2$|port-slot=1|port-type=physical
-wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=$i_{N-1}$|port-slot=1|port-type=physical
-wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=$i_N$|port-slot=1|port-type=physical
+wire|id=wire-11|from=addr-11|host=atom-1|kind=index|name=port-open-1|origin=port-open|port-face=90|port-label=i_1|port-slot=1|port-type=physical
+wire|id=wire-12|from=addr-12|host=atom-2|kind=index|name=port-open-2|origin=port-open|port-face=90|port-label=i_2|port-slot=1|port-type=physical
+wire|id=wire-13|from=addr-13|host=atom-4|kind=index|name=port-open-3|origin=port-open|port-face=90|port-label=i_{N-1}|port-slot=1|port-type=physical
+wire|id=wire-14|from=addr-14|host=atom-5|kind=index|name=port-open-4|origin=port-open|port-face=90|port-label=i_N|port-slot=1|port-type=physical
 kernel-boundary|signature=phys:n, phys:n, phys:n, phys:n
 ink-use|picture=k1|class=glyph|id=1|shape=circle
 glyph-geometry|picture=k1|owner=1|shape=circle|xmin=-182117|xmax=182117|ymin=-182117|ymax=182117|radius=0|stroke=18022|x1=0|y1=0|x2=0|y2=0|x3=0|y3=0

--- a/docs/tenkz/chapters2/ch-tutorial.tex
+++ b/docs/tenkz/chapters2/ch-tutorial.tex
@@ -22,11 +22,11 @@ body declarations.  Each source is complete and uses canonical public syntax.
 The environment chooses a contraction grid.  \tnkey{physical=up} is picture
 policy.  Each \tncmd{tn} declares an atom; \verb|&| advances one site.
 
-Beamer reads a frame's body before typesetting it, under the catcodes in
-force when the frame opens, so a chained picture's \verb|&| is still an
-alignment tab and the frame stops with a misplaced-tab error.  Mark the frame
-\texttt{[fragile]}; beamer then defers that reading until the picture's own
-catcode for \verb|&| applies.
+Beamer reads a frame's body before typesetting it, so a chained picture
+reaches the environment with its \verb|&| already an ordinary alignment tab.
+The environment reads its body as captured tokens and gives that tab the
+site advance itself, so a chained picture compiles in a plain frame; no
+\texttt{[fragile]} marking is needed.
 
 \subsection{A channel sandwich}
 

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2633,6 +2633,19 @@ grep -Fq 'check|scope=2|relation=1|result=equal' \
   echo "FAIL: later valid equation inherited the malformed scope" >&2
   exit 1
 }
+# A beamer frame hands the kernel a pre-tokenized body, so its column tabs
+# arrive as the document's alignment character.  The chained fixture holds
+# exactly when the tab and the row break both advance the cursor there.
+beamer_atoms=$(grep -c '^atom|' "$WORK/r_beamer_frame.tnlog" || true)
+[ "$beamer_atoms" -eq 6 ] || {
+  echo "FAIL: the plain beamer frame's chained body lost atoms" >&2
+  exit 1
+}
+grep -Fq '|addr=(2,3)|' "$WORK/r_beamer_frame.tnlog" || {
+  echo "FAIL: the plain beamer frame's chained body lost its cursor" >&2
+  exit 1
+}
+
 regression_count=$(find "$WORK" -maxdepth 1 -name 'r_*.tex' | wc -l | tr -d ' ')
 echo "PASS: $regression_count review regressions hold"
 

--- a/tests/tenkz/kernel/regression/r_beamer_frame.tex
+++ b/tests/tenkz/kernel/regression/r_beamer_frame.tex
@@ -1,0 +1,16 @@
+% Regression: a chained picture compiles inside a plain beamer frame.
+% Beamer tokenizes a frame body long before any picture code runs, so the
+% body reaches the kernel carrying the document's alignment character; the
+% captured-body reading gives that token the column step without [fragile].
+\documentclass{beamer}
+\usepackage{tenkz}
+
+\begin{document}
+\begin{frame}{Chained picture}
+  \tenkzkernel
+  \begin{tenkz}[rows={wire,wire}, cols=3, bonds=grid]
+    \tn{} & \tn{} & \tn{} \\
+    \tn{} & \tn{} & \tn{}
+  \end{tenkz}
+\end{frame}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_equation_policy.tex
+++ b/tests/tenkz/kernel/regression/r_equation_policy.tex
@@ -16,21 +16,20 @@
     \quark_if_no_value:NF \l_tmpa_tl
       { \errmessage{tenkzeq check policy leaked into its panel} }
   }
+% The panel body is captured under document catcodes, so the probe needs a
+% document-level name.
+\cs_new_eq:NN \tenkzTestSharedPolicy \__tenkz_test_shared_policy:
 \ExplSyntaxOff
 \makeatother
 \begin{document}
 \tenkzkernel
 \begin{tenkzeq}[size=m, align=2, check={signature}]
   \begin{tenkz}[rows={ket,wire}, cols=1, size=s, align=1]
-    \ExplSyntaxOn
-    \__tenkz_test_shared_policy:
-    \ExplSyntaxOff
+    \tenkzTestSharedPolicy
   \end{tenkz}
   =
   \begin{tenkz}[rows={ket,wire}, cols=1]
-    \ExplSyntaxOn
-    \__tenkz_test_shared_policy:
-    \ExplSyntaxOff
+    \tenkzTestSharedPolicy
   \end{tenkz}
 \end{tenkzeq}
 \mbox{parsed}

--- a/tests/tenkz/kernel/regression/r_index_pair_scaling.tex
+++ b/tests/tenkz/kernel/regression/r_index_pair_scaling.tex
@@ -36,13 +36,14 @@
     \int_compare:nNnF { \g__tenkz_test_index_pairing_int } = {0}
       {\errmessage{ordinary~index~routes~entered~the~pairing~candidate~pass}}
   }
+% The picture body is captured under document catcodes, so the probe needs a
+% document-level name.
+\cs_new_eq:NN \tenkzTestManyIndexWires \__tenkz_test_many_index_wires:
 \ExplSyntaxOff
 \makeatother
 \begin{document}
 \tenkzkernel
 \begin{tenkz}[rows={wire}, cols=1, bonds=none]
-  \ExplSyntaxOn
-  \__tenkz_test_many_index_wires:
-  \ExplSyntaxOff
+  \tenkzTestManyIndexWires
 \end{tenkz}
 \end{document}

--- a/tests/tenkz/kernel/regression/r_setup_persistence.tex
+++ b/tests/tenkz/kernel/regression/r_setup_persistence.tex
@@ -14,14 +14,15 @@
     \str_if_eq:VnF \l_tmpa_tl {review-table}
       { \errmessage{sizes setup did not reach the picture model} }
   }
+% The picture body is captured under document catcodes, so the probe needs a
+% document-level name.
+\cs_new_eq:NN \tenkzTestSetupPersistence \__tenkz_test_setup_persistence:
 \ExplSyntaxOff
 \makeatother
 \begin{document}
 \tenkzkernel
 \tnset{theme=review, sizes={review-table}}
 \begin{tenkz}[rows={wire}, cols=1, bonds=none]
-  \ExplSyntaxOn
-  \__tenkz_test_setup_persistence:
-  \ExplSyntaxOff
+  \tenkzTestSetupPersistence
 \end{tenkz}
 \end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2394,8 +2394,12 @@
     \__tenkz_kernel_keys:nn { tenkz-kernel-picture } {#1}
     \bool_set_false:N \l__tenkz_kernel_group_keys_bool
     \__tenkz_kernel_commit:
+    % the group body arrives as one grabbed argument, so its column tabs
+    % are the document's alignment character; give them the column step
+    \tl_set:Nn \l__tenkz_kernel_group_body_tl {#2}
+    \__tenkz_kernel_rewrite_tabs:N \l__tenkz_kernel_group_body_tl
     \ignorespaces
-    #2
+    \tl_use:N \l__tenkz_kernel_group_body_tl
     \ignorespaces
   }
 
@@ -16148,7 +16152,6 @@
     % keyval syntax inside the picture is plain even under tenkzeq's
     % active relation glyph
     \char_set_catcode_other:N \=
-    \char_set_catcode_active:N \&
     \__tenkz_model_reset:
     \__tenkz_geom_reset:
     \prop_clear:N \l__tenkz_kernel_node_prop
@@ -16205,9 +16208,6 @@
     \prop_clear:N \l__tenkz_kernel_stage_prop
     \cs_set_eq:NN \tn \__tenkz_kernel_tn_cmd
     \cs_set_eq:NN \\ \__tenkz_kernel_newrow:
-    \char_set_active_eq:NN \& \__tenkz_kernel_nextcol:
-    % and the break between the option list and the first declaration
-    \ignorespaces
   }
 \cs_new_protected:Npn \__tenkz_kernel_end:
   {
@@ -16472,8 +16472,45 @@
     \__tenkz_kernel_tnmark:nnn { form = prose } { panel } {#1}
   }
 
+% The picture body is captured, then executed.  A frame-collecting class --
+% beamer is the standing example -- tokenizes a frame body long before any
+% picture code runs, so a catcode arrangement made at picture entry can
+% never reach a chained body's column tabs.  The captured tokens therefore
+% keep the document's alignment character, and the rewrite below gives that
+% token the column step: the same reading the grid and cd surfaces give
+% their captured bodies, and it holds in a plain beamer frame.  A tab nested
+% in a braced argument is data and stays untouched; \tngroup applies the
+% same rewrite to its own body.
+\tl_new:N \l__tenkz_kernel_body_tl
+\tl_new:N \l__tenkz_kernel_group_body_tl
+\cs_new_protected:Npn \__tenkz_kernel_rewrite_tabs:N #1
+  { \tl_replace_all:Nnn #1 { & } { \__tenkz_kernel_nextcol: } }
 \NewDocumentCommand \__tenkz_kernel_env_begin_cmd { O{} }
-  { \__tenkz_kernel_begin:n {#1} }
+  {
+    \__tenkz_kernel_begin:n {#1}
+    \tl_clear:N \l__tenkz_kernel_body_tl
+    \__tenkz_kernel_env_body:w
+  }
+% #1 is the chunk before the next \end and #2 that \end's environment name.
+% Chunks accumulate until the name is our own, so a different environment
+% closed inside the body passes through intact; the picture's own \end is
+% reinserted for the ordinary environment closing.
+\cs_new_protected:Npn \__tenkz_kernel_env_body:w #1 \end #2
+  {
+    \tl_put_right:Nn \l__tenkz_kernel_body_tl {#1}
+    \str_if_eq:nnTF {#2} {tenkz}
+      {
+        \__tenkz_kernel_rewrite_tabs:N \l__tenkz_kernel_body_tl
+        % the break between the option list and the first declaration
+        \ignorespaces
+        \tl_use:N \l__tenkz_kernel_body_tl
+        \end {tenkz}
+      }
+      {
+        \tl_put_right:Nn \l__tenkz_kernel_body_tl { \end {#2} }
+        \__tenkz_kernel_env_body:w
+      }
+  }
 \NewDocumentCommand \__tenkz_kernel_eq_env_begin_cmd { O{} }
   { \__tenkz_kernel_eq_begin:n {#1} }
 \NewDocumentCommand \tenkzkernel { }


### PR DESCRIPTION
Closes LionSR/tenkz#160.  Tracking: LionSR/tenkz#13.

## The defect

Beamer tokenizes a frame body long before any picture code runs, so the
catcode arrangement the kernel made at picture entry never reached a chained
body's `&`: by the time `\begin{tenkz}` executed, every tab was already
frozen as the document's alignment character, and a plain frame stopped with
*Misplaced alignment tab character &*.  Three decks carried a `[fragile]`
marking as the workaround.

## The mechanism, and why this one

The kernel environment now captures its body up to the picture's own `\end`,
rewrites the alignment character into the column step, and executes the
captured tokens.  `\tngroup` applies the same rewrite to its grabbed body.

Of the two cures the issue names, this is the smaller:

- *Rebinding at environment entry* is what the kernel already did
  (`\char_set_catcode_active:N \&` inside the picture opener), and it cannot
  work: catcodes act at reading time, and beamer has already read the frame.
- *An active `&` at package load* would defend the kernel but would change
  every document that loads the package: `&` would arrive at the grid and cd
  surfaces as an active token, and their captured-body readers split on the
  alignment character, so both dialects would need compensating rewrites --
  and package load would stop being inert.

The captured-body reading instead *deletes* the catcode arrangement and
makes the kernel read its body exactly as the grid (`+b` capture, split on
`&`) and cd (`+b` capture, `&` rewritten to the cell separator) surfaces
already read theirs.  A tab nested in a braced argument is data and stays
untouched, matching the cd dialect's documented reading.

One stated consequence: a captured body keeps the catcodes of its reading
context, so a picture body can no longer switch to expl3 syntax midway.
Three kernel regressions used that device to call test probes with expl3
names; they now bind a document-level probe name in the preamble
(`r_equation_policy`, `r_index_pair_scaling`, `r_setup_persistence`).

The `tenkzeq` wrapper still records its relation glyph through an active `=`
made at its own entry, so an equation (as opposed to a single chained
picture) inside a beamer frame remains untreated; no deck writes one.

## Decks, manual, regression

- The three `[fragile]` markings are dropped and all three decks compile.
- The decks' committed event streams are regenerated; the only delta is the
  `port-label` math-shift peeling from LionSR/TNLean#5568, whose rule postdates the
  streams' last pin (2026-08-05 vs 2026-08-06).  The frames' records are
  otherwise unchanged.
- The manual's tutorial paragraph now states the plain-frame reading
  (manual2, page 4).
- `tests/tenkz/kernel/regression/r_beamer_frame.tex` pins the behaviour: a
  chained 2x3 lattice inside a plain beamer frame; the probes assert six
  atoms and the `(2,3)` cursor advance, so both the tab and the row break
  are exercised through beamer's pre-tokenized body.

## Gates

- `scripts/tenkz_kernel_probes.sh` -- PASS: 128 review regressions hold, 10
  sugar pairs byte-identical in events and pixels, 12 kernel record streams
  byte-identical, kernel pixels byte-identical.
- `scripts/tenkz_golden.sh --check` -- PASS: 264 event streams
  byte-identical to the golden baseline.
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` -- PASS:
  census stable at 201, all 159 flags carry verdicts.  No census movement,
  so no SHRINK.md append.
- `python3 scripts/check_tenkz_dispositions.py` -- PASS: 201 blueprint
  occurrences and 264 standalone fixtures reconcile exactly.
- `python3 scripts/tenkz_manual_doctest.py` -- PASS: 14 displayed and 25
  reference examples; manual2 compiles twice.
- `scripts/tenkz_pixelpair.sh origin/main` -- PASS: 6 pages byte-identical
  at 300 dpi against the true-legacy origin/main package.

## Render evidence

- `r_beamer_frame.pdf` page 1 at 200 dpi: the 2x3 lattice draws with its
  seven grid bonds inside the plain frame, no clipping, no stray ink.
- `presentation20260207.pdf` page 2, `presentation20260222_technical.pdf`
  page 4, `presentation20260318_agentic_formalization.pdf` page 5, each at
  200 dpi: the five-site MPS chain renders with its physical legs
  ($i_1, i_2, \dots, i_N$), dots skin, per-site $A$ labels, and periodic
  wrap, identical in appearance to the fragile-frame renders.
- `manual2.pdf` page 4 at 150 dpi: the revised tutorial paragraph typesets
  cleanly beside Example 3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `\tenkz` body parsing and `&` handling in `tenkz-kernel.code.tex`; beamer and regression coverage reduce risk, but any document relying on inline expl3 or old catcode behavior in picture bodies could break.
> 
> **Overview**
> Fixes **misplaced `&`** when a chained `\begin{tenkz}` sits in a **plain** beamer frame: beamer freezes the frame body before picture entry, so catcode tricks at environment open never reached column tabs.
> 
> The kernel now **captures** the `\tenkz` body (and `\tngroup` bodies), **rewrites** document-level `&` into the column step, then executes—matching grid/cd captured-body behavior. **Active `&` at picture entry is removed**; picture bodies no longer switch to expl3 mid-body (three regressions now call document-level probe names).
> 
> **Decks:** `[fragile]` dropped on three presentation frames; **tnlogs** regenerated (`port-label` math-shift peeling only). **Manual** tutorial updated. New **`r_beamer_frame`** regression and probe checks for six atoms and `(2,3)` cursor in a plain frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1362140af31cc9daf38600c2d007c89c8da1eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->