### PR TITLE
feat(MPDO): package the normal Case-I structural corollary

### DIFF
--- a/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
@@ -189,9 +189,9 @@ neighboring operators whose complex traces form a normalized rank-one matrix.
 The factorization itself retains the source isometry, the sector equivalence,
 the left and right factor tensors, and the exact physical-slice factorization.
 
-The extension across inactive Hayashi sectors is the project-derived zero-weight
-completion of the coherently rephased inverse-map witness; CPSV16 does not specify
-this inactive-sector convention.
+**Local fix (inactive sectors):** the zero-weight extension belongs to the
+coherently rephased inverse-map witness; CPSV16 does not specify this
+inactive-sector convention. See `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
 
 **Scope restriction (normal Case I):** this theorem assumes injectivity, the
 strong area law, literal zero correlation length, and normality. It makes no

--- a/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
@@ -193,9 +193,10 @@ The extension across inactive Hayashi sectors is the project-derived zero-weight
 completion of the coherently rephased inverse-map witness; CPSV16 does not specify
 this inactive-sector convention.
 
-**Scope restriction (normal Case I):** this theorem assumes the strong area law,
-literal zero correlation length, and normality. It makes no scale-invariant ZCL
-or Case-II claim.
+**Scope restriction (normal Case I):** this theorem assumes injectivity, the
+strong area law, literal zero correlation length, and normality. It makes no
+scale-invariant ZCL or Case-II claim. See
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex` for the precise paper boundary.
 
 Source: arXiv:1606.00608, Appendix C.2, the corollary after Lemma C.5, lines
 1503--1506. -/
@@ -207,7 +208,8 @@ theorem exists_physicalSectorFactorization_rank_one_coefficients_of_isSAL_of_lit
       (∀ k h, (F.neighboringOperator k h).PosSemidef) ∧
         (∀ k h, (F.neighboringOperator k h).trace = (a k * b h : ℂ)) ∧
           (∑ k, a k * b k) = 1 := by
-  obtain ⟨F, _, _, _, a, b, _, _, hpos, _, _, _, _, hab, hsum⟩ :=
+  obtain ⟨F, p, aActive, bActive, a, b, hp, hpsum, hpos, habActive,
+      hsumActive, hagree, hzero, hab, hsum⟩ :=
     exists_neighboringOperator_trace_rank_one_coefficients_of_isSAL_of_literal_ZCL
       K hK hSAL hZCL_sq hK_normal
   refine ⟨F, a, b, hpos, ?_, hsum⟩

--- a/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean
@@ -184,4 +184,35 @@ theorem exists_neighboringOperator_trace_rank_one_coefficients_of_isSAL_of_liter
   exact ⟨F, p, aActive, bActive, a, b, hp, hpsum, hpos, habActive,
     hsumActive, hagree, hzero, hab, hsum⟩
 
+/-- In normal Case I, the physical-sector factorization has positive semidefinite
+neighboring operators whose complex traces form a normalized rank-one matrix.
+The factorization itself retains the source isometry, the sector equivalence,
+the left and right factor tensors, and the exact physical-slice factorization.
+
+The extension across inactive Hayashi sectors is the project-derived zero-weight
+completion of the coherently rephased inverse-map witness; CPSV16 does not specify
+this inactive-sector convention.
+
+**Scope restriction (normal Case I):** this theorem assumes the strong area law,
+literal zero correlation length, and normality. It makes no scale-invariant ZCL
+or Case-II claim.
+
+Source: arXiv:1606.00608, Appendix C.2, the corollary after Lemma C.5, lines
+1503--1506. -/
+theorem exists_physicalSectorFactorization_rank_one_coefficients_of_isSAL_of_literal_ZCL
+    (K : MPOTensor d D) (hK : K.IsInjective) (hSAL : IsSAL K)
+    (hZCL_sq : physTraceTransfer K * physTraceTransfer K = physTraceTransfer K)
+    (hK_normal : MPSTensor.IsNormalTensor K.toMPSTensor) :
+    ∃ F : PhysicalSectorFactorization K, ∃ a b : Fin F.sectorCount → ℝ,
+      (∀ k h, (F.neighboringOperator k h).PosSemidef) ∧
+        (∀ k h, (F.neighboringOperator k h).trace = (a k * b h : ℂ)) ∧
+          (∑ k, a k * b k) = 1 := by
+  obtain ⟨F, _, _, _, a, b, _, _, hpos, _, _, _, _, hab, hsum⟩ :=
+    exists_neighboringOperator_trace_rank_one_coefficients_of_isSAL_of_literal_ZCL
+      K hK hSAL hZCL_sq hK_normal
+  refine ⟨F, a, b, hpos, ?_, hsum⟩
+  intro k h
+  rw [(hpos k h).isHermitian.trace_eq_ofReal_re, hab k h]
+  norm_cast
+
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -245,39 +245,59 @@
 % **Normal Case-I boundary:**
 % rem:mpdo_sal_zcl_rank_one_normalization_boundary records that the raw witness
 % has the displayed SAL, ZCL, and inverse-map identities but is not the normal tensor
