### PR TITLE
feat(MPU): prove normalized transfer trace identity

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -36,6 +36,9 @@ with composition. We also relate it to the Kraus representation.
 * `transferMatrix_mulVec_eq`: `T̂ *ᵥ vec(ρ) = vec(T(ρ))`
 * `transferMatrix_comp`: `(S ∘ T)^ = Ŝ * T̂`
 * `transferMatrix_id`: the transfer matrix of the identity is the identity
+* `transferMatrix_pow`: transfer matrices preserve powers
+* `trace_transferMatrix_eq_linearMap_trace`: matrix trace agrees with operator trace
+* `transferMatrix_hasEigenvalue_iff`: a map and its transfer matrix have the same eigenvalues
 * `transferMatrix_kraus`: for a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer
   matrix is `∑ᵢ K'ᵢ ⊗ₖ Kᵢ`
 * `IsPositiveMap.comp_unitaryConjLM`: positive maps remain positive after

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -8,6 +8,8 @@ import TNLean.Algebra.MatrixTracePairing
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.LinearAlgebra.Matrix.StdBasis
+import Mathlib.LinearAlgebra.Eigenspace.Basic
 import Mathlib.Data.Matrix.Basis
 
 /-!
@@ -201,6 +203,66 @@ theorem transferMatrix_injective :
   have key := congr_fun (congr_fun (congrArg Matrix.mulVec h) M.vec) (j, i)
   simp only [transferMatrix_mulVec_eq, Matrix.vec] at key
   exact key
