### PR TITLE
feat(Channel): prove Choi-dominated Doeblin contraction (Wolf Chapter 8, Eq. (8.86))

### DIFF
--- a/TNLean/Analysis/TraceNormContractivity.lean
+++ b/TNLean/Analysis/TraceNormContractivity.lean
@@ -453,37 +453,41 @@ map `T'(X) = tr[X]·Y` has Choi matrix `(1/d)(Y ⊗ 𝟙)` in the output-factor-
 tensor order of `ChoiRectangular.choiMatrix`.
 
 `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, line 973. -/
-lemma choiMatrix_tracePrepareMap [NeZero d]
+lemma choiMatrix_tracePrepareMap (d d' : ℕ)
     (Y : Matrix (Fin d') (Fin d') ℂ) :
     ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) =
       (1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)) := by
-  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
-  ext ⟨a, i⟩ ⟨b, j⟩
-  -- Compute both sides elementwise
-  calc
-    ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) (a, i) (b, j)
-        = (tracePrepareMap (α := Fin d) Y
-            (Matrix.bipartiteSlice (Matrix.omegaProj d) i j)) a b := by
-      rw [ChoiRectangular.choiMatrix_apply]
-    _ = (Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) • Y) a b := by
-      rw [tracePrepareMap_apply]
-    _ = Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) * Y a b := by
-      rw [Matrix.smul_apply, smul_eq_mul]
-    _ = Matrix.trace ((1 / (d : ℂ)) • Matrix.single i j (1 : ℂ)) * Y a b := by
-      have h := ChoiJamiolkowski.omegaSlice_eq_single (D := d) i j
-      rw [h, ChoiJamiolkowski.omegaCoeff_eq_inv hdpos]
-      simp [Matrix.smul_single]
-    _ = ((1 / (d : ℂ)) * Matrix.trace (Matrix.single i j (1 : ℂ))) * Y a b := by
-      rw [Matrix.trace_smul, smul_eq_mul]
-    _ = (1 / (d : ℂ)) * (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ))
-          (a, i) (b, j) := by
-      by_cases hij : i = j
-      · subst hij
-        simp [kroneckerMap_apply]
-      · simp [kroneckerMap_apply, hij]
-    _ = ((1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)))
-          (a, i) (b, j) := by
-      rw [Matrix.smul_apply, smul_eq_mul]
+  by_cases hd : d = 0
+  · subst hd
+    ext ⟨a, i⟩ ⟨b, j⟩
+    exact Fin.elim0 i
+  · haveI : NeZero d := ⟨hd⟩
+    have hdpos : 0 < d := Nat.pos_of_ne_zero hd
+    ext ⟨a, i⟩ ⟨b, j⟩
+    calc
+      ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) (a, i) (b, j)
+          = (tracePrepareMap (α := Fin d) Y
+              (Matrix.bipartiteSlice (Matrix.omegaProj d) i j)) a b := by
+        rw [ChoiRectangular.choiMatrix_apply]
+      _ = (Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) • Y) a b := by
+        rw [tracePrepareMap_apply]
+      _ = Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) * Y a b := by
+        rw [Matrix.smul_apply, smul_eq_mul]
+      _ = Matrix.trace ((1 / (d : ℂ)) • Matrix.single i j (1 : ℂ)) * Y a b := by
+        have h := ChoiJamiolkowski.omegaSlice_eq_single (D := d) i j
+        rw [h, ChoiJamiolkowski.omegaCoeff_eq_inv hdpos]
+        simp [Matrix.smul_single]
+      _ = ((1 / (d : ℂ)) * Matrix.trace (Matrix.single i j (1 : ℂ))) * Y a b := by
+        rw [Matrix.trace_smul, smul_eq_mul]
+      _ = (1 / (d : ℂ)) * (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ))
+            (a, i) (b, j) := by
+        by_cases hij : i = j
+        · subst hij
+          simp [kroneckerMap_apply]
+        · simp [kroneckerMap_apply, hij]
+      _ = ((1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)))
+            (a, i) (b, j) := by
+        rw [Matrix.smul_apply, smul_eq_mul]
 
 /-- **Wolf Chapter 8, Eq. (8.86): Choi-dominated Doeblin contraction.**
 
@@ -506,7 +510,7 @@ positive, satisfying the hypothesis of Theorem 8.17.
 
 `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 971–979. -/
 theorem traceNorm_map_sub_map_le_of_choi_domination
-    {D D' : ℕ} [NeZero D]
+    {D D' : ℕ}
     {ε : ℝ}
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D') (Fin D') ℂ}
     {Y : Matrix (Fin D') (Fin D') ℂ}
@@ -520,60 +524,66 @@ theorem traceNorm_map_sub_map_le_of_choi_domination
     {ρ₁ ρ₂ : Matrix (Fin D) (Fin D) ℂ} (h₁ : ρ₁.PosSemidef)
     (h₂ : ρ₂.PosSemidef) (h₁tr : ρ₁.trace = 1) (h₂tr : ρ₂.trace = 1) :
     traceNorm (T ρ₁ - T ρ₂) ≤ (1 - ε) * traceNorm (ρ₁ - ρ₂) := by
