### PR TITLE
feat(Analysis): package Wolf Birkhoff theorem

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.Analysis
 
+import TNLean.Analysis.Birkhoff
 import TNLean.Analysis.CfcConjugation
 import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.CfcLogAdditive

--- a/TNLean/Analysis/Birkhoff.lean
+++ b/TNLean/Analysis/Birkhoff.lean
@@ -26,7 +26,7 @@ namespace TNLean
 The set of `d × d` doubly stochastic matrices over `ℝ` equals the convex
 hull of the `d × d` permutation matrices.
 -/
-theorem wolf_birkhoff_doublyStochastic_convexHull {d : ℕ} :
+theorem wolf_birkhoff_doubly_stochastic_convex_hull {d : ℕ} :
     (doublyStochastic ℝ (Fin d) : Set (Matrix (Fin d) (Fin d) ℝ)) =
       convexHull ℝ {σ.permMatrix ℝ | σ : Equiv.Perm (Fin d)} :=
   _root_.doublyStochastic_eq_convexHull_permMatrix
@@ -37,7 +37,7 @@ theorem wolf_birkhoff_doublyStochastic_convexHull {d : ℕ} :
 The extreme points of the set of `d × d` doubly stochastic matrices over
 `ℝ` are exactly the `d × d` permutation matrices.
 -/
-theorem wolf_birkhoff_extremePoints_doublyStochastic {d : ℕ} :
+theorem wolf_birkhoff_extreme_points_doubly_stochastic {d : ℕ} :
     Set.extremePoints ℝ ((doublyStochastic ℝ (Fin d) : Set (Matrix (Fin d) (Fin d) ℝ))) =
       {σ.permMatrix ℝ | σ : Equiv.Perm (Fin d)} :=
   _root_.extremePoints_doublyStochastic

--- a/TNLean/Analysis/Birkhoff.lean
+++ b/TNLean/Analysis/Birkhoff.lean
@@ -21,8 +21,6 @@ extreme partial-permutation-matrix characterization) is missing.
 See `docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex`.
 -/
 
-open Set
-
 namespace TNLean
 
 /--

