### PR TITLE
doc(blueprint): migrate the tnpic pictures onto the kernel

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -399,16 +399,20 @@ $G_{\alpha,\beta}^{ij}=\bigoplus_\gamma
 % source states the algebraic identity and direct-sum decomposition, but
 % contains no dedicated diagram for U_{\alpha,\beta}.
 \par\noindent\hfil
-\tnpic[rows={op,op}]{
-    \tnfuse[combined=west]{U_{\alpha,\beta}} &
-    \tn[mpo, up=$i$]{M_\alpha} &
-    \tnfuse[combined=east]{U_{\alpha,\beta}^{\dagger}} \\
-    & \tn[mpo, down=$j$]{M_\beta} &
-}
+\tenkzkernel
+\begin{tenkz}[rows={op,op}, cols=3]
+    \tnfuse[at=(1,1), name=U, skin=pill]{U_{\alpha,\beta}}
+    \tn[at=(1,2), skin=mpo,
+        ports={90:physical:$i$, 270:physical}]{M_\alpha}
+    \tn[at=(2,2), skin=mpo,
+        ports={90:physical, 270:physical:$j$}]{M_\beta}
+    \tnfuse[at=(1,3), name=Ud, skin=pill]{U_{\alpha,\beta}^{\dagger}}
+    \tnwire{open w}{U.180} \tnwire{Ud.0}{open e}
+\end{tenkz}
 \qquad$=$\qquad
-\tnpic[physical=updown]{
-    \tn[mpo, up=$i$, down=$j$]{G_{\alpha,\beta}}
-}
+\begin{tenkz}[cols=1, west=open, east=open]
+    \tn[skin=mpo, ports={90:physical:$i$, 270:physical:$j$}]{G_{\alpha,\beta}}
+\end{tenkz}
 \hfil\par
 
 \begin{lemma}[Weighted zipper identities on the active support]
@@ -628,56 +632,76 @@ weights in the length-independent case at
 %   row 3: (2,2,1,1)=(2,2,1,1).
 % Ink-to-index map: each M box carries one product factor; their vertical
 %   stroke is the q contraction and their outer legs are i,j.  Each H box is
-%   the single aggregate letter \(H_{\alpha,\beta}^{ij}\).  A fusion bar
-%   presents the separate \(\alpha,\beta\) ports at \(\{1,2\}\) and the fused
-%   port at center.  The
-%   H--bar bonds lie on a fused row; the second row is structural, and the
-%   reconstruction hole prevents it from adding a second H channel.
+%   the single aggregate letter \(H_{\alpha,\beta}^{ij}\) and stands across
+%   both wire rows.  A fusion wedge spans the two rows as well: its two
+%   per-row strands are the separate \(\alpha,\beta\) indices and its
+%   centered stub is the fused index, so each H--wedge bond is one fused
+%   contraction and no second H channel exists.
 % Source verdict: Bultinck et al. arXiv:1511.08090, Eq. (21), states the two
 %   zipper orientations algebraically but gives no dedicated figure for that
-%   equation.  CPSV16 Theorem 4.14(iii) supplies the MPDO identity.  The old
-%   catalogue picture fixes only row order and topology, not coordinates;
-%   therefore the current diagonal fused bonds preserve the asserted
-%   contraction without inventing a centred tall H atom.
+%   equation.  CPSV16 Theorem 4.14(iii) supplies the MPDO identity.  The
+%   source fixes only row order and topology, not coordinates; H drawn
+%   across both rows carries the same asserted contraction, since the fused
+%   index is one bond however tall its carrier stands.
 \par\noindent\hfil
-\tnpic[rows={op,op}]{
-  \tnfuse[span=2, west at=center, east at={1,2}]{U_{\alpha,\beta}} &
-  \tn[mpo, up=$i$]{M_\alpha} \\
-  & \tn[mpo, down=$j$]{M_\beta}
-}
+\tenkzkernel
+\begin{tenkz}[rows={op,op}, cols=2, east=open]
+    \tnfuse[at=(1,1), name=U, skin=pill]{U_{\alpha,\beta}}
+    \tn[at=(1,2), skin=mpo,
+        ports={90:physical:$i$, 270:physical}]{M_\alpha}
+    \tn[at=(2,2), skin=mpo,
+        ports={90:physical, 270:physical:$j$}]{M_\beta}
+    \tnwire{open w}{U.180}
+\end{tenkz}
 \qquad$=$\qquad
