### PR TITLE
style(Lean): remove recurring base-module warnings

### DIFF
--- a/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
+++ b/TNLean/Algebra/ShiftedTracePowerSpectrum.lean
@@ -144,7 +144,7 @@ theorem spectrum_diff_zero_eq_singleton_of_forall_trace_pow_eq_one_of_one_lt
   ext μ
   constructor
   · rintro ⟨hμ, hμ0⟩
-    have hμ_ne : μ ≠ 0 := by simp at hμ0; exact hμ0
+    have hμ_ne : μ ≠ 0 := by simpa only [Set.mem_singleton_iff] using hμ0
     simp [eq_one_of_mem_spectrum_of_forall_trace_pow_eq_one_of_one_lt A h hμ hμ_ne]
   · intro hμ
     have hμ1 : μ = 1 := by simpa using hμ

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -279,7 +279,7 @@ theorem transferMatrix_hasEigenvalue_iff
     rw [Module.End.hasEigenvector_iff]
     constructor
     · rw [Module.End.mem_eigenspace_iff]
-      apply Matrix.vec_inj.mp
+      apply (Matrix.vec_inj (A := T X) (B := μ • X)).mp
       rw [Matrix.vec_smul, ← transferMatrix_mulVec_eq, ← Matrix.toLin'_apply]
       exact hv.apply_eq_smul
     · intro hX

--- a/TNLean/MPS/Structure/BlockPermutation.lean
+++ b/TNLean/MPS/Structure/BlockPermutation.lean
@@ -110,17 +110,20 @@ noncomputable def componentMap
     Matrix (Fin (D (σ i))) (Fin (D (σ i))) ℂ :=
   blockComponentMap T σ i M
 
+omit [Fintype ι] [∀ i, NeZero (D i)] in
 private theorem componentMap_map_zero
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+* _} {σ : ι ≃ ι} {i : ι} :
     componentMap T σ i 0 = 0 := by
   simp [componentMap, blockComponentMap, Pi.single_zero, map_zero]
 
+omit [Fintype ι] [∀ i, NeZero (D i)] in
 private theorem componentMap_map_add
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+* _} {σ : ι ≃ ι} {i : ι}
     (M N : Matrix (Fin (D i)) (Fin (D i)) ℂ) :
     componentMap T σ i (M + N) = componentMap T σ i M + componentMap T σ i N := by
   simp [componentMap, blockComponentMap, Pi.single_add, map_add, Pi.add_apply]
 
+omit [Fintype ι] [∀ i, NeZero (D i)] in
 theorem componentMap_map_mul
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+* _} {σ : ι ≃ ι} {i : ι}
     (M N : Matrix (Fin (D i)) (Fin (D i)) ℂ) :
@@ -137,6 +140,7 @@ theorem componentMap_map_one
   simp only [componentMap, blockComponentMap, ringEquiv_single_one_eq T σ hσ i,
     Pi.single_eq_same]
 
+omit [Fintype ι] [∀ i, NeZero (D i)] in
 /-- The component map commutes with ℂ-scalar multiplication when T is a ℂ-algebra map. -/
 theorem componentMap_map_smul_of_algEquiv
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃ₐ[ℂ] _} {σ : ι ≃ ι} {i : ι}


### PR DESCRIPTION
### Motivation

- Six linter warnings from three high-fanout modules replay in ordinary Algebra, Channel, and MPDO builds, obscuring warnings in changed code.
- Each warning has a local statement-preserving correction; no suppression is needed.

### Description

- Replace one flexible hypothesis simplification with an explicit singleton-membership simplification.
- Specialize the two matrix arguments of `Matrix.vec_inj` so the transfer-matrix proof focuses a single goal.
- Omit two genuinely unused section instances from four component-map homomorphism lemmas.
- Preserve every declaration name, theorem statement, and proof meaning.

### Testing

- `lake build TNLean.Algebra.ShiftedTracePowerSpectrum` — 0 warnings
- `lake build TNLean.Channel.TransferMatrix` — 0 warnings
- `lake build TNLean.MPS.Structure.BlockPermutation` — 0 warnings
- `git diff --check origin/main...HEAD`

---
Closes #5842
Advances #5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 identified the exact warning sites, made the six local proof-script fixes, and ran the targeted warm-cache validation. The maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only and linter-scoping edits with no API or mathematical statement changes; risk is negligible.
> 
> **Overview**
> Clears six recurring linter warnings in three high-fanout modules so ordinary Algebra, Channel, and MPS builds surface fewer noise warnings in changed code.
> 
> In **ShiftedTracePowerSpectrum**, the proof that `μ ≠ 0` from membership in `spectrum \ {0}` uses an explicit `simpa only [Set.mem_singleton_iff]` instead of a broader `simp at` step.
> 
> In **TransferMatrix**, the eigenvalue–transfer-matrix equivalence proof applies `Matrix.vec_inj` with explicit matrix arguments `T X` and `μ • X` so the goal is focused before rewriting.
> 
> In **BlockPermutation**, four `componentMap` homomorphism lemmas (`map_zero`, `map_add`, `map_mul`, and `map_smul_of_algEquiv`) **omit** the section-level `[Fintype ι]` and `[∀ i, NeZero (D i)]` instances that those statements do not use.
> 
> **No theorem statements, names, or mathematical content change**—only proof scripts and instance scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5192aa9b287f23e0ac637d89d41afdabbcdae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->