-% assumed in Case I; its normal representative loses literal ZCL. The all-sector
-% coefficient conclusion is now complete. The source corollary still requires one
-% structural statement containing the physical isometry and left--right tensors.
-% Documented in
+% assumed in Case I; its normal representative loses literal ZCL. The completed
+% source corollary retains the physical isometry and left--right tensors of the
+% selected physical-sector factorization. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{corollary}[Local sector structure from SAL and ZCL (all-sector boundary)]
+\begin{corollary}[Local sector structure from SAL and ZCL]
     \label{cor:mpdo_sal_zcl_local_sector_structure}
-    \notready
-    \uses{def:is_sal, def:mpo_physical_trace_transfer,
-        thm:sal_implies_eta_structure,
-        thm:mpdo_casei_all_sector_rank_one_coefficients_of_is_sal}
+    \lean{MPOTensor.exists_physicalSectorFactorization_rank_one_coefficients_of_isSAL_of_literal_ZCL}
+    \leanok
+    \uses{def:mpdo, def:injective, def:is_sal,
+        def:mpo_physical_trace_transfer, def:nt_cpsv,
+        def:mpdo_physical_sector_factorization}
     Let $\mathcal K$ be an injective normal matrix product density operator
     tensor satisfying the strong area law and literal zero correlation length,
     \begin{align}
         \mathcal T_{\mathcal K}^2&=\mathcal T_{\mathcal K}.
         \notag
     \end{align}
-    Then
-    there are
-    an isometry, closed sector tensors, positive neighboring operators
-    $\eta_{k,h}$, and real families $(a_k)_k,(b_k)_k$ such that the inverse-map
-    sector decomposition holds and
+    Then there are a physical-sector factorization
     \begin{align}
-        \tr(\eta_{k,h})&=a_kb_h, \notag\\
-        \sum_k a_kb_k&=1. \notag
+        \C^d&\simeq\bigoplus_k(B_k^L\otimes B_k^R),
+        \notag
     \end{align}
-    This is the structural corollary at
-    \cite[Appendix~C.2, lines~1501--1505]{Cirac2016MPDO_arXiv}. Its printed
-    derivation combines Lemma~C.4 with the rank-one matrix step in Lemma~C.5.
-    The all-sector coefficient theorem supplies the rank-one matrix step.
-    The remaining task is to combine it with the physical isometry and the
-    left--right tensors in one structural statement.
+    with
+    \begin{align}
+        U\kappa_{\beta,\alpha}U^\dagger
+        &=\bigoplus_k(l_k)_\beta\otimes(r_k)_\alpha,
+        \notag
+    \end{align}
+    positive semidefinite neighboring operators $\eta_{k,h}$, and real
+    families $(a_k)_k,(b_k)_k$ such that
+    \begin{align}
+        \tr(\eta_{k,h})&=a_kb_h,
+        \notag
+    \end{align}
+    and
+    \begin{align}
+        \sum_k a_kb_k&=1.
+        \notag
+    \end{align}
+    The orientation of $U$ is the physical-sector-factorization convention
+    displayed above. No additional closure property of the sector tensors is
+    asserted. This is the structural corollary at
+    \cite[Appendix~C.2, lines~1503--1506]{Cirac2016MPDO_arXiv}.
 \end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_casei_all_sector_rank_one_coefficients_of_is_sal}
