### PR TITLE
feat(MPS/MPU): factor the two-site MPO through source tensors

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -17,6 +17,7 @@ import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
+import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.ThreeFormSpan
 import TNLean.MPS.MPU.TransferMatrix

--- a/TNLean/MPS/MPU/SourceUV.lean
+++ b/TNLean/MPS/MPU/SourceUV.lean
@@ -3,14 +3,13 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceFactors
 
 /-!
 # Source-factor tensors for matrix product unitaries
 
 This file defines the tensors $u$ and $v$ from arXiv:1703.09188, equations
-`uuvv`--`uUnitary` (lines 521--554). The product-index orders are kept
+`SVDforms2` and `uuvv` (lines 526--540). The product-index orders are kept
 explicit: $u : d^2 \to \ell \times r$ and $v : r \times \ell \to d^2$.
 The two-site factorization therefore includes the paper's swap of the dotted
 and solid source bonds rather than identifying the two product orders.
@@ -29,7 +28,7 @@ The row order is `(left source, right source)` and the physical column order is
 `(first ket site, second ket site)`. Its two triangles are $Y_1$ and $X_2$.
 
 Source: arXiv:1703.09188, equation `uu` and Figure `II_umatrix.png`, lines
-521--534. -/
+532--540. -/
 noncomputable def sourceU (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
     Matrix (Fin ℓ[U] × Fin r[U]) (Fin d × Fin d) ℂ :=
   fun (l, r) (i₁, i₂) ↦ ∑ β : Fin D,
@@ -41,7 +40,7 @@ The physical row order is `(first bra site, second bra site)` and the column
 order is `(right source, left source)`. Its two triangles are $X_1$ and $Y_2$.
 
 Source: arXiv:1703.09188, equation `vdagger` and Figure `II_vmatrix.png`, lines
-521--534. -/
+532--540. -/
 noncomputable def sourceV (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
     Matrix (Fin d × Fin d) (Fin r[U] × Fin ℓ[U]) ℂ :=
   fun (j₁, j₂) (r, l) ↦ ∑ α : Fin D,
@@ -49,7 +48,7 @@ noncomputable def sourceV (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
 
 /-- Stable entry formula for $u$ in the exact solid/dotted leg order.
 
-Source: arXiv:1703.09188, equation `uu`, lines 521--534. -/
+Source: arXiv:1703.09188, equation `uu`, lines 532--540. -/
 @[simp] theorem sourceU_apply (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (l : Fin ℓ[U]) (r : Fin r[U]) (i₁ i₂ : Fin d) :
     sourceU U ρ hρ (l, r) (i₁, i₂) = ∑ β : Fin D,
@@ -57,7 +56,7 @@ Source: arXiv:1703.09188, equation `uu`, lines 521--534. -/
 
 /-- Stable entry formula for $v$ in the exact dotted/solid leg order.
 
-Source: arXiv:1703.09188, equation `vdagger`, lines 521--534. -/
+Source: arXiv:1703.09188, equation `vdagger`, lines 532--540. -/
 @[simp] theorem sourceV_apply (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (j₁ j₂ : Fin d) (r : Fin r[U]) (l : Fin ℓ[U]) :
     sourceV U ρ hρ (j₁, j₂) (r, l) = ∑ α : Fin D,
@@ -65,7 +64,7 @@ Source: arXiv:1703.09188, equation `vdagger`, lines 521--534. -/
 
 /-- Entry formula for the conjugate transpose of $u$.
 
-Source: arXiv:1703.09188, equation `uUnitary`, lines 536--554. -/
+Source: arXiv:1703.09188, equations `uuvv` and `uu`, lines 532--540. -/
 @[simp] theorem sourceU_conjTranspose_apply
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (i₁ i₂ : Fin d) (l : Fin ℓ[U]) (r : Fin r[U]) :
@@ -74,7 +73,7 @@ Source: arXiv:1703.09188, equation `uUnitary`, lines 536--554. -/
 
 /-- Entry formula for the conjugate transpose of $v$.
 
-Source: arXiv:1703.09188, equation `vdagger`, lines 521--534. -/
+Source: arXiv:1703.09188, equation `vdagger`, lines 532--540. -/
 @[simp] theorem sourceV_conjTranspose_apply
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (r : Fin r[U]) (l : Fin ℓ[U]) (j₁ j₂ : Fin d) :
@@ -83,7 +82,7 @@ Source: arXiv:1703.09188, equation `vdagger`, lines 521--534. -/
 
 /-- The traced product of two local letters factors through the source tensors.
 
-Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 515--534. -/
+Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 526--540. -/
 theorem trace_mul_eq_sourceU_mul_sourceV_swap
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (i₁ i₂ j₁ j₂ : Fin d) :
@@ -138,7 +137,7 @@ theorem trace_mul_eq_sourceU_mul_sourceV_swap
 
 /-- Entrywise two-site factorization in the paper's site and bond order.
 
-Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 515--534. -/
+Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 526--540. -/
 theorem mpo_two_pair_entry_eq_sourceU_mul_sourceV_swap
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (i₁ i₂ j₁ j₂ : Fin d) :
@@ -158,7 +157,7 @@ columns of $v$ have order $r\times\ell$, so `Equiv.prodComm` explicitly swaps
 them to the $\ell\times r$ order used by the rows of $u$. This is the one-site
 translation/bond swap visible in the paper figures.
 
-Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 515--534. -/
+Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 526--540. -/
 theorem mpo_two_reindex_eq_sourceU_transpose_mul_sourceV_swap_transpose
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
     Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d)) (mpo U 2) =

--- a/TNLean/MPS/MPU/SourceUV.lean
+++ b/TNLean/MPS/MPU/SourceUV.lean
@@ -160,10 +160,12 @@ translation/bond swap visible in the paper figures.
 Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 526--540. -/
 theorem mpo_two_reindex_eq_sourceU_transpose_mul_sourceV_swap_transpose
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
-    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d)) (mpo U 2) =
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (mpo U 2) =
       (sourceU U ρ hρ)ᵀ *
         (Matrix.reindex (Equiv.refl (Fin d × Fin d))
-          (Equiv.prodComm (Fin r[U]) (Fin ℓ[U])) (sourceV U ρ hρ))ᵀ := by
+          (Equiv.prodComm (Fin r[U]) (Fin ℓ[U]))
+          (sourceV U ρ hρ))ᵀ := by
   classical
   ext i j
   rcases i with ⟨i₁, i₂⟩

