### PR TITLE
feat(MPS/ParentHamiltonian): package doubly-normalized source-length BNT kernel equality

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -293,7 +293,16 @@ Let \(r\ge2\), let every block be injective at length \(L_0>0\), and assume
 on the complementary segment \(N-L_0\) identifies the boundary matrices before
 and after moving the cut. Each block component therefore satisfies every
 periodic local constraint. This is arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1424--1456. -/
+lines 1424--1456.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -402,7 +411,16 @@ interaction length is
 \[
   3(r-1)(L_0+1)+1 \leq L,
 \]
-and the chain length satisfies \(L+L_0\leq N\). -/
+and the chain length satisfies \(L+L_0\leq N\).
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -446,7 +464,16 @@ theorem
 chain space is the sum of the periodic chain spaces of its blocks.
 
 This is the equality in arXiv:quant-ph/0608197, Theorem 12, proof lines
-1424--1456. -/
+1424--1456.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -475,7 +502,16 @@ of the block-diagonal parent-Hamiltonian kernel in the span of the BNT matrix
 product vectors.
 
 This is the final conditional step in arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1424--1456. -/
+lines 1424--1456.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -510,7 +546,16 @@ theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_c
 BNT block direct sum is exactly the span of the periodic component vectors.
 
 This packages the final equality in arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1424--1456. -/
+lines 1424--1456.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -531,13 +531,15 @@ theorem ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_c
     LinearMap.ker (parentHamiltonian
       (toTensorFromBlocks (d := d) (μ := μ) A) L N) =
       bntMPSVectorSpan A N := by
