### PR TITLE
feat(MPS): promote WordTupleSpanTop gauge invariance

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.FundamentalTheorem.ProductAlgebra
 import TNLean.MPS.MPDO.PerCopyHorizontalCF
+import TNLean.MPS.SharedInfra.WordTupleGauge
 import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 import Mathlib.LinearAlgebra.Prod
 import Mathlib.RingTheory.Noetherian.Defs
@@ -63,46 +64,6 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d : ℕ} {r : ℕ} {dim : Fin r → ℕ}
-
-/-- The tuple of length-`L` word evaluations across all blocks. -/
-def wordTuple
-    (A : (k : Fin r) → MPSTensor d (dim k))
-    (L : ℕ) (w : Fin L → Fin d) :
-    (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ :=
-  fun k => evalWord (A k) (List.ofFn w)
-
-/-- Finite-length span condition on the product algebra of block matrices. -/
-def WordTupleSpanTop
-    (A : (k : Fin r) → MPSTensor d (dim k))
-    (L : ℕ) : Prop :=
-  Submodule.span ℂ (Set.range (wordTuple A L)) = ⊤
-
-/-- Reindexing the common physical alphabet by an equivalence preserves the
-simultaneous word-tuple span.
-
-This is the index transport used in the simultaneous BNT blocking of
-arXiv:1606.00608, lines 317--345. -/
-theorem wordTupleSpanTop_reindexPhysical_equiv {d' : ℕ}
-    (e : Fin d' ≃ Fin d) (A : (k : Fin r) → MPSTensor d (dim k)) (L : ℕ) :
-    WordTupleSpanTop (fun k ↦ reindexPhysical e (A k)) L ↔
-      WordTupleSpanTop A L := by
-  unfold WordTupleSpanTop
-  have hRange :
-      Set.range (wordTuple (fun k ↦ reindexPhysical e (A k)) L) =
-        Set.range (wordTuple A L) := by
-    ext X
-    constructor
-    · rintro ⟨w, rfl⟩
-      refine ⟨fun i ↦ e (w i), ?_⟩
-      funext k
-      simp [wordTuple, evalWord_reindexPhysical, List.map_ofFn,
-        Function.comp_def]
-    · rintro ⟨w, rfl⟩
-      refine ⟨fun i ↦ e.symm (w i), ?_⟩
-      funext k
-      simp [wordTuple, evalWord_reindexPhysical, List.map_ofFn,
-        Function.comp_def]
-  rw [hRange]
 
 /-- A simultaneous one-letter span makes every member of the tensor family
 injective.

--- a/TNLean/MPS/MPDO/CPSVSharpBlocking.lean
+++ b/TNLean/MPS/MPDO/CPSVSharpBlocking.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.CanonicalForm.ActiveBNTRefinement
 import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 import TNLean.MPS.MPDO.SourceBNTBlocking
+import TNLean.MPS.SharedInfra.WordTupleGauge
 
 /-!
 # Sharp blocking bound for literal CPSV canonical form
@@ -33,49 +34,6 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-private theorem wordTupleSpanTop_of_family_gaugeEquiv
-    {g L : ℕ} {dim : Fin g → ℕ}
-    {A B : (j : Fin g) → MPSTensor d (dim j)}
-    (hSpan : WordTupleSpanTop A L)
-    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
-    WordTupleSpanTop B L := by
-  classical
-  choose X hX using hGauge
-  unfold WordTupleSpanTop at hSpan ⊢
-  apply top_unique
-  intro M _
-  let M' : (j : Fin g) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ := fun j =>
-    (↑((X j)⁻¹) : Matrix _ _ ℂ) * M j * (X j : Matrix _ _ ℂ)
-  have hM' : M' ∈ Submodule.span ℂ (Set.range (wordTuple A L)) := by
-    rw [hSpan]
-    exact Submodule.mem_top
-  obtain ⟨c, hc⟩ := (Submodule.mem_span_range_iff_exists_fun ℂ).mp hM'
-  apply (Submodule.mem_span_range_iff_exists_fun ℂ).2
-  refine ⟨c, ?_⟩
-  funext j
-  have hcj : (∑ w, c w • evalWord (A j) (List.ofFn w)) = M' j := by
-    simpa [wordTuple, Fintype.linearCombination_apply] using congrFun hc j
-  have hGoal : (∑ w, c w • evalWord (B j) (List.ofFn w)) = M j := by
-    calc
-      (∑ w, c w • evalWord (B j) (List.ofFn w)) =
-          ∑ w, c w • ((X j : Matrix _ _ ℂ) *
-            evalWord (A j) (List.ofFn w) *
-            (↑((X j)⁻¹) : Matrix _ _ ℂ)) := by
-        apply Finset.sum_congr rfl
-        intro w _
-        rw [evalWord_gauge (X j) (hX j)]
-      _ = (X j : Matrix _ _ ℂ) *
-          (∑ w, c w • evalWord (A j) (List.ofFn w)) *
-          (↑((X j)⁻¹) : Matrix _ _ ℂ) := by
-        rw [Matrix.mul_sum, Finset.sum_mul]
-        apply Finset.sum_congr rfl
-        intro w _
-        simp
-      _ = (X j : Matrix _ _ ℂ) * M' j *
-          (↑((X j)⁻¹) : Matrix _ _ ℂ) := by rw [hcj]
-      _ = M j := by simp [M', Matrix.mul_assoc]
-  simpa [wordTuple] using hGoal
 
 /-- A CPSV basis of normal tensors with total representative bond dimension at most `K`
 has simultaneous product-algebra span at a positive length at most `3 * K ^ 5`.
@@ -142,8 +100,7 @@ theorem IsCPSVBasisOfNormalTensors.exists_positive_wordTupleSpanTop_le_three_cap
     · have hPreparedSpan :=
         wordTupleSpanTop_of_card_eq_one_of_isNBlkInjective
           prepared hCountOne hBlk0
-      exact wordTupleSpanTop_of_family_gaugeEquiv hPreparedSpan
-        (fun j => (hGauge j).symm)
+      exact wordTupleSpanTop_of_family_gaugeEquiv_symm hPreparedSpan hGauge
   · have hCountTwo : 2 ≤ g := by omega
     have hBlk1 : ∀ j, IsNBlkInjective (prepared j) (K ^ 4 + 1) := by
       intro j
@@ -167,8 +124,7 @@ theorem IsCPSVBasisOfNormalTensors.exists_positive_wordTupleSpanTop_le_three_cap
         hBlk0 hBlk1 hBlk3 hK4pos hCountTwo
     have hSpan : WordTupleSpanTop B
         ((g - 1) * ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1)))) :=
-      wordTupleSpanTop_of_family_gaugeEquiv hPreparedSpan
-        (fun j => (hGauge j).symm)
+      wordTupleSpanTop_of_family_gaugeEquiv_symm hPreparedSpan hGauge
     refine ⟨(g - 1) * ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1))),
       Nat.mul_pos (by omega) (by omega), ?_, hSpan⟩
     have hCountLeSum : g ≤ ∑ j, dim j := by

