### PR TITLE
feat(MPU): define source matrix cuts M₁, M₂ and ranks r, ℓ

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -9,3 +9,4 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.MPS.MPU
 
 import TNLean.MPS.MPU.Basic
+import TNLean.MPS.MPU.SourceCuts

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -96,12 +96,12 @@ def sourceCutM₂ : Matrix (Fin D × Fin d) (Fin d × Fin D) ℂ :=
 @[simp] lemma sourceCutM₂_apply (α : Fin D) (i : Fin d) (j : Fin d) (β : Fin D) :
     sourceCutM₂ U (α, i) (j, β) = U i j α β := rfl
 
-/-! ### Reindexing to `Fin (D * d)` and `Fin (d * D)` (thin bridges) -/
+/-! ### Reindexing to `Fin (D * d)` and `Fin (d * D)` (reindexed formulations) -/
 
 /-- ${\cal M}_1$ reindexed to `Fin (D * d)` rows and `Fin (d * D)` columns
 via the standard product encoding `finProdFinEquiv`.
 
-This is a thin bridge; the primary definition remains `sourceCutM₁`. -/
+This is a reindexed formulation; the primary definition remains `sourceCutM₁`. -/
 def sourceCutM₁Fin : Matrix (Fin (D * d)) (Fin (d * D)) ℂ :=
   Matrix.reindex
     (finProdFinEquiv (m := D) (n := d))

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -169,13 +169,15 @@ lemma leftRank_eq : ℓ[U] = (sourceCutM₂ U).rank := rfl
 
 /-- The right rank $r = \operatorname{rank} {\cal M}_1 \le D d$,
 since ${\cal M}_1$ has $Dd$ rows and $dD$ columns. -/
-theorem rightRank_bound : (sourceCutM₁ U).rank ≤ D * d := by
+theorem rightRank_bound : r[U] ≤ D * d := by
+  rw [rightRank]
   refine (Matrix.rank_le_card_width (sourceCutM₁ U)).trans ?_
   simp [Fintype.card_fin, mul_comm]
 
 /-- The left rank $\ell = \operatorname{rank} {\cal M}_2 \le D d$,
 since ${\cal M}_2$ also has $Dd$ rows and $dD$ columns. -/