+    Apply Theorem~\ref{thm:mpdo_casei_all_sector_rank_one_coefficients_of_is_sal}.
+    Its factorization witness already contains the physical isometry, the
+    direct-sum physical-slice formula, and positive neighboring operators;
+    its all-sector coefficient identity is an equality in $\C$.
+\end{proof}
 
 \begin{theorem}[Positive neighboring sectors generate positive periodic operators]
     \label{thm:mpdo_neighboring_sector_positivity}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -295,8 +295,12 @@
     \uses{thm:mpdo_casei_all_sector_rank_one_coefficients_of_is_sal}
     Apply Theorem~\ref{thm:mpdo_casei_all_sector_rank_one_coefficients_of_is_sal}.
     Its factorization witness already contains the physical isometry, the
-    direct-sum physical-slice formula, and positive neighboring operators;
-    its all-sector coefficient identity is an equality in $\C$.
+    direct-sum physical-slice formula, and positive neighboring operators.
+    Theorem~\ref{thm:mpdo_casei_all_sector_rank_one_coefficients_of_is_sal}
+    gives the real-part identity
+    $\operatorname{Re}\tr(\eta_{k,h})=a_kb_h$. Positivity makes each
+    neighboring operator Hermitian, so its trace is real and the displayed
+    complex trace identity follows.
 \end{proof}
 
 \begin{theorem}[Positive neighboring sectors generate positive periodic operators]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -262,7 +262,7 @@
         \mathcal T_{\mathcal K}^2&=\mathcal T_{\mathcal K}.
         \notag
     \end{align}
-    Then there are a physical-sector factorization
+    Then there is a physical-sector factorization
     \begin{align}
         \C^d&\simeq\bigoplus_k(B_k^L\otimes B_k^R),
         \notag

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -53,8 +53,8 @@ trace-normalized RFP-to-ZCL-and-SAL result, the unrestricted Proposition
 `prop3to4`, the fixed-bond/source-ZCL SAL theorem, the literal sharp
 `propblockinj` theorem, and the literal CPSV topological-projector commuting
 Gibbs theorem, the paper has 45 theorem-like occurrences and 40 distinct
-results. The occurrence-level count is 24 complete, 7 partial, and 14
-not-ready; the distinct-result count is 23 complete, 5 partial, and 12
+results. The occurrence-level count is 25 complete, 7 partial, and 13
+not-ready; the distinct-result count is 24 complete, 5 partial, and 11
 not-ready. Here **not-ready** means that the printed statement is false,
 ambiguous, or depends essentially on a formally refuted source lemma. It does
 not mean that every printed result has been formalized. In particular, the
@@ -65,17 +65,17 @@ The distinct count is the 40 source `thm`, `prop`, `cor`, and `lem`
 environments. The occurrence count adds five Appendix A/D restatements.
 The following ledger makes the count reproducible from source line numbers:
 
-- **Complete (23 distinct):** 249, 253, 342, 398, 606, 945, 1013, 1080, 1121,
-  1130, 1274, 1333, 1351, 1406, 1484, 1510, 1569, 1597, 1647, 1680, 1786,
-  1835, and 2221.
+- **Complete (24 distinct):** 249, 253, 342, 398, 606, 945, 1013, 1080, 1121,
+  1130, 1274, 1333, 1351, 1406, 1484, 1503, 1510, 1569, 1597, 1647, 1680,
+  1786, 1835, and 2221.
 - **Partial (5 distinct):** 278, 801, 851, 972, and 1801.
