### PR TITLE
doc: post-merge review fixes for the Aug 6-8 merge wave

### DIFF
--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -516,9 +516,11 @@ theorem exists_strictMono_tendsto_pow_peripheralProjection_clm
     hPos.tendsto_endEquiv_pow_peripheralProjection hTP hnmono hn⟩
 
 /-- The phase-weighted peripheral projection `T_φ' = T ∘ T_φ` of a positive
-trace-preserving map is positive: the positive-only case of the preservation
-assertion in Wolf Proposition 6.3(ii) (no complete positivity needed, since
-positive maps are closed under composition). -/
+trace-preserving map is positive: the positive-only case for `T_φ'` of the
+preservation assertion in the opening of Wolf, Proposition 6.3
+(`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--229; item
+(ii) itself states only the composition identity). Positive maps are closed
+under composition, so no complete positivity is needed. -/
 theorem peripheralWeightedProjection_isPositiveMap
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
     IsPositiveMap T.peripheralWeightedProjection := by

--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -521,7 +521,10 @@ theorem peripheralWeightedProjection_isPositiveMap
   exact hPos _ ((hPos.peripheralProjection_isPositiveMap hTP) _ hX)
 
 /-- The phase-weighted peripheral projection `T_φ' = T ∘ T_φ` of a positive
-trace-preserving map is trace-preserving: both factors preserve the trace. -/
+trace-preserving map is trace-preserving: both factors preserve the trace.
+This is the positive-only case for `T_φ'` of the preservation assertion in
+Wolf, Proposition 6.3
+(`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--229). -/
 theorem peripheralWeightedProjection_isTracePreservingMap
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
     IsTracePreservingMap T.peripheralWeightedProjection := by

--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -427,8 +427,6 @@ theorem exists_strictMono_tendsto_pow_peripheralProjection
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
     ∃ n : ℕ → ℕ, StrictMono n ∧ 0 < n 0 ∧
       ∀ X, Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop (𝓝 (T.peripheralProjection X)) := by
-  classical
-  letI := (peripheralEigenvalues_finite T).fintype
   obtain ⟨n, hnmono, hn0, hn⟩ := exists_dirichlet_recurrent_subsequence (T := T)
   exact ⟨n, hnmono, hn0, fun X ↦
     hPos.tendsto_pow_apply_peripheralProjection hTP hnmono hn X⟩
@@ -512,8 +510,6 @@ theorem exists_strictMono_tendsto_pow_peripheralProjection_clm
       (∀ X, Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop (𝓝 (T.peripheralProjection X))) ∧
         Tendsto (fun i : ℕ ↦ endEquiv (T ^ n i)) atTop
           (𝓝 (endEquiv T.peripheralProjection)) := by
-  classical
-  letI := (peripheralEigenvalues_finite T).fintype
   obtain ⟨n, hnmono, hn0, hn⟩ := exists_dirichlet_recurrent_subsequence (T := T)
   exact ⟨n, hnmono, hn0,
     fun X ↦ hPos.tendsto_pow_apply_peripheralProjection hTP hnmono hn X,

--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -489,18 +489,6 @@ theorem peripheralProjection_isTracePreservingMap
   rw [hconst] at hlim
   exact tendsto_nhds_unique hlim tendsto_const_nhds
 
-/-- The peripheral spectral projection `T_φ` of a completely positive
-trace-preserving map is completely positive: in finite dimension the set of
-completely positive maps is closed, and along the recurrent subsequence the
-powers converge to `T_φ` in the operator norm. -/
-theorem peripheralProjection_isCPMap
-    (hCP : IsCPMap T) (hTP : IsTracePreservingMap T) :
-    IsCPMap T.peripheralProjection := by
-  obtain ⟨n, hnmono, -, hn⟩ :=
-    hCP.isPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection hTP
-  exact IsCPMap.of_tendsto_toCLM (fun i ↦ IsCPMap.pow hCP (n i))
-    (ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional hn)
-
 /-- **Wolf Proposition 6.3(i), combined form.**  Along one and the same
 Dirichlet recurrent subsequence, the powers converge to `T_φ` both pointwise
 and in the operator norm. -/
@@ -539,6 +527,17 @@ theorem peripheralWeightedProjection_isTracePreservingMap
   intro X
   rw [Module.End.peripheralWeightedProjection, LinearMap.comp_apply, hTP,
     hPos.peripheralProjection_isTracePreservingMap hTP]
+
+/-- The peripheral spectral projection `T_φ` of a completely positive
+trace-preserving map is completely positive: in finite dimension the set of
+completely positive maps is closed, and along the recurrent subsequence the
+powers converge to `T_φ` in the operator norm. -/
+theorem peripheralProjection_isCPMap
+    (hCP : IsCPMap T) (hTP : IsTracePreservingMap T) :
+    IsCPMap T.peripheralProjection := by
+  obtain ⟨n, -, -, -, hn⟩ :=
+    hCP.isPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection_clm hTP
+  exact IsCPMap.of_tendsto_toCLM (fun i ↦ IsCPMap.pow hCP (n i)) hn
 
 end IsPositiveMap
 

--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -406,6 +406,19 @@ theorem tendsto_pow_apply_peripheralProjection
   exact hsum.congr' (Filter.Eventually.of_forall fun i ↦ by
     rw [← map_add, add_sub_cancel])
 
+/-- The Dirichlet recurrent subsequence of the peripheral phases: strictly
+monotone exponents along which every peripheral eigenvalue's powers tend to
+one. Shared by the pointwise and operator-norm convergence statements of
+Wolf Proposition 6.3(i). -/
+private theorem exists_dirichlet_recurrent_subsequence :
+    ∃ n : ℕ → ℕ, StrictMono n ∧ 0 < n 0 ∧
+      ∀ μ ∈ peripheralEigenvalues T, Tendsto (fun i : ℕ ↦ μ ^ n i) atTop (𝓝 1) := by
+  classical
+  letI := (peripheralEigenvalues_finite T).fintype
+  obtain ⟨n, hnmono, hn0, hn⟩ := Dirichlet.exists_strictMono_pow_tendsto_one
+    (fun μ : peripheralEigenvalues T ↦ (μ : ℂ)) (fun μ ↦ μ.prop.2)
+  exact ⟨n, hnmono, hn0, fun μ hμ ↦ hn ⟨μ, hμ⟩⟩
+
 /-- **Wolf Proposition 6.3(i).**  For a positive trace-preserving map there is
 a strictly monotone sequence of exponents — the Dirichlet recurrent
 subsequence of the peripheral phases — along which `T ^ (n i) → T_φ`
@@ -416,10 +429,9 @@ theorem exists_strictMono_tendsto_pow_peripheralProjection
       ∀ X, Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop (𝓝 (T.peripheralProjection X)) := by
   classical
   letI := (peripheralEigenvalues_finite T).fintype
-  obtain ⟨n, hnmono, hn0, hn⟩ := Dirichlet.exists_strictMono_pow_tendsto_one
-    (fun μ : peripheralEigenvalues T ↦ (μ : ℂ)) (fun μ ↦ μ.prop.2)
+  obtain ⟨n, hnmono, hn0, hn⟩ := exists_dirichlet_recurrent_subsequence (T := T)
   exact ⟨n, hnmono, hn0, fun X ↦
-    hPos.tendsto_pow_apply_peripheralProjection hTP hnmono (fun μ hμ ↦ hn ⟨μ, hμ⟩) X⟩
+    hPos.tendsto_pow_apply_peripheralProjection hTP hnmono hn X⟩
 
 /-- **Wolf Proposition 6.3(i), operator-norm form.**  Along the recurrent
 subsequence, the powers converge to `T_φ` in the operator norm (as continuous
@@ -502,12 +514,10 @@ theorem exists_strictMono_tendsto_pow_peripheralProjection_clm
           (𝓝 (endEquiv T.peripheralProjection)) := by
   classical
   letI := (peripheralEigenvalues_finite T).fintype
-  obtain ⟨n, hnmono, hn0, hn⟩ := Dirichlet.exists_strictMono_pow_tendsto_one
-    (fun μ : peripheralEigenvalues T ↦ (μ : ℂ)) (fun μ ↦ μ.prop.2)
+  obtain ⟨n, hnmono, hn0, hn⟩ := exists_dirichlet_recurrent_subsequence (T := T)
   exact ⟨n, hnmono, hn0,
-    fun X ↦ hPos.tendsto_pow_apply_peripheralProjection hTP hnmono
-      (fun μ hμ ↦ hn ⟨μ, hμ⟩) X,
-    hPos.tendsto_endEquiv_pow_peripheralProjection hTP hnmono (fun μ hμ ↦ hn ⟨μ, hμ⟩)⟩
+    fun X ↦ hPos.tendsto_pow_apply_peripheralProjection hTP hnmono hn X,
+    hPos.tendsto_endEquiv_pow_peripheralProjection hTP hnmono hn⟩
 
 /-- The phase-weighted peripheral projection `T_φ' = T ∘ T_φ` of a positive
 trace-preserving map is positive: the positive-only case of the preservation

--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -491,6 +491,44 @@ theorem peripheralProjection_isCPMap
   exact IsCPMap.of_tendsto_toCLM (fun i ↦ IsCPMap.pow hCP (n i))
     (ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional hn)
 
+/-- **Wolf Proposition 6.3(i), combined form.**  Along one and the same
+Dirichlet recurrent subsequence, the powers converge to `T_φ` both pointwise
+and in the operator norm. -/
+theorem exists_strictMono_tendsto_pow_peripheralProjection_clm
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    ∃ n : ℕ → ℕ, StrictMono n ∧ 0 < n 0 ∧
+      (∀ X, Tendsto (fun i : ℕ ↦ (T ^ n i) X) atTop (𝓝 (T.peripheralProjection X))) ∧
+        Tendsto (fun i : ℕ ↦ endEquiv (T ^ n i)) atTop
+          (𝓝 (endEquiv T.peripheralProjection)) := by
+  classical
+  letI := (peripheralEigenvalues_finite T).fintype
+  obtain ⟨n, hnmono, hn0, hn⟩ := Dirichlet.exists_strictMono_pow_tendsto_one
+    (fun μ : peripheralEigenvalues T ↦ (μ : ℂ)) (fun μ ↦ μ.prop.2)
+  exact ⟨n, hnmono, hn0,
+    fun X ↦ hPos.tendsto_pow_apply_peripheralProjection hTP hnmono
+      (fun μ hμ ↦ hn ⟨μ, hμ⟩) X,
+    hPos.tendsto_endEquiv_pow_peripheralProjection hTP hnmono (fun μ hμ ↦ hn ⟨μ, hμ⟩)⟩
+
+/-- The phase-weighted peripheral projection `T_φ' = T ∘ T_φ` of a positive
+trace-preserving map is positive: the positive-only case of the preservation
+assertion in Wolf Proposition 6.3(ii) (no complete positivity needed, since
+positive maps are closed under composition). -/
+theorem peripheralWeightedProjection_isPositiveMap
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    IsPositiveMap T.peripheralWeightedProjection := by
+  intro X hX
+  rw [Module.End.peripheralWeightedProjection, LinearMap.comp_apply]
+  exact hPos _ ((hPos.peripheralProjection_isPositiveMap hTP) _ hX)
+
+/-- The phase-weighted peripheral projection `T_φ' = T ∘ T_φ` of a positive
+trace-preserving map is trace-preserving: both factors preserve the trace. -/
+theorem peripheralWeightedProjection_isTracePreservingMap
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    IsTracePreservingMap T.peripheralWeightedProjection := by
+  intro X
+  rw [Module.End.peripheralWeightedProjection, LinearMap.comp_apply, hTP,
+    hPos.peripheralProjection_isTracePreservingMap hTP]
+
 end IsPositiveMap
 
 /-! ### Channel packaging and the mean-ergodic absorption identity -/

--- a/TNLean/MPS/MPDO/RescalingStableChiUniformity.lean
+++ b/TNLean/MPS/MPDO/RescalingStableChiUniformity.lean
@@ -58,8 +58,6 @@ documented as future work in
   Theorem 4.14(ii) and lines 995--1010
 -/
 
-open scoped Matrix
-
 noncomputable section
 
 namespace MPOTensor.RescalingStableLengthDependentRFP
@@ -164,7 +162,9 @@ noncomputable def oneLabelChiTracePowerForm :
 /-- **R's one-label structure coefficient equals the trace of the `L`-th
 ordinary matrix power of `R`'s own local factor `wMat`.** For every positive
 length `L`,
-`oneLabelCoeffs.coeff L 0 0 0 = tr(wMat^L) = 1 + (7/25)^L`. This realizes
+`oneLabelCoeffs.coeff L 0 0 0 = tr(wMat^L)` (and `tr(wMat^L) = tr(χ^L) =
+1 + (7/25)^L` by `wMat_pow_trace_eq_oneLabelChi_matrix_pow_trace` and the
+diagonal power trace). This realizes
 the coefficient-level trace-power identity of `oneLabelChiTracePowerForm`
 concretely from the local factor of `R`'s own closed-operator factorization
 `mpo_R_eq_B_mul_wN_mul_transpose`, via the Walsh–Hadamard diagonalization

--- a/TNLean/MPS/MPDO/RescalingStableChiUniformity.lean
+++ b/TNLean/MPS/MPDO/RescalingStableChiUniformity.lean
@@ -162,9 +162,10 @@ noncomputable def oneLabelChiTracePowerForm :
 /-- **R's one-label structure coefficient equals the trace of the `L`-th
 ordinary matrix power of `R`'s own local factor `wMat`.** For every positive
 length `L`,
-`oneLabelCoeffs.coeff L 0 0 0 = tr(wMat^L)` (and `tr(wMat^L) = tr(χ^L) =
-1 + (7/25)^L` by `wMat_pow_trace_eq_oneLabelChi_matrix_pow_trace` and the
-diagonal power trace). This realizes
+`oneLabelCoeffs.coeff L 0 0 0 = tr(wMat^L)` (the closed form
+`tr(wMat^L) = 1 + (7/25)^L` follows by
+`wMat_pow_trace_eq_oneLabelChi_matrix_pow_trace` and the diagonal power
+trace). This realizes
 the coefficient-level trace-power identity of `oneLabelChiTracePowerForm`
 concretely from the local factor of `R`'s own closed-operator factorization
 `mpo_R_eq_B_mul_wN_mul_transpose`, via the Walsh–Hadamard diagonalization

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -76,7 +76,9 @@
     Its peripheral subspace is the sum of the maximal generalized eigenspaces
     for eigenvalues $\mu$ with $|\mu|=1$; its non-peripheral subspace is the
     corresponding sum for the remaining eigenvalues. This is the splitting
-    underlying \cite[Equation~(6.12)]{Wolf2012Quantum}.
+    induced by the full spectral decomposition of
+    \cite[Equation~(6.5)]{Wolf2012Quantum}, with the peripheral projection
+    itself defined in \cite[Equation~(6.12)]{Wolf2012Quantum}.
 \end{definition}
 
 \begin{theorem}[Complementarity of the peripheral splitting]

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -75,8 +75,8 @@
     Let $T$ be an endomorphism of a finite-dimensional complex vector space.
     Its peripheral subspace is the sum of the maximal generalized eigenspaces
     for eigenvalues $\mu$ with $|\mu|=1$; its non-peripheral subspace is the
-    corresponding sum for the remaining eigenvalues. This is the splitting in
-    \cite[Equation~(6.11)]{Wolf2012Quantum}.
+    corresponding sum for the remaining eigenvalues. This is the splitting
+    underlying \cite[Equation~(6.12)]{Wolf2012Quantum}.
 \end{definition}
 
 \begin{theorem}[Complementarity of the peripheral splitting]
@@ -124,7 +124,8 @@
     \label{thm:peripheral_projection_recurrent_subsequence}
     \lean{IsPositiveMap.tendsto_pow_apply_peripheralProjection,
         IsPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection,
-        IsPositiveMap.tendsto_endEquiv_pow_peripheralProjection}
+        IsPositiveMap.tendsto_endEquiv_pow_peripheralProjection,
+        IsPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection_clm}
     \leanok
     \uses{cor:dirichlet_phase_recurrence,
         def:peripheral_spectral_projections,
@@ -161,6 +162,8 @@
     \label{cor:peripheral_projection_channel}
     \lean{IsPositiveMap.peripheralProjection_isPositiveMap,
         IsPositiveMap.peripheralProjection_isTracePreservingMap,
+        IsPositiveMap.peripheralWeightedProjection_isPositiveMap,
+        IsPositiveMap.peripheralWeightedProjection_isTracePreservingMap,
         IsPositiveMap.peripheralProjection_isCPMap,
         IsChannel.peripheralProjection,
         IsChannel.peripheralWeightedProjection}
@@ -168,9 +171,11 @@
     \uses{thm:peripheral_projection_recurrent_subsequence,
         def:peripheral_spectral_projections}
     The peripheral projection of a positive trace-preserving map is positive
-    and trace-preserving. If the original map is completely positive, then
-    $T_\varphi$ and $T_\varphi'$ are quantum channels. This is the
-    preservation assertion in \cite[Proposition~6.3(ii)]{Wolf2012Quantum}.
+    and trace-preserving, and then the weighted projection $T_\varphi'$ is
+    positive and trace-preserving as well. If the original map is completely
+    positive, then $T_\varphi$ and $T_\varphi'$ are quantum channels. This
+    is the preservation assertion in
+    \cite[Proposition~6.3(ii)]{Wolf2012Quantum}.
 \end{corollary}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -174,8 +174,9 @@
     and trace-preserving, and then the weighted projection $T_\varphi'$ is
     positive and trace-preserving as well. If the original map is completely
     positive, then $T_\varphi$ and $T_\varphi'$ are quantum channels. This
-    is the preservation assertion in
-    \cite[Proposition~6.3(ii)]{Wolf2012Quantum}.
+    is the preservation assertion in the opening clause of
+    \cite[Proposition~6.3]{Wolf2012Quantum} (item~(ii) itself states only the
+    composition identity).
 \end{corollary}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -822,7 +822,7 @@
     \label{lem:mpdo_bnt_label_rescaling_stable_injective}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.R_toMPSTensor_isInjective}
     \leanok
-    \uses{def:injective}
+    \uses{def:injective, thm:mpdo_bnt_label_rescaling_stable_length_dependence}
     The $16$ letters $R^{pq}$ of the doubled-index tensor
     $R^{\bullet\bullet}$ span the full bond matrix algebra $M_4(\C)$.
 \end{lemma}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -818,28 +818,42 @@
     \end{align}
 \end{proof}
 
-\begin{theorem}[The literal CPSV canonical form of $R$]%
-    \label{thm:mpdo_bnt_label_rescaling_stable_cf}
+\begin{lemma}[Algebraic injectivity of $R^{\bullet\bullet}$]%
+    \label{lem:mpdo_bnt_label_rescaling_stable_injective}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.R_toMPSTensor_isInjective}
-    \lean{MPOTensor.RescalingStableLengthDependentRFP.R_toMPSTensor_isCPSVCanonicalForm}
     \leanok