--- a/TNLean/Analysis/Birkhoff.lean
+++ b/TNLean/Analysis/Birkhoff.lean
@@ -14,6 +14,11 @@ permutation matrices, and its extreme points are exactly the
 permutation matrices.
 
 Source: `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 263–266.
+
+**Scope restriction (Wolf Theorem 8.6):** only the doubly-stochastic half is
+formalized; the doubly-substochastic half (definition, polytope structure,
+extreme partial-permutation-matrix characterization) is missing.
+See `docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex`.
 -/
 
 open Set
@@ -21,23 +26,31 @@ open Set
 namespace TNLean
 
 /--
-**Birkhoff's theorem** (doubly-stochastic half, Wolf Chapter 8, lines 263–266).
+**Birkhoff's theorem** (Wolf Theorem 8.6, Chapter 8, lines 263–266).
 
 The set of `d × d` doubly stochastic matrices over `ℝ` equals the convex
 hull of the `d × d` permutation matrices.
+
+**Scope restriction (Wolf Theorem 8.6):** only the doubly-stochastic half is
+formalized; the doubly-substochastic half is missing.
+See `docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex`.
 -/
-theorem wolf_birkhoff_doubly_stochastic_convex_hull {d : ℕ} :
+theorem wolf_birkhoff_doublyStochastic_convexHull {d : ℕ} :
     (doublyStochastic ℝ (Fin d) : Set (Matrix (Fin d) (Fin d) ℝ)) =
       convexHull ℝ {σ.permMatrix ℝ | σ : Equiv.Perm (Fin d)} :=
   _root_.doublyStochastic_eq_convexHull_permMatrix
 
 /--
-**Birkhoff's theorem** (doubly-stochastic half, Wolf Chapter 8, lines 263–266).
+**Birkhoff's theorem** (Wolf Theorem 8.6, Chapter 8, lines 263–266).
 
 The extreme points of the set of `d × d` doubly stochastic matrices over
 `ℝ` are exactly the `d × d` permutation matrices.
+
+**Scope restriction (Wolf Theorem 8.6):** only the doubly-stochastic half is
+formalized; the doubly-substochastic half is missing.
+See `docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex`.
 -/
-theorem wolf_birkhoff_extreme_points_doubly_stochastic {d : ℕ} :
+theorem wolf_birkhoff_extremePoints_doublyStochastic {d : ℕ} :
     Set.extremePoints ℝ ((doublyStochastic ℝ (Fin d) : Set (Matrix (Fin d) (Fin d) ℝ))) =
       {σ.permMatrix ℝ | σ : Equiv.Perm (Fin d)} :=
   _root_.extremePoints_doublyStochastic

--- a/TNLean/Analysis/Birkhoff.lean
+++ b/TNLean/Analysis/Birkhoff.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Convex.Birkhoff
+
+/-!
+# Birkhoff's theorem for doubly stochastic matrices (Wolf Chapter 8)
+
+The doubly-stochastic half of Birkhoff's theorem: the set of `d × d`
+doubly stochastic matrices over `ℝ` is the convex hull of the `d × d`
+permutation matrices, and its extreme points are exactly the
+permutation matrices.
+
+Source: `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 263–266.
+-/
+
+open Set
+
+namespace TNLean
+
+/--
+**Birkhoff's theorem** (doubly-stochastic half, Wolf Chapter 8, lines 263–266).
+
+The set of `d × d` doubly stochastic matrices over `ℝ` equals the convex
+hull of the `d × d` permutation matrices.
+-/
+theorem wolf_birkhoff_doublyStochastic_convexHull {d : ℕ} :
+    (doublyStochastic ℝ (Fin d) : Set (Matrix (Fin d) (Fin d) ℝ)) =
+      convexHull ℝ {σ.permMatrix ℝ | σ : Equiv.Perm (Fin d)} :=
+  _root_.doublyStochastic_eq_convexHull_permMatrix
+
+/--
+**Birkhoff's theorem** (doubly-stochastic half, Wolf Chapter 8, lines 263–266).
+
+The extreme points of the set of `d × d` doubly stochastic matrices over
+`ℝ` are exactly the `d × d` permutation matrices.
+-/
+theorem wolf_birkhoff_extremePoints_doublyStochastic {d : ℕ} :
+    Set.extremePoints ℝ ((doublyStochastic ℝ (Fin d) : Set (Matrix (Fin d) (Fin d) ℝ))) =
+      {σ.permMatrix ℝ | σ : Equiv.Perm (Fin d)} :=
+  _root_.extremePoints_doublyStochastic
+
+end TNLean

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -9,6 +9,7 @@ This chapter develops trace distance, von Neumann entropy, and their basic
 properties for finite-dimensional quantum systems.
 
 \input{chapter/ch19_entropy_trace_norm}
+\input{chapter/ch19_entropy_majorization}
 \input{chapter/ch19_entropy_von_neumann_and_relative_i}
 \input{chapter/ch19_entropy_von_neumann_and_relative_ii}
 \input{chapter/ch19_entropy_tripartite_and_ssa_i}

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -41,9 +41,8 @@ stochastic matrices.
     \begin{align}
       (P_\sigma)_{ij}=0
       &\Longrightarrow A_{ij}=B_{ij}=0, \\
-      1=\sum_j A_{ij}=A_{i,\sigma(i)},\qquad
-      1=\sum_j B_{ij}
-      &=B_{i,\sigma(i)}.
+      1=\sum_j A_{ij} &= A_{i,\sigma(i)}, \\
+      1=\sum_j B_{ij} &= B_{i,\sigma(i)}.
     \end{align}
     Thus $A=B=P_\sigma$, so every permutation matrix is extreme.
     Conversely, a non-permutation matrix has a Birkhoff decomposition

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -34,11 +34,18 @@ stochastic matrices.
     \end{align}
     Indeed, every doubly stochastic matrix is a convex combination of
     permutation matrices, while convexity of $\mathcal{DS}_d$ gives the
