### PR TITLE
feat(ParentHamiltonian): add inverse-Gram projector infrastructure

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -21,6 +21,7 @@ import TNLean.Analysis.EntropyMarkovForward
 import TNLean.Analysis.EntropyMarkovReverse
 import TNLean.Analysis.EntropyReindex
 import TNLean.Analysis.HayashiMarkovStructure
+import TNLean.Analysis.InjectiveRangeProjector
 import TNLean.Analysis.IsometricCompression
 import TNLean.Analysis.JordanBlockPower
 import TNLean.Analysis.KleinInequality
@@ -35,6 +36,7 @@ import TNLean.Analysis.MatrixOrderTopology
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.MatrixTraceInequalities
 import TNLean.Analysis.MeanErgodic
+import TNLean.Analysis.NeumannInverse
 import TNLean.Analysis.OperatorConvexity
 import TNLean.Analysis.PosSemidefCommute
 import TNLean.Analysis.ProbabilityEntropy

--- a/TNLean/Analysis/InjectiveRangeProjector.lean
+++ b/TNLean/Analysis/InjectiveRangeProjector.lean
@@ -11,7 +11,7 @@ import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 # Range projectors of injective finite-dimensional maps
 
 For an injective map \(T\) between finite-dimensional Hilbert spaces, this file
-packages the standard formula
+records the standard formula
 \[
   P_{\operatorname{ran} T}=T(T^\dagger T)^{-1}T^\dagger.
 \]

--- a/TNLean/Analysis/InjectiveRangeProjector.lean
+++ b/TNLean/Analysis/InjectiveRangeProjector.lean
@@ -10,8 +10,8 @@ import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 /-!
 # Range projectors of injective finite-dimensional maps
 
-For an injective map \(T\) between finite-dimensional Hilbert spaces, this file
-records the standard formula
+For an injective map \(T\) with finite-dimensional Hilbert domain and complete
+Hilbert codomain, this file records the standard formula
 \[
   P_{\operatorname{ran} T}=T(T^\dagger T)^{-1}T^\dagger.
 \]

