### PR TITLE
style(MPDO): clean rescaling-stable RFP warnings

### DIFF
--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
@@ -119,7 +119,7 @@ lemma A_map_star (k : Fin 4) : (A k).map (starRingEnd ℂ) = A k := by
     simp [A, Matrix.map_apply, starRingEnd_apply]
 
 lemma A_trace (k : Fin 4) : Matrix.trace (A k) = if k = 0 ∨ k = 1 then (4/5 : ℂ) else 0 := by
-  fin_cases k <;> simp [A, Matrix.trace] <;> norm_num
+  fin_cases k <;> simp [A, Matrix.trace]
 
 /-! ### The MPO tensor (undone-vertical reading) -/
 
@@ -133,7 +133,6 @@ view gives the MPO tensor `R^{pq}_{ab} = (25/32)·B^{ab}_{pq}`, i.e.
 `(p₁,p₂) = bondEquiv⁻¹ p` etc.
 
 Source: arXiv:1606.00608, lines 995--1010 (project example). -/
-
 @[simp] lemma bondEquiv_symm_val (k : Fin 4) : bondEquiv.symm k =
     match k with
     | 0 => ((0 : Fin 2), (0 : Fin 2))
@@ -168,12 +167,12 @@ lemma physTraceTransfer_R_entry (a b : Fin 4) : physTraceTransfer R a b =
   -- Expand the Kronecker product: (A a)(i₁,j₁)*conj(A b)(i₂,j₂)
   fin_cases a <;> fin_cases b <;>
     simp [R_apply, Fin.sum_univ_four, Matrix.kroneckerMap_apply,
-      A_map_star, Matrix.map_apply, starRingEnd_apply,
-      A, Matrix.trace, bondEquiv_symm_val] <;> norm_num
+      starRingEnd_apply, A, Matrix.trace, bondEquiv_symm_val] <;> norm_num
 
 /-- The physical-trace transfer of `R` is idempotent: it is the rank-one
-projector $(25/32)\,|t\rangle\langle t|$ with $t_a = \operatorname{tr}(A^a) = (4/5, 4/5, 0, 0)$.  This is
-the literal zero-correlation-length identity of arXiv:1606.00608,
+projector $(25/32)\,|t\rangle\langle t|$ with
+$t_a = \operatorname{tr}(A^a) = (4/5, 4/5, 0, 0)$.  This is the literal
+zero-correlation-length identity of arXiv:1606.00608,
 Definition 4.2, lines 735--741 (project example). -/
 theorem physTraceTransfer_R_idempotent :
     physTraceTransfer R * physTraceTransfer R = physTraceTransfer R := by
@@ -259,7 +258,7 @@ lemma oneLabelChiScaled_posEntries {s : ℝ} (hs : 0 < s) :
   fin_cases k
   · simp [oneLabelChiScaled, hs]
   · have hlam : (0 : ℝ) < lambda := by norm_num [lambda]
-    simp [oneLabelChiScaled]
+    change (0 : ℂ) < (s : ℂ) * (lambda : ℂ)
     rw [show (s : ℂ) * (lambda : ℂ) = ((s * lambda : ℝ) : ℂ) by norm_cast]
     exact_mod_cast mul_pos hs hlam
 


### PR DESCRIPTION
### Motivation

- `RescalingStableLengthDependentRFP.lean` emitted eight linter headers in every MPDO build.
- Controlled isolated warm-cache compilation showed the module itself is not an intrinsic hotspot: 8.7 s, 8.5 s, and 8.6 s before the patch (median 8.6 s).

### Description

- Remove an ineffective and unreachable trailing tactic.
- Remove one command-internal blank line and two unused simp arguments.
- Wrap one long source line.
- Replace one flexible unfolding simplification with an explicit `change` of the scaled chi entry.
- Preserve every declaration and theorem statement, including the distinction between the singleton multiplicity coefficient and chi.

### Testing

- `lake build TNLean.MPS.MPDO.RescalingStableLengthDependentRFP` — success, 0 target-file warnings
- three forced post-patch warm-cache compiles: 9.2 s, 10.0 s, 10.0 s; no performance-improvement claim is made
- `git diff --check origin/main...HEAD`

Final diff: one file, 6 insertions, 7 deletions.

---
Closes #5852
Advances #5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 measured the isolated baseline, applied the local warning fixes, diagnosed and repaired an initially insufficient linter suggestion, and ran exact-hot-main validation. The maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only style and linter cleanup in an MPDO example file; no API, runtime, or security impact.
> 
> **Overview**
> Cleans **eight linter warnings** in `RescalingStableLengthDependentRFP.lean` without changing any declaration or theorem statement.
> 
> Tactic tweaks: drops an ineffective trailing `norm_num` after `A_trace`, removes unused `simp` arguments (`A_map_star`, `Matrix.map_apply`) in `physTraceTransfer_R_entry`, and replaces a flexible `simp` in `oneLabelChiScaled_posEntries` with an explicit `change` on the scaled χ entry before `norm_cast`. Also removes stray blank lines and wraps a long doc-comment line for the physical-trace projector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ae809e41ebfc507ba26a2164133aa5a63cf325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->