### PR TITLE
feat(Analysis): add quantitative inverse-Gram control

### DIFF
--- a/TNLean/Analysis/InjectiveRangeProjector.lean
+++ b/TNLean/Analysis/InjectiveRangeProjector.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.NeumannInverse
+
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.Projection.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
@@ -30,6 +32,56 @@ noncomputable def inverseGram (T : E →L[𝕜] F) (hT : Function.Injective T) :
   LinearMap.toContinuousLinearMap <|
     (LinearEquiv.ofInjectiveEndo (T.adjoint.comp T).toLinearMap
       ((T.adjoint_comp_self_injective_iff).2 hT)).symm.toLinearMap
+
+/-- The inverse Gram operator is a left inverse of the Gram operator. -/
+@[simp]
+theorem inverseGram_comp_adjoint_comp_self (T : E →L[𝕜] F)
+    (hT : Function.Injective T) :
+    (inverseGram T hT).comp (T.adjoint.comp T) = ContinuousLinearMap.id 𝕜 E := by
+  ext x
+  exact (LinearEquiv.ofInjectiveEndo (T.adjoint.comp T).toLinearMap
+    ((T.adjoint_comp_self_injective_iff).2 hT)).symm_apply_apply x
+
+/-- The inverse Gram operator is a right inverse of the Gram operator. -/
+@[simp]
+theorem adjoint_comp_self_comp_inverseGram (T : E →L[𝕜] F)
+    (hT : Function.Injective T) :
+    (T.adjoint.comp T).comp (inverseGram T hT) = ContinuousLinearMap.id 𝕜 E := by
+  ext x
+  exact (LinearEquiv.ofInjectiveEndo (T.adjoint.comp T).toLinearMap
+    ((T.adjoint_comp_self_injective_iff).2 hT)).apply_symm_apply x
+
+/-- The inverse Gram operator agrees with the inverse operation on continuous linear maps. -/
+theorem inverseGram_eq_inverse (T : E →L[𝕜] F) (hT : Function.Injective T) :
+    inverseGram T hT = (T.adjoint.comp T).inverse := by
+  symm
+  exact ContinuousLinearMap.inverse_eq
+    (adjoint_comp_self_comp_inverseGram T hT)
+    (inverseGram_comp_adjoint_comp_self T hT)
+
+/-- The inverse Gram operator agrees with the ring-theoretic inverse. -/
+theorem inverseGram_eq_ringInverse (T : E →L[𝕜] F) (hT : Function.Injective T) :
+    inverseGram T hT = Ring.inverse (T.adjoint.comp T) := by
+  rw [ContinuousLinearMap.ringInverse_eq_inverse]
+  exact inverseGram_eq_inverse T hT
+
+/-- If the Gram operator is within norm `a < 1` of the identity, then its inverse
+has norm at most `(1 - a)⁻¹`. The denominator is the Neumann inverse bound. -/
+theorem norm_inverseGram_le_of_norm_one_sub_adjoint_comp_self_le
+    (T : E →L[𝕜] F) (hT : Function.Injective T) {a : ℝ}
+    (ha : ‖1 - T.adjoint.comp T‖ ≤ a) (ha_lt_one : a < 1) :
+    ‖inverseGram T hT‖ ≤ (1 - a)⁻¹ := by
+  cases subsingleton_or_nontrivial E with
+  | inl hE =>
+      letI : Subsingleton E := hE
+      have hzero : inverseGram T hT = 0 := Subsingleton.elim _ _
+      rw [hzero, norm_zero]
+      exact inv_nonneg.mpr (sub_nonneg.mpr ha_lt_one.le)
+  | inr hE =>
+      letI : Nontrivial E := hE
+      rw [inverseGram_eq_ringInverse]
+      simpa only [sub_sub_cancel] using
+        NormedRing.norm_inverse_one_sub_le (1 - T.adjoint.comp T) ha ha_lt_one
 
 /-- The continuous range projector written through the inverse Gram operator. -/
 noncomputable def injectiveRangeProjector (T : E →L[𝕜] F)

--- a/TNLean/Analysis/InjectiveRangeProjector.lean
+++ b/TNLean/Analysis/InjectiveRangeProjector.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Analysis.NeumannInverse
-
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.Projection.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
@@ -13,10 +12,15 @@ import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 # Range projectors of injective finite-dimensional maps
 
 For an injective map \(T\) with finite-dimensional Hilbert domain and complete
