### PR TITLE
feat(Algebra): prove bounded products for nil matrix algebras

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -44,6 +44,7 @@ import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixTracePairing
 import TNLean.Algebra.NatInterval
 import TNLean.Algebra.NewtonGirard
+import TNLean.Algebra.NilMatrixSubalgebra
 import TNLean.Algebra.OperatorBlock
 import TNLean.Algebra.OperatorSchmidt
 import TNLean.Algebra.OrthogonalProjection

--- a/TNLean/Algebra/NilMatrixSubalgebra.lean
+++ b/TNLean/Algebra/NilMatrixSubalgebra.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 Sirui Lu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import Mathlib.Algebra.Lie.Engel
+import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.LinearAlgebra.Matrix.ToLin
+
+/-!
+# Nil subalgebras of finite-dimensional endomorphism algebras
+
+This file proves the finite-dimensional nil-matrix theorem: if every element of a possibly
+nonunital associative subalgebra of endomorphisms is nilpotent, then every mixed product whose
+length is the dimension of the space vanishes.  The proof applies Engel's theorem to the associated
+Lie algebra and bounds its lower central series by dimension.
+
+The bound is product length `finrank K V`, not a strict bound below it.
+
+**Local fix (arXiv:1703.09188, lines 405--426):** the paper's strict intermediate estimate is
+replaced by the dimension-sharp weak bound.  The source correction is documented in
+`docs/paper-gaps/mpu_nil_matrix_bound.tex`.  Classically, the algebra of strictly upper-triangular
+matrices shows that products of length one less than the dimension need not vanish; no formal
+sharpness example is asserted here.
+
+For `List.prod`, factors are multiplied from left to right.  Since multiplication in
+`Module.End K V` is composition, the rightmost factor acts first.
+-/
+
+open Module
+
+namespace LieModule
+
+variable (K L V : Type*) [Field K] [LieRing L] [LieAlgebra K L]
+  [AddCommGroup V] [Module K V] [LieRingModule L V] [LieModule K L V]
+  [FiniteDimensional K V]
+
+/-- A nilpotent Lie action on a finite-dimensional vector space has lower central series zero by
+step `finrank K V`. -/
+theorem lowerCentralSeries_finrank_eq_bot [IsNilpotent L V] :
+    lowerCentralSeries K L V (finrank K V) = ⊥ := by
+  let C : ℕ → LieSubmodule K L V := lowerCentralSeries K L V
+  have hstrict (k : ℕ) (hk : C k ≠ ⊥) : C (k + 1) < C k := by
+    refine lt_of_le_of_ne (antitone_lowerCentralSeries K L V (Nat.le_succ k)) ?_
+    intro heq
+    have hstable : ∀ m : ℕ, C (k + m) = C k := by
+      intro m
+      induction m with
+      | zero => simp
+      | succ m ih =>
+          change lowerCentralSeries K L V ((k + m) + 1) = C k
+          rw [lowerCentralSeries_succ]
+          change ⁅(⊤ : LieSubmodule K L L), C (k + m)⁆ = C k
+          rw [ih]
+          exact (show C (k + 1) = ⁅(⊤ : LieSubmodule K L L), C k⁆ by
+            simp only [C, lowerCentralSeries_succ]).symm.trans heq
+    obtain ⟨N, hN⟩ := IsNilpotent.nilpotent K L V
+    apply hk
+    rw [← hstable N]
+    exact eq_bot_iff.mpr <| hN ▸ antitone_lowerCentralSeries K L V (Nat.le_add_left N k)
+  have hdim : ∀ k : ℕ, C k ≠ ⊥ → finrank K (C k : Submodule K V) + k ≤ finrank K V := by
+    intro k
+    induction k with
+    | zero =>
+        intro _
+        change finrank K (⊤ : Submodule K V) + 0 ≤ finrank K V
+        simp
+    | succ k ih =>
+        intro hk
+        have hk' : C k ≠ ⊥ := fun h ↦ hk <| eq_bot_iff.mpr <|
+          h ▸ antitone_lowerCentralSeries K L V (Nat.le_succ k)
+        have hdrop := Submodule.finrank_lt_finrank_of_lt (hstrict k hk')
+        have hbound := ih hk'
+        omega
+  by_contra hne
+  have hpos : 0 < finrank K (C (finrank K V) : Submodule K V) :=
+    Module.finrank_pos_iff.mpr <| (LieSubmodule.nontrivial_iff_ne_bot K L V).mpr hne
+  have := hdim (finrank K V) hne
+  omega
+
+end LieModule
+
+namespace NonUnitalSubalgebra
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V]
+
+/-- A nonunital associative subalgebra of endomorphisms, regarded as a Lie subalgebra under the
+commutator bracket. -/
+def toLieSubalgebra (A : NonUnitalSubalgebra K (Module.End K V)) :
+    LieSubalgebra K (Module.End K V) where
+  carrier := A
+  add_mem' := A.add_mem
+  zero_mem' := A.zero_mem
+  smul_mem' := fun c _ hx ↦ A.smul_mem c hx
+  lie_mem' hx hy := by
+    rw [LieRing.of_associative_ring_bracket]
+    exact A.sub_mem (A.mul_mem hx hy) (A.mul_mem hy hx)
+
+variable [FiniteDimensional K V]
+
+/-- Every mixed product of `finrank K V` elements of a nil nonunital endomorphism subalgebra
+vanishes.
+
+The statement includes the zero-dimensional case: there `finrank K V = 0`, the empty product is
+the identity endomorphism, and that identity equals zero. -/
+theorem list_prod_eq_zero_of_forall_isNilpotent
+    (A : NonUnitalSubalgebra K (Module.End K V))
+    (hnil : ∀ a : A, IsNilpotent (a : Module.End K V))
+    (l : List (Module.End K V)) (hl : ∀ a ∈ l, a ∈ A)
+    (hlen : l.length = finrank K V) : l.prod = 0 := by
+  let L := A.toLieSubalgebra
+  have hLieNil : LieModule.IsNilpotent L V :=
+    (LieModule.isNilpotent_iff_forall' (R := K)).mpr fun a ↦ by
+      rw [LieSubalgebra.toEnd_eq, LieModule.toEnd_module_end]
+      change IsNilpotent (a : Module.End K V)
+      have ha : (a : Module.End K V) ∈ A := a.property
+      exact hnil (⟨a, ha⟩ : A)
+  letI : LieModule.IsNilpotent L V := hLieNil
+  have hmem (v : V) : l.prod v ∈ LieModule.lowerCentralSeries K L V l.length := by
+    clear hlen
+    induction l with
+    | nil => simp
+    | cons a l ih =>
+        simp only [List.prod_cons, List.length_cons, Module.End.mul_apply]
+        rw [LieModule.lowerCentralSeries_succ]
+        have ha : a ∈ L := by
+          change a ∈ A
+          exact hl a List.mem_cons_self
+        change ⁅(⟨a, ha⟩ : L), l.prod v⁆ ∈ _
+        exact LieSubmodule.lie_mem_lie (LieSubmodule.mem_top _) <|
+          ih fun b hb ↦ hl b (List.mem_cons_of_mem a hb)
+  ext v
+  rw [LinearMap.zero_apply, ← LieSubmodule.mem_bot (R := K) (L := L),
+    ← LieModule.lowerCentralSeries_finrank_eq_bot K L V, ← hlen]
+  exact hmem v
+
+end NonUnitalSubalgebra
+
+namespace NonUnitalSubalgebra
+
+variable {K n : Type*} [Field K] [Fintype n] [DecidableEq n]
+
+/-- Matrix form of the finite-dimensional nil-matrix theorem: every mixed product of
+`Fintype.card n` matrices in a nil nonunital matrix subalgebra is zero. -/
+theorem matrix_list_prod_eq_zero_of_forall_isNilpotent
+    (A : NonUnitalSubalgebra K (Matrix n n K))
+    (hnil : ∀ a : A, IsNilpotent (a : Matrix n n K))
+    (l : List (Matrix n n K)) (hl : ∀ a ∈ l, a ∈ A)
+    (hlen : l.length = Fintype.card n) : l.prod = 0 := by
+  let e : Matrix n n K ≃ₐ[K] Module.End K (n → K) := Matrix.toLinAlgEquiv'
+  let B : NonUnitalSubalgebra K (Module.End K (n → K)) := A.map e.toAlgHom.toNonUnitalAlgHom
+  have hBnil : ∀ b : B, IsNilpotent (b : Module.End K (n → K)) := by
+    intro b
+    obtain ⟨a, ha, hab⟩ := (NonUnitalSubalgebra.mem_map).mp b.property
+    rw [← hab]
+    exact (hnil ⟨a, ha⟩).map e
+  have hlB : ∀ b ∈ l.map e, b ∈ B := by
+    intro b hb
+    obtain ⟨a, ha, rfl⟩ := List.mem_map.mp hb
+    exact (NonUnitalSubalgebra.mem_map).mpr ⟨a, hl a ha, rfl⟩
+  apply e.injective
+  rw [map_zero, map_list_prod]
+  exact B.list_prod_eq_zero_of_forall_isNilpotent hBnil (l.map e) hlB <| by
+    simpa [Module.finrank_pi] using hlen
+
+end NonUnitalSubalgebra

--- a/TNLean/Algebra/NilMatrixSubalgebra.lean
+++ b/TNLean/Algebra/NilMatrixSubalgebra.lean
@@ -104,7 +104,11 @@ variable [FiniteDimensional K V]
 vanishes.
 
 The statement includes the zero-dimensional case: there `finrank K V = 0`, the empty product is
-the identity endomorphism, and that identity equals zero. -/
+the identity endomorphism, and that identity equals zero.
+
+**Local fix (arXiv:1703.09188, lines 405--426):** this theorem supplies the corrected weak bound at
+the ambient dimension in place of the source's unavailable strict bound.  The correction is
+documented in `docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
 theorem list_prod_eq_zero_of_forall_isNilpotent
     (A : NonUnitalSubalgebra K (Module.End K V))
     (hnil : ∀ a : A, IsNilpotent (a : Module.End K V))
@@ -143,7 +147,11 @@ namespace NonUnitalSubalgebra
 variable {K n : Type*} [Field K] [Fintype n] [DecidableEq n]
 
 /-- Matrix form of the finite-dimensional nil-matrix theorem: every mixed product of
-`Fintype.card n` matrices in a nil nonunital matrix subalgebra is zero. -/
+`Fintype.card n` matrices in a nil nonunital matrix subalgebra is zero.
+
+**Local fix (arXiv:1703.09188, lines 405--426):** this specialization gives the corrected matrix
+bound used by the source's blocking argument.  The correction is documented in
+`docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
 theorem matrix_list_prod_eq_zero_of_forall_isNilpotent
     (A : NonUnitalSubalgebra K (Matrix n n K))
     (hnil : ∀ a : A, IsNilpotent (a : Matrix n n K))

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -52,14 +52,14 @@ argument of \cite[lines~405--426]{Cirac2017MPU}.
     is therefore zero.
 \end{proof}
 
-\begin{corollary}[Nil matrix subalgebras]
-    \label{cor:mpu_nil_matrices}
+\begin{theorem}[Nil matrix subalgebras]
+    \label{thm:mpu_nil_matrices}
     \lean{NonUnitalSubalgebra.matrix_list_prod_eq_zero_of_forall_isNilpotent}
     \leanok
     Let $A$ be a not necessarily unital associative subalgebra of
     $n\times n$ matrices over a field.  If every matrix in $A$ is nilpotent,
     then every ordered product of $n$ matrices from $A$ vanishes.
-\end{corollary}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_nil_matrix}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4,6 +4,25 @@ This chapter develops the algebraic prerequisites for matrix product unitaries
 from arXiv:1703.09188.  The first result supplies the corrected nil-matrix
 bound used in the blocking argument at lines 405--426.
 
