### PR TITLE
refactor(Algebra): expose the Gram reshuffle matrix

### DIFF
--- a/TNLean/Algebra/RectangularChoi.lean
+++ b/TNLean/Algebra/RectangularChoi.lean
@@ -24,8 +24,11 @@ The argument is independent of positivity and channel normalization.
 
 - `Matrix.linearMapMatrix`: the matrix of a linear map in the matrix-unit bases
 - `Matrix.rectangularChoi`: the unnormalized rectangular Choi matrix
-- `Matrix.gramReshuffleMatrix`: the matrix with entries \(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\); its `toEuclideanCLM` image is `gramReshuffle`
-- `Matrix.gramReshuffle`: the Euclidean CLM of the reshuffling \(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\)
+- `Matrix.gramReshuffleMatrix`: the matrix with entries
+    \(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\);
+    its `toEuclideanCLM` image is `gramReshuffle`
+- `Matrix.gramReshuffle`: the Euclidean CLM of the reshuffling
+    \(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\)
 - `Matrix.IsHilbertSchmidtContraction`: contraction for the Hilbert--Schmidt norm
 
 ## Main results
@@ -116,19 +119,18 @@ theorem gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq
     ∑ p : (α × α) × (α × α), ‖gramReshuffleMatrix Φ p.1 p.2‖ ^ 2 =
     ∑ p : (α × α) × (α × α), ‖rectangularChoi Φ p.1 p.2‖ ^ 2 := by
   classical
-  let e : ((α × α) × (α × α)) ≃ ((α × α) × (α × α)) := {
-    toFun p := ((p.2.2, p.2.1), (p.1.2, p.1.1))
-    invFun p := ((p.2.2, p.2.1), (p.1.2, p.1.1))
-    left_inv p := by rfl
-    right_inv p := by rfl
-  }
+  let e : ((α × α) × (α × α)) ≃ ((α × α) × (α × α)) :=
+    (Equiv.prodComm (α × α) (α × α)).trans
+      ((Equiv.prodComm α α).prodCongr (Equiv.prodComm α α))
+  have he (p : (α × α) × (α × α)) : e p = ((p.2.2, p.2.1), (p.1.2, p.1.1)) := by
+    simp [e, Equiv.trans_apply, Equiv.prodComm_apply, Prod.swap]
   calc
     ∑ p : (α × α) × (α × α), ‖gramReshuffleMatrix Φ p.1 p.2‖ ^ 2 =
         ∑ p : (α × α) × (α × α),
           ‖rectangularChoi Φ (p.2.2, p.2.1) (p.1.2, p.1.1)‖ ^ 2 :=
       by simp [gramReshuffleMatrix]
     _ = ∑ p : (α × α) × (α × α), ‖rectangularChoi Φ p.1 p.2‖ ^ 2 :=
-      Fintype.sum_equiv e _ _ fun _ ↦ rfl
+      Fintype.sum_equiv e _ _ (fun p ↦ by simp [he p])
 
 /-- Reshaping a coefficient matrix into the rectangular Choi matrix preserves its
 squared Frobenius norm. -/

--- a/TNLean/Algebra/RectangularChoi.lean
+++ b/TNLean/Algebra/RectangularChoi.lean
@@ -24,8 +24,8 @@ The argument is independent of positivity and channel normalization.
 
 - `Matrix.linearMapMatrix`: the matrix of a linear map in the matrix-unit bases
 - `Matrix.rectangularChoi`: the unnormalized rectangular Choi matrix
-- `Matrix.gramReshuffleMatrix`: the matrix whose \(((b,a),(e,c))\) entry is `rectangularChoi Φ (c,e) (a,b)`
-- `Matrix.gramReshuffle`: the Euclidean operator `toEuclideanCLM (gramReshuffleMatrix Φ)`
+- `Matrix.gramReshuffleMatrix`: the matrix with entries \(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\); its `toEuclideanCLM` image is `gramReshuffle`
+- `Matrix.gramReshuffle`: the Euclidean CLM of the reshuffling \(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\)
 - `Matrix.IsHilbertSchmidtContraction`: contraction for the Hilbert--Schmidt norm
 
 ## Main results