-  have hFactor :
-      (L₀ + 1) + ((L₀ + 1) + (L₀ + 1)) ≤
-        (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
-    have hrpred : 1 ≤ r - 1 := by omega
-    simpa only [one_mul] using
-      (Nat.mul_le_mul_right ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) hrpred)
-  have hL : L₀ < L := by omega
+  have hL : L₀ < L := by
+    calc
+      L₀ < ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 := by omega
+      _ ≤ (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 :=
+        Nat.add_le_add_right (by
+          simpa only [one_mul] using
+            (Nat.mul_le_mul_right ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
+              (show 1 ≤ r - 1 by omega))) 1
+      _ ≤ L := hRange
   have hN : 0 < N := by omega
   have hNtwo : 2 ≤ N := by omega
   have hLN : L ≤ N := by omega

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -9,6 +9,7 @@ import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
 import TNLean.MPS.ParentHamiltonian.CyclicTranslation
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
+import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 
 /-!
 # Boundary closing by comparison across a cyclic cut
@@ -504,6 +505,52 @@ theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_c
   exact le_of_eq
     (chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07
       μ A hμ hr hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hRange hNlarge)
+
+/-- At the PGVWC07 source range, the parent-Hamiltonian kernel of the normalized
+BNT block direct sum is exactly the span of the periodic component vectors.
+
+This packages the final equality in arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1424--1456. -/
+theorem ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d]
+    (hRange :
+      (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N) :
+    LinearMap.ker (parentHamiltonian
+      (toTensorFromBlocks (d := d) (μ := μ) A) L N) =
+      bntMPSVectorSpan A N := by
+  have hFactor :
+      (L₀ + 1) + ((L₀ + 1) + (L₀ + 1)) ≤
+        (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+    have hrpred : 1 ≤ r - 1 := by omega
+    simpa only [one_mul] using
+      (Nat.mul_le_mul_right ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) hrpred)
+  have hL : L₀ < L := by omega
+  have hN : 0 < N := by omega
+  have hNtwo : 2 ≤ N := by omega
+  have hLN : L ≤ N := by omega
+  have hNstrict : L₀ + 1 < N := by omega
+  apply le_antisymm
+  · apply
+      ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07
+        μ A hμ hr hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hRange hNlarge
+    intro j
+    exact le_of_eq (chainGroundSpace_eq_mpvSubmodule_normal
+      ⟨L₀, hL₀, hBlk j⟩ (hBlk j) hL₀ hNtwo hL hLN hNstrict)
+  · exact bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks
+      μ A hμ hN hLN
 
 /-- The normalized BNT block-diagonal periodic chain space is the sum of the
 single-block periodic chain spaces in the finite Condition C1 range, and the

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -548,12 +548,10 @@ BNT block direct sum is exactly the span of the periodic component vectors.
 This packages the final equality in arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1424--1456.
 
-**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
-length bound, `hUnital` is the source identity
-\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
-source dual fixed-point equation
-\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is documented in
+**Scope restriction:** This PGVWC07 source-length specialization is doubly
+normalized: `hUnital` is the source identity, while `hLeft` fixes the general
+positive dual fixed point to \(\Lambda_j=1\). See
+`docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex` and
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean
@@ -300,8 +300,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -418,8 +418,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07
@@ -471,8 +471,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -509,8 +509,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -553,8 +553,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -149,7 +149,16 @@ to the sum of the open-boundary block spaces.
 For \(r\ge2\), injectivity at the common length \(L_0>0\), and
 \(L\ge3(r-1)(L_0+1)+1\), the one-step intersection identity propagates the local
 constraints to the full chain. This is arXiv:quant-ph/0608197, Theorem 12,
-proof lines 1424--1452. -/
+proof lines 1424--1452.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem
     chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -419,7 +428,16 @@ For \(r\ge2\) and \(L\ge3(r-1)(L_0+1)+1\), every vector in the periodic chain
 space of \(\bigoplus_j\mu_jA_j\) is a sum of vectors in the open-boundary spaces
 \(G_N(A_j)\). Choosing boundary matrices for these summands gives a single
 block-diagonal boundary matrix, as in arXiv:quant-ph/0608197, Theorem 12,
-proof lines 1424--1452. -/
+proof lines 1424--1452.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -79,37 +79,13 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
 
-/-- Finite-length block injectivity gives the periodic-boundary inclusion into the
-sum of local block ground spaces.
-
-Let
-\[
-  B=\bigoplus_j\mu_jA_j,\qquad S_M=\bigvee_jG_M(A_j).
-\]
-Assume each block is injective at length \(L_0\), the blocks are separated
-normalized BNT blocks, and
-\[
-  M-1\ge (L_0+1)+(r-1)((L_0+1)+((L_0+1)+(L_0+1))).
-\]
-Then the one-step identity for \(S_M\) from arXiv:quant-ph/0608197 holds.
-Consequently, for every \(N\ge L\) in this range,
-\[
-  \mathcal G_{N,L}(B)\subseteq S_N.
-\]
-This is the inclusion into the linear span of block local ground spaces used in
-Theorem 12 of arXiv:quant-ph/0608197 (proof lines
-1430--1456). The replacement of \(S_N\) by periodic block chain spaces is the
-separate step of closing the boundaries with block-diagonal boundary
-conditions.
-
-The proof uses only the span-based one-step intersection identity for normalized
-BNT product spans, which is independent of the boundary-condition comparison at
-boundary-crossing windows. The periodic-boundary upgrade — replacing the
-open-boundary span \(\bigvee_jG_N(A_j)\) by
-\(\sum_j\mathcal G_{N,L}(A_j)\) — is the separate comparison of
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
-arXiv:2011.12127, Section IV.C, lines 2126--2128. It is proved by the global
-change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`. -/
+/-- Finite-length block injectivity gives the inclusion into the sum of local
+block ground spaces: \(\mathcal G_{N,L}(B)\subseteq\bigvee_j G_N(A_j)\). Assumes
+each block is injective at \(L_0>0\), the blocks are separated normalized BNT
+blocks, and \(M-1\ge(L_0+1)+(r-1)((L_0+1)+((L_0+1)+(L_0+1)))\). This is the
+inclusion used in Theorem 12 of arXiv:quant-ph/0608197 (proof lines
+1430--1456). The periodic-boundary upgrade is proved by the global change-of-cut
+theorem in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -156,8 +132,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem
     chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07
@@ -269,30 +245,11 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_
       A hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital (by omega)
 
 /-- Open-boundary block decomposition for vectors satisfying the block-diagonal
-periodic constraints.
-
-Let
-\[
-  B=\bigoplus_j\mu_jA_j.
-\]
-Assume the blocks are irreducible, left-canonical, normalized in self-overlap,
-pairwise not gauge-phase equivalent, unital, and injective at a common positive
-length. Then every
+periodic constraints. Under the normalized BNT block-separation hypotheses, every
 \(\psi\in\mathcal G_{N,L}(B)\) has a unique decomposition
-\[
-  \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).
-\]
-This is an open-boundary decomposition. The periodic-boundary upgrade in
-arXiv:quant-ph/0608197, Theorem 12, is a separate boundary-condition
-comparison: one must prove \(\psi_j\in\mathcal G_{N,L}(A_j)\) for the
-block components produced here.
-
-The decomposition uses only the span-based open-boundary inclusion and
-block-separation independence, both independent of the boundary-condition
-comparison at boundary-crossing windows. That periodic-boundary comparison
-(arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
-arXiv:2011.12127, Section IV.C, lines 2126--2128) is proved by the global
-change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`. -/
+\(\psi=\sum_j\psi_j\) with \(\psi_j\in G_N(A_j)\). The periodic-boundary upgrade
+to \(\mathcal G_{N,L}(A_j)\) is proved by the global change-of-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -339,42 +296,11 @@ theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_
   exact sub_eq_zero.mp hzero
 
 /-- Block-diagonal boundary conditions for a vector satisfying the block-diagonal
-periodic constraints.
-
-Let
-\[
-  B=\bigoplus_j\mu_jA_j.
-\]
-Under the normalized BNT block-separation hypotheses and the \(L_0\)-block
-injectivity range bound, every \(\psi\in\mathcal G_{N,L}(B)\) can be
-represented by block-diagonal boundary conditions
-\[
-  \psi=\Gamma_N^B\!\left(\bigoplus_jX_j\right)
-\]
-and each component vector
-\[
-  \Gamma_N^{A_j}(\mu_j^NX_j)
-\]
-lies in the open-boundary ground space \(G_N(A_j)\).
-
-The latter membership is the defining open-boundary range property of the
-displayed boundary matrix. The substantive assertion is the block-diagonal
-representation of \(\psi\). The periodic-boundary upgrade is the separate
-boundary-condition comparison for the cyclic windows crossing the chosen cut.
-
-This proves the displayed statement, in which the component membership is the
-open-boundary range property \(\Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j)\). The
-boundary-condition comparison in arXiv:quant-ph/0608197, proof lines
-1454--1456, and arXiv:2011.12127, lines 2126--2128, shows, under the
-comparison identities, that these same component
-vectors lie in \(\mathcal G_{N,L}(A_j)\).
-
-The block-diagonal boundary representation and the open-boundary component
-membership use only the span-based open-boundary inclusion, independently of
-the boundary-condition comparison at boundary-crossing windows. The
-periodic-boundary upgrade to \(\mathcal G_{N,L}(A_j)\) (arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1456; arXiv:2011.12127, Section IV.C, lines
-2126--2128) is proved by the global change-of-cut theorem in
+periodic constraints. Under the normalized BNT block-separation hypotheses, every
+\(\psi\in\mathcal G_{N,L}(B)\) can be represented by block-diagonal boundary
+conditions \(\psi=\Gamma_N^B(\bigoplus_jX_j)\) with each component
+\(\Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j)\). The periodic-boundary upgrade to
+\(\mathcal G_{N,L}(A_j)\) is proved by the global change-of-cut theorem in
 `BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
@@ -435,8 +361,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07
@@ -535,33 +461,11 @@ theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_
   · exact chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital hN hL hLN hRange
 
-/-- Finite-length block injectivity gives the two established inclusions for the
-block-diagonal periodic chain space.
-
-Let
-\[
-  B=\bigoplus_j\mu_jA_j.
-\]
-Under the normalized BNT block-separation hypotheses and the corresponding
-finite injectivity range,
-\[
-  \bigvee_j \mathcal G_{N,L}(A_j)
-  \subseteq
-  \mathcal G_{N,L}(B)
-  \subseteq
-  \bigvee_j G_N(A_j),
-\]
-and the right-hand local block sum is internal. The separate step from
-arXiv:quant-ph/0608197 is
-to close the boundaries with block-diagonal boundary conditions.
-
-Both displayed inclusions and the internal-direct-sum conclusion use only the
-span-based open-boundary results, independently of the boundary-condition
-comparison at boundary-crossing windows. The periodic-boundary upgrade
-replacing \(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\)
-(arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
-arXiv:2011.12127, Section IV.C, lines 2126--2128) is proved by the global
-change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`. -/
+/-- Finite-length block injectivity gives the two established inclusions:
+\(\bigvee_j\mathcal G_{N,L}(A_j)\subseteq\mathcal G_{N,L}(B)\subseteq\bigvee_j G_N(A_j)\),
+with the right-hand sum internal. The periodic-boundary upgrade replacing
+\(\bigvee_j G_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\) is proved by the
+global change-of-cut theorem in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -222,8 +222,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -310,8 +310,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -407,8 +407,8 @@ length bound, `hUnital` is the source identity
 \(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
 source dual fixed-point equation
 \(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
-\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
-documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\(\Lambda_j=1\). The general normalization is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -215,7 +215,16 @@ For at least two blocks, the sharp direct-sum argument gives the full tuple
 span at length \(3(r-1)(L_0+1)\). Right-canonical normalization then propagates
 that span to every larger length. Thus no additional injective prefix is
 needed. The base span is arXiv:quant-ph/0608197, lines 1346--1421; the unital
-propagation is lines 893--898. -/
+propagation is lines 893--898.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -294,7 +303,16 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
 /-- In the PGVWC07 source range, the normalized BNT local spaces form an
 internal direct sum.
 
-This is the direct-sum lemma in arXiv:quant-ph/0608197, lines 1346--1421. -/
+This is the direct-sum lemma in arXiv:quant-ph/0608197, lines 1346--1421.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -382,7 +400,16 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
 range in PGVWC07, Theorem 12.
 
 The internal middle-word length is at least \(3(r-1)(L_0+1)\). This is the
-intersection step in arXiv:quant-ph/0608197, lines 1424--1452. -/
+intersection step in arXiv:quant-ph/0608197, lines 1424--1452.
+
+**Scope restriction (doubly normalized specialization):** At the PGVWC07 source
+length bound, `hUnital` is the source identity
+\(\sum_a A^j_a(A^j_a)^\dagger=1\), while `hLeft` additionally specializes the
+source dual fixed-point equation
+\(\sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j\) to
+\(\Lambda_j=1\). The general normalization is tracked in issue #5751 and
+documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
 theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -424,7 +424,7 @@ with the chosen basis of normal tensors.
     the displayed containment.
 \end{proof}
 
-\begin{theorem}[Parent-Hamiltonian kernel equality with the BNT span]
+\begin{theorem}[Doubly-normalized PGVWC07 source-length kernel equality]
     \label{thm:gs_eq_bnt_span}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
     \leanok
@@ -434,11 +434,23 @@ with the chosen basis of normal tensors.
     normalized self-overlap. Assume that no two distinct blocks are equivalent
     up to gauge and phase. Let $\mu_j\ne0$ for every $j$. Suppose there is a
     common $L_0>0$ such that the words of length $L_0$ in each block $A_j$ span
-    $\MN{D_j}$, and suppose also, for every $1\le j\le g$, that
+    $\MN{D_j}$. In this doubly-normalized specialization, assume for every
+    $1\le j\le g$ that
     \begin{align}
-        \sum_{a=1}^d A_j^a A_j^{a\,\dagger}&=\Id.
+        \sum_{a=1}^d A_j^a A_j^{a\,\dagger}&=\Id,
+        \notag\\
+        \sum_{a=1}^d A_j^{a\,\dagger}A_j^a&=\Id.
         \notag
     \end{align}
+    The first identity is the normalization used in the source. In the general
+    source canonical form, the second identity is replaced by a positive
+    definite matrix $\Lambda_j$ satisfying
+    \begin{align}
+        \sum_{a=1}^d A_j^{a\,\dagger}\Lambda_j A_j^a&=\Lambda_j.
+        \notag
+    \end{align}
+    Thus the result below is the special case $\Lambda_j=\Id$ of the source
+    normalization.
     If
     \begin{align}
         L&\ge 3(g-1)(L_0+1)+1,
@@ -468,4 +480,35 @@ with the chosen basis of normal tensors.
     containment of the kernel in the BNT span. Conversely,
     Lemma~\ref{lem:bnt_span_le_parent_hamiltonian_kernel} gives the reverse
     containment directly.
+\end{proof}
+
+
+\begin{theorem}[PGVWC07 source-length kernel equality at general canonical normalization]
+    \label{thm:gs_eq_bnt_span_source_normalization}
+    \notready
+    \uses{def:parent_hamiltonian, def:bnt_span}
+    Retain the same block, injectivity, nonzero-dimension, nonzero-weight, and
+    source-length hypotheses. For every $1\le j\le g$, assume there is a
+    positive definite matrix $\Lambda_j$ such that
+    \begin{align}
+        \sum_{a=1}^d A_j^a A_j^{a\,\dagger}&=\Id,
+        \notag\\
+        \sum_{a=1}^d A_j^{a\,\dagger}\Lambda_j A_j^a&=\Lambda_j.
+        \notag
+    \end{align}
+    Then
+    \begin{align}
+        \ker H_L^{(N)}\!\left(\bigoplus_j \mu_j A_j\right)
+        &=
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \notready
+    The doubly-normalized case is Theorem~\ref{thm:gs_eq_bnt_span}. Passing
+    from the general positive dual fixed points to that case requires the
+    gauge-transport argument recorded in the normalization-scope note and
+    tracked in follow-up issue~\#5751.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -424,17 +424,18 @@ with the chosen basis of normal tensors.
     the displayed containment.
 \end{proof}
 
-\begin{theorem}[Periodic-boundary equality with the BNT span]
+\begin{theorem}[Parent-Hamiltonian kernel equality with the BNT span]
     \label{thm:gs_eq_bnt_span}
-    \notready
-    \uses{thm:parent_ground_space_le_bnt_span, lem:bnt_mpv_mem_ground_space,
-        def:parent_hamiltonian_ground_space_bnt, def:bnt_span}
-    Under the hypotheses of
-    Theorem~\ref{thm:parent_ground_space_le_bnt_span}, the corresponding
-    periodic-boundary ground space is exactly the span of the BNT component
-    vectors:
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
+    \leanok
+    \uses{thm:block_diagonal_chain_space_global_cut,
+        cor:block_diagonal_kernel_global_cut, lem:bnt_mpv_mem_ground_space,
+        thm:chain_ground_space_eq_mpv_normal, def:bnt_span}
+    Under the normalized BNT hypotheses and the source length bounds of
+    Theorem~\ref{thm:block_diagonal_chain_space_global_cut}, the
+    parent-Hamiltonian kernel is exactly the span of the BNT component vectors:
     \begin{align}
-        \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
+        \ker H_L^{(N)}\!\left(\bigoplus_j \mu_j A_j\right)
         &=
         \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
         \label{eq:parent_bnt_ground_space}
@@ -442,32 +443,14 @@ with the chosen basis of normal tensors.
 \end{theorem}
 
 \begin{proof}
-    \notready
-    \uses{thm:parent_ground_space_le_bnt_span, lem:bnt_mpv_mem_ground_space}
-    We prove the two inclusions separately. The inclusion
-    \begin{align}
-        \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
-        &\subseteq
-        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
-        \notag
-    \end{align}
-    is exactly Theorem~\ref{thm:parent_ground_space_le_bnt_span}. For the reverse
-    inclusion, the nonzero-weight hypothesis and
-    Lemma~\ref{lem:bnt_mpv_mem_ground_space} show that each vector
-    $V^{(N)}(A_j)$ lies in
-    $\mathcal G_{N,L}(\bigoplus_j \mu_j A_j)$. Since this ground space is
-    linear, it contains every linear combination of such vectors, and hence
-    contains $\spn\{V^{(N)}(A_j):j=1,\ldots,g\}$. Thus
-    \begin{align}
-        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
-        &\subseteq
-        \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right),
-        \notag
-    \end{align}
-    and the two spaces are equal, as stated in
-    (\ref{eq:parent_bnt_ground_space}).
+    \leanok
+    \uses{cor:block_diagonal_kernel_global_cut,
+        lem:bnt_mpv_mem_ground_space, thm:chain_ground_space_eq_mpv_normal}
+    The source length bounds imply $L_0<L$, $L\le N$, and $L_0+1<N$.
+    Theorem~\ref{thm:chain_ground_space_eq_mpv_normal} therefore identifies
+    each single-block periodic chain space with its matrix-product-vector
+    line. Corollary~\ref{cor:block_diagonal_kernel_global_cut} gives the
+    containment of the kernel in the BNT span. Conversely,
+    Lemma~\ref{lem:bnt_mpv_mem_ground_space} places every component vector in
+    the parent-Hamiltonian kernel. Taking spans gives the reverse containment.
 \end{proof}
-
-\noindent\emph{Remark.} A separate kernel-identification statement for these
-direct-sum block families would convert the periodic-boundary ground-space
-statement into the corresponding statement for $\ker(H_N)$.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -510,5 +510,5 @@ with the chosen basis of normal tensors.
     The doubly-normalized case is Theorem~\ref{thm:gs_eq_bnt_span}. Passing
     from the general positive dual fixed points to that case requires the
     gauge-transport argument recorded in the normalization-scope note and
-    tracked in follow-up issue~\#5751.
+    recorded in the normalization-scope note.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -428,12 +428,10 @@ with the chosen basis of normal tensors.
     \label{thm:gs_eq_bnt_span}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{thm:block_diagonal_chain_space_global_cut,
-        cor:block_diagonal_kernel_global_cut, lem:bnt_mpv_mem_ground_space,
-        thm:chain_ground_space_eq_mpv_normal, def:bnt_span}
-    Under the normalized BNT hypotheses and the source length bounds of
-    Theorem~\ref{thm:block_diagonal_chain_space_global_cut}, the
-    parent-Hamiltonian kernel is exactly the span of the BNT component vectors:
+    \uses{def:parent_hamiltonian, def:bnt_span}
+    Under the normalized BNT hypotheses and the PGVWC07 source length bounds,
+    the parent-Hamiltonian kernel is exactly the span of the BNT component
+    vectors:
     \begin{align}
         \ker H_L^{(N)}\!\left(\bigoplus_j \mu_j A_j\right)
         &=
@@ -445,12 +443,13 @@ with the chosen basis of normal tensors.
 \begin{proof}
     \leanok
     \uses{cor:block_diagonal_kernel_global_cut,
-        lem:bnt_mpv_mem_ground_space, thm:chain_ground_space_eq_mpv_normal}
+        thm:chain_ground_space_eq_mpv_normal,
+        lem:bnt_span_le_parent_hamiltonian_kernel}
     The source length bounds imply $L_0<L$, $L\le N$, and $L_0+1<N$.
     Theorem~\ref{thm:chain_ground_space_eq_mpv_normal} therefore identifies
     each single-block periodic chain space with its matrix-product-vector
     line. Corollary~\ref{cor:block_diagonal_kernel_global_cut} gives the
     containment of the kernel in the BNT span. Conversely,
