### PR TITLE
docs(ParentHamiltonian): fix late spectral-gap hygiene reviews

### DIFF
--- a/TNLean/Analysis/TwoProjectionCompression.lean
+++ b/TNLean/Analysis/TwoProjectionCompression.lean
@@ -279,10 +279,12 @@ Let `U` and `V` be the ranges of the ground-space projections `qᵢ` and `qⱼ`.
 common intersection removed, is at most `η`, then
 `hᵢhⱼ + hⱼhᵢ ≥ -η(hᵢ + hⱼ)` as a quadratic-form inequality.
 
-This is the generic two-projection bridge from the ground-space principal-angle estimate to
-arXiv:2011.12127, Section IV.C, `eq:4:martingale-2` (lines 2176--2182). It does not assert the
-false all-vector norm compression bound for the excitation product. The MPS-specific task is only
-to supply the uniform ground-space Friedrichs bound in the chosen blocking convention, as recorded
+This is the generic two-projection reduction from the ground-space
+principal-angle estimate to arXiv:2011.12127, Section IV.C,
+`eq:4:martingale-2` (lines 2176--2182). It does not assert the false all-vector
+norm compression bound for the excitation product. The MPS-specific task is only
+to supply the uniform ground-space Friedrichs bound in the chosen blocking
+convention, as recorded
 in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound
     (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
@@ -43,7 +43,7 @@ hypothesis `hBoundary` here. The span-based open-boundary decomposition is prove
 (its summands lie in \(G_N(A_j)\)); the periodic-boundary upgrade is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128. It is retained
-as the explicit hypothesis of this intermediate API; the source-range conclusion
+as the explicit hypothesis of this intermediate theorem; the source-range conclusion
 without it is
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
@@ -46,7 +46,10 @@ boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 as the explicit hypothesis of this intermediate API; the source-range conclusion
 without it is
 `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
-in `BNTBlockDiagonalBoundaryClosing`. -/
+in `BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
@@ -42,9 +42,11 @@ with periodic components \(\psi_j\in\mathcal G_{N,L}(A_j)\) is the explicit
 hypothesis `hBoundary` here. The span-based open-boundary decomposition is proved
 (its summands lie in \(G_N(A_j)\)); the periodic-boundary upgrade is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
-1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
-from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128. It is retained
+as the explicit hypothesis of this intermediate API; the source-range conclusion
+without it is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
+in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
@@ -45,8 +45,7 @@ boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128. It is retained
 as the explicit hypothesis of this intermediate API; the source-range conclusion
 without it is
-`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
-in `BNTBlockDiagonalBoundaryClosing`.
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 
 This scope restriction is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -803,9 +803,7 @@ belong to \(\mathcal G_{N,L}(A_j)\).
 
 These identities are assumptions of this theorem. The boundary-condition
 comparison theorem below gives the conclusion for each block from the displayed
-boundary-crossing
-form. Deriving this displayed form from the source comparison is documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+boundary-crossing form.
 
 This result follows the block-diagonal boundary conditions of arXiv:2011.12127,
 lines 2126--2128, and precedes the final equality in
@@ -822,7 +820,10 @@ is the boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proo
 lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128,
 retained as an explicit assumption in this intermediate
 complementary-word API. The source-range conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`. -/
+`BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -888,7 +889,10 @@ boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as
 an explicit hypothesis of this intermediate complementary-word API. The
 source-range conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`. -/
+`BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -819,9 +819,10 @@ is the boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/060819
 (its block components lie in \(G_N(A_j)\)) and does not assume the
 boundary-crossing comparison. The periodic-boundary upgrade encoded by `hIdentity`
 is the boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet
-derived from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128,
+retained as an explicit assumption in this intermediate
+complementary-word API. The source-range conclusion without it is the global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -884,9 +885,10 @@ block-diagonal boundary representation is the boundary-comparison-free open-boun
 arXiv:quant-ph/0608197, Theorem 12, independent of the boundary-crossing
 comparison. The periodic-boundary upgrade encoded by `hIdentity` is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
-1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
-from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as
+an explicit hypothesis of this intermediate complementary-word API. The
+source-range conclusion without it is the global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -888,8 +888,8 @@ comparison. The periodic-boundary upgrade encoded by `hIdentity` is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as
 an explicit hypothesis of this intermediate complementary-word API. The
-source-range conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`.
+source-range conclusion without it is the global-cut theorem
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 
 This scope restriction is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -819,7 +819,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by `hIdentit
 is the boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128,
 retained as an explicit assumption in this intermediate
-complementary-word API. The source-range conclusion without it is the global-cut theorem in
+complementary-word form. The source-range conclusion without it is the global-cut theorem in
 `BNTBlockDiagonalBoundaryClosing`.
 
 This scope restriction is documented in
@@ -887,7 +887,7 @@ arXiv:quant-ph/0608197, Theorem 12, independent of the boundary-crossing
 comparison. The periodic-boundary upgrade encoded by `hIdentity` is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as
-an explicit hypothesis of this intermediate complementary-word API. The
+an explicit hypothesis of this intermediate complementary-word form. The
 source-range conclusion without it is the global-cut theorem
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -72,7 +72,10 @@ tail-word span at length \(N-i\) for each boundary-crossing interval. This is
 an explicit assumption of this intermediate span-dependent form.
 The
 source-range conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`. -/
+`BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -186,7 +189,10 @@ boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128,
 retained as an explicit assumption in this intermediate theorem. The
 source-range conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`. -/
+`BNTBlockDiagonalBoundaryClosing`.
+
+These scope restrictions are documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -260,7 +266,10 @@ large-length BNT product-span bound alone: for a crossing interval beginning at
 \(i=N-1\), the required tail length is \(1\). Thus this theorem is only the
 span-dependent intermediate form; the global-cut
 theorem in `BNTBlockDiagonalBoundaryClosing` removes the hypothesis at the source
-range. -/
+range.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -330,7 +339,10 @@ boundary-crossing comparison.
 **Scope restriction (crossing span):** This intermediate theorem retains the
 crossing-tail span hypothesis. The global-cut theorem in
 `BNTBlockDiagonalBoundaryClosing` supplies the source-range periodic-boundary
-upgrade without that hypothesis. -/
+upgrade without that hypothesis.
+
+These scope restrictions are documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -417,7 +429,10 @@ assumes the simultaneous tail-word span at the crossing tails of length
 \(N-i<(L_0+1)+3(r-1)(L_0+1)\). For the interval beginning at \(i=N-1\) the tail
 length is \(1\), so the finite BNT range does not supply this span. The global-cut theorem in
 `BNTBlockDiagonalBoundaryClosing` proves the
-source-range conclusion without `hShortSpan`. -/
+source-range conclusion without `hShortSpan`.
+
+These scope restrictions are documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -503,7 +518,10 @@ shortest crossing tails, where \(N-i\) can be \(1\). This is therefore a
 span-dependent intermediate theorem. The global-cut
 theorem
 in `BNTBlockDiagonalBoundaryClosing` proves the source-range periodic-boundary
-upgrade without this hypothesis. -/
+upgrade without this hypothesis.
+
+These scope restrictions are documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -566,7 +584,10 @@ shortest crossing tails, where \(N-i\) can be \(1\). This is therefore a
 span-dependent intermediate theorem. The global-cut
 theorem
 in `BNTBlockDiagonalBoundaryClosing` proves the source-range periodic-boundary
-upgrade without this hypothesis. -/
+upgrade without this hypothesis.
+
+These scope restrictions are documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -627,7 +648,10 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, retained as an explicit assumption of this intermediate theorem. The
 source-range conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`. -/
+`BNTBlockDiagonalBoundaryClosing`.
+
+These scope restrictions are documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -698,7 +722,10 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, retained as an explicit assumption of this intermediate theorem. The
 source-range conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`. -/
+`BNTBlockDiagonalBoundaryClosing`.
+
+These scope restrictions are documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -761,7 +788,10 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, retained as an explicit assumption of this intermediate theorem. The
 source-range conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`. -/
+`BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -839,7 +869,10 @@ simultaneous tail-word products of length \(N-i\) span the product algebra for
 each boundary-crossing interval. This is an explicit assumption of this intermediate theorem;
 the source-range
 conclusion without it is the global-cut theorem in
-`BNTBlockDiagonalBoundaryClosing`. -/
+`BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -26,15 +26,11 @@ The source proof writes this comparison with boundary-indexed matrices
 \(\beta\) and \(\rho\) below are the word coordinates obtained by opening the
 periodic boundary at the chosen cut, not additional source terminology.
 
-**Proof-state note:** The \(E^j\)-normalization calculation is formalized by
-`pgvwc07_complementary_word_cde_identities_of_block_boundary_trace_decomposition`
-and `pgvwc07_complementary_word_boundary_identities_formula_of_compatibility`.
-The remaining comparison problem is to derive the displayed \(C^j,D^j\)
-compatibility from periodic-boundary membership in the source range
-\(b\ge2\), \(L\ge3(b-1)(L_0+1)+1\), and \(N\ge L+L_0\), where \(b\) is the
-number of blocks in arXiv:quant-ph/0608197, Theorem 12. This derivation should
-not use the short tail-word span hypothesis assumed by the conditional
-statements below.
+**API note:** The span-dependent and explicit-comparison declarations below
+record intermediate forms of the PGVWC07 \(C^j,D^j,E^j\) argument. The source-range
+conclusion without short crossing-tail span or external comparison hypotheses is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
+in `BNTBlockDiagonalBoundaryClosing`.
 -/
 
 open scoped Matrix BigOperators
@@ -73,8 +69,10 @@ lines 2126--2128.
 
 **Scope restriction (crossing span):** The statement assumes the short
 tail-word span at length \(N-i\) for each boundary-crossing interval. This is
-the remaining visible source-range gap recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+an explicit assumption of this intermediate span-dependent form.
+The
+source-range conclusion without it is the global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -174,8 +172,8 @@ window, not terminology of the source statement.
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
-\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
 
 **Scope restriction (periodic-boundary comparison):** The opened-boundary
 \(C^j,D^j\) comparison `hComparison` is the explicit hypothesis here. The
@@ -185,9 +183,10 @@ is the boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/060819
 block components lie in \(G_N(A_j)\)) and does not assume the boundary-crossing
 comparison. The periodic-boundary upgrade encoded by `hComparison` is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
-1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
-from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128,
+retained as an explicit assumption in this intermediate theorem. The
+source-range conclusion without it is the global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -258,9 +257,10 @@ block-diagonal boundary conditions in arXiv:2011.12127, Section IV.C, lines
 simultaneous block-word tuples of length \(N-i\) span the product algebra at
 each boundary-crossing interval \(i\). This is not a consequence of the
 large-length BNT product-span bound alone: for a crossing interval beginning at
-\(i=N-1\), the required tail length is \(1\). Removing that span hypothesis is
-part of the remaining comparison with the cited source recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+\(i=N-1\), the required tail length is \(1\). Thus this theorem is only the
+span-dependent intermediate form; the global-cut
+theorem in `BNTBlockDiagonalBoundaryClosing` removes the hypothesis at the source
+range. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -319,19 +319,18 @@ and \(i_{m+1}\).
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
-\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
 
 The block-diagonal boundary representation used here is the
 boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/0608197,
 Theorem 12 (its block components lie in \(G_N(A_j)\)) and does not assume the
 boundary-crossing comparison.
 
-**Scope restriction (crossing span):** The residual source-scope gap is the
-crossing-tail span hypothesis noted above, which supplies the periodic-boundary
-upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
-arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+**Scope restriction (crossing span):** This intermediate theorem retains the
+crossing-tail span hypothesis. The global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing` supplies the source-range periodic-boundary
+upgrade without that hypothesis. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -410,15 +409,15 @@ block-diagonal boundary conditions of arXiv:2011.12127, Section IV.C, lines
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated
 in the current BNT range derived from length-\(L_0\) block injectivity,
-\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
 
 **Scope restriction (short crossing tails):** The hypothesis `hShortSpan`
 assumes the simultaneous tail-word span at the crossing tails of length
 \(N-i<(L_0+1)+3(r-1)(L_0+1)\). For the interval beginning at \(i=N-1\) the tail
-length is \(1\), so the finite BNT range does not supply this span. Replacing
-it by the source \(C^j,D^j\) comparison in the source range is the residual
-recorded in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+length is \(1\), so the finite BNT range does not supply this span. The global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing` proves the
+source-range conclusion without `hShortSpan`. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_short_crossing_span_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -488,8 +487,8 @@ arXiv:2011.12127, Section IV.C, lines 2126--2128.
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated
 in the current BNT range derived from length-\(L_0\) block injectivity,
-\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
 
 The block-diagonal boundary representation used here is the
 boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/0608197,
@@ -500,11 +499,11 @@ boundary-crossing comparison.
 block-word tuples of length \(N-i\) span the product algebra for each
 boundary-crossing interval beginning at \(i\). The finite BNT range gives
 large-length simultaneous product spans; it does not by itself supply the
-shortest crossing tails, where \(N-i\) can be \(1\). This visible hypothesis is
-the residual source-scope gap in the periodic-boundary upgrade
-(arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
-arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+shortest crossing tails, where \(N-i\) can be \(1\). This is therefore a
+span-dependent intermediate theorem. The global-cut
+theorem
+in `BNTBlockDiagonalBoundaryClosing` proves the source-range periodic-boundary
+upgrade without this hypothesis. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -551,8 +550,8 @@ which is the ground-space assertion in the source theorem.
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated
 in the current BNT range derived from length-\(L_0\) block injectivity,
-\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
 
 The block-diagonal boundary representation used here is the
 boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/0608197,
@@ -563,11 +562,11 @@ boundary-crossing comparison.
 block-word tuples of length \(N-i\) span the product algebra for each
 boundary-crossing interval beginning at \(i\). The finite BNT range gives
 large-length simultaneous product spans; it does not by itself supply the
-shortest crossing tails, where \(N-i\) can be \(1\). This visible hypothesis is
-the residual source-scope gap in the periodic-boundary upgrade
-(arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
-arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+shortest crossing tails, where \(N-i\) can be \(1\). This is therefore a
+span-dependent intermediate theorem. The global-cut
+theorem
+in `BNTBlockDiagonalBoundaryClosing` proves the source-range periodic-boundary
+upgrade without this hypothesis. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -616,8 +615,8 @@ periodic-boundary equality.
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
-\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
 
 **Scope restriction (periodic-boundary comparison):** The opened-boundary
 \(C^j,D^j\) comparison `hComparison` is the explicit hypothesis here. The
@@ -626,8 +625,9 @@ inclusion of arXiv:quant-ph/0608197, Theorem 12, independent of the
 boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
-2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+2126--2128, retained as an explicit assumption of this intermediate theorem. The
+source-range conclusion without it is the global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -686,8 +686,8 @@ under the assumed opened-boundary \(C^j,D^j\) comparison.
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
-\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
 
 **Scope restriction (periodic-boundary comparison):** The opened-boundary
 \(C^j,D^j\) comparison `hComparison` is the explicit hypothesis here. The
@@ -696,8 +696,9 @@ inclusion of arXiv:quant-ph/0608197, Theorem 12, independent of the
 boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
-2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+2126--2128, retained as an explicit assumption of this intermediate theorem. The
+source-range conclusion without it is the global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -758,8 +759,9 @@ inclusion of arXiv:quant-ph/0608197, Theorem 12, independent of the
 boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
-2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+2126--2128, retained as an explicit assumption of this intermediate theorem. The
+source-range conclusion without it is the global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -834,9 +836,10 @@ lines 2126--2128.
 
 **Scope restriction (crossing span):** The statement assumes that the
 simultaneous tail-word products of length \(N-i\) span the product algebra for
-each boundary-crossing interval. This is the remaining visible gap relative to
-the source comparison; it is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+each boundary-crossing interval. This is an explicit assumption of this intermediate theorem;
+the source-range
+conclusion without it is the global-cut theorem in
+`BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -26,7 +26,7 @@ The source proof writes this comparison with boundary-indexed matrices
 \(\beta\) and \(\rho\) below are the word coordinates obtained by opening the
 periodic boundary at the chosen cut, not additional source terminology.
 
-**API note:** The span-dependent and explicit-comparison declarations below
+**Scope note:** The span-dependent and explicit-comparison declarations below
 record intermediate forms of the PGVWC07 \(C^j,D^j,E^j\) argument. The source-range
 conclusion without short crossing-tail span or external comparison hypotheses is
 `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -503,7 +503,7 @@ arXiv:2011.12127, Section IV.C, lines 2126--2128.
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated
 in the current BNT range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
-`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 
 The block-diagonal boundary representation used here is the
 boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/0608197,
@@ -516,8 +516,7 @@ boundary-crossing interval beginning at \(i\). The finite BNT range gives
 large-length simultaneous product spans; it does not by itself supply the
 shortest crossing tails, where \(N-i\) can be \(1\). This is therefore a
 span-dependent intermediate theorem. The global-cut
-theorem
-in `BNTBlockDiagonalBoundaryClosing` proves the source-range periodic-boundary
+theorem proves the source-range periodic-boundary
 upgrade without this hypothesis.
 
 These scope restrictions are documented in
@@ -569,7 +568,7 @@ which is the ground-space assertion in the source theorem.
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated
 in the current BNT range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
-`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07`.
 
 The block-diagonal boundary representation used here is the
 boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/0608197,
@@ -582,8 +581,7 @@ boundary-crossing interval beginning at \(i\). The finite BNT range gives
 large-length simultaneous product spans; it does not by itself supply the
 shortest crossing tails, where \(N-i\) can be \(1\). This is therefore a
 span-dependent intermediate theorem. The global-cut
-theorem
-in `BNTBlockDiagonalBoundaryClosing` proves the source-range periodic-boundary
+theorem proves the source-range periodic-boundary
 upgrade without this hypothesis.
 
 These scope restrictions are documented in
@@ -637,7 +635,7 @@ periodic-boundary equality.
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
-`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 
 **Scope restriction (periodic-boundary comparison):** The opened-boundary
 \(C^j,D^j\) comparison `hComparison` is the explicit hypothesis here. The
@@ -711,7 +709,7 @@ under the assumed opened-boundary \(C^j,D^j\) comparison.
 arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range conclusion is
-`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`.
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_of_global_cut_bnt_c1_pgvwc07`.
 
 **Scope restriction (periodic-boundary comparison):** The opened-boundary
 \(C^j,D^j\) comparison `hComparison` is the explicit hypothesis here. The

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -545,7 +545,7 @@ comparison. The periodic-boundary upgrade encoded by `hTrace` — the boundary t
 comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-condition
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
-explicit assumption in this intermediate trace-decomposition API. The
+explicit assumption in this intermediate trace-decomposition theorem. The
 source-range conclusion without it is
 `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
 in `BNTBlockDiagonalBoundaryClosing`.
@@ -626,7 +626,7 @@ theorem. The periodic-boundary upgrade encoded by `hTrace` — the boundary trac
 comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-condition
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
-explicit assumption in this intermediate trace-decomposition API. The
+explicit assumption in this intermediate trace-decomposition theorem. The
 source-range conclusion without it is
 `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
 in `BNTBlockDiagonalBoundaryClosing`.
@@ -698,7 +698,7 @@ trace-decomposition form of the boundary-condition comparison in
 arXiv:quant-ph/0608197, Theorem 12. It assumes a finite simultaneous word-spanning
 length \(m\) and the trace equality at that length, for every
 boundary-crossing interval and every block-diagonal boundary representation.
-The trace equality remains the explicit input of this intermediate API. The
+The trace equality remains the explicit input of this intermediate theorem. The
 source-range global-cut theorem proves the periodic-boundary conclusion without
 requiring this trace-decomposition hypothesis.
 
@@ -710,7 +710,7 @@ comparison. The periodic-boundary upgrade encoded by `hTrace` — the boundary t
 comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-condition
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
-explicit assumption in this intermediate trace-decomposition API. The
+explicit assumption in this intermediate trace-decomposition theorem. The
 source-range conclusion without it is
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 
@@ -785,7 +785,7 @@ theorem. The periodic-boundary upgrade encoded by `hTrace` — the boundary trac
 comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-condition
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
-explicit assumption in this intermediate trace-decomposition API. The
+explicit assumption in this intermediate trace-decomposition theorem. The
 source-range conclusion without it is
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -712,8 +712,7 @@ comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
 explicit assumption in this intermediate trace-decomposition API. The
 source-range conclusion without it is
-`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
-in `BNTBlockDiagonalBoundaryClosing`.
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 
 This scope restriction is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
@@ -788,8 +787,7 @@ comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
 explicit assumption in this intermediate trace-decomposition API. The
 source-range conclusion without it is
-`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
-in `BNTBlockDiagonalBoundaryClosing`.
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_global_cut_bnt_c1_pgvwc07`.
 
 This scope restriction is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -544,9 +544,11 @@ block components lie in \(G_N(A_j)\)) and does not assume the boundary-crossing
 comparison. The periodic-boundary upgrade encoded by `hTrace` — the boundary trace
 comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-condition
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
-arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
-ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
+explicit assumption in this intermediate trace-decomposition API. The
+source-range conclusion without it is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
+in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -620,9 +622,11 @@ comparison; the common middle-word span is supplied by the BNT block-separation
 theorem. The periodic-boundary upgrade encoded by `hTrace` — the boundary trace
 comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-condition
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
-arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
-ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
+explicit assumption in this intermediate trace-decomposition API. The
+source-range conclusion without it is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
+in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -688,9 +692,9 @@ trace-decomposition form of the boundary-condition comparison in
 arXiv:quant-ph/0608197, Theorem 12. It assumes a finite simultaneous word-spanning
 length \(m\) and the trace equality at that length, for every
 boundary-crossing interval and every block-diagonal boundary representation.
-Deriving that equality from the source \(C^j,D^j\) comparison, with
-\(D^j_\beta=(\mu_j^N X_j)A^j_\beta\), is the remaining step recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+The trace equality remains the explicit input of this intermediate API. The
+source-range global-cut theorem proves the periodic-boundary conclusion without
+requiring this trace-decomposition hypothesis.
 
 **Scope restriction (periodic-boundary comparison):** The boundary trace
 decomposition `hTrace` is the explicit hypothesis here. The underlying
@@ -699,9 +703,11 @@ arXiv:quant-ph/0608197, Theorem 12, independent of the boundary-crossing
 comparison. The periodic-boundary upgrade encoded by `hTrace` — the boundary trace
 comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-condition
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
-arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
-ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
+explicit assumption in this intermediate trace-decomposition API. The
+source-range conclusion without it is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
+in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -770,9 +776,11 @@ comparison; the common middle-word span is supplied by the BNT block-separation
 theorem. The periodic-boundary upgrade encoded by `hTrace` — the boundary trace
 comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-condition
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
-arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
-ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
+explicit assumption in this intermediate trace-decomposition API. The
+source-range conclusion without it is
+`exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
+in `BNTBlockDiagonalBoundaryClosing`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -548,7 +548,10 @@ arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
 explicit assumption in this intermediate trace-decomposition API. The
 source-range conclusion without it is
 `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
-in `BNTBlockDiagonalBoundaryClosing`. -/
+in `BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -626,7 +629,10 @@ arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
 explicit assumption in this intermediate trace-decomposition API. The
 source-range conclusion without it is
 `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
-in `BNTBlockDiagonalBoundaryClosing`. -/
+in `BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -707,7 +713,10 @@ arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
 explicit assumption in this intermediate trace-decomposition API. The
 source-range conclusion without it is
 `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
-in `BNTBlockDiagonalBoundaryClosing`. -/
+in `BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -780,7 +789,10 @@ arXiv:2011.12127, Section IV.C, lines 2126--2128, retained as an
 explicit assumption in this intermediate trace-decomposition API. The
 source-range conclusion without it is
 `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07`
-in `BNTBlockDiagonalBoundaryClosing`. -/
+in `BNTBlockDiagonalBoundaryClosing`.
+
+This scope restriction is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -22,11 +22,12 @@ estimate for overlapping length-\(L\) windows has the form
 given window. Together with \(h_i^2=h_i\) this gives the quadratic-form
 inequality \(H^2\ge \gamma H\), and the spectral theorem turns that into the
 norm bound \(\gamma\|v\|\le \|Hv\|\) on \((\ker H)^\perp\). The
-MPS-specific anticommutator estimate remains a separate hypothesis. A
-norm-compression estimate from principal angles is also recorded as a sufficient
-stronger route.
+MPS-specific anticommutator estimate remains a separate hypothesis. Stronger
+all-vector norm-compression estimates for the excitation projections are also
+recorded as conditional sufficient hypotheses; they are not the source
+principal-angle estimate for the local ground spaces.
 
-The four components are:
+The five components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale` (quadratic form implies norm bound);
@@ -53,8 +54,10 @@ The four components are:
         \(h_i h_j+h_j h_i\ge -c_{ij}(1-\gamma)(h_i+h_j)\)
 
    with coefficients whose rows are summable uniformly in the chain length.
-   Principal-angle estimates may supply this bound through a norm-compression
-   inequality for the corresponding excitation projections.
+   The cited principal-angle estimates concern the reduced local ground
+   spaces. Converting them to this anticommutator bound remains the source-facing
+   quantitative input; the all-vector excitation-projection norm bounds recorded
+   in this development are only stronger conditional sufficient hypotheses.
 5. **Row-sum bound** \(\sum_{j\ne i} c_{ij}\le 1\): at most \(2(L-1)\) local terms
    overlap a given length-\(L\) cyclic window under the convention used here.
 6. **Quadratic form to norm bound**: combining these estimates with \(h_i^2=h_i\)

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -27,12 +27,14 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The five components are:
+The six components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale` (quadratic form implies norm bound);
 * `Martingale.Transport` — Euclidean local projectors, ground-space and
   Hamiltonian transport, positivity, commutation, and kernel identification;
+* `Martingale.OpenChain` — open-chain ground-space projectors, their intersection,
+  and the projector-defect reduction to an anticommutator estimate;
 * `Martingale.OverlapReduction` — reduction from overlapping-window commutation
   to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -33,6 +33,8 @@ The five components are:
   `FrustrationFree.spectralGap_of_martingale` (quadratic form implies norm bound);
 * `Martingale.Transport` — Euclidean local projectors, ground-space and
   Hamiltonian transport, positivity, commutation, and kernel identification;
+* `Martingale.OverlapReduction` — reduction from overlapping-window commutation
+  to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered
   cross-term and anticommutator bounds to concrete cyclic-window estimates;
 * `Martingale.Gap` — conditional gap theorems from the overlapping cyclic-window

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -209,7 +209,7 @@ principal-angle estimate. Once assumed, it gives the anticommutator inequality
 with uniformly summable rows. Since at most \(2(L-1)\) local terms overlap a
 length-\(L\) cyclic window, combining this estimate with \(h_i^2=h_i\) yields
 \(H^2\geq\gamma H\). The spectral theorem then gives
-\(\gamma\lVert vVert\leq\lVert HvVert\) on \((\ker H)^\perp\).
+\(\gamma\lVert v\rVert\leq\lVert Hv\rVert\) on \((\ker H)^\perp\).
 
 Despite its historical short name, this declaration is conditional. The
 source-matching conditional theorem is

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -8,11 +8,12 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 /-!
 # Uniform spectral gap for the MPS parent Hamiltonian
 
-**Root-only.** This file contains the final conditional spectral-gap theorems
-for the MPS parent Hamiltonian. The source anticommutator estimate remains an
-explicit hypothesis. A cyclic-window norm-compression estimate, obtainable from
-principal-angle bounds when available, is recorded as a sufficient stronger
-hypothesis.
+**Root-only.** This file contains conditional spectral-gap theorems for the
+MPS parent Hamiltonian. The source anticommutator estimate remains an explicit
+hypothesis. All-vector cyclic-window norm and operator-product estimates for the
+excitation projections are recorded only as stronger conditional sufficient
+hypotheses; they are not the source principal-angle estimate for the local
+ground spaces.
 
 ## Main results
 
@@ -197,32 +198,19 @@ orthogonal complement of the ground space satisfies
 The orthogonal complement is computed in the `EuclideanSpace` structure
 on `NSiteSpace d N ≃ Cfg d N → ℂ`.
 
-**Proof strategy (Kastoryano–Lucia 2018 / Nachtergaele 1996).** The parent
-Hamiltonian \(H_N = ∑ᵢ hᵢ\) is a frustration-free sum of local orthogonal
-projectors (`parentHamiltonian_frustrationFree`). The intersection property
-`groundSpace_intersection` gives the local relation
+**Conditional proof boundary.** This theorem assumes the all-vector
+excitation-projection estimate displayed in its statement. That estimate is
+strictly stronger than the source anticommutator condition and is not supplied
+merely by the intersection property or by the cited reduced ground-space
+principal-angle estimate. Once assumed, `Martingale.Reduction` converts it to
+the ordered cross-term estimate, performs the finite cyclic row count, and
+applies the spectral theorem.
 
-    \(\ker h_{\mathrm{left}} \cap \ker h_{\mathrm{right}} \subseteq \ker h\)
+Despite its historical short name, this declaration is conditional. The
+source-matching conditional theorem is
+`parentHamiltonian_gapped_of_anticommutator`.
 
-where \(h_{\mathrm{left}}\) and \(h_{\mathrm{right}}\) are the two overlapping
-length-\(L\) projectors and \(h\) is the length-\(L+1\) projector. The remaining
-principal-angle estimate
-supplies the martingale operator inequality
-
-    \(h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)\)
-
-with row-summable coefficients. At most \(2(L-1)\) local terms overlap a given
-length-\(L\) cyclic window, so the chosen coefficients have row sum at most one.
-Combined with \(h_i^2 = h_i\), this yields the quadratic-form inequality
-\(H² ≥ γ H\), which feeds into the abstract lemma
-`FrustrationFree.spectralGap_of_martingale` to produce the norm bound
-\(γ ‖v‖ ≤ ‖H v‖\) on \((\ker H)^\perp\). The `LinearMap.IsPositive` hypothesis required
-by `FrustrationFree.spectralGap_of_martingale` is automatic here because
-\(H_N = ∑ᵢ hᵢ\) is a sum of orthogonal projectors.
-
-This theorem records the stronger norm-compression route. The source-matching
-conditional theorem is `parentHamiltonian_gapped_of_anticommutator`. The proof
-below invokes
+This theorem records the stronger norm-compression route. Its proof invokes
 `parentHamiltonianES_gap_bound_of_overlap_norm_bound`, which combines the already
 formalized martingale reductions after the overlapping-window estimate is given. -/
 theorem parentHamiltonian_gapped
