### PR TITLE
feat(tenkz): enforce boundary signatures across equations

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -40,6 +40,7 @@ on:
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/tenkz_audit.py'
+      - 'scripts/tenkz_blueprint_sweep.py'
       - 'scripts/tenkz_rmp.py'
       - 'scripts/update_tenkz_dimension_inventory.py'
       - 'scripts/tenkzlib/**'
@@ -101,6 +102,7 @@ on:
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/tenkz_audit.py'
+      - 'scripts/tenkz_blueprint_sweep.py'
       - 'scripts/tenkz_rmp.py'
       - 'scripts/update_tenkz_dimension_inventory.py'
       - 'scripts/tenkzlib/**'
@@ -197,6 +199,7 @@ jobs:
               - 'scripts/blueprint_bibtex.py'
               - 'scripts/check_reader_facing_prose.py'
               - 'scripts/tenkz_audit.py'
+              - 'scripts/tenkz_blueprint_sweep.py'
               - 'scripts/tenkz_rmp.py'
               - 'scripts/tenkzlib/**'
               - 'scripts/tenkz_language.py'
@@ -223,6 +226,7 @@ jobs:
               - 'scripts/tenkz_manual_doctest.py'
               - 'scripts/test_tenkz_manual_doctest.py'
               - 'scripts/tenkz_audit.py'
+              - 'scripts/tenkz_blueprint_sweep.py'
               - 'scripts/tenkz_rmp.py'
               - 'scripts/tenkzlib/**'
               - 'scripts/tenkz_corpus.sh'
@@ -307,6 +311,11 @@ jobs:
 
       - name: Test tenkz render baseline replacement
         run: python3 scripts/test_tenkz_corpus_render.py
+
+      # The seeded equation defects: a mismatched group must fail the audit
+      # and a clean one must pass, wherever tenkz pictures compile.
+      - name: Test tenkz equation group enforcement
+        run: python3 scripts/test_tenkz_equation_audit.py
 
       - name: Test tenkz manual extraction and reference coverage
         run: python3 scripts/test_tenkz_manual_doctest.py
@@ -723,6 +732,14 @@ jobs:
           if [ "$cmd_status" -ne 0 ]; then
             exit "$cmd_status"
           fi
+
+      # Every blueprint picture compiled standalone during the web build and
+      # left its event stream in the render cache; the sweep audits all of
+      # them, so the boundary-signature rules reach the volume's figures and
+      # not only the regression corpus.
+      - name: Sweep tenkz blueprint event streams
+        if: env.TEX_CHANGED == 'true'
+        run: python3 scripts/tenkz_blueprint_sweep.py
 
       - name: Test tenkz equation web layout
         if: env.TEX_CHANGED == 'true'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -41,6 +41,7 @@ on:
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_blueprint_sweep.py'
+      - 'scripts/test_tenkz_blueprint_sweep.py'
       - 'scripts/tenkz_rmp.py'
       - 'scripts/update_tenkz_dimension_inventory.py'
       - 'scripts/tenkzlib/**'
@@ -103,6 +104,7 @@ on:
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_blueprint_sweep.py'
+      - 'scripts/test_tenkz_blueprint_sweep.py'
       - 'scripts/tenkz_rmp.py'
       - 'scripts/update_tenkz_dimension_inventory.py'
       - 'scripts/tenkzlib/**'
@@ -200,6 +202,7 @@ jobs:
               - 'scripts/check_reader_facing_prose.py'
               - 'scripts/tenkz_audit.py'
               - 'scripts/tenkz_blueprint_sweep.py'
+              - 'scripts/test_tenkz_blueprint_sweep.py'
               - 'scripts/tenkz_rmp.py'
               - 'scripts/tenkzlib/**'
               - 'scripts/tenkz_language.py'
@@ -227,6 +230,7 @@ jobs:
               - 'scripts/test_tenkz_manual_doctest.py'
               - 'scripts/tenkz_audit.py'
               - 'scripts/tenkz_blueprint_sweep.py'
+              - 'scripts/test_tenkz_blueprint_sweep.py'
               - 'scripts/tenkz_rmp.py'
               - 'scripts/tenkzlib/**'
               - 'scripts/tenkz_corpus.sh'
@@ -315,7 +319,9 @@ jobs:
       # The seeded equation defects: a mismatched group must fail the audit
       # and a clean one must pass, wherever tenkz pictures compile.
       - name: Test tenkz equation group enforcement
-        run: python3 scripts/test_tenkz_equation_audit.py
+        run: |
+          python3 scripts/test_tenkz_equation_audit.py
+          python3 scripts/test_tenkz_blueprint_sweep.py
 
       - name: Test tenkz manual extraction and reference coverage
         run: python3 scripts/test_tenkz_manual_doctest.py

--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -354,6 +354,23 @@ def render_unit(unit_source: str, svg_dir: Path) -> tuple[Path | None, bool]:
     return svg_path, False
 
 
+def unit_event_log(unit_source: str, svg_dir: Path) -> Path | None:
+    """Return the ``.tnlog`` one unit wrote, compiling it when absent.
+
+    The event stream is the audit's subject and the SVG is the reader's, so
+    the two are cached the same way and by the same compile; a sweep asks for
+    the log and gets whichever the last render left behind.
+    """
+
+    stem = f"tenkz-{unit_hash(unit_source)}"
+    log_path = _CACHE_DIR / f"{stem}.tnlog"
+    if log_path.is_file():
+        return log_path
+    if not _compile_unit(unit_source, stem, svg_dir / f"{stem}.svg"):
+        return None
+    return log_path if log_path.is_file() else None
+
+
 # --------------------------------------------------------------------------
 # plasTeX layer.  Deferred import so scripts/test_tenkz_pic.py can exercise
 # the compile+cache core above without a plasTeX installation.

--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -331,6 +331,10 @@ def _compile_unit(unit_source: str, stem: str, svg_path: Path) -> bool:
     if converter.returncode != 0 or not svg_path.is_file():
         log_path = _CACHE_DIR / f"{stem}.convert.log"
         log_path.write_text(converter.stdout, encoding="utf-8")
+        # The engine wrote a complete stream but the unit did not render, so
+        # the pair is incomplete; leaving the stream behind would let the
+        # next caller call the unit sound.
+        (_CACHE_DIR / f"{stem}.tnlog").unlink(missing_ok=True)
         raise RuntimeError(
             f"tenkz SVG conversion failed for {unit_source!r}; see {log_path}"
         )
@@ -368,9 +372,12 @@ def unit_event_log(unit_source: str, svg_dir: Path) -> Path | None:
 
     stem = f"tenkz-{unit_hash(unit_source)}"
     log_path = _CACHE_DIR / f"{stem}.tnlog"
-    if log_path.is_file():
+    svg_path = svg_dir / f"{stem}.svg"
+    # One compile writes both artifacts, so both together are the evidence
+    # that it finished: a stream without its drawing is a run that stopped.
+    if log_path.is_file() and svg_path.is_file():
         return log_path
-    if not _compile_unit(unit_source, stem, svg_dir / f"{stem}.svg"):
+    if not _compile_unit(unit_source, stem, svg_path):
         return None
     return log_path if log_path.is_file() else None
 

--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -310,6 +310,10 @@ def _compile_unit(unit_source: str, stem: str, svg_path: Path) -> bool:
     if engine.returncode != 0:
         log_path = _CACHE_DIR / f"{stem}.compile.log"
         log_path.write_text(engine.stdout, encoding="utf-8")
+        # A run that stopped partway still wrote whatever events it reached.
+        # Leaving that behind would let the next caller read a fragment as a
+        # finished stream.
+        (_CACHE_DIR / f"{stem}.tnlog").unlink(missing_ok=True)
         raise RuntimeError(
             f"tenkz picture compilation failed for {unit_source!r}; see {log_path}"
         )

--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -372,12 +372,13 @@ def unit_event_log(unit_source: str, svg_dir: Path) -> Path | None:
 
     stem = f"tenkz-{unit_hash(unit_source)}"
     log_path = _CACHE_DIR / f"{stem}.tnlog"
-    svg_path = svg_dir / f"{stem}.svg"
-    # One compile writes both artifacts, so both together are the evidence
-    # that it finished: a stream without its drawing is a run that stopped.
-    if log_path.is_file() and svg_path.is_file():
+    # The stream is the evidence that the compile finished, because a run
+    # that stopped at either stage takes its stream with it.  The drawing is
+    # not: it lands wherever its caller asked for it, so a stream cached
+    # beside one caller's SVG is still this caller's answer.
+    if log_path.is_file():
         return log_path
-    if not _compile_unit(unit_source, stem, svg_path):
+    if not _compile_unit(unit_source, stem, svg_dir / f"{stem}.svg"):
         return None
     return log_path if log_path.is_file() else None
 

--- a/blueprint/src/chapter/ch12_symmetry_string_order.tex
+++ b/blueprint/src/chapter/ch12_symmetry_string_order.tex
@@ -72,6 +72,9 @@ physical state symmetry requires additional hypotheses.
     % physical-up=0 | physical-down=0.
     % The site count stands as a label below the chain: a brace under the
     % conjugate row would run through that row's labels.
+    % The rung operators name themselves to the east: the first rung stands
+    % in the mouth of the west cup, and a name written west of it lands on
+    % the Lambda bead riding that cup's bend.
     \begin{center}
         \tenkzkernel
         \begin{tenkz}[rows={ket,bra}, cols=4, west={cup=$\Lambda$}, east=cup]
@@ -80,9 +83,9 @@ physical state symmetry requires additional hypotheses.
             \tn[label pos=s, conjugate]{\overline{A}} &
             \tn[label pos=s, conjugate]{\overline{A}} & \tn[skin=dots]{} &
             \tn[label pos=s, conjugate]{\overline{A}}
-            \tn[species=operator, label pos=w, at=on bond-1-1-2-1 0.5]{u}
-            \tn[species=operator, label pos=w, at=on bond-1-2-2-2 0.5]{u}
-            \tn[species=operator, label pos=w, at=on bond-1-4-2-4 0.5]{u}
+            \tn[species=operator, label pos=e, at=on bond-1-1-2-1 0.5]{u}
+            \tn[species=operator, label pos=e, at=on bond-1-2-2-2 0.5]{u}
+            \tn[species=operator, label pos=e, at=on bond-1-4-2-4 0.5]{u}
             \tnmark[form=label]{2 s of midway (2,2) and (2,3)}{$L\text{ sites}$}
         \end{tenkz}.
     \end{center}

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -101,6 +101,49 @@ tex_api = "breaking-change"
 tnlog = "breaking-versioned"
 ```
 
+## Equation grouping
+
+A boundary signature is checkable only against another boundary signature,
+so the enforceable unit is not the picture but the group of pictures one
+equation relates. tenkz has exactly one such group: the `tenkzeq`
+environment, whose relation glyphs delimit the sides and whose juxtaposed
+panels form a product term (`LANGUAGE-1.0.md` §7). The environment writes its
+number into every panel's `picture` record and one `check` record for every
+joiner it resolves, so a reader of the event stream alone knows which
+pictures an author asserted equal and which comparisons were performed. That
+is what makes the group enforceable: a mismatch inside one is a hard finding
+of the stream, needing no source file and no reading of the mathematics
+between the panels.
+
+Two other spellings were considered and are rejected.
+
+A shared **`equation=<id>` picture key** would let any pictures anywhere in a
+document declare themselves one group. It is rejected because it separates
+the assertion from the thing asserted. The claim an equation makes is made by
+the relation glyph standing between two panels; an identifier repeated on
+scattered pictures restates that claim in a second place, where it can go
+stale, contradict the typeset mathematics, or group panels no reader sees
+side by side. It also gives the author two ways to spell one concept, which
+the grammar's one-concept-one-spelling rule forbids, and it cannot express
+the product joiner at all: an identifier says which pictures belong together
+but not in which order they contract.
+
+**Automatic grouping of consecutive pictures in one display**, inferred from
+the order pictures appear in the event stream, needs no spelling at all. It is
+rejected because the event stream records no displays. A picture's position in
+the stream is the order TeX shipped it, which merges the panels of a display
+with pictures from surrounding prose, from a float, from a footnote, and from
+the same paragraph; nothing in the stream separates them. Recovering the
+display would mean parsing the source beside the log and guessing which
+separator is a relation — precisely the heuristic that made the old sibling
+check advisory. Inference cannot be made hard, because the author never
+declared anything for it to be hard about.
+
+The audit keeps that heuristic, downgraded to what it is. Two consecutive
+pictures joined by a source `=` outside every group raise the advisory
+`eq-sibling-mismatch`: not a defect in the diagram but a picture pair still
+to be moved into the scope. The hard rules apply inside the group only.
+
 ## Compatibility ownership
 
 tenkz has two public surfaces. A release decision names both; compatibility on

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -144,6 +144,13 @@ pictures joined by a source `=` outside every group raise the advisory
 `eq-sibling-mismatch`: not a defect in the diagram but a picture pair still
 to be moved into the scope. The hard rules apply inside the group only.
 
+The heuristic also states its own limit. A display that asserts a relation
+somewhere but joins other panels another way — a product, a sum, an arrow —
+is read as `eq-sibling-unread` and nothing is claimed about it, because the
+pairwise reading would compare one factor against a whole side. That is the
+same argument one tier down: the composition is exactly what the scope
+classifies and a reading of the source cannot.
+
 ## Compatibility ownership
 
 tenkz has two public surfaces. A release decision names both; compatibility on

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -65,7 +65,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch03_single.tex` | L251 `tenkz` → `P-grid` | — | — |
 | `ch04_channels_choi_foundations.tex` | L87 `tenkz` → `P-grid` | — | — |
 | `ch11_fundamental_theorem_core.tex` | L42, 46 `tenkz` → `P-grid` | — | — |
-| `ch12_symmetry_string_order.tex` | L41, 77, 359, 364, 395, 401, 446, 452, 485, 490, 528, 534, 839, 844 `tenkz` → `P-grid` | — | — |
+| `ch12_symmetry_string_order.tex` | L41, 80, 362, 367, 398, 404, 449, 455, 488, 493, 531, 537, 842, 847 `tenkz` → `P-grid` | — | — |
 | `ch12_symmetry_virtual_and_cohomology.tex` | L181, 196, 330, 459, 473 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -417,6 +417,15 @@ python3 scripts/tenkz_audit.py <job>.tnlog
 python3 scripts/tenkz_lint.py <source>.tex
 ```
 
+The blueprint's own pictures are audited as a set.  Each one compiles
+standalone during `leanblueprint web` and leaves its event stream in the
+render cache, so after a web build the sweep is a read; run alone it compiles
+what the cache lacks.
+
+```sh
+python3 scripts/tenkz_blueprint_sweep.py
+```
+
 Render every affected PDF and inspect it.  Exit status is not visual review.
 
 ```sh
@@ -438,6 +447,10 @@ Generated PDFs and PNGs are build artifacts, not committed source.
   a case carries `kernel` whether it spells the retained switch or only the
   `tenkz` environment; the retired `grid` tag is rejected.
 - A diagrammatic equation has the intended boundary signature on both sides.