-    Lemma~\ref{lem:bnt_mpv_mem_ground_space} places every component vector in
-    the parent-Hamiltonian kernel. Taking spans gives the reverse containment.
+    Lemma~\ref{lem:bnt_span_le_parent_hamiltonian_kernel} gives the reverse
+    containment directly.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -429,8 +429,25 @@ with the chosen basis of normal tensors.
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{def:parent_hamiltonian, def:bnt_span}
-    Under the normalized BNT hypotheses and the PGVWC07 source length bounds,
-    the parent-Hamiltonian kernel is exactly the span of the BNT component
+    Let $d\ge1$ and $g\ge2$. For $1\le j\le g$, let $D_j\ge1$ and
+    let $A_j=(A_j^a)_{a=1}^d$ be an irreducible left-canonical block with
+    normalized self-overlap. Assume that no two distinct blocks are equivalent
+    up to gauge and phase. Let $\mu_j\ne0$ for every $j$. Suppose there is a
+    common $L_0>0$ such that the words of length $L_0$ in each block $A_j$ span
+    $\MN{D_j}$, and suppose also that
+    \begin{align}
+        \sum_{a=1}^d A_j^a A_j^{a\,\dagger}&=\Id
+        \qquad (1\le j\le g).
+        \notag
+    \end{align}
+    If
+    \begin{align}
+        L&\ge 3(g-1)(L_0+1)+1,
+        \notag\\
+        N&\ge L+L_0,
+        \notag
+    \end{align}
+    then the parent-Hamiltonian kernel is exactly the span of the BNT component
     vectors:
     \begin{align}
         \ker H_L^{(N)}\!\left(\bigoplus_j \mu_j A_j\right)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -430,7 +430,7 @@ with the chosen basis of normal tensors.
     \leanok
     \uses{def:parent_hamiltonian, def:bnt_span, def:block_diagonal_tensor,
         def:irreducible_tensor, def:left_canonical_tensor,
-        def:blocks_not_gauge_phase_equiv, def:l_blk_injective}
+        def:blocks_not_gauge_phase_equiv, def:l_blk_injective, def:mpv_overlap}
     % Scope restriction documented in
     % docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
     Let $d\ge1$ and $g\ge2$. For $0\le j<g$, let $D_j\ge1$ and
