### PR TITLE
refactor(MPDO): factor pair-trace separation duality

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -473,6 +473,32 @@ private theorem exists_pair_trace_repr {m n : Type*} [Fintype m] [Fintype n]
           (f.comp (LinearMap.inr ℂ (Matrix m m ℂ) (Matrix n n ℂ))) M.2 = _
       rw [hA M.1, hB M.2]
 
+private theorem pair_matrix_span_top_of_pair_trace_separating {D₁ D₂ : ℕ}
+    (W : Submodule ℂ
+      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ))
+    (hSep : ∀ (ΔA : Matrix (Fin D₁) (Fin D₁) ℂ)
+        (ΔB : Matrix (Fin D₂) (Fin D₂) ℂ),
+      (∀ M ∈ W, Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0) →
+        ΔA = 0 ∧ ΔB = 0) :
+    W = ⊤ := by
+  classical
+  by_contra hnot
+  have hlt : W < ⊤ := lt_of_le_of_ne le_top hnot
+  obtain ⟨f, hfne, hfker⟩ := Submodule.exists_le_ker_of_lt_top W hlt
+  obtain ⟨ΔA, ΔB, hf_repr⟩ := exists_pair_trace_repr f
+  have hΔ : ΔA = 0 ∧ ΔB = 0 := by
+    refine hSep ΔA ΔB ?_
+    intro M hM
+    have hf0 : f M = 0 := hfker hM
+    simpa [hf_repr] using hf0
+  have hfzero : f = 0 := by
+    apply LinearMap.ext
+    intro M
+    have hM := hf_repr M
+    rw [hΔ.1, hΔ.2] at hM
+    simpa using hM
+  exact hfne hfzero
+
 private theorem pair_trace_zero_on_span {D₁ D₂ : ℕ}
     {Ω : Set (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ)}
     (ΔA : Matrix (Fin D₁) (Fin D₁) ℂ)
@@ -522,27 +548,15 @@ theorem pairWordTupleSpanTop_of_pairTraceSeparatingAt {D₁ D₂ : ℕ}
     PairWordTupleSpanTop A B S := by
   classical
   unfold PairWordTupleSpanTop
-  by_contra hnot
-  let W : Submodule ℂ
-      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
-    Submodule.span ℂ (Set.range (pairWordTuple A B S))
-  have hlt : W < ⊤ := lt_of_le_of_ne le_top (by simpa [W] using hnot)
-  obtain ⟨f, hfne, hfker⟩ := Submodule.exists_le_ker_of_lt_top W hlt
-  obtain ⟨ΔA, ΔB, hf_repr⟩ := exists_pair_trace_repr f
-  have hΔ : ΔA = 0 ∧ ΔB = 0 := by
-    refine hSep ΔA ΔB ?_
-    intro w
-    have hwmem : pairWordTuple A B S w ∈ W :=
-      Submodule.subset_span ⟨w, rfl⟩
-    have hf0 : f (pairWordTuple A B S w) = 0 := hfker hwmem
-    simpa [pairWordTuple, hf_repr] using hf0
-  have hfzero : f = 0 := by
-    apply LinearMap.ext
-    intro M
-    have hM := hf_repr M
-    rw [hΔ.1, hΔ.2] at hM
-    simpa using hM
-  exact hfne hfzero
+  exact pair_matrix_span_top_of_pair_trace_separating
+    (Submodule.span ℂ (Set.range (pairWordTuple A B S))) (by
+      intro ΔA ΔB hZero
+      refine hSep ΔA ΔB ?_
+      intro w
+      have hwmem : pairWordTuple A B S w ∈
+          Submodule.span ℂ (Set.range (pairWordTuple A B S)) :=
+        Submodule.subset_span ⟨w, rfl⟩
+      simpa [pairWordTuple] using hZero (pairWordTuple A B S w) hwmem)
 
 /-- Homogeneous pair product-span gives homogeneous trace separation. -/
 theorem pairTraceSeparatingAt_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
