### PR TITLE
feat(Channel/Wigner): prove two-pure-state charpoly formula

### DIFF
--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -20,12 +20,9 @@ open scoped BigOperators
 
 namespace Fintype
 
-/-- Pull a common left factor out of a finite sum of triple products.
-
-This replaces the repeated normalization
-`rw [Finset.mul_sum]; apply Finset.sum_congr rfl; intro i _; ring`.
-The identity needs only a non-unital semiring; commutative-semiring callers
-may reorder the common factor before applying it. -/
+/-- In a non-unital semiring, a common left factor can be pulled out of a
+finite sum of triple products:
+$\sum_i (a f_i) g_i = a \sum_i f_i g_i$. -/
 theorem sum_mul_mul_eq_mul_sum_mul {ι R : Type*} [Fintype ι] [NonUnitalSemiring R]
     (a : R) (f g : ι → R) :
     (∑ i, a * f i * g i) = a * ∑ i, f i * g i := by

--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -20,6 +20,18 @@ open scoped BigOperators
 
 namespace Fintype
 
+/-- Pull a common left factor out of a finite sum of triple products.
+
+This replaces the repeated normalization
+`rw [Finset.mul_sum]; apply Finset.sum_congr rfl; intro i _; ring`.
+The identity needs only a semiring; commutative-semiring callers may reorder
+the common factor before applying it. -/
+theorem sum_mul_mul_eq_mul_sum_mul {ι R : Type*} [Fintype ι] [Semiring R]
+    (a : R) (f g : ι → R) :
+    (∑ i, a * f i * g i) = a * ∑ i, f i * g i := by
+  rw [Finset.mul_sum]
+  exact Finset.sum_congr rfl fun i _ => mul_assoc a (f i) (g i)
+
 /-- Reindex a sum over a finite dependent pair by `finSigmaFinEquiv`. -/
 theorem sum_finSigmaFinEquiv {g : ℕ} {mult : Fin g → ℕ} {β : Type*}
     [AddCommMonoid β] (f : ((j : Fin g) × Fin (mult j)) → β) :

--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -24,9 +24,9 @@ namespace Fintype
 
 This replaces the repeated normalization
 `rw [Finset.mul_sum]; apply Finset.sum_congr rfl; intro i _; ring`.
-The identity needs only a semiring; commutative-semiring callers may reorder
-the common factor before applying it. -/
-theorem sum_mul_mul_eq_mul_sum_mul {ι R : Type*} [Fintype ι] [Semiring R]
+The identity needs only a non-unital semiring; commutative-semiring callers
+may reorder the common factor before applying it. -/
+theorem sum_mul_mul_eq_mul_sum_mul {ι R : Type*} [Fintype ι] [NonUnitalSemiring R]
     (a : R) (f g : ι → R) :
     (∑ i, a * f i * g i) = a * ∑ i, f i * g i := by
   rw [Finset.mul_sum]

--- a/TNLean/Algebra/PerronFrobenius/PerronVector.lean
+++ b/TNLean/Algebra/PerronFrobenius/PerronVector.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.Algebra.PerronFrobenius.Idempotent
 import TNLean.Algebra.PerronFrobenius.Substochastic
 
@@ -58,9 +59,8 @@ theorem IsPrimitive.exists_pos_eigenvector_one_of_pow_two_eq_pow_three
     rw [hT2]
     ext i
     simp only [Matrix.mulVec, Matrix.vecMulVec_apply, dotProduct]
-    have hfactor : (∑ x, a i * b x * a x) = a i * ∑ x, b x * a x := by
-      rw [Finset.mul_sum]
-      exact Finset.sum_congr rfl (fun x _ => by ring)
+    have hfactor : (∑ x, a i * b x * a x) = a i * ∑ x, b x * a x :=
+      Fintype.sum_mul_mul_eq_mul_sum_mul (a i) b a
     rw [hfactor, show (∑ x, b x * a x) = b ⬝ᵥ a from rfl, dotProduct_comm b a, hab, mul_one]
   set u : n → ℝ := T.mulVec a with hu
   have hu_pos : ∀ i, 0 < u i := by
@@ -133,9 +133,8 @@ theorem IsPrimitive.exists_rowStochastic_diagonal_conj_of_pow_two_eq_pow_three
     refine ⟨hPnn, ?_⟩
     ext i
     simp only [Matrix.mulVec, dotProduct, Pi.one_apply, mul_one, hPapply]
