### PR TITLE
feat(Channel/Wigner): recognize pure states by charpoly

### DIFF
--- a/TNLean/Channel/Wigner.lean
+++ b/TNLean/Channel/Wigner.lean
@@ -10,5 +10,6 @@ Authors: TNLean contributors
 
 import TNLean.Channel.Wigner.ProjectiveCarrierBridge
 import TNLean.Channel.Wigner.ProjectivePureState
+import TNLean.Channel.Wigner.PureStateCharpoly
 import TNLean.Channel.Wigner.Rigidity
 import TNLean.Channel.Wigner.Upstream

--- a/TNLean/Channel/Wigner/PureStateCharpoly.lean
+++ b/TNLean/Channel/Wigner/PureStateCharpoly.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.HermitianUnitaryConjugacy
+import TNLean.Channel.Wigner.ProjectivePureState
+
+/-!
+# Pure-state matrices from characteristic polynomials
+
+A Hermitian matrix whose characteristic polynomial agrees with that of a normalized pure-state
+matrix is itself a normalized pure-state matrix. Unitary conjugacy of Hermitian matrices reduces the
+claim to the unitary action on projective rays.
+
+## Main declaration
+
+* `Projectivization.exists_pureStateMatrix_eq_of_isHermitian_charpoly_eq`
+-/
+
+open scoped LinearAlgebra.Projectivization Matrix
+
+namespace Projectivization
+
+variable {d : ℕ}
+
+/-- A Hermitian matrix with the characteristic polynomial of a normalized pure-state matrix is the
+normalized pure-state matrix of another projective ray. -/
+theorem exists_pureStateMatrix_eq_of_isHermitian_charpoly_eq
+    (A : Matrix (Fin d) (Fin d) ℂ) (p : ℙ ℂ (Fin d → ℂ)) (hA : A.IsHermitian)
+    (hcharpoly : A.charpoly = (pureStateMatrix p).charpoly) :
+    ∃ q : ℙ ℂ (Fin d → ℂ), pureStateMatrix q = A := by
+  have hP : (pureStateMatrix p).IsHermitian :=
+    (isOrthogonalProjection_pureStateMatrix p).1
+  have heigenvalues : hP.eigenvalues = hA.eigenvalues :=
+    (hP.eigenvalues_eq_eigenvalues_iff hA).mpr hcharpoly.symm
+  let oneFin : Matrix (Fin d) (Fin d) ℂ := 1
+  have hconj : ∃ U : Matrix (Fin d) (Fin d) ℂ,
+      U * star U = oneFin ∧ A = U * pureStateMatrix p * star U := by
+    letI : DecidableEq (Fin d) := Classical.decEq (Fin d)
+    have hcharpoly' : (pureStateMatrix p).charpoly = A.charpoly :=
+      (hP.eigenvalues_eq_eigenvalues_iff hA).mp heigenvalues
+    rcases Matrix.IsHermitian.exists_unitary_conj_of_charpoly_eq hP hA hcharpoly' with
+      ⟨U, hU⟩
+    refine ⟨U, ?_, hU⟩
+    calc
+      (U : Matrix (Fin d) (Fin d) ℂ) * star (U : Matrix (Fin d) (Fin d) ℂ) = 1 :=
+        Matrix.mem_unitaryGroup_iff.mp U.property
+      _ = oneFin := by
+        ext i j
+        simp [oneFin, Matrix.one_apply]
+  rcases hconj with ⟨Umat, hUmat, hconj⟩
+  have hUmat' : Umat * star Umat = 1 := by simpa only [oneFin] using hUmat
+  let U : Matrix.unitaryGroup (Fin d) ℂ :=
+    ⟨Umat, Matrix.mem_unitaryGroup_iff.mpr hUmat'⟩
+  refine ⟨unitaryAction U p, ?_⟩
+  calc
+    pureStateMatrix (unitaryAction U p) =
+        (U : Matrix (Fin d) (Fin d) ℂ) * pureStateMatrix p *
+          (U : Matrix (Fin d) (Fin d) ℂ)ᴴ := pureStateMatrix_unitaryAction U p
+    _ = A := hconj.symm
+
+end Projectivization

--- a/TNLean/Channel/Wigner/PureStateCharpoly.lean
+++ b/TNLean/Channel/Wigner/PureStateCharpoly.lean
@@ -25,7 +25,8 @@ namespace Projectivization
 variable {d : ℕ}
 
 /-- A Hermitian matrix with the characteristic polynomial of a normalized pure-state matrix is the
