### PR TITLE
fix(tenkz): draw the fuse, the off-cell slot, and the wide atom's policy ports

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
@@ -219,10 +219,9 @@
     % physical-down=3).
     \tenkzkernel
     \begin{tenkz}[rows={op,op,op}, cols=3]
-        \tn[at=(1,1), skin=pill, wide=3, ports={90@1:physical, 90@2:physical, 90@3:physical}]{U}
+        \tn[at=(1,1), skin=pill, wide=3, physical=up]{U}
         \tn[at=(2,1), skin=box, wide=3, name=M]{\widetilde M}
-        \tn[at=(3,1), skin=pill, wide=3,
-            ports={270@1:physical, 270@2:physical, 270@3:physical}]{U^\dagger}
+        \tn[at=(3,1), skin=pill, wide=3, physical=down]{U^\dagger}
         \tnwire{open w}{M.180} \tnwire{M.0}{open e}
     \end{tenkz}
     $ = \bigoplus_\alpha $

--- a/blueprint/src/chapter/ch20_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch20_mpdo_foundations.tex
@@ -375,11 +375,10 @@ Diagrammatically,
         \end{tenkz}
         $ = $
         \begin{tenkz}[rows={op,op}, cols=3]
-            \tn[at=(1,1), name=e, skin=pill, wires=2]{e}
+            \tnfuse[at=(1,1), name=e, skin=pill]{e} \tnwire{open w}{e.180}
             \tn[at=(1,2), skin=box, ports={90:physical:$i$}]{A}
             \tn[at=(2,2), skin=box, ports={270:physical:$j$}]{\overline{A}}
-            \tn[at=(1,3), name=ei, skin=pill, wires=2]{e^{-1}}
-            \tnwire{open w}{e.180} \tnwire{ei.0}{open e}
+            \tnfuse[at=(1,3), name=ei, skin=pill]{e^{-1}} \tnwire{ei.0}{open e}
         \end{tenkz}
     \end{tenkzequation}
 \end{definition}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch16_channel_representations_choi_and_kraus.tex` | L673 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 230, 369, 382, 433 `tenkz` → `P-grid` | — | — |
+| `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 644 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | L17, 126, 373, 377 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -289,7 +289,11 @@ a .. b                 the records between a and b in the frame's own order
 Operands compose: in productions four through eight an operand is itself an
 address, so `crossing of g and on r 0.4` is well formed. `crossing` operands
 must resolve to wires. The slot suffix `@k` is optional when the angle
-carries one slot: `B.270` means `B.270@1`. A cell named without a member
+carries one slot: `B.270` means `B.270@1`. A face's slot count is the
+atom's own measured extent (`wide=` across a vertical face, `wires=`
+across a horizontal one), and it answers wherever the atom stands — a
+spanning atom at a midway or on-wire address keeps every slot a
+frame-anchored one would. A cell named without a member
 index denotes the whole cell, which is what a cell means to a selection.
 
 Every record class is addressable by name, generated names included, and the
@@ -800,7 +804,7 @@ policy for the shared leg; write the ports for the lone one.
 | Sugar | Expands to |
 |---|---|
 | `sandwich` | `rows={ket,op,bra}` |
-| `physical=up\|down\|updown\|none` | expander: declares each frame-cell atom's outward centre port physical; geometric overlay atoms are excluded; in a plane this is the independent page-transverse axis, not a numeric in-plane face |
+| `physical=up\|down\|updown\|none` | expander: declares each frame-cell atom's outward face physical, one port per face slot — a `wide=k` atom answers with `k` legs, one per spanned cell, exactly as the authored `90@1..@k` port list; geometric overlay atoms are excluded; in a plane this is the independent page-transverse axis, not a numeric in-plane face |
 | `boundary=open\|none` | `west=<w>, east=<w>` |
 | `boundary=periodic`, `periodic` | `west=trace, east=trace` |
 | `west={cup=$m$}` (any side) | side `cup` + `\tn[skin=ring, at=on <cup wire> 0.5]{m}` |
@@ -816,7 +820,7 @@ policy for the shared leg; write the ports for the lone one.
 | `\tn*[k]{m}` | `\tn[conjugate, k]{m}` |
 | `\tnbond[k]{a}{b}` | `\tnwire[kind=index, k]{a}{b}` |
 | `\tnstring[k]{verbs}` | `\tnwire[kind=string, ...]` — verb table below |
-| `\tnfuse[k]{m}` | prelude fuse atom (`skin=tri`, `wires=`, `ports=`); tenure: 0 benchmark consumers, held by 4 blueprint figures |
+| `\tnfuse[k]{m}` | `\tn[skin=tri, wires=2, k]{m}` — the prelude fuse atom, its split side bonded by the frame; authored keys follow the preset, so `skin=`, `wires=`, `ports=` in `k` override it; tenure: 0 benchmark consumers, held by 5 blueprint figures |
 | `\tnspan[form]{k}{m}` | `\tnmark[form=...]{(r,c) .. (r,c+k-1)}{m}` |
 | `\tndots` | `\tn[skin=dots]{}` (elision bit read by the audit) |
 | `\tnskip` | `\tn[void=open]{}` |

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2549,3 +2549,30 @@ from 213 parser paths to 178. M3 is untouched at 0. M4 is untouched at
 decrease is the session's own evidence.
 | flag:lonely-type:direction-policy | keep: `dir=` is the contract's one spelling of a space against its dual (`LANGUAGE-1.0` §2.4), lonely only because the 0.7 connection twin left with its front end; expiry 0.9 |
 | flag:lonely-type:name-list | keep: `\tnset{species={...}}` is the document's species declaration itself, lonely only because the free region's member list left with its dialect; expiry 0.9 |
+
+### 2026-08-09 — the three mop-up idioms draw (#5624)
+
+The mop-up wave's three measured gaps close. The signed `\tnfuse` sugar
+row gains its kernel-tier reading — the prelude fuse atom, a `wires=2`
+atom the frame bonds, authored keys overriding the preset — and the two
+LPDO wedges shrink back from their hand-spelled expansions to the sugar.
+A slot span now answers from the atom's own measured silhouette wherever
+the atom stands, so a spanning atom at a midway address keeps every slot
+its `wires=`/`wide=` extent declares. And a wide atom answering the
+`physical=` policy mints one leg per face slot, named per spanned cell,
+exactly as the authored `90@1..@k` port list; the finite-separation
+isometry stack shrinks back onto the policy. Both re-sugared pictures
+render byte-identical to their expansions at 200 dpi, and the sugar-pair
+probe pins the fuse pair in events and pixels.
+
+No meter moves: the census is stable, no registry row is added or
+removed, and the kernel binds the existing `\tnfuse` command exactly as
+it binds `\tnbond`. The disposition checker learns that a sugar command
+the kernel binds owes no migration work under the switch, the same
+doctrine signed keys already enjoy. Demand for `\tnfuse` moves to two
+kernel-tier blueprint consumers beside the eight ch21 occurrences still
+awaiting their own redraw.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:command:tnfuse | demoted at the language landing: a prelude-declared fuse atom (`LANGUAGE-1.0` §9) whose kernel-tier reading landed with #5624; two kernel-tier blueprint wedges consume the sugar and the eight ch21 occurrences ride their figures' own redraw rows; expiry 0.9 |

--- a/scripts/check_tenkz_dispositions.py
+++ b/scripts/check_tenkz_dispositions.py
@@ -90,6 +90,11 @@ SUGAR_COMMANDS = (
     "tndots",
     "tnskip",
 )
