### PR TITLE
feat(MPS/MPU): transport supplied simple witnesses

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -17,6 +17,7 @@ import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
+import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.ThreeFormSpan
 import TNLean.MPS.MPU.TransferMatrix
 import TNLean.MPS.MPU.TransferStabilization

--- a/TNLean/MPS/MPU/SuppliedFixedWitnesses.lean
+++ b/TNLean/MPS/MPU/SuppliedFixedWitnesses.lean
@@ -84,7 +84,7 @@ and only then substitutes the supplied transfer power.  No uniqueness of
 rank-one witnesses is used.
 
 Source: arXiv:1703.09188, equations `simple1`, `simple2`, and `Erightleft`,
-lines 356--374 and 429--438. -/
+lines 274--280, 356--374, and 429--438. -/
 theorem IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec
     [NeZero d] {W : MPOTensor d D} (hW : IsMPUSimple W)
     (ρ Φ : Fin (D * D) → ℂ) (J : ℕ) (hJ : 0 < J)

--- a/TNLean/MPS/MPU/SuppliedFixedWitnesses.lean
+++ b/TNLean/MPS/MPU/SuppliedFixedWitnesses.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SimpleBlocking
+
+/-!
+# Simple contractions with supplied fixed witnesses
+
+This file transports the existential witnesses of an MPU-simple tensor to the
+separately supplied rank-one projector from a normalized transfer power.
+
+The result follows the insertion argument of arXiv:1703.09188: the
+existential simple witnesses first show that every pair of double-layer letters
+is unchanged by inserting a positive power of the normalized diagonal.  Only
+then is that power replaced by the supplied rank-one matrix.
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+private theorem normalizedDiagonal_eq_smul_sum_diagonal
+    (W : MPOTensor d D) :
+    normalizedDiagonal W = ((d : ℂ)⁻¹) • ∑ q : Fin d, W q q := by
+  classical
+  simp only [normalizedDiagonal, contractPhysical, Matrix.one_apply, ite_smul,
+    one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true]
+
+private theorem simple_letter_mul_normalizedDiagonal_mul_letter
+    [NeZero d] {W : MPOTensor d D} (hW : IsMPUSimple W)
+    (i j k l : Fin d) :
+    doubleLayerTensor W i j * normalizedDiagonal (doubleLayerTensor W) *
+        doubleLayerTensor W k l =
+      doubleLayerTensor W i j * doubleLayerTensor W k l := by
+  classical
+  obtain ⟨a, b, h₁, h₂⟩ := hW
+  let R := Matrix.vecMulVec b a
+  have hsandwich (q : Fin d) :
+      R * doubleLayerTensor W q q * R = R := by
+    have h := Matrix.vecMulVec_mul_mul_vecMulVec_eq_trace_smul
+      b a (doubleLayerTensor W q q)
+    have htrace : Matrix.trace (doubleLayerTensor W q q * R) = 1 := by
+      change Matrix.trace (doubleLayerTensor W q q * Matrix.vecMulVec b a) = 1
+      rw [Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, dotProduct_comm]
+      simpa using h₁ q q
+    simpa only [R, htrace, one_smul] using h
+  rw [normalizedDiagonal_eq_smul_sum_diagonal]
+  simp only [Matrix.mul_smul, Matrix.smul_mul, Finset.mul_sum, Finset.sum_mul]
+  have hterm (q : Fin d) :
+      doubleLayerTensor W i j * doubleLayerTensor W q q *
+          doubleLayerTensor W k l =
+        doubleLayerTensor W i j * R * doubleLayerTensor W k l := by
+    calc
+      _ = (doubleLayerTensor W i j * R * doubleLayerTensor W q q) *
+          doubleLayerTensor W k l := by rw [← h₂ i j q q]
+      _ = doubleLayerTensor W i j * R *
+          (doubleLayerTensor W q q * R * doubleLayerTensor W k l) := by
+            rw [← h₂ q q k l]; simp [Matrix.mul_assoc]
+      _ = doubleLayerTensor W i j * (R * doubleLayerTensor W q q * R) *
+          doubleLayerTensor W k l := by simp [Matrix.mul_assoc]
+      _ = doubleLayerTensor W i j * R * doubleLayerTensor W k l := by rw [hsandwich]
+  simp_rw [hterm]
+  have hd : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+  ext x y
+  simp only [Matrix.smul_apply]
+  change (d : ℂ)⁻¹ * ((d : ℕ) •
+    (doubleLayerTensor W i j * R * doubleLayerTensor W k l) x y) = _
+  rw [nsmul_eq_mul, ← mul_assoc, inv_mul_cancel₀ hd, one_mul]
+  exact congrArg (fun M ↦ M x y) (h₂ i j k l).symm
+
+/-- If a simple tensor has a positive normalized-diagonal power equal to a
+supplied rank-one matrix, then `simple2` holds with exactly those supplied
+witnesses.
+
+The proof inserts the normalized diagonal between two letters using the
+existing existential `simple1` and `simple2` witnesses, iterates that insertion,
+and only then substitutes the supplied transfer power.  No uniqueness of
+rank-one witnesses is used.
+
+Source: arXiv:1703.09188, equations `simple1`, `simple2`, and `Erightleft`,
+lines 356--374 and 429--438. -/
+theorem IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec
+    [NeZero d] {W : MPOTensor d D} (hW : IsMPUSimple W)
+    (ρ Φ : Fin (D * D) → ℂ) (J : ℕ) (hJ : 0 < J)
+    (hpower : normalizedDiagonal (doubleLayerTensor W) ^ J =
+      Matrix.vecMulVec ρ Φ) :
+    ∀ i j k l : Fin d,
+      doubleLayerTensor W i j * doubleLayerTensor W k l =
+        doubleLayerTensor W i j * Matrix.vecMulVec ρ Φ *
+          doubleLayerTensor W k l := by
+  intro i j k l
+  let E := normalizedDiagonal (doubleLayerTensor W)
+  have hinsert : doubleLayerTensor W i j * E * doubleLayerTensor W k l =
+      doubleLayerTensor W i j * doubleLayerTensor W k l :=
+    simple_letter_mul_normalizedDiagonal_mul_letter hW i j k l
+  have hE : E = ((d : ℂ)⁻¹) • ∑ q : Fin d, doubleLayerTensor W q q :=
+    normalizedDiagonal_eq_smul_sum_diagonal (doubleLayerTensor W)
+  have hleftIdem : doubleLayerTensor W i j * E * E =
+      doubleLayerTensor W i j * E := by
+    calc
+      doubleLayerTensor W i j * E * E =
+          doubleLayerTensor W i j * E *
+            (((d : ℂ)⁻¹) • ∑ q : Fin d, doubleLayerTensor W q q) := by rw [hE]
+      _ = ((d : ℂ)⁻¹) • ∑ q : Fin d,
+            doubleLayerTensor W i j * E * doubleLayerTensor W q q := by
+              rw [Matrix.mul_smul, Finset.mul_sum]
+      _ = ((d : ℂ)⁻¹) • ∑ q : Fin d,
+            doubleLayerTensor W i j * doubleLayerTensor W q q := by
+              congr 1
+              apply Finset.sum_congr rfl
+              intro q _
+              exact simple_letter_mul_normalizedDiagonal_mul_letter hW i j q q
+      _ = doubleLayerTensor W i j * E := by
+              rw [hE, Matrix.mul_smul, Finset.mul_sum]
+  have hleftPow : ∀ N : ℕ, 0 < N →
+      doubleLayerTensor W i j * E ^ N = doubleLayerTensor W i j * E := by
+    intro N hN
+    obtain ⟨N, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hN)
+    clear hN
+    induction N with
+    | zero => simp
+    | succ N ih =>
+        rw [pow_succ, ← Matrix.mul_assoc, ih, hleftIdem]
+  calc
+    doubleLayerTensor W i j * doubleLayerTensor W k l =
+        doubleLayerTensor W i j * E ^ J * doubleLayerTensor W k l := by
+          rw [hleftPow J hJ, hinsert]
+    _ = doubleLayerTensor W i j * Matrix.vecMulVec ρ Φ *
+        doubleLayerTensor W k l := by rw [hpower]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -770,8 +770,9 @@ closing a chain of $N$ copies of $\mathcal U$.
     \lean{MPOTensor.IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec}
     \leanok
     \uses{def:mpu_simple}
