### PR TITLE
style(Channel): wrap Choi-Doeblin source lines

### DIFF
--- a/TNLean/Channel/ChoiDoeblin.lean
+++ b/TNLean/Channel/ChoiDoeblin.lean
@@ -11,9 +11,11 @@ import TNLean.Channel.SupportCompletion
 # Choi-dominated Doeblin contraction
 
 If the rectangular Choi matrix of a trace-preserving, Hermiticity-preserving
-linear map $T : M_D(\mathbb{C}) \to M_{D'}(\mathbb{C})$ dominates $(\varepsilon/D)(Y \otimes \mathbf{1})$ for some $\varepsilon \ge 0$
-and Hermitian $Y$ with $\mathrm{tr}[Y] = 1$, then $T$ satisfies the Doeblin trace-norm
-contraction $\|T(\rho_1) - T(\rho_2)\|_1 \le (1 - \varepsilon)\|\rho_1 - \rho_2\|_1$ for all density matrices.
+linear map $T : M_D(\mathbb{C}) \to M_{D'}(\mathbb{C})$ dominates
+$(\varepsilon/D)(Y \otimes \mathbf{1})$ for some $\varepsilon \ge 0$ and Hermitian $Y$
+with $\mathrm{tr}[Y] = 1$, then $T$ satisfies the Doeblin trace-norm contraction
+$\|T(\rho_1) - T(\rho_2)\|_1 \le (1 - \varepsilon)\|\rho_1 - \rho_2\|_1$ for all
+density matrices.
 
 The proof constructs the trace-prepare map $T'(X) = \mathrm{tr}[X]Y$, computes its
 rectangular Choi matrix as $(1/D)(Y \otimes \mathbf{1})$, uses the rectangular CP/PSD
@@ -45,8 +47,9 @@ namespace Matrix
 /-- **Choi matrix of the trace-prepare map** (auxiliary lemma for Eq. (8.86)).
 
 For an arbitrary matrix $Y$ on the output space, the trace-prepare
-map $T'(X) = \mathrm{tr}[X]Y$ has Choi matrix $(1/d)(Y \otimes \mathbf{1})$ in the output-factor-first
-tensor order of `ChoiRectangular.choiMatrix`.
+map $T'(X) = \mathrm{tr}[X]Y$ has Choi matrix
+$(1/d)(Y \otimes \mathbf{1})$ in the output-factor-first tensor order of
+`ChoiRectangular.choiMatrix`.
 
 `Notes/WolfNoteTexSource/ch08_distance_measures.tex`, line 973. -/
 lemma choiMatrix_tracePrepareMap (d d' : ℕ)


### PR DESCRIPTION
### Motivation

- The newly merged Choi-dominated Doeblin module emitted three line-length warnings in ordinary Channel and TNLean builds.
- All three sites are reader-facing source prose and can be wrapped without changing content.

### Description

- Wrap only the three warning-bearing lines in `TNLean/Channel/ChoiDoeblin.lean`.
- Preserve every word, declaration, theorem statement, proof, Wolf Eq. (8.86) reference, and Blueprint link.
- Add no linter suppression and make no mathematical change.

### Testing

- `lake build TNLean.Channel.ChoiDoeblin` — success, 0 target-file warnings
- `git diff --check origin/main...HEAD`

---
Closes LionSR/QICLean#312
Advances LionSR/TNLean#5836
Follow-up to LionSR/QICLean#309 and PR LionSR/TNLean#5833

### Agent assistance

- TeXRA with OpenAI GPT-5.6 identified the three exact warning sites, performed the prose-preserving wraps, and ran exact-hot-main targeted validation. The maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only line wrapping with no executable or proof changes.
> 
> **Overview**
> **Formatting-only** change in `TNLean/Channel/ChoiDoeblin.lean`: long reader-facing prose in the module doc and in the `choiMatrix_tracePrepareMap` doc comment is split across lines so the file builds without line-length warnings.
> 
> No edits to lemmas, proofs, theorem statements, imports, or mathematical wording—only line breaks in comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6e19eb3eecca383ba667f6997c63b5ce99fc76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->