+\begin{lemma}[Dimension bound for a nilpotent Lie action]
+    \label{lem:mpu_lcs_finrank}
+    \lean{LieModule.lowerCentralSeries_finrank_eq_bot}
+    \leanok
+    Let a Lie algebra $L$ act nilpotently on a finite-dimensional vector space
+    $V$ over a field $K$.  Write $C_r(L,V)$ for the $r$th term of the lower
+    central series of this action.  Then
+    \[
+        C_{\dim_K(V)}(L,V)=0.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    As long as $C_r(L,V)$ is nonzero, nilpotency prevents two consecutive
+    terms from being equal: equality would make every later term equal, in
+    contradiction with eventual vanishing.  Thus each nonzero step strictly
+    lowers dimension, and at most $\dim_K(V)$ such steps are possible.
+\end{proof}
+
 \begin{theorem}[Finite-dimensional nil-matrix theorem]
     \label{thm:mpu_nil_matrix}
     \lean{NonUnitalSubalgebra.list_prod_eq_zero_of_forall_isNilpotent}
@@ -17,11 +36,20 @@ bound used in the blocking argument at lines 405--426.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:mpu_lcs_finrank}
     Regard $A$ as a Lie algebra under the commutator bracket.  Engel's theorem
-    makes $V$ a nilpotent Lie module.  Its lower central series strictly drops
-    at every nonzero step, so a dimension count forces the term indexed by
-    $\dim_K(V)$ to vanish.  An ordered product of $r$ elements of $A$, applied
-    to any vector, belongs to the $r$th term of this series.
+    makes $V$ a nilpotent Lie module, so the dimension bound gives
+    \[
+        C_{\dim_K(V)}(A,V)=0.
+    \]
+    For every nonnegative integer $r$, every ordered family
+    $a_1,\ldots,a_r$ in $A$, and every vector $v$ in $V$, induction on $r$
+    gives
+    \[
+        (a_1\cdots a_r)v\in C_r(A,V).
+    \]
+    Taking $r=\dim_K(V)$ proves that the product annihilates every vector and
+    is therefore zero.
 \end{proof}
 
 \begin{corollary}[Nil matrix subalgebras]
