### PR TITLE
feat(Analysis): bridge ground-space angles to excitation anticommutators

### DIFF
--- a/TNLean/Analysis/TwoProjectionCompression.lean
+++ b/TNLean/Analysis/TwoProjectionCompression.lean
@@ -138,8 +138,6 @@ private theorem friedrichs_anticommutator_reduced
   have hsumProj : ‖x‖ ^ 2 + ‖y‖ ^ 2 ≤ (1 + η) * ‖v‖ ^ 2 := by
     let S := ‖x‖ ^ 2 + ‖y‖ ^ 2
     have hS : 0 ≤ S := add_nonneg (sq_nonneg _) (sq_nonneg _)
-    have hsumNormNonneg : 0 ≤ ‖x + y‖ := norm_nonneg _
-    have hvNormNonneg : 0 ≤ ‖v‖ := norm_nonneg _
     have hηone : 0 ≤ 1 + η := by linarith
     by_cases hS0 : S = 0
     · rw [show ‖x‖ ^ 2 + ‖y‖ ^ 2 = 0 from hS0]
@@ -175,7 +173,6 @@ private theorem friedrichs_anticommutator_reduced
   have heSq : (1 - η) * (‖a‖ ^ 2 + ‖b‖ ^ 2) ≤ ‖e‖ ^ 2 := by
     have hc : 0 ≤ 1 - η := sub_nonneg.mpr hηle
     have hQ : 0 ≤ ‖a‖ ^ 2 + ‖b‖ ^ 2 := add_nonneg (sq_nonneg _) (sq_nonneg _)
-    have heNorm : 0 ≤ ‖e‖ := norm_nonneg _
     have hvNorm : 0 ≤ ‖v‖ := norm_nonneg _
     by_cases hv0 : ‖v‖ = 0
     · have hv : v = 0 := norm_eq_zero.mp hv0

--- a/TNLean/Analysis/TwoProjectionCompression.lean
+++ b/TNLean/Analysis/TwoProjectionCompression.lean
@@ -8,9 +8,10 @@ import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
 /-!
 # Norm compression for two orthogonal projections
 
-This file proves the elementary Hilbert-space passage from a Friedrichs overlap
-bound for two subspaces to a norm estimate for the product of their orthogonal
-projections. The common intersection is removed before the overlap bound is
+This file proves elementary Hilbert-space consequences of a Friedrichs overlap
+bound for two subspaces. Besides norm estimates for products of orthogonal projections,
+it gives the source anticommutator lower bound for the complementary excitation
+projections. The common ground-space intersection is removed before the overlap bound is
 applied.
 -/
 
@@ -33,6 +34,17 @@ def IsFriedrichsBound (U V : Submodule ℂ E) (η : ℝ) : Prop :=
     ∀ y : E, y ∈ V → y ∈ (U ⊓ V)ᗮ →
       ‖⟪x, y⟫_ℂ‖ ≤ η * ‖x‖ * ‖y‖
 
