### PR TITLE
feat(Algebra): bound Gram reshuffle norm by Frobenius mass

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -57,6 +57,7 @@ import TNLean.Algebra.NatInterval
 import TNLean.Algebra.NewtonGirard
 import TNLean.Algebra.NilMatrixSubalgebra
 import TNLean.Algebra.OperatorBlock
+import TNLean.Algebra.OperatorNormFrobenius
 import TNLean.Algebra.OperatorSchmidt
 import TNLean.Algebra.OrthogonalProjection
 import TNLean.Algebra.PerronFrobenius

--- a/TNLean/Algebra/OperatorNormFrobenius.lean
+++ b/TNLean/Algebra/OperatorNormFrobenius.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.RectangularChoi
+
+import Mathlib.Analysis.Real.Sqrt
+
+/-!
+# Euclidean operator norm and entrywise Frobenius mass
+
+This file bounds the Euclidean operator norm of a finite complex matrix by its
+entrywise Frobenius mass. It also applies the bound to the reshuffled Choi matrix.
+
+## Main results
+
+- `Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq`
+- `Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq`
+-/
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The squared Euclidean operator norm of a complex matrix is bounded by the sum of
+its squared entry norms. -/
+theorem toEuclideanCLM_norm_sq_le_sum_norm_sq (A : Matrix n n ℂ) :
+    ‖(Matrix.toEuclideanCLM (n := n) (𝕜 := ℂ)) A‖ ^ 2 ≤
+      ∑ p : n × n, ‖A p.1 p.2‖ ^ 2 := by
+  let S := ∑ p : n × n, ‖A p.1 p.2‖ ^ 2
+  have hS : 0 ≤ S := Finset.sum_nonneg fun _ _ ↦ sq_nonneg _
+  have hop : ‖(Matrix.toEuclideanCLM (n := n) (𝕜 := ℂ)) A‖ ≤ √S := by
+    refine ContinuousLinearMap.opNorm_le_bound _ (Real.sqrt_nonneg _) fun x ↦ ?_
+    rw [← sq_le_sq₀ (norm_nonneg _) (mul_nonneg (Real.sqrt_nonneg _) (norm_nonneg _))]
+    rw [mul_pow, Real.sq_sqrt hS, EuclideanSpace.norm_sq_eq,
+      EuclideanSpace.norm_sq_eq]
+    change (∑ i, ‖∑ j, A i j * WithLp.ofLp x j‖ ^ 2) ≤
+      S * ∑ j, ‖WithLp.ofLp x j‖ ^ 2
+    calc
+      (∑ i, ‖∑ j, A i j * WithLp.ofLp x j‖ ^ 2) ≤
+          ∑ i, (∑ j, ‖A i j‖ ^ 2) * ∑ j, ‖WithLp.ofLp x j‖ ^ 2 := by
+        gcongr with i
+        calc
+          ‖∑ j, A i j * WithLp.ofLp x j‖ ^ 2 ≤
+              (∑ j, ‖A i j‖ * ‖WithLp.ofLp x j‖) ^ 2 :=
+            pow_le_pow_left₀ (norm_nonneg _)
+              ((norm_sum_le _ _).trans_eq (by simp only [norm_mul])) 2
+          _ ≤ (∑ j, ‖A i j‖ ^ 2) * ∑ j, ‖WithLp.ofLp x j‖ ^ 2 :=
+            Finset.sum_mul_sq_le_sq_mul_sq Finset.univ _ _
+      _ = S * ∑ j, ‖WithLp.ofLp x j‖ ^ 2 := by
+        rw [← Finset.sum_mul]
+        congr 1
+        dsimp only [S]
+        rw [Fintype.sum_prod_type]
+  exact (pow_le_pow_left₀ (norm_nonneg _) hop 2).trans_eq (Real.sq_sqrt hS)
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-- The squared Euclidean operator norm of the reshuffled Choi matrix is bounded by the
+entrywise squared mass of the rectangular Choi matrix. -/
+theorem gramReshuffle_norm_sq_le_rectangularChoi_norm_sq
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    ‖gramReshuffle Φ‖ ^ 2 ≤
+      ∑ p : (α × α) × (α × α), ‖rectangularChoi Φ p.1 p.2‖ ^ 2 := by
+  rw [gramReshuffle]
+  exact (toEuclideanCLM_norm_sq_le_sum_norm_sq (gramReshuffleMatrix Φ)).trans_eq
+    (gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq Φ)
+
+end Matrix