-theorem leftRank_bound : (sourceCutM₂ U).rank ≤ D * d := by
+theorem leftRank_bound : ℓ[U] ≤ D * d := by
+  rw [leftRank]
   refine (Matrix.rank_le_card_width (sourceCutM₂ U)).trans ?_
   simp [Fintype.card_fin, mul_comm]
 

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.Defs
+import Mathlib.LinearAlgebra.Matrix.Rank
+import Mathlib.Logic.Equiv.Fin.Basic
+
+/-!
+# Source matrix cuts and ranks of an MPU tensor
+
+This module defines the two source matrices ${\cal M}_1$ and ${\cal M}_2$
+obtained from a four-index tensor ${\cal U}$ by regrouping its indices, and
+the associated ranks $r$ and $\ell$, following
+[Cirac--Perez-Garcia--Schuch--Verstraete 2017, arXiv:1703.09188],
+Section II, Definition II.3 (label `defnrl`).
+
+A tensor ${\cal U}$ generating a matrix product unitary (MPU) carries four
+indices: up $i$ (ket, first physical), down $j$ (bra, second physical),
+left $\alpha$ (left virtual), right $\beta$ (right virtual).  In the MPU
+paper these appear as four-leg tensors where vertical lines carry physical
+indices and horizontal lines carry virtual (auxiliary) ones.
+
+## Source matrices ${\cal M}_1$, ${\cal M}_2$
+
+Following lines 458–477 of the paper, we combine indices in two different
+ways to form rectangular matrices:
+
+* ${\cal M}_1$ groups **row = (left, down)** and **column = (up, right)**:
+  $({\cal M}_1)_{(\alpha,j),(i,\beta)} = {\cal U}^{i}_{j,\alpha,\beta}$
+  (using the paper's graphical convention), or equivalently
+  `U i j α β` in `MPOTensor` notation (ket, bra, left-virtual, right-virtual).
+
+* ${\cal M}_2$ groups **row = (left, up)** and **column = (down, right)**:
+  $({\cal M}_2)_{(\alpha,i),(j,\beta)} = {\cal U}^{i}_{j,\alpha,\beta}$.
+
+## Ranks $r$ and $\ell$
+
+We set $r := \operatorname{rank} {\cal M}_1$,
+$\ell := \operatorname{rank} {\cal M}_2$ as in Definition II.3 of the paper.
+
+## Main definitions
+
+* `MPOTensor.sourceCutM₁`, `MPOTensor.sourceCutM₂`: the two source matrices
+  with product-index rows and columns.
+* `MPOTensor.sourceCutM₁Fin`, `MPOTensor.sourceCutM₂Fin`: reindexed versions
+  `Matrix (Fin (D * d)) (Fin (d * D)) ℂ`.
+* `MPOTensor.sourceRank₁` (`r`), `MPOTensor.sourceRank₂` (`ℓ`): the ranks.
+
+## Main results
+
+* `sourceCutM₁_rank_bound`, `sourceCutM₂_rank_bound`: rank bounds
+  $r \le \min(Dd, dD) = Dd$ and similarly $\ell \le Dd$.
+* `sourceCut_entry` lemmas: `[simp]` entry formulas for both cuts and both
+  index forms.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1703.09188,
+  Section II, Definition II.3 and lines 458–477.
+-/
+
+open scoped Matrix
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-! ### Product-index source matrices (primary definitions) -/
+
+/-- ${\cal M}_1$: group **row = (left, down)** and **column = (up, right)**.
+
+The entry $({\cal M}_1)_{(\alpha,j),(i,\beta)}$ equals `U i j α β` where
+`i` = up (ket), `j` = down (bra), `α` = left virtual, `β` = right virtual.
+
+This follows arXiv:1703.09188, eq.~(II_SVD). -/
+def sourceCutM₁ : Matrix (Fin D × Fin d) (Fin d × Fin D) ℂ :=
+  fun (α, j) (i, β) => U i j α β
+
+/-- ${\cal M}_2$: group **row = (left, up)** and **column = (down, right)**.
+
+The entry $({\cal M}_2)_{(\alpha,i),(j,\beta)}$ equals `U i j α β`.
+
+This follows arXiv:1703.09188, eq.~(II_SVD). -/
+def sourceCutM₂ : Matrix (Fin D × Fin d) (Fin d × Fin D) ℂ :=
+  fun (α, i) (j, β) => U i j α β
+
+/-! ### Entry lemmas — `[simp]` -/
+
+@[simp] lemma sourceCutM₁_apply (α : Fin D) (j : Fin d) (i : Fin d) (β : Fin D) :
+    sourceCutM₁ U (α, j) (i, β) = U i j α β := rfl
+
+@[simp] lemma sourceCutM₂_apply (α : Fin D) (i : Fin d) (j : Fin d) (β : Fin D) :
+    sourceCutM₂ U (α, i) (j, β) = U i j α β := rfl
+
+/-! ### Reindexing to `Fin (D * d)` and `Fin (d * D)` (thin bridges) -/
+
+/-- ${\cal M}_1$ reindexed to `Fin (D * d)` rows and `Fin (d * D)` columns
+via the standard product encoding `finProdFinEquiv`.
+
+This is a thin bridge; the primary definition remains `sourceCutM₁`. -/
+def sourceCutM₁Fin : Matrix (Fin (D * d)) (Fin (d * D)) ℂ :=
+  Matrix.reindex
+    (finProdFinEquiv (m := D) (n := d))
+    (finProdFinEquiv (m := d) (n := D))
+    (sourceCutM₁ U)
+
+/-- ${\cal M}_2$ reindexed to `Fin (D * d)` rows and `Fin (d * D)` columns. -/
+def sourceCutM₂Fin : Matrix (Fin (D * d)) (Fin (d * D)) ℂ :=
+  Matrix.reindex
+    (finProdFinEquiv (m := D) (n := d))
+    (finProdFinEquiv (m := d) (n := D))
+    (sourceCutM₂ U)
+
+lemma sourceCutM₁Fin_eq_reindex : sourceCutM₁Fin U =
+    Matrix.reindex
+      (finProdFinEquiv (m := D) (n := d))
+      (finProdFinEquiv (m := d) (n := D))
+      (sourceCutM₁ U) := rfl
+
+lemma sourceCutM₂Fin_eq_reindex : sourceCutM₂Fin U =
+    Matrix.reindex
+      (finProdFinEquiv (m := D) (n := d))
+      (finProdFinEquiv (m := d) (n := D))
+      (sourceCutM₂ U) := rfl
+
+@[simp] lemma sourceCutM₁Fin_apply (r : Fin (D * d)) (c : Fin (d * D)) :
+    sourceCutM₁Fin U r c =
+      sourceCutM₁ U
+        ((finProdFinEquiv (m := D) (n := d)).symm r)
+        ((finProdFinEquiv (m := d) (n := D)).symm c) := rfl
+
+@[simp] lemma sourceCutM₂Fin_apply (r : Fin (D * d)) (c : Fin (d * D)) :
+    sourceCutM₂Fin U r c =
+      sourceCutM₂ U
+        ((finProdFinEquiv (m := D) (n := d)).symm r)
+        ((finProdFinEquiv (m := d) (n := D)).symm c) := rfl
+
+lemma sourceCutM₁_rank_eq_sourceCutM₁Fin_rank :
+    (sourceCutM₁ U).rank = (sourceCutM₁Fin U).rank := by
+  rw [sourceCutM₁Fin_eq_reindex, Matrix.rank_reindex]
+
+lemma sourceCutM₂_rank_eq_sourceCutM₂Fin_rank :
+    (sourceCutM₂ U).rank = (sourceCutM₂Fin U).rank := by
+  rw [sourceCutM₂Fin_eq_reindex, Matrix.rank_reindex]
+
+/-! ### Source ranks $r$ and $\ell$ (Definition II.3, label `defnrl`) -/
+
+/-- The rank $r$ of ${\cal M}_1$, as in arXiv:1703.09188, Definition II.3. -/
+noncomputable def sourceRank₁ : ℕ := (sourceCutM₁ U).rank
+
+/-- The rank $\ell$ of ${\cal M}_2$, as in arXiv:1703.09188, Definition II.3. -/
+noncomputable def sourceRank₂ : ℕ := (sourceCutM₂ U).rank
+
+-- Notation corresponding to the paper's `r` and `ℓ`
+@[inherit_doc sourceRank₁] scoped notation "r[" U "]" => MPOTensor.sourceRank₁ U
+@[inherit_doc sourceRank₂] scoped notation "ℓ[" U "]" => MPOTensor.sourceRank₂ U
+
+lemma sourceRank₁_eq : r[U] = (sourceCutM₁ U).rank := rfl
+
+lemma sourceRank₂_eq : ℓ[U] = (sourceCutM₂ U).rank := rfl
+
+/-! ### Rank bounds -/
+
+/-- $r = \operatorname{rank} {\cal M}_1 \le D d$, since ${\cal M}_1$
+has $Dd$ rows and $dD$ columns. -/
+theorem sourceCutM₁_rank_bound : (sourceCutM₁ U).rank ≤ D * d := by
+  refine (Matrix.rank_le_card_width (sourceCutM₁ U)).trans ?_
+  simp [Fintype.card_fin, mul_comm]
+
+/-- $\ell = \operatorname{rank} {\cal M}_2 \le D d$, since ${\cal M}_2$
+also has $Dd$ rows and $dD$ columns. -/
+theorem sourceCutM₂_rank_bound : (sourceCutM₂ U).rank ≤ D * d := by
+  refine (Matrix.rank_le_card_width (sourceCutM₂ U)).trans ?_
+  simp [Fintype.card_fin, mul_comm]
+
+theorem sourceRank₁_bound : r[U] ≤ D * d :=
+  sourceCutM₁_rank_bound U
+
+theorem sourceRank₂_bound : ℓ[U] ≤ D * d :=
+  sourceCutM₂_rank_bound U
+
+/-! ### Literal verification: identity tensor
+
+We verify the ranks for the identity MPU tensor
+${\cal U}^{i}_{j,\alpha,\beta} = \delta_{i,j} \cdot \delta_{\alpha,\beta}$.
+For this tensor both ${\cal M}_1$ and ${\cal M}_2$ become identity-like
+matrices on $\min(Dd, dD) = Dd$ dimensions, so both ranks equal $D d$.
+
+This example is source-relevant: the identity MPU is the trivial case of
+Definition II.3, and the ranks saturate the bound $r, \ell \le Dd$. -/
+
+/-- The identity MPU tensor: `idU d D i j α β = δ_{i,j} · δ_{α,β}`.
+When $d$ and $D$ are concrete naturals the physical and virtual identity
+Kronecker deltas are `if i = j ∧ α = β then 1 else 0`. -/
+def idU (d D : ℕ) : MPOTensor d D :=
+  fun i j α β => if i = j ∧ α = β then 1 else 0
+
+lemma sourceCutM₁_idU (d D : ℕ) (α : Fin D) (j : Fin d) (i : Fin d) (β : Fin D) :
+    sourceCutM₁ (idU d D) (α, j) (i, β) = if i = j ∧ α = β then 1 else 0 := by
+  simp [idU, sourceCutM₁]
+
+lemma sourceCutM₂_idU (d D : ℕ) (α : Fin D) (i : Fin d) (j : Fin d) (β : Fin D) :
+    sourceCutM₂ (idU d D) (α, i) (j, β) = if i = j ∧ α = β then 1 else 0 := by
+  simp [idU, sourceCutM₂]
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -62,9 +62,6 @@ definition `defnrl` and lines 697–704 of the paper.
   Section III, definition `defnrl`, lines 450–477 and 697–704.
 -/
 
-open scoped Matrix
-open Matrix
-
 namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -14,7 +14,7 @@ This module defines the two source matrices ${\cal M}_1$ and ${\cal M}_2$
 obtained from a four-index tensor ${\cal U}$ by regrouping its indices, and
 the associated ranks $r$ and $\ell$, following
 [Cirac--Perez-Garcia--Schuch--Verstraete 2017, arXiv:1703.09188],
-Section II, Definition II.3 (label `defnrl`).
+Section III, definition `defnrl`, lines 450–477.
 
 A tensor ${\cal U}$ generating a matrix product unitary (MPU) carries four
 indices: up $i$ (ket, first physical), down $j$ (bra, second physical),
@@ -37,8 +37,9 @@ ways to form rectangular matrices:
 
 ## Ranks $r$ and $\ell$
 
-We set $r := \operatorname{rank} {\cal M}_1$,
-$\ell := \operatorname{rank} {\cal M}_2$ as in Definition II.3 of the paper.
+We set $r := \operatorname{rank} {\cal M}_1$ (the **right rank**) and
+$\ell := \operatorname{rank} {\cal M}_2$ (the **left rank**), as in
+definition `defnrl` and lines 697–704 of the paper.
 
 ## Main definitions
 
@@ -46,11 +47,11 @@ $\ell := \operatorname{rank} {\cal M}_2$ as in Definition II.3 of the paper.
   with product-index rows and columns.
 * `MPOTensor.sourceCutM₁Fin`, `MPOTensor.sourceCutM₂Fin`: reindexed versions
   `Matrix (Fin (D * d)) (Fin (d * D)) ℂ`.
-* `MPOTensor.sourceRank₁` (`r`), `MPOTensor.sourceRank₂` (`ℓ`): the ranks.
+* `MPOTensor.rightRank` (`r`), `MPOTensor.leftRank` (`ℓ`): the ranks.
 
 ## Main results
 
-* `sourceCutM₁_rank_bound`, `sourceCutM₂_rank_bound`: rank bounds
+* `rightRank_bound`, `leftRank_bound`: rank bounds
   $r \le \min(Dd, dD) = Dd$ and similarly $\ell \le Dd$.
 * `sourceCut_entry` lemmas: `[simp]` entry formulas for both cuts and both
   index forms.
@@ -58,7 +59,7 @@ $\ell := \operatorname{rank} {\cal M}_2$ as in Definition II.3 of the paper.
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1703.09188,
-  Section II, Definition II.3 and lines 458–477.
+  Section III, definition `defnrl`, lines 450–477 and 697–704.
 -/
 
 open scoped Matrix
@@ -146,64 +147,36 @@ lemma sourceCutM₂_rank_eq_sourceCutM₂Fin_rank :
     (sourceCutM₂ U).rank = (sourceCutM₂Fin U).rank := by
   rw [sourceCutM₂Fin_eq_reindex, Matrix.rank_reindex]
 
-/-! ### Source ranks $r$ and $\ell$ (Definition II.3, label `defnrl`) -/
+/-! ### Right and left ranks $r$ and $\ell$ (definition `defnrl`, lines 697–704) -/
 
-/-- The rank $r$ of ${\cal M}_1$, as in arXiv:1703.09188, Definition II.3. -/
-noncomputable def sourceRank₁ : ℕ := (sourceCutM₁ U).rank
+/-- The **right rank** $r = \operatorname{rank} {\cal M}_1$, as in
+arXiv:1703.09188, definition `defnrl` (lines 450–477) and lines 697–704. -/
+noncomputable def rightRank : ℕ := (sourceCutM₁ U).rank
 
-/-- The rank $\ell$ of ${\cal M}_2$, as in arXiv:1703.09188, Definition II.3. -/
-noncomputable def sourceRank₂ : ℕ := (sourceCutM₂ U).rank
+/-- The **left rank** $\ell = \operatorname{rank} {\cal M}_2$, as in
+arXiv:1703.09188, definition `defnrl` (lines 450–477) and lines 697–704. -/
+noncomputable def leftRank : ℕ := (sourceCutM₂ U).rank
 
 -- Notation corresponding to the paper's `r` and `ℓ`
-@[inherit_doc sourceRank₁] scoped notation "r[" U "]" => MPOTensor.sourceRank₁ U
-@[inherit_doc sourceRank₂] scoped notation "ℓ[" U "]" => MPOTensor.sourceRank₂ U
+@[inherit_doc rightRank] scoped notation "r[" U "]" => MPOTensor.rightRank U
+@[inherit_doc leftRank] scoped notation "ℓ[" U "]" => MPOTensor.leftRank U
 
-lemma sourceRank₁_eq : r[U] = (sourceCutM₁ U).rank := rfl
+lemma rightRank_eq : r[U] = (sourceCutM₁ U).rank := rfl
 
-lemma sourceRank₂_eq : ℓ[U] = (sourceCutM₂ U).rank := rfl
+lemma leftRank_eq : ℓ[U] = (sourceCutM₂ U).rank := rfl
 
 /-! ### Rank bounds -/
 
-/-- $r = \operatorname{rank} {\cal M}_1 \le D d$, since ${\cal M}_1$
-has $Dd$ rows and $dD$ columns. -/
-theorem sourceCutM₁_rank_bound : (sourceCutM₁ U).rank ≤ D * d := by
+/-- The right rank $r = \operatorname{rank} {\cal M}_1 \le D d$,
+since ${\cal M}_1$ has $Dd$ rows and $dD$ columns. -/
+theorem rightRank_bound : (sourceCutM₁ U).rank ≤ D * d := by
   refine (Matrix.rank_le_card_width (sourceCutM₁ U)).trans ?_
   simp [Fintype.card_fin, mul_comm]
 
-/-- $\ell = \operatorname{rank} {\cal M}_2 \le D d$, since ${\cal M}_2$
-also has $Dd$ rows and $dD$ columns. -/
-theorem sourceCutM₂_rank_bound : (sourceCutM₂ U).rank ≤ D * d := by
+/-- The left rank $\ell = \operatorname{rank} {\cal M}_2 \le D d$,
+since ${\cal M}_2$ also has $Dd$ rows and $dD$ columns. -/
+theorem leftRank_bound : (sourceCutM₂ U).rank ≤ D * d := by
   refine (Matrix.rank_le_card_width (sourceCutM₂ U)).trans ?_
   simp [Fintype.card_fin, mul_comm]
-
-theorem sourceRank₁_bound : r[U] ≤ D * d :=
-  sourceCutM₁_rank_bound U
-
-theorem sourceRank₂_bound : ℓ[U] ≤ D * d :=
-  sourceCutM₂_rank_bound U
-
-/-! ### Literal verification: identity tensor
-
-We verify the ranks for the identity MPU tensor
-${\cal U}^{i}_{j,\alpha,\beta} = \delta_{i,j} \cdot \delta_{\alpha,\beta}$.
-For this tensor both ${\cal M}_1$ and ${\cal M}_2$ become identity-like
-matrices on $\min(Dd, dD) = Dd$ dimensions, so both ranks equal $D d$.
-
-This example is source-relevant: the identity MPU is the trivial case of
-Definition II.3, and the ranks saturate the bound $r, \ell \le Dd$. -/
-
-/-- The identity MPU tensor: `idU d D i j α β = δ_{i,j} · δ_{α,β}`.
-When $d$ and $D$ are concrete naturals the physical and virtual identity
-Kronecker deltas are `if i = j ∧ α = β then 1 else 0`. -/
-def idU (d D : ℕ) : MPOTensor d D :=
-  fun i j α β => if i = j ∧ α = β then 1 else 0
-
-lemma sourceCutM₁_idU (d D : ℕ) (α : Fin D) (j : Fin d) (i : Fin d) (β : Fin D) :
-    sourceCutM₁ (idU d D) (α, j) (i, β) = if i = j ∧ α = β then 1 else 0 := by
-  simp [idU, sourceCutM₁]
-
-lemma sourceCutM₂_idU (d D : ℕ) (α : Fin D) (i : Fin d) (j : Fin d) (β : Fin D) :
-    sourceCutM₂ (idU d D) (α, i) (j, β) = if i = j ∧ α = β then 1 else 0 := by
-  simp [idU, sourceCutM₂]
 
 end MPOTensor

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -53,7 +53,7 @@ definition `defnrl` and lines 697–704 of the paper.
 
 * `rightRank_bound`, `leftRank_bound`: rank bounds
   $r \le \min(Dd, dD) = Dd$ and similarly $\ell \le Dd$.
-* `sourceCut_entry` lemmas: `[simp]` entry formulas for both cuts and both
+* `sourceCutM₁_apply`, `sourceCutM₂_apply`, `sourceCutM₁Fin_apply`, `sourceCutM₂Fin_apply`: `[simp]` entry formulas for both cuts and both
   index forms.
 
 ## References

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -53,8 +53,8 @@ definition `defnrl` and lines 697–704 of the paper.
 
 * `rightRank_bound`, `leftRank_bound`: rank bounds
   $r \le \min(Dd, dD) = Dd$ and similarly $\ell \le Dd$.
-* `sourceCutM₁_apply`, `sourceCutM₂_apply`, `sourceCutM₁Fin_apply`, `sourceCutM₂Fin_apply`: `[simp]` entry formulas for both cuts and both
-  index forms.
+* `sourceCutM₁_apply`, `sourceCutM₂_apply`, `sourceCutM₁Fin_apply`,
+  `sourceCutM₂Fin_apply`: `[simp]` entry formulas for both cuts and both index forms.
 
 ## References
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -175,7 +175,8 @@ $i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
 
 \begin{definition}[Source matrix cuts]
     \label{def:mpu_source_cuts}
-    \lean{MPOTensor.sourceCutM₁, MPOTensor.sourceCutM₂}
+    \lean{MPOTensor.sourceCutM₁, MPOTensor.sourceCutM₂,
+      MPOTensor.sourceCutM₁_apply, MPOTensor.sourceCutM₂_apply}
     \leanok
     The first and second source matrix cuts of $\mathcal U$ are the matrices
     $\mathcal M_1$ and $\mathcal M_2$ defined by
@@ -187,31 +188,17 @@ $i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
     \end{align}
     Thus $\mathcal M_1$ groups the left auxiliary index with the lower
     physical index, whereas $\mathcal M_2$ groups it with the upper physical
-    index.
+    index.  The displayed equations also give their entrywise evaluation
+    formulas.
 \end{definition}
-
-\begin{lemma}[Entries of the source matrix cuts]
-    \label{lem:mpu_source_cut_entries}
-    \lean{MPOTensor.sourceCutM₁_apply, MPOTensor.sourceCutM₂_apply}
-    \leanok
-    \uses{def:mpu_source_cuts}
-    For all $i,j\in P$ and $\alpha,\beta\in A$, the entries of the two cuts
-    are
-    \begin{align}
-        (\mathcal M_1)_{(\alpha,j),(i,\beta)}
-            &= \mathcal U^i_{j,\alpha,\beta}, \\
-        (\mathcal M_2)_{(\alpha,i),(j,\beta)}
-            &= \mathcal U^i_{j,\alpha,\beta}.
-    \end{align}
-\end{lemma}
-
-\begin{proof}\leanok
-    Both identities follow directly from Definition~\ref{def:mpu_source_cuts}.
-\end{proof}
 
 \begin{definition}[Enumerated source matrix cuts]
     \label{def:mpu_source_cuts_fin}
-    \lean{MPOTensor.sourceCutM₁Fin, MPOTensor.sourceCutM₂Fin}
+    \lean{MPOTensor.sourceCutM₁Fin, MPOTensor.sourceCutM₂Fin,
+      MPOTensor.sourceCutM₁Fin_eq_reindex, MPOTensor.sourceCutM₂Fin_eq_reindex,
+      MPOTensor.sourceCutM₁Fin_apply, MPOTensor.sourceCutM₂Fin_apply,
+      MPOTensor.sourceCutM₁_rank_eq_sourceCutM₁Fin_rank,
+      MPOTensor.sourceCutM₂_rank_eq_sourceCutM₂Fin_rank}
     \leanok
     \uses{def:mpu_source_cuts}
     Choose the standard enumerations
@@ -219,43 +206,16 @@ $i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
     $P\times A\cong\{0,\ldots,dD-1\}$.  The enumerated source cuts
     $\widetilde{\mathcal M}_1$ and $\widetilde{\mathcal M}_2$ are obtained
     from $\mathcal M_1$ and $\mathcal M_2$ by transporting their row and
-    column indices along these bijections.
-\end{definition}
-
-\begin{lemma}[Reindexing formulas for the source cuts]
-    \label{lem:mpu_source_cut_reindex}
-    \lean{MPOTensor.sourceCutM₁Fin_eq_reindex, MPOTensor.sourceCutM₂Fin_eq_reindex,
-      MPOTensor.sourceCutM₁Fin_apply, MPOTensor.sourceCutM₂Fin_apply}
-    \leanok
-    \uses{def:mpu_source_cuts, def:mpu_source_cuts_fin}
-    Each enumerated source cut is the corresponding product-indexed cut
-    transported along the standard row and column bijections.  In particular,
-    its entry at enumerated indices is the entry of the original cut at their
-    inverse images.
-\end{lemma}
-
-\begin{proof}\leanok
-    This is the defining property of transport of a matrix along bijections.
-\end{proof}
-
-\begin{lemma}[Ranks are invariant under source-cut enumeration]
-    \label{lem:mpu_source_cut_rank_reindex}
-    \lean{MPOTensor.sourceCutM₁_rank_eq_sourceCutM₁Fin_rank,
-      MPOTensor.sourceCutM₂_rank_eq_sourceCutM₂Fin_rank}
-    \leanok
-    \uses{lem:mpu_source_cut_reindex}
-    Reindexing does not change either matrix rank:
+    column indices along these bijections.  Their entries are obtained by
+    applying the original cuts to the inverse images of the enumerated
+    indices, and bijective reindexing preserves their ranks:
     \begin{align}
         \operatorname{rank}(\mathcal M_1)
             &= \operatorname{rank}(\widetilde{\mathcal M}_1), \\
         \operatorname{rank}(\mathcal M_2)
             &= \operatorname{rank}(\widetilde{\mathcal M}_2).
     \end{align}
-\end{lemma}
-
-\begin{proof}\leanok
-    Matrix rank is invariant under bijective reindexing of rows and columns.
-\end{proof}
+\end{definition}
 
 \begin{definition}[Right and left ranks]
     \label{def:mpu_right_left_ranks}
@@ -274,7 +234,7 @@ $i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
     \label{thm:mpu_right_rank_bound}
     \lean{MPOTensor.rightRank_bound}
     \leanok
-    \uses{def:mpu_source_cuts, def:mpu_right_left_ranks}
+    \uses{def:mpu_right_left_ranks}
     Every tensor $\mathcal U$ of physical dimension $d$ and auxiliary
     dimension $D$ satisfies
     \begin{align}
@@ -283,6 +243,7 @@ $i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpu_source_cuts}
     The rank of $\mathcal M_1$ is at most its number $dD=Dd$ of columns.
 \end{proof}
 