-    converse inclusion in the first identity.  If a permutation matrix is a
-    nontrivial convex combination of two doubly stochastic matrices,
-    nonnegativity forces both matrices to vanish at every zero entry of the
-    permutation matrix; their row sums then force both matrices to equal that
-    permutation matrix.  Hence every permutation matrix is extreme.
+    converse inclusion in the first identity.  Suppose that a permutation
+    matrix $P_\sigma$ is a convex combination
+    $P_\sigma=tA+(1-t)B$, where $0<t<1$ and $A,B$ are doubly stochastic.
+    Nonnegativity and the row sums give
+    \begin{align}
+      (P_\sigma)_{ij}=0
+      &\Longrightarrow A_{ij}=B_{ij}=0, \\
+      1=\sum_j A_{ij}=A_{i,\sigma(i)},\qquad
+      1=\sum_j B_{ij}
+      &=B_{i,\sigma(i)}.
+    \end{align}
+    Thus $A=B=P_\sigma$, so every permutation matrix is extreme.
     Conversely, a non-permutation matrix has a Birkhoff decomposition
     involving at least two distinct permutation matrices and is therefore
     not extreme, which proves the second identity.

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -28,12 +28,10 @@ stochastic matrices.
     doubly stochastic matrices and let $\mathcal{P}_d$ be the set of
     $d \times d$ permutation matrices.  The Birkhoff--von Neumann
     decomposition gives
-    \[
-    \begin{aligned}
+    \begin{align}
       \mathcal{DS}_d &= \operatorname{conv}(\mathcal{P}_d), \\
       \operatorname{ext}(\mathcal{DS}_d) &= \mathcal{P}_d .
-    \end{aligned}
-    \]
+    \end{align}
     Indeed, every doubly stochastic matrix is a convex combination of
     permutation matrices, while convexity of $\mathcal{DS}_d$ gives the
     converse inclusion in the first identity.  Each permutation matrix is

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -7,15 +7,18 @@
 Birkhoff's theorem characterizes the convex geometry of doubly
 stochastic matrices.
 
-\begin{theorem}[Birkhoff]
+\begin{theorem}[Birkhoff (doubly-stochastic part)]
     \label{thm:birkhoff_doubly_stochastic}
-    \lean{TNLean.wolf_birkhoff_doubly_stochastic_convex_hull}
-    \lean{TNLean.wolf_birkhoff_extreme_points_doubly_stochastic}
+    \lean{TNLean.wolf_birkhoff_doublyStochastic_convexHull}
+    \lean{TNLean.wolf_birkhoff_extremePoints_doublyStochastic}
     \leanok
     The set of doubly stochastic matrices in $M_d(\R)$ is the convex
     hull of the $d\times d$ permutation matrices, and its extreme
     points are exactly the permutation matrices.
     See \cite[Chapter~8, Theorem~8.6]{Wolf2012Quantum}.
+    The doubly-substochastic half of Theorem~8.6 (definition of
+    substochastic matrices, their polytope structure, and extreme
+    partial-permutation-matrix characterization) is not yet formalized.
 \end{theorem}
 % The doubly-substochastic half of Birkhoff's theorem (extreme
 % points of the substochastic matrices) is not formalized; #3959.
@@ -25,12 +28,12 @@ stochastic matrices.
     doubly stochastic matrices and let $\mathcal{P}_d$ be the set of
     $d \times d$ permutation matrices.  The Birkhoff--von Neumann
     decomposition gives
-    \
+    \[
     \begin{aligned}
       \mathcal{DS}_d &= \operatorname{conv}(\mathcal{P}_d), \\
       \operatorname{ext}(\mathcal{DS}_d) &= \mathcal{P}_d .
     \end{aligned}
-    \
+    \]
     Indeed, every doubly stochastic matrix is a convex combination of
     permutation matrices, while convexity of $\mathcal{DS}_d$ gives the
     converse inclusion in the first identity.  Each permutation matrix is

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -1,0 +1,33 @@
+%% =========================================================
+%% Majorization and Birkhoff's theorem
+%% Doubly-stochastic half.
+%% =========================================================
+
+\section{Majorization}
+
+Majorization is a preorder on real vectors that captures when one
+probability distribution is more ``mixed'' than another.
+Its convex-geometric foundation is Birkhoff's theorem.
+
+\begin{theorem}[Birkhoff]
+    \label{thm:birkhoff_doubly_stochastic}
+    \lean{TNLean.wolf_birkhoff_doublyStochastic_convexHull}
+    \lean{TNLean.wolf_birkhoff_extremePoints_doublyStochastic}
+    \leanok
+    The set of doubly stochastic matrices in $M_d(\R)$ is the convex
+    hull of the $d\times d$ permutation matrices, and its extreme
+    points are exactly the permutation matrices.
+    See \cite[Chapter~8, lines~263--266]{Wolf2012Quantum}.
+\end{theorem}
+% The doubly-substochastic half of Birkhoff's theorem (extreme
+% points of the substochastic matrices) is not formalized; #3959.
+
+\begin{proof}\leanok
+    Every doubly stochastic matrix is a convex combination of
+    permutation matrices, and every convex combination of permutation
+    matrices is doubly stochastic (the first identity).  Since the
+    permutation matrices themselves are extreme points of the doubly
+    stochastic matrices and no other extreme points exist, the second
+    identity follows.
+\end{proof}
+\endinput

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -16,9 +16,9 @@ stochastic matrices.
     hull of the $d\times d$ permutation matrices, and its extreme
     points are exactly the permutation matrices.
     See \cite[Chapter~8, Theorem~8.6]{Wolf2012Quantum}.
