### PR TITLE
feat(MPS/MPU): identify reduced CFII transfer witnesses

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -44,6 +44,7 @@ import TNLean.Algebra.MatrixCongruence
 import TNLean.Algebra.MatrixFamilySupport
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.MatrixOperatorSpace
+import TNLean.Algebra.MatrixPosDefTransport
 import TNLean.Algebra.MatrixRankBaseChange
 import TNLean.Algebra.MatrixRankClosed
 import TNLean.Algebra.MatrixReindexUnitary

--- a/TNLean/Algebra/MatrixPosDefTransport.lean
+++ b/TNLean/Algebra/MatrixPosDefTransport.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Matrix.PosDef
+
+/-!
+# Positive-definite transport by rectangular unitary matrices
+
+This module records the positive-definite congruence needed when an isometric
+inclusion is known to fill its ambient finite-dimensional space.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace Matrix
+
+variable {m n : Type*} [Finite m] [Fintype n] [DecidableEq m]
+
+/-- Conjugating a positive-definite matrix by a rectangular matrix with a
+right inverse given by its conjugate transpose preserves positive definiteness. -/
+theorem PosDef.mul_mul_conjTranspose_of_mul_conjTranspose_eq_one
+    {A : Matrix n n ℂ} (hA : A.PosDef) (V : Matrix m n ℂ)
+    (hV : V * Vᴴ = 1) : (V * A * Vᴴ).PosDef := by
+  letI := Fintype.ofFinite m
+  apply hA.mul_mul_conjTranspose_same
+  intro x y hxy
+  have := congrArg (fun z => Matrix.vecMul z Vᴴ) hxy
+  simpa [Matrix.vecMul_vecMul, hV] using this
+
+end Matrix

--- a/TNLean/Algebra/MatrixTracePairing.lean
+++ b/TNLean/Algebra/MatrixTracePairing.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Matrix.Basis
 import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.LinearAlgebra.Dimension.Finite
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
@@ -25,6 +26,7 @@ linear map between matrix algebras.
   nonzero matrix span the full matrix algebra
 * `Matrix.submodule_sup_ne_top_of_mul_eq_zero` — two nonzero matrix subspaces with
   one-sided zero product cannot span the full matrix algebra
+* `Matrix.vec_one_dotProduct_vec_eq_trace` — vectorized identity pairing equals the trace
 * `Matrix.trace_mul_right_eq_zero_iff` — nondegeneracy of the trace pairing over `ℂ`
 * `Matrix.traceAdjointMap` — the trace-pairing adjoint of a linear map between matrix algebras
 * `Matrix.trace_traceAdjointMap_mul` — the adjoint satisfies `tr(E*(ρ) X) = tr(ρ E(X))`
@@ -35,6 +37,12 @@ linear map between matrix algebras.
 open scoped Matrix BigOperators
 
 namespace Matrix
+
+/-- Pairing the vectorized identity with a vectorized matrix gives its trace. -/
+theorem vec_one_dotProduct_vec_eq_trace {n : ℕ} (X : Matrix (Fin n) (Fin n) ℂ) :
+    (1 : Matrix (Fin n) (Fin n) ℂ).vec ⬝ᵥ X.vec = Matrix.trace X := by
+  classical
+  simp [dotProduct, Matrix.vec, Matrix.trace, Matrix.one_apply, Fintype.sum_prod_type]
 
 /-- **David/Perez-Garcia et al. Lemma `lem1` (two-sided nonzero matrix span).**
 

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -146,12 +146,6 @@ private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
 
 /-! ### Fundamental property: T̂ represents T in the vectorized picture -/
 
-/-- Pairing the vectorized identity with a vectorized matrix gives its trace. -/
-theorem Matrix.vec_one_dotProduct_vec_eq_trace (X : Matrix (Fin D) (Fin D) ℂ) :
-    (1 : Matrix (Fin D) (Fin D) ℂ).vec ⬝ᵥ X.vec = Matrix.trace X := by
-  classical
-  simp [dotProduct, Matrix.vec, Matrix.trace, Matrix.one_apply, Fintype.sum_prod_type]
-
 /-- The vectorized identity is a left fixed vector of the transfer matrix of a
 trace-preserving linear map. -/
 theorem vecMul_vec_one_transferMatrix_eq_of_trace_preserving

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -146,6 +146,31 @@ private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
 
 /-! ### Fundamental property: T̂ represents T in the vectorized picture -/
 
+/-- Pairing the vectorized identity with a vectorized matrix gives its trace. -/
+theorem Matrix.vec_one_dotProduct_vec_eq_trace (X : Matrix (Fin D) (Fin D) ℂ) :
+    (1 : Matrix (Fin D) (Fin D) ℂ).vec ⬝ᵥ X.vec = Matrix.trace X := by
+  classical
+  simp [dotProduct, Matrix.vec, Matrix.trace, Matrix.one_apply, Fintype.sum_prod_type]
+
+/-- The vectorized identity is a left fixed vector of the transfer matrix of a
+trace-preserving linear map. -/
+theorem vecMul_vec_one_transferMatrix_eq_of_trace_preserving
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hT : ∀ X, Matrix.trace (T X) = Matrix.trace X) :
+    Matrix.vecMul (1 : Matrix (Fin D) (Fin D) ℂ).vec (transferMatrix T) =
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec := by
+  classical
+  ext ⟨l, k⟩
+  rw [show Matrix.vecMul (1 : Matrix (Fin D) (Fin D) ℂ).vec (transferMatrix T) (l, k) =
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec ⬝ᵥ
+        (T (Matrix.single k l 1)).vec from rfl]
+  rw [Matrix.vec_one_dotProduct_vec_eq_trace, hT]
+  change Matrix.trace (Matrix.single k l 1) = if k = l then 1 else 0
+  by_cases hkl : k = l
+  · subst l
+    rw [if_pos rfl, Matrix.trace_single_eq_same]
+  · rw [if_neg hkl, Matrix.trace_single_eq_of_ne (i := k) (j := l) (c := (1 : ℂ)) hkl]
+
 /-- **Key property**: the transfer matrix faithfully represents `T`:
 `(T̂ *ᵥ vec(ρ)) = vec(T(ρ))`.
 

--- a/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
+++ b/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
@@ -45,12 +45,12 @@ variable {d D : ℕ} {A : MPSTensor d D}
 namespace CPSVCanonicalFormData
 
 /-- The inclusion of a retained canonical block into the ambient bond space. -/
