### PR TITLE
feat(MPS/ParentHamiltonian): add source-shaped PGVWC tuple spans

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -5,6 +5,8 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
+import TNLean.MPS.Core.TPGauge
+import TNLean.MPS.Symmetry.StringOrderAux
 
 /-!
 # BNT block-separation hypotheses for PGVWC block intersections
@@ -18,7 +20,7 @@ PGVWC07 one-step block-intersection identity.
   direct-sum lemma used there.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
 namespace MPSTensor
 
@@ -208,6 +210,82 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
   exact wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
     A hBlk1 hUnital hPair (by simpa [S] using hn)
 
+/-- A positive dual fixed point prepares the left-canonical family needed only
+for the sharp BNT separation argument.
+
+For each source block \(A^j\), set
+\(B^j_a=(\Lambda^j)^{1/2}A^j_a(\Lambda^j)^{-1/2}\). Positivity of
+\(\Lambda^j\) makes this an invertible gauge, while the dual fixed-point
+equation makes \(B^j\) left-canonical. Irreducibility, fixed-length injectivity,
+self-overlap normalization, and pairwise gauge-phase inequivalence pass to the
+prepared family. The sharp tuple span is then transported back to the source
+representatives.
+
+This is the normalization change used in PGVWC07, Theorem 12: the source blocks
+need not also satisfy the left-canonical identity. -/
+theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (Λ : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hΛ : ∀ j, (Λ j).PosDef)
+    (hDualFixed : ∀ j,
+      transferMap (d := d) (D := dim j) (fun a => (A j a)ᴴ) (Λ j) = Λ j)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1))
+    (hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))))
+    (hL₀ : 0 < L₀) :
+    WordTupleSpanTop A
+      ((r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))) := by
+  let prepared : (j : Fin r) → MPSTensor d (dim j) :=
+    fun j => tpGauge (A j) (Λ j)
+  have hGauge : ∀ j, GaugeEquiv (A j) (prepared j) := by
+    intro j
+    exact gaugeEquiv_tpGauge (A j) (Λ j) (hΛ j)
+  have hPreparedIrr : HasIrreducibleBlocks (d := d) prepared :=
+    HasIrreducibleBlocks.ofForall fun j =>
+      isIrreducibleTensor_tpGauge_of_isIrreducibleMap
+        (A j) (Λ j) (hΛ j)
+        (isIrreducibleMap_of_isIrreducibleTensor (A j) (hIrr.block_irreducible j))
+  have hPreparedLeft : IsLeftCanonicalBlockFamily (d := d) prepared :=
+    IsLeftCanonicalBlockFamily.ofForall fun j =>
+      tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint
+        (A j) (Λ j) (hΛ j) (hDualFixed j)
+  have hPreparedOverlap : HasNormalizedSelfOverlap (d := d) prepared := by
+    refine HasNormalizedSelfOverlap.ofForall fun j => ?_
+    have heq :
+        (fun N => mpvOverlap (d := d) (prepared j) (prepared j) N) =
+          fun N => mpvOverlap (d := d) (A j) (A j) N := by
+      funext N
+      simp only [mpvOverlap]
+      apply Finset.sum_congr rfl
+      intro σ _
+      rw [← GaugeEquiv.sameMPV (hGauge j) N σ]
+    rw [heq]
+    exact hOverlap.overlap_tendsto_one j
+  have hPreparedDistinct : BlocksNotGaugePhaseEquiv (d := d) prepared := by
+    intro j k hjk hdim hGPE
+    apply hBlocks j k hjk hdim
+    exact gaugePhaseEquiv_of_gaugeEquiv_left_right_cast hdim
+      (hGauge j) (by simpa [prepared] using hGPE) (hGauge k)
+  have hPreparedBlk0 : ∀ k, IsNBlkInjective (prepared k) L₀ :=
+    fun k => isNBlkInjective_of_gaugeEquiv (hBlk0 k) (hGauge k)
+  have hPreparedBlk1 : ∀ k, IsNBlkInjective (prepared k) (L₀ + 1) :=
+    fun k => isNBlkInjective_of_gaugeEquiv (hBlk1 k) (hGauge k)
+  have hPreparedBlk3 : ∀ k,
+      IsNBlkInjective (prepared k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) :=
+    fun k => isNBlkInjective_of_gaugeEquiv (hBlk3 k) (hGauge k)
+  have hPreparedSpan :=
+    wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1
+      prepared hPreparedIrr hPreparedLeft hPreparedOverlap hPreparedDistinct
+      hPreparedBlk0 hPreparedBlk1 hPreparedBlk3 hL₀ hr
+  exact wordTupleSpanTop_of_family_gaugeEquiv_symm hPreparedSpan hGauge
+
 /-- The normalized BNT hypotheses give the simultaneous product span in the
 source range of PGVWC07, Theorem 12.
 
@@ -251,6 +329,43 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
       ((r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))) :=
     wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1
       A hIrr hLeft hOverlap hBlocks hBlk0 hBlk1 hBlk3 hL₀ hr
+  exact wordTupleSpanTop_of_ge_of_unital A hBase hUnital hn
+
+/-- The PGVWC07 source normalization gives the simultaneous product span at
+all lengths above the sharp BNT bound.
+
+The positive dual fixed points are used only to prepare a left-canonical gauge
+for the base separation theorem. The resulting base span is transported back,
+and the source identity \(\sum_a A^j_aA^{j\dagger}_a=I\) propagates it to
+longer words. No diagonality hypothesis on the dual fixed points is needed. -/
+theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (Λ : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hΛ : ∀ j, (Λ j).PosDef)
+    (hDualFixed : ∀ j,
+      transferMap (d := d) (D := dim j) (fun a => (A j a)ᴴ) (Λ j) = Λ j)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn : (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    WordTupleSpanTop A n := by
+  have hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1) := by
+    intro k
+    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  have hBlk3 : ∀ k : Fin r,
+      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+    intro k
+    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  have hBase :=
+    wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint
+      A hr hIrr hOverlap hBlocks Λ hΛ hDualFixed hBlk0 hBlk1 hBlk3 hL₀
   exact wordTupleSpanTop_of_ge_of_unital A hBase hUnital hn
 
 /-- Under the normalized BNT block-separation hypotheses, the local spaces
@@ -331,6 +446,30 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07
   groundSpace_iSupIndep_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
       A hr hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
+
+/-- Under the PGVWC07 source normalization, the block local spaces form an
+internal direct sum throughout the sharp source range. -/
+theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (Λ : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hΛ : ∀ j, (Λ j).PosDef)
+    (hDualFixed : ∀ j,
+      transferMap (d := d) (D := dim j) (fun a => (A j a)ᴴ) (Λ j) = Λ j)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn : (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    iSupIndep fun j : Fin r => groundSpace (A j) n :=
+  groundSpace_iSupIndep_of_wordTupleSpanTop A
+    (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
+      A hr hIrr hOverlap hBlocks Λ hΛ hDualFixed hBlk0 hL₀ hUnital hn)
 
 /-- BNT block-separation conditions and PGVWC07 normalization give the one-step
 block-intersection identity at every length above the BNT block-separation
@@ -432,6 +571,37 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_p
   exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
       A hr hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
+    hUnital
+
+/-- The PGVWC07 one-step restriction-intersection identity holds under the
+source unital normalization and positive dual fixed points, without a
+left-canonical hypothesis on the source representatives. -/
+theorem
+    pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hr : 2 ≤ r)
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (Λ : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hΛ : ∀ j, (Λ j).PosDef)
+    (hDualFixed : ∀ j,
+      transferMap (d := d) (D := dim j) (fun a => (A j a)ᴴ) (Λ j) = Λ j)
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    {n : ℕ}
+    (hn : (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
+    ((⨅ b : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictLastₗ b)) ⊓
+      (⨅ a : Fin d,
+        (⨆ j : Fin r, groundSpace (A j) (n + 1)).comap (restrictFirstₗ a))) =
+      ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
+    (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
+      A hr hIrr hOverlap hBlocks Λ hΛ hDualFixed hBlk0 hL₀ hUnital hn)
     hUnital
 
 /-- Normalized BNT block-separation hypotheses give the large-length block

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 import TNLean.MPS.Core.TPGauge
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.Symmetry.StringOrderAux
 
 /-!
@@ -217,14 +218,17 @@ For each source block \(A^j\), set
 \(B^j_a=(\Lambda^j)^{1/2}A^j_a(\Lambda^j)^{-1/2}\). Positivity of
 \(\Lambda^j\) makes this an invertible gauge, while the dual fixed-point
 equation makes \(B^j\) left-canonical. Irreducibility, fixed-length injectivity,
-self-overlap normalization, and pairwise gauge-phase inequivalence pass to the
-prepared family. The sharp tuple span is then transported back to the source
-representatives.
+and pairwise gauge-phase inequivalence pass to the prepared family. Its
+fixed-length injectivity and left-canonical normalization imply normality, hence
+self-overlap normalization. The sharp tuple span is then transported back to the
+source representatives.
 
 Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
 The positive dual datum used for the prepared gauge is supplied by the canonical
 normalization theorem at lines 742--763. These line numbers refer to
-`Papers/quant-ph_0608197/MPSarchive.tex` in this repository. Scope: this result
+`Papers/quant-ph_0608197/MPSarchive.tex` in this repository.
+
+**Scope note:** This result
 establishes only the fixed-length tuple span; it does not establish the global-cut
 or parent-Hamiltonian kernel conclusions. -/
 theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint
@@ -232,7 +236,6 @@ theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_d
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hr : 2 ≤ r)
     (hIrr : HasIrreducibleBlocks (d := d) A)