--- a/TNLean/Algebra/OperatorNormFrobenius.lean
+++ b/TNLean/Algebra/OperatorNormFrobenius.lean
@@ -50,10 +50,12 @@ theorem toEuclideanCLM_norm_sq_le_sum_norm_sq (A : Matrix n n ℂ) :
             Finset.sum_mul_sq_le_sq_mul_sq Finset.univ _ _
       _ = S * ∑ j, ‖WithLp.ofLp x j‖ ^ 2 := by
         rw [← Finset.sum_mul]
-        congr 1
-        dsimp only [S]
+        unfold S
         rw [Fintype.sum_prod_type]
-  exact (pow_le_pow_left₀ (norm_nonneg _) hop 2).trans_eq (Real.sq_sqrt hS)
+  calc
+    ‖(Matrix.toEuclideanCLM (n := n) (𝕜 := ℂ)) A‖ ^ 2 ≤ (√S) ^ 2 :=
+      pow_le_pow_left₀ (norm_nonneg _) hop 2
+    _ = S := Real.sq_sqrt hS
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -308,6 +308,25 @@ orthogonal projector is the canonical representative used here.
     vectors.
 \end{proof}
 
+\begin{theorem}[Euclidean operator norm bounded by Frobenius mass]
+    \label{thm:euclidean_operator_norm_sq_le_frobenius}
+    \lean{Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq}
+    \leanok
+    Let $I$ be a finite index set and let $B=(B_{ij})_{i,j\in I}$ be a complex
+    matrix.  Then the squared operator norm of $B$ on $\ell^2(I)$ satisfies
+    \begin{align}
+      \lVert B\rVert_{\ell^2(I)\to\ell^2(I)}^2
+      &\leq \sum_{(i,j)\in I\times I}\lvert B_{ij}\rvert^2.
+      \label{eq:euclidean_operator_norm_sq_le_frobenius}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply Cauchy--Schwarz to each row of $Bx$, sum over the rows, and take the
+    supremum over unit vectors $x\in\ell^2(I)$.
+\end{proof}
+
 \begin{theorem}[Entrywise Frobenius invariance of Gram reshuffling]
     \label{thm:gram_reshuffle_matrix_norm_sq}
     \lean{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq}
@@ -334,6 +353,36 @@ orthogonal projector is the canonical representative used here.
     The map $((b,a),(e,c))\mapsto((c,e),(a,b))$ is an involution (bijection)
     on the product index space.  Reindexing the sum of squared norms by this
     involution yields the claimed equality.
+\end{proof}
+
+\begin{theorem}[Operator bound for a reshuffled Choi matrix]
+    \label{thm:gram_reshuffle_norm_sq_le_rectangular_choi}
+    \lean{Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq}
+    \leanok
+    \uses{def:gram_reshuffle,
+        thm:euclidean_operator_norm_sq_le_frobenius,
+        thm:gram_reshuffle_matrix_norm_sq}
+    Let $I$ be a finite index set and let
+    $\mathcal L\colon\mathbb C^{I\times I}\to\mathbb C^{I\times I}$ be
+    complex-linear.  Then
+    \begin{align}
+      \bigl\lVert\mathscr R(\mathcal L)\bigr\rVert_{
+        \ell^2(I\times I)\to\ell^2(I\times I)}^2
+      &\leq
+      \sum_{u,v\in I\times I}
+        \bigl\lvert J(\mathcal L)_{u,v}\bigr\rvert^2.
+      \label{eq:gram_reshuffle_norm_sq_le_rectangular_choi}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:euclidean_operator_norm_sq_le_frobenius,
+        thm:gram_reshuffle_matrix_norm_sq}
+    Apply Theorem~\ref{thm:euclidean_operator_norm_sq_le_frobenius} to
+    $R(\mathcal L)$, then use
+    Theorem~\ref{thm:gram_reshuffle_matrix_norm_sq} to rewrite its entrywise
+    Frobenius mass as that of $J(\mathcal L)$.
 \end{proof}
 
 \begin{theorem}[Transfer--Gram Choi reshuffling]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -359,9 +359,7 @@ orthogonal projector is the canonical representative used here.
     \label{thm:gram_reshuffle_norm_sq_le_rectangular_choi}
     \lean{Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq}
     \leanok
