### PR TITLE
docs(blueprint): record MPU core and blocking declarations

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -102,25 +102,13 @@ closing a chain of $N$ copies of $\mathcal U$.
 \begin{definition}[Matrix product unitary tensor]
     \label{def:mpu}
     \lean{MPOTensor.IsMPU}
+    \lean{MPOTensor.IsMPU.mpo_mem_unitaryGroup}
     \leanok
+    \uses{def:mpo_family}
     The tensor $\mathcal U$ generates matrix product unitaries if $U^{(N)}$ is
     unitary for every integer $N>1$.  This is the matrix product unitary
     condition in \cite[Section~III, equation~(10)]{Cirac2017MPU}.
 \end{definition}
-
-\begin{lemma}[Unitarity at a fixed system size]
-    \label{lem:mpu_unitary_fixed_size}
-    \lean{MPOTensor.IsMPU.mpo_mem_unitaryGroup}
-    \leanok
-    \uses{def:mpu}
-    If $\mathcal U$ generates matrix product unitaries and $N>1$, then
-    $U^{(N)}$ is unitary.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{def:mpu}
-    This is the defining condition at system size $N$.
-\end{proof}
 
 \begin{lemma}[First matrix product unitarity equation]
     \label{lem:mpu_mul_adjoint}
@@ -134,7 +122,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{lem:mpu_unitary_fixed_size}
+    \uses{def:mpu}
     Expand the unitary-group condition for $U^{(N)}$.
 \end{proof}
 
@@ -152,7 +140,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{lem:mpu_unitary_fixed_size}
+    \uses{def:mpu}
     Use the equivalent left-multiplied characterization of a unitary matrix.
 \end{proof}
 