-    The doubly-substochastic half of Theorem~8.6 (definition of
-    substochastic matrices, their polytope structure, and extreme
-    partial-permutation-matrix characterization) is not yet formalized.
+    This statement concerns only doubly stochastic matrices; the
+    corresponding assertion of Theorem~8.6 for doubly substochastic
+    matrices is not included here.
 \end{theorem}
 % The doubly-substochastic half of Birkhoff's theorem (extreme
 % points of the substochastic matrices) is not formalized; #3959.

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -15,17 +15,27 @@ stochastic matrices.
     The set of doubly stochastic matrices in $M_d(\R)$ is the convex
     hull of the $d\times d$ permutation matrices, and its extreme
     points are exactly the permutation matrices.
-    See \cite[Chapter~8, lines~263--266]{Wolf2012Quantum}.
+    See \cite[Chapter~8, Theorem~8.6]{Wolf2012Quantum}.
 \end{theorem}
 % The doubly-substochastic half of Birkhoff's theorem (extreme
 % points of the substochastic matrices) is not formalized; #3959.
 
 \begin{proof}\leanok
-    Every doubly stochastic matrix is a convex combination of
-    permutation matrices, and every convex combination of permutation
-    matrices is doubly stochastic (the first identity).  Since the
-    permutation matrices themselves are extreme points of the doubly
-    stochastic matrices and no other extreme points exist, the second
-    identity follows.
+    Let $\mathcal{DS}_d \subset M_d(\mathbb{R})$ be the set of $d \times d$
+    doubly stochastic matrices and let $\mathcal{P}_d$ be the set of
+    $d \times d$ permutation matrices.  Mathlib establishes both
+    characterizations separately:
+    \[
+    \begin{aligned}
+      \mathcal{DS}_d &= \operatorname{conv}(\mathcal{P}_d), \\
+      \operatorname{ext}(\mathcal{DS}_d) &= \mathcal{P}_d .
+    \end{aligned}
+    \]
+    The first identity says every doubly stochastic matrix is a convex
+    combination of permutation matrices, and conversely every convex
+    combination of permutation matrices is doubly stochastic.  The second
+    identifies the extreme points of the doubly stochastic matrices as
+    exactly the permutation matrices.  Both results are reused directly
+    from Mathlib (no reproof).
 \end{proof}
 \endinput

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -23,19 +23,19 @@ stochastic matrices.
 \begin{proof}\leanok
     Let $\mathcal{DS}_d \subset M_d(\mathbb{R})$ be the set of $d \times d$
     doubly stochastic matrices and let $\mathcal{P}_d$ be the set of
-    $d \times d$ permutation matrices.  Mathlib establishes both
-    characterizations separately:
-    \[
+    $d \times d$ permutation matrices.  The Birkhoff--von Neumann
+    decomposition gives
+    \
     \begin{aligned}
       \mathcal{DS}_d &= \operatorname{conv}(\mathcal{P}_d), \\
       \operatorname{ext}(\mathcal{DS}_d) &= \mathcal{P}_d .
     \end{aligned}
-    \]
-    The first identity says every doubly stochastic matrix is a convex
-    combination of permutation matrices, and conversely every convex
-    combination of permutation matrices is doubly stochastic.  The second
-    identifies the extreme points of the doubly stochastic matrices as
-    exactly the permutation matrices.  Both results are reused directly
-    from Mathlib (no reproof).
+    \
+    Indeed, every doubly stochastic matrix is a convex combination of
+    permutation matrices, while convexity of $\mathcal{DS}_d$ gives the
+    converse inclusion in the first identity.  Each permutation matrix is
+    extreme.  Conversely, a non-permutation matrix has a Birkhoff
+    decomposition involving at least two distinct permutation matrices and
+    is therefore not extreme, which proves the second identity.
 \end{proof}
 \endinput

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -1,18 +1,16 @@
 %% =========================================================