-    \uses{def:gram_reshuffle,
-        thm:euclidean_operator_norm_sq_le_frobenius,
-        thm:gram_reshuffle_matrix_norm_sq}
+    \uses{def:gram_reshuffle}
     Let $I$ be a finite index set and let
     $\mathcal L\colon\mathbb C^{I\times I}\to\mathbb C^{I\times I}$ be
     complex-linear.  Then
@@ -377,7 +375,8 @@ orthogonal projector is the canonical representative used here.
 
 \begin{proof}
     \leanok
-    \uses{thm:euclidean_operator_norm_sq_le_frobenius,
+    \uses{def:gram_reshuffle,
+        thm:euclidean_operator_norm_sq_le_frobenius,
         thm:gram_reshuffle_matrix_norm_sq}
     Apply Theorem~\ref{thm:euclidean_operator_norm_sq_le_frobenius} to
     $R(\mathcal L)$, then use

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -512,10 +512,29 @@ Euclidean operator with matrix entries
 \end{align}
 The algebraic matrix $R(\mathcal L)$ with these entries is
 \leanid{Matrix.gramReshuffleMatrix}, and the operator
-$\mathscr R(\mathcal L)$ is \leanid{Matrix.gramReshuffle}.  The entrywise Frobenius squared sum is
-invariant under this reshuffling
-(\leanid{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq});
-this entrywise identity does not establish an operator-norm comparison.
+$\mathscr R(\mathcal L)$ is \leanid{Matrix.gramReshuffle}.  The entrywise
+Frobenius squared sum is invariant under this reshuffling
+(\leanid{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq}).
+The generic Euclidean estimate
+\leanid{Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq} proves, for every finite
+index set $I$ and every complex matrix $B\in\mathbb C^{I\times I}$,
+\begin{align}
+  \lVert B\rVert_{\ell^2(I)\to\ell^2(I)}^2
+  &\leq \sum_{i,j\in I}\lvert B_{ij}\rvert^2.
+\end{align}
+Combining these two facts gives the completed reshuffled-Choi corollary
+\leanid{Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq}:
+\begin{align}
+  \lVert\mathscr R(\mathcal L)\rVert_{
+    \ell^2(I\times I)\to\ell^2(I\times I)}^2
+  &\leq \sum_{u,v\in I\times I}
+    \lvert J(\mathcal L)_{u,v}\rvert^2.
+\end{align}
+This proves only an operator-norm bound by entrywise Frobenius mass.  It proves
+neither operator-norm invariance nor preservation of singular values under
+reshuffling, and it gives no direct bound by the default operator norm of
+$\mathcal L$ as a map on matrices.
+
 \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} upgrades the coordinate
 identity to the exact operator equality
 \begin{align}
@@ -523,7 +542,13 @@ identity to the exact operator equality
 \end{align}
 The ordering is a Choi reshuffling.  It must not be replaced by the generally
 false Hilbert--Schmidt expression
-$\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.
+$\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.  In the current
+unweighted Frobenius coordinates, a primitive trace-preserving transfer map
+converges to the fixed-point projection $P_{\mathrm{fix}}$, represented by
+\leanid{fixedPointProj}.  The limiting Gram operator is therefore
+$\mathscr R(P_{\mathrm{fix}})$, generally not the identity.  Thus the
+completed generic inequalities do not by themselves provide a Neumann-series
+estimate for $1-\mathcal K_L$.
 
 The generic identity
 \begin{align}
