### PR TITLE
refactor(Channel): extract generic corner compression

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -32,6 +32,7 @@ import TNLean.Channel.InformationallyCompleteEffects
 import TNLean.Channel.Irreducible
 import TNLean.Channel.KoashiImoto
 import TNLean.Channel.KrausCPTP
+import TNLean.Channel.KrausCornerCompression
 import TNLean.Channel.KrausFreedom
 import TNLean.Channel.KrausMap
 import TNLean.Channel.KrausRank

--- a/TNLean/Channel/FixedPoint/CornerAlgebra.lean
+++ b/TNLean/Channel/FixedPoint/CornerAlgebra.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Channel.Peripheral.CyclicDecomposition.Basic
+import TNLean.Algebra.CornerCompression
 import Mathlib.RingTheory.Idempotents
 
 /-!

--- a/TNLean/Channel/FixedPoint/CornerBlockForm.lean
+++ b/TNLean/Channel/FixedPoint/CornerBlockForm.lean
@@ -102,8 +102,8 @@ theorem cornerFixedPoints_blockDiagonal_iff
   have hAtp : ∑ i : Fin d, (A i)ᴴ * A i = Q :=
     cornerCompressionKraus_isTP K h_tp hQproj hInv
   -- Compress the corner family to the support sector along the isometry `V`.
-  obtain ⟨r, C, φ, V, -, hCtp, -, hIntertw, -, -, hLetter, hVtV, hVVt, hφV⟩ :=
-    MPSTensor.exists_compressedTensor_of_supported_projection_with_letter_and_isometry
+  obtain ⟨r, C, φ, V, -, hCtp, hIntertw, -, -, -, hCi, hVtV, hVVt, hφV⟩ :=
+    exists_cornerCompression_of_supported_projection
       A Q hQproj hAsupp hAtp
   have hCtp' : IsTP C := hCtp
   have hCi : ∀ i : Fin d, C i = Vᴴ * A i * V := by
@@ -153,16 +153,9 @@ theorem cornerFixedPoints_blockDiagonal_iff
     intro X
     have hφmem : Q * (φ X).1 * Q = (φ X).1 := (φ X).2
     have hintertw' : (φ (adjointMap C X)).1 = Q * adjointMap K (φ X).1 * Q := by