-    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
     (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
     (Λ : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
     (hΛ : ∀ j, (Λ j).PosDef)
@@ -260,25 +263,21 @@ theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_d
     IsLeftCanonicalBlockFamily.ofForall fun j =>
       tpGauge_isTP_of_transferMap_conjTranspose_fixedPoint
         (A j) (Λ j) (hΛ j) (hDualFixed j)
-  have hPreparedOverlap : HasNormalizedSelfOverlap (d := d) prepared := by
-    refine HasNormalizedSelfOverlap.ofForall fun j => ?_
-    have heq :
-        (fun N => mpvOverlap (d := d) (prepared j) (prepared j) N) =
-          fun N => mpvOverlap (d := d) (A j) (A j) N := by
-      funext N
-      simp only [mpvOverlap]
-      apply Finset.sum_congr rfl
-      intro σ _
-      rw [← GaugeEquiv.sameMPV (hGauge j) N σ]
-    rw [heq]
-    exact hOverlap.overlap_tendsto_one j
+  have hPreparedBlk0 : ∀ k, IsNBlkInjective (prepared k) L₀ :=
+    fun k => isNBlkInjective_of_gaugeEquiv (hBlk0 k) (hGauge k)
+  have hPreparedNormal : ∀ j, IsNormal (prepared j) :=
+    fun j => ⟨L₀, hL₀, hPreparedBlk0 j⟩
+  have hPreparedNormalTensor : ∀ j, IsNormalTensor (prepared j) :=
+    fun j => isNormalTensor_of_isNormal_leftCanonical
+      (prepared j) (hPreparedNormal j) (hPreparedLeft.leftCanonical j)
+  have hPreparedOverlap : HasNormalizedSelfOverlap (d := d) prepared :=
+    HasNormalizedSelfOverlap.ofForall fun j =>
+      (hPreparedNormalTensor j).selfOverlap_tendsto_one
   have hPreparedDistinct : BlocksNotGaugePhaseEquiv (d := d) prepared := by
     intro j k hjk hdim hGPE
     apply hBlocks j k hjk hdim
     exact gaugePhaseEquiv_of_gaugeEquiv_left_right_cast hdim
       (hGauge j) (by simpa [prepared] using hGPE) (hGauge k)
-  have hPreparedBlk0 : ∀ k, IsNBlkInjective (prepared k) L₀ :=
-    fun k => isNBlkInjective_of_gaugeEquiv (hBlk0 k) (hGauge k)
   have hPreparedBlk1 : ∀ k, IsNBlkInjective (prepared k) (L₀ + 1) :=
     fun k => isNBlkInjective_of_gaugeEquiv (hBlk1 k) (hGauge k)
   have hPreparedBlk3 : ∀ k,
@@ -346,7 +345,9 @@ longer words. No diagonality hypothesis on the dual fixed points is needed.
 Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
 The positive dual datum used for the prepared gauge is supplied by the canonical
 normalization theorem at lines 742--763. These line numbers refer to
-`Papers/quant-ph_0608197/MPSarchive.tex` in this repository. Scope: this result
+`Papers/quant-ph_0608197/MPSarchive.tex` in this repository.
+
+**Scope note:** This result
 establishes only the propagated tuple span; it does not establish the global-cut
 or parent-Hamiltonian kernel conclusions. -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
@@ -354,7 +355,6 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPo
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hr : 2 ≤ r)
     (hIrr : HasIrreducibleBlocks (d := d) A)
-    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
     (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
     (Λ : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
     (hΛ : ∀ j, (Λ j).PosDef)
@@ -376,7 +376,7 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPo
     exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
   have hBase :=
     wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint
-      A hr hIrr hOverlap hBlocks Λ hΛ hDualFixed hBlk0 hBlk1 hBlk3 hL₀
+      A hr hIrr hBlocks Λ hΛ hDualFixed hBlk0 hBlk1 hBlk3 hL₀
   exact wordTupleSpanTop_of_ge_of_unital A hBase hUnital hn
 
 /-- Under the normalized BNT block-separation hypotheses, the local spaces
@@ -464,7 +464,9 @@ internal direct sum throughout the sharp source range.
 Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
 The positive dual datum used to reach the prepared canonical gauge is supplied
 by the canonical normalization theorem at lines 742--763. These line numbers
-refer to `Papers/quant-ph_0608197/MPSarchive.tex` in this repository. Scope: this
+refer to `Papers/quant-ph_0608197/MPSarchive.tex` in this repository.
+
+**Scope note:** This
 result establishes only independence of the block local spaces; it does not
 establish the global-cut or parent-Hamiltonian kernel conclusions. -/
 theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
@@ -472,7 +474,6 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFi
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hr : 2 ≤ r)
     (hIrr : HasIrreducibleBlocks (d := d) A)
-    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
     (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
     (Λ : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
     (hΛ : ∀ j, (Λ j).PosDef)
@@ -487,7 +488,7 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFi
     iSupIndep fun j : Fin r => groundSpace (A j) n :=
   groundSpace_iSupIndep_of_wordTupleSpanTop A
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
-      A hr hIrr hOverlap hBlocks Λ hΛ hDualFixed hBlk0 hL₀ hUnital hn)
+      A hr hIrr hBlocks Λ hΛ hDualFixed hBlk0 hL₀ hUnital hn)
 
 /-- BNT block-separation conditions and PGVWC07 normalization give the one-step
 block-intersection identity at every length above the BNT block-separation
@@ -598,7 +599,9 @@ left-canonical hypothesis on the source representatives.
 Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
 The positive dual datum used to reach the prepared canonical gauge is supplied
 by the canonical normalization theorem at lines 742--763. These line numbers
-refer to `Papers/quant-ph_0608197/MPSarchive.tex` in this repository. Scope: this
+refer to `Papers/quant-ph_0608197/MPSarchive.tex` in this repository.
+
+**Scope note:** This
 result establishes only the one-step restriction-intersection identity; it does
 not establish the global-cut or parent-Hamiltonian kernel conclusions. -/
 theorem
@@ -607,7 +610,6 @@ theorem
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hr : 2 ≤ r)
     (hIrr : HasIrreducibleBlocks (d := d) A)
-    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
     (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
     (Λ : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
     (hΛ : ∀ j, (Λ j).PosDef)
@@ -626,7 +628,7 @@ theorem
       ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
   exact pgvwc07_iSup_groundSpace_eq_restriction_intersection A
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
-      A hr hIrr hOverlap hBlocks Λ hΛ hDualFixed hBlk0 hL₀ hUnital hn)
+      A hr hIrr hBlocks Λ hΛ hDualFixed hBlk0 hL₀ hUnital hn)
     hUnital
 
 /-- Normalized BNT block-separation hypotheses give the large-length block

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -221,8 +221,12 @@ self-overlap normalization, and pairwise gauge-phase inequivalence pass to the
 prepared family. The sharp tuple span is then transported back to the source
 representatives.
 
-This is the normalization change used in PGVWC07, Theorem 12: the source blocks
-need not also satisfy the left-canonical identity. -/
+Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+The positive dual datum used for the prepared gauge is supplied by the canonical
+normalization theorem at lines 742--763. These line numbers refer to
+`Papers/quant-ph_0608197/MPSarchive.tex` in this repository. Scope: this result
+establishes only the fixed-length tuple span; it does not establish the global-cut
+or parent-Hamiltonian kernel conclusions. -/
 theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -337,7 +341,14 @@ all lengths above the sharp BNT bound.
 The positive dual fixed points are used only to prepare a left-canonical gauge
 for the base separation theorem. The resulting base span is transported back,
 and the source identity \(\sum_a A^j_aA^{j\dagger}_a=I\) propagates it to
-longer words. No diagonality hypothesis on the dual fixed points is needed. -/
+longer words. No diagonality hypothesis on the dual fixed points is needed.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+The positive dual datum used for the prepared gauge is supplied by the canonical
+normalization theorem at lines 742--763. These line numbers refer to
+`Papers/quant-ph_0608197/MPSarchive.tex` in this repository. Scope: this result
+establishes only the propagated tuple span; it does not establish the global-cut
+or parent-Hamiltonian kernel conclusions. -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -448,7 +459,14 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07
       A hr hIrr hLeft hOverlap hBlocks hBlk0 hL₀ hUnital hn)
 
 /-- Under the PGVWC07 source normalization, the block local spaces form an
-internal direct sum throughout the sharp source range. -/
+internal direct sum throughout the sharp source range.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+The positive dual datum used to reach the prepared canonical gauge is supplied
+by the canonical normalization theorem at lines 742--763. These line numbers
+refer to `Papers/quant-ph_0608197/MPSarchive.tex` in this repository. Scope: this
+result establishes only independence of the block local spaces; it does not
+establish the global-cut or parent-Hamiltonian kernel conclusions. -/
 theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -575,7 +593,14 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_p
 
 /-- The PGVWC07 one-step restriction-intersection identity holds under the
 source unital normalization and positive dual fixed points, without a
-left-canonical hypothesis on the source representatives. -/
+left-canonical hypothesis on the source representatives.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+The positive dual datum used to reach the prepared canonical gauge is supplied
+by the canonical normalization theorem at lines 742--763. These line numbers
+refer to `Papers/quant-ph_0608197/MPSarchive.tex` in this repository. Scope: this
+result establishes only the one-step restriction-intersection identity; it does
+not establish the global-cut or parent-Hamiltonian kernel conclusions. -/
 theorem
     pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -223,14 +223,15 @@ fixed-length injectivity and left-canonical normalization imply normality, hence
 self-overlap normalization. The sharp tuple span is then transported back to the
 source representatives.
 
-Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+Source: PGVWC07, arXiv:quant-ph/0608197, direct-sum proof lines 1346--1421.
 The positive dual datum used for the prepared gauge is supplied by the canonical
 normalization theorem at lines 742--763. These line numbers refer to
 `Papers/quant-ph_0608197/MPSarchive.tex` in this repository.
 
-**Scope note:** This result
+**Scope restriction (PGVWC07 parent-Hamiltonian conclusion):** This result
 establishes only the fixed-length tuple span; it does not establish the global-cut
-or parent-Hamiltonian kernel conclusions. -/
+or parent-Hamiltonian kernel conclusions. The remaining conclusion is documented
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -342,14 +343,16 @@ for the base separation theorem. The resulting base span is transported back,
 and the source identity \(\sum_a A^j_aA^{j\dagger}_a=I\) propagates it to
 longer words. No diagonality hypothesis on the dual fixed points is needed.
 
-Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
-The positive dual datum used for the prepared gauge is supplied by the canonical
-normalization theorem at lines 742--763. These line numbers refer to
+Source: PGVWC07, arXiv:quant-ph/0608197, direct-sum proof lines 1346--1421
+and unital propagation lines 893--898. The positive dual datum used for the
+prepared gauge is supplied by the canonical normalization theorem at lines
+742--763. These line numbers refer to
 `Papers/quant-ph_0608197/MPSarchive.tex` in this repository.
 
-**Scope note:** This result
+**Scope restriction (PGVWC07 parent-Hamiltonian conclusion):** This result
 establishes only the propagated tuple span; it does not establish the global-cut
-or parent-Hamiltonian kernel conclusions. -/
+or parent-Hamiltonian kernel conclusions. The remaining conclusion is documented
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -461,14 +464,16 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07
 /-- Under the PGVWC07 source normalization, the block local spaces form an
 internal direct sum throughout the sharp source range.
 
-Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 12, proof lines 1424--1456.
+Source: PGVWC07, arXiv:quant-ph/0608197, direct-sum proof lines 1346--1421.
 The positive dual datum used to reach the prepared canonical gauge is supplied
 by the canonical normalization theorem at lines 742--763. These line numbers
 refer to `Papers/quant-ph_0608197/MPSarchive.tex` in this repository.
 
-**Scope note:** This
-result establishes only independence of the block local spaces; it does not
-establish the global-cut or parent-Hamiltonian kernel conclusions. -/
+**Scope restriction (PGVWC07 parent-Hamiltonian conclusion):** This result
+establishes only independence of the block local spaces; it does not establish
+the global-cut or parent-Hamiltonian kernel conclusions. The remaining
+conclusion is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -601,9 +606,11 @@ The positive dual datum used to reach the prepared canonical gauge is supplied
 by the canonical normalization theorem at lines 742--763. These line numbers
 refer to `Papers/quant-ph_0608197/MPSarchive.tex` in this repository.
 
-**Scope note:** This
-result establishes only the one-step restriction-intersection identity; it does
-not establish the global-cut or parent-Hamiltonian kernel conclusions. -/
+**Scope restriction (PGVWC07 parent-Hamiltonian conclusion):** This result
+establishes only the one-step restriction-intersection identity; it does not
+establish the global-cut or parent-Hamiltonian kernel conclusions. The remaining
+conclusion is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -134,6 +134,19 @@ theorem wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSe
     omega
   rwa [hlen] at hSpan
 
+private theorem isNBlkInjective_succ_and_three_mul_succ_of_unital
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    {L₀ : ℕ}
+    (hBlk0 : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hUnital : ∀ k : Fin r, ∑ a : Fin d, A k a * (A k a)ᴴ = 1) :
+    (∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1)) ∧
+      ∀ k : Fin r,
+        IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
+  constructor <;> intro k
+  · exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  · exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+
 /-- BNT block-separation conditions and PGVWC07 normalization give the
 simultaneous product span at every length above the BNT block-separation bound.
 
@@ -198,12 +211,8 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
       (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
     WordTupleSpanTop A n := by
   let S : ℕ := (L₀ + 1) + ((L₀ + 1) + (L₀ + 1))
-  have hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1) := by
-    intro k
-    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
-  have hBlk3 : ∀ k : Fin r, IsNBlkInjective (A k) S := by
-    intro k
-    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  obtain ⟨hBlk1, hBlk3⟩ :=
+    isNBlkInjective_succ_and_three_mul_succ_of_unital A hBlk0 hUnital
   have hPair : HasPairBlockSeparatingWords A S := by
     simpa [S] using
       (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
@@ -322,13 +331,8 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07
     {n : ℕ}
     (hn : (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
     WordTupleSpanTop A n := by
-  have hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1) := by
-    intro k
-    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
-  have hBlk3 : ∀ k : Fin r,
-      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
-    intro k
-    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  obtain ⟨hBlk1, hBlk3⟩ :=
+    isNBlkInjective_succ_and_three_mul_succ_of_unital A hBlk0 hUnital
   have hBase : WordTupleSpanTop A
       ((r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))) :=
     wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1
@@ -370,13 +374,8 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPo
     {n : ℕ}
     (hn : (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) ≤ n) :
     WordTupleSpanTop A n := by
-  have hBlk1 : ∀ k : Fin r, IsNBlkInjective (A k) (L₀ + 1) := by
-    intro k
-    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
-  have hBlk3 : ∀ k : Fin r,
-      IsNBlkInjective (A k) ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) := by
-    intro k
-    exact isNBlkInjective_of_ge_of_unital (A k) (hUnital k) (hBlk0 k) (by omega)
+  obtain ⟨hBlk1, hBlk3⟩ :=
+    isNBlkInjective_succ_and_three_mul_succ_of_unital A hBlk0 hUnital
   have hBase :=
     wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint
       A hr hIrr hBlocks Λ hΛ hDualFixed hBlk0 hBlk1 hBlk3 hL₀

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
@@ -379,7 +379,7 @@
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length,
-        thm:pgvwc_product_span_source_length,
+        thm:pgvwc_product_span_doubly_normalized,
         lem:parent_cyclic_translate_preserves_chain_space,
         lem:block_boundary_intertwiner_from_global_cut,
         lem:block_diagonal_boundary_component_right_boundary_matrices}
@@ -417,7 +417,7 @@
 \begin{proof}
     \leanok
     \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length,
-        thm:pgvwc_product_span_source_length,
+        thm:pgvwc_product_span_doubly_normalized,
         lem:parent_cyclic_translate_preserves_chain_space,
         lem:block_boundary_intertwiner_from_global_cut,
         lem:block_diagonal_boundary_component_right_boundary_matrices}
@@ -437,7 +437,7 @@
         \notag
     \end{align}
     The length bound and
-    Theorem~\ref{thm:pgvwc_product_span_source_length} imply that the
+    Theorem~\ref{thm:pgvwc_product_span_doubly_normalized} imply that the
     simultaneous products of length $N-L_0$ span the product algebra.
     Therefore,
     Lemma~\ref{lem:block_boundary_intertwiner_from_global_cut} gives, block by
@@ -502,7 +502,7 @@
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
         lem:block_diagonal_boundary_representation_inclusion,
         lem:block_diagonal_boundary_closing_equality,
-        thm:pgvwc_block_space_independence_source_length}
+        thm:pgvwc_block_space_independence_doubly_normalized}
     Under the same hypotheses,
     \begin{align}
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
@@ -518,13 +518,13 @@
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
         lem:block_diagonal_boundary_representation_inclusion,
         lem:block_diagonal_boundary_closing_equality,
-        thm:pgvwc_block_space_independence_source_length}
+        thm:pgvwc_block_space_independence_doubly_normalized}
     Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut}
     gives the forward inclusion in the displayed equality. Every periodic
     single-block vector is a periodic vector for the block-diagonal tensor,
     which gives the reverse inclusion.
     For independence, write $\phi_j=\Gamma_N^{A^j}(X_j)$ and suppose that
-    $\sum_j\phi_j=0$. Theorem~\ref{thm:pgvwc_block_space_independence_source_length} and
+    $\sum_j\phi_j=0$. Theorem~\ref{thm:pgvwc_block_space_independence_doubly_normalized} and
     nondegeneracy of the trace pairing give
     \begin{align}
         \sum_j\Gamma_N^{A^j}(X_j)=0

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_periodic_components.tex
@@ -379,7 +379,7 @@
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_bnt_c1_pgvwc07}
     \leanok
     \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length,
-        lem:pgvwc_product_span_source_length,
+        thm:pgvwc_product_span_source_length,
         lem:parent_cyclic_translate_preserves_chain_space,
         lem:block_boundary_intertwiner_from_global_cut,
         lem:block_diagonal_boundary_component_right_boundary_matrices}
@@ -417,7 +417,7 @@
 \begin{proof}
     \leanok
     \uses{lem:bnt_block_diagonal_open_boundary_matrices_source_length,
-        lem:pgvwc_product_span_source_length,
+        thm:pgvwc_product_span_source_length,
         lem:parent_cyclic_translate_preserves_chain_space,
         lem:block_boundary_intertwiner_from_global_cut,
         lem:block_diagonal_boundary_component_right_boundary_matrices}
@@ -437,7 +437,7 @@
         \notag
     \end{align}
     The length bound and
-    Lemma~\ref{lem:pgvwc_product_span_source_length} imply that the
+    Theorem~\ref{thm:pgvwc_product_span_source_length} imply that the
     simultaneous products of length $N-L_0$ span the product algebra.
     Therefore,
     Lemma~\ref{lem:block_boundary_intertwiner_from_global_cut} gives, block by