-    Let $W$ be simple with positive physical dimension, and suppose that for
-    some $J>0$ its normalized diagonal satisfies
+    Let $\mathcal U$ be simple with positive physical dimension, let $W$ be
+    its double layer, and let $E$ be the normalized diagonal of $W$.  Suppose
+    that for some $J>0$,
     \begin{align}
         E^J&=|\rho)(\Phi|.
     \end{align}
@@ -784,6 +785,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpu_simple}
     Choose the witnesses $a,b$ from simplicity and put $R=|b)(a|$.  Expanding
     the normalized diagonal as the average of the diagonal letters, the two
     defining simple contractions give

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -765,6 +765,42 @@ closing a chain of $N$ copies of $\mathcal U$.
     on $k'-k$ proves the claim.
 \end{proof}
 
+\begin{theorem}[Supplied-projector simple2 contraction]
+    \label{thm:mpu_supplied_projector_simple2}
+    \lean{MPOTensor.IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec}
+    \leanok
+    \uses{def:mpu_simple,thm:mpu_blocked_double_layer_diagonal}
+    Let $W$ be simple, and suppose that for some $J>0$ its normalized
+    diagonal satisfies
+    \begin{align}
+        E^J&=|\rho)(\Phi|.
+    \end{align}
+    Then the simple insertion identity holds with these same supplied
+    witnesses:
+    \begin{align}
+        W^{ij}W^{k\ell}
+        &=W^{ij}|\rho)(\Phi|W^{k\ell}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose the witnesses $a,b$ from simplicity and put $R=|b)(a|$.  Expanding
+    the normalized diagonal as the average of the diagonal letters, the two
+    defining simple contractions give
+    \begin{align}
+        W^{ij} E W^{k\ell}&=W^{ij}W^{k\ell}.
+    \end{align}
+    Indeed, insert $R$ on both sides of each diagonal letter; its middle
+    sandwich is $R W^{qq}R=R$ by the first contraction, and the normalized sum
+    contains $d$ equal terms.  The same identity makes
+    $W^{ij}E^N=W^{ij}E$ for every $N>0$.  Hence
+    \begin{align}
+        W^{ij}E^J W^{k\ell}&=W^{ij}W^{k\ell}.
+    \end{align}
+    Substituting the supplied equality $E^J=|\rho)(\Phi|$ proves the claim.
+    No uniqueness of rank-one factorizations is used.
+\end{proof}
+
 \begin{theorem}[The fixed-point simple1 contraction]
     \label{thm:mpu_simple1}
     \lean{MPOTensor.IsMPU.exists_normalized_fixed_points_simple1,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -769,9 +769,9 @@ closing a chain of $N$ copies of $\mathcal U$.
     \label{thm:mpu_supplied_projector_simple2}
     \lean{MPOTensor.IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec}
     \leanok
-    \uses{def:mpu_simple,thm:mpu_blocked_double_layer_diagonal}
-    Let $W$ be simple, and suppose that for some $J>0$ its normalized
-    diagonal satisfies
+    \uses{def:mpu_simple}
+    Let $W$ be simple with positive physical dimension, and suppose that for
+    some $J>0$ its normalized diagonal satisfies
     \begin{align}
         E^J&=|\rho)(\Phi|.
     \end{align}


### PR DESCRIPTION
## Summary

- add `MPOTensor.IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec`
- transport existential MPU-simple witnesses to separately supplied vectors `ρ, Φ` when a positive normalized-diagonal power is `Matrix.vecMulVec ρ Φ`
- document the source-faithful insertion proof in Chapter 28 and expose the module through the generated MPU aggregator

The proof follows arXiv:1703.09188, equations `simple1`, `simple2`, and `Erightleft`: expand the normalized diagonal, use the existential simple contractions to insert it between double-layer letters, iterate the insertion to the supplied positive power, and only then substitute `E ^ J = |ρ)(Φ|`. It does not identify or assume uniqueness of rank-one witnesses.

This PR is intentionally limited to the missing supplied-witness `simple2` transport. It reuses the merged snake-case `exists_normalized_fixed_points_simple1` API and does not duplicate supplied `simple1` or fixed-point declarations. It contains no stacked SourceUV or matching-contraction work from #5834/#5839.

## Validation

- `lake env lean TNLean/MPS/MPU/SuppliedFixedWitnesses.lean`
- `lake build TNLean.MPS.MPU.SuppliedFixedWitnesses TNLean.MPS.MPU`
- generated import aggregator check
- reader-facing prose and proof-integrity scans
- Lean file-policy and text-style scans
- tactic-pattern scan
- source-level blueprint declaration generation, synchronization, and changed-declaration coverage (6862/6862 references; Chapter 28 171/171)

Closes #5853.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proof module and blueprint prose only; no changes to runtime services, auth, or existing MPU APIs beyond the aggregator import.
> 
> **Overview**
> Adds **`IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec`**: when a positive power of the normalized double-layer diagonal equals a supplied rank-one matrix `vecMulVec ρ Φ`, the **`simple2`** insertion identity holds for those same **ρ, Φ**—not only for existential witnesses from `IsMPUSimple`.
> 
> The proof follows the Cirac et al. insertion route: expand the normalized diagonal, use existing **`simple1`/`simple2`** to show inserting **E** between letters is harmless, prove **`W^{ij} E^N = W^{ij} E`** for **N > 0**, then substitute **`E^J = |ρ)(Φ|`**. Uniqueness of rank-one factorizations is not assumed.
> 
> Chapter 28 documents this as the supplied-projector **`simple2`** theorem; **`TNLean.MPS.MPU`** imports the new **`SuppliedFixedWitnesses`** module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cb6cb512d0bb0a16be875ab0ad5e1bb9271c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->