### PR TITLE
style(Channel): remove command-internal blank lines

### DIFF
--- a/TNLean/Channel/LorentzNormalForm/Basic.lean
+++ b/TNLean/Channel/LorentzNormalForm/Basic.lean
@@ -54,7 +54,6 @@ section FilteringOperations
 /-- An `SLFiltering` for `D × D` matrices bundles a matrix `S` with
 `det S = 1` (and `S` invertible) together with its associated CP map
 `Φ(X) = S X S†`.  Such maps are called *filtering operations* in Wolf Section 2.3. -/
-
 structure SLFiltering (D : ℕ) where
   /-- The filtering matrix, with determinant 1. -/
   S : Matrix (Fin D) (Fin D) ℂ
@@ -68,7 +67,6 @@ structure SLFiltering (D : ℕ) where
   cp : IsCPMap map
 
 /-- The matrix `S` of an SL-filtering is invertible (follows from `det_eq_one`). -/
-
 lemma SLFiltering.S_isUnit {D : ℕ} (Φ : SLFiltering D) : IsUnit Φ.S := by
   have h : Φ.S.det = 1 := Φ.det_eq_one
   have hdet : IsUnit (Φ.S.det) := by rw [h]; exact isUnit_one
@@ -76,7 +74,6 @@ lemma SLFiltering.S_isUnit {D : ℕ} (Φ : SLFiltering D) : IsUnit Φ.S := by
   refine (Matrix.isUnit_iff_isUnit_det Φ.S).mpr hdet
 
 /-- The identity map is an SL-filtering (S = 1). -/
-
 noncomputable def SLFiltering.id (D : ℕ) : SLFiltering D where
   S := 1
   det_eq_one := by simp
@@ -85,7 +82,6 @@ noncomputable def SLFiltering.id (D : ℕ) : SLFiltering D where
   cp := unitaryConjLM_isCPMap (D := D) 1
 
 /-- Composition of two SL-filterings is an SL-filtering. -/
-
 noncomputable def SLFiltering.comp {D : ℕ} (Φ Ψ : SLFiltering D) : SLFiltering D where
   S := Φ.S * Ψ.S
   det_eq_one := by
@@ -95,7 +91,6 @@ noncomputable def SLFiltering.comp {D : ℕ} (Φ Ψ : SLFiltering D) : SLFilteri
   cp := unitaryConjLM_isCPMap (D := D) (Φ.S * Ψ.S)
 
 /-- `unitaryConjLM A ∘ₗ unitaryConjLM B = unitaryConjLM (A * B)`. -/
-
 lemma unitaryConjLM_comp {D : ℕ} (A B : Matrix (Fin D) (Fin D) ℂ) :
     unitaryConjLM (D := D) A ∘ₗ unitaryConjLM (D := D) B =
     unitaryConjLM (D := D) (A * B) := by
@@ -117,19 +112,16 @@ Wolf Proposition 2.9.
 
 We use the partial-trace formulation to avoid depending on the adjoint of `T`
 as a Hilbert–Schmidt operator. -/
-
 def DoublyStochastic : Prop :=
   (∃ c₁ : ℂ, T 1 = c₁ • (1 : Matrix (Fin D) (Fin D) ℂ)) ∧
   (∃ c₂ : ℂ, Matrix.traceLeft (choiMatrix T) = c₂ • (1 : Matrix (Fin D) (Fin D) ℂ))
 
 /-- Doubly-stochastic implies T(1) ∝ 1. -/
-
 lemma DoublyStochastic.unital (hT : DoublyStochastic T) :
     ∃ c : ℂ, T 1 = c • (1 : Matrix (Fin D) (Fin D) ℂ) := hT.1
 
 /-- Doubly-stochastic implies the partial trace of the Choi matrix is ∝ 1
 (equivalently, T*(1) ∝ 1). -/
