### PR TITLE
feat(ParentHamiltonian): package the Gram Choi reshuffling

### DIFF
--- a/TNLean/Algebra/RectangularChoi.lean
+++ b/TNLean/Algebra/RectangularChoi.lean
@@ -74,6 +74,29 @@ theorem rectangularChoi_apply
     rectangularChoi L (i, a) (j, b) = L (single i j 1) a b := by
   rw [rectangularChoi, linearMapMatrix_apply]
 
+/-- The linear operator with matrix entries obtained from the Choi matrix by
+\(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\). -/
+noncomputable def gramReshuffle
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    EuclideanSpace ℂ (α × α) →L[ℂ] EuclideanSpace ℂ (α × α) :=
+  Matrix.toEuclideanCLM (n := α × α) (𝕜 := ℂ) fun (b, a) (e, c) ↦
+    rectangularChoi Φ (c, e) (a, b)
+
+/-- The matrix-unit coefficients of the reshuffled Choi operator are
+\(J(\Phi)_{(c,e),(a,b)}\). -/
+@[simp]
+theorem inner_single_gramReshuffle_single
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) (a b c e : α) :
+    inner ℂ (EuclideanSpace.single (b, a) 1)
+      (gramReshuffle Φ (EuclideanSpace.single (e, c) 1)) =
+      rectangularChoi Φ (c, e) (a, b) := by
+  classical
+  change inner ℂ (WithLp.toLp 2 (Pi.single (b, a) 1))
+    (Matrix.toEuclideanCLM (n := α × α) (𝕜 := ℂ) _
+      (WithLp.toLp 2 (Pi.single (e, c) 1))) = _
+  rw [Matrix.toEuclideanCLM_toLp, EuclideanSpace.inner_toLp_toLp]
+  simp [Matrix.mulVec_single]
+
 /-- Reshaping a coefficient matrix into the rectangular Choi matrix preserves its
 squared Frobenius norm. -/
 theorem rectangularChoi_frobenius_parseval

--- a/TNLean/Algebra/RectangularChoi.lean
+++ b/TNLean/Algebra/RectangularChoi.lean
@@ -24,10 +24,12 @@ The argument is independent of positivity and channel normalization.
 
 - `Matrix.linearMapMatrix`: the matrix of a linear map in the matrix-unit bases
 - `Matrix.rectangularChoi`: the unnormalized rectangular Choi matrix
+- `Matrix.gramReshuffle`: the Euclidean operator obtained by reshuffling Choi entries
 - `Matrix.IsHilbertSchmidtContraction`: contraction for the Hilbert--Schmidt norm
 
 ## Main results
 
+- `Matrix.inner_single_gramReshuffle_single`
 - `Matrix.rectangularChoi_frobenius_parseval`
 - `Matrix.rectangularChoi_frobenius_parseval_matrix_units`
 - `Matrix.rectangularChoi_frobenius_sq_le_finrank_range`

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -10,8 +10,6 @@ import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.Spectral.MixedTransfer
 
-import Mathlib.Analysis.InnerProductSpace.Adjoint
-
 /-!
 # Gram operators for MPS ground-space maps
 
@@ -142,6 +140,30 @@ noncomputable def groundSpaceGram (A : MPSTensor d D) (L : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ] EuclideanSpace ℂ (Fin D × Fin D) :=
   (groundSpaceMapES A L).adjoint.comp (groundSpaceMapES A L)
 
