### PR TITLE
feat(ParentHamiltonian): add spectator boundary maps

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -58,6 +58,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
+import TNLean.MPS.ParentHamiltonian.SpectatorBoundary
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.TripartiteDecorrelation
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
@@ -66,9 +66,11 @@ boundary coordinates.
 
 For Nachtergaele C3 (arXiv:cond-mat/9410110, eq. (2.4)), take
 \(K := n - l\), \(L := l + 1\), and let the common ambient space be
-\(\mathcal{H}_{K+L} = \mathcal{H}_{n+1}\).  The left window (first \(K+L-1\) sites) is not directly
-the range of a spectator-indexed left boundary map; it is the subspace
-`InLeftGround` defined by fixing the *last* site.
+\(\mathcal{H}_{K+L} = \mathcal{H}_{n+1}\).  After Euclidean-space transport,
+the tail window is the range of `tailBoundaryMap A K L`, while the left window
+(first \(K+L-1\) sites with one final spectator) is the range of
+`leftBoundaryMap A (K+L-1) 1`.  Thus the two transport theorems below realize
+both C3 subspaces as boundary-map ranges in this common ambient space.
 
 ## References
 

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
@@ -353,9 +353,10 @@ maps, after transport by the canonical `WithLp` isomorphism, with the
 Hilbert-space ground submodules used in the open-chain martingale condition
 (Chapter~13, Nachtergaele C3). -/
 
-/-- The Euclidean-space transport of the tail boundary map range
-equals the open-chain tail ground submodule. -/
-
+/-- For a suffix of length one, `prefixRestrictₗ τ` coincides with
+`restrictLast (τ 0)`.  This is used to connect the left boundary map range
+(at \(L=1\)) to the open-chain left ground space defined by fixing the
+last site. -/
 lemma prefixRestrictₗ_one_eq_restrictLast {d K : ℕ} (τ : Fin 1 → Fin d)
     (ψ : NSiteSpace d (K + 1)) :
     prefixRestrictₗ τ ψ = restrictLast ψ (τ 0) := by
@@ -363,6 +364,10 @@ lemma prefixRestrictₗ_one_eq_restrictLast {d K : ℕ} (τ : Fin 1 → Fin d)
   simp [prefixRestrictₗ_apply, restrictLast_apply, Fin.append_right_eq_snoc]
 
 
+/-- The Euclidean-space transport of the tail boundary map range identifies
+with `openChainTailGroundSpaceES`.  This is the exact common-ambient
+identification required for the open-chain martingale condition C3
+(Nachtergaele, arXiv:cond-mat/9410110, eq. (2.4)). -/
 theorem tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES
     (A : MPSTensor d D) (K L : ℕ) :
     Submodule.map ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm).toLinearMap
@@ -382,6 +387,11 @@ theorem tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES
     _ = openChainTailGroundSpaceES A K L := by
       simp [openChainTailGroundSpaceES]
 
