### PR TITLE
feat(MPU): prove conditional normalized normality

### DIFF
--- a/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
+++ b/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
@@ -7,20 +7,25 @@ import TNLean.Algebra.TracePowerCharPoly
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import Mathlib.FieldTheory.IsAlgClosed.Spectrum
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
+import Mathlib.LinearAlgebra.Eigenspace.Zero
 
 /-!
-# Trace Powers Above One Determine the Nonzero Spectrum
+# Trace Powers Above One Determine the Characteristic Polynomial
 
 For a square complex matrix `A`, suppose `tr(A^k) = 1` for every `k > 1`.
-Then the nonzero part of the spectrum is exactly `{1}`. This is the precise
-power-sum consequence used in arXiv:1703.09188, Proposition
-`prop:normal-tensor`, lines 349--354.
+Then its characteristic polynomial is `X ^ (n - 1) * (X - 1)`. In particular,
+the nonzero part of the spectrum is exactly `{1}`, and the root `1` has
+algebraic multiplicity one. This is the precise power-sum consequence used in
+arXiv:1703.09188, Proposition `prop:normal-tensor`, lines 349--354.
 
 The proof applies the all-positive-moment characteristic-polynomial theorem
 to `A ^ 2` and `A ^ 3`. Spectral mapping then gives, for each nonzero spectral
 value `μ`, both `μ ^ 2 = 1` and `μ ^ 3 = 1`, hence `μ = 1`. Applying spectral
 mapping in the reverse direction to the spectral value `1` of `A ^ 2` proves
-that `1` itself occurs in the spectrum of `A`.
+that `1` itself occurs in the spectrum of `A`. Finally, the generalized
+`1`-eigenspace of `A` embeds into that of `A ^ 2`; the latter has dimension one,
+so `1` has multiplicity one for `A`. Factoring the split characteristic
+polynomial gives the exact formula.
 
 No positivity, normality, diagonalizability, or first-moment hypothesis is
 used.
@@ -57,10 +62,11 @@ value of `A` equals one.
 This is the set-spectrum part of arXiv:1703.09188, Proposition
 `prop:normal-tensor`, lines 349--354.
 
-**Scope restriction (set spectrum only):** the source proposition also states
-that the sole nonzero eigenvalue has algebraic multiplicity one. This theorem
-proves only that every nonzero spectral value equals one. See
-`docs/paper-gaps/cpsv17_transfer_trace_power.tex`. -/
+**Scope restriction (set spectrum only):** This theorem proves only that every
+nonzero spectral value equals one; set equality alone does not record algebraic
+multiplicity. See `docs/paper-gaps/cpsv17_transfer_trace_power.tex`. The exact
+multiplicity and characteristic-polynomial conclusion is
+`Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt`. -/
 theorem eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
     (A : Matrix n n ℂ)
     (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1)
@@ -96,10 +102,10 @@ spectrum of `A`.
 This is the existence part of the spectral conclusion in arXiv:1703.09188,
 Proposition `prop:normal-tensor`, lines 349--354.
 
-**Scope restriction (set spectrum only):** the source proposition also states
-that the sole nonzero eigenvalue has algebraic multiplicity one. This theorem
-proves only that `1` is a spectral value. See
-`docs/paper-gaps/cpsv17_transfer_trace_power.tex`. -/
+**Scope restriction (set spectrum only):** This theorem proves only that `1` is
+a spectral value; it does not record algebraic multiplicity. See
+`docs/paper-gaps/cpsv17_transfer_trace_power.tex`. The exact conclusion is
+`Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt`. -/
 theorem one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt
     (A : Matrix n n ℂ)
     (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1) :
@@ -126,10 +132,11 @@ spectrum of `A` is the singleton `{1}`.
 This is the set-spectrum consequence used in arXiv:1703.09188,
 Proposition `prop:normal-tensor`, lines 349--354.
 
-**Scope restriction (set spectrum only):** the source proposition also states
-that the sole nonzero eigenvalue has algebraic multiplicity one. This theorem
-proves only equality of the nonzero spectrum as a set. See
-`docs/paper-gaps/cpsv17_transfer_trace_power.tex`. -/
+**Scope restriction (set spectrum only):** This theorem proves only equality of
+the nonzero spectrum as a set; set equality alone does not assert algebraic
+multiplicity. See `docs/paper-gaps/cpsv17_transfer_trace_power.tex`. The exact
+multiplicity and characteristic-polynomial conclusion is
+`Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt`. -/
 theorem spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt
     (A : Matrix n n ℂ)
     (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1) :
@@ -143,5 +150,119 @@ theorem spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt
     have hμ1 : μ = 1 := by simpa using hμ
     subst μ
     exact ⟨one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt A h, by simp⟩