--- a/TNLean/MPS/SharedInfra.lean
+++ b/TNLean/MPS/SharedInfra.lean
@@ -15,3 +15,4 @@ import TNLean.MPS.SharedInfra.KrausAdjointSetup
 import TNLean.MPS.SharedInfra.Scaling
 import TNLean.MPS.SharedInfra.SectorCompression
 import TNLean.MPS.SharedInfra.SectorDecomposition
+import TNLean.MPS.SharedInfra.WordTupleGauge

--- a/TNLean/MPS/SharedInfra/WordTupleGauge.lean
+++ b/TNLean/MPS/SharedInfra/WordTupleGauge.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Defs
+import Mathlib.LinearAlgebra.Finsupp.LinearCombination
+
+/-!
+# Gauge transport for simultaneous MPS word spans
+
+This module defines the fixed-length tuple of word evaluations for a block family and proves
+that spanning the product of the block matrix algebras is invariant under an independent
+invertible virtual gauge in every block.  The gauges need not be unitary.
+
+The nonunitary form is needed in the normalization route for the block-separation argument of
+Pérez-García--Verstraete--Wolf--Cirac: one may establish the BNT separation certificate after
+gauging each block to a left-canonical prepared representative, then transport that certificate
+back to the source unital gauge carrying its positive dual fixed point.  This transport is only
+one ingredient of that route; it does not by itself remove the remaining normalization
+hypotheses from the parent-Hamiltonian theorem.
+
+## Main declarations
+
+* `wordTuple` — simultaneous length-`L` word evaluation in every block.
+* `WordTupleSpanTop` — the tuples span the full product matrix algebra.
+* `wordTupleSpanTop_iff_of_family_gaugeEquiv` — invariance under blockwise invertible gauges.
+
+## References
+
+* Pérez-García, Verstraete, Wolf, Cirac, quant-ph/0608197, lines 742--763 and 1424--1456.
+* Cirac, Pérez-García, Schuch, Verstraete, arXiv:1606.00608, lines 317--345.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ} {r : ℕ} {dim : Fin r → ℕ}
+
+/-- The tuple of length-`L` word evaluations across all blocks. -/
+def wordTuple
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (L : ℕ) (w : Fin L → Fin d) :
+    (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ :=
+  fun k => evalWord (A k) (List.ofFn w)
+
+/-- Finite-length span condition on the product algebra of block matrices. -/
+def WordTupleSpanTop
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (L : ℕ) : Prop :=
+  Submodule.span ℂ (Set.range (wordTuple A L)) = ⊤
+
+/-- Reindexing the common physical alphabet by an equivalence preserves the
+simultaneous word-tuple span.
+
+This is the index transport used in the simultaneous BNT blocking of
+arXiv:1606.00608, lines 317--345. -/
+theorem wordTupleSpanTop_reindexPhysical_equiv {d' : ℕ}
+    (e : Fin d' ≃ Fin d) (A : (k : Fin r) → MPSTensor d (dim k)) (L : ℕ) :
+    WordTupleSpanTop (fun k ↦ reindexPhysical e (A k)) L ↔
+      WordTupleSpanTop A L := by
+  unfold WordTupleSpanTop
+  have hRange :
+      Set.range (wordTuple (fun k ↦ reindexPhysical e (A k)) L) =
+        Set.range (wordTuple A L) := by
+    ext X
+    constructor
+    · rintro ⟨w, rfl⟩
+      refine ⟨fun i ↦ e (w i), ?_⟩
+      funext k
+      simp [wordTuple, evalWord_reindexPhysical, List.map_ofFn,
+        Function.comp_def]
+    · rintro ⟨w, rfl⟩
+      refine ⟨fun i ↦ e.symm (w i), ?_⟩
+      funext k
+      simp [wordTuple, evalWord_reindexPhysical, List.map_ofFn,
+        Function.comp_def]
+  rw [hRange]
+
+/-- A full simultaneous word-tuple span is preserved by independent invertible
+virtual gauges in the blocks; no gauge is assumed unitary.
+
+This is the forward transport used to pass a BNT separation certificate from one
+normalization to another while preserving the block-family indices and bond dimensions.
+In the PGVWC07 normalization route it transports the certificate from a left-canonical
+prepared family back to the source unital/dual-fixed-point gauge. -/
+theorem wordTupleSpanTop_of_family_gaugeEquiv
+    {A B : (j : Fin r) → MPSTensor d (dim j)} {L : ℕ}
+    (hSpan : WordTupleSpanTop A L)
+    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
+    WordTupleSpanTop B L := by
+  classical
+  choose X hX using hGauge
+  unfold WordTupleSpanTop at hSpan ⊢
+  apply top_unique
+  intro M _
+  let M' : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ := fun j =>
+    (↑((X j)⁻¹) : Matrix _ _ ℂ) * M j * (X j : Matrix _ _ ℂ)
+  have hM' : M' ∈ Submodule.span ℂ (Set.range (wordTuple A L)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  obtain ⟨c, hc⟩ := (Submodule.mem_span_range_iff_exists_fun ℂ).mp hM'
+  apply (Submodule.mem_span_range_iff_exists_fun ℂ).2
+  refine ⟨c, ?_⟩
+  funext j
+  have hcj : (∑ w, c w • evalWord (A j) (List.ofFn w)) = M' j := by
+    simpa [wordTuple, Fintype.linearCombination_apply] using congrFun hc j
+  have hGoal : (∑ w, c w • evalWord (B j) (List.ofFn w)) = M j := by
+    calc
+      (∑ w, c w • evalWord (B j) (List.ofFn w)) =
+          ∑ w, c w • ((X j : Matrix _ _ ℂ) *
+            evalWord (A j) (List.ofFn w) *
+            (↑((X j)⁻¹) : Matrix _ _ ℂ)) := by
+        apply Finset.sum_congr rfl
+        intro w _
+        rw [evalWord_gauge (X j) (hX j)]
+      _ = (X j : Matrix _ _ ℂ) *
+          (∑ w, c w • evalWord (A j) (List.ofFn w)) *
+          (↑((X j)⁻¹) : Matrix _ _ ℂ) := by
+        rw [Matrix.mul_sum, Finset.sum_mul]
+        apply Finset.sum_congr rfl
+        intro w _
+        simp
+      _ = (X j : Matrix _ _ ℂ) * M' j *
+          (↑((X j)⁻¹) : Matrix _ _ ℂ) := by rw [hcj]
+      _ = M j := by simp [M', Matrix.mul_assoc]
+  simpa [wordTuple] using hGoal
+
+/-- A full simultaneous word-tuple span can be transported against a given
+blockwise invertible gauge relation.
+
+This is the directional form used when the certificate is known in the target gauge and is
+needed in the source gauge carrying the PGVWC07 positive dual fixed point. -/
+theorem wordTupleSpanTop_of_family_gaugeEquiv_symm
+    {A B : (j : Fin r) → MPSTensor d (dim j)} {L : ℕ}
+    (hSpan : WordTupleSpanTop B L)
+    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
+    WordTupleSpanTop A L :=
+  wordTupleSpanTop_of_family_gaugeEquiv hSpan (fun j ↦ (hGauge j).symm)
+
+/-- Simultaneous fixed-length word tuples span the product matrix algebra before a
+blockwise invertible gauge change if and only if they span it afterwards.
+
+The equivalence is nonunitary and preserves the original block-family indexing and every
+block bond dimension.  It supports transport between a left-canonical prepared gauge and
+the source unital/dual-fixed-point gauge in the PGVWC07 separation argument; further
+normalization-dependent parent-Hamiltonian steps remain separate. -/
+theorem wordTupleSpanTop_iff_of_family_gaugeEquiv
+    {A B : (j : Fin r) → MPSTensor d (dim j)} {L : ℕ}
+    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
+    WordTupleSpanTop A L ↔ WordTupleSpanTop B L :=
+  ⟨fun hSpan ↦ wordTupleSpanTop_of_family_gaugeEquiv hSpan hGauge,
+    fun hSpan ↦ wordTupleSpanTop_of_family_gaugeEquiv_symm hSpan hGauge⟩
+
+end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt_block_injective_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_block_injective_form.tex
@@ -215,7 +215,7 @@ apply it to coefficient-form and sector BNTs.
         thm:exact_pow_four_block_injectivity_normal_left_canonical,
         thm:wordspan_blk_inj_succ,
         lem:bnt_direct_sum_block_separation_word_span,
-        lem:gauge_invariance_block_injective}
+        thm:word_tuple_span_gauge_invariance}
     Put every representative in its trace-preserving Perron gauge. Since
     $D_j\leq\sum_kD_k\leq K$, quantum Wielandt and homogeneous-span
     propagation make every representative block-injective at $K^4$,

--- a/blueprint/src/chapter/ch10_bnt_block_injective_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_block_injective_form.tex
@@ -33,8 +33,8 @@ apply it to coefficient-form and sector BNTs.
     condition of \cite[lines~2113--2117]{Cirac2021Matrix}.
 \end{definition}
 
-\begin{lemma}[Gauge invariance of simultaneous fixed-length product spans]
-    \label{lem:word_tuple_span_gauge_invariance}
+\begin{theorem}[Gauge invariance of simultaneous fixed-length product spans]
+    \label{thm:word_tuple_span_gauge_invariance}
     \lean{MPSTensor.wordTupleSpanTop_of_family_gaugeEquiv}
     \lean{MPSTensor.wordTupleSpanTop_of_family_gaugeEquiv_symm}
     \lean{MPSTensor.wordTupleSpanTop_iff_of_family_gaugeEquiv}
@@ -43,10 +43,9 @@ apply it to coefficient-form and sector BNTs.
     Let $(A_j)_{j=1}^g$ and $(B_j)_{j=1}^g$ be tensor families with the same
     physical dimension and the same bond dimension $D_j$ in each labelled
     block. Suppose that for every $j$ there is an arbitrary invertible matrix
-    $X_j\in\GL_{D_j}(\C)$ such that
+    $X_j\in\GL_{D_j}(\C)$ such that, for every physical index $i$,
     \begin{align}
-        B_j^i&=X_jA_j^iX_j^{-1}
-        \qquad\text{for every physical index }i.
+        B_j^i&=X_jA_j^iX_j^{-1}.
         \notag
     \end{align}
     Then, at every fixed length $L$,
@@ -64,7 +63,7 @@ apply it to coefficient-form and sector BNTs.
     unital gauge carrying a positive dual fixed point. This supplies only the
     simultaneous-span transport; the subsequent source-gauge boundary and
     parent-Hamiltonian arguments are separate.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch10_bnt_block_injective_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_block_injective_form.tex
@@ -6,6 +6,7 @@ apply it to coefficient-form and sector BNTs.
 
 \begin{definition}[Fixed-length block-injective canonical-form condition]
     \label{def:blockwise_product_word_span}
+    \lean{MPSTensor.wordTuple}
     \lean{MPSTensor.WordTupleSpanTop}
     \leanok
     For a fixed blocked length $m$, the fixed-length form of the
@@ -31,6 +32,55 @@ apply it to coefficient-form and sector BNTs.
     This is the fixed-length form of the block-injective canonical-form
     condition of \cite[lines~2113--2117]{Cirac2021Matrix}.
 \end{definition}
+
+\begin{lemma}[Gauge invariance of simultaneous fixed-length product spans]
+    \label{lem:word_tuple_span_gauge_invariance}
+    \lean{MPSTensor.wordTupleSpanTop_of_family_gaugeEquiv}
+    \lean{MPSTensor.wordTupleSpanTop_of_family_gaugeEquiv_symm}
+    \lean{MPSTensor.wordTupleSpanTop_iff_of_family_gaugeEquiv}
+    \leanok
+    \uses{def:blockwise_product_word_span, def:gauge_equiv}
+    Let $(A_j)_{j=1}^g$ and $(B_j)_{j=1}^g$ be tensor families with the same
+    physical dimension and the same bond dimension $D_j$ in each labelled
+    block. Suppose that for every $j$ there is an arbitrary invertible matrix
+    $X_j\in\GL_{D_j}(\C)$ such that
+    \begin{align}
+        B_j^i&=X_jA_j^iX_j^{-1}
+        \qquad\text{for every physical index }i.
+        \notag
+    \end{align}
+    Then, at every fixed length $L$,
+    \begin{align}
+        \spn\{(A_1^\omega,\ldots,A_g^\omega):|\omega|=L\}
+          =\prod_{j=1}^g\MN{D_j}
+        \quad\Longleftrightarrow\quad
+        \spn\{(B_1^\omega,\ldots,B_g^\omega):|\omega|=L\}
+          =\prod_{j=1}^g\MN{D_j}.
+        \notag
+    \end{align}
+    Both directions hold for general invertible gauges; no unitarity condition
+    is imposed. In particular, a separation certificate proved after passing
+    to left-canonical representatives can be transported back to a source
+    unital gauge carrying a positive dual fixed point. This supplies only the
+    simultaneous-span transport; the subsequent source-gauge boundary and
+    parent-Hamiltonian arguments are separate.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:eval_word_gauge}
+    Given a target tuple $(M_j)_j$, conjugate it backwards to
+    $(X_j^{-1}M_jX_j)_j$. If the word tuples of $(A_j)_j$ span the product
+    algebra, one common coefficient family $(c_\omega)_\omega$ expresses this
+    conjugated tuple. Gauge covariance of word evaluation then gives
+    \begin{align}
+        \sum_{|\omega|=L}c_\omega B_j^\omega
+          &=X_j\left(\sum_{|\omega|=L}c_\omega A_j^\omega\right)X_j^{-1}
+          =M_j
+    \end{align}
+    for every $j$. Thus the $(B_j)_j$ word tuples span the product algebra.
+    Replacing every $X_j$ by $X_j^{-1}$ proves the reverse implication.
+\end{proof}
 
 \begin{lemma}[Direct-sum block injectivity at the source length]
     \label{lem:bnt_direct_sum_block_separation_word_span}


### PR DESCRIPTION
## Summary

- move the exact `wordTuple` / `WordTupleSpanTop` definitions into shared MPS infrastructure
- prove nonunitary block-family gauge transport in both directions and as an iff, preserving each block index and bond dimension
- refactor `CPSVSharpBlocking` to use the shared reverse-direction transport instead of its private duplicate
- document the intended normalization use: transport BNT separation certificates between a left-canonical prepared gauge and the source unital gauge with positive dual fixed point

## Exact shared statements

```lean
theorem wordTupleSpanTop_of_family_gaugeEquiv
    {A B : (j : Fin r) → MPSTensor d (dim j)} {L : ℕ}
    (hSpan : WordTupleSpanTop A L)
    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
    WordTupleSpanTop B L

theorem wordTupleSpanTop_of_family_gaugeEquiv_symm
    {A B : (j : Fin r) → MPSTensor d (dim j)} {L : ℕ}
    (hSpan : WordTupleSpanTop B L)
    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
    WordTupleSpanTop A L

theorem wordTupleSpanTop_iff_of_family_gaugeEquiv
    {A B : (j : Fin r) → MPSTensor d (dim j)} {L : ℕ}
    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
    WordTupleSpanTop A L ↔ WordTupleSpanTop B L
```

## Validation

- `lake build TNLean.MPS.SharedInfra.WordTupleGauge TNLean.MPS.MPDO.BiCFDerivation.Core TNLean.MPS.MPDO.CPSVSharpBlocking`
- oversized Lean-file policy
- numbered-module policy
- generated import-aggregator coverage
- forbidden proof-integrity token check
- `git diff --check`

## Review requested

Please review both source faithfulness (especially the PGVWC07 normalization role and the explicit statement that this does not complete the whole normalization theorem) and proof correctness/maintainability.

Closes #5755
Refs #5751

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proofs are relocated and deduplicated with no changes to auth, data, or runtime behavior; risk is limited to Mathlib proof maintenance and import wiring.
> 
> **Overview**
> **Centralizes** `wordTuple`, `WordTupleSpanTop`, and physical reindexing transport in `TNLean.MPS.SharedInfra.WordTupleGauge`, wired through the `SharedInfra` aggregator, and **removes** the duplicate definitions from `BiCFDerivation.Core`.
> 
> The new module proves that a full simultaneous product-algebra span at fixed length is **invariant under blockwise invertible gauges** (not necessarily unitary): forward transport (`wordTupleSpanTop_of_family_gaugeEquiv`), reverse transport (`wordTupleSpanTop_of_family_gaugeEquiv_symm`), and an iff (`wordTupleSpanTop_iff_of_family_gaugeEquiv`). **`CPSVSharpBlocking`** drops its private gauge lemma and calls the shared reverse transport when moving a separation certificate from left-canonical prepared blocks back to the source family.
> 
> The blueprint chapter adds **Theorem** `word_tuple_span_gauge_invariance` and links `wordTuple` in the definition; the sharp CPSV span proof now cites that theorem instead of a separate gauge-invariance lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e2ce526d8fcb0cfa0e41d7c6c2d8240e1a0b2c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->