-Hilbert codomain, this file records the standard formula
+Hilbert codomain, this file develops the inverse Gram operator
+\((T^\dagger T)^{-1}\), identifies it with the canonical and ring inverses, and
+records the range-projector formula
 \[
   P_{\operatorname{ran} T}=T(T^\dagger T)^{-1}T^\dagger.
 \]
+It also derives the quantitative bound
+\(\lVert(T^\dagger T)^{-1}\rVert\le(1-a)^{-1}\) from
+\(\lVert 1-T^\dagger T\rVert\le a<1\).
 -/
 
 
@@ -106,9 +110,11 @@ theorem injectiveRangeProjector_eq_starProjection (T : E →L[𝕜] F)
     rw [map_sub, injectiveRangeProjector, comp_apply, comp_apply]
     change T.adjoint x - (T.adjoint.comp T)
       (inverseGram T hT (T.adjoint x)) = 0
-    rw [inverseGram]
-    exact sub_eq_zero.mpr
-      ((LinearEquiv.ofInjectiveEndo (T.adjoint.comp T).toLinearMap
-        ((T.adjoint_comp_self_injective_iff).2 hT)).apply_symm_apply (T.adjoint x)).symm
+    have hGram :
+        (T.adjoint.comp T) (inverseGram T hT (T.adjoint x)) = T.adjoint x := by
+      change ((T.adjoint.comp T).comp (inverseGram T hT)) (T.adjoint x) = T.adjoint x
+      rw [adjoint_comp_self_comp_inverseGram]
+      rfl
+    rw [hGram, sub_self]
 
 end ContinuousLinearMap

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -306,9 +306,95 @@ orthogonal projector is the canonical representative used here.
     \label{def:inverse_gram}
     \lean{ContinuousLinearMap.inverseGram}
     \leanok
-    For an injective map $T$ with finite-dimensional domain, define
-    $S_T:=(T^\dagger T)^{-1}$.
+    For an injective continuous linear map $T$ with finite-dimensional domain,
+    let $S_T$ be the continuous endomorphism induced by the inverse linear
+    equivalence of the Gram endomorphism $T^\dagger T$.
 \end{definition}
+
+\begin{theorem}[Left inverse-Gram identity]
+    \label{thm:inverse_gram_left_inverse}
+    \lean{ContinuousLinearMap.inverseGram_comp_adjoint_comp_self}
+    \leanok
+    \uses{def:inverse_gram}
+    Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
+    finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
+    complete $\mathbb K$-Hilbert space.  If $T\colon E\to F$ is an injective
+    continuous linear map, then
+    \begin{align}
+      S_T(T^\dagger T)&=I_E.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:inverse_gram}
+    By definition, $S_T$ is induced by the inverse linear equivalence of the
+    injective endomorphism $T^\dagger T$.  The inverse equivalence followed by
+    the original map is the identity.
+\end{proof}
+
+\begin{theorem}[Right inverse-Gram identity]
+    \label{thm:inverse_gram_right_inverse}
+    \lean{ContinuousLinearMap.adjoint_comp_self_comp_inverseGram}
+    \leanok
+    \uses{def:inverse_gram}
+    Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
+    finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
+    complete $\mathbb K$-Hilbert space.  If $T\colon E\to F$ is an injective
+    continuous linear map, then
+    \begin{align}
+      (T^\dagger T)S_T&=I_E.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:inverse_gram}
+    By definition, $S_T$ is induced by the inverse linear equivalence of
+    $T^\dagger T$.  The original map followed by its inverse equivalence is the
+    identity.
+\end{proof}
+
+\begin{theorem}[Inverse Gram as the canonical inverse]
+    \label{thm:inverse_gram_eq_inverse}
+    \lean{ContinuousLinearMap.inverseGram_eq_inverse}
+    \leanok
+    \uses{def:inverse_gram}
+    Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
+    finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
+    complete $\mathbb K$-Hilbert space.  If $T\colon E\to F$ is an injective
+    continuous linear map, then the inverse Gram operator is the canonical
+    inverse of the Gram endomorphism:
+    \begin{align}
+      S_T&=(T^\dagger T)^{-1}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:inverse_gram_left_inverse, thm:inverse_gram_right_inverse}
+    The two inverse identities characterize the canonical inverse of a
+    continuous linear endomorphism.
+\end{proof}
+
+\begin{theorem}[Inverse Gram as the ring inverse]
+    \label{thm:inverse_gram_eq_ring_inverse}
+    \lean{ContinuousLinearMap.inverseGram_eq_ringInverse}
+    \leanok
+    \uses{def:inverse_gram}
+    Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
+    finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
+    complete $\mathbb K$-Hilbert space.  If $T\colon E\to F$ is an injective
+    continuous linear map, then $S_T$ is the inverse of $T^\dagger T$ in the
+    ring of continuous endomorphisms of $E$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:inverse_gram_eq_inverse}
+    For continuous linear endomorphisms, the ring inverse agrees with the
+    canonical inverse.
+\end{proof}
 
 \begin{definition}[Injective range-projector candidate]
     \label{def:injective_range_projector}