+
+/-- The maximal generalized eigenspace of a matrix at `1` is contained in the maximal
+generalized eigenspace of its square at `1`.
+
+Indeed, `A ^ 2 - 1 = (A + 1) * (A - 1)`, and the two factors commute. -/
+theorem maxGenEigenspace_one_le_sq (A : Matrix n n ℂ) :
+    Module.End.maxGenEigenspace A.toLin' 1 ≤
+      Module.End.maxGenEigenspace (A ^ 2).toLin' 1 := by
+  intro x hx
+  rw [Module.End.mem_maxGenEigenspace] at hx ⊢
+  obtain ⟨k, hk⟩ := hx
+  refine ⟨k, ?_⟩
+  let f : Module.End ℂ (n → ℂ) := A.toLin'
+  have hbase : (A ^ 2).toLin' - (1 : ℂ) • (1 : Module.End ℂ (n → ℂ)) =
+      (f + 1) * (f - 1) := by
+    calc
+      (A ^ 2).toLin' - (1 : ℂ) • (1 : Module.End ℂ (n → ℂ)) =
+          f * f - 1 * 1 := by simp [f, pow_two, Module.End.mul_eq_comp]
+      _ = (f + 1) * (f - 1) :=
+        (Commute.one_right f).mul_self_sub_mul_self_eq
+  have hcomm : Commute (f + 1) (f - 1) :=
+    ((Commute.refl f).sub_right (Commute.one_right f)).add_left
+      ((Commute.one_left f).sub_right (Commute.refl 1))
+  have hid : ((A ^ 2).toLin' - (1 : ℂ) • (1 : Module.End ℂ (n → ℂ))) ^ k =
+      (A.toLin' + (1 : Module.End ℂ (n → ℂ))) ^ k *
+        (A.toLin' - (1 : Module.End ℂ (n → ℂ))) ^ k := by
+    rw [hbase, hcomm.mul_pow]
+  rw [hid, Module.End.mul_apply]
+  have hk' : ((A.toLin' - (1 : Module.End ℂ (n → ℂ))) ^ k) x = 0 := by
+    simpa only [one_smul] using hk
+  rw [hk', map_zero]
+
+/-- Squaring a complex matrix cannot decrease the algebraic multiplicity of the
+root `1` of its characteristic polynomial. -/
+theorem rootMultiplicity_one_charpoly_le_sq (A : Matrix n n ℂ) :
+    A.charpoly.rootMultiplicity 1 ≤ (A ^ 2).charpoly.rootMultiplicity 1 := by
+  rw [← Matrix.charpoly_toLin', ← Matrix.charpoly_toLin',
+    ← LinearMap.finrank_maxGenEigenspace_eq, ← LinearMap.finrank_maxGenEigenspace_eq]
+  exact Submodule.finrank_mono (maxGenEigenspace_one_le_sq A)
+
+/-- If `tr(A ^ k) = 1` for every `k > 1`, then the root `1` of the
+characteristic polynomial of `A` has algebraic multiplicity one.
+
+No first-moment, positivity, normality, or diagonalizability hypothesis is used.
+Source: arXiv:1703.09188, Proposition `prop:normal-tensor`, lines 349--354. -/
+theorem charpoly_rootMultiplicity_one_eq_one_of_forall_trace_pow_eq_one_of_one_lt
+    (A : Matrix n n ℂ)
+    (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1) :
+    A.charpoly.rootMultiplicity 1 = 1 := by
+  have hpow2 :=
+    forall_trace_pow_pow_eq_one_of_forall_trace_pow_eq_one_of_one_lt A h 2 (by omega)
+  have hchar2 :=
+    charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one (A ^ 2) hpow2
+  have hle : A.charpoly.rootMultiplicity 1 ≤ 1 := by
+    refine (rootMultiplicity_one_charpoly_le_sq A).trans_eq ?_
+    rw [hchar2, Polynomial.rootMultiplicity_mul]
+    · rw [Polynomial.rootMultiplicity_eq_zero]
+      · simpa using
+          (Polynomial.rootMultiplicity_X_sub_C_self (R := ℂ) (x := (1 : ℂ)))
+      · simp [Polynomial.IsRoot]
+    · exact mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero)
+        (Polynomial.X_sub_C_ne_zero 1)
+  have hpos : 0 < A.charpoly.rootMultiplicity 1 := by
+    rw [Polynomial.rootMultiplicity_pos (A.charpoly_monic.ne_zero)]
+    exact mem_spectrum_iff_isRoot_charpoly.mp
+      (one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt A h)
+  omega
+
+/-- If `tr(A ^ k) = 1` for every `k > 1`, then
+`charpoly A = X ^ (n - 1) * (X - 1)`.
+
+Thus `1` is the sole nonzero eigenvalue and has algebraic multiplicity one;
+all remaining roots are zero. No first-moment, positivity, normality, or
+diagonalizability hypothesis is used.
+
+Source: arXiv:1703.09188, Proposition `prop:normal-tensor`, lines 349--354. -/
+theorem charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt
+    (A : Matrix n n ℂ)
+    (h : ∀ k : ℕ, 1 < k → trace (A ^ k) = 1) :
+    A.charpoly = X ^ (Fintype.card n - 1) * (X - 1) := by
+  classical
+  let r := A.charpoly.roots
+  have hr_card : r.card = Fintype.card n := by
+    rw [← Matrix.charpoly_natDegree_eq_dim A]
+    exact (IsAlgClosed.splits A.charpoly).natDegree_eq_card_roots.symm
+  have hone_mult : A.charpoly.rootMultiplicity 1 = 1 :=
+    charpoly_rootMultiplicity_one_eq_one_of_forall_trace_pow_eq_one_of_one_lt A h
+  have hone_count : r.count 1 = 1 := by
+    simpa [r, Polynomial.count_roots] using hone_mult
+  have hone_mem : (1 : ℂ) ∈ r := Multiset.count_pos.mp (by omega)
+  have herase_card : (r.erase 1).card = Fintype.card n - 1 := by
+    rw [Multiset.card_erase_of_mem hone_mem, hr_card]
+    simp [Nat.pred_eq_sub_one]
+  have herase_all_zero : ∀ z ∈ r.erase 1, z = 0 := by
+    intro z hz
+    by_contra hz0
+    have hzmem : z ∈ r := Multiset.mem_of_mem_erase hz
+    have hzroot : IsRoot A.charpoly z :=
+      (Polynomial.mem_roots (A.charpoly_monic.ne_zero)).mp (by simpa [r] using hzmem)
+    have hzspec : z ∈ spectrum ℂ A := mem_spectrum_iff_isRoot_charpoly.mpr hzroot
+    have hz1 : z = 1 :=
+      eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt A h hzspec hz0
+    subst z
+    have hcount_pos : 0 < (r.erase 1).count 1 := Multiset.count_pos.mpr hz
+    rw [Multiset.count_erase_self, hone_count] at hcount_pos
+    omega
+  have herase : r.erase 1 = Multiset.replicate (Fintype.card n - 1) 0 :=
+    Multiset.eq_replicate.mpr ⟨herase_card, herase_all_zero⟩
+  have hroots : r = 1 ::ₘ Multiset.replicate (Fintype.card n - 1) 0 := by
+    rw [← herase, Multiset.cons_erase hone_mem]
+  rw [(IsAlgClosed.splits A.charpoly).eq_prod_roots_of_monic A.charpoly_monic]
+  rw [show A.charpoly.roots = r from rfl, hroots]
+  simp [Multiset.map_replicate, Multiset.prod_replicate]
+  ring
 
 end Matrix

--- a/TNLean/Channel/Peripheral.lean
+++ b/TNLean/Channel/Peripheral.lean
@@ -29,4 +29,5 @@ import TNLean.Channel.Peripheral.Powers
 import TNLean.Channel.Peripheral.SpectralProjection
 import TNLean.Channel.Peripheral.SpectralRadius
 import TNLean.Channel.Peripheral.Spectrum
+import TNLean.Channel.Peripheral.TransferMatrix
 import TNLean.Channel.Peripheral.UnitalKraus

--- a/TNLean/Channel/Peripheral/TransferMatrix.lean
+++ b/TNLean/Channel/Peripheral/TransferMatrix.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixOperatorSpace
+import TNLean.Algebra.ShiftedTracePowerSpectrum
+import TNLean.Channel.Peripheral.Spectrum
+import TNLean.Channel.TransferMatrix
+
+/-!
+# Shifted Transfer Traces and Primitivity
+
+This file transfers the shifted trace-power criterion for a transfer matrix to spectral
+radius and primitivity of the represented matrix endomorphism.
+
+No positivity, normality, diagonalizability, or first-moment hypothesis is used.
+-/
+
+open scoped Matrix ENNReal NNReal Matrix.Norms.Operator
+
+variable {D : ℕ}
+
+/-- If every transfer-matrix power of exponent greater than one has trace one, then the
+represented matrix endomorphism has spectral radius one and is primitive.
+
+The proof first applies the shifted nonzero-spectrum theorem to the transfer matrix and
+then transports its eigenvalues through `transferMatrix_hasEigenvalue_iff`.
+
+Source: Cirac--Perez-Garcia--Schuch--Verstraete, Proposition
+`prop:normal-tensor`, lines 349--354. -/
+theorem spectralRadius_eq_one_and_isPrimitive_of_transferMatrix_shifted_trace [NeZero D]
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (htrace : ∀ N : ℕ, 1 < N → Matrix.trace (transferMatrix T ^ N) = 1) :
+    spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) T) = 1 ∧
+      IsPrimitive T := by
+  let M := transferMatrix T
+  have hnonzero : spectrum ℂ M \ {0} = {1} :=
+    Matrix.spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt M htrace
+  have hclass : ∀ z : ℂ, z ∈ spectrum ℂ M → z = 0 ∨ z = 1 := by
+    intro z hz
+    by_cases hz0 : z = 0
+    · exact Or.inl hz0
+    · right
+      have hz' : z ∈ spectrum ℂ M \ {0} := ⟨hz, by simpa using hz0⟩
+      rw [hnonzero] at hz'
+      simpa using hz'
+  have hmatrix_of_eigenvalue :
+      ∀ z : ℂ, Module.End.HasEigenvalue T z → z ∈ spectrum ℂ M := by
+    intro z hz
+    have hzM : Module.End.HasEigenvalue M.toLin' z :=
+      (transferMatrix_hasEigenvalue_iff T z).mp hz
+    have hzSpec : z ∈ spectrum ℂ M.toLin' :=
+      Module.End.hasEigenvalue_iff_mem_spectrum.mp hzM
+    simpa [M, Matrix.spectrum_toLin'] using hzSpec
+  have h1M : (1 : ℂ) ∈ spectrum ℂ M := by
+    have : (1 : ℂ) ∈ spectrum ℂ M \ {0} := by rw [hnonzero]; simp
+    exact this.1
+  have h1EigM : Module.End.HasEigenvalue M.toLin' (1 : ℂ) := by
+    rw [Module.End.hasEigenvalue_iff_mem_spectrum]
+    simpa [Matrix.spectrum_toLin'] using h1M
+  have h1EigT : Module.End.HasEigenvalue T (1 : ℂ) := by
+    exact (transferMatrix_hasEigenvalue_iff T 1).mpr h1EigM
+  have hspecCont :
+      spectrum ℂ ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) T) =
+        spectrum ℂ T :=
+    AlgEquiv.spectrum_eq (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) T
+  have hrad :
+      spectralRadius ℂ
+          ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) T) = 1 := by
+    apply le_antisymm
+    · rw [spectralRadius]
+      refine iSup₂_le fun z hz => ?_
+      have hzT : z ∈ spectrum ℂ T := hspecCont ▸ hz
+      have hzEig : Module.End.HasEigenvalue T z :=
+        Module.End.hasEigenvalue_iff_mem_spectrum.mpr hzT
+      rcases hclass z (hmatrix_of_eigenvalue z hzEig) with rfl | rfl <;> norm_num
+    · rw [spectralRadius]
+      have h1T : (1 : ℂ) ∈ spectrum ℂ T :=
+        Module.End.hasEigenvalue_iff_mem_spectrum.mp h1EigT
+      have h1Cont : (1 : ℂ) ∈
+          spectrum ℂ ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) T) :=
+        hspecCont.symm ▸ h1T
+      simpa using (@le_iSup₂ ENNReal ℂ (· ∈ spectrum ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) T)) _
+          (fun z _ => (‖z‖₊ : ENNReal)) 1 h1Cont)
+  refine ⟨hrad, ?_⟩
+  change peripheralEigenvalues T = {1}
+  ext z
+  constructor
+  · intro hz
+    change Module.End.HasEigenvalue T z ∧ ‖z‖ = 1 at hz
+    have hzM := hmatrix_of_eigenvalue z hz.1
+    have hz0 : z ≠ 0 := by
+      intro hz0
+      subst z
+      norm_num at hz
+    have hzDiff : z ∈ spectrum ℂ M \ {0} := ⟨hzM, by simpa using hz0⟩
+    rw [hnonzero] at hzDiff
+    exact hzDiff
+  · intro hz
+    have hz1 : z = 1 := by simpa using hz
+    subst z
+    exact ⟨h1EigT, by simp⟩

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.Peripheral.TransferMatrix
 import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.MPU.ActiveTransferMultiplicity