-      have h1 : (φ (MPSTensor.transferMap (d := d) (D := r) (fun i => (C i)ᴴ) X)).1 =
-          MPSTensor.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1) := hIntertw X
-      have h2 : MPSTensor.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1) =
-          adjointMap A (φ X).1 := by simp [adjointMap, MPSTensor.transferMap_apply]
-      have h3 : adjointMap A (φ X).1 = Q * adjointMap K (φ X).1 * Q := by
-        rw [hAdef]; exact adjointMap_cornerCompressionKraus_eq K hQproj hφmem
-      have h4 : MPSTensor.transferMap (d := d) (D := r) (fun i => (C i)ᴴ) X =
-          adjointMap C X := by simp [adjointMap, MPSTensor.transferMap_apply]
-      rw [h4] at h1
-      rw [h1, h2, h3]
+      rw [hIntertw X]
+      rw [hAdef]
+      exact adjointMap_cornerCompressionKraus_eq K hQproj hφmem
     constructor
     · intro hfix
       have hval : (φ (adjointMap C X)).1 = (φ X).1 := by rw [hintertw', hfix]

--- a/TNLean/Channel/FixedPoint/CornerBlockForm.lean
+++ b/TNLean/Channel/FixedPoint/CornerBlockForm.lean
@@ -103,7 +103,7 @@ theorem cornerFixedPoints_blockDiagonal_iff
     cornerCompressionKraus_isTP K h_tp hQproj hInv
   -- Compress the corner family to the support sector along the isometry `V`.
   obtain ⟨r, C, φ, V, -, hCtp, hIntertw, -, -, -, hCi, hVtV, hVVt, hφV⟩ :=
-    exists_cornerCompression_of_supported_projection
+    exists_corner_compression_of_supported_projection
       A Q hQproj hAsupp hAtp
   have hCtp' : IsTP C := hCtp
   -- The compressed Schrödinger map has the positive definite fixed point `σ`.

--- a/TNLean/Channel/FixedPoint/CornerBlockForm.lean
+++ b/TNLean/Channel/FixedPoint/CornerBlockForm.lean
@@ -93,8 +93,8 @@ theorem cornerFixedPoints_blockDiagonal_iff
   have hQproj : IsOrthogonalProjection Q := isOrthogonalProjection_stationaryProj hρ_psd
   have hInv : ∀ i : Fin d, (1 - Q) * K i * Q = 0 :=
     stationaryProj_lowerZero K hρ_psd hρ_fix
-  have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
-  have hρQ : ρ * Q = ρ := MPSTensor.mul_supportProj (D := D) (ρ := ρ) hρ_psd
+  have hQρ : Q * ρ = ρ := stationaryProj_mul hρ_psd
+  have hρQ : ρ * Q = ρ := mul_stationaryProj hρ_psd
   have hQρQ : Q * ρ * Q = ρ := by rw [hQρ, hρQ]
   set A : Fin d → Mat := cornerCompressionKraus K Q with hAdef
   have hAsupp : ∀ i : Fin d, Q * A i * Q = A i :=
@@ -106,13 +106,6 @@ theorem cornerFixedPoints_blockDiagonal_iff
     exists_cornerCompression_of_supported_projection
       A Q hQproj hAsupp hAtp
   have hCtp' : IsTP C := hCtp
-  have hCi : ∀ i : Fin d, C i = Vᴴ * A i * V := by
-    intro i
-    have h : V * C i * Vᴴ = A i := by simpa [hφV] using hLetter i
-    calc
-      C i = (Vᴴ * V) * C i * (Vᴴ * V) := by rw [hVtV]; simp
-      _ = Vᴴ * (V * C i * Vᴴ) * V := by simp [Matrix.mul_assoc]
-      _ = Vᴴ * A i * V := by rw [h]
   -- The compressed Schrödinger map has the positive definite fixed point `σ`.
   set σ : Matrix (Fin r) (Fin r) ℂ := Vᴴ * ρ * V with hσdef
   have hσpd : σ.PosDef := by

--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -302,14 +302,15 @@ theorem cornerFixed_mul
   rw [hφX₁₂] at hfinal
   exact hfinal
 
-/-- **Wolf Corollary 6.6.**
+/-- **Finite-Kraus strengthening of Wolf Corollary 6.6.**
 
 Let `T*(Y) = ∑ᵢ Kᵢ† Y Kᵢ` (`= adjointMap K`) be a trace-preserving Schwarz map,
 so unitality of `T*` is `IsTP K`. Let `ρ` be a PSD fixed point of the Schrödinger
 map `T = map K`, with support projection `Q := stationaryProj`. Then the
 corner-restricted fixed-point set
 `{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}`
-is a `StarSubalgebra` of the corner algebra `Q M_D(ℂ) Q`.
+is a `StarSubalgebra` of the corner algebra `Q M_D(ℂ) Q`. Wolf Corollary 6.6 is
+recovered when `ρ` is chosen with maximum rank.
 
 The carrier consists of the corner elements `Y : hQ.Corner` (`Q Y Q = Y`) with
 `Q (adjointMap K Y) Q = Y`. -/

--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -7,8 +7,8 @@ import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.StationaryProjection
 import TNLean.Channel.FixedPoint.SupportInvariance
-import TNLean.Channel.Spectral.Support
 import TNLean.Channel.KrausCornerCompression
+import TNLean.Channel.Spectral.Support
 
 /-!
 # Corner-restricted fixed points for finite Kraus maps

--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -8,7 +8,7 @@ import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.StationaryProjection
 import TNLean.Channel.FixedPoint.SupportInvariance
 import TNLean.Channel.Spectral.Support
-import TNLean.MPS.CanonicalForm.CyclicSectors.Compression
+import TNLean.Channel.KrausCornerCompression
 
 /-!
 # Corner-restricted fixed points form a `*`-algebra (Wolf Corollary 6.6)
@@ -222,17 +222,11 @@ theorem cornerFixed_mul
     cornerCompressionKraus_supported K hQproj
   have hAtp : ∑ i : Fin d, (A i)ᴴ * A i = Q :=
     cornerCompressionKraus_isTP K h_tp hQproj hInv
-  obtain ⟨n, C, φ, V, _hdim, hCtp, _hMpv, hIntertw, hMul, _hStar, hLetter, hVtV, hVVt, hφV⟩ :=
-    MPSTensor.exists_compressedTensor_of_supported_projection_with_letter_and_isometry
+  obtain ⟨n, C, φ, V, _hdim, hCtp, hIntertw, hMul, _hStar, hLetter, hCi,
+    hVtV, hVVt, hφV⟩ :=
+    exists_cornerCompression_of_supported_projection
       A Q hQproj hAsupp hAtp
   have hCtp' : IsTP C := hCtp
-  have hCi : ∀ i : Fin d, C i = Vᴴ * A i * V := by
-    intro i
-    have h : V * C i * Vᴴ = A i := by simpa [hφV] using hLetter i
-    calc
-      C i = (Vᴴ * V) * C i * (Vᴴ * V) := by rw [hVtV]; simp
-      _ = Vᴴ * (V * C i * Vᴴ) * V := by simp [Matrix.mul_assoc]
-      _ = Vᴴ * A i * V := by rw [h]
   set σ : Matrix (Fin n) (Fin n) ℂ := Vᴴ * ρ * V with hσdef
   have hσpd : σ.PosDef := by
     have := Matrix.PosSemidef.compression_on_support_posDef (D := D) (ρ := ρ) hρ_psd
@@ -272,16 +266,9 @@ theorem cornerFixed_mul
     intro X
     have hφmem : Q * (φ X).1 * Q = (φ X).1 := (φ X).2
     have hintertw' : (φ (adjointMap C X)).1 = Q * adjointMap K (φ X).1 * Q := by
-      have h1 : (φ (MPSTensor.transferMap (d := d) (D := n) (fun i => (C i)ᴴ) X)).1 =
-          MPSTensor.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1) := hIntertw X
-      have h2 : MPSTensor.transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1) =
-          adjointMap A (φ X).1 := by simp [adjointMap, MPSTensor.transferMap_apply]
-      have h3 : adjointMap A (φ X).1 = Q * adjointMap K (φ X).1 * Q := by
-        rw [hAdef]; exact adjointMap_cornerCompressionKraus_eq K hQproj hφmem
-      have h4 : MPSTensor.transferMap (d := d) (D := n) (fun i => (C i)ᴴ) X =
-          adjointMap C X := by simp [adjointMap, MPSTensor.transferMap_apply]
-      rw [h4] at h1
-      rw [h1, h2, h3]
+      rw [hIntertw X]
+      rw [hAdef]
+      exact adjointMap_cornerCompressionKraus_eq K hQproj hφmem
     constructor
     · intro hfix
       have hval : (φ (adjointMap C X)).1 = (φ X).1 := by rw [hintertw', hfix]

--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -11,29 +11,30 @@ import TNLean.Channel.Spectral.Support
 import TNLean.Channel.KrausCornerCompression
 
 /-!
-# Corner-restricted fixed points form a `*`-algebra (Wolf Corollary 6.6)
+# Corner-restricted fixed points for finite Kraus maps
 
-This file formalizes Wolf Corollary 6.6. Let `T*(Y) = ∑ᵢ Kᵢ† Y Kᵢ` be a
-trace-preserving Schwarz map (here represented by a Kraus family `K`, so that
-`T* = adjointMap K` and unitality of `T*` is `IsTP K`). Let `ρ` be the
-maximum-rank fixed point of the Schrödinger map `T(X) = ∑ᵢ Kᵢ X Kᵢ†` and let
-`Q := supportProj ρ` be its support projection. Then the corner-restricted
-fixed-point set
+This file proves the completely positive finite-Kraus specialization of Wolf
+Corollary 6.6. Wolf assumes an abstract unital Schwarz map, whereas the Kraus
+presentation here imposes complete positivity. Write
+`T(X) = ∑ᵢ Kᵢ X Kᵢ†` and `T*(Y) = ∑ᵢ Kᵢ† Y Kᵢ`. Within the finite-Kraus setting,
+the result strengthens the maximum-rank-fixed-point case by allowing any positive
+semidefinite fixed point `ρ` of `T`. If `Q := supportProj ρ`, then
 `{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}`
-is a `*`-subalgebra of the corner algebra `Q M_D(ℂ) Q`.
+is a `*`-subalgebra of the corner algebra `Q M_D(ℂ) Q`. At maximum rank this is
+the completely positive finite-Kraus specialization of Wolf Corollary 6.6.
 
-The proof follows Wolf: the stated set is exactly the fixed-point set of the
-compressed adjoint map on the support sector. The compressed Kraus family is
-trace-preserving on the sector and the compressed Schrödinger map has a
-positive-definite (full-rank) fixed point, so Wolf Theorem 6.12 applies.
-The `*`-algebra structure is then transported back to the ambient corner along
-the compression isomorphism `φ : M_n(ℂ) ≃ Q M_D(ℂ) Q`.
+The proof follows Wolf's support-compression argument. The stated set is the
+fixed-point set of the compressed adjoint map on the support sector. The
+compressed Kraus family is trace-preserving on the sector and the compressed
+Schrödinger map has a positive-definite fixed point, so Wolf Theorem 6.12
+applies. The `*`-algebra structure is then carried back to the ambient corner
+along the compression isomorphism `φ : M_n(ℂ) ≃ Q M_D(ℂ) Q`.
 
 ## Main declarations
 
 * `Kraus.cornerCompressionKraus`: the compressed Kraus family `Q Kᵢ Q`.
-* `Kraus.cornerFixedPointsStarSubalgebra`: Wolf Corollary 6.6 — the
-  corner-restricted fixed points form a `StarSubalgebra` of the corner algebra.
+* `Kraus.cornerFixedPointsStarSubalgebra`: the finite-Kraus support-corner fixed
+  points form a `StarSubalgebra` of the corner algebra.
 
 The block representation of this corner algebra, in the sense of Equation (1.39) of
 *Quantum Channels & Operations* (Wolf 2012) with the zero block on the complement of the
@@ -302,15 +303,22 @@ theorem cornerFixed_mul
   rw [hφX₁₂] at hfinal
   exact hfinal
 
-/-- **Finite-Kraus strengthening of Wolf Corollary 6.6.**
+/-- **Support-corner fixed points for finite Kraus maps.**
 
-Let `T*(Y) = ∑ᵢ Kᵢ† Y Kᵢ` (`= adjointMap K`) be a trace-preserving Schwarz map,
-so unitality of `T*` is `IsTP K`. Let `ρ` be a PSD fixed point of the Schrödinger
-map `T = map K`, with support projection `Q := stationaryProj`. Then the
-corner-restricted fixed-point set
+Let `T*(Y) = ∑ᵢ Kᵢ† Y Kᵢ` (`= adjointMap K`) be the adjoint of a
+trace-preserving finite Kraus map. Let `ρ` be a PSD fixed point of the
+Schrödinger map `T = map K`, with support projection `Q := stationaryProj`.
+Then the corner-restricted fixed-point set
 `{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}`
-is a `StarSubalgebra` of the corner algebra `Q M_D(ℂ) Q`. Wolf Corollary 6.6 is
-recovered when `ρ` is chosen with maximum rank.
+is a `StarSubalgebra` of the corner algebra `Q M_D(ℂ) Q`. Within the
+finite-Kraus setting, this strengthens the maximum-rank-fixed-point case by
+allowing an arbitrary PSD fixed point. At maximum rank it gives the completely
+positive finite-Kraus specialization of Wolf Corollary 6.6.
+
+**Scope restriction (finite Kraus family):** Wolf Corollary 6.6 assumes an
+abstract unital Schwarz map, while a finite Kraus representation imposes
+complete positivity. See
+`docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex`.
 
 The carrier consists of the corner elements `Y : hQ.Corner` (`Q Y Q = Y`) with
 `Q (adjointMap K Y) Q = Y`. -/

--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -16,19 +16,19 @@ import TNLean.Channel.Spectral.Support
 This file proves the completely positive finite-Kraus specialization of Wolf
 Corollary 6.6. Wolf assumes an abstract unital Schwarz map, whereas the Kraus
 presentation here imposes complete positivity. Write
-`T(X) = ∑ᵢ Kᵢ X Kᵢ†` and `T*(Y) = ∑ᵢ Kᵢ† Y Kᵢ`. Within the finite-Kraus setting,
+\(T(X) = ∑ᵢ Kᵢ X Kᵢ†\) and \(T^*(Y) = ∑ᵢ Kᵢ† Y Kᵢ\). Within the finite-Kraus setting,
 the result strengthens the maximum-rank-fixed-point case by allowing any positive
-semidefinite fixed point `ρ` of `T`. If `Q := supportProj ρ`, then
-`{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}`
-is a `*`-subalgebra of the corner algebra `Q M_D(ℂ) Q`. At maximum rank this is
+semidefinite fixed point \(ρ\) of \(T\). If \(Q\) is the support projection of \(ρ\), then
+\(\{Y ∈ Q M_D(ℂ) Q \mid Q T^*(Y) Q = Y\}\)
+is a \(*\)-subalgebra of the corner algebra \(Q M_D(ℂ) Q\). At maximum rank this is
 the completely positive finite-Kraus specialization of Wolf Corollary 6.6.
 
 The proof follows Wolf's support-compression argument. The stated set is the
 fixed-point set of the compressed adjoint map on the support sector. The
 compressed Kraus family is trace-preserving on the sector and the compressed
 Schrödinger map has a positive-definite fixed point, so Wolf Theorem 6.12
-applies. The `*`-algebra structure is then carried back to the ambient corner
-along the compression isomorphism `φ : M_n(ℂ) ≃ Q M_D(ℂ) Q`.
+applies. The \(*\)-algebra structure is then carried back to the ambient corner
+along the compression isomorphism \(φ : M_n(ℂ) ≃ Q M_D(ℂ) Q\).
 
 ## Main declarations
 
@@ -305,12 +305,12 @@ theorem cornerFixed_mul
 
 /-- **Support-corner fixed points for finite Kraus maps.**
 
-Let `T*(Y) = ∑ᵢ Kᵢ† Y Kᵢ` (`= adjointMap K`) be the adjoint of a
-trace-preserving finite Kraus map. Let `ρ` be a PSD fixed point of the
-Schrödinger map `T = map K`, with support projection `Q := stationaryProj`.
-Then the corner-restricted fixed-point set
-`{Y ∈ Q M_D(ℂ) Q | Q T*(Y) Q = Y}`
-is a `StarSubalgebra` of the corner algebra `Q M_D(ℂ) Q`. Within the
+Let \(T^*(Y) = ∑ᵢ Kᵢ† Y Kᵢ\), represented by `adjointMap K`, be the adjoint of a
+trace-preserving finite Kraus map. Let \(ρ\) be a PSD fixed point of the
+Schrödinger map \(T\), represented by `map K`, with support projection \(Q\),
+represented by `stationaryProj`. Then the corner-restricted fixed-point set
+\(\{Y ∈ Q M_D(ℂ) Q \mid Q T^*(Y) Q = Y\}\)
+is a `StarSubalgebra` of the corner algebra \(Q M_D(ℂ) Q\). Within the
 finite-Kraus setting, this strengthens the maximum-rank-fixed-point case by
 allowing an arbitrary PSD fixed point. At maximum rank it gives the completely
 positive finite-Kraus specialization of Wolf Corollary 6.6.
@@ -320,8 +320,8 @@ abstract unital Schwarz map, while a finite Kraus representation imposes
 complete positivity. See
 `docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex`.
 
-The carrier consists of the corner elements `Y : hQ.Corner` (`Q Y Q = Y`) with
-`Q (adjointMap K Y) Q = Y`. -/
+The carrier consists of the corner elements `Y : hQ.Corner` satisfying \(QYQ=Y\) and
+\(Q\,T^*(Y)\,Q=Y\). -/
 noncomputable def cornerFixedPointsStarSubalgebra
     (K : Fin d → Mat) (h_tp : IsTP K) {ρ : Mat} (hρ_psd : ρ.PosSemidef)
     (hρ_fix : map K ρ = ρ) :

--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -224,7 +224,7 @@ theorem cornerFixed_mul
     cornerCompressionKraus_isTP K h_tp hQproj hInv
   obtain ⟨n, C, φ, V, _hdim, hCtp, hIntertw, hMul, _hStar, hLetter, hCi,
     hVtV, hVVt, hφV⟩ :=
-    exists_cornerCompression_of_supported_projection
+    exists_corner_compression_of_supported_projection
       A Q hQproj hAsupp hAtp
   have hCtp' : IsTP C := hCtp
   set σ : Matrix (Fin n) (Fin n) ℂ := Vᴴ * ρ * V with hσdef

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -160,8 +160,8 @@ private theorem exists_weighted_compression
     cornerCompressionKraus_supported K hQproj
   have hAtp : ∑ i : Fin d, (A i)ᴴ * A i = Q :=
     cornerCompressionKraus_isTP K h_tp hQproj hInv
-  obtain ⟨r, C, φ, V, -, hCtp, -, -, -, -, hLetter, hVtV, hVVt, hφV⟩ :=
-    MPSTensor.exists_compressedTensor_of_supported_projection_with_letter_and_isometry
+  obtain ⟨r, C, _φ, V, -, hCtp, -, -, -, -, hCi, hVtV, hVVt, -⟩ :=
+    exists_cornerCompression_of_supported_projection
       A Q hQproj hAsupp hAtp
   have hCtp' : IsTP C := hCtp
   have hCi : ∀ i : Fin d, C i = Vᴴ * A i * V := by

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -71,7 +71,7 @@ theorem stationaryProj_mul_cfc_sqrt {ρ : Mat} (hρ_psd : ρ.PosSemidef) :
   have hS_herm : Sᴴ = S := by
     simpa [S] using Matrix.conjTranspose_cfc_sqrt ρ
   have hSS : S * S = ρ := CFC.sqrt_mul_sqrt_self ρ hρ_psd.nonneg
-  have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
+  have hQρ : Q * ρ = ρ := stationaryProj_mul hρ_psd
   -- `(1 - Q) S` has vanishing square, hence vanishes.
   have h0 : ((1 - Q) * S) * ((1 - Q) * S)ᴴ = 0 := by
     have h1 : (1 - Q)ᴴ = 1 - Q := by
@@ -152,8 +152,8 @@ private theorem exists_weighted_compression
   have hQherm : Qᴴ = Q := hQproj.1.eq
   have hInv : ∀ i : Fin d, (1 - Q) * K i * Q = 0 :=
     stationaryProj_lowerZero K hρ_psd hρ_fix
-  have hQρ : Q * ρ = ρ := MPSTensor.supportProj_mul (D := D) (ρ := ρ) hρ_psd
-  have hρQ : ρ * Q = ρ := MPSTensor.mul_supportProj (D := D) (ρ := ρ) hρ_psd
+  have hQρ : Q * ρ = ρ := stationaryProj_mul hρ_psd
+  have hρQ : ρ * Q = ρ := mul_stationaryProj hρ_psd
   have hQρQ : Q * ρ * Q = ρ := by rw [hQρ, hρQ]
   set A : Fin d → Mat := cornerCompressionKraus K Q with hAdef
   have hAsupp : ∀ i : Fin d, Q * A i * Q = A i :=
@@ -164,13 +164,6 @@ private theorem exists_weighted_compression
     exists_cornerCompression_of_supported_projection
       A Q hQproj hAsupp hAtp
   have hCtp' : IsTP C := hCtp
-  have hCi : ∀ i : Fin d, C i = Vᴴ * A i * V := by
-    intro i
-    have h : V * C i * Vᴴ = A i := by simpa [hφV] using hLetter i
-    calc
-      C i = (Vᴴ * V) * C i * (Vᴴ * V) := by rw [hVtV]; simp
-      _ = Vᴴ * (V * C i * Vᴴ) * V := by simp [Matrix.mul_assoc]
-      _ = Vᴴ * A i * V := by rw [h]
   set σ : Matrix (Fin r) (Fin r) ℂ := Vᴴ * ρ * V with hσdef
   have hσpd : σ.PosDef := by
     have := Matrix.PosSemidef.compression_on_support_posDef (D := D) (ρ := ρ) hρ_psd

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -161,7 +161,7 @@ private theorem exists_weighted_compression
   have hAtp : ∑ i : Fin d, (A i)ᴴ * A i = Q :=
     cornerCompressionKraus_isTP K h_tp hQproj hInv
   obtain ⟨r, C, _φ, V, -, hCtp, -, -, -, -, hCi, hVtV, hVVt, -⟩ :=
-    exists_cornerCompression_of_supported_projection
+    exists_corner_compression_of_supported_projection
       A Q hQproj hAsupp hAtp
   have hCtp' : IsTP C := hCtp
   set σ : Matrix (Fin r) (Fin r) ℂ := Vᴴ * ρ * V with hσdef

--- a/TNLean/Channel/KrausCornerCompression.lean
+++ b/TNLean/Channel/KrausCornerCompression.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.CornerCompression
+import TNLean.Channel.KrausMap
+
+/-!
+# Compression of a finite Kraus family to a projection corner
+
+A finite matrix family supported on an orthogonal projection can be represented on the
+support coordinates of that projection. The resulting family is trace-preserving when the
+ambient normalization equals the projection. The support isometry identifies its Kraus map
+and adjoint map with the corresponding ambient corner actions.
+
+## Main declaration
+
+* `Kraus.exists_cornerCompression_of_supported_projection`: compression of a supported
+  finite Kraus family to the support matrix algebra.
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {d D : ℕ}
+
+/-- Compress a finite matrix family supported on an orthogonal projection to the support
+matrix algebra. The result includes the corner equivalence, its support isometry, the
+trace-preserving normalization, the adjoint-map intertwining, and the algebraic identities
+needed to move between the compressed and ambient corners. -/
+theorem exists_cornerCompression_of_supported_projection
+    (A : Fin d → MatrixAlg D) (P : MatrixAlg D)
+    (hP : IsOrthogonalProjection P)
+    (hSupp : ∀ i : Fin d, P * A i * P = A i)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = P) :
+    ∃ (n : ℕ) (C : Fin d → MatrixAlg n)
+      (φ : MatrixAlg n ≃ₗ[ℂ] cornerSubmodule P)
+      (V : Matrix (Fin D) (Fin n) ℂ),
+      ((n : ℂ) = Matrix.trace P) ∧
+      IsTP C ∧
+      (∀ X : MatrixAlg n,
+        (φ (adjointMap C X)).1 = adjointMap A (φ X).1) ∧
+      (∀ X Y : MatrixAlg n, (φ (X * Y)).1 = (φ X).1 * (φ Y).1) ∧
+      (∀ X : MatrixAlg n, (φ Xᴴ).1 = ((φ X).1)ᴴ) ∧
+      (∀ i : Fin d, (φ (C i)).1 = A i) ∧
+      (∀ i : Fin d, C i = Vᴴ * A i * V) ∧
+      Vᴴ * V = 1 ∧
+      V * Vᴴ = P ∧
+      (∀ X : MatrixAlg n, (φ X).1 = V * X * Vᴴ) := by
+  classical
+  obtain ⟨Umat, S, T, n, -, eST, eS, hUU, hU'U, hPdiag_std, hP_decomp,
+    hPdiag_back, htrace, -⟩ := ProjectionSpectralSplit.ofOrthogonalProjection P hP
+  let Pdiag : MatrixAlg D := Umatᴴ * P * Umat
+  let P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
+    Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)
+  let expand : MatrixAlg n →ₗ[ℂ] MatrixAlg D :=
+    cornerCompressionExpand Umat eST eS
+  let φ : MatrixAlg n ≃ₗ[ℂ] cornerSubmodule P :=
+    cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 rfl
+      hP_decomp rfl hPdiag_std hPdiag_back hU'U hUU
+  let V : Matrix (Fin D) (Fin n) ℂ := cornerCompressionIsometry Umat eST eS
+  have hV_iso : Vᴴ * V = 1 :=
+    cornerCompressionIsometry_conjTranspose_mul Umat eST eS hU'U
+  have hExpand_one : expand 1 = P :=
+    cornerCompressionExpand_one (P := P) (Pdiag := Pdiag) Umat eST eS P0 rfl
+      hP_decomp hPdiag_back
+  have hV_range : V * Vᴴ = P := by
+    rw [show V * Vᴴ = expand 1 by
+      simpa [V, expand] using
+        (cornerCompressionExpand_eq_isometry Umat eST eS (1 : MatrixAlg n)).symm]
+    exact hExpand_one
+  have hφ_apply (X : MatrixAlg n) : (φ X).1 = expand X := rfl
+  have hExpand_eq_V (X : MatrixAlg n) : expand X = V * X * Vᴴ := by
+    simpa [expand, V] using cornerCompressionExpand_eq_isometry Umat eST eS X
+  let C : Fin d → MatrixAlg n := fun i => Vᴴ * A i * V
+  have hCompression : ∀ i : Fin d, C i = Vᴴ * A i * V := fun _ => rfl
+  have hLetter : ∀ i : Fin d, expand (C i) = A i := by
+    intro i
+    rw [hExpand_eq_V]
+    change V * (Vᴴ * A i * V) * Vᴴ = A i
+    calc
+      V * (Vᴴ * A i * V) * Vᴴ = (V * Vᴴ) * A i * (V * Vᴴ) := by
+        simp only [Matrix.mul_assoc]
+      _ = P * A i * P := by rw [hV_range]
+      _ = A i := hSupp i
+  refine ⟨n, C, φ, V, htrace, ?_, ?_, ?_, ?_, ?_, hCompression,
+    hV_iso, hV_range, ?_⟩
+  · change ∑ i : Fin d, (C i)ᴴ * C i = 1
+    apply φ.injective
+    apply Subtype.ext
+    rw [hφ_apply, hφ_apply, map_sum]
+    have hsum : (∑ i : Fin d, expand ((C i)ᴴ * C i)) =
+        ∑ i : Fin d, (A i)ᴴ * A i := by
+      refine Finset.sum_congr rfl ?_
+      intro i _
+      rw [cornerCompressionExpand_mul Umat eST eS hU'U,
+        ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
+    calc
+      (∑ i : Fin d, expand ((C i)ᴴ * C i)) = ∑ i : Fin d, (A i)ᴴ * A i := hsum
+      _ = P := hTP
+      _ = expand 1 := by rw [hExpand_one]
+  · intro Z
+    rw [hφ_apply]
+    simp only [adjointMap_apply]
+    rw [map_sum]
+    refine Finset.sum_congr rfl ?_
+    intro i _
+    rw [cornerCompressionExpand_mul Umat eST eS hU'U,
+      cornerCompressionExpand_mul Umat eST eS hU'U,
+      ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
+  · intro X Y
+    simp only [hφ_apply]
+    exact cornerCompressionExpand_mul Umat eST eS hU'U X Y
+  · intro X
+    simp only [hφ_apply]
+    exact (cornerCompressionExpand_conjTranspose Umat eST eS X).symm
+  · intro i
+    rw [hφ_apply]
+    exact hLetter i
+  · intro X
+    rw [hφ_apply, hExpand_eq_V]
+
+end Kraus

--- a/TNLean/Channel/KrausCornerCompression.lean
+++ b/TNLean/Channel/KrausCornerCompression.lean
@@ -16,7 +16,7 @@ and adjoint map with the corresponding ambient corner actions.
 
 ## Main declaration
 
-* `Kraus.exists_cornerCompression_of_supported_projection`: compression of a supported
+* `Kraus.exists_corner_compression_of_supported_projection`: compression of a supported
   finite Kraus family to the support matrix algebra.
 -/
 
@@ -31,7 +31,7 @@ variable {d D : ℕ}
 matrix algebra. The result includes the corner equivalence, its support isometry, the
 trace-preserving normalization, the adjoint-map intertwining, and the algebraic identities
 needed to move between the compressed and ambient corners. -/
-theorem exists_cornerCompression_of_supported_projection
+theorem exists_corner_compression_of_supported_projection
     (A : Fin d → MatrixAlg D) (P : MatrixAlg D)
     (hP : IsOrthogonalProjection P)
     (hSupp : ∀ i : Fin d, P * A i * P = A i)

--- a/TNLean/Channel/KrausCornerCompression.lean
+++ b/TNLean/Channel/KrausCornerCompression.lean
@@ -14,7 +14,7 @@ support coordinates of that projection. The resulting family is trace-preserving
 ambient normalization equals the projection. The support isometry identifies its Kraus map
 and adjoint map with the corresponding ambient corner actions.
 
-## Main declaration
+## Main results
 
 * `Kraus.exists_corner_compression_of_supported_projection`: compression of a supported
   finite Kraus family to the support matrix algebra.

--- a/TNLean/Channel/KrausCornerCompression.lean
+++ b/TNLean/Channel/KrausCornerCompression.lean
@@ -103,7 +103,7 @@ theorem exists_cornerCompression_of_supported_projection
       _ = P := hTP
       _ = expand 1 := by rw [hExpand_one]
   · intro Z
-    rw [hφ_apply]
+    change expand (adjointMap C Z) = adjointMap A (expand Z)
     simp only [adjointMap_apply]
     rw [map_sum]
     refine Finset.sum_congr rfl ?_

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Channel.Peripheral.CyclicDecomposition
 import TNLean.Channel.KrausCornerCompression
+import TNLean.Channel.Peripheral.CyclicDecomposition
 
 /-!
 # Compression to cyclic sectors

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -69,7 +69,7 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       (∀ X : Matrix (Fin n) (Fin n) ℂ, (φ X).1 = V * X * Vᴴ) := by
   obtain ⟨n, C, φ, V, hdim, hCtp, hIntertw, hMul, hStar, hLetter, hCompression,
     hVtV, hVVt, hφV⟩ :=
-    Kraus.exists_cornerCompression_of_supported_projection A P hP hSupp hTP
+    Kraus.exists_corner_compression_of_supported_projection A P hP hSupp hTP
   have hPV : P * V = V := by
     rw [← hVVt, Matrix.mul_assoc, hVtV, Matrix.mul_one]
   have hIntertwineLetter : ∀ i : Fin d, A i * V = V * C i := by

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Peripheral.CyclicDecomposition
+import TNLean.Channel.KrausCornerCompression
 
 /-!
 # Compression to cyclic sectors
@@ -66,76 +67,30 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       Vᴴ * V = 1 ∧
       V * Vᴴ = P ∧
       (∀ X : Matrix (Fin n) (Fin n) ℂ, (φ X).1 = V * X * Vᴴ) := by
-  classical
-  obtain ⟨Umat, S, T, n, -, eST, eS, hUU, hU'U, hPdiag_std, hP_decomp,
-    hPdiag_back, htrace, -⟩ := ProjectionSpectralSplit.ofOrthogonalProjection P hP
-  let Pdiag : MatrixAlg D := Umatᴴ * P * Umat
-  let P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-    Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)
-  let expand : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] MatrixAlg D :=
-    cornerCompressionExpand Umat eST eS
-  let φ : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
-    cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 rfl
-      hP_decomp rfl hPdiag_std hPdiag_back hU'U hUU
-  let V : Matrix (Fin D) (Fin n) ℂ := cornerCompressionIsometry Umat eST eS
-  have hV_iso : Vᴴ * V = 1 := by
-    exact cornerCompressionIsometry_conjTranspose_mul Umat eST eS hU'U
-  have hExpand_one : expand 1 = P := by
-    exact cornerCompressionExpand_one (P := P) (Pdiag := Pdiag) Umat eST eS P0 rfl
-      hP_decomp hPdiag_back
-  have hV_range : V * Vᴴ = P := by
-    rw [show V * Vᴴ = expand 1 by
-      simpa [V, expand] using
-        (cornerCompressionExpand_eq_isometry Umat eST eS
-          (1 : Matrix (Fin n) (Fin n) ℂ)).symm]
-    exact hExpand_one
-  have hφ_apply (X : Matrix (Fin n) (Fin n) ℂ) : (φ X).1 = expand X := rfl
-  have hExpand_eq_V (X : Matrix (Fin n) (Fin n) ℂ) : expand X = V * X * Vᴴ := by
-    simpa [expand, V] using cornerCompressionExpand_eq_isometry Umat eST eS X
-  let C : MPSTensor d n := fun i => Vᴴ * A i * V
-  have hLetter : ∀ i : Fin d, expand (C i) = A i := by
-    intro i
-    rw [hExpand_eq_V]
-    change V * (Vᴴ * A i * V) * Vᴴ = A i
-    calc
-      V * (Vᴴ * A i * V) * Vᴴ = (V * Vᴴ) * A i * (V * Vᴴ) := by
-        simp only [Matrix.mul_assoc]
-      _ = P * A i * P := by rw [hV_range]
-      _ = A i := hSupp i
+  obtain ⟨n, C, φ, V, hdim, hCtp, hIntertw, hMul, hStar, hLetter, hCompression,
+    hVtV, hVVt, hφV⟩ :=
+    Kraus.exists_cornerCompression_of_supported_projection A P hP hSupp hTP
   have hPV : P * V = V := by
