### PR TITLE
refactor(MPDO): factor transported vertical-sector positivity

### DIFF
--- a/TNLean/MPS/MPDO/VerticalSectorIdentity.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorIdentity.lean
@@ -47,22 +47,8 @@ theorem transportedVerticalSector_composites_eq_id
     h.SbarTbar = LinearMap.id ∧
       h.TbarSbar = LinearMap.id := by
   classical
-  have hTbarpos (X : VerticalSectorAlgebra h.dim₁)
-      (hX : IsVerticalSectorPosSemidef X) :
-      IsVerticalSectorPosSemidef (h.Tbar X) := by
-    exact transportedVerticalSectorT_posSemidef
-      h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.hMult₁ h.hWeight₁ h.U₁ h.U₂ h.T h.hTCPTP X hX
-  have hSbarpos (X : VerticalSectorAlgebra h.dim₂)
-      (hX : IsVerticalSectorPosSemidef X) :
-      IsVerticalSectorPosSemidef (h.Sbar X) := by
-    exact transportedVerticalSectorS_posSemidef
-      h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂ h.U₁ h.U₂ h.S h.hSCPTP X hX
-  have hF₁pos : Matrix.IsPositiveDirectSumMap h.SbarTbar := by
-    intro X hX
-    exact hSbarpos (h.Tbar X) (hTbarpos X hX)
-  have hF₂pos : Matrix.IsPositiveDirectSumMap h.TbarSbar := by
-    intro X hX
-    exact hTbarpos (h.Sbar X) (hSbarpos X hX)
+  have hF₁pos := h.SbarTbar_isPositiveDirectSumMap
+  have hF₂pos := h.TbarSbar_isPositiveDirectSumMap
   obtain ⟨hF₁TP, hF₂TP, _, _⟩ :=
     transportedVerticalSector_composites_tracePreserving h
   obtain ⟨hF₁Schwarz, hF₂Schwarz⟩ :=

--- a/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
@@ -37,6 +37,66 @@ noncomputable section
 
 namespace MPOTensor
 
