### PR TITLE
fix(tenkz): map a waived relation onto the gap its glyph sits on

### DIFF
--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -1531,11 +1531,27 @@ class Audit:
                 # what the kernel's own malformed-scope path does -- and it
                 # honours the source's waivers there for the same reason the
                 # kernel honours its own: an author who opted a relation out
-                # did not opt back in by losing a record elsewhere.
-                self._compare_adjacent(members, scope, modulo, waived)
+                # did not opt back in by losing a record elsewhere.  The
+                # waivers name relations and the walk visits gaps, so they are
+                # mapped onto the gaps their glyphs sit on first.
+                self._compare_adjacent(
+                    members, scope, modulo,
+                    _waived_gaps(waived, relation_gaps),
+                )
                 continue
             if not products:
-                self._compare_adjacent(members, scope, modulo, waived)
+                # Every side is one panel here, so the k-th relation is the
+                # k-th gap and the two numberings coincide.
+                for relation in range(1, len(members)):
+                    if relation in waived:
+                        continue
+                    self._compare_panels(
+                        self.pictures[members[relation - 1]],
+                        self.pictures[members[relation]],
+                        self.hard, "eq-boundary-mismatch",
+                        f"sit on relation {relation} of equation scope {scope}",
+                        modulo=modulo,
+                    )
                 continue
             # A composite side's signature is a fold over an interface the
             # kernel resolves, and its verdict is the `check` record that
@@ -1570,15 +1586,22 @@ class Audit:
         return sides
 
     def _compare_adjacent(self, members: list[int], scope: int, modulo: bool,
-                          waived: set[int]) -> None:
-        for relation in range(1, len(members)):
-            if relation in waived:
+                          waived_gaps: set[int]) -> None:
+        """Compare a scope's panels pair by pair, skipping the waived gaps.
+
+        The pairs are gaps, not relations: this runs where the group's own
+        account of its joiners did not hold, so a panel's neighbour is all
+        that is left to compare it against.
+        """
+        for gap in range(1, len(members)):
+            if gap in waived_gaps:
                 continue
             self._compare_panels(
-                self.pictures[members[relation - 1]],
-                self.pictures[members[relation]],
+                self.pictures[members[gap - 1]],
+                self.pictures[members[gap]],
                 self.hard, "eq-boundary-mismatch",
-                f"sit on relation {relation} of equation scope {scope}",
+                f"are adjacent panels {gap} and {gap + 1} of equation "
+                f"scope {scope}",
                 modulo=modulo,
             )
 
@@ -1827,6 +1850,24 @@ def _tenkzeq_declares_bundles(source: str, position: int) -> bool:
 _ORIENTATIONS = frozenset({"to", "from"})
 _BUNDLE = re.compile(r"bundle=([1-9]\d*)")
 _PRODUCT_PAIR = re.compile(r"(\d+)-(\d+)")
+
+
+def _waived_gaps(waived: set[int], relation_gaps: set[int]) -> set[int]:
+    """The gaps a scope's waived relations sit on.
+
+    A waiver names a relation by its ordinal while a pairwise comparison walks
+    gaps, and the two agree only where every side is one panel.  The k-th
+    relation glyph of a source sits on the k-th of its relation gaps, so where
+    the source is read the ordinals are mapped through it; with no source
+    there is nothing to map them through and they stand as they are.
+    """
+    if not relation_gaps:
+        return set(waived)
+    ordered = sorted(relation_gaps)
+    return {
+        ordered[relation - 1] for relation in waived
+        if 1 <= relation <= len(ordered)
+    }
 
 
 def _product_pair(event: Event, panels: int) -> int | None:

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -417,9 +417,8 @@ class ScopePolicy(NamedTuple):
 
     waived: set[int]         # relations its `check={off={k: ...}}` retires
     modulo_bundles: bool     # whether it compares a bundle as its multiplicity
-    relation_gaps: set[int]  # gaps holding a relation glyph
-    product_gaps: set[int]   # gaps holding none, joining by juxtaposition
-    relation_count: Optional[int]  # relation glyphs over all its gaps
+    relation_order: tuple[int, ...]  # the gap each relation glyph sits on
+    product_gaps: set[int]   # gaps holding no glyph, joining by juxtaposition
 
 
 @dataclass
@@ -1347,19 +1346,21 @@ class Audit:
                 for left, right in zip(members, members[1:])
             ]
             marks = [relation_marks(separator) for separator in separators]
-            relation_gaps = {
-                position + 1 for position, count in enumerate(marks) if count
-            }
+            # One entry per glyph, in source order, so the k-th relation keeps
+            # the gap it sits on even where a gap carries more than one.
+            relation_order = tuple(
+                position + 1
+                for position, count in enumerate(marks)
+                for _ in range(count)
+            )
             product_gaps = {
                 position + 1 for position, count in enumerate(marks) if not count
             }
