### PR TITLE
feat(ParentHamiltonian): specialize the inverse-Gram ground projector

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -5,6 +5,8 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.FrobeniusHilbert
 import TNLean.Algebra.RectangularChoi
+import TNLean.Analysis.InjectiveRangeProjector
+import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.Spectral.MixedTransfer
 
@@ -64,6 +66,60 @@ theorem range_groundSpaceMapES (A : MPSTensor d D) (L : ℕ) :
     exact ⟨Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X,
       groundSpaceMapES_frobeniusEquivEuclidean_apply A L X⟩
 
+/-- Block injectivity at length \(L\) makes the Hilbert-space boundary map
+\(\Gamma_L\) injective. -/
+theorem groundSpaceMapES_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}
+    (hInj : IsNBlkInjective A L) :
+    Function.Injective (groundSpaceMapES A L) := by
+  intro x y hxy
+  obtain ⟨X, rfl⟩ := (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).surjective x
+  obtain ⟨Y, rfl⟩ := (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).surjective y
+  apply congrArg (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D))
+  apply groundSpaceMap_injective_of_isNBlkInjective hInj
+  apply (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm.injective
+  rw [groundSpaceMapES_frobeniusEquivEuclidean_apply,
+    groundSpaceMapES_frobeniusEquivEuclidean_apply] at hxy
+  exact hxy
+
+/-- If \(A\) is block-injective at a positive length \(L₀\), then its
+Hilbert-space boundary map is injective at every length \(L \ge L₀\). -/
+theorem groundSpaceMapES_injective_of_isNBlkInjective_of_le
+    {A : MPSTensor d D} {L₀ L : ℕ} (hL₀ : 0 < L₀)
+    (hInj : IsNBlkInjective A L₀) (hL : L₀ ≤ L) :
+    Function.Injective (groundSpaceMapES A L) :=
+  groundSpaceMapES_injective_of_isNBlkInjective
+    (isNBlkInjective_of_le hL₀ hInj hL)
+
+/-- For a block-injective MPS, the inverse-Gram range projector of
+\(\Gamma_L\) is the orthogonal projector onto the physical local ground space.
+This is the physical range projector, not the virtual transfer fixed-point
+projector `fixedPointProj`; it does not assert an overlapping-window estimate. -/
+theorem injectiveRangeProjector_groundSpaceMapES_eq_starProjection
+    (A : MPSTensor d D) (L : ℕ) (hInj : IsNBlkInjective A L) :
+    ContinuousLinearMap.injectiveRangeProjector (groundSpaceMapES A L)
+      (groundSpaceMapES_injective_of_isNBlkInjective hInj) =
+        (groundSpaceES A L).starProjection := by
+  rw [ContinuousLinearMap.injectiveRangeProjector_eq_starProjection]
+  exact congrArg (fun K : Submodule ℂ (EuclideanSpace ℂ (Cfg d L)) => K.starProjection)
+    (range_groundSpaceMapES A L)
+
+/-- For every \(L \ge L₀\), the physical MPS ground-space projector is
+\[
+  P_{G_L(A)} = \Gamma_L (\Gamma_L^\dagger \Gamma_L)^{-1} \Gamma_L^\dagger.
+\]
+Here the inverse is `ContinuousLinearMap.inverseGram`. This is the physical
+range projector, not the virtual `fixedPointProj`; it does not assert an
+overlapping-window estimate. -/
+theorem groundSpaceES_starProjection_eq_groundSpaceMapES_comp_inverseGram_comp_adjoint
+    (A : MPSTensor d D) {L₀ L : ℕ} (hL₀ : 0 < L₀)
+    (hInj : IsNBlkInjective A L₀) (hL : L₀ ≤ L) :
+    (groundSpaceES A L).starProjection =
+      (groundSpaceMapES A L).comp
+        ((ContinuousLinearMap.inverseGram (groundSpaceMapES A L)
+          (groundSpaceMapES_injective_of_isNBlkInjective_of_le hL₀ hInj hL)).comp
+            (groundSpaceMapES A L).adjoint) := by
+  exact (injectiveRangeProjector_groundSpaceMapES_eq_starProjection A L
+    (isNBlkInjective_of_le hL₀ hInj hL)).symm
 
 @[simp]
 theorem groundSpaceMapES_single (A : MPSTensor d D) (L : ℕ) (a b : Fin D) :

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -67,7 +67,7 @@ theorem range_groundSpaceMapES (A : MPSTensor d D) (L : ℕ) :
       groundSpaceMapES_frobeniusEquivEuclidean_apply A L X⟩
 
 /-- Block injectivity at length \(L\) makes the Hilbert-space boundary map
-\(\Gamma_L\) injective. -/
+\(\Gamma_L^{\mathrm{ES}}\) injective. -/
 theorem groundSpaceMapES_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}
     (hInj : IsNBlkInjective A L) :
     Function.Injective (groundSpaceMapES A L) := by
