### PR TITLE
doc(Channel): align steering terminology with Wolf

### DIFF
--- a/TNLean/Channel/QuantumSteering.lean
+++ b/TNLean/Channel/QuantumSteering.lean
@@ -95,11 +95,11 @@ private theorem bipartiteBlock_vecMulVec_eq (ψ : Fin dA × Fin dB → ℂ) (i�
   simp only [Matrix.bipartiteBlock_apply, Matrix.vecMulVec_apply, Pi.star_apply,
     Matrix.schmidtCoeffMatrix_apply]
 
-/-- **Partial-trace consequence of the transpose trick** (Wolf, line 364, in general
-purification-independent form): for any linear map `T` on Bob's system and any bipartite
-vector `ψ` with coefficient matrix `C`, tracing out Bob's system after applying
-`id ⊗ T` to `|ψ⟩⟨ψ|` equals `C (T*(1))ᵀ Cᴴ`, where `T*` is the trace-pairing
-adjoint of `T`.
+/-- **Partial-trace consequence of the transpose trick** (Wolf, line 364, in
+general purification-independent form): for any linear map `T` on Bob's system
+and any bipartite vector `ψ` with coefficient matrix `C`, tracing out Bob's
+system after applying `id ⊗ T` to `|ψ⟩⟨ψ|` equals
+`C (T*(1))ᵀ Cᴴ`, where `T*` is the trace-pairing adjoint of `T`.
 
 Wolf derives this for the specific canonical purification `ψ = (√ρ ⊗ 1)|Ω⟩`;
 the identity holds for an arbitrary purification since it only uses the

--- a/TNLean/Channel/QuantumSteering.lean
+++ b/TNLean/Channel/QuantumSteering.lean
@@ -14,7 +14,7 @@ import TNLean.Channel.SingleKraus
 import TNLean.Channel.TensorMap
 
 /-!
-# Quantum steering via instruments (Wolf Chapter 1, Proposition 1.2)
+# Quantum steering via instruments (Wolf Chapter 1, Proposition 1.3)
 
 This file proves Wolf's quantum-steering proposition: for a density operator
 `ρ` with purification `ψ`, every convex decomposition `ρ = Σᵢ λᵢ ρᵢ` is
@@ -40,7 +40,7 @@ lines 348--357 (statement) and 359--370 (proof sketch).
   is the general (purification-independent) form of the identity Wolf
   derives at line 364 for the canonical purification `ψ = (√ρ ⊗ 1)|Ω⟩`.
 * `Matrix.exists_instrument_of_isConvexDecomposition`: **Wolf Proposition
-  1.2 (Quantum steering)**. For every convex decomposition `ρ = Σᵢ λᵢ ρᵢ`
+  1.3 (Quantum steering)**. For every convex decomposition `ρ = Σᵢ λᵢ ρᵢ`
   there is an instrument `{Tᵢ}` on Bob's system with
   `λᵢ • ρᵢ = Tr_B[(id ⊗ Tᵢ)(|ψ⟩⟨ψ|)]` for every `i`.
 
@@ -83,7 +83,7 @@ theorem traceAdjointMap_singleKrausMap_one {α β : Type*} [Fintype α] [Fintype
   rw [Matrix.traceAdjointMap_singleKrausMap, singleKrausMap_apply, Matrix.mul_one,
     Matrix.conjTranspose_conjTranspose]
 
-/-! ### The transpose-trick identity -/
+/-! ### Partial-trace consequence of the transpose trick -/
 
 /-- The `(i₁, j₁)`-block of `vecMulVec ψ (star ψ)` is the outer product of
 the corresponding rows of the coefficient matrix. -/
@@ -95,9 +95,9 @@ private theorem bipartiteBlock_vecMulVec_eq (ψ : Fin dA × Fin dB → ℂ) (i�
   simp only [Matrix.bipartiteBlock_apply, Matrix.vecMulVec_apply, Pi.star_apply,
     Matrix.schmidtCoeffMatrix_apply]
 
-/-- **The transpose trick** (Wolf, line 364, in general purification-independent
-form): for any linear map `T` on Bob's system and any bipartite vector `ψ`
-with coefficient matrix `C`, tracing out Bob's system after applying
+/-- **Partial-trace consequence of the transpose trick** (Wolf, line 364, in general
+purification-independent form): for any linear map `T` on Bob's system and any bipartite
+vector `ψ` with coefficient matrix `C`, tracing out Bob's system after applying
 `id ⊗ T` to `|ψ⟩⟨ψ|` equals `C (T*(1))ᵀ Cᴴ`, where `T*` is the trace-pairing
 adjoint of `T`.
 

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -203,7 +203,7 @@ reduced state.
     $\rho=\sum_i\lambda_i\rho_i$.
 \end{definition}
 
-\begin{theorem}[The transpose trick]\label{thm:transpose_trick}
+\begin{theorem}[Partial-trace consequence of the transpose trick]\label{thm:transpose_trick}
     \lean{Matrix.partialTraceRight_idTensorMap_vecMulVec}
     \leanok
     For a bipartite vector $\psi\in\C^{d_A}\otimes\C^{d_B}$ with coefficient


### PR DESCRIPTION
Aligns the Chapter 1 steering documentation with Wolf's source: quantum steering is Proposition 1.3, while the formalized arbitrary-vector identity is described as the partial-trace consequence of the transpose trick rather than Eq. (1.24) itself. Lean declarations, theorem statements, proofs, blueprint tags, labels, and dependency edges are unchanged.

## Validation

- `lake build TNLean.Channel.QuantumSteering`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — 6587/6587 entries synchronized
- `./scripts/build_blueprint_ch01_12.sh` — focused 216-page volume compiled

Closes LionSR/QICLean#287.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text and blueprint title changes only; formal names, proofs, and sync tags are unchanged.
> 
> **Overview**
> Aligns **reader-facing prose** in `QuantumSteering.lean` and the Chapter 1 blueprint with Wolf’s numbering and naming, without changing Lean declarations, theorem statements, proofs, or `\lean{}` tags.
> 
> **Quantum steering** is now cited as Wolf **Proposition 1.3** (was 1.2) in the module doc and main-results list. The identity `partialTraceRight_idTensorMap_vecMulVec` is labeled the **partial-trace consequence of the transpose trick** instead of “the transpose trick,” matching that it is the purification-independent partial-trace formula Wolf uses at line 364—not Eq. (1.24) itself. The blueprint theorem title is updated the same way; label `thm:transpose_trick` and the `\lean{Matrix.partialTraceRight_idTensorMap_vecMulVec}` link stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4565dd96ea2cd066d8498813d2772b338646f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->