+import TNLean.MPS.MPU.TransferMatrix
 
 /-!
 # Full-support CPSV canonical forms
@@ -16,8 +19,9 @@ representative is used as an ambient tensor.
 intended reduced canonical representative in the argument for arXiv:1703.09188,
 Proposition `prop:normal-tensor`. The paper's canonical-form definition itself
 permits displayed zero-weight blocks, and the formalization does not construct
-the reduced representative obtained by omitting them. This module also does not
-formalize the proposition's spectral derivation from `IsMPU`. See
+the reduced representative obtained by omitting them. Consequently the MPU
+normality capstone below assumes full active support and does not claim bare
+`IsMPU` implies ambient normality. See
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`.
 -/
 
@@ -249,3 +253,36 @@ theorem isNormalTensor_of_card_active_eq_one_of_fullActiveSupport
 end CPSVCanonicalFormData
 
 end MPSTensor
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The normalized flattening of an MPU is normal when the chosen CPSV canonical-form
+representative has full active support.
+
+**Scope restriction (full active support):** Bare `IsMPU` does not imply normality for a
+nonminimal ambient representative: adjoining a zero virtual direct summand preserves all
+periodic operators but introduces a nontrivial invariant projection. This theorem treats
+the intended reduced representative in arXiv:1703.09188, Proposition
+`prop:normal-tensor`, lines 319--326 and 344--354, by requiring full active support.
+See `docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
+theorem IsMPU.isNormalTensor_normalizedFlattening_of_cpsv
+    [NeZero d] [NeZero D] {U : MPOTensor d D}
+    (hU : U.IsMPU)
+    (data : MPSTensor.CPSVCanonicalFormData U.normalizedFlattening)
+    (hfull : data.HasFullActiveSupport) :
+    MPSTensor.IsNormalTensor U.normalizedFlattening := by
+  have htrace : ∀ N : ℕ, 1 < N →
+      Matrix.trace
+        (transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ N) = 1 :=
+    fun _ hN => hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN
+  have hcard : Fintype.card data.Active = 1 :=
+    data.card_active_eq_one_of_shifted_transfer_trace htrace
+  obtain ⟨hrad, hprim⟩ :=
+    spectralRadius_eq_one_and_isPrimitive_of_transferMatrix_shifted_trace
+      (MPSTensor.transferMap U.normalizedFlattening) htrace
+  exact data.isNormalTensor_of_card_active_eq_one_of_fullActiveSupport
+    hcard hfull hrad hprim
+
+end MPOTensor

--- a/TNLean/MPS/MPU/TransferMatrix.lean
+++ b/TNLean/MPS/MPU/TransferMatrix.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.Peripheral.TransferMatrix
 import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPDO.Purity
 import TNLean.Spectral.MPVOverlapTrace
@@ -20,6 +21,8 @@ Cirac--Perez-Garcia--Schuch--Verstraete.
 * `MPOTensor.mpvOverlap_normalizedFlattening_self` — its self-overlap scaling law.
 * `MPOTensor.IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one` — for every `N > 1`,
   the trace of the `N`-th power of its transfer matrix is one.
+* `MPOTensor.IsMPU.normalizedFlattening_nonzero_spectrum` — the nonzero transfer-matrix
+  spectrum of the normalized flattening is `{1}`.
 
 ## References
 
@@ -82,5 +85,17 @@ theorem IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one
   push_cast
   rw [← mul_pow]
   simp [NeZero.ne d]
+
+/-- The transfer matrix of the normalized flattening of an MPU has nonzero set spectrum
+exactly `{1}`.
+
+This is the set-spectrum conclusion in Cirac--Perez-Garcia--Schuch--Verstraete,
+Proposition `prop:normal-tensor`, lines 349--354. It does not assert algebraic
+multiplicity. -/
+theorem IsMPU.normalizedFlattening_nonzero_spectrum
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) :
+    spectrum ℂ (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) \ {0} = {1} :=
+  Matrix.spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt _
+    (fun _ hN => hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN)
 
 end MPOTensor

--- a/TNLean/MPS/MPU/TransferMatrix.lean
+++ b/TNLean/MPS/MPU/TransferMatrix.lean
@@ -15,14 +15,19 @@ This file defines the paper-normalized doubled-physical-index MPS tensor associa
 and proves the transfer-matrix trace identity used in Proposition `prop:normal-tensor` of
 Cirac--Perez-Garcia--Schuch--Verstraete.
 
-## Main definitions and results
+## Main definitions
 
 * `MPOTensor.normalizedFlattening` — the doubled-index MPS tensor `U / sqrt d`.
+
+## Main results
+
 * `MPOTensor.mpvOverlap_normalizedFlattening_self` — its self-overlap scaling law.
 * `MPOTensor.IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one` — for every `N > 1`,
   the trace of the `N`-th power of its transfer matrix is one.
 * `MPOTensor.IsMPU.normalizedFlattening_nonzero_spectrum` — the nonzero transfer-matrix
   spectrum of the normalized flattening is `{1}`.
+* `MPOTensor.IsMPU.normalizedFlattening_charpoly` — its exact characteristic polynomial is
+  `X ^ (D * D - 1) * (X - 1)`.
 
 ## References
 
@@ -31,6 +36,7 @@ Cirac--Perez-Garcia--Schuch--Verstraete.
 -/
 
 open scoped Matrix BigOperators
+open Polynomial
 
 namespace MPOTensor
 
@@ -90,12 +96,30 @@ theorem IsMPU.trace_transferMatrix_normalizedFlattening_pow_eq_one
 exactly `{1}`.
 
 This is the set-spectrum conclusion in Cirac--Perez-Garcia--Schuch--Verstraete,
-Proposition `prop:normal-tensor`, lines 349--354. It does not assert algebraic
-multiplicity. -/
+Proposition `prop:normal-tensor`, lines 349--354.
+
+**Scope restriction (set spectrum only):** Set equality alone does not assert
+algebraic multiplicity. See `docs/paper-gaps/cpsv17_transfer_trace_power.tex`.
+The exact conclusion is `MPOTensor.IsMPU.normalizedFlattening_charpoly`. -/
 theorem IsMPU.normalizedFlattening_nonzero_spectrum
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) :
     spectrum ℂ (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) \ {0} = {1} :=
   Matrix.spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt _
     (fun _ hN => hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN)