+  The equation group is `tenkzeq` and nothing else (`DESIGN.md`, "Equation
+  grouping"): inside it a mismatch is a hard finding of both the compiler and
+  the audit, while two pictures joined by a bare source `=` raise only the
+  advisory that names the pair still to be moved into the scope.
 - A matrix keeps two open virtual indices, a doubled-space map keeps four,
   and a scalar keeps none.
 - The applied channel is `[sandwich, east={cup=$X$}]`; a west cup feeds the

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -417,10 +417,12 @@ python3 scripts/tenkz_audit.py <job>.tnlog
 python3 scripts/tenkz_lint.py <source>.tex
 ```
 
-The blueprint's own pictures are audited as a set.  Each one compiles
-standalone during `leanblueprint web` and leaves its event stream in the
-render cache, so after a web build the sweep is a read; run alone it compiles
-what the cache lacks.
+The blueprint's own pictures are audited as a set, and the audited unit is
+the display rather than the panel: a picture in a displayed row compiles with
+the whole row, so one stream holds every panel and the equation checks have
+something to compare.  The closing line states how far those checks reached —
+how many displays declared an equation scope, and how many were read only
+through the source `=`.
 
 ```sh
 python3 scripts/tenkz_blueprint_sweep.py

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -171,10 +171,14 @@ hole, its boundary entries — stands unchanged.
 | `name=` | identifier | — | generated | `TKZ-NAME-*` |
 
 `dir=` draws the direction mark of a directed index, virtual or physical; it
-changes no topology. On a resolved physical index the typed record, the port
-consumption and mismatch checking, and the physical-leg stroke all stand; the
-orientation of a directed physical open end enters the exposed boundary
-signature, while an internal directed contraction leaves no boundary entry.
+changes no topology, and it enters the boundary signature. On a resolved
+physical index the typed record, the port consumption and mismatch checking,
+and the physical-leg stroke all stand. The orientation of a directed open
+end, virtual or physical, is the last field of that end's exposed entry —
+`to` when the index leaves the panel, `from` when it enters — so a space is
+distinguished from its dual and the two sides of a relation must agree on
+orientation and not merely on count. An internal directed contraction leaves
+no boundary entry.
 The mark stands at the named station along the leg's daylight — the stretch
 of the leg outside the silhouette of the glyph it springs from — so the same
 placement rule inks on every bearing, and a wide silhouette can no longer

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -173,10 +173,12 @@ hole, its boundary entries — stands unchanged.
 `dir=` draws the direction mark of a directed index, virtual or physical; it
 changes no topology, and it enters the boundary signature. On a resolved
 physical index the typed record, the port consumption and mismatch checking,
-and the physical-leg stroke all stand. The orientation of a directed open
-end, virtual or physical, is the last field of that end's exposed entry —
-`to` when the index leaves the panel, `from` when it enters — so a space is
-distinguished from its dual and the two sides of a relation must agree on
+and the physical-leg stroke all stand. In that end's exposed entry the
+orientation follows the face and precedes any strand weight — `to` when the
+index leaves the panel, `from` when it enters, so `open:e:to` and
+`open:e:to:bundle=3` — which keeps the weight the entry's last field and a
+directed bundle expandable to its own multiplicity. A space is thereby
+distinguished from its dual, and the two sides of a relation must agree on
 orientation and not merely on count. An internal directed contraction leaves
 no boundary entry.
 The mark stands at the named station along the leg's daylight — the stretch

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -2878,3 +2878,33 @@ named factor; no other registry dimension moves.
 | flag:consumers:key:kernel-picture:metrics | keep-because: kernel-scope rows count no demand-corpus consumers before the S4 surface swap, as every other kernel-picture row records; the leaf already carries its first blueprint consumer in the ch21 structure-operator recursion and its Extension-gate in #5620; expiry 0.8 |
 
 Extension-gate: #5620
+
+### 2026-08-08 — the event-stream layer reviewed as one system
+
+The simplification gate ran over every `\tenkz@event` emitter at once, which
+had never happened: the emitters accreted a tier at a time and were only ever
+read one tier at a time. Five files write events. `tenkz-core` owns the writer
+and the measured-geometry records; `tenkz-geometry` writes one development
+probe; `tenkz-tree`, `tenkz-string`, and `tenkz-kernel` write their own record
+classes. Read together they are one system with one writer and one late-bound
+name, which the kernel rebinds while it suppresses a measuring pass and
+restores afterwards — the indirection is what makes the suppression possible
+and stays.
+
+The gate found one dead limb. `\tenkz@beginpicture` was the dialect era's
+picture opener: it advanced a global uniqueness counter, assigned the emitting
+identity, and wrote the `picture` record. Since the surface swap the kernel
+opens every picture and states its own identity, and the opener had no caller
+anywhere in the package. Its counter, its language variable, and it are gone,
+and the label-overlap harness — the one consumer left, a synthetic canvas that
+fabricates a picture record for measured geometry — states the four lines it
+needs itself. Every golden event stream is byte-identical across the deletion,
+which is the proof the limb was dead.
+
+Nothing else in the layer is redundant. The geometry probe has no schema row
+and the audit reports it as an unknown kind, which is the correct
+forward-compatible reading of a development record with three fixtures and no
+production caller; it earns its place until those fixtures do not.
+
+The census does not move: no registry row, parser leaf, or alias changes, and
+no flag is raised that a previous session has not already answered.

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -39,9 +39,15 @@ Hard errors (exit 1):
                        the drawing directions may rotate.
   eq-unchecked        An equation group holds panels its own check records
                       never folded into a relation: the group's arithmetic
-                      (relations plus contractions plus one equals panels)
-                      does not close, so some panel's boundary was never
-                      compared.
+                      (relations plus distinct adjacent contractions plus one
+                      equals panels) does not close, so some panel's boundary
+                      was never compared.  A check record whose scope owns no
+                      panel at all fails the same way.
+  eq-check-off        A waiver and its source disagree: the stream retires a
+                      relation the source never opted out of, or the source
+                      opts out of a relation the stream checked anyway.  The
+                      stream is then stale against the source it is read with,
+                      and no waiver is honoured.
 
 Advisories (never affect the exit code):
   eq-sibling-mismatch  Consecutive kernel pictures joined by `=` in the
@@ -51,9 +57,15 @@ Advisories (never affect the exit code):
                        checkable is `tenkzeq` (DESIGN.md, "Equation
                        grouping"), so a mismatch here reports a picture pair
                        still to be moved into the scope.
+  eq-sibling-unread    Pictures share one display but are not all joined by a
+                       relation, so the display states a product, a sum, or a
+                       map that only the scope classifies.  Reading it
+                       pairwise would compare one factor against a whole side,
+                       so nothing is claimed about it at all.
   eq-check-off         An equation group waived one relation with
-                       `check={off={k: reason}}`.  The waiver is legal and
-                       never silent: it is reported with its reason.
+                       `check={off={k: reason}}`, and its source declares the
+                       same waiver.  Legal, and never silent: it is reported
+                       with its reason.
   repeated-topology    Identical canonical atom+bond content in several
                        pictures: review ordinary TeX composition.  Repetition
                        alone never extends the public grammar.
@@ -1301,16 +1313,36 @@ class Audit:
         an identity between maps of different types.
 
         Two rules apply.  The group's arithmetic must close -- relations plus
-        contractions plus one equals panels -- so that no panel escapes
-        comparison; a group whose arithmetic fails is read as unchecked, and
-        its panels are then compared pair by pair with no waiver honoured.
-        And where every side is one panel, the panels' own boundary records
-        are compared here whatever the kernel's verdict said, so a stream
-        whose comparison never ran is caught rather than trusted.
+        distinct adjacent contractions plus one equals panels -- so that no
+        panel escapes comparison; a group whose arithmetic fails is read as
+        unchecked, and its panels are then compared pair by pair with no
+        waiver honoured.  And where every side is one panel, the panels' own
+        boundary records are compared here whatever the kernel's verdict said,
+        so a stream whose comparison never ran is caught rather than trusted.
+
+        Both halves of the ownership are checked.  A panel names its scope and
+        a check names the scope it belongs to; a check whose scope owns no
+        panel is an equation the stream does not contain, and a waiver the
+        source and the stream disagree about means the two are not the same
+        document.
         """
         _, scope_pictures = self._scope_index()
         scope_events, malformed_scopes = self._scope_checks()
         authorized = self._source_authorized_offs()
+        for scope in sorted(set(scope_events) | set(malformed_scopes)):
+            if scope in scope_pictures:
+                continue
+            # A check record's scope is its ownership key.  A scope that owns
+            # no panel names an equation the stream does not contain, which is
+            # what an emitter losing `scope=` from its picture headers looks
+            # like: the comparisons are recorded and the panels they name have
+            # left the group.
+            self.hard(
+                "eq-unchecked", self.log_path.name,
+                f"equation scope {scope} records "
+                f"{len(scope_events.get(scope, []))} check(s) but owns no "
+                f"panel; the scope's pictures never claimed it",
+            )
         for scope in sorted(scope_pictures):
             members = scope_pictures[scope]
             records = scope_events.get(scope, [])
@@ -1321,7 +1353,17 @@ class Audit:
             relations = {
                 int(event.attrs["relation"]): event for event in relation_records
             }
-            products = [event for event in records if "product" in event.attrs]
+            product_records = [event for event in records if "product" in event.attrs]
+            # A contraction names the adjacent panel pair it folded.  Only a
+            # well-formed sequence of distinct adjacent pairs counts toward
+            # closure: otherwise one pair recorded twice stands in for another
+            # that was lost, and the panel that pair held escapes comparison.
+            products = {
+                pair for pair in (
+                    _product_pair(event, len(members)) for event in product_records
+                )
+                if pair is not None
+            }
             modulo = any(
                 event.attrs.get("modulo") == "bundles" for event in records
             )
@@ -1330,18 +1372,27 @@ class Audit:
                 scope not in malformed_scopes
                 and len(relation_records) == len(relations)
                 and set(relations) == set(range(1, len(relations) + 1))
+                and len(product_records) == len(products)
                 and len(relations) + len(products) + 1 == len(members)
             )
             waived: set[int] = {
                 relation for relation, event in relations.items()
                 if event.attrs.get("result") == "off"
             }
-            if authorized is not None and waived != authorized.get(scope, set()):
-                for relation in sorted(waived - authorized.get(scope, set())):
+            declared = set() if authorized is None else authorized.get(scope, set())
+            if authorized is not None and waived != declared:
+                for relation in sorted(waived - declared):
                     self.hard(
                         "eq-check-off", where,
                         f"equation scope {scope} waives relation {relation} "
                         f"but its source declares no such opt-out",
+                    )
+                for relation in sorted(declared - waived):
+                    self.hard(
+                        "eq-check-off", where,
+                        f"the source waives relation {relation} of equation "
+                        f"scope {scope} but the stream records no waiver; the "
+                        f"stream predates this source",
                     )
                 waived = set()
             else:
@@ -1360,8 +1411,9 @@ class Audit:
                         "eq-unchecked", where,
                         f"equation scope {scope} holds {len(members)} panel(s) "
                         f"but records {len(relation_records)} relation(s) and "
-                        f"{len(products)} contraction(s); every panel must "
-                        f"fold into a compared side",
+                        f"{len(product_records)} contraction(s) over "
+                        f"{len(products)} distinct adjacent pair(s); every "
+                        f"panel must fold into a compared side",
                     )
                 self._compare_adjacent(members, scope, modulo, waived=set())
                 continue
@@ -1408,32 +1460,74 @@ class Audit:
                f"but open-leg classes differ: {sig_left} vs {sig_right}"
                f"{source}")
 
-    def check_equation_boundaries(self) -> None:
-        """Advise on pictures joined by a source `=` outside every group.
+    def _display_runs(self) -> list[list[int]]:
+        """Maximal runs of pictures the source sets in one display.
 
-        The mechanism is `tenkzeq`; a bare `=` between two pictures is a
-        reading of the source, not a declaration, so a mismatch here reports
-        migration work rather than failing the stream.
+        Two consecutive pictures share a display when the source between them
+        crosses no environment and no display-math boundary and is short.
+        Panels of a `tenkzeq` scope are excluded: their group owns them.
+        """
+        picture_scopes, _ = self._scope_index()
+        runs: list[list[int]] = []
+        current: list[int] = []
+        for index in range(len(self.pictures)):
+            picture = self.pictures[index]
+            if picture.lang != "kernel" or index in picture_scopes:
+                current = []
+                continue
+            if current:
+                previous, this = self.constructs[current[-1]], self.constructs[index]
+                separator = (
+                    self._tex_src[previous.end:this.start]
+                    if previous.end <= this.start else None
+                )
+                if separator is None or not one_display(separator):
+                    runs.append(current)
+                    current = []
+            current.append(index)
+            if len(current) == 1:
+                runs.append(current)
+        return [run for run in runs if len(run) > 1]
+
+    def check_equation_boundaries(self) -> None:
+        """Advise on pictures the source sets in one display, out of scope.
+
+        The mechanism is `tenkzeq`; the mathematics between two pictures is a
+        reading of the source, not a declaration, so nothing here fails the
+        stream.  A display whose panels are all joined by a relation is read
+        pairwise.  A display that asserts a relation somewhere but joins other
+        panels another way -- a product, a sum, an arrow -- states a
+        composition only the scope can classify, and the pairwise reading
+        would compare one factor against a whole side; it is reported as
+        unread rather than guessed at.  Pictures that assert no relation at
+        all are simply adjacent, and nothing is said about them.
         """
         if not self.tex_linked:
             return
-        picture_scopes, _ = self._scope_index()
-        for i in range(len(self.pictures) - 1):
-            a, b = self.pictures[i], self.pictures[i + 1]
-            if a.lang != b.lang or a.lang != "kernel":
+        for run in self._display_runs():
+            separators = [
+                self._tex_src[self.constructs[left].end:self.constructs[right].start]
+                for left, right in zip(run, run[1:])
+            ]
+            if not any(same_equation(separator) for separator in separators):
+                continue  # adjacent pictures, not a display asserting anything
+            first = self.constructs[run[0]]
+            if not all(same_equation(separator) for separator in separators):
+                self.adv(
+                    "eq-sibling-unread",
+                    f"{self.log_path.name}:{self.pictures[run[0]].line}",
+                    f"{len(run)} pictures share one display but are not all "
+                    f"joined by a relation; the composition they state is the "
+                    f"scope's to classify [{self.tex_path.name}:{first.line}]",
+                )
                 continue
-            if i in picture_scopes and picture_scopes.get(i + 1) == picture_scopes[i]:
-                continue  # one group: check_equation_groups owns the pair
-            ca, cb = self.constructs[i], self.constructs[i + 1]
-            if ca.end > cb.start:
-                continue  # nested constructs: no linear separator
-            if not same_equation(self._tex_src[ca.end:cb.start]):
-                continue
-            self._compare_panels(
-                a, b, self.adv, "eq-sibling-mismatch",
-                "sit on one source `=` outside every equation group",
-                f" [{self.tex_path.name}:{ca.line}]",
-            )
+            for left, right in zip(run, run[1:]):
+                self._compare_panels(
+                    self.pictures[left], self.pictures[right], self.adv,
+                    "eq-sibling-mismatch",
+                    "sit on one source `=` outside every equation group",
+                    f" [{self.tex_path.name}:{self.constructs[left].line}]",
+                )
 
     # ---------------- driver ----------------
 
@@ -1567,6 +1661,23 @@ def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
 
 _ORIENTATIONS = frozenset({"to", "from"})
 _BUNDLE = re.compile(r"bundle=([1-9]\d*)")
+_PRODUCT_PAIR = re.compile(r"(\d+)-(\d+)")
+
+
+def _product_pair(event: Event, panels: int) -> int | None:
+    """The left panel of a contraction, or `None` when it names no pair.
+
+    A contraction folds one adjacent pair of a scope's panels, so a record
+    naming a non-adjacent or out-of-range pair describes a fold the group
+    cannot contain.
+    """
+    match = _PRODUCT_PAIR.fullmatch(event.attrs.get("product", ""))
+    if match is None:
+        return None
+    left, right = int(match.group(1)), int(match.group(2))
+    if right != left + 1 or left < 1 or right > panels:
+        return None
+    return left
 
 
 def boundary_classes(signature: tuple[str, ...],
@@ -1605,6 +1716,16 @@ def signature_entry_class(item: str) -> tuple[str, str, str]:
     orientation = next((part for part in rest if part in _ORIENTATIONS), "none")
     weight = next((part for part in rest if part not in _ORIENTATIONS), "single")
     return kind, re.sub(r"\s*=\s*", "=", weight), orientation
+
+
+def one_display(sep: str) -> bool:
+    """True when the comment-stripped source between two pictures keeps them
+    in one display: it crosses no environment, no display-math boundary and
+    no cell separator, and is short.  Inline mathematics is the joiner the
+    display is made of and does not end it."""
+    if any(tok in sep for tok in ("\\[", "\\]", "&", "\\begin", "\\end")):
+        return False
+    return len(sep.strip()) <= 200
 
 
 def same_equation(sep: str) -> bool:

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -1281,11 +1281,14 @@ class Audit:
                 spans.append((stack.pop(), token.start()))
         return spans
 
-    def _source_check_policy(self) -> Optional[dict[int, tuple[set[int], bool]]]:
+    def _source_check_policy(
+        self,
+    ) -> Optional[dict[int, tuple[set[int], bool, set[int]]]]:
         """Per scope, the check policy the source itself declares.
 
-        The policy is the relations it waives and whether it compares modulo
-        bundles.  `None` when no source is linked: the stream is then the only
+        The policy is the relations it waives, whether it compares modulo
+        bundles, and which adjacent panel pairs its own joiners contract --
+        the gaps its panels sit across without a relation between them.  `None` when no source is linked: the stream is then the only
         witness of its own policy, which is honoured and reported.  With a
         source, a waiver counts and a bundle expansion applies only where the
         environment's own `check=` says so, so a stale or edited stream can
@@ -1295,7 +1298,7 @@ class Audit:
         if not self.tex_linked:
             return None
         picture_scopes, scope_pictures = self._scope_index()
-        authorized: dict[int, tuple[set[int], bool]] = {}
+        authorized: dict[int, tuple[set[int], bool, set[int]]] = {}
         for begin, end in self._tenkzeq_spans():
             members = [
                 index for index, construct in enumerate(self.constructs)
@@ -1317,9 +1320,23 @@ class Audit:
                     f"{sorted(str(picture_scopes.get(member, 'no scope')) for member in members)}",
                 )
                 continue
+            # The separator reading recognizes a relation but never rules one
+            # out -- a relation set inside braces reads as unknown -- so what
+            # the source settles is where a contraction cannot be: across a
+            # gap it demonstrably writes a relation over.
+            relation_gaps = {
+                position + 1
+                for position, (left, right) in enumerate(zip(members, members[1:]))
+                if same_equation(
+                    self._tex_src[
+                        self.constructs[left].end:self.constructs[right].start
+                    ]
+                )
+            }
             authorized[scope] = (
                 _tenkzeq_declared_offs(self._tex_src, begin) or set(),
                 _tenkzeq_declares_bundles(self._tex_src, begin),
+                relation_gaps,
             )
         return authorized
 
@@ -1389,9 +1406,9 @@ class Audit:
                 event.attrs.get("modulo") == "bundles" for event in records
             )
             where = f"{self.log_path.name}:{self.pictures[members[0]].line}"
-            declared, declared_modulo = (
-                (set(), logged_modulo) if policy is None
-                else policy.get(scope, (set(), False))
+            declared, declared_modulo, relation_gaps = (
+                (set(), logged_modulo, set()) if policy is None
+                else policy.get(scope, (set(), False, set()))
             )
             # A bundle expansion loosens the comparison, so the source has to
             # ask for it: a stale stream carrying `modulo=bundles` past a
@@ -1416,6 +1433,11 @@ class Audit:
                 and len(relation_records) == len(relations)
                 and set(relations) == set(range(1, len(relations) + 1))
                 and len(product_records) == len(products)
+                # A contraction recorded across a gap the source writes a
+                # relation over folds panels the author never juxtaposed, and
+                # leaves the pair the author did juxtapose unchecked, while
+                # the count still balances.
+                and not (products & relation_gaps)
                 and len(relations) + len(products) + 1 == len(members)
             )
             waived: set[int] = {
@@ -1527,11 +1549,13 @@ class Audit:
                     if previous.end <= this.start else None
                 )
                 if separator is None or not one_display(separator):
-                    runs.append(current)
                     current = []
-            current.append(index)
-            if len(current) == 1:
+            if not current:
+                # A run enters the list once, when it opens; it is the same
+                # list that grows, so closing it must not enter it again.
+                current = []
                 runs.append(current)
+            current.append(index)
         return [run for run in runs if len(run) > 1]
 
     def check_equation_boundaries(self) -> None:

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -415,10 +415,11 @@ def _stroked_polygon_intersects_roundrect(
 class ScopePolicy(NamedTuple):
     """What one equation's own source says about how it is checked."""
 
-    waived: set[int]        # relations its `check={off={k: ...}}` retires
-    modulo_bundles: bool    # whether it compares a bundle as its multiplicity
-    relation_gaps: set[int]  # gaps it writes a recognized relation across
-    product_gaps: set[int]   # gaps it leaves empty, joining by juxtaposition
+    waived: set[int]         # relations its `check={off={k: ...}}` retires
+    modulo_bundles: bool     # whether it compares a bundle as its multiplicity
+    relation_gaps: set[int]  # gaps holding a relation glyph
+    product_gaps: set[int]   # gaps holding none, joining by juxtaposition
+    relation_count: Optional[int]  # relation glyphs over all its gaps
 
 
 @dataclass
@@ -1297,16 +1298,17 @@ class Audit:
         return spans
 
     def _source_check_policy(self) -> Optional[dict[int, ScopePolicy]]:
-        """Per scope, the check policy the source itself declares.
+        r"""Per scope, the check policy the source itself declares.
 
         The policy is the relations it waives, whether it compares modulo
-        bundles, and what its own joiners settle about each gap between its
-        panels.  Two things a source settles positively: a gap it writes a
-        recognized relation across is a relation, and a gap it leaves empty
-        carries no mathematics at all and so can only be juxtaposition.  The
-        reading claims nothing about the gaps in between -- a relation set
-        inside braces is one it does not recognize -- so neither rule is ever
-        phrased as the absence of evidence.  `None` when no source is linked: the stream is then the only
+        bundles, and which gap between its panels each joiner occupies.  That
+        last part is exact rather than heuristic.  `tenkzeq` makes `=` the
+        active relation glyph over its whole body while a picture resets it,
+        so between two panels every unescaped `=` records one relation and a
+        gap holding none joins its panels by juxtaposition -- a product.
+        Reading the gaps for that one character therefore names the same
+        joiners the kernel recorded, `\mbox{a=b}` included, which no reading
+        of the mathematics could do.  `None` when no source is linked: the stream is then the only
         witness of its own policy, which is honoured and reported.  With a
         source, a waiver counts and a bundle expansion applies only where the
         environment's own `check=` says so, so a stale or edited stream can
@@ -1344,19 +1346,20 @@ class Audit:
                 ]
                 for left, right in zip(members, members[1:])
             ]
+            marks = [relation_marks(separator) for separator in separators]
             relation_gaps = {
-                position + 1 for position, separator in enumerate(separators)
-                if same_equation(separator)
+                position + 1 for position, count in enumerate(marks) if count
             }
             product_gaps = {
-                position + 1 for position, separator in enumerate(separators)
-                if not separator.strip()
+                position + 1 for position, count in enumerate(marks) if not count
             }
+            relation_count = sum(marks)
             authorized[scope] = ScopePolicy(
                 _tenkzeq_declared_offs(self._tex_src, begin) or set(),
                 _tenkzeq_declares_bundles(self._tex_src, begin),
                 relation_gaps,
                 product_gaps,
+                relation_count,
             )
         return authorized
 
@@ -1373,8 +1376,8 @@ class Audit:
         Two rules apply.  The group's arithmetic must close -- relations plus
         distinct adjacent contractions plus one equals panels -- so that no
         panel escapes comparison; a group whose arithmetic fails is read as
-        unchecked, and its panels are then compared pair by pair with no
-        waiver honoured.  And a side that is one panel is compared here
+        unchecked, and its panels are then compared pair by pair, keeping the
+        waivers the source authorizes.  And a side that is one panel is compared here
         whatever the kernel's verdict said, so a stream whose comparison never
         ran is caught rather than trusted -- for every relation of a group
         with no contraction in it, and, where the source settles which gaps
@@ -1430,10 +1433,16 @@ class Audit:
                 event.attrs.get("modulo") == "bundles" for event in records
             )
             where = f"{self.log_path.name}:{self.pictures[members[0]].line}"
-            declared, declared_modulo, relation_gaps, product_gaps = (
-                ScopePolicy(set(), logged_modulo, set(), set()) if policy is None
-                else policy.get(scope, ScopePolicy(set(), False, set(), set()))
+            source = (
+                None if policy is None
+                else policy.get(
+                    scope, ScopePolicy(set(), False, set(), set(), None)
+                )
             )
+            declared = set() if source is None else source.waived
+            declared_modulo = logged_modulo if source is None else source.modulo_bundles
+            relation_gaps = set() if source is None else source.relation_gaps
+            product_gaps = set() if source is None else source.product_gaps
             # A bundle expansion loosens the comparison, so the source has to
             # ask for it: a stale stream carrying `modulo=bundles` past a
             # source that no longer says so would accept a bundle against a
@@ -1457,14 +1466,16 @@ class Audit:
                 and len(relation_records) == len(relations)
                 and set(relations) == set(range(1, len(relations) + 1))
                 and len(product_records) == len(products)
-                # The joiners must partition the gaps the source settles: a
-                # contraction cannot sit where the source writes a relation,
-                # and a gap the source leaves empty joins its panels by
-                # juxtaposition and nothing else, so a contraction has to name
-                # it.  Either failure leaves a panel outside every side while
-                # the count still balances.
-                and not (products & relation_gaps)
-                and product_gaps <= products
+                # With a source the joiners are placed, not merely counted:
+                # the contractions are exactly the gaps holding no relation
+                # glyph, and there are as many relations as glyphs.  A stream
+                # that moves a joiner to another gap leaves a panel outside
+                # every side while its counts still balance.
+                and (source is None or products == product_gaps)
+                and (
+                    source is None or source.relation_count is None
+                    or len(relations) == source.relation_count
+                )
                 and len(relations) + len(products) + 1 == len(members)
             )
             waived: set[int] = {
@@ -1509,7 +1520,12 @@ class Audit:
                         f"{len(products)} distinct adjacent pair(s); every "
                         f"panel must fold into a compared side",
                     )
-                self._compare_adjacent(members, scope, modulo, waived=set())
+                # The fallback reads the panels as adjacent pairs, which is
+                # what the kernel's own malformed-scope path does -- and it
+                # honours the source's waivers there for the same reason the
+                # kernel honours its own: an author who opted a relation out
+                # did not opt back in by losing a record elsewhere.
+                self._compare_adjacent(members, scope, modulo, waived)
                 continue
             if not products:
                 self._compare_adjacent(members, scope, modulo, waived)
@@ -1853,6 +1869,19 @@ def signature_entry_class(item: str) -> tuple[str, str, str]:
     orientation = next((part for part in rest if part in _ORIENTATIONS), "none")
     weight = next((part for part in rest if part not in _ORIENTATIONS), "single")
     return kind, re.sub(r"\s*=\s*", "=", weight), orientation
+
+
+_RELATION_MARK = re.compile(r"(?<!\\)(?:\\\\)*=")
+
+
+def relation_marks(sep: str) -> int:
+    r"""The relation glyphs one gap of an equation body holds.
+
+    Inside `tenkzeq` the equals sign is the active relation glyph and a
+    picture resets it, so between two panels each unescaped `=` records one
+    relation.  A `\=` is a control symbol and never becomes that token.
+    """
+    return len(_RELATION_MARK.findall(sep))
 
 
 def one_display(sep: str) -> bool:

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -1274,7 +1274,13 @@ class Audit:
         """Source spans of the equation environments, innermost first."""
         spans: list[tuple[int, int]] = []
         stack: list[int] = []
