### PR TITLE
feat(Channel): assemble coordinate direct-sum expectation

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -23,6 +23,7 @@ import TNLean.Channel.Determinant.Bound
 import TNLean.Channel.Determinant.HeisenbergDual
 import TNLean.Channel.Determinant.HilbertSchmidt
 import TNLean.Channel.Determinant.UnitaryCharacterization
+import TNLean.Channel.DirectSumConditionalExpectation
 import TNLean.Channel.EntanglementWitness
 import TNLean.Channel.FaithfulMarginalWhitenedChoi
 import TNLean.Channel.FixedPoint

--- a/TNLean/Channel/DirectSumConditionalExpectation.lean
+++ b/TNLean/Channel/DirectSumConditionalExpectation.lean
@@ -63,40 +63,57 @@ noncomputable def coordinateRightFactorStarAlgHom :
   toFun B := directSumDiagonalEmbedding fun k ↦
     rightKroneckerEmbed (m := Fin (m k)) (B k)
   map_one' := by
-    change Matrix.blockDiagonal' _ = 1
-    rw [← Matrix.blockDiagonal'_one]
-    congr 1
-    funext k
-    exact map_one (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k)))
+    have h : (fun k ↦ rightKroneckerEmbed (m := Fin (m k))
+        ((1 : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) k)) =
+        (1 : ∀ k, Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ) := by
+      funext k
+      exact map_one (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k)))
+    rw [h]
+    exact Matrix.blockDiagonal'_one
   map_mul' A B := by
-    rw [← directSumDiagonalEmbedding_mul]
-    congr 1
-    funext k
-    exact map_mul (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k) (B k)
+    have h : (fun k ↦ rightKroneckerEmbed (m := Fin (m k)) ((A * B) k)) =
+        (fun k ↦ rightKroneckerEmbed (m := Fin (m k)) (A k)) *
+          fun k ↦ rightKroneckerEmbed (m := Fin (m k)) (B k) := by
+      funext k
+      exact map_mul (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k) (B k)
+    rw [h]
+    exact directSumDiagonalEmbedding_mul _ _
   map_zero' := by
-    change Matrix.blockDiagonal' _ = 0
-    rw [← Matrix.blockDiagonal'_zero]
-    congr 1
-    funext k
-    exact map_zero (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k)))
+    have h : (fun k ↦ rightKroneckerEmbed (m := Fin (m k))
+        ((0 : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) k)) =
+        (0 : ∀ k, Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ) := by
+      funext k
+      exact map_zero (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k)))
+    rw [h]
+    exact LinearMap.map_zero directSumDiagonalEmbedding
   map_add' A B := by
-    rw [← Matrix.blockDiagonal'_add]
-    congr 1
-    funext k
-    exact map_add (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k) (B k)
+    have h : (fun k ↦ rightKroneckerEmbed (m := Fin (m k)) ((A + B) k)) =
+        (fun k ↦ rightKroneckerEmbed (m := Fin (m k)) (A k)) +
+          fun k ↦ rightKroneckerEmbed (m := Fin (m k)) (B k) := by
+      funext k
+      exact map_add (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k) (B k)
+    rw [h]
+    exact LinearMap.map_add directSumDiagonalEmbedding _ _
   commutes' r := by
     rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one]