-    \uses{def:cpsv_canonical_form, def:nt_cpsv,
-        thm:mpdo_bnt_label_rescaling_stable_length_dependence}
-    The doubled-index tensor $A=R^{\bullet\bullet}$ (bond dimension $4$,
-    $16$ letters $R^{pq}$, $p,q\in\{0,\ldots,3\}$) is in the canonical form
-    of Definition~\ref{def:cpsv_canonical_form}, eq.~\eqref{eq:cpsv_canonical_form}:
-    a single retained normal block occupying the full ambient bond
-    dimension~$4$ ($r=1$, $D_1=4$, $U=\Id$), with weight
-    $\mu=\sqrt{337/512}$, the unique positive scalar making the retained
-    block's transfer map exactly idempotent (hence spectral-radius one).
-\end{theorem}
+    The $16$ letters $R^{pq}$ of the doubled-index tensor
+    $R^{\bullet\bullet}$ span the full bond matrix algebra $M_4(\C)$.
+\end{lemma}
+
 \begin{proof}\leanok
     Each letter $R^{pq}$ is, up to a nonzero scalar, one of the $16$
     matrix units of the bond algebra $\C^{4\times4}$: the outer-product
     structure of $R^{pq}$ collapses to a single matrix-unit letter because
     each factor $A^a$, $A^b$ of the vertical letters $B^{ab}=A^a\otimes
     \overline{A^b}$ is itself a scaled matrix unit of $\C^{2\times2}$.