+# Sugar commands the kernel tier binds to their signed expansions.  Under
+# `\tenkzkernel` these owe no migration work, exactly as a key with a signed
+# `kernel-` registry row owes none: the surface switch reads them as their
+# ledger expansions where they stand.
+KERNEL_SUGAR_COMMANDS = frozenset({"tnbond", "tnfuse"})
 BARE_DEAD_FLAGS = ("boundary legs", "maps")
 SIGNED_KEYS_BY_SCOPE = {
     scope: {
@@ -531,7 +536,11 @@ def fragment_target_codes(source: str, kernel: bool = False) -> frozenset[str]:
         "planes",
     }:
         codes.add("C-frame")
-    if any(re.search(rf"\\{name}\b", source) for name in SUGAR_COMMANDS):
+    if any(
+        re.search(rf"\\{name}\b", source)
+        for name in SUGAR_COMMANDS
+        if not (kernel and name in KERNEL_SUGAR_COMMANDS)
+    ):
         codes.add("C-record")
     if re.search(r"\\tn\*", source):
         codes.add("C-record")

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1614,7 +1614,8 @@ for pixel_fixture in \
     r_physical_dir r_pill_skin_prelude r_pill_skin_roundrect \
     r_region_diagonal r_region_pinch_staircase r_ring_closure \
     r_wire_stroke r_noncell_port_slot r_noncell_port_slot_cell \
-    r_wide_policy_legs r_wide_policy_ports; do
+    r_wide_policy_legs r_wide_policy_ports \
+    r_route_noncell_slots r_route_noncell_slots_cell; do
   if ! pdftoppm -singlefile -png -r 300 \
       "$WORK/$pixel_fixture.pdf" "$WORK/$pixel_fixture" >/dev/null 2>&1; then
     echo "FAIL: $pixel_fixture fixture could not be rasterized" >&2
@@ -2812,6 +2813,36 @@ grep -Fxq 'kernel-boundary|signature=phys:n, phys:n' \
 }
 cmp -s "$WORK/r_wide_policy_legs.png" "$WORK/r_wide_policy_ports.png" || {
   echo "FAIL: the wide policy legs render apart from authored slot ports" >&2
+  exit 1
+}
+# A route over a spanning atom meets one distinct exit per slot, ordered by
+# the slot's place on the span rather than by record id, wherever the atom
+# stands: the midway and cell-anchored spellings publish the same crossing
+# order and render byte-identical.
+for half in r_route_noncell_slots r_route_noncell_slots_cell; do
+  grep -Fq 'cross=over at crossing of lift and port-open-2,over at crossing of lift and port-open-1|' \
+      "$WORK/$half.tnlog" || {
+    echo "FAIL: $half did not meet the span's exits in slot order" >&2
+    exit 1
+  }
+done
+cmp -s "$WORK/r_route_noncell_slots.png" \
+    "$WORK/r_route_noncell_slots_cell.png" || {
+  echo "FAIL: a route over a midway span renders apart from its cell anchor" >&2
+  exit 1
+}
+# On a curved carrier a wide atom's policy legs and its boundary signature
+# agree per slot: two stations, two bearings, no duplicated host bearing.
+for leg in leg-n-1-1 leg-n-1-2; do
+  grep -Fq "|kind=index|name=$leg|origin=policy-leg|port-type=physical|" \
+      "$WORK/r_circle_wide_policy.tnlog" || {
+    echo "FAIL: the circle-frame wide policy atom lost slot leg $leg" >&2
+    exit 1
+  }
+done
+grep -Fxq 'kernel-boundary|signature=phys:e, phys:n' \
+    "$WORK/r_circle_wide_policy.tnlog" || {
+  echo "FAIL: the circle-frame wide policy signature left its slot bearings" >&2
   exit 1
 }
 

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1613,7 +1613,8 @@ for pixel_fixture in \
     r_label_turn r_mpo_skin_box r_mpo_skin_prelude r_parallel_lanes \
     r_physical_dir r_pill_skin_prelude r_pill_skin_roundrect \
     r_region_diagonal r_region_pinch_staircase r_ring_closure \
-    r_wire_stroke; do
+    r_wire_stroke r_noncell_port_slot r_noncell_port_slot_cell \
+    r_wide_policy_legs r_wide_policy_ports; do
   if ! pdftoppm -singlefile -png -r 300 \
       "$WORK/$pixel_fixture.pdf" "$WORK/$pixel_fixture" >/dev/null 2>&1; then
     echo "FAIL: $pixel_fixture fixture could not be rasterized" >&2
@@ -2175,7 +2176,8 @@ for strict_negative in \
   n_strict_sandwich \
   n_strict_role \
   n_strict_tnbond \
-  n_strict_tnprose
+  n_strict_tnprose \
+  n_strict_tnfuse
 do
   source="$KERNEL/negative/$strict_negative.tex"
   if ( cd "$WORK" &&
@@ -2217,7 +2219,6 @@ for contract_negative in \
   n_sealed_duplicate_port \
   n_sealed_malformed_port \
   n_port_slot \
-  n_noncell_port_slot \
   n_port_open_name \
   n_padded_duplicate_port \
   n_rounding_duplicate_port \
@@ -2286,8 +2287,6 @@ do
   [ "$contract_negative" = n_sealed_malformed_port ] &&
     expected='[TKZ-PORT-PARSE]'
   [ "$contract_negative" = n_port_slot ] &&
-    expected='[TKZ-PORT-SLOT]'
-  [ "$contract_negative" = n_noncell_port_slot ] &&
     expected='[TKZ-PORT-SLOT]'
   [ "$contract_negative" = n_port_open_name ] &&
     expected='[TKZ-LANG-NAME-COLLISION]'
@@ -2760,11 +2759,67 @@ grep -Fq '|addr=(2,3)|' "$WORK/r_beamer_frame.tnlog" || {
   exit 1
 }
 
+# A slot span answers from the atom's own measured silhouette wherever it
+# stands: a wires=2 atom at a midway address keeps slot 2 for wires and for
+# authored open ports, and its contracted picture renders exactly as the
+# cell-anchored spelling.
+[ "$(grep -c '^wire|' "$WORK/r_noncell_port_slot.tnlog" || true)" -eq 2 ] || {
+  echo "FAIL: a midway-addressed spanning atom lost a slot wire" >&2
+  exit 1
+}
+for slot_port in \
+  '|port-face=0|port-slot=1|port-type=virtual' \
+  '|port-face=0|port-slot=2|port-type=virtual' \
+  '|port-face=180|port-slot=1|port-type=virtual'; do
+  grep -F '|origin=port-open|' "$WORK/r_noncell_port_open_slots.tnlog" |
+    grep -Fq "$slot_port" || {
+    echo "FAIL: a midway-addressed atom lost the authored port $slot_port" >&2
+    exit 1
+  }
+done
+grep -Fxq 'kernel-boundary|signature=open:e, open:e, open:w' \
+    "$WORK/r_noncell_port_open_slots.tnlog" || {
+  echo "FAIL: the midway-addressed fuse lost its open boundary" >&2
+  exit 1
+}
+cmp -s "$WORK/r_noncell_port_slot.png" "$WORK/r_noncell_port_slot_cell.png" || {
+  echo "FAIL: a midway-addressed slot span renders apart from its cell anchor" >&2
+  exit 1
+}
+# A wide atom answering the physical policy mints one leg per face slot,
+# named per spanned cell; a wire consuming one slot retires that slot's leg
+# alone; the ink equals the authored slot-port spelling.
+for leg in leg-n-1-1 leg-n-1-2 leg-n-1-3 leg-n-2-1 leg-n-2-3; do
+  grep -Fq "|kind=index|name=$leg|origin=policy-leg|port-type=physical|" \
+      "$WORK/r_wide_policy_legs.tnlog" || {
+    echo "FAIL: the wide policy atom lost slot leg $leg" >&2
+    exit 1
+  }
+done
+if grep -Fq '|name=leg-n-2-2|' "$WORK/r_wide_policy_legs.tnlog"; then
+  echo "FAIL: a consumed slot of a wide policy atom kept its leg" >&2
+  exit 1
+fi
+[ "$(grep -Fc 'kernel-boundary|signature=phys:n, phys:n, phys:n' \
+      "$WORK/r_wide_policy_legs.tnlog" || true)" -eq 1 ] || {
+  echo "FAIL: the wide policy atom lost its three-index boundary" >&2
+  exit 1
+}
+grep -Fxq 'kernel-boundary|signature=phys:n, phys:n' \
+    "$WORK/r_wide_policy_legs.tnlog" || {
+  echo "FAIL: the slot-consumed wide policy atom lost its two-index boundary" >&2
+  exit 1
+}
+cmp -s "$WORK/r_wide_policy_legs.png" "$WORK/r_wide_policy_ports.png" || {
+  echo "FAIL: the wide policy legs render apart from authored slot ports" >&2
+  exit 1
+}
+
 regression_count=$(find "$WORK" -maxdepth 1 -name 'r_*.tex' | wc -l | tr -d ' ')
 echo "PASS: $regression_count review regressions hold"
 
 fail=0
-for pair in s1 s2 s3 s4 s5 s6 s7 s8 s9 s10; do
+for pair in s1 s2 s3 s4 s5 s6 s7 s8 s9 s10 s11; do
   if ! cmp -s "$WORK/${pair}_sugar.tnlog" "$WORK/${pair}_kernel.tnlog"; then
     echo "FAIL: sugar pair $pair diverges from its kernel expansion" >&2
     diff "$WORK/${pair}_sugar.tnlog" "$WORK/${pair}_kernel.tnlog" >&2 || true
@@ -2788,7 +2843,7 @@ for pair in s1 s2 s3 s4 s5 s6 s7 s8 s9 s10; do
   fi
 done
 [ "$fail" -eq 0 ] &&
-  echo "PASS: 10 sugar spellings byte-identical to their expansions in events and pixels"
+  echo "PASS: 11 sugar spellings byte-identical to their expansions in events and pixels"
 
 CURRENT="$WORK/current.sha256"
 ( cd "$WORK"

--- a/scripts/test_check_tenkz_dispositions.py
+++ b/scripts/test_check_tenkz_dispositions.py
@@ -139,6 +139,23 @@ def main() -> int:
         ), source
         assert guard.fragment_target_codes(source) != frozenset({"P-grid"}), source
 
+    # A sugar command the kernel binds (tnfuse, tnbond) owes no migration
+    # work under the switch; one it does not yet bind still does.
+    kernel_bound_sugar = (
+        r"\begin{tenkz}[rows={op,op}, cols=3]"
+        r"\tnfuse[at=(1,1), name=e, skin=pill]{e}\end{tenkz}",
+        r"\begin{tenkz}[rows={wire,wire}, cols=2]"
+        r"\tnbond{(1,1)}{(2,2)}\end{tenkz}",
+    )
+    for source in kernel_bound_sugar:
+        assert guard.fragment_target_codes(source, True) == frozenset(
+            {"P-grid"}
+        ), source
+        assert "C-record" in guard.fragment_target_codes(source), source
+    assert "C-record" in guard.fragment_target_codes(
+        r"\begin{tenkz}[rows={wire}, cols=2]\tndots\end{tenkz}", True
+    )
+
     # Keys with no kernel row keep their codemod under the switch.
     unsigned_policy = (
         r"\begin{tenkz}[periodic]\tn{}\end{tenkz}",

--- a/tests/tenkz/kernel/negative/n_strict_tnfuse.tex
+++ b/tests/tenkz/kernel/negative/n_strict_tnfuse.tex
@@ -1,3 +1,4 @@
+% Negative regression: strict mode rejects the fuse-atom sugar command.
 \documentclass{standalone}
 \usepackage{tenkz}
 \makeatletter
@@ -7,9 +8,8 @@
 \makeatother
 \begin{document}
 \tenkzkernel
-\begin{tenkz}[rows={wire}, cols=2, bonds=none]
-  \tn[at=(1,1), name=A]{A}
-  \tn[at=(1,2), name=B]{B}
-  \tn[at={midway A and B}, wide=2, ports={90@2:physical}]{M}
+\tnset{strict}
+\begin{tenkz}[rows={op,op}, cols=2]
+  \tnfuse[at=(1,1), name=V]{V}
 \end{tenkz}
 \end{document}

--- a/tests/tenkz/kernel/regression/r_circle_wide_policy.tex
+++ b/tests/tenkz/kernel/regression/r_circle_wide_policy.tex
@@ -1,0 +1,14 @@
+% Regression: on a curved carrier a wide atom's policy legs leave along
+% each spanned station's own radial, and the boundary signature carries
+% those same slot-local bearings -- one entry per drawn index, not a
+% duplicated host bearing.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={op}, cols=4, frame=circle, bonds=none]
+  \tn[at=(1,1), name=W, skin=pill, wide=2, physical=up]{W}
+  \tn[at=(1,3), skin=dot]{}
+  \tn[at=(1,4), skin=dot]{}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_noncell_port_open_slots.tex
+++ b/tests/tenkz/kernel/regression/r_noncell_port_open_slots.tex
@@ -1,0 +1,12 @@
+% Regression: authored open ports on a midway-addressed spanning atom keep
+% their slots -- the span answers from the atom's own measured silhouette,
+% not from a frame cell -- and each unconsumed slot grows its open leg.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=1, bonds=none]
+  \tn[at=midway (1,1) and (2,1), name=f, skin=pill, wires=2,
+      ports={0@1:virtual, 0@2:virtual, 180:virtual}]{f}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_noncell_port_slot.tex
+++ b/tests/tenkz/kernel/regression/r_noncell_port_slot.tex
@@ -1,0 +1,16 @@
+% Regression: a slot span answers from the atom's own measured silhouette
+% wherever the atom stands, so a spanning atom at a midway address keeps
+% every slot for its wires and renders exactly as its cell-anchored
+% spelling (r_noncell_port_slot_cell).
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=2, bonds=none]
+  \tn[at=(1,2), name=A, skin=box]{A}
+  \tn[at=(2,2), name=B, skin=box]{B}
+  \tn[at=midway (1,1) and (2,1), name=e, skin=pill, wires=2]{e}
+  \tnwire{e.0@1}{A.180}
+  \tnwire{e.0@2}{B.180}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_noncell_port_slot_cell.tex
+++ b/tests/tenkz/kernel/regression/r_noncell_port_slot_cell.tex
@@ -1,0 +1,14 @@
+% Control for r_noncell_port_slot: the same picture with the spanning atom
+% cell-anchored; the pair must render byte-identical rasters.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=2, bonds=none]
+  \tn[at=(1,2), name=A, skin=box]{A}
+  \tn[at=(2,2), name=B, skin=box]{B}
+  \tn[at=(1,1), name=e, skin=pill, wires=2]{e}
+  \tnwire{e.0@1}{A.180}
+  \tnwire{e.0@2}{B.180}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_physical_policy_endpoint_order.tex
+++ b/tests/tenkz/kernel/regression/r_physical_policy_endpoint_order.tex
@@ -32,9 +32,9 @@
     \__tenkz_test_policy_endpoint_stroke:nn {#1}{#2}
   }
 \cs_new_eq:NN