-        for token in re.finditer(r"\\(begin|end)\{tenkzeq\}", self._tex_src):
+        # TeX reads the space after a control word as part of it, so
+        # `\begin {tenkzeq}` opens the same environment; the shared construct
+        # scanner allows it and the span scan must agree, or a spaced source
+        # would look to the audit like an equation with no source at all.
+        for token in re.finditer(
+            r"\\(begin|end)\s*\{tenkzeq\}", self._tex_src
+        ):
             if token.group(1) == "begin":
                 stack.append(token.end())
             elif stack:
@@ -1354,9 +1360,13 @@ class Audit:
         distinct adjacent contractions plus one equals panels -- so that no
         panel escapes comparison; a group whose arithmetic fails is read as
         unchecked, and its panels are then compared pair by pair with no
-        waiver honoured.  And where every side is one panel, the panels' own
-        boundary records are compared here whatever the kernel's verdict said,
-        so a stream whose comparison never ran is caught rather than trusted.
+        waiver honoured.  And a side that is one panel is compared here
+        whatever the kernel's verdict said, so a stream whose comparison never
+        ran is caught rather than trusted -- for every relation of a group
+        with no contraction in it, and, where the source settles which gaps
+        its relations cross, for the single-panel sides of a group that holds
+        one too.  Only a composite side's fold is left to the kernel, which is
+        the one answer the audit does not recompute.
 
         Both halves of the ownership are checked.  A panel names its scope and
         a check names the scope it belongs to; a check whose scope owns no
@@ -1484,12 +1494,40 @@ class Audit:
                     )
                 self._compare_adjacent(members, scope, modulo, waived=set())
                 continue
-            if products:
-                # A product group's signature is a fold over an interface the
-                # kernel resolves; its verdict is the `check` record, which
-                # `check_kernel_checks` rejects when it says mismatch.
+            if not products:
+                self._compare_adjacent(members, scope, modulo, waived)
                 continue
-            self._compare_adjacent(members, scope, modulo, waived)
+            # A composite side's signature is a fold over an interface the
+            # kernel resolves, and its verdict is the `check` record that
+            # `check_kernel_checks` rejects when it says mismatch.  The sides
+            # that are one panel need no fold, so where the source settles
+            # every gap -- each one either a relation it writes or a
+            # contraction the stream records -- their relations are compared
+            # here as well.
+            gaps = relation_gaps | products
+            if not relation_gaps or len(gaps) != len(members) - 1:
+                continue
+            sides = self._scope_sides(members, sorted(relation_gaps))
+            for relation, (left, right) in enumerate(zip(sides, sides[1:]), 1):
+                if relation in waived or len(left) != 1 or len(right) != 1:
+                    continue
+                self._compare_panels(
+                    self.pictures[left[0]], self.pictures[right[0]],
+                    self.hard, "eq-boundary-mismatch",
+                    f"sit on relation {relation} of equation scope {scope}",
+                    modulo=modulo,
+                )
+
+    @staticmethod
+    def _scope_sides(members: list[int], relation_gaps: list[int]) -> list[list[int]]:
+        """The panel groups a scope's relations delimit, in source order."""
+        sides: list[list[int]] = []
+        start = 0
+        for gap in relation_gaps:
+            sides.append(members[start:gap])
+            start = gap
+        sides.append(members[start:])
+        return sides
 
     def _compare_adjacent(self, members: list[int], scope: int, modulo: bool,
                           waived: set[int]) -> None:

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -43,11 +43,13 @@ Hard errors (exit 1):
                       equals panels) does not close, so some panel's boundary
                       was never compared.  A check record whose scope owns no
                       panel at all fails the same way.
-  eq-check-off        A waiver and its source disagree: the stream retires a
-                      relation the source never opted out of, or the source
-                      opts out of a relation the stream checked anyway.  The
-                      stream is then stale against the source it is read with,
-                      and no waiver is honoured.
+  eq-check-drift      The stream's check policy is not its source's: it
+                      retires a relation the source never opted out of, the
+                      source opts out of a relation the stream checked anyway,
+                      or the two disagree about comparing modulo bundles.  The
+                      stream is then stale against the source it is read with;
+                      only the waivers both state stand, and the comparison
+                      runs in the stricter of the two readings.
 
 Advisories (never affect the exit code):
   eq-sibling-mismatch  Consecutive kernel pictures joined by `=` in the
@@ -1275,19 +1277,21 @@ class Audit:
                 spans.append((stack.pop(), token.start()))
         return spans
 
-    def _source_authorized_offs(self) -> Optional[dict[int, set[int]]]:
-        """Per scope, the relations the source itself waives.
+    def _source_check_policy(self) -> Optional[dict[int, tuple[set[int], bool]]]:
+        """Per scope, the check policy the source itself declares.
 
