### PR TITLE
docs(ParentHamiltonian): mark lem:isup_chain_ground_space_block_le_parent_ground_space as formalized

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -168,7 +168,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{lemma}[Forward inclusion for the direct-sum tensor]
     \label{lem:isup_chain_ground_space_block_le_parent_ground_space}
-    \notready
+    \lean{MPSTensor.iSup_chainGroundSpace_block_le_toTensorFromBlocks}
+    \leanok
     \uses{def:parent_hamiltonian_ground_space_bnt,
         lem:isup_chain_ground_space_block_le_assembled}
     Let $A^i=\bigoplus_j\mu_j A_j^i$ be in block-injective canonical form,
@@ -183,8 +184,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \end{align}
 \end{lemma}
 
-\begin{proof}
-    \notready
+\begin{proof}\leanok
     The block-injective canonical-form hypothesis supplies $\mu_j\neq0$ for
     every $j$, and the block-diagonal periodic-boundary ground space is
     $\mathcal G_{N,L}(\bigoplus_j \mu_j A_j)$ by definition.


### PR DESCRIPTION
## Summary

Audit of `blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex` and `blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex` for `\notready` entries whose exact statements are already formalized by existing Lean declarations.

## Changes

**One entry updated:**

- **`lem:isup_chain_ground_space_block_le_parent_ground_space`** ("Forward inclusion for the direct-sum tensor") — replaced `\notready` with `\lean{MPSTensor.iSup_chainGroundSpace_block_le_toTensorFromBlocks}\leanok`. The Lean declaration proves the same conclusion (blockwise chain ground space sum ⊆ block-diagonal chain ground space) under weaker hypotheses, so the blueprint statement is fully covered. The proof was also marked `\leanok` since it is a one-line application of the existing lemma.

**All other `\notready` entries remain unchanged** because they are either:
- Composite/capstone theorems with no single Lean counterpart (e.g., `thm:block_diagonal_ground_space_intersection`)
- Conditional lemmas with explicit hypotheses that differ from any Lean declaration
- Trivial definitional identities with no named Lean lemma
- Lemmas with extra hypotheses not required by the nearest Lean declaration (no exact match)

## Evidence

The Lean declaration `MPSTensor.iSup_chainGroundSpace_block_le_toTensorFromBlocks` (in `TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean`) proves:
```
(⨆ j, chainGroundSpace (A j) L N) ≤ chainGroundSpace (toTensorFromBlocks μ A) L N
```
under the hypotheses `μ j ≠ 0`, `0 < N`, `L ≤ N`. The blueprint entry's hypothesis (block-injective canonical form) implies `μ j ≠ 0`, making the Lean theorem a direct formalization of the statement.

Refs #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint audit with no Lean or runtime code changes; only TeX `\notready` / `\lean` metadata for an already-proven declaration.
> 
> **Overview**
> Marks **Forward inclusion for the direct-sum tensor** (`lem:isup_chain_ground_space_block_le_parent_ground_space`) as formalized in the blueprint by wiring it to `MPSTensor.iSup_chainGroundSpace_block_le_toTensorFromBlocks` and adding `\leanok` on the lemma and its proof.
> 
> The proof block is no longer `\notready`; it is tagged `\leanok` because the argument is a direct appeal to the existing Lean theorem once block-injective canonical form gives nonzero weights and the block-diagonal ground space is identified by definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d59880e0c9b72920ff1326097b8d3dcdbbbdda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->