@@ -493,7 +493,7 @@ with the chosen basis of normal tensors.
     \notready
     \uses{def:parent_hamiltonian, def:bnt_span, def:block_diagonal_tensor,
         def:irreducible_tensor, def:blocks_not_gauge_phase_equiv,
-        def:l_blk_injective}
+        def:l_blk_injective, def:mpv_overlap}
     Retain the same nonzero dimensions and weights, irreducibility, normalized
     self-overlap, gauge-phase inequivalence, common block-injectivity length,
     and source-length bounds, but do not assume left-canonicality. For every
@@ -516,9 +516,13 @@ with the chosen basis of normal tensors.
 
 \begin{proof}
     \notready
-    \uses{thm:gs_eq_bnt_span}
-    The doubly-normalized case is Theorem~\ref{thm:gs_eq_bnt_span}. Passing
-    from the general positive dual fixed points to that case requires the
-    gauge-transport argument recorded in the normalization-scope note.
-    % Gauge transport for the general normalization is tracked in issue #5751.
+    A square-root gauge can normalize the dual fixed-point equation, but does
+    not in general preserve the source unital identity. The proof therefore
+    requires weighted, gauge-covariant versions of simultaneous span
+    propagation and the boundary-matrix calculation, followed by transport of
+    the periodic chain spaces, parent-Hamiltonian kernel, and component-vector
+    span through the blockwise gauges.
+    % The normalization scope and elimination plan are recorded in
+    % docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex; tracking
+    % remains in issue #5751.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -434,10 +434,9 @@ with the chosen basis of normal tensors.
     normalized self-overlap. Assume that no two distinct blocks are equivalent
     up to gauge and phase. Let $\mu_j\ne0$ for every $j$. Suppose there is a
     common $L_0>0$ such that the words of length $L_0$ in each block $A_j$ span