+
+/-- The transfer-matrix representation preserves powers of matrix endomorphisms. -/
+theorem transferMatrix_pow
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (N : ℕ) :
+    transferMatrix (T ^ N) = transferMatrix T ^ N := by
+  induction N with
+  | zero =>
+      change transferMatrix (LinearMap.id : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] _) = 1
+      exact transferMatrix_id
+  | succ N ih =>
+      rw [pow_succ, pow_succ]
+      change transferMatrix ((T ^ N) ∘ₗ T) = _
+      rw [transferMatrix_comp, ih]
+
+/-- Matrix trace of the transfer matrix equals the basis-independent operator trace.
+
+The nonzero bond-dimension assumption records the genuine matrix-algebra setting used in
+Wolf Section 2.2 and in the MPU transfer argument. -/
+theorem trace_transferMatrix_eq_linearMap_trace [NeZero D]
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (transferMatrix T) =
+      LinearMap.trace ℂ (Matrix (Fin D) (Fin D) ℂ) T := by
+  let b : Module.Basis (Fin D × Fin D) ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.stdBasis ℂ (Fin D) (Fin D)
+  rw [LinearMap.trace_eq_matrix_trace ℂ b]
+  simp only [Matrix.trace, Matrix.diag, LinearMap.toMatrix_apply]
+  rw [Fintype.sum_prod_type, Fintype.sum_prod_type]
+  simp only [transferMatrix_apply, b, Matrix.stdBasis_eq_single]
+  simp only [Matrix.stdBasis, Module.Basis.map_repr]
+  exact Finset.sum_comm
+
+/-- A matrix endomorphism and its transfer matrix have the same eigenvalues. -/
+theorem transferMatrix_hasEigenvalue_iff
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (μ : ℂ) :
+    Module.End.HasEigenvalue T μ ↔
+      Module.End.HasEigenvalue (transferMatrix T).toLin' μ := by
+  constructor
+  · intro h
+    obtain ⟨X, hX⟩ := h.exists_hasEigenvector
+    apply Module.End.hasEigenvalue_of_hasEigenvector
+    rw [Module.End.hasEigenvector_iff]
+    constructor
+    · rw [Module.End.mem_eigenspace_iff, Matrix.toLin'_apply,
+        transferMatrix_mulVec_eq, hX.apply_eq_smul, Matrix.vec_smul]
+    · exact fun hv => hX.2 (Matrix.vec_inj.mp (by simpa using hv))
+  · intro h
+    obtain ⟨v, hv⟩ := h.exists_hasEigenvector
+    obtain ⟨X, rfl⟩ := Matrix.vec_bijective.2 v
+    apply Module.End.hasEigenvalue_of_hasEigenvector
+    rw [Module.End.hasEigenvector_iff]
+    constructor
+    · rw [Module.End.mem_eigenspace_iff]
+      apply Matrix.vec_inj.mp
+      rw [Matrix.vec_smul, ← transferMatrix_mulVec_eq, ← Matrix.toLin'_apply]
+      exact hv.apply_eq_smul
+    · intro hX
+      apply hv.2
+      simp [hX]
 
 /-! ### Transfer matrix as a linear map -/
 

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -11,3 +11,4 @@ Authors: TNLean contributors
 import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.SourceCuts
+import TNLean.MPS.MPU.TransferMatrix

--- a/TNLean/MPS/MPU/TransferMatrix.lean
+++ b/TNLean/MPS/MPU/TransferMatrix.lean
@@ -36,8 +36,8 @@ variable {d D : ℕ}
 /-- The paper-normalized doubled-index MPS tensor associated to an MPO tensor:
 `normalizedFlattening U = U.toMPSTensor / sqrt d`.
 
-Source: Cirac--Perez-Garcia--Schuch--Verstraete, Proposition `prop:normal-tensor`,
-lines 344--354. -/
+Source: Cirac--Perez-Garcia--Schuch--Verstraete, equation `eq:transfer-op`,
+lines 336--340. -/
 noncomputable def normalizedFlattening (U : MPOTensor d D) : MPSTensor (d * d) D :=
   fun ij => ((Real.sqrt d : ℂ)⁻¹) • U.toMPSTensor ij
 

--- a/TNLean/MPS/MPU/TransferMatrix.lean
+++ b/TNLean/MPS/MPU/TransferMatrix.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Basic
+import TNLean.MPS.MPDO.Purity
+import TNLean.Spectral.MPVOverlapTrace
+
+/-!
+# Normalized transfer matrix of a Matrix Product Unitary
+
+This file defines the paper-normalized doubled-physical-index MPS tensor associated to an MPO
+and proves the transfer-matrix trace identity used in Proposition `prop:normal-tensor` of
+Cirac--Perez-Garcia--Schuch--Verstraete.
+
+## Main definitions and results
+
+* `MPOTensor.normalizedFlattening` — the doubled-index MPS tensor `U / sqrt d`.
+* `MPOTensor.mpvOverlap_normalizedFlattening_self` — its self-overlap scaling law.
+* `MPOTensor.IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one` — for every `N > 1`,
+  the trace of the `N`-th power of its transfer matrix is one.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, "Matrix Product Unitaries: Structure,
+  Symmetries, and Topological Invariants", Proposition `prop:normal-tensor`, lines 344--354.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The paper-normalized doubled-index MPS tensor associated to an MPO tensor:
+`normalizedFlattening U = U.toMPSTensor / sqrt d`.
+
+Source: Cirac--Perez-Garcia--Schuch--Verstraete, Proposition `prop:normal-tensor`,
+lines 344--354. -/
+noncomputable def normalizedFlattening (U : MPOTensor d D) : MPSTensor (d * d) D :=
+  fun ij => ((Real.sqrt d : ℂ)⁻¹) • U.toMPSTensor ij
+
+/-- The length-`N` self-overlap of the normalized flattening is `d⁻ᴺ` times the raw
+self-overlap. The physical dimension is explicitly nonzero so that division by `sqrt d`
+has the paper's intended meaning.
+
+Source: Cirac--Perez-Garcia--Schuch--Verstraete, Proposition `prop:normal-tensor`,
+lines 344--354. -/
+theorem mpvOverlap_normalizedFlattening_self [NeZero d]
+    (U : MPOTensor d D) (N : ℕ) :
+    MPSTensor.mpvOverlap U.normalizedFlattening U.normalizedFlattening N =
+      ((d : ℂ)⁻¹) ^ N *
+        MPSTensor.mpvOverlap U.toMPSTensor U.toMPSTensor N := by
+  change MPSTensor.mpvOverlap
+      (fun i => ((Real.sqrt d : ℂ)⁻¹) • U.toMPSTensor i)
+      (fun i => ((Real.sqrt d : ℂ)⁻¹) • U.toMPSTensor i) N = _
+  rw [MPSTensor.mpvOverlap_smul_self]
+  congr 2
+  have hd : (0 : ℝ) < d := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d)
+  simp only [RCLike.star_def, map_inv₀, Complex.conj_ofReal]
+  rw [← mul_inv, ← Complex.ofReal_mul, Real.mul_self_sqrt hd.le]
+  simp
+
+/-- For an MPU and every system size `N > 1`, the transfer matrix of the normalized
+flattening satisfies `trace(E^N) = 1`.
+
+The restriction `N > 1` is exact: `IsMPU` asserts unitarity only at those lengths, so no
+length-one identity is claimed. Both physical and bond dimensions are explicitly nonzero.
+
+Source: Cirac--Perez-Garcia--Schuch--Verstraete, Proposition `prop:normal-tensor`,
+lines 344--354, using equation `UisUnitary`, lines 327--335. -/
+theorem IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
+    {N : ℕ} (hN : 1 < N) :
+    Matrix.trace (transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ N) = 1 := by
+  rw [MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap]
+  rw [mpvOverlap_normalizedFlattening_self, mpvOverlap_toMPSTensor_self,
+    hU.mpo_mul_conjTranspose_mpo hN, Matrix.trace_one]
+  rw [Fintype.card_pi_const]
+  push_cast
+  rw [← mul_pow]
+  simp [NeZero.ne d]
+
+end MPOTensor