-    rw [← hV_range, Matrix.mul_assoc, hV_iso, Matrix.mul_one]
+    rw [← hVVt, Matrix.mul_assoc, hVtV, Matrix.mul_one]
   have hIntertwineLetter : ∀ i : Fin d, A i * V = V * C i := by
     intro i
     calc
       A i * V = (P * A i * P) * V := by rw [hSupp i]
       _ = P * A i * (P * V) := by rw [Matrix.mul_assoc (P * A i) P V]
       _ = P * A i * V := by rw [hPV]
-      _ = (V * Vᴴ) * A i * V := by rw [hV_range]
+      _ = (V * Vᴴ) * A i * V := by rw [hVVt]
       _ = V * (Vᴴ * A i * V) := by simp only [Matrix.mul_assoc]
-      _ = V * C i := rfl
+      _ = V * C i := by rw [hCompression i]
   have hEvalCompression (w : List (Fin d)) :
       evalWord C w = Vᴴ * evalWord A w * V := by
     calc
       evalWord C w = 1 * evalWord C w := (Matrix.one_mul _).symm
-      _ = (Vᴴ * V) * evalWord C w := by rw [hV_iso]
+      _ = (Vᴴ * V) * evalWord C w := by rw [hVtV]
       _ = Vᴴ * (V * evalWord C w) := Matrix.mul_assoc _ _ _
       _ = Vᴴ * (evalWord A w * V) := by
         rw [evalWord_intertwine A C V hIntertwineLetter w]
       _ = Vᴴ * evalWord A w * V := (Matrix.mul_assoc _ _ _).symm