-    $\MN{D_j}$, and suppose also that
+    $\MN{D_j}$, and suppose also, for every $1\le j\le g$, that
     \begin{align}
-        \sum_{a=1}^d A_j^a A_j^{a\,\dagger}&=\Id
-        \qquad (1\le j\le g).
+        \sum_{a=1}^d A_j^a A_j^{a\,\dagger}&=\Id.
         \notag
     \end{align}
     If

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -507,8 +507,9 @@ with the chosen basis of normal tensors.
 
 \begin{proof}
     \notready
+    \uses{thm:gs_eq_bnt_span}
     The doubly-normalized case is Theorem~\ref{thm:gs_eq_bnt_span}. Passing
     from the general positive dual fixed points to that case requires the
-    gauge-transport argument recorded in the normalization-scope note and
-    recorded in the normalization-scope note.
+    gauge-transport argument recorded in the normalization-scope note.
+    % Gauge transport for the general normalization is tracked in issue #5751.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -428,30 +428,34 @@ with the chosen basis of normal tensors.
     \label{thm:gs_eq_bnt_span}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07}
     \leanok
-    \uses{def:parent_hamiltonian, def:bnt_span}
-    Let $d\ge1$ and $g\ge2$. For $1\le j\le g$, let $D_j\ge1$ and
-    let $A_j=(A_j^a)_{a=1}^d$ be an irreducible left-canonical block with
+    \uses{def:parent_hamiltonian, def:bnt_span, def:block_diagonal_tensor,
+        def:irreducible_tensor, def:left_canonical_tensor,
+        def:blocks_not_gauge_phase_equiv, def:l_blk_injective}
+    % Scope restriction documented in
+    % docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
+    Let $d\ge1$ and $g\ge2$. For $0\le j<g$, let $D_j\ge1$ and
+    let $A_j=(A_j^a)_{a=0}^{d-1}$ be an irreducible left-canonical block with
     normalized self-overlap. Assume that no two distinct blocks are equivalent