--- a/TNLean/Analysis/InjectiveRangeProjector.lean
+++ b/TNLean/Analysis/InjectiveRangeProjector.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+
+/-!
+# Range projectors of injective finite-dimensional maps
+
+For an injective map \(T\) between finite-dimensional Hilbert spaces, this file
+packages the standard formula
+\[
+  P_{\operatorname{ran} T}=T(T^\dagger T)^{-1}T^\dagger.
+\]
+-/
+
+
+namespace ContinuousLinearMap
+
+variable {𝕜 E F : Type*} [RCLike 𝕜]
+  [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E] [CompleteSpace E]
+  [NormedAddCommGroup F] [InnerProductSpace 𝕜 F] [CompleteSpace F]
+
+/-- The continuous inverse of the Gram endomorphism of an injective
+finite-dimensional continuous linear map. -/
+noncomputable def inverseGram (T : E →L[𝕜] F) (hT : Function.Injective T) : E →L[𝕜] E :=
+  LinearMap.toContinuousLinearMap <|
+    (LinearEquiv.ofInjectiveEndo (T.adjoint.comp T).toLinearMap
+      ((T.adjoint_comp_self_injective_iff).2 hT)).symm.toLinearMap
+
+/-- The continuous range projector written through the inverse Gram operator. -/
+noncomputable def injectiveRangeProjector (T : E →L[𝕜] F)
+    (hT : Function.Injective T) : F →L[𝕜] F :=
+  T.comp ((inverseGram T hT).comp T.adjoint)
+
+/-- The continuous inverse-Gram formula is exactly the orthogonal projector
+onto the range of an injective finite-dimensional map. -/
+theorem injectiveRangeProjector_eq_starProjection (T : E →L[𝕜] F)
+    (hT : Function.Injective T) :
+    injectiveRangeProjector T hT = T.range.starProjection := by
+  ext x
+  symm
+  apply Submodule.eq_starProjection_of_mem_orthogonal
+  · exact ⟨inverseGram T hT (T.adjoint x), rfl⟩
+  · rw [Submodule.mem_orthogonal']
+    intro _ hy
+    obtain ⟨y, rfl⟩ := hy
+    change inner 𝕜 (x - injectiveRangeProjector T hT x) (T y) = 0
+    rw [← T.adjoint_inner_left y (x - injectiveRangeProjector T hT x)]
+    suffices T.adjoint (x - injectiveRangeProjector T hT x) = 0 by rw [this, inner_zero_left]
+    rw [map_sub, injectiveRangeProjector, comp_apply, comp_apply]
+    change T.adjoint x - (T.adjoint.comp T)
+      (inverseGram T hT (T.adjoint x)) = 0
+    rw [inverseGram]
+    exact sub_eq_zero.mpr
+      ((LinearEquiv.ofInjectiveEndo (T.adjoint.comp T).toLinearMap
+        ((T.adjoint_comp_self_injective_iff).2 hT)).apply_symm_apply (T.adjoint x)).symm
+
+end ContinuousLinearMap

--- a/TNLean/Analysis/NeumannInverse.lean
+++ b/TNLean/Analysis/NeumannInverse.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Normed.Ring.Units
+
+/-!
+# A quantitative Neumann inverse bound
+
+This file records the denominator estimate used for inverse Gram operators.
+-/
+
+namespace NormedRing
+
+variable {R : Type*} [NormedRing R] [NormOneClass R] [HasSummableGeomSeries R]
+
+/-- Quantitative Neumann bound.  If \(\lVert t\rVert\le a<1\), then
+\(\lVert(1-t)^{-1}\rVert\le(1-a)^{-1}\). -/
+theorem norm_inverse_one_sub_le (t : R) {a : ℝ} (ht : ‖t‖ ≤ a) (ha : a < 1) :
+    ‖Ring.inverse (1 - t)‖ ≤ (1 - a)⁻¹ := by
+  have ht_one : ‖t‖ < 1 := ht.trans_lt ha
+  rw [inverse_one_sub t ht_one]
+  change ‖∑' n : ℕ, t ^ n‖ ≤ (1 - a)⁻¹
+  calc
+    ‖∑' n : ℕ, t ^ n‖ ≤ (1 - ‖t‖)⁻¹ := by
+      simpa using tsum_geometric_le_of_norm_lt_one t ht_one
+    _ ≤ (1 - a)⁻¹ := by
+      exact (inv_le_inv₀ (sub_pos.mpr ht_one) (sub_pos.mpr ha)).2 (by linarith)
+
+end NormedRing

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -40,6 +40,7 @@ import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.GroundSpace
+import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -5,8 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.FrobeniusHilbert
 import TNLean.Algebra.RectangularChoi
-import TNLean.Analysis.InjectiveRangeProjector
-import TNLean.Analysis.NeumannInverse
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.Spectral.MixedTransfer
 

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FrobeniusHilbert
+import TNLean.Algebra.RectangularChoi
+import TNLean.Analysis.InjectiveRangeProjector
+import TNLean.Analysis.NeumannInverse
+import TNLean.MPS.ParentHamiltonian.Defs
+import TNLean.Spectral.MixedTransfer
+
+import Mathlib.Analysis.InnerProductSpace.Adjoint
+
+/-!
+# Gram operators for MPS ground-space maps
+
+This file realizes the boundary map \(\Gamma_L\) between finite-dimensional
+Hilbert spaces and identifies its Gram operator with the exact reshuffling of
+the Choi matrix of the iterated transfer map.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+section FrobeniusRealization
+
+open scoped Matrix.Norms.Frobenius
+
+/-- The boundary map \(\Gamma_L\), with the virtual matrix space carrying the
+Hilbert--Schmidt inner product and the physical configuration space carrying
+the standard \(\ell^2\) inner product. -/
+noncomputable def groundSpaceMapES (A : MPSTensor d D) (L : ℕ) :
+    EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ] EuclideanSpace ℂ (Cfg d L) :=
+  LinearMap.toContinuousLinearMap <|
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm.toLinearMap.comp
+      ((groundSpaceMap A L).comp
+        (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm.toLinearEquiv.toLinearMap)
+
+@[simp]
+theorem groundSpaceMapES_frobeniusEquivEuclidean_apply
+    (A : MPSTensor d D) (L : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    groundSpaceMapES A L (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X) =
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm (groundSpaceMap A L X) := by
+  change (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm
+      (groundSpaceMap A L
+        ((Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X))) = _
+  rw [(Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm_apply_apply]
+
+/-- The Hilbert-space realization has exactly the physical local ground space
+as its range. -/
+theorem range_groundSpaceMapES (A : MPSTensor d D) (L : ℕ) :
+    (groundSpaceMapES A L).range = groundSpaceES A L := by
+  ext v
+  constructor
+  · rintro ⟨x, rfl⟩
+    obtain ⟨X, rfl⟩ := (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).surjective x
+    change (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm
+      (groundSpaceMap A L X) ∈ groundSpaceES A L
+    exact ⟨groundSpaceMap A L X, ⟨X, rfl⟩, rfl⟩
+  · rintro ⟨ψ, ⟨X, rfl⟩, rfl⟩
+    exact ⟨Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X,
+      groundSpaceMapES_frobeniusEquivEuclidean_apply A L X⟩
+
+
+@[simp]
+theorem groundSpaceMapES_single (A : MPSTensor d D) (L : ℕ) (a b : Fin D) :
+    groundSpaceMapES A L (EuclideanSpace.single (b, a) 1) =
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm
+        (groundSpaceMap A L (Matrix.single a b 1)) := by
+  rw [← groundSpaceMapES_frobeniusEquivEuclidean_apply A L (Matrix.single a b 1)]
+  apply congrArg (groundSpaceMapES A L)
+  apply PiLp.ext
+  rintro ⟨j, i⟩
+  simp [Matrix.frobeniusEquivEuclidean_apply, EuclideanSpace.single]
+
+end FrobeniusRealization
+
+/-- The finite-dimensional Gram operator \(\Gamma_L^\dagger\Gamma_L\). -/
+noncomputable def groundSpaceGram (A : MPSTensor d D) (L : ℕ) :
+    EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ] EuclideanSpace ℂ (Fin D × Fin D) :=
+  (groundSpaceMapES A L).adjoint.comp (groundSpaceMapES A L)
+
+/-- Matrix-unit entry of the MPS Gram operator.  The right-hand side is the
+precise Choi reshuffling: it is not the Hilbert--Schmidt pairing with the
+iterated transfer map. -/
+theorem inner_single_groundSpaceGram_single_eq_rectangularChoi
+    (A : MPSTensor d D) (L : ℕ) (a b c e : Fin D) :
+    inner ℂ (EuclideanSpace.single (b, a) 1)
+      (groundSpaceGram A L (EuclideanSpace.single (e, c) 1)) =
+      Matrix.rectangularChoi ((transferMap (d := d) (D := D) A) ^ L)
+        (c, e) (a, b) := by
+  classical
+  rw [groundSpaceGram, ContinuousLinearMap.comp_apply, ContinuousLinearMap.adjoint_inner_right]
+  rw [groundSpaceMapES_single, groundSpaceMapES_single]
+  change inner ℂ
+    (WithLp.toLp 2 (groundSpaceMap A L (Matrix.single a b 1)))
+    (WithLp.toLp 2 (groundSpaceMap A L (Matrix.single c e 1))) = _
+  rw [EuclideanSpace.inner_toLp_toLp, Matrix.rectangularChoi_apply,
+    transferMap_pow_apply']
+  have hmul (W : Matrix (Fin D) (Fin D) ℂ) :
+      ((W * Matrix.single c a 1 * Wᴴ : Matrix (Fin D) (Fin D) ℂ) e b) =
+        W e c * star (W b a) := by
+    rw [Matrix.mul_apply]
+    calc
+      ∑ j, ((W * Matrix.single c a 1 : Matrix (Fin D) (Fin D) ℂ) e j) * Wᴴ j b =
+          ((W * Matrix.single c a 1 : Matrix (Fin D) (Fin D) ℂ) e a) * Wᴴ a b := by
+        apply Finset.sum_eq_single a
+        · intro j _ hja
+          rw [Matrix.mul_apply]
+          simp [hja.symm]
+        · simp
+      _ = W e c * star (W b a) := by
+        rw [Matrix.mul_apply]
+        simp [Matrix.single_apply]
+  rw [show (∑ σ : Fin L → Fin d,
+      evalWord A (List.ofFn σ) * Matrix.single c a 1 *
+        (evalWord A (List.ofFn σ))ᴴ) =
+      ∑ σ ∈ (Finset.univ : Finset (Fin L → Fin d)),
+        evalWord A (List.ofFn σ) * Matrix.single c a 1 *
+          (evalWord A (List.ofFn σ))ᴴ by rfl, Matrix.sum_apply]
+  simp_rw [hmul]
+  simp [groundSpaceMap_apply, Matrix.trace_mul_single, dotProduct]
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -149,6 +149,44 @@ orthogonal projector is the canonical representative used here.
     $\Gamma_L\colon\MN{D}\to\ell^2(\Fin{d}^{L})$.
 \end{definition}
 
+\begin{theorem}[Boundary-map transport under Frobenius vectorization]
+    \label{thm:ground_space_map_es_frobenius}
+    \lean{MPSTensor.groundSpaceMapES_frobeniusEquivEuclidean_apply}
+    \leanok
+    \uses{def:ground_space_map_es, def:frobenius_vectorization}
+    Let $U\colon\MN{D}\to\ell^2(\Fin{D}\times\Fin{D})$ be Frobenius
+    vectorization, with the target indexed in column--row order, and let
+    $\iota_L$ be the computational-basis identification on the physical
+    coefficient space.  Then, for every $X\in\MN{D}$,
+    $\Gamma_L^{\mathrm{ES}}(U(X))=\iota_L(\Gamma_L(X))$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:ground_space_map}
+    By definition, $\Gamma_L^{\mathrm{ES}}$ is the composite of $U^{-1}$,
+    the original boundary map $\Gamma_L$, and $\iota_L$.  Applying this
+    composite to $U(X)$ and cancelling $U^{-1}U$ gives the claimed identity.
+\end{proof}
+
+\begin{theorem}[Boundary map on a matrix unit]
+    \label{thm:ground_space_map_es_single}
+    \lean{MPSTensor.groundSpaceMapES_single}
+    \leanok
+    \uses{def:ground_space_map_es, def:frobenius_vectorization}
+    Let $e_{(b,a)}$ denote the Frobenius coordinate vector representing the
+    virtual matrix unit $E_{ab}$.  Then
+    $\Gamma_L^{\mathrm{ES}}(e_{(b,a)})=\iota_L(\Gamma_L(E_{ab}))$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_map_es_frobenius}
+    Frobenius vectorization records a matrix entry $(a,b)$ at the
+    column--row coordinate $(b,a)$, so $U(E_{ab})=e_{(b,a)}$.  Substitute
+    this identity into the boundary-map transport theorem.
+\end{proof}
+
 \begin{theorem}[Exact range of the Hilbert-space boundary map]
     \label{thm:range_ground_space_map_es}
     \lean{MPSTensor.range_groundSpaceMapES}
@@ -156,6 +194,15 @@ orthogonal projector is the canonical representative used here.
     \uses{def:ground_space_map_es, def:ground_space_es}
     The range of $\Gamma_L$ is exactly $G_L^{\mathrm{ES}}(A)$.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_map_es_frobenius, def:ground_space_parent}
+    Every virtual vector is $U(X)$ for a unique matrix $X$, and the transport
+    identity sends it to $\iota_L(\Gamma_L(X))$.  These are exactly the
+    vectors in $\iota_L(\range\Gamma_L)=G_L^{\mathrm{ES}}(A)$, proving both
+    inclusions.
+\end{proof}
 
 \begin{definition}[Ground-space Gram operator]
     \label{def:ground_space_gram}
@@ -184,15 +231,63 @@ orthogonal projector is the canonical representative used here.
     $\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.
 \end{theorem}
 
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_map_es_single, lem:ground_space_map_apply}
+    Move the adjoint in $\mathcal K_L=\Gamma_L^\dagger\Gamma_L$ across the
+    inner product and expand the two boundary-map coefficients.  For each
+    physical word $\sigma$, the resulting summand is
+    $(A^\sigma)_{ec}\,\overline{(A^\sigma)_{ba}}$.  On the other hand,
+    expanding the transfer power on $E_{ca}$ gives
+    \begin{align}
+      \bigl(\mathcal E_A^L(E_{ca})\bigr)_{eb}
+      &=\sum_\sigma (A^\sigma)_{ec}\,
+        \overline{(A^\sigma)_{ba}}.
+    \end{align}
+    The defining Choi indexing
+    $J(\mathcal L)_{(c,e),(a,b)}=(\mathcal L(E_{ca}))_{eb}$ now yields the
+    stated reshuffling.
+\end{proof}
+
+\begin{definition}[Inverse Gram operator]
+    \label{def:inverse_gram}
+    \lean{ContinuousLinearMap.inverseGram}
+    \leanok
+    For an injective map $T$ with finite-dimensional domain, define
+    $S_T:=(T^\dagger T)^{-1}$.
+\end{definition}
+
+\begin{definition}[Injective range-projector candidate]
+    \label{def:injective_range_projector}
+    \lean{ContinuousLinearMap.injectiveRangeProjector}
+    \leanok
+    \uses{def:inverse_gram}
+    For injective $T$, define the operator $Q_T:=T S_T T^\dagger$ on its
+    codomain.
+\end{definition}
+
 \begin{theorem}[Injective range-projector formula]
     \label{thm:injective_range_projector_inverse_gram}
     \lean{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}
     \leanok
-    If $T$ is an injective map between finite-dimensional Hilbert spaces, then
+    \uses{def:injective_range_projector}
+    If $T$ is an injective map from a finite-dimensional Hilbert space into a
+    complete Hilbert space, then
     \begin{align}
       P_{\range T}&=T(T^\dagger T)^{-1}T^\dagger.
     \end{align}
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:inverse_gram}
+    The vector $Q_Tx$ lies in $\range T$.  Moreover,
+    $T^\dagger Q_Tx=(T^\dagger T)S_TT^\dagger x=T^\dagger x$, so for every
+    $y$ the adjoint identity gives
+    $\langle x-Q_Tx,Ty\rangle=0$.  Thus $x-Q_Tx$ is orthogonal to
+    $\range T$, and the range--orthogonal decomposition characterizing the
+    orthogonal projector gives $Q_T=P_{\range T}$.
+\end{proof}
 
 \begin{theorem}[Neumann inverse estimate]
     \label{thm:neumann_inverse_norm_bound}