-\tnpic[rows={op:fused,wire:west none}]{
-  \tn[mpo, west at=center, east at=center, up=$i$, down=$j$]{H} &
-  \tnfuse[span=2, west at=center, east at={1,2}]{U_{\alpha,\beta}} \\
-  &
-}
+\begin{tenkz}[rows={op,op}, cols=2, bonds=none]
+    \tn[at=(1,1), skin=mpo, wires=2, name=H,
+        ports={90:physical:$i$, 270:physical:$j$, 180:virtual, 0:virtual}]{H}
+    \tnfuse[at=(1,2), name=U, skin=pill]{U_{\alpha,\beta}}
+    \tnwire{open w}{H.180}
+    \tnwire{H.0}{U.180}
+    \tnwire{U.0@1}{open e}
+    \tnwire{U.0@2}{open e}
+\end{tenkz}
 \hfil\par
 \par\noindent\hfil
-\tnpic[rows={op,op}]{
-  \tn[mpo, up=$i$]{M_\alpha} &
-  \tnfuse[span=2, west at={1,2}, east at=center]
-    {U_{\alpha,\beta}^{\dagger}} \\
-  \tn[mpo, down=$j$]{M_\beta} &
-}
+\tenkzkernel
+\begin{tenkz}[rows={op,op}, cols=2, west=open]
+    \tn[at=(1,1), skin=mpo,
+        ports={90:physical:$i$, 270:physical}]{M_\alpha}
+    \tn[at=(2,1), skin=mpo,
+        ports={90:physical, 270:physical:$j$}]{M_\beta}
+    \tnfuse[at=(1,2), name=Ud, skin=pill]{U_{\alpha,\beta}^{\dagger}}
+    \tnwire{Ud.0}{open e}
+\end{tenkz}
 \qquad$=$\qquad
-\tnpic[rows={op:fused,wire:east none}]{
-  \tnfuse[span=2, west at={1,2}, east at=center]
-    {U_{\alpha,\beta}^{\dagger}} &
-  \tn[mpo, west at=center, east at=center, up=$i$, down=$j$]{H} \\
-  &
-}
+\begin{tenkz}[rows={op,op}, cols=2, bonds=none]
+    \tnfuse[at=(1,1), name=Ud, skin=pill]{U_{\alpha,\beta}^{\dagger}}
+    \tn[at=(1,2), skin=mpo, wires=2, name=H,
+        ports={90:physical:$i$, 270:physical:$j$, 180:virtual, 0:virtual}]{H}
+    \tnwire{open w}{Ud.180@1}
+    \tnwire{open w}{Ud.180@2}
+    \tnwire{Ud.0}{H.180}
+    \tnwire{H.0}{open e}
+\end{tenkz}
 \hfil\par
 \par\noindent\hfil
-\tnpic[rows={op,op}]{
-  \tn[mpo, up=$i$]{M_\alpha} \\
-  \tn[mpo, down=$j$]{M_\beta}
-}
+\tenkzkernel
+\begin{tenkz}[rows={op,op}, cols=1, west=open, east=open]
+    \tn[skin=mpo, ports={90:physical:$i$, 270:physical}]{M_\alpha} \\
+    \tn[skin=mpo, ports={90:physical, 270:physical:$j$}]{M_\beta}
+\end{tenkz}
 \qquad$=$\qquad
-\tnpic[rows={op:fused,wire}]{
-  \tnfuse[span=2, west at={1,2}, east at=center]
-    {U_{\alpha,\beta}^{\dagger}} &
-  \tn[mpo, west at=center, east at=center, up=$i$, down=$j$]{H} &
-  \tnfuse[span=2, west at=center, east at={1,2}]{U_{\alpha,\beta}} \\
-  & \tnskip &
-}
+\begin{tenkz}[rows={op,op}, cols=3, bonds=none]
+    \tnfuse[at=(1,1), name=Ud, skin=pill]{U_{\alpha,\beta}^{\dagger}}
+    \tn[at=(1,2), skin=mpo, wires=2, name=H,
+        ports={90:physical:$i$, 270:physical:$j$, 180:virtual, 0:virtual}]{H}
+    \tnfuse[at=(1,3), name=U, skin=pill]{U_{\alpha,\beta}}
+    \tnwire{open w}{Ud.180@1}
+    \tnwire{open w}{Ud.180@2}
+    \tnwire{Ud.0}{H.180}
+    \tnwire{H.0}{U.180}
+    \tnwire{U.0@1}{open e}
+    \tnwire{U.0@2}{open e}
+\end{tenkz}
 \hfil\par

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -28,32 +28,50 @@
     %   q_\ell and contracts the bra index of M_\alpha with the ket index of
     %   M_\beta.  Their periodic rows contract a_0=a_L and b_0=b_L
     %   independently; i_\ell and j_\ell remain free.  On the right, the
