### PR TITLE
feat(Algebra): determine nonzero spectrum from shifted trace powers

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -60,6 +60,7 @@ import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.RectangularChoi
 import TNLean.Algebra.ScalarCommutant
 import TNLean.Algebra.ScalarPowerSumIdentity
+import TNLean.Algebra.ShiftedTracePowerSpectrum
 import TNLean.Algebra.SkolemNoether
 import TNLean.Algebra.SkolemNoetherUnitary
 import TNLean.Algebra.SpinCover

--- a/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
+++ b/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.TracePowerCharPoly
+import Mathlib.Analysis.Complex.Polynomial.Basic
+import Mathlib.FieldTheory.IsAlgClosed.Spectrum
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
+
+/-!
+# Trace Powers Above One Determine the Nonzero Spectrum
+
+For a square complex matrix `A`, suppose `tr(A^k) = 1` for every `k > 1`.
+Then the nonzero part of the spectrum is exactly `{1}`. This is the precise
+power-sum consequence used in arXiv:1703.09188, Proposition
+`prop:normal-tensor`, lines 349--354.
+
+The proof applies the all-positive-moment characteristic-polynomial theorem
+to `A ^ 2` and `A ^ 3`. Spectral mapping then gives, for each nonzero spectral
+value `μ`, both `μ ^ 2 = 1` and `μ ^ 3 = 1`, hence `μ = 1`. Applying spectral
+mapping in the reverse direction to the spectral value `1` of `A ^ 2` proves
+that `1` itself occurs in the spectrum of `A`.
+
+No positivity, normality, diagonalizability, or first-moment hypothesis is
+used.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1703.09188,
+  Proposition `prop:normal-tensor`, lines 349--354
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2016] arXiv:1606.00608,
+  Lemma A.5, lines 1155--1163
+-/
+
+open scoped Matrix
+open Polynomial
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- A moment hypothesis for exponents above one becomes an all-positive-moment
+hypothesis after replacing `A` by `A ^ m`, provided `m > 1`. -/
+theorem forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt
+    (A : Matrix n n ℂ)
+    (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1)
+    (m : ℕ) (hm : 1 < m) :
+    ∀ k : ℕ, 0 < k → trace ((A ^ m) ^ k) = 1 := by
+  intro k hk
+  rw [← pow_mul]
+  exact h (m * k) (hm.trans_le (Nat.le_mul_of_pos_right m hk))
+
+/-- If all traces `tr(A^k)` with `k > 1` equal one, every nonzero spectral
+value of `A` equals one.
+
+This is the set-spectrum part of arXiv:1703.09188, Proposition
+`prop:normal-tensor`, lines 349--354. It does not assert algebraic
+multiplicity. -/
+theorem eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
+    (A : Matrix n n ℂ)
+    (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1)
+    {μ : ℂ} (hμ : μ ∈ spectrum ℂ A) (hμ0 : μ ≠ 0) :
+    μ = 1 := by
+  have hpow2 :=
+    forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt A h 2 (by omega)
+  have hpow3 :=
+    forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt A h 3 (by omega)
+  have hchar2 :=
+    charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one (A ^ 2) hpow2
+  have hchar3 :=
+    charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one (A ^ 3) hpow3
+  have hμ2root : IsRoot (A ^ 2).charpoly (μ ^ 2) :=
+    mem_spectrum_iff_isRoot_charpoly.mp (spectrum.pow_mem_pow A 2 hμ)
+  have hμ3root : IsRoot (A ^ 3).charpoly (μ ^ 3) :=
+    mem_spectrum_iff_isRoot_charpoly.mp (spectrum.pow_mem_pow A 3 hμ)
+  have hμ2sub : μ ^ 2 - 1 = 0 := by
+    rw [hchar2] at hμ2root
+    simpa [IsRoot, hμ0] using hμ2root
+  have hμ2 : μ ^ 2 = 1 := sub_eq_zero.mp hμ2sub
+  have hμ3sub : μ ^ 3 - 1 = 0 := by
+    rw [hchar3] at hμ3root
+    simpa [IsRoot, hμ0] using hμ3root
+  have hμ3 : μ ^ 3 = 1 := sub_eq_zero.mp hμ3sub
+  calc
+    μ = μ ^ 3 / μ ^ 2 := by field_simp
+    _ = 1 := by rw [hμ2, hμ3]; simp
+
+/-- If all traces `tr(A^k)` with `k > 1` equal one, then one belongs to the
+spectrum of `A`.
+
+This is the existence part of the spectral conclusion in arXiv:1703.09188,
+Proposition `prop:normal-tensor`, lines 349--354. -/
+theorem one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
+    (A : Matrix n n ℂ)
+    (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1) :
+    (1 : ℂ) ∈ spectrum ℂ A := by
+  have hpow2 :=
+    forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt A h 2 (by omega)
+  have hchar2 :=
+    charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one (A ^ 2) hpow2
+  have hone_sq : (1 : ℂ) ∈ spectrum ℂ (A ^ 2) := by
+    apply mem_spectrum_of_isRoot_charpoly
+    rw [hchar2]
+    simp [IsRoot]
+  rw [spectrum.map_pow_of_pos (𝕜 := ℂ) (a := A) (n := 2) (by omega)] at hone_sq
+  rcases hone_sq with ⟨μ, hμ, hμ2⟩
+  have hμ0 : μ ≠ 0 := by
+    intro hμ0
+    simp [hμ0] at hμ2
+  have hμ1 := eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt A h hμ hμ0
+  simpa [hμ1] using hμ
+
+/-- If all traces `tr(A^k)` with `k > 1` equal one, the nonzero part of the
+spectrum of `A` is the singleton `{1}`.
+
+This is the exact set-spectrum consequence used in arXiv:1703.09188,
+Proposition `prop:normal-tensor`, lines 349--354. The statement concerns
+spectral values as a set and therefore does not claim their algebraic
+multiplicities. -/
+theorem spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt
+    (A : Matrix n n ℂ)
+    (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1) :
+    spectrum ℂ A \ {0} = {1} := by
+  ext μ
+  constructor
+  · rintro ⟨hμ, hμ0⟩
+    have hμ_ne : μ ≠ 0 := by simp at hμ0; exact hμ0
+    simp [eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt A h hμ hμ_ne]
+  · intro hμ
+    have hμ1 : μ = 1 := by simpa using hμ
+    subst μ
+    exact ⟨one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt A h, by simp⟩
+
+end Matrix