@@ -502,7 +502,7 @@
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
         lem:block_diagonal_boundary_representation_inclusion,
         lem:block_diagonal_boundary_closing_equality,
-        lem:pgvwc_product_span_source_length}
+        thm:pgvwc_block_space_independence_source_length}
     Under the same hypotheses,
     \begin{align}
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
@@ -518,13 +518,13 @@
     \uses{thm:block_diagonal_boundary_periodic_components_from_global_cut,
         lem:block_diagonal_boundary_representation_inclusion,
         lem:block_diagonal_boundary_closing_equality,
-        lem:pgvwc_product_span_source_length}
+        thm:pgvwc_block_space_independence_source_length}
     Theorem~\ref{thm:block_diagonal_boundary_periodic_components_from_global_cut}
     gives the forward inclusion in the displayed equality. Every periodic
     single-block vector is a periodic vector for the block-diagonal tensor,
     which gives the reverse inclusion.
     For independence, write $\phi_j=\Gamma_N^{A^j}(X_j)$ and suppose that
-    $\sum_j\phi_j=0$. Lemma~\ref{lem:pgvwc_product_span_source_length} and
+    $\sum_j\phi_j=0$. Theorem~\ref{thm:pgvwc_block_space_independence_source_length} and
     nondegeneracy of the trace pairing give
     \begin{align}
         \sum_j\Gamma_N^{A^j}(X_j)=0

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -407,6 +407,13 @@ direct.
     invariant face.
 \end{theorem}
 
+\begin{proof}
+    \leanok
+    Tensor irreducibility is the absence of a nontrivial invariant matrix
+    projection, which is precisely the corresponding irreducibility condition
+    for the transfer map.
+\end{proof}
+
 \begin{lemma}[Positive square-root gauging preserves irreducibility]
     \label{lem:tp_gauge_preserves_irreducibility}
     \lean{MPSTensor.isIrreducibleTensor_tpGauge_of_isIrreducibleMap}
@@ -417,6 +424,13 @@ direct.
     $\Lambda^{1/2}A\Lambda^{-1/2}$ is irreducible.
 \end{lemma}
 
+\begin{proof}
+    \leanok
+    The square-root gauge conjugates the transfer map by an invertible
+    similarity. Invariant faces therefore correspond bijectively before and
+    after gauging.
+\end{proof}
+
 \begin{lemma}[Gauge-phase equivalence transports across two gauges]
     \label{lem:gauge_phase_equiv_transport_left_right}
     \lean{MPSTensor.gaugePhaseEquiv_of_gaugeEquiv_left_right_cast}
@@ -425,6 +439,13 @@ direct.
     Gauge equivalent replacements on both sides preserve gauge-phase
     equivalence, including after identifying equal bond dimensions.
 \end{lemma}
+
+\begin{proof}
+    \leanok
+    Compose the left gauge, the gauge-phase intertwiner, and the inverse right
+    gauge. After transporting across the bond-dimension identification, the
+    composite is the required gauge-phase intertwiner.
+\end{proof}
 
 \begin{theorem}[Prepared-gauge simultaneous product span]
     \label{thm:pgvwc_prepared_gauge_product_span}
@@ -493,19 +514,16 @@ direct.
     back to the source representatives.
 \end{proof}
 
-\begin{lemma}[Simultaneous product span at the source length]
-    \label{lem:pgvwc_product_span_source_length}
+\begin{theorem}[Simultaneous product span at the source length]
+    \label{thm:pgvwc_product_span_source_length}
     \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
-    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
     \uses{def:blockwise_product_word_span,
-        def:blocks_not_gauge_phase_equiv,
-        def:ground_space_parent}
+        def:blocks_not_gauge_phase_equiv}
     Let $r\ge2$, and let the bond dimensions $D_1,\ldots,D_r$ be positive.
     Suppose that every block $A^j$ is irreducible and that no two distinct
     blocks of the same bond dimension are gauge-phase equivalent. Let $L_0>0$,
-    and suppose
-    that every block is injective at length $L_0$:
+    and suppose every block is injective at length $L_0$:
     \begin{align}
         \spn\{A^j_w:|w|=L_0\}&=\MN{D_j}. \notag
     \end{align}
@@ -515,21 +533,20 @@ direct.
         \sum_aA^j_aA^{j\,\dagger}_a&=\Id,
         &\sum_a(A^j_a)^\dagger\Lambda^jA^j_a&=\Lambda^j. \notag
     \end{align}
-    For every $n\ge 3(r-1)(L_0+1)$, one has
-    $\spn\{(A^1_w,\ldots,A^r_w):|w|=n\} =\prod_j\MN{D_j}$.
-    Consequently the spaces $G_n(A^j)$ form an internal sum. No identity
-    $\sum_a(A^j_a)^\dagger A^j_a=\Id$ is assumed for the source blocks.
-    The doubly-normalized specialization remains available separately. This is
-    the simultaneous spanning estimate used in
+    For every $n\ge 3(r-1)(L_0+1)$,
+    \begin{align}
+        \spn\{(A^1_w,\ldots,A^r_w):|w|=n\}&=\prod_j\MN{D_j}. \notag
+    \end{align}
+    No identity $\sum_a(A^j_a)^\dagger A^j_a=\Id$ is assumed for the source
+    blocks. This is the simultaneous spanning estimate used in
     \cite[Theorem~12, proof lines~1424--1456]{PerezGarcia2007Matrix}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:wordspan_propagation_unital,
         lem:unital_simultaneous_product_span_propagation,
-        thm:pgvwc_prepared_gauge_product_span,
-        lem:product_span_block_image_direct_sum}
+        thm:pgvwc_prepared_gauge_product_span}
     Theorem~\ref{thm:wordspan_propagation_unital} first gives
     \begin{align}
         \spn\{A^j_w:|w|=L_0\}=\MN{D_j}
@@ -539,34 +556,47 @@ direct.
         &\Longrightarrow
         \spn\{A^j_w:|w|=3(L_0+1)\}=\MN{D_j}. \notag
     \end{align}
-    Theorem~\ref{thm:pgvwc_prepared_gauge_product_span} then gives the full
+    Theorem~\ref{thm:pgvwc_prepared_gauge_product_span} gives the full
     simultaneous span at $q=3(r-1)(L_0+1)$ on the source representatives.
     The source unital identity and
     Lemma~\ref{lem:unital_simultaneous_product_span_propagation} propagate
-    this equality to every $n\ge q$. To prove independence, write
-    $\phi_j=\Gamma_n^{A^j}(X_j)$ and suppose that $\sum_j\phi_j=0$.
-    Comparison of the coefficient of each word, followed by the simultaneous
-    spanning equality, gives
+    this equality to every $n\ge q$.
+\end{proof}
+
+\begin{theorem}[Block-space independence at the source length]
+    \label{thm:pgvwc_block_space_independence_source_length}
+    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
+    \leanok
+    \uses{thm:pgvwc_product_span_source_length, def:ground_space_parent}
+    Under the hypotheses of
+    Theorem~\ref{thm:pgvwc_product_span_source_length}, the spaces $G_n(A^j)$
+    form an internal sum for every $n\ge3(r-1)(L_0+1)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:pgvwc_product_span_source_length,
+        lem:product_span_block_image_direct_sum}
+    Write $\phi_j=\Gamma_n^{A^j}(X_j)$ and suppose that
+    $\sum_j\phi_j=0$. The simultaneous spanning equality gives
     \begin{align}
         \sum_j \Gamma_n^{A^j}(X_j)=0
-        &\quad\Longrightarrow\quad
-        \left(\forall (M_j)_j,
-            \sum_j\tr(X_jM_j)=0\right)
-        \quad\Longrightarrow\quad
+        &\Longrightarrow
+        \left(\forall (M_j)_j,\ \sum_j\tr(X_jM_j)=0\right)
+        \Longrightarrow
         \forall j,\ X_j=0. \notag
     \end{align}
-    Indeed, in the last implication one takes a tuple supported in one block
-    and uses nondegeneracy of the trace pairing. Hence every $\phi_j$ vanishes,
-    so the spaces $G_n(A^j)$ form an internal sum.
+    Hence every $\phi_j$ vanishes.
 \end{proof}
 
 \begin{theorem}[Direct-sum restriction intersection at the source length]
     \label{thm:pgvwc_direct_sum_intersection_source_length}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
-    \uses{def:ground_space_parent}
+    \uses{def:ground_space_parent,
+        thm:pgvwc_block_space_independence_source_length}
     Under the hypotheses of
-    Lemma~\ref{lem:pgvwc_product_span_source_length}, let
+    Theorem~\ref{thm:pgvwc_product_span_source_length}, let
     $m\ge3(r-1)(L_0+1)+1$. Then
     \begin{align}
         \C^d\otimes\left(\sum_jG_m(A^j)\right)
@@ -575,7 +605,8 @@ direct.
         &=
         \sum_jG_{m+1}(A^j). \notag
     \end{align}
-    Lemma~\ref{lem:pgvwc_product_span_source_length} also shows that the sums
+    Theorem~\ref{thm:pgvwc_block_space_independence_source_length} also shows
+    that the sums
     at lengths $m$ and $m+1$ are internal. This is the direct-sum lemma in the
     proof of
     \cite[Theorem~12, proof lines~1346--1456]{PerezGarcia2007Matrix}.
@@ -583,7 +614,7 @@ direct.
 
 \begin{proof}
     \leanok