+/-- At suffix length \(L=1\) (the C3 specialization), the Euclidean-space
+transport of the left boundary map range identifies with
+`openChainLeftGroundSpaceES`.  This complements the tail transport
+theorem to place both overlapping ground spaces in the same ambient
+Hilbert space. -/
 theorem leftBoundaryMap_range_map_symm_eq_openChainLeftGroundSpaceES
     (A : MPSTensor d D) (K : ℕ) :
     Submodule.map ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + 1))).symm).toLinearMap

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
@@ -1,0 +1,425 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
+import TNLean.MPS.ParentHamiltonian.SuffixWindow
+
+/-!
+# Spectator-indexed boundary maps for overlapping MPS windows
+
+This file defines the spectator-indexed tail and left boundary maps that
+embed virtual-space data into a common ambient physical Hilbert space, and
+proves exact range and word-factorization identities.  These are the maps
+required to place overlapping ground spaces in the same ambient
+Hilbert space before a spectral-gap estimate can compare their projectors.
+
+All lemmas are purely algebraic and exact; no convergence norm or contraction
+estimate is asserted.
+
+## Main definitions
+
+* `MPSTensor.tailBoundaryMap A K L` --- maps a family
+  \(\{Y_u\}\) (indexed by \(K\)-site prefix configurations) to a vector
+  on \(K+L\) sites via \(\psi(u,    au)=    r(A^    au Y_u)\).
+* `MPSTensor.prefixRestrictₗ` --- fixes a suffix \(    au\) and restricts
+  to the prefix (the left-sided analogue of `tailRestrictₗ`).
+* `MPSTensor.leftBoundaryMap A K L` --- maps a family
+  \(\{Z_    au\}\) (indexed by \(L\)-site suffix configurations) to a vector
+  on \(K+L\) sites via \(\psi(u,    au)=    r(A^u Z_    au)\).
+
+## Main results
+
+* `MPSTensor.tailBoundaryMap_factorization` --- the standard
+  length-\((K+L)\) boundary map factors through the tail boundary map:
+  \(\Gamma_{K+L}(X)=\Gamma^{\mathrm{tail}}_{K,L}(u\mapsto X A^u)\).
+* `MPSTensor.tailBoundaryMap_range_eq` --- the range of the tail boundary
+  map is exactly the tail ground space
+  \(\{\psi\mid\forall u,\;\operatorname{tail\_restrict}_u\psi\in G_L(A)\}\).
+* `MPSTensor.tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES`
+  --- after Euclidean-space transport, the tail range identifies with
+  `openChainTailGroundSpaceES`.
+* `MPSTensor.leftBoundaryMap_factorization` --- the symmetric factorization:
+  \(\Gamma_{K+L}(X)=\Gamma^{\mathrm{left}}_{K,L}(    au\mapsto A^    au X)\).
+* `MPSTensor.leftBoundaryMap_range_eq` --- the range of the left boundary
+  map is exactly the left ground space
+  \(\{\psi\midorall    au,\;\operatorname{prefix\_restrict}_    au\psi\in G_K(A)\}\).
+* `MPSTensor.leftBoundaryMap_range_map_symm_eq_openChainLeftGroundSpaceES`
+  --- at \(L=1\) (the C3 specialization), the Euclidean-space transport of the
+  left range identifies with `openChainLeftGroundSpaceES`.
+
+## Scope restriction (FNW contraction not derived)
+
+The algebraic identities above place both ground spaces as ranges of boundary
+maps on the same ambient \(H_{K+L}\).  The FNW transfer-mixing estimate that
+would bound the defect \(\|P_{\mathrm{tail}}\circ P_{\mathrm{left}}
+-P_{\mathrm{full}}\|\) using the inverse-Gram range-projector formula
+(`GroundSpaceGram.lean`) and the spectral properties of the transfer operator
+is not derived here.  Deriving that numerical contraction from the Gram/transfer
+identities and inverse-Gram control remains open.  Both boundary maps are
+unweighted (Frobenius) and the Gram identities are normalization-neutral; the
+contraction estimate may require a second fixed-point metric or weighted
+boundary coordinates.
+
+## Open-chain context
+
+For Nachtergaele C3 (arXiv:cond-mat/9410110, eq. (2.4)), take
+\(K := n - l\), \(L := l + 1\), and let the common ambient space be
+\(H_{K+L}=H_{n+1}\).  The left window (first \(K+L-1\) sites) is not directly
+the range of a spectator-indexed left boundary map; it is the subspace
+`InLeftGround` defined by fixing the *last* site.
+
+## References
+
+* B. Nachtergaele, arXiv:cond-mat/9410110, eqs. (2.4)--(2.5), Theorem 3,
+  and Section 6.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Prefix restriction (left symmetric of `tailRestrictₗ`) -/
+
+/-- Fix a suffix \(τ : Fin L → Fin d\) and restrict a \(K+L\)-site state to its
+first \(K\) sites.  This is the left-sided analogue of \(tailRestrictₗ\). -/
+def prefixRestrictₗ {d K L : ℕ} (τ : Fin L → Fin d) :
+    NSiteSpace d (K + L) →ₗ[ℂ] NSiteSpace d K where
+  toFun ψ := fun σ => ψ (Fin.append σ τ)
+  map_add' ψ₁ ψ₂ := by ext σ; simp
+  map_smul' c ψ := by ext σ; simp
+
+@[simp] theorem prefixRestrictₗ_apply {d K L : ℕ} (τ : Fin L → Fin d)
+    (ψ : NSiteSpace d (K + L)) (σ : Fin K → Fin d) :
+    prefixRestrictₗ τ ψ σ = ψ (Fin.append σ τ) := rfl
+
+/-- The prefix restriction of a ground-space vector: fixing the suffix τ and
+keeping the prefix variable moves the suffix word to the left factor of the
+virtual matrix. -/
+@[simp] theorem prefixRestrictₗ_groundSpaceMap (A : MPSTensor d D) {K L : ℕ}
+    (τ : Fin L → Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
+    prefixRestrictₗ τ (groundSpaceMap A (K + L) X) =
+      groundSpaceMap A K (evalWord A (List.ofFn τ) * X) := by
+  ext σ
+  simp only [prefixRestrictₗ_apply, groundSpaceMap_apply]
+  calc
+    Matrix.trace (evalWord A (List.ofFn (Fin.append σ τ)) * X)
+        = Matrix.trace ((evalWord A (List.ofFn σ) * evalWord A (List.ofFn τ)) * X) := by
+          simp [List.ofFn_fin_append, evalWord_append A]
+    _ = Matrix.trace (evalWord A (List.ofFn σ) * (evalWord A (List.ofFn τ) * X)) := by
+          simp [Matrix.mul_assoc]
+
+/-! ### Tail (prefix-spectator) boundary map -/
+
+/-- Spectator-indexed tail boundary map.
+
+For a family \(Y : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ\) indexed by
+\(K\)-site prefix configurations, the map produces a vector on \(K+L\) sites by
+\[
+  (\Gamma^{\mathrm{tail}}_{K,L}(Y))(u,\tau)
+  = \operatorname{tr}\bigl(A^{\tau}\;Y_u\bigr),
+\]
+where \(u\) is the prefix and \(τ\) is the suffix.
+When \(Y_u = X·A^u\) the output equals the standard \(Γ_{K+L}(X)\). -/
+noncomputable def tailBoundaryMap (A : MPSTensor d D) (K L : ℕ) :
+    ((Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ) →ₗ[ℂ] NSiteSpace d (K + L) where
+  toFun Y σ := Matrix.trace (evalWord A (List.ofFn (σ ∘ Fin.natAdd K)) *
+    Y (σ ∘ Fin.castAdd L))
+  map_add' Y₁ Y₂ := by ext σ; simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c Y := by ext σ; simp [Matrix.trace_smul, smul_eq_mul]
+
+@[simp] theorem tailBoundaryMap_apply (A : MPSTensor d D) (K L : ℕ)
+    (Y : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ) (σ : Cfg d (K + L)) :
+    tailBoundaryMap A K L Y σ =
+      Matrix.trace (evalWord A (List.ofFn (σ ∘ Fin.natAdd K)) *
+        Y (σ ∘ Fin.castAdd L)) :=
+  rfl
+
+/-- The tail boundary map on a prefix–suffix pair reduces to the local
+ground-space map on the suffix. -/
+theorem tailBoundaryMap_append (A : MPSTensor d D) (K L : ℕ)
+    (Y : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (u : Fin K → Fin d) (τ : Fin L → Fin d) :
+    tailBoundaryMap A K L Y (Fin.append u τ) =
+      groundSpaceMap A L (Y u) τ := by
+  calc
+    tailBoundaryMap A K L Y (Fin.append u τ)
+        = Matrix.trace (evalWord A
+            (List.ofFn ((Fin.append u τ) ∘ Fin.natAdd K)) *
+          Y ((Fin.append u τ) ∘ Fin.castAdd L)) := rfl
+    _ = Matrix.trace (evalWord A (List.ofFn τ) * Y u) := by
+      have h_suffix : (Fin.append u τ) ∘ Fin.natAdd K = τ := by
+        ext i; simp [Fin.append_right]
+      have h_prefix : (Fin.append u τ) ∘ Fin.castAdd L = u := by
+        ext i; simp [Fin.append_left]
+      simp [h_suffix, h_prefix]
+    _ = groundSpaceMap A L (Y u) τ := by simp [groundSpaceMap_apply]
+
+/-- Restricting the tail boundary map to the suffix for a fixed prefix \(u\)
+recovers \(Γ_L(Y_u)\). -/
+@[simp] theorem tailRestrictₗ_tailBoundaryMap (A : MPSTensor d D) (K L : ℕ)
+    (Y : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ) (u : Fin K → Fin d) :
+    tailRestrictₗ u (tailBoundaryMap A K L Y) = groundSpaceMap A L (Y u) := by
+  ext τ
+  simp [tailBoundaryMap_append A K L Y u τ]
+
+/-- Word-factorization identity: the standard length-\((K+L)\) boundary map
+factors through the tail boundary map by \(X ↦ (λ u, X·A^u)\).
+\[
+  \Gamma_{K+L}(X) = \Gamma^{\mathrm{tail}}_{K,L}(\lambda u,\; X\,A^u).
+\] -/
+theorem tailBoundaryMap_factorization (A : MPSTensor d D) (K L : ℕ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    tailBoundaryMap A K L
+      (fun u : Fin K → Fin d => X * evalWord A (List.ofFn u)) =
+        groundSpaceMap A (K + L) X := by
+  ext σ
+  rw [tailBoundaryMap_apply, groundSpaceMap_apply]
+  set u := σ ∘ Fin.castAdd L
+  set τ := σ ∘ Fin.natAdd K
+  have hσ : σ = Fin.append u τ := Fin.append_castAdd_natAdd.symm
+  calc
+    Matrix.trace (evalWord A (List.ofFn τ) * (X * evalWord A (List.ofFn u)))
+        = Matrix.trace ((X * evalWord A (List.ofFn u)) *
+          evalWord A (List.ofFn τ)) := by
+      rw [Matrix.trace_mul_comm]
+    _ = Matrix.trace (X * (evalWord A (List.ofFn u) *
+      evalWord A (List.ofFn τ))) := by
+      simp [Matrix.mul_assoc]
+    _ = Matrix.trace (evalWord A (List.ofFn (Fin.append u τ)) * X) := by
+      calc
+        Matrix.trace (X * (evalWord A (List.ofFn u) * evalWord A (List.ofFn τ)))
+            = Matrix.trace ((evalWord A (List.ofFn u) *
+              evalWord A (List.ofFn τ)) * X) := by
+          rw [Matrix.trace_mul_comm]
+        _ = Matrix.trace ((evalWord A (List.ofFn u ++ List.ofFn τ)) * X) := by
+          simp [evalWord_append A]
+        _ = Matrix.trace (evalWord A (List.ofFn (Fin.append u τ)) * X) := by
+          simp [List.ofFn_fin_append]
+    _ = groundSpaceMap A (K + L) X σ := by simp [hσ, groundSpaceMap_apply]
+
+/-- The range of the tail boundary map equals the tail ground space:
+vectors whose suffix restriction lies in the local ground space for
+every prefix configuration. -/
+theorem tailBoundaryMap_range_eq (A : MPSTensor d D) (K L : ℕ) :
+    (tailBoundaryMap A K L).range =
+      {ψ : NSiteSpace d (K + L) | ∀ u : Fin K → Fin d,
+        tailRestrictₗ u ψ ∈ groundSpace A L} := by
+  ext ψ
+  constructor
+  · rintro ⟨Y, rfl⟩ u
+    rw [tailRestrictₗ_tailBoundaryMap A K L Y u]
+    exact ⟨Y u, rfl⟩
+  · intro hψ
+    -- For each prefix u, pick a matrix Y_u representing the suffix slice
+    have hY : ∀ u : Fin K → Fin d,
+        tailRestrictₗ u ψ ∈ (groundSpaceMap A L).range := by
+      intro u
+      have hu := hψ u
+      simpa [groundSpace] using hu
+    -- Extract choice function Y
+    choose Y hY' using (fun u => (LinearMap.mem_range).mp (hY u))
+    -- hY' : ∀ u, groundSpaceMap A L (Y u) = tailRestrictₗ u ψ
+    refine ⟨Y, ?_⟩
+    ext σ
+    rw [tailBoundaryMap_apply]
+    set u := σ ∘ Fin.castAdd L
+    set τ := σ ∘ Fin.natAdd K
+    have hσ_eq : Fin.append u τ = σ := Fin.append_castAdd_natAdd
+    have h_tail_eq : tailRestrictₗ u ψ τ = groundSpaceMap A L (Y u) τ := by
+      rw [hY' u]
+    rw [tailRestrictₗ_apply, hσ_eq, groundSpaceMap_apply] at h_tail_eq
+    -- h_tail_eq : ψ σ = trace (evalWord A (List.ofFn τ) * Y u)
+    simpa [groundSpaceMap_apply] using h_tail_eq.symm
+
+/-! ### Left (suffix-spectator) boundary map -/
+
+/-- Spectator-indexed left boundary map.
+
+For a family \(Z : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ\) indexed by
+\(L\)-site suffix configurations, the map produces a vector on \(K+L\) sites by
+\[
+  (\Gamma^{\mathrm{left}}_{K,L}(Z))(u,\tau)
+  = \operatorname{tr}\bigl(A^{u}\;Z_{\tau}\bigr),
+\]
+where \(u\) is the prefix and \(τ\) is the suffix.
+When \(Z_τ = A^τ·X\) the output equals the standard \(Γ_{K+L}(X)\). -/
+noncomputable def leftBoundaryMap (A : MPSTensor d D) (K L : ℕ) :
+    ((Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ) →ₗ[ℂ] NSiteSpace d (K + L) where
+  toFun Z σ := Matrix.trace (evalWord A (List.ofFn (σ ∘ Fin.castAdd L)) *
+    Z (σ ∘ Fin.natAdd K))
+  map_add' Z₁ Z₂ := by ext σ; simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c Z := by ext σ; simp [Matrix.trace_smul, smul_eq_mul]
+
+@[simp] theorem leftBoundaryMap_apply (A : MPSTensor d D) (K L : ℕ)
+    (Z : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ) (σ : Cfg d (K + L)) :
+    leftBoundaryMap A K L Z σ =
+      Matrix.trace (evalWord A (List.ofFn (σ ∘ Fin.castAdd L)) *
+        Z (σ ∘ Fin.natAdd K)) :=
+  rfl
+
+/-- The left boundary map on a prefix–suffix pair reduces to the local
+ground-space map on the prefix. -/
+theorem leftBoundaryMap_append (A : MPSTensor d D) (K L : ℕ)
+    (Z : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (u : Fin K → Fin d) (τ : Fin L → Fin d) :
+    leftBoundaryMap A K L Z (Fin.append u τ) =
+      groundSpaceMap A K (Z τ) u := by
+  calc
+    leftBoundaryMap A K L Z (Fin.append u τ)
+        = Matrix.trace (evalWord A
+            (List.ofFn ((Fin.append u τ) ∘ Fin.castAdd L)) *
+          Z ((Fin.append u τ) ∘ Fin.natAdd K)) := rfl
+    _ = Matrix.trace (evalWord A (List.ofFn u) * Z τ) := by
+      have h_prefix : (Fin.append u τ) ∘ Fin.castAdd L = u := by
+        ext i; simp [Fin.append_left]
+      have h_suffix : (Fin.append u τ) ∘ Fin.natAdd K = τ := by
+        ext i; simp [Fin.append_right]
+      simp [h_prefix, h_suffix]
+    _ = groundSpaceMap A K (Z τ) u := by simp [groundSpaceMap_apply]
+
+/-- Restricting the left boundary map to the prefix for a fixed suffix \(τ\)
+recovers \(Γ_K(Z_τ)\). -/
+@[simp] theorem prefixRestrictₗ_leftBoundaryMap (A : MPSTensor d D) (K L : ℕ)
+    (Z : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ) (τ : Fin L → Fin d) :
+    prefixRestrictₗ τ (leftBoundaryMap A K L Z) = groundSpaceMap A K (Z τ) := by
+  ext σ
+  simp [leftBoundaryMap_append A K L Z σ τ]
+
+/-- Word-factorization identity (left side): the standard length-\((K+L)\)
+boundary map factors through the left boundary map by \(X ↦ (λ τ, A^τ·X)\).
+\[
+  \Gamma_{K+L}(X) = \Gamma^{\mathrm{left}}_{K,L}(\lambda \tau,\; A^\tau\,X).
+\] -/
+theorem leftBoundaryMap_factorization (A : MPSTensor d D) (K L : ℕ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    leftBoundaryMap A K L
+      (fun τ : Fin L → Fin d => evalWord A (List.ofFn τ) * X) =
+        groundSpaceMap A (K + L) X := by
+  ext σ
+  rw [leftBoundaryMap_apply, groundSpaceMap_apply]
+  set u := σ ∘ Fin.castAdd L
+  set τ := σ ∘ Fin.natAdd K
+  have hσ : σ = Fin.append u τ := Fin.append_castAdd_natAdd.symm
+  calc
+    Matrix.trace (evalWord A (List.ofFn u) * (evalWord A (List.ofFn τ) * X))
+        = Matrix.trace ((evalWord A (List.ofFn u) *
+          evalWord A (List.ofFn τ)) * X) := by
+      simp [Matrix.mul_assoc]
+    _ = Matrix.trace (evalWord A (List.ofFn u ++ List.ofFn τ) * X) := by
+      simp [evalWord_append A]
+    _ = Matrix.trace (evalWord A (List.ofFn (Fin.append u τ)) * X) := by
+      simp [List.ofFn_fin_append]
+    _ = groundSpaceMap A (K + L) X σ := by simp [hσ, groundSpaceMap_apply]
+
+/-- The range of the left boundary map equals the left ground space:
+vectors whose prefix restriction lies in the local ground space for
+every suffix configuration. -/
+theorem leftBoundaryMap_range_eq (A : MPSTensor d D) (K L : ℕ) :
+    (leftBoundaryMap A K L).range =
+      {ψ : NSiteSpace d (K + L) | ∀ τ : Fin L → Fin d,
+        prefixRestrictₗ τ ψ ∈ groundSpace A K} := by
+  ext ψ
+  constructor
+  · rintro ⟨Z, rfl⟩ τ
+    rw [prefixRestrictₗ_leftBoundaryMap A K L Z τ]
+    exact ⟨Z τ, rfl⟩
+  · intro hψ
+    have hZ : ∀ τ : Fin L → Fin d,
+        prefixRestrictₗ τ ψ ∈ (groundSpaceMap A K).range := by
+      intro τ
+      have hτ := hψ τ
+      simpa [groundSpace] using hτ
+    choose Z hZ' using (fun τ => (LinearMap.mem_range).mp (hZ τ))
+    refine ⟨Z, ?_⟩
+    ext σ
+    rw [leftBoundaryMap_apply]
+    set u := σ ∘ Fin.castAdd L
+    set τ := σ ∘ Fin.natAdd K
+    have hσ_eq : Fin.append u τ = σ := Fin.append_castAdd_natAdd
+    have h_pre_eq : prefixRestrictₗ τ ψ u = groundSpaceMap A K (Z τ) u := by
+      rw [hZ' τ]
+    rw [prefixRestrictₗ_apply, hσ_eq, groundSpaceMap_apply] at h_pre_eq
+    -- h_pre_eq : ψ σ = trace (evalWord A (List.ofFn u) * Z τ)
+    simpa [groundSpaceMap_apply] using h_pre_eq.symm
+
+/-! ### Euclidean-space transport to open-chain submodules
+
+The following theorems identify the ranges of the spectator-indexed boundary
+maps, after transport by the canonical `WithLp` isomorphism, with the
+Hilbert-space ground submodules used in the open-chain martingale condition
+(Chapter~13, Nachtergaele C3). -/
+
+/-- The Euclidean-space transport of the tail boundary map range
+equals the open-chain tail ground submodule. -/
+
+lemma prefixRestrictₗ_one_eq_restrictLast {d K : ℕ} (τ : Fin 1 → Fin d)
+    (ψ : NSiteSpace d (K + 1)) :
+    prefixRestrictₗ τ ψ = restrictLast ψ (τ 0) := by
+  ext σ
+  simp [prefixRestrictₗ_apply, restrictLast_apply, Fin.append_right_eq_snoc]
+
+
+theorem tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES
+    (A : MPSTensor d D) (K L : ℕ) :
+    Submodule.map ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm).toLinearMap
+      (tailBoundaryMap A K L).range =
+    openChainTailGroundSpaceES A K L :=
+  calc
+    Submodule.map ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm).toLinearMap
+        (tailBoundaryMap A K L).range
+      = Submodule.map ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm).toLinearMap
+          (⨅ u : Fin K → Fin d, (groundSpace A L).comap (tailRestrictₗ u)) := by
+        congr 1
+        apply Submodule.ext
+        intro ψ
+        have h_set := tailBoundaryMap_range_eq A K L
+        have h_mem := congrArg (fun (s : Set (NSiteSpace d (K + L))) => ψ ∈ s) h_set
+        simpa [Submodule.mem_iInf, groundSpace, tailRestrictₗ] using h_mem
+    _ = openChainTailGroundSpaceES A K L := by
+      simp [openChainTailGroundSpaceES]
+
+theorem leftBoundaryMap_range_map_symm_eq_openChainLeftGroundSpaceES
+    (A : MPSTensor d D) (K : ℕ) :
+    Submodule.map ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + 1))).symm).toLinearMap
+      (leftBoundaryMap A K 1).range =
+    openChainLeftGroundSpaceES A K :=
+  calc
+    Submodule.map ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + 1))).symm).toLinearMap
+        (leftBoundaryMap A K 1).range
+      = Submodule.map ((WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + 1))).symm).toLinearMap
+          (⨅ j : Fin d, (groundSpace A K).comap (restrictLastₗ j)) := by
+        congr 1
+        apply Submodule.ext
+        intro ψ
+        have h_set := leftBoundaryMap_range_eq A K 1
+        have h1 : ψ ∈ (leftBoundaryMap A K 1).range ↔
+            ∀ τ : Fin 1 → Fin d, prefixRestrictₗ τ ψ ∈ groundSpace A K := by
+          have := congrArg (fun (s : Set (NSiteSpace d (K + 1))) => ψ ∈ s) h_set
+          simpa using this
+        have h2 : (∀ τ : Fin 1 → Fin d, prefixRestrictₗ τ ψ ∈ groundSpace A K) ↔
+            (∀ j : Fin d, (restrictLastₗ j) ψ ∈ groundSpace A K) := by
+          constructor
+          · intro h j
+            have h_pre := h (fun _ => j)
+            have eq_pre : prefixRestrictₗ (fun _ : Fin 1 => j) ψ = (restrictLastₗ j) ψ := by
+              simpa [restrictLast] using prefixRestrictₗ_one_eq_restrictLast
+                (fun _ : Fin 1 => j) ψ
+            rwa [eq_pre] at h_pre
+          · intro h τ
+            have h_last := h (τ 0)
+            have eq_last : prefixRestrictₗ τ ψ = (restrictLastₗ (τ 0)) ψ := by
+              simpa [restrictLast] using prefixRestrictₗ_one_eq_restrictLast τ ψ
+            rw [eq_last]
+            exact h_last
+        have h3 : (∀ j : Fin d, (restrictLastₗ j) ψ ∈ groundSpace A K) ↔
+            ψ ∈ ⨅ j : Fin d, (groundSpace A K).comap (restrictLastₗ j) := by
+          simp [Submodule.mem_iInf]
+        exact (h1.trans h2).trans h3
+    _ = openChainLeftGroundSpaceES A K := by
+      simp [openChainLeftGroundSpaceES]
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
@@ -22,12 +22,12 @@ estimate is asserted.
 
 * `MPSTensor.tailBoundaryMap A K L` --- maps a family
   \(\{Y_u\}\) (indexed by \(K\)-site prefix configurations) to a vector