@@ -204,6 +299,21 @@ orthogonal projector is the canonical representative used here.
       \lVert(1-t)^{-1}\rVert&\le(1-a)^{-1}.
     \end{align}
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $\lVert t\rVert\le a<1$, the Neumann series converges and
+    $(1-t)^{-1}=\sum_{n\ge0}t^n$.  The triangle inequality and
+    submultiplicativity give
+    \begin{align}
+      \left\lVert\sum_{n\ge0}t^n\right\rVert
+      &\le \sum_{n\ge0}\lVert t\rVert^n
+       =(1-\lVert t\rVert)^{-1}
+       \le(1-a)^{-1},
+    \end{align}
+    where the last step uses monotonicity of the reciprocal on the positive
+    reals.
+\end{proof}
 
 \begin{definition}[Canonical parent interaction]\label{def:parent_interaction}
     \lean{MPSTensor.parentInteraction}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -142,20 +142,20 @@ orthogonal projector is the canonical representative used here.
     \label{def:ground_space_map_es}
     \lean{MPSTensor.groundSpaceMapES}
     \leanok
-    \uses{def:ground_space_map, def:ground_space_es}
+    \uses{def:ground_space_map}
     Equip $\MN{D}$ with the Hilbert--Schmidt inner product and the physical
     coefficient space with its computational-basis $\ell^2$ inner product.
     The resulting map is again denoted by
     $\Gamma_L\colon\MN{D}\to\ell^2(\Fin{d}^{L})$.
 \end{definition}
 