+
+/-- The transfer matrix of the normalized flattening of an MPU has characteristic
+polynomial `X ^ (D * D - 1) * (X - 1)`. Hence its sole nonzero eigenvalue is
+`1`, with algebraic multiplicity one.
+
+Source: Cirac--Perez-Garcia--Schuch--Verstraete, Proposition
+`prop:normal-tensor`, lines 349--354. -/
+theorem IsMPU.normalizedFlattening_charpoly
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) :
+    (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)).charpoly =
+      X ^ (D * D - 1) * (X - 1) := by
+  simpa [Fintype.card_prod, Fintype.card_fin] using
+    Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt
+      (transferMatrix (MPSTensor.transferMap U.normalizedFlattening))
+      (fun _ hN => hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN)
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -812,3 +812,80 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Finally, if $K$ were empty, every weight and therefore $A$ would vanish,
     contradicting $\tr(E^2)=1$.  Consequently $|K|=1$.
 \end{proof}
+
+\section{Normalized transfer spectrum and conditional normality}
+
+\begin{theorem}[Shifted transfer traces imply radius one and primitivity]
+    \label{thm:mpu_shifted_transfer_trace_primitive}
+    \lean{spectralRadius_eq_one_and_isPrimitive_of_transferMatrix_shifted_trace}
+    \leanok
+    \uses{def:mpu_transfer_matrix}
+    Let $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map with $D>0$.
+    If
+    \begin{align}
+        \tr(\widehat T^{\,N})&=1
+    \end{align}
+    for every integer $N>1$, then $T$ has spectral radius one and its only
+    eigenvalue on the unit circle is $1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_shifted_trace_power_spectrum,
+        thm:mpu_transfer_matrix_eigenvalues}
+    The shifted trace-power theorem gives
+    \begin{align}
+        \sigma(\widehat T)\setminus\{0\}&=\{1\}.
+    \end{align}
+    Column stacking identifies the eigenvalues of $T$ and $\widehat T$.
+    Thus every spectral value of $T$ is either $0$ or $1$, and $1$ occurs.
+    The spectral radius is therefore one, while the only eigenvalue of norm
+    one is $1$.
+\end{proof}
+
+\begin{theorem}[Nonzero spectrum of the normalized MPU transfer matrix]
+    \label{thm:mpu_normalized_transfer_nonzero_spectrum}
+    \lean{MPOTensor.IsMPU.normalizedFlattening_nonzero_spectrum}
+    \leanok
+    \uses{def:mpu_normalized_flattening,def:mpu_transfer_matrix}
+    Let $U$ be an MPU tensor with positive physical and bond dimensions, and
+    let $E$ be the transfer matrix of its normalized flattening. Then
+    \begin{align}
+        \sigma(E)\setminus\{0\}&=\{1\}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_normalized_transfer_trace,
+        thm:mpu_shifted_trace_power_spectrum}
+    The normalized transfer identity supplies $\tr(E^N)=1$ for every $N>1$,
+    so the shifted trace-power spectrum theorem applies directly.
+\end{proof}
+
+\begin{theorem}[Normality of a full-support normalized MPU representative]
+    \label{thm:mpu_normalized_full_support_normal}
+    \lean{MPOTensor.IsMPU.isNormalTensor_normalizedFlattening_of_cpsv}
+    \leanok
+    \uses{def:mpu,def:mpu_normalized_flattening,
+        def:mpu_full_active_support}
+    Let $U$ be an MPU tensor with positive physical and bond dimensions.
+    Suppose that the normalized flattening is equipped with CPSV
+    canonical-form data whose active blocks have full support in the ambient
+    bond space. Then the normalized flattening is a normal tensor.
+
+    The full-support hypothesis is essential for this ambient representative.
+    Adjoining a zero virtual direct summand preserves every periodic operator
+    but introduces a nontrivial invariant projection. Thus this theorem does
+    not assert that an arbitrary, possibly nonminimal MPU representative is
+    normal.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_normalized_transfer_trace,
+        thm:mpu_shifted_transfer_trace_card_active,
+        thm:mpu_shifted_transfer_trace_primitive,
+        thm:mpu_unique_active_full_support_normal}
+    The normalized transfer traces force the active block set to have
+    cardinality one. The same traces give spectral radius one and primitivity.
+    Full active support then identifies the unique active block with the
+    ambient bond space, so the full-support normality theorem applies.
+\end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -259,33 +259,30 @@ nonzero spectrum as a set.
   exponent $mr$ gives the result.
 \end{proof}
 
-\begin{theorem}[Trace powers above one determine the characteristic polynomial]
+\begin{theorem}[Trace powers above one determine the nonzero spectrum]
   \label{thm:mpu_shifted_trace_power_spectrum}
   \lean{Matrix.spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt,
-    Matrix.charpoly_rootMultiplicity_one_eq_one_of_forall_trace_pow_eq_one_of_one_lt,
-    Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt}
+    Matrix.eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt,
+    Matrix.one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt}
   \leanok
-  Let $A$ be an $n\times n$ complex matrix.  If $\tr(A^k)=1$ for every
-  $k>1$, then
+  Let $A$ be an $n\times n$ complex matrix. If $\tr(A^k)=1$ for every
+  integer $k>1$, then
   \begin{align}
-    \sigma(A)\setminus\{0\}&=\{1\},
-    &\operatorname{mult}_{1}(\chi_A)&=1,
-    &\chi_A(X)&=X^{n-1}(X-1).
+    \sigma(A)\setminus\{0\}&=\{1\}.
   \end{align}
-  Thus $1$ is the sole nonzero eigenvalue and has algebraic multiplicity one.
-  This is the exact shifted-moment conclusion of
-  \cite[Proposition~III.1]{Cirac2017MPU}; the first set equality alone would
-  not assert algebraic multiplicity.
+  Thus $1$ occurs and every nonzero spectral value equals $1$. This is the
+  set-spectrum consequence of \cite[Proposition~III.1]{Cirac2017MPU}; set
+  equality alone does not assert algebraic multiplicity.
 \end{theorem}
 
 \begin{proof}\leanok
   \uses{thm:mpu_shifted_trace_power_moments,thm:mpu_trace_power_all}
-  For every $r\ge1$, the hypothesis gives
+  For every positive integer $r$, the shifted moments give
   \begin{align}
     \tr((A^2)^r)&=\tr(A^{2r})=1,
     &\tr((A^3)^r)&=\tr(A^{3r})=1.
   \end{align}
-  Hence Theorem~\ref{thm:mpu_trace_power_all} yields
+  Hence
   \begin{align}
     \chi_{A^2}(X)&=\chi_{A^3}(X)=X^{n-1}(X-1).
   \end{align}
@@ -296,17 +293,86 @@ nonzero spectrum as a set.
     &\mu&=1.
   \end{align}
   Conversely, spectral mapping from $1\in\sigma(A^2)$ supplies a nonzero
-  spectral value of $A$, hence $1\in\sigma(A)$.
+  spectral value of $A$, which must be $1$.
+\end{proof}
 
-  The factorization
+\begin{theorem}[Generalized eigenspace inclusion under squaring]
+  \label{thm:mpu_generalized_eigenspace_one_square}
+  \lean{Matrix.maxGenEigenspace_one_le_sq}
+  \leanok
+  For a complex square matrix $A$, write $G_1(A)$ for its maximal generalized
+  eigenspace at the eigenvalue $1$. Then
+  \begin{align}
+    G_1(A)&\subseteq G_1(A^2).
+  \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+  The commuting factorization
   \begin{align}
     A^2-\Id&=(A+\Id)(A-\Id)
   \end{align}
