### PR TITLE
fix(tenkz): keep the equation's relation glyphs through a beamer frame

### DIFF
--- a/docs/slides/presentation20260218_tao_technical.tex
+++ b/docs/slides/presentation20260218_tao_technical.tex
@@ -255,9 +255,7 @@ Key references:~\cite{Perez-Garcia2007Matrix,Cirac2021Matrix,Cirac2017Annals,Wol
 \end{frame}
 
 % SOURCE: audits/2026-02-20_invariant_subspace_step_literature_map.txt
-% The equation wrapper reads its relation glyphs from unprocessed tokens,
-% so its frame is fragile.
-\begin{frame}[fragile]{Step~(i): canonical form reduction~\cite{Cirac2017Annals,Cirac2021Matrix}}
+\begin{frame}{Step~(i): canonical form reduction~\cite{Cirac2017Annals,Cirac2021Matrix}}
     \vspace{-0.7em}
 
     \begin{columns}[T]

--- a/docs/tenkz/chapters2/ch-tutorial.tex
+++ b/docs/tenkz/chapters2/ch-tutorial.tex
@@ -28,10 +28,11 @@ open ink is declared content, so the picture exposes exactly the indices its
 atoms state.
 
 Beamer reads a frame's body before typesetting it, so a chained picture
-reaches the environment with its \verb|&| already an ordinary alignment tab.
-The environment reads its body as captured tokens and gives that tab the
-site advance itself, so a chained picture compiles in a plain frame; no
-\texttt{[fragile]} marking is needed.
+reaches the environment with its \verb|&| already an ordinary alignment tab,
+and an equation reaches the wrapper with its relation glyph already an
+ordinary character.  Both read their bodies as captured tokens and find the
+tab and the glyph there themselves, so a chained picture and an equation
+each compile in a plain frame; no \texttt{[fragile]} marking is needed.
 
 \subsection{A channel sandwich}
 

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2805,6 +2805,23 @@ grep -Fq '|addr=(2,3)|' "$WORK/r_beamer_frame.tnlog" || {
   echo "FAIL: the plain beamer frame's chained body lost its cursor" >&2
   exit 1
 }
+# The relation glyph arrives pre-tokenized in the same frame.  The equation
+# fixture holds exactly when both panels reach the audit and the glyph
+# between them is read as the relation ending the first side.
+beamer_eq_pictures=$(grep -c '^picture|' "$WORK/r_beamer_equation.tnlog" || true)
+[ "$beamer_eq_pictures" -eq 2 ] || {
+  echo "FAIL: the plain beamer frame's equation lost a panel" >&2
+  exit 1
+}
+grep -Fq 'check|scope=1|relation=1|result=equal' \
+  "$WORK/r_beamer_equation.tnlog" || {
+  echo "FAIL: the plain beamer frame's equation lost its relation glyph" >&2
+  exit 1
+}
+if grep -Fq 'reason=relation-count' "$WORK/r_beamer_equation.tnlog"; then
+  echo "FAIL: the plain beamer frame's equation counted its relations wrong" >&2
+  exit 1
+fi
 # A math alignment cell holds the body scan hostage to the alignment counter:
 # mathtools' gathered template and amsmath's aligned both leave it at zero,
 # where a raw tab once ended the cell mid-scan.  The chained fixture holds

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2822,6 +2822,26 @@ if grep -Fq 'reason=relation-count' "$WORK/r_beamer_equation.tnlog"; then
   echo "FAIL: the plain beamer frame's equation counted its relations wrong" >&2
   exit 1
 fi
+# The equation reads its own token stream for glyphs, and a picture owns
+# everything it consumes.  The fixture holds exactly when the two panel
+# labels keep their own equals, the panels' option lists keep their key
+# separators, and the single glyph between the panels is the only relation.
+panel_equals_checks=$(grep -c '^check|' "$WORK/r_equation_panel_equals.tnlog" || true)
+[ "$panel_equals_checks" -eq 1 ] || {
+  echo "FAIL: a panel's own equals was counted as an equation relation" >&2
+  exit 1
+}
+grep -Fq 'check|scope=1|relation=1|result=equal' \
+  "$WORK/r_equation_panel_equals.tnlog" || {
+  echo "FAIL: the equation lost the relation standing between its panels" >&2
+  exit 1
+}
+for label in 'A=B' 'D=E'; do
+  grep -Fq "|label=$label|" "$WORK/r_equation_panel_equals.tnlog" || {
+    echo "FAIL: the panel label $label lost its own equals" >&2
+    exit 1
+  }
+done
 # A math alignment cell holds the body scan hostage to the alignment counter:
 # mathtools' gathered template and amsmath's aligned both leave it at zero,
 # where a raw tab once ended the cell mid-scan.  The chained fixture holds

--- a/tests/tenkz/kernel/regression/r_beamer_equation.tex
+++ b/tests/tenkz/kernel/regression/r_beamer_equation.tex
@@ -1,0 +1,22 @@
+% Regression: an equation keeps its relation glyphs inside a plain beamer
+% frame.  Beamer tokenizes a frame body long before any equation code runs,
+% so the relation glyph reaches the wrapper as a frozen other-character; the
+% captured-body reading finds it there and the audit compares the two sides
+% without [fragile].
+\documentclass{beamer}
+\usepackage{tenkz}
+
+\begin{document}
+\begin{frame}{Equation}
+  \tenkzkernel
+  \begin{tenkzeq}[check={signature}]
+    \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+      \tn[ports={0:virtual, 180:virtual}]{A}
+    \end{tenkz}
+    =
+    \begin{tenkz}[rows={wire}, cols=2, bonds=grid]
+      \tn[ports={180:virtual}]{B} & \tn[ports={0:virtual}]{B}
+    \end{tenkz}
+  \end{tenkzeq}
+\end{frame}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_equation_panel_equals.tex
+++ b/tests/tenkz/kernel/regression/r_equation_panel_equals.tex
@@ -1,0 +1,20 @@
+% Regression: an equals a panel owns is that panel's mathematics, not the
+% equation's joiner.  The equation sweeps its own token stream for relation
+% glyphs, so the boundary it must respect is the term: a label's $A=B$ and
+% a key separator in a panel's option list are both inside a picture and
+% both stay plain, while the one glyph standing between the two panels is
+% the single relation the audit compares.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkzeq}[check={signature}]
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+    \tn[ports={0:virtual, 180:virtual}]{$A=B$}
+  \end{tenkz}
+  =
+  \begin{tenkz}[rows={wire}, cols=2, bonds=grid]
+    \tn[ports={180:virtual}]{C} & \tn[ports={0:virtual}]{$D=E$}
+  \end{tenkz}
+\end{tenkzeq}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -308,10 +308,7 @@
     % marker; give each one back the plain equals the keyval and value
     % parsers read.
     \bool_if:NT \l__tenkz_kernel_ineq_bool