-\begin{lemma}[Exact range of the Hilbert-space boundary map]
-    \label{lem:range_ground_space_map_es}
+\begin{theorem}[Exact range of the Hilbert-space boundary map]
+    \label{thm:range_ground_space_map_es}
     \lean{MPSTensor.range_groundSpaceMapES}
     \leanok
     \uses{def:ground_space_map_es, def:ground_space_es}
     The range of $\Gamma_L$ is exactly $G_L^{\mathrm{ES}}(A)$.
-\end{lemma}
+\end{theorem}
 
 \begin{definition}[Ground-space Gram operator]
     \label{def:ground_space_gram}
@@ -163,47 +163,47 @@ orthogonal projector is the canonical representative used here.
     \leanok
     \uses{def:ground_space_map_es}
     The boundary Gram operator is
-    \[
+    \begin{align}
         \mathcal K_L:=\Gamma_L^\dagger\Gamma_L.
-    \]
+    \end{align}
 \end{definition}
 
-\begin{lemma}[Transfer--Gram Choi reshuffling]
-    \label{lem:ground_space_gram_choi_reshuffling}
+\begin{theorem}[Transfer--Gram Choi reshuffling]
+    \label{thm:ground_space_gram_choi_reshuffling}
     \lean{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}
     \leanok
-    \uses{def:ground_space_gram}
+    \uses{def:ground_space_gram, def:transfer_map, def:rectangular_choi}
     Let $E_{ab}$ denote the virtual matrix units and let $\mathcal E_A$ be the
     transfer map. Then