-  with commuting factors includes the maximal generalized $1$-eigenspace of
-  $A$ in that of $A^2$.  Since $1$ has multiplicity one in $\chi_{A^2}$,
-  it has multiplicity at most one in $\chi_A$; its occurrence makes the
-  multiplicity exactly one.  All remaining roots are zero, and splitting the
-  monic characteristic polynomial gives
+  gives, for every nonnegative integer $k$,
+  \begin{align}
+    (A^2-\Id)^k&=(A+\Id)^k(A-\Id)^k.
+  \end{align}
+  Therefore every vector annihilated by a power of $A-\Id$ is annihilated by
+  the corresponding power of $A^2-\Id$.
+\end{proof}
+
+\begin{theorem}[Multiplicity at one does not decrease under squaring]
+  \label{thm:mpu_root_multiplicity_one_square}
+  \lean{Matrix.rootMultiplicity_one_charpoly_le_sq}
+  \leanok
+  For every complex square matrix $A$,
+  \begin{align}
+    \operatorname{mult}_{1}(\chi_A)
+      &\le \operatorname{mult}_{1}(\chi_{A^2}).
+  \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:mpu_generalized_eigenspace_one_square}
+  With $G_1$ as above, algebraic multiplicity equals the dimension of the
+  maximal generalized eigenspace. Hence
+  \begin{align}
+    \operatorname{mult}_{1}(\chi_A)
+      &=\dim G_1(A)\\
+      &\le\dim G_1(A^2)
+       =\operatorname{mult}_{1}(\chi_{A^2}).
+  \end{align}
+\end{proof}
+
+\begin{theorem}[Trace powers above one determine the characteristic polynomial]
+  \label{thm:mpu_shifted_trace_power_charpoly}
+  \lean{Matrix.charpoly_rootMultiplicity_one_eq_one_of_forall_trace_pow_eq_one_of_one_lt,
+    Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt}
+  \leanok
+  Let $A$ be an $n\times n$ complex matrix. If $\tr(A^k)=1$ for every
+  integer $k>1$, then
+  \begin{align}
+    \operatorname{mult}_{1}(\chi_A)&=1,
+    &\chi_A(X)&=X^{n-1}(X-1).
+  \end{align}
+  Thus $1$ is the sole nonzero eigenvalue and has algebraic multiplicity one.
+  This is the exact shifted-moment conclusion of
+  \cite[Proposition~III.1]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:mpu_shifted_trace_power_moments,thm:mpu_trace_power_all,
+    thm:mpu_shifted_trace_power_spectrum,
+    thm:mpu_root_multiplicity_one_square}
+  Applying the all-positive trace-power theorem to $A^2$ gives
+  \begin{align}
+    \chi_{A^2}(X)&=X^{n-1}(X-1),
+    &\operatorname{mult}_{1}(\chi_{A^2})&=1.
+  \end{align}
+  The multiplicity inequality therefore bounds
+  $\operatorname{mult}_{1}(\chi_A)$ by one. The set-spectrum theorem shows
+  that $1$ occurs, so this multiplicity is positive and hence equals one.
+  The same set-spectrum theorem excludes every other nonzero root. Splitting
+  the monic characteristic polynomial now yields
   \begin{align}
     \operatorname{mult}_{1}(\chi_A)&=1,
     &\chi_A(X)&=X^{n-1}(X-1).
@@ -890,10 +956,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{proof}\leanok
     \uses{thm:mpu_normalized_transfer_trace,
-        thm:mpu_shifted_trace_power_spectrum}
-    The normalized transfer identity gives the shifted moments
+        thm:mpu_shifted_trace_power_charpoly}
+    For every integer $N>1$, the normalized transfer identity gives
     \begin{align}
-        \tr(E^N)&=1 &&(N>1).
+        \tr(E^N)&=1.
     \end{align}
     Applying the exact shifted trace-power theorem in dimension $D^2$ yields
     \begin{align}
@@ -927,25 +993,26 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         thm:mpu_shifted_transfer_trace_card_active,
         thm:mpu_shifted_transfer_trace_primitive,
         thm:mpu_unique_active_full_support_normal}
-    Write $K$ for the active block set. The normalized transfer identity gives
+    Write $\widetilde U$ for the normalized flattening, set
+    $T=\mathcal E_{\widetilde U}$ for its transfer map, and let
+    $E=\widehat T$ be the corresponding transfer matrix. Also write $K$ for
+    the active block set and $D_k$ for the bond dimension of an active block
+    $k\in K$. For every integer $N>1$, the normalized transfer identity gives
     \begin{align}
-        \tr(E^N)&=1 &&(N>1).
+        \tr(E^N)&=1.
     \end{align}
     The active-multiplicity theorem and the transfer-spectrum theorem then give
     \begin{align}
         |K|&=1,
-        &r(E)&=1,
-        &\operatorname{peripheral}(E)&=\{1\}.
+        &r(T)&=1,
+        &\operatorname{peripheral}(T)&=\{1\}.
     \end{align}
     Full active support supplies
     \begin{align}
         \sum_{k\in K}D_k&=D.
     \end{align}
     Since $K$ is a singleton, its unique active block has ambient dimension
-    $D$ and therefore makes the ambient tensor irreducible. Combining this
-    irreducibility with the displayed radius and peripheral-spectrum fields
-    gives
-    \begin{align}
-        \widetilde U&\text{ is a normal tensor}.
-    \end{align}
+    $D$ and therefore makes $\widetilde U$ irreducible. The displayed radius
+    and peripheral-spectrum identities provide its remaining normality
+    fields. Consequently $\widetilde U$ is a normal tensor.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -259,39 +259,58 @@ nonzero spectrum as a set.
   exponent $mr$ gives the result.
 \end{proof}
 
-\begin{theorem}[Trace powers above one determine the nonzero spectrum]
+\begin{theorem}[Trace powers above one determine the characteristic polynomial]
   \label{thm:mpu_shifted_trace_power_spectrum}
   \lean{Matrix.spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt,
-    Matrix.eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt,
-    Matrix.one_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt}
+    Matrix.charpoly_rootMultiplicity_one_eq_one_of_forall_trace_pow_eq_one_of_one_lt,
+    Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt}
   \leanok
   Let $A$ be an $n\times n$ complex matrix.  If $\tr(A^k)=1$ for every
   $k>1$, then
   \begin{align}
-    \sigma(A)\setminus\{0\}&=\{1\}.
+    \sigma(A)\setminus\{0\}&=\{1\},
+    &\operatorname{mult}_{1}(\chi_A)&=1,
+    &\chi_A(X)&=X^{n-1}(X-1).
   \end{align}
-  Thus $1$ occurs as a spectral value and every nonzero spectral value equals
-  $1$.  This is the set-spectrum conclusion of
-  \cite[Proposition~1]{Cirac2017MPU}; it does not assert
-  algebraic multiplicity.
+  Thus $1$ is the sole nonzero eigenvalue and has algebraic multiplicity one.
+  This is the exact shifted-moment conclusion of
+  \cite[Proposition~III.1]{Cirac2017MPU}; the first set equality alone would
+  not assert algebraic multiplicity.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{thm:mpu_shifted_trace_power_moments, thm:mpu_trace_power_all}
+  \uses{thm:mpu_shifted_trace_power_moments,thm:mpu_trace_power_all}
   For every $r\ge1$, the hypothesis gives
-  $\tr((A^2)^r)=\tr(A^{2r})=1$ and
-  $\tr((A^3)^r)=\tr(A^{3r})=1$.  Hence, by
-  Theorem~\ref{thm:mpu_trace_power_all},
+  \begin{align}
+    \tr((A^2)^r)&=\tr(A^{2r})=1,
+    &\tr((A^3)^r)&=\tr(A^{3r})=1.
+  \end{align}
+  Hence Theorem~\ref{thm:mpu_trace_power_all} yields
   \begin{align}
     \chi_{A^2}(X)&=\chi_{A^3}(X)=X^{n-1}(X-1).
   \end{align}
   If $\mu\in\sigma(A)$ is nonzero, spectral mapping places $\mu^2$ in
-  $\sigma(A^2)$ and $\mu^3$ in $\sigma(A^3)$.  The two characteristic
-  polynomials give $\mu^2=\mu^3=1$, and therefore $\mu=1$.
+  $\sigma(A^2)$ and $\mu^3$ in $\sigma(A^3)$, so
+  \begin{align}
+    \mu^2&=\mu^3=1,
+    &\mu&=1.
+  \end{align}
+  Conversely, spectral mapping from $1\in\sigma(A^2)$ supplies a nonzero
+  spectral value of $A$, hence $1\in\sigma(A)$.
 
