### PR TITLE
refactor(MPS/MPDO): share cyclic-window product API

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -182,47 +182,6 @@ private theorem physicalCoordinateMatrixN_mpo
   rw [Fintype.sum_prod_type] at h
   exact h
 
-private def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
-  toFun k := ⟨(i.val + k.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
-  invFun k := ⟨(k.val + N - i.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
-  left_inv k := by
-    apply Fin.ext
-    exact MPSTensor.offset_mod_eq i.isLt k.isLt
-  right_inv k := by
-    apply Fin.ext
-    exact MPSTensor.add_offset_mod_eq i.isLt k.isLt
-
-private def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
-    Fin L ⊕ Fin (N - L) ≃ Fin N :=
-  finSumFinEquiv |>.trans (finCongr (Nat.add_sub_of_le hLN)) |>.trans
-    (cyclicShiftEquiv N i)
-
-@[simp] private theorem cyclicWindowIndexEquiv_inl
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin L) :
-    cyclicWindowIndexEquiv L N hLN i (Sum.inl r) =
-      ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := rfl
-
-@[simp] private theorem cyclicWindowIndexEquiv_inr
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin (N - L)) :
-    cyclicWindowIndexEquiv L N hLN i (Sum.inr r) =
-      ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := by
-  apply Fin.ext
-  change (i.val + (L + r.val)) % N = (i.val + L + r.val) % N
-  congr 1
-  omega
-
-private theorem prod_cyclicWindow_complement
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (f : Fin N → ℂ) :
-    (∏ n : Fin N, f n) =
-      (∏ r : Fin L, f ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) *
-        (∏ r : Fin (N - L),
-          f ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) := by
-  rw [Fintype.prod_equiv (cyclicWindowIndexEquiv L N hLN i).symm
-    f (fun x ↦ f (cyclicWindowIndexEquiv L N hLN i x))
-    (fun n ↦ by simp)]
-  rw [Fintype.prod_sum_type]
-  simp only [cyclicWindowIndexEquiv_inl, cyclicWindowIndexEquiv_inr]
-
 private theorem reindex_physicalCoordinateMatrixN_windowComplement
     (F : PhysicalSectorFactorization K) {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
     Matrix.reindex
@@ -246,7 +205,7 @@ private theorem reindex_physicalCoordinateMatrixN_windowComplement
   have hv : (fun r ↦ t ⟨(i.val + 2 + r.val) % N,
       Nat.mod_lt _ (Fin.pos i)⟩) = v := congrArg Prod.snd het
   change (∏ n : Fin N, F.physicalCoordinateMatrix (s n) (t n)) = _
-  rw [prod_cyclicWindow_complement 2 N hN i]
+  rw [MPSTensor.prod_cyclicWindow_complement 2 N hN i]
   simp only [MPSTensor.extractWindow] at hx hy
   simp only [physicalCoordinateMatrixN, Matrix.kroneckerMap_apply]
   apply congrArg₂ (fun a b : ℂ ↦ a * b)

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.ListProduct
 import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorProductRealization
+import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 
 /-!
 # Physical transport of the sector product realization

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -81,49 +81,6 @@ theorem singleKrausMap_list_prod_of_ne_nil
           exact congrArg (singleKrausMap V X * ·)
             (ih (by simp))
 
-private def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
-  toFun k := ⟨(i.val + k.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
-  invFun k := ⟨(k.val + N - i.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
-  left_inv k := by
-    apply Fin.ext
-    exact MPSTensor.offset_mod_eq i.isLt k.isLt
-  right_inv k := by
-    apply Fin.ext
-    exact MPSTensor.add_offset_mod_eq i.isLt k.isLt
-
-private def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
-    Fin L ⊕ Fin (N - L) ≃ Fin N :=
-  finSumFinEquiv |>.trans (finCongr (Nat.add_sub_of_le hLN)) |>.trans
-    (cyclicShiftEquiv N i)
-
-@[simp] private theorem cyclicWindowIndexEquiv_inl
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin L) :
-    cyclicWindowIndexEquiv L N hLN i (Sum.inl r) =
-      ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := rfl
-
-@[simp] private theorem cyclicWindowIndexEquiv_inr
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin (N - L)) :
-    cyclicWindowIndexEquiv L N hLN i (Sum.inr r) =
-      ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := by
-  apply Fin.ext
-  change (i.val + (L + r.val)) % N = (i.val + L + r.val) % N
-  congr 1
-  omega
-
-private theorem prod_cyclicWindow_complement
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (f : Fin N → ℂ) :
-    (∏ n : Fin N, f n) =
-      (∏ r : Fin L,
-        f ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) *
-        (∏ r : Fin (N - L),
-          f ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) := by
-  rw [Fintype.prod_equiv
-    (cyclicWindowIndexEquiv L N hLN i).symm f
-    (fun x ↦ f (cyclicWindowIndexEquiv L N hLN i x))
-    (fun n ↦ by simp)]
-  rw [Fintype.prod_sum_type]
-  simp only [cyclicWindowIndexEquiv_inl, cyclicWindowIndexEquiv_inr]
-
 private theorem reindex_sitewisePhysicalMatrix_windowComplement
     (V : Matrix (Fin d) (Fin e) ℂ) {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
     Matrix.reindex (windowComplementEquiv (d := d) 2 N hN i)
@@ -146,7 +103,7 @@ private theorem reindex_sitewisePhysicalMatrix_windowComplement
       Nat.mod_lt _ (Fin.pos i)⟩) = v :=
     congrArg Prod.snd (ee.apply_symm_apply (y, v))
   change (∏ n : Fin N, V (s n) (t n)) = _
-  rw [prod_cyclicWindow_complement 2 N hN i]
+  rw [MPSTensor.prod_cyclicWindow_complement 2 N hN i]
   simp only [MPSTensor.extractWindow] at hx hy
   simp only [sitewisePhysicalMatrix, Matrix.kroneckerMap_apply]
   apply congrArg₂ (fun a b : ℂ ↦ a * b)
@@ -171,7 +128,7 @@ private theorem embed_twoSiteSectorProjection_eq_finKronecker
   simp only [embedLocalOperator_apply, sitewisePhysicalMatrix,
     Matrix.finKronecker_apply]
   by_cases hAgree : AgreesOutsideWindow (d := d) 2 hN i σ τ
-  · rw [if_pos hAgree, prod_cyclicWindow_complement 2 N hN i]
+  · rw [if_pos hAgree, MPSTensor.prod_cyclicWindow_complement 2 N hN i]
     rw [agreesOutsideWindow_iff] at hAgree
     apply Eq.symm
     calc

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.MPS.MPDO.PhysicalSupportBondCommutativity
+import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 
 /-!
 # Finite-chain products on an isometric physical support

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -37,6 +37,7 @@ import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
 import TNLean.MPS.ParentHamiltonian.CyclicTranslation
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
+import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.ExtendRight

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindowIndex.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindowIndex.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.Defs
+
+/-!
+# Cyclic window indices
+
+This file provides index equivalences that split a periodic chain into a consecutive
+window and its ordered complement, together with the corresponding product factorization.
+
+## Main definitions
+
+* `MPSTensor.cyclicShiftEquiv` — rotates the site indices so that a chosen site is first.
+* `MPSTensor.cyclicWindowIndexEquiv` — splits the chain into a cyclic window and its
+  ordered complement.
+
+## Main results
+
+* `MPSTensor.cyclicWindowIndexEquiv_inl` — evaluates the equivalence on a window index.
+* `MPSTensor.cyclicWindowIndexEquiv_inr` — evaluates the equivalence on a complementary
+  index.
+* `MPSTensor.prod_cyclicWindow_complement` — factors a product into a cyclic window and
+  its ordered complement.
+-/
+
+open scoped BigOperators
+
+namespace MPSTensor
+
+/-- Cyclically shift the indices of an \(N\)-site chain so that \(i\) becomes the
+initial site. -/
+def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
+  toFun k := ⟨(i.val + k.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  invFun k := ⟨(k.val + N - i.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  left_inv k := by
+    apply Fin.ext
+    exact offset_mod_eq i.isLt k.isLt
+  right_inv k := by
+    apply Fin.ext
+    exact add_offset_mod_eq i.isLt k.isLt
+
+/-- Split cyclic chain indices into a window of length \(L\) starting at \(i\) and
+its ordered complement. -/
+def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+    Fin L ⊕ Fin (N - L) ≃ Fin N :=
+  finSumFinEquiv |>.trans (finCongr (Nat.add_sub_of_le hLN)) |>.trans
+    (cyclicShiftEquiv N i)
+
+/-- Evaluate the cyclic window equivalence on a window index. -/
+@[simp] theorem cyclicWindowIndexEquiv_inl
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin L) :
+    cyclicWindowIndexEquiv L N hLN i (Sum.inl r) =
+      ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := rfl
+
+/-- Evaluate the cyclic window equivalence on a complementary index. -/
+@[simp] theorem cyclicWindowIndexEquiv_inr
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin (N - L)) :
+    cyclicWindowIndexEquiv L N hLN i (Sum.inr r) =
+      ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := by
+  apply Fin.ext
+  change (i.val + (L + r.val)) % N = (i.val + L + r.val) % N
+  congr 1
+  omega
+
+/-- Factor a product over a cyclic chain into a consecutive window and its
+ordered complement. -/
+theorem prod_cyclicWindow_complement {M : Type*} [CommMonoid M]
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (f : Fin N → M) :
+    (∏ n : Fin N, f n) =
+      (∏ r : Fin L,
+        f ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) *
+        (∏ r : Fin (N - L),
+          f ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) := by
+  rw [Fintype.prod_equiv
+    (cyclicWindowIndexEquiv L N hLN i).symm f
+    (fun x ↦ f (cyclicWindowIndexEquiv L N hLN i x))
+    (fun n ↦ by simp)]
+  rw [Fintype.prod_sum_type]
+  simp only [cyclicWindowIndexEquiv_inl, cyclicWindowIndexEquiv_inr]
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -154,11 +154,13 @@ def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
   finSumFinEquiv |>.trans (finCongr (Nat.add_sub_of_le hLN)) |>.trans
     (cyclicShiftEquiv N i)
 
+/-- Evaluate the cyclic window equivalence on a window index. -/
 @[simp] theorem cyclicWindowIndexEquiv_inl
     (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin L) :
     cyclicWindowIndexEquiv L N hLN i (Sum.inl r) =
       ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := rfl
 
+/-- Evaluate the cyclic window equivalence on a complementary index. -/
 @[simp] theorem cyclicWindowIndexEquiv_inr
     (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin (N - L)) :
     cyclicWindowIndexEquiv L N hLN i (Sum.inr r) =

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -26,11 +26,6 @@ and the finite-chain parent Hamiltonian.
 * `MPSTensor.replaceWindow L i σ τ` — replaces the \(L\) consecutive site values in
   \(\sigma\) starting at position \(i\) with values from \(\tau\).
 
-* `MPSTensor.cyclicShiftEquiv` — rotates the site indices so that a chosen site is first.
-
-* `MPSTensor.cyclicWindowIndexEquiv` — splits the chain into a cyclic window and its
-  ordered complement.
-
 * `MPSTensor.localTerm A L N i` — the parent interaction embedded at site \(i\) on
   the \(N\)-site periodic chain, acting as `parentInteraction` on the window
   \(\{i, i+1, \ldots, i+L-1 \bmod N\}\) and as the identity on the complement.
@@ -39,11 +34,6 @@ and the finite-chain parent Hamiltonian.
 
 * `MPSTensor.IsFrustrationFree` — the parent-Hamiltonian ground-state
   condition \(hᵢ ψ = 0\) for every local term.
-
-## Main results
-
-* `MPSTensor.prod_cyclicWindow_complement` — factors a product into a cyclic window
-  and its ordered complement.
 -/
 
 open scoped BigOperators
@@ -144,57 +134,6 @@ lemma add_offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
       rw [this, Nat.add_mod, Nat.mod_self]
       simpa using Nat.mod_eq_of_lt hsub
     rw [hmod, Nat.add_sub_of_le hab, Nat.mod_eq_of_lt hb]
-
-/-- Cyclically shift the indices of an \(N\)-site chain so that \(i\) becomes the
-initial site. -/
-def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
-  toFun k := ⟨(i.val + k.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
-  invFun k := ⟨(k.val + N - i.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
-  left_inv k := by
-    apply Fin.ext
-    exact offset_mod_eq i.isLt k.isLt
-  right_inv k := by
-    apply Fin.ext
-    exact add_offset_mod_eq i.isLt k.isLt
-
-/-- Split cyclic chain indices into a window of length \(L\) starting at \(i\) and
-its ordered complement. -/
-def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
-    Fin L ⊕ Fin (N - L) ≃ Fin N :=
-  finSumFinEquiv |>.trans (finCongr (Nat.add_sub_of_le hLN)) |>.trans
-    (cyclicShiftEquiv N i)
-
-/-- Evaluate the cyclic window equivalence on a window index. -/
-@[simp] theorem cyclicWindowIndexEquiv_inl
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin L) :
-    cyclicWindowIndexEquiv L N hLN i (Sum.inl r) =
-      ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := rfl
-
-/-- Evaluate the cyclic window equivalence on a complementary index. -/
-@[simp] theorem cyclicWindowIndexEquiv_inr
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin (N - L)) :
-    cyclicWindowIndexEquiv L N hLN i (Sum.inr r) =
-      ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := by
-  apply Fin.ext
-  change (i.val + (L + r.val)) % N = (i.val + L + r.val) % N
-  congr 1
-  omega
-
-/-- Factor a product over a cyclic chain into a consecutive window and its
-ordered complement. -/
-theorem prod_cyclicWindow_complement {M : Type*} [CommMonoid M]
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (f : Fin N → M) :
-    (∏ n : Fin N, f n) =
-      (∏ r : Fin L,
-        f ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) *
-        (∏ r : Fin (N - L),
-          f ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) := by
-  rw [Fintype.prod_equiv
-    (cyclicWindowIndexEquiv L N hLN i).symm f
-    (fun x ↦ f (cyclicWindowIndexEquiv L N hLN i x))
-    (fun n ↦ by simp)]
-  rw [Fintype.prod_sum_type]
-  simp only [cyclicWindowIndexEquiv_inl, cyclicWindowIndexEquiv_inr]
 
 /-- Extracting a window after replacing it recovers the replacement values. -/
 @[simp] lemma extractWindow_replaceWindow (L : ℕ) (hLN : L ≤ N) {α : Type*}

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -135,6 +135,55 @@ lemma add_offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
       simpa using Nat.mod_eq_of_lt hsub
     rw [hmod, Nat.add_sub_of_le hab, Nat.mod_eq_of_lt hb]
 
+/-- Cyclically shift the indices of an `N`-site chain so that `i` becomes the
+initial site. -/
+def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
+  toFun k := ⟨(i.val + k.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  invFun k := ⟨(k.val + N - i.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  left_inv k := by
+    apply Fin.ext
+    exact offset_mod_eq i.isLt k.isLt
+  right_inv k := by
+    apply Fin.ext
+    exact add_offset_mod_eq i.isLt k.isLt
+
+/-- Split cyclic chain indices into a window of length `L` starting at `i` and
+its ordered complement. -/
+def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+    Fin L ⊕ Fin (N - L) ≃ Fin N :=
+  finSumFinEquiv |>.trans (finCongr (Nat.add_sub_of_le hLN)) |>.trans
+    (cyclicShiftEquiv N i)
+
+@[simp] theorem cyclicWindowIndexEquiv_inl
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin L) :
+    cyclicWindowIndexEquiv L N hLN i (Sum.inl r) =
+      ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := rfl
+
+@[simp] theorem cyclicWindowIndexEquiv_inr
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (r : Fin (N - L)) :
+    cyclicWindowIndexEquiv L N hLN i (Sum.inr r) =
+      ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩ := by
+  apply Fin.ext
+  change (i.val + (L + r.val)) % N = (i.val + L + r.val) % N
+  congr 1
+  omega
+
+/-- Factor a product over a cyclic chain into a consecutive window and its
+ordered complement. -/
+theorem prod_cyclicWindow_complement {M : Type*} [CommMonoid M]
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (f : Fin N → M) :
+    (∏ n : Fin N, f n) =
+      (∏ r : Fin L,
+        f ⟨(i.val + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) *
+        (∏ r : Fin (N - L),
+          f ⟨(i.val + L + r.val) % N, Nat.mod_lt _ (Fin.pos i)⟩) := by
+  rw [Fintype.prod_equiv
+    (cyclicWindowIndexEquiv L N hLN i).symm f
+    (fun x ↦ f (cyclicWindowIndexEquiv L N hLN i x))
+    (fun n ↦ by simp)]
+  rw [Fintype.prod_sum_type]
+  simp only [cyclicWindowIndexEquiv_inl, cyclicWindowIndexEquiv_inr]
+
 /-- Extracting a window after replacing it recovers the replacement values. -/
 @[simp] lemma extractWindow_replaceWindow (L : ℕ) (hLN : L ≤ N) {α : Type*}
     (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -145,7 +145,7 @@ lemma add_offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
       simpa using Nat.mod_eq_of_lt hsub
     rw [hmod, Nat.add_sub_of_le hab, Nat.mod_eq_of_lt hb]
 
-/-- Cyclically shift the indices of an `N`-site chain so that `i` becomes the
+/-- Cyclically shift the indices of an \(N\)-site chain so that \(i\) becomes the
 initial site. -/
 def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
   toFun k := ⟨(i.val + k.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
@@ -157,7 +157,7 @@ def cyclicShiftEquiv (N : ℕ) (i : Fin N) : Fin N ≃ Fin N where
     apply Fin.ext
     exact add_offset_mod_eq i.isLt k.isLt
 
-/-- Split cyclic chain indices into a window of length `L` starting at `i` and
+/-- Split cyclic chain indices into a window of length \(L\) starting at \(i\) and
 its ordered complement. -/
 def cyclicWindowIndexEquiv (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
     Fin L ⊕ Fin (N - L) ≃ Fin N :=

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -26,6 +26,11 @@ and the finite-chain parent Hamiltonian.
 * `MPSTensor.replaceWindow L i σ τ` — replaces the \(L\) consecutive site values in
   \(\sigma\) starting at position \(i\) with values from \(\tau\).
 
+* `MPSTensor.cyclicShiftEquiv` — rotates the site indices so that a chosen site is first.
+
+* `MPSTensor.cyclicWindowIndexEquiv` — splits the chain into a cyclic window and its
+  ordered complement.
+
 * `MPSTensor.localTerm A L N i` — the parent interaction embedded at site \(i\) on
   the \(N\)-site periodic chain, acting as `parentInteraction` on the window
   \(\{i, i+1, \ldots, i+L-1 \bmod N\}\) and as the identity on the complement.
@@ -34,6 +39,11 @@ and the finite-chain parent Hamiltonian.
 
 * `MPSTensor.IsFrustrationFree` — the parent-Hamiltonian ground-state
   condition \(hᵢ ψ = 0\) for every local term.
+
+## Main results
+
+* `MPSTensor.prod_cyclicWindow_complement` — factors a product into a cyclic window
+  and its ordered complement.
 -/
 
 open scoped BigOperators

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -361,11 +361,10 @@ abstracted — record why, so it is not re-proposed).
   when `a` and `b` are both less than `N`.
 - **Reuse:** the public lemma `MPSTensor.add_offset_mod_eq` in
   `TNLean/MPS/ParentHamiltonian/Defs.lean` records this inverse identity.
-- **Result:** `MPOTensor.windowComplementEquiv` in `CommutingForm.lean` and the private
-  `cyclicShiftEquiv` definitions in `PhysicalSectorProductTransport.lean` and
-  `PhysicalSupportProductTransport.lean` now apply the lemma directly, as does its original
-  `MPSTensor.replaceWindow_extractWindow` caller. The Lean sources lose 41 lines net
-  (6 insertions and 47 deletions).
+- **Result:** `MPOTensor.windowComplementEquiv` in `CommutingForm.lean` and the shared
+  `MPSTensor.cyclicShiftEquiv` in `ParentHamiltonian/CyclicWindowIndex.lean` apply the lemma
+  directly, as does its original `MPSTensor.replaceWindow_extractWindow` caller. The initial
+  promotion reduced the Lean sources by 41 lines net (6 insertions and 47 deletions).
 
 ### Cyclic window index and product decomposition
 - **Pattern:** two physical-product modules privately defined the same cyclic shift,
@@ -374,14 +373,16 @@ abstracted — record why, so it is not re-proposed).
 - **Reuse:** `MPSTensor.cyclicShiftEquiv`, `MPSTensor.cyclicWindowIndexEquiv`,
   `MPSTensor.cyclicWindowIndexEquiv_inl`, `MPSTensor.cyclicWindowIndexEquiv_inr`, and
   `MPSTensor.prod_cyclicWindow_complement` in
-  `TNLean/MPS/ParentHamiltonian/Defs.lean` provide the shared API; the product theorem
-  holds for every commutative monoid.
+  `TNLean/MPS/ParentHamiltonian/CyclicWindowIndex.lean` provide the shared API; the
+  product theorem holds for every commutative monoid. Isolating these declarations from
+  `ParentHamiltonian/Defs.lean` avoids invalidating its broad downstream import cone.
 - **Result:** the exact call sites are `reindex_sitewisePhysicalMatrix_windowComplement`
   and `embed_twoSiteSectorProjection_eq_finKronecker` in
   `PhysicalSupportProductTransport.lean`, and
   `reindex_physicalCoordinateMatrixN_windowComplement` in
-  `PhysicalSectorProductTransport.lean`. Across the three Lean files, the final diff is
-  64 insertions and 87 deletions, a net reduction of 23 lines.
+  `PhysicalSectorProductTransport.lean`. Across the four changed Lean files, including
+  the generated ParentHamiltonian aggregator, the final diff is 90 insertions and 87
+  deletions, a net increase of 3 lines.
 
 ### Product-marginal support kernel
 - **Pattern:** the simultaneous marginal-support whitening proof and the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -381,7 +381,7 @@ abstracted — record why, so it is not re-proposed).
   `PhysicalSupportProductTransport.lean`, and
   `reindex_physicalCoordinateMatrixN_windowComplement` in
   `PhysicalSectorProductTransport.lean`. Across the three Lean files, the final diff is
-  54 insertions and 87 deletions, a net reduction of 33 lines.
+  64 insertions and 87 deletions, a net reduction of 23 lines.
 
 ### Product-marginal support kernel
 - **Pattern:** the simultaneous marginal-support whitening proof and the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -381,7 +381,7 @@ abstracted — record why, so it is not re-proposed).
   `PhysicalSupportProductTransport.lean`, and
   `reindex_physicalCoordinateMatrixN_windowComplement` in
   `PhysicalSectorProductTransport.lean`. Across the three Lean files, the final diff is
-  52 insertions and 87 deletions, a net reduction of 35 lines.
+  54 insertions and 87 deletions, a net reduction of 33 lines.
 
 ### Product-marginal support kernel
 - **Pattern:** the simultaneous marginal-support whitening proof and the

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -367,6 +367,22 @@ abstracted — record why, so it is not re-proposed).
   `MPSTensor.replaceWindow_extractWindow` caller. The Lean sources lose 41 lines net
   (6 insertions and 47 deletions).
 
+### Cyclic window index and product decomposition
+- **Pattern:** two physical-product modules privately defined the same cyclic shift,
+  window/complement index equivalence, its two evaluation lemmas, and the resulting
+  product factorization.
+- **Reuse:** `MPSTensor.cyclicShiftEquiv`, `MPSTensor.cyclicWindowIndexEquiv`,
+  `MPSTensor.cyclicWindowIndexEquiv_inl`, `MPSTensor.cyclicWindowIndexEquiv_inr`, and
+  `MPSTensor.prod_cyclicWindow_complement` in
+  `TNLean/MPS/ParentHamiltonian/Defs.lean` provide the shared API; the product theorem
+  holds for every commutative monoid.
+- **Result:** the exact call sites are `reindex_sitewisePhysicalMatrix_windowComplement`
+  and `embed_twoSiteSectorProjection_eq_finKronecker` in
+  `PhysicalSupportProductTransport.lean`, and
+  `reindex_physicalCoordinateMatrixN_windowComplement` in
+  `PhysicalSectorProductTransport.lean`. Across the three Lean files, the final diff is
+  52 insertions and 87 deletions, a net reduction of 35 lines.
+
 ### Product-marginal support kernel
 - **Pattern:** the simultaneous marginal-support whitening proof and the
   mutual-information estimate both need the support inclusion


### PR DESCRIPTION
## What changed

- promote the cyclic shift and window/complement index equivalences into the narrow `MPSTensor` module `ParentHamiltonian/CyclicWindowIndex`
- generalize the cyclic product factorization to arbitrary commutative monoids
- delete the two private five-declaration suites and route all three consumers through the shared API
- keep `ParentHamiltonian/Defs` unchanged so its broad downstream cone does not rebuild for this auxiliary API
- synchronize both affected tactic-ledger entries with the final shared declarations

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.CyclicWindowIndex TNLean.MPS.MPDO.PhysicalSupportProductTransport TNLean.MPS.MPDO.PhysicalSectorProductTransport` (9135 jobs, warm exact-main cache)
- `python3 scripts/generate_import_aggregators.py --check`
- generated-import, duplicate-declaration, call-site, import-scope, protected-boundary, forbidden-token, and `git diff --check` checks
- exact-head independent review: approved after the tactic-ledger synchronization

Lean sources: 90 insertions, 87 deletions, net +3 lines. The small net increase isolates the API from the broad `ParentHamiltonian/Defs` import cone.

Closes #5823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor and deduplication with no described changes to public theorem statements; risk is limited to import wiring and build scope.
> 
> **Overview**
> Duplicates of the cyclic shift, window/complement index equivalence, and product factorization are **removed** from `PhysicalSectorProductTransport.lean` and `PhysicalSupportProductTransport.lean` and **replaced** by imports of **`TNLean/MPS/ParentHamiltonian/CyclicWindowIndex.lean`**.
> 
> That module now exposes **`MPSTensor.cyclicShiftEquiv`**, **`cyclicWindowIndexEquiv`**, the **`inl`/`inr` evaluation lemmas**, and **`prod_cyclicWindow_complement`** for arbitrary commutative monoids. The three MPDO proofs that split a length-`N` sitewise product into a 2-site window and its complement now call **`MPSTensor.prod_cyclicWindow_complement`** instead of local copies.
> 
> The generated **`ParentHamiltonian`** aggregator adds the new import, and **`docs/tactic_patterns.md`** records the shared API and call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85eabc5e2f89a4b10c15b3fc6ce26f420f2da712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
