### PR TITLE
feat(MPDO): prove the Case-I rectangular relation

### DIFF
--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -66,11 +66,12 @@ conjugation, entrywise by `P ⊙ P`; if more than one sector were active,
 `tr(S^N) → 0` (`Matrix.trace_pow_tendsto_zero_of_nonneg_le_hadamard_self`),
 a contradiction.
 
-The remaining Case-I relation `Q(1−LQ)L = 0` is the same fact as
-`T² = T` under the rectangular decomposition `T = QL` already used in
-`activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL`'s proof;
-restating it in that form is not yet formalized.  The route is sketched in
-the paper-gap note `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+The rectangular Case-I relation `Q(1−LQ)L = 0` is proved as the
+project-derived rectangular form of `T² = T`, using the same factors
+`T = QL` as in the proof of
+`activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL`.  This is the
+notation used in CPSV16, Appendix C.2, Lemma C.5, lines 1473--1499; the paper
+does not print the rectangular identity as a separate displayed theorem.
 
 ## Main declarations
 
@@ -94,6 +95,8 @@ the paper-gap note `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
   **the active sector is unique**
 * `activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL`:
   **the Case-I relation** `T² = T`
+* `caseI_rectangular_remainder_eq_zero_of_literal_ZCL`:
+  **the rectangular Case-I relation** `Q(1−LQ)L = 0`
 
 ## Source fidelity
 
@@ -161,6 +164,32 @@ theorem activeSectorTraceSqMatrix_nonneg
     exact Matrix.posSemidef_self_mul_conjTranspose (F.neighboringOperator k h)
   exact (Complex.nonneg_iff.mp hsq.trace_nonneg).1
 
+/-- The product of the theorem-local Case-I trace factors is the complexification of
+`activeSectorTraceMatrix`.  This is the rectangular identity `QL = T` used in CPSV16,
+Appendix C.2, Lemma C.5, lines 1473--1499. -/
+private theorem trace_rightTensor_mul_trace_leftTensor_eq_map_activeSectorTraceMatrix
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    let Q : Matrix (F.ActiveSector p) (Fin D) ℂ :=
+      fun k alpha ↦ (F.rightTensor k alpha).trace
+    let L : Matrix (Fin D) (F.ActiveSector p) ℂ :=
+      fun beta h ↦ (F.leftTensor h beta).trace
+    Q * L = Matrix.map (F.activeSectorTraceMatrix p) Complex.ofReal := by
+  dsimp only
+  ext k h
+  simp only [Matrix.mul_apply, Matrix.map_apply,
+    PhysicalSectorFactorization.activeSectorTraceMatrix]
+  rw [← (hpos k h).isHermitian.trace_eq_ofReal_re]
+  simp only [PhysicalSectorFactorization.neighboringOperator, Matrix.trace,
+    Matrix.diag, Matrix.of_apply]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [Finset.mul_sum]
+  rw [Fintype.sum_prod_type]
+  simp_rw [Finset.sum_mul]
+  rw [Finset.sum_comm]
+
 /-- **The literal ZCL identity `physTraceTransfer² = physTraceTransfer`
 forces `T² = T³` for the active-sector trace matrix, without any positive
 scalar normalization.**
@@ -218,22 +247,8 @@ theorem activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL
     Matrix.pow_two_eq_pow_three_of_rectangular_idempotent L Q h_idem
   -- TC = Q*L is the complex version of T
   have hTC : Q * L = Matrix.map T Complex.ofReal := by