--- a/TNLean/MPS/Overlap/Basic.lean
+++ b/TNLean/MPS/Overlap/Basic.lean
@@ -124,6 +124,18 @@ lemma mpvOverlap_eq_mul_of_mpv_eq_mul
   rw [h σ]
   ring
 
+/-- Scaling both copies of a tensor by `c` scales its length-`N` self-overlap by
+`(c * star c) ^ N`. -/
+theorem mpvOverlap_smul_self (c : ℂ) {d D : ℕ} (A : MPSTensor d D) (N : ℕ) :
+    mpvOverlap (fun i => c • A i) (fun i => c • A i) N =
+      (c * star c) ^ N * mpvOverlap A A N := by
+  classical
+  simp only [mpvOverlap, mpv, coeff, evalWord_smul, List.length_ofFn,
+    Matrix.trace_smul, smul_eq_mul, star_mul, star_pow]
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl fun σ _ => ?_
+  ring
+
 /-- Conjugate symmetry for `mpvOverlap`. -/
 lemma mpvOverlap_star_swap {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (N : ℕ) :

--- a/TNLean/Spectral/MPVOverlapTrace.lean
+++ b/TNLean/Spectral/MPVOverlapTrace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.TransferMatrix
 import TNLean.MPS.Overlap.Basic
 import TNLean.Spectral.MixedTransfer
 import TNLean.Spectral.TraceExpansion
@@ -98,6 +99,22 @@ theorem trace_mixedTransferMap_pow_eq_mpvOverlap {d D : ℕ} [NeZero D]
             simp [Matrix.trace]
 
 end Main
+
+/-- The matrix trace of a power of the mixed transfer matrix is the MPV overlap. -/
+theorem trace_transferMatrix_mixedTransferMap_pow_eq_mpvOverlap
+    {d D : ℕ} [NeZero D] (A B : MPSTensor d D) (N : ℕ) :
+    Matrix.trace (transferMatrix (mixedTransferMap A B) ^ N) =
+      mpvOverlap (d := d) A B N := by
+  rw [← transferMatrix_pow, trace_transferMatrix_eq_linearMap_trace]
+  exact trace_mixedTransferMap_pow_eq_mpvOverlap A B N
+
+/-- The matrix trace of a power of an MPS transfer matrix is its self-overlap. -/
+theorem trace_transferMatrix_transferMap_pow_eq_mpvOverlap
+    {d D : ℕ} [NeZero D] (A : MPSTensor d D) (N : ℕ) :
+    Matrix.trace (transferMatrix (transferMap A) ^ N) =
+      mpvOverlap (d := d) A A N := by
+  rw [← mixedTransferMap_self]
+  exact trace_transferMatrix_mixedTransferMap_pow_eq_mpvOverlap A A N
 
 /-! ## Rectangular overlaps for different bond dimensions -/
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -488,6 +488,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPSTensor.trace_transferMatrix_mixedTransferMap_pow_eq_mpvOverlap,
       MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap}
     \leanok
+    \uses{def:mixed_transfer,def:mpv_overlap}
     Let $A$ and $B$ be matrix product tensors with the same positive bond
     dimension, and let $F_{A,B}(X)=\sum_i A^iX(B^i)^\dagger$ be their mixed
     transfer map.  Then
@@ -518,7 +519,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \widetilde U^{ij}&=\frac{1}{\sqrt d}\,U^{ij}.
     \end{align}
     This is the normalization used in the normal-tensor argument of
-    \cite[lines~344--354]{Cirac2017MPU}.
+    \cite[Proposition~III.1]{Cirac2017MPU}.
 \end{definition}
 
 \begin{theorem}[Self-overlap scaling]
@@ -566,7 +567,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \tr(E^N)&=1.
     \end{align}
     This is the trace identity in the proof of the normal-tensor result
-    \cite[lines~344--354]{Cirac2017MPU}.
+    \cite[Proposition~III.1]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -439,3 +439,101 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     Combine the preceding irreducibility conclusion with the supplied
     spectral-radius and primitivity properties.
 \end{proof}