-%% Majorization and Birkhoff's theorem
-%% Doubly-stochastic half.
+%% Birkhoff's theorem --- doubly-stochastic half
 %% =========================================================
 
-\section{Majorization}
+\section{Birkhoff's theorem}
 
-Majorization is a preorder on real vectors that captures when one
-probability distribution is more ``mixed'' than another.
-Its convex-geometric foundation is Birkhoff's theorem.
+Birkhoff's theorem characterizes the convex geometry of doubly
+stochastic matrices.
 
 \begin{theorem}[Birkhoff]
     \label{thm:birkhoff_doubly_stochastic}
-    \lean{TNLean.wolf_birkhoff_doublyStochastic_convexHull}
-    \lean{TNLean.wolf_birkhoff_extremePoints_doublyStochastic}
+    \lean{TNLean.wolf_birkhoff_doubly_stochastic_convex_hull}
+    \lean{TNLean.wolf_birkhoff_extreme_points_doubly_stochastic}
     \leanok
     The set of doubly stochastic matrices in $M_d(\R)$ is the convex
     hull of the $d\times d$ permutation matrices, and its extreme

--- a/blueprint/src/chapter/ch19_entropy_majorization.tex
+++ b/blueprint/src/chapter/ch19_entropy_majorization.tex
@@ -34,9 +34,13 @@ stochastic matrices.
     \end{align}
     Indeed, every doubly stochastic matrix is a convex combination of
     permutation matrices, while convexity of $\mathcal{DS}_d$ gives the
-    converse inclusion in the first identity.  Each permutation matrix is
-    extreme.  Conversely, a non-permutation matrix has a Birkhoff
-    decomposition involving at least two distinct permutation matrices and
-    is therefore not extreme, which proves the second identity.
+    converse inclusion in the first identity.  If a permutation matrix is a
+    nontrivial convex combination of two doubly stochastic matrices,
+    nonnegativity forces both matrices to vanish at every zero entry of the
+    permutation matrix; their row sums then force both matrices to equal that
+    permutation matrix.  Hence every permutation matrix is extreme.
+    Conversely, a non-permutation matrix has a Birkhoff decomposition
+    involving at least two distinct permutation matrices and is therefore
+    not extreme, which proves the second identity.
 \end{proof}
 \endinput

--- a/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
+++ b/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
@@ -73,11 +73,15 @@ support of a substochastic matrix may omit rows or columns.
     instead of~$=1$.
   \item Define the set of partial permutation matrices over
     $\operatorname{Fin} d$ and establish that each is doubly substochastic.
-  \item Carry out a Birkhoff-style decomposition: every doubly substochastic
-    matrix can be written as a convex combination of partial permutation
-    matrices.  The standard proof appends a dummy row and column to reduce to
-    the doubly stochastic case (the ``dilation trick''), which would reuse the
-    already-formalized Mathlib Birkhoff theorem.
+  \item Carry out a Birkhoff-style decomposition by completing a
+    $d\times d$ doubly substochastic matrix to a $2d\times 2d$ doubly
+    stochastic block matrix.  The diagonal off-blocks encode the row and
+    column deficits.  A nonnegative lower-right block has row sums equal to
+    the original column sums and column sums equal to the original row sums;
+    it can be obtained from their normalized outer product when the total
+    matrix sum is nonzero, with the zero case treated separately.  Applying
+    Birkhoff's theorem to this completion and restricting permutation
+    matrices to the original block yields partial permutation matrices.
   \item Prove that the extreme points of the doubly substochastic set are
     exactly the partial permutation matrices, adapting the extreme-point
     argument from the stochastic case.

--- a/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
+++ b/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
@@ -1,0 +1,97 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Wolf Theorem~8.6 --- the Doubly-Substochastic Half of Birkhoff}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\section{The source statement}
+
+Wolf's Theorem~8.6 (``Birkhoff's theorem'') states two characterizations
+in the same theorem environment
+\cite[Chapter~8, Theorem~8.6]{Wolf2012Quantum}.  The local source is
+\path{Notes/WolfNoteTexSource/ch08_distance_measures.tex}, lines~263--266.
+
+\begin{enumerate}
+  \item[\textbf{DS}] The set of $d\times d$ doubly stochastic matrices is the
+    convex hull of the $d\times d$ permutation matrices, and its extreme
+    points are exactly the permutation matrices.
+  \item[\textbf{Sub}] The set of $d\times d$ doubly substochastic matrices is
+    the convex hull of the $d\times d$ partial permutation matrices, and its
+    extreme points are exactly the partial permutation matrices.
+\end{enumerate}
+
+\section{Formalized component}
+
+The doubly-stochastic half (DS) is formalized as two declarations:
+\begin{itemize}
+  \item \leanid{TNLean.wolf_birkhoff_doublyStochastic_convexHull}
+    --- the set of doubly stochastic matrices is the convex hull of the
+    permutation matrices, in \doclink{TNLean/Analysis/Birkhoff};
+  \item \leanid{TNLean.wolf_birkhoff_extremePoints_doublyStochastic}
+    --- the extreme points of the doubly stochastic matrices are exactly the
+    permutation matrices, likewise in \doclink{TNLean/Analysis/Birkhoff}.
+\end{itemize}
+Both are direct reuse of Mathlib's existing Birkhoff theorems
+(\leanid{doublyStochastic_eq_convexHull_permMatrix} and
+\leanid{extremePoints_doublyStochastic}) without reproof.
+
+\section{Missing component}
+
+The doubly-substochastic half (Sub) has not been formalized.  It requires
+the following definitions and results:
+\begin{enumerate}
+  \item Define the predicate ``doubly substochastic'': a nonnegative square
+    matrix whose row sums and column sums are each bounded by~$1$.
+  \item Define the partial permutation matrices: square $\{0,1\}$-matrices
+    with at most one~$1$ in each row and each column, all other entries~$0$.
+  \item Prove that the set of doubly substochastic matrices is the convex hull
+    of the partial permutation matrices, and that its extreme points are
+    exactly the partial permutation matrices.  This is the substochastic
+    analogue of Birkhoff's theorem.
+\end{enumerate}
+The substochastic polytope is larger (containing the stochastic polytope as a
+face) and the extreme-point argument differs from the stochastic case:
+permutation matrices are replaced by partial permutation matrices, and the
+support of a substochastic matrix may omit rows or columns.
+
+\section{Elimination plan}
+
+\begin{enumerate}
+  \item Port the predicate \leanid{doublyStochastic} from Mathlib to a
+    ``doubly substochastic'' predicate \leanid{doublySubstochastic}, borrowing
+    the nonnegativity, row-sum, and column-sum structure with $\le 1$ bounds
+    instead of~$=1$.
+  \item Define the set of partial permutation matrices over
+    $\operatorname{Fin} d$ and establish that each is doubly substochastic.
+  \item Carry out a Birkhoff-style decomposition: every doubly substochastic
+    matrix can be written as a convex combination of partial permutation
+    matrices.  The standard proof appends a dummy row and column to reduce to
+    the doubly stochastic case (the ``dilation trick''), which would reuse the
+    already-formalized Mathlib Birkhoff theorem.
+  \item Prove that the extreme points of the doubly substochastic set are
+    exactly the partial permutation matrices, adapting the extreme-point
+    argument from the stochastic case.
+\end{enumerate}
+
+\section{Verdict}
+
+This is a \emph{scope restriction}.  The doubly-stochastic half of Wolf
+Theorem~8.6 (the two Birkhoff characterizations for stochastic matrices) is
+fully formalized and linked to the blueprint.  The doubly-substochastic half
+(definition, polytope structure, and extreme partial-permutation-matrix
+characterization) is not yet formalized.  Tracking: \ghissue{3959}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
+++ b/docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex
@@ -74,14 +74,24 @@ support of a substochastic matrix may omit rows or columns.
   \item Define the set of partial permutation matrices over
     $\operatorname{Fin} d$ and establish that each is doubly substochastic.
   \item Carry out a Birkhoff-style decomposition by completing a