-  on \(K+L\) sites via \(\psi(u,    au)=    r(A^    au Y_u)\).
-* `MPSTensor.prefixRestrictₗ` --- fixes a suffix \(    au\) and restricts
+  on \(K+L\) sites via \(\psi(u,\tau)=  \tr(A^{\tau} Y_u)\).
+* `MPSTensor.prefixRestrictₗ` --- fixes a suffix \(\tau\) and restricts
   to the prefix (the left-sided analogue of `tailRestrictₗ`).
 * `MPSTensor.leftBoundaryMap A K L` --- maps a family
-  \(\{Z_    au\}\) (indexed by \(L\)-site suffix configurations) to a vector
-  on \(K+L\) sites via \(\psi(u,    au)=    r(A^u Z_    au)\).
+  \(\{Z_{\tau}\}\) (indexed by \(L\)-site suffix configurations) to a vector
+  on \(K+L\) sites via \(\psi(u,\tau)=  \tr(A^{u} Z_{\tau})\).
 
 ## Main results
 
@@ -41,10 +41,10 @@ estimate is asserted.
   --- after Euclidean-space transport, the tail range identifies with
   `openChainTailGroundSpaceES`.
 * `MPSTensor.leftBoundaryMap_factorization` --- the symmetric factorization:
-  \(\Gamma_{K+L}(X)=\Gamma^{\mathrm{left}}_{K,L}(    au\mapsto A^    au X)\).
+  \(\Gamma_{K+L}(X)=\Gamma^{\mathrm{left}}_{K,L}(\tau\mapsto A^{\tau} X)\).
 * `MPSTensor.leftBoundaryMap_range_eq` --- the range of the left boundary
   map is exactly the left ground space
-  \(\{\psi\midorall    au,\;\operatorname{prefix\_restrict}_    au\psi\in G_K(A)\}\).
+  \(\{\psi\mid\forall \tau,\;\operatorname{prefix\_restrict}_{\tau}\psi\in G_K(A)\}\).
 * `MPSTensor.leftBoundaryMap_range_map_symm_eq_openChainLeftGroundSpaceES`
   --- at \(L=1\) (the C3 specialization), the Euclidean-space transport of the
   left range identifies with `openChainLeftGroundSpaceES`.
@@ -52,7 +52,7 @@ estimate is asserted.
 ## Scope restriction (FNW contraction not derived)
 
 The algebraic identities above place both ground spaces as ranges of boundary
-maps on the same ambient \(H_{K+L}\).  The FNW transfer-mixing estimate that
+maps on the same ambient \(\mathcal{H}_{K+L}\).  The FNW transfer-mixing estimate that
 would bound the defect \(\|P_{\mathrm{tail}}\circ P_{\mathrm{left}}
 -P_{\mathrm{full}}\|\) using the inverse-Gram range-projector formula
 (`GroundSpaceGram.lean`) and the spectral properties of the transfer operator
@@ -66,7 +66,7 @@ boundary coordinates.
 
 For Nachtergaele C3 (arXiv:cond-mat/9410110, eq. (2.4)), take
 \(K := n - l\), \(L := l + 1\), and let the common ambient space be
-\(H_{K+L}=H_{n+1}\).  The left window (first \(K+L-1\) sites) is not directly
+\(\mathcal{H}_{K+L} = \mathcal{H}_{n+1}\).  The left window (first \(K+L-1\) sites) is not directly
 the range of a spectator-indexed left boundary map; it is the subspace
 `InLeftGround` defined by fixing the *last* site.
 
