### PR TITLE
feat(Channel/Wigner): classify Hermitian spectrum preservers

### DIFF
--- a/TNLean/Channel/Wigner.lean
+++ b/TNLean/Channel/Wigner.lean
@@ -12,5 +12,6 @@ import TNLean.Channel.Wigner.ProjectiveCarrierBridge
 import TNLean.Channel.Wigner.ProjectivePureState
 import TNLean.Channel.Wigner.PureStateCharpoly
 import TNLean.Channel.Wigner.Rigidity
+import TNLean.Channel.Wigner.SpectrumPreserver
 import TNLean.Channel.Wigner.TwoPureStateCharpoly
 import TNLean.Channel.Wigner.Upstream

--- a/TNLean/Channel/Wigner/SpectrumPreserver.lean
+++ b/TNLean/Channel/Wigner/SpectrumPreserver.lean
@@ -57,7 +57,8 @@ theorem exists_unitary_conj_or_transpose_of_preserves_hermitian_spectrum
       (isOrthogonalProjection_pureStateMatrix p).1
     exact exists_pureStateMatrix_eq_of_isHermitian_charpoly_eq
       (T (pureStateMatrix p)) p (hHermitian _ hp) (hcharpoly _ hp)
-  let f : ℙ ℂ (Fin d → ℂ) → ℙ ℂ (Fin d → ℂ) := fun p ↦ Classical.choose (himage p)
+  let f : ℙ ℂ (Fin d → ℂ) → ℙ ℂ (Fin d → ℂ) := fun p ↦
+    Classical.choose (himage p)
   have hfimage : ∀ p, pureStateMatrix (f p) = T (pureStateMatrix p) := fun p ↦
     Classical.choose_spec (himage p)
   have hftransition : ∀ p q, transitionProbability (f p) (f q) =

--- a/TNLean/Channel/Wigner/SpectrumPreserver.lean
+++ b/TNLean/Channel/Wigner/SpectrumPreserver.lean
@@ -31,7 +31,7 @@ variable {d : ℕ}
 /-- A complex-linear adjoint-preserving map that preserves the complex spectrum as a set on every
 Hermitian matrix is either unitary conjugation or unitary conjugation after transposition.
 
-This is the corollary "Spectrum preserving maps" in Wolf, Chapter 1, lines 289--305. The
+This is the corollary "Spectrum preserving maps" in Wolf, Chapter 1, lines 289--296. The
 hypothesis `hstar` is Wolf's definition of a Hermitian map at line 290. -/
 theorem exists_unitary_conj_or_transpose_of_preserves_hermitian_spectrum
     (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)