--- a/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
+++ b/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
@@ -114,10 +114,13 @@ theorem one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
 /-- If all traces `tr(A^k)` with `k > 1` equal one, the nonzero part of the
 spectrum of `A` is the singleton `{1}`.
 
-This is the exact set-spectrum consequence used in arXiv:1703.09188,
-Proposition `prop:normal-tensor`, lines 349--354. The statement concerns
-spectral values as a set and therefore does not claim their algebraic
-multiplicities. -/
+This is the set-spectrum consequence used in arXiv:1703.09188,
+Proposition `prop:normal-tensor`, lines 349--354.
+
+**Scope restriction (set spectrum only):** the source proposition also states
+that the sole nonzero eigenvalue has algebraic multiplicity one. This theorem
+proves only equality of the nonzero spectrum as a set. See
+`docs/paper-gaps/cpsv17_transfer_trace_power.tex`. -/
 theorem spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt
     (A : Matrix n n ℂ)
     (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1) :

--- a/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
+++ b/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
@@ -55,8 +55,12 @@ theorem forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt
 value of `A` equals one.
 
 This is the set-spectrum part of arXiv:1703.09188, Proposition
-`prop:normal-tensor`, lines 349--354. It does not assert algebraic
-multiplicity. -/
+`prop:normal-tensor`, lines 349--354.
+
+**Scope restriction (set spectrum only):** the source proposition also states
+that the sole nonzero eigenvalue has algebraic multiplicity one. This theorem
+proves only that every nonzero spectral value equals one. See
+`docs/paper-gaps/cpsv17_transfer_trace_power.tex`. -/
 theorem eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
     (A : Matrix n n ℂ)
     (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1)

--- a/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
+++ b/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
@@ -94,7 +94,12 @@ theorem eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
 spectrum of `A`.
 
 This is the existence part of the spectral conclusion in arXiv:1703.09188,