-normalized pure-state matrix of another projective ray. -/
+normalized pure-state matrix of another projective ray. This supplies the pure-state image
+identification used in the spectrum-preserving-map argument of Wolf, Chapter 1, lines 287--296. -/
 theorem exists_pureStateMatrix_eq_of_isHermitian_charpoly_eq
     (A : Matrix (Fin d) (Fin d) ℂ) (p : ℙ ℂ (Fin d → ℂ)) (hA : A.IsHermitian)
     (hcharpoly : A.charpoly = (pureStateMatrix p).charpoly) :

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -1395,6 +1395,33 @@ $v$ is multiplied by a nonzero scalar.
     factors of the outer product.
 \end{proof}
 
+\begin{theorem}[Recognizing pure states by the characteristic polynomial]
+    \label{thm:pure_state_matrix_of_hermitian_charpoly_eq}
+    \lean{Projectivization.exists_pureStateMatrix_eq_of_isHermitian_charpoly_eq}
+    \leanok
+    \uses{def:projective_pure_state_matrix}
+    Let $A\in M_d(\C)$ be Hermitian, and let $p$ be a projective ray. If
+    \begin{align}
+        \chi_A=\chi_{P_p},
+    \end{align}
+    then there is a projective ray $q$ such that
+    \begin{align}
+        P_q=A.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:hermitian_charpoly_unitary_conjugacy,
+      thm:projective_pure_state_bridge}
+    The matrix $P_p$ is Hermitian. Equality of the characteristic polynomials
+    therefore gives a unitary $U$ such that
+    \begin{align}
+        A=UP_pU^\dagger.
+    \end{align}
+    Taking $q=U\cdot p$ and using $P_{U\cdot p}=UP_pU^\dagger$ proves the
+    claim.
+\end{proof}
+
 \begin{theorem}[Normalized and unnormalized pure states]
     \label{thm:star_dot_self_smul_normalized_pure_state_matrix}
     \lean{Projectivization.star_dot_self_smul_normalizedPureStateMatrix}


### PR DESCRIPTION
## What changed

- add the MPS-free Channel/Wigner theorem `Projectivization.exists_pureStateMatrix_eq_of_isHermitian_charpoly_eq`
- prove that a Hermitian matrix with the characteristic polynomial of `pureStateMatrix p` is `pureStateMatrix q` for a projective ray `q`, using Hermitian unitary conjugacy, orthogonal-projection Hermiticity, and the unitary action on rays
- keep the statement free of dimension-positivity assumptions and avoid a redundant range/subtype corollary because the existential equality is the form needed by the spectrum-preserver argument
- regenerate the Wigner import aggregator and add theorem- and proof-level Blueprint dependencies in Chapter 1

## Validation

- duplicate declaration audit across TNLean — no existing pure-state characteristic-polynomial recognition theorem found
- `lake build TNLean.Channel.Wigner.PureStateCharpoly TNLean.Channel.Wigner` — 3083 jobs
- `lake build` — 9966 jobs
- `lake build lint_style && lake exe lint_style --github` — pass
- proof-integrity diff guard and reader-facing prose guard — pass
- oversized-module guard and numbered-module debt ratchet — pass; 0 new violations
- recursive import-cone audit — 14 TNLean modules traversed, no `TNLean.MPS` import reached
- import aggregator `--check` — 51 generated files covering 1256 production modules
- Blueprint sync and CI sync — 6676/6676 theorem-like entries complete
- changed-declaration Blueprint coverage and `lake exe checkdecls blueprint/lean_decls` — pass
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'` — pass, 0 undefined cross-references (standalone citation warnings only)
- `git diff --check`, exact tag/diff checks, and clean worktree — pass

Closes LionSR/QICLean#307.
Advances LionSR/QICLean#295.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Wigner/Channel lemma and Blueprint sync only; no changes to auth, persistence, or existing proof paths beyond wiring the new import.
> 
> **Overview**
> Adds **`Projectivization.exists_pureStateMatrix_eq_of_isHermitian_charpoly_eq`**: if Hermitian `A` has the same characteristic polynomial as `pureStateMatrix p`, then `A = pureStateMatrix q` for some projective ray `q`. The proof chains Hermitian unitary conjugacy from matching charpolys with **`pureStateMatrix_unitaryAction`** so `A` equals the pure-state matrix of `unitaryAction U p`.
> 
> Chapter 1 Blueprint gains theorem **Recognizing pure states by the characteristic polynomial** (`thm:pure_state_matrix_of_hermitian_charpoly_eq`) with a proof sketch, and the Wigner aggregator imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95487406ea1512c3acaa3250c6fb75e327297db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->