@@ -285,10 +273,10 @@ overlapping cyclic-window estimate
 positive lower bound on the parent Hamiltonian, independent of the chain length.
 
 This is the version of `parentHamiltonian_gapped` with an arbitrary compression
-constant.  It is the appropriate target if the principal-angle estimates cited
-in arXiv:2011.12127, Section IV.C, first produce an unspecified positive
-compression constant rather than the explicit coefficient
-\((1 - 1/(4L)) / (2(L-1))\). -/
+constant. It is a stronger conditional interface, not the source
+principal-angle target: the cited estimates concern the reduced local
+ground-space projections, whereas this theorem assumes an all-vector estimate
+for the excitation projections. -/
 theorem parentHamiltonian_gapped_of_overlap_norm_constant
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)
@@ -326,8 +314,9 @@ anticommutator reduction `re_inner_anticommutator_ge_neg_of_norm_apply_le`, any
 such bound with \(\eta\,2(L-1) < 1\) yields the positive gap constant
 \(1 - \eta\,2(L-1)\).
 
-Like `parentHamiltonianES_gap_bound_of_principal_angle_compression`, this is a
-conditional reduction, not an achievable MPS estimate in the generic overlapping
+Like
+`parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt`, this
+is a conditional reduction, not an achievable MPS estimate in the generic overlapping
 case: \(p_i, p_j\) are the excitation projections, and when their ranges share a
 nonzero vector one has \(\|p_i p_j\| = 1\), making the hypothesis unsatisfiable
 for \(\eta < 1\).  In degenerate cases, for instance when an excitation

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -278,8 +278,8 @@ overlapping cyclic-window estimate
 positive lower bound on the parent Hamiltonian, independent of the chain length.
 
 This is the version of `parentHamiltonian_gapped` with an arbitrary compression