-Proposition `prop:normal-tensor`, lines 349--354. -/
+Proposition `prop:normal-tensor`, lines 349--354.
+
+**Scope restriction (set spectrum only):** the source proposition also states
+that the sole nonzero eigenvalue has algebraic multiplicity one. This theorem
+proves only that `1` is a spectral value. See
+`docs/paper-gaps/cpsv17_transfer_trace_power.tex`. -/
 theorem one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
     (A : Matrix n n ℂ)
     (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1) :

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2,7 +2,7 @@
 
 This chapter develops the algebraic prerequisites for matrix product unitaries.
 The first result supplies the corrected nil-matrix bound used in the blocking
-argument of \cite[lines~405--426]{Cirac2017MPU}.
+argument of \cite{Cirac2017MPU}.
 
 \begin{theorem}[Dimension bound for a nilpotent Lie action]
     \label{thm:mpu_lcs_finrank}
@@ -71,7 +71,7 @@ argument of \cite[lines~405--426]{Cirac2017MPU}.
 
 The length $n$ is a weak bound, not a strict bound below $n$; the latter is
 false for strictly upper-triangular matrices.  This corrects the intermediate
-strict inequality in \cite[lines~405--426]{Cirac2017MPU} without changing its
+strict inequality in \cite{Cirac2017MPU} without changing its
 final strict $D^4$ estimate.
 
 \section{The matrix product unitary condition}
@@ -169,7 +169,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \section{Trace-power lemma}\label{sec:mpu_trace_power}
 
 For the transfer-matrix spectrum argument of
-\cite[Proposition~1, lines~349--354]{Cirac2017MPU} we first record the
+\cite[Proposition~1]{Cirac2017MPU} we first record the
 algebraic fact that a matrix whose positive powers all have trace~$1$ must have
 characteristic polynomial $X^{n-1}(X-1)$.  The source assumes only the powers
 with exponent strictly greater than one; this weaker hypothesis determines the
@@ -246,13 +246,13 @@ nonzero spectrum as a set.
   finite-range hypothesis of Theorem~\ref{thm:mpu_trace_power_le_card}.
 \end{proof}
 
-\begin{lemma}[Shifted moments under matrix powers]
-  \label{lem:mpu_shifted_trace_power_moments}
+\begin{theorem}[Shifted moments under matrix powers]
+  \label{thm:mpu_shifted_trace_power_moments}
   \lean{Matrix.forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt}
   \leanok
   Let $A$ be an $n\times n$ complex matrix such that $\tr(A^k)=1$ for every
   $k>1$, and let $m>1$.  Then $\tr((A^m)^r)=1$ for every $r\ge1$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
   For $r\ge1$, one has $(A^m)^r=A^{mr}$ and $mr>1$, so the hypothesis at
@@ -267,24 +267,24 @@ nonzero spectrum as a set.
   \leanok
   Let $A$ be an $n\times n$ complex matrix.  If $\tr(A^k)=1$ for every
   $k>1$, then
-  \begin{align*}
+  \begin{align}
     \sigma(A)\setminus\{0\}&=\{1\}.
-  \end{align*}
+  \end{align}
   Thus $1$ occurs as a spectral value and every nonzero spectral value equals
   $1$.  This is the set-spectrum conclusion of
-  \cite[Proposition~1, lines~349--354]{Cirac2017MPU}; it does not assert
+  \cite[Proposition~1]{Cirac2017MPU}; it does not assert
   algebraic multiplicity.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{lem:mpu_shifted_trace_power_moments, thm:mpu_trace_power_all}
+  \uses{thm:mpu_shifted_trace_power_moments, thm:mpu_trace_power_all}
   For every $r\ge1$, the hypothesis gives
   $\tr((A^2)^r)=\tr(A^{2r})=1$ and
   $\tr((A^3)^r)=\tr(A^{3r})=1$.  Hence, by
   Theorem~\ref{thm:mpu_trace_power_all},
-  \begin{align*}
+  \begin{align}
     \chi_{A^2}(X)&=\chi_{A^3}(X)=X^{n-1}(X-1).