+private theorem starProjection_mem_orthogonal_of_le
+    (U W : Submodule ℂ E) (hWU : W ≤ U) {v : E} (hvW : v ∈ Wᗮ) :
+    U.starProjection v ∈ Wᗮ := by
+  rw [Submodule.mem_orthogonal'] at hvW ⊢
+  intro z hz
+  calc
+    ⟪U.starProjection v, z⟫_ℂ = ⟪v, U.starProjection z⟫_ℂ :=
+      U.inner_starProjection_left_eq_right v z
+    _ = ⟪v, z⟫_ℂ := by rw [U.starProjection_eq_self_iff.mpr (hWU hz)]
+    _ = 0 := hvW z hz
+
 /-- A Friedrichs overlap bound controls the orthogonal projection of a vector
 in one reduced subspace onto the other reduced subspace.
 
@@ -50,14 +62,8 @@ theorem norm_starProjection_le_of_friedrichs_bound
   let x := U.starProjection v
   change ‖x‖ ≤ η * ‖v‖
   have hxU : x ∈ U := U.starProjection_apply_mem v
-  have hxInter : x ∈ (U ⊓ V)ᗮ := by
-    rw [Submodule.mem_orthogonal'] at hvInter ⊢
-    intro z hz
-    calc
-      ⟪x, z⟫_ℂ = ⟪v, U.starProjection z⟫_ℂ :=
-        U.inner_starProjection_left_eq_right v z
-      _ = ⟪v, z⟫_ℂ := by rw [U.starProjection_eq_self_iff.mpr hz.1]
-      _ = 0 := hvInter z hz
+  have hxInter : x ∈ (U ⊓ V)ᗮ :=
+    starProjection_mem_orthogonal_of_le U (U ⊓ V) inf_le_left hvInter
   have hInner := hAngle x hxU hxInter v hvV hvInter
   have hInnerEq : ⟪x, v⟫_ℂ = ⟪x, x⟫_ℂ := by
     calc
@@ -90,13 +96,192 @@ theorem norm_starProjection_starProjection_le_of_friedrichs_bound
       η * ‖V.starProjection v‖ := by
   apply norm_starProjection_le_of_friedrichs_bound U V hη hAngle
   · exact V.starProjection_apply_mem v
-  · rw [Submodule.mem_orthogonal'] at hvInter ⊢
-    intro z hz
+  · exact starProjection_mem_orthogonal_of_le V (U ⊓ V) inf_le_right hvInter
+
+private theorem friedrichs_anticommutator_reduced
+    (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η) (hηle : η ≤ 1)
+    (hAngle : IsFriedrichsBound U V η)
+    {v : E} (hvInter : v ∈ (U ⊓ V)ᗮ) :
+    -η * (RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) +
+      RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ)) ≤
+      RCLike.re (⟪Uᗮ.starProjection v, Vᗮ.starProjection v⟫_ℂ) +
+      RCLike.re (⟪Vᗮ.starProjection v, Uᗮ.starProjection v⟫_ℂ) := by
+  let x := U.starProjection v
+  let y := V.starProjection v
+  let a := Uᗮ.starProjection v
+  let b := Vᗮ.starProjection v
+  have hxU : x ∈ U := U.starProjection_apply_mem v
+  have hyV : y ∈ V := V.starProjection_apply_mem v
+  have hxInter : x ∈ (U ⊓ V)ᗮ :=
+    starProjection_mem_orthogonal_of_le U (U ⊓ V) inf_le_left hvInter
+  have hyInter : y ∈ (U ⊓ V)ᗮ :=
+    starProjection_mem_orthogonal_of_le V (U ⊓ V) inf_le_right hvInter
+  have hxyNorm : ‖⟪x, y⟫_ℂ‖ ≤ η * ‖x‖ * ‖y‖ :=
+    hAngle x hxU hxInter y hyV hyInter
+  have hxyRe : RCLike.re (⟪x, y⟫_ℂ) ≤ η * ‖x‖ * ‖y‖ :=
+    (RCLike.re_le_norm _).trans hxyNorm
+  have hsumNorm : ‖x + y‖ ^ 2 ≤
+      (1 + η) * (‖x‖ ^ 2 + ‖y‖ ^ 2) := by
+    rw [norm_add_sq (𝕜 := ℂ)]
+    nlinarith [sq_nonneg (‖x‖ - ‖y‖)]
+  have hxv : RCLike.re (⟪x, v⟫_ℂ) = ‖x‖ ^ 2 := by
+    change RCLike.re (⟪U.starProjection v, v⟫_ℂ) = ‖U.starProjection v‖ ^ 2
+    exact U.re_inner_starProjection_eq_normSq v
+  have hyv : RCLike.re (⟪y, v⟫_ℂ) = ‖y‖ ^ 2 := by
+    change RCLike.re (⟪V.starProjection v, v⟫_ℂ) = ‖V.starProjection v‖ ^ 2
+    exact V.re_inner_starProjection_eq_normSq v
+  have hsumInner : RCLike.re (⟪x + y, v⟫_ℂ) = ‖x‖ ^ 2 + ‖y‖ ^ 2 := by
+    rw [inner_add_left, map_add, hxv, hyv]
+  have hinnerNorm : ‖x‖ ^ 2 + ‖y‖ ^ 2 ≤ ‖x + y‖ * ‖v‖ := by
+    rw [← hsumInner]
+    exact (RCLike.re_le_norm _).trans (norm_inner_le_norm (x + y) v)
+  have hsumProj : ‖x‖ ^ 2 + ‖y‖ ^ 2 ≤ (1 + η) * ‖v‖ ^ 2 := by
+    let S := ‖x‖ ^ 2 + ‖y‖ ^ 2
+    have hS : 0 ≤ S := add_nonneg (sq_nonneg _) (sq_nonneg _)
+    have hsumNormNonneg : 0 ≤ ‖x + y‖ := norm_nonneg _
+    have hvNormNonneg : 0 ≤ ‖v‖ := norm_nonneg _
+    have hηone : 0 ≤ 1 + η := by linarith
+    by_cases hS0 : S = 0
+    · rw [show ‖x‖ ^ 2 + ‖y‖ ^ 2 = 0 from hS0]
+      exact mul_nonneg hηone (sq_nonneg _)
+    · have hSpos : 0 < S := lt_of_le_of_ne hS (Ne.symm hS0)
+      have hsq : S ^ 2 ≤ ‖x + y‖ ^ 2 * ‖v‖ ^ 2 := by
+        dsimp [S]
+        nlinarith
+      dsimp [S] at hSpos ⊢
+      nlinarith
+  have hav : RCLike.re (⟪a, v⟫_ℂ) = ‖a‖ ^ 2 := by
+    change RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) = ‖Uᗮ.starProjection v‖ ^ 2
+    exact Uᗮ.re_inner_starProjection_eq_normSq v
+  have hbv : RCLike.re (⟪b, v⟫_ℂ) = ‖b‖ ^ 2 := by
+    change RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ) = ‖Vᗮ.starProjection v‖ ^ 2
+    exact Vᗮ.re_inner_starProjection_eq_normSq v
+  have hpythU := U.norm_sq_eq_add_norm_sq_starProjection v
+  have hpythV := V.norm_sq_eq_add_norm_sq_starProjection v
+  change ‖v‖ ^ 2 = ‖x‖ ^ 2 + ‖a‖ ^ 2 at hpythU
+  change ‖v‖ ^ 2 = ‖y‖ ^ 2 + ‖b‖ ^ 2 at hpythV
+  have hdiagLower :
+      (1 - η) * ‖v‖ ^ 2 ≤ ‖a‖ ^ 2 + ‖b‖ ^ 2 := by
+    nlinarith [hsumProj]
+  let e := a + b
+  have hev : RCLike.re (⟪e, v⟫_ℂ) = ‖a‖ ^ 2 + ‖b‖ ^ 2 := by
+    dsimp [e]
+    rw [inner_add_left]
+    change RCLike.re (⟪a, v⟫_ℂ) + RCLike.re (⟪b, v⟫_ℂ) = _
+    rw [hav, hbv]
+  have hinnerE : ‖a‖ ^ 2 + ‖b‖ ^ 2 ≤ ‖e‖ * ‖v‖ := by
+    rw [← hev]
+    exact (RCLike.re_le_norm _).trans (norm_inner_le_norm e v)
+  have heSq : (1 - η) * (‖a‖ ^ 2 + ‖b‖ ^ 2) ≤ ‖e‖ ^ 2 := by
+    have hc : 0 ≤ 1 - η := sub_nonneg.mpr hηle
+    have hQ : 0 ≤ ‖a‖ ^ 2 + ‖b‖ ^ 2 := add_nonneg (sq_nonneg _) (sq_nonneg _)
+    have heNorm : 0 ≤ ‖e‖ := norm_nonneg _
+    have hvNorm : 0 ≤ ‖v‖ := norm_nonneg _
+    by_cases hv0 : ‖v‖ = 0
+    · have hv : v = 0 := norm_eq_zero.mp hv0
+      subst v
+      simp [a, b, e]
+    · have hvpos : 0 < ‖v‖ := lt_of_le_of_ne hvNorm (Ne.symm hv0)
+      have hQsq : (‖a‖ ^ 2 + ‖b‖ ^ 2) ^ 2 ≤ ‖e‖ ^ 2 * ‖v‖ ^ 2 := by
+        nlinarith
+      have hcQ := mul_le_mul_of_nonneg_left hdiagLower hQ
+      have hmul :
+          ((1 - η) * (‖a‖ ^ 2 + ‖b‖ ^ 2)) * ‖v‖ ^ 2 ≤
+            ‖e‖ ^ 2 * ‖v‖ ^ 2 := by
+        nlinarith
+      exact (mul_le_mul_iff_of_pos_right (sq_pos_of_pos hvpos)).mp hmul
+  have hconj : RCLike.re (⟪b, a⟫_ℂ) = RCLike.re (⟪a, b⟫_ℂ) := by
+    rw [← inner_conj_symm a b, RCLike.conj_re]
+  rw [show RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) = ‖a‖ ^ 2 from hav,
+    show RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ) = ‖b‖ ^ 2 from hbv]
+  change -η * (‖a‖ ^ 2 + ‖b‖ ^ 2) ≤
+    RCLike.re (⟪a, b⟫_ℂ) + RCLike.re (⟪b, a⟫_ℂ)
+  rw [hconj]
+  have heExpand : ‖e‖ ^ 2 = ‖a‖ ^ 2 + 2 * RCLike.re (⟪a, b⟫_ℂ) + ‖b‖ ^ 2 := by
+    exact norm_add_sq a b
+  nlinarith [heSq]
+
+private theorem friedrichs_anticommutator_of_le_one
+    (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η) (hηle : η ≤ 1)
+    (hAngle : IsFriedrichsBound U V η) (v : E) :
+    -η * (RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) +
+      RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ)) ≤
+      RCLike.re (⟪Uᗮ.starProjection v, Vᗮ.starProjection v⟫_ℂ) +
+      RCLike.re (⟪Vᗮ.starProjection v, Uᗮ.starProjection v⟫_ℂ) := by
+  let W := U ⊓ V
+  let p := W.starProjection v
+  let z := v - p
+  have hzInter : z ∈ Wᗮ := W.sub_starProjection_mem_orthogonal v
+  have hpU : p ∈ U := by
+    exact (W.starProjection_apply_mem v).1
+  have hpV : p ∈ V := by
+    exact (W.starProjection_apply_mem v).2
+  have hUzero : Uᗮ.starProjection p = 0 := by
+    rw [Uᗮ.starProjection_apply_eq_zero_iff]
+    exact U.le_orthogonal_orthogonal hpU
+  have hVzero : Vᗮ.starProjection p = 0 := by
+    rw [Vᗮ.starProjection_apply_eq_zero_iff]
+    exact V.le_orthogonal_orthogonal hpV
+  have hUz : Uᗮ.starProjection z = Uᗮ.starProjection v := by
+    simp [z, map_sub, hUzero]
+  have hVz : Vᗮ.starProjection z = Vᗮ.starProjection v := by
+    simp [z, map_sub, hVzero]
+  have hUdiag : RCLike.re (⟪Uᗮ.starProjection z, z⟫_ℂ) =
+      RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) := by
+    rw [Uᗮ.re_inner_starProjection_eq_normSq,
+      Uᗮ.re_inner_starProjection_eq_normSq]
+    change ‖Uᗮ.starProjection z‖ ^ 2 = ‖Uᗮ.starProjection v‖ ^ 2
+    rw [hUz]
+  have hVdiag : RCLike.re (⟪Vᗮ.starProjection z, z⟫_ℂ) =
+      RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ) := by
+    rw [Vᗮ.re_inner_starProjection_eq_normSq,
+      Vᗮ.re_inner_starProjection_eq_normSq]
+    change ‖Vᗮ.starProjection z‖ ^ 2 = ‖Vᗮ.starProjection v‖ ^ 2
+    rw [hVz]
+  have h :=
+    friedrichs_anticommutator_reduced U V hη hηle hAngle hzInter
+  rw [hUdiag, hVdiag, hUz, hVz] at h
+  exact h
+
+/-- A Friedrichs bound for two ground-space ranges gives the anticommutator lower bound
+for their complementary excitation projections.
+
+Let `U` and `V` be the ranges of the ground-space projections `qᵢ` and `qⱼ`. Then
+`Uᗮ.starProjection` and `Vᗮ.starProjection` are the complementary excitation projections
+`hᵢ = 1 - qᵢ` and `hⱼ = 1 - qⱼ`. If the Friedrichs overlap of `U` and `V`, with their
+common intersection removed, is at most `η`, then
+`hᵢhⱼ + hⱼhᵢ ≥ -η(hᵢ + hⱼ)` as a quadratic-form inequality.
+
+This is the generic two-projection bridge from the ground-space principal-angle estimate to
+arXiv:2011.12127, Section IV.C, `eq:4:martingale-2` (lines 2176--2182). It does not assert the
+false all-vector norm compression bound for the excitation product. The MPS-specific task is only
+to supply the uniform ground-space Friedrichs bound in the chosen blocking convention, as recorded
+in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound
+    (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
+    (hAngle : IsFriedrichsBound U V η) (v : E) :
+    -η * (RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) +
+      RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ)) ≤
+      RCLike.re (⟪Uᗮ.starProjection v, Vᗮ.starProjection v⟫_ℂ) +
+      RCLike.re (⟪Vᗮ.starProjection v, Uᗮ.starProjection v⟫_ℂ) := by
+  by_cases hηle : η ≤ 1
+  · exact friedrichs_anticommutator_of_le_one U V hη hηle hAngle v
+  · have hOne : IsFriedrichsBound U V 1 := by
+      intro x _ _ y _ _
+      simpa using norm_inner_le_norm x y
+    have h :=
+      friedrichs_anticommutator_of_le_one U V (η := 1) zero_le_one le_rfl hOne v
+    have hdiag : 0 ≤ RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) +
+        RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ) :=
+      add_nonneg (Uᗮ.re_inner_starProjection_nonneg v)
+        (Vᗮ.re_inner_starProjection_nonneg v)
     calc
