### PR TITLE
refactor(ParentHamiltonian): factor martingale coefficient bound

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -168,7 +168,7 @@ theorem parentHamiltonianES_quadratic_form_of_anticommutator_local_term_bounds
       (fun i : Fin N => localTermES A L i)
       (fun i : Fin N => localTermES_isSymmetricProjection A L i) c hRow hCol hAnti v)
 
-private lemma martingaleCoefficient_le_one (L : ℕ) (hL : 1 < L) :
+private lemma martingale_coefficient_le_one (L : ℕ) (hL : 1 < L) :
     ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
   have hLpos : (0 : ℝ) < (L : ℝ) := by
     exact_mod_cast Nat.zero_lt_of_lt hL
@@ -203,7 +203,7 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
           ‖parentHamiltonianES A L N v‖ := by
   refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
   intro N hLN v
-  have hγle := martingaleCoefficient_le_one L hL
+  have hγle := martingale_coefficient_le_one L hL
   exact parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
     A L N hγle (c N) (hRow N hLN) (hCross N hLN) v
 
@@ -239,7 +239,7 @@ theorem parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds
           ‖parentHamiltonianES A L N v‖ := by
   refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
   intro N hLN v
-  have hγle := martingaleCoefficient_le_one L hL
+  have hγle := martingale_coefficient_le_one L hL
   exact parentHamiltonianES_quadratic_form_of_anticommutator_local_term_bounds
     A L N hγle (c N) (hRow N hLN) (hCol N hLN) (hAnti N hLN) v
 
@@ -324,7 +324,7 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator
           ‖parentHamiltonianES A L N v‖ := by
   refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
   intro N hLN v
-  have hγle := martingaleCoefficient_le_one L hL
+  have hγle := martingale_coefficient_le_one L hL
   have hm : 0 < 2 * (L - 1) :=
     Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
   exact parentHamiltonianES_quadratic_form_of_finite_overlap_anticommutator
@@ -465,7 +465,7 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_ordered_cross_term
           ‖parentHamiltonianES A L N v‖ := by
   refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
   intro N hLN v
-  have hγle := martingaleCoefficient_le_one L hL
+  have hγle := martingale_coefficient_le_one L hL
   have hm : 0 < 2 * (L - 1) :=
     Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
   exact parentHamiltonianES_quadratic_form_of_finite_overlap_ordered_cross_term

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -168,6 +168,14 @@ theorem parentHamiltonianES_quadratic_form_of_anticommutator_local_term_bounds
       (fun i : Fin N => localTermES A L i)
       (fun i : Fin N => localTermES_isSymmetricProjection A L i) c hRow hCol hAnti v)
 
+private lemma martingaleCoefficient_le_one (L : ℕ) (hL : 1 < L) :
+    ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
+  have hLpos : (0 : ℝ) < (L : ℝ) := by
+    exact_mod_cast Nat.zero_lt_of_lt hL
+  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
+    exact_mod_cast Nat.le_of_lt hL
+  exact (div_le_one (mul_pos (by norm_num) hLpos)).2 (by nlinarith [hLge_one])
+
 /-- Uniform explicit gap-bound reduction from ordered local cross-term row
 bounds.
 
@@ -195,14 +203,7 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
           ‖parentHamiltonianES A L N v‖ := by
   refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
   intro N hLN v
-  have hLpos : (0 : ℝ) < (L : ℝ) := by
-    exact_mod_cast Nat.zero_lt_of_lt hL
-  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
-    exact_mod_cast Nat.le_of_lt hL
-  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
-    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
-    rw [div_le_iff₀ hden]
-    nlinarith [hLge_one]
+  have hγle := martingaleCoefficient_le_one L hL
   exact parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
     A L N hγle (c N) (hRow N hLN) (hCross N hLN) v
 
@@ -238,14 +239,7 @@ theorem parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds
           ‖parentHamiltonianES A L N v‖ := by
   refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
   intro N hLN v
-  have hLpos : (0 : ℝ) < (L : ℝ) := by
-    exact_mod_cast Nat.zero_lt_of_lt hL
-  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
-    exact_mod_cast Nat.le_of_lt hL
-  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
-    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
-    rw [div_le_iff₀ hden]
-    nlinarith [hLge_one]
+  have hγle := martingaleCoefficient_le_one L hL
   exact parentHamiltonianES_quadratic_form_of_anticommutator_local_term_bounds
     A L N hγle (c N) (hRow N hLN) (hCol N hLN) (hAnti N hLN) v
 
