### PR TITLE
style(Channel): clean peripheral command and section warnings

### DIFF
--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -406,6 +406,7 @@ theorem tendsto_pow_apply_peripheralProjection
   exact hsum.congr' (Filter.Eventually.of_forall fun i ↦ by
     rw [← map_add, add_sub_cancel])
 
+omit [NeZero D] in
 /-- The Dirichlet recurrent subsequence of the peripheral phases: strictly
 monotone exponents along which every peripheral eigenvalue's powers tend to
 one. Shared by the pointwise and operator-norm convergence statements of

--- a/TNLean/Channel/Peripheral/JordanBlocks.lean
+++ b/TNLean/Channel/Peripheral/JordanBlocks.lean
@@ -86,7 +86,6 @@ lemma pow_apply_rank_two_genEig
         _ = μ • ((T - μ • (1 : V →ₗ[ℂ] V)) X) := by simp
     -- Substitute into the expression
     rw [h_TTX]
-
     have h_TX : T X = μ • X + (T - μ • (1 : V →ₗ[ℂ] V)) X := by
       calc
         T X = ((T - μ • (1 : V →ₗ[ℂ] V)) + μ • (1 : V →ₗ[ℂ] V)) X := by simp
@@ -419,7 +418,6 @@ private theorem peripheral_Jordan_trivial_of_hasBoundedOrbits
     simp [hX_zero]
   | succ m ih =>
     set N := T - μ • (1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-
     by_cases hm : m = 0
     · subst hm; simpa using hNk
     · -- m ≥ 1, rank-2 reduction


### PR DESCRIPTION
### Motivation

- Three mechanical warnings remained in the Channel peripheral cone: two command-internal blank lines and one private theorem carrying an unused section instance.
- These warnings replayed in ordinary Channel and TNLean builds.

### Description

- Remove exactly two blank lines inside commands in `JordanBlocks.lean`.
- Add a local `omit [NeZero D] in` scope to the private Dirichlet recurrent-subsequence theorem in `CesaroRecurrence.lean`.
- Preserve every declaration proposition, proof, and Wolf source boundary; add no suppression.

### Testing

- `lake build TNLean.Channel.Peripheral.JordanBlocks TNLean.Channel.Peripheral.CesaroRecurrence` — success, 0 target-file warnings
- `git diff --check origin/main...HEAD`

---
Closes LionSR/QICLean#313
Advances LionSR/TNLean#5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 identified the three warning sites, made the local whitespace/scope changes, and ran exact-hot-main targeted validation. The maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace and Lean `omit` scoping only; no mathematical or API changes.
> 
> **Overview**
> Clears three build warnings in the Channel peripheral cone without changing any proofs or propositions.
> 
> In **`CesaroRecurrence.lean`**, a local **`omit [NeZero D] in`** wraps the private **`exists_dirichlet_recurrent_subsequence`** theorem so the section instance is not carried where it is unused.
> 
> In **`JordanBlocks.lean`**, two stray blank lines inside proof commands are removed (after **`rw [h_TTX]`** and after **`set N`** in the **`k`** induction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373df76840dfeab5bc59c9a31a2b4e80446f6220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->