### PR TITLE
feat(Algebra): prove Hermitian unitary conjugacy

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -29,6 +29,7 @@ import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.FrobeniusHilbert
 import TNLean.Algebra.GramMatrixLI
 import TNLean.Algebra.HermitianHelpers
+import TNLean.Algebra.HermitianUnitaryConjugacy
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.Algebra.ListProduct

--- a/TNLean/Algebra/HermitianUnitaryConjugacy.lean
+++ b/TNLean/Algebra/HermitianUnitaryConjugacy.lean
@@ -10,17 +10,16 @@ import Mathlib.Analysis.Matrix.Spectrum
 
 Two finite complex Hermitian matrices with the same characteristic polynomial are unitarily
 conjugate. The proof identifies their ordered eigenvalue lists and compares their unitary spectral
-decompositions.
+decompositions. This is the spectral classification used in Wolf, Proposition 1.4.
 -/
-
-open scoped Matrix
 
 namespace Matrix.IsHermitian
 
-variable {n : Type*} [Fintype n] [DecidableEq n]
+variable {n : Type*} [Fintype n]
 
+open scoped Classical in
 /-- Two finite complex Hermitian matrices with the same characteristic polynomial are unitarily
-conjugate. -/
+conjugate, as used in Wolf, Proposition 1.4. -/
 theorem exists_unitary_conj_of_charpoly_eq {A B : Matrix n n ℂ} (hA : A.IsHermitian)
     (hB : B.IsHermitian) (hcharpoly : A.charpoly = B.charpoly) :
     ∃ U : Matrix.unitaryGroup n ℂ, B = (U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ) := by

--- a/TNLean/Algebra/HermitianUnitaryConjugacy.lean
+++ b/TNLean/Algebra/HermitianUnitaryConjugacy.lean
@@ -10,7 +10,7 @@ import Mathlib.Analysis.Matrix.Spectrum
 
 Two finite complex Hermitian matrices with the same characteristic polynomial are unitarily
 conjugate. The proof identifies their ordered eigenvalue lists and compares their unitary spectral
-decompositions. This is the spectral classification used in Wolf, Proposition 1.4.
+decompositions.
 -/
 
 namespace Matrix.IsHermitian
@@ -19,7 +19,7 @@ variable {n : Type*} [Fintype n]
 
 open scoped Classical in
 /-- Two finite complex Hermitian matrices with the same characteristic polynomial are unitarily
-conjugate, as used in Wolf, Proposition 1.4. -/
+conjugate. -/
 theorem exists_unitary_conj_of_charpoly_eq {A B : Matrix n n ℂ} (hA : A.IsHermitian)
     (hB : B.IsHermitian) (hcharpoly : A.charpoly = B.charpoly) :
     ∃ U : Matrix.unitaryGroup n ℂ, B = (U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ) := by
