### PR TITLE
fix(blueprint): restore Cirac2017Annals to MPDO paper, add Cirac2017MPU

### DIFF
--- a/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
@@ -491,7 +491,7 @@ are recorded in Section~\ref{sec:app_spectral_decay}.
 The preceding transfer-operator gap results require \emph{injectivity} of both
 tensors. The following variants weaken this to \emph{irreducibility} together
 with the trace-preserving normalization (\ref{eq:spec_tp_normalization}),
-following Cirac et al.~\cite{Cirac2017Annals} and the irreducibility theory
+following Cirac et al.~\cite{Cirac2016MPDO_arXiv} and the irreducibility theory
 of~\cite[Section~6.2]{Wolf2012Quantum}. The argument replaces the
 Kraus-commutation step with a Cauchy--Schwarz rigidity argument for the
 Perron--Frobenius fixed point.

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -146,13 +146,26 @@
 
 @article{Cirac2017Annals,
   author       = {Cirac, J. Ignacio and P{\'e}rez-Garc{\'i}a, David and Schuch, Norbert and Verstraete, Frank},
+  title        = {Matrix Product Density Operators: Renormalization Fixed Points and Boundary Theories},
+  journal      = {Annals of Physics},
+  volume       = {378},
+  pages        = {100--149},
+  year         = {2017},
+  doi          = {10.1016/j.aop.2016.12.030},
+  eprint       = {1606.00608},
+  eprinttype   = {arxiv},
+}
+
+@article{Cirac2017MPU,
+  author       = {Cirac, J. Ignacio and P{\'e}rez-Garc{\'i}a, David and Schuch, Norbert and Verstraete, Frank},
   title        = {Matrix Product Unitaries: Structure, Symmetries, and Topological Invariants},
   journal      = {Journal of Statistical Mechanics: Theory and Experiment},
   volume       = {2017},
   number       = {8},
   pages        = {083105},
   year         = {2017},
-  eprint       = {1710.04799},
+  doi          = {10.1088/1742-5468/aa7e55},
+  eprint       = {1703.09188},
   eprinttype   = {arxiv},
 }
 

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -144,18 +144,6 @@
 }
 
 
-@article{Cirac2017Annals,
-  author       = {Cirac, J. Ignacio and P{\'e}rez-Garc{\'i}a, David and Schuch, Norbert and Verstraete, Frank},
-  title        = {Matrix Product Density Operators: Renormalization Fixed Points and Boundary Theories},
-  journal      = {Annals of Physics},
-  volume       = {378},
-  pages        = {100--149},
-  year         = {2017},
-  doi          = {10.1016/j.aop.2016.12.030},
-  eprint       = {1606.00608},
-  eprinttype   = {arxiv},
-}
-
 @article{Cirac2017MPU,
   author       = {Cirac, J. Ignacio and P{\'e}rez-Garc{\'i}a, David and Schuch, Norbert and Verstraete, Frank},
   title        = {Matrix Product Unitaries: Structure, Symmetries, and Topological Invariants},


### PR DESCRIPTION
## Summary

`Cirac2017Annals` was a corrupted alias that held incorrect metadata for the MPDO paper (originally the MPU paper's title, journal, and a wrong arXiv ID). Rather than restore it as a duplicate of the existing canonical key `Cirac2016MPDO_arXiv`, this PR:

1. **Removes `Cirac2017Annals` entirely** from `blueprint/src/references.bib` — the canonical `Cirac2016MPDO_arXiv` entry already covers the MPDO paper (\emph{Matrix Product Density Operators: Renormalization Fixed Points and Boundary Theories}, arXiv 1606.00608; published Ann.\ Phys.\ 378 (2017) 100--149).

2. **Reroutes the sole blueprint citation** in `ch07_spectral_mixed_transfer_and_overlap.tex` from `Cirac2017Annals` to `Cirac2016MPDO_arXiv`.

3. **Adds a distinct `Cirac2017MPU`** entry for \emph{Matrix Product Unitaries: Structure, Symmetries, and Topological Invariants}, J. Stat. Mech. (2017) 083105, DOI `10.1088/1742-5468/aa7e55`, arXiv `1703.09188`.

## Verification

- Zero remaining `\cite{Cirac2017Annals}` in the blueprint tree.
- No duplicate BibTeX keys.
- `blueprint_bibtex.py` passes cleanly — no missing or duplicate keys.

Closes #5723.
Related to #5704.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bibliography and citation-only edits; no Lean or mathematical content changes.
> 
> **Overview**
> Fixes a **bibliography key mismatch** in the spectral chapter: the irreducible-TP transfer-gap section now cites **`Cirac2016MPDO_arXiv`** (the MPDO paper) instead of **`Cirac2017Annals`**, aligning the in-text reference with the MPDO source used elsewhere in the blueprint.
> 
> In **`references.bib`**, the entry keyed **`Cirac2017MPU`** is updated with the published **DOI** and the correct **arXiv** id (`1703.09188`) for the Matrix Product Unitaries J. Stat. Mech. paper, separating MPU metadata from the MPDO Annals work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4079f4f9072f594f9d89daa6a83cc0b1a0008deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->