-- **Not-ready (12 distinct):** 349, 354, 500, 534, 543, 583, 777, 1155,
-  1197, 1503, 1740, and 1810.
+- **Not-ready (11 distinct):** 349, 354, 500, 534, 543, 583, 777, 1155,
+  1197, 1740, and 1810.
 - **Additional occurrences:** the Appendix A restatements at 1137, 1167,
   and 1172 inherit partial, not-ready, and not-ready status, respectively; the
   Appendix D restatements at 1863 and 1929 inherit complete and partial status.
   Thus the five restatements add one complete, two partial, and two not-ready
-  occurrences, giving the displayed totals 24/7/14.
+  occurrences, giving the displayed totals 25/7/13.
 
 Definitions, equations, and explanatory proof-segment rows are not counted.
 In particular, Eq. `II_XAX` at 1072--1077 is excluded, while the purification
@@ -161,7 +161,7 @@ segments of Theorems 3.1 and 3.10, not additional theorem occurrences.
 | Lemma `Lsigma3` | 1351–1359 | SAL gives the three-site Markov decomposition | `TNLean/Analysis/EntropyMarkovForward.lean` (`Matrix.hayashi_ssa_equality_characterization_forward`); `TNLean/MPS/MPDO/SimpleLocalStructure.lean`; `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex` | **complete** — the ambient HJPW blocks are normalized with $p_j=\operatorname{Re}\operatorname{tr}\omega_j$, nonnegative weights summing to one, and recovered trace-one right states on every supported sector. At supported zero weight only the left factor may be a normalized filler; on complementary sectors both factors may be fillers. The Hayashi fibre order and unitary orientation are fixed explicitly, and the characterization is axiom-free |
 | Lemma `propSN` | 1406–1411 | SAL gives a positive physical-sector factorization with primitive active trace matrix | `TNLean/MPS/MPDO/InverseMapActiveSectorPrimitivity.lean` (`exists_positive_physicalSectorFactorization_activeSectorTraceMatrix_isPrimitive_of_isSAL`) | **complete** |
 | Lemma `SALZCL` / Lemma C.5 | 1484–1502 | SAL and ZCL force the trace coefficients to have rank one on every sector label | `TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean` (`MPOTensor.exists_neighboringOperator_trace_rank_one_coefficients_of_isSAL_of_literal_ZCL`); `docs/paper-gaps/cpgsv17_pf_rank_one.tex` | **complete** — under the standing normal Case-I hypotheses, injectivity, normality, SAL, and literal physical-trace idempotence give normalized rank-one coefficients for all Hayashi sector labels. The project extends the active coefficients by zero; the zero-weight reparameterized and rephased factorization makes every incident neighboring operator vanish. This realizes the source's all-index coefficient statement, though the source does not distinguish TNLean's active and inactive sectors. This neither replaces literal ZCL by TNLean's scale-invariant source-ZCL condition nor gives a Case-II conclusion. The raw four-sector tensor remains outside the normal Case-I hypotheses, and its normal representative loses literal ZCL |