-  refine ⟨n, C, φ, V, htrace, ?_, ?_, ?_, ?_, ?_, ?_, hV_iso, hV_range, ?_⟩
-  · apply φ.injective
-    apply Subtype.ext
-    rw [hφ_apply, hφ_apply]
-    rw [map_sum]
-    have hsum : (∑ i : Fin d, expand ((C i)ᴴ * C i)) = (∑ i : Fin d, (A i)ᴴ * A i) := by
-      refine Finset.sum_congr rfl ?_
-      intro i _
-      rw [cornerCompressionExpand_mul Umat eST eS hU'U,
-        ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
-    calc
-      (∑ i : Fin d, expand ((C i)ᴴ * C i)) = (∑ i : Fin d, (A i)ᴴ * A i) := hsum
-      _ = P := hTP
-      _ = expand 1 := by rw [hExpand_one]
+  refine ⟨n, C, φ, V, hdim, hCtp, ?_, ?_, hMul, hStar, hLetter, hVtV, hVVt, hφV⟩
   · intro N σ
     let w := List.ofFn σ
     change Matrix.trace (evalWord C w) = Matrix.trace (P * evalWord A w)
@@ -145,30 +100,10 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
           Matrix.trace ((evalWord A w * V) * Vᴴ) := by
             rw [Matrix.mul_assoc]
             exact Matrix.trace_mul_comm _ _
-      _ = Matrix.trace (evalWord A w * P) := by rw [Matrix.mul_assoc, hV_range]
+      _ = Matrix.trace (evalWord A w * P) := by rw [Matrix.mul_assoc, hVVt]
       _ = Matrix.trace (P * evalWord A w) := Matrix.trace_mul_comm _ _
-  · intro Z
-    rw [hφ_apply]
-    change expand (transferMap (d := d) (D := n) (fun j => (C j)ᴴ) Z) =
-      transferMap (d := d) (D := D) (fun j => (A j)ᴴ) (expand Z)
-    simp only [transferMap_apply, Matrix.conjTranspose_conjTranspose]
-    rw [map_sum]
-    refine Finset.sum_congr rfl ?_
-    intro i _
-    rw [cornerCompressionExpand_mul Umat eST eS hU'U,
-      cornerCompressionExpand_mul Umat eST eS hU'U,
-      ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
-  · intro X Y
-    simp only [hφ_apply]
-    exact cornerCompressionExpand_mul Umat eST eS hU'U X Y
   · intro X
-    simp only [hφ_apply]
-    exact (cornerCompressionExpand_conjTranspose Umat eST eS X).symm
-  · intro i
-    rw [hφ_apply]
-    exact hLetter i
-  · intro X
-    rw [hφ_apply, hExpand_eq_V]
+    simpa [Kraus.adjointMap, transferMap_apply] using hIntertw X
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
@@ -319,12 +319,11 @@ Support isometries first realize the cyclic corners. The remaining results place
         \label{eq:canonical_corner_trace}
     \end{align}
     \begin{proof}\leanok
-        Diagonalize the projection $P$ by a unitary change of basis. The
-        inclusion of the support coordinates gives a rectangular isometry $V$
-        satisfying (\ref{eq:canonical_support_isometry}). Compress the letters
-        of $A$ to this support and let $\varphi$ be the corresponding corner
-        isomorphism. The support relation $PA^iP=A^i$ gives the corner-letter
-        identity. For each word
+        \uses{thm:supported_kraus_corner_compression}
+        Apply Theorem~\ref{thm:supported_kraus_corner_compression} to the
+        family $(A^i)_i$. It gives $C$, $\varphi$, and $V$ satisfying
+        (\ref{eq:canonical_support_isometry}) and $\varphi(C^i)=A^i$. It remains
+        to identify the coefficients of the associated words. For each word
         $\sigma=(\sigma_1,\ldots,\sigma_N)$, cyclicity of the trace and
         $VV^\dagger=P$ give
         \begin{align}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
@@ -46,15 +46,15 @@ the ambient fixed-point space a zero-block representation.
 
 \begin{proof}
     \leanok
-    \uses{thm:support_proj_fixed, thm:compression_on_support_posDef,
-        thm:adjointFixedPoints_block_form}
+    \uses{thm:support_proj_fixed, thm:supported_kraus_corner_compression,
+        thm:compression_on_support_posDef, thm:adjointFixedPoints_block_form}
     Since $\rho$ is a fixed point of $E$, the support projection satisfies
     $(\Id-Q)K_iQ=0$ by Theorem~\ref{thm:support_proj_fixed}, so the
     compressed family $QK_iQ$ is supported on the corner and
-    trace-preserving there. Choose a support isometry
-    $V:\C^r\to\C^D$ with $V^\dagger V=\Id_r$ and $VV^\dagger=Q$, and
-    compress the family to the support sector. The compressed family $C$ is
-    trace-preserving on $\C^r$, and
+    trace-preserving there. Theorem~\ref{thm:supported_kraus_corner_compression}
+    gives a support isometry $V:\C^r\to\C^D$ with
+    $V^\dagger V=\Id_r$ and $VV^\dagger=Q$, together with a compressed family
+    $C$ that is trace-preserving on $\C^r$. Moreover,
     $\sigma=V^\dagger\rho V$ is a positive definite fixed point of the
     compressed Schr\"odinger map by
     Theorem~\ref{thm:compression_on_support_posDef}. The block form of the
@@ -137,6 +137,7 @@ restriction disappears
 \begin{proof}
     \leanok
     \uses{thm:weightedFixedPointsStarSubalgebra,
+        thm:supported_kraus_corner_compression,
         thm:compression_on_support_posDef, thm:support_proj_fixed}
     Closure under addition, scalars, and conjugation is linearity together
     with the stability of fixed points under conjugate transposition. The
@@ -154,9 +155,10 @@ restriction disappears
     For closure under multiplication, compress to the support sector. Since
     $\rho$ is a fixed point of $T$, the support projection satisfies
     $(\Id-Q)K_iQ=0$ by Theorem~\ref{thm:support_proj_fixed}. The compressed
-    family $QK_iQ$ is trace-preserving on the corner. Choose a support
+    family $QK_iQ$ is trace-preserving on the corner.
+    Theorem~\ref{thm:supported_kraus_corner_compression} gives a support
     isometry $V:\C^r\to\C^D$ with $V^\dagger V=\Id_r$ and
-    $VV^\dagger=Q$; compression along $V$ produces a trace-preserving
+    $VV^\dagger=Q$, together with a trace-preserving compressed
     family $C$ on $\C^r$ whose Schr\"odinger map has the positive definite
     fixed point $\sigma=V^\dagger\rho V$ by
     Theorem~\ref{thm:compression_on_support_posDef}. The square root
@@ -231,9 +233,11 @@ points supported on the support of $\rho$.
 
 \begin{proof}
     \leanok
-    \uses{thm:compression_on_support_posDef, thm:support_proj_fixed}
-    Compress to the support sector as in the proof of
-    Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra} and set
+    \uses{thm:supported_kraus_corner_compression,
+        thm:compression_on_support_posDef, thm:support_proj_fixed}
+    Use Theorem~\ref{thm:supported_kraus_corner_compression} to compress to
+    the support sector as in the proof of
+    Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra}, and set
     \begin{align}
         Y
          & =V\left(\sqrt{\sigma}^{-1}(V^\dagger XV)

--- a/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_corners_and_maximal_support.tex
@@ -46,15 +46,14 @@ the ambient fixed-point space a zero-block representation.
 
 \begin{proof}
     \leanok
-    \uses{thm:support_proj_fixed, thm:supported_corner_compression_isometry,
-        thm:compression_on_support_posDef, thm:adjointFixedPoints_block_form}
+    \uses{thm:support_proj_fixed, thm:compression_on_support_posDef,
+        thm:adjointFixedPoints_block_form}
     Since $\rho$ is a fixed point of $E$, the support projection satisfies
     $(\Id-Q)K_iQ=0$ by Theorem~\ref{thm:support_proj_fixed}, so the
     compressed family $QK_iQ$ is supported on the corner and
-    trace-preserving there. Compress it to the support sector along the
-    isometry $V:\C^r\to\C^D$ of
-    Theorem~\ref{thm:supported_corner_compression_isometry}, which satisfies
-    $V^\dagger V=\Id_r$ and $VV^\dagger=Q$. The compressed family $C$ is
+    trace-preserving there. Choose a support isometry
+    $V:\C^r\to\C^D$ with $V^\dagger V=\Id_r$ and $VV^\dagger=Q$, and
+    compress the family to the support sector. The compressed family $C$ is
     trace-preserving on $\C^r$, and
     $\sigma=V^\dagger\rho V$ is a positive definite fixed point of the
     compressed Schr\"odinger map by
@@ -138,9 +137,7 @@ restriction disappears
 \begin{proof}
     \leanok
     \uses{thm:weightedFixedPointsStarSubalgebra,
-        thm:supported_corner_compression_isometry,
-        thm:compression_on_support_posDef,
-        thm:support_proj_fixed}
+        thm:compression_on_support_posDef, thm:support_proj_fixed}
     Closure under addition, scalars, and conjugation is linearity together
     with the stability of fixed points under conjugate transposition. The
     corner unit $Q$ belongs to the set because