-    have hfactor : (∑ j, (v i)⁻¹ * T i j * v j) = (v i)⁻¹ * ∑ j, T i j * v j := by
-      rw [Finset.mul_sum]
-      exact Finset.sum_congr rfl (fun j _ => by ring)
+    have hfactor : (∑ j, (v i)⁻¹ * T i j * v j) = (v i)⁻¹ * ∑ j, T i j * v j :=
+      Fintype.sum_mul_mul_eq_mul_sum_mul (v i)⁻¹ (T i) v
     rw [hfactor, show (∑ j, T i j * v j) = T.mulVec v i from rfl, hTv,
       inv_mul_cancel₀ (hv i).ne']
   · have hPpow : ∀ k, ((Matrix.diagonal v)⁻¹ * T * Matrix.diagonal v) ^ k =

--- a/TNLean/Analysis/MarginalSupport.lean
+++ b/TNLean/Analysis/MarginalSupport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.Entropy
 
@@ -286,9 +287,10 @@ theorem liftA_mul (M N : Matrix (Fin dB × Fin dC) (Fin dB × Fin dC) ℂ) :
       = (if p.1 = a then (1 : ℂ) else 0) * (if a = q.1 then 1 else 0)
           * ∑ bc, M p.2 bc * N bc q.2 := by
     intro a
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun bc _ => ?_
-    ring
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      Fintype.sum_mul_mul_eq_mul_sum_mul
+        ((if p.1 = a then (1 : ℂ) else 0) * (if a = q.1 then 1 else 0))
+        (fun bc => M p.2 bc) (fun bc => N bc q.2)
   rw [Finset.sum_congr rfl fun a _ => hstep a, ← Finset.sum_mul]
   congr 1
   -- ∑ a (if p.1 = a)·(if a = q.1) = if p.1 = q.1: the first indicator picks a = p.1.

--- a/TNLean/Channel/BreuerHallIndecomposable.lean
+++ b/TNLean/Channel/BreuerHallIndecomposable.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.Channel.BreuerHallMap
 import TNLean.Channel.DecomposablePPT
 import TNLean.Channel.MaximallyEntangled
@@ -421,9 +422,9 @@ private theorem unitarity_sandwich_contraction
   have hstep3 : ∀ i1 : Fin d, star (U i1 i2) * (∑ a : Fin d, U i1 a * M j2 a)
       = ∑ a : Fin d, M j2 a * (star (U i1 i2) * U i1 a) := by
     intro i1
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl fun a _ => ?_
-    ring
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      (Fintype.sum_mul_mul_eq_mul_sum_mul (star (U i1 i2))
+        (fun a => U i1 a) (fun a => M j2 a)).symm
   simp_rw [hstep3]
   rw [Finset.sum_comm]
   simp_rw [← Finset.mul_sum, unitarity_column_contraction hUunit]
@@ -475,9 +476,10 @@ private theorem trace_breuerHall_trace_summand
             (∑ i1 : Fin d, star (U i1 i2) * U i1 j2) := by
       rw [Finset.sum_comm]
       refine Finset.sum_congr rfl fun j2 _ => ?_
-      rw [Finset.mul_sum]
-      refine Finset.sum_congr rfl fun i1 _ => ?_
-      ring
+      simpa only [mul_comm, mul_left_comm, mul_assoc] using
+        Fintype.sum_mul_mul_eq_mul_sum_mul
+          ((Matrix.bipartiteSlice ρ i2 j2).trace)
+          (fun i1 => star (U i1 i2)) (fun i1 => U i1 j2)
     rw [h1]
     simp_rw [unitarity_column_contraction hUunit]
     rw [Finset.sum_eq_single i2]

--- a/TNLean/Channel/KoashiImoto/MarkovBipartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/MarkovBipartiteBlockForm.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.Channel.KoashiImoto.InvariantConditionalBlockForm
 
 /-!
@@ -319,10 +320,10 @@ private theorem exists_bipartiteBlockForm_of_conditionalSlice_blockForm
               rw [Finset.mul_sum]
               apply Finset.sum_congr rfl
               intro a _
-              rw [Finset.mul_sum]
-              apply Finset.sum_congr rfl
-              intro b _
-              ring
+              simpa only [mul_comm, mul_left_comm, mul_assoc] using
+                (Fintype.sum_mul_mul_eq_mul_sum_mul
+                  (σ j zk.1 zl.1) (fun x => informationallyCompleteEffect s x a)
+                  (fun x => ω j (a, zk.2) (x, zl.2))).symm
     · calc
         conditionalSlice R (informationallyCompleteEffect s)
             (e ⟨j, zk⟩) (e ⟨j', zl⟩) = 0 := by

--- a/TNLean/Channel/Wigner.lean
+++ b/TNLean/Channel/Wigner.lean
@@ -12,4 +12,5 @@ import TNLean.Channel.Wigner.ProjectiveCarrierBridge
 import TNLean.Channel.Wigner.ProjectivePureState
 import TNLean.Channel.Wigner.PureStateCharpoly
 import TNLean.Channel.Wigner.Rigidity
+import TNLean.Channel.Wigner.TwoPureStateCharpoly
 import TNLean.Channel.Wigner.Upstream

--- a/TNLean/Channel/Wigner/ProjectivePureState.lean
+++ b/TNLean/Channel/Wigner/ProjectivePureState.lean
@@ -25,6 +25,7 @@ Wigner rigidity.
 ## Main declarations
 
 * `Projectivization.pureStateMatrix`
+* `Projectivization.star_dot_self_ne_zero`
 * `Projectivization.star_dot_self_smul_normalizedPureStateMatrix`
 * `Projectivization.linearMap_eq_of_eq_on_pureStateMatrix`
 * `Projectivization.transitionProbability`
@@ -80,7 +81,8 @@ theorem pureStateMatrix_mk (v : Fin d → ℂ) (hv : v ≠ 0) :
     pureStateMatrix (Projectivization.mk ℂ v hv) = normalizedPureStateMatrix v :=
   rfl
 
-private theorem star_dot_self_ne_zero (v : Fin d → ℂ) (hv : v ≠ 0) :
+/-- The Hermitian self-dot-product of a nonzero complex vector is nonzero. -/
+theorem star_dot_self_ne_zero (v : Fin d → ℂ) (hv : v ≠ 0) :
     star v ⬝ᵥ v ≠ 0 := by
   rw [dotProduct_comm]
   let w : EuclideanSpace ℂ (Fin d) := WithLp.toLp 2 v

--- a/TNLean/Channel/Wigner/ProjectivePureState.lean
+++ b/TNLean/Channel/Wigner/ProjectivePureState.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Projectivization.Basic
+import TNLean.Algebra.FinSum
 import TNLean.Algebra.OrthogonalProjection
 import TNLean.Channel.WolfProps
 
@@ -56,10 +57,8 @@ private theorem normalizedPureStateMatrix_smul (v : Fin d → ℂ) (c : ℂ) (hc
     Matrix.vecMulVec_apply, dotProduct, star_smul, star_mul, smul_eq_mul]
   rw [show (∑ x, star (v x) * star c * (c * v x)) =
       star c * c * ∑ x, star (v x) * v x by
-    rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro x _
-    ring]
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      Fintype.sum_mul_mul_eq_mul_sum_mul (star c * c) (fun x => star (v x)) v]
   have hsc : star c ≠ 0 := star_ne_zero.mpr hc
   field_simp [hsc]
 

--- a/TNLean/Channel/Wigner/TwoPureStateCharpoly.lean
+++ b/TNLean/Channel/Wigner/TwoPureStateCharpoly.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff
+import TNLean.Channel.Wigner.ProjectivePureState
+
+/-!
+# Characteristic polynomial of two pure states
+
+This module proves the multiplicity-aware form of the two-pure-state spectrum calculation in
+Wolf, Chapter 1, lines 289--296. In dimension at least two, the proof factors the sum of the two
+pure-state matrices as a rectangular product and compares the characteristic polynomials of the
+two product orders. The dimensions zero and one are treated separately.
+
+## Main results
+
+* `Projectivization.charpoly_add_pureStateMatrix_of_two_le`
+* `Projectivization.charpoly_add_pureStateMatrix_fin_one`
+* `Projectivization.trace_pureStateMatrix_mul_eq_of_charpoly_add_eq`
+-/
+
+open scoped LinearAlgebra.Projectivization Matrix
+open Polynomial
+
+namespace Projectivization
+
+variable {d : ℕ}
+
+/-- There are no projective rays in the zero-dimensional complex vector space. -/
+theorem isEmpty_projectivization_fin_zero : IsEmpty (ℙ ℂ (Fin 0 → ℂ)) := by
+  constructor
+  intro p
+  exact p.rep_nonzero (Subsingleton.elim p.rep 0)
+
+/-- In complex dimension one, every normalized pure-state matrix is the identity. -/
+theorem pureStateMatrix_fin_one (p : ℙ ℂ (Fin 1 → ℂ)) : pureStateMatrix p = 1 := by
+  have htr := trace_pureStateMatrix p
+  ext i j
+  fin_cases i
+  fin_cases j
+  simpa [Matrix.trace_fin_one] using htr
+
+/-- In complex dimension one, the sum of two pure-state matrices has characteristic polynomial
+$X-2$. This is the explicit low-dimensional replacement for the formula with exponent $d-2$. -/
+theorem charpoly_add_pureStateMatrix_fin_one (p q : ℙ ℂ (Fin 1 → ℂ)) :
+    (pureStateMatrix p + pureStateMatrix q).charpoly = X - 2 := by
+  rw [pureStateMatrix_fin_one p, pureStateMatrix_fin_one q]
+  simp [Matrix.charpoly, Matrix.charmatrix]
+  norm_num
+
+private theorem star_dot_self_ne_zero (v : Fin d → ℂ) (hv : v ≠ 0) :
+    star v ⬝ᵥ v ≠ 0 := by
+  rw [dotProduct_comm]
+  let w : EuclideanSpace ℂ (Fin d) := WithLp.toLp 2 v
+  have hw : w ≠ 0 := by simpa [w] using hv
+  rw [← EuclideanSpace.inner_eq_star_dotProduct w w]
+  exact inner_self_ne_zero (𝕜 := ℂ) |>.mpr hw
+
+/-- The multiplicity-aware characteristic polynomial of the sum of two normalized pure-state
+matrices in dimension at least two. This is Wolf's Chapter 1 calculation with the omitted
+$d-2$ zero eigenvalues restored. -/
+theorem charpoly_add_pureStateMatrix_of_two_le (hd : 2 ≤ d)
+    (p q : ℙ ℂ (Fin d → ℂ)) :
+    (pureStateMatrix p + pureStateMatrix q).charpoly =
+      X ^ (d - 2) *
+        ((X - 1) ^ 2 - C (Matrix.trace (pureStateMatrix p * pureStateMatrix q))) := by
+  classical
+  let vp := p.rep
+  let vq := q.rep
+  let ap : ℂ := star vp ⬝ᵥ vp
+  let aq : ℂ := star vq ⬝ᵥ vq
+  have hap : ap ≠ 0 := star_dot_self_ne_zero vp p.rep_nonzero
+  have haq : aq ≠ 0 := star_dot_self_ne_zero vq q.rep_nonzero
+  let A : Matrix (Fin d) (Fin 2) ℂ := fun i j ↦ ![vp i, vq i] j
+  let B : Matrix (Fin 2) (Fin d) ℂ :=
+    fun j i ↦ ![ap⁻¹ * star (vp i), aq⁻¹ * star (vq i)] j
+  have hAB : A * B = pureStateMatrix p + pureStateMatrix q := by
+    rw [← p.mk_rep, ← q.mk_rep, pureStateMatrix_mk, pureStateMatrix_mk]
+    ext i j
+    simp [A, B, Matrix.mul_apply, Fin.sum_univ_two, normalizedPureStateMatrix, vp, vq,
+      ap, aq, Matrix.vecMulVec_apply, Pi.star_apply]
+    ring
+  have h00 : (B * A) 0 0 = 1 := by
+    simp only [A, B, Matrix.mul_apply, Matrix.cons_val_zero, ap, vp]
+    calc
+      ∑ x, ap⁻¹ * star (vp x) * vp x = ap⁻¹ * ∑ x, star (vp x) * vp x := by
+        rw [Finset.mul_sum]
+        apply Finset.sum_congr rfl
+        intro i _
+        ring
+      _ = ap⁻¹ * ap := rfl
+      _ = 1 := inv_mul_cancel₀ hap
+  have h11 : (B * A) 1 1 = 1 := by
+    simp only [A, B, Matrix.mul_apply, Matrix.cons_val_zero, Matrix.cons_val_one, aq, vq]
+    calc
+      ∑ x, aq⁻¹ * star (vq x) * vq x = aq⁻¹ * ∑ x, star (vq x) * vq x := by
+        rw [Finset.mul_sum]
+        apply Finset.sum_congr rfl
+        intro i _
+        ring
+      _ = aq⁻¹ * aq := rfl
+      _ = 1 := inv_mul_cancel₀ haq
+  have h01 : (B * A) 0 1 = ap⁻¹ * (star vp ⬝ᵥ vq) := by
+    simp only [A, B, Matrix.mul_apply, Matrix.cons_val_zero, Matrix.cons_val_one, dotProduct,
+      Pi.star_apply]
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    ring
+  have h10 : (B * A) 1 0 = aq⁻¹ * (star vq ⬝ᵥ vp) := by
+    simp only [A, B, Matrix.mul_apply, Matrix.cons_val_zero, Matrix.cons_val_one, dotProduct,
+      Pi.star_apply]
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    ring
+  have htr : (B * A).trace = 2 := by
+    rw [Matrix.trace_fin_two, h00, h11]
+    norm_num
+  have hdet : (B * A).det =
+      1 - Matrix.trace (pureStateMatrix p * pureStateMatrix q) := by
+    rw [Matrix.det_fin_two, h00, h11, h01, h10,
+      trace_pureStateMatrix_mul_pureStateMatrix]
+    simp only [transitionProbability, vp, vq, ap, aq]
+    field_simp
+  rw [← hAB, Matrix.charpoly_mul_comm_of_le A B]
+  · rw [Matrix.charpoly_fin_two, htr, hdet]
+    simp only [Fintype.card_fin]
+    congr 1
+    rw [map_sub, map_one, Polynomial.C_ofNat]
+    ring
+  · simpa using hd
+
+/-- Equality of the characteristic polynomials of two sums of pure-state matrices determines
+the transition probability, in every dimension. The zero-dimensional case has no rays, the
+one-dimensional case is constant, and dimensions at least two follow by cancelling the restored
+factor $X^{d-2}$. -/
+theorem trace_pureStateMatrix_mul_eq_of_charpoly_add_eq
+    (p q r s : ℙ ℂ (Fin d → ℂ))
+    (hchar : (pureStateMatrix p + pureStateMatrix q).charpoly =
+      (pureStateMatrix r + pureStateMatrix s).charpoly) :
+    Matrix.trace (pureStateMatrix p * pureStateMatrix q) =
+      Matrix.trace (pureStateMatrix r * pureStateMatrix s) := by
+  by_cases hd0 : d = 0
+  · subst d
+    exact (isEmpty_projectivization_fin_zero.false p).elim
+  by_cases hd1 : d = 1
+  · subst d
+    simp [pureStateMatrix_fin_one]
+  have hd : 2 ≤ d := by omega
+  rw [charpoly_add_pureStateMatrix_of_two_le hd,
+    charpoly_add_pureStateMatrix_of_two_le hd] at hchar
+  have hpow : X ^ (d - 2) ≠ (0 : Polynomial ℂ) :=
+    pow_ne_zero _ X_ne_zero
+  have hquadratic := mul_left_cancel₀ hpow hchar
+  have hconstant :
+      C (Matrix.trace (pureStateMatrix p * pureStateMatrix q)) =
+        C (Matrix.trace (pureStateMatrix r * pureStateMatrix s)) :=
+    sub_right_inj.mp hquadratic
+  exact C_injective hconstant
+
+end Projectivization

--- a/TNLean/Channel/Wigner/TwoPureStateCharpoly.lean
+++ b/TNLean/Channel/Wigner/TwoPureStateCharpoly.lean
@@ -14,10 +14,9 @@ Wolf, Chapter 1, lines 289--296. In dimension at least two, the proof factors th
 pure-state matrices as a rectangular product and compares the characteristic polynomials of the
 two product orders. The dimensions zero and one are treated separately.
 
-**Local fix (docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex):** Wolf's
-spectrum shorthand lists the two possibly nonzero eigenvalues but omits the $d-2$ zero eigenvalues
-and their multiplicities. The characteristic-polynomial statement restores them; this correction
-does not assert that Wolf's intended spectrum-preserver argument is false.
+Wolf's spectrum shorthand lists the two possibly nonzero eigenvalues but omits the $d-2$ zero
+eigenvalues and their multiplicities. The characteristic-polynomial statement below restores them;
+see `docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex` for the source audit.
 
 ## Main results
 
@@ -57,7 +56,13 @@ theorem charpoly_add_pureStateMatrix_fin_one (p q : ℙ ℂ (Fin 1 → ℂ)) :
 
 /-- The multiplicity-aware characteristic polynomial of the sum of two normalized pure-state
 matrices in dimension at least two. This is Wolf's Chapter 1 calculation with the omitted
-$d-2$ zero eigenvalues restored. -/
+$d-2$ zero eigenvalues restored.
+
+**Local fix (zero eigenvalue multiplicities):** Wolf's spectrum shorthand lists the two possibly
+nonzero eigenvalues but omits the remaining $d-2$ zero eigenvalues and their multiplicities. The
+characteristic-polynomial formula restores them; see
+`docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex`. This correction does not assert
+that Wolf's intended spectrum-preserver argument is false. -/
 theorem charpoly_add_pureStateMatrix_of_two_le (hd : 2 ≤ d)
     (p q : ℙ ℂ (Fin d → ℂ)) :
     (pureStateMatrix p + pureStateMatrix q).charpoly =

--- a/TNLean/Channel/Wigner/TwoPureStateCharpoly.lean
+++ b/TNLean/Channel/Wigner/TwoPureStateCharpoly.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff
+import TNLean.Algebra.FinSum
 import TNLean.Channel.Wigner.ProjectivePureState
 
 /-!
@@ -87,37 +88,25 @@ theorem charpoly_add_pureStateMatrix_of_two_le (hd : 2 ≤ d)
   have h00 : (B * A) 0 0 = 1 := by
     simp only [A, B, Matrix.mul_apply, Matrix.cons_val_zero, ap, vp]
     calc
-      ∑ x, ap⁻¹ * star (vp x) * vp x = ap⁻¹ * ∑ x, star (vp x) * vp x := by
-        rw [Finset.mul_sum]
-        apply Finset.sum_congr rfl
-        intro i _
-        ring
+      ∑ x, ap⁻¹ * star (vp x) * vp x = ap⁻¹ * ∑ x, star (vp x) * vp x :=
+        Fintype.sum_mul_mul_eq_mul_sum_mul ap⁻¹ (star vp) vp
       _ = ap⁻¹ * ap := rfl
       _ = 1 := inv_mul_cancel₀ hap
   have h11 : (B * A) 1 1 = 1 := by
     simp only [A, B, Matrix.mul_apply, Matrix.cons_val_zero, Matrix.cons_val_one, aq, vq]
     calc
-      ∑ x, aq⁻¹ * star (vq x) * vq x = aq⁻¹ * ∑ x, star (vq x) * vq x := by
-        rw [Finset.mul_sum]
-        apply Finset.sum_congr rfl
-        intro i _
-        ring
+      ∑ x, aq⁻¹ * star (vq x) * vq x = aq⁻¹ * ∑ x, star (vq x) * vq x :=
+        Fintype.sum_mul_mul_eq_mul_sum_mul aq⁻¹ (star vq) vq
       _ = aq⁻¹ * aq := rfl
       _ = 1 := inv_mul_cancel₀ haq
   have h01 : (B * A) 0 1 = ap⁻¹ * (star vp ⬝ᵥ vq) := by
     simp only [A, B, Matrix.mul_apply, Matrix.cons_val_zero, Matrix.cons_val_one, dotProduct,
       Pi.star_apply]
-    rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro i _
-    ring
+    exact Fintype.sum_mul_mul_eq_mul_sum_mul ap⁻¹ (star vp) vq
   have h10 : (B * A) 1 0 = aq⁻¹ * (star vq ⬝ᵥ vp) := by
     simp only [A, B, Matrix.mul_apply, Matrix.cons_val_zero, Matrix.cons_val_one, dotProduct,
       Pi.star_apply]
-    rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro i _
-    ring
+    exact Fintype.sum_mul_mul_eq_mul_sum_mul aq⁻¹ (star vq) vp
   have htr : (B * A).trace = 2 := by
     rw [Matrix.trace_fin_two, h00, h11]
     norm_num

--- a/TNLean/Channel/Wigner/TwoPureStateCharpoly.lean
+++ b/TNLean/Channel/Wigner/TwoPureStateCharpoly.lean
@@ -14,6 +14,11 @@ Wolf, Chapter 1, lines 289--296. In dimension at least two, the proof factors th
 pure-state matrices as a rectangular product and compares the characteristic polynomials of the
 two product orders. The dimensions zero and one are treated separately.
 
+**Local fix (docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex):** Wolf's
+spectrum shorthand lists the two possibly nonzero eigenvalues but omits the $d-2$ zero eigenvalues
+and their multiplicities. The characteristic-polynomial statement restores them; this correction
+does not assert that Wolf's intended spectrum-preserver argument is false.
+
 ## Main results
 
 * `Projectivization.charpoly_add_pureStateMatrix_of_two_le`
@@ -49,14 +54,6 @@ theorem charpoly_add_pureStateMatrix_fin_one (p q : ℙ ℂ (Fin 1 → ℂ)) :
   rw [pureStateMatrix_fin_one p, pureStateMatrix_fin_one q]
   simp [Matrix.charpoly, Matrix.charmatrix]
   norm_num
-
-private theorem star_dot_self_ne_zero (v : Fin d → ℂ) (hv : v ≠ 0) :
-    star v ⬝ᵥ v ≠ 0 := by
-  rw [dotProduct_comm]
-  let w : EuclideanSpace ℂ (Fin d) := WithLp.toLp 2 v
-  have hw : w ≠ 0 := by simpa [w] using hv
-  rw [← EuclideanSpace.inner_eq_star_dotProduct w w]
-  exact inner_self_ne_zero (𝕜 := ℂ) |>.mpr hw
 
 /-- The multiplicity-aware characteristic polynomial of the sum of two normalized pure-state
 matrices in dimension at least two. This is Wolf's Chapter 1 calculation with the omitted

--- a/TNLean/Channel/WolfProps.lean
+++ b/TNLean/Channel/WolfProps.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.Channel.KrausFreedom
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Tactic.LinearCombination
@@ -533,9 +534,10 @@ theorem exists_isometric_mixing_of_pureEnsembleDensity_eq
         fun i => sandwich_entry (ψ i) (K i) (hK_apply i) X a b c₀.isLt
       simp_rw [each_i]
       simp only [pureEnsembleDensity, Matrix.sum_apply, Matrix.vecMulVec_apply,
-        Pi.star_apply, Finset.mul_sum]
-      refine Finset.sum_congr rfl (fun i _ => ?_)
-      ring
+        Pi.star_apply]
+      simpa only [mul_comm, mul_left_comm, mul_assoc] using
+        Fintype.sum_mul_mul_eq_mul_sum_mul (X c₀ c₀)
+          (fun i => ψ i a) (fun i => star (ψ i b))
     have rhs_eq : (∑ j, L j * X * (L j)ᴴ) a b =
         X c₀ c₀ * (pureEnsembleDensity φ) a b := by
       rw [Matrix.sum_apply]
