### PR TITLE
feat(Algebra): add dimension-explicit Gram reshuffle norm bound

### DIFF
--- a/TNLean/Algebra/OperatorNormFrobenius.lean
+++ b/TNLean/Algebra/OperatorNormFrobenius.lean
@@ -17,6 +17,7 @@ entrywise Frobenius mass. It also applies the bound to the reshuffled Choi matri
 
 - `Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq`
 - `Matrix.sum_entry_norm_sq_le_card_mul_norm_sq`
+- `Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq`
 - `Matrix.gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq`
 -/
 
@@ -85,15 +86,20 @@ theorem sum_entry_norm_sq_le_card_mul_norm_sq (A : Matrix α α ℂ) :
       Finset.sum_le_sum fun j _ ↦ sum_column_norm_sq_le_norm_sq A j
     _ = (Fintype.card α : ℝ) * ‖A‖ ^ 2 := by simp
 
-/-- Every complex matrix unit has L² operator norm at most one. -/
-theorem single_one_norm_le_one (i j : α) :
-    ‖(single i j 1 : Matrix α α ℂ)‖ ≤ 1 := by
-  rw [l2_opNorm_def]
-  refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one fun x ↦ ?_
-  change ‖(EuclideanSpace.equiv α ℂ).symm (single i j 1 *ᵥ x)‖ ≤ 1 * ‖x‖
-  rw [single_mulVec]
-  change ‖EuclideanSpace.single i ((1 : ℂ) * x.ofLp j)‖ ≤ 1 * ‖x‖
-  simpa using PiLp.norm_apply_le x j
+/-- Every complex matrix unit has L² operator norm one. -/
+theorem l2_opNorm_single_one (i j : α) :
+    ‖(single i j 1 : Matrix α α ℂ)‖ = 1 := by
+  apply le_antisymm
+  · rw [l2_opNorm_def]
+    refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one fun x ↦ ?_
+    change ‖(EuclideanSpace.equiv α ℂ).symm (single i j 1 *ᵥ x)‖ ≤ 1 * ‖x‖
+    rw [single_mulVec]
+    change ‖EuclideanSpace.single i ((1 : ℂ) * x.ofLp j)‖ ≤ 1 * ‖x‖
+    simpa using PiLp.norm_apply_le x j
+  · have h := (single i j 1 : Matrix α α ℂ).l2_opNorm_mulVec
+      (EuclideanSpace.single j (1 : ℂ))
+    rw [single_mulVec_eq] at h
+    simpa using h
 
 /-- The squared Euclidean operator norm of the reshuffled Choi matrix is bounded by the
 entrywise squared mass of the rectangular Choi matrix. -/
@@ -130,13 +136,11 @@ theorem gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq
         _ ≤ (Fintype.card α : ℝ) * ‖LinearMap.toContinuousLinearMap Φ‖ ^ 2 := by
           gcongr
           calc
-            ‖Φ (single c a 1)‖ ≤
-                ‖LinearMap.toContinuousLinearMap Φ‖ * ‖(single c a 1 : Matrix α α ℂ)‖ :=
+            ‖Φ (single c a 1)‖ ≤ ‖LinearMap.toContinuousLinearMap Φ‖ *
+                ‖(single c a 1 : Matrix α α ℂ)‖ :=
               (LinearMap.toContinuousLinearMap Φ).le_opNorm _
-            _ ≤ ‖LinearMap.toContinuousLinearMap Φ‖ * 1 := by
-              gcongr
-              exact single_one_norm_le_one c a
-            _ = ‖LinearMap.toContinuousLinearMap Φ‖ := mul_one _
+            _ = ‖LinearMap.toContinuousLinearMap Φ‖ := by
+              rw [l2_opNorm_single_one, mul_one]
     _ = (Fintype.card α : ℝ) ^ 3 * ‖LinearMap.toContinuousLinearMap Φ‖ ^ 2 := by
       simp only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
       ring

--- a/TNLean/Algebra/OperatorNormFrobenius.lean
+++ b/TNLean/Algebra/OperatorNormFrobenius.lean
@@ -111,8 +111,9 @@ theorem gramReshuffle_norm_sq_le_rectangularChoi_norm_sq
   exact (toEuclideanCLM_norm_sq_le_sum_norm_sq (gramReshuffleMatrix Φ)).trans_eq
     (gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq Φ)
 
