### PR TITLE
feat(Channel/Wigner): add pure-state extensionality

### DIFF
--- a/TNLean/Channel/Wigner/ProjectivePureState.lean
+++ b/TNLean/Channel/Wigner/ProjectivePureState.lean
@@ -25,7 +25,7 @@ Wigner rigidity.
 ## Main declarations
 
 * `Projectivization.pureStateMatrix`
-* `Projectivization.selfDot_smul_normalizedPureStateMatrix`
+* `Projectivization.star_dot_self_smul_normalizedPureStateMatrix`
 * `Projectivization.linearMap_eq_of_eq_on_pureStateMatrix`
 * `Projectivization.transitionProbability`
 * `Projectivization.transitionProbability_mk`
@@ -90,7 +90,7 @@ private theorem star_dot_self_ne_zero (v : Fin d → ℂ) (hv : v ≠ 0) :
 
 /-- Rescaling the normalized pure-state matrix of a nonzero vector by its
 squared norm recovers its rank-one self-outer-product. -/
-theorem selfDot_smul_normalizedPureStateMatrix (v : Fin d → ℂ) (hv : v ≠ 0) :
+theorem star_dot_self_smul_normalizedPureStateMatrix (v : Fin d → ℂ) (hv : v ≠ 0) :
     (star v ⬝ᵥ v) • normalizedPureStateMatrix v = Matrix.vecMulVec v (star v) := by
   rw [normalizedPureStateMatrix, smul_smul, mul_inv_cancel₀ (star_dot_self_ne_zero v hv),
     one_smul]
@@ -108,7 +108,7 @@ theorem linearMap_eq_of_eq_on_pureStateMatrix
     simp
   · have hp := h (Projectivization.mk ℂ v hv)
     rw [pureStateMatrix_mk] at hp
-    rw [← selfDot_smul_normalizedPureStateMatrix v hv, map_smul, map_smul, hp]
+    rw [← star_dot_self_smul_normalizedPureStateMatrix v hv, map_smul, map_smul, hp]
 
 private theorem normalizedPureStateMatrix_isOrthogonalProjection
     (v : Fin d → ℂ) (hv : v ≠ 0) :

--- a/TNLean/Channel/Wigner/ProjectivePureState.lean
+++ b/TNLean/Channel/Wigner/ProjectivePureState.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Projectivization.Basic
 import TNLean.Algebra.OrthogonalProjection
+import TNLean.Channel.WolfProps
 
 /-!
 # Projective rays as normalized pure-state matrices
@@ -24,6 +25,8 @@ Wigner rigidity.
 ## Main declarations
 
 * `Projectivization.pureStateMatrix`
+* `Projectivization.selfDot_smul_normalizedPureStateMatrix`
+* `Projectivization.linearMap_eq_of_eq_on_pureStateMatrix`
 * `Projectivization.transitionProbability`
 * `Projectivization.transitionProbability_mk`
 * `Projectivization.trace_pureStateMatrix_mul_pureStateMatrix`
@@ -84,6 +87,29 @@ private theorem star_dot_self_ne_zero (v : Fin d → ℂ) (hv : v ≠ 0) :
   have hw : w ≠ 0 := by simpa [w] using hv
   rw [← EuclideanSpace.inner_eq_star_dotProduct w w]
   exact inner_self_ne_zero (𝕜 := ℂ) |>.mpr hw