@@ -544,9 +546,10 @@ theorem exists_isometric_mixing_of_pureEnsembleDensity_eq
         fun j => sandwich_entry (φ j) (L j) (hL_apply j) X a b c₀.isLt
       simp_rw [each_j]
       simp only [pureEnsembleDensity, Matrix.sum_apply, Matrix.vecMulVec_apply,
-        Pi.star_apply, Finset.mul_sum]
-      refine Finset.sum_congr rfl (fun j _ => ?_)
-      ring
+        Pi.star_apply]
+      simpa only [mul_comm, mul_left_comm, mul_assoc] using
+        Fintype.sum_mul_mul_eq_mul_sum_mul (X c₀ c₀)
+          (fun j => φ j a) (fun j => star (φ j b))
     rw [lhs_eq, rhs_eq, hρ]
   -- Apply rectangular Kraus freedom to extract the isometry `V`.
   obtain ⟨V, hV_iso, hV_decomp⟩ := kraus_rectangular_freedom' K L hKraus hCard

--- a/TNLean/Entropy/ClassicalMutualInformation.lean
+++ b/TNLean/Entropy/ClassicalMutualInformation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import Mathlib.Algebra.BigOperators.Field
 import Mathlib.LinearAlgebra.Matrix.Rank
 import TNLean.Analysis.ProbabilityEntropy
@@ -314,10 +315,8 @@ private theorem classicalMutualInformation_rowPerturbation
               ∑ x : X, ε * (∑ y : Y, β x * Real.negMulLog (P x y)) := by
             apply Finset.sum_congr rfl
             intro x _
-            rw [Finset.mul_sum]
-            apply Finset.sum_congr rfl
-            intro y _
-            ring
+            simpa only [mul_comm, mul_left_comm, mul_assoc] using
+              (Fintype.sum_mul_mul_eq_mul_sum_mul (R := ℝ) _ _ _)
           _ = ε * (∑ x : X, ∑ y : Y, β x * Real.negMulLog (P x y)) :=
             (Finset.mul_sum Finset.univ
               (fun x : X ↦ ∑ y : Y, β x * Real.negMulLog (P x y)) ε).symm

--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.BNT.Bridge
 import TNLean.MPS.MPDO.BNTAssociativity
 import TNLean.MPS.MPDO.BNTFusionTensorClause
@@ -281,10 +282,10 @@ theorem hasIdempotentCoefficientForm_of_blockedRepresentations
       intro q _
       apply Finset.sum_congr rfl
       intro r _
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro k _
-      ring)
+      simpa only [mul_comm, mul_left_comm, mul_assoc] using
+        (Fintype.sum_mul_mul_eq_mul_sum_mul (D₁.weight α q ^ L)
+          (fun _ => D₁.weight β r ^ L)
+          (fun k => Fam.chi.entry α β γ k ^ L)).symm)
   intro γ
   have hTwoTrace : ∑ r, C.twoEntry γ r = m.traceScalar γ := by
     change ∑ r, twoEntry γ r = ∑ q, D₁.weight γ q

--- a/TNLean/MPS/MPDO/BNTLeftTripleFusion.lean
+++ b/TNLean/MPS/MPDO/BNTLeftTripleFusion.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.BNTFusionIsometries
 
 /-!
@@ -64,9 +65,9 @@ private theorem kronecker_sum_mulTensor {p a bd1 bd2 : ℕ} (X : Matrix (Fin a) 
     Equiv.symm_symm, Equiv.prodCongr_apply, Prod.map_apply, Equiv.refl_symm, Equiv.coe_refl,
     id_eq, Equiv.prodAssoc_apply, Matrix.sum_apply, Matrix.kronecker_apply,
     Equiv.symm_apply_apply]
-  rw [Finset.mul_sum]
-  refine Finset.sum_congr rfl fun j _ => ?_
-  ring
+  simpa only [mul_assoc] using
+    Fintype.sum_mul_mul_eq_mul_sum_mul (X x1 y1)
+      (fun j => Y i j x2 y2) (fun j => Z j k x3 y3)
 
 namespace BNTFusionIsometryFamily
 

--- a/TNLean/MPS/MPDO/BNTProjectorSelection.lean
+++ b/TNLean/MPS/MPDO/BNTProjectorSelection.lean
@@ -564,7 +564,9 @@ theorem ketLeftMul_bntSectorProjection_commonWeightAbsorbedBasis
           ∑ x, bntSectorProjection hC hρ hη hR s a x *
             S.basisMPOTensor s x b β α := by
       simpa only [mul_comm, mul_left_comm, mul_assoc] using
-        (Fintype.sum_mul_mul_eq_mul_sum_mul (R := ℂ) _ _ _)
+        Fintype.sum_mul_mul_eq_mul_sum_mul (S.commonWeight hWeight s)
+          (fun x => bntSectorProjection hC hρ hη hR s a x)
+          (fun x => S.basisMPOTensor s x b β α)
     _ = _ := by rw [h]
 
 /-- Returning the absorbed-weight MPO representative to doubled-index MPS

--- a/TNLean/MPS/MPDO/BNTProjectorSelection.lean
+++ b/TNLean/MPS/MPDO/BNTProjectorSelection.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.BNTSourceSectorProjectors
 import TNLean.MPS.MPDO.CommonWeightAbsorption
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
@@ -562,10 +563,8 @@ theorem ketLeftMul_bntSectorProjection_commonWeightAbsorbedBasis
         S.commonWeight hWeight s *
           ∑ x, bntSectorProjection hC hρ hη hR s a x *
             S.basisMPOTensor s x b β α := by
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro x _
-      ring
+      simpa only [mul_comm, mul_left_comm, mul_assoc] using
+        (Fintype.sum_mul_mul_eq_mul_sum_mul (R := ℂ) _ _ _)
     _ = _ := by rw [h]
 
 /-- Returning the absorbed-weight MPO representative to doubled-index MPS

--- a/TNLean/MPS/MPDO/BNTRightTripleFusion.lean
+++ b/TNLean/MPS/MPDO/BNTRightTripleFusion.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.BNTFusionIsometries
 
 /-!
@@ -57,10 +58,10 @@ private theorem kronecker_sum_mulTensor_right {p a bd1 bd2 : ℕ}
     Equiv.symm_symm, Equiv.prodCongr_apply, Prod.map_apply, Equiv.refl_symm,
     Equiv.coe_refl, id_eq, Equiv.prodAssoc_apply, Matrix.sum_apply,
     Matrix.kronecker_apply, Equiv.symm_apply_apply]
-  rw [Finset.mul_sum]
-  refine Finset.sum_congr rfl fun j _ => ?_
   simp
