### PR TITLE
chore(tenkz): stage the CTAN package tree from the entry point

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -73,6 +73,8 @@ on:
       - 'scripts/test_tenkz_kernel_audit.py'
       - 'scripts/test_tnlog.py'
       - 'scripts/test_texcase.py'
+      - 'scripts/tenkz_ctan.py'
+      - 'scripts/test_tenkz_ctan.py'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -139,6 +141,8 @@ on:
       - 'scripts/test_tenkz_kernel_audit.py'
       - 'scripts/test_tnlog.py'
       - 'scripts/test_texcase.py'
+      - 'scripts/tenkz_ctan.py'
+      - 'scripts/test_tenkz_ctan.py'
   workflow_dispatch:
 
 concurrency:
@@ -253,6 +257,9 @@ jobs:
               - 'scripts/test_tenkz_dimension_inventory.py'
               - 'scripts/update_tenkz_dimension_inventory.py'
               - 'scripts/test_tenkz_cubic.py'
+              - 'scripts/tenkz_ctan.py'
+              - 'scripts/test_tenkz_ctan.py'
+              - 'docs/tenkz/ctan/**'
             shrink:
               - 'blueprint/src/chapter/**'
               - 'tex/tenkz/**'
@@ -342,6 +349,13 @@ jobs:
 
       - name: Compile tenkz manual examples standalone
         run: python3 scripts/tenkz_manual_doctest.py
+
+      # The same check tenkz-release-policy.yml runs, here with an engine
+      # present: the archive is unpacked on its own and a picture compiled
+      # against it, so a runtime file the upload forgot fails rather than
+      # falling back to the repository copy.
+      - name: Check the CTAN archive against a clean installation
+        run: python3 scripts/tenkz_ctan.py check --require-smoke
 
       - name: Check tenkz kernel record contracts
         run: scripts/tenkz_kernel_probes.sh

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -75,6 +75,7 @@ on:
       - 'scripts/test_texcase.py'
       - 'scripts/tenkz_ctan.py'
       - 'scripts/test_tenkz_ctan.py'
+      - 'LICENSE'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -143,6 +144,7 @@ on:
       - 'scripts/test_texcase.py'
       - 'scripts/tenkz_ctan.py'
       - 'scripts/test_tenkz_ctan.py'
+      - 'LICENSE'
   workflow_dispatch:
 
 concurrency:
@@ -257,9 +259,14 @@ jobs:
               - 'scripts/test_tenkz_dimension_inventory.py'
               - 'scripts/update_tenkz_dimension_inventory.py'
               - 'scripts/test_tenkz_cubic.py'
+              # Everything the CTAN archive stages: the material comes from
+              # outside `tex/tenkz/` and `docs/tenkz/*.tex`, so the staging
+              # check is gated on its sources too.
               - 'scripts/tenkz_ctan.py'
               - 'scripts/test_tenkz_ctan.py'
               - 'docs/tenkz/ctan/**'
+              - 'docs/tenkz/CHANGES.md'
+              - 'LICENSE'
             shrink:
               - 'blueprint/src/chapter/**'
               - 'tex/tenkz/**'

--- a/.github/workflows/tenkz-release-policy.yml
+++ b/.github/workflows/tenkz-release-policy.yml
@@ -60,3 +60,13 @@ jobs:
 
       - name: Report the activation pins
         run: python3 tests/tenkz/release-harness/supervisor.py pins
+
+      # The upload archive, checked wherever the release payload is checked.
+      # This job installs no TeX, so the check reports its clean-install step
+      # skipped here; pr-ci.yml runs the same command with `--require-smoke`
+      # in the job that already has an engine.
+      - name: Test the CTAN staging contracts
+        run: python3 scripts/test_tenkz_ctan.py
+
+      - name: Check the CTAN staging tree and its archive
+        run: python3 scripts/tenkz_ctan.py check

--- a/docs/tenkz/RELEASE-POLICY.md
+++ b/docs/tenkz/RELEASE-POLICY.md
@@ -125,6 +125,7 @@ at the exact release head:
 | picture-source lint and shared parsers | `python3 scripts/tenkz_lint.py`; `test_tnlog.py`, `test_texcase.py`, `test_tenkz_kernel_audit.py` | `pr-ci.yml`, `blueprint` |
 | evidence-ledger validity | `python3 scripts/check_tenkz_policy.py` (+ `test_check_tenkz_policy.py`, `test_tenkz_policy_evidence.py`) | `tenkz-policy.yml` |
 | release harness, inventory, and assertions | `python3 tests/tenkz/release-harness/selftest.py`; `supervisor.py check-inventory`, `run-all`, `check-readiness` | `tenkz-release-policy.yml` |
+| CTAN staging tree and archive | `python3 scripts/tenkz_ctan.py check` (+ `test_tenkz_ctan.py`) | `tenkz-release-policy.yml`; `pr-ci.yml`, `tenkz-corpus` runs it with `--require-smoke` |
 | migration guards | `python3 scripts/check_tenkz_dispositions.py`; `python3 scripts/check_tenkz_demolition.py` | `tenkz-demolition.yml`; both expire with the S4 migration (`HACKING.md` §Pull-request evidence) |
 
 **(this page)** The render evidence standard is working agreement 5 on #4183,
@@ -162,6 +163,17 @@ invariants only the writers hold. The in-band `major.minor` header it declares
 does not exist yet and remains owned by #4162/#4703, so until that lands the
 event surface is held by the golden digests rather than by version
 negotiation.
+
+The upload archive reads that same declaration and states nothing of its own.
+`python3 scripts/tenkz_ctan.py archive` walks the load graph from
+`tenkz.sty`, stages the runtime files it finds together with the
+reader-facing material pinned in `docs/tenkz/ctan/MANIFEST.toml`, and writes
+`tenkz-VERSION.zip` with every timestamp taken from the declared date, so the
+archive is a function of the tree and two builds of one tree agree byte for
+byte. `python3 scripts/tenkz_ctan.py check` proves that by building twice and
+comparing, and `sync` prints what each release artifact currently says about
+its version. The steps between a release head and an accepted upload are in
+`docs/tenkz/ctan/UPLOAD-CHECKLIST.md`.
 
 Tags are `tenkz-vMAJOR.MINOR.PATCH`, annotated, never moved or reused. Bare
 `vMAJOR.MINOR.PATCH` tags belong to the Lean toolchain

--- a/docs/tenkz/ctan/CITATION.cff
+++ b/docs/tenkz/ctan/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: "1.2.0"
+message: "If you use tenkz in published work, please cite it as below."
+title: "tenkz: tensor-network diagrams from a description of the network"
+abstract: >-
+  A LaTeX package that draws tensor networks — matrix product states, PEPS
+  sheets, string diagrams, and channel sandwiches — from a statement of the
+  network's structure rather than from placed coordinates, and writes an
+  event stream recording the structure it resolved.
+type: software
+authors:
+  - family-names: "Lu"
+    given-names: "Sirui"
+    email: "sirui.lu@mpq.mpg.de"
+    affiliation: "Max-Planck-Institut für Quantenoptik"
+version: "0.7"
+date-released: "2026-07-22"
+license: "Apache-2.0"
+repository-code: "https://github.com/LionSR/TNLean"
+url: "https://github.com/LionSR/TNLean/tree/main/tex/tenkz"
+keywords:
+  - "LaTeX"
+  - "TikZ"
+  - "tensor networks"
+  - "matrix product states"
+  - "diagrams"

--- a/docs/tenkz/ctan/MANIFEST.toml
+++ b/docs/tenkz/ctan/MANIFEST.toml
@@ -1,0 +1,73 @@
+# What the tenkz upload archive contains, pinned.
+#
+# `scripts/tenkz_ctan.py` walks the load graph from `tex/tenkz/tenkz.sty` and
+# compares the walk against `[runtime]` below. The pin is not the source of
+# the closure — the entry point is — so this file cannot make the archive
+# carry a stage the package does not load, or hide one it does. What the pin
+# buys is a failed check when the load graph moves: a new stage module, a new
+# required package, a new TikZ library, or a deleted one, all stop here until
+# somebody decides whether the upload changes with them.
+#
+# The staged order is the load order for the runtime files and the order below
+# for the rest. Member order is part of the archive's bytes.
+
+schema = 1
+package = "tenkz"
+
+[runtime]
+# Walked from `tenkz.sty`, in load order. The last two are the lockout: the
+# render stage creates the ink primitives, so it loads after every stage that
+# might reference them, and the kernel language loads after render so its
+# records meet the same primitives.
+files = [
+  "tenkz.sty",
+  "tenkz-language.code.tex",
+  "tenkz-language-registry.tex",
+  "tenkz-model.code.tex",
+  "tenkz-core.code.tex",
+  "tenkz-metric.code.tex",
+  "tenkz-geometry.code.tex",
+  "tenkz-string.code.tex",
+  "tenkz-tree.code.tex",
+  "tenkz-render.code.tex",
+  "tenkz-kernel.code.tex",
+]
+
+[runtime.requires]
+# What the archive does not carry and the installation must already have.
+# Three of the libraries come from packages of their own rather than from
+# pgf: `hobby` and `spath3` are separate CTAN packages, and an installation
+# without them fails at load, not at the first curve.
+packages = ["tikz"]
+libraries = [
+  "arrows.meta",
+  "backgrounds",
+  "calc",
+  "decorations.markings",
+  "decorations.pathreplacing",
+  "fit",
+  "hobby",
+  "intersections",
+  "shapes.geometric",
+  "spath3",
+]
+
+[material]
+# Staged name = the file it is copied from, unmodified. The version and date
+# these carry are checked against the `\ProvidesPackage` line; none of them
+# declares a version of its own.
+"README.md" = "docs/tenkz/ctan/README.md"
+"LICENSE" = "LICENSE"
+"CHANGES.md" = "docs/tenkz/CHANGES.md"
+"CITATION.cff" = "docs/tenkz/ctan/CITATION.cff"
+"tenkz.bib" = "docs/tenkz/ctan/tenkz.bib"
+
+[source_tree]
+# Everything in `tex/tenkz/` the upload deliberately leaves out. Anything else
+# found there that the entry point does not load fails the check.
+#
+# `examples/` holds the registry's one-picture-per-command examples. They are
+# compiled by the manual doc-test and are not reader documentation; the
+# documentation an upload carries is the manual, whose reproducible build is
+# the open work of the release.
+excluded = ["examples"]

--- a/docs/tenkz/ctan/README.md
+++ b/docs/tenkz/ctan/README.md
@@ -1,0 +1,87 @@
+# tenkz — tensor-network diagrams from a description of the network
+
+tenkz draws matrix product states, tensor trains, PEPS sheets, string
+diagrams, and channel sandwiches from a statement of what the network is.
+An author writes down the tensors, their indices, and how the indices meet;
+the drawing measures where the ink goes. No coordinates and no lengths
+appear in a picture source.
+
+A picture is a set of typed records — atoms, wires, and marks — placed at
+addresses inside a declared frame. The frame, which may be a flat grid, a
+projected plane, or a circle, gives every address a position and its own
+local axes, so an outward physical leg is the row's own normal rather than a
+page direction, and a label's quadrant is a bearing in the host's axes. Every
+index ends in exactly one of three ways: a bond to another tensor, a closure,
+or a declared open leg. A pictured equation checks that its two sides expose
+the same open indices.
+
+Two tensors of a matrix product state, each with one open bond index and one
+physical index:
+
+```latex
+\begin{tenkz}[cols=2]
+  \tn[ports={180:virtual:$\alpha$, 90:physical:$i_1$}]{A} &
+  \tn[ports={0:virtual:$\beta$, 90:physical:$i_2$}]{B}
+\end{tenkz}
+```
+
+The two tensors are chained by `&`, the bond between them is drawn because
+their adjacent index slots meet, and the open indices are the ones the source
+names.
+
+While drawing, tenkz writes an event stream recording the structure it
+resolved — every atom, index, closure, and region. The stream is a
+documented side surface: checking tools read it to confirm that a printed
+picture and the contraction it claims to show agree.
+
+## Requirements
+
+- LaTeX2e with expl3, as distributed with TeX Live 2023 or later.
+- pgf/TikZ.
+- The `hobby` and `spath3` packages. Both provide TikZ libraries that tenkz
+  loads at package load, and both are distributed separately from pgf; an
+  installation missing either one fails when the package loads.
+
+The regression corpus, the manual, and the reference figures are built with
+XeTeX. pdfTeX and LuaTeX compile the language as well, and are not covered by
+the project's tests.
+
+## Installation
+
+Unpack the archive and put its `.sty` and `.tex` files where LaTeX looks for
+input, either in a local texmf tree under `tex/latex/tenkz/` or beside the
+document. Then
+
+```latex
+\usepackage{tenkz}
+```
+
+loads the package and binds the diagram language: the `tenkz` and `tenkzeq`
+environments and the body commands exist as soon as the package is loaded.
+
+## Documentation
+
+The manual states the language: every environment, command, and key, with a
+picture for each and the failure each rejects. It is the contract the version
+policy freezes. Manual and sources:
+<https://github.com/LionSR/TNLean/tree/main/docs/tenkz>.
+
+## Author and maintainer
+
+Sirui Lu <sirui.lu@mpq.mpg.de>
+
+tenkz is written for TNLean, a Lean 4 formalization of the mathematics of
+tensor networks, and is developed in that repository:
+<https://github.com/LionSR/TNLean>. Defect reports and questions belong in
+its issue tracker: <https://github.com/LionSR/TNLean/issues>.
+
+## License
+
+Apache License, Version 2.0. The full terms are in the `LICENSE` file
+distributed with this package, and every runtime file names the license in
+its header.
+
+## Version
+
+Version 0.7, released 2026-07-22. The change record is in `CHANGES.md`, and
+`CITATION.cff` and `tenkz.bib` carry the citation metadata.

--- a/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
+++ b/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
@@ -1,0 +1,99 @@
+# Uploading tenkz to CTAN
+
+The steps between a release head and an accepted upload, in order. Nothing
+here authorizes a version bump: the version is whatever
+`tex/tenkz/tenkz.sty` declares, and only the release-preparation change
+named by `RELEASE-POLICY.md` §3 may change it.
+
+## 1. Before building the archive
+
+- [ ] The release head is the exact commit the campaign signed off. The
+      archive is a function of the tree, so any later commit is a different
+      archive.
+- [ ] The standing gates listed in `RELEASE-POLICY.md` §2 are green at that
+      head.
+- [ ] `python3 scripts/tenkz_ctan.py check` passes at that head, with a TeX
+      installation present so the clean-install check runs rather than being
+      skipped. Add `--require-smoke` to make its absence a failure.
+- [ ] `python3 scripts/tenkz_ctan.py sync` shows the version and date the
+      release artifacts agree on. Disagreement is the release-preparation
+      change's work, not the archive builder's.
+- [ ] The manual is built reproducibly and is ready to be carried by the
+      archive. Open work: the archive currently stages no manual, because
+      its reproducible build is not finished. CTAN expects documentation in
+      the package, so this is the last blocking item before an upload, not a
+      refinement.
+
+## 2. Building the archive
+
+```
+python3 scripts/tenkz_ctan.py archive --out build/ctan
+```
+
+writes `build/ctan/tenkz/` (the tree as it will unpack),
+`build/ctan/tenkz-VERSION.zip`, and the archive's digest beside it. Record
+the digest in the release notes and in the announcement's archive-hash
+field.
+
+- [ ] The digest recorded in the release notes is the digest the command
+      printed at the release head, produced by the environment that built the
+      uploaded archive. The staged tree is byte-identical wherever it is
+      built; the archive's compressed bytes additionally depend on the
+      compression library, so a digest is quoted for one archive rather than
+      as a property of the version.
+- [ ] The archive unpacks into a single `tenkz/` directory.
+
+## 3. The upload form
+
+CTAN's form asks for the fields below. The values come from the staged
+material, so they are reviewed with it rather than typed fresh each time.
+
+| Field | Value |
+|---|---|
+| Package name | `tenkz` |
+| Version | the `\ProvidesPackage` version at the release head |
+| License | Apache License 2.0 (CTAN's free-license key `apache2`) |
+| Author | Sirui Lu |
+| Maintainer contact | sirui.lu@mpq.mpg.de |
+| Summary | tensor-network diagrams from a description of the network |
+| Description | the opening section of the staged `README.md` |
+| Home page | https://github.com/LionSR/TNLean |
+| Repository | https://github.com/LionSR/TNLean |
+| Bug tracker | https://github.com/LionSR/TNLean/issues |
+| Support | the same tracker |
+| Suggested directory | `graphics/pgf/contrib/tenkz` |
+| Announcement | `docs/tenkz/ANNOUNCEMENT-1.0-draft.md`, with every pending field filled |
+
+A note on the license, for whoever fills the form. The repository is under
+the Apache License 2.0 and the package inherits it; CTAN accepts that
+license and classifies it as free. LaTeX packages more often carry the LaTeX
+Project Public License, and some distribution tooling assumes it. Choosing
+to add LPPL 1.3c as an alternative is a maintainer decision, and it must be
+made before the upload rather than after, because a license stated on CTAN
+is hard to correct later.
+
+## 4. After the upload
+
+- [ ] The announcement's CTAN URL, release URL, archive hash, and freeze
+      commit are filled in.
+- [ ] The package appears in TeX Live's next update, and the `hobby` and
+      `spath3` dependencies are recorded so a distribution build does not
+      drop them.
+
+## What the check proves, and what it does not
+
+`scripts/tenkz_ctan.py check` proves the archive is a function of the tree:
+it builds twice, under two file-creation masks and in two directories, and
+compares the bytes. It walks the load graph from `tenkz.sty` and refuses a
+runtime file the entry point does not load, or a load the pinned manifest
+does not know about. It reads the version from the one declaration that owns
+it and rejects a README, citation record, or archive name that states
+another. It normalizes permissions and rejects compilation leftovers and
+names outside the invariant ASCII subset. Finally it unpacks the archive on
+its own and compiles a picture against it, so a runtime file the archive
+forgot is a failed run rather than a silent fall-back to the repository copy.
+
+It does not judge the manual, the prose, or the mathematics, and it does not
+know whether the release campaign permits a tag. Those are read by the
+gates in `RELEASE-POLICY.md` §2 and by the campaign harness in
+`tests/tenkz/release-harness/`.

--- a/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
+++ b/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
@@ -95,6 +95,11 @@ file it opened and requiring that every tenkz file resolved inside the
 unpacked directory — so a runtime file the archive forgot is a failed run
 rather than a silent fall-back to a copy already installed on the machine.
 
+Every finding is a printed line of the report, and the check prints all of
+them: a staged name an unpacking tool would misread does not cut the report
+short. The commands that write stop on those same findings, read from the
+same checks, because a command that writes has nowhere to put one.
+
 It does not judge the manual, the prose, or the mathematics, and it does not
 know whether the release campaign permits a tag. Those are read by the
 gates in `RELEASE-POLICY.md` §2 and by the campaign harness in

--- a/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
+++ b/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
@@ -90,8 +90,10 @@ does not know about. It reads the version from the one declaration that owns
 it and rejects a README, citation record, or archive name that states
 another. It normalizes permissions and rejects compilation leftovers and
 names outside the invariant ASCII subset. Finally it unpacks the archive on
-its own and compiles a picture against it, so a runtime file the archive
-forgot is a failed run rather than a silent fall-back to the repository copy.
+its own and compiles a picture against it, asking the engine to record every
+file it opened and requiring that every tenkz file resolved inside the
+unpacked directory — so a runtime file the archive forgot is a failed run
+rather than a silent fall-back to a copy already installed on the machine.
 
 It does not judge the manual, the prose, or the mathematics, and it does not
 know whether the release campaign permits a tag. Those are read by the

--- a/docs/tenkz/ctan/tenkz.bib
+++ b/docs/tenkz/ctan/tenkz.bib
@@ -1,0 +1,13 @@
+% Citation metadata for the tenkz package, staged into the upload archive.
+% The version and date are checked against the \ProvidesPackage line of
+% tex/tenkz/tenkz.sty by scripts/tenkz_ctan.py; do not edit them here alone.
+
+@manual{tenkz,
+  title        = {{tenkz}: tensor-network diagrams from a description of the
+                  network},
+  author       = {Lu, Sirui},
+  year         = {2026},
+  month        = {7},
+  note         = {LaTeX package, version 0.7},
+  url          = {https://github.com/LionSR/TNLean/tree/main/tex/tenkz},
+}

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -79,11 +79,15 @@ DEFAULT_OUT = ROOT / "build/ctan"
 PACKAGE = "tenkz"
 DECLARATION = re.compile(r"^\\ProvidesPackage\{tenkz\}\[([^]]*)\]", re.MULTILINE)
 # The version spelling `RELEASE-POLICY.md` §3 fixes: major, minor, and an
-# optional patch, each a nonempty run of digits. A typo such as `v1..0` is a
-# malformed declaration, not a version this tool carries into an archive name.
+# optional patch, each a nonempty run of digits, followed by a description.
+# A typo such as `v1..0` is a malformed declaration, not a version this tool
+# carries into an archive name. The pattern matches the whole payload, and
+# spells it as `tests/tenkz/release-harness/tex_api_package_version.py` does,
+# so the two gates cannot disagree about the same declaration.
 PAYLOAD = re.compile(
     r"(?P<date>[0-9]{4})/([0-9]{2})/([0-9]{2}) "
-    r"v(?P<version>[0-9]+\.[0-9]+(?:\.[0-9]+)?) "
+    r"v(?P<version>[0-9]+\.[0-9]+(?:\.[0-9]+)?) \S.*",
+    re.DOTALL,
 )
 # TeX allows space, and a comment-blanked newline, between a control word and
 # its arguments, so the patterns allow it too: `\RequirePackage {tikz}` is a
@@ -99,6 +103,15 @@ LIBRARY_CALL = re.compile(r"\\usetikzlibrary\s*\{([^}]*)\}", re.DOTALL)
 # invariant ASCII subset, no leading dot or dash, no space.
 SAFE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 
+# Names Windows reserves for devices, whatever suffix follows them, and which
+# an unpacking tool there cannot write. A CTAN archive is unpacked on every
+# platform TeX Live runs on.
+RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{digit}" for digit in range(1, 10)}
+    | {f"LPT{digit}" for digit in range(1, 10)}
+)
+
 # What a LaTeX run leaves beside its sources. None of it belongs in an upload,
 # and none of it belongs in the directory the upload is walked from either.
 DEBRIS_SUFFIXES = frozenset(
@@ -109,8 +122,15 @@ DEBRIS_SUFFIXES = frozenset(
     }
 )
 
-# Midnight UTC on 1 January 1980, the earliest moment a zip entry can carry.
+# The window a zip entry's date field can express: from midnight UTC on 1
+# January 1980 to the end of 2107. An earlier moment is raised to the floor,
+# because `SOURCE_DATE_EPOCH=0` is a convention meaning "no meaningful date";
+# a later one is refused, because a date past 2107 is a mistake and clamping
+# it would silently mis-date the upload.
 ZIP_EPOCH_FLOOR = 315532800
+ZIP_EPOCH_CEILING = int(
+    datetime(2107, 12, 31, 23, 59, 58, tzinfo=timezone.utc).timestamp()
+)
 
 # The staged names an upload carries whatever else the manifest declares. A
 # manifest that dropped one of these would build an archive without a licence
@@ -164,7 +184,7 @@ def read_release(entry: Path = ENTRY) -> Release:
             f"{entry.name} must carry exactly one "
             f"\\ProvidesPackage{{tenkz}} line; found {len(declarations)}"
         )
