### PR TITLE
refactor(MPS/MPDO): reuse the cyclic offset inverse

### DIFF
--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -127,7 +127,6 @@ def windowComplementEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
     funext k
     simp only
     let offset := (k.val + N - i.val) % N
-    have hoffN : offset < N := Nat.mod_lt _ (Fin.pos i)
     have hsite : (i.val + offset) % N = k.val :=
       MPSTensor.add_offset_mod_eq i.isLt k.isLt
     by_cases hoff : offset < L

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -128,19 +128,8 @@ def windowComplementEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
     simp only
     let offset := (k.val + N - i.val) % N
     have hoffN : offset < N := Nat.mod_lt _ (Fin.pos i)
-    have hsite : (i.val + offset) % N = k.val := by
-      rcases lt_or_ge k.val i.val with hki | hik
-      · have hmod : offset = k.val + N - i.val := by
-          simp only [offset]
-          rw [Nat.mod_eq_of_lt (by omega)]
-        rw [hmod, show i.val + (k.val + N - i.val) = k.val + N by omega,
-          Nat.add_mod_right, Nat.mod_eq_of_lt k.isLt]
-      · have hmod : offset = k.val - i.val := by
-          simp only [offset]
-          have heq : k.val + N - i.val = N + (k.val - i.val) := by omega
-          rw [heq, Nat.add_mod_left,
-            Nat.mod_eq_of_lt (lt_of_le_of_lt (Nat.sub_le _ _) k.isLt)]
-        rw [hmod, Nat.add_sub_of_le hik, Nat.mod_eq_of_lt k.isLt]
+    have hsite : (i.val + offset) % N = k.val :=
+      MPSTensor.add_offset_mod_eq i.isLt k.isLt
     by_cases hoff : offset < L
     · rw [dif_pos hoff]
       exact congrArg σ (Fin.ext hsite)

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -190,22 +190,7 @@ private def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
     exact MPSTensor.offset_mod_eq i.isLt k.isLt
   right_inv k := by
     apply Fin.ext
-    change (i.val + ((k.val + N - i.val) % N)) % N = k.val
-    let offset := (k.val + N - i.val) % N
-    have hsite : (i.val + offset) % N = k.val := by
-      rcases lt_or_ge k.val i.val with hki | hik
-      · have hmod : offset = k.val + N - i.val := by
-          simp only [offset]
-          rw [Nat.mod_eq_of_lt (by omega)]
-        rw [hmod, show i.val + (k.val + N - i.val) = k.val + N by omega,
-          Nat.add_mod_right, Nat.mod_eq_of_lt k.isLt]
-      · have hmod : offset = k.val - i.val := by
-          simp only [offset]
-          have heq : k.val + N - i.val = N + (k.val - i.val) := by omega
-          rw [heq, Nat.add_mod_left,
-            Nat.mod_eq_of_lt (lt_of_le_of_lt (Nat.sub_le _ _) k.isLt)]
-        rw [hmod, Nat.add_sub_of_le hik, Nat.mod_eq_of_lt k.isLt]
-    exact hsite
+    exact MPSTensor.add_offset_mod_eq i.isLt k.isLt
 
 private def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
     Fin L ⊕ Fin (N - L) ≃ Fin N :=

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -89,22 +89,7 @@ private def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
     exact MPSTensor.offset_mod_eq i.isLt k.isLt
   right_inv k := by
     apply Fin.ext
-    change (i.val + ((k.val + N - i.val) % N)) % N = k.val
-    let offset := (k.val + N - i.val) % N
-    have hsite : (i.val + offset) % N = k.val := by
-      rcases lt_or_ge k.val i.val with hki | hik
-      · have hmod : offset = k.val + N - i.val := by
-          simp only [offset]
-          rw [Nat.mod_eq_of_lt (by omega)]
-        rw [hmod, show i.val + (k.val + N - i.val) = k.val + N by omega,
-          Nat.add_mod_right, Nat.mod_eq_of_lt k.isLt]
-      · have hmod : offset = k.val - i.val := by
-          simp only [offset]
-          have heq : k.val + N - i.val = N + (k.val - i.val) := by omega
-          rw [heq, Nat.add_mod_left,
-            Nat.mod_eq_of_lt (lt_of_le_of_lt (Nat.sub_le _ _) k.isLt)]
-        rw [hmod, Nat.add_sub_of_le hik, Nat.mod_eq_of_lt k.isLt]
-    exact hsite
+    exact MPSTensor.add_offset_mod_eq i.isLt k.isLt
 
 private def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
     Fin L ⊕ Fin (N - L) ≃ Fin N :=

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -120,7 +120,8 @@ lemma offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
   · rw [Nat.mod_eq_sub_mod hab, Nat.mod_eq_of_lt (by omega : a + b - N < N),
       show a + b - N + N - a = b from by omega, Nat.mod_eq_of_lt hb]
 