-      ⟪V.starProjection v, z⟫_ℂ = ⟪v, V.starProjection z⟫_ℂ :=
-        V.inner_starProjection_left_eq_right v z
-      _ = ⟪v, z⟫_ℂ := by rw [V.starProjection_eq_self_iff.mpr hz.2]
-      _ = 0 := hvInter z hz
+      -η * (RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) +
+          RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ)) ≤
+          -1 * (RCLike.re (⟪Uᗮ.starProjection v, v⟫_ℂ) +
+            RCLike.re (⟪Vᗮ.starProjection v, v⟫_ℂ)) := by
+        exact mul_le_mul_of_nonneg_right (neg_le_neg_iff.mpr (le_of_not_ge hηle)) hdiag
+      _ ≤ _ := h
 
 /-- On the reduced range of the first projection, a Friedrichs overlap bound
 gives the directional compression estimate

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -82,6 +82,7 @@
     \label{thm:friedrichs_ground_space_excitation_anticommutator}
     \lean{Submodule.re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
     \leanok
+    \uses{def:friedrichs_overlap_bound}
     Let $U$ and $V$ be ground-space ranges in a finite-dimensional complex
     Hilbert space, let $W=U\cap V$, and let $q_U$ and $q_V$ be the orthogonal
     projectors onto $U$ and $V$. Suppose that $\eta\ge0$ and
@@ -119,10 +120,7 @@
 
 \begin{lemma}[MPS anticommutator input for the martingale condition]\label{lem:martingale_mps}
     \notready
-    \uses{thm:martingale_criterion,
-        thm:friedrichs_ground_space_excitation_anticommutator,
-        def:parent_interaction, def:local_term_parent,
-        thm:ground_space_intersection, def:injective}
+    \uses{def:parent_interaction, def:local_term_parent, def:injective}
     Let $A$ be injective and fix an interaction range $L \ge 2$ as in
     Definition~\ref{def:parent_interaction}. Let
     $h_L(A):=\Pi_{G_L(A)^\perp}$ be the $L$-site parent interaction, and for
@@ -174,7 +172,7 @@
 
 \begin{proof}
     \uses{thm:friedrichs_ground_space_excitation_anticommutator,
-        thm:ground_space_intersection, def:injective}
+        thm:ground_space_intersection, thm:martingale_criterion}
     \notready
     The cited martingale paragraph compares the anticommutator estimate with
     principal angles between the local ground spaces. If

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -172,7 +172,7 @@
 
 \begin{proof}
     \uses{thm:friedrichs_ground_space_excitation_anticommutator,
-        thm:ground_space_intersection, thm:martingale_criterion}
+        thm:ground_space_intersection}
     \notready
     The cited martingale paragraph compares the anticommutator estimate with
     principal angles between the local ground spaces. If

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -78,10 +78,51 @@
     $\lambda\ge\gamma$~\cite{Kastoryano2018Martingale}.
 \end{proof}
 