@@ -426,6 +512,34 @@ orthogonal projector is the canonical representative used here.
     \end{align}
     where the last step uses monotonicity of the reciprocal on the positive
     reals.
+\end{proof}
+
+\begin{theorem}[Quantitative inverse-Gram estimate]
+    \label{thm:inverse_gram_norm_bound}
+    \lean{ContinuousLinearMap.norm_inverseGram_le_of_norm_one_sub_adjoint_comp_self_le}
+    \leanok
+    \uses{def:inverse_gram}
+    Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
+    finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
+    complete $\mathbb K$-Hilbert space.  Let $T\colon E\to F$ be an injective
+    continuous linear map.  If $a\in\mathbb R$ satisfies $a<1$ and
+    \begin{align}
+      \lVert I_E-T^\dagger T\rVert&\le a,
+    \end{align}
+    then
+    \begin{align}
+      \lVert S_T\rVert&\le(1-a)^{-1}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:inverse_gram_eq_ring_inverse,
+        thm:neumann_inverse_norm_bound}
+    If $E$ is trivial, then $S_T=0$ and the bound follows from $a<1$.
+    Otherwise, identify $S_T$ with the ring inverse of $T^\dagger T$ and apply
+    Theorem~\ref{thm:neumann_inverse_norm_bound} to
+    $t=I_E-T^\dagger T$.
 \end{proof}
 
 \begin{definition}[Canonical parent interaction]\label{def:parent_interaction}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -311,89 +311,35 @@ orthogonal projector is the canonical representative used here.
     equivalence of the Gram endomorphism $T^\dagger T$.
 \end{definition}
 
-\begin{theorem}[Left inverse-Gram identity]
-    \label{thm:inverse_gram_left_inverse}
+\begin{theorem}[Inverse-Gram identities]
+    \label{thm:inverse_gram_identities}
     \lean{ContinuousLinearMap.inverseGram_comp_adjoint_comp_self}
-    \leanok
-    \uses{def:inverse_gram}
-    Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
-    finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
-    complete $\mathbb K$-Hilbert space.  If $T\colon E\to F$ is an injective
-    continuous linear map, then
-    \begin{align}
-      S_T(T^\dagger T)&=I_E.
-    \end{align}
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{def:inverse_gram}
-    By definition, $S_T$ is induced by the inverse linear equivalence of the
-    injective endomorphism $T^\dagger T$.  The inverse equivalence followed by
-    the original map is the identity.
-\end{proof}
-
-\begin{theorem}[Right inverse-Gram identity]
-    \label{thm:inverse_gram_right_inverse}
     \lean{ContinuousLinearMap.adjoint_comp_self_comp_inverseGram}
-    \leanok
-    \uses{def:inverse_gram}
-    Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
-    finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
-    complete $\mathbb K$-Hilbert space.  If $T\colon E\to F$ is an injective
-    continuous linear map, then
-    \begin{align}
-      (T^\dagger T)S_T&=I_E.
-    \end{align}
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{def:inverse_gram}
-    By definition, $S_T$ is induced by the inverse linear equivalence of
-    $T^\dagger T$.  The original map followed by its inverse equivalence is the
-    identity.
-\end{proof}
-
-\begin{theorem}[Inverse Gram as the canonical inverse]
-    \label{thm:inverse_gram_eq_inverse}
     \lean{ContinuousLinearMap.inverseGram_eq_inverse}