@@ -170,7 +158,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{lem:mpu_unitary_fixed_size, thm:mpu_reindex_unitary,
+    \uses{def:mpu, thm:mpu_reindex_unitary,
         thm:mpdo_closed_chain_physical_blocking}
     At system size $N$, closing the blocked tensor gives $U^{(NL)}$, up to the
     canonical bijection between $N$ blocked configurations and $NL$ unblocked

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -76,7 +76,7 @@ final strict $D^4$ estimate.
 
 \section{The matrix product unitary condition}
 
-Let $\mathcal U=(U^{ij})_{i,j=1}^d$ be a matrix product operator tensor of
+Let $\mathcal U=\{U^{ij}\}_{i,j=0}^{d-1}$ be a matrix product operator tensor of
 bond dimension $D$, and write $U^{(N)}$ for the periodic operator obtained by
 closing a chain of $N$ copies of $\mathcal U$.
 
@@ -105,7 +105,7 @@ closing a chain of $N$ copies of $\mathcal U$.
     \leanok
     The tensor $\mathcal U$ generates matrix product unitaries if $U^{(N)}$ is
     unitary for every integer $N>1$.  This is the matrix product unitary
-    condition in \cite[lines~319--335]{Cirac2017MPU}.
+    condition in \cite[Section~III, equation~(10)]{Cirac2017MPU}.
 \end{definition}
 
 \begin{lemma}[Unitarity at a fixed system size]
@@ -126,7 +126,7 @@ closing a chain of $N$ copies of $\mathcal U$.
     \label{lem:mpu_mul_adjoint}
     \lean{MPOTensor.IsMPU.mpo_mul_conjTranspose_mpo}
     \leanok
-    \uses{lem:mpu_unitary_fixed_size}
+    \uses{def:mpu}
     If $\mathcal U$ generates matrix product unitaries and $N>1$, then
     \begin{align}
         U^{(N)}\bigl(U^{(N)}\bigr)^\dagger &= \Id.
@@ -142,13 +142,13 @@ closing a chain of $N$ copies of $\mathcal U$.
     \label{lem:mpu_adjoint_mul}
     \lean{MPOTensor.IsMPU.conjTranspose_mpo_mul_mpo}
     \leanok
-    \uses{lem:mpu_unitary_fixed_size}
+    \uses{def:mpu}
     If $\mathcal U$ generates matrix product unitaries and $N>1$, then
     \begin{align}
         \bigl(U^{(N)}\bigr)^\dagger U^{(N)} &= \Id.
     \end{align}
     This is the unitarity equation displayed in
-    \cite[lines~331--335]{Cirac2017MPU}.
+    \cite[Section~III, equation~(12)]{Cirac2017MPU}.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -156,23 +156,22 @@ closing a chain of $N$ copies of $\mathcal U$.
     Use the equivalent left-multiplied characterization of a unitary matrix.
 \end{proof}
 
-\begin{theorem}[Physical blocking preserves matrix product unitarity]
-    \label{thm:mpu_blocking}
+\begin{lemma}[Physical blocking preserves matrix product unitarity]
+    \label{lem:mpu_blocking}
     \lean{MPOTensor.IsMPU.blockTensor}
     \leanok
-    \uses{def:mpu, lem:mpu_unitary_fixed_size,
-        thm:mpu_reindex_unitary}
+    \uses{def:mpu}
     Suppose that $\mathcal U$ generates matrix product unitaries.  For every
-    positive integer $L$, the tensor $\mathcal U_L$ obtained by blocking $L$
-    adjacent sites also generates matrix product unitaries.  This is the
-    blocking operation of \cite[lines~295--305]{Cirac2017MPU}; the paper uses
-    without further comment that a blocked MPU tensor again generates a
-    unitary family \cite[line~356]{Cirac2017MPU}.
-\end{theorem}
+    positive integer $L$, the tensor $\mathcal U^{[L]}$ obtained by blocking
+    $L$ adjacent sites also generates matrix product unitaries.  This is the
+    blocking operation of \cite[Definition~II.5 and equation~(9)]{Cirac2017MPU};
+    preservation of the MPU property under blocking is used in the proof of
+    \cite[Proposition~III.2]{Cirac2017MPU}.
+\end{lemma}
 
 \begin{proof}\leanok
-    \uses{def:mpu, lem:mpu_unitary_fixed_size,
-        thm:mpu_reindex_unitary}
+    \uses{lem:mpu_unitary_fixed_size, thm:mpu_reindex_unitary,
+        thm:mpdo_closed_chain_physical_blocking}
     At system size $N$, closing the blocked tensor gives $U^{(NL)}$, up to the
     canonical bijection between $N$ blocked configurations and $NL$ unblocked
     configurations.  If $N>1$ and $L>0$, then $NL>1$, so $U^{(NL)}$ is

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -166,7 +166,7 @@ closing a chain of $N$ copies of $\mathcal U$.
     $L$ adjacent sites also generates matrix product unitaries.  This is the
     blocking operation of \cite[Definition~II.5 and equation~(9)]{Cirac2017MPU};
     preservation of the MPU property under blocking is used in the proof of
-    \cite[Proposition~III.2]{Cirac2017MPU}.
+    \cite[Proposition~III.3]{Cirac2017MPU}.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -73,3 +73,108 @@ The length $n$ is a weak bound, not a strict bound below $n$; the latter is
 false for strictly upper-triangular matrices.  This corrects the intermediate
 strict inequality in \cite[lines~405--426]{Cirac2017MPU} without changing its
 final strict $D^4$ estimate.
+
+\section{The matrix product unitary condition}
+
+Let $\mathcal U=(U^{ij})_{i,j=1}^d$ be a matrix product operator tensor of
+bond dimension $D$, and write $U^{(N)}$ for the periodic operator obtained by
+closing a chain of $N$ copies of $\mathcal U$.
+
+\begin{theorem}[Unitarity under simultaneous reindexing]
+    \label{thm:mpu_reindex_unitary}
+    \lean{Matrix.reindex_mem_unitaryGroup}
+    \leanok
+    Let $I$ and $J$ be finite sets, let $e\colon I\to J$ be a bijection, and
+    let $A$ be a unitary matrix indexed by $I$.  The matrix indexed by $J$
+    whose $(j,k)$ entry is
+    \begin{align}
+        A_{e^{-1}(j),e^{-1}(k)}
+    \end{align}
+    is unitary.
+\end{theorem}
+
+\begin{proof}\leanok
+    Simultaneous reindexing preserves the identity and matrix multiplication,
+    and it commutes with the conjugate transpose.  Reindex the equation
+    $AA^\dagger=\Id$.
+\end{proof}
+
+\begin{definition}[Matrix product unitary tensor]
+    \label{def:mpu}
+    \lean{MPOTensor.IsMPU}
+    \leanok
+    The tensor $\mathcal U$ generates matrix product unitaries if $U^{(N)}$ is
+    unitary for every integer $N>1$.  This is the matrix product unitary
+    condition in \cite[lines~319--335]{Cirac2017MPU}.
+\end{definition}
+
+\begin{lemma}[Unitarity at a fixed system size]
+    \label{lem:mpu_unitary_fixed_size}
+    \lean{MPOTensor.IsMPU.mpo_mem_unitaryGroup}
+    \leanok
+    \uses{def:mpu}
+    If $\mathcal U$ generates matrix product unitaries and $N>1$, then
+    $U^{(N)}$ is unitary.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:mpu}
+    This is the defining condition at system size $N$.
+\end{proof}
+
+\begin{lemma}[First matrix product unitarity equation]
+    \label{lem:mpu_mul_adjoint}
+    \lean{MPOTensor.IsMPU.mpo_mul_conjTranspose_mpo}
+    \leanok
+    \uses{lem:mpu_unitary_fixed_size}
+    If $\mathcal U$ generates matrix product unitaries and $N>1$, then
+    \begin{align}
+        U^{(N)}\bigl(U^{(N)}\bigr)^\dagger &= \Id.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:mpu_unitary_fixed_size}
+    Expand the unitary-group condition for $U^{(N)}$.
+\end{proof}
+
+\begin{lemma}[Second matrix product unitarity equation]
+    \label{lem:mpu_adjoint_mul}
+    \lean{MPOTensor.IsMPU.conjTranspose_mpo_mul_mpo}
+    \leanok
+    \uses{lem:mpu_unitary_fixed_size}
+    If $\mathcal U$ generates matrix product unitaries and $N>1$, then
+    \begin{align}
+        \bigl(U^{(N)}\bigr)^\dagger U^{(N)} &= \Id.
+    \end{align}
+    This is the unitarity equation displayed in
+    \cite[lines~331--335]{Cirac2017MPU}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:mpu_unitary_fixed_size}
+    Use the equivalent left-multiplied characterization of a unitary matrix.
+\end{proof}
+
+\begin{theorem}[Physical blocking preserves matrix product unitarity]
+    \label{thm:mpu_blocking}
+    \lean{MPOTensor.IsMPU.blockTensor}
+    \leanok
+    \uses{def:mpu, lem:mpu_unitary_fixed_size,
+        thm:mpu_reindex_unitary}
+    Suppose that $\mathcal U$ generates matrix product unitaries.  For every
+    positive integer $L$, the tensor $\mathcal U_L$ obtained by blocking $L$
+    adjacent sites also generates matrix product unitaries.  This is the
+    blocking operation of \cite[lines~295--305]{Cirac2017MPU}; the paper uses
+    without further comment that a blocked MPU tensor again generates a
+    unitary family \cite[line~356]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu, lem:mpu_unitary_fixed_size,
+        thm:mpu_reindex_unitary}
+    At system size $N$, closing the blocked tensor gives $U^{(NL)}$, up to the
+    canonical bijection between $N$ blocked configurations and $NL$ unblocked
+    configurations.  If $N>1$ and $L>0$, then $NL>1$, so $U^{(NL)}$ is
+    unitary.  Simultaneous reindexing preserves unitarity.
+\end{proof}


### PR DESCRIPTION
Follow-up to #5721 and #5705.

Adds the required LeanBlueprint entries for the MPU core predicate, its unitarity equations, matrix reindexing preservation, and blocking preservation. The implementation PR merged while this dedicated blueprint pass was still running.

Checks:
- `lake env lean TNLean/MPS/MPU/Basic.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint sync with no runtime or proof changes; only adds LaTeX and Lean name links for already-merged code.
> 
> **Overview**
> Adds a new **matrix product unitary condition** section to chapter 28 of the blueprint, wiring existing Lean declarations into the formal document after the merged implementation work.
> 
> The section defines **IsMPU** (periodic closed-chain operators unitary for all \(N>1\)), records the two standard unitarity equations as lemmas, and states that **simultaneous matrix reindexing** preserves unitarity (`Matrix.reindex_mem_unitaryGroup`). It also documents **physical blocking**: blocking \(L\) sites preserves the MPU property, with a proof outline that reindexes \(U^{(NL)}\) and cites closed-chain blocking from the MPDO chapter.
> 
> All entries are marked `\leanok` and point at `MPOTensor.IsMPU` and related lemmas in `TNLean/MPS/MPU/Basic.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a686ee55df46c47eb462623ba0dbce4ab3ac5c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->