+/-- The operator whose matrix is the explicitly permuted rectangular Choi matrix of `L`.
+This packages Choi reshuffling at operator level; it is neither a transfer fixed-point
+identity nor an FNW contraction estimate. -/
+noncomputable def gramReshuffle
+    (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ] EuclideanSpace ℂ (Fin D × Fin D) :=
+  Matrix.toEuclideanCLM (n := Fin D × Fin D) (𝕜 := ℂ) fun (b, a) (e, c) ↦
+    Matrix.rectangularChoi L (c, e) (a, b)
+
+/-- Matrix-unit coordinates of the operator-level Choi reshuffling. -/
+@[simp]
+theorem inner_single_gramReshuffle_single
+    (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (a b c e : Fin D) :
+    inner ℂ (EuclideanSpace.single (b, a) 1)
+      (gramReshuffle L (EuclideanSpace.single (e, c) 1)) =
+      Matrix.rectangularChoi L (c, e) (a, b) := by
+  classical
+  change inner ℂ (WithLp.toLp 2 (Pi.single (b, a) 1))
+    (Matrix.toEuclideanCLM (n := Fin D × Fin D) (𝕜 := ℂ) _
+      (WithLp.toLp 2 (Pi.single (e, c) 1))) = _
+  rw [Matrix.toEuclideanCLM_toLp, EuclideanSpace.inner_toLp_toLp]
+  simp [Matrix.mulVec_single]
+
 /-- Matrix-unit entry of the MPS Gram operator.  The right-hand side is the
 precise Choi reshuffling: it is not the Hilbert--Schmidt pairing with the
 iterated transfer map. -/
@@ -182,5 +204,20 @@ theorem inner_single_groundSpaceGram_single_eq_rectangularChoi
           (evalWord A (List.ofFn σ))ᴴ by rfl, Matrix.sum_apply]
   simp_rw [hmul]
   simp [groundSpaceMap_apply, Matrix.trace_mul_single, dotProduct]
+
+/-- The MPS Gram operator is the operator-level packaging of the already-proved
+rectangular-Choi reshuffling. This is not a transfer fixed-point identity or an
+FNW overlapping-window contraction. -/
+theorem groundSpaceGram_eq_gramReshuffle (A : MPSTensor d D) (L : ℕ) :
+    groundSpaceGram A L =
+      gramReshuffle ((transferMap (d := d) (D := D) A) ^ L) := by
+  apply ContinuousLinearMap.coe_injective
+  refine (EuclideanSpace.basisFun (Fin D × Fin D) ℂ).toBasis.ext fun ⟨e, c⟩ => ?_
+  apply PiLp.ext
+  rintro ⟨b, a⟩
+  have h := (inner_single_groundSpaceGram_single_eq_rectangularChoi A L a b c e).trans
+    (inner_single_gramReshuffle_single ((transferMap (d := d) (D := D) A) ^ L)
+      a b c e).symm
+  simpa [PiLp.inner_apply] using h
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean
@@ -140,30 +140,6 @@ noncomputable def groundSpaceGram (A : MPSTensor d D) (L : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ] EuclideanSpace ℂ (Fin D × Fin D) :=
   (groundSpaceMapES A L).adjoint.comp (groundSpaceMapES A L)
 
