### PR TITLE
fix(tenkz): read a chained picture's body inside a math alignment cell

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2756,6 +2756,25 @@ grep -Fq '|addr=(2,3)|' "$WORK/r_beamer_frame.tnlog" || {
   echo "FAIL: the plain beamer frame's chained body lost its cursor" >&2
   exit 1
 }
+# A math alignment cell holds the body scan hostage to the alignment counter:
+# mathtools' gathered template and amsmath's aligned both leave it at zero,
+# where a raw tab once ended the cell mid-scan.  The chained fixture holds
+# exactly when both cells' pictures keep every atom and the tab and the row
+# break both advance the cursor there.
+alignment_pictures=$(grep -c '^picture|' "$WORK/r_alignment_cell.tnlog" || true)
+[ "$alignment_pictures" -eq 2 ] || {
+  echo "FAIL: an alignment cell lost a chained picture" >&2
+  exit 1
+}
+alignment_atoms=$(grep -c '^atom|' "$WORK/r_alignment_cell.tnlog" || true)
+[ "$alignment_atoms" -eq 6 ] || {
+  echo "FAIL: an alignment cell's chained body lost atoms" >&2
+  exit 1
+}
+grep -Fq '|addr=(2,2)|' "$WORK/r_alignment_cell.tnlog" || {
+  echo "FAIL: an alignment cell's chained body lost its cursor" >&2
+  exit 1
+}
 
 # A slot span answers from the atom's own measured silhouette wherever it
 # stands: a wires=2 atom at a midway address keeps slot 2 for wires and for

--- a/tests/tenkz/kernel/regression/r_alignment_cell.tex
+++ b/tests/tenkz/kernel/regression/r_alignment_cell.tex
@@ -1,0 +1,23 @@
+% Regression: a chained picture compiles inside a math alignment cell.
+% mathtools rebuilds gathered on a cell template that leaves the alignment
+% counter at zero, and amsmath's aligned does the same, so the captured-body
+% scan once met the cell's end-of-template marker at the first raw tab and
+% died in a runaway.  The align-safe scan reads both bodies whole.
+\documentclass{article}
+\usepackage{mathtools}
+\usepackage{tenkz}
+
+\begin{document}
+\tenkzkernel
+\[\begin{gathered}
+  \begin{tenkz}[rows={wire}, cols=2, physical=up, west=open, east=open]
+    \tn{} & \tn{}
+  \end{tenkz}
+\end{gathered}\]
+\[\begin{aligned}
+  \begin{tenkz}[rows={wire,wire}, cols=2, bonds=grid]
+    \tn{} & \tn{} \\
+    \tn{} & \tn{}
+  \end{tenkz}
+\end{aligned}\]
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -17287,6 +17287,16 @@
 % their captured bodies, and it holds in a plain beamer frame.  A tab nested
 % in a braced argument is data and stays untouched; \tngroup applies the
 % same rewrite to its own body.
