### PR TITLE
doc(tenkz): drop the retired route=curve compatibility claims

### DIFF
--- a/docs/tenkz/LANGUAGE.md
+++ b/docs/tenkz/LANGUAGE.md
@@ -122,7 +122,8 @@ The canonical examples include these distinctions:
   policy overrides the picture's: `boundary=none, east=cup` seals the west
   and bends the east, because the specific statement outranks the general
   one. A cup that finds no pair to bend is an error, not a blank space.
-- `route=arc` is canonical; `route=curve` is a compatibility alias.
+- `route=arc` is the canonical curved spelling; the route family is
+  `straight`, `orth`, and `arc`.
 
 ## Extension gates
 

--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -93,7 +93,7 @@
   \qritem{explicit scope}{document, picture, object, connection}
   \qritem{typed ports}{virtual joins virtual; physical joins physical}
   \qritem{role/species}{semantic style, never topology}
-  \qritem{route=arc}{canonical spelling; curve is compatibility only}
+  \qritem{route=arc}{the canonical curved spelling; the family is straight, orth, arc}
 
   \qrsection{Verification}
   \qritem{xelatex}{compile the exact source}


### PR DESCRIPTION
The free-dialect demolition (#5626) removed the route=curve alias from
the registry, so the surviving parser accepts straight, orth, and arc
only. The language sketch and the quickref card still promised the
compatibility spelling; both now state the real family.

Closes LionSR/tenkz#181.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to canonical spelling text; no parser, registry, or runtime behavior changes.
> 
> **Overview**
> Updates the **normative language sketch** (`LANGUAGE.md`) and the **manual quickref card** (`manual2.tex`) so they no longer describe `route=curve` as a compatibility spelling.
> 
> Both now say **`route=arc` is the canonical curved route** and name the accepted family as **`straight`**, **`orth`**, and **`arc`**, matching the parser/registry after the free-dialect demolition removed the `curve` alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b63886761ecc84260a143d85ded86af634c2272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->