### PR TITLE
doc(blueprint): add the Case-I trace-decay lemmas

### DIFF
--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -270,15 +270,6 @@ theorem activeSectorTraceMatrix_pow_two_eq_pow_three_of_literal_ZCL
       _ = (T ^ 3).map Complex.ofReal := h2
   exact hT_sq_cu
 
-/-! ## Proved components
-
-The following theorems capture the proved matrix-algebra components of the
-Lemma C.5 Case-I argument.  The final singleton-consequence theorem
-`lemmaC5_caseI_singleton` is deferred (see the remaining-gap section
-below for the two missing pieces).
--/
-
-
 /-- If `T² = T³` and `T` is primitive, then every entry of `T²` is positive.
 This is the Perron-projection lemma used in the Case-I route.
 
@@ -298,10 +289,10 @@ theorem activeSectorTraceMatrix_pow_two_pos (F : PhysicalSectorFactorization K)
   have hTprim := F.activeSectorTraceMatrix_isPrimitive p hpos hspan hnonzero htriangle
   exact hTprim.pow_two_pos_of_pow_two_eq_pow_three hTsq_eq_Tcu
 
-/-! ## Lemma C.5 Case I — remaining theorems
+/-! ## Lemma C.5 Case I — completed route
 
 The matrix-algebra components above give `S ≤ T²` entrywise, `T² = T³` from
-literal ZCL, primitivity of `T`, and `T² > 0` entrywise.  Four further
+literal ZCL, primitivity of `T`, and `T² > 0` entrywise.  The following four
 theorems complete the Case-I argument:
 
 1. **Trace similarity** `tr(S_hat ^ N) = tr(S^N)` where `S_hat` is the diagonal

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -960,8 +960,8 @@
     $S^*_{k,h}=\re\tr(\eta_{k,h}^2)$.
 \end{proof}
 
-\begin{lemma}[Trace invariance under squared diagonal similarity]
-    \label{lem:mpdo_trace_pow_similarity_squared_diagonal}
+\begin{theorem}[Trace invariance under squared diagonal similarity]
+    \label{thm:mpdo_trace_pow_similarity_squared_diagonal}
     \lean{MPOTensor.trace_pow_similarity_squared_diagonal}
     \leanok
     Let $I$ be a finite index set, let $S\in\mathbb R^{I\times I}$, and
@@ -979,7 +979,7 @@
     This project lemma isolates the diagonal-conjugation calculation used in
     the Case-I argument. It is not a separately stated result of
     \cite{Cirac2016MPDO_arXiv}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -1069,7 +1069,7 @@
       thm:mpdo_active_trace_matrix_literal_zcl_powers,
       thm:mpdo_active_sector_three_step_return_and_primitivity,
       thm:mpdo_overlap_formula,
-      lem:mpdo_trace_pow_similarity_squared_diagonal,
+      thm:mpdo_trace_pow_similarity_squared_diagonal,
       thm:matrix_trace_pow_tendsto_zero_of_nonneg_le_hadamard_self}
     By contradiction, suppose $|I_*|\geq2$. The overlap formula and the
     normal self-overlap limit
@@ -1080,8 +1080,9 @@
     matching squared diagonal conjugate $\widehat S$ of $S^*$ is
     entrywise non-negative and bounded by $P\odot P$. On the nontrivial
     active-sector set, Theorem~\ref{thm:matrix_trace_pow_tendsto_zero_of_nonneg_le_hadamard_self}
-    gives $\tr(\widehat S^N)\to0$. Lemma~\ref{lem:mpdo_trace_pow_similarity_squared_diagonal}
-    then gives $\tr((S^*)^N)\to0$, contradicting the limit $1$.
+    gives $\tr(\widehat S^N)\to0$.
+    Theorem~\ref{thm:mpdo_trace_pow_similarity_squared_diagonal} then gives
+    $\tr((S^*)^N)\to0$, contradicting the limit $1$.
 \end{proof}
 
 \begin{theorem}[The Case-I relation $(T^*)^2=T^*$]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -639,9 +639,6 @@
     entries of $\eta_{k_n,k_{n+1}}^2$.
 \end{proof}
 