-  \__tenkz_test_policy_endpoint_leg:nn
-  \__tenkz_kernel_r_leg:nn
-\cs_set_protected:Npn \__tenkz_kernel_r_leg:nn #1#2
+  \__tenkz_test_policy_endpoint_leg:nnn
+  \__tenkz_kernel_r_leg_slot:nnn
+\cs_set_protected:Npn \__tenkz_kernel_r_leg_slot:nnn #1#2#3
   {
     \__tenkz_model_get:nnN {#1} {name} \l_tmpa_tl
     \str_case:Vn \l_tmpa_tl
@@ -42,7 +42,7 @@
         {A}{\int_gincr:N \g__tenkz_test_policy_endpoint_leg_int}
         {B}{\int_gincr:N \g__tenkz_test_policy_endpoint_leg_int}
       }
-    \__tenkz_test_policy_endpoint_leg:nn {#1}{#2}
+    \__tenkz_test_policy_endpoint_leg:nnn {#1}{#2}{#3}
   }
 \AtEndDocument
   {

--- a/tests/tenkz/kernel/regression/r_policy_port_label_equality.tex
+++ b/tests/tenkz/kernel/regression/r_policy_port_label_equality.tex
@@ -23,12 +23,12 @@
     \__tenkz_test_policy_equal_labelnode:nnn {#1}{#2}{#3}
   }
 \cs_new_eq:NN
-  \__tenkz_test_policy_equal_leg:nn
-  \__tenkz_kernel_r_leg:nn
-\cs_set_protected:Npn \__tenkz_kernel_r_leg:nn #1#2
+  \__tenkz_test_policy_equal_leg:nnn
+  \__tenkz_kernel_r_leg_slot:nnn
+\cs_set_protected:Npn \__tenkz_kernel_r_leg_slot:nnn #1#2#3
   {
     \int_gincr:N \g__tenkz_test_policy_equal_leg_int
-    \__tenkz_test_policy_equal_leg:nn {#1}{#2}
+    \__tenkz_test_policy_equal_leg:nnn {#1}{#2}{#3}
   }
 \AtEndDocument
   {

--- a/tests/tenkz/kernel/regression/r_route_noncell_slots.tex
+++ b/tests/tenkz/kernel/regression/r_route_noncell_slots.tex
@@ -1,0 +1,15 @@
+% Regression: a route over a midway-addressed spanning atom meets one
+% distinct exit per slot, ordered by the slot's place on the span rather
+% than by record id -- the ports are declared in reverse slot order to
+% catch a centre-collapsed sort -- and renders exactly as its
+% cell-anchored spelling (r_route_noncell_slots_cell).
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=3, bonds=none]
+  \tn[at=midway (1,2) and (2,2), name=M, skin=pill, wires=2,
+      ports={180@2:virtual, 180@1:virtual}]{M}
+  \tnwire[kind=string, name=lift, route={w of M}, crossing=over]{open}{open}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_route_noncell_slots_cell.tex
+++ b/tests/tenkz/kernel/regression/r_route_noncell_slots_cell.tex
@@ -1,0 +1,13 @@
+% Control for r_route_noncell_slots: the same picture with the spanning
+% atom cell-anchored; the pair must render byte-identical rasters and
+% publish the same slot-ordered route exits.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire,wire}, cols=3, bonds=none]
+  \tn[at=(1,2), name=M, skin=pill, wires=2,
+      ports={180@2:virtual, 180@1:virtual}]{M}
+  \tnwire[kind=string, name=lift, route={w of M}, crossing=over]{open}{open}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_unmatched_port_legs.tex
+++ b/tests/tenkz/kernel/regression/r_unmatched_port_legs.tex
@@ -72,9 +72,9 @@
     \__tenkz_test_port_stroke:nn {#1}{#2}
   }
 \cs_new_eq:NN
-  \__tenkz_test_policy_port_leg:nn
-  \__tenkz_kernel_r_leg:nn
-\cs_set_protected:Npn \__tenkz_kernel_r_leg:nn #1#2
+  \__tenkz_test_policy_port_leg:nnn
+  \__tenkz_kernel_r_leg_slot:nnn
+\cs_set_protected:Npn \__tenkz_kernel_r_leg_slot:nnn #1#2#3
   {
     \__tenkz_model_get:nnN {#1} {name} \l_tmpa_tl
     \str_case:Vn \l_tmpa_tl
@@ -82,7 +82,7 @@
         {H}{ \int_gincr:N \g__tenkz_test_consumed_policy_leg_int }
         {J}{ \int_gincr:N \g__tenkz_test_consumed_policy_leg_int }
       }
-    \__tenkz_test_policy_port_leg:nn {#1}{#2}
+    \__tenkz_test_policy_port_leg:nnn {#1}{#2}{#3}
   }
 \cs_new_eq:NN
   \__tenkz_test_bonded_port_label:nn

--- a/tests/tenkz/kernel/regression/r_wide_policy_legs.tex
+++ b/tests/tenkz/kernel/regression/r_wide_policy_legs.tex
@@ -1,0 +1,18 @@
+% Regression: a wide atom answering the physical policy mints one leg per
+% face slot, named per spanned cell, and a wire consuming one slot retires
+% that slot's leg alone.  Renders exactly as the authored slot-port spelling
+% (r_wide_policy_ports).
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={op}, cols=3, physical=up]
+  \tn[at=(1,1), skin=pill, wide=3]{U}
+\end{tenkz}
+\mbox{p}
+\begin{tenkz}[rows={wire,wire}, cols=3, bonds=none]
+  \tn[at=(1,2), name=D, skin=box, ports={270:physical}]{D}
+  \tn[at=(2,1), name=U, skin=pill, wide=3, physical=up]{U}
+  \tnwire{U.90@2}{D.270}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_wide_policy_ports.tex
+++ b/tests/tenkz/kernel/regression/r_wide_policy_ports.tex
@@ -1,0 +1,19 @@
+% Control for r_wide_policy_legs: the same two pictures with the wide
+% atoms' policy answers spelled as authored slot ports; the pair must
+% render byte-identical rasters.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={op}, cols=3]
+  \tn[at=(1,1), skin=pill, wide=3,
+      ports={90@1:physical, 90@2:physical, 90@3:physical}]{U}
+\end{tenkz}
+\mbox{p}
+\begin{tenkz}[rows={wire,wire}, cols=3, bonds=none]
+  \tn[at=(1,2), name=D, skin=box, ports={270:physical}]{D}
+  \tn[at=(2,1), name=U, skin=pill, wide=3,
+      ports={90@1:physical, 90@2:physical, 90@3:physical}]{U}
+  \tnwire{U.90@2}{D.270}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/sugar/s11_kernel.tex
+++ b/tests/tenkz/kernel/sugar/s11_kernel.tex
@@ -1,0 +1,23 @@
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={op,op}, cols=3]
+  \tn[at=(1,1), name=e, skin=pill, wires=2]{e}
+  \tn[at=(1,2), skin=box, ports={90:physical:$i$}]{A}
+  \tn[at=(2,2), skin=box, ports={270:physical:$j$}]{\overline{A}}
+  \tn[at=(1,3), name=ei, skin=pill, wires=2]{e^{-1}}
+  \tnwire{open w}{e.180} \tnwire{ei.0}{open e}
+\end{tenkz}
+\mbox{p}
+\begin{tenkz}[rows={op,op}, cols=2]
+  \tn[at=(1,1), name=V, skin=tri, wires=2]{V}
+  \tn[at=(1,2), skin=box]{P}
+  \tn[at=(2,2), skin=box]{Q}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/sugar/s11_sugar.tex
+++ b/tests/tenkz/kernel/sugar/s11_sugar.tex
@@ -1,0 +1,23 @@
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={op,op}, cols=3]
+  \tnfuse[at=(1,1), name=e, skin=pill]{e}
+  \tn[at=(1,2), skin=box, ports={90:physical:$i$}]{A}
+  \tn[at=(2,2), skin=box, ports={270:physical:$j$}]{\overline{A}}
+  \tnfuse[at=(1,3), name=ei, skin=pill]{e^{-1}}
+  \tnwire{open w}{e.180} \tnwire{ei.0}{open e}
+\end{tenkz}
+\mbox{p}
+\begin{tenkz}[rows={op,op}, cols=2]
+  \tnfuse[at=(1,1), name=V]{V}
+  \tn[at=(1,2), skin=box]{P}
+  \tn[at=(2,2), skin=box]{Q}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1591,16 +1591,24 @@
 
 \cs_new_protected:Npn \__tenkz_kernel_signature_physical_axis:nn #1#2
   {
-    \__tenkz_kernel_policy_leg_exposed:nnT {#1}
-      { \str_if_eq:nnTF {#2} {n} {90} {270} }
+    \__tenkz_kernel_policy_leg_span:nN {#1}
+      \l__tenkz_kernel_policy_span_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_policy_span_tl
       {
-        \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2}
-          \l__tenkz_kernel_r_leg_turn_tl \l_tmpa_tl
-        \exp_args:NV \__tenkz_kernel_signature_bearing:nN
-          \l__tenkz_kernel_r_leg_turn_tl
-          \l__tenkz_kernel_port_face_tl
-        \seq_put_right:Ne \l__tenkz_kernel_emit_seq
-          { phys: \tl_use:N \l__tenkz_kernel_port_face_tl }
+        \int_step_inline:nn { \l__tenkz_kernel_policy_span_tl }
+          {
+            \__tenkz_kernel_policy_leg_exposed:nnnT {#1}
+              { \str_if_eq:nnTF {#2} {n} {90} {270} } {##1}
+              {
+                \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2}
+                  \l__tenkz_kernel_r_leg_turn_tl \l_tmpa_tl
+                \exp_args:NV \__tenkz_kernel_signature_bearing:nN
+                  \l__tenkz_kernel_r_leg_turn_tl
+                  \l__tenkz_kernel_port_face_tl
+                \seq_put_right:Ne \l__tenkz_kernel_emit_seq
+                  { phys: \tl_use:N \l__tenkz_kernel_port_face_tl }
+              }
+          }
       }
   }
 
@@ -4118,26 +4126,29 @@
       }
   }
 
-\cs_new_protected:Npn
-  \__tenkz_kernel_policy_leg_port_slot:nN #1#2
+% The policy slots on the outward face of #1: one per spanned cell, read
+% from the atom's own measured extent, so a wide atom answers the picture
+% policy with one leg per face slot exactly as an authored `90@1..@k` port
+% list would.  q_no_value when the atom renders no policy leg at all, and
+% one on a plane frame, whose policy is the per-member transverse axis
+% rather than an in-plane face slot.
+\tl_new:N \l__tenkz_kernel_policy_span_tl
+\cs_new_protected:Npn \__tenkz_kernel_policy_leg_span:nN #1#2
   {
     \tl_set:Nn #2 { \q_no_value }
     \__tenkz_kernel_policy_leg_renders:nT {#1}
       {
-        \__tenkz_model_get:nnN {#1} {wide}
-          \l__tenkz_kernel_port_span_tl
-        \quark_if_no_value:NT \l__tenkz_kernel_port_span_tl
-          { \tl_set:Nn \l__tenkz_kernel_port_span_tl {1} }
-        \int_if_odd:nT { \l__tenkz_kernel_port_span_tl }
+        \str_if_eq:eeTF { \__tenkz_kernel_r_frame_word: } {plane}
+          { \tl_set:Nn #2 {1} }
           {
-            \tl_set:Ne #2
-              { \int_eval:n { ( \l__tenkz_kernel_port_span_tl + 1 ) / 2 } }
+            \__tenkz_model_get:nnN {#1} {wide} #2
+            \quark_if_no_value:NT #2 { \tl_set:Nn #2 {1} }
           }
       }
   }
 
 \prg_new_protected_conditional:Npnn
-  \__tenkz_kernel_policy_leg_exposed:nn #1#2 { T, F, TF }
+  \__tenkz_kernel_policy_leg_exposed:nnn #1#2#3 { T, F, TF }
   {
     \__tenkz_kernel_policy_leg_renders:nTF {#1}
       {
@@ -4155,52 +4166,42 @@
               { \prg_return_true: }
           }
           {
-            \__tenkz_kernel_policy_leg_port_slot:nN {#1}
-              \l__tenkz_kernel_port_slot_tl
-            \quark_if_no_value:NTF \l__tenkz_kernel_port_slot_tl
-              {
-                % An even-width centre lies between numbered slots, so no
-                % authored port endpoint can consume this policy leg.
-                \prg_return_true:
-              }
-              {
-                \prop_if_in:NeTF
-                  \l__tenkz_kernel_port_external_consumer_prop
-                  {#1/#2/\l__tenkz_kernel_port_slot_tl}
-                  { \prg_return_false: }
-                  { \prg_return_true: }
-              }
+            \prop_if_in:NeTF
+              \l__tenkz_kernel_port_external_consumer_prop
+              {#1/#2/\int_eval:n {#3}}
+              { \prg_return_false: }
+              { \prg_return_true: }
           }
       }
       { \prg_return_false: }
   }
 
+% A slot span belongs to the atom's own measured silhouette, so it answers
+% wherever the atom stands: a spanning atom at a midway or on-wire address
+% keeps every slot its `wide=`/`wires=` extent declares, exactly as at a
+% frame cell.
 \cs_new_protected:Npn \__tenkz_kernel_port_validate_slot:n #1
   {
-    \__tenkz_kernel_atom_cell_placed:nTF {#1}
+    \exp_args:NV \__tenkz_kernel_r_face_side:n
+      \l__tenkz_kernel_port_face_tl
+    \str_case:VnF \l__tenkz_kernel_r_face_side_tl
       {
-        \exp_args:NV \__tenkz_kernel_r_face_side:n
-          \l__tenkz_kernel_port_face_tl
-        \str_case:VnF \l__tenkz_kernel_r_face_side_tl
+        {n}
           {
-            {n}
-              {
-                \__tenkz_model_get:nnN {#1} {wide}
-                  \l__tenkz_kernel_port_span_tl
-              }
-            {s}
-              {
-                \__tenkz_model_get:nnN {#1} {wide}
-                  \l__tenkz_kernel_port_span_tl
-              }
-          }
-          {
-            \__tenkz_model_get:nnN {#1} {wires}
+            \__tenkz_model_get:nnN {#1} {wide}
               \l__tenkz_kernel_port_span_tl
           }
-        \quark_if_no_value:NT \l__tenkz_kernel_port_span_tl
-          { \tl_set:Nn \l__tenkz_kernel_port_span_tl {1} }
+        {s}
+          {
+            \__tenkz_model_get:nnN {#1} {wide}
+              \l__tenkz_kernel_port_span_tl
+          }
       }
+      {
+        \__tenkz_model_get:nnN {#1} {wires}
+          \l__tenkz_kernel_port_span_tl
+      }
+    \quark_if_no_value:NT \l__tenkz_kernel_port_span_tl
       { \tl_set:Nn \l__tenkz_kernel_port_span_tl {1} }
     \int_compare:nNnT
       { \l__tenkz_kernel_port_slot_tl }
@@ -4392,40 +4393,47 @@
               }
           }
       }
-    % A flat or circular policy owns the centre slot of its local north/south
-    % face.  A plane policy instead owns the frame's independent transverse
-    % axis; no authored in-plane port can consume or refine that third axis.
+    % A flat or circular policy owns every slot of its local north/south
+    % face, one per spanned cell.  A plane policy instead owns the frame's
+    % independent transverse axis; no authored in-plane port can consume or
+    % refine that third axis.
     \str_if_eq:eeF { \__tenkz_kernel_r_frame_word: } {plane}
       {
         \__tenkz_model_map_ids:nn {atom}
+          { \__tenkz_kernel_port_policy_register_atom:n {##1} }
+      }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_port_policy_register_atom:n #1
+  {
+    \__tenkz_kernel_policy_leg_span:nN {#1}
+      \l__tenkz_kernel_policy_span_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_policy_span_tl
+      {
+        \__tenkz_model_get:nnN {#1} {physical}
+          \l__tenkz_kernel_atom_phys_tl
+        \quark_if_no_value:NF \l__tenkz_kernel_atom_phys_tl
           {
-            \__tenkz_kernel_policy_leg_port_slot:nN {##1}
-              \l__tenkz_kernel_port_slot_tl
-            \quark_if_no_value:NF \l__tenkz_kernel_port_slot_tl
+            \int_step_inline:nn { \l__tenkz_kernel_policy_span_tl }
               {
-                \__tenkz_model_get:nnN {##1} {physical}
-                  \l__tenkz_kernel_scratch_tl
-                \quark_if_no_value:NF \l__tenkz_kernel_scratch_tl
+                \str_case:Vn \l__tenkz_kernel_atom_phys_tl
                   {
-                    \str_case:Vn \l__tenkz_kernel_scratch_tl
+                    {up}
                       {
-                        {up}
-                          {
-                            \__tenkz_kernel_port_policy_register:nnn
-                              {##1} {90} {\l__tenkz_kernel_port_slot_tl}
-                          }
-                        {down}
-                          {
-                            \__tenkz_kernel_port_policy_register:nnn
-                              {##1} {270} {\l__tenkz_kernel_port_slot_tl}
-                          }
-                        {updown}
-                          {
-                            \__tenkz_kernel_port_policy_register:nnn
-                              {##1} {90} {\l__tenkz_kernel_port_slot_tl}
-                            \__tenkz_kernel_port_policy_register:nnn
-                              {##1} {270} {\l__tenkz_kernel_port_slot_tl}
-                          }
+                        \__tenkz_kernel_port_policy_register:nnn
+                          {#1} {90} {##1}
+                      }
+                    {down}
+                      {
+                        \__tenkz_kernel_port_policy_register:nnn
+                          {#1} {270} {##1}
+                      }
+                    {updown}
+                      {
+                        \__tenkz_kernel_port_policy_register:nnn
+                          {#1} {90} {##1}
+                        \__tenkz_kernel_port_policy_register:nnn
+                          {#1} {270} {##1}
                       }
                   }
               }
@@ -4888,43 +4896,55 @@
           }
       }
   }
-% One policy leg, on face #2 of atom #1.  The leg exists exactly when the
-% renderer will grow one, so the record and the ink answer the same question,
-% and it takes the canonical name the leg pass and the crossing grammar
-% already spell.
+% One policy leg per exposed slot, on face #2 of atom #1.  A leg exists
+% exactly when the renderer will grow one, so the records and the ink answer
+% the same question, and each takes the canonical name of the spanned cell
+% it leaves -- the name the leg pass and the crossing grammar already spell.
 \cs_new_protected:Npn \__tenkz_kernel_policy_leg_record:nn #1#2
   {
-    \__tenkz_kernel_policy_leg_exposed:nnT {#1}
-      { \str_if_eq:nnTF {#2} {n} {90} {270} }
+    \__tenkz_kernel_policy_leg_span:nN {#1}
+      \l__tenkz_kernel_policy_span_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_policy_span_tl
       {
-        \__tenkz_kernel_atom_rc:nNNN {#1}
-          \l__tenkz_kernel_leg_row_tl \l__tenkz_kernel_leg_col_tl
-          \l_tmpa_bool
-        \bool_if:NT \l_tmpa_bool
+        \int_step_inline:nn { \l__tenkz_kernel_policy_span_tl }
           {
-            \__tenkz_kernel_leg_name:nN {#2} \l__tenkz_kernel_leg_name_tl
-            \prop_if_in:NVTF \l__tenkz_kernel_named_prop
+            \__tenkz_kernel_policy_leg_exposed:nnnT {#1}
+              { \str_if_eq:nnTF {#2} {n} {90} {270} } {##1}
+              { \__tenkz_kernel_policy_leg_record_slot:nnn {#1} {#2} {##1} }
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_policy_leg_record_slot:nnn #1#2#3
+  {
+    \__tenkz_kernel_atom_rc:nNNN {#1}
+      \l__tenkz_kernel_leg_row_tl \l__tenkz_kernel_leg_col_tl
+      \l_tmpa_bool
+    \bool_if:NT \l_tmpa_bool
+      {
+        \tl_set:Ne \l__tenkz_kernel_leg_col_tl
+          { \int_eval:n { \l__tenkz_kernel_leg_col_tl + #3 - 1 } }
+        \__tenkz_kernel_leg_name:nN {#2} \l__tenkz_kernel_leg_name_tl
+        \prop_if_in:NVTF \l__tenkz_kernel_named_prop
+          \l__tenkz_kernel_leg_name_tl
+          {
+            \prop_get:NVN \l__tenkz_kernel_named_prop
+              \l__tenkz_kernel_leg_name_tl \l__tenkz_kernel_scratch_tl
+            \msg_error:nnee {tenkz}{kernel-name-collision}
+              { \tl_use:N \l__tenkz_kernel_leg_name_tl }
+              { \tl_use:N \l__tenkz_kernel_scratch_tl }
+          }
+          {
+            \__tenkz_model_record_wire:e
+              {
+                kind = index , origin = policy-leg ,
+                name = \tl_use:N \l__tenkz_kernel_leg_name_tl ,
+                host = #1 , face = #2 ,
+                row = \tl_use:N \l__tenkz_kernel_leg_row_tl ,
+                col = \tl_use:N \l__tenkz_kernel_leg_col_tl ,
+                port-type = physical
+              }
+            \exp_args:NV \__tenkz_kernel_register_last_wire:n
               \l__tenkz_kernel_leg_name_tl
-              {
-                \prop_get:NVN \l__tenkz_kernel_named_prop
-                  \l__tenkz_kernel_leg_name_tl \l__tenkz_kernel_scratch_tl
-                \msg_error:nnee {tenkz}{kernel-name-collision}
-                  { \tl_use:N \l__tenkz_kernel_leg_name_tl }
-                  { \tl_use:N \l__tenkz_kernel_scratch_tl }
-              }
-              {
-                \__tenkz_model_record_wire:e
-                  {
-                    kind = index , origin = policy-leg ,
-                    name = \tl_use:N \l__tenkz_kernel_leg_name_tl ,
-                    host = #1 , face = #2 ,
-                    row = \tl_use:N \l__tenkz_kernel_leg_row_tl ,
-                    col = \tl_use:N \l__tenkz_kernel_leg_col_tl ,
-                    port-type = physical
-                  }
-                \exp_args:NV \__tenkz_kernel_register_last_wire:n
-                  \l__tenkz_kernel_leg_name_tl
-              }
           }
       }
   }
@@ -8926,17 +8946,25 @@
 
 \cs_new_protected:Npn \__tenkz_kernel_route_policy_face_add:nnn #1#2#3
   {
-    \__tenkz_kernel_policy_leg_exposed:nnT {#1}
-      { \str_if_eq:nnTF {#2} {n} {90} {270} }
+    \__tenkz_kernel_policy_leg_span:nN {#1}
+      \l__tenkz_kernel_policy_span_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_policy_span_tl
       {
-        \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2}
-          \l__tenkz_kernel_r_leg_turn_tl
-          \l__tenkz_kernel_r_physical_anchor_tl
-        \exp_args:NV \__tenkz_kernel_route_page_bearing_side:nN
-          \l__tenkz_kernel_r_leg_turn_tl
-          \l__tenkz_kernel_port_face_tl
-        \str_if_eq:VnT \l__tenkz_kernel_port_face_tl {#3}
-          { \__tenkz_kernel_route_face_add:nn {#1} {#3} }
+        \int_step_inline:nn { \l__tenkz_kernel_policy_span_tl }
+          {
+            \__tenkz_kernel_policy_leg_exposed:nnnT {#1}
+              { \str_if_eq:nnTF {#2} {n} {90} {270} } {##1}
+              {
+                \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2}
+                  \l__tenkz_kernel_r_leg_turn_tl
+                  \l__tenkz_kernel_r_physical_anchor_tl
+                \exp_args:NV \__tenkz_kernel_route_page_bearing_side:nN
+                  \l__tenkz_kernel_r_leg_turn_tl
+                  \l__tenkz_kernel_port_face_tl
+                \str_if_eq:VnT \l__tenkz_kernel_port_face_tl {#3}
+                  { \__tenkz_kernel_route_face_add:nnn {#1} {#3} {##1} }
+              }
+          }
       }
   }
 
@@ -9002,7 +9030,7 @@
           }
       }
   }
-\cs_new_protected:Npn \__tenkz_kernel_route_face_add:nn #1#2
+\cs_new_protected:Npn \__tenkz_kernel_route_face_add:nnn #1#2#3
   {
     % an ellipsis occupies its cell and grows no leg
     \__tenkz_model_get:nnN {#1} {skin} \l__tenkz_kernel_ro_b_tl
@@ -9013,6 +9041,9 @@
           \l__tenkz_kernel_ro_bool
         \bool_if:NT \l__tenkz_kernel_ro_bool
           {
+            % the leg of slot #3 leaves the spanned cell #3 - 1 columns east
+            \tl_set:Ne \l__tenkz_kernel_ro_col_tl
+              { \int_eval:n { \l__tenkz_kernel_ro_col_tl + #3 - 1 } }
             \tl_set:Ne \l__tenkz_kernel_ro_tl
               {
                 leg - #2 - \tl_use:N \l__tenkz_kernel_ro_row_tl
@@ -10477,11 +10508,47 @@
               }
           }
           {
-            % A non-cell atom still owns its first port on every face.  Its
-            % center supplies the transverse coordinate; the glyph anchor
-            % supplies the face-normal coordinate during ink.
-            \__tenkz_geom_place_rel:nVee {#1}
-              \l__tenkz_kernel_r_tl {0} {0}
+            % A non-cell atom owns every slot its own measured extent
+            % declares: the slot walks the span symmetrically about the
+            % atom's centre, along its local span axis, at the same cell
+            % step a frame-anchored spanning atom gives its slots.  The
+            % glyph anchor still supplies the face-normal coordinate
+            % during ink.
+            \__tenkz_kernel_r_span:nNN { \tl_use:N \l__tenkz_kernel_r_tl }
+              \l__tenkz_kernel_r_b_tl \l__tenkz_kernel_r_c_tl
+            \exp_args:Ne \__tenkz_kernel_r_face_side:n
+              { \__tenkz_kernel_r_item:nn {#1} {face} }
+            \exp_args:Ne \__tenkz_kernel_r_turn:nN
+              { \tl_use:N \l__tenkz_kernel_r_tl } \l__tenkz_kernel_r_row_tl
+            \str_case:VnTF \l__tenkz_kernel_r_face_side_tl
+              {
+                {e} { }
+                {w} { }
+              }
+              {
+                % e/w faces: the slot walks the rows, along local south
+                \__tenkz_geom_place_rel:nVee {#1} \l__tenkz_kernel_r_tl
+                  { \fp_eval:n { \l__tenkz_kernel_r_row_tl - 90 } }
+                  {
+                    \fp_eval:n
+                      {
+                        \__tenkz_kernel_r_item:nn {#1} {slot}
+                        - ( \l__tenkz_kernel_r_c_tl + 1 ) / 2
+                      }
+                  }
+              }
+              {
+                % n/s faces: the slot walks the columns, along local east
+                \__tenkz_geom_place_rel:nVee {#1} \l__tenkz_kernel_r_tl
+                  { \tl_use:N \l__tenkz_kernel_r_row_tl }
+                  {
+                    \fp_eval:n
+                      {
+                        \__tenkz_kernel_r_item:nn {#1} {slot}
+                        - ( \l__tenkz_kernel_r_b_tl + 1 ) / 2
+                      }
+                  }
+              }
           }
       }
   }
@@ -11478,21 +11545,13 @@
                 \str_case:Vn \l__tenkz_kernel_r_tl
                   {
                     {up}
-                      {
-                        \__tenkz_kernel_policy_leg_exposed:nnT {##1} {90}
-                          { \__tenkz_kernel_r_leg:nn {##1} {n} }
-                      }
+                      { \__tenkz_kernel_r_leg:nn {##1} {n} }
                     {down}
-                      {
-                        \__tenkz_kernel_policy_leg_exposed:nnT {##1} {270}
-                          { \__tenkz_kernel_r_leg:nn {##1} {s} }
-                      }
+                      { \__tenkz_kernel_r_leg:nn {##1} {s} }
                     {updown}
                       {
-                        \__tenkz_kernel_policy_leg_exposed:nnT {##1} {90}
-                          { \__tenkz_kernel_r_leg:nn {##1} {n} }
-                        \__tenkz_kernel_policy_leg_exposed:nnT {##1} {270}
-                          { \__tenkz_kernel_r_leg:nn {##1} {s} }
+                        \__tenkz_kernel_r_leg:nn {##1} {n}
+                        \__tenkz_kernel_r_leg:nn {##1} {s}
                       }
                   }
               }
@@ -11754,16 +11813,45 @@
       }
   }
 
+% One ink walk per exposed slot: the legs of a spanning atom leave one per
+% spanned cell, exactly where the same slots' authored ports would.
 \cs_new_protected:Npn \__tenkz_kernel_r_leg:nn #1#2
+  {
+    \__tenkz_kernel_policy_leg_span:nN {#1}
+      \l__tenkz_kernel_policy_span_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_policy_span_tl
+      {
+        \int_step_inline:nn { \l__tenkz_kernel_policy_span_tl }
+          {
+            \__tenkz_kernel_policy_leg_exposed:nnnT {#1}
+              { \str_if_eq:nnTF {#2} {n} {90} {270} } {##1}
+              { \__tenkz_kernel_r_leg_slot:nnn {#1} {#2} {##1} }
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_leg_slot:nnn #1#2#3
   {
     \__tenkz_kernel_atom_rc:nNNN {#1}
       \l__tenkz_kernel_leg_row_tl \l__tenkz_kernel_leg_col_tl \l_tmpa_bool
     \bool_if:NT \l_tmpa_bool
       {
+        \tl_set:Ne \l__tenkz_kernel_leg_col_tl
+          { \int_eval:n { \l__tenkz_kernel_leg_col_tl + #3 - 1 } }
         \__tenkz_kernel_leg_name:nN {#2} \l__tenkz_kernel_leg_name_tl
         \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2}
           \l__tenkz_kernel_leg_dir_tl
           \l__tenkz_kernel_r_physical_anchor_tl
+        % A spanning atom's non-first slots read the frame at their own
+        % spanned cell: its local bearing and its cell point, which is where
+        % the same slot's authored port stands.
+        \int_compare:nNnT { \l__tenkz_kernel_policy_span_tl } > {1}
+          {
+            \__tenkz_geom_local_bearing:nnnnN {kpic}
+              { \l__tenkz_kernel_leg_row_tl }
+              { \l__tenkz_kernel_leg_col_tl }
+              { \str_if_eq:nnTF {#2} {n} {90} {270} }
+              \l__tenkz_kernel_leg_dir_tl
+          }
         \bool_set_false:N \l__tenkz_kernel_leg_planned_bool
         \bool_if:NT \l__tenkz_kernel_r_basis_plane_bool
           {
@@ -11792,8 +11880,17 @@
               }
           }
           {
-            \__tenkz_kernel_r_xy:nNN {#1}
-              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+            \int_compare:nNnTF { \l__tenkz_kernel_policy_span_tl } > {1}
+              {
+                \__tenkz_kernel_r_frame_xy:nnNN
+                  { \l__tenkz_kernel_leg_row_tl }
+                  { \l__tenkz_kernel_leg_col_tl }
+                  \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+              }
+              {
+                \__tenkz_kernel_r_xy:nNN {#1}
+                  \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+              }
           }
         \fp_set:Nn \l__tenkz_kernel_r_reach_fp
           { \__tenkz_metric_ratio:n {physleg} }
@@ -16918,6 +17015,16 @@
     \__tenkz_kernel_sugar:n {tnprose}
     \__tenkz_kernel_tnmark:nnn { form = prose } { panel } {#1}
   }
+% The prelude fuse atom of the sugar ledger: a `wires=2` atom the frame
+% bonds, wearing the ledger's `tri` silhouette until an author's `skin=`
+% overrides it.  Authored keys follow the preset, so any of the three
+% defaults yields to the author's spelling.
+\NewDocumentCommand \__tenkz_kernel_tnfuse_cmd { O{} m }
+  {
+    \__tenkz_kernel_sugar:n {tnfuse}
+    \__tenkz_kernel_tn:nn { skin = tri , wires = 2 , #1 } {#2}
+    \ignorespaces
+  }
 
 % The picture body is captured, then executed.  A frame-collecting class --
 % beamer is the standing example -- tokenizes a frame body long before any
@@ -16973,6 +17080,7 @@
     \cs_set_eq:NN \tndeclare \__tenkz_kernel_tndeclare_cmd
     \cs_set_eq:NN \tnbond \__tenkz_kernel_tnbond_cmd
     \cs_set_eq:NN \tnprose \__tenkz_kernel_tnprose_cmd
+    \cs_set_eq:NN \tnfuse \__tenkz_kernel_tnfuse_cmd
   }
 
 \ExplSyntaxOff

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1600,8 +1600,8 @@
             \__tenkz_kernel_policy_leg_exposed:nnnT {#1}
               { \str_if_eq:nnTF {#2} {n} {90} {270} } {##1}
               {
-                \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2}
-                  \l__tenkz_kernel_r_leg_turn_tl \l_tmpa_tl
+                \__tenkz_kernel_policy_slot_bearing:nnnN {#1} {#2} {##1}
+                  \l__tenkz_kernel_r_leg_turn_tl
                 \exp_args:NV \__tenkz_kernel_signature_bearing:nN
                   \l__tenkz_kernel_r_leg_turn_tl
                   \l__tenkz_kernel_port_face_tl
@@ -4143,6 +4143,35 @@
           {
             \__tenkz_model_get:nnN {#1} {wide} #2
             \quark_if_no_value:NT #2 { \tl_set:Nn #2 {1} }
+          }
+      }
+  }
+
+% The page bearing of slot #3's policy leg on face #2 (n|s) of atom #1,
+% left in #4.  A spanning atom on a curved carrier grows each leg along its
+% own spanned cell's local normal, so every consumer of the bearing -- the
+% ink, the boundary signature, the route-face classifier -- reads this one
+% production and agrees with the drawn indices.  The caller has resolved
+% the atom's span into \l__tenkz_kernel_policy_span_tl; a span of one keeps
+% the host's own axis, plane carriers included.
+\cs_new_protected:Npn \__tenkz_kernel_policy_slot_bearing:nnnN #1#2#3#4
+  {
+    \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2} #4
+      \l__tenkz_kernel_r_physical_anchor_tl
+    \int_compare:nNnT { \l__tenkz_kernel_policy_span_tl } > {1}
+      {
+        \__tenkz_kernel_atom_rc:nNNN {#1}
+          \l__tenkz_kernel_leg_row_tl \l__tenkz_kernel_leg_col_tl
+          \l_tmpa_bool
+        \bool_if:NT \l_tmpa_bool
+          {
+            \tl_set:Ne \l__tenkz_kernel_leg_col_tl
+              { \int_eval:n { \l__tenkz_kernel_leg_col_tl + #3 - 1 } }
+            \__tenkz_geom_local_bearing:nnnnN {kpic}
+              { \l__tenkz_kernel_leg_row_tl }
+              { \l__tenkz_kernel_leg_col_tl }
+              { \str_if_eq:nnTF {#2} {n} {90} {270} }
+              #4
           }
       }
   }
@@ -8955,9 +8984,8 @@
             \__tenkz_kernel_policy_leg_exposed:nnnT {#1}
               { \str_if_eq:nnTF {#2} {n} {90} {270} } {##1}
               {
-                \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2}
+                \__tenkz_kernel_policy_slot_bearing:nnnN {#1} {#2} {##1}
                   \l__tenkz_kernel_r_leg_turn_tl
-                  \l__tenkz_kernel_r_physical_anchor_tl
                 \exp_args:NV \__tenkz_kernel_route_page_bearing_side:nN
                   \l__tenkz_kernel_r_leg_turn_tl
                   \l__tenkz_kernel_port_face_tl
@@ -9131,7 +9159,16 @@
       }
       {
         % A derived carrier has no integer cell, but its resolved port still
-        % has one logical position in the picture frame.
+        % has one logical position in the picture frame.  The port's slot
+        % walks the span symmetrically about that centre, at the same cell
+        % step a frame-anchored spanning atom gives its slots, so a route
+        % meets one distinct exit per slot here too.
+        \__tenkz_kernel_r_span:nNN {#1}
+          \l__tenkz_kernel_ro_b_tl \l__tenkz_kernel_ro_tl
+        \__tenkz_model_get:nnN {#3} {port-slot}
+          \l__tenkz_kernel_port_slot_tl
+        \quark_if_no_value:NT \l__tenkz_kernel_port_slot_tl
+          { \tl_set:Nn \l__tenkz_kernel_port_slot_tl {1} }
         \__tenkz_kernel_r_xy:nNN {#1}
           \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
         \__tenkz_geom_unapply:nnnNN {kpic}
@@ -9146,18 +9183,49 @@
           {
             \str_case:nnF {#2}
               {
-                {e}{ \l__tenkz_kernel_ro_row_tl }
-                {w}{ \l__tenkz_kernel_ro_row_tl }
+                {e}
+                  {
+                    \l__tenkz_kernel_ro_row_tl
+                    + \l__tenkz_kernel_port_slot_tl
+                    - ( \l__tenkz_kernel_ro_tl + 1 ) / 2
+                  }
+                {w}
+                  {
+                    \l__tenkz_kernel_ro_row_tl
+                    + \l__tenkz_kernel_port_slot_tl
+                    - ( \l__tenkz_kernel_ro_tl + 1 ) / 2
+                  }
               }
-              { \l__tenkz_kernel_ro_col_tl }
+              {
+                \l__tenkz_kernel_ro_col_tl
+                + \l__tenkz_kernel_port_slot_tl
+                - ( \l__tenkz_kernel_ro_b_tl + 1 ) / 2
+              }
           }
           {
-            \str_case:nnF {#2}
+            \str_case:nn {#2}
               {
-                {e}{ \l__tenkz_kernel_ro_col_tl }
-                {w}{ \l__tenkz_kernel_ro_col_tl }
+                {n}
+                  {
+                    \l__tenkz_kernel_ro_row_tl
+                    - ( \l__tenkz_kernel_ro_tl - 1 ) / 2
+                  }
+                {s}
+                  {
+                    \l__tenkz_kernel_ro_row_tl
+                    + ( \l__tenkz_kernel_ro_tl - 1 ) / 2
+                  }
+                {e}
+                  {
+                    \l__tenkz_kernel_ro_col_tl
+                    + ( \l__tenkz_kernel_ro_b_tl - 1 ) / 2
+                  }
+                {w}
+                  {
+                    \l__tenkz_kernel_ro_col_tl
+                    - ( \l__tenkz_kernel_ro_b_tl - 1 ) / 2
+                  }
               }
-              { \l__tenkz_kernel_ro_row_tl }
           }
       }
   }
@@ -11838,20 +11906,12 @@
         \tl_set:Ne \l__tenkz_kernel_leg_col_tl
           { \int_eval:n { \l__tenkz_kernel_leg_col_tl + #3 - 1 } }
         \__tenkz_kernel_leg_name:nN {#2} \l__tenkz_kernel_leg_name_tl
-        \__tenkz_kernel_r_physical_axis:nnNN {#1} {#2}
+        % A spanning atom's slots read the frame at their own spanned cell:
+        % its local bearing and its cell point, which is where the same
+        % slot's authored port stands.  The one bearing production keeps the
+        % ink, the signature, and the route classifier in agreement.
+        \__tenkz_kernel_policy_slot_bearing:nnnN {#1} {#2} {#3}
           \l__tenkz_kernel_leg_dir_tl
-          \l__tenkz_kernel_r_physical_anchor_tl
-        % A spanning atom's non-first slots read the frame at their own
-        % spanned cell: its local bearing and its cell point, which is where
-        % the same slot's authored port stands.
-        \int_compare:nNnT { \l__tenkz_kernel_policy_span_tl } > {1}
-          {
-            \__tenkz_geom_local_bearing:nnnnN {kpic}
-              { \l__tenkz_kernel_leg_row_tl }
-              { \l__tenkz_kernel_leg_col_tl }
-              { \str_if_eq:nnTF {#2} {n} {90} {270} }
-              \l__tenkz_kernel_leg_dir_tl
-          }
         \bool_set_false:N \l__tenkz_kernel_leg_planned_bool
         \bool_if:NT \l__tenkz_kernel_r_basis_plane_bool
           {


### PR DESCRIPTION
Closes LionSR/TNLean#5624; execution tracker LionSR/tenkz#13. The three documented idioms PR LionSR/TNLean#5622 had to expand by hand — the same defect class as the nine fixed during the conciseness campaign — now draw as documented, and the hand-spelled blueprint expansions shrink back to their sugar. One PR rather than three: the fuse sugar expands into a `wires=2` spanning atom whose slots the other two fixes govern, all three share the sugar/regression probe wiring and the SHRINK/DISPOSITIONS ledger entries, and the demand evidence (the re-sugared pictures) exercises them together.

## Per-fix mechanism

1. **`\tnfuse` has no kernel-tier placement** (`TKZ-KERNEL-RENDER-UNPLACED`). The kernel now binds `\tnfuse` under `\tenkzkernel` exactly as it binds `\tnbond`: `\__tenkz_kernel_tnfuse_cmd` expands to `\tn[skin=tri, wires=2, <keys>]{m}` — the §9 prelude fuse atom, its split side bonded by the frame — with authored keys following the preset so `skin=pill` overrides the ledger's `tri`. `\tnset{strict}` rejects it through the shared sugar guard (`n_strict_tnfuse`).
2. **`wires=` slot spans resolved only at a frame cell** (`TKZ-PORT-SLOT` at a `midway` address). `\__tenkz_kernel_port_validate_slot:n` now reads the span from the atom's own `wide=`/`wires=` extent unconditionally instead of forcing span 1 off-cell, and `\__tenkz_kernel_r_port:n`'s non-cell branch walks the slot symmetrically about the atom's centre along its local span axis — the same cell step a frame-anchored spanning atom gives its slots — instead of collapsing every slot onto the centre.
3. **A wide atom's `physical=` policy minted only the centre port.** The centre-slot helper became `\__tenkz_kernel_policy_leg_span:nN`, and the policy's four consumers — identity registration, the leg records, the leg ink walk, and the boundary signature — loop one slot per spanned cell. A `wide=3` atom answering the policy mints `leg-n-r-c .. leg-n-r-(c+2)`, one named record and one leg per spanned cell, each individually consumable by a wire at `U.90@k`, with the boundary counting `phys:n` three times — exactly the authored `90@1..@3` port list, pixel-for-pixel. Spans of one keep the previous code path byte-for-byte; a plane frame keeps its per-member transverse axis.

## Blueprint line delta: −2

- `ch20_mpdo_foundations.tex` (LPDO RHS): the wedges respell as `\tnfuse[at=(1,1), name=e, skin=pill]{e}` beside their boundary wires; 5 additions vs 6 deletions across the picture (8 → 7 source lines).
- `ch20_mpdo_canonical_forms_intro_finite_separation.tex` (U M̃ U† stack): the three-slot port lists respell as `physical=up` / `physical=down`; 8 → 7 source lines, and the two-line `U^\dagger` spelling returns to one.
- Net −2 (4 insertions, 6 deletions), reversing the growth the two gap-carrying pictures paid in LionSR/TNLean#5622. Issue LionSR/TNLean#5624's acceptance names `ch20_mpdo_canonical_forms_first_site_contractions.tex`, but the wave's hand expansions live in `..._intro_finite_separation.tex` (see LionSR/TNLean#5622's diff); the first-site file contains none.

## Render evidence

Both re-sugared pictures were compiled through the pipeline preamble (`macros/common` + `tenkz` + `macros/diagrams`, under `\tenkzkernel`) before and after the change and rasterized at 200 dpi with `pdftocairo`: `lpdo_orig.png` vs `lpdo_new.png` and `umu_orig.png` vs `umu_new.png` compare **byte-identical** (`cmp`), and both event streams audit clean (`tenkz_audit.py`, 0 advisories). The sugar-pair probe additionally pins the fuse pair (`s11_sugar`/`s11_kernel`, mirroring the LPDO RHS plus a bare-preset wedge) byte-identical in events and at 300 dpi, and the new regression pairs pin the other two fixes in events and same-session rasters: `r_noncell_port_slot` vs `r_noncell_port_slot_cell` (a midway fuse renders exactly as its cell anchor), `r_wide_policy_legs` vs `r_wide_policy_ports` (policy legs render exactly as authored slot ports, consumed slot included), `r_noncell_port_open_slots` (authored off-cell slot ports and their boundary).

## Ledgers and gates

- `docs/tenkz/LANGUAGE-1.0.md`: the `\tnfuse` and `physical=` §9 rows state their now-real expansions; §3 states that a slot span answers from the atom's own measured extent wherever it stands.
- `docs/tenkz/SHRINK.md`: appended 2026-08-09 session; census stable (no registry change — the kernel binds the existing command), `flag:consumers:command:tnfuse` verdict updated to the landed kernel reading with its two kernel-tier blueprint consumers.
- `docs/tenkz/DISPOSITIONS.md`: line re-pins only; counts unchanged (both pictures stay `P-grid`). The checker learns that a kernel-bound sugar command (`tnfuse`, `tnbond`) owes no migration work under the switch — the same doctrine signed keys already enjoy — with new classifier tests.
- `n_noncell_port_slot` (the negative pinning the old refusal) is retired in favour of the positive regressions above; three leg-instrumentation fixtures re-hook the per-slot walk (`r_leg_slot:nnn`), preserving their guarded contracts.
- Passing (re-run after the rebase onto LionSR/TNLean#5626 and the review follow-up commit): `tenkz_kernel_probes.sh` (141 regressions, 11 sugar pairs in events and pixels, 12 kernel record streams and pixels byte-identical — no re-pin), `tenkz_golden.sh --check` (211 streams byte-identical), `tenkz_shrink.py gate` (census stable at 177, all 161 flags carry verdicts), `check_tenkz_dispositions.py` + its tests (201 occurrences, 211 fixtures reconcile), `tenkz_pixelpair.sh origin/main` (4 pages byte-identical at 300 dpi — the manifest lost a page to LionSR/TNLean#5626's fixture retirement), `test_tenkz_kernel_audit.py`, `test_tenkz_equation_audit.py`, `test_tenkz_pic.py`, `test_tenkz_language.py`, `tenkz_lint.py` on both chapters.

## Review follow-up

The second commit answers the two review threads with one span/bearing discipline: `route_port_target_add`'s derived-carrier branch walks a spanning atom's slots about its centre exactly as the cell branch walks them from its anchor (regression pair `r_route_noncell_slots` / `r_route_noncell_slots_cell`: reverse-order slot ports, identical slot-ordered crossings, byte-identical rasters), and the new single bearing production `policy_slot_bearing` serves the leg ink, the boundary signature, and the route-face classifier alike, so a wide atom on a curved carrier reports the slot-local bearings it draws (`r_circle_wide_policy`: signature `phys:e, phys:n`, previously a duplicated `phys:n, phys:n`). Both re-sugared blueprint pictures re-verified byte-identical at 200 dpi after the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tenkz kernel port/policy/leg/route logic in `tenkz-kernel.code.tex`, but behavior is pinned by byte-identical sugar pairs, raster regressions, and extended probe scripts.
> 
> **Overview**
> Closes the mop-up idioms from the tenkz 1.0 contract: **`\tnfuse`** is kernel-bound (like `\tnbond`) to the prelude fuse atom `\tn[skin=tri, wires=2, …]`, with strict-mode rejection and an **s11** sugar-pair probe.
> 
> **Slot spans** now follow each atom’s `wide=` / `wires=` extent even at `midway` / on-wire addresses, so authored `@k` ports, wires, routes, and open legs match a cell-anchored spelling (new regression pairs). **`physical=` on a wide atom** mints one policy leg and boundary entry per face slot, consumable at `U.90@k` like an explicit port list; registration, leg records, ink, signatures, and route faces all loop per slot via **`policy_leg_span`** and **`policy_slot_bearing`** (including correct slot-local bearings on circle frames).
> 
> Blueprint **ch20** LPDO and finite-separation figures shrink back to `\tnfuse` and `physical=up` / `down` instead of hand-expanded ports. **LANGUAGE-1.0**, **SHRINK**, disposition checker (**kernel-bound sugar** exempt from `C-record`), and kernel probes gain the new fixtures and the retired **`n_noncell_port_slot`** negative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2daf262d0df4aa49f975c18eef37155c8a5044f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

