### PR TITLE
feat(MPS/MPU): formalize simple contraction identities

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -185,6 +185,7 @@ import TNLean.MPS.MPDO.OrthogonalSectorAreaLaw
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.PeriodicExclusion
+import TNLean.MPS.MPDO.PhysicalAdjoint
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
 import TNLean.MPS.MPDO.PhysicalSectorActiveBond

--- a/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
+++ b/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.PosSemidefSupport
 import TNLean.MPS.FundamentalTheorem.Basic
-import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.MPDO.PhysicalAdjoint
 import TNLean.MPS.MPDO.StackedLayers
 
 /-!
@@ -34,63 +34,7 @@ namespace MPOTensor
 
 variable {d g : ℕ} {bondDim : Fin g → ℕ}
 
-/-! ### Physical adjoint -/
-
-/-- The physical adjoint of an MPO tensor swaps its ket and bra indices and conjugates each
-virtual matrix entry, without transposing the virtual indices:
-$$(K^\sharp)^{ij}_{\beta\alpha} = \overline{K^{ji}_{\beta\alpha}}.$$
-
-This local adjoint relates layer annihilation to the two-sided support condition in equation
-`PjKiPj`; unlike `adjointTensor`, it does not reverse virtual multiplication.
-
-Source: arXiv:1606.00608, Appendix C.2, equations `AppKxKy=0`--`PjKiPj`,
-lines 1634--1689. -/
-def physicalAdjointTensor (K : MPOTensor d D) : MPOTensor d D :=
-  fun i j β α ↦ star (K j i β α)
-
-/-- Evaluating the physical adjoint swaps the physical indices and conjugates the entry. -/
-@[simp] theorem physicalAdjointTensor_apply (K : MPOTensor d D)
-    (i j : Fin d) (β α : Fin D) :
-    physicalAdjointTensor K i j β α = star (K j i β α) := rfl
-
-/-- Physical slices of the physical adjoint are the conjugate transposes of the original
-physical slices.  Only physical indices are transposed.
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1634--1689. -/
-theorem physicalSlice_physicalAdjointTensor (K : MPOTensor d D) (β α : Fin D) :
-    physicalSlice (physicalAdjointTensor K) β α = (physicalSlice K β α)ᴴ := by
-  ext i j
-  rfl
-
-/-- Closed words of the physical adjoint are entrywise conjugates of the words with ket and
-bra configurations exchanged. -/
-theorem evalWord_physicalAdjointTensor (K : MPOTensor d D)
-    (is js : List (Fin d)) (hlen : is.length = js.length) :
-    evalWord (physicalAdjointTensor K) is js =
-      (evalWord K js is).map (starRingEnd ℂ) := by
-  induction is generalizing js with
-  | nil =>
-      simp only [List.length_nil, eq_comm, List.length_eq_zero_iff] at hlen
-      subst js
-      exact (starRingEnd ℂ).mapMatrix.map_one.symm
-  | cons i is ih =>
-      cases js with
-      | nil => simp at hlen
-      | cons j js =>
-          simp only [List.length_cons, Nat.succ.injEq] at hlen
-          simp only [evalWord_cons, ih js hlen]
-          exact ((starRingEnd ℂ).mapMatrix.map_mul (K j i) (evalWord K js is)).symm
-
-/-- The physical adjoint generates the conjugate-transposed periodic operator family without
-spatial reflection.
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1634--1689. -/
-theorem mpo_physicalAdjointTensor (K : MPOTensor d D) (N : ℕ)
-    (σ τ : Fin N → Fin d) :
-    mpo (physicalAdjointTensor K) N σ τ = star (mpo K N τ σ) := by
-  rw [mpo_apply, mpoMatrixEntry, evalWord_physicalAdjointTensor K _ _ (by simp),
-    ← AddMonoidHom.map_trace (starRingEnd ℂ)]
-  rfl
+/-! ### Physical-adjoint consequences for MPDO tensors -/
 
 /-- Positivity of every nonempty periodic operator makes an MPO tensor and its physical adjoint
 produce the same positive-length MPV family.  The positive-length convention is the weakest