@@ -579,27 +593,14 @@ theorem pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo {D₁ D₂ : �
     PairCumulativeWordTupleSpanTop A B S := by
   classical
   unfold PairCumulativeWordTupleSpanTop
-  by_contra hnot
-  let W : Submodule ℂ
-      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
-    pairCumulativeSpan A B S
-  have hlt : W < ⊤ := lt_of_le_of_ne le_top (by simpa [W] using hnot)
-  obtain ⟨f, hfne, hfker⟩ := Submodule.exists_le_ker_of_lt_top W hlt
-  obtain ⟨ΔA, ΔB, hf_repr⟩ := exists_pair_trace_repr f
-  have hΔ : ΔA = 0 ∧ ΔB = 0 := by
-    refine hSep ΔA ΔB ?_
-    intro w hw
-    have hwmem : pairEvalWordTuple A B w ∈ W :=
-      pairEvalWordTuple_mem_pairCumulativeSpan A B hw
-    have hf0 : f (pairEvalWordTuple A B w) = 0 := hfker hwmem
-    simpa [pairEvalWordTuple, hf_repr] using hf0
-  have hfzero : f = 0 := by
-    apply LinearMap.ext
-    intro M
-    have hM := hf_repr M
-    rw [hΔ.1, hΔ.2] at hM
-    simpa using hM
-  exact hfne hfzero
+  exact pair_matrix_span_top_of_pair_trace_separating
+    (pairCumulativeSpan A B S) (by
+      intro ΔA ΔB hZero
+      refine hSep ΔA ΔB ?_
+      intro w hw
+      have hwmem : pairEvalWordTuple A B w ∈ pairCumulativeSpan A B S :=
+        pairEvalWordTuple_mem_pairCumulativeSpan A B hw
+      simpa [pairEvalWordTuple] using hZero (pairEvalWordTuple A B w) hwmem)
 
 /-- Cumulative pair product-span gives cumulative trace separation. -/
 theorem pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop {D₁ D₂ : ℕ}
@@ -664,27 +665,14 @@ theorem pairAllWordsSpanTop_of_pairTraceSeparatingAll {D₁ D₂ : ℕ}
     PairAllWordsSpanTop A B := by
   classical
   unfold PairAllWordsSpanTop
-  by_contra hnot
-  let W : Submodule ℂ
-      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ) :=
-    pairAllWordsSpan A B
-  have hlt : W < ⊤ := lt_of_le_of_ne le_top (by simpa [W] using hnot)
-  obtain ⟨f, hfne, hfker⟩ := Submodule.exists_le_ker_of_lt_top W hlt
-  obtain ⟨ΔA, ΔB, hf_repr⟩ := exists_pair_trace_repr f
-  have hΔ : ΔA = 0 ∧ ΔB = 0 := by
-    refine hSep ΔA ΔB ?_
-    intro w
-    have hwmem : pairEvalWordTuple A B w ∈ W :=
-      Submodule.subset_span ⟨w, rfl⟩
-    have hf0 : f (pairEvalWordTuple A B w) = 0 := hfker hwmem
-    simpa [pairEvalWordTuple, hf_repr] using hf0
-  have hfzero : f = 0 := by
-    apply LinearMap.ext
-    intro M
-    have hM := hf_repr M
-    rw [hΔ.1, hΔ.2] at hM
-    simpa using hM
-  exact hfne hfzero
+  exact pair_matrix_span_top_of_pair_trace_separating
+    (pairAllWordsSpan A B) (by
+      intro ΔA ΔB hZero
+      refine hSep ΔA ΔB ?_
+      intro w
+      have hwmem : pairEvalWordTuple A B w ∈ pairAllWordsSpan A B :=
+        Submodule.subset_span ⟨w, rfl⟩
+      simpa [pairEvalWordTuple] using hZero (pairEvalWordTuple A B w) hwmem)
 
 /-- The span of all finite pair words gives trace separation by all finite pair words. -/
 theorem pairTraceSeparatingAll_of_pairAllWordsSpanTop {D₁ D₂ : ℕ}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -356,6 +356,17 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### MPDO pair-trace separation duality
+- **Pattern:** use Hahn--Banach separation for a proper pair-matrix submodule,
+  represent the separating functional as a pair trace, and contradict trace
+  separation by proving the representing pair is zero.
+- **Reuse:** the private file-local helper
+  `pair_matrix_span_top_of_pair_trace_separating` in
+  `TNLean/MPS/MPDO/BiCFDerivation/Core.lean`.
+- **Result:** three copies in the homogeneous, cumulative, and all-word pair-span
+  criteria now reduce to generator membership facts. Public theorem statements and
+  trace-pairing order are unchanged.
+
 ### Martingale coefficient upper bound
 - **Pattern:** prove `((1 : ℝ) / (4 * (L : ℝ))) ≤ 1` from `hL : 1 < L` by
   deriving positivity of `L`, casting `1 ≤ L`, and clearing the positive denominator.


### PR DESCRIPTION
### Motivation

- Three BiCF duality proofs repeated the same proper-submodule separation, pair-trace representation, and zero-functional contradiction.
- Mathlib supplies the generic submodule separator but not TNLean's concrete pair-trace representation step.

### Description

- Add private file-local `pair_matrix_span_top_of_pair_trace_separating` for an arbitrary pair-matrix submodule.
- Route the homogeneous, cumulative, and all-word span-from-trace-separation theorems through the helper.
- Leave each public proof responsible only for its distinct generator-membership argument.
- Record the three-occurrence completed local refactor in the tactic ledger.
- Preserve all public statements, trace-pairing order, BiCF source boundaries, Blueprint links, and imports.

### Testing

- `lake env lean TNLean/MPS/MPDO/BiCFDerivation/Core.lean` — success, no output
- `lake build TNLean.MPS.MPDO.BiCFDerivation.Core` — success, 3073 jobs
- `lake build TNLean` — success, 10008 jobs
- `python3 scripts/generate_import_aggregators.py --check` — 51 aggregators / 1298 production modules current
- no new `sorry` / `axiom` / `unsafe`; `git diff --check origin/main...HEAD`
- exact-head independent review — approved, no findings

---
Closes #5892

### Agent assistance

- TeXRA with OpenAI GPT-5.6 identified the three repeated duality proofs, implemented the private helper, and ran targeted/full validation. A separate exact-head review approved the rebased branch; the maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactor inside MPDO BiCF derivation with no API or import changes; mathematical statements and proof obligations are preserved.
> 
> **Overview**
> Extracts the repeated **Hahn–Banach / pair-trace duality** argument into a private helper `pair_matrix_span_top_of_pair_trace_separating` in `BiCFDerivation/Core.lean`. That lemma shows an arbitrary pair-matrix submodule equals the full space when no nonzero pair of trace test matrices annihilate every element of the submodule.
> 
> **`pairWordTupleSpanTop_of_pairTraceSeparatingAt`**, **`pairCumulativeWordTupleSpanTop_of_pairTraceSeparatingUpTo`**, and **`pairAllWordsSpanTop_of_pairTraceSeparatingAll`** now invoke the helper and only prove the distinct generator-membership facts (homogeneous length-`S` words, cumulative words up to `S`, and all finite words). Public theorem statements and trace-pairing conventions are unchanged.
> 
> The tactic ledger documents this as a completed local refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265b0eb1966b2563b1966c2f4332090db4a6421b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->