-    change directSumDiagonalEmbedding _ = r • (1 : Matrix _ _ ℂ)
-    rw [← Matrix.blockDiagonal'_smul, ← Matrix.blockDiagonal'_one]
-    congr 1
-    funext k
-    exact map_smul (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) r 1
+    have h : (fun k ↦ rightKroneckerEmbed (m := Fin (m k))
+        ((r • (1 : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ)) k)) =
+        r • (1 : ∀ k, Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ) := by
+      funext k
+      change rightKroneckerEmbed (m := Fin (m k)) (r • 1) = r • 1
+      rw [map_smul, map_one]
+    rw [h, LinearMap.map_smul, show directSumDiagonalEmbedding
+      (1 : ∀ k, Matrix (Fin (m k) × Fin (d k)) (Fin (m k) × Fin (d k)) ℂ) = 1 from
+        Matrix.blockDiagonal'_one]
   map_star' A := by
-    rw [star_eq_conjTranspose, star_eq_conjTranspose,
-      ← directSumDiagonalEmbedding_conjTranspose]
-    congr 1
-    funext k
-    exact map_star (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k)
+    have h : (fun k ↦ rightKroneckerEmbed (m := Fin (m k)) (star A k)) =
+        fun k ↦ star (rightKroneckerEmbed (m := Fin (m k)) (A k)) := by
+      funext k
+      exact map_star (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k)
+    rw [h]
+    simpa only [star_eq_conjTranspose] using
+      (directSumDiagonalEmbedding_conjTranspose
+        (fun k ↦ rightKroneckerEmbed (m := Fin (m k)) (A k)))
 
 @[simp]
 theorem coordinateRightFactorStarAlgHom_apply
@@ -138,6 +155,7 @@ noncomputable def coordinateDirectSumConditionalExpectation :
   directSumExtension (LinearMap.piMap fun k ↦
     rightFactorConditionalExpectation (m := m k) (d := d k))
 
+omit [Fintype κ] in
 /-- Explicit evaluation formula for the coordinate direct-sum expectation. -/
 @[simp]
 theorem coordinateDirectSumConditionalExpectation_apply
@@ -148,11 +166,14 @@ theorem coordinateDirectSumConditionalExpectation_apply
         (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
           (((m k : ℂ)⁻¹) • partialTraceLeft
             (directSumDiagonalCompression A k)) := by
-  rw [coordinateDirectSumConditionalExpectation, directSumExtension_apply]
+  change Matrix.blockDiagonal' (fun k ↦
+    rightFactorConditionalExpectation (m := m k) (d := d k)
+      (directSumDiagonalCompression A k)) = _
   congr 1
   funext k
   exact rightFactorConditionalExpectation_apply _
 
+omit [Fintype κ] in
 /-- Every off-diagonal block of the coordinate direct-sum expectation vanishes. -/
 theorem coordinateDirectSumConditionalExpectation_offDiagonal
     (A : Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
@@ -208,6 +229,7 @@ theorem coordinateDirectSumConditionalExpectation_fixes
   funext k
   exact rightFactorConditionalExpectation_fixes (B k)
 
+omit [Fintype κ] in
 /-- The coordinate direct-sum expectation is idempotent. -/
 theorem coordinateDirectSumConditionalExpectation_idempotent
     (hm : ∀ k, 0 < m k)
@@ -216,15 +238,28 @@ theorem coordinateDirectSumConditionalExpectation_idempotent
     coordinateDirectSumConditionalExpectation (m := m) (d := d)
         (coordinateDirectSumConditionalExpectation (m := m) (d := d) A) =
       coordinateDirectSumConditionalExpectation (m := m) (d := d) A := by
-  rw [coordinateDirectSumConditionalExpectation_apply A]
-  exact coordinateDirectSumConditionalExpectation_fixes hm _
+  letI (k : κ) : NeZero (m k) := ⟨Nat.ne_of_gt (hm k)⟩
+  let T := LinearMap.piMap fun k ↦
+    rightFactorConditionalExpectation (m := m k) (d := d k)
+  change directSumExtension T
+      (directSumDiagonalEmbedding (T (directSumDiagonalCompression A))) =
+    directSumDiagonalEmbedding (T (directSumDiagonalCompression A))
+  apply (directSumExtension_embedding_eq_self_iff _ _).2
+  funext k
+  exact rightFactorConditionalExpectation_idempotent _
 
+omit [Fintype κ] in
 /-- The coordinate direct-sum expectation is unital. -/
 theorem coordinateDirectSumConditionalExpectation_unital
     (hm : ∀ k, 0 < m k) :
     coordinateDirectSumConditionalExpectation (m := m) (d := d) 1 = 1 := by
-  rw [← map_one (coordinateRightFactorStarAlgHom (m := m) (d := d))]
-  exact coordinateDirectSumConditionalExpectation_fixes hm 1
+  letI (k : κ) : NeZero (m k) := ⟨Nat.ne_of_gt (hm k)⟩
+  rw [show (1 : Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+      ((k : κ) × (Fin (m k) × Fin (d k))) ℂ) =
+        directSumDiagonalEmbedding 1 from Matrix.blockDiagonal'_one.symm]
+  apply (directSumExtension_embedding_eq_self_iff _ _).2
+  funext k
+  exact rightFactorConditionalExpectation_unital
 
 /-- The coordinate normalized partial trace is a conditional expectation onto
 `⊕ k, (1_{mₖ} ⊗ M_{dₖ}(ℂ))`. -/

--- a/TNLean/Channel/DirectSumConditionalExpectation.lean
+++ b/TNLean/Channel/DirectSumConditionalExpectation.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.DirectSumKraus
+import TNLean.Channel.RightFactorConditionalExpectation
+
+/-!
+# Coordinate direct-sum conditional expectation
+
+This file constructs, in the coordinates of the finite-dimensional star-algebra
+classification, the trace-preserving conditional expectation onto
+\[
+  \bigoplus_k \bigl(\mathbf 1_{m_k} \otimes M_{d_k}(\mathbb C)\bigr).
+\]
+For a matrix `A` on the direct sum, its value is
+\[
+  \operatorname{blockDiagonal}'\!\left(k \mapsto
+    \mathbf 1_{m_k} \otimes
+      \bigl(m_k^{-1}\operatorname{tr}_{m_k}(A_{kk})\bigr)\right),
+\]
+where `Aₖₖ` is the `k`-th diagonal compression. Complete positivity is obtained
+by applying the one-block right-factor expectation in every coordinate and then
+using the existing direct-sum Kraus extension; no new Kraus family is introduced.
+
+This is the coordinate direct-sum retraction used in Wolf's operator-system
+extension argument. Arbitrary unitary change of coordinates and codomain
+corestriction are not part of this construction.
+
+## Main definitions
+
+* `Matrix.coordinateRightFactorStarAlgHom`: the coordinate embedding of the
+  direct sum of right matrix factors.
+* `Matrix.coordinateRightFactorStarSubalgebra`: its range.
+* `Matrix.coordinateDirectSumConditionalExpectation`: the normalized
+  coordinate direct-sum expectation.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 1.5,
+  Equation (1.40), and the operator-system extension theorem; local source
+  `Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 536--570
+  and 616--626.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker BigOperators
+open Matrix
+
+noncomputable section
+
+namespace Matrix
+
+variable {κ : Type*} [Fintype κ] [DecidableEq κ]
+variable {m d : κ → ℕ}
+
+/-- The coordinate star-algebra embedding
+`(Bₖ)ₖ ↦ blockDiagonal' (k ↦ 1_{mₖ} ⊗ Bₖ)`. -/
+noncomputable def coordinateRightFactorStarAlgHom :
+    (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) →⋆ₐ[ℂ]
+      Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+        ((k : κ) × (Fin (m k) × Fin (d k))) ℂ where
+  toFun B := directSumDiagonalEmbedding fun k ↦
+    rightKroneckerEmbed (m := Fin (m k)) (B k)
+  map_one' := by
+    change Matrix.blockDiagonal' _ = 1
+    rw [← Matrix.blockDiagonal'_one]
+    congr 1
+    funext k
+    exact map_one (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k)))
+  map_mul' A B := by
+    rw [← directSumDiagonalEmbedding_mul]
+    congr 1
+    funext k
+    exact map_mul (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k) (B k)
+  map_zero' := by
+    change Matrix.blockDiagonal' _ = 0
+    rw [← Matrix.blockDiagonal'_zero]
+    congr 1
+    funext k
+    exact map_zero (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k)))
+  map_add' A B := by
+    rw [← Matrix.blockDiagonal'_add]
+    congr 1
+    funext k
+    exact map_add (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k) (B k)
+  commutes' r := by
+    rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one]
+    change directSumDiagonalEmbedding _ = r • (1 : Matrix _ _ ℂ)
+    rw [← Matrix.blockDiagonal'_smul, ← Matrix.blockDiagonal'_one]
+    congr 1
+    funext k
+    exact map_smul (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) r 1
+  map_star' A := by
+    rw [star_eq_conjTranspose, star_eq_conjTranspose,
+      ← directSumDiagonalEmbedding_conjTranspose]
+    congr 1
+    funext k
+    exact map_star (rightKroneckerEmbed (m := Fin (m k)) (n := Fin (d k))) (A k)
+
+@[simp]
+theorem coordinateRightFactorStarAlgHom_apply
+    (B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    coordinateRightFactorStarAlgHom (m := m) B =
+      Matrix.blockDiagonal' fun k ↦
+        (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k :=
+  rfl
+
+/-- The coordinate star subalgebra
+`⊕ k, (1_{mₖ} ⊗ M_{dₖ}(ℂ))`. -/
+def coordinateRightFactorStarSubalgebra :
+    StarSubalgebra ℂ
+      (Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+        ((k : κ) × (Fin (m k) × Fin (d k))) ℂ) :=
+  StarAlgHom.range (coordinateRightFactorStarAlgHom (m := m) (d := d))
+
+/-- Exact membership in the coordinate right-factor star subalgebra. -/
+theorem mem_coordinateRightFactorStarSubalgebra
+    (A : Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+      ((k : κ) × (Fin (m k) × Fin (d k))) ℂ) :
+    A ∈ coordinateRightFactorStarSubalgebra (m := m) (d := d) ↔
+      ∃ B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+        A = Matrix.blockDiagonal' fun k ↦
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
+  constructor
+  · rintro ⟨B, hB⟩
+    exact ⟨B, hB.symm⟩
+  · rintro ⟨B, rfl⟩
+    exact ⟨B, rfl⟩
+
+/-- The coordinate direct-sum conditional expectation obtained by applying the
+normalized right-factor expectation separately to every diagonal block. -/
+noncomputable def coordinateDirectSumConditionalExpectation :
+    Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+        ((k : κ) × (Fin (m k) × Fin (d k))) ℂ →ₗ[ℂ]
+      Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+        ((k : κ) × (Fin (m k) × Fin (d k))) ℂ :=
+  directSumExtension (LinearMap.piMap fun k ↦
+    rightFactorConditionalExpectation (m := m k) (d := d k))
+
+/-- Explicit evaluation formula for the coordinate direct-sum expectation. -/
+@[simp]
+theorem coordinateDirectSumConditionalExpectation_apply
+    (A : Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+      ((k : κ) × (Fin (m k) × Fin (d k))) ℂ) :
+    coordinateDirectSumConditionalExpectation (m := m) (d := d) A =
+      Matrix.blockDiagonal' fun k ↦
+        (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+          (((m k : ℂ)⁻¹) • partialTraceLeft
+            (directSumDiagonalCompression A k)) := by
+  rw [coordinateDirectSumConditionalExpectation, directSumExtension_apply]
+  congr 1
+  funext k
+  exact rightFactorConditionalExpectation_apply _
+
+/-- Every off-diagonal block of the coordinate direct-sum expectation vanishes. -/
+theorem coordinateDirectSumConditionalExpectation_offDiagonal
+    (A : Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+      ((k : κ) × (Fin (m k) × Fin (d k))) ℂ)
+    {k l : κ} (hkl : k ≠ l) (i : Fin (m k) × Fin (d k))
+    (j : Fin (m l) × Fin (d l)) :
+    coordinateDirectSumConditionalExpectation (m := m) (d := d) A ⟨k, i⟩ ⟨l, j⟩ = 0 := by
+  rw [coordinateDirectSumConditionalExpectation_apply,
+    Matrix.blockDiagonal'_apply_ne _ _ _ hkl]
+
+/-- Positivity and trace preservation of the coordinate direct-sum expectation. -/
+theorem coordinateDirectSumConditionalExpectation_isKrausCPTP
+    (hm : ∀ k, 0 < m k) :
+    IsKrausCPTP (coordinateDirectSumConditionalExpectation (m := m) (d := d)) := by
+  letI (k : κ) : NeZero (m k) := ⟨Nat.ne_of_gt (hm k)⟩
+  apply isKrausCPTP_of_isKrausCP_trace_preserving
+  · change IsKrausCP (directSumExtension (LinearMap.piMap fun k ↦
+      rightFactorConditionalExpectation (m := m k) (d := d k)))
+    rw [← directSumMapExtension_self]
+    exact isKrausDirectSumMap_piMap _ fun k ↦
+      rightFactorConditionalExpectation_isKrausCP
+  · intro A
+    apply (IsTracePreservingDirectSumMap.directSumExtension_isTracePreservingMap
+      (T := LinearMap.piMap fun k ↦
+        rightFactorConditionalExpectation (m := m k) (d := d k)) ?_) A
+    intro B
+    apply Finset.sum_congr rfl
+    intro k _
+    exact rightFactorConditionalExpectation_isKrausCPTP.trace_map (B k)
+
+/-- The coordinate direct-sum expectation takes values in the coordinate
+right-factor star subalgebra. -/
+theorem coordinateDirectSumConditionalExpectation_range_subset
+    (A : Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+      ((k : κ) × (Fin (m k) × Fin (d k))) ℂ) :
+    coordinateDirectSumConditionalExpectation (m := m) (d := d) A ∈
+      coordinateRightFactorStarSubalgebra (m := m) (d := d) := by
+  rw [mem_coordinateRightFactorStarSubalgebra,
+    coordinateDirectSumConditionalExpectation_apply]
+  exact ⟨fun k ↦ ((m k : ℂ)⁻¹) • partialTraceLeft
+    (directSumDiagonalCompression A k), rfl⟩
+
+/-- The coordinate direct-sum expectation fixes its target star subalgebra
+pointwise. -/
+theorem coordinateDirectSumConditionalExpectation_fixes
+    (hm : ∀ k, 0 < m k)
+    (B : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    coordinateDirectSumConditionalExpectation (m := m) (d := d)
+        (coordinateRightFactorStarAlgHom (m := m) B) =
+      coordinateRightFactorStarAlgHom (m := m) B := by
+  letI (k : κ) : NeZero (m k) := ⟨Nat.ne_of_gt (hm k)⟩
+  apply (directSumExtension_embedding_eq_self_iff _ _).2
+  funext k
+  exact rightFactorConditionalExpectation_fixes (B k)
+
+/-- The coordinate direct-sum expectation is idempotent. -/
+theorem coordinateDirectSumConditionalExpectation_idempotent
+    (hm : ∀ k, 0 < m k)
+    (A : Matrix ((k : κ) × (Fin (m k) × Fin (d k)))
+      ((k : κ) × (Fin (m k) × Fin (d k))) ℂ) :
+    coordinateDirectSumConditionalExpectation (m := m) (d := d)
+        (coordinateDirectSumConditionalExpectation (m := m) (d := d) A) =
+      coordinateDirectSumConditionalExpectation (m := m) (d := d) A := by
+  rw [coordinateDirectSumConditionalExpectation_apply A]
+  exact coordinateDirectSumConditionalExpectation_fixes hm _
+
+/-- The coordinate direct-sum expectation is unital. -/
+theorem coordinateDirectSumConditionalExpectation_unital
+    (hm : ∀ k, 0 < m k) :
+    coordinateDirectSumConditionalExpectation (m := m) (d := d) 1 = 1 := by
+  rw [← map_one (coordinateRightFactorStarAlgHom (m := m) (d := d))]
+  exact coordinateDirectSumConditionalExpectation_fixes hm 1
+
+/-- The coordinate normalized partial trace is a conditional expectation onto
+`⊕ k, (1_{mₖ} ⊗ M_{dₖ}(ℂ))`. -/
+theorem coordinateDirectSumConditionalExpectation_isConditionalExpectation
+    (hm : ∀ k, 0 < m k) :
+    Kraus.IsConditionalExpectation
+      (coordinateDirectSumConditionalExpectation (m := m) (d := d))
+      (coordinateRightFactorStarSubalgebra (m := m) (d := d)) where
+  positive :=
+    (isKrausCP_iff_isCPMap.mp
+      (coordinateDirectSumConditionalExpectation_isKrausCPTP hm).isKrausCP).isPositiveMap
+  idempotent := coordinateDirectSumConditionalExpectation_idempotent hm
+  unital := coordinateDirectSumConditionalExpectation_unital hm
+  range_subset := coordinateDirectSumConditionalExpectation_range_subset
+  fixes A hA := by
+    rw [mem_coordinateRightFactorStarSubalgebra] at hA
+    obtain ⟨B, rfl⟩ := hA
+    exact coordinateDirectSumConditionalExpectation_fixes hm B
+
+/-- The coordinate direct-sum map is simultaneously CPTP and a conditional
+expectation onto `⊕ k, (1_{mₖ} ⊗ M_{dₖ}(ℂ))`. -/
+theorem coordinateDirectSumConditionalExpectation_isKrausCPTP_and_isConditionalExpectation
+    (hm : ∀ k, 0 < m k) :
+    IsKrausCPTP (coordinateDirectSumConditionalExpectation (m := m) (d := d)) ∧
+      Kraus.IsConditionalExpectation
+        (coordinateDirectSumConditionalExpectation (m := m) (d := d))
+        (coordinateRightFactorStarSubalgebra (m := m) (d := d)) :=
+  ⟨coordinateDirectSumConditionalExpectation_isKrausCPTP hm,
+    coordinateDirectSumConditionalExpectation_isConditionalExpectation hm⟩
+
+end Matrix

--- a/TNLean/Channel/DirectSumConditionalExpectation.lean
+++ b/TNLean/Channel/DirectSumConditionalExpectation.lean
@@ -25,8 +25,12 @@ by applying the one-block right-factor expectation in every coordinate and then
 using the existing direct-sum Kraus extension; no new Kraus family is introduced.
 
 This is the coordinate direct-sum retraction used in Wolf's operator-system
-extension argument. Arbitrary unitary change of coordinates and codomain
-corestriction are not part of this construction.
+extension argument.
+
+**Scope restriction (coordinate direct sum):** Arbitrary unitary change of
+coordinates and codomain corestriction are not part of this construction. The
+relationship with the full unitarily transported statement is recorded in
+`docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex`.
 
 ## Main definitions
 

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -672,8 +672,10 @@ algebra is a single full matrix algebra $\MN{m}$; see
         &\subseteq\End(\mathcal H).
         \notag
     \end{align}
-    This is the coordinate direct-sum form of
-    \cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum}. Relative to
+    This is the normalized trace-preserving coordinate choice obtained by
+    specializing the block densities in
+    \cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum} to maximally
+    mixed densities. Relative to
     Wolf's $\MN{d_k}\otimes\mathbb1_{m_k}$ convention, the displayed
     $\mathbb1_{m_k}\otimes\MN{d_k}$ order is obtained by interchanging the
     tensor factors. This theorem concerns only the displayed direct-sum

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -685,7 +685,7 @@ algebra is a single full matrix algebra $\MN{m}$; see
     \uses{thm:right_factor_conditional_expectation,
       lem:direct_sum_kraus_composition_schwarz,
       thm:direct_sum_full_matrix_extension_compatibility,
-      lem:direct_sum_extension_embedding_fixed,
+      thm:direct_sum_extension_embedding_fixed,
       thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving,
       thm:is_kraus_cptp_trace_map,
       lem:is_kraus_cp_basic,

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -678,7 +678,8 @@ algebra is a single full matrix algebra $\MN{m}$; see
     $\mathbb1_{m_k}\otimes\MN{d_k}$ order is obtained by interchanging the
     tensor factors. This theorem concerns only the displayed direct-sum
     coordinates; it does not conjugate the subalgebra by an arbitrary unitary
-    or corestrict the codomain.
+    or corestrict the codomain. This coordinate restriction is documented in
+    \path{docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -687,6 +687,7 @@ algebra is a single full matrix algebra $\MN{m}$; see
 \begin{proof}\leanok
     \uses{thm:right_factor_conditional_expectation,
       lem:direct_sum_kraus_composition_schwarz,
+      thm:direct_sum_map_extension_self,
       thm:direct_sum_full_matrix_extension_compatibility,
       thm:direct_sum_extension_embedding_fixed,
       thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving,

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -684,7 +684,13 @@ algebra is a single full matrix algebra $\MN{m}$; see
 \begin{proof}\leanok
     \uses{thm:right_factor_conditional_expectation,
       lem:direct_sum_kraus_composition_schwarz,
-      thm:direct_sum_full_matrix_extension_compatibility}
+      thm:direct_sum_full_matrix_extension_compatibility,
+      lem:direct_sum_extension_embedding_fixed,
+      thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving,
+      thm:is_kraus_cptp_trace_map,
+      lem:is_kraus_cp_basic,
+      lem:is_kraus_cp_iff_is_cp_map,
+      thm:cp_is_positive}
     Compress $A$ to the family $(A_{kk})_{k\in K}$ and apply the normalized
     partial-trace expectation from
     Theorem~\ref{thm:right_factor_conditional_expectation} in each coordinate.

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -646,6 +646,13 @@ algebra is a single full matrix algebra $\MN{m}$; see
 \begin{theorem}[Coordinate direct-sum conditional expectation]
     \label{thm:coordinate_direct_sum_conditional_expectation}
     \lean{Matrix.coordinateDirectSumConditionalExpectation_apply}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_offDiagonal}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_isKrausCPTP}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_range_subset}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_fixes}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_idempotent}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_unital}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_isConditionalExpectation}
     \lean{Matrix.coordinateDirectSumConditionalExpectation_isKrausCPTP_and_isConditionalExpectation}
     \leanok
     \uses{def:is_kraus_cptp, def:is_conditional_expectation}
