### PR TITLE
doc(blueprint): sync Case-I singleton hypotheses

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -985,12 +985,25 @@
     \uses{def:mpdo_active_sector_trace_matrix, def:nt_cpsv,
       thm:mpdo_active_trace_matrix_literal_zcl_powers,
       thm:mpdo_overlap_formula}
-    Let ${\cal K}$ be an MPO tensor with a physical-sector factorization
-    and sector weights $p_k$, such that every neighboring operator is
-    positive semidefinite, the left tensor of every zero-weight sector
-    vanishes, and the underlying tensor is normal in the sense of
-    Definition~\ref{def:nt_cpsv}. Then the active sector set has exactly
-    one element:
+    Let ${\cal K}$ be an MPO tensor of positive bond dimension $D$ with a
+    physical-sector factorization and sector weights $p_k$, and let
+    $I_*=\{k:p_k\ne0\}$. Suppose that every neighboring operator
+    $\eta_{k,h}$ is positive semidefinite,
+    \begin{align}
+        \spn_{\C}\{A_{k;x,y}:k\in I_*\}&=\MN{D},
+        \notag
+    \end{align}
+    and, for every $k\in I_*$, some virtual matrix $A_{k;x,y}$ is nonzero.
+    Suppose also that every nonzero $\eta_{k,h}$ with $k,h\in I_*$ admits
+    $j\in I_*$ such that $\eta_{h,j}\ne0$ and $\eta_{j,k}\ne0$, that the
+    physical-trace transfer is literally idempotent,
+    \begin{align}
+        \mathcal T_{\cal K}^2&=\mathcal T_{\cal K},
+        \notag
+    \end{align}
+    that $p_k=0$ implies that the left tensor of sector $k$ vanishes, that
+    the underlying tensor is normal in the sense of
+    Definition~\ref{def:nt_cpsv}, and that $I_*$ is nonempty. Then
     \begin{align}
         \left|I_*\right|&=1.
         \notag
@@ -1002,7 +1015,10 @@
 
 \begin{proof}
     \leanok
-    \uses{def:mpdo_active_sector_trace_matrix, thm:mpdo_overlap_formula}
+    \uses{def:mpdo_active_sector_trace_matrix,
+      thm:mpdo_active_trace_matrix_literal_zcl_powers,
+      thm:mpdo_active_sector_three_step_return_and_primitivity,
+      thm:mpdo_overlap_formula}
     By contradiction: suppose $|I_*|\geq2$. The overlap formula and the
     normal self-overlap limit
     (\cite[lines~1080--1100]{Cirac2016MPDO_arXiv}) give
@@ -1022,7 +1038,25 @@
     \leanok
     \uses{thm:mpdo_active_sector_singleton,
       thm:mpdo_active_trace_matrix_literal_zcl_powers}
-    Under the hypotheses of Theorem~\ref{thm:mpdo_active_sector_singleton},
+    Let ${\cal K}$ be an MPO tensor of positive bond dimension $D$ with a
+    physical-sector factorization and sector weights $p_k$, and let
+    $I_*=\{k:p_k\ne0\}$. Suppose that every neighboring operator
+    $\eta_{k,h}$ is positive semidefinite,
+    \begin{align}
+        \spn_{\C}\{A_{k;x,y}:k\in I_*\}&=\MN{D},
+        \notag
+    \end{align}
+    and, for every $k\in I_*$, some virtual matrix $A_{k;x,y}$ is nonzero.
+    Suppose also that every nonzero $\eta_{k,h}$ with $k,h\in I_*$ admits
+    $j\in I_*$ such that $\eta_{h,j}\ne0$ and $\eta_{j,k}\ne0$, that the
+    physical-trace transfer is literally idempotent,
+    \begin{align}
+        \mathcal T_{\cal K}^2&=\mathcal T_{\cal K},
+        \notag
+    \end{align}
+    that $p_k=0$ implies that the left tensor of sector $k$ vanishes, that
+    the underlying tensor is normal in the sense of
+    Definition~\ref{def:nt_cpsv}, and that $I_*$ is nonempty. Then
     \begin{align}
         \left(T^*\right)^2&=T^*.
         \notag
@@ -1034,7 +1068,8 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_active_sector_singleton}
+    \uses{thm:mpdo_active_sector_singleton,
+      thm:mpdo_active_trace_matrix_literal_zcl_powers}
     On the singleton active sector set, $T^*$ is a scalar $t$. Stabilization
     gives $t^2=t^3$, and positivity of $(T^*)^2$ gives $t^2>0$, hence
     $t=1$ and $t^2=t$.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -1016,6 +1016,7 @@
 \begin{proof}
     \leanok
     \uses{def:mpdo_active_sector_trace_matrix,
+      lem:mpdo_active_sector_trace_sq_matrix,
       thm:mpdo_active_trace_matrix_literal_zcl_powers,
       thm:mpdo_active_sector_three_step_return_and_primitivity,
       thm:mpdo_overlap_formula}


### PR DESCRIPTION
## What changed

- states all hypotheses of `card_activeSector_eq_one_of_literal_ZCL` in the Chapter 21 theorem: positive bond dimension, positivity, full active one-site span, a nonzero virtual matrix per active sector, triangular return, literal ZCL, inactive-left vanishing, normality, and active-sector nonemptiness;
- repeats the exact hypothesis boundary for `activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL` instead of hiding it behind an informal cross-reference;
- adds the existing blueprint dependencies for the literal-ZCL powers and active-sector primitivity results.

The issue also names `trace_pow_similarity_squared_diagonal` and `Matrix.trace_pow_tendsto_zero_of_nonneg_le_hadamard_self` as requested `\uses` entries. Those Lean declarations currently have no blueprint theorem labels, so this PR does not invent dangling labels; their mathematical roles remain stated explicitly in the proof.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` — 6542/6542 synchronized at this branch base;
- targeted declaration resolution for both `\lean{}` tags — passed;
- two direct `lualatex` passes for `blueprint/src/print.tex` with `TEXINPUTS="../../tex/tenkz//:"` — passed;
- `git diff --check` — passed;
- only the intended Chapter 21 source file changed; generated artifacts removed.

Closes #5556. Advances #5404 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX sync in the blueprint; no changes to formal proofs or application code.
> 
> **Overview**
> Aligns the Chapter 21 blueprint with the Lean declarations `card_activeSector_eq_one_of_literal_ZCL` and `activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL` by spelling out every hypothesis in the theorem statements instead of a short informal bundle.
> 
> For **the active sector is unique** and **the Case-I relation \((T^*)^2=T^*\)**, the text now explicitly requires positive bond dimension \(D\), PSD neighboring operators \(\eta_{k,h}\), \(\spn_{\C}\{A_{k;x,y}:k\in I_*\}=\MN{D}\), a nonzero virtual matrix per active sector, triangle closure on nonzero \(\eta\) edges, literal idempotent physical-trace transfer \(\mathcal T_{\cal K}^2=\mathcal T_{\cal K}\), vanishing left tensors on zero-weight sectors, normality (`def:nt_cpsv`), and nonempty \(I_*\). The second theorem no longer points only to the first via “under the hypotheses of …”; it repeats the same boundary.
> 
> Proof **`\uses`** lines are updated to cite `lem:mpdo_active_sector_trace_sq_matrix`, `thm:mpdo_active_sector_three_step_return_and_primitivity`, and `thm:mpdo_active_trace_matrix_literal_zcl_powers` where the blueprint already tracks those results. No new dangling labels for Lean lemmas without blueprint tags (as noted in the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b102dec9747409c8a1ae2c082aaa971679cf2f4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->