@@ -183,22 +183,16 @@ theorem tailBoundaryMap_factorization (A : MPSTensor d D) (K L : ℕ)
   have hσ : σ = Fin.append u τ := Fin.append_castAdd_natAdd.symm
   calc
     Matrix.trace (evalWord A (List.ofFn τ) * (X * evalWord A (List.ofFn u)))
-        = Matrix.trace ((X * evalWord A (List.ofFn u)) *
-          evalWord A (List.ofFn τ)) := by
-      rw [Matrix.trace_mul_comm]
-    _ = Matrix.trace (X * (evalWord A (List.ofFn u) *
-      evalWord A (List.ofFn τ))) := by
+        = Matrix.trace (evalWord A (List.ofFn u) *
+          (evalWord A (List.ofFn τ) * X)) := by
+      rw [Matrix.trace_mul_cycle' (evalWord A (List.ofFn τ)) X
+        (evalWord A (List.ofFn u))]
+    _ = Matrix.trace ((evalWord A (List.ofFn u) * evalWord A (List.ofFn τ)) * X) := by
       simp [Matrix.mul_assoc]
+    _ = Matrix.trace (evalWord A (List.ofFn u ++ List.ofFn τ) * X) := by
+      simp [evalWord_append A]
     _ = Matrix.trace (evalWord A (List.ofFn (Fin.append u τ)) * X) := by
-      calc
-        Matrix.trace (X * (evalWord A (List.ofFn u) * evalWord A (List.ofFn τ)))
-            = Matrix.trace ((evalWord A (List.ofFn u) *
-              evalWord A (List.ofFn τ)) * X) := by
-          rw [Matrix.trace_mul_comm]
-        _ = Matrix.trace ((evalWord A (List.ofFn u ++ List.ofFn τ)) * X) := by
-          simp [evalWord_append A]
-        _ = Matrix.trace (evalWord A (List.ofFn (Fin.append u τ)) * X) := by
-          simp [List.ofFn_fin_append]
+      simp [List.ofFn_fin_append]
     _ = groundSpaceMap A (K + L) X σ := by simp [hσ, groundSpaceMap_apply]
 
 /-- The range of the tail boundary map equals the tail ground space:

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean
@@ -67,9 +67,9 @@ boundary coordinates.
 For Nachtergaele C3 (arXiv:cond-mat/9410110, eq. (2.4)), take
 \(K := n - l\), \(L := l + 1\), and let the common ambient space be
 \(\mathcal{H}_{K+L} = \mathcal{H}_{n+1}\).  After Euclidean-space transport,
-the tail window is the range of `tailBoundaryMap A K L`, while the left window
-(first \(K+L-1\) sites with one final spectator) is the range of
-`leftBoundaryMap A (K+L-1) 1`.  Thus the two transport theorems below realize
+the tail window is the range of \(\Gamma^{\mathrm{tail}}_{K,L}\), while the
+left window (first \(K+L-1\) sites with one final spectator) is the range of
+\(\Gamma^{\mathrm{left}}_{K+L-1,1}\).  Thus the two transport theorems below realize
 both C3 subspaces as boundary-map ranges in this common ambient space.
 
 ## References
@@ -349,8 +349,8 @@ maps, after transport by the canonical `WithLp` isomorphism, with the
 Hilbert-space ground submodules used in the open-chain martingale condition
 (Chapter~13, Nachtergaele C3). -/
 
-/-- For a suffix of length one, `prefixRestrictₗ τ` coincides with
-`restrictLast (τ 0)`.  This is used to connect the left boundary map range
+/-- For a one-site suffix \(\tau\), prefix restriction by \(\tau\) coincides
+with last-site restriction at \(\tau(0)\).  This is used to connect the left boundary map range
 (at \(L=1\)) to the open-chain left ground space defined by fixing the
 last site. -/
 lemma prefixRestrictₗ_one_eq_restrictLast {d K : ℕ} (τ : Fin 1 → Fin d)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -115,7 +115,7 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{thm:tail_boundary_map_append}
-    This is Lemma~\ref{thm:tail_boundary_map_append} applied pointwise:
+    This is Theorem~\ref{thm:tail_boundary_map_append} applied pointwise:
     for each $\tau$, $(R^{\mathrm{tail}}_u\psi)(\tau)=\psi(u,\tau)$.
 \end{proof}
 
@@ -204,7 +204,7 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{thm:left_boundary_map_append}
-    Pointwise application of Lemma~\ref{thm:left_boundary_map_append}:
+    Pointwise application of Theorem~\ref{thm:left_boundary_map_append}:
     for each $\sigma$, $(P_\tau\psi)(\sigma)=\psi(\sigma,\tau)$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1,3 +1,241 @@
