### PR TITLE
feat(MPS/MPU): classify second-block residual span

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -16,5 +16,6 @@ import TNLean.MPS.MPU.ResidualAlgebra
 import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
+import TNLean.MPS.MPU.ThreeFormSpan
 import TNLean.MPS.MPU.TransferMatrix
 import TNLean.MPS.MPU.TransferStabilization

--- a/TNLean/MPS/MPU/ThreeFormSpan.lean
+++ b/TNLean/MPS/MPU/ThreeFormSpan.lean
@@ -1,0 +1,470 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.ResidualAlgebra
+
+/-!
+# Three-form span for the second MPU blocking
+
+This file formalizes the ordered-word step in arXiv:1703.09188, Proposition
+`blockingsimple`, lines 415--425.  Once residual products of length `D²` vanish,
+a product of letters `c E + S` has, after removal of its all-`E` term, only the
+basis-independent span of the forms `E A`, `A E`, and `A E A`.
+
+No assertion is made that a coefficient in an arbitrary physical basis has one
+exclusive type.  The invariant conclusion is membership in the sum of the
+three submodules.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+section ThreeFormSubmodules
+
+variable {R : Type*} [CommRing R]
+variable {B : Type*} [Ring B] [Algebra R B]
+
+/-- The span of products `E * A` with `A` in a residual nonunital algebra.
+
+Source: arXiv:1703.09188, equation `sprimeforms`, type 1, lines 415--424. -/
+def projectorMulResidualSubmodule (E : B) (A : NonUnitalSubalgebra R B) :
+    Submodule R B :=
+  Submodule.span R {x | ∃ a : A, x = E * (a : B)}
+
+/-- The span of products `A * E` with `A` in a residual nonunital algebra.
+
+Source: arXiv:1703.09188, equation `sprimeforms`, type 2, lines 415--424. -/
+def residualMulProjectorSubmodule (E : B) (A : NonUnitalSubalgebra R B) :
+    Submodule R B :=
+  Submodule.span R {x | ∃ a : A, x = (a : B) * E}
+
+/-- The span of products `A * E * B` with `A` and `B` in a residual
+nonunital algebra.
+
+Source: arXiv:1703.09188, equation `sprimeforms`, type 3, lines 415--424. -/
+def residualMulProjectorMulResidualSubmodule
+    (E : B) (A : NonUnitalSubalgebra R B) : Submodule R B :=
+  Submodule.span R {x | ∃ a b : A, x = (a : B) * E * (b : B)}
+
+/-- The basis-invariant sum of the three source forms `E A`, `A E`, and
+`A E A`.
+
+Source: arXiv:1703.09188, equation `sprimeforms`, lines 415--424. -/
+def threeFormSubmodule (E : B) (A : NonUnitalSubalgebra R B) : Submodule R B :=
+  projectorMulResidualSubmodule E A ⊔
+    residualMulProjectorSubmodule E A ⊔
+      residualMulProjectorMulResidualSubmodule E A
+
+private def HasThreeForm (E : B) (A : NonUnitalSubalgebra R B) (x : B) : Prop :=
+  (∃ a : A, x = E * (a : B)) ∨
+    (∃ a : A, x = (a : B) * E) ∨
+      ∃ a b : A, x = (a : B) * E * (b : B)
+
+private theorem HasThreeForm.mem_threeFormSubmodule
+    {E : B} {A : NonUnitalSubalgebra R B} {x : B}
+    (hx : HasThreeForm E A x) : x ∈ threeFormSubmodule E A := by
+  rcases hx with ⟨a, rfl⟩ | ⟨a, rfl⟩ | ⟨a, b, rfl⟩
+  · apply Submodule.mem_sup_left
+    apply Submodule.mem_sup_left
+    exact Submodule.subset_span ⟨a, rfl⟩
+  · apply Submodule.mem_sup_left
+    apply Submodule.mem_sup_right
+    exact Submodule.subset_span ⟨a, rfl⟩
+  · apply Submodule.mem_sup_right
+    exact Submodule.subset_span ⟨a, b, rfl⟩
+
+private theorem HasThreeForm.zero (E : B) (A : NonUnitalSubalgebra R B) :
+    HasThreeForm E A 0 := by
+  left
+  exact ⟨0, by simp⟩
+
+private theorem HasThreeForm.projector_mul
+    {E : B} {A : NonUnitalSubalgebra R B} (hE : E * E = E)
+    (hEAE : ∀ a : A, E * (a : B) * E = 0)
+    {x : B} (hx : HasThreeForm E A x) : HasThreeForm E A (E * x) := by
+  rcases hx with ⟨a, rfl⟩ | ⟨a, rfl⟩ | ⟨a, b, rfl⟩
+  · left
+    exact ⟨a, by simp [← mul_assoc, hE]⟩
+  · rw [← mul_assoc, hEAE a]
+    exact HasThreeForm.zero E A
+  · rw [← mul_assoc, ← mul_assoc, hEAE a, zero_mul]
+    exact HasThreeForm.zero E A
+
+private theorem HasThreeForm.residual_mul
+    {E : B} {A : NonUnitalSubalgebra R B} (a : A)
+    {x : B} (hx : HasThreeForm E A x) : HasThreeForm E A ((a : B) * x) := by
+  rcases hx with ⟨b, rfl⟩ | ⟨b, rfl⟩ | ⟨b, c, rfl⟩
+  · right; right
+    exact ⟨a, b, by simp [mul_assoc]⟩
+  · right; left
+    exact ⟨⟨(a : B) * b, A.mul_mem a.property b.property⟩, by simp [mul_assoc]⟩
+  · right; right
+    exact ⟨⟨(a : B) * b, A.mul_mem a.property b.property⟩, c, by simp [mul_assoc]⟩
+
+private theorem pow_eq_self_of_pos {E : B} (hE : E * E = E)
+    {N : ℕ} (hN : 0 < N) : E ^ N = E := by
+  obtain ⟨N, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hN)
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      rw [pow_succ, ih (by omega), hE]
+
+
+private theorem list_prod_mem_of_ne_nil
+    (A : NonUnitalSubalgebra R B) (l : List B) (hne : l ≠ [])
+    (hl : ∀ x ∈ l, x ∈ A) : l.prod ∈ A := by
+  induction l with
+  | nil => simp at hne
+  | cons x l ih =>
+      by_cases hl_nil : l = []
+      · subst l
+        simpa using hl x (by simp)
+      · rw [List.prod_cons]
+        exact A.mul_mem (hl x (by simp))
+          (ih hl_nil (fun y hy ↦ hl y (List.mem_cons_of_mem x hy)))
+
+private theorem ordered_option_word_classification
+    (E : B) (A : NonUnitalSubalgebra R B) (hE : E * E = E)
+    (hEAE : ∀ a : A, E * (a : B) * E = 0)
+    (l : List (Option A)) :
+    ((∀ o ∈ l, o = none) ∧
+        (l.map (fun o ↦ o.elim E (fun a ↦ (a : B)))).prod = E ^ l.length) ∨
+      (∃ la : List A, l = la.map some ∧
+        (l.map (fun o ↦ o.elim E (fun a ↦ (a : B)))).prod =
+          (la.map ((↑) : A → B)).prod) ∨
+      HasThreeForm E A (l.map (fun o ↦ o.elim E (fun a ↦ (a : B)))).prod := by
+  induction l with
+  | nil => exact Or.inl ⟨by simp, by simp⟩
+  | cons o l ih =>
+      rcases o with _ | a
+      · rcases ih with ⟨hnone, hprod⟩ | ⟨la, rfl, hprod⟩ | hthree
+        · left
+          exact ⟨by simpa using hnone, by simp [hprod, pow_succ']⟩
+        · by_cases hla : la = []
+          · subst la
+            left
+            simp
+          · right; right
+            have hpos : 0 < la.length := List.length_pos_iff.mpr hla
+            rw [show (none :: List.map some la).map
+                (fun o ↦ o.elim E (fun a ↦ (a : B))) =
+                E :: la.map ((↑) : A → B) by simp,
+              List.prod_cons]
+            left
+            exact ⟨⟨(la.map ((↑) : A → B)).prod,
+              list_prod_mem_of_ne_nil A _
+                (fun h ↦ hla (List.map_eq_nil_iff.mp h)) (fun b hb ↦ by
+                obtain ⟨a, _, rfl⟩ := List.mem_map.mp hb
+                exact a.property)⟩, rfl⟩
+        · right; right
+          simpa using hthree.projector_mul hE hEAE
+      · rcases ih with ⟨hnone, hprod⟩ | ⟨la, rfl, hprod⟩ | hthree
+        · by_cases hl : l = []
+          · subst l
+            right; left
+            exact ⟨[a], by simp, by simp⟩
+          · right; right
+            have hpos : 0 < l.length := List.length_pos_iff.mpr hl
+            have hpow : E ^ l.length = E := pow_eq_self_of_pos hE hpos
+            rw [List.map_cons, List.prod_cons, hprod, hpow]
+            right; left
+            exact ⟨a, rfl⟩
+        · right; left
+          refine ⟨a :: la, by simp, ?_⟩
+          simp
+        · right; right
+          simpa using hthree.residual_mul a
+
+/-- Ordered noncommutative product-of-sums classification.  Removing the
+all-projector term from a product of `N` letters `cₖ E + Sₖ` leaves the
+three-form submodule, provided length-`N` residual products vanish.
+
+Source: arXiv:1703.09188, equations `Sprime=0` and `sprimeforms`, lines 410--424. -/
+theorem ordered_prod_smul_projector_add_sub_mem_threeFormSubmodule
+    (E : B) (A : NonUnitalSubalgebra R B) (hE : E * E = E)
+    (hEAE : ∀ a : A, E * (a : B) * E = 0)
+    {N : ℕ} (hN : 0 < N)
+    (hvanish : ∀ l : List B, (∀ x ∈ l, x ∈ A) → l.length = N → l.prod = 0)
+    (c : Fin N → R) (S : Fin N → A) :
+    (List.ofFn (fun k ↦ c k • E + (S k : B))).prod - (∏ k, c k) • E ∈
+      threeFormSubmodule E A := by
+  classical
+  let f : Fin N → Bool → B := fun k b ↦ if b then (S k : B) else c k • E
+  have hexpand := List.prod_ofFn_sum f
+  have hsum (k : Fin N) : ∑ b : Bool, f k b = c k • E + (S k : B) := by
+    simp [f, add_comm]
+  simp_rw [hsum] at hexpand
+  rw [hexpand]
+  let eChoice : Fin N → Bool := fun _ ↦ false
+  rw [← Finset.add_sum_erase _ _ (Finset.mem_univ eChoice)]
+  have heword : (List.ofFn fun k ↦ f k (eChoice k)).prod = (∏ k, c k) • E := by
+    change (List.ofFn fun k ↦ c k • E).prod = _
+    calc
+      _ = (∏ k, c k) • (List.ofFn fun _ : Fin N ↦ E).prod :=
+        List.prod_ofFn_smul c (fun _ ↦ E)
+      _ = (∏ k, c k) • E := by
+        rw [List.ofFn_const, List.prod_replicate, pow_eq_self_of_pos hE hN]
+  rw [heword, add_sub_cancel_left]
+  apply Submodule.sum_mem
+  intro choice hchoice
+  have hne : choice ≠ eChoice := by
+    simpa using hchoice
+  let options : List (Option A) :=
+    List.ofFn (fun k ↦ if choice k then some (S k) else none)
+  let coeff : Fin N → R := fun k ↦ if choice k then 1 else c k
+  let base : Fin N → B := fun k ↦ if choice k then (S k : B) else E
+  have hfactor (k : Fin N) : f k (choice k) = coeff k • base k := by
+    by_cases hk : choice k = true <;> simp [f, coeff, base, hk]
+  have hbase : List.ofFn base =
+      options.map (fun o ↦ o.elim E (fun a ↦ (a : B))) := by
+    simp only [options, List.map_ofFn]
+    apply congrArg List.ofFn
+    funext k
+    by_cases hk : choice k = true <;> simp [base, hk]
+  have hword : (List.ofFn fun k ↦ f k (choice k)).prod =
+      (∏ k, if choice k then (1 : R) else c k) •
+        (options.map (fun o ↦ o.elim E (fun a ↦ (a : B)))).prod := by
+    simp_rw [hfactor]
+    calc
+      _ = (∏ k, coeff k) • (List.ofFn base).prod :=
+        List.prod_ofFn_smul coeff base
+      _ = (∏ k, if choice k then (1 : R) else c k) •
+          (options.map (fun o ↦ o.elim E (fun a ↦ (a : B)))).prod := by
+        rw [hbase]
+  rw [hword]
+  apply Submodule.smul_mem
+  rcases ordered_option_word_classification E A hE hEAE options with
+      ⟨hallE, _⟩ | ⟨la, hla, hprod⟩ | hthree
+  · exfalso
+    apply hne
+    funext k
+    have hk := hallE (if choice k then some (S k) else none)
+      (List.mem_ofFn.mpr ⟨k, by simp⟩)
+    simpa using hk
+  · have hlen : la.length = N := by
+      rw [← List.length_map some, ← hla]
+      simp [options]
+    have hmem : ∀ x ∈ la.map ((↑) : A → B), x ∈ A := by
+      intro x hx
+      obtain ⟨a, _, hax⟩ := List.mem_map.mp hx
+      rw [← hax]
+      exact a.property
+    rw [hprod, hvanish _ hmem (by simpa using hlen)]
+    exact (threeFormSubmodule E A).zero_mem
+  · exact hthree.mem_threeFormSubmodule
+
+end ThreeFormSubmodules
+
+section ResidualThreeForms
+
+private theorem exists_nonempty_residual_word_of_mem_closure
+    {U : MPOTensor d D}
+    {x : Matrix (Fin (D * D)) (Fin (D * D)) ℂ}
+    (hx : x ∈ Subsemigroup.closure (residualGeneratorSet U)) :
+    ∃ l : List (Matrix (Fin (D * D)) (Fin (D * D)) ℂ),
+      l ≠ [] ∧ (∀ a ∈ l, a ∈ residualGeneratorSet U) ∧ l.prod = x := by
+  induction hx using Subsemigroup.closure_induction with
+  | mem x hx => exact ⟨[x], by simp, by simpa, by simp⟩
+  | mul x y _ _ hx hy =>
+      obtain ⟨lx, hlx, hlxs, hxl⟩ := hx
+      obtain ⟨ly, hly, hlys, hyl⟩ := hy
+      refine ⟨lx ++ ly, ?_, ?_, ?_⟩
+      · simp [hlx]
+      · intro a ha
+        exact List.mem_append.mp ha |>.elim (hlxs a) (hlys a)
+      · rw [List.prod_append, hxl, hyl]
+
+/-- The rank-one normalized diagonal annihilates every element of the residual
+algebra when placed on both sides.
+
+Source: arXiv:1703.09188, equation `ESE=0`, lines 405--410. -/
+theorem IsMPU.normalizedDiagonal_mul_mem_residualAlgebra_mul_normalizedDiagonal_eq_zero
+    [NeZero d] {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ Φ : Fin (D * D) → ℂ)
+    (hE : normalizedDiagonal (doubleLayerTensor U) = Matrix.vecMulVec ρ Φ)
+    (A : residualAlgebra U) :
+    normalizedDiagonal (doubleLayerTensor U) * (A : Matrix (Fin (D * D)) (Fin (D * D)) ℂ) *
+      normalizedDiagonal (doubleLayerTensor U) = 0 := by
+  let E := normalizedDiagonal (doubleLayerTensor U)
+  change E * (A : Matrix (Fin (D * D)) (Fin (D * D)) ℂ) * E = 0
+  have hA := A.property
+  change (A : Matrix (Fin (D * D)) (Fin (D * D)) ℂ) ∈
+    (NonUnitalAlgebra.adjoin ℂ (residualGeneratorSet U)).toSubmodule at hA
+  rw [NonUnitalAlgebra.adjoin_eq_span] at hA
+  have hspan : ∀ x : Matrix (Fin (D * D)) (Fin (D * D)) ℂ,
+      x ∈ Submodule.span ℂ (Subsemigroup.closure (residualGeneratorSet U)) →
+        E * x * E = 0 := by
+    intro x hx
+    induction hx using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨l, hne, hl, rfl⟩ := exists_nonempty_residual_word_of_mem_closure hx
+        have hX : ∀ a ∈ l, ∃ X, a = residualSlice (doubleLayerTensor U) X := by
+          intro a ha
+          obtain ⟨X, hX⟩ := hl a ha
+          exact ⟨X, hX.symm⟩
+        let X' : Fin l.length → Matrix (Fin d) (Fin d) ℂ := fun k ↦
+          Classical.choose (hX l[k] (List.get_mem l k))
+        have hlword : l = List.ofFn
+            (fun k ↦ residualSlice (doubleLayerTensor U) (X' k)) := by
+          calc
+            l = List.ofFn (fun k ↦ l[k]) := (List.ofFn_get l).symm
+            _ = _ := by
+              congr 1
+              funext k
+              exact Classical.choose_spec (hX l[k] (List.get_mem l k))
+        have hpos : 0 < l.length := List.length_pos_iff.mpr hne
+        rw [hlword]
+        exact hU.normalizedDiagonal_mul_prod_residualSlice_mul_normalizedDiagonal_eq_zero
+          hpos X' ρ Φ hE
+    | zero => simp
+    | add x y _ _ hx hy => simp [Matrix.mul_add, Matrix.add_mul, hx, hy]
+    | smul c x _ hx => simp [hx]
+  exact hspan _ hA
+
+private theorem doubleLayer_entry_eq_diagonal_add_residual
+    [NeZero d] (U : MPOTensor d D) (i j : Fin d) :
+    doubleLayerTensor U i j =
+      (if i = j then (1 : ℂ) else 0) • normalizedDiagonal (doubleLayerTensor U) +
+        residualSlice (doubleLayerTensor U) (Matrix.single j i 1) := by
+  rw [residualSlice, contractPhysical_single]
+  by_cases hij : i = j
+  · subst j
+    rw [if_pos rfl, Matrix.trace_single_eq_same]
+    simp
+  · rw [if_neg hij, Matrix.trace_single_eq_of_ne j i (1 : ℂ) (Ne.symm hij)]
+    simp
+
+private theorem diagonal_coeff_prod_eq
+    {N d : ℕ} (I J : Fin (MPSTensor.blockPhysDim d N)) :
+    (∏ k : Fin N, if MPSTensor.decodeBlock d N I k = MPSTensor.decodeBlock d N J k
+      then (1 : ℂ) else 0) = if I = J then 1 else 0 := by
+  classical
+  by_cases hIJ : I = J
+  · subst J
+    simp
+  · rw [if_neg hIJ]
+    have hdiff : ∃ k : Fin N,
+        MPSTensor.decodeBlock d N I k ≠ MPSTensor.decodeBlock d N J k := by
+      by_contra h
+      push Not at h
+      apply hIJ
+      exact (MPSTensor.decodeBlockEquiv d N).injective (funext h)
+    obtain ⟨k, hk⟩ := hdiff
+    exact Finset.prod_eq_zero (Finset.mem_univ k) (if_neg hk)
+
+/-- Every matrix-unit residual coefficient after the second, length-`D²`
+blocking belongs to the basis-invariant sum of the forms `E A`, `A E`, and
+`A E A`.
+
+Source: arXiv:1703.09188, equation `sprimeforms`, lines 415--424. -/
+theorem IsMPU.residualSlice_doubleLayerTensor_blockTensor_single_mem_threeFormSubmodule
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ Φ : Fin (D * D) → ℂ)
+    (hE : normalizedDiagonal (doubleLayerTensor U) = Matrix.vecMulVec ρ Φ)
+    (hEidem : normalizedDiagonal (doubleLayerTensor U) *
+      normalizedDiagonal (doubleLayerTensor U) = normalizedDiagonal (doubleLayerTensor U))
+    (I J : Fin (MPSTensor.blockPhysDim d (D * D))) :
+    residualSlice
+        (doubleLayerTensor (MPOTensor.blockTensor U (D * D))) (Matrix.single J I 1) ∈
+      threeFormSubmodule (normalizedDiagonal (doubleLayerTensor U)) (residualAlgebra U) := by
+  classical
+  let E := normalizedDiagonal (doubleLayerTensor U)
+  let σ := MPSTensor.decodeBlock d (D * D) I
+  let τ := MPSTensor.decodeBlock d (D * D) J
+  let c : Fin (D * D) → ℂ := fun k ↦ if σ k = τ k then 1 else 0
+  let S : Fin (D * D) → residualAlgebra U := fun k ↦
+    ⟨residualSlice (doubleLayerTensor U) (Matrix.single (τ k) (σ k) 1),
+      residualSlice_mem_residualAlgebra U _⟩
+  have hN : 0 < D * D := Nat.mul_pos (NeZero.pos D) (NeZero.pos D)
+  have hword := ordered_prod_smul_projector_add_sub_mem_threeFormSubmodule
+    E (residualAlgebra U) hEidem
+    (hU.normalizedDiagonal_mul_mem_residualAlgebra_mul_normalizedDiagonal_eq_zero ρ Φ hE)
+    hN (fun l hl hlen ↦ hU.residualAlgebra_list_prod_eq_zero l hl hlen) c S
+  have hentry : MPOTensor.blockTensor (doubleLayerTensor U) (D * D) I J =
+      (List.ofFn (fun k ↦ c k • E + (S k : Matrix (Fin (D * D)) (Fin (D * D)) ℂ))).prod := by
+    simp only [blockTensor_apply, MPSTensor.wordOfBlock, evalWord_ofFn]
+    apply congrArg List.prod
+    apply congrArg List.ofFn
+    funext k
+    simpa [E, c, S, σ, τ] using
+      doubleLayer_entry_eq_diagonal_add_residual U (σ k) (τ k)
+  have hc : (∏ k, c k) = if I = J then 1 else 0 :=
+    diagonal_coeff_prod_eq I J
+  have htrace : Matrix.trace (Matrix.single J I (1 : ℂ)) =
+      if I = J then 1 else 0 := by
+    by_cases hIJ : I = J
+    · subst J
+      rw [if_pos rfl, Matrix.trace_single_eq_same]
+    · rw [if_neg hIJ,
+        Matrix.trace_single_eq_of_ne J I (1 : ℂ) (Ne.symm hIJ)]
+  rw [doubleLayerTensor_blockTensor, residualSlice, contractPhysical_single,
+    normalizedDiagonal_blockTensor, hentry, htrace, ← hc]
+  change _ - (∏ k, c k) • E ^ (D * D) ∈ _
+  rw [pow_eq_self_of_pos hEidem hN]
+  exact hword
+
+/-- Residual slicing is linear in the physical argument.
+
+Source: arXiv:1703.09188, equation `WIsom`, lines 390--395. -/
+private noncomputable def residualSliceLinear (W : MPOTensor d D) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
+  toFun := residualSlice W
+  map_add' X Y := by
+    simp only [residualSlice, ← contractPhysicalLinear_apply, map_add, Matrix.trace_add,
+      add_smul]
+    module
+  map_smul' c X := by
+    simp only [residualSlice, ← contractPhysicalLinear_apply, map_smul, Matrix.trace_smul,
+      RingHom.id_apply]
+    module
+
+/-- Evaluation of the residual-slice linear map.
+
+Source: arXiv:1703.09188, equation `WIsom`, lines 390--395. -/
+@[simp] private theorem residualSliceLinear_apply (W : MPOTensor d D)
+    (X : Matrix (Fin d) (Fin d) ℂ) :
+    residualSliceLinear W X = residualSlice W X := rfl
+
+/-- Every residual coefficient after the second, length-`D²` blocking belongs
+to the basis-invariant sum of the forms `E A`, `A E`, and `A E A`.
+
+This is a span statement, not an exclusive type assignment to coefficients in
+an arbitrary physical basis.
+
+Source: arXiv:1703.09188, equation `sprimeforms`, lines 415--424. -/
+theorem IsMPU.residualSlice_doubleLayerTensor_blockTensor_mem_threeFormSubmodule
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ Φ : Fin (D * D) → ℂ)
+    (hE : normalizedDiagonal (doubleLayerTensor U) = Matrix.vecMulVec ρ Φ)
+    (hEidem : normalizedDiagonal (doubleLayerTensor U) *
+      normalizedDiagonal (doubleLayerTensor U) = normalizedDiagonal (doubleLayerTensor U))
+    (X : Matrix (Fin (MPSTensor.blockPhysDim d (D * D)))
+      (Fin (MPSTensor.blockPhysDim d (D * D))) ℂ) :
+    residualSlice (doubleLayerTensor (MPOTensor.blockTensor U (D * D))) X ∈
+      threeFormSubmodule (normalizedDiagonal (doubleLayerTensor U)) (residualAlgebra U) := by
+  classical
+  let W := doubleLayerTensor (MPOTensor.blockTensor U (D * D))
+  change residualSliceLinear W X ∈ _
+  rw [Matrix.matrix_eq_sum_single X]
+  simp only [map_sum, residualSliceLinear_apply]
+  apply Submodule.sum_mem
+  intro i _
+  apply Submodule.sum_mem
+  intro j _
+  have hsingle : Matrix.single i j (X i j) =
+      (X i j) • Matrix.single i j (1 : ℂ) := by
+    ext a b
+    simp [Matrix.single]
+  rw [hsingle, ← residualSliceLinear_apply, map_smul, residualSliceLinear_apply]
+  apply Submodule.smul_mem
+  exact hU.residualSlice_doubleLayerTensor_blockTensor_single_mem_threeFormSubmodule
+    ρ Φ hE hEidem j i
+
+end ResidualThreeForms
+
+end MPOTensor

--- a/TNLean/MPS/MPU/ThreeFormSpan.lean
+++ b/TNLean/MPS/MPU/ThreeFormSpan.lean
@@ -109,10 +109,11 @@ private theorem HasThreeForm.residual_mul
 private theorem pow_eq_self_of_pos {E : B} (hE : E * E = E)
     {N : ℕ} (hN : 0 < N) : E ^ N = E := by
   obtain ⟨N, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hN)