@@ -78,15 +78,16 @@ theorem rectangularChoi_apply
     rectangularChoi L (i, a) (j, b) = L (single i j 1) a b := by
   rw [rectangularChoi, linearMapMatrix_apply]
 
-/-- The matrix whose \((b,a),(e,c)\) entry is the rectangular Choi entry
-\(J(\Phi)_{(c,e),(a,b)}\).  Its `toEuclideanCLM` image is `gramReshuffle`. -/
+/-- The algebraic matrix of the reshuffling \(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\).
+Its `toEuclideanCLM` image is `gramReshuffle`. -/
 noncomputable def gramReshuffleMatrix
     (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
     Matrix (α × α) (α × α) ℂ :=
   fun (b, a) (e, c) ↦ rectangularChoi Φ (c, e) (a, b)
 
-/-- The linear operator obtained by applying `Matrix.toEuclideanCLM`
-to `gramReshuffleMatrix`. -/
+/-- The Euclidean operator obtained by reshuffling Choi entries:
+\(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\).
+It is `Matrix.toEuclideanCLM` of `gramReshuffleMatrix`. -/
 noncomputable def gramReshuffle
     (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
     EuclideanSpace ℂ (α × α) →L[ℂ] EuclideanSpace ℂ (α × α) :=

--- a/TNLean/Algebra/RectangularChoi.lean
+++ b/TNLean/Algebra/RectangularChoi.lean
@@ -24,12 +24,14 @@ The argument is independent of positivity and channel normalization.
 
 - `Matrix.linearMapMatrix`: the matrix of a linear map in the matrix-unit bases
 - `Matrix.rectangularChoi`: the unnormalized rectangular Choi matrix
-- `Matrix.gramReshuffle`: the Euclidean operator obtained by reshuffling Choi entries
+- `Matrix.gramReshuffleMatrix`: the matrix whose \(((b,a),(e,c))\) entry is `rectangularChoi Φ (c,e) (a,b)`
+- `Matrix.gramReshuffle`: the Euclidean operator `toEuclideanCLM (gramReshuffleMatrix Φ)`
 - `Matrix.IsHilbertSchmidtContraction`: contraction for the Hilbert--Schmidt norm
 
 ## Main results
 
 - `Matrix.inner_single_gramReshuffle_single`
+- `Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq`
 - `Matrix.rectangularChoi_frobenius_parseval`
 - `Matrix.rectangularChoi_frobenius_parseval_matrix_units`
 - `Matrix.rectangularChoi_frobenius_sq_le_finrank_range`
@@ -76,13 +78,19 @@ theorem rectangularChoi_apply
     rectangularChoi L (i, a) (j, b) = L (single i j 1) a b := by
   rw [rectangularChoi, linearMapMatrix_apply]
 
-/-- The linear operator with matrix entries obtained from the Choi matrix by
-\(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\). -/
+/-- The matrix whose \((b,a),(e,c)\) entry is the rectangular Choi entry
+\(J(\Phi)_{(c,e),(a,b)}\).  Its `toEuclideanCLM` image is `gramReshuffle`. -/
+noncomputable def gramReshuffleMatrix
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    Matrix (α × α) (α × α) ℂ :=
+  fun (b, a) (e, c) ↦ rectangularChoi Φ (c, e) (a, b)
+
+/-- The linear operator obtained by applying `Matrix.toEuclideanCLM`
+to `gramReshuffleMatrix`. -/
 noncomputable def gramReshuffle
     (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
     EuclideanSpace ℂ (α × α) →L[ℂ] EuclideanSpace ℂ (α × α) :=
-  Matrix.toEuclideanCLM (n := α × α) (𝕜 := ℂ) fun (b, a) (e, c) ↦
-    rectangularChoi Φ (c, e) (a, b)
+  (Matrix.toEuclideanCLM (n := α × α) (𝕜 := ℂ)) (gramReshuffleMatrix Φ)
 
 /-- The matrix-unit coefficients of the reshuffled Choi operator are
 \(J(\Phi)_{(c,e),(a,b)}\). -/
@@ -93,11 +101,33 @@ theorem inner_single_gramReshuffle_single
       (gramReshuffle Φ (EuclideanSpace.single (e, c) 1)) =
       rectangularChoi Φ (c, e) (a, b) := by
   classical
+  rw [gramReshuffle]
   change inner ℂ (WithLp.toLp 2 (Pi.single (b, a) 1))
-    (Matrix.toEuclideanCLM (n := α × α) (𝕜 := ℂ) _
+    ((Matrix.toEuclideanCLM (n := α × α) (𝕜 := ℂ)) (gramReshuffleMatrix Φ)
       (WithLp.toLp 2 (Pi.single (e, c) 1))) = _
   rw [Matrix.toEuclideanCLM_toLp, EuclideanSpace.inner_toLp_toLp]
-  simp [Matrix.mulVec_single]
+  simp [gramReshuffleMatrix, Matrix.mulVec_single]
+
+/-- The sum of squared entry norms of `gramReshuffleMatrix` equals that of
+`rectangularChoi`; the two matrices differ only by a reshuffling of indices. -/
+theorem gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    ∑ p : (α × α) × (α × α), ‖gramReshuffleMatrix Φ p.1 p.2‖ ^ 2 =
+    ∑ p : (α × α) × (α × α), ‖rectangularChoi Φ p.1 p.2‖ ^ 2 := by
+  classical
+  let e : ((α × α) × (α × α)) ≃ ((α × α) × (α × α)) := {
+    toFun p := ((p.2.2, p.2.1), (p.1.2, p.1.1))
+    invFun p := ((p.2.2, p.2.1), (p.1.2, p.1.1))
+    left_inv p := by rfl
+    right_inv p := by rfl
+  }
+  calc
+    ∑ p : (α × α) × (α × α), ‖gramReshuffleMatrix Φ p.1 p.2‖ ^ 2 =
+        ∑ p : (α × α) × (α × α),
+          ‖rectangularChoi Φ (p.2.2, p.2.1) (p.1.2, p.1.1)‖ ^ 2 :=
+      by simp [gramReshuffleMatrix]
+    _ = ∑ p : (α × α) × (α × α), ‖rectangularChoi Φ p.1 p.2‖ ^ 2 :=
+      Fintype.sum_equiv e _ _ fun _ ↦ rfl
 
 /-- Reshaping a coefficient matrix into the rectangular Choi matrix preserves its
 squared Frobenius norm. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -313,8 +313,9 @@ orthogonal projector is the canonical representative used here.
     \lean{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq}
     \leanok
     \uses{def:gram_reshuffle}
-    The sum of squared entry norms of $R(\mathcal L)$ equals that of the
-    rectangular Choi matrix:
+    For every complex-linear map $\mathcal L\colon\MN{D}\to\MN{D}$, the sum
+    of squared entry norms of $R(\mathcal L)$ equals that of the rectangular
+    Choi matrix:
     \begin{align}
       \sum_{p:(\Fin{D}\times\Fin{D})\times(\Fin{D}\times\Fin{D})}
       \bigl\|R(\mathcal L)_{p_1,p_2}\bigr\|^2

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -265,16 +265,19 @@ orthogonal projector is the canonical representative used here.
 \begin{definition}[Operator-level Gram reshuffling]
     \label{def:gram_reshuffle}
     \lean{Matrix.gramReshuffle}
+    \lean{Matrix.gramReshuffleMatrix}
     \leanok
     \uses{def:rectangular_choi}
-    For a complex-linear map $\mathcal L\colon\MN{D}\to\MN{D}$, define the
-    operator $\mathscr R(\mathcal L)$ on
-    $\ell^2(\Fin{D}\times\Fin{D})$ by the matrix entries
+    For a complex-linear map $\mathcal L\colon\MN{D}\to\MN{D}$, let
+    $R(\mathcal L)$ be the matrix with entries
     \begin{align}
-      \mathscr R(\mathcal L)_{(b,a),(e,c)}
+      R(\mathcal L)_{(b,a),(e,c)}
       &:=J(\mathcal L)_{(c,e),(a,b)}.
-      \label{eq:gram_reshuffle_entries}
+      \label{eq:gram_reshuffle_matrix_entries}
     \end{align}
+    The operator $\mathscr R(\mathcal L)$ on
+    $\ell^2(\Fin{D}\times\Fin{D})$ is then the Euclidean CLM of this matrix:
+    $\mathscr R(\mathcal L):=\operatorname{toEuclideanCLM}(R(\mathcal L))$.
     Thus the row--column pair $((b,a),(e,c))$ is sent explicitly to the Choi
     row--column pair $((c,e),(a,b))$.
 \end{definition}
@@ -294,7 +297,7 @@ orthogonal projector is the canonical representative used here.
       \label{eq:gram_reshuffle_single}
     \end{align}
     This is the coordinate identity in
-    (\ref{eq:gram_reshuffle_entries}); it is not a Hilbert--Schmidt pairing of
+    (\ref{eq:gram_reshuffle_matrix_entries}); it is not a Hilbert--Schmidt pairing of
     $E_{ab}$ with $\mathcal L(E_{ce})$.
 \end{theorem}
 
@@ -303,6 +306,33 @@ orthogonal projector is the canonical representative used here.
     \uses{def:gram_reshuffle}
     Evaluate the matrix of $\mathscr R(\mathcal L)$ on the two standard basis
     vectors.
+\end{proof}
+
+\begin{theorem}[Entrywise Frobenius invariance of Gram reshuffling]
+    \label{thm:gram_reshuffle_matrix_norm_sq}
+    \lean{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq}
+    \leanok
+    \uses{def:gram_reshuffle}
+    The sum of squared entry norms of $R(\mathcal L)$ equals that of the
+    rectangular Choi matrix:
+    \begin{align}
+      \sum_{p:(\alpha\times\alpha)\times(\alpha\times\alpha)}
+      \bigl\|R(\mathcal L)_{p_1,p_2}\bigr\|^2
+      &=
+      \sum_{p:(\alpha\times\alpha)\times(\alpha\times\alpha)}
+      \bigl\|J(\mathcal L)_{p_1,p_2}\bigr\|^2.
+      \label{eq:gram_reshuffle_matrix_norm_sq}
+    \end{align}
+    The two matrices differ only by a reshuffling of indices; the equality is
+    entrywise Frobenius, not operator norm.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:gram_reshuffle}
+    The map $((b,a),(e,c))\mapsto((c,e),(a,b))$ is a fixed-point-free involution
+    on the product index space.  Reindexing the sum of squared norms by this
+    involution yields the claimed equality.
 \end{proof}
 
 \begin{theorem}[Transfer--Gram Choi reshuffling]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -276,8 +276,8 @@ orthogonal projector is the canonical representative used here.
       \label{eq:gram_reshuffle_matrix_entries}
     \end{align}
     The operator $\mathscr R(\mathcal L)$ on
-    $\ell^2(\Fin{D}\times\Fin{D})$ is then the Euclidean CLM of this matrix:
-    $\mathscr R(\mathcal L):=\operatorname{toEuclideanCLM}(R(\mathcal L))$.
+    $\ell^2(\Fin{D}\times\Fin{D})$ is represented by the matrix $R(\mathcal L)$
+    in the standard orthonormal basis.
     Thus the row--column pair $((b,a),(e,c))$ is sent explicitly to the Choi
     row--column pair $((c,e),(a,b))$.
 \end{definition}
@@ -316,10 +316,10 @@ orthogonal projector is the canonical representative used here.
     The sum of squared entry norms of $R(\mathcal L)$ equals that of the
     rectangular Choi matrix:
     \begin{align}
-      \sum_{p:(\alpha\times\alpha)\times(\alpha\times\alpha)}
+      \sum_{p:(\Fin{D}\times\Fin{D})\times(\Fin{D}\times\Fin{D})}
       \bigl\|R(\mathcal L)_{p_1,p_2}\bigr\|^2
       &=
-      \sum_{p:(\alpha\times\alpha)\times(\alpha\times\alpha)}
+      \sum_{p:(\Fin{D}\times\Fin{D})\times(\Fin{D}\times\Fin{D})}
       \bigl\|J(\mathcal L)_{p_1,p_2}\bigr\|^2.
       \label{eq:gram_reshuffle_matrix_norm_sq}
     \end{align}
@@ -330,7 +330,7 @@ orthogonal projector is the canonical representative used here.
 \begin{proof}
     \leanok
     \uses{def:gram_reshuffle}
-    The map $((b,a),(e,c))\mapsto((c,e),(a,b))$ is a fixed-point-free involution
+    The map $((b,a),(e,c))\mapsto((c,e),(a,b))$ is an involution (bijection)
     on the product index space.  Reindexing the sum of squared norms by this
     involution yields the claimed equality.
 \end{proof}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -510,13 +510,12 @@ Euclidean operator with matrix entries
   \mathscr R(\mathcal L)_{(b,a),(e,c)}
     &:=J(\mathcal L)_{(c,e),(a,b)}.
 \end{align}
-The algebraic matrix $\operatorname{gramReshuffleMatrix}\,\Phi$ with these
-entries is \leanid{Matrix.gramReshuffleMatrix}, so that
-$\mathscr R(\mathcal L)=\operatorname{toEuclideanCLM}(\operatorname{gramReshuffleMatrix}\,\mathcal L)$
-is \leanid{Matrix.gramReshuffle}.  The entrywise Frobenius squared sum is
+The algebraic matrix $R(\mathcal L)$ with these entries is
+\leanid{Matrix.gramReshuffleMatrix}, and the operator
+$\mathscr R(\mathcal L)$ is \leanid{Matrix.gramReshuffle}.  The entrywise Frobenius squared sum is
 invariant under this reshuffling
-(\leanid{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq}),
-though the operator norm is not.
+(\leanid{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq});
+this entrywise identity does not establish an operator-norm comparison.
 \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} upgrades the coordinate
 identity to the exact operator equality
 \begin{align}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -510,7 +510,13 @@ Euclidean operator with matrix entries
   \mathscr R(\mathcal L)_{(b,a),(e,c)}
     &:=J(\mathcal L)_{(c,e),(a,b)}.
 \end{align}
-This is \leanid{Matrix.gramReshuffle}, and
+The algebraic matrix $\operatorname{gramReshuffleMatrix}\,\Phi$ with these
+entries is \leanid{Matrix.gramReshuffleMatrix}, so that
+$\mathscr R(\mathcal L)=\operatorname{toEuclideanCLM}(\operatorname{gramReshuffleMatrix}\,\mathcal L)$
+is \leanid{Matrix.gramReshuffle}.  The entrywise Frobenius squared sum is
+invariant under this reshuffling
+(\leanid{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq}),
+though the operator norm is not.
 \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} upgrades the coordinate
 identity to the exact operator equality
 \begin{align}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 915, 957 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 945, 987 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 945, 987 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 946, 988 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
Closes #5857.\n\n## Summary\n- factor the four-index coefficient matrix as `Matrix.gramReshuffleMatrix`\n- express `Matrix.gramReshuffle` through `Matrix.toEuclideanCLM`\n- prove exact invariance of the sum of squared entry norms under the reshuffling involution\n\n## Scope\nThis is an entrywise Frobenius identity only. It does not claim operator-norm or singular-value invariance and does not establish the FNW prefactor.\n\n## Verification\n- `lake env lean TNLean/Algebra/RectangularChoi.lean`\n- `lake env lean TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean`\n- reader-facing prose and diff checks\n\nAddresses #5752.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor in `RectangularChoi.lean` with documentation alignment; no changes to runtime behavior or security-sensitive paths.
> 
> **Overview**
> Introduces **`Matrix.gramReshuffleMatrix`** as the explicit four-index coefficient matrix for the Choi index reshuffle \(J(\Phi)_{(c,e),(a,b)} \mapsto R(\Phi)_{(b,a),(e,c)}\), and defines **`Matrix.gramReshuffle`** as `toEuclideanCLM` of that matrix instead of baking the entries inline.
> 
> Adds **`gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq`**, showing the sum of squared entry norms matches **`rectangularChoi`** via a bijective reindexing of \(((\alpha\times\alpha)\times(\alpha\times\alpha))\) indices. **`inner_single_gramReshuffle_single`** is updated to route through the new matrix definition.
> 
> Blueprint and gap docs now name \(R(\mathcal L)\) vs \(\mathscr R(\mathcal L)\), link the new Lean symbols, and state explicitly that this is **entrywise Frobenius** invariance—not operator norm or singular-value comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d70694cf857bf240e698b8cd84aeb640091952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->