@@ -290,7 +251,7 @@ $i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
     \label{thm:mpu_left_rank_bound}
     \lean{MPOTensor.leftRank_bound}
     \leanok
-    \uses{def:mpu_source_cuts, def:mpu_right_left_ranks}
+    \uses{def:mpu_right_left_ranks}
     Every tensor $\mathcal U$ of physical dimension $d$ and auxiliary
     dimension $D$ satisfies
     \begin{align}
@@ -299,5 +260,6 @@ $i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpu_source_cuts}
     The rank of $\mathcal M_2$ is at most its number $dD=Dd$ of columns.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -166,67 +166,56 @@ closing a chain of $N$ copies of $\mathcal U$.
     unitary.  Simultaneous reindexing preserves unitarity.
 \end{proof}
 
-We now introduce the two matrix unfoldings used in the singular-value analysis
-of a matrix product unitary tensor in Section~III of
-\cite{Cirac2017MPU}.  Let $P$ and $A$ be finite index sets of cardinalities
-$d$ and $D$, respectively, and write
-$\mathcal U^i_{j,\alpha,\beta}$ for the entries of a tensor $\mathcal U$, where
-$i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
+We now introduce the two matrices used for the singular-value decompositions of
+a Matrix Product Unitary tensor in Section~III of \cite{Cirac2017MPU}.  Write
+$\mathcal U^i_{j,\alpha,\beta}$ for the entries of the tensor, where $i,j$ are
+physical indices and $\alpha,\beta$ are auxiliary indices.
 