@@ -90,10 +90,11 @@ theorem groundSpaceMapES_injective_of_isNBlkInjective_of_le
   groundSpaceMapES_injective_of_isNBlkInjective
     (isNBlkInjective_of_le hL₀ hInj hL)
 
-/-- For a block-injective MPS, the inverse-Gram range projector of
-\(\Gamma_L\) is the orthogonal projector onto the physical local ground space.
-This is the physical range projector, not the virtual transfer fixed-point
-projector `fixedPointProj`; it does not assert an overlapping-window estimate. -/
+/-- If \(A\) is block-injective at length \(L\), the inverse-Gram range
+projector of \(\Gamma_L^{\mathrm{ES}}\) is the orthogonal projector onto the
+physical local ground space. This is the physical range projector, not the
+virtual transfer fixed-point projector `fixedPointProj`; it does not assert an
+overlapping-window estimate. -/
 theorem injectiveRangeProjector_groundSpaceMapES_eq_starProjection
     (A : MPSTensor d D) (L : ℕ) (hInj : IsNBlkInjective A L) :
     ContinuousLinearMap.injectiveRangeProjector (groundSpaceMapES A L)
@@ -103,9 +104,11 @@ theorem injectiveRangeProjector_groundSpaceMapES_eq_starProjection
   exact congrArg (fun K : Submodule ℂ (EuclideanSpace ℂ (Cfg d L)) => K.starProjection)
     (range_groundSpaceMapES A L)
 
-/-- For every \(L \ge L₀\), the physical MPS ground-space projector is
+/-- If \(L₀ > 0\), \(A\) is \(L₀\)-block injective, and \(L \ge L₀\), then
 \[
-  P_{G_L(A)} = \Gamma_L (\Gamma_L^\dagger \Gamma_L)^{-1} \Gamma_L^\dagger.
+  P_{G_L^{\mathrm{ES}}(A)} = \Gamma_L^{\mathrm{ES}}
+    ((\Gamma_L^{\mathrm{ES}})^\dagger \Gamma_L^{\mathrm{ES}})^{-1}
+    (\Gamma_L^{\mathrm{ES}})^\dagger.
 \]
 Here the inverse is `ContinuousLinearMap.inverseGram`. This is the physical
 range projector, not the virtual `fixedPointProj`; it does not assert an

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -212,6 +212,44 @@ orthogonal projector is the canonical representative used here.
     inclusions.
 \end{proof}
 