-    match = PAYLOAD.match(declarations[0])
+    match = PAYLOAD.fullmatch(declarations[0])
     if match is None:
         raise SystemExit(
             f"{entry.name} declares {declarations[0]!r}, which is not "
@@ -266,7 +286,14 @@ def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
             "and header checks never read"
         )
     for name, relative in manifest["material"].items():
-        content[name] = ROOT / relative
+        source = (ROOT / relative).resolve()
+        if not source.is_relative_to(ROOT):
+            raise SystemExit(
+                f"{MANIFEST_LABEL} stages {name} from {source}, outside the "
+                "repository; the archive is built from the tree and from "
+                "nothing else"
+            )
+        content[name] = source
     refused = check_names(content).failures
     if refused:
         raise SystemExit(
@@ -276,12 +303,62 @@ def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
     return content
 
 
+def require_complete_material(manifest: dict) -> None:
+    """Refuse to write an upload that is missing material every upload carries.
+
+    The reporting command says which entry is absent and keeps going; a
+    command that writes has nowhere to put that finding, so it stops.
+    """
+
+    missing = [name for name in REQUIRED_MATERIAL if name not in manifest["material"]]
+    if missing:
+        raise SystemExit(
+            f"{MANIFEST_LABEL} stages no {missing}; an upload carries "
+            f"{list(REQUIRED_MATERIAL)}"
+        )
+
+
+def clear_destination(destination: Path) -> None:
+    """Empty the output directory of this tool's own artifacts, and nothing else.
+
+    The output directory is an option, and an option that recursively deleted
+    whatever it was pointed at would be a bad trade for the convenience of
+    rebuilding in place. So the directory itself is never removed: the staged
+    tree and the archives this tool writes are, and anything else standing
+    there stops the run.
+    """
+
+    resolved = destination.resolve()
+    if resolved == Path(resolved.root) or ROOT.is_relative_to(resolved):
+        raise SystemExit(
+            f"{resolved} contains the repository (or is the file-system root) "
+            "and is not an output directory"
+        )
+    if not resolved.exists():
+        return
+    if not resolved.is_dir():
+        raise SystemExit(f"{resolved} is not a directory")
+    ours = []
+    for entry in sorted(resolved.iterdir()):
+        mine = entry.name == PACKAGE or (
+            entry.name.startswith(f"{PACKAGE}-")
+            and (entry.name.endswith(".zip") or entry.name.endswith(".zip.sha256"))
+        )
+        if not mine:
+            raise SystemExit(
+                f"{resolved} holds {entry.name}, which this tool did not write; "
+                "point --out at a directory it owns"
+            )
+        ours.append(entry)
+    for entry in ours:
+        shutil.rmtree(entry) if entry.is_dir() else entry.unlink()
+
+
 def stage(destination: Path, epoch: int, content: dict[str, Path]) -> Path:
-    """Write the staging tree, replacing whatever stood there before."""
+    """Write the staging tree, replacing this tool's earlier output."""
 
     tree = destination / PACKAGE
-    if destination.exists():
-        shutil.rmtree(destination)
+    clear_destination(destination)
     tree.mkdir(parents=True)
     for name, source in content.items():
         target = tree / name
@@ -340,7 +417,9 @@ def build(destination: Path) -> tuple[Path, Release, str]:
     release = read_release()
     epoch = chosen_epoch(release)
     closure = walk_closure()
-    content = staged_content(read_manifest(), closure)
+    manifest = read_manifest()
+    require_complete_material(manifest)
+    content = staged_content(manifest, closure)
     stage(destination, epoch, content)
     archive = write_archive(destination, release, epoch, content)
     return archive, release, hashlib.sha256(archive.read_bytes()).hexdigest()
@@ -356,7 +435,19 @@ def chosen_epoch(release: Release) -> int:
     """
 
     value = os.environ.get("SOURCE_DATE_EPOCH")
-    chosen = int(value) if value else release.epoch
+    if not value:
+        return max(release.epoch, ZIP_EPOCH_FLOOR)
+    try:
+        chosen = int(value)
+    except ValueError:
+        raise SystemExit(
+            f"SOURCE_DATE_EPOCH is {value!r}, which is not a number of seconds"
+        ) from None
+    if chosen > ZIP_EPOCH_CEILING:
+        raise SystemExit(
+            f"SOURCE_DATE_EPOCH is {chosen}, later than the last moment a zip "
+            f"entry can carry ({ZIP_EPOCH_CEILING}, the end of 2107)"
+        )
     return max(chosen, ZIP_EPOCH_FLOOR)
 
 
@@ -448,10 +539,9 @@ def check_material(manifest: dict) -> Report:
     for name, relative in declared.items():
         source = ROOT / relative
         report.require(source.is_file(), f"{relative} is declared and missing")
-    readme = ROOT / declared.get("README.md", "docs/tenkz/ctan/README.md")
-    if not readme.is_file():
+    text = _material_text(manifest, "README.md")
+    if not text:
         return report
-    text = readme.read_text(encoding="utf-8")
     for heading in ("## Requirements", "## Author and maintainer", "## License"):
         report.require(
             heading in text, f"the CTAN README carries no {heading[3:]!r} section"
@@ -491,6 +581,14 @@ def check_names(content: dict[str, Path]) -> Report:
         report.require(
             SAFE_NAME.fullmatch(name) is not None,
             f"{name!r} is not spelled in the invariant ASCII subset",
+        )
+        report.require(
+            not name.endswith("."),
+            f"{name!r} ends in a dot, which Windows drops when it unpacks",
+        )
+        report.require(
+            name.split(".")[0].upper() not in RESERVED_NAMES,
+            f"{name!r} is a reserved device name on Windows, whatever its suffix",
         )
         collision = seen.get(name.lower())
         report.require(
@@ -547,15 +645,20 @@ def check_headers(closure: Closure, source: Path = SOURCE) -> Report:
 
 
 def _material_text(manifest: dict, name: str) -> str:
-    """The staged material's text, or nothing when the file is absent.
+    """The staged material's text, or nothing when it is absent or undeclared.
 
-    An absent file is the material check's finding to report. Reading it here
-    would raise before any check printed its line, which turns a named missing
-    file into a traceback.
+    An undeclared entry and an absent file are both the material check's
+    findings to report. Indexing or reading here would raise before any check
+    printed its line, which turns a named mistake into a traceback. Bytes are
+    decoded permissively for the same reason: the encoding audit owns that
+    verdict, and it prints one line rather than a stack.
     """
 
-    path = ROOT / manifest["material"][name]
-    return path.read_text(encoding="utf-8") if path.is_file() else ""
+    relative = manifest["material"].get(name)
+    if relative is None:
+        return ""
+    path = ROOT / relative
+    return path.read_bytes().decode("utf-8", errors="replace") if path.is_file() else ""
 
 
 def check_version(release: Release, manifest: dict) -> Report:
@@ -570,13 +673,15 @@ def check_version(release: Release, manifest: dict) -> Report:
         f"{ENTRY.relative_to(ROOT)}",
     )
     citation = _material_text(manifest, "CITATION.cff")
+    # Anchored to the start of a line: a commented or nested occurrence of the
+    # right string beside a stale live value would otherwise satisfy this.
     report.require(
-        f'version: "{release.version}"' in citation,
-        f"the citation record must state version {release.version}",
+        re.search(rf'^version: "{re.escape(release.version)}"\s*$', citation, re.M),
+        f"the citation record must state version {release.version} as its own field",
     )
     report.require(
-        f'date-released: "{release.date}"' in citation,
-        f"the citation record must state date-released {release.date}",
+        re.search(rf'^date-released: "{re.escape(release.date)}"\s*$', citation, re.M),
+        f"the citation record must state date-released {release.date} as its own field",
     )
     bibliography = _material_text(manifest, "tenkz.bib")
     year, month, _ = release.date.split("-")
@@ -802,26 +907,28 @@ def command_check(require_smoke: bool, keep: Path | None) -> int:
     release = read_release()
     manifest = read_manifest()
     closure = walk_closure()
+    material = check_material(manifest)
     reports = [
         check_closure(closure, manifest),
         check_source_tree(closure, manifest),
-        check_material(manifest),
+        material,
         check_headers(closure),
         check_version(release, manifest),
     ]
     content = staged_content(manifest, closure)
-    reports.append(check_encoding(content))
+    encoding = check_encoding(content)
+    reports.append(encoding)
     reports.append(check_names(content))
-    # Nothing below this line can run against a file that is not there, and a
-    # traceback would replace the report naming the file. The checks that need
-    # a built tree report themselves skipped instead, and the missing file is
-    # already a failure of its own.
-    absent = sorted(name for name, source in content.items() if not source.is_file())
+    # A build cannot run against material that is absent, undeclared, or
+    # unreadable, and a traceback would replace the report naming it. The
+    # checks that need a built tree report themselves skipped instead; the
+    # material is already a failure of its own.
+    blocked = material.failures + encoding.failures
     digest = ""
-    if absent:
+    if blocked:
         for name in ("permissions", "debris", "determinism", "clean-install"):
             skipped = Report(name)