-        `None` when no source is linked: the stream is then the only witness
-        of its own waivers, which are honoured and reported.  With a source,
-        a waiver counts only where the environment's own `check={off={k:
-        reason}}` names it, so a stale or edited stream cannot retire a
-        comparison the author never opted out of.
+        The policy is the relations it waives and whether it compares modulo
+        bundles.  `None` when no source is linked: the stream is then the only
+        witness of its own policy, which is honoured and reported.  With a
+        source, a waiver counts and a bundle expansion applies only where the
+        environment's own `check=` says so, so a stale or edited stream can
+        neither retire a comparison the author never opted out of nor loosen
+        one the author never loosened.
         """
         if not self.tex_linked:
             return None
         picture_scopes, scope_pictures = self._scope_index()
-        authorized: dict[int, set[int]] = {}
+        authorized: dict[int, tuple[set[int], bool]] = {}
         for begin, end in self._tenkzeq_spans():
             members = [
                 index for index, construct in enumerate(self.constructs)
@@ -1299,7 +1303,10 @@ class Audit:
             scope = scopes.pop()
             if scope is None or scope_pictures.get(scope) != members:
                 continue
-            authorized[scope] = _tenkzeq_declared_offs(self._tex_src, begin) or set()
+            authorized[scope] = (
+                _tenkzeq_declared_offs(self._tex_src, begin) or set(),
+                _tenkzeq_declares_bundles(self._tex_src, begin),
+            )
         return authorized
 
     def check_equation_groups(self) -> None:
@@ -1328,7 +1335,7 @@ class Audit:
         """
         _, scope_pictures = self._scope_index()
         scope_events, malformed_scopes = self._scope_checks()
-        authorized = self._source_authorized_offs()
+        policy = self._source_check_policy()
         for scope in sorted(set(scope_events) | set(malformed_scopes)):
             if scope in scope_pictures:
                 continue
@@ -1364,10 +1371,29 @@ class Audit:
                 )
                 if pair is not None
             }
-            modulo = any(
+            logged_modulo = any(
                 event.attrs.get("modulo") == "bundles" for event in records
             )
             where = f"{self.log_path.name}:{self.pictures[members[0]].line}"
+            declared, declared_modulo = (
+                (set(), logged_modulo) if policy is None
+                else policy.get(scope, (set(), False))
+            )
+            # A bundle expansion loosens the comparison, so the source has to
+            # ask for it: a stale stream carrying `modulo=bundles` past a
+            # source that no longer says so would accept a bundle against a
+            # count the current source rejects.  The comparison then runs in
+            # the stricter of the two readings.
+            modulo = logged_modulo and declared_modulo
+            if policy is not None and logged_modulo != declared_modulo:
+                self.hard(
+                    "eq-check-drift", where,
+                    f"equation scope {scope} compares "
+                    f"{'modulo bundles' if logged_modulo else 'strand for strand'}"
+                    f" but its source asks for "
+                    f"{'modulo bundles' if declared_modulo else 'strand for strand'}"
+                    f"; the stream is not this source's",
+                )
             closed = (
                 scope not in malformed_scopes
                 and len(relation_records) == len(relations)
@@ -1379,31 +1405,33 @@ class Audit:
                 relation for relation, event in relations.items()
                 if event.attrs.get("result") == "off"
             }
-            declared = set() if authorized is None else authorized.get(scope, set())
-            if authorized is not None and waived != declared:
+            if policy is not None:
                 for relation in sorted(waived - declared):
                     self.hard(
-                        "eq-check-off", where,
+                        "eq-check-drift", where,
                         f"equation scope {scope} waives relation {relation} "
                         f"but its source declares no such opt-out",
                     )
                 for relation in sorted(declared - waived):
                     self.hard(
-                        "eq-check-off", where,
+                        "eq-check-drift", where,
                         f"the source waives relation {relation} of equation "
                         f"scope {scope} but the stream records no waiver; the "
                         f"stream predates this source",
                     )
-                waived = set()
-            else:
-                for relation in sorted(waived):
-                    event = relations[relation]
-                    self.adv(
-                        "eq-check-off",
-                        f"{self.log_path.name}:{event.line}",
-                        f"equation scope {scope} waived relation {relation}: "
-                        f"{event.attrs.get('reason', '(no reason recorded)')}",
-                    )
+                # Only the waivers both state stand.  A forged one on its own
+                # relation retires nothing; it does not retire the author's
+                # honest opt-out on another relation of the same equation,
+                # which would report a mismatch the author waived.
+                waived &= declared
+            for relation in sorted(waived):
+                event = relations[relation]
+                self.adv(
+                    "eq-check-off",
+                    f"{self.log_path.name}:{event.line}",
+                    f"equation scope {scope} waived relation {relation}: "
+                    f"{event.attrs.get('reason', '(no reason recorded)')}",
+                )
             if not closed:
                 if scope not in malformed_scopes:
                     # A malformed scope already failed as a hard kernel-check.
@@ -1657,6 +1685,19 @@ def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
         if match is not None:
             declared.add(int(match.group(1)))
     return declared
+
+
+def _tenkzeq_declares_bundles(source: str, position: int) -> bool:
+    """True when one equation's own options ask to compare modulo bundles."""
+    options = following_group(source, position, "[", "]")
+    if options is None:
+        return False
+    for key, value in top_level_options(options):
+        if key != "check" or value is None:
+            continue
+        if re.search(r"modulo\s*=\s*bundles", value) is not None:
+            return True
+    return False
 
 
 _ORIENTATIONS = frozenset({"to", "from"})

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -31,13 +31,29 @@ Hard errors (exit 1):
                       recorded under/over occlusion, or hit no intersection.
   kernel-check        A kernel equation check reported a malformed relation
                       or unequal boundary signatures.
-  eq-boundary-mismatch Consecutive kernel pictures joined by `=` in the
-                       source have different boundary kinds or
-                       multiplicities.  A tensor equation equates two maps
-                       of one type, so the multisets of open legs must agree
-                       side-to-side; their drawing directions may rotate.
+  eq-boundary-mismatch Two panels of one equation group expose different
+                       boundary kinds, multiplicities, or orientations.  A
+                       tensor equation equates two maps of one type, so the
+                       multisets of open legs must agree side-to-side, an
+                       index leaving one side must leave the other, and only
+                       the drawing directions may rotate.
+  eq-unchecked        An equation group holds panels its own check records
+                      never folded into a relation: the group's arithmetic
+                      (relations plus contractions plus one equals panels)
+                      does not close, so some panel's boundary was never
+                      compared.
 
 Advisories (never affect the exit code):
+  eq-sibling-mismatch  Consecutive kernel pictures joined by `=` in the
+                       source, outside any equation group, expose different
+                       boundaries.  The source `=` is a heuristic, not a
+                       declaration: the mechanism that makes an equation
+                       checkable is `tenkzeq` (DESIGN.md, "Equation
+                       grouping"), so a mismatch here reports a picture pair
+                       still to be moved into the scope.
+  eq-check-off         An equation group waived one relation with
+                       `check={off={k: reason}}`.  The waiver is legal and
+                       never silent: it is reported with its reason.
   repeated-topology    Identical canonical atom+bond content in several
                        pictures: review ordinary TeX composition.  Repetition
                        alone never extends the public grammar.
@@ -47,11 +63,17 @@ Advisories (never affect the exit code):
   stale-log            The source declares picture constructs but the log
                        has none (failed or interrupted compile).
 
-Source heuristic (documented, deliberately simple): picture-producing
-constructs (`\\begin{tenkz...}`) are matched to log pictures in order of
-appearance; standalone `\\tntree` drawings emit no picture event and are
-excluded.  The match is used only when the counts agree.
-Two consecutive pictures are "one displayed equation" when the source
+The equation group is the `tenkzeq` scope and nothing else.  Every panel of
+one scope carries that scope's number in its `picture` record and the scope
+writes one `check` record per joiner, so the in-group enforcement above reads
+the stream alone and runs wherever a picture compiles -- no source, no
+heuristic.
+
+Source heuristic (documented, deliberately simple, advisory only): out of
+scope, picture-producing constructs (`\\begin{tenkz...}`) are matched to log
+pictures in order of appearance; standalone `\\tntree` drawings emit no
+picture event and are excluded.  The match is used only when the counts
+agree.  Two consecutive pictures are "one displayed equation" when the source
 between them contains `=` and no math-mode boundary (`$`, `\\[`, `\\]`),
 no cell separator `&`, no other environment, and is short.
 
@@ -69,7 +91,7 @@ from collections import Counter
 from dataclasses import dataclass
 from fractions import Fraction
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from tenkzlib.texcase import (
     Construct,
@@ -1187,13 +1209,15 @@ class Audit:
         if self.tex_linked:
             self._tex_src = src
 
-    def check_equation_boundaries(self) -> None:
-        if not self.tex_linked:
-            return
-        relation_checks: dict[int, Event] = {}
-        # The kernel stamps each equation picture and relation with one scope.
-        # Missing, duplicate, or malformed records therefore fail locally and
-        # can never shift an accepted result onto another equation.
+    # ---------------- the equation group ----------------
+
+    def _scope_index(self) -> tuple[dict[int, int], dict[int, list[int]]]:
+        """Map picture position to its `tenkzeq` scope and back.
+
+        A picture record carries `scope=` exactly when it is a panel of an
+        equation group, so the grouping is a fact of the stream and needs
+        neither source nor heuristic.
+        """
         picture_indices = {
             picture.ident: index for index, picture in enumerate(self.pictures)
         }
@@ -1209,7 +1233,10 @@ class Audit:
             scope_index = int(scope)
             picture_scopes[picture] = scope_index
             scope_pictures.setdefault(scope_index, []).append(picture)
+        return picture_scopes, scope_pictures
 
+    def _scope_checks(self) -> tuple[dict[int, list[Event]], set[int]]:
+        """Each scope's `check` records, and the scopes that failed arity."""
         scope_events: dict[int, list[Event]] = {}
         malformed_scopes: set[int] = set()
         for event in self.log_events:
@@ -1223,134 +1250,190 @@ class Audit:
                 malformed_scopes.add(scope_index)
                 continue
             scope_events.setdefault(scope_index, []).append(event)
+        return scope_events, malformed_scopes
 
-        equation_tokens = list(re.finditer(
-            r"\\(begin|end)\{tenkzeq\}", self._tex_src
-        ))
-        equation_stack: list[re.Match[str]] = []
-        for token in equation_tokens:
+    def _tenkzeq_spans(self) -> list[tuple[int, int]]:
+        """Source spans of the equation environments, innermost first."""
+        spans: list[tuple[int, int]] = []
+        stack: list[int] = []
+        for token in re.finditer(r"\\(begin|end)\{tenkzeq\}", self._tex_src):
             if token.group(1) == "begin":
-                equation_stack.append(token)
-                continue
-            if not equation_stack:
-                continue
-            begin = equation_stack.pop()
-            first_construct = next(
-                (construct for construct in self.constructs
-                 if begin.end() <= construct.start < token.start()),
-                None,
-            )
-            if first_construct is None:
-                continue
-            declared_offs = _tenkzeq_declared_offs(self._tex_src, begin.end())
-            if declared_offs is None:
-                continue
+                stack.append(token.end())
+            elif stack:
+                spans.append((stack.pop(), token.start()))
+        return spans
+
+    def _source_authorized_offs(self) -> Optional[dict[int, set[int]]]:
+        """Per scope, the relations the source itself waives.
+
+        `None` when no source is linked: the stream is then the only witness
+        of its own waivers, which are honoured and reported.  With a source,
+        a waiver counts only where the environment's own `check={off={k:
+        reason}}` names it, so a stale or edited stream cannot retire a
+        comparison the author never opted out of.
+        """
+        if not self.tex_linked:
+            return None
+        picture_scopes, scope_pictures = self._scope_index()
+        authorized: dict[int, set[int]] = {}
+        for begin, end in self._tenkzeq_spans():
             members = [
                 index for index, construct in enumerate(self.constructs)
-                if begin.end() <= construct.start and construct.end <= token.start()
+                if begin <= construct.start and construct.end <= end
             ]
-            logged_scopes = {picture_scopes.get(member) for member in members}
-            if len(logged_scopes) != 1 or None in logged_scopes:
+            scopes = {picture_scopes.get(member) for member in members}
+            if len(scopes) != 1 or None in scopes:
                 continue
-            scope = next(
-                value for value in logged_scopes if value is not None
-            )
-            if scope in malformed_scopes or scope_pictures.get(scope) != members:
+            scope = scopes.pop()
+            if scope is None or scope_pictures.get(scope) != members:
                 continue
-            # Relation ordinals follow the joiners: adjacent members whose
-            # separator is relation glue own one relation each, and members
-            # adjacent without one are a product group inside a single side,
-            # so a scope may legally log fewer relations than member gaps.
-            relation_pairs = [
-                index
-                for index in range(len(members) - 1)
-                if same_equation(self._tex_src[
-                    self.constructs[members[index]].end:
-                    self.constructs[members[index + 1]].start
-                ])
-            ]
-            expected_relations = set(range(1, len(relation_pairs) + 1))
-            scope_records = scope_events.get(scope, [])
-            # A scope record is a relation comparison or a product
-            # contraction; anything else disables the scope.
-            if any(
-                "relation" not in event.attrs and "product" not in event.attrs
-                for event in scope_records
-            ):
-                continue
-            events = [
-                event for event in scope_records if "relation" in event.attrs
-            ]
-            relation_numbers = [
-                int(event.attrs["relation"])
-                for event in events
+            authorized[scope] = _tenkzeq_declared_offs(self._tex_src, begin) or set()
+        return authorized
+
+    def check_equation_groups(self) -> None:
+        """Enforce the boundary signature inside every equation group.
+
+        The group is the `tenkzeq` scope.  Two facts carry it in the stream:
+        every panel's `picture` record names its scope, and the scope writes
+        one `check` record per joiner -- a relation comparison or a product
+        contraction.  A mismatch inside a group is a hard error, not an
+        advisory: an equation whose sides expose different boundaries states
+        an identity between maps of different types.
+
+        Two rules apply.  The group's arithmetic must close -- relations plus
+        contractions plus one equals panels -- so that no panel escapes
+        comparison; a group whose arithmetic fails is read as unchecked, and
+        its panels are then compared pair by pair with no waiver honoured.
+        And where every side is one panel, the panels' own boundary records
+        are compared here whatever the kernel's verdict said, so a stream
+        whose comparison never ran is caught rather than trusted.
+        """
+        _, scope_pictures = self._scope_index()
+        scope_events, malformed_scopes = self._scope_checks()
+        authorized = self._source_authorized_offs()
+        for scope in sorted(scope_pictures):
+            members = scope_pictures[scope]
+            records = scope_events.get(scope, [])
+            relation_records = [
+                event for event in records
                 if event.attrs.get("relation", "").isdigit()
             ]
-            # Every relation record in the scope must own exactly one
-            # expected relation.  Missing, duplicate, unowned, and surplus
-            # records disable the whole scope instead of authorizing a waiver.
-            if (
-                len(events) != len(expected_relations)
-                or len(relation_numbers) != len(events)
-                or set(relation_numbers) != expected_relations
-            ):
-                continue
-            by_relation = {
-                int(event.attrs["relation"]): event for event in events
+            relations = {
+                int(event.attrs["relation"]): event for event in relation_records
             }
-            logged_offs = {
-                relation for relation, event in by_relation.items()
+            products = [event for event in records if "product" in event.attrs]
+            modulo = any(
+                event.attrs.get("modulo") == "bundles" for event in records
+            )
+            where = f"{self.log_path.name}:{self.pictures[members[0]].line}"
+            closed = (
+                scope not in malformed_scopes
+                and len(relation_records) == len(relations)
+                and set(relations) == set(range(1, len(relations) + 1))
+                and len(relations) + len(products) + 1 == len(members)
+            )
+            waived: set[int] = {
+                relation for relation, event in relations.items()
                 if event.attrs.get("result") == "off"
             }
-            # An event-stream opt-out is authority only when the same relation
-            # is explicitly waived in this source scope.
-            if logged_offs != declared_offs:
+            if authorized is not None and waived != authorized.get(scope, set()):
+                for relation in sorted(waived - authorized.get(scope, set())):
+                    self.hard(
+                        "eq-check-off", where,
+                        f"equation scope {scope} waives relation {relation} "
+                        f"but its source declares no such opt-out",
+                    )
+                waived = set()
+            else:
+                for relation in sorted(waived):
+                    event = relations[relation]
+                    self.adv(
+                        "eq-check-off",
+                        f"{self.log_path.name}:{event.line}",
+                        f"equation scope {scope} waived relation {relation}: "
+                        f"{event.attrs.get('reason', '(no reason recorded)')}",
+                    )
+            if not closed:
+                if scope not in malformed_scopes:
+                    # A malformed scope already failed as a hard kernel-check.
+                    self.hard(
+                        "eq-unchecked", where,
+                        f"equation scope {scope} holds {len(members)} panel(s) "
+                        f"but records {len(relation_records)} relation(s) and "
+                        f"{len(products)} contraction(s); every panel must "
+                        f"fold into a compared side",
+                    )
+                self._compare_adjacent(members, scope, modulo, waived=set())
                 continue
-            for relation, pair_index in enumerate(relation_pairs, 1):
-                relation_checks[members[pair_index]] = by_relation[relation]
+            if products:
+                # A product group's signature is a fold over an interface the
+                # kernel resolves; its verdict is the `check` record, which
+                # `check_kernel_checks` rejects when it says mismatch.
+                continue
+            self._compare_adjacent(members, scope, modulo, waived)
 
+    def _compare_adjacent(self, members: list[int], scope: int, modulo: bool,
+                          waived: set[int]) -> None:
+        for relation in range(1, len(members)):
+            if relation in waived:
+                continue
+            self._compare_panels(
+                self.pictures[members[relation - 1]],
+                self.pictures[members[relation]],
+                self.hard, "eq-boundary-mismatch",
+                f"sit on relation {relation} of equation scope {scope}",
+                modulo=modulo,
+            )
+
+    def _compare_panels(self, left: Picture, right: Picture,
+                        report: Callable[[str, str, str], None], rule: str,
+                        relation: str, source: str = "",
+                        modulo: bool = False) -> None:
+        """Report when two panels expose different open-leg classes.
+
+        Only the page face is dropped: a panel drawn rotated cuts the same
+        indices on other sides of its frame.  Everything else the entry
+        states -- virtual or physical, strand weight, and the orientation of
+        a directed index -- belongs to the index and must agree.
+        """
+        sig_left, sig_right = left.kernel_boundary(), right.kernel_boundary()
+        if sig_left is None or sig_right is None or sig_left == sig_right:
+            return
+        classes_left = boundary_classes(sig_left, modulo)
+        classes_right = boundary_classes(sig_right, modulo)
+        if classes_left == classes_right:
+            return
+        report(rule, f"{self.log_path.name}:{left.line}",
+               f"pictures {left.ident} and {right.ident} {relation} "
+               f"but open-leg classes differ: {sig_left} vs {sig_right}"
+               f"{source}")
+
+    def check_equation_boundaries(self) -> None:
+        """Advise on pictures joined by a source `=` outside every group.
+
+        The mechanism is `tenkzeq`; a bare `=` between two pictures is a
+        reading of the source, not a declaration, so a mismatch here reports
+        migration work rather than failing the stream.
+        """
+        if not self.tex_linked:
+            return
+        picture_scopes, _ = self._scope_index()
         for i in range(len(self.pictures) - 1):
             a, b = self.pictures[i], self.pictures[i + 1]
             if a.lang != b.lang or a.lang != "kernel":
                 continue
+            if i in picture_scopes and picture_scopes.get(i + 1) == picture_scopes[i]:
+                continue  # one group: check_equation_groups owns the pair
             ca, cb = self.constructs[i], self.constructs[i + 1]
             if ca.end > cb.start:
                 continue  # nested constructs: no linear separator
-            sep = self._tex_src[ca.end:cb.start]
-            if not same_equation(sep):
+            if not same_equation(self._tex_src[ca.end:cb.start]):
                 continue
-            relation_check = relation_checks.get(i)
-            if (
-                relation_check is not None
-                and relation_check.attrs.get("result") in {"equal", "off"}
-            ):
-                continue
-            sig_a, sig_b = a.kernel_boundary(), b.kernel_boundary()
-            if sig_a is None or sig_b is None or sig_a == sig_b:
-                continue
-            # Rotation may change only the direction field.  Everything
-            # after it, notably strand weight, remains semantic.
-            def without_direction(item: str) -> tuple[str, ...]:
-                parts = item.split(":")
-                kind = parts[0].strip()
-                if kind in {"edge", "open"}:
-                    kind = "virtual"
-                weight = (
-                    ":".join(parts[2:]).strip()
-                    if len(parts) > 2 else "single"
-                )
-                weight = re.sub(r"\s*=\s*", "=", weight)
-                return kind, weight
-
-            kinds_a = Counter(without_direction(item) for item in sig_a)
-            kinds_b = Counter(without_direction(item) for item in sig_b)
-            if kinds_a == kinds_b:
-                continue
-            self.hard("eq-boundary-mismatch",
-                      f"{self.log_path.name}:{a.line}",
-                      f"pictures {a.ident} and {b.ident} sit on one `=` "
-                      f"but open-leg kinds differ: {sig_a} vs {sig_b} "
-                      f"[{self.tex_path.name}:{ca.line}]")
+            self._compare_panels(
+                a, b, self.adv, "eq-sibling-mismatch",
+                "sit on one source `=` outside every equation group",
+                f" [{self.tex_path.name}:{ca.line}]",
+            )
 
     # ---------------- driver ----------------
 
@@ -1363,6 +1446,7 @@ class Audit:
         self.check_kernel_checks()
         self.check_bbox_coverage()
         self.check_label_overlaps()
+        self.check_equation_groups()
         self.check_equation_boundaries()
         self.check_repeated_topology()
         return self.report()
@@ -1457,7 +1541,7 @@ def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
     """Return source-authorized opt-outs from one equation's actual options.
 
     ``None`` means that the environment has no single top-level ``check`` key,
-    so its event records cannot authorize source-linked boundary delegation.
+    so the source authorizes no waiver at all.
     """
     options = following_group(source, position, "[", "]")
     if options is None:
@@ -1479,6 +1563,48 @@ def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
         if match is not None:
             declared.add(int(match.group(1)))
     return declared
+
+
+_ORIENTATIONS = frozenset({"to", "from"})
+_BUNDLE = re.compile(r"bundle=([1-9]\d*)")
+
+
+def boundary_classes(signature: tuple[str, ...],
+                     modulo_bundles: bool = False) -> Counter:
+    """The multiset of open-leg classes a boundary signature exposes.
+
+    Under `check={modulo=bundles}` a bundled strand stands for its own
+    multiplicity of single strands, and the comparison expands it, exactly as
+    the kernel's own comparison does.
+    """
+    classes: Counter = Counter()
+    for item in signature:
+        kind, weight, orientation = signature_entry_class(item)
+        bundle = _BUNDLE.fullmatch(weight) if modulo_bundles else None
+        if bundle is None:
+            classes[(kind, weight, orientation)] += 1
+        else:
+            classes[(kind, "single", orientation)] += int(bundle.group(1))
+    return classes
+
+
+def signature_entry_class(item: str) -> tuple[str, str, str]:
+    """Classify one boundary-signature entry, dropping only its page face.
+
+    An entry is ``kind:face`` followed by the optional fields the index
+    itself carries: a strand weight, and the orientation of a directed
+    index (``to`` when it leaves the panel, ``from`` when it enters).  A
+    rotated panel cuts its indices on other faces of its frame, so the face
+    is not compared; weight and orientation are the index's own and are.
+    """
+    parts = [part.strip() for part in item.split(":")]
+    kind = parts[0]
+    if kind in {"edge", "open"}:
+        kind = "virtual"
+    rest = parts[2:]
+    orientation = next((part for part in rest if part in _ORIENTATIONS), "none")
+    weight = next((part for part in rest if part not in _ORIENTATIONS), "single")
+    return kind, re.sub(r"\s*=\s*", "=", weight), orientation
 
 
 def same_equation(sep: str) -> bool:

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -105,7 +105,7 @@ from collections import Counter
 from dataclasses import dataclass
 from fractions import Fraction
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, NamedTuple, Optional
 
 from tenkzlib.texcase import (
     Construct,
@@ -410,6 +410,15 @@ def _stroked_polygon_intersects_roundrect(
         )
         for center, diameter in circles
     )
+
+
+class ScopePolicy(NamedTuple):
+    """What one equation's own source says about how it is checked."""
+
+    waived: set[int]        # relations its `check={off={k: ...}}` retires
+    modulo_bundles: bool    # whether it compares a bundle as its multiplicity
+    relation_gaps: set[int]  # gaps it writes a recognized relation across
+    product_gaps: set[int]   # gaps it leaves empty, joining by juxtaposition
 
 
 @dataclass
@@ -1287,14 +1296,17 @@ class Audit:
                 spans.append((stack.pop(), token.start()))
         return spans
 
-    def _source_check_policy(
-        self,
-    ) -> Optional[dict[int, tuple[set[int], bool, set[int]]]]:
+    def _source_check_policy(self) -> Optional[dict[int, ScopePolicy]]:
         """Per scope, the check policy the source itself declares.
 
         The policy is the relations it waives, whether it compares modulo
-        bundles, and which adjacent panel pairs its own joiners contract --
-        the gaps its panels sit across without a relation between them.  `None` when no source is linked: the stream is then the only
+        bundles, and what its own joiners settle about each gap between its
+        panels.  Two things a source settles positively: a gap it writes a
+        recognized relation across is a relation, and a gap it leaves empty
+        carries no mathematics at all and so can only be juxtaposition.  The
+        reading claims nothing about the gaps in between -- a relation set
+        inside braces is one it does not recognize -- so neither rule is ever
+        phrased as the absence of evidence.  `None` when no source is linked: the stream is then the only
         witness of its own policy, which is honoured and reported.  With a
         source, a waiver counts and a bundle expansion applies only where the
         environment's own `check=` says so, so a stale or edited stream can
@@ -1304,7 +1316,7 @@ class Audit:
         if not self.tex_linked:
             return None
         picture_scopes, scope_pictures = self._scope_index()
-        authorized: dict[int, tuple[set[int], bool, set[int]]] = {}
+        authorized: dict[int, ScopePolicy] = {}
         for begin, end in self._tenkzeq_spans():
             members = [
                 index for index, construct in enumerate(self.constructs)
@@ -1326,23 +1338,25 @@ class Audit:
                     f"{sorted(str(picture_scopes.get(member, 'no scope')) for member in members)}",
                 )
                 continue
-            # The separator reading recognizes a relation but never rules one
-            # out -- a relation set inside braces reads as unknown -- so what
-            # the source settles is where a contraction cannot be: across a
-            # gap it demonstrably writes a relation over.
+            separators = [
+                self._tex_src[
+                    self.constructs[left].end:self.constructs[right].start
+                ]
+                for left, right in zip(members, members[1:])
+            ]
             relation_gaps = {
-                position + 1
-                for position, (left, right) in enumerate(zip(members, members[1:]))
-                if same_equation(
-                    self._tex_src[
-                        self.constructs[left].end:self.constructs[right].start
-                    ]
-                )
+                position + 1 for position, separator in enumerate(separators)
+                if same_equation(separator)
             }
-            authorized[scope] = (
+            product_gaps = {
+                position + 1 for position, separator in enumerate(separators)
+                if not separator.strip()
+            }
+            authorized[scope] = ScopePolicy(
                 _tenkzeq_declared_offs(self._tex_src, begin) or set(),
                 _tenkzeq_declares_bundles(self._tex_src, begin),
                 relation_gaps,
+                product_gaps,
             )
         return authorized
 
@@ -1416,9 +1430,9 @@ class Audit:
                 event.attrs.get("modulo") == "bundles" for event in records
             )
             where = f"{self.log_path.name}:{self.pictures[members[0]].line}"
-            declared, declared_modulo, relation_gaps = (
-                (set(), logged_modulo, set()) if policy is None
-                else policy.get(scope, (set(), False, set()))
+            declared, declared_modulo, relation_gaps, product_gaps = (
+                ScopePolicy(set(), logged_modulo, set(), set()) if policy is None
+                else policy.get(scope, ScopePolicy(set(), False, set(), set()))
             )
             # A bundle expansion loosens the comparison, so the source has to
             # ask for it: a stale stream carrying `modulo=bundles` past a
@@ -1443,11 +1457,14 @@ class Audit:
                 and len(relation_records) == len(relations)
                 and set(relations) == set(range(1, len(relations) + 1))
                 and len(product_records) == len(products)
-                # A contraction recorded across a gap the source writes a
-                # relation over folds panels the author never juxtaposed, and
-                # leaves the pair the author did juxtapose unchecked, while
+                # The joiners must partition the gaps the source settles: a
+                # contraction cannot sit where the source writes a relation,
+                # and a gap the source leaves empty joins its panels by
+                # juxtaposition and nothing else, so a contraction has to name
+                # it.  Either failure leaves a panel outside every side while
                 # the count still balances.
                 and not (products & relation_gaps)
+                and product_gaps <= products
                 and len(relations) + len(products) + 1 == len(members)
             )
             waived: set[int] = {

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -1429,8 +1429,15 @@ class Audit:
                 )
                 if pair is not None
             }
+            # Only a comparison states the mode it ran in; a waiver ran none
+            # and says nothing, so a scope whose every relation is waived
+            # leaves the mode unobserved rather than observed to be off.
+            stated = [
+                event for event in records
+                if event.attrs.get("result") in {"equal", "mismatch", "contracted"}
+            ]
             logged_modulo = any(
-                event.attrs.get("modulo") == "bundles" for event in records
+                event.attrs.get("modulo") == "bundles" for event in stated
             )
             where = f"{self.log_path.name}:{self.pictures[members[0]].line}"
             source = (
@@ -1449,7 +1456,7 @@ class Audit:
             # count the current source rejects.  The comparison then runs in
             # the stricter of the two readings.
             modulo = logged_modulo and declared_modulo
-            if policy is not None and logged_modulo != declared_modulo:
+            if policy is not None and stated and logged_modulo != declared_modulo:
                 self.hard(
                     "eq-check-drift", where,
                     f"equation scope {scope} compares "
@@ -1771,11 +1778,12 @@ _INLINE_EQUALITY_GLUE = re.compile(
 )
 
 
-def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
-    """Return source-authorized opt-outs from one equation's actual options.
+def _tenkzeq_check_value(source: str, position: int) -> str | None:
+    """One equation's `check=` value, unwrapped from its braces.
 
-    ``None`` means that the environment has no single top-level ``check`` key,
-    so the source authorizes no waiver at all.
+    ``None`` when the environment states no single top-level `check` key, in
+    which case it declares no policy at all -- neither a waiver nor a
+    comparison mode -- and both readers below agree on that.
     """
     options = following_group(source, position, "[", "]")
     if options is None:
@@ -1789,6 +1797,14 @@ def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
     grouped = following_group_span(check_value, 0, "{", "}")
     if grouped is not None and not check_value[grouped[1] :].strip():
         check_value = grouped[0]
+    return check_value
+
+
+def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
+    """Return source-authorized opt-outs from one equation's actual options."""
+    check_value = _tenkzeq_check_value(source, position)
+    if check_value is None:
+        return None
     declared: set[int] = set()
     for key, value in top_level_options(check_value):
         if key != "off" or value is None:
@@ -1801,15 +1817,11 @@ def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
 
 def _tenkzeq_declares_bundles(source: str, position: int) -> bool:
     """True when one equation's own options ask to compare modulo bundles."""
-    options = following_group(source, position, "[", "]")
-    if options is None:
-        return False
-    for key, value in top_level_options(options):
-        if key != "check" or value is None:
-            continue
-        if re.search(r"modulo\s*=\s*bundles", value) is not None:
-            return True
-    return False
+    check_value = _tenkzeq_check_value(source, position)
+    return (
+        check_value is not None
+        and re.search(r"modulo\s*=\s*bundles", check_value) is not None
+    )
 
 
 _ORIENTATIONS = frozenset({"to", "from"})

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -1266,6 +1266,10 @@ class Audit:
             scope_events.setdefault(scope_index, []).append(event)
         return scope_events, malformed_scopes
 
+    def _tex_line(self, offset: int) -> int:
+        """The source line an offset falls on."""
+        return self._tex_src.count("\n", 0, offset) + 1
+
     def _tenkzeq_spans(self) -> list[tuple[int, int]]:
         """Source spans of the equation environments, innermost first."""
         spans: list[tuple[int, int]] = []
@@ -1298,10 +1302,20 @@ class Audit:
                 if begin <= construct.start and construct.end <= end
             ]
             scopes = {picture_scopes.get(member) for member in members}
-            if len(scopes) != 1 or None in scopes:
-                continue
-            scope = scopes.pop()
+            scope = scopes.pop() if len(scopes) == 1 else None
+            # The source states which pictures one equation holds and the
+            # stream states which scope each picture claimed.  Where the two
+            # do not name the same group, the comparisons that ran were
+            # between panels no author put on one relation.
             if scope is None or scope_pictures.get(scope) != members:
+                self.hard(
+                    "eq-unchecked",
+                    f"{self.tex_path.name}:{self._tex_line(begin)}",
+                    f"the source states an equation over "
+                    f"{len(members)} picture(s) that the stream does not "
+                    f"group: its panels claim "
+                    f"{sorted(str(picture_scopes.get(member, 'no scope')) for member in members)}",
+                )
                 continue
             authorized[scope] = (
                 _tenkzeq_declared_offs(self._tex_src, begin) or set(),
@@ -1396,6 +1410,9 @@ class Audit:
                 )
             closed = (
                 scope not in malformed_scopes
+                # An equation asserts at least one relation, so a scope
+                # recording none compared nothing, however its panels count.
+                and relations
                 and len(relation_records) == len(relations)
                 and set(relations) == set(range(1, len(relations) + 1))
                 and len(product_records) == len(products)

--- a/scripts/tenkz_blueprint_sweep.py
+++ b/scripts/tenkz_blueprint_sweep.py
@@ -34,6 +34,7 @@ Exit status: 1 iff some unit's stream has a hard finding.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -163,11 +164,14 @@ def main(argv: list[str]) -> int:
             # Name the linked copy after the source it came from, so a
             # source-linked finding's bracket reads as the chapter it is about.
             source_path = Path(tmp) / f"{unit.path.stem}-{unit.line}.tex"
-            # One figure that will not compile or convert must not take the
-            # sweep down with it: the rest of the volume still has an answer.
+            # One figure that will not compile, convert, or finish inside
+            # its timeout must not take the sweep down with it: the rest of
+            # the volume still has an answer.
             try:
                 log_path = tenkz_pic.unit_event_log(unit.source, svg_dir)
-            except (RuntimeError, OSError) as failure:
+            except (
+                RuntimeError, OSError, subprocess.SubprocessError
+            ) as failure:
                 print(f"  HARD [unit-compile] {where}: {failure}")
                 failed.append(where)
                 continue

--- a/scripts/tenkz_blueprint_sweep.py
+++ b/scripts/tenkz_blueprint_sweep.py
@@ -1,24 +1,41 @@
 #!/usr/bin/env python3
 """Audit the event stream of every tenkz picture in the blueprint.
 
-The web build compiles each picture standalone and caches it by a content
-hash of its own source plus the library's (`blueprint/src/Packages/
-tenkz_pic.py`), leaving one `.tnlog` per picture beside the SVG.  This sweep
-walks the blueprint sources, asks that pipeline for each picture's stream,
-and runs `tenkz_audit.py` over all of them, so a hard finding names the
-chapter file and line it came from rather than a hash.
+The web build compiles a picture standalone and caches it by a content hash
+of its own source plus the library's (`blueprint/src/Packages/tenkz_pic.py`),
+leaving one `.tnlog` beside the SVG.  This sweep walks the blueprint sources,
+asks that pipeline for each unit's stream, and runs `tenkz_audit.py` over all
+of them, so a hard finding names the chapter file and line it came from
+rather than a hash.
 
-A picture whose stream is absent is compiled here; after `leanblueprint web`
-every stream is already cached and the sweep is a read.
+**The unit is the display, not the panel.**  A picture standing alone is its
+own unit; a picture inside a displayed row (`tenkzequation`) is compiled with
+the whole row, so one stream holds every panel of that display and the
+equation checks have something to compare.  Compiling the panels apart would
+leave every display's boundary unchecked, which is coverage this check would
+be claiming and not performing.
+
+How far the equation checks reach depends on what the display declares.  A
+display written as `tenkzeq` stamps its scope into every panel record and the
+hard group rules apply.  A display written with the blueprint's presentational
+row states its relation only as typeset mathematics, so the panels are read
+through the source `=` and a mismatch is advisory (`DESIGN.md`, "Equation
+grouping").  The closing line states both counts: a run whose displays are all
+presentational has performed no hard group check, and says so.
+
+A unit whose stream is absent is compiled here; after `leanblueprint web`
+every panel-sized stream is cached, and the display-sized ones are compiled
+by this sweep.
 
 Usage: tenkz_blueprint_sweep.py [--src blueprint/src] [--quiet]
-Exit status: 1 iff some picture's stream has a hard finding.
+Exit status: 1 iff some unit's stream has a hard finding.
 """
 
 from __future__ import annotations
 
 import re
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -29,40 +46,66 @@ sys.path.insert(0, str(REPO / "blueprint/src/Packages"))
 from tenkz_audit import Audit  # noqa: E402
 from tenkzlib.texcase import strip_comments  # noqa: E402
 
-# The environments plasTeX captures verbatim and renders as one unit.  Only
-# the tenkz surface writes an event stream; `tikzcd` is drawn by tikz-cd.
-UNIT_ENVIRONMENTS = ("tenkz",)
+# The picture environment plasTeX captures verbatim; `tikzcd` is drawn by
+# tikz-cd and writes no event stream.
+PICTURE = re.compile(r"\\begin\{tenkz\}(.*?)\\end\{tenkz\}", re.S)
+
+# The rows that hold several panels around the mathematics between them.
+# `tenkzeq` is the language's own equation scope; `tenkzequation` is the
+# blueprint's presentational row, whose migration is #5693.
+DISPLAYS = re.compile(
+    r"\\begin\{(tenkzeq|tenkzequation)\}(.*?)\\end\{\1\}", re.S
+)
 
 
 @dataclass(frozen=True)
 class Unit:
-    """One picture: where the source states it, and what it states."""
+    """One audited compile: where the source states it, and what it states."""
 
     path: Path
     line: int
     source: str
+    display: bool  # a whole row of panels rather than a lone picture
 
 
 def scan_units(src_dir: Path) -> list[Unit]:
-    """Every picture unit in the blueprint sources, in file order."""
-    pattern = re.compile(
-        r"\\begin\{(" + "|".join(UNIT_ENVIRONMENTS) + r")\}(.*?)\\end\{\1\}",
-        re.S,
-    )
+    """Every audit unit in the blueprint sources, in file order.
+
+    A display holding at least one picture is one unit carrying all its
+    panels; every picture outside every display is a unit of its own.  A
+    `tenkzeq` display keeps its own environment, since the scope is what the
+    hard checks read; a presentational row contributes its body, because the
+    row is layout the audit has no use for and its macro is not available to
+    a standalone compile.
+    """
     units: list[Unit] = []
     for path in sorted(src_dir.rglob("*.tex")):
         if any(part.startswith(".") for part in path.relative_to(src_dir).parts):
             continue  # the render cache holds generated copies, not sources
-        text = path.read_text(encoding="utf-8")
         # A commented-out picture is not drawn, so it owns no stream; the
         # offsets of the surviving ones must still name their real lines.
-        live = strip_comments(text)
-        for match in pattern.finditer(live):
+        live = strip_comments(path.read_text(encoding="utf-8"))
+        found: list[Unit] = []
+        covered: list[tuple[int, int]] = []
+        for match in DISPLAYS.finditer(live):
+            if not PICTURE.search(match.group(2)):
+                continue  # a row of prose or of tikz-cd: no stream to audit
             name = match.group(1)
-            unit = f"\\begin{{{name}}}{match.group(2)}\\end{{{name}}}"
-            units.append(
-                Unit(path, live.count("\n", 0, match.start()) + 1, unit)
+            source = (
+                match.group(0) if name == "tenkzeq" else match.group(2)
             )
+            found.append(
+                Unit(path, live.count("\n", 0, match.start()) + 1, source, True)
+            )
+            covered.append((match.start(), match.end()))
+        for match in PICTURE.finditer(live):
+            if any(start <= match.start() < end for start, end in covered):
+                continue  # audited as a panel of its display
+            source = f"\\begin{{tenkz}}{match.group(1)}\\end{{tenkz}}"
+            found.append(
+                Unit(path, live.count("\n", 0, match.start()) + 1, source, False)
+            )
+        units.extend(sorted(found, key=lambda unit: unit.line))
     return units
 
 
@@ -85,34 +128,58 @@ def main(argv: list[str]) -> int:
         return 1
     failed: list[str] = []
     advisories = 0
-    for unit in units:
-        where = f"{unit.path.relative_to(REPO)}:{unit.line}"
-        log_path = tenkz_pic.unit_event_log(unit.source, svg_dir)
-        if log_path is None:
-            print(f"  MISSING {where}: no event stream and no SVG toolchain")
-            failed.append(where)
-            continue
-        audit = Audit(log_path, None)
-        audit.parse_log()
-        audit.link_tex()
-        audit.check_empty_pictures()
-        audit.check_dialects()
-        audit.check_kernel_crossings()
-        audit.check_kernel_checks()
-        audit.check_bbox_coverage()
-        audit.check_label_overlaps()
-        audit.check_equation_groups()
-        audit.check_repeated_topology()
-        hard = [f for f in audit.findings if f.severity == "HARD"]
-        advisories += sum(1 for f in audit.findings if f.severity == "ADV")
-        if hard:
-            failed.append(where)
-        for finding in audit.findings:
-            if finding.severity == "HARD" or not quiet:
-                print(f"  {finding.severity:<4} [{finding.rule}] {where}: "
-                      f"{finding.msg}")
-    print(f"tenkz-blueprint-sweep: {len(units)} picture(s), "
+    pictures = 0
+    displays = 0
+    scoped = 0
+    with tempfile.TemporaryDirectory(prefix="tenkz_blueprint_sweep_") as tmp:
+        for unit in units:
+            where = f"{unit.path.relative_to(REPO)}:{unit.line}"
+            # Name the linked copy after the source it came from, so a
+            # source-linked finding's bracket reads as the chapter it is about.
+            source_path = Path(tmp) / f"{unit.path.stem}-{unit.line}.tex"
+            log_path = tenkz_pic.unit_event_log(unit.source, svg_dir)
+            if log_path is None:
+                print(f"  MISSING {where}: no event stream and no SVG toolchain")
+                failed.append(where)
+                continue
+            # The unit's own source is what the log came from, so the
+            # source-linked half of the audit reads exactly this display.
+            source_path.write_text(unit.source, encoding="utf-8")
+            audit = Audit(log_path, source_path)
+            audit.parse_log()
+            audit.link_tex()
+            audit.check_empty_pictures()
+            audit.check_dialects()
+            audit.check_kernel_crossings()
+            audit.check_kernel_checks()
+            audit.check_bbox_coverage()
+            audit.check_label_overlaps()
+            audit.check_equation_groups()
+            audit.check_equation_boundaries()
+            audit.check_repeated_topology()
+            pictures += len(audit.pictures)
+            displays += 1 if unit.display else 0
+            if unit.display and any(
+                event.kind == "picture" and "scope" in event.attrs
+                for event in audit.log_events
+            ):
+                scoped += 1
+            hard = [f for f in audit.findings if f.severity == "HARD"]
+            advisories += sum(1 for f in audit.findings if f.severity == "ADV")
+            if hard:
+                failed.append(where)
+            for finding in audit.findings:
+                if finding.severity == "HARD" or not quiet:
+                    print(f"  {finding.severity:<4} [{finding.rule}] {where}: "
+                          f"{finding.msg}")
+    print(f"tenkz-blueprint-sweep: {pictures} picture(s) in {len(units)} unit(s), "
           f"{len(failed)} with hard findings, {advisories} advisory(ies)")
+    print(f"  equation displays: {displays}; carrying a tenkzeq scope "
+          f"(hard group checks): {scoped}; read through the source `=` "
+          f"(advisory only): {displays - scoped}")
+    if displays and not scoped:
+        print("  NOTE: no blueprint display declares an equation scope, so no "
+              "hard group check ran over the volume; the migration is #5693.")
     return 1 if failed else 0
 
 

--- a/scripts/tenkz_blueprint_sweep.py
+++ b/scripts/tenkz_blueprint_sweep.py
@@ -52,8 +52,11 @@ from tenkzlib.texcase import (  # noqa: E402
 # The rows that hold several panels around the mathematics between them.
 # `tenkzeq` is the language's own equation scope; `tenkzequation` is the
 # blueprint's presentational row, whose migration is #5693.
+# TeX reads the space after a control word as part of it, so `\begin {tenkzeq}`
+# opens the same environment; the shared construct scanner allows it and so
+# must this, or a spaced wrapper would leave its panels ungrouped.
 DISPLAYS = re.compile(
-    r"\\begin\{(tenkzeq|tenkzequation)\}(.*?)\\end\{\1\}", re.S
+    r"\\begin\s*\{(tenkzeq|tenkzequation)\}(.*?)\\end\s*\{\1\}", re.S
 )
 
 

--- a/scripts/tenkz_blueprint_sweep.py
+++ b/scripts/tenkz_blueprint_sweep.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Audit the event stream of every tenkz picture in the blueprint.
+
+The web build compiles each picture standalone and caches it by a content
+hash of its own source plus the library's (`blueprint/src/Packages/
+tenkz_pic.py`), leaving one `.tnlog` per picture beside the SVG.  This sweep
+walks the blueprint sources, asks that pipeline for each picture's stream,
+and runs `tenkz_audit.py` over all of them, so a hard finding names the
+chapter file and line it came from rather than a hash.
+
+A picture whose stream is absent is compiled here; after `leanblueprint web`
+every stream is already cached and the sweep is a read.
+
+Usage: tenkz_blueprint_sweep.py [--src blueprint/src] [--quiet]
+Exit status: 1 iff some picture's stream has a hard finding.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+sys.path.insert(0, str(REPO / "blueprint/src/Packages"))
+
+from tenkz_audit import Audit  # noqa: E402
+from tenkzlib.texcase import strip_comments  # noqa: E402
+
+# The environments plasTeX captures verbatim and renders as one unit.  Only
+# the tenkz surface writes an event stream; `tikzcd` is drawn by tikz-cd.
+UNIT_ENVIRONMENTS = ("tenkz",)
+
+
+@dataclass(frozen=True)
+class Unit:
+    """One picture: where the source states it, and what it states."""
+
+    path: Path
+    line: int
+    source: str
+
+
+def scan_units(src_dir: Path) -> list[Unit]:
+    """Every picture unit in the blueprint sources, in file order."""
+    pattern = re.compile(
+        r"\\begin\{(" + "|".join(UNIT_ENVIRONMENTS) + r")\}(.*?)\\end\{\1\}",
+        re.S,
+    )
+    units: list[Unit] = []
+    for path in sorted(src_dir.rglob("*.tex")):
+        if any(part.startswith(".") for part in path.relative_to(src_dir).parts):
+            continue  # the render cache holds generated copies, not sources
+        text = path.read_text(encoding="utf-8")
+        # A commented-out picture is not drawn, so it owns no stream; the
+        # offsets of the surviving ones must still name their real lines.
+        live = strip_comments(text)
+        for match in pattern.finditer(live):
+            name = match.group(1)
+            unit = f"\\begin{{{name}}}{match.group(2)}\\end{{{name}}}"
+            units.append(
+                Unit(path, live.count("\n", 0, match.start()) + 1, unit)
+            )
+    return units
+
+
+def main(argv: list[str]) -> int:
+    if "-h" in argv or "--help" in argv:
+        print(__doc__.strip().splitlines()[0])
+        print("usage: tenkz_blueprint_sweep.py [--src DIR] [--quiet]")
+        return 0
+    quiet = "--quiet" in argv
+    src_dir = REPO / "blueprint/src"
+    if "--src" in argv:
+        src_dir = Path(argv[argv.index("--src") + 1]).resolve()
+
+    import tenkz_pic
+
+    svg_dir = src_dir / ".tenkz_svg_cache" / "sweep_svg"
+    units = scan_units(src_dir)
+    if not units:
+        print(f"tenkz-blueprint-sweep: no pictures under {src_dir}")
+        return 1
+    failed: list[str] = []
+    advisories = 0
+    for unit in units:
+        where = f"{unit.path.relative_to(REPO)}:{unit.line}"
+        log_path = tenkz_pic.unit_event_log(unit.source, svg_dir)
+        if log_path is None:
+            print(f"  MISSING {where}: no event stream and no SVG toolchain")
+            failed.append(where)
+            continue
+        audit = Audit(log_path, None)
+        audit.parse_log()
+        audit.link_tex()
+        audit.check_empty_pictures()
+        audit.check_dialects()
+        audit.check_kernel_crossings()
+        audit.check_kernel_checks()
+        audit.check_bbox_coverage()
+        audit.check_label_overlaps()
+        audit.check_equation_groups()
+        audit.check_repeated_topology()
+        hard = [f for f in audit.findings if f.severity == "HARD"]
+        advisories += sum(1 for f in audit.findings if f.severity == "ADV")
+        if hard:
+            failed.append(where)
+        for finding in audit.findings:
+            if finding.severity == "HARD" or not quiet:
+                print(f"  {finding.severity:<4} [{finding.rule}] {where}: "
+                      f"{finding.msg}")
+    print(f"tenkz-blueprint-sweep: {len(units)} picture(s), "
+          f"{len(failed)} with hard findings, {advisories} advisory(ies)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tenkz_blueprint_sweep.py
+++ b/scripts/tenkz_blueprint_sweep.py
@@ -44,11 +44,10 @@ sys.path.insert(0, str(REPO / "scripts"))
 sys.path.insert(0, str(REPO / "blueprint/src/Packages"))
 
 from tenkz_audit import Audit  # noqa: E402
-from tenkzlib.texcase import strip_comments  # noqa: E402
-
-# The picture environment plasTeX captures verbatim; `tikzcd` is drawn by
-# tikz-cd and writes no event stream.
-PICTURE = re.compile(r"\\begin\{tenkz\}(.*?)\\end\{tenkz\}", re.S)
+from tenkzlib.texcase import (  # noqa: E402
+    scan_picture_event_constructs,
+    strip_comments,
+)
 
 # The rows that hold several panels around the mathematics between them.
 # `tenkzeq` is the language's own equation scope; `tenkzequation` is the
@@ -85,28 +84,52 @@ def scan_units(src_dir: Path) -> list[Unit]:
         # A commented-out picture is not drawn, so it owns no stream; the
         # offsets of the surviving ones must still name their real lines.
         live = strip_comments(path.read_text(encoding="utf-8"))
+        # The shared scanner owns picture syntax and matches begin against end
+        # by nesting, so an outer picture keeps the inner one it contains.
+        constructs = scan_picture_event_constructs(live)
+        pictures = [
+            construct for construct in constructs
+            if not any(
+                other.start < construct.start and construct.end <= other.end
+                for other in constructs
+            )
+        ]
         found: list[Unit] = []
         covered: list[tuple[int, int]] = []
         for match in DISPLAYS.finditer(live):
-            if not PICTURE.search(match.group(2)):
+            if not any(
+                match.start() <= picture.start and picture.end <= match.end()
+                for picture in pictures
+            ):
                 continue  # a row of prose or of tikz-cd: no stream to audit
-            name = match.group(1)
             source = (
-                match.group(0) if name == "tenkzeq" else match.group(2)
+                match.group(0) if match.group(1) == "tenkzeq" else match.group(2)
             )
             found.append(
                 Unit(path, live.count("\n", 0, match.start()) + 1, source, True)
             )
             covered.append((match.start(), match.end()))
-        for match in PICTURE.finditer(live):
-            if any(start <= match.start() < end for start, end in covered):
+        for picture in pictures:
+            if any(start <= picture.start < end for start, end in covered):
                 continue  # audited as a panel of its display
-            source = f"\\begin{{tenkz}}{match.group(1)}\\end{{tenkz}}"
             found.append(
-                Unit(path, live.count("\n", 0, match.start()) + 1, source, False)
+                Unit(
+                    path,
+                    live.count("\n", 0, picture.start) + 1,
+                    live[picture.start:picture.end],
+                    False,
+                )
             )
         units.extend(sorted(found, key=lambda unit: unit.line))
     return units
+
+
+def _relative(path: Path) -> Path:
+    """The repository-relative name when there is one, else the path itself."""
+    try:
+        return path.relative_to(REPO)
+    except ValueError:
+        return path
 
 
 def main(argv: list[str]) -> int:
@@ -133,11 +156,18 @@ def main(argv: list[str]) -> int:
     scoped = 0
     with tempfile.TemporaryDirectory(prefix="tenkz_blueprint_sweep_") as tmp:
         for unit in units:
-            where = f"{unit.path.relative_to(REPO)}:{unit.line}"
+            where = f"{_relative(unit.path)}:{unit.line}"
             # Name the linked copy after the source it came from, so a
             # source-linked finding's bracket reads as the chapter it is about.
             source_path = Path(tmp) / f"{unit.path.stem}-{unit.line}.tex"
-            log_path = tenkz_pic.unit_event_log(unit.source, svg_dir)
+            # One figure that will not compile or convert must not take the
+            # sweep down with it: the rest of the volume still has an answer.
+            try:
+                log_path = tenkz_pic.unit_event_log(unit.source, svg_dir)
+            except (RuntimeError, OSError) as failure:
+                print(f"  HARD [unit-compile] {where}: {failure}")
+                failed.append(where)
+                continue
             if log_path is None:
                 print(f"  MISSING {where}: no event stream and no SVG toolchain")
                 failed.append(where)

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -476,6 +476,19 @@ for bearing in e n w s; do
     exit 1
   }
 done
+# A directed bundle keeps its multiplicity: the orientation precedes the
+# strand weight, so `modulo=bundles' still expands the bundle and the
+# equation of one directed bundle against three directed singles holds.
+grep -Fq 'kernel-boundary|signature=open:e:to:bundle=3' \
+    "$WORK/r_bundle_dir_modulo.tnlog" || {
+  echo "FAIL: the directed bundle lost its expandable weight field" >&2
+  exit 1
+}
+grep -Fq 'check|scope=1|relation=1|result=equal|modulo=bundles' \
+    "$WORK/r_bundle_dir_modulo.tnlog" || {
+  echo "FAIL: a directed bundle no longer expands modulo bundles" >&2
+  exit 1
+}
 # A directed index states its orientation in the boundary signature whether
 # it is virtual or physical, normalized to the cut: the departing panel's
 # four legs leave, the arriving panel's four enter.

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -476,6 +476,20 @@ for bearing in e n w s; do
     exit 1
   }
 done