@@ -575,12 +600,18 @@ are parameters of the quoted FNW estimate, not bounds derived by the present
 formal development.
 
 What remains open is the source-specific comparison of these exact inverse-Gram
-range projectors on the two overlapping physical windows.  The first two formal
-steps are now completed:
+range projectors on the two overlapping physical windows.  The completed exact
+and generic prerequisites now include:
 \begin{itemize}
   \item The Choi reshuffling is packaged as the exact operator identity
     \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} (module
     \path{TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean}).
+  \item The generic operator-norm--to--entrywise-Frobenius estimate and its
+    reshuffled-Choi corollary are
+    \leanid{Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq} and
+    \leanid{Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq}.
+    These do not compare directly with the default operator norm of the
+    transfer map.
   \item The spectator-indexed boundary maps for the tail and left windows are
     defined in \path{TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean},
     together with their exact range equalities
@@ -617,7 +648,7 @@ left and tail ground subspaces of Definition~4.2
 \leanid{MPSTensor.openChainTailGroundSpaceES}), their intersection equals
 \(\mathcal G_{K+L_0+1}^{\mathrm{ES}}(A)\) under block injectivity
 with \(D\ge 1\) and \(L_0>0\)
-(\leanid{MPSTensor.openChainLeft_inf_tailGroundSpaceES}),
+(\leanid{MPSTensor.openChainLeft_inf_tailGroundSpaceES}).
 The symbols \(P^{\mathrm{left}}_{K+L_0}(A)\) and
 \(P^{\mathrm{tail}}_{K,L_0+1}(A)\) denote the orthogonal projectors onto
 \(\mathcal U_{K+L_0}(A)\) and \(\mathcal V_{K,L_0+1}(A)\), respectively,

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 995, 1037 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 994, 1036 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 946, 988 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 995, 1037 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- prove the generic finite-dimensional bound $\|B\|_{2\to2}^2 \le \sum_{i,j}|B_{ij}|^2$ without relying on an ambiguous matrix norm instance
- combine it with the exact Gram/Choi entry reshuffling to bound `Matrix.gramReshuffle` by rectangular-Choi entrywise mass
- synchronize Chapter 13 and the martingale paper-gap note while retaining the remaining transfer-norm and fixed-point-metric blockers

## Scope

This PR does **not** claim that reshuffling preserves singular values or operator norm, does not identify the reshuffled matrix with the ordinary superoperator matrix, and does not compare the Gram directly with the identity. In unweighted Frobenius coordinates the limiting comparison remains `gramReshuffle (fixedPointProj ...)`.

## Verification

- `lake env lean TNLean/Algebra/OperatorNormFrobenius.lean`
- `lake exe lint_style --github`
- full `leanblueprint web`
- blueprint sync, reader-facing prose, and tenkz disposition checks

Closes #5864

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure analytic inequalities on finite matrices with documentation sync; no auth, runtime, or behavioral product changes.
> 
> **Overview**
> Adds formal **Euclidean operator-norm** bounds tied to **entrywise Frobenius mass**, and wires them into the Gram/Choi reshuffling story in Chapter 13 and the martingale paper-gap note.
> 
> **Lean:** New `TNLean/Algebra/OperatorNormFrobenius.lean` proves `Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq` (‖B‖² on ℓ² ≤ ∑|B_ij|²) and `Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq` by combining that bound with the existing entrywise Frobenius invariance of `gramReshuffleMatrix` vs `rectangularChoi`.
> 
> **Blueprint / docs:** Chapter 13 gains matching theorems (`thm:euclidean_operator_norm_sq_le_frobenius`, `thm:gram_reshuffle_norm_sq_le_rectangular_choi`). The CPGSV21 martingale gap note records these as completed prerequisites and **explicitly states limits**: no singular-value or operator-norm invariance under reshuffling, no direct comparison to the transfer map’s default operator norm, and Neumann-series control of `1 - 𝒦_L` still blocked by the `fixedPointProj` limiting metric—not claimed solved here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afa378761e0b6cce083ab7e3a7a342a1b3a8e512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->