-/-- The operator whose matrix is the explicitly permuted rectangular Choi matrix of `L`.
-This packages Choi reshuffling at operator level; it is neither a transfer fixed-point
-identity nor an FNW contraction estimate. -/
-noncomputable def gramReshuffle
-    (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
-    EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ] EuclideanSpace ℂ (Fin D × Fin D) :=
-  Matrix.toEuclideanCLM (n := Fin D × Fin D) (𝕜 := ℂ) fun (b, a) (e, c) ↦
-    Matrix.rectangularChoi L (c, e) (a, b)
-
-/-- Matrix-unit coordinates of the operator-level Choi reshuffling. -/
-@[simp]
-theorem inner_single_gramReshuffle_single
-    (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (a b c e : Fin D) :
-    inner ℂ (EuclideanSpace.single (b, a) 1)
-      (gramReshuffle L (EuclideanSpace.single (e, c) 1)) =
-      Matrix.rectangularChoi L (c, e) (a, b) := by
-  classical
-  change inner ℂ (WithLp.toLp 2 (Pi.single (b, a) 1))
-    (Matrix.toEuclideanCLM (n := Fin D × Fin D) (𝕜 := ℂ) _
-      (WithLp.toLp 2 (Pi.single (e, c) 1))) = _
-  rw [Matrix.toEuclideanCLM_toLp, EuclideanSpace.inner_toLp_toLp]
-  simp [Matrix.mulVec_single]
-
 /-- Matrix-unit entry of the MPS Gram operator.  The right-hand side is the
 precise Choi reshuffling: it is not the Hilbert--Schmidt pairing with the
 iterated transfer map. -/
@@ -205,19 +181,16 @@ theorem inner_single_groundSpaceGram_single_eq_rectangularChoi
   simp_rw [hmul]
   simp [groundSpaceMap_apply, Matrix.trace_mul_single, dotProduct]
 
-/-- The MPS Gram operator is the operator-level packaging of the already-proved
-rectangular-Choi reshuffling. This is not a transfer fixed-point identity or an
-FNW overlapping-window contraction. -/
+/-- The Gram operator of \(\Gamma_L\) equals the reshuffling of the Choi matrix
+of the \(L\)-fold transfer map. -/
 theorem groundSpaceGram_eq_gramReshuffle (A : MPSTensor d D) (L : ℕ) :
-    groundSpaceGram A L =
-      gramReshuffle ((transferMap (d := d) (D := D) A) ^ L) := by
+    groundSpaceGram A L = Matrix.gramReshuffle ((transferMap A) ^ L) := by
   apply ContinuousLinearMap.coe_injective
   refine (EuclideanSpace.basisFun (Fin D × Fin D) ℂ).toBasis.ext fun ⟨e, c⟩ => ?_
   apply PiLp.ext
   rintro ⟨b, a⟩
   have h := (inner_single_groundSpaceGram_single_eq_rectangularChoi A L a b c e).trans
-    (inner_single_gramReshuffle_single ((transferMap (d := d) (D := D) A) ^ L)
-      a b c e).symm
+    (Matrix.inner_single_gramReshuffle_single ((transferMap A) ^ L) a b c e).symm
   simpa [PiLp.inner_apply] using h
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -264,7 +264,7 @@ orthogonal projector is the canonical representative used here.
 
 \begin{definition}[Operator-level Gram reshuffling]
     \label{def:gram_reshuffle}
-    \lean{MPSTensor.gramReshuffle}
+    \lean{Matrix.gramReshuffle}
     \leanok
     \uses{def:rectangular_choi}
     For a complex-linear map $\mathcal L\colon\MN{D}\to\MN{D}$, define the
@@ -281,10 +281,11 @@ orthogonal projector is the canonical representative used here.
 
 \begin{theorem}[Matrix-unit coordinates of Gram reshuffling]
     \label{thm:gram_reshuffle_single}
-    \lean{MPSTensor.inner_single_gramReshuffle_single}
+    \lean{Matrix.inner_single_gramReshuffle_single}
     \leanok
     \uses{def:gram_reshuffle}
-    Let $\mathbf e_{(j,i)}$ be the standard unit vector at $(j,i)$.  For all
+    Let $\mathcal L\colon\MN{D}\to\MN{D}$ be complex-linear and let
+    $\mathbf e_{(j,i)}$ be the standard unit vector at $(j,i)$.  For all
     $a,b,c,e\in\Fin{D}$,
     \begin{align}
       \bigl\langle \mathbf e_{(b,a)},
@@ -348,8 +349,7 @@ orthogonal projector is the canonical representative used here.
     \label{thm:ground_space_gram_eq_gram_reshuffle}
     \lean{MPSTensor.groundSpaceGram_eq_gramReshuffle}
     \leanok
-    \uses{thm:ground_space_gram_choi_reshuffling,
-        thm:gram_reshuffle_single}
+    \uses{def:ground_space_gram, def:gram_reshuffle, def:transfer_map}
     The ground-space Gram operator is exactly the operator-level reshuffling of
     the Choi matrix of the iterated transfer map:
     \begin{align}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -262,6 +262,48 @@ orthogonal projector is the canonical representative used here.
     \end{align}
 \end{definition}
 
+\begin{definition}[Operator-level Gram reshuffling]
+    \label{def:gram_reshuffle}
+    \lean{MPSTensor.gramReshuffle}
+    \leanok
+    \uses{def:rectangular_choi}
+    For a complex-linear map $\mathcal L\colon\MN{D}\to\MN{D}$, define the
+    operator $\mathscr R(\mathcal L)$ on
+    $\ell^2(\Fin{D}\times\Fin{D})$ by the matrix entries
+    \begin{align}
+      \mathscr R(\mathcal L)_{(b,a),(e,c)}
+      &:=J(\mathcal L)_{(c,e),(a,b)}.
+      \label{eq:gram_reshuffle_entries}
+    \end{align}
+    Thus the row--column pair $((b,a),(e,c))$ is sent explicitly to the Choi
+    row--column pair $((c,e),(a,b))$.
+\end{definition}
+
+\begin{theorem}[Matrix-unit coordinates of Gram reshuffling]
+    \label{thm:gram_reshuffle_single}
+    \lean{MPSTensor.inner_single_gramReshuffle_single}
+    \leanok
+    \uses{def:gram_reshuffle}
+    Let $\mathbf e_{(j,i)}$ be the standard unit vector at $(j,i)$.  For all
+    $a,b,c,e\in\Fin{D}$,
+    \begin{align}
+      \bigl\langle \mathbf e_{(b,a)},
+        \mathscr R(\mathcal L)\mathbf e_{(e,c)}\bigr\rangle_{\ell^2}
+      &=J(\mathcal L)_{(c,e),(a,b)}.
+      \label{eq:gram_reshuffle_single}
+    \end{align}
+    This is the coordinate identity in
+    (\ref{eq:gram_reshuffle_entries}); it is not a Hilbert--Schmidt pairing of
+    $E_{ab}$ with $\mathcal L(E_{ce})$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:gram_reshuffle}
+    Evaluate the matrix of $\mathscr R(\mathcal L)$ on the two standard basis
+    vectors.
+\end{proof}
+
 \begin{theorem}[Transfer--Gram Choi reshuffling]
     \label{thm:ground_space_gram_choi_reshuffling}
     \lean{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}
