### PR TITLE
feat(MPU): stabilize normalized transfer powers

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -47,6 +47,7 @@ import TNLean.Algebra.MatrixRankBaseChange
 import TNLean.Algebra.MatrixRankClosed
 import TNLean.Algebra.MatrixReindexUnitary
 import TNLean.Algebra.MatrixSpectralDecomp
+import TNLean.Algebra.MatrixStabilization
 import TNLean.Algebra.MatrixTracePairing
 import TNLean.Algebra.MatrixTracePowerContinuity
 import TNLean.Algebra.NatInterval

--- a/TNLean/Algebra/MatrixStabilization.lean
+++ b/TNLean/Algebra/MatrixStabilization.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff
+import TNLean.Algebra.PerronFrobenius.RankOne
+
+/-!
+# Stabilized rank-one matrix powers
+
+This module gives a Cayley--Hamilton criterion for stabilization at a bounded
+power and records the resulting normalized rank-one projector.
+
+## Main definitions
+
+* `Matrix.StabilizedRankOneData` records a positive stabilization exponent,
+  its bound, normalized outer-product witnesses, and all later powers.
+
+## Main results
+
+* `Matrix.pow_card_eq_pow_pred_of_charpoly_eq_X_pow_pred_mul_X_sub_one` gives
+  bounded stabilization from the characteristic polynomial.
+* `Matrix.StabilizedRankOneData.power_eq_vec_mul_vec_of_fixed` identifies the
+  stabilized projector using any normalized fixed pair.
+-/
+
+open scoped Matrix BigOperators
+open Polynomial
+
+namespace Matrix
+
+/-! ### Cayley--Hamilton elimination and rank-one factorization -/
+
+variable {ι : Type*} [Fintype ι]
+
+/-- If the characteristic polynomial is `X^(n-1) * (X-1)`, Cayley--Hamilton
+kills the zero-primary component after exponent `n-1`.
+
+This is the generalized-eigenspace/Jordan-elimination step used at
+arXiv:1703.09188, lines 397--409, expressed without choosing a Jordan basis. -/
+theorem pow_card_eq_pow_pred_of_charpoly_eq_X_pow_pred_mul_X_sub_one
+    [DecidableEq ι] [Nonempty ι] (E : Matrix ι ι ℂ)
+    (hchar : E.charpoly = X ^ (Fintype.card ι - 1) * (X - 1)) :
+    E ^ Fintype.card ι = E ^ (Fintype.card ι - 1) := by
+  have hCH := E.aeval_self_charpoly
+  rw [hchar, map_mul, map_pow, aeval_X, map_sub, aeval_X, map_one] at hCH
+  have hn : Fintype.card ι - 1 + 1 = Fintype.card ι := by
+    have : 0 < Fintype.card ι := Fintype.card_pos
+    omega
+  rw [mul_sub, mul_one, ← pow_succ, hn] at hCH
+  exact sub_eq_zero.mp hCH
+
+/-- A complex idempotent matrix of trace one is an outer product. -/
+theorem exists_eq_vec_mul_vec_of_mul_self_eq_self_of_trace_eq_one
+    {T : Matrix ι ι ℂ} (hTT : T * T = T) (hTrace : Matrix.trace T = 1) :
+    ∃ a b : ι → ℂ, T = Matrix.vecMulVec a b := by
+  change Matrix.HasRankOneFactorization T
+  exact Matrix.hasRankOneFactorization_of_mul_self_eq_self hTT hTrace
+
+/-! ### Reusable stabilized-transfer structure -/
+
+/-- Data witnessing that a matrix stabilizes at a bounded positive power to a
+normalized rank-one projector.
+
+Here `right ⬝ᵥ left = 1` is the normalization `(Φ|ρ) = 1`, up to the harmless
+commutation of complex scalars in the coordinate dot product. The equality
+`power_eq` is the source formula `E^J = |ρ)(Φ|`.
+
+Source: arXiv:1703.09188, lines 397--409. -/
+structure StabilizedRankOneData [DecidableEq ι] (E : Matrix ι ι ℂ) (bound : ℕ) where
+  /-- The blocking exponent that eliminates the zero-primary component. -/
+  exponent : ℕ
+  /-- The source blocking exponent is positive. -/
+  exponent_pos : 0 < exponent
+  /-- The exponent lies below the advertised ambient-dimensional bound. -/
+  exponent_le : exponent ≤ bound
+  /-- The normalized right fixed witness `ρ`. -/
+  right : ι → ℂ
+  /-- The normalized left fixed witness `Φ`. -/
+  left : ι → ℂ
+  /-- Normalization of the left/right pairing. -/
+  pairing_eq_one : right ⬝ᵥ left = 1
+  /-- The stabilized power is the outer product `|ρ)(Φ|`. -/
+  power_eq : E ^ exponent = Matrix.vecMulVec right left
+  /-- Every later power equals the stabilized projector. -/
+  stable : ∀ k, exponent ≤ k → E ^ k = E ^ exponent
+
+namespace StabilizedRankOneData
+
+variable [DecidableEq ι] {E : Matrix ι ι ℂ} {bound : ℕ}
+
+/-- The stabilized transfer matrix is idempotent. -/
+theorem projector_idempotent (data : StabilizedRankOneData E bound) :
+    E ^ data.exponent * E ^ data.exponent = E ^ data.exponent := by
+  rw [← pow_add]
+  exact data.stable _ (Nat.le_add_right _ _)
+
+/-- The right witness is fixed by the original transfer matrix. -/
+theorem right_fixed (data : StabilizedRankOneData E bound) :
+    E *ᵥ data.right = data.right := by
+  have hPright : E ^ data.exponent *ᵥ data.right = data.right := by
+    rw [data.power_eq, Matrix.vecMulVec_mulVec, dotProduct_comm,
+      data.pairing_eq_one]
+    simp
+  calc
+    E *ᵥ data.right = E *ᵥ (E ^ data.exponent *ᵥ data.right) := by rw [hPright]
+    _ = (E * E ^ data.exponent) *ᵥ data.right := by rw [Matrix.mulVec_mulVec]
+    _ = E ^ (data.exponent + 1) *ᵥ data.right := by rw [← pow_succ']
+    _ = E ^ data.exponent *ᵥ data.right := by
+      rw [data.stable _ (Nat.le_succ data.exponent)]
+    _ = data.right := hPright
+
+/-- The left witness is fixed by the original transfer matrix. -/
+theorem left_fixed (data : StabilizedRankOneData E bound) :
+    Matrix.vecMul data.left E = data.left := by
+  have hleftP : Matrix.vecMul data.left (E ^ data.exponent) = data.left := by
+    rw [data.power_eq, Matrix.vecMul_vecMulVec, dotProduct_comm,
+      data.pairing_eq_one, one_smul]
+  calc
+    Matrix.vecMul data.left E =
+        Matrix.vecMul (Matrix.vecMul data.left (E ^ data.exponent)) E := by rw [hleftP]
+    _ = Matrix.vecMul data.left (E ^ data.exponent * E) := by
+      rw [Matrix.vecMul_vecMul]
+    _ = Matrix.vecMul data.left (E ^ (data.exponent + 1)) := by rw [pow_succ]
+    _ = Matrix.vecMul data.left (E ^ data.exponent) := by
+      rw [data.stable _ (Nat.le_succ data.exponent)]
+    _ = data.left := hleftP
+
+/-- Any normalized pair of left and right fixed witnesses gives the same
+outer-product factorization of the stabilized projector. -/
+theorem power_eq_vec_mul_vec_of_fixed (data : StabilizedRankOneData E bound)
+    (right' left' : ι → ℂ) (hpair : left' ⬝ᵥ right' = 1)
+    (hright : E *ᵥ right' = right') (hleft : Matrix.vecMul left' E = left') :
+    E ^ data.exponent = Matrix.vecMulVec right' left' := by
+  have hright_pow : E ^ data.exponent *ᵥ right' = right' := by
+    induction data.exponent with
+    | zero => simp
+    | succ n ih =>
+      rw [pow_succ', ← Matrix.mulVec_mulVec, ih, hright]
+  have hleft_pow : Matrix.vecMul left' (E ^ data.exponent) = left' := by
+    induction data.exponent with
+    | zero => simp
+    | succ n ih =>
+      rw [pow_succ, ← Matrix.vecMul_vecMul, ih, hleft]
+  have hright' : (data.left ⬝ᵥ right') • data.right = right' := by
+    rw [data.power_eq, Matrix.vecMulVec_mulVec] at hright_pow
+    simpa [Algebra.smul_def, dotProduct_comm] using hright_pow
+  have hleft' : (left' ⬝ᵥ data.right) • data.left = left' := by
+    rw [data.power_eq, Matrix.vecMul_vecMulVec] at hleft_pow
+    exact hleft_pow
+  rw [data.power_eq]
+  rw [← hright', ← hleft'] at hpair ⊢
+  have hscalar :
+      (data.left ⬝ᵥ right') * (left' ⬝ᵥ data.right) = 1 := by
+    simpa [dotProduct_comm, mul_comm, mul_left_comm, mul_assoc,
+      data.pairing_eq_one] using hpair
+  ext i j
+  simp only [Matrix.vecMulVec_apply, Pi.smul_apply, smul_eq_mul]
+  calc
+    data.right i * data.left j =
+        ((data.left ⬝ᵥ right') * (left' ⬝ᵥ data.right)) *
+          (data.right i * data.left j) := by rw [hscalar, one_mul]
+    _ = (data.left ⬝ᵥ right') * data.right i *
+          ((left' ⬝ᵥ data.right) * data.left j) := by ring
+
+/-- Construct stabilized rank-one data from one equality of consecutive powers
+and the trace-one normalization at that power. -/
+noncomputable def of_power_succ_eq [Nonempty ι]
+    (J bound : ℕ) (hJpos : 0 < J) (hJle : J ≤ bound)
+    (hstep : E ^ (J + 1) = E ^ J) (htrace : Matrix.trace (E ^ J) = 1) :
+    StabilizedRankOneData E bound := by
+  have hstable : ∀ k, J ≤ k → E ^ k = E ^ J := by
+    intro k hk
+    obtain ⟨t, rfl⟩ := Nat.exists_eq_add_of_le hk
+    induction t with
+    | zero => rfl
+    | succ t iht =>
+      rw [Nat.add_succ, pow_succ, iht (Nat.le_add_right _ _), ← pow_succ, hstep]
+  have hidem : E ^ J * E ^ J = E ^ J := by
+    rw [← pow_add]
+    exact hstable _ (Nat.le_add_right _ _)
+  let hex := Matrix.exists_eq_vec_mul_vec_of_mul_self_eq_self_of_trace_eq_one hidem htrace
+  let right := Classical.choose hex
+  let left := Classical.choose (Classical.choose_spec hex)
+  have hfac : E ^ J = Matrix.vecMulVec right left :=
+    Classical.choose_spec (Classical.choose_spec hex)
+  refine ⟨J, hJpos, hJle, right, left, ?_, hfac, hstable⟩
+  rw [← Matrix.trace_vecMulVec, ← hfac]
+  exact htrace
+
+end StabilizedRankOneData
+end Matrix
+

--- a/TNLean/Algebra/MatrixStabilization.lean
+++ b/TNLean/Algebra/MatrixStabilization.lean
@@ -191,4 +191,3 @@ noncomputable def of_power_succ_eq [Nonempty ι]
 
 end StabilizedRankOneData
 end Matrix
-

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -76,10 +76,9 @@ namespace Matrix
 
 variable {n : ℕ}
 
-/-- A square real matrix has the rank-one factorization of Appendix C.2,
-Lemma C.4 if it is an outer product of two vectors. -/
-def HasRankOneFactorization {ι : Type*} (T : Matrix ι ι ℝ) : Prop :=
-  ∃ a b : ι → ℝ, T = Matrix.vecMulVec a b
+/-- A square matrix has a rank-one factorization if it is an outer product of two vectors. -/
+def HasRankOneFactorization {R ι : Type*} [Mul R] (T : Matrix ι ι R) : Prop :=
+  ∃ a b : ι → R, T = Matrix.vecMulVec a b
 
 /-- The traces of all positive powers of `T` agree with the trace of `T`
 itself. This is the matrix-theoretic consequence of the ZCL step used in
@@ -87,28 +86,28 @@ Appendix C.2, Lemma C.4. -/
 def TracePowersConstant (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   ∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T
 
-/-- An idempotent real matrix of trace one has a rank-one factorization.
+/-- An idempotent real or complex matrix of trace one has a rank-one factorization.
 
 This criterion excludes precisely the nilpotent generalized zero-eigenspace
 which is invisible to traces of powers.  It is the algebraic conclusion needed
 after retaining the operator-valued ZCL identity in arXiv:1606.00608,
 Appendix C.2, lines 1489--1497. -/
 theorem hasRankOneFactorization_of_mul_self_eq_self
-    {ι : Type*} [Fintype ι]
-    {T : Matrix ι ι ℝ}
+    {R ι : Type*} [RCLike R] [Fintype ι]
+    {T : Matrix ι ι R}
     (hTT : T * T = T) (hTrace : Matrix.trace T = 1) :
     HasRankOneFactorization T := by
   classical
-  let f : (ι → ℝ) →ₗ[ℝ] (ι → ℝ) := Matrix.toLin' T
+  let f : (ι → R) →ₗ[R] (ι → R) := Matrix.toLin' T
   have hf : IsIdempotentElem f := by
     change Matrix.toLin' T ∘ₗ Matrix.toLin' T = Matrix.toLin' T
     rw [← Matrix.toLin'_mul, hTT]
-  have hrank : Module.finrank ℝ (LinearMap.range f) = 1 := by
+  have hrank : Module.finrank R (LinearMap.range f) = 1 := by
     have h := (LinearMap.isProj_range_iff_isIdempotentElem f).2 hf |>.trace
     rw [Matrix.trace_toLin'_eq, hTrace] at h
     exact_mod_cast h.symm
   rcases finrank_eq_one_iff'.mp hrank with ⟨u, hu, hspan⟩
-  let b : ι → ℝ := fun j ↦
+  let b : ι → R := fun j ↦
     Classical.choose (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
   refine ⟨u.1, b, ?_⟩
   ext i j

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -13,3 +13,4 @@ import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.TransferMatrix
+import TNLean.MPS.MPU.TransferStabilization

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -1,0 +1,343 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Projection
+import Mathlib.LinearAlgebra.Trace
+import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.MPU.TransferMatrix
+
+/-!
+# Jordan elimination for the normalized MPU transfer matrix
+
+The exact characteristic polynomial of the normalized transfer matrix is
+`X ^ (D * D - 1) * (X - 1)`. Cayley--Hamilton therefore makes its
+`(D * D - 1)`-st and `D * D`-th powers equal. This is the coordinate-free
+replacement for blocking by the largest zero-eigenvalue Jordan block in the
+source. The stabilized power is an idempotent of trace one, hence a rank-one
+projector with normalized left and right fixed witnesses.
+
+## Main definitions
+
+* `Matrix.StabilizedRankOneData` packages a positive stabilization exponent,
+  its bound, normalized outer-product witnesses, and stabilization of all
+  later powers.
+
+## Main results
+
+* `MPOTensor.IsMPU.normalizedTransferStabilization` eliminates the zero-primary
+  component after the explicit exponent `D * D - 1` when `1 < D`.
+* `MPOTensor.IsMPU.normalizedTransferStabilization_fin_one` treats the
+  one-dimensional bond space separately.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, "Matrix Product Unitaries: Structure,
+  Symmetries, and Topological Invariants", lines 397--409.
+-/
+
+open scoped Matrix BigOperators
+open Polynomial
+
+namespace Matrix
+
+/-! ### Cayley--Hamilton elimination and rank-one factorization -/
+
+variable {ι : Type*} [Fintype ι]
+
+/-- If the characteristic polynomial is `X^(n-1) * (X-1)`, Cayley--Hamilton
+kills the zero-primary component after exponent `n-1`.
+
+This is the generalized-eigenspace/Jordan-elimination step used at
+arXiv:1703.09188, lines 397--409, expressed without choosing a Jordan basis. -/
+theorem pow_card_eq_pow_pred_of_charpoly_eq_X_pow_pred_mul_X_sub_one
+    [DecidableEq ι] [Nonempty ι] (E : Matrix ι ι ℂ)
+    (hchar : E.charpoly = X ^ (Fintype.card ι - 1) * (X - 1)) :
+    E ^ Fintype.card ι = E ^ (Fintype.card ι - 1) := by
+  have hCH := E.aeval_self_charpoly
+  rw [hchar, map_mul, map_pow, aeval_X, map_sub, aeval_X, map_one] at hCH
+  have hn : Fintype.card ι - 1 + 1 = Fintype.card ι := by
+    have : 0 < Fintype.card ι := Fintype.card_pos
+    omega
+  rw [mul_sub, mul_one, ← pow_succ, hn] at hCH
+  exact sub_eq_zero.mp hCH
+
+/-- A complex idempotent matrix of trace one is an outer product.
+
+The proof identifies the range of the idempotent with a one-dimensional
+subspace and factors its columns through a generator. It is the matrix
+factorization used after zero-primary elimination in arXiv:1703.09188,
+lines 397--409. -/
+theorem exists_eq_vecMulVec_of_mul_self_eq_self_of_trace_eq_one
+    {T : Matrix ι ι ℂ} (hTT : T * T = T) (hTrace : Matrix.trace T = 1) :
+    ∃ a b : ι → ℂ, T = Matrix.vecMulVec a b := by
+  classical
+  let f : (ι → ℂ) →ₗ[ℂ] (ι → ℂ) := Matrix.toLin' T
+  have hf : IsIdempotentElem f := by
+    change Matrix.toLin' T ∘ₗ Matrix.toLin' T = Matrix.toLin' T
+    rw [← Matrix.toLin'_mul, hTT]
+  have hrank : Module.finrank ℂ (LinearMap.range f) = 1 := by
+    have h := (LinearMap.isProj_range_iff_isIdempotentElem f).2 hf |>.trace
+    rw [Matrix.trace_toLin'_eq, hTrace] at h
+    exact_mod_cast h.symm
+  rcases finrank_eq_one_iff'.mp hrank with ⟨u, _hu, hspan⟩
+  let b : ι → ℂ := fun j ↦
+    Classical.choose (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
+  refine ⟨u.1, b, ?_⟩
+  ext i j
+  have hb := Classical.choose_spec
+    (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
+  have hb' := congrArg (fun x : LinearMap.range f ↦ x.1 i) hb
+  have heval : f (Pi.single j 1) i = T i j := by
+    simp [f, Matrix.toLin'_apply]
+  change Classical.choose _ * u.1 i = f (Pi.single j 1) i at hb'
+  rw [heval] at hb'
+  simpa [b, Matrix.vecMulVec_apply, mul_comm] using hb'.symm
+
+/-! ### Reusable stabilized-transfer package -/
+
+/-- Data witnessing that a matrix stabilizes at a bounded positive power to a
+normalized rank-one projector.
+
+Here `right ⬝ᵥ left = 1` is the normalization `(Φ|ρ) = 1`, up to the harmless
+commutation of complex scalars in the coordinate dot product. The equality
+`power_eq` is the source formula `E^J = |ρ)(Φ|`.
+
+Source: arXiv:1703.09188, lines 397--409. -/
+structure StabilizedRankOneData [DecidableEq ι] (E : Matrix ι ι ℂ) (bound : ℕ) where
+  /-- The blocking exponent that eliminates the zero-primary component. -/
+  exponent : ℕ
+  /-- The source blocking exponent is positive. -/
+  exponent_pos : 0 < exponent
+  /-- The exponent lies below the advertised ambient-dimensional bound. -/
+  exponent_le : exponent ≤ bound
+  /-- The normalized right fixed witness `ρ`. -/
+  right : ι → ℂ
+  /-- The normalized left fixed witness `Φ`. -/
+  left : ι → ℂ
+  /-- Normalization of the left/right pairing. -/
+  pairing_eq_one : right ⬝ᵥ left = 1
+  /-- The stabilized power is the outer product `|ρ)(Φ|`. -/
+  power_eq : E ^ exponent = Matrix.vecMulVec right left
+  /-- Every later power equals the stabilized projector. -/
+  stable : ∀ k, exponent ≤ k → E ^ k = E ^ exponent
+
+namespace StabilizedRankOneData
+
+variable [DecidableEq ι] {E : Matrix ι ι ℂ} {bound : ℕ}
+
+/-- The stabilized transfer matrix is idempotent. -/
+theorem projector_idempotent (data : StabilizedRankOneData E bound) :
+    E ^ data.exponent * E ^ data.exponent = E ^ data.exponent := by
+  rw [← pow_add]
+  exact data.stable _ (Nat.le_add_right _ _)
+
+/-- The right witness is fixed by the original transfer matrix. -/
+theorem right_fixed (data : StabilizedRankOneData E bound) :
+    E *ᵥ data.right = data.right := by
+  have hPright : E ^ data.exponent *ᵥ data.right = data.right := by
+    rw [data.power_eq, Matrix.vecMulVec_mulVec, dotProduct_comm,
+      data.pairing_eq_one]
+    simp
+  calc
+    E *ᵥ data.right = E *ᵥ (E ^ data.exponent *ᵥ data.right) := by rw [hPright]
+    _ = (E * E ^ data.exponent) *ᵥ data.right := by rw [Matrix.mulVec_mulVec]
+    _ = E ^ (data.exponent + 1) *ᵥ data.right := by rw [← pow_succ']
+    _ = E ^ data.exponent *ᵥ data.right := by
+      rw [data.stable _ (Nat.le_succ data.exponent)]
+    _ = data.right := hPright
+
+/-- The left witness is fixed by the original transfer matrix. -/
+theorem left_fixed (data : StabilizedRankOneData E bound) :
+    Matrix.vecMul data.left E = data.left := by
+  have hleftP : Matrix.vecMul data.left (E ^ data.exponent) = data.left := by
+    rw [data.power_eq, Matrix.vecMul_vecMulVec, dotProduct_comm,
+      data.pairing_eq_one, one_smul]
+  calc
+    Matrix.vecMul data.left E =
+        Matrix.vecMul (Matrix.vecMul data.left (E ^ data.exponent)) E := by rw [hleftP]
+    _ = Matrix.vecMul data.left (E ^ data.exponent * E) := by
+      rw [Matrix.vecMul_vecMul]
+    _ = Matrix.vecMul data.left (E ^ (data.exponent + 1)) := by rw [pow_succ]
+    _ = Matrix.vecMul data.left (E ^ data.exponent) := by
+      rw [data.stable _ (Nat.le_succ data.exponent)]
+    _ = data.left := hleftP
+
+/-- Any normalized pair of left and right fixed witnesses gives the same
+outer-product factorization of the stabilized projector. -/
+theorem power_eq_vecMulVec_of_fixed (data : StabilizedRankOneData E bound)
+    (right' left' : ι → ℂ) (hpair : left' ⬝ᵥ right' = 1)
+    (hright : E *ᵥ right' = right') (hleft : Matrix.vecMul left' E = left') :
+    E ^ data.exponent = Matrix.vecMulVec right' left' := by
+  have hright_pow : E ^ data.exponent *ᵥ right' = right' := by
+    induction data.exponent with
+    | zero => simp
+    | succ n ih =>
+      rw [pow_succ', ← Matrix.mulVec_mulVec, ih, hright]
+  have hleft_pow : Matrix.vecMul left' (E ^ data.exponent) = left' := by
+    induction data.exponent with
+    | zero => simp
+    | succ n ih =>
+      rw [pow_succ, ← Matrix.vecMul_vecMul, ih, hleft]
+  have hright' : (data.left ⬝ᵥ right') • data.right = right' := by
+    rw [data.power_eq, Matrix.vecMulVec_mulVec] at hright_pow
+    simpa [Algebra.smul_def, dotProduct_comm] using hright_pow
+  have hleft' : (left' ⬝ᵥ data.right) • data.left = left' := by
+    rw [data.power_eq, Matrix.vecMul_vecMulVec] at hleft_pow
+    exact hleft_pow
+  rw [data.power_eq]
+  rw [← hright', ← hleft'] at hpair ⊢
+  have hscalar :
+      (data.left ⬝ᵥ right') * (left' ⬝ᵥ data.right) = 1 := by
+    simpa [dotProduct_comm, mul_comm, mul_left_comm, mul_assoc,
+      data.pairing_eq_one] using hpair
+  ext i j
+  simp only [Matrix.vecMulVec_apply, Pi.smul_apply, smul_eq_mul]
+  calc
+    data.right i * data.left j =
+        ((data.left ⬝ᵥ right') * (left' ⬝ᵥ data.right)) *
+          (data.right i * data.left j) := by rw [hscalar, one_mul]
+    _ = (data.left ⬝ᵥ right') * data.right i *
+          ((left' ⬝ᵥ data.right) * data.left j) := by ring
+
+/-- Construct stabilized rank-one data from one equality of consecutive powers
+and the trace-one normalization at that power. -/
+noncomputable def of_power_succ_eq [Nonempty ι]
+    (J bound : ℕ) (hJpos : 0 < J) (hJle : J ≤ bound)
+    (hstep : E ^ (J + 1) = E ^ J) (htrace : Matrix.trace (E ^ J) = 1) :
+    StabilizedRankOneData E bound := by
+  have hstable : ∀ k, J ≤ k → E ^ k = E ^ J := by
+    intro k hk
+    obtain ⟨t, rfl⟩ := Nat.exists_eq_add_of_le hk
+    induction t with
+    | zero => rfl
+    | succ t iht =>
+      rw [Nat.add_succ, pow_succ, iht (Nat.le_add_right _ _), ← pow_succ, hstep]
+  have hidem : E ^ J * E ^ J = E ^ J := by
+    rw [← pow_add]
+    exact hstable _ (Nat.le_add_right _ _)
+  let hex := Matrix.exists_eq_vecMulVec_of_mul_self_eq_self_of_trace_eq_one hidem htrace
+  let right := Classical.choose hex
+  let left := Classical.choose (Classical.choose_spec hex)
+  have hfac : E ^ J = Matrix.vecMulVec right left :=
+    Classical.choose_spec (Classical.choose_spec hex)
+  refine ⟨J, hJpos, hJle, right, left, ?_, hfac, hstable⟩
+  rw [← Matrix.trace_vecMulVec, ← hfac]
+  exact htrace
+
+end StabilizedRankOneData
+end Matrix
+
+namespace MPOTensor
+
+/-! ### Normalized MPU transfer stabilization -/
+
+variable {d D : ℕ}
+
+/-- For an MPU of bond dimension `D > 1`, the normalized transfer matrix
+stabilizes at the explicit positive exponent `J = D * D - 1`. Its stabilized
+value is `|ρ)(Φ|`, with normalized left and right fixed witnesses, and every
+power at least `J` has the same value.
+
+Cayley--Hamilton applied to
+`χ_E(X) = X^(D²-1)(X-1)` eliminates precisely the zero-primary component; no
+ambient normality or diagonalizability is asserted.
+
+Source: arXiv:1703.09188, lines 397--409. -/
+noncomputable def IsMPU.normalizedTransferStabilization
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D) :
+    Matrix.StabilizedRankOneData
+      (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) (D * D - 1) := by
+  let E := transferMatrix (MPSTensor.transferMap U.normalizedFlattening)
+  have hD2 : 2 ≤ D := by omega
+  have hDD : 4 ≤ D * D := Nat.mul_le_mul hD2 hD2
+  have hchar : E.charpoly = X ^ (Fintype.card (Fin D × Fin D) - 1) * (X - 1) := by
+    simpa [E, Fintype.card_prod, Fintype.card_fin] using hU.normalizedFlattening_charpoly
+  have hpow :=
+    Matrix.pow_card_eq_pow_pred_of_charpoly_eq_X_pow_pred_mul_X_sub_one E hchar
+  have hstep : E ^ ((D * D - 1) + 1) = E ^ (D * D - 1) := by
+    simpa [Fintype.card_prod, Fintype.card_fin,
+      Nat.sub_add_cancel (by omega : 1 ≤ D * D)] using hpow
+  exact Matrix.StabilizedRankOneData.of_power_succ_eq (D * D - 1) (D * D - 1)
+    (by omega) le_rfl hstep
+    (hU.trace_transferMatrix_normalizedFlattening_pow_eq_one (by omega))
+
+/-- Source-shaped unbundled form of normalized transfer stabilization:
+there are normalized left/right fixed witnesses and a positive
+`J ≤ D * D - 1` such that `E^J = |ρ)(Φ|` and all later powers equal this
+rank-one projector.
+
+The proof removes the zero-primary component by Cayley--Hamilton; it does not
+infer ambient normality from bare `IsMPU`.
+
+Source: arXiv:1703.09188, lines 397--409. -/
+theorem IsMPU.exists_normalizedTransfer_stabilizes_to_rankOne
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D) :
+    ∃ J : ℕ, 0 < J ∧ J ≤ D * D - 1 ∧
+      ∃ ρ Φ : Fin D × Fin D → ℂ,
+        Φ ⬝ᵥ ρ = 1 ∧
+        transferMatrix (MPSTensor.transferMap U.normalizedFlattening) *ᵥ ρ = ρ ∧
+        Matrix.vecMul Φ
+          (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) = Φ ∧
+        transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J =
+          Matrix.vecMulVec ρ Φ ∧
+        ∀ k, J ≤ k →
+          transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ k =
+            transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J := by
+  let data := hU.normalizedTransferStabilization hD
+  refine ⟨data.exponent, data.exponent_pos, data.exponent_le,
+    data.right, data.left, ?_, data.right_fixed, data.left_fixed,
+    data.power_eq, data.stable⟩
+  rw [dotProduct_comm]
+  exact data.pairing_eq_one
+
+/-- On a chosen reduced CPSV canonical-form-II representative, the
+stabilized factorization uses the representative's normalized fixed witnesses
+`ρ` and `Φ` themselves.
+
+**Scope restriction (chosen reduced CFII representative):** The full-active-support
+premise selects the reduced representative intended in arXiv:1703.09188,
+lines 397--405. The formalization does not claim that a bare ambient `IsMPU`
+representative is normal or already in CFII. See
+`docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
+theorem IsMPU.normalizedTransfer_pow_eq_vecMulVec_of_reduced_cpsvCFII
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D)
+    (cfii : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
+    (_hfull : ∑ k : cfii.toCPSVCanonicalFormData.Active,
+      cfii.dim k.1 = D)
+    (ρ Φ : Fin D × Fin D → ℂ)
+    (hpair : Φ ⬝ᵥ ρ = 1)
+    (hright : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) *ᵥ ρ = ρ)
+    (hleft : Matrix.vecMul Φ
+      (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) = Φ) :
+    transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ (D * D - 1) =
+      Matrix.vecMulVec ρ Φ := by
+  exact (hU.normalizedTransferStabilization hD).power_eq_vecMulVec_of_fixed
+    ρ Φ hpair hright hleft
+
+/-- In bond dimension one, the normalized transfer matrix is already the
+identity and stabilizes at exponent one. This separate statement is necessary
+because no positive exponent can satisfy `J ≤ D * D - 1 = 0`.
+
+Source: arXiv:1703.09188, lines 397--409, specialized to `D = 1`. -/
+noncomputable def IsMPU.normalizedTransferStabilization_fin_one
+    [NeZero d] {U : MPOTensor d 1} (hU : IsMPU U) :
+    Matrix.StabilizedRankOneData
+      (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) 1 := by
+  let E := transferMatrix (MPSTensor.transferMap U.normalizedFlattening)
+  have hchar : E.charpoly = X ^ (Fintype.card (Fin 1 × Fin 1) - 1) * (X - 1) := by
+    simpa [E, Fintype.card_prod, Fintype.card_fin] using hU.normalizedFlattening_charpoly
+  have hpow :=
+    Matrix.pow_card_eq_pow_pred_of_charpoly_eq_X_pow_pred_mul_X_sub_one E hchar
+  have hE : E = 1 := by
+    simpa [Fintype.card_prod, Fintype.card_fin] using hpow
+  have hE' : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) = 1 := by
+    simpa [E] using hE
+  apply Matrix.StabilizedRankOneData.of_power_succ_eq 1 1 Nat.zero_lt_one le_rfl
+  · rw [hE']
+    simp
+  · rw [hE']
+    simp
+
+end MPOTensor

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Projection
 import Mathlib.LinearAlgebra.Trace
-import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.MPU.TransferMatrix
 
 /-!
@@ -291,30 +290,6 @@ theorem IsMPU.exists_normalizedTransfer_stabilizes_to_rankOne
     data.power_eq, data.stable⟩
   rw [dotProduct_comm]
   exact data.pairing_eq_one
-
-/-- On a chosen reduced CPSV canonical-form-II representative, the
-stabilized factorization uses the representative's normalized fixed witnesses
-`ρ` and `Φ` themselves.
-
-**Scope restriction (chosen reduced CFII representative):** The full-active-support
-premise selects the reduced representative intended in arXiv:1703.09188,
-lines 397--405. The formalization does not claim that a bare ambient `IsMPU`
-representative is normal or already in CFII. See
-`docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
-theorem IsMPU.normalizedTransfer_pow_eq_vecMulVec_of_reduced_cpsvCFII
-    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D)
-    (cfii : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
-    (_hfull : ∑ k : cfii.toCPSVCanonicalFormData.Active,
-      cfii.dim k.1 = D)
-    (ρ Φ : Fin D × Fin D → ℂ)
-    (hpair : Φ ⬝ᵥ ρ = 1)
-    (hright : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) *ᵥ ρ = ρ)
-    (hleft : Matrix.vecMul Φ
-      (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) = Φ) :
-    transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ (D * D - 1) =
-      Matrix.vecMulVec ρ Φ := by
-  exact (hU.normalizedTransferStabilization hD).power_eq_vecMulVec_of_fixed
-    ρ Φ hpair hright hleft
 
 /-- In bond dimension one, the normalized transfer matrix is already the
 identity and stabilizes at exponent one. This separate statement is necessary

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -3,32 +3,31 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.LinearAlgebra.Projection
-import Mathlib.LinearAlgebra.Trace
+import TNLean.Algebra.MatrixStabilization
 import TNLean.MPS.MPU.TransferMatrix
 
 /-!
-# Jordan elimination for the normalized MPU transfer matrix
+# Stabilization of the normalized MPU transfer matrix
 
 The exact characteristic polynomial of the normalized transfer matrix is
 `X ^ (D * D - 1) * (X - 1)`. Cayley--Hamilton therefore makes its
-`(D * D - 1)`-st and `D * D`-th powers equal. This is the coordinate-free
-replacement for blocking by the largest zero-eigenvalue Jordan block in the
-source. The stabilized power is an idempotent of trace one, hence a rank-one
-projector with normalized left and right fixed witnesses.
+`(D * D - 1)`-st and `D * D`-th powers equal. The stabilized power is an
+idempotent of trace one, hence a rank-one projector with normalized left and
+right fixed witnesses.
 
 ## Main definitions
 
-* `Matrix.StabilizedRankOneData` packages a positive stabilization exponent,
-  its bound, normalized outer-product witnesses, and stabilization of all
-  later powers.
+* `MPOTensor.IsMPU.normalizedTransferStabilization` gives stabilized rank-one
+  data for bond dimension greater than one.
+* `MPOTensor.IsMPU.normalizedTransferStabilization_fin_one` gives the
+  one-dimensional data at exponent one.
 
 ## Main results
 
-* `MPOTensor.IsMPU.normalizedTransferStabilization` eliminates the zero-primary
-  component after the explicit exponent `D * D - 1` when `1 < D`.
-* `MPOTensor.IsMPU.normalizedTransferStabilization_fin_one` treats the
-  one-dimensional bond space separately.
+* `MPOTensor.IsMPU.exists_normalized_transfer_stabilizes_to_rank_one` gives
+  the source-shaped bounded stabilization theorem.
+* `MPOTensor.IsMPU.normalized_transfer_matrix_eq_one_fin_one` proves that the
+  one-dimensional normalized transfer matrix is the identity.
 
 ## References
 
@@ -38,195 +37,6 @@ projector with normalized left and right fixed witnesses.
 
 open scoped Matrix BigOperators
 open Polynomial
-
-namespace Matrix
-
-/-! ### Cayley--Hamilton elimination and rank-one factorization -/
-
-variable {ι : Type*} [Fintype ι]
-
-/-- If the characteristic polynomial is `X^(n-1) * (X-1)`, Cayley--Hamilton
-kills the zero-primary component after exponent `n-1`.
-
-This is the generalized-eigenspace/Jordan-elimination step used at
-arXiv:1703.09188, lines 397--409, expressed without choosing a Jordan basis. -/
-theorem pow_card_eq_pow_pred_of_charpoly_eq_X_pow_pred_mul_X_sub_one
-    [DecidableEq ι] [Nonempty ι] (E : Matrix ι ι ℂ)
-    (hchar : E.charpoly = X ^ (Fintype.card ι - 1) * (X - 1)) :
-    E ^ Fintype.card ι = E ^ (Fintype.card ι - 1) := by
-  have hCH := E.aeval_self_charpoly
-  rw [hchar, map_mul, map_pow, aeval_X, map_sub, aeval_X, map_one] at hCH
-  have hn : Fintype.card ι - 1 + 1 = Fintype.card ι := by
-    have : 0 < Fintype.card ι := Fintype.card_pos
-    omega
-  rw [mul_sub, mul_one, ← pow_succ, hn] at hCH
-  exact sub_eq_zero.mp hCH
-
-/-- A complex idempotent matrix of trace one is an outer product.
-
-The proof identifies the range of the idempotent with a one-dimensional
-subspace and factors its columns through a generator. It is the matrix
-factorization used after zero-primary elimination in arXiv:1703.09188,
-lines 397--409. -/
-theorem exists_eq_vecMulVec_of_mul_self_eq_self_of_trace_eq_one
-    {T : Matrix ι ι ℂ} (hTT : T * T = T) (hTrace : Matrix.trace T = 1) :
-    ∃ a b : ι → ℂ, T = Matrix.vecMulVec a b := by
-  classical
-  let f : (ι → ℂ) →ₗ[ℂ] (ι → ℂ) := Matrix.toLin' T
-  have hf : IsIdempotentElem f := by
-    change Matrix.toLin' T ∘ₗ Matrix.toLin' T = Matrix.toLin' T
-    rw [← Matrix.toLin'_mul, hTT]
-  have hrank : Module.finrank ℂ (LinearMap.range f) = 1 := by
-    have h := (LinearMap.isProj_range_iff_isIdempotentElem f).2 hf |>.trace
-    rw [Matrix.trace_toLin'_eq, hTrace] at h
-    exact_mod_cast h.symm
-  rcases finrank_eq_one_iff'.mp hrank with ⟨u, _hu, hspan⟩
-  let b : ι → ℂ := fun j ↦
-    Classical.choose (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
-  refine ⟨u.1, b, ?_⟩
-  ext i j
-  have hb := Classical.choose_spec
-    (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
-  have hb' := congrArg (fun x : LinearMap.range f ↦ x.1 i) hb
-  have heval : f (Pi.single j 1) i = T i j := by
-    simp [f, Matrix.toLin'_apply]
-  change Classical.choose _ * u.1 i = f (Pi.single j 1) i at hb'
-  rw [heval] at hb'
-  simpa [b, Matrix.vecMulVec_apply, mul_comm] using hb'.symm
-
-/-! ### Reusable stabilized-transfer package -/
-
-/-- Data witnessing that a matrix stabilizes at a bounded positive power to a
-normalized rank-one projector.
-
-Here `right ⬝ᵥ left = 1` is the normalization `(Φ|ρ) = 1`, up to the harmless
-commutation of complex scalars in the coordinate dot product. The equality
-`power_eq` is the source formula `E^J = |ρ)(Φ|`.
-
-Source: arXiv:1703.09188, lines 397--409. -/
-structure StabilizedRankOneData [DecidableEq ι] (E : Matrix ι ι ℂ) (bound : ℕ) where
-  /-- The blocking exponent that eliminates the zero-primary component. -/
-  exponent : ℕ
-  /-- The source blocking exponent is positive. -/
-  exponent_pos : 0 < exponent
-  /-- The exponent lies below the advertised ambient-dimensional bound. -/
-  exponent_le : exponent ≤ bound
-  /-- The normalized right fixed witness `ρ`. -/
-  right : ι → ℂ
-  /-- The normalized left fixed witness `Φ`. -/
-  left : ι → ℂ
-  /-- Normalization of the left/right pairing. -/
-  pairing_eq_one : right ⬝ᵥ left = 1
-  /-- The stabilized power is the outer product `|ρ)(Φ|`. -/
-  power_eq : E ^ exponent = Matrix.vecMulVec right left
-  /-- Every later power equals the stabilized projector. -/
-  stable : ∀ k, exponent ≤ k → E ^ k = E ^ exponent
-
-namespace StabilizedRankOneData
-
-variable [DecidableEq ι] {E : Matrix ι ι ℂ} {bound : ℕ}
-
-/-- The stabilized transfer matrix is idempotent. -/
-theorem projector_idempotent (data : StabilizedRankOneData E bound) :
-    E ^ data.exponent * E ^ data.exponent = E ^ data.exponent := by
-  rw [← pow_add]
-  exact data.stable _ (Nat.le_add_right _ _)
-
-/-- The right witness is fixed by the original transfer matrix. -/
-theorem right_fixed (data : StabilizedRankOneData E bound) :
-    E *ᵥ data.right = data.right := by
-  have hPright : E ^ data.exponent *ᵥ data.right = data.right := by
-    rw [data.power_eq, Matrix.vecMulVec_mulVec, dotProduct_comm,
-      data.pairing_eq_one]
-    simp
-  calc
-    E *ᵥ data.right = E *ᵥ (E ^ data.exponent *ᵥ data.right) := by rw [hPright]
-    _ = (E * E ^ data.exponent) *ᵥ data.right := by rw [Matrix.mulVec_mulVec]
-    _ = E ^ (data.exponent + 1) *ᵥ data.right := by rw [← pow_succ']
-    _ = E ^ data.exponent *ᵥ data.right := by
-      rw [data.stable _ (Nat.le_succ data.exponent)]
-    _ = data.right := hPright
-
-/-- The left witness is fixed by the original transfer matrix. -/
-theorem left_fixed (data : StabilizedRankOneData E bound) :
-    Matrix.vecMul data.left E = data.left := by
-  have hleftP : Matrix.vecMul data.left (E ^ data.exponent) = data.left := by
-    rw [data.power_eq, Matrix.vecMul_vecMulVec, dotProduct_comm,
-      data.pairing_eq_one, one_smul]
-  calc
-    Matrix.vecMul data.left E =
-        Matrix.vecMul (Matrix.vecMul data.left (E ^ data.exponent)) E := by rw [hleftP]
-    _ = Matrix.vecMul data.left (E ^ data.exponent * E) := by
-      rw [Matrix.vecMul_vecMul]
-    _ = Matrix.vecMul data.left (E ^ (data.exponent + 1)) := by rw [pow_succ]
-    _ = Matrix.vecMul data.left (E ^ data.exponent) := by
-      rw [data.stable _ (Nat.le_succ data.exponent)]
-    _ = data.left := hleftP
-
-/-- Any normalized pair of left and right fixed witnesses gives the same
-outer-product factorization of the stabilized projector. -/
-theorem power_eq_vecMulVec_of_fixed (data : StabilizedRankOneData E bound)
-    (right' left' : ι → ℂ) (hpair : left' ⬝ᵥ right' = 1)
-    (hright : E *ᵥ right' = right') (hleft : Matrix.vecMul left' E = left') :
-    E ^ data.exponent = Matrix.vecMulVec right' left' := by
-  have hright_pow : E ^ data.exponent *ᵥ right' = right' := by
-    induction data.exponent with
-    | zero => simp
-    | succ n ih =>
-      rw [pow_succ', ← Matrix.mulVec_mulVec, ih, hright]
-  have hleft_pow : Matrix.vecMul left' (E ^ data.exponent) = left' := by
-    induction data.exponent with
-    | zero => simp
-    | succ n ih =>
-      rw [pow_succ, ← Matrix.vecMul_vecMul, ih, hleft]
-  have hright' : (data.left ⬝ᵥ right') • data.right = right' := by
-    rw [data.power_eq, Matrix.vecMulVec_mulVec] at hright_pow
-    simpa [Algebra.smul_def, dotProduct_comm] using hright_pow
-  have hleft' : (left' ⬝ᵥ data.right) • data.left = left' := by
-    rw [data.power_eq, Matrix.vecMul_vecMulVec] at hleft_pow
-    exact hleft_pow
-  rw [data.power_eq]
-  rw [← hright', ← hleft'] at hpair ⊢
-  have hscalar :
-      (data.left ⬝ᵥ right') * (left' ⬝ᵥ data.right) = 1 := by
-    simpa [dotProduct_comm, mul_comm, mul_left_comm, mul_assoc,
-      data.pairing_eq_one] using hpair
-  ext i j
-  simp only [Matrix.vecMulVec_apply, Pi.smul_apply, smul_eq_mul]
-  calc
-    data.right i * data.left j =
-        ((data.left ⬝ᵥ right') * (left' ⬝ᵥ data.right)) *
-          (data.right i * data.left j) := by rw [hscalar, one_mul]
-    _ = (data.left ⬝ᵥ right') * data.right i *
-          ((left' ⬝ᵥ data.right) * data.left j) := by ring
-
-/-- Construct stabilized rank-one data from one equality of consecutive powers
-and the trace-one normalization at that power. -/
-noncomputable def of_power_succ_eq [Nonempty ι]
-    (J bound : ℕ) (hJpos : 0 < J) (hJle : J ≤ bound)
-    (hstep : E ^ (J + 1) = E ^ J) (htrace : Matrix.trace (E ^ J) = 1) :
-    StabilizedRankOneData E bound := by
-  have hstable : ∀ k, J ≤ k → E ^ k = E ^ J := by
-    intro k hk
-    obtain ⟨t, rfl⟩ := Nat.exists_eq_add_of_le hk
-    induction t with
-    | zero => rfl
-    | succ t iht =>
-      rw [Nat.add_succ, pow_succ, iht (Nat.le_add_right _ _), ← pow_succ, hstep]
-  have hidem : E ^ J * E ^ J = E ^ J := by
-    rw [← pow_add]
-    exact hstable _ (Nat.le_add_right _ _)
-  let hex := Matrix.exists_eq_vecMulVec_of_mul_self_eq_self_of_trace_eq_one hidem htrace
-  let right := Classical.choose hex
-  let left := Classical.choose (Classical.choose_spec hex)
-  have hfac : E ^ J = Matrix.vecMulVec right left :=
-    Classical.choose_spec (Classical.choose_spec hex)
-  refine ⟨J, hJpos, hJle, right, left, ?_, hfac, hstable⟩
-  rw [← Matrix.trace_vecMulVec, ← hfac]
-  exact htrace
-
-end StabilizedRankOneData
-end Matrix
 
 namespace MPOTensor
 
@@ -249,8 +59,8 @@ noncomputable def IsMPU.normalizedTransferStabilization
     Matrix.StabilizedRankOneData
       (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) (D * D - 1) := by
   let E := transferMatrix (MPSTensor.transferMap U.normalizedFlattening)
-  have hD2 : 2 ≤ D := by omega
-  have hDD : 4 ≤ D * D := Nat.mul_le_mul hD2 hD2
+  have hDD : 4 ≤ D * D :=
+    Nat.mul_le_mul (by omega : 2 ≤ D) (by omega : 2 ≤ D)
   have hchar : E.charpoly = X ^ (Fintype.card (Fin D × Fin D) - 1) * (X - 1) := by
     simpa [E, Fintype.card_prod, Fintype.card_fin] using hU.normalizedFlattening_charpoly
   have hpow :=
@@ -271,7 +81,7 @@ The proof removes the zero-primary component by Cayley--Hamilton; it does not
 infer ambient normality from bare `IsMPU`.
 
 Source: arXiv:1703.09188, lines 397--409. -/
-theorem IsMPU.exists_normalizedTransfer_stabilizes_to_rankOne
+theorem IsMPU.exists_normalized_transfer_stabilizes_to_rank_one
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D) :
     ∃ J : ℕ, 0 < J ∧ J ≤ D * D - 1 ∧
       ∃ ρ Φ : Fin D × Fin D → ℂ,
@@ -291,15 +101,12 @@ theorem IsMPU.exists_normalizedTransfer_stabilizes_to_rankOne
   rw [dotProduct_comm]
   exact data.pairing_eq_one
 
-/-- In bond dimension one, the normalized transfer matrix is already the
-identity and stabilizes at exponent one. This separate statement is necessary
-because no positive exponent can satisfy `J ≤ D * D - 1 = 0`.
+/-- In bond dimension one, the normalized transfer matrix of an MPU is the identity.
 
 Source: arXiv:1703.09188, lines 397--409, specialized to `D = 1`. -/
-noncomputable def IsMPU.normalizedTransferStabilization_fin_one
+theorem IsMPU.normalized_transfer_matrix_eq_one_fin_one
     [NeZero d] {U : MPOTensor d 1} (hU : IsMPU U) :
-    Matrix.StabilizedRankOneData
-      (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) 1 := by
+    transferMatrix (MPSTensor.transferMap U.normalizedFlattening) = 1 := by
   let E := transferMatrix (MPSTensor.transferMap U.normalizedFlattening)
   have hchar : E.charpoly = X ^ (Fintype.card (Fin 1 × Fin 1) - 1) * (X - 1) := by
     simpa [E, Fintype.card_prod, Fintype.card_fin] using hU.normalizedFlattening_charpoly
@@ -307,12 +114,22 @@ noncomputable def IsMPU.normalizedTransferStabilization_fin_one
     Matrix.pow_card_eq_pow_pred_of_charpoly_eq_X_pow_pred_mul_X_sub_one E hchar
   have hE : E = 1 := by
     simpa [Fintype.card_prod, Fintype.card_fin] using hpow
-  have hE' : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) = 1 := by
-    simpa [E] using hE
+  simpa [E] using hE
+
+/-- In bond dimension one, the normalized transfer matrix stabilizes at exponent one.
+This separate definition is necessary because no positive exponent can satisfy
+`J ≤ D * D - 1 = 0`.
+
+Source: arXiv:1703.09188, lines 397--409, specialized to `D = 1`. -/
+noncomputable def IsMPU.normalizedTransferStabilization_fin_one
+    [NeZero d] {U : MPOTensor d 1} (hU : IsMPU U) :
+    Matrix.StabilizedRankOneData
+      (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) 1 := by
+  have hE := hU.normalized_transfer_matrix_eq_one_fin_one
   apply Matrix.StabilizedRankOneData.of_power_succ_eq 1 1 Nat.zero_lt_one le_rfl
-  · rw [hE']
+  · rw [hE]
     simp
-  · rw [hE']
+  · rw [hE]
     simp
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1003,7 +1003,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_normalized_transfer_nonzero_spectrum}
+    \uses{thm:mpu_normalized_transfer_nonzero_spectrum,
+        thm:mpu_normalized_transfer_trace}
     The exact characteristic polynomial is
     \begin{align}
         \chi_E(X)&=X^{D^2-1}(X-1).
@@ -1037,8 +1038,6 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{lemma}[Identification with chosen reduced-CFII fixed points]
     \label{lem:mpu_reduced_cfii_transfer_stabilization}
-    \uses{thm:mpu_normalized_transfer_stabilization,
-        thm:mpu_stabilized_fixed_pair_uniqueness}
     Suppose the normalized flattening is presented by a chosen canonical-form-II
     representative whose active blocks fill the bond space. Let $\rho$ and
     $\Phi$ be the diagonal positive right fixed point and the identity left
@@ -1052,6 +1051,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}
+    \uses{thm:mpu_normalized_transfer_stabilization,
+        thm:mpu_stabilized_fixed_pair_uniqueness}
     The finite-blocking theorem shows that every normalized left and right fixed
     pair factors the stabilized projector. It remains to transport the
     blockwise canonical-form-II fixed points through the full-support ambient

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -971,7 +971,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Finite blocking eliminates the zero-primary transfer component]
     \label{thm:mpu_normalized_transfer_stabilization}
-    \lean{MPOTensor.IsMPU.exists_normalizedTransfer_stabilizes_to_rankOne}
+    \lean{MPOTensor.IsMPU.exists_normalized_transfer_stabilizes_to_rank_one}
     \leanok
     \uses{def:mpu,def:mpu_normalized_flattening,def:transfer_map,
         def:mpu_transfer_matrix,thm:mpu_normalized_transfer_nonzero_spectrum}
@@ -989,16 +989,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     such that
     \begin{align}
-        E^J&=\lvert\rho)(\Phi\rvert,
-        &E^k&=E^J\qquad(k\geq J).
+        E^J&=\lvert\rho)(\Phi\rvert.
+    \end{align}
+    Moreover, for every integer $k\geq J$,
+    \begin{align}
+        E^k&=E^J.
     \end{align}
     Thus blocking $J$ sites removes the entire generalized zero-eigenspace.
-    For $D=1$, the transfer matrix is already the identity and stabilization
-    holds at exponent one; the positive bound above is impossible because
-    $D^2-1=0$.
+    The one-dimensional case is stated separately below.
 
-    This is the Jordan-elimination step of
-    \cite[Section~III, lines~397--409]{Cirac2017MPU}.
+    This is the Jordan-elimination step in
+    \cite[proof of Proposition~III.2(ii)]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1016,9 +1017,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $EP=PE=P$.
 \end{proof}
 
-\begin{lemma}[Uniqueness of the normalized fixed-pair factorization]
-    \label{lem:mpu_stabilized_fixed_pair_uniqueness}
-    \lean{Matrix.StabilizedRankOneData.power_eq_vecMulVec_of_fixed}
+\begin{theorem}[Uniqueness of the normalized fixed-pair factorization]
+    \label{thm:mpu_stabilized_fixed_pair_uniqueness}
+    \lean{Matrix.StabilizedRankOneData.power_eq_vec_mul_vec_of_fixed}
     \leanok
     Let $P=E^J$ be a stabilized rank-one transfer power with normalized left
     and right factors. If $\rho'$ and $\Phi'$ are any other fixed vectors with
@@ -1026,7 +1027,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \begin{align}
         P=\lvert\rho')(\Phi'\rvert.
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Applying $P$ to $\rho'$ and applying $\Phi'$ to $P$ shows that the two
@@ -1037,7 +1038,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{lemma}[Identification with chosen reduced-CFII fixed points]
     \label{lem:mpu_reduced_cfii_transfer_stabilization}
     \uses{thm:mpu_normalized_transfer_stabilization,
-        lem:mpu_stabilized_fixed_pair_uniqueness}
+        thm:mpu_stabilized_fixed_pair_uniqueness}
     Suppose the normalized flattening is presented by a chosen canonical-form-II
     representative whose active blocks fill the bond space. Let $\rho$ and
     $\Phi$ be the diagonal positive right fixed point and the identity left
@@ -1058,16 +1059,20 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     % Formalization of this remaining step is tracked in GitHub issue #5786.
 \end{proof}
 
-\begin{lemma}[One-dimensional transfer stabilization]
-    \label{lem:mpu_transfer_stabilization_fin_one}
-    \lean{MPOTensor.IsMPU.normalizedTransferStabilization_fin_one}
+\begin{theorem}[One-dimensional normalized transfer matrix]
+    \label{thm:mpu_normalized_transfer_fin_one}
+    \lean{MPOTensor.IsMPU.normalized_transfer_matrix_eq_one_fin_one}
     \leanok
     \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_transfer_matrix}
-    If the bond dimension is $D=1$, then $E=1$ and the normalized transfer
-    matrix stabilizes at the positive exponent one.
-\end{lemma}
+    If the bond dimension is $D=1$, then the normalized transfer matrix satisfies
+    \begin{align}
+        E&=1.
+    \end{align}
+    Consequently its powers stabilize at the positive exponent one.
+\end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_normalized_transfer_nonzero_spectrum}
     In dimension one the characteristic polynomial identity reduces to
     $\chi_E(X)=X-1$, and Cayley--Hamilton gives $E=1$.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -975,8 +975,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \leanok
     \uses{def:mpu,def:mpu_normalized_flattening,def:transfer_map,
         def:mpu_transfer_matrix,thm:mpu_normalized_transfer_nonzero_spectrum}
-    Let $U$ be an MPU tensor of bond dimension $D>1$, and let $E$ be the
-    transfer matrix of its normalized flattening. There is an integer
+    Let $U$ be an MPU tensor with physical dimension $d>0$ and bond
+    dimension $D>1$, and let $E$ be the transfer matrix of its normalized
+    flattening. There is an integer
     $J$ satisfying
     \begin{align}
         0<J\leq D^2-1
@@ -1065,7 +1066,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.IsMPU.normalized_transfer_matrix_eq_one_fin_one}
     \leanok
     \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_transfer_matrix}
-    If the bond dimension is $D=1$, then the normalized transfer matrix satisfies
+    If the physical dimension satisfies $d>0$ and the bond dimension is $D=1$,
+    then the normalized transfer matrix satisfies
     \begin{align}
         E&=1.
     \end{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -969,6 +969,89 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
 \end{proof}
 
+\begin{theorem}[Finite blocking eliminates the zero-primary transfer component]
+    \label{thm:mpu_normalized_transfer_stabilization}
+    \lean{MPOTensor.IsMPU.exists_normalizedTransfer_stabilizes_to_rankOne}
+    \leanok
+    \uses{def:mpu,def:mpu_normalized_flattening,def:transfer_map,
+        def:mpu_transfer_matrix,thm:mpu_normalized_transfer_nonzero_spectrum}
+    Let $U$ be an MPU tensor of bond dimension $D>1$, and let $E$ be the
+    transfer matrix of its normalized flattening. There is an integer
+    $J$ satisfying
+    \begin{align}
+        0<J\leq D^2-1
+    \end{align}
+    and vectors $\rho,\Phi$ satisfying
+    \begin{align}
+        (\Phi\mid\rho)&=1,
+        &E\rho&=\rho,
+        &(\Phi\mid E&=(\Phi\mid,
+    \end{align}
+    such that
+    \begin{align}
+        E^J&=\lvert\rho)(\Phi\rvert,
+        &E^k&=E^J\qquad(k\geq J).
+    \end{align}
+    Thus blocking $J$ sites removes the entire generalized zero-eigenspace.
+    For $D=1$, the transfer matrix is already the identity and stabilization
+    holds at exponent one; the positive bound above is impossible because
+    $D^2-1=0$.
+
+    This is the Jordan-elimination step of
+    \cite[Section~III, lines~397--409]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_normalized_transfer_nonzero_spectrum}
+    The exact characteristic polynomial is
+    \begin{align}
+        \chi_E(X)&=X^{D^2-1}(X-1).
+    \end{align}
+    Cayley--Hamilton gives $E^{D^2}=E^{D^2-1}$. Hence every power from
+    $J=D^2-1$ onward is equal, and $P=E^J$ is idempotent. Since $J>1$, the
+    normalized transfer trace identity gives $\tr(P)=1$. The range of an
+    idempotent has dimension equal to its trace, so $P$ has rank one and
+    factors as $P=\lvert\rho)(\Phi\rvert$. Taking the factors with
+    $(\Phi\mid\rho)=1$ gives the displayed fixed-point identities from
+    $EP=PE=P$.
+\end{proof}
+
+\begin{lemma}[Identification with chosen reduced-CFII fixed points]
+    \label{lem:mpu_reduced_cfii_transfer_stabilization}
+    \lean{MPOTensor.IsMPU.normalizedTransfer_pow_eq_vecMulVec_of_reduced_cpsvCFII}
+    \leanok
+    \uses{thm:mpu_normalized_transfer_stabilization}
+    Suppose the normalized flattening is presented by a chosen canonical-form-II
+    representative whose active blocks fill the bond space. If $\rho$ and $\Phi$
+    are its normalized right and left fixed vectors, then
+    \begin{align}
+        E^{D^2-1}=\lvert\rho)(\Phi\rvert.
+    \end{align}
+    This is a statement about the chosen reduced representative; it does not
+    assert that every ambient MPU tensor is itself in canonical form II.
+\end{lemma}
+
+\begin{proof}\leanok
+    The finite-blocking theorem gives a normalized rank-one stabilized
+    projector. Any other normalized left and right fixed pair factors the same
+    projector: applying the projector to $\rho$ and applying $\Phi$ on the left
+    identifies the two factors up to reciprocal scalars.
+\end{proof}
+
+\begin{lemma}[One-dimensional transfer stabilization]
+    \label{lem:mpu_transfer_stabilization_fin_one}
+    \lean{MPOTensor.IsMPU.normalizedTransferStabilization_fin_one}
+    \leanok
+    \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_transfer_matrix}
+    If the bond dimension is $D=1$, then $E=1$ and the normalized transfer
+    matrix stabilizes at the positive exponent one.
+\end{lemma}
+
+\begin{proof}\leanok
+    In dimension one the characteristic polynomial identity reduces to
+    $\chi_E(X)=X-1$, and Cayley--Hamilton gives $E=1$.
+\end{proof}
+
 \begin{theorem}[Normality of a full-support normalized MPU representative]
     \label{thm:mpu_normalized_full_support_normal}
     \lean{MPOTensor.IsMPU.isNormalTensor_normalizedFlattening_of_cpsv}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1016,14 +1016,33 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $EP=PE=P$.
 \end{proof}
 
+\begin{lemma}[Uniqueness of the normalized fixed-pair factorization]
+    \label{lem:mpu_stabilized_fixed_pair_uniqueness}
+    \lean{Matrix.StabilizedRankOneData.power_eq_vecMulVec_of_fixed}
+    \leanok
+    Let $P=E^J$ be a stabilized rank-one transfer power with normalized left
+    and right factors. If $\rho'$ and $\Phi'$ are any other fixed vectors with
+    $(\Phi'\mid\rho')=1$, then
+    \begin{align}
+        P=\lvert\rho')(\Phi'\rvert.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Applying $P$ to $\rho'$ and applying $\Phi'$ to $P$ shows that the two
+    pairs of rank-one factors differ by reciprocal scalars. Their normalized
+    pairings force the product of those scalars to be one.
+\end{proof}
+
 \begin{lemma}[Identification with chosen reduced-CFII fixed points]
     \label{lem:mpu_reduced_cfii_transfer_stabilization}
-    \lean{MPOTensor.IsMPU.normalizedTransfer_pow_eq_vecMulVec_of_reduced_cpsvCFII}
-    \leanok
-    \uses{thm:mpu_normalized_transfer_stabilization}
+    \uses{thm:mpu_normalized_transfer_stabilization,
+        lem:mpu_stabilized_fixed_pair_uniqueness}
     Suppose the normalized flattening is presented by a chosen canonical-form-II
-    representative whose active blocks fill the bond space. If $\rho$ and $\Phi$
-    are its normalized right and left fixed vectors, then
+    representative whose active blocks fill the bond space. Let $\rho$ and
+    $\Phi$ be the diagonal positive right fixed point and the identity left
+    fixed point supplied by that representative, normalized by
+    $(\Phi\mid\rho)=1$. Then
     \begin{align}
         E^{D^2-1}=\lvert\rho)(\Phi\rvert.
     \end{align}
@@ -1031,11 +1050,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     assert that every ambient MPU tensor is itself in canonical form II.
 \end{lemma}
 
-\begin{proof}\leanok
-    The finite-blocking theorem gives a normalized rank-one stabilized
-    projector. Any other normalized left and right fixed pair factors the same
-    projector: applying the projector to $\rho$ and applying $\Phi$ on the left
-    identifies the two factors up to reciprocal scalars.
+\begin{proof}
+    The finite-blocking theorem shows that every normalized left and right fixed
+    pair factors the stabilized projector. It remains to transport the
+    blockwise canonical-form-II fixed points through the full-support ambient
+    reconstruction and prove the displayed pairing and fixed equations.
+    % Formalization of this remaining step is tracked in GitHub issue #5786.
 \end{proof}
 
 \begin{lemma}[One-dimensional transfer stabilization]


### PR DESCRIPTION
## Summary

- derive bounded zero-primary elimination from the exact shifted-moment characteristic polynomial using Cayley--Hamilton
- record stabilized rank-one matrix powers in the generic algebra layer, reusing a real-or-complex generalization of the existing idempotent rank-one factorization
- specialize the algebraic structure to normalized MPU transfer matrices and prove the source-shaped exponent bound
- prove uniqueness for any normalized fixed pair and handle bond dimension `D = 1` with a direct theorem that the normalized transfer matrix equals the identity
- synchronize Chapter 28 while leaving reduced-CFII ambient witness transport explicitly unproved and tracked in #5786

Source: `Papers/1703.09188/paper_v2.tex`, proof of Proposition III.2(ii), local source lines 397--409.

This PR does not claim bare `IsMPU` implies ambient normality or CFII membership.

Closes #5778.

## Checks

- focused builds of `TNLean.Algebra.PerronFrobenius.RankOne`, `TNLean.Algebra.PerronFrobenius.Idempotent`, `TNLean.Algebra.MatrixStabilization`, `TNLean.MPS.MPDO.SimpleLocalStructure`, `TNLean.MPS.MPU.TransferStabilization`, and `TNLean.MPS.MPU`
- direct Lean checks of all changed modules and the MPU aggregate
- exact public-statement inspection with `#check`
- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch28_mpu.tex`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci --changed-files TNLean/Algebra/MatrixStabilization.lean TNLean/MPS/MPU/TransferStabilization.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check origin/main`
- proof-bypass and stale-name scans: clean

The declaration synchronization check passed with all 72 formalized Chapter 28 entries resolved. The unproved reduced-CFII identification has no `\\lean` or `\\leanok` tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formalize a core MPU blocking argument on transfer-matrix powers, but they build on existing trace and characteristic-polynomial results and do not extend bare `IsMPU` to ambient normality.
> 
> **Overview**
> Adds a **generic algebra layer** for matrices whose characteristic polynomial is `X^(n-1)(X-1)`: Cayley–Hamilton yields `E^n = E^(n-1)`, and consecutive equal powers with trace one produce **`StabilizedRankOneData`** (bounded exponent, normalized `|ρ)(Φ|`, stability of all later powers). **`HasRankOneFactorization`** and the idempotent trace-one factorization theorem are generalized from real matrices to **`RCLike`** scalars so complex transfer matrices can reuse the same rank-one step.
> 
> **MPU specialization** (`TransferStabilization`): for `IsMPU` with `D > 1`, the normalized flattening transfer matrix stabilizes at **`J = D² - 1`** as a rank-one projector with normalized fixed witnesses; **`D = 1`** is handled separately (**`E = 1`**, stabilization at exponent one). A lemma shows any other normalized fixed pair gives the same outer product.
> 
> Chapter 28 blueprint is synced with lean tags; identification with reduced canonical-form-II fixed points remains **explicitly unproved** (tracked in #5786).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391d4aa731f900fbc870828615febc937334e22a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->