@@ -32,6 +60,14 @@ bound used in the blocking argument at lines 405--426.
     $n\times n$ matrices over a field.  If every matrix in $A$ is nilpotent,
     then every ordered product of $n$ matrices from $A$ vanishes.
 \end{corollary}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_nil_matrix}
+    Transport the matrix algebra to the endomorphisms of the coordinate space
+    through the standard algebra equivalence.  Nilpotency, membership, and the
+    ordered product are preserved, so the finite-dimensional nil-matrix
+    theorem applies; injectivity of the equivalence returns the zero matrix.
+\end{proof}
 
 The length $n$ is a weak bound, not a strict bound below $n$; the latter is
 false for strictly upper-triangular matrices.  This corrects the intermediate

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1,0 +1,39 @@
+\chapter{Matrix Product Unitaries}\label{ch:mpu}
+
+This chapter develops the algebraic prerequisites for matrix product unitaries
+from arXiv:1703.09188.  The first result supplies the corrected nil-matrix
+bound used in the blocking argument at lines 405--426.
+
+\begin{theorem}[Finite-dimensional nil-matrix theorem]
+    \label{thm:mpu_nil_matrix}
+    \lean{NonUnitalSubalgebra.list_prod_eq_zero_of_forall_isNilpotent}
+    \leanok
+    Let $V$ be a finite-dimensional vector space over a field $K$, and let
+    $A\subseteq\operatorname{End}_K(V)$ be a not necessarily unital
+    associative subalgebra.  If every element of $A$ is nilpotent, then every
+    ordered product of $\dim_K(V)$ elements of $A$ is zero.  The empty product
+    in dimension zero is also zero because the identity endomorphism of the
+    zero space is zero.
+\end{theorem}
+
+\begin{proof}\leanok
+    Regard $A$ as a Lie algebra under the commutator bracket.  Engel's theorem
+    makes $V$ a nilpotent Lie module.  Its lower central series strictly drops
+    at every nonzero step, so a dimension count forces the term indexed by
+    $\dim_K(V)$ to vanish.  An ordered product of $r$ elements of $A$, applied
+    to any vector, belongs to the $r$th term of this series.
+\end{proof}
+
+\begin{corollary}[Nil matrix subalgebras]
+    \label{cor:mpu_nil_matrices}
+    \lean{NonUnitalSubalgebra.matrix_list_prod_eq_zero_of_forall_isNilpotent}
+    \leanok
+    Let $A$ be a not necessarily unital associative subalgebra of
+    $n\times n$ matrices over a field.  If every matrix in $A$ is nilpotent,
+    then every ordered product of $n$ matrices from $A$ vanishes.
+\end{corollary}
+
+The length $n$ is a weak bound, not a strict bound below $n$; the latter is
+false for strictly upper-triangular matrices.  This corrects the intermediate
+strict inequality in the cited blocking argument without changing its final
+strict $D^4$ estimate.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1,8 +1,8 @@
 \chapter{Matrix Product Unitaries}\label{ch:mpu}
 