@@ -300,6 +342,33 @@ orthogonal projector is the canonical representative used here.
     The defining Choi indexing
     $J(\mathcal L)_{(c,e),(a,b)}=(\mathcal L(E_{ca}))_{eb}$ now yields the
     stated reshuffling.
+\end{proof}
+
+\begin{theorem}[Ground-space Gram operator as a reshuffled Choi matrix]
+    \label{thm:ground_space_gram_eq_gram_reshuffle}
+    \lean{MPSTensor.groundSpaceGram_eq_gramReshuffle}
+    \leanok
+    \uses{thm:ground_space_gram_choi_reshuffling,
+        thm:gram_reshuffle_single}
+    The ground-space Gram operator is exactly the operator-level reshuffling of
+    the Choi matrix of the iterated transfer map:
+    \begin{align}
+      \mathcal K_L
+      &=\mathscr R\!\left(\mathcal E_A^L\right).
+      \label{eq:ground_space_gram_eq_gram_reshuffle}
+    \end{align}
+    The equality is an equality of operators on
+    $\ell^2(\Fin{D}\times\Fin{D})$.  Its entries are those in
+    (\ref{eq:gram_reshuffle_single}), rather than Hilbert--Schmidt pairings with
+    $\mathcal E_A^L$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_gram_choi_reshuffling,
+        thm:gram_reshuffle_single}
+    The two operators have equal matrix coefficients on every pair of standard
+    basis vectors.  Hence they are equal.
 \end{proof}
 
 \begin{definition}[Inverse Gram operator]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -504,17 +504,17 @@ exact identity is
       =(\mathcal E_A^L(E_{ca}))_{e,b}.
 \end{align}
 This is \leanid{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}.
-For any matrix endomorphism $\mathcal L$, let $\mathcal R(\mathcal L)$ be the
+For any matrix endomorphism $\mathcal L$, let $\mathscr R(\mathcal L)$ be the
 Euclidean operator with matrix entries
 \begin{align}