-  \end{align*}
+  \end{align}
   If $\mu\in\sigma(A)$ is nonzero, spectral mapping places $\mu^2$ in
   $\sigma(A^2)$ and $\mu^3$ in $\sigma(A^3)$.  The two characteristic
   polynomials give $\mu^2=\mu^3=1$, and therefore $\mu=1$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -168,9 +168,12 @@ closing a chain of $N$ copies of $\mathcal U$.
 
 \section{Trace-power lemma}\label{sec:mpu_trace_power}
 
-For the transfer-matrix spectrum argument of \cite[Proposition~1]{Cirac2017MPU} we need the algebraic fact that a matrix
-whose positive powers all have trace~$1$ must have characteristic polynomial
-$X^{n-1}(X-1)$.
+For the transfer-matrix spectrum argument of
+\cite[Proposition~1, lines~349--354]{Cirac2017MPU} we first record the
+algebraic fact that a matrix whose positive powers all have trace~$1$ must have
+characteristic polynomial $X^{n-1}(X-1)$.  The source assumes only the powers
+with exponent strictly greater than one; this weaker hypothesis determines the
+nonzero spectrum as a set.
 
 \begin{definition}[Rank-one diagonal idempotent]
   \label{def:mpu_diagonal_one_at}
@@ -241,6 +244,54 @@ $X^{n-1}(X-1)$.
   trace of an empty matrix is $0$; the conclusion follows vacuously.
   When $n\ge1$, the hypothesis on all positive powers implies the
   finite-range hypothesis of Theorem~\ref{thm:mpu_trace_power_le_card}.
+\end{proof}
+
+\begin{lemma}[Shifted moments under matrix powers]
+  \label{lem:mpu_shifted_trace_power_moments}
+  \lean{Matrix.forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt}
+  \leanok
+  Let $A$ be an $n\times n$ complex matrix such that $\tr(A^k)=1$ for every
+  $k>1$, and let $m>1$.  Then $\tr((A^m)^r)=1$ for every $r\ge1$.
+\end{lemma}
+
+\begin{proof}\leanok
+  For $r\ge1$, one has $(A^m)^r=A^{mr}$ and $mr>1$, so the hypothesis at
+  exponent $mr$ gives the result.
+\end{proof}
+
+\begin{theorem}[Trace powers above one determine the nonzero spectrum]
+  \label{thm:mpu_shifted_trace_power_spectrum}
+  \lean{Matrix.spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt,
+    Matrix.eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt,
+    Matrix.one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt}
+  \leanok
+  Let $A$ be an $n\times n$ complex matrix.  If $\tr(A^k)=1$ for every
+  $k>1$, then
+  \begin{align*}
+    \sigma(A)\setminus\{0\}&=\{1\}.
+  \end{align*}
+  Thus $1$ occurs as a spectral value and every nonzero spectral value equals
+  $1$.  This is the set-spectrum conclusion of
+  \cite[Proposition~1, lines~349--354]{Cirac2017MPU}; it does not assert
+  algebraic multiplicity.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{lem:mpu_shifted_trace_power_moments, thm:mpu_trace_power_all}
+  For every $r\ge1$, the hypothesis gives
+  $\tr((A^2)^r)=\tr(A^{2r})=1$ and
+  $\tr((A^3)^r)=\tr(A^{3r})=1$.  Hence, by
+  Theorem~\ref{thm:mpu_trace_power_all},
+  \begin{align*}
+    \chi_{A^2}(X)&=\chi_{A^3}(X)=X^{n-1}(X-1).
+  \end{align*}
+  If $\mu\in\sigma(A)$ is nonzero, spectral mapping places $\mu^2$ in
+  $\sigma(A^2)$ and $\mu^3$ in $\sigma(A^3)$.  The two characteristic
+  polynomials give $\mu^2=\mu^3=1$, and therefore $\mu=1$.
+
+  The value $1$ belongs to $\sigma(A^2)$.  Spectral mapping supplies
+  $\mu\in\sigma(A)$ with $\mu^2=1$; this $\mu$ is nonzero, so the
+  nonzero-value argument gives $\mu=1$.
 \end{proof}
 
 We now introduce the two matrices used for the singular-value decompositions of

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,18 +24,6 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
-### shifted moments under matrix powers — promoted
-- **Pattern:** turn `tr(A^k) = 1` for every `k > 1` into an all-positive-moment
-  hypothesis for `A ^ m` by rewriting `(A ^ m) ^ k = A ^ (m * k)` and proving
-  `1 < m * k` from `1 < m` and `0 < k`.
-- **Seen:** three uses for the square and cube spectral-mapping arguments in
-  `TNLean/Algebra/ShiftedTracePowerSpectrum.lean` (2026-08-09).
-- **Abstraction:**
-  `Matrix.forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt` in
-  `TNLean/Algebra/ShiftedTracePowerSpectrum.lean`.
-- **Notes:** the lemma isolates the exponent arithmetic needed before applying
-  an all-positive trace-power theorem to a matrix power.
-
 ### pure gauge to heterogeneous repeated blocks — promoted
 - **Pattern:** convert `GaugeEquiv A B` to `HetRepeatedBlocks A B` by passing
   through `EquivalentBlocks`, choosing unit phase, and embedding the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,18 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### shifted moments under matrix powers — promoted