@@ -33,6 +33,5 @@ theorem exists_unitary_conj_of_charpoly_eq {A B : Matrix n n ℂ} (hA : A.IsHerm
   rw [← Unitary.conjStarAlgAut_symm]
   exact congrArg (Unitary.conjStarAlgAut ℂ (Matrix n n ℂ) hB.eigenvectorUnitary)
     ((Unitary.conjStarAlgAut ℂ (Matrix n n ℂ) hA.eigenvectorUnitary).symm_apply_apply _).symm
-
 
 end Matrix.IsHermitian

--- a/TNLean/Algebra/HermitianUnitaryConjugacy.lean
+++ b/TNLean/Algebra/HermitianUnitaryConjugacy.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Matrix.Spectrum
+
+/-!
+# Unitary conjugacy of Hermitian matrices
+
+Two finite complex Hermitian matrices with the same characteristic polynomial are unitarily
+conjugate. The proof identifies their ordered eigenvalue lists and compares their unitary spectral
+decompositions.
+-/
+
+open scoped Matrix
+
+namespace Matrix.IsHermitian
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Two finite complex Hermitian matrices with the same characteristic polynomial are unitarily
+conjugate. -/
+theorem exists_unitary_conj_of_charpoly_eq {A B : Matrix n n ℂ} (hA : A.IsHermitian)
+    (hB : B.IsHermitian) (hcharpoly : A.charpoly = B.charpoly) :
+    ∃ U : Matrix.unitaryGroup n ℂ, B = (U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ) := by
+  have heigenvalues : hA.eigenvalues = hB.eigenvalues :=
+    (hA.eigenvalues_eq_eigenvalues_iff hB).mpr hcharpoly
+  let U : Matrix.unitaryGroup n ℂ := hB.eigenvectorUnitary * star hA.eigenvectorUnitary
+  refine ⟨U, ?_⟩
+  change B = Unitary.conjStarAlgAut ℂ _ U A
+  rw [hA.spectral_theorem, hB.spectral_theorem]
+  simp only [U, heigenvalues, Unitary.conjStarAlgAut_mul_apply]
+  rw [← Unitary.conjStarAlgAut_symm]
+  exact congrArg (Unitary.conjStarAlgAut ℂ (Matrix n n ℂ) hB.eigenvectorUnitary)
+    ((Unitary.conjStarAlgAut ℂ (Matrix n n ℂ) hA.eigenvectorUnitary).symm_apply_apply _).symm
+
+
+end Matrix.IsHermitian

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1276,6 +1276,32 @@ $M_M(\C)$, $M=\sum_kd_k$.
     $\MN{p}$ gives $\widetilde T|_S=T$.
 \end{proof}
 
+\begin{theorem}[Hermitian matrices with the same characteristic polynomial]
+    \label{thm:hermitian_charpoly_unitary_conjugacy}
+    \lean{Matrix.IsHermitian.exists_unitary_conj_of_charpoly_eq}
+    \leanok
+    Let $A,B\in M_d(\C)$ be Hermitian. If their characteristic polynomials
+    agree, then there is a unitary matrix $U\in M_d(\C)$ such that
+    \begin{align}
+        B=UAU^\dagger.
+    \end{align}
+    This is the finite-dimensional spectral classification used in
+    \cite[Chapter~1, Proposition~1.4]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Equality of the characteristic polynomials gives equality of the ordered
+    eigenvalue lists. Write the two spectral decompositions as
+    \begin{align}
+        A=U_A D U_A^\dagger.
+    \end{align}
+    Likewise,
+    \begin{align}
+        B=U_B D U_B^\dagger.
+    \end{align}
+    Then $U=U_BU_A^\dagger$ is unitary and $B=UAU^\dagger$.
+\end{proof}
+
 \section{Pure states, projective rays, and Wigner's theorem}
 
 A nonzero vector $v\in\C^d$ determines a ray $[v]$ and the normalized

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1276,6 +1276,12 @@ $M_M(\C)$, $M=\sum_kd_k$.
     $\MN{p}$ gives $\widetilde T|_S=T$.
 \end{proof}
 
+\section{Set spectra and spectral multiplicities}
+
+For a finite Hermitian matrix, the characteristic polynomial records the
+ordered eigenvalues with their multiplicities. This determines the matrix up
+to unitary conjugation.
+
 \begin{theorem}[Hermitian matrices with the same characteristic polynomial]
     \label{thm:hermitian_charpoly_unitary_conjugacy}
     \lean{Matrix.IsHermitian.exists_unitary_conj_of_charpoly_eq}
@@ -1285,8 +1291,6 @@ $M_M(\C)$, $M=\sum_kd_k$.
     \begin{align}
         B=UAU^\dagger.
     \end{align}
-    This is the finite-dimensional spectral classification used in
-    \cite[Chapter~1, Proposition~1.4]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1299,7 +1303,14 @@ $M_M(\C)$, $M=\sum_kd_k$.
     \begin{align}
         B=U_B D U_B^\dagger.
     \end{align}
-    Then $U=U_BU_A^\dagger$ is unitary and $B=UAU^\dagger$.
+    Set
+    \begin{align}
+        U=U_BU_A^\dagger.
+    \end{align}
+    This matrix is unitary, and cancellation of $U_A^\dagger U_A$ gives
+    \begin{align}
+        B=UAU^\dagger.
+    \end{align}
 \end{proof}
 
 \section{Pure states, projective rays, and Wigner's theorem}


### PR DESCRIPTION
## What changed

- add the MPS-free Algebra theorem `Matrix.IsHermitian.exists_unitary_conj_of_charpoly_eq` for finite complex Hermitian matrices
- identify the ordered eigenvalue functions through `Matrix.IsHermitian.eigenvalues_eq_eigenvalues_iff`, then conjugate between the two spectral decompositions by the product of their eigenvector unitaries
- keep the statement free of dimension-positivity and explicit decidable-equality assumptions
- regenerate the Algebra import aggregator and place the project auxiliary result in Chapter 1's set-spectrum and spectral-multiplicity section

## Validation

- duplicate declaration audit across TNLean and Mathlib — no existing unitary-conjugacy theorem found
- `lake build TNLean.Algebra.HermitianUnitaryConjugacy TNLean.Algebra` — 3215 jobs
- `lake build` — 9958 jobs
- `lake build lint_style && lake exe lint_style --github` — pass
- proof-integrity diff guard and reader-facing prose guard — pass
- module-policy tests, oversized-module guard, and numbered-module debt ratchet — pass; 0 new violations
- import aggregator generator tests and `--check` — 50 generated files covering 1249 production modules
- tenkz Blueprint lint — 241 files, 0 findings
- Blueprint sync and CI sync — 6633/6633 theorem-like entries complete
- changed-declaration Blueprint coverage and `lake exe checkdecls blueprint/lean_decls` — pass
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'` — pass, 0 undefined cross-references (standalone citation warnings only)
- `git diff --check` and clean worktree — pass

Closes LionSR/QICLean#303.
Advances LionSR/QICLean#295.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New standalone algebra lemma and blueprint prose; no changes to auth, runtime paths, or existing proof APIs beyond a new import and aggregator entry.
> 
> **Overview**
> **Adds** `Matrix.IsHermitian.exists_unitary_conj_of_charpoly_eq`: for finite complex Hermitian `A` and `B`, matching characteristic polynomials yield a unitary `U` with `B = U A U†`. The proof matches ordered eigenvalues via `eigenvalues_eq_eigenvalues_iff`, then builds `U` from the two eigenvector unitaries and the spectral theorem.
> 
> **Registers** the result in `TNLean.Algebra` and **adds** a new blueprint section (“Set spectra and spectral multiplicities”) with theorem `thm:hermitian_charpoly_unitary_conjugacy` and a proof sketch aligned with Wolf Proposition 1.4 context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 992c2ca123fa832882b1034737671e361599d303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

