### PR TITLE
docs(MPU): complete source-cut blueprint coverage

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -173,8 +173,12 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{definition}[First matrix associated to a Matrix Product Unitary tensor]
     \label{def:mpu_source_matrix_one}
-    \lean{MPOTensor.sourceCutM₁}
+    \lean{MPOTensor.sourceCutM₁, MPOTensor.sourceCutM₁_apply,
+        MPOTensor.sourceCutM₁Fin, MPOTensor.sourceCutM₁Fin_eq_reindex,
+        MPOTensor.sourceCutM₁Fin_apply,
+        MPOTensor.sourceCutM₁_rank_eq_sourceCutM₁Fin_rank}
     \leanok
+    \uses{def:mpo_tensor}
     The matrix $M_1$ is obtained by combining the left auxiliary index with the
     lower physical index, and the upper physical index with the right auxiliary
     index. Thus
@@ -182,12 +186,24 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         (M_1)_{(\alpha,j),(i,\beta)}
         &= \mathcal U^i_{j,\alpha,\beta}.
     \end{align}
+    Transporting the row and column indices along the standard product
+    enumerations gives a matrix $\widetilde M_1$ indexed by
+    $\{0,\ldots,Dd-1\}\times\{0,\ldots,dD-1\}$. Its entries are obtained by
+    applying $M_1$ to the inverse images of the enumerated indices, and
+    \begin{align}
+        \operatorname{rank}(\widetilde M_1)
+        &= \operatorname{rank}(M_1).
+    \end{align}
 \end{definition}
 
 \begin{definition}[Second matrix associated to a Matrix Product Unitary tensor]
     \label{def:mpu_source_matrix_two}
-    \lean{MPOTensor.sourceCutM₂}
+    \lean{MPOTensor.sourceCutM₂, MPOTensor.sourceCutM₂_apply,
+        MPOTensor.sourceCutM₂Fin, MPOTensor.sourceCutM₂Fin_eq_reindex,
+        MPOTensor.sourceCutM₂Fin_apply,
+        MPOTensor.sourceCutM₂_rank_eq_sourceCutM₂Fin_rank}
     \leanok
+    \uses{def:mpo_tensor}
     The matrix $M_2$ is obtained by combining the left auxiliary index with the
     upper physical index, and the lower physical index with the right auxiliary
     index. Thus
@@ -195,11 +211,19 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         (M_2)_{(\alpha,i),(j,\beta)}
         &= \mathcal U^i_{j,\alpha,\beta}.
     \end{align}
+    Transporting the row and column indices along the standard product
+    enumerations gives a matrix $\widetilde M_2$ indexed by
+    $\{0,\ldots,Dd-1\}\times\{0,\ldots,dD-1\}$. Its entries are obtained by
+    applying $M_2$ to the inverse images of the enumerated indices, and
+    \begin{align}
+        \operatorname{rank}(\widetilde M_2)
+        &= \operatorname{rank}(M_2).
+    \end{align}
 \end{definition}
 
 \begin{definition}[Right rank]
     \label{def:mpu_right_rank}
-    \lean{MPOTensor.rightRank}
+    \lean{MPOTensor.rightRank, MPOTensor.rightRank_eq}
     \leanok
     \uses{def:mpu_source_matrix_one}
     The right rank is
@@ -210,7 +234,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{definition}[Left rank]
     \label{def:mpu_left_rank}
-    \lean{MPOTensor.leftRank}
+    \lean{MPOTensor.leftRank, MPOTensor.leftRank_eq}
     \leanok
     \uses{def:mpu_source_matrix_two}
     The left rank is
@@ -234,8 +258,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}
     \leanok
     \uses{def:mpu_source_matrix_one}
-    The matrix $M_1$ has $Dd$ rows and $dD$ columns, so its rank is at most
-    $Dd$.
+    The matrix $M_1$ has $dD$ columns. Its rank is at most its number of
+    columns, hence at most $dD=Dd$.
 \end{proof}
 
 \begin{theorem}[Left-rank bound]
@@ -253,6 +277,6 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}
     \leanok
     \uses{def:mpu_source_matrix_two}
-    The matrix $M_2$ has $Dd$ rows and $dD$ columns, so its rank is at most
-    $Dd$.
+    The matrix $M_2$ has $dD$ columns. Its rank is at most its number of
+    columns, hence at most $dD=Dd$.
 \end{proof}


### PR DESCRIPTION
Follow-up to #5728 for #5722.

This resolves substantive blueprint feedback that arrived after #5728 merged:

- links every public source-cut, reindexing, entry, rank-preservation, and rank-definition declaration from its appropriate parent blueprint entry;
- documents the finite-index reindexings without introducing redundant standalone narrative nodes;
- adds the missing `def:mpo_tensor` dependencies to both source-matrix definitions;
- aligns both rank-bound proof sketches with the actual column-rank argument in Lean.

Checks:

- `lake env lean TNLean/MPS/MPU/SourceCuts.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (`ch28_mpu.tex`: 27/27; global pre-existing sync issues remain)
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`

This PR is blueprint-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint–Lean sync only; no executable code or proof logic changes.
> 
> **Overview**
> Blueprint-only follow-up in `ch28_mpu.tex` that ties MPU **source-cut** material to Lean and fixes proof sketches.
> 
> **Lean links** are expanded on the two source-matrix definitions (`M_1`, `M_2`) and on right/left rank: finite reindexings (`sourceCutM₁Fin` / `sourceCutM₂Fin`), entry lemmas, rank-preservation equalities, and `rightRank_eq` / `leftRank_eq`. Both matrix definitions now `\uses{def:mpo_tensor}`.
> 
> **Narrative** adds the standard product-enumeration matrices $\widetilde M_1$ and $\widetilde M_2$ and states $\operatorname{rank}(\widetilde M_i)=\operatorname{rank}(M_i)$ without new standalone blueprint nodes.
> 
> **Rank-bound proofs** for right and left rank are rewritten to bound by **column count** ($dD$ columns, hence rank $\leq dD = Dd$), matching the Lean column-rank argument instead of citing $Dd$ rows and $dD$ columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562cb81e142964593e23d287407870fc69293047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->