### PR TITLE
refactor(Channel/MPS): clear low-risk import leaves

### DIFF
--- a/TNLean/Algebra/SkolemNoether.lean
+++ b/TNLean/Algebra/SkolemNoether.lean
@@ -3,10 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.Defs
-
-import Mathlib.LinearAlgebra.GeneralLinearGroup.AlgEquiv
+import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Dimension.Finrank
+import Mathlib.LinearAlgebra.GeneralLinearGroup.AlgEquiv
+import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.RingTheory.SimpleRing.Matrix
 
 /-!

--- a/TNLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -13,7 +13,6 @@ import TNLean.Channel.Peripheral.PeriodicityRemoval
 import TNLean.Channel.Peripheral.ClosureFixedPoint
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.Primitive
-import TNLean.MPS.Irreducible.Adjoint
 import TNLean.Spectral.TransferOperatorGap
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.NumberTheory.Real.Irrational

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Basic
-import TNLean.MPS.Core.Transfer
 import TNLean.Algebra.MatrixTracePairing
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.LinearAlgebra.Matrix.Vec
@@ -52,8 +51,6 @@ with composition. We also relate it to the Kraus representation.
   Chapter 3, Proposition 3.8 — conjugation `X ↦ Y X Y†` and its transpose
   variant `X ↦ Y Xᵀ Y†` by an invertible `Y` map the positive semidefinite
   cone onto itself
-* `MPSTensor.transferMatrix_eq`: the MPS transfer map `E_A` has transfer
-  matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ`
 
 ## References
 
@@ -242,23 +239,6 @@ theorem transferMatrix_kraus
   simp only [Matrix.mul_apply, Matrix.single_apply, Matrix.conjTranspose_apply]
   simp only [ite_and, mul_ite, mul_one, mul_zero, ite_mul, zero_mul,
     Finset.sum_ite_eq, Finset.mem_univ, ↓reduceIte, mul_comm]
-
-/-! ### Connection to MPS transfer maps -/
-
-namespace MPSTensor
-
-/-- The MPS transfer map `E_A(X) = ∑ᵢ Aᵢ X Aᵢ†` has transfer matrix
-`∑ᵢ Āᵢ ⊗ₖ Aᵢ`.
-
-This relates Wolf's Section 2.2 transfer matrix for quantum channels to the MPS
-transfer operator. -/
-theorem transferMatrix_eq (A : MPSTensor d D) :
-    transferMatrix (MPSTensor.transferMap A) =
-      ∑ n : Fin d,
-        (A n).map (starRingEnd ℂ) ⊗ₖ A n :=
-  transferMatrix_kraus A _ (fun X => by simp [transferMap_apply])
-
-end MPSTensor
 
 /-! ### Propositions 2.5-2.6: Transfer matrix characterizations of TP, unital, and HP maps -/
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -205,8 +205,6 @@ project import.
 * `transferMatrix_id` — transfer matrix of identity = identity ✓
 * `transferMatrix_injective` — the representation is faithful ✓
 * `transferMatrix_kraus` — Kraus form: `T̂ = ∑ᵢ K'ᵢ ⊗ₖ Kᵢ` ✓
-* `MPSTensor.transferMatrix_eq` — MPS bridge:
-  `E_A` has transfer matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ` ✓
 
 ### Section 2.2–2.3 Transfer matrix characterizations & normal forms (Propositions 2.5-2.8)
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -205,6 +205,8 @@ project import.
 * `transferMatrix_id` — transfer matrix of identity = identity ✓
 * `transferMatrix_injective` — the representation is faithful ✓
 * `transferMatrix_kraus` — Kraus form: `T̂ = ∑ᵢ K'ᵢ ⊗ₖ Kᵢ` ✓