-  -- Step 1: construct T' = tracePrepareMap Y
-  set T' := tracePrepareMap (α := Fin D) Y with hT'_def
-  -- T' is trace-preserving (since tr Y = 1)
-  have htrT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, (T' X).trace = X.trace := by
-    intro X
-    rw [hT'_def, tracePrepareMap_trace, hYtr, mul_one]
-  -- T' is Hermiticity-preserving
-  have hhermT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, X.IsHermitian → (T' X).IsHermitian := by
-    intro X hX
-    have htr_star : star (X.trace) = X.trace := by
+  by_cases hD : D = 0
+  · subst hD
+    have hzero : (ρ₁ : Matrix (Fin 0) (Fin 0) ℂ).trace = (0 : ℂ) := by simp
+    rw [hzero] at h₁tr
+    norm_num at h₁tr
+  · haveI : NeZero D := ⟨hD⟩
+    -- Step 1: construct T' = tracePrepareMap Y
+    set T' := tracePrepareMap (α := Fin D) Y with hT'_def
+    -- T' is trace-preserving (since tr Y = 1)
+    have htrT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, (T' X).trace = X.trace := by
+      intro X
+      rw [hT'_def, tracePrepareMap_trace, hYtr, mul_one]
+    -- T' is Hermiticity-preserving
+    have hhermT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, X.IsHermitian → (T' X).IsHermitian := by
+      intro X hX
+      have htr_star : star (X.trace) = X.trace := by
+        calc
+          star (X.trace) = (Xᴴ).trace := by rw [Matrix.trace_conjTranspose]
+          _ = X.trace := by rw [hX]
+      rw [hT'_def, tracePrepareMap_apply]
       calc
-        star (X.trace) = (Xᴴ).trace := by rw [Matrix.trace_conjTranspose]
-        _ = X.trace := by rw [hX]
-    rw [hT'_def, tracePrepareMap_apply]
-    calc
-      (X.trace • Y)ᴴ = star (X.trace) • Yᴴ := by simp [Matrix.conjTranspose_smul]
-      _ = star (X.trace) • Y := by rw [hYherm.eq]
-      _ = X.trace • Y := by rw [htr_star]
-  -- T' has the special form T'(X) = tr[X]·Y
-  have hT'_form : ∃ Y' : Matrix (Fin D') (Fin D') ℂ,
-      ∀ X : Matrix (Fin D) (Fin D) ℂ, T' X = (X.trace) • Y' := by
-    refine ⟨Y, ?_⟩
-    intro X
-    rw [hT'_def, tracePrepareMap_apply]
-  -- Step 2: key identity choiMatrix(T') = (1/D)(Y ⊗ 𝟙)
-  have hchoi_T' : ChoiRectangular.choiMatrix T' =
-      (1 / (D : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) :=
-    choiMatrix_tracePrepareMap Y
-  -- Step 3: choi(T - ε·T') ≥ 0 via linearity and Choi domination
-  have hchoi_diff_pos : (ChoiRectangular.choiMatrix (T - (ε : ℂ) • T')).PosSemidef := by
-    have hsub : ChoiRectangular.choiMatrix (T - (ε : ℂ) • T') =
-        ChoiRectangular.choiMatrix T - ChoiRectangular.choiMatrix ((ε : ℂ) • T') :=
-      (ChoiRectangular.choiMatrixLinearMap (d := D) (d' := D')).map_sub T ((ε : ℂ) • T')
-    rw [hsub, ChoiRectangular.choiMatrix_smul, hchoi_T']
-    -- Now:  choi(T) - (ε:ℂ) • ((1/D)(Y⊗1)) = choi(T) - ((ε:ℂ)/D)(Y⊗1)
-    have hsmul : (ε : ℂ) • ((1 / (D : ℂ)) •
-        (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ))) =
-        ((ε : ℂ) / (D : ℂ)) •
-        (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) := by
-      rw [smul_smul]
-      congr
-      ring
-    rw [hsmul]
-    -- hchoi says choi(T) ≥ ((ε:ℂ)/D)(Y⊗1), so the difference is PSD
-    exact (Matrix.le_iff.mp hchoi)
-  -- Step 4: by rectangular CP/PSD equivalence, T - ε·T' is completely positive
-  have hCP_diff : IsKrausCP (T - (ε : ℂ) • T') :=
-    (ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef (T - (ε : ℂ) • T')).mpr hchoi_diff_pos
-  -- Hence T - ε·T' preserves PSD (positive map)
-  have hpos_diff : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef →
-      ((T - (ε : ℂ) • T') ρ).PosSemidef :=
-    fun ρ hρ => hCP_diff.map_posSemidef hρ
-  -- Step 5: apply the quantum Doeblin theorem
-  exact traceNorm_map_sub_map_le_of_doeblin htrT htrT' hhermT hhermT' hT'_form
-    hε_nonneg hpos_diff h₁ h₂ h₁tr h₂tr
+        (X.trace • Y)ᴴ = star (X.trace) • Yᴴ := by simp [Matrix.conjTranspose_smul]
+        _ = star (X.trace) • Y := by rw [hYherm.eq]
+        _ = X.trace • Y := by rw [htr_star]
+    -- T' has the special form T'(X) = tr[X]·Y
+    have hT'_form : ∃ Y' : Matrix (Fin D') (Fin D') ℂ,
+        ∀ X : Matrix (Fin D) (Fin D) ℂ, T' X = (X.trace) • Y' := by
+      refine ⟨Y, ?_⟩
+      intro X
+      rw [hT'_def, tracePrepareMap_apply]
+    -- Step 2: key identity choiMatrix(T') = (1/D)(Y ⊗ 𝟙)
+    have hchoi_T' : ChoiRectangular.choiMatrix T' =
+        (1 / (D : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) :=
+      choiMatrix_tracePrepareMap D D' Y
+    -- Step 3: choi(T - ε·T') ≥ 0 via linearity and Choi domination
+    have hchoi_diff_pos : (ChoiRectangular.choiMatrix (T - (ε : ℂ) • T')).PosSemidef := by
+      have hsub : ChoiRectangular.choiMatrix (T - (ε : ℂ) • T') =
+          ChoiRectangular.choiMatrix T - ChoiRectangular.choiMatrix ((ε : ℂ) • T') :=
+        (ChoiRectangular.choiMatrixLinearMap (d := D) (d' := D')).map_sub T ((ε : ℂ) • T')
+      rw [hsub, ChoiRectangular.choiMatrix_smul, hchoi_T']
+      -- Now:  choi(T) - (ε:ℂ) • ((1/D)(Y⊗1)) = choi(T) - ((ε:ℂ)/D)(Y⊗1)
+      have hsmul : (ε : ℂ) • ((1 / (D : ℂ)) •
+          (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ))) =
+          ((ε : ℂ) / (D : ℂ)) •
+          (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+        rw [smul_smul]
+        congr
+        ring
+      rw [hsmul]
+      -- hchoi says choi(T) ≥ ((ε:ℂ)/D)(Y⊗1), so the difference is PSD
+      exact (Matrix.le_iff.mp hchoi)
+    -- Step 4: by rectangular CP/PSD equivalence, T - ε·T' is completely positive
+    have hCP_diff : IsKrausCP (T - (ε : ℂ) • T') :=
+      (ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef (T - (ε : ℂ) • T')).mpr hchoi_diff_pos
+    -- Hence T - ε·T' preserves PSD (positive map)
+    have hpos_diff : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef →
+        ((T - (ε : ℂ) • T') ρ).PosSemidef :=
+      fun ρ hρ => hCP_diff.map_posSemidef hρ
+    -- Step 5: apply the quantum Doeblin theorem
+    exact traceNorm_map_sub_map_le_of_doeblin htrT htrT' hhermT hhermT' hT'_form
+      hε_nonneg hpos_diff h₁ h₂ h₁tr h₂tr
 
 end Matrix

--- a/TNLean/Analysis/TraceNormContractivity.lean
+++ b/TNLean/Analysis/TraceNormContractivity.lean
@@ -53,13 +53,17 @@ requires no continuity hypothesis because the spectrum of a matrix is finite.
   contractivity, generalizes Eq. (8.79) to maps with scaled trace.
 * `Matrix.traceNorm_map_sub_map_le_of_doeblin` — Wolf Theorem 8.17
   (quantum Doeblin), Eq. (8.82).
+* `Matrix.choiMatrix_tracePrepareMap` — the rectangular Choi matrix
+  of the trace-prepare map is $(1/d)(Y \otimes \mathbf{1})$.
+* `Matrix.traceNorm_map_sub_map_le_of_choi_domination` — Wolf Eq. (8.86):
+  Choi-dominated Doeblin contraction.
 
 ## References
 
 Michael M. Wolf, *Quantum Channels & Operations: Guided Tour* (July 5, 2012),
 Chapter 8, Theorems 8.16 and 8.17 (printed numbering);
-Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 898-918 (Thm. 8.16)
-and 943-969 (Thm. 8.17).
+Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 898-918 (Thm. 8.16),
+943-969 (Thm. 8.17), and 971-979 (Eq. (8.86)).
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -449,7 +453,7 @@ map `T'(X) = tr[X]·Y` has Choi matrix `(1/d)(Y ⊗ 𝟙)` in the output-factor-
 tensor order of `ChoiRectangular.choiMatrix`.
 
 `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, line 973. -/
-theorem choiMatrix_tracePrepareMap [NeZero d]
+lemma choiMatrix_tracePrepareMap [NeZero d]
     (Y : Matrix (Fin d') (Fin d') ℂ) :
     ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) =
       (1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)) := by

--- a/TNLean/Analysis/TraceNormContractivity.lean
+++ b/TNLean/Analysis/TraceNormContractivity.lean
@@ -6,10 +6,7 @@ Authors: Sirui Lu
 import TNLean.Analysis.TraceNormAbs
 import TNLean.Algebra.MatrixAux
 import TNLean.Channel.ChoiRectangular
-import TNLean.Channel.ChoiJamiolkowski
-import TNLean.Channel.KrausCPTP
 import TNLean.Channel.SupportCompletion
-import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
 # Trace-norm contractivity of trace-preserving positive maps
@@ -441,16 +438,13 @@ theorem traceNorm_map_sub_map_le_of_doeblin
   -- Step 5: apply the scaled-trace contractivity theorem to S
   have h_herm : (ρ₁ - ρ₂).IsHermitian := h₁.isHermitian.sub h₂.isHermitian
   exact traceNorm_map_le_of_positive_of_scaledTrace hpos_diff htr_scale
-
-
     h_one_minus_ε_nonneg h_herm
-
 
 /-! ### Choi-dominated Doeblin contraction (Wolf Chapter 8, Eq. (8.86)) -/
 
 /-- **Choi matrix of the trace-prepare map** (auxiliary lemma for Eq. (8.86)).
 
-For a Hermitian matrix `Y` of trace one on the output space, the trace-prepare
+For an arbitrary matrix `Y` on the output space, the trace-prepare
 map `T'(X) = tr[X]·Y` has Choi matrix `(1/d)(Y ⊗ 𝟙)` in the output-factor-first
 tensor order of `ChoiRectangular.choiMatrix`.
 
@@ -487,11 +481,12 @@ theorem choiMatrix_tracePrepareMap [NeZero d]
     _ = ((1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)))
           (a, i) (b, j) := by
       rw [Matrix.smul_apply, smul_eq_mul]
+
 /-- **Wolf Chapter 8, Eq. (8.86): Choi-dominated Doeblin contraction.**
 
 Let `T : M_D(ℂ) → M_{D'}(ℂ)` be a trace-preserving, Hermiticity-preserving
-linear map.  If there exist `ε ≥ 0` and a Hermitian `Y` with trace one such
-that the (rectangular, output-factor-first) Choi matrix satisfies
+linear map.  For `ε ≥ 0` and a Hermitian `Y` with trace one, if
+the (rectangular, output-factor-first) Choi matrix satisfies
 ```
 τ = choi(T) ≥ (ε/D)(Y ⊗ 𝟙),
 ```

--- a/TNLean/Analysis/TraceNormContractivity.lean
+++ b/TNLean/Analysis/TraceNormContractivity.lean
@@ -5,8 +5,6 @@ Authors: Sirui Lu
 -/
 import TNLean.Analysis.TraceNormAbs
 import TNLean.Algebra.MatrixAux
-import TNLean.Channel.ChoiRectangular
-import TNLean.Channel.SupportCompletion
 
 /-!
 # Trace-norm contractivity of trace-preserving positive maps
@@ -53,17 +51,13 @@ requires no continuity hypothesis because the spectrum of a matrix is finite.
   contractivity, generalizes Eq. (8.79) to maps with scaled trace.
 * `Matrix.traceNorm_map_sub_map_le_of_doeblin` — Wolf Theorem 8.17
   (quantum Doeblin), Eq. (8.82).
-* `Matrix.choiMatrix_tracePrepareMap` — the rectangular Choi matrix
-  of the trace-prepare map is $(1/d)(Y \otimes \mathbf{1})$.
-* `Matrix.traceNorm_map_sub_map_le_of_choi_domination` — Wolf Eq. (8.86):
-  Choi-dominated Doeblin contraction.
 
 ## References
 
 Michael M. Wolf, *Quantum Channels & Operations: Guided Tour* (July 5, 2012),
 Chapter 8, Theorems 8.16 and 8.17 (printed numbering);
-Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 898-918 (Thm. 8.16),
-943-969 (Thm. 8.17), and 971-979 (Eq. (8.86)).
+Notes/WolfNoteTexSource/ch08_distance_measures.tex lines 898-918 (Thm. 8.16)
+and 943-969 (Thm. 8.17).
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -443,147 +437,5 @@ theorem traceNorm_map_sub_map_le_of_doeblin
   have h_herm : (ρ₁ - ρ₂).IsHermitian := h₁.isHermitian.sub h₂.isHermitian
   exact traceNorm_map_le_of_positive_of_scaledTrace hpos_diff htr_scale
     h_one_minus_ε_nonneg h_herm
-
-/-! ### Choi-dominated Doeblin contraction (Wolf Chapter 8, Eq. (8.86)) -/
-
-/-- **Choi matrix of the trace-prepare map** (auxiliary lemma for Eq. (8.86)).
-
-For an arbitrary matrix `Y` on the output space, the trace-prepare
-map `T'(X) = tr[X]·Y` has Choi matrix `(1/d)(Y ⊗ 𝟙)` in the output-factor-first
-tensor order of `ChoiRectangular.choiMatrix`.
-
-`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, line 973. -/
-lemma choiMatrix_tracePrepareMap (d d' : ℕ)
-    (Y : Matrix (Fin d') (Fin d') ℂ) :
-    ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) =
-      (1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)) := by
-  by_cases hd : d = 0
-  · subst hd
-    ext ⟨a, i⟩ ⟨b, j⟩
-    exact Fin.elim0 i
-  · haveI : NeZero d := ⟨hd⟩
-    have hdpos : 0 < d := Nat.pos_of_ne_zero hd
-    ext ⟨a, i⟩ ⟨b, j⟩
-    calc
-      ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) (a, i) (b, j)
-          = (tracePrepareMap (α := Fin d) Y
-              (Matrix.bipartiteSlice (Matrix.omegaProj d) i j)) a b := by
-        rw [ChoiRectangular.choiMatrix_apply]
-      _ = (Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) • Y) a b := by
-        rw [tracePrepareMap_apply]
-      _ = Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) * Y a b := by
-        rw [Matrix.smul_apply, smul_eq_mul]
-      _ = Matrix.trace ((1 / (d : ℂ)) • Matrix.single i j (1 : ℂ)) * Y a b := by
-        have h := ChoiJamiolkowski.omegaSlice_eq_single (D := d) i j
-        rw [h, ChoiJamiolkowski.omegaCoeff_eq_inv hdpos]
-        simp [Matrix.smul_single]
-      _ = ((1 / (d : ℂ)) * Matrix.trace (Matrix.single i j (1 : ℂ))) * Y a b := by
-        rw [Matrix.trace_smul, smul_eq_mul]
-      _ = (1 / (d : ℂ)) * (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ))
-            (a, i) (b, j) := by
-        by_cases hij : i = j
-        · subst hij
-          simp [kroneckerMap_apply]
-        · simp [kroneckerMap_apply, hij]
-      _ = ((1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)))
-            (a, i) (b, j) := by
-        rw [Matrix.smul_apply, smul_eq_mul]
-
-/-- **Wolf Chapter 8, Eq. (8.86): Choi-dominated Doeblin contraction.**
-
-Let `T : M_D(ℂ) → M_{D'}(ℂ)` be a trace-preserving, Hermiticity-preserving
-linear map.  For `ε ≥ 0` and a Hermitian `Y` with trace one, if
-the (rectangular, output-factor-first) Choi matrix satisfies
-```
-τ = choi(T) ≥ (ε/D)(Y ⊗ 𝟙),
-```
-then for all density operators `ρ₁, ρ₂ ∈ M_D`,
-```
-‖T(ρ₁) - T(ρ₂)‖₁ ≤ (1 - ε) ‖ρ₁ - ρ₂‖₁.
-```
-
-The proof constructs `T'(X) = tr[X]·Y` (the trace-prepare map) and applies
-`Matrix.traceNorm_map_sub_map_le_of_doeblin` (Wolf Theorem 8.17, Eq. (8.82)).
-The Choi domination guarantees, via the rectangular CP/PSD equivalence
-(`ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef`), that `T - ε·T'` is
-positive, satisfying the hypothesis of Theorem 8.17.
-
-`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 971–979. -/
-theorem traceNorm_map_sub_map_le_of_choi_domination
-    {D D' : ℕ}
-    {ε : ℝ}
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D') (Fin D') ℂ}
-    {Y : Matrix (Fin D') (Fin D') ℂ}
-    (htrT : ∀ X : Matrix (Fin D) (Fin D) ℂ, (T X).trace = X.trace)
-    (hhermT : ∀ X : Matrix (Fin D) (Fin D) ℂ, X.IsHermitian → (T X).IsHermitian)
-    (hYherm : Y.IsHermitian)
-    (hYtr : Y.trace = 1)
-    (hε_nonneg : 0 ≤ ε)
-    (hchoi : ChoiRectangular.choiMatrix T ≥
-      ((ε : ℂ) / (D : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)))
-    {ρ₁ ρ₂ : Matrix (Fin D) (Fin D) ℂ} (h₁ : ρ₁.PosSemidef)
-    (h₂ : ρ₂.PosSemidef) (h₁tr : ρ₁.trace = 1) (h₂tr : ρ₂.trace = 1) :
-    traceNorm (T ρ₁ - T ρ₂) ≤ (1 - ε) * traceNorm (ρ₁ - ρ₂) := by
-  by_cases hD : D = 0
-  · subst hD
-    have hzero : (ρ₁ : Matrix (Fin 0) (Fin 0) ℂ).trace = (0 : ℂ) := by simp
-    rw [hzero] at h₁tr
-    norm_num at h₁tr
-  · haveI : NeZero D := ⟨hD⟩
-    -- Step 1: construct T' = tracePrepareMap Y
-    set T' := tracePrepareMap (α := Fin D) Y with hT'_def
-    -- T' is trace-preserving (since tr Y = 1)
-    have htrT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, (T' X).trace = X.trace := by
-      intro X
-      rw [hT'_def, tracePrepareMap_trace, hYtr, mul_one]
-    -- T' is Hermiticity-preserving
-    have hhermT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, X.IsHermitian → (T' X).IsHermitian := by
-      intro X hX
-      have htr_star : star (X.trace) = X.trace := by
-        calc
-          star (X.trace) = (Xᴴ).trace := by rw [Matrix.trace_conjTranspose]
-          _ = X.trace := by rw [hX]
-      rw [hT'_def, tracePrepareMap_apply]
-      calc
-        (X.trace • Y)ᴴ = star (X.trace) • Yᴴ := by simp [Matrix.conjTranspose_smul]
-        _ = star (X.trace) • Y := by rw [hYherm.eq]
-        _ = X.trace • Y := by rw [htr_star]
-    -- T' has the special form T'(X) = tr[X]·Y
-    have hT'_form : ∃ Y' : Matrix (Fin D') (Fin D') ℂ,
-        ∀ X : Matrix (Fin D) (Fin D) ℂ, T' X = (X.trace) • Y' := by
-      refine ⟨Y, ?_⟩
-      intro X
-      rw [hT'_def, tracePrepareMap_apply]
-    -- Step 2: key identity choiMatrix(T') = (1/D)(Y ⊗ 𝟙)
-    have hchoi_T' : ChoiRectangular.choiMatrix T' =
-        (1 / (D : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) :=
-      choiMatrix_tracePrepareMap D D' Y
-    -- Step 3: choi(T - ε·T') ≥ 0 via linearity and Choi domination
-    have hchoi_diff_pos : (ChoiRectangular.choiMatrix (T - (ε : ℂ) • T')).PosSemidef := by
-      have hsub : ChoiRectangular.choiMatrix (T - (ε : ℂ) • T') =
-          ChoiRectangular.choiMatrix T - ChoiRectangular.choiMatrix ((ε : ℂ) • T') :=
-        (ChoiRectangular.choiMatrixLinearMap (d := D) (d' := D')).map_sub T ((ε : ℂ) • T')
-      rw [hsub, ChoiRectangular.choiMatrix_smul, hchoi_T']
-      -- Now:  choi(T) - (ε:ℂ) • ((1/D)(Y⊗1)) = choi(T) - ((ε:ℂ)/D)(Y⊗1)
-      have hsmul : (ε : ℂ) • ((1 / (D : ℂ)) •
-          (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ))) =
-          ((ε : ℂ) / (D : ℂ)) •
-          (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) := by
-        rw [smul_smul]
-        congr
-        ring
-      rw [hsmul]
-      -- hchoi says choi(T) ≥ ((ε:ℂ)/D)(Y⊗1), so the difference is PSD
-      exact (Matrix.le_iff.mp hchoi)
-    -- Step 4: by rectangular CP/PSD equivalence, T - ε·T' is completely positive
-    have hCP_diff : IsKrausCP (T - (ε : ℂ) • T') :=
-      (ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef (T - (ε : ℂ) • T')).mpr hchoi_diff_pos
-    -- Hence T - ε·T' preserves PSD (positive map)
-    have hpos_diff : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef →
-        ((T - (ε : ℂ) • T') ρ).PosSemidef :=
-      fun ρ hρ => hCP_diff.map_posSemidef hρ
-    -- Step 5: apply the quantum Doeblin theorem
-    exact traceNorm_map_sub_map_le_of_doeblin htrT htrT' hhermT hhermT' hT'_form
-      hε_nonneg hpos_diff h₁ h₂ h₁tr h₂tr
 
 end Matrix

--- a/TNLean/Analysis/TraceNormContractivity.lean
+++ b/TNLean/Analysis/TraceNormContractivity.lean
@@ -5,6 +5,11 @@ Authors: Sirui Lu
 -/
 import TNLean.Analysis.TraceNormAbs
 import TNLean.Algebra.MatrixAux
+import TNLean.Channel.ChoiRectangular
+import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.KrausCPTP
+import TNLean.Channel.SupportCompletion
+import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
 # Trace-norm contractivity of trace-preserving positive maps
@@ -436,6 +441,141 @@ theorem traceNorm_map_sub_map_le_of_doeblin
   -- Step 5: apply the scaled-trace contractivity theorem to S
   have h_herm : (ρ₁ - ρ₂).IsHermitian := h₁.isHermitian.sub h₂.isHermitian
   exact traceNorm_map_le_of_positive_of_scaledTrace hpos_diff htr_scale
+
+
     h_one_minus_ε_nonneg h_herm
+
+
+/-! ### Choi-dominated Doeblin contraction (Wolf Chapter 8, Eq. (8.86)) -/
+
+/-- **Choi matrix of the trace-prepare map** (auxiliary lemma for Eq. (8.86)).
+
+For a Hermitian matrix `Y` of trace one on the output space, the trace-prepare
+map `T'(X) = tr[X]·Y` has Choi matrix `(1/d)(Y ⊗ 𝟙)` in the output-factor-first
+tensor order of `ChoiRectangular.choiMatrix`.
+
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, line 973. -/
+theorem choiMatrix_tracePrepareMap [NeZero d]
+    (Y : Matrix (Fin d') (Fin d') ℂ) :
+    ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) =
+      (1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)) := by
+  classical
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  ext ⟨a, i⟩ ⟨b, j⟩
+  -- Compute both sides elementwise
+  calc
+    ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) (a, i) (b, j)
+        = (tracePrepareMap (α := Fin d) Y
+            (Matrix.bipartiteSlice (Matrix.omegaProj d) i j)) a b := by
+      rw [ChoiRectangular.choiMatrix_apply]
+    _ = (Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) • Y) a b := by
+      rw [tracePrepareMap_apply]
+    _ = Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) * Y a b := by
+      rw [Matrix.smul_apply, smul_eq_mul]
+    _ = Matrix.trace ((1 / (d : ℂ)) • Matrix.single i j (1 : ℂ)) * Y a b := by
+      have h := ChoiJamiolkowski.omegaSlice_eq_single (D := d) i j
+      rw [h, ChoiJamiolkowski.omegaCoeff_eq_inv hdpos]
+      simp [Matrix.smul_single]
+    _ = ((1 / (d : ℂ)) * Matrix.trace (Matrix.single i j (1 : ℂ))) * Y a b := by
+      rw [Matrix.trace_smul, smul_eq_mul]
+    _ = ((1 : ℂ) / (d : ℂ)) * (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ))
+          (a, i) (b, j) := by
+      by_cases hij : i = j
+      · subst hij
+        simp [kroneckerMap_apply]
+      · simp [kroneckerMap_apply, hij]
+    _ = ((1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)))
+          (a, i) (b, j) := by
+      rw [Matrix.smul_apply, smul_eq_mul]
+/-- **Wolf Chapter 8, Eq. (8.86): Choi-dominated Doeblin contraction.**
+
+Let `T : M_D(ℂ) → M_{D'}(ℂ)` be a trace-preserving, Hermiticity-preserving
+linear map.  If there exist `ε ≥ 0` and a Hermitian `Y` with trace one such
+that the (rectangular, output-factor-first) Choi matrix satisfies
+```
+τ = choi(T) ≥ (ε/D)(Y ⊗ 𝟙),
+```
+then for all density operators `ρ₁, ρ₂ ∈ M_D`,
+```
+‖T(ρ₁) - T(ρ₂)‖₁ ≤ (1 - ε) ‖ρ₁ - ρ₂‖₁.
+```
+
+The proof constructs `T'(X) = tr[X]·Y` (the trace-prepare map) and applies
+`Matrix.traceNorm_map_sub_map_le_of_doeblin` (Wolf Theorem 8.17, Eq. (8.82)).
+The Choi domination guarantees, via the rectangular CP/PSD equivalence
+(`ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef`), that `T - ε·T'` is
+positive, satisfying the hypothesis of Theorem 8.17.
+
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 971–979. -/
+theorem traceNorm_map_sub_map_le_of_choi_domination
+    {D D' : ℕ} [NeZero D]
+    {ε : ℝ}
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D') (Fin D') ℂ}
+    {Y : Matrix (Fin D') (Fin D') ℂ}
+    (htrT : ∀ X : Matrix (Fin D) (Fin D) ℂ, (T X).trace = X.trace)
+    (hhermT : ∀ X : Matrix (Fin D) (Fin D) ℂ, X.IsHermitian → (T X).IsHermitian)
+    (hYherm : Y.IsHermitian)
+    (hYtr : Y.trace = 1)
+    (hε_nonneg : 0 ≤ ε)
+    (hchoi : ChoiRectangular.choiMatrix T ≥
+      ((ε : ℂ) / (D : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)))
+    {ρ₁ ρ₂ : Matrix (Fin D) (Fin D) ℂ} (h₁ : ρ₁.PosSemidef)
+    (h₂ : ρ₂.PosSemidef) (h₁tr : ρ₁.trace = 1) (h₂tr : ρ₂.trace = 1) :
+    traceNorm (T ρ₁ - T ρ₂) ≤ (1 - ε) * traceNorm (ρ₁ - ρ₂) := by
+  -- Step 1: construct T' = tracePrepareMap Y
+  set T' := tracePrepareMap (α := Fin D) Y with hT'_def
+  -- T' is trace-preserving (since tr Y = 1)
+  have htrT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, (T' X).trace = X.trace := by
+    intro X
+    rw [hT'_def, tracePrepareMap_trace, hYtr, mul_one]
+  -- T' is Hermiticity-preserving
+  have hhermT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, X.IsHermitian → (T' X).IsHermitian := by
+    intro X hX
+    have htr_star : star (X.trace) = X.trace := by
+      calc
+        star (X.trace) = (Xᴴ).trace := by rw [Matrix.trace_conjTranspose]
+        _ = X.trace := by rw [hX]
+    rw [hT'_def, tracePrepareMap_apply]
+    calc
+      (X.trace • Y)ᴴ = star (X.trace) • Yᴴ := by simp [Matrix.conjTranspose_smul]
+      _ = star (X.trace) • Y := by rw [hYherm.eq]
+      _ = X.trace • Y := by rw [htr_star]
+  -- T' has the special form T'(X) = tr[X]·Y
+  have hT'_form : ∃ Y' : Matrix (Fin D') (Fin D') ℂ,
+      ∀ X : Matrix (Fin D) (Fin D) ℂ, T' X = (X.trace) • Y' := by
+    refine ⟨Y, ?_⟩
+    intro X
+    rw [hT'_def, tracePrepareMap_apply]
+  -- Step 2: key identity choiMatrix(T') = (1/D)(Y ⊗ 𝟙)
+  have hchoi_T' : ChoiRectangular.choiMatrix T' =
+      (1 / (D : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) :=
+    choiMatrix_tracePrepareMap Y
+  -- Step 3: choi(T - ε·T') ≥ 0 via linearity and Choi domination
+  have hchoi_diff_pos : (ChoiRectangular.choiMatrix (T - (ε : ℂ) • T')).PosSemidef := by
+    have hsub : ChoiRectangular.choiMatrix (T - (ε : ℂ) • T') =
+        ChoiRectangular.choiMatrix T - ChoiRectangular.choiMatrix ((ε : ℂ) • T') :=
+      (ChoiRectangular.choiMatrixLinearMap (d := D) (d' := D')).map_sub T ((ε : ℂ) • T')
+    rw [hsub, ChoiRectangular.choiMatrix_smul, hchoi_T']
+    -- Now:  choi(T) - (ε:ℂ) • ((1/D)(Y⊗1)) = choi(T) - ((ε:ℂ)/D)(Y⊗1)
+    have hsmul : (ε : ℂ) • ((1 / (D : ℂ)) •
+        (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ))) =
+        ((ε : ℂ) / (D : ℂ)) •
+        (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+      rw [smul_smul, div_eq_mul_inv, ← mul_assoc]
+      congr
+      ring
+    rw [hsmul]
+    -- hchoi says choi(T) ≥ ((ε:ℂ)/D)(Y⊗1), so the difference is PSD
+    exact (Matrix.le_iff.mp hchoi)
+  -- Step 4: by rectangular CP/PSD equivalence, T - ε·T' is completely positive
+  have hCP_diff : IsKrausCP (T - (ε : ℂ) • T') :=
+    (ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef (T - (ε : ℂ) • T')).mpr hchoi_diff_pos
+  -- Hence T - ε·T' preserves PSD (positive map)
+  have hpos_diff : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef →
+      ((T - (ε : ℂ) • T') ρ).PosSemidef :=
+    fun ρ hρ => hCP_diff.map_posSemidef hρ
+  -- Step 5: apply the quantum Doeblin theorem
+  exact traceNorm_map_sub_map_le_of_doeblin htrT htrT' hhermT hhermT' hT'_form
+    hε_nonneg hpos_diff h₁ h₂ h₁tr h₂tr
 
 end Matrix

--- a/TNLean/Analysis/TraceNormContractivity.lean
+++ b/TNLean/Analysis/TraceNormContractivity.lean
@@ -453,7 +453,6 @@ theorem choiMatrix_tracePrepareMap [NeZero d]
     (Y : Matrix (Fin d') (Fin d') ℂ) :
     ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) =
       (1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)) := by
-  classical
   have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
   ext ⟨a, i⟩ ⟨b, j⟩
   -- Compute both sides elementwise
@@ -472,7 +471,7 @@ theorem choiMatrix_tracePrepareMap [NeZero d]
       simp [Matrix.smul_single]
     _ = ((1 / (d : ℂ)) * Matrix.trace (Matrix.single i j (1 : ℂ))) * Y a b := by
       rw [Matrix.trace_smul, smul_eq_mul]
-    _ = ((1 : ℂ) / (d : ℂ)) * (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ))
+    _ = (1 / (d : ℂ)) * (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ))
           (a, i) (b, j) := by
       by_cases hij : i = j
       · subst hij
@@ -556,7 +555,7 @@ theorem traceNorm_map_sub_map_le_of_choi_domination
         (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ))) =
         ((ε : ℂ) / (D : ℂ)) •
         (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) := by
-      rw [smul_smul, div_eq_mul_inv, ← mul_assoc]
+      rw [smul_smul]
       congr
       ring
     rw [hsmul]

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.Channel.Basic
 import TNLean.Channel.BreuerHallIndecomposable
 import TNLean.Channel.BreuerHallMap
+import TNLean.Channel.ChoiDoeblin
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.ChoiRectangular
 import TNLean.Channel.ChoiTypeMap

--- a/TNLean/Channel/ChoiDoeblin.lean
+++ b/TNLean/Channel/ChoiDoeblin.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.TraceNormContractivity
+import TNLean.Channel.ChoiRectangular
+import TNLean.Channel.SupportCompletion
+
+/-!
+# Choi-dominated Doeblin contraction (Wolf Chapter 8, Eq. (8.86))
+
+If the rectangular Choi matrix of a trace-preserving, Hermiticity-preserving
+linear map `T : M_D(ℂ) → M_{D'}(ℂ)` dominates `(ε/D)(Y ⊗ 𝟙)` for some `ε ≥ 0`
+and Hermitian `Y` with `tr[Y] = 1`, then `T` satisfies the Doeblin trace-norm
+contraction `‖T(ρ₁) - T(ρ₂)‖₁ ≤ (1 - ε)‖ρ₁ - ρ₂‖₁` for all density matrices.
+
+The proof constructs the trace-prepare map `T'(X) = tr[X]·Y`, computes its
+rectangular Choi matrix as `(1/D)(Y ⊗ 𝟙)`, uses the rectangular CP/PSD
+equivalence to derive positivity of `T - ε·T'`, and applies the quantum
+Doeblin theorem (`Matrix.traceNorm_map_sub_map_le_of_doeblin`).
+
+## Main results
+
+* `Matrix.choiMatrix_tracePrepareMap` — the rectangular Choi matrix
+  of the trace-prepare map is `(1/d)(Y ⊗ 𝟙)`.
+* `Matrix.traceNorm_map_sub_map_le_of_choi_domination` — Wolf Eq. (8.86):
+  Choi-dominated Doeblin contraction.
+
+## References
+
+Michael M. Wolf, *Quantum Channels & Operations: Guided Tour* (July 5, 2012),
+Chapter 8, Eq. (8.86);
+Notes/WolfNoteTexSource/ch08_distance_measures.tex, lines 971–979.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+
+noncomputable section
+
+namespace Matrix
+
+/-! ### Choi-dominated Doeblin contraction (Wolf Chapter 8, Eq. (8.86)) -/
+
+/-- **Choi matrix of the trace-prepare map** (auxiliary lemma for Eq. (8.86)).
+
+For an arbitrary matrix `Y` on the output space, the trace-prepare
+map `T'(X) = tr[X]·Y` has Choi matrix `(1/d)(Y ⊗ 𝟙)` in the output-factor-first
+tensor order of `ChoiRectangular.choiMatrix`.
+
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, line 973. -/
+lemma choiMatrix_tracePrepareMap (d d' : ℕ)
+    (Y : Matrix (Fin d') (Fin d') ℂ) :
+    ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) =
+      (1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)) := by
+  by_cases hd : d = 0
+  · subst hd
+    ext ⟨a, i⟩ ⟨b, j⟩
+    exact Fin.elim0 i
+  · haveI : NeZero d := ⟨hd⟩
+    have hdpos : 0 < d := Nat.pos_of_ne_zero hd
+    ext ⟨a, i⟩ ⟨b, j⟩
+    calc
+      ChoiRectangular.choiMatrix (tracePrepareMap (α := Fin d) Y) (a, i) (b, j)
+          = (tracePrepareMap (α := Fin d) Y
+              (Matrix.bipartiteSlice (Matrix.omegaProj d) i j)) a b := by
+        rw [ChoiRectangular.choiMatrix_apply]
+      _ = (Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) • Y) a b := by
+        rw [tracePrepareMap_apply]
+      _ = Matrix.trace (Matrix.bipartiteSlice (Matrix.omegaProj d) i j) * Y a b := by
+        rw [Matrix.smul_apply, smul_eq_mul]
+      _ = Matrix.trace ((1 / (d : ℂ)) • Matrix.single i j (1 : ℂ)) * Y a b := by
+        have h := ChoiJamiolkowski.omegaSlice_eq_single (D := d) i j
+        rw [h, ChoiJamiolkowski.omegaCoeff_eq_inv hdpos]
+        simp [Matrix.smul_single]
+      _ = ((1 / (d : ℂ)) * Matrix.trace (Matrix.single i j (1 : ℂ))) * Y a b := by
+        rw [Matrix.trace_smul, smul_eq_mul]
+      _ = (1 / (d : ℂ)) * (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ))
+            (a, i) (b, j) := by
+        by_cases hij : i = j
+        · subst hij
+          simp [kroneckerMap_apply]
+        · simp [kroneckerMap_apply, hij]
+      _ = ((1 / (d : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin d) (Fin d) ℂ)))
+            (a, i) (b, j) := by
+        rw [Matrix.smul_apply, smul_eq_mul]
+
+/-- **Wolf Chapter 8, Eq. (8.86): Choi-dominated Doeblin contraction.**
+
+Let `T : M_D(ℂ) → M_{D'}(ℂ)` be a trace-preserving, Hermiticity-preserving
+linear map.  For `ε ≥ 0` and a Hermitian `Y` with trace one, if
+the (rectangular, output-factor-first) Choi matrix satisfies
+```
+τ = choi(T) ≥ (ε/D)(Y ⊗ 𝟙),
+```
+then for all density operators `ρ₁, ρ₂ ∈ M_D`,
+```
+‖T(ρ₁) - T(ρ₂)‖₁ ≤ (1 - ε) ‖ρ₁ - ρ₂‖₁.
+```
+
+The proof constructs `T'(X) = tr[X]·Y` (the trace-prepare map) and applies
+`Matrix.traceNorm_map_sub_map_le_of_doeblin` (Wolf Theorem 8.17, Eq. (8.82)).
+The Choi domination guarantees, via the rectangular CP/PSD equivalence
+(`ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef`), that `T - ε·T'` is
+positive, satisfying the hypothesis of Theorem 8.17.
+
+`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 971–979. -/
+theorem traceNorm_map_sub_map_le_of_choi_domination
+    {D D' : ℕ}
+    {ε : ℝ}
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D') (Fin D') ℂ}
+    {Y : Matrix (Fin D') (Fin D') ℂ}
+    (htrT : ∀ X : Matrix (Fin D) (Fin D) ℂ, (T X).trace = X.trace)
+    (hhermT : ∀ X : Matrix (Fin D) (Fin D) ℂ, X.IsHermitian → (T X).IsHermitian)
+    (hYherm : Y.IsHermitian)
+    (hYtr : Y.trace = 1)
+    (hε_nonneg : 0 ≤ ε)
+    (hchoi : ChoiRectangular.choiMatrix T ≥
+      ((ε : ℂ) / (D : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)))
+    {ρ₁ ρ₂ : Matrix (Fin D) (Fin D) ℂ} (h₁ : ρ₁.PosSemidef)
+    (h₂ : ρ₂.PosSemidef) (h₁tr : ρ₁.trace = 1) (h₂tr : ρ₂.trace = 1) :
+    traceNorm (T ρ₁ - T ρ₂) ≤ (1 - ε) * traceNorm (ρ₁ - ρ₂) := by
+  by_cases hD : D = 0
+  · subst hD
+    have hzero : (ρ₁ : Matrix (Fin 0) (Fin 0) ℂ).trace = (0 : ℂ) := by simp
+    rw [hzero] at h₁tr
+    norm_num at h₁tr
+  · haveI : NeZero D := ⟨hD⟩
+    -- Step 1: construct T' = tracePrepareMap Y
+    set T' := tracePrepareMap (α := Fin D) Y with hT'_def
+    -- T' is trace-preserving (since tr Y = 1)
+    have htrT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, (T' X).trace = X.trace := by
+      intro X
+      rw [hT'_def, tracePrepareMap_trace, hYtr, mul_one]
+    -- T' is Hermiticity-preserving
+    have hhermT' : ∀ X : Matrix (Fin D) (Fin D) ℂ, X.IsHermitian → (T' X).IsHermitian := by
+      intro X hX
+      have htr_star : star (X.trace) = X.trace := by
+        calc
+          star (X.trace) = (Xᴴ).trace := by rw [Matrix.trace_conjTranspose]
+          _ = X.trace := by rw [hX]
+      rw [hT'_def, tracePrepareMap_apply]
+      calc
+        (X.trace • Y)ᴴ = star (X.trace) • Yᴴ := by simp [Matrix.conjTranspose_smul]
+        _ = star (X.trace) • Y := by rw [hYherm.eq]
+        _ = X.trace • Y := by rw [htr_star]
+    -- T' has the special form T'(X) = tr[X]·Y
+    have hT'_form : ∃ Y' : Matrix (Fin D') (Fin D') ℂ,
+        ∀ X : Matrix (Fin D) (Fin D) ℂ, T' X = (X.trace) • Y' := by
+      refine ⟨Y, ?_⟩
+      intro X
+      rw [hT'_def, tracePrepareMap_apply]
+    -- Step 2: key identity choiMatrix(T') = (1/D)(Y ⊗ 𝟙)
+    have hchoi_T' : ChoiRectangular.choiMatrix T' =
+        (1 / (D : ℂ)) • (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) :=
+      choiMatrix_tracePrepareMap D D' Y
+    -- Step 3: choi(T - ε·T') ≥ 0 via linearity and Choi domination
+    have hchoi_diff_pos : (ChoiRectangular.choiMatrix (T - (ε : ℂ) • T')).PosSemidef := by
+      have hsub : ChoiRectangular.choiMatrix (T - (ε : ℂ) • T') =
+          ChoiRectangular.choiMatrix T - ChoiRectangular.choiMatrix ((ε : ℂ) • T') :=
+        (ChoiRectangular.choiMatrixLinearMap (d := D) (d' := D')).map_sub T ((ε : ℂ) • T')
+      rw [hsub, ChoiRectangular.choiMatrix_smul, hchoi_T']
+      -- Now:  choi(T) - (ε:ℂ) • ((1/D)(Y⊗1)) = choi(T) - ((ε:ℂ)/D)(Y⊗1)
+      have hsmul : (ε : ℂ) • ((1 / (D : ℂ)) •
+          (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ))) =
+          ((ε : ℂ) / (D : ℂ)) •
+          (kroneckerMap (· * ·) Y (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+        rw [smul_smul]
+        congr
+        ring
+      rw [hsmul]
+      -- hchoi says choi(T) ≥ ((ε:ℂ)/D)(Y⊗1), so the difference is PSD
+      exact (Matrix.le_iff.mp hchoi)
+    -- Step 4: by rectangular CP/PSD equivalence, T - ε·T' is completely positive
+    have hCP_diff : IsKrausCP (T - (ε : ℂ) • T') :=
+      (ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef (T - (ε : ℂ) • T')).mpr hchoi_diff_pos
+    -- Hence T - ε·T' preserves PSD (positive map)
+    have hpos_diff : ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosSemidef →
+        ((T - (ε : ℂ) • T') ρ).PosSemidef :=
+      fun ρ hρ => hCP_diff.map_posSemidef hρ
+    -- Step 5: apply the quantum Doeblin theorem
+    exact traceNorm_map_sub_map_le_of_doeblin htrT htrT' hhermT hhermT' hT'_form
+      hε_nonneg hpos_diff h₁ h₂ h₁tr h₂tr
+
+end Matrix

--- a/TNLean/Channel/ChoiDoeblin.lean
+++ b/TNLean/Channel/ChoiDoeblin.lean
@@ -11,19 +11,19 @@ import TNLean.Channel.SupportCompletion
 # Choi-dominated Doeblin contraction
 
 If the rectangular Choi matrix of a trace-preserving, Hermiticity-preserving
-linear map `T : M_D(ℂ) → M_{D'}(ℂ)` dominates `(ε/D)(Y ⊗ 𝟙)` for some `ε ≥ 0`
-and Hermitian `Y` with `tr[Y] = 1`, then `T` satisfies the Doeblin trace-norm
-contraction `‖T(ρ₁) - T(ρ₂)‖₁ ≤ (1 - ε)‖ρ₁ - ρ₂‖₁` for all density matrices.
+linear map $T : M_D(\mathbb{C}) \to M_{D'}(\mathbb{C})$ dominates $(\varepsilon/D)(Y \otimes \mathbf{1})$ for some $\varepsilon \ge 0$
+and Hermitian $Y$ with $\mathrm{tr}[Y] = 1$, then $T$ satisfies the Doeblin trace-norm
+contraction $\|T(\rho_1) - T(\rho_2)\|_1 \le (1 - \varepsilon)\|\rho_1 - \rho_2\|_1$ for all density matrices.
 
-The proof constructs the trace-prepare map `T'(X) = tr[X]·Y`, computes its
-rectangular Choi matrix as `(1/D)(Y ⊗ 𝟙)`, uses the rectangular CP/PSD
-equivalence to derive positivity of `T - ε·T'`, and applies the quantum
+The proof constructs the trace-prepare map $T'(X) = \mathrm{tr}[X]Y$, computes its
+rectangular Choi matrix as $(1/D)(Y \otimes \mathbf{1})$, uses the rectangular CP/PSD
+equivalence to derive positivity of $T - \varepsilon T'$, and applies the quantum
 Doeblin theorem (`Matrix.traceNorm_map_sub_map_le_of_doeblin`).
 
 ## Main results
 
 * `Matrix.choiMatrix_tracePrepareMap` — the rectangular Choi matrix
-  of the trace-prepare map is `(1/d)(Y ⊗ 𝟙)`.
+  of the trace-prepare map is $(1/d)(Y \otimes \mathbf{1})$.
 * `Matrix.traceNorm_map_sub_map_le_of_choi_domination` — Wolf Eq. (8.86):
   Choi-dominated Doeblin contraction.
 
@@ -44,8 +44,8 @@ namespace Matrix
 
 /-- **Choi matrix of the trace-prepare map** (auxiliary lemma for Eq. (8.86)).
 
-For an arbitrary matrix `Y` on the output space, the trace-prepare
-map `T'(X) = tr[X]·Y` has Choi matrix `(1/d)(Y ⊗ 𝟙)` in the output-factor-first
+For an arbitrary matrix $Y$ on the output space, the trace-prepare
+map $T'(X) = \mathrm{tr}[X]Y$ has Choi matrix $(1/d)(Y \otimes \mathbf{1})$ in the output-factor-first
 tensor order of `ChoiRectangular.choiMatrix`.
 
 `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, line 973. -/
@@ -87,21 +87,21 @@ lemma choiMatrix_tracePrepareMap (d d' : ℕ)
 
 /-- **Choi-dominated Doeblin contraction.**
 
-Let `T : M_D(ℂ) → M_{D'}(ℂ)` be a trace-preserving, Hermiticity-preserving
-linear map.  For `ε ≥ 0` and a Hermitian `Y` with trace one, if
+Let $T : M_D(\mathbb{C}) \to M_{D'}(\mathbb{C})$ be a trace-preserving, Hermiticity-preserving
+linear map.  For $\varepsilon \ge 0$ and a Hermitian $Y$ with trace one, if
 the (rectangular, output-factor-first) Choi matrix satisfies
 ```
 τ = choi(T) ≥ (ε/D)(Y ⊗ 𝟙),
 ```
-then for all density operators `ρ₁, ρ₂ ∈ M_D`,
+then for all density operators $\rho_1, \rho_2 \in M_D$,
 ```
 ‖T(ρ₁) - T(ρ₂)‖₁ ≤ (1 - ε) ‖ρ₁ - ρ₂‖₁.
 ```
 
-The proof constructs `T'(X) = tr[X]·Y` (the trace-prepare map) and applies
+The proof constructs $T'(X) = \mathrm{tr}[X]Y$ (the trace-prepare map) and applies
 `Matrix.traceNorm_map_sub_map_le_of_doeblin` (Wolf Theorem 8.17, Eq. (8.82)).
 The Choi domination guarantees, via the rectangular CP/PSD equivalence
-(`ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef`), that `T - ε·T'` is
+(`ChoiRectangular.isKrausCP_iff_choiMatrix_posSemidef`), that $T - \varepsilon T'$ is
 positive, satisfying the hypothesis of Theorem 8.17.
 
 `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 971–979. -/

--- a/TNLean/Channel/ChoiDoeblin.lean
+++ b/TNLean/Channel/ChoiDoeblin.lean
@@ -8,7 +8,7 @@ import TNLean.Channel.ChoiRectangular
 import TNLean.Channel.SupportCompletion
 
 /-!
-# Choi-dominated Doeblin contraction (Wolf Chapter 8, Eq. (8.86))
+# Choi-dominated Doeblin contraction
 
 If the rectangular Choi matrix of a trace-preserving, Hermiticity-preserving
 linear map `T : M_D(ℂ) → M_{D'}(ℂ)` dominates `(ε/D)(Y ⊗ 𝟙)` for some `ε ≥ 0`
@@ -40,7 +40,7 @@ noncomputable section
 
 namespace Matrix
 
-/-! ### Choi-dominated Doeblin contraction (Wolf Chapter 8, Eq. (8.86)) -/
+/-! ### Choi-dominated Doeblin contraction -/
 
 /-- **Choi matrix of the trace-prepare map** (auxiliary lemma for Eq. (8.86)).
 
@@ -85,7 +85,7 @@ lemma choiMatrix_tracePrepareMap (d d' : ℕ)
             (a, i) (b, j) := by
         rw [Matrix.smul_apply, smul_eq_mul]
 
-/-- **Wolf Chapter 8, Eq. (8.86): Choi-dominated Doeblin contraction.**
+/-- **Choi-dominated Doeblin contraction.**
 
 Let `T : M_D(ℂ) → M_{D'}(ℂ)` be a trace-preserving, Hermiticity-preserving
 linear map.  For `ε ≥ 0` and a Hermitian `Y` with trace one, if

--- a/blueprint/src/chapter/ch19_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch19_entropy_trace_norm.tex
@@ -581,6 +581,63 @@ Theorem~\ref{thm:trace_norm_abs}.
     scaled-trace theorem applies and yields the claimed bound.
 \end{proof}
 
+\begin{lemma}[Choi matrix of the trace-prepare map]
+    \label{lem:choi_matrix_trace_prepare}
+    \lean{Matrix.choiMatrix_tracePrepareMap}
+    \uses{def:choi_matrix_rectangular, def:trace_prepare_map}
+    Let $Y\in\MN{D'}$ be arbitrary.  In the rectangular
+    (output-factor-first) Choi representation,
+    \begin{align}
+        \tau(\mathrm{tracePrepareMap}_{\MN{D}\to\MN{D'}}(Y))
+        = \frac{1}{D}\,(Y\otimes\Id).
+        \label{eq:choi_trace_prepare}
+    \end{align}
+    See \cite[Chapter~8, Eq.~(8.86)]{Wolf2012Quantum}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:omega_slice_single}
+    Direct computation using the elementwise formula for the
+    omega slice and linearity of the Choi assignment.
+\end{proof}
+
+\begin{theorem}[Choi-dominated Doeblin contraction]
+    \label{thm:choi_dominated_doeblin}
+    \lean{Matrix.traceNorm_map_sub_map_le_of_choi_domination}
+    \leanok
+    \uses{def:trace_norm, def:choi_matrix_rectangular,
+      def:trace_preserving_rectangular, def:density_matrices,
+      thm:quantum_doeblin_contraction}
+    Let $T:\MN{D}\to\MN{D'}$ be a trace-preserving,
+    Hermiticity-preserving linear map and $Y\in\MN{D'}$ Hermitian
+    with $\tr[Y]=1$.  If there exists $\varepsilon\geq0$ such that
+    the rectangular Choi matrix $\tau(T)$ satisfies
+    \begin{align}
+        \tau(T) \ge \frac{\varepsilon}{D}\,(Y\otimes\Id),
+        \label{eq:choi_domination}
+    \end{align}
+    then for all density operators $\rho_1,\rho_2\in\MN{D}$,
+    \begin{equation}
+        \lVert T(\rho_1)-T(\rho_2)\rVert_{\tr}
+        \le (1-\varepsilon)\,\lVert\rho_1-\rho_2\rVert_{\tr}.
+        \label{eq:choi_doeblin_contraction}
+    \end{equation}
+    See \cite[Chapter~8, Eq.~(8.86)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:quantum_doeblin_contraction, lem:choi_matrix_trace_prepare,
+      lem:choi_cp_equivalence_rectangular}
+    Set $T'(X)=\tr[X]\,Y$ (the map $\mathrm{tracePrepareMap}(Y)$).
+    By Lemma~\ref{lem:choi_matrix_trace_prepare},
+    $\tau(T')=(1/D)(Y\otimes\Id)$. Linearity of the Choi assignment gives
+    $\tau(T-\varepsilon T')=\tau(T)-\varepsilon\tau(T')
+    \ge0$, so $T-\varepsilon T'$ is completely positive
+    (the rectangular Choi CP equivalence) and hence
+    positive. Theorem~\ref{thm:quantum_doeblin_contraction} then
+    yields the asserted bound.
+\end{proof}
+
 \section{Projective pinching}
 
 \begin{theorem}[Projective pinching inequality]

--- a/blueprint/src/chapter/ch19_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch19_entropy_trace_norm.tex
@@ -609,6 +609,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{def:choi_matrix_rect, def:trace_prepare_map}
     The normalized omega slice is $D^{-1}E_{ij}$, where $E_{ij}$ is the
     matrix unit.  Since $\tr(E_{ij})=\delta_{ij}$, the trace of the slice
     is $D^{-1}\delta_{ij}$, and $T'_Y$ multiplies this scalar by $Y$.
@@ -631,17 +632,17 @@ Theorem~\ref{thm:trace_norm_abs}.
         \label{eq:choi_domination}
     \end{align}
     then for all density operators $\rho_1,\rho_2\in\MN{D}$,
-    \begin{equation}
+    \begin{align}
         \lVert T(\rho_1)-T(\rho_2)\rVert_{\tr}
         \le (1-\varepsilon)\,\lVert\rho_1-\rho_2\rVert_{\tr}.
         \label{eq:choi_doeblin_contraction}
-    \end{equation}
+    \end{align}
     See \cite[Chapter~8, Eq.~(8.86)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:quantum_doeblin_contraction, lem:choi_matrix_trace_prepare,
-      thm:choi_rect_cp}
+      thm:choi_rect_cp, def:trace_prepare_map, lem:is_kraus_cp_basic}
     Since $\tr[Y]=1$, $T'_Y$ is trace-preserving:
     $\tr[T'_Y(X)]=\tr[X]\tr[Y]=\tr[X]$.  Since $Y$ is Hermitian and
     $\tr[X]$ is real for Hermitian $X$, $T'_Y$ is Hermiticity-preserving.

--- a/blueprint/src/chapter/ch19_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch19_entropy_trace_norm.tex
@@ -586,12 +586,10 @@ Theorem~\ref{thm:trace_norm_abs}.
     \lean{Matrix.tracePrepareMap}
     \lean{Matrix.tracePrepareMap_apply}
     \leanok
-    For any matrix $Y\in\MN{D'}$, the trace-prepare map
-    $\mathrm{tracePrepareMap}_{\MN{D}\to\MN{D'}}(Y)$
-    discards the input and prepares $Y$ with the trace weight:
+    For any matrix $Y\in\MN{D'}$, define
+    $T'_Y:\MN{D}\to\MN{D'}$ by
     \begin{align}
-        \mathrm{tracePrepareMap}_{\MN{D}\to\MN{D'}}(Y)(X)
-        = \tr[X]\,Y.
+        T'_Y(X) = \tr[X]\,Y.
         \label{eq:trace_prepare_map}
     \end{align}
 \end{definition}
@@ -601,19 +599,21 @@ Theorem~\ref{thm:trace_norm_abs}.
     \lean{Matrix.choiMatrix_tracePrepareMap}
     \leanok
     \uses{def:choi_matrix_rect, def:trace_prepare_map}
-    Let $Y\in\MN{D'}$ be arbitrary.  In the rectangular
-    (output-factor-first) Choi representation,
+    For arbitrary $Y\in\MN{D'}$, the rectangular
+    (output-factor-first) Choi matrix of $T'_Y$ is
     \begin{align}
-        \tau(\mathrm{tracePrepareMap}_{\MN{D}\to\MN{D'}}(Y))
-        = \frac{1}{D}\,(Y\otimes\Id).
+        \tau(T'_Y) = \frac{1}{D}\,(Y\otimes\Id).
         \label{eq:choi_trace_prepare}
     \end{align}
     See \cite[Chapter~8, Eq.~(8.86)]{Wolf2012Quantum}.
 \end{lemma}
 
 \begin{proof}\leanok
-    Direct computation using the elementwise formula for the
-    omega slice and linearity of the Choi assignment.
+    The normalized omega slice is $D^{-1}E_{ij}$, where $E_{ij}$ is the
+    matrix unit.  Since $\tr(E_{ij})=\delta_{ij}$, the trace of the slice
+    is $D^{-1}\delta_{ij}$, and $T'_Y$ multiplies this scalar by $Y$.
+    On the other hand, $(Y\otimes\Id)_{(a,i),(b,j)} = Y_{ab}\,\delta_{ij}$,
+    so both sides equal $D^{-1}Y_{ab}\,\delta_{ij}$.
 \end{proof}
 
 \begin{theorem}[Choi-dominated Doeblin contraction]
@@ -642,13 +642,15 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{proof}\leanok
     \uses{thm:quantum_doeblin_contraction, lem:choi_matrix_trace_prepare,
       thm:choi_rect_cp}
-    Set $T'(X)=\tr[X]\,Y$ (the map $\mathrm{tracePrepareMap}(Y)$).
+    Since $\tr[Y]=1$, $T'_Y$ is trace-preserving:
+    $\tr[T'_Y(X)]=\tr[X]\tr[Y]=\tr[X]$.  Since $Y$ is Hermitian and
+    $\tr[X]$ is real for Hermitian $X$, $T'_Y$ is Hermiticity-preserving.
     By Lemma~\ref{lem:choi_matrix_trace_prepare},
-    $\tau(T')=(1/D)(Y\otimes\Id)$. Linearity of the Choi assignment gives
-    $\tau(T-\varepsilon T')=\tau(T)-\varepsilon\tau(T')
-    \ge0$, so $T-\varepsilon T'$ is completely positive
-    (the rectangular Choi CP equivalence) and hence
-    positive. Theorem~\ref{thm:quantum_doeblin_contraction} then
+    $\tau(T'_Y)=(1/D)(Y\otimes\Id)$. Linearity of the Choi assignment gives
+    $\tau(T-\varepsilon T'_Y)=\tau(T)-\varepsilon\tau(T'_Y)
+    \ge0$, so $T-\varepsilon T'_Y$ is completely positive
+    (the rectangular Choi CP equivalence, Theorem~\ref{thm:choi_rect_cp})
+    and hence positive. Theorem~\ref{thm:quantum_doeblin_contraction} then
     yields the asserted bound.
 \end{proof}
 

--- a/blueprint/src/chapter/ch19_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch19_entropy_trace_norm.tex
@@ -581,10 +581,25 @@ Theorem~\ref{thm:trace_norm_abs}.
     scaled-trace theorem applies and yields the claimed bound.
 \end{proof}
 
+\begin{definition}[Trace-prepare map]
+    \label{def:trace_prepare_map}
+    \lean{Matrix.tracePrepareMap}
+    \lean{Matrix.tracePrepareMap_apply}
+    \leanok
+    For any matrix $Y\in\MN{D'}$, the trace-prepare map
+    $\mathrm{tracePrepareMap}_{\MN{D}\to\MN{D'}}(Y)$
+    discards the input and prepares $Y$ with the trace weight:
+    \begin{align}
+        \mathrm{tracePrepareMap}_{\MN{D}\to\MN{D'}}(Y)(X)
+        = \tr[X]\,Y.
+        \label{eq:trace_prepare_map}
+    \end{align}
+\end{definition}
+
 \begin{lemma}[Choi matrix of the trace-prepare map]
     \label{lem:choi_matrix_trace_prepare}
     \lean{Matrix.choiMatrix_tracePrepareMap}
-    \uses{def:choi_matrix_rectangular, def:trace_prepare_map}
+    \uses{def:choi_matrix_rect, def:trace_prepare_map}
     Let $Y\in\MN{D'}$ be arbitrary.  In the rectangular
     (output-factor-first) Choi representation,
     \begin{align}
@@ -596,7 +611,6 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{lem:omega_slice_single}
     Direct computation using the elementwise formula for the
     omega slice and linearity of the Choi assignment.
 \end{proof}
@@ -605,7 +619,7 @@ Theorem~\ref{thm:trace_norm_abs}.
     \label{thm:choi_dominated_doeblin}
     \lean{Matrix.traceNorm_map_sub_map_le_of_choi_domination}
     \leanok
-    \uses{def:trace_norm, def:choi_matrix_rectangular,
+    \uses{def:trace_norm, def:choi_matrix_rect,
       def:trace_preserving_rectangular, def:density_matrices}
     Let $T:\MN{D}\to\MN{D'}$ be a trace-preserving,
     Hermiticity-preserving linear map and $Y\in\MN{D'}$ Hermitian
@@ -626,7 +640,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     \uses{thm:quantum_doeblin_contraction, lem:choi_matrix_trace_prepare,
-      lem:choi_cp_equivalence_rectangular}
+      thm:choi_rect_cp}
     Set $T'(X)=\tr[X]\,Y$ (the map $\mathrm{tracePrepareMap}(Y)$).
     By Lemma~\ref{lem:choi_matrix_trace_prepare},
     $\tau(T')=(1/D)(Y\otimes\Id)$. Linearity of the Choi assignment gives

--- a/blueprint/src/chapter/ch19_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch19_entropy_trace_norm.tex
@@ -606,11 +606,10 @@ Theorem~\ref{thm:trace_norm_abs}.
     \lean{Matrix.traceNorm_map_sub_map_le_of_choi_domination}
     \leanok
     \uses{def:trace_norm, def:choi_matrix_rectangular,
-      def:trace_preserving_rectangular, def:density_matrices,
-      thm:quantum_doeblin_contraction}
+      def:trace_preserving_rectangular, def:density_matrices}
     Let $T:\MN{D}\to\MN{D'}$ be a trace-preserving,
     Hermiticity-preserving linear map and $Y\in\MN{D'}$ Hermitian
-    with $\tr[Y]=1$.  If there exists $\varepsilon\geq0$ such that
+    with $\tr[Y]=1$.  For $\varepsilon\geq0$, if
     the rectangular Choi matrix $\tau(T)$ satisfies
     \begin{align}
         \tau(T) \ge \frac{\varepsilon}{D}\,(Y\otimes\Id),

--- a/blueprint/src/chapter/ch19_entropy_trace_norm.tex
+++ b/blueprint/src/chapter/ch19_entropy_trace_norm.tex
@@ -599,6 +599,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{lemma}[Choi matrix of the trace-prepare map]
     \label{lem:choi_matrix_trace_prepare}
     \lean{Matrix.choiMatrix_tracePrepareMap}
+    \leanok
     \uses{def:choi_matrix_rect, def:trace_prepare_map}
     Let $Y\in\MN{D'}$ be arbitrary.  In the rectangular
     (output-factor-first) Choi representation,


### PR DESCRIPTION
Closes LionSR/QICLean#310.

## Summary

New module `TNLean/Channel/ChoiDoeblin.lean` with two declarations:

1. **`Matrix.choiMatrix_tracePrepareMap`** — the rectangular Choi matrix
   of the trace-prepare map `T'(X) = tr[X]·Y` is `(1/d)(Y ⊗ 𝟙)` in the
   output-factor-first tensor order of `ChoiRectangular.choiMatrix`.

2. **`Matrix.traceNorm_map_sub_map_le_of_choi_domination`** — Wolf Chapter 8,
   Eq. (8.86): if the rectangular Choi matrix satisfies
   `τ ≥ (ε/D)(Y ⊗ 𝟙)` with Y Hermitian and trace Y = 1, then the trace-norm
   Doeblin bound `‖T(ρ₁)-T(ρ₂)‖₁ ≤ (1-ε)‖ρ₁-ρ₂‖₁` holds for all density
   matrices.

## Architecture

The module sits in the Channel layer, importing `Analysis.TraceNormContractivity`
(no reverse Analysis→Channel dependency).  It imports `Channel.ChoiRectangular`
and `Channel.SupportCompletion`.

## Proof structure

Constructs `T' = tracePrepareMap Y`, uses linearity of the Choi assignment
and the rectangular CP/PSD equivalence to obtain positivity of `T - ε·T'`,
then applies the quantum Doeblin theorem (`Matrix.traceNorm_map_sub_map_le_of_doeblin`).

## Zero-dimension handling

Both declarations handle `d=0` / `D=0` explicitly without typeclass
`[NeZero d]`/`[NeZero D]` in public signatures.  Zero case: `Fin.elim0`
for the lemma; density trace contradiction for the theorem.

## Faithfulness

- No PSD assumption on Y (only Hermitian + trace 1), matching Wolf Eq. (8.86)
- Rectangular (output-factor-first) Choi order matching `ChoiRectangular`
- Exact factor `(1/D)(Y⊗1)` derived via `ChoiJamiolkowski.omegaSlice_eq_single`
- No `sorry`/`admit`/`axiom`/`native_decide`/`unsafeCast`

## Files changed

- `TNLean/Channel/ChoiDoeblin.lean` — new (188 lines)
- `TNLean/Channel.lean` — regenerated import aggregator
- `TNLean/Analysis/TraceNormContractivity.lean` — reverted to origin/main
- `blueprint/src/chapter/ch19_entropy_trace_norm.tex` — blueprint entries (57 lines)

## Verification

`lake build TNLean.Channel.ChoiDoeblin` succeeds (3058 jobs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs in the Channel layer reusing existing Choi and trace-norm infrastructure; no auth, runtime, or API surface changes.
> 
> **Overview**
> Adds **`TNLean/Channel/ChoiDoeblin.lean`** formalizing Wolf Chapter 8, Eq. (8.86): when the rectangular Choi matrix dominates `(ε/D)(Y ⊗ 𝟙)` for Hermitian `Y` with trace 1, trace-preserving maps get the Doeblin trace-norm bound on density matrices.
> 
> **`Matrix.choiMatrix_tracePrepareMap`** shows the trace-prepare map `T'(X) = tr[X]·Y` has Choi matrix `(1/d)(Y ⊗ 𝟙)` in `ChoiRectangular`’s output-first order (including `d = 0` via `Fin.elim0`).
> 
> **`Matrix.traceNorm_map_sub_map_le_of_choi_domination`** builds `T' = tracePrepareMap Y`, uses Choi linearity and domination to get PSD `choi(T − εT')`, then rectangular CP/PSD equivalence and **`traceNorm_map_sub_map_le_of_doeblin`** from Analysis.
> 
> The generated **`TNLean.Channel`** aggregator imports the new module. **Blueprint** `ch19_entropy_trace_norm.tex` adds the trace-prepare definition, the Choi lemma, and the main theorem with Lean links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ffaea2e2c3a563c9f162f9c07aa86f338facb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->