-| Corollary | 1503–1506 | SAL and ZCL imply the displayed structural form | `TNLean/MPS/MPDO/PhysicalSectorFactorization.lean`; `InverseMapLemmaC5CaseI.lean`; `docs/paper-gaps/cpgsv17_pf_rank_one.tex` | **not-ready** — the normal Case-I all-sector rank-one coefficients are complete. A declaration must still combine them with the physical isometry and left--right tensors in the structural statement printed in the corollary |
+| Corollary | 1503–1506 | SAL and ZCL imply the displayed structural form | `TNLean/MPS/MPDO/InverseMapLemmaC5CaseI.lean` (`MPOTensor.exists_physicalSectorFactorization_rank_one_coefficients_of_isSAL_of_literal_ZCL`); `PhysicalSectorFactorization.lean`; `docs/paper-gaps/cpgsv17_pf_rank_one.tex` | **complete** — on the normal Case-I and literal-ZCL surface, the factorization supplies TNLean's direct-sum physical-slice formula, ambient positive semidefinite neighboring operators, the exact complex identity \(\operatorname{tr}(\eta_{k,h})=a_kb_h\), and \(\sum_k a_kb_k=1\). The inactive-sector zero-weight completion is project-derived; this is neither TNLean's scale-invariant source-ZCL condition nor a Case-II result |
 | Prop `3to5` | 1510–1517 | The structural data give trace-preserving coarse-graining and refinement maps | `TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean`; `PhysicalSectorRefinementIdentity.lean`; `PhysicalSectorBlockedRFP.lean`; `PhysicalSectorPhysicalTransport.lean` (`NeighboringTraceFactorization.blockTwo_isRFPViaTS`); `docs/paper-gaps/cpgsv17_mpdo_blocked_rfp_physical_transport.tex`; `docs/paper-gaps/cpgsv17_mpdo_zero_weight_preparation_completion.tex`; `docs/paper-gaps/cpgsv17_mpdo_theorem_4_9_implication_label.tex` | **complete** — the physical-transport theorem carries the sector-coordinate channels back to the original blocked tensor. Two local fixes are disclosed: zero-weight preparation is completed on the quotient, and the source Appendix label \((iii)\Rightarrow(v)\) is corrected to the implication actually proved, \((iv)\Rightarrow(v)\) |
 | Prop `3to4` | 1569–1577 | SAL gives the commuting product form | `TNLean/MPS/MPDO/CommutingFormBridge.lean`; `GSNNCHSectorSum.lean`; related physical-sector modules | **complete** |
 | Prop `4to2` | 1597–1601 | Commuting form and ZCL imply SAL | `TNLean/MPS/MPDO/CyclicActiveAreaLaw.lean` (`EtaLocalStructureData.isSAL_of_isSourceZCL`); `ZCL.lean` (`MPOTensor.IsSourceZCL.bondDim_ne_zero`); `CyclicActiveMarkovDecomposition.lean`; `FixedBondPositivePhysicalSectorRepresentative.lean`; `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` | **complete** — all-cut Hayashi decompositions for the original injective MPDO tensor in the selected physical coordinates imply SAL there, and the selected one-site isometry preserves SAL for the source tensor. Source ZCL itself forces nonzero bond dimension, so neither normality nor any property of the selected fixed tensor is assumed |