-This chapter develops the algebraic prerequisites for matrix product unitaries
-from arXiv:1703.09188.  The first result supplies the corrected nil-matrix
-bound used in the blocking argument at lines 405--426.
+This chapter develops the algebraic prerequisites for matrix product unitaries.
+The first result supplies the corrected nil-matrix bound used in the blocking
+argument of \cite[lines~405--426]{Cirac2017MPU}.
 
 \begin{theorem}[Dimension bound for a nilpotent Lie action]
     \label{thm:mpu_lcs_finrank}
@@ -71,5 +71,5 @@ bound used in the blocking argument at lines 405--426.
 
 The length $n$ is a weak bound, not a strict bound below $n$; the latter is
 false for strictly upper-triangular matrices.  This corrects the intermediate
-strict inequality in the cited blocking argument without changing its final
-strict $D^4$ estimate.
+strict inequality in \cite[lines~405--426]{Cirac2017MPU} without changing its
+final strict $D^4$ estimate.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4,17 +4,17 @@ This chapter develops the algebraic prerequisites for matrix product unitaries
 from arXiv:1703.09188.  The first result supplies the corrected nil-matrix
 bound used in the blocking argument at lines 405--426.
 
-\begin{lemma}[Dimension bound for a nilpotent Lie action]
-    \label{lem:mpu_lcs_finrank}
+\begin{theorem}[Dimension bound for a nilpotent Lie action]
+    \label{thm:mpu_lcs_finrank}
     \lean{LieModule.lowerCentralSeries_finrank_eq_bot}
     \leanok
     Let a Lie algebra $L$ act nilpotently on a finite-dimensional vector space
     $V$ over a field $K$.  Write $C_r(L,V)$ for the $r$th term of the lower
     central series of this action.  Then
-    \[
-        C_{\dim_K(V)}(L,V)=0.
-    \]
-\end{lemma}
+    \begin{align}
+        C_{\dim_K(V)}(L,V) &= 0.
+    \end{align}
+\end{theorem}
 
 \begin{proof}\leanok
     As long as $C_r(L,V)$ is nonzero, nilpotency prevents two consecutive
@@ -36,18 +36,18 @@ bound used in the blocking argument at lines 405--426.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpu_lcs_finrank}
+    \uses{thm:mpu_lcs_finrank}
     Regard $A$ as a Lie algebra under the commutator bracket.  Engel's theorem
     makes $V$ a nilpotent Lie module, so the dimension bound gives
-    \[
-        C_{\dim_K(V)}(A,V)=0.
-    \]
+    \begin{align}
+        C_{\dim_K(V)}(A,V) &= 0.
+    \end{align}
     For every nonnegative integer $r$, every ordered family
     $a_1,\ldots,a_r$ in $A$, and every vector $v$ in $V$, induction on $r$
     gives
-    \[
-        (a_1\cdots a_r)v\in C_r(A,V).
-    \]
+    \begin{align}
+        (a_1\cdots a_r)v &\in C_r(A,V).
+    \end{align}
     Taking $r=\dim_K(V)$ proves that the product annihilates every vector and
     is therefore zero.
 \end{proof}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -25,6 +25,7 @@
 \input{chapter/ch20_mpdo}
 \input{chapter/ch26_mps_rfp}
 \input{chapter/ch27_channel_asymptotics}
+\input{chapter/ch28_mpu}
 \input{chapter/ch21_mpdo_rfp}
 \input{chapter/ch21_mpdo_rfp_algebraic}
 % \input{chapter/ch22_periodic_ft}

--- a/docs/paper-gaps/mpu_nil_matrix_bound.tex
+++ b/docs/paper-gaps/mpu_nil_matrix_bound.tex
@@ -1,17 +1,89 @@
-% Source correction for arXiv:1703.09188, lines 405--426.
-\section*{Nil-matrix product-length bound in the MPU blocking argument}
+\documentclass{article}
 
-The blocking argument in arXiv:1703.09188, lines 405--426, invokes
-Nagata--Higman and Razmyslov to claim an intermediate nilpotency length
-$J'<D^2$.  Those general nil-algebra results do not supply this strict linear
-bound.  In the concrete situation the algebra acts on a complex vector space
-of dimension $D^2$, so the classical finite-dimensional nil-matrix theorem
-(Levitzki's theorem, equivalently the simultaneous strict-triangularization
-corollary of Engel's theorem) gives the correct bound $J'\leq D^2$.
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
 
-The strict inequality is unavailable in general: strictly upper-triangular
-$n\times n$ matrices admit nonzero mixed products of length $n-1$.  The final
-estimate needed by the paper remains strict because its earlier Jordan-block
-length satisfies $J<D^2$, hence $JJ'<D^4$.  The formalization proves product
-length exactly the ambient dimension and does not claim a formalized
-strict-upper-triangular sharpness example.
+\input{command}
+
+\title{Nil-Matrix Product-Length Bound in the MPU Blocking Argument}
+\author{}
+\date{2026-08-08}
+
+\begin{document}
+\maketitle
+
+\section{The source assertion}
+
+The blocking argument for matrix product unitaries in
+\cite[lines~405--426]{Cirac2017MPU} considers a possibly nonunital associative
+subalgebra $A$ of the endomorphisms of a complex vector space of dimension
+$D^2$.  Every element of $A$ is nilpotent.  The source invokes results of
+Nagata--Higman and Razmyslov to choose a mixed-product length $J'$ satisfying
+\begin{align}
+  J' &< D^2,
+  & A^{J'} &= 0.                                         \label{eq:source-bound}
+\end{align}
+Here $A^{J'}=0$ means that every ordered product of $J'$ elements of $A$
+vanishes.
+
+The cited nil-algebra references are Nagata, \emph{Journal of the Mathematical
+Society of Japan} 4 (1952), 296--301; Higman, \emph{Proceedings of the
+Cambridge Philosophical Society} 52 (1956), 1--4; and Razmyslov,
+\emph{Izvestiya Akademii Nauk SSSR, Seriya Matematicheskaya} 38 (1974).
+These results provide nilpotency theorems and general quantitative bounds, but
+do not supply the strict linear estimate in \eqref{eq:source-bound}.
+
+\section{The corrected nil-matrix bound}
+
+Let $V$ be an $n$-dimensional vector space over a field and let
+$A\subseteq\operatorname{End}(V)$ be a possibly nonunital associative
+subalgebra consisting entirely of nilpotent endomorphisms.  The classical
+finite-dimensional nil-matrix theorem, also known as Levitzki's theorem and
+equivalently obtainable from Engel's theorem by simultaneous strict
+triangularization, gives
+\begin{align}
+  A^n &= 0.                                               \label{eq:corrected-bound}
+\end{align}
+Thus the concrete transfer-space algebra in the source satisfies
+\begin{align}
+  J' &\leq D^2.                                          \label{eq:transfer-bound}
+\end{align}
+The weak inequality is sharp in general: the algebra of strictly
+upper-triangular $n\times n$ matrices admits a nonzero ordered product of
+$n-1$ matrix units.  Accordingly, no general replacement of
+\eqref{eq:transfer-bound} by $J'<D^2$ is available.
+
+\section{Effect on the blocking estimate}
+
+The source has already obtained a first Jordan-block length $J$ satisfying
+$J<D^2$.  Combining this strict inequality with the corrected weak bound gives
+\begin{align}
+  JJ' &< D^2D^2 = D^4.                                   \label{eq:final-bound}
+\end{align}
+Therefore the final strict blocking estimate is unchanged.  Only the
+intermediate claim $J'<D^2$ is replaced by $J'\leq D^2$.
+
+The formal development proves \eqref{eq:corrected-bound} for arbitrary
+finite-dimensional vector spaces and then transports it to square matrices.
+\footnote{Formal declarations:
+  \leanid{NonUnitalSubalgebra.list_prod_eq_zero_of_forall_isNilpotent} and
+  \leanid{NonUnitalSubalgebra.matrix_list_prod_eq_zero_of_forall_isNilpotent}
+  in \doclink{TNLean/Algebra/NilMatrixSubalgebra}.}
+It includes the zero-dimensional case and fixes the ordered-product convention.
+The strict-upper-triangular example is recorded here only as the mathematical
+reason that a strict bound is unavailable; no formalization of that example is
+claimed.
+
+\section{Classification}
+
+\textbf{Verdict: local correction.}  Replacing the unsupported intermediate
+strict bound by the finite-dimensional nil-matrix bound preserves every
+hypothesis and conclusion needed by the surrounding blocking argument, and
+\eqref{eq:final-bound} retains the source's final strict estimate.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/mpu_nil_matrix_bound.tex
+++ b/docs/paper-gaps/mpu_nil_matrix_bound.tex
@@ -1,0 +1,17 @@
+% Source correction for arXiv:1703.09188, lines 405--426.
+\section*{Nil-matrix product-length bound in the MPU blocking argument}
+
+The blocking argument in arXiv:1703.09188, lines 405--426, invokes
+Nagata--Higman and Razmyslov to claim an intermediate nilpotency length
+$J'<D^2$.  Those general nil-algebra results do not supply this strict linear
+bound.  In the concrete situation the algebra acts on a complex vector space
+of dimension $D^2$, so the classical finite-dimensional nil-matrix theorem
+(Levitzki's theorem, equivalently the simultaneous strict-triangularization
+corollary of Engel's theorem) gives the correct bound $J'\leq D^2$.
+
+The strict inequality is unavailable in general: strictly upper-triangular
+$n\times n$ matrices admit nonzero mixed products of length $n-1$.  The final
+estimate needed by the paper remains strict because its earlier Jordan-block
+length satisfies $J<D^2$, hence $JJ'<D^4$.  The formalization proves product
+length exactly the ambient dimension and does not claim a formalized
+strict-upper-triangular sharpness example.

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -268,3 +268,18 @@
   eprint       = {1306.3142},
   eprinttype   = {arxiv},
 }
+
+@article{Cirac2017MPU,
+  author       = {Cirac, J. Ignacio and P{\'e}rez-Garc{\'i}a, David and
+                  Schuch, Norbert and Verstraete, Frank},
+  title        = {Matrix Product Unitaries: Structure, Symmetries, and
+                  Topological Invariants},
+  journal      = {Journal of Statistical Mechanics: Theory and Experiment},
+  volume       = {2017},
+  number       = {8},
+  pages        = {083105},
+  year         = {2017},
+  doi          = {10.1088/1742-5468/aa7e55},
+  eprint       = {1703.09188},
+  eprinttype   = {arxiv},
+}


### PR DESCRIPTION
## Summary

- prove that the lower central series of a finite-dimensional nilpotent Lie module vanishes by its ambient dimension
- apply Engel's theorem to a nil `NonUnitalSubalgebra` of endomorphisms and prove every ordered mixed product of `finrank K V` elements vanishes
- specialize the result to arbitrary square matrices, including the zero-dimensional case
- document product order and the correction from the paper's unavailable strict intermediate bound to the dimension-sharp weak bound
- add the MPU blueprint entry and source-correction note

## Mathematical route

A nonunital associative endomorphism subalgebra is closed under commutators, hence defines a Lie subalgebra. `LieModule.isNilpotent_iff_forall'` turns elementwise nilpotency into nilpotency of its action. Every nonzero step of the lower central series then drops strictly; finite-dimensionality forces the term at `finrank K V` to be bottom. A list product of length `r`, applied to a vector, lies in the `r`th lower-central-series term.

`List.prod` multiplies left-to-right, while endomorphism multiplication is composition, so the rightmost factor acts first.

## Source correction

The strict intermediate estimate printed in arXiv:1703.09188, lines 405--426, is replaced by the correct bound `J' ≤ D²`. The final paper estimate remains strict because the earlier factor satisfies `J < D²`. This is recorded in `docs/paper-gaps/mpu_nil_matrix_bound.tex`; no formal strict-upper-triangular sharpness example is claimed.

## Checks

- `lake env lean TNLean/Algebra/NilMatrixSubalgebra.lean`
- `lake env lean TNLean/Algebra.lean`
- proof-integrity grep for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`
- `git diff --check`

Closes #5720
Prerequisite for #5707

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib algebra proofs and documentation only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds formal proofs that **nilpotent Lie actions** vanish on the lower central series at ambient dimension, and that **every ordered product of `finrank` (or `n` matrix) elements** in a nil nonunital subalgebra is zero—via Engel's theorem and induction on list products.
> 
> The MPU blocking argument in Cirac et al. (arXiv:1703.09188) used an unsupported strict bound `J' < D²`; this PR supplies the **dimension-sharp weak bound** `J' ≤ D²` and documents that the **final strict `D⁴` estimate** is unchanged. New `TNLean/Algebra/NilMatrixSubalgebra.lean`, blueprint chapter `ch28_mpu`, and `docs/paper-gaps/mpu_nil_matrix_bound.tex` record the correction; `Cirac2017MPU` is added to paper-gaps references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28581a8c4071b9095e94a10b9a9991536c2305a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->