-/-- Reshuffling the Choi matrix of a linear map on `α × α` matrices costs at most
-`card α ^ 3` when its squared L² operator norm is compared with that of the map. -/
+/-- Reshuffling the Choi matrix of a linear map on \(\alpha \times \alpha\) matrices
+costs at most \((\operatorname{card} \alpha)^3\) when its squared L² operator norm is
+compared with that of the map. -/
 theorem gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq
     (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
     ‖gramReshuffle Φ‖ ^ 2 ≤

--- a/TNLean/Algebra/OperatorNormFrobenius.lean
+++ b/TNLean/Algebra/OperatorNormFrobenius.lean
@@ -16,8 +16,11 @@ entrywise Frobenius mass. It also applies the bound to the reshuffled Choi matri
 ## Main results
 
 - `Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq`
-- `Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq`
+- `Matrix.sum_entry_norm_sq_le_card_mul_norm_sq`
+- `Matrix.gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq`
 -/
+
+open scoped Matrix.Norms.L2Operator
 
 namespace Matrix
 
@@ -59,6 +62,39 @@ theorem toEuclideanCLM_norm_sq_le_sum_norm_sq (A : Matrix n n ℂ) :
 
 variable {α : Type*} [Fintype α] [DecidableEq α]
 
+/-- The squared Euclidean mass of one column is bounded by the squared L² operator norm. -/
+theorem sum_column_norm_sq_le_norm_sq (A : Matrix α α ℂ) (j : α) :
+    (∑ i, ‖A i j‖ ^ 2) ≤ ‖A‖ ^ 2 := by
+  have h := A.l2_opNorm_mulVec (EuclideanSpace.single j (1 : ℂ))
+  change ‖(EuclideanSpace.equiv α ℂ).symm (A *ᵥ Pi.single j 1)‖ ≤
+    ‖A‖ * ‖EuclideanSpace.single j (1 : ℂ)‖ at h
+  have h' : ‖(EuclideanSpace.equiv α ℂ).symm (A.col j)‖ ≤ ‖A‖ := by
+    simpa using h
+  simpa [EuclideanSpace.norm_sq_eq, col_apply] using
+    pow_le_pow_left₀ (norm_nonneg _) h' 2
+
+/-- The entrywise squared mass of a square matrix is at most its number of columns
+multiplied by the squared L² operator norm. -/
+theorem sum_entry_norm_sq_le_card_mul_norm_sq (A : Matrix α α ℂ) :
+    (∑ p : α × α, ‖A p.1 p.2‖ ^ 2) ≤
+      (Fintype.card α : ℝ) * ‖A‖ ^ 2 := by
+  rw [Fintype.sum_prod_type]
+  calc
+    (∑ i, ∑ j, ‖A i j‖ ^ 2) = ∑ j, ∑ i, ‖A i j‖ ^ 2 := Finset.sum_comm
+    _ ≤ ∑ _j : α, ‖A‖ ^ 2 :=
+      Finset.sum_le_sum fun j _ ↦ sum_column_norm_sq_le_norm_sq A j
+    _ = (Fintype.card α : ℝ) * ‖A‖ ^ 2 := by simp
+
+/-- Every complex matrix unit has L² operator norm at most one. -/
+theorem single_one_norm_le_one (i j : α) :
+    ‖(single i j 1 : Matrix α α ℂ)‖ ≤ 1 := by
+  rw [l2_opNorm_def]
+  refine ContinuousLinearMap.opNorm_le_bound _ zero_le_one fun x ↦ ?_
+  change ‖(EuclideanSpace.equiv α ℂ).symm (single i j 1 *ᵥ x)‖ ≤ 1 * ‖x‖
+  rw [single_mulVec]
+  change ‖EuclideanSpace.single i ((1 : ℂ) * x.ofLp j)‖ ≤ 1 * ‖x‖
+  simpa using PiLp.norm_apply_le x j
+
 /-- The squared Euclidean operator norm of the reshuffled Choi matrix is bounded by the
 entrywise squared mass of the rectangular Choi matrix. -/
 theorem gramReshuffle_norm_sq_le_rectangularChoi_norm_sq
@@ -68,5 +104,41 @@ theorem gramReshuffle_norm_sq_le_rectangularChoi_norm_sq
   rw [gramReshuffle]
   exact (toEuclideanCLM_norm_sq_le_sum_norm_sq (gramReshuffleMatrix Φ)).trans_eq
     (gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq Φ)
+
+/-- Reshuffling the Choi matrix of a linear map on `α × α` matrices costs at most
+`card α ^ 3` when its squared L² operator norm is compared with that of the map. -/
+theorem gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    ‖gramReshuffle Φ‖ ^ 2 ≤
+      (Fintype.card α : ℝ) ^ 3 * ‖LinearMap.toContinuousLinearMap Φ‖ ^ 2 := by
+  refine (gramReshuffle_norm_sq_le_rectangularChoi_norm_sq Φ).trans ?_
+  simp_rw [Fintype.sum_prod_type]
+  simp_rw [rectangularChoi_apply]
+  calc
+    (∑ c, ∑ e, ∑ a, ∑ b, ‖Φ (single c a 1) e b‖ ^ 2) =
+        ∑ c, ∑ a, ∑ e, ∑ b, ‖Φ (single c a 1) e b‖ ^ 2 := by
+      congr with c
+      rw [Finset.sum_comm]
+    _ ≤ ∑ _c : α, ∑ _a : α,
+        (Fintype.card α : ℝ) * ‖LinearMap.toContinuousLinearMap Φ‖ ^ 2 := by
+      gcongr with c a
+      calc
+        (∑ e, ∑ b, ‖Φ (single c a 1) e b‖ ^ 2) ≤
+            (Fintype.card α : ℝ) * ‖Φ (single c a 1)‖ ^ 2 := by
+          simpa only [Fintype.sum_prod_type] using
+            sum_entry_norm_sq_le_card_mul_norm_sq (Φ (single c a 1))
+        _ ≤ (Fintype.card α : ℝ) * ‖LinearMap.toContinuousLinearMap Φ‖ ^ 2 := by
+          gcongr
+          calc
+            ‖Φ (single c a 1)‖ ≤
+                ‖LinearMap.toContinuousLinearMap Φ‖ * ‖(single c a 1 : Matrix α α ℂ)‖ :=
+              (LinearMap.toContinuousLinearMap Φ).le_opNorm _
+            _ ≤ ‖LinearMap.toContinuousLinearMap Φ‖ * 1 := by
+              gcongr
+              exact single_one_norm_le_one c a
+            _ = ‖LinearMap.toContinuousLinearMap Φ‖ := mul_one _
+    _ = (Fintype.card α : ℝ) ^ 3 * ‖LinearMap.toContinuousLinearMap Φ‖ ^ 2 := by
+      simp only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+      ring
 
 end Matrix

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -327,6 +327,64 @@ orthogonal projector is the canonical representative used here.
     supremum over unit vectors $x\in\ell^2(I)$.
 \end{proof}
 
+\begin{theorem}[Squared mass of one column]
+    \label{thm:sum_column_norm_sq_le_l2_operator_norm_sq}
+    \lean{Matrix.sum_column_norm_sq_le_norm_sq}
+    \leanok
+    Let $I$ be a finite index set, let $A=(A_{ij})_{i,j\in I}$ be a complex
+    matrix, and let $j\in I$.  Then
+    \begin{align}
+      \sum_{i\in I}\lvert A_{ij}\rvert^2
+      &\leq \lVert A\rVert_{\ell^2(I)\to\ell^2(I)}^2.
+      \label{eq:sum_column_norm_sq_le_l2_operator_norm_sq}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply $A$ to the unit vector supported at $j$.  Its image is the $j$th
+    column of $A$, while the vector itself has Euclidean norm one.
+\end{proof}
+
+\begin{theorem}[Entrywise mass bounded by the $L^2$ operator norm]
+    \label{thm:sum_entry_norm_sq_le_card_mul_l2_operator_norm_sq}
+    \lean{Matrix.sum_entry_norm_sq_le_card_mul_norm_sq}
+    \leanok
+    Let $I$ be a finite index set and let $A=(A_{ij})_{i,j\in I}$ be a complex
+    matrix.  Then
+    \begin{align}
+      \sum_{(i,j)\in I\times I}\lvert A_{ij}\rvert^2
+      &\leq |I|\,
+        \lVert A\rVert_{\ell^2(I)\to\ell^2(I)}^2.
+      \label{eq:sum_entry_norm_sq_le_card_mul_l2_operator_norm_sq}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:sum_column_norm_sq_le_l2_operator_norm_sq}
+    Sum Theorem~\ref{thm:sum_column_norm_sq_le_l2_operator_norm_sq} over all
+    columns.
+\end{proof}
+
+\begin{theorem}[$L^2$ operator norm of a matrix unit]
+    \label{thm:l2_operator_norm_matrix_unit}
+    \lean{Matrix.l2_opNorm_single_one}
+    \leanok
+    Let $I$ be a finite index set.  For every $i,j\in I$, the matrix unit
+    $E_{ij}$ satisfies
+    \begin{align}
+      \lVert E_{ij}\rVert_{\ell^2(I)\to\ell^2(I)}=1.
+      \label{eq:l2_operator_norm_matrix_unit}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The matrix unit sends the unit vector at $j$ to the unit vector at $i$ and
+    sends every vector to a scalar multiple of that unit vector.
+\end{proof}
+
 \begin{theorem}[Entrywise Frobenius invariance of Gram reshuffling]
     \label{thm:gram_reshuffle_matrix_norm_sq}
     \lean{Matrix.gramReshuffleMatrix_norm_sq_eq_rectangularChoi_norm_sq}