-            skipped.skipped = f"{len(absent)} declared file(s) missing: {absent}"
+            skipped.skipped = f"the staged material is not complete ({len(blocked)} finding(s))"
             reports.append(skipped)
     else:
         with tempfile.TemporaryDirectory(prefix="tenkz-ctan-check-") as directory:

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -77,6 +77,7 @@ MANIFEST_LABEL = (
 DEFAULT_OUT = ROOT / "build/ctan"
 
 PACKAGE = "tenkz"
+MANIFEST_SCHEMA = 1
 DECLARATION = re.compile(r"^\\ProvidesPackage\{tenkz\}\[([^]]*)\]", re.MULTILINE)
 # The version spelling `RELEASE-POLICY.md` §3 fixes: major, minor, and an
 # optional patch, each a nonempty run of digits, followed by a description.
@@ -137,14 +138,24 @@ ZIP_EPOCH_CEILING = int(
 # or without a change record, and every check below it would still pass.
 REQUIRED_MATERIAL = ("README.md", "LICENSE", "CHANGES.md", "CITATION.cff", "tenkz.bib")
 
-# A phrase each required file carries if it is the file its staged name says.
 # Existence is not identity: a manifest can point a staged name at the wrong
 # existing file, and an upload whose LICENSE is the change record is worse
 # than one with no licence at all, because it looks answered.
+#
+# Two of the five are named elsewhere already — `DESIGN.md` calls
+# `docs/tenkz/CHANGES.md` the release change record, and the licence is the
+# repository's — so those are pinned to their source rather than sniffed. A
+# phrase would not do for them: a change record has no durable sentence, and
+# the licence's name appears in the README that sits beside it.
+CANONICAL_MATERIAL = {
+    "LICENSE": "LICENSE",
+    "CHANGES.md": "docs/tenkz/CHANGES.md",
+}
+
+# The other three are recognized by a phrase each carries and the others do
+# not.
 MATERIAL_MARKS = {
     "README.md": "## Requirements",
-    "LICENSE": "Apache License",
-    "CHANGES.md": "# tenkz",
     "CITATION.cff": "cff-version:",
     "tenkz.bib": "@manual{tenkz",
 }
@@ -190,7 +201,13 @@ class Release:
 
 
 def read_release(entry: Path = ENTRY) -> Release:
-    declarations = DECLARATION.findall(entry.read_text(encoding="utf-8"))
+    try:
+        text = entry.read_bytes().decode("utf-8")
+    except FileNotFoundError:
+        raise SystemExit(f"{entry.name} is missing; there is no package to stage") from None
+    except UnicodeDecodeError as error:
+        raise SystemExit(f"{entry.name} is not UTF-8 and cannot be read: {error}") from None
+    declarations = DECLARATION.findall(text)
     if len(declarations) != 1:
         raise SystemExit(
             f"{entry.name} must carry exactly one "
@@ -262,16 +279,48 @@ def read_manifest() -> dict:
     """The pinned staging tree, or a message naming what is wrong with it."""
 
     try:
-        return tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+        manifest = tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
     except FileNotFoundError:
         raise SystemExit(f"{MANIFEST_LABEL} is missing") from None
     except tomllib.TOMLDecodeError as error:
         raise SystemExit(f"{MANIFEST_LABEL} does not parse: {error}") from None
+    # The schema and the package are read before anything else is trusted: a
+    # later schema means this tool would be interpreting a manifest written
+    # for a different one, and a different package means it is not this
+    # package's manifest at all. Both fail closed.
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        raise SystemExit(
+            f"{MANIFEST_LABEL} declares schema {manifest.get('schema')!r}; this "
+            f"tool reads schema {MANIFEST_SCHEMA}"
+        )
+    if manifest.get("package") != PACKAGE:
+        raise SystemExit(
+            f"{MANIFEST_LABEL} declares package {manifest.get('package')!r}, "
+            f"not {PACKAGE!r}"
+        )
+    return manifest
 
 
 # --------------------------------------------------------------------------
 # Staging and the archive
 # --------------------------------------------------------------------------
+
+
+def inside_repository(name: str, source: Path) -> Path:
+    """The staged file's source, resolved, or a refusal to leave the tree.
+
+    Every source is resolved, runtime files included: a runtime file may be a
+    link, and a link out of the tree would put a machine's own files in an
+    archive that claims to be a function of this repository.
+    """
+
+    resolved = source.resolve()
+    if not resolved.is_relative_to(ROOT):
+        raise SystemExit(
+            f"{name} is staged from {resolved}, outside the repository; the "
+            "archive is built from the tree and from nothing else"
+        )
+    return resolved
 
 
 def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
@@ -289,7 +338,9 @@ def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
     resolved before anybody read the report saying so.
     """
 
-    content: dict[str, Path] = {name: SOURCE / name for name in closure.files}
+    content: dict[str, Path] = {}
+    for name in closure.files:
+        content[name] = inside_repository(name, SOURCE / name)
     collisions = sorted(set(manifest["material"]) & set(closure.files))
     if collisions:
         raise SystemExit(
@@ -298,14 +349,7 @@ def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
             "and header checks never read"
         )
     for name, relative in manifest["material"].items():
-        source = (ROOT / relative).resolve()
-        if not source.is_relative_to(ROOT):
-            raise SystemExit(
-                f"{MANIFEST_LABEL} stages {name} from {source}, outside the "
-                "repository; the archive is built from the tree and from "
-                "nothing else"
-            )
-        content[name] = source
+        content[name] = inside_repository(name, ROOT / relative)
     refused = check_names(content).failures
     if refused:
         raise SystemExit(
@@ -578,6 +622,12 @@ def check_material(manifest: dict) -> Report:
     # What each required name must turn out to be. A manifest that points a
     # staged name at the wrong existing file — the change record staged as
     # LICENSE, say — passes every check that only asks whether a path exists.
+    for name, canonical in CANONICAL_MATERIAL.items():
+        report.require(
+            declared.get(name, canonical) == canonical,
+            f"{name} is staged from {declared.get(name)!r}; it is the "
+            f"repository's {canonical}",
+        )
     for name, mark in MATERIAL_MARKS.items():
         text = _material_text(manifest, name)
         if not text:
@@ -938,7 +988,9 @@ def command_closure() -> int:
 def command_stage(out: Path) -> int:
     release = read_release()
     epoch = chosen_epoch(release)
-    content = staged_content(read_manifest(), walk_closure())
+    manifest = read_manifest()
+    require_complete_material(manifest)
+    content = staged_content(manifest, walk_closure())
     tree = stage(out, epoch, content)
     print(f"staged {len(content)} files under {tree}")
     return 0

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -152,6 +152,15 @@ CANONICAL_MATERIAL = {
     "CHANGES.md": "docs/tenkz/CHANGES.md",
 }
 
+# The tables a staging manifest is made of, and the keys each one is read for.
+# The checks below index them without asking, which is what a manifest that
+# has passed `read_manifest` is for.
+MANIFEST_TABLES = {
+    "runtime": ("files", "requires"),
+    "material": (),
+    "source_tree": ("excluded",),
+}
+
 # The other three are recognized by a phrase each carries and the others do
 # not.
 MATERIAL_MARKS = {
@@ -298,6 +307,29 @@ def read_manifest() -> dict:
             f"{MANIFEST_LABEL} declares package {manifest.get('package')!r}, "
             f"not {PACKAGE!r}"
         )
+    # Every reader below indexes these tables directly, because a manifest
+    # that has been read is a manifest that describes a staging tree. A file
+    # missing one of them is not one, and it says so here rather than as a
+    # key error from whichever check happened to reach it first.
+    for table, keys in MANIFEST_TABLES.items():
+        section = manifest.get(table)
+        if not isinstance(section, dict):
+            raise SystemExit(
+                f"{MANIFEST_LABEL} declares no [{table}] table; a staging "
+                "manifest names the runtime, the material, and what the "
+                "source tree excludes"
+            )
+        for key in keys:
+            if key not in section:
+                raise SystemExit(
+                    f"{MANIFEST_LABEL} declares [{table}] without {key!r}"
+                )
+    requires = manifest["runtime"]["requires"]
+    if not isinstance(requires, dict) or not {"packages", "libraries"} <= set(requires):
+        raise SystemExit(
+            f"{MANIFEST_LABEL} declares [runtime.requires] without its "
+            "packages and libraries"
+        )
     return manifest
 
 
@@ -330,51 +362,62 @@ def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
     the order the manifest declares. Archive member order is part of the
     bytes, so it comes from the tree rather than from a directory listing.
 
-    Two manifest mistakes are refused here rather than reported later, because
-    the next thing that happens to this mapping is a write. A material entry
-    named after a runtime file would ship under a name the closure and header
-    checks read from a different file; a name outside the invariant subset —
-    a traversal, most of all — would be joined to the staging directory and
-    resolved before anybody read the report saying so.
+    Two manifest mistakes make this mapping unwritable: a material entry named
+    after a runtime file, which would ship under a name the closure and header
+    checks read from a different file, and a name outside the invariant subset,
+    which would be joined to the staging directory and resolved. Both are
+    findings of the `names` check, which the reporting command prints and
+    `require_writable_names` turns into a refusal before any write.
+
+    A source outside the repository is refused here and on both paths: it is
+    not a mistake in what the archive would be called but in what it would
+    contain, and resolving it is how it is found at all.
     """
 
     content: dict[str, Path] = {}
     for name in closure.files:
         content[name] = inside_repository(name, SOURCE / name)
-    collisions = sorted(set(manifest["material"]) & set(closure.files))
-    if collisions:
-        raise SystemExit(
-            f"{MANIFEST_LABEL} stages material under the runtime "
-            f"name(s) {collisions}; the archive would carry a file the closure "
-            "and header checks never read"
-        )
     for name, relative in manifest["material"].items():
         content[name] = inside_repository(name, ROOT / relative)
-    refused = check_names(content).failures
-    if refused:
-        raise SystemExit(
-            f"{MANIFEST_LABEL} names a staged file that will not be "
-            "written: " + "; ".join(refused)
-        )
     return content
 
 
-def require_complete_material(manifest: dict) -> None:
-    """Refuse to write an upload that is missing material every upload carries.
+def require_writable_names(manifest: dict, closure: Closure,
+                           content: dict[str, Path]) -> None:
+    """The name check, as a refusal rather than a report.
 
-    The reporting command says which entry is absent and keeps going; a
-    command that writes has nowhere to put that finding, so it stops.
+    The reporting command says what is wrong with a staged name and keeps
+    going; a command that writes has nowhere to put a finding, so it stops on
+    any of them. Both readings come from the same check, so they cannot drift
+    apart.
     """
 
-    missing = [name for name in REQUIRED_MATERIAL if name not in manifest["material"]]
-    if missing:
+    findings = check_names(content, manifest, closure).failures
+    if findings:
         raise SystemExit(
-            f"{MANIFEST_LABEL} stages no {missing}; an upload carries "
-            f"{list(REQUIRED_MATERIAL)}"
+            f"{MANIFEST_LABEL} names a staged file that will not be "
+            "written: " + "; ".join(findings)
         )
 
 
-def clear_destination(destination: Path) -> None:
+def require_sound_material(manifest: dict) -> None:
+    """The material check, as a refusal rather than a report.
+
+    The reporting command says what is wrong with the material and keeps
+    going; a command that writes has nowhere to put a finding, so it stops on
+    any of them — a missing entry, an absent file, a staged name pointing at
+    the wrong one. Both readings come from the same check, so they cannot
+    drift apart.
+    """
+
+    findings = check_material(manifest).failures
+    if findings:
+        raise SystemExit(
+            f"{MANIFEST_LABEL} does not describe an upload: " + "; ".join(findings)
+        )
+
+
+def clear_destination(destination: Path, release: Release) -> None:
     """Empty the output directory of this tool's own artifacts, and nothing else.
 
     The output directory is an option, and an option that recursively deleted
@@ -406,27 +449,34 @@ def clear_destination(destination: Path) -> None:
         return
     if not resolved.is_dir():
         raise SystemExit(f"{resolved} is not a directory")
+    # Exactly the three things this run would write, each in the shape it
+    # would write them. A name that merely looks like one of them — a private
+    # `tenkz-notes.zip`, or a plain file called `tenkz` — is somebody else's.
+    expected = {
+        PACKAGE: "directory",
+        f"{release.archive_stem}.zip": "file",
+        f"{release.archive_stem}.zip.sha256": "file",
+    }
     ours = []
     for entry in sorted(resolved.iterdir()):
-        mine = entry.name == PACKAGE or (
-            entry.name.startswith(f"{PACKAGE}-")
-            and (entry.name.endswith(".zip") or entry.name.endswith(".zip.sha256"))
-        )
-        if not mine:
+        shape = expected.get(entry.name)
+        if shape is None or (shape == "directory") != entry.is_dir():
             raise SystemExit(
-                f"{resolved} holds {entry.name}, which this tool did not write; "
-                "point --out at a directory it owns"
+                f"{resolved} holds {entry.name}, which this run did not write; "
+                f"it writes {sorted(expected)} and removes nothing else"
             )
         ours.append(entry)
     for entry in ours:
         shutil.rmtree(entry) if entry.is_dir() else entry.unlink()
 
 
-def stage(destination: Path, epoch: int, content: dict[str, Path]) -> Path:
+def stage(
+    destination: Path, release: Release, epoch: int, content: dict[str, Path]
+) -> Path:
     """Write the staging tree, replacing this tool's earlier output."""
 
     tree = destination / PACKAGE
-    clear_destination(destination)
+    clear_destination(destination, release)
     tree.mkdir(parents=True)
     for name, source in content.items():
         target = tree / name
@@ -486,9 +536,10 @@ def build(destination: Path) -> tuple[Path, Release, str]:
     epoch = chosen_epoch(release)
     closure = walk_closure()
     manifest = read_manifest()
-    require_complete_material(manifest)
+    require_sound_material(manifest)
     content = staged_content(manifest, closure)
-    stage(destination, epoch, content)
+    require_writable_names(manifest, closure, content)
+    stage(destination, release, epoch, content)
     archive = write_archive(destination, release, epoch, content)
     return archive, release, hashlib.sha256(archive.read_bytes()).hexdigest()
 
@@ -670,10 +721,25 @@ def check_encoding(content: dict[str, Path]) -> Report:
     return report
 
 
-def check_names(content: dict[str, Path]) -> Report:
-    """Names an unpacking tool cannot misread, on any file system."""
+def check_names(content: dict[str, Path], manifest: dict | None = None,
+                closure: Closure | None = None) -> Report:
+    """Names an unpacking tool cannot misread, on any file system.
+
+    Given the manifest and the closure, the check also answers whether the
+    material stages a name the runtime already carries: the mapping itself
+    cannot say so, because the second entry has taken the first one's place
+    in it by the time anybody looks.
+    """
 
     report = Report("names")
+    if manifest is not None and closure is not None:
+        collisions = sorted(set(manifest["material"]) & set(closure.files))
+        report.require(
+            not collisions,
+            f"{MANIFEST_LABEL} stages material under the runtime "
+            f"name(s) {collisions}; the archive would carry a file the closure "
+            "and header checks never read",
+        )
     seen: dict[str, str] = {}
     for name in content:
         report.require(
@@ -759,6 +825,19 @@ def _material_text(manifest: dict, name: str) -> str:
     return path.read_bytes().decode("utf-8", errors="replace") if path.is_file() else ""
 
 
+def _live_bibtex(bibliography: str) -> str:
+    """The entries of a BibTeX file, with its prose and its comments removed.
+
+    Everything outside an entry is prose BibTeX never reads, and a `%` line is
+    a comment by every convention this repository writes them under. Both can
+    hold a version, a year, or a month, and neither states one: the record's
+    own fields do, and they are what the version check reads.
+    """
+
+    uncommented = re.sub(r"(?m)^\s*%.*$", "", bibliography)
+    return "\n".join(re.findall(r"@\w+\s*\{.*?\n\}", uncommented, re.DOTALL))
+
+
 def check_version(release: Release, manifest: dict) -> Report:
     """One declaration, and every other record checked against it."""
 
@@ -772,27 +851,35 @@ def check_version(release: Release, manifest: dict) -> Report:
     )
     citation = _material_text(manifest, "CITATION.cff")
     # Anchored to the start of a line: a commented or nested occurrence of the
-    # right string beside a stale live value would otherwise satisfy this.
-    report.require(
-        re.search(rf'^version: "{re.escape(release.version)}"\s*$', citation, re.M),
-        f"the citation record must state version {release.version} as its own field",
-    )
-    report.require(
-        re.search(rf'^date-released: "{re.escape(release.date)}"\s*$', citation, re.M),
-        f"the citation record must state date-released {release.date} as its own field",
-    )
-    bibliography = _material_text(manifest, "tenkz.bib")
+    # right string beside a stale live value would otherwise satisfy this. A
+    # top-level field is stated once, so a second one — the stale line a
+    # release edit left behind — is a finding and not a second chance.
+    for field_name, value in (
+        ("version", release.version),
+        ("date-released", release.date),
+    ):
+        stated = re.findall(rf'^{field_name}: "([^"]*)"\s*$', citation, re.M)
+        report.require(
+            stated == [value],
+            f"the citation record must state {field_name} {value} as its own "
+            f"field, once; it states {stated}",
+        )
+    bibliography = _live_bibtex(_material_text(manifest, "tenkz.bib"))
     year, month, _ = release.date.split("-")
+    # Read from the fields themselves, with the comments taken out first: a
+    # BibTeX comment holding the right year beside a live field holding last
+    # year's is a stale record, and it reads as one here.
     report.require(
-        f"version {release.version}" in bibliography,
-        f"the BibTeX record must state version {release.version}",
+        re.search(rf"note\s*=\s*\{{[^}}]*version\s+{re.escape(release.version)}",
+                  bibliography) is not None,
+        f"the BibTeX record must state version {release.version} in its note field",
     )
     report.require(
-        re.search(rf"year\s*=\s*\{{{year}\}}", bibliography) is not None,
+        re.search(rf"year\s*=\s*\{{\s*{year}\s*\}}", bibliography) is not None,
         f"the BibTeX record must state year {year}",
     )
     report.require(
-        re.search(rf"month\s*=\s*\{{{int(month)}\}}", bibliography) is not None,
+        re.search(rf"month\s*=\s*\{{\s*{int(month)}\s*\}}", bibliography) is not None,
         f"the BibTeX record must state month {int(month)}",
     )
     report.notes.append(f"{release.archive_stem}.zip from v{release.version} of {release.date}")
@@ -989,9 +1076,11 @@ def command_stage(out: Path) -> int:
     release = read_release()
     epoch = chosen_epoch(release)
     manifest = read_manifest()
-    require_complete_material(manifest)
-    content = staged_content(manifest, walk_closure())
-    tree = stage(out, epoch, content)
+    require_sound_material(manifest)
+    closure = walk_closure()
+    content = staged_content(manifest, closure)
+    require_writable_names(manifest, closure, content)
+    tree = stage(out, release, epoch, content)
     print(f"staged {len(content)} files under {tree}")
     return 0
 
@@ -1024,13 +1113,15 @@ def command_check(require_smoke: bool, keep: Path | None) -> int:
     ]
     content = staged_content(manifest, closure)
     encoding = check_encoding(content)
+    names = check_names(content, manifest, closure)
     reports.append(encoding)
-    reports.append(check_names(content))
+    reports.append(names)
     # A build cannot run against material that is absent, undeclared, or
-    # unreadable, and a traceback would replace the report naming it. The
-    # checks that need a built tree report themselves skipped instead; the
-    # material is already a failure of its own.
-    blocked = material.failures + encoding.failures
+    # unreadable, or against a name it would refuse to write, and a traceback
+    # would replace the report naming it. The checks that need a built tree
+    # report themselves skipped instead; the finding is already a failure of
+    # its own.
+    blocked = material.failures + encoding.failures + names.failures
     digest = ""
     if blocked:
         for name in ("permissions", "debris", "determinism", "clean-install"):

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -1,0 +1,710 @@
+#!/usr/bin/env python3
+"""The CTAN staging tree for tenkz, and the checks that keep it honest.
+
+CTAN receives an archive, not a repository. This tool builds that archive
+from the tree — the runtime files the entry point actually loads, plus the
+reader-facing material an upload must carry — and then proves the properties
+an upload is judged on, rather than asserting them.
+
+What the tool refuses to guess:
+
+  the runtime closure   The staged runtime is walked from
+                        `tex/tenkz/tenkz.sty`, following `\\input` through the
+                        stage modules and reading `\\RequirePackage` and
+                        `\\usetikzlibrary` for what the archive does not carry.
+                        A pinned copy in `docs/tenkz/ctan/MANIFEST.toml` fails
+                        the check when the load graph moves, so a new stage
+                        module cannot reach an upload unnoticed.
+
+  the version           One declaration owns it, the `\\ProvidesPackage` line
+                        of `tex/tenkz/tenkz.sty`. The archive name, the
+                        README, and the citation records are checked against
+                        that line; none of them may state a version of their
+                        own. This tool never edits a version.
+
+  the timestamps        Every staged file and every archive member is dated
+                        from `SOURCE_DATE_EPOCH` when the environment sets it,
+                        and otherwise from the package's own declared date, so
+                        the archive is a function of the tree and of nothing
+                        else. Determinism is checked by building twice, under
+                        two file-creation masks and in two directories, and
+                        comparing the bytes.
+
+Commands:
+
+  closure       print the runtime closure and what the archive expects to find
+  stage         write the staging tree under --out (default build/ctan)
+  archive       write the tree, the archive, and the archive's digest
+  sync          report the version and date state of the release artifacts
+  check         run every acceptance check and report one line each
+
+`check` exits 1 on the first failing check's report, 0 when every check
+passed or was skipped for a missing engine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from tenkzlib.texcase import strip_comments  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "tex/tenkz"
+ENTRY = SOURCE / "tenkz.sty"
+MATERIAL = ROOT / "docs/tenkz/ctan"
+MANIFEST = MATERIAL / "MANIFEST.toml"
+DEFAULT_OUT = ROOT / "build/ctan"
+
+PACKAGE = "tenkz"
+DECLARATION = re.compile(r"^\\ProvidesPackage\{tenkz\}\[([^]]*)\]", re.MULTILINE)
+PAYLOAD = re.compile(r"(?P<date>[0-9]{4})/([0-9]{2})/([0-9]{2}) v(?P<version>[0-9.]+) ")
+INPUT_CALL = re.compile(r"\\input\{([^}]*)\}")
+REQUIRE_CALL = re.compile(r"\\RequirePackage(?:\[[^]]*\])?\{([^}]*)\}")
+LIBRARY_CALL = re.compile(r"\\usetikzlibrary\{([^}]*)\}", re.DOTALL)
+
+# A name CTAN can carry through any file system and any unpacking tool: the
+# invariant ASCII subset, no leading dot or dash, no space.
+SAFE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+# What a LaTeX run leaves beside its sources. None of it belongs in an upload,
+# and none of it belongs in the directory the upload is walked from either.
+DEBRIS_SUFFIXES = frozenset(
+    {
+        ".aux", ".bbl", ".blg", ".fdb_latexmk", ".fls", ".glo", ".gz", ".idx",
+        ".ilg", ".ind", ".log", ".nav", ".out", ".snm", ".tnlog", ".toc",
+        ".vrb", ".xdv",
+    }
+)
+
+# The one licence marker every runtime file carries, and the sentence beside
+# it. Both are checked; the identifier is what a machine reads.
+LICENSE_MARKER = "% SPDX-License-Identifier: Apache-2.0"
+LICENSE_SENTENCE = "% Copyright the TNLean project; see LICENSE for the full terms."
+
+SMOKE_DOCUMENT = r"""\documentclass{article}
+\usepackage{tenkz}
+\begin{document}
+\begin{tenkz}[cols=2]
+  \tn[ports={180:virtual:$\alpha$, 90:physical:$i_1$}]{A} &
+  \tn[ports={0:virtual:$\beta$, 90:physical:$i_2$}]{B}
+\end{tenkz}
+\end{document}
+"""
+
+
+# --------------------------------------------------------------------------
+# The declared version, and the closure walked from the entry point
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Release:
+    """The one version declaration, read from the one file that holds it."""
+
+    version: str
+    date: str
+
+    @property
+    def epoch(self) -> int:
+        """Midnight UTC on the declared date, as the archive's one timestamp."""
+
+        moment = datetime.strptime(self.date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        return int(moment.timestamp())
+
+    @property
+    def archive_stem(self) -> str:
+        return f"{PACKAGE}-{self.version}"
+
+
+def read_release(entry: Path = ENTRY) -> Release:
+    declarations = DECLARATION.findall(entry.read_text(encoding="utf-8"))
+    if len(declarations) != 1:
+        raise SystemExit(
+            f"{entry.name} must carry exactly one "
+            f"\\ProvidesPackage{{tenkz}} line; found {len(declarations)}"
+        )
+    match = PAYLOAD.match(declarations[0])
+    if match is None:
+        raise SystemExit(
+            f"{entry.name} declares {declarations[0]!r}, which is not "
+            "spelled [YYYY/MM/DD vVERSION description]"
+        )
+    year, month, day = match.group(1), match.group(2), match.group(3)
+    return Release(version=match["version"], date=f"{year}-{month}-{day}")
+
+
+@dataclass
+class Closure:
+    """What the entry point loads, and what it expects the system to have."""
+
+    files: list[str] = field(default_factory=list)
+    packages: list[str] = field(default_factory=list)
+    libraries: list[str] = field(default_factory=list)
+
+
+def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
+    """Follow the load graph from the entry point, in load order.
+
+    Comments are blanked before the graph is read, so a stage named only in
+    prose — the load-order commentary in `tenkz.sty` names several — never
+    enters the closure, and a stage commented out leaves it.
+    """
+
+    closure = Closure()
+    packages: list[str] = []
+    libraries: list[str] = []
+
+    def visit(name: str) -> None:
+        if name in closure.files:
+            return
+        path = source / name
+        if not path.is_file():
+            raise SystemExit(f"{entry} loads {name}, which is missing")
+        closure.files.append(name)
+        text = strip_comments(path.read_text(encoding="utf-8"))
+        for group in REQUIRE_CALL.findall(text):
+            packages.extend(part.strip() for part in group.split(",") if part.strip())
+        for group in LIBRARY_CALL.findall(text):
+            libraries.extend(part.strip() for part in group.split(",") if part.strip())
+        for target in INPUT_CALL.findall(text):
+            visit(target.strip())
+
+    visit(entry)
+    closure.packages = sorted(set(packages))
+    closure.libraries = sorted(set(libraries))
+    return closure
+
+
+def read_manifest() -> dict:
+    return tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------
+# Staging and the archive
+# --------------------------------------------------------------------------
+
+
+def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
+    """Every staged name, in the order the archive stores it, and its source.
+
+    Runtime files keep their load order, the reader-facing material follows in
+    the order the manifest declares. Archive member order is part of the
+    bytes, so it comes from the tree rather than from a directory listing.
+    """
+
+    content: dict[str, Path] = {name: SOURCE / name for name in closure.files}
+    for name, relative in manifest["material"].items():
+        content[name] = ROOT / relative
+    return content
+
+
+def stage(destination: Path, epoch: int, content: dict[str, Path]) -> Path:
+    """Write the staging tree, replacing whatever stood there before."""
+
+    tree = destination / PACKAGE
+    if destination.exists():
+        shutil.rmtree(destination)
+    tree.mkdir(parents=True)
+    for name, source in content.items():
+        target = tree / name
+        target.write_bytes(source.read_bytes())
+        target.chmod(0o644)
+        os.utime(target, (epoch, epoch))
+    tree.chmod(0o755)
+    os.utime(tree, (epoch, epoch))
+    return tree
+
+
+def write_archive(destination: Path, release: Release, epoch: int,
+                  content: dict[str, Path]) -> Path:
+    """Write the upload archive, with every varying field fixed.
+
+    Four fields of a zip entry are otherwise written from the machine that
+    built it: the modification time, the permission bits, the creating system,
+    and the member order. All four are set here.
+
+    One field is not fixed by this file: the compressed bytes come from the
+    compression library the builder links, at the level named here. Two builds
+    of one tree in one environment agree, which is what the determinism check
+    proves and what a recorded digest means; a digest carried across a
+    compression-library change is not a claim this tool makes. The staged tree
+    beside the archive has no such caveat, and the check compares it too.
+    """
+
+    archive = destination / f"{release.archive_stem}.zip"
+    moment = datetime.fromtimestamp(epoch, tz=timezone.utc).timetuple()[:6]
+    with zipfile.ZipFile(
+        archive, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+    ) as bundle:
+        directory = zipfile.ZipInfo(f"{PACKAGE}/", date_time=moment)
+        directory.create_system = 3
+        directory.external_attr = (0o040755 << 16) | 0x10
+        bundle.writestr(directory, b"")
+        for name, source in content.items():
+            entry = zipfile.ZipInfo(f"{PACKAGE}/{name}", date_time=moment)
+            entry.create_system = 3
+            entry.external_attr = 0o100644 << 16
+            entry.compress_type = zipfile.ZIP_DEFLATED
+            bundle.writestr(entry, source.read_bytes())
+    archive.chmod(0o644)
+    os.utime(archive, (epoch, epoch))
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    receipt = destination / f"{release.archive_stem}.zip.sha256"
+    receipt.write_text(f"{digest}  {archive.name}\n", encoding="utf-8")
+    receipt.chmod(0o644)
+    os.utime(receipt, (epoch, epoch))
+    return archive
+
+
+def build(destination: Path) -> tuple[Path, Release, str]:
+    """Stage the tree and write the archive; answer the archive's digest."""
+
+    release = read_release()
+    epoch = chosen_epoch(release)
+    closure = walk_closure()
+    content = staged_content(read_manifest(), closure)
+    stage(destination, epoch, content)
+    archive = write_archive(destination, release, epoch, content)
+    return archive, release, hashlib.sha256(archive.read_bytes()).hexdigest()
+
+
+def chosen_epoch(release: Release) -> int:
+    """`SOURCE_DATE_EPOCH` when the environment sets it, the package date else."""
+
+    value = os.environ.get("SOURCE_DATE_EPOCH")
+    if value:
+        return int(value)
+    return release.epoch
+
+
+# --------------------------------------------------------------------------
+# The checks
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Report:
+    """One check's verdict, and every reason it holds or fails."""
+
+    name: str
+    failures: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    skipped: str = ""
+
+    def require(self, condition: object, reason: str) -> None:
+        if not condition:
+            self.failures.append(reason)
+
+    @property
+    def status(self) -> str:
+        if self.failures:
+            return "FAIL"
+        return "SKIP" if self.skipped else "ok"
+
+
+def check_closure(closure: Closure, manifest: dict) -> Report:
+    report = Report("closure")
+    runtime = manifest["runtime"]
+    report.require(
+        closure.files == runtime["files"],
+        f"the load graph walked from {ENTRY.name} is {closure.files}, and "
+        f"{MANIFEST.relative_to(ROOT)} pins {runtime['files']}",
+    )
+    report.require(
+        closure.packages == runtime["requires"]["packages"],
+        f"loaded packages are {closure.packages}, pinned "
+        f"{runtime['requires']['packages']}",
+    )
+    report.require(
+        closure.libraries == runtime["requires"]["libraries"],
+        f"loaded TikZ libraries are {closure.libraries}, pinned "
+        f"{runtime['requires']['libraries']}",
+    )
+    report.notes.append(
+        f"{len(closure.files)} runtime files; needs {', '.join(closure.packages)} "
+        f"and {len(closure.libraries)} TikZ libraries"
+    )
+    return report
+
+
+def check_source_tree(closure: Closure, manifest: dict, source: Path = SOURCE) -> Report:
+    """Nothing in the source directory is unaccounted for, and none of it is debris."""
+
+    report = Report("sources")
+    excluded = set(manifest["source_tree"]["excluded"])
+    for entry in sorted(source.iterdir()):
+        if entry.name in excluded:
+            continue
+        report.require(
+            entry.is_file(),
+            f"{entry.name} is a directory that the upload neither carries nor excludes",
+        )
+        report.require(
+            entry.suffix not in DEBRIS_SUFFIXES,
+            f"{entry.name} is a compilation leftover in the source tree",
+        )
+        report.require(
+            entry.name in closure.files,
+            f"{entry.name} is not loaded by {ENTRY.name} and is not "
+            f"excluded in {MANIFEST.relative_to(ROOT)}",
+        )
+    return report
+
+
+def check_material(manifest: dict) -> Report:
+    """The reader-facing material an upload must carry, and what it must say."""
+
+    report = Report("material")
+    for name, relative in manifest["material"].items():
+        source = ROOT / relative
+        report.require(source.is_file(), f"{relative} is declared and missing")
+    readme = ROOT / manifest["material"]["README.md"]
+    if not readme.is_file():
+        return report
+    text = readme.read_text(encoding="utf-8")
+    for heading in ("## Requirements", "## Author and maintainer", "## License"):
+        report.require(
+            heading in text, f"the CTAN README carries no {heading[3:]!r} section"
+        )
+    report.require(
+        "@" in text, "the CTAN README states no contact address"
+    )
+    return report
+
+
+def check_encoding(content: dict[str, Path]) -> Report:
+    """Every staged file decodes as UTF-8, and none carries a byte-order mark."""
+
+    report = Report("encoding")
+    for name, source in content.items():
+        raw = source.read_bytes()
+        report.require(
+            not raw.startswith(b"\xef\xbb\xbf"),
+            f"{name} begins with a byte-order mark",
+        )
+        try:
+            raw.decode("utf-8")
+        except UnicodeDecodeError as error:
+            report.failures.append(f"{name} is not UTF-8: {error}")
+    return report
+
+
+def check_names(content: dict[str, Path]) -> Report:
+    """Names an unpacking tool cannot misread, on any file system."""
+
+    report = Report("names")
+    seen: dict[str, str] = {}
+    for name in content:
+        report.require(
+            SAFE_NAME.fullmatch(name) is not None,
+            f"{name!r} is not spelled in the invariant ASCII subset",
+        )
+        collision = seen.get(name.lower())
+        report.require(
+            collision is None,
+            f"{name!r} and {collision!r} differ only in case",
+        )
+        seen[name.lower()] = name
+    return report
+
+
+def check_permissions(tree: Path) -> Report:
+    """One mode for files, one for directories, whatever the builder's mask."""
+
+    report = Report("permissions")
+    for path in sorted(tree.rglob("*")):
+        expected = 0o755 if path.is_dir() else 0o644
+        mode = path.stat().st_mode & 0o777
+        report.require(
+            mode == expected,
+            f"{path.name} is mode {mode:o}, and the upload normalizes to {expected:o}",
+        )
+    return report
+
+
+def check_debris(tree: Path) -> Report:
+    """The staged tree carries sources and reader-facing material, nothing else."""
+
+    report = Report("debris")
+    for path in sorted(tree.rglob("*")):
+        if path.is_dir():
+            continue
+        report.require(
+            path.suffix not in DEBRIS_SUFFIXES,
+            f"{path.name} is a compilation leftover and would ship",
+        )
+    return report
+
+
+def check_headers(closure: Closure, source: Path = SOURCE) -> Report:
+    """Every runtime file names its licence where a reader of that file looks."""
+
+    report = Report("headers")
+    for name in closure.files:
+        head = "\n".join((source / name).read_text(encoding="utf-8").splitlines()[:12])
+        report.require(
+            LICENSE_MARKER in head,
+            f"{name} carries no licence identifier in its first twelve lines",
+        )
+        report.require(
+            LICENSE_SENTENCE in head,
+            f"{name} carries no copyright sentence in its first twelve lines",
+        )
+    return report
+
+
+def check_version(release: Release, manifest: dict) -> Report:
+    """One declaration, and every other record checked against it."""
+
+    report = Report("version")
+    readme = (ROOT / manifest["material"]["README.md"]).read_text(encoding="utf-8")
+    stated = f"Version {release.version}, released {release.date}."
+    report.require(
+        stated in readme,
+        f"the CTAN README must state {stated!r}, the version declared by "
+        f"{ENTRY.relative_to(ROOT)}",
+    )
+    citation = (ROOT / manifest["material"]["CITATION.cff"]).read_text(encoding="utf-8")
+    report.require(
+        f'version: "{release.version}"' in citation,
+        f"the citation record must state version {release.version}",
+    )
+    report.require(
+        f'date-released: "{release.date}"' in citation,
+        f"the citation record must state date-released {release.date}",
+    )
+    bibliography = (ROOT / manifest["material"]["tenkz.bib"]).read_text(encoding="utf-8")
+    report.require(
+        f"version {release.version}" in bibliography,
+        f"the BibTeX record must state version {release.version}",
+    )
+    report.notes.append(f"{release.archive_stem}.zip from v{release.version} of {release.date}")
+    return report
+
+
+def check_determinism(release: Release) -> Report:
+    """Build twice and compare the bytes, under two masks and in two places."""
+
+    report = Report("determinism")
+    digests: list[str] = []
+    listings: list[list[tuple[str, int, int]]] = []
+    for label, mask in (("first", 0o022), ("second", 0o077)):
+        previous = os.umask(mask)
+        try:
+            with tempfile.TemporaryDirectory(prefix=f"tenkz-ctan-{label}-") as directory:
+                archive, _, digest = build(Path(directory) / "out")
+                digests.append(digest)
+                tree = archive.parent / PACKAGE
+                listings.append(
+                    sorted(
+                        (
+                            str(path.relative_to(tree)),
+                            path.stat().st_mode & 0o777,
+                            path.stat().st_mtime_ns,
+                        )
+                        for path in tree.rglob("*")
+                    )
+                )
+        finally:
+            os.umask(previous)
+    report.require(
+        digests[0] == digests[1],
+        f"two builds of the same tree gave {digests[0]} and {digests[1]}",
+    )
+    report.require(
+        listings[0] == listings[1],
+        "two staged trees differ in name, mode, or modification time",
+    )
+    report.notes.append(f"{release.archive_stem}.zip is sha256 {digests[0]}")
+    return report
+
+
+def check_smoke(archive: Path, required: bool) -> Report:
+    """Unpack the archive alone and compile a document against it.
+
+    The search path names the unpacked directory and then the installation,
+    so a runtime file the archive forgot is a failed run rather than a silent
+    fall-back to the repository copy.
+    """
+
+    report = Report("clean-install")
+    if shutil.which("xelatex") is None:
+        if required:
+            report.failures.append("xelatex is absent and the check was required")
+        else:
+            report.skipped = "xelatex is absent"
+        return report
+    with tempfile.TemporaryDirectory(prefix="tenkz-ctan-smoke-") as directory:
+        room = Path(directory)
+        with zipfile.ZipFile(archive) as bundle:
+            bundle.extractall(room)
+        document = room / "smoke.tex"
+        document.write_text(SMOKE_DOCUMENT, encoding="utf-8")
+        environment = dict(os.environ)
+        environment["TEXINPUTS"] = f"{room / PACKAGE}//:"
+        environment["TEXMFOUTPUT"] = str(room)
+        finished = subprocess.run(
+            ["xelatex", "-interaction=nonstopmode", "-halt-on-error", "smoke.tex"],
+            cwd=room,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        if finished.returncode != 0:
+            tail = "\n".join(finished.stdout.splitlines()[-25:])
+            report.failures.append(
+                f"a document using only the unpacked archive failed to compile:\n{tail}"
+            )
+        else:
+            report.notes.append("a two-cell picture compiled from the unpacked archive")
+    return report
+
+
+def release_sync(release: Release) -> list[tuple[str, str]]:
+    """What each release artifact currently says about its version and date.
+
+    The version freeze is a release decision, not this tool's: the rows are
+    reported and never enforced here. `docs/tenkz/RELEASE-POLICY.md` §3 owns
+    the agreement a tag requires.
+    """
+
+    manual = (ROOT / "docs/tenkz/manual2.tex").read_text(encoding="utf-8")
+    changes = (ROOT / "docs/tenkz/CHANGES.md").read_text(encoding="utf-8")
+    tnlog = (ROOT / "docs/tenkz/TNLOG.md").read_text(encoding="utf-8")
+    dateline = re.search(r"The TNLean project \\quad---\\quad ([^\\]*)\\par", manual)
+    event = re.search(r'^version = "([0-9.]+)"', tnlog, re.MULTILINE)
+    return [
+        ("tex/tenkz/tenkz.sty", f"v{release.version} of {release.date}"),
+        ("docs/tenkz/manual2.tex", (dateline.group(1).strip() if dateline else "no date line")),
+        ("docs/tenkz/CHANGES.md", changes.splitlines()[0].lstrip("# ").strip()),
+        ("docs/tenkz/TNLOG.md", f"event format {event.group(1)}" if event else "no version"),
+    ]
+
+
+# --------------------------------------------------------------------------
+# Commands
+# --------------------------------------------------------------------------
+
+
+def command_closure() -> int:
+    closure = walk_closure()
+    print(f"runtime closure of {ENTRY.relative_to(ROOT)}, in load order:")
+    for name in closure.files:
+        print(f"  {name}")
+    print(f"loads: {', '.join(closure.packages)}")
+    print(f"TikZ libraries: {', '.join(closure.libraries)}")
+    return 0
+
+
+def command_stage(out: Path) -> int:
+    release = read_release()
+    epoch = chosen_epoch(release)
+    content = staged_content(read_manifest(), walk_closure())
+    tree = stage(out, epoch, content)
+    print(f"staged {len(content)} files under {tree}")
+    return 0
+
+
+def command_archive(out: Path) -> int:
+    archive, release, digest = build(out)
+    print(f"wrote {archive}")
+    print(f"sha256 {digest}")
+    print(f"version v{release.version} of {release.date}")
+    return 0
+
+
+def command_sync() -> int:
+    for artifact, state in release_sync(read_release()):
+        print(f"  {artifact:28s} {state}")
+    return 0
+
+
+def command_check(require_smoke: bool, keep: Path | None) -> int:
+    release = read_release()
+    manifest = read_manifest()
+    closure = walk_closure()
+    reports = [
+        check_closure(closure, manifest),
+        check_source_tree(closure, manifest),
+        check_material(manifest),
+        check_headers(closure),
+        check_version(release, manifest),
+    ]
+    content = staged_content(manifest, closure)
+    reports.append(check_encoding(content))
+    reports.append(check_names(content))
+    with tempfile.TemporaryDirectory(prefix="tenkz-ctan-check-") as directory:
+        destination = keep if keep is not None else Path(directory) / "out"
+        archive, _, digest = build(destination)
+        reports.append(check_permissions(destination / PACKAGE))
+        reports.append(check_debris(destination / PACKAGE))
+        reports.append(check_determinism(release))
+        reports.append(check_smoke(archive, require_smoke))
+    for report in reports:
+        print(f"  {report.status:4s} {report.name}")
+        for note in report.notes:
+            print(f"         {note}")
+        if report.skipped:
+            print(f"         skipped: {report.skipped}")
+        for failure in report.failures:
+            for line in failure.splitlines():
+                print(f"         {line}")
+    print("release artifacts, for the preparation change that synchronizes them:")
+    for artifact, state in release_sync(release):
+        print(f"  {artifact:28s} {state}")
+    failed = [report.name for report in reports if report.failures]
+    if failed:
+        print(f"tenkz-ctan: FAIL: {', '.join(failed)}")
+        return 1
+    print(f"tenkz-ctan: PASS: {release.archive_stem}.zip is sha256 {digest}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("closure", help="print the runtime closure")
+    staging = commands.add_parser("stage", help="write the staging tree")
+    staging.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    packing = commands.add_parser("archive", help="write the tree and the archive")
+    packing.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    commands.add_parser("sync", help="report the release artifacts' version state")
+    checking = commands.add_parser("check", help="run every acceptance check")
+    checking.add_argument(
+        "--require-smoke",
+        action="store_true",
+        help="fail rather than skip when no TeX engine is installed",
+    )
+    checking.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="keep the checked tree and archive here instead of discarding them",
+    )
+    arguments = parser.parse_args(argv)
+    if arguments.command == "closure":
+        return command_closure()
+    if arguments.command == "stage":
+        return command_stage(arguments.out)
+    if arguments.command == "archive":
+        return command_archive(arguments.out)
+    if arguments.command == "sync":
+        return command_sync()
+    return command_check(arguments.require_smoke, arguments.out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -70,7 +70,13 @@ DEFAULT_OUT = ROOT / "build/ctan"
 
 PACKAGE = "tenkz"
 DECLARATION = re.compile(r"^\\ProvidesPackage\{tenkz\}\[([^]]*)\]", re.MULTILINE)
-PAYLOAD = re.compile(r"(?P<date>[0-9]{4})/([0-9]{2})/([0-9]{2}) v(?P<version>[0-9.]+) ")
+# The version spelling `RELEASE-POLICY.md` §3 fixes: major, minor, and an
+# optional patch, each a nonempty run of digits. A typo such as `v1..0` is a
+# malformed declaration, not a version this tool carries into an archive name.
+PAYLOAD = re.compile(
+    r"(?P<date>[0-9]{4})/([0-9]{2})/([0-9]{2}) "
+    r"v(?P<version>[0-9]+\.[0-9]+(?:\.[0-9]+)?) "
+)
 INPUT_CALL = re.compile(r"\\input\{([^}]*)\}")
 REQUIRE_CALL = re.compile(r"\\RequirePackage(?:\[[^]]*\])?\{([^}]*)\}")
 LIBRARY_CALL = re.compile(r"\\usetikzlibrary\{([^}]*)\}", re.DOTALL)
@@ -192,7 +198,14 @@ def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
 
 
 def read_manifest() -> dict:
-    return tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+    """The pinned staging tree, or a message naming what is wrong with it."""
+
+    try:
+        return tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"{MANIFEST.relative_to(ROOT)} is missing") from None
+    except tomllib.TOMLDecodeError as error:
+        raise SystemExit(f"{MANIFEST.relative_to(ROOT)} does not parse: {error}") from None
 
 
 # --------------------------------------------------------------------------
@@ -206,11 +219,31 @@ def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
     Runtime files keep their load order, the reader-facing material follows in
     the order the manifest declares. Archive member order is part of the
     bytes, so it comes from the tree rather than from a directory listing.
+
+    Two manifest mistakes are refused here rather than reported later, because
+    the next thing that happens to this mapping is a write. A material entry
+    named after a runtime file would ship under a name the closure and header
+    checks read from a different file; a name outside the invariant subset —
+    a traversal, most of all — would be joined to the staging directory and
+    resolved before anybody read the report saying so.
     """
 
     content: dict[str, Path] = {name: SOURCE / name for name in closure.files}
+    collisions = sorted(set(manifest["material"]) & set(closure.files))
+    if collisions:
+        raise SystemExit(
+            f"{MANIFEST.relative_to(ROOT)} stages material under the runtime "
+            f"name(s) {collisions}; the archive would carry a file the closure "
+            "and header checks never read"
+        )
     for name, relative in manifest["material"].items():
         content[name] = ROOT / relative
+    refused = check_names(content).failures
+    if refused:
+        raise SystemExit(
+            f"{MANIFEST.relative_to(ROOT)} names a staged file that will not be "
+            "written: " + "; ".join(refused)
+        )
     return content
 
 

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -137,6 +137,18 @@ ZIP_EPOCH_CEILING = int(
 # or without a change record, and every check below it would still pass.
 REQUIRED_MATERIAL = ("README.md", "LICENSE", "CHANGES.md", "CITATION.cff", "tenkz.bib")
 
+# A phrase each required file carries if it is the file its staged name says.
+# Existence is not identity: a manifest can point a staged name at the wrong
+# existing file, and an upload whose LICENSE is the change record is worse
+# than one with no licence at all, because it looks answered.
+MATERIAL_MARKS = {
+    "README.md": "## Requirements",
+    "LICENSE": "Apache License",
+    "CHANGES.md": "# tenkz",
+    "CITATION.cff": "cff-version:",
+    "tenkz.bib": "@manual{tenkz",
+}
+
 # The one licence marker every runtime file carries, and the sentence beside
 # it. Both are checked; the identifier is what a machine reads.
 LICENSE_MARKER = "% SPDX-License-Identifier: Apache-2.0"
@@ -326,6 +338,13 @@ def clear_destination(destination: Path) -> None:
     rebuilding in place. So the directory itself is never removed: the staged
     tree and the archives this tool writes are, and anything else standing
     there stops the run.
+
+    Recognizing artifacts by name is not enough on its own. `tex/` holds a
+    directory called `tenkz`, and it is the package's sources; a destination
+    inside the repository is therefore confined to `build/`, which the
+    repository ignores and which holds nothing else's work. Outside the
+    repository any directory will do, as long as it holds only this tool's
+    artifacts.
     """
 
     resolved = destination.resolve()
@@ -333,6 +352,11 @@ def clear_destination(destination: Path) -> None:
         raise SystemExit(
             f"{resolved} contains the repository (or is the file-system root) "
             "and is not an output directory"
+        )
+    if resolved.is_relative_to(ROOT) and not resolved.is_relative_to(ROOT / "build"):
+        raise SystemExit(
+            f"{resolved} is inside the repository and outside build/; an output "
+            "directory there would stand among tracked files"
         )
     if not resolved.exists():
         return
@@ -425,6 +449,18 @@ def build(destination: Path) -> tuple[Path, Release, str]:
     return archive, release, hashlib.sha256(archive.read_bytes()).hexdigest()
 
 
+def even_second(epoch: int) -> int:
+    """The moment a zip entry can actually store.
+
+    A zip date field counts in two-second steps, so an odd second stamped on
+    the staged tree would arrive in the archive as the second before it, and
+    the tree and the archive would disagree about the one timestamp they are
+    supposed to share.
+    """
+
+    return epoch - (epoch % 2)
+
+
 def chosen_epoch(release: Release) -> int:
     """`SOURCE_DATE_EPOCH` when the environment sets it, the package date else.
 
@@ -436,7 +472,7 @@ def chosen_epoch(release: Release) -> int:
 
     value = os.environ.get("SOURCE_DATE_EPOCH")
     if not value:
-        return max(release.epoch, ZIP_EPOCH_FLOOR)
+        return even_second(max(release.epoch, ZIP_EPOCH_FLOOR))
     try:
         chosen = int(value)
     except ValueError:
@@ -448,7 +484,7 @@ def chosen_epoch(release: Release) -> int:
             f"SOURCE_DATE_EPOCH is {chosen}, later than the last moment a zip "
             f"entry can carry ({ZIP_EPOCH_CEILING}, the end of 2107)"
         )
-    return max(chosen, ZIP_EPOCH_FLOOR)
+    return even_second(max(chosen, ZIP_EPOCH_FLOOR))
 
 
 # --------------------------------------------------------------------------
@@ -539,6 +575,18 @@ def check_material(manifest: dict) -> Report:
     for name, relative in declared.items():
         source = ROOT / relative
         report.require(source.is_file(), f"{relative} is declared and missing")
+    # What each required name must turn out to be. A manifest that points a
+    # staged name at the wrong existing file — the change record staged as
+    # LICENSE, say — passes every check that only asks whether a path exists.
+    for name, mark in MATERIAL_MARKS.items():
+        text = _material_text(manifest, name)
+        if not text:
+            continue
+        report.require(
+            mark in text,
+            f"the file staged as {name} does not read as one: it does not "
+            f"contain {mark!r}",
+        )
     text = _material_text(manifest, "README.md")
     if not text:
         return report
@@ -852,15 +900,22 @@ def release_sync(release: Release) -> list[tuple[str, str]]:
     the agreement a tag requires.
     """
 
-    manual = (ROOT / "docs/tenkz/manual2.tex").read_text(encoding="utf-8")
-    changes = (ROOT / "docs/tenkz/CHANGES.md").read_text(encoding="utf-8")
-    tnlog = (ROOT / "docs/tenkz/TNLOG.md").read_text(encoding="utf-8")
+    def text(relative: str) -> str:
+        # The report is the last thing the command prints, after the findings
+        # it exists to report. A missing artifact must not replace them.
+        path = ROOT / relative
+        return path.read_text(encoding="utf-8", errors="replace") if path.is_file() else ""
+
+    manual = text("docs/tenkz/manual2.tex")
+    changes = text("docs/tenkz/CHANGES.md")
+    tnlog = text("docs/tenkz/TNLOG.md")
     dateline = re.search(r"The TNLean project \\quad---\\quad ([^\\]*)\\par", manual)
     event = re.search(r'^version = "([0-9.]+)"', tnlog, re.MULTILINE)
+    heading = changes.splitlines()[0].lstrip("# ").strip() if changes else "absent"
     return [
         ("tex/tenkz/tenkz.sty", f"v{release.version} of {release.date}"),
         ("docs/tenkz/manual2.tex", (dateline.group(1).strip() if dateline else "no date line")),
-        ("docs/tenkz/CHANGES.md", changes.splitlines()[0].lstrip("# ").strip()),
+        ("docs/tenkz/CHANGES.md", heading),
         ("docs/tenkz/TNLOG.md", f"event format {event.group(1)}" if event else "no version"),
     ]
 

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -55,7 +55,7 @@ import tempfile
 import tomllib
 import zipfile
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -65,7 +65,15 @@ ROOT = Path(__file__).resolve().parents[1]
 SOURCE = ROOT / "tex/tenkz"
 ENTRY = SOURCE / "tenkz.sty"
 MATERIAL = ROOT / "docs/tenkz/ctan"
-MANIFEST = MATERIAL / "MANIFEST.toml"
+# The pinned staging tree. An environment variable may name another one, so
+# the contract tests can run the whole command against a manifest that is
+# wrong on purpose without editing a tracked file to do it.
+MANIFEST = Path(
+    os.environ.get("TENKZ_CTAN_MANIFEST") or MATERIAL / "MANIFEST.toml"
+)
+MANIFEST_LABEL = (
+    str(MANIFEST.relative_to(ROOT)) if MANIFEST.is_relative_to(ROOT) else str(MANIFEST)
+)
 DEFAULT_OUT = ROOT / "build/ctan"
 
 PACKAGE = "tenkz"
@@ -77,9 +85,15 @@ PAYLOAD = re.compile(
     r"(?P<date>[0-9]{4})/([0-9]{2})/([0-9]{2}) "
     r"v(?P<version>[0-9]+\.[0-9]+(?:\.[0-9]+)?) "
 )
-INPUT_CALL = re.compile(r"\\input\{([^}]*)\}")
-REQUIRE_CALL = re.compile(r"\\RequirePackage(?:\[[^]]*\])?\{([^}]*)\}")
-LIBRARY_CALL = re.compile(r"\\usetikzlibrary\{([^}]*)\}", re.DOTALL)
+# TeX allows space, and a comment-blanked newline, between a control word and
+# its arguments, so the patterns allow it too: `\RequirePackage {tikz}` is a
+# load, and a closure that missed it would let the manifest pin a dependency
+# list the package does not have.
+INPUT_CALL = re.compile(r"\\input\s*\{([^}]*)\}", re.DOTALL)
+REQUIRE_CALL = re.compile(
+    r"\\RequirePackage\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}", re.DOTALL
+)
+LIBRARY_CALL = re.compile(r"\\usetikzlibrary\s*\{([^}]*)\}", re.DOTALL)
 
 # A name CTAN can carry through any file system and any unpacking tool: the
 # invariant ASCII subset, no leading dot or dash, no space.
@@ -97,6 +111,11 @@ DEBRIS_SUFFIXES = frozenset(
 
 # Midnight UTC on 1 January 1980, the earliest moment a zip entry can carry.
 ZIP_EPOCH_FLOOR = 315532800
+
+# The staged names an upload carries whatever else the manifest declares. A
+# manifest that dropped one of these would build an archive without a licence
+# or without a change record, and every check below it would still pass.
+REQUIRED_MATERIAL = ("README.md", "LICENSE", "CHANGES.md", "CITATION.cff", "tenkz.bib")
 
 # The one licence marker every runtime file carries, and the sentence beside
 # it. Both are checked; the identifier is what a machine reads.
@@ -152,6 +171,13 @@ def read_release(entry: Path = ENTRY) -> Release:
             "spelled [YYYY/MM/DD vVERSION description]"
         )
     year, month, day = match.group(1), match.group(2), match.group(3)
+    try:
+        date(int(year), int(month), int(day))
+    except ValueError:
+        raise SystemExit(
+            f"{entry.name} declares {year}/{month}/{day}, which is not a "
+            "calendar date"
+        ) from None
     return Release(version=match["version"], date=f"{year}-{month}-{day}")
 
 
@@ -183,7 +209,10 @@ def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
         if not path.is_file():
             raise SystemExit(f"{entry} loads {name}, which is missing")
         closure.files.append(name)
-        text = strip_comments(path.read_text(encoding="utf-8"))
+        try:
+            text = strip_comments(path.read_bytes().decode("utf-8"))
+        except UnicodeDecodeError as error:
+            raise SystemExit(f"{name} is not UTF-8 and cannot be read: {error}") from None
         for group in REQUIRE_CALL.findall(text):
             packages.extend(part.strip() for part in group.split(",") if part.strip())
         for group in LIBRARY_CALL.findall(text):
@@ -203,9 +232,9 @@ def read_manifest() -> dict:
     try:
         return tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        raise SystemExit(f"{MANIFEST.relative_to(ROOT)} is missing") from None
+        raise SystemExit(f"{MANIFEST_LABEL} is missing") from None
     except tomllib.TOMLDecodeError as error:
-        raise SystemExit(f"{MANIFEST.relative_to(ROOT)} does not parse: {error}") from None
+        raise SystemExit(f"{MANIFEST_LABEL} does not parse: {error}") from None
 
 
 # --------------------------------------------------------------------------
@@ -232,7 +261,7 @@ def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
     collisions = sorted(set(manifest["material"]) & set(closure.files))
     if collisions:
         raise SystemExit(
-            f"{MANIFEST.relative_to(ROOT)} stages material under the runtime "
+            f"{MANIFEST_LABEL} stages material under the runtime "
             f"name(s) {collisions}; the archive would carry a file the closure "
             "and header checks never read"
         )
@@ -241,7 +270,7 @@ def staged_content(manifest: dict, closure: Closure) -> dict[str, Path]:
     refused = check_names(content).failures
     if refused:
         raise SystemExit(
-            f"{MANIFEST.relative_to(ROOT)} names a staged file that will not be "
+            f"{MANIFEST_LABEL} names a staged file that will not be "
             "written: " + "; ".join(refused)
         )
     return content
@@ -362,7 +391,7 @@ def check_closure(closure: Closure, manifest: dict) -> Report:
     report.require(
         closure.files == runtime["files"],
         f"the load graph walked from {ENTRY.name} is {closure.files}, and "
-        f"{MANIFEST.relative_to(ROOT)} pins {runtime['files']}",
+        f"{MANIFEST_LABEL} pins {runtime['files']}",
     )
     report.require(
         closure.packages == runtime["requires"]["packages"],
@@ -400,7 +429,7 @@ def check_source_tree(closure: Closure, manifest: dict, source: Path = SOURCE) -
         report.require(
             entry.name in closure.files,
             f"{entry.name} is not loaded by {ENTRY.name} and is not "
-            f"excluded in {MANIFEST.relative_to(ROOT)}",
+            f"excluded in {MANIFEST_LABEL}",
         )
     return report
 
@@ -409,10 +438,17 @@ def check_material(manifest: dict) -> Report:
     """The reader-facing material an upload must carry, and what it must say."""
 
     report = Report("material")
-    for name, relative in manifest["material"].items():
+    declared = manifest["material"]
+    for name in REQUIRED_MATERIAL:
+        report.require(
+            name in declared,
+            f"{MANIFEST_LABEL} stages no {name}, which every upload "
+            "must carry",
+        )
+    for name, relative in declared.items():
         source = ROOT / relative
         report.require(source.is_file(), f"{relative} is declared and missing")
-    readme = ROOT / manifest["material"]["README.md"]
+    readme = ROOT / declared.get("README.md", "docs/tenkz/ctan/README.md")
     if not readme.is_file():
         return report
     text = readme.read_text(encoding="utf-8")
@@ -431,6 +467,9 @@ def check_encoding(content: dict[str, Path]) -> Report:
 
     report = Report("encoding")
     for name, source in content.items():
+        if not source.is_file():
+            report.failures.append(f"{name} is declared and missing")
+            continue
         raw = source.read_bytes()
         report.require(
             not raw.startswith(b"\xef\xbb\xbf"),
@@ -773,13 +812,25 @@ def command_check(require_smoke: bool, keep: Path | None) -> int:
     content = staged_content(manifest, closure)
     reports.append(check_encoding(content))
     reports.append(check_names(content))
-    with tempfile.TemporaryDirectory(prefix="tenkz-ctan-check-") as directory:
-        destination = keep if keep is not None else Path(directory) / "out"
-        archive, _, digest = build(destination)
-        reports.append(check_permissions(destination / PACKAGE))
-        reports.append(check_debris(destination / PACKAGE))
-        reports.append(check_determinism(release))
-        reports.append(check_smoke(archive, require_smoke))
+    # Nothing below this line can run against a file that is not there, and a
+    # traceback would replace the report naming the file. The checks that need
+    # a built tree report themselves skipped instead, and the missing file is
+    # already a failure of its own.
+    absent = sorted(name for name, source in content.items() if not source.is_file())
+    digest = ""
+    if absent:
+        for name in ("permissions", "debris", "determinism", "clean-install"):
+            skipped = Report(name)
+            skipped.skipped = f"{len(absent)} declared file(s) missing: {absent}"
+            reports.append(skipped)
+    else:
+        with tempfile.TemporaryDirectory(prefix="tenkz-ctan-check-") as directory:
+            destination = keep if keep is not None else Path(directory) / "out"
+            archive, _, digest = build(destination)
+            reports.append(check_permissions(destination / PACKAGE))
+            reports.append(check_debris(destination / PACKAGE))
+            reports.append(check_determinism(release))
+            reports.append(check_smoke(archive, require_smoke))
     for report in reports:
         print(f"  {report.status:4s} {report.name}")
         for note in report.notes:

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -89,6 +89,9 @@ DEBRIS_SUFFIXES = frozenset(
     }
 )
 
+# Midnight UTC on 1 January 1980, the earliest moment a zip entry can carry.
+ZIP_EPOCH_FLOOR = 315532800
+
 # The one licence marker every runtime file carries, and the sentence beside
 # it. Both are checked; the identifier is what a machine reads.
 LICENSE_MARKER = "% SPDX-License-Identifier: Apache-2.0"
@@ -282,12 +285,17 @@ def build(destination: Path) -> tuple[Path, Release, str]:
 
 
 def chosen_epoch(release: Release) -> int:
-    """`SOURCE_DATE_EPOCH` when the environment sets it, the package date else."""
+    """`SOURCE_DATE_EPOCH` when the environment sets it, the package date else.
+
+    A zip entry cannot carry a date before 1980, and `0` is a common value for
+    the environment variable, so an earlier moment is raised to the format's
+    floor rather than crashing the build. The staged tree is raised with it:
+    one moment stamps both, or the tree and the archive would disagree.
+    """
 
     value = os.environ.get("SOURCE_DATE_EPOCH")
-    if value:
-        return int(value)
-    return release.epoch
+    chosen = int(value) if value else release.epoch
+    return max(chosen, ZIP_EPOCH_FLOOR)
 
 
 # --------------------------------------------------------------------------
@@ -425,7 +433,7 @@ def check_permissions(tree: Path) -> Report:
     """One mode for files, one for directories, whatever the builder's mask."""
 
     report = Report("permissions")
-    for path in sorted(tree.rglob("*")):
+    for path in [tree, *sorted(tree.rglob("*"))]:
         expected = 0o755 if path.is_dir() else 0o644
         mode = path.stat().st_mode & 0o777
         report.require(
@@ -466,18 +474,30 @@ def check_headers(closure: Closure, source: Path = SOURCE) -> Report:
     return report
 
 
+def _material_text(manifest: dict, name: str) -> str:
+    """The staged material's text, or nothing when the file is absent.
+
+    An absent file is the material check's finding to report. Reading it here
+    would raise before any check printed its line, which turns a named missing
+    file into a traceback.
+    """
+
+    path = ROOT / manifest["material"][name]
+    return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+
 def check_version(release: Release, manifest: dict) -> Report:
     """One declaration, and every other record checked against it."""
 
     report = Report("version")
-    readme = (ROOT / manifest["material"]["README.md"]).read_text(encoding="utf-8")
+    readme = _material_text(manifest, "README.md")
     stated = f"Version {release.version}, released {release.date}."
     report.require(
         stated in readme,
         f"the CTAN README must state {stated!r}, the version declared by "
         f"{ENTRY.relative_to(ROOT)}",
     )
-    citation = (ROOT / manifest["material"]["CITATION.cff"]).read_text(encoding="utf-8")
+    citation = _material_text(manifest, "CITATION.cff")
     report.require(
         f'version: "{release.version}"' in citation,
         f"the citation record must state version {release.version}",
@@ -486,10 +506,19 @@ def check_version(release: Release, manifest: dict) -> Report:
         f'date-released: "{release.date}"' in citation,
         f"the citation record must state date-released {release.date}",
     )
-    bibliography = (ROOT / manifest["material"]["tenkz.bib"]).read_text(encoding="utf-8")
+    bibliography = _material_text(manifest, "tenkz.bib")
+    year, month, _ = release.date.split("-")
     report.require(
         f"version {release.version}" in bibliography,
         f"the BibTeX record must state version {release.version}",
+    )
+    report.require(
+        re.search(rf"year\s*=\s*\{{{year}\}}", bibliography) is not None,
+        f"the BibTeX record must state year {year}",
+    )
+    report.require(
+        re.search(rf"month\s*=\s*\{{{int(month)}\}}", bibliography) is not None,
+        f"the BibTeX record must state month {int(month)}",
     )
     report.notes.append(f"{release.archive_stem}.zip from v{release.version} of {release.date}")
     return report
@@ -532,13 +561,42 @@ def check_determinism(release: Release) -> Report:
     return report
 
 
-def check_smoke(archive: Path, required: bool) -> Report:
-    """Unpack the archive alone and compile a document against it.
+def resolved_runtime_files(record: Path) -> list[str]:
+    """The runtime files the engine actually opened, from its input record.
 
-    The search path names the unpacked directory and then the installation,
-    so a runtime file the archive forgot is a failed run rather than a silent
-    fall-back to the repository copy.
+    The search path ends in an empty element, which is what restores the
+    installation's own directories after the unpacked archive — an author who
+    installs the package still needs `tikz`, `hobby`, and `spath3`. That same
+    rule means a machine with an older tenkz installed could answer a file the
+    archive forgot, and the run would pass while proving nothing. So the
+    engine is asked to record every file it opened, and the record, not the
+    exit status, says where the runtime came from.
     """
+
+    opened: list[str] = []
+    for line in record.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.startswith("INPUT "):
+            continue
+        path = line[len("INPUT "):].strip()
+        if Path(path).name.startswith(PACKAGE):
+            opened.append(path)
+    return opened
+
+
+def foreign_runtime_files(opened: list[str], room: Path, unpacked: Path) -> list[str]:
+    """Those of the opened files that came from somewhere else.
+
+    A record line may name a path relative to the directory the engine ran in,
+    so the room is the base against which a name is resolved.
+    """
+
+    return [
+        path for path in opened if not (room / path).resolve().is_relative_to(unpacked)
+    ]
+
+
+def check_smoke(archive: Path, required: bool) -> Report:
+    """Unpack the archive alone and compile a document against it."""
 
     report = Report("clean-install")
     if shutil.which("xelatex") is None:
@@ -551,25 +609,61 @@ def check_smoke(archive: Path, required: bool) -> Report:
         room = Path(directory)
         with zipfile.ZipFile(archive) as bundle:
             bundle.extractall(room)
+        unpacked = (room / PACKAGE).resolve()
         document = room / "smoke.tex"
         document.write_text(SMOKE_DOCUMENT, encoding="utf-8")
         environment = dict(os.environ)
-        environment["TEXINPUTS"] = f"{room / PACKAGE}//:"
+        environment["TEXINPUTS"] = f"{unpacked}//:"
         environment["TEXMFOUTPUT"] = str(room)
-        finished = subprocess.run(
-            ["xelatex", "-interaction=nonstopmode", "-halt-on-error", "smoke.tex"],
-            cwd=room,
-            env=environment,
-            capture_output=True,
-            text=True,
-        )
-        if finished.returncode != 0:
-            tail = "\n".join(finished.stdout.splitlines()[-25:])
-            report.failures.append(
-                f"a document using only the unpacked archive failed to compile:\n{tail}"
+        try:
+            finished = subprocess.run(
+                [
+                    "xelatex",
+                    "-interaction=nonstopmode",
+                    "-halt-on-error",
+                    "-recorder",
+                    "smoke.tex",
+                ],
+                cwd=room,
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=120,
             )
-        else:
-            report.notes.append("a two-cell picture compiled from the unpacked archive")
+        except subprocess.TimeoutExpired:
+            report.failures.append(
+                "a document using only the unpacked archive did not finish "
+                "compiling within 120 seconds"
+            )
+            return report
+        if finished.returncode != 0:
+            tail = "\n".join(
+                (finished.stdout + finished.stderr).splitlines()[-25:]
+            )
+            report.failures.append(
+                "a document using only the unpacked archive failed to compile, "
+                f"exit {finished.returncode}:\n{tail}"
+            )
+            return report
+        record = room / "smoke.fls"
+        if not record.is_file():
+            report.failures.append("the engine wrote no input record to read")
+            return report
+        opened = resolved_runtime_files(record)
+        strangers = foreign_runtime_files(opened, room, unpacked)
+        report.require(
+            opened, "the run opened no tenkz file, so it proved nothing"
+        )
+        report.require(
+            not strangers,
+            "the run resolved runtime files outside the unpacked archive, so an "
+            f"installed copy answered for it: {sorted(set(strangers))}",
+        )
+        if not report.failures:
+            report.notes.append(
+                f"a two-cell picture compiled from the unpacked archive, "
+                f"reading {len(set(opened))} of its files and no other tenkz file"
+            )
     return report
 
 

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -178,14 +178,21 @@ def test_the_version_comes_from_one_declaration_or_from_none() -> None:
 
 
 def test_a_manifest_that_would_write_the_wrong_file_is_refused() -> None:
+    """The write path stops on an unwritable name; the report names it and
+    keeps going, and both readings come from the one check."""
+
     closure = tenkz_ctan.walk_closure()
     for material, fragment in (
         ({"tenkz.sty": "LICENSE"}, "runtime name"),
         ({"../outside.md": "LICENSE"}, "will not be written"),
         ({"README.md": "LICENSE", "readme.md": "LICENSE"}, "differ only in case"),
     ):
+        manifest = {"material": material}
+        content = tenkz_ctan.staged_content(manifest, closure)
+        report = tenkz_ctan.check_names(content, manifest, closure)
+        assert report.failures, material
         try:
-            tenkz_ctan.staged_content({"material": material}, closure)
+            tenkz_ctan.require_writable_names(manifest, closure, content)
         except SystemExit as refusal:
             assert fragment in str(refusal), (material, str(refusal))
         else:
@@ -282,13 +289,16 @@ def test_the_archive_is_a_function_of_the_files_it_carries() -> None:
 
 
 def test_staging_ignores_the_builders_file_creation_mask() -> None:
+    release = tenkz_ctan.Release(version="0.7", date="2026-07-22")
     with tempfile.TemporaryDirectory() as directory:
         room = Path(directory)
         subject = room / "tenkz.sty"
         subject.write_text("% one\n", encoding="utf-8")
         previous = os.umask(0o077)
         try:
-            tree = tenkz_ctan.stage(room / "out", 1000000, {"tenkz.sty": subject})
+            tree = tenkz_ctan.stage(
+                room / "out", release, 1000000, {"tenkz.sty": subject}
+            )
         finally:
             os.umask(previous)
         assert (tree / "tenkz.sty").stat().st_mode & 0o777 == 0o644
@@ -409,25 +419,45 @@ def test_the_staged_tree_carries_no_compilation_leftovers() -> None:
 
 
 def test_an_output_directory_loses_only_this_tools_artifacts() -> None:
+    release = tenkz_ctan.read_release()
     with tempfile.TemporaryDirectory() as directory:
         out = Path(directory) / "out"
         out.mkdir()
         (out / PACKAGE_DIR).mkdir()
-        (out / "tenkz-0.7.zip").write_text("old\n", encoding="utf-8")
-        tenkz_ctan.clear_destination(out)
+        (out / f"{release.archive_stem}.zip").write_text("old\n", encoding="utf-8")
+        tenkz_ctan.clear_destination(out, release)
         assert list(out.iterdir()) == []
 
         (out / "somebody-elses-notes.txt").write_text("keep me\n", encoding="utf-8")
         try:
-            tenkz_ctan.clear_destination(out)
+            tenkz_ctan.clear_destination(out, release)
         except SystemExit as refusal:
             assert "somebody-elses-notes.txt" in str(refusal), str(refusal)
         else:
             raise AssertionError("a directory this tool does not own was emptied")
         assert (out / "somebody-elses-notes.txt").is_file()
 
+        # An archive of another release, and a plain file wearing the staged
+        # tree's name: both are somebody else's, whatever they are called.
+        (out / "somebody-elses-notes.txt").unlink()
+        (out / "tenkz-0.1.zip").write_text("an older release\n", encoding="utf-8")
+        try:
+            tenkz_ctan.clear_destination(out, release)
+        except SystemExit as refusal:
+            assert "tenkz-0.1.zip" in str(refusal), str(refusal)
+        else:
+            raise AssertionError("an archive this run does not write was removed")
+        (out / "tenkz-0.1.zip").unlink()
+        (out / PACKAGE_DIR).write_text("not the staged tree\n", encoding="utf-8")
+        try:
+            tenkz_ctan.clear_destination(out, release)
+        except SystemExit as refusal:
+            assert PACKAGE_DIR in str(refusal), str(refusal)
+        else:
+            raise AssertionError("a file wearing the tree's name was removed")
+
     try:
-        tenkz_ctan.clear_destination(ROOT)
+        tenkz_ctan.clear_destination(ROOT, release)
     except SystemExit as refusal:
         assert "is not an output directory" in str(refusal), str(refusal)
     else:
@@ -436,12 +466,94 @@ def test_an_output_directory_loses_only_this_tools_artifacts() -> None:
     # `tex/` holds a directory called `tenkz`, and it is the package's own
     # sources. Recognizing artifacts by name cannot be the only guard.
     try:
-        tenkz_ctan.clear_destination(ROOT / "tex")
+        tenkz_ctan.clear_destination(ROOT / "tex", release)
     except SystemExit as refusal:
         assert "outside build/" in str(refusal), str(refusal)
     else:
         raise AssertionError("the source directory was accepted as an output directory")
     assert (ROOT / "tex/tenkz/tenkz.sty").is_file()
+
+
+def _without_table(manifest: str, table: str) -> str:
+    """The manifest with one table and its sub-tables taken out."""
+
+    kept: list[str] = []
+    dropping = False
+    for line in manifest.splitlines(keepends=True):
+        header = line.strip()
+        if header.startswith("["):
+            dropping = header == f"[{table}]" or header.startswith(f"[{table}.")
+        if not dropping:
+            kept.append(line)
+    return "".join(kept)
+
+
+def test_a_manifest_without_its_tables_is_named_rather_than_raised() -> None:
+    """A parseable manifest that is not a staging manifest says which table it
+    is missing, instead of failing as a key error inside whichever check
+    reached it first."""
+
+    original = (ROOT / "docs/tenkz/ctan/MANIFEST.toml").read_text(encoding="utf-8")
+    for table, fragment in (
+        ("runtime", "no [runtime] table"),
+        ("material", "no [material] table"),
+        ("source_tree", "no [source_tree] table"),
+    ):
+        with tempfile.TemporaryDirectory() as directory:
+            broken = Path(directory) / "MANIFEST.toml"
+            broken.write_text(_without_table(original, table), encoding="utf-8")
+            completed = subprocess.run(
+                [sys.executable, str(ROOT / "scripts/tenkz_ctan.py"), "check"],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "TENKZ_CTAN_MANIFEST": str(broken)},
+            )
+        assert completed.returncode != 0, table
+        assert fragment in completed.stdout + completed.stderr, (
+            table,
+            completed.stdout,
+            completed.stderr,
+        )
+
+
+def test_a_record_stating_its_version_twice_fails() -> None:
+    """A release edit that leaves the previous line standing beside the new one
+    has stated two versions, and a citation record states one."""
+
+    manifest = tenkz_ctan.read_manifest()
+    release = tenkz_ctan.read_release()
+    citation = ROOT / manifest["material"]["CITATION.cff"]
+    original = citation.read_text(encoding="utf-8")
+    stale = original.replace(
+        f'version: "{release.version}"',
+        f'version: "0.1"\nversion: "{release.version}"',
+        1,
+    )
+    try:
+        citation.write_text(stale, encoding="utf-8")
+        failures = tenkz_ctan.check_version(release, manifest).failures
+    finally:
+        citation.write_text(original, encoding="utf-8")
+    assert any("once" in reason for reason in failures), failures
+
+
+def test_a_commented_version_does_not_answer_for_the_record() -> None:
+    """A BibTeX comment holding the right year beside a live field holding the
+    wrong one is a stale record, and it reads as one."""
+
+    manifest = tenkz_ctan.read_manifest()
+    release = tenkz_ctan.read_release()
+    bibliography = ROOT / manifest["material"]["tenkz.bib"]
+    original = bibliography.read_text(encoding="utf-8")
+    year = release.date.split("-")[0]
+    stale = original.replace(f"year         = {{{year}}}", "year         = {1999}")
+    stale = f"% year = {{{year}}}, version {release.version}\n" + stale
+    try:
+        bibliography.write_text(stale, encoding="utf-8")
+        failures = tenkz_ctan.check_version(release, manifest).failures
+    finally:
+        bibliography.write_text(original, encoding="utf-8")
+    assert any(f"year {year}" in reason for reason in failures), failures
 
 
 def test_a_material_name_pointed_at_the_wrong_file_is_reported() -> None:
@@ -494,10 +606,10 @@ def test_material_from_outside_the_repository_is_refused() -> None:
 
 def test_the_write_path_refuses_incomplete_material() -> None:
     manifest = tenkz_ctan.read_manifest()
-    tenkz_ctan.require_complete_material(manifest)
+    tenkz_ctan.require_sound_material(manifest)
     thinned = {"material": {k: v for k, v in manifest["material"].items() if k != "LICENSE"}}
     try:
-        tenkz_ctan.require_complete_material(thinned)
+        tenkz_ctan.require_sound_material(thinned)
     except SystemExit as refusal:
         assert "LICENSE" in str(refusal), str(refusal)
     else:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Contract tests for the CTAN staging tree and its checks.
+
+Each test seeds the defect the corresponding check exists to catch, so a
+check that stopped catching it fails here rather than passing quietly at a
+release. The end-to-end run against the real tree is the last test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/tenkz_ctan.py"
+
+sys.path.insert(0, str(ROOT / "scripts"))
+import tenkz_ctan  # noqa: E402
+
+
+STAGE_CONTRACT = (
+    "% Input: nothing\n"
+    "% Output: nothing\n"
+    "% Owned state: none\n"
+    "% Invariants: none\n"
+    "% Next stage: none\n"
+    "% SPDX-License-Identifier: Apache-2.0\n"
+    "% Copyright the TNLean project; see LICENSE for the full terms.\n"
+)
+
+
+def fake_source(room: Path) -> Path:
+    """A source directory shaped like `tex/tenkz`, with a two-stage load graph."""
+
+    source = room / "tex"
+    source.mkdir(parents=True)
+    (source / "tenkz.sty").write_text(
+        STAGE_CONTRACT
+        + "\\ProvidesPackage{tenkz}[2026/07/22 v0.7 Declarative diagrams]\n"
+        "\\RequirePackage{tikz}\n"
+        "\\usetikzlibrary{calc,\n  hobby}\n"
+        "% \\input{tenkz-tombstone.code.tex}\n"
+        "\\input{tenkz-stage.code.tex}\n",
+        encoding="utf-8",
+    )
+    (source / "tenkz-stage.code.tex").write_text(
+        STAGE_CONTRACT + "\\input{tenkz-leaf.code.tex}\n", encoding="utf-8"
+    )
+    (source / "tenkz-leaf.code.tex").write_text(STAGE_CONTRACT, encoding="utf-8")
+    return source
+
+
+def test_closure_reads_the_load_graph_and_not_the_prose() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        source = fake_source(Path(directory))
+        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+    assert closure.files == [
+        "tenkz.sty",
+        "tenkz-stage.code.tex",
+        "tenkz-leaf.code.tex",
+    ], closure.files
+    assert closure.packages == ["tikz"]
+    assert closure.libraries == ["calc", "hobby"], closure.libraries
+
+
+def test_closure_agrees_with_the_pinned_manifest() -> None:
+    report = tenkz_ctan.check_closure(
+        tenkz_ctan.walk_closure(), tenkz_ctan.read_manifest()
+    )
+    assert not report.failures, report.failures
+
+
+def test_a_source_file_outside_the_load_graph_fails_the_check() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        source = fake_source(Path(directory))
+        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+        manifest = {"source_tree": {"excluded": []}}
+        assert not tenkz_ctan.check_source_tree(closure, manifest, source).failures
+        (source / "tenkz-orphan.code.tex").write_text("% nothing\n", encoding="utf-8")
+        (source / "tenkz.log").write_text("a compilation leftover\n", encoding="utf-8")
+        failures = tenkz_ctan.check_source_tree(closure, manifest, source).failures
+    assert any("tenkz-orphan.code.tex" in reason for reason in failures), failures
+    assert any("leftover" in reason for reason in failures), failures
+
+
+def test_an_unlicensed_runtime_file_fails_the_header_audit() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        source = fake_source(Path(directory))
+        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+        assert not tenkz_ctan.check_headers(closure, source).failures
+        stripped = (source / "tenkz-leaf.code.tex").read_text(encoding="utf-8")
+        (source / "tenkz-leaf.code.tex").write_text(
+            stripped.replace(tenkz_ctan.LICENSE_MARKER, "% none of your business"),
+            encoding="utf-8",
+        )
+        failures = tenkz_ctan.check_headers(closure, source).failures
+    assert any("tenkz-leaf.code.tex" in reason for reason in failures), failures
+
+
+def test_the_version_comes_from_one_declaration_or_from_none() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        entry = Path(directory) / "tenkz.sty"
+        entry.write_text(
+            "\\ProvidesPackage{tenkz}[2026/07/22 v0.7 Declarative diagrams]\n",
+            encoding="utf-8",
+        )
+        release = tenkz_ctan.read_release(entry)
+        assert (release.version, release.date) == ("0.7", "2026-07-22")
+        assert release.archive_stem == "tenkz-0.7"
+
+        entry.write_text(
+            "\\ProvidesPackage{tenkz}[2026/07/22 v0.7 One]\n"
+            "\\ProvidesPackage{tenkz}[2026/07/23 v0.8 Two]\n",
+            encoding="utf-8",
+        )
+        assert _refuses(entry, "exactly one")
+
+        entry.write_text("\\ProvidesPackage{tenkz}[whenever v0.7]\n", encoding="utf-8")
+        assert _refuses(entry, "not\nspelled".replace("\n", " "))
+
+
+def _refuses(entry: Path, fragment: str) -> bool:
+    try:
+        tenkz_ctan.read_release(entry)
+    except SystemExit as refusal:
+        return fragment in str(refusal)
+    return False
+
+
+def test_a_stated_version_other_than_the_declared_one_fails() -> None:
+    manifest = tenkz_ctan.read_manifest()
+    assert not tenkz_ctan.check_version(tenkz_ctan.read_release(), manifest).failures
+    invented = tenkz_ctan.Release(version="9.9", date="1999-01-01")
+    failures = tenkz_ctan.check_version(invented, manifest).failures
+    assert len(failures) == 4, failures
+
+
+def test_the_archive_is_a_function_of_the_files_it_carries() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        room = Path(directory)
+        subject = room / "tenkz.sty"
+        subject.write_text("% one\n", encoding="utf-8")
+        release = tenkz_ctan.Release(version="0.7", date="2026-07-22")
+        digests = []
+        for label in ("first", "second"):
+            destination = room / label
+            destination.mkdir()
+            archive = tenkz_ctan.write_archive(
+                destination, release, release.epoch, {"tenkz.sty": subject}
+            )
+            digests.append(archive.read_bytes())
+        assert digests[0] == digests[1]
+
+        subject.write_text("% two\n", encoding="utf-8")
+        destination = room / "third"
+        destination.mkdir()
+        changed = tenkz_ctan.write_archive(
+            destination, release, release.epoch, {"tenkz.sty": subject}
+        )
+        assert changed.read_bytes() != digests[0]
+
+
+def test_staging_ignores_the_builders_file_creation_mask() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        room = Path(directory)
+        subject = room / "tenkz.sty"
+        subject.write_text("% one\n", encoding="utf-8")
+        previous = os.umask(0o077)
+        try:
+            tree = tenkz_ctan.stage(room / "out", 1000000, {"tenkz.sty": subject})
+        finally:
+            os.umask(previous)
+        assert (tree / "tenkz.sty").stat().st_mode & 0o777 == 0o644
+        assert tree.stat().st_mode & 0o777 == 0o755
+        assert (tree / "tenkz.sty").stat().st_mtime == 1000000
+
+
+def test_the_environment_may_fix_the_timestamp() -> None:
+    release = tenkz_ctan.Release(version="0.7", date="2026-07-22")
+    previous = os.environ.get("SOURCE_DATE_EPOCH")
+    os.environ["SOURCE_DATE_EPOCH"] = "1600000000"
+    try:
+        assert tenkz_ctan.chosen_epoch(release) == 1600000000
+    finally:
+        if previous is None:
+            del os.environ["SOURCE_DATE_EPOCH"]
+        else:
+            os.environ["SOURCE_DATE_EPOCH"] = previous
+    assert tenkz_ctan.chosen_epoch(release) == release.epoch
+
+
+def test_names_outside_the_invariant_subset_fail() -> None:
+    accidental = Path("/dev/null")
+    report = tenkz_ctan.check_names(
+        {
+            "tenkz.sty": accidental,
+            "tenkz-café.tex": accidental,
+            "-tenkz.tex": accidental,
+            "TENKZ.STY": accidental,
+        }
+    )
+    assert len(report.failures) == 3, report.failures
+    assert any("café" in reason for reason in report.failures)
+    assert any("differ only in case" in reason for reason in report.failures)
+
+
+def test_the_staged_tree_carries_no_compilation_leftovers() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        tree = Path(directory) / "tenkz"
+        tree.mkdir()
+        (tree / "tenkz.sty").write_text("% one\n", encoding="utf-8")
+        assert not tenkz_ctan.check_debris(tree).failures
+        (tree / "tenkz.log").write_text("a compilation leftover\n", encoding="utf-8")
+        failures = tenkz_ctan.check_debris(tree).failures
+    assert any("would ship" in reason for reason in failures), failures
+
+
+def test_check_passes_now() -> None:
+    subprocess.run([sys.executable, str(SCRIPT), "check"], check=True)
+
+
+if __name__ == "__main__":
+    for name, test in sorted(globals().items()):
+        if name.startswith("test_") and callable(test):
+            test()
+            print(f"PASS {name}")

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/tenkz_ctan.py"
+PACKAGE_DIR = "tenkz"
 
 sys.path.insert(0, str(ROOT / "scripts"))
 import tenkz_ctan  # noqa: E402
@@ -168,6 +169,13 @@ def test_the_version_comes_from_one_declaration_or_from_none() -> None:
         )
         assert _refuses(entry, "is not a calendar date")
 
+        # An empty description, which the release harness's own assertion
+        # rejects; the two gates read the same declaration and must agree.
+        entry.write_text(
+            "\\ProvidesPackage{tenkz}[2026/07/22 v0.7 ]\n", encoding="utf-8"
+        )
+        assert _refuses(entry, "not spelled")
+
 
 def test_a_manifest_that_would_write_the_wrong_file_is_refused() -> None:
     closure = tenkz_ctan.walk_closure()
@@ -303,6 +311,20 @@ def test_the_environment_may_fix_the_timestamp() -> None:
         # reproducibility convention hands out most often.
         os.environ["SOURCE_DATE_EPOCH"] = "0"
         assert tenkz_ctan.chosen_epoch(release) == tenkz_ctan.ZIP_EPOCH_FLOOR
+        # Past the format's ceiling is a mistake, not a convention, so it is
+        # refused rather than clamped; nonsense is refused by its own message.
+        for value, fragment in (
+            ("9999999999", "later than the last moment"),
+            ("not-a-number", "not a number of seconds"),
+        ):
+            os.environ["SOURCE_DATE_EPOCH"] = value
+            try:
+                tenkz_ctan.chosen_epoch(release)
+            except SystemExit as refusal:
+                assert fragment in str(refusal), str(refusal)
+            else:
+                raise AssertionError(f"{value} was accepted")
+        os.environ["SOURCE_DATE_EPOCH"] = "0"
         with tempfile.TemporaryDirectory() as directory:
             room = Path(directory)
             subject = room / "tenkz.sty"
@@ -359,11 +381,16 @@ def test_names_outside_the_invariant_subset_fail() -> None:
             "tenkz-café.tex": accidental,
             "-tenkz.tex": accidental,
             "TENKZ.STY": accidental,
+            "README.": accidental,
+            "NUL": accidental,
+            "com1.tex": accidental,
         }
     )
-    assert len(report.failures) == 3, report.failures
+    assert len(report.failures) == 6, report.failures
     assert any("café" in reason for reason in report.failures)
     assert any("differ only in case" in reason for reason in report.failures)
+    assert any("ends in a dot" in reason for reason in report.failures)
+    assert sum("reserved device name" in reason for reason in report.failures) == 2
 
 
 def test_the_staged_tree_carries_no_compilation_leftovers() -> None:
@@ -375,6 +402,87 @@ def test_the_staged_tree_carries_no_compilation_leftovers() -> None:
         (tree / "tenkz.log").write_text("a compilation leftover\n", encoding="utf-8")
         failures = tenkz_ctan.check_debris(tree).failures
     assert any("would ship" in reason for reason in failures), failures
+
+
+def test_an_output_directory_loses_only_this_tools_artifacts() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        out = Path(directory) / "out"
+        out.mkdir()
+        (out / PACKAGE_DIR).mkdir()
+        (out / "tenkz-0.7.zip").write_text("old\n", encoding="utf-8")
+        tenkz_ctan.clear_destination(out)
+        assert list(out.iterdir()) == []
+
+        (out / "somebody-elses-notes.txt").write_text("keep me\n", encoding="utf-8")
+        try:
+            tenkz_ctan.clear_destination(out)
+        except SystemExit as refusal:
+            assert "somebody-elses-notes.txt" in str(refusal), str(refusal)
+        else:
+            raise AssertionError("a directory this tool does not own was emptied")
+        assert (out / "somebody-elses-notes.txt").is_file()
+
+    try:
+        tenkz_ctan.clear_destination(ROOT)
+    except SystemExit as refusal:
+        assert "is not an output directory" in str(refusal), str(refusal)
+    else:
+        raise AssertionError("the repository was accepted as an output directory")
+
+
+def test_material_from_outside_the_repository_is_refused() -> None:
+    closure = tenkz_ctan.walk_closure()
+    for value in ("/etc/hosts", "../outside-the-tree"):
+        try:
+            tenkz_ctan.staged_content({"material": {"LICENSE": value}}, closure)
+        except SystemExit as refusal:
+            assert "outside the" in str(refusal), str(refusal)
+        else:
+            raise AssertionError(f"{value} was staged")
+
+
+def test_the_write_path_refuses_incomplete_material() -> None:
+    manifest = tenkz_ctan.read_manifest()
+    tenkz_ctan.require_complete_material(manifest)
+    thinned = {"material": {k: v for k, v in manifest["material"].items() if k != "LICENSE"}}
+    try:
+        tenkz_ctan.require_complete_material(thinned)
+    except SystemExit as refusal:
+        assert "LICENSE" in str(refusal), str(refusal)
+    else:
+        raise AssertionError("an archive without a licence was allowed")
+
+
+def test_the_clean_install_failure_paths_report_what_went_wrong() -> None:
+    """The two branches no engine reaches on a healthy tree."""
+
+    class Bounced:
+        returncode = 3
+        stdout = "! LaTeX Error: File `tenkz.sty' not found.\n"
+        stderr = "the engine's own complaint\n"
+
+    with tempfile.TemporaryDirectory() as directory:
+        archive, _, _ = tenkz_ctan.build(Path(directory) / "out")
+        engine = tenkz_ctan.shutil.which
+        runner = tenkz_ctan.subprocess.run
+        try:
+            tenkz_ctan.shutil.which = lambda _name: "/somewhere/xelatex"
+            tenkz_ctan.subprocess.run = lambda *a, **k: Bounced()
+            failed = tenkz_ctan.check_smoke(archive, required=True)
+
+            def expire(*_args, **_kwargs):
+                raise subprocess.TimeoutExpired(cmd="xelatex", timeout=120)
+
+            tenkz_ctan.subprocess.run = expire
+            timed_out = tenkz_ctan.check_smoke(archive, required=True)
+        finally:
+            tenkz_ctan.shutil.which = engine
+            tenkz_ctan.subprocess.run = runner
+    assert any("exit 3" in reason for reason in failed.failures), failed.failures
+    assert any(
+        "the engine's own complaint" in reason for reason in failed.failures
+    ), failed.failures
+    assert any("120 seconds" in reason for reason in timed_out.failures), timed_out.failures
 
 
 def test_check_passes_now() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -456,7 +456,29 @@ def test_a_material_name_pointed_at_the_wrong_file_is_reported() -> None:
         )
     }
     report = tenkz_ctan.check_material(swapped)
-    assert any("staged as LICENSE" in reason for reason in report.failures), report.failures
+    assert any(
+        "LICENSE is staged from" in reason for reason in report.failures
+    ), report.failures
+    assert any(
+        "CHANGES.md is staged from" in reason for reason in report.failures
+    ), report.failures
+
+    # The three recognized by content rather than by canonical path: the
+    # citation record staged from the BibTeX record and back.
+    crossed = {
+        "material": dict(
+            manifest["material"],
+            **{
+                "CITATION.cff": manifest["material"]["tenkz.bib"],
+                "tenkz.bib": manifest["material"]["CITATION.cff"],
+            },
+        )
+    }
+    report = tenkz_ctan.check_material(crossed)
+    assert any(
+        "staged as CITATION.cff does not read as one" in reason
+        for reason in report.failures
+    ), report.failures
 
 
 def test_material_from_outside_the_repository_is_refused() -> None:
@@ -480,6 +502,23 @@ def test_the_write_path_refuses_incomplete_material() -> None:
         assert "LICENSE" in str(refusal), str(refusal)
     else:
         raise AssertionError("an archive without a licence was allowed")
+
+    # Both writing commands, not only the reporting one.
+    good = (ROOT / "docs/tenkz/ctan/MANIFEST.toml").read_text(encoding="utf-8")
+    without = good.replace('"LICENSE" = "LICENSE"\n', "")
+    assert without != good
+    with tempfile.TemporaryDirectory() as directory:
+        broken = Path(directory) / "MANIFEST.toml"
+        broken.write_text(without, encoding="utf-8")
+        for command in ("stage", "archive"):
+            finished = subprocess.run(
+                [sys.executable, str(SCRIPT), command, "--out", f"{directory}/out"],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "TENKZ_CTAN_MANIFEST": str(broken)},
+            )
+            assert finished.returncode != 0, (command, finished.stdout)
+            assert "LICENSE" in finished.stderr, (command, finished.stderr)
 
 
 def test_the_clean_install_failure_paths_report_what_went_wrong() -> None:
@@ -512,6 +551,38 @@ def test_the_clean_install_failure_paths_report_what_went_wrong() -> None:
         "the engine's own complaint" in reason for reason in failed.failures
     ), failed.failures
     assert any("120 seconds" in reason for reason in timed_out.failures), timed_out.failures
+
+
+def test_the_manifest_declares_the_schema_and_the_package() -> None:
+    good = (ROOT / "docs/tenkz/ctan/MANIFEST.toml").read_text(encoding="utf-8")
+    for edit, fragment in (
+        (("schema = 1", "schema = 999"), "this tool reads schema 1"),
+        (('package = "tenkz"', 'package = "not-tenkz"'), "not 'tenkz'"),
+    ):
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "MANIFEST.toml"
+            manifest.write_text(good.replace(*edit), encoding="utf-8")
+            finished = subprocess.run(
+                [sys.executable, str(SCRIPT), "check"],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "TENKZ_CTAN_MANIFEST": str(manifest)},
+            )
+        assert finished.returncode != 0, finished.stdout
+        assert "Traceback" not in finished.stderr, finished.stderr
+        assert fragment in finished.stderr, finished.stderr
+
+
+def test_a_runtime_source_outside_the_repository_is_refused() -> None:
+    try:
+        tenkz_ctan.inside_repository("tenkz.sty", Path("/etc/hosts"))
+    except SystemExit as refusal:
+        assert "outside the repository" in str(refusal), str(refusal)
+    else:
+        raise AssertionError("a source outside the tree was staged")
+    assert tenkz_ctan.inside_repository(
+        "tenkz.sty", ROOT / "tex/tenkz/tenkz.sty"
+    ) == (ROOT / "tex/tenkz/tenkz.sty").resolve()
 
 
 def test_the_release_report_survives_an_absent_artifact() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -133,9 +133,23 @@ def _refuses(entry: Path, fragment: str) -> bool:
 def test_a_stated_version_other_than_the_declared_one_fails() -> None:
     manifest = tenkz_ctan.read_manifest()
     assert not tenkz_ctan.check_version(tenkz_ctan.read_release(), manifest).failures
-    invented = tenkz_ctan.Release(version="9.9", date="1999-01-01")
+    invented = tenkz_ctan.Release(version="9.9", date="1999-02-01")
     failures = tenkz_ctan.check_version(invented, manifest).failures
-    assert len(failures) == 4, failures
+    assert len(failures) == 6, failures
+    assert any("year 1999" in reason for reason in failures), failures
+    assert any("month 2" in reason for reason in failures), failures
+
+
+def test_absent_material_is_reported_rather_than_raised() -> None:
+    manifest = {
+        "material": {
+            "README.md": "docs/tenkz/ctan/nothing-here.md",
+            "CITATION.cff": "docs/tenkz/ctan/nothing-here.cff",
+            "tenkz.bib": "docs/tenkz/ctan/nothing-here.bib",
+        }
+    }
+    report = tenkz_ctan.check_version(tenkz_ctan.read_release(), manifest)
+    assert len(report.failures) == 6, report.failures
 
 
 def test_the_archive_is_a_function_of_the_files_it_carries() -> None:
@@ -176,20 +190,69 @@ def test_staging_ignores_the_builders_file_creation_mask() -> None:
         assert (tree / "tenkz.sty").stat().st_mode & 0o777 == 0o644
         assert tree.stat().st_mode & 0o777 == 0o755
         assert (tree / "tenkz.sty").stat().st_mtime == 1000000
+        assert not tenkz_ctan.check_permissions(tree).failures
+        tree.chmod(0o700)
+        failures = tenkz_ctan.check_permissions(tree).failures
+        tree.chmod(0o755)
+    assert any("700" in reason for reason in failures), failures
 
 
 def test_the_environment_may_fix_the_timestamp() -> None:
     release = tenkz_ctan.Release(version="0.7", date="2026-07-22")
     previous = os.environ.get("SOURCE_DATE_EPOCH")
-    os.environ["SOURCE_DATE_EPOCH"] = "1600000000"
     try:
+        os.environ["SOURCE_DATE_EPOCH"] = "1600000000"
         assert tenkz_ctan.chosen_epoch(release) == 1600000000
+        # A zip entry carries no date before 1980, and 0 is the value the
+        # reproducibility convention hands out most often.
+        os.environ["SOURCE_DATE_EPOCH"] = "0"
+        assert tenkz_ctan.chosen_epoch(release) == tenkz_ctan.ZIP_EPOCH_FLOOR
+        with tempfile.TemporaryDirectory() as directory:
+            room = Path(directory)
+            subject = room / "tenkz.sty"
+            subject.write_text("% one\n", encoding="utf-8")
+            archive = tenkz_ctan.write_archive(
+                room, release, tenkz_ctan.chosen_epoch(release), {"tenkz.sty": subject}
+            )
+            assert archive.is_file()
     finally:
         if previous is None:
             del os.environ["SOURCE_DATE_EPOCH"]
         else:
             os.environ["SOURCE_DATE_EPOCH"] = previous
     assert tenkz_ctan.chosen_epoch(release) == release.epoch
+
+
+def test_the_clean_install_check_reads_where_the_runtime_came_from() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        record = Path(directory) / "smoke.fls"
+        record.write_text(
+            "PWD /work\n"
+            "INPUT /work/tenkz/tenkz.sty\n"
+            "INPUT /usr/share/texmf/tex/latex/tikz/tikz.sty\n"
+            "INPUT tenkz/tenkz-render.code.tex\n"
+            "OUTPUT /work/smoke.pdf\n",
+            encoding="utf-8",
+        )
+        opened = tenkz_ctan.resolved_runtime_files(record)
+    assert opened == ["/work/tenkz/tenkz.sty", "tenkz/tenkz-render.code.tex"], opened
+
+    with tempfile.TemporaryDirectory() as directory:
+        room = Path(directory).resolve()
+        unpacked = room / "tenkz"
+        unpacked.mkdir()
+        installed = room / "texmf"
+        installed.mkdir()
+        strangers = tenkz_ctan.foreign_runtime_files(
+            [
+                str(unpacked / "tenkz.sty"),
+                "tenkz/tenkz-render.code.tex",
+                str(installed / "tenkz-kernel.code.tex"),
+            ],
+            room,
+            unpacked,
+        )
+    assert strangers == [str(installed / "tenkz-kernel.code.tex")], strangers
 
 
 def test_names_outside_the_invariant_subset_fail() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -307,6 +307,10 @@ def test_the_environment_may_fix_the_timestamp() -> None:
     try:
         os.environ["SOURCE_DATE_EPOCH"] = "1600000000"
         assert tenkz_ctan.chosen_epoch(release) == 1600000000
+        # A zip date counts in two-second steps, so an odd second stamped on
+        # the tree would arrive in the archive as the second before it.
+        os.environ["SOURCE_DATE_EPOCH"] = "1600000001"
+        assert tenkz_ctan.chosen_epoch(release) == 1600000000
         # A zip entry carries no date before 1980, and 0 is the value the
         # reproducibility convention hands out most often.
         os.environ["SOURCE_DATE_EPOCH"] = "0"
@@ -429,6 +433,31 @@ def test_an_output_directory_loses_only_this_tools_artifacts() -> None:
     else:
         raise AssertionError("the repository was accepted as an output directory")
 
+    # `tex/` holds a directory called `tenkz`, and it is the package's own
+    # sources. Recognizing artifacts by name cannot be the only guard.
+    try:
+        tenkz_ctan.clear_destination(ROOT / "tex")
+    except SystemExit as refusal:
+        assert "outside build/" in str(refusal), str(refusal)
+    else:
+        raise AssertionError("the source directory was accepted as an output directory")
+    assert (ROOT / "tex/tenkz/tenkz.sty").is_file()
+
+
+def test_a_material_name_pointed_at_the_wrong_file_is_reported() -> None:
+    manifest = tenkz_ctan.read_manifest()
+    swapped = {
+        "material": dict(
+            manifest["material"],
+            **{
+                "LICENSE": manifest["material"]["CHANGES.md"],
+                "CHANGES.md": manifest["material"]["LICENSE"],
+            },
+        )
+    }
+    report = tenkz_ctan.check_material(swapped)
+    assert any("staged as LICENSE" in reason for reason in report.failures), report.failures
+
 
 def test_material_from_outside_the_repository_is_refused() -> None:
     closure = tenkz_ctan.walk_closure()
@@ -483,6 +512,26 @@ def test_the_clean_install_failure_paths_report_what_went_wrong() -> None:
         "the engine's own complaint" in reason for reason in failed.failures
     ), failed.failures
     assert any("120 seconds" in reason for reason in timed_out.failures), timed_out.failures
+
+
+def test_the_release_report_survives_an_absent_artifact() -> None:
+    """It is printed after the findings, so it must not replace them."""
+
+    release = tenkz_ctan.read_release()
+    root = tenkz_ctan.ROOT
+    try:
+        with tempfile.TemporaryDirectory() as directory:
+            tenkz_ctan.ROOT = Path(directory)
+            rows = tenkz_ctan.release_sync(release)
+    finally:
+        tenkz_ctan.ROOT = root
+    assert [artifact for artifact, _ in rows] == [
+        "tex/tenkz/tenkz.sty",
+        "docs/tenkz/manual2.tex",
+        "docs/tenkz/CHANGES.md",
+        "docs/tenkz/TNLOG.md",
+    ], rows
+    assert dict(rows)["docs/tenkz/CHANGES.md"] == "absent", rows
 
 
 def test_check_passes_now() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -119,7 +119,31 @@ def test_the_version_comes_from_one_declaration_or_from_none() -> None:
         assert _refuses(entry, "exactly one")
 
         entry.write_text("\\ProvidesPackage{tenkz}[whenever v0.7]\n", encoding="utf-8")
-        assert _refuses(entry, "not\nspelled".replace("\n", " "))
+        assert _refuses(entry, "not spelled")
+
+        # A dotted run of digits is not a version. Each of these would
+        # otherwise become an archive name and three citation strings.
+        for typo in ("v1..0", "v1.", "v.1", "v..."):
+            entry.write_text(
+                f"\\ProvidesPackage{{tenkz}}[2026/07/22 {typo} Diagrams]\n",
+                encoding="utf-8",
+            )
+            assert _refuses(entry, "not spelled"), typo
+
+
+def test_a_manifest_that_would_write_the_wrong_file_is_refused() -> None:
+    closure = tenkz_ctan.walk_closure()
+    for material, fragment in (
+        ({"tenkz.sty": "LICENSE"}, "runtime name"),
+        ({"../outside.md": "LICENSE"}, "will not be written"),
+        ({"README.md": "LICENSE", "readme.md": "LICENSE"}, "differ only in case"),
+    ):
+        try:
+            tenkz_ctan.staged_content({"material": material}, closure)
+        except SystemExit as refusal:
+            assert fragment in str(refusal), (material, str(refusal))
+        else:
+            raise AssertionError(f"{material} was staged rather than refused")
 
 
 def _refuses(entry: Path, fragment: str) -> bool:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -66,6 +66,38 @@ def test_closure_reads_the_load_graph_and_not_the_prose() -> None:
     assert closure.libraries == ["calc", "hobby"], closure.libraries
 
 
+def test_closure_reads_tex_spacing_before_arguments() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory) / "tex"
+        source.mkdir()
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT
+            + "\\RequirePackage [draft] {tikz}\n"
+            "\\usetikzlibrary\n  {calc}\n"
+            "\\input % the stage below\n  {tenkz-stage.code.tex}\n",
+            encoding="utf-8",
+        )
+        (source / "tenkz-stage.code.tex").write_text(STAGE_CONTRACT, encoding="utf-8")
+        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+    assert closure.files == ["tenkz.sty", "tenkz-stage.code.tex"], closure.files
+    assert closure.packages == ["tikz"], closure.packages
+    assert closure.libraries == ["calc"], closure.libraries
+
+
+def test_a_runtime_file_that_is_not_utf8_is_refused_by_name() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        source = fake_source(Path(directory))
+        (source / "tenkz-leaf.code.tex").write_bytes(
+            STAGE_CONTRACT.encode("utf-8") + b"% \xff\xfe not text\n"
+        )
+        try:
+            tenkz_ctan.walk_closure(source, "tenkz.sty")
+        except SystemExit as refusal:
+            assert "tenkz-leaf.code.tex is not UTF-8" in str(refusal), str(refusal)
+        else:
+            raise AssertionError("a file that is not UTF-8 was walked")
+
+
 def test_closure_agrees_with_the_pinned_manifest() -> None:
     report = tenkz_ctan.check_closure(
         tenkz_ctan.walk_closure(), tenkz_ctan.read_manifest()
@@ -130,6 +162,12 @@ def test_the_version_comes_from_one_declaration_or_from_none() -> None:
             )
             assert _refuses(entry, "not spelled"), typo
 
+        # A date of the right shape that no calendar has.
+        entry.write_text(
+            "\\ProvidesPackage{tenkz}[2026/02/31 v0.7 Diagrams]\n", encoding="utf-8"
+        )
+        assert _refuses(entry, "is not a calendar date")
+
 
 def test_a_manifest_that_would_write_the_wrong_file_is_refused() -> None:
     closure = tenkz_ctan.walk_closure()
@@ -174,6 +212,40 @@ def test_absent_material_is_reported_rather_than_raised() -> None:
     }
     report = tenkz_ctan.check_version(tenkz_ctan.read_release(), manifest)
     assert len(report.failures) == 6, report.failures
+
+    material = tenkz_ctan.check_material(manifest)
+    assert any("LICENSE" in reason for reason in material.failures), material.failures
+    assert any("CHANGES.md" in reason for reason in material.failures), material.failures
+
+    encoding = tenkz_ctan.check_encoding(
+        {name: ROOT / relative for name, relative in manifest["material"].items()}
+    )
+    assert len(encoding.failures) == 3, encoding.failures
+
+
+def test_the_whole_check_reports_a_missing_file_rather_than_raising() -> None:
+    """The command itself, not one check in isolation: a manifest that names a
+    file which is not there must print its report and exit 1."""
+
+    original = (ROOT / "docs/tenkz/ctan/MANIFEST.toml").read_text(encoding="utf-8")
+    broken = original.replace(
+        '"CITATION.cff" = "docs/tenkz/ctan/CITATION.cff"',
+        '"CITATION.cff" = "docs/tenkz/ctan/nothing-here.cff"',
+    )
+    assert broken != original
+    with tempfile.TemporaryDirectory() as directory:
+        manifest = Path(directory) / "MANIFEST.toml"
+        manifest.write_text(broken, encoding="utf-8")
+        finished = subprocess.run(
+            [sys.executable, str(SCRIPT), "check"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "TENKZ_CTAN_MANIFEST": str(manifest)},
+        )
+    assert finished.returncode == 1, finished.stdout + finished.stderr
+    assert "Traceback" not in finished.stderr, finished.stderr
+    assert "nothing-here.cff is declared and missing" in finished.stdout, finished.stdout
+    assert "SKIP clean-install" in finished.stdout, finished.stdout
 
 
 def test_the_archive_is_a_function_of_the_files_it_carries() -> None:

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -3,6 +3,8 @@
 % Owned state: semantic themes, measurements, and the event writer.
 % Invariants: drawing never parses picture syntax or mutates validated topology.
 % Next stage: dialect front ends translate their syntax into shared services.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 % Metric doctrine: ONE base pitch; every repeated distance is a named ratio
 % of it.  Profiles (compact, inline) are a scale factor applied at the base,

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -3,6 +3,8 @@
 % Owned state: the frame table, the placement request store, and resolved positions.
 % Invariants:  positions resolve topologically or error; nothing here emits ink.
 % Next stage:  rendering turns resolved records into marks on the page.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 % Geometry answers three questions and nothing else.  WHERE: frames map
 % logical addresses to points (one 2x2 matrix plus offset, or a circle of

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -3,6 +3,8 @@
 % Owned state: the chain cursor, the address node table, panel and relation stores.
 % Invariants:  every record is written before validation; addresses parse or error.
 % Next stage:  tenkz-model.code.tex holds the records; geometry resolves the nodes.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 % This file is the language stage of the 1.0 kernel.  The sentence model it
 % implements: a picture draws one typed tensor network in one frame; frames

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -3,6 +3,8 @@
 % Owned state: none; the consumer callbacks own all accumulated registry state.
 % Invariants: one canonical record per concept; aliases are explicitly marked.
 % Next stage: tenkz-language.code.tex installs the declared parser front doors.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 
 \__tenkz_language_registry_environment:nnnn {tenkz}{kernel}{picture}
   {One typed tensor network in one frame.}

--- a/tex/tenkz/tenkz-language.code.tex
+++ b/tex/tenkz/tenkz-language.code.tex
@@ -3,6 +3,8 @@
 % Owned state: registry records, atom descriptors, and language validation state.
 % Invariants: public syntax is normalized before any model or geometry mutation.
 % Next stage: tenkz-model.code.tex receives validated semantic records.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 
 \ExplSyntaxOn
 \seq_new:N \g__tenkz_language_environments_seq

--- a/tex/tenkz/tenkz-metric.code.tex
+++ b/tex/tenkz/tenkz-metric.code.tex
@@ -3,6 +3,8 @@
 % Owned state: the global registry of values, kinds, and motivations.
 % Invariants:  every entry carries a motivation; a name resolves or errors.
 % Next stage:  geometry and rendering measure exclusively through the accessor.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 % The registry is the metric table of LANGUAGE-1.0: one pitch, named ratios,
 % and print-size floors, each with its reason.  No public path accepts a

--- a/tex/tenkz/tenkz-model.code.tex
+++ b/tex/tenkz/tenkz-model.code.tex
@@ -3,6 +3,8 @@
 % Owned state: the record store, class sequences, id counter, and validation phase flag.
 % Invariants: records are normalized before validation; topology is immutable after validation.
 % Next stage: style and geometry resolve metrics and silhouettes from these records.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 % The record classes follow LANGUAGE-1.0.md: PICTURE, ATOM, WIRE, MARK, plus
 % frame records.  Every record is a flat field set stored under "id/field";

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -3,6 +3,8 @@
 % Owned state: none; rendering reads records and draws, remembering nothing.
 % Invariants:  no parsing, no topology, no recovery; label text never rotates.
 % Next stage:  events serialize the same records this stage consumed.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 % RENDER-PRIMITIVE LOCKOUT.  This file is loaded LAST by tenkz.sty, and the
 % ink primitives below are created here with \cs_new.  Load order documents

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -3,6 +3,8 @@
 % Owned state: the string registry and crossing, join, and gap ledgers.
 % Invariants:  declared crossings exist; geometric crossings are declared.
 % Next stage:  tenkz-render draws strings; the language stage supplies records.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 % Curve model.  A string routes through waypoints as a Hobby spline: Hobby's
 % algorithm (the METAFONT curve engine) chooses tangents and curvature

--- a/tex/tenkz/tenkz-tree.code.tex
+++ b/tex/tenkz/tenkz-tree.code.tex
@@ -3,6 +3,8 @@
 % Owned state: the parse stack, vertex topology, skin choice, and tree ids.
 % Invariants: the word parses to exactly one rooted tree before any ink.
 % Next stage: shared event services emit the resolved model used for rendering.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 %   \tntree[keys]{(((a\,b)_x\,c)_y\,d)_e}
 %       a fusion tree from a parenthesization word: leaves on a top

--- a/tex/tenkz/tenkz.sty
+++ b/tex/tenkz/tenkz.sty
@@ -3,6 +3,8 @@
 % Owned state: none; this file is the dependency probe and stage load map.
 % Invariants: language loads before model, shared services, and the kernel.
 % Next stage: tenkz-language.code.tex validates and registers public syntax.
+% SPDX-License-Identifier: Apache-2.0
+% Copyright the TNLean project; see LICENSE for the full terms.
 %
 % The one language: the 1.0 kernel — tenkz, tenkzeq, and the body
 % commands — bound as the public surface at package load.  Fusion


### PR DESCRIPTION
Closes LionSR/tenkz#129.

A staging tree and a verifier around the handwritten `.sty` and `.code.tex`
modules. No `.dtx`, no TDS layout, no l3build, and no version change: the
version stays whatever `tex/tenkz/tenkz.sty` declares, and this change reads
that declaration rather than writing one.

## The runtime closure, walked rather than listed

`scripts/tenkz_ctan.py closure` follows `\input` from the post-#4699 entry
point with comments blanked first, and reads `\RequirePackage` and
`\usetikzlibrary` for what the archive does not carry:

```
tenkz.sty
tenkz-language.code.tex
tenkz-language-registry.tex      (loaded by the language stage, not by tenkz.sty)
tenkz-model.code.tex
tenkz-core.code.tex
tenkz-metric.code.tex
tenkz-geometry.code.tex
tenkz-string.code.tex
tenkz-tree.code.tex
tenkz-render.code.tex
tenkz-kernel.code.tex
loads: tikz
TikZ libraries: arrows.meta, backgrounds, calc, decorations.markings,
  decorations.pathreplacing, fit, hobby, intersections, shapes.geometric, spath3
```

Two of those libraries — `hobby` and `spath3` — are not part of pgf. They are
separate CTAN packages, loaded at package load, so an installation without
them fails at `\usepackage{tenkz}` rather than at the first curve. The CTAN
README states both under requirements; the upload checklist repeats them for
the distribution build.

`docs/tenkz/ctan/MANIFEST.toml` pins the walk's result. The pin is not the
source of the closure — the entry point is — so it cannot make the archive
carry a stage the package does not load. What it buys is a failed check when
the load graph moves: a new stage module, a new required package, or a
deleted one stops here until somebody decides whether the upload changes with
it.

## What the archive contains

`tenkz/` with the eleven runtime files, plus `README.md` (the CTAN README,
written for a stranger: what the package draws, requirements, installation,
documentation, author and maintainer contact, license, version), `LICENSE`,
`CHANGES.md`, `CITATION.cff`, and `tenkz.bib`. The manual is not staged, and
that is the last blocking item before an actual upload; it is LionSR/tenkz#8's
reproducible build, and the checklist says so rather than leaving a reader to
notice.

## How determinism is proven

`check` builds the tree and archive twice, under two file-creation masks
(`022` and `077`) and in two temporary directories, and compares the archive
bytes and every staged name, mode, and modification time. Timestamps come
from `SOURCE_DATE_EPOCH` when the environment sets it and from the package's
own declared date otherwise, so the archive is a function of the tree and of
nothing else — not of the clock, not of the builder's mask, not of the
directory it was built in. Member order is the load order followed by the
manifest's order, never a directory listing; permission bits, creating
system, and timestamps are set on every entry.

One honest caveat, recorded in the code and in the checklist: the compressed
bytes come from the compression library the builder links. Two builds in one
environment agree, which is what a recorded digest means; the staged tree
beside the archive has no such caveat and is compared too.

## The other checks

- **sources** — every file in `tex/tenkz/` is either in the closure or
  declared excluded, and none of it is a compilation leftover.
- **material** — the declared material exists, and the README carries
  requirements, contact, and license sections.
- **headers** — every runtime file names its license in its own header. The
  files carried none; each gains two lines below the five-line stage contract
  that `tenkz_language.py check` pins, so both checks are satisfied.
- **version** — the README, the citation record, and the BibTeX record must
  state the version and date of the one `\ProvidesPackage` declaration, and
  the archive is named from it (`tenkz-0.7.zip`). `sync` prints what each
  release artifact currently says; it reports and never enforces, because the
  agreement a tag requires is the release-preparation change's work.
- **encoding, names, permissions, debris** — UTF-8 without a byte-order mark;
  the invariant ASCII subset with no case-collisions; `0644` and `0755`
  whatever the builder's mask; no auxiliary files.
- **clean-install** — the archive is unpacked on its own and a two-cell
  picture is compiled against it, with the engine recording every file it
  opens. Every opened `tenkz*` file must resolve inside the unpacked
  directory, so a machine with an older tenkz installed cannot answer for a
  file the archive forgot; the search path still ends open, because the
  installation has to supply tikz, hobby, and spath3. Verified to have teeth:
  deleting `tenkz-render.code.tex` from the unpacked copy makes the run
  exit 1. Bounded at 120 seconds.

## Where it runs

Wired into the existing `Check tenkz release harness and inventory` job in
`tenkz-release-policy.yml`, which runs on every pull request. That job
installs no TeX, so the clean-install step reports itself skipped there; the
`tenkz-corpus` job in `pr-ci.yml`, which already has an engine, runs the same
command with `--require-smoke`. No parallel job was added.

## Evidence

```
python3 scripts/tenkz_ctan.py check          PASS (12 checks, clean-install included)
python3 -m pytest scripts/test_tenkz_ctan.py -q      16 passed
python3 scripts/tenkz_shrink.py gate         PASS: census stable at 86
python3 scripts/tenkz_language.py check      PASS: 100 records
python3 scripts/check_tenkz_policy.py        PASS
python3 scripts/check_tenkz_dispositions.py  PASS
python3 scripts/check_tenkz_demolition.py    PASS
python3 scripts/tenkz_lint.py 'tex/tenkz/*.tex'      0 findings
tests/tenkz/release-harness/selftest.py      PASS: 10 probes, 18 escape guards
supervisor.py check-inventory / run-all / check-readiness   PASS
scripts/tenkz_kernel_probes.sh               PASS: 149 regressions, 11 sugar spellings, 12 record streams, pixels byte-identical
scripts/tenkz_golden.sh --check              PASS: 9 event streams byte-identical
python3 scripts/tenkz_rmp.py check --all     PASS: 130 targets; verdicts unchanged
python3 -m pytest scripts/test_tenkz_*.py scripts/test_check_tenkz_*.py -q   63 passed, 1 pre-existing collection error
```

The runtime edits are comment lines only, so no event stream or pixel moves.
The archive's digest is the same on this machine and on the CI runner
(`ba4c36c73b5476de2be998316b5c3571fe96f2ec2c942741840dd836e126b0a4`), which
is more than the determinism check claims and worth recording.

## Review

Sixteen bot findings, all held and answered in `e2d7739` and `45a8931`. The
sharpest: the clean-install check proved less than it claimed, because the
open search path would let an installed tenkz answer for a file the archive
forgot — the run now reads the engine's own record of what it opened. The
rest: BibTeX year and month were unchecked, absent material raised before any
report printed, a name the archive cannot carry was reported rather than
refused before writing, a material key could shadow a runtime file, an epoch
before 1980 crashed the build, the version pattern accepted `v1..0`, the
staged directory's own mode went unchecked, the smoke failure hid stderr and
the exit status, the run was unbounded, and the corpus filter missed `LICENSE`
and the change record.

## Found and not fixed

- `docs/tenkz/ANNOUNCEMENT-1.0-draft.md` still shows `\tnX{X}` in its one
  figure. `CHANGES.md` retires that spelling in favour of `\tn[skin=ring]{m}`,
  and LionSR/tenkz#132's own acceptance list forbids stale transitional syntax in the
  announcement. Left for LionSR/tenkz#132.
- `scripts/test_tenkz_corpus_render.py::test_repo_relative_render_dir` takes a
  `work` fixture that does not exist, so a `pytest` sweep of the script tests
  reports a collection error. It passes when run as a program, which is how CI
  runs it. Pre-existing and untouched here.
- The repository license is Apache 2.0 and the package inherits it. CTAN
  accepts that license, and LaTeX packages more often carry the LPPL. Whether
  to add LPPL 1.3c as an alternative is a maintainer decision, recorded in the
  checklist where the upload form asks for it, and not made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnoDwvwGWDw1eQgJpHnTzL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release gates and upload integrity (archive contents and clean-install verification), but does not change diagram rendering logic beyond license header comments in runtime sources.
> 
> **Overview**
> Adds **CTAN upload packaging** for tenkz: `scripts/tenkz_ctan.py` walks the runtime load graph from `tenkz.sty`, stages runtime files plus pinned reader material (`docs/tenkz/ctan/MANIFEST.toml`), and builds a deterministic `tenkz-VERSION.zip` whose version comes only from `\ProvidesPackage`.
> 
> New **acceptance checks** cover manifest closure vs. the walk, source-tree hygiene, required material (README, LICENSE, CHANGES, citation files), SPDX headers on runtime files, cross-artifact version alignment, encoding/safe names/permissions/debris, **double-build byte identity**, and a **clean-install smoke compile** that uses the engine’s input record so missing archive files cannot be masked by an installed copy.
> 
> **CI** runs `test_tenkz_ctan.py` and `tenkz_ctan.py check` in the release-policy job; `pr-ci` runs `check --require-smoke` where TeX is available. **Docs** add CTAN README, upload checklist, and RELEASE-POLICY row. **Runtime `.tex`/`sty` files** gain Apache-2.0 SPDX comment lines only (no behavioral change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0fcd8ccd625c782ea4a294205d399730807684a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->