+
+\section{Transfer-matrix bridges}
+
+Let $D$ be a positive integer and let
+$T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map.  Write $\widehat T$
+for its matrix in the column-stacking identification
+$M_D(\mathbb C)\cong\mathbb C^{D^2}$.
+
+\begin{theorem}[Powers and traces of transfer matrices]
+    \label{thm:mpu_transfer_matrix_power_trace}
+    \lean{transferMatrix_pow,trace_transferMatrix_eq_linearMap_trace}
+    \leanok
+    For every nonnegative integer $N$,
+    \begin{align}
+        \widehat{T^N}&=(\widehat T)^N,
+        &\tr(\widehat T)&=\operatorname{Tr}(T),
+    \end{align}
+    where the second trace is the operator trace of the endomorphism of
+    $M_D(\mathbb C)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Compatibility with composition proves the power identity by induction.
+    For the trace identity, expand the operator trace in the matrix-unit basis.
+    The two diagonal sums differ only by exchanging the row and column indices.
+\end{proof}
+
+\begin{theorem}[Eigenvalues of a transfer matrix]
+    \label{thm:mpu_transfer_matrix_eigenvalues}
+    \lean{transferMatrix_hasEigenvalue_iff}
+    \leanok
+    A complex number $\mu$ is an eigenvalue of $T$ if and only if it is an
+    eigenvalue of $\widehat T$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Column stacking is a linear bijection and intertwines $T$ with
+    multiplication by $\widehat T$.  It therefore carries nonzero
+    eigenmatrices to nonzero eigenvectors and conversely.
+\end{proof}
+
+\begin{theorem}[Transfer-matrix powers as periodic overlaps]
+    \label{thm:mpu_transfer_matrix_overlap}
+    \lean{MPSTensor.trace_transferMatrix_mixedTransferMap_pow_eq_mpvOverlap,
+      MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap}
+    \leanok
+    Let $A$ and $B$ be matrix product tensors with the same positive bond
+    dimension, and let $F_{A,B}(X)=\sum_i A^iX(B^i)^\dagger$ be their mixed
+    transfer map.  Then
+    \begin{align}
+        \tr\!\left(\widehat{F_{A,B}}^{\,N}\right)
+          &=\sum_\sigma \operatorname{mpv}(A,\sigma)
+             \overline{\operatorname{mpv}(B,\sigma)}.
+    \end{align}
+    In particular, taking $B=A$ identifies the trace of the $N$th power of
+    the ordinary transfer matrix with the length-$N$ self-overlap.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_transfer_matrix_power_trace}
+    Replace the matrix power by the transfer matrix of the corresponding
+    operator power, identify matrix trace with operator trace, and expand the
+    latter over periodic words.
+\end{proof}
+
+\begin{definition}[Normalized flattening of an MPO tensor]
+    \label{def:mpu_normalized_flattening}
+    \lean{MPOTensor.normalizedFlattening}
+    \leanok
+    For an MPO tensor $U$ of physical dimension $d>0$, its normalized
+    flattening is the doubled-physical-index MPS tensor
+    \begin{align}
+        \widetilde U^{ij}&=\frac{1}{\sqrt d}\,U^{ij}.
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Normalized MPU transfer trace]
+    \label{thm:mpu_normalized_transfer_trace}
+    \lean{MPSTensor.mpvOverlap_smul_self,
+      MPOTensor.mpvOverlap_normalizedFlattening_self,
+      MPOTensor.IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one}
+    \leanok
+    Let $U$ be an MPU tensor with positive physical and bond dimensions, and
+    let $E$ be the transfer matrix of its normalized flattening.  For every
+    integer $N>1$,
+    \begin{align}
+        \tr(E^N)&=1.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_transfer_matrix_overlap,def:mpu_normalized_flattening}
+    Scaling both tensor copies by $1/\sqrt d$ multiplies the length-$N$
+    self-overlap by $d^{-N}$.  The raw self-overlap is the trace of
+    $\operatorname{MPO}_N(U)\operatorname{MPO}_N(U)^\dagger$.  Since $N>1$,
+    the MPU equation makes this product the identity on a space of dimension
+    $d^N$.  Its trace is therefore $d^N$, and the normalization gives one.
+\end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -517,6 +517,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         \widetilde U^{ij}&=\frac{1}{\sqrt d}\,U^{ij}.
     \end{align}
+    This is the normalization used in the normal-tensor argument of
+    \cite[lines~344--354]{Cirac2017MPU}.
 \end{definition}
 
 \begin{theorem}[Self-overlap scaling]
@@ -524,6 +526,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPSTensor.mpvOverlap_smul_self,
       MPOTensor.mpvOverlap_normalizedFlattening_self}
     \leanok
+    \uses{def:mpu_normalized_flattening}
     For a matrix product tensor $A$, a complex number $c$, and a nonnegative
     integer $N$, scaling every local matrix by $c$ gives
     \begin{align}
@@ -545,7 +548,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpu_normalized_flattening}
+    \uses{lem:eval_word_smul}
     Each length-$N$ coefficient is multiplied by $c^N$.  Multiplication by
     its complex conjugate gives the first identity.  Taking
     $c=1/\sqrt d$ gives the second.
@@ -555,18 +558,20 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_normalized_transfer_trace}
     \lean{MPOTensor.IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one}
     \leanok
+    \uses{def:mpu,def:mpu_normalized_flattening}
     Let $U$ be an MPU tensor with positive physical and bond dimensions, and
     let $E$ be the transfer matrix of its normalized flattening.  For every
     integer $N>1$,
     \begin{align}
         \tr(E^N)&=1.
     \end{align}