-\begin{definition}[Source matrix cuts]
-    \label{def:mpu_source_cuts}
-    \lean{MPOTensor.sourceCutM₁, MPOTensor.sourceCutM₂,
-      MPOTensor.sourceCutM₁_apply, MPOTensor.sourceCutM₂_apply}
+\begin{definition}[First matrix associated to a Matrix Product Unitary tensor]
+    \label{def:mpu_source_matrix_one}
+    \lean{MPOTensor.sourceCutM₁}
     \leanok
-    The first and second source matrix cuts of $\mathcal U$ are the matrices
-    $\mathcal M_1$ and $\mathcal M_2$ defined by
+    The matrix $M_1$ is obtained by combining the left auxiliary index with the
+    lower physical index, and the upper physical index with the right auxiliary
+    index. Thus
     \begin{align}
-        (\mathcal M_1)_{(\alpha,j),(i,\beta)}
-            &= \mathcal U^i_{j,\alpha,\beta}, \\
-        (\mathcal M_2)_{(\alpha,i),(j,\beta)}
-            &= \mathcal U^i_{j,\alpha,\beta}.
-    \end{align}
-    Thus $\mathcal M_1$ groups the left auxiliary index with the lower
-    physical index, whereas $\mathcal M_2$ groups it with the upper physical
-    index.  The displayed equations also give their entrywise evaluation
-    formulas.
-\end{definition}
-
-\begin{definition}[Enumerated source matrix cuts]
-    \label{def:mpu_source_cuts_fin}
-    \lean{MPOTensor.sourceCutM₁Fin, MPOTensor.sourceCutM₂Fin,
-      MPOTensor.sourceCutM₁Fin_eq_reindex, MPOTensor.sourceCutM₂Fin_eq_reindex,
-      MPOTensor.sourceCutM₁Fin_apply, MPOTensor.sourceCutM₂Fin_apply,
-      MPOTensor.sourceCutM₁_rank_eq_sourceCutM₁Fin_rank,
-      MPOTensor.sourceCutM₂_rank_eq_sourceCutM₂Fin_rank}
-    \leanok
-    \uses{def:mpu_source_cuts}
-    Choose the standard enumerations
-    $A\times P\cong\{0,\ldots,Dd-1\}$ and
-    $P\times A\cong\{0,\ldots,dD-1\}$.  The enumerated source cuts
-    $\widetilde{\mathcal M}_1$ and $\widetilde{\mathcal M}_2$ are obtained
-    from $\mathcal M_1$ and $\mathcal M_2$ by transporting their row and
-    column indices along these bijections.  Their entries are obtained by
-    applying the original cuts to the inverse images of the enumerated
-    indices, and bijective reindexing preserves their ranks:
-    \begin{align}
-        \operatorname{rank}(\mathcal M_1)
-            &= \operatorname{rank}(\widetilde{\mathcal M}_1), \\
-        \operatorname{rank}(\mathcal M_2)
-            &= \operatorname{rank}(\widetilde{\mathcal M}_2).
+        (M_1)_{(\alpha,j),(i,\beta)}
+        &= \mathcal U^i_{j,\alpha,\beta}.
     \end{align}
 \end{definition}
 