+- **Pattern:** turn `tr(A^k) = 1` for every `k > 1` into an all-positive-moment
+  hypothesis for `A ^ m` by rewriting `(A ^ m) ^ k = A ^ (m * k)` and proving
+  `1 < m * k` from `1 < m` and `0 < k`.
+- **Seen:** three uses for the square and cube spectral-mapping arguments in
+  `TNLean/Algebra/ShiftedTracePowerSpectrum.lean` (2026-08-09).
+- **Abstraction:**
+  `Matrix.forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt` in
+  `TNLean/Algebra/ShiftedTracePowerSpectrum.lean`.
+- **Notes:** the lemma isolates the exponent arithmetic needed before applying
+  an all-positive trace-power theorem to a matrix power.
+
 ### pure gauge to heterogeneous repeated blocks — promoted
 - **Pattern:** convert `GaugeEquiv A B` to `HetRepeatedBlocks A B` by passing
   through `EquivalentBlocks`, choosing unit phase, and embedding the


### PR DESCRIPTION
## Summary

- prove that `tr(A^k) = 1` for every `k > 1` forces the nonzero set spectrum of a square complex matrix to be exactly `{1}`
- apply the merged trace-power characteristic-polynomial theorem to `A^2` and `A^3`, then use spectral mapping for uniqueness and existence of the spectral value `1`
- keep the conclusion explicitly at set-spectrum level, without claiming algebraic multiplicity
- add the source-cited shifted-moment lemma and spectrum theorem to the MPU blueprint

No positivity, normality, diagonalizability, or `k = 1` hypothesis is used.

## Verification

- `lake env lean TNLean/Algebra/ShiftedTracePowerSpectrum.lean`
- blueprint synchronization and changed-declaration coverage
- reader-facing prose check
- import-aggregator check
- diff and whitespace checks

Closes #5737
Prerequisite for #5706

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal linear algebra with no runtime, auth, or data paths; scope is limited to new theorems and blueprint sync, with multiplicity deliberately out of scope.
> 
> **Overview**
> Formalizes the **set-spectrum** consequence of Cirac et al.’s transfer-matrix argument: if `tr(A^k) = 1` for every `k > 1` on a square complex matrix `A`, then `σ(A) \ {0} = {1}`—without requiring `k = 1`, positivity, or normality.
> 
> New module `TNLean/Algebra/ShiftedTracePowerSpectrum.lean` adds a **shifted-moment** lemma (traces of `(A^m)^r` from the `k > 1` hypothesis when `m > 1`), then applies the existing all-positive-moment charpoly theorem to `A^2` and `A^3` and uses spectral mapping so nonzero eigenvalues satisfy `μ^2 = μ^3 = 1` hence `μ = 1`, with a reverse spectral-mapping step to show `1 ∈ σ(A)`. Docstrings and the MPU blueprint (`ch28_mpu.tex`) state explicitly that **algebraic multiplicity** of the nonzero eigenvalue is **not** proved (see paper-gaps doc).
> 
> The algebra import aggregator picks up the new module; blueprint trace-power section adds the shifted-moment and spectrum theorems and tightens citations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62cd9c249ccaf4d36904ed61e61adecb27f4bbf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->