### PR TITLE
style(Periodic): clean sector-match proof warnings

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/SectorMatch/Basic.lean
+++ b/TNLean/MPS/Periodic/Overlap/SectorMatch/Basic.lean
@@ -211,8 +211,9 @@ lemma exists_ambient_corner_gauge_of_gaugePhase
     simpa only [Matrix.star_eq_conjTranspose] using
       Matrix.UnitaryGroup.star_mul_self W
   have hgCB (i : Fin e) : g (CB i) = c₀ • CA i := by
-    simp [g, hW i, Matrix.unitaryReindexLinearEquiv_apply,
-      Matrix.mul_assoc, hW_star_W]
+    simp only [g, hW i, Matrix.unitaryReindexLinearEquiv_apply, Equiv.refl_symm,
+      Matrix.reindex_refl_refl, Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_assoc,
+      hW_star_W, Matrix.mul_one]
     rw [Matrix.star_eq_conjTranspose, ← Matrix.mul_assoc,
       hW_star_W, Matrix.one_mul]
   have htransport (i : Fin e) :

--- a/TNLean/MPS/Periodic/Overlap/SectorMatch/Contraction.lean
+++ b/TNLean/MPS/Periodic/Overlap/SectorMatch/Contraction.lean
@@ -82,10 +82,10 @@ lemma sectorTensor_proportional_of_blockedMatch
     (hB_blocks_lc :
       ∀ k, ∑ i : Fin (blockPhysDim d m),
         (blocksB k i)ᴴ * blocksB k i = 1)
-    (hA_mpv :
+    (_hA_mpv :
       SameMPV₂ (blockTensor A m)
         (toTensorFromBlocks (μ := fun _ => 1) blocksA))
-    (hB_mpv :
+    (_hB_mpv :
       SameMPV₂ (blockTensor B m)
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
     {PA PB : Fin m → MatrixAlg D}
@@ -114,7 +114,6 @@ lemma sectorTensor_proportional_of_blockedMatch
       Uglob * Uglobᴴ = 1 ∧
       Uglobᴴ * Uglob = 1 ∧
       ∀ i, A i = ξ • (Uglob * B i * Uglobᴴ) := by
-  clear hA_mpv hB_mpv
   obtain ⟨L, hL_pos, Ω, hΩ⟩ :=
     exists_common_sectorDecompositionMaps_of_isNormal_leftCanonical
       blocksA hA_blocks_lc hNondeg hNormal
@@ -256,7 +255,7 @@ lemma sectorTensor_proportional_of_blockedMatch
     simp only [combinedWord, cyclicList_zero_card_eq_ofFn, List.length_flatten,
       List.map_ofFn, List.sum_ofFn, segments]
     simp only [Function.comp_apply, List.length_cons, List.length_ofFn]
-    simp
+    simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
     exact Nat.mul_comm m (m * L + 1)
   have hcombinedWord_corner :
       ∀ (σ : Fin m → Fin d) (ρ : Fin m → (Fin (m * L) → Fin d)),
@@ -660,11 +659,11 @@ lemma sectorTensor_proportional_of_blockedMatch
     simpa only [γ, norm_mul, hξ_norm, mul_one] using h
   have hP_sum : ∑ k, P k = 1 := by
     change (∑ k, PA (-k)) = 1
-    convert (Equiv.sum_comp (Equiv.neg (Fin m)) PA).trans hPA_sum using 1 <;>
+    convert (Equiv.sum_comp (Equiv.neg (Fin m)) PA).trans hPA_sum using 1;
       rfl
   have hQ_sum : ∑ k, Q k = 1 := by
     change (∑ k, PB (-k)) = 1
-    convert (Equiv.sum_comp (Equiv.neg (Fin m)) PB).trans hPB_sum using 1 <;>
+    convert (Equiv.sum_comp (Equiv.neg (Fin m)) PB).trans hPB_sum using 1;
       rfl
   have hA_cyclic : ∀ i, A i = ∑ k, P k * A i * P (k + 1) := by
     intro i
@@ -688,7 +687,7 @@ lemma sectorTensor_proportional_of_blockedMatch
   have hκB_norm : ∀ v, ‖κB v‖ = 1 := fun v => hκ_norm (v - q')
   have hκB_prod : ∏ v, κB v = 1 := by
     change (∏ v, κ (v - q')) = 1
-    convert (Equiv.prod_comp (Equiv.subRight q') κ).trans hκ_prod using 1 <;>
+    convert (Equiv.prod_comp (Equiv.subRight q') κ).trans hκ_prod using 1;
       rfl
   obtain ⟨φ, hφ_norm, hφ⟩ :=
     TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one
@@ -732,7 +731,7 @@ lemma sectorTensor_proportional_of_blockedMatch
     have hcob := hφ u
     change κ (u + q' - q') =
       φ (u + q') * (φ (u + q' + 1))⁻¹ at hcob
-    convert hcob.symm using 1 <;> abel
+    convert hcob.symm using 1; abel
   have hVprod : ∀ (u : Fin m) (i : Fin d),
       V (u + q') * cornerLetter Q B (u + q') i * (V (u + q' + 1))ᴴ =
         κ u • T u i := by


### PR DESCRIPTION
### Motivation

- After the recent warning cleanups, eight fixable warnings remained in the periodic sector-match cone: two flexible simplifications, two intentionally unused hypothesis names, and four unnecessary sequence-focus operators.

### Description

- Replace both flexible `simp` calls with checked `simp only` sets.
- Retain the two public `SameMPV₂` hypotheses while marking their local names intentionally unused; remove the now-redundant `clear`.
- Replace only the four linter-identified `<;>` operators by plain tactic sequencing; leave the non-warning occurrence untouched.
- Preserve every theorem proposition, periodic-sector proof, source/Blueprint boundary, and downstream caller.

### Testing

- direct Lean on `Basic.lean` — silent
- direct Lean on `Contraction.lean` — zero warnings; two pre-existing info-only `abel_nf` suggestions
- targeted build of `Basic`, `Contraction`, and `SectorMatch` — success, 8939 jobs, zero target warnings
- `lake build TNLean` — success, 10008 jobs; warning headers 25 → 16, with no periodic-sector warnings
- `python3 scripts/generate_import_aggregators.py --check` — 51 aggregators / 1298 production modules current
- `git diff --check origin/main...HEAD`
- exact-head independent review — approved, no findings

---
Closes #5888
Advances #5836

### Agent assistance

- TeXRA with OpenAI GPT-5.6 audited and transformed all eight warning sites, then ran targeted/full validation. A separate exact-head review approved the rebased branch; the maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Stylistic proof and naming changes only; no logic, API, or security-sensitive behavior is altered.
> 
> **Overview**
> **Proof-only cleanup** in periodic sector-match `Basic.lean` and `Contraction.lean`: no theorem statements, proof boundaries, or downstream callers change.
> 
> In `exists_ambient_corner_gauge_of_gaugePhase`, the flexible `simp` on `hgCB` is replaced with an explicit `simp only` list (unitary reindex, `Equiv.refl_symm`, and matrix smul/mul lemmas). In `sectorTensor_proportional_of_blockedMatch`, the two `SameMPV₂` hypotheses stay in the signature but are renamed `_hA_mpv` / `_hB_mpv` so the unused-hypothesis linter is satisfied without the old `clear`; four `convert … using 1 <;> rfl` sites use plain `; rfl` instead of `<;>`.
> 
> These edits address the remaining fixable linter warnings in this cone while leaving propositions and periodic-sector proofs intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a172d52f517c42128116478c3121ccb08353e69a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->