@@ -157,10 +154,9 @@ restriction disappears
     For closure under multiplication, compress to the support sector. Since
     $\rho$ is a fixed point of $T$, the support projection satisfies
     $(\Id-Q)K_iQ=0$ by Theorem~\ref{thm:support_proj_fixed}. The compressed
-    family $QK_iQ$ is trace-preserving on the corner, and compression along
-    the isometry $V:\C^r\to\C^D$ of
-    Theorem~\ref{thm:supported_corner_compression_isometry}, with
-    $V^\dagger V=\Id_r$ and $VV^\dagger=Q$, produces a trace-preserving
+    family $QK_iQ$ is trace-preserving on the corner. Choose a support
+    isometry $V:\C^r\to\C^D$ with $V^\dagger V=\Id_r$ and
+    $VV^\dagger=Q$; compression along $V$ produces a trace-preserving
     family $C$ on $\C^r$ whose Schr\"odinger map has the positive definite
     fixed point $\sigma=V^\dagger\rho V$ by
     Theorem~\ref{thm:compression_on_support_posDef}. The square root
@@ -235,9 +231,7 @@ points supported on the support of $\rho$.
 
 \begin{proof}
     \leanok
-    \uses{thm:supported_corner_compression_isometry,
-        thm:compression_on_support_posDef,
-        thm:support_proj_fixed}
+    \uses{thm:compression_on_support_posDef, thm:support_proj_fixed}
     Compress to the support sector as in the proof of
     Theorem~\ref{thm:weightedCornerFixedPointsStarSubalgebra} and set
     \begin{align}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -438,7 +438,7 @@ sector is positive definite.
     finite-Kraus setting, this strengthens the maximum-rank-fixed-point case
     by allowing an arbitrary positive semidefinite fixed point. At maximum
     rank it gives the completely positive finite-Kraus specialization of