-    \uses{lem:pgvwc_product_span_source_length,
+    \uses{thm:pgvwc_product_span_source_length,
         lem:block_restriction_intersection_subspace}
     Let a vector belong to both restricted spaces. The two endpoint
     decompositions give boundary matrices $C_a^j$ and $D_b^j$. For every pair

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -398,16 +398,16 @@ direct.
     block-separating equations with $S=3(L_0+1)$.
 \end{proof}
 
-\begin{lemma}[Prepared-gauge simultaneous product span]
-    \label{lem:pgvwc_prepared_gauge_product_span}
+\begin{theorem}[Prepared-gauge simultaneous product span]
+    \label{thm:pgvwc_prepared_gauge_product_span}
     \lean{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint}
     \leanok
     \uses{def:blockwise_product_word_span,
         def:blocks_not_gauge_phase_equiv}
     Let $r\ge2$, and let the bond dimensions $D_1,\ldots,D_r$ be positive.
-    Suppose that every block $A^j$ is irreducible, that
-    $O_{A^jA^j}(N)\longrightarrow1$, and that no two distinct blocks of the
-    same bond dimension are gauge-phase equivalent. Let $L_0>0$, and suppose
+    Suppose that every block $A^j$ is irreducible and that no two distinct
+    blocks of the same bond dimension are gauge-phase equivalent. Let $L_0>0$,
+    and suppose
     that, for every $j$,
     \begin{align}
         \spn\{A^j_w:|w|=L_0\}
@@ -427,7 +427,7 @@ direct.
         &=\prod_j\MN{D_j}. \notag
     \end{align}
     Diagonality of $\Lambda^j$ is not needed.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -435,13 +435,17 @@ direct.
         thm:tp_gauge_from_adjoint_fixed,
         thm:gauge_invariance,
         lem:gauge_invariance_block_injective,
+        thm:is_normal_tensor_of_is_normal_left_canonical,
+        thm:cpsv_normal_mpv_phase_gauge,
         lem:bnt_direct_sum_block_separation_word_span,
         thm:word_tuple_span_gauge_invariance}
     The square-root gauge is invertible by positive definiteness, and the dual
     fixed-point equation makes the prepared blocks left-canonical. Similarity
-    preserves irreducibility, fixed-length injectivity, normalized self-overlaps,
-    and pairwise inequivalence up to gauge and phase. Apply the existing sharp
-    separation theorem to the prepared family and then use
+    preserves irreducibility, fixed-length injectivity, and pairwise inequivalence
+    up to gauge and phase. Positive-length injectivity makes each prepared block
+    algebraically normal; left-canonicality then makes it a normal tensor, whose
+    self-overlap converges to one. Apply the existing sharp separation theorem to
+    the prepared family and then use
     Theorem~\ref{thm:word_tuple_span_gauge_invariance} in the reverse direction.
 \end{proof}
 
@@ -454,9 +458,9 @@ direct.
         def:blocks_not_gauge_phase_equiv,
         def:ground_space_parent}
     Let $r\ge2$, and let the bond dimensions $D_1,\ldots,D_r$ be positive.
-    Suppose that every block $A^j$ is irreducible, that
-    $O_{A^jA^j}(N)\longrightarrow1$, and that no two distinct blocks of the
-    same bond dimension are gauge-phase equivalent. Let $L_0>0$, and suppose
+    Suppose that every block $A^j$ is irreducible and that no two distinct
+    blocks of the same bond dimension are gauge-phase equivalent. Let $L_0>0$,
+    and suppose
     that every block is injective at length $L_0$:
     \begin{align}
         \spn\{A^j_w:|w|=L_0\}&=\MN{D_j}. \notag
@@ -479,9 +483,9 @@ direct.
 \begin{proof}
     \leanok
     \uses{lem:unital_simultaneous_product_span_propagation,
-        lem:pgvwc_prepared_gauge_product_span,
+        thm:pgvwc_prepared_gauge_product_span,
         lem:product_span_block_image_direct_sum}
-    Lemma~\ref{lem:pgvwc_prepared_gauge_product_span} gives the full
+    Theorem~\ref{thm:pgvwc_prepared_gauge_product_span} gives the full
     simultaneous span at $q=3(r-1)(L_0+1)$ on the source representatives.
     The source unital identity and
     Lemma~\ref{lem:unital_simultaneous_product_span_propagation} propagate

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -398,31 +398,70 @@ direct.
     block-separating equations with $S=3(L_0+1)$.
 \end{proof}
 
+\begin{lemma}[Prepared-gauge simultaneous product span]
+    \label{lem:pgvwc_prepared_gauge_product_span}
+    \lean{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint}
+    \leanok
+    \uses{thm:tp_gauge_from_adjoint_fixed,
+        thm:word_tuple_span_gauge_invariance,
+        lem:bnt_direct_sum_block_separation_word_span}
+    Let $r\ge2$. For each block $A^j$, suppose that $\Lambda^j$ is positive
+    definite and
+    \begin{align}
+        \sum_a(A^j_a)^\dagger\Lambda^jA^j_a&=\Lambda^j. \notag
+    \end{align}
+    Gauge $A^j$ temporarily by $(\Lambda^j)^{1/2}$. The resulting block is
+    left-canonical, so the sharp three-block separation argument applies in
+    that gauge. Transporting its conclusion back gives
+    \begin{align}
+        \spn\{(A^1_w,\ldots,A^r_w):|w|=3(r-1)(L_0+1)\}
+        &=\prod_j\MN{D_j}. \notag
+    \end{align}
+    Diagonality of $\Lambda^j$ is not needed for this argument.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The square-root gauge is invertible by positive definiteness, and the dual
+    fixed-point equation makes the prepared blocks left-canonical. Similarity
+    preserves irreducibility, fixed-length injectivity, closed self-overlaps,
+    and pairwise inequivalence up to gauge and phase. Apply the existing sharp
+    separation theorem to the prepared family and then use
+    Lemma~\ref{thm:word_tuple_span_gauge_invariance} in the reverse direction.
+\end{proof}
+
 \begin{lemma}[Simultaneous product span at the source length]
     \label{lem:pgvwc_product_span_source_length}
-    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
-    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
+    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
     \uses{lem:unital_simultaneous_product_span_propagation,
-        lem:bnt_direct_sum_block_separation_word_span}
-    Let $r\ge2$. Suppose that the normalized BNT blocks are injective at the
-    common length $L_0>0$ and satisfy
-    $\sum_aA^j_aA^{j\,\dagger}_a=\Id$. For every
-    $n\ge 3(r-1)(L_0+1)$, one has
+        lem:pgvwc_prepared_gauge_product_span}
+    Let $r\ge2$. Suppose that the BNT blocks are injective at the common length
+    $L_0>0$ and, for every $j$, satisfy the PGVWC07 canonical data
+    \begin{align}
+        \sum_aA^j_aA^{j\,\dagger}_a&=\Id,
+        &\Lambda^j&>0,
+        &\sum_a(A^j_a)^\dagger\Lambda^jA^j_a&=\Lambda^j. \notag
+    \end{align}
+    For every $n\ge 3(r-1)(L_0+1)$, one has
     $\spn\{(A^1_w,\ldots,A^r_w):|w|=n\} =\prod_j\MN{D_j}$.
-    Consequently the spaces $G_n(A^j)$ form an internal sum. This is the
-    simultaneous spanning estimate used in
+    Consequently the spaces $G_n(A^j)$ form an internal sum. No identity
+    $\sum_a(A^j_a)^\dagger A^j_a=\Id$ is assumed for the source blocks.
+    The doubly-normalized specialization remains available separately. This is
+    the simultaneous spanning estimate used in
     \cite[Theorem~12, proof lines~1424--1456]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{lem:unital_simultaneous_product_span_propagation,
-        lem:bnt_direct_sum_block_separation_word_span,
+        lem:pgvwc_prepared_gauge_product_span,
         lem:product_span_block_image_direct_sum}
-    The block-separation argument gives the full simultaneous span at
-    $q=3(r-1)(L_0+1)$.
-    Lemma~\ref{lem:unital_simultaneous_product_span_propagation} propagates
+    Lemma~\ref{lem:pgvwc_prepared_gauge_product_span} gives the full
+    simultaneous span at $q=3(r-1)(L_0+1)$ on the source representatives.
+    The source unital identity and
+    Lemma~\ref{lem:unital_simultaneous_product_span_propagation} propagate
     this equality to every $n\ge q$. To prove independence, write
     $\phi_j=\Gamma_n^{A^j}(X_j)$ and suppose that $\sum_j\phi_j=0$.
     Comparison of the coefficient of each word, followed by the simultaneous
@@ -442,7 +481,7 @@ direct.
 
 \begin{theorem}[Direct-sum restriction intersection at the source length]
     \label{thm:pgvwc_direct_sum_intersection_source_length}
-    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
     \uses{lem:pgvwc_product_span_source_length,
         lem:block_restriction_intersection_subspace}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -593,8 +593,7 @@ direct.
     \label{thm:pgvwc_direct_sum_intersection_source_length}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