+\subsection{Spectator-indexed boundary maps}\label{subsec:spectator_boundary_maps}
+
+The tail and left boundary maps embed virtual-space data into a common
+ambient $(K+L)$-site Hilbert space.  This places the overlapping ground
+spaces as ranges of linear maps on the same ambient space, a necessary
+step before their projectors can be compared in the martingale condition.
+All statements are exact algebraic identities; no FNW contraction or
+norm estimate is derived here.
+
+\begin{definition}[Prefix restriction]\label{def:prefix_restrict}
+    \lean{MPSTensor.prefixRestrictₗ}
+    \leanok
+    \uses{def:tail_restrict_parent}
+    For $K,L\in\N$ and a fixed suffix configuration $\tau\colon\Fin L\to\Fin d$, the
+    \emph{prefix restriction} is the $\C$-linear map
+    $P_\tau\colon\C^{\Fin d^{K+L}}\to\C^{\Fin d^K}$ defined by
+    $(P_\tau\psi)(\sigma)=\psi(\sigma,\tau)$ for $\sigma\colon\Fin K\to\Fin d$.
+    This is the left-sided analogue of the suffix restriction of
+    Definition~\ref{def:tail_restrict_parent}.
+\end{definition}
+
+\begin{lemma}[Prefix restriction of a ground-space vector]\label{lem:prefix_restrict_ground_space_map}
+    \lean{MPSTensor.prefixRestrictₗ_groundSpaceMap}
+    \leanok
+    \uses{def:prefix_restrict, def:ground_space_map, lem:eval_word_append}
+    For every boundary matrix $X\in\MN{D}$ and every suffix $\tau$,
+    \begin{align}
+        P_\tau\bigl(\Gamma_{K+L}(X)\bigr)
+        &=\Gamma_K\bigl(A^\tau X\bigr).
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:eval_word_append}
+    Expand $\Gamma_{K+L}(X)(\sigma,\tau)=\tr(A^{\sigma,\tau}X)$,
+    factor $A^{\sigma,\tau}=A^\sigma A^\tau$, and use cyclicity of the trace
+    to move $A^\sigma$ to the front:
+    $\tr(A^\sigma(A^\tau X))=\Gamma_K(A^\tau X)(\sigma)$.
+\end{proof}
+
+\begin{definition}[Tail boundary map]\label{def:tail_boundary_map}
+    \lean{MPSTensor.tailBoundaryMap}
+    \leanok
+    \uses{def:ground_space_map}
+    For $K,L\in\N$, the \emph{tail boundary map} is the $\C$-linear map
+    \begin{align}
+        \Gamma^{\mathrm{tail}}_{K,L}\colon
+        \bigl((\Fin K\to\Fin d)\to\MN{D}\bigr)
+        \to\C^{\Fin d^{K+L}}
+    \end{align}
+    defined for every family $Y\colon(\Fin K\to\Fin d)\to\MN{D}$ by
+    \begin{align}
+        \Gamma^{\mathrm{tail}}_{K,L}(Y)(u,\tau)
+        &=\tr\bigl(A^\tau\,Y_u\bigr),
+    \end{align}
+    where $u\colon\Fin K\to\Fin d$ is the prefix and
+    $\tau\colon\Fin L\to\Fin d$ is the suffix.
+    When $Y_u=X A^u$ the output equals the standard $\Gamma_{K+L}(X)$.
+\end{definition}
+
+\begin{definition}[Left boundary map]\label{def:left_boundary_map}
+    \lean{MPSTensor.leftBoundaryMap}
+    \leanok
+    \uses{def:ground_space_map}
+    For $K,L\in\N$, the \emph{left boundary map} is the $\C$-linear map
+    \begin{align}
+        \Gamma^{\mathrm{left}}_{K,L}\colon
+        \bigl((\Fin L\to\Fin d)\to\MN{D}\bigr)
+        \to\C^{\Fin d^{K+L}}
+    \end{align}
+    defined for every family $Z\colon(\Fin L\to\Fin d)\to\MN{D}$ by
+    \begin{align}
+        \Gamma^{\mathrm{left}}_{K,L}(Z)(u,\tau)
+        &=\tr\bigl(A^{u}\,Z_{\tau}\bigr),
+    \end{align}
+    where $u\colon\Fin K\to\Fin d$ is the prefix and
+    $\tau\colon\Fin L\to\Fin d$ is the suffix.
+    When $Z_\tau=A^\tau X$ the output equals the standard $\Gamma_{K+L}(X)$.
+\end{definition}
+
+\begin{theorem}[Tail boundary map factorization]\label{thm:tail_boundary_map_factorization}
+    \lean{MPSTensor.tailBoundaryMap_factorization}
+    \leanok
+    \uses{def:tail_boundary_map, def:ground_space_map, lem:eval_word_append}
+    The standard length-$(K+L)$ boundary map factors through the tail boundary map:
+    \begin{align}
+        \Gamma_{K+L}(X)
+        &=\Gamma^{\mathrm{tail}}_{K,L}\bigl(u\mapsto X A^{u}\bigr)
+    \end{align}
+    for every $X\in\MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:eval_word_append}
+    Write a configuration $\sigma\in\Fin d^{K+L}$ as $\sigma=(u,\tau)$ with
+    $u\in\Fin d^K$ and $\tau\in\Fin d^L$.  Substitute $Y_u=X A^u$ into the
+    definition of $\Gamma^{\mathrm{tail}}_{K,L}$, apply
+    $\tr(A^\tau(X A^u))=\tr(X A^u A^\tau)$ by cyclicity of the trace,
+    factor $A^u A^\tau=A^{u,\tau}$ by multiplicativity of word evaluation
+    (Lemma~\ref{lem:eval_word_append}), and identify the result with
+    $\Gamma_{K+L}(X)(u,\tau)=\tr(A^{u,\tau}X)$.
+\end{proof}
+
+\begin{theorem}[Tail boundary map range]\label{thm:tail_boundary_map_range_eq}
+    \lean{MPSTensor.tailBoundaryMap_range_eq}
+    \leanok
+    \uses{def:tail_boundary_map, def:ground_space_parent, def:tail_restrict_parent}
+    The range of the tail boundary map is exactly the tail ground space:
+    \begin{align}
+        \range\bigl(\Gamma^{\mathrm{tail}}_{K,L}\bigr)
+        &=\bigl\{\psi\in\C^{\Fin d^{K+L}}
+            \mid \forall u\in\Fin d^K,\;
+            R^{\mathrm{tail}}_u\psi\in G_L(A)\bigr\}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:tail_restrict_parent, def:ground_space_parent}
+    For the forward inclusion, if $\psi=\Gamma^{\mathrm{tail}}_{K,L}(Y)$ then
+    $R^{\mathrm{tail}}_u\psi=\Gamma_L(Y_u)$ for every prefix $u$, so the suffix
+    restriction lies in $G_L(A)$.
+    Conversely, given $\psi$ with $R^{\mathrm{tail}}_u\psi\in G_L(A)$ for every $u$,
+    choose for each $u$ a matrix $Y_u\in\MN{D}$ with
+    $\Gamma_L(Y_u)=R^{\mathrm{tail}}_u\psi$.  Then
+    $\Gamma^{\mathrm{tail}}_{K,L}(Y)(u,\tau)=\tr(A^\tau Y_u)
+    =\Gamma_L(Y_u)(\tau)=(R^{\mathrm{tail}}_u\psi)(\tau)=\psi(u,\tau)$,
+    so $\psi$ lies in the range.
+\end{proof}
+
+\begin{theorem}[Left boundary map factorization]\label{thm:left_boundary_map_factorization}
+    \lean{MPSTensor.leftBoundaryMap_factorization}
+    \leanok
+    \uses{def:left_boundary_map, def:ground_space_map, lem:eval_word_append}
+    The standard length-$(K+L)$ boundary map factors through the left boundary map:
+    \begin{align}
+        \Gamma_{K+L}(X)
+        &=\Gamma^{\mathrm{left}}_{K,L}\bigl(\tau\mapsto A^{\tau}X\bigr)
+    \end{align}
+    for every $X\in\MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:eval_word_append}
+    Substitute $Z_\tau=A^\tau X$ into the definition of
+    $\Gamma^{\mathrm{left}}_{K,L}$, giving
+    $\tr(A^u(A^\tau X))=\tr((A^u A^\tau)X)$.  Factor $A^u A^\tau=A^{u,\tau}$ by
+    Lemma~\ref{lem:eval_word_append} and identify the result with
+    $\Gamma_{K+L}(X)(u,\tau)$.
+\end{proof}
+
+\begin{theorem}[Left boundary map range]\label{thm:left_boundary_map_range_eq}
+    \lean{MPSTensor.leftBoundaryMap_range_eq}
+    \leanok
+    \uses{def:left_boundary_map, def:ground_space_parent, def:prefix_restrict}
+    The range of the left boundary map is exactly the left ground space:
+    \begin{align}
+        \range\bigl(\Gamma^{\mathrm{left}}_{K,L}\bigr)
+        &=\bigl\{\psi\in\C^{\Fin d^{K+L}}
+            \mid \forall \tau\in\Fin d^L,\;
+            P_\tau\psi\in G_K(A)\bigr\}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:prefix_restrict, def:ground_space_parent}
+    The proof is symmetric to Theorem~\ref{thm:tail_boundary_map_range_eq}.
+    If $\psi=\Gamma^{\mathrm{left}}_{K,L}(Z)$ then
+    $P_\tau\psi=\Gamma_K(Z_\tau)$, so the prefix restriction lies in $G_K(A)$.
+    Conversely, given $\psi$ with $P_\tau\psi\in G_K(A)$ for every $\tau$, choose
+    $Z_\tau$ with $\Gamma_K(Z_\tau)=P_\tau\psi$; then
+    $\Gamma^{\mathrm{left}}_{K,L}(Z)(u,\tau)=\tr(A^u Z_\tau)
+    =\Gamma_K(Z_\tau)(u)=(P_\tau\psi)(u)=\psi(u,\tau)$.
+\end{proof}
+
+\begin{theorem}[Tail boundary map range: Euclidean-space transport]\label{thm:tail_boundary_map_range_es_transport}
+    \lean{MPSTensor.tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES}
+    \leanok
+    \uses{thm:tail_boundary_map_range_eq, def:open_chain_ground_subspaces_es}
+    For every $K,L\in\N$, transport of the tail boundary map range by the
+    inverse canonical $\ell^2$ isomorphism
+    identifies it with the open-chain tail ground submodule:
+    \begin{align}
+        \iota_{K+L}^{-1}\bigl(\range(\Gamma^{\mathrm{tail}}_{K,L})\bigr)
+        &=\mathcal V_{K,L}(A).
+    \end{align}
+    Concretely, a vector $v$ in the $(K+L)$-site Euclidean space belongs to
+    $\mathcal V_{K,L}(A)$ exactly when the corresponding function satisfies the
+    tail ground condition (Definition~\ref{def:in_tail_ground}).
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:tail_boundary_map_range_eq}
+    By Theorem~\ref{thm:tail_boundary_map_range_eq}, the range equals the
+    intersection over prefixes $u$ of the ground-space comaps
+    $(R^{\mathrm{tail}}_u)^{-1}(G_L(A))$.  Transporting this intersection
+    through the canonical $\ell^2$ identification and unfolding the definition
+    of $\mathcal V_{K,L}(A)$ (Definition~\ref{def:open_chain_ground_subspaces_es})
+    gives the stated equality.
+\end{proof}
+
+\begin{theorem}[Left boundary map range: Euclidean-space transport ($L=1$)]%
+    \label{thm:left_boundary_map_range_es_transport}
+    \lean{MPSTensor.leftBoundaryMap_range_map_symm_eq_openChainLeftGroundSpaceES}
+    \leanok
+    \uses{thm:left_boundary_map_range_eq, def:open_chain_ground_subspaces_es}
+    At $L=1$, transport of the left boundary map range by the inverse canonical
+    $\ell^2$ isomorphism identifies
+    it with the open-chain left ground submodule:
+    \begin{align}
+        \iota_{K+1}^{-1}\bigl(\range(\Gamma^{\mathrm{left}}_{K,1})\bigr)
+        &=\mathcal U_K(A).
+    \end{align}
+    Concretely, a vector $v$ in the $(K+1)$-site Euclidean space belongs to
+    $\mathcal U_K(A)$ exactly when the corresponding function satisfies the
+    left ground condition (every fixed-final-site restriction lies in $G_K(A)$;
+    Definition~\ref{def:in_left_ground}).
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:left_boundary_map_range_eq, def:prefix_restrict, def:restrict_last}
+    By Theorem~\ref{thm:left_boundary_map_range_eq} with $L=1$, the range equals
+    the intersection over suffixes $\tau\colon\Fin 1\to\Fin d$ of the comaps
+    $P_\tau^{-1}(G_K(A))$.  For $L=1$, each suffix $\tau$ is determined by a
+    single index $j\in\Fin d$, and the prefix restriction $P_\tau$ reduces to
+    $R^\mathrm{last}_j$, the last-site restriction of
+    Definition~\ref{def:restrict_last}
+    (Lemma~\ref{lem:prefix_restrict_ground_space_map}).  Transporting the
+    resulting intersection through the canonical $\ell^2$ identification and
+    unfolding Definition~\ref{def:open_chain_ground_subspaces_es} gives
+    $\mathcal U_K(A)$.
+\end{proof}
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -8,7 +8,7 @@ All statements are exact algebraic identities; no FNW contraction or
 norm estimate is derived here.
 
 \begin{definition}[Prefix restriction]\label{def:prefix_restrict}
-    \lean{MPSTensor.prefixRestrictₗ}
+    \lean{MPSTensor.prefixRestrictₗ, MPSTensor.prefixRestrictₗ_apply}
     \leanok
     \uses{def:tail_restrict_parent}
     For $K,L\in\N$ and a fixed suffix configuration $\tau\colon\Fin L\to\Fin d$, the
@@ -41,7 +41,7 @@ norm estimate is derived here.
 \end{proof}
 
 \begin{definition}[Tail boundary map]\label{def:tail_boundary_map}
-    \lean{MPSTensor.tailBoundaryMap}
+    \lean{MPSTensor.tailBoundaryMap, MPSTensor.tailBoundaryMap_apply}
     \leanok
     \uses{def:eval_word}
     For $K,L\in\N$, the \emph{tail boundary map} is the $\C$-linear map
@@ -61,7 +61,7 @@ norm estimate is derived here.
 \end{definition}
 
 \begin{definition}[Left boundary map]\label{def:left_boundary_map}
-    \lean{MPSTensor.leftBoundaryMap}
+    \lean{MPSTensor.leftBoundaryMap, MPSTensor.leftBoundaryMap_apply}
     \leanok
     \uses{def:eval_word}
     For $K,L\in\N$, the \emph{left boundary map} is the $\C$-linear map

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -43,7 +43,7 @@ norm estimate is derived here.
 \begin{definition}[Tail boundary map]\label{def:tail_boundary_map}
     \lean{MPSTensor.tailBoundaryMap}
     \leanok
-    \uses{def:ground_space_map}
+    \uses{def:eval_word}
     For $K,L\in\N$, the \emph{tail boundary map} is the $\C$-linear map
     \begin{align}
         \Gamma^{\mathrm{tail}}_{K,L}\colon
@@ -63,7 +63,7 @@ norm estimate is derived here.
 \begin{definition}[Left boundary map]\label{def:left_boundary_map}
     \lean{MPSTensor.leftBoundaryMap}
     \leanok
-    \uses{def:ground_space_map}
+    \uses{def:eval_word}
     For $K,L\in\N$, the \emph{left boundary map} is the $\C$-linear map
     \begin{align}
         \Gamma^{\mathrm{left}}_{K,L}\colon
@@ -80,7 +80,7 @@ norm estimate is derived here.
     When $Z_\tau=A^\tau X$ the output equals the standard $\Gamma_{K+L}(X)$.
 \end{definition}
 
-\begin{lemma}[Tail boundary map on a prefix--suffix pair]\label{lem:tail_boundary_map_append}
+\begin{theorem}[Tail boundary map on a prefix--suffix pair]\label{thm:tail_boundary_map_append}
     \lean{MPSTensor.tailBoundaryMap_append}
     \leanok
     \uses{def:tail_boundary_map, def:ground_space_map}