+# A directed index states its orientation in the boundary signature whether
+# it is virtual or physical, normalized to the cut: the departing panel's
+# four legs leave, the arriving panel's four enter.
+grep -Fq 'kernel-boundary|signature=open:e:to, open:n:to, open:s:to, open:w:to' \
+    "$WORK/r_dir_open_bearings.tnlog" || {
+  echo "FAIL: the departing virtual legs lost their signature orientation" >&2
+  exit 1
+}
+grep -Fq \
+  'kernel-boundary|signature=open:e:from, open:n:from, open:s:from, open:w:from' \
+    "$WORK/r_dir_open_bearings.tnlog" || {
+  echo "FAIL: the arriving virtual legs lost their signature orientation" >&2
+  exit 1
+}
 # A wire declares its stroke; the absent key and solid= are the same rail.
 for spelling in dashed dotted; do
   [ "$(grep -c "|stroke=$spelling|" "$WORK/r_wire_stroke.tnlog" || true)" \
@@ -2254,6 +2268,7 @@ for contract_negative in \
   n_port_cell_type \
   n_cell_port_type \
   n_physical_dir_mismatch \
+  n_virtual_dir_mismatch \
   n_route_end_inside_hull \
   n_physical_open_port_type \
   n_interface_open_port_type \
@@ -2310,6 +2325,8 @@ do
   [ "$contract_negative" = n_cell_port_type ] &&
     expected='[TKZ-PORT-TYPE]'
   [ "$contract_negative" = n_physical_dir_mismatch ] &&
+    expected='[TKZ-EQ-SIGNATURE]'
+  [ "$contract_negative" = n_virtual_dir_mismatch ] &&
     expected='[TKZ-EQ-SIGNATURE]'
   [ "$contract_negative" = n_route_end_inside_hull ] &&
     expected='[TKZ-ROUTE-END-INSIDE]'
@@ -2759,14 +2776,22 @@ python3 "$REPO/scripts/tenkz_audit.py" \
 grep -Fv 'check|scope=1|relation=1|' \
   "$WORK/r_check_scope_nested.tnlog" \
   >"$WORK/r_check_scope_nested_truncated.tnlog"
-python3 "$REPO/scripts/tenkz_audit.py" \
+# A relation whose record went missing leaves its own group unchecked, and
+# the later group's record never covers it.
+if python3 "$REPO/scripts/tenkz_audit.py" \
   "$WORK/r_check_scope_nested_truncated.tnlog" \
   "$KERNEL/regression/r_check_scope_nested.tex" \
-  >"$WORK/r_check_scope_nested_truncated.audit" || {
+  >"$WORK/r_check_scope_nested_truncated.audit"; then
+  echo "FAIL: a missing relation record left the equation group checked" >&2
+  cat "$WORK/r_check_scope_nested_truncated.audit" >&2
+  exit 1
+fi
+if ! grep -F 'HARD [eq-unchecked]' \
+  "$WORK/r_check_scope_nested_truncated.audit" | grep -Fq 'scope 1'; then
   echo "FAIL: a missing record stole the later equation scope" >&2
   cat "$WORK/r_check_scope_nested_truncated.audit" >&2
   exit 1
-}
+fi
 
 scope_malformed="$KERNEL/negative/n_check_scope_malformed_then_valid.tex"
 if ( cd "$WORK" &&

--- a/scripts/tenkzlib/tnlog.py
+++ b/scripts/tenkzlib/tnlog.py
@@ -245,6 +245,13 @@ FORBIDDEN_FIELDS: dict[str, frozenset[str]] = {
     "check": frozenset({"picture"}),
 }
 
+# A check record names the one joiner it resolved: a relation it compared or a
+# product interface it contracted.  Carrying both would let one record stand
+# for two joiners and close a scope that recorded only one of them.
+EXCLUSIVE_FIELDS: dict[str, frozenset[str]] = {
+    "check": frozenset({"relation", "product"}),
+}
+
 
 @dataclass
 class Event:
@@ -390,6 +397,15 @@ def parse_log(
                     "malformed-event",
                     where,
                     f"{kind} event forbids field(s): {', '.join(forbidden)}: {line}",
+                )
+                valid = False
+            exclusive = sorted(EXCLUSIVE_FIELDS.get(kind, frozenset()) & attrs.keys())
+            if len(exclusive) > 1:
+                hard(
+                    "malformed-event",
+                    where,
+                    f"{kind} event names more than one joiner: "
+                    f"{', '.join(exclusive)}: {line}",
                 )
                 valid = False
             event.valid = valid

--- a/scripts/test_tenkz_blueprint_sweep.py
+++ b/scripts/test_tenkz_blueprint_sweep.py
@@ -37,6 +37,13 @@ SOURCES = {
         "% \\begin{tenkz}\\tn{dead}\\end{tenkz}\n"
         "\\begin{tenkz}\\tn{live}\\end{tenkz}\n"
     ),
+    "spaced.tex": (
+        "\\begin {tenkzequation}\n"
+        "\\begin{tenkz}\\tn{A}\\end{tenkz}\n"
+        "$ = $\n"
+        "\\begin{tenkz}\\tn{B}\\end{tenkz}\n"
+        "\\end {tenkzequation}\n"
+    ),
     "prose_row.tex": (
         "\\begin{tenkzequation}\n$a = b$\n\\end{tenkzequation}\n"
     ),
@@ -77,6 +84,12 @@ def main() -> int:
 
     # A row with no picture writes no event stream.
     assert "prose_row.tex" not in units, names
+
+    # TeX reads the space after a control word as part of it, so a spaced
+    # wrapper opens the same environment and keeps its panels together.
+    assert names.count("spaced.tex") == 1, names
+    assert units["spaced.tex"].display
+    assert units["spaced.tex"].source.count("\\begin{tenkz}") == 2
 
     print(f"tenkz-blueprint-sweep-units: {len(names)} unit(s) over "
           f"{len(SOURCES)} source(s) selected as expected")

--- a/scripts/test_tenkz_blueprint_sweep.py
+++ b/scripts/test_tenkz_blueprint_sweep.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Focused regressions for the blueprint sweep's unit selection.
+
+The sweep decides what one audited compile is.  Getting that wrong is not a
+wrong answer but a missing question: a display split into panels leaves every
+equation unchecked, and a nested picture cut at its inner `\\end` compiles a
+fragment.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tenkz_blueprint_sweep import scan_units
+
+
+SOURCES = {
+    "display.tex": (
+        "\\begin{tenkzequation}\n"
+        "\\begin{tenkz}\\tn{A}\\end{tenkz}\n"
+        "$ = $\n"
+        "\\begin{tenkz}\\tn{B}\\end{tenkz}\n"
+        "\\end{tenkzequation}\n"
+    ),
+    "scope.tex": (
+        "\\begin{tenkzeq}[check={signature}]\n"
+        "\\begin{tenkz}\\tn{A}\\end{tenkz}\n=\n"
+        "\\begin{tenkz}\\tn{B}\\end{tenkz}\n"
+        "\\end{tenkzeq}\n"
+    ),
+    "nested.tex": (
+        "\\begin{tenkz}\\tngroup{\\begin{tenkz}\\tn{I}\\end{tenkz}}\\end{tenkz}\n"
+    ),
+    "commented.tex": (
+        "% \\begin{tenkz}\\tn{dead}\\end{tenkz}\n"
+        "\\begin{tenkz}\\tn{live}\\end{tenkz}\n"
+    ),
+    "prose_row.tex": (
+        "\\begin{tenkzequation}\n$a = b$\n\\end{tenkzequation}\n"
+    ),
+}
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="tenkz_sweep_units_") as tmp:
+        root = Path(tmp)
+        for name, text in SOURCES.items():
+            (root / name).write_text(text, encoding="utf-8")
+        units = {unit.path.name: unit for unit in scan_units(root)}
+        names = [unit.path.name for unit in scan_units(root)]
+
+    # A display is one unit holding both its panels, not two units.
+    assert names.count("display.tex") == 1, names
+    assert units["display.tex"].display
+    assert units["display.tex"].source.count("\\begin{tenkz}") == 2
+
+    # A `tenkzeq` display keeps its environment: the scope is what the hard
+    # rules read, and dropping it would drop the check records with it.
+    assert units["scope.tex"].source.startswith("\\begin{tenkzeq}")
+    assert "check={signature}" in units["scope.tex"].source
+
+    # A presentational row contributes its body, whose macro a standalone
+    # compile does not have.
+    assert not units["display.tex"].source.startswith("\\begin{tenkzequation}")
+
+    # A nested picture belongs to its parent's unit, and the parent is not cut
+    # short at the inner `\end`.
+    assert names.count("nested.tex") == 1, names
+    assert units["nested.tex"].source.count("\\begin{tenkz}") == 2
+    assert units["nested.tex"].source.endswith("\\end{tenkz}")
+
+    # A commented-out picture draws nothing and owns no unit.
+    assert names.count("commented.tex") == 1, names
+    assert "dead" not in units["commented.tex"].source
+
+    # A row with no picture writes no event stream.
+    assert "prose_row.tex" not in units, names
+
+    print(f"tenkz-blueprint-sweep-units: {len(names)} unit(s) over "
+          f"{len(SOURCES)} source(s) selected as expected")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -344,10 +344,58 @@ def main() -> int:
     )
     assert once.count(("eq-sibling-mismatch", "ADV")) == 1, once
 