+    This is the trace identity in the proof of the normal-tensor result
+    \cite[lines~344--354]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_transfer_matrix_overlap,thm:mpu_self_overlap_scaling,
-        thm:mpdo_doubled_overlap_hilbert_schmidt,lem:mpu_mul_adjoint,
-        def:mpu_normalized_flattening}
+        thm:mpdo_doubled_overlap_hilbert_schmidt,lem:mpu_mul_adjoint}
     Scaling both tensor copies by $1/\sqrt d$ multiplies the length-$N$
     self-overlap by $d^{-N}$.  The raw self-overlap is the trace of
     $\operatorname{MPO}_N(U)\operatorname{MPO}_N(U)^\dagger$.  Since $N>1$,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -559,7 +559,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         thm:mixed_self}
     Replace the matrix power by the transfer matrix of the corresponding
     operator power, identify matrix trace with operator trace, and expand the
-    latter over periodic words.
+    latter over periodic words.  For the ordinary self-transfer statement,
+    specialize to $B=A$ and use the identity $F_{A,A}=\mathcal E_A$ from
+    Theorem~\ref{thm:mixed_self}.
 \end{proof}
 
 \begin{definition}[Normalized flattening of an MPO tensor]
@@ -630,8 +632,18 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \uses{thm:mpu_transfer_matrix_overlap,thm:mpu_self_overlap_scaling,
         thm:mpdo_doubled_overlap_hilbert_schmidt,lem:mpu_mul_adjoint}
     Scaling both tensor copies by $1/\sqrt d$ multiplies the length-$N$
-    self-overlap by $d^{-N}$.  The raw self-overlap is the trace of
-    $U^{(N)}(U^{(N)})^\dagger$.  Since $N>1$,
-    the MPU equation makes this product the identity on a space of dimension
-    $d^N$.  Its trace is therefore $d^N$, and the normalization gives one.
+    self-overlap by $d^{-N}$.  The doubled-index overlap identity and MPU
+    unitarity give the complete chain
+    \begin{align}
+        \tr(E^N)
+        &=\sum_\sigma V^{(N)}(\widetilde U)_\sigma
+            \overline{V^{(N)}(\widetilde U)_\sigma}\\
+        &=d^{-N}\sum_\sigma V^{(N)}(U^{\mathrm{MPS}})_\sigma
+            \overline{V^{(N)}(U^{\mathrm{MPS}})_\sigma}\\
+        &=d^{-N}\tr\!\left(U^{(N)}(U^{(N)})^\dagger\right)\\
+        &=d^{-N}\tr(\Id)\\
+        &=d^{-N}d^N\\
+        &=1.
+    \end{align}
+    Here the fourth equality uses $N>1$, so that the MPU equation applies.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -498,7 +498,8 @@ $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_transfer_matrix_power_trace}
+    \uses{thm:mpu_transfer_matrix_power_trace,thm:overlap_trace,
+        thm:mixed_self}
     Replace the matrix power by the transfer matrix of the corresponding
     operator power, identify matrix trace with operator trace, and expand the
     latter over periodic words.
@@ -515,11 +516,41 @@ $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
     \end{align}
 \end{definition}
 
+\begin{theorem}[Self-overlap scaling]
+    \label{thm:mpu_self_overlap_scaling}
+    \lean{MPSTensor.mpvOverlap_smul_self,
+      MPOTensor.mpvOverlap_normalizedFlattening_self}
+    \leanok
+    For a matrix product tensor $A$, a complex number $c$, and a nonnegative
+    integer $N$, scaling every local matrix by $c$ gives
+    \begin{align}
+        \sum_\sigma \operatorname{mpv}(cA,\sigma)
+          \overline{\operatorname{mpv}(cA,\sigma)}
+        &=(c\overline c)^N
+          \sum_\sigma \operatorname{mpv}(A,\sigma)
+          \overline{\operatorname{mpv}(A,\sigma)}.
+    \end{align}
+    Consequently, if $d>0$ and $U$ is an MPO tensor of physical dimension
+    $d$, then
+    \begin{align}
+        \sum_\sigma \operatorname{mpv}(\widetilde U,\sigma)
+          \overline{\operatorname{mpv}(\widetilde U,\sigma)}
+        &=d^{-N}
+          \sum_\sigma \operatorname{mpv}(U,\sigma)
+          \overline{\operatorname{mpv}(U,\sigma)}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_normalized_flattening}
+    Each length-$N$ coefficient is multiplied by $c^N$.  Multiplication by
+    its complex conjugate gives the first identity.  Taking
+    $c=1/\sqrt d$ gives the second.
+\end{proof}
+
 \begin{theorem}[Normalized MPU transfer trace]
     \label{thm:mpu_normalized_transfer_trace}
-    \lean{MPSTensor.mpvOverlap_smul_self,
-      MPOTensor.mpvOverlap_normalizedFlattening_self,
-      MPOTensor.IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one}
+    \lean{MPOTensor.IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one}
     \leanok
     Let $U$ be an MPU tensor with positive physical and bond dimensions, and
     let $E$ be the transfer matrix of its normalized flattening.  For every