-    \uses{def:ground_space_parent,
-        thm:pgvwc_block_space_independence_source_length}
+    \uses{def:ground_space_parent}
     Under the hypotheses of
     Theorem~\ref{thm:pgvwc_product_span_source_length}, let
     $m\ge3(r-1)(L_0+1)+1$. Then

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -433,7 +433,6 @@ direct.
     \leanok
     \uses{lem:tp_gauge_equiv,
         thm:tp_gauge_from_adjoint_fixed,
-        thm:gauge_invariance,
         lem:gauge_invariance_block_injective,
         thm:is_normal_tensor_of_is_normal_left_canonical,
         thm:cpsv_normal_mpv_phase_gauge,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -549,6 +549,23 @@ direct.
     inclusion follows by splitting a word of length $m+1$ at either endpoint.
 \end{proof}
 
+\begin{remark}[Doubly normalized specialization]
+    \label{rem:pgvwc_direct_sum_doubly_normalized_specialization}
+    \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \leanok
+    Under the hypotheses above, assume additionally that every block has
+    normalized self-overlap and satisfies
+    \begin{align}
+        \sum_a(A^j_a)^\dagger A^j_a&=\Id. \notag
+    \end{align}
+    The retained doubly normalized declarations give the same simultaneous
+    product span, internal-sum independence, and one-step
+    restriction-intersection identity. They are the specialization
+    $\Lambda^j=\Id$ of the source-normalized results.
+\end{remark}
+
 \begin{lemma}[Product span makes the sum of local spaces direct]
     \label{lem:product_span_block_image_direct_sum}
     \lean{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -402,32 +402,47 @@ direct.
     \label{lem:pgvwc_prepared_gauge_product_span}
     \lean{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint}
     \leanok
-    \uses{thm:tp_gauge_from_adjoint_fixed,
-        thm:word_tuple_span_gauge_invariance,
-        lem:bnt_direct_sum_block_separation_word_span}
-    Let $r\ge2$. For each block $A^j$, suppose that $\Lambda^j$ is positive
-    definite and
+    \uses{def:blockwise_product_word_span,
+        def:blocks_not_gauge_phase_equiv}
+    Let $r\ge2$, and let the bond dimensions $D_1,\ldots,D_r$ be positive.
+    Suppose that every block $A^j$ is irreducible, that
+    $O_{A^jA^j}(N)\longrightarrow1$, and that no two distinct blocks of the
+    same bond dimension are gauge-phase equivalent. Let $L_0>0$, and suppose
+    that, for every $j$,
+    \begin{align}
+        \spn\{A^j_w:|w|=L_0\}
+        &=\MN{D_j}, \notag\\
+        \spn\{A^j_w:|w|=L_0+1\}
+        &=\MN{D_j}, \notag\\
+        \spn\{A^j_w:|w|=3(L_0+1)\}
+        &=\MN{D_j}. \notag
+    \end{align}
+    For every $j$, let $\Lambda^j$ be positive definite and satisfy
     \begin{align}
         \sum_a(A^j_a)^\dagger\Lambda^jA^j_a&=\Lambda^j. \notag
     \end{align}
-    Gauge $A^j$ temporarily by $(\Lambda^j)^{1/2}$. The resulting block is
-    left-canonical, so the sharp three-block separation argument applies in
-    that gauge. Transporting its conclusion back gives
+    Then
     \begin{align}
         \spn\{(A^1_w,\ldots,A^r_w):|w|=3(r-1)(L_0+1)\}
         &=\prod_j\MN{D_j}. \notag
     \end{align}
-    Diagonality of $\Lambda^j$ is not needed for this argument.
+    Diagonality of $\Lambda^j$ is not needed.
 \end{lemma}
 
 \begin{proof}
     \leanok
+    \uses{lem:tp_gauge_equiv,
+        thm:tp_gauge_from_adjoint_fixed,
+        thm:gauge_invariance,
+        lem:gauge_invariance_block_injective,
+        lem:bnt_direct_sum_block_separation_word_span,
+        thm:word_tuple_span_gauge_invariance}
     The square-root gauge is invertible by positive definiteness, and the dual
     fixed-point equation makes the prepared blocks left-canonical. Similarity
-    preserves irreducibility, fixed-length injectivity, closed self-overlaps,
+    preserves irreducibility, fixed-length injectivity, normalized self-overlaps,
     and pairwise inequivalence up to gauge and phase. Apply the existing sharp
     separation theorem to the prepared family and then use
-    Lemma~\ref{thm:word_tuple_span_gauge_invariance} in the reverse direction.
+    Theorem~\ref{thm:word_tuple_span_gauge_invariance} in the reverse direction.
 \end{proof}
 
 \begin{lemma}[Simultaneous product span at the source length]
@@ -435,13 +450,21 @@ direct.
     \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
     \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
-    \uses{lem:unital_simultaneous_product_span_propagation,
-        lem:pgvwc_prepared_gauge_product_span}
-    Let $r\ge2$. Suppose that the BNT blocks are injective at the common length
-    $L_0>0$ and, for every $j$, satisfy the PGVWC07 canonical data
+    \uses{def:blockwise_product_word_span,
+        def:blocks_not_gauge_phase_equiv,
+        def:ground_space_parent}
+    Let $r\ge2$, and let the bond dimensions $D_1,\ldots,D_r$ be positive.
+    Suppose that every block $A^j$ is irreducible, that
+    $O_{A^jA^j}(N)\longrightarrow1$, and that no two distinct blocks of the
+    same bond dimension are gauge-phase equivalent. Let $L_0>0$, and suppose
+    that every block is injective at length $L_0$:
+    \begin{align}
+        \spn\{A^j_w:|w|=L_0\}&=\MN{D_j}. \notag
+    \end{align}
+    For every $j$, let $\Lambda^j$ be positive definite and assume the PGVWC07
+    canonical identities
     \begin{align}
         \sum_aA^j_aA^{j\,\dagger}_a&=\Id,
-        &\Lambda^j&>0,
         &\sum_a(A^j_a)^\dagger\Lambda^jA^j_a&=\Lambda^j. \notag
     \end{align}
     For every $n\ge 3(r-1)(L_0+1)$, one has
@@ -483,8 +506,7 @@ direct.
     \label{thm:pgvwc_direct_sum_intersection_source_length}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}
     \leanok
-    \uses{lem:pgvwc_product_span_source_length,
-        lem:block_restriction_intersection_subspace}
+    \uses{def:ground_space_parent}
     Under the hypotheses of
     Lemma~\ref{lem:pgvwc_product_span_source_length}, let
     $m\ge3(r-1)(L_0+1)+1$. Then

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -469,14 +469,29 @@ direct.
         thm:cpsv_normal_mpv_phase_gauge,
         lem:bnt_direct_sum_block_separation_word_span,
         thm:word_tuple_span_gauge_invariance}
-    The square-root gauge is invertible by positive definiteness, and the dual
-    fixed-point equation makes the prepared blocks left-canonical. Similarity
-    preserves irreducibility, fixed-length injectivity, and pairwise inequivalence
-    up to gauge and phase. Positive-length injectivity makes each prepared block
-    algebraically normal; left-canonicality then makes it a normal tensor, whose
-    self-overlap converges to one. Apply the existing sharp separation theorem to
-    the prepared family and then use
-    Theorem~\ref{thm:word_tuple_span_gauge_invariance} in the reverse direction.
+    Define the prepared blocks by
+    \begin{align}
+        B^j_a&=(\Lambda^j)^{1/2}A^j_a(\Lambda^j)^{-1/2}. \notag
+    \end{align}
+    Positive definiteness makes this an invertible gauge, while the dual
+    fixed-point equation gives
+    \begin{align}
+        \sum_a(B^j_a)^\dagger B^j_a&=\Id. \notag
+    \end{align}
+    Gauge transport preserves irreducibility, the three fixed-length
+    injectivity statements, and pairwise inequivalence up to gauge and phase.
+    Thus every $B^j$ is algebraically normal and left-canonical, so
+    \begin{align}
+        \lim_{N\to\infty}
+        \left\langle V^{(N)}(B^j),V^{(N)}(B^j)\right\rangle&=1. \notag
+    \end{align}
+    The sharp separation theorem now gives
+    \begin{align}
+        \spn\{(B^1_w,\ldots,B^r_w):|w|=3(r-1)(L_0+1)\}
+        &=\prod_j\MN{D_j}. \notag
+    \end{align}
+    Theorem~\ref{thm:word_tuple_span_gauge_invariance} transports this equality
+    back to the source representatives.
 \end{proof}
 
 \begin{lemma}[Simultaneous product span at the source length]
@@ -495,8 +510,8 @@ direct.
     \begin{align}
         \spn\{A^j_w:|w|=L_0\}&=\MN{D_j}. \notag
     \end{align}
-    For every $j$, let $\Lambda^j$ be positive definite and assume the PGVWC07
-    canonical identities
+    For every $j$, let $\Lambda^j$ be positive definite and assume the canonical
+    identities from \cite{PerezGarcia2007Matrix}:
     \begin{align}
         \sum_aA^j_aA^{j\,\dagger}_a&=\Id,
         &\sum_a(A^j_a)^\dagger\Lambda^jA^j_a&=\Lambda^j. \notag
@@ -516,8 +531,15 @@ direct.
         lem:unital_simultaneous_product_span_propagation,
         thm:pgvwc_prepared_gauge_product_span,
         lem:product_span_block_image_direct_sum}
-    Theorem~\ref{thm:wordspan_propagation_unital} first propagates block
-    injectivity from $L_0$ to $L_0+1$ and $3(L_0+1)$.
+    Theorem~\ref{thm:wordspan_propagation_unital} first gives
+    \begin{align}
+        \spn\{A^j_w:|w|=L_0\}=\MN{D_j}
+        &\Longrightarrow
+        \spn\{A^j_w:|w|=L_0+1\}=\MN{D_j}
+        \notag\\
+        &\Longrightarrow
+        \spn\{A^j_w:|w|=3(L_0+1)\}=\MN{D_j}. \notag
+    \end{align}
     Theorem~\ref{thm:pgvwc_prepared_gauge_product_span} then gives the full
     simultaneous span at $q=3(r-1)(L_0+1)$ on the source representatives.
     The source unital identity and

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -411,7 +411,7 @@ direct.
     \label{lem:tp_gauge_preserves_irreducibility}
     \lean{MPSTensor.isIrreducibleTensor_tpGauge_of_isIrreducibleMap}
     \leanok