-    up to gauge and phase. Let $\mu_j\ne0$ for every $j$. Suppose there is a
-    common $L_0>0$ such that the words of length $L_0$ in each block $A_j$ span
-    $\MN{D_j}$. In this doubly-normalized specialization, assume for every
-    $1\le j\le g$ that
+    up to gauge and phase. For every $0\le j<g$, let $\mu_j\ne0$. Suppose
+    there is a common $L_0>0$ such that the words of length $L_0$ in each
+    block $A_j$ span $\MN{D_j}$. In this doubly-normalized specialization,
+    assume for every
+    $0\le j<g$ that
     \begin{align}
-        \sum_{a=1}^d A_j^a A_j^{a\,\dagger}&=\Id,
+        \sum_{a=0}^{d-1} A_j^a A_j^{a\,\dagger}&=\Id,
         \notag\\
-        \sum_{a=1}^d A_j^{a\,\dagger}A_j^a&=\Id.
+        \sum_{a=0}^{d-1} A_j^{a\,\dagger}A_j^a&=\Id.
         \notag
     \end{align}
     The first identity is the normalization used in the source. In the general
     source canonical form, the second identity is replaced by a positive
     definite matrix $\Lambda_j$ satisfying
     \begin{align}
-        \sum_{a=1}^d A_j^{a\,\dagger}\Lambda_j A_j^a&=\Lambda_j.
+        \sum_{a=0}^{d-1} A_j^{a\,\dagger}\Lambda_j A_j^a&=\Lambda_j.
         \notag
     \end{align}