@@ -530,7 +561,9 @@ $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_transfer_matrix_overlap,def:mpu_normalized_flattening}
+    \uses{thm:mpu_transfer_matrix_overlap,thm:mpu_self_overlap_scaling,
+        thm:mpdo_doubled_overlap_hilbert_schmidt,lem:mpu_mul_adjoint,
+        def:mpu_normalized_flattening}
     Scaling both tensor copies by $1/\sqrt d$ multiplies the length-$N$
     self-overlap by $d^{-N}$.  The raw self-overlap is the trace of
     $\operatorname{MPO}_N(U)\operatorname{MPO}_N(U)^\dagger$.  Since $N>1$,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -443,38 +443,90 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \section{Transfer-matrix identities}
 
 Let $D$ be a positive integer and let
-$T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map.  Write $\widehat T$
-for its matrix in the column-stacking identification
-$M_D(\mathbb C)\cong\mathbb C^{D^2}$.
+$T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map.
+
+\begin{definition}[Transfer matrix of a matrix endomorphism]
+    \label{def:mpu_transfer_matrix}
+    \lean{transferMatrix}
+    \leanok
+    Let $E_{k\ell}$ denote the matrix unit with its only nonzero entry in
+    row $k$ and column $\ell$.  The transfer matrix $\widehat T$ is the
+    matrix indexed by pairs of bond indices with entries
+    \begin{align}
+        \widehat T_{(j,i),(\ell,k)}
+        &:=(T(E_{k\ell}))_{ij}.
+    \end{align}
+    Equivalently, this is the matrix of $T$ under the column-stacking
+    identification $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
+\end{definition}
+
+\begin{theorem}[Functoriality of transfer matrices]
+    \label{thm:mpu_transfer_matrix_functoriality}
+    \lean{transferMatrix_id,transferMatrix_comp}
+    \leanok
+    \uses{def:mpu_transfer_matrix}
+    For linear maps $S,T:M_D(\mathbb C)\to M_D(\mathbb C)$,
+    \begin{align}
+        \widehat{\operatorname{id}}&=\Id,\\
+        \widehat{S\circ T}&=\widehat S\,\widehat T.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand both sides on matrix units.  The identity formula is immediate,
+    while the composition formula follows by summing over the intermediate
+    row and column indices.
+\end{proof}
+
+\begin{theorem}[Transfer matrices intertwine column stacking]
+    \label{thm:mpu_transfer_matrix_vectorization}
+    \lean{transferMatrix_mulVec_eq}
+    \leanok
+    \uses{def:mpu_transfer_matrix}
+    For every $\rho\in M_D(\mathbb C)$,
+    \begin{align}
+        \widehat T\,\operatorname{vec}(\rho)
+        &=\operatorname{vec}(T(\rho)).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand $\rho$ in the matrix-unit basis and compare every vectorized
+    coordinate.
+\end{proof}
 
 \begin{theorem}[Powers and traces of transfer matrices]
     \label{thm:mpu_transfer_matrix_power_trace}
     \lean{transferMatrix_pow,trace_transferMatrix_eq_linearMap_trace}
     \leanok
+    \uses{def:mpu_transfer_matrix}
     For every nonnegative integer $N$,
     \begin{align}
-        \widehat{T^N}&=(\widehat T)^N,
-        &\tr(\widehat T)&=\operatorname{Tr}(T),
+        \widehat{T^N}&=(\widehat T)^N,\\
+        \tr(\widehat T)&=\operatorname{Tr}(T),
     \end{align}
     where the second trace is the operator trace of the endomorphism of
     $M_D(\mathbb C)$.
 \end{theorem}
 
 \begin{proof}\leanok
-    Compatibility with composition proves the power identity by induction.
-    For the trace identity, expand the operator trace in the matrix-unit basis.
-    The two diagonal sums differ only by exchanging the row and column indices.
+    \uses{thm:mpu_transfer_matrix_functoriality}
+    Functoriality proves the power identity by induction.  For the trace
+    identity, expand the operator trace in the matrix-unit basis.  The two
+    diagonal sums differ only by exchanging the row and column indices.
 \end{proof}
 
 \begin{theorem}[Eigenvalues of a transfer matrix]
     \label{thm:mpu_transfer_matrix_eigenvalues}
     \lean{transferMatrix_hasEigenvalue_iff}
     \leanok
+    \uses{def:mpu_transfer_matrix}
     A complex number $\mu$ is an eigenvalue of $T$ if and only if it is an
     eigenvalue of $\widehat T$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_transfer_matrix_vectorization}
     Column stacking is a linear bijection and intertwines $T$ with
     multiplication by $\widehat T$.  It therefore carries nonzero
     eigenmatrices to nonzero eigenvectors and conversely.
