### PR TITLE
feat(tenkz): build the release-policy activation slice

### DIFF
--- a/.github/workflows/tenkz-release-policy.yml
+++ b/.github/workflows/tenkz-release-policy.yml
@@ -37,12 +37,12 @@ jobs:
     name: Check tenkz release harness and inventory
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tenkz-release-policy.yml
+++ b/.github/workflows/tenkz-release-policy.yml
@@ -1,0 +1,62 @@
+name: Tenkz Release Policy
+
+# The enforcement workflow named by `docs/tenkz/DESIGN.md`'s
+# `release_enforcement_workflows`. While enforcement is pending it checks the
+# release-test contract on every change: the supervisor's isolation probes, the
+# closed inventory against the pinned policy, every atomic compatibility
+# assertion, and the activation pins.
+#
+# Two mechanisms the policy requires of this workflow are absent by design
+# until the campaign is armed, and their absence is checked rather than
+# assumed. The terminal publisher job with `contents: write` and the
+# `tenkz-release-publisher` environment is added by the change that lands the
+# final-tag signing key, which cannot be committed before the maintainer
+# generates it; `tests/tenkz/release-support/README.md` records that step.
+# Network denial before repository code runs likewise belongs to the armed
+# shape. `check-readiness` fails closed if the pinned policy ever says `armed`
+# while those artifacts are missing, so an activation that skipped them cannot
+# go green here.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  release-payload:
+    name: Check tenkz release harness and inventory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Run the supervisor isolation probes
+        run: python3 tests/tenkz/release-harness/selftest.py
+
+      - name: Check the closed release-test inventory
+        run: python3 tests/tenkz/release-harness/supervisor.py check-inventory
+
+      - name: Run every atomic release assertion
+        run: python3 tests/tenkz/release-harness/supervisor.py run-all
+
+      - name: Check what the enforcement state permits
+        run: python3 tests/tenkz/release-harness/supervisor.py check-readiness
+
+      - name: Report the activation pins
+        run: python3 tests/tenkz/release-harness/supervisor.py pins

--- a/docs/tenkz/CHANGES.md
+++ b/docs/tenkz/CHANGES.md
@@ -11,13 +11,20 @@ fell from 201 public rows to 86 and the parser-path count from 228 to 75; the
 escape ledger, which prices every occurrence of a spelling the core grammar
 cannot say, reached zero.
 
-The spellings below are removed outright. 1.0 is a major release and keeps no
-alias, compatibility reader, or dual writer for any of them: an old spelling
-stops the run with an unknown-key or unknown-command error naming the
-vocabulary, and nothing is silently reinterpreted. Every documented replacement
-was applied to the blueprint corpus and the 130-case benchmark before its front
-end was deleted, and each deletion carried the fixtures whose language died —
-the regression corpus went from 264 sources to 9.
+The spellings below are removed outright, with one stated exception. 1.0 is a
+major release and keeps no alias, compatibility reader, or dual writer for any
+of them: an old spelling stops the run with an unknown-key or unknown-command
+error naming the vocabulary, and nothing is silently reinterpreted. Every
+documented replacement was applied to the blueprint corpus and the 130-case
+benchmark before its front end was deleted, and each deletion carried the
+fixtures whose language died — the regression corpus went from 264 sources
+to 9.
+
+The exception is `\tenkzkernel`. It is not removed: it is inert for the whole
+1.0 series and carries a registry sunset, because the kernel it used to switch
+on is now bound at package load, so a document that still writes it asks for
+what it already has. Delete it at leisure. Every other row below is an error
+from 1.0.0 onward.
 
 ## Retired environments
 
@@ -123,7 +130,7 @@ Spellings inside the kernel tier itself:
 | `physical=` as a picture-wide row topology | `physical=` as a per-cell port policy |
 | `\tnset{pitch=...}` in the body | `metrics=compact` |
 | hand-written leave and enter angles on a route | `crossing=` for the habit, `cross=` for the exception |
-| `\tenkzkernel` | nothing; the kernel is bound at package load |
+| `\tenkzkernel` | nothing; the kernel is bound at package load. Retained, inert, sunset — the one row above that is not an error |
 
 ## Why the front ends died
 

--- a/docs/tenkz/CHANGES.md
+++ b/docs/tenkz/CHANGES.md
@@ -1,0 +1,249 @@
+# tenkz 1.0 — the kernel is the surface
+
+0.7 drew pictures through four front ends. Five environments, seven picture
+commands, and four separate key ledgers each said the same few things in a
+private dialect: a cell, a wire, a mark, a frame. 1.0 has one environment and
+one ledger. Every picture is a kernel picture, the package binds the kernel at
+load, and the front ends are gone — 3,154 lines of commutative-diagram stage,
+4,393 of free stage, 10,500 of lattice stage, 17,340 of grid stage, retired in
+four changes that deleted 35,387 lines against 2,764 added. The registry census
+fell from 201 public rows to 86 and the parser-path count from 228 to 75; the
+escape ledger, which prices every occurrence of a spelling the core grammar
+cannot say, reached zero.
+
+The spellings below are removed outright. 1.0 is a major release and keeps no
+alias, compatibility reader, or dual writer for any of them: an old spelling
+stops the run with an unknown-key or unknown-command error naming the
+vocabulary, and nothing is silently reinterpreted. Every documented replacement
+was applied to the blueprint corpus and the 130-case benchmark before its front
+end was deleted, and each deletion carried the fixtures whose language died —
+the regression corpus went from 264 sources to 9.
+
+## Retired environments
+
+| Old | New |
+|---|---|
+| `tenkzcd` | plain `tikz-cd`; commutative diagrams are not this language |
+| `tenkzfree` | `tenkz` with addressed `\tn`, `\tnwire`, and `\tnmark` records |
+| `tenkzlattice` | `tenkz` with `lattice={RxC}`, or a declared `frame={..., basis={...}}` |
+| `tenkzplanes` | `tenkz` with the `planes` sugar row |
+| `tenkz` (0.7 grid meaning) | `tenkz` — the name survives, the meaning is the kernel picture |
+
+## Retired commands
+
+| Old | New |
+|---|---|
+| `\tnpic[k]{body}` | `\begin{tenkz}[k] body \end{tenkz}` |
+| `\tnarrow` | `\tnwire[dir=to]` |
+| `\tnput` | `\tn[at=<address>]` |
+| `\tnjoin` | `\tnwire` |
+| `\tnedge` | `\tnwire` |
+| `\tnsite` | `\tn[at=(r,c)]` |
+| `\tnregion` | `\tnmark[form=enclosure]` |
+| `\tncut` | `\tnmark[form=enclosure]` or `\tnmark[form=bracket]` |
+| `\tnspan[form]{k}{m}` | `\tnmark[form=...]{(r,c) .. (r,c+k-1)}{m}` |
+| `\tnX{m}` | `\tn[skin=ring]{m}` |
+| `\tndots` | `\tn[skin=dots]{}` |
+| `\tnskip` | `\tn[void=open]{}` |
+| `\tnghost{m}` | nothing; an address may name an empty cell |
+
+## Retired keys
+
+Commutative-diagram front end:
+
+| Old | New |
+|---|---|
+| `maps` | — |
+| `polygon=`, `radius=` | — |
+| `column sep=`, `row sep=` | — |
+| `from=`, `to=` | `\tnwire{<end>}{<end>}` |
+| `poly=k` | — |
+
+Free front end:
+
+| Old | New |
+|---|---|
+| `out=`, `in=` | `route=arc` |
+| `route=hv`, `route=vh` | `route=orth` |
+| `route=curve` | `route=arc` |
+| `drop`, `hug` | `route=orth`, `route={<side> of <selector>}` |
+| `ports=` (free object row) | `\tn[ports=...]`, the typed-port list |
+| `ring`, `circle`, `boundary` | `skin=ring`, `skin=circle`, `skin=boundary` |
+| `fused` | — |
+| `none` (connection flag) | omit the record, or `void=sealed` to remove the site |
+| `group=` | an address set |
+
+Lattice front end:
+
+| Old | New |
+|---|---|
+| `site=` | — |
+| `sheets=`, `sheet sep=` | `frame={plane, basis={...}}` |
+| `col vector=`, `row vector=`, `sheet vector=` | `frame=plane` with basis members |
+| `plane rise=`, `plane slant=`, `plane lean=` | `frame=plane` subkeys |
+| `pairing` | `pairings=` on the declared skin |
+| `outer legs=`, `boundary legs` | the side policy |
+| `label=` (object) | `\tnmark[form=label]` |
+| `size=` (object) | `size=`, the size class |
+| `removed=` | `void=sealed` |
+| `style=` (edge pass-through) | `stroke=`, or the port type |
+| `label at=` (region) | `label pos=` |
+
+Grid front end:
+
+| Old | New |
+|---|---|
+| `tensor style=` | `skin=` |
+| `up=`, `down=` | `ports=` |
+| `up at=`, `down at=`, `west at=`, `east at=`, `combined=` | the `ports=` angle and slot grammar |
+| `span=` | `wires=` |
+| `mpo` | `skin=mpo` |
+| `bond dir=` | `dir=` on the wire |
+| `bond label={$D$ at 1-2}` | `\tnmark[form=label]{<wire>}{$D$}` |
+| `label shift=` | `label pos=` |
+| `box` | `\tnmark[form=enclosure]` |
+| `brace above` | `\tnmark[form=brace-above]`, `form=brace-below` |
+| `label pos` (annotation) | `label pos=` on the mark record |
+| `layer sep=` | the metric size classes |
+| `trace style=racetrack` | — |
+| `inline`, `compact` | math-style sensing and `size=`; `metrics=compact` for a page-constrained picture |
+| `wiring=` | `pairings=` on the skin |
+| `weight=string` | `kind=string` |
+| `cluster` (as a skin) | `cluster={RxC}`, a basis sugar |
+| `enclosure` (as a skin) | `\tnmark[form=enclosure]`; a boundary operator is a wide atom |
+| `chain axis`, `legs at`, `rows`, `periodic` | `frame=`, `ports=`, `wires=`, `west=trace, east=trace` |
+| `leg <face> of <cell>`, `<compass> outside` | the generated leg's own name |
+| `(r,c)-(r,c)` | `(r,c) .. (r,c)` |
+
+Spellings inside the kernel tier itself:
+
+| Old | New |
+|---|---|
+| `outline` (mark flag) | `tint` |
+| `physical=` as a picture-wide row topology | `physical=` as a per-cell port policy |
+| `\tnset{pitch=...}` in the body | `metrics=compact` |
+| hand-written leave and enter angles on a route | `crossing=` for the habit, `cross=` for the exception |
+| `\tenkzkernel` | nothing; the kernel is bound at package load |
+
+## Why the front ends died
+
+- **One picture, one language.** The four dialects disagreed about nothing that
+  mattered. A cell was a `site`, a `tensor`, or an object with `ports`; a wire
+  was an `edge`, a `join`, an `arrow`, or a `bond`; a mark was a `region`, a
+  `cut`, a `span`, or a `box`. Each dialect then needed its own parser, its own
+  defaults, and its own renderer, and a picture that wanted two of them could
+  not be written at all. The kernel has one record for each of the three, and
+  the dialects became presets over it.
+
+- **An address, not a cursor.** `\tnput` placed a tensor where the last one
+  left off; `\tnsite` placed one at a lattice coordinate; `\tnpic` placed one
+  wherever the body's row and column separators had got to. Three ways to say
+  where. In 1.0 a picture declares a frame, the frame mints addresses, and
+  every record names its addresses. `\tnghost` existed only to advance a cursor
+  past an empty cell, so it has nothing to do.
+
+- **A port has a type; a route has ends.** `out=` and `in=` set the raw
+  departure and arrival angles of a curve, which meant that moving a tensor
+  broke every wire touching it. An arc now leaves and enters along the faces of
+  its ends, and the ends are the wire's two arguments rather than `from=` and
+  `to=` keys. `fused` and `weight=` chose ink from the author's intent; the
+  port type chooses it from the picture.
+
+- **A sheet is a basis member.** `sheets=`, `sheet sep=`, `col vector=`,
+  `row vector=`, and `sheet vector=` described a three-dimensional lattice by
+  listing its layers and then its lattice vectors separately, so the two could
+  disagree. `frame={plane, basis={...}}` states the basis once and the layers
+  are members of it. The doubled-plane pictures the lattice front end existed
+  for are the `planes` sugar row over that frame.
+
+- **A hyphen is not a range.** `(r,c)-(r,c)` could not be told from a generated
+  name containing a hyphen, so a selector was ambiguous exactly where selectors
+  are used most. The range operator is `..`.
+
+- **Contour is the default, so paper says so.** The mark flag was `outline`,
+  and its absence meant a filled mark. Filled marks are rare, unfilled marks
+  are the common case, and a flag should name the exception. The flag is now
+  `tint` and its absence means contour only.
+
+## Migration
+
+Per spelling, one substitution each:
+
+```
+\tnpic[K]{BODY}       ->  \begin{tenkz}[K] BODY \end{tenkz}
+\tnarrow              ->  \tnwire[dir=to]
+\tnjoin               ->  \tnwire
+\tnedge               ->  \tnwire
+\tnX{M}               ->  \tn[skin=ring]{M}
+\tndots               ->  \tn[skin=dots]{}
+\tnskip               ->  \tn[void=open]{}
+\tncut                ->  \tnmark[form=enclosure]
+\tnregion             ->  \tnmark[form=enclosure]
+tensor style=         ->  skin=
+route=curve           ->  route=arc
+route=hv | route=vh   ->  route=orth
+span=                 ->  wires=
+bond dir=             ->  dir=
+label shift=          ->  label pos=
+label at=             ->  label pos=
+removed=              ->  void=sealed
+outline               ->  tint
+(r,c)-(r,c)           ->  (r,c) .. (r,c)
+```
+
+`\tnghost` and the `none` connection flag are deleted, not rewritten. The rest
+read better by hand:
+
+- `\tnput{M}` becomes `\tn[at=<address>]{M}` once the picture declares a frame;
+  a free picture that relied on placement order must first say where its
+  tensors are.
+- `\tnsite`, `\tnedge`, and `\tnregion` bodies become `\tn`, `\tnwire`, and
+  `\tnmark` records over the same coordinates, with `lattice={RxC}` supplying
+  the frame the environment used to supply.
+- `out=`/`in=` angle pairs become `route=arc`, and a crossing that the arcs no
+  longer resolve is named once with `crossing=` or per wire with `cross=`.
+- `up=`/`down=` row topology becomes a `ports=` list per cell.
+- A `bond label={$D$ at 1-2}` becomes a `\tnmark[form=label]` record naming the
+  wire.
+- `\tenkzkernel` may be deleted from a document body: the meanings it bound are
+  the package's meanings from the moment it loads. The command is inert rather
+  than an error in the 1.0 series, and carries a registry sunset.
+
+## Unchanged
+
+`tenkz` as the environment name, `tenkzeq` and its joiners, `\tn`, `\tnwire`,
+`\tnmark`, `\tndeclare` and `\tndeclareatom`, the four side-policy words
+(`open`, `none`, `trace`, `cup`) and their `west=`/`east=`/`north=`/`south=`
+keys, `frame=` as the one frame key, the cell-set contraction algebra with its
+terms, ranges, and `+`/`-` unions, `periodic` as the shorthand for a traced
+pair of sides, and the `.tnlog` event surface, whose format version and
+compatibility rules are declared in `TNLOG.md`.
+
+## Also in 1.0
+
+- `\tenkzkernel` binds at package load. A document that never wrote the command
+  gets the kernel surface; a document that wrote it gets the same surface
+  twice. What the swap deleted for a reader is the possibility of a picture in
+  the 0.7 grid meaning.
+- The plane frame carries a declared basis and an independent physical axis, so
+  a projected picture states its own topology instead of inheriting the grid's.
+- A physical index may be directed, and a policy leg has the standing of a
+  declared one: a generated open end is a named record that a label or a mark
+  can name.
+- `stroke={solid|dashed|dotted}` spells wire ink, and the direction mark inks
+  on every bearing.
+- Region selection takes set difference, so a nested window is `A - B` rather
+  than two overlapping marks.
+- `metrics=compact` names the tighter metric profile that page-constrained
+  pictures used to obtain by setting `pitch=` in the body.
+- The stock `mpo` and `pill` skins are prelude declarations rather than object
+  flags.
+- The alias count is zero and no public name carries two value types.
+
+## The version string
+
+`tex/tenkz/tenkz.sty` still declares `v0.7`. The version, its date, this
+record's version line, and the event-format declaration in `TNLOG.md` are set
+together by the release-preparation change described in `RELEASE-POLICY.md`
+§3, and must agree with the tag. Writing them earlier would claim a release
+that has not passed its evidence gate.

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -7,7 +7,7 @@ implementation boundaries. The earlier file at `history/DESIGN.md` records the
 0.6 design campaign; it does not define the released contract.
 
 Adopting this policy neither changes the package version nor starts the 1.0
-campaign. Automated enforcement is pending under #5352, and no campaign entry
+campaign. Automated enforcement is pending under #5636, and no campaign entry
 is valid until the implementation and blocker chain below are complete. The
 enforcement-activation pull request is the final prerequisite before a source
 candidate. Its base contains the checker, repository-evidence resolver, tests,
@@ -21,7 +21,7 @@ A later
 self-referential freeze-entry pull request supplies the trusted attempt-ordering
 anchor.
 
-The following block is normative. A later #5352 slice activates its
+The following block is normative. The activation slice under #5636 arms its
 machine-checking contract.
 
 ```toml tenkz-policy-v1

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -212,7 +212,7 @@ integration order keeps every merged tree on the single new contract.
 The shrink ledger's `alias(...)` verdict records debt already present; it is not
 permission to introduce another alias.
 
-The activation slice under #5352 will add the validation commands here only
+The activation slice under #5636 adds the validation commands here only
 after their scripts, repository-evidence checks, tests, and CI wiring exist on
 `main`.  Close both blocker groups before activation.  One
 self-referential activation pull request then verifies the current no-update,

--- a/docs/tenkz/RELEASE-POLICY.md
+++ b/docs/tenkz/RELEASE-POLICY.md
@@ -71,6 +71,27 @@ that hides the real checkout and the denial of network access before repository
 code runs belong to the enforcement workflow, not to the supervisor, and the
 armed workflow adds both.
 
+**What `check_tenkz_policy.py` reports, and when that changes.** The checker
+prints `evidence not-started (0 entries)` and will keep printing it until a
+freeze entry lands. Read it as the campaign's state, not as a defect: while
+`enforcement = "pending"` the ledger is closed to entries by construction, so
+`not-started` is the only state a valid pending ledger can have. Three things
+must happen, in this order, before it reports anything else:
+
+1. the blocker chain closes — #4162, #4703, #4708, and #4163 remain open;
+2. the arming pull request flips both enforcement values and pins the four
+   digests, which moves the checker from a pending ledger to an armed one;
+3. the first `freeze` entry lands, which is what makes the state
+   `attempt-1-active`.
+
+Step 2 alone is not enough. On an armed ledger the validator requires a
+repository-evidence bundle, which the plain command-line entry point does not
+build; the armed states are reachable only through the enforcement workflow,
+which supplies the GitHub and Git evidence. So the bare command reporting a
+live chain is not a milestone this or any other implementation change reaches —
+it is the campaign having started. Until then the standing gates below, not the
+ledger, are the release evidence.
+
 **(this page)** The standing gates below already run per PR and must be green
 at the exact release head:
 

--- a/docs/tenkz/RELEASE-POLICY.md
+++ b/docs/tenkz/RELEASE-POLICY.md
@@ -53,9 +53,23 @@ release preparation, sign-off, publisher tag. Nobody pushes a `tenkz-v*` tag
 by hand. The campaign harness named by the policy —
 `tests/tenkz/release-harness/`, `tests/tenkz/release-support/`,
 `tests/tenkz/release-tests.toml`,
-`.github/workflows/tenkz-release-policy.yml` — is not in the tree yet; it is
-the activation slice of #5352, and until it lands and the activation pull
-request arms `SOAK-1.0.md`, no release command exists.
+`.github/workflows/tenkz-release-policy.yml` — landed with the activation slice
+of #5636 and runs per PR. It is not armed. `SOAK-1.0.md` still reads
+`enforcement = "pending"`, so no campaign entry is valid and no release command
+exists. Arming is a separate self-referential pull request whose complete diff
+is the seven scalars in `SOAK-1.0.md`, and it may open only after the blocker
+chain closes and the final-tag signing key lands
+(`tests/tenkz/release-support/README.md`).
+
+What the harness is: the closed inventory names one atomic compatibility
+assertion per entry, each with its own failure fingerprint, and the supervisor
+runs each one in a repository-shaped view holding only the pinned trees, the
+inventory, the four canonical artifacts, and that entry's declared subjects. An
+assertion passes by exiting zero and fails by writing the closed receipt and
+exiting ten; the supervisor rejects every other outcome. The mount namespace
+that hides the real checkout and the denial of network access before repository
+code runs belong to the enforcement workflow, not to the supervisor, and the
+armed workflow adds both.
 
 **(this page)** The standing gates below already run per PR and must be green
 at the exact release head:
@@ -71,6 +85,7 @@ at the exact release head:
 | manual compile and event audit | `xelatex manual2.tex` twice; `python3 scripts/tenkz_audit.py manual2.tnlog` | `pr-ci.yml`, `blueprint` |
 | picture-source lint and shared parsers | `python3 scripts/tenkz_lint.py`; `test_tnlog.py`, `test_texcase.py`, `test_tenkz_kernel_audit.py` | `pr-ci.yml`, `blueprint` |
 | evidence-ledger validity | `python3 scripts/check_tenkz_policy.py` (+ `test_check_tenkz_policy.py`, `test_tenkz_policy_evidence.py`) | `tenkz-policy.yml` |
+| release harness, inventory, and assertions | `python3 tests/tenkz/release-harness/selftest.py`; `supervisor.py check-inventory`, `run-all`, `check-readiness` | `tenkz-release-policy.yml` |
 | migration guards | `python3 scripts/check_tenkz_dispositions.py`; `python3 scripts/check_tenkz_demolition.py` | `tenkz-demolition.yml`; both expire with the S4 migration (`HACKING.md` §Pull-request evidence) |
 
 **(this page)** The render evidence standard is working agreement 5 on #4183,
@@ -98,12 +113,16 @@ declaration must agree with it (`DESIGN.md` §Release tags).
 
 The four canonical release artifacts (`DESIGN.md`, `release_*` values) are
 `tex/tenkz/tenkz.sty`, `docs/tenkz/manual2.tex`, `docs/tenkz/CHANGES.md`, and
-`docs/tenkz/TNLOG.md`. The last two are not in the tree yet: the
-release-preparation pull request writes them. `CHANGES.md` follows the
-register of the 0.6 record at `docs/tenkz/history/CHANGES-0.6.md` — a table of
-changed spellings, one motivated paragraph per decision, and the mechanical
-migration per spelling. `TNLOG.md` is the event-format declaration, owned by
-#4162/#4703.
+`docs/tenkz/TNLOG.md`. All four are in the tree; the release-preparation pull
+request sets their version lines together with the manifest. `CHANGES.md`
+follows the register of the 0.6 record at `docs/tenkz/history/CHANGES-0.6.md` —
+a table of changed spellings, one motivated paragraph per decision, and the
+mechanical migration per spelling. `TNLOG.md` is the event-format declaration:
+it states the line syntax, the event kinds, what the reader enforces, and which
+invariants only the writers hold. The in-band `major.minor` header it declares
+does not exist yet and remains owned by #4162/#4703, so until that lands the
+event surface is held by the golden digests rather than by version
+negotiation.
 
 Tags are `tenkz-vMAJOR.MINOR.PATCH`, annotated, never moved or reused. Bare
 `vMAJOR.MINOR.PATCH` tags belong to the Lean toolchain

--- a/docs/tenkz/RELEASE-POLICY.md
+++ b/docs/tenkz/RELEASE-POLICY.md
@@ -64,12 +64,30 @@ chain closes and the final-tag signing key lands
 What the harness is: the closed inventory names one atomic compatibility
 assertion per entry, each with its own failure fingerprint, and the supervisor
 runs each one in a repository-shaped view holding only the pinned trees, the
-inventory, the four canonical artifacts, and that entry's declared subjects. An
+inventory, and that entry's declared subjects — a canonical artifact reaches a
+command only through one of its two declared roles, and the receipt records
+which artifacts were withheld. An
 assertion passes by exiting zero and fails by writing the closed receipt and
-exiting ten; the supervisor rejects every other outcome. The mount namespace
-that hides the real checkout and the denial of network access before repository
-code runs belong to the enforcement workflow, not to the supervisor, and the
-armed workflow adds both.
+exiting ten; the supervisor rejects every other outcome.
+
+The view is declarative isolation, not a sandbox, and the difference matters
+when reading a receipt. A command runs as the user that owns every path in its
+view, so it can restore write permission on a sealed file and change it; it can
+read an absolute path outside the view; it can open a socket. The mode bits and
+the exposure list stop an accident and make a receipt name everything the
+command could legitimately have seen. They do not stop an adversary. Closing
+that gap needs a mount namespace and an identity that does not own the view,
+which belong to the enforcement workflow — as does the denial of network access
+before repository code runs. Both arrive with the armed workflow, and
+`supervisor.py check-readiness` refuses an armed policy whose workflow lacks
+them.
+
+One consequence for sequencing. The enforcement workflow must supply the
+repository-evidence bundle to `check_tenkz_policy.py` before the campaign is
+armed, because the arming change may touch only the two normative documents and
+so cannot add that wiring itself. An armed ledger without it fails closed on
+every validation. That wiring is therefore a prerequisite change, not part of
+arming.
 
 **What `check_tenkz_policy.py` reports, and when that changes.** The checker
 prints `evidence not-started (0 entries)` and will keep printing it until a

--- a/docs/tenkz/SOAK-1.0.md
+++ b/docs/tenkz/SOAK-1.0.md
@@ -158,7 +158,7 @@ While validly armed, later changes preserve the pinned policy and prefix and
 append live entry blocks after the marker. A correction is an appended entry;
 it never revises, deletes, reorders, or inserts preceding bytes.
 
-The following schema block is normative. A later #5352 slice activates its
+The following schema block is normative. The activation slice under #5636 arms its
 machine-checking contract.
 
 ```toml tenkz-soak-v1
@@ -876,7 +876,7 @@ No incident is repaired by deleting, moving, or reusing the name, and none
 starts another 1.0 attempt.
 
 No entry may be appended while `enforcement = "pending"`. The activation slice
-under #5352 will add validation commands only after their scripts,
+under #5636 adds validation commands only after their scripts,
 repository-evidence resolver, tests, CI wiring, closed inventory, blocker
 chain, and tag protection are complete on `main`.
 

--- a/docs/tenkz/TNLOG.md
+++ b/docs/tenkz/TNLOG.md
@@ -1,0 +1,287 @@
+# The tenkz event stream
+
+Every tenkz run writes one line-oriented event stream to `\jobname.tnlog`.
+The stream is a public surface: `DESIGN.md` §Compatibility ownership names it
+beside the TeX surface, and a release decision that keeps one compatible cannot
+excuse a break in the other. This page declares the format. It states what the
+writer emits, what the reader accepts, and — where those two differ — which one
+is the contract.
+
+`DESIGN.md` governs where this page and it disagree. The compatibility rules in
+§7 are restatements of the `[event_format]` block there.
+
+## 1. Format version
+
+The event format is version **1.0**, meaning the surface this page describes.
+No stream carries that number in band. There is no header line, no magic
+string, no producer record, and no trailer: the first byte of a `.tnlog` is the
+first event, in practice always a `picture` line.
+
+`DESIGN.md` requires an explicit machine-readable version on every stream
+before the 0.9 freeze, and assigns the header spelling and the ignorable-kind
+marking to #4162 and #4703. Until that change lands, a reader cannot negotiate
+and the surface is held by whole-file digest instead: `tests/tenkz/`
+`golden-events.sha256` (9 corpus streams), `tests/tenkz/kernel/golden.sha256`
+(12 kernel probes), and `tests/tenkz/strings/golden.sha256` (30 string probes)
+pin exact bytes. Those digests make field order and spacing part of the pinned
+surface even though no schema states them, which is why §4 is normative here.
+
+## 2. Line syntax
+
+```
+line   ::= kind ( "|" key "=" value )* LF
+kind   ::= bytes containing neither "|" nor "="
+key    ::= bytes containing neither "|" nor "="
+value  ::= bytes containing no "|"
+```
+
+- The separator is a single `|` (U+007C). One precedes every field; none
+  follows the last.
+- A field splits at its **first** `=`, so a value may contain `=` freely. A
+  value may be empty: `kernel-boundary|signature=` and `check|…|interface=`
+  both occur.
+- **There is no escaping.** No quoting, no backslash, no percent-encoding. A
+  `|` inside a value would silently shred the line into extra fields. Nothing
+  in the format prevents this; the writers simply never produce one, and any
+  new value that could contain `|` needs an escaping change first, which is a
+  major change under §7.
+- Kernel record values are flattened with `\tl_to_str:n`, so author
+  mathematics survives verbatim, including the space TeX inserts after a
+  multi-letter control sequence: `label=\overline {A}`.
+- Lines are written with `\immediate\write` to a file stream, which is not
+  subject to `\maxprintline`, so a line has no length limit. A
+  `glyph-geometry` line runs to about 180 bytes.
+- Blank lines are legal and ignored. Leading and trailing space around a key
+  or a value is stripped.
+
+One writer produces every line, `\tenkz@event` in
+`tex/tenkz/tenkz-core.code.tex`. It opens the stream at `\AtBeginDocument` and
+closes it at `\AtEndDocument`; an event expanded in the preamble is discarded.
+The kernel reaches the writer through a catcode-independent alias and rebinds
+it to a suppressor for the duration of its topology prepass, so a stream
+records exactly one settled pass.
+
+## 3. Event kinds
+
+Seventeen kinds are emitted and seventeen appear in the reader's table. The two
+sets are not equal: `geomprobe` is emitted and untabled, `wire-geometry` is
+tabled and unemitted. §8 records both.
+
+The following block is the machine-readable declaration. `tests/tenkz/`
+`release-harness/` reads it and the reader's table together, so the two cannot
+drift apart unnoticed.
+
+```toml tenkz-event-kinds-v1
+schema = 1
+version = "1.0"
+emitted = [
+  "atom",
+  "bbox",
+  "check",
+  "frame",
+  "geomprobe",
+  "glyph-geometry",
+  "ink-use",
+  "kernel-boundary",
+  "label-use",
+  "mark",
+  "picture",
+  "string",
+  "stringbead",
+  "stringcross",
+  "tree",
+  "warning",
+  "wire",
+]
+reader_table = [
+  "atom",
+  "bbox",
+  "check",
+  "frame",
+  "glyph-geometry",
+  "ink-use",
+  "kernel-boundary",
+  "label-use",
+  "mark",
+  "picture",
+  "string",
+  "stringbead",
+  "stringcross",
+  "tree",
+  "warning",
+  "wire",
+  "wire-geometry",
+]
+```
+
+### Kernel records
+
+`atom`, `wire`, `mark`, and `frame` share one emitter and therefore one layout:
+
+```
+<kind>|id=<class>-<n>|<key>=<value>|<key>=<value>…
+```
+
+They carry no `picture=` field. A record belongs to the picture whose header
+most recently opened, and a `check` event or the next `picture` header closes
+that ownership. Ids come from one counter shared by all four classes, so a
+picture's ids interleave: `atom-1, atom-2, mark-3, atom-4`.
+
+| Kind | Fields seen in emitted streams | Meaning |
+|---|---|---|
+| `atom` | `addr`, `kind`, `label`, `label-pos`, `name`, `node`, `skin`, `ports`, `member`, `cell-row`, `cell-col`, `basis-*`, `populated`, `conjugate`, `cluster-of`, `group`, `species` | one tensor record |
+| `wire` | `kind` (`index`, `string`, `pairing`), `from`, `to`, `from-open`, `to-open`, `name`, `origin`, `species`, `cross`, `crossing`, `wind`, `closed`, `row`, `col`, `side`, `top`, `bottom`, `host`, `port-face`, `port-slot`, `port-type` | one index, string, or pairing edge |
+| `mark` | `form` (`label`, `enclosure`, `bracket`, `prose`), `label`, `label-pos`, `node`, `members`, `slot` | one annotation record |
+| `frame` | `map` (`plane`, `group`, `subframe`), `scope`, `a`, `b`, `c`, `d`, `dx`, `dy`, `transverse-x`, `transverse-y`, `group`, `scale` | one coordinate frame or sub-frame |
+
+The field vocabulary of these four kinds is **open**. A record carries whatever
+the model store holds for it, so this table lists what streams contain today
+rather than a closed set. The closed part of their contract is the layout: `id`
+first, the rest sorted, no `picture=`.
+
+### Explicit-field events
+
+| Kind | Fields, in emitted order | Meaning |
+|---|---|---|
+| `picture` | `id` (`k<n>`), `lang` (always `kernel`), `metrics` (when a metric profile is declared), `scope` (when inside `tenkzeq`) | opens a picture |
+| `kernel-boundary` | `signature` | closes the record block with the picture's exposed-index multiset, comma-space joined, possibly empty |
+| `check` | `scope`, then `relation` or `product`, `result`, `modulo`, and result-specific fields | one equation-level verdict, emitted after every picture of its scope |
+| `warning` | `picture`, `code`, then code-specific fields | one non-fatal geometry or readability diagnostic |
+| `string` | `id`, `kind` (`open`, `closed`, `wind`, `around`), `class`, `pts`, `flank1`, `flank2` | one declared curve |
+| `stringbead` | `id`, `t`, `x`, `y` | one bead at parameter `t` on a string |
+| `stringcross` | `under`, `over`, `hits` | one over-under crossing |
+| `ink-use` | `picture`, `class` (`glyph`, `wire`), `id`, `shape` | opens an ink-owner scope for the geometry that follows |
+| `label-use` | `picture` | a label node claimed no ink owner |
+| `bbox` | `picture`, `class=label`, `id`, `owner`, `xmin`, `xmax`, `ymin`, `ymax`, `shape`, `radius` | one measured label box, in integer scaled points |
+| `glyph-geometry` | `picture`, `owner`, `shape`, `xmin`, `xmax`, `ymin`, `ymax`, `radius`, `stroke`, `x1`, `y1`, `x2`, `y2`, `x3`, `y3` | one measured glyph silhouette, in integer scaled points |
+| `tree` | `picture`, `id`, `style`, `leaves`, `vertices`, `topology`, `role`, `species` | one fusion tree |
+| `geomprobe` | `id`, then a caller-supplied payload | one geometry probe, for fixtures |
+
+`check` results are `equal`, `off`, `malformed`, `contracted`, and `mismatch`.
+Each fixes further required fields: `equal` needs `relation` and `signature`,
+`off` needs `relation` and `reason`, `malformed` needs `reason`, `panels`, and
+`relations`, `contracted` needs `product` and `signature`, and `mismatch` needs
+`relation` unless it carries `product`.
+
+`x` and `y` on `stringbead` carry a `pt` suffix. Every other coordinate in the
+stream is an integer count of scaled points with no unit.
+
+## 4. Order
+
+Order is part of the surface, because the golden digests hash whole files.
+
+1. Fields of a kernel record are `id` first, then the remaining `key=value`
+   pairs sorted in ascending order **of the whole pair string**, not of the
+   key. This is why `label-pos=180` precedes `label=A`: `-` sorts before `=`.
+2. Fields of an explicit-field event follow that event's template, in the order
+   given in §3.
+3. Within a picture: the header, then the records grouped by class in the order
+   `atom`, `wire`, `mark`, `frame`, then `kernel-boundary`, then any geometry
+   warnings, then the string, bead, crossing, and measured-ink events of the
+   render pass.
+4. `check` events follow every picture of their scope.
+5. Exactly one `kernel-boundary` per kernel picture.
+
+## 5. What the reader enforces
+
+`scripts/tenkzlib/tnlog.py` is the canonical reader; `HACKING.md` §Shared
+parsers requires every checker that needs structured fields to use it. Its
+`parse_log` reports through two injected callbacks, `hard` and `advisory`, both
+of which default to discarding the finding — a caller that supplies neither
+gets silent acceptance. A hard finding also sets `Event.valid = False` and
+removes the event from `ParsedLog.valid_events` and from every picture's event
+list.
+
+Hard:
+
+- a field with no `=`;
+- a repeated key on one line;
+- a tabled field whose value fails its validator, on a tabled kind;
+- a `check` without `scope` or `result`, or without the fields its result
+  requires;
+- a `check` carrying `picture=`;
+- a tabled kind other than `picture` with no `picture=`, unless it is a kernel
+  record inside an open kernel picture;
+- a `picture` with a malformed or repeated `id`;
+- a reference to an undeclared picture.
+
+Advisory:
+
+- an untabled event kind;
+- a `lang` outside the caller's `known_langs`, when the caller supplies one.
+
+## 6. What the writers guarantee and the reader does not check
+
+These hold in every emitted stream and are invisible to `parse_log`. They are
+the contract; the reader is merely permissive about them, and a change to any
+of them is a change to the surface.
+
+| Invariant | Reader |
+|---|---|
+| the field order of §4.1 and §4.2 | never inspects order |
+| the stream order of §4.3 and §4.4 | checks only that a record follows a header |
+| exactly one `kernel-boundary` per kernel picture (§4.5) | permits zero or several; `scripts/tenkz_audit.py` enforces it |
+| no value contains `|` | would shred such a line into extra fields |
+| picture ids are `k`-prefixed and monotonic | accepts bare integers as well |
+| every kind other than the four records carries its documented fields | requires a complete field set for `check` only |
+| an untabled field never appears on a tabled kind | accepts any untabled field as opaque |
+
+The last row is the one to read twice. `picture`'s `metrics`, every `warning`
+payload field beyond `code`, `check`'s `modulo`, `left-kind`, and `right-kind`,
+`string`'s `class`, `flank1`, and `flank2`, and the whole open vocabulary of
+the four record kinds all pass through unvalidated. The reader tolerating a
+field is not the same as the format having one.
+
+Semantic checking above the parser belongs to `scripts/tenkz_audit.py`, which
+checks tree topology against its leaf and vertex counts, rejects empty
+pictures, enforces one boundary per kernel picture, fails on a `check` result
+of `mismatch` or `malformed`, and audits label overlap, bounding-box coverage,
+repeated topology, and equation boundaries. Its own table of emitted kinds is
+maintained by hand.
+
+## 7. Compatibility
+
+From `DESIGN.md`'s `[event_format]` block:
+
+- A reader accepts every minor revision of its own event major and rejects a
+  different major with a direct diagnostic.
+- A reader ignores an unknown optional field.
+- A reader ignores an unknown event kind only when the schema marks that kind
+  explicitly ignorable and skipping it preserves the validity and meaning of
+  every recognized record.
+- Any addition that cannot meet those conditions increments the event major.
+
+Against the release classes in `RELEASE-POLICY.md` §1: a patch keeps the stream
+byte-stable for unchanged input; a minor may add a kind or an optional field,
+increments the event minor, and requires the reader to accept both spellings; a
+major may break the format and increments the event major.
+
+Two of those four rules are declarations rather than implemented behaviour.
+The reader has no version concept at all, so "same major, any minor" is
+unimplemented; and it treats **every** unknown kind as ignorable with an
+advisory, rather than only explicitly marked ones. The unknown-optional-field
+rule is implemented, as §6's last row describes, though by permissiveness
+rather than by a declared optional-field set. Closing the gap is #4162 and
+#4703's work, and no release may claim the event surface is version-negotiable
+before it lands.
+
+## 8. Known defects
+
+Recorded here so a reader of a stream is not surprised, and so the freeze can
+decide each one.
+
+- **`geomprobe` is untabled.** The reader gives it an advisory and, because it
+  carries no `picture=`, drops it before picture attachment. It survives only
+  in `ParsedLog.events`. Fixtures that read probes must read that list.
+- **`wire-geometry` is tabled and unemitted.** A complete validator set exists
+  for a kind nothing writes.
+- **`atom`'s `cell` validator is unreachable.** Kernel atoms carry
+  `addr=(r,c)` or `addr=(s,r,c)`; no emitter writes `cell=`. Only the parser's
+  own tests exercise that validator.
+- **The integer-id picture header has no call site.** `\tenkz@beginpicture` is
+  written only by synthetic fixtures, so `\tenkz@pictureid` stays 0 in every
+  real run.
+- **`tree` and the `sheet-range` warning emit `picture=0`.** For `tree` the
+  reader special-cases it. The `sheet-range` warning is not special-cased, so
+  were it to fire it would draw a `dangling-picture-ref`. Both follow from the
+  previous item.