@@ -382,6 +440,39 @@ orthogonal projector is the canonical representative used here.
     $R(\mathcal L)$, then use
     Theorem~\ref{thm:gram_reshuffle_matrix_norm_sq} to rewrite its entrywise
     Frobenius mass as that of $J(\mathcal L)$.
+\end{proof}
+
+\begin{theorem}[Dimension bound for Gram reshuffling]
+    \label{thm:gram_reshuffle_norm_sq_le_card_cube_mul_operator_norm_sq}
+    \lean{Matrix.gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq}
+    \leanok
+    \uses{def:gram_reshuffle}
+    Let $I$ be a finite index set, equip $\mathbb C^{I\times I}$ with its
+    $L^2$ operator norm, and let
+    $\mathcal L\colon\mathbb C^{I\times I}\to\mathbb C^{I\times I}$ be
+    complex-linear.  Denote the operator norm of $\mathcal L$ for these matrix
+    norms by $\lVert\mathcal L\rVert_{\mathrm{op},L^2}$.  Then
+    \begin{align}
+      \bigl\lVert\mathscr R(\mathcal L)\bigr\rVert_{
+        \ell^2(I\times I)\to\ell^2(I\times I)}^2
+      &\leq |I|^3\,
+        \lVert\mathcal L\rVert_{\mathrm{op},L^2}^2.
+      \label{eq:gram_reshuffle_norm_sq_le_card_cube_mul_operator_norm_sq}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:rectangular_choi,
+        thm:gram_reshuffle_norm_sq_le_rectangular_choi,
+        thm:sum_entry_norm_sq_le_card_mul_l2_operator_norm_sq,
+        thm:l2_operator_norm_matrix_unit}
+    Use Theorem~\ref{thm:gram_reshuffle_norm_sq_le_rectangular_choi} and expand
+    the Choi matrix in matrix units.  For each of the $|I|^2$ input matrix
+    units, Theorem~\ref{thm:sum_entry_norm_sq_le_card_mul_l2_operator_norm_sq}
+    contributes a factor $|I|$.  The operator-norm estimate for $\mathcal L$
+    and Theorem~\ref{thm:l2_operator_norm_matrix_unit} bound the remaining
+    matrix norm.
 \end{proof}
 
 \begin{theorem}[Transfer--Gram Choi reshuffling]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -530,10 +530,29 @@ Combining these two facts gives the completed reshuffled-Choi corollary
   &\leq \sum_{u,v\in I\times I}
     \lvert J(\mathcal L)_{u,v}\rvert^2.
 \end{align}