+
+/-- Rescaling the normalized pure-state matrix of a nonzero vector by its
+squared norm recovers its rank-one self-outer-product. -/
+theorem selfDot_smul_normalizedPureStateMatrix (v : Fin d → ℂ) (hv : v ≠ 0) :
+    (star v ⬝ᵥ v) • normalizedPureStateMatrix v = Matrix.vecMulVec v (star v) := by
+  rw [normalizedPureStateMatrix, smul_smul, mul_inv_cancel₀ (star_dot_self_ne_zero v hv),
+    one_smul]
+
+/-- Two complex-linear matrix maps that agree on every normalized pure-state
+matrix agree on all matrices. -/
+theorem linearMap_eq_of_eq_on_pureStateMatrix
+    (T S : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
+    (h : ∀ p : ℙ ℂ (Fin d → ℂ), T (pureStateMatrix p) = S (pureStateMatrix p)) :
+    T = S := by
+  apply WolfProps.linearMap_eq_of_eq_on_rankOne
+  intro v
+  by_cases hv : v = 0
+  · subst v
+    simp
+  · have hp := h (Projectivization.mk ℂ v hv)
+    rw [pureStateMatrix_mk] at hp
+    rw [← selfDot_smul_normalizedPureStateMatrix v hv, map_smul, map_smul, hp]
+
 private theorem normalizedPureStateMatrix_isOrthogonalProjection
     (v : Fin d → ℂ) (hv : v ≠ 0) :
     IsOrthogonalProjection (normalizedPureStateMatrix v) := by

--- a/TNLean/Channel/WolfProps.lean
+++ b/TNLean/Channel/WolfProps.lean
@@ -36,6 +36,8 @@ Wolf's *Quantum Channels & Operations: Guided Tour*:
   every rank-one self-outer-product ray is a scalar multiple of the identity.
 * `WolfProps.linearMap_eq_id_of_fixes_rankOne` — Proposition 2.3 (linear-algebra
   form): a linear map fixing every `vecMulVec v (star v)` is the identity.
+* `WolfProps.linearMap_eq_of_eq_on_rankOne` — two linear maps that agree on every
+  `vecMulVec v (star v)` are equal.
 * `WolfProps.channel_eq_id_of_fixes_pureStates` — Proposition 2.3 (channel form):
   a quantum channel fixing every pure-state projector is the identity.
 * `WolfProps.pureEnsembleDensity_eq_of_isometric_mixing` — Proposition 2.4
@@ -334,6 +336,23 @@ theorem linearMap_eq_id_of_fixes_rankOne
   have hc_one : c = 1 := by
     simpa [Matrix.vecMulVec_apply, Pi.star_apply, i₀] using hii
   simpa [hc_one] using hc
+
+/-- Two complex-linear matrix maps are equal if they agree on every rank-one
+self-outer-product `vecMulVec v (star v)`. -/
+theorem linearMap_eq_of_eq_on_rankOne
+    (T S : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (h : ∀ v : Fin D → ℂ,
+      T (Matrix.vecMulVec v (star v)) = S (Matrix.vecMulVec v (star v))) :
+    T = S := by
+  have hfix : T - S + LinearMap.id = LinearMap.id :=
+    linearMap_eq_id_of_fixes_rankOne (T - S + LinearMap.id) fun v ↦ by
+      simp only [LinearMap.add_apply, LinearMap.sub_apply, LinearMap.id_apply, h v,
+        sub_self, zero_add]
+  apply LinearMap.ext
+  intro X
+  have hX := LinearMap.congr_fun hfix X
+  simpa only [LinearMap.add_apply, LinearMap.sub_apply, LinearMap.id_apply,
+    add_eq_right, sub_eq_zero] using hX
 
 /-- **Proposition 2.3 (Wolf), pure-state form**: any linear map (in particular any
 quantum channel) leaving every pure-state projector `vecMulVec v (star v)`

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1358,6 +1358,44 @@ $v$ is multiplied by a nonzero scalar.
     factors of the outer product.
 \end{proof}
 
+\begin{lemma}[Normalized and unnormalized pure states]
+    \label{lem:self_dot_smul_normalized_pure_state_matrix}
+    \lean{Projectivization.selfDot_smul_normalizedPureStateMatrix}
+    \leanok
+    \uses{def:projective_pure_state_matrix}
+    For every nonzero $v\in\C^d$,
+    \begin{align}
+        \langle v,v\rangle P_{[v]}=\ketbra{v}{v}.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute the definition
+    $P_{[v]}=\langle v,v\rangle^{-1}\ketbra{v}{v}$ and use
+    $\langle v,v\rangle\ne0$.
+\end{proof}
+
+\begin{theorem}[Pure-state extensionality for linear maps]
+    \label{thm:linear_map_eq_of_eq_on_pure_state_matrix}
+    \lean{Projectivization.linearMap_eq_of_eq_on_pureStateMatrix}
+    \leanok
+    \uses{def:projective_pure_state_matrix}
+    Let $T,S:\MN{d}\to\MN{d}$ be complex-linear maps. If
+    \begin{align}
+        T(P_p)=S(P_p)
+    \end{align}
+    for every ray $p$ in $\C^d$, then $T=S$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:self_dot_smul_normalized_pure_state_matrix,
+      thm:linearMap_eq_of_eq_on_rankOne}
+    For $v\ne0$, multiply the equality at $p=[v]$ by
+    $\langle v,v\rangle$ to obtain
+    $T(\ketbra{v}{v})=S(\ketbra{v}{v})$. The same equality is immediate for
+    $v=0$. Rank-one extensionality now gives $T=S$.
+\end{proof}
+
 \begin{theorem}[Transition probability on representatives]
     \label{thm:projective_transition_probability_mk}
     \lean{Projectivization.transitionProbability_mk}

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1358,16 +1358,16 @@ $v$ is multiplied by a nonzero scalar.
     factors of the outer product.
 \end{proof}
 
-\begin{lemma}[Normalized and unnormalized pure states]
-    \label{lem:self_dot_smul_normalized_pure_state_matrix}
-    \lean{Projectivization.selfDot_smul_normalizedPureStateMatrix}
+\begin{theorem}[Normalized and unnormalized pure states]
+    \label{thm:star_dot_self_smul_normalized_pure_state_matrix}
+    \lean{Projectivization.star_dot_self_smul_normalizedPureStateMatrix}
     \leanok
     \uses{def:projective_pure_state_matrix}
     For every nonzero $v\in\C^d$,
     \begin{align}
         \langle v,v\rangle P_{[v]}=\ketbra{v}{v}.
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Substitute the definition
@@ -1388,7 +1388,7 @@ $v$ is multiplied by a nonzero scalar.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:self_dot_smul_normalized_pure_state_matrix,
+    \uses{thm:star_dot_self_smul_normalized_pure_state_matrix,
       thm:linearMap_eq_of_eq_on_rankOne}
     For $v\ne0$, multiply the equality at $p=[v]$ by
     $\langle v,v\rangle$ to obtain

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -551,6 +551,24 @@ The next three corollaries support channel decompositions and correspond to
     For $D=0$ the matrix algebra is trivial, so the conclusion also holds.
 \end{proof}
 
+\begin{theorem}[Rank-one extensionality for linear maps]
+    \label{thm:linearMap_eq_of_eq_on_rankOne}
+    \lean{WolfProps.linearMap_eq_of_eq_on_rankOne}
+    \leanok
+    Let $T,S:\MN{D}\to\MN{D}$ be complex-linear maps. If
+    \begin{align}
+        T(\ketbra{v}{v})=S(\ketbra{v}{v})
+    \end{align}
+    for every $v\in\C^D$, then $T=S$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:linearMap_eq_id_of_fixes_rankOne}
+    The map $T-S+\id$ fixes every matrix $\ketbra{v}{v}$, so
+    Theorem~\ref{thm:linearMap_eq_id_of_fixes_rankOne} gives
+    $T-S+\id=\id$. Hence $T=S$.
+\end{proof}
+
 \begin{definition}[Pure-state ensemble density]
     \label{def:pureEnsembleDensity}
     \lean{WolfProps.pureEnsembleDensity}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -72,7 +72,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 493, 535 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