+\begin{theorem}[Reduced ground-space overlap bounds the excitation anticommutator]%
+    \label{thm:friedrichs_ground_space_excitation_anticommutator}
+    \lean{Submodule.re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
+    \leanok
+    Let $U$ and $V$ be ground-space ranges in a finite-dimensional complex
+    Hilbert space, let $W=U\cap V$, and let $q_U$ and $q_V$ be the orthogonal
+    projectors onto $U$ and $V$. Suppose that $\eta\ge0$ and
+    \begin{align}
+        |\langle x,y\rangle|
+        &\le \eta\,\|x\|\,\|y\|
+        \label{eq:ph_reduced_friedrichs_overlap}
+    \end{align}
+    whenever $x\in U\cap W^\perp$ and $y\in V\cap W^\perp$. Define the
+    complementary excitation projections by $h_U=\Id-q_U$ and
+    $h_V=\Id-q_V$. Then, for every vector $v$,
+    \begin{align}
+        \re\langle h_Uv,h_Vv\rangle
+        +\re\langle h_Vv,h_Uv\rangle
+        &\ge
+        -\eta\bigl(
+            \re\langle h_Uv,v\rangle
+            +\re\langle h_Vv,v\rangle
+        \bigr).
+        \label{eq:ph_friedrichs_excitation_anticommutator}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Remove the component of $v$ in the common intersection $W$; both
+    excitation projections are unchanged. If $\eta\le1$, apply
+    (\ref{eq:ph_reduced_friedrichs_overlap}) to the reduced ground-space
+    components $q_Uv$ and $q_Vv$, and combine the resulting principal-angle
+    estimate with the orthogonal decompositions
+    $v=q_Uv+h_Uv=q_Vv+h_Vv$. If $\eta>1$, the same conclusion follows from
+    the universal overlap bound with coefficient $1$ and the non-negativity
+    of the two diagonal excitation forms.
+\end{proof}
+
 \begin{lemma}[MPS anticommutator input for the martingale condition]\label{lem:martingale_mps}
     \notready
-    \uses{thm:martingale_criterion, def:parent_interaction,
-        def:local_term_parent, thm:ground_space_intersection, def:injective}
+    \uses{thm:martingale_criterion,
+        thm:friedrichs_ground_space_excitation_anticommutator,
+        def:parent_interaction, def:local_term_parent,
+        thm:ground_space_intersection, def:injective}
     Let $A$ be injective and fix an interaction range $L \ge 2$ as in
     Definition~\ref{def:parent_interaction}. Let
     $h_L(A):=\Pi_{G_L(A)^\perp}$ be the $L$-site parent interaction, and for
@@ -132,7 +173,8 @@
 \end{lemma}
 
 \begin{proof}
-    \uses{thm:ground_space_intersection, def:injective}
+    \uses{thm:friedrichs_ground_space_excitation_anticommutator,
+        thm:ground_space_intersection, def:injective}
     \notready
     The cited martingale paragraph compares the anticommutator estimate with
     principal angles between the local ground spaces. If
@@ -140,12 +182,15 @@
     projectors, the Kastoryano--Lucia estimate cited there concerns
     $\delta(\ell)=\|q_iq_j-P\|$, where $P$ projects onto
     $\ker(h_i+h_j)=\ker h_i\cap\ker h_j$ and $\ell$ is the overlap length.
-    What remains is to derive the anticommutator estimate above, with its
-    blocking convention and constants, for the cyclic-window local terms. The
-    intersection property identifies $\ker h_i\cap\ker h_j$ with the parent
-    ground space on the union of the two windows, but it does not by itself
-    supply this numerical inequality. The directed excitation-projection
-    estimate
+    Theorem~\ref{thm:friedrichs_ground_space_excitation_anticommutator} supplies
+    the generic passage from such a reduced ground-space overlap bound to the
+    anticommutator estimate for the complementary excitation projections.
+    What remains is to obtain the required uniform Friedrichs bound, with the
+    source blocking convention and constants, for the cyclic-window local
+    ground spaces. The intersection property identifies
+    $\ker h_i\cap\ker h_j$ with the parent ground space on the union of the two
+    windows, but it does not by itself supply this numerical bound. The directed
+    excitation-projection estimate
     \begin{align}
         \|h_i h_j v\|
         &\le \eta\|h_i v\|,

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -255,11 +255,19 @@ existential MPS gap theorem, but it would not immediately be the displayed
 all-$L$ estimate with constant $1/(4L)$ unless the constants are converted to
 the same blocking convention.
 
-Consequently the remaining comparison is not whether the row-sum algebra is
-valid; that part has been isolated and formalized. The remaining comparison is
-whether the cited FNW--Nachtergaele--Kastoryano principal-angle estimates supply
-the required cyclic-window anticommutator estimate, with constants independent
-of the chain length, after the same blocking convention has been fixed.
+Consequently the remaining comparison is neither the row-sum algebra nor the
+generic two-projection geometry; both parts have been isolated and formalized.
+In particular,
+\leanid{re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
+shows that a Friedrichs bound $\eta$ for the two ground-space ranges, after
+removing their common intersection, gives
+\[
+  h_i h_j+h_jh_i\ge -\eta(h_i+h_j)
+\]
+for the complementary excitation projections. The remaining comparison is
+whether the cited FNW--Nachtergaele--Kastoryano estimates supply the required
+uniform ground-space Friedrichs bound, with constants independent of the chain
+length, after the same blocking convention has been fixed.
 The qualitative fact that two finite-dimensional subspaces have a well-defined
 principal-angle decomposition is not enough: the martingale reduction needs a
 uniform numerical bound after the same blocking convention has been fixed.
@@ -323,9 +331,10 @@ and
 with public reformulations
 \leanid{parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant} and
 \leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. The remaining
-MPS-specific task is unchanged: to produce a uniform anticommutator (or
-ground-space principal-angle) estimate for overlapping cyclic windows, using the
-intersection identity $\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
+MPS-specific task is to produce a uniform ground-space principal-angle estimate
+for overlapping cyclic windows; the generic theorem above then supplies the
+anticommutator estimate. This uses the intersection identity
+$\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
 \leanid{adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}; a uniform
 small bound on $\|p_ip_j\|$ itself is not available in the generic overlapping
 case, since that norm is $1$ whenever the two excitation ranges have a common


### PR DESCRIPTION
## Summary

Formalizes the generic source-faithful two-projection bridge needed by the MPS parent-Hamiltonian martingale argument. A Friedrichs bound on two reduced **ground-space ranges** implies the Cirac anticommutator lower bound for their complementary excitation projections:

$$
h_i h_j+h_j h_i\ge-\eta(h_i+h_j).
$$

The proof removes the common ground-space intersection before applying the angle bound and does **not** use the false all-vector excitation-compression estimate. Chapter 13 now has a declaration-exact entry in the principal-angle dependency path, and the paper-gap note identifies the remaining input as the blocked FNW/Nachtergaele MPS ground-space estimate.

## Sources

- Cirac et al., arXiv:2011.12127 §IV.C, `eq:4:martingale-2`
- Kastoryano–Lucia, arXiv:1705.09491, Definition 2 and Remark 2

## Verification

- `lake env lean TNLean/Analysis/TwoProjectionCompression.lean`
- targeted module build
- independent Mathlib-style/correctness review and simplification
- reader-facing prose check
- blueprint/Lean synchronization: all 6644 theorem-like entries synchronized
- exact declaration elaboration and `git diff --check`

Repository-wide blueprint/web checks retain the documented baseline duplicate-environment/time-limit failures; the exact new declaration and entry were checked directly.

Closes #5733
Refs #5455, #460, #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to formal analysis lemmas, blueprint documentation, and a paper-gap note; no runtime, auth, or data paths are touched.
> 
> **Overview**
> Adds the **generic Hilbert-space bridge** from a reduced Friedrichs overlap bound on two ground-space ranges to the **excitation anticommutator** inequality needed by the martingale spectral-gap argument (`h_i h_j + h_j h_i \ge -\eta(h_i + h_j)` in quadratic form). The Lean proof in `TwoProjectionCompression.lean` introduces a shared helper `starProjection_mem_orthogonal_of_le` and refactors existing norm estimates to use it, then proves the anticommutator bound via reduced vectors on `(U \cap V)^\perp` and a fallback when \(\eta > 1\).
> 
> The blueprint gains **Theorem** `thm:friedrichs_ground_space_excitation_anticommutator` with a `\leanok` proof sketch, and `lem:martingale_mps` now cites that theorem so the **remaining MPS work** is framed as obtaining a uniform ground-space Friedrichs bound—not re-deriving anticommutator geometry. `docs/paper-gaps/cpgsv21_martingale_overlap.tex` is updated to say row-sum algebra and two-projection geometry are formalized; the open comparison is the blocked FNW/Nachtergaele principal-angle input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 452465b06c873a7b3bae240eca981c7291fb0ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->