--- a/TNLean/MPS/MPDO/PhysicalAdjoint.lean
+++ b/TNLean/MPS/MPDO/PhysicalAdjoint.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.Defs
+
+/-!
+# Physical adjoint of an MPO tensor
+
+This file defines the physical adjoint, which exchanges and conjugates the
+physical indices of an MPO tensor without reversing its virtual chain, and
+proves the corresponding word and periodic-operator identities.
+
+## Main definition
+
+* `MPOTensor.physicalAdjointTensor` — physical adjoint without virtual reflection.
+
+## Main results
+
+* `MPOTensor.evalWord_physicalAdjointTensor` — word evaluation under physical adjoint.
+* `MPOTensor.mpo_physicalAdjointTensor` — the periodic family is conjugate-transposed.
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The physical adjoint of an MPO tensor swaps its ket and bra indices and conjugates each
+virtual matrix entry, without transposing the virtual indices:
+$$(K^\sharp)^{ij}_{\beta\alpha} = \overline{K^{ji}_{\beta\alpha}}.$$
+
+This local adjoint relates layer annihilation to the two-sided support condition in equation
+`PjKiPj`; unlike `adjointTensor`, it does not reverse virtual multiplication.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppKxKy=0`--`PjKiPj`,
+lines 1634--1689. -/
+def physicalAdjointTensor (K : MPOTensor d D) : MPOTensor d D :=
+  fun i j β α ↦ star (K j i β α)
+
+/-- Evaluating the physical adjoint swaps the physical indices and conjugates the entry. -/
+@[simp] theorem physicalAdjointTensor_apply (K : MPOTensor d D)
+    (i j : Fin d) (β α : Fin D) :
+    physicalAdjointTensor K i j β α = star (K j i β α) := rfl
+
+/-- Physical slices of the physical adjoint are the conjugate transposes of the original
+physical slices.  Only physical indices are transposed.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1634--1689. -/
+theorem physicalSlice_physicalAdjointTensor (K : MPOTensor d D) (β α : Fin D) :
+    physicalSlice (physicalAdjointTensor K) β α = (physicalSlice K β α)ᴴ := by
+  ext i j
+  rfl
+
+/-- Closed words of the physical adjoint are entrywise conjugates of the words with ket and
+bra configurations exchanged. -/
+theorem evalWord_physicalAdjointTensor (K : MPOTensor d D)
+    (is js : List (Fin d)) (hlen : is.length = js.length) :
+    evalWord (physicalAdjointTensor K) is js =
+      (evalWord K js is).map (starRingEnd ℂ) := by
+  induction is generalizing js with
+  | nil =>
+      simp only [List.length_nil, eq_comm, List.length_eq_zero_iff] at hlen
+      subst js
+      exact (starRingEnd ℂ).mapMatrix.map_one.symm
+  | cons i is ih =>
+      cases js with
+      | nil => simp at hlen
+      | cons j js =>
+          simp only [List.length_cons, Nat.succ.injEq] at hlen
+          simp only [evalWord_cons, ih js hlen]
+          exact ((starRingEnd ℂ).mapMatrix.map_mul (K j i) (evalWord K js is)).symm
+
+/-- The physical adjoint generates the conjugate-transposed periodic operator family without
+spatial reflection.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1634--1689. -/
+theorem mpo_physicalAdjointTensor (K : MPOTensor d D) (N : ℕ)
+    (σ τ : Fin N → Fin d) :
+    mpo (physicalAdjointTensor K) N σ τ = star (mpo K N τ σ) := by
+  rw [mpo_apply, mpoMatrixEntry, evalWord_physicalAdjointTensor K _ _ (by simp),
+    ← AddMonoidHom.map_trace (starRingEnd ℂ)]
+  rfl
+
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/PhysicalAdjoint.lean
+++ b/TNLean/MPS/MPDO/PhysicalAdjoint.lean
@@ -84,5 +84,4 @@ theorem mpo_physicalAdjointTensor (K : MPOTensor d D) (N : ℕ)
     ← AddMonoidHom.map_trace (starRingEnd ℂ)]
   rfl
 
-
 end MPOTensor

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -11,5 +11,6 @@ Authors: TNLean contributors
 import TNLean.MPS.MPU.ActiveTransferMultiplicity
 import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPU.CanonicalForm
+import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.TransferMatrix

--- a/TNLean/MPS/MPU/Simple.lean
+++ b/TNLean/MPS/MPU/Simple.lean
@@ -190,13 +190,11 @@ double-layer letters.
 Source: arXiv:1703.09188, equation `simple2`, lines 363--374 and Figure
 `II_Simple2.png`. -/
 theorem simple2 {U : MPOTensor d D} (hU : IsMPUSimple U) :
-    ∃ a b : Fin (D * D) → ℂ,
-      (∀ i j : Fin d,
-        a ⬝ᵥ (doubleLayerTensor U i j *ᵥ b) = if i = j then 1 else 0) ∧
-      (∀ i j k l : Fin d,
-        doubleLayerTensor U i j * doubleLayerTensor U k l =
-          doubleLayerTensor U i j * vecMulVec b a * doubleLayerTensor U k l) :=
-  hU
+    ∃ a b : Fin (D * D) → ℂ, ∀ i j k l : Fin d,
+      doubleLayerTensor U i j * doubleLayerTensor U k l =
+        doubleLayerTensor U i j * vecMulVec b a * doubleLayerTensor U k l := by
+  obtain ⟨a, b, _, h₂⟩ := hU
+  exact ⟨a, b, h₂⟩
 
 /-- Sequentially applying `simple2` around a closed double-layer chain and
 then `simple1` at every site gives the physical identity.

--- a/TNLean/MPS/MPU/Simple.lean
+++ b/TNLean/MPS/MPU/Simple.lean
@@ -1,0 +1,252 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalAdjoint
+import TNLean.MPS.MPDO.OperatorProduct
+import TNLean.MPS.MPU.Basic
+
+/-!
+# Simple matrix product unitary tensors
+
+This file formalizes the double layer and the two exact local contraction identities
+`simple1` and `simple2` from arXiv:1703.09188, Section III.A.  It then follows the
+paper's sequential contraction proof that every simple tensor generates a matrix
+product unitary.
+
+The upper tensor in the paper's diagrams is the physical adjoint: its physical
+indices are exchanged and its entries are conjugated, while the virtual chain is
+not reflected.  Accordingly the double layer uses `physicalAdjointTensor`, not
+`adjointTensor`.
+
+## Main definitions
+
+* `doubleLayerTensor` — the local tensor for \(U^\dagger U\).
+* `IsMPUSimple` — the paper's `simple1` and `simple2` identities.
+
+## Main results
+
+* `IsMPUSimple.isMPU` — a simple tensor generates MPU.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, "Matrix Product Unitaries:
+  Structure, Symmetries, and Topological Invariants", arXiv:1703.09188,
+  Section III.A, lines 359--388 and Figures `II_Simple1.png`, `II_Simple2.png`.
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The local **double layer** obtained by placing the physical adjoint of `U`
+above `U` and contracting their adjacent physical legs.  Its bond index is the
+canonical enumeration of a pair of original bond indices.
+
+Closing a chain of these letters gives `mpo U N` conjugate-transposed times
+`mpo U N`; see `mpo_doubleLayerTensor`.
+
+Source: arXiv:1703.09188, Section III.A, lines 363--388 and Figures
+`II_Simple1.png`, `II_Simple2.png`. -/
+noncomputable def doubleLayerTensor (U : MPOTensor d D) : MPOTensor d (D * D) :=
+  mulTensor (physicalAdjointTensor U) U
+
+/-- The exact local, canonically reindexed form of the double-layer letter:
+\((W^{ik})_{(β₁,β₂),(α₁,α₂)}\) is obtained from
+\(\sum_j (U^\sharp)^{ij} \otimes U^{jk}\) using `finProdFinEquiv` on both
+bond indices.
+
+Source: arXiv:1703.09188, Definition III.2, lines 363--374 and Figures
+`II_Simple1.png`, `II_Simple2.png`. -/
+@[simp] theorem doubleLayerTensor_apply (U : MPOTensor d D) (i k : Fin d) :
+    doubleLayerTensor U i k =
+      (∑ j : Fin d, (physicalAdjointTensor U i j) ⊗ₖ (U j k)).submatrix
+        finProdFinEquiv.symm finProdFinEquiv.symm := by
+  rw [doubleLayerTensor, mulTensor_apply]
+
+/-- Closing the double layer gives the global product \((U^{(N)})^\dagger U^{(N)}\).
+
+This fixes the diagram orientation: the upper layer is the physical adjoint,
+which generates the conjugate transpose without reflecting the virtual chain.
+
+Source: arXiv:1703.09188, lines 363--388, especially the product contracted in
+the proof of Proposition III.3(i). -/
+theorem mpo_doubleLayerTensor (U : MPOTensor d D) (N : ℕ) :
+    mpo (doubleLayerTensor U) N = (mpo U N)ᴴ * mpo U N := by
+  rw [doubleLayerTensor, mpo_mulTensor]
+  congr 1
+  ext σ τ
+  rw [mpo_physicalAdjointTensor]
+  rfl
+
+/-- An MPU tensor is **simple** when its double-layer letters have boundary
+vectors `a` and `b` satisfying the two diagrammatic identities `simple1` and
+`simple2`.
+
+Writing \(W^{ij}\) for a double-layer letter and
+\(R=|b)(a|\), the fields are exactly
+\[
+  (a|W^{ij}|b)=\delta_{ij}, \qquad
+  W^{ij}W^{k\ell}=W^{ij}R W^{k\ell}.
+\]
+Thus `simple1` closes one letter with the witnesses to the physical identity,
+while `simple2` inserts the rank-one operator \(|b)(a|\) between two adjacent
+letters.  This notion is unrelated to the CPSV16 predicate `MPOTensor.IsSimple`.
+
+Source: arXiv:1703.09188, Definition III.2, equations `simple1` and `simple2`,
+lines 363--374 and Figures `II_Simple1.png`, `II_Simple2.png`. -/
+def IsMPUSimple (U : MPOTensor d D) : Prop :=
+  ∃ a b : Fin (D * D) → ℂ,
+    (∀ i j : Fin d,
+      a ⬝ᵥ (doubleLayerTensor U i j *ᵥ b) = if i = j then 1 else 0) ∧
+    (∀ i j k l : Fin d,
+      doubleLayerTensor U i j * doubleLayerTensor U k l =
+        doubleLayerTensor U i j * vecMulVec b a * doubleLayerTensor U k l)
+
+namespace IsMPUSimple
+
+private theorem sandwich_mul_rankOne_mul {n : Type*} [Fintype n]
+    (a b : n → ℂ) (A X : Matrix n n ℂ) :
+    a ⬝ᵥ ((A * vecMulVec b a * X) *ᵥ b) =
+      (a ⬝ᵥ (A *ᵥ b)) * (a ⬝ᵥ (X *ᵥ b)) := by
+  simp only [Matrix.mul_vecMulVec, Matrix.vecMulVec_mul,
+    Matrix.vecMulVec_mulVec, dotProduct_smul, Matrix.dotProduct_mulVec]
+  simp [dotProduct, Finset.mul_sum, Finset.sum_mul]
+
+private theorem sandwich_listProd {n : Type*} [Fintype n] [DecidableEq n]
+    (a b : n → ℂ) (P : Matrix n n ℂ → Prop)
+    (hpair : ∀ A B, P A → P B → A * B = A * vecMulVec b a * B) :
+    ∀ l : List (Matrix n n ℂ), l ≠ [] → (∀ A ∈ l, P A) →
+      a ⬝ᵥ (l.prod *ᵥ b) =
+        (l.map fun A ↦ a ⬝ᵥ (A *ᵥ b)).prod := by
+  intro l hl hP
+  induction l with
+  | nil => exact (hl rfl).elim
+  | cons A l ih =>
+      cases l with
+      | nil => simp
+      | cons B l =>
+          have hA : P A := hP A (by simp)
+          have hB : P B := hP B (by simp)
+          have htail : ∀ X ∈ B :: l, P X := by
+            intro X hX
+            exact hP X (by simp [hX])
+          rw [List.prod_cons, List.prod_cons, ← Matrix.mul_assoc,
+            hpair A B hA hB, Matrix.mul_assoc,
+            sandwich_mul_rankOne_mul]
+          change (a ⬝ᵥ (A *ᵥ b)) * (a ⬝ᵥ ((B :: l).prod *ᵥ b)) = _
+          rw [ih (by simp) htail]
+          simp
+
+private theorem trace_mul_rankOne_mul {n : Type*} [Fintype n]
+    (a b : n → ℂ) (A X : Matrix n n ℂ) :
+    Matrix.trace (A * vecMulVec b a * X) = a ⬝ᵥ ((X * A) *ᵥ b) := by
+  rw [Matrix.trace_mul_comm (A * vecMulVec b a) X, ← Matrix.mul_assoc,
+    Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, ← Matrix.mulVec_mulVec]
+  simp [dotProduct, mul_comm]
+
+private theorem trace_listProd {n : Type*} [Fintype n] [DecidableEq n]
+    (a b : n → ℂ) (P : Matrix n n ℂ → Prop)
+    (hpair : ∀ A B, P A → P B → A * B = A * vecMulVec b a * B)
+    (l : List (Matrix n n ℂ)) (hl : 1 < l.length) (hP : ∀ A ∈ l, P A) :
+    Matrix.trace l.prod = (l.map fun A ↦ a ⬝ᵥ (A *ᵥ b)).prod := by
+  rcases l with _ | ⟨A, l⟩
+  · simp at hl
+  cases l with
+  | nil => simp at hl
+  | cons B l =>
+      have hA : P A := hP A (by simp)
+      have hB : P B := hP B (by simp)
+      have hrot : ∀ X ∈ (B :: l) ++ [A], P X := by
+        intro X hX
+        apply hP X
+        simp only [List.mem_append, List.mem_cons] at hX ⊢
+        tauto
+      rw [List.prod_cons, List.prod_cons, ← Matrix.mul_assoc,
+        hpair A B hA hB, Matrix.mul_assoc, trace_mul_rankOne_mul]
+      have hprod : ((B :: l) ++ [A]).prod = B * l.prod * A := by
+        simp [Matrix.mul_assoc]
+      rw [← hprod, sandwich_listProd a b P hpair _ (by simp) hrot]
+      simp [mul_comm, mul_left_comm]
+
+/-- The `simple1` contraction supplied by witnesses for an MPU-simple tensor.
+
+Source: arXiv:1703.09188, equation `simple1`, lines 363--370 and Figure
+`II_Simple1.png`. -/
+theorem simple1 {U : MPOTensor d D} (hU : IsMPUSimple U) :
+    ∃ a b : Fin (D * D) → ℂ, ∀ i j : Fin d,
+      a ⬝ᵥ (doubleLayerTensor U i j *ᵥ b) = if i = j then 1 else 0 := by
+  obtain ⟨a, b, h₁, _⟩ := hU
+  exact ⟨a, b, h₁⟩
+
+/-- The exact `simple2` contraction supplied by the same witnesses as
+`simple1`: the rank-one operator \(|b)(a|\) may be inserted between adjacent
+double-layer letters.
+
+Source: arXiv:1703.09188, equation `simple2`, lines 363--374 and Figure
+`II_Simple2.png`. -/
+theorem simple2 {U : MPOTensor d D} (hU : IsMPUSimple U) :
+    ∃ a b : Fin (D * D) → ℂ,
+      (∀ i j : Fin d,
+        a ⬝ᵥ (doubleLayerTensor U i j *ᵥ b) = if i = j then 1 else 0) ∧
+      (∀ i j k l : Fin d,
+        doubleLayerTensor U i j * doubleLayerTensor U k l =
+          doubleLayerTensor U i j * vecMulVec b a * doubleLayerTensor U k l) :=
+  hU
+
+/-- Sequentially applying `simple2` around a closed double-layer chain and
+then `simple1` at every site gives the physical identity.
+
+Source: arXiv:1703.09188, Proposition III.3(i), lines 378--388. -/
+theorem mpo_doubleLayerTensor_eq_one {U : MPOTensor d D} (hU : IsMPUSimple U)
+    (N : ℕ) (hN : 1 < N) :
+    mpo (doubleLayerTensor U) N =
+      (1 : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) := by
+  obtain ⟨a, b, h₁, h₂⟩ := hU
+  ext σ τ
+  rw [mpo_apply, mpoMatrixEntry, Matrix.one_apply]
+  rw [evalWord_ofFn]
+  let P : Matrix (Fin (D * D)) (Fin (D * D)) ℂ → Prop :=
+    fun A ↦ ∃ i j, A = doubleLayerTensor U i j
+  have hP : ∀ A ∈ List.ofFn (fun x : Fin N ↦ doubleLayerTensor U (σ x) (τ x)), P A := by
+    intro A hA
+    simp only [List.mem_ofFn] at hA
+    obtain ⟨x, rfl⟩ := hA
+    exact ⟨σ x, τ x, rfl⟩
+  have hpair : ∀ A B, P A → P B → A * B = A * vecMulVec b a * B := by
+    rintro A B ⟨i, j, rfl⟩ ⟨k, l, rfl⟩
+    exact h₂ i j k l
+  rw [trace_listProd a b P hpair _ (by simpa) hP]
+  rw [List.map_ofFn, List.prod_ofFn]
+  simp only [Function.comp_apply, h₁]
+  by_cases hστ : σ = τ
+  · subst τ
+    simp
+  · rw [if_neg hστ]
+    have hpoint : ∃ x, σ x ≠ τ x := by
+      by_contra h
+      apply hστ
+      funext x
+      exact not_ne_iff.mp (not_exists.mp h x)
+    obtain ⟨x, hx⟩ := hpoint
+    apply Finset.prod_eq_zero (Finset.mem_univ x)
+    simp [hx]
+
+/-- Every simple tensor generates a matrix product unitary, by the paper's
+sequential contraction route through `simple2` and `simple1`.
+
+Source: arXiv:1703.09188, Proposition III.3(i), lines 378--388. -/
+theorem isMPU {U : MPOTensor d D} (hU : IsMPUSimple U) : IsMPU U := by
+  intro N hN
+  rw [Matrix.mem_unitaryGroup_iff']
+  simp only [Matrix.star_eq_conjTranspose]
+  rw [← mpo_doubleLayerTensor]
+  exact hU.mpo_doubleLayerTensor_eq_one N hN
+
+end IsMPUSimple
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -166,6 +166,110 @@ closing a chain of $N$ copies of $\mathcal U$.
     unitary.  Simultaneous reindexing preserves unitarity.
 \end{proof}
 
+
+\section{Simple matrix product unitary tensors}
+
+\begin{definition}[Double layer]
+    \label{def:mpu_double_layer}
+    \lean{MPOTensor.doubleLayerTensor,
+        MPOTensor.doubleLayerTensor_apply}
+    \leanok
+    \uses{def:mpdo_physical_adjoint,def:mpdo_operator_product}
+    For an MPO tensor $\mathcal U$, let $\mathcal W$ be the double-layer
+    tensor obtained by placing the physical adjoint above $\mathcal U$ and
+    contracting the adjacent physical legs:
+    \begin{align}
+        \mathcal W^{ik}
+        &=\sum_j (\mathcal U^\sharp)^{ij}\otimes\mathcal U^{jk}.
+    \end{align}
+    The bond space of $\mathcal W$ is the product of the two original bond
+    spaces.  The physical adjoint exchanges and conjugates the physical
+    indices without reversing the order of the virtual chain, exactly as in
+    the barred upper layer of Figures~\texttt{II\_Simple1.png} and
+    \texttt{II\_Simple2.png} of \cite{Cirac2017MPU}.
+\end{definition}
+
+\begin{theorem}[Closed double layer]
+    \label{thm:mpu_closed_double_layer}
+    \lean{MPOTensor.mpo_doubleLayerTensor}
+    \leanok
+    \uses{def:mpu_double_layer}
+    For every chain length $N$, closing the double layer gives
+    \begin{align}
+        W^{(N)}&=\bigl(U^{(N)}\bigr)^\dagger U^{(N)}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_physical_adjoint, thm:mpdo_operator_product_mpo}
+    The operator family is multiplicative under the local product tensor, and
+    the physical adjoint generates the conjugate transpose without reflecting
+    the chain.
+\end{proof}
+
+\begin{definition}[Simple matrix product unitary tensor]
+    \label{def:mpu_simple}
+    \lean{MPOTensor.IsMPUSimple,
+        MPOTensor.IsMPUSimple.simple1,
+        MPOTensor.IsMPUSimple.simple2}
+    \leanok
+    \uses{def:mpu_double_layer}
+    The tensor $\mathcal U$ is \emph{simple} if there are vectors $a,b$ in
+    the double-layer bond space such that, for all physical indices
+    $i,j,k,\ell$,
+    \begin{align}
+        (a|W^{ij}|b)&=\delta_{ij},
+        \tag{simple1}\label{eq:mpu_simple1}\\
+        W^{ij}W^{k\ell}
+          &=W^{ij}|b)(a|W^{k\ell}.
+        \tag{simple2}\label{eq:mpu_simple2}
+    \end{align}
+    Thus (\ref{eq:mpu_simple1}) closes one double-layer letter to the
+    physical identity, while (\ref{eq:mpu_simple2}) inserts the rank-one
+    operator $|b)(a|$ between adjacent letters.  These are precisely the two
+    diagrams in \cite[Definition~III.2]{Cirac2017MPU}.
+\end{definition}
+
+\begin{theorem}[Sequential contraction of a simple double layer]
+    \label{thm:mpu_simple_closed_identity}
+    \lean{MPOTensor.IsMPUSimple.mpo_doubleLayerTensor_eq_one}
+    \leanok
+    \uses{def:mpu_simple}
+    If $\mathcal U$ is simple and $N>1$, then
+    \begin{align}
+        W^{(N)}&=\Id.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_simple}
+    Apply (\ref{eq:mpu_simple2}) sequentially between neighboring letters.
+    The inserted rank-one operators split the periodic contraction into the
+    product of the one-letter contractions $(a|W^{\sigma_x\tau_x}|b)$.
+    Identity~(\ref{eq:mpu_simple1}) turns this product into
+    $\prod_x\delta_{\sigma_x,\tau_x}$, which is the matrix element of the
+    physical identity.
+\end{proof}
+
+\begin{theorem}[A simple tensor generates matrix product unitaries]
+    \label{thm:mpu_simple_is_mpu}
+    \lean{MPOTensor.IsMPUSimple.isMPU}
+    \leanok
+    \uses{def:mpu, def:mpu_simple}
+    Every simple tensor generates matrix product unitaries.
+    This is \cite[Proposition~III.3(i)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_closed_double_layer, thm:mpu_simple_closed_identity}
+    For every $N>1$, the closed-double-layer identity and the sequential
+    contraction give
+    \begin{align}
+        \bigl(U^{(N)}\bigr)^\dagger U^{(N)}&=\Id.
+    \end{align}
+    Hence $U^{(N)}$ is unitary.
+\end{proof}
+
 \section{Trace-power lemma}\label{sec:mpu_trace_power}
 
 For the transfer-matrix spectrum argument of

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -171,7 +171,8 @@ closing a chain of $N$ copies of $\mathcal U$.
 
 \begin{definition}[Double layer]
     \label{def:mpu_double_layer}
-    \lean{MPOTensor.doubleLayerTensor}
+    \lean{MPOTensor.doubleLayerTensor,
+        MPOTensor.doubleLayerTensor_apply}
     \leanok
     \uses{def:mpdo_physical_adjoint,def:mpdo_operator_product}
     For an MPO tensor $\mathcal U$, let $\mathcal W$ be the double-layer
@@ -208,7 +209,9 @@ closing a chain of $N$ copies of $\mathcal U$.
 
 \begin{definition}[Simple matrix product unitary tensor]
     \label{def:mpu_simple}
-    \lean{MPOTensor.IsMPUSimple}
+    \lean{MPOTensor.IsMPUSimple,
+        MPOTensor.IsMPUSimple.simple1,
+        MPOTensor.IsMPUSimple.simple2}
     \leanok
     \uses{def:mpu_double_layer}
     The tensor $\mathcal U$ is \emph{simple} if there are vectors $a,b$ in

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -171,8 +171,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 
 \begin{definition}[Double layer]
     \label{def:mpu_double_layer}
-    \lean{MPOTensor.doubleLayerTensor,
-        MPOTensor.doubleLayerTensor_apply}
+    \lean{MPOTensor.doubleLayerTensor}
     \leanok
     \uses{def:mpdo_physical_adjoint,def:mpdo_operator_product}
     For an MPO tensor $\mathcal U$, let $\mathcal W$ be the double-layer
@@ -209,9 +208,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 
 \begin{definition}[Simple matrix product unitary tensor]
     \label{def:mpu_simple}
-    \lean{MPOTensor.IsMPUSimple,
-        MPOTensor.IsMPUSimple.simple1,
-        MPOTensor.IsMPUSimple.simple2}
+    \lean{MPOTensor.IsMPUSimple}
     \leanok
     \uses{def:mpu_double_layer}
     The tensor $\mathcal U$ is \emph{simple} if there are vectors $a,b$ in


### PR DESCRIPTION
## Summary

- define the physical-adjoint double-layer tensor as `mulTensor (physicalAdjointTensor U) U`, with its exact `finProdFinEquiv`-reindexed local formula
- formalize the MPU paper's `simple1` and `simple2` diagrams as the disambiguated predicate `MPOTensor.IsMPUSimple`
- prove the closed double layer is `(mpo U N)ᴴ * mpo U N` using the existing operator-family bridges
- prove sequential contraction gives the identity for every `N > 1`, hence every MPU-simple tensor satisfies `IsMPU` with no dimension, nondegeneracy, or canonical-form hypotheses
- add source-linked blueprint entries for the local identities and Proposition III.3(i)

The diagram orientation was checked directly against `II_Simple1.png` and `II_Simple2.png`: the barred upper layer is the physical adjoint, `simple1` is `(a|W^{ij}|b) = δᵢⱼ`, and `simple2` is `W^{ij}W^{kℓ} = W^{ij}|b)(a|W^{kℓ}`. This notion is explicitly distinguished from the unrelated CPSV16 `MPOTensor.IsSimple`.

## Checks

- `lake env lean TNLean/MPS/MPU/Simple.lean`
- `lake env lean TNLean/MPS/MPU.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch28_mpu.tex`
- `python3 scripts/generate_import_aggregators.py --check`
- changed-file proof-bypass scan and `git diff --check`
- `#print axioms` audit: only standard `propext`, `Classical.choice`, and `Quot.sound`

Closes #5776

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization and import reshuffling with no runtime, auth, or data-path changes; proofs reuse existing MPO/MPU infrastructure.
> 
> **Overview**
> Moves **`physicalAdjointTensor`** and its word/`mpo` lemmas into **`TNLean/MPS/MPDO/PhysicalAdjoint.lean`**, and switches **`BNTLayerOrthogonality`** to import that module instead of duplicating the definition.
> 
> Adds **`TNLean/MPS/MPU/Simple.lean** with the MPU paper’s double layer (`mulTensor (physicalAdjointTensor U) U`), the **`IsMPUSimple`** predicate matching **`simple1`** / **`simple2`**, and proofs that a closed double layer is **`(mpo U N)ᴴ * mpo U N`**, that **`W^{(N)} = 1`** for **`N > 1`** via sequential contraction, and hence **`IsMPU`** with no extra hypotheses. **`TNLean/MPS/MPU.lean`** aggregates **`Simple`**; **`MPDO.lean`** imports **`PhysicalAdjoint`**.
> 
> The blueprint chapter **`ch28_mpu.tex`** gains a new section on simple MPU tensors (double layer, closed identity, Proposition III.3(i)) with Lean links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead1014305bd7e2472592f650f38cc55271715ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->