@@ -664,15 +671,18 @@ algebra is a single full matrix algebra $\MN{m}$; see
           \bigl(m_k^{-1}\tr_{m_k}(A_{kk})\bigr)\right)
         \notag
     \end{align}
-    is trace-preserving and completely positive. It is a conditional
-    expectation onto the coordinate subalgebra
+    has zero off-diagonal output blocks. It is trace-preserving and completely
+    positive, and it is a conditional expectation onto the coordinate
+    subalgebra
     \begin{align}
         \bigoplus_{k\in K}
           \bigl(\mathbb1_{m_k}\otimes\MN{d_k}\bigr)
         &\subseteq\End(\mathcal H).
         \notag
     \end{align}
-    This is the normalized trace-preserving coordinate choice obtained by
+    Thus its range lies in this subalgebra, it fixes the subalgebra pointwise,
+    and it is unital and idempotent. This is the normalized trace-preserving
+    coordinate choice obtained by
     specializing the block densities in
     \cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum} to maximally
     mixed densities. Relative to

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -641,6 +641,60 @@ algebra is a single full matrix algebra $\MN{m}$; see
     the range inclusion.
 \end{proof}
 
+% Coordinate finite-direct-sum consequence of the preceding one-block result.
+% This does not include unitary conjugation to an arbitrary represented algebra.
+\begin{theorem}[Coordinate direct-sum conditional expectation]
+    \label{thm:coordinate_direct_sum_conditional_expectation}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_apply}
+    \lean{Matrix.coordinateDirectSumConditionalExpectation_isKrausCPTP_and_isConditionalExpectation}
+    \leanok
+    \uses{def:is_kraus_cptp, def:is_conditional_expectation}
+    Let $K$ be finite, let $m_k\geq1$, and set
+    \begin{align}
+        \mathcal H
+        &=\bigoplus_{k\in K}\bigl(\C^{m_k}\otimes\C^{d_k}\bigr).
+        \notag
+    \end{align}
+    For $A\in\End(\mathcal H)$, write $A_{kk}$ for its $k$-th diagonal
+    block. The map
+    \begin{align}
+        E(A)
+        &=\operatorname{diag}_{k\in K}\!\left(
+          \mathbb1_{m_k}\otimes
+          \bigl(m_k^{-1}\tr_{m_k}(A_{kk})\bigr)\right)
+        \notag
+    \end{align}
+    is trace-preserving and completely positive. It is a conditional
+    expectation onto the coordinate subalgebra
+    \begin{align}
+        \bigoplus_{k\in K}
+          \bigl(\mathbb1_{m_k}\otimes\MN{d_k}\bigr)
+        &\subseteq\End(\mathcal H).
+        \notag
+    \end{align}
+    This theorem concerns only the displayed direct-sum coordinates; it does
+    not conjugate the subalgebra by an arbitrary unitary or corestrict the
+    codomain.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:right_factor_conditional_expectation,
+      def:kraus_map_between_direct_sums,
+      lem:direct_sum_kraus_composition_schwarz,
+      thm:direct_sum_full_matrix_extension_compatibility}
+    Compress $A$ to the family $(A_{kk})_{k\in K}$ and apply the normalized
+    partial-trace expectation from
+    Theorem~\ref{thm:right_factor_conditional_expectation} in each coordinate.
+    The coordinatewise Kraus theorem makes the resulting map on the finite
+    sum completely positive, and its canonical full-matrix extension discards
+    the off-diagonal blocks. Each coordinate preserves trace, so preservation
+    of the total block trace implies preservation of the trace on
+    $\End(\mathcal H)$. The displayed formula shows that the range lies in the
+    coordinate subalgebra. The one-block fixation identity holds in every
+    summand, hence $E$ fixes that subalgebra pointwise; idempotence and
+    unitality follow.
+\end{proof}
+
 \begin{definition}[Operator system]\label{def:operator_system}
     \lean{Matrix.IsOperatorSystem}
     \leanok

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -672,14 +672,17 @@ algebra is a single full matrix algebra $\MN{m}$; see
         &\subseteq\End(\mathcal H).
         \notag
     \end{align}