@@ -488,7 +540,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPSTensor.trace_transferMatrix_mixedTransferMap_pow_eq_mpvOverlap,
       MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap}
     \leanok
-    \uses{def:mixed_transfer,def:mpv_overlap}
+    \uses{def:mpu_transfer_matrix,def:mixed_transfer,def:mpv_overlap,
+        def:mps_tensor}
     Let $A$ and $B$ be matrix product tensors with the same positive bond
     dimension, and let $F_{A,B}(X)=\sum_i A^iX(B^i)^\dagger$ be their mixed
     transfer map.  Then
@@ -513,13 +566,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{def:mpu_normalized_flattening}
     \lean{MPOTensor.normalizedFlattening}
     \leanok
+    \uses{def:mpo_tensor,def:mps_tensor,def:mpo_to_mps}
     For an MPO tensor $U$ of physical dimension $d>0$, its normalized
     flattening is the doubled-physical-index MPS tensor
     \begin{align}
         \widetilde U^{ij}&=\frac{1}{\sqrt d}\,U^{ij}.
     \end{align}
     This is the normalization used in the normal-tensor argument of
-    \cite[Proposition~III.1]{Cirac2017MPU}.
+    \cite[Section~III, equation~(13)]{Cirac2017MPU}.
 \end{definition}
 
 \begin{theorem}[Self-overlap scaling]
@@ -527,7 +581,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPSTensor.mpvOverlap_smul_self,
       MPOTensor.mpvOverlap_normalizedFlattening_self}
     \leanok
-    \uses{def:mpu_normalized_flattening}
+    \uses{def:mpu_normalized_flattening,def:mpv_overlap,def:mpo_to_mps,
+        def:mpo_tensor,def:mps_tensor}
     For a matrix product tensor $A$, a complex number $c$, and a nonnegative
     integer $N$, scaling every local matrix by $c$ gives
     \begin{align}
@@ -543,8 +598,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \sum_\sigma V^{(N)}(\widetilde U)_\sigma
           \overline{V^{(N)}(\widetilde U)_\sigma}
         &=d^{-N}
-          \sum_\sigma V^{(N)}(U)_\sigma
-          \overline{V^{(N)}(U)_\sigma}.
+          \sum_\sigma V^{(N)}(U^{\mathrm{MPS}})_\sigma
+          \overline{V^{(N)}(U^{\mathrm{MPS}})_\sigma}.
     \end{align}
 \end{theorem}
 
@@ -559,7 +614,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_normalized_transfer_trace}
     \lean{MPOTensor.IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one}
     \leanok
-    \uses{def:mpu,def:mpu_normalized_flattening}
+    \uses{def:mpu,def:mpo_tensor,def:mps_tensor,def:mpu_normalized_flattening,
+        def:transfer_map,def:mpu_transfer_matrix}
     Let $U$ be an MPU tensor with positive physical and bond dimensions, and
     let $E$ be the transfer matrix of its normalized flattening.  For every
     integer $N>1$,
@@ -575,7 +631,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         thm:mpdo_doubled_overlap_hilbert_schmidt,lem:mpu_mul_adjoint}
     Scaling both tensor copies by $1/\sqrt d$ multiplies the length-$N$
     self-overlap by $d^{-N}$.  The raw self-overlap is the trace of
-    $\operatorname{MPO}_N(U)\operatorname{MPO}_N(U)^\dagger$.  Since $N>1$,
+    $U^{(N)}(U^{(N)})^\dagger$.  Since $N>1$,
     the MPU equation makes this product the identity on a space of dimension
     $d^N$.  Its trace is therefore $d^N$, and the normalization gives one.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -440,7 +440,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     spectral-radius and primitivity properties.
 \end{proof}
 
-\section{Transfer-matrix bridges}
+\section{Transfer-matrix identities}
 
 Let $D$ be a positive integer and let
 $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map.  Write $\widehat T$
@@ -480,6 +480,9 @@ $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
     eigenmatrices to nonzero eigenvectors and conversely.
 \end{proof}
 