@@ -89,7 +89,7 @@ norm estimate is derived here.
         \Gamma^{\mathrm{tail}}_{K,L}(Y)(u,\tau)
         &=\Gamma_L(Y_u)(\tau).
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -100,22 +100,22 @@ norm estimate is derived here.
     $\Gamma_L(Y_u)(\tau)=\tr(A^\tau Y_u)$.
 \end{proof}
 
-\begin{lemma}[Suffix restriction of the tail boundary map]\label{lem:tail_restrict_tail_boundary_map}
+\begin{theorem}[Suffix restriction of the tail boundary map]\label{thm:tail_restrict_tail_boundary_map}
     \lean{MPSTensor.tailRestrictₗ_tailBoundaryMap}
     \leanok
-    \uses{lem:tail_boundary_map_append, def:tail_restrict_parent}
+    \uses{thm:tail_boundary_map_append, def:tail_restrict_parent}
     Restricting the tail boundary map to the suffix for a fixed prefix
     $u\in\Fin d^K$ recovers $\Gamma_L(Y_u)$:
     \begin{align}
         R^{\mathrm{tail}}_u\bigl(\Gamma^{\mathrm{tail}}_{K,L}(Y)\bigr)
         &=\Gamma_L(Y_u).
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{lem:tail_boundary_map_append}
-    This is Lemma~\ref{lem:tail_boundary_map_append} applied pointwise:
+    \uses{thm:tail_boundary_map_append}
+    This is Lemma~\ref{thm:tail_boundary_map_append} applied pointwise:
     for each $\tau$, $(R^{\mathrm{tail}}_u\psi)(\tau)=\psi(u,\tau)$.
 \end{proof}
 
@@ -136,11 +136,11 @@ norm estimate is derived here.
     \uses{lem:eval_word_append}
     Write a configuration $\sigma\in\Fin d^{K+L}$ as $\sigma=(u,\tau)$ with
     $u\in\Fin d^K$ and $\tau\in\Fin d^L$.  Substitute $Y_u=X A^u$ into the
-    definition of $\Gamma^{\mathrm{tail}}_{K,L}$, apply
-    $\tr(A^\tau(X A^u))=\tr(X A^u A^\tau)$ by cyclicity of the trace,
-    factor $A^u A^\tau=A^{u,\tau}$ by multiplicativity of word evaluation
-    (Lemma~\ref{lem:eval_word_append}), and identify the result with
-    $\Gamma_{K+L}(X)(u,\tau)=\tr(A^{u,\tau}X)$.
+    definition of $\Gamma^{\mathrm{tail}}_{K,L}$, apply the three-factor
+    trace cycle $\tr(A^\tau(X A^u))=\tr(A^u(A^\tau X))$, reassociate
+    $\tr(A^u(A^\tau X))=\tr((A^u A^\tau)X)$, factor $A^u A^\tau=A^{u,\tau}$
+    by multiplicativity of word evaluation (Lemma~\ref{lem:eval_word_append}),
+    and identify the result with $\Gamma_{K+L}(X)(u,\tau)=\tr(A^{u,\tau}X)$.
 \end{proof}
 
 \begin{theorem}[Tail boundary map range]\label{thm:tail_boundary_map_range_eq}
@@ -158,7 +158,7 @@ norm estimate is derived here.
 
 \begin{proof}
     \leanok
-    \uses{def:tail_restrict_parent, def:ground_space_parent}
+    \uses{thm:tail_restrict_tail_boundary_map, def:tail_restrict_parent, def:ground_space_parent}
     For the forward inclusion, if $\psi=\Gamma^{\mathrm{tail}}_{K,L}(Y)$ then
     $R^{\mathrm{tail}}_u\psi=\Gamma_L(Y_u)$ for every prefix $u$, so the suffix
     restriction lies in $G_L(A)$.
@@ -170,7 +170,7 @@ norm estimate is derived here.
     so $\psi$ lies in the range.
 \end{proof}
 
-\begin{lemma}[Left boundary map on a prefix--suffix pair]\label{lem:left_boundary_map_append}
+\begin{theorem}[Left boundary map on a prefix--suffix pair]\label{thm:left_boundary_map_append}
     \lean{MPSTensor.leftBoundaryMap_append}
     \leanok
     \uses{def:left_boundary_map, def:ground_space_map}
@@ -179,7 +179,7 @@ norm estimate is derived here.
         \Gamma^{\mathrm{left}}_{K,L}(Z)(u,\tau)
         &=\Gamma_K(Z_\tau)(u).
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -189,22 +189,22 @@ norm estimate is derived here.
     $\Gamma_K(Z_\tau)(u)=\tr(A^u Z_\tau)$.
 \end{proof}
 
-\begin{lemma}[Prefix restriction of the left boundary map]\label{lem:prefix_restrict_left_boundary_map}
+\begin{theorem}[Prefix restriction of the left boundary map]\label{thm:prefix_restrict_left_boundary_map}
     \lean{MPSTensor.prefixRestrictₗ_leftBoundaryMap}
     \leanok
-    \uses{lem:left_boundary_map_append, def:prefix_restrict}
+    \uses{thm:left_boundary_map_append, def:prefix_restrict}
     Restricting the left boundary map to the prefix for a fixed suffix
     $\tau\in\Fin d^L$ recovers $\Gamma_K(Z_\tau)$:
     \begin{align}
         P_\tau\bigl(\Gamma^{\mathrm{left}}_{K,L}(Z)\bigr)
         &=\Gamma_K(Z_\tau).
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{lem:left_boundary_map_append}
-    Pointwise application of Lemma~\ref{lem:left_boundary_map_append}:
+    \uses{thm:left_boundary_map_append}
+    Pointwise application of Lemma~\ref{thm:left_boundary_map_append}:
     for each $\sigma$, $(P_\tau\psi)(\sigma)=\psi(\sigma,\tau)$.
 \end{proof}
 
@@ -245,7 +245,7 @@ norm estimate is derived here.
 
 \begin{proof}
     \leanok
-    \uses{def:prefix_restrict, def:ground_space_parent}
+    \uses{thm:prefix_restrict_left_boundary_map, def:prefix_restrict, def:ground_space_parent}
     The proof is symmetric to Theorem~\ref{thm:tail_boundary_map_range_eq}.
     If $\psi=\Gamma^{\mathrm{left}}_{K,L}(Z)$ then
     $P_\tau\psi=\Gamma_K(Z_\tau)$, so the prefix restriction lies in $G_K(A)$.
@@ -281,7 +281,7 @@ norm estimate is derived here.
     inverse canonical $\ell^2$ isomorphism
     identifies it with the open-chain tail ground submodule:
     \begin{align}
-        \iota_{K+L}^{-1}\bigl(\range(\Gamma^{\mathrm{tail}}_{K,L})\bigr)
+        \iota_{K+L}\bigl(\range(\Gamma^{\mathrm{tail}}_{K,L})\bigr)
         &=\mathcal V_{K,L}(A).
     \end{align}
     Concretely, a vector $v$ in the $(K+L)$-site Euclidean space belongs to
@@ -309,7 +309,7 @@ norm estimate is derived here.
     $\ell^2$ isomorphism identifies
     it with the open-chain left ground submodule:
     \begin{align}
-        \iota_{K+1}^{-1}\bigl(\range(\Gamma^{\mathrm{left}}_{K,1})\bigr)
+        \iota_{K+1}\bigl(\range(\Gamma^{\mathrm{left}}_{K,1})\bigr)
         &=\mathcal U_K(A).
     \end{align}
     Concretely, a vector $v$ in the $(K+1)$-site Euclidean space belongs to

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -34,9 +34,10 @@ norm estimate is derived here.
     \leanok
     \uses{lem:eval_word_append}
     Expand $\Gamma_{K+L}(X)(\sigma,\tau)=\tr(A^{\sigma,\tau}X)$,
-    factor $A^{\sigma,\tau}=A^\sigma A^\tau$, and use cyclicity of the trace
-    to move $A^\sigma$ to the front:
-    $\tr(A^\sigma(A^\tau X))=\Gamma_K(A^\tau X)(\sigma)$.
+    factor $A^{\sigma,\tau}=A^\sigma A^\tau$ by
+    Lemma~\ref{lem:eval_word_append}, and reassociate:
+    $\tr((A^\sigma A^\tau)X)=\tr(A^\sigma(A^\tau X))
+    =\Gamma_K(A^\tau X)(\sigma)$.
 \end{proof}
 
 \begin{definition}[Tail boundary map]\label{def:tail_boundary_map}
@@ -78,6 +79,45 @@ norm estimate is derived here.
     $\tau\colon\Fin L\to\Fin d$ is the suffix.
     When $Z_\tau=A^\tau X$ the output equals the standard $\Gamma_{K+L}(X)$.
 \end{definition}
+
+\begin{lemma}[Tail boundary map on a prefix--suffix pair]\label{lem:tail_boundary_map_append}
+    \lean{MPSTensor.tailBoundaryMap_append}
+    \leanok
+    \uses{def:tail_boundary_map, def:ground_space_map}
+    For every prefix $u\colon\Fin K\to\Fin d$ and suffix $\tau\colon\Fin L\to\Fin d$,
+    \begin{align}
+        \Gamma^{\mathrm{tail}}_{K,L}(Y)(u,\tau)
+        &=\Gamma_L(Y_u)(\tau).
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Unfold the definition of $\Gamma^{\mathrm{tail}}_{K,L}$ on the pair
+    $(u,\tau)=\Fin.\!append\;u\;\tau$, use the decomposition
+    $(\Fin.\!append\;u\;\tau)\circ\Fin.\!natAdd\;K=\tau$ and
+    $(\Fin.\!append\;u\;\tau)\circ\Fin.\!castAdd\;L=u$, and apply
+    $\Gamma_L(Y_u)(\tau)=\tr(A^\tau Y_u)$.
+\end{proof}
+
+\begin{lemma}[Suffix restriction of the tail boundary map]\label{lem:tail_restrict_tail_boundary_map}
+    \lean{MPSTensor.tailRestrictₗ_tailBoundaryMap}
+    \leanok
+    \uses{lem:tail_boundary_map_append, def:tail_restrict_parent}
+    Restricting the tail boundary map to the suffix for a fixed prefix
+    $u\in\Fin d^K$ recovers $\Gamma_L(Y_u)$:
+    \begin{align}
+        R^{\mathrm{tail}}_u\bigl(\Gamma^{\mathrm{tail}}_{K,L}(Y)\bigr)
+        &=\Gamma_L(Y_u).
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:tail_boundary_map_append}
+    This is Lemma~\ref{lem:tail_boundary_map_append} applied pointwise:
+    for each $\tau$, $(R^{\mathrm{tail}}_u\psi)(\tau)=\psi(u,\tau)$.
+\end{proof}
 
 \begin{theorem}[Tail boundary map factorization]\label{thm:tail_boundary_map_factorization}
     \lean{MPSTensor.tailBoundaryMap_factorization}
