### PR TITLE
feat(MPS/MPU): bound active blocks from transfer traces

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.MPS.MPU
 
+import TNLean.MPS.MPU.ActiveTransferMultiplicity
 import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.SourceCuts

--- a/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
+++ b/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
@@ -298,7 +298,7 @@ This is the algebraic-multiplicity step in arXiv:1703.09188, Proposition
 `prop:normal-tensor`, lines 349--354. No full-active-support, positivity,
 normality, diagonalizability, or first-moment hypothesis is required for the
 ambient tensor. -/
-theorem card_active_eq_one_of_shifted_transfer_trace [NeZero D]
+theorem card_active_eq_one_of_shifted_transfer_trace
     (data : CPSVCanonicalFormData A)
     (htrace : ∀ N, 1 < N →
       Matrix.trace (transferMatrix (transferMap A) ^ N) = 1) :

--- a/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
+++ b/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
@@ -1,0 +1,381 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ShiftedTracePowerSpectrum
+import TNLean.Channel.TransferMatrix
+import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
+import TNLean.MPS.SharedInfra.Scaling
+import Mathlib.LinearAlgebra.Eigenspace.Zero
+
+/-!
+# Active Canonical Blocks and Transfer Multiplicity
+
+This file proves the algebraic multiplicity step in arXiv:1703.09188,
+Proposition `prop:normal-tensor`, lines 349--354. For literal CPSV canonical-form
+data, the shifted transfer-trace identities force exactly one nonzero-weight
+canonical block.
+
+Each normal block supplies an unweighted fixed vector. Its weighted block has
+eigenvalue `weight * star weight`; after embedding the corresponding diagonal
+corner into the ambient bond space, the shifted nonzero-spectrum theorem forces
+this eigenvalue to be one. The resulting ambient fixed vectors are linearly
+independent. Applying the all-positive trace-power characteristic-polynomial
+theorem to the square of the transfer matrix bounds their number by one.
+
+No positivity, normality, diagonalizability, full-active-support, or first-moment
+hypothesis is imposed on the ambient tensor.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1703.09188,
+  Proposition `prop:normal-tensor`, lines 349--354
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2016] arXiv:1606.00608,
+  Section 2.3, lines 214--263
+-/
+
+open scoped Matrix BigOperators
+open Polynomial
+
+namespace MPSTensor
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+namespace CPSVCanonicalFormData
+
+/-- The inclusion of a retained canonical block into the ambient bond space. -/
+private noncomputable def ambientBlockInclusion (data : CPSVCanonicalFormData A) (k : Fin data.r) :
+    Matrix (Fin D) (Fin (data.dim k)) ℂ :=
+  data.ambient_coisometryᴴ * blockInclusion data.dim k
+
+/-- A retained block inclusion into the ambient bond space is an isometry. -/
+private theorem ambientBlockInclusion_conjTranspose_mul_self
+    (data : CPSVCanonicalFormData A) (k : Fin data.r) :
+    (data.ambientBlockInclusion k)ᴴ * data.ambientBlockInclusion k = 1 := by
+  rw [ambientBlockInclusion, Matrix.conjTranspose_mul]
+  simp only [Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc data.ambient_coisometry data.ambient_coisometryᴴ,
+    data.coisometric, Matrix.one_mul, blockInclusion_conjTranspose_mul_self]
+
+/-- Ambient inclusions of distinct retained blocks have orthogonal ranges. -/
+private theorem ambientBlockInclusion_conjTranspose_mul_eq_zero
+    (data : CPSVCanonicalFormData A) {k l : Fin data.r} (hkl : k ≠ l) :
+    (data.ambientBlockInclusion k)ᴴ * data.ambientBlockInclusion l = 0 := by
+  rw [ambientBlockInclusion, ambientBlockInclusion, Matrix.conjTranspose_mul]
+  simp only [Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc data.ambient_coisometry data.ambient_coisometryᴴ,
+    data.coisometric, Matrix.one_mul,
+    blockInclusion_conjTranspose_mul_eq_zero data.dim hkl]
+
+/-- The CPSV reconstruction intertwines an ambient block inclusion with the
+corresponding weighted canonical block. -/
+private theorem mul_ambientBlockInclusion
+    (data : CPSVCanonicalFormData A) (k : Fin data.r) (i : Fin d) :
+    A i * data.ambientBlockInclusion k =
+      data.ambientBlockInclusion k * (data.weights k • data.blocks k i) := by
+  rw [data.reconstruct i, ambientBlockInclusion]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc data.ambient_coisometry data.ambient_coisometryᴴ,
+    data.coisometric, Matrix.one_mul, toTensorFromBlocks_mul_blockInclusion]
+
+/-- Compressing a matrix supported in one ambient block corner recovers that matrix. -/
+private theorem ambientBlockCompression_self
+    (data : CPSVCanonicalFormData A) (k : Fin data.r)
+    (X : Matrix (Fin (data.dim k)) (Fin (data.dim k)) ℂ) :
+    (data.ambientBlockInclusion k)ᴴ *
+        (data.ambientBlockInclusion k * X * (data.ambientBlockInclusion k)ᴴ) *
+      data.ambientBlockInclusion k = X := by
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (data.ambientBlockInclusion k)ᴴ,
+    data.ambientBlockInclusion_conjTranspose_mul_self, Matrix.one_mul]
+  rw [Matrix.mul_one]
+
+/-- Compressing a matrix supported in a different ambient block corner gives zero. -/
+private theorem ambientBlockCompression_eq_zero_of_ne
+    (data : CPSVCanonicalFormData A) {k l : Fin data.r} (hkl : k ≠ l)
+    (X : Matrix (Fin (data.dim l)) (Fin (data.dim l)) ℂ) :
+    (data.ambientBlockInclusion k)ᴴ *
+        (data.ambientBlockInclusion l * X * (data.ambientBlockInclusion l)ᴴ) *
+      data.ambientBlockInclusion k = 0 := by
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (data.ambientBlockInclusion k)ᴴ,
+    data.ambientBlockInclusion_conjTranspose_mul_eq_zero hkl,
+    Matrix.zero_mul]
+
+/-- Nonzero matrices placed in the distinct ambient canonical-block corners are
+linearly independent. -/
+private theorem linearIndependent_ambientBlockCorners
+    (data : CPSVCanonicalFormData A)
+    (X : (k : data.Active) → Matrix (Fin (data.dim k.1)) (Fin (data.dim k.1)) ℂ)
+    (hX : ∀ k, X k ≠ 0) :
+    LinearIndependent ℂ (fun k : data.Active =>
+      data.ambientBlockInclusion k.1 * X k * (data.ambientBlockInclusion k.1)ᴴ) := by
+  classical
+  rw [Fintype.linearIndependent_iff]
+  intro c hsum k
+  have hcompressed := congrArg
+    (fun Z : Matrix (Fin D) (Fin D) ℂ =>
+      (data.ambientBlockInclusion k.1)ᴴ * Z * data.ambientBlockInclusion k.1) hsum
+  simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_smul, Matrix.smul_mul,
+    Matrix.mul_zero, Matrix.zero_mul] at hcompressed
+  have hterm : ∀ l : data.Active,
+      (data.ambientBlockInclusion k.1)ᴴ *
+          (data.ambientBlockInclusion l.1 * X l * (data.ambientBlockInclusion l.1)ᴴ) *
+        data.ambientBlockInclusion k.1 = if l = k then X k else 0 := by
+    intro l
+    by_cases hlk : l = k
+    · subst l
+      rw [if_pos rfl, data.ambientBlockCompression_self]
+    · rw [if_neg hlk]
+      exact data.ambientBlockCompression_eq_zero_of_ne
+        (k := k.1) (l := l.1) (fun h => hlk (Subtype.ext h.symm)) (X l)
+  simp_rw [hterm] at hcompressed
+  have hck : c k • X k = 0 := by
+    calc
+      c k • X k = ∑ l, c l • if l = k then X k else 0 := by simp
+      _ = 0 := hcompressed
+  exact (smul_eq_zero.mp hck).resolve_right (hX k)
+
+/-- A normal MPS block has a nonzero fixed vector for its transfer map. -/
+private theorem exists_nonzero_transferMap_fixedVector_of_normal
+    {n : ℕ} {B : MPSTensor d n} (hB : IsNormalTensor B) :
+    ∃ X : Matrix (Fin n) (Fin n) ℂ, X ≠ 0 ∧ transferMap B X = X := by
+  have hone : (1 : ℂ) ∈ peripheralEigenvalues (transferMap B) := by
+    rw [hB.primitive_transfer]
+    simp
+  obtain ⟨X, hX⟩ := hone.1.exists_hasEigenvector
+  exact ⟨X, hX.2, by simpa using hX.apply_eq_smul⟩
+
+/-- A chosen nonzero transfer fixed vector for one retained normal block. -/
+private noncomputable def blockFixedVector (data : CPSVCanonicalFormData A) (k : Fin data.r) :
+    Matrix (Fin (data.dim k)) (Fin (data.dim k)) ℂ :=
+  Classical.choose (exists_nonzero_transferMap_fixedVector_of_normal (data.blocks_normal k))
+
+/-- The chosen normal-block fixed vector is nonzero. -/
+private theorem blockFixedVector_ne (data : CPSVCanonicalFormData A) (k : Fin data.r) :
+    data.blockFixedVector k ≠ 0 :=
+  (Classical.choose_spec
+    (exists_nonzero_transferMap_fixedVector_of_normal (data.blocks_normal k))).1
+
+/-- The chosen normal-block vector is fixed by the unweighted block transfer map. -/
+private theorem transferMap_blockFixedVector (data : CPSVCanonicalFormData A) (k : Fin data.r) :
+    transferMap (data.blocks k) (data.blockFixedVector k) = data.blockFixedVector k :=
+  (Classical.choose_spec
+    (exists_nonzero_transferMap_fixedVector_of_normal (data.blocks_normal k))).2
+
+/-- The transfer eigenvalue contributed by a weighted active block. -/
+private noncomputable def activeTransferEigenvalue
+    (data : CPSVCanonicalFormData A) (k : data.Active) : ℂ :=
+  data.weights k.1 * starRingEnd ℂ (data.weights k.1)
+
+/-- The weighted active block acts on its unweighted fixed vector with eigenvalue
+`weight * star weight`. -/
+private theorem transferMap_weightedBlock_blockFixedVector
+    (data : CPSVCanonicalFormData A) (k : data.Active) :
+    transferMap (fun i => data.weights k.1 • data.blocks k.1 i)
+        (data.blockFixedVector k.1) =
+      data.activeTransferEigenvalue k • data.blockFixedVector k.1 := by
+  rw [transferMap_smul, data.transferMap_blockFixedVector]
+  rfl
+
+/-- The ambient matrix obtained by transporting one active block fixed vector. -/
+private noncomputable def ambientActiveVector
+    (data : CPSVCanonicalFormData A) (k : data.Active) : Matrix (Fin D) (Fin D) ℂ :=
+  data.ambientBlockInclusion k.1 * data.blockFixedVector k.1 *
+    (data.ambientBlockInclusion k.1)ᴴ
+
+/-- An active block's transported ambient vector is nonzero. -/
+private theorem ambientActiveVector_ne
+    (data : CPSVCanonicalFormData A) (k : data.Active) :
+    data.ambientActiveVector k ≠ 0 := by
+  intro hzero
+  apply data.blockFixedVector_ne k.1
+  calc
+    data.blockFixedVector k.1 =
+        (data.ambientBlockInclusion k.1)ᴴ * data.ambientActiveVector k *
+          data.ambientBlockInclusion k.1 :=
+      (data.ambientBlockCompression_self k.1 (data.blockFixedVector k.1)).symm
+    _ = 0 := by rw [hzero]; simp
+
+/-- Before spectral normalization, the transported ambient vector has the weighted
+block eigenvalue `weight * star weight`. -/
+private theorem transferMap_ambientActiveVector
+    (data : CPSVCanonicalFormData A) (k : data.Active) :
+    transferMap A (data.ambientActiveVector k) =
+      data.activeTransferEigenvalue k • data.ambientActiveVector k := by
+  rw [ambientActiveVector, transferMap_conj_of_intertwine A
+    (fun i => data.weights k.1 • data.blocks k.1 i)
+    (data.ambientBlockInclusion k.1) (data.mul_ambientBlockInclusion k.1)
+    (data.blockFixedVector k.1)]
+  rw [data.transferMap_weightedBlock_blockFixedVector k]
+  simp [Matrix.mul_smul, Matrix.smul_mul]
+
+/-- An active block's weighted transfer eigenvalue is nonzero. -/
+private theorem activeTransferEigenvalue_ne
+    (data : CPSVCanonicalFormData A) (k : data.Active) :
+    data.activeTransferEigenvalue k ≠ 0 := by
+  simp [activeTransferEigenvalue, k.2]
+
+/-- Shifted ambient transfer traces normalize every active weighted-block
+eigenvalue to one. -/
+private theorem activeTransferEigenvalue_eq_one
+    (data : CPSVCanonicalFormData A)
+    (htrace : ∀ N, 1 < N →
+      Matrix.trace (transferMatrix (transferMap A) ^ N) = 1)
+    (k : data.Active) :
+    data.activeTransferEigenvalue k = 1 := by
+  have hEig : Module.End.HasEigenvalue (transferMap A) (data.activeTransferEigenvalue k) :=
+    hasEigenvalue_of_eigenvector_eq _ _ (data.ambientActiveVector k)
+      (data.transferMap_ambientActiveVector k) (data.ambientActiveVector_ne k)
+  have hEigMatrix : Module.End.HasEigenvalue
+      (transferMatrix (transferMap A)).toLin' (data.activeTransferEigenvalue k) :=
+    (transferMatrix_hasEigenvalue_iff (transferMap A) _).mp hEig
+  have hspecLin : data.activeTransferEigenvalue k ∈
+      spectrum ℂ (transferMatrix (transferMap A)).toLin' :=
+    Module.End.hasEigenvalue_iff_mem_spectrum.mp hEigMatrix
+  have hspec : data.activeTransferEigenvalue k ∈
+      spectrum ℂ (transferMatrix (transferMap A)) := by
+    simpa using hspecLin
+  exact Matrix.eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
+    (transferMatrix (transferMap A)) htrace hspec (data.activeTransferEigenvalue_ne k)
+
+/-- Under shifted ambient transfer traces, each transported active-block vector
+is fixed by the ambient transfer map. -/
+private theorem transferMap_ambientActiveVector_eq_self
+    (data : CPSVCanonicalFormData A)
+    (htrace : ∀ N, 1 < N →
+      Matrix.trace (transferMatrix (transferMap A) ^ N) = 1)
+    (k : data.Active) :
+    transferMap A (data.ambientActiveVector k) = data.ambientActiveVector k := by
+  rw [data.transferMap_ambientActiveVector k, data.activeTransferEigenvalue_eq_one htrace k,
+    one_smul]
+
+/-- The shifted trace hypothesis bounds the one-eigenspace of the squared
+transfer matrix by one dimension. -/
+private theorem finrank_eigenspace_one_transferMatrix_sq_le_one
+    (htrace : ∀ N, 1 < N →
+      Matrix.trace (transferMatrix (transferMap A) ^ N) = 1) :
+    Module.finrank ℂ
+      (Module.End.eigenspace ((transferMatrix (transferMap A) ^ 2).toLin') (1 : ℂ)) ≤ 1 := by
+  let M := transferMatrix (transferMap A)
+  have hpow2 :=
+    Matrix.forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt
+      M htrace 2 (by omega)
+  have hchar : (M ^ 2).charpoly =
+      X ^ (Fintype.card (Fin D × Fin D) - 1) * (X - 1) :=
+    Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one
+      (M ^ 2) hpow2
+  calc
+    Module.finrank ℂ (Module.End.eigenspace ((M ^ 2).toLin') (1 : ℂ)) ≤
+        ((M ^ 2).toLin').charpoly.rootMultiplicity 1 :=
+      LinearMap.finrank_eigenspace_le _ _
+    _ = 1 := by
+      rw [Matrix.charpoly_toLin', hchar]
+      rw [Polynomial.rootMultiplicity_mul]
+      · rw [Polynomial.rootMultiplicity_eq_zero]
+        · simpa using
+            (Polynomial.rootMultiplicity_X_sub_C_self (R := ℂ) (x := (1 : ℂ)))
+        · simp [Polynomial.IsRoot]
+      · exact mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero)
+          (Polynomial.X_sub_C_ne_zero 1)
+
+/-- The active canonical blocks give linearly independent ambient transfer fixed
+vectors. -/
+private theorem linearIndependent_ambientActiveVector
+    (data : CPSVCanonicalFormData A) :
+    LinearIndependent ℂ data.ambientActiveVector := by
+  change LinearIndependent ℂ (fun k : data.Active =>
+    data.ambientBlockInclusion k.1 * data.blockFixedVector k.1 *
+      (data.ambientBlockInclusion k.1)ᴴ)
+  exact data.linearIndependent_ambientBlockCorners
+    (fun k : data.Active => data.blockFixedVector k.1)
+    (fun k => data.blockFixedVector_ne k.1)
+
+/-- Shifted transfer traces force exactly one active CPSV canonical block.
+
+This is the algebraic-multiplicity step in arXiv:1703.09188, Proposition
+`prop:normal-tensor`, lines 349--354. No full-active-support, positivity,
+normality, diagonalizability, or first-moment hypothesis is required for the
+ambient tensor. -/
+theorem card_active_eq_one_of_shifted_transfer_trace [NeZero D]
+    (data : CPSVCanonicalFormData A)
+    (htrace : ∀ N, 1 < N →
+      Matrix.trace (transferMatrix (transferMap A) ^ N) = 1) :
+    Fintype.card data.Active = 1 := by
+  classical
+  have hactive : Nonempty data.Active := by
+    by_contra hempty
+    haveI : IsEmpty data.Active := not_nonempty_iff.mp hempty
+    have hweight : ∀ k : Fin data.r, data.weights k = 0 := by
+      intro k
+      by_contra hk
+      exact isEmptyElim (⟨k, hk⟩ : data.Active)
+    have hAzero : A = 0 := by
+      funext i
+      rw [data.reconstruct i]
+      have hassembly : toTensorFromBlocks data.weights data.blocks i = 0 := by
+        unfold toTensorFromBlocks
+        simp only [hweight, zero_smul]
+        change Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+          (Matrix.blockDiagonal' (0 : ∀ k : Fin data.r,
+            Matrix (Fin (data.dim k)) (Fin (data.dim k)) ℂ)) = 0
+        rw [Matrix.blockDiagonal'_zero]
+        simp
+      rw [hassembly]
+      simp
+    have htwo := htrace 2 (by omega)
+    rw [hAzero] at htwo
+    have htransferZero :
+        transferMatrix (transferMap (0 : MPSTensor d D)) = 0 := by
+      ext ⟨a, b⟩ ⟨c, e⟩
+      simp [transferMatrix, transferMap_apply]
+    rw [htransferZero] at htwo
+    simp at htwo
+  let M := transferMatrix (transferMap A)
+  let f : Module.End ℂ (Fin D × Fin D → ℂ) := (M ^ 2).toLin'
+  let v : data.Active → f.eigenspace (1 : ℂ) := fun k =>
+    ⟨(data.ambientActiveVector k).vec, by
+      rw [Module.End.mem_eigenspace_iff]
+      change (M ^ 2).toLin' (data.ambientActiveVector k).vec =
+        (1 : ℂ) • (data.ambientActiveVector k).vec
+      rw [Matrix.toLin'_apply]
+      change transferMatrix (transferMap A) ^ 2 *ᵥ (data.ambientActiveVector k).vec = _
+      rw [← transferMatrix_pow, transferMatrix_mulVec_eq]
+      have hfix := data.transferMap_ambientActiveVector_eq_self htrace k
+      have hpow : ((transferMap A) ^ 2) (data.ambientActiveVector k) =
+          data.ambientActiveVector k := by
+        change transferMap A (transferMap A (data.ambientActiveVector k)) =
+          data.ambientActiveVector k
+        rw [hfix, hfix]
+      rw [hpow, one_smul]⟩
+  let vecLM : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin D × Fin D → ℂ) := {
+    toFun := Matrix.vec
+    map_add' := by intros; rfl
+    map_smul' := by intros; rfl }
+  have hvecKer : LinearMap.ker vecLM = ⊥ := by
+    rw [LinearMap.ker_eq_bot']
+    intro X hX
+    exact Matrix.vec_inj.mp hX
+  have hLIvec : LinearIndependent ℂ
+      (fun k : data.Active => (data.ambientActiveVector k).vec) := by
+    simpa [vecLM, Function.comp_def] using
+      data.linearIndependent_ambientActiveVector.map' vecLM hvecKer
+  have hLIv : LinearIndependent ℂ v := by
+    rw [Fintype.linearIndependent_iff]
+    intro c hsum k
+    apply Fintype.linearIndependent_iff.mp hLIvec c _ k
+    have hcoe := congrArg
+      (fun z : f.eigenspace (1 : ℂ) => (z : Fin D × Fin D → ℂ)) hsum
+    simpa [v] using hcoe
+  have hcard_le_finrank : Fintype.card data.Active ≤ Module.finrank ℂ (f.eigenspace 1) :=
+    hLIv.fintype_card_le_finrank
+  have hfinrank_le : Module.finrank ℂ (f.eigenspace 1) ≤ 1 := by
+    simpa [f, M] using finrank_eigenspace_one_transferMatrix_sq_le_one
+      (A := A) htrace
+  have hcard_pos : 0 < Fintype.card data.Active := Fintype.card_pos_iff.mpr hactive
+  omega
+
+end CPSVCanonicalFormData
+
+end MPSTensor

--- a/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
+++ b/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
@@ -177,7 +177,7 @@ private theorem transferMap_weightedBlock_blockFixedVector
         (data.blockFixedVector k.1) =
       data.activeTransferEigenvalue k • data.blockFixedVector k.1 := by
   rw [transferMap_smul, data.transferMap_blockFixedVector]
-  rfl
+  simp [activeTransferEigenvalue]
 
 /-- The ambient matrix obtained by transporting one active block fixed vector. -/
 private noncomputable def ambientActiveVector

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.MPU.ActiveTransferMultiplicity
 import TNLean.MPS.CanonicalForm.Reduction
 
 /-!

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.Definitions
-import TNLean.MPS.MPU.ActiveTransferMultiplicity
 import TNLean.MPS.CanonicalForm.Reduction
 
 /-!

--- a/TNLean/MPS/SharedInfra/BlockAssembly.lean
+++ b/TNLean/MPS/SharedInfra/BlockAssembly.lean
@@ -31,6 +31,67 @@ noncomputable def toTensorFromBlocks {r : ℕ} {dim : Fin r → ℕ}
   (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
     (Matrix.blockDiagonal' fun k => (μ k) • (A k i))
 
+/-- The coordinate inclusion of one dependent block into the flattened direct sum.
+
+This is the coordinate inclusion underlying the block reconstruction in
+arXiv:1606.00608, eq. `II_CF1`, lines 214--225. -/
+noncomputable def blockInclusion {r : ℕ} (dim : Fin r → ℕ) (k : Fin r) :
+    Matrix (Fin (∑ j : Fin r, dim j)) (Fin (dim k)) ℂ :=
+  fun x y => if x = finSigmaFinEquiv ⟨k, y⟩ then 1 else 0
+
+@[simp]
+theorem blockInclusion_apply {r : ℕ} (dim : Fin r → ℕ) (k : Fin r)
+    (x : Fin (∑ j : Fin r, dim j)) (y : Fin (dim k)) :
+    blockInclusion dim k x y = if x = finSigmaFinEquiv ⟨k, y⟩ then 1 else 0 := rfl
+
+/-- A flattened dependent-block coordinate inclusion is an isometry. -/
+theorem blockInclusion_conjTranspose_mul_self {r : ℕ} (dim : Fin r → ℕ) (k : Fin r) :
+    (blockInclusion dim k)ᴴ * blockInclusion dim k = 1 := by
+  classical
+  ext x y
+  by_cases hxy : x = y
+  · simp [Matrix.mul_apply, Matrix.one_apply, hxy]
+  · simp [Matrix.mul_apply, hxy, Ne.symm hxy]
+
+/-- Coordinate inclusions of distinct dependent blocks have orthogonal ranges. -/
+theorem blockInclusion_conjTranspose_mul_eq_zero {r : ℕ} (dim : Fin r → ℕ)
+    {k l : Fin r} (hkl : k ≠ l) :
+    (blockInclusion dim k)ᴴ * blockInclusion dim l = 0 := by
+  classical
+  ext x y
+  have hflat : finSigmaFinEquiv ⟨k, x⟩ ≠ finSigmaFinEquiv ⟨l, y⟩ := by
+    intro h
+    apply hkl
+    exact congrArg Sigma.fst (finSigmaFinEquiv.injective h)
+  simp [Matrix.mul_apply, Ne.symm hflat]
+
+/-- A flattened dependent-block inclusion intertwines the assembled tensor with its
+weighted block. This is the coordinate form of arXiv:1606.00608, eq. `II_CF1`,
+lines 214--225. -/
+theorem toTensorFromBlocks_mul_blockInclusion {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (k : Fin r) (i : Fin d) :
+    toTensorFromBlocks (d := d) μ A i * blockInclusion dim k =
+      blockInclusion dim k * (μ k • A k i) := by
+  classical
+  ext x y
+  generalize hs : finSigmaFinEquiv.symm x = sx
+  rcases sx with ⟨l, z⟩
+  by_cases hlk : l = k
+  · subst l
+    have hx : x = finSigmaFinEquiv ⟨k, z⟩ := by
+      rw [← finSigmaFinEquiv.apply_symm_apply x, hs]
+    simp [toTensorFromBlocks, blockInclusion, Matrix.mul_apply, hx]
+  · have hxne : ∀ z' : Fin (dim k), x ≠ finSigmaFinEquiv ⟨k, z'⟩ := by
+      intro z' hx
+      apply hlk
+      have : (⟨l, z⟩ : (j : Fin r) × Fin (dim j)) = ⟨k, z'⟩ := by
+        apply finSigmaFinEquiv.injective
+        rw [← hs, finSigmaFinEquiv.apply_symm_apply, hx]
+      exact congrArg Sigma.fst this
+    simp [toTensorFromBlocks, blockInclusion, Matrix.mul_apply, hs, hxne]
+    rw [Matrix.blockDiagonal'_apply_ne _ _ _ hlk]
+
 /-- Flatten the dependent block coordinates after reindexing the block family by an
 equivalence. -/
 noncomputable def blockIndexCoordinateEquiv {r : ℕ} {ι : Type*}

--- a/TNLean/MPS/SharedInfra/BlockAssembly.lean
+++ b/TNLean/MPS/SharedInfra/BlockAssembly.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.DependentBlockDiagonal
 import TNLean.Analysis.CoisometricCompression
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.Overlap.Basic
@@ -37,33 +38,47 @@ This is the coordinate inclusion underlying the block reconstruction in
 arXiv:1606.00608, eq. `II_CF1`, lines 214--225. -/
 noncomputable def blockInclusion {r : ℕ} (dim : Fin r → ℕ) (k : Fin r) :
     Matrix (Fin (∑ j : Fin r, dim j)) (Fin (dim k)) ℂ :=
-  fun x y => if x = finSigmaFinEquiv ⟨k, y⟩ then 1 else 0
+  Matrix.reindex finSigmaFinEquiv (Equiv.refl _)
+    (Matrix.sigmaBlockInclusion (fun j : Fin r => Fin (dim j)) k)
 
 @[simp]
 theorem blockInclusion_apply {r : ℕ} (dim : Fin r → ℕ) (k : Fin r)
     (x : Fin (∑ j : Fin r, dim j)) (y : Fin (dim k)) :
-    blockInclusion dim k x y = if x = finSigmaFinEquiv ⟨k, y⟩ then 1 else 0 := rfl
+    blockInclusion dim k x y = if x = finSigmaFinEquiv ⟨k, y⟩ then 1 else 0 := by
+  simp only [blockInclusion, Matrix.reindex_apply, Matrix.submatrix_apply,
+    Equiv.refl_symm, Equiv.coe_refl, Matrix.sigmaBlockInclusion]
+  by_cases h : x = finSigmaFinEquiv ⟨k, y⟩ <;>
+    simp [h, Equiv.symm_apply_eq]
 
 /-- A flattened dependent-block coordinate inclusion is an isometry. -/
 theorem blockInclusion_conjTranspose_mul_self {r : ℕ} (dim : Fin r → ℕ) (k : Fin r) :
     (blockInclusion dim k)ᴴ * blockInclusion dim k = 1 := by
-  classical
-  ext x y
-  by_cases hxy : x = y
-  · simp [Matrix.mul_apply, Matrix.one_apply, hxy]
-  · simp [Matrix.mul_apply, hxy, Ne.symm hxy]
+  let dim' := fun j : Fin r => Fin (dim j)
+  let e : ((j : Fin r) × dim' j) ≃ Fin (∑ j, dim j) := finSigmaFinEquiv
+  let E := Matrix.sigmaBlockInclusion dim' k
+  change (Matrix.reindex e (Equiv.refl _) E)ᴴ *
+      Matrix.reindex e (Equiv.refl _) E = 1
+  rw [Matrix.conjTranspose_reindex]
+  change Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) e Eᴴ *
+      Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) E = 1
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) e (Equiv.refl _),
+    Matrix.sigmaBlockInclusion_isometry, Matrix.reindexLinearEquiv_one]
 
 /-- Coordinate inclusions of distinct dependent blocks have orthogonal ranges. -/
 theorem blockInclusion_conjTranspose_mul_eq_zero {r : ℕ} (dim : Fin r → ℕ)
     {k l : Fin r} (hkl : k ≠ l) :
     (blockInclusion dim k)ᴴ * blockInclusion dim l = 0 := by
-  classical
-  ext x y
-  have hflat : finSigmaFinEquiv ⟨k, x⟩ ≠ finSigmaFinEquiv ⟨l, y⟩ := by
-    intro h
-    apply hkl
-    exact congrArg Sigma.fst (finSigmaFinEquiv.injective h)
-  simp [Matrix.mul_apply, Ne.symm hflat]
+  let dim' := fun j : Fin r => Fin (dim j)
+  let e : ((j : Fin r) × dim' j) ≃ Fin (∑ j, dim j) := finSigmaFinEquiv
+  let E := fun j => Matrix.sigmaBlockInclusion dim' j
+  change (Matrix.reindex e (Equiv.refl _) (E k))ᴴ *
+      Matrix.reindex e (Equiv.refl _) (E l) = 0
+  rw [Matrix.conjTranspose_reindex]
+  change Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) e (E k)ᴴ *
+      Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) (E l) = 0
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) e (Equiv.refl _),
+    Matrix.sigmaBlockInclusion_conjTranspose_mul_of_ne dim' hkl,
+    map_zero]
 
 /-- A flattened dependent-block inclusion intertwines the assembled tensor with its
 weighted block. This is the coordinate form of arXiv:1606.00608, eq. `II_CF1`,
@@ -73,24 +88,20 @@ theorem toTensorFromBlocks_mul_blockInclusion {r : ℕ} {dim : Fin r → ℕ}
     (k : Fin r) (i : Fin d) :
     toTensorFromBlocks (d := d) μ A i * blockInclusion dim k =
       blockInclusion dim k * (μ k • A k i) := by
-  classical
-  ext x y
-  generalize hs : finSigmaFinEquiv.symm x = sx
-  rcases sx with ⟨l, z⟩
-  by_cases hlk : l = k
-  · subst l
-    have hx : x = finSigmaFinEquiv ⟨k, z⟩ := by
-      rw [← finSigmaFinEquiv.apply_symm_apply x, hs]
-    simp [toTensorFromBlocks, blockInclusion, Matrix.mul_apply, hx]
-  · have hxne : ∀ z' : Fin (dim k), x ≠ finSigmaFinEquiv ⟨k, z'⟩ := by
-      intro z' hx
-      apply hlk
-      have : (⟨l, z⟩ : (j : Fin r) × Fin (dim j)) = ⟨k, z'⟩ := by
-        apply finSigmaFinEquiv.injective
-        rw [← hs, finSigmaFinEquiv.apply_symm_apply, hx]
-      exact congrArg Sigma.fst this
-    simp [toTensorFromBlocks, blockInclusion, Matrix.mul_apply, hs, hxne]
-    rw [Matrix.blockDiagonal'_apply_ne _ _ _ hlk]
+  let dim' := fun j : Fin r => Fin (dim j)
+  let e : ((j : Fin r) × dim' j) ≃ Fin (∑ j, dim j) := finSigmaFinEquiv
+  let E := Matrix.sigmaBlockInclusion dim' k
+  let B := fun j : Fin r => μ j • A j i
+  change Matrix.reindex e e (Matrix.blockDiagonal' B) *
+      Matrix.reindex e (Equiv.refl _) E =
+        Matrix.reindex e (Equiv.refl _) E * B k
+  change Matrix.reindexLinearEquiv ℂ ℂ e e (Matrix.blockDiagonal' B) *
+      Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) E =
+        Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) E *
+          Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) (Equiv.refl _) (B k)
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ e e (Equiv.refl _),
+    Matrix.reindexLinearEquiv_mul ℂ ℂ e (Equiv.refl _) (Equiv.refl _),
+    Matrix.blockDiagonal'_mul_sigmaBlockInclusion]
 
 /-- Flatten the dependent block coordinates after reindexing the block family by an
 equivalence. -/

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex
@@ -229,6 +229,7 @@ The results below turn reducing projections into support isometries, compress te
     \label{lem:matrix_sigma_block_inclusion}
     \lean{Matrix.sigmaBlockInclusion}
     \lean{Matrix.sigmaBlockInclusion_isometry}
+    \lean{Matrix.sigmaBlockInclusion_conjTranspose_mul_of_ne}
     \lean{Matrix.blockDiagonal'_mul_sigmaBlockInclusion}
     \lean{Matrix.sigmaBlockInclusion_conjTranspose_mul_blockDiagonal'}
     \lean{Matrix.sigmaBlockInclusion_compression}
@@ -236,10 +237,14 @@ The results below turn reducing projections into support isometries, compress te
     \lean{Matrix.blockDiagonal'_commute_sigmaBlockInclusion_rangeProjection}
     \leanok
     Let $E_k:H_k\to\bigoplus_lH_l$ be the canonical inclusion and let
-    $B=\bigoplus_lB_l$. Then
+    $B=\bigoplus_lB_l$. For distinct $k$ and $\ell$, the corresponding
+    inclusions have orthogonal ranges. The identities are
     \begin{align}
         E_k^\dagger E_k
          & =\Id,
+        \notag                       \\
+        E_k^\dagger E_\ell
+         & =0,
         \notag                       \\
         BE_k
          & =E_kB_k,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -698,3 +698,85 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     Here the fourth equality uses $N>1$, so that the MPU equation applies.
 \end{proof}
+
+\section{Active-block transfer multiplicity}
+
+\begin{definition}[Flattened dependent-block inclusion]
+    \label{def:mpu_dependent_block_inclusion}
+    \lean{MPSTensor.blockInclusion}
+    \leanok
+    Let $(n_k)_{k\in K}$ be a finite family of nonnegative integers and put
+    $n=\sum_{k\in K}n_k$.  For each $k\in K$, define
+    $J_k:\mathbb C^{n_k}\to\mathbb C^n$ by
+    \begin{align}
+        (J_k)_{x,a}&=\begin{cases}
+            1,&x=(k,a),\\
+            0,&x\ne(k,a),
+        \end{cases}
+    \end{align}
+    where the pairs $(k,a)$ are flattened in the direct-sum order.
+\end{definition}
+
+\begin{theorem}[Dependent-block inclusion identities]
+    \label{thm:mpu_dependent_block_inclusion_identities}
+    \lean{MPSTensor.blockInclusion_apply,
+        MPSTensor.blockInclusion_conjTranspose_mul_self,
+        MPSTensor.blockInclusion_conjTranspose_mul_eq_zero,
+        MPSTensor.toTensorFromBlocks_mul_blockInclusion}
+    \leanok
+    \uses{def:mpu_dependent_block_inclusion}
+    The inclusions satisfy
+    \begin{align}
+        J_k^\dagger J_k&=\Id,\\
+        J_k^\dagger J_\ell&=0\quad(k\ne\ell).
+    \end{align}
+    If $B^i=\bigoplus_k\mu_k A_k^i$ is a weighted block-diagonal tensor,
+    then
+    \begin{align}
+        B^iJ_k&=J_k(\mu_kA_k^i).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_dependent_block_inclusion}
+    The first two identities follow by evaluating the coordinate delta
+    functions.  For the last identity, the $k$th column block of $B^i$ has
+    only the $k$th row block nonzero, where it equals $\mu_kA_k^i$.
+\end{proof}
+
+\begin{theorem}[Shifted transfer traces determine one active block]
+    \label{thm:mpu_shifted_transfer_trace_card_active}
+    \lean{MPSTensor.CPSVCanonicalFormData.card_active_eq_one_of_shifted_transfer_trace}
+    \leanok
+    \uses{def:cpsv_canonical_form,def:mpu_transfer_matrix}
+    Let $A$ have literal CPSV canonical-form data with active block set
+    $K=\{k:\mu_k\ne0\}$ and positive ambient bond dimension.  If its transfer
+    matrix $E$ satisfies $\tr(E^N)=1$ for every integer $N>1$, then
+    \begin{align}
+        |K|&=1.
+    \end{align}
+    This is the active-block multiplicity consequence used in
+    \cite[Proposition~1, lines~349--354]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_dependent_block_inclusion_identities,
+        thm:mpu_shifted_trace_power_spectrum,thm:mpu_trace_power_all,
+        thm:mpu_transfer_matrix_vectorization,
+        thm:mpu_transfer_matrix_eigenvalues}
+    Each normal block $A_k$ has a nonzero transfer fixed vector $X_k$.
+    After weighting, its eigenvalue is
+    $q_k=\mu_k\overline{\mu_k}\ne0$.  The reconstruction coisometry and
+    Theorem~\ref{thm:mpu_dependent_block_inclusion_identities} transport
+    $X_k$ to a nonzero ambient eigenmatrix supported in the $k$th corner.
+    Theorem~\ref{thm:mpu_shifted_trace_power_spectrum} gives $q_k=1$.
+
+    Compression to the $k$th corner recovers $X_k$ and annihilates every
+    other corner, so the transported active-block vectors are linearly
+    independent.  Vectorizing places them in the $1$-eigenspace of $E^2$.
+    The shifted traces give $\tr((E^2)^r)=1$ for every $r\ge1$; hence
+    Theorem~\ref{thm:mpu_trace_power_all} gives
+    $\chi_{E^2}(X)=X^{D^2-1}(X-1)$.  Thus that eigenspace has dimension at
+    most one.  Finally, if $K$ were empty, every weight and therefore $A$
+    would vanish, contradicting $\tr(E^2)=1$.  Consequently $|K|=1$.
+\end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -739,9 +739,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    The first two identities follow by evaluating the coordinate delta
-    functions.  For the last identity, the $k$th column block of $B^i$ has
-    only the $k$th row block nonzero, where it equals $\mu_kA_k^i$.
+    \uses{lem:matrix_sigma_block_inclusion}
+    Reindex the canonical dependent-summand inclusion along the equivalence
+    between dependent pairs and flattened coordinates.  Transporting its
+    isometry, cross-block orthogonality, and block-diagonal intertwining
+    identities gives the three displayed formulas.
 \end{proof}
 
 \begin{theorem}[Shifted transfer traces determine one active block]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -750,8 +750,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \leanok
     \uses{def:cpsv_canonical_form,def:mpu_transfer_matrix}
     Let $A$ have literal CPSV canonical-form data with active block set
-    $K=\{k:\mu_k\ne0\}$ and positive ambient bond dimension.  If its transfer
-    matrix $E$ satisfies $\tr(E^N)=1$ for every integer $N>1$, then
+    $K=\{k:\mu_k\ne0\}$.  If its transfer matrix $E$ satisfies
+    $\tr(E^N)=1$ for every integer $N>1$, then
     \begin{align}
         |K|&=1.
     \end{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -705,16 +705,21 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{def:mpu_dependent_block_inclusion}
     \lean{MPSTensor.blockInclusion}
     \leanok
-    Let $(n_k)_{k\in K}$ be a finite family of nonnegative integers and put
-    $n=\sum_{k\in K}n_k$.  For each $k\in K$, define
-    $J_k:\mathbb C^{n_k}\to\mathbb C^n$ by
+    Let the blocks be indexed by $k\in\Fin{r}$, let $n_k$ be their
+    nonnegative dimensions, and put $n=\sum_{k\in\Fin{r}}n_k$.  The standard
+    block-order bijection is
+    \begin{align}
+        \phi\colon \bigsqcup_{k\in\Fin{r}}\Fin{n_k}
+          &\longrightarrow \Fin{n},\\
+        \phi(k,a)&=\sum_{j=0}^{k-1}n_j+a.
+    \end{align}
+    For each $k\in\Fin{r}$, define $J_k:\mathbb C^{n_k}\to\mathbb C^n$ by
     \begin{align}
         (J_k)_{x,a}&=\begin{cases}
-            1,&x=(k,a),\\
-            0,&x\ne(k,a),
+            1,&x=\phi(k,a),\\
+            0,&x\ne\phi(k,a).
         \end{cases}
     \end{align}
-    where the pairs $(k,a)$ are flattened in the direct-sum order.
 \end{definition}
 
 \begin{theorem}[Dependent-block inclusion identities]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -775,18 +775,39 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         thm:mpu_transfer_matrix_vectorization,
         thm:mpu_transfer_matrix_eigenvalues}
     Each normal block $A_k$ has a nonzero transfer fixed vector $X_k$.
-    After weighting, its eigenvalue is
-    $q_k=\mu_k\overline{\mu_k}\ne0$.  The reconstruction coisometry and
-    Theorem~\ref{thm:mpu_dependent_block_inclusion_identities} transport
-    $X_k$ to a nonzero ambient eigenmatrix supported in the $k$th corner.
+    Let $U$ be the reconstruction coisometry and let $J_k$ be the flattened
+    inclusion of the $k$th block.  Define the ambient inclusion and transported
+    matrix by
+    \begin{align}
+        V_k&=U^\dagger J_k,
+        &Y_k&=V_kX_kV_k^\dagger.
+    \end{align}
+    The matrix $Y_k$ is nonzero and is an ambient transfer eigenmatrix with
+    eigenvalue $q_k=\mu_k\overline{\mu_k}\ne0$.
     Theorem~\ref{thm:mpu_shifted_trace_power_spectrum} gives $q_k=1$.
 
-    Compression to the $k$th corner recovers $X_k$ and annihilates every
-    other corner, so the transported active-block vectors are linearly
-    independent.  Vectorizing places them in the $1$-eigenspace of $E^2$.
-    The shifted traces give $\tr((E^2)^r)=1$ for every $r\ge1$; hence
-    Theorem~\ref{thm:mpu_trace_power_all} gives
-    $\chi_{E^2}(X)=X^{D^2-1}(X-1)$.  Thus that eigenspace has dimension at
-    most one.  Finally, if $K$ were empty, every weight and therefore $A$
-    would vanish, contradicting $\tr(E^2)=1$.  Consequently $|K|=1$.
+    For distinct $k$ and $\ell$, the inclusion identities give
+    \begin{align}
+        V_k^\dagger Y_kV_k&=X_k,\\
+        V_k^\dagger Y_\ell V_k&=0.
+    \end{align}
+    Hence the matrices $Y_k$, for $k\in K$, are linearly independent.
+    Vectorizing gives
+    \begin{align}
+        \operatorname{vec}(Y_k)&\in\ker(E^2-\Id).
+    \end{align}
+    The shifted traces and Theorem~\ref{thm:mpu_trace_power_all} give
+    \begin{align}
+        \tr((E^2)^r)&=1\quad(r\ge1),\\
+        \chi_{E^2}(X)&=X^{D^2-1}(X-1).
+    \end{align}
+    The eigenspace dimension is bounded by the algebraic multiplicity, so
+    \begin{align}
+        |K|
+          &\le \dim\ker(E^2-\Id)
+          \le \mult_{1}(\chi_{E^2})
+          =1.
+    \end{align}
+    Finally, if $K$ were empty, every weight and therefore $A$ would vanish,
+    contradicting $\tr(E^2)=1$.  Consequently $|K|=1$.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -725,10 +725,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         MPSTensor.toTensorFromBlocks_mul_blockInclusion}
     \leanok
     \uses{def:mpu_dependent_block_inclusion}
-    The inclusions satisfy
+    The inclusions satisfy the following identities, with the second holding
+    for distinct $k$ and $\ell$:
     \begin{align}
         J_k^\dagger J_k&=\Id,\\
-        J_k^\dagger J_\ell&=0\quad(k\ne\ell).
+        J_k^\dagger J_\ell&=0.
     \end{align}
     If $B^i=\bigoplus_k\mu_k A_k^i$ is a weighted block-diagonal tensor,
     then
@@ -738,7 +739,6 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpu_dependent_block_inclusion}
     The first two identities follow by evaluating the coordinate delta
     functions.  For the last identity, the $k$th column block of $B^i$ has
     only the $k$th row block nonzero, where it equals $\mu_kA_k^i$.
@@ -756,12 +756,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         |K|&=1.
     \end{align}
     This is the active-block multiplicity consequence used in
-    \cite[Proposition~1, lines~349--354]{Cirac2017MPU}.
+    \cite[Proposition~III.1]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_dependent_block_inclusion_identities,
+        thm:mpu_shifted_trace_power_moments,
         thm:mpu_shifted_trace_power_spectrum,thm:mpu_trace_power_all,
+        thm:mpu_transfer_matrix_power_trace,
         thm:mpu_transfer_matrix_vectorization,
         thm:mpu_transfer_matrix_eigenvalues}
     Each normal block $A_k$ has a nonzero transfer fixed vector $X_k$.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -760,7 +760,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_dependent_block_inclusion_identities,
+    \uses{lem:transfer_map_corner_intertwine,
+        thm:mpu_dependent_block_inclusion_identities,
         thm:mpu_shifted_trace_power_moments,
         thm:mpu_shifted_trace_power_spectrum,thm:mpu_trace_power_all,
         thm:mpu_transfer_matrix_power_trace,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -796,9 +796,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         \operatorname{vec}(Y_k)&\in\ker(E^2-\Id).
     \end{align}
-    The shifted traces and Theorem~\ref{thm:mpu_trace_power_all} give
+    For every $r\ge1$, the shifted traces and
+    Theorem~\ref{thm:mpu_trace_power_all} give
     \begin{align}
-        \tr((E^2)^r)&=1\quad(r\ge1),\\
+        \tr((E^2)^r)&=1,\\
         \chi_{E^2}(X)&=X^{D^2-1}(X-1).
     \end{align}
     The eigenspace dimension is bounded by the algebraic multiplicity, so


### PR DESCRIPTION
## Summary

- add flattened dependent-block inclusion matrices with same-block isometry, cross-block orthogonality, and weighted block-intertwining identities
- construct one nonzero ambient transfer eigenvector from each active CPSV normal block
- first identify its weighted eigenvalue as `weight * star weight`, then use the shifted nonzero-spectrum theorem to normalize that eigenvalue to one
- prove the active-indexed ambient vectors linearly independent by block-corner compression
- vectorize them into the one-eigenspace of the squared transfer matrix and bound its dimension using the all-positive trace-power characteristic polynomial and algebraic root multiplicity one
- derive active nonemptiness from the `N = 2` trace identity and conclude that exactly one active block remains
- add source-cited Chapter 28 blueprint entries

The theorem requires neither `HasFullActiveSupport` nor `ActiveBNTRefinement`, and introduces no ambient positivity, normality, diagonalizability, or first-moment hypothesis.

## Verification

- targeted Lean checks for `BlockAssembly.lean`, `ActiveTransferMultiplicity.lean`, `MPU/CanonicalForm.lean`, and `MPU.lean`
- proof-integrity grep on changed Lean modules
- blueprint synchronization and changed-declaration coverage
- reader-facing prose validation
- import-aggregator and diff checks

Closes #5762
Prerequisite for #5706

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics (Lean proofs and blueprint prose); no runtime services, auth, or data paths.
> 
> **Overview**
> Adds the **algebraic multiplicity step** for CPSV canonical form: if ambient transfer traces satisfy `tr(E^N)=1` for all `N>1`, then exactly one canonical block has nonzero weight—without full active support, ambient positivity, or normality assumptions.
> 
> **Shared infrastructure:** `blockInclusion` and lemmas (isometry, cross-block orthogonality, `toTensorFromBlocks` intertwining) in `BlockAssembly.lean`, built from `DependentBlockDiagonal` / `sigmaBlockInclusion`.
> 
> **Main proof** (`ActiveTransferMultiplicity.lean`): from each active normal block, build a nonzero ambient transfer eigenmatrix with eigenvalue `μ·\bar{μ}`; shifted trace-power spectrum forces that eigenvalue to **1**. Block-corner compression shows these ambient fixed vectors are linearly independent; vectorizing into `ker(E²−I)` and bounding that eigenspace via `χ_{E²}(X)=X^{D²−1}(X−1)` yields `|Active|≤1`, with `|Active|≥1` from `tr(E²)=1`.
> 
> Blueprint Chapter 28 and appendix entries document the inclusion identities and the cardinality theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9966b017b86dcba82932e40878971943c5b108c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->