+    # Seeded defect: `panel1 = panel2 = panel3 panel4`.  The last side folds
+    # over a contraction and stays the kernel's to answer for, but the first
+    # relation has one panel on each side, and a mismatch there is the audit's
+    # to find however confidently the record says otherwise.
+    beside_product_source = (
+        "\\begin{tenkzeq}[check={signature}]\n"
+        f"{PANELS[0]}=\n{PANELS[1]}=\n{PANELS[0]}{PANELS[1]}"
+        "\\end{tenkzeq}\n"
+    )
+    beside_product_records = (
+        "check|scope=1|product=3-4|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n"
+        "check|scope=1|relation=2|result=equal|signature=open:w\n"
+    )
+    beside_product = audit_rules(
+        panel(1, "open:w") + panel(2, "phys:up") + panel(3, "open:w")
+        + panel(4, "open:e") + beside_product_records,
+        beside_product_source,
+    )
+    mismatched_sides = [
+        rule for rule, _ in beside_product if rule == "eq-boundary-mismatch"
+    ]
+    assert len(mismatched_sides) == 1, beside_product
+
+    # The same shape with single sides that do agree stays clean: the fold
+    # over the contraction is not recomputed here.
+    beside_product_clean = audit_rules(
+        panel(1, "open:w") + panel(2, "open:w") + panel(3, "open:w")
+        + panel(4, "open:e") + beside_product_records,
+        beside_product_source,
+    )
+    assert not beside_product_clean, beside_product_clean
+
+    # A spaced environment name opens the same equation, so its declared
+    # waiver is the source's and not a forgery.
+    spaced = audit_rules(
+        group_log(
+            "open:w",
+            "phys:up",
+            "check|scope=1|relation=1|result=off|reason=drafted\n",
+        ),
+        group_source("[check={signature, off={1: drafted}}]").replace(
+            "\\begin{tenkzeq}", "\\begin {tenkzeq}"
+        ).replace("\\end{tenkzeq}", "\\end {tenkzeq}"),
+    )
+    assert ("eq-check-off", "ADV") in spaced, spaced
+    assert "eq-check-drift" not in [rule for rule, _ in spaced], spaced
+
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 23 seeded group checks passed"
+        "and 26 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -409,6 +409,57 @@ def main() -> int:
     )
     assert not gap_partition_whole, gap_partition_whole
 
+    # Seeded defect: gaps the reading of the mathematics settles nothing
+    # about.  The stream claims a relation on the last gap and a contraction
+    # on the middle one; the source spells a product sign on both, so the
+    # contractions are the two gaps holding no relation glyph and there is
+    # one relation, not two.
+    unsettled_source = (
+        "\\begin{tenkzeq}[check={signature}]\n"
+        f"{PANELS[0]}=\n{PANELS[1]}$\\otimes$\n{PANELS[0]}$\\otimes$\n{PANELS[1]}"
+        "\\end{tenkzeq}\n"
+    )
+    unsettled = audit_rules(
+        panel(1, "open:w") + panel(2, "open:w") + panel(3, "open:e")
+        + panel(4, "phys:up")
+        + "check|scope=1|product=2-3|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n"
+        "check|scope=1|relation=2|result=equal|signature=open:w\n",
+        unsettled_source,
+    )
+    assert ("eq-unchecked", "HARD") in unsettled, unsettled
+    assert ("eq-boundary-mismatch", "HARD") in unsettled, unsettled
+
+    # The same display read the way the kernel reads it: one relation over
+    # the equals sign, a contraction on each product sign.
+    unsettled_whole = audit_rules(
+        panel(1, "open:w") + panel(2, "open:w") + panel(3, "open:e")
+        + panel(4, "open:w")
+        + "check|scope=1|product=2-3|result=contracted|signature=open:w\n"
+        "check|scope=1|product=3-4|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n",
+        unsettled_source,
+    )
+    assert not unsettled_whole, unsettled_whole
+
+    # A relation the source waives stays waived when the scope fails closure
+    # for a reason of its own: an author who opted a relation out did not opt
+    # back in by losing a record elsewhere.
+    waived_under_failure = audit_rules(
+        panel(1, "open:w") + panel(2, "phys:up") + panel(3, "phys:up")
+        + "check|scope=1|relation=1|result=off|reason=drafted\n"
+        "check|scope=1|relation=2|result=equal|signature=open:w\n"
+        "check|scope=1|relation=2|result=equal|signature=open:w\n",
+        "\\begin{tenkzeq}[check={signature, off={1: drafted}}]\n"
+        f"{PANELS[0]}=\n{PANELS[1]}=\n{PANELS[0]}"
+        "\\end{tenkzeq}\n",
+    )
+    assert ("eq-unchecked", "HARD") in waived_under_failure, waived_under_failure
+    assert ("eq-check-off", "ADV") in waived_under_failure, waived_under_failure
+    assert "eq-boundary-mismatch" not in [
+        rule for rule, _ in waived_under_failure
+    ], waived_under_failure
+
     # A spaced environment name opens the same equation, so its declared
     # waiver is the source's and not a forgery.
     spaced = audit_rules(
@@ -427,7 +478,7 @@ def main() -> int:
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 28 seeded group checks passed"
+        "and 31 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -62,18 +62,35 @@ def group_log(left: str, right: str, records: str) -> str:
     )
 
 
-def audit_rules(log: str, source: str) -> list[tuple[str, str]]:
-    """Run the whole equation half of the audit on one seeded stream."""
+def panel(index: int, signature: str, scope: str = "|scope=1") -> str:
+    """One panel of a seeded stream: its header, one atom, its boundary."""
+    return (
+        f"picture|id=k{index}|lang=kernel{scope}\n"
+        "atom|id=atom-1|cell=1-1|kind=tn\n"
+        f"kernel-boundary|signature={signature}\n"
+    )
+
+
+def audit_rules(log: str, source: str | None = None) -> list[tuple[str, str]]:
+    """Run the whole equation half of the audit on one seeded stream.
+
+    Passing no source runs the log-only half, which is what the blueprint
+    sweep and any unlinked consumer see.
+    """
     with tempfile.TemporaryDirectory(prefix="tenkz_equation_audit_") as tmp:
         work = Path(tmp)
-        tex_path = work / "fixture.tex"
         log_path = work / "fixture.tnlog"
-        tex_path.write_text(source, encoding="utf-8")
         log_path.write_text(log, encoding="utf-8")
+        tex_path = None
+        if source is not None:
+            tex_path = work / "fixture.tex"
+            tex_path.write_text(source, encoding="utf-8")
         audit = Audit(log_path, tex_path)
         audit.parse_log()
         audit.link_tex()
-        assert audit.tex_linked, "equation fixture did not link to its source"
+        assert source is None or audit.tex_linked, (
+            "equation fixture did not link to its source"
+        )
         audit.check_kernel_checks()
         audit.check_equation_groups()
         audit.check_equation_boundaries()
@@ -145,6 +162,18 @@ def main() -> int:
     assert ("eq-check-off", "HARD") in forged, forged
     assert ("eq-boundary-mismatch", "HARD") in forged, forged
 
+    # A waiver the source declares but the stream never recorded means the
+    # two are not the same document, even where the panels agree.
+    stale = audit_rules(
+        group_log(
+            "open:w",
+            "open:w",
+            "check|scope=1|relation=1|result=equal|signature=open:w\n",
+        ),
+        group_source("[check={signature, off={1: drafted}}]"),
+    )
+    assert ("eq-check-off", "HARD") in stale, stale
+
     # The kernel's own refusal stays a hard finding of its own.
     refused = audit_rules(
         group_log(
@@ -157,10 +186,50 @@ def main() -> int:
     )
     assert ("kernel-check", "HARD") in refused, refused
 
+    # Seeded defect: one contraction lost and another recorded twice.  The
+    # count closes, but panel 4 was never folded into a side.
+    duplicated_product = audit_rules(
+        panel(1, "open:w") + panel(2, "open:e") + panel(3, "open:w")
+        + panel(4, "open:e")
+        + "check|scope=1|product=1-2|result=contracted|signature=open:w\n"
+        "check|scope=1|product=1-2|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n"
+    )
+    assert ("eq-unchecked", "HARD") in duplicated_product, duplicated_product
+
+    # The same group with both contractions recorded closes and passes.
+    honest_product = audit_rules(
+        panel(1, "open:w") + panel(2, "open:e") + panel(3, "open:w")
+        + panel(4, "open:e")
+        + "check|scope=1|product=1-2|result=contracted|signature=open:w\n"
+        "check|scope=1|product=3-4|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n"
+    )
+    assert not honest_product, honest_product
+
+    # Seeded defect: the panels lost the scope their checks still name.
+    orphaned = audit_rules(
+        panel(1, "open:w", scope="") + panel(2, "phys:up", scope="")
+        + "check|scope=7|relation=1|result=equal|signature=open:w\n"
+    )
+    assert ("eq-unchecked", "HARD") in orphaned, orphaned
+
+    # A display asserting a relation over a product says nothing pairwise:
+    # the right factor of the product is not the side the relation names.
+    product_display = audit_rules(
+        panel(1, "open:w, open:e", scope="") + panel(2, "open:w", scope="")
+        + panel(3, "open:e", scope=""),
+        f"{PANELS[0]}$ = $\n{PANELS[1]}$ \\otimes $\n{PANELS[0]}",
+    )
+    assert ("eq-sibling-unread", "ADV") in product_display, product_display
+    assert "eq-sibling-mismatch" not in [
+        rule for rule, _ in product_display
+    ], product_display
+
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 8 seeded group checks passed"
+        "and 13 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -270,10 +270,46 @@ def main() -> int:
     mismatches = [rule for rule, _ in mixed if rule == "eq-boundary-mismatch"]
     assert len(mismatches) == 1, mixed
 
+    # Seeded defect: a scope whose arity failure went missing with its
+    # record.  One panel and no relation compares nothing, whatever the
+    # arithmetic says.
+    relationless = audit_rules(panel(1, "open:w"))
+    assert ("eq-unchecked", "HARD") in relationless, relationless
+
+    # Seeded defect: one record claiming to be both joiners of a three-panel
+    # scope.  A check names the one joiner it resolved.
+    two_faced = audit_rules(
+        panel(1, "open:w") + panel(2, "open:e") + panel(3, "open:w")
+        + "check|scope=1|relation=1|product=1-2|result=contracted"
+        "|signature=open:w\n"
+    )
+    assert ("malformed-event", "HARD") in two_faced, two_faced
+    assert ("eq-unchecked", "HARD") in two_faced, two_faced
+
+    # Seeded defect: two source equations whose panels the stream has
+    # cross-assigned.  Each scope owns two panels and a relation record, so
+    # the arithmetic closes, but neither authored pair was compared.
+    crossed_source = (
+        "\\begin{tenkzeq}[check={signature}]\n"
+        f"{PANELS[0]}=\n{PANELS[1]}"
+        "\\end{tenkzeq}\n"
+        "\\begin{tenkzeq}[check={signature}]\n"
+        f"{PANELS[0]}=\n{PANELS[1]}"
+        "\\end{tenkzeq}\n"
+    )
+    crossed = audit_rules(
+        panel(1, "open:w") + panel(2, "open:w", scope="|scope=2")
+        + panel(3, "open:w", scope="|scope=1") + panel(4, "open:w", scope="|scope=2")
+        + "check|scope=1|relation=1|result=equal|signature=open:w\n"
+        "check|scope=2|relation=1|result=equal|signature=open:w\n",
+        crossed_source,
+    )
+    assert ("eq-unchecked", "HARD") in crossed, crossed
+
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 16 seeded group checks passed"
+        "and 20 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Focused regression tests for tenkz equation-separator recognition."""
+"""Regressions for the equation group and the source-separator reading.
+
+The group is the `tenkzeq` scope: a mismatch inside one is a hard finding
+read from the stream alone, while two pictures joined by a source `=` outside
+every group stay advisory.  The seeded defects below are the audit half of
+the enforcement; the kernel half lives in `tests/tenkz/kernel/negative/`.
+"""
 
 import tempfile
 from pathlib import Path
@@ -30,22 +36,34 @@ NEGATIVE = (
     r"$\;=\;\text{extra}$",
 )
 
+PANELS = (
+    "\\begin{tenkz}\n\\tn{A}\n\\end{tenkz}\n",
+    "\\begin{tenkz}\n\\tn{B}\n\\end{tenkz}\n",
+)
 
-def equation_boundary_rules(separator: str) -> list[str]:
-    """Run the source-linked boundary check on two mismatched fixtures."""
-    source = (
-        "\\begin{tenkz}\n\\tn{A}\n\\end{tenkz}\n"
-        f"{separator}\n"
-        "\\begin{tenkz}\n\\tn{B}\n\\end{tenkz}\n"
+
+def group_source(options: str = "[check={signature}]") -> str:
+    return (
+        f"\\begin{{tenkzeq}}{options}\n"
+        f"{PANELS[0]}=\n{PANELS[1]}"
+        "\\end{tenkzeq}\n"
     )
-    log = (
-        "picture|id=k1|lang=kernel\n"
+
+
+def group_log(left: str, right: str, records: str) -> str:
+    return (
+        "picture|id=k1|lang=kernel|scope=1\n"
         "atom|id=atom-1|cell=1-1|kind=tn\n"
-        "kernel-boundary|signature=open:e,open:w\n"
-        "picture|id=k2|lang=kernel\n"
+        f"kernel-boundary|signature={left}\n"
+        "picture|id=k2|lang=kernel|scope=1\n"
         "atom|id=atom-1|cell=1-1|kind=tn\n"
-        "kernel-boundary|signature=up:physical\n"
+        f"kernel-boundary|signature={right}\n"
+        f"{records}"
     )
+
+
+def audit_rules(log: str, source: str) -> list[tuple[str, str]]:
+    """Run the whole equation half of the audit on one seeded stream."""
     with tempfile.TemporaryDirectory(prefix="tenkz_equation_audit_") as tmp:
         work = Path(tmp)
         tex_path = work / "fixture.tex"
@@ -55,9 +73,19 @@ def equation_boundary_rules(separator: str) -> list[str]:
         audit = Audit(log_path, tex_path)
         audit.parse_log()
         audit.link_tex()
-        assert audit.tex_linked, "equation-boundary fixture did not link to its source"
+        assert audit.tex_linked, "equation fixture did not link to its source"
+        audit.check_kernel_checks()
+        audit.check_equation_groups()
         audit.check_equation_boundaries()
-        return [finding.rule for finding in audit.findings]
+        return [(finding.rule, finding.severity) for finding in audit.findings]
+
+
+def sibling_rules(separator: str) -> list[tuple[str, str]]:
+    """Two mismatched pictures joined by `separator` outside every group."""
+    return audit_rules(
+        group_log("open:e, open:w", "phys:up", "").replace("|scope=1", ""),
+        f"{PANELS[0]}{separator}\n{PANELS[1]}",
+    )
 
 
 def main() -> int:
@@ -65,12 +93,74 @@ def main() -> int:
         assert same_equation(separator), f"expected equation glue: {separator!r}"
     for separator in NEGATIVE:
         assert not same_equation(separator), f"expected boundary: {separator!r}"
-    assert "eq-boundary-mismatch" in equation_boundary_rules(r"$\;=\;$")
-    assert "eq-boundary-mismatch" not in equation_boundary_rules(r"$x=y$")
+
+    # Out of scope the source `=` is a reading, so a mismatch advises.
+    assert ("eq-sibling-mismatch", "ADV") in sibling_rules(r"$\;=\;$")
+    assert not sibling_rules(r"$x=y$")
+
+    # Seeded defect: unequal boundaries inside one group are a hard finding.
+    equal_record = "check|scope=1|relation=1|result=equal|signature=open:w\n"
+    mismatched = audit_rules(
+        group_log("open:w", "phys:up", equal_record), group_source()
+    )
+    assert ("eq-boundary-mismatch", "HARD") in mismatched, mismatched
+
+    # Seeded defect: the same count of physical legs, opposite orientations.
+    directed = audit_rules(
+        group_log("phys:n:to", "phys:n:from", equal_record), group_source()
+    )
+    assert ("eq-boundary-mismatch", "HARD") in directed, directed
+
+    # The clean group passes, orientation included.
+    clean = audit_rules(
+        group_log("phys:n:to", "phys:s:to", equal_record), group_source()
+    )
+    assert not clean, clean
+
+    # Seeded defect: a panel no relation ever folded into a side.
+    unchecked = audit_rules(group_log("open:w", "open:w", ""), group_source())
+    assert ("eq-unchecked", "HARD") in unchecked, unchecked
+
+    # A waiver the source declares is honoured, and never silent.
+    waived = audit_rules(
+        group_log(
+            "open:w",
+            "phys:up",
+            "check|scope=1|relation=1|result=off|reason=drafted\n",
+        ),
+        group_source("[check={signature, off={1: drafted}}]"),
+    )
+    assert ("eq-check-off", "ADV") in waived, waived
+    assert "eq-boundary-mismatch" not in [rule for rule, _ in waived], waived
+
+    # A waiver the source does not declare retires nothing.
+    forged = audit_rules(
+        group_log(
+            "open:w",
+            "phys:up",
+            "check|scope=1|relation=1|result=off|reason=drafted\n",
+        ),
+        group_source(),
+    )
+    assert ("eq-check-off", "HARD") in forged, forged
+    assert ("eq-boundary-mismatch", "HARD") in forged, forged
+
+    # The kernel's own refusal stays a hard finding of its own.
+    refused = audit_rules(
+        group_log(
+            "open:w",
+            "phys:up",
+            "check|scope=1|relation=1|result=mismatch"
+            "|left=open:w|right=phys:up\n",
+        ),
+        group_source(),
+    )
+    assert ("kernel-check", "HARD") in refused, refused
+
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 2 source-linked checks passed"
+        "and 8 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -460,6 +460,35 @@ def main() -> int:
         rule for rule, _ in waived_under_failure
     ], waived_under_failure
 
+    # A waiver runs no comparison and so states no comparison mode: a scope
+    # whose every relation is waived leaves the mode unobserved, not observed
+    # to be off, and its source's `modulo=bundles` is no disagreement.
+    all_waived = audit_rules(
+        group_log(
+            "open:w",
+            "open:w",
+            "check|scope=1|relation=1|result=off|reason=drafted\n",
+        ),
+        group_source("[check={signature, modulo=bundles, off={1: drafted}}]"),
+    )
+    assert ("eq-check-off", "ADV") in all_waived, all_waived
+    assert "eq-check-drift" not in [rule for rule, _ in all_waived], all_waived
+
+    # Two `check=` keys state no single policy, and both halves of the policy
+    # reader say so: the waiver reader already refused such a source, and the
+    # comparison mode is refused with it rather than taken from one of them.
+    two_checks = audit_rules(
+        group_log(
+            "open:e:bundle=2",
+            "open:e, open:e",
+            "check|scope=1|relation=1|result=equal|modulo=bundles"
+            "|signature=open:e, open:e\n",
+        ),
+        group_source("[check={signature, modulo=bundles}, check={signature}]"),
+    )
+    assert ("eq-check-drift", "HARD") in two_checks, two_checks
+    assert ("eq-boundary-mismatch", "HARD") in two_checks, two_checks
+
     # A spaced environment name opens the same equation, so its declared
     # waiver is the source's and not a forgery.
     spaced = audit_rules(
@@ -478,7 +507,7 @@ def main() -> int:
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 31 seeded group checks passed"
+        "and 33 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -159,7 +159,7 @@ def main() -> int:
         ),
         group_source(),
     )
-    assert ("eq-check-off", "HARD") in forged, forged
+    assert ("eq-check-drift", "HARD") in forged, forged
     assert ("eq-boundary-mismatch", "HARD") in forged, forged
 
     # A waiver the source declares but the stream never recorded means the
@@ -172,7 +172,7 @@ def main() -> int:
         ),
         group_source("[check={signature, off={1: drafted}}]"),
     )