-    \leanok
-    \uses{def:inverse_gram}
-    Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
-    finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
-    complete $\mathbb K$-Hilbert space.  If $T\colon E\to F$ is an injective
-    continuous linear map, then the inverse Gram operator is the canonical
-    inverse of the Gram endomorphism:
-    \begin{align}
-      S_T&=(T^\dagger T)^{-1}.
-    \end{align}
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:inverse_gram_left_inverse, thm:inverse_gram_right_inverse}
-    The two inverse identities characterize the canonical inverse of a
-    continuous linear endomorphism.
-\end{proof}
-
-\begin{theorem}[Inverse Gram as the ring inverse]
-    \label{thm:inverse_gram_eq_ring_inverse}
     \lean{ContinuousLinearMap.inverseGram_eq_ringInverse}
     \leanok
     \uses{def:inverse_gram}
     Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
     finite-dimensional complete $\mathbb K$-Hilbert space, and let $F$ be a
     complete $\mathbb K$-Hilbert space.  If $T\colon E\to F$ is an injective
-    continuous linear map, then $S_T$ is the inverse of $T^\dagger T$ in the
-    ring of continuous endomorphisms of $E$.
+    continuous linear map, then the inverse Gram operator is a two-sided
+    inverse of the Gram endomorphism:
+    \begin{align}
+      S_T(T^\dagger T)&=I_E,
+      & (T^\dagger T)S_T&=I_E.
+    \end{align}
+    Consequently, $S_T$ is both the canonical inverse and the ring inverse of
+    $T^\dagger T$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:inverse_gram_eq_inverse}
-    For continuous linear endomorphisms, the ring inverse agrees with the
-    canonical inverse.
+    \uses{def:inverse_gram}
+    By definition, $S_T$ is induced by the inverse linear equivalence of the
+    injective endomorphism $T^\dagger T$.  The two inverse-equivalence
+    identities give the displayed left and right inverse identities.  These
+    identities characterize the canonical inverse of a continuous linear
+    endomorphism, which agrees with its inverse in the endomorphism ring.
 \end{proof}
 
 \begin{definition}[Injective range-projector candidate]
@@ -534,7 +480,7 @@ orthogonal projector is the canonical representative used here.
 
 \begin{proof}
     \leanok