-constant. It is a stronger conditional interface, not the source
-principal-angle target: the cited estimates concern the reduced local
+constant. It assumes a stronger sufficient estimate, not the source
+principal-angle estimate: the cited estimates concern the reduced local
 ground-space projections, whereas this theorem assumes an all-vector estimate
 for the excitation projections. -/
 theorem parentHamiltonian_gapped_of_overlap_norm_constant

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -202,9 +202,14 @@ on `NSiteSpace d N ≃ Cfg d N → ℂ`.
 excitation-projection estimate displayed in its statement. That estimate is
 strictly stronger than the source anticommutator condition and is not supplied
 merely by the intersection property or by the cited reduced ground-space
-principal-angle estimate. Once assumed, `Martingale.Reduction` converts it to
-the ordered cross-term estimate, performs the finite cyclic row count, and
-applies the spectral theorem.
+principal-angle estimate. Once assumed, it gives the anticommutator inequality
+\[
+  h_i h_j + h_j h_i \geq -c_{ij}(1-\gamma)(h_i+h_j)
+\]
+with uniformly summable rows. Since at most \(2(L-1)\) local terms overlap a
+length-\(L\) cyclic window, combining this estimate with \(h_i^2=h_i\) yields
+\(H^2\geq\gamma H\). The spectral theorem then gives
+\(\gamma\lVert vVert\leq\lVert HvVert\) on \((\ker H)^\perp\).
 
 Despite its historical short name, this declaration is conditional. The
 source-matching conditional theorem is

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -722,11 +722,6 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
   exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
     A L hL hγpos hγle hηle hOverlapNorm
 
