### PR TITLE
feat(ParentHamiltonian): package open-chain projector geometry

### DIFF
--- a/TNLean/Analysis/TwoProjectionCompression.lean
+++ b/TNLean/Analysis/TwoProjectionCompression.lean
@@ -37,10 +37,10 @@ def IsFriedrichsBound (U V : Submodule ℂ E) (η : ℝ) : Prop :=
 /-- An operator-norm bound for the defect of two orthogonal ground-space
 projections bounds their Friedrichs overlap.
 
-This is the abstract projector interface for Nachtergaele's martingale
-condition C3 in arXiv:cond-mat/9410110, eq. (2.4): after the common ground
-space is removed, the defect operator is the product of the two reduced
-projections. -/
+This lemma connects the operator-norm projector defect to the Friedrichs
+overlap used in Nachtergaele's martingale condition C3,
+arXiv:cond-mat/9410110, eq. (2.4): after the common ground space is removed,
+the defect operator is the product of the two reduced projections. -/
 theorem isFriedrichsBound_of_norm_starProjection_comp_sub_inf_starProjection_le
     (U V : Submodule ℂ E) {η : ℝ}
     (hDefect : ‖U.starProjection ∘L V.starProjection -

--- a/TNLean/Analysis/TwoProjectionCompression.lean
+++ b/TNLean/Analysis/TwoProjectionCompression.lean
@@ -34,6 +34,36 @@ def IsFriedrichsBound (U V : Submodule ℂ E) (η : ℝ) : Prop :=
     ∀ y : E, y ∈ V → y ∈ (U ⊓ V)ᗮ →
       ‖⟪x, y⟫_ℂ‖ ≤ η * ‖x‖ * ‖y‖
 
+/-- An operator-norm bound for the defect of two orthogonal ground-space
+projections bounds their Friedrichs overlap.
+
+This is the abstract projector interface for Nachtergaele's martingale
+condition C3 in arXiv:cond-mat/9410110, eq. (2.4): after the common ground
+space is removed, the defect operator is the product of the two reduced
+projections. -/
+theorem isFriedrichsBound_of_norm_starProjection_comp_sub_inf_starProjection_le
+    (U V : Submodule ℂ E) {η : ℝ}
+    (hDefect : ‖U.starProjection ∘L V.starProjection -
+      (U ⊓ V).starProjection‖ ≤ η) :
+    IsFriedrichsBound U V η := by
+  have hη : 0 ≤ η := (norm_nonneg _).trans hDefect
+  intro x hxU _ y hyV hyInter
+  have hyVproj : V.starProjection y = y := V.starProjection_eq_self_iff.mpr hyV
+  have hyInterProj : (U ⊓ V).starProjection y = 0 :=
+    (U ⊓ V).starProjection_apply_eq_zero_iff.mpr hyInter
+  have hProj : ‖U.starProjection y‖ ≤ η * ‖y‖ := by
+    have hApply := ContinuousLinearMap.le_of_opNorm_le
+      (U.starProjection ∘L V.starProjection - (U ⊓ V).starProjection) hDefect y
+    simpa [hyVproj, hyInterProj] using hApply
+  calc
+    ‖⟪x, y⟫_ℂ‖ = ‖⟪U.starProjection x, y⟫_ℂ‖ := by
+      rw [U.starProjection_eq_self_iff.mpr hxU]
+    _ = ‖⟪x, U.starProjection y⟫_ℂ‖ := by
+      rw [U.inner_starProjection_left_eq_right]
+    _ ≤ ‖x‖ * ‖U.starProjection y‖ := norm_inner_le_norm _ _
+    _ ≤ ‖x‖ * (η * ‖y‖) := mul_le_mul_of_nonneg_left hProj (norm_nonneg x)
+    _ = η * ‖x‖ * ‖y‖ := by ring
+
 private theorem starProjection_mem_orthogonal_of_le
     (U W : Submodule ℂ E) (hWU : W ≤ U) {v : E} (hvW : v ∈ Wᗮ) :
     U.starProjection v ∈ Wᗮ := by

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -48,6 +48,7 @@ import TNLean.MPS.ParentHamiltonian.LocalSupportTransport
 import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -4,10 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
-import TNLean.MPS.ParentHamiltonian.Martingale.Transport
+import TNLean.MPS.ParentHamiltonian.Martingale.Gap
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
-import TNLean.MPS.ParentHamiltonian.Martingale.Gap
+import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 
 /-!
 # Martingale estimate for parent Hamiltonians

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
@@ -10,13 +10,14 @@ import TNLean.MPS.ParentHamiltonian.ExtendRight
 /-!
 # Open-chain ground-projector geometry
 
-This file packages the two open-chain ground spaces in Nachtergaele's
-martingale condition C3 and connects the corresponding projector defect to the
-generic Friedrichs-angle anticommutator estimate.
+This file defines the two open-chain ground spaces in Nachtergaele's
+martingale condition C3 and proves that the corresponding projector defect
+implies the generic Friedrichs-angle anticommutator estimate.
 
 **Scope restriction (Nachtergaele C3):** This file formalizes only the open-chain
-projector geometry and its defect-to-Friedrichs/anticommutator interface. The FNW
-numerical transfer bound controlling the defect remains unformalized; see
+projector geometry and the implication from its defect to the Friedrichs and
+anticommutator bounds. The FNW numerical transfer bound controlling the defect
+remains unformalized; see
 `docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
 
 For the increasing intervals \(\Lambda_n = [1, n]\) in arXiv:cond-mat/9410110,

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
@@ -14,6 +14,11 @@ This file packages the two open-chain ground spaces in Nachtergaele's
 martingale condition C3 and connects the corresponding projector defect to the
 generic Friedrichs-angle anticommutator estimate.
 
+**Scope restriction (Nachtergaele C3):** This file formalizes only the open-chain
+projector geometry and its defect-to-Friedrichs/anticommutator interface. The FNW
+numerical transfer bound controlling the defect remains unformalized; see
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
+
 For the increasing intervals \(\Lambda_n = [1, n]\) in arXiv:cond-mat/9410110,
 eq. (2.4), the two spaces are the ground conditions on \(\Lambda_n\) and on the tail
 \(\Lambda_{n+1} \setminus \Lambda_{n-l}\) inside the common ambient chain

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.TwoProjectionCompression
+import TNLean.MPS.ParentHamiltonian.Defs
+import TNLean.MPS.ParentHamiltonian.ExtendRight
+
+/-!
+# Open-chain ground-projector geometry
+
+This file packages the two open-chain ground spaces in Nachtergaele's
+martingale condition C3 and connects the corresponding projector defect to the
+generic Friedrichs-angle anticommutator estimate.
+
+For the increasing intervals \(\Lambda_n = [1, n]\) in arXiv:cond-mat/9410110,
+eq. (2.4), the two spaces are the ground conditions on \(\Lambda_n\) and on the tail
+\(\Lambda_{n+1} \setminus \Lambda_{n-l}\) inside the common ambient chain
+\(\Lambda_{n+1}\). Their
+intersection is the ground space on \(\Lambda_{n+1}\).
+
+## Main results
+
+* `MPSTensor.openChainLeftGroundSpaceES` — the left-window ground space.
+* `MPSTensor.openChainTailGroundSpaceES` — the tail-window ground space.
+* `MPSTensor.openChainLeft_inf_tailGroundSpaceES` — their intersection is the
+  longer open-chain ground space at the block-injectivity length.
+* `MPSTensor.re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect` —
+  the source-facing anticommutator consequence of the C3 projector defect.
+
+## References
+
+* B. Nachtergaele, arXiv:cond-mat/9410110, eqs. (2.4)--(2.5), Theorem 3,
+  and Section 6.
+-/
+
+open scoped InnerProductSpace
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The open-chain left-window ground subspace on \(L + 1\) sites.
+
+Membership says that every restriction obtained by fixing the final site lies
+in \(G_L(A)\). This is the Hilbert-space range of the projector
+\(G_{\Lambda_n}\) acting in the ambient space for \(\Lambda_{n+1}\) in Nachtergaele,
+arXiv:cond-mat/9410110, eq. (2.4). -/
+noncomputable def openChainLeftGroundSpaceES (A : MPSTensor d D) (L : ℕ) :
+    Submodule ℂ (EuclideanSpace ℂ (Cfg d (L + 1))) :=
+  (⨅ j : Fin d, (groundSpace A L).comap (restrictLastₗ j)).map
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d (L + 1))).symm.toLinearMap
+
+/-- The open-chain tail-window ground subspace on \(K + L\) sites.
+
+Membership says that every restriction obtained by fixing the \(K\)-site prefix
+lies in \(G_L(A)\). For \(L = l + 1\), this is the Hilbert-space range of
+\(G_{\Lambda_{n+1} \setminus \Lambda_{n-l}}\) in Nachtergaele,
+arXiv:cond-mat/9410110, eq. (2.4). -/
+noncomputable def openChainTailGroundSpaceES (A : MPSTensor d D) (K L : ℕ) :
+    Submodule ℂ (EuclideanSpace ℂ (Cfg d (K + L))) :=
+  (⨅ u : Fin K → Fin d, (groundSpace A L).comap (tailRestrictₗ u)).map
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm.toLinearMap
+
+/-- The orthogonal projector onto the open-chain left-window ground subspace. -/
+noncomputable def openChainLeftGroundProjectionES (A : MPSTensor d D) (L : ℕ) :
+    EuclideanSpace ℂ (Cfg d (L + 1)) →L[ℂ] EuclideanSpace ℂ (Cfg d (L + 1)) :=
+  (openChainLeftGroundSpaceES A L).starProjection
+
+/-- The orthogonal projector onto the open-chain tail-window ground subspace. -/
+noncomputable def openChainTailGroundProjectionES (A : MPSTensor d D) (K L : ℕ) :
+    EuclideanSpace ℂ (Cfg d (K + L)) →L[ℂ] EuclideanSpace ℂ (Cfg d (K + L)) :=
+  (openChainTailGroundSpaceES A K L).starProjection
+
+/-- Membership in the left-window Hilbert subspace is exactly
+`InLeftGround` after transport by the canonical `WithLp` equivalence. -/
+@[simp] theorem mem_openChainLeftGroundSpaceES_iff (A : MPSTensor d D) (L : ℕ)
+    (v : EuclideanSpace ℂ (Cfg d (L + 1))) :
+    v ∈ openChainLeftGroundSpaceES A L ↔
+      InLeftGround A L (WithLp.linearEquiv 2 ℂ (NSiteSpace d (L + 1)) v) := by
+  rw [openChainLeftGroundSpaceES, Submodule.mem_map_equiv]
+  simp [InLeftGround, restrictLast]
+
+/-- Membership in the tail-window Hilbert subspace is exactly `InTailGround`
+after transport by the canonical `WithLp` equivalence. -/
+@[simp] theorem mem_openChainTailGroundSpaceES_iff (A : MPSTensor d D) (K L : ℕ)
+    (v : EuclideanSpace ℂ (Cfg d (K + L))) :
+    v ∈ openChainTailGroundSpaceES A K L ↔
+      InTailGround A K L (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L)) v) := by
+  rw [openChainTailGroundSpaceES, Submodule.mem_map_equiv]
+  simp [InTailGround]
+
+/-- The left-window and tail-window ground spaces intersect in the longer
+open-chain ground space.
+
+With \(n = K + L₀\) and \(l = L₀\), this identifies the common range of
+\(G_{\Lambda_n}\) and \(G_{\Lambda_{n+1} \setminus \Lambda_{n-l}}\) with
+\(G_{\Lambda_{n+1}}\), as used in
+Nachtergaele, arXiv:cond-mat/9410110, eq. (2.4). The proof is the existing
+open-chain grow-back theorem at the block-injectivity length. -/
+theorem openChainLeft_inf_tailGroundSpaceES [NeZero D]
+    {A : MPSTensor d D} {K L₀ : ℕ} (hInj : IsNBlkInjective A L₀)
+    (hL₀ : 0 < L₀) :
+    openChainLeftGroundSpaceES A (K + L₀) ⊓
+      openChainTailGroundSpaceES A K (L₀ + 1) =
+        groundSpaceES A (K + L₀ + 1) := by
+  ext v
+  rw [Submodule.mem_inf, mem_openChainLeftGroundSpaceES_iff,
+    mem_openChainTailGroundSpaceES_iff, mem_groundSpaceES_iff]
+  constructor
+  · rintro ⟨hLeft, hTail⟩
+    exact groundSpace_extend_right_of_isNBlkInjective hInj hL₀ hLeft hTail
+  · intro hv
+    exact ⟨groundSpace_inLeftGround A (K + L₀) hv,
+      groundSpace_inTailGround A K (L₀ + 1) hv⟩
+
+set_option maxHeartbeats 800000 in
+-- The expanded finite-dimensional projector statement requires extra elaboration budget.
+set_option synthInstance.maxHeartbeats 100000 in
+-- Finite-dimensional orthogonal-projection instances require additional synthesis budget.
+/-- Nachtergaele's open-chain ground-projector defect implies the
+anticommutator lower bound for the complementary excitation projections.
+
+Here the tail projector is \(G_{\Lambda_{n+1} \setminus \Lambda_{n-l}}\), the left
+projector is \(G_{\Lambda_n}\), and the subtracted projector is
+\(G_{\Lambda_{n+1}}\). Thus the hypothesis is the defect appearing in condition C3,
+arXiv:cond-mat/9410110, eq. (2.4),
+after identifying its common ground-space range. The later FNW transfer-mixing
+estimate supplies the numerical bound on this defect; it is not asserted here. -/
+theorem re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect
+    [NeZero D] {A : MPSTensor d D} {K L₀ : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) {η : ℝ}
+    (hDefect :
+      ‖openChainTailGroundProjectionES A K (L₀ + 1) ∘L
+          openChainLeftGroundProjectionES A (K + L₀) -
+        (groundSpaceES A (K + L₀ + 1)).starProjection‖ ≤ η)
+    (v : EuclideanSpace ℂ (Cfg d (K + L₀ + 1))) :
+    -η *
+        (RCLike.re
+            (⟪(openChainTailGroundSpaceES A K (L₀ + 1))ᗮ.starProjection v, v⟫_ℂ) +
+          RCLike.re
+            (⟪(openChainLeftGroundSpaceES A (K + L₀))ᗮ.starProjection v, v⟫_ℂ)) ≤
+      RCLike.re
+          (⟪(openChainTailGroundSpaceES A K (L₀ + 1))ᗮ.starProjection v,
+            (openChainLeftGroundSpaceES A (K + L₀))ᗮ.starProjection v⟫_ℂ) +
+        RCLike.re
+          (⟪(openChainLeftGroundSpaceES A (K + L₀))ᗮ.starProjection v,
+            (openChainTailGroundSpaceES A K (L₀ + 1))ᗮ.starProjection v⟫_ℂ) := by
+  let U := openChainTailGroundSpaceES A K (L₀ + 1)
+  let V := openChainLeftGroundSpaceES A (K + L₀)
+  have hInter : U ⊓ V = groundSpaceES A (K + L₀ + 1) := by
+    rw [inf_comm]
+    exact openChainLeft_inf_tailGroundSpaceES hInj hL₀
+  have hη : 0 ≤ η := (norm_nonneg _).trans hDefect
+  have hDefect' :
+      ‖U.starProjection ∘L V.starProjection -
+        (groundSpaceES A (K + L₀ + 1)).starProjection‖ ≤ η := by
+    simpa [U, V, openChainTailGroundProjectionES,
+      openChainLeftGroundProjectionES] using hDefect
+  have hAngle : Submodule.IsFriedrichsBound U V η := by
+    apply Submodule.isFriedrichsBound_of_norm_starProjection_comp_sub_inf_starProjection_le
+    simpa only [hInter] using hDefect'
+  exact
+    Submodule.re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound
+      U V hη hAngle v
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_boundary.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_boundary.tex
@@ -24,7 +24,7 @@ $X A^j=A^jX$.
 
 \begin{proof}
     \leanok
-    \uses{lem:ground_space_map_injective_blk}
+    \uses{thm:ground_space_map_injective_blk}
     The trace identity for this cyclic interval is tested against all words of
     length $L_0$. Injectivity of $\Gamma_{L_0}$, which follows from
     $L_0$-block injectivity, turns these test-word identities into
@@ -45,7 +45,7 @@ $X A^j=A^jX$.
 
 \begin{proof}
     \leanok
-    \uses{lem:ground_space_map_injective_blk}
+    \uses{thm:ground_space_map_injective_blk}
     Factor the cyclic word at the second cyclic position, rotate the trace, and
     use injectivity of $\Gamma_{L_0}$ to remove the length-$L_0$ test word.
 \end{proof}
@@ -299,7 +299,7 @@ $X A^j=A^jX$.
     \label{lem:boundary_closing_endpoint_word_products}
     \lean{MPSTensor.boundary_closing_endpoint_word_products_common_background}
     \leanok
-    \uses{lem:cyclic_window_boundary_matrix_transport}
+    \uses{thm:cyclic_window_boundary_matrix_transport}
     Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$.
     Let $\psi$ be a state on the chain of length $M+1$. Suppose that matrices
     $Y_r(\rho)$, for $0\le r\le L_0-1$, represent the length-$(L_0+1)$ cyclic
@@ -315,7 +315,7 @@ $X A^j=A^jX$.
 
 \begin{proof}
     \leanok
-    Use Lemma~\ref{lem:cyclic_window_boundary_matrix_transport} for the
+    Use Theorem~\ref{thm:cyclic_window_boundary_matrix_transport} for the
     $L_0-1$ adjacent restrictions starting at $i_0=M+1-L_0$. For
     $0\le r<L_0-1$, the two endpoint words are determined by
     \begin{align}
@@ -331,7 +331,7 @@ $X A^j=A^jX$.
     \lean{MPSTensor.closure_property_boundary_condition_product_of_window_witnesses,
         MPSTensor.closure_property_boundary_condition_product_of_window_witnesses_mul_right}
     \leanok
-    \uses{rem:cyclic_window_operators, lem:cyclic_window_boundary_matrix_transport}
+    \uses{rem:cyclic_window_operators, thm:cyclic_window_boundary_matrix_transport}
     Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$. Let
     $\psi$ be a state on the chain of length $M+1$, and suppose matrices
     $Y_i(\rho)$ represent the length-$(L_0+1)$ cyclic restrictions
@@ -348,7 +348,7 @@ $X A^j=A^jX$.
 
 \begin{proof}
     \leanok
-    Apply Lemma~\ref{lem:cyclic_window_boundary_matrix_transport} to the
+    Apply Theorem~\ref{thm:cyclic_window_boundary_matrix_transport} to the
     $L_0-1$ restrictions beginning at $M+1-L_0+r$, with
     $Y_r(\rho)=Y_{M+1-L_0+r}(\rho)$. With $i_0=M+1-L_0$, the site labels
     satisfy
@@ -404,7 +404,7 @@ $X A^j=A^jX$.
     \label{lem:closure_property_boundary_condition_long_product_window_witnesses}
     \lean{MPSTensor.closure_property_boundary_condition_long_product_of_window_witnesses}
     \leanok
-    \uses{rem:cyclic_window_operators, lem:cyclic_window_boundary_matrix_transport}
+    \uses{rem:cyclic_window_operators, thm:cyclic_window_boundary_matrix_transport}
     Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$. Let
     $\psi$ be a state on the chain of length $M+1$, and suppose matrices
     $Y_i(\rho)$ represent the length-$(L_0+1)$ cyclic restrictions
@@ -421,7 +421,7 @@ $X A^j=A^jX$.
 
 \begin{proof}
     \leanok
-    Apply Lemma~\ref{lem:cyclic_window_boundary_matrix_transport} to the
+    Apply Theorem~\ref{thm:cyclic_window_boundary_matrix_transport} to the
     $M+2-L_0$ restrictions beginning at $M+r$ modulo $M+1$. With $i_0=M$, the
     site labels satisfy
     \begin{align}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -396,6 +396,47 @@
     two states coincide, so $\psi$ lies in $G_{K+L_0+1}(A)$.
 \end{proof}
 
+\begin{definition}[Open-chain left and tail ground subspaces]
+    \label{def:open_chain_ground_subspaces_es}
+    \lean{MPSTensor.openChainLeftGroundSpaceES,
+        MPSTensor.openChainTailGroundSpaceES,
+        MPSTensor.openChainLeftGroundProjectionES,
+        MPSTensor.openChainTailGroundProjectionES,
+        MPSTensor.mem_openChainLeftGroundSpaceES_iff,
+        MPSTensor.mem_openChainTailGroundSpaceES_iff}
+    \leanok
+    \uses{def:in_left_ground, def:in_tail_ground, def:ground_space_parent}
+    In the Hilbert space of an open chain, let
+    $\mathcal U_{K,L_0}(A)$ be the subspace satisfying the ground condition on
+    the first $K+L_0$ sites, and let $\mathcal V_{K,L_0}(A)$ be the subspace
+    satisfying the ground condition on the last $L_0+1$ sites. Equivalently,
+    membership is tested by fixing respectively the final site or every
+    prefix of length $K$ and applying the corresponding restriction map.
+\end{definition}
+
+\begin{theorem}[Open-chain left--tail ground-space intersection]
+    \label{thm:open_chain_left_tail_ground_intersection}
+    \lean{MPSTensor.openChainLeft_inf_tailGroundSpaceES}
+    \leanok
+    \uses{def:open_chain_ground_subspaces_es,
+        thm:ground_space_extend_right_block_injective}
+    If $A$ is $L_0$-block-injective and $L_0>0$, then
+    \begin{align}
+        \mathcal U_{K,L_0}(A)\cap\mathcal V_{K,L_0}(A)
+        &=\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A). \notag
+    \end{align}
+    In Nachtergaele's notation, with $n=K+L_0$ and $l=L_0$, this is the
+    common range identity for $G_{\Lambda_n}$ and
+    $G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}$ inside $\Lambda_{n+1}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The forward inclusion is the growing-back step at the injectivity length.
+    Conversely, a vector in the longer ground space remains in the ground
+    space after every left or tail restriction.
+\end{proof}
+
 \begin{theorem}[Open-chain iteration of the intersection property]%
     \label{thm:normal_open_chain_range_reduction}
     \lean{MPSTensor.contiguous_mem_groundSpace_of_isNBlkInjective}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -30,8 +30,8 @@
     $M \in \MN{D}$, and the trace pairing gives $X = 0$.
 \end{proof}
 
-\begin{lemma}[Ground-space map injectivity after blocking]
-    \label{lem:ground_space_map_injective_blk}
+\begin{theorem}[Ground-space map injectivity after blocking]
+    \label{thm:ground_space_map_injective_blk}
     \lean{MPSTensor.groundSpaceMap_injective_of_isNBlkInjective}
     \leanok
     \uses{thm:ground_space_map_injective_word_span, def:l_blk_injective}
@@ -220,8 +220,8 @@
     interval does not wrap around the ring.
 \end{remark}
 
-\begin{lemma}[One-site restrictions of cyclic-window boundary conditions]
-    \label{lem:cyclic_window_boundary_matrix_transport}
+\begin{theorem}[One-site restrictions of cyclic-window boundary conditions]
+    \label{thm:cyclic_window_boundary_matrix_transport}
     \lean{MPSTensor.cyclicRestrictₗ_restrictFirst_groundSpaceMap}
     \lean{MPSTensor.cyclicRestrictₗ_restrictLast_groundSpaceMap}
     \lean{MPSTensor.adjacent_cyclicRestrictₗ_witness_overlap}
@@ -404,10 +404,15 @@
         MPSTensor.openChainTailGroundProjectionES}
     \leanok
     \uses{def:in_left_ground, def:in_tail_ground, def:ground_space_parent}
-    In the Hilbert space of an open chain, let
-    $\mathcal U_{K,L_0}(A)$ be the subspace satisfying the ground condition on
-    the first $K+L_0$ sites, and let $\mathcal V_{K,L_0}(A)$ be the subspace
-    satisfying the ground condition on the last $L_0+1$ sites.
+    For every $L\in\N$, let $\mathcal U_L(A)$ be the subspace of the
+    $(L+1)$-site Hilbert space whose corresponding functions satisfy the left
+    ground condition: every fixed-final-site restriction belongs to $G_L(A)$.
+    For every $K,L\in\N$, let $\mathcal V_{K,L}(A)$ be the subspace of the
+    $(K+L)$-site Hilbert space whose corresponding functions satisfy the tail
+    ground condition: every fixed-prefix restriction belongs to $G_L(A)$.
+    These definitions include $L=0$. Let $P^{\mathrm{left}}_L(A)$ and
+    $P^{\mathrm{tail}}_{K,L}(A)$ be the orthogonal projectors onto
+    $\mathcal U_L(A)$ and $\mathcal V_{K,L}(A)$, respectively.
 \end{definition}
 
 \begin{theorem}[Membership in the open-chain left ground subspace]
@@ -416,9 +421,9 @@
     \leanok
     \uses{def:open_chain_ground_subspaces_es, def:in_left_ground}
     Under the canonical $\ell^2$ identification, a Hilbert-space vector
-    belongs to $\mathcal U_{K,L_0}(A)$ exactly when the corresponding function
+    belongs to $\mathcal U_L(A)$ exactly when the corresponding function
     satisfies the left ground condition: every fixed-final-site restriction
-    belongs to $G_{K+L_0}(A)$.
+    belongs to $G_L(A)$.
 \end{theorem}
 
 \begin{proof}
@@ -433,9 +438,9 @@
     \leanok
     \uses{def:open_chain_ground_subspaces_es, def:in_tail_ground}
     Under the canonical $\ell^2$ identification, a Hilbert-space vector
-    belongs to $\mathcal V_{K,L_0}(A)$ exactly when the corresponding function
+    belongs to $\mathcal V_{K,L}(A)$ exactly when the corresponding function
     satisfies the tail ground condition: every fixed-prefix restriction
-    belongs to $G_{L_0+1}(A)$.
+    belongs to $G_L(A)$.
 \end{theorem}
 
 \begin{proof}
@@ -452,7 +457,7 @@
         def:l_blk_injective}
     If $D\ge1$, $A$ is $L_0$-block-injective, and $L_0>0$, then
     \begin{align}
-        \mathcal U_{K,L_0}(A)\cap\mathcal V_{K,L_0}(A)
+        \mathcal U_{K+L_0}(A)\cap\mathcal V_{K,L_0+1}(A)
         &=\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A). \notag
     \end{align}
     In Nachtergaele's notation, with $n=K+L_0$ and $l=L_0$, this is the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -415,8 +415,10 @@
     \lean{MPSTensor.mem_openChainLeftGroundSpaceES_iff}
     \leanok
     \uses{def:open_chain_ground_subspaces_es, def:in_left_ground}
-    A vector belongs to $\mathcal U_{K,L_0}(A)$ exactly when fixing its final
-    site gives a vector satisfying the left ground condition.
+    Under the canonical $\ell^2$ identification, a Hilbert-space vector
+    belongs to $\mathcal U_{K,L_0}(A)$ exactly when the corresponding function
+    satisfies the left ground condition: every fixed-final-site restriction
+    belongs to $G_{K+L_0}(A)$.
 \end{lemma}
 
 \begin{proof}
@@ -430,8 +432,10 @@
     \lean{MPSTensor.mem_openChainTailGroundSpaceES_iff}
     \leanok
     \uses{def:open_chain_ground_subspaces_es, def:in_tail_ground}
-    A vector belongs to $\mathcal V_{K,L_0}(A)$ exactly when every fixed-prefix
-    restriction satisfies the tail ground condition.
+    Under the canonical $\ell^2$ identification, a Hilbert-space vector
+    belongs to $\mathcal V_{K,L_0}(A)$ exactly when the corresponding function
+    satisfies the tail ground condition: every fixed-prefix restriction
+    belongs to $G_{L_0+1}(A)$.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -401,25 +401,50 @@
     \lean{MPSTensor.openChainLeftGroundSpaceES,
         MPSTensor.openChainTailGroundSpaceES,
         MPSTensor.openChainLeftGroundProjectionES,
-        MPSTensor.openChainTailGroundProjectionES,
-        MPSTensor.mem_openChainLeftGroundSpaceES_iff,
-        MPSTensor.mem_openChainTailGroundSpaceES_iff}
+        MPSTensor.openChainTailGroundProjectionES}
     \leanok
     \uses{def:in_left_ground, def:in_tail_ground, def:ground_space_parent}
     In the Hilbert space of an open chain, let
     $\mathcal U_{K,L_0}(A)$ be the subspace satisfying the ground condition on
     the first $K+L_0$ sites, and let $\mathcal V_{K,L_0}(A)$ be the subspace
-    satisfying the ground condition on the last $L_0+1$ sites. Equivalently,
-    membership is tested by fixing respectively the final site or every
-    prefix of length $K$ and applying the corresponding restriction map.
+    satisfying the ground condition on the last $L_0+1$ sites.
 \end{definition}
+
+\begin{lemma}[Membership in the open-chain left ground subspace]
+    \label{lem:mem_open_chain_left_ground_space_es}
+    \lean{MPSTensor.mem_openChainLeftGroundSpaceES_iff}
+    \leanok
+    \uses{def:open_chain_ground_subspaces_es, def:in_left_ground}
+    A vector belongs to $\mathcal U_{K,L_0}(A)$ exactly when fixing its final
+    site gives a vector satisfying the left ground condition.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Transport through the canonical $\ell^2$ equivalence and unfold the
+    left-site restriction condition.
+\end{proof}
+
+\begin{lemma}[Membership in the open-chain tail ground subspace]
+    \label{lem:mem_open_chain_tail_ground_space_es}
+    \lean{MPSTensor.mem_openChainTailGroundSpaceES_iff}
+    \leanok
+    \uses{def:open_chain_ground_subspaces_es, def:in_tail_ground}
+    A vector belongs to $\mathcal V_{K,L_0}(A)$ exactly when every fixed-prefix
+    restriction satisfies the tail ground condition.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Transport through the canonical $\ell^2$ equivalence and unfold the tail
+    restriction condition.
+\end{proof}
 
 \begin{theorem}[Open-chain left--tail ground-space intersection]
     \label{thm:open_chain_left_tail_ground_intersection}
     \lean{MPSTensor.openChainLeft_inf_tailGroundSpaceES}
     \leanok
-    \uses{def:open_chain_ground_subspaces_es,
-        thm:ground_space_extend_right_block_injective}
+    \uses{def:open_chain_ground_subspaces_es, def:ground_space_es}
     If $A$ is $L_0$-block-injective and $L_0>0$, then
     \begin{align}
         \mathcal U_{K,L_0}(A)\cap\mathcal V_{K,L_0}(A)
@@ -432,6 +457,10 @@
 
 \begin{proof}
     \leanok
+    \uses{lem:mem_open_chain_left_ground_space_es,
+        lem:mem_open_chain_tail_ground_space_es, lem:mem_ground_space_es,
+        thm:ground_space_extend_right_block_injective,
+        lem:ground_space_in_left_ground, lem:ground_space_in_tail_ground}
     The forward inclusion is the growing-back step at the injectivity length.
     Conversely, a vector in the longer ground space remains in the ground
     space after every left or tail restriction.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -38,7 +38,7 @@
     If the length-$L_0$ products span the full matrix algebra,
     $\spn\{A^\omega : |\omega| = L_0\} = \MN{D}$, then $\Gamma_{L_0}$ is
     injective.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -250,7 +250,7 @@
     In particular, if the two endpoint words are named by the equations
     $a_r=\rho(i_0+r)$ and $b_r=\rho(i_0+r+L+1)$, with site labels read modulo
     $N$, then the same transport identity is written as $Y_0A^a=A^bY_n$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -410,8 +410,8 @@
     satisfying the ground condition on the last $L_0+1$ sites.
 \end{definition}
 
-\begin{lemma}[Membership in the open-chain left ground subspace]
-    \label{lem:mem_open_chain_left_ground_space_es}
+\begin{theorem}[Membership in the open-chain left ground subspace]
+    \label{thm:mem_open_chain_left_ground_space_es}
     \lean{MPSTensor.mem_openChainLeftGroundSpaceES_iff}
     \leanok
     \uses{def:open_chain_ground_subspaces_es, def:in_left_ground}
@@ -419,7 +419,7 @@
     belongs to $\mathcal U_{K,L_0}(A)$ exactly when the corresponding function
     satisfies the left ground condition: every fixed-final-site restriction
     belongs to $G_{K+L_0}(A)$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -427,8 +427,8 @@
     left-site restriction condition.
 \end{proof}
 
-\begin{lemma}[Membership in the open-chain tail ground subspace]
-    \label{lem:mem_open_chain_tail_ground_space_es}
+\begin{theorem}[Membership in the open-chain tail ground subspace]
+    \label{thm:mem_open_chain_tail_ground_space_es}
     \lean{MPSTensor.mem_openChainTailGroundSpaceES_iff}
     \leanok
     \uses{def:open_chain_ground_subspaces_es, def:in_tail_ground}
@@ -436,7 +436,7 @@
     belongs to $\mathcal V_{K,L_0}(A)$ exactly when the corresponding function
     satisfies the tail ground condition: every fixed-prefix restriction
     belongs to $G_{L_0+1}(A)$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -448,8 +448,9 @@
     \label{thm:open_chain_left_tail_ground_intersection}
     \lean{MPSTensor.openChainLeft_inf_tailGroundSpaceES}
     \leanok
-    \uses{def:open_chain_ground_subspaces_es, def:ground_space_es}
-    If $A$ is $L_0$-block-injective and $L_0>0$, then
+    \uses{def:open_chain_ground_subspaces_es, def:ground_space_es,
+        def:l_blk_injective}
+    If $D\ge1$, $A$ is $L_0$-block-injective, and $L_0>0$, then
     \begin{align}
         \mathcal U_{K,L_0}(A)\cap\mathcal V_{K,L_0}(A)
         &=\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A). \notag
@@ -461,8 +462,8 @@
 
 \begin{proof}
     \leanok
-    \uses{lem:mem_open_chain_left_ground_space_es,
-        lem:mem_open_chain_tail_ground_space_es, lem:mem_ground_space_es,
+    \uses{thm:mem_open_chain_left_ground_space_es,
+        thm:mem_open_chain_tail_ground_space_es, lem:mem_ground_space_es,
         thm:ground_space_extend_right_block_injective,
         lem:ground_space_in_left_ground, lem:ground_space_in_tail_ground}
     The forward inclusion is the growing-back step at the injectivity length.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_boundary_equations.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_boundary_equations.tex
@@ -202,7 +202,7 @@
 
 \begin{proof}
     \leanok
-    \uses{lem:ground_space_map_injective_blk}
+    \uses{thm:ground_space_map_injective_blk}
     The trace identities say exactly that, for each fixed pair
     $(\alpha,\nu)$,
     \begin{align}
@@ -211,7 +211,7 @@
         \notag
     \end{align}
     Since $A$ is $L_0$-block-injective, $\Gamma_{L_0}$ is injective by
-    Lemma~\ref{lem:ground_space_map_injective_blk}. Hence
+    Theorem~\ref{thm:ground_space_map_injective_blk}. Hence
     $X A^\alpha A^\nu=A^\alpha Y_\nu$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_boundary_products.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_boundary_products.tex
@@ -3,8 +3,8 @@
     \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_closing_restrictions}
     \leanok
     \uses{def:l_blk_injective, def:ground_space_map,
-        rem:cyclic_window_operators, lem:ground_space_map_injective_blk,
-        lem:cyclic_window_boundary_matrix_transport,
+        rem:cyclic_window_operators, thm:ground_space_map_injective_blk,
+        thm:cyclic_window_boundary_matrix_transport,
         lem:wrapped_middle_backgrounds}
     Let $A$ be $L_0$-block-injective with $L_0>0$, and let $L_0\le M$.
     Let $\psi$ be a state on the chain of length $M+1$, and let
@@ -54,8 +54,8 @@
         \notag
     \end{align}
     where the two sides are identified by
-    Lemma~\ref{lem:cyclic_window_boundary_matrix_transport}. By
-    Lemma~\ref{lem:ground_space_map_injective_blk},
+    Theorem~\ref{thm:cyclic_window_boundary_matrix_transport}. By
+    Theorem~\ref{thm:ground_space_map_injective_blk},
     $Y_M(\tau^+_j(\mu))A^j = Y_{M+1-L_0}(\tau^-_j(\mu))A^j$.
     Right multiplication by $A^\sigma$ gives the asserted product equation.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
@@ -429,6 +429,28 @@
     $y\in V\cap(U\cap V)^\perp$.
 \end{definition}
 
+\begin{lemma}[Projector defect bounds the Friedrichs overlap]
+    \label{lem:projector_defect_to_friedrichs}
+    \lean{Submodule.isFriedrichsBound_of_norm_starProjection_comp_sub_inf_starProjection_le}
+    \leanok
+    \uses{def:friedrichs_overlap_bound}
+    Let $P_U$, $P_V$, and $P_{U\cap V}$ be the orthogonal projections onto
+    $U$, $V$, and their intersection. If
+    \begin{align}
+        \|P_UP_V-P_{U\cap V}\|&\le\eta, \notag
+    \end{align}
+    then the Friedrichs overlap of $U$ and $V$ is at most $\eta$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    For $y\in V\cap(U\cap V)^\perp$, the defect applied to $y$ is $P_Uy$.
+    Hence $\|P_Uy\|\le\eta\|y\|$. If also
+    $x\in U\cap(U\cap V)^\perp$, self-adjointness of $P_U$ gives
+    $\langle x,y\rangle=\langle x,P_Uy\rangle$, and Cauchy--Schwarz proves
+    the claim.
+\end{proof}
+
 \begin{lemma}[Projection compression from a Friedrichs overlap bound]
     \label{lem:two_projection_friedrichs_compression}
     \lean{Submodule.norm_starProjection_le_of_friedrichs_bound}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
@@ -429,8 +429,8 @@
     $y\in V\cap(U\cap V)^\perp$.
 \end{definition}
 
-\begin{lemma}[Projector defect bounds the Friedrichs overlap]
-    \label{lem:projector_defect_to_friedrichs}
+\begin{theorem}[Projector defect bounds the Friedrichs overlap]
+    \label{thm:projector_defect_to_friedrichs}
     \lean{Submodule.isFriedrichsBound_of_norm_starProjection_comp_sub_inf_starProjection_le}
     \leanok
     \uses{def:friedrichs_overlap_bound}
@@ -440,7 +440,7 @@
         \|P_UP_V-P_{U\cap V}\|&\le\eta, \notag
     \end{align}
     then the Friedrichs overlap of $U$ and $V$ is at most $\eta$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -118,27 +118,29 @@
     of the two diagonal excitation forms.
 \end{proof}
 
-\begin{corollary}[Nachtergaele open-chain projector defect]
-    \label{cor:nachtergaele_open_chain_projector_defect}
+\begin{theorem}[Nachtergaele open-chain projector defect]
+    \label{thm:nachtergaele_open_chain_projector_defect}
     \lean{MPSTensor.re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect}
     \leanok
-    \uses{def:open_chain_ground_subspaces_es, def:ground_space_es}
-    Put $\Lambda_n=[1,n]$, let $U$ be the tail ground space on
+    \uses{def:open_chain_ground_subspaces_es, def:ground_space_es,
+        def:l_blk_injective}
+    Assume $D\ge1$ and let $A$ be $L_0$-block-injective with $L_0>0$. Set
+    $n=K+L_0$ and $l=L_0$. Let $U$ be the tail ground space on
     $\Lambda_{n+1}\setminus\Lambda_{n-l}$, and let $V$ be the left ground
     space on $\Lambda_n$, both in the Hilbert space on $\Lambda_{n+1}$.
-    Assume that $A$ is $L_0$-block-injective with $L_0>0$, and suppose
+    Suppose
     \begin{align}
         \|G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
           -G_{\Lambda_{n+1}}\|&\le\eta. \notag
     \end{align}
     Then the complementary excitation projections satisfy the quadratic-form
     anticommutator lower bound with coefficient $\eta$.
-\end{corollary}
+\end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:open_chain_left_tail_ground_intersection,
-        lem:projector_defect_to_friedrichs,
+        thm:projector_defect_to_friedrichs,
         thm:friedrichs_ground_space_excitation_anticommutator}
     The open-chain intersection theorem identifies $U\cap V$ with the ground
     space on $\Lambda_{n+1}$. The projector-defect adapter gives a Friedrichs

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -118,6 +118,34 @@
     of the two diagonal excitation forms.
 \end{proof}
 
+\begin{corollary}[Nachtergaele open-chain projector defect]
+    \label{cor:nachtergaele_open_chain_projector_defect}
+    \lean{MPSTensor.re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect}
+    \leanok
+    \uses{thm:friedrichs_ground_space_excitation_anticommutator,
+        thm:open_chain_left_tail_ground_intersection,
+        lem:projector_defect_to_friedrichs}
+    Put $\Lambda_n=[1,n]$, let $U$ be the tail ground space on
+    $\Lambda_{n+1}\setminus\Lambda_{n-l}$, and let $V$ be the left ground
+    space on $\Lambda_n$, both in the Hilbert space on $\Lambda_{n+1}$.
+    Under the block-injectivity hypotheses of
+    Theorem~\ref{thm:open_chain_left_tail_ground_intersection}, suppose
+    \begin{align}
+        \|G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
+          -G_{\Lambda_{n+1}}\|&\le\eta. \notag
+    \end{align}
+    Then the complementary excitation projections satisfy the quadratic-form
+    anticommutator lower bound with coefficient $\eta$.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    The open-chain intersection theorem identifies $U\cap V$ with the ground
+    space on $\Lambda_{n+1}$. The projector-defect adapter gives a Friedrichs
+    overlap bound, and the reduced two-projection theorem gives the stated
+    anticommutator inequality.
+\end{proof}
+
 \begin{lemma}[MPS anticommutator input for the martingale condition]\label{lem:martingale_mps}
     \notready
     \uses{def:parent_interaction, def:local_term_parent, def:injective}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -125,16 +125,25 @@
     \uses{def:open_chain_ground_subspaces_es, def:ground_space_es,
         def:l_blk_injective}
     Assume $D\ge1$ and let $A$ be $L_0$-block-injective with $L_0>0$. Set
-    $n=K+L_0$ and $l=L_0$. Let $U$ be the tail ground space on
-    $\Lambda_{n+1}\setminus\Lambda_{n-l}$, and let $V$ be the left ground
-    space on $\Lambda_n$, both in the Hilbert space on $\Lambda_{n+1}$.
-    Suppose
+    $n=K+L_0$ and $l=L_0$, and write
+    \begin{align}
+        S&=\mathcal U_{K+L_0}(A), &
+        T&=\mathcal V_{K,L_0+1}(A). \notag
+    \end{align}
+    Thus $S$ and $T$ are the left and tail ground spaces in the Hilbert space
+    on $\Lambda_{n+1}$. Let $q_S=P_{S^\perp}$ and $q_T=P_{T^\perp}$ be the
+    complementary excitation projections. If
     \begin{align}
         \|G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
-          -G_{\Lambda_{n+1}}\|&\le\eta. \notag
+          -G_{\Lambda_{n+1}}\|&\le\eta, \notag
     \end{align}
-    Then the complementary excitation projections satisfy the quadratic-form
-    anticommutator lower bound with coefficient $\eta$.
+    then every vector $v$ in the Hilbert space on $\Lambda_{n+1}$ satisfies
+    \begin{align}
+        -\eta\bigl(
+          \re\langle q_Tv,v\rangle+\re\langle q_Sv,v\rangle\bigr)
+        &\le
+          \re\langle q_Tv,q_Sv\rangle+\re\langle q_Sv,q_Tv\rangle. \notag
+    \end{align}
 \end{theorem}
 
 \begin{proof}
@@ -142,7 +151,7 @@
     \uses{thm:open_chain_left_tail_ground_intersection,
         thm:projector_defect_to_friedrichs,
         thm:friedrichs_ground_space_excitation_anticommutator}
-    The open-chain intersection theorem identifies $U\cap V$ with the ground
+    The open-chain intersection theorem identifies $S\cap T$ with the ground
     space on $\Lambda_{n+1}$. The projector-defect adapter gives a Friedrichs
     overlap bound, and the reduced two-projection theorem gives the stated
     anticommutator inequality.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -122,14 +122,11 @@
     \label{cor:nachtergaele_open_chain_projector_defect}
     \lean{MPSTensor.re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect}
     \leanok
-    \uses{thm:friedrichs_ground_space_excitation_anticommutator,
-        thm:open_chain_left_tail_ground_intersection,
-        lem:projector_defect_to_friedrichs}
+    \uses{def:open_chain_ground_subspaces_es, def:ground_space_es}
     Put $\Lambda_n=[1,n]$, let $U$ be the tail ground space on
     $\Lambda_{n+1}\setminus\Lambda_{n-l}$, and let $V$ be the left ground
     space on $\Lambda_n$, both in the Hilbert space on $\Lambda_{n+1}$.
-    Under the block-injectivity hypotheses of
-    Theorem~\ref{thm:open_chain_left_tail_ground_intersection}, suppose
+    Assume that $A$ is $L_0$-block-injective with $L_0>0$, and suppose
     \begin{align}
         \|G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
           -G_{\Lambda_{n+1}}\|&\le\eta. \notag
@@ -140,6 +137,9 @@
 
 \begin{proof}
     \leanok
+    \uses{thm:open_chain_left_tail_ground_intersection,
+        lem:projector_defect_to_friedrichs,
+        thm:friedrichs_ground_space_excitation_anticommutator}
     The open-chain intersection theorem identifies $U\cap V$ with the ground
     space on $\Lambda_{n+1}$. The projector-defect adapter gives a Friedrichs
     overlap bound, and the reduced two-projection theorem gives the stated

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -113,6 +113,46 @@ projection estimates inherited from Fannes--Nachtergaele--Werner
 convert one of these source estimates to the cyclic-window inequality used
 below, with constants in the same blocking convention.
 
+\subsection{Compiled open-chain interface}
+
+The source-faithful open-chain geometry is now isolated before any cyclic
+specialization. In the common Hilbert space on $\Lambda_{n+1}$, the formal
+subspaces
+\leanid{openChainLeftGroundSpaceES} and
+\leanid{openChainTailGroundSpaceES} are the ranges of $G_{\Lambda_n}$ and
+$G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}$, expressed using the existing
+last-site and fixed-prefix restriction maps. Under $L_0$-block injectivity,
+with $n=K+L_0$ and $l=L_0$, the theorem
+\leanid{openChainLeft_inf_tailGroundSpaceES} proves
+\[
+  U\cap V=\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A).
+\]
+
+The generic theorem
+\leanid{isFriedrichsBound_of_norm_starProjection_comp_sub_inf_starProjection_le}
+converts
+\[
+  \|P_UP_V-P_{U\cap V}\|\le\eta
+\]
+into a Friedrichs bound. Combining these two results with the complementary
+projection theorem gives the compiled open-chain corollary
+\leanid{re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect}.
+Its hypothesis is precisely the C3 defect
+\[
+  \|G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}
+    -G_{\Lambda_{n+1}}\|\le\eta,
+\]
+using the identity following condition C3 in
+\cite[Equation~(2.4)]{Nachtergaele1996Spectral}. Equation~(2.5) is the
+separate batched condition C3$'$ involving $E_n^{(p)}$.
+
+The remaining source step is numerical, not geometric: one must formalize the
+FNW transfer-mixing estimate that bounds this open-chain defect uniformly in
+$n$ by an exponentially decaying function of $l$ (or formalize the Section~6
+C3$'$ route with its batched difference). No cyclic rotation, interval
+evaluator, excitation compression, or numerical transfer estimate is included
+in the compiled interface.
+
 \section{Finite-row martingale reduction}
 
 The current development separates the finite-row martingale algebra from the

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -113,7 +113,7 @@ projection estimates inherited from Fannes--Nachtergaele--Werner
 convert one of these source estimates to the cyclic-window inequality used
 below, with constants in the same blocking convention.
 
-\subsection{Compiled open-chain interface}
+\subsection{Open-chain projector geometry}
 
 The source-faithful open-chain geometry is now isolated before any cyclic
 specialization. In the common Hilbert space on $\Lambda_{n+1}$, the formal
@@ -135,7 +135,7 @@ converts
   \|P_UP_V-P_{U\cap V}\|\le\eta
 \]
 into a Friedrichs bound. Combining these two results with the complementary
-projection theorem gives the compiled open-chain corollary
+projection theorem gives the open-chain corollary
 \leanid{re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect}.
 Its hypothesis is precisely the C3 defect
 \[
@@ -151,7 +151,7 @@ FNW transfer-mixing estimate that bounds this open-chain defect uniformly in
 $n$ by an exponentially decaying function of $l$ (or formalize the Section~6
 C3$'$ route with its batched difference). No cyclic rotation, interval
 evaluator, excitation compression, or numerical transfer estimate is included
-in the compiled interface.
+in these results.
 
 \section{Finite-row martingale reduction}
 


### PR DESCRIPTION
## Summary

- package the left-window and tail-window open-chain ground spaces as finite-dimensional Hilbert submodules with named orthogonal projectors
- prove their intersection is the longer open-chain ground space at the block-injectivity length
- convert the ordered projector defect into a Friedrichs overlap bound and then into the complementary-excitation anticommutator inequality
- synchronize Chapter 13 and the martingale paper-gap note with the formal declarations

## Source-faithfulness scope

This follows Nachtergaele, arXiv:cond-mat/9410110, condition C3 and equation (2.4), with
$\Lambda_n=[1,n]$ and the ordered defect
$G_{\Lambda_{n+1}\setminus\Lambda_{n-l}}G_{\Lambda_n}-G_{\Lambda_{n+1}}$.
The Lean composition order is therefore tail projector after left projector. The existing restriction maps and `groundSpaceES` transport are used; no interval evaluator or cyclic-rotation route is introduced.

The prose distinguishes C3 from the separate batched condition C3' in equation (2.5). This PR deliberately does not add the FNW exponential numerical estimate, an all-vector excitation compression, or a cyclic-window estimate.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.OpenChain TNLean.MPS.ParentHamiltonian.Martingale TNLean.MPS.ParentHamiltonian`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean`
- targeted Mathlib lint audit for `docBlame`, `unusedArguments`, and `simpNF`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --warn-missing-blueprint --diff-base origin/main --diff-head HEAD --changed-files TNLean/Analysis/TwoProjectionCompression.lean TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean`
- targeted `lake exe checkdecls` for all nine new declaration anchors
- `leanblueprint web`

Closes #5748

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of Hilbert-space geometry and abstract projection lemmas with no auth, runtime, or data-path changes; remaining martingale gap still depends on unformalized numerical input.
> 
> **Overview**
> Adds **open-chain Hilbert subspaces** for Nachtergaele martingale C3 (left-window and tail-window ground conditions with named orthogonal projectors) and proves their **intersection** is the longer open-chain ground space at block-injectivity length.
> 
> A new generic lemma converts **projector defect** `‖P_U P_V − P_{U∩V}‖ ≤ η` into a **Friedrichs overlap** bound; combined with existing two-projection machinery, the open-chain **C3 defect** yields the complementary-excitation **anticommutator** inequality. The FNW numerical transfer estimate that would bound the defect is **not** included.
> 
> Blueprint Chapter 13 and `docs/paper-gaps/cpgsv21_martingale_overlap.tex` are updated; several ground-space-map and cyclic-window transport results are promoted from lemma to theorem in prose cross-references only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e2dfba07d185c05d340d390dde1e8681ec5cef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->