-  \mathcal R(\mathcal L)_{(b,a),(e,c)}
+  \mathscr R(\mathcal L)_{(b,a),(e,c)}
     &:=J(\mathcal L)_{(c,e),(a,b)}.
 \end{align}
 This is \leanid{Matrix.gramReshuffle}, and
 \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} upgrades the coordinate
 identity to the exact operator equality
 \begin{align}
-  \mathcal K_L&=\mathcal R(\mathcal E_A^L).
+  \mathcal K_L&=\mathscr R(\mathcal E_A^L).
 \end{align}
 The ordering is a Choi reshuffling.  It must not be replaced by the generally
 false Hilbert--Schmidt expression

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -510,7 +510,7 @@ Euclidean operator with matrix entries
   \mathcal R(\mathcal L)_{(b,a),(e,c)}
     &:=J(\mathcal L)_{(c,e),(a,b)}.
 \end{align}
-This is \leanid{MPSTensor.gramReshuffle}, and
+This is \leanid{Matrix.gramReshuffle}, and
 \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} upgrades the coordinate
 identity to the exact operator equality
 \begin{align}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -504,8 +504,20 @@ exact identity is
       =(\mathcal E_A^L(E_{ca}))_{e,b}.
 \end{align}
 This is \leanid{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}.
-The ordering on the right is a Choi reshuffling.  It must not be replaced by the
-generally false Hilbert--Schmidt expression
+For any matrix endomorphism $\mathcal L$, let $\mathcal R(\mathcal L)$ be the
+Euclidean operator with matrix entries
+\begin{align}
+  \mathcal R(\mathcal L)_{(b,a),(e,c)}
+    &:=J(\mathcal L)_{(c,e),(a,b)}.
+\end{align}
+This is \leanid{MPSTensor.gramReshuffle}, and
+\leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} upgrades the coordinate
+identity to the exact operator equality
+\begin{align}
+  \mathcal K_L&=\mathcal R(\mathcal E_A^L).
+\end{align}
+The ordering is a Choi reshuffling.  It must not be replaced by the generally
+false Hilbert--Schmidt expression
 $\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.
 
 The generic identity

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 846, 888 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 915, 957 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- defines the generic Euclidean operator obtained from the explicitly permuted rectangular Choi matrix;
- proves its matrix-unit coordinate identity with the exact index order
  $$((b,a),(e,c))\mapsto((c,e),(a,b));$$
- upgrades the existing coordinate theorem to the operator equality
  $$
  \mathcal K_L=\mathcal R(\mathcal E_A^L);
  $$
- synchronizes Chapter 13 and the martingale paper-gap note.

## Source boundary

This is exact operator-level packaging of the already-proved transfer–Gram Choi reshuffling for #5752. It supplies no norm estimate, fixed-point identification, or FNW overlapping-window contraction. Those remain separate subsequent slices.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.GroundSpaceGram`
- full `lake build` during blueprint review
- `leanblueprint checkdecls` and `leanblueprint web`
- Lean diagnostics, lint/style review, tenkz disposition reconciliation, and `git diff --check`

Refs #5752, #5455, #460, #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure linear-algebra packaging of an already-proved coordinate identity; no changes to norms, transfer fixed points, or FNW contraction estimates.
> 
> **Overview**
> Introduces **`Matrix.gramReshuffle`**, a generic Euclidean operator on \(\ell^2(D\times D)\) whose matrix entries permute the rectangular Choi indices \(((c,e),(a,b)) \mapsto ((b,a),(e,c))\), together with **`inner_single_gramReshuffle_single`** for matrix-unit coordinates.
> 
> **Upgrades** the existing MPS coordinate identity to **`groundSpaceGram_eq_gramReshuffle`**: \(\mathcal K_L = \mathscr R(\mathcal E_A^L)\) as operators, not only inner products on basis vectors. Removes an unused adjoint import from `GroundSpaceGram.lean`.
> 
> Blueprint Chapter 13 and the martingale paper-gap note are updated to define \(\mathscr R\), record the single-vector theorem, and cite the operator equality—still distinguishing Choi reshuffling from the false Hilbert–Schmidt pairing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b612d8468aad434f6a2f84eba80925a649c8cbab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->