+For a matrix product tensor $A$, write $V^{(N)}(A)_\sigma$ for the
+coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
+
 \begin{theorem}[Transfer-matrix powers as periodic overlaps]
     \label{thm:mpu_transfer_matrix_overlap}
     \lean{MPSTensor.trace_transferMatrix_mixedTransferMap_pow_eq_mpvOverlap,
@@ -490,8 +493,8 @@ $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
     transfer map.  Then
     \begin{align}
         \tr\!\left(\widehat{F_{A,B}}^{\,N}\right)
-          &=\sum_\sigma \operatorname{mpv}(A,\sigma)
-             \overline{\operatorname{mpv}(B,\sigma)}.
+          &=\sum_\sigma V^{(N)}(A)_\sigma
+             \overline{V^{(N)}(B)_\sigma}.
     \end{align}
     In particular, taking $B=A$ identifies the trace of the $N$th power of
     the ordinary transfer matrix with the length-$N$ self-overlap.
@@ -524,20 +527,20 @@ $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
     For a matrix product tensor $A$, a complex number $c$, and a nonnegative
     integer $N$, scaling every local matrix by $c$ gives
     \begin{align}
-        \sum_\sigma \operatorname{mpv}(cA,\sigma)
-          \overline{\operatorname{mpv}(cA,\sigma)}
+        \sum_\sigma V^{(N)}(cA)_\sigma
+          \overline{V^{(N)}(cA)_\sigma}
         &=(c\overline c)^N
-          \sum_\sigma \operatorname{mpv}(A,\sigma)
-          \overline{\operatorname{mpv}(A,\sigma)}.
+          \sum_\sigma V^{(N)}(A)_\sigma
+          \overline{V^{(N)}(A)_\sigma}.
     \end{align}
     Consequently, if $d>0$ and $U$ is an MPO tensor of physical dimension
     $d$, then
     \begin{align}
-        \sum_\sigma \operatorname{mpv}(\widetilde U,\sigma)
-          \overline{\operatorname{mpv}(\widetilde U,\sigma)}
+        \sum_\sigma V^{(N)}(\widetilde U)_\sigma
+          \overline{V^{(N)}(\widetilde U)_\sigma}
         &=d^{-N}
-          \sum_\sigma \operatorname{mpv}(U,\sigma)
-          \overline{\operatorname{mpv}(U,\sigma)}.
+          \sum_\sigma V^{(N)}(U)_\sigma
+          \overline{V^{(N)}(U)_\sigma}.
     \end{align}
 \end{theorem}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -540,8 +540,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPSTensor.trace_transferMatrix_mixedTransferMap_pow_eq_mpvOverlap,
       MPSTensor.trace_transferMatrix_transferMap_pow_eq_mpvOverlap}
     \leanok
-    \uses{def:mpu_transfer_matrix,def:mixed_transfer,def:mpv_overlap,
-        def:mps_tensor}
+    \uses{def:mpu_transfer_matrix,def:mixed_transfer,def:transfer_map,
+        def:mpv_overlap,def:mps_tensor}
     Let $A$ and $B$ be matrix product tensors with the same positive bond
     dimension, and let $F_{A,B}(X)=\sum_i A^iX(B^i)^\dagger$ be their mixed
     transfer map.  Then


### PR DESCRIPTION
## Summary

- add general transfer-matrix power, operator-trace, and eigenvalue bridges
- identify mixed/self MPS overlaps with traces of transfer-matrix powers
- add reusable scalar self-overlap scaling
- define the paper-normalized MPO flattening `U / sqrt d`
- prove `tr(E^N) = 1` for an MPU at every `N > 1`, with explicit nonzero physical and bond dimensions
- document the bridges and normalized trace argument in Chapter 28

This is a prerequisite for #5706.

## Checks

- `lake env lean TNLean/Channel/TransferMatrix.lean`
- `lake env lean TNLean/MPS/Overlap/Basic.lean`
- `lake env lean TNLean/Spectral/MPVOverlapTrace.lean`
- `lake env lean TNLean/MPS/MPU/TransferMatrix.lean`
- `lake env lean TNLean/MPS/MPU.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- proof-integrity grep and `python3 scripts/tactic_pattern_scan.py`

`leanblueprint checkdecls` was also attempted after regenerating the ignored declaration list, but the full-project checker could not start because this targeted-cache worktree lacks the unrelated artifact `TNLean/MPS/BNT/Construction.olean`. No broad build was run, in accordance with the issue's cache constraint.

Closes #5736.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean additions along existing spectral/transfer-matrix lines; no runtime or security surface. Risk is mainly proof maintenance and import-graph coupling for downstream MPU work (#5706).
> 
> **Overview**
> Adds **transfer-matrix bridges** (powers, operator trace, eigenvalue equivalence) and identifies **matrix traces of transfer-map powers** with MPV overlaps, then uses them to prove the Cirac et al. **normalized MPU trace identity** `tr(E^N) = 1` for `N > 1`.
> 
> In `TNLean/Channel/TransferMatrix.lean`, new lemmas show `transferMatrix (T^N) = (transferMatrix T)^N`, matrix trace matches `LinearMap.trace`, and eigenvalues agree via vectorization. `TNLean/Spectral/MPVOverlapTrace.lean` wires these to `trace(transferMatrix(...)^N) = mpvOverlap`. `mpvOverlap_smul_self` in overlap basics handles scaling both tensor copies.
> 
> **New** `MPOTensor.normalizedFlattening` (`U.toMPSTensor / sqrt d`) and `IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one` chain overlap scaling, MPU unitarity, and `trace_one` to get the trace. Chapter 28 blueprint documents transfer-matrix identities and the normalized trace argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d389606546f46412ebcadbbf36d6a3a0aa4945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->