-    Corollary~6.6 of~\cite{Wolf2012Quantum}, whose hypothesis is an abstract
+    \cite[Corollary~6.6]{Wolf2012Quantum}, whose hypothesis is an abstract
     unital Schwarz map.
     % Scope restriction (finite Kraus family): see
     % docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex.

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -281,7 +281,8 @@ following~\cite[Section~6.4, Propositions~6.10--6.11]{Wolf2012Quantum}.
 
 This subsection establishes the results on the corner algebra,
 $*$-structure, and compression of a PSD fixed point onto its support sector
-needed for~\cite[Corollary~6.6]{Wolf2012Quantum}: the corner carries a
+needed for the completely positive finite-Kraus specialization of
+\cite[Corollary~6.6]{Wolf2012Quantum}: the corner carries a
 $\C$-algebra and $*$-structure, the two standard presentations of the corner
 are identified, and the compression of a PSD fixed point onto its support
 sector is positive definite.
@@ -327,6 +328,76 @@ sector is positive definite.
     over~$\C$.
 \end{remark}
 
+\begin{theorem}[Compression of a supported finite Kraus family]%
+    \label{thm:supported_kraus_corner_compression}
+    \lean{Kraus.exists_corner_compression_of_supported_projection}
+    \leanok
+    Let $P\in\MN{D}$ be an orthogonal projection and let
+    $A_1,\ldots,A_d\in\MN{D}$ satisfy
+    \begin{align}
+        PA_iP
+         & =A_i,
+        \notag        \\
+        \sum_i A_i^\dagger A_i
+         & =P.
+        \label{eq:spectral_supported_kraus_normalization}
+    \end{align}
+    Then there are $n=\tr P$, matrices $C_i\in\MN{n}$, an isometry
+    $V:\C^n\to\C^D$, and a linear isomorphism
+    $\varphi:\MN{n}\xrightarrow{\sim}P\MN{D}P$ such that
+    \begin{align}
+        V^\dagger V
+         & =\Id_n,
+        \notag        \\
+        VV^\dagger
+         & =P,
+        \notag        \\
+        C_i
+         & =V^\dagger A_iV,
+        \notag        \\
+        \varphi(X)
+         & =VXV^\dagger,
+        \notag        \\
+        \varphi(C_i)
+         & =A_i,
+        \notag        \\
+        \sum_i C_i^\dagger C_i
+         & =\Id_n.
+        \label{eq:spectral_supported_kraus_compression}
+    \end{align}
+    If
+    $T_A^*(X)=\sum_iA_i^\dagger XA_i$ and
+    $T_C^*(X)=\sum_iC_i^\dagger XC_i$, then
+    \begin{align}
+        \varphi(T_C^*(X))
+         & =T_A^*(\varphi(X)),
+        \notag                              \\
+        \varphi(XY)
+         & =\varphi(X)\varphi(Y),
+        \notag                              \\
+        \varphi(X^\dagger)
+         & =\varphi(X)^\dagger.
+        \label{eq:spectral_supported_kraus_intertwining}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Diagonalize $P$ and let $V$ include its eigenvalue-one coordinates into
+    $\C^D$. Then $V^\dagger V=\Id_n$ and $VV^\dagger=P$. Define
+    $C_i=V^\dagger A_iV$ and $\varphi(X)=VXV^\dagger$. The support relation
+    $PA_iP=A_i$ gives $\varphi(C_i)=A_i$, while
+    \begin{align}
+        \sum_i C_i^\dagger C_i
+         & =V^\dagger\left(\sum_iA_i^\dagger A_i\right)V
+          =V^\dagger PV
+          =\Id_n.
+        \notag
+    \end{align}
+    Inserting $VV^\dagger=P$ and using $PA_iP=A_i$ gives the intertwining,
+    product, and adjoint identities in
+    (\ref{eq:spectral_supported_kraus_intertwining}).
+\end{proof}
+
 \begin{theorem}[Faithful compression onto the support]%
     \label{thm:compression_on_support_posDef}
     \lean{Matrix.PosSemidef.compression_on_support_posDef}