-    \[
+    \begin{align}
       \langle E_{ab},\mathcal K_L(E_{ce})\rangle_{\mathrm{HS}}
-      =J(\mathcal E_A^L)_{(c,e),(a,b)}.
-    \]
+      &=J(\mathcal E_A^L)_{(c,e),(a,b)}.
+    \end{align}
     Thus the Gram operator is the indicated Choi reshuffling; in particular it
     is not obtained by replacing the right-hand side with
     $\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.
-\end{lemma}
+\end{theorem}
 
-\begin{lemma}[Injective range-projector formula]
-    \label{lem:injective_range_projector_inverse_gram}
+\begin{theorem}[Injective range-projector formula]
+    \label{thm:injective_range_projector_inverse_gram}
     \lean{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}
     \leanok
     If $T$ is an injective map between finite-dimensional Hilbert spaces, then
-    \[
-      P_{\range T}=T(T^\dagger T)^{-1}T^\dagger.
-    \]
-\end{lemma}
+    \begin{align}
+      P_{\range T}&=T(T^\dagger T)^{-1}T^\dagger.
+    \end{align}
+\end{theorem}
 
-\begin{lemma}[Neumann inverse estimate]
-    \label{lem:neumann_inverse_norm_bound}
+\begin{theorem}[Neumann inverse estimate]
+    \label{thm:neumann_inverse_norm_bound}
     \lean{NormedRing.norm_inverse_one_sub_le}
     \leanok
     If $\lVert t\rVert\le a<1$ in a normed ring with convergent geometric
     series and $\lVert 1\rVert=1$, then
-    \[
-      \lVert(1-t)^{-1}\rVert\le(1-a)^{-1}.
-    \]
-\end{lemma}
+    \begin{align}
+      \lVert(1-t)^{-1}\rVert&\le(1-a)^{-1}.
+    \end{align}
+\end{theorem}
 
 \begin{definition}[Canonical parent interaction]\label{def:parent_interaction}
     \lean{MPSTensor.parentInteraction}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -138,6 +138,73 @@ orthogonal projector is the canonical representative used here.
     $G_L^{\mathrm{ES}}(A)=\iota_L(G_L(A))$.
 \end{proof}
 
+\begin{definition}[Hilbert-space boundary map]
+    \label{def:ground_space_map_es}
+    \lean{MPSTensor.groundSpaceMapES}
+    \leanok
+    \uses{def:ground_space_map, def:ground_space_es}
+    Equip $\MN{D}$ with the Hilbert--Schmidt inner product and the physical
+    coefficient space with its computational-basis $\ell^2$ inner product.
+    The resulting map is again denoted by
+    $\Gamma_L\colon\MN{D}\to\ell^2(\Fin{d}^{L})$.
+\end{definition}
+
+\begin{lemma}[Exact range of the Hilbert-space boundary map]
+    \label{lem:range_ground_space_map_es}
+    \lean{MPSTensor.range_groundSpaceMapES}
+    \leanok
+    \uses{def:ground_space_map_es, def:ground_space_es}
+    The range of $\Gamma_L$ is exactly $G_L^{\mathrm{ES}}(A)$.
+\end{lemma}
+
+\begin{definition}[Ground-space Gram operator]
+    \label{def:ground_space_gram}
+    \lean{MPSTensor.groundSpaceGram}
+    \leanok
+    \uses{def:ground_space_map_es}
+    The boundary Gram operator is
+    \[
+        \mathcal K_L:=\Gamma_L^\dagger\Gamma_L.
+    \]
+\end{definition}
+
+\begin{lemma}[Transfer--Gram Choi reshuffling]
+    \label{lem:ground_space_gram_choi_reshuffling}
+    \lean{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}
+    \leanok
+    \uses{def:ground_space_gram}
+    Let $E_{ab}$ denote the virtual matrix units and let $\mathcal E_A$ be the
+    transfer map. Then
+    \[
+      \langle E_{ab},\mathcal K_L(E_{ce})\rangle_{\mathrm{HS}}
+      =J(\mathcal E_A^L)_{(c,e),(a,b)}.
+    \]
+    Thus the Gram operator is the indicated Choi reshuffling; in particular it
+    is not obtained by replacing the right-hand side with
+    $\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.
+\end{lemma}
+
+\begin{lemma}[Injective range-projector formula]
+    \label{lem:injective_range_projector_inverse_gram}
+    \lean{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}
+    \leanok
+    If $T$ is an injective map between finite-dimensional Hilbert spaces, then
+    \[
+      P_{\range T}=T(T^\dagger T)^{-1}T^\dagger.
+    \]
+\end{lemma}
+
+\begin{lemma}[Neumann inverse estimate]
+    \label{lem:neumann_inverse_norm_bound}
+    \lean{NormedRing.norm_inverse_one_sub_le}
+    \leanok
+    If $\lVert t\rVert\le a<1$ in a normed ring with convergent geometric
+    series and $\lVert 1\rVert=1$, then
+    \[
+      \lVert(1-t)^{-1}\rVert\le(1-a)^{-1}.
+    \]
+\end{lemma}
+
 \begin{definition}[Canonical parent interaction]\label{def:parent_interaction}
     \lean{MPSTensor.parentInteraction}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -142,11 +142,18 @@ orthogonal projector is the canonical representative used here.
     \label{def:ground_space_map_es}
     \lean{MPSTensor.groundSpaceMapES}
     \leanok