-@[deprecated parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
-  (since := "2026-08-09")]
-alias parentHamiltonianES_gap_bound_of_principal_angle_compression :=
-  parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
-
 /-- Uniform gap-bound reduction from an overlap operator-product norm estimate
 with a separate coefficient.
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -722,39 +722,10 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
   exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
     A L hL hγpos hγle hηle hOverlapNorm
 
-/-- Finite-row norm-compression sufficient condition for the martingale argument.
-
-Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.C, lines 2168--2182,
-relates the parent-Hamiltonian gap to the principal angles between overlapping
-local ground spaces. This theorem does not formalize that principal-angle
-estimate itself; it assumes directly a norm-compression bound for the excitation
-projections. In the cyclic-window specialization, if every overlapping pair
-satisfies
-\[
-  \|p_i p_j v\| \le \eta \|p_i v\|,
-  \qquad \eta\,2(L-1)<1,
-\]
-then the Euclidean-space parent Hamiltonians have the displayed uniform lower
-bound. The MPS-specific passage from the source principal-angle estimate to such
-an excitation-projection bound remains separate; it is recorded in
-`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
-theorem parentHamiltonianES_gap_bound_of_principal_angle_compression
-    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
-    (hηnonneg : 0 ≤ η)
-    (hηlt : η * (((2 * (L - 1) : ℕ) : ℝ)) < 1)
-    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
-      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
-        ∀ v : EuclideanSpace ℂ (Cfg d N),
-          ‖localTermES A L i (localTermES A L j v)‖ ≤
-            η * ‖localTermES A L i v‖) :
-    0 < 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) ∧
-    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
-      (v : EuclideanSpace ℂ (Cfg d N)),
-      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
-        (1 - η * (((2 * (L - 1) : ℕ) : ℝ))) * ‖v‖ ≤
-          ‖parentHamiltonianES A L N v‖ :=
+@[deprecated parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
+  (since := "2026-08-09")]
+alias parentHamiltonianES_gap_bound_of_principal_angle_compression :=
   parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
-    A L hL hηnonneg hηlt hOverlapNorm
 
 /-- Uniform gap-bound reduction from an overlap operator-product norm estimate
 with a separate coefficient.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -424,9 +424,11 @@ Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc}.
     tail-word span hypothesis and in the longer stated range. The independence
     of the $N$-site spaces is a separate conclusion of
     Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
-    Thus the statement remains conditional on the short tail-word spans; it is
-    not the unconditional boundary-condition comparison in the source theorem.
-    % Source-faithful replacement of the tail-word span hypothesis is tracked in issue~\#3597.
+    This intermediate statement remains conditional on the short tail-word
+    spans. The source-range conclusion without them is supplied by the global
+    change-of-cut theorem
+    \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07},
+    which completes the boundary-condition comparison in the source theorem.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -427,7 +427,7 @@ Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc}.
     This intermediate statement remains conditional on the short tail-word
     spans. The source-range conclusion without them is supplied by the global
     change-of-cut theorem
-    \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07},
+    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut},
     which completes the boundary-condition comparison in the source theorem.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -427,8 +427,16 @@ Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc}.
     This intermediate statement remains conditional on the short tail-word
     spans. The source-range conclusion without them is supplied by the global
     change-of-cut theorem
-    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut},
-    which completes the boundary-condition comparison in the source theorem.
+    Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut}
+    only in the currently formalized doubly normalized specialization
+    $\Lambda_j=\Id$. For the unrestricted source normalization, with positive
+    definite dual fixed points satisfying
+    \begin{align}
+        \sum_a A_j^{a\,\dagger}\Lambda_j A_j^a&=\Lambda_j, \notag
+    \end{align}
+    the corresponding source-range theorem remains unformalized.
+    % General normalization is tracked in issues #5751 and #5770. Neither issue
+    % is cited here as a completed theorem.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -159,7 +159,8 @@
 
 \begin{lemma}[MPS anticommutator input for the martingale condition]\label{lem:martingale_mps}
     \notready
-    \uses{def:parent_interaction, def:local_term_parent, def:injective}
+    \uses{thm:martingale_criterion,
+        def:parent_interaction, def:local_term_parent, def:injective}
     Let $A$ be injective and fix an interaction range $L \ge 2$ as in
     Definition~\ref{def:parent_interaction}. Let
     $h_L(A):=\Pi_{G_L(A)^\perp}$ be the $L$-site parent interaction, and for
@@ -222,12 +223,13 @@
     Theorem~\ref{thm:friedrichs_ground_space_excitation_anticommutator} supplies
     the generic passage from such a reduced ground-space overlap bound to the
     anticommutator estimate for the complementary excitation projections.
-    What remains is to obtain the required uniform Friedrichs bound, with the
-    source blocking convention and constants, for the cyclic-window local
-    ground spaces. The intersection property identifies
+    What remains is the blocked MPS reduced ground-space Friedrichs estimate,
+    with the source blocking convention and uniform constants. The intersection
+    property identifies
     $\ker h_i\cap\ker h_j$ with the parent ground space on the union of the two
-    windows, but it does not by itself supply this numerical bound. The directed
-    excitation-projection estimate
+    windows, but it does not by itself supply this numerical bound.
+    % Live blocked MPS estimate: https://github.com/LionSR/TNLean/issues/5455.
+    The directed excitation-projection estimate
     \begin{align}
         \|h_i h_j v\|
         &\le \eta\|h_i v\|,
@@ -236,7 +238,8 @@
         &<1,
         \notag
     \end{align}
-    remains useful as a sufficient strengthening of the source condition.
+    remains a valid stronger conditional implication, but it is not the source
+    principal-angle target.
 
     \emph{Row-sum bound.}
     Since $L\ge2$, each site $i$ overlaps with at most $2(L-1)$
@@ -261,7 +264,8 @@
     $h_i h_j+h_jh_i \ge -c_{\{i,j\}}(1-\gamma)(h_i+h_j)$.
     If this estimate is obtained with the displayed row-summable coefficients,
     Lemma~\ref{lem:parent_hamiltonian_anticommutator_rowsum_gap} gives the gap.
-    A sufficient stronger route is the norm-compression statement
+    A stronger conditional implication is the all-vector norm-compression
+    statement
     \begin{align}
         \|h_i h_j v\|
         &\le \eta\|h_i v\|,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
@@ -445,7 +445,6 @@
     \label{lem:parent_hamiltonian_cyclic_overlap_norm_constant_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt}
-    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_principal_angle_compression}
     \leanok
     \uses{lem:parent_hamiltonian_finite_overlap_norm_quadratic,
         lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive,
@@ -465,8 +464,9 @@
     every admissible $N$ and every
     $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
     $(1-\eta m)\|v\| \le \|H_{N,L}^{\mathrm{ES}}(A)v\|$.
-    This strict compression form is a norm-compression sufficient condition, not
-    the principal-angle estimate itself. It is a sufficient strengthening of the
+    This strict all-vector compression form is a stronger conditional
+    sufficient condition, not the source principal-angle estimate itself. It is
+    a sufficient strengthening of the
     anticommutator martingale estimate in
     Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}.
     It does not prove the remaining MPS-specific estimate; it isolates the

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -614,9 +614,10 @@ and then into
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary}.
 The current BNT specialization then obtains that boundary representation through
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1}.
-Thus the crossing comparison is not an independent trace-comparison assumption:
-the present proof boundary is the crossing-tail word-span hypothesis and the
-choice of block-diagonal boundary representation for a vector
+Thus the crossing comparison is not an independent trace-comparison assumption.
+For the earlier crossing-span route, the proof boundary was the crossing-tail
+word-span hypothesis and the choice of block-diagonal boundary representation
+for a vector
 \(\psi\in\mathcal K_{N,L}(\widehat A)\).  In the normalized BNT specialization,
 that representation is supplied by the block-diagonal boundary theorem displayed
 below.

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -21,8 +21,8 @@ can be compared with the quantitative estimate isolated in the formal
 parent-Hamiltonian proof.\footnote{For
     traceability, the finite-row reduction is recorded in
     \href{https://github.com/LionSR/TNLean/issues/1044}{issue \#1044}. The remaining
-    quantitative estimate is recorded in
-    \href{https://github.com/LionSR/TNLean/issues/952}{issue \#952}, and the broader
+    blocked MPS ground-space estimate is recorded in
+    \href{https://github.com/LionSR/TNLean/issues/5455}{issue \#5455}, and the broader
     parent-Hamiltonian theorem in
     \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}
 The relevant source passage is the discussion of gaps for MPS parent Hamiltonians
@@ -312,9 +312,10 @@ The qualitative fact that two finite-dimensional subspaces have a well-defined
 principal-angle decomposition is not enough: the martingale reduction needs a
 uniform numerical bound after the same blocking convention has been fixed.
 
-The norm-compression route remains available as a stronger sufficient target:
-any estimate (N$_\eta$) with $\eta\,2(L-1)<1$ gives a positive gap through the
-already formalized reduction. There is, however, a directional point. If
+The all-vector norm-compression theorem remains available as a stronger
+conditional implication: any estimate (N$_\eta$) with
+$\eta\,2(L-1)<1$ gives a positive gap through the already formalized reduction.
+It is not the source principal-angle target. There is, however, a directional point. If
 (N$_\eta$) is imposed for all vectors
 $v$, then $p_i v=0$ implies $p_i p_j v=0$. Thus $p_j$ maps $\ker p_i$ into
 $\ker p_i$. This is stronger than merely knowing that the
@@ -370,11 +371,12 @@ and
 \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt},
 with public reformulations
 \leanid{parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant} and
-\leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. The remaining
-MPS-specific task is to produce a uniform ground-space principal-angle estimate
-for overlapping cyclic windows; the generic theorem above then supplies the
-anticommutator estimate. This uses the intersection identity
-$\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
+\leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. The correct
+remaining route is to prove the blocked MPS reduced ground-space Friedrichs
+estimate tracked in issue~\#5455. The generic theorem
+\leanid{re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
+then supplies the excitation-projection anticommutator estimate. This route uses
+the intersection identity $\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
 \leanid{adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}; a uniform
 small bound on $\|p_ip_j\|$ itself is not available in the generic overlapping
 case, since that norm is $1$ whenever the two excitation ranges have a common
@@ -420,10 +422,11 @@ or matched precisely to the cited martingale estimates.
 
 Once the quantitative comparison with the cited martingale estimates is settled,
 the blueprint should say that the cyclic-window anticommutator estimate follows
-from those estimates under the convention used here. If the proof instead goes
-through norm compression, the blueprint should say explicitly that the
-compression bound (N$_\eta$) with $\eta\,2(L-1)<1$ is a stronger sufficient
-estimate implying the anticommutator route.
+from those estimates under the convention used here. The blueprint should
+identify the reduced ground-space
+Friedrichs-to-anticommutator reduction as the source-facing route. The all-vector
+compression bound (N$_\eta$), if separately assumed, is only a stronger
+conditional estimate implying a gap.
 
 \section{Conclusion}
 


### PR DESCRIPTION
## Summary

- fixes forward the two late review threads from #5746 by replacing noun uses of the banned prose term “bridge” with precise reduction terminology
- restores `thm:martingale_criterion` to the statement dependencies of `lem:martingale_mps`, while keeping the Friedrichs anticommutator theorem and ground-space intersection in the disjoint proof dependencies
- deprecates the misleading principal-angle compression alias in favor of the correctly named all-vector norm-bound theorem and clarifies that those norm/operator-product routes are only stronger conditional implications
- updates Chapter 13 and the parent-Hamiltonian paper-gap notes to use the reduced ground-space Friedrichs-to-anticommutator reduction as the source-facing route and #5455 as the live blocked MPS input
- points legacy conditional PGVWC wrappers to the completed global-cut theorem rather than presenting #3597 as an open boundary

This PR explicitly resolves late review threads:

- `PRRT_kwDORK8b986XiHA4`
- `PRRT_kwDORK8b986XiHCP`

and includes the broader parent-Hamiltonian documentation/API-hygiene cleanup reviewed after #5746.

## Validation

- `lake env lean` on `TNLean/Analysis/TwoProjectionCompression.lean` and all seven touched parent-Hamiltonian Lean files
- diff-aware reader-facing prose check
- `leanblueprint web` dependency/web build
- refreshed declaration list plus diff-aware blueprint/Lean synchronization: 6674/6674 entries
- `git diff --check origin/main..HEAD`

No theorem statement or proof was changed; the only API change is a deprecated compatibility alias to the existing correctly named theorem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment, blueprint, and paper-gap documentation only; no formal proof or theorem-statement edits. Risk is limited to possible doc/Lean name cross-reference drift.
> 
> **Overview**
> Documentation and comment hygiene for the parent-Hamiltonian spectral-gap and block-diagonal ground-space tracks. **No theorem statements or proofs change**; the only API touch is dropping the misleading `parentHamiltonianES_gap_bound_of_principal_angle_compression` alias.
> 
> **Spectral gap / martingale:** Docstrings and Chapter 13 now treat the **reduced ground-space Friedrichs → anticommutator** path as the source-facing input (live work **#5455**), while **all-vector** excitation norm/operator-product bounds are labeled **stronger conditional** sufficient routes—not the cited principal-angle estimate. `lem:martingale_mps` again **uses** `thm:martingale_criterion` in its dependency list. `Martingale.lean` module text is expanded (e.g. OpenChain, OverlapReduction) and “bridge” prose becomes **reduction**.
> 
> **Block-diagonal PGVWC:** Intermediate theorems’ scope notes no longer read as open gaps; they say periodic-boundary / crossing-span / trace inputs are **explicit hypotheses** of intermediate forms and point to **`BNTBlockDiagonalBoundaryClosing`** global-cut conclusions (`*_global_cut_bnt_c1_pgvwc07`). Blueprint crossing-span lemma notes the unconditional source-range upgrade is the global-cut theorem (currently **Λ_j = Id**).
> 
> **Paper gaps:** `cpgsv21_martingale_overlap.tex` and `cpgsv21_block_diagonal_parent_ground_space.tex` match this framing; issue pointers shift from **#952** to **#5455** for the blocked MPS estimate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fbe6eb3fa7e88c2e0d1b6daa507613de508dd2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->