-\begin{definition}[Right and left ranks]
-    \label{def:mpu_right_left_ranks}
-    \lean{MPOTensor.rightRank, MPOTensor.leftRank,
-      MPOTensor.rightRank_eq, MPOTensor.leftRank_eq}
+\begin{definition}[Second matrix associated to a Matrix Product Unitary tensor]
+    \label{def:mpu_source_matrix_two}
+    \lean{MPOTensor.sourceCutM₂}
     \leanok
-    \uses{def:mpu_source_cuts}
-    The right rank $r[\mathcal U]$ and left rank $\ell[\mathcal U]$ are
+    The matrix $M_2$ is obtained by combining the left auxiliary index with the
+    upper physical index, and the lower physical index with the right auxiliary
+    index. Thus
     \begin{align}
-        r[\mathcal U] &= \operatorname{rank}(\mathcal M_1), \\
-        \ell[\mathcal U] &= \operatorname{rank}(\mathcal M_2).
+        (M_2)_{(\alpha,i),(j,\beta)}
+        &= \mathcal U^i_{j,\alpha,\beta}.
+    \end{align}
+\end{definition}
+
+\begin{definition}[Right rank]
+    \label{def:mpu_right_rank}
+    \lean{MPOTensor.rightRank}
+    \leanok
+    \uses{def:mpu_source_matrix_one}
+    The right rank is
+    \begin{align}
+        r &= \operatorname{rank}(M_1).
+    \end{align}
+\end{definition}
+
+\begin{definition}[Left rank]
+    \label{def:mpu_left_rank}
+    \lean{MPOTensor.leftRank}
+    \leanok
+    \uses{def:mpu_source_matrix_two}
+    The left rank is
+    \begin{align}
+        \ell &= \operatorname{rank}(M_2).
     \end{align}
 \end{definition}
 