-    \uses{def:irreducible_tensor, lem:tp_gauge_equiv}
+    \uses{def:irreducible_tensor}
     Let $A$ have positive bond dimension and irreducible transfer map. If
     $\Lambda>0$, then the square-root-gauged tensor
     $\Lambda^{1/2}A\Lambda^{-1/2}$ is irreducible.
@@ -421,7 +421,7 @@ direct.
     \label{lem:gauge_phase_equiv_transport_left_right}
     \lean{MPSTensor.gaugePhaseEquiv_of_gaugeEquiv_left_right_cast}
     \leanok
-    \uses{def:blocks_not_gauge_phase_equiv}
+    \uses{def:gauge_equiv, def:gauge_phase_equiv}
     Gauge equivalent replacements on both sides preserve gauge-phase
     equivalence, including after identifying equal bond dimensions.
 \end{lemma}
@@ -482,8 +482,7 @@ direct.
     injectivity statements, and pairwise inequivalence up to gauge and phase.
     Thus every $B^j$ is algebraically normal and left-canonical, so
     \begin{align}
-        \lim_{N\to\infty}
-        \left\langle V^{(N)}(B^j),V^{(N)}(B^j)\right\rangle&=1. \notag
+        O_{B^jB^j}(N)&\longrightarrow1. \notag
     \end{align}
     The sharp separation theorem now gives
     \begin{align}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex
@@ -398,6 +398,34 @@ direct.
     block-separating equations with $S=3(L_0+1)$.
 \end{proof}
 
+\begin{theorem}[Tensor irreducibility implies transfer-map irreducibility]
+    \label{thm:irreducible_tensor_to_transfer_map}
+    \lean{MPSTensor.isIrreducibleMap_of_isIrreducibleTensor}
+    \leanok
+    \uses{def:irreducible_tensor}
+    If an MPS tensor is irreducible, then its transfer map has no nontrivial
+    invariant face.
+\end{theorem}
+
+\begin{lemma}[Positive square-root gauging preserves irreducibility]
+    \label{lem:tp_gauge_preserves_irreducibility}
+    \lean{MPSTensor.isIrreducibleTensor_tpGauge_of_isIrreducibleMap}
+    \leanok
+    \uses{def:irreducible_tensor, lem:tp_gauge_equiv}
+    Let $A$ have positive bond dimension and irreducible transfer map. If
+    $\Lambda>0$, then the square-root-gauged tensor
+    $\Lambda^{1/2}A\Lambda^{-1/2}$ is irreducible.
+\end{lemma}
+
+\begin{lemma}[Gauge-phase equivalence transports across two gauges]
+    \label{lem:gauge_phase_equiv_transport_left_right}
+    \lean{MPSTensor.gaugePhaseEquiv_of_gaugeEquiv_left_right_cast}
+    \leanok
+    \uses{def:blocks_not_gauge_phase_equiv}
+    Gauge equivalent replacements on both sides preserve gauge-phase
+    equivalence, including after identifying equal bond dimensions.
+\end{lemma}
+
 \begin{theorem}[Prepared-gauge simultaneous product span]
     \label{thm:pgvwc_prepared_gauge_product_span}
     \lean{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint}
@@ -433,6 +461,9 @@ direct.
     \leanok
     \uses{lem:tp_gauge_equiv,
         thm:tp_gauge_from_adjoint_fixed,
+        thm:irreducible_tensor_to_transfer_map,
+        lem:tp_gauge_preserves_irreducibility,
+        lem:gauge_phase_equiv_transport_left_right,
         lem:gauge_invariance_block_injective,
         thm:is_normal_tensor_of_is_normal_left_canonical,
         thm:cpsv_normal_mpv_phase_gauge,
@@ -481,10 +512,13 @@ direct.
 
 \begin{proof}
     \leanok
-    \uses{lem:unital_simultaneous_product_span_propagation,
+    \uses{thm:wordspan_propagation_unital,
+        lem:unital_simultaneous_product_span_propagation,
         thm:pgvwc_prepared_gauge_product_span,
         lem:product_span_block_image_direct_sum}
-    Theorem~\ref{thm:pgvwc_prepared_gauge_product_span} gives the full
+    Theorem~\ref{thm:wordspan_propagation_unital} first propagates block
+    injectivity from $L_0$ to $L_0+1$ and $3(L_0+1)$.
+    Theorem~\ref{thm:pgvwc_prepared_gauge_product_span} then gives the full
     simultaneous span at $q=3(r-1)(L_0+1)$ on the source representatives.
     The source unital identity and
     Lemma~\ref{lem:unital_simultaneous_product_span_propagation} propagate
@@ -549,22 +583,74 @@ direct.
     inclusion follows by splitting a word of length $m+1$ at either endpoint.
 \end{proof}
 
-\begin{remark}[Doubly normalized specialization]
-    \label{rem:pgvwc_direct_sum_doubly_normalized_specialization}
+\begin{theorem}[Doubly normalized simultaneous product span]
+    \label{thm:pgvwc_product_span_doubly_normalized}
     \lean{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \leanok
+    \uses{def:blockwise_product_word_span,
+        def:blocks_not_gauge_phase_equiv, def:mpv_overlap}
+    Let $r\ge2$, and let the bond dimensions be positive. Suppose that the
+    blocks are irreducible, have normalized self-overlap, are pairwise
+    inequivalent up to gauge and phase, and are injective at a common length
+    $L_0>0$. Assume both normalization identities
+    \begin{align}
+        \sum_aA^j_aA^{j\,\dagger}_a&=\Id,
+        &\sum_a(A^j_a)^\dagger A^j_a&=\Id. \notag
+    \end{align}
+    Then for every $n\ge3(r-1)(L_0+1)$,
+    \begin{align}
+        \spn\{(A^1_w,\ldots,A^r_w):|w|=n\}&=\prod_j\MN{D_j}. \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:wordspan_propagation_unital,
+        lem:bnt_direct_sum_block_separation_word_span,
+        lem:unital_simultaneous_product_span_propagation}
+    Propagate injectivity to the two longer lengths used by the sharp block
+    separation theorem, obtain the simultaneous span at
+    $3(r-1)(L_0+1)$, and propagate it using the right-unital identity.
+\end{proof}
+
+\begin{theorem}[Doubly normalized block-space independence]
+    \label{thm:pgvwc_block_space_independence_doubly_normalized}
     \lean{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
+    \leanok
+    \uses{thm:pgvwc_product_span_doubly_normalized, def:ground_space_parent}
+    Under the hypotheses of
+    Theorem~\ref{thm:pgvwc_product_span_doubly_normalized}, the spaces
+    $G_n(A^j)$ form an internal sum for every
+    $n\ge3(r-1)(L_0+1)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:pgvwc_product_span_doubly_normalized,
+        lem:product_span_block_image_direct_sum}
+    Apply nondegeneracy of the trace pairing to the simultaneous product span.
+\end{proof}
+
+\begin{theorem}[Doubly normalized restriction intersection]
+    \label{thm:pgvwc_direct_sum_intersection_doubly_normalized}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07}
     \leanok
-    Under the hypotheses above, assume additionally that every block has
-    normalized self-overlap and satisfies
+    \uses{thm:pgvwc_product_span_doubly_normalized, def:ground_space_parent}
+    Under the same hypotheses, if $m\ge3(r-1)(L_0+1)+1$, then
     \begin{align}
-        \sum_a(A^j_a)^\dagger A^j_a&=\Id. \notag
+        \C^d\otimes\left(\sum_jG_m(A^j)\right)
+        \cap\left(\sum_jG_m(A^j)\right)\otimes\C^d
+        &=\sum_jG_{m+1}(A^j). \notag
     \end{align}
-    The retained doubly normalized declarations give the same simultaneous
-    product span, internal-sum independence, and one-step
-    restriction-intersection identity. They are the specialization
-    $\Lambda^j=\Id$ of the source-normalized results.
-\end{remark}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:pgvwc_product_span_doubly_normalized,
+        lem:block_restriction_intersection_subspace}
+    Use the simultaneous product span at length $m-1$ in the endpoint
+    restriction calculation.
+\end{proof}
 
 \begin{lemma}[Product span makes the sum of local spaces direct]
     \label{lem:product_span_block_image_direct_sum}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -143,26 +143,27 @@ definite fixed point $\Lambda_j$ satisfying
 \begin{align}
   \sum_a (A^j_a)^\dagger\Lambda_j A^j_a=\Lambda_j.
 \end{align}
-The current source-length declarations additionally assume
+The source-shaped gauge-preparation, simultaneous word-span, internal-sum, and
+one-step restriction-intersection declarations no longer assume
 \begin{align}
-  \sum_a (A^j_a)^\dagger A^j_a=I,
+  \sum_a (A^j_a)^\dagger A^j_a=I.
 \end{align}