-private noncomputable def ambientBlockInclusion (data : CPSVCanonicalFormData A) (k : Fin data.r) :
+noncomputable def ambientBlockInclusion (data : CPSVCanonicalFormData A) (k : Fin data.r) :
     Matrix (Fin D) (Fin (data.dim k)) ℂ :=
   data.ambient_coisometryᴴ * blockInclusion data.dim k
 
 /-- A retained block inclusion into the ambient bond space is an isometry. -/
-private theorem ambientBlockInclusion_conjTranspose_mul_self
+theorem ambientBlockInclusion_conjTranspose_mul_self
     (data : CPSVCanonicalFormData A) (k : Fin data.r) :
     (data.ambientBlockInclusion k)ᴴ * data.ambientBlockInclusion k = 1 := by
   rw [ambientBlockInclusion, Matrix.conjTranspose_mul]
@@ -59,7 +59,7 @@ private theorem ambientBlockInclusion_conjTranspose_mul_self
     data.coisometric, Matrix.one_mul, blockInclusion_conjTranspose_mul_self]
 
 /-- Ambient inclusions of distinct retained blocks have orthogonal ranges. -/
-private theorem ambientBlockInclusion_conjTranspose_mul_eq_zero
+theorem ambientBlockInclusion_conjTranspose_mul_eq_zero
     (data : CPSVCanonicalFormData A) {k l : Fin data.r} (hkl : k ≠ l) :
     (data.ambientBlockInclusion k)ᴴ * data.ambientBlockInclusion l = 0 := by
   rw [ambientBlockInclusion, ambientBlockInclusion, Matrix.conjTranspose_mul]
@@ -70,7 +70,7 @@ private theorem ambientBlockInclusion_conjTranspose_mul_eq_zero
 
 /-- The CPSV reconstruction intertwines an ambient block inclusion with the
 corresponding weighted canonical block. -/
-private theorem mul_ambientBlockInclusion
+theorem mul_ambientBlockInclusion
     (data : CPSVCanonicalFormData A) (k : Fin data.r) (i : Fin d) :
     A i * data.ambientBlockInclusion k =
       data.ambientBlockInclusion k * (data.weights k • data.blocks k i) := by
@@ -165,7 +165,7 @@ private theorem transferMap_blockFixedVector (data : CPSVCanonicalFormData A) (k
     (exists_nonzero_transferMap_fixedVector_of_normal (data.blocks_normal k))).2
 
 /-- The transfer eigenvalue contributed by a weighted active block. -/
-private noncomputable def activeTransferEigenvalue
+noncomputable def activeTransferEigenvalue
     (data : CPSVCanonicalFormData A) (k : data.Active) : ℂ :=
   data.weights k.1 * starRingEnd ℂ (data.weights k.1)
 
@@ -212,14 +212,14 @@ private theorem transferMap_ambientActiveVector
   simp [Matrix.mul_smul, Matrix.smul_mul]
 
 /-- An active block's weighted transfer eigenvalue is nonzero. -/
-private theorem activeTransferEigenvalue_ne
+theorem activeTransferEigenvalue_ne
     (data : CPSVCanonicalFormData A) (k : data.Active) :
     data.activeTransferEigenvalue k ≠ 0 := by
   simp [activeTransferEigenvalue, k.2]
 
 /-- Shifted ambient transfer traces normalize every active weighted-block
 eigenvalue to one. -/
-private theorem activeTransferEigenvalue_eq_one
+theorem activeTransferEigenvalue_eq_one
     (data : CPSVCanonicalFormData A)
     (htrace : ∀ N, 1 < N →
       Matrix.trace (transferMatrix (transferMap A) ^ N) = 1)

--- a/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
+++ b/TNLean/MPS/MPU/ActiveTransferMultiplicity.lean
@@ -59,7 +59,7 @@ theorem ambientBlockInclusion_conjTranspose_mul_self
     data.coisometric, Matrix.one_mul, blockInclusion_conjTranspose_mul_self]
 
 /-- Ambient inclusions of distinct retained blocks have orthogonal ranges. -/
-theorem ambientBlockInclusion_conjTranspose_mul_eq_zero
+private theorem ambientBlockInclusion_conjTranspose_mul_eq_zero
     (data : CPSVCanonicalFormData A) {k l : Fin data.r} (hkl : k ≠ l) :
     (data.ambientBlockInclusion k)ᴴ * data.ambientBlockInclusion l = 0 := by
   rw [ambientBlockInclusion, ambientBlockInclusion, Matrix.conjTranspose_mul]
@@ -212,7 +212,7 @@ private theorem transferMap_ambientActiveVector
   simp [Matrix.mul_smul, Matrix.smul_mul]
 
 /-- An active block's weighted transfer eigenvalue is nonzero. -/
-theorem activeTransferEigenvalue_ne
+private theorem activeTransferEigenvalue_ne
     (data : CPSVCanonicalFormData A) (k : data.Active) :
     data.activeTransferEigenvalue k ≠ 0 := by
   simp [activeTransferEigenvalue, k.2]

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -210,6 +210,36 @@ theorem isIrreducibleTensor_of_active_dim_eq
   funext i
   rw [hrec i, hinv, Algebra.mul_smul_comm, Algebra.smul_mul_assoc]
 
+/-- Under full active support, the unique active block has the ambient bond dimension. -/
+theorem active_dim_eq_of_card_active_eq_one_of_fullActiveSupport
+    (data : CPSVCanonicalFormData A) (hcard : Fintype.card data.Active = 1)
+    (hfull : data.HasFullActiveSupport) (k : data.Active) :
+    data.dim k.1 = D := by
+  classical
+  letI : Unique data.Active :=
+    Classical.choice (Fintype.card_eq_one_iff_nonempty_unique.mp hcard)
+  have hk : k = default := Subsingleton.elim _ _
+  have hsum : (∑ j : data.Active, data.dim j.1) = data.dim k.1 := by
+    rw [hk]
+    exact Fintype.sum_unique (fun j : data.Active => data.dim j.1)
+  exact hsum.symm.trans hfull
+
+/-- Under full active support, the unique active block inclusion is onto as well
+as isometric. -/
+theorem ambientBlockInclusion_mul_conjTranspose_eq_one
+    (data : CPSVCanonicalFormData A) (hcard : Fintype.card data.Active = 1)
+    (hfull : data.HasFullActiveSupport) (k : data.Active) :
+    data.ambientBlockInclusion k.1 * (data.ambientBlockInclusion k.1)ᴴ = 1 := by
+  have hdim := data.active_dim_eq_of_card_active_eq_one_of_fullActiveSupport
+    hcard hfull k
+  have hcarddim : Fintype.card (Fin D) = Fintype.card (Fin (data.dim k.1)) := by
+    simp [hdim]
+  exact (Matrix.mul_eq_one_comm_of_card_eq
+      (Fin D) (Fin (data.dim k.1)) ℂ
+      (A := data.ambientBlockInclusion k.1)
+      (B := (data.ambientBlockInclusion k.1)ᴴ) hcarddim).mpr
+    (data.ambientBlockInclusion_conjTranspose_mul_self k.1)
+
 /-- Full active support and a unique active block force ambient tensor irreducibility.
 
 **Scope restriction (unique full-support active block):** This is the algebraic

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.MatrixStabilization
+import TNLean.Algebra.MatrixPosDefTransport
+import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.TransferMatrix
 
 /-!