-    %   upper wire row is the multiplicity trace
+    %   upper loop is the multiplicity trace
     %   tr(\chi_{\alpha,\beta,\gamma}^{L}) (labelled \chi in the ink), and the
-    %   lower operator row is O_L(M_\gamma).  These two loops have no pairleg.
+    %   lower loop is O_L(M_\gamma).  The two loops share no index, so each
+    %   is a whole picture, and their juxtaposition is the product of a
+    %   scalar and an operator.
     %   The sum over \gamma is a sector sum, not a contraction edge.
     % Boundary signatures (virtual-west, virtual-east, physical-up,
     %   physical-down): both sides have semantic signature (0,0,L,L).
     %   Each three-site representative emits (0,0,3,3).
-    \tnpic[compact, rows={op,op}, periodic]{
-        \tn[mpo, up=$i_1$]{M_\alpha} &
-        \tn[mpo]{M_\alpha} & \tndots &
-        \tn[mpo, up=$i_L$]{M_\alpha} \\
-        \tn[mpo, down=$j_1$]{M_\beta}
-            \tnspan[brace below]{4}{$L\text{ sites}$} &
-        \tn[mpo]{M_\beta} & \tndots &
-        \tn[mpo, down=$j_L$]{M_\beta}
-    }
-    \qquad$=\sum_\gamma$\qquad
-    % The doubled row gap makes the absent chi--M_gamma pairleg unmistakable
-    % at print size.
-    \tnpic[compact, rows={wire,op}, layer sep=2, periodic]{
-        \tn[box]{\chi} & \tn[box]{\chi} & \tndots & \tn[box]{\chi} \\
-        \tn[mpo, up=$i_1$, down=$j_1$]{M_\gamma}
-            \tnspan[brace below]{4}{$L\text{ sites}$} &
-        \tn[mpo]{M_\gamma} & \tndots &
-        \tn[mpo, up=$i_L$, down=$j_L$]{M_\gamma}
-    }
+    % The elided columns contract in pairs like the displayed ones, and the
+    %   frame would mint that pairleg between the two ellipsis cells as a
+    %   stub; the left panel therefore authors its bonds and leaves the
+    %   ellipsis column bare.
+    \tenkzkernel
+    \begin{tenkz}[rows={op,op}, cols=4, west=trace, east=trace, bonds=none]
+        \tn[skin=mpo, ports={90:physical:$i_1$, 270:physical}]{M_\alpha} &
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{M_\alpha} &
+        \tn[skin=dots]{} &
+        \tn[skin=mpo, ports={90:physical:$i_L$, 270:physical}]{M_\alpha} \\
+        \tn[skin=mpo, ports={90:physical, 270:physical:$j_1$}]{M_\beta} &
+        \tn[skin=mpo, ports={90:physical, 270:physical}]{M_\beta} &
+        \tn[skin=dots]{} &
+        \tn[skin=mpo, ports={90:physical, 270:physical:$j_L$}]{M_\beta}
+        \tnwire{(1,1)}{(1,2)} \tnwire{(1,2)}{(1,3)} \tnwire{(1,3)}{(1,4)}
+        \tnwire{(2,1)}{(2,2)} \tnwire{(2,2)}{(2,3)} \tnwire{(2,3)}{(2,4)}
+        \tnwire{(1,1)}{(2,1)} \tnwire{(1,2)}{(2,2)} \tnwire{(1,4)}{(2,4)}
+        \tnmark[form=bracket]{(2,1) .. (2,4)}{$L\text{ sites}$}
+    \end{tenkz}
+    \quad$=\sum_\gamma$\quad
+    \begin{tabular}[c]{@{}c@{}}
+        {\begin{tenkz}[cols=4, west=trace, east=trace]
+            \tn[skin=box]{\chi} & \tn[skin=box]{\chi} & \tn[skin=dots]{} &
+            \tn[skin=box]{\chi}
+        \end{tenkz}} \\
+        {\begin{tenkz}[cols=4, west=trace, east=trace]
+            \tn[skin=mpo,
+                ports={90:physical:$i_1$, 270:physical:$j_1$}]{M_\gamma} &
+            \tn[skin=mpo, ports={90:physical, 270:physical}]{M_\gamma} &
+            \tn[skin=dots]{} &
+            \tn[skin=mpo,
+                ports={90:physical:$i_L$, 270:physical:$j_L$}]{M_\gamma}
+            \tnmark[form=bracket]{(1,1) .. (1,4)}{$L\text{ sites}$}
+        \end{tenkz}}
+    \end{tabular}
     \caption{Closing an $L$-site chain of the local fusion identity. On the
         left, the bra legs of the $M_\alpha$ operator are contracted with the
         ket legs of the $M_\beta$ operator. On the right, the multiplicity loop

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -626,21 +626,22 @@ the remaining sites unchanged.
     % the contracted virtual index \gamma.  Each blue stroke is a typed map
     % between the complete objects at its endpoints, never a tensor contraction.
     \par\noindent\hfil
+    {\tenkzkernel
     \begin{tikzcd}[channel, ampersand replacement=\&,
         column sep=10mm, row sep=8mm]
-      \tnpic[inline, physical=updown]{
-        \tn[mpo]{M}
-      } \arrow[r, "\mathcal T"] \&
-      \tnpic[inline, physical=updown]{
-        \tn[mpo]{M} & \tn[mpo]{M}
-      } \\
-      \tnpic[inline, physical=updown]{
-        \tn[mpo]{M} & \tn[mpo]{M}
-      } \arrow[r, "\mathcal S"] \&
-      \tnpic[inline, physical=updown]{
-        \tn[mpo]{M}
-      }
-    \end{tikzcd}
+      {\begin{tenkz}[cols=1, west=open, east=open, physical=updown]
+        \tn[skin=mpo]{M}
+      \end{tenkz}} \arrow[r, "\mathcal T"] \&
+      {\begin{tenkz}[cols=2, west=open, east=open, physical=updown]
+        \tn[skin=mpo]{M} & \tn[skin=mpo]{M}
+      \end{tenkz}} \\
+      {\begin{tenkz}[cols=2, west=open, east=open, physical=updown]
+        \tn[skin=mpo]{M} & \tn[skin=mpo]{M}
+      \end{tenkz}} \arrow[r, "\mathcal S"] \&
+      {\begin{tenkz}[cols=1, west=open, east=open, physical=updown]
+        \tn[skin=mpo]{M}
+      \end{tenkz}}
+    \end{tikzcd}}
     \hfil\par
 \end{definition}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -308,8 +308,9 @@
     % =\widehat{\cal K}_4(X); the reverse row is the corresponding pair of
     % \widehat{\mathcal S} identities.
     % Ink-to-index: every \widehat{\cal K} box has west/east virtual indices
-    % and upper/lower physical indices.  Each dashed span groups two adjacent
-    % tensor bodies into one blocked local site and introduces no contraction.
+    % and upper/lower physical indices.  Each enclosure mark groups two
+    % adjacent tensor bodies into one blocked local site and introduces no
+    % contraction.
     % Contractions: only adjacent east--west virtual legs are summed.  All
     % upper and lower physical legs, and both outer virtual legs, remain free.
     % Boundary signatures (virtual-west, virtual-east, physical-up,
@@ -320,48 +321,60 @@
     % channels algebraically but has no dedicated figure.  The rows reproduce
     % that composition using the local tensors already defined here.
     \begin{tenkzequation}
+        \tenkzkernel
         $\widehat{\mathcal T}^{\,2}:\quad$
-        \tnpic[compact, physical=updown, tensor style=box]{%
-            \tn[mpo]{\widehat{\cal K}}
-                \tnspan[box, label pos=south]{2}{\widehat{\cal K}^{[2]}} &
-            \tn[mpo]{\widehat{\cal K}}}
+        \begin{tenkz}[cols=2, west=open, east=open, physical=updown]
+            \tn[skin=mpo]{\widehat{\cal K}} & \tn[skin=mpo]{\widehat{\cal K}}
+            \tnmark[form=enclosure, label pos=s]{(1,1) .. (1,2)}
+                {$\widehat{\cal K}^{[2]}$}
+        \end{tenkz}
         $\quad\xrightarrow{\widehat{\mathcal T}}\quad$
-        \tnpic[compact, physical=updown, tensor style=box]{%
-            \tn[mpo]{\widehat{\cal K}} &
-            \tn[mpo]{\widehat{\cal K}} &
-            \tn[mpo]{\widehat{\cal K}}}
+        \begin{tenkz}[cols=3, west=open, east=open, physical=updown]
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}}
+        \end{tenkz}
         $\quad\xrightarrow{\widehat{\mathcal T}_{(12)3}}\quad$
