### PR TITLE
feat(Channel): extend cp maps into matrix subalgebras

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -55,6 +55,7 @@ import TNLean.Channel.OpenSystem
 import TNLean.Channel.OperatorSystem
 import TNLean.Channel.OperatorSystemExtension
 import TNLean.Channel.OperatorSystemExtensionDirectSum
+import TNLean.Channel.OperatorSystemExtensionStarSubalgebra
 import TNLean.Channel.OrderedCP
 import TNLean.Channel.POVM
 import TNLean.Channel.POVM.RankOneNaimark

--- a/TNLean/Channel/OperatorSystemExtensionStarSubalgebra.lean
+++ b/TNLean/Channel/OperatorSystemExtensionStarSubalgebra.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.OperatorSystemExtensionDirectSum
+import TNLean.Channel.StarSubalgebraConditionalExpectation
+
+/-!
+# Extending completely positive maps into matrix star subalgebras
+
+Wolf's proposition on extending completely positive maps from operator systems
+(`Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 616--626) allows both the
+domain and codomain to be finite-dimensional `C^*`-algebras. The domain is represented as a
+finite direct sum of full matrix algebras, while the codomain is represented as a star
+subalgebra of a full matrix algebra.
+
+The ambient direct-sum extension is composed with a trace-preserving completely positive
+conditional expectation onto the codomain subalgebra. Its range can then be restricted to the
+subalgebra. Complete positivity of the restricted map is stated after the canonical inclusion
+into the ambient matrix algebra.
+
+## Main results
+
+* `Matrix.IsCPMapDirectSum.comp_isKrausCP`: postcomposition of a completely positive map from a
+  direct sum with a Kraus completely positive matrix map preserves complete positivity.
+* `Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range`: an ambient
+  extension whose range lies in the prescribed matrix star subalgebra.
+* `Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra`: the extension with
+  codomain restricted to the matrix star subalgebra.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 1][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+namespace Matrix
+
+variable {r : ℕ} {d : Fin r → ℕ} {p q : ℕ}
+
+/-- Postcomposing a completely positive map from a direct sum of matrix algebras with a Kraus
+completely positive map preserves complete positivity. -/
+theorem IsCPMapDirectSum.comp_isKrausCP
+    {F : (∀ k : Fin r, Matrix (Fin (d k)) (Fin (d k)) ℂ) →ₗ[ℂ]
+      Matrix (Fin p) (Fin p) ℂ}
+    {E : Matrix (Fin p) (Fin p) ℂ →ₗ[ℂ] Matrix (Fin q) (Fin q) ℂ}
+    (hF : IsCPMapDirectSum F) (hE : IsKrausCP E) :
+    IsCPMapDirectSum (E ∘ₗ F) := by
+  intro j X hX
+  have hcomp :
+      tensorMapIdDirectSum (E ∘ₗ F) X = tensorMapId E (tensorMapIdDirectSum F X) := by
+    ext ⟨a, i⟩ ⟨b, l⟩
+    rfl
+  rw [hcomp]
+  exact tensorMapId_posSemidef_of_isKrausCP hE (hF j X hX)
+
+/-- **Extending cp maps from operator systems, with range in a matrix star subalgebra**
+(Wolf Ch. 1, lines 616--626): if a completely positive map on an operator system in a finite
+direct sum of matrix algebras takes values in a matrix star subalgebra, then it has a completely
+positive ambient-matrix-valued extension whose whole range lies in that subalgebra. -/
+theorem exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range
+    [NeZero (∑ k, d k)] [NeZero p]
+    {S : Submodule ℂ (∀ k : Fin r, Matrix (Fin (d k)) (Fin (d k)) ℂ)}
+    (hS : IsOperatorSystemDirectSum S)
+    (B : StarSubalgebra ℂ (Matrix (Fin p) (Fin p) ℂ))
+    {T : ↥S →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ}
+    (hT : IsCPOnOperatorSystemDirectSum T) (hRange : ∀ x, T x ∈ B) :
+    ∃ T' : (∀ k : Fin r, Matrix (Fin (d k)) (Fin (d k)) ℂ) →ₗ[ℂ]
+        Matrix (Fin p) (Fin p) ℂ,
+      IsCPMapDirectSum T' ∧ (∀ A, T' A ∈ B) ∧ ∀ x : ↥S, T' x.1 = T x := by
+  obtain ⟨F, hFcp, hFext⟩ := exists_cp_extension_of_operatorSystem_directSum hS hT
+  obtain ⟨E, hEcptp, hE⟩ := B.exists_krausCPTP_conditionalExpectation
+  refine ⟨E ∘ₗ F, hFcp.comp_isKrausCP hEcptp.isKrausCP, ?_, ?_⟩
+  · exact fun A ↦ hE.range_subset (F A)
+  · intro x
+    rw [LinearMap.comp_apply, hFext x]
+    exact hE.fixes (T x) (hRange x)
+
+/-- **Extending cp maps from operator systems, finite-dimensional matrix-algebra form**
+(Wolf Ch. 1, lines 616--626): a completely positive map from an operator system in a finite
+direct sum of full matrix algebras to a matrix star subalgebra extends to the whole domain.
+Complete positivity is measured after the canonical inclusion of the codomain subalgebra into
+its ambient full matrix algebra. -/
+theorem exists_cp_extension_of_operatorSystem_directSum_starSubalgebra
+    [NeZero (∑ k, d k)] [NeZero p]
+    {S : Submodule ℂ (∀ k : Fin r, Matrix (Fin (d k)) (Fin (d k)) ℂ)}
+    (hS : IsOperatorSystemDirectSum S)
+    (B : StarSubalgebra ℂ (Matrix (Fin p) (Fin p) ℂ))
+    {T : ↥S →ₗ[ℂ] ↥B}
+    (hT : IsCPOnOperatorSystemDirectSum (B.subtype.toLinearMap ∘ₗ T)) :
+    ∃ T' : (∀ k : Fin r, Matrix (Fin (d k)) (Fin (d k)) ℂ) →ₗ[ℂ] ↥B,
+      IsCPMapDirectSum (B.subtype.toLinearMap ∘ₗ T') ∧ ∀ x : ↥S, T' x.1 = T x := by
+  obtain ⟨G, hGcp, hGrange, hGext⟩ :=
+    exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range hS B hT
+      (fun x ↦ (T x).2)
+  let T' := LinearMap.codRestrict B.toSubalgebra.toSubmodule G hGrange
+  refine ⟨T', ?_, ?_⟩
+  · have hinclude : B.subtype.toLinearMap ∘ₗ T' = G := by
+      ext A
+      rfl
+    rw [hinclude]
+    exact hGcp
+  · intro x
+    apply Subtype.ext
+    exact hGext x
+
+end Matrix

--- a/TNLean/Channel/OperatorSystemExtensionStarSubalgebra.lean
+++ b/TNLean/Channel/OperatorSystemExtensionStarSubalgebra.lean
@@ -60,7 +60,12 @@ theorem IsCPMapDirectSum.comp_isKrausCP
 /-- **Extending cp maps from operator systems, with range in a matrix star subalgebra**
 (Wolf Ch. 1, lines 616--626): if a completely positive map on an operator system in a finite
 direct sum of matrix algebras takes values in a matrix star subalgebra, then it has a completely
-positive ambient-matrix-valued extension whose whole range lies in that subalgebra. -/
+positive ambient-matrix-valued extension whose whole range lies in that subalgebra.
+
+**Scope restriction (concrete matrix realization):** Wolf states the result for arbitrary
+finite-dimensional `C^*`-algebras. Here the domain is given in direct-sum matrix coordinates and
+the codomain algebra is a concrete unital star subalgebra of a full matrix algebra. Documented in
+`docs/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.tex`. -/
 theorem exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range
     [NeZero (∑ k, d k)] [NeZero p]
     {S : Submodule ℂ (∀ k : Fin r, Matrix (Fin (d k)) (Fin (d k)) ℂ)}
@@ -83,7 +88,12 @@ theorem exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range
 (Wolf Ch. 1, lines 616--626): a completely positive map from an operator system in a finite
 direct sum of full matrix algebras to a matrix star subalgebra extends to the whole domain.
 Complete positivity is measured after the canonical inclusion of the codomain subalgebra into
-its ambient full matrix algebra. -/
+its ambient full matrix algebra.
+
+**Scope restriction (concrete matrix realization):** Wolf states the result for arbitrary
+finite-dimensional `C^*`-algebras. Here the domain is given in direct-sum matrix coordinates and
+the codomain is a concrete unital star subalgebra of a full matrix algebra. Documented in
+`docs/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.tex`. -/
 theorem exists_cp_extension_of_operatorSystem_directSum_starSubalgebra
     [NeZero (∑ k, d k)] [NeZero p]
     {S : Submodule ℂ (∀ k : Fin r, Matrix (Fin (d k)) (Fin (d k)) ℂ)}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1192,6 +1192,90 @@ $M_M(\C)$, $M=\sum_kd_k$.
     $S$.
 \end{proof}
 
+% Wolf Chapter 1, lines 616--626: matrix-realized finite-dimensional codomain.
+\begin{theorem}[Postcomposition with a Kraus completely positive map]
+    \label{thm:cp_direct_sum_postcomp_kraus}
+    \lean{Matrix.IsCPMapDirectSum.comp_isKrausCP}
+    \leanok
+    \uses{def:cp_map_direct_sum, def:is_kraus_cp}
+    Let $F:\bigoplus_{k<r}M_{d_k}(\C)\to\MN{p}$ be completely positive and
+    let $E:\MN{p}\to\MN{q}$ have a Kraus representation. Then $E\circ F$ is
+    completely positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:kraus_cp_tensor_id}
+    At each matrix level $j$, the ampliations satisfy
+    \begin{align}
+        ((E\circ F)\otimes\id_j)(X)
+        &=(E\otimes\id_j)((F\otimes\id_j)(X)).
+    \end{align}
+    If every component of $X$ is positive semidefinite, complete positivity
+    of $F$ makes the inner matrix positive semidefinite. The Kraus
+    representation of $E\otimes\id_j$ then preserves its positivity.
+\end{proof}
+
+\begin{theorem}[Extension with range in a matrix subalgebra]
+    \label{thm:extend_cp_operator_system_subalgebra_range}
+    \lean{Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range}
+    \leanok
+    \uses{def:operator_system_direct_sum, def:cp_on_operator_system_direct_sum,
+      def:cp_map_direct_sum}
+    Let $d_0,\dots,d_{r-1}$ be natural numbers, not all zero, let $p\geq1$,
+    let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, and let
+    $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra. Suppose that
+    $T:S\to\MN{p}$ is completely positive and $T(S)\subseteq\mathcal B$.
+    Then there is a completely positive map
+    $G:\bigoplus_{k<r}M_{d_k}(\C)\to\MN{p}$ such that
+    $G(\bigoplus_{k<r}M_{d_k}(\C))\subseteq\mathcal B$ and $G|_S=T$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:extend_cp_operator_system_direct_sum,
+      thm:matrix_star_subalgebra_cptp_conditional_expectation,
+      lem:is_kraus_cp_basic,
+      thm:cp_direct_sum_postcomp_kraus}
+    Theorem~\ref{thm:extend_cp_operator_system_direct_sum} gives a completely
+    positive extension $F$ with values in $\MN{p}$. Choose the conditional
+    expectation $E:\MN{p}\to\MN{p}$ from
+    Theorem~\ref{thm:matrix_star_subalgebra_cptp_conditional_expectation}; its
+    range lies in $\mathcal B$. Set $G=E\circ F$.
+    Theorem~\ref{thm:cp_direct_sum_postcomp_kraus} shows that $G$ is completely
+    positive, while $E(\MN{p})\subseteq\mathcal B$.
+    For $x\in S$, one has $F(x)=T(x)\in\mathcal B$, and therefore
+    $G(x)=E(T(x))=T(x)$.
+\end{proof}
+
+\begin{theorem}[Extending cp maps from operator systems to matrix subalgebras]
+    \label{thm:extend_cp_operator_system_star_subalgebra}
+    \lean{Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra}
+    \leanok
+    \uses{def:operator_system_direct_sum, def:cp_on_operator_system_direct_sum,
+      def:cp_map_direct_sum}
+    Let $d_0,\dots,d_{r-1}$ be natural numbers, not all zero, let $p\geq1$,
+    let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, let
+    $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra, and let
+    $T:S\to\mathcal B$ be completely positive, where positivity in
+    $\mathcal B$ is read through its inclusion in $\MN{p}$. Then there is a
+    linear map
+    \begin{align}
+        \widetilde T:
+        \bigoplus_{k<r}M_{d_k}(\C)&\longrightarrow\mathcal B
+    \end{align}
+    whose inclusion into $\MN{p}$ is completely positive and which satisfies
+    $\widetilde T|_S=T$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:extend_cp_operator_system_subalgebra_range}
+    Apply Theorem~\ref{thm:extend_cp_operator_system_subalgebra_range} to the
+    composite of $T$ with the inclusion $\mathcal B\hookrightarrow\MN{p}$.
+    Since the resulting ambient map $G$ takes every value in $\mathcal B$, it
+    defines a map $\widetilde T$ with codomain $\mathcal B$. Its composite
+    with the inclusion is $G$, hence is completely positive, and equality in
+    $\MN{p}$ gives $\widetilde T|_S=T$.
+\end{proof}
+
 \section{Pure states, projective rays, and Wigner's theorem}
 
 A nonzero vector $v\in\C^d$ determines a ray $[v]$ and the normalized
@@ -1310,87 +1394,3 @@ $v$ is multiplied by a nonzero scalar.
     $F(P)=UPU^\dagger$ for every $P$, or
     $F(P)=UP^{\mathsf T}U^\dagger$ for every $P$.
 \end{theorem}
-
-% Wolf Chapter 1, lines 616--626: matrix-realized finite-dimensional codomain.
-\begin{theorem}[Postcomposition with a Kraus completely positive map]
-    \label{thm:cp_direct_sum_postcomp_kraus}
-    \lean{Matrix.IsCPMapDirectSum.comp_isKrausCP}
-    \leanok
-    \uses{def:cp_map_direct_sum, def:is_kraus_cp}
-    Let $F:\bigoplus_{k<r}M_{d_k}(\C)\to\MN{p}$ be completely positive and
-    let $E:\MN{p}\to\MN{q}$ have a Kraus representation. Then $E\circ F$ is
-    completely positive.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:kraus_cp_tensor_id}
-    At each matrix level $j$, the ampliations satisfy
-    \begin{align}
-        ((E\circ F)\otimes\id_j)(X)
-        &=(E\otimes\id_j)((F\otimes\id_j)(X)).
-    \end{align}
-    If every component of $X$ is positive semidefinite, complete positivity
-    of $F$ makes the inner matrix positive semidefinite. The Kraus
-    representation of $E\otimes\id_j$ then preserves its positivity.
-\end{proof}
-
-\begin{theorem}[Extension with range in a matrix subalgebra]
-    \label{thm:extend_cp_operator_system_subalgebra_range}
-    \lean{Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range}
-    \leanok
-    \uses{def:operator_system_direct_sum, def:cp_on_operator_system_direct_sum,
-      def:cp_map_direct_sum}
-    Let $d_0,\dots,d_{r-1}$ be natural numbers, not all zero, let $p\geq1$,
-    let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, and let
-    $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra. Suppose that
-    $T:S\to\MN{p}$ is completely positive and $T(S)\subseteq\mathcal B$.
-    Then there is a completely positive map
-    $G:\bigoplus_{k<r}M_{d_k}(\C)\to\MN{p}$ such that
-    $G(\bigoplus_{k<r}M_{d_k}(\C))\subseteq\mathcal B$ and $G|_S=T$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:extend_cp_operator_system_direct_sum,
-      thm:matrix_star_subalgebra_cptp_conditional_expectation,
-      lem:is_kraus_cp_basic,
-      thm:cp_direct_sum_postcomp_kraus}
-    Theorem~\ref{thm:extend_cp_operator_system_direct_sum} gives a completely
-    positive extension $F$ with values in $\MN{p}$. Choose the conditional
-    expectation $E:\MN{p}\to\MN{p}$ from
-    Theorem~\ref{thm:matrix_star_subalgebra_cptp_conditional_expectation}; its
-    range lies in $\mathcal B$. Set $G=E\circ F$.
-    Theorem~\ref{thm:cp_direct_sum_postcomp_kraus} shows that $G$ is completely
-    positive, while $E(\MN{p})\subseteq\mathcal B$.
-    For $x\in S$, one has $F(x)=T(x)\in\mathcal B$, and therefore
-    $G(x)=E(T(x))=T(x)$.
-\end{proof}
-
-\begin{theorem}[Extending cp maps from operator systems to matrix subalgebras]
-    \label{thm:extend_cp_operator_system_star_subalgebra}
-    \lean{Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra}
-    \leanok
-    \uses{def:operator_system_direct_sum, def:cp_on_operator_system_direct_sum,
-      def:cp_map_direct_sum}
-    Let $d_0,\dots,d_{r-1}$ be natural numbers, not all zero, let $p\geq1$,
-    let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, let
-    $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra, and let
-    $T:S\to\mathcal B$ be completely positive, where positivity in
-    $\mathcal B$ is read through its inclusion in $\MN{p}$. Then there is a
-    linear map
-    \begin{align}
-        \widetilde T:
-        \bigoplus_{k<r}M_{d_k}(\C)&\longrightarrow\mathcal B
-    \end{align}
-    whose inclusion into $\MN{p}$ is completely positive and which satisfies
-    $\widetilde T|_S=T$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:extend_cp_operator_system_subalgebra_range}
-    Apply Theorem~\ref{thm:extend_cp_operator_system_subalgebra_range} to the
-    composite of $T$ with the inclusion $\mathcal B\hookrightarrow\MN{p}$.
-    Since the resulting ambient map $G$ takes every value in $\mathcal B$, it
-    defines a map $\widetilde T$ with codomain $\mathcal B$. Its composite
-    with the inclusion is $G$, hence is completely positive, and equality in
-    $\MN{p}$ gives $\widetilde T|_S=T$.
-\end{proof}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1340,8 +1340,9 @@ $v$ is multiplied by a nonzero scalar.
     \leanok
     \uses{def:operator_system_direct_sum, def:cp_on_operator_system_direct_sum,
       def:cp_map_direct_sum}
-    Let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, and
-    let $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra. Suppose that
+    Let $d_0,\dots,d_{r-1}$ be natural numbers, not all zero, let $p\geq1$,
+    let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, and let
+    $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra. Suppose that
     $T:S\to\MN{p}$ is completely positive and $T(S)\subseteq\mathcal B$.
     Then there is a completely positive map
     $G:\bigoplus_{k<r}M_{d_k}(\C)\to\MN{p}$ such that
@@ -1351,6 +1352,7 @@ $v$ is multiplied by a nonzero scalar.
 \begin{proof}\leanok
     \uses{thm:extend_cp_operator_system_direct_sum,
       thm:matrix_star_subalgebra_cptp_conditional_expectation,
+      lem:is_kraus_cp_basic,
       thm:cp_direct_sum_postcomp_kraus}
     Theorem~\ref{thm:extend_cp_operator_system_direct_sum} gives a completely
     positive extension $F$ with values in $\MN{p}$. Choose the conditional
@@ -1369,7 +1371,8 @@ $v$ is multiplied by a nonzero scalar.
     \leanok
     \uses{def:operator_system_direct_sum, def:cp_on_operator_system_direct_sum,
       def:cp_map_direct_sum}
-    Let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, let
+    Let $d_0,\dots,d_{r-1}$ be natural numbers, not all zero, let $p\geq1$,
+    let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, let
     $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra, and let
     $T:S\to\mathcal B$ be completely positive, where positivity in
     $\mathcal B$ is read through its inclusion in $\MN{p}$. Then there is a

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1310,3 +1310,83 @@ $v$ is multiplied by a nonzero scalar.
     $F(P)=UPU^\dagger$ for every $P$, or
     $F(P)=UP^{\mathsf T}U^\dagger$ for every $P$.
 \end{theorem}
+
+% Wolf Chapter 1, lines 616--626: matrix-realized finite-dimensional codomain.
+\begin{theorem}[Postcomposition with a Kraus completely positive map]
+    \label{thm:cp_direct_sum_postcomp_kraus}
+    \lean{Matrix.IsCPMapDirectSum.comp_isKrausCP}
+    \leanok
+    \uses{def:cp_map_direct_sum, def:is_kraus_cp}
+    Let $F:\bigoplus_{k<r}M_{d_k}(\C)\to\MN{p}$ be completely positive and
+    let $E:\MN{p}\to\MN{q}$ have a Kraus representation. Then $E\circ F$ is
+    completely positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:kraus_cp_tensor_id}
+    At each matrix level $j$, the ampliations satisfy
+    \begin{align}
+        ((E\circ F)\otimes\id_j)(X)
+        &=(E\otimes\id_j)((F\otimes\id_j)(X)).
+    \end{align}
+    If every component of $X$ is positive semidefinite, complete positivity
+    of $F$ makes the inner matrix positive semidefinite. The Kraus
+    representation of $E\otimes\id_j$ then preserves its positivity.
+\end{proof}
+
+\begin{theorem}[Extension with range in a matrix subalgebra]
+    \label{thm:extend_cp_operator_system_subalgebra_range}
+    \lean{Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range}
+    \leanok
+    \uses{def:operator_system_direct_sum, def:cp_on_operator_system_direct_sum,
+      def:cp_map_direct_sum}
+    Let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, and
+    let $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra. Suppose that
+    $T:S\to\MN{p}$ is completely positive and $T(S)\subseteq\mathcal B$.
+    Then there is a completely positive map
+    $G:\bigoplus_{k<r}M_{d_k}(\C)\to\MN{p}$ such that
+    $G(\bigoplus_{k<r}M_{d_k}(\C))\subseteq\mathcal B$ and $G|_S=T$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:extend_cp_operator_system_direct_sum,
+      thm:matrix_star_subalgebra_cptp_conditional_expectation,
+      thm:cp_direct_sum_postcomp_kraus}
+    Theorem~\ref{thm:extend_cp_operator_system_direct_sum} gives a completely
+    positive extension $F$ with values in $\MN{p}$. Choose the conditional
+    expectation $E:\MN{p}\to\mathcal B$ from
+    Theorem~\ref{thm:matrix_star_subalgebra_cptp_conditional_expectation} and
+    set $G=E\circ F$. Theorem~\ref{thm:cp_direct_sum_postcomp_kraus} shows
+    that $G$ is completely positive, while $E(\MN{p})\subseteq\mathcal B$.
+    For $x\in S$, one has $F(x)=T(x)\in\mathcal B$, and therefore
+    $G(x)=E(T(x))=T(x)$.
+\end{proof}
+
+\begin{theorem}[Extending cp maps from operator systems to matrix subalgebras]
+    \label{thm:extend_cp_operator_system_star_subalgebra}
+    \lean{Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra}
+    \leanok
+    \uses{def:operator_system_direct_sum, def:cp_on_operator_system_direct_sum,
+      def:cp_map_direct_sum}
+    Let $S\subseteq\bigoplus_{k<r}M_{d_k}(\C)$ be an operator system, let
+    $\mathcal B\subseteq\MN{p}$ be a unital $*$-subalgebra, and let
+    $T:S\to\mathcal B$ be completely positive, where positivity in
+    $\mathcal B$ is read through its inclusion in $\MN{p}$. Then there is a
+    linear map
+    \begin{align}
+        \widetilde T:
+        \bigoplus_{k<r}M_{d_k}(\C)&\longrightarrow\mathcal B
+    \end{align}
+    whose inclusion into $\MN{p}$ is completely positive and which satisfies
+    $\widetilde T|_S=T$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:extend_cp_operator_system_subalgebra_range}
+    Apply Theorem~\ref{thm:extend_cp_operator_system_subalgebra_range} to the
+    composite of $T$ with the inclusion $\mathcal B\hookrightarrow\MN{p}$.
+    Since the resulting ambient map $G$ takes every value in $\mathcal B$, it
+    defines a map $\widetilde T$ with codomain $\mathcal B$. Its composite
+    with the inclusion is $G$, hence is completely positive, and equality in
+    $\MN{p}$ gives $\widetilde T|_S=T$.
+\end{proof}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1354,10 +1354,11 @@ $v$ is multiplied by a nonzero scalar.
       thm:cp_direct_sum_postcomp_kraus}
     Theorem~\ref{thm:extend_cp_operator_system_direct_sum} gives a completely
     positive extension $F$ with values in $\MN{p}$. Choose the conditional
-    expectation $E:\MN{p}\to\mathcal B$ from
-    Theorem~\ref{thm:matrix_star_subalgebra_cptp_conditional_expectation} and
-    set $G=E\circ F$. Theorem~\ref{thm:cp_direct_sum_postcomp_kraus} shows
-    that $G$ is completely positive, while $E(\MN{p})\subseteq\mathcal B$.
+    expectation $E:\MN{p}\to\MN{p}$ from
+    Theorem~\ref{thm:matrix_star_subalgebra_cptp_conditional_expectation}; its
+    range lies in $\mathcal B$. Set $G=E\circ F$.
+    Theorem~\ref{thm:cp_direct_sum_postcomp_kraus} shows that $G$ is completely
+    positive, while $E(\MN{p})\subseteq\mathcal B$.
     For $x\in S$, one has $F(x)=T(x)\in\mathcal B$, and therefore
     $G(x)=E(T(x))=T(x)$.
 \end{proof}

--- a/docs/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.tex
+++ b/docs/paper-gaps/wolf_ch01_operator_system_extension_matrix_scope.tex
@@ -7,9 +7,9 @@
 
 \input{command}
 
-\title{Wolf's Operator-System Extension: Full-Matrix-Algebra Scope Restriction}
+\title{Wolf's Operator-System Extension: Matrix-Algebra Realization}
 \author{}
-\date{2026-08-06}
+\date{2026-08-08}
 
 \begin{document}
 \maketitle
@@ -57,32 +57,35 @@ level descends through this embedding
 block-diagonal matrix is positive semidefinite exactly when each of its
 diagonal blocks is.
 
-The codomain algebra $\mathcal B$ remains a full matrix algebra
-$\mathcal B=\MN{p}$. This \emph{is} a residual scope restriction. The source
-statement quantifies $\mathcal B$ over every finite-dimensional $C^*$-algebra,
-while the source's displayed proof only constructs an $M_n(\mathbb C)$-valued
-extension: the ancilla dimension $n$ is fixed with
-$\mathcal B\subseteq M_n(\mathbb C)$, and Hahn--Banach plus Choi--Jamiolkowski
-yield a completely positive $\tilde T:\mathcal A\to M_n(\mathbb C)$. The final
-$\mathcal B$-valued step is left implicit in the source; it follows by
-composing with a completely positive conditional expectation
-$M_n(\mathbb C)\to\mathcal B$ onto the subalgebra (for instance the
-trace-preserving one), which the library does not currently provide in this
-generality.
+The codomain is now allowed to be any unital $*$-subalgebra
+$\mathcal B\subseteq\MN{p}$. The theorem
+\leanid{Matrix.exists_cp_extension_of_operatorSystem_directSum_starSubalgebra}
+(\doclink{TNLean/Channel/OperatorSystemExtensionStarSubalgebra}) starts with a
+map $T:S\to\mathcal B$ and returns an extension
+$\widetilde T:\bigoplus_k\MN{d_k}\to\mathcal B$. Complete positivity is stated
+after the canonical inclusion $\mathcal B\hookrightarrow\MN{p}$, because the
+direct-sum complete-positivity predicate has a full matrix codomain.
+
+The construction supplies the final step left implicit in the source's proof.
+First, \leanid{Matrix.exists_cp_extension_of_operatorSystem_directSum} gives an
+ambient extension $F:\bigoplus_k\MN{d_k}\to\MN{p}$. Next,
+\leanid{StarSubalgebra.exists_krausCPTP_conditionalExpectation} gives a
+trace-preserving completely positive conditional expectation
+$E:\MN{p}\to\MN{p}$ with range in $\mathcal B$ and $E|_{\mathcal B}=\mathrm{id}$.
+The map $E\circ F$ remains completely positive, takes values in $\mathcal B$,
+and agrees with $T$ on $S$. Restricting its codomain gives $\widetilde T$.
 
 \section{Verdict}
 
-\textbf{Closed for the domain algebra; codomain restriction remains.} Wolf's
-proposition is now formalized at its stated generality for the domain algebra
-$\mathcal A$: an arbitrary finite direct sum $\bigoplus_{k<r} M_{d_k}(\mathbb
-C)$, not only the one-summand case. No hypothesis is added beyond the source
-statement (the direct-sum operator-system and complete-positivity predicates
-match the source's definitions on each summand, and complete positivity at
-level $j$ is exactly the source's $T\otimes\mathrm{id}_j$ positivity condition
-applied block by block). The codomain restriction $\mathcal B=M_p(\mathbb C)$
-remains a residual scope restriction, documented above and in the module
-docstring of \doclink{TNLean/Channel/OperatorSystemExtension}; the general
-codomain subalgebra is tracked in \ghissue{5645}.
+\textbf{Closed for matrix-realized finite-dimensional algebras.} The domain is
+a finite direct sum $\bigoplus_{k<r}M_{d_k}(\mathbb C)$ and the codomain is a
+concrete unital $*$-subalgebra of a full matrix algebra, exactly the
+representation chosen in Wolf's displayed proof. The formal theorem does not
+quantify over an abstract finite-dimensional $C^*$-algebra type lacking a
+specified matrix representation, and it should not be cited as such an
+abstract theorem. It closes the matrix-algebra scope gap tracked in
+\ghissue{5645}: neither the domain nor the codomain is required to be a single
+full matrix algebra.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- add `Matrix.IsCPMapDirectSum.comp_isKrausCP` for postcomposition by a Kraus completely positive matrix map
- compose the direct-sum operator-system extension with the matrix-star-subalgebra CPTP conditional expectation and prove ambient range and agreement
- corestrict to the literal subtype-valued extension, with complete positivity stated after the canonical inclusion into the ambient matrix algebra
- add source-faithful Chapter 1 Blueprint coverage and close the matrix-realized codomain scope note without claiming an abstract unrepresented C*-algebra theorem

## Validation

- `lake build TNLean.Channel.OperatorSystemExtensionStarSubalgebra` (3154 jobs)
- `lake build TNLean.Channel` (9071 jobs; confirms compatibility with the TransferMatrix adapter relocation)
- `lake build lint_style`; `lake exe lint_style --github`
- reader-facing prose, Lean file-policy, compilation-time checker, oversized-file, numbered-module, and import-aggregator checks
- capstone transitive import cone: 70 TNLean modules, 0 `TNLean.MPS` modules
- Blueprint sync and reverse declaration coverage: 6627/6627, no changed declaration missing Blueprint coverage
- `lake exe checkdecls blueprint/lean_decls`; `leanblueprint checkdecls`
- double `lualatex` Blueprint compile: 883 pages, no undefined cross-references
- standalone paper-gap compile: 2 pages
- forbidden-token, proof-integrity, final-newline, range-diff, and `git diff --check` validation

Closes LionSR/QICLean#294.
Closes LionSR/QICLean#283.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New formal theorems in channel/operator-system theory with nontrivial composition and codomain restriction; scope is documented as matrix-realized only, but incorrect use as an abstract C*-algebra result would be a citation risk.
> 
> **Overview**
> Extends Wolf’s direct-sum operator-system CP extension so the **codomain** can be a unital matrix `*$`-subalgebra, not only a full `M_p(ℂ)`, by postcomposing the ambient extension with a CPTP conditional expectation onto `B`.
> 
> Adds `OperatorSystemExtensionStarSubalgebra.lean` with **`IsCPMapDirectSum.comp_isKrausCP`** (Kraus postcomposition preserves direct-sum CP), **`exists_cp_extension_of_operatorSystem_directSum_starSubalgebra_range`** (`G = E ∘ F` with range in `B`), and **`exists_cp_extension_of_operatorSystem_directSum_starSubalgebra`** (codomain-restricted extension with CP stated after inclusion into `M_p`). Registers the module in `Channel.lean`, mirrors the three results in Blueprint Chapter 1, and updates the paper-gap note to **closed for matrix-realized** domain/codomain without claiming an abstract unrepresented `C^*`-algebra theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20fc82cf88fe0c15976873f58fd426ee0e6324a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->