### PR TITLE
refactor(MPS): lower irreducibility conjugation theorem

### DIFF
--- a/TNLean/MPS/CanonicalForm/Reduction.lean
+++ b/TNLean/MPS/CanonicalForm/Reduction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
+import TNLean.Algebra.PosSemidefSupport
 
 /-!
 # Iterated invariant-projection splitting: irreducible block decomposition
@@ -53,7 +54,7 @@ These are separate steps in the canonical-form construction.
 * Pérez-García, Verstraete, Wolf, and Cirac, Theorem Th:TIcanonical,
   proof lines 765–833.
 -/
-open scoped Matrix BigOperators
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
 
 namespace MPSTensor
 
@@ -89,6 +90,119 @@ theorem isIrreducibleTensor_smul
         simp [Matrix.mul_assoc]
       _ = 0 := hLower i
   exact (smul_eq_zero.mp h).resolve_left hc
+
+/-! ### Irreducibility under rescaled conjugation
+
+The unital normalization of an irreducible corner conjugates the letters by
+the square root of the positive transfer eigenvector.  Conjugation by an
+invertible matrix does not preserve orthogonality, so an invariant orthogonal
+projection of the conjugated tensor corresponds to an invariant *subspace* of
+the original tensor; the support projection of the transported subspace
+recovers an invariant orthogonal projection. -/
+
+/-- **Rescaled conjugation preserves tensor irreducibility.** If `B` admits
+no nontrivial invariant orthogonal projection, neither does
+`c • (X⁻¹ * B v * X)` for an invertible `X` and a nonzero scalar `c`: an
+invariant orthogonal projection `P` of the conjugated tensor transports to
+the invariant subspace of `B` spanned by the columns of `X * P`, whose
+support projection is a nontrivial invariant orthogonal projection of `B`.
+
+This is the normalization step of arXiv:1606.00608, lines 224--225, for the
+corner tensors: the rescaled unital gauge of an irreducible corner is again
+irreducible. -/
+theorem isIrreducibleTensor_smul_conj (B : MPSTensor d D)
+    (hIrr : IsIrreducibleTensor B) {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X)
+    {c : ℂ} (hc : c ≠ 0) :
+    IsIrreducibleTensor (fun v => c • (X⁻¹ * B v * X)) := by
+  classical
+  intro hHas
+  apply hIrr
+  obtain ⟨P, hPproj, hP0, hP1, hPinv⟩ := hHas
+  have hXdet : IsUnit X.det := (Matrix.isUnit_iff_isUnit_det X).mp hX
+  have hXHdet : IsUnit Xᴴ.det := by
+    rw [Matrix.det_conjTranspose]
+    exact hXdet.star
+  set Y : Matrix (Fin D) (Fin D) ℂ := X * P with hY
+  set π : Matrix (Fin D) (Fin D) ℂ :=
+    supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) with hπ
+  refine ⟨π, isOrthogonalProjection_supportProj (D := D) (ρ := Y * Yᴴ)
+    (hρ := Matrix.posSemidef_self_mul_conjTranspose Y), ?_, ?_, ?_⟩
+  · -- `π ≠ 0` because `Y ≠ 0`.
+    have hYne : Y ≠ 0 := by
+      intro h0
+      apply hP0
+      calc P = X⁻¹ * (X * P) := (Matrix.nonsing_inv_mul_cancel_left X P hXdet).symm
+        _ = 0 := by rw [← hY, h0, Matrix.mul_zero]
+    have hSne : Y * Yᴴ ≠ 0 := fun h0 =>
+      hYne (Matrix.self_mul_conjTranspose_eq_zero.mp h0)
+    exact supportProj_ne_zero_of_ne_zero (Y * Yᴴ)
+      (Matrix.posSemidef_self_mul_conjTranspose Y) hSne
+  · -- `π ≠ 1`: a nonzero vector in the kernel of `P` transports to the
+    -- kernel of `Y * Yᴴ`, hence of `π`.
+    have h1Pne : (1 : Matrix (Fin D) (Fin D) ℂ) - P ≠ 0 := by
+      intro h0
+      exact hP1 (by rw [sub_eq_zero] at h0; exact h0.symm)
+    obtain ⟨i, j, hij⟩ : ∃ i j, ((1 : Matrix (Fin D) (Fin D) ℂ) - P) i j ≠ 0 := by
+      by_contra hall
+      push Not at hall
+      exact h1Pne (Matrix.ext fun i j => hall i j)
+    set w : Fin D → ℂ := ((1 : Matrix (Fin D) (Fin D) ℂ) - P) *ᵥ Pi.single j 1 with hw
+    have hwne : w ≠ 0 := by
+      intro h0
+      apply hij
+      have := congrFun h0 i
+      simpa [hw, Matrix.mulVec, dotProduct, Pi.single_apply] using this
+    have hP1P : P * ((1 : Matrix (Fin D) (Fin D) ℂ) - P) = 0 := by
+      rw [Matrix.mul_sub, Matrix.mul_one, hPproj.2, sub_self]
+    have hPw : P *ᵥ w = 0 := by
+      rw [hw, Matrix.mulVec_mulVec, hP1P, Matrix.zero_mulVec]
+    set v : Fin D → ℂ := (Xᴴ)⁻¹ *ᵥ w with hv
+    have hXHv : Xᴴ *ᵥ v = w := by
+      rw [hv, Matrix.mulVec_mulVec, Matrix.mul_nonsing_inv Xᴴ hXHdet,
+        Matrix.one_mulVec]
+    have hvne : v ≠ 0 := by
+      intro h0
+      apply hwne
+      rw [← hXHv, h0, Matrix.mulVec_zero]
+    have hYY : Y * Yᴴ = X * (P * Xᴴ) := by
+      rw [hY, Matrix.conjTranspose_mul, hPproj.1.eq]
+      calc X * P * (P * Xᴴ) = X * (P * P * Xᴴ) := by simp only [Matrix.mul_assoc]
+        _ = X * (P * Xᴴ) := by rw [hPproj.2]
+    have hSv : (Y * Yᴴ) *ᵥ v = 0 := by
+      rw [hYY, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec, hXHv, hPw,
+        Matrix.mulVec_zero]
+    have hπv : π *ᵥ v = 0 :=
+      supportProj_mulVec_eq_zero_of_mulVec_eq_zero (Y * Yᴴ)
+        (Matrix.posSemidef_self_mul_conjTranspose Y) v hSv
+    intro h1
+    apply hvne
+    rw [← Matrix.one_mulVec v, ← h1, hπv]
+  · -- Invariance: `(1 - π) * B v * π = 0` for every letter.
+    intro u
+    have h' : ((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P = 0 := by
+      have hs : c • (((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P) = 0 := by
+        have := hPinv u
+        calc c • (((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P)
+            = (1 - P) * (c • (X⁻¹ * B u * X)) * P := by
+              rw [Matrix.mul_smul, Matrix.smul_mul]
+          _ = 0 := this
+      exact (smul_eq_zero.mp hs).resolve_left hc
+    have hinv' : X⁻¹ * B u * X * P = P * (X⁻¹ * B u * X * P) := by
+      have h'' : X⁻¹ * B u * X * P - P * (X⁻¹ * B u * X * P) = 0 := by
+        have := h'
+        rw [Matrix.sub_mul, Matrix.sub_mul, Matrix.one_mul] at this
+        rw [← this]
+        simp only [Matrix.mul_assoc]
+      exact sub_eq_zero.mp h''
+    have hGB : B u * Y = Y * (X⁻¹ * B u * X * P) := by
+      calc B u * Y = B u * X * P := by rw [hY, Matrix.mul_assoc]
+        _ = X * (X⁻¹ * (B u * X * P)) :=
+            (Matrix.mul_nonsing_inv_cancel_left X _ hXdet).symm
+        _ = X * (X⁻¹ * B u * X * P) := by simp only [Matrix.mul_assoc]
+        _ = X * (P * (X⁻¹ * B u * X * P)) := by rw [← hinv']
+        _ = Y * (X⁻¹ * B u * X * P) := by rw [hY]; simp only [Matrix.mul_assoc]
+    exact one_sub_supportProj_mul_mul_supportProj_eq_zero Y hGB
+
 
 /-! ## Auxiliary lemmas about casts and MPVs -/
 

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.StackedLayers
+import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.Channel.Peripheral.CyclicDecomposition.Decomposition
 import TNLean.Channel.Peripheral.CyclicDecomposition.LetterShift
 import TNLean.Channel.Peripheral.GroupStructure
@@ -56,8 +57,6 @@ CPSV canonical-form hypothesis; see
 
 ## Main results
 
-* `MPSTensor.isIrreducibleTensor_smul_conj`: tensor irreducibility is
-  preserved by rescaled conjugation with an invertible matrix.
 * `MPSTensor.spectralUnitalGauge_schwarz_setup`: the rescaled unital gauge of
   an irreducible corner satisfies the hypotheses of Wolf Theorem 6.6.
 * `MPOTensor.exists_displaced_invariant_projector_of_periodic_vector`: a
@@ -89,118 +88,6 @@ open scoped Matrix ComplexOrder MatrixOrder BigOperators Fin.NatCast
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-! ### Irreducibility under rescaled conjugation
-
-The unital normalization of an irreducible corner conjugates the letters by
-the square root of the positive transfer eigenvector.  Conjugation by an
-invertible matrix does not preserve orthogonality, so an invariant orthogonal
-projection of the conjugated tensor corresponds to an invariant *subspace* of
-the original tensor; the support projection of the transported subspace
-recovers an invariant orthogonal projection. -/
-
-/-- **Rescaled conjugation preserves tensor irreducibility.** If `B` admits
-no nontrivial invariant orthogonal projection, neither does
-`c • (X⁻¹ * B v * X)` for an invertible `X` and a nonzero scalar `c`: an
-invariant orthogonal projection `P` of the conjugated tensor transports to
-the invariant subspace of `B` spanned by the columns of `X * P`, whose
-support projection is a nontrivial invariant orthogonal projection of `B`.
-
-This is the normalization step of arXiv:1606.00608, lines 224--225, for the
-corner tensors: the rescaled unital gauge of an irreducible corner is again
-irreducible. -/
-theorem isIrreducibleTensor_smul_conj (B : MPSTensor d D)
-    (hIrr : IsIrreducibleTensor B) {X : Matrix (Fin D) (Fin D) ℂ} (hX : IsUnit X)
-    {c : ℂ} (hc : c ≠ 0) :
-    IsIrreducibleTensor (fun v => c • (X⁻¹ * B v * X)) := by
-  classical
-  intro hHas
-  apply hIrr
-  obtain ⟨P, hPproj, hP0, hP1, hPinv⟩ := hHas
-  have hXdet : IsUnit X.det := (Matrix.isUnit_iff_isUnit_det X).mp hX
-  have hXHdet : IsUnit Xᴴ.det := by
-    rw [Matrix.det_conjTranspose]
-    exact hXdet.star
-  set Y : Matrix (Fin D) (Fin D) ℂ := X * P with hY
-  set π : Matrix (Fin D) (Fin D) ℂ :=
-    supportProj (D := D) (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) with hπ
-  refine ⟨π, isOrthogonalProjection_supportProj (D := D) (ρ := Y * Yᴴ)
-    (hρ := Matrix.posSemidef_self_mul_conjTranspose Y), ?_, ?_, ?_⟩
-  · -- `π ≠ 0` because `Y ≠ 0`.
-    have hYne : Y ≠ 0 := by
-      intro h0
-      apply hP0
-      calc P = X⁻¹ * (X * P) := (Matrix.nonsing_inv_mul_cancel_left X P hXdet).symm
-        _ = 0 := by rw [← hY, h0, Matrix.mul_zero]
-    have hSne : Y * Yᴴ ≠ 0 := fun h0 =>
-      hYne (Matrix.self_mul_conjTranspose_eq_zero.mp h0)
-    exact supportProj_ne_zero_of_ne_zero (Y * Yᴴ)
-      (Matrix.posSemidef_self_mul_conjTranspose Y) hSne
-  · -- `π ≠ 1`: a nonzero vector in the kernel of `P` transports to the
-    -- kernel of `Y * Yᴴ`, hence of `π`.
-    have h1Pne : (1 : Matrix (Fin D) (Fin D) ℂ) - P ≠ 0 := by
-      intro h0
-      exact hP1 (by rw [sub_eq_zero] at h0; exact h0.symm)
-    obtain ⟨i, j, hij⟩ : ∃ i j, ((1 : Matrix (Fin D) (Fin D) ℂ) - P) i j ≠ 0 := by
-      by_contra hall
-      push Not at hall
-      exact h1Pne (Matrix.ext fun i j => hall i j)
-    set w : Fin D → ℂ := ((1 : Matrix (Fin D) (Fin D) ℂ) - P) *ᵥ Pi.single j 1 with hw
-    have hwne : w ≠ 0 := by
-      intro h0
-      apply hij
-      have := congrFun h0 i
-      simpa [hw, Matrix.mulVec, dotProduct, Pi.single_apply] using this
-    have hP1P : P * ((1 : Matrix (Fin D) (Fin D) ℂ) - P) = 0 := by
-      rw [Matrix.mul_sub, Matrix.mul_one, hPproj.2, sub_self]
-    have hPw : P *ᵥ w = 0 := by
-      rw [hw, Matrix.mulVec_mulVec, hP1P, Matrix.zero_mulVec]
-    set v : Fin D → ℂ := (Xᴴ)⁻¹ *ᵥ w with hv
-    have hXHv : Xᴴ *ᵥ v = w := by
-      rw [hv, Matrix.mulVec_mulVec, Matrix.mul_nonsing_inv Xᴴ hXHdet,
-        Matrix.one_mulVec]
-    have hvne : v ≠ 0 := by
-      intro h0
-      apply hwne
-      rw [← hXHv, h0, Matrix.mulVec_zero]
-    have hYY : Y * Yᴴ = X * (P * Xᴴ) := by
-      rw [hY, Matrix.conjTranspose_mul, hPproj.1.eq]
-      calc X * P * (P * Xᴴ) = X * (P * P * Xᴴ) := by simp only [Matrix.mul_assoc]
-        _ = X * (P * Xᴴ) := by rw [hPproj.2]
-    have hSv : (Y * Yᴴ) *ᵥ v = 0 := by
-      rw [hYY, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec, hXHv, hPw,
-        Matrix.mulVec_zero]
-    have hπv : π *ᵥ v = 0 :=
-      supportProj_mulVec_eq_zero_of_mulVec_eq_zero (Y * Yᴴ)
-        (Matrix.posSemidef_self_mul_conjTranspose Y) v hSv
-    intro h1
-    apply hvne
-    rw [← Matrix.one_mulVec v, ← h1, hπv]
-  · -- Invariance: `(1 - π) * B v * π = 0` for every letter.
-    intro u
-    have h' : ((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P = 0 := by
-      have hs : c • (((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P) = 0 := by
-        have := hPinv u
-        calc c • (((1 : Matrix (Fin D) (Fin D) ℂ) - P) * (X⁻¹ * B u * X) * P)
-            = (1 - P) * (c • (X⁻¹ * B u * X)) * P := by
-              rw [Matrix.mul_smul, Matrix.smul_mul]
-          _ = 0 := this
-      exact (smul_eq_zero.mp hs).resolve_left hc
-    have hinv' : X⁻¹ * B u * X * P = P * (X⁻¹ * B u * X * P) := by
-      have h'' : X⁻¹ * B u * X * P - P * (X⁻¹ * B u * X * P) = 0 := by
-        have := h'
-        rw [Matrix.sub_mul, Matrix.sub_mul, Matrix.one_mul] at this
-        rw [← this]
-        simp only [Matrix.mul_assoc]
-      exact sub_eq_zero.mp h''
-    have hGB : B u * Y = Y * (X⁻¹ * B u * X * P) := by
-      calc B u * Y = B u * X * P := by rw [hY, Matrix.mul_assoc]
-        _ = X * (X⁻¹ * (B u * X * P)) :=
-            (Matrix.mul_nonsing_inv_cancel_left X _ hXdet).symm
-        _ = X * (X⁻¹ * B u * X * P) := by simp only [Matrix.mul_assoc]
-        _ = X * (P * (X⁻¹ * B u * X * P)) := by rw [← hinv']
-        _ = Y * (X⁻¹ * B u * X * P) := by rw [hY]; simp only [Matrix.mul_assoc]
-    exact one_sub_supportProj_mul_mul_supportProj_eq_zero Y hGB
 
 /-! ### The unital gauge of a corner satisfies the Wolf Theorem 6.6 hypotheses -/
 

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.CyclicProjector
 import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.CanonicalForm.Reduction
 
 /-!
 # Full-support CPSV canonical forms
@@ -21,7 +21,7 @@ formalize the proposition's spectral derivation from `IsMPU`. See
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators Matrix.Norms.Operator
 
 namespace MPSTensor
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -389,11 +389,19 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}\leanok
     \uses{def:cpsv_canonical_form,
         thm:irreducible_tensor_smul_conj}
-    The total-dimension bound and positivity of every retained block dimension
-    force this block to be the only retained block.  The ambient coisometry is
-    square, hence unitary.  The reconstruction is therefore a nonzero scalar
-    multiple and unitary conjugate of the normal block, which preserves
-    irreducibility.
+    If $k$ is the active block with $D_k=D$, the total-dimension bound gives
+    \begin{align}
+      D = D_k \leq \sum_{j=1}^r D_j \leq D.
+    \end{align}
+    Since every retained block dimension is positive, these equalities force
+    $k$ to be the only retained block.  After reindexing its bond coordinates,
+    the ambient coisometry $U$ is square, hence unitary, and reconstruction reads
+    \begin{align}
+      A^i = U^*\bigl(\mu_k B^i\bigr)U,
+    \end{align}
+    where $B$ is the reindexed normal block and $\mu_k\ne0$.  Thus
+    Theorem~\ref{thm:irreducible_tensor_smul_conj} transports irreducibility of
+    $B$ through the nonzero rescaling and unitary conjugation.
 \end{proof}
 
 \begin{theorem}[Unique active block with full support]
@@ -407,9 +415,13 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}\leanok
     \uses{thm:mpu_active_block_ambient_irreducible}
-    The full-support sum over the singleton active family says that its unique
-    block has dimension $D$.  Apply
-    Theorem~\ref{thm:mpu_active_block_ambient_irreducible}.
+    Let $k$ be the unique active block.  The singleton sum and full-support
+    identity give
+    \begin{align}
+      \sum_{j\in\mathrm{Active}} D_j = D_k = D.
+    \end{align}
+    Thus $k$ has ambient bond dimension, so
+    Theorem~\ref{thm:mpu_active_block_ambient_irreducible} applies.
 \end{proof}
 
 \begin{theorem}[Normality of a unique full-support active block]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -381,6 +381,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_active_block_ambient_irreducible}
     \lean{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_active_dim_eq}
     \leanok
+    \uses{def:cpsv_canonical_form}
     If an active block has bond dimension $D$, then the ambient tensor $A$ is
     irreducible.
 \end{theorem}


### PR DESCRIPTION
## Summary
- move `MPSTensor.isIrreducibleTensor_smul_conj` from the broad MPDO cyclic-projector module into `MPS/CanonicalForm/Reduction`
- retain the declaration name and downstream API while removing the duplicate old declaration
- narrow MPU canonical-form imports to canonical-form modules
- record `def:cpsv_canonical_form` as both a statement and proof dependency where the canonical-form data and fields are used

Follow-up to merged PR #5749 and issue #5738. This addresses the late review threads:
- https://github.com/LionSR/TNLean/pull/5749#discussion_r3742181545
- https://github.com/LionSR/TNLean/pull/5749#discussion_r3742181547

## Checks
- `lake env lean TNLean/MPS/CanonicalForm/Reduction.lean`
- `lake build TNLean.MPS.CanonicalForm.Reduction`
- `lake env lean TNLean/MPS/MPDO/CyclicProjector.lean`
- `lake env lean TNLean/MPS/MPU/CanonicalForm.lean`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- targeted blueprint synchronization
- reader-facing prose check
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and import cleanup with no behavioral change to the theorem; MPU blueprint text is documentation-only.
> 
> **Overview**
> **Moves** `isIrreducibleTensor_smul_conj` from `MPDO/CyclicProjector` into `MPS/CanonicalForm/Reduction`, next to other irreducibility lemmas, with the same API and a new `PosSemidefSupport` import for the proof.
> 
> `CyclicProjector` now imports `Reduction` and drops the duplicate theorem; `MPU/CanonicalForm` no longer pulls in the MPDO cyclic-projector stack and only imports canonical-form modules.
> 
> Blueprint MPU proofs for ambient-dimensional active blocks are expanded (dimension equalities, unitary reconstruction) and **`def:cpsv_canonical_form`** is recorded as a dependency where canonical-form data is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9dcd4ea739e6c1a828f4ed38a9e81047e1529f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->