@@ -234,32 +223,36 @@ $i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
     \label{thm:mpu_right_rank_bound}
     \lean{MPOTensor.rightRank_bound}
     \leanok
-    \uses{def:mpu_right_left_ranks}
-    Every tensor $\mathcal U$ of physical dimension $d$ and auxiliary
-    dimension $D$ satisfies
+    \uses{def:mpu_right_rank}
+    If the physical and auxiliary dimensions are $d$ and $D$, respectively,
+    then
     \begin{align}
-        r[\mathcal U] &\leq Dd.
+        r &\leq Dd.
     \end{align}
 \end{theorem}
 
-\begin{proof}\leanok
-    \uses{def:mpu_source_cuts}
-    The rank of $\mathcal M_1$ is at most its number $dD=Dd$ of columns.
+\begin{proof}
+    \leanok
+    \uses{def:mpu_source_matrix_one}
+    The matrix $M_1$ has $Dd$ rows and $dD$ columns, so its rank is at most
+    $Dd$.
 \end{proof}
 
 \begin{theorem}[Left-rank bound]
     \label{thm:mpu_left_rank_bound}
     \lean{MPOTensor.leftRank_bound}
     \leanok
-    \uses{def:mpu_right_left_ranks}
-    Every tensor $\mathcal U$ of physical dimension $d$ and auxiliary
-    dimension $D$ satisfies
+    \uses{def:mpu_left_rank}
+    If the physical and auxiliary dimensions are $d$ and $D$, respectively,
+    then
     \begin{align}