-    This theorem concerns only the displayed direct-sum coordinates; it does
-    not conjugate the subalgebra by an arbitrary unitary or corestrict the
-    codomain.
+    This is the coordinate direct-sum form of
+    \cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum}. Relative to
+    Wolf's $\MN{d_k}\otimes\mathbb1_{m_k}$ convention, the displayed
+    $\mathbb1_{m_k}\otimes\MN{d_k}$ order is obtained by interchanging the
+    tensor factors. This theorem concerns only the displayed direct-sum
+    coordinates; it does not conjugate the subalgebra by an arbitrary unitary
+    or corestrict the codomain.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:right_factor_conditional_expectation,
-      def:kraus_map_between_direct_sums,
       lem:direct_sum_kraus_composition_schwarz,
       thm:direct_sum_full_matrix_extension_compatibility}
     Compress $A$ to the family $(A_{kk})_{k\in K}$ and apply the normalized

--- a/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
@@ -813,6 +813,29 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     conclusion of that passage.
 \end{definition}
 
+\begin{theorem}[Embedding and compression for the canonical extension]
+    \label{thm:direct_sum_extension_embedding_compression}
+    \lean{Matrix.directSumDiagonalCompression_embedding}
+    \lean{Matrix.directSumExtension_apply}
+    \leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    For every $A\in\mathcal A$ and every linear map
+    $T:\mathcal A\to\mathcal B$,
+    \begin{align}
+        \pi_A(\iota_A(A))
+        &=A, \notag\\
+        \widehat T(X)
+        &=\iota_B(T(\pi_A(X))).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    The first identity follows by extracting each diagonal block of
+    $\iota_A(A)$. The second is the defining evaluation formula for the
+    canonical extension.
+\end{proof}
+
 \begin{theorem}[Fixed embedded families under the canonical extension]
     \label{thm:direct_sum_extension_embedding_fixed}
     \lean{Matrix.directSumExtension_embedding_eq_self_iff}