+\begin{theorem}[Hilbert-space boundary-map injectivity]
+    \label{thm:ground_space_map_es_injective_block}
+    \lean{MPSTensor.groundSpaceMapES_injective_of_isNBlkInjective}
+    \leanok
+    \uses{def:ground_space_map_es, def:l_blk_injective}
+    If $A$ is $L$-block injective, then
+    $\Gamma_L^{\mathrm{ES}}$ is injective.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_map_es_frobenius,
+        thm:ground_space_map_injective_blk}
+    Write each virtual vector uniquely as $U(X)$ by Frobenius vectorization.
+    The transport identity reduces equality of their images under
+    $\Gamma_L^{\mathrm{ES}}$ to equality of the images of the corresponding
+    matrices under $\Gamma_L$.  Block injectivity makes the latter map
+    injective.
+\end{proof}
+
+\begin{theorem}[Long-length Hilbert-space boundary-map injectivity]
+    \label{thm:ground_space_map_es_injective_block_of_le}
+    \lean{MPSTensor.groundSpaceMapES_injective_of_isNBlkInjective_of_le}
+    \leanok
+    \uses{def:ground_space_map_es, def:l_blk_injective}
+    Suppose that $L_0>0$, that $A$ is $L_0$-block injective, and that
+    $L\ge L_0$.  Then $\Gamma_L^{\mathrm{ES}}$ is injective.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_map_es_injective_block,
+        thm:wordspan_blk_inj_succ}
+    Positive-length propagation makes $A$ block injective at length $L$.
+    The preceding theorem then gives injectivity of
+    $\Gamma_L^{\mathrm{ES}}$.
+\end{proof}
+
 \begin{definition}[Ground-space Gram operator]
     \label{def:ground_space_gram}
     \lean{MPSTensor.groundSpaceGram}
@@ -302,6 +340,66 @@ orthogonal projector is the canonical representative used here.
     $\langle x-Q_Tx,Ty\rangle=0$.  Thus $x-Q_Tx$ is orthogonal to
     $\range T$, and the range--orthogonal decomposition characterizing the
     orthogonal projector gives $Q_T=P_{\range T}$.
+\end{proof}
+
+% Maintainer note: this is the dependency-closed projector slice for issue #5752.
+% Its source boundary is the inverse-Gram/range-projector identity; it does not
+% include or assert the FNW overlapping-window estimate.
+\begin{theorem}[Physical ground-space range projector]
+    \label{thm:ground_space_map_es_injective_range_projector}
+    \lean{MPSTensor.injectiveRangeProjector_groundSpaceMapES_eq_starProjection}
+    \leanok
+    \uses{def:ground_space_map_es, def:ground_space_es,
+        def:injective_range_projector,
+        thm:ground_space_map_es_injective_block}
+    If $A$ is $L$-block injective, then the injective range projector of
+    $\Gamma_L^{\mathrm{ES}}$ is the physical orthogonal projector onto the
+    local ground space:
+    \begin{align}
+      Q_{\Gamma_L^{\mathrm{ES}}}
+      &=P_{G_L^{\mathrm{ES}}(A)}.
+    \end{align}
+    In particular, this is the physical range projector on the local Hilbert
+    space, not the virtual transfer fixed-point projector.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:injective_range_projector_inverse_gram,
+        thm:range_ground_space_map_es}
+    The general injective range-projector theorem identifies
+    $Q_{\Gamma_L^{\mathrm{ES}}}$ with the orthogonal projector onto
+    $\range(\Gamma_L^{\mathrm{ES}})$.  The exact-range theorem identifies
+    this range with $G_L^{\mathrm{ES}}(A)$.
+\end{proof}
+
+\begin{theorem}[Physical ground-space inverse-Gram projector formula]
+    \label{thm:ground_space_es_projection_inverse_gram}
+    \lean{MPSTensor.groundSpaceES_starProjection_eq_groundSpaceMapES_comp_inverseGram_comp_adjoint}
+    \leanok
+    \uses{def:ground_space_es, def:ground_space_map_es, def:inverse_gram,
+        thm:ground_space_map_es_injective_block_of_le}
+    Suppose that $L_0>0$, that $A$ is $L_0$-block injective, and that
+    $L\ge L_0$.  Then the physical orthogonal projector onto the local ground
+    space is
+    \begin{align}
+      P_{G_L^{\mathrm{ES}}(A)}
+      &=\Gamma_L^{\mathrm{ES}}
+        \left((\Gamma_L^{\mathrm{ES}})^\dagger
+              \Gamma_L^{\mathrm{ES}}\right)^{-1}
+        (\Gamma_L^{\mathrm{ES}})^\dagger.
+    \end{align}
+    Thus the displayed operator is the physical range projector on
+    $\ell^2(\Fin{d}^{L})$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_map_es_injective_range_projector,
+        thm:wordspan_blk_inj_succ}
+    Positive-length propagation makes $A$ block injective at length $L$.
+    Apply the physical range-projector identity at that length and unfold its
+    inverse-Gram expression.
 \end{proof}
 
 \begin{theorem}[Neumann inverse estimate]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -517,22 +517,24 @@ for injective finite-dimensional maps is
 \leanid{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}, and the
 denominator estimate $\|(1-t)^{-1}\|\le(1-a)^{-1}$ under
 $\|t\|\le a<1$ is \leanid{NormedRing.norm_inverse_one_sub_le}.
