### PR TITLE
feat(Channel): construct matrix conditional expectations

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -87,6 +87,7 @@ import TNLean.Channel.Separable
 import TNLean.Channel.SingleKraus
 import TNLean.Channel.SingleKrausPositivity
 import TNLean.Channel.Spectral
+import TNLean.Channel.StarSubalgebraConditionalExpectation
 import TNLean.Channel.Stinespring
 import TNLean.Channel.SupportCompletion
 import TNLean.Channel.SupportedMarginalChannel

--- a/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
+++ b/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.ScalarCommutant
 import TNLean.Algebra.StarSubalgebraBlockForm
 import TNLean.Analysis.MatrixSqrt
+import TNLean.Channel.KrausCPTP
 import TNLean.Channel.PositiveConditionalExpectation
 import TNLean.Channel.Schwarz.PositiveMapProperties
 
@@ -171,6 +172,39 @@ theorem unitaryReindexLinearEquiv_symm_posSemidef
     ((unitaryReindexLinearEquiv e U hU).symm A).PosSemidef := by
   rw [unitaryReindexLinearEquiv_symm_apply]
   exact (hA.submatrix e.symm).mul_mul_conjTranspose_same (B := U)
+
+/-- Changing to unitary block coordinates is trace-preserving and completely positive. -/
+theorem unitaryReindexLinearEquiv_toLinearMap_isKrausCPTP
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    IsKrausCPTP (unitaryReindexLinearEquiv e U hU).toLinearMap := by
+  rw [show (unitaryReindexLinearEquiv e U hU).toLinearMap =
+      equivReindexMap e.symm ∘ₗ singleKrausMap (star U) by
+    apply LinearMap.ext
+    intro A
+    simp [unitaryReindexLinearEquiv_apply, equivReindexMap,
+      Matrix.coe_reindexLinearEquiv, Matrix.star_eq_conjTranspose]]
+  apply isKrausCPTP_comp
+  · apply singleKrausMap_isKrausCPTP
+    simpa only [Matrix.star_eq_conjTranspose,
+      Matrix.conjTranspose_conjTranspose] using Matrix.mem_unitaryGroup_iff.mp hU
+  · exact equivReindexMap_isKrausCPTP e.symm
+
+/-- Returning from unitary block coordinates is trace-preserving and completely positive. -/
+theorem unitaryReindexLinearEquiv_symm_toLinearMap_isKrausCPTP
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    IsKrausCPTP (unitaryReindexLinearEquiv e U hU).symm.toLinearMap := by
+  rw [show (unitaryReindexLinearEquiv e U hU).symm.toLinearMap =
+      singleKrausMap U ∘ₗ equivReindexMap e by
+    apply LinearMap.ext
+    intro A
+    simp [unitaryReindexLinearEquiv_symm_apply, equivReindexMap,
+      Matrix.coe_reindexLinearEquiv, Matrix.star_eq_conjTranspose]]
+  apply isKrausCPTP_comp
+  · exact equivReindexMap_isKrausCPTP e
+  · apply singleKrausMap_isKrausCPTP
+    simpa only [Matrix.star_eq_conjTranspose] using Matrix.mem_unitaryGroup_iff'.mp hU
 
 /-- A matrix acting on the traced factor may be moved across an input before taking the
 partial trace.

--- a/TNLean/Channel/StarSubalgebraConditionalExpectation.lean
+++ b/TNLean/Channel/StarSubalgebraConditionalExpectation.lean
@@ -10,8 +10,8 @@ import TNLean.Channel.PositiveConditionalExpectationDirectSum
 # Trace-preserving conditional expectations onto matrix star subalgebras
 
 Every star subalgebra of a full complex matrix algebra has unitary block coordinates in
-which it is a direct sum of right matrix factors.  Transporting the normalized coordinate
-expectation through this change of coordinates gives a trace-preserving completely positive
+which it is a direct sum of right matrix factors.  Conjugating the normalized coordinate
+expectation by this change of coordinates gives a trace-preserving completely positive
 conditional expectation onto the original star subalgebra.
 
 ## Main result