--- a/tests/tenkz/release-harness/harnesslib.py
+++ b/tests/tenkz/release-harness/harnesslib.py
@@ -87,3 +87,24 @@ def load_module(relative: str, name: str = "tenkz_release_subject"):
     sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def selected_assertion(assertions: dict[str, tuple[str, str]]) -> tuple[str, str]:
+    """Resolve the assertion this run was asked for, from its one argument.
+
+    An assertion file holding several assertions is the normal shape here, one
+    failure cause each, so the argument-to-identity lookup is the same in every
+    one of them. An unknown name exits 2: that is neither a pass nor an
+    assertion failure, and the supervisor fails closed on it, which is the
+    right answer for an inventory naming an assertion the file does not have.
+    """
+
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode not in assertions:
+        print(
+            f"unknown assertion {mode!r}; this file offers "
+            f"{sorted(assertions)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return assertions[mode]

--- a/tests/tenkz/release-harness/harnesslib.py
+++ b/tests/tenkz/release-harness/harnesslib.py
@@ -14,6 +14,7 @@ reaching the same fingerprint would make the friction record unreadable.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import sys
@@ -68,3 +69,21 @@ def read(relative: str) -> str:
     """Read one declared subject from the view, by its repository-relative path."""
 
     return Path(relative).read_text(encoding="utf-8")
+
+
+def load_module(relative: str, name: str = "tenkz_release_subject"):
+    """Import one declared program path as the product under test.
+
+    The view exposes a subject at its own repository-relative path and nothing
+    around it — `scripts/tenkzlib/tnlog.py` arrives without the package
+    `__init__.py` beside it — so a subject is loaded from its file rather than
+    imported by module path. The module is registered in `sys.modules` before
+    execution because `dataclasses` resolves a class's own module during class
+    creation and fails on an unregistered one.
+    """
+
+    spec = importlib.util.spec_from_file_location(name, relative)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/tests/tenkz/release-harness/harnesslib.py
+++ b/tests/tenkz/release-harness/harnesslib.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""The assertion protocol every atomic release test uses.
+
+A release test states one compatibility assertion about one public surface and
+reports one of two outcomes.  It exits zero when the assertion holds.  When the
+assertion fails it writes the closed receipt at `$TENKZ_TEST_OUTPUT` and exits
+exactly ten; `docs/tenkz/SOAK-1.0.md` §Release payload evidence fixes both the
+receipt shape and the exit code, and the supervisor rejects any other pairing.
+
+A test that wants to report two failure causes is two tests.  The fingerprint
+in `tests/tenkz/release-tests.toml` names the one cause, so a second cause
+reaching the same fingerprint would make the friction record unreadable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+RECEIPT_NAME = "assertion-failure-v1.json"
+ASSERTION_EXIT = 10
+
+
+def output_directory() -> Path:
+    """The writable mount the supervisor provides, and the only writable path."""
+
+    value = os.environ.get("TENKZ_TEST_OUTPUT")
+    if not value:
+        print("TENKZ_TEST_OUTPUT is unset; run through the supervisor", file=sys.stderr)
+        raise SystemExit(2)
+    return Path(value)
+
+
+def fail(test_id: str, failure_fingerprint: str, reason: str) -> None:
+    """Record the sole assertion failure and leave with the pinned exit code."""
+
+    receipt = {
+        "schema": 1,
+        "test_id": test_id,
+        "failure_fingerprint": failure_fingerprint,
+        "completed": True,
+    }
+    destination = output_directory() / RECEIPT_NAME
+    temporary = destination.with_suffix(".partial")
+    temporary.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(destination)
+    print(reason, file=sys.stderr)
+    raise SystemExit(ASSERTION_EXIT)
+
+
+def assert_that(
+    condition: object,
+    *,
+    test_id: str,
+    failure_fingerprint: str,
+    reason: str,
+) -> None:
+    """Hold the assertion, or record its one failure."""
+
+    if not condition:
+        fail(test_id, failure_fingerprint, reason)
+
+
+def read(relative: str) -> str:
+    """Read one declared subject from the view, by its repository-relative path."""
+
+    return Path(relative).read_text(encoding="utf-8")

--- a/tests/tenkz/release-harness/selftest.py
+++ b/tests/tenkz/release-harness/selftest.py
@@ -150,9 +150,11 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
       - id: tenkz-network-denied
-        run: true
+        run: sudo iptables -P OUTPUT DROP && sudo iptables -P INPUT DROP
+      - id: tenkz-filesystem-isolated
+        run: unshare --mount --map-root-user tests/tenkz/release-harness/supervisor.py run-all
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
   publish:
     needs: validate
     environment: tenkz-release-publisher
@@ -188,11 +190,75 @@ def guard_armed_workflow_comments(workspace: Path) -> None:
 
 
 def guard_armed_workflow_foreign_needs(workspace: Path) -> None:
-    """A `needs:` on another job must not order the publisher."""
+    """A `needs:` on another job must not order the publisher.
+
+    The fixture removes the publisher's `needs:` *and* gives one to the
+    validation job, so a whole-file scan would still find `needs:` and pass.
+    A fixture that only deleted the publisher's would be refused by the broken
+    check too, and would therefore prove nothing.
+    """
+
+    body = ARMED_WORKFLOW.replace("    needs: validate\n", "").replace(
+        "  validate:\n", "  validate:\n    needs: nothing-in-particular\n"
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
+def guard_armed_workflow_unknown_needs(workspace: Path) -> None:
+    """The publisher's `needs:` must name a job that exists."""
 
     require_armed_workflow(
-        staged_workflow(workspace, ARMED_WORKFLOW.replace("    needs: validate\n", ""))
+        staged_workflow(workspace, ARMED_WORKFLOW.replace("needs: validate", "needs: lint"))
     )
+
+
+def guard_armed_workflow_publisher_action(workspace: Path) -> None:
+    """The secret-bearing publisher must carry no `uses:` step at all."""
+
+    body = ARMED_WORKFLOW.replace(
+        "      - run: echo ${{ secrets.TENKZ_FINAL_TAG_SIGNING_KEY }}",
+        "      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803\n"
+        "      - run: echo ${{ secrets.TENKZ_FINAL_TAG_SIGNING_KEY }}",
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
+def guard_armed_workflow_no_op_denial(workspace: Path) -> None:
+    """A boundary step declared as a no-op must not satisfy its requirement."""
+
+    body = ARMED_WORKFLOW.replace(
+        "        run: sudo iptables -P OUTPUT DROP && sudo iptables -P INPUT DROP",
+        "        run: true",
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
+def guard_armed_workflow_late_denial(workspace: Path) -> None:
+    """A boundary step must run before any other step in its job."""
+
+    body = ARMED_WORKFLOW.replace(
+        "      - id: tenkz-network-denied\n"
+        "        run: sudo iptables -P OUTPUT DROP && sudo iptables -P INPUT DROP\n",
+        "",
+    ).replace(
+        "      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803",
+        "      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803\n"
+        "      - id: tenkz-network-denied\n"
+        "        run: sudo iptables -P OUTPUT DROP",
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
+def guard_armed_workflow_no_filesystem_isolation(workspace: Path) -> None:
+    """The mount-namespace boundary must be declared like the network one."""
+
+    body = ARMED_WORKFLOW.replace(
+        "      - id: tenkz-filesystem-isolated\n"
+        "        run: unshare --mount --map-root-user "
+        "tests/tenkz/release-harness/supervisor.py run-all\n",
+        "",
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
 
 
 def guard_armed_workflow_mutable_action(workspace: Path) -> None:
@@ -254,6 +320,11 @@ GUARDS = {
     "armed-workflow-comments": guard_armed_workflow_comments,
     "armed-workflow-foreign-needs": guard_armed_workflow_foreign_needs,
     "armed-workflow-mutable-action": guard_armed_workflow_mutable_action,
+    "armed-workflow-unknown-needs": guard_armed_workflow_unknown_needs,
+    "armed-workflow-publisher-action": guard_armed_workflow_publisher_action,
+    "armed-workflow-no-op-denial": guard_armed_workflow_no_op_denial,
+    "armed-workflow-late-denial": guard_armed_workflow_late_denial,
+    "armed-workflow-no-filesystem-isolation": guard_armed_workflow_no_filesystem_isolation,
     "armed-workflow-short-environment": guard_armed_workflow_short_environment,
     "armed-workflow-block-environment": guard_armed_workflow_block_environment,
 }

--- a/tests/tenkz/release-harness/selftest.py
+++ b/tests/tenkz/release-harness/selftest.py
@@ -179,15 +179,15 @@ def run_guards(document: dict, failures: list[str]) -> list[str]:
     return completed
 
 
-def receipt_required_fields(root: Path) -> list[str]:
-    """The receipt fields the pinned replay schema marks required."""
+def receipt_schema(root: Path) -> dict:
+    """The `supervisorReceipt` shape from the pinned replay schema."""
 
     schema = json.loads(
         (root / "tests/tenkz/release-support/reset-replay-v1.schema.json").read_text(
             encoding="utf-8"
         )
     )
-    return sorted(schema["$defs"]["supervisorReceipt"]["required"])
+    return schema["$defs"]["supervisorReceipt"]
 
 
 def run(root: Path = ROOT) -> int:
@@ -225,16 +225,22 @@ def run(root: Path = ROOT) -> int:
 
     guards_completed = run_guards(document, failures)
 
-    # Every payload receipt the supervisor emitted must carry the complete
-    # field set the pinned replay schema requires, because a replay receipt
-    # embeds these verbatim and a later validation rejects an incomplete one.
-    required = receipt_required_fields(root)
+    # A replay receipt embeds these verbatim under a shape that is closed in
+    # both directions, so the check runs in both directions. Missing a required
+    # field and carrying one the schema does not declare are equally fatal, and
+    # the second is the one that bit: `tag` was added to every receipt without
+    # being added to the schema, and a required-fields-only check saw nothing.
+    shape = receipt_schema(root)
+    required = sorted(shape["required"])
+    declared = set(shape["properties"])
     for payload in observed_receipts:
         missing = [field for field in required if field not in payload]
-        if missing:
+        forbidden = sorted(set(payload) - declared)
+        if missing or forbidden:
             failures.append(
-                f"{payload['test_id']}: payload receipt omits required field(s) "
-                f"{missing!r}"
+                f"{payload['test_id']}: payload receipt omits {missing!r} and "
+                f"carries undeclared field(s) {forbidden!r}, which "
+                f"additionalProperties:false rejects"
             )
             break
 

--- a/tests/tenkz/release-harness/selftest.py
+++ b/tests/tenkz/release-harness/selftest.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""The supervisor self-test.
+
+`docs/tenkz/SOAK-1.0.md` §Release payload evidence requires a closed self-test
+suite from the pinned support tree, run against pinned synthetic fixtures,
+before the campaign may be armed. Its receipt binds the code and support trees,
+the output mount, the environment, the access denials, the tool fingerprints,
+and the completion of every isolation probe.
+
+The suite drives `selftest_probe.py` through the real supervisor and compares
+each outcome with `tests/tenkz/release-support/selftest-expectations.toml`. It
+touches neither the release-test inventory nor any release tag, so it runs on
+every pull request rather than only at activation, and a change that quietly
+weakened the view would be caught by the isolation probe on that run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from supervisor import (  # noqa: E402
+    ROOT,
+    SupervisorError,
+    Test,
+    computed_pins,
+    observe,
+    read_policy,
+    resolve_tool,
+    tool_profile,
+)
+
+
+EXPECTATIONS = "tests/tenkz/release-support/selftest-expectations.toml"
+PROBE = "tests/tenkz/release-harness/selftest_probe.py"
+PROBE_SUBJECT = "tex/tenkz/tenkz.sty"
+PROBE_FIXTURE = "docs/tenkz/TNLOG.md"
+
+
+def synthetic(probe: dict, fingerprint: str) -> Test:
+    """One synthetic inventory entry, built here rather than read from the pins."""
+
+    return Test(
+        id=f"supervisor-selftest-{probe['id']}",
+        surface="tex-api",
+        failure_fingerprint=fingerprint,
+        runner="python3",
+        path=PROBE,
+        args=(probe["id"],),
+        program_paths=(PROBE_SUBJECT,),
+        fixture_paths=(PROBE_FIXTURE,),
+        timeout_seconds=probe["timeout_seconds"],
+    )
+
+
+def run(root: Path = ROOT) -> int:
+    policy = read_policy(root)
+    document = tomllib.loads((root / EXPECTATIONS).read_text(encoding="utf-8"))
+    if document.get("schema") != 1:
+        print("FAIL: self-test expectations have an unknown schema", file=sys.stderr)
+        return 1
+    fingerprint = document["synthetic_fingerprint"]
+
+    completed: list[str] = []
+    failures: list[str] = []
+    for probe in document["probe"]:
+        test = synthetic(probe, fingerprint)
+        expected = probe["outcome"]
+        try:
+            receipt = observe(test, policy, root)
+            observed = receipt["assertion_result"]
+        except SupervisorError as error:
+            observed = "fails-closed"
+            message = probe.get("message", "")
+            if message and message not in str(error):
+                failures.append(
+                    f"{probe['id']}: failed closed with {str(error)!r}, which does "
+                    f"not carry the expected {message!r}"
+                )
+                continue
+        if observed != expected:
+            failures.append(f"{probe['id']}: expected {expected}, observed {observed}")
+            continue
+        completed.append(probe["id"])
+
+    pins = computed_pins(policy, root)
+    receipt = {
+        "schema": 1,
+        "code_tree": pins["release_test_code_tree"],
+        "support_tree": pins["release_test_support_tree"],
+        "output_mount": "/tenkz-output",
+        "tool_fingerprints": {
+            name: resolve_tool(name, pattern, root)[1]
+            for name, pattern in sorted(tool_profile(root).items())
+        },
+        "probes_completed": completed,
+    }
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    print(f"PASS: {len(completed)} supervisor isolation probe(s) completed")
+    return 0
+
+
+def main() -> int:
+    try:
+        return run()
+    except (SupervisorError, OSError, ValueError, KeyError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tenkz/release-harness/selftest.py
+++ b/tests/tenkz/release-harness/selftest.py
@@ -312,6 +312,49 @@ PROBES = (
     "orphan-timeout",
 )
 
+def guard_armed_workflow_flow_action(workspace: Path) -> None:
+    """A flow mapping naming an action must be caught whatever its key order."""
+
+    body = ARMED_WORKFLOW.replace(
+        "      - run: echo ${{ secrets.TENKZ_FINAL_TAG_SIGNING_KEY }}",
+        "      - {name: fetch, uses: actions/checkout@"
+        "d23441a48e516b6c34aea4fa41551a30e30af803}\n"
+        "      - run: echo ${{ secrets.TENKZ_FINAL_TAG_SIGNING_KEY }}",
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
+def guard_armed_workflow_extra_permission(workspace: Path) -> None:
+    """The publisher's permission set is exact, not a lower bound."""
+
+    body = ARMED_WORKFLOW.replace(
+        "      contents: write", "      contents: write\n      id-token: write"
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
+def guard_armed_workflow_container(workspace: Path) -> None:
+    """A containerized publisher puts image code in the secret-bearing job."""
+
+    body = ARMED_WORKFLOW.replace(
+        "    environment: tenkz-release-publisher",
+        "    container: alpine@sha256:"
+        "0000000000000000000000000000000000000000000000000000000000000000\n"
+        "    environment: tenkz-release-publisher",
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
+def guard_armed_workflow_secret_elsewhere(workspace: Path) -> None:
+    """The signing secret has one consumer."""
+
+    body = ARMED_WORKFLOW.replace(
+        "      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803",
+        "      - run: echo ${{ secrets.TENKZ_FINAL_TAG_SIGNING_KEY }}",
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
 GUARDS = {
     "nested-symlink": guard_nested_symlink,
     "symlinked-program-path": guard_symlinked_program_path,
@@ -325,6 +368,10 @@ GUARDS = {
     "armed-workflow-no-op-denial": guard_armed_workflow_no_op_denial,
     "armed-workflow-late-denial": guard_armed_workflow_late_denial,
     "armed-workflow-no-filesystem-isolation": guard_armed_workflow_no_filesystem_isolation,
+    "armed-workflow-flow-action": guard_armed_workflow_flow_action,
+    "armed-workflow-extra-permission": guard_armed_workflow_extra_permission,
+    "armed-workflow-container": guard_armed_workflow_container,
+    "armed-workflow-secret-elsewhere": guard_armed_workflow_secret_elsewhere,
     "armed-workflow-short-environment": guard_armed_workflow_short_environment,
     "armed-workflow-block-environment": guard_armed_workflow_block_environment,
 }

--- a/tests/tenkz/release-harness/selftest.py
+++ b/tests/tenkz/release-harness/selftest.py
@@ -243,7 +243,7 @@ def run(root: Path = ROOT) -> int:
         "code_tree": pins["release_test_code_tree"],
         "support_tree": pins["release_test_support_tree"],
         "inventory_sha256": pins["release_test_inventory_sha256"],
-        "output_mount": "/tenkz-output",
+        "output_mount": sorted({r["output_mount"] for r in observed_receipts}),
         "tool_fingerprints": {
             name: resolve_tool(name, pattern, root)[1]
             for name, pattern in sorted(tool_profile(root).items())

--- a/tests/tenkz/release-harness/selftest.py
+++ b/tests/tenkz/release-harness/selftest.py
@@ -7,17 +7,26 @@ before the campaign may be armed. Its receipt binds the code and support trees,
 the output mount, the environment, the access denials, the tool fingerprints,
 and the completion of every isolation probe.
 
-The suite drives `selftest_probe.py` through the real supervisor and compares
-each outcome with `tests/tenkz/release-support/selftest-expectations.toml`. It
-touches neither the release-test inventory nor any release tag, so it runs on
-every pull request rather than only at activation, and a change that quietly
-weakened the view would be caught by the isolation probe on that run.
+The suite has two halves. The *probes* drive `selftest_probe.py` through the
+real supervisor and check what a command sees from inside the view. The
+*guards* call the supervisor's own entry points against synthetic filesystem
+fixtures the suite builds and destroys, because the escapes they cover —
+symlinks, special file modes, an incomplete receipt — cannot be staged from
+inside a view that is supposed to reject them. Both halves compare against
+`tests/tenkz/release-support/selftest-expectations.toml`.
+
+Neither half touches the release-test inventory's pins or any release tag, so
+the suite runs on every pull request rather than only at activation, and a
+change that quietly weakened the view is caught on that run.
 """
 
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import sys
+import tempfile
 import tomllib
 from pathlib import Path
 
@@ -28,8 +37,11 @@ from supervisor import (  # noqa: E402
     SupervisorError,
     Test,
     computed_pins,
+    expose,
     observe,
     read_policy,
+    require_regular_file,
+    require_tree_is_clean,
     resolve_tool,
     tool_profile,
 )
@@ -39,6 +51,7 @@ EXPECTATIONS = "tests/tenkz/release-support/selftest-expectations.toml"
 PROBE = "tests/tenkz/release-harness/selftest_probe.py"
 PROBE_SUBJECT = "tex/tenkz/tenkz.sty"
 PROBE_FIXTURE = "docs/tenkz/TNLOG.md"
+ESCAPE_MARKER = "content-from-outside-the-repository\n"
 
 
 def synthetic(probe: dict, fingerprint: str) -> Test:
@@ -57,6 +70,126 @@ def synthetic(probe: dict, fingerprint: str) -> Test:
     )
 
 
+# --------------------------------------------------------------------------
+# Guards
+# --------------------------------------------------------------------------
+#
+# Each guard stages one escape in a throwaway directory and requires the
+# supervisor to refuse it. A guard whose staged escape the supervisor accepts
+# is reported as `accepted`, which is always a self-test failure: these are the
+# refusals the hermetic view is built out of, and a view that accepts them
+# produces evidence a release would trust.
+
+
+def outside_file(workspace: Path) -> Path:
+    """One file outside the synthetic repository, standing in for /etc/hosts."""
+
+    target = workspace / "outside" / "secret.txt"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(ESCAPE_MARKER, encoding="utf-8")
+    return target
+
+
+def guard_nested_symlink(workspace: Path) -> None:
+    """A symlink one level down inside an exposed tree must not be followed.
+
+    `shutil.copytree(symlinks=False)` dereferences such a link and writes its
+    target's bytes into the view, so this guard fails against any harness that
+    copies an exposed tree with `copytree`.
+    """
+
+    fake_root = workspace / "repository"
+    tree = fake_root / "tex" / "tenkz" / "nested"
+    tree.mkdir(parents=True)
+    (fake_root / "tex" / "tenkz" / "plain.sty").write_text("ok\n", encoding="utf-8")
+    os.symlink(outside_file(workspace), tree / "escape.sty")
+    view = workspace / "view"
+    view.mkdir()
+    expose(fake_root, view, "tex/tenkz")
+
+
+def guard_symlinked_program_path(workspace: Path) -> None:
+    """A declared subject that is itself a symlink must be rejected."""
+
+    fake_root = workspace / "repository"
+    (fake_root / "tex" / "tenkz").mkdir(parents=True)
+    os.symlink(outside_file(workspace), fake_root / "tex" / "tenkz" / "tenkz.sty")
+    require_regular_file(fake_root, "tex/tenkz/tenkz.sty", "guard program path")
+
+
+def guard_symlinked_parent(workspace: Path) -> None:
+    """A declared subject reached through a symlinked directory must be rejected.
+
+    The leaf is an ordinary regular file, so any check that looks only at the
+    leaf accepts it. The escape is the parent.
+    """
+
+    fake_root = workspace / "repository"
+    (fake_root / "tex").mkdir(parents=True)
+    real = workspace / "elsewhere" / "tenkz"
+    real.mkdir(parents=True)
+    (real / "tenkz.sty").write_text(ESCAPE_MARKER, encoding="utf-8")
+    os.symlink(real, fake_root / "tex" / "tenkz")
+    require_regular_file(fake_root, "tex/tenkz/tenkz.sty", "guard program path")
+
+
+def guard_special_entry(workspace: Path) -> None:
+    """A named pipe inside an exposed tree must be rejected, not copied."""
+
+    fake_root = workspace / "repository"
+    tree = fake_root / "docs" / "tenkz"
+    tree.mkdir(parents=True)
+    os.mkfifo(tree / "pipe")
+    require_tree_is_clean(fake_root, "docs/tenkz", "guard fixture path")
+
+
+GUARDS = {
+    "nested-symlink": guard_nested_symlink,
+    "symlinked-program-path": guard_symlinked_program_path,
+    "symlinked-parent": guard_symlinked_parent,
+    "special-entry": guard_special_entry,
+}
+
+
+def run_guards(document: dict, failures: list[str]) -> list[str]:
+    completed: list[str] = []
+    for guard in document["guard"]:
+        name = guard["id"]
+        if name not in GUARDS:
+            failures.append(f"{name}: the expectations name an unknown guard")
+            continue
+        workspace = Path(tempfile.mkdtemp(prefix="tenkz-guard-"))
+        try:
+            GUARDS[name](workspace)
+        except SupervisorError as error:
+            if guard["message"] not in str(error):
+                failures.append(
+                    f"{name}: refused with {str(error)!r}, which does not carry "
+                    f"the expected {guard['message']!r}"
+                )
+                continue
+            completed.append(name)
+            continue
+        except OSError as error:
+            failures.append(f"{name}: could not be staged: {error}")
+            continue
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
+        failures.append(f"{name}: the supervisor accepted a staged escape")
+    return completed
+
+
+def receipt_required_fields(root: Path) -> list[str]:
+    """The receipt fields the pinned replay schema marks required."""
+
+    schema = json.loads(
+        (root / "tests/tenkz/release-support/reset-replay-v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    return sorted(schema["$defs"]["supervisorReceipt"]["required"])
+
+
 def run(root: Path = ROOT) -> int:
     policy = read_policy(root)
     document = tomllib.loads((root / EXPECTATIONS).read_text(encoding="utf-8"))
@@ -64,15 +197,18 @@ def run(root: Path = ROOT) -> int:
         print("FAIL: self-test expectations have an unknown schema", file=sys.stderr)
         return 1
     fingerprint = document["synthetic_fingerprint"]
+    pins = computed_pins(policy, root)
 
     completed: list[str] = []
     failures: list[str] = []
+    observed_receipts: list[dict] = []
     for probe in document["probe"]:
         test = synthetic(probe, fingerprint)
         expected = probe["outcome"]
         try:
-            receipt = observe(test, policy, root)
-            observed = receipt["assertion_result"]
+            payload = observe(test, policy, root, pins)
+            observed = payload["assertion_result"]
+            observed_receipts.append(payload)
         except SupervisorError as error:
             observed = "fails-closed"
             message = probe.get("message", "")
@@ -87,24 +223,44 @@ def run(root: Path = ROOT) -> int:
             continue
         completed.append(probe["id"])
 
-    pins = computed_pins(policy, root)
+    guards_completed = run_guards(document, failures)
+
+    # Every payload receipt the supervisor emitted must carry the complete
+    # field set the pinned replay schema requires, because a replay receipt
+    # embeds these verbatim and a later validation rejects an incomplete one.
+    required = receipt_required_fields(root)
+    for payload in observed_receipts:
+        missing = [field for field in required if field not in payload]
+        if missing:
+            failures.append(
+                f"{payload['test_id']}: payload receipt omits required field(s) "
+                f"{missing!r}"
+            )
+            break
+
     receipt = {
         "schema": 1,
         "code_tree": pins["release_test_code_tree"],
         "support_tree": pins["release_test_support_tree"],
+        "inventory_sha256": pins["release_test_inventory_sha256"],
         "output_mount": "/tenkz-output",
         "tool_fingerprints": {
             name: resolve_tool(name, pattern, root)[1]
             for name, pattern in sorted(tool_profile(root).items())
         },
         "probes_completed": completed,
+        "guards_completed": guards_completed,
+        "receipt_fields_required": required,
     }
     if failures:
         for failure in failures:
             print(f"FAIL: {failure}", file=sys.stderr)
         return 1
     print(json.dumps(receipt, indent=2, sort_keys=True))
-    print(f"PASS: {len(completed)} supervisor isolation probe(s) completed")
+    print(
+        f"PASS: {len(completed)} isolation probe(s) and {len(guards_completed)} "
+        f"escape guard(s) completed"
+    )
     return 0
 
 

--- a/tests/tenkz/release-harness/selftest.py
+++ b/tests/tenkz/release-harness/selftest.py
@@ -40,6 +40,7 @@ from supervisor import (  # noqa: E402
     expose,
     observe,
     read_policy,
+    require_armed_workflow,
     require_regular_file,
     require_tree_is_clean,
     resolve_tool,
@@ -143,39 +144,147 @@ def guard_special_entry(workspace: Path) -> None:
     require_tree_is_clean(fake_root, "docs/tenkz", "guard fixture path")
 
 
+ARMED_WORKFLOW_PATH = ".github/workflows/tenkz-release-policy.yml"
+ARMED_WORKFLOW = """name: x
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      - id: tenkz-network-denied
+        run: true
+  publish:
+    needs: validate
+    environment: tenkz-release-publisher
+    permissions:
+      contents: write
+    steps:
+      - run: echo ${{ secrets.TENKZ_FINAL_TAG_SIGNING_KEY }}
+"""
+
+
+def staged_workflow(workspace: Path, body: str) -> Path:
+    fake_root = workspace / "repository"
+    (fake_root / ".github" / "workflows").mkdir(parents=True)
+    (fake_root / ARMED_WORKFLOW_PATH).write_text(body, encoding="utf-8")
+    return fake_root
+
+
+def guard_armed_workflow_comments(workspace: Path) -> None:
+    """Markers appearing only in comments must not satisfy the armed check.
+
+    The pending workflow's own header names the publisher environment and
+    `contents: write` while explaining that neither exists, so a substring
+    check passed on its own documentation.
+    """
+
+    body = (
+        "name: x\n"
+        "# tenkz-release-publisher contents: write "
+        "TENKZ_FINAL_TAG_SIGNING_KEY tenkz-network-denied\n"
+        "jobs:\n  validate:\n    needs: nothing\n    steps:\n      - run: true\n"
+    )
+    require_armed_workflow(staged_workflow(workspace, body))
+
+
+def guard_armed_workflow_foreign_needs(workspace: Path) -> None:
+    """A `needs:` on another job must not order the publisher."""
+
+    require_armed_workflow(
+        staged_workflow(workspace, ARMED_WORKFLOW.replace("    needs: validate\n", ""))
+    )
+
+
+def guard_armed_workflow_mutable_action(workspace: Path) -> None:
+    """A tag-pinned action must not pass the closure requirement."""
+
+    require_armed_workflow(
+        staged_workflow(
+            workspace,
+            ARMED_WORKFLOW.replace("@d23441a48e516b6c34aea4fa41551a30e30af803", "@v6"),
+        )
+    )
+
+
+def guard_armed_workflow_short_environment(workspace: Path) -> None:
+    """Both legal spellings of `environment:` must be accepted.
+
+    This guard expects acceptance, not refusal: a check that rejected the
+    single-line form would refuse a correctly armed workflow.
+    """
+
+    require_armed_workflow(staged_workflow(workspace, ARMED_WORKFLOW))
+
+
+def guard_armed_workflow_block_environment(workspace: Path) -> None:
+    """The block spelling of `environment:` must be accepted too."""
+
+    require_armed_workflow(
+        staged_workflow(
+            workspace,
+            ARMED_WORKFLOW.replace(
+                "    environment: tenkz-release-publisher",
+                "    environment:\n      name: tenkz-release-publisher",
+            ),
+        )
+    )
+
+
 GUARDS = {
     "nested-symlink": guard_nested_symlink,
     "symlinked-program-path": guard_symlinked_program_path,
     "symlinked-parent": guard_symlinked_parent,
     "special-entry": guard_special_entry,
+    "armed-workflow-comments": guard_armed_workflow_comments,
+    "armed-workflow-foreign-needs": guard_armed_workflow_foreign_needs,
+    "armed-workflow-mutable-action": guard_armed_workflow_mutable_action,
+    "armed-workflow-short-environment": guard_armed_workflow_short_environment,
+    "armed-workflow-block-environment": guard_armed_workflow_block_environment,
 }
 
 
 def run_guards(document: dict, failures: list[str]) -> list[str]:
+    """Run each guard and compare the supervisor's answer with its expectation.
+
+    Most guards expect a refusal. A few expect acceptance: a check that refuses
+    a legal spelling is as wrong as one that accepts an illegal shape, and only
+    a guard that expects acceptance can catch it.
+    """
+
     completed: list[str] = []
     for guard in document["guard"]:
         name = guard["id"]
+        expected = guard.get("outcome", "refused")
         if name not in GUARDS:
             failures.append(f"{name}: the expectations name an unknown guard")
             continue
         workspace = Path(tempfile.mkdtemp(prefix="tenkz-guard-"))
+        observed = "accepted"
+        detail = ""
         try:
             GUARDS[name](workspace)
         except SupervisorError as error:
-            if guard["message"] not in str(error):
-                failures.append(
-                    f"{name}: refused with {str(error)!r}, which does not carry "
-                    f"the expected {guard['message']!r}"
-                )
-                continue
-            completed.append(name)
-            continue
+            observed, detail = "refused", str(error)
         except OSError as error:
             failures.append(f"{name}: could not be staged: {error}")
-            continue
-        finally:
             shutil.rmtree(workspace, ignore_errors=True)
-        failures.append(f"{name}: the supervisor accepted a staged escape")
+            continue
+        shutil.rmtree(workspace, ignore_errors=True)
+
+        if observed != expected:
+            failures.append(
+                f"{name}: expected the supervisor to have {expected} this, and it "
+                f"{observed} it{': ' + detail if detail else ''}"
+            )
+            continue
+        message = guard.get("message", "")
+        if observed == "refused" and message and message not in detail:
+            failures.append(
+                f"{name}: refused with {detail!r}, which does not carry the "
+                f"expected {message!r}"
+            )
+            continue
+        completed.append(name)
     return completed
 
 

--- a/tests/tenkz/release-harness/selftest.py
+++ b/tests/tenkz/release-harness/selftest.py
@@ -230,6 +230,22 @@ def guard_armed_workflow_block_environment(workspace: Path) -> None:
     )
 
 
+# The closed probe set. `selftest_probe.py` implements each mode; the
+# expectations name each one and its outcome. The three collections must agree
+# exactly, so neither a probe nor an expectation can quietly disappear.
+PROBES = (
+    "pass",
+    "assertion",
+    "unrelated-exit",
+    "exit-without-receipt",
+    "isolation",
+    "environment",
+    "readonly",
+    "timeout",
+    "bool-schema",
+    "orphan-timeout",
+)
+
 GUARDS = {
     "nested-symlink": guard_nested_symlink,
     "symlinked-program-path": guard_symlinked_program_path,
@@ -306,6 +322,22 @@ def run(root: Path = ROOT) -> int:
         print("FAIL: self-test expectations have an unknown schema", file=sys.stderr)
         return 1
     fingerprint = document["synthetic_fingerprint"]
+
+    # The suite is closed in both directions. An expectations file listing no
+    # probes and no guards is valid TOML and would have printed a cheerful
+    # "0 isolation probe(s) completed", letting activation pin a support tree
+    # carrying no isolation evidence at all.
+    named_probes = {probe["id"] for probe in document.get("probe", [])}
+    named_guards = {guard["id"] for guard in document.get("guard", [])}
+    if named_probes != set(PROBES) or named_guards != set(GUARDS):
+        print(
+            f"FAIL: the expectations name probes {sorted(named_probes)} and guards "
+            f"{sorted(named_guards)}, which differ from the suite's "
+            f"{sorted(PROBES)} and {sorted(GUARDS)}",
+            file=sys.stderr,
+        )
+        return 1
+
     pins = computed_pins(policy, root)
 
     completed: list[str] = []

--- a/tests/tenkz/release-harness/selftest_probe.py
+++ b/tests/tenkz/release-harness/selftest_probe.py
@@ -13,9 +13,12 @@ the synthetic fingerprint rather than as a crash.
 
 from __future__ import annotations
 
+import json
 import os
+import subprocess
 import sys
 import time
+import tomllib
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -31,22 +34,13 @@ def test_id() -> str:
 
     return f"supervisor-selftest-{sys.argv[1] if len(sys.argv) > 1 else 'unknown'}"
 
-# Exposed to every command: the pinned trees, the inventory, and the four
-# canonical artifacts.  Nothing else in the repository may be reachable.
-DECLARED = (
-    "tests/tenkz/release-harness/harnesslib.py",
-    "tests/tenkz/release-support/tool-profile.toml",
-    "tests/tenkz/release-tests.toml",
-    "tex/tenkz/tenkz.sty",
-    "docs/tenkz/TNLOG.md",
-)
-UNDECLARED = (
-    "scripts/check_tenkz_policy.py",
-    "docs/tenkz/SOAK-1.0.md",
-    "tests/tenkz/census-baseline.json",
-    "lakefile.toml",
-    "TNLean.lean",
-)
+# The pinned manifest of everything this run may see, read from the support
+# tree, which is itself exposed.  The probe compares it with the *complete*
+# view rather than sampling a handful of paths: sampling passes whenever a
+# regression exposes something the sample forgot to name, and this probe is the
+# activation evidence that the access denials hold.
+MANIFEST = "tests/tenkz/release-support/selftest-expectations.toml"
+TOOL_PROFILE = "tests/tenkz/release-support/tool-profile.toml"
 
 
 def check(condition: object, reason: str) -> None:
@@ -58,11 +52,33 @@ def check(condition: object, reason: str) -> None:
     )
 
 
+def allowed_view() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    document = tomllib.loads(Path(MANIFEST).read_text(encoding="utf-8"))
+    view = document["view"]
+    return tuple(view["roots"]), tuple(view["files"])
+
+
 def mode_isolation() -> None:
-    absent = [path for path in DECLARED if not Path(path).exists()]
+    roots, files = allowed_view()
+
+    absent = [path for path in files if not Path(path).exists()]
     check(not absent, f"the view is missing declared entries {absent!r}")
-    present = [path for path in UNDECLARED if Path(path).exists()]
-    check(not present, f"the view exposes undeclared entries {present!r}")
+    missing_roots = [root for root in roots if not Path(root).is_dir()]
+    check(not missing_roots, f"the view is missing pinned trees {missing_roots!r}")
+
+    # Every regular file anywhere in the view must be inside a pinned tree or
+    # be one of the named blobs. Anything else entered the view undeclared.
+    unexpected = sorted(
+        str(path)
+        for path in Path(".").rglob("*")
+        if path.is_file()
+        and str(path) not in files
+        and not any(str(path).startswith(f"{root}/") for root in roots)
+    )
+    check(
+        not unexpected,
+        f"the view exposes {len(unexpected)} undeclared entr(ies): {unexpected[:10]!r}",
+    )
 
 
 def mode_environment() -> None:
@@ -97,6 +113,22 @@ def mode_environment() -> None:
     check(
         not repository_directories,
         f"PATH reaches into the pinned trees at {repository_directories!r}",
+    )
+
+    # PATH must name the allowlist, not a directory that happens to contain
+    # it. A CPython install ships `pip`, `pydoc`, and versioned interpreters
+    # beside `python3`, so putting the interpreter's parent on PATH would hand
+    # the command every one of them un-fingerprinted.
+    allowed = set(tomllib.loads(Path(TOOL_PROFILE).read_text(encoding="utf-8"))["tool"])
+    reachable: set[str] = set()
+    for entry in os.environ["PATH"].split(os.pathsep):
+        directory = Path(entry)
+        if directory.is_dir():
+            reachable.update(item.name for item in directory.iterdir())
+    check(
+        reachable == allowed,
+        f"PATH reaches {sorted(reachable - allowed)!r} beyond the tool allowlist "
+        f"{sorted(allowed)!r}",
     )
 
 
@@ -172,6 +204,29 @@ def main() -> int:
         mode_readonly()
         return 0
     if mode == "timeout":
+        time.sleep(30)
+        return 0
+    if mode == "bool-schema":
+        # A receipt whose `schema` is JSON `true` must not be read as version 1
+        # merely because Python considers `True == 1`.
+        receipt = output_directory() / "assertion-failure-v1.json"
+        receipt.write_text(
+            json.dumps(
+                {
+                    "schema": True,
+                    "test_id": test_id(),
+                    "failure_fingerprint": FINGERPRINT,
+                    "completed": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return 10
+    if mode == "orphan-timeout":
+        # Leave a descendant running and then hang. The supervisor must bound
+        # the whole process group, not just this process.
+        subprocess.Popen([sys.executable, "-c", "import time; time.sleep(300)"])
         time.sleep(30)
         return 0
     print(f"unknown probe mode {mode!r}", file=sys.stderr)

--- a/tests/tenkz/release-harness/selftest_probe.py
+++ b/tests/tenkz/release-harness/selftest_probe.py
@@ -100,14 +100,52 @@ def mode_environment() -> None:
     )
 
 
-def mode_readonly() -> None:
-    subject = Path("tex/tenkz/tenkz.sty")
+def refused(action) -> bool:
+    """Run one mutation and report whether the view refused it."""
+
     try:
-        with subject.open("a", encoding="utf-8"):
-            writable = True
+        action()
     except OSError:
-        writable = False
-    check(not writable, "a declared subject is writable inside the view")
+        return True
+    return False
+
+
+def mode_readonly() -> None:
+    # Appending to a declared subject is the shallow half of the guarantee.
+    subject = Path("tex/tenkz/tenkz.sty")
+    check(
+        refused(lambda: subject.open("a", encoding="utf-8").close()),
+        "a declared subject is writable inside the view",
+    )
+
+    # The deep half: a writable directory permits create, rename, and unlink,
+    # so a command could delete a declared subject and put its own bytes at the
+    # same path while every file in the view still reads mode 444. Each probe
+    # below mutates a *directory*, not a file, and each must be refused.
+    directory = Path("tex/tenkz")
+    intruder = directory / "intruder.sty"
+    check(
+        refused(lambda: intruder.write_text("x\n", encoding="utf-8")),
+        f"a new file can be created under the read-only subject tree {directory}",
+    )
+    check(
+        refused(lambda: (directory / "intruder-dir").mkdir()),
+        f"a new directory can be created under {directory}",
+    )
+    check(
+        refused(lambda: subject.rename(directory / "renamed.sty")),
+        f"a declared subject can be renamed inside {directory}",
+    )
+    check(
+        refused(subject.unlink),
+        f"a declared subject can be deleted from {directory}",
+    )
+    check(
+        subject.exists() and not intruder.exists(),
+        f"{directory} was mutated despite refusing every recorded attempt",
+    )
+
+    # The output mount is the one writable path.
     probe = output_directory() / "writable-probe"
     probe.write_text("ok\n", encoding="utf-8")
     check(probe.read_text(encoding="utf-8") == "ok\n", "the output mount is not writable")

--- a/tests/tenkz/release-harness/selftest_probe.py
+++ b/tests/tenkz/release-harness/selftest_probe.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""The one synthetic program the supervisor self-test drives.
+
+Each mode exercises one property of the hermetic view or one branch of the
+supervisor's outcome classification. The probe is never in the release-test
+inventory; `selftest.py` builds synthetic inventory entries for it and checks
+the outcome against the pinned expectations in the support tree.
+
+Modes that assert something about the view report through the same protocol as
+a real release test, so a broken view is reported as an assertion failure with
+the synthetic fingerprint rather than as a crash.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from harnesslib import assert_that, output_directory  # noqa: E402
+
+
+FINGERPRINT = "5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e"
+
+
+def test_id() -> str:
+    """The synthetic entry id `selftest.py` gave this run, derived from the mode."""
+
+    return f"supervisor-selftest-{sys.argv[1] if len(sys.argv) > 1 else 'unknown'}"
+
+# Exposed to every command: the pinned trees, the inventory, and the four
+# canonical artifacts.  Nothing else in the repository may be reachable.
+DECLARED = (
+    "tests/tenkz/release-harness/harnesslib.py",
+    "tests/tenkz/release-support/tool-profile.toml",
+    "tests/tenkz/release-tests.toml",
+    "tex/tenkz/tenkz.sty",
+    "docs/tenkz/TNLOG.md",
+)
+UNDECLARED = (
+    "scripts/check_tenkz_policy.py",
+    "docs/tenkz/SOAK-1.0.md",
+    "tests/tenkz/census-baseline.json",
+    "lakefile.toml",
+    "TNLean.lean",
+)
+
+
+def check(condition: object, reason: str) -> None:
+    assert_that(
+        condition,
+        test_id=test_id(),
+        failure_fingerprint=FINGERPRINT,
+        reason=reason,
+    )
+
+
+def mode_isolation() -> None:
+    absent = [path for path in DECLARED if not Path(path).exists()]
+    check(not absent, f"the view is missing declared entries {absent!r}")
+    present = [path for path in UNDECLARED if Path(path).exists()]
+    check(not present, f"the view exposes undeclared entries {present!r}")
+
+
+def mode_environment() -> None:
+    # The supervisor sets exactly these. An operating system may inject others
+    # into any child — macOS adds `__CF_USER_TEXT_ENCODING` — so the assertion
+    # is that nothing beyond the declared set carries a path. That is the rule
+    # the ledger states: no inherited repository-path variables.
+    declared = {
+        "PATH",
+        "LC_ALL",
+        "LANG",
+        "TZ",
+        "HOME",
+        "TENKZ_TEST_OUTPUT",
+        "PYTHONDONTWRITEBYTECODE",
+    }
+    missing = sorted(declared - set(os.environ))
+    check(not missing, f"the environment is missing {missing!r}")
+    leaked = sorted(
+        name
+        for name, value in os.environ.items()
+        if name not in declared and "/" in value
+    )
+    check(not leaked, f"the environment carries inherited path variables {leaked!r}")
+    check(os.environ.get("LC_ALL") == "C", "LC_ALL is not the fixed locale")
+    check(os.environ.get("TZ") == "UTC", "TZ is not the fixed timezone")
+    repository_directories = [
+        entry
+        for entry in os.environ["PATH"].split(os.pathsep)
+        if "release-harness" in entry or "release-support" in entry
+    ]
+    check(
+        not repository_directories,
+        f"PATH reaches into the pinned trees at {repository_directories!r}",
+    )
+
+
+def mode_readonly() -> None:
+    subject = Path("tex/tenkz/tenkz.sty")
+    try:
+        with subject.open("a", encoding="utf-8"):
+            writable = True
+    except OSError:
+        writable = False
+    check(not writable, "a declared subject is writable inside the view")
+    probe = output_directory() / "writable-probe"
+    probe.write_text("ok\n", encoding="utf-8")
+    check(probe.read_text(encoding="utf-8") == "ok\n", "the output mount is not writable")
+    probe.unlink()
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode == "pass":
+        return 0
+    if mode == "assertion":
+        check(False, "the probe reports its one synthetic assertion failure")
+    if mode == "unrelated-exit":
+        return 3
+    if mode == "exit-without-receipt":
+        return 10
+    if mode == "isolation":
+        mode_isolation()
+        return 0
+    if mode == "environment":
+        mode_environment()
+        return 0
+    if mode == "readonly":
+        mode_readonly()
+        return 0
+    if mode == "timeout":
+        time.sleep(30)
+        return 0
+    print(f"unknown probe mode {mode!r}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -50,6 +50,7 @@ import sys
 import tempfile
 import tomllib
 from dataclasses import dataclass
+from datetime import date as calendar_date
 from pathlib import Path
 
 
@@ -869,7 +870,7 @@ MANIFEST_FIELDS = {
     "test_code_tree",
     "test_support_tree",
 }
-ISO_DATE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
+ISO_DATE = re.compile(r"(?P<y>[0-9]{4})-(?P<m>[0-9]{2})-(?P<d>[0-9]{2})")
 
 
 def validate_manifest(
@@ -908,7 +909,12 @@ def validate_manifest(
         f"{relative} version {release['version']!r} is not the tag's {version!r}",
     )
     date = str(release["date"])
-    require(ISO_DATE.fullmatch(date) is not None, f"{relative} date is not ISO 8601")
+    match = ISO_DATE.fullmatch(date)
+    require(match is not None, f"{relative} date is not spelled YYYY-MM-DD")
+    try:
+        calendar_date(int(match["y"]), int(match["m"]), int(match["d"]))
+    except ValueError:
+        require(False, f"{relative} date {date} is not a calendar date")
     for field, pin in (
         ("test_inventory_sha256", "release_test_inventory_sha256"),
         ("test_code_tree", "release_test_code_tree"),
@@ -919,16 +925,38 @@ def validate_manifest(
             f"{relative} {field} does not equal this tree's {pins[pin]}",
         )
 
-    # The package metadata and manual declare the manifest's version and date;
-    # the change record and event-format declaration name the tag and version.
-    declaration = (root / policy.package_metadata).read_text(encoding="utf-8")
+    # The package metadata and manual declare the manifest's version *and*
+    # date; the change record and event-format declaration name the exact tag.
+    # A bare version substring is not a declaration — every one of these files
+    # mentions version numbers in prose — so each is matched at its canonical
+    # declaration line.
+    slashed = date.replace("-", "/")
+    package = (root / policy.package_metadata).read_text(encoding="utf-8")
     require(
-        f"v{version}" in declaration and date.replace("-", "/") in declaration,
-        f"{policy.package_metadata} does not declare version {version} at {date}",
+        re.search(
+            rf"\\ProvidesPackage\{{tenkz\}}\[{re.escape(slashed)} v{re.escape(version)} ",
+            package,
+        )
+        is not None,
+        f"{policy.package_metadata} does not declare v{version} dated {slashed}",
     )
-    for artifact in (policy.manual, policy.change_record, policy.event_format):
+    manual = (root / policy.manual).read_text(encoding="utf-8")
+    require(
+        re.search(
+            rf"(?m)^\\date\{{[^}}]*{re.escape(date)}[^}}]*\}}|"
+            rf"^\\tenkzversion\{{{re.escape(version)}\}}",
+            manual,
+        )
+        is not None
+        or (version in manual and date in manual),
+        f"{policy.manual} does not declare version {version} dated {date}",
+    )
+    for artifact in (policy.change_record, policy.event_format):
         text = (root / artifact).read_text(encoding="utf-8")
-        require(version in text, f"{artifact} does not name version {version}")
+        require(
+            tag in text,
+            f"{artifact} does not name the exact tag {tag}",
+        )
     return release
 
 
@@ -1066,8 +1094,15 @@ def observe(
     finally:
         make_writable(view)
         if output_mount is not None:
+            # `lstat`, and never `is_file()`: a symlink or a special entry left
+            # in the mount would otherwise raise out of `finally` and discard
+            # the classification the run had already reached.
             for leftover in sorted(output_mount.rglob("*"), reverse=True):
-                leftover.unlink() if leftover.is_file() else leftover.rmdir()
+                try:
+                    mode = os.lstat(leftover).st_mode
+                    leftover.rmdir() if stat.S_ISDIR(mode) else leftover.unlink()
+                except OSError:
+                    pass
         shutil.rmtree(workspace, ignore_errors=True)
 
 
@@ -1282,130 +1317,218 @@ def require_fixed_tagger(root: Path) -> None:
 ARMED_WORKFLOW = ".github/workflows/tenkz-release-policy.yml"
 YAML_COMMENT = re.compile(r"(?m)(?:(?<=^)|(?<=\s))#.*$")
 MUTABLE_ACTION = re.compile(r"uses:[ \t]*\S+@(?!\b[0-9a-f]{40}\b)\S+")
-# Both block style (`- uses: x`) and YAML flow style (`- {uses: x}`) name an
-# action. A flow mapping pinned to a full SHA evaded both this check and the
-# mutable-reference one, which is the combination that mattered.
-ANY_ACTION = re.compile(r"(?m)^[ \t]+(?:-[ \t]+)?[{[]?[ \t]*uses:[ \t]*\S+")
-JOBS_KEY = re.compile(r"(?m)^jobs:[ \t]*$")
-# `[ \t]` rather than `\s`: `\s` matches a newline, so a header at the very
-# start of the scanned text absorbs the preceding line break into its indent
-# and measures one deeper than the same header found mid-text.
-JOB_HEADER = re.compile(r"(?m)^([ \t]+)([A-Za-z_][\w-]*):[ \t]*$")
-# `environment: name` and the block form `environment:\n  name: name` are both
-# legal GitHub spellings of the same thing, so both must match.
-PUBLISHER_ENVIRONMENT = re.compile(
-    r"(?m)^\s+environment:\s*(?:tenkz-release-publisher\s*$"
-    r"|\s*\n\s+name:\s*tenkz-release-publisher\s*$)"
-)
-PUBLISHER_NEEDS = re.compile(r"(?m)^[ \t]+needs:[ \t]*(.+)$")
-STEP_MARKER = re.compile(r"(?m)^[ \t]+-[ \t]+(?:id|name|uses|run):")
+
+
 NO_OP_RUN = re.compile(r"^(?:true|:|echo\b.*)$")
 BOUNDARY_STEPS = {
-    "tenkz-network-denied": (
-        "denies network access before repository code runs",
-        "release_enforcement_network",
-    ),
+    "tenkz-network-denied": "denies network access before repository code runs",
     "tenkz-filesystem-isolated": (
         "places the run in a mount namespace under an identity that does not "
-        "own the checkout",
-        "release_test_protocol",
+        "own the checkout"
     ),
 }
-PUBLISHER_REQUIREMENTS = (
-    (
-        re.compile(r"(?m)^[ \t]+contents:[ \t]*write[ \t]*$"),
-        "a job-level `contents: write` permission",
-    ),
-    (
-        re.compile(r"\$\{\{\s*secrets\.TENKZ_FINAL_TAG_SIGNING_KEY\s*\}\}"),
-        "a reference to the TENKZ_FINAL_TAG_SIGNING_KEY secret",
-    ),
-)
 
 
-def workflow_jobs(text: str) -> dict[str, str]:
-    """Split a workflow's `jobs:` mapping into one text block per job.
+# --------------------------------------------------------------------------
+# A YAML subset, enough for a workflow
+# --------------------------------------------------------------------------
+#
+# Six findings on this file in a row came from matching workflow structure with
+# regular expressions: a flow mapping evaded an action check, then evaded it
+# again with the keys reordered; a permission set was checked by presence; a
+# `needs:` was checked by nonemptiness. Each fix was a longer pattern and each
+# left the next shape open. The workflow is a mapping of mappings, so it is
+# parsed as one. This handles block mappings, block sequences, flow mappings
+# and sequences, and plain or quoted scalars — which is the whole of what a
+# workflow file needs — and nothing else, because anything it cannot parse
+# should fail closed rather than be guessed at.
 
-    This is not a YAML parser and does not need to be: job keys are the only
-    mapping at their indentation under `jobs:`, so a block runs from one such
-    key to the next. Splitting matters because the publisher's requirements are
-    requirements *on the publisher job* — a `needs:` belonging to a validation
-    job says nothing about what orders the publisher.
+
+def parse_yaml(text: str) -> dict:
+    """Parse a comment-stripped workflow into nested dicts, lists, and strings."""
+
+    lines = []
+    for raw in text.splitlines():
+        if not raw.strip():
+            continue
+        lines.append((len(raw) - len(raw.lstrip(" ")), raw.strip()))
+    value, _ = _parse_block(lines, 0, 0)
+    return value if isinstance(value, dict) else {}
+
+
+def _parse_block(lines: list[tuple[int, str]], index: int, indent: int):
+    if index >= len(lines):
+        return None, index
+    if lines[index][1].startswith("- "):
+        items = []
+        while (
+            index < len(lines)
+            and lines[index][0] >= indent
+            and lines[index][1].startswith("- ")
+        ):
+            body = lines[index][1][2:].strip()
+            inner = lines[index][0] + 2
+            if ":" in body and not body.startswith(("{", "[")):
+                nested = [(inner, body)]
+                index += 1
+                while index < len(lines) and lines[index][0] >= inner and not (
+                    lines[index][0] == inner and lines[index][1].startswith("- ")
+                ):
+                    nested.append(lines[index])
+                    index += 1
+                value, _ = _parse_block(nested, 0, inner)
+                items.append(value)
+            else:
+                items.append(_scalar(body))
+                index += 1
+            while (
+                index < len(lines)
+                and lines[index][0] > indent
+                and not lines[index][1].startswith("- ")
+            ):
+                index += 1
+        return items, index
+
+    mapping = {}
+    while index < len(lines) and lines[index][0] >= indent:
+        depth, body = lines[index]
+        if depth > indent:
+            index += 1
+            continue
+        if ":" not in body:
+            index += 1
+            continue
+        key, _, rest = body.partition(":")
+        key, rest = key.strip(), rest.strip()
+        if rest:
+            mapping[key] = _scalar(rest)
+            index += 1
+            continue
+        index += 1
+        if index < len(lines) and (
+            lines[index][0] > depth
+            or (lines[index][0] == depth and lines[index][1].startswith("- "))
+        ):
+            child = lines[index][0]
+            value, index = _parse_block(lines, index, child)
+            mapping[key] = value
+        else:
+            mapping[key] = ""
+    return mapping, index
+
+
+def _scalar(text: str):
+    text = text.strip()
+    if text.startswith("{") and text.endswith("}"):
+        return {
+            k.strip(): _scalar(v)
+            for k, _, v in (item.partition(":") for item in _split_flow(text[1:-1]))
+            if k.strip()
+        }
+    if text.startswith("[") and text.endswith("]"):
+        return [_scalar(item) for item in _split_flow(text[1:-1]) if item.strip()]
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        return text[1:-1]
+    return text
+
+
+def _split_flow(text: str) -> list[str]:
+    parts, depth, current = [], 0, []
+    for char in text:
+        if char in "{[":
+            depth += 1
+        elif char in "}]":
+            depth -= 1
+        if char == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current))
+    return [part for part in parts if part.strip()]
+
+
+def workflow_jobs(text: str) -> dict:
+    """The workflow's `jobs:` mapping, parsed."""
+
+    jobs = parse_yaml(text).get("jobs")
+    return jobs if isinstance(jobs, dict) else {}
+
+
+def steps_of(job: dict) -> list[dict]:
+    steps = job.get("steps") if isinstance(job, dict) else None
+    if not isinstance(steps, list):
+        return []
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def environment_name(job: dict) -> str:
+    """The job's environment, in either the scalar or the mapping spelling."""
+
+    value = job.get("environment") if isinstance(job, dict) else None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        name = value.get("name")
+        return name if isinstance(name, str) else ""
+    return ""
+
+
+def needs_of(job: dict) -> set[str]:
+    value = job.get("needs") if isinstance(job, dict) else None
+    if isinstance(value, str):
+        return {value} if value else set()
+    if isinstance(value, list):
+        return {item for item in value if isinstance(item, str)}
+    return set()
+
+
+def mentions_secret(value: object) -> bool:
+    if isinstance(value, str):
+        return "TENKZ_FINAL_TAG_SIGNING_KEY" in value
+    if isinstance(value, dict):
+        return any(mentions_secret(item) for item in value.values())
+    if isinstance(value, list):
+        return any(mentions_secret(item) for item in value)
+    return False
+
+
+def boundary_failures(name: str, job_name: str, job: dict) -> list[str]:
+    """Check one declared boundary step: present, early, and not a no-op.
+
+    What a checker can establish is that the workflow declares the step, that
+    it precedes every ordinary step in its job, and that its command is not a
+    placeholder. What it cannot establish is that the command achieves what it
+    is named for. `RELEASE-POLICY.md` §2 records that residue: the marker is
+    the workflow author's declaration, and the review of the arming change is
+    what confirms it.
     """
 
-    start = JOBS_KEY.search(text)
-    if start is None:
-        return {}
-    body = text[start.end() :]
-    headers = list(JOB_HEADER.finditer(body))
-    if not headers:
-        return {}
-    indent = min(len(header.group(1)) for header in headers)
-    jobs: dict[str, str] = {}
-    tops = [header for header in headers if len(header.group(1)) == indent]
-    for index, header in enumerate(tops):
-        stop = tops[index + 1].start() if index + 1 < len(tops) else len(body)
-        jobs[header.group(2)] = body[header.start() : stop]
-    return jobs
-
-
-def named_steps(block: str) -> list[tuple[int, str]]:
-    """Each step in one job block, as its position and its text."""
-
-    marks = [match.start() for match in STEP_MARKER.finditer(block)]
-    return [
-        (index, block[start : marks[index + 1] if index + 1 < len(marks) else len(block)])
-        for index, start in enumerate(marks)
+    description = BOUNDARY_STEPS[name]
+    steps = steps_of(job)
+    positions = [
+        index
+        for index, step in enumerate(steps)
+        if step.get("id") == name or step.get("name") == name
     ]
-
-
-def boundary_step_failures(name: str, block: str, job: str) -> list[str]:
-    """Check one declared boundary step: present, first, and not a no-op.
-
-    What a checker can establish about these steps is that the workflow
-    declares one, that it runs before any other step in its job, and that its
-    command is not a placeholder. What it cannot establish is that the command
-    achieves what it is named for. `RELEASE-POLICY.md` §2 records that residue:
-    the marker is the workflow author's declaration, and the review of the
-    arming change is what confirms it.
-    """
-
-    description = BOUNDARY_STEPS[name][0]
-    steps = named_steps(block)
-    matching = [
-        (index, text)
-        for index, text in steps
-        if re.search(rf"(?m)^[ \t]+(?:-[ \t]+)?(?:id|name):[ \t]*{re.escape(name)}[ \t]*$", text)
-    ]
-    if not matching:
-        return [f"job {job} has no step named {name}, which {description}"]
-    index, text = matching[0]
-    failures = []
-    # There is more than one boundary step, so "first" cannot be the rule.
-    # Each must precede every step that is not itself a boundary — that is the
-    # ordering the policy states: before repository code runs.
-    boundary_positions = {
-        position
-        for position, step in steps
-        if any(
-            re.search(
-                rf"(?m)^[ \t]+(?:-[ \t]+)?(?:id|name):[ \t]*{re.escape(other)}[ \t]*$",
-                step,
-            )
-            for other in BOUNDARY_STEPS
-        )
+    if not positions:
+        return [f"job {job_name} has no step named {name}, which {description}"]
+    boundary = {
+        index
+        for index, step in enumerate(steps)
+        if step.get("id") in BOUNDARY_STEPS or step.get("name") in BOUNDARY_STEPS
     }
-    ordinary = [position for position, _ in steps if position not in boundary_positions]
-    if ordinary and index > min(ordinary):
+    ordinary = [index for index in range(len(steps)) if index not in boundary]
+    failures = []
+    if ordinary and positions[0] > min(ordinary):
         failures.append(
-            f"job {job} runs {min(ordinary) + 1} ordinary step(s) before {name}; "
-            f"the step that {description} must precede repository code"
+            f"job {job_name} runs an ordinary step before {name}; the step that "
+            f"{description} must precede repository code"
         )
-    run = re.search(r"(?m)^[ \t]+run:[ \t]*(?:\|[ \t]*\n[ \t]+)?(.+)$", text)
-    command = run.group(1).strip() if run else ""
-    if not command or NO_OP_RUN.fullmatch(command):
+    command = steps[positions[0]].get("run", "")
+    if not isinstance(command, str) or NO_OP_RUN.fullmatch(command.strip()):
         failures.append(
-            f"job {job} declares {name} as the no-op {command!r}; a step that "
+            f"job {job_name} declares {name} as the no-op {command!r}; a step that "
             f"{description} has to do something"
         )
     return failures
@@ -1415,90 +1538,114 @@ def require_armed_workflow(root: Path) -> None:
     """Check the mechanisms the armed enforcement workflow must carry.
 
     The workflow's own header says `check-readiness` fails closed when these
-    are missing, so this is where that promise is kept.
-
-    The checks read the file with its comments stripped and are scoped to the
-    job they are about. A whole-file substring search would be satisfied by
-    this very file's header, which names the publisher environment and
-    `contents: write` while explaining that neither exists yet; a whole-file
-    pattern search would be satisfied by any other job's `needs:`. A check that
-    its own documentation passes is not a check.
+    are missing, so this is where that promise is kept. Everything below reads
+    the parsed workflow rather than its text: a substring search was satisfied
+    by this file's own header comment, and a pattern search was satisfied by
+    the wrong job or by a mapping whose keys happened to be in another order.
     """
 
     require_regular_file(root, ARMED_WORKFLOW, "the enforcement workflow")
     text = YAML_COMMENT.sub("", (root / ARMED_WORKFLOW).read_text(encoding="utf-8"))
     jobs = workflow_jobs(text)
+    require(jobs, f"{ARMED_WORKFLOW} declares no jobs")
     publishers = [
-        name for name, block in jobs.items() if PUBLISHER_ENVIRONMENT.search(block)
+        name
+        for name, job in jobs.items()
+        if environment_name(job) == "tenkz-release-publisher"
     ]
     require(
-        publishers,
-        f"armed policy but {ARMED_WORKFLOW} has no job whose `environment:` is "
-        f"tenkz-release-publisher",
-    )
-    require(
         len(publishers) == 1,
-        f"{ARMED_WORKFLOW} has {len(publishers)} publisher jobs {publishers}; the "
-        f"campaign has one terminal publisher",
+        f"{ARMED_WORKFLOW} has {len(publishers)} job(s) whose `environment:` is "
+        f"tenkz-release-publisher; the campaign has one terminal publisher",
     )
     publisher_name = publishers[0]
     publisher = jobs[publisher_name]
+    failures: list[str] = []
 
-    failures = [
-        f"the {publisher_name} job lacks {description}"
-        for pattern, description in PUBLISHER_REQUIREMENTS
-        if pattern.search(publisher) is None
-    ]
-
-    # The publisher's `needs:` must name a real validation job, not merely be
-    # nonempty: an arbitrary dependency lets the job that writes the release
-    # tag start without the gate it exists behind.
-    needs = PUBLISHER_NEEDS.search(publisher)
-    if needs is None:
+    # The publisher's permission set is exact. `contents: write` alongside
+    # another capability is more authority than the contract grants the one job
+    # that holds the signing key.
+    permissions = publisher.get("permissions")
+    if permissions != {"contents": "write"}:
         failures.append(
-            f"the {publisher_name} job has no `needs:`, so nothing orders it "
-            f"after post-merge validation"
+            f"the {publisher_name} job declares permissions {permissions!r}; the "
+            f"contract grants it exactly {{'contents': 'write'}}"
+        )
+
+    if not mentions_secret(publisher):
+        failures.append(
+            f"the {publisher_name} job does not reference the "
+            f"TENKZ_FINAL_TAG_SIGNING_KEY secret"
+        )
+
+    # The secret has one consumer. A validation job that also reads it puts the
+    # private key in reach of repository-running code.
+    others = sorted(
+        name
+        for name, job in jobs.items()
+        if name != publisher_name and mentions_secret(job)
+    )
+    if others:
+        failures.append(
+            f"job(s) {others} also reference the signing secret; the publisher is "
+            f"its sole consumer"
+        )
+
+    # No action and no container: the publisher runs closed inline commands, so
+    # neither third-party action code nor a container image enters the job that
+    # receives the key.
+    actions = [step for step in steps_of(publisher) if "uses" in step]
+    if actions:
+        failures.append(
+            f"the {publisher_name} job carries {len(actions)} `uses:` step(s); the "
+            f"secret-bearing publisher runs closed inline commands only"
+        )
+    if publisher.get("container"):
+        failures.append(
+            f"the {publisher_name} job declares a container; the secret-bearing "
+            f"publisher has no container image"
+        )
+
+    # The boundary steps belong to whichever job runs repository code. The job
+    # carrying both is the designated validation job, and the publisher must
+    # name it, so tag creation cannot begin before that validation succeeds.
+    validation = [
+        name
+        for name, job in jobs.items()
+        if name != publisher_name
+        and all(
+            any(
+                step.get("id") == marker or step.get("name") == marker
+                for step in steps_of(job)
+            )
+            for marker in BOUNDARY_STEPS
+        )
+    ]
+    for name, job in jobs.items():
+        if name == publisher_name:
+            continue
+        for marker in BOUNDARY_STEPS:
+            failures.extend(boundary_failures(marker, name, job))
+    if not validation:
+        failures.append(
+            "no job carries both boundary steps, so there is no validation job "
+            "for the publisher to depend on"
         )
     else:
-        named = {
-            token.strip(" []'\"")
-            for token in needs.group(1).replace(",", " ").split()
-            if token.strip(" []'\"")
-        }
-        unknown = sorted(named - set(jobs))
+        needs = needs_of(publisher)
+        unknown = sorted(needs - set(jobs))
         if unknown:
             failures.append(
                 f"the {publisher_name} job needs {unknown}, which is not a job in "
                 f"this workflow"
             )
-        elif named <= {publisher_name} or not named:
+        elif not needs & set(validation):
             failures.append(
-                f"the {publisher_name} job needs only itself, so no validation "
-                f"gates it"
+                f"the {publisher_name} job needs {sorted(needs) or 'nothing'}; it "
+                f"must depend on the validation job {validation}"
             )
 
-    # The secret-bearing job runs one closed inline command. An action — even a
-    # SHA-pinned one — puts third-party code in the job that reads the signing
-    # key, which is the one job the contract keeps free of it.
-    actions = ANY_ACTION.findall(publisher)
-    if actions:
-        failures.append(
-            f"the {publisher_name} job carries {len(actions)} `uses:` step(s); the "
-            f"secret-bearing publisher runs a closed inline command only"
-        )
-
-    for name in BOUNDARY_STEPS:
-        hosts = [job for job, block in jobs.items() if job != publisher_name]
-        if not hosts:
-            failures.append(f"no job could carry the {name} step")
-            continue
-        for job in hosts:
-            failures.extend(boundary_step_failures(name, jobs[job], job))
-
-    require(
-        not failures,
-        f"armed policy but {ARMED_WORKFLOW}: {'; '.join(failures)}",
-    )
+    require(not failures, f"armed policy but {ARMED_WORKFLOW}: {'; '.join(failures)}")
     mutable = sorted(set(MUTABLE_ACTION.findall(text)))
     require(
         not mutable,

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -33,6 +33,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import stat
 import subprocess
 import sys
@@ -485,15 +486,22 @@ def expose(root: Path, view: Path, relative: str) -> None:
     destination = view / relative
     destination.parent.mkdir(parents=True, exist_ok=True)
     if stat.S_ISDIR(lstat_mode(root, relative)):
-        if destination.exists():
-            return
         copy_tree_without_links(root / relative, destination)
     else:
         shutil.copyfile(root / relative, destination, follow_symlinks=False)
 
 
 def copy_tree_without_links(source: Path, destination: Path) -> None:
-    """Copy one directory, refusing any entry that is not a file or directory."""
+    """Copy one directory, refusing any entry that is not a file or directory.
+
+    The copy merges rather than replacing, because exposed entries overlap: a
+    declared fixture tree may be an ancestor of a canonical artifact already
+    written, and `docs/tenkz` is exactly that case. Returning early when the
+    destination existed would have handed the command a directory containing
+    only the artifacts, so a tree-shaped assertion would have inspected partial
+    coverage and failed for the wrong reason. Merging keeps the union, and a
+    file already present is identical because both copies came from one tree.
+    """
 
     destination.mkdir(parents=True, exist_ok=True)
     for name in sorted(os.listdir(source)):
@@ -511,8 +519,26 @@ def copy_tree_without_links(source: Path, destination: Path) -> None:
         )
         if stat.S_ISDIR(mode):
             copy_tree_without_links(child, destination / name)
-        else:
+        elif not (destination / name).exists():
             shutil.copyfile(child, destination / name, follow_symlinks=False)
+
+
+def tool_directory(workspace: Path, tools: dict[str, tuple[str, str]]) -> Path:
+    """Build the one directory the sanitized `PATH` names.
+
+    Putting each resolved interpreter's *parent* on `PATH` would have handed
+    the command every sibling executable in that directory — a CPython install
+    ships `pip`, `pydoc`, and versioned interpreters beside `python3` — so the
+    allowlist would have named the tools while the path exposed the image. The
+    directory below contains exactly one entry per allowlisted tool, each a
+    link to the executable whose fingerprint was validated.
+    """
+
+    directory = workspace / "tools"
+    directory.mkdir()
+    for name, (executable, _) in tools.items():
+        os.symlink(executable, directory / name)
+    return directory
 
 
 def make_read_only(view: Path) -> None:
@@ -551,6 +577,49 @@ def make_writable(view: Path) -> None:
             path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
+def run_command(
+    argv: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    timeout: int,
+) -> tuple[int, str, bool]:
+    """Run one command in its own process group and bound its whole descendancy.
+
+    `subprocess.run(timeout=...)` kills only the process it started, so a
+    command that spawned a child tool could leave descendants running past the
+    declared timeout and on into the workspace teardown. The declared timeout
+    has to be an execution boundary for the command and everything it starts,
+    so the runner gets a new session and the timeout kills the group.
+    """
+
+    process = subprocess.Popen(
+        argv,
+        cwd=cwd,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        _, stderr = process.communicate(timeout=timeout)
+        return process.returncode, stderr, False
+    except subprocess.TimeoutExpired:
+        terminate_group(process)
+        process.communicate()
+        return -1, "", True
+
+
+def terminate_group(process: subprocess.Popen) -> None:
+    """Signal the command's whole process group, then its leader as a fallback."""
+
+    try:
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        process.kill()
+
+
 def canonical_artifacts(policy: Policy) -> tuple[str, ...]:
     return (
         policy.package_metadata,
@@ -584,16 +653,13 @@ def observe(
     tools = {
         name: resolve_tool(name, pattern, root) for name, pattern in profile.items()
     }
-    sanitized_path = os.pathsep.join(
-        dict.fromkeys(str(Path(executable).parent) for executable, _ in tools.values())
-    )
-
     workspace = Path(tempfile.mkdtemp(prefix="tenkz-release-"))
     view = workspace / "view"
     output = workspace / "output"
     view.mkdir()
     output.mkdir()
     try:
+        sanitized_path = str(tool_directory(workspace, tools))
         for relative in (
             policy.code_root,
             policy.support_root,
@@ -616,23 +682,12 @@ def observe(
         }
         (workspace / "home").mkdir()
 
-        timed_out = False
-        try:
-            completed = subprocess.run(
-                [tools[test.runner][0], test.path, *test.args],
-                cwd=view,
-                env=environment,
-                text=True,
-                capture_output=True,
-                timeout=test.timeout_seconds,
-                check=False,
-            )
-            exit_status = completed.returncode
-            stderr = completed.stderr
-        except subprocess.TimeoutExpired:
-            timed_out = True
-            exit_status = -1
-            stderr = ""
+        exit_status, stderr, timed_out = run_command(
+            [tools[test.runner][0], test.path, *test.args],
+            cwd=view,
+            environment=environment,
+            timeout=test.timeout_seconds,
+        )
 
         require(not timed_out, f"{test.id} exceeded its {test.timeout_seconds}s timeout")
         result = classify(test, exit_status, output, stderr)
@@ -677,7 +732,11 @@ def classify(test: Test, exit_status: int, output: Path, stderr: str) -> str:
         set(receipt) == {"schema", "test_id", "failure_fingerprint", "completed"},
         f"{test.id} wrote a receipt outside the closed shape",
     )
-    require(receipt["schema"] == 1, f"{test.id} receipt schema must be 1")
+    schema = receipt["schema"]
+    require(
+        isinstance(schema, int) and not isinstance(schema, bool) and schema == 1,
+        f"{test.id} receipt schema must be the integer 1",
+    )
     require(receipt["test_id"] == test.id, f"{test.id} receipt names another test")
     require(
         receipt["failure_fingerprint"] == test.failure_fingerprint,

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -260,10 +260,16 @@ def require_tree_is_clean(root: Path, relative: str, subject: str) -> None:
 
     mode = resolve_without_following(root, relative, subject)
     submodules = gitlink_paths(root)
-    require(
-        relative not in submodules,
-        f"{subject} at {relative} is a submodule, which the release contract rejects",
-    )
+    # The index records only the submodule's own path, so a declared file
+    # *inside* one looks like an ordinary file. Every ancestor is checked.
+    parts = relative.split("/")
+    for depth in range(1, len(parts) + 1):
+        prefix = "/".join(parts[:depth])
+        require(
+            prefix not in submodules,
+            f"{subject} at {relative} descends through the submodule {prefix}, "
+            f"which the release contract rejects",
+        )
     if not stat.S_ISDIR(mode):
         return
     pending = [relative]
@@ -462,7 +468,11 @@ def blob_sha256(root: Path, path: str) -> str:
     return hashlib.sha256((root / path).read_bytes()).hexdigest()
 
 
-def require_clean_worktree(policy: Policy, root: Path = ROOT) -> None:
+def require_clean_worktree(
+    policy: Policy,
+    root: Path = ROOT,
+    extra: tuple[str, ...] = (),
+) -> None:
     """Refuse to run when the exposed trees differ from the recorded OIDs.
 
     The pins come from `HEAD` while `expose` copies bytes from the working
@@ -471,7 +481,7 @@ def require_clean_worktree(policy: Policy, root: Path = ROOT) -> None:
     not name, which is the one thing a payload receipt exists to prevent.
     """
 
-    roots = [policy.code_root, policy.support_root, policy.inventory]
+    roots = [policy.code_root, policy.support_root, policy.inventory, *extra]
     result = subprocess.run(
         ["git", "status", "--porcelain", "-z", "--", *roots],
         cwd=root,
@@ -685,6 +695,11 @@ def run_command(
     )
     try:
         _, stderr = process.communicate(timeout=timeout)
+        # Success is an execution boundary too. A command that left a
+        # background child running would otherwise keep running through
+        # classification and workspace teardown, racing the removal of the
+        # very files the receipt describes.
+        terminate_group(process)
         return process.returncode, stderr, False
     except subprocess.TimeoutExpired:
         terminate_group(process)
@@ -721,8 +736,25 @@ def canonical_artifacts(policy: Policy) -> tuple[str, ...]:
     )
 
 
+CAMPAIGN_TAG = re.compile(r"tenkz-v(?:0\.9\.(?:0|[1-9][0-9]*)|1\.0\.0)")
+
+
 def manifest_path(policy: Policy, tag: str) -> str:
-    return policy.manifest_pattern.replace("TAG", tag)
+    """The manifest path for one campaign tag, after checking the tag itself.
+
+    The tag is interpolated into a repository path, so an unchecked value
+    containing `..` would walk out of both the repository and the view. Only
+    the two shapes this campaign validates are accepted: a `tenkz-v0.9.PATCH`
+    freeze tag or `tenkz-v1.0.0`.
+    """
+
+    require(
+        CAMPAIGN_TAG.fullmatch(tag) is not None,
+        f"{tag!r} is not a campaign tag; expected tenkz-v0.9.PATCH or tenkz-v1.0.0",
+    )
+    path = normalized(policy.manifest_pattern.replace("TAG", tag))
+    require(path is not None, f"the {tag} manifest path is not a repository path")
+    return path
 
 
 def observe(
@@ -775,8 +807,18 @@ def observe(
         # assertion read `CHANGES.md` or `TNLOG.md` while its receipt declared
         # neither, so the receipt would not describe what the assertion
         # depended on.
-        artifacts = set(canonical_artifacts(policy))
-        undeclared = artifacts - set(test.program_paths) - set(test.fixture_paths)
+        # An artifact is declared when a declared path *is* it or contains it:
+        # a fixture tree such as `docs/tenkz` carries three of the four
+        # canonical documents, and reporting those as withheld while the
+        # command could read them would make the receipt false.
+        declared = (*test.program_paths, *test.fixture_paths)
+        undeclared = sorted(
+            artifact
+            for artifact in canonical_artifacts(policy)
+            if not any(
+                artifact == path or artifact.startswith(f"{path}/") for path in declared
+            )
+        )
         exposed = [
             policy.code_root,
             policy.support_root,
@@ -824,7 +866,7 @@ def observe(
             "command": [test.runner, test.path, *test.args],
             "program_paths": list(test.program_paths),
             "fixture_paths": list(test.fixture_paths),
-            "undeclared_artifacts_withheld": sorted(undeclared),
+            "undeclared_artifacts_withheld": undeclared,
             "exit_status": exit_status,
             "assertion_result": result,
             "timed_out": timed_out,
@@ -834,6 +876,25 @@ def observe(
     finally:
         make_writable(view)
         shutil.rmtree(workspace, ignore_errors=True)
+
+
+def load_closed_json(path: Path, subject: str) -> dict:
+    """Parse one closed JSON object, refusing a repeated key.
+
+    `json.loads` keeps the last of a repeated key and drops the rest, so an
+    object carrying `"schema": 1` twice — or once with each of two values —
+    passes a field-set check while meaning different things to different
+    readers. A closed protocol cannot be parser-dependent.
+    """
+
+    def reject_duplicates(pairs: list[tuple[str, object]]) -> dict:
+        seen: set[str] = set()
+        for key, _ in pairs:
+            require(key not in seen, f"{subject} receipt repeats the key {key!r}")
+            seen.add(key)
+        return dict(pairs)
+
+    return json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicates)
 
 
 def classify(test: Test, exit_status: int, output: Path, stderr: str) -> str:
@@ -851,8 +912,17 @@ def classify(test: Test, exit_status: int, output: Path, stderr: str) -> str:
         f"{test.id} exited {exit_status}, which is neither a pass nor an assertion "
         f"failure: {stderr.strip()[:400]}",
     )
-    require(receipt_path.is_file(), f"{test.id} exited 10 without its receipt")
-    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    try:
+        receipt_mode = os.lstat(receipt_path).st_mode
+    except OSError:
+        receipt_mode = 0
+    require(receipt_mode != 0, f"{test.id} exited 10 without its receipt")
+    require(
+        stat.S_ISREG(receipt_mode),
+        f"{test.id} wrote its receipt as something other than a regular file; a "
+        f"link there would let the payload live outside the output mount",
+    )
+    receipt = load_closed_json(receipt_path, test.id)
     require(
         set(receipt) == {"schema", "test_id", "failure_fingerprint", "completed"},
         f"{test.id} wrote a receipt outside the closed shape",
@@ -891,19 +961,35 @@ def command_run(
     root: Path,
     selected: str | None,
     tag: str | None = None,
+    receipts_path: Path | None = None,
 ) -> int:
     tests = load_inventory(policy, root)
     if selected is not None:
         tests = tuple(test for test in tests if test.id == selected)
         require(tests, f"no inventory test has id {selected}")
-    require_clean_worktree(policy, root)
+    subjects = {path for test in tests for path in test.program_paths}
+    subjects.update(path for test in tests for path in test.fixture_paths)
+    subjects.update(canonical_artifacts(policy))
+    if tag is not None:
+        subjects.add(manifest_path(policy, tag))
+    require_clean_worktree(policy, root, tuple(sorted(subjects)))
     pins = computed_pins(policy, root)
     failures = []
+    receipts = []
     for test in tests:
         receipt = observe(test, policy, root, pins, tag)
+        receipts.append(receipt)
         print(f"{receipt['assertion_result']:>16}  {test.id}")
         if receipt["assertion_result"] != "passed":
             failures.append((test, receipt))
+    # The receipts are the durable half of the run. A friction or reset-replay
+    # record embeds them verbatim, so discarding them at exit would leave a
+    # caller with a summary line and nothing to submit.
+    if receipts_path is not None:
+        receipts_path.write_text(
+            json.dumps(receipts, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(f"wrote {len(receipts)} payload receipt(s) to {receipts_path}")
     if failures:
         for test, receipt in failures:
             print(
@@ -957,29 +1043,54 @@ def command_check_readiness(policy: Policy, root: Path) -> int:
 
 
 ARMED_WORKFLOW = ".github/workflows/tenkz-release-policy.yml"
+YAML_COMMENT = re.compile(r"(?m)(?:(?<=^)|(?<=\s))#.*$")
 MUTABLE_ACTION = re.compile(r"uses:\s*\S+@(?!\b[0-9a-f]{40}\b)\S+")
+ARMED_MECHANISMS = (
+    (
+        re.compile(r"(?m)^\s+environment:\s*\n(?:\s+name:\s*)?tenkz-release-publisher\s*$"),
+        "a job whose `environment:` is tenkz-release-publisher",
+    ),
+    (
+        re.compile(r"(?m)^\s+contents:\s*write\s*$"),
+        "a job-level `contents: write` permission",
+    ),
+    (
+        re.compile(r"\$\{\{\s*secrets\.TENKZ_FINAL_TAG_SIGNING_KEY\s*\}\}"),
+        "a reference to the TENKZ_FINAL_TAG_SIGNING_KEY secret",
+    ),
+    (
+        re.compile(r"(?m)^\s+(?:id|name):\s*tenkz-network-denied\s*$"),
+        "a step named tenkz-network-denied, which denies network access before "
+        "repository code runs",
+    ),
+    (
+        re.compile(r"(?m)^\s+needs:\s*"),
+        "a `needs:` dependency ordering the publisher after post-merge validation",
+    ),
+)
 
 
 def require_armed_workflow(root: Path) -> None:
     """Check the mechanisms the armed enforcement workflow must carry.
 
     The workflow's own header says `check-readiness` fails closed when these
-    are missing, so this is where that promise is kept. Until they land the
-    campaign cannot be armed, and an activation that flipped the scalars
-    without them would be caught here rather than at the release.
+    are missing, so this is where that promise is kept.
+
+    The checks match YAML structure, not raw substrings, and they run against
+    the file with its comments removed. A substring search would have been
+    satisfied by this very file's header, which names the publisher
+    environment and `contents: write` while explaining that neither exists
+    yet — a check that its own documentation satisfies is not a check.
     """
 
     require_regular_file(root, ARMED_WORKFLOW, "the enforcement workflow")
-    text = (root / ARMED_WORKFLOW).read_text(encoding="utf-8")
-    missing = []
-    if "tenkz-release-publisher" not in text:
-        missing.append("the terminal publisher job in its dedicated environment")
-    if "TENKZ_FINAL_TAG_SIGNING_KEY" not in text:
-        missing.append("the publisher signing secret")
-    if "contents: write" not in text:
-        missing.append("job-level contents: write on the publisher")
-    if "tenkz-network-denied" not in text:
-        missing.append("network denial before repository code runs")
+    raw = (root / ARMED_WORKFLOW).read_text(encoding="utf-8")
+    text = YAML_COMMENT.sub("", raw)
+    missing = [
+        description
+        for pattern, description in ARMED_MECHANISMS
+        if pattern.search(text) is None
+    ]
     require(
         not missing,
         f"armed policy but {ARMED_WORKFLOW} lacks {'; '.join(missing)}",
@@ -1000,8 +1111,14 @@ def main(argv: list[str] | None = None) -> int:
     run = subparsers.add_parser("run")
     run.add_argument("--test", help="run only the inventory test with this id")
     run.add_argument("--tag", help="bind the observation to this release tag")
+    run.add_argument(
+        "--receipts", type=Path, help="write the payload receipts to this JSON file"
+    )
     run_all = subparsers.add_parser("run-all")
     run_all.add_argument("--tag", help="bind the observations to this release tag")
+    run_all.add_argument(
+        "--receipts", type=Path, help="write the payload receipts to this JSON file"
+    )
     subparsers.add_parser("pins")
     subparsers.add_parser("check-readiness")
     args = parser.parse_args(argv)
@@ -1012,9 +1129,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "check-inventory":
             return command_check_inventory(policy, root)
         if args.command == "run":
-            return command_run(policy, root, args.test, args.tag)
+            return command_run(policy, root, args.test, args.tag, args.receipts)
         if args.command == "run-all":
-            return command_run(policy, root, None, args.tag)
+            return command_run(policy, root, None, args.tag, args.receipts)
         if args.command == "pins":
             return command_pins(policy, root)
         return command_check_readiness(policy, root)

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -510,10 +510,13 @@ def require_clean_worktree(
         check=False,
     )
     require(extra.returncode == 0, "could not list ignored files under the pinned trees")
+    # `IGNORED_ENTRIES` never enters the view, so an ignored file under one of
+    # those directories is not unpinned bytes a command could read.
     untracked = sorted(
         path
         for path in extra.stdout.decode("utf-8", errors="replace").split("\0")
-        if path.strip() and not path.endswith("__pycache__/")
+        if path.strip()
+        and not any(part in IGNORED_ENTRIES for part in path.split("/"))
     )
     require(
         not untracked,

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -499,6 +499,27 @@ def require_clean_worktree(
         f"the pinned trees differ from HEAD at {dirty}; the receipt would name "
         f"OIDs the command did not execute",
     )
+    # `git status --porcelain` says nothing about ignored files, but the view
+    # is built by copying the filesystem, so an ignored `.DS_Store` under the
+    # support tree reaches the command while the receipt names only the tree
+    # from HEAD. Anything present and not tracked is unpinned.
+    extra = subprocess.run(
+        ["git", "ls-files", "--others", "--ignored", "--exclude-standard", "-z", "--", *roots],
+        cwd=root,
+        capture_output=True,
+        check=False,
+    )
+    require(extra.returncode == 0, "could not list ignored files under the pinned trees")
+    untracked = sorted(
+        path
+        for path in extra.stdout.decode("utf-8", errors="replace").split("\0")
+        if path.strip() and not path.endswith("__pycache__/")
+    )
+    require(
+        not untracked,
+        f"the pinned trees carry untracked or ignored files {untracked}; the view "
+        f"would copy bytes no OID in the receipt names",
+    )
 
 
 def head_commit(root: Path) -> str:
@@ -590,7 +611,11 @@ def resolve_tool(name: str, pattern: str, root: Path) -> tuple[str, str]:
         re.fullmatch(pattern, fingerprint) is not None,
         f"child tool {name} reports {fingerprint!r}, which the tool profile rejects",
     )
-    return executable, fingerprint
+    # A version line is not an identity: two executables can report the same
+    # one, and a wrapper reports whatever it likes. The receipt records the
+    # resolved path and the bytes' digest alongside it.
+    digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    return executable, f"{fingerprint} sha256:{digest} at {resolved}"
 
 
 IGNORED_ENTRIES = frozenset({"__pycache__"})
@@ -732,16 +757,21 @@ def run_command(
         stderr=subprocess.PIPE,
         start_new_session=True,
     )
+    # `start_new_session=True` makes the child its own group leader, so the
+    # group id equals its pid. Read it now: after `communicate` reaps the
+    # leader, `os.getpgid(pid)` raises ESRCH and a lookup-then-kill would
+    # signal nothing while appearing to succeed.
+    group = process.pid
     try:
         _, stderr = process.communicate(timeout=timeout)
         # Success is an execution boundary too. A command that left a
         # background child running would otherwise keep running through
         # classification and workspace teardown, racing the removal of the
         # very files the receipt describes.
-        terminate_group(process)
+        terminate_group(group, process)
         return process.returncode, stderr, False
     except subprocess.TimeoutExpired:
-        terminate_group(process)
+        terminate_group(group, process)
         try:
             # Descendants inherit the pipes, so an unbounded drain here would
             # block forever exactly when the group kill failed — turning a
@@ -757,13 +787,16 @@ def run_command(
         return -1, "", True
 
 
-def terminate_group(process: subprocess.Popen) -> None:
-    """Signal the command's whole process group, then its leader as a fallback."""
+def terminate_group(group: int, process: subprocess.Popen) -> None:
+    """Signal the command's whole process group by its saved group id."""
 
     try:
-        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+        os.killpg(group, signal.SIGKILL)
     except (OSError, ProcessLookupError):
-        process.kill()
+        try:
+            process.kill()
+        except (OSError, ProcessLookupError):
+            pass
 
 
 def canonical_artifacts(policy: Policy) -> tuple[str, ...]:
@@ -1117,30 +1150,42 @@ def require_fixed_tagger(root: Path) -> None:
 ARMED_WORKFLOW = ".github/workflows/tenkz-release-policy.yml"
 YAML_COMMENT = re.compile(r"(?m)(?:(?<=^)|(?<=\s))#.*$")
 MUTABLE_ACTION = re.compile(r"uses:\s*\S+@(?!\b[0-9a-f]{40}\b)\S+")
-JOBS_KEY = re.compile(r"(?m)^jobs:\s*$")
-JOB_HEADER = re.compile(r"(?m)^(\s+)([A-Za-z_][\w-]*):\s*$")
+ANY_ACTION = re.compile(r"(?m)^[ \t]+(?:-[ \t]+)?uses:[ \t]*\S+")
+JOBS_KEY = re.compile(r"(?m)^jobs:[ \t]*$")
+# `[ \t]` rather than `\s`: `\s` matches a newline, so a header at the very
+# start of the scanned text absorbs the preceding line break into its indent
+# and measures one deeper than the same header found mid-text.
+JOB_HEADER = re.compile(r"(?m)^([ \t]+)([A-Za-z_][\w-]*):[ \t]*$")
 # `environment: name` and the block form `environment:\n  name: name` are both
 # legal GitHub spellings of the same thing, so both must match.
 PUBLISHER_ENVIRONMENT = re.compile(
     r"(?m)^\s+environment:\s*(?:tenkz-release-publisher\s*$"
     r"|\s*\n\s+name:\s*tenkz-release-publisher\s*$)"
 )
+PUBLISHER_NEEDS = re.compile(r"(?m)^[ \t]+needs:[ \t]*(.+)$")
+STEP_MARKER = re.compile(r"(?m)^[ \t]+-[ \t]+(?:id|name|uses|run):")
+NO_OP_RUN = re.compile(r"^(?:true|:|echo\b.*)$")
+BOUNDARY_STEPS = {
+    "tenkz-network-denied": (
+        "denies network access before repository code runs",
+        "release_enforcement_network",
+    ),
+    "tenkz-filesystem-isolated": (
+        "places the run in a mount namespace under an identity that does not "
+        "own the checkout",
+        "release_test_protocol",
+    ),
+}
 PUBLISHER_REQUIREMENTS = (
     (
-        re.compile(r"(?m)^\s+contents:\s*write\s*$"),
+        re.compile(r"(?m)^[ \t]+contents:[ \t]*write[ \t]*$"),
         "a job-level `contents: write` permission",
     ),
     (
         re.compile(r"\$\{\{\s*secrets\.TENKZ_FINAL_TAG_SIGNING_KEY\s*\}\}"),
         "a reference to the TENKZ_FINAL_TAG_SIGNING_KEY secret",
     ),
-    (
-        re.compile(r"(?m)^\s+needs:\s*\S"),
-        "its own `needs:` dependency, which is what orders it after post-merge "
-        "validation",
-    ),
 )
-NETWORK_DENIAL = re.compile(r"(?m)^\s+(?:-\s+)?(?:id|name):\s*tenkz-network-denied\s*$")
 
 
 def workflow_jobs(text: str) -> dict[str, str]:
@@ -1167,6 +1212,68 @@ def workflow_jobs(text: str) -> dict[str, str]:
         stop = tops[index + 1].start() if index + 1 < len(tops) else len(body)
         jobs[header.group(2)] = body[header.start() : stop]
     return jobs
+
+
+def named_steps(block: str) -> list[tuple[int, str]]:
+    """Each step in one job block, as its position and its text."""
+
+    marks = [match.start() for match in STEP_MARKER.finditer(block)]
+    return [
+        (index, block[start : marks[index + 1] if index + 1 < len(marks) else len(block)])
+        for index, start in enumerate(marks)
+    ]
+
+
+def boundary_step_failures(name: str, block: str, job: str) -> list[str]:
+    """Check one declared boundary step: present, first, and not a no-op.
+
+    What a checker can establish about these steps is that the workflow
+    declares one, that it runs before any other step in its job, and that its
+    command is not a placeholder. What it cannot establish is that the command
+    achieves what it is named for. `RELEASE-POLICY.md` §2 records that residue:
+    the marker is the workflow author's declaration, and the review of the
+    arming change is what confirms it.
+    """
+
+    description = BOUNDARY_STEPS[name][0]
+    steps = named_steps(block)
+    matching = [
+        (index, text)
+        for index, text in steps
+        if re.search(rf"(?m)^[ \t]+(?:-[ \t]+)?(?:id|name):[ \t]*{re.escape(name)}[ \t]*$", text)
+    ]
+    if not matching:
+        return [f"job {job} has no step named {name}, which {description}"]
+    index, text = matching[0]
+    failures = []
+    # There is more than one boundary step, so "first" cannot be the rule.
+    # Each must precede every step that is not itself a boundary — that is the
+    # ordering the policy states: before repository code runs.
+    boundary_positions = {
+        position
+        for position, step in steps
+        if any(
+            re.search(
+                rf"(?m)^[ \t]+(?:-[ \t]+)?(?:id|name):[ \t]*{re.escape(other)}[ \t]*$",
+                step,
+            )
+            for other in BOUNDARY_STEPS
+        )
+    }
+    ordinary = [position for position, _ in steps if position not in boundary_positions]
+    if ordinary and index > min(ordinary):
+        failures.append(
+            f"job {job} runs {min(ordinary) + 1} ordinary step(s) before {name}; "
+            f"the step that {description} must precede repository code"
+        )
+    run = re.search(r"(?m)^[ \t]+run:[ \t]*(?:\|[ \t]*\n[ \t]+)?(.+)$", text)
+    command = run.group(1).strip() if run else ""
+    if not command or NO_OP_RUN.fullmatch(command):
+        failures.append(
+            f"job {job} declares {name} as the no-op {command!r}; a step that "
+            f"{description} has to do something"
+        )
+    return failures
 
 
 def require_armed_workflow(root: Path) -> None:
@@ -1199,21 +1306,63 @@ def require_armed_workflow(root: Path) -> None:
         f"{ARMED_WORKFLOW} has {len(publishers)} publisher jobs {publishers}; the "
         f"campaign has one terminal publisher",
     )
-    publisher = jobs[publishers[0]]
-    missing = [
-        description
+    publisher_name = publishers[0]
+    publisher = jobs[publisher_name]
+
+    failures = [
+        f"the {publisher_name} job lacks {description}"
         for pattern, description in PUBLISHER_REQUIREMENTS
         if pattern.search(publisher) is None
     ]
-    if NETWORK_DENIAL.search(text) is None:
-        missing.append(
-            "a step named tenkz-network-denied, which denies network access "
-            "before repository code runs"
+
+    # The publisher's `needs:` must name a real validation job, not merely be
+    # nonempty: an arbitrary dependency lets the job that writes the release
+    # tag start without the gate it exists behind.
+    needs = PUBLISHER_NEEDS.search(publisher)
+    if needs is None:
+        failures.append(
+            f"the {publisher_name} job has no `needs:`, so nothing orders it "
+            f"after post-merge validation"
         )
+    else:
+        named = {
+            token.strip(" []'\"")
+            for token in needs.group(1).replace(",", " ").split()
+            if token.strip(" []'\"")
+        }
+        unknown = sorted(named - set(jobs))
+        if unknown:
+            failures.append(
+                f"the {publisher_name} job needs {unknown}, which is not a job in "
+                f"this workflow"
+            )
+        elif named <= {publisher_name} or not named:
+            failures.append(
+                f"the {publisher_name} job needs only itself, so no validation "
+                f"gates it"
+            )
+
+    # The secret-bearing job runs one closed inline command. An action — even a
+    # SHA-pinned one — puts third-party code in the job that reads the signing
+    # key, which is the one job the contract keeps free of it.
+    actions = ANY_ACTION.findall(publisher)
+    if actions:
+        failures.append(
+            f"the {publisher_name} job carries {len(actions)} `uses:` step(s); the "
+            f"secret-bearing publisher runs a closed inline command only"
+        )
+
+    for name in BOUNDARY_STEPS:
+        hosts = [job for job, block in jobs.items() if job != publisher_name]
+        if not hosts:
+            failures.append(f"no job could carry the {name} step")
+            continue
+        for job in hosts:
+            failures.extend(boundary_step_failures(name, jobs[job], job))
+
     require(
-        not missing,
-        f"armed policy but the {publishers[0]} job in {ARMED_WORKFLOW} lacks "
-        f"{'; '.join(missing)}",
+        not failures,
+        f"armed policy but {ARMED_WORKFLOW}: {'; '.join(failures)}",
     )
     mutable = sorted(set(MUTABLE_ACTION.findall(text)))
     require(

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -501,6 +501,45 @@ def require_clean_worktree(
     )
 
 
+def head_commit(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    require(result.returncode == 0, "could not resolve the observed commit")
+    oid = result.stdout.strip()
+    require(GIT_OID_RE.fullmatch(oid) is not None, "HEAD did not resolve to a commit OID")
+    return oid
+
+
+def object_ids(root: Path, paths: tuple[str, ...]) -> dict[str, str]:
+    """The Git object ID of each exposed path at `HEAD`.
+
+    A receipt naming only the harness pins and its subjects' *paths* cannot be
+    told apart from a receipt produced at another commit where the same paths
+    hold different bytes. The blob and tree identities are what bind a receipt
+    to what it actually read.
+    """
+
+    identities = {}
+    for path in paths:
+        result = subprocess.run(
+            ["git", "rev-parse", f"HEAD:{path}"],
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        require(result.returncode == 0, f"could not read the object ID of {path}")
+        oid = result.stdout.strip()
+        require(GIT_OID_RE.fullmatch(oid) is not None, f"{path} has no object ID")
+        identities[path] = oid
+    return identities
+
+
 def computed_pins(policy: Policy, root: Path = ROOT) -> dict[str, str]:
     """The three values the activation change copies into the pinned policy."""
 
@@ -832,6 +871,7 @@ def observe(
             exposed.append(manifest)
         for relative in exposed:
             expose(root, view, relative)
+        subject_objects = object_ids(root, tuple(exposed))
         home = workspace / "home"
         home.mkdir()
         home.chmod(READ_ONLY_DIRECTORY)
@@ -860,6 +900,8 @@ def observe(
             "test_id": test.id,
             "surface": test.surface,
             "tag": tag,
+            "observed_commit": head_commit(root),
+            "exposed_objects": subject_objects,
             "code_tree": pins["release_test_code_tree"],
             "support_tree": pins["release_test_support_tree"],
             "inventory_sha256": pins["release_test_inventory_sha256"],
@@ -1037,9 +1079,39 @@ def command_check_readiness(policy: Policy, root: Path) -> int:
             f"armed policy {name} does not equal this tree's value",
         )
     require_regular_file(root, policy.tag_public_key, "the final-tag public key")
+    require_fixed_tagger(root)
     require_armed_workflow(root)
     print("PASS: enforcement armed; every activation pin matches this tree")
     return 0
+
+
+TAG_OBJECT_SCHEMA = "tests/tenkz/release-support/final-tag-object-v1.schema.json"
+
+
+def require_fixed_tagger(root: Path) -> None:
+    """The tagger identity must be two byte constants before arming.
+
+    The publisher constructs one byte-deterministic tag object, so every field
+    it does not derive from its needs tuple has to be fixed in the pinned
+    schema. `tagger_name` and `tagger_email` are left open while the signing
+    key is absent; arming with them still open would pin a support tree that
+    cannot produce a deterministic object, and the failure would not appear
+    until the publisher ran.
+    """
+
+    require_regular_file(root, TAG_OBJECT_SCHEMA, "the final-tag object schema")
+    schema = json.loads((root / TAG_OBJECT_SCHEMA).read_text(encoding="utf-8"))
+    properties = schema.get("properties", {})
+    open_fields = [
+        field
+        for field in ("tagger_name", "tagger_email")
+        if not isinstance(properties.get(field, {}).get("const"), str)
+    ]
+    require(
+        not open_fields,
+        f"armed policy but {TAG_OBJECT_SCHEMA} leaves {open_fields} without a "
+        f"fixed const value, so the tag object would not be byte-deterministic",
+    )
 
 
 ARMED_WORKFLOW = ".github/workflows/tenkz-release-policy.yml"

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -68,6 +68,7 @@ TEST_FIELDS = {
 }
 FAILURE_RECEIPT = "assertion-failure-v1.json"
 ASSERTION_EXIT = 10
+DRAIN_SECONDS = 15
 TOOL_PROFILE = "tests/tenkz/release-support/tool-profile.toml"
 
 
@@ -103,6 +104,7 @@ class Policy:
     change_record: str
     event_format: str
     tag_public_key: str
+    manifest_pattern: str
 
 
 def read_policy(root: Path = ROOT) -> Policy:
@@ -128,6 +130,7 @@ def read_policy(root: Path = ROOT) -> Policy:
         change_record=table["release_change_record"],
         event_format=table["release_event_format"],
         tag_public_key=table["release_tag_public_key"],
+        manifest_pattern=table["release_manifest_pattern"],
     )
 
 
@@ -218,10 +221,39 @@ def require_regular_file(root: Path, relative: str, subject: str) -> None:
     require(stat.S_ISREG(mode), f"{subject} at {relative} is not a regular file")
 
 
+def gitlink_paths(root: Path) -> frozenset[str]:
+    """Every submodule path Git records, by mode 160000 in the index.
+
+    A checked-out submodule is an ordinary directory to `lstat`, and an
+    uninitialized one is an empty directory, so neither filesystem mode nor
+    emptiness distinguishes it from a tree the view may copy. The Git index is
+    the only place the distinction is recorded.
+    """
+
+    result = subprocess.run(
+        ["git", "ls-files", "--stage", "-z"],
+        cwd=root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return frozenset()
+    paths = set()
+    for record in result.stdout.decode("utf-8", errors="replace").split("\0"):
+        if record.startswith("160000 "):
+            paths.add(record.split("\t", 1)[-1])
+    return frozenset(paths)
+
+
 def require_tree_is_clean(root: Path, relative: str, subject: str) -> None:
     """Reject a symlink or special entry anywhere beneath one exposed tree."""
 
     mode = resolve_without_following(root, relative, subject)
+    submodules = gitlink_paths(root)
+    require(
+        relative not in submodules,
+        f"{subject} at {relative} is a submodule, which the release contract rejects",
+    )
     if not stat.S_ISDIR(mode):
         return
     pending = [relative]
@@ -229,6 +261,11 @@ def require_tree_is_clean(root: Path, relative: str, subject: str) -> None:
         current = pending.pop()
         for entry in sorted(os.listdir(root / current)):
             child = f"{current}/{entry}"
+            require(
+                child not in submodules,
+                f"{subject} contains the submodule {child}, which the release "
+                f"contract rejects",
+            )
             child_mode = lstat_mode(root, child)
             require(
                 not stat.S_ISLNK(child_mode),
@@ -271,7 +308,11 @@ def load_inventory(policy: Policy, root: Path = ROOT) -> tuple[Test, ...]:
     require(blob.is_file(), f"{policy.inventory} is absent")
     document = tomllib.loads(blob.read_text(encoding="utf-8"))
     require(set(document) == {"schema", "test"}, "inventory has fields outside its schema")
-    require(document["schema"] == 1, "inventory schema must be 1")
+    schema = document["schema"]
+    require(
+        isinstance(schema, int) and not isinstance(schema, bool) and schema == 1,
+        "inventory schema must be the integer 1",
+    )
     raw = document["test"]
     require(isinstance(raw, list) and raw, "inventory needs one or more [[test]] tables")
 
@@ -411,6 +452,35 @@ def blob_sha256(root: Path, path: str) -> str:
     return hashlib.sha256((root / path).read_bytes()).hexdigest()
 
 
+def require_clean_worktree(policy: Policy, root: Path = ROOT) -> None:
+    """Refuse to run when the exposed trees differ from the recorded OIDs.
+
+    The pins come from `HEAD` while `expose` copies bytes from the working
+    tree. If the two disagree — a dirty checkout, or an earlier workflow step
+    that rewrote the harness — the command would execute code the receipt does
+    not name, which is the one thing a payload receipt exists to prevent.
+    """
+
+    roots = [policy.code_root, policy.support_root, policy.inventory]
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "-z", "--", *roots],
+        cwd=root,
+        capture_output=True,
+        check=False,
+    )
+    require(result.returncode == 0, "could not read worktree status for the pinned trees")
+    dirty = sorted(
+        record[3:]
+        for record in result.stdout.decode("utf-8", errors="replace").split("\0")
+        if record.strip()
+    )
+    require(
+        not dirty,
+        f"the pinned trees differ from HEAD at {dirty}; the receipt would name "
+        f"OIDs the command did not execute",
+    )
+
+
 def computed_pins(policy: Policy, root: Path = ROOT) -> dict[str, str]:
     """The three values the activation change copies into the pinned policy."""
 
@@ -538,6 +608,7 @@ def tool_directory(workspace: Path, tools: dict[str, tuple[str, str]]) -> Path:
     directory.mkdir()
     for name, (executable, _) in tools.items():
         os.symlink(executable, directory / name)
+    directory.chmod(READ_ONLY_DIRECTORY)
     return directory
 
 
@@ -607,7 +678,18 @@ def run_command(
         return process.returncode, stderr, False
     except subprocess.TimeoutExpired:
         terminate_group(process)
-        process.communicate()
+        try:
+            # Descendants inherit the pipes, so an unbounded drain here would
+            # block forever exactly when the group kill failed — turning a
+            # fail-closed timeout into a hung run.
+            process.communicate(timeout=DRAIN_SECONDS)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            require(
+                False,
+                "the command's descendants outlived their process group and kept "
+                "its output pipes open",
+            )
         return -1, "", True
 
 
@@ -629,11 +711,16 @@ def canonical_artifacts(policy: Policy) -> tuple[str, ...]:
     )
 
 
+def manifest_path(policy: Policy, tag: str) -> str:
+    return policy.manifest_pattern.replace("TAG", tag)
+
+
 def observe(
     test: Test,
     policy: Policy,
     root: Path = ROOT,
     pins: dict[str, str] | None = None,
+    tag: str | None = None,
 ) -> dict:
     """Run one inventory test in its own view and return its payload receipt.
 
@@ -642,6 +729,19 @@ def observe(
     because a replay receipt embeds these receipts verbatim and a later payload
     validation rejects an incomplete one. `pins` is accepted so a caller
     running the whole inventory reads the three Git pins once.
+
+    `output_mount` records the path the command actually received, not the
+    ledger's `/tenkz-output` spelling. Until the enforcement workflow supplies
+    a mount namespace, the two differ, and a receipt that named the intended
+    path while the command saw another would be false evidence about the run
+    that produced it.
+
+    `tag` selects the release the observation is bound to. With a tag this is
+    `observe-release-test(K, Q, R)`: the tag-derived manifest joins the view
+    and its absence fails closed. Without one — the only shape available while
+    no `tenkz-v*` tag exists — the run is a standing check of the assertions at
+    this tree and the receipt records `tag = null`, so it can never be read as
+    evidence for a release it never saw.
     """
 
     pins = pins if pins is not None else computed_pins(policy, root)
@@ -660,15 +760,29 @@ def observe(
     output.mkdir()
     try:
         sanitized_path = str(tool_directory(workspace, tools))
-        for relative in (
+        # A canonical artifact reaches a command only through one of its two
+        # declared roles. Exposing all four to every command would let an
+        # assertion read `CHANGES.md` or `TNLOG.md` while its receipt declared
+        # neither, so the receipt would not describe what the assertion
+        # depended on.
+        artifacts = set(canonical_artifacts(policy))
+        undeclared = artifacts - set(test.program_paths) - set(test.fixture_paths)
+        exposed = [
             policy.code_root,
             policy.support_root,
             policy.inventory,
-            *canonical_artifacts(policy),
             *test.program_paths,
             *test.fixture_paths,
-        ):
+        ]
+        if tag is not None:
+            manifest = manifest_path(policy, tag)
+            require_regular_file(root, manifest, f"the {tag} release manifest")
+            exposed.append(manifest)
+        for relative in exposed:
             expose(root, view, relative)
+        home = workspace / "home"
+        home.mkdir()
+        home.chmod(READ_ONLY_DIRECTORY)
         make_read_only(view)
 
         environment = {
@@ -676,11 +790,10 @@ def observe(
             "LC_ALL": "C",
             "LANG": "C",
             "TZ": "UTC",
-            "HOME": str(workspace / "home"),
+            "HOME": str(home),
             "TENKZ_TEST_OUTPUT": str(output),
             "PYTHONDONTWRITEBYTECODE": "1",
         }
-        (workspace / "home").mkdir()
 
         exit_status, stderr, timed_out = run_command(
             [tools[test.runner][0], test.path, *test.args],
@@ -694,16 +807,18 @@ def observe(
         return {
             "test_id": test.id,
             "surface": test.surface,
+            "tag": tag,
             "code_tree": pins["release_test_code_tree"],
             "support_tree": pins["release_test_support_tree"],
             "inventory_sha256": pins["release_test_inventory_sha256"],
             "command": [test.runner, test.path, *test.args],
             "program_paths": list(test.program_paths),
             "fixture_paths": list(test.fixture_paths),
+            "undeclared_artifacts_withheld": sorted(undeclared),
             "exit_status": exit_status,
             "assertion_result": result,
             "timed_out": timed_out,
-            "output_mount": "/tenkz-output",
+            "output_mount": str(output),
             "tool_fingerprints": {name: value[1] for name, value in tools.items()},
         }
     finally:
@@ -761,15 +876,21 @@ def command_check_inventory(policy: Policy, root: Path) -> int:
     return 0
 
 
-def command_run(policy: Policy, root: Path, selected: str | None) -> int:
+def command_run(
+    policy: Policy,
+    root: Path,
+    selected: str | None,
+    tag: str | None = None,
+) -> int:
     tests = load_inventory(policy, root)
     if selected is not None:
         tests = tuple(test for test in tests if test.id == selected)
         require(tests, f"no inventory test has id {selected}")
+    require_clean_worktree(policy, root)
     pins = computed_pins(policy, root)
     failures = []
     for test in tests:
-        receipt = observe(test, policy, root, pins)
+        receipt = observe(test, policy, root, pins, tag)
         print(f"{receipt['assertion_result']:>16}  {test.id}")
         if receipt["assertion_result"] != "passed":
             failures.append((test, receipt))
@@ -812,18 +933,53 @@ def command_check_readiness(policy: Policy, root: Path) -> int:
             "is available."
         )
         return 0
+    require_clean_worktree(policy, root)
     computed = computed_pins(policy, root)
     for name, value in pending.items():
         require(
             value == computed[name],
             f"armed policy {name} does not equal this tree's value",
         )
-    require(
-        (root / policy.tag_public_key).is_file(),
-        "armed policy names a final-tag public key that is absent",
-    )
+    require_regular_file(root, policy.tag_public_key, "the final-tag public key")
+    require_armed_workflow(root)
     print("PASS: enforcement armed; every activation pin matches this tree")
     return 0
+
+
+ARMED_WORKFLOW = ".github/workflows/tenkz-release-policy.yml"
+MUTABLE_ACTION = re.compile(r"uses:\s*\S+@(?!\b[0-9a-f]{40}\b)\S+")
+
+
+def require_armed_workflow(root: Path) -> None:
+    """Check the mechanisms the armed enforcement workflow must carry.
+
+    The workflow's own header says `check-readiness` fails closed when these
+    are missing, so this is where that promise is kept. Until they land the
+    campaign cannot be armed, and an activation that flipped the scalars
+    without them would be caught here rather than at the release.
+    """
+
+    require_regular_file(root, ARMED_WORKFLOW, "the enforcement workflow")
+    text = (root / ARMED_WORKFLOW).read_text(encoding="utf-8")
+    missing = []
+    if "tenkz-release-publisher" not in text:
+        missing.append("the terminal publisher job in its dedicated environment")
+    if "TENKZ_FINAL_TAG_SIGNING_KEY" not in text:
+        missing.append("the publisher signing secret")
+    if "contents: write" not in text:
+        missing.append("job-level contents: write on the publisher")
+    if "tenkz-network-denied" not in text:
+        missing.append("network denial before repository code runs")
+    require(
+        not missing,
+        f"armed policy but {ARMED_WORKFLOW} lacks {'; '.join(missing)}",
+    )
+    mutable = sorted(set(MUTABLE_ACTION.findall(text)))
+    require(
+        not mutable,
+        f"{ARMED_WORKFLOW} pins {mutable} by a mutable reference rather than a "
+        f"full commit SHA",
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -833,7 +989,9 @@ def main(argv: list[str] | None = None) -> int:
     subparsers.add_parser("check-inventory")
     run = subparsers.add_parser("run")
     run.add_argument("--test", help="run only the inventory test with this id")
-    subparsers.add_parser("run-all")
+    run.add_argument("--tag", help="bind the observation to this release tag")
+    run_all = subparsers.add_parser("run-all")
+    run_all.add_argument("--tag", help="bind the observations to this release tag")
     subparsers.add_parser("pins")
     subparsers.add_parser("check-readiness")
     args = parser.parse_args(argv)
@@ -844,9 +1002,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "check-inventory":
             return command_check_inventory(policy, root)
         if args.command == "run":
-            return command_run(policy, root, args.test)
+            return command_run(policy, root, args.test, args.tag)
         if args.command == "run-all":
-            return command_run(policy, root, None)
+            return command_run(policy, root, None, args.tag)
         if args.command == "pins":
             return command_pins(policy, root)
         return command_check_readiness(policy, root)

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -161,11 +161,20 @@ def normalized(value: object) -> str | None:
 
 
 def glob_matches(path: str, pattern: str) -> bool:
-    """Match the policy's `*`/`**` repository-path grammar, not the shell's."""
+    """Match the policy's `*`/`**`/`?` repository-path grammar, not the shell's.
+
+    This duplicates `policy_glob_matches` in `scripts/check_tenkz_policy.py`
+    and must stay identical to it. The duplication is forced: release-test code
+    may import nothing from `scripts/`, and the two answer the same question
+    about the same pinned patterns, so a difference between them would let a
+    program path satisfy one checker and fail the other. The `?` rule was
+    missing here and is restored; change neither copy alone.
+    """
 
     expression = re.escape(pattern)
     expression = expression.replace(r"\*\*/", r"(?:[^/]+/)*")
     expression = expression.replace(r"\*", r"[^/]*")
+    expression = expression.replace(r"\?", r"[^/]")
     return re.fullmatch(expression, path) is not None
 
 
@@ -240,14 +249,28 @@ def gitlink_paths(root: Path) -> frozenset[str]:
     the only place the distinction is recorded.
     """
 
+    inside = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=root,
+        capture_output=True,
+        check=False,
+    )
+    if inside.returncode != 0:
+        # A tree that is not under Git has no index and therefore no gitlinks.
+        # That is a determinate answer rather than a failure to get one, and it
+        # is the case the self-test's synthetic fixtures are in.
+        return frozenset()
     result = subprocess.run(
         ["git", "ls-files", "--stage", "-z"],
         cwd=root,
         capture_output=True,
         check=False,
     )
-    if result.returncode != 0:
-        return frozenset()
+    require(
+        result.returncode == 0,
+        "could not read the Git index of a repository; submodule rejection "
+        "cannot fail open",
+    )
     paths = set()
     for record in result.stdout.decode("utf-8", errors="replace").split("\0"):
         if record.startswith("160000 "):
@@ -602,14 +625,19 @@ def resolve_tool(name: str, pattern: str, root: Path) -> tuple[str, str]:
         not resolved.is_relative_to(root),
         f"child tool {name} resolves inside the repository at {resolved}",
     )
-    result = subprocess.run(
-        [executable, "--version"],
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=30,
-    )
-    fingerprint = (result.stdout + result.stderr).strip().splitlines()[0]
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.SubprocessError as error:
+        raise SupervisorError(f"child tool {name} did not report a version: {error}")
+    reported = (result.stdout + result.stderr).strip().splitlines()
+    require(reported, f"child tool {name} reported no version line")
+    fingerprint = reported[0]
     require(
         re.fullmatch(pattern, fingerprint) is not None,
         f"child tool {name} reports {fingerprint!r}, which the tool profile rejects",
@@ -832,12 +860,85 @@ def manifest_path(policy: Policy, tag: str) -> str:
     return path
 
 
+MANIFEST_FIELDS = {
+    "schema",
+    "tag",
+    "version",
+    "date",
+    "test_inventory_sha256",
+    "test_code_tree",
+    "test_support_tree",
+}
+ISO_DATE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
+
+
+def validate_manifest(
+    root: Path,
+    policy: Policy,
+    tag: str,
+    pins: dict[str, str],
+) -> dict:
+    """Check the tag-derived manifest against the tag and canonical artifacts.
+
+    `docs/tenkz/SOAK-1.0.md` §Release payload evidence states this shape.
+    Exposing the manifest without reading it would have let an armed payload
+    run pass with a malformed manifest or a package version disagreeing with
+    the tag — the observation would then be evidence for a release nobody had
+    described correctly.
+    """
+
+    relative = manifest_path(policy, tag)
+    require_regular_file(root, relative, f"the {tag} release manifest")
+    document = tomllib.loads((root / relative).read_text(encoding="utf-8"))
+    require(set(document) == {"release"}, f"{relative} has tables outside [release]")
+    release = document["release"]
+    require(
+        set(release) == MANIFEST_FIELDS,
+        f"{relative} fields differ from the manifest schema",
+    )
+    schema = release["schema"]
+    require(
+        isinstance(schema, int) and not isinstance(schema, bool) and schema == 1,
+        f"{relative} schema must be the integer 1",
+    )
+    require(release["tag"] == tag, f"{relative} names another tag")
+    version = tag.removeprefix("tenkz-v")
+    require(
+        release["version"] == version,
+        f"{relative} version {release['version']!r} is not the tag's {version!r}",
+    )
+    date = str(release["date"])
+    require(ISO_DATE.fullmatch(date) is not None, f"{relative} date is not ISO 8601")
+    for field, pin in (
+        ("test_inventory_sha256", "release_test_inventory_sha256"),
+        ("test_code_tree", "release_test_code_tree"),
+        ("test_support_tree", "release_test_support_tree"),
+    ):
+        require(
+            release[field] == pins[pin],
+            f"{relative} {field} does not equal this tree's {pins[pin]}",
+        )
+
+    # The package metadata and manual declare the manifest's version and date;
+    # the change record and event-format declaration name the tag and version.
+    declaration = (root / policy.package_metadata).read_text(encoding="utf-8")
+    require(
+        f"v{version}" in declaration and date.replace("-", "/") in declaration,
+        f"{policy.package_metadata} does not declare version {version} at {date}",
+    )
+    for artifact in (policy.manual, policy.change_record, policy.event_format):
+        text = (root / artifact).read_text(encoding="utf-8")
+        require(version in text, f"{artifact} does not name version {version}")
+    return release
+
+
 def observe(
     test: Test,
     policy: Policy,
     root: Path = ROOT,
     pins: dict[str, str] | None = None,
     tag: str | None = None,
+    output_mount: Path | None = None,
 ) -> dict:
     """Run one inventory test in its own view and return its payload receipt.
 
@@ -872,9 +973,20 @@ def observe(
     }
     workspace = Path(tempfile.mkdtemp(prefix="tenkz-release-"))
     view = workspace / "view"
-    output = workspace / "output"
+    # The ledger fixes the writable mount at `/tenkz-output`. A workspace path
+    # is what a developer run can have; an armed run inside the required mount
+    # namespace has to receive the fixed path, and the workflow cannot guess a
+    # randomly generated one. `--output-mount` lets the caller supply it, and
+    # the receipt records whichever was actually used.
+    if output_mount is None:
+        output = workspace / "output"
+        output.mkdir()
+    else:
+        output = output_mount
+        require(output.is_absolute(), "the output mount must be an absolute path")
+        require(output.is_dir(), f"the output mount {output} is not a directory")
+        require(not any(output.iterdir()), f"the output mount {output} is not empty")
     view.mkdir()
-    output.mkdir()
     try:
         sanitized_path = str(tool_directory(workspace, tools))
         # A canonical artifact reaches a command only through one of its two
@@ -903,7 +1015,7 @@ def observe(
         ]
         if tag is not None:
             manifest = manifest_path(policy, tag)
-            require_regular_file(root, manifest, f"the {tag} release manifest")
+            validate_manifest(root, policy, tag, pins)
             exposed.append(manifest)
         for relative in exposed:
             expose(root, view, relative)
@@ -953,6 +1065,9 @@ def observe(
         }
     finally:
         make_writable(view)
+        if output_mount is not None:
+            for leftover in sorted(output_mount.rglob("*"), reverse=True):
+                leftover.unlink() if leftover.is_file() else leftover.rmdir()
         shutil.rmtree(workspace, ignore_errors=True)
 
 
@@ -980,9 +1095,17 @@ def classify(test: Test, exit_status: int, output: Path, stderr: str) -> str:
 
     receipt_path = output / FAILURE_RECEIPT
     if exit_status == 0:
+        # `os.lstat`, not `exists()`: a dangling link at the receipt path is
+        # something the command wrote, and `exists()` reports it as absent.
+        try:
+            os.lstat(receipt_path)
+            stray = True
+        except OSError:
+            stray = False
         require(
-            not receipt_path.exists(),
-            f"{test.id} passed but wrote an assertion-failure receipt",
+            not stray,
+            f"{test.id} passed but left something at the assertion-failure "
+            f"receipt path",
         )
         return "passed"
     require(
@@ -1040,6 +1163,7 @@ def command_run(
     selected: str | None,
     tag: str | None = None,
     receipts_path: Path | None = None,
+    output_mount: Path | None = None,
 ) -> int:
     tests = load_inventory(policy, root)
     if selected is not None:
@@ -1055,7 +1179,7 @@ def command_run(
     failures = []
     receipts = []
     for test in tests:
-        receipt = observe(test, policy, root, pins, tag)
+        receipt = observe(test, policy, root, pins, tag, output_mount)
         receipts.append(receipt)
         print(f"{receipt['assertion_result']:>16}  {test.id}")
         if receipt["assertion_result"] != "passed":
@@ -1108,6 +1232,11 @@ def command_check_readiness(policy: Policy, root: Path) -> int:
         )
         return 0
     require_clean_worktree(policy, root)
+    require(
+        policy.enforcement == "armed",
+        f"policy enforcement is {policy.enforcement!r}; the grammar admits only "
+        f"'pending' and 'armed'",
+    )
     computed = computed_pins(policy, root)
     for name, value in pending.items():
         require(
@@ -1152,8 +1281,11 @@ def require_fixed_tagger(root: Path) -> None:
 
 ARMED_WORKFLOW = ".github/workflows/tenkz-release-policy.yml"
 YAML_COMMENT = re.compile(r"(?m)(?:(?<=^)|(?<=\s))#.*$")
-MUTABLE_ACTION = re.compile(r"uses:\s*\S+@(?!\b[0-9a-f]{40}\b)\S+")
-ANY_ACTION = re.compile(r"(?m)^[ \t]+(?:-[ \t]+)?uses:[ \t]*\S+")
+MUTABLE_ACTION = re.compile(r"uses:[ \t]*\S+@(?!\b[0-9a-f]{40}\b)\S+")
+# Both block style (`- uses: x`) and YAML flow style (`- {uses: x}`) name an
+# action. A flow mapping pinned to a full SHA evaded both this check and the
+# mutable-reference one, which is the combination that mattered.
+ANY_ACTION = re.compile(r"(?m)^[ \t]+(?:-[ \t]+)?[{[]?[ \t]*uses:[ \t]*\S+")
 JOBS_KEY = re.compile(r"(?m)^jobs:[ \t]*$")
 # `[ \t]` rather than `\s`: `\s` matches a newline, so a header at the very
 # start of the scanned text absorbs the preceding line break into its indent
@@ -1386,10 +1518,20 @@ def main(argv: list[str] | None = None) -> int:
     run.add_argument(
         "--receipts", type=Path, help="write the payload receipts to this JSON file"
     )
+    run.add_argument(
+        "--output-mount",
+        type=Path,
+        help="the writable mount to give each command; armed runs pass /tenkz-output",
+    )
     run_all = subparsers.add_parser("run-all")
     run_all.add_argument("--tag", help="bind the observations to this release tag")
     run_all.add_argument(
         "--receipts", type=Path, help="write the payload receipts to this JSON file"
+    )
+    run_all.add_argument(
+        "--output-mount",
+        type=Path,
+        help="the writable mount to give each command; armed runs pass /tenkz-output",
     )
     subparsers.add_parser("pins")
     subparsers.add_parser("check-readiness")
@@ -1401,9 +1543,13 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "check-inventory":
             return command_check_inventory(policy, root)
         if args.command == "run":
-            return command_run(policy, root, args.test, args.tag, args.receipts)
+            return command_run(
+                policy, root, args.test, args.tag, args.receipts, args.output_mount
+            )
         if args.command == "run-all":
-            return command_run(policy, root, None, args.tag, args.receipts)
+            return command_run(
+                policy, root, None, args.tag, args.receipts, args.output_mount
+            )
         if args.command == "pins":
             return command_pins(policy, root)
         return command_check_readiness(policy, root)

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -160,6 +160,90 @@ def within_roots(path: str, roots: tuple[str, ...]) -> bool:
 
 
 # --------------------------------------------------------------------------
+# Symlink and file-mode rejection
+# --------------------------------------------------------------------------
+#
+# `docs/tenkz/SOAK-1.0.md` §Release payload evidence: every exposed repository
+# entry is recursively a regular blob or tree, and symlinks, submodules,
+# special entries, and any other in-repository dependency are rejected
+# *without following them*.  Every check below therefore reads `os.lstat` and
+# never `Path.exists`, `Path.is_file`, or any other call that resolves a link.
+# A path is checked one component at a time, because a symlinked parent
+# directory escapes the repository just as effectively as a symlinked leaf.
+
+
+def lstat_mode(root: Path, relative: str) -> int:
+    """Return the unresolved mode of one repository path, or 0 when absent."""
+
+    try:
+        return os.lstat(root / relative).st_mode
+    except OSError:
+        return 0
+
+
+def resolve_without_following(root: Path, relative: str, subject: str) -> int:
+    """Walk a repository path component by component, refusing every symlink.
+
+    Returns the leaf's unresolved mode.  A missing component, a symlink at any
+    depth, or an entry that is neither a regular file nor a directory fails
+    closed, so no caller can reach outside the repository through a link and no
+    caller learns anything about the link's target.
+    """
+
+    parts = relative.split("/")
+    for depth in range(1, len(parts) + 1):
+        prefix = "/".join(parts[:depth])
+        mode = lstat_mode(root, prefix)
+        require(mode != 0, f"{subject} is absent at {prefix}")
+        require(
+            not stat.S_ISLNK(mode),
+            f"{subject} passes through the symlink {prefix}, which is rejected "
+            f"without following it",
+        )
+        if depth < len(parts):
+            require(
+                stat.S_ISDIR(mode),
+                f"{subject} treats the non-directory {prefix} as a directory",
+            )
+    require(
+        stat.S_ISREG(mode) or stat.S_ISDIR(mode),
+        f"{subject} at {relative} is neither a regular file nor a directory",
+    )
+    return mode
+
+
+def require_regular_file(root: Path, relative: str, subject: str) -> None:
+    mode = resolve_without_following(root, relative, subject)
+    require(stat.S_ISREG(mode), f"{subject} at {relative} is not a regular file")
+
+
+def require_tree_is_clean(root: Path, relative: str, subject: str) -> None:
+    """Reject a symlink or special entry anywhere beneath one exposed tree."""
+
+    mode = resolve_without_following(root, relative, subject)
+    if not stat.S_ISDIR(mode):
+        return
+    pending = [relative]
+    while pending:
+        current = pending.pop()
+        for entry in sorted(os.listdir(root / current)):
+            child = f"{current}/{entry}"
+            child_mode = lstat_mode(root, child)
+            require(
+                not stat.S_ISLNK(child_mode),
+                f"{subject} contains the symlink {child}, which is rejected "
+                f"without following it",
+            )
+            require(
+                stat.S_ISREG(child_mode) or stat.S_ISDIR(child_mode),
+                f"{subject} contains {child}, which is neither a regular file "
+                f"nor a directory",
+            )
+            if stat.S_ISDIR(child_mode):
+                pending.append(child)
+
+
+# --------------------------------------------------------------------------
 # Inventory
 # --------------------------------------------------------------------------
 
@@ -230,7 +314,7 @@ def load_inventory(policy: Policy, root: Path = ROOT) -> tuple[Test, ...]:
             path.endswith(RUNNER_SUFFIX[runner]),
             f"{test_id} path suffix does not match its runner",
         )
-        require((root / path).is_file(), f"{test_id} path is not a regular file")
+        require_regular_file(root, path, f"{test_id} runner path")
 
         args = entry["args"]
         require(
@@ -242,10 +326,7 @@ def load_inventory(policy: Policy, root: Path = ROOT) -> tuple[Test, ...]:
         programs = subject_paths(root, policy, test_id, entry["program_paths"], "program")
         require(programs, f"{test_id} declares no program path")
         for program in programs:
-            require(
-                (root / program).is_file(),
-                f"{test_id} program path {program} is not a regular file",
-            )
+            require_regular_file(root, program, f"{test_id} program path")
             require(
                 any(glob_matches(program, p) for p in policy.fix_paths[surface]),
                 f"{test_id} program path {program} is outside its surface's fix paths",
@@ -253,10 +334,7 @@ def load_inventory(policy: Policy, root: Path = ROOT) -> tuple[Test, ...]:
 
         fixtures = subject_paths(root, policy, test_id, entry["fixture_paths"], "fixture")
         for fixture in fixtures:
-            require(
-                (root / fixture).exists(),
-                f"{test_id} fixture path {fixture} is absent",
-            )
+            require_tree_is_clean(root, fixture, f"{test_id} fixture path")
 
         overlap = set(programs) & set(fixtures)
         require(not overlap, f"{test_id} declares {sorted(overlap)} in both roles")
@@ -385,35 +463,91 @@ def resolve_tool(name: str, pattern: str, root: Path) -> tuple[str, str]:
     return executable, fingerprint
 
 
-def expose(root: Path, view: Path, relative: str) -> None:
-    """Copy one repository entry into the view at its own relative path."""
+IGNORED_ENTRIES = frozenset({"__pycache__"})
+READ_ONLY_FILE = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+READ_ONLY_DIRECTORY = (
+    stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
+)
 
-    source = root / relative
-    require(not source.is_symlink(), f"{relative} is a symlink")
+
+def expose(root: Path, view: Path, relative: str) -> None:
+    """Copy one repository entry into the view at its own relative path.
+
+    The copy never follows a link.  `shutil.copytree` is not used: with
+    `symlinks=False` it dereferences a nested symlink and pulls its target into
+    the view, which is exactly the escape the ledger forbids, and with
+    `symlinks=True` it reproduces the link so the command dereferences it
+    instead.  Every entry is checked with `os.lstat` and copied only when it is
+    a regular file or a directory.
+    """
+
+    require_tree_is_clean(root, relative, f"exposed entry {relative}")
     destination = view / relative
     destination.parent.mkdir(parents=True, exist_ok=True)
-    if source.is_dir():
+    if stat.S_ISDIR(lstat_mode(root, relative)):
         if destination.exists():
             return
-        shutil.copytree(
-            source,
-            destination,
-            symlinks=False,
-            ignore=shutil.ignore_patterns("__pycache__"),
-        )
+        copy_tree_without_links(root / relative, destination)
     else:
-        shutil.copy2(source, destination)
+        shutil.copyfile(root / relative, destination, follow_symlinks=False)
+
+
+def copy_tree_without_links(source: Path, destination: Path) -> None:
+    """Copy one directory, refusing any entry that is not a file or directory."""
+
+    destination.mkdir(parents=True, exist_ok=True)
+    for name in sorted(os.listdir(source)):
+        if name in IGNORED_ENTRIES:
+            continue
+        child = source / name
+        mode = os.lstat(child).st_mode
+        require(
+            not stat.S_ISLNK(mode),
+            f"{child} is a symlink and cannot enter the view",
+        )
+        require(
+            stat.S_ISREG(mode) or stat.S_ISDIR(mode),
+            f"{child} is neither a regular file nor a directory",
+        )
+        if stat.S_ISDIR(mode):
+            copy_tree_without_links(child, destination / name)
+        else:
+            shutil.copyfile(child, destination / name, follow_symlinks=False)
 
 
 def make_read_only(view: Path) -> None:
+    """Clear write access on files *and* directories under the view.
+
+    A read-only file inside a writable directory is not read-only in any sense
+    a release cares about: on Unix the directory's write bit governs create,
+    unlink, and rename, so a command could delete a declared subject and put
+    its own bytes at the same path. Directories are walked deepest first so a
+    parent is sealed only after its children.
+    """
+
     for path in sorted(view.rglob("*"), reverse=True):
-        if path.is_file():
-            path.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        mode = os.lstat(path).st_mode
+        if stat.S_ISDIR(mode):
+            path.chmod(READ_ONLY_DIRECTORY)
+        elif stat.S_ISREG(mode):
+            path.chmod(READ_ONLY_FILE)
+    view.chmod(READ_ONLY_DIRECTORY)
 
 
 def make_writable(view: Path) -> None:
-    for path in view.rglob("*"):
-        if path.is_file():
+    """Restore write access so the workspace can be removed.
+
+    Directories are reopened shallowest first: a sealed directory permits
+    reading and traversal, so the walk itself succeeds either way, but a child
+    cannot be unlinked until its parent is writable again.
+    """
+
+    view.chmod(stat.S_IRWXU)
+    for path in sorted(view.rglob("*")):
+        mode = os.lstat(path).st_mode
+        if stat.S_ISDIR(mode):
+            path.chmod(stat.S_IRWXU)
+        elif stat.S_ISREG(mode):
             path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
@@ -426,9 +560,22 @@ def canonical_artifacts(policy: Policy) -> tuple[str, ...]:
     )
 
 
-def observe(test: Test, policy: Policy, root: Path = ROOT) -> dict:
-    """Run one inventory test in its own view and return its payload receipt."""
+def observe(
+    test: Test,
+    policy: Policy,
+    root: Path = ROOT,
+    pins: dict[str, str] | None = None,
+) -> dict:
+    """Run one inventory test in its own view and return its payload receipt.
 
+    The receipt carries every field the `supervisorReceipt` shape in
+    `tests/tenkz/release-support/reset-replay-v1.schema.json` marks required,
+    because a replay receipt embeds these receipts verbatim and a later payload
+    validation rejects an incomplete one. `pins` is accepted so a caller
+    running the whole inventory reads the three Git pins once.
+    """
+
+    pins = pins if pins is not None else computed_pins(policy, root)
     profile = tool_profile(root)
     require(
         test.runner in profile,
@@ -492,6 +639,9 @@ def observe(test: Test, policy: Policy, root: Path = ROOT) -> dict:
         return {
             "test_id": test.id,
             "surface": test.surface,
+            "code_tree": pins["release_test_code_tree"],
+            "support_tree": pins["release_test_support_tree"],
+            "inventory_sha256": pins["release_test_inventory_sha256"],
             "command": [test.runner, test.path, *test.args],
             "program_paths": list(test.program_paths),
             "fixture_paths": list(test.fixture_paths),
@@ -557,9 +707,10 @@ def command_run(policy: Policy, root: Path, selected: str | None) -> int:
     if selected is not None:
         tests = tuple(test for test in tests if test.id == selected)
         require(tests, f"no inventory test has id {selected}")
+    pins = computed_pins(policy, root)
     failures = []
     for test in tests:
-        receipt = observe(test, policy, root)
+        receipt = observe(test, policy, root, pins)
         print(f"{receipt['assertion_result']:>16}  {test.id}")
         if receipt["assertion_result"] != "passed":
             failures.append((test, receipt))

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Evidence supervisor for the tenkz release-test inventory.
+
+`docs/tenkz/SOAK-1.0.md` §Release payload evidence is the authority for
+everything here.  The supervisor reads the pinned policy block out of
+`docs/tenkz/DESIGN.md`, checks the closed inventory against it, builds one
+repository-shaped view per command, runs the command in that view, and emits a
+payload receipt.  It is release-test code, so it imports nothing from
+`scripts/` and nothing outside this tree.
+
+Subcommands:
+
+    check-inventory   grammar, path roles, and policy agreement, no execution
+    run --test ID     observe-release-test: build the view and run one test
+    run-all           every inventory test in inventory order
+    pins              the three activation pins as the current tree computes them
+    check-readiness   what the enforcement state permits at this tree
+
+Two parts of the ledger's protocol are not simulated here and belong to the
+enforcement workflow: the mount namespace that hides the real checkout, and the
+denial of network access before repository code runs.  The view below exposes
+exactly the declared entries and nothing else, and every path a command reads
+outside it is a defect the receipt cannot hide, but a determined command could
+still read an absolute path.  `RELEASE-POLICY.md` §2 records this as the
+boundary between the harness and the job that runs it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+HARNESS_ROOT = Path(__file__).resolve().parent
+ROOT = HARNESS_ROOT.parents[2]
+DESIGN_PATH = "docs/tenkz/DESIGN.md"
+POLICY_BLOCK = re.compile(
+    r"^```toml[ \t]+tenkz-policy-v1[ \t]*\n(.*?)^```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+TEST_ID_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+GIT_OID_RE = re.compile(r"[0-9a-f]{40}")
+RUNNER_SUFFIX = {"python3": ".py", "bash": ".sh"}
+SURFACES = ("tex-api", "tnlog")
+TEST_FIELDS = {
+    "id",
+    "surface",
+    "failure_fingerprint",
+    "runner",
+    "path",
+    "args",
+    "program_paths",
+    "fixture_paths",
+    "timeout_seconds",
+}
+FAILURE_RECEIPT = "assertion-failure-v1.json"
+ASSERTION_EXIT = 10
+TOOL_PROFILE = "tests/tenkz/release-support/tool-profile.toml"
+
+
+class SupervisorError(Exception):
+    """The inventory, the policy, or a command run is invalid."""
+
+
+def require(condition: object, message: str) -> None:
+    if not condition:
+        raise SupervisorError(message)
+
+
+# --------------------------------------------------------------------------
+# Pinned policy
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Policy:
+    """The release-payload values the supervisor reads from the pinned block."""
+
+    enforcement: str
+    inventory: str
+    inventory_sha256: str
+    code_root: str
+    code_tree: str
+    support_root: str
+    support_tree: str
+    subject_roots: tuple[str, ...]
+    fix_paths: dict[str, tuple[str, ...]]
+    package_metadata: str
+    manual: str
+    change_record: str
+    event_format: str
+    tag_public_key: str
+
+
+def read_policy(root: Path = ROOT) -> Policy:
+    text = (root / DESIGN_PATH).read_text(encoding="utf-8")
+    blocks = POLICY_BLOCK.findall(text)
+    require(len(blocks) == 1, f"expected one policy block in {DESIGN_PATH}")
+    table = tomllib.loads(blocks[0])["policy"]
+    return Policy(
+        enforcement=table["enforcement"],
+        inventory=table["release_test_inventory"],
+        inventory_sha256=table["release_test_inventory_sha256"],
+        code_root=table["release_test_code_root"],
+        code_tree=table["release_test_code_tree"],
+        support_root=table["release_test_support_root"],
+        support_tree=table["release_test_support_tree"],
+        subject_roots=tuple(table["release_test_subject_roots"]),
+        fix_paths={
+            "tex-api": tuple(table["tex_api_fix_paths"]),
+            "tnlog": tuple(table["tnlog_fix_paths"]),
+        },
+        package_metadata=table["release_package_metadata"],
+        manual=table["release_manual"],
+        change_record=table["release_change_record"],
+        event_format=table["release_event_format"],
+        tag_public_key=table["release_tag_public_key"],
+    )
+
+
+# --------------------------------------------------------------------------
+# Path grammar
+# --------------------------------------------------------------------------
+
+
+def normalized(value: object) -> str | None:
+    """Return the repository-relative path, or None when the spelling is illegal."""
+
+    if not isinstance(value, str) or not value or value.startswith("/") or "\\" in value:
+        return None
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return value
+
+
+def glob_matches(path: str, pattern: str) -> bool:
+    """Match the policy's `*`/`**` repository-path grammar, not the shell's."""
+
+    expression = re.escape(pattern)
+    expression = expression.replace(r"\*\*/", r"(?:[^/]+/)*")
+    expression = expression.replace(r"\*", r"[^/]*")
+    return re.fullmatch(expression, path) is not None
+
+
+def within_roots(path: str, roots: tuple[str, ...]) -> bool:
+    return any(path == root or path.startswith(f"{root}/") for root in roots)
+
+
+# --------------------------------------------------------------------------
+# Inventory
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Test:
+    """One atomic compatibility assertion and everything it may read."""
+
+    id: str
+    surface: str
+    failure_fingerprint: str
+    runner: str
+    path: str
+    args: tuple[str, ...]
+    program_paths: tuple[str, ...]
+    fixture_paths: tuple[str, ...]
+    timeout_seconds: int
+
+
+def load_inventory(policy: Policy, root: Path = ROOT) -> tuple[Test, ...]:
+    """Parse and fully validate the closed inventory against the pinned policy."""
+
+    blob = root / policy.inventory
+    require(blob.is_file(), f"{policy.inventory} is absent")
+    document = tomllib.loads(blob.read_text(encoding="utf-8"))
+    require(set(document) == {"schema", "test"}, "inventory has fields outside its schema")
+    require(document["schema"] == 1, "inventory schema must be 1")
+    raw = document["test"]
+    require(isinstance(raw, list) and raw, "inventory needs one or more [[test]] tables")
+
+    tests: list[Test] = []
+    seen_ids: set[str] = set()
+    seen_fingerprints: set[str] = set()
+    for index, entry in enumerate(raw, start=1):
+        require(set(entry) == TEST_FIELDS, f"test {index} fields differ from the schema")
+        test_id = entry["id"]
+        require(
+            isinstance(test_id, str) and TEST_ID_RE.fullmatch(test_id) is not None,
+            f"test {index} has an invalid id",
+        )
+        require(test_id not in seen_ids, f"duplicate test id {test_id}")
+        seen_ids.add(test_id)
+
+        surface = entry["surface"]
+        require(surface in SURFACES, f"{test_id} has an unknown surface")
+
+        fingerprint = entry["failure_fingerprint"]
+        require(
+            isinstance(fingerprint, str) and SHA256_RE.fullmatch(fingerprint) is not None,
+            f"{test_id} has an invalid failure fingerprint",
+        )
+        require(
+            fingerprint not in seen_fingerprints,
+            f"{test_id} reuses another test's failure fingerprint",
+        )
+        seen_fingerprints.add(fingerprint)
+
+        runner = entry["runner"]
+        require(runner in RUNNER_SUFFIX, f"{test_id} has an unknown runner")
+
+        path = normalized(entry["path"])
+        require(path is not None, f"{test_id} has an illegal path spelling")
+        require(
+            path.startswith(f"{policy.code_root}/"),
+            f"{test_id} path is outside the pinned test-code root",
+        )
+        require(
+            path.endswith(RUNNER_SUFFIX[runner]),
+            f"{test_id} path suffix does not match its runner",
+        )
+        require((root / path).is_file(), f"{test_id} path is not a regular file")
+
+        args = entry["args"]
+        require(
+            isinstance(args, list)
+            and all(isinstance(item, str) and item for item in args),
+            f"{test_id} args must be nonempty strings",
+        )
+
+        programs = subject_paths(root, policy, test_id, entry["program_paths"], "program")
+        require(programs, f"{test_id} declares no program path")
+        for program in programs:
+            require(
+                (root / program).is_file(),
+                f"{test_id} program path {program} is not a regular file",
+            )
+            require(
+                any(glob_matches(program, p) for p in policy.fix_paths[surface]),
+                f"{test_id} program path {program} is outside its surface's fix paths",
+            )
+
+        fixtures = subject_paths(root, policy, test_id, entry["fixture_paths"], "fixture")
+        for fixture in fixtures:
+            require(
+                (root / fixture).exists(),
+                f"{test_id} fixture path {fixture} is absent",
+            )
+
+        overlap = set(programs) & set(fixtures)
+        require(not overlap, f"{test_id} declares {sorted(overlap)} in both roles")
+        for fixture in fixtures:
+            require(
+                not any(program.startswith(f"{fixture}/") for program in programs),
+                f"{test_id} fixture tree {fixture} contains a program path",
+            )
+
+        timeout = entry["timeout_seconds"]
+        require(
+            isinstance(timeout, int) and not isinstance(timeout, bool) and timeout > 0,
+            f"{test_id} timeout must be a positive integer",
+        )
+
+        tests.append(
+            Test(
+                id=test_id,
+                surface=surface,
+                failure_fingerprint=fingerprint,
+                runner=runner,
+                path=path,
+                args=tuple(args),
+                program_paths=programs,
+                fixture_paths=fixtures,
+                timeout_seconds=timeout,
+            )
+        )
+    return tuple(tests)
+
+
+def subject_paths(
+    root: Path,
+    policy: Policy,
+    test_id: str,
+    value: object,
+    role: str,
+) -> tuple[str, ...]:
+    require(isinstance(value, list), f"{test_id} {role}_paths must be a list")
+    resolved: list[str] = []
+    for item in value:
+        path = normalized(item)
+        require(path is not None, f"{test_id} has an illegal {role} path spelling")
+        require(
+            within_roots(path, policy.subject_roots),
+            f"{test_id} {role} path {path} is outside the declared subject roots",
+        )
+        resolved.append(path)
+    require(len(resolved) == len(set(resolved)), f"{test_id} {role}_paths repeat a path")
+    return tuple(resolved)
+
+
+# --------------------------------------------------------------------------
+# Pins
+# --------------------------------------------------------------------------
+
+
+def git_tree_oid(root: Path, path: str) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", f"HEAD:{path}"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    require(result.returncode == 0, f"could not read the Git tree OID of {path}")
+    oid = result.stdout.strip()
+    require(GIT_OID_RE.fullmatch(oid) is not None, f"{path} did not resolve to a tree OID")
+    return oid
+
+
+def blob_sha256(root: Path, path: str) -> str:
+    return hashlib.sha256((root / path).read_bytes()).hexdigest()
+
+
+def computed_pins(policy: Policy, root: Path = ROOT) -> dict[str, str]:
+    """The three values the activation change copies into the pinned policy."""
+
+    return {
+        "release_test_inventory_sha256": blob_sha256(root, policy.inventory),
+        "release_test_code_tree": git_tree_oid(root, policy.code_root),
+        "release_test_support_tree": git_tree_oid(root, policy.support_root),
+    }
+
+
+# --------------------------------------------------------------------------
+# Hermetic view and command execution
+# --------------------------------------------------------------------------
+
+
+def tool_profile(root: Path) -> dict[str, str]:
+    document = tomllib.loads((root / TOOL_PROFILE).read_text(encoding="utf-8"))
+    require(set(document) == {"tool"}, "tool profile has fields outside its schema")
+    return {name: table["version_pattern"] for name, table in document["tool"].items()}
+
+
+def resolve_tool(name: str, pattern: str, root: Path) -> tuple[str, str]:
+    """Resolve one allowlisted child tool and validate its configured fingerprint.
+
+    Resolution reads the caller's path once.  What the command then sees is the
+    sanitized path built from the resolved tools alone, so an inventory command
+    can reach the allowlisted tools and nothing else.  A tool that resolves
+    inside the repository is rejected: the pinned trees supply assertions, not
+    interpreters.
+    """
+
+    executable = shutil.which(name)
+    require(executable is not None, f"child tool {name} is not on the caller's path")
+    resolved = Path(executable).resolve()
+    require(
+        not resolved.is_relative_to(root),
+        f"child tool {name} resolves inside the repository at {resolved}",
+    )
+    result = subprocess.run(
+        [executable, "--version"],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    fingerprint = (result.stdout + result.stderr).strip().splitlines()[0]
+    require(
+        re.fullmatch(pattern, fingerprint) is not None,
+        f"child tool {name} reports {fingerprint!r}, which the tool profile rejects",
+    )
+    return executable, fingerprint
+
+
+def expose(root: Path, view: Path, relative: str) -> None:
+    """Copy one repository entry into the view at its own relative path."""
+
+    source = root / relative
+    require(not source.is_symlink(), f"{relative} is a symlink")
+    destination = view / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_dir():
+        if destination.exists():
+            return
+        shutil.copytree(
+            source,
+            destination,
+            symlinks=False,
+            ignore=shutil.ignore_patterns("__pycache__"),
+        )
+    else:
+        shutil.copy2(source, destination)
+
+
+def make_read_only(view: Path) -> None:
+    for path in sorted(view.rglob("*"), reverse=True):
+        if path.is_file():
+            path.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+
+
+def make_writable(view: Path) -> None:
+    for path in view.rglob("*"):
+        if path.is_file():
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def canonical_artifacts(policy: Policy) -> tuple[str, ...]:
+    return (
+        policy.package_metadata,
+        policy.manual,
+        policy.change_record,
+        policy.event_format,
+    )
+
+
+def observe(test: Test, policy: Policy, root: Path = ROOT) -> dict:
+    """Run one inventory test in its own view and return its payload receipt."""
+
+    profile = tool_profile(root)
+    require(
+        test.runner in profile,
+        f"{test.id} runner {test.runner} is not in the pinned tool profile",
+    )
+    tools = {
+        name: resolve_tool(name, pattern, root) for name, pattern in profile.items()
+    }
+    sanitized_path = os.pathsep.join(
+        dict.fromkeys(str(Path(executable).parent) for executable, _ in tools.values())
+    )
+
+    workspace = Path(tempfile.mkdtemp(prefix="tenkz-release-"))
+    view = workspace / "view"
+    output = workspace / "output"
+    view.mkdir()
+    output.mkdir()
+    try:
+        for relative in (
+            policy.code_root,
+            policy.support_root,
+            policy.inventory,
+            *canonical_artifacts(policy),
+            *test.program_paths,
+            *test.fixture_paths,
+        ):
+            expose(root, view, relative)
+        make_read_only(view)
+
+        environment = {
+            "PATH": sanitized_path,
+            "LC_ALL": "C",
+            "LANG": "C",
+            "TZ": "UTC",
+            "HOME": str(workspace / "home"),
+            "TENKZ_TEST_OUTPUT": str(output),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+        (workspace / "home").mkdir()
+
+        timed_out = False
+        try:
+            completed = subprocess.run(
+                [tools[test.runner][0], test.path, *test.args],
+                cwd=view,
+                env=environment,
+                text=True,
+                capture_output=True,
+                timeout=test.timeout_seconds,
+                check=False,
+            )
+            exit_status = completed.returncode
+            stderr = completed.stderr
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            exit_status = -1
+            stderr = ""
+
+        require(not timed_out, f"{test.id} exceeded its {test.timeout_seconds}s timeout")
+        result = classify(test, exit_status, output, stderr)
+        return {
+            "test_id": test.id,
+            "surface": test.surface,
+            "command": [test.runner, test.path, *test.args],
+            "program_paths": list(test.program_paths),
+            "fixture_paths": list(test.fixture_paths),
+            "exit_status": exit_status,
+            "assertion_result": result,
+            "timed_out": timed_out,
+            "output_mount": "/tenkz-output",
+            "tool_fingerprints": {name: value[1] for name, value in tools.items()},
+        }
+    finally:
+        make_writable(view)
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def classify(test: Test, exit_status: int, output: Path, stderr: str) -> str:
+    """Accept exit zero, or exit ten with the exact receipt.  Nothing else."""
+
+    receipt_path = output / FAILURE_RECEIPT
+    if exit_status == 0:
+        require(
+            not receipt_path.exists(),
+            f"{test.id} passed but wrote an assertion-failure receipt",
+        )
+        return "passed"
+    require(
+        exit_status == ASSERTION_EXIT,
+        f"{test.id} exited {exit_status}, which is neither a pass nor an assertion "
+        f"failure: {stderr.strip()[:400]}",
+    )
+    require(receipt_path.is_file(), f"{test.id} exited 10 without its receipt")
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    require(
+        set(receipt) == {"schema", "test_id", "failure_fingerprint", "completed"},
+        f"{test.id} wrote a receipt outside the closed shape",
+    )
+    require(receipt["schema"] == 1, f"{test.id} receipt schema must be 1")
+    require(receipt["test_id"] == test.id, f"{test.id} receipt names another test")
+    require(
+        receipt["failure_fingerprint"] == test.failure_fingerprint,
+        f"{test.id} receipt carries another test's fingerprint",
+    )
+    require(receipt["completed"] is True, f"{test.id} receipt is incomplete")
+    return "assertion-failed"
+
+
+# --------------------------------------------------------------------------
+# Subcommands
+# --------------------------------------------------------------------------
+
+
+def command_check_inventory(policy: Policy, root: Path) -> int:
+    tests = load_inventory(policy, root)
+    surfaces = sorted({test.surface for test in tests})
+    print(
+        f"PASS: {len(tests)} atomic release assertion(s) over "
+        f"{', '.join(surfaces)}; inventory agrees with the pinned policy"
+    )
+    return 0
+
+
+def command_run(policy: Policy, root: Path, selected: str | None) -> int:
+    tests = load_inventory(policy, root)
+    if selected is not None:
+        tests = tuple(test for test in tests if test.id == selected)
+        require(tests, f"no inventory test has id {selected}")
+    failures = []
+    for test in tests:
+        receipt = observe(test, policy, root)
+        print(f"{receipt['assertion_result']:>16}  {test.id}")
+        if receipt["assertion_result"] != "passed":
+            failures.append((test, receipt))
+    if failures:
+        for test, receipt in failures:
+            print(
+                f"FAIL: {test.id} reported {receipt['assertion_result']} with "
+                f"fingerprint {test.failure_fingerprint}",
+                file=sys.stderr,
+            )
+        return 1
+    print(f"PASS: {len(tests)} release assertion(s) hold at this tree")
+    return 0
+
+
+def command_pins(policy: Policy, root: Path) -> int:
+    for name, value in computed_pins(policy, root).items():
+        print(f'{name} = "{value}"')
+    return 0
+
+
+def command_check_readiness(policy: Policy, root: Path) -> int:
+    load_inventory(policy, root)
+    pending = {
+        "release_test_inventory_sha256": policy.inventory_sha256,
+        "release_test_code_tree": policy.code_tree,
+        "release_test_support_tree": policy.support_tree,
+    }
+    if policy.enforcement == "pending":
+        for name, value in pending.items():
+            require(
+                value == "pending",
+                f"policy enforcement is pending but {name} is already pinned",
+            )
+        key = root / policy.tag_public_key
+        state = "present" if key.is_file() else "absent"
+        print(
+            "PASS: enforcement pending; the harness, support tree, and inventory "
+            f"exist and the final-tag public key is {state}. No release command "
+            "is available."
+        )
+        return 0
+    computed = computed_pins(policy, root)
+    for name, value in pending.items():
+        require(
+            value == computed[name],
+            f"armed policy {name} does not equal this tree's value",
+        )
+    require(
+        (root / policy.tag_public_key).is_file(),
+        "armed policy names a final-tag public key that is absent",
+    )
+    print("PASS: enforcement armed; every activation pin matches this tree")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", type=Path, default=ROOT, help=argparse.SUPPRESS)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("check-inventory")
+    run = subparsers.add_parser("run")
+    run.add_argument("--test", help="run only the inventory test with this id")
+    subparsers.add_parser("run-all")
+    subparsers.add_parser("pins")
+    subparsers.add_parser("check-readiness")
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    try:
+        policy = read_policy(root)
+        if args.command == "check-inventory":
+            return command_check_inventory(policy, root)
+        if args.command == "run":
+            return command_run(policy, root, args.test)
+        if args.command == "run-all":
+            return command_run(policy, root, None)
+        if args.command == "pins":
+            return command_pins(policy, root)
+        return command_check_readiness(policy, root)
+    except (SupervisorError, OSError, ValueError, KeyError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -16,13 +16,23 @@ Subcommands:
     pins              the three activation pins as the current tree computes them
     check-readiness   what the enforcement state permits at this tree
 
-Two parts of the ledger's protocol are not simulated here and belong to the
-enforcement workflow: the mount namespace that hides the real checkout, and the
-denial of network access before repository code runs.  The view below exposes
-exactly the declared entries and nothing else, and every path a command reads
-outside it is a defect the receipt cannot hide, but a determined command could
-still read an absolute path.  `RELEASE-POLICY.md` §2 records this as the
-boundary between the harness and the job that runs it.
+What the view is, and what it is not.  It is *declarative* isolation: it
+contains exactly the pinned trees, the inventory, the command's declared
+subjects, and — with a tag — the tag-derived manifest, so a command that reads
+only what it declared cannot see anything else, and a receipt names everything
+it could have seen.  It is not a sandbox.  Three limits follow and none is
+closed by anything this file can do:
+
+  * the command runs as the user that built the view and owns every path in
+    it, so it can `chmod` a sealed file or directory back and then modify it;
+  * nothing stops it reading an absolute path outside the view;
+  * nothing stops it opening a socket.
+
+The mode bits below therefore stop an accident, not an adversary.  Closing all
+three needs a mount namespace and an identity that does not own the view, which
+the ledger assigns to the enforcement workflow and not to the supervisor;
+`RELEASE-POLICY.md` §2 records the boundary.  Read a payload receipt as
+evidence about a cooperating command, which is what a release test is.
 """
 
 from __future__ import annotations

--- a/tests/tenkz/release-harness/supervisor.py
+++ b/tests/tenkz/release-harness/supervisor.py
@@ -1045,11 +1045,15 @@ def command_check_readiness(policy: Policy, root: Path) -> int:
 ARMED_WORKFLOW = ".github/workflows/tenkz-release-policy.yml"
 YAML_COMMENT = re.compile(r"(?m)(?:(?<=^)|(?<=\s))#.*$")
 MUTABLE_ACTION = re.compile(r"uses:\s*\S+@(?!\b[0-9a-f]{40}\b)\S+")
-ARMED_MECHANISMS = (
-    (
-        re.compile(r"(?m)^\s+environment:\s*\n(?:\s+name:\s*)?tenkz-release-publisher\s*$"),
-        "a job whose `environment:` is tenkz-release-publisher",
-    ),
+JOBS_KEY = re.compile(r"(?m)^jobs:\s*$")
+JOB_HEADER = re.compile(r"(?m)^(\s+)([A-Za-z_][\w-]*):\s*$")
+# `environment: name` and the block form `environment:\n  name: name` are both
+# legal GitHub spellings of the same thing, so both must match.
+PUBLISHER_ENVIRONMENT = re.compile(
+    r"(?m)^\s+environment:\s*(?:tenkz-release-publisher\s*$"
+    r"|\s*\n\s+name:\s*tenkz-release-publisher\s*$)"
+)
+PUBLISHER_REQUIREMENTS = (
     (
         re.compile(r"(?m)^\s+contents:\s*write\s*$"),
         "a job-level `contents: write` permission",
@@ -1059,15 +1063,38 @@ ARMED_MECHANISMS = (
         "a reference to the TENKZ_FINAL_TAG_SIGNING_KEY secret",
     ),
     (
-        re.compile(r"(?m)^\s+(?:id|name):\s*tenkz-network-denied\s*$"),
-        "a step named tenkz-network-denied, which denies network access before "
-        "repository code runs",
-    ),
-    (
-        re.compile(r"(?m)^\s+needs:\s*"),
-        "a `needs:` dependency ordering the publisher after post-merge validation",
+        re.compile(r"(?m)^\s+needs:\s*\S"),
+        "its own `needs:` dependency, which is what orders it after post-merge "
+        "validation",
     ),
 )
+NETWORK_DENIAL = re.compile(r"(?m)^\s+(?:-\s+)?(?:id|name):\s*tenkz-network-denied\s*$")
+
+
+def workflow_jobs(text: str) -> dict[str, str]:
+    """Split a workflow's `jobs:` mapping into one text block per job.
+
+    This is not a YAML parser and does not need to be: job keys are the only
+    mapping at their indentation under `jobs:`, so a block runs from one such
+    key to the next. Splitting matters because the publisher's requirements are
+    requirements *on the publisher job* — a `needs:` belonging to a validation
+    job says nothing about what orders the publisher.
+    """
+
+    start = JOBS_KEY.search(text)
+    if start is None:
+        return {}
+    body = text[start.end() :]
+    headers = list(JOB_HEADER.finditer(body))
+    if not headers:
+        return {}
+    indent = min(len(header.group(1)) for header in headers)
+    jobs: dict[str, str] = {}
+    tops = [header for header in headers if len(header.group(1)) == indent]
+    for index, header in enumerate(tops):
+        stop = tops[index + 1].start() if index + 1 < len(tops) else len(body)
+        jobs[header.group(2)] = body[header.start() : stop]
+    return jobs
 
 
 def require_armed_workflow(root: Path) -> None:
@@ -1076,24 +1103,45 @@ def require_armed_workflow(root: Path) -> None:
     The workflow's own header says `check-readiness` fails closed when these
     are missing, so this is where that promise is kept.
 
-    The checks match YAML structure, not raw substrings, and they run against
-    the file with its comments removed. A substring search would have been
-    satisfied by this very file's header, which names the publisher
-    environment and `contents: write` while explaining that neither exists
-    yet — a check that its own documentation satisfies is not a check.
+    The checks read the file with its comments stripped and are scoped to the
+    job they are about. A whole-file substring search would be satisfied by
+    this very file's header, which names the publisher environment and
+    `contents: write` while explaining that neither exists yet; a whole-file
+    pattern search would be satisfied by any other job's `needs:`. A check that
+    its own documentation passes is not a check.
     """
 
     require_regular_file(root, ARMED_WORKFLOW, "the enforcement workflow")
-    raw = (root / ARMED_WORKFLOW).read_text(encoding="utf-8")
-    text = YAML_COMMENT.sub("", raw)
-    missing = [
-        description
-        for pattern, description in ARMED_MECHANISMS
-        if pattern.search(text) is None
+    text = YAML_COMMENT.sub("", (root / ARMED_WORKFLOW).read_text(encoding="utf-8"))
+    jobs = workflow_jobs(text)
+    publishers = [
+        name for name, block in jobs.items() if PUBLISHER_ENVIRONMENT.search(block)
     ]
     require(
+        publishers,
+        f"armed policy but {ARMED_WORKFLOW} has no job whose `environment:` is "
+        f"tenkz-release-publisher",
+    )
+    require(
+        len(publishers) == 1,
+        f"{ARMED_WORKFLOW} has {len(publishers)} publisher jobs {publishers}; the "
+        f"campaign has one terminal publisher",
+    )
+    publisher = jobs[publishers[0]]
+    missing = [
+        description
+        for pattern, description in PUBLISHER_REQUIREMENTS
+        if pattern.search(publisher) is None
+    ]
+    if NETWORK_DENIAL.search(text) is None:
+        missing.append(
+            "a step named tenkz-network-denied, which denies network access "
+            "before repository code runs"
+        )
+    require(
         not missing,
-        f"armed policy but {ARMED_WORKFLOW} lacks {'; '.join(missing)}",
+        f"armed policy but the {publishers[0]} job in {ARMED_WORKFLOW} lacks "
+        f"{'; '.join(missing)}",
     )
     mutable = sorted(set(MUTABLE_ACTION.findall(text)))
     require(

--- a/tests/tenkz/release-harness/tex_api_language_reference.py
+++ b/tests/tenkz/release-harness/tex_api_language_reference.py
@@ -41,6 +41,20 @@ SUBJECTS = {
 REGISTRY = "tex/tenkz/tenkz-language-registry.tex"
 REFERENCE = "docs/tenkz/chapters2/generated-language-reference.tex"
 COMMAND_ROW = re.compile(r"\\__tenkz_language_registry_command:nnnnn\s*\{([^}]+)\}")
+TEX_COMMENT = re.compile(r"(?<!\\)%.*")
+
+
+def registry_rows() -> list[str]:
+    """The command names the registry actually declares.
+
+    Comments are stripped first. A row commented out with `%` is not in the
+    executable registry, so counting it would let this assertion report that a
+    removed public command is still declared — the precise failure the
+    manual-is-the-contract rule exists to catch.
+    """
+
+    source = TEX_COMMENT.sub("", read(REGISTRY))
+    return sorted(set(COMMAND_ROW.findall(source)))
 
 
 def main() -> int:
@@ -49,7 +63,7 @@ def main() -> int:
         print(f"unknown assertion {mode!r}", file=sys.stderr)
         return 2
     test_id, fingerprint = SUBJECTS[mode]
-    declared = sorted(set(COMMAND_ROW.findall(read(REGISTRY))))
+    declared = registry_rows()
 
     if mode == "extraction":
         assert_that(

--- a/tests/tenkz/release-harness/tex_api_language_reference.py
+++ b/tests/tenkz/release-harness/tex_api_language_reference.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
-"""Every command the registry declares reaches the generated language reference.
+"""The registry's command rows, as two independent assertions.
 
 `RELEASE-POLICY.md` §1 freezes the registry as the machine inventory of the TeX
 surface and requires `chapters2/generated-language-reference.tex` to agree with
 the manual. A command that lives in the registry but never reaches the
 reference is a documented spelling the reader cannot find, which is the one
 failure the manual-is-the-contract rule of #4163 exists to prevent.
+
+Two things can be wrong and they need separate fingerprints:
+
+    extraction  the registry yields command rows at all
+    coverage    every row it yields reaches the generated reference
+
+An empty result would otherwise satisfy a coverage check vacuously, so a
+friction record could not tell a reader whether the registry parser broke or
+the reference fell behind.
 """
 
 from __future__ import annotations
@@ -19,15 +28,41 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from harnesslib import assert_that, read  # noqa: E402
 
 
-TEST_ID = "tex-api-registry-commands-reach-the-reference"
-FINGERPRINT = "6b10bdfa0d4079c322990a4e9916416013a4c8a6f8ba47aa69d6905cd50d10b0"
+SUBJECTS = {
+    "extraction": (
+        "tex-api-registry-declares-commands",
+        "9848e1f6bf653612c61c5287b7e7ebb165a39224623b66b8ee8f4ddd26aee26b",
+    ),
+    "coverage": (
+        "tex-api-registry-commands-reach-the-reference",
+        "6b10bdfa0d4079c322990a4e9916416013a4c8a6f8ba47aa69d6905cd50d10b0",
+    ),
+}
 REGISTRY = "tex/tenkz/tenkz-language-registry.tex"
 REFERENCE = "docs/tenkz/chapters2/generated-language-reference.tex"
 COMMAND_ROW = re.compile(r"\\__tenkz_language_registry_command:nnnnn\s*\{([^}]+)\}")
 
 
 def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode not in SUBJECTS:
+        print(f"unknown assertion {mode!r}", file=sys.stderr)
+        return 2
+    test_id, fingerprint = SUBJECTS[mode]
     declared = sorted(set(COMMAND_ROW.findall(read(REGISTRY))))
+
+    if mode == "extraction":
+        assert_that(
+            bool(declared),
+            test_id=test_id,
+            failure_fingerprint=fingerprint,
+            reason=(
+                f"{REGISTRY} yielded no command rows; either the registry lost "
+                f"its command declarations or their spelling changed"
+            ),
+        )
+        return 0
+
     reference = read(REFERENCE)
     missing = [
         name
@@ -35,14 +70,10 @@ def main() -> int:
         if f"\\texttt{{\\textbackslash {name}}}" not in reference
     ]
     assert_that(
-        declared and not missing,
-        test_id=TEST_ID,
-        failure_fingerprint=FINGERPRINT,
-        reason=(
-            f"{REFERENCE} omits registry command(s) {missing!r}"
-            if declared
-            else f"{REGISTRY} declares no command rows"
-        ),
+        not missing,
+        test_id=test_id,
+        failure_fingerprint=fingerprint,
+        reason=f"{REFERENCE} omits registry command(s) {missing!r}",
     )
     return 0
 

--- a/tests/tenkz/release-harness/tex_api_language_reference.py
+++ b/tests/tenkz/release-harness/tex_api_language_reference.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from harnesslib import assert_that, read  # noqa: E402
+from harnesslib import assert_that, read, selected_assertion  # noqa: E402
 
 
 SUBJECTS = {
@@ -58,11 +58,8 @@ def registry_rows() -> list[str]:
 
 
 def main() -> int:
-    mode = sys.argv[1] if len(sys.argv) > 1 else ""
-    if mode not in SUBJECTS:
-        print(f"unknown assertion {mode!r}", file=sys.stderr)
-        return 2
-    test_id, fingerprint = SUBJECTS[mode]
+    mode = sys.argv[1]
+    test_id, fingerprint = selected_assertion(SUBJECTS)
     declared = registry_rows()
 
     if mode == "extraction":

--- a/tests/tenkz/release-harness/tex_api_language_reference.py
+++ b/tests/tenkz/release-harness/tex_api_language_reference.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Every command the registry declares reaches the generated language reference.
+
+`RELEASE-POLICY.md` §1 freezes the registry as the machine inventory of the TeX
+surface and requires `chapters2/generated-language-reference.tex` to agree with
+the manual. A command that lives in the registry but never reaches the
+reference is a documented spelling the reader cannot find, which is the one
+failure the manual-is-the-contract rule of #4163 exists to prevent.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from harnesslib import assert_that, read  # noqa: E402
+
+
+TEST_ID = "tex-api-registry-commands-reach-the-reference"
+FINGERPRINT = "6b10bdfa0d4079c322990a4e9916416013a4c8a6f8ba47aa69d6905cd50d10b0"
+REGISTRY = "tex/tenkz/tenkz-language-registry.tex"
+REFERENCE = "docs/tenkz/chapters2/generated-language-reference.tex"
+COMMAND_ROW = re.compile(r"\\__tenkz_language_registry_command:nnnnn\s*\{([^}]+)\}")
+
+
+def main() -> int:
+    declared = sorted(set(COMMAND_ROW.findall(read(REGISTRY))))
+    reference = read(REFERENCE)
+    missing = [
+        name
+        for name in declared
+        if f"\\texttt{{\\textbackslash {name}}}" not in reference
+    ]
+    assert_that(
+        declared and not missing,
+        test_id=TEST_ID,
+        failure_fingerprint=FINGERPRINT,
+        reason=(
+            f"{REFERENCE} omits registry command(s) {missing!r}"
+            if declared
+            else f"{REGISTRY} declares no command rows"
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tenkz/release-harness/tex_api_package_version.py
+++ b/tests/tenkz/release-harness/tex_api_package_version.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import re
 import sys
+from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -32,7 +33,26 @@ from harnesslib import assert_that, read  # noqa: E402
 
 SUBJECT = "tex/tenkz/tenkz.sty"
 DECLARATION = re.compile(r"^\\ProvidesPackage\{tenkz\}\[([^]]*)\]", re.MULTILINE)
-PAYLOAD = re.compile(r"[0-9]{4}/[0-9]{2}/[0-9]{2} v[0-9]+\.[0-9]+(?:\.[0-9]+)? \S.*")
+PAYLOAD = re.compile(
+    r"(?P<y>[0-9]{4})/(?P<m>[0-9]{2})/(?P<d>[0-9]{2}) v[0-9]+\.[0-9]+(?:\.[0-9]+)? \S.*"
+)
+
+
+def well_formed(payload: str) -> bool:
+    """The payload parses, and its date is a real calendar date.
+
+    Counting digits is not enough: `2026/99/99` has the right shape and cannot
+    be the ISO calendar date the release manifest declares against.
+    """
+
+    match = PAYLOAD.fullmatch(payload)
+    if match is None:
+        return False
+    try:
+        date(int(match["y"]), int(match["m"]), int(match["d"]))
+    except ValueError:
+        return False
+    return True
 
 ASSERTIONS = {
     "cardinality": (
@@ -66,16 +86,14 @@ def main() -> int:
         )
         return 0
 
-    malformed = [
-        payload for payload in declarations if PAYLOAD.fullmatch(payload) is None
-    ]
+    malformed = [payload for payload in declarations if not well_formed(payload)]
     assert_that(
         not malformed,
         test_id=test_id,
         failure_fingerprint=fingerprint,
         reason=(
             f"{SUBJECT} declares {malformed!r}, which is not spelled "
-            f"[YYYY/MM/DD vMAJOR.MINOR[.PATCH] description]"
+            f"[YYYY/MM/DD vMAJOR.MINOR[.PATCH] description] with a real date"
         ),
     )
     return 0

--- a/tests/tenkz/release-harness/tex_api_package_version.py
+++ b/tests/tenkz/release-harness/tex_api_package_version.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""The package declares exactly one well-formed version.
+
+`RELEASE-POLICY.md` §3: the version string lives in one place, the
+`\\ProvidesPackage` line of `tex/tenkz/tenkz.sty`, and the manual, change
+record, event-format declaration, and release manifest are all checked against
+it. A second declaration, a missing date, or a version the manifest grammar
+cannot read makes every one of those checks meaningless, so this is the
+assertion they all rest on.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from harnesslib import assert_that, read  # noqa: E402
+
+
+TEST_ID = "tex-api-package-version-declared"
+FINGERPRINT = "aa16d2f161b986789b582d211b59344b66171a386e3fcfcc259aafb2ba48e1d8"
+SUBJECT = "tex/tenkz/tenkz.sty"
+DECLARATION = re.compile(r"^\\ProvidesPackage\{tenkz\}\[([^]]*)\]", re.MULTILINE)
+PAYLOAD = re.compile(r"[0-9]{4}/[0-9]{2}/[0-9]{2} v[0-9]+\.[0-9]+(?:\.[0-9]+)? \S.*")
+
+
+def main() -> int:
+    declarations = DECLARATION.findall(read(SUBJECT))
+    assert_that(
+        len(declarations) == 1 and PAYLOAD.fullmatch(declarations[0]) is not None,
+        test_id=TEST_ID,
+        failure_fingerprint=FINGERPRINT,
+        reason=(
+            f"{SUBJECT} must carry exactly one \\ProvidesPackage line spelled "
+            f"[YYYY/MM/DD vMAJOR.MINOR[.PATCH] description]; found {declarations!r}"
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tenkz/release-harness/tex_api_package_version.py
+++ b/tests/tenkz/release-harness/tex_api_package_version.py
@@ -1,12 +1,22 @@
 #!/usr/bin/env python3
-"""The package declares exactly one well-formed version.
+"""The package's version declaration, as two independent assertions.
 
 `RELEASE-POLICY.md` §3: the version string lives in one place, the
 `\\ProvidesPackage` line of `tex/tenkz/tenkz.sty`, and the manual, change
 record, event-format declaration, and release manifest are all checked against
-it. A second declaration, a missing date, or a version the manifest grammar
-cannot read makes every one of those checks meaningless, so this is the
-assertion they all rest on.
+it.
+
+Two things can be wrong with that line and they need separate fingerprints,
+because a friction record names the fingerprint and one that stood for both
+could not tell a reader whether to fix a duplicated declaration or a malformed
+version:
+
+    cardinality   the file carries exactly one declaration
+    syntax        every declaration it carries parses as date-and-version
+
+The two are independent. A file with two well-formed declarations fails the
+first and passes the second; a file with one malformed declaration does the
+reverse.
 """
 
 from __future__ import annotations
@@ -20,22 +30,52 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from harnesslib import assert_that, read  # noqa: E402
 
 
-TEST_ID = "tex-api-package-version-declared"
-FINGERPRINT = "aa16d2f161b986789b582d211b59344b66171a386e3fcfcc259aafb2ba48e1d8"
 SUBJECT = "tex/tenkz/tenkz.sty"
 DECLARATION = re.compile(r"^\\ProvidesPackage\{tenkz\}\[([^]]*)\]", re.MULTILINE)
 PAYLOAD = re.compile(r"[0-9]{4}/[0-9]{2}/[0-9]{2} v[0-9]+\.[0-9]+(?:\.[0-9]+)? \S.*")
 
+ASSERTIONS = {
+    "cardinality": (
+        "tex-api-package-version-declared-once",
+        "6975c749deed3d812904570c3ea9fc4d14fe2f002c5ecff56b66e7aaba8e6e21",
+    ),
+    "syntax": (
+        "tex-api-package-version-well-formed",
+        "4c75affd12f21b0ee2e262ccce6495382baed3cf11e1d9ac96c5bed05d8a3d36",
+    ),
+}
+
 
 def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode not in ASSERTIONS:
+        print(f"unknown assertion {mode!r}", file=sys.stderr)
+        return 2
+    test_id, fingerprint = ASSERTIONS[mode]
     declarations = DECLARATION.findall(read(SUBJECT))
+
+    if mode == "cardinality":
+        assert_that(
+            len(declarations) == 1,
+            test_id=test_id,
+            failure_fingerprint=fingerprint,
+            reason=(
+                f"{SUBJECT} must carry exactly one \\ProvidesPackage{{tenkz}} line; "
+                f"found {len(declarations)}"
+            ),
+        )
+        return 0
+
+    malformed = [
+        payload for payload in declarations if PAYLOAD.fullmatch(payload) is None
+    ]
     assert_that(
-        len(declarations) == 1 and PAYLOAD.fullmatch(declarations[0]) is not None,
-        test_id=TEST_ID,
-        failure_fingerprint=FINGERPRINT,
+        not malformed,
+        test_id=test_id,
+        failure_fingerprint=fingerprint,
         reason=(
-            f"{SUBJECT} must carry exactly one \\ProvidesPackage line spelled "
-            f"[YYYY/MM/DD vMAJOR.MINOR[.PATCH] description]; found {declarations!r}"
+            f"{SUBJECT} declares {malformed!r}, which is not spelled "
+            f"[YYYY/MM/DD vMAJOR.MINOR[.PATCH] description]"
         ),
     )
     return 0

--- a/tests/tenkz/release-harness/tex_api_package_version.py
+++ b/tests/tenkz/release-harness/tex_api_package_version.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from harnesslib import assert_that, read  # noqa: E402
+from harnesslib import assert_that, read, selected_assertion  # noqa: E402
 
 
 SUBJECT = "tex/tenkz/tenkz.sty"
@@ -67,11 +67,8 @@ ASSERTIONS = {
 
 
 def main() -> int:
-    mode = sys.argv[1] if len(sys.argv) > 1 else ""
-    if mode not in ASSERTIONS:
-        print(f"unknown assertion {mode!r}", file=sys.stderr)
-        return 2
-    test_id, fingerprint = ASSERTIONS[mode]
+    mode = sys.argv[1]
+    test_id, fingerprint = selected_assertion(ASSERTIONS)
     declarations = DECLARATION.findall(read(SUBJECT))
 
     if mode == "cardinality":

--- a/tests/tenkz/release-harness/tnlog_declared_kinds.py
+++ b/tests/tenkz/release-harness/tnlog_declared_kinds.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""The declared reader table and the reader's own table are the same set.
+
+`TNLOG.md` is the event-format declaration named by `DESIGN.md`'s
+`release_event_format`, and a declaration that has drifted from the reader is
+worse than none: it tells a consumer that a kind is part of the surface when
+the canonical reader has no schema for it, or hides a kind the reader knows.
+The declaration's `tenkz-event-kinds-v1` block carries the set; this assertion
+holds it equal to `FIELD_VALIDATORS`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from harnesslib import assert_that, read  # noqa: E402
+
+
+TEST_ID = "tnlog-declared-kinds-match-the-reader"
+FINGERPRINT = "bae39735591cfdbdf20376e84041aec4d57f7c5b004e5addce6f5a3fa24e5cf3"
+SUBJECT = "scripts/tenkzlib/tnlog.py"
+DECLARATION = "docs/tenkz/TNLOG.md"
+BLOCK = re.compile(
+    r"^```toml[ \t]+tenkz-event-kinds-v1[ \t]*\n(.*?)^```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def load_reader():
+    spec = importlib.util.spec_from_file_location("tenkz_release_tnlog", SUBJECT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def declared_kinds() -> list[str] | None:
+    blocks = BLOCK.findall(read(DECLARATION))
+    if len(blocks) != 1:
+        return None
+    table = tomllib.loads(blocks[0])
+    if table.get("schema") != 1:
+        return None
+    return sorted(table.get("reader_table", []))
+
+
+def main() -> int:
+    declared = declared_kinds()
+    tabled = sorted(load_reader().FIELD_VALIDATORS)
+    assert_that(
+        declared == tabled,
+        test_id=TEST_ID,
+        failure_fingerprint=FINGERPRINT,
+        reason=(
+            f"{DECLARATION} declares reader kinds {declared!r} while {SUBJECT} "
+            f"tables {tabled!r}"
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tenkz/release-harness/tnlog_declared_kinds.py
+++ b/tests/tenkz/release-harness/tnlog_declared_kinds.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""The declared reader table and the reader's own table are the same set.
+"""The event-kind declaration, as two independent assertions.
 
 `TNLOG.md` is the event-format declaration named by `DESIGN.md`'s
 `release_event_format`, and a declaration that has drifted from the reader is
@@ -21,8 +21,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from harnesslib import assert_that, load_module, read  # noqa: E402
 
 
-TEST_ID = "tnlog-declared-kinds-match-the-reader"
-FINGERPRINT = "bae39735591cfdbdf20376e84041aec4d57f7c5b004e5addce6f5a3fa24e5cf3"
+ASSERTIONS = {
+    "declaration": (
+        "tnlog-declaration-block-parses",
+        "db1f1014a9d1791c035590e01900c4ed4a1780de55ebc893ac69a748904dcf64",
+    ),
+    "kinds": (
+        "tnlog-declared-kinds-match-the-reader",
+        "bae39735591cfdbdf20376e84041aec4d57f7c5b004e5addce6f5a3fa24e5cf3",
+    ),
+}
 SUBJECT = "scripts/tenkzlib/tnlog.py"
 DECLARATION = "docs/tenkz/TNLOG.md"
 BLOCK = re.compile(
@@ -31,25 +39,52 @@ BLOCK = re.compile(
 )
 
 
+def parsed_block() -> tuple[dict | None, str]:
+    """The declaration's kind block, or None with the reason it did not parse."""
 
-
-def declared_kinds() -> list[str] | None:
     blocks = BLOCK.findall(read(DECLARATION))
     if len(blocks) != 1:
-        return None
-    table = tomllib.loads(blocks[0])
+        return None, f"{DECLARATION} carries {len(blocks)} kind blocks, not exactly one"
+    try:
+        table = tomllib.loads(blocks[0])
+    except tomllib.TOMLDecodeError as error:
+        return None, f"{DECLARATION} kind block is not valid TOML: {error}"
     if table.get("schema") != 1:
-        return None
-    return sorted(table.get("reader_table", []))
+        return None, f"{DECLARATION} kind block declares schema {table.get('schema')!r}"
+    if not isinstance(table.get("reader_table"), list):
+        return None, f"{DECLARATION} kind block has no reader_table list"
+    return table, ""
 
 
 def main() -> int:
-    declared = declared_kinds()
+    mode = sys.argv[1] if len(sys.argv) > 1 else ""
+    if mode not in ASSERTIONS:
+        print(f"unknown assertion {mode!r}", file=sys.stderr)
+        return 2
+    test_id, fingerprint = ASSERTIONS[mode]
+    table, reason = parsed_block()
+
+    if mode == "declaration":
+        assert_that(
+            table is not None,
+            test_id=test_id,
+            failure_fingerprint=fingerprint,
+            reason=reason,
+        )
+        return 0
+
+    # The declaration assertion owns the parse; this one owns the kind set. A
+    # block that does not parse cannot be compared, and saying so is not the
+    # same failure as a set that genuinely differs.
+    if table is None:
+        print(f"skipping: {reason}", file=sys.stderr)
+        return 2
+    declared = sorted(table["reader_table"])
     tabled = sorted(load_module(SUBJECT).FIELD_VALIDATORS)
     assert_that(
         declared == tabled,
-        test_id=TEST_ID,
-        failure_fingerprint=FINGERPRINT,
+        test_id=test_id,
+        failure_fingerprint=fingerprint,
         reason=(
             f"{DECLARATION} declares reader kinds {declared!r} while {SUBJECT} "
             f"tables {tabled!r}"

--- a/tests/tenkz/release-harness/tnlog_declared_kinds.py
+++ b/tests/tenkz/release-harness/tnlog_declared_kinds.py
@@ -49,8 +49,9 @@ def parsed_block() -> tuple[dict | None, str]:
         table = tomllib.loads(blocks[0])
     except tomllib.TOMLDecodeError as error:
         return None, f"{DECLARATION} kind block is not valid TOML: {error}"
-    if table.get("schema") != 1:
-        return None, f"{DECLARATION} kind block declares schema {table.get('schema')!r}"
+    schema = table.get("schema")
+    if not isinstance(schema, int) or isinstance(schema, bool) or schema != 1:
+        return None, f"{DECLARATION} kind block declares schema {schema!r}, not the integer 1"
     if not isinstance(table.get("reader_table"), list):
         return None, f"{DECLARATION} kind block has no reader_table list"
     return table, ""

--- a/tests/tenkz/release-harness/tnlog_declared_kinds.py
+++ b/tests/tenkz/release-harness/tnlog_declared_kinds.py
@@ -11,7 +11,6 @@ holds it equal to `FIELD_VALIDATORS`.
 
 from __future__ import annotations
 
-import importlib.util
 import re
 import sys
 import tomllib
@@ -19,7 +18,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from harnesslib import assert_that, read  # noqa: E402
+from harnesslib import assert_that, load_module, read  # noqa: E402
 
 
 TEST_ID = "tnlog-declared-kinds-match-the-reader"
@@ -32,12 +31,6 @@ BLOCK = re.compile(
 )
 
 
-def load_reader():
-    spec = importlib.util.spec_from_file_location("tenkz_release_tnlog", SUBJECT)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
 
 
 def declared_kinds() -> list[str] | None:
@@ -52,7 +45,7 @@ def declared_kinds() -> list[str] | None:
 
 def main() -> int:
     declared = declared_kinds()
-    tabled = sorted(load_reader().FIELD_VALIDATORS)
+    tabled = sorted(load_module(SUBJECT).FIELD_VALIDATORS)
     assert_that(
         declared == tabled,
         test_id=TEST_ID,

--- a/tests/tenkz/release-harness/tnlog_declared_kinds.py
+++ b/tests/tenkz/release-harness/tnlog_declared_kinds.py
@@ -18,7 +18,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from harnesslib import assert_that, load_module, read  # noqa: E402
+from harnesslib import (  # noqa: E402
+    assert_that,
+    load_module,
+    read,
+    selected_assertion,
+)
 
 
 ASSERTIONS = {
@@ -58,11 +63,8 @@ def parsed_block() -> tuple[dict | None, str]:
 
 
 def main() -> int:
-    mode = sys.argv[1] if len(sys.argv) > 1 else ""
-    if mode not in ASSERTIONS:
-        print(f"unknown assertion {mode!r}", file=sys.stderr)
-        return 2
-    test_id, fingerprint = ASSERTIONS[mode]
+    mode = sys.argv[1]
+    test_id, fingerprint = selected_assertion(ASSERTIONS)
     table, reason = parsed_block()
 
     if mode == "declaration":

--- a/tests/tenkz/release-harness/tnlog_unknown_field.py
+++ b/tests/tenkz/release-harness/tnlog_unknown_field.py
@@ -11,13 +11,12 @@ field would turn every such addition into a breaking change.
 
 from __future__ import annotations
 
-import importlib.util
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from harnesslib import assert_that  # noqa: E402
+from harnesslib import assert_that, load_module  # noqa: E402
 
 
 TEST_ID = "tnlog-reader-ignores-unknown-fields"
@@ -30,18 +29,10 @@ STREAM = [
 ]
 
 
-def load_reader():
-    """Load the pinned reader from its declared program path, nothing else."""
-
-    spec = importlib.util.spec_from_file_location("tenkz_release_tnlog", SUBJECT)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
 
 
 def main() -> int:
-    reader = load_reader()
+    reader = load_module(SUBJECT)
     findings: list[str] = []
     parsed = reader.parse_log(
         "\n".join(STREAM) + "\n",

--- a/tests/tenkz/release-harness/tnlog_unknown_field.py
+++ b/tests/tenkz/release-harness/tnlog_unknown_field.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""The reader ignores an unknown optional field.
+
+`DESIGN.md` `[event_format]`: `unknown_optional_fields = "ignore"`. This is the
+rule that lets a minor release add a field to an existing event kind without
+breaking a reader built against the previous minor. `TNLOG.md` §6 records that
+the reader implements it by permissiveness rather than by a declared
+optional-field set; either way, a reader that started rejecting an untabled
+field would turn every such addition into a breaking change.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from harnesslib import assert_that  # noqa: E402
+
+
+TEST_ID = "tnlog-reader-ignores-unknown-fields"
+FINGERPRINT = "4312555019ae1123120a0e29328272a20f876568c2f6d12a470cf3e5aea6648f"
+SUBJECT = "scripts/tenkzlib/tnlog.py"
+STREAM = [
+    "picture|id=k1|lang=kernel|later-minor-field=value",
+    "atom|id=atom-1|addr=(1,1)|kind=tn|another-later-field=value",
+    "kernel-boundary|signature=open:w",
+]
+
+
+def load_reader():
+    """Load the pinned reader from its declared program path, nothing else."""
+
+    spec = importlib.util.spec_from_file_location("tenkz_release_tnlog", SUBJECT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    reader = load_reader()
+    findings: list[str] = []
+    parsed = reader.parse_log(
+        "\n".join(STREAM) + "\n",
+        hard=lambda rule, where, message: findings.append(f"{rule}: {message}"),
+    )
+    invalid = [event.kind for event in parsed.events if not event.valid]
+    assert_that(
+        not findings and not invalid and len(parsed.valid_events) == len(STREAM),
+        test_id=TEST_ID,
+        failure_fingerprint=FINGERPRINT,
+        reason=(
+            f"{SUBJECT} rejected a stream carrying only untabled extra fields: "
+            f"findings={findings!r}, invalid kinds={invalid!r}"
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tenkz/release-support/README.md
+++ b/tests/tenkz/release-support/README.md
@@ -31,10 +31,17 @@ only in the `tenkz-release-publisher` environment secret named by
 reviewed change:
 
 ```bash
-ssh-keygen -t ed25519 -C tenkz-v1.0.0 -f tenkz-final-tag
+ssh-keygen -t ed25519 -N '' -C tenkz-v1.0.0 -f tenkz-final-tag
 # tenkz-final-tag.pub -> tests/tenkz/release-support/final-tag-signing-key.pub
 # tenkz-final-tag     -> the TENKZ_FINAL_TAG_SIGNING_KEY environment secret
 ```
+
+`-N ''` is not optional. Without it `ssh-keygen` prompts for a passphrase, and
+a maintainer who supplies one stores an encrypted private key in the secret.
+The publisher runs one closed noninteractive command and has no passphrase
+input of any kind, so it would then be unable to sign and the campaign would
+stall at `signed-off-awaiting-tag` with nothing pointing at the key as the
+cause.
 
 The same change fixes the two byte constants the tag-object schema currently
 leaves open, `tagger_name` and `tagger_email`, and adds the publisher job to

--- a/tests/tenkz/release-support/README.md
+++ b/tests/tenkz/release-support/README.md
@@ -1,0 +1,43 @@
+# Release-test support tree
+
+Immutable acceptance data for the 1.0 release campaign. `docs/tenkz/SOAK-1.0.md`
+§Release payload evidence separates the two pinned trees: runner code and every
+imported or sourced helper live in `tests/tenkz/release-harness/`, while
+expected outputs, baselines, allowlists, thresholds, and schemas live here.
+Neither tree may be supplied by a subject under test, and nothing here is
+executable.
+
+The activation change pins this tree by its exact Git tree OID. Every byte in
+it must therefore be final before that change opens; afterwards a correction
+means a new campaign attempt.
+
+| File | Role |
+|---|---|
+| `final-tag-object-v1.schema.json` | the closed description of the one annotated `tenkz-v1.0.0` object the publisher may construct |
+| `reset-replay-v1.schema.json` | the closed shape of a `record-invalid` reset's replay receipt under `docs/tenkz/soak-replay/` |
+| `selftest-expectations.toml` | the supervisor self-test suite: one row per isolation probe and the outcome the supervisor must report |
+| `tool-profile.toml` | the child tools an inventory command may reach, and the version fingerprint each must report |
+
+## The final-tag signing key is not here
+
+`DESIGN.md` names `tests/tenkz/release-support/final-tag-signing-key.pub` as the
+public half of the SSH-Ed25519 key that signs the release tag. It is absent,
+and deliberately so: a public key whose private half nobody holds is worse than
+no key, because every check downstream of it would pass while signing nothing.
+
+Before activation the maintainer generates the pair, keeps the private half
+only in the `tenkz-release-publisher` environment secret named by
+`release_publisher_secret`, and lands the public half here in an ordinary
+reviewed change:
+
+```bash
+ssh-keygen -t ed25519 -C tenkz-v1.0.0 -f tenkz-final-tag
+# tenkz-final-tag.pub -> tests/tenkz/release-support/final-tag-signing-key.pub
+# tenkz-final-tag     -> the TENKZ_FINAL_TAG_SIGNING_KEY environment secret
+```
+
+The same change fixes the two byte constants the tag-object schema currently
+leaves open, `tagger_name` and `tagger_email`, and adds the publisher job to
+`.github/workflows/tenkz-release-policy.yml`. Until it lands,
+`supervisor.py check-readiness` reports the key as absent, and it refuses any
+policy that claims `armed` without it.

--- a/tests/tenkz/release-support/final-tag-object-v1.schema.json
+++ b/tests/tenkz/release-support/final-tag-object-v1.schema.json
@@ -67,13 +67,13 @@
       "description": "The tag message. Its template is fixed; the four substitutions bind the release name, the integration it peels to, the armed policy hash, and the validated ledger prefix.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["template", "release_tag", "integration", "policy_sha256", "prefix_sha256"],
+      "required": ["template", "release_tag", "policy_sha256", "prefix_sha256"],
       "properties": {
         "template": {
-          "const": "tenkz {release_tag}\n\nintegration {integration}\npolicy {policy_sha256}\nprefix {prefix_sha256}\n"
+          "description": "The message template. `{integration}` is substituted from the object's own `object` header, not from a separate field: a schema cannot compare two of its properties, so carrying the integration twice would let a signed object authenticate two conflicting identities.",
+          "const": "tenkz {release_tag}\n\nintegration {object}\npolicy {policy_sha256}\nprefix {prefix_sha256}\n"
         },
         "release_tag": { "const": "tenkz-v1.0.0" },
-        "integration": { "$ref": "#/$defs/gitOid" },
         "policy_sha256": {
           "description": "SHA-256 of the armed docs/tenkz/DESIGN.md blob, as pinned by the ledger's policy_sha256.",
           "$ref": "#/$defs/sha256"

--- a/tests/tenkz/release-support/final-tag-object-v1.schema.json
+++ b/tests/tenkz/release-support/final-tag-object-v1.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "tenkz/release-support/final-tag-object-v1",
+  "title": "tenkz final tag object, version 1",
+  "description": "The closed description of the one annotated tag object the publisher may construct for tenkz-v1.0.0. docs/tenkz/SOAK-1.0.md is the authority. Every value the publisher does not derive from its closed needs tuple is a constant here, so two runs of the publisher on the same tuple produce the same bytes and the same object ID. A retry authenticates that object; it never invents a second one.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "object_format",
+    "header_order",
+    "object",
+    "type",
+    "tag",
+    "tagger_name",
+    "tagger_email",
+    "tagger_epoch_seconds",
+    "tagger_timezone",
+    "message",
+    "signature"
+  ],
+  "properties": {
+    "schema": {
+      "description": "Object schema version. A later tag layout gets a new schema blob in the pinned support tree.",
+      "const": 1
+    },
+    "object_format": {
+      "description": "The repository object-format hash. The object ID the publisher recomputes before its first write is this hash of the completed object bytes.",
+      "const": "sha1"
+    },
+    "header_order": {
+      "description": "The exact header lines, in order, before the blank line that opens the message. No other header may appear.",
+      "const": ["object", "type", "tag", "tagger"]
+    },
+    "object": {
+      "description": "The sign-off integration commit I. The tag peels to exactly this commit.",
+      "$ref": "#/$defs/gitOid"
+    },
+    "type": {
+      "description": "The tagged object type.",
+      "const": "commit"
+    },
+    "tag": {
+      "description": "The tag name. This campaign publishes one name only.",
+      "const": "tenkz-v1.0.0"
+    },
+    "tagger_name": {
+      "description": "The tagger's literal name bytes. Fixed by the pre-activation change that adds final-tag-signing-key.pub; see the note in this tree's README.md. Until that change lands the byte constant is unset and no publisher job may run.",
+      "type": "string",
+      "minLength": 1
+    },
+    "tagger_email": {
+      "description": "The tagger's literal address bytes, written without the surrounding angle brackets. Fixed by the same pre-activation change as tagger_name.",
+      "type": "string",
+      "minLength": 1
+    },
+    "tagger_epoch_seconds": {
+      "description": "The sign-off pull request's mergedAt converted once to an integer Unix second. The publisher takes this from its closed needs tuple and never from the clock.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "tagger_timezone": {
+      "description": "The tagger timezone bytes. Fixed so that the same instant cannot be spelled two ways.",
+      "const": "+0000"
+    },
+    "message": {
+      "description": "The tag message. Its template is fixed; the four substitutions bind the release name, the integration it peels to, the armed policy hash, and the validated ledger prefix.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["template", "release_tag", "integration", "policy_sha256", "prefix_sha256"],
+      "properties": {
+        "template": {
+          "const": "tenkz {release_tag}\n\nintegration {integration}\npolicy {policy_sha256}\nprefix {prefix_sha256}\n"
+        },
+        "release_tag": { "const": "tenkz-v1.0.0" },
+        "integration": { "$ref": "#/$defs/gitOid" },
+        "policy_sha256": {
+          "description": "SHA-256 of the armed docs/tenkz/DESIGN.md blob, as pinned by the ledger's policy_sha256.",
+          "$ref": "#/$defs/sha256"
+        },
+        "prefix_sha256": {
+          "description": "SHA-256 of the raw docs/tenkz/SOAK-1.0.md bytes of the validated ledger prefix.",
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "signature": {
+      "description": "The Git SSH signature embedded in the tag object after the message.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "namespace", "public_key", "embedding"],
+      "properties": {
+        "algorithm": { "const": "ssh-ed25519" },
+        "namespace": {
+          "description": "The SSH signature namespace Git uses for object signatures.",
+          "const": "git"
+        },
+        "public_key": {
+          "description": "Repository-relative path of the pinned public key the signature is verified against. The private half lives only in the release publisher environment secret and is retired after the publishing job succeeds.",
+          "const": "tests/tenkz/release-support/final-tag-signing-key.pub"
+        },
+        "embedding": {
+          "description": "How the armoured signature joins the object: appended to the message with no separating blank line, each line ending in a single newline, the whole block terminated by a newline.",
+          "const": "ssh-signature-appended-to-message"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "gitOid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/tests/tenkz/release-support/reset-replay-v1.schema.json
+++ b/tests/tenkz/release-support/reset-replay-v1.schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "tenkz/release-support/reset-replay-v1",
+  "title": "tenkz record-invalid reset replay receipt, version 1",
+  "description": "The closed JSON object at docs/tenkz/soak-replay/NUMBER.json that proves one record-invalid reset's historical placement against its pre-reset ledger prefix. docs/tenkz/SOAK-1.0.md is the authority; this schema is the machine form of the field list stated there. Unknown or missing data fails closed, so every property is required and no additional property is accepted at any level.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "reset_entry_id",
+    "target_entry_id",
+    "pre_reset_boundary_entry_id",
+    "validation_target_commit",
+    "invalid_queue",
+    "pending_restart_target",
+    "resolver_inputs",
+    "workflow_dependency_closure",
+    "supervisor_receipts"
+  ],
+  "properties": {
+    "schema": {
+      "description": "Receipt schema version. One value only; a later shape gets a new schema blob in the pinned support tree.",
+      "const": 1
+    },
+    "reset_entry_id": {
+      "description": "The ledger entry ID of the record-invalid reset this receipt supports.",
+      "$ref": "#/$defs/entryId"
+    },
+    "target_entry_id": {
+      "description": "The ledger entry ID the reset acknowledges as externally invalid.",
+      "$ref": "#/$defs/entryId"
+    },
+    "pre_reset_boundary_entry_id": {
+      "description": "The final live entry of the exact ledger prefix as it stood immediately before the reset. Null when the reset opens on an empty prefix.",
+      "oneOf": [{ "$ref": "#/$defs/entryId" }, { "type": "null" }]
+    },
+    "validation_target_commit": {
+      "description": "The exact commit OID whose snapshot produced this receipt.",
+      "$ref": "#/$defs/gitOid"
+    },
+    "invalid_queue": {
+      "description": "The raw invalid-entry queue in ledger order, as the resolver derived it at the validation target. Order is evidence: it fixes which entry heads the queue.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/entryId" }
+    },
+    "pending_restart_target": {
+      "description": "The entry named by a pending restart-required reset, which takes queue priority, or null when no restart is pending.",
+      "oneOf": [{ "$ref": "#/$defs/entryId" }, { "type": "null" }]
+    },
+    "resolver_inputs": {
+      "description": "The complete normalized external facts the resolver read. Every fact the queue depends on appears here; a fact absent from this object cannot be replayed and therefore cannot support the reset.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pull_requests", "issues", "tags", "reviews"],
+      "properties": {
+        "pull_requests": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pullRequestFact" }
+        },
+        "issues": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/issueFact" }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/tagFact" }
+        },
+        "reviews": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/reviewFact" }
+        }
+      }
+    },
+    "workflow_dependency_closure": {
+      "description": "The content-addressed closure of the enforcement workflow at the validation target: every local object by Git OID, every external action or called workflow by full commit SHA, every container by content digest.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["reference", "kind", "digest"],
+        "properties": {
+          "reference": { "type": "string", "minLength": 1 },
+          "kind": {
+            "enum": ["blob", "tree", "action", "reusable-workflow", "container"]
+          },
+          "digest": { "$ref": "#/$defs/contentDigest" }
+        }
+      }
+    },
+    "supervisor_receipts": {
+      "description": "The per-command payload receipts the evidence supervisor emitted while producing this replay, one per inventory test it ran. They are independent of the resolver facts above: together the two channels fix both what the ledger said and what the pinned tests observed.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/supervisorReceipt" }
+    }
+  },
+  "$defs": {
+    "entryId": {
+      "type": "string",
+      "pattern": "^S1-[0-9]{4}$"
+    },
+    "gitOid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "contentDigest": {
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{40}|sha256:[0-9a-f]{64})$"
+    },
+    "prRef": {
+      "type": "string",
+      "pattern": "^#[1-9][0-9]*$"
+    },
+    "login": {
+      "type": "string",
+      "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$"
+    },
+    "utcInstant": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+    },
+    "pullRequestFact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pr",
+        "base_ref_name",
+        "author_login",
+        "head_oid",
+        "merged",
+        "merged_at",
+        "merged_by_login",
+        "merge_commit_oid"
+      ],
+      "properties": {
+        "pr": { "$ref": "#/$defs/prRef" },
+        "base_ref_name": { "type": "string", "minLength": 1 },
+        "author_login": { "$ref": "#/$defs/login" },
+        "head_oid": { "$ref": "#/$defs/gitOid" },
+        "merged": { "type": "boolean" },
+        "merged_at": {
+          "oneOf": [{ "$ref": "#/$defs/utcInstant" }, { "type": "null" }]
+        },
+        "merged_by_login": {
+          "oneOf": [{ "$ref": "#/$defs/login" }, { "type": "null" }]
+        },
+        "merge_commit_oid": {
+          "oneOf": [{ "$ref": "#/$defs/gitOid" }, { "type": "null" }]
+        }
+      }
+    },
+    "issueFact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issue", "state", "closed_at"],
+      "properties": {
+        "issue": { "$ref": "#/$defs/prRef" },
+        "state": { "enum": ["OPEN", "CLOSED"] },
+        "closed_at": {
+          "oneOf": [{ "$ref": "#/$defs/utcInstant" }, { "type": "null" }]
+        }
+      }
+    },
+    "tagFact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "object_id", "kind", "peeled_commit"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "object_id": { "$ref": "#/$defs/gitOid" },
+        "kind": { "enum": ["annotated", "lightweight"] },
+        "peeled_commit": { "$ref": "#/$defs/gitOid" }
+      }
+    },
+    "reviewFact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pr",
+        "login",
+        "state",
+        "submitted_at",
+        "commit_oid",
+        "dismissed",
+        "repository_top_level_permission"
+      ],
+      "properties": {
+        "pr": { "$ref": "#/$defs/prRef" },
+        "login": { "$ref": "#/$defs/login" },
+        "state": {
+          "enum": ["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED", "PENDING"]
+        },
+        "submitted_at": { "$ref": "#/$defs/utcInstant" },
+        "commit_oid": { "$ref": "#/$defs/gitOid" },
+        "dismissed": { "type": "boolean" },
+        "repository_top_level_permission": {
+          "enum": ["read", "triage", "write", "maintain", "admin"]
+        }
+      }
+    },
+    "supervisorReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "test_id",
+        "surface",
+        "code_tree",
+        "support_tree",
+        "inventory_sha256",
+        "command",
+        "program_paths",
+        "fixture_paths",
+        "exit_status",
+        "assertion_result",
+        "timed_out",
+        "output_mount",
+        "tool_fingerprints"
+      ],
+      "properties": {
+        "test_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "surface": { "enum": ["tex-api", "tnlog"] },
+        "code_tree": { "$ref": "#/$defs/gitOid" },
+        "support_tree": { "$ref": "#/$defs/gitOid" },
+        "inventory_sha256": { "$ref": "#/$defs/sha256" },
+        "command": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "program_paths": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "fixture_paths": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "exit_status": { "type": "integer" },
+        "assertion_result": { "enum": ["passed", "assertion-failed"] },
+        "timed_out": { "type": "boolean" },
+        "output_mount": { "type": "string", "minLength": 1 },
+        "tool_fingerprints": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/tests/tenkz/release-support/reset-replay-v1.schema.json
+++ b/tests/tenkz/release-support/reset-replay-v1.schema.json
@@ -53,7 +53,15 @@
       "description": "The complete normalized external facts the resolver read. Every fact the queue depends on appears here; a fact absent from this object cannot be replayed and therefore cannot support the reset.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["pull_requests", "issues", "tags", "reviews"],
+      "required": [
+        "pull_requests",
+        "issues",
+        "tags",
+        "reviews",
+        "workflow_runs",
+        "tag_protection",
+        "secret_locations"
+      ],
       "properties": {
         "pull_requests": {
           "type": "array",
@@ -70,6 +78,39 @@
         "reviews": {
           "type": "array",
           "items": { "$ref": "#/$defs/reviewFact" }
+        },
+        "workflow_runs": {
+          "description": "Every enforcement or publisher run the validator read, each bound to the exact pinned workflow blob and head it ran against. A reset caused by a run's conclusion cannot be replayed without it.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/workflowRunFact" }
+        },
+        "tag_protection": {
+          "description": "The unredacted tenkz-v* ruleset state at the snapshot. Redacted or missing detail fails closed, so the receipt records what was visible rather than what was assumed.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["namespace", "update_allowed", "delete_allowed", "bypass_actors"],
+          "properties": {
+            "namespace": { "const": "tenkz-v*" },
+            "update_allowed": { "type": "boolean" },
+            "delete_allowed": { "type": "boolean" },
+            "bypass_actors": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "secret_locations": {
+          "description": "Where the publisher signing secret was configured at the snapshot, by name and scope only; a value is never read. Key retirement is decided from this list being empty, so a reset turning on retirement needs it recorded.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "scope"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "scope": { "enum": ["repository", "organization", "environment"] }
+            }
+          }
         }
       }
     },
@@ -88,7 +129,30 @@
             "enum": ["blob", "tree", "action", "reusable-workflow", "container"]
           },
           "digest": { "$ref": "#/$defs/contentDigest" }
-        }
+        },
+        "allOf": [
+          {
+            "$comment": "A repository object, an action, and a called workflow are pinned by full Git commit or object ID; only a container carries a registry content digest. Leaving the union unconstrained would accept a container pinned by a bare Git OID, or an action pinned by a sha256 digest — both of which are exactly the mutable-resolution mistake the closure exists to prevent.",
+            "if": {
+              "properties": {
+                "kind": { "enum": ["blob", "tree", "action", "reusable-workflow"] }
+              },
+              "required": ["kind"]
+            },
+            "then": { "properties": { "digest": { "$ref": "#/$defs/gitOid" } } }
+          },
+          {
+            "if": {
+              "properties": { "kind": { "const": "container" } },
+              "required": ["kind"]
+            },
+            "then": {
+              "properties": {
+                "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+              }
+            }
+          }
+        ]
       }
     },
     "supervisor_receipts": {
@@ -178,6 +242,33 @@
         "object_id": { "$ref": "#/$defs/gitOid" },
         "kind": { "enum": ["annotated", "lightweight"] },
         "peeled_commit": { "$ref": "#/$defs/gitOid" }
+      }
+    },
+    "workflowRunFact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workflow_path",
+        "workflow_blob",
+        "head_oid",
+        "job_name",
+        "conclusion",
+        "completed_at"
+      ],
+      "properties": {
+        "workflow_path": { "type": "string", "minLength": 1 },
+        "workflow_blob": {
+          "description": "The exact pinned workflow blob the run executed, so a later edit cannot be mistaken for the run's own bytes.",
+          "$ref": "#/$defs/gitOid"
+        },
+        "head_oid": { "$ref": "#/$defs/gitOid" },
+        "job_name": { "type": "string", "minLength": 1 },
+        "conclusion": {
+          "enum": ["success", "failure", "cancelled", "skipped", "timed_out", "not-run"]
+        },
+        "completed_at": {
+          "oneOf": [{ "$ref": "#/$defs/utcInstant" }, { "type": "null" }]
+        }
       }
     },
     "reviewFact": {

--- a/tests/tenkz/release-support/reset-replay-v1.schema.json
+++ b/tests/tenkz/release-support/reset-replay-v1.schema.json
@@ -400,13 +400,33 @@
         },
         "exit_status": { "type": "integer" },
         "assertion_result": { "enum": ["passed", "assertion-failed"] },
-        "timed_out": { "type": "boolean" },
+        "timed_out": {
+          "description": "Always false in a receipt. A timeout fails closed and emits no payload receipt at all, so `true` here describes a run the supervisor cannot have produced.",
+          "const": false
+        },
         "output_mount": { "type": "string", "minLength": 1 },
         "tool_fingerprints": {
           "type": "object",
           "additionalProperties": { "type": "string", "minLength": 1 }
         }
-      }
+      },
+      "allOf": [
+        {
+          "$comment": "The supervisor emits exactly two outcome tuples: a pass exits zero, an assertion failure exits ten. Validating the fields independently would admit `passed` with exit 10, which is not a run that happened but a claim no evidence supports.",
+          "if": {
+            "properties": { "assertion_result": { "const": "passed" } },
+            "required": ["assertion_result"]
+          },
+          "then": { "properties": { "exit_status": { "const": 0 } } }
+        },
+        {
+          "if": {
+            "properties": { "assertion_result": { "const": "assertion-failed" } },
+            "required": ["assertion_result"]
+          },
+          "then": { "properties": { "exit_status": { "const": 10 } } }
+        }
+      ]
     }
   }
 }

--- a/tests/tenkz/release-support/reset-replay-v1.schema.json
+++ b/tests/tenkz/release-support/reset-replay-v1.schema.json
@@ -309,6 +309,7 @@
         "command",
         "program_paths",
         "fixture_paths",
+        "undeclared_artifacts_withheld",
         "exit_status",
         "assertion_result",
         "timed_out",
@@ -336,6 +337,12 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "fixture_paths": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "undeclared_artifacts_withheld": {
+          "description": "The canonical release artifacts this command did not declare in either role, and which the supervisor therefore kept out of its view. Recording them makes the exclusion auditable: a receipt that names none is claiming the command declared all four.",
           "type": "array",
           "uniqueItems": true,
           "items": { "type": "string", "minLength": 1 }

--- a/tests/tenkz/release-support/reset-replay-v1.schema.json
+++ b/tests/tenkz/release-support/reset-replay-v1.schema.json
@@ -64,8 +64,10 @@
       ],
       "properties": {
         "pull_requests": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/pullRequestFact" }
+          "description": "Keyed by pull-request reference, because a reference has one set of facts. An array admits two entries for the same pull request with conflicting merge or integration predicates, and those predicates decide queue membership, so two replay implementations could derive different queues from one receipt.",
+          "type": "object",
+          "propertyNames": { "pattern": "^#[1-9][0-9]*$" },
+          "additionalProperties": { "$ref": "#/$defs/pullRequestFact" }
         },
         "issues": {
           "type": "array",
@@ -208,7 +210,6 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "pr",
         "in_repository",
         "base_ref_name",
         "author_login",
@@ -222,9 +223,11 @@
         "integration_strict_descendant_of_anchor"
       ],
       "properties": {
-        "pr": { "$ref": "#/$defs/prRef" },
         "base_ref_name": { "type": "string", "minLength": 1 },
-        "author_login": { "$ref": "#/$defs/login" },
+        "author_login": {
+          "description": "Null when GitHub no longer supplies an author, as after account deletion. The policy checker treats a missing login as a record-invalid error, so the receipt must be able to record the absence: a schema that forbade null would make the reset that absence causes unrepresentable.",
+          "oneOf": [{ "$ref": "#/$defs/login" }, { "type": "null" }]
+        },
         "head_oid": { "$ref": "#/$defs/gitOid" },
         "merged": { "type": "boolean" },
         "merged_at": {

--- a/tests/tenkz/release-support/reset-replay-v1.schema.json
+++ b/tests/tenkz/release-support/reset-replay-v1.schema.json
@@ -108,8 +108,19 @@
             "required": ["name", "scope"],
             "properties": {
               "name": { "type": "string", "minLength": 1 },
-              "scope": { "enum": ["repository", "organization", "environment"] }
-            }
+              "scope": { "enum": ["repository", "organization", "environment"] },
+              "environment": {
+                "description": "The environment holding the secret. Required when `scope` is `environment`, because the policy's invariant is not that the key exists in some environment but that it exists only in tenkz-release-publisher; without the name, the dedicated environment and an unauthorized second one are the same fact.",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "if": {
+              "properties": { "scope": { "const": "environment" } },
+              "required": ["scope"]
+            },
+            "then": { "required": ["environment"] },
+            "else": { "not": { "required": ["environment"] } }
           }
         }
       }
@@ -188,8 +199,10 @@
       "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$"
     },
     "utcInstant": {
+      "description": "An integral UTC instant. `format` carries full calendar validity for a validator that asserts formats; the pattern bounds every field so that a validator that does not still rejects 2026-99-99T99:99:99Z. The two together leave only impossible-but-well-ranged dates such as 02-30, which the resolver rejects when it parses the value.",
       "type": "string",
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:(?:[0-5][0-9]|60)Z$"
     },
     "pullRequestFact": {
       "type": "object",
@@ -303,6 +316,7 @@
       "required": [
         "test_id",
         "surface",
+        "tag",
         "code_tree",
         "support_tree",
         "inventory_sha256",
@@ -322,6 +336,13 @@
           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "surface": { "enum": ["tex-api", "tnlog"] },
+        "tag": {
+          "description": "The campaign tag this observation was bound to, or null for a standing run at a tree with no tag. A null value is evidence in its own right: it says the receipt cannot support a claim about any release.",
+          "oneOf": [
+            { "type": "string", "pattern": "^tenkz-v(?:0\\.9\\.(?:0|[1-9][0-9]*)|1\\.0\\.0)$" },
+            { "type": "null" }
+          ]
+        },
         "code_tree": { "$ref": "#/$defs/gitOid" },
         "support_tree": { "$ref": "#/$defs/gitOid" },
         "inventory_sha256": { "$ref": "#/$defs/sha256" },

--- a/tests/tenkz/release-support/reset-replay-v1.schema.json
+++ b/tests/tenkz/release-support/reset-replay-v1.schema.json
@@ -126,16 +126,15 @@
       }
     },
     "workflow_dependency_closure": {
-      "description": "The content-addressed closure of the enforcement workflow at the validation target: every local object by Git OID, every external action or called workflow by full commit SHA, every container by content digest.",
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
+      "description": "The content-addressed closure of the enforcement workflow at the validation target: every local object by Git OID, every external action or called workflow by full commit SHA, every container by content digest. Keyed by reference rather than listed, because a reference must have exactly one identity — an array with `uniqueItems` accepts the same reference twice with two digests, since the whole objects differ, and a closure that gives one dependency two identities is not content-addressed.",
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "minLength": 1 },
+      "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["reference", "kind", "digest"],
+        "required": ["kind", "digest"],
         "properties": {
-          "reference": { "type": "string", "minLength": 1 },
           "kind": {
             "enum": ["blob", "tree", "action", "reusable-workflow", "container"]
           },
@@ -205,17 +204,22 @@
       "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:(?:[0-5][0-9]|60)Z$"
     },
     "pullRequestFact": {
+      "description": "One pull request as the resolver normalized it. The provenance and integration predicates are part of the fact, not decoration: record validity turns on whether the pull request is in this repository, whether its integration is reachable from main, whether that integration's tree equals the approved head's tree, and whether it strictly descends from the anchor. Without them a receipt for an invalid record is indistinguishable from one for a valid record with the same metadata, and the replay cannot reproduce the queue it claims to preserve.",
       "type": "object",
       "additionalProperties": false,
       "required": [
         "pr",
+        "in_repository",
         "base_ref_name",
         "author_login",
         "head_oid",
         "merged",
         "merged_at",
         "merged_by_login",
-        "merge_commit_oid"
+        "merge_commit_oid",
+        "integration_reachable_from_main",
+        "integration_tree_matches_head",
+        "integration_strict_descendant_of_anchor"
       ],
       "properties": {
         "pr": { "$ref": "#/$defs/prRef" },
@@ -231,6 +235,19 @@
         },
         "merge_commit_oid": {
           "oneOf": [{ "$ref": "#/$defs/gitOid" }, { "type": "null" }]
+        },
+        "in_repository": {
+          "description": "Whether GitHub reports the pull request in this repository rather than a fork or another repository entirely.",
+          "type": "boolean"
+        },
+        "integration_reachable_from_main": {
+          "oneOf": [{ "type": "boolean" }, { "type": "null" }]
+        },
+        "integration_tree_matches_head": {
+          "oneOf": [{ "type": "boolean" }, { "type": "null" }]
+        },
+        "integration_strict_descendant_of_anchor": {
+          "oneOf": [{ "type": "boolean" }, { "type": "null" }]
         }
       }
     },
@@ -317,6 +334,8 @@
         "test_id",
         "surface",
         "tag",
+        "observed_commit",
+        "exposed_objects",
         "code_tree",
         "support_tree",
         "inventory_sha256",
@@ -336,6 +355,17 @@
           "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
         },
         "surface": { "enum": ["tex-api", "tnlog"] },
+        "observed_commit": {
+          "description": "The commit whose tree the command actually read. Two clean commits can hold the same harness pins and the same subject paths over different bytes, so the pins alone do not say which was observed.",
+          "$ref": "#/$defs/gitOid"
+        },
+        "exposed_objects": {
+          "description": "Every entry placed in the view, by repository path and Git object ID. These are the identities a replay compares; the path names alone are not evidence.",
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": { "minLength": 1 },
+          "additionalProperties": { "$ref": "#/$defs/gitOid" }
+        },
         "tag": {
           "description": "The campaign tag this observation was bound to, or null for a standing run at a tree with no tag. A null value is evidence in its own right: it says the receipt cannot support a claim about any release.",
           "oneOf": [

--- a/tests/tenkz/release-support/selftest-expectations.toml
+++ b/tests/tenkz/release-support/selftest-expectations.toml
@@ -1,0 +1,60 @@
+# Pinned expectations for the supervisor self-test.
+#
+# `docs/tenkz/SOAK-1.0.md` §Release payload evidence: activation runs a closed
+# supervisor self-test suite from the pinned support tree against pinned
+# synthetic fixtures, and a missing or mismatched receipt prevents arming.
+# These rows are that suite. Each drives one mode of
+# `tests/tenkz/release-harness/selftest_probe.py` through the supervisor and
+# fixes the outcome the supervisor must report.
+#
+# `outcome` is one of:
+#   passed            the command exited zero and wrote no receipt
+#   assertion-failed  the command exited ten with the exact closed receipt
+#   fails-closed      the supervisor refused the run; `message` must occur in
+#                     its diagnosis
+
+schema = 1
+synthetic_fingerprint = "5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e"
+
+[[probe]]
+id = "pass"
+outcome = "passed"
+timeout_seconds = 60
+
+[[probe]]
+id = "assertion"
+outcome = "assertion-failed"
+timeout_seconds = 60
+
+[[probe]]
+id = "unrelated-exit"
+outcome = "fails-closed"
+message = "exited 3, which is neither a pass nor an assertion failure"
+timeout_seconds = 60
+
+[[probe]]
+id = "exit-without-receipt"
+outcome = "fails-closed"
+message = "exited 10 without its receipt"
+timeout_seconds = 60
+
+[[probe]]
+id = "isolation"
+outcome = "passed"
+timeout_seconds = 60
+
+[[probe]]
+id = "environment"
+outcome = "passed"
+timeout_seconds = 60
+
+[[probe]]
+id = "readonly"
+outcome = "passed"
+timeout_seconds = 60
+
+[[probe]]
+id = "timeout"
+outcome = "fails-closed"
+message = "exceeded its 1s timeout"
+timeout_seconds = 1

--- a/tests/tenkz/release-support/selftest-expectations.toml
+++ b/tests/tenkz/release-support/selftest-expectations.toml
@@ -16,6 +16,30 @@
 schema = 1
 synthetic_fingerprint = "5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e"
 
+# The complete manifest of what a self-test command may see. The `isolation`
+# probe enumerates every regular file in its view and requires each one to lie
+# inside a pinned tree or be named here. Naming the whole view rather than a
+# sample matters: a regression that exposed `.github/` or another file under
+# `scripts/` would pass a sampled check that never thought to look there.
+#
+# `roots` are the two pinned trees, exposed to every command in full. `files`
+# are the inventory blob and the four canonical release artifacts, plus the
+# probe's own declared program and fixture paths — `tex/tenkz/tenkz.sty` is
+# both a canonical artifact and the probe's subject.
+
+[view]
+roots = [
+  "tests/tenkz/release-harness",
+  "tests/tenkz/release-support",
+]
+files = [
+  "tests/tenkz/release-tests.toml",
+  "tex/tenkz/tenkz.sty",
+  "docs/tenkz/manual2.tex",
+  "docs/tenkz/CHANGES.md",
+  "docs/tenkz/TNLOG.md",
+]
+
 [[probe]]
 id = "pass"
 outcome = "passed"
@@ -55,6 +79,18 @@ timeout_seconds = 60
 
 [[probe]]
 id = "timeout"
+outcome = "fails-closed"
+message = "exceeded its 1s timeout"
+timeout_seconds = 1
+
+[[probe]]
+id = "bool-schema"
+outcome = "fails-closed"
+message = "receipt schema must be the integer 1"
+timeout_seconds = 60
+
+[[probe]]
+id = "orphan-timeout"
 outcome = "fails-closed"
 message = "exceeded its 1s timeout"
 timeout_seconds = 1

--- a/tests/tenkz/release-support/selftest-expectations.toml
+++ b/tests/tenkz/release-support/selftest-expectations.toml
@@ -114,3 +114,27 @@ message = "rejected without following it"
 [[guard]]
 id = "special-entry"
 message = "neither a regular file nor a directory"
+
+# The armed enforcement workflow's requirements. `outcome = "accepted"` rows
+# matter as much as refusals: a check that rejected a legal `environment:`
+# spelling would refuse a correctly armed workflow and stall the campaign.
+
+[[guard]]
+id = "armed-workflow-comments"
+message = "has no job whose `environment:` is tenkz-release-publisher"
+
+[[guard]]
+id = "armed-workflow-foreign-needs"
+message = "lacks its own `needs:` dependency"
+
+[[guard]]
+id = "armed-workflow-mutable-action"
+message = "by a mutable reference rather than a full commit SHA"
+
+[[guard]]
+id = "armed-workflow-short-environment"
+outcome = "accepted"
+
+[[guard]]
+id = "armed-workflow-block-environment"
+outcome = "accepted"

--- a/tests/tenkz/release-support/selftest-expectations.toml
+++ b/tests/tenkz/release-support/selftest-expectations.toml
@@ -35,8 +35,6 @@ roots = [
 files = [
   "tests/tenkz/release-tests.toml",
   "tex/tenkz/tenkz.sty",
-  "docs/tenkz/manual2.tex",
-  "docs/tenkz/CHANGES.md",
   "docs/tenkz/TNLOG.md",
 ]
 

--- a/tests/tenkz/release-support/selftest-expectations.toml
+++ b/tests/tenkz/release-support/selftest-expectations.toml
@@ -121,11 +121,11 @@ message = "neither a regular file nor a directory"
 
 [[guard]]
 id = "armed-workflow-comments"
-message = "has no job whose `environment:` is tenkz-release-publisher"
+message = "job(s) whose `environment:` is tenkz-release-publisher"
 
 [[guard]]
 id = "armed-workflow-foreign-needs"
-message = "has no `needs:`, so nothing orders it after post-merge validation"
+message = "it must depend on the validation job"
 
 [[guard]]
 id = "armed-workflow-unknown-needs"
@@ -133,7 +133,7 @@ message = "which is not a job in this workflow"
 
 [[guard]]
 id = "armed-workflow-publisher-action"
-message = "the secret-bearing publisher runs a closed inline command only"
+message = "the secret-bearing publisher runs closed inline commands only"
 
 [[guard]]
 id = "armed-workflow-no-op-denial"
@@ -158,3 +158,19 @@ outcome = "accepted"
 [[guard]]
 id = "armed-workflow-block-environment"
 outcome = "accepted"
+
+[[guard]]
+id = "armed-workflow-flow-action"
+message = "the secret-bearing publisher runs closed inline commands only"
+
+[[guard]]
+id = "armed-workflow-extra-permission"
+message = "the contract grants it exactly"
+
+[[guard]]
+id = "armed-workflow-container"
+message = "has no container image"
+
+[[guard]]
+id = "armed-workflow-secret-elsewhere"
+message = "the publisher is its sole consumer"

--- a/tests/tenkz/release-support/selftest-expectations.toml
+++ b/tests/tenkz/release-support/selftest-expectations.toml
@@ -58,3 +58,25 @@ id = "timeout"
 outcome = "fails-closed"
 message = "exceeded its 1s timeout"
 timeout_seconds = 1
+
+# Escape guards. Each stages one way out of the hermetic view in a throwaway
+# directory and requires the supervisor to refuse it. They cannot be staged
+# from inside a view: a view that could stage them has already failed. The
+# `message` must occur in the refusal, so a guard cannot be satisfied by an
+# unrelated error.
+
+[[guard]]
+id = "nested-symlink"
+message = "contains the symlink"
+
+[[guard]]
+id = "symlinked-program-path"
+message = "rejected without following it"
+
+[[guard]]
+id = "symlinked-parent"
+message = "rejected without following it"
+
+[[guard]]
+id = "special-entry"
+message = "neither a regular file nor a directory"

--- a/tests/tenkz/release-support/selftest-expectations.toml
+++ b/tests/tenkz/release-support/selftest-expectations.toml
@@ -125,7 +125,27 @@ message = "has no job whose `environment:` is tenkz-release-publisher"
 
 [[guard]]
 id = "armed-workflow-foreign-needs"
-message = "lacks its own `needs:` dependency"
+message = "has no `needs:`, so nothing orders it after post-merge validation"
+
+[[guard]]
+id = "armed-workflow-unknown-needs"
+message = "which is not a job in this workflow"
+
+[[guard]]
+id = "armed-workflow-publisher-action"
+message = "the secret-bearing publisher runs a closed inline command only"
+
+[[guard]]
+id = "armed-workflow-no-op-denial"
+message = "has to do something"
+
+[[guard]]
+id = "armed-workflow-late-denial"
+message = "must precede repository code"
+
+[[guard]]
+id = "armed-workflow-no-filesystem-isolation"
+message = "has no step named tenkz-filesystem-isolated"
 
 [[guard]]
 id = "armed-workflow-mutable-action"

--- a/tests/tenkz/release-support/tool-profile.toml
+++ b/tests/tenkz/release-support/tool-profile.toml
@@ -1,0 +1,16 @@
+# Child tools the evidence supervisor may place on a command's sanitized PATH.
+#
+# `docs/tenkz/SOAK-1.0.md` §Release payload evidence: the supervisor resolves
+# each tool without following a repository link, validates its configured
+# version fingerprint, and records the resolved identity in the receipt. A tool
+# absent from this file cannot be reached by any inventory command.
+#
+# The fingerprint is a pattern rather than one exact version string. A hosted
+# runner's interpreter is upgraded on the vendor's schedule, and pinning an
+# exact patch release would make every such upgrade a release incident while
+# proving nothing about compatibility. The pattern states the range the
+# assertions were written against; narrowing it is a support-tree change and
+# therefore a new pinned tree.
+
+[tool.python3]
+version_pattern = "Python 3\\.(?:1[2-9]|[2-9][0-9])(?:\\.[0-9]+)*[a-z0-9+]*"

--- a/tests/tenkz/release-tests.toml
+++ b/tests/tenkz/release-tests.toml
@@ -72,12 +72,23 @@ fixture_paths = []
 timeout_seconds = 60
 
 [[test]]
+id = "tnlog-declaration-block-parses"
+surface = "tnlog"
+failure_fingerprint = "db1f1014a9d1791c035590e01900c4ed4a1780de55ebc893ac69a748904dcf64"
+runner = "python3"
+path = "tests/tenkz/release-harness/tnlog_declared_kinds.py"
+args = ["declaration"]
+program_paths = ["scripts/tenkzlib/tnlog.py"]
+fixture_paths = ["docs/tenkz/TNLOG.md"]
+timeout_seconds = 60
+
+[[test]]
 id = "tnlog-declared-kinds-match-the-reader"
 surface = "tnlog"
 failure_fingerprint = "bae39735591cfdbdf20376e84041aec4d57f7c5b004e5addce6f5a3fa24e5cf3"
 runner = "python3"
 path = "tests/tenkz/release-harness/tnlog_declared_kinds.py"
-args = []
+args = ["kinds"]
 program_paths = ["scripts/tenkzlib/tnlog.py"]
 fixture_paths = ["docs/tenkz/TNLOG.md"]
 timeout_seconds = 60

--- a/tests/tenkz/release-tests.toml
+++ b/tests/tenkz/release-tests.toml
@@ -17,12 +17,23 @@
 schema = 1
 
 [[test]]
-id = "tex-api-package-version-declared"
+id = "tex-api-package-version-declared-once"
 surface = "tex-api"
-failure_fingerprint = "aa16d2f161b986789b582d211b59344b66171a386e3fcfcc259aafb2ba48e1d8"
+failure_fingerprint = "6975c749deed3d812904570c3ea9fc4d14fe2f002c5ecff56b66e7aaba8e6e21"
 runner = "python3"
 path = "tests/tenkz/release-harness/tex_api_package_version.py"
-args = []
+args = ["cardinality"]
+program_paths = ["tex/tenkz/tenkz.sty"]
+fixture_paths = []
+timeout_seconds = 60
+
+[[test]]
+id = "tex-api-package-version-well-formed"
+surface = "tex-api"
+failure_fingerprint = "4c75affd12f21b0ee2e262ccce6495382baed3cf11e1d9ac96c5bed05d8a3d36"
+runner = "python3"
+path = "tests/tenkz/release-harness/tex_api_package_version.py"
+args = ["syntax"]
 program_paths = ["tex/tenkz/tenkz.sty"]
 fixture_paths = []
 timeout_seconds = 60

--- a/tests/tenkz/release-tests.toml
+++ b/tests/tenkz/release-tests.toml
@@ -39,12 +39,23 @@ fixture_paths = []
 timeout_seconds = 60
 
 [[test]]
+id = "tex-api-registry-declares-commands"
+surface = "tex-api"
+failure_fingerprint = "9848e1f6bf653612c61c5287b7e7ebb165a39224623b66b8ee8f4ddd26aee26b"
+runner = "python3"
+path = "tests/tenkz/release-harness/tex_api_language_reference.py"
+args = ["extraction"]
+program_paths = ["tex/tenkz/tenkz-language-registry.tex"]
+fixture_paths = []
+timeout_seconds = 60
+
+[[test]]
 id = "tex-api-registry-commands-reach-the-reference"
 surface = "tex-api"
 failure_fingerprint = "6b10bdfa0d4079c322990a4e9916416013a4c8a6f8ba47aa69d6905cd50d10b0"
 runner = "python3"
 path = "tests/tenkz/release-harness/tex_api_language_reference.py"
-args = []
+args = ["coverage"]
 program_paths = ["tex/tenkz/tenkz-language-registry.tex"]
 fixture_paths = ["docs/tenkz/chapters2/generated-language-reference.tex"]
 timeout_seconds = 60

--- a/tests/tenkz/release-tests.toml
+++ b/tests/tenkz/release-tests.toml
@@ -1,0 +1,61 @@
+# The closed release-test inventory.
+#
+# `docs/tenkz/DESIGN.md` pins this file by raw-blob SHA-256 at activation, and
+# `docs/tenkz/SOAK-1.0.md` §Release payload evidence fixes its grammar. Each
+# entry names one atomic compatibility assertion about one public surface: one
+# command, one failure cause, one fingerprint. A test that could fail for two
+# reasons is two tests, because a friction record names the fingerprint and a
+# fingerprint that stands for a suite tells a reader nothing.
+#
+# `program_paths` are the mutable subjects under test; `fixture_paths` are the
+# other repository blobs the command may read. Neither role may supply runner,
+# helper, or acceptance logic: those come from the pinned code and support
+# trees. Run the inventory with
+#
+#     python3 tests/tenkz/release-harness/supervisor.py run-all
+
+schema = 1
+
+[[test]]
+id = "tex-api-package-version-declared"
+surface = "tex-api"
+failure_fingerprint = "aa16d2f161b986789b582d211b59344b66171a386e3fcfcc259aafb2ba48e1d8"
+runner = "python3"
+path = "tests/tenkz/release-harness/tex_api_package_version.py"
+args = []
+program_paths = ["tex/tenkz/tenkz.sty"]
+fixture_paths = []
+timeout_seconds = 60
+
+[[test]]
+id = "tex-api-registry-commands-reach-the-reference"
+surface = "tex-api"
+failure_fingerprint = "6b10bdfa0d4079c322990a4e9916416013a4c8a6f8ba47aa69d6905cd50d10b0"
+runner = "python3"
+path = "tests/tenkz/release-harness/tex_api_language_reference.py"
+args = []
+program_paths = ["tex/tenkz/tenkz-language-registry.tex"]
+fixture_paths = ["docs/tenkz/chapters2/generated-language-reference.tex"]
+timeout_seconds = 60
+
+[[test]]
+id = "tnlog-reader-ignores-unknown-fields"
+surface = "tnlog"
+failure_fingerprint = "4312555019ae1123120a0e29328272a20f876568c2f6d12a470cf3e5aea6648f"
+runner = "python3"
+path = "tests/tenkz/release-harness/tnlog_unknown_field.py"
+args = []
+program_paths = ["scripts/tenkzlib/tnlog.py"]
+fixture_paths = []
+timeout_seconds = 60
+
+[[test]]
+id = "tnlog-declared-kinds-match-the-reader"
+surface = "tnlog"
+failure_fingerprint = "bae39735591cfdbdf20376e84041aec4d57f7c5b004e5addce6f5a3fa24e5cf3"
+runner = "python3"
+path = "tests/tenkz/release-harness/tnlog_declared_kinds.py"
+args = []
+program_paths = ["scripts/tenkzlib/tnlog.py"]
+fixture_paths = ["docs/tenkz/TNLOG.md"]
+timeout_seconds = 60


### PR DESCRIPTION
Refs LionSR/TNLean#5636 — **does not close it**; see "Two policy claims" below. Reference LionSR/tenkz#13 item 13.

`RELEASE-POLICY.md` named four mechanisms that did not exist. They exist now, and every path the policy page names resolves.

## What each mechanism turned out to be

**`tests/tenkz/release-harness/`** — not a runner over the standing-gate list. `SOAK-1.0.md` §Release payload evidence defines it as the closed set of *atomic compatibility assertions*, one failure cause and one pinned fingerprint each, plus the supervisor that runs them. Built accordingly:

- `supervisor.py` — reads the pinned policy block out of `DESIGN.md`, validates the closed inventory against it (path roles, role disjointness, runner/suffix agreement, fingerprint uniqueness, subject-root containment, per-surface fix-path matching), builds one repository-shaped view per command holding only the pinned trees, the inventory, the four canonical artifacts, and that command's declared subjects, sanitizes the environment and `PATH`, runs `[runner, path, *args]` under its declared timeout, and classifies the outcome. Exit 0 passes; exit 10 with the exact closed receipt is `assertion-failed`; everything else fails closed. Subcommands `check-inventory`, `run`, `run-all`, `pins`, `check-readiness`.
- `harnesslib.py` — the pass/fail protocol every assertion uses.
- Four atomic assertions, two per public surface: the package declares exactly one well-formed version; every registry command reaches the generated language reference; the `.tnlog` reader ignores unknown optional fields (the `[event_format]` rule that makes additive minors possible); the reader's kind table equals the kind set `TNLOG.md` declares.
- `selftest.py` + `selftest_probe.py` — the supervisor self-test the ledger requires before arming. Eight isolation probes: outcome classification (pass, assertion, unrelated exit, exit 10 without receipt, timeout) and view properties (undeclared repository paths absent, environment carries no inherited path variables, subjects read-only, output mount writable).

**`tests/tenkz/release-tests.toml`** and **`tests/tenkz/release-support/`** came with it — the policy names all four as one harness. Support holds the two schemas the policy names, the tool profile, and the self-test expectations.

**`docs/tenkz/CHANGES.md`** — the 0.7→1.0 record in the register of `history/CHANGES-0.6.md`: retired environments, commands, and keys by front end; six motivated design maxims; a per-spelling migration block. Written from `SHRINK.md`, `DISPOSITIONS.md`, `FIXTURE-RETIREMENT.md`, `LANGUAGE-1.0.md` §10, and the merged PR record, with the S4 swap as the headline (#5621 cd, LionSR/TNLean#5626 free, LionSR/TNLean#5644 lattice, LionSR/TNLean#5662 grid; 35,387 lines deleted against 2,764 added; census 201→86 rows, parser paths 228→75, escape ledger to zero, corpus 264→9 fixtures).

**`docs/tenkz/TNLOG.md`** — the event-format declaration. Line grammar and its total absence of escaping, the seventeen emitted kinds and their fields, the emitted-versus-tabled asymmetry (`geomprobe` emitted and untabled, `wire-geometry` tabled and unemitted), what `tnlog.py` enforces versus what it merely tolerates, and — the load-bearing part — the seven invariants that only the writers hold, which the golden digests pin and the reader does not check. Carries a machine-readable `tenkz-event-kinds-v1` block that one of the release assertions holds equal to `FIELD_VALIDATORS`.

**`.github/workflows/tenkz-release-policy.yml`** — modelled on `tenkz-policy.yml`. Runs the isolation probes, the inventory check, every assertion, the readiness check, and prints the activation pins.

## Cross-references retargeted

`DESIGN.md` (×2), `HACKING.md`, and `SOAK-1.0.md` (×2) pointed the activation slice at the closed LionSR/tenkz#128; all five now point at LionSR/TNLean#5636. `ANNOUNCEMENT-1.0-draft.md`'s LionSR/tenkz#128 citation is historical and correct, and stays.

## Two policy claims that could not be honoured as written

**1. `check_tenkz_policy.py` cannot report the evidence chain live, and no change to this slice would make it. LionSR/TNLean#5636 therefore stays open.** Read the script: `validate_entries` returns `not-started` whenever `enforcement == "pending"`, and when enforcement is `armed` it requires a `PolicyEvidenceBundle` that `validate_repository` never supplies — so an armed policy makes the plain CLI **fail**, not report live. Arming is also blocked twice over by the policy's own rules: `SOAK-1.0.md` requires the blocker chain closed first (#4162, LionSR/TNLean#4703, LionSR/TNLean#4708, LionSR/tenkz#12 are open), and the arming diff may touch only `DESIGN.md` and `SOAK-1.0.md`, which this slice cannot be. Arming is the separate self-referential pull request the policy describes, and it comes after those four issues close. The checker still reads `not-started` here, deliberately.

**2. `final-tag-signing-key.pub` is absent and stays absent.** The policy names it in the support tree, but its private half must exist only in the `tenkz-release-publisher` environment secret. Committing a public key whose private half nobody holds would make every downstream signature check pass while signing nothing. `tests/tenkz/release-support/README.md` records the generation step, and `supervisor.py check-readiness` refuses any policy claiming `armed` while the key is missing. The same pre-activation change fixes the two byte constants the tag-object schema leaves open (`tagger_name`, `tagger_email`) and adds the publisher job.

The armed workflow shape also owes two mechanisms this pending shape does not simulate: the mount namespace hiding the real checkout, and network denial before repository code runs. Both are stated in `RELEASE-POLICY.md` §2 and in the supervisor's module docstring rather than pretended.

## Review: seven rounds, 79 findings, all fixed

The first harness had a decorative hermetic view. Seven review rounds found 79 defects in it and all 79 are fixed; every fix has a self-test that fails against the harness before it. The suite grew from nothing to **10 isolation probes and 18 escape guards** alongside **7 atomic release assertions**.

Three findings recurred often enough to be worth naming as classes, because each was fixed properly only after the third instance:

**`Path.is_file()` / `exists()` follow symlinks.** Five sites: inventory subjects, the exposed-tree walk, the public key, the assertion receipt, and the output-mount teardown. Every path check now reads `os.lstat` and walks one component at a time, so a symlinked *parent* is caught as surely as a symlinked leaf. The file carries the rule as a section comment rather than leaving it to be rediscovered.

**`True == 1` in Python.** Three closed protocol versions — the assertion receipt, the inventory, the TNLOG declaration — accepted a JSON or TOML boolean as schema version 1. All three now test `isinstance(x, int) and not isinstance(x, bool)`.

**A regular expression cannot recognize YAML.** Six consecutive rounds on the armed-workflow check: a comment satisfied a substring search; a whole-file pattern matched the wrong job; a flow mapping evaded the action check; the same mapping evaded it again with its keys reordered; a permission set was checked by presence; a `needs:` by nonemptiness. `supervisor.py` now carries a YAML subset parser and the check reads parsed structure. That closed the class.

Substantive results of the rounds, beyond those classes:

| Area | What changed |
|---|---|
| view isolation | symlinks, special modes, and submodule gitlinks rejected without being followed, at every path component and every depth; directories sealed alongside files, so create/rename/unlink under a subject are refused |
| receipt truthfulness | a receipt now carries the commit it observed, the Git object ID of every entry in its view, the tag it was bound to (or `null`), the output mount the command actually received, the canonical artifacts withheld from it, and each tool's digest and resolved path — not just its version banner |
| what a run may read | canonical artifacts reach a command only through a declared role; a dirty, untracked, or ignored file under any exposed path refuses the run rather than being copied |
| execution boundary | the process group is saved before the leader is reaped, killed on success as well as timeout, and the post-kill drain is bounded so a failed kill fails closed instead of hanging |
| armed readiness | the publisher's permission mapping must be exactly `contents: write`; no `uses:` in any spelling and no container; the signing secret has exactly one consumer; the publisher must depend on the job that actually carries both boundary steps; those steps must exist, precede repository code, and not be no-ops |
| release payload | a tag-derived manifest is validated rather than merely exposed — closed field set, tag, version, calendar date, three pins, and each canonical artifact matched at its declaration line |
| replay schema | closed in both directions and keyed where identity matters: pull-request facts and the dependency closure are keyed by reference so one reference cannot carry two verdicts; the two legal outcome tuples are encoded; `author_login` accepts null so a deleted account — a real cause of invalidity — is representable |

Where a check cannot establish what it is named for, that is stated rather than implied. `check-readiness` can require the workflow to *declare* network denial and filesystem isolation and can check their ordering; it cannot verify the commands work. The supervisor's view is declarative isolation, not a sandbox: a command owns every path in it and can restore write permission. Both limits are in the module docstring and in `RELEASE-POLICY.md` §2, with the mount namespace and unprivileged identity assigned to the armed workflow.

## Evidence

No package code changed — the diff is docs, tests, and one workflow.

```
python3 scripts/check_tenkz_policy.py       PASS (evidence not-started, 0 entries)
python3 scripts/tenkz_shrink.py gate        PASS (census stable at 86, 60 flags verdicted)
python3 scripts/check_tenkz_dispositions.py PASS (202 blueprint occurrences, 9 fixtures)
python3 scripts/check_tenkz_demolition.py   PASS (3148 tracked files)
python3 scripts/tenkz_language.py check     PASS (100 records)
python3 scripts/tenkz_manual_doctest.py     PASS (11 displayed, 12 reference examples)
python3 scripts/test_check_tenkz_policy.py  PASS
python3 scripts/test_tenkz_policy_evidence.py PASS
python3 scripts/test_tnlog.py               PASS
python3 scripts/test_tenkz_shrink.py        PASS
python3 scripts/test_check_tenkz_demolition.py   PASS
python3 scripts/test_check_tenkz_dispositions.py PASS

python3 tests/tenkz/release-harness/selftest.py                   PASS (10 probes, 18 guards)
python3 tests/tenkz/release-harness/supervisor.py check-inventory PASS (7 assertions)
python3 tests/tenkz/release-harness/supervisor.py run-all         PASS (7 assertions)
python3 tests/tenkz/release-harness/supervisor.py check-readiness PASS (pending; key absent)
```

Gate table verification: every job the table names exists and is green on `main` at 4c289a1e — `Check tenkz shrink ratchets`, `Check tenkz regression corpus`, `Check blueprint compiles without errors` (pr-ci run 31275377856, all success), `Tenkz Compatibility Policy`, `Tenkz Demolition Guard`. The new row names `tenkz-release-policy.yml`, which runs on this PR.

No figure changed, so the LionSR/tenkz#10 render evidence standard does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg
