### PR TITLE
feat(Channel): prove Wolf projective pinching inequality

### DIFF
--- a/TNLean/Channel/POVM.lean
+++ b/TNLean/Channel/POVM.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.OrthogonalProjection
 import TNLean.Channel.Basic
-import TNLean.Channel.Stinespring
 import TNLean.Channel.Semigroup.CPClosure
+import TNLean.Channel.Stinespring
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
 
@@ -41,11 +42,12 @@ larger (dilated) Hilbert space via an isometry (Wolf Eq. (2.16)).
 * `POVM.ofPSDResolutionOfIdentity` — converse direction: every isometry together
   with a PSD resolution of identity on the dilated space yields a POVM via
   `E_i := Vᴴ P_i V`.
+* `projectivePOVM_pinching` — Wolf Eq. (8.56), the projective pinching inequality.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 2.6
-  (Neumark's theorem)][Wolf2012QChannels]
+  (Neumark's theorem) and Chapter 8, Eq. (8.56)][Wolf2012QChannels]
 -/
 
 open scoped Matrix MatrixOrder ComplexOrder
@@ -373,3 +375,106 @@ noncomputable def posteriorState (i : Fin n)
   (I.probability i rho)⁻¹ • I.maps i rho
 
 end Instrument
+
+/-! ### Projective pinching inequality (Wolf Eq. (8.56)) -/
+
+/-- Expansion: (A - B)·ρ·(A - B) = A·ρ·A + B·ρ·B - A·ρ·B - B·ρ·A -/
+private lemma expand_pinching_term {D : ℕ} (A B ρ : Matrix (Fin D) (Fin D) ℂ) :
+    (A - B) * ρ * (A - B) = A * ρ * A + B * ρ * B - A * ρ * B - B * ρ * A := by
+  noncomm_ring
+
+/-- Algebraic identity behind the projective pinching inequality. -/
+private lemma pinching_difference_identity {D k : ℕ}
+    (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (P : Fin k → Matrix (Fin D) (Fin D) ℂ)
+    (hPsum : ∑ i : Fin k, P i = 1) :
+    (∑ i : Fin k, ∑ j : Fin k, (P i - P j) * ρ * (P i - P j)) =
+      (2 : ℂ) • ((k : ℂ) • (∑ i : Fin k, P i * ρ * P i) - ρ) := by
+  have h_cross : (∑ i : Fin k, ∑ j : Fin k, P i * ρ * P j) = ρ := by
+    calc
+      _ = (∑ i : Fin k, P i * ρ) * (∑ j : Fin k, P j) := by
+        simpa only [Matrix.mul_assoc] using
+          (Finset.sum_mul_sum Finset.univ Finset.univ (fun i ↦ P i * ρ) P).symm
+      _ = ((∑ i : Fin k, P i) * ρ) * (∑ j : Fin k, P j) := by
+        congr 1
+        exact (Finset.sum_mul Finset.univ P ρ).symm
+      _ = ρ := by rw [hPsum, Matrix.one_mul, Matrix.mul_one]
+  have h_cross' : (∑ i : Fin k, ∑ j : Fin k, P j * ρ * P i) = ρ := by
+    calc
+      _ = ∑ j : Fin k, ∑ i : Fin k, P j * ρ * P i :=
+        @Finset.sum_comm (Fin k) (Matrix (Fin D) (Fin D) ℂ) (Fin k) _
+          Finset.univ Finset.univ (fun i j ↦ P j * ρ * P i)
+      _ = ρ := h_cross
+  have h_diag :
+      (∑ i : Fin k, ∑ _j : Fin k, P i * ρ * P i) =
+        (k : ℂ) • (∑ i : Fin k, P i * ρ * P i) := by
+    simp only [Finset.sum_const, Finset.card_fin]
+    simp_rw [← Nat.cast_smul_eq_nsmul ℂ k]
+    rw [Finset.smul_sum]
+  have h_diag' :
+      (∑ _i : Fin k, ∑ j : Fin k, P j * ρ * P j) =
+        (k : ℂ) • (∑ i : Fin k, P i * ρ * P i) := by
+    rw [Finset.sum_comm]
+    exact h_diag
+  calc
+    (∑ i : Fin k, ∑ j : Fin k, (P i - P j) * ρ * (P i - P j)) =
+        ∑ i : Fin k, ∑ j : Fin k,
+          (P i * ρ * P i + P j * ρ * P j - P i * ρ * P j - P j * ρ * P i) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      apply Finset.sum_congr rfl
+      intro j _
+      exact expand_pinching_term (P i) (P j) ρ
+    _ = (∑ i : Fin k, ∑ _j : Fin k, P i * ρ * P i) +
+          (∑ _i : Fin k, ∑ j : Fin k, P j * ρ * P j) -
+          (∑ i : Fin k, ∑ j : Fin k, P i * ρ * P j) -
+          (∑ i : Fin k, ∑ j : Fin k, P j * ρ * P i) := by
+      simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+    _ = _ := by rw [h_diag, h_diag', h_cross, h_cross']; module
+
+/-- **Wolf Eq. (8.56): projective pinching inequality.**
+Let `ρ` be a density operator on `M_D(ℂ)` and `{P_i}_{i = 1,…,k}` a
+projective POVM (each `P_i` is an orthogonal projection and they sum to
+the identity).  Define the pinching map `T(ρ) := ∑_i P_i ρ P_i`.
+Then `ρ ≤ k · T(ρ)` in the PSD order.
+
+Source: M. Wolf, *Quantum Channels & Operations: Guided Tour*, Eq. (8.56);
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 681–700. -/
+theorem projectivePOVM_pinching {D k : ℕ}
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ_dm : ρ ∈ densityMatrices D)
+    (P : Fin k → Matrix (Fin D) (Fin D) ℂ)
+    (hPproj : ∀ i, IsOrthogonalProjection (P i))
+    (hPsum : ∑ i : Fin k, P i = 1) :
+    ρ ≤ (k : ℂ) • (∑ i : Fin k, P i * ρ * P i) := by
+  rw [Matrix.le_iff]
+  have hρ_psd : ρ.PosSemidef := hρ_dm.1
+  have hPherm : ∀ i, (P i).IsHermitian := fun i => (hPproj i).1
+  have h_identity := pinching_difference_identity ρ P hPsum
+  have h_diff : (k : ℂ) • (∑ i : Fin k, P i * ρ * P i) - ρ = (2⁻¹ : ℂ) •
+      (∑ i : Fin k, ∑ j : Fin k, (P i - P j) * ρ * (P i - P j)) := by
+    calc
+      (k : ℂ) • (∑ i : Fin k, P i * ρ * P i) - ρ =
+          (2⁻¹ : ℂ) •
+            ((2 : ℂ) • ((k : ℂ) • (∑ i : Fin k, P i * ρ * P i) - ρ)) := by
+        simp
+      _ = (2⁻¹ : ℂ) • (∑ i : Fin k, ∑ j : Fin k,
+          (P i - P j) * ρ * (P i - P j)) := by rw [h_identity]
+  rw [h_diff]
+  -- Each summand is PSD
+  have h_summand_psd : ∀ i j : Fin k,
+      ((P i - P j) * ρ * (P i - P j)).PosSemidef := by
+    intro i j
+    have h_diff_herm : (P i - P j).IsHermitian := (hPherm i).sub (hPherm j)
+    have h := hρ_psd.mul_mul_conjTranspose_same (P i - P j)
+    simpa [h_diff_herm.eq] using h
+  -- Sum of PSD matrices is PSD
+  have h_sum_psd : (∑ i : Fin k, ∑ j : Fin k,
+      (P i - P j) * ρ * (P i - P j)).PosSemidef :=
+    Matrix.posSemidef_sum (Finset.univ : Finset (Fin k)) (fun i _ =>
+      Matrix.posSemidef_sum (Finset.univ : Finset (Fin k)) (fun j _ => h_summand_psd i j))
+  -- (1/2) · (PSD sum) is PSD because 2⁻¹ ≥ 0 in ℂ
+  refine h_sum_psd.smul ?_
+  have h_half_nonneg : (0 : ℂ) ≤ (2⁻¹ : ℂ) := by
+    have h : (0 : ℝ) ≤ 1 / 2 := by norm_num
+    convert RCLike.ofReal_nonneg.mpr h using 1; norm_num
+  exact h_half_nonneg

--- a/TNLean/Channel/POVM.lean
+++ b/TNLean/Channel/POVM.lean
@@ -378,12 +378,8 @@ end Instrument
 
 /-! ### Projective pinching inequality (Wolf Eq. (8.56)) -/
 
-/-- Expansion: (A - B)·ρ·(A - B) = A·ρ·A + B·ρ·B - A·ρ·B - B·ρ·A -/
-private lemma expand_pinching_term {D : ℕ} (A B ρ : Matrix (Fin D) (Fin D) ℂ) :
-    (A - B) * ρ * (A - B) = A * ρ * A + B * ρ * B - A * ρ * B - B * ρ * A := by
-  noncomm_ring
-
-/-- Algebraic identity behind the projective pinching inequality. -/
+/-- Algebraic identity behind the projective pinching inequality:
+`∑_{i,j} (P_i - P_j) ρ (P_i - P_j) = 2 (k T(ρ) - ρ)` where `T(ρ) = ∑_i P_i ρ P_i`. -/
 private lemma pinching_difference_identity {D k : ℕ}
     (ρ : Matrix (Fin D) (Fin D) ℂ)
     (P : Fin k → Matrix (Fin D) (Fin D) ℂ)
@@ -400,11 +396,8 @@ private lemma pinching_difference_identity {D k : ℕ}
         exact (Finset.sum_mul Finset.univ P ρ).symm
       _ = ρ := by rw [hPsum, Matrix.one_mul, Matrix.mul_one]
   have h_cross' : (∑ i : Fin k, ∑ j : Fin k, P j * ρ * P i) = ρ := by
-    calc
-      _ = ∑ j : Fin k, ∑ i : Fin k, P j * ρ * P i :=
-        @Finset.sum_comm (Fin k) (Matrix (Fin D) (Fin D) ℂ) (Fin k) _
-          Finset.univ Finset.univ (fun i j ↦ P j * ρ * P i)
-      _ = ρ := h_cross
+    rw [Finset.sum_comm]
+    exact h_cross
   have h_diag :
       (∑ i : Fin k, ∑ _j : Fin k, P i * ρ * P i) =
         (k : ℂ) • (∑ i : Fin k, P i * ρ * P i) := by
@@ -414,22 +407,19 @@ private lemma pinching_difference_identity {D k : ℕ}
   have h_diag' :
       (∑ _i : Fin k, ∑ j : Fin k, P j * ρ * P j) =
         (k : ℂ) • (∑ i : Fin k, P i * ρ * P i) := by
-    rw [Finset.sum_comm]
-    exact h_diag
+    rw [Finset.sum_comm]; exact h_diag
   calc
     (∑ i : Fin k, ∑ j : Fin k, (P i - P j) * ρ * (P i - P j)) =
         ∑ i : Fin k, ∑ j : Fin k,
           (P i * ρ * P i + P j * ρ * P j - P i * ρ * P j - P j * ρ * P i) := by
-      apply Finset.sum_congr rfl
-      intro i _
-      apply Finset.sum_congr rfl
-      intro j _
-      exact expand_pinching_term (P i) (P j) ρ
+      refine Finset.sum_congr rfl fun i _ =>
+        Finset.sum_congr rfl fun j _ => ?_
+      noncomm_ring
     _ = (∑ i : Fin k, ∑ _j : Fin k, P i * ρ * P i) +
           (∑ _i : Fin k, ∑ j : Fin k, P j * ρ * P j) -
           (∑ i : Fin k, ∑ j : Fin k, P i * ρ * P j) -
           (∑ i : Fin k, ∑ j : Fin k, P j * ρ * P i) := by
-      simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+      simp [Finset.sum_add_distrib, Finset.sum_sub_distrib]
     _ = _ := by rw [h_diag, h_diag', h_cross, h_cross']; module
 
 /-- **Wolf Eq. (8.56): projective pinching inequality.**
@@ -475,6 +465,7 @@ theorem projectivePOVM_pinching {D k : ℕ}
   -- (1/2) · (PSD sum) is PSD because 2⁻¹ ≥ 0 in ℂ
   refine h_sum_psd.smul ?_
   have h_half_nonneg : (0 : ℂ) ≤ (2⁻¹ : ℂ) := by
-    have h : (0 : ℝ) ≤ 1 / 2 := by norm_num
-    convert RCLike.ofReal_nonneg.mpr h using 1; norm_num
+    have h : (0 : ℝ) ≤ 1/2 := by norm_num
+    convert RCLike.ofReal_nonneg.mpr h using 1
+    norm_num
   exact h_half_nonneg

--- a/blueprint/src/chapter/ch19_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch19_entropy_trace_norm.tex
@@ -498,11 +498,11 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \section{Projective pinching}
 
-\begin{lemma}[Projective pinching inequality]
-    \label{lem:projective_povm_pinching}
+\begin{theorem}[Projective pinching inequality]
+    \label{thm:projective_povm_pinching}
     \lean{projectivePOVM_pinching}
     \leanok
-    \uses{def:density_matrices}
+    \uses{def:density_matrices, def:orthogonal_projection_channel}
     Let $\rho\in\MN{d}$ be a density matrix and let
     $P_1,\ldots,P_k\in\MN{d}$ be orthogonal projections satisfying
     $\sum_{i=1}^k P_i=\Id$.  Define
@@ -515,7 +515,7 @@ Theorem~\ref{thm:trace_norm_abs}.
         \label{eq:projective_pinching}
     \end{align}
     This is \cite[Chapter~8, Eq.~(8.56)]{Wolf2012Quantum}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     For $A_{ij}=P_i-P_j$, positivity of $\rho$ gives

--- a/blueprint/src/chapter/ch19_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch19_entropy_trace_norm.tex
@@ -495,3 +495,36 @@ Theorem~\ref{thm:trace_norm_abs}.
     $\rho_1-\rho_2$ is Hermitian as a difference of positive semidefinite
     matrices, so Theorem~\ref{thm:trace_norm_contractivity} applies.
 \end{proof}
+
+\section{Projective pinching}
+
+\begin{lemma}[Projective pinching inequality]
+    \label{lem:projective_povm_pinching}
+    \lean{projectivePOVM_pinching}
+    \leanok
+    \uses{def:density_matrices}
+    Let $\rho\in\MN{d}$ be a density matrix and let
+    $P_1,\ldots,P_k\in\MN{d}$ be orthogonal projections satisfying
+    $\sum_{i=1}^k P_i=\Id$.  Define
+    \begin{align}
+        T(X) &= \sum_{i=1}^k P_iXP_i .
+    \end{align}
+    Then
+    \begin{align}
+        \rho &\le kT(\rho).
+        \label{eq:projective_pinching}
+    \end{align}
+    This is \cite[Chapter~8, Eq.~(8.56)]{Wolf2012Quantum}.
+\end{lemma}
+
+\begin{proof}\leanok
+    For $A_{ij}=P_i-P_j$, positivity of $\rho$ gives
+    $A_{ij}\rho A_{ij}^{\dagger}\ge 0$.  Since the projections are
+    Hermitian and sum to the identity, expansion and collection of the four
+    double sums gives
+    \begin{align}
+        \sum_{i,j=1}^k A_{ij}\rho A_{ij}^{\dagger}
+        &= 2\bigl(kT(\rho)-\rho\bigr).
+    \end{align}
+    Thus $kT(\rho)-\rho$ is positive semidefinite.
+\end{proof}


### PR DESCRIPTION
Closes LionSR/QICLean#302.

## Summary

Formalizes Wolf Chapter 8, Eq. (8.56), from
`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 681–700.
For a density matrix `ρ` and orthogonal projections `P i` resolving the
identity, `projectivePOVM_pinching` proves

`ρ ≤ (k : ℂ) • ∑ i, P i * ρ * P i`.

The public signature has exactly the source hypotheses and does not assume
pairwise orthogonality separately. The proof uses the operator-valued form of
Wolf's finite-dimensional Cauchy–Schwarz calculation:

`∑ i,j, (P i - P j) ρ (P i - P j) = 2 (k T(ρ) - ρ)`.

Each summand is positive semidefinite. The blueprint entry uses Wolf's notation
and cites Chapter 8, Eq. (8.56).

## Verification

- `lake env lean TNLean/Channel/POVM.lean`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- changed-file proof-integrity scan: no `sorry`, `admit`, `axiom`,
  `native_decide`, `unsafeCast`, or compilation suppression
- changed files have no lines over 100 columns
- `git diff --check`

The worktree was APFS-seeded from hot main and reused the prebuilt Mathlib
cache. No Mathlib rebuild, cache clearing, or broad Lake build was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of a standard matrix inequality in channel/POVM theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`projectivePOVM_pinching`** in `POVM.lean`, formalizing Wolf Chapter 8 Eq. (8.56): for a density matrix `ρ` and orthogonal projections summing to the identity, the pinching map `T(ρ) = ∑ᵢ Pᵢ ρ Pᵢ` satisfies **ρ ≤ k · T(ρ)** in the PSD order.
> 
> The proof expands **∑ᵢⱼ (Pᵢ − Pⱼ) ρ (Pᵢ − Pⱼ)** via a private **`pinching_difference_identity`** (linked to **2(k T(ρ) − ρ)**), then shows each summand is PSD and scales by a nonnegative half to get **k T(ρ) − ρ ≥ 0**. Hypotheses use **`IsOrthogonalProjection`** without extra pairwise orthogonality assumptions.
> 
> The blueprint gains a **Projective pinching** section with theorem **`thm:projective_povm_pinching`** synced to the Lean name, plus a short proof sketch matching the operator expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e43f2350dff399a6a55e4407c49d7f68b3b6100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->