-| `ch16_channel_representations_choi_and_kraus.tex` | L673 `tenkz` → `P-grid` | — | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- add `WolfProps.linearMap_eq_of_eq_on_rankOne` for two complex-linear matrix maps, reducing equality to `WolfProps.linearMap_eq_id_of_fixes_rankOne` through the map $T-S+\mathrm{id}$
- add `Projectivization.selfDot_smul_normalizedPureStateMatrix`, which recovers $|v\rangle\langle v|$ from the normalized pure-state matrix of every nonzero vector
- add `Projectivization.linearMap_eq_of_eq_on_pureStateMatrix`; the proof treats $v=0$ separately and rescales the projective equality for $v\ne0$ before applying rank-one extensionality
- keep the full transitive import cone Channel-level and MPS-free, with no dimension assumptions
- add exact Blueprint statements and proof dependencies in the Chapter 1 and channel-representation chapters; generated import aggregators remain current
- audit Mathlib and TNLean before implementation; neither contains an existing theorem with either extensionality statement

## Validation

- `lake build TNLean.Channel.WolfProps TNLean.Channel.Wigner.ProjectivePureState` — 3034 jobs
- `lake build` — 9957 jobs
- `lake build lint_style && lake exe lint_style --github`
- forbidden proof-integrity token diff guard, reader-facing prose guard, oversized-module guard, and numbered-module debt ratchet — pass
- import cone audit — 51 transitive project modules, 0 `TNLean.MPS` imports
- import aggregator tests/check — 50 generated files covering 1248 production modules
- Blueprint Lean sync/CI sync — 6635/6635 theorem-like entries complete
- `leanblueprint checkdecls` — pass
- double `lualatex` compile with `TEXINPUTS='../../tex/tenkz//:'` — pass, 0 undefined `Reference` warnings (baseline citation warnings only)
- theorem axiom checks — `[propext, Classical.choice, Quot.sound]` for all three declarations
- `git diff --check origin/main...HEAD` and clean worktree — pass

Closes LionSR/QICLean#304.
Advances LionSR/QICLean#295.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formalize core linear-map extensionality used in the Wolf/Wigner pure-state pipeline, but proofs are localized reductions to existing rank-one rigidity with no changes to runtime or security-sensitive code.
> 
> **Overview**
> Adds **extensionality lemmas** for complex-linear maps on matrix algebras: agreement on all rank-one self-outer-products `vecMulVec v (star v)` or on all normalized projective pure-state matrices `pureStateMatrix p` forces **equality of the maps**.
> 
> In `WolfProps`, `linearMap_eq_of_eq_on_rankOne` proves `T = S` by showing `T - S + id` fixes every rank-one projector, then invoking the existing Prop 2.3 identity lemma. In `ProjectivePureState`, `star_dot_self_smul_normalizedPureStateMatrix` links normalized rays to unnormalized `|v⟩⟨v|`, and `linearMap_eq_of_eq_on_pureStateMatrix` rescales the projective case (and treats `v = 0`) before calling rank-one extensionality. **Blueprint** statements and proof dependencies are added in Chapter 1 and the channel-representations chapter; a docs disposition line number is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d2816163ea642983f3f5b7d9fa684acb8e1c280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->