-            relation_count = sum(marks)
             authorized[scope] = ScopePolicy(
                 _tenkzeq_declared_offs(self._tex_src, begin) or set(),
                 _tenkzeq_declares_bundles(self._tex_src, begin),
-                relation_gaps,
+                relation_order,
                 product_gaps,
-                relation_count,
             )
         return authorized
 
@@ -1442,13 +1443,12 @@ class Audit:
             where = f"{self.log_path.name}:{self.pictures[members[0]].line}"
             source = (
                 None if policy is None
-                else policy.get(
-                    scope, ScopePolicy(set(), False, set(), set(), None)
-                )
+                else policy.get(scope, ScopePolicy(set(), False, (), set()))
             )
             declared = set() if source is None else source.waived
             declared_modulo = logged_modulo if source is None else source.modulo_bundles
-            relation_gaps = set() if source is None else source.relation_gaps
+            relation_order = () if source is None else source.relation_order
+            relation_gaps = set(relation_order)
             product_gaps = set() if source is None else source.product_gaps
             # A bundle expansion loosens the comparison, so the source has to
             # ask for it: a stale stream carrying `modulo=bundles` past a
@@ -1479,10 +1479,7 @@ class Audit:
                 # that moves a joiner to another gap leaves a panel outside
                 # every side while its counts still balance.
                 and (source is None or products == product_gaps)
-                and (
-                    source is None or source.relation_count is None
-                    or len(relations) == source.relation_count
-                )
+                and (source is None or len(relations) == len(relation_order))
                 and len(relations) + len(products) + 1 == len(members)
             )
             waived: set[int] = {
@@ -1536,7 +1533,7 @@ class Audit:
                 # mapped onto the gaps their glyphs sit on first.
                 self._compare_adjacent(
                     members, scope, modulo,
-                    _waived_gaps(waived, relation_gaps),
+                    _waived_gaps(waived, relation_order),
                 )
                 continue
             if not products:
@@ -1852,21 +1849,20 @@ _BUNDLE = re.compile(r"bundle=([1-9]\d*)")
 _PRODUCT_PAIR = re.compile(r"(\d+)-(\d+)")
 
 
-def _waived_gaps(waived: set[int], relation_gaps: set[int]) -> set[int]:
+def _waived_gaps(waived: set[int], relation_order: tuple[int, ...]) -> set[int]:
     """The gaps a scope's waived relations sit on.
 
     A waiver names a relation by its ordinal while a pairwise comparison walks
-    gaps, and the two agree only where every side is one panel.  The k-th
-    relation glyph of a source sits on the k-th of its relation gaps, so where
-    the source is read the ordinals are mapped through it; with no source
-    there is nothing to map them through and they stand as they are.
+    gaps, and the two agree only where every side is one panel.  The source
+    lists the gap each of its relation glyphs sits on, one entry per glyph, so
+    a gap carrying two of them keeps both ordinals; with no source there is
+    nothing to map them through and they stand as they are.
     """
-    if not relation_gaps:
+    if not relation_order:
         return set(waived)
-    ordered = sorted(relation_gaps)
     return {
-        ordered[relation - 1] for relation in waived
-        if 1 <= relation <= len(ordered)
+        relation_order[relation - 1] for relation in waived
+        if 1 <= relation <= len(relation_order)
     }
 
 

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -1538,17 +1538,11 @@ class Audit:
                 continue
             if not products:
                 # Every side is one panel here, so the k-th relation is the
-                # k-th gap and the two numberings coincide.
-                for relation in range(1, len(members)):
-                    if relation in waived:
-                        continue
-                    self._compare_panels(
-                        self.pictures[members[relation - 1]],
-                        self.pictures[members[relation]],
-                        self.hard, "eq-boundary-mismatch",
-                        f"sit on relation {relation} of equation scope {scope}",
-                        modulo=modulo,
-                    )
+                # k-th gap: the walk is the same one, and it can say which
+                # relation each pair sits on.
+                self._compare_adjacent(
+                    members, scope, modulo, waived, by_relation=True
+                )
                 continue
             # A composite side's signature is a fold over an interface the
             # kernel resolves, and its verdict is the `check` record that
@@ -1583,12 +1577,14 @@ class Audit:
         return sides
 
     def _compare_adjacent(self, members: list[int], scope: int, modulo: bool,
-                          waived_gaps: set[int]) -> None:
+                          waived_gaps: set[int],
+                          by_relation: bool = False) -> None:
         """Compare a scope's panels pair by pair, skipping the waived gaps.
 
-        The pairs are gaps, not relations: this runs where the group's own
-        account of its joiners did not hold, so a panel's neighbour is all
-        that is left to compare it against.
+        `by_relation` says whether a pair can be named as the relation it sits
+        on.  It can where every side is one panel; where the group's own
+        account of its joiners did not hold, a panel's neighbour is all there
+        is to compare it against and the finding says only that.
         """
         for gap in range(1, len(members)):
             if gap in waived_gaps:
@@ -1597,6 +1593,8 @@ class Audit:
                 self.pictures[members[gap - 1]],
                 self.pictures[members[gap]],
                 self.hard, "eq-boundary-mismatch",
+                f"sit on relation {gap} of equation scope {scope}"
+                if by_relation else
                 f"are adjacent panels {gap} and {gap + 1} of equation "
                 f"scope {scope}",
                 modulo=modulo,

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -532,6 +532,24 @@ def main() -> int:
     assert ("eq-check-off", "ADV") in waived_gap, waived_gap
     assert waived_gap_pair(waived_gap_source) == (1, 2), waived_gap
 
+    # Seeded defect: two relation glyphs in one gap.  The scope is malformed
+    # -- a side with no panel -- but the second glyph is still the second
+    # relation, and a waiver naming it must reach the gap it sits on.
+    doubled_glyph_source = (
+        "\\begin{tenkzeq}[check={signature, off={2: drafted}}]\n"
+        f"{PANELS[0]}= =\n{PANELS[1]}"
+        "\\end{tenkzeq}\n"
+    )
+    doubled_glyph = audit_rules(
+        panel(1, "open:w") + panel(2, "phys:up")
+        + "check|scope=1|relation=1|result=off|reason=drafted\n"
+        "check|scope=1|relation=2|result=off|reason=drafted\n",
+        doubled_glyph_source,
+    )
+    assert "eq-boundary-mismatch" not in [
+        rule for rule, _ in doubled_glyph
+    ], doubled_glyph
+
     # A spaced environment name opens the same equation, so its declared
     # waiver is the source's and not a forgery.
     spaced = audit_rules(
@@ -550,7 +568,7 @@ def main() -> int:
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 35 seeded group checks passed"
+        "and 36 seeded group checks passed"
     )
     return 0
 

--- a/scripts/test_tenkz_equation_audit.py
+++ b/scripts/test_tenkz_equation_audit.py
@@ -97,6 +97,31 @@ def audit_rules(log: str, source: str | None = None) -> list[tuple[str, str]]:
         return [(finding.rule, finding.severity) for finding in audit.findings]
 
 