-which is the special case $\Lambda_j=I$. Consequently the declarations whose
-names end in \texttt{\_pgvwc07} along the global-cut route are doubly normalized
-specializations at the PGVWC07 source length bound, rather than formalizations
-of the unrestricted normalization in Theorem~12.
+They use the positive square root of $\Lambda_j$ only to prepare a temporary
+left-canonical gauge for the sharp fixed-length separation theorem, transport
+the resulting tuple span back to the original representatives, and propagate
+it there using the source identity
+$\sum_a A^j_a(A^j_a)^\dagger=I$.  This source-faithful local layer is completed
+by \href{https://github.com/LionSR/TNLean/issues/5764}{issue~\#5764}.
 
-Eliminating this restriction requires a gauge-covariant version of the route.
-For each positive definite $\Lambda_j$, conjugation by its positive square root
-turns the dual fixed-point equation into the identity fixed-point equation. One
-must transport the simultaneous word spans, open-boundary maps, periodic chain
-spaces, block direct sum, parent-Hamiltonian kernel, and component-vector span
-through these blockwise gauges. The source identity
-$\sum_a A^j_a(A^j_a)^\dagger=I$ must be retained by expressing the tuple-span
-propagation and boundary-matrix calculation in their corresponding weighted,
-gauge-covariant forms, rather than assuming that both unweighted identities
-hold in one gauge. This elimination is tracked by
-\href{https://github.com/LionSR/TNLean/issues/5751}{follow-up issue~\#5751}.
+The global-cut, boundary, periodic chain-space, and parent-Hamiltonian kernel
+declarations have not yet been threaded through the positive dual data.  They
+still additionally assume
+$\sum_a (A^j_a)^\dagger A^j_a=I$, the special case $\Lambda_j=I$, and hence
+remain doubly normalized specializations at the PGVWC07 source length bound.
+Transporting the source-shaped local result through those global arguments is
+tracked by \href{https://github.com/LionSR/TNLean/issues/5770}{issue~\#5770}.
+That issue has not merged, so the unrestricted parent-Hamiltonian theorem is
+not complete.
 
 \section{The block-diagonal intersection identity}
 

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -268,14 +268,14 @@ The proved one-step conclusion is therefore
 \end{align}
 for all sufficiently large $m$ satisfying the product-span hypotheses.
 The tuple-span, internal-sum, and one-step intersection statements now hold
-under the source canonical data
+under the source canonical data: for each block $j$, let $\Lambda^j$ be a
+positive definite matrix satisfying
 \begin{align}
   \sum_aA^j_aA^{j\dagger}_a&=I,
-  &\Lambda^j&>0,
-  &\sum_aA^{j\dagger}_a\Lambda^jA^j_a&=\Lambda^j,
+  &\sum_aA^{j\dagger}_a\Lambda^jA^j_a&=\Lambda^j.
 \end{align}
-without requiring either diagonality of $\Lambda^j$ or the additional identity
-$\sum_aA^{j\dagger}_aA^j_a=I$ on the same representative.  The proof uses the
+These statements require neither diagonality of $\Lambda^j$ nor the additional
+identity $\sum_aA^{j\dagger}_aA^j_a=I$ on the same representative. The proof uses the
 positive dual fixed point only to prepare a temporary left-canonical gauge for
 the sharp base separation theorem, transports the tuple span back, and then
 propagates it with the source unital identity.\footnote{Lean declarations:

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -286,21 +286,27 @@ The earlier doubly-normalized declarations remain available as special-purpose
 siblings.
 
 This normalization relaxation has not yet been threaded through the global
-change-of-cut and kernel statements.  Those declarations still use the
-left-canonical source hypothesis when they propagate the cyclic local
+change-of-cut and kernel statements.  Those declarations remain honestly
+restricted to the doubly-normalized specialization: in addition to
+$\sum_aA^j_aA^{j\dagger}_a=I$, they assume
+$\sum_aA^{j\dagger}_aA^j_a=I$, which specializes the positive dual fixed point
+to $\Lambda^j=I$.  Under that extra identity they propagate the cyclic local
 constraints to
 \begin{align}
   \mathcal K_{N,L}(\widehat A)\subseteq
   S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
 \end{align}
-and when they make the sum defining $S_N$ internal.\footnote{Lean declarations:
+and make the sum defining $S_N$ internal.\footnote{Lean declarations:
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07},
 \leanid{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07},
 and
 \leanid{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07}.}
-The global boundary threading is therefore the remaining normalization-scope
-step; the completed source-shaped tuple-span layer alone does not establish the
-full unrestricted parent-Hamiltonian theorem.
+Threading the positive dual data through the global change-of-cut and kernel
+capstones remains open in
+\href{https://github.com/LionSR/TNLean/issues/5770}{issue~\#5770}; it is not
+completed by the source-shaped tuple-span and one-step intersection layer above.
+Consequently the full unrestricted parent-Hamiltonian theorem is not yet
+established.
 
 Earlier conditional reductions isolated the source comparison in the coordinates
 obtained by opening the periodic boundary for boundary-crossing windows. Suppose

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -265,27 +265,42 @@ The proved one-step conclusion is therefore
   =
   \bigoplus_j \mathcal G_{m+1}^{A_j}
 \end{align}
-for all sufficiently large $m$ satisfying the product-span hypotheses.\footnote{
-Lean declarations:
-\leanid{MPSTensor.pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop},
-\leanid{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}, and
-\leanid{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07}.}
-The corresponding source-range declarations then propagate the cyclic
-local constraints to
+for all sufficiently large $m$ satisfying the product-span hypotheses.
+The tuple-span, internal-sum, and one-step intersection statements now hold
+under the source canonical data
+\begin{align}
+  \sum_aA^j_aA^{j\dagger}_a&=I,
+  &\Lambda^j&>0,
+  &\sum_aA^{j\dagger}_a\Lambda^jA^j_a&=\Lambda^j,
+\end{align}
+without requiring either diagonality of $\Lambda^j$ or the additional identity
+$\sum_aA^{j\dagger}_aA^j_a=I$ on the same representative.  The proof uses the
+positive dual fixed point only to prepare a temporary left-canonical gauge for
+the sharp base separation theorem, transports the tuple span back, and then
+propagates it with the source unital identity.\footnote{Lean declarations:
+\leanid{MPSTensor.wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1_of_dualFixedPoint},
+\leanid{MPSTensor.wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint},
+\leanid{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}, and
+\leanid{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint}.}
+The earlier doubly-normalized declarations remain available as special-purpose
+siblings.
+
+This normalization relaxation has not yet been threaded through the global
+change-of-cut and kernel statements.  Those declarations still use the
+left-canonical source hypothesis when they propagate the cyclic local
+constraints to
 \begin{align}
   \mathcal K_{N,L}(\widehat A)\subseteq
   S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
 \end{align}
-and make the sum defining $S_N$ internal.\footnote{Lean declarations:
+and when they make the sum defining $S_N$ internal.\footnote{Lean declarations:
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07},
 \leanid{MPSTensor.groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1_pgvwc07},
 and
 \leanid{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07}.}
-The former residual was the source boundary-condition comparison: starting with a
-vector in the periodic-boundary space $\mathcal K_{N,L}(\widehat A)$, produce
-block-diagonal boundary matrices whose block components again belong to the
-blockwise periodic-boundary spaces. The global change-of-cut theorem now proves
-this conclusion at the source length bound.
+The global boundary threading is therefore the remaining normalization-scope
+step; the completed source-shaped tuple-span layer alone does not establish the
+full unrestricted parent-Hamiltonian theorem.
 
 Earlier conditional reductions isolated the source comparison in the coordinates
 obtained by opening the periodic boundary for boundary-crossing windows. Suppose


### PR DESCRIPTION
## Summary

- prepare each source block temporarily with its positive dual fixed point, run the existing sharp left-canonical BNT tuple-span theorem there, and transport `WordTupleSpanTop` back through the shared nonunitary gauge invariance
- propagate the transported base span at all larger source lengths using only the source identity `∑ₐ Aₐ Aₐᴴ = I`
- add source-shaped internal-sum and one-step restriction-intersection wrappers with no diagonality or source left-canonical hypothesis
- preserve the existing doubly-normalized declarations and all prepared-gauge pair-separation machinery unchanged
- update Chapter 13 and the parent-Hamiltonian normalization-scope note to separate this completed tuple-span layer from the still-pending global boundary/kernel threading

## Source shape

For each block, the new declarations assume

```text
∑ₐ Aₐ Aₐᴴ = I,
Λ > 0,
∑ₐ Aₐᴴ Λ Aₐ = Λ,
```

and do not assume `Λ = I`, diagonality of `Λ`, or `∑ₐ Aₐᴴ Aₐ = I` on the source representative.

## Scope

This PR intentionally does **not** change the global-cut, boundary-closing, or kernel capstones and does not claim the parent issue complete.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockIntersection`
- `lake build TNLean`
- blueprint declaration index regeneration and sync
- `lake exe checkdecls blueprint/lean_decls`
- reader-facing prose policy
- oversized Lean-file policy
- numbered-module policy
- forbidden proof-integrity token audit
- `git diff --check`

Closes #5764
Refs #5751

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formalize sensitive block-intersection and ground-space algebra in the parent-Hamiltonian route, but the diff is additive and explicitly scoped to the tuple-span layer rather than kernel or global-cut conclusions.
> 
> **Overview**
> Adds **source-faithful** PGVWC07 local lemmas: simultaneous block word spans, internal sums of ground spaces, and the one-step restriction–intersection identity under **right-unital** normalization plus a **positive dual fixed point** Λ, without requiring Λ = I, diagonality, or ∑ₐ Aₐᴴ Aₐ = I on the original blocks.
> 
> The core proof pattern gauges each block temporarily with `tpGauge` using Λ^{1/2}, runs the existing sharp left-canonical BNT separation on the prepared family, then transports `WordTupleSpanTop` back via gauge equivalence and propagates to all larger lengths using only ∑ₐ Aₐ Aₐᴴ = I. A small helper consolidates unital propagation of block injectivity at L₀+1 and 3(L₀+1).
> 
> **Doubly normalized** declarations and global-cut / boundary / kernel capstones are unchanged; blueprint and `docs/paper-gaps` now label them separately and note that threading positive Λ through those global arguments remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4b3044faee65aa4840ff036e5b6595fe918a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->