-This proves only an operator-norm bound by entrywise Frobenius mass.  It proves
-neither operator-norm invariance nor preservation of singular values under
-reshuffling, and it gives no direct bound by the default operator norm of
-$\mathcal L$ as a map on matrices.
+The remaining generic conversion is also complete.  Equip
+$\mathbb C^{I\times I}$ with its $L^2$ operator norm and write
+$\lVert\mathcal L\rVert_{\mathrm{op},L^2}$ for the resulting operator norm of
+$\mathcal L$.  The column estimate
+\leanid{Matrix.sum_column_norm_sq_le_norm_sq}, its entrywise consequence
+\leanid{Matrix.sum_entry_norm_sq_le_card_mul_norm_sq}, and the matrix-unit
+normalization \leanid{Matrix.l2_opNorm_single_one} give
+\leanid{Matrix.gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq}:
+\begin{align}
+  \lVert\mathscr R(\mathcal L)\rVert_{
+    \ell^2(I\times I)\to\ell^2(I\times I)}^2
+  &\leq |I|^3\,\lVert\mathcal L\rVert_{\mathrm{op},L^2}^2.
+\end{align}
+Thus for $I=\Fin D$ the corresponding norm factor is $D^{3/2}$.  This is a
+safe generic dimension conversion.  It is not claimed sharp, and it is not
+identified with the FNW source prefactor $c=D^2$.
+
+Reshuffling is still not operator-norm invariant and need not preserve singular
+values.  The identity map gives the basic boundary: its operator norm on
+$\mathbb C^{D\times D}$ is one, whereas
+$\lVert\mathscr R(\mathrm{id})\rVert=D$ for $D>0$.  Hence the preceding
+$D^{3/2}$ factor is an upper bound, not an invariance statement or a source
+constant.
 
 \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} upgrades the coordinate
 identity to the exact operator equality