--- a/TNLean/MPS/MPU/SourceUV.lean
+++ b/TNLean/MPS/MPU/SourceUV.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SimpleBlocking
+import TNLean.MPS.MPU.SourceFactors
+
+/-!
+# Source-factor tensors for matrix product unitaries
+
+This file defines the tensors $u$ and $v$ from arXiv:1703.09188, equations
+`uuvv`--`uUnitary` (lines 521--554). The product-index orders are kept
+explicit: $u : d^2 \to \ell \times r$ and $v : r \times \ell \to d^2$.
+The two-site factorization therefore includes the paper's swap of the dotted
+and solid source bonds rather than identifying the two product orders.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- The paper's source tensor $u : d^2 \to \ell\times r$.
+
+The row order is `(left source, right source)` and the physical column order is
+`(first ket site, second ket site)`. Its two triangles are $Y_1$ and $X_2$.
+
+Source: arXiv:1703.09188, equation `uu` and Figure `II_umatrix.png`, lines
+521--534. -/
+noncomputable def sourceU (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    Matrix (Fin ℓ[U] × Fin r[U]) (Fin d × Fin d) ℂ :=
+  fun (l, r) (i₁, i₂) ↦ ∑ β : Fin D,
+    sourceY₁ U ρ hρ r (i₁, β) * sourceX₂ U (β, i₂) l
+
+/-- The paper's source tensor $v : r\times\ell \to d^2$.
+
+The physical row order is `(first bra site, second bra site)` and the column
+order is `(right source, left source)`. Its two triangles are $X_1$ and $Y_2$.
+
+Source: arXiv:1703.09188, equation `vdagger` and Figure `II_vmatrix.png`, lines
+521--534. -/
+noncomputable def sourceV (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    Matrix (Fin d × Fin d) (Fin r[U] × Fin ℓ[U]) ℂ :=
+  fun (j₁, j₂) (r, l) ↦ ∑ α : Fin D,
+    sourceX₁ U ρ hρ (α, j₁) r * sourceY₂ U l (j₂, α)
+
+/-- Stable entry formula for $u$ in the exact solid/dotted leg order.
+
+Source: arXiv:1703.09188, equation `uu`, lines 521--534. -/
+@[simp] theorem sourceU_apply (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (l : Fin ℓ[U]) (r : Fin r[U]) (i₁ i₂ : Fin d) :
+    sourceU U ρ hρ (l, r) (i₁, i₂) = ∑ β : Fin D,
+      sourceY₁ U ρ hρ r (i₁, β) * sourceX₂ U (β, i₂) l := rfl
+
+/-- Stable entry formula for $v$ in the exact dotted/solid leg order.
+
+Source: arXiv:1703.09188, equation `vdagger`, lines 521--534. -/
+@[simp] theorem sourceV_apply (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (j₁ j₂ : Fin d) (r : Fin r[U]) (l : Fin ℓ[U]) :
+    sourceV U ρ hρ (j₁, j₂) (r, l) = ∑ α : Fin D,
+      sourceX₁ U ρ hρ (α, j₁) r * sourceY₂ U l (j₂, α) := rfl
+
+/-- Entry formula for the conjugate transpose of $u$.
+
+Source: arXiv:1703.09188, equation `uUnitary`, lines 536--554. -/
+@[simp] theorem sourceU_conjTranspose_apply
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i₁ i₂ : Fin d) (l : Fin ℓ[U]) (r : Fin r[U]) :
+    (sourceU U ρ hρ)ᴴ (i₁, i₂) (l, r) = star (∑ β : Fin D,
+      sourceY₁ U ρ hρ r (i₁, β) * sourceX₂ U (β, i₂) l) := rfl
+
+/-- Entry formula for the conjugate transpose of $v$.
+
+Source: arXiv:1703.09188, equation `vdagger`, lines 521--534. -/
+@[simp] theorem sourceV_conjTranspose_apply
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (r : Fin r[U]) (l : Fin ℓ[U]) (j₁ j₂ : Fin d) :
+    (sourceV U ρ hρ)ᴴ (r, l) (j₁, j₂) = star (∑ α : Fin D,
+      sourceX₁ U ρ hρ (α, j₁) r * sourceY₂ U l (j₂, α)) := rfl
+
+/-- The traced product of two local letters factors through the source tensors.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 515--534. -/
+theorem trace_mul_eq_sourceU_mul_sourceV_swap
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i₁ i₂ j₁ j₂ : Fin d) :
+    Matrix.trace (U i₁ j₁ * U i₂ j₂) =
+      ∑ lr : Fin ℓ[U] × Fin r[U],
+        sourceU U ρ hρ lr (i₁, i₂) * sourceV U ρ hρ (j₁, j₂) (lr.2, lr.1) := by
+  classical
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, sourceU, sourceV,
+    Finset.mul_sum, Finset.sum_mul]
+  have h₁ (α β : Fin D) :
+      U i₁ j₁ α β = ∑ r, sourceX₁ U ρ hρ (α, j₁) r *
+        sourceY₁ U ρ hρ r (i₁, β) := by
+    simpa only [Matrix.mul_apply] using
+      (sourceX₁_mul_sourceY₁_apply U ρ hρ α j₁ i₁ β).symm
+  have h₂ (β α : Fin D) :
+      U i₂ j₂ β α = ∑ l, sourceX₂ U (β, i₂) l * sourceY₂ U l (j₂, α) := by
+    simpa only [Matrix.mul_apply] using
+      (sourceX₂_mul_sourceY₂_apply U β i₂ j₂ α).symm
+  simp_rw [h₁, h₂]
+  simp only [Finset.mul_sum, Finset.sum_mul]
+  let f := fun (α β : Fin D) (l : Fin ℓ[U]) (r : Fin r[U]) ↦
+    sourceX₁ U ρ hρ (α, j₁) r * sourceY₁ U ρ hρ r (i₁, β) *
+      (sourceX₂ U (β, i₂) l * sourceY₂ U l (j₂, α))
+  change (∑ α, ∑ β, ∑ l, ∑ r, f α β l r) = _
+  calc
+    _ = ∑ α, ∑ l, ∑ β, ∑ r, f α β l r := by
+      apply Finset.sum_congr rfl
+      intro α _
+      exact Finset.sum_comm
+    _ = ∑ l, ∑ α, ∑ β, ∑ r, f α β l r := Finset.sum_comm
+    _ = ∑ l, ∑ α, ∑ r, ∑ β, f α β l r := by
+      apply Finset.sum_congr rfl
+      intro l _
+      apply Finset.sum_congr rfl
+      intro α _
+      exact Finset.sum_comm
+    _ = ∑ l, ∑ r, ∑ α, ∑ β, f α β l r := by
+      apply Finset.sum_congr rfl
+      intro l _
+      exact Finset.sum_comm
+    _ = ∑ lr : Fin ℓ[U] × Fin r[U], ∑ α, ∑ β, f α β lr.1 lr.2 := by
+      rw [Fintype.sum_prod_type]
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro lr _
+      apply Finset.sum_congr rfl
+      intro α _
+      apply Finset.sum_congr rfl
+      intro β _
+      simp only [f]
+      ring
+
+/-- Entrywise two-site factorization in the paper's site and bond order.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 515--534. -/
+theorem mpo_two_pair_entry_eq_sourceU_mul_sourceV_swap
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i₁ i₂ j₁ j₂ : Fin d) :
+    mpo U 2 ![i₁, i₂] ![j₁, j₂] =
+      ∑ lr : Fin ℓ[U] × Fin r[U],
+        sourceU U ρ hρ lr (i₁, i₂) * sourceV U ρ hρ (j₁, j₂) (lr.2, lr.1) := by
+  rw [mpo_apply, mpoMatrixEntry, evalWord_ofFn]
+  simpa only [List.ofFn_succ, List.ofFn_zero, List.prod_cons, List.prod_nil,
+    Matrix.mul_one, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_succ,
+    Matrix.cons_val_fin_one] using
+    trace_mul_eq_sourceU_mul_sourceV_swap U ρ hρ i₁ i₂ j₁ j₂
+
+/-- The exact two-site periodic MPO factorization through $u$ and $v$.
+
+The two-site physical configurations are reindexed by `finTwoArrowEquiv`. The
+columns of $v$ have order $r\times\ell$, so `Equiv.prodComm` explicitly swaps
+them to the $\ell\times r$ order used by the rows of $u$. This is the one-site
+translation/bond swap visible in the paper figures.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uuvv`, lines 515--534. -/
+theorem mpo_two_reindex_eq_sourceU_transpose_mul_sourceV_swap_transpose
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d)) (mpo U 2) =
+      (sourceU U ρ hρ)ᵀ *
+        (Matrix.reindex (Equiv.refl (Fin d × Fin d))
+          (Equiv.prodComm (Fin r[U]) (Fin ℓ[U])) (sourceV U ρ hρ))ᵀ := by
+  classical
+  ext i j
+  rcases i with ⟨i₁, i₂⟩
+  rcases j with ⟨j₁, j₂⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.mul_apply,
+    Matrix.transpose_apply, Equiv.refl_symm, Equiv.refl_apply, Equiv.prodComm_symm,
+    Equiv.prodComm_apply, finTwoArrowEquiv_symm_apply]
+  rw [mpo_two_pair_entry_eq_sourceU_mul_sourceV_swap U ρ hρ i₁ i₂ j₁ j₂]
+  apply Finset.sum_congr rfl
+  rintro ⟨l, r⟩ _
+  rfl
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1443,6 +1443,71 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{proof}
 
+\begin{definition}[Source tensors $u$ and $v$]
+    \label{def:mpu_source_uv}
+    \lean{MPOTensor.sourceU,MPOTensor.sourceV,
+        MPOTensor.sourceU_apply,MPOTensor.sourceV_apply,
+        MPOTensor.sourceU_conjTranspose_apply,
+        MPOTensor.sourceV_conjTranspose_apply}
+    \leanok
+    \uses{def:mpu_weighted_source_factors}
+    For a positive definite source weight $\rho$, define
+    \begin{align}
+        u &: \mathbb C^d\otimes\mathbb C^d
+            \longrightarrow \mathbb C^\ell\otimes\mathbb C^r,\\
+        v &: \mathbb C^r\otimes\mathbb C^\ell
+            \longrightarrow \mathbb C^d\otimes\mathbb C^d
+    \end{align}
+    by
+    \begin{align}
+        u_{(l,r),(i_1,i_2)}
+          &=\sum_\beta (Y_1)_{r,(i_1,\beta)}(X_2)_{(\beta,i_2),l},\\
+        v_{(j_1,j_2),(r,l)}
+          &=\sum_\alpha (X_1)_{(\alpha,j_1),r}(Y_2)_{l,(j_2,\alpha)}.
+    \end{align}
+    The source legs of $u$ have order $\ell\times r$, whereas those of $v$
+    have order $r\times\ell$. These are equations \texttt{uu} and
+    \texttt{vdagger} in \cite[Section~III]{Cirac2017MPU}. The entry formulas
+    also fix the conjugate-transpose orientation.
+\end{definition}
+
+\begin{theorem}[Exact translated two-site source factorization]
+    \label{thm:mpu_source_uv_two_site_factorization}
+    \lean{MPOTensor.trace_mul_eq_sourceU_mul_sourceV_swap,
+        MPOTensor.mpo_two_pair_entry_eq_sourceU_mul_sourceV_swap,
+        MPOTensor.mpo_two_reindex_eq_sourceU_transpose_mul_sourceV_swap_transpose}
+    \leanok
+    \uses{def:mpu_source_uv,thm:mpu_source_factorization_entries}
+    Identify a two-site physical configuration with an ordered pair in
+    $\Fin d\times\Fin d$. Then
+    \begin{align}
+        \operatorname{reindex}(U^{(2)})
+          &=u^{\mathsf T}\bigl(\operatorname{swap}_{r,\ell}v\bigr)^{\mathsf T}.
+    \end{align}
+    The transpose records the periodic entry orientation. The map
+    $\operatorname{swap}_{r,\ell}$ is the explicit equivalence
+    $r\times\ell\simeq\ell\times r$; the two product orders are not silently
+    identified. This is the bond swap, or one-site translation, in
+    \cite[Section~III, equations \texttt{SVDforms2}--\texttt{uuvv}]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_factorizations}
+    At physical pairs $(i_1,i_2)$ and $(j_1,j_2)$, expand the periodic trace as
+    \begin{align}
+        \sum_{\alpha,\beta}
+          \mathcal U^{i_1}_{j_1,\alpha,\beta}
+          \mathcal U^{i_2}_{j_2,\beta,\alpha}.
+    \end{align}
+    Use $M_1=X_1Y_1$ for the first letter and $M_2=X_2Y_2$ for the second.
+    Reordering the four scalar finite sums gives
+    \begin{align}
+        \sum_{l,r}u_{(l,r),(i_1,i_2)}v_{(j_1,j_2),(r,l)}.
+    \end{align}
+    Reindexing both physical configuration spaces and explicitly swapping
+    $(r,l)$ to $(l,r)$ gives the matrix identity.
+\end{proof}
+
 \begin{theorem}[Right-rank bound]
     \label{thm:mpu_right_rank_bound}
     \lean{MPOTensor.rightRank_bound}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1477,7 +1477,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.mpo_two_pair_entry_eq_sourceU_mul_sourceV_swap,
         MPOTensor.mpo_two_reindex_eq_sourceU_transpose_mul_sourceV_swap_transpose}
     \leanok
-    \uses{def:mpu_source_uv}
+    \uses{def:mpu_source_uv,def:mpo_family}
     Identify a two-site physical configuration with an ordered pair in
     $\Fin d\times\Fin d$. Then
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1466,9 +1466,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
           &=\sum_\alpha (X_1)_{(\alpha,j_1),r}(Y_2)_{l,(j_2,\alpha)}.
     \end{align}
     The source legs of $u$ have order $\ell\times r$, whereas those of $v$
-    have order $r\times\ell$. These are equations \texttt{uu} and
-    \texttt{vdagger} in \cite[Section~III]{Cirac2017MPU}. The entry formulas
-    also fix the conjugate-transpose orientation.
+    have order $r\times\ell$. These are the two source tensors introduced
+    after the source-cut decompositions in \cite[Section~III]{Cirac2017MPU}.
+    The entry formulas also fix the conjugate-transpose orientation.
 \end{definition}
 
 \begin{theorem}[Exact translated two-site source factorization]
@@ -1477,7 +1477,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.mpo_two_pair_entry_eq_sourceU_mul_sourceV_swap,
         MPOTensor.mpo_two_reindex_eq_sourceU_transpose_mul_sourceV_swap_transpose}
     \leanok
-    \uses{def:mpu_source_uv,thm:mpu_source_factorization_entries}
+    \uses{def:mpu_source_uv}
     Identify a two-site physical configuration with an ordered pair in
     $\Fin d\times\Fin d$. Then
     \begin{align}
@@ -1487,19 +1487,20 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     The transpose records the periodic entry orientation. The map
     $\operatorname{swap}_{r,\ell}$ is the explicit equivalence
     $r\times\ell\simeq\ell\times r$; the two product orders are not silently
-    identified. This is the bond swap, or one-site translation, in
-    \cite[Section~III, equations \texttt{SVDforms2}--\texttt{uuvv}]{Cirac2017MPU}.
+    identified. This is the bond swap, or one-site translation, in the
+    source-tensor decomposition of \cite[Section~III]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_source_factorizations}
+    \uses{thm:mpu_source_factorization_entries}
     At physical pairs $(i_1,i_2)$ and $(j_1,j_2)$, expand the periodic trace as
     \begin{align}
         \sum_{\alpha,\beta}
           \mathcal U^{i_1}_{j_1,\alpha,\beta}
           \mathcal U^{i_2}_{j_2,\beta,\alpha}.
     \end{align}
-    Use $M_1=X_1Y_1$ for the first letter and $M_2=X_2Y_2$ for the second.
+    Use the entry forms of $M_1=X_1Y_1$ for the first letter and
+    $M_2=X_2Y_2$ for the second.
     Reordering the four scalar finite sums gives
     \begin{align}
         \sum_{l,r}u_{(l,r),(i_1,i_2)}v_{(j_1,j_2),(r,l)}.


### PR DESCRIPTION
## Summary

- define the paper source tensors `sourceU : Matrix (Fin ℓ[U] × Fin r[U]) (Fin d × Fin d) ℂ` and `sourceV : Matrix (Fin d × Fin d) (Fin r[U] × Fin ℓ[U]) ℂ`
- expose stable entry and conjugate-transpose formulas with the exact solid/dotted source-leg orientation
- prove the entrywise and matrix-level two-site periodic MPO factorization, using `finTwoArrowEquiv` for the physical pair and an explicit `Equiv.prodComm` swap from `r × ℓ` to `ℓ × r`
- document the construction and factorization in Chapter 28 and expose the focused module through the generated MPU aggregator

This follows arXiv:1703.09188, equations `SVDforms2` and `uuvv` (lines 526–540). The transpose in the matrix identity records the periodic MPO entry orientation, while the explicit product equivalence records the paper's one-site translation/bond swap.

The PR is intentionally limited to the `u,v` definitions and exact two-site factorization. It contains no `u`-isometry theorem, source-rank inequality, matching-contraction support, or alternate rank shortcut; those remain in dependent work.

## Validation

- `lake env lean TNLean/MPS/MPU/SourceUV.lean`
- `lake build TNLean.MPS.MPU.SourceUV TNLean.MPS.MPU`
- generated import-aggregator check
- reader-facing prose and proof-integrity scans
- Lean file-policy and text-style checks
- tactic-pattern scan
- source-level blueprint generation/synchronization and changed-declaration coverage (6900 references; Chapter 28 183/183; total 6936/6936)

Closes #5834.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of existing source-factor machinery with no runtime, auth, or data-path changes; risk is limited to proof correctness and index/bond bookkeeping in the new Lean module.
> 
> **Overview**
> Introduces **`sourceU`** and **`sourceV`**—the Cirac et al. source tensors built from the existing weighted source factors—with explicit **ℓ×r** vs **r×ℓ** leg order (no silent identification).
> 
> Adds **`SourceUV.lean`** with `@[simp]` entry and conjugate-transpose formulas, then proves the **exact two-site periodic MPO factorization**: entrywise trace/product identities and the matrix identity **`reindex(U^(2)) = u^T · (swap_{r,ℓ} v)^T`**, using `finTwoArrowEquiv` on physical pairs and **`Equiv.prodComm`** for the bond swap.
> 
> **`MPU.lean`** imports the new module; **Chapter 28** documents the definition and factorization theorem with blueprint `lean` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82cd86670cb0f102a3933fec4b0576e4c004f55f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->