-        \tnpic[compact, physical=updown, tensor style=box]{%
-            \tn[mpo]{\widehat{\cal K}}
-                \tnspan[box, label pos=south]{2}{\widehat{\cal K}^{[2]}} &
-            \tn[mpo]{\widehat{\cal K}} &
-            \tn[mpo]{\widehat{\cal K}}
-                \tnspan[box, label pos=south]{2}{\widehat{\cal K}^{[2]}} &
-            \tn[mpo]{\widehat{\cal K}}}
+        \begin{tenkz}[cols=4, west=open, east=open, physical=updown]
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}}
+            \tnmark[form=enclosure, label pos=s]{(1,1) .. (1,2)}
+                {$\widehat{\cal K}^{[2]}$}
+            \tnmark[form=enclosure, label pos=s]{(1,3) .. (1,4)}
+                {$\widehat{\cal K}^{[2]}$}
+        \end{tenkz}
     \end{tenkzequation}
     \par    \begin{tenkzequation}
+        \tenkzkernel
         $\widehat{\mathcal S}^{\,2}:\quad$
-        \tnpic[compact, physical=updown, tensor style=box]{%
-            \tn[mpo]{\widehat{\cal K}}
-                \tnspan[box, label pos=south]{2}{\widehat{\cal K}^{[2]}} &
-            \tn[mpo]{\widehat{\cal K}} &
-            \tn[mpo]{\widehat{\cal K}}
-                \tnspan[box, label pos=south]{2}{\widehat{\cal K}^{[2]}} &
-            \tn[mpo]{\widehat{\cal K}}}
+        \begin{tenkz}[cols=4, west=open, east=open, physical=updown]
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}}
+            \tnmark[form=enclosure, label pos=s]{(1,1) .. (1,2)}
+                {$\widehat{\cal K}^{[2]}$}
+            \tnmark[form=enclosure, label pos=s]{(1,3) .. (1,4)}
+                {$\widehat{\cal K}^{[2]}$}
+        \end{tenkz}
         $\quad\xrightarrow{\widehat{\mathcal S}_{(123)4}}\quad$