+  clear hN
   induction N with
   | zero => simp
   | succ N ih =>
-      rw [pow_succ, ih (by omega), hE]
+      rw [pow_succ, ih, hE]
 
 
 private theorem list_prod_mem_of_ne_nil

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -527,6 +527,87 @@ closing a chain of $N$ copies of $\mathcal U$.
     generator belongs to $\mathfrak S$, giving the stated specialization.
 \end{proof}
 
+\begin{definition}[Three-form residual subspace]
+    \label{def:mpu_three_form_subspace}
+    \lean{MPOTensor.projectorMulResidualSubmodule,
+        MPOTensor.residualMulProjectorSubmodule,
+        MPOTensor.residualMulProjectorMulResidualSubmodule,
+        MPOTensor.threeFormSubmodule}
+    \leanok
+    \uses{def:mpu_residual_algebra}
+    Let $E$ be the normalized diagonal after the first blocking and let
+    $\mathfrak S$ be its residual nonunital algebra.  Define
+    \begin{align}
+        \mathcal T={}&\operatorname{span}\{EA:A\in\mathfrak S\}
+          +\operatorname{span}\{AE:A\in\mathfrak S\}\\
+          &+\operatorname{span}\{AEB:A,B\in\mathfrak S\}.
+    \end{align}
+    This is the basis-independent sum of the three forms in equation
+    \texttt{sprimeforms} of
+    \cite[Proposition~III.3(ii)]{Cirac2017MPU}.
+\end{definition}
+
+\begin{theorem}[Ordered second-block expansion]
+    \label{thm:mpu_ordered_second_block_expansion}
+    \lean{MPOTensor.ordered_prod_smul_projector_add_sub_mem_threeFormSubmodule}
+    \leanok
+    \uses{def:mpu_three_form_subspace}
+    Suppose $E^2=E$, $EAE=0$ for every $A\in\mathfrak S$, and every ordered
+    product of $N>0$ elements of $\mathfrak S$ vanishes.  For scalars $c_k$
+    and elements $S_k\in\mathfrak S$,
+    \begin{align}
+      \prod_{k=0}^{N-1}(c_kE+S_k)
+        -\left(\prod_{k=0}^{N-1}c_k\right)E&\in\mathcal T.
+    \end{align}
+    Products are taken in increasing site order and need not commute.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the product as a sum over binary choices of $E$ or $S_k$, retaining
+    the original order.  The all-$E$ choice is the subtracted term because
+    $E^q=E$ for $q>0$.  The all-residual choice vanishes by the length-$N$
+    hypothesis.  In every remaining word, contiguous copies of $E$ collapse.
+    If two resulting copies of $E$ are separated by a nonempty residual word,
+    the factor $EAE$ makes the word zero.  Thus each surviving word has one
+    contiguous projector block and belongs to one of the three summands of
+    $\mathcal T$.
+\end{proof}
+
+\begin{theorem}[Second-block residuals lie in the three-form subspace]
+    \label{thm:mpu_second_block_residual_three_forms}
+    \lean{MPOTensor.IsMPU.normalizedDiagonal_mul_mem_residualAlgebra_mul_normalizedDiagonal_eq_zero,
+        MPOTensor.IsMPU.residualSlice_doubleLayerTensor_blockTensor_single_mem_threeFormSubmodule,
+        MPOTensor.IsMPU.residualSlice_doubleLayerTensor_blockTensor_mem_threeFormSubmodule}
+    \leanok
+    \uses{def:mpu,def:mpu_residual_algebra,def:mpu_three_form_subspace}
+    Let the first-block tensor be an MPU of bond dimension $D>0$.  Assume its
+    normalized double-layer diagonal $E$ is a rank-one idempotent.  After a
+    second blocking of exactly $D^2$ sites, every residual coefficient belongs
+    to $\mathcal T$.
+
+    The conclusion is membership in the sum of the three subspaces.  It does
+    not assign one exclusive type to a coefficient in an arbitrary physical
+    basis.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_controlled_mixed_residual_trace,
+        thm:mpu_residual_product_d_sq,
+        thm:mpu_ordered_second_block_expansion}
+    First extend $EPE=0$ from nonempty residual words $P$ to every element of
+    $\mathfrak S$ by writing the generated algebra as the linear span of the
+    multiplicative semigroup of residual generators.  For a blocked matrix
+    unit, each local double-layer entry is
+    \begin{align}
+        \delta_{ij}E+R_{ij}.
+    \end{align}
+    The ordered expansion theorem applies with $N=D^2$.  Its all-$E$
+    coefficient is the blocked Kronecker delta and is exactly removed by the
+    residual slice.  Hence every blocked matrix-unit residual lies in
+    $\mathcal T$.  Expanding an arbitrary physical matrix in matrix units and
+    using linearity proves the result.
+\end{proof}
+
 \section{Trace-power lemma}\label{sec:mpu_trace_power}
 
 For the transfer-matrix spectrum argument of