-Block injectivity makes the Hilbert-space boundary map injective at its base
-length and every longer length; this is recorded by
+Suppose that $L_0>0$ and that $A$ is $L_0$-block injective.  Block
+injectivity then makes the Hilbert-space boundary map injective at every length
+$L\ge L_0$; this is recorded by
 \leanid{MPSTensor.groundSpaceMapES_injective_of_isNBlkInjective} and
 \leanid{MPSTensor.groundSpaceMapES_injective_of_isNBlkInjective_of_le}.
-The specialization
+Writing $\mathcal G_L^{\mathrm{ES}}(A)$ for the physical local ground space, the
+specialization
 \leanid{MPSTensor.groundSpaceES_starProjection_eq_groundSpaceMapES_comp_inverseGram_comp_adjoint}
-therefore proves the exact physical formula
+therefore proves, for every $L\ge L_0$, the exact physical formula
 \begin{align}
-  P_{\mathcal G_L(A)}
+  P_{\mathcal G_L^{\mathrm{ES}}(A)}
     &=\Gamma_L^{\mathrm{ES}}\mathcal K_L^{-1}
-      (\Gamma_L^{\mathrm{ES}})^\dagger,
-  &L&\ge L_0.
+      (\Gamma_L^{\mathrm{ES}})^\dagger.
 \end{align}
-This is the orthogonal projector onto $\operatorname{ran}\Gamma_L$.  It is not
-the transfer fixed-point projector \leanid{fixedPointProj}; the latter acts on
-the virtual matrix space and cannot substitute for the inverse-Gram formula.
+This is the orthogonal projector onto
+$\operatorname{ran}\Gamma_L^{\mathrm{ES}}$.  It is not the transfer fixed-point
+projector \leanid{fixedPointProj}; the latter acts on the virtual matrix space
+and cannot substitute for the inverse-Gram formula.
 
 To state the source estimate, let $l\in\mathbb N$ be the overlap length and let
 $0\le\lambda<1$ be an admissible transfer-mixing rate satisfying

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -517,10 +517,22 @@ for injective finite-dimensional maps is
 \leanid{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}, and the
 denominator estimate $\|(1-t)^{-1}\|\le(1-a)^{-1}$ under
 $\|t\|\le a<1$ is \leanid{NormedRing.norm_inverse_one_sub_le}.