-    \uses{thm:inverse_gram_eq_ring_inverse,
+    \uses{thm:inverse_gram_identities,
         thm:neumann_inverse_norm_bound}
     If $E$ is trivial, then $S_T=0$ and the bound follows from $a<1$.
     Otherwise, identify $S_T$ with the ring inverse of $T^\dagger T$ and apply

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -326,7 +326,9 @@ orthogonal projector is the canonical representative used here.
     inverse of the Gram endomorphism:
     \begin{align}
       S_T(T^\dagger T)&=I_E,
-      & (T^\dagger T)S_T&=I_E.
+      \label{eq:inverse_gram_left}\\
+      (T^\dagger T)S_T&=I_E.
+      \label{eq:inverse_gram_right}
     \end{align}
     Consequently, $S_T$ is both the canonical inverse and the ring inverse of
     $T^\dagger T$.
@@ -336,10 +338,11 @@ orthogonal projector is the canonical representative used here.
     \leanok
     \uses{def:inverse_gram}
     By definition, $S_T$ is induced by the inverse linear equivalence of the
-    injective endomorphism $T^\dagger T$.  The two inverse-equivalence
-    identities give the displayed left and right inverse identities.  These
-    identities characterize the canonical inverse of a continuous linear
-    endomorphism, which agrees with its inverse in the endomorphism ring.
+    injective endomorphism $T^\dagger T$.  The inverse-equivalence identities
+    give (\ref{eq:inverse_gram_left}) and
+    (\ref{eq:inverse_gram_right}).  Together these equations characterize the
+    canonical inverse of a continuous linear endomorphism, which agrees with
+    its inverse in the endomorphism ring.
 \end{proof}
 
 \begin{definition}[Injective range-projector candidate]
@@ -365,7 +368,7 @@ orthogonal projector is the canonical representative used here.
 
 \begin{proof}
     \leanok
-    \uses{def:inverse_gram}
+    \uses{def:inverse_gram, thm:inverse_gram_identities}
     The vector $Q_Tx$ lies in $\range T$.  Moreover,
     $T^\dagger Q_Tx=(T^\dagger T)S_TT^\dagger x=T^\dagger x$, so for every
     $y$ the adjoint identity gives

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -517,7 +517,7 @@ for injective finite-dimensional maps is
 \leanid{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}, and the
 denominator estimate $\|(1-t)^{-1}\|\le(1-a)^{-1}$ under
 $\|t\|\le a<1$ is \leanid{NormedRing.norm_inverse_one_sub_le}.  For an injective
-$T$, the identities
+$T$, write $S_T:=(T^\dagger T)^{-1}$ for its inverse Gram operator.  The identities
 \leanid{ContinuousLinearMap.inverseGram_comp_adjoint_comp_self} and
 \leanid{ContinuousLinearMap.adjoint_comp_self_comp_inverseGram} show that
 $S_T$ is both a left and right inverse of $T^\dagger T$.

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -516,7 +516,20 @@ The generic identity
 for injective finite-dimensional maps is
 \leanid{ContinuousLinearMap.injectiveRangeProjector_eq_starProjection}, and the
 denominator estimate $\|(1-t)^{-1}\|\le(1-a)^{-1}$ under
-$\|t\|\le a<1$ is \leanid{NormedRing.norm_inverse_one_sub_le}.
+$\|t\|\le a<1$ is \leanid{NormedRing.norm_inverse_one_sub_le}.  For an injective
+$T$, the identities
+\leanid{ContinuousLinearMap.inverseGram_comp_adjoint_comp_self} and
+\leanid{ContinuousLinearMap.adjoint_comp_self_comp_inverseGram} show that
+$S_T$ is both a left and right inverse of $T^\dagger T$.
+The theorem \leanid{ContinuousLinearMap.inverseGram_eq_ringInverse} identifies
+it with the canonical ring inverse.  Consequently,
+\leanid{ContinuousLinearMap.norm_inverseGram_le_of_norm_one_sub_adjoint_comp_self_le}
+proves directly that
+\begin{align}
+  \lVert S_T\rVert&\le (1-a)^{-1}
+\end{align}
+whenever $\lVert 1-T^\dagger T\rVert\le a<1$.
+
 Suppose that $L_0>0$ and that $A$ is $L_0$-block injective.  Block
 injectivity then makes the Hilbert-space boundary map injective at every length
 $L\ge L_0$; this is recorded by

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 843, 885 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 846, 888 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 897, 939 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 843, 885 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 783, 825 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 897, 939 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- proves that `inverseGram T hT` is both a left and right inverse of the Gram operator $T^\dagger T$;
- identifies it with Mathlib's canonical continuous inverse and ring inverse;
- derives the quantitative bound
  $$
  \|\operatorname{inverseGram}(T)\|\le (1-a)^{-1}
  $$
  from $\|1-T^\dagger T\|\le a<1$, including the subsingleton-domain case;
- synchronizes the Chapter 13 inverse-Gram entries and the martingale paper-gap note.

## Source boundary

This is source-neutral inverse-Gram algebra for the route in #5752. It establishes the exact origin of the $(1-a)^{-1}$ denominator through Neumann control. It does not assert or reconstruct the FNW overlapping-window contraction.

## Verification

- `lake build TNLean.Analysis.InjectiveRangeProjector`
- Lean diagnostics and full local lint of the modified module
- `leanblueprint web`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv21_martingale_overlap.tex`
- tenkz disposition reconciliation and `git diff --check`

Refs #5752, #5455, #460, #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure analysis and documentation on an existing `inverseGram` API; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Adds **inverse-Gram algebra** for injective maps: left/right inverse lemmas for `inverseGram` against `T†T`, identification with Mathlib’s continuous and ring inverses, and **`norm_inverseGram_le_of_norm_one_sub_adjoint_comp_self_le`** bounding ‖inverseGram‖ by `(1-a)⁻¹` when ‖1 − T†T‖ ≤ a < 1 (via `NeumannInverse` and a subsingleton-domain branch). The range-projector proof is refactored to use the new right-inverse lemma instead of unfolding the linear equivalence.
> 
> Blueprint Chapter 13 gains **`thm:inverse_gram_identities`** and **`thm:inverse_gram_norm_bound`**, with the injective range-projector proof citing the identities. The martingale overlap paper-gap note documents the Lean names for inverse Gram and the norm bound. **`DISPOSITIONS.md`** line refs for `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` are updated after blueprint growth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052328bdc6b853424d716dba94183279e54ebc5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->