-    assert ("eq-check-off", "HARD") in stale, stale
+    assert ("eq-check-drift", "HARD") in stale, stale
 
     # The kernel's own refusal stays a hard finding of its own.
     refused = audit_rules(
@@ -226,10 +226,54 @@ def main() -> int:
         rule for rule, _ in product_display
     ], product_display
 
+    # Seeded defect: a stale stream compares modulo bundles past a source
+    # that asks for strand-for-strand, and the loose reading is not honoured.
+    loosened = audit_rules(
+        group_log(
+            "open:e:bundle=2",
+            "open:e, open:e",
+            "check|scope=1|relation=1|result=equal|modulo=bundles"
+            "|signature=open:e, open:e\n",
+        ),
+        group_source(),
+    )
+    assert ("eq-check-drift", "HARD") in loosened, loosened
+    assert ("eq-boundary-mismatch", "HARD") in loosened, loosened
+
+    # The same comparison the source does ask for is honoured.
+    bundled = audit_rules(
+        group_log(
+            "open:e:bundle=2",
+            "open:e, open:e",
+            "check|scope=1|relation=1|result=equal|modulo=bundles"
+            "|signature=open:e, open:e\n",
+        ),
+        group_source("[check={signature, modulo=bundles}]"),
+    )
+    assert not bundled, bundled
+
+    # A forged waiver on one relation retires nothing, and retires nothing of
+    # the author's honest waiver on another relation of the same equation.
+    mixed_source = (
+        "\\begin{tenkzeq}[check={signature, off={2: drafted}}]\n"
+        f"{PANELS[0]}=\n{PANELS[1]}=\n{PANELS[0]}"
+        "\\end{tenkzeq}\n"
+    )
+    mixed = audit_rules(
+        panel(1, "open:w") + panel(2, "phys:up") + panel(3, "open:e")
+        + "check|scope=1|relation=1|result=off|reason=forged\n"
+        "check|scope=1|relation=2|result=off|reason=drafted\n",
+        mixed_source,
+    )
+    assert ("eq-check-drift", "HARD") in mixed, mixed
+    assert ("eq-check-off", "ADV") in mixed, mixed
+    mismatches = [rule for rule, _ in mixed if rule == "eq-boundary-mismatch"]
+    assert len(mismatches) == 1, mixed
+
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 13 seeded group checks passed"
+        "and 16 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -306,10 +306,48 @@ def main() -> int:
     )
     assert ("eq-unchecked", "HARD") in crossed, crossed
 
+    # Seeded defect: `panel1 = panel2 panel3` contracts only the second gap,
+    # so a record folding the first one leaves panel 3 uncompared even though
+    # the count balances.
+    product_side_source = (
+        "\\begin{tenkzeq}[check={signature}]\n"
+        f"{PANELS[0]}=\n{PANELS[1]}{PANELS[0]}"
+        "\\end{tenkzeq}\n"
+    )
+    crossed_product = audit_rules(
+        panel(1, "open:w") + panel(2, "open:e") + panel(3, "open:w")
+        + "check|scope=1|product=1-2|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n",
+        product_side_source,
+    )
+    assert ("eq-unchecked", "HARD") in crossed_product, crossed_product
+
+    # The contraction the source does state closes the same scope.
+    honest_side = audit_rules(
+        panel(1, "open:w") + panel(2, "open:e") + panel(3, "open:w")
+        + "check|scope=1|product=2-3|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n",
+        product_side_source,
+    )
+    assert not honest_side, honest_side
+
+    # A display run enters the report once, whether it ends at a boundary or
+    # at the end of the stream.
+    boundary_source = (
+        f"{PANELS[0]}$ = $\n{PANELS[1]}\n"
+        "\\begin{center}\n" + PANELS[0] + "\\end{center}\n"
+    )
+    once = audit_rules(
+        panel(1, "open:w", scope="") + panel(2, "phys:up", scope="")
+        + panel(3, "open:w", scope=""),
+        boundary_source,
+    )
+    assert once.count(("eq-sibling-mismatch", "ADV")) == 1, once
+
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 20 seeded group checks passed"
+        "and 23 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -377,6 +377,38 @@ def main() -> int:
     )
     assert not beside_product_clean, beside_product_clean
 
+    # Seeded defect: `A = B C D` written with two relation records and one
+    # contraction.  The count balances and the contraction stays clear of the
+    # one recognized relation, but a gap the source leaves empty joins its
+    # panels by juxtaposition and nothing else, so a contraction has to name
+    # it -- and the panel behind the unnamed gap carries the mismatch.
+    gap_partition_source = (
+        "\\begin{tenkzeq}[check={signature}]\n"
+        f"{PANELS[0]}=\n{PANELS[1]}{PANELS[0]}{PANELS[1]}"
+        "\\end{tenkzeq}\n"
+    )
+    gap_partition = audit_rules(
+        panel(1, "open:w") + panel(2, "open:w") + panel(3, "open:e")
+        + panel(4, "phys:up")
+        + "check|scope=1|product=2-3|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n"
+        "check|scope=1|relation=2|result=equal|signature=open:w\n",
+        gap_partition_source,
+    )
+    assert ("eq-unchecked", "HARD") in gap_partition, gap_partition
+    assert ("eq-boundary-mismatch", "HARD") in gap_partition, gap_partition
+
+    # The same display with a contraction on each juxtaposed gap closes.
+    gap_partition_whole = audit_rules(
+        panel(1, "open:w") + panel(2, "open:w") + panel(3, "open:e")
+        + panel(4, "open:w")
+        + "check|scope=1|product=2-3|result=contracted|signature=open:w\n"
+        "check|scope=1|product=3-4|result=contracted|signature=open:w\n"
+        "check|scope=1|relation=1|result=equal|signature=open:w\n",
+        gap_partition_source,
+    )
+    assert not gap_partition_whole, gap_partition_whole
+
     # A spaced environment name opens the same equation, so its declared
     # waiver is the source's and not a forgery.
     spaced = audit_rules(
@@ -395,7 +427,7 @@ def main() -> int:
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 26 seeded group checks passed"
+        "and 28 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_kernel_audit.py
+++ b/scripts/test_tenkz_kernel_audit.py
@@ -21,6 +21,10 @@ string|id=b|kind=open|pts=2
 string|id=c|kind=wind|pts=2
 string|id=d|kind=around|pts=2
 stringcross|under=b|over=a|hits=1
+picture|id=k2|lang=kernel|scope=1
+atom|id=atom-2|cell=1-2|kind=tn
+mark|id=mark-4|form=label
+kernel-boundary|signature=open:e, open:w
 check|scope=1|relation=1|result=equal|signature=open:e, open:w
 """
 
@@ -43,6 +47,7 @@ def audit_log(log: str, source: str | None = None) -> Audit:
         audit.check_kernel_checks()
         audit.check_bbox_coverage()
         audit.check_label_overlaps()
+        audit.check_equation_groups()
         audit.check_equation_boundaries()
         return audit
 
@@ -80,10 +85,15 @@ def main() -> int:
         GOOD_LOG + tree_event,
         r"\tntree{(a\,b)_c}"
         "\n"
+        r"\begin{tenkz}[rows={wire}]\tn{}\end{tenkz}"
+        "\n"
         r"\begin{tenkz}[rows={wire}]\tn{}\end{tenkz}",
     )
     assert mixed_tree.tex_linked
-    assert [construct.name for construct in mixed_tree.constructs] == ["tenkz"]
+    assert [construct.name for construct in mixed_tree.constructs] == [
+        "tenkz",
+        "tenkz",
+    ]
     assert not {
         finding.rule for finding in mixed_tree.findings
     } & {"stale-log", "tex-unlinked"}
@@ -176,10 +186,10 @@ kernel-boundary|signature=phys:up
     equation = audit_log(equation_log, equation_source)
     equation_mismatches = [
         finding for finding in equation.findings
-        if finding.rule == "eq-boundary-mismatch"
+        if finding.rule == "eq-sibling-mismatch"
     ]
     assert len(equation_mismatches) == 1, equation.findings
-    assert equation_mismatches[0].severity == "HARD", equation_mismatches
+    assert equation_mismatches[0].severity == "ADV", equation_mismatches
 
     matching_physical_equation = audit_log(
         equation_log.replace(
@@ -188,7 +198,7 @@ kernel-boundary|signature=phys:up
         ),
         equation_source,
     )
-    assert "eq-boundary-mismatch" not in [
+    assert "eq-sibling-mismatch" not in [
         finding.rule for finding in matching_physical_equation.findings
     ]
 
@@ -196,7 +206,7 @@ kernel-boundary|signature=phys:up
         equation_log.replace("open:w", "edge:n").replace("phys:up", "edge:e"),
         equation_source,
     )
-    assert "eq-boundary-mismatch" not in [
+    assert "eq-sibling-mismatch" not in [
         finding.rule for finding in rotated_open_equation.findings
     ]
 
@@ -204,7 +214,7 @@ kernel-boundary|signature=phys:up
         equation_log.replace("phys:up", "edge:e"),
         equation_source,
     )
-    assert "eq-boundary-mismatch" not in [
+    assert "eq-sibling-mismatch" not in [
         finding.rule for finding in mixed_virtual_equation.findings
     ]
 
@@ -216,10 +226,10 @@ kernel-boundary|signature=phys:up
     )
     weighted_mismatches = [
         finding for finding in weighted_open_equation.findings
-        if finding.rule == "eq-boundary-mismatch"
+        if finding.rule == "eq-sibling-mismatch"
     ]
     assert len(weighted_mismatches) == 1, weighted_open_equation.findings
-    assert weighted_mismatches[0].severity == "HARD", weighted_mismatches
+    assert weighted_mismatches[0].severity == "ADV", weighted_mismatches
 
     equivalent_bundle_equation = audit_log(
         equation_log.replace("open:w", "edge:n:bundle=3").replace(
@@ -227,7 +237,7 @@ kernel-boundary|signature=phys:up
         ),
         equation_source,
     )
-    assert "eq-boundary-mismatch" not in [
+    assert "eq-sibling-mismatch" not in [
         finding.rule for finding in equivalent_bundle_equation.findings
     ]
 
@@ -237,7 +247,7 @@ kernel-boundary|signature=phys:up
         ),
         equation_source,
     )
-    assert "eq-boundary-mismatch" in [
+    assert "eq-sibling-mismatch" in [
         finding.rule for finding in different_bundle_equation.findings
     ]
 
@@ -250,9 +260,12 @@ kernel-boundary|signature=phys:up
     )
     checked_equation_log = (
         equation_log.replace("|lang=kernel", "|lang=kernel|scope=1")
-        .replace("open:w", "edge:w:bundle=3")
-        .replace("phys:up", "open:e")
-        + "check|scope=1|relation=1|result=equal|modulo=bundles|signature=edge:e\n"
+        .replace("kernel-boundary|signature=open:w",
+                 "kernel-boundary|signature=edge:w:bundle=3")
+        .replace("kernel-boundary|signature=phys:up",
+                 "kernel-boundary|signature=open:e, open:e, open:e")
+        + "check|scope=1|relation=1|result=equal|modulo=bundles"
+          "|signature=edge:e, edge:e, edge:e\n"
     )
     checked_equation = audit_log(checked_equation_log, checked_equation_source)
     assert "eq-boundary-mismatch" not in [
@@ -374,7 +387,9 @@ kernel-boundary|signature=phys:up
         finding.rule for finding in invalid_picture_scope.findings
     ]
     assert "malformed-event" in invalid_picture_rules
-    assert "eq-boundary-mismatch" in invalid_picture_rules
+    # The surviving panels land in two different scopes, so neither scope
+    # closes its arithmetic and the group is read as unchecked.
+    assert "eq-unchecked" in invalid_picture_rules
 
     for picture_reference in ("oops", "k1"):
         picture_owned_check = audit_log(

--- a/scripts/test_tenkz_kernel_audit.py
+++ b/scripts/test_tenkz_kernel_audit.py
@@ -304,7 +304,10 @@ kernel-boundary|signature=phys:up
             "check={signature, off={1: documented}}",
         ),
     )
-    assert "eq-boundary-mismatch" in [
+    # The scope holds one relation gap, so a second relation record is one
+    # joiner too many and the group is unchecked; the waiver the source does
+    # declare still stands over the pair it names.
+    assert "eq-unchecked" in [
         finding.rule for finding in surplus_opt_out.findings
     ]
 
@@ -317,7 +320,10 @@ kernel-boundary|signature=phys:up
             "check={signature, off={1: documented}}",
         ),
     )
-    assert "eq-boundary-mismatch" in [
+    # The scope holds one relation gap, so a second relation record is one
+    # joiner too many and the group is unchecked; the waiver the source does
+    # declare still stands over the pair it names.
+    assert "eq-unchecked" in [
         finding.rule for finding in duplicate_opt_out.findings
     ]
 

--- a/scripts/test_tenkz_label_overlap.py
+++ b/scripts/test_tenkz_label_overlap.py
@@ -31,7 +31,7 @@ SOURCE = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \pagestyle{empty}
@@ -219,7 +219,7 @@ AFFINE_GLYPHS = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \pagestyle{empty}
@@ -270,7 +270,7 @@ INVALID_CORNERS = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \pagestyle{empty}
@@ -288,7 +288,7 @@ ROUNDED_TRIANGLE = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -304,7 +304,7 @@ OVERSIZED_OUTER_SEP = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -321,7 +321,7 @@ INACTIVE_SNAPSHOT = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \pagestyle{empty}
@@ -342,7 +342,7 @@ TRANSFORMED_RECT = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -358,7 +358,7 @@ TRANSFORMED_CIRCLE = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -374,7 +374,7 @@ TRANSFORMED_TRIANGLE = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -390,7 +390,7 @@ TRANSFORMED_LABEL = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -405,7 +405,7 @@ DRAW_ONLY_GLYPH = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -421,7 +421,7 @@ NONRECTANGLE_LABEL = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -436,7 +436,7 @@ NONAUDITED_CUSTOMIZATION = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \usetikzlibrary{fadings}
@@ -453,7 +453,7 @@ NESTED_END_HOOK = r"""
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 \begin{document}
@@ -490,7 +490,7 @@ def customized_glyph(options: str, preamble: str = "") -> str:
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 %s
@@ -509,7 +509,7 @@ def customized_label(options: str, preamble: str = "") -> str:
 \usepackage{tenkz}
 \makeatletter
 \newenvironment{tenkztestcanvas}
-  {\tenkz@beginpicture{kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
+  {\global\advance\tenkz@pictureid by 1\relax\tenkz@auditpicturetrue\def\tenkz@auditpictureid{\the\tenkz@pictureid}\tenkz@event{picture|id=\the\tenkz@pictureid|lang=kernel}\tenkz@event{atom|picture=\the\tenkz@pictureid|cell=1-1|kind=dot}\tenkz@event{kernel-boundary|picture=\the\tenkz@pictureid|signature=}\begin{tikzpicture}[tenkz every picture]}
   {\end{tikzpicture}}
 \makeatother
 %s

--- a/tests/tenkz/kernel/negative/n_virtual_dir_mismatch.tex
+++ b/tests/tenkz/kernel/negative/n_virtual_dir_mismatch.tex
@@ -1,0 +1,20 @@
+% Negative: a virtual index leaving one panel cannot equal one entering the
+% other.  A directed bond names a space; the reversed arrow names its dual,
+% and the two sides of a relation must agree on orientation and not merely
+% on the count of open legs.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkzeq}[check={signature}]
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+    \tn[at=(1,1), name=A, ports={0:virtual}]{A}
+    \tnwire[dir=to]{A.0}{open e}
+  \end{tenkz}
+  =
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+    \tn[at=(1,1), name=B, ports={0:virtual}]{B}
+    \tnwire[dir=from]{B.0}{open e}
+  \end{tenkz}
+\end{tenkzeq}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_bundle_dir_modulo.tex
+++ b/tests/tenkz/kernel/regression/r_bundle_dir_modulo.tex
@@ -1,0 +1,25 @@
+% Regression: a directed bundle keeps its multiplicity.  The orientation of
+% a directed open end follows the face and precedes the strand weight, so the
+% bundle stays the entry's last field and `modulo=bundles' expands a directed
+% bundle into that many equivalently oriented single strands.  Writing the
+% orientation last instead made the equation below refuse.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkzeq}[check={signature, modulo=bundles}]
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+    \tn[at=(1,1), name=A, ports={0:virtual}]{A}
+    \tnwire[dir=to, weight=bundle=3]{A.0}{open e}
+  \end{tenkz}
+  =
+  \begin{tenkz}[rows={wire,wire,wire}, cols=1, bonds=none]
+    \tn[at=(1,1), name=B, ports={0:virtual}]{B}
+    \tn[at=(2,1), name=C, ports={0:virtual}]{C}
+    \tn[at=(3,1), name=D, ports={0:virtual}]{D}
+    \tnwire[dir=to]{B.0}{open e}
+    \tnwire[dir=to]{C.0}{open e}
+    \tnwire[dir=to]{D.0}{open e}
+  \end{tenkz}
+\end{tenkzeq}
+\end{document}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-pulling-through.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-pulling-through.tex
@@ -6,10 +6,16 @@
 % Source: paper TN-Review-main.tex line 1356; author source ImagesReview Section
 %   III/ImagesReview Section III.tex lines 170-197
 % Capabilities: kernel, pulling-through, rotated-action, ring-closure
+% Signature: the source panel gives each segment the arrowhead of the tensor
+%   that claims it, so a leg that a pulled-through string passes carries no
+%   drawn orientation on its outer half.  The two sides therefore state
+%   their directed plaquette legs on opposite faces, and the relation is
+%   opted out by name rather than decorated with arrowheads the author
+%   never drew.
 \[
   \tenkzkernel
   \tndeclare{species}{op}{hue=source:red}
-  \begin{tenkzeq}
+  \begin{tenkzeq}[check={signature, off={1: the source marks each segment per tensor}}]
     \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5, bonds=none]
       % the plaquette ring: four MPO tensors joined by the red ring, with
       % the lambda insertion on the north-west ring wire

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-diagram-three.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-diagram-three.tex
@@ -6,10 +6,16 @@
 % Source: author source ImagesReview Section III/ImagesReview Section III.tex
 %   lines 170-197; archival output Dia3.pdf
 % Capabilities: kernel, rotated-action, ring-closure
+% Signature: the source panel gives each segment the arrowhead of the tensor
+%   that claims it, so a leg that a pulled-through string passes carries no
+%   drawn orientation on its outer half.  The two sides therefore state
+%   their directed plaquette legs on opposite faces, and the relation is
+%   opted out by name rather than decorated with arrowheads the author
+%   never drew.
 \[
   \tenkzkernel
   \tndeclare{species}{op}{hue=source:red}
-  \begin{tenkzeq}
+  \begin{tenkzeq}[check={signature, off={1: the source marks each segment per tensor}}]
     \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5, bonds=none]
       % the plaquette ring: four MPO tensors joined by the red ring, with
       % the lambda insertion on the north-west ring wire

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -559,11 +559,11 @@ status = "faithful"
 pairing = "verified"
 pairing_by = "site-glyph-source-review-2026-07-27"
 defects = []
-case_sha256 = "df473749edab188356d41e30f67b8765e7a8841d02797240324d96314c181138"
+case_sha256 = "a4f2e10685507dbe6528a21f2f214767ca1f4eed15a4900ff29a8a8c7d340f37"
 reviewed = "2026-08-05"
 renderer = "fable-w7-crossings-vision-review-2026-08-05-200dpi"
 second_viewer = "fable-w7-crossings-recheck-2026-08-05-400dpi"
-note = "Kernel respell of eq50redarrows: the red ring closes through all four tensors with lambda on the north-west ring wire, both action tensors ride the north/west then south/east legs with the joining string and both free string ends, and all six direction marks match the source flow; the diamond ring, straight action chord, and stadium lambda are the house forms for the source's rounded curves."
+note = "Kernel respell of eq50redarrows: the red ring closes through all four tensors with lambda on the north-west ring wire, both action tensors ride the north/west then south/east legs with the joining string and both free string ends, and all six direction marks match the source flow; the diamond ring, straight action chord, and stadium lambda are the house forms for the source's rounded curves. The equation now names its opt-out: with directed open ends in the boundary signature the two sides state their plaquette legs on opposite faces, which is the source panel's own decoration rule (each segment carries the arrowhead of the tensor that claims it) and not a difference of type; the rendered ink is byte-identical at 300 dpi to the reviewed panel."
 
 [[verdict]]
 id = "rmp-iii-a-commuting-hamiltonian"
@@ -1269,11 +1269,11 @@ status = "faithful"
 pairing = "verified"
 pairing_by = "site-glyph-source-review-2026-07-27"
 defects = []
-case_sha256 = "a2feb5daecfbbb1d406197c1417a97a6651c0c5d9b2e2c812f4cf4c11d840b13"
+case_sha256 = "b839d24857d91ded0de88a14c7d428711a578b756a3c21f61952db87e490eb7a"
 reviewed = "2026-08-05"
 renderer = "fable-w7-crossings-vision-review-2026-08-05-200dpi"
 second_viewer = "fable-w7-crossings-recheck-2026-08-05-400dpi"
-note = "Body now equals the pulling-through respell of the same author lines (Dia3.pdf): the earlier kernel-free body relocated lambda and omitted the two boundary action tensors and their joining string; both panels now carry the full rotated action pair, and the per-edge direction marks the K1 residue named draw from dir= on each leg."
+note = "Body now equals the pulling-through respell of the same author lines (Dia3.pdf): the earlier kernel-free body relocated lambda and omitted the two boundary action tensors and their joining string; both panels now carry the full rotated action pair, and the per-edge direction marks the K1 residue named draw from dir= on each leg. The equation now names its opt-out: with directed open ends in the boundary signature the two sides state their plaquette legs on opposite faces, which is the source panel's own decoration rule (each segment carries the arrowhead of the tensor that claims it) and not a difference of type; the rendered ink is byte-identical at 300 dpi to the reviewed panel."
 
 [[verdict]]
 id = "rmp-workbench-iii-historical-composite"

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -367,16 +367,14 @@
 % ---------- event stream (v2, minimal Phase-0 writer) ----------
 \newwrite\tenkz@log
 \newif\iftenkz@logopen
-% Two registers, two jobs.  \tenkz@pictureuid is the GLOBAL uniqueness
-% counter: it only ever grows, so every picture's id is fresh.
-% \tenkz@pictureid is the EMITTING context: it is assigned LOCALLY at each
-% picture's begin (every begin site sits inside its picture's group), so
-% closing the group RESTORES the enclosing picture's id -- a nested picture
-% inside another picture's cell must not steal the parent's later events,
-% and back in running prose the register reverts to 0, which is how
-% a bare \tntree logs picture=0.
+% One writer, one emitting context.  The picture surface owns its own
+% identity and hands it to the shared renderer as \tenkz@auditpictureid,
+% assigned LOCALLY inside the picture's group so that closing the group
+% RESTORES the enclosing picture's id -- a nested picture inside another
+% picture's cell must not steal the parent's later events.  Back in running
+% prose \tenkz@pictureid is the identity of no picture, which is how a bare
+% \tntree logs picture=0.
 \newcount\tenkz@pictureid