+def waived_gap_pair(source: str) -> tuple[int, int] | None:
+    """The panels the waived-gap fixture's fallback actually compared."""
+    import re
+    from tenkz_audit import Audit
+    with tempfile.TemporaryDirectory(prefix="tenkz_equation_audit_") as tmp:
+        work = Path(tmp)
+        (work / "fixture.tex").write_text(source, encoding="utf-8")
+        (work / "fixture.tnlog").write_text(
+            panel(1, "open:w") + panel(2, "phys:up") + panel(3, "phys:up")
+            + "check|scope=1|relation=1|result=off|reason=drafted\n",
+            encoding="utf-8",
+        )
+        audit = Audit(work / "fixture.tnlog", work / "fixture.tex")
+        audit.parse_log()
+        audit.link_tex()
+        audit.check_equation_groups()
+        for finding in audit.findings:
+            if finding.rule != "eq-boundary-mismatch":
+                continue
+            match = re.search(r"pictures k(\d+) and k(\d+)", finding.msg)
+            if match is not None:
+                return int(match.group(1)), int(match.group(2))
+    return None
+
+
 def sibling_rules(separator: str) -> list[tuple[str, str]]:
     """Two mismatched pictures joined by `separator` outside every group."""
     return audit_rules(
@@ -489,6 +514,24 @@ def main() -> int:
     assert ("eq-check-drift", "HARD") in two_checks, two_checks
     assert ("eq-boundary-mismatch", "HARD") in two_checks, two_checks
 
+    # Seeded defect: `A B = C` waives its one relation, which sits on the
+    # second gap.  A waiver names a relation while a pairwise comparison walks
+    # gaps, so the fallback must skip the gap the relation is on and compare
+    # the juxtaposition -- not the reverse.
+    waived_gap_source = (
+        "\\begin{tenkzeq}[check={signature, off={1: drafted}}]\n"
+        f"{PANELS[0]}{PANELS[1]}=\n{PANELS[0]}"
+        "\\end{tenkzeq}\n"
+    )
+    waived_gap = audit_rules(
+        panel(1, "open:w") + panel(2, "phys:up") + panel(3, "phys:up")
+        + "check|scope=1|relation=1|result=off|reason=drafted\n",
+        waived_gap_source,
+    )
+    assert ("eq-unchecked", "HARD") in waived_gap, waived_gap
+    assert ("eq-check-off", "ADV") in waived_gap, waived_gap
+    assert waived_gap_pair(waived_gap_source) == (1, 2), waived_gap
+
     # A spaced environment name opens the same equation, so its declared
     # waiver is the source's and not a forgery.
     spaced = audit_rules(
@@ -507,7 +550,7 @@ def main() -> int:
     print(
         "tenkz-equation-audit: "
         f"{len(POSITIVE)} positive, {len(NEGATIVE)} negative, "
-        "and 33 seeded group checks passed"
+        "and 35 seeded group checks passed"
     )
     return 0
 


### PR DESCRIPTION
The last review finding on LionSR/TNLean#5696 landed after that PR had already merged, so its fix comes as its own change. Cherry-picked from `a3a22eb62` on the merged branch, rebased onto current main.

## The defect

A waiver names a relation by its ordinal; the fallback comparison — the one that runs when a group cannot account for its own joiners — walks gaps. The two numberings agree only where every side is one panel, which is precisely not the case in the scopes that reach the fallback.

For `A B = C` with the relation waived and the contraction record missing, the fallback skipped gap 1 — the juxtaposition it should have compared — compared gap 2, which the author had opted out of, and announced it as "relation 2", a number that equation does not have.

## The fix

The source places the glyphs, so the mapping is exact: the k-th relation glyph sits on the k-th of the gaps holding one, and `_waived_gaps` sends the waived ordinals through `sorted(relation_gaps)` before the walk. With no source there is nothing to map them through and the ordinals stand as they are, which the helper says rather than assumes.

`_compare_adjacent` now takes gaps rather than relations and its findings say so — "are adjacent panels 2 and 3 of equation scope 1" — because a comparison that runs on a group that could not account for its joiners has no relation number to offer. The closed single-panel path keeps relation numbering, where the two coincide.

## Seed

`waived_gap` in `test_tenkz_equation_audit.py`: the display above, with the panels chosen so the two readings are distinguishable — the juxtaposed pair differs, the waived pair agrees. It asserts `eq-unchecked`, the advisory waiver, and that the pair actually compared is panels 1 and 2. Pre-fix it compares the waived pair, finds nothing there, and reports no mismatch at all.

## Gates

Run one at a time on this branch; a neighbouring worktree was competing for the machine and timed two of them out on the first attempt.

- `scripts/tenkz_kernel_probes.sh --check` — 146 review regressions, 11 sugar pairs, 12 kernel record streams and pixels byte-identical
- `scripts/tenkz_golden.sh --check` — 9 event streams byte-identical
- `python3 scripts/tenkz_rmp.py check --all` — 130 targets; 90 faithful / 40 cosmetic-gap / 0 blocked; pairing 120 verified / 10 context-only
- `scripts/tenkz_corpus.sh`, `scripts/tenkz_blueprint_sweep.py` (202 pictures in 169 units, 0 hard), `tenkz_shrink.py gate` (census stable at 86), dispositions and its self-test, `tenkz_lint.py` (278 files, 0 findings), `test_tenkz_pic.py`
- `test_tenkz_equation_audit.py` at 35 seeded group checks, plus `test_tenkz_kernel_audit.py`, `test_tnlog.py`, `test_tenkz_blueprint_sweep.py`

Follows LionSR/TNLean#5696. Tracker: LionSR/tenkz#13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ4zVmMLCAAxi4ZKxcCZyg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the tenkz audit script and its equation regression tests; no runtime LaTeX kernel or security-sensitive paths are modified.
> 
> **Overview**
> Fixes **tenkz equation-group auditing** when a scope’s joiner arithmetic fails and the audit falls back to comparing adjacent panels. Waivers are keyed by **relation ordinal**, but the walk uses **gap indices**; those only line up when every side is a single panel—which is exactly when scopes often hit the fallback.
> 
> **`ScopePolicy`** now stores **`relation_order`**: one gap index per relation glyph in source order (so two `=` in one gap still give distinct ordinals 1 and 2). Closure checks compare relation count to `len(relation_order)` instead of a separate glyph count.
> 
> **`_waived_gaps`** maps waived relation numbers to the gaps their glyphs occupy via `relation_order`; the malformed-scope fallback passes those gaps into **`_compare_adjacent`**, which skips gaps instead of treating waiver ordinals as gap numbers. Example: `A B = C` with relation 1 waived must skip gap 2 and compare panels 1–2, not compare the waived pair.
> 
> **`_compare_adjacent`** messages distinguish **relation-numbered** pairs (closed, single-panel sides) from **adjacent panel** pairs on the fallback path.
> 
> Tests add **`waived_gap`** and **`doubled_glyph`** seeded cases plus **`waived_gap_pair`** to assert which panels were compared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad0dcd3d0c1a1b6208af038c1f30de3787bebbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->