@@ -327,7 +327,7 @@ These are known oversized (documented in #1512/#1522) and do not block unrelated
 
 ## 7. Key remaining coverage gaps
 
-The 17 non-complete distinct CPSV16 results comprise 5 partial and 12
+The 16 non-complete distinct CPSV16 results comprise 5 partial and 11
 not-ready results. They are source-ambiguous, formally refuted, research-level,
 owner-held, or scope-restricted by the current formal interface. Lemma
 `Lsigma3`, the Hayashi strong-subadditivity equality characterization, and the
@@ -350,7 +350,6 @@ axiom-free.
 | Partial | CPSV16 | Proposition 4.5 | Monotonicity and the finite-chain bound are complete, including the stronger estimate $I_L\le 2\log D$; the proposition remains partial only because the unrestricted thermodynamic-limit clause is formally refuted | `TNLean/MPS/MPDO/MutualInfoMonotone.lean` (`MPOTensor.mutualInfoChain_monotone`); `TNLean/MPS/MPDO/MutualInfoAreaLaw.lean` (`MPOTensor.mutualInfoChain_le_two_log_bondDim`, `MPOTensor.IsMPDO.mutualInfoChain_le_four_log_bondDim`); `TNLean/MPS/MPDO/ThermodynamicLimitCounterexample.lean`; `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex` |
 | Partial | CPSV16 | Theorem 4.9 | Implication \((i)\Rightarrow(ii)\), the HJPW/Hayashi equality characterization, and the exact Petz-recovery construction are complete. The remaining SAL-and-ZCL structural implication requires the unformalized Case-II passage from BNT projectors to all-sector factorization data for every BNT tensor | `TNLean/Analysis/EntropyMarkovForward.lean`; `TNLean/Channel/PetzProductReference.lean`; `TNLean/MPS/MPDO/BNTSeparatingProjectors.lean`; `BNTSourceSectorProjectors.lean`; `docs/paper-gaps/cpgsv17_pf_rank_one.tex` |
 | Partial/corrected | CPSV16 | Theorem 4.14 | The equivalence between the RFP condition and the tensor-attached BNT algebra clause is complete under the printed standing assumptions. The fusion equivalence is complete for the documented active-support correction to clause (iii), but this is not the unrestricted printed clause. The mixed-prefix marked comparison gives the scalar Gram identity, unitary sector gauges, and the full trace-preserving completely positive maps. | `TNLean/MPS/MPDO/BNTAlgebraTensorClauseReflectedTarget.lean`; `TNLean/MPS/MPDO/CPSVBNTTheoremEquivalence.lean`; `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex` |
-| Not-ready | CPSV16 | Structural corollary, lines 1503–1506 | The normal Case-I all-sector coefficients are complete, but they must still be combined with the physical isometry and left--right tensors in one structural statement | `TNLean/MPS/MPDO/PhysicalSectorFactorization.lean`; `InverseMapLemmaC5CaseI.lean` |
 | Complete | CPSV16 | Proposition `4to2`, lines 1597–1601 | The selected physical coordinates give all-cut Markov decompositions for the original tensor, hence SAL, which is transported back through the one-site isometry | `MPOTensor.EtaLocalStructureData.isSAL_of_isSourceZCL` |
 | Not-ready | CPSV16 | Proposition `prop2to3` | The BNT-sector argument must still prove MPDO positivity, SAL, and literal ZCL for every BNT tensor and then produce the all-sector Case-I structural datum | `TNLean/MPS/MPDO/BNTSeparatingProjectors.lean`; `BNTSourceSectorProjectors.lean` |
 | Partial | CPSV16 | Proposition `prop4to2` | The corrected canonical-BNT theorem is complete under ambient source ZCL, the standing biCF one-letter span, and one-site positivity of each absorbed sector. Positive commuting bonds give every $N\geq2$ positivity, so no full sector-MPDO or normality premise remains. The printed GSNNCH-only statement still omits ambient ZCL, and its unambiguous bond realization begins at $N=2$ | `TNLean/MPS/MPDO/OrthogonalSectorAreaLaw.lean` (`MPOTensor.isSAL_of_commonWeightAbsorbedBasisMPOTensor_of_proportionalSectors_of_isSourceZCL`); `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` |

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -840,16 +840,28 @@ In the zero-weight-reparameterized and rephased factorization selected by the
 construction, $p_k=0$ makes both every incoming and every outgoing neighboring
 operator vanish. Hence
 \[
-  \operatorname{Re}\operatorname{tr}(\eta_{k,h})=a_kb_h
+  \operatorname{tr}(\eta_{k,h})=a_kb_h
 \]
 for every pair of sector labels, and filtering the diagonal sum to $I_*$ gives
 $\sum_k a_kb_k=1$. This is a project-derived realization of the printed
 all-index coefficient equation in Lemma~C.5: CPSV16 quantifies sector labels
 without defining TNLean's active--inactive split or its ambient filler sectors.
-It completes Lemma~C.5 on the stated normal Case-I and literal-ZCL surface.
-The structural corollary at lines~1503--1505 remains open, since it must still
-package these coefficients with the physical isometry and the left--right
-tensors in one statement.
+
+The structural corollary at lines~1503--1506 is now formalized by
+\leanid{MPOTensor.exists_physicalSectorFactorization_rank_one_coefficients_of_isSAL_of_literal_ZCL}.
+It retains the selected physical-sector factorization itself: an isometry $U$
+with TNLean's orientation
+\[
+  U\kappa_{\beta,\alpha}U^\dagger
+    =\bigoplus_k(l_k)_\beta\otimes(r_k)_\alpha,
+\]
+its left and right factor matrices, and ambient positive semidefinite
+neighboring operators.  Together with the exact complex trace identity above
+and the normalization, this completes the normal Case-I corollary on the
+literal-ZCL surface.  It asserts no additional closure property of the sector
+tensors.  The orientation is the convention of
+\leanid{MPOTensor.PhysicalSectorFactorization}, rather than an identification
+with a separately drawn graphical orientation in the source.
 
 The all-cut Markov proof and the source-selected inverse-map calculation show
 that the raw four-sector tensor satisfies the displayed SAL, literal ZCL, and
@@ -857,9 +869,10 @@ inverse-map relations while the asserted factorization
 $T_{k,h}=a_kb_h$ does not exist. However, that tensor is not the injective
 normal tensor assumed in Case~I, and its normal representative loses literal
 ZCL. The raw example therefore does not refute Lemma~C.5 under its complete
-standing hypotheses. The coefficient theorem above does not supply the
-structural corollary or a later Case-II argument; the latter still requires a
-proof that normality survives the relevant rescaling.
+standing hypotheses. The completed normal Case-I corollary does not replace
+literal ZCL by TNLean's scale-invariant \leanid{MPOTensor.IsSourceZCL}
+predicate, and it supplies no Case-II statement. The Case-II passage remains
+separate under issue \ghissue{5673}.
 
 The raw witness $\mathcal K$ nevertheless has explicit trace-preserving
 completely positive renormalization maps, both before and after two-site

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -786,18 +786,18 @@ in Case~I. Its normal representative loses literal ZCL. Thus the example
 isolates the normalization-sensitive step needed for
 $T_{k,h}=a_kb_h$; it does not refute Lemma~C.5 under all standing hypotheses.
 
-This obstruction propagates to every source statement whose proof invokes the
-rank-one factorization from Lemma~C.5.  In particular, the structural
-corollary at lines~1501--1505 and the proposition proving Theorem~4.9
-(ii)$\Rightarrow$(iv) at lines~1740--1788 are not formalized from their stated
-SAL and ZCL hypotheses.  The proof of Theorem~4.9
-(ii)$\Rightarrow$(v) at lines~1810--1825 is likewise invalid. The normalized
-representative above shows that the broadened implication formed with TNLean's
-up-to-scalar \leanid{MPOTensor.IsSourceZCL} predicate is false; it does not meet
-the paper's literal ZCL diagram and therefore does not settle the exact source
-statement. The constructions from an explicitly supplied rank-one neighboring
-trace factorization remain valid restricted results, but they do not establish
-the three source statements.
+This obstruction does not survive the full normal Case-I hypotheses: the
+completed route below excludes it and formalizes the structural corollary at
+lines~1503--1506. It remains relevant to the later Case-II passage. The
+proposition proving Theorem~4.9 (ii)$\Rightarrow$(iv) at lines~1740--1788 and
+the proof of (ii)$\Rightarrow$(v) at lines~1810--1825 are not yet formalized
+from their stated SAL and ZCL hypotheses. The normalized representative above
+shows that the broadened implication formed with TNLean's up-to-scalar
+\leanid{MPOTensor.IsSourceZCL} predicate is false; it does not meet the paper's
+literal ZCL diagram and therefore does not settle the exact source statement.
+The constructions from an explicitly supplied rank-one neighboring trace
+factorization remain valid restricted results, but they do not establish these
+two later implications.
 
 \section{Conclusion}
 
@@ -838,7 +838,10 @@ $I_* = \{k:p_k\ne0\}$ and set
 \]
 In the zero-weight-reparameterized and rephased factorization selected by the
 construction, $p_k=0$ makes both every incoming and every outgoing neighboring