-    ext k h
-    simp only [Matrix.mul_apply, Q, L, Matrix.map_apply, T,
-      PhysicalSectorFactorization.activeSectorTraceMatrix]
-    change (∑ j, (F.rightTensor (k : Fin F.sectorCount) j).trace *
-      (F.leftTensor (h : Fin F.sectorCount) j).trace) =
-        ((F.neighboringOperator k h).trace.re : ℂ)
-    rw [← (hpos k h).isHermitian.trace_eq_ofReal_re]
-    simp only [PhysicalSectorFactorization.neighboringOperator, Matrix.trace,
-      Matrix.diag, Matrix.of_apply]
-    rw [Finset.sum_comm]
-    apply Finset.sum_congr rfl
-    intro j _
-    rw [Finset.mul_sum]
-    rw [Fintype.sum_prod_type]
-    simp_rw [Finset.sum_mul]
-    rw [Finset.sum_comm]
+    simpa only [Q, L, T] using
+      trace_rightTensor_mul_trace_leftTensor_eq_map_activeSectorTraceMatrix K F p hpos
   -- Transfer the relation to T
   rw [hTC] at h_TC_sq_cu
   have hT_sq_cu : T ^ 2 = T ^ 3 := by
@@ -289,7 +304,7 @@ theorem activeSectorTraceMatrix_pow_two_pos (F : PhysicalSectorFactorization K)
 /-! ## Lemma C.5 Case I — remaining theorems
 
 The matrix-algebra components above give `S ≤ T²` entrywise, `T² = T³` from
-literal ZCL, primitivity of `T`, and `T² > 0` entrywise.  Three further
+literal ZCL, primitivity of `T`, and `T² > 0` entrywise.  Four further
 theorems complete the Case-I argument:
 
 1. **Trace similarity** `tr(S_hat ^ N) = tr(S^N)` where `S_hat` is the diagonal
@@ -298,7 +313,9 @@ theorems complete the Case-I argument:
    the doubled-index self-overlap in terms of the active-sector
    trace-squared matrix.
 3. **Singleton assembly** Prove `card(ActiveSector p) = 1`, which forces
-   `T² = T` and `Q(1−LQ)L = 0`.
+   `T² = T`.
+4. **Rectangular form** Rewrite `T² = T` through `T = QL` as
+   `Q(1−LQ)L = 0`.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma C.5 (`SALZCL`), lines
 1473--1499; Case-I assumptions at lines 1374--1381; self-overlap limit at