@@ -35,7 +37,7 @@ right fixed witnesses.
   Symmetries, and Topological Invariants", lines 397--409.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder
 open Polynomial
 
 namespace MPOTensor
@@ -100,6 +102,133 @@ theorem IsMPU.exists_normalized_transfer_stabilizes_to_rank_one
     data.power_eq, data.stable⟩
   rw [dotProduct_comm]
   exact data.pairing_eq_one
+
+/-- A chosen reduced canonical-form-II representative supplies the positive
+right fixed matrix and identity left fixed vector that factor the exact stabilized
+normalized transfer power.
+
+The active block and the equation transporting its normalized diagonal fixed
+matrix into the ambient bond space are retained explicitly in the conclusion.
+The ambient matrix is positive definite, but is not asserted to be diagonal.
+
+**Scope restriction (full active support):** This is the reduced-representative
+route in arXiv:1703.09188, equation `Erightleft` (lines 269--280) and lines
+397--405. See `docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
+theorem IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D)
+    (cfii : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
+    (hfull : cfii.toCPSVCanonicalFormData.HasFullActiveSupport) :
+    ∃ (k : cfii.toCPSVCanonicalFormData.Active)
+      (Λ : Matrix (Fin (cfii.dim k.1)) (Fin (cfii.dim k.1)) ℂ)
+      (ρ : Matrix (Fin D) (Fin D) ℂ),
+      (∀ l : cfii.toCPSVCanonicalFormData.Active, l = k) ∧
+      Λ.PosDef ∧ Λ.IsDiag ∧ Matrix.trace Λ = 1 ∧
+      MPSTensor.transferMap (cfii.blocks k.1) Λ = Λ ∧
+      ρ = cfii.ambientBlockInclusion k.1 * Λ *
+        (cfii.ambientBlockInclusion k.1)ᴴ ∧
+      ρ.PosDef ∧ Matrix.trace ρ = 1 ∧
+      MPSTensor.transferMap U.normalizedFlattening ρ = ρ ∧
+      Matrix.vecMul (1 : Matrix (Fin D) (Fin D) ℂ).vec
+        (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) =
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec ∧
+      transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ (D * D - 1) =
+        Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec := by
+  classical
+  let base := cfii.toCPSVCanonicalFormData
+  have htrace : ∀ N : ℕ, 1 < N →
+      Matrix.trace
+        (transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ N) = 1 :=
+    fun N hN => hU.trace_transferMatrix_normalizedFlattening_pow_eq_one hN
+  have hcard : Fintype.card base.Active = 1 :=
+    base.card_active_eq_one_of_shifted_transfer_trace htrace
+  letI : Unique base.Active :=
+    Classical.choice (Fintype.card_eq_one_iff_nonempty_unique.mp hcard)
+  let k : base.Active := default
+  obtain ⟨Λ₀, hΛ₀pd, hΛ₀diag, hΛ₀fix⟩ := cfii.blocks_fixed_point k.1
+  letI : Nonempty (Fin (cfii.dim k.1)) := Fin.pos_iff_nonempty.mp (cfii.dim_pos k.1)
+  let Λ : Matrix (Fin (cfii.dim k.1)) (Fin (cfii.dim k.1)) ℂ :=
+    (Matrix.trace Λ₀)⁻¹ • Λ₀
+  have hΛtrace_pos : 0 < Matrix.trace Λ₀ := hΛ₀pd.trace_pos
+  have hΛtrace_ne : Matrix.trace Λ₀ ≠ 0 := ne_of_gt hΛtrace_pos
+  have hΛpd : Λ.PosDef := hΛ₀pd.smul (inv_pos.mpr hΛtrace_pos)
+  have hΛdiag : Λ.IsDiag := hΛ₀diag.smul _
+  have hΛtrace : Matrix.trace Λ = 1 := by
+    simp [Λ, Matrix.trace_smul, hΛtrace_ne]
+  have hΛfix : MPSTensor.transferMap (cfii.blocks k.1) Λ = Λ := by
+    simp only [Λ, map_smul, hΛ₀fix]
+  have hweight : base.activeTransferEigenvalue k = 1 :=
+    base.activeTransferEigenvalue_eq_one htrace k
+  have hweight' : cfii.weights k.1 * starRingEnd ℂ (cfii.weights k.1) = 1 := by
+    simpa [base, MPSTensor.CPSVCanonicalFormData.activeTransferEigenvalue] using hweight
+  have hweightedFix :
+      MPSTensor.transferMap (fun i => cfii.weights k.1 • cfii.blocks k.1 i) Λ = Λ := by
+    rw [MPSTensor.transferMap_smul, hΛfix, hweight', one_smul]
+  let V := base.ambientBlockInclusion k.1
+  let ρ : Matrix (Fin D) (Fin D) ℂ := V * Λ * Vᴴ
+  have hVstarV : Vᴴ * V = 1 :=
+    base.ambientBlockInclusion_conjTranspose_mul_self k.1
+  have hVVstar : V * Vᴴ = 1 :=
+    base.ambientBlockInclusion_mul_conjTranspose_eq_one hcard hfull k
+  have hρpd : ρ.PosDef :=
+    hΛpd.mul_mul_conjTranspose_of_mul_conjTranspose_eq_one V hVVstar
+  have hρtrace : Matrix.trace ρ = 1 := by
+    change Matrix.trace (V * Λ * Vᴴ) = 1
+    rw [Matrix.trace_mul_comm (V * Λ) Vᴴ, ← Matrix.mul_assoc, hVstarV,
+      Matrix.one_mul, hΛtrace]
+  have hρfix : MPSTensor.transferMap U.normalizedFlattening ρ = ρ := by
+    change MPSTensor.transferMap U.normalizedFlattening (V * Λ * Vᴴ) = V * Λ * Vᴴ
+    rw [MPSTensor.transferMap_conj_of_intertwine U.normalizedFlattening
+      (fun i => cfii.weights k.1 • cfii.blocks k.1 i) V
+      (base.mul_ambientBlockInclusion k.1) Λ, hweightedFix]
+  have hweightedLeft :
+      MPSTensor.IsLeftCanonical (fun i => cfii.weights k.1 • cfii.blocks k.1 i) := by
+    unfold MPSTensor.IsLeftCanonical
+    simp only [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+    rw [← Finset.smul_sum, cfii.blocks_left_canonical k.1]
+    have hweightStar : cfii.weights k.1 * star (cfii.weights k.1) = 1 := by
+      simpa using hweight'
+    rw [hweightStar, one_smul]
+  have hAeq : ∀ i, U.normalizedFlattening i =
+      V * (cfii.weights k.1 • cfii.blocks k.1 i) * Vᴴ := by
+    intro i
+    calc
+      U.normalizedFlattening i = U.normalizedFlattening i * 1 := by rw [Matrix.mul_one]
+      _ = U.normalizedFlattening i * (V * Vᴴ) := by rw [hVVstar]
+      _ = (U.normalizedFlattening i * V) * Vᴴ := by rw [Matrix.mul_assoc]
+      _ = V * (cfii.weights k.1 • cfii.blocks k.1 i) * Vᴴ := by
+        rw [base.mul_ambientBlockInclusion k.1]
+  have hAleft : MPSTensor.IsLeftCanonical U.normalizedFlattening := by
+    unfold MPSTensor.IsLeftCanonical at hweightedLeft ⊢
+    calc
+      ∑ i, (U.normalizedFlattening i)ᴴ * U.normalizedFlattening i =
+          ∑ i, V * ((cfii.weights k.1 • cfii.blocks k.1 i)ᴴ *
+            (cfii.weights k.1 • cfii.blocks k.1 i)) * Vᴴ := by
+        apply Finset.sum_congr rfl
+        intro i _
+        rw [hAeq i, Matrix.conjTranspose_mul, Matrix.conjTranspose_mul]
+        simp only [Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+        rw [← Matrix.mul_assoc Vᴴ V, hVstarV, Matrix.one_mul]
+      _ = V * (∑ i, (cfii.weights k.1 • cfii.blocks k.1 i)ᴴ *
+            (cfii.weights k.1 • cfii.blocks k.1 i)) * Vᴴ := by
+        rw [Matrix.mul_sum, Matrix.sum_mul]
+      _ = 1 := by rw [hweightedLeft, Matrix.mul_one, hVVstar]
+  have hleft : Matrix.vecMul (1 : Matrix (Fin D) (Fin D) ℂ).vec
+      (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) =
+        (1 : Matrix (Fin D) (Fin D) ℂ).vec :=
+    vecMul_vec_one_transferMatrix_eq_of_trace_preserving _
+      (fun X => MPSTensor.trace_transferMap U.normalizedFlattening X hAleft)
+  have hright : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) *ᵥ ρ.vec =
+      ρ.vec := by
+    rw [transferMatrix_mulVec_eq, hρfix]
+  have hpair : (1 : Matrix (Fin D) (Fin D) ℂ).vec ⬝ᵥ ρ.vec = 1 := by
+    rw [Matrix.vec_one_dotProduct_vec_eq_trace, hρtrace]
+  have hpower := (hU.normalizedTransferStabilization hD).power_eq_vec_mul_vec_of_fixed
+    ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec hpair hright hleft
+  change transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ (D * D - 1) =
+    Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec at hpower
+  refine ⟨k, Λ, ρ, fun l => Subsingleton.elim _ _, hΛpd, hΛdiag, hΛtrace,
+    hΛfix, rfl, hρpd, hρtrace, hρfix, hleft, ?_⟩
+  simpa using hpower
 
 /-- In bond dimension one, the normalized transfer matrix of an MPU is the identity.
 

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -186,11 +186,21 @@ theorem IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii
   have hweightedLeft :
       MPSTensor.IsLeftCanonical (fun i => cfii.weights k.1 • cfii.blocks k.1 i) := by
     unfold MPSTensor.IsLeftCanonical
-    simp only [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
-    rw [← Finset.smul_sum, cfii.blocks_left_canonical k.1]
     have hweightStar : cfii.weights k.1 * star (cfii.weights k.1) = 1 := by
       simpa using hweight'
-    rw [hweightStar, one_smul]
+    have hweightStarComm : star (cfii.weights k.1) * cfii.weights k.1 = 1 := by
+      rw [mul_comm, hweightStar]
+    calc
+      ∑ i, (cfii.weights k.1 • cfii.blocks k.1 i)ᴴ *
+          (cfii.weights k.1 • cfii.blocks k.1 i) =
+          ∑ i, (star (cfii.weights k.1) * cfii.weights k.1) •
+            ((cfii.blocks k.1 i)ᴴ * cfii.blocks k.1 i) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        rw [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+      _ = (star (cfii.weights k.1) * cfii.weights k.1) • 1 := by
+        rw [← Finset.smul_sum, cfii.blocks_left_canonical k.1]
+      _ = 1 := by rw [hweightStarComm, one_smul]
   have hAeq : ∀ i, U.normalizedFlattening i =
       V * (cfii.weights k.1 • cfii.blocks k.1 i) * Vᴴ := by
     intro i

--- a/TNLean/MPS/MPU/TransferStabilization.lean
+++ b/TNLean/MPS/MPU/TransferStabilization.lean
@@ -28,6 +28,9 @@ right fixed witnesses.
 
 * `MPOTensor.IsMPU.exists_normalized_transfer_stabilizes_to_rank_one` gives
   the source-shaped bounded stabilization theorem.
+* `MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii`
+  identifies the stabilized power with the fixed pair supplied by chosen
+  reduced canonical-form-II data.
 * `MPOTensor.IsMPU.normalized_transfer_matrix_eq_one_fin_one` proves that the
   one-dimensional normalized transfer matrix is the identity.
 

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -60,6 +60,51 @@
     \end{align}
 \end{proof}
 
+\begin{theorem}[Positive-definite transport by a coisometry]
+    \label{thm:matrix_posdef_coisometric_transport}
+    \lean{Matrix.PosDef.mul_mul_conjTranspose_of_mul_conjTranspose_eq_one}
+    \leanok
+    Let $A>0$ be a square complex matrix and let $V$ be a possibly rectangular
+    matrix satisfying $VV^\dagger=\Id$. Then
+    \begin{align}
+        VAV^\dagger&>0.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    For a row vector $x$, one has
+    \begin{align}
+        x(VAV^\dagger)x^\dagger&=(xV)A(xV)^\dagger.
+    \end{align}
+    Moreover, $xV=0$ implies
+    \begin{align}
+        x&=x(VV^\dagger)=0.
+    \end{align}
+    Thus every nonzero $x$ gives $xV\ne0$, and positive definiteness of $A$
+    makes the displayed quadratic form strictly positive.
+\end{proof}
+
+\begin{lemma}[Vectorized identity realizes the trace pairing]
+    \label{lem:matrix_vec_identity_trace_pairing}
+    \lean{Matrix.vec_one_dotProduct_vec_eq_trace}
+    \leanok
+    For every square complex matrix $X$,
+    \begin{align}
+        \operatorname{vec}(\Id)\mathbin{\boldsymbol\cdot}
+            \operatorname{vec}(X)&=\tr(X).
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Expanding column stacking gives
+    \begin{align}
+        \sum_{i,j}(\Id)_{ij}X_{ij}
+        &=\sum_{i,j}\delta_{ij}X_{ij}
+         =\sum_iX_{ii}
+         =\tr(X).
+    \end{align}
+\end{proof}
+
 \begin{lemma}[Pairwise orthogonality from a projection resolution]
     \label{lem:orthogonal_projection_mul_eq_zero_of_sum_eq_one}
     \lean{orthogonalProjection_mul_eq_zero_of_sum_eq_one}

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -84,8 +84,8 @@
     makes the displayed quadratic form strictly positive.
 \end{proof}
 
-\begin{lemma}[Vectorized identity realizes the trace pairing]
-    \label{lem:matrix_vec_identity_trace_pairing}
+\begin{theorem}[Vectorized identity realizes the trace pairing]
+    \label{thm:matrix_vec_identity_trace_pairing}
     \lean{Matrix.vec_one_dotProduct_vec_eq_trace}
     \leanok
     For every square complex matrix $X$,
@@ -93,7 +93,7 @@
         \operatorname{vec}(\Id)\mathbin{\boldsymbol\cdot}
             \operatorname{vec}(X)&=\tr(X).
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Expanding column stacking gives

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1463,7 +1463,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_reduced_cfii_transfer_stabilization}
     \lean{MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii}
     \leanok
-    \uses{def:mpu,def:mpu_normalized_flattening}
+    \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
+        def:mpu_full_active_support}
     Suppose $d>0$, $D>1$, and $\mathcal U$ is an MPU whose normalized
     flattening is presented by chosen canonical-form-II data with active blocks
     filling the bond space. There is a
@@ -1493,8 +1494,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpu_full_active_support,
-        thm:mpu_shifted_transfer_trace_card_active,
+    \uses{thm:mpu_shifted_transfer_trace_card_active,
         thm:mpu_normalized_transfer_stabilization,
         thm:mpu_stabilized_fixed_pair_uniqueness}
     The shifted trace identities select one active block. Full active support

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1498,16 +1498,54 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         thm:mpu_shifted_transfer_trace_card_active,
         thm:mpu_normalized_transfer_stabilization,
         thm:mpu_stabilized_fixed_pair_uniqueness}
-    The shifted trace identities select one active block. Full active support
-    makes its isometric inclusion onto, so conjugation by that inclusion
-    preserves positive definiteness and trace. Normalize the block fixed point
-    before conjugating it. The active weight has squared modulus one, hence the
-    intertwining equation transports block fixedness to $E(\rho)=\rho$.
-    Transporting the blockwise left-canonical identity shows that the ambient
-    transfer map preserves trace, so the vectorized identity is left fixed and
-    its pairing with $\rho$ is $\tr(\rho)=1$. Uniqueness of the normalized
-    fixed-pair factorization now identifies the stabilized power with
-    $\lvert\rho)(\Phi\rvert$.
+    The shifted trace identities give
+    \begin{align}
+        \tr(E^N)=1\quad(N>1)
+        \quad\Longrightarrow\quad
+        \operatorname{card}(\mathrm{Active})=1.
+    \end{align}
+    Let $k$ be this active block. Canonical form II supplies a diagonal
+    $\Lambda_0>0$ fixed by the unweighted block transfer map. Normalize it by
+    \begin{align}
+        \Lambda&=\tr(\Lambda_0)^{-1}\Lambda_0,
+        &\tr(\Lambda)&=1.
+    \end{align}
+    If $\omega_k$ is the active weight, then
+    \begin{align}
+        \lvert\omega_k\rvert^2&=1,
+        &E_k(\Lambda)&=\Lambda,
+    \end{align}
+    where $E_k$ is the transfer map of the weighted block
+    $\widetilde B_k=\omega_k B_k$. Full active support makes the block inclusion
+    $V=V_k$ both isometric and onto:
+    \begin{align}
+        V^\dagger V&=I,
+        &VV^\dagger&=I.
+    \end{align}
+    Hence $\rho=V\Lambda V^\dagger$ is positive definite with trace one, and
+    the intertwining equations $A_iV=V\widetilde B_k(i)$ give the fixedness
+    transport
+    \begin{align}
+        E(V\Lambda V^\dagger)
+        &=V E_k(\Lambda)V^\dagger
+         =V\Lambda V^\dagger
+         =\rho.
+    \end{align}
+    The blockwise left-canonical identity transports similarly:
+    \begin{align}
+        \sum_i \widetilde B_k(i)^\dagger\widetilde B_k(i)=I
+        \quad\Longrightarrow\quad
+        \sum_i A_i^\dagger A_i=I
+        \quad\Longrightarrow\quad
+        (\Phi\rvert E=(\Phi\rvert.
+    \end{align}
+    Finally,
+    \begin{align}
+        (\Phi\mid\rho)&=\tr(\rho)=1,
+        &E^{D^2-1}&=\lvert\rho)(\Phi\rvert,
+    \end{align}
+    where the last equality is the uniqueness of the normalized fixed-pair
+    factorization for the stabilized power.
 \end{proof}
 
 \begin{theorem}[One-dimensional normalized transfer matrix]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1461,26 +1461,49 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{lemma}[Identification with chosen reduced-CFII fixed points]
     \label{lem:mpu_reduced_cfii_transfer_stabilization}
-    Suppose the normalized flattening is presented by a chosen canonical-form-II
-    representative whose active blocks fill the bond space. Let $\rho$ and
-    $\Phi$ be the diagonal positive right fixed point and the identity left
-    fixed point supplied by that representative, normalized by
-    $(\Phi\mid\rho)=1$. Then
+    \lean{MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii}
+    \leanok
+    Suppose $D>1$ and the normalized flattening is presented by chosen
+    canonical-form-II data whose active blocks fill the bond space. There is a
+    unique active block $k$. Normalize its diagonal positive definite fixed
+    matrix $\Lambda_k$ to have trace one, and let $V_k$ be its inclusion into
+    the ambient bond space. Then
+    \begin{align}
+        \rho&=V_k\Lambda_kV_k^\dagger,
+        &\rho&>0,
+        &\tr(\rho)&=1,\\
+        E\lvert\rho)&=\lvert\rho),
+        &(\Phi\rvert E&=(\Phi\rvert,
+        &(\Phi\mid\rho)&=1,
+    \end{align}
+    where $(\Phi\rvert$ is the vectorized identity. Consequently,
     \begin{align}
         E^{D^2-1}=\lvert\rho)(\Phi\rvert.
     \end{align}
-    This is a statement about the chosen reduced representative; it does not
-    assert that every ambient MPU tensor is itself in canonical form II.
+    % Source labels: Erightleft and prop:normal-tensor.
+    The diagonal matrix is the block matrix $\Lambda_k$ in the canonical-form-II
+    equations of \cite[lines 269--280]{Cirac2017MPU}; its ambient transport
+    $\rho$ need not be diagonal. This is a statement about the chosen reduced
+    representative and the blocking step in
+    \cite[proof of Proposition~III.2(ii)]{Cirac2017MPU}; it does not assert
+    that every ambient MPU tensor is itself in canonical form II.
 \end{lemma}
 
-\begin{proof}
-    \uses{thm:mpu_normalized_transfer_stabilization,
+\begin{proof}\leanok
+    \uses{def:mpu_full_active_support,
+        thm:mpu_shifted_transfer_trace_card_active,
+        thm:mpu_normalized_transfer_stabilization,
         thm:mpu_stabilized_fixed_pair_uniqueness}
-    The finite-blocking theorem shows that every normalized left and right fixed
-    pair factors the stabilized projector. It remains to transport the
-    blockwise canonical-form-II fixed points through the full-support ambient
-    reconstruction and prove the displayed pairing and fixed equations.
-    % Formalization of this remaining step is tracked in GitHub issue #5786.
+    The shifted trace identities select one active block. Full active support
+    makes its isometric inclusion onto, so conjugation by that inclusion
+    preserves positive definiteness and trace. Normalize the block fixed point
+    before conjugating it. The active weight has squared modulus one, hence the
+    intertwining equation transports block fixedness to $E(\rho)=\rho$.
+    Transporting the blockwise left-canonical identity shows that the ambient
+    transfer map preserves trace, so the vectorized identity is left fixed and
+    its pairing with $\rho$ is $\tr(\rho)=1$. Uniqueness of the normalized
+    fixed-pair factorization now identifies the stabilized power with
+    $\lvert\rho)(\Phi\rvert$.
 \end{proof}
 
 \begin{theorem}[One-dimensional normalized transfer matrix]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1066,7 +1066,7 @@ $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:matrix_vec_identity_trace_pairing}
+    \uses{thm:matrix_vec_identity_trace_pairing}
     On the column indexed by the matrix unit $E_{k\ell}$,
     \begin{align}
         \bigl((\Phi\rvert\widehat T\bigr)_{(\ell,k)}
@@ -1595,7 +1595,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii}
     \leanok
     \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
-        def:mpu_full_active_support}
+        def:mpu_full_active_support,def:mpu_ambient_block_inclusion}
     Suppose $d>0$, $D>1$, and $\mathcal U$ is an MPU whose normalized
     flattening is presented by chosen canonical-form-II data with active blocks
     filling the bond space. There is a
@@ -1628,10 +1628,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \uses{thm:mpu_normalized_transfer_trace,
         thm:mpu_shifted_transfer_trace_card_active,
         thm:mpu_active_transfer_eigenvalue_one,
+        thm:mpu_ambient_block_isometry_intertwining,
         thm:mpu_unique_active_full_support_geometry,
         thm:matrix_posdef_coisometric_transport,
-        lem:matrix_vec_identity_trace_pairing,
+        lem:transfer_map_corner_intertwine,
         thm:transfer_matrix_trace_preserving_identity_left_fixed,
+        thm:mpu_transfer_matrix_vectorization,
+        thm:matrix_vec_identity_trace_pairing,
         thm:mpu_normalized_transfer_stabilization,
         thm:mpu_stabilized_fixed_pair_uniqueness}
     The shifted trace identities satisfy $\tr(E^N)=1$ for every integer

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1463,6 +1463,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_reduced_cfii_transfer_stabilization}
     \lean{MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii}
     \leanok
+    \uses{def:mpu,def:mpu_normalized_flattening}
     Suppose $d>0$, $D>1$, and $\mathcal U$ is an MPU whose normalized
     flattening is presented by chosen canonical-form-II data with active blocks
     filling the bond space. There is a
@@ -1483,7 +1484,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     % Source labels: Erightleft and prop:normal-tensor.
     The diagonal matrix is the block matrix $\Lambda_k$ in the canonical-form-II
-    fixed-point equations in \cite[equations~(6a)--(6b)]{Cirac2017MPU}; its ambient transport
+    fixed-point equations in
+    \cite[equations~(6a)--(6b)]{Cirac2017MPU}; its ambient transport
     $\rho$ need not be diagonal. This is a statement about the chosen reduced
     representative and the blocking step in
     \cite[proof of Proposition~III.2(ii)]{Cirac2017MPU}; it does not assert
@@ -1491,8 +1493,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpu,def:mpu_normalized_flattening,
-        def:mpu_full_active_support,
+    \uses{def:mpu_full_active_support,
         thm:mpu_shifted_transfer_trace_card_active,
         thm:mpu_normalized_transfer_stabilization,
         thm:mpu_stabilized_fixed_pair_uniqueness}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1053,6 +1053,32 @@ $T:M_D(\mathbb C)\to M_D(\mathbb C)$ be a linear map.
     coordinate.
 \end{proof}
 
+\begin{theorem}[Trace preservation fixes the vectorized identity on the left]
+    \label{thm:transfer_matrix_trace_preserving_identity_left_fixed}
+    \lean{vecMul_vec_one_transferMatrix_eq_of_trace_preserving}
+    \leanok
+    \uses{def:mpu_transfer_matrix,def:trace_preserving}
+    If $T:M_D(\mathbb C)\to M_D(\mathbb C)$ preserves trace and
+    $(\Phi\rvert=\operatorname{vec}(\Id)^{\mathsf T}$, then
+    \begin{align}
+        (\Phi\rvert\widehat T&=(\Phi\rvert.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:matrix_vec_identity_trace_pairing}
+    On the column indexed by the matrix unit $E_{k\ell}$,
+    \begin{align}
+        \bigl((\Phi\rvert\widehat T\bigr)_{(\ell,k)}
+        &=\operatorname{vec}(\Id)\mathbin{\boldsymbol\cdot}
+            \operatorname{vec}(T(E_{k\ell}))\\
+        &=\tr(T(E_{k\ell}))
+         =\tr(E_{k\ell})
+         =\delta_{k\ell}.
+    \end{align}
+    These are precisely the coordinates of $(\Phi\rvert$.
+\end{proof}
+
 \begin{theorem}[Powers and traces of transfer matrices]
     \label{thm:mpu_transfer_matrix_power_trace}
     \lean{transferMatrix_pow,trace_transferMatrix_eq_linearMap_trace}
@@ -1256,6 +1282,111 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     between dependent pairs and flattened coordinates.  Transporting its
     isometry, cross-block orthogonality, and block-diagonal intertwining
     identities gives the three displayed formulas.
+\end{proof}
+
+\begin{definition}[Ambient inclusion of a canonical block]
+    \label{def:mpu_ambient_block_inclusion}
+    \lean{MPSTensor.CPSVCanonicalFormData.ambientBlockInclusion}
+    \leanok
+    \uses{def:cpsv_canonical_form,def:mpu_dependent_block_inclusion}
+    If $U$ is the reconstruction coisometry and $J_k$ is the inclusion of the
+    $k$th retained block, define
+    \begin{align}
+        V_k&=U^\dagger J_k.
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Ambient block isometry and intertwining]
+    \label{thm:mpu_ambient_block_isometry_intertwining}
+    \lean{MPSTensor.CPSVCanonicalFormData.ambientBlockInclusion_conjTranspose_mul_self,
+        MPSTensor.CPSVCanonicalFormData.mul_ambientBlockInclusion}
+    \leanok
+    \uses{def:cpsv_canonical_form,def:mpu_ambient_block_inclusion}
+    For every retained block and physical index $i$,
+    \begin{align}
+        V_k^\dagger V_k&=\Id,\\
+        A^iV_k&=V_k(\mu_k A_k^i).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_dependent_block_inclusion_identities}
+    The coisometry $UU^\dagger=\Id$ and $J_k^\dagger J_k=\Id$ give
+    \begin{align}
+        V_k^\dagger V_k
+        &=J_k^\dagger UU^\dagger J_k
+         =J_k^\dagger J_k
+         =\Id.
+    \end{align}
+    The canonical reconstruction and block-diagonal intertwining give
+    \begin{align}
+        A^iV_k
+        &=U^\dagger\Bigl(\bigoplus_j\mu_jA_j^i\Bigr)J_k
+         =U^\dagger J_k(\mu_kA_k^i)
+         =V_k(\mu_kA_k^i).
+    \end{align}
+\end{proof}
+
+\begin{definition}[Active weighted-block transfer eigenvalue]
+    \label{def:mpu_active_transfer_eigenvalue}
+    \lean{MPSTensor.CPSVCanonicalFormData.activeTransferEigenvalue}
+    \leanok
+    \uses{def:cpsv_canonical_form}
+    For an active block $k$, define its weighted transfer eigenvalue by
+    \begin{align}
+        q_k&=\mu_k\overline{\mu_k}=\lvert\mu_k\rvert^2.
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Shifted traces normalize every active weight]
+    \label{thm:mpu_active_transfer_eigenvalue_one}
+    \lean{MPSTensor.CPSVCanonicalFormData.activeTransferEigenvalue_eq_one}
+    \leanok
+    \uses{def:mpu_active_transfer_eigenvalue,def:mpu_transfer_matrix}
+    If the ambient transfer matrix satisfies $\tr(E^N)=1$ for every integer
+    $N>1$, then every active block satisfies
+    \begin{align}
+        q_k&=1.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_ambient_block_isometry_intertwining,
+        thm:mpu_shifted_trace_power_spectrum,
+        thm:mpu_transfer_matrix_eigenvalues}
+    Choose a nonzero fixed matrix $X_k$ for the unweighted normal block and set
+    $Y_k=V_kX_kV_k^\dagger$. The isometry and intertwining identities give
+    \begin{align}
+        Y_k&\ne0,
+        &E(Y_k)&=q_kY_k.
+    \end{align}
+    Thus $q_k$ lies in the ambient transfer spectrum; it is nonzero because
+    $k$ is active. The shifted trace-power spectrum is $\{0,1\}$, hence
+    $q_k=1$.
+\end{proof}
+
+\begin{theorem}[Unique full-support block geometry]
+    \label{thm:mpu_unique_active_full_support_geometry}
+    \lean{MPSTensor.CPSVCanonicalFormData.active_dim_eq_of_card_active_eq_one_of_fullActiveSupport,
+        MPSTensor.CPSVCanonicalFormData.ambientBlockInclusion_mul_conjTranspose_eq_one}
+    \leanok
+    \uses{def:mpu_full_active_support,def:mpu_ambient_block_inclusion}
+    If there is exactly one active block $k$ and active support fills the
+    ambient bond space, then
+    \begin{align}
+        D_k&=D,
+        &V_kV_k^\dagger&=\Id.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_ambient_block_isometry_intertwining}
+    The full-support sum reduces to the unique summand:
+    \begin{align}
+        D&=\sum_{j\in\mathrm{Active}}D_j=D_k.
+    \end{align}
+    Therefore $V_k$ is a square matrix. Since $V_k^\dagger V_k=\Id$, finite
+    equal-dimensional inverse symmetry gives $V_kV_k^\dagger=\Id$.
 \end{proof}
 
 \begin{theorem}[Shifted transfer traces determine one active block]
@@ -1496,11 +1627,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{proof}\leanok
     \uses{thm:mpu_normalized_transfer_trace,
         thm:mpu_shifted_transfer_trace_card_active,
+        thm:mpu_active_transfer_eigenvalue_one,
+        thm:mpu_unique_active_full_support_geometry,
+        thm:matrix_posdef_coisometric_transport,
+        lem:matrix_vec_identity_trace_pairing,
+        thm:transfer_matrix_trace_preserving_identity_left_fixed,
         thm:mpu_normalized_transfer_stabilization,
         thm:mpu_stabilized_fixed_pair_uniqueness}
-    The shifted trace identities give
+    The shifted trace identities satisfy $\tr(E^N)=1$ for every integer
+    $N>1$ and give
     \begin{align}
-        \tr(E^N)=1\quad(N>1)
+        \tr(E^N)=1
         \quad\Longrightarrow\quad
         \operatorname{card}(\mathrm{Active})=1.
     \end{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1459,12 +1459,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     pairings force the product of those scalars to be one.
 \end{proof}
 
-\begin{lemma}[Identification with chosen reduced-CFII fixed points]
-    \label{lem:mpu_reduced_cfii_transfer_stabilization}
+\begin{theorem}[Identification with chosen reduced-CFII fixed points]
+    \label{thm:mpu_reduced_cfii_transfer_stabilization}
     \lean{MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii}
     \leanok
-    Suppose $D>1$ and the normalized flattening is presented by chosen
-    canonical-form-II data whose active blocks fill the bond space. There is a
+    Suppose $d>0$, $D>1$, and $\mathcal U$ is an MPU whose normalized
+    flattening is presented by chosen canonical-form-II data with active blocks
+    filling the bond space. There is a
     unique active block $k$. Normalize its diagonal positive definite fixed
     matrix $\Lambda_k$ to have trace one, and let $V_k$ be its inclusion into
     the ambient bond space. Then
@@ -1482,15 +1483,16 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \end{align}
     % Source labels: Erightleft and prop:normal-tensor.
     The diagonal matrix is the block matrix $\Lambda_k$ in the canonical-form-II
-    equations of \cite[lines 269--280]{Cirac2017MPU}; its ambient transport
+    fixed-point equations in \cite[equations~(6a)--(6b)]{Cirac2017MPU}; its ambient transport
     $\rho$ need not be diagonal. This is a statement about the chosen reduced
     representative and the blocking step in
     \cite[proof of Proposition~III.2(ii)]{Cirac2017MPU}; it does not assert
     that every ambient MPU tensor is itself in canonical form II.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpu_full_active_support,
+    \uses{def:mpu,def:mpu_normalized_flattening,
+        def:mpu_full_active_support,
         thm:mpu_shifted_transfer_trace_card_active,
         thm:mpu_normalized_transfer_stabilization,
         thm:mpu_stabilized_fixed_pair_uniqueness}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1494,7 +1494,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_shifted_transfer_trace_card_active,
+    \uses{thm:mpu_normalized_transfer_trace,
+        thm:mpu_shifted_transfer_trace_card_active,
         thm:mpu_normalized_transfer_stabilization,
         thm:mpu_stabilized_fixed_pair_uniqueness}
     The shifted trace identities select one active block. Full active support


### PR DESCRIPTION
## Summary

- expose the existing ambient active-block inclusion, isometry/intertwining, and active-weight normalization facts needed outside `ActiveTransferMultiplicity`
- derive the unique full-support active block's ambient dimension and surjective inclusion
- normalize its diagonal positive-definite CFII fixed matrix `Λ`, transport it as `ρ = V Λ Vᴴ`, and prove ambient positivity, trace one, right fixedness, and identity-left-fixedness
- identify the exact power `E^(D*D-1)` with `vecMulVec ρ.vec 1.vec` through `normalizedTransferStabilization` and `power_eq_vec_mul_vec_of_fixed`
- complete Chapter 28's reduced-CFII stabilization entry, preserving the `Erightleft`/Proposition III.2(ii) provenance and explicitly avoiding any claim that ambient `ρ` is diagonal

## Source fidelity

This follows `Papers/1703.09188/paper_v2.tex` lines 269–280 (`Erightleft`) and 397–405. The theorem requires the supplied CFII data and `HasFullActiveSupport`; it does not infer ambient CFII or normality from bare `IsMPU`.

## Validation

- `lake build TNLean.MPS.MPU.TransferStabilization`
- targeted declaration check for `MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`

Closes #5786.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial Lean in MPU transfer stabilization and canonical-form geometry; correctness depends on intertwining and pos-def transport lemmas, but changes are localized to formal proofs and blueprint sync rather than runtime or security-critical paths.
> 
> **Overview**
> Formalizes the **reduced canonical-form-II** route that identifies stabilized normalized MPU transfer powers with explicit fixed witnesses (closes the gap tracked in issue #5786).
> 
> **New algebraic lemmas:** `MatrixPosDefTransport` shows **V A Vᴴ** stays positive definite when **V Vᴴ = 1**; `vec_one_dotProduct_vec_eq_trace` links the vectorized identity to the trace; `vecMul_vec_one_transferMatrix_eq_of_trace_preserving` shows trace-preserving transfer maps fix the vectorized identity on the left.
> 
> **CPSV / canonical form:** Several `ambientBlockInclusion` facts are **public**; with a **unique active block** and **full active support**, the active block has ambient dimension **D** and **V Vᴴ = 1**.
> 
> **Main theorem** `normalized_transfer_power_eq_vecMulVec_of_reduced_cfii`: from supplied CFII data and full active support, builds normalized diagonal block fixed matrix **Λ**, ambient **ρ = V Λ Vᴴ**, proves positivity, trace one, right/left fixedness, and **E^(D²−1) = vecMulVec ρ.vec 1.vec** via stabilization uniqueness—not claiming ambient **ρ** is diagonal.
> 
> Blueprint Ch. 4 and Ch. 28 updated with matching theorems and a full proof for reduced-CFII stabilization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f16df3e65eaad9043827e7d12ab9378572036f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->