--- a/TNLean/Channel/Wigner/SpectrumPreserver.lean
+++ b/TNLean/Channel/Wigner/SpectrumPreserver.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.HermitianSpectrumPreserver
+import TNLean.Channel.Wigner.PureStateCharpoly
+import TNLean.Channel.Wigner.Rigidity
+import TNLean.Channel.Wigner.TwoPureStateCharpoly
+
+/-!
+# Classification of Hermitian spectrum preservers
+
+A complex-linear map on square complex matrices that commutes with the adjoint and preserves the
+spectrum as a set on Hermitian matrices is either unitary conjugation or unitary conjugation after
+transposition. The proof identifies the images of normalized pure-state matrices, applies Wigner
+rigidity to the induced map on projective rays, and extends the resulting equality by complex
+linearity.
+
+## Main declaration
+
+* `Projectivization.exists_unitary_conj_or_transpose_of_preserves_hermitian_spectrum`
+-/
+
+open scoped LinearAlgebra.Projectivization Matrix
+
+namespace Projectivization
+
+variable {d : ℕ}
+
+/-- A complex-linear adjoint-preserving map that preserves the complex spectrum as a set on every
+Hermitian matrix is either unitary conjugation or unitary conjugation after transposition.
+
+This is the corollary "Spectrum preserving maps" in Wolf, Chapter 1, lines 289--305. The
+hypothesis `hstar` is Wolf's definition of a Hermitian map at line 290. -/
+theorem exists_unitary_conj_or_transpose_of_preserves_hermitian_spectrum
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ)
+    (hstar : ∀ X : Matrix (Fin d) (Fin d) ℂ, T (Xᴴ) = (T X)ᴴ)
+    (hSpectrum : ∀ A : Matrix (Fin d) (Fin d) ℂ,
+      A.IsHermitian → spectrum ℂ (T A) = spectrum ℂ A) :
+    ∃ U : Matrix.unitaryGroup (Fin d) ℂ,
+      (∀ X, T X = (U : Matrix (Fin d) (Fin d) ℂ) * X *
+        (U : Matrix (Fin d) (Fin d) ℂ)ᴴ) ∨
+      (∀ X, T X = (U : Matrix (Fin d) (Fin d) ℂ) * Xᵀ *
+        (U : Matrix (Fin d) (Fin d) ℂ)ᴴ) := by
+  have hHermitian : ∀ A : Matrix (Fin d) (Fin d) ℂ,
+      A.IsHermitian → (T A).IsHermitian := by
+    intro A hA
+    rw [Matrix.IsHermitian, ← hstar A, hA]
+  have hcharpoly : ∀ A : Matrix (Fin d) (Fin d) ℂ,
+      A.IsHermitian → (T A).charpoly = A.charpoly :=
+    Matrix.charpoly_map_eq_of_preserves_hermitian_spectrum T hHermitian hSpectrum
+  have himage : ∀ p : ℙ ℂ (Fin d → ℂ),
+      ∃ q : ℙ ℂ (Fin d → ℂ), pureStateMatrix q = T (pureStateMatrix p) := by
+    intro p
+    have hp : (pureStateMatrix p).IsHermitian :=
+      (isOrthogonalProjection_pureStateMatrix p).1
+    exact exists_pureStateMatrix_eq_of_isHermitian_charpoly_eq
+      (T (pureStateMatrix p)) p (hHermitian _ hp) (hcharpoly _ hp)
+  let f : ℙ ℂ (Fin d → ℂ) → ℙ ℂ (Fin d → ℂ) := fun p ↦ Classical.choose (himage p)
+  have hfimage : ∀ p, pureStateMatrix (f p) = T (pureStateMatrix p) := fun p ↦
+    Classical.choose_spec (himage p)
+  have hftransition : ∀ p q, transitionProbability (f p) (f q) =
+      transitionProbability p q := by
+    intro p q
+    rw [← trace_pureStateMatrix_mul_pureStateMatrix,
+      ← trace_pureStateMatrix_mul_pureStateMatrix]
+    apply trace_pureStateMatrix_mul_eq_of_charpoly_add_eq
+    rw [hfimage, hfimage, ← T.map_add]
+    exact hcharpoly _ ((isOrthogonalProjection_pureStateMatrix p).1.add
+      (isOrthogonalProjection_pureStateMatrix q).1)
+  rcases wigner_rigidity_fin hftransition with ⟨U, hU⟩ | ⟨U, hU⟩
+  · let S : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ :=
+      { toFun X := (U : Matrix (Fin d) (Fin d) ℂ) * X *
+          (U : Matrix (Fin d) (Fin d) ℂ)ᴴ
+        map_add' X Y := by rw [mul_add, add_mul]
+        map_smul' c X := by
+          simp only [RingHom.id_apply]
+          rw [mul_smul_comm, smul_mul_assoc] }
+    have hTS : T = S := linearMap_eq_of_eq_on_pureStateMatrix T S fun p ↦ by
+      calc
+        T (pureStateMatrix p) = pureStateMatrix (f p) := (hfimage p).symm
+        _ = pureStateMatrix (unitaryAction U p) := congrArg pureStateMatrix (hU p)
+        _ = (U : Matrix (Fin d) (Fin d) ℂ) * pureStateMatrix p *
+            (U : Matrix (Fin d) (Fin d) ℂ)ᴴ := pureStateMatrix_unitaryAction U p
+        _ = S (pureStateMatrix p) := rfl
+    exact ⟨U, Or.inl (fun X ↦ by rw [hTS]; rfl)⟩
+  · let S : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ :=
+      { toFun X := (U : Matrix (Fin d) (Fin d) ℂ) * Xᵀ *
+          (U : Matrix (Fin d) (Fin d) ℂ)ᴴ
+        map_add' X Y := by rw [Matrix.transpose_add, mul_add, add_mul]
+        map_smul' c X := by
+          simp only [RingHom.id_apply, Matrix.transpose_smul]
+          rw [mul_smul_comm, smul_mul_assoc] }
+    have hTS : T = S := linearMap_eq_of_eq_on_pureStateMatrix T S fun p ↦ by
+      calc
+        T (pureStateMatrix p) = pureStateMatrix (f p) := (hfimage p).symm
+        _ = pureStateMatrix (unitaryAction U (coordinateConjugation p)) :=
+          congrArg pureStateMatrix (hU p)
+        _ = (U : Matrix (Fin d) (Fin d) ℂ) *
+            pureStateMatrix (coordinateConjugation p) *
+            (U : Matrix (Fin d) (Fin d) ℂ)ᴴ :=
+          pureStateMatrix_unitaryAction U (coordinateConjugation p)
+        _ = (U : Matrix (Fin d) (Fin d) ℂ) * (pureStateMatrix p)ᵀ *
+            (U : Matrix (Fin d) (Fin d) ℂ)ᴴ := by
+          rw [pureStateMatrix_coordinateConjugation]
+        _ = S (pureStateMatrix p) := rfl
+    exact ⟨U, Or.inr (fun X ↦ by rw [hTS]; rfl)⟩
+
+end Projectivization

--- a/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_spectrum_and_wigner.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_spectrum_and_wigner.tex
@@ -539,3 +539,67 @@ $v$ is multiplied by a nonzero scalar.
     $P_{U\cdot p}=UP_pU^\dagger$ and
     $P_{\overline p}=P_p^{\mathsf T}$ give the two stated formulas.
 \end{proof}