-  The value $1$ belongs to $\sigma(A^2)$.  Spectral mapping supplies
-  $\mu\in\sigma(A)$ with $\mu^2=1$; this $\mu$ is nonzero, so the
-  nonzero-value argument gives $\mu=1$.
+  The factorization
+  \begin{align}
+    A^2-\Id&=(A+\Id)(A-\Id)
+  \end{align}
+  with commuting factors includes the maximal generalized $1$-eigenspace of
+  $A$ in that of $A^2$.  Since $1$ has multiplicity one in $\chi_{A^2}$,
+  it has multiplicity at most one in $\chi_A$; its occurrence makes the
+  multiplicity exactly one.  All remaining roots are zero, and splitting the
+  monic characteristic polynomial gives
+  \begin{align}
+    \operatorname{mult}_{1}(\chi_A)&=1,
+    &\chi_A(X)&=X^{n-1}(X-1).
+  \end{align}
 \end{proof}
 
 We now introduce the two matrices used for the singular-value decompositions of
@@ -819,64 +838,88 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_shifted_transfer_trace_primitive}
     \lean{spectralRadius_eq_one_and_isPrimitive_of_transferMatrix_shifted_trace}
     \leanok
-    \uses{def:mpu_transfer_matrix}
+    \uses{def:mpu_transfer_matrix,def:primitive_channel}
     Let $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map with $D>0$.
-    If
+    If $\tr(\widehat T^{\,N})=1$ for every integer $N>1$, then
     \begin{align}
-        \tr(\widehat T^{\,N})&=1
+        r(T)&=1,
+        &\operatorname{peripheral}(T)&=\{1\}.
     \end{align}
-    for every integer $N>1$, then $T$ has spectral radius one and its only
-    eigenvalue on the unit circle is $1$.
+    This is the radius-and-primitivity part of
+    \cite[Proposition~III.1]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_shifted_trace_power_spectrum,
         thm:mpu_transfer_matrix_eigenvalues}
-    The shifted trace-power theorem gives
+    The shifted traces give
     \begin{align}
         \sigma(\widehat T)\setminus\{0\}&=\{1\}.
     \end{align}
     Column stacking identifies the eigenvalues of $T$ and $\widehat T$.
-    Thus every spectral value of $T$ is either $0$ or $1$, and $1$ occurs.
-    The spectral radius is therefore one, while the only eigenvalue of norm
-    one is $1$.
+    Consequently every spectral value of $T$ is zero or one, and one occurs,
+    so
+    \begin{align}
+        r(T)&=\max_{\lambda\in\sigma(T)}|\lambda|=1.
+    \end{align}
+    Restricting to eigenvalues of modulus one gives
+    \begin{align}
+        \operatorname{peripheral}(T)&=\{1\},
+    \end{align}
+    which is primitivity.
 \end{proof}
 
-\begin{theorem}[Nonzero spectrum of the normalized MPU transfer matrix]
+\begin{theorem}[Exact spectrum of the normalized MPU transfer matrix]
     \label{thm:mpu_normalized_transfer_nonzero_spectrum}
-    \lean{MPOTensor.IsMPU.normalizedFlattening_nonzero_spectrum}
+    \lean{MPOTensor.IsMPU.normalizedFlattening_nonzero_spectrum,
+        MPOTensor.IsMPU.normalizedFlattening_charpoly}
     \leanok
-    \uses{def:mpu_normalized_flattening,def:mpu_transfer_matrix}
+    \uses{def:mpu,def:mpu_normalized_flattening,def:transfer_map,
+        def:mpu_transfer_matrix}
     Let $U$ be an MPU tensor with positive physical and bond dimensions, and
     let $E$ be the transfer matrix of its normalized flattening. Then
     \begin{align}
-        \sigma(E)\setminus\{0\}&=\{1\}.
+        \sigma(E)\setminus\{0\}&=\{1\},
+        &\operatorname{mult}_{1}(\chi_E)&=1,
+        &\chi_E(X)&=X^{D^2-1}(X-1).
     \end{align}
+    This is the transfer-matrix conclusion of
+    \cite[Proposition~III.1]{Cirac2017MPU}. The first set equality alone does
+    not assert algebraic multiplicity.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_normalized_transfer_trace,
         thm:mpu_shifted_trace_power_spectrum}
-    The normalized transfer identity supplies $\tr(E^N)=1$ for every $N>1$,
-    so the shifted trace-power spectrum theorem applies directly.
+    The normalized transfer identity gives the shifted moments
+    \begin{align}
+        \tr(E^N)&=1 &&(N>1).
+    \end{align}
+    Applying the exact shifted trace-power theorem in dimension $D^2$ yields
+    \begin{align}
+        \chi_E(X)&=X^{D^2-1}(X-1),
+        &\operatorname{mult}_{1}(\chi_E)&=1,
+        &\sigma(E)\setminus\{0\}&=\{1\}.
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Normality of a full-support normalized MPU representative]
     \label{thm:mpu_normalized_full_support_normal}
     \lean{MPOTensor.IsMPU.isNormalTensor_normalizedFlattening_of_cpsv}
     \leanok
-    \uses{def:mpu,def:mpu_normalized_flattening,
-        def:mpu_full_active_support}
+    \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_canonical_form,
+        def:mpu_full_active_support,def:normal}
     Let $U$ be an MPU tensor with positive physical and bond dimensions.
     Suppose that the normalized flattening is equipped with CPSV
     canonical-form data whose active blocks have full support in the ambient
     bond space. Then the normalized flattening is a normal tensor.
 
-    The full-support hypothesis is essential for this ambient representative.
-    Adjoining a zero virtual direct summand preserves every periodic operator
-    but introduces a nontrivial invariant projection. Thus this theorem does
-    not assert that an arbitrary, possibly nonminimal MPU representative is
-    normal.
+    This is the full-support representative form of
+    \cite[Proposition~III.1]{Cirac2017MPU}. The full-support hypothesis is
+    essential for this ambient representative: adjoining a zero virtual
+    direct summand preserves every periodic operator but introduces a
+    nontrivial invariant projection. Thus the theorem does not assert that an
+    arbitrary, possibly nonminimal MPU representative is normal.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -884,8 +927,25 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         thm:mpu_shifted_transfer_trace_card_active,
         thm:mpu_shifted_transfer_trace_primitive,
         thm:mpu_unique_active_full_support_normal}
-    The normalized transfer traces force the active block set to have
-    cardinality one. The same traces give spectral radius one and primitivity.
-    Full active support then identifies the unique active block with the
-    ambient bond space, so the full-support normality theorem applies.
+    Write $K$ for the active block set. The normalized transfer identity gives
+    \begin{align}
+        \tr(E^N)&=1 &&(N>1).
+    \end{align}
+    The active-multiplicity theorem and the transfer-spectrum theorem then give
+    \begin{align}
+        |K|&=1,
+        &r(E)&=1,
+        &\operatorname{peripheral}(E)&=\{1\}.
+    \end{align}
+    Full active support supplies
+    \begin{align}
+        \sum_{k\in K}D_k&=D.
+    \end{align}
+    Since $K$ is a singleton, its unique active block has ambient dimension
+    $D$ and therefore makes the ambient tensor irreducible. Combining this
+    irreducibility with the displayed radius and peripheral-spectrum fields
+    gives
+    \begin{align}
+        \widetilde U&\text{ is a normal tensor}.
+    \end{align}
 \end{proof}

--- a/docs/paper-gaps/cpsv17_transfer_trace_power.tex
+++ b/docs/paper-gaps/cpsv17_transfer_trace_power.tex
@@ -16,18 +16,27 @@
 
 \section{Source statement}
 
-Let $U$ be a matrix-product unitary of bond dimension $D$, and let
-$\widetilde U$ denote its normalized flattening.  Its transfer map is the
-linear endomorphism $T:M_D(\mathbb C)\to M_D(\mathbb C)$ given by
+Let $U$ be a matrix-product unitary of physical dimension $d$ and bond
+dimension $D$.  Combine its two physical indices into
+$a=(p,q)\in\{1,\ldots,d\}^2$ and define its normalized flattening by
+$\widetilde U^{(p,q)}=d^{-1/2}U^{p,q}$.  Its transfer map is the linear
+endomorphism $T:M_D(\mathbb C)\to M_D(\mathbb C)$ given by
 \begin{align}
