### PR TITLE
doc(blueprint): migrate the last grid-tier pictures onto the kernel

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
@@ -101,12 +101,14 @@
         % the block index j only, while the gauge blocks X_{j,q} depend on
         % both indices.  Both sides carry the same boundary signature
         % (virtual-west=1 | virtual-east=1 | physical-up=1 | physical-down=1).
-        \begin{tenkz}[physical=updown]
-            \tn{K}
+        \tenkzkernel
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+            \tn[ports={90:physical, 270:physical}]{K}
         \end{tenkz}
         $ = $
-        \begin{tenkz}[physical=updown]
-            \tnX{X} & \tn{\bigoplus_j\mathcal K_j} & \tnX{X^{-1}}
+        \begin{tenkz}[rows={wire}, cols=3, west=open, east=open]
+            \tn[skin=ring]{X} & \tn[ports={90:physical, 270:physical}]{\bigoplus_j\mathcal K_j} &
+            \tn[skin=ring]{X^{-1}}
         \end{tenkz}
     \end{center}
     \caption{Horizontal canonical form of the doubled tensor: the gauge $X$,
@@ -215,10 +217,13 @@
     % signature
     % (virtual-west=1 | virtual-east=1 | physical-up=3 |
     % physical-down=3).
-    \begin{tenkz}[rows={op:none, op, op:none}, tensor style=box]
-        \tn[pill, wide=3, legs at={1,2,3}]{U} & & \\
-        \tn[wide=3]{\widetilde M} & & \\
-        \tn[pill, wide=3, legs at={1,2,3}]{U^\dagger} & &
+    \tenkzkernel
+    \begin{tenkz}[rows={op,op,op}, cols=3]
+        \tn[at=(1,1), skin=pill, wide=3, ports={90@1:physical, 90@2:physical, 90@3:physical}]{U}
+        \tn[at=(2,1), skin=box, wide=3, name=M]{\widetilde M}
+        \tn[at=(3,1), skin=pill, wide=3,
+            ports={270@1:physical, 270@2:physical, 270@3:physical}]{U^\dagger}
+        \tnwire{open w}{M.180} \tnwire{M.0}{open e}
     \end{tenkz}
     $ = \bigoplus_\alpha $
     {\tenkzkernel

--- a/blueprint/src/chapter/ch20_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch20_mpdo_foundations.tex
@@ -369,14 +369,17 @@ Diagrammatically,
     % virtual indices.  No east cup is present, since beta remains free.
     The local contraction is
     \begin{tenkzequation}
-        \begin{tenkz}[physical=updown, tensor style=box]
-            \tn[mpo, up=$i$, down=$j$]{M}
+        \tenkzkernel
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+            \tn[skin=mpo, ports={90:physical:$i$, 270:physical:$j$}]{M}
         \end{tenkz}
         $ = $
-        \begin{tenkz}[rows={op,op}, tensor style=box]
-            \tnfuse{e} & \tn[up=$i$]{A} &
-                \tnfuse[combined=east]{e^{-1}}\\
-                       & \tn*[down=$j$]{A} &
+        \begin{tenkz}[rows={op,op}, cols=3]
+            \tn[at=(1,1), name=e, skin=pill, wires=2]{e}
+            \tn[at=(1,2), skin=box, ports={90:physical:$i$}]{A}
+            \tn[at=(2,2), skin=box, ports={270:physical:$j$}]{\overline{A}}
+            \tn[at=(1,3), name=ei, skin=pill, wires=2]{e^{-1}}
+            \tnwire{open w}{e.180} \tnwire{ei.0}{open e}
         \end{tenkz}
     \end{tenkzequation}
 \end{definition}

--- a/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
@@ -602,8 +602,9 @@ representation.
         % (virtual-west=1 | virtual-east=1 | physical-up=1).
         % Source verdict: CPSV16 Theorem 3.11 and its graphical explanation,
         % Papers/1606.00608/MPDO-22-12-17-2.tex:543--562.
-        \begin{tenkz}[physical=up, tensor style=box]
-            \tn{A}
+        \tenkzkernel
+        \begin{tenkz}[rows={wire}, cols=1, west=open, east=open]
+            \tn[skin=box, ports={90:physical}]{A}
         \end{tenkz}
         $ = $
         % TENKZ-II-RFP-BEGIN

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,9 +75,9 @@ separate public-surface occurrence and therefore appears separately.
 | `ch16_channel_representations_choi_and_kraus.tex` | L673 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L225, 364, 377, 428 `tenkz` → `P-grid` | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record` |
+| `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 230, 369, 382, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 644 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_foundations.tex` | L17, 126 `tenkz` → `P-grid` | — | L372 `tenkz` → `C-policy+C-record+R-record`<br>L376 `tenkz` → `C-record+R-record` |
+| `ch20_mpdo_foundations.tex` | L17, 126, 373, 377 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_foundations.tex` | L87, 92 `tenkz` → `P-grid` | — | — |
@@ -108,7 +108,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch24_peps_ft_normal_union.tex` | L214, 263, 289, 301, 316 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_region_transfer_covariance.tex` | L351, 355, 359, 363 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_torus_translation_and_reference_windows.tex` | L23 `tenkz` → `P-grid` | — | — |
-| `ch26_mps_rfp_normal_isometry_canonical_forms.tex` | L453, 457, 611 `tenkz` → `P-grid` | — | L605 `tenkz` → `C-policy+R-record` |
+| `ch26_mps_rfp_normal_isometry_canonical_forms.tex` | L453, 457, 606, 612 `tenkz` → `P-grid` | — | — |
 | `ch26_mps_rfp_physical_blocking.tex` | L198, 202, 220, 225 `tenkz` → `P-grid` | — | — |
 
 ### Blueprint reconciliation
@@ -124,9 +124,9 @@ separate public-surface occurrence and therefore appears separately.
 
 | Disposition | Occurrences |
 |---|---:|
-| preserve | 145 |
-| codemod | 13 |
-| redraw | 43 |
+| preserve | 151 |
+| codemod | 11 |
+| redraw | 39 |
 | **Total** | **201** |
 
 The raw count is 170 environment openings plus 31 command occurrences,

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2444,3 +2444,46 @@ untouched.
 | flag:consumers:environment:tenkzfree | dies at S4: the blueprint's last free-graph pictures left with this wave and the ch24 chapters, so the environment's demand-corpus consumers are gone; the front end and its fixtures are booked to the dialect retirement (FIXTURE-RETIREMENT.md); expiry 0.9 |
 | flag:consumers:command:tnput | dies at S4 with the 0.7 tier that reads it: the kernel carries its own row where the concept survives, and no demand-corpus consumer remains; the fixture uses ride the dialect's own retirement; expiry 0.9 |
 | flag:consumers:command:tnjoin | dies at S4 with the 0.7 tier that reads it: the kernel carries its own row where the concept survives, and no demand-corpus consumer remains; the fixture uses ride the dialect's own retirement; expiry 0.9 |
+
+### 2026-08-08 — the last grid-tier blueprint pictures take the kernel
+
+The six 0.7 grid pictures the earlier waves left behind — the LPDO
+local contraction and its doubled-index tensor in the MPDO foundations,
+the horizontal canonical form of the doubled tensor and its direct-sum
+panel, the finite-separation isometry stack, and the ch26 fixed-point
+panel whose right-hand side already rode the kernel — now carry
+`\tenkzkernel`. `tensor style=` and the `up=`/`down=` shorthands become
+typed `ports=` with the index written on its port; the `\tnfuse` wedges
+become the prelude fuse shape the sugar ledger signs, spelled as
+`wires=2` atoms whose split legs the frame bonds to the two rows; the
+`op:none` row modifier and `legs at=` become slotted `ports=` on a
+`wide=3` atom; `\tnX` becomes `skin=ring` and `\tn*` becomes the
+overline in the label. The isometry stack takes the stock `skin=pill`
+its disposition row demanded. One picture stays on the grid tier, as
+before: the MPV-overlap ladder, blocked on a per-row trace return that
+clears the two-row selection it closes.
+
+The wave measures three kernel gaps and names them rather than hiding
+them. A fuse record inside a kernel picture is refused unplaced, so the
+signed `\tnfuse` sugar row has no kernel-tier reading yet and both
+migrated wedges spell its expansion by hand — the LPDO panel pays three
+source lines over its 0.7 spelling for exactly this reason. A `wires=`
+slot span resolves only at a frame cell, so a fuse standing at a
+`midway` address loses its second slot and is refused. And a wide
+atom's `physical=` policy mints one centre port rather than one per
+spanned cell, so a three-legged isometry face spells its three slots by
+hand.
+
+All six meters are unchanged from the ch24 wave: M1 stays at 140 kernel
+rows and 201 total, M2 at 228 parser paths, M3 at 6 escapes — the new
+pictures ride the kernel grammar with none — M4 at its frozen 25.94,
+and no alias or overload moves. The blueprint disposition ledger moves
+145 preserve, 13 codemod, 43 redraw to 151, 11, and 39 over the
+constant 201. Demand moves four times and takes its verdicts below.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:object:up | dies at S4 with the 0.7 object ledger: `up=` is tombstoned onto `ports=` (`LANGUAGE-1.0` §10), the migrated pictures write the physical index on its typed port, and both remaining demand-corpus consumers are ch21 fusion-isometry figures booked `C-picture+C-policy+C-record+R-record` for their own redraw; expiry 0.9 |
+| flag:consumers:key:object:down | dies at S4 with the 0.7 object ledger, exactly as `up=` above: the two remaining consumers are the same ch21 fusion-isometry figures awaiting their own redraw; expiry 0.9 |
+| flag:consumers:key:setup:tensor style | dies at S4 with the 0.7 setup tier: the kernel names a silhouette per atom through the signed `skin=` row, which is how every migrated picture now spells it; the one remaining consumer is the ch21 refinement-channel picture-term figure, booked to its own redraw row; expiry 0.9 |
+| flag:sugar-shaped:command:tnfuse | demoted at the language landing: a prelude-declared fuse atom (`LANGUAGE-1.0` §9); the kernel tier does not yet place a fuse record — the gap this wave measured — so the migrated wedges spell the expansion as `wires=2` atoms bonded by the frame, and all eight remaining occurrences ride the ch21 fusion-isometry figures awaiting their own redraw; expiry 0.9 |


### PR DESCRIPTION
Part of LionSR/TNLean#4699 (stage S4); execution tracker LionSR/tenkz#13.

The blueprint's last 0.7 grid-tier pictures take `\tenkzkernel`. After this PR the only 0.7 picture left in the blueprint is the MPV-overlap ladder at `ch02_mps.tex` L983, blocked on a named kernel gap: a per-row trace return that clears the whole two-row selection it closes — the kernel still drops every flat-row return one clearance below its own row, which would run the upper ring's return through the ladder. Its redraw disposition row stands. (The census also surfaced a sixth grid-tier straggler beyond the five booked ones — the ch26 fixed-point panel at L605, whose right-hand side already rode the kernel — so it is migrated here too; without it the "only ch02 L983 remains" statement would be false.)

## Per-picture line deltas and boundary-leg judgments

| Picture | 0.7 → kernel lines | Boundary judgment |
|---|---|---|
| `ch20_mpdo_foundations.tex` L372 (LPDO LHS, M) | 3 → 3 | `west=open, east=open`: α, β are the free virtual indices of `eq:mpdo_lpdo_factorization`; i up and j down as labelled typed ports. Audited signature `open:w, open:e, phys:n, phys:s` = (1,1,1,1), matching the figure comment. |
| `ch20_mpdo_foundations.tex` L376 (LPDO RHS, e/A/Ā/e⁻¹) | 5 → 8 | No side policy: the single α and β legs are explicit `\tnwire{open w}{e.180}` / `{ei.0}{open e}` wires, because `west=open` on a two-row picture mints one leg per row (two legs — wrong signature, verified in the event stream). The k contraction is the frame bond between A and Ā; both fuse-to-row bonds are frame bonds off the `wires=2` spanning atoms. Signature (1,1,1,1) = LHS. |
| `ch20_..._intro_finite_separation.tex` L104 (K) | 3 → 3 | `west=open, east=open` + up/down typed ports: (1,1,1,1) per the comment; ports spelled on the atom, not as picture policy, per the §9 sparse-row doctrine. |
| `ch20_..._intro_finite_separation.tex` L108 (X ⊕Kⱼ X⁻¹) | 3 → 4 | Same sides; only the middle tensor carries the up/down ports — the gauge capsules ride the virtual wire with no physical leg, exactly as the figure comment states. Audited (1,1,1,1) on both panels. |
| `ch20_..._intro_finite_separation.tex` L218 (U M̃ U† stack) | 5 → 8 | M̃ alone owns the west/east virtual legs (explicit open wires); U's three up and U†'s three down slot ports stay open; the six inter-row contractions are frame bonds. Audited signature (1,1,3,3), matching the comment. Takes the stock `skin=pill` the disposition row demanded (#5480). |
| `ch26_..._isometry_canonical_forms.tex` L605 (A panel) | 3 → 3 | `west=open, east=open` + one up physical port: (1,1,1 up) per the comment; matches the kernel right-hand side it equals. |

Net picture source: 22 → 29 lines (+3 `\tenkzkernel` switch lines, booked C-switch). Three pictures shrink or hold; the two that grow do so for the kernel gaps below, spelled as the §9-documented expansions rather than workarounds.

## Kernel gaps found

1. **`\tnfuse` has no kernel-tier placement.** Inside a kernel picture a fuse record fails `[TKZ-KERNEL-RENDER-UNPLACED]` — the signed §9 sugar row (`prelude fuse atom (skin=tri, wires=, ports=)`) has no kernel reading yet, so both wedges spell the expansion by hand; that is the whole +3 on the LPDO RHS.
2. **`wires=` slot spans resolve only at a frame cell.** A fuse at `at=midway (1,1) and (2,1)` loses its second east slot: `[TKZ-PORT-SLOT] slot 2 on face 0 ... exceeds its span 1`. Spanning atoms therefore anchor at a cell.
3. **A wide atom's `physical=` policy mints one centre port, not one per spanned cell.** The `wide=3` isometry faces spell `90@1..90@3` by hand — a slot-range or per-cell policy spelling would return the U-stack to its 0.7 length.
4. (Also observed, cosmetic: `skin=tri` + `wires=2` obeys the circumscribing-square rule and renders a two-pitch-wide triangle, which is why the wedges take the pill silhouette instead of the ledger's `tri`.)

## Render evidence

Every migrated picture and its pre-migration 0.7 original were compiled standalone through the pipeline preamble (`macros/common` + `tenkz` + `macros/diagrams`, kernel version under `\tenkzkernel`) and rasterized at 200 dpi with `pdftocairo`, then inspected side by side: `orig_lpdo.png` / `final_lpdo.png` (both LPDO panels), `orig_hcf.png` / `final_hcf.png` (both canonical-form panels), `orig_umu.png` / `final_umu.png` + `final_umu_full.png` (isometry stack, including the following direct-sum picture under the same switch), `orig_ch26.png` / `final_ch26.png`. No leg is lost; the kernel U-stack additionally repairs the 0.7 render's mis-anchored diagonal strokes from `legs at=` into the wide atom's centre. Event streams audited clean (`tenkz_audit.py`, 0 advisories) with the signatures quoted above.

## Ledgers and gates

- `docs/tenkz/DISPOSITIONS.md`: six rows discharged to `P-grid` with re-pinned lines; counters 145/13/43 → 151/11/39 over the constant 201.
- `docs/tenkz/SHRINK.md`: appended 2026-08-08 session sentencing the four flags the drained spellings raise (`up=`, `down=` at 2 consumers, `tensor style=` at 1, sugar-shaped `\tnfuse`); meters unchanged, `tests/tenkz/census-baseline.json` byte-identical (verified by diff), so no re-pin.
- Passing: `check_tenkz_dispositions.py`, `test_check_tenkz_dispositions.py`, `tenkz_shrink.py gate` (census stable at 201, all 177 flags carry verdicts), `tenkz_kernel_probes.sh` (all four suites), `test_tenkz_pic.py`, `test_tenkz_index_routing.py`, and `test_tenkz_equation_web.py` against a freshly built `leanblueprint web` (17 equations, expected picture counts, all wrappers contained on desktop and mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are blueprint TeX diagrams and tenkz migration documentation only; no runtime, auth, or data paths. Residual risk is visual/regression in compiled figures if kernel rendering diverges from the audited standalone renders described in the PR.
> 
> **Overview**
> Closes the blueprint **tenkz** migration wave for six figures that were still on the 0.7 grid tier: LPDO **M** and its **e / A / Ā / e⁻¹** factorization in MPDO foundations, the horizontal canonical **K** and **X ⊕ 𝒦ⱼ X⁻¹** panels, the **U M̃ U†** vertical direct-sum stack, and the ch26 **A** fixed-point panel.
> 
> Each picture now opens with `\tenkzkernel` and uses explicit **rows/cols**, **west/east=open**, typed **`ports=`** (replacing **`up=`/`down=`** and **`tensor style=`**), **`skin=`** for rings/pills/boxes, and hand-wired **`tnwire`** where side policies would mint the wrong boundary count. **`tnfuse`** wedges are spelled as **`wires=2`** pill atoms plus frame bonds because kernel placement for fuse records is not available yet.
> 
> **`docs/tenkz/DISPOSITIONS.md`** reclassifies those lines to **`P-grid`** preserve (151 preserve / 11 codemod / 39 redraw over 201). **`docs/tenkz/SHRINK.md`** records the session, unchanged shrink meters, and flag verdicts for drained spellings (**`up=`**, **`down=`**, **`tensor style=`**, sugar **`tnfuse`**). The only remaining 0.7 grid straggler in the census is **ch02_mps** L983 (MPV ladder), still blocked on a named kernel gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067f25bfca9b8e85aa421a189dfe85b17b1e624b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