@@ -854,6 +871,54 @@ theorem activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL
   have heq : (T ^ 2) i i = (T ^ 2) i i * T i i := by rw [← hcollapse3, ← hTsq3]
   have hTii : T i i = 1 := (mul_left_cancel₀ (hTsqpos i i).ne' (by rw [mul_one]; exact heq)).symm
   rw [hcollapse2, hTii, mul_one]
+
+/-- **The rectangular Case-I relation `Q(1−LQ)L = 0`.**  Here
+`L β h = tr(F.leftTensor h β)` and `Q k α = tr(F.rightTensor k α)` are the Case-I
+factors, and `QL` is the complexification of the active-sector trace matrix `T`.
+Thus this identity is the algebraic form of
+`activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL`, namely `T² = T`.
+
+This is a project-derived rectangular form in the notation of CPSV16, Appendix C.2,
+Lemma C.5, lines 1473--1499, rather than a separate displayed theorem in the paper. -/
+theorem caseI_rectangular_remainder_eq_zero_of_literal_ZCL
+    [NeZero D] (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hspan : Submodule.span ℂ (Set.range (F.activeSectorOneSiteMatrixFamily p)) = ⊤)
+    (hnonzero : ∀ k : F.ActiveSector p,
+      ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0)
+    (htriangle : ∀ {k h : F.ActiveSector p}, F.neighboringOperator k h ≠ 0 →
+      ∃ j : F.ActiveSector p, F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0)
+    (hZCL_sq : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    (hK_normal : MPSTensor.IsNormalTensor K.toMPSTensor)
+    [hne : Nonempty (F.ActiveSector p)] :
+    let L : Matrix (Fin D) (F.ActiveSector p) ℂ :=
+      fun beta h ↦ (F.leftTensor h beta).trace
+    let Q : Matrix (F.ActiveSector p) (Fin D) ℂ :=
+      fun k alpha ↦ (F.rightTensor k alpha).trace
+    Q * (1 - L * Q) * L = 0 := by
+  dsimp only
+  let L : Matrix (Fin D) (F.ActiveSector p) ℂ :=
+    fun beta h ↦ (F.leftTensor h beta).trace
+  let Q : Matrix (F.ActiveSector p) (Fin D) ℂ :=
+    fun k alpha ↦ (F.rightTensor k alpha).trace
+  let T := F.activeSectorTraceMatrix p
+  have hT : T ^ 2 = T :=
+    activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL K F p hpos hspan hnonzero htriangle
+      hZCL_sq hinactive hK_normal
+  have hQL : Q * L = Matrix.map T Complex.ofReal := by
+    simpa only [Q, L, T] using
+      trace_rightTensor_mul_trace_leftTensor_eq_map_activeSectorTraceMatrix K F p hpos
+  have hmap : (Matrix.map T Complex.ofReal) ^ 2 = Matrix.map T Complex.ofReal := by
+    calc
+      (Matrix.map T Complex.ofReal) ^ 2 = Matrix.map (T ^ 2) Complex.ofReal := by
+        exact (Matrix.map_pow T Complex.ofRealHom 2).symm
+      _ = Matrix.map T Complex.ofReal := congrArg (fun M ↦ Matrix.map M Complex.ofReal) hT
+  calc
+    Q * (1 - L * Q) * L = Q * L - (Q * L) ^ 2 := by
+      simp [Matrix.mul_sub, Matrix.sub_mul, pow_two, Matrix.mul_assoc]
+    _ = Matrix.map T Complex.ofReal - (Matrix.map T Complex.ofReal) ^ 2 := by rw [hQL]
+    _ = 0 := sub_eq_zero.mpr hmap.symm
 
 end singletonSector
 

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -69,9 +69,10 @@ a contradiction.
 The rectangular Case-I relation `Q(1−LQ)L = 0` is proved as the
 project-derived rectangular form of `T² = T`, using the same factors
 `T = QL` as in the proof of
-`activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL`.  This is the
-notation used in CPSV16, Appendix C.2, Lemma C.5, lines 1473--1499; the paper
-does not print the rectangular identity as a separate displayed theorem.
+`activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL`.  The factors
+come from the tensors $l_h$ and $r_k$ of CPSV16, Appendix C.2, Lemma C.5,
+lines 1473--1499; `L` and `Q` are project notation, and the paper does not
+print the rectangular identity as a separate displayed theorem.
 
 ## Main declarations
 
@@ -165,8 +166,9 @@ theorem activeSectorTraceSqMatrix_nonneg
   exact (Complex.nonneg_iff.mp hsq.trace_nonneg).1
 
 /-- The product of the theorem-local Case-I trace factors is the complexification of
-`activeSectorTraceMatrix`.  This is the rectangular identity `QL = T` used in CPSV16,
-Appendix C.2, Lemma C.5, lines 1473--1499. -/
+`activeSectorTraceMatrix`.  In the project's rectangular notation this is `QL = T`,
+built from the tensors $l_h$ and $r_k$ of CPSV16, Appendix C.2, Lemma C.5,
+lines 1473--1499. -/
 private theorem trace_rightTensor_mul_trace_leftTensor_eq_map_activeSectorTraceMatrix
     (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
@@ -236,11 +238,6 @@ theorem activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL
   -- From literal ZCL, L*Q is idempotent
   have h_idem : IsIdempotentElem (L * Q) := by
     rw [← hphys]
-    -- IsIdempotentElem means M * M = M
-    -- We have physTraceTransfer * physTraceTransfer = physTraceTransfer
-    -- So physTraceTransfer is idempotent
-    change physTraceTransfer K * physTraceTransfer K = physTraceTransfer K at hZCL_sq
-    -- IsIdempotentElem M := M * M = M
     exact hZCL_sq
   -- Apply rectangular idempotent lemma: (Q*L)² = (Q*L)³
   have h_TC_sq_cu : (Q * L) ^ 2 = (Q * L) ^ 3 :=
@@ -878,8 +875,9 @@ factors, and `QL` is the complexification of the active-sector trace matrix `T`.
 Thus this identity is the algebraic form of
 `activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL`, namely `T² = T`.
 
-This is a project-derived rectangular form in the notation of CPSV16, Appendix C.2,
-Lemma C.5, lines 1473--1499, rather than a separate displayed theorem in the paper. -/
+This is a project-derived rectangular form, in project notation, of the factors built
+from $l_h$ and $r_k$ in CPSV16, Appendix C.2, Lemma C.5, lines 1473--1499; the paper
+does not state it as a separate displayed theorem. -/
 theorem caseI_rectangular_remainder_eq_zero_of_literal_ZCL
     [NeZero D] (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -896,11 +896,7 @@ theorem caseI_rectangular_remainder_eq_zero_of_literal_ZCL
     let Q : Matrix (F.ActiveSector p) (Fin D) ℂ :=
       fun k alpha ↦ (F.rightTensor k alpha).trace
     Q * (1 - L * Q) * L = 0 := by
-  dsimp only
-  let L : Matrix (Fin D) (F.ActiveSector p) ℂ :=
-    fun beta h ↦ (F.leftTensor h beta).trace
-  let Q : Matrix (F.ActiveSector p) (Fin D) ℂ :=
-    fun k alpha ↦ (F.rightTensor k alpha).trace
+  intro L Q
   let T := F.activeSectorTraceMatrix p
   have hT : T ^ 2 = T :=
     activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL K F p hpos hspan hnonzero htriangle

--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -875,9 +875,10 @@ factors, and `QL` is the complexification of the active-sector trace matrix `T`.
 Thus this identity is the algebraic form of
 `activeSectorTraceMatrix_pow_two_eq_of_literal_ZCL`, namely `T² = T`.
 
-This is a project-derived rectangular form, in project notation, of the factors built
-from $l_h$ and $r_k$ in CPSV16, Appendix C.2, Lemma C.5, lines 1473--1499; the paper
-does not state it as a separate displayed theorem. -/
+**Local fix (`docs/paper-gaps/cpgsv17_pf_rank_one.tex`):** this is a project-derived
+rectangular form, in project notation, of the factors built from $l_h$ and $r_k$ in
+CPSV16, Appendix C.2, Lemma C.5, lines 1473--1499; the paper does not state it as a
+separate displayed theorem. -/
 theorem caseI_rectangular_remainder_eq_zero_of_literal_ZCL
     [NeZero D] (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -1085,8 +1085,8 @@
     Theorem~\ref{thm:mpdo_active_trace_matrix_pow_two_eq}, define the
     rectangular trace-pairing matrices
     \begin{align}
-        L_{\beta,h}&=\tr(l_h^\beta),
-        &Q_{k,\alpha}&=\tr(r_k^\alpha).
+        L_{\beta,h}&=\tr\!\left((l_h)_\beta\right),
+        &Q_{k,\alpha}&=\tr\!\left((r_k)_\alpha\right).
         \notag
     \end{align}
     Then

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -1075,3 +1075,42 @@
     gives $t^2=t^3$, and positivity of $(T^*)^2$ gives $t^2>0$, hence
     $t=1$ and $t^2=t$.
 \end{proof}
+
+\begin{theorem}[Rectangular form of the Case-I relation]
+    \label{thm:mpdo_casei_rectangular_remainder}
+    \lean{MPOTensor.caseI_rectangular_remainder_eq_zero_of_literal_ZCL}
+    \leanok
+    \uses{thm:mpdo_active_trace_matrix_pow_two_eq}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_active_trace_matrix_pow_two_eq}, define the
+    rectangular trace-pairing matrices
+    \begin{align}
+        L_{\beta,h}&=\tr(l_h^\beta),
+        &Q_{k,\alpha}&=\tr(r_k^\alpha).
+        \notag
+    \end{align}
+    Then
+    \begin{align}
+        Q(1-LQ)L&=0.
+        \notag
+    \end{align}
+    This is a project-derived rectangular form, in project notation, of the
+    $l_h,r_k$ factors from
+    \cite[Appendix~C.2, Lemma~C.5, lines~1473--1499]{Cirac2016MPDO_arXiv};
+    the source does not state it as a separate displayed theorem.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_active_trace_matrix_pow_two_eq}
+    The trace pairing gives $QL=T^*$. Therefore
+    \begin{align}
+        Q(1-LQ)L
+        &=QL-(QL)^2
+         =T^*-(T^*)^2
+         =0,
+        \notag
+    \end{align}
+    where the last equality is
+    Theorem~\ref{thm:mpdo_active_trace_matrix_pow_two_eq}.
+\end{proof}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -806,28 +806,40 @@ primitive entrywise non-negative matrix with constant traces of positive powers
 need not have rank one. The obstruction is a nilpotent Jordan component at the
 zero eigenvalue, which is not detected by the trace identities.
 
-The formal development now proves two corrected sufficient theorems.  The
+The formal development proves two corrected sufficient matrix theorems.  The
 first derives the rank-one factorization from positive semidefiniteness, trace
 normalization, and the trace-power identities.  The second derives
 $T^2=T$ from the sector-pairing identity and linear independence of the closed
 sector tensors; trace one then gives the same rank-one factorization directly.
-These two corrected direct rank-one criteria remain available as independent
-matrix results.  The unrelated aggregate bundle that paired a three-site
-Markov witness with an independently supplied trace matrix has been retired:
-it imposed no relation between the state, the matrix, and an MPO tensor, and
-therefore added no consequence to either criterion.
+These criteria remain available as independent matrix results.  The unrelated
+aggregate bundle that paired a three-site Markov witness with an independently
+supplied trace matrix has been retired: it imposed no relation between the
+state, the matrix, and an MPO tensor, and therefore added no consequence to
+either criterion.
+
+The completed normal Case-I route supplies a third, tensor-attached result at
+the source hypothesis boundary formalized in
+\leanid{MPOTensor.caseI_rectangular_remainder_eq_zero_of_literal_ZCL}.
+Normality and literal ZCL, together with the physical-sector positivity and
+primitivity data, force the active sector to be unique and hence $T^2=T$.
+For the project factors $T=QL$, this gives
+\[
+  Q(1-LQ)L=QL-(QL)^2=0.
+\]
+Thus the nilpotent-zero obstruction is excluded on this normal Case-I surface;
+idempotence of $LQ$ alone would still yield only $T^2=T^3$.
 
 The all-cut Markov proof and the source-selected inverse-map calculation show
 that the raw four-sector tensor satisfies the displayed SAL, literal ZCL, and
 inverse-map relations while the asserted factorization
 $T_{k,h}=a_kb_h$ does not exist. However, that tensor is not the injective
 normal tensor assumed in Case~I, and its normal representative loses literal
-ZCL. Consequently Lemma~C.5 and the downstream source implications remain
-unsettled at this normalization boundary; the raw example does not refute them
-under their complete standing hypotheses. The direct matrix conclusions remain
-available under positive semidefiniteness or the appropriate linear-independence
-hypothesis, but those additional conditions do not supply the source's
-structural corollary and must not be attributed to it.
+ZCL. The raw example therefore does not refute Lemma~C.5 under its complete standing
+hypotheses, and the normal Case-I theorem above resolves its rectangular
+matrix obstruction.  The full source rank-one-factorization package and the
+downstream normalization step used after absorbing BNT coefficients remain
+unsettled; in particular, this Case-I result must not be transported to the
+later Case-II argument without proving that normality survives the rescaling.
 
 The raw witness $\mathcal K$ nevertheless has explicit trace-preserving
 completely positive renormalization maps, both before and after two-site

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -573,6 +573,19 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### rectangular complement expansion — candidate
+- **Pattern:** expand a rectangular remainder by associativity:
+  `Q * (1 - L * Q) * L = Q * L - (Q * L) * (Q * L)`.
+- **Seen:** two occurrences: `rectangular_remainder_eq_mul_sub_sq` in
+  `TNLean/MPS/MPDO/ActiveSectorSpanningCounterexample.lean` and
+  `caseI_rectangular_remainder_eq_zero_of_literal_ZCL` in
+  `TNLean/MPS/MPDO/LemmaC5CaseI.lean` (review on 2026-08-08).
+- **Abstraction:** if a third occurrence appears, promote the expansion to a
+  general rectangular-matrix lemma over a nonunital nonassociative ring with
+  the finite-index assumptions needed for matrix multiplication.
+- **Notes:** Below the rule-of-three promotion threshold; keep the explicit
+  calculation so each application exposes the relevant opposite product.
+
 ### stationary-sector rank-one physical probes — candidate
 - **Pattern:** choose the trace-one stationary state of an irreducible
   left-canonical sector, realize rank-one inserted maps by physical


### PR DESCRIPTION
## What changed

- factors the repeated Case-I identity
  `Q * L = Matrix.map (F.activeSectorTraceMatrix p) Complex.ofReal`
  into a private source-local lemma and reuses it in the existing literal-ZCL proof;
- proves `caseI_rectangular_remainder_eq_zero_of_literal_ZCL` with exactly the established singleton-sector hypotheses;
- derives
  \[
  Q(1-LQ)L=QL-(QL)^2=0
  \]
  from the already-proved `(F.activeSectorTraceMatrix p)^2 = F.activeSectorTraceMatrix p`;
- records the result in Chapter 21 with exact hypotheses inherited from the preceding `T²=T` theorem and a formula-first proof;
- states the source boundary precisely: `L,Q` are project notation for factors built from CPSV16's $l_h,r_k$, and the paper does not print this rectangular identity as a separate theorem.

This does **not** infer the result from idempotence of `LQ`, which only gives `(QL)^2=(QL)^3`; the singleton-sector theorem is the essential extra input.

## Validation

- `lake build TNLean.MPS.MPDO.LemmaC5CaseI` — passed (9169 jobs);
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` — 6546/6546 entries synchronized;
- two direct `lualatex` passes for `blueprint/src/print.tex` with `TEXINPUTS="../../tex/tenkz//:"` — passed (only the repository's expected standalone citation warnings);
- `git diff --check` — passed;
- added-line scan for `sorry`, `axiom`, and `native_decide` — none.

Closes #5555. Advances #5404 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a theorem on the critical Lemma C.5 Case-I path with many standing hypotheses (normality, literal ZCL, primitivity); proof is localized and reuses existing results, but mistakes here would affect downstream MPDO claims.
> 
> **Overview**
> Formalizes the remaining **Case-I rectangular identity** `Q(1−LQ)L = 0` as `caseI_rectangular_remainder_eq_zero_of_literal_ZCL`, derived from the already-proved active-sector idempotence `T² = T` and the factorization `QL = T` (project notation for CPSV16’s $l_h$, $r_k$ factors—not a separate displayed theorem in the source).
> 
> **Refactor:** the shared identity `Q * L = Matrix.map (activeSectorTraceMatrix) Complex.ofReal` is pulled into private lemma `trace_rightTensor_mul_trace_leftTensor_eq_map_activeSectorTraceMatrix` and reused in the literal-ZCL `T² = T³` proof.
> 
> **Docs:** Chapter 21 adds Theorem `mpdo_casei_rectangular_remainder`; `cpgsv17_pf_rank_one.tex` records the normal Case-I route as resolving this rectangular obstruction (with explicit limits on transporting to Case-II); `tactic_patterns.md` notes a candidate for promoting rectangular remainder expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd87e0c2a743257ad1e7945f6903da0d4f91dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