@@ -35,7 +35,8 @@ completely positive conditional expectation.
 
 The map is obtained from the coordinate direct-sum expectation by the unitary block
 coordinates of Wolf, Equation (1.39).  This is the matrix-algebra codomain step in the
-operator-system extension argument following Wolf, Proposition 1.5 and Equation (1.40);
+operator-system extension argument following Wolf, Proposition 1.5 and Equation (1.40),
+local source `Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 536--577;
 it does not corestrict the codomain to the subtype of the star subalgebra. -/
 theorem exists_krausCPTP_conditionalExpectation
     {n : Type*} [Fintype n] [DecidableEq n]

--- a/TNLean/Channel/StarSubalgebraConditionalExpectation.lean
+++ b/TNLean/Channel/StarSubalgebraConditionalExpectation.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.DirectSumConditionalExpectation
+import TNLean.Channel.PositiveConditionalExpectationDirectSum
+
+/-!
+# Trace-preserving conditional expectations onto matrix star subalgebras
+
+Every star subalgebra of a full complex matrix algebra has unitary block coordinates in
+which it is a direct sum of right matrix factors.  Transporting the normalized coordinate
+expectation through this change of coordinates gives a trace-preserving completely positive
+conditional expectation onto the original star subalgebra.
+
+## Main result
+
+* `StarSubalgebra.exists_krausCPTP_conditionalExpectation`: every matrix star subalgebra is
+  the range of a trace-preserving completely positive conditional expectation.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 1.5 and
+  Equation (1.40)][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace StarSubalgebra
+
+/-- Every star subalgebra of a full complex matrix algebra admits a trace-preserving
+completely positive conditional expectation.
+
+The map is obtained from the coordinate direct-sum expectation by the unitary block
+coordinates of Wolf, Equation (1.39).  This is the matrix-algebra codomain step in the
+operator-system extension argument following Wolf, Proposition 1.5 and Equation (1.40);
+it does not corestrict the codomain to the subtype of the star subalgebra. -/
+theorem exists_krausCPTP_conditionalExpectation
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (S : StarSubalgebra ℂ (Matrix n n ℂ)) :
+    ∃ E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ,
+      IsKrausCPTP E ∧ Kraus.IsConditionalExpectation E S := by
+  classical
+  obtain ⟨K, d, m, e, U, hU, hd, hm, hBlock⟩ :=
+    S.exists_unitary_conj_blockDiagonal_iff
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  let E₀ := Matrix.coordinateDirectSumConditionalExpectation (m := m) (d := d)
+  let E := Φ.symm.toLinearMap ∘ₗ E₀ ∘ₗ Φ.toLinearMap
+  obtain ⟨hE₀CPTP, hE₀⟩ :=
+    Matrix.coordinateDirectSumConditionalExpectation_isKrausCPTP_and_isConditionalExpectation
+      hm
+  have hΦCPTP : IsKrausCPTP Φ.toLinearMap :=
+    Matrix.unitaryReindexLinearEquiv_toLinearMap_isKrausCPTP e U hU
+  have hΦsymmCPTP : IsKrausCPTP Φ.symm.toLinearMap :=
+    Matrix.unitaryReindexLinearEquiv_symm_toLinearMap_isKrausCPTP e U hU
+  have hECPTP : IsKrausCPTP E :=
+    isKrausCPTP_comp (isKrausCPTP_comp hΦCPTP hE₀CPTP) hΦsymmCPTP
+  have hSymmConj (A : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+      ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ) :
+      star U * Φ.symm A * U = Matrix.reindex e e A := by
+    rw [Matrix.unitaryReindexLinearEquiv_symm_apply]
+    have hUstarU : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hU
+    calc
+      star U * (U * Matrix.reindex e e A * star U) * U =
+          (star U * U) * Matrix.reindex e e A * (star U * U) := by
+        simp only [Matrix.mul_assoc]
+      _ = Matrix.reindex e e A := by rw [hUstarU, Matrix.one_mul, Matrix.mul_one]
+  refine ⟨E, hECPTP, ?_⟩
+  let hE₀' : Kraus.IsConditionalExpectation E₀
+      (Matrix.coordinateRightFactorStarSubalgebra (m := m) (d := d)) := hE₀
+  exact {
+    positive := (isKrausCP_iff_isCPMap.mp hECPTP.isKrausCP).isPositiveMap
+    idempotent := by
+      intro A
+      change Φ.symm (E₀ (Φ (Φ.symm (E₀ (Φ A))))) = Φ.symm (E₀ (Φ A))
+      rw [Φ.apply_symm_apply, hE₀'.idempotent]
+    unital := by
+      change Φ.symm (E₀ (Φ 1)) = 1
+      rw [Matrix.unitaryReindexLinearEquiv_one, hE₀'.unital,
+        ← Matrix.unitaryReindexLinearEquiv_one e U hU, Φ.symm_apply_apply]
+    range_subset := by
+      intro A
+      apply (hBlock (E A)).mpr
+      obtain ⟨B, hB⟩ := (Matrix.mem_coordinateRightFactorStarSubalgebra
+        (m := m) (d := d) (E₀ (Φ A))).mp (hE₀'.range_subset (Φ A))
+      refine ⟨B, ?_⟩
+      change star U * Φ.symm (E₀ (Φ A)) * U = _
+      rw [hSymmConj, hB]
+    fixes := by
+      intro A hA
+      obtain ⟨B, hB⟩ := (hBlock A).mp hA
+      have hΦA : Φ A = Matrix.blockDiagonal' fun k ↦
+          (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k := by
+        rw [Matrix.unitaryReindexLinearEquiv_apply, hB]
+        simpa only [Matrix.symm_reindexLinearEquiv, Matrix.coe_reindexLinearEquiv] using
+          (Matrix.reindexLinearEquiv ℂ ℂ e e).symm_apply_apply
+            (Matrix.blockDiagonal' fun k ↦
+              (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ B k)
+      have hE₀Fix : E₀ (Φ A) = Φ A := hE₀'.fixes (Φ A)
+        ((Matrix.mem_coordinateRightFactorStarSubalgebra
+          (m := m) (d := d) (Φ A)).mpr ⟨B, hΦA⟩)
+      change Φ.symm (E₀ (Φ A)) = A
+      rw [hE₀Fix, Φ.symm_apply_apply]
+  }
+
+end StarSubalgebra

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseDirectSumUnitary.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseDirectSumUnitary.lean
@@ -173,57 +173,6 @@ theorem UnitarySectorConjugacy.directSumUnitaryS_apply
   simp [directSumUnitaryS, sectorLinearEquiv,
     Matrix.star_eq_conjTranspose]
 
-private theorem UnitarySectorConjugacy.forwardComponent_isKrausCPTP
-    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S)
-    (γ : Fin H.labelCount) :
-    IsKrausCPTP
-      (Matrix.unitaryReindexLinearEquiv
-        (finCongr (S.bondDim_eq γ)) (C.unitary γ)
-          (C.unitary γ).property).symm.toLinearMap := by
-  rw [show (Matrix.unitaryReindexLinearEquiv
-      (finCongr (S.bondDim_eq γ)) (C.unitary γ)
-        (C.unitary γ).property).symm.toLinearMap =
-      singleKrausMap (C.unitary γ) ∘ₗ
-        Matrix.equivReindexMap (finCongr (S.bondDim_eq γ)) by
-    apply LinearMap.ext
-    intro X
-    simp [Matrix.unitaryReindexLinearEquiv_symm_apply,
-      Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
-      Matrix.star_eq_conjTranspose]]
-  apply isKrausCPTP_comp
-    (Matrix.equivReindexMap_isKrausCPTP (finCongr (S.bondDim_eq γ)))
-  apply singleKrausMap_isKrausCPTP
-  simpa only [Matrix.star_eq_conjTranspose] using
-    Matrix.mem_unitaryGroup_iff'.mp (C.unitary γ).property
-
-private theorem UnitarySectorConjugacy.backwardComponent_isKrausCPTP
-    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S)
-    (γ : Fin H.labelCount) :
-    IsKrausCPTP
-      (Matrix.unitaryReindexLinearEquiv
-        (finCongr (S.bondDim_eq γ)) (C.unitary γ)
-          (C.unitary γ).property).toLinearMap := by
-  rw [show (Matrix.unitaryReindexLinearEquiv
-      (finCongr (S.bondDim_eq γ)) (C.unitary γ)
-        (C.unitary γ).property).toLinearMap =
-      Matrix.equivReindexMap (finCongr (S.bondDim_eq γ)).symm ∘ₗ
-        singleKrausMap
-          ((C.unitary γ : Matrix
-            (Fin (S.decomposition.bondDim (S.relabel γ)))
-            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ) by
-    apply LinearMap.ext
-    intro Y
-    simp [Matrix.unitaryReindexLinearEquiv_apply,
-      Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
-      Matrix.star_eq_conjTranspose]]
-  apply isKrausCPTP_comp
-  · apply singleKrausMap_isKrausCPTP
-    simpa only [Matrix.star_eq_conjTranspose,
-      Matrix.conjTranspose_conjTranspose] using
-      Matrix.mem_unitaryGroup_iff.mp (C.unitary γ).property
-  · exact Matrix.equivReindexMap_isKrausCPTP
-      (finCongr (S.bondDim_eq γ)).symm
-
 /-- The map \(\widetilde T\) is completely positive between the two finite
 direct sums.
 
@@ -239,7 +188,8 @@ theorem UnitarySectorConjugacy.directSumUnitaryT_isKrausDirectSumMap
     intro X
     rfl]
   exact Matrix.isKrausDirectSumMap_piMap _
-    (fun γ ↦ (C.forwardComponent_isKrausCPTP γ).isKrausCP)
+    (fun γ ↦ (Matrix.unitaryReindexLinearEquiv_symm_toLinearMap_isKrausCPTP
+      (finCongr (S.bondDim_eq γ)) (C.unitary γ) (C.unitary γ).property).isKrausCP)
 
 /-- The map \(\widetilde S\) is completely positive between the two finite
 direct sums.
@@ -256,7 +206,8 @@ theorem UnitarySectorConjugacy.directSumUnitaryS_isKrausDirectSumMap
     intro Y
     rfl]
   exact Matrix.isKrausDirectSumMap_piMap _
-    (fun γ ↦ (C.backwardComponent_isKrausCPTP γ).isKrausCP)
+    (fun γ ↦ (Matrix.unitaryReindexLinearEquiv_toLinearMap_isKrausCPTP
+      (finCongr (S.bondDim_eq γ)) (C.unitary γ) (C.unitary γ).property).isKrausCP)
 
 /-- The map \(\widetilde T\) preserves the sum of the traces of its simple
 matrix summands.
@@ -268,7 +219,8 @@ theorem UnitarySectorConjugacy.directSumUnitaryT_isTracePreservingBetweenDirectS
   intro X
   apply Finset.sum_congr rfl
   intro γ _
-  exact (C.forwardComponent_isKrausCPTP γ).trace_map (X γ)
+  exact (Matrix.unitaryReindexLinearEquiv_symm_toLinearMap_isKrausCPTP
+    (finCongr (S.bondDim_eq γ)) (C.unitary γ) (C.unitary γ).property).trace_map (X γ)
 
 /-- The map \(\widetilde S\) preserves the sum of the traces of its simple
 matrix summands.
@@ -280,7 +232,8 @@ theorem UnitarySectorConjugacy.directSumUnitaryS_isTracePreservingBetweenDirectS
   intro Y
   apply Finset.sum_congr rfl
   intro γ _
-  exact (C.backwardComponent_isKrausCPTP γ).trace_map (Y γ)
+  exact (Matrix.unitaryReindexLinearEquiv_toLinearMap_isKrausCPTP
+    (finCongr (S.bondDim_eq γ)) (C.unitary γ) (C.unitary γ).property).trace_map (Y γ)
 
 /-- The direct-sum map \(\widetilde S\) is a left inverse of
 \(\widetilde T\).

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -718,27 +718,51 @@ algebra is a single full matrix algebra $\MN{m}$; see
     unitality follow.
 \end{proof}
 
-% Unitary transport of the coordinate expectation from Equation (1.39).
-\begin{theorem}[Unitary block-coordinate channels]
-    \label{thm:unitary_reindex_channels}
+% Unitary coordinate changes associated with Equation (1.39).
+\begin{lemma}[Positivity in unitary block coordinates]
+    \label{lem:unitary_reindex_posSemidef}
     \lean{Matrix.unitaryReindexLinearEquiv_posSemidef}
     \lean{Matrix.unitaryReindexLinearEquiv_symm_posSemidef}
+    \leanok
+    Let $e:H\simeq I$ be an equivalence of finite index sets and let
+    $U$ be a unitary matrix indexed by $I$. The mutually inverse coordinate
+    changes
+    \begin{align}
+        \Phi(A)&=e^{-1}(U^\dagger A U)
+        \notag
+    \end{align}
+    and
+    \begin{align}
+        \Phi^{-1}(X)&=Ue(X)U^\dagger
+        \notag
+    \end{align}
+    both preserve positive semidefiniteness.
+\end{lemma}
+
+\begin{proof}\leanok
+    Unitary conjugation preserves positive semidefiniteness, as does
+    reindexing a matrix along an equivalence. Apply these facts in the two
+    possible orders.
+\end{proof}
+
+\begin{theorem}[Unitary block-coordinate channels]
+    \label{thm:unitary_reindex_channels}
     \lean{Matrix.unitaryReindexLinearEquiv_toLinearMap_isKrausCPTP}
     \lean{Matrix.unitaryReindexLinearEquiv_symm_toLinearMap_isKrausCPTP}
     \leanok
     \uses{def:is_kraus_cptp}
     Let $e:H\simeq I$ be an equivalence of finite index sets and let
-    $U$ be a unitary matrix indexed by $I$. The forward coordinate change is
+    $U$ be a unitary matrix indexed by $I$. Define
     \begin{align}
-        \Phi(A)&=e^{-1}(U^\dagger A U).
+        \Phi(A)&=e^{-1}(U^\dagger A U)
         \notag
     \end{align}
-    Its inverse is
+    and
     \begin{align}
         \Phi^{-1}(X)&=Ue(X)U^\dagger.
         \notag
     \end{align}
-    are trace-preserving and completely positive.
+    Both $\Phi$ and $\Phi^{-1}$ are trace-preserving and completely positive.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -719,8 +719,8 @@ algebra is a single full matrix algebra $\MN{m}$; see
 \end{proof}
 
 % Unitary coordinate changes associated with Equation (1.39).
-\begin{lemma}[Positivity in unitary block coordinates]
-    \label{lem:unitary_reindex_posSemidef}
+\begin{theorem}[Positivity in unitary block coordinates]
+    \label{thm:unitary_reindex_posSemidef}
     \lean{Matrix.unitaryReindexLinearEquiv_posSemidef}
     \lean{Matrix.unitaryReindexLinearEquiv_symm_posSemidef}
     \leanok
@@ -737,7 +737,7 @@ algebra is a single full matrix algebra $\MN{m}$; see
         \notag
     \end{align}
     both preserve positive semidefiniteness.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Unitary conjugation preserves positive semidefiniteness, as does
@@ -787,13 +787,19 @@ algebra is a single full matrix algebra $\MN{m}$; see
     trace-preserving completely positive map $E:\MN{n}\to\MN{n}$ that is
     a conditional expectation onto $\mathcal B$: it is unital and
     idempotent, its range lies in $\mathcal B$, and it fixes every element
-    of $\mathcal B$.
+    of $\mathcal B$. This is the normalized trace-preserving choice in the
+    family described by
+    \cite[Proposition~1.5 and Equation~(1.40)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:starSubalgebra_unitary_block_diagonal_iff,
       thm:coordinate_direct_sum_conditional_expectation,
-      thm:unitary_reindex_channels}
+      thm:unitary_reindex_channels,
+      lem:is_kraus_cptp_comp,
+      lem:is_kraus_cp_basic,
+      lem:is_kraus_cp_iff_is_cp_map,
+      thm:cp_is_positive}
     By the finite-dimensional block form, choose unitary coordinates in
     which
     \begin{align}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -718,6 +718,77 @@ algebra is a single full matrix algebra $\MN{m}$; see
     unitality follow.
 \end{proof}
 
+% Unitary transport of the coordinate expectation from Equation (1.39).
+\begin{theorem}[Unitary block-coordinate channels]
+    \label{thm:unitary_reindex_channels}
+    \lean{Matrix.unitaryReindexLinearEquiv_toLinearMap_isKrausCPTP}
+    \lean{Matrix.unitaryReindexLinearEquiv_symm_toLinearMap_isKrausCPTP}
+    \leanok
+    \uses{def:is_kraus_cptp}
+    Let $e:H\simeq I$ be an equivalence of finite index sets and let
+    $U$ be a unitary matrix indexed by $I$. The forward coordinate change is
+    \begin{align}
+        \Phi(A)&=e^{-1}(U^\dagger A U).
+        \notag
+    \end{align}
+    Its inverse is
+    \begin{align}
+        \Phi^{-1}(X)&=Ue(X)U^\dagger.
+        \notag
+    \end{align}
+    are trace-preserving and completely positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_equiv_reindex_cptp,
+      thm:mpdo_single_kraus_map_cptp,
+      lem:is_kraus_cptp_comp}
+    The forward map is the composition of conjugation by $U^\dagger$ with
+    reindexing by $e^{-1}$, while the inverse is reindexing by $e$ followed
+    by conjugation by $U$. Unitarity makes both single-Kraus conjugations
+    trace preserving. Equivalence reindexing is trace preserving and
+    completely positive, and composition preserves these properties.
+\end{proof}
+
+% Wolf ch01 source lines 539--577: combine the unital block form (1.39),
+% the conditional expectations (1.40), and the two building blocks named at line 577.
+\begin{theorem}[Trace-preserving conditional expectation onto a matrix subalgebra]
+    \label{thm:matrix_star_subalgebra_cptp_conditional_expectation}
+    \lean{StarSubalgebra.exists_krausCPTP_conditionalExpectation}
+    \leanok
+    \uses{def:is_kraus_cptp, def:is_conditional_expectation}
+    For every unital $*$-subalgebra $\mathcal B\subseteq\MN{n}$, there is a
+    trace-preserving completely positive map $E:\MN{n}\to\MN{n}$ that is
+    a conditional expectation onto $\mathcal B$: it is unital and
+    idempotent, its range lies in $\mathcal B$, and it fixes every element
+    of $\mathcal B$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:starSubalgebra_unitary_block_diagonal_iff,
+      thm:coordinate_direct_sum_conditional_expectation,
+      thm:unitary_reindex_channels}
+    By the finite-dimensional block form, choose unitary coordinates in
+    which
+    \begin{align}
+        \mathcal B
+        &=\bigoplus_k\bigl(\mathbb1_{m_k}\otimes\MN{d_k}\bigr).
+        \notag
+    \end{align}
+    Let $E_0$ be the coordinate direct-sum expectation and set
+    \begin{align}
+        E&=\Phi^{-1}\circ E_0\circ\Phi.
+        \notag
+    \end{align}
+    Theorem~\ref{thm:unitary_reindex_channels} and closure under composition
+    show that $E$ is trace-preserving and completely positive. The identities
+    $\Phi\Phi^{-1}=\id$ and $E_0^2=E_0$ give $E^2=E$, and all three maps are
+    unital. Finally, the block-membership equivalence identifies
+    $\Phi(\mathcal B)$ with the coordinate subalgebra. Thus the range of $E$
+    lies in $\mathcal B$, and the pointwise fixation of that coordinate
+    subalgebra by $E_0$ implies $E(B)=B$ for every $B\in\mathcal B$.
+\end{proof}
+
 \begin{definition}[Operator system]\label{def:operator_system}
     \lean{Matrix.IsOperatorSystem}
     \leanok

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -721,6 +721,8 @@ algebra is a single full matrix algebra $\MN{m}$; see
 % Unitary transport of the coordinate expectation from Equation (1.39).
 \begin{theorem}[Unitary block-coordinate channels]
     \label{thm:unitary_reindex_channels}
+    \lean{Matrix.unitaryReindexLinearEquiv_posSemidef}
+    \lean{Matrix.unitaryReindexLinearEquiv_symm_posSemidef}
     \lean{Matrix.unitaryReindexLinearEquiv_toLinearMap_isKrausCPTP}
     \lean{Matrix.unitaryReindexLinearEquiv_symm_toLinearMap_isKrausCPTP}
     \leanok


### PR DESCRIPTION
### Motivation

- Wolf's finite-dimensional block form, Proposition 1.5, and Equation (1.40) give a conditional expectation onto every unital matrix star-subalgebra.
- Issue LionSR/QICLean#292 asks for the trace-preserving completely positive choice obtained by conjugating the coordinate direct-sum expectation from LionSR/QICLean#291 through the unitary block coordinates.
- Source: `Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 536–577.