-  ring
+  simpa only [mul_comm, mul_left_comm, mul_assoc] using
+    Fintype.sum_mul_mul_eq_mul_sum_mul (X x2 y2)
+      (fun j => Y i j x1 y1) (fun j => Z j k x3 y3)
 
 namespace BNTFusionIsometryFamily
 

--- a/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
+++ b/TNLean/MPS/MPDO/BNTSectorAreaLaw.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.BNTSectorAnalyticProperties
 import TNLean.MPS.MPDO.LocalOrthogonalSumAreaLaw
 import TNLean.MPS.MPDO.PhysicalSupportRestriction
@@ -108,10 +109,10 @@ private theorem firstSiteMatrix_mul_normalizedMPO_of_ketLeftMul_eq
         = (mpo M (N + 1)).trace⁻¹ *
             ∑ i : Fin d, P a i *
               Matrix.trace (M i b * evalWord M (List.ofFn σ') (List.ofFn τ')) := by
-          rw [Finset.mul_sum]
-          apply Finset.sum_congr rfl
-          intro i _
-          ring
+          simpa only [mul_comm, mul_left_comm, mul_assoc] using
+            Fintype.sum_mul_mul_eq_mul_sum_mul
+              (mpo M (N + 1)).trace⁻¹ (fun i => P a i)
+              (fun i => Matrix.trace (M i b * evalWord M (List.ofFn σ') (List.ofFn τ')))
     _ = (mpo M (N + 1)).trace⁻¹ *
         Matrix.trace ((∑ i : Fin d, P a i • M i b) *
           evalWord M (List.ofFn σ') (List.ofFn τ')) := by

--- a/TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean
+++ b/TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.BNTClosingSelection
 import TNLean.MPS.MPDO.BNTThreeSiteCollapse
@@ -248,10 +249,12 @@ theorem reducedBlockState_reindex_isThreeSiteFamilyClosure_of_sameMPV₂Pos
         ((Matrix.trace (M.mpo (L + 3)))⁻¹ * S.coeff (3 + L) j) *
           ∑ w, mpo (S.basisMPOTensor j) (3 + L)
             (Fin.append u w) (Fin.append v w) := by
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro w _
-      ring
+      simpa only [mul_comm, mul_left_comm, mul_assoc, mul_one, one_mul] using
+        Fintype.sum_mul_mul_eq_mul_sum_mul
+          ((Matrix.trace (M.mpo (L + 3)))⁻¹ * S.coeff (3 + L) j)
+          (fun w => mpo (S.basisMPOTensor j) (3 + L)
+            (Fin.append u w) (Fin.append v w))
+          (fun _ => 1)
     _ = ((Matrix.trace (M.mpo (L + 3)))⁻¹ * S.coeff (3 + L) j) *
           Matrix.trace
             ((S.basisMPOTensor j).evalWord (List.ofFn u) (List.ofFn v) *

--- a/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.CompleteZipperFusionFourfold
 
 /-!
@@ -558,10 +559,8 @@ theorem middleFourfoldSynthesis_mul_leftInnerToMiddlePrintedFMatrix
     simp_rw [Finset.sum_mul]
     apply Finset.sum_congr rfl
     intro yh _
-    simp_rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro yi _
-    ring
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      (Fintype.sum_mul_mul_eq_mul_sum_mul (R := ℂ) _ _ _)
   · simp_rw [Finset.mul_sum]
     apply Finset.sum_congr rfl
     intro yh _
@@ -676,10 +675,8 @@ theorem pairFourfoldSynthesis_mul_leftAssocToPairPrintedFMatrix
     simp_rw [Finset.sum_mul]
     apply Finset.sum_congr rfl
     intro yf _
-    simp_rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro yj _
-    ring
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      (Fintype.sum_mul_mul_eq_mul_sum_mul (R := ℂ) _ _ _)
   · simp_rw [Finset.mul_sum]
     apply Finset.sum_congr rfl
     intro yf _
@@ -738,10 +735,8 @@ theorem rightAssocFourfoldSynthesis_mul_pairToRightAssocPrintedFMatrix
     simp_rw [Finset.sum_mul]
     apply Finset.sum_congr rfl
     intro yj _
-    simp_rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro yi _
-    ring
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      (Fintype.sum_mul_mul_eq_mul_sum_mul (R := ℂ) _ _ _)
   · simp_rw [Finset.mul_sum]
     rw [Finset.sum_comm]
     apply Finset.sum_congr rfl

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.CyclicActiveFourthRegionContraction
 
 /-!
@@ -218,11 +219,8 @@ theorem reindex_threeSuffixSectorContraction_eq_cyclicActiveUnnormalized
       rw [sum_swap]
       have factor_sum (A : ℂ)
           (u v : F.CyclicActiveSector → ℂ) :
-          (∑ r, A * u r * v r) = A * ∑ r, u r * v r := by
-        rw [Finset.mul_sum]
-        apply Finset.sum_congr rfl
-        intro r hr
-        ring
+          (∑ r, A * u r * v r) = A * ∑ r, u r * v r :=
+        Fintype.sum_mul_mul_eq_mul_sum_mul A u v
       simp_rw [factor_sum]
       simp_rw [F.sum_cyclicActive_trace_mul_trace_eq_pow_two hpos]
       simp only [cyclicActiveRetainedWord]
@@ -230,14 +228,17 @@ theorem reindex_threeSuffixSectorContraction_eq_cyclicActiveUnnormalized
           (L C : F.CyclicActiveSector → F.CyclicActiveSector → ℂ) :
           (∑ q, B * (R q * ∑ h, L q h * C q h)) =
             B * ∑ q, ∑ h, C q h * (R q * L q h) := by
-        rw [Finset.mul_sum]
-        apply Finset.sum_congr rfl
-        intro q hq
-        rw [Finset.mul_sum]
-        congr 1
-        apply Finset.sum_congr rfl
-        intro h hh
-        ring
+        calc
+          _ = B * ∑ q, R q * ∑ h, L q h * C q h := by
+            simpa only [mul_assoc] using
+              Fintype.sum_mul_mul_eq_mul_sum_mul B R
+                (fun q => ∑ h, L q h * C q h)
+          _ = _ := by
+            congr 1
+            apply Finset.sum_congr rfl
+            intro q _
+            simpa only [mul_comm, mul_left_comm, mul_assoc] using
+              (Fintype.sum_mul_mul_eq_mul_sum_mul (R q) (L q) (C q)).symm
       exact distribute _ _ _ _
 
 /-- Every retained sector block of the three-suffix contraction has the

--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.SectorTrace
 import TNLean.MPS.MPDO.AreaLaw
@@ -454,7 +455,9 @@ private lemma katoCFBlock_transferMap_eq_id_aux (s : ℂ) (B : MPSTensor 4 1)
       refine Finset.sum_congr rfl (fun p _ => ?_)
       rw [one_by_one_mul_conj_apply (B p) X]
     _ = (X 0 0) * (∑ p : Fin 4, (B p 0 0) * star (B p 0 0)) := by
-      rw [Finset.mul_sum]; refine Finset.sum_congr rfl (fun p _ => ?_); ring
+      simpa only [mul_comm, mul_left_comm, mul_assoc] using
+        Fintype.sum_mul_mul_eq_mul_sum_mul (X 0 0)
+          (fun p => B p 0 0) (fun p => star (B p 0 0))
     _ = (X 0 0) * (1 : ℂ) := by
       have hsum : (∑ p : Fin 4, (B p 0 0) * star (B p 0 0)) = (1 : ℂ) := by
         rw [Fin.sum_univ_four, hB0, hB1, hB2, hB3]

--- a/TNLean/MPS/MPDO/PerCopyHorizontalCF.lean
+++ b/TNLean/MPS/MPDO/PerCopyHorizontalCF.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.VerticalCF
 
 /-!
@@ -168,8 +169,10 @@ theorem blockwise_insert_eq_of_mpv_agree
                   Matrix.trace (A k i * MPSTensor.evalWord (A k) (List.ofFn w)))
             = (μ k) ^ (L + 1) * ∑ i : Fin d, W s i *
                 Matrix.trace (A k i * MPSTensor.evalWord (A k) (List.ofFn w)) := by
-              rw [Finset.mul_sum]
-              refine Finset.sum_congr rfl fun i _ => by ring
+              simpa only [mul_comm, mul_left_comm, mul_assoc] using
+                Fintype.sum_mul_mul_eq_mul_sum_mul ((μ k) ^ (L + 1)) (W s)
+                  (fun i => Matrix.trace
+                    (A k i * MPSTensor.evalWord (A k) (List.ofFn w)))
         _   = (μ k) ^ (L + 1) * ∑ i : Fin d, Matrix.trace
                 ((W s i • A k i) * MPSTensor.evalWord (A k) (List.ofFn w)) := by
               congr 1

--- a/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 
 /-!
@@ -113,10 +114,8 @@ theorem changePhysicalBasis_smul
   simp_rw [Finset.mul_sum, Finset.sum_mul]
   apply Finset.sum_congr rfl
   intro x _
-  rw [Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro y _
-  ring
+  simpa only [mul_comm, mul_left_comm, mul_assoc] using
+    (Fintype.sum_mul_mul_eq_mul_sum_mul (R := ℂ) _ _ _)
 
 theorem sectorCoordinateTensor_eq_changePhysicalBasis
     (F : PhysicalSectorFactorization K) :

--- a/TNLean/MPS/MPDO/RepresentativeGroupedLemmaL.lean
+++ b/TNLean/MPS/MPDO/RepresentativeGroupedLemmaL.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.MPS.MPDO.BiCFDerivation.Core
 import TNLean.MPS.SharedInfra.SectorDecomposition
@@ -107,8 +108,10 @@ theorem insertedTensor_basis_eq_of_firstSiteActionAgree_of_coeff_ne_zero
                 Matrix.trace (P.basis j i * evalWord (P.basis j) (List.ofFn w))) =
             P.coeff (L + 1) j * ∑ i : Fin d, W s i *
               Matrix.trace (P.basis j i * evalWord (P.basis j) (List.ofFn w)) := by
-                rw [Finset.mul_sum]
-                refine Finset.sum_congr rfl fun i _ ↦ by ring
+                simpa only [mul_comm, mul_left_comm, mul_assoc] using
+                  Fintype.sum_mul_mul_eq_mul_sum_mul (P.coeff (L + 1) j) (W s)
+                    (fun i => Matrix.trace
+                      (P.basis j i * evalWord (P.basis j) (List.ofFn w)))
         _ = P.coeff (L + 1) j * ∑ i : Fin d, Matrix.trace
               ((W s i • P.basis j i) * evalWord (P.basis j) (List.ofFn w)) := by
                 congr 1

--- a/TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.TopologicalProjectors
 
 /-!
@@ -488,10 +489,12 @@ private theorem appendFusionFirstStage_reconstruction
         simp only [X, Y, mulTensor_apply, Matrix.submatrix_apply,
           finProdFinEquiv_symm_apply, Matrix.sum_apply, Matrix.smul_apply,
           Matrix.kroneckerMap_apply, smul_eq_mul]
-        rw [Finset.mul_sum]
-        apply Finset.sum_congr rfl
-        intro j _
-        ring
+        simpa only [mul_comm, mul_left_comm, mul_assoc] using
+          (Fintype.sum_mul_mul_eq_mul_sum_mul
+            (fusionHistoryWeight Fam α previous h.1 h.2)
+            (fun j => Fam.tensor β j k x.modNat y.modNat)
+            (fun j => Fam.tensor (fusionHistoryFinalLabel Fam α previous h)
+              i j x.divNat y.divNat)).symm
       _ = _ := by
         rw [← hblock]
         unfold recursiveProjectorQ X Y