-    \uses{def:ground_space_map}
-    Equip $\MN{D}$ with the Hilbert--Schmidt inner product and the physical
-    coefficient space with its computational-basis $\ell^2$ inner product.
-    The resulting map is again denoted by
-    $\Gamma_L\colon\MN{D}\to\ell^2(\Fin{d}^{L})$.
+    \uses{def:ground_space_map, def:frobenius_vectorization}
+    Let $U\colon\MN{D}\to\ell^2(\Fin{D}\times\Fin{D})$ be Frobenius
+    vectorization in column--row coordinates.  The Hilbert-space boundary map
+    is
+    \begin{align}
+      \Gamma_L^{\mathrm{ES}}
+      &:=\iota_L\circ\Gamma_L\circ U^{-1}
+      \colon\ell^2(\Fin{D}\times\Fin{D})
+      \longrightarrow\ell^2(\Fin{d}^{L}).
+    \end{align}
+    Thus $\Gamma_L^{\mathrm{ES}}$ has a Euclidean coordinate-space domain,
+    whereas the original map $\Gamma_L$ has matrix domain $\MN{D}$.
 \end{definition}
 
 \begin{theorem}[Boundary-map transport under Frobenius vectorization]
@@ -192,7 +199,8 @@ orthogonal projector is the canonical representative used here.
     \lean{MPSTensor.range_groundSpaceMapES}
     \leanok
     \uses{def:ground_space_map_es, def:ground_space_es}
-    The range of $\Gamma_L$ is exactly $G_L^{\mathrm{ES}}(A)$.
+    The range of $\Gamma_L^{\mathrm{ES}}$ is exactly
+    $G_L^{\mathrm{ES}}(A)$.
 \end{theorem}
 
 \begin{proof}
@@ -211,7 +219,8 @@ orthogonal projector is the canonical representative used here.
     \uses{def:ground_space_map_es}
     The boundary Gram operator is
     \begin{align}
-        \mathcal K_L:=\Gamma_L^\dagger\Gamma_L.
+        \mathcal K_L
+        :=(\Gamma_L^{\mathrm{ES}})^\dagger\Gamma_L^{\mathrm{ES}}.
     \end{align}
 \end{definition}
 
@@ -233,8 +242,10 @@ orthogonal projector is the canonical representative used here.
 
 \begin{proof}
     \leanok
-    \uses{thm:ground_space_map_es_single, lem:ground_space_map_apply}
-    Move the adjoint in $\mathcal K_L=\Gamma_L^\dagger\Gamma_L$ across the
+    \uses{thm:ground_space_map_es_single, lem:ground_space_map_apply, thm:mixed_pow}
+    Move the adjoint in
+    $\mathcal K_L=(\Gamma_L^{\mathrm{ES}})^\dagger\Gamma_L^{\mathrm{ES}}$
+    across the
     inner product and expand the two boundary-map coefficients.  For each
     physical word $\sigma$, the resulting summand is
     $(A^\sigma)_{ec}\,\overline{(A^\sigma)_{ba}}$.  On the other hand,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -229,12 +229,16 @@ orthogonal projector is the canonical representative used here.
     \lean{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}
     \leanok
     \uses{def:ground_space_gram, def:transfer_map, def:rectangular_choi}
-    Let $E_{ab}$ denote the virtual matrix units and let $\mathcal E_A$ be the
-    transfer map. Then
+    Let $\mathbf e_{(j,i)}:=\operatorname{single}_{(j,i)}(1)$ denote the
+    standard unit vector in $\ell^2(\Fin{D}\times\Fin{D})$, and let
+    $\mathcal E_A$ be the transfer map.  Then
     \begin{align}
-      \langle E_{ab},\mathcal K_L(E_{ce})\rangle_{\mathrm{HS}}
+      \bigl\langle \mathbf e_{(b,a)},
+        \mathcal K_L(\mathbf e_{(e,c)})\bigr\rangle_{\ell^2}
       &=J(\mathcal E_A^L)_{(c,e),(a,b)}.
     \end{align}
+    Under Frobenius vectorization, $\mathbf e_{(b,a)}=U(E_{ab})$ and
+    $\mathbf e_{(e,c)}=U(E_{ce})$, explaining the reversed coordinate order.
     Thus the Gram operator is the indicated Choi reshuffling; in particular it
     is not obtained by replacing the right-hand side with
     $\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -457,6 +457,48 @@ explicit than the review paragraph: the exact constants and the cyclic-window
 blocking convention still have to be compared with the FNW, Nachtergaele, and
 Kastoryano--Lucia estimates.
 