-    Thus the result below is the special case $\Lambda_j=\Id$ of the source
-    normalization.
-    If
+    Thus this theorem has the explicit scope restriction $\Lambda_j=\Id$ and
+    does not assert the unrestricted source result. If
     \begin{align}
         L&\ge 3(g-1)(L_0+1)+1,
         \notag\\
@@ -463,7 +467,7 @@ with the chosen basis of normal tensors.
     \begin{align}
         \ker H_L^{(N)}\!\left(\bigoplus_j \mu_j A_j\right)
         &=
-        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
+        \spn\{V^{(N)}(A_j):j=0,\ldots,g-1\}.
         \label{eq:parent_bnt_ground_space}
     \end{align}
 \end{theorem}
@@ -473,6 +477,8 @@ with the chosen basis of normal tensors.
     \uses{cor:block_diagonal_kernel_global_cut,
         thm:chain_ground_space_eq_mpv_normal,
         lem:bnt_span_le_parent_hamiltonian_kernel}
+    % Scope restriction documented in
+    % docs/paper-gaps/pgvwc07_ti_canonical_form_scope.tex.
     The source length bounds imply $L_0<L$, $L\le N$, and $L_0+1<N$.
     Theorem~\ref{thm:chain_ground_space_eq_mpv_normal} therefore identifies
     each single-block periodic chain space with its matrix-product-vector
@@ -482,25 +488,28 @@ with the chosen basis of normal tensors.
     containment directly.
 \end{proof}
 
-
 \begin{theorem}[PGVWC07 source-length kernel equality at general canonical normalization]
     \label{thm:gs_eq_bnt_span_source_normalization}
     \notready
-    \uses{def:parent_hamiltonian, def:bnt_span}
-    Retain the same block, injectivity, nonzero-dimension, nonzero-weight, and
-    source-length hypotheses. For every $1\le j\le g$, assume there is a
-    positive definite matrix $\Lambda_j$ such that
+    \uses{def:parent_hamiltonian, def:bnt_span, def:block_diagonal_tensor,
+        def:irreducible_tensor, def:blocks_not_gauge_phase_equiv,
+        def:l_blk_injective}
+    Retain the same nonzero dimensions and weights, irreducibility, normalized
+    self-overlap, gauge-phase inequivalence, common block-injectivity length,
+    and source-length bounds, but do not assume left-canonicality. For every
+    $0\le j<g$, assume there is a positive definite matrix $\Lambda_j$ such
+    that
     \begin{align}
-        \sum_{a=1}^d A_j^a A_j^{a\,\dagger}&=\Id,
+        \sum_{a=0}^{d-1} A_j^a A_j^{a\,\dagger}&=\Id,
         \notag\\
-        \sum_{a=1}^d A_j^{a\,\dagger}\Lambda_j A_j^a&=\Lambda_j.
+        \sum_{a=0}^{d-1} A_j^{a\,\dagger}\Lambda_j A_j^a&=\Lambda_j.
         \notag
     \end{align}
     Then
     \begin{align}
         \ker H_L^{(N)}\!\left(\bigoplus_j \mu_j A_j\right)
         &=
-        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
+        \spn\{V^{(N)}(A_j):j=0,\ldots,g-1\}.
         \notag
     \end{align}
 \end{theorem}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -517,12 +517,13 @@ with the chosen basis of normal tensors.
 \begin{proof}
     \notready
     A square-root gauge can normalize the dual fixed-point equation, but does
-    not in general preserve the source unital identity. The proof therefore
-    requires weighted, gauge-covariant versions of simultaneous span
-    propagation and the boundary-matrix calculation, followed by transport of
-    the periodic chain spaces, parent-Hamiltonian kernel, and component-vector
-    span through the blockwise gauges.
+    not in general preserve the source unital identity. The proof must first
+    transport the simultaneous fixed-length tuple-span equation through the
+    blockwise gauges. It must then use the source unital identity to propagate
+    that span to longer words and carry out the weighted boundary comparison.
+    Gauge-covariant identifications of the periodic chain spaces,
+    parent-Hamiltonian kernel, and component-vector span complete the route.
     % The normalization scope and elimination plan are recorded in