+%
+% The scan itself must survive an outer alignment cell.  Inside gathered or
+% aligned (amsmath, and mathtools' rebuilt gathered) the picture sits in an
+% \halign cell whose template leaves the alignment counter at zero, so the
+% first raw tab met while grabbing the delimited body would make TeX close
+% the cell -- inserting the outer end-of-template marker mid-scan, the
+% "Forbidden control sequence" runaway.  The align-safe pair brackets the
+% whole scan: it raises the alignment counter by an unmatched brace read
+% under a skipped conditional, so a tab is an ordinary token to the grab,
+% and lowers it again before the captured body executes.
 \tl_new:N \l__tenkz_kernel_body_tl
 \tl_new:N \l__tenkz_kernel_group_body_tl
 \cs_new_protected:Npn \__tenkz_kernel_rewrite_tabs:N #1
@@ -17295,6 +17305,7 @@
   {
     \__tenkz_kernel_begin:n {#1}
     \tl_clear:N \l__tenkz_kernel_body_tl
+    \group_align_safe_begin:
     \__tenkz_kernel_env_body:w
   }
 % #1 is the chunk before the next \end and #2 that \end's environment name.
@@ -17306,6 +17317,7 @@
     \tl_put_right:Nn \l__tenkz_kernel_body_tl {#1}
     \str_if_eq:nnTF {#2} {tenkz}
       {
+        \group_align_safe_end:
         \__tenkz_kernel_rewrite_tabs:N \l__tenkz_kernel_body_tl
         % the break between the option list and the first declaration
         \ignorespaces


### PR DESCRIPTION
Closes LionSR/TNLean#5651.  Tracker: LionSR/tenkz#13.

## Regression

PR LionSR/TNLean#5617 moved the kernel picture to captured-body reading: the environment
grabs its body up to its own `\end` with a delimited scan, rewrites the
document's alignment-tab tokens into the column step, and executes the
result.  Inside a math alignment cell that scan dies.  mathtools rebuilds
`gathered` on the cell template `\MT_gathered_pre: \strut@$\m@th
\displaystyle##$ \MT_gathered_post:`, and amsmath's `aligned` template is
likewise unbraced, so the alignment counter sits at zero inside the cell.
The first raw `&` met while TeX is grabbing the delimited body then closes
the cell mid-scan: TeX inserts the v-part of the template followed by the
outer end-of-template marker, which is exactly the reported runaway

```
Runaway argument?
 \tn {} $\MT_gathered_post:
! Forbidden control sequence found while scanning use of \__tenkz_kernel_env_body:w.
```

The minimal reproduction from LionSR/TNLean#5651 fails on main in all four combinations
(`gathered`/`aligned` under amsmath alone and under mathtools) — the issue's
mathtools framing understated the surface; any `\halign` cell whose template
leaves the counter at zero is affected, and the grid-deletion agent's
independent `aligned` hit was the same defect.

## Mechanism

Two align-safe brackets around the body scan, nothing else:

- `\group_align_safe_begin:` before `\__tenkz_kernel_env_body:w` starts the
  delimited grab;
- `\group_align_safe_end:` in the terminal branch, after the picture's own
  `\end{tenkz}` has been recognized and before the captured body is rewritten
  and executed.

The expl3 pair raises the alignment counter by one unmatched brace read under
a skipped conditional, and lowers it symmetrically.  With the counter
nonzero, a catcode-4 tab met during the grab is an ordinary token that lands
in the captured body — the cell's template can no longer be triggered
mid-scan — and the existing rewrite then gives that token the column step
exactly as before.  Outside any alignment the counter is far from zero
already, so the brackets are inert there: the beamer plain-frame reading and
every other LionSR/TNLean#5617 behaviour are unchanged, as the byte-identical golden
streams and kernel probes confirm.

I considered the documented-contract route (brace-wrap inside math
alignments plus a fail-fast diagnostic).  It is strictly worse here: the
capture can be made robust with two tokens, the brace-wrap rule would
re-impose a spelling burden the capture model was introduced to remove, and
the pre-#5617 kernel accepted these bodies in alignments, so the contract
position is that they compile.  The tikz-cd house idiom (#5641) is
unaffected and still needed there, since tikz-cd splits its matrix body
textually before any picture code runs.

## Evidence

- Minimal reproduction from LionSR/TNLean#5651 compiles; so do the `aligned` and
  amsmath-only variants.
- New regression fixture `tests/tenkz/kernel/regression/r_alignment_cell.tex`
  pins a chained picture inside mathtools' `gathered` and inside `aligned`
  (tab and row break both advancing the cursor), with structural assertions
  in `scripts/tenkz_kernel_probes.sh` beside the beamer block.
- `scripts/tenkz_golden.sh --check`: 159 event streams byte-identical.
- `scripts/tenkz_kernel_probes.sh --check`: 141 review regressions hold (including the new
  alignment-cell assertions), 11 sugar spellings byte-identical in events and
  pixels, 12 kernel record streams byte-identical, kernel pixels
  byte-identical.
- `scripts/tenkz_pixelpair.sh origin/main`: 4 pages byte-identical at 300 dpi.
- `python3 scripts/tenkz_rmp.py check --id rmp-workbench-ii-historical-composite`: PASS.
- `python3 scripts/tenkz_rmp.py book --all`: PASS, wrote
  `output/pdf/tenkz-rmp-benchmark.pdf` (2026-08-08 15:00).
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`: census
  stable at 142, all 139 flags carry verdicts.
- `python3 scripts/test_check_tenkz_dispositions.py` and
  `python3 scripts/check_tenkz_dispositions.py`: 202 blueprint occurrences
  and 159 standalone fixtures reconcile exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core environment body capture in the kernel; scope is small (two align-safe brackets) but any mistake could break tab/row parsing outside alignments.
> 
> **Overview**
> Fixes a **runaway / forbidden control sequence** when a `tenkz` picture with a captured body (tabs and row breaks) sits inside **math alignment cells** (`gathered`, `aligned`, including mathtools’ rebuilt `gathered`). Those cells leave TeX’s alignment counter at zero, so the first raw `&` during the delimited body grab used to close the outer cell mid-scan.
> 
> The kernel now brackets the whole `\__tenkz_kernel_env_body:w` grab with expl3’s **`group_align_safe_begin:` / `group_align_safe_end:`**, so tabs are ordinary tokens during capture and the existing tab rewrite still runs before execution. **Beamer** and other non-alignment contexts stay unchanged.
> 
> Adds regression **`r_alignment_cell.tex`** and matching structural checks in **`tenkz_kernel_probes.sh`** (picture/atom counts and cursor address).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5fda4e6ed75eca12cec1a4db0fc1b3adc2a7420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->