@@ -828,6 +851,7 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:direct_sum_extension_embedding_compression}
     Diagonal compression is a left inverse of block-diagonal embedding. Hence
     \begin{align}
         \widehat T(\iota(A))

--- a/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
@@ -813,6 +813,33 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     conclusion of that passage.
 \end{definition}
 
+\begin{lemma}[Fixed embedded families under the canonical extension]
+    \label{lem:direct_sum_extension_embedding_fixed}
+    \lean{Matrix.directSumExtension_embedding_eq_self_iff}
+    \leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    Let $T:\mathcal A\to\mathcal A$ be a linear endomorphism of a finite sum
+    of matrix algebras. For every $A\in\mathcal A$,
+    \begin{align}
+        \widehat T(\iota(A))=\iota(A)
+        &\quad\Longleftrightarrow\quad T(A)=A.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    Diagonal compression is a left inverse of block-diagonal embedding. Hence
+    \begin{align}
+        \widehat T(\iota(A))
+        &=\iota(T(A)).
+        \notag
+    \end{align}
+    If this equals $\iota(A)$, applying diagonal compression gives
+    $T(A)=A$. Conversely, substituting $T(A)=A$ gives the fixed-point
+    identity.
+\end{proof}
+
 Definition~\ref{def:direct_sum_full_matrix_extension} and the trace-adjoint
 laws in Lemma~\ref{lem:direct_sum_rectangular_trace_adjoint} provide
 supporting facts for the classification argument. By themselves, they do