-      {
-        \regex_replace_all:nnN
-          { \c{__tenkz_kernel_eq_rel:} } { = } \l__tenkz_kernel_opts_tl
-      }
+      { \__tenkz_kernel_revert_rels:N \l__tenkz_kernel_opts_tl }
     % Parameterized alphabet words remain one key value even though their
     % canonical spelling contains `=`.
     \regex_replace_all:nnN
@@ -17838,6 +17835,13 @@
       {
         \group_align_safe_end:
         \__tenkz_kernel_rewrite_tabs:N \l__tenkz_kernel_body_tl
+        % A picture standing in an equation is a term, not the equation's
+        % own token stream: the `=' of a label or a mark's prose is that
+        % panel's mathematics and no joiner of the equation around it.  The
+        % equation's sweep cannot see the picture boundary, so the picture
+        % announces it here and gives its whole body the plain equals back.
+        \bool_if:NT \l__tenkz_kernel_ineq_bool
+          { \__tenkz_kernel_revert_rels:N \l__tenkz_kernel_body_tl }
         % the break between the option list and the first declaration
         \ignorespaces
         \tl_use:N \l__tenkz_kernel_body_tl
@@ -17860,14 +17864,24 @@
 % The sweep reaches every brace level, because the active glyph did: a
 % joiner is the mathematics standing between two terms (LANGUAGE-1.0
 % section 7), and the braces of an \mbox or an \ensuremath around that
-% mathematics are its spelling, not its depth.  A panel's option list is
-% swept along with the joiners, so its key separators arrive at
-% \__tenkz_kernel_keys:nn wearing the marker; that door gives them back the
-% plain equals before l3keys reads them, exactly as it gave back the active
-% glyph.
+% mathematics are its spelling, not its depth.
+%
+% What separates a joiner from an equals that merely looks like one is the
+% term boundary, not the brace: the equation may read its own token stream,
+% and everything a picture consumes belongs to that picture.  The catcode
+% arrangement drew this boundary with \char_set_catcode_other:N \= at
+% picture entry, which put the picture's body back on the plain equals; the
+% capture draws the same boundary by reverting the marker on the two token
+% ranges a picture owns.  Its option list is read before the picture's own
+% capture starts, and \__tenkz_kernel_keys:nn reverts it there; its body is
+% reverted by \__tenkz_kernel_env_body:w above.  So $A=B$ on a panel's label
+% is that panel's mathematics, while a=b in an \mbox between two panels is
+% the equation's, and each is read as what it is.
 \tl_new:N \l__tenkz_kernel_eq_body_tl
 \cs_new_protected:Npn \__tenkz_kernel_rewrite_rels:N #1
   { \regex_replace_all:nnN { = } { \c{__tenkz_kernel_eq_rel:} } #1 }
+\cs_new_protected:Npn \__tenkz_kernel_revert_rels:N #1
+  { \regex_replace_all:nnN { \c{__tenkz_kernel_eq_rel:} } { = } #1 }
 \NewDocumentCommand \__tenkz_kernel_eq_env_begin_cmd { O{} }
   {
     \__tenkz_kernel_eq_begin:n {#1}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -303,11 +303,15 @@
 \cs_new_protected:Npn \__tenkz_kernel_keys:nn #1#2
   {
     \tl_set:Nn \l__tenkz_kernel_opts_tl {#2}
-    % A panel option list under tenkzeq is tokenized while `=` is the
-    % active relation glyph; rewrite each one to the plain equals the
-    % keyval and value parsers read.
+    % A panel option list standing in an equation body was swept by the
+    % relation rewrite, so its key separators arrive wearing the relation
+    % marker; give each one back the plain equals the keyval and value
+    % parsers read.
     \bool_if:NT \l__tenkz_kernel_ineq_bool
-      { \regex_replace_all:nnN { = } { = } \l__tenkz_kernel_opts_tl }
+      {
+        \regex_replace_all:nnN
+          { \c{__tenkz_kernel_eq_rel:} } { = } \l__tenkz_kernel_opts_tl
+      }
     % Parameterized alphabet words remain one key value even though their
     % canonical spelling contains `=`.
     \regex_replace_all:nnN
@@ -17262,9 +17266,10 @@
   { \__tenkz_kernel_tn:nn {#1} {#2} \ignorespaces }
 
 % tenkzeq: the audit scope.  Panels accumulate their signatures globally
-% (each panel closes its own group); the active `=` records one relation
-% per glyph together with its place in the panel sequence, and the audit
-% compares the composite sides those places delimit.
+% (each panel closes its own group); each relation glyph standing in the
+% equation body records one relation together with its place in the panel
+% sequence, and the audit compares the composite sides those places
+% delimit.  The body capture below finds the glyphs.
 \cs_new_protected:Npn \__tenkz_kernel_eq_begin:n #1
   {
     \bool_if:NT \l__tenkz_kernel_ineq_bool
@@ -17311,8 +17316,6 @@
     \prop_set_eq:NN
       \l__tenkz_kernel_eq_policy_prop \l__tenkz_kernel_stage_prop
     \prop_clear:N \l__tenkz_kernel_stage_prop
-    \char_set_catcode_active:N \=
-    \char_set_active_eq:NN \= \__tenkz_kernel_eq_rel:
   }
 \cs_new_protected:Npn \__tenkz_kernel_eq_rel:
   {
@@ -17845,8 +17848,48 @@
         \__tenkz_kernel_env_body:w
       }
   }
+% The equation body is captured on the same terms, and for the same reason.
+% A relation glyph is an ordinary `=' the author writes between panels, and
+% the wrapper used to recognize it by making `=' active at equation entry.
+% That arrangement fails wherever the body was tokenized earlier: in a plain
+% beamer frame every `=' reaches the wrapper as a frozen other-character, no
+% relation is recorded, and the audit reports an equation with panels and no
+% relations.  The capture reads the glyphs out of the tokens instead, so the
+% reading no longer depends on when the body was tokenized.
+%
+% The sweep reaches every brace level, because the active glyph did: a
+% joiner is the mathematics standing between two terms (LANGUAGE-1.0
+% section 7), and the braces of an \mbox or an \ensuremath around that
+% mathematics are its spelling, not its depth.  A panel's option list is
+% swept along with the joiners, so its key separators arrive at
+% \__tenkz_kernel_keys:nn wearing the marker; that door gives them back the
+% plain equals before l3keys reads them, exactly as it gave back the active
+% glyph.
+\tl_new:N \l__tenkz_kernel_eq_body_tl
+\cs_new_protected:Npn \__tenkz_kernel_rewrite_rels:N #1
+  { \regex_replace_all:nnN { = } { \c{__tenkz_kernel_eq_rel:} } #1 }
 \NewDocumentCommand \__tenkz_kernel_eq_env_begin_cmd { O{} }
-  { \__tenkz_kernel_eq_begin:n {#1} }
+  {
+    \__tenkz_kernel_eq_begin:n {#1}
+    \tl_clear:N \l__tenkz_kernel_eq_body_tl
+    \group_align_safe_begin:
+    \__tenkz_kernel_eq_body:w
+  }
+\cs_new_protected:Npn \__tenkz_kernel_eq_body:w #1 \end #2
+  {
+    \tl_put_right:Nn \l__tenkz_kernel_eq_body_tl {#1}
+    \str_if_eq:nnTF {#2} {tenkzeq}
+      {
+        \group_align_safe_end:
+        \__tenkz_kernel_rewrite_rels:N \l__tenkz_kernel_eq_body_tl
+        \tl_use:N \l__tenkz_kernel_eq_body_tl
+        \end {tenkzeq}
+      }
+      {
+        \tl_put_right:Nn \l__tenkz_kernel_eq_body_tl { \end {#2} }
+        \__tenkz_kernel_eq_body:w
+      }
+  }
 \NewDocumentCommand \tenkzkernel { }
   {
     \cs_set_eq:NN \tenkz \__tenkz_kernel_env_begin_cmd


### PR DESCRIPTION
Closes LionSR/TNLean#5674.  Tracker: LionSR/tenkz#13.

## The defect

The equation wrapper recognized its relation glyphs by catcode: at equation
entry it made `=` active and bound the active token to the recording call.
Catcodes act at reading time, and beamer reads a frame body long before any
equation code runs, so in a plain frame every `=` reached the wrapper already
frozen as an other-character.  Nothing recorded a relation, and the equation
then failed the arity rule it was innocent of --
`[TKZ-EQ-ARITY] an equation with 2 panel(s) has 0 relation glyph(s)`.  One
deck carried `[fragile]` as the workaround.

This is the residue PR LionSR/TNLean#5617 named when it moved the picture environment to
captured-body reading: "the `tenkzeq` wrapper still records its relation
glyph through an active `=` made at its own entry, so an equation inside a
beamer frame remains untreated".

## Mechanism

The wrapper reads its body the way the picture already reads its own.
`\__tenkz_kernel_eq_env_begin_cmd` grabs the body up to the equation's own
`\end` with a delimited scan, rewrites the relation glyphs into
`\__tenkz_kernel_eq_rel:`, and executes the captured tokens; a foreign `\end`
met on the way accumulates and passes through intact.  The scan is bracketed
by the `\group_align_safe_begin:`/`_end:` pair from PR LionSR/TNLean#5653, so an equation
in a math alignment cell keeps the same protection the picture has.  The two
catcode assignments at equation entry are deleted: reading the glyphs out of
the tokens does not care when the tokens were made, which is exactly the
property the active glyph lacked.

The sweep reaches every brace level, and that is deliberate rather than
incidental.  The active glyph acted at every depth, and
`r_check_scope_nested` pins the consequence: an `=` inside `\mbox{a=b}`
standing between two panels is a relation.  LANGUAGE-1.0 section 7 agrees --
a joiner is the mathematics standing between two terms, and the braces of an
`\mbox` around that mathematics are its spelling, not its depth.  A
top-level-only rewrite would have been cheaper and would have quietly
narrowed the language, so the rewrite is `\regex_replace_all:nnN`, which
descends.

What brace depth cannot do is separate a joiner from an equals that merely
looks like one: `$A=B$` on a panel's label sits at depth one too, and it is
that panel's mathematics, not the equation's.  The separator is the term.
The catcode arrangement drew that boundary with `\char_set_catcode_other:N
\=` at picture entry, which put the picture's body back on the plain equals
while the active glyph stayed in force outside it; the capture draws the same
boundary by reverting the marker on the two token ranges a picture owns.  Its
option list is read before the picture's own capture starts, and
`\__tenkz_kernel_keys:nn` reverts it there; its captured body is reverted by
`\__tenkz_kernel_env_body:w`.  Both call one named operation,
`\__tenkz_kernel_revert_rels:N`, so the two doors cannot drift apart.

I did not take the documented-contract route the issue offers as the
alternative.  It would have had to say that an equation needs `[fragile]`,
which is a spelling burden the capture model exists to remove, and the
diagnostic it would carry would still be a refusal rather than a picture.
The mechanism above is four lines of scan plus one rewrite, and it makes the
equation read like the picture beside it.

Beamer is the reported surface but not the only one: written as
`\fbox{\begin{tenkzeq}...}` the same equation fails on `origin/main` with the
same arity error, because `\fbox` grabs its argument as a token list too.
Any box-grabbing argument pre-tokenizes the body, and the capture fixes them
all.

## Regression

`tests/tenkz/kernel/regression/r_equation_panel_equals.tex` pins the term
boundary: two panel labels carrying `$A=B$` and `$D=E$`, panel option lists
carrying key separators inside and outside a picture body, and one joiner
between the panels.  The probes assert exactly one `check|` record,
`check|scope=1|relation=1|result=equal`, and both labels surviving into the
stream.  It fails against the first draft of this branch (`exit 1`,
`relations=3`) and passes now.

`tests/tenkz/kernel/regression/r_beamer_equation.tex` puts a two-panel
equation with `check={signature}` in a plain beamer frame.  The right panel
is chained, so the fixture exercises the pre-tokenized alignment tab and the
pre-tokenized relation glyph in the same frame.  The probes assert two
panels, `check|scope=1|relation=1|result=equal`, and the absence of
`reason=relation-count` -- the exact record the reported failure emitted.

## Deck

`docs/slides/presentation20260218_tao_technical.tex` is the only deck that
writes a `tenkzeq`, and its `[fragile]` marking (with the comment explaining
it) is dropped.  The deck compiles, and page 11 -- the blocking equation,
`C` above the `B` word with the relation glyph between the panels -- is
byte-identical at 200 dpi to the render from the same deck with the
`[fragile]` marking restored.  The other decks' `[fragile]` markings are all
verbatim or listing frames and are untouched.

The manual's tutorial paragraph (manual2, page 4) now states the plain-frame
reading for the equation beside the picture.

## Gates

- `scripts/tenkz_kernel_probes.sh` -- PASS: 145 review regressions hold
  (143 before the two new fixtures), 11 sugar spellings byte-identical in events
  and pixels, 12 kernel record streams byte-identical, kernel pixels
  byte-identical.
- `scripts/tenkz_golden.sh --check` -- PASS: 9 event streams byte-identical.
- `scripts/tenkz_corpus.sh` -- PASS: 9 standalone corpus files.
- `python3 scripts/tenkz_rmp.py check --all` -- PASS: 130 targets; verdicts
  unchanged (faithful 90, cosmetic-gap 40, pairing verified 120).
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` -- PASS:
  census stable at 86, all 60 flags carry verdicts.  No census movement, so
  no SHRINK.md append.
- `python3 scripts/check_tenkz_dispositions.py` and its self-test -- PASS:
  202 blueprint occurrences and 9 standalone fixtures reconcile exactly.
- `python3 scripts/test_tenkz_equation_audit.py` -- PASS: 5 positive, 12
  negative, 2 source-linked checks.
- `python3 scripts/test_tenkz_kernel_audit.py`,
  `test_tenkz_language.py`, `test_tenkz_shrink.py`,
  `check_tenkz_policy.py`, `check_tenkz_demolition.py` -- PASS.
- `python3 scripts/tenkz_manual_doctest.py` -- PASS: 11 displayed and 12
  reference examples; manual2 compiles twice.
- `scripts/tenkz_string_probes.sh` -- PASS: 30 artifacts byte-identical.
- `python3 scripts/tenkz_lint.py` on the deck and the new fixture -- 0
  findings.
- `test_tenkz_equation_web.py` does not run here: no `playwright` module in
  this environment, unchanged by this branch.

A repo-wide scan finds 59 `tenkzeq` bodies across tests, decks, and the RMP
corpus; all compile.  The one body that nests an equation is
`n_nested_equation`, whose `[TKZ-EQ-NESTED]` refusal the probes still pin.

## Render evidence

- `r_beamer_equation.pdf` page 1: both panels draw inside the plain frame
  with the relation glyph between them and the audit recording
  `result=equal`.
- `presentation20260218_tao_technical.pdf` page 11 at 200 dpi: byte-identical
  to the `[fragile]` render.
- `manual2.pdf` page 4 at 150 dpi: the revised tutorial paragraph typesets
  cleanly above Example 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core equation parsing and relation detection in `tenkz-kernel.code.tex`; behavior is heavily regression-tested but mistakes could mis-audit equation signatures or break non-Beamer `tenkzeq` usage.
> 
> **Overview**
> **Fixes `tenkzeq` in plain Beamer frames** by recording relation glyphs from captured tokens instead of an active `=` at equation entry. Beamer tokenizes frame bodies early, so `=` reached the wrapper as a frozen character and the audit saw zero relations (`TKZ-EQ-ARITY`).
> 
> The `tenkzeq` wrapper now **captures its body** (like `tenkz` pictures), rewrites joiner `=` to `\__tenkz_kernel_eq_rel:`, and drops the catcode hook. Nested `\mbox{a=b}` between panels still counts as relations at all brace depths. **Panel-owned equals** (`$A=B$` labels, option-list `=`) are reverted inside picture bodies and option parsing so only the glyph between panels is audited.
> 
> Adds regression fixtures for Beamer equations and panel-internal equals; extends kernel probes; removes `[fragile]` from the one deck `tenkzeq` and updates the manual tutorial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0af70ff07726c3289e07b2799198eef9870793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