-
 lemma DoublyStochastic.tracePreserving (hT : DoublyStochastic T) :
     ∃ c : ℂ, Matrix.traceLeft (choiMatrix T) =
       c • (1 : Matrix (Fin D) (Fin D) ℂ) := hT.2
@@ -144,7 +136,6 @@ variable {D : ℕ}
 
 /-- Entry formula for conjugation by `A ⊗ₖ 1` (identity on the second factor).
 The two tensor factors may have different dimensions. -/
-
 lemma kron_one_conj_entry {dOut dIn : ℕ} (A : Matrix (Fin dOut) (Fin dOut) ℂ)
     (M : Matrix (Fin dOut × Fin dIn) (Fin dOut × Fin dIn) ℂ)
     (i₁ : Fin dOut) (i₂ : Fin dIn) (j₁ : Fin dOut) (j₂ : Fin dIn) :
@@ -178,7 +169,6 @@ lemma kron_one_conj_entry {dOut dIn : ℕ} (A : Matrix (Fin dOut) (Fin dOut) ℂ
 
 /-- Entry formula for conjugation by `1 ⊗ₖ B` (identity on the first factor).
 The two tensor factors may have different dimensions. -/
-
 lemma one_kron_conj_entry {dOut dIn : ℕ} (B : Matrix (Fin dIn) (Fin dIn) ℂ)
     (M : Matrix (Fin dOut × Fin dIn) (Fin dOut × Fin dIn) ℂ)
     (i₁ : Fin dOut) (i₂ : Fin dIn) (j₁ : Fin dOut) (j₂ : Fin dIn) :
@@ -212,7 +202,6 @@ lemma one_kron_conj_entry {dOut dIn : ℕ} (B : Matrix (Fin dIn) (Fin dIn) ℂ)
 
 /-- `tr_A` commutes with conjugation by `1 ⊗ₖ X` (acting on the second factor):
 `tr_A((1 ⊗ X) ρ (1 ⊗ X)†) = X (tr_A ρ) X†`. -/
-
 lemma traceLeft_one_kron_conj {dOut dIn : ℕ} (X : Matrix (Fin dIn) (Fin dIn) ℂ)
     (ρ : Matrix (Fin dOut × Fin dIn) (Fin dOut × Fin dIn) ℂ) :
     Matrix.traceLeft (((1 : Matrix (Fin dOut) (Fin dOut) ℂ) ⊗ₖ X) * ρ *
@@ -235,7 +224,6 @@ lemma traceLeft_one_kron_conj {dOut dIn : ℕ} (X : Matrix (Fin dIn) (Fin dIn) �
 
 /-- `tr_B` commutes with conjugation by `X ⊗ₖ 1` (acting on the first factor):
 `tr_B((X ⊗ 1) ρ (X ⊗ 1)†) = X (tr_B ρ) X†`. -/
-
 lemma traceRight_kron_one_conj {dOut dIn : ℕ} (X : Matrix (Fin dOut) (Fin dOut) ℂ)
     (ρ : Matrix (Fin dOut × Fin dIn) (Fin dOut × Fin dIn) ℂ) :
     Matrix.traceRight ((X ⊗ₖ (1 : Matrix (Fin dIn) (Fin dIn) ℂ)) * ρ *
@@ -258,7 +246,6 @@ lemma traceRight_kron_one_conj {dOut dIn : ℕ} (X : Matrix (Fin dOut) (Fin dOut
 
 /-- Conjugating a matrix unit by `B` spreads it over all matrix units:
 `B (single i₂ j₂ c) B† = ∑ a b, (B a i₂ · conj(B b j₂)) (single a b c)`. -/
-
 lemma single_conj_spread {n : ℕ} (B : Matrix (Fin n) (Fin n) ℂ)
     (i₂ j₂ : Fin n) (c : ℂ) :
     B * Matrix.single i₂ j₂ c * Bᴴ
@@ -286,7 +273,6 @@ lemma single_conj_spread {n : ℕ} (B : Matrix (Fin n) (Fin n) ℂ)
 
 /-- Choi matrix of post-composition with conjugation by `A`:
 `choi(Ad_A ∘ T) = (A ⊗ 1) choi(T) (A ⊗ 1)†`. -/
-
 lemma choiMatrix_unitaryConj_comp (A : Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     choiMatrix (unitaryConjLM A ∘ₗ T)
@@ -303,7 +289,6 @@ lemma choiMatrix_unitaryConj_comp (A : Matrix (Fin D) (Fin D) ℂ)
 
 /-- Choi matrix of pre-composition with conjugation by `B`:
 `choi(T ∘ Ad_B) = (1 ⊗ Bᵀ) choi(T) (1 ⊗ Bᵀ)†`. -/
-
 lemma choiMatrix_comp_unitaryConj (B : Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     choiMatrix (T ∘ₗ unitaryConjLM B)
@@ -320,12 +305,10 @@ lemma choiMatrix_comp_unitaryConj (B : Matrix (Fin D) (Fin D) ℂ)
   ring
 
 /-- `Matrix.traceLeft` agrees with `Matrix.traceLeftA`. -/
-
 lemma traceLeft_eq_traceLeftA (ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) :
     Matrix.traceLeft ρ = Matrix.traceLeftA ρ := rfl
 
 /-- The full trace equals the trace of the right partial trace: `tr(X) = tr(tr_B(X))`. -/
-
 lemma trace_eq_trace_traceRight {dOut dIn : ℕ}
     (X : Matrix (Fin dOut × Fin dIn) (Fin dOut × Fin dIn) ℂ) :
     X.trace = (Matrix.traceRight X).trace := by
@@ -333,7 +316,6 @@ lemma trace_eq_trace_traceRight {dOut dIn : ℕ}
   exact Fintype.sum_prod_type _
 
 /-- The reduced state `tr_B(choi T)` equals (up to the `|Ω⟩` normalization) `T 1`. -/
-
 lemma traceRight_choiMatrix
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     Matrix.traceRight (choiMatrix T)
@@ -354,7 +336,6 @@ lemma traceRight_choiMatrix
   rw [← Matrix.sum_apply, ← map_sum, Matrix.sum_single_one]
 
 /-- The `|Ω⟩` normalization constant is nonzero. -/
-
 lemma omega_coeff_ne_zero (hD : 0 < D) :
     (((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * star ((1 : ℂ) / ((D : ℝ).sqrt : ℂ))) ≠ 0 := by
   have hsqrt : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
@@ -372,7 +353,6 @@ variable {d₁ d₂ : ℕ}
 
 /-- Choi matrix of post-composition with conjugation by `A`, rectangular form:
 `choi(Ad_A ∘ T) = (A ⊗ 1) choi(T) (A ⊗ 1)†` for `A` on the output factor. -/
-
 lemma choiMatrixRect_unitaryConj_comp (A : Matrix (Fin d₂) (Fin d₂) ℂ)
     (T : Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ) :
     ChoiRectangular.choiMatrix (unitaryConjLM A ∘ₗ T)
@@ -391,7 +371,6 @@ lemma choiMatrixRect_unitaryConj_comp (A : Matrix (Fin d₂) (Fin d₂) ℂ)
 /-- Choi matrix of pre-composition with conjugation by `B`, rectangular form:
 `choi(T ∘ Ad_B) = (1 ⊗ Bᵀ) choi(T) (1 ⊗ Bᵀ)†` for `B` on the input factor.
 This is Wolf's "irrelevant transposition" of the first filtering factor. -/
-
 lemma choiMatrixRect_comp_unitaryConj (B : Matrix (Fin d₁) (Fin d₁) ℂ)
     (T : Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ) :
     ChoiRectangular.choiMatrix (T ∘ₗ unitaryConjLM B)
@@ -413,7 +392,6 @@ algebras is **doubly-stochastic** if `T(𝟙)` and `T*(𝟙)` are both proportio
 to the identity matrix, where `T*` is the trace-pairing adjoint.  This is the
 rectangular normal-form condition of Wolf Proposition 2.9
 (`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 923–929). -/
-
 def DoublyStochasticRect
     (T : Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ) : Prop :=
   (∃ c₁ : ℂ, T 1 = c₁ • (1 : Matrix (Fin d₂) (Fin d₂) ℂ)) ∧

--- a/TNLean/Channel/LorentzNormalForm/Infimum.lean
+++ b/TNLean/Channel/LorentzNormalForm/Infimum.lean
@@ -69,7 +69,6 @@ set
 its minimum by the extreme value theorem; a value outside the sublevel set is
 automatically larger than the value at the identity, so this minimiser is
 global. -/
-
 lemma infimum_is_attained
     {d₁ d₂ : ℕ} {τ : Matrix (Fin d₂ × Fin d₁) (Fin d₂ × Fin d₁) ℂ}
     (hτ_posDef : τ.PosDef) :
@@ -228,7 +227,6 @@ variable {D : ℕ}
 /-- A positive-definite matrix can be normalized to a scalar matrix by an
 `SL(D, ℂ)` congruence: there exists `S` with `det S = 1` and
 `S M S† = r • 1` for some `r ≥ 0`.  Take `S = c · √M⁻¹` with `cᴰ = det √M`. -/
-
 lemma exists_sl_normalize [NeZero D] {M : Matrix (Fin D) (Fin D) ℂ}
     (hM : M.PosDef) :
     ∃ S : Matrix (Fin D) (Fin D) ℂ, S.det = 1 ∧
@@ -258,7 +256,6 @@ lemma exists_sl_normalize [NeZero D] {M : Matrix (Fin D) (Fin D) ℂ}
 with the same determinant as a positive-definite `M`, and `tr N` is the minimum
 of `tr (S M S†)` over `det S = 1`, then `N` is a scalar matrix.  This is the
 AM–GM equality argument: the minimum saturates `Dᴰ det = (tr)ᴰ`. -/
-
 lemma posDef_orbit_min_isScalar [NeZero D] {M N : Matrix (Fin D) (Fin D) ℂ}
     (hM : M.PosDef) (hN : N.PosSemidef) (hdet : N.det = M.det)
     (hmin : ∀ S : Matrix (Fin D) (Fin D) ℂ, S.det = 1 →

--- a/TNLean/Channel/LorentzNormalForm/NormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm/NormalForm.lean
@@ -59,7 +59,6 @@ classification of the possible doubly-stochastic normal forms.
 (Wolf, *Quantum Channels & Operations*, Section 2.3) states it for a general
 `T : M_{d₁}(ℂ) → M_{d₂}(ℂ)` with separate filterings on each factor.  Documented
 in `docs/paper-gaps/wolf_prop28_square_case.tex`. -/
-
 theorem exists_normal_form_generic
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (_hCP : IsCPMap T)
@@ -208,7 +207,6 @@ The proof follows the source: the infimum of
 trace–determinant AM–GM bound, so both reduced operators are scalar
 (`posDef_orbit_min_isScalar`).  The square case `d₁ = d₂` is
 `exists_normal_form_generic` above. -/
-
 theorem exists_normal_form_generic_rect [NeZero d₁] [NeZero d₂]
     (T : Matrix (Fin d₁) (Fin d₁) ℂ →ₗ[ℂ] Matrix (Fin d₂) (Fin d₂) ℂ)
     (_hCP : IsKrausCP T)

--- a/TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm/QubitNormalForm.lean
@@ -71,7 +71,6 @@ section LorentzNormalFormQubit
 /-- The four Pauli matrices as 2×2 complex matrices, indexed by `Fin 4`:
 `σ₀ = [[1,0],[0,1]]`, `σ₁ = [[0,1],[1,0]]`, `σ₂ = [[0,-I],[I,0]]`,
 `σ₃ = [[1,0],[0,-1]]`. -/
-
 def pauliMatrices : Fin 4 → Matrix (Fin 2) (Fin 2) ℂ
   | 0 => !![1, 0; 0, 1]
   | 1 => !![0, 1; 1, 0]
@@ -85,7 +84,6 @@ def pauliMatrices : Fin 4 → Matrix (Fin 2) (Fin 2) ℂ
 This is the `4×4` matrix representing `T` in the Pauli basis
 `{σ₀/√2, σ₁/√2, σ₂/√2, σ₃/√2}`, so that `T̂` has real entries for
 Hermiticity-preserving `T`. -/
-
 noncomputable def pauliTransferEntry
     (T : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ)
     (i j : Fin 4) : ℂ :=
@@ -98,7 +96,6 @@ form** (Wolf Proposition 2.11, case 1) if its Pauli-basis transfer matrix is dia
 
 Furthermore, the singular values satisfy the complete-positivity condition
 `λ₁ + λ₂ ≤ 1 + λ₃` (not checked here; future refinement). -/
-
 def IsLorentzDiagonal
     (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
   IsChannel T' ∧ T' 1 = (1 : Matrix (Fin 2) (Fin 2) ℂ) ∧
@@ -111,7 +108,6 @@ normal form** (Wolf Proposition 2.11, case 2) if its Pauli-basis transfer matrix
 The channel condition supplies the trace-preserving first row. The predicate
 records the non-trivial translation entry, the three diagonal entries, and the
 vanishing of all off-diagonal entries except the allowed translation. -/
-
 def IsLorentzNonDiagonal
     (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
   IsChannel T' ∧
@@ -128,7 +124,6 @@ form** (Wolf Proposition 2.11, case 3) if its Pauli-basis transfer matrix has
 `Δ = 0` and `v = (0, 0, 1)`.  That is, only `T̂_{00} = 1` and
 `T̂_{30} = 1` are nonzero; the channel maps every input to the pure state
 `(1 + σ_z)/2`. -/
-
 def IsLorentzSingular
     (T' : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
   IsChannel T' ∧


### PR DESCRIPTION
### Motivation

- The Lorentz-normal-form Channel cone emitted 32 command-internal blank-line warnings on exact main.
- These mechanical warnings dominated the build warning stream without conveying proof problems.

### Description

- Remove only the 32 blank lines located inside Lean commands across the four Lorentz-normal-form modules.
- Preserve declaration separation, comments, declarations, theorem statements, and proof tactics byte-for-byte otherwise.
- Add no linter suppressions and make no mathematical change.

### Testing

- `lake build TNLean.Channel.LorentzNormalForm.Basic`
- `lake build TNLean.Channel.LorentzNormalForm.Infimum`
- `lake build TNLean.Channel.LorentzNormalForm.NormalForm`
- `lake build TNLean.Channel.LorentzNormalForm.QubitNormalForm`
- Target-file `linter.style.emptyLine` warnings: 32 before, 0 after
- `git diff --check origin/main...HEAD`

---
Closes #5843
Advances #5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 enumerated the exact linter sites, removed only the command-internal blank lines, and ran the targeted warm-cache validation. The maintainer reviewed the complete deletion-only diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure style cleanup with no logic, API, or proof edits; risk is limited to accidental whitespace changes, which the PR scope and targeted builds aim to exclude.
> 
> **Overview**
> Removes **32 blank lines inside Lean commands** across `Basic.lean`, `Infimum.lean`, `NormalForm.lean`, and `QubitNormalForm.lean` in the Lorentz normal form Channel cone, clearing `linter.style.emptyLine` warnings without changing proofs or math.
> 
> Deletions sit immediately after doc comments (`/-- ... -/`) and before `structure`, `def`, `lemma`, and `theorem` headers—formatting only; declaration spacing between separate items, comments, and tactic scripts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd589807ac3b76a6ee218174b6f7321109e30edb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->