### PR TITLE
style(MPDO): use standard induction in Lemma C.5 proof

### DIFF
--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -346,9 +346,10 @@ theorem trace_pow_similarity_diagonal (S : Matrix n n ℝ) (d : n → ℝ) (hd :
     Matrix.mul_nonsing_inv (Matrix.diagonal d) h_det
   have h_pow : ((Matrix.diagonal d)⁻¹ * S * Matrix.diagonal d) ^ N =
       (Matrix.diagonal d)⁻¹ * (S ^ N) * Matrix.diagonal d := by
-    induction' N with k ih
-    · simp [h_mul]
-    · rw [pow_succ, pow_succ, ih]
+    induction N with
+    | zero => simp [h_mul]
+    | succ k ih =>
+      rw [pow_succ, pow_succ, ih]
       calc
         ((Matrix.diagonal d)⁻¹ * (S ^ k) * Matrix.diagonal d) *
             ((Matrix.diagonal d)⁻¹ * S * Matrix.diagonal d) =


### PR DESCRIPTION
### Motivation

- The exact-main build had one remaining MPDO warning: the Lemma C.5 diagonal-similarity proof used legacy `induction'` syntax.

### Description

- Replace `induction' N with k ih` by standard `induction N with | zero => ... | succ k ih => ...`.
- Preserve both branch bodies, theorem statement, diagonal-similarity telescoping argument, and CPSV16 Lemma C.5 source boundary.
- Add no suppression and make no other proof change.

### Testing

- `lake env lean TNLean/MPS/MPDO/LemmaC5CaseI.lean` — success, no output
- `lake build TNLean.MPS.MPDO.LemmaC5CaseI` — success, 9175 jobs, zero target warnings
- `lake build TNLean` — success, 10007 jobs, no `LemmaC5CaseI.lean` warnings
- `python3 scripts/generate_import_aggregators.py --check` — 51 aggregators / 1297 production modules current
- `git diff --check origin/main...HEAD`
- exact-head independent review — approved, no findings

---
Closes #5885
Advances #5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 identified the legacy tactic warning, translated it to standard Lean induction syntax, and ran targeted/full validation. A separate exact-head review approved the branch; the maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only syntax modernization with identical branch logic; no API or mathematical content changes.
> 
> **Overview**
> Replaces legacy `induction' N with k ih` with standard `induction N with | zero => ... | succ k ih => ...` in the diagonal similarity telescoping step of `trace_pow_similarity_diagonal` in `LemmaC5CaseI.lean`.
> 
> The zero and successor branch bodies are unchanged; this clears the remaining MPDO legacy-tactic warning without altering the Lemma C.5 Case-I proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173ea96bc0969775730ffb676aaced8678690a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->