-Consequently the physical local ground projector is the orthogonal projector
-onto $\operatorname{ran}\Gamma_L$.  It is not the transfer fixed-point
-projector \leanid{fixedPointProj}; the latter acts on the virtual matrix space
-and cannot substitute for the inverse-Gram formula.
+Block injectivity makes the Hilbert-space boundary map injective at its base
+length and every longer length; this is recorded by
+\leanid{MPSTensor.groundSpaceMapES_injective_of_isNBlkInjective} and
+\leanid{MPSTensor.groundSpaceMapES_injective_of_isNBlkInjective_of_le}.
+The specialization
+\leanid{MPSTensor.groundSpaceES_starProjection_eq_groundSpaceMapES_comp_inverseGram_comp_adjoint}
+therefore proves the exact physical formula
+\begin{align}
+  P_{\mathcal G_L(A)}
+    &=\Gamma_L^{\mathrm{ES}}\mathcal K_L^{-1}
+      (\Gamma_L^{\mathrm{ES}})^\dagger,
+  &L&\ge L_0.
+\end{align}
+This is the orthogonal projector onto $\operatorname{ran}\Gamma_L$.  It is not
+the transfer fixed-point projector \leanid{fixedPointProj}; the latter acts on
+the virtual matrix space and cannot substitute for the inverse-Gram formula.
 
 To state the source estimate, let $l\in\mathbb N$ be the overlap length and let
 $0\le\lambda<1$ be an admissible transfer-mixing rate satisfying
@@ -530,9 +542,13 @@ the auxiliary, or bond, dimension.  Choose $l$ so that $c\lambda^l<1$.  These
 are parameters of the quoted FNW estimate, not bounds derived by the present
 formal infrastructure.
 
-What remains open is the source-specific FNW comparison of the inverse-Gram
-range projectors on the two overlapping physical windows.  In particular, the
-present infrastructure does not prove the contraction
+What remains open is the source-specific comparison of these exact inverse-Gram
+range projectors on the two overlapping physical windows.  The next formal
+steps are to package the Choi reshuffling as an operator identity with a verified
+norm bound, construct the spectator-indexed boundary maps for the left and tail
+windows, and derive their common-ambient contraction directly from the MPS word
+factorization.  In particular, the present infrastructure does not prove the
+contraction
 \begin{align}
   c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},
   \qquad c\lambda^l<1,

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 685, 727 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 783, 825 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- transports block injectivity to the Hilbert-space MPS boundary map at the base length and every longer length;
- specializes the generic injective range-projector theorem to prove the exact physical formula
  $$
  P_{G_L(A)}=\Gamma_L^{\mathrm{ES}}\bigl((\Gamma_L^{\mathrm{ES}})^\dagger\Gamma_L^{\mathrm{ES}}\bigr)^{-1}(\Gamma_L^{\mathrm{ES}})^\dagger,
  \qquad L\ge L_0;
  $$
- distinguishes this physical range projector from the virtual transfer fixed-point projector;
- synchronizes Chapter 13 and the martingale paper-gap note while leaving the FNW overlapping-window contraction explicitly open.

## Source boundary

This is the next dependency-closed slice of #5752. It proves only exact identities derived from the existing MPS boundary map and generic inverse-Gram theorem. It does not reconstruct or attribute an unverified FNW intermediate derivation and does not claim the final numerical defect estimate.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.GroundSpaceGram`
- `leanblueprint web`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv21_martingale_overlap.tex`
- diagnostics and `git diff --check`

Refs #5752, #5455, #460, #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are formal proofs and documentation in the parent-Hamiltonian Gram layer; no runtime, auth, or data paths. Risk is mainly mathematical correctness of new Lean theorems, scoped to existing injective-range-projector infrastructure.
> 
> **Overview**
> Under **block injectivity**, this PR proves that the Hilbert-space boundary map `groundSpaceMapES` is injective (at the base length and at all longer lengths via propagation), and that the **physical** orthogonal projector onto the local ground space equals the standard inverse-Gram formula `Γ (K⁻¹ Γ†)`—explicitly **not** the virtual transfer `fixedPointProj`.
> 
> Lean additions live in `GroundSpaceGram.lean` (new imports for `InjectiveRangeProjector` and `BlockStrip`). Chapter 13 blueprint entries and proofs are synchronized to these lemmas. The martingale overlap paper-gap note is updated to cite the new exact projector identity while keeping the FNW overlapping-window contraction and numerical defect estimate **explicitly open** (#5752).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db686d7c08ccf70bb72c5833b150e1a90e0d1c71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->