-  T(X)&=\sum_a \widetilde U^a X(\widetilde U^a)^\dagger.
+  T(X)&=\sum_{a\in\{1,\ldots,d\}^2}
+    \widetilde U^a X(\widetilde U^a)^\dagger.
 \end{align}
+This is \leanid{MPSTensor.transferMap} applied to
+\leanid{MPOTensor.normalizedFlattening}.
 For matrix units $F_{k\ell}$, let $E=\widehat T$ be the column-stacked
-transfer-matrix representation of $T$, characterized by
+transfer-matrix representation of $T$.  Explicitly, column stacking means
+$\operatorname{vec}(X)_{(j,i)}=X_{ij}$, and $E$ is characterized by
 \begin{align}
   E_{(j,i),(\ell,k)}&=\bigl(T(F_{k\ell})\bigr)_{ij},\\
   E\,\operatorname{vec}(X)&=\operatorname{vec}(T(X)).
 \end{align}
+These identities are the defining convention of
+\leanid{transferMatrix} and its application lemma
+\leanid{transferMatrix_mulVec_eq}.
 Thus $E$ is indexed by pairs of bond indices and has matrix dimension
 $n=D^2$. For any $n\times n$ matrix $B$, write
 \begin{align}

--- a/docs/paper-gaps/cpsv17_transfer_trace_power.tex
+++ b/docs/paper-gaps/cpsv17_transfer_trace_power.tex
@@ -16,27 +16,47 @@
 
 \section{Source statement}
 
-Let $E$ be the $n\times n$ complex transfer matrix of the normalized
-flattening of a matrix-product unitary.  Proposition~III.1 of
-\cite{Cirac2017MPU} derives
+Let $U$ be a matrix-product unitary of bond dimension $D$, and let
+$\widetilde U$ denote its normalized flattening.  Its transfer map is the
+linear endomorphism $T:M_D(\mathbb C)\to M_D(\mathbb C)$ given by
 \begin{align}
-  \tr(E^N)&=1 &&(N>1)
+  T(X)&=\sum_a \widetilde U^a X(\widetilde U^a)^\dagger.
+\end{align}
+For matrix units $F_{k\ell}$, let $E=\widehat T$ be the column-stacked
+transfer-matrix representation of $T$, characterized by
+\begin{align}
+  E_{(j,i),(\ell,k)}&=\bigl(T(F_{k\ell})\bigr)_{ij},\\
+  E\,\operatorname{vec}(X)&=\operatorname{vec}(T(X)).
+\end{align}
+Thus $E$ is indexed by pairs of bond indices and has matrix dimension
+$n=D^2$. For any $n\times n$ matrix $B$, write
+\begin{align}
+  \chi_B(X)&=\det(X\Id_n-B)
+\end{align}
+for its characteristic polynomial; in particular, $\chi_E$ denotes the
+characteristic polynomial of the transfer matrix.
+
+For every integer $N>1$, Proposition~III.1 of
+\cite{Cirac2017MPU} derives the shifted moment identity
+\begin{align}
+  \tr(E^N)&=1.
   \tag{shifted moments}
 \end{align}
-and concludes that the sole nonzero eigenvalue is $1$, with algebraic
-multiplicity one.  Equivalently,
+It concludes that the sole nonzero eigenvalue of $E$ is $1$, with algebraic
+multiplicity one. Equivalently,
 \begin{align}
   \chi_E(X)&=X^{n-1}(X-1).
   \tag{source conclusion}
 \end{align}
 The cited Lemma~A.5 of \cite{Cirac2016MPDO_arXiv} is naturally stated with
-all positive moments, including the first moment.  The MPU hypothesis above
+all positive moments, including the first moment. The MPU hypothesis above
 does not supply $\tr(E)=1$.
 
 \section{Exact shifted-moment argument}
 
-The missing first moment is unnecessary.  For every $m\ge1$, the shifted
-moments imply
+Fix the transfer matrix $E$, its dimension $n$, and its characteristic
+polynomial $\chi_E$ as defined above. The missing first moment is
+unnecessary. For every $m\ge1$, the shifted moments imply
 \begin{align}
   \tr((E^2)^m)&=\tr(E^{2m})=1,
   &\tr((E^3)^m)&=\tr(E^{3m})=1.
@@ -89,8 +109,8 @@ moments with exponent greater than one.\footnote{Formal declarations:
 and
 \leanid{Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt}
 in \doclink{TNLean/Algebra/ShiftedTracePowerSpectrum}.}
-For the normalized flattening of an MPU, the specialization gives the exponent
-$D^2-1$.\footnote{Formal declaration:
+For the normalized flattening of an MPU of bond dimension $D$, the
+specialization gives the exponent $D^2-1$.\footnote{Formal declaration:
 \leanid{MPOTensor.IsMPU.normalizedFlattening_charpoly} in
 \doclink{TNLean/MPS/MPU/TransferMatrix}.}
 

--- a/docs/paper-gaps/cpsv17_transfer_trace_power.tex
+++ b/docs/paper-gaps/cpsv17_transfer_trace_power.tex
@@ -7,8 +7,7 @@
 
 \input{command}
 
-\title{Trace-Power Lemma: All-Positive-Moment Prerequisite\\
-for the MPU Transfer-Matrix Spectrum Argument}
+\title{Shifted Trace Powers and the Exact MPU Transfer Spectrum}
 \author{}
 \date{2026-08-09}
 
@@ -17,63 +16,83 @@ for the MPU Transfer-Matrix Spectrum Argument}
 
 \section{Source statement}
 
-\cite[Proposition~1]{Cirac2017MPU} asserts: if $E$ is the transfer matrix
-of a matrix-product unitary, then $\tr(E^N)=1$ for all $N>1$, and consequently
-the spectrum of $E$ contains a single eigenvalue equal to one with the rest
-vanishing.  The paper cites Lemma~A.5 of \cite{Cirac2016MPDO_arXiv}.
+Let $E$ be the $n\times n$ complex transfer matrix of the normalized
+flattening of a matrix-product unitary.  Proposition~III.1 of
+\cite{Cirac2017MPU} derives
+\begin{align}
+  \tr(E^N)&=1 &&(N>1)
+  \tag{shifted moments}
+\end{align}
+and concludes that the sole nonzero eigenvalue is $1$, with algebraic
+multiplicity one.  Equivalently,
+\begin{align}
+  \chi_E(X)&=X^{n-1}(X-1).
+  \tag{source conclusion}
+\end{align}
+The cited Lemma~A.5 of \cite{Cirac2016MPDO_arXiv} is naturally stated with
+all positive moments, including the first moment.  The MPU hypothesis above
+does not supply $\tr(E)=1$.
 
-\section{The present formalization}
+\section{Exact shifted-moment argument}
 
-This PR (\ghpr{5732}) proves the algebraic statement: a complex $n\times n$
-matrix whose positive powers all have trace~$1$ satisfies
-$\chi_A(X)=X^{\,n-1}(X-1)$.  The proof is purely algebraic via Newton--Girard
-identities.  The hypothesis requires $\tr(A^k)=1$ for \emph{all} $k\ge 1$,
-including $k=1$.
+The missing first moment is unnecessary.  For every $m\ge1$, the shifted
+moments imply
+\begin{align}
+  \tr((E^2)^m)&=\tr(E^{2m})=1,
+  &\tr((E^3)^m)&=\tr(E^{3m})=1.
+\end{align}
+The all-positive-moment characteristic-polynomial theorem therefore gives
+\begin{align}
+  \chi_{E^2}(X)&=\chi_{E^3}(X)=X^{n-1}(X-1).
+\end{align}
+If $\lambda\ne0$ is a spectral value of $E$, spectral mapping gives
+\begin{align}
+  \lambda^2&=1,
+  &\lambda^3&=1,
+  &\lambda&=1.
+\end{align}
+Conversely, spectral mapping from $1\in\sigma(E^2)$ supplies a nonzero
+spectral value of $E$, so
+\begin{align}
+  \sigma(E)\setminus\{0\}&=\{1\}.
+\end{align}
+This set equality alone does not determine algebraic multiplicity.
 