+namespace VerticalSectorHypotheses
+
+/-- The transported vertical-sector refinement map preserves positivity under
+the strong Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4,
+lines 1972--1979. -/
+theorem Tbar_posSemidef
+    {g₁ g₂ d D : ℕ}
+    (h : VerticalSectorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D))
+    (X : VerticalSectorAlgebra h.dim₁)
+    (hX : IsVerticalSectorPosSemidef X) :
+    IsVerticalSectorPosSemidef (h.Tbar X) := by
+  exact transportedVerticalSectorT_posSemidef
+    h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.hMult₁ h.hWeight₁
+    h.U₁ h.U₂ h.T h.hTCPTP X hX
+
+/-- The transported vertical-sector coarse-graining map preserves positivity
+under the strong Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4,
+lines 1972--1979. -/
+theorem Sbar_posSemidef
+    {g₁ g₂ d D : ℕ}
+    (h : VerticalSectorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D))
+    (X : VerticalSectorAlgebra h.dim₂)
+    (hX : IsVerticalSectorPosSemidef X) :
+    IsVerticalSectorPosSemidef (h.Sbar X) := by
+  exact transportedVerticalSectorS_posSemidef
+    h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂
+    h.U₁ h.U₂ h.S h.hSCPTP X hX
+
+/-- The coarse-graining--refinement square composite preserves positivity on
+the first vertical-sector algebra.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
+theorem SbarTbar_isPositiveDirectSumMap
+    {g₁ g₂ d D : ℕ}
+    (h : VerticalSectorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
+    Matrix.IsPositiveDirectSumMap h.SbarTbar := by
+  intro X hX
+  exact h.Sbar_posSemidef (h.Tbar X) (h.Tbar_posSemidef X hX)
+
+/-- The refinement--coarse-graining square composite preserves positivity on
+the second vertical-sector algebra.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
+theorem TbarSbar_isPositiveDirectSumMap
+    {g₁ g₂ d D : ℕ}
+    (h : VerticalSectorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
+    Matrix.IsPositiveDirectSumMap h.TbarSbar := by
+  intro X hX
+  exact h.Tbar_posSemidef (h.Sbar X) (h.Sbar_posSemidef X hX)
+
+end VerticalSectorHypotheses
+
 /-- The transported coarse-graining and refinement maps, as well as their two
 square composites, preserve the appropriate total sector traces.
 
@@ -54,22 +114,10 @@ theorem transportedVerticalSector_composites_tracePreserving
       Matrix.IsTracePreservingBetweenDirectSums h.Tbar ∧
       Matrix.IsTracePreservingBetweenDirectSums h.Sbar := by
   classical
-  have hTbarpos (X : VerticalSectorAlgebra h.dim₁)
-      (hX : IsVerticalSectorPosSemidef X) :
-      IsVerticalSectorPosSemidef (h.Tbar X) := by
-    exact transportedVerticalSectorT_posSemidef
-      h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.hMult₁ h.hWeight₁ h.U₁ h.U₂ h.T h.hTCPTP X hX
-  have hSbarpos (X : VerticalSectorAlgebra h.dim₂)
-      (hX : IsVerticalSectorPosSemidef X) :
-      IsVerticalSectorPosSemidef (h.Sbar X) := by
-    exact transportedVerticalSectorS_posSemidef
-      h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂ h.U₁ h.U₂ h.S h.hSCPTP X hX
-  have hF₁pos : Matrix.IsPositiveDirectSumMap h.SbarTbar := by
-    intro X hX
-    exact hSbarpos (h.Tbar X) (hTbarpos X hX)
-  have hF₂pos : Matrix.IsPositiveDirectSumMap h.TbarSbar := by
-    intro X hX
-    exact hTbarpos (h.Sbar X) (hSbarpos X hX)
+  have hTbarpos := h.Tbar_posSemidef
+  have hSbarpos := h.Sbar_posSemidef
+  have hF₁pos := h.SbarTbar_isPositiveDirectSumMap
+  have hF₂pos := h.TbarSbar_isPositiveDirectSumMap
   have hTbarle (X : VerticalSectorAlgebra h.dim₁)
       (hX : IsVerticalSectorPosSemidef X) :
       verticalSectorTrace (h.Tbar X) ≤ verticalSectorTrace X :=

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -730,6 +730,22 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### transported vertical-sector positivity — candidate
+- **Pattern:** reconstruct positivity of the transported `Tbar` and `Sbar`
+  maps from their underlying transported-sector positivity theorems, then
+  compose the two witnesses to prove positivity of `SbarTbar` and `TbarSbar`.
+- **Seen:** two large occurrences across
+  `TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean` and
+  `TNLean/MPS/MPDO/VerticalSectorIdentity.lean` before factoring
+  (2026-08-09).
+- **Abstraction:** `MPOTensor.VerticalSectorHypotheses.Tbar_posSemidef`,
+  `Sbar_posSemidef`, `SbarTbar_isPositiveDirectSumMap`, and
+  `TbarSbar_isPositiveDirectSumMap` in
+  `TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean`.
+- **Notes:** the accessors remove the duplicated proof blocks and four long-line
+  warnings while staying at the Appendix C.4 trace-preservation import
+  boundary. Mark as promoted if a third call site appears.
+
 ### positive-part support-projection trace estimate — candidate
 - **Pattern:** for a positive linear map `T` and Hermitian `H`, decompose
   `T H = T H⁺ - T H⁻`, obtain the support projection `P` of `(T H)⁺`, and


### PR DESCRIPTION
### Motivation

- Two Appendix C.4 consumers independently reconstructed positivity of the transported vertical-sector maps and both square composites.
- The duplicated raw argument trains also emitted four long-line warnings.

### Description

- Add structure-level positivity accessors for `Tbar`, `Sbar`, `SbarTbar`, and `TbarSbar` at the existing trace-preservation import boundary.
- Route trace preservation and the identity-composition proof through the shared accessors.
- Record the two-occurrence factoring as a tactic-ledger candidate; promote it only if a third call site appears.
- Preserve every theorem statement, hypothesis, Appendix C.4 source boundary, and proof meaning.

### Testing

- `lake build TNLean.MPS.MPDO.VerticalSectorTracePreservation` — success, 0 target-file warnings
- `lake build TNLean.MPS.MPDO.VerticalSectorIdentity` — success, 0 target-file warnings
- `lake env lean` on both changed Lean files — success, no output
- `lake build TNLean` — success, 10006 jobs
- `python3 scripts/generate_import_aggregators.py --check` — 51 aggregators / 1296 production modules current
- `git diff --check origin/main...HEAD`
- exact-head independent review — approved, no blockers

---
Closes #5875
Advances #5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 identified the repeated proof blocks, implemented the shared accessors, and ran targeted/full validation. A separate exact-head review approved the corrected branch; the maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural refactor with no changes to public theorem statements or mathematical content; only shared positivity witnesses replace duplicated proof blocks.
> 
> **Overview**
> Factors duplicated Appendix C.4 positivity arguments into shared **`VerticalSectorHypotheses`** accessors on the existing trace-preservation import boundary.
> 
> **`VerticalSectorTracePreservation.lean`** now defines **`Tbar_posSemidef`**, **`Sbar_posSemidef`**, **`SbarTbar_isPositiveDirectSumMap`**, and **`TbarSbar_isPositiveDirectSumMap`**, each wrapping the underlying transported-sector positivity theorems. **`transportedVerticalSector_composites_tracePreserving`** and **`transportedVerticalSector_composites_eq_id`** call these accessors instead of rebuilding the same `have` blocks inline.
> 
> **`docs/tactic_patterns.md`** records the pattern as a tactic-ledger **candidate** (promote only if a third call site appears). Theorem statements, hypotheses, and proof meaning are unchanged; the refactor mainly removes duplication and long-line warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88f6d1499b37d42c579b320d83db0d53d7f039c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->