-        \ell[\mathcal U] &\leq Dd.
+        \ell &\leq Dd.
     \end{align}
 \end{theorem}
 
-\begin{proof}\leanok
-    \uses{def:mpu_source_cuts}
-    The rank of $\mathcal M_2$ is at most its number $dD=Dd$ of columns.
+\begin{proof}
+    \leanok
+    \uses{def:mpu_source_matrix_two}
+    The matrix $M_2$ has $Dd$ rows and $dD$ columns, so its rank is at most
+    $Dd$.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -165,3 +165,139 @@ closing a chain of $N$ copies of $\mathcal U$.
     configurations.  If $N>1$ and $L>0$, then $NL>1$, so $U^{(NL)}$ is
     unitary.  Simultaneous reindexing preserves unitarity.
 \end{proof}
+
+We now introduce the two matrix unfoldings used in the singular-value analysis
+of a matrix product unitary tensor in Section~III of
+\cite{Cirac2017MPU}.  Let $P$ and $A$ be finite index sets of cardinalities
+$d$ and $D$, respectively, and write
+$\mathcal U^i_{j,\alpha,\beta}$ for the entries of a tensor $\mathcal U$, where
+$i,j\in P$ are physical indices and $\alpha,\beta\in A$ are auxiliary indices.
+
+\begin{definition}[Source matrix cuts]
+    \label{def:mpu_source_cuts}
+    \lean{MPOTensor.sourceCutM₁, MPOTensor.sourceCutM₂}
+    \leanok
+    The first and second source matrix cuts of $\mathcal U$ are the matrices
+    $\mathcal M_1$ and $\mathcal M_2$ defined by
+    \begin{align}
+        (\mathcal M_1)_{(\alpha,j),(i,\beta)}
+            &= \mathcal U^i_{j,\alpha,\beta}, \\
+        (\mathcal M_2)_{(\alpha,i),(j,\beta)}
+            &= \mathcal U^i_{j,\alpha,\beta}.
+    \end{align}
+    Thus $\mathcal M_1$ groups the left auxiliary index with the lower
+    physical index, whereas $\mathcal M_2$ groups it with the upper physical
+    index.
+\end{definition}
+
+\begin{lemma}[Entries of the source matrix cuts]
+    \label{lem:mpu_source_cut_entries}
+    \lean{MPOTensor.sourceCutM₁_apply, MPOTensor.sourceCutM₂_apply}
+    \leanok
+    \uses{def:mpu_source_cuts}
+    For all $i,j\in P$ and $\alpha,\beta\in A$, the entries of the two cuts
+    are
+    \begin{align}
+        (\mathcal M_1)_{(\alpha,j),(i,\beta)}
+            &= \mathcal U^i_{j,\alpha,\beta}, \\
+        (\mathcal M_2)_{(\alpha,i),(j,\beta)}
+            &= \mathcal U^i_{j,\alpha,\beta}.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Both identities follow directly from Definition~\ref{def:mpu_source_cuts}.
+\end{proof}
+
+\begin{definition}[Enumerated source matrix cuts]
+    \label{def:mpu_source_cuts_fin}
+    \lean{MPOTensor.sourceCutM₁Fin, MPOTensor.sourceCutM₂Fin}
+    \leanok
+    \uses{def:mpu_source_cuts}
+    Choose the standard enumerations
+    $A\times P\cong\{0,\ldots,Dd-1\}$ and
+    $P\times A\cong\{0,\ldots,dD-1\}$.  The enumerated source cuts
+    $\widetilde{\mathcal M}_1$ and $\widetilde{\mathcal M}_2$ are obtained
+    from $\mathcal M_1$ and $\mathcal M_2$ by transporting their row and
+    column indices along these bijections.
+\end{definition}
+
+\begin{lemma}[Reindexing formulas for the source cuts]
+    \label{lem:mpu_source_cut_reindex}
+    \lean{MPOTensor.sourceCutM₁Fin_eq_reindex, MPOTensor.sourceCutM₂Fin_eq_reindex,
+      MPOTensor.sourceCutM₁Fin_apply, MPOTensor.sourceCutM₂Fin_apply}
+    \leanok
+    \uses{def:mpu_source_cuts, def:mpu_source_cuts_fin}
+    Each enumerated source cut is the corresponding product-indexed cut
+    transported along the standard row and column bijections.  In particular,
+    its entry at enumerated indices is the entry of the original cut at their
+    inverse images.
+\end{lemma}
+
+\begin{proof}\leanok
+    This is the defining property of transport of a matrix along bijections.
+\end{proof}
+
+\begin{lemma}[Ranks are invariant under source-cut enumeration]
+    \label{lem:mpu_source_cut_rank_reindex}
+    \lean{MPOTensor.sourceCutM₁_rank_eq_sourceCutM₁Fin_rank,
+      MPOTensor.sourceCutM₂_rank_eq_sourceCutM₂Fin_rank}
+    \leanok
+    \uses{lem:mpu_source_cut_reindex}
+    Reindexing does not change either matrix rank:
+    \begin{align}
+        \operatorname{rank}(\mathcal M_1)
+            &= \operatorname{rank}(\widetilde{\mathcal M}_1), \\
+        \operatorname{rank}(\mathcal M_2)
+            &= \operatorname{rank}(\widetilde{\mathcal M}_2).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Matrix rank is invariant under bijective reindexing of rows and columns.
+\end{proof}
+
+\begin{definition}[Right and left ranks]
+    \label{def:mpu_right_left_ranks}
+    \lean{MPOTensor.rightRank, MPOTensor.leftRank,
+      MPOTensor.rightRank_eq, MPOTensor.leftRank_eq}
+    \leanok
+    \uses{def:mpu_source_cuts}
+    The right rank $r[\mathcal U]$ and left rank $\ell[\mathcal U]$ are
+    \begin{align}
+        r[\mathcal U] &= \operatorname{rank}(\mathcal M_1), \\
+        \ell[\mathcal U] &= \operatorname{rank}(\mathcal M_2).
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Right-rank bound]
+    \label{thm:mpu_right_rank_bound}
+    \lean{MPOTensor.rightRank_bound}
+    \leanok
+    \uses{def:mpu_source_cuts, def:mpu_right_left_ranks}
+    Every tensor $\mathcal U$ of physical dimension $d$ and auxiliary
+    dimension $D$ satisfies
+    \begin{align}
+        r[\mathcal U] &\leq Dd.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    The rank of $\mathcal M_1$ is at most its number $dD=Dd$ of columns.
+\end{proof}
+
+\begin{theorem}[Left-rank bound]
+    \label{thm:mpu_left_rank_bound}
+    \lean{MPOTensor.leftRank_bound}
+    \leanok
+    \uses{def:mpu_source_cuts, def:mpu_right_left_ranks}
+    Every tensor $\mathcal U$ of physical dimension $d$ and auxiliary
+    dimension $D$ satisfies
+    \begin{align}
+        \ell[\mathcal U] &\leq Dd.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    The rank of $\mathcal M_2$ is at most its number $dD=Dd$ of columns.
+\end{proof}


