### PR TITLE
refactor(Algebra): share subtype sum restriction

### DIFF
--- a/TNLean/MPS/MPDO/CyclicActiveAdjacentCoefficientExtraction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveAdjacentCoefficientExtraction.lean
@@ -39,21 +39,6 @@ private theorem reducedBlockState_eq_of_mpo_eq_smul
   unfold reducedBlockState
   rw [hnormalized]
 
-private theorem sum_eq_sum_subtype_of_eq_zero
-    {α M : Type*} [Fintype α] [AddCommMonoid M]
-    (p : α → Prop) [DecidablePred p] (f : α → M)
-    (hzero : ∀ x, ¬p x → f x = 0) :
-    ∑ x, f x = ∑ x : {x // p x}, f x := by
-  classical
-  calc
-    _ = ∑ x ∈ Finset.univ.filter p, f x := by
-      symm
-      apply Finset.sum_subset (Finset.filter_subset _ _)
-      intro x hx hxnot
-      rw [hzero x]
-      simpa using hxnot
-    _ = _ := Finset.sum_subtype _ (by simp) f
-
 private def cyclicActiveSectorSubtypeEquiv
     (F : PhysicalSectorFactorization K) :
     {q : Fin F.sectorCount // F.IsCyclicActiveSector q} ≃
@@ -331,7 +316,9 @@ private theorem sum_sector_trace_two_eq_cyclicActive_pow_two
     _ = ∑ r : {r : Fin F.sectorCount // F.IsCyclicActiveSector r},
         Matrix.trace (F.neighboringOperator q r) *
           Matrix.trace (F.neighboringOperator r h) := by
-      apply sum_eq_sum_subtype_of_eq_zero
+      apply Finset.sum_congr_set
+      · intro r hr
+        rfl
       intro r hr
       by_contra hne
       have hmul := mul_ne_zero_iff.mp hne
@@ -369,7 +356,9 @@ private theorem sum_sector_trace_three_eq_cyclicActive_pow_three
           Matrix.trace (F.neighboringOperator q a) *
             Matrix.trace (F.neighboringOperator a b) *
               Matrix.trace (F.neighboringOperator b h) := by
-      apply sum_eq_sum_subtype_of_eq_zero
+      apply Finset.sum_congr_set
+      · intro a ha
+        rfl
       intro a ha
       apply Finset.sum_eq_zero
       intro b _
@@ -397,7 +386,9 @@ private theorem sum_sector_trace_three_eq_cyclicActive_pow_three
               Matrix.trace (F.neighboringOperator b h) := by
       apply Finset.sum_congr rfl
       intro a _
-      apply sum_eq_sum_subtype_of_eq_zero
+      apply Finset.sum_congr_set
+      · intro b hb
+        rfl
       intro b hb
       by_contra hne
       have habc := mul_ne_zero_iff.mp hne

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
@@ -24,21 +24,6 @@ namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D}
 
-private theorem sum_eq_sum_subtype_of_eq_zero
-    {α M : Type*} [Fintype α] [AddCommMonoid M]
-    (p : α → Prop) [DecidablePred p] (f : α → M)
-    (hzero : ∀ x, ¬p x → f x = 0) :
-    ∑ x, f x = ∑ x : {x // p x}, f x := by
-  classical
-  calc
-    _ = ∑ x ∈ Finset.univ.filter p, f x := by
-      symm
-      apply Finset.sum_subset (Finset.filter_subset _ _)
-      intro x hx hxnot
-      rw [hzero x]
-      simpa using hxnot
-    _ = _ := Finset.sum_subtype _ (by simp) f
-
 private def cyclicActiveWordSubtypeEquiv
     (F : PhysicalSectorFactorization K) (N : ℕ) :
     {t : Fin N → Fin F.sectorCount // ∀ i, F.IsCyclicActiveSector (t i)} ≃
@@ -146,7 +131,10 @@ theorem reindex_threeSuffixSectorContraction_eq_cyclicActiveUnnormalized
             F.cyclicNeighboringProduct (Fin.append k t.1)
               (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z)
               (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z) := by
-    apply sum_eq_sum_subtype_of_eq_zero
+    apply Finset.sum_congr_set
+      {t : Fin 3 → Fin F.sectorCount | ∀ i, F.IsCyclicActiveSector (t i)}
+    · intro t ht
+      rfl
     intro t ht
     apply Finset.sum_eq_zero
     intro z hz

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -356,6 +356,16 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Vanishing-complement subtype sums
+- **Pattern:** replace a finite sum by the sum over a predicate subtype after proving that every
+  term outside the predicate is zero.
+- **Reuse:** apply Mathlib's `Finset.sum_congr_set` directly, with reflexivity on the predicate
+  and the existing proof that the summand vanishes off it.
+- **Result:** the two private copies were deleted, and all four call sites now use the Mathlib
+  theorem directly: three in `CyclicActiveAdjacentCoefficientExtraction.lean` and one in
+  `CyclicActiveFourthRegionFormula.lean`. The complete diff has 23 insertions and 34 deletions
+  across three files.
+
 ### Cyclic offset inverse identity
 - **Pattern:** adding the residue `(b + N - a) % N` to `a` modulo `N` recovers `b`
   when `a` and `b` are both less than `N`.


### PR DESCRIPTION
### Motivation

- Two cyclic-active MPDO modules contained byte-identical private proofs restricting a finite sum to a predicate subtype when the summand vanishes outside that predicate.
- Mathlib already supplies the exact zero-off-support subtype interface, so the four call sites reuse it directly rather than introducing a TNLean wrapper.

### Description

- Delete both private helpers and apply `Finset.sum_congr_set` directly at all four call sites.
- Retain each existing zero-off-support proof body and every surrounding public theorem statement.
- Record the Mathlib reuse and exact final diff in `docs/tactic_patterns.md`.
- Add no project API or import; change no CPSV16 statement or source boundary.

### Testing

- `lake build TNLean.MPS.MPDO.CyclicActiveAdjacentCoefficientExtraction TNLean.MPS.MPDO.CyclicActiveFourthRegionFormula` (9171 jobs, exact hot-main cache)
- `lake build TNLean` (10002 jobs; full warm-cache gate)
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check origin/main...HEAD`
- exact-head independent review: approved after replacing the initially proposed project wrapper with direct Mathlib reuse

Final diff: 3 files, 23 insertions, 34 deletions; net −11 lines.

---
Closes #5832

### Agent assistance

- TeXRA with OpenAI GPT-5.6 identified the duplicate proofs, found and verified Mathlib's exact interface, rewired the four applications, and ran the warm-cache validation. The maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only deduplication using an existing Mathlib finite-sum lemma; no changes to public MPDO statements or runtime behavior.
> 
> **Overview**
> Removes **duplicate private proofs** that restricted a finite sum to a predicate subtype when summands vanish outside the predicate, and routes **four call sites** through Mathlib's `Finset.sum_congr_set` instead.
> 
> In `CyclicActiveAdjacentCoefficientExtraction.lean` and `CyclicActiveFourthRegionFormula.lean`, each site supplies reflexivity on the predicate and the existing off-support vanishing argument; the cyclic-active coefficient and fourth-region proofs are unchanged at the theorem level. `docs/tactic_patterns.md` records this as a completed **vanishing-complement subtype sum** refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca0aeb02c3c84cf575aac9b65ad9ace8804a75d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

