### PR TITLE
docs(MPU): align source-cut rank explanations

### DIFF
--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -165,14 +165,14 @@ lemma leftRank_eq : ℓ[U] = (sourceCutM₂ U).rank := rfl
 /-! ### Rank bounds -/
 
 /-- The right rank $r = \operatorname{rank} {\cal M}_1 \le D d$,
-since ${\cal M}_1$ has $Dd$ rows and $dD$ columns. -/
+since ${\cal M}_1$ has $dD$ columns. -/
 theorem rightRank_bound : r[U] ≤ D * d := by
   rw [rightRank]
   refine (Matrix.rank_le_card_width (sourceCutM₁ U)).trans ?_
   simp [Fintype.card_fin, mul_comm]
 
 /-- The left rank $\ell = \operatorname{rank} {\cal M}_2 \le D d$,
-since ${\cal M}_2$ also has $Dd$ rows and $dD$ columns. -/
+since ${\cal M}_2$ also has $dD$ columns. -/
 theorem leftRank_bound : ℓ[U] ≤ D * d := by
   rw [leftRank]
   refine (Matrix.rank_le_card_width (sourceCutM₂ U)).trans ?_


### PR DESCRIPTION
Closes #5750.

Aligns the two source-cut rank-bound docstrings with the actual `Matrix.rank_le_card_width` proofs and the corrected Chapter 28 blueprint argument: each rank is bounded by the $dD$ column count.

Checks:
- `lake env lean TNLean/MPS/MPU/SourceCuts.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Mathlib docstrings; no proof or definition logic is modified.
> 
> **Overview**
> Updates the docstrings for **`rightRank_bound`** and **`leftRank_bound`** in `SourceCuts.lean` so they match how the theorems are proved.
> 
> Each bound previously claimed both source matrices had “$Dd$ rows and $dD$ columns.” The proofs only invoke **`Matrix.rank_le_card_width`**, so the docstrings now state that $r$ and $\ell$ are bounded because ${\cal M}_1$ and ${\cal M}_2$ each have $dD$ columns—aligned with the Chapter 28 blueprint argument referenced in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037dc0d1ba19a9b7ac769489f503f7f090e9b483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->