### PR TITLE
style(MPDO): mark grouped-Gram witnesses implicit-only

### DIFF
--- a/TNLean/MPS/MPDO/CPSVGroupedGramNormalization.lean
+++ b/TNLean/MPS/MPDO/CPSVGroupedGramNormalization.lean
@@ -51,7 +51,7 @@ theorem grouped_sector_gram_eq_pos_smul_one
     {M : MPOTensor d D} (hCanonical : IsCPSVCanonicalForm M.toMPSTensor)
     (hM : IsMPDO M)
     (μ : Fin r → ℂ) (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
-    (hDimPos : ∀ k, 0 < dim k)
+    (_hDimPos : ∀ k, 0 < dim k)
     (hNormal : ∀ k, MPSTensor.IsNormalTensor (blocks k))
     (hdim : ∀ j q, dim ((C).repr j) = dim ((C).enum j q))
     (X : (j : Fin (C).g) → (q : Fin ((C).copies j)) →
@@ -72,7 +72,7 @@ theorem grouped_sector_gram_eq_pos_smul_one
     ∃ ω : ℝ, 0 < ω ∧
       (X j q : Matrix (Fin (dim ((C).enum j q)))
         (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q = (ω : ℂ) • 1 := by
-  letI : NeZero (dim ((C).enum j q)) := ⟨(hDimPos _).ne'⟩
+  letI : NeZero (dim ((C).enum j q)) := ⟨(_hDimPos _).ne'⟩
   let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
     (blocks ((C).repr j))
   have hNormalA : MPSTensor.IsNormal A :=

--- a/TNLean/MPS/MPDO/GroupedGramNormalization.lean
+++ b/TNLean/MPS/MPDO/GroupedGramNormalization.lean
@@ -54,7 +54,7 @@ theorem IsMPDO.grouped_sector_gram_eq_pos_smul_one
     {M : MPOTensor d D} (hM : IsMPDO M)
     (hHorizontal : IsHorizontalCF M)
     (μ : Fin r → ℂ) (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
-    (hDimPos : ∀ k, 0 < dim k)
+    (_hDimPos : ∀ k, 0 < dim k)
     (hNormal : ∀ k, MPSTensor.IsNormalTensor (blocks k))
     (hdim : ∀ j q, dim ((C).repr j) = dim ((C).enum j q))
     (X : (j : Fin (C).g) → (q : Fin ((C).copies j)) →
@@ -75,7 +75,7 @@ theorem IsMPDO.grouped_sector_gram_eq_pos_smul_one
     ∃ ω : ℝ, 0 < ω ∧
       (X j q : Matrix (Fin (dim ((C).enum j q)))
         (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q = (ω : ℂ) • 1 := by
-  letI : NeZero (dim ((C).enum j q)) := ⟨(hDimPos _).ne'⟩
+  letI : NeZero (dim ((C).enum j q)) := ⟨(_hDimPos _).ne'⟩
   let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
     (blocks ((C).repr j))
   have hNormalA : MPSTensor.IsNormal A :=


### PR DESCRIPTION
### Motivation

- The paired grouped-Gram normalization theorems emitted two implicit-use binder warnings in every MPDO full build.
- The dimension-positivity witnesses remain mathematically required, but Lean references them only through proof-local instance construction.

### Description

- Rename the two affected `hDimPos` binders to `_hDimPos` and update their proof-local references.
- Preserve binder types, theorem statements up to binder spelling, proof meaning, CPSV16 citations, and the BNT-refined scope restriction.
- Add no linter suppression and make no unrelated change.

### Testing

- `lake build TNLean.MPS.MPDO.GroupedGramNormalization TNLean.MPS.MPDO.CPSVGroupedGramNormalization`
- Both changed modules build successfully with 0 target-file warnings.
- `git diff --check origin/main...HEAD`

---
Closes #5846
Advances #5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 enumerated the exact warning sites, made the binder-only changes, and ran current-hot-main targeted validation. The maintainer reviewed the complete four-line patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Binder renames only; no proof logic, theorem content, or mathematical meaning changes beyond silencing linter warnings.
> 
> **Overview**
> Renames the dimension-positivity hypothesis `hDimPos` to `_hDimPos` on **`grouped_sector_gram_eq_pos_smul_one`** in `CPSVGroupedGramNormalization.lean` and `GroupedGramNormalization.lean`, and updates the proof-local `NeZero` instance line to use `_hDimPos`.
> 
> The binder type is unchanged; only Lean’s implicit-use naming convention is applied so full MPDO builds no longer emit implicit-use binder warnings on these theorems. **`grouped_sector_exists_unitary_normalization`** and other callers still pass the witness explicitly where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb309a21f90441e5c596977157c26297c582a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->