-\newcount\tenkz@pictureuid
 \newif\iftenkz@auditpicture
 \tenkz@auditpicturefalse
 \def\tenkz@auditpictureid{\the\tenkz@pictureid}
@@ -384,13 +382,6 @@
 \AtEndDocument{\iftenkz@logopen\immediate\closeout\tenkz@log\fi}
 \def\tenkz@event#1{\iftenkz@logopen
   \immediate\write\tenkz@log{#1}\fi}
-\def\tenkz@picturelang{none}
-\def\tenkz@beginpicture#1{\global\advance\tenkz@pictureuid by 1\relax
-  \tenkz@pictureid=\tenkz@pictureuid
-  \tenkz@auditpicturetrue
-  \def\tenkz@auditpictureid{\the\tenkz@pictureid}%
-  \def\tenkz@picturelang{#1}%
-  \tenkz@event{picture|id=\the\tenkz@pictureid|lang=#1}}
 
 % Measured audit geometry.  Coordinates are written as integer scaled points,
 % so the event stream is independent of locale and TeX's decimal formatting.

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1559,13 +1559,39 @@
 % ---------- boundary signatures --------------------------------------------------------
 % The signature of a panel is the sorted multiset of its exposed indices:
 % one entry per open wire end and one per outward physical port.  tenkzeq
-% compares adjacent panels and errors on mismatch.  A directed physical open
-% end carries its orientation: the entry says whether the index leaves the
-% panel (to) or enters it (from), so a space and its dual cannot pass for one
-% another.  An internal directed contraction exposes nothing and leaves no
-% entry.
+% compares adjacent panels and errors on mismatch.  A directed open end,
+% virtual or physical, carries its orientation: the entry says whether the
+% index leaves the panel (to) or enters it (from), so a space and its dual
+% cannot pass for one another and two sides of a relation must agree on
+% orientation and not merely on count.  An internal directed contraction
+% exposes nothing and leaves no entry.  The orientation is the entry's last
+% field; a port and a policy leg declare no direction, so only a wire end
+% carries one.
 
 \tl_new:N \l__tenkz_kernel_sig_dir_tl
+\tl_new:N \l__tenkz_kernel_sig_dir_src_tl
+
+% The orientation of a directed index at the end being described, normalized
+% to the cut: the barb ends at this end (to, the index leaves the panel) or
+% at the other end (from, the index enters it).  #1 is the wire record, #2
+% the end (`from' or `to'); an undirected wire yields the empty suffix.
+\cs_new_protected:Npn \__tenkz_kernel_signature_dir:nnN #1#2#3
+  {
+    \tl_clear:N #3
+    \__tenkz_model_get:nnN {#1} {dir} \l__tenkz_kernel_sig_dir_src_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_sig_dir_src_tl
+      {
+        \str_if_eq:VnF \l__tenkz_kernel_sig_dir_src_tl {none}
+          {
+            \tl_set:Ne #3
+              {
+                :
+                \str_if_eq:VnTF \l__tenkz_kernel_sig_dir_src_tl {#2}
+                  {to} {from}
+              }
+          }
+      }
+  }
 
 \cs_new_protected:Npn \__tenkz_kernel_bearing_normalize:nN #1#2
   {
@@ -1723,37 +1749,25 @@
                     \__tenkz_model_get:nnN
                       {##1} {####1-open-type}
                       \l__tenkz_kernel_port_type_tl
-                    % The orientation of a directed physical index is part of
-                    % the exposed entry, normalized to the cut: the barb ends
-                    % at this end (to, the index leaves) or at the other end
-                    % (from, the index enters).
-                    \tl_clear:N \l__tenkz_kernel_sig_dir_tl
-                    \str_if_eq:VnT \l__tenkz_kernel_port_type_tl {physical}
-                      {
-                        \__tenkz_model_get:nnN {##1} {dir} \l_tmpa_tl
-                        \quark_if_no_value:NF \l_tmpa_tl
-                          {
-                            \str_if_eq:VnF \l_tmpa_tl {none}
-                              {
-                                \tl_set:Ne \l__tenkz_kernel_sig_dir_tl
-                                  {
-                                    :
-                                    \str_if_eq:VnTF \l_tmpa_tl {####1}
-                                      {to} {from}
-                                  }
-                              }
-                          }
-                      }
+                    % The orientation of a directed index is part of the
+                    % exposed entry whether the index is virtual or physical:
+                    % a directed virtual leg states the bond space against
+                    % its dual exactly as a directed physical leg does.
+                    % A physical index carries no strand weight, so the
+                    % orientation is the third field there and the fourth
+                    % beside a weight.
+                    \__tenkz_kernel_signature_dir:nnN {##1} {####1}
+                      \l__tenkz_kernel_sig_dir_tl
                     \seq_put_right:Ne \l__tenkz_kernel_emit_seq
                       {
                         \str_if_eq:VnTF
                           \l__tenkz_kernel_port_type_tl {physical}
                           {phys}{open}
                         : \tl_use:N \l__tenkz_kernel_scratch_tl
-                        \str_if_eq:VnTF
+                        \str_if_eq:VnF
                           \l__tenkz_kernel_port_type_tl {physical}
-                          { \tl_use:N \l__tenkz_kernel_sig_dir_tl }
                           { \tl_use:N \l_tmpb_tl }
+                        \tl_use:N \l__tenkz_kernel_sig_dir_tl
                       }
                   }
               }
@@ -1766,11 +1780,14 @@
                   {
                     \str_if_eq:VnT \l_tmpa_tl {outside}
                       {
+                        \__tenkz_kernel_signature_dir:nnN {##1} {####1}
+                          \l__tenkz_kernel_sig_dir_tl
                         \seq_put_right:Ne \l__tenkz_kernel_emit_seq
                           {
                             edge: \prop_item:Ne \l__tenkz_kernel_node_prop
                               { \l__tenkz_kernel_scratch_tl / side }
                             \tl_use:N \l_tmpb_tl
+                            \tl_use:N \l__tenkz_kernel_sig_dir_tl
                           }
                       }
                   }

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1564,9 +1564,10 @@
 % index leaves the panel (to) or enters it (from), so a space and its dual
 % cannot pass for one another and two sides of a relation must agree on
 % orientation and not merely on count.  An internal directed contraction
-% exposes nothing and leaves no entry.  The orientation is the entry's last
-% field; a port and a policy leg declare no direction, so only a wire end
-% carries one.
+% exposes nothing and leaves no entry.  The orientation follows the face and
+% precedes the strand weight, which stays the entry's last field so that a
+% bundle expands to its multiplicity whichever way it points; a port and a
+% policy leg declare no direction, so only a wire end carries one.
 
 \tl_new:N \l__tenkz_kernel_sig_dir_tl
 \tl_new:N \l__tenkz_kernel_sig_dir_src_tl
@@ -1753,9 +1754,10 @@
                     % exposed entry whether the index is virtual or physical:
                     % a directed virtual leg states the bond space against
                     % its dual exactly as a directed physical leg does.
-                    % A physical index carries no strand weight, so the
-                    % orientation is the third field there and the fourth
-                    % beside a weight.
+                    % The orientation follows the face and precedes any
+                    % strand weight, so a bundle stays the entry's last
+                    % field and a directed bundle still expands to its own
+                    % multiplicity.
                     \__tenkz_kernel_signature_dir:nnN {##1} {####1}
                       \l__tenkz_kernel_sig_dir_tl
                     \seq_put_right:Ne \l__tenkz_kernel_emit_seq
@@ -1764,10 +1766,10 @@
                           \l__tenkz_kernel_port_type_tl {physical}
                           {phys}{open}
                         : \tl_use:N \l__tenkz_kernel_scratch_tl
+                        \tl_use:N \l__tenkz_kernel_sig_dir_tl
                         \str_if_eq:VnF
                           \l__tenkz_kernel_port_type_tl {physical}
                           { \tl_use:N \l_tmpb_tl }
-                        \tl_use:N \l__tenkz_kernel_sig_dir_tl
                       }
                   }
               }
@@ -1786,8 +1788,8 @@
                           {
                             edge: \prop_item:Ne \l__tenkz_kernel_node_prop
                               { \l__tenkz_kernel_scratch_tl / side }
-                            \tl_use:N \l_tmpb_tl
                             \tl_use:N \l__tenkz_kernel_sig_dir_tl
+                            \tl_use:N \l_tmpb_tl
                           }
                       }
                   }


### PR DESCRIPTION
A diagram whose boundary signature is checked is the graphical analogue of a term that typechecks. This makes the check enforceable: it names the group, hardens the finding inside it, gives a directed index its orientation, and runs the whole thing wherever a picture compiles.

## The grouping decision (DESIGN.md, "Equation grouping")

**`tenkzeq` is the mechanism.** The environment writes its scope number into every panel's `picture` record and one `check` record per joiner, so a reader of the stream alone knows which pictures an author asserted equal and which comparisons ran. That is what makes the group enforceable without a source file or a heuristic.

Two alternatives are recorded as rejected:

- **A shared `equation=<id>` picture key** separates the assertion from the thing asserted. The claim is made by the relation glyph standing between two panels; an identifier repeated on scattered pictures restates it where it can go stale, contradict the typeset mathematics, or group panels no reader sees side by side. It also gives one concept two spellings, and it cannot express the product joiner at all — an identifier says which pictures belong together, not in which order they contract.
- **Automatic grouping of consecutive pictures in one display, inferred from event order**, is rejected because the stream records no displays. A picture's position is the order TeX shipped it, which merges the panels of a display with pictures from prose, a float, a footnote, and the same paragraph. Recovering the display means parsing the source beside the log and guessing which separator is a relation — exactly the heuristic that made the old sibling check advisory. Inference cannot be made hard, because the author declared nothing for it to be hard about.

## Enforcement

`check_equation_groups` reads the group from the stream and runs with no source:

- **`eq-boundary-mismatch` (HARD)** — two panels of one group expose different open-leg classes. The audit compares the panels' own boundary records whatever the kernel's verdict said, so a stream whose comparison never ran is caught rather than trusted. Only the page face is dropped; kind, weight, and orientation must agree.
- **`eq-unchecked` (HARD)** — the group's arithmetic does not close (relations plus contractions plus one equals panels), so some panel never folded into a compared side. A group that fails this is read as unchecked and its panels are compared pair by pair with no waiver honoured.
- **`eq-check-off`** — a waiver is never silent. Declared in the source, it is reported as an advisory with its reason; present in the stream but absent from the source, it is a hard finding and retires nothing.
- **`eq-sibling-mismatch` (ADV)** — two pictures on a bare source `=` outside every group. Not a defect in the diagram: a pair still to be moved into the scope.

The source-authorization guarantee the old delegation path carried is kept: with a linked source only the environment's own `check={off={k: reason}}` authorizes a waiver.

## Directed signatures (#4183 judgment)

`dir=` enters the boundary signature for **virtual** indices as well as physical ones — the judgment's case is a space against its dual, which is a bond index. The orientation is the entry's last field, normalized to the cut: `to` when the index leaves the panel, `from` when it enters. Ports and policy legs declare no direction and are untouched, so no existing stream moved a byte. `LANGUAGE-1.0` §2.4 states the amended reading.

## Seeded defects

- `n_virtual_dir_mismatch` — a virtual index leaving one panel against one entering the other; refused with `TKZ-EQ-SIGNATURE`, wired into the kernel probes' contract-negative list.
- `r_dir_open_bearings` gains signature assertions pinning that the departing panel's four legs leave and the arriving panel's four enter.
- `test_tenkz_equation_audit.py` is rewritten around eight seeded group streams: unequal boundaries, equal counts with opposite orientations, a clean group, an unfolded panel, a declared waiver, a forged waiver, and the kernel's own refusal. The clean corpus still passes.

## Blueprint sweep

`scripts/tenkz_blueprint_sweep.py` walks the blueprint sources, asks the web pipeline for each picture's event stream, and audits all of them, naming the chapter file and line rather than a content hash. **202 pictures, one catch:**

| figure | finding | disposition |
|---|---|---|
| `ch12_symmetry_string_order.tex:77` (stationary-boundary block-twist functional, `0802.0447` lines 380–385) | HARD `label-overlap`: the first rung operator's name lands on the Λ bead riding the west cup's bend | The three rung operators name themselves to the east. Dropping the pin instead is worse — the station rule then puts all three names on the conjugate row's glyphs. |

The RMP corpus is audited by the same rules and the directed signature caught a real pair there too:

| target | finding | disposition |
|---|---|---|
| `rmp-iii-a-pulling-through` and `rmp-workbench-iii-diagram-three` (`2011.12127` eq. 50, `fig3_fig3-pepe_eq50redarrows.pdf`) | `TKZ-EQ-SIGNATURE`: the two sides state their directed plaquette legs on opposite faces with opposite orientation | Read against the author panel at 300 dpi: the source gives each segment the arrowhead of the tensor that claims it, so a leg a pulled-through string passes carries no drawn orientation on its outer half. The relation takes a named opt-out rather than arrowheads the author never drew; both verdicts stay `faithful` and the ink is byte-identical at 300 dpi to the reviewed panels. |

The blueprint's own equations are **not** in scope: its 33 diagrammatic displays sit in `tenkzequation`, a presentational wrapper, so none has ever had its sides compared. That migration is LionSR/TNLean#5693, with the 33 displays classified there.

## CI

- Blueprint job: the sweep runs after `leanblueprint web`, when every stream is already cached.
- Corpus job: the seeded group defects run beside the corpus, which already audits every fixture and every RMP target through the same rules.

## The LionSR/TNLean#4158 gate over the event-stream layer

Run over every `\tenkz@event` emitter at once for the first time; recorded in the `SHRINK.md` session of 2026-08-08. Five files write events, one writer, one late-bound name the kernel rebinds to suppress a measuring pass — the indirection earns its place. The gate found one dead limb: `\tenkz@beginpicture`, the dialect era's picture opener, has had no caller since the surface swap; its global counter and language variable go with it, and the label-overlap harness states the four lines it needs itself. Every golden stream is byte-identical across the deletion, which is the proof the limb was dead. The geometry probe keeps its unschematized kind: three fixtures, no production caller, and the audit's unknown-kind advisory is the correct reading.

## Gates

All run on the final tree after rebase onto current main.

- `scripts/tenkz_kernel_probes.sh --check` — 142 review regressions, 11 sugar pairs, 12 kernel record streams and pixels byte-identical
- `scripts/tenkz_golden.sh --check` — 9 event streams byte-identical
- `python3 scripts/tenkz_rmp.py check --all` — 130 targets; verdicts 90 faithful / 40 cosmetic-gap / 0 blocked; pairing 120 verified / 10 context-only
- `scripts/tenkz_corpus.sh`, `scripts/tenkz_string_probes.sh` (30 artifacts byte-identical)
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — census stable at 86, all 60 flags carry verdicts
- `python3 scripts/check_tenkz_dispositions.py` and its self-test — 202 blueprint occurrences reconcile
- `python3 scripts/tenkz_manual_doctest.py` plus a two-pass manual build and audit
- `python3 scripts/tenkz_blueprint_sweep.py` — 202 pictures, 0 hard, 0 advisories
- `test_tenkz_equation_audit.py`, `test_tenkz_kernel_audit.py`, `test_tnlog.py`, `test_texcase.py`, `test_tenkz_label_overlap.py`, `test_tenkz_index_routing.py`, `test_tenkz_tree.py`, `test_tenkz_peps_torus.py`, `test_tenkz_pic.py`, `test_tenkz_dimension_inventory.py`, `tenkz_lint.py` (275 files, 0 findings)
- Same-session pixel pair against a detached `origin/main` build: both re-verdicted RMP panels byte-identical at 300 dpi

Closes LionSR/tenkz#27. Tracker: LionSR/tenkz#13. Follow-up: LionSR/TNLean#5693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tenkz audit semantics (hard vs advisory), kernel boundary signatures, and CI gates over all blueprint/RMP figures; localized TeX fixes and opt-outs limit user-facing breakage outside diagram equations.
> 
> **Overview**
> **tenkzeq** is now the enforceable equation unit: panels carry `scope=` in the event stream and one `check` record per joiner, so **`check_equation_groups`** can hard-fail mismatched open-leg classes, incomplete group arithmetic, and stream/source check-policy drift. Bare source `=` pairs outside any group stay **advisory** (`eq-sibling-mismatch` / `eq-sibling-unread`).
> 
> Directed indices (**virtual and physical**) enter boundary signatures with orientation before strand weight (`to`/`from`), enabling bundle expansion under `modulo=bundles` and new regression/negative fixtures.
> 
> **`tenkz_blueprint_sweep.py`** audits every blueprint picture’s cached `.tnlog` (display-sized units, not isolated panels), wired into CI after the web build. **`tenkz_pic`** exposes `unit_event_log` and drops partial `.tnlog` on failed compile/convert.
> 
> Kernel removes dead `\tenkz@beginpicture`; label-overlap harness emits `picture` records directly. RMP pulling-through cases opt out signature checks with documented reasons; ch12 rung operator labels move east to avoid overlap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 857263332f137d3daa04551888d2860cb3db170b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->