### PR DESCRIPTION
Closes LionSR/TNLean#5722
Prerequisite for LionSR/TNLean#5708

## Summary
Define `MPOTensor.sourceCutM₁` and `MPOTensor.sourceCutM₂`, the two source matrices
obtained by regrouping the four indices of an MPU tensor, following
[arXiv:1703.09188](https://arxiv.org/abs/1703.09188) (Cirac–Perez-Garcia–Schuch–Verstraete),
Section III, definition `defnrl`, lines 450–477.

### Conventions
- `MPOTensor d D = Fin d → Fin d → Matrix (Fin D) (Fin D) ℂ` (ket, bra, left-virtual, right-virtual)
- `sourceCutM₁`: row = (left, down), column = (up, right) — entry `(α,j),(i,β) ↦ U i j α β`
- `sourceCutM₂`: row = (left, up), column = (down, right) — entry `(α,i),(j,β) ↦ U i j α β`
- `rightRank` = `r` (right rank), `leftRank` = `ℓ` (left rank) as in paper lines 697–704

### Contents
- Primary product-index matrix definitions
- `Fin (D*d)` reindexed formulations
- `[simp]` entry lemmas for all four index forms
- Rank bounds `r, ℓ ≤ D·d`
- Module under `TNLean/MPS/MPU/` with conventional aggregator updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New definitions and elementary rank bounds on existing `MPOTensor` infrastructure; no changes to auth, runtime behavior, or core MPU unitarity logic.
> 
> **Overview**
> Adds **`TNLean/MPS/MPU/SourceCuts.lean`** and wires it through the generated **`TNLean.MPS.MPU`** aggregator, formalizing Cirac et al. (arXiv:1703.09188) Section III source cuts for an **`MPOTensor`**.
> 
> **`sourceCutM₁`** and **`sourceCutM₂`** are the two index-regroupings into matrices (product-index rows/columns plus **`Fin (D·d)`** reindexings via **`finProdFinEquiv`**), with **`[simp]`** entry lemmas and rank-preservation under reindexing.
> 
> **`rightRank`** (**`r`**) and **`leftRank`** (**`ℓ`**) are the matrix ranks, with scoped notation **`r[U]`** / **`ℓ[U]`**, and **`rightRank_bound`** / **`leftRank_bound`** proving **`r, ℓ ≤ D·d`**.
> 
> The blueprint chapter **`ch28_mpu.tex`** gains matching definitions and rank-bound theorems with Lean links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e9280f684f2ce221dd06f0f77d8cd2092323c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->