@@ -330,14 +324,7 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator
           ‖parentHamiltonianES A L N v‖ := by
   refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
   intro N hLN v
-  have hLpos : (0 : ℝ) < (L : ℝ) := by
-    exact_mod_cast Nat.zero_lt_of_lt hL
-  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
-    exact_mod_cast Nat.le_of_lt hL
-  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
-    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
-    rw [div_le_iff₀ hden]
-    nlinarith [hLge_one]
+  have hγle := martingaleCoefficient_le_one L hL
   have hm : 0 < 2 * (L - 1) :=
     Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
   exact parentHamiltonianES_quadratic_form_of_finite_overlap_anticommutator
@@ -478,14 +465,7 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_ordered_cross_term
           ‖parentHamiltonianES A L N v‖ := by
   refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
   intro N hLN v
-  have hLpos : (0 : ℝ) < (L : ℝ) := by
-    exact_mod_cast Nat.zero_lt_of_lt hL
-  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
-    exact_mod_cast Nat.le_of_lt hL
-  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
-    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
-    rw [div_le_iff₀ hden]
-    nlinarith [hLge_one]
+  have hγle := martingaleCoefficient_le_one L hL
   have hm : 0 < 2 * (L - 1) :=
     Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
   exact parentHamiltonianES_quadratic_form_of_finite_overlap_ordered_cross_term

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -356,6 +356,15 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Martingale coefficient upper bound
+- **Pattern:** prove `((1 : ℝ) / (4 * (L : ℝ))) ≤ 1` from `hL : 1 < L` by
+  deriving positivity of `L`, casting `1 ≤ L`, and clearing the positive denominator.
+- **Reuse:** the private file-local lemma `martingaleCoefficient_le_one` in
+  `TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean` uses Mathlib's
+  `div_le_one` to reduce the estimate to `1 ≤ 4 * L`.
+- **Result:** four explicit gap-bound reductions now share the same coefficient
+  estimate. Public theorem statements and proof routes are unchanged.
+
 ### Vanishing-complement subtype sums
 - **Pattern:** replace a finite sum by the sum over a predicate subtype after proving that every
   term outside the predicate is zero.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -359,7 +359,7 @@ abstracted — record why, so it is not re-proposed).
 ### Martingale coefficient upper bound
 - **Pattern:** prove `((1 : ℝ) / (4 * (L : ℝ))) ≤ 1` from `hL : 1 < L` by
   deriving positivity of `L`, casting `1 ≤ L`, and clearing the positive denominator.
-- **Reuse:** the private file-local lemma `martingaleCoefficient_le_one` in
+- **Reuse:** the private file-local lemma `martingale_coefficient_le_one` in
   `TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean` uses Mathlib's
   `div_le_one` to reduce the estimate to `1 ≤ 4 * L`.
 - **Result:** four explicit gap-bound reductions now share the same coefficient


### PR DESCRIPTION
### Motivation

- Four parent-Hamiltonian gap reductions repeated the same real-arithmetic proof that `1 / (4L) ≤ 1` from `1 < L`.
- Mathlib already provides the generic `div_le_one` interface; only the local natural-number specialization was missing.

### Description

- Add private file-local `martingaleCoefficient_le_one` using `div_le_one`.
- Replace the four duplicated positivity/cast/denominator-clearing blocks with the shared lemma.
- Record the four-occurrence local refactor in the tactic ledger.
- Preserve every public theorem statement, source boundary, and proof route.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean` — success, no output
- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Reduction` — success, 3128 jobs
- `lake build TNLean` — success, 10006 jobs
- `python3 scripts/generate_import_aggregators.py --check` — 51 aggregators / 1296 production modules current
- `git diff --check origin/main...HEAD`
- exact-head independent review — approved, no findings

---
Closes #5877

### Agent assistance

- TeXRA with OpenAI GPT-5.6 found the repeated arithmetic blocks, reused the Mathlib interface, and ran targeted/full validation. A separate exact-head review approved the branch; the maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof deduplication in formal Lean with no API, runtime, or security impact; mathematical claims and public interfaces are preserved.
> 
> **Overview**
> Four parent-Hamiltonian martingale gap reductions each proved that the explicit coefficient **1/(4L)** is at most 1 from `1 < L`. The PR adds a private lemma `martingale_coefficient_le_one` that uses Mathlib's `div_le_one` and replaces those four identical arithmetic blocks with one shared call.
> 
> **Public theorem statements and proof routes are unchanged.** The tactic pattern ledger documents the refactor under completed refactors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e12b0252b71b9de419ab95e1f3d685e136c3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->