-private lemma add_offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
+/-- Adding the cyclic offset from `a` to `b` modulo `N` recovers `b`. -/
+lemma add_offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
     (a + ((b + N - a) % N)) % N = b := by
   rcases lt_or_ge b a with hab | hab
   · have hmod : (b + N - a) % N = b + N - a := by

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -364,8 +364,8 @@ abstracted — record why, so it is not re-proposed).
 - **Result:** `MPOTensor.windowComplementEquiv` in `CommutingForm.lean` and the private
   `cyclicShiftEquiv` definitions in `PhysicalSectorProductTransport.lean` and
   `PhysicalSupportProductTransport.lean` now apply the lemma directly, as does its original
-  `MPSTensor.replaceWindow_extractWindow` caller. The Lean sources lose 40 lines net
-  (6 insertions and 46 deletions).
+  `MPSTensor.replaceWindow_extractWindow` caller. The Lean sources lose 41 lines net
+  (6 insertions and 47 deletions).
 
 ### Product-marginal support kernel
 - **Pattern:** the simultaneous marginal-support whitening proof and the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -356,6 +356,17 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Cyclic offset inverse identity
+- **Pattern:** adding the residue `(b + N - a) % N` to `a` modulo `N` recovers `b`
+  when `a` and `b` are both less than `N`.
+- **Reuse:** the public lemma `MPSTensor.add_offset_mod_eq` in
+  `TNLean/MPS/ParentHamiltonian/Defs.lean` records this inverse identity.
+- **Result:** `MPOTensor.windowComplementEquiv` in `CommutingForm.lean` and the private
+  `cyclicShiftEquiv` definitions in `PhysicalSectorProductTransport.lean` and
+  `PhysicalSupportProductTransport.lean` now apply the lemma directly, as does its original
+  `MPSTensor.replaceWindow_extractWindow` caller. The Lean sources lose 40 lines net
+  (6 insertions and 46 deletions).
+
 ### Product-marginal support kernel
 - **Pattern:** the simultaneous marginal-support whitening proof and the
   mutual-information estimate both need the support inclusion


### PR DESCRIPTION
## What changed

- promote the existing cyclic-offset inverse as public `MPSTensor.add_offset_mod_eq`;
- replace three independent 13-18-line modular-arithmetic proofs in `CommutingForm`, `PhysicalSectorProductTransport`, and `PhysicalSupportProductTransport` with direct applications;
- preserve the original `replaceWindow_extractWindow` caller and every surrounding public statement;
- record the promoted lemma and all four call sites in the completed-refactor ledger.

Lean sources: 6 insertions, 46 deletions, **net −40 lines**. No imports or mathematical interfaces changed.

## Validation

- targeted builds for all four affected modules — 9134 jobs
- `lake build TNLean.MPS.MPDO`
- `lake build TNLean` — 9997 jobs
- generated import-aggregator and module-policy checks
- Blueprint/Lean synchronization and reader-prose checks
- repeated modular-proof-pattern scan
- `git diff --check`
- axioms for `MPSTensor.add_offset_mod_eq`: `propext`, `Quot.sound`
- independent exact-head review: approved, no findings

Closes #5814

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof deduplication and lemma visibility change with no import or mathematical interface changes; risk is limited to proof correctness of the shared modular identity.
> 
> **Overview**
> Promotes the existing cyclic-offset inverse identity to public **`MPSTensor.add_offset_mod_eq`** in `ParentHamiltonian/Defs.lean` (with a doc comment) and drops three ~15-line modular-arithmetic proofs that all proved the same `(a + ((b + N - a) % N)) % N = b` fact.
> 
> **`CommutingForm`** (`windowComplementEquiv` `left_inv`) and the private **`cyclicShiftEquiv`** in **`PhysicalSectorProductTransport`** and **`PhysicalSupportProductTransport`** now call the lemma directly for `right_inv` (and the commuting form case for `hsite`). Public definitions and theorem statements are unchanged; **`replaceWindow_extractWindow`** was already using the lemma.
> 
> The tactic-pattern ledger records this as a completed refactor (~41 net Lean lines removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1468d036bb6b6d0828e7462c87627962d7ffceb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->