-    % docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex; tracking
-    % remains in issue #5751.
+    % docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex. Tracking
+    % remains in issues #5751 and #5755.
 \end{proof}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -132,6 +132,38 @@ means boundary matrices of the form
   (X_j,Y_j\in M_{D_j}(\mathbb C)).
 \end{align}
 
+\section{Normalization scope}
+
+The PGVWC07 source normalization used in the block-intersection calculation is
+\begin{align}
+  \sum_a A^j_a(A^j_a)^\dagger=I.
+\end{align}
+For the dual transfer operator, the general canonical form has a positive
+definite fixed point $\Lambda_j$ satisfying
+\begin{align}
+  \sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j.
+\end{align}
+The current source-length declarations additionally assume
+\begin{align}
+  \sum_a (A^j_a)^\dagger A^j_a=I,
+\end{align}
+which is the special case $\Lambda_j=I$. Consequently the declarations whose
+names end in \texttt{\_pgvwc07} along the global-cut route are doubly normalized
+specializations at the PGVWC07 source length bound, rather than formalizations
+of the unrestricted normalization in Theorem~12.
+
+Eliminating this restriction requires a gauge-covariant version of the route.
+For each positive definite $\Lambda_j$, conjugation by its positive square root
+turns the dual fixed-point equation into the identity fixed-point equation. One
+must transport the simultaneous word spans, open-boundary maps, periodic chain
+spaces, block direct sum, parent-Hamiltonian kernel, and component-vector span
+through these blockwise gauges. The source identity
+$\sum_a A^j_a(A^j_a)^\dagger=I$ must be retained by expressing the tuple-span
+propagation and boundary-matrix calculation in their corresponding weighted,
+gauge-covariant forms, rather than assuming that both unweighted identities
+hold in one gauge. This elimination is tracked by
+\href{https://github.com/LionSR/TNLean/issues/5751}{follow-up issue~\#5751}.
+
 \section{The block-diagonal intersection identity}
 
 The older representation paper \cite[Theorem \emph{Degeneracy of the ground


### PR DESCRIPTION
## Summary

Packages the PGVWC07 **source-length, doubly-normalized specialization** of the equality between the block-diagonal parent-Hamiltonian kernel and `bntMPSVectorSpan`. The proof follows the existing global change-of-cut route, derives blockwise periodic uniqueness from `chainGroundSpace_eq_mpvSubmodule_normal`, and combines the two established inclusions.

This is not presented as the unrestricted normalization of PGVWC07 Theorem 12. The Lean route assumes both

- the source identity `Σₐ Aʲₐ (Aʲₐ)† = I` (`hUnital`), and
- the additional identity specialization `Σₐ (Aʲₐ)† Aʲₐ = I` (`hLeft`), corresponding to `Λⱼ = I` in the source dual fixed-point equation `Σₐ (Aʲₐ)† Λⱼ Aʲₐ = Λⱼ`.

All affected `*_pgvwc07` declarations on the global-cut route are marked as doubly normalized specializations. Chapter 13 marks only that restricted kernel equality `\leanok`; the source theorem with general positive-definite `Λⱼ` remains `\notready`. The normalization gap and gauge-transport elimination plan are documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` and tracked by #5751.

## Source

- Pérez-García–Verstraete–Wolf–Cirac, quant-ph/0608197, Theorem 12, source length bound
- Cirac et al., arXiv:2011.12127 §IV.C, lines 2108–2128

## Verification

- targeted Lean compilation of `BNTBlockIntersection.lean`
- targeted Lean compilation of `BNTBlockDiagonalChain.lean`
- targeted Lean compilation of `BNTBlockDiagonalBoundaryClosing.lean`
- reader-facing prose check
- source-level blueprint synchronization: 6647/6647
- `git diff --check`

Closes #5740
Refs #460, #190, #5751

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantive formal proof packaging in the parent-Hamiltonian ground-space chain; risk is mainly correctness of the doubly-normalized scope claims and blueprint alignment, not runtime or security.
> 
> **Overview**
> Packages the **PGVWC07 source-length, doubly-normalized** equality \(\ker H_L^{(N)}(\bigoplus_j \mu_j A_j) = \mathrm{bntMPSVectorSpan}\) in Lean via a new theorem `ker_parentHamiltonian_toTensorFromBlocks_eq_bntMPSVectorSpan_of_global_cut_bnt_c1_pgvwc07`, combining the existing global-cut containment with `bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks` and blockwise `chainGroundSpace_eq_mpvSubmodule_normal` (new `UniqueGroundState` import).
> 
> **Scope labeling:** `*_pgvwc07` declarations on the global-cut route and related docstrings now state explicitly that `hUnital` and `hLeft` mean both unital identities (\(\Lambda_j = I\)), not PGVWC07’s general positive-definite \(\Lambda_j\); the gap doc adds a **Normalization scope** section and points to issue #5751.
> 
> **Blueprint:** Chapter 13’s kernel-equality theorem is marked `\leanok` for this specialization; a separate `\notready` theorem keeps the general \(\Lambda_j\) normalization target.
> 
> Lean module doc comments in `BNTBlockDiagonalChain` are shortened without changing theorem statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f0e1b0ac8078341aefd5f20bfd83e7420e2b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->