-        \tnpic[compact, physical=updown, tensor style=box]{%
-            \tn[mpo]{\widehat{\cal K}} &
-            \tn[mpo]{\widehat{\cal K}} &
-            \tn[mpo]{\widehat{\cal K}}}
+        \begin{tenkz}[cols=3, west=open, east=open, physical=updown]
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}} &
+            \tn[skin=mpo]{\widehat{\cal K}}
+        \end{tenkz}
         $\quad\xrightarrow{\widehat{\mathcal S}}\quad$
-        \tnpic[compact, physical=updown, tensor style=box]{%
-            \tn[mpo]{\widehat{\cal K}}
-                \tnspan[box, label pos=south]{2}{\widehat{\cal K}^{[2]}} &
-            \tn[mpo]{\widehat{\cal K}}}
+        \begin{tenkz}[cols=2, west=open, east=open, physical=updown]
+            \tn[skin=mpo]{\widehat{\cal K}} & \tn[skin=mpo]{\widehat{\cal K}}
+            \tnmark[form=enclosure, label pos=s]{(1,1) .. (1,2)}
+                {$\widehat{\cal K}^{[2]}$}
+        \end{tenkz}
     \end{tenkzequation}
     \caption{The superscripts in $\widehat{\mathcal T}^2$ and
     $\widehat{\mathcal S}^2$ denote successive overlapping applications.
-    The dashed frames identify the two-site and four-site endpoints with one
+    The enclosures identify the two-site and four-site endpoints with one
     and two sites of the blocked tensor. This is the channel construction in
     \cite[Appendix~C.2, lines~1821--1825]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_blocked_rfp_channels}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -83,14 +83,14 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_foundations.tex` | L87, 92 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 293, 294, 295, 296, 298 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
-| `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | L447 `tenkz` → `P-grid` | L559, 561 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_renormalization.tex` | — | — | L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | L403, 413, 648, 657, 669, 678, 690, 695 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | L45, 61, 65, 465 `tenkz` → `P-grid` | L577, 579 `tntree` → `C-tree` | — |
+| `ch21_mpdo_rfp_renormalization.tex` | L632, 635, 638, 641 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | L282, 288 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | L44, 49, 53, 70, 78, 130, 265, 270, 275, 282, 287, 486, 704, 710, 714 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L793, 806, 814, 821, 895, 902 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L326, 332, 338, 352, 363, 369 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L333, 852, 856, 862, 867 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | L48, 52, 169, 173, 374, 378, 391, 395, 438, 442, 446, 455, 459 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
@@ -115,26 +115,26 @@ separate public-surface occurrence and therefore appears separately.
 
 | Raw construct | Occurrences |
 |---|---:|
-| `tenkz` | 170 |
+| `tenkz` | 191 |
 | `tenkzcd` | 0 |
 | `tenkzplanes` | 0 |
-| `tnpic` | 20 |
+| `tnpic` | 0 |
 | `tntree` | 11 |
-| **Total** | **201** |
+| **Total** | **202** |
 
 | Disposition | Occurrences |
 |---|---:|
-| preserve | 152 |
+| preserve | 173 |
 | codemod | 11 |
-| redraw | 38 |
-| **Total** | **201** |
+| redraw | 18 |
 
-The raw count is 170 environment openings plus 31 command occurrences,
-which reconciles to 201. The issue baseline counted 106 `tenkz`,
+The raw count is 191 environment openings plus 11 command occurrences,
+which reconciles to 202. The issue baseline counted 106 `tenkz`,
 36 `tenkzfree`, 18 `tenkzlattice`, 6 `tenkzcd`, 0 `tenkzeq`,
 0 `tenkzplanes`, and 41 `\tnpic`/`\tntree` lines; the six `tenkzcd`
 pictures have since been respelled onto plain tikz-cd, discharging every
-blueprint `R-cd` row.
+blueprint `R-cd` row, and the twenty `\tnpic` pictures have since been
+redrawn as kernel grid pictures, discharging every blueprint `\tnpic` row.
 
 ## Standalone fixture inventory
 

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -127,6 +127,7 @@ separate public-surface occurrence and therefore appears separately.
 | preserve | 173 |
 | codemod | 11 |
 | redraw | 18 |
+| **Total** | **202** |
 
 The raw count is 191 environment openings plus 11 command occurrences,
 which reconciles to 202. The issue baseline counted 106 `tenkz`,

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2613,3 +2613,42 @@ by hand and each row's demand count drops below tenure. Verdicts:
 |---|---|
 | flag:consumers:command:tndots | keep-because: a signed 1.0 sugar row (`\tndots` expands to the ellipsis atom, `LANGUAGE-1.0` §9) whose kernel-tier reading does not exist yet — the gap this wave measured — so the migrated ladder writes the expansion and the two remaining demand-corpus consumers are 0.7 pictures awaiting their own migration (`ch20_mpdo_foundations`, `ch21` product laws); tenure recounts at the S4 swap; expiry 0.9 |
 | flag:consumers:command:tnspan | keep-because: a signed 1.0 sugar row (`\tnspan[form]{k}{m}` expands to a ranged `\tnmark`, `LANGUAGE-1.0` §9) whose span form is refused undrawn on the kernel tier — the gap this wave measured — so the migrated ladder writes the `\tnmark[form=bracket]` expansion and the two remaining demand-corpus consumers are 0.7 ch21 pictures awaiting their own migration; tenure recounts at the S4 swap; expiry 0.9 |
+
+### 2026-08-09 — the blueprint's twenty `\tnpic` pictures take the kernel
+
+The last 0.7 command surface in the blueprint is gone: the twenty
+`\tnpic` pictures across four ch21 files — the fusion-coisometry G
+equation and the unweighted zipper triple, the trace-power product
+law, the two-step refinement-channel rows, and the renormalization
+fixed-point square — are redrawn as kernel grid pictures under
+`\tenkzkernel`. The eight fusion wedges consume the `\tnfuse` sugar
+row #5624 bound, H stands as a `wires=2` atom across both wire rows,
+physical labels stand on their typed ports, every declared side is
+derived from the figure's stated boundary signature, and the
+renormalization square keeps its tikz-cd carrier with one kernel
+picture per cell, each brace-wrapped so its column tabs stay out of
+the diagram's own alignment. The refinement spans become
+range-addressed enclosure marks, and the product law's multiplicity
+and operator loops — which share no index — stand as two whole traced
+pictures whose juxtaposition is the product of a scalar and an
+operator.
+
+Two idiom gaps measured along the way, recorded on #4709: a multi-row
+frame mints its vertical bond under an ellipsis column too, so a
+paired-row chain with an elision authors its bonds under `bonds=none`;
+and one row of a multi-row frame cannot be traced alone — a side word
+closes every row and `trace=` closes cells to themselves — so disjoint
+loops separate into whole pictures, which is the honest sentence for a
+tensor product of closed diagrams.
+
+No meter moves: the census, parser paths, escape uses, alias and
+overload ledgers are unchanged, and every spelling the redraw writes
+already had a signed kernel or sugar row. The wave drops four 0.7
+spellings' demand:
+
+| Flag | Verdict |
+|---|---|
+| flag:consumers:command:tnpic | dies at S4 with the 0.7 grid front end: the blueprint's twenty pictures are redrawn as kernel grid pictures and zero demand consumers remain; the signed §9 sugar row over the picture environment waits on the kernel binding and math-style sensing recorded on #4908; expiry 0.9 |
+| flag:consumers:key:object:mpo | dies at S4 with the 0.7 object ledger: the kernel spells the silhouette through the prelude skin (`skin=mpo`), which every redrawn figure now writes; zero demand consumers remain; expiry 0.9 |
+| flag:consumers:command:tndots | keep-because: this wave's loops write the kernel spelling `\tn[skin=dots]`, leaving two 0.7 consumers — the ch02 blocked-overlap ladder and the tangent-projector benchmark case — that retire with their own redraw rows at the S4 surface swap; folds into `\tn[skin=dots]` at the language landing; expiry 0.9 |
+| flag:consumers:command:tnspan | keep-because: the refinement rows now state their blocked sites as range-addressed enclosure marks, leaving the ch02 blocked-overlap ladder as the one 0.7 consumer, which retires with its own redraw row at the S4 surface swap; expiry 0.9 |

--- a/scripts/test_tenkz_equation_web.py
+++ b/scripts/test_tenkz_equation_web.py
@@ -102,7 +102,7 @@ def _assert_source_linked_groups(repo_root: Path) -> None:
         strict=True,
     ):
         assert anchor in body, anchor
-        assert body.count(r"\tnpic") == 3, anchor
+        assert body.count(r"\begin{tenkz}") == 3, anchor
         assert body.count(r"\xrightarrow") == 2, anchor
 
 


### PR DESCRIPTION
The blueprint's last 0.7 command surface is gone: the twenty `\tnpic`
pictures across four ch21 files are redrawn as kernel grid pictures under
`\tenkzkernel`, and the grid tier's blueprint demand is now zero.

## Per-file counts

| file | `\tnpic` before | after | kernel pictures added |
|---|---:|---:|---:|
| `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | 8 | 0 | 8 |
| `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | 6 | 0 | 6 |
| `ch21_mpdo_rfp_renormalization.tex` | 4 | 0 | 4 |
| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | 2 | 0 | 3 |

The product law's right side separates into two whole traced pictures —
the multiplicity loop and the operator loop share no index, so their
juxtaposition is the product of a scalar and an operator — hence 21
kernel pictures replace 20 `\tnpic`.

## Spelling notes

- The eight fusion wedges consume the `\tnfuse` sugar row bound by LionSR/TNLean#5624
  (`skin=pill` as in the ch20 LPDO wedges); the aggregate `H` stands as a
  `wires=2` atom across both wire rows, and each H–wedge bond is one
  fused contraction.
- Physical index labels stand on typed ports; every declared side is
  derived from the figure's stated boundary signature (each figure's
  signature comment is unchanged and still matches).
- The renormalization square keeps its tikz-cd carrier with one kernel
  picture per cell. Each nested picture is brace-wrapped so its column
  tabs stay out of the diagram's own alignment (the `ampersand
  replacement` trap: a bare `&` inside a cell body is still an alignment
  tab to the matrix underneath).
- The refinement `\tnspan[box]` groups become range-addressed
  `\tnmark[form=enclosure]` marks.

## G3 occurrences

None. All twenty occurrences are display pictures (figure blocks,
`tenkzequation` rows, or tikz-cd cells); no occurrence needs
inline-in-text embedding, so nothing waits on LionSR/tenkz#87.

## Kernel gaps measured (recorded in the shrink session, on LionSR/tenkz#13)

1. A multi-row frame mints its vertical bond under an ellipsis column
   too: two facing `skin=dots` cells get a floating pairleg stub, and no
   spelling suppresses a single frame bond, so the product law's left
   panel authors its bonds under `bonds=none` (nine wires for one stub).
2. One row of a multi-row frame cannot be traced alone: a side `trace`
   word closes every row (an empty spacer row included), and `trace=`
   closes cells to themselves. Disjoint loops therefore separate into
   whole pictures, which is the right sentence for a tensor product of
   closed diagrams, but it costs a `tabular` stack where 0.7 had
   `layer sep=2`.

## Ledgers

- `DISPOSITIONS.md`: the four redraw rows discharge; counters recompute
  to 172 preserve / 11 codemod / 19 redraw over the new 202 total
  (191 environments + 11 `\tntree`); checker and self-test pass.
- `SHRINK.md`: new appended session sentences the four flags the drained
  spellings raise — `\tnpic` (0 demand consumers, dies at S4; §9 sugar
  row waits on LionSR/tenkz#87), 0.7 `mpo` object flag (0 consumers, dies at S4),
  `\tndots` and `\tnspan` (remaining consumers are the ch02
  blocked-overlap ladder and one benchmark case, retiring with their own
  rows). Gate passes with no meter movement.

## Line delta

Blueprint: +174 −118 (net +56). The kernel spells typed ports and
authored records where 0.7 wrote `up=`/`down=` shorthands; the two gaps
above account for the bulk of the surplus. Whole PR: +228 −132.

## Gates

- `scripts/tenkz_kernel_probes.sh --check` — pass (141 regressions, 11
  sugar pairs, 12 record streams, pixels byte-identical)
- `scripts/tenkz_golden.sh --check` — pass (211 streams)
- `python3 scripts/check_tenkz_dispositions.py` (+ self-test) — pass
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — pass
- `python3 scripts/test_tenkz_pic.py` — pass
- `python3 scripts/test_tenkz_equation_web.py` — pass (17 equation rows,
  picture counts unchanged; its source anchor for the refinement rows now
  counts `\begin{tenkz}` panels where it counted `\tnpic`)
- `scripts/tenkz_pixelpair.sh origin/main` — pass (4 pages byte-identical
  at 300 dpi; no `tex/tenkz/` change in this PR)

## Render evidence

Every migrated picture rendered at 200 dpi beside its 0.7 original
(xelatex standalone with the web pipeline's preamble) and inspected:
the fusion-coisometry G equation, the three zipper rows, the trace-power
product law, both refinement-channel rows, and the whole renormalization
tikz-cd square. Topology, boundary legs, labels, and elisions match the
originals; the kernel routes both trace rails of a paired row below the
chain (0.7 drew the first above), and enclosure marks replace the dashed
span boxes — both house kernel forms.

Part of LionSR/TNLean#4699; tracker LionSR/tenkz#13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TeX diagram and migration-ledger changes only; topology and boundary semantics are preserved and gates report byte-identical renders versus the prior 0.7 originals.
> 
> **Overview**
> Removes the blueprint’s remaining **0.7 `\tnpic` surface** by redrawing **twenty** display figures in four ch21 files as **`\tenkzkernel` / `\begin{tenkz}`** kernel grid pictures. Fusion coisometry and zipper identities, the trace-power product law, the renormalization **tikz-cd** square (one kernel picture per cell, brace-wrapped), and the two-step refinement-channel rows are spelled with **`skin=mpo`**, **`skin=pill`** fusion wedges, typed **`ports=`**, hand-authored **`tnwire`** (including **`bonds=none`** where ellipsis columns would mint stray bonds), and **`tnmark[form=enclosure]`** instead of dashed span boxes.
> 
> The product-law right side splits into **two whole traced pictures** in a **`tabular` stack** because the multiplicity and operator loops share no index.
> 
> **`DISPOSITIONS.md`** discharges the four redraw rows and updates counts (**`\tnpic` → 0**); **`SHRINK.md`** records the migration session; **`test_tenkz_equation_web.py`** asserts three `\begin{tenkz}` panels per refinement equation row instead of three `\tnpic` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef6ac5b2b505048d8f91bc3efc9ff43e82ba9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->