+* `MPSTensor.transferMatrix_eq` — MPS transfer-operator specialization, stated in
+  `TNLean.MPS.Core.TransferMatrix`: `E_A` has transfer matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ` ✓
 
 ### Section 2.2–2.3 Transfer matrix characterizations & normal forms (Propositions 2.5-2.8)
 

--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -22,3 +22,4 @@ import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Core.Transfer
+import TNLean.MPS.Core.TransferMatrix

--- a/TNLean/MPS/Core/TransferMatrix.lean
+++ b/TNLean/MPS/Core/TransferMatrix.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.TransferMatrix
+import TNLean.MPS.Core.Transfer
+
+/-!
+# Transfer-matrix representation of MPS transfer maps
+
+This file relates the generic transfer matrix of a linear map to the transfer
+map associated with an MPS tensor.
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The MPS transfer map `E_A(X) = ∑ᵢ Aᵢ X Aᵢ†` has transfer matrix
+`∑ᵢ Āᵢ ⊗ₖ Aᵢ`.
+
+This relates Wolf's Section 2.2 transfer matrix for quantum channels to the MPS
+transfer operator. -/
+theorem transferMatrix_eq (A : MPSTensor d D) :
+    transferMatrix (MPSTensor.transferMap A) =
+      ∑ n : Fin d,
+        (A n).map (starRingEnd ℂ) ⊗ₖ A n :=
+  transferMatrix_kraus A _ (fun X => by simp [transferMap_apply])
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Channel.TransferMatrix
+import TNLean.MPS.Core.TransferMatrix
 import TNLean.MPS.Core.CyclicTrace
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.ZCL


### PR DESCRIPTION
## What changed

- replace the `TNLean.MPS.Defs` dependency of `Algebra/SkolemNoether.lean` with exact generic Mathlib imports while preserving all `MPSTensor.*` names
- move only `MPSTensor.transferMatrix_eq` from the generic Channel transfer-matrix module to `TNLean.MPS.Core.TransferMatrix`, preserving its statement and declaration name
- update the exact MPS consumer and generated MPS Core aggregator while retaining a non-importing Channel-index cross-reference to the relocated specialization
- remove the unused direct MPS adjoint import from semigroup primitivity

## Dependency counts

Counting production modules under each area whose imports directly or transitively reach an `TNLean.MPS.*` module:

- Algebra direct: 6 → 5; transitive: 10 → 6
- Channel direct: 10 → 8; transitive: 51 → 41
- combined transitive Algebra/Channel count: 61 → 47

This is the low-risk leaf slice only; remaining Channel/Algebra-to-MPS dependencies are intentionally unchanged.

## Validation

- `lake build TNLean.Algebra.SkolemNoether`
- `lake build TNLean.Channel.Semigroup.Primitivity.Basic`
- `lake build TNLean.Channel.TransferMatrix TNLean.Channel.WolfChapter2Index TNLean.MPS.Core.TransferMatrix TNLean.MPS.Core TNLean.MPS.MPDO.LocalPurificationRFP`
- `lake build TNLean.Algebra TNLean.Channel TNLean.MPS` (9723 jobs)
- `lake build` (9944 jobs)
- `lake build lint_style && lake exe lint_style`
- `python3 scripts/generate_import_aggregators.py --check`
- Lean module-policy tests and oversized/numbered-module guards
- reader-facing prose check
- changed-file diagnostics: zero errors or warnings
- `git diff --check origin/main...HEAD`

Closes #5680

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and file moves only; no changed theorem statements or proofs beyond relocation. Low risk for build graph and module policy.
> 
> **Overview**
> This PR **reduces transitive MPS coupling** in Algebra and Channel by touching import leaves only; theorem statements and `MPSTensor.*` names stay the same.
> 
> **Algebra:** `SkolemNoether.lean` no longer imports `TNLean.MPS.Defs`; it pulls in the specific Mathlib modules (complex matrices, finrank, `AlgEquiv`, `GL` defs, simple matrix rings) needed for the existing `MPSTensor` namespace theorems.
> 
> **Channel ↔ MPS bridge:** `MPSTensor.transferMatrix_eq` is **removed** from generic `TNLean.Channel.TransferMatrix` and **added** in new `TNLean.MPS.Core.TransferMatrix` (same proof via `transferMatrix_kraus`). `TNLean.MPS.Core` aggregates the new module; `LocalPurificationRFP` imports Core instead of Channel for this lemma. `WolfChapter2Index` documents the new location.
> 
> **Cleanup:** `Semigroup/Primitivity/Basic` drops the unused `TNLean.MPS.Irreducible.Adjoint` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f943b705f029b29507fbc57c481bfc3a19804d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
