### PR TITLE
style(MPDO): stabilize Kato obstruction simplifications

### DIFF
--- a/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
+++ b/TNLean/MPS/MPDO/KatoDeformedRFPObstruction.lean
@@ -514,7 +514,8 @@ private theorem toMPSTensor_eq_toTensorFromBlocks :
   rw [hflat_symm x, hflat_symm y]
   by_cases h : x = y
   · subst y
-    simp [Matrix.blockDiagonal', katoCFWeights, katoCFBlocks, katoCFBlock0, katoCFBlock1]
+    simp only [Fin.isValue, Matrix.blockDiagonal'_apply_eq, Matrix.smul_apply, smul_eq_mul,
+      katoCFWeights, katoCFBlocks]
     by_cases hp_diag : p.divNat = p.modNat
     · have hp_val : p = 0 ∨ p = 3 := by
         fin_cases p
@@ -767,7 +768,7 @@ private lemma reducedBlockState_tensor_eq_scaled_one {N L : ℕ}
       sum_configurationSign_eq_zero (Nat.sub_pos_of_lt hLN)
     simp [hsum_zero, Matrix.one_apply_eq,
       show ((1 : ℂ) / 2) = (2 : ℂ)⁻¹ by norm_num]
-  · simp [huv, Matrix.one_apply_ne huv, smul_apply]
+  · simp [huv, Matrix.one_apply_ne huv]
 
 /-- For $d \neq 0$, $d \cdot \operatorname{negMulLog}(d^{-1}) = \log d$
 (project derivation). -/
@@ -804,7 +805,7 @@ private lemma blockEntropy_tensor_eq {N L : ℕ} (hLpos : 1 ≤ L) (hLN : L < N)
   -- Now compute von Neumann entropy of c • 1 via charpoly
   rw [vonNeumannEntropy_eq_charpoly_roots _ h_scaled_herm]
   have h_card : Fintype.card (Fin L → Fin 2) = 2 ^ L := by
-    simp [Fintype.card_fun, Fintype.card_fin]
+    simp [Fintype.card_fin]
   have h_charpoly : (((2 : ℂ)⁻¹ ^ L : ℂ) •
       (1 : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ)).charpoly =
       (Polynomial.X - Polynomial.C ((2 : ℂ)⁻¹ ^ L : ℂ)) ^


### PR DESCRIPTION
### Motivation

- One broad Kato-obstruction simplification emitted 14 warning headers, and two later simp lists emitted one unused-argument warning each.
- The warning stream obscured failures in a source-facing MPDO obstruction module.

### Description

- Replace the broad initial `simp` with an explicit `simp only` normal form that retains the required weight/block unfolding.
- Remove only the unused `smul_apply` and `Fintype.card_fun` arguments at the two later sites.
- Preserve every declaration, theorem statement, Kato obstruction argument, and CPSV/RFP scope boundary.
- Add no linter suppression.

### Testing

- `lake build TNLean.MPS.MPDO.KatoDeformedRFPObstruction` — success, 0 target-file warnings
- `git diff --check origin/main...HEAD`

Final diff: one file, 4 insertions, 3 deletions.

---
Closes #5861
Advances #5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 identified the linter sites, implemented the explicit simplification, caught and repaired an initially underpowered linter-suggested simp set, and ran exact-hot-main validation. The maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tactic-only edits in one MPDO obstruction file; no API, semantics, or proof claims change beyond eliminating simp linter warnings.
> 
> **Overview**
> **Cleans up `simp` usage** in `toMPSTensor_eq_toTensorFromBlocks` and two entropy lemmas so the file builds without linter noise.
> 
> In the diagonal `x = y` branch of the CPSV block-diagonal proof, a bare `simp` that pulled in many lemmas (and produced many warning headers) is replaced with an explicit `simp only` list: `Fin.isValue`, `Matrix.blockDiagonal'_apply_eq`, `Matrix.smul_apply`, `smul_eq_mul`, and the Kato weight/block defs—same unfolding behavior, narrower rewrite set.
> 
> Two follow-up `simp` calls drop unused arguments only: `smul_apply` on the reduced-block-state identity line and `Fintype.card_fun` on the `Fintype.card (Fin L → Fin 2) = 2 ^ L` step. No statement or proof-structure changes beyond these tactic edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deef6cc0416fb5fc0945087b32a46f47f69611cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->