### PR TITLE
fix(tenkz): guard the physical-closure glyph-anchor reads for skin=none

### DIFF
--- a/tests/tenkz/kernel/regression/r_void_physical_closure.tex
+++ b/tests/tenkz/kernel/regression/r_void_physical_closure.tex
@@ -1,0 +1,135 @@
+% Regression: a void=open hole keeps its plane physical closure ink.  The
+% row-zero opening and both row-zero trace spellings route through the
+% hole's skinless record, and each physical support degrades to the hole's
+% site point instead of raising the glyph-face diagnostic (issue 5619).
+% A skinned partner in the same closure keeps its measured glyph face.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+
+\int_new:N \g__tenkz_test_voidcl_open_int
+\int_new:N \g__tenkz_test_voidcl_trace_int
+\fp_new:N \l__tenkz_test_voidcl_x_fp
+\fp_new:N \l__tenkz_test_voidcl_y_fp
+
+\cs_new_protected:Npn \__tenkz_test_voidcl_close:nnn #1#2#3
+  {
+    \fp_compare:nNnF { abs((#1)-(#2)) } < { 0.000001 }
+      { \errmessage{#3} }
+  }
+
+% The opening's start point is the hole's own site point, and its tip
+% stands one physical-leg reach up the transverse axis.
+\cs_new_eq:NN
+  \__tenkz_test_voidcl_axis_open:n
+  \__tenkz_kernel_r_wire_physical_axis_open:n
+\cs_set_protected:Npn \__tenkz_kernel_r_wire_physical_axis_open:n #1
+  {
+    \__tenkz_test_voidcl_axis_open:n {#1}
+    \exp_args:NV \__tenkz_geom_xy:nNN
+      \l__tenkz_kernel_physical_axis_host_tl
+      \l__tenkz_test_voidcl_x_fp \l__tenkz_test_voidcl_y_fp
+    \__tenkz_test_voidcl_close:nnn
+      { \l__tenkz_kernel_r_x_fp } { \l__tenkz_test_voidcl_x_fp }
+      {a~void~opening~left~its~site~point}
+    \__tenkz_test_voidcl_close:nnn
+      { \l__tenkz_kernel_r_y_fp } { \l__tenkz_test_voidcl_y_fp }
+      {a~void~opening~left~its~site~point}
+    \__tenkz_test_voidcl_close:nnn
+      { \l__tenkz_kernel_r_yb_fp - \l__tenkz_kernel_r_y_fp }
+      { \__tenkz_metric_ratio:n {physleg} }
+      {a~void~opening~lost~its~named~excursion}
+    \int_gincr:N \g__tenkz_test_voidcl_open_int
+  }
+
+% Every void support of a trace is the void's site point, including the
+% clearance-owning east read; a skinned partner keeps a real glyph face,
+% which stands off its site point.
+\cs_new_eq:NN
+  \__tenkz_test_voidcl_trace:n
+  \__tenkz_kernel_r_physical_trace_plane:n
+\cs_set_protected:Npn \__tenkz_kernel_r_physical_trace_plane:n #1
+  {
+    \__tenkz_test_voidcl_trace:n {#1}
+    \exp_args:NV \__tenkz_geom_xy:nNN
+      \l__tenkz_kernel_physical_axis_host_tl
+      \l__tenkz_test_voidcl_x_fp \l__tenkz_test_voidcl_y_fp
+    \__tenkz_test_voidcl_close:nnn
+      { \l__tenkz_kernel_phtrace_from_x_fp } { \l__tenkz_test_voidcl_x_fp }
+      {a~void~trace~support~left~its~site~point}
+    \__tenkz_test_voidcl_close:nnn
+      { \l__tenkz_kernel_phtrace_from_y_fp } { \l__tenkz_test_voidcl_y_fp }
+      {a~void~trace~support~left~its~site~point}
+    \__tenkz_test_voidcl_close:nnn
+      { \l__tenkz_kernel_phtrace_from_east_x_fp }
+      { \l__tenkz_test_voidcl_x_fp }
+      {a~void~trace~clearance~read~left~its~site~point}
+    \__tenkz_test_voidcl_close:nnn
+      {
+        \l__tenkz_kernel_phtrace_from_tip_y_fp
+        - \l__tenkz_kernel_phtrace_from_y_fp
+      }
+      { \__tenkz_metric_ratio:n {physleg} }
+      {a~void~trace~lost~its~named~north~excursion}
+    \str_if_eq:VVTF
+      \l__tenkz_kernel_physical_axis_host_tl
+      \l__tenkz_kernel_physical_axis_other_host_tl
+      {
+        \__tenkz_test_voidcl_close:nnn
+          { \l__tenkz_kernel_phtrace_to_x_fp }
+          { \l__tenkz_test_voidcl_x_fp }
+          {a~one-site~void~trace~split~its~two~supports}
+        \__tenkz_test_voidcl_close:nnn
+          { \l__tenkz_kernel_phtrace_to_y_fp }
+          { \l__tenkz_test_voidcl_y_fp }
+          {a~one-site~void~trace~split~its~two~supports}
+      }
+      {
+        \exp_args:NV \__tenkz_geom_xy:nNN
+          \l__tenkz_kernel_physical_axis_other_host_tl
+          \l__tenkz_test_voidcl_x_fp \l__tenkz_test_voidcl_y_fp
+        \fp_compare:nNnF
+          {
+            abs(
+              \l__tenkz_kernel_phtrace_to_y_fp
+              - \l__tenkz_test_voidcl_y_fp )
+          } > { 0.000001 }
+          { \errmessage{a~skinned~trace~partner~lost~its~glyph~face} }
+      }
+    \int_gincr:N \g__tenkz_test_voidcl_trace_int
+  }
+
+\AtEndDocument
+  {
+    \int_compare:nNnF { \g__tenkz_test_voidcl_open_int } = {1}
+      { \errmessage{the~void~opening~was~not~inspected~once} }
+    \int_compare:nNnF { \g__tenkz_test_voidcl_trace_int } = {2}
+      { \errmessage{the~two~void~traces~were~not~both~inspected} }
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+% A row-zero opening whose column host is an open hole; the skinned
+% neighbour answers the same policy through its ordinary policy leg.
+\begin{tenkz}[
+    rows={wire}, cols=2, bonds=none, physical=up,
+    open={(physical,1)}, frame=plane]
+  \tn[void=open, name=H]{} & \tn[skin=box]{S}
+\end{tenkz}
+% A one-site trace closes both transverse directions on the hole itself.
+\begin{tenkz}[
+    rows={wire}, cols=1, bonds=none, physical=updown, trace=physical,
+    frame={plane,basis={wire at (0,0)}}]
+  \tn[at=(1,1,1), void=open, name=I]{}
+\end{tenkz}
+% A two-site trace joins the hole's site point to a real glyph face.
+\begin{tenkz}[
+    rows={wire,wire}, cols=1, bonds=none, physical=updown,
+    trace={(physical,1)}, frame=plane]
+  \tn[void=open, name=J]{} \\
+  \tn[skin=box]{R}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -10017,6 +10017,28 @@
       }
   }
 
+% A physical carrier read that tolerates a barren `none` host.  A void hole
+% keeps its physical indices, so the closure ink that consumes them is
+% legitimate even though the hole has no glyph face to probe.  Its support
+% degrades to the host's site point -- the same centre-origin fallback the
+% policy-leg renderer established -- while every other host keeps the exact
+% measured glyph face.  A direct authored face query still raises the
+% face-none diagnostic through \__tenkz_kernel_r_glyph_face_validate:nN.
+\cs_new_protected:Npn \__tenkz_kernel_r_glyph_anchor_or_site_xy:nnNN #1#2#3#4
+  {
+    \bool_set_true:N \l__tenkz_kernel_hull_measure_valid_bool
+    \__tenkz_kernel_hull_resolve_skin:n {#1}
+    \str_if_eq:VnT \l__tenkz_kernel_hull_skin_tl {none}
+      {
+        \prop_if_in:NnF \l__tenkz_kernel_skin_pairing_host_prop {#1}
+          { \bool_set_false:N \l__tenkz_kernel_hull_measure_valid_bool }
+      }
+    \bool_if:NT \l__tenkz_kernel_hull_measure_valid_bool
+      { \__tenkz_kernel_r_glyph_anchor_xy:nnNN {#1}{#2}#3#4 }
+    \bool_if:NF \l__tenkz_kernel_hull_measure_valid_bool
+      { \__tenkz_kernel_r_xy:nNN {#1} #3#4 }
+  }
+
 % ---------- physical-leg lane plan -------------------------------------------
 % The planner is data-only: the physical-leg renderer collects every eligible
 % request, resolves once, then consumes the resulting S--B--T paths.  Corridors
@@ -10778,7 +10800,7 @@
           \l__tenkz_kernel_r_b_tl
           \l__tenkz_kernel_leg_dir_tl
           \l__tenkz_kernel_r_physical_anchor_tl
-        \exp_args:NVV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+        \exp_args:NVV \__tenkz_kernel_r_glyph_anchor_or_site_xy:nnNN
           \l__tenkz_kernel_physical_axis_host_tl
           \l__tenkz_kernel_r_physical_anchor_tl
           \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
@@ -14238,21 +14260,21 @@
       \l__tenkz_kernel_phtrace_to_axis_tl
       \l__tenkz_kernel_phtrace_to_dir_tl
       \l__tenkz_kernel_phtrace_to_anchor_tl
-    \exp_args:NVV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+    \exp_args:NVV \__tenkz_kernel_r_glyph_anchor_or_site_xy:nnNN
       \l__tenkz_kernel_physical_axis_host_tl
       \l__tenkz_kernel_phtrace_from_anchor_tl
       \l__tenkz_kernel_phtrace_from_x_fp
       \l__tenkz_kernel_phtrace_from_y_fp
-    \exp_args:NVV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+    \exp_args:NVV \__tenkz_kernel_r_glyph_anchor_or_site_xy:nnNN
       \l__tenkz_kernel_physical_axis_other_host_tl
       \l__tenkz_kernel_phtrace_to_anchor_tl
       \l__tenkz_kernel_phtrace_to_x_fp
       \l__tenkz_kernel_phtrace_to_y_fp
-    \exp_args:NV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+    \exp_args:NV \__tenkz_kernel_r_glyph_anchor_or_site_xy:nnNN
       \l__tenkz_kernel_physical_axis_host_tl {east}
       \l__tenkz_kernel_phtrace_from_east_x_fp
       \l__tenkz_kernel_phtrace_from_east_y_fp
-    \exp_args:NV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+    \exp_args:NV \__tenkz_kernel_r_glyph_anchor_or_site_xy:nnNN
       \l__tenkz_kernel_physical_axis_other_host_tl {east}
       \l__tenkz_kernel_phtrace_to_east_x_fp
       \l__tenkz_kernel_phtrace_to_east_y_fp


### PR DESCRIPTION
Follow-up from LionSR/TNLean#5616, which defaulted a void site's resolved skin to `none`. Part of the kernel rebuild tracked in LionSR/tenkz#13.

Closes LionSR/tenkz#180

## Consumer sweep

Every read of `\__tenkz_kernel_r_glyph_anchor_xy:nnNN` in `tex/tenkz/tenkz-kernel.code.tex`, with the per-site decision:

| Consumer | Reads | Decision |
|---|---|---|
| `\__tenkz_kernel_r_leg:nn` (policy legs) | 1 | Already guarded (the model for this fix): a barren `none` host degrades to the centre-origin fallback. Unchanged. |
| `\__tenkz_kernel_r_wire_physical_axis_open:n` (row-zero plane opening) | 1 | **Guarded.** The opening's support degrades to the hole's site point; the leg keeps its named physical-leg excursion up the transverse axis. |
| `\__tenkz_kernel_r_physical_trace_plane:n` (row-zero `trace=` closure) | 4 | **Guarded.** Both transverse supports and both clearance-owning east reads degrade to the hole's site point; a skinned partner in the same closure keeps its measured glyph face, and the `max(...)` clearance stays well defined. |

The sweep also covered the other measurement-node reads: the skin-wire path only serves pairing-registered hosts, the equation-cell trace read checks node existence before probing, and the flat-frame trace renderer uses frame coordinates, not glyph anchors. No further unguarded consumer exists.

Rather than guarding each call site by hand, the two renderers route through one shared carrier read, `\__tenkz_kernel_r_glyph_anchor_or_site_xy:nnNN`: the live glyph face when the host owns one, the host's site point when a barren `none` host has none.

`\__tenkz_kernel_r_glyph_face_validate:nN` keeps its hard `[TKZ-GLYPH-FACE-NONE]` diagnostic for direct authored face queries — `r_exact_glyph_faces.tex` pins that contract, and centralizing a silent fallback inside `\__tenkz_kernel_r_glyph_anchor_xy:nnNN` itself would have erased a deliberate author-facing error.

## Mathematical reading

A void hole keeps its physical indices (#5609), so the closure ink that consumes them is legitimate; the hole simply has no glyph extent. Its face therefore degenerates to its site point — the same centre-origin fallback the policy-leg renderer already carried — instead of raising a diagnostic meant for authored queries on skinless records.

## Regression fixture

`tests/tenkz/kernel/regression/r_void_physical_closure.tex` fails before the fix (hard `[TKZ-GLYPH-FACE-NONE]` at the first picture) and pins all three routes:

1. a row-zero opening whose column host is a `void=open` hole (start point = site point, excursion = `physleg`);
2. a one-site `trace=physical` closure on a hole (both supports and the east clearance read collapse to the site point);
3. a two-site `trace={(physical,1)}` joining a hole's site point to a real glyph face (the skinned partner must *not* collapse).

## Gates

- `scripts/tenkz_kernel_probes.sh --check` — pass: 142 review regressions hold, 11 sugar spellings byte-identical in events and pixels, 12 kernel record streams and pixels byte-identical
- `scripts/tenkz_golden.sh --check` — pass: 159 event streams byte-identical (no re-pins)
- `scripts/tenkz_pixelpair.sh origin/main` — pass: 4 pages byte-identical at 300 dpi
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — pass: census stable at 142 (internal function only; no public vocabulary change)
- `python3 scripts/test_check_tenkz_dispositions.py` + `check_tenkz_dispositions.py` — pass: 202 blueprint occurrences and 159 standalone fixtures reconcile
- `python3 scripts/test_check_tenkz_demolition.py` + `check_tenkz_demolition.py` — pass
- `python3 scripts/tenkz_lint.py tests/tenkz/kernel/regression/r_void_physical_closure.tex` — 0 findings

## Render evidence

`r_void_physical_closure.tex` rasterized at 300 dpi (xelatex + pdftoppm): the void opening stands as a short leg at the hole's site point beside S's ordinary policy leg; the one-site void trace closes as a capsule through the site point; the mixed trace joins the hole's site point to R's measured south face with the pair-trace clearance. No `[TKZ-GLYPH-FACE-NONE]` on any route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches kernel physical-closure geometry for void hosts; behavior is narrowly scoped with a regression fixture and unchanged strict diagnostics for direct glyph-face queries.
> 
> **Overview**
> Fixes **`[TKZ-GLYPH-FACE-NONE]`** when plane **physical closure** (row-zero openings and `trace=physical`) runs on **`void=open`** holes that have no glyph face after the void skin default (#5616).
> 
> Introduces **`\\__tenkz_kernel_r_glyph_anchor_or_site_xy:nnNN`**, used in **`\\__tenkz_kernel_r_wire_physical_axis_open:n`** and **`\\__tenkz_kernel_r_physical_trace_plane:n`** instead of **`\\__tenkz_kernel_r_glyph_anchor_xy:nnNN`**. Barren **`skin=none`** hosts without pairing registration get the host **site point**; skinned hosts still use measured glyph anchors. Direct authored face queries still go through **`\\__tenkz_kernel_r_glyph_anchor_xy`** and keep the hard diagnostic.
> 
> Adds regression **`r_void_physical_closure.tex`** for void openings, one-site void traces, and mixed void–skinned traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268e5772bbd13a06a6082b6e621b4410a7d20964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->