-The paper only supplies moments for $N>1$.  This PR does \emph{not} recover
-$\tr(E)=1$ from the definition of the transfer matrix or from the unitary
-hypothesis.  It is a self-contained Newton--Girard prerequisite that needs
-the stronger all-positive-moment input.
+For multiplicity, use the commuting factorization
+\begin{align}
+  E^2-\Id&=(E+\Id)(E-\Id).
+\end{align}
+Every generalized $1$-eigenvector of $E$ is consequently a generalized
+$1$-eigenvector of $E^2$.  Hence
+\begin{align}
+  \operatorname{mult}_{1}(\chi_E)
+  &\le \operatorname{mult}_{1}(\chi_{E^2})
+   =1.
+\end{align}
+Since $1\in\sigma(E)$, the left-hand side is positive and therefore equals
+one.  All other nonzero roots have already been excluded.  Splitting the
+monic characteristic polynomial over $\mathbb C$ yields
+\begin{align}
+  \operatorname{mult}_{1}(\chi_E)&=1,
+  &\chi_E(X)&=X^{n-1}(X-1).
+\end{align}
+No identity for $\tr(E)$, positivity, normality, or diagonalizability is used.
 
-\section{The $k>1$ conclusion}
+\section{Verdict and formalization status}
 
-The source's exact $k>1$ conclusion is handled by \ghissue{5737} using
-a purely algebraic spectral-mapping argument.  From $\tr(E^N)=1$ for all
-$N>1$ we have $\tr((E^2)^m)=\tr(E^{2m})=1$ and
-$\tr((E^3)^m)=\tr(E^{3m})=1$ for every $m\ge 1$.  Applying the
-all-positive-powers charpoly theorem of this PR to the matrices $E^2$
-and $E^3$ separately gives
-$\chi_{E^2}(X)=\chi_{E^3}(X)=X^{\,n-1}(X-1)$.  By the spectral mapping
-theorem, the eigenvalues of $E^2$ and $E^3$ are $\{\lambda^2\}$ and
-$\{\lambda^3\}$ for eigenvalues $\lambda$ of $E$.  Hence every nonzero
-eigenvalue $\lambda$ of $E$ satisfies $\lambda^2=\lambda^3=1$, so
-$\lambda=1$.  Thus $\operatorname{spectrum}(E)\setminus\{0\}=\{1\}$ as
-a set.  No positivity, spectral radius, or Perron--Frobenius hypotheses
-are required.
-
-This set-level result (the nonzero spectrum is exactly $\{1\}$) is
-\emph{distinct} from the characteristic-polynomial factorization proved
-in this PR, which additionally shows that the eigenvalue~$1$ has algebraic
-multiplicity~$1$ (all other roots are~$0$).  The algebraic multiplicity
-theorem is a separate, still-unpackaged result.
-
-\section{Formalization status}
-
-\textbf{Verdict: scoped stronger-hypothesis prerequisite.}
-The two Lean theorems in
-\doclink{TNLean/Algebra/TracePowerCharPoly} prove the consequence
-for $k\ge 1$:
-\begin{itemize}
-  \item \leanid{Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_trace_pow_eq_one_of_le_card}
-        (finite-range, $1\le k\le n$, requires $n\ge1$),
-  \item \leanid{Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one}
-        (all $k\ge 1$, cardinality derived internally).
-\end{itemize}
-The source-level gap (conclusion from $N>1$ moments alone) is assigned to
-\ghissue{5737}, which proves the set-spectrum result without recovering the
-first moment.  The algebraic multiplicity theorem follows from the charpoly
-factorization proved here once the spectral reduction in \ghissue{5737} is
-applied.
+\textbf{Verdict: the shifted-moment multiplicity gap is closed.}
+The set-spectrum statement remains available as a deliberately narrower
+consequence, but the exact source conclusion is now formalized directly from
+moments with exponent greater than one.\footnote{Formal declarations:
+\leanid{Matrix.spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt},
+\leanid{Matrix.charpoly_rootMultiplicity_one_eq_one_of_forall_trace_pow_eq_one_of_one_lt},
+and
+\leanid{Matrix.charpoly_eq_X_pow_pred_mul_X_sub_one_of_forall_trace_pow_eq_one_of_one_lt}
+in \doclink{TNLean/Algebra/ShiftedTracePowerSpectrum}.}
+For the normalized flattening of an MPU, the specialization gives the exponent
+$D^2-1$.\footnote{Formal declaration:
+\leanid{MPOTensor.IsMPU.normalizedFlattening_charpoly} in
+\doclink{TNLean/MPS/MPU/TransferMatrix}.}
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -63,9 +63,10 @@ representative before applying the proposition or explicitly assume full active
 support for the chosen ambient representative.  The formalization does not yet
 construct the representative reduction.  The latter
 implication is formalized by
-\leanid{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_card_active_eq_one_of_fullActiveSupport};
-its normal-tensor conclusion still takes the spectral-radius and primitivity
-conclusions supplied by the proposition's spectral argument as separate data.
+\leanid{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_card_active_eq_one_of_fullActiveSupport}.
+The spectral-radius and primitivity conclusions are derived from the shifted
+normalized transfer traces and combined with full active support in
+\leanid{MPOTensor.IsMPU.isNormalTensor_normalizedFlattening_of_cpsv}.
 Bare \leanid{MPOTensor.IsMPU} is deliberately not used to infer ambient
 normality.
 


### PR DESCRIPTION
## Summary

- derive spectral radius one and primitivity of a matrix endomorphism from shifted transfer-matrix traces, using the shifted nonzero-spectrum theorem and the transfer-matrix eigenvalue bridge
- expose the nonzero transfer spectrum of an MPU's normalized flattening as `{1}`
- prove the exact shifted-moment characteristic polynomial `X^(n-1)(X-1)` and specialize it to the normalized MPU transfer matrix with exponent `D² - 1`
- prove normality of the normalized flattening for CPSV canonical-form data with full active support
- document the nonminimal-representative obstruction in the Lean theorem, Chapter 28, and `docs/paper-gaps/mpu_canonical_form_full_support.tex`

The capstone deliberately does **not** claim bare `IsMPU → IsNormalTensor`: adjoining a zero virtual summand preserves the periodic MPU operators while destroying ambient irreducibility.

## Verification

- `lake env lean TNLean/Algebra/ShiftedTracePowerSpectrum.lean`
- `lake env lean TNLean/Channel/Peripheral/TransferMatrix.lean`
- `lake env lean TNLean/MPS/MPU/TransferMatrix.lean`
- `lake env lean TNLean/MPS/MPU/CanonicalForm.lean`
- focused `#check` of all three new public declarations
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`

- blueprint synchronization and reverse declaration coverage checks
- focused declaration validation through a temporary library root
- successful full blueprint web render and targeted Chapter 28 / paper-gap LaTeX compilation

Closes #5706

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are substantial formal math in spectral/transfer-matrix and MPU normality paths; the capstone is intentionally scoped (full active support), so callers must not treat bare `IsMPU` as implying normality.
> 
> **Overview**
> Extends the shifted trace-power story from **nonzero set spectrum** `{1}` to the **exact characteristic polynomial** `X^(n-1)(X-1)` and multiplicity one at `1`, without assuming `tr(A)=1`. New algebra in `ShiftedTracePowerSpectrum` uses generalized-eigenspace inclusion under squaring and bounds multiplicity via `A^2`.
> 
> **Transfer / MPU pipeline:** `Channel/Peripheral/TransferMatrix` derives spectral radius one and primitivity from shifted transfer-matrix traces; MPU transfer results add nonzero spectrum `{1}` and charpoly `X^(D²-1)(X-1)` for normalized flattenings. **Capstone:** `IsMPU.isNormalTensor_normalizedFlattening_of_cpsv` proves normality only when CPSV data has **full active support**—not bare `IsMPU` (zero summands break irreducibility). Blueprint Chapter 28 and paper-gap docs are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aab361dc2603aa83406ba53829c2f9e70743511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