+
+\begin{theorem}[Spectrum preserving maps]
+    \label{thm:hermitian_spectrum_preserver_classification}
+    \lean{Projectivization.exists_unitary_conj_or_transpose_of_preserves_hermitian_spectrum}
+    \leanok
+    Let $T:\MN{d}\to\MN{d}$ be complex linear. Suppose that
+    \begin{align}
+        T(X^\dagger)=T(X)^\dagger
+    \end{align}
+    for every $X\in\MN{d}$, and that
+    \begin{align}
+        \sigma(T(A))=\sigma(A)
+    \end{align}
+    for every Hermitian $A\in\MN{d}$. Then there is a unitary $U$ such that
+    either
+    \begin{align}
+        T(X)=UXU^\dagger
+    \end{align}
+    for every $X\in\MN{d}$, or
+    \begin{align}
+        T(X)=UX^{\mathsf T}U^\dagger
+    \end{align}
+    for every $X\in\MN{d}$. This is the spectrum-preserver classification
+    in \cite[Chapter~1, Spectrum preserving maps]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:hermitian_set_spectrum_charpoly,
+      thm:pure_state_matrix_of_hermitian_charpoly_eq,
+      thm:transition_probability_of_sum_charpoly,
+      thm:projective_wigner_rigidity,
+      thm:linear_map_eq_of_eq_on_pure_state_matrix}
+    The adjoint identity shows that $T(A)$ is Hermitian whenever $A$ is
+    Hermitian. Hence Theorem~\ref{thm:hermitian_set_spectrum_charpoly} gives
+    \begin{align}
+        \chi_{T(A)}=\chi_A
+    \end{align}
+    for every Hermitian $A$. For each projective ray $p$, recognize
+    $T(P_p)$ by its characteristic polynomial and choose a ray $f(p)$ such
+    that
+    \begin{align}
+        P_{f(p)}=T(P_p).
+    \end{align}
+    For rays $p,q$, linearity and characteristic-polynomial preservation give
+    \begin{align}
+        \chi_{P_{f(p)}+P_{f(q)}}
+        =\chi_{T(P_p+P_q)}
+        =\chi_{P_p+P_q}.
+    \end{align}
+    Theorem~\ref{thm:transition_probability_of_sum_charpoly} therefore shows
+    that $f$ preserves transition probabilities. Projective Wigner rigidity
+    gives a unitary $U$ and either
+    \begin{align}
+        f(p)=U\cdot p
+    \end{align}
+    for every $p$, or
+    \begin{align}
+        f(p)=U\cdot\overline p
+    \end{align}
+    for every $p$. Thus $T$ agrees on every $P_p$ with, respectively,
+    $X\mapsto UXU^\dagger$ or $X\mapsto UX^{\mathsf T}U^\dagger$.
+    Pure-state extensionality gives the corresponding equality on all
+    matrices.
+\end{proof}

--- a/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_spectrum_and_wigner.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_wolf_ch01_spectrum_and_wigner.tex
@@ -569,6 +569,7 @@ $v$ is multiplied by a nonzero scalar.
     \uses{thm:hermitian_set_spectrum_charpoly,
       thm:pure_state_matrix_of_hermitian_charpoly_eq,
       thm:transition_probability_of_sum_charpoly,
+      thm:projective_pure_state_bridge,
       thm:projective_wigner_rigidity,
       thm:linear_map_eq_of_eq_on_pure_state_matrix}
     The adjoint identity shows that $T(A)$ is Hermitian whenever $A$ is


### PR DESCRIPTION
## What changed

- add `Projectivization.exists_unitary_conj_or_transpose_of_preserves_hermitian_spectrum`, the final classification from Wolf Chapter 1, lines 289--296
- keep Wolf's exact public assumptions: complex linearity, $T(X^\dagger)=T(X)^\dagger$, and equality of complex spectra as sets on Hermitian inputs
- derive characteristic-polynomial preservation internally, identify pure-state images, recover transition probabilities from characteristic polynomials of two-state sums, apply projective Wigner rigidity, and extend from pure states to all matrices
- handle dimensions zero and one through the existing all-dimensional pure-state results, with no nonemptiness, positivity, bijectivity, multiplicativity, or $d\ge2$ assumptions
- add exact Blueprint statement and proof dependencies in the relocated Wolf Chapter 1 spectrum/Wigner section

## Validation

- `lake build TNLean.Channel.Wigner.SpectrumPreserver TNLean.Channel.Wigner` (3091 jobs at the final rebase)
- full `lake build` (9987 jobs) and `lake exe lint_style` at the final Lean head
- import-aggregator check (51 generated files covering 1274 modules)
- Lean module-policy tests, oversized-file guard, numbered-module guard, reader-facing prose diff check, forbidden-token proof-integrity check, style, and `git diff --check`
- Blueprint source sync (6757/6757 theorem-like entries; the Wolf spectrum/Wigner file is 39/39 formalized)
- `leanblueprint checkdecls` and double LuaLaTeX with `TEXINPUTS="../../tex/tenkz//:"` (zero undefined theorem cross-references) at the exact head

Closes LionSR/QICLean#295