-operator vanish. Hence
+operator vanish. On active pairs, the all-sector theorem first gives
+$\operatorname{Re}\operatorname{tr}(\eta_{k,h})=a_kb_h$.
+Every neighboring operator is positive semidefinite, hence Hermitian with real
+trace. Therefore
 \[
   \operatorname{tr}(\eta_{k,h})=a_kb_h
 \]

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -91,7 +91,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L793, 806, 814, 821, 895, 902 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L326, 332, 338, 352, 363, 369 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L359, 878, 882, 888, 893 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L363, 882, 886, 892, 897 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | L48, 52, 169, 173, 374, 378, 391, 395, 438, 442, 446, 455, 459 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -91,7 +91,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | L793, 806, 814, 821, 895, 902 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L326, 332, 338, 352, 363, 369 `tenkz` → `P-grid` | — | — |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L339, 858, 862, 868, 873 `tenkz` → `P-grid` | — | — |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L359, 878, 882, 888, 893 `tenkz` → `P-grid` | — | — |
 | `ch23_algebraic_ft_foundations.tex` | L48, 52, 169, 173, 374, 378, 391, 395, 438, 442, 446, 455, 459 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- add `MPOTensor.exists_physicalSectorFactorization_rank_one_coefficients_of_isSAL_of_literal_ZCL`, packaging one normal Case-I witness with:
  - the physical-sector factorization and its exact physical-slice direct-sum identity;
  - ambient positive semidefinite neighboring operators;
  - real families `a,b` satisfying the exact complex trace identity `trace (η k h) = a k * b h` and `∑ k, a k * b k = 1`;