-    Consequently the $16$ letters span the full bond matrix algebra, so
+    Hence the standard matrix-unit basis lies in the span of the letters.
+\end{proof}
+
+\begin{theorem}[The literal CPSV canonical form of $R$]%
+    \label{thm:mpdo_bnt_label_rescaling_stable_cf}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.R_toMPSTensor_isCPSVCanonicalForm}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:nt_cpsv,
+        thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    The doubled-index tensor $A=R^{\bullet\bullet}$ (bond dimension $4$,
+    $16$ letters $R^{pq}$, $p,q\in\{0,\ldots,3\}$) is in the canonical form
+    of Definition~\ref{def:cpsv_canonical_form}
+    (\ref{eq:cpsv_canonical_form}):
+    a single retained normal block occupying the full ambient bond
+    dimension~$4$ ($r=1$, $D_1=4$, $U=\Id$), with weight
+    $\mu=\sqrt{337/512}$, the unique positive scalar making the retained
+    block's transfer map exactly idempotent (hence spectral-radius one).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:mpdo_bnt_label_rescaling_stable_injective}
+    By Lemma~\ref{lem:mpdo_bnt_label_rescaling_stable_injective}, the $16$
+    letters span the full bond matrix algebra, so
     $A$ is algebraically injective, and no nontrivial invariant orthogonal
     projection exists.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -822,6 +822,7 @@
     \label{lem:mpdo_bnt_label_rescaling_stable_injective}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.R_toMPSTensor_isInjective}
     \leanok