-    $d\times d$ doubly substochastic matrix to a $2d\times 2d$ doubly
-    stochastic block matrix.  The diagonal off-blocks encode the row and
-    column deficits.  A nonnegative lower-right block has row sums equal to
-    the original column sums and column sums equal to the original row sums;
-    it can be obtained from their normalized outer product when the total
-    matrix sum is nonzero, with the zero case treated separately.  Applying
-    Birkhoff's theorem to this completion and restricting permutation
-    matrices to the original block yields partial permutation matrices.
+    $d\times d$ doubly substochastic matrix $M$ to a $2d\times 2d$
+    doubly stochastic block matrix.  Write
+    \begin{align}
+      u_i&=\sum_j M_{ij}, & v_j&=\sum_i M_{ij}, &
+      r_i&=1-u_i, & c_j&=1-v_j, & s&=\sum_{i,j}M_{ij}.
+    \end{align}
+    For $s>0$, set $S_{ji}=v_ju_i/s$; for $s=0$, set $S=0$.  Then
+    \begin{align}
+      \sum_i S_{ji}&=v_j, & \sum_j S_{ji}&=u_i, \\
+      \widetilde M&=
+      \begin{pmatrix}M&\operatorname{diag}(r)\\
+      \operatorname{diag}(c)&S\end{pmatrix}, &
+      \sum_b\widetilde M_{ab}&=1, &
+      \sum_a\widetilde M_{ab}&=1.
+    \end{align}
+    Thus $\widetilde M$ is doubly stochastic.  Applying Birkhoff's theorem
+    to this completion and restricting permutation matrices to the original
+    block yields partial permutation matrices.
   \item Prove that the extreme points of the doubly substochastic set are
     exactly the partial permutation matrices, adapting the extreme-point
     argument from the stochastic case.