--- a/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
@@ -836,6 +836,20 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     canonical extension.
 \end{proof}
 
+\begin{theorem}[Agreement of the two direct-sum extensions]
+    \label{thm:direct_sum_map_extension_self}
+    \lean{Matrix.directSumMapExtension_self}
+    \leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    If $T:\mathcal A\to\mathcal A$ is an endomorphism, then its full-matrix
+    extension as a map between two finite sums agrees with its canonical
+    endomorphic extension.
+\end{theorem}
+
+\begin{proof}\leanok
+    Both maps are $\iota_A\circ T\circ\pi_A$.
+\end{proof}
+
 \begin{theorem}[Fixed embedded families under the canonical extension]
     \label{thm:direct_sum_extension_embedding_fixed}
     \lean{Matrix.directSumExtension_embedding_eq_self_iff}
@@ -844,7 +858,7 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     Let $T:\mathcal A\to\mathcal A$ be a linear endomorphism of a finite sum
     of matrix algebras. For every $A\in\mathcal A$,
     \begin{align}
-        \widehat T(\iota(A))=\iota(A)
+        \widehat T(\iota_A(A))=\iota_A(A)
         &\quad\Longleftrightarrow\quad T(A)=A.
         \notag
     \end{align}
@@ -854,11 +868,11 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     \uses{thm:direct_sum_extension_embedding_compression}
     Diagonal compression is a left inverse of block-diagonal embedding. Hence
     \begin{align}
