### PR TITLE
refactor(Channel): relocate partial-transpose algebra lemmas

### DIFF
--- a/TNLean/Channel/BreuerHallIndecomposable.lean
+++ b/TNLean/Channel/BreuerHallIndecomposable.lean
@@ -214,20 +214,6 @@ theorem breuerHallSymmetricWitness_posSemidef (U : Matrix (Fin d) (Fin d) ℂ) :
 
 /-! ## Partial-transpose identities -/
 
-/-- The first-factor partial transpose of the identity matrix is the identity matrix. -/
-theorem partialTransposeLeft_one (d d' : ℕ) :
-    Matrix.partialTransposeLeft (1 : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) = 1 := by
-  ext p q
-  simp only [Matrix.partialTransposeLeft_apply, Matrix.one_apply, Prod.ext_iff]
-  congr 1
-  simp [eq_comm]
-
-/-- The first-factor partial transpose is additive. -/
-theorem partialTransposeLeft_add {d d' : ℕ} (A B : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
-    Matrix.partialTransposeLeft (A + B)
-      = Matrix.partialTransposeLeft A + Matrix.partialTransposeLeft B := by
-  ext p q; simp [Matrix.partialTransposeLeft_apply, Matrix.add_apply]
-
 /-- The first-factor partial transpose of the SWAP operator is the (identity-)twisted
 maximally entangled projector: `F^{T₁} = twistedOmegaProj 1`. -/
 theorem partialTransposeLeft_swapMatrix (d : ℕ) :

--- a/TNLean/Channel/PartialTranspose.lean
+++ b/TNLean/Channel/PartialTranspose.lean
@@ -107,6 +107,22 @@ theorem partialTransposeRight_apply (ρ : Matrix (Fin d × Fin d') (Fin d × Fin
     (p q : Fin d × Fin d') :
     partialTransposeRight ρ p q = ρ (p.1, q.2) (q.1, p.2) := rfl
 
+/-! ### Basic algebraic rules -/
+
+/-- The first-factor partial transpose of the identity matrix is the identity matrix. -/
+theorem partialTransposeLeft_one (d d' : ℕ) :
+    partialTransposeLeft (1 : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) = 1 := by
+  ext p q
+  simp only [partialTransposeLeft_apply, Matrix.one_apply, Prod.ext_iff]
+  congr 1
+  simp [eq_comm]
+
+/-- The first-factor partial transpose is additive. -/
+theorem partialTransposeLeft_add (A B : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    partialTransposeLeft (A + B) = partialTransposeLeft A + partialTransposeLeft B := by
+  ext p q
+  simp [partialTransposeLeft_apply, Matrix.add_apply]
+
 /-! ### Involution -/
 
 /-- The first-factor partial transpose is an involution: `(ρ^{T₁})^{T₁} = ρ`. -/


### PR DESCRIPTION
### Motivation

- `partialTransposeLeft_one` and `partialTransposeLeft_add` are general algebraic facts, but were defined in the specialized Breuer–Hall indecomposability module.

### Description

- Relocate both declarations into `TNLean/Channel/PartialTranspose.lean` beside the core partial-transpose API.
- Preserve both `Matrix.*` FQNs, effective signatures, docstrings, and proof bodies.
- Keep the existing acyclic import chain; Breuer–Hall continues to receive the lemmas through `DecomposablePPT -> PartialTranspose`.
- Add no new imports or Blueprint changes.

### Testing

- direct Lean on both changed files — success, no output
- `lake build TNLean.Channel.PartialTranspose TNLean.Channel.BreuerHallIndecomposable` — success, 3053 jobs
- `lake build TNLean` — success, 10008 jobs
- `python3 scripts/generate_import_aggregators.py --check` — 51 aggregators / 1298 production modules current
- `git diff --check origin/main...HEAD`
- exact-head independent review — approved, no findings; FQNs/signatures/import graph checked

---
Closes LionSR/QICLean#282

### Agent assistance

- TeXRA with OpenAI GPT-5.6 performed the relocation and ran targeted/full validation. A separate exact-head review approved the branch; the maintainer reviewed the complete diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure file relocation of general algebraic lemmas with preserved proofs and no import-graph changes; behavior and API surface stay the same.
> 
> **Overview**
> Moves **`partialTransposeLeft_one`** and **`partialTransposeLeft_add`** out of the Breuer–Hall indecomposability file into **`PartialTranspose.lean`**, grouped under a new **Basic algebraic rules** section next to the core partial-transpose API.
> 
> The two lemmas are removed from **`BreuerHallIndecomposable.lean`**; proofs, docstrings, and effective behavior are unchanged. Breuer–Hall proofs still call them (sometimes with the `Matrix.` prefix) via the existing import chain through **`DecomposablePPT`** → **`PartialTranspose`**, with no new imports or Blueprint updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 055dba04eebd862e527c301e2e9822d421dbd68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->