- derive the complex identity from the merged all-sector real-part theorem using positivity, hence Hermiticity and reality of trace;
- mark the CPSV16 Appendix C.2 structural corollary complete in the Blueprint, coverage ledger, and paper-gap note;
- keep the boundary explicit: normal Case I, injectivity, SAL, literal ZCL, and project-derived zero-weight completion only—not `IsSourceZCL`, Case II, or tensor-attached vertical BNT coefficients.

Source: CPSV16/arXiv:1606.00608, Appendix C.2, lines 1503–1506. This is packaging of the coherent witness proved in #5686, not a new structural construction.

## Validation

- `lake build TNLean.MPS.MPDO.InverseMapLemmaC5CaseI` — passed (9173 jobs)
- full `lake build` — passed (9957 jobs)
- Blueprint declaration generation, CI sync, and `leanblueprint checkdecls` — passed (6633/6633 entries)
- Blueprint `lualatex` twice with `TEXINPUTS='../../tex/tenkz//:'` — passed; zero undefined cross-references
- import aggregators, forbidden-token, numbered-file, oversized-file, reader-facing prose, tenkz disposition/policy, and `git diff --check` gates — passed
- independent Lean/source/Blueprint review — initial findings fixed; exact-head re-review requested

Closes #5672.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change sits on the formal MPDO inverse-map / SAL–ZCL chain, but it only repackages an existing witness and documents scope limits; no new algebraic construction or auth-like surface.
> 
> **Overview**
> Completes the CPSV16 Appendix C.2 structural corollary (lines 1503–1506) by **packaging** the merged all-sector rank-one witness from #5686 into one Lean theorem, not by a new inverse-map construction.
> 
> **Lean:** Adds `exists_physicalSectorFactorization_rank_one_coefficients_of_isSAL_of_literal_ZCL`, which returns a `PhysicalSectorFactorization` with PSD neighboring operators, real `a`, `b` satisfying the **exact complex** trace identity `trace (η k h) = a k * b h`, and `∑ k, a k * b k = 1`. The complex trace step uses the existing real-part all-sector theorem plus Hermiticity of traces from positivity.
> 
> **Blueprint & docs:** The capstone corollary is marked `\leanok` with a proof; the coverage ledger moves this result from not-ready to complete (25/7/13 occurrences). The rank-one paper-gap note records that the normal Case-I corollary is formalized while Case-II passages remain open.
> 
> **Boundary (unchanged):** injectivity, normality, SAL, **literal** physical-trace idempotence, and project-derived zero-weight inactive-sector completion—not `IsSourceZCL` or Case-II BNT packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721214fd8fd6347b0df7c983eab2281365017930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->