@@ -356,21 +427,27 @@ sector is positive definite.
     \leanok
     \uses{thm:compression_on_support_posDef, rem:corner_algebra_star_instances,
         thm:adjointFixedPointsStarSubalgebra, thm:support_proj_fixed}
-    Let $T(X)=\sum_iK_iXK_i^\dagger$ be trace-preserving, let its adjoint
-    $T^*(Y)=\sum_iK_i^\dagger YK_i$ satisfy the Schwarz inequality, let
-    $\rho\succeq0$ satisfy $T(\rho)=\rho$, and let $Q=\supp(\rho)$. Then
+    Let $T(X)=\sum_iK_iXK_i^\dagger$ be a trace-preserving finite Kraus map,
+    with adjoint $T^*(Y)=\sum_iK_i^\dagger YK_i$. Let $\rho\succeq0$ satisfy
+    $T(\rho)=\rho$, and let $Q=\supp(\rho)$. Then
     \begin{align}
         \{Y\in Q\MN{D}Q\mid QT^*(Y)Q=Y\}
         \label{eq:spectral_corner_fixed_set}
     \end{align}
-    is a $*$-subalgebra of the corner algebra $Q\MN{D}Q$. This finite-Kraus
-    statement strengthens Corollary~6.6 of~\cite{Wolf2012Quantum}, which is
-    recovered when $\rho$ is chosen with maximum rank.
+    is a $*$-subalgebra of the corner algebra $Q\MN{D}Q$. Within the
+    finite-Kraus setting, this strengthens the maximum-rank-fixed-point case
+    by allowing an arbitrary positive semidefinite fixed point. At maximum
+    rank it gives the completely positive finite-Kraus specialization of
+    Corollary~6.6 of~\cite{Wolf2012Quantum}, whose hypothesis is an abstract
+    unital Schwarz map.
+    % Scope restriction (finite Kraus family): see
+    % docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:compression_on_support_posDef, thm:adjointFixedPointsStarSubalgebra,
+    \uses{thm:supported_kraus_corner_compression,
+        thm:compression_on_support_posDef, thm:adjointFixedPointsStarSubalgebra,
         thm:support_proj_fixed}
     The set in (\ref{eq:spectral_corner_fixed_set}) is the fixed-point set
     of the compressed map $\widetilde{T}^*$ on the support sector. Since