-        \widehat T(\iota(A))
-        &=\iota(T(A)).
+        \widehat T(\iota_A(A))
+        &=\iota_A(T(A)).
         \notag
     \end{align}
-    If this equals $\iota(A)$, applying diagonal compression gives
+    If this equals $\iota_A(A)$, applying diagonal compression gives
     $T(A)=A$. Conversely, substituting $T(A)=A$ gives the fixed-point
     identity.
 \end{proof}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
@@ -819,13 +819,13 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     \lean{Matrix.directSumExtension_apply}
     \leanok
     \uses{def:direct_sum_full_matrix_extension}
-    For every $A\in\mathcal A$ and every linear map
-    $T:\mathcal A\to\mathcal B$,
+    For every $A\in\mathcal A$, every $X\in\End(\mathcal H_A)$, and every
+    linear endomorphism $T:\mathcal A\to\mathcal A$,
     \begin{align}
         \pi_A(\iota_A(A))
         &=A, \notag\\
         \widehat T(X)
-        &=\iota_B(T(\pi_A(X))).
+        &=\iota_A(T(\pi_A(X))).
         \notag
     \end{align}
 \end{theorem}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_wedderburn_ii.tex
@@ -813,8 +813,8 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     conclusion of that passage.
 \end{definition}
 
-\begin{lemma}[Fixed embedded families under the canonical extension]
-    \label{lem:direct_sum_extension_embedding_fixed}
+\begin{theorem}[Fixed embedded families under the canonical extension]
+    \label{thm:direct_sum_extension_embedding_fixed}
     \lean{Matrix.directSumExtension_embedding_eq_self_iff}
     \leanok
     \uses{def:direct_sum_full_matrix_extension}