-% Proved Case-I components; the singleton-sector assembly (the Case-I
-% relations $(T^*)^2=T^*$ and $Q(1-LQ)L=0$) is not yet formalized.  The
-% route is sketched in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{lemma}[Trace-squared matrix of the neighboring operators]
     \label{lem:mpdo_active_sector_trace_sq_matrix}
     \lean{MPOTensor.activeSectorTraceSqMatrix,
@@ -681,13 +678,6 @@
     to $\eta_{k,h}$.
 \end{proof}
 
-% Proved Case-I components.  The remaining singleton-sector assembly
-% is not yet formalized: the Case-I relations $(T^*)^2=T^*$ and
-% $Q(1-LQ)L=0$ in the rectangular decomposition
-% $\mathcal T_{\cal K}=LQ$.  The virtual-spanning counterexample above
-% shows that the last relation does not follow from virtual spanning
-% alone.  The route is sketched in
-% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{theorem}[Literal zero correlation length stabilizes the active
     trace matrix]
     \label{thm:mpdo_active_trace_matrix_literal_zcl_powers}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -978,6 +978,73 @@
     $S^*_{k,h}=\re\tr(\eta_{k,h}^2)$.
 \end{proof}
 
+\begin{lemma}[Trace invariance under squared diagonal similarity]
+    \label{lem:mpdo_trace_pow_similarity_squared_diagonal}
+    \lean{MPOTensor.trace_pow_similarity_squared_diagonal}
+    \leanok
+    Let $I$ be a finite index set, let $S\in\mathbb R^{I\times I}$, and
+    let $v\in\mathbb R^I$ satisfy $v_i>0$ for every $i\in I$. Put
+    \begin{align}
+        D&=\diag(v_i^2).
+        \notag
+    \end{align}
+    Then, for every $N\geq0$,
+    \begin{align}
+        \tr\!\left((D^{-1}SD)^N\right)
+        &=\tr(S^N).
+        \notag
+    \end{align}
+    This project lemma isolates the diagonal-conjugation calculation used in
+    the Case-I argument. It is not a separately stated result of
+    \cite{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Every diagonal entry of $D$ is nonzero, so $D$ is invertible. Induction
+    on $N$ gives
+    \begin{align}
+        (D^{-1}SD)^N&=D^{-1}S^ND.
+        \notag
+    \end{align}
+    Cyclicity of trace and $DD^{-1}=1$ then give the claimed equality.
+\end{proof}
+
+\begin{theorem}[Trace-power decay below a stochastic Hadamard square]
+    \label{thm:matrix_trace_pow_tendsto_zero_of_nonneg_le_hadamard_self}
+    \lean{Matrix.trace_pow_tendsto_zero_of_nonneg_le_hadamard_self}
+    \leanok
+    Let $I$ be a finite set with at least two elements, and let
+    $P,S\in\mathbb R^{I\times I}$. Suppose that $P$ is primitive and
+    row-stochastic, and that, for all $i,j\in I$,
+    \begin{align}
+        0\leq S_{i,j}&\leq(P\odot P)_{i,j}=P_{i,j}^2.
+        \notag
+    \end{align}
+    Then
+    \begin{align}
+        \tr(S^N)&\longrightarrow0
+        \qquad\text{as }N\to\infty.
+        \notag
+    \end{align}
+    This project matrix-theoretic lemma is used in the Case-I argument. It
+    is not a separately stated result of \cite{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Entrywise non-negativity gives $\tr(S^N)\geq0$. Entrywise domination is
+    preserved by matrix powers, and hence
+    \begin{align}
+        \tr(S^N)&\leq\tr\!\left((P\odot P)^N\right).
+        \notag
+    \end{align}
+    Every power of $P\odot P$ has operator norm at most one. Primitivity
+    gives a positive power whose operator norm is strictly below one; the
+    division algorithm then shows that $(P\odot P)^N\to0$. Thus its trace
+    tends to zero, and the squeeze theorem proves the result.
+\end{proof}
+
 \begin{theorem}[The active sector is unique]
     \label{thm:mpdo_active_sector_singleton}
     \lean{MPOTensor.card_activeSector_eq_one_of_literal_ZCL}
@@ -1019,18 +1086,20 @@
       lem:mpdo_active_sector_trace_sq_matrix,
       thm:mpdo_active_trace_matrix_literal_zcl_powers,
       thm:mpdo_active_sector_three_step_return_and_primitivity,
-      thm:mpdo_overlap_formula}
-    By contradiction: suppose $|I_*|\geq2$. The overlap formula and the
+      thm:mpdo_overlap_formula,
+      lem:mpdo_trace_pow_similarity_squared_diagonal,
+      thm:matrix_trace_pow_tendsto_zero_of_nonneg_le_hadamard_self}
+    By contradiction, suppose $|I_*|\geq2$. The overlap formula and the
     normal self-overlap limit
     (\cite[lines~1080--1100]{Cirac2016MPDO_arXiv}) give
-    $\tr((S^*)^N)\to1$. Conjugating the primitive trace matrix $T^*$ by
-    its positive Perron eigenvector (with eigenvalue $1$, obtained from
-    the positive rank-one factorization of $(T^*)^2$ under $(T^*)^2=(T^*)^3$)
-    yields a row-stochastic primitive matrix $P$; the matching squared
-    conjugation of $S^*$ is bounded entrywise by $P\odot P$. Since
-    $|I_*|\geq2$, $P$ is an irreducible substochastic matrix on a
-    nontrivial index set, so $\tr((S^*)^N)\to0$, contradicting the limit
-    of $1$.
+    $\tr((S^*)^N)\to1$. The relation $(T^*)^2=(T^*)^3$ and primitivity
+    supply a positive Perron eigenvector with eigenvalue $1$. Conjugating
+    by its diagonal gives a row-stochastic primitive matrix $P$. The
+    matching squared diagonal conjugate $\widehat S$ of $S^*$ is
+    entrywise non-negative and bounded by $P\odot P$. On the nontrivial
+    active-sector set, Theorem~\ref{thm:matrix_trace_pow_tendsto_zero_of_nonneg_le_hadamard_self}
+    gives $\tr(\widehat S^N)\to0$. Lemma~\ref{lem:mpdo_trace_pow_similarity_squared_diagonal}
+    then gives $\tr((S^*)^N)\to0$, contradicting the limit $1$.
 \end{proof}
 
 \begin{theorem}[The Case-I relation $(T^*)^2=T^*$]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -758,14 +758,6 @@
     Theorem~\ref{thm:matrix_primitive_pow_two_rank_one}.
 \end{proof}
 
-% Elementary combinatorial infrastructure for the overlap formula
-% $O_{{\cal K}^{\mathrm{MPS}}{\cal K}^{\mathrm{MPS}}}(N)=\tr((S^*)^N)$,
-% which is not yet assembled: reconciling the active-sector-restricted
-% index set $I_*$ used by $S^*$ with the full sector index set that the
-% cyclic-product trace factorization of
-% Theorem~\ref{thm:mpdo_cyclic_neighboring_trace_products} ranges over
-% remains open.  The route is sketched in
-% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{lemma}[Indicator-path expansion of a matrix power]
     \label{lem:mpdo_pow_apply_path_indicator}
     \lean{MPOTensor.pow_apply_eq_sum_path_indicator}
@@ -1029,8 +1021,9 @@
         \tr(S^N)&\leq\tr\!\left((P\odot P)^N\right).
         \notag
     \end{align}
-    Every power of $P\odot P$ has operator norm at most one. Primitivity
-    gives a positive power whose operator norm is strictly below one; the
+    Every power of $P\odot P$ has $L^\infty$ operator norm at most one.
+    Primitivity gives a positive power whose $L^\infty$ operator norm is
+    strictly below one; the
     division algorithm then shows that $(P\odot P)^N\to0$. Thus its trace
     tends to zero, and the squeeze theorem proves the result.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex
@@ -1003,10 +1003,9 @@
         0\leq S_{i,j}&\leq(P\odot P)_{i,j}=P_{i,j}^2.
         \notag
     \end{align}
-    Then
+    Then, as $N\to\infty$,
     \begin{align}
-        \tr(S^N)&\longrightarrow0
-        \qquad\text{as }N\to\infty.
+        \tr(S^N)&\longrightarrow0.
         \notag
     \end{align}
     This project matrix-theoretic lemma is used in the Case-I argument. It


### PR DESCRIPTION
## What changed

- adds a Chapter 21 lemma for `trace_pow_similarity_squared_diagonal`, with the exact quantifier $N\ge0$ and a formula-first diagonal-similarity proof;
- adds a theorem for `Matrix.trace_pow_tendsto_zero_of_nonneg_le_hadamard_self`, including the finite nontrivial index set, primitive row-stochastic matrix, nonnegativity, and entrywise Hadamard-square bound;
- wires both labels into the proof of active-sector uniqueness;
- corrects that proof's direction: trace decay is proved for the squared-diagonal conjugate and then transported back to $S^*$, while the normal overlap independently gives the contradictory limit $1$;
- describes the Hadamard-square decay through a strictly contractive positive power and the division algorithm, matching the Lean proof rather than asserting an unsupported immediate row deficit;
- removes two stale source comments that still said the now-merged singleton, $T^2=T$, and rectangular steps were unformalized.

Both new entries are explicitly project lemmas supporting the CPSV16 Case-I route, not theorems separately stated in the paper.

## Validation

- declaration scan/sync completed; both new `\lean{}` targets resolve;
- targeted builds of `TNLean.MPS.MPDO.LemmaC5CaseI` and `TNLean.Algebra.PerronFrobenius.Substochastic` passed (9169 jobs);
- two direct `lualatex` passes for `blueprint/src/print.tex` with `TEXINPUTS="../../tex/tenkz//:"` passed (only expected standalone bibliography warnings);
- `git diff --check` passed;
- changed the Chapter 21 source plus stale status comments in `TNLean/MPS/MPDO/LemmaC5CaseI.lean`; no Lean statements or proofs changed, and generated artifacts were removed.

Closes #5638. Advances #5404 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment updates only; mathematical content mirrors existing Lean and does not alter proofs or runtime behavior.
> 
> **Overview**
> Blueprint Chapter 21 now documents two **project lemmas** that were already in Lean: **trace invariance under squared diagonal similarity** (`trace_pow_similarity_squared_diagonal`) and **trace-power decay** when a nonnegative matrix is entrywise bounded by a primitive row-stochastic **Hadamard square** (`Matrix.trace_pow_tendsto_zero_of_nonneg_le_hadamard_self`), with proofs aligned to the formalization (contractive positive power of `P⊙P`, division algorithm).
> 
> The **active-sector uniqueness** proof is rewritten so decay is proved for the squared-diagonal conjugate **Ŝ** of `S*`, then transported back via trace similarity, while the overlap formula still gives `tr((S*)^N)→1`—fixing the logical direction relative to the old sketch.
> 
> Stale “not yet formalized” comments are removed in the blueprint and in `LemmaC5CaseI.lean`; the Case-I route is marked **completed** in Lean commentary. **No Lean statements or proofs were changed.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a60bb169cadbd20a6a05ed175d24a39575f5051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