@@ -378,8 +455,9 @@ sector is positive definite.
     $(\Id-Q)K_iQ=0$, so the compressed family $QK_iQ$ is supported on the
     corner and is trace-preserving there:
     $\sum_i(QK_iQ)^\dagger(QK_iQ)=Q$.
-    Compressing this family to the support sector gives a unital map, while
-    the compression of $\rho$ is a positive-definite fixed point by
+    Theorem~\ref{thm:supported_kraus_corner_compression} compresses this
+    family to a unital map on the support sector, while the compression of
+    $\rho$ is a positive-definite fixed point by
     Theorem~\ref{thm:compression_on_support_posDef}. The structure theorem
     for fixed points of unital Schwarz maps with a positive-definite fixed
     point (Theorem~\ref{thm:adjointFixedPointsStarSubalgebra}) makes the

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -363,7 +363,9 @@ sector is positive definite.
         \{Y\in Q\MN{D}Q\mid QT^*(Y)Q=Y\}
         \label{eq:spectral_corner_fixed_set}
     \end{align}
-    is a $*$-subalgebra of the corner algebra $Q\MN{D}Q$.
+    is a $*$-subalgebra of the corner algebra $Q\MN{D}Q$. This finite-Kraus
+    statement strengthens Corollary~6.6 of~\cite{Wolf2012Quantum}, which is
+    recovered when $\rho$ is chosen with maximum rank.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
## What changed

- adds `Kraus.exists_corner_compression_of_supported_projection`, a generic finite-family compression theorem returning the compressed family, corner equivalence, support isometry, TP normalization, adjoint-map intertwining, multiplicativity, star preservation, and explicit letter compression;
- migrates `CornerFixedPoints`, `CornerBlockForm`, and `WeightedCornerFixedPoints` from the MPS cyclic-sector theorem and transfer-map notation to the generic Kraus API;
- reduces `CornerAlgebra` to the generic Algebra corner-compression import;
- keeps all three established `MPSTensor.exists_compressedTensor_*` FQNs and theorem statements unchanged, with the MPS wrapper reconstructing the word-trace/MPV conclusion from the generic support isometry;
- adds exact Blueprint coverage and proof dependencies for the generic theorem;
- records the finite-Kraus/complete-positivity scope relative to Wolf Corollary 6.6.

## Dependency impact

Exact `origin/main` to PR-head measurements:

- direct Channel modules importing MPS: **6 -> 5**;
- direct Channel-to-MPS edges: **8 -> 7**;
- transitively MPS-dependent Channel modules: **40 -> 34**.

The six newly MPS-free modules are:

- `TNLean.Channel.FixedPoint.CornerAlgebra`;
- `TNLean.Channel.FixedPoint.CornerFixedPoints`;
- `TNLean.Channel.FixedPoint.CornerBlockForm`;
- `TNLean.Channel.FixedPoint.WeightedCornerFixedPoints`;
- `TNLean.Channel.FixedPoint.MaximalRank`;
- `TNLean.Channel.FixedPoint.MaximalSupport`.

## Compatibility

- The three public MPS compression theorem signatures are byte-for-byte unchanged.
- A client importing the old MPS module and checking all three declarations compiles unchanged.
- Existing public Channel declarations retain their FQNs and theorem types.
- The MPS MPV identity, including the `N = 0` case, is reconstructed from word intertwining and trace cyclicity.

## Validation

- `lake build TNLean.Channel TNLean.MPS.CanonicalForm.CyclicSectors` (**9109 jobs**)
- final warm-cache `lake build` (**10012 jobs**)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls` (**6937/6937**)
- two direct LuaLaTeX passes with zero undefined cross-references; standalone citation warnings only
- `git diff --check`
- exact-head independent Lean/API/Blueprint review: approved with no remaining findings

Closes LionSR/QICLean#315.
Advances LionSR/TNLean#5679.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The refactor touches core support-compression logic used in Wolf fixed-point arguments; proofs are simplified but dependency and API wiring changed across Channel and MPS layers, though public theorem signatures stay compatible.
> 
> **Overview**
> Extracts **projection-corner compression** for finite matrix families into `Kraus.exists_corner_compression_of_supported_projection` in `TNLean/Channel/KrausCornerCompression.lean`, built on `TNLean.Algebra.CornerCompression` instead of MPS cyclic-sector machinery.
> 
> **Channel fixed-point proofs** (`CornerFixedPoints`, `CornerBlockForm`, `WeightedCornerFixedPoints`, `CornerAlgebra`) now call this Kraus API and drop direct MPS compression imports; local `stationaryProj` lemmas replace `MPSTensor.supportProj_*`, and adjoint intertwining proofs are shorter. **MPS** `Compression.lean` keeps the same `exists_compressedTensor_*` theorem statements but delegates the core construction to the generic theorem and only adds word/trace/MPV consequences.
> 
> Blueprint adds **`thm:supported_kraus_corner_compression`** and rewires ch27 proofs to cite it; Wolf Corollary 6.6 documentation is tightened to the **finite-Kraus / complete positivity** scope versus Wolf’s abstract unital Schwarz map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1157b875318927dc7944a73150cea5d5a34ac9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->