### PR DESCRIPTION
Closes LionSR/QICLean#305.

## Summary

Packages the doubly-stochastic half of Birkhoff's theorem from Wolf Chapter 8,
`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 263–266.

## Changes

- Adds `TNLean/Analysis/Birkhoff.lean`, directly specializing Mathlib's Birkhoff
  identities to real matrices indexed by `Fin d`:
  - `TNLean.wolf_birkhoff_doubly_stochastic_convex_hull`;
  - `TNLean.wolf_birkhoff_extreme_points_doubly_stochastic`.
- Adds a source-matched blueprint entry in
  `blueprint/src/chapter/ch19_entropy_majorization.tex`.
- Wires the new Lean and blueprint modules into their generated/parent aggregators.

## Scope

This closes only the doubly-stochastic half of the source environment. The
second, doubly-substochastic half and its partial-permutation extreme points
remain open under LionSR/QICLean#47. No majorization theorem is claimed here.

## Verification

- `lake env lean TNLean/Analysis/Birkhoff.lean`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- changed-file proof-integrity scan: no `sorry`, `admit`, `axiom`,
  `native_decide`, or `unsafeCast`
- `git diff origin/main...HEAD --check`

The worktree was seeded from hot main and reused the prebuilt Mathlib cache; no
Mathlib rebuild or cache-clearing command was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin Mathlib wrappers plus blueprint and gap documentation; no new proofs or changes to security-critical or data-handling code.
> 
> **Overview**
> Packages the **doubly-stochastic half** of Wolf Theorem 8.6 (Birkhoff) for real `d×d` matrices indexed by `Fin d`, without reproving Mathlib.
> 
> Adds `TNLean/Analysis/Birkhoff.lean` with `wolf_birkhoff_doublyStochastic_convexHull` and `wolf_birkhoff_extremePoints_doublyStochastic`, each proved by specializing existing Mathlib Birkhoff identities (`doublyStochastic_eq_convexHull_permMatrix` and `extremePoints_doublyStochastic`). The generated aggregator `TNLean/Analysis.lean` imports the new module.
> 
> The blueprint gains a **Birkhoff's theorem** section in `ch19_entropy_majorization.tex` (included from `ch19_entropy.tex`), with `\leanok` links to those declarations and an explicit note that the doubly-substochastic half of Wolf 8.6 is out of scope.
> 
> Documents the remaining **doubly-substochastic** half as a scope gap in `docs/paper-gaps/wolf_ch8_birkhoff_doubly_substochastic_gap.tex` (tracking LionSR/QICLean#47).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2015ceb8d08fa069f6af147f2c5d17b131393141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->