@@ -130,6 +170,44 @@ norm estimate is derived here.
     so $\psi$ lies in the range.
 \end{proof}
 
+\begin{lemma}[Left boundary map on a prefix--suffix pair]\label{lem:left_boundary_map_append}
+    \lean{MPSTensor.leftBoundaryMap_append}
+    \leanok
+    \uses{def:left_boundary_map, def:ground_space_map}
+    For every prefix $u\colon\Fin K\to\Fin d$ and suffix $\tau\colon\Fin L\to\Fin d$,
+    \begin{align}
+        \Gamma^{\mathrm{left}}_{K,L}(Z)(u,\tau)
+        &=\Gamma_K(Z_\tau)(u).
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Unfold the definition of $\Gamma^{\mathrm{left}}_{K,L}$ on the pair
+    $(u,\tau)$, use $(\Fin.\!append\;u\;\tau)\circ\Fin.\!castAdd\;L=u$ and
+    $(\Fin.\!append\;u\;\tau)\circ\Fin.\!natAdd\;K=\tau$, and apply
+    $\Gamma_K(Z_\tau)(u)=\tr(A^u Z_\tau)$.
+\end{proof}
+
+\begin{lemma}[Prefix restriction of the left boundary map]\label{lem:prefix_restrict_left_boundary_map}
+    \lean{MPSTensor.prefixRestrictₗ_leftBoundaryMap}
+    \leanok
+    \uses{lem:left_boundary_map_append, def:prefix_restrict}
+    Restricting the left boundary map to the prefix for a fixed suffix
+    $\tau\in\Fin d^L$ recovers $\Gamma_K(Z_\tau)$:
+    \begin{align}
+        P_\tau\bigl(\Gamma^{\mathrm{left}}_{K,L}(Z)\bigr)
+        &=\Gamma_K(Z_\tau).
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:left_boundary_map_append}
+    Pointwise application of Lemma~\ref{lem:left_boundary_map_append}:
+    for each $\sigma$, $(P_\tau\psi)(\sigma)=\psi(\sigma,\tau)$.
+\end{proof}
+
 \begin{theorem}[Left boundary map factorization]\label{thm:left_boundary_map_factorization}
     \lean{MPSTensor.leftBoundaryMap_factorization}
     \leanok
@@ -175,6 +253,24 @@ norm estimate is derived here.
     $Z_\tau$ with $\Gamma_K(Z_\tau)=P_\tau\psi$; then
     $\Gamma^{\mathrm{left}}_{K,L}(Z)(u,\tau)=\tr(A^u Z_\tau)
     =\Gamma_K(Z_\tau)(u)=(P_\tau\psi)(u)=\psi(u,\tau)$.
+\end{proof}
+
+\begin{lemma}[Prefix restriction at $L=1$]\label{lem:prefix_restrict_one_eq_restrict_last}
+    \lean{MPSTensor.prefixRestrictₗ_one_eq_restrictLast}
+    \leanok
+    \uses{def:prefix_restrict, def:restrict_last}
+    For $L=1$, the prefix restriction $P_\tau$ coincides with the last-site
+    restriction: $P_\tau\psi=R^{\mathrm{last}}(\psi,\tau(0))$ for every
+    $\tau\colon\Fin 1\to\Fin d$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Unfolding both sides: for $\sigma\in\Fin d^K$,
+    $(P_\tau\psi)(\sigma)=\psi(\sigma,\tau)$ while
+    $R^{\mathrm{last}}(\psi,j)(\sigma)=\psi(\sigma_1,\dots,\sigma_K,j)$ with
+    $j=\tau(0)$.  These are equal because $\Fin.\!append\;\sigma\;\tau$ puts
+    $\tau$ after $\sigma$, matching the $\Fin.\!snoc$ pattern of $R^{\mathrm{last}}$.
 \end{proof}
 
 \begin{theorem}[Tail boundary map range: Euclidean-space transport]\label{thm:tail_boundary_map_range_es_transport}
@@ -224,15 +320,15 @@ norm estimate is derived here.
 
 \begin{proof}
     \leanok
-    \uses{thm:left_boundary_map_range_eq, def:prefix_restrict, def:restrict_last}
+    \uses{thm:left_boundary_map_range_eq, lem:prefix_restrict_one_eq_restrict_last, def:restrict_last}
     By Theorem~\ref{thm:left_boundary_map_range_eq} with $L=1$, the range equals
     the intersection over suffixes $\tau\colon\Fin 1\to\Fin d$ of the comaps
     $P_\tau^{-1}(G_K(A))$.  For $L=1$, each suffix $\tau$ is determined by a
-    single index $j\in\Fin d$, and the prefix restriction $P_\tau$ reduces to
-    $R^\mathrm{last}_j$, the last-site restriction of
-    Definition~\ref{def:restrict_last}
-    (Lemma~\ref{lem:prefix_restrict_ground_space_map}).  Transporting the
-    resulting intersection through the canonical $\ell^2$ identification and
+    single index $j\in\Fin d$, and Lemma~\ref{lem:prefix_restrict_one_eq_restrict_last}
+    identifies $P_\tau$ with $R^{\mathrm{last}}(\cdot,j)$, the last-site restriction of
+    Definition~\ref{def:restrict_last}.  Transporting the
+    resulting intersection $\bigcap_{j\in\Fin d}(R^{\mathrm{last}}(\cdot,j))^{-1}(G_K(A))$
+    through the canonical $\ell^2$ identification and
     unfolding Definition~\ref{def:open_chain_ground_subspaces_es} gives
     $\mathcal U_K(A)$.
 \end{proof}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -592,17 +592,35 @@ range with the open-chain tail subspace \(V\), while specializing the left
 transport theorem to \((K+L_0, 1)\) identifies its range with the open-chain
 left subspace \(U\), both in the common ambient
 \(\mathcal H_{K+L_0+1}\); see Section~\ref{sec:open_chain_projector_geometry}.
-The remaining task is to bound the defect
+The remaining task is to bound the projector defect
 \begin{align}
-  \|P_V P_U-P_{U\cap V}\|
+    \bigl\|
+        \mathcal P^{\mathrm{ES}}_{\mathcal V_{K,L_0+1}(A)}
+        \mathcal P^{\mathrm{ES}}_{\mathcal U_{K+L_0}(A)}
+      - \mathcal P^{\mathrm{ES}}_{\mathcal
+        G_{K+L_0+1}^{\mathrm{ES}}(A)}
+    \bigr\|
 \end{align}
-from the Gram/transfer identities, the word-factorization, and
-inverse-Gram norm control.  The present formal development does not yet
+in the common ambient \(\mathcal H_{K+L_0+1}\) (Nachtergaele C3,
+arXiv:cond-mat/9410110, eq.\ (2.4)).  Here
+\(\mathcal U_{K+L_0}(A)\) and \(\mathcal V_{K,L_0+1}(A)\) are the
+left and tail ground subspaces defined earlier, their intersection equals
+\(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\) under block injectivity,
+and \(\mathcal P^{\mathrm{ES}}\) denotes the orthogonal projector in
+the \(\ell^2\) Hilbert-space realization.
+
+The two ranges are transported into this common ambient by
+\leanid{MPSTensor.tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES}
+(specialized to \((K, L_0+1)\)) and
+\leanid{MPSTensor.leftBoundaryMap_range_map_symm_eq_openChainLeftGroundSpaceES}
+(specialized to \((K+L_0, 1)\)).
+
+The present formal development does not yet
 bound \(\|1-\mathcal K_L\|\) (the deviation of the Gram operator from the
 correctly normalized limiting Gram) by the transfer-mixing rate, so the
-inverse-Gram estimate cannot yet be instantiated; the bounds on
-\(P_VP_U-P_{U\cap V}\) are therefore conditional on both the transfer
-spectral estimate and the Gram-deviation control.  The development does not
+inverse-Gram estimate cannot yet be instantiated; the bound on the displayed
+projector defect is therefore conditional on both the transfer spectral
+estimate and the Gram-deviation control.  The development does not
 prove the contraction
 \begin{align}
   c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -584,14 +584,18 @@ steps are now completed:
     and word-factorization identities
     (\leanid{MPSTensor.tailBoundaryMap_factorization},
      \leanid{MPSTensor.leftBoundaryMap_factorization}).
-    These place the overlapping ground spaces as ranges of boundary maps on the
-    same ambient \(\mathcal H_{K+L}\).
+    These give exact range models in the physical space
+    \(\mathcal H_{K+L}\); the C3 specializations are stated next.
 \end{itemize}
-Specializing the tail transport theorem to \((K, L_0+1)\) identifies its
-range with the open-chain tail subspace \(V\), while specializing the left
-transport theorem to \((K+L_0, 1)\) identifies its range with the open-chain
-left subspace \(U\), both in the common ambient
-\(\mathcal H_{K+L_0+1}\); see Section~\ref{sec:open_chain_projector_geometry}.
+Fix \(K,L_0\in\mathbb N\) and let
+\(\mathcal H_{K+L_0+1}\) be the \((K+L_0+1)\)-site Euclidean space
+\(\ell^2(\Fin d^{K+L_0+1})\).  Specializing the tail transport theorem to
+\((K,L_0+1)\) identifies its range with the open-chain tail subspace
+\(\mathcal V_{K,L_0+1}(A)\), while specializing the left transport theorem to
+\((K+L_0,1)\) (the only length at which the left boundary map matches the
+Nachtergaele C3 left-window convention) identifies its range with the
+open-chain left subspace \(\mathcal U_{K+L_0}(A)\), both in the common ambient
+\(\mathcal H_{K+L_0+1}\).
 The remaining task is to bound the projector defect
 \begin{align}
     \bigl\|
@@ -604,8 +608,11 @@ The remaining task is to bound the projector defect
 in the common ambient \(\mathcal H_{K+L_0+1}\) (Nachtergaele C3,
 arXiv:cond-mat/9410110, eq.\ (2.4)).  Here
 \(\mathcal U_{K+L_0}(A)\) and \(\mathcal V_{K,L_0+1}(A)\) are the