@@ -606,12 +625,15 @@ and generic prerequisites now include:
   \item The Choi reshuffling is packaged as the exact operator identity
     \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} (module
     \path{TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean}).
-  \item The generic operator-norm--to--entrywise-Frobenius estimate and its
-    reshuffled-Choi corollary are
-    \leanid{Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq} and
-    \leanid{Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq}.
-    These do not compare directly with the default operator norm of the
-    transfer map.
+  \item The generic operator-norm--to--entrywise-Frobenius estimate, its
+    reshuffled-Choi corollary, and the safe dimension conversion are
+    \leanid{Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq},
+    \leanid{Matrix.gramReshuffle_norm_sq_le_rectangularChoi_norm_sq}, and
+    \leanid{Matrix.gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq}.
+    The last theorem gives squared factor $|I|^3$ against the squared operator
+    norm of the map when the matrix space carries its $L^2$ operator norm.
+    For $I=\Fin D$ this is norm factor $D^{3/2}$; it is not claimed sharp and
+    is not the FNW prefactor $c=D^2$.
   \item The spectator-indexed boundary maps for the tail and left windows are
     defined in \path{TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean},
     together with their exact range equalities

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 994, 1036 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1085, 1127 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- prove column and entrywise-mass bounds for the default matrix $L^2$ operator norm
- prove the exact $L^2$ norm of a complex matrix unit
- derive $\|\operatorname{gramReshuffle}(\Phi)\|^2 \le |I|^3 \|\Phi\|_{\mathrm{op}}^2$ using `LinearMap.toContinuousLinearMap`
- synchronize Chapter 13 and the martingale paper-gap note

## Scope guardrails

The $|I|^3$ squared factor (norm factor $D^{3/2}$ for `Fin D`) is a safe generic estimate, not claimed sharp and not identified with the FNW source prefactor $c=D^2$. Reshuffling is not operator-norm invariant: for nonzero dimension, `gramReshuffle id` has norm $D$ while the identity endomorphism has norm $1$. The limiting unweighted Gram remains `gramReshuffle(fixedPointProj ...)`, not the identity. This PR proves no inverse-Gram projector estimate or FNW contraction.

## Verification

- `lake env lean TNLean/Algebra/OperatorNormFrobenius.lean`
- `lake exe lint_style --github`
- full blueprint web and declaration checks
- reader-facing prose and tenkz disposition/policy checks

Closes #5876

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are formal analysis lemmas and synchronized documentation; no runtime, auth, or data-handling paths are touched.
> 
> **Overview**
> Adds **Lean proofs** that bridge entrywise Frobenius mass and the default matrix **L² operator norm**, then uses them to bound reshuffled Choi Gram operators by **|I|³** against the map’s squared operator norm.
> 
> New lemmas include column and full entrywise mass estimates (`sum_column_norm_sq_le_norm_sq`, `sum_entry_norm_sq_le_card_mul_norm_sq`), **L² norm = 1** for matrix units (`l2_opNorm_single_one`), and `gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq` chaining the existing reshuffled-Choi Frobenius bound through those estimates.
> 
> **Chapter 13** blueprint and the **martingale overlap** paper-gap note are updated with matching theorems and prose: the **D^{3/2}** norm factor is documented as a safe generic bound, explicitly **not** sharp and **not** the FNW **D²** prefactor; reshuffling is **not** operator-norm invariant. A tenkz disposition line reference is adjusted for the longer chapter file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7c93f2849d00653426a0d6ce45036707225fb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->