+\section{Inverse-Gram infrastructure and the remaining FNW contraction}
+
+For the open-chain boundary map
+\[
+  \Gamma_L(X)(\sigma)=\operatorname{tr}(A^\sigma X),
+\]
+the finite-dimensional Hilbert realization, its exact range, and its Gram
+operator are now recorded by
+\leanid{MPSTensor.groundSpaceMapES},
+\leanid{MPSTensor.range_groundSpaceMapES}, and
+\leanid{MPSTensor.groundSpaceGram}.  On virtual matrix units, the exact identity
+\[
+ \langle E_{ab},\Gamma_L^\dagger\Gamma_L(E_{ce})\rangle_{\mathrm{HS}}
+ =J(\mathcal E_A^L)_{(c,e),(a,b)}
+\]
+is \leanid{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}.
+The ordering on the right is a Choi reshuffling.  It must not be replaced by the
+generally false Hilbert--Schmidt expression
+$\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.
+
+The generic identity
+\[
+  P_{\operatorname{ran}T}=T(T^\dagger T)^{-1}T^\dagger
+\]
+for injective finite-dimensional maps is
+\leanid{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}, and the
+denominator
+estimate $\|(1-t)^{-1}\|\le(1-a)^{-1}$ under $\|t\|\le a<1$ is
+\leanid{NormedRing.norm_inverse_one_sub_le}.  Consequently the physical local
+ground projector is the orthogonal projector onto
+$\operatorname{ran}\Gamma_L$.  It is not the transfer fixed-point projector
+\leanid{fixedPointProj}; the latter acts on the virtual matrix space
+and cannot substitute for the inverse-Gram formula.
+
+What remains open is the source-specific FNW comparison of the inverse-Gram
+range projectors on the two overlapping physical windows.  In particular, the
+present infrastructure does not prove the contraction
+$a_l(1+a_l)/(1-a_l)$, does not identify the physical projector with a transfer
+fixed-point projector, and does not establish the final numerical overlap or
+spectral-gap bound.  That load-bearing overlapping-window estimate remains the
+MPS-specific task tracked in issue \#5752.
+
 \textbf{Verdict:} open gap.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -494,10 +494,16 @@ and cannot substitute for the inverse-Gram formula.
 What remains open is the source-specific FNW comparison of the inverse-Gram
 range projectors on the two overlapping physical windows.  In particular, the
 present infrastructure does not prove the contraction
-$a_l(1+a_l)/(1-a_l)$, does not identify the physical projector with a transfer
-fixed-point projector, and does not establish the final numerical overlap or
-spectral-gap bound.  That load-bearing overlapping-window estimate remains the
-MPS-specific task tracked in issue \#5752.
+\[
+  c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},
+  \qquad c\lambda^l<1,
+\]
+which appears as equation \path{boundAm} in
+\cite[Section~6]{Nachtergaele1996Spectral}, does not identify the physical
+projector with a transfer fixed-point projector, and does not establish the
+final numerical overlap or spectral-gap bound.  That load-bearing
+overlapping-window estimate remains the MPS-specific task tracked in issue
+\#5752.
 
 \textbf{Verdict:} open gap.
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -459,48 +459,87 @@ Kastoryano--Lucia estimates.
 
 \section{Inverse-Gram infrastructure and the remaining FNW contraction}
 
-For the open-chain boundary map
-\[
-  \Gamma_L(X)(\sigma)=\operatorname{tr}(A^\sigma X),
-\]
-the finite-dimensional Hilbert realization, its exact range, and its Gram
-operator are now recorded by
-\leanid{MPSTensor.groundSpaceMapES},
+For $n\ge1$, write $[n]:=\{0,\ldots,n-1\}$.  Fix an MPS tensor
+$A=\{A^s\}_{s\in[d]}$ with $A^s\in\mathbb C^{D\times D}$.  For
+$a,b\in[D]$, let $E_{ab}$ be the matrix unit with its only nonzero entry,
+equal to one, in row $a$ and column $b$.  The transfer map and its $L$-fold
+composition are
+\begin{align}
+  \mathcal E_A(X)
+    &:=\sum_{s\in[d]}A^sX(A^s)^\dagger,
+  &
+  \mathcal E_A^L
+    &:=\underbrace{\mathcal E_A\circ\cdots\circ\mathcal E_A}_{L\text{ factors}}.
+\end{align}
+For a linear map $T\colon\mathbb C^{D\times D}\to
+\mathbb C^{D\times D}$, this note uses the rectangular Choi convention
+\begin{align}
+  J(T)_{(i,a),(j,b)}
+    &:=(T(E_{ij}))_{a,b}.
+\end{align}
+
+The open-chain boundary map is
+\begin{align}
+  \Gamma_L(X)(\sigma)
+    &:=\operatorname{tr}(A^\sigma X).
+\end{align}
+Let $U\colon\mathbb C^{D\times D}\to\ell^2([D]\times[D])$ be Frobenius
+vectorization, so that $U(E_{ab})=\mathbf e_{(b,a)}$ for the standard unit
+vector $\mathbf e_{(b,a)}$.  After the canonical physical $\ell^2$
+identification, write $\Gamma_L^{\mathrm{ES}}$ for the transported boundary
+map and
+\begin{align}
+  \mathcal K_L
+    &:=(\Gamma_L^{\mathrm{ES}})^\dagger\Gamma_L^{\mathrm{ES}}.
+\end{align}
+Its finite-dimensional Hilbert realization, exact range, and Gram operator are
+recorded by \leanid{MPSTensor.groundSpaceMapES},
 \leanid{MPSTensor.range_groundSpaceMapES}, and
-\leanid{MPSTensor.groundSpaceGram}.  On virtual matrix units, the exact identity
-\[
- \langle E_{ab},\Gamma_L^\dagger\Gamma_L(E_{ce})\rangle_{\mathrm{HS}}
- =J(\mathcal E_A^L)_{(c,e),(a,b)}
-\]
-is \leanid{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}.
+\leanid{MPSTensor.groundSpaceGram}.  With the coordinate order just fixed, the
+exact identity is
+\begin{align}
+  \left\langle \mathbf e_{(b,a)},
+    \mathcal K_L(\mathbf e_{(e,c)})\right\rangle_{\ell^2}
+    &=J(\mathcal E_A^L)_{(c,e),(a,b)}
+      =(\mathcal E_A^L(E_{ca}))_{e,b}.
+\end{align}
+This is \leanid{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}.
 The ordering on the right is a Choi reshuffling.  It must not be replaced by the
 generally false Hilbert--Schmidt expression
 $\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.
 
 The generic identity