### Description

- Add public CPTP theorems for `Matrix.unitaryReindexLinearEquiv` and its inverse, using equivalence reindexing, single-Kraus maps, and closure under composition.
- Replace the private MPDO copies of these proofs with the public Channel declarations.
- Add `StarSubalgebra.exists_krausCPTP_conditionalExpectation`, with
  `E = Φ.symm ∘ E₀ ∘ Φ`, and prove CPTP, idempotence, unitality, range inclusion, and pointwise fixation from the coordinate expectation and the exact block-membership equivalence.
- Add Chapter 1 Blueprint coverage with separate positivity and CPTP entries and exact statement/proof dependencies.
- Keep the scope to star-subalgebras of full complex matrix algebras. This does not corestrict the codomain to the subtype and does not compose with the operator-system extension theorem.
- The new transport module has a 64-module TNLean import cone with zero MPS imports. The only MPS change removes the former private duplicate proofs and redirects their consumers to the Channel API.

### Testing

- `lake build TNLean.Channel.StarSubalgebraConditionalExpectation TNLean.MPS.MPDO.BNTAlgebraTensorClauseDirectSumUnitary TNLean.Channel`
- `PYTHONPATH=scripts python3 scripts/test_lean_file_policies.py -v`
- `PYTHONPATH=scripts python3 scripts/check_oversized_lean_files.py --root . --import-only-aggregator TNLean.lean` — 1291 files scanned, zero violations
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` — 49 aggregators, 1237 production modules
- `lake build lint_style` and `lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tenkz_lint.py 'blueprint/src/chapter/*.tex'` — 241 files, zero findings
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — 6624/6624 entries
- Changed-declaration Blueprint coverage — zero missing declarations
- `lake exe checkdecls blueprint/lean_decls`
- Two `lualatex` Blueprint passes — 882 pages, zero undefined cross-references
- Proof-integrity scan of all changed Lean files — zero blockers or warnings
- Recursive import-cone audit — zero MPS imports from the new Channel module
- `git diff --check origin/main...HEAD`

---
Closes LionSR/QICLean#292

### Agent assistance

- OpenAI Codex developed the Lean proofs, API deduplication, Blueprint entries, and validation under maintainer direction; all mathematical statements and source scope remain reviewable in the committed diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The new expectation theorem is foundational for Wolf Ch.1 operator-system extension and composes several prior lemmas; errors in conjugation or block-membership would affect downstream channel theory, but changes are localized to standard unitary/Kraus machinery without auth or data handling.
> 
> **Overview**
> Adds **public CPTP theorems** for `Matrix.unitaryReindexLinearEquiv` and its inverse, proving trace preservation and complete positivity via single-Kraus conjugation and equivalence reindexing composed with existing Kraus closure lemmas.
> 
> Introduces **`StarSubalgebra.exists_krausCPTP_conditionalExpectation`**: for any matrix star-subalgebra, builds \(E = \Phi^{-1} \circ E_0 \circ \Phi\) from Wolf’s unitary block coordinates and the coordinate direct-sum expectation, and proves CPTP plus conditional-expectation properties (idempotent, unital, range in \(\mathcal B\), fixes \(\mathcal B\)).
> 
> **MPDO** `BNTAlgebraTensorClauseDirectSumUnitary` drops private duplicate CPTP proofs and calls the new Channel API. Chapter 1 **Blueprint** adds unitary coordinate positivity/CPTP entries and the matrix subalgebra conditional-expectation theorem with explicit proof dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9287f9790125d48e182aef21f030c2754d5f4376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->