### PR DESCRIPTION
## Summary

- define the basis-invariant sum of the `EA`, `AE`, and `AEA` residual subspaces
- prove an ordered noncommutative expansion for products of `cₖ E + Sₖ`
- eliminate all-residual words with the merged exact-length `D²` theorem and separated projectors via `E A E = 0`
- identify exact second-block residual slices and prove arbitrary residual coefficients lie in the three-form span
- synchronize Chapter 28 with the source-faithful span statement

The result deliberately makes no exclusive per-coefficient typing claim, and this PR stops before the `simple1`/`simple2` bounded-blocking capstone tracked in #5810.

## Proof route

For each ordered binary choice in the product-of-sums expansion, the all-projector word is subtracted, the all-residual word vanishes by `IsMPU.residualAlgebra_list_prod_eq_zero` at length `D²`, and any word with separated projector blocks vanishes after extending `E P E = 0` from residual words to the residual algebra. Every survivor therefore has one projector block and belongs to one of the three invariant summands. Matrix-unit expansion and linearity give the arbitrary physical coefficient theorem.

## Validation

- `lake env lean TNLean/MPS/MPU/ThreeFormSpan.lean`
- `lake build TNLean.MPS.MPU.ThreeFormSpan`
- `lake build TNLean.MPS.MPU`
- generated import frontier tests and `--check`
- reader-facing prose diff check
- blueprint source synchronization and changed-declaration coverage (6877/6877)
- proof-integrity, numbered-file, oversized-file, whitespace, and focused forbidden-token checks
- tactic-pattern scan

Closes #5809.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation only; no runtime, auth, or data-path changes. Risk is limited to proof correctness in the MPU formalization layer.
> 
> **Overview**
> Adds **`ThreeFormSpan.lean**` and wires it into the MPU aggregator, formalizing Cirac et al.’s second blocking step: after length-`D²` residual products vanish, the part of an ordered product of `cₖ E + Sₖ` left after removing the all-`E` term lies in the basis-invariant span of **EA**, **AE**, and **AEA**.
> 
> The generic route defines `threeFormSubmodule` and proves `ordered_prod_smul_projector_add_sub_mem_threeFormSubmodule` by expanding binary choices, killing the all-residual word via `residualAlgebra_list_prod_eq_zero`, and classifying surviving ordered words. For MPU tensors it extends `E P E = 0` from residual words to all of `residualAlgebra`, then shows second `D²`-block residual slices (matrix units and arbitrary coefficients) lie in that span—explicitly as membership in the sum, not exclusive per-coefficient typing.
> 
> **Chapter 28** blueprint prose is synchronized with definitions, the ordered expansion theorem, and the second-block residual three-form theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 774913a59ea1d3045c7c7f07d0abc7428ef5dab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->