-\[
-  P_{\operatorname{ran}T}=T(T^\dagger T)^{-1}T^\dagger
-\]
+\begin{align}
+  P_{\operatorname{ran}T}
+    &=T(T^\dagger T)^{-1}T^\dagger
+\end{align}
 for injective finite-dimensional maps is
 \leanid{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}, and the
-denominator
-estimate $\|(1-t)^{-1}\|\le(1-a)^{-1}$ under $\|t\|\le a<1$ is
-\leanid{NormedRing.norm_inverse_one_sub_le}.  Consequently the physical local
-ground projector is the orthogonal projector onto
-$\operatorname{ran}\Gamma_L$.  It is not the transfer fixed-point projector
-\leanid{fixedPointProj}; the latter acts on the virtual matrix space
+denominator estimate $\|(1-t)^{-1}\|\le(1-a)^{-1}$ under
+$\|t\|\le a<1$ is \leanid{NormedRing.norm_inverse_one_sub_le}.
+Consequently the physical local ground projector is the orthogonal projector
+onto $\operatorname{ran}\Gamma_L$.  It is not the transfer fixed-point
+projector \leanid{fixedPointProj}; the latter acts on the virtual matrix space
 and cannot substitute for the inverse-Gram formula.
+
+To state the source estimate, let $l\in\mathbb N$ be the overlap length and let
+$0\le\lambda<1$ be an admissible transfer-mixing rate satisfying
+$|\mu|<\lambda$ for every non-unit eigenvalue $\mu$ of the relevant transfer
+operator.  Let $c\ge0$ be its prefactor; the source allows $c=k^2$ when $k$ is
+the auxiliary, or bond, dimension.  Choose $l$ so that $c\lambda^l<1$.  These
+are parameters of the quoted FNW estimate, not bounds derived by the present
+formal infrastructure.
 
 What remains open is the source-specific FNW comparison of the inverse-Gram
 range projectors on the two overlapping physical windows.  In particular, the
 present infrastructure does not prove the contraction
-\[
+\begin{align}
   c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},
   \qquad c\lambda^l<1,
-\]
+\end{align}
 which appears as equation \path{boundAm} in
-\cite[Section~6]{Nachtergaele1996Spectral}, does not identify the physical
-projector with a transfer fixed-point projector, and does not establish the
+\cite[Section~6]{Nachtergaele1996Spectral}; it does not identify the physical
+projector with a transfer fixed-point projector, and it does not establish the
 final numerical overlap or spectral-gap bound.  That load-bearing
 overlapping-window estimate remains the MPS-specific task tracked in issue
 \#5752.

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 670, 712 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 681, 723 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 493, 535 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 560, 602 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 560, 602 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 670, 712 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 681, 723 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 685, 727 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- realize the MPS boundary map as a finite-dimensional continuous Hilbert-space map and prove its range is exactly the physical local ground space
- define the ground-space Gram operator and prove the exact matrix-unit/rectangular-Choi reshuffling identity for the iterated transfer map
- add the generic continuous inverse-Gram formula for the orthogonal projector onto the range of an injective map
- add the generic quantitative Neumann inverse bound
- synchronize Chapter 13 and the martingale paper-gap note, explicitly distinguishing the physical range projector from `fixedPointProj`

The remaining FNW overlapping-window contraction and numerical estimate stay in #5752; this PR does not identify the physical projector with the transfer fixed-point projector and does not claim the final overlap bound.

## Verification

- `lake build TNLean.Analysis.InjectiveRangeProjector TNLean.Analysis.NeumannInverse TNLean.MPS.ParentHamiltonian.GroundSpaceGram TNLean.MPS.ParentHamiltonian`
- targeted `#check`s for all new public declarations
- proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in changed Lean files
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- targeted blueprint synchronization found all new declarations; the repository-wide checker remains red on the pre-existing global declaration/build baseline (its missing list did not include declarations from this PR)

Closes #5759

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-style proofs and documentation in the parent-Hamiltonian formalization track; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **formal Lean infrastructure** for inverse-Gram range projectors on MPS ground-space boundary maps, plus blueprint and paper-gap documentation. The FNW overlapping-window contraction and final overlap bound remain open (#5752).
> 
> **MPS ground-space Hilbert realization** (`GroundSpaceGram.lean`): defines `groundSpaceMapES` as the boundary map on Frobenius/Euclidean coordinates, proves its range is the physical local ground space, defines `groundSpaceGram`, and proves matrix-unit entries match the **rectangular Choi reshuffling** of the iterated transfer map—not the Hilbert–Schmidt pairing.
> 
> **Generic analysis** (`InjectiveRangeProjector.lean`, `NeumannInverse.lean`): injective maps get `inverseGram` and `injectiveRangeProjector` with proof that `P_{\mathrm{ran} T} = T(T^\dagger T)^{-1}T^\dagger`; normed rings get `‖(1-t)^{-1}‖ ≤ (1-a)^{-1}` when `‖t‖ ≤ a < 1`.
> 
> **Docs** extend Chapter 13 blueprint and the martingale overlap paper-gap note, explicitly separating the **physical range projector** from `fixedPointProj` on the virtual matrix space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2032d22a78d283ad4c2a84e9375e5462cb11481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->