@@ -825,10 +825,9 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
         &\quad\Longleftrightarrow\quad T(A)=A.
         \notag
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:direct_sum_full_matrix_extension}
     Diagonal compression is a left inverse of block-diagonal embedding. Hence
     \begin{align}
         \widehat T(\iota(A))

--- a/docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex
+++ b/docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex
@@ -6,7 +6,7 @@
 
 \input{command}
 
-\title{Wolf Proposition~1.5: One-Factor Scope Restriction}
+\title{Wolf Proposition~1.5: Factor and Coordinate Direct-Sum Scope Restrictions}
 \author{}
 \date{2026-07-18}
 
@@ -42,6 +42,21 @@ source proposition.  In particular, the representing matrix is only required
 to be positive semidefinite and to have trace one.  Thus the theorem is a
 faithful scope-restricted case, but it is not the full direct-sum
 classification of Proposition~1.5.
+
+The theorem
+\leanid{Matrix.coordinateDirectSumConditionalExpectation_isKrausCPTP_and_isConditionalExpectation}
+constructs the normalized trace-preserving choice simultaneously on all
+summands in displayed direct-sum coordinates.  In the tensor-factor order used
+by TNLean, its range is
+\[
+    \bigoplus_{k=1}^{K}\mathbf 1_{m_k}\otimes M_{d_k}(\mathbb C),
+\]
+and its formula is obtained from Wolf's order by interchanging the two tensor
+factors.  This theorem includes the coordinatewise partial traces and removal
+of off-diagonal blocks, but it neither conjugates an arbitrary represented
+subalgebra into these coordinates nor corestricts the ambient matrix-valued map
+to that subalgebra.  It is therefore a coordinate construction, not the full
+unitarily transported statement of Proposition~1.5.
 
 \section{Resolution of the direct-sum argument}
 


### PR DESCRIPTION
## What changed

- bundle the coordinate embedding and range star-subalgebra for
  `⊕ k, (1_{m k} ⊗ M_{d k}(ℂ))`, with an exact membership characterization
- construct the normalized coordinate direct-sum expectation and prove its evaluation and off-diagonal formulas
- prove CPTP under `hm : ∀ k, 0 < m k` through the existing coordinatewise Kraus/direct-sum extension APIs, without introducing a new Kraus family
- prove range inclusion, pointwise fixation, idempotence, unitality, and package `Kraus.IsConditionalExpectation`, together with a combined capstone
- add the generated Channel import and a source-faithful Chapter 1 Blueprint theorem, including Wolf Proposition 1.5 / Equation (1.40) provenance and TNLean's interchanged tensor-factor order

## Validation

- `lake build TNLean.Channel.DirectSumConditionalExpectation TNLean.Channel`
- `lake exe lint_style`
- `PYTHONPATH=scripts python3 scripts/check_oversized_lean_files.py --root . --import-only-aggregator TNLean.lean`
- `python3 scripts/check_numbered_lean_files.py --root . --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- double `lualatex -interaction=nonstopmode -halt-on-error print.tex` with the project `TEXINPUTS`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check origin/main...HEAD`

Closes LionSR/QICLean#291
Advances LionSR/QICLean#283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and blueprint documentation on channel/operator-system theory; no runtime, auth, or data-path changes. Scope is explicitly coordinate-only, not arbitrary unitary conjugation.
> 
> **Overview**
> Adds **`TNLean/Channel/DirectSumConditionalExpectation.lean`**, which builds the normalized trace-preserving conditional expectation onto **⊕ₖ (1_{mₖ} ⊗ M_{dₖ}(ℂ))** in displayed direct-sum coordinates by extending the existing one-block **`rightFactorConditionalExpectation`** per summand via **`directSumExtension`**, without a new Kraus family. The file also defines the coordinate right-factor embedding and star-subalgebra, and proves evaluation/off-diagonal formulas, **CPTP** under **`∀ k, 0 < m k`**, range inclusion, fixation, idempotence, unitality, and **`Kraus.IsConditionalExpectation`**.
> 
> **Blueprint** Chapter 1 gains theorem **`coordinate_direct_sum_conditional_expectation`** (Wolf Prop. 1.5 / Eq. (1.40) provenance, TNLean tensor-factor order). Chapter 27 adds direct-sum extension lemmas (**embedding/compression**, **`directSumMapExtension_self`**, **`directSumExtension_embedding_eq_self_iff`**). **`docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex`** is updated to document coordinate vs. full unitary-transport scope. **`TNLean/Channel.lean`** imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ea7ac4272c40e9a929d99e7e486de4895a086b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->