### PR TITLE
doc(MPU): cite Proposition III.3 for nilpotence

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -499,7 +499,8 @@ nonzero spectrum as a set.
   The zero matrix has the same positive trace powers as $A$ and characteristic
   polynomial $X^n$. Newton--Girard therefore identifies the two characteristic
   polynomials. This is the characteristic-polynomial consequence of the
-  all-positive trace condition obtained in \cite[lines~405--410]{Cirac2017MPU}.
+  all-positive trace condition obtained in
+  \cite[proof of Proposition~III.3]{Cirac2017MPU}.
 \end{proof}
 
 \begin{theorem}[Shifted vanishing moments under matrix powers]
@@ -529,11 +530,11 @@ nonzero spectrum as a set.
     \chi_A(X)&=X^n.
   \end{align}
   The source obtains the all-positive trace hypothesis in
-  \cite[lines~405--410]{Cirac2017MPU}; its specialization is the elementwise
-  nilpotence assertion used before the nil-matrix theorem. The result above is
-  a stronger generalization because it assumes vanishing only for $N>1$. It is
-  useful independently and requires no positivity, normality, or
-  diagonalizability.
+  \cite[proof of Proposition~III.3]{Cirac2017MPU}; its specialization is
+  the elementwise nilpotence assertion used before the nil-matrix theorem. The
+  result above is a stronger generalization because it assumes vanishing only
+  for $N>1$. It is useful independently and requires no positivity, normality,
+  or diagonalizability.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary

- replace both Chapter 28 TeX line-range citations for the shifted-nilpotence entries
- identify the source passage as the proof of Proposition III.3 in Cirac et al.
- leave the Lean declarations and proofs unchanged

## Validation

- exact locator count: two new locators and no remaining `lines~405--410` locator
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint pdf`

Closes #5799.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bibliography locator fixes in blueprint TeX only; no executable code or proof logic changes.
> 
> **Overview**
> **Documentation-only** update in Chapter 28 (`ch28_mpu.tex`): two Cirac et al. references for the shifted-nilpotence / vanishing trace-power material are retargeted from a vague line range (`lines~405--410`) to **the proof of Proposition III.3**.
> 
> The prose around the zero-trace characteristic polynomial theorem and the shifted zero trace powers nilpotence theorem is unchanged aside from citation locators. **Lean declarations and proofs are not modified.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b630cac1a52083dacd735f65505c82ea3a69b5b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->