+    \uses{def:injective}
     The $16$ letters $R^{pq}$ of the doubled-index tensor
     $R^{\bullet\bullet}$ span the full bond matrix algebra $M_4(\C)$.
 \end{lemma}

--- a/docs/paper-gaps/choi_rectangular_scope.tex
+++ b/docs/paper-gaps/choi_rectangular_scope.tex
@@ -110,8 +110,8 @@ development; the Choi correspondence is phrased relative to it.
 
 \section{Surviving square-only declarations}
 
-The dimension-generic Kraus API (updated 2026-08-06): the cardinality,
-rank, and freedom declarations are stated once, for rectangular Kraus
+The dimension-generic Kraus API states the cardinality,
+rank, and freedom declarations once, for rectangular Kraus
 operators $K_j\in M_{d'\times d}(\C)$, and the square development is the
 specialization $d=d'$.  Concretely, \leanid{Channel.HasKrausCard},
 \leanid{Channel.HasKrausRankLE}, \leanid{Channel.choiRank},

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -124,7 +124,7 @@ Verdict: closed at the example level, coefficient statement only.
 The uniform BNT-label $\chi$-trace-power statement of Theorem~4.14(ii),
 already separated from the blocked bases by the generic
 \leanid{MPOTensor.PositiveBNTLabelChiTracePowerForm} apparatus of
-Section~``BNT-label coefficient objects'' above, is now realized for the
+Section~``BNT-label coefficient objects'' below, is now realized for the
 rescaling-stable example's tensor $R$ with its one BNT label and
 $\chi=\operatorname{diag}(1,7/25)$
 (\leanid{MPOTensor.RescalingStableLengthDependentRFP.oneLabelChi}).  The
@@ -162,7 +162,7 @@ algebra-structure witness needed for that operator-level closure, from the
 future work.  The general Theorem~4.14(ii) statement --- one $\chi$-witness
 per BNT-label triple, constructed from an arbitrary MPDO tensor rather than
 attached by hand to a single example --- also remains a scope restriction,
-per the ``BNT-label coefficient objects'' section above.
+per the ``BNT-label coefficient objects'' section below.
 
 \section{Relation to the algebra-to-fusion converse}
 


### PR DESCRIPTION
## Summary

Clears the 10 unresolved bot-review threads left on the merged PRs #5630 (3), #5594 (4), #5595 (2), #5629 (1), including two 🔴 blueprint-faithfulness items.

### Lean additions ()
- `IsPositiveMap.exists_strictMono_tendsto_pow_peripheralProjection_clm`: the combined pointwise **and** operator-norm recurrent-subsequence existential along **one** Dirichlet subsequence (Wolf Prop 6.3(i)) — previously the blueprint entry's `\leanok` covered the two convergence modes only by separate existentials.
- `IsPositiveMap.peripheralWeightedProjection_isPositiveMap` and `..._isTracePreservingMap`: the positive-only (non-CP) case of the preservation assertion in Wolf Prop 6.3(ii) for the weighted projection \varphi'$ (positive maps are closed under composition; both factors preserve trace).

### Blueprint
- `ch06_qpf_cesaro_fixed_points.tex`: peripheral splitting now cites Wolf Equation **(6.12)** (6.11 is \infty$); recurrent-subsequence entry links the combined theorem; channel corollary states and links the positive-only weighted case.
- `ch21_mpdo_rfp_bnt_coefficients.tex`: `R_toMPSTensor_isInjective` (span injectivity) split into its own lemma entry `lem:mpdo_bnt_label_rescaling_stable_injective` — it proves a different statement than the canonical-form theorem it was tagged on; `\eqref` → plain parenthesized `\ref` per the style guide.

### Docs / docstrings
- `RescalingStableChiUniformity.lean`: docstring no longer chains the closed form +(7/25)^L$ into the theorem's own equality (that step is `wMat_pow_trace_eq_oneLabelChi_matrix_pow_trace` + the diagonal power trace); removed unused `open scoped Matrix`.
- `cpgsv17_blocked_chi_uniformity.tex`: two "above" → "below" direction fixes (the referenced section follows).
- `choi_rectangular_scope.tex`: changelog-style paragraph reworded as exposition.

## Validation
- Full `lake build`: 9937 jobs, success
- `lake exe lint_style`: exit 0; no sorry/axiom additions
- Blueprint sync + `leanblueprint checkdecls`: exit 0
- Blueprint PDF (two passes): 0 undefined references/citations
- Both gap notes compile under latexmk: clean
- Reader-facing prose gate: no violations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, blueprint linking, and small theorem packaging or composition-based proofs on existing peripheral machinery; no new axioms or changes to core channel definitions.
> 
> **Overview**
> Post-merge cleanup from bot review threads: **Lean** gains Wolf Prop 6.3 coverage that was missing from the blueprint links, plus **blueprint** and **gap-note** alignment.
> 
> **Cesaro / peripheral spectral theory (`CesaroRecurrence.lean`):** A private `exists_dirichlet_recurrent_subsequence` centralizes the Dirichlet subsequence construction; the pointwise existential and a new **`exists_strictMono_tendsto_pow_peripheralProjection_clm`** package **one** subsequence with both pointwise and operator-norm convergence to `T_φ`. **`peripheralWeightedProjection_isPositiveMap`** and **`peripheralWeightedProjection_isTracePreservingMap`** prove the positive-only preservation of `T_φ' = T ∘ T_φ` (composition closure). **`peripheralProjection_isCPMap`** now uses the combined CLM existential instead of assembling separate existentials.
> 
> **Blueprint:** `ch06` cites Wolf (6.12) for the peripheral projection, links the combined recurrent-subsequence theorem, and extends the channel corollary with the weighted positive/trace-preserving case. **`ch21`** splits **`R_toMPSTensor_isInjective`** into lemma **`lem:mpdo_bnt_label_rescaling_stable_injective`** so injectivity is not tagged on the canonical-form theorem.
> 
> **Docs / docstrings:** `RescalingStableChiUniformity` docstring defers the closed trace form to separate lemmas; minor wording in gap notes (`above`→`below`, Kraus API exposition).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c273509f3d858fcede86b0557cf884f5b9c308f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->