--- a/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
+++ b/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.EigenvectorProjection
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.TopologicalDensityDecomposition
 
 /-!
@@ -417,10 +418,10 @@ private theorem sum_smul_recursiveProjectorQ
   · subst h'
     simp only [Matrix.sum_apply, Matrix.smul_apply,
       Matrix.blockDiagonal'_apply_eq, smul_eq_mul]
-    rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro i _
-    ring
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      Fintype.sum_mul_mul_eq_mul_sum_mul
+        (Fam.fusionHistoryWeight α previous h.1 h.2) a
+        (fun i => P i h.1 x y)
   · simp [Matrix.sum_apply, Matrix.smul_apply,
       Matrix.blockDiagonal'_apply_ne _ _ _ hhh']
 

--- a/TNLean/MPS/MPDO/VerticalProductPairBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalProductPairBlocks.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.VerticalProductReconstruction
 
 /-!
@@ -628,8 +629,10 @@ theorem mulTensor_verticalAssembledTensor_reindex
     simp only [Matrix.submatrix_apply, Equiv.symm_apply_apply,
       Matrix.smul_apply, smul_eq_mul, Matrix.sum_apply,
       Matrix.kroneckerMap_apply]
-    rw [Finset.mul_sum]
-    exact Finset.sum_congr rfl fun x _ => by ring
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      Fintype.sum_mul_mul_eq_mul_sum_mul (weight α q * weight β r)
+        (fun x => B α (finProdFinEquiv (a, x)) i i')
+        (fun x => B β (finProdFinEquiv (x, b)) j j')
   · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hp]
     simp only [Matrix.sum_apply, Matrix.kroneckerMap_apply]
     apply Finset.sum_eq_zero

--- a/TNLean/MPS/RFP/AppendixBSupport.lean
+++ b/TNLean/MPS/RFP/AppendixBSupport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.RFP.CommutingBridge
 
 /-!
@@ -139,10 +140,10 @@ Source: arXiv:1606.00608, equations (3.16)--(3.17), lines 549--578. -/
           (∏ t : Fin N, hStruct.U (σ t) (q t).1 (q t).2)) * v q := by
       apply Finset.sum_congr rfl
       intro σ _
-      rw [Finset.mul_sum]
-      apply Finset.sum_congr rfl
-      intro q _
-      ring
+      simpa only [mul_comm, mul_left_comm, mul_assoc] using
+        (Fintype.sum_mul_mul_eq_mul_sum_mul
+          (∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) v
+          (fun q => ∏ t : Fin N, hStruct.U (σ t) (q t).1 (q t).2)).symm
     _ = ∑ q : Fin N → Fin D × Fin D,
         (∑ σ : Cfg d N, (∏ t : Fin N,
           star (hStruct.U (σ t) (p t).1 (p t).2) *

--- a/TNLean/MPS/RFP/BellPairCIDObstruction.lean
+++ b/TNLean/MPS/RFP/BellPairCIDObstruction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.RFP.ZeroCorrelationLength
 
@@ -142,10 +143,8 @@ private lemma single_sum_snd (s : Fin 2 → ℂ) (X : Matrix (Fin 2) (Fin 2) ℂ
       rw [map_sum]
     rw [h1]
     congr 1
-    rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro b _
-    ring
+    simpa only [mul_comm, mul_left_comm, mul_assoc] using
+      Fintype.sum_mul_mul_eq_mul_sum_mul (1 / 2 : ℂ) s (fun b => X b b)
   rw [Finset.sum_congr rfl fun a _ => hinner a]
   rw [show (∑ a : Fin 2, Matrix.single a a ((1 / 2 : ℂ) * (∑ b : Fin 2, s b * X b b))) =
       ((1 / 2 : ℂ) * (∑ b : Fin 2, s b * X b b)) • ∑ a : Fin 2, Matrix.single a a 1 from by

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.RFP.StructuralForm
 import TNLean.Spectral.GaugeConstruction
 import TNLean.Channel.KrausRepresentation
@@ -842,8 +843,9 @@ theorem unitPairIsometry_transfer (U : MPSTensor d D)
         refine Finset.sum_congr rfl fun j _ => ?_
         rw [Finset.sum_comm]
         refine Finset.sum_congr rfl fun k _ => ?_
-        rw [Finset.mul_sum]
-        exact Finset.sum_congr rfl fun i _ => by ring
+        simpa only [mul_comm, mul_left_comm, mul_assoc] using
+          Fintype.sum_mul_mul_eq_mul_sum_mul (Z k j)
+            (fun i => U i x k) (fun i => star (U i y j))
     _ = ∑ j : Fin D, ∑ k : Fin D, Z k j * (if x = y ∧ k = j then 1 else 0) := by
         simp_rw [inner]
     _ = Matrix.trace Z * (if x = y then 1 else 0) := by

--- a/TNLean/PEPS/TorusWindowChain4.lean
+++ b/TNLean/PEPS/TorusWindowChain4.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.PEPS.TorusWindowChain3
 import TNLean.PEPS.ConfigurationCalculus
 
@@ -451,7 +452,18 @@ theorem bareExtendInsert_trans {R S P : Finset V} (hRS : R ⊆ S) (hSP : S ⊆ P
             (regionComplementBoundaryConfig (G := G) A S ν')
             (restrictSubRegionσ (V := V) (d := d) Finset.sdiff_subset σ)
             (regionComplementBoundaryConfig (G := G) A P ν) from by
-      rw [Finset.mul_sum]; refine Finset.sum_congr rfl (fun ν' _ => ?_); ring]
+      simpa only [mul_comm, mul_left_comm, mul_assoc] using
+        Fintype.sum_mul_mul_eq_mul_sum_mul
+          (C μ (restrictSubRegionσ (V := V) (d := d) (hRS.trans hSP) σ))
+          (fun ν' => (nestedThreeBlockGeometry (V := V) hRS).threeBlockBlueCoeff
+            (regionComplementBoundaryConfig (G := G) A R μ)
+            (restrictSubRegionσ (V := V) (d := d) Finset.sdiff_subset
+              (restrictSubRegionσ (V := V) (d := d) hSP σ))
+            (regionComplementBoundaryConfig (G := G) A S ν'))
+          (fun ν' => (nestedThreeBlockGeometry (V := V) hSP).threeBlockBlueCoeff
+            (regionComplementBoundaryConfig (G := G) A S ν')
+            (restrictSubRegionσ (V := V) (d := d) Finset.sdiff_subset σ)
+            (regionComplementBoundaryConfig (G := G) A P ν))]
   rw [← mul_smul_comm]
   congr 1
   exact threeBlockBlueCoeff_comp (A := A) hRS hSP

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1550,8 +1550,8 @@ $v$ is multiplied by a nonzero scalar.
     $\C^0$.
 \end{proof}
 
-\begin{corollary}[Recovering transition probability from sum characteristic polynomials]
-    \label{cor:transition_probability_of_sum_charpoly}
+\begin{theorem}[Recovering transition probability from sum characteristic polynomials]
+    \label{thm:transition_probability_of_sum_charpoly}
     \lean{Projectivization.trace_pureStateMatrix_mul_eq_of_charpoly_add_eq}
     \leanok
     \uses{def:projective_pure_state_matrix}
@@ -1563,7 +1563,7 @@ $v$ is multiplied by a nonzero scalar.
     \begin{align}
         \tr(P_pP_q)=\tr(P_rP_s).
     \end{align}
-\end{corollary}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:charpoly_sum_two_pure_states}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1507,14 +1507,13 @@ $v$ is multiplied by a nonzero scalar.
         =X^{d-2}\bigl((X-1)^2-\tr(P_pP_q)\bigr).
         \label{eq:charpoly_sum_two_pure_states}
     \end{align}
-    Wolf's displayed pair of eigenvalues
-    $1\pm\sqrt{\tr(P_pP_q)}$ suppresses the $d-2$ zero eigenvalues and their
-    multiplicities \cite[Chapter~1, Corollary ``Spectrum preserving maps'']{Wolf2012Quantum}.
-    This local
-    source correction is recorded in
-    \path{docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex}; it
-    does not assert that Wolf's intended argument is false.
 \end{theorem}
+% Source audit: Wolf's displayed pair of eigenvalues
+% $1\pm\sqrt{\tr(P_pP_q)}$ suppresses the $d-2$ zero eigenvalues and their
+% multiplicities; see Chapter 1, Corollary ``Spectrum preserving maps'' in
+% \cite{Wolf2012Quantum}. The local correction is recorded in
+% \path{docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex}; it
+% does not assert that Wolf's intended argument is false.
 
 \begin{proof}\leanok
     \uses{thm:projective_pure_state_bridge}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1488,6 +1488,87 @@ $v$ is multiplied by a nonzero scalar.
     which gives the displayed quotient.
 \end{proof}
 
+\begin{theorem}[Characteristic polynomial of two pure states]
+    \label{thm:charpoly_sum_two_pure_states}
+    \lean{Projectivization.isEmpty_projectivization_fin_zero}
+    \lean{Projectivization.pureStateMatrix_fin_one}
+    \lean{Projectivization.charpoly_add_pureStateMatrix_fin_one}
+    \lean{Projectivization.charpoly_add_pureStateMatrix_of_two_le}
+    \leanok
+    \uses{def:projective_pure_state_matrix,
+      thm:projective_pure_state_bridge}
+    There are no projective rays when $d=0$. When $d=1$, every pure-state
+    matrix is the identity and
+    \begin{align}
+        \chi_{P_p+P_q}(X)=X-2.
+    \end{align}
+    If $d\geq2$, then
+    \begin{align}
+        \chi_{P_p+P_q}(X)
+        =X^{d-2}\bigl((X-1)^2-\tr(P_pP_q)\bigr).
+        \label{eq:charpoly_sum_two_pure_states}
+    \end{align}
+    Wolf's displayed pair of eigenvalues
+    $1\pm\sqrt{\tr(P_pP_q)}$ suppresses the $d-2$ zero eigenvalues and their
+    multiplicities \cite[Chapter~1, lines 289--296]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    For $d\geq2$, choose nonzero representatives $v,w$ of $p,q$, and define
+    $A\in M_{d,2}(\C)$ and $B\in M_{2,d}(\C)$ by
+    \begin{align}
+        A=\begin{pmatrix}v&w\end{pmatrix}.
+    \end{align}
+    Define the second factor by
+    \begin{align}
+        B=\begin{pmatrix}
+          \langle v,v\rangle^{-1}v^\dagger\\
+          \langle w,w\rangle^{-1}w^\dagger
+        \end{pmatrix}.
+    \end{align}
+    Then $AB=P_p+P_q$. The characteristic-polynomial identity for rectangular
+    products gives
+    \begin{align}
+        \chi_{AB}(X)=X^{d-2}\chi_{BA}(X).
+    \end{align}
+    Direct calculation yields
+    \begin{align}
+        \tr(BA)=2.
+    \end{align}
+    It also gives
+    \begin{align}
+        \det(BA)=1-\tr(P_pP_q).
+    \end{align}
+    Substitution into the quadratic characteristic polynomial of $BA$ proves
+    (\ref{eq:charpoly_sum_two_pure_states}). In dimension one, trace one forces
+    each pure-state matrix to equal the identity. The zero-dimensional claim
+    follows because a projective ray would require a nonzero vector in
+    $\C^0$.
+\end{proof}
+
+\begin{corollary}[Recovering transition probability from sum characteristic polynomials]
+    \label{cor:transition_probability_of_sum_charpoly}
+    \lean{Projectivization.trace_pureStateMatrix_mul_eq_of_charpoly_add_eq}
+    \leanok
+    \uses{thm:charpoly_sum_two_pure_states}
+    For projective rays $p,q,r,s$ in $\C^d$, if
+    \begin{align}
+        \chi_{P_p+P_q}=\chi_{P_r+P_s},
+    \end{align}
+    then
+    \begin{align}
+        \tr(P_pP_q)=\tr(P_rP_s).
+    \end{align}
+\end{corollary}
+
+\begin{proof}\leanok
+    For $d\geq2$, apply
+    (\ref{eq:charpoly_sum_two_pure_states}) to both sums and cancel the nonzero
+    polynomial $X^{d-2}$. Equality of the remaining constant terms gives the
+    result. In dimension one both traces equal one, while in dimension zero
+    there are no rays.
+\end{proof}
+
 \begin{theorem}[Projective Wigner rigidity]
     \label{thm:projective_wigner_rigidity}
     \lean{Projectivization.wigner_rigidity_fin}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1509,7 +1509,8 @@ $v$ is multiplied by a nonzero scalar.
     \end{align}
     Wolf's displayed pair of eigenvalues
     $1\pm\sqrt{\tr(P_pP_q)}$ suppresses the $d-2$ zero eigenvalues and their
-    multiplicities \cite[Chapter~1, lines 289--296]{Wolf2012Quantum}. This local
+    multiplicities \cite[Chapter~1, Corollary ``Spectrum preserving maps'']{Wolf2012Quantum}.
+    This local
     source correction is recorded in
     \path{docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex}; it
     does not assert that Wolf's intended argument is false.

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1495,8 +1495,7 @@ $v$ is multiplied by a nonzero scalar.
     \lean{Projectivization.charpoly_add_pureStateMatrix_fin_one}
     \lean{Projectivization.charpoly_add_pureStateMatrix_of_two_le}
     \leanok
-    \uses{def:projective_pure_state_matrix,
-      thm:projective_pure_state_bridge}
+    \uses{def:projective_pure_state_matrix}
     There are no projective rays when $d=0$. When $d=1$, every pure-state
     matrix is the identity and
     \begin{align}
@@ -1510,10 +1509,14 @@ $v$ is multiplied by a nonzero scalar.
     \end{align}
     Wolf's displayed pair of eigenvalues
     $1\pm\sqrt{\tr(P_pP_q)}$ suppresses the $d-2$ zero eigenvalues and their
-    multiplicities \cite[Chapter~1, lines 289--296]{Wolf2012Quantum}.
+    multiplicities \cite[Chapter~1, lines 289--296]{Wolf2012Quantum}. This local
+    source correction is recorded in
+    \path{docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex}; it
+    does not assert that Wolf's intended argument is false.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:projective_pure_state_bridge}
     For $d\geq2$, choose nonzero representatives $v,w$ of $p,q$, and define
     $A\in M_{d,2}(\C)$ and $B\in M_{2,d}(\C)$ by
     \begin{align}
@@ -1550,7 +1553,7 @@ $v$ is multiplied by a nonzero scalar.
     \label{cor:transition_probability_of_sum_charpoly}
     \lean{Projectivization.trace_pureStateMatrix_mul_eq_of_charpoly_add_eq}
     \leanok
-    \uses{thm:charpoly_sum_two_pure_states}
+    \uses{def:projective_pure_state_matrix}
     For projective rays $p,q,r,s$ in $\C^d$, if
     \begin{align}
         \chi_{P_p+P_q}=\chi_{P_r+P_s},
@@ -1562,6 +1565,7 @@ $v$ is multiplied by a nonzero scalar.
 \end{corollary}
 
 \begin{proof}\leanok
+    \uses{thm:charpoly_sum_two_pure_states}
     For $d\geq2$, apply
     (\ref{eq:charpoly_sum_two_pure_states}) to both sums and cancel the nonzero
     polynomial $X^{d-2}$. Equality of the remaining constant terms gives the

--- a/docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex
+++ b/docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex
@@ -1,0 +1,70 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Zero Multiplicities in Wolf's Two-Pure-State Spectrum Shorthand}
+\author{}
+\date{2026-08-08}
+
+\begin{document}
+\maketitle
+
+\section{The source display}
+
+In the proof of the spectrum-preserver consequence following Wigner's theorem,
+Wolf considers Hermitian rank-one projections $P,Q\in M_d(\mathbb C)$ and
+writes that the spectrum of $P+Q$ is
+\begin{align}
+  1\pm\sqrt{\tr(PQ)}.
+\end{align}
+The statement appears in Chapter~1, lines 289--296 of the local source,
+\path{Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex}.
+
+\section{The suppressed eigenvalues}
+
+The range of $P+Q$ lies in the span of the two one-dimensional ranges of $P$
+and $Q$. Hence $P+Q$ vanishes on a subspace of dimension at least $d-2$.
+Counting algebraic multiplicities, its characteristic polynomial is
+\begin{align}
+  \chi_{P+Q}(X)
+  =X^{d-2}((X-1)^2-\tr(PQ))
+  \qquad(d\geq2).
+\end{align}
+Thus the displayed pair gives the two eigenvalues arising on the span of the
+pure states, but it suppresses the remaining $d-2$ zero eigenvalues and their
+multiplicities. In dimension one the separate formula is
+\begin{align}
+  \chi_{P+Q}(X)=X-2,
+\end{align}
+because every normalized rank-one projection is the identity. In dimension
+zero there are no projective pure states.
+
+\section{Formal correction}
+
+The declaration
+\leanid{Projectivization.charpoly_add_pureStateMatrix_of_two_le} proves the
+multiplicity-aware formula through a $d\times2$ and $2\times d$ factorization.
+The declaration
+\leanid{Projectivization.trace_pureStateMatrix_mul_eq_of_charpoly_add_eq}
+then recovers $\tr(PQ)$ from equality of two such characteristic polynomials.
+Both are in
+\doclink{TNLean/Channel/Wigner/TwoPureStateCharpoly}; the low-dimensional cases
+are stated explicitly there. This correction is tracked by \ghissue{5683}.
+
+\section{Classification}
+
+This is a local correction to a spectrum shorthand, not a claim that Wolf's
+intended spectrum-preserver argument is false. The displayed pair identifies
+the nonzero two-dimensional part used to recover the transition probability.
+The formal statement uses characteristic polynomials because they retain all
+zero eigenvalues and all algebraic multiplicities without ambiguity.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex
+++ b/docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex
@@ -35,9 +35,11 @@ Counting algebraic multiplicities, its characteristic polynomial is
   =X^{d-2}((X-1)^2-\tr(PQ))
   \qquad(d\geq2).
 \end{align}
-Thus the displayed pair gives the two eigenvalues arising on the span of the
-pure states, but it suppresses the remaining $d-2$ zero eigenvalues and their
-multiplicities. In dimension one the separate formula is
+The displayed values are precisely the two roots of
+$(X-1)^2-\tr(PQ)$. The factor $X^{d-2}$ supplies the guaranteed additional
+zero multiplicity. If $P=Q$, then the quadratic is $X(X-2)$ and contributes
+one further zero, so the total zero multiplicity is $d-1$. In dimension one
+the separate formula is
 \begin{align}
   \chi_{P+Q}(X)=X-2,
 \end{align}
@@ -59,8 +61,8 @@ are stated explicitly there. This correction is tracked by \ghissue{5683}.
 \section{Classification}
 
 This is a local correction to a spectrum shorthand, not a claim that Wolf's
-intended spectrum-preserver argument is false. The displayed pair identifies
-the nonzero two-dimensional part used to recover the transition probability.
+intended spectrum-preserver argument is false. The roots of the quadratic
+factor retain the transition-probability information used in that argument.
 The formal statement uses characteristic polynomials because they retain all
 zero eigenvalues and all algebraic multiplicities without ambiguity.
 

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -142,6 +142,41 @@ This is a local well-posedness correction, not an assertion that the
 nonempty-case Radon--Nikodym theorem is false. The source's word ``set'' and
 summation notation leave the boundary implicit; Lean must state it.
 
+\section{Suppressed zero multiplicities in the two-pure-state spectrum}
+\label{sec:two-pure-state-spectrum}
+
+\paragraph{Formalization trigger.}
+The Lean theorem
+\leanid{Projectivization.charpoly_add_pureStateMatrix_of_two_le} keeps the full
+characteristic polynomial of a sum of two normalized pure-state matrices. The
+correction is documented in
+\path{docs/paper-gaps/wolf_ch01_two_pure_state_zero_multiplicities.tex}.
+
+\paragraph{Printed source and its role.}
+In the spectrum-preserver argument following Wigner's theorem, Chapter~1 says
+that the spectrum of two Hermitian rank-one projections $P,Q$ is
+\begin{equation}
+  1\pm\sqrt{\operatorname{tr}(PQ)}.
+\end{equation}
+This pair describes the restriction of $P+Q$ to the span of the two pure-state
+ranges.
+
+\paragraph{Correction.}
+For $d\geq2$, the multiplicity-aware statement is
+\begin{equation}
+  \chi_{P+Q}(X)
+  =X^{d-2}\bigl((X-1)^2-\operatorname{tr}(PQ)\bigr).
+\end{equation}
+The source shorthand suppresses the $d-2$ zero eigenvalues and their
+multiplicities. Dimension one has the separate formula $\chi_{P+Q}(X)=X-2$,
+and dimension zero has no projective pure states.
+
+\paragraph{Classification.}
+This is a local correction to the displayed spectrum shorthand, not a claim
+that Wolf's intended spectrum-preserver argument is false. The two displayed
+values contain the transition-probability information used in that argument;
+the characteristic polynomial records the complete multiplicity data.
+
 \section{Formalization gaps that are not source corrections}
 
 The following Wolf-specific paper-gap notes are intentionally \emph{not}
@@ -165,9 +200,10 @@ errata entries:
 \section{Conclusion}
 
 At present the formalization-derived record contains one genuine mathematical
-source error (Section~\ref{sec:lorentz}) and one explicit boundary convention
-(Section~\ref{sec:radon-nikodym}).  These are the only corrections asserted by
-the Lean documentation itself.
+source error (Section~\ref{sec:lorentz}), one explicit boundary convention
+(Section~\ref{sec:radon-nikodym}), and one local correction to a spectrum
+shorthand (Section~\ref{sec:two-pure-state-spectrum}). These are the corrections
+asserted by the Lean documentation itself.
 
 \appendix
 \section{Corrected errors in the local LaTeX transcription}

--- a/docs/paper-gaps/wolf_lecture_notes_errata.tex
+++ b/docs/paper-gaps/wolf_lecture_notes_errata.tex
@@ -158,8 +158,8 @@ that the spectrum of two Hermitian rank-one projections $P,Q$ is
 \begin{equation}
   1\pm\sqrt{\operatorname{tr}(PQ)}.
 \end{equation}
-This pair describes the restriction of $P+Q$ to the span of the two pure-state
-ranges.
+These values are the two roots of the quadratic
+$(X-1)^2-\operatorname{tr}(PQ)$.
 
 \paragraph{Correction.}
 For $d\geq2$, the multiplicity-aware statement is
@@ -167,9 +167,10 @@ For $d\geq2$, the multiplicity-aware statement is
   \chi_{P+Q}(X)
   =X^{d-2}\bigl((X-1)^2-\operatorname{tr}(PQ)\bigr).
 \end{equation}
-The source shorthand suppresses the $d-2$ zero eigenvalues and their
-multiplicities. Dimension one has the separate formula $\chi_{P+Q}(X)=X-2$,
-and dimension zero has no projective pure states.
+The factor $X^{d-2}$ supplies the guaranteed additional zero multiplicity.
+If $P=Q$, then the quadratic is $X(X-2)$ and contributes one further zero, so
+the total zero multiplicity is $d-1$. Dimension one has the separate formula
+$\chi_{P+Q}(X)=X-2$, and dimension zero has no projective pure states.
 
 \paragraph{Classification.}
 This is a local correction to the displayed spectrum shorthand, not a claim

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -75,6 +75,28 @@ abstracted — record why, so it is not re-proposed).
 - **Abstraction:** `@[mps_transfer]` simp set + `transfer_simp` macro
   (`TNLean/MPS/Tactic/Basic.lean`).
 
+### finite-sum common-left-factor normalization — promoted
+- **Pattern:**
+  ```lean
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  ring
+  ```
+- **Seen:** six occurrences across
+  `TNLean/Channel/Wigner/TwoPureStateCharpoly.lean`,
+  `TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`, and
+  `TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean` before promotion.
+- **Abstraction:** `Fintype.sum_mul_mul_eq_mul_sum_mul` in
+  `TNLean/Algebra/FinSum.lean`.
+- **Notes:** the shared identity requires only a semiring and pulls a common
+  left factor from a sum of triple products. The two complex-valued callers
+  whose common factor was in the middle first use commutativity to put it in
+  the canonical position. All six scanner-known sites now call the lemma; the
+  four-line pattern no longer appears in the scanner report. The consumer
+  proofs remove 24 repeated tactic lines; the documented lemma and three
+  direct imports leave the Lean-source refactor at three net added lines.
+
 ### dependent finite-sum flattening — promoted
 - **Pattern:** pass between the double sum over `j` and `q : Fin (mult j)` and the
   single sum over `Fin (∑ j, mult j)` reindexed by `finSigmaFinEquiv.symm`.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -105,9 +105,9 @@ abstracted — record why, so it is not re-proposed).
   when the common factor is not initially on the left. All 19 sites now call
   the lemma, and all 14 consumer files import `TNLean.Algebra.FinSum` directly.
   This removes 76 repeated tactic lines. The final 12-site pass, including
-  three `simp_rw` variants, adds and removes 48 Lean-source lines; together
-  with the initial seven-site pass, the cumulative refactor has 77 additions
-  and 78 deletions, so it removes one Lean-source line net. A binder- and
+  three `simp_rw` variants, has 50 additions and 48 deletions in Lean source;
+  together with the initial seven-site pass, the cumulative refactor has 79
+  additions and 78 deletions, so it adds one Lean-source line net. A binder- and
   `rw`/`simp_rw`-insensitive repository-wide assertion finds no equivalent
   four-line block and exactly 19 calls of the shared lemma.
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -83,21 +83,33 @@ abstracted — record why, so it is not re-proposed).
   intro i _
   ring
   ```
-- **Seen:** seven occurrences across
+- **Seen:** 19 occurrences across 14 files before promotion:
+  `TNLean/Channel/KoashiImoto/MarkovBipartiteBlockForm.lean`,
   `TNLean/Channel/Wigner/ProjectivePureState.lean`,
   `TNLean/Channel/Wigner/TwoPureStateCharpoly.lean`,
-  `TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`, and
-  `TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean` before promotion.
+  `TNLean/Entropy/ClassicalMutualInformation.lean`,
+  `TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean`,
+  `TNLean/MPS/MPDO/BNTProjectorSelection.lean`,
+  `TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`,
+  `TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean`,
+  `TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean`,
+  `TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean`,
+  `TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean`,
+  `TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean`,
+  `TNLean/MPS/RFP/AppendixBSupport.lean`, and
+  `TNLean/MPS/RFP/BellPairCIDObstruction.lean`.
 - **Abstraction:** `Fintype.sum_mul_mul_eq_mul_sum_mul` in
   `TNLean/Algebra/FinSum.lean`.
 - **Notes:** the shared identity requires only a non-unital semiring and pulls
-  a common left factor from a sum of triple products. The three sites whose
-  common factor was in the middle first use commutativity to put it in the
-  canonical position. All seven sites now call the lemma, and all four
-  consumer files import `TNLean.Algebra.FinSum` directly. The consumer proofs
-  remove 28 repeated tactic lines; after the mathematical lemma documentation
-  and four direct imports, the cumulative Lean-source refactor removes one
-  line net (29 additions, 30 deletions).
+  a common left factor from a sum of triple products. Callers use commutativity
+  when the common factor is not initially on the left. All 19 sites now call
+  the lemma, and all 14 consumer files import `TNLean.Algebra.FinSum` directly.
+  This removes 76 repeated tactic lines. The final 12-site pass, including
+  three `simp_rw` variants, adds and removes 48 Lean-source lines; together
+  with the initial seven-site pass, the cumulative refactor has 77 additions
+  and 78 deletions, so it removes one Lean-source line net. A binder- and
+  `rw`/`simp_rw`-insensitive repository-wide assertion finds no equivalent
+  four-line block and exactly 19 calls of the shared lemma.
 
 ### dependent finite-sum flattening — promoted
 - **Pattern:** pass between the double sum over `j` and `q : Fin (mult j)` and the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -78,13 +78,15 @@ abstracted — record why, so it is not re-proposed).
 ### finite-sum common-left-factor normalization — promoted
 - **Pattern:** a finite sum differs from a factored form only by pulling one
   index-independent left factor through summands of the form `a * f i * g i`.
-  The original proofs used `rw` or `simp_rw [Finset.mul_sum]`, a
-  `Finset.sum_congr` binder (tactic, functional, or semicolon form), and `ring`.
-- **Seen:** 35 directly equivalent occurrences across 26 files:
+  The original proofs used `rw`, `simp_rw`, or `simp only` with
+  `Finset.mul_sum`, a `Finset.sum_congr` binder (tactic, functional, or
+  semicolon form), and `ring`.
+- **Seen:** 37 directly equivalent occurrences across 27 files:
   `TNLean/Algebra/PerronFrobenius/PerronVector.lean`,
   `TNLean/Analysis/MarginalSupport.lean`,
   `TNLean/Channel/BreuerHallIndecomposable.lean`,
   `TNLean/Channel/KoashiImoto/MarkovBipartiteBlockForm.lean`,
+  `TNLean/Channel/WolfProps.lean`,
   `TNLean/Channel/Wigner/ProjectivePureState.lean`,
   `TNLean/Channel/Wigner/TwoPureStateCharpoly.lean`,
   `TNLean/Entropy/ClassicalMutualInformation.lean`,
@@ -109,25 +111,33 @@ abstracted — record why, so it is not re-proposed).
   `TNLean/PEPS/TorusWindowChain4.lean`.
 - **Abstraction:** `Fintype.sum_mul_mul_eq_mul_sum_mul` in
   `TNLean/Algebra/FinSum.lean`.
-- **Result:** all 35 sites call the shared lemma, and all 26 consumer files
-  import `TNLean.Algebra.FinSum` directly. The broad final pass found 16 sites
-  in 12 new files, including functional binders, one-line semicolon proofs,
-  and both levels of the nested `distribute` identity in
-  `CyclicActiveFourthRegionFormula.lean`. It replaced 41 old tactic source
-  lines; together with the earlier 76, the promotion removes 117 repeated
-  tactic lines. The final pass has 76 additions and 44 deletions in Lean
-  source. Cumulatively, the promotion has 155 additions and 122 deletions,
-  for a net 33 Lean-source lines added; the increase comes from explicit
-  factors in theorem applications rather than repeated per-summand proofs.
-- **Audit scope:** the final audit examined all 445 Lean-source tokens
-  `Finset.mul_sum`, without assuming a tactic head, rewrite direction, binder
-  spelling, line breaks, or semicolon layout. It conservatively retained every
-  token having `sum_congr` and `ring` within the next 16 lines. This superset
-  found 109 residual candidate windows across 55 files: 21 are token/nearby-step
-  false positives, 60 perform nested, two-sided, or reordered sums, and 28 use
-  additional per-summand mathematics. All are category (B), not further
-  instances of the promoted identity. Representative proofs simultaneously distribute both
-  left and right factors or reorder nested sums (`EntropyMarkovReverse.lean`,
+- **Result:** all 37 sites call the shared lemma, and all 27 consumer files
+  import `TNLean.Algebra.FinSum` directly. The broad final passes found 18 sites
+  in 13 new files, including functional binders, one-line semicolon proofs,
+  both levels of the nested `distribute` identity in
+  `CyclicActiveFourthRegionFormula.lean`, and the two commutative-factor forms
+  in `WolfProps.lean`. They replaced 47 old tactic source lines; together with
+  the earlier 76, the promotion removes 123 repeated tactic lines. The broad
+  final passes have 85 additions and 50 deletions in Lean source.
+  Cumulatively, the promotion has 164 additions and 128 deletions, for a net
+  36 Lean-source lines added; the increase comes from explicit factors in
+  theorem applications rather than repeated per-summand proofs.
+- **Audit scope:** at reviewed head `2231755c7`, the final audit examined all
+  453 textual occurrences of `Finset.mul_sum` across 445 Lean source lines,
+  without assuming a tactic head, rewrite direction, binder spelling, line
+  breaks, or semicolon layout. Eight lines contain the token twice. The audit
+  therefore used token occurrences for the broad population, but source-line
+  windows and enclosing proof blocks for classification; duplicated tokens on
+  one line were not counted as separate proofs. The forward-window triage
+  retained 109 source-line windows across 55 files having `sum_congr` and
+  `ring` within the next 16 lines. Two windows were the directly equivalent
+  commutative-factor forms in `WolfProps.lean` and are now migrated. Among the
+  remaining audited windows, 21 are token/nearby-step false positives, 60
+  perform nested, two-sided, or reordered sums, and 26 use additional
+  per-summand mathematics. These residual windows are category (B), not further
+  instances identified as the promoted identity. Representative proofs
+  simultaneously distribute both left and right factors or reorder nested sums
+  (`EntropyMarkovReverse.lean`,
   `ProjectionGeometry.lean`, `BNTMarkovKeyFormula.lean`,
   `HayashiSectorComparison.lean`); rewrite each summand using mathematical
   hypotheses, field identities, indicators, or case splits
@@ -141,9 +151,10 @@ abstracted — record why, so it is not re-proposed).
   shared lemma increases AC-normalization cost without removing that
   transformation. A stricter command-only screen leaves nine syntactic
   occurrences, forming six nested or indicator proof blocks, all among these
-  category-(B) cases. Accordingly, this entry claims completeness only for
-  pure common-left-factor associativity; it does not claim that repository-wide
-  `Finset.mul_sum`/`sum_congr`/`ring` combinations are absent.
+  category-(B) cases. Accordingly, this entry reports the 37 sites actually
+  migrated and the residual candidate classification at the audited head; it
+  does not claim repository-wide completeness or the absence of further
+  `Finset.mul_sum`/`sum_congr`/`ring` combinations.
 
 ### dependent finite-sum flattening — promoted
 - **Pattern:** pass between the double sum over `j` and `q : Fin (mult j)` and the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -89,8 +89,8 @@ abstracted — record why, so it is not re-proposed).
   `TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean` before promotion.
 - **Abstraction:** `Fintype.sum_mul_mul_eq_mul_sum_mul` in
   `TNLean/Algebra/FinSum.lean`.
-- **Notes:** the shared identity requires only a semiring and pulls a common
-  left factor from a sum of triple products. The two complex-valued callers
+- **Notes:** the shared identity requires only a non-unital semiring and pulls
+  a common left factor from a sum of triple products. The two complex-valued callers
   whose common factor was in the middle first use commutativity to put it in
   the canonical position. All six scanner-known sites now call the lemma; the
   four-line pattern no longer appears in the scanner report. The consumer

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -76,40 +76,74 @@ abstracted — record why, so it is not re-proposed).
   (`TNLean/MPS/Tactic/Basic.lean`).
 
 ### finite-sum common-left-factor normalization — promoted
-- **Pattern:**
-  ```lean
-  rw [Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro i _
-  ring
-  ```
-- **Seen:** 19 occurrences across 14 files before promotion:
+- **Pattern:** a finite sum differs from a factored form only by pulling one
+  index-independent left factor through summands of the form `a * f i * g i`.
+  The original proofs used `rw` or `simp_rw [Finset.mul_sum]`, a
+  `Finset.sum_congr` binder (tactic, functional, or semicolon form), and `ring`.
+- **Seen:** 35 directly equivalent occurrences across 26 files:
+  `TNLean/Algebra/PerronFrobenius/PerronVector.lean`,
+  `TNLean/Analysis/MarginalSupport.lean`,
+  `TNLean/Channel/BreuerHallIndecomposable.lean`,
   `TNLean/Channel/KoashiImoto/MarkovBipartiteBlockForm.lean`,
   `TNLean/Channel/Wigner/ProjectivePureState.lean`,
   `TNLean/Channel/Wigner/TwoPureStateCharpoly.lean`,
   `TNLean/Entropy/ClassicalMutualInformation.lean`,
   `TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean`,
+  `TNLean/MPS/MPDO/BNTLeftTripleFusion.lean`,
   `TNLean/MPS/MPDO/BNTProjectorSelection.lean`,
+  `TNLean/MPS/MPDO/BNTRightTripleFusion.lean`,
   `TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`,
   `TNLean/MPS/MPDO/BNTThreeSiteReducedClosure.lean`,
   `TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean`,
+  `TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean`,
+  `TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean`,
+  `TNLean/MPS/MPDO/PerCopyHorizontalCF.lean`,
   `TNLean/MPS/MPDO/PhysicalSectorCoordinateTransport.lean`,
+  `TNLean/MPS/MPDO/RepresentativeGroupedLemmaL.lean`,
   `TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean`,
   `TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean`,
-  `TNLean/MPS/RFP/AppendixBSupport.lean`, and
-  `TNLean/MPS/RFP/BellPairCIDObstruction.lean`.
+  `TNLean/MPS/MPDO/VerticalProductPairBlocks.lean`,
+  `TNLean/MPS/RFP/AppendixBSupport.lean`,
+  `TNLean/MPS/RFP/BellPairCIDObstruction.lean`,
+  `TNLean/MPS/RFP/StructuralFull.lean`, and
+  `TNLean/PEPS/TorusWindowChain4.lean`.
 - **Abstraction:** `Fintype.sum_mul_mul_eq_mul_sum_mul` in
   `TNLean/Algebra/FinSum.lean`.
-- **Notes:** the shared identity requires only a non-unital semiring and pulls
-  a common left factor from a sum of triple products. Callers use commutativity
-  when the common factor is not initially on the left. All 19 sites now call
-  the lemma, and all 14 consumer files import `TNLean.Algebra.FinSum` directly.
-  This removes 76 repeated tactic lines. The final 12-site pass, including
-  three `simp_rw` variants, has 50 additions and 48 deletions in Lean source;
-  together with the initial seven-site pass, the cumulative refactor has 79
-  additions and 78 deletions, so it adds one Lean-source line net. A binder- and
-  `rw`/`simp_rw`-insensitive repository-wide assertion finds no equivalent
-  four-line block and exactly 19 calls of the shared lemma.
+- **Result:** all 35 sites call the shared lemma, and all 26 consumer files
+  import `TNLean.Algebra.FinSum` directly. The broad final pass found 16 sites
+  in 12 new files, including functional binders, one-line semicolon proofs,
+  and both levels of the nested `distribute` identity in
+  `CyclicActiveFourthRegionFormula.lean`. It replaced 41 old tactic source
+  lines; together with the earlier 76, the promotion removes 117 repeated
+  tactic lines. The final pass has 76 additions and 44 deletions in Lean
+  source. Cumulatively, the promotion has 155 additions and 122 deletions,
+  for a net 33 Lean-source lines added; the increase comes from explicit
+  factors in theorem applications rather than repeated per-summand proofs.
+- **Audit scope:** the final audit examined all 445 Lean-source tokens
+  `Finset.mul_sum`, without assuming a tactic head, rewrite direction, binder
+  spelling, line breaks, or semicolon layout. It conservatively retained every
+  token having `sum_congr` and `ring` within the next 16 lines. This superset
+  found 109 residual candidate windows across 55 files: 21 are token/nearby-step
+  false positives, 60 perform nested, two-sided, or reordered sums, and 28 use
+  additional per-summand mathematics. All are category (B), not further
+  instances of the promoted identity. Representative proofs simultaneously distribute both
+  left and right factors or reorder nested sums (`EntropyMarkovReverse.lean`,
+  `ProjectionGeometry.lean`, `BNTMarkovKeyFormula.lean`,
+  `HayashiSectorComparison.lean`); rewrite each summand using mathematical
+  hypotheses, field identities, indicators, or case splits
+  (`Proportional.lean`, `CyclicActiveThreeBoundaryTrace.lean`, and the PEPS
+  kernel-descent files); or combine subtraction, division, real-part, and
+  two-sided sum transformations (the relative-entropy files). Some windows
+  are deliberate false positives where the `ring` belongs to a later proof
+  step, such as `TorusWindowChain3.lean`. The indicator expansion in
+  `UnionInjectivityOverlap3.lean` remains in this class: it is part of a sum
+  expansion and permutation, and replacing its inner reassociation by the
+  shared lemma increases AC-normalization cost without removing that
+  transformation. A stricter command-only screen leaves nine syntactic
+  occurrences, forming six nested or indicator proof blocks, all among these
+  category-(B) cases. Accordingly, this entry claims completeness only for
+  pure common-left-factor associativity; it does not claim that repository-wide
+  `Finset.mul_sum`/`sum_congr`/`ring` combinations are absent.
 
 ### dependent finite-sum flattening — promoted
 - **Pattern:** pass between the double sum over `j` and `q : Fin (mult j)` and the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -83,19 +83,21 @@ abstracted — record why, so it is not re-proposed).
   intro i _
   ring
   ```
-- **Seen:** six occurrences across
+- **Seen:** seven occurrences across
+  `TNLean/Channel/Wigner/ProjectivePureState.lean`,
   `TNLean/Channel/Wigner/TwoPureStateCharpoly.lean`,
   `TNLean/MPS/MPDO/BNTSectorAreaLaw.lean`, and
   `TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean` before promotion.
 - **Abstraction:** `Fintype.sum_mul_mul_eq_mul_sum_mul` in
   `TNLean/Algebra/FinSum.lean`.
 - **Notes:** the shared identity requires only a non-unital semiring and pulls
-  a common left factor from a sum of triple products. The two complex-valued callers
-  whose common factor was in the middle first use commutativity to put it in
-  the canonical position. All six scanner-known sites now call the lemma; the
-  four-line pattern no longer appears in the scanner report. The consumer
-  proofs remove 24 repeated tactic lines; the documented lemma and three
-  direct imports leave the Lean-source refactor at three net added lines.
+  a common left factor from a sum of triple products. The three sites whose
+  common factor was in the middle first use commutativity to put it in the
+  canonical position. All seven sites now call the lemma, and all four
+  consumer files import `TNLean.Algebra.FinSum` directly. The consumer proofs
+  remove 28 repeated tactic lines; after the mathematical lemma documentation
+  and four direct imports, the cumulative Lean-source refactor removes one
+  line net (29 additions, 30 deletions).
 
 ### dependent finite-sum flattening — promoted
 - **Pattern:** pass between the double sum over `j` and `q : Fin (mult j)` and the


### PR DESCRIPTION
## What changed

- prove the multiplicity-aware formula
  \[
  \chi_{P_p+P_q}(X)=X^{d-2}\bigl((X-1)^2-\operatorname{tr}(P_pP_q)\bigr)
  \]
  for $d\ge 2$ by factoring the sum as a $d\times2$/$2\times d$ product and applying `Matrix.charpoly_mul_comm_of_le`
- compute the resulting $2\times2$ trace and determinant using the existing pure-state transition-probability trace identity
- handle $d=0$ by proving that no projective ray exists, and handle $d=1$ with the separate formula $\chi_{P_p+P_q}(X)=X-2$
- recover $\operatorname{tr}(P_pP_q)$ in every dimension from equality of the characteristic polynomials of two pure-state sums
- add Chapter 1 Blueprint coverage explaining that Wolf suppresses the $d-2$ zero eigenvalues and their multiplicities
- keep the new 155-line module inside `Channel/Wigner`, with no MPS dependency
- promote the non-unital-semiring identity `Fintype.sum_mul_mul_eq_mul_sum_mul` in `TNLean/Algebra/FinSum.lean`, refactor all seven call sites across four direct consumers, and record the corrected 28-line reduction and net −1 Lean-source accounting in the tactic-pattern ledger

## Validation

- post-rebase changed-consumer build passed for `ProjectivePureState`, `TwoPureStateCharpoly`, `BNTSectorAreaLaw`, and `TopologicalTerminalSpectral` (9200-job combined target)
- `lake build TNLean` — passed at the rebased exact head (9965 jobs)
- `lake build` — passed at the rebased exact head (9965 jobs; pre-existing warnings only, none in the changed modules)
- tactic-pattern scanner default/strict runs and syntax check — passed; a binder-insensitive assertion found zero equivalent four-line blocks in the four refactored consumers and exactly seven shared-lemma calls
- `lake exe lint_style` — passed
- oversized-file and numbered-module policy checks — passed (0 oversized files, 0 new numbered violations)
- `python3 scripts/generate_import_aggregators.py --check` — passed (50 aggregators, 1249 production modules)
- Blueprint source sync and CI scan — passed (6637/6637 theorem-like entries)
- `leanblueprint checkdecls` — passed after rebuilding the root import frontier
- the new Wolf source-correction note and updated general errata — compiled successfully with `latexmk`
- Blueprint direct compilation — completed from clean auxiliaries with repeated `lualatex` passes and zero undefined cross-references; only the repository's expected standalone citation warnings remain
- proof-integrity scan and `git diff --check origin/main...HEAD` — passed

Closes LionSR/QICLean#296

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New spectral/charpoly mathematics on the Wigner pure-state layer plus a broad mechanical refactor across many modules; proofs are lemma-driven but touch a large surface area.
> 
> **Overview**
> Adds **Wolf Chapter 1** formalization for the sum of two normalized pure-state matrices: multiplicity-aware characteristic polynomial with restored \(X^{d-2}\) zero factors, low-dimensional cases, and recovery of \(\mathrm{tr}(P_p P_q)\) from matching charpolys (`TwoPureStateCharpoly.lean`). Blueprint Chapter 1 and paper-gap/errata notes document Wolf’s suppressed zero multiplicities.
> 
> Introduces **`Fintype.sum_mul_mul_eq_mul_sum_mul`** in `TNLean/Algebra/FinSum.lean` and refactors many finite-sum proofs (Perron–Frobenius, channels, MPS/PEPS, entropy, etc.) to use it instead of repeated `Finset.mul_sum` / `ring` steps. **`star_dot_self_ne_zero`** is exported from `ProjectivePureState` for the new charpoly proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d56e59caba653ee1cfb0fbd99c9df2cdf11443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