-left and tail ground subspaces defined earlier, their intersection equals
-\(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\) under block injectivity,
+left and tail ground subspaces of Definition~4.2
+(\leanid{MPSTensor.openChainLeftGroundSpaceES} and
+\leanid{MPSTensor.openChainTailGroundSpaceES}), their intersection equals
+\(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\) under block injectivity
+(\leanid{MPSTensor.openChainLeft_inf_tailGroundSpaceES}),
 and \(\mathcal P^{\mathrm{ES}}\) denotes the orthogonal projector in
 the \(\ell^2\) Hilbert-space realization.
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -601,7 +601,7 @@ The remaining task is to bound the projector defect
     \bigl\|
         P^{\mathrm{tail}}_{K,L_0+1}(A)\,
         P^{\mathrm{left}}_{K+L_0}(A)
-      - P^{\mathrm{full}}_{K+L_0+1}(A)
+      - P_{\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)}
     \bigr\|
 \end{align}
 in the common ambient \(\mathcal H_{K+L_0+1}\) (Nachtergaele C3,
@@ -613,11 +613,11 @@ left and tail ground subspaces of Definition~4.2
 \(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\) under block injectivity
 with \(D\ge 1\) and \(L_0>0\)
 (\leanid{MPSTensor.openChainLeft_inf_tailGroundSpaceES}),
-and \(P^{\mathrm{left}}_{K+L_0}(A)\), \(P^{\mathrm{tail}}_{K,L_0+1}(A)\),
-and \(P^{\mathrm{full}}_{K+L_0+1}(A)\) denote the orthogonal projectors onto
-\(\mathcal U_{K+L_0}(A)\), \(\mathcal V_{K,L_0+1}(A)\), and
-\(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\), respectively (the canonical
-Chapter~13 notation of Definition~4.2).
+The symbols \(P^{\mathrm{left}}_{K+L_0}(A)\) and
+\(P^{\mathrm{tail}}_{K,L_0+1}(A)\) denote the orthogonal projectors onto
+\(\mathcal U_{K+L_0}(A)\) and \(\mathcal V_{K,L_0+1}(A)\), respectively,
+as in Definition~4.2, while \(P_{\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)}\)
+denotes the orthogonal projector onto the full ground subspace.
 
 The two ranges are transported into this common ambient by
 \leanid{MPSTensor.tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -457,7 +457,7 @@ explicit than the review paragraph: the exact constants and the cyclic-window
 blocking convention still have to be compared with the FNW, Nachtergaele, and
 Kastoryano--Lucia estimates.
 
-\section{Inverse-Gram infrastructure and the remaining FNW contraction}
+\section{Inverse-Gram reduction and the remaining FNW contraction}
 
 For $n\ge1$, write $[n]:=\{0,\ldots,n-1\}$.  Fix an MPS tensor
 $A=\{A^s\}_{s\in[d]}$ with $A^s\in\mathbb C^{D\times D}$.  For
@@ -567,15 +567,43 @@ $|\mu|<\lambda$ for every non-unit eigenvalue $\mu$ of the relevant transfer
 operator.  Let $c\ge0$ be its prefactor; the source allows $c=k^2$ when $k$ is
 the auxiliary, or bond, dimension.  Choose $l$ so that $c\lambda^l<1$.  These
 are parameters of the quoted FNW estimate, not bounds derived by the present
-formal infrastructure.
+formal development.
 
 What remains open is the source-specific comparison of these exact inverse-Gram
-range projectors on the two overlapping physical windows.  The next formal
-steps are to package the Choi reshuffling as an operator identity with a verified
-norm bound, construct the spectator-indexed boundary maps for the left and tail
-windows, and derive their common-ambient contraction directly from the MPS word
-factorization.  In particular, the present infrastructure does not prove the
-contraction
+range projectors on the two overlapping physical windows.  The first two formal
+steps are now completed:
+\begin{itemize}
+  \item The Choi reshuffling is packaged as the exact operator identity
+    \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} (module
+    \path{TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean}).
+  \item The spectator-indexed boundary maps for the tail and left windows are
+    defined in \path{TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean},
+    together with their exact range equalities
+    (\leanid{MPSTensor.tailBoundaryMap_range_eq},
+     \leanid{MPSTensor.leftBoundaryMap_range_eq})
+    and word-factorization identities
+    (\leanid{MPSTensor.tailBoundaryMap_factorization},
+     \leanid{MPSTensor.leftBoundaryMap_factorization}).
+    These place the overlapping ground spaces as ranges of boundary maps on the
+    same ambient \(\mathcal H_{K+L}\).
+\end{itemize}
+Specializing the tail transport theorem to \((K, L_0+1)\) identifies its
+range with the open-chain tail subspace \(V\), while specializing the left
+transport theorem to \((K+L_0, 1)\) identifies its range with the open-chain
+left subspace \(U\), both in the common ambient
+\(\mathcal H_{K+L_0+1}\); see Section~\ref{sec:open_chain_projector_geometry}.
+The remaining task is to bound the defect
+\begin{align}
+  \|P_V P_U-P_{U\cap V}\|
+\end{align}
+from the Gram/transfer identities, the word-factorization, and
+inverse-Gram norm control.  The present formal development does not yet
+bound \(\|1-\mathcal K_L\|\) (the deviation of the Gram operator from the
+correctly normalized limiting Gram) by the transfer-mixing rate, so the
+inverse-Gram estimate cannot yet be instantiated; the bounds on
+\(P_VP_U-P_{U\cap V}\) are therefore conditional on both the transfer
+spectral estimate and the Gram-deviation control.  The development does not
+prove the contraction
 \begin{align}
   c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},
   \qquad c\lambda^l<1,
@@ -583,9 +611,10 @@ contraction
 which appears as equation \path{boundAm} in
 \cite[Section~6]{Nachtergaele1996Spectral}; it does not identify the physical
 projector with a transfer fixed-point projector, and it does not establish the
-final numerical overlap or spectral-gap bound.  That load-bearing
-overlapping-window estimate remains the MPS-specific task tracked in issue
-\#5752.
+final numerical overlap or spectral-gap bound.  That overlapping-window
+estimate remains open; both boundary maps are unweighted (Frobenius) and the
+Gram identities are normalization-neutral, so the contraction estimate may
+require a second fixed-point metric or weighted boundary coordinates.
 
 \textbf{Verdict:} open gap.
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -599,10 +599,9 @@ open-chain left subspace \(\mathcal U_{K+L_0}(A)\), both in the common ambient
 The remaining task is to bound the projector defect
 \begin{align}
     \bigl\|
-        \mathcal P^{\mathrm{ES}}_{\mathcal V_{K,L_0+1}(A)}
-        \mathcal P^{\mathrm{ES}}_{\mathcal U_{K+L_0}(A)}
-      - \mathcal P^{\mathrm{ES}}_{\mathcal
-        G_{K+L_0+1}^{\mathrm{ES}}(A)}
+        P^{\mathrm{tail}}_{K,L_0+1}(A)\,
+        P^{\mathrm{left}}_{K+L_0}(A)
+      - P^{\mathrm{full}}_{K+L_0+1}(A)
     \bigr\|
 \end{align}
 in the common ambient \(\mathcal H_{K+L_0+1}\) (Nachtergaele C3,
@@ -613,8 +612,11 @@ left and tail ground subspaces of Definition~4.2
 \leanid{MPSTensor.openChainTailGroundSpaceES}), their intersection equals
 \(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\) under block injectivity
 (\leanid{MPSTensor.openChainLeft_inf_tailGroundSpaceES}),
-and \(\mathcal P^{\mathrm{ES}}\) denotes the orthogonal projector in
-the \(\ell^2\) Hilbert-space realization.
+and \(P^{\mathrm{left}}_{K+L_0}(A)\), \(P^{\mathrm{tail}}_{K,L_0+1}(A)\),
+and \(P^{\mathrm{full}}_{K+L_0+1}(A)\) denote the orthogonal projectors onto
+\(\mathcal U_{K+L_0}(A)\), \(\mathcal V_{K,L_0+1}(A)\), and
+\(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\), respectively (the canonical
+Chapter~13 notation of Definition~4.2).
 
 The two ranges are transported into this common ambient by
 \leanid{MPSTensor.tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -611,6 +611,7 @@ left and tail ground subspaces of Definition~4.2
 (\leanid{MPSTensor.openChainLeftGroundSpaceES} and
 \leanid{MPSTensor.openChainTailGroundSpaceES}), their intersection equals
 \(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\) under block injectivity
+with \(D\ge 1\) and \(L_0>0\)
 (\leanid{MPSTensor.openChainLeft_inf_tailGroundSpaceES}),
 and \(P^{\mathrm{left}}_{K+L_0}(A)\), \(P^{\mathrm{tail}}_{K,L_0+1}(A)\),
 and \(P^{\mathrm{full}}_{K+L_0+1}(A)\) denote the orthogonal projectors onto


### PR DESCRIPTION
Closes #5848.\n\n## Summary\n- define prefix restriction and spectator-indexed tail/left boundary maps in the common physical ambient space\n- prove exact restriction, range, and MPS word-factorization identities\n- synchronize the ParentHamiltonian aggregator, Chapter 13 blueprint, and martingale paper-gap note\n\n## Scope\nThis PR does not claim the FNW projector contraction. The maps use unweighted Frobenius boundary coordinates; the later norm estimate may require a weighted fixed-point metric.\n\n## Verification\n- `lake env lean TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean`\n- `python3 scripts/blueprint_lean_sync.py --ci`\n- `git diff --check origin/main...HEAD`\n\nAddresses #5752 and #5455.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics additions (definitions and exact lemmas) with documentation sync; no runtime, auth, or data-path changes. Residual risk is proof-maintenance complexity in a large Lean file, not production impact.
> 
> **Overview**
> Adds **spectator-indexed tail and left boundary maps** that embed prefix- or suffix-indexed virtual data into the same \((K+L)\)-site physical Hilbert space, plus **`prefixRestrictₗ`** as the left analogue of tail restriction.
> 
> The new Lean module proves exact **restriction**, **range**, **MPS word-factorization**, and **\(\ell^2\) transport** identities linking those ranges to **`openChainTailGroundSpaceES`** and **`openChainLeftGroundSpaceES`** (C3 left window at \(L=1\)). **`ParentHamiltonian.lean`** imports the module; Chapter 13 blueprint and **`cpgsv21_martingale_overlap.tex`** are aligned and note that the **FNW projector-defect / Gram contraction** is still open (unweighted Frobenius coordinates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea61570519cb01319879b77edbb8c809b6427c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->