### PR TITLE
feat(ParentHamiltonian): prove physical Gram convergence

### DIFF
--- a/TNLean/Algebra/RectangularChoi.lean
+++ b/TNLean/Algebra/RectangularChoi.lean
@@ -96,6 +96,18 @@ noncomputable def gramReshuffle
     EuclideanSpace ℂ (α × α) →L[ℂ] EuclideanSpace ℂ (α × α) :=
   (Matrix.toEuclideanCLM (n := α × α) (𝕜 := ℂ)) (gramReshuffleMatrix Φ)
 
+/-- Reshuffling commutes with subtraction. -/
+@[simp]
+theorem gramReshuffle_sub
+    (Φ Ψ : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    gramReshuffle (Φ - Ψ) = gramReshuffle Φ - gramReshuffle Ψ := by
+  have hmatrix :
+      gramReshuffleMatrix (Φ - Ψ) = gramReshuffleMatrix Φ - gramReshuffleMatrix Ψ := by
+    ext ⟨b, a⟩ ⟨e, c⟩
+    simp [gramReshuffleMatrix]
+  ext x ⟨b, a⟩
+  simp [gramReshuffle, hmatrix]
+
 /-- The matrix-unit coefficients of the reshuffled Choi operator are
 \(J(\Phi)_{(c,e),(a,b)}\). -/
 @[simp]

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -43,6 +43,7 @@ import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
+import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -41,9 +41,9 @@ import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.ExtendRight
+import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
-import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace

--- a/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
@@ -68,4 +68,47 @@ theorem groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
       gcongr
       exact hbound n
 
+/-- Under the same complementary spectral-radius hypothesis, the ground-space Gram
+operators converge to the reshuffled fixed-point projection. -/
+theorem groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
+    (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (htr : trace ρ ≠ 0)
+    (hTP : IsTracePreservingMap (transferMap A))
+    (hρ : transferMap A ρ = ρ)
+    (hgap :
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (transferMap A - fixedPointProj ρ htr)) < 1) :
+    Filter.Tendsto (fun n => groundSpaceGram A n) Filter.atTop
+      (nhds (Matrix.gramReshuffle (fixedPointProj ρ htr))) := by
+  rcases groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
+    A ρ htr hTP hρ hgap with ⟨C, r, _hC, hr_pos, hr_lt_one, hbound⟩
+  have hrpow : Filter.Tendsto (fun n : ℕ => r ^ n) Filter.atTop (nhds 0) :=
+    tendsto_pow_atTop_nhds_zero_of_lt_one hr_pos.le hr_lt_one
+  have hrhs : Filter.Tendsto
+      (fun n : ℕ => (D : ℝ) ^ 3 * (C * r ^ n) ^ 2) Filter.atTop (nhds 0) := by
+    simpa only [zero_pow (by norm_num : (2 : ℕ) ≠ 0), mul_zero] using
+      (tendsto_const_nhds.mul ((tendsto_const_nhds.mul hrpow).pow 2))
+  have hsq : Filter.Tendsto
+      (fun n : ℕ =>
+        ‖groundSpaceGram A n - Matrix.gramReshuffle (fixedPointProj ρ htr)‖ ^ 2)
+      Filter.atTop (nhds 0) := by
+    apply squeeze_zero' (Filter.Eventually.of_forall fun _ => sq_nonneg _)
+      _ hrhs
+    filter_upwards [Filter.eventually_ge_atTop (1 : ℕ)] with n hn
+    exact hbound n hn
+  have hnorm : Filter.Tendsto
+      (fun n : ℕ =>
+        ‖groundSpaceGram A n - Matrix.gramReshuffle (fixedPointProj ρ htr)‖)
+      Filter.atTop (nhds 0) := by
+    have hsqrt := (Real.continuous_sqrt.tendsto 0).comp hsq
+    change Filter.Tendsto
+      (fun n : ℕ =>
+        Real.sqrt
+          (‖groundSpaceGram A n - Matrix.gramReshuffle (fixedPointProj ρ htr)‖ ^ 2))
+      Filter.atTop (nhds (Real.sqrt 0)) at hsqrt
+    simpa only [Real.sqrt_sq (norm_nonneg _), Real.sqrt_zero] using hsqrt
+  rw [← tendsto_sub_nhds_zero_iff, tendsto_zero_iff_norm_tendsto_zero]
+  exact hnorm
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.OperatorNormFrobenius
+import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
+import TNLean.Spectral.QuantitativeGap
+
+/-!
+# Convergence of MPS ground-space Gram operators
+
+This file bounds the ground-space Gram operator by combining the exact Choi
+reshuffling identity with geometric decay of the complementary transfer map.
+-/
+
+open scoped Matrix Matrix.Norms.L2Operator NNReal ENNReal
+open Matrix
+
+attribute [local instance 1001]
+  ContinuousLinearMap.toNormedAddCommGroup
+  ContinuousLinearMap.toNormedSpace
+  ContinuousLinearMap.toNormedRing
+  ContinuousLinearMap.toNormedAlgebra
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If the complementary transfer map has spectral radius less than one, then the
+squared distance from the ground-space Gram operator to the reshuffled fixed-point
+projection decays geometrically, up to the dimension-cubed norm-conversion factor. -/
+theorem groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
+    (A : MPSTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (htr : trace ρ ≠ 0)
+    (hTP : IsTracePreservingMap (transferMap A))
+    (hρ : transferMap A ρ = ρ)
+    (hgap :
+      spectralRadius ℂ
+        ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+          (transferMap A - fixedPointProj ρ htr)) < 1) :
+    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧ ∀ n, 1 ≤ n →
+      ‖groundSpaceGram A n - Matrix.gramReshuffle (fixedPointProj ρ htr)‖ ^ 2 ≤
+        (D : ℝ) ^ 3 * (C * r ^ n) ^ 2 := by
+  let N := transferMap A - fixedPointProj ρ htr
+  let T := (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) N
+  rcases geometric_bound_of_spectralRadius_lt_one T (by simpa [T, N] using hgap) with
+    ⟨C, r, hC, hr_pos, hr_lt_one, hbound⟩
+  refine ⟨C, r, hC, hr_pos, hr_lt_one, ?_⟩
+  intro n hn
+  have hpow : (transferMap A) ^ n = fixedPointProj ρ htr + N ^ n := by
+    simpa [N] using
+      pow_eq_fixedPointProj_add_compl_pow (E := transferMap A) (ρ := ρ) htr hTP hρ hn
+  calc
+    ‖groundSpaceGram A n - Matrix.gramReshuffle (fixedPointProj ρ htr)‖ ^ 2 =
+        ‖Matrix.gramReshuffle (N ^ n)‖ ^ 2 := by
+      rw [groundSpaceGram_eq_gramReshuffle, ← Matrix.gramReshuffle_sub, hpow]
+      simp
+    _ ≤ (D : ℝ) ^ 3 *
+        ‖LinearMap.toContinuousLinearMap (N ^ n)‖ ^ 2 := by
+      simpa using Matrix.gramReshuffle_norm_sq_le_card_cube_mul_opNorm_sq (N ^ n)
+    _ = (D : ℝ) ^ 3 * ‖T ^ n‖ ^ 2 := by
+      change (D : ℝ) ^ 3 *
+        ‖(Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) (N ^ n)‖ ^ 2 = _
+      rw [map_pow (Module.End.toContinuousLinearMap
+        (Matrix (Fin D) (Fin D) ℂ)) N n]
+    _ ≤ (D : ℝ) ^ 3 * (C * r ^ n) ^ 2 := by
+      gcongr
+      exact hbound n
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
@@ -5,23 +5,22 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.OperatorNormFrobenius
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
-import TNLean.Spectral.QuantitativeGap
+import TNLean.Spectral.TransferOperatorGapCommon
 
 /-!
 # Convergence of MPS ground-space Gram operators
 
 This file bounds the ground-space Gram operator by combining the exact Choi
 reshuffling identity with geometric decay of the complementary transfer map.
+
+## Main results
+
+- `MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric`
+- `MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj`
 -/
 
 open scoped Matrix Matrix.Norms.L2Operator NNReal ENNReal
 open Matrix
-
-attribute [local instance 1001]
-  ContinuousLinearMap.toNormedAddCommGroup
-  ContinuousLinearMap.toNormedSpace
-  ContinuousLinearMap.toNormedRing
-  ContinuousLinearMap.toNormedAlgebra
 
 namespace MPSTensor
 

--- a/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramConvergence.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.OperatorNormFrobenius
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
+import TNLean.MPS.Structure.PrimitivityBridge
 import TNLean.Spectral.TransferOperatorGapCommon
 
 /-!
@@ -17,6 +18,8 @@ reshuffling identity with geometric decay of the complementary transfer map.
 
 - `MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric`
 - `MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj`
+- `MPSTensor.IsPrimitiveMPS.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric`
+- `MPSTensor.IsPrimitiveMPS.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj`
 -/
 
 open scoped Matrix Matrix.Norms.L2Operator NNReal ENNReal
@@ -109,5 +112,48 @@ theorem groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
     simpa only [Real.sqrt_sq (norm_nonneg _), Real.sqrt_zero] using hsqrt
   rw [← tendsto_sub_nhds_zero_iff, tendsto_zero_iff_norm_tendsto_zero]
   exact hnorm
+
+/-- A primitive MPS tensor satisfies the quantitative geometric bound for convergence of
+its ground-space Gram operators to the reshuffled fixed-point projection. -/
+theorem IsPrimitiveMPS.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) :
+    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧ ∀ n, 1 ≤ n →
+      ‖groundSpaceGram A n - Matrix.gramReshuffle
+        (fixedPointProj ρ (by
+          intro h
+          exact hP.fixedPoint_ne_zero
+            ((Matrix.PosSemidef.trace_eq_zero_iff hP.fixedPoint_psd).1 h)))‖ ^ 2 ≤
+        (D : ℝ) ^ 3 * (C * r ^ n) ^ 2 := by
+  have htr : trace ρ ≠ 0 := by
+    intro h
+    exact hP.fixedPoint_ne_zero
+      ((Matrix.PosSemidef.trace_eq_zero_iff hP.fixedPoint_psd).1 h)
+  have hTP : IsTracePreservingMap (transferMap A) := by
+    intro X
+    exact trace_transferMap A X hP.norm
+  exact MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
+    A ρ htr hTP hP.fixedPoint_is_fixed hP.complementary_transfer_map_gap
+
+/-- The ground-space Gram operators of a primitive MPS tensor converge to the reshuffled
+fixed-point projection. -/
+theorem IsPrimitiveMPS.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) :
+    Filter.Tendsto (fun n => groundSpaceGram A n) Filter.atTop
+      (nhds (Matrix.gramReshuffle
+        (fixedPointProj ρ (by
+          intro h
+          exact hP.fixedPoint_ne_zero
+            ((Matrix.PosSemidef.trace_eq_zero_iff hP.fixedPoint_psd).1 h))))) := by
+  have htr : trace ρ ≠ 0 := by
+    intro h
+    exact hP.fixedPoint_ne_zero
+      ((Matrix.PosSemidef.trace_eq_zero_iff hP.fixedPoint_psd).1 h)
+  have hTP : IsTracePreservingMap (transferMap A) := by
+    intro X
+    exact trace_transferMap A X hP.norm
+  exact MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
+    A ρ htr hTP hP.fixedPoint_is_fixed hP.complementary_transfer_map_gap
 
 end MPSTensor

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -127,7 +127,7 @@ private theorem spectralRadius_compl_lt_one_of_primitive_fixedPoint [NeZero D]
 
 /-- Gelfand's formula: if `spectralRadius(T) < 1`, then `‖T ^ n‖ ≤ C · r ^ n`
 for some `C > 0` and `0 < r < 1`, uniformly in `n`. -/
-private theorem geometric_bound_of_spectralRadius_lt_one
+theorem geometric_bound_of_spectralRadius_lt_one
     {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [CompleteSpace V]
     (T : V →L[ℂ] V)
     (hT : spectralRadius ℂ T < 1) :

--- a/TNLean/Spectral/QuantitativeGap.lean
+++ b/TNLean/Spectral/QuantitativeGap.lean
@@ -125,64 +125,6 @@ private theorem spectralRadius_compl_lt_one_of_primitive_fixedPoint [NeZero D]
     exact (NNReal.coe_lt_one).1 this
   exact ⟨htrρ, by simpa [E] using hgap⟩
 
-/-- Gelfand's formula: if `spectralRadius(T) < 1`, then `‖T ^ n‖ ≤ C · r ^ n`
-for some `C > 0` and `0 < r < 1`, uniformly in `n`. -/
-theorem geometric_bound_of_spectralRadius_lt_one
-    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [CompleteSpace V]
-    (T : V →L[ℂ] V)
-    (hT : spectralRadius ℂ T < 1) :
-    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧
-      ∀ n : ℕ, ‖T ^ n‖ ≤ C * r ^ n := by
-  obtain ⟨r, hr_above, hr_below⟩ := ENNReal.lt_iff_exists_nnreal_btwn.mp hT
-  have hr_lt_one : (r : ℝ) < 1 := by
-    exact_mod_cast hr_below
-  have hr_pos : 0 < (r : ℝ) := by
-    exact_mod_cast (lt_of_le_of_lt
-      (show (0 : ℝ≥0∞) ≤ spectralRadius ℂ T from bot_le) hr_above)
-  have hev :
-      ∀ᶠ n in Filter.atTop, ‖T ^ n‖₊ < r ^ n := by
-    have gelfand := spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius T
-    filter_upwards [gelfand.eventually (eventually_lt_nhds hr_above),
-      Filter.eventually_gt_atTop 0] with n hn hn_pos
-    rw [one_div, ENNReal.rpow_inv_lt_iff (Nat.cast_pos.mpr hn_pos)] at hn
-    rw [ENNReal.rpow_natCast] at hn
-    exact_mod_cast hn
-  obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp hev
-  let S : ℝ := Finset.sum (Finset.range N) fun k => ‖T ^ k‖ / (r : ℝ) ^ k
-  let C : ℝ := S + 1
-  refine ⟨C, r, by positivity, hr_pos, hr_lt_one, ?_⟩
-  intro n
-  by_cases hn : N ≤ n
-  · have hnorm : ‖T ^ n‖ ≤ (r : ℝ) ^ n := by
-      exact_mod_cast (hN n hn).le
-    have hC_ge_one : 1 ≤ C := by
-      have hS_nonneg : 0 ≤ S := by
-        dsimp [S]
-        positivity
-      dsimp [C]
-      linarith
-    calc
-      ‖T ^ n‖ ≤ (r : ℝ) ^ n := hnorm
-      _ = 1 * (r : ℝ) ^ n := by ring
-      _ ≤ C * (r : ℝ) ^ n := by
-        gcongr
-  · have hn_lt : n < N := Nat.lt_of_not_ge hn
-    have hterm : ‖T ^ n‖ / (r : ℝ) ^ n ≤ S := by
-      dsimp [S]
-      exact Finset.single_le_sum
-        (f := fun k => ‖T ^ k‖ / (r : ℝ) ^ k)
-        (by intro k hk; positivity)
-        (Finset.mem_range.mpr hn_lt)
-    have hterm' : ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := by
-      exact (div_le_iff₀ (pow_pos hr_pos n)).1 hterm
-    have hS_le_C : S ≤ C := by
-      dsimp [C]
-      linarith
-    calc
-      ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := hterm'
-      _ ≤ C * (r : ℝ) ^ n := by
-        gcongr
-
 /-- Pointwise version of `geometric_bound_of_spectralRadius_lt_one`:
 if `spectralRadius(T) < 1`, then `‖T ^ n x‖ ≤ C · r ^ n · ‖x‖`. -/
 private theorem geometric_apply_bound_of_spectralRadius_lt_one

--- a/TNLean/Spectral/TransferOperatorGapCommon.lean
+++ b/TNLean/Spectral/TransferOperatorGapCommon.lean
@@ -14,6 +14,11 @@ import Mathlib.Analysis.SpecificLimits.Normed
 Dimension-independent eigenvector iteration, trace-preserving word sums,
 Frobenius-square identities, and Banach-algebra power convergence used by both
 square and rectangular mixed-transfer gap theorems.
+
+## Main results
+
+- `MPSTensor.geometric_bound_of_spectralRadius_lt_one`
+- `MPSTensor.pow_tendsto_zero_of_spectralRadius_lt_one`
 -/
 
 open scoped Matrix ComplexOrder BigOperators NNReal ENNReal
@@ -104,6 +109,64 @@ lemma sum_frobSq_words (K : MPSTensor d D) (hK : ∑ i : Fin d, (K i)ᴴ * K i =
   simp [Matrix.trace_one, Fintype.card_fin]
 
 /-! ### Power convergence from spectral radius bound -/
+
+/-- Gelfand's formula: if `spectralRadius(T) < 1`, then `‖T ^ n‖ ≤ C · r ^ n`
+for some `C > 0` and `0 < r < 1`, uniformly in `n`. -/
+theorem geometric_bound_of_spectralRadius_lt_one
+    {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V] [CompleteSpace V]
+    (T : V →L[ℂ] V)
+    (hT : spectralRadius ℂ T < 1) :
+    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧
+      ∀ n : ℕ, ‖T ^ n‖ ≤ C * r ^ n := by
+  obtain ⟨r, hr_above, hr_below⟩ := ENNReal.lt_iff_exists_nnreal_btwn.mp hT
+  have hr_lt_one : (r : ℝ) < 1 := by
+    exact_mod_cast hr_below
+  have hr_pos : 0 < (r : ℝ) := by
+    exact_mod_cast (lt_of_le_of_lt
+      (show (0 : ℝ≥0∞) ≤ spectralRadius ℂ T from bot_le) hr_above)
+  have hev :
+      ∀ᶠ n in Filter.atTop, ‖T ^ n‖₊ < r ^ n := by
+    have gelfand := spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectralRadius T
+    filter_upwards [gelfand.eventually (eventually_lt_nhds hr_above),
+      Filter.eventually_gt_atTop 0] with n hn hn_pos
+    rw [one_div, ENNReal.rpow_inv_lt_iff (Nat.cast_pos.mpr hn_pos)] at hn
+    rw [ENNReal.rpow_natCast] at hn
+    exact_mod_cast hn
+  obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp hev
+  let S : ℝ := Finset.sum (Finset.range N) fun k => ‖T ^ k‖ / (r : ℝ) ^ k
+  let C : ℝ := S + 1
+  refine ⟨C, r, by positivity, hr_pos, hr_lt_one, ?_⟩
+  intro n
+  by_cases hn : N ≤ n
+  · have hnorm : ‖T ^ n‖ ≤ (r : ℝ) ^ n := by
+      exact_mod_cast (hN n hn).le
+    have hC_ge_one : 1 ≤ C := by
+      have hS_nonneg : 0 ≤ S := by
+        dsimp [S]
+        positivity
+      dsimp [C]
+      linarith
+    calc
+      ‖T ^ n‖ ≤ (r : ℝ) ^ n := hnorm
+      _ = 1 * (r : ℝ) ^ n := by ring
+      _ ≤ C * (r : ℝ) ^ n := by
+        gcongr
+  · have hn_lt : n < N := Nat.lt_of_not_ge hn
+    have hterm : ‖T ^ n‖ / (r : ℝ) ^ n ≤ S := by
+      dsimp [S]
+      exact Finset.single_le_sum
+        (f := fun k => ‖T ^ k‖ / (r : ℝ) ^ k)
+        (by intro k hk; positivity)
+        (Finset.mem_range.mpr hn_lt)
+    have hterm' : ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := by
+      exact (div_le_iff₀ (pow_pos hr_pos n)).1 hterm
+    have hS_le_C : S ≤ C := by
+      dsimp [C]
+      linarith
+    calc
+      ‖T ^ n‖ ≤ S * (r : ℝ) ^ n := hterm'
+      _ ≤ C * (r : ℝ) ^ n := by
+        gcongr
 
 /-- **Powers tend to zero when spectral radius < 1.** -/
 theorem pow_tendsto_zero_of_spectralRadius_lt_one

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -282,6 +282,26 @@ orthogonal projector is the canonical representative used here.
     row--column pair $((c,e),(a,b))$.
 \end{definition}
 
+\begin{theorem}[Gram reshuffling commutes with subtraction]
+    \label{thm:gram_reshuffle_sub}
+    \lean{Matrix.gramReshuffle_sub}
+    \leanok
+    \uses{def:gram_reshuffle}
+    For complex-linear maps
+    $\mathcal L,\mathcal M\colon\MN{D}\to\MN{D}$,
+    \begin{align}
+      \mathscr R(\mathcal L-\mathcal M)
+      &=\mathscr R(\mathcal L)-\mathscr R(\mathcal M).
+      \label{eq:gram_reshuffle_sub}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:gram_reshuffle}
+    The defining matrix entries of the Choi reshuffling are linear in the map.
+\end{proof}
+
 \begin{theorem}[Matrix-unit coordinates of Gram reshuffling]
     \label{thm:gram_reshuffle_single}
     \lean{Matrix.inner_single_gramReshuffle_single}
@@ -475,6 +495,27 @@ orthogonal projector is the canonical representative used here.
     matrix norm.
 \end{proof}
 
+\begin{theorem}[Geometric power bound below unit spectral radius]
+    \label{thm:geometric_bound_of_spectral_radius_lt_one}
+    \lean{MPSTensor.geometric_bound_of_spectralRadius_lt_one}
+    \leanok
+    Let $V$ be a complex Banach space and let $T\colon V\to V$ be a bounded
+    linear operator.  If $\rho_{\mathrm{spec}}(T)<1$, then there are real
+    constants $C,r$ with $C>0$ and $0<r<1$ such that
+    \begin{align}
+      \lVert T^n\rVert&\leq C r^n
+      \label{eq:geometric_bound_of_spectral_radius_lt_one}
+    \end{align}
+    for every $n\in\N$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Choose $r$ strictly between the spectral radius and one.  Gelfand's formula
+    gives $\lVert T^n\rVert<r^n$ for all sufficiently large $n$; enlarging the
+    constant $C$ absorbs the finitely many remaining powers.
+\end{proof}
+
 \begin{theorem}[Transfer--Gram Choi reshuffling]
     \label{thm:ground_space_gram_choi_reshuffling}
     \lean{MPSTensor.inner_single_groundSpaceGram_single_eq_rectangularChoi}
@@ -540,6 +581,78 @@ orthogonal projector is the canonical representative used here.
     The two operators have equal matrix coefficients on every pair of standard
     basis vectors.  Hence they are equal.
 \end{proof}
+
+\begin{theorem}[Geometric convergence of the ground-space Gram operator]
+    \label{thm:ground_space_gram_geometric_fixed_point}
+    \lean{MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric}
+    \leanok
+    \uses{def:ground_space_gram, def:gram_reshuffle, def:transfer_map,
+        def:fixed_point_proj, def:trace_preserving}
+    Let $A$ be an MPS tensor of bond dimension $D$, let $\rho\in\MN{D}$ satisfy
+    $\tr(\rho)\neq0$, and let $P_\rho$ be the fixed-point projection
+    \begin{align}
+      P_\rho(X)&=\frac{\tr(X)}{\tr(\rho)}\rho.
+    \end{align}
+    Suppose that $\mathcal E_A$ is trace-preserving,
+    $\mathcal E_A(\rho)=\rho$, and
+    \begin{align}
+      \rho_{\mathrm{spec}}(\mathcal E_A-P_\rho)&<1.
+    \end{align}
+    Then there are real constants $C,r$ with $C>0$ and $0<r<1$ such that,
+    for every $n\geq1$,
+    \begin{align}
+      \bigl\lVert\mathcal K_n-\mathscr R(P_\rho)\bigr\rVert^2
+      &\leq D^3\bigl(Cr^n\bigr)^2.
+      \label{eq:ground_space_gram_geometric_fixed_point}
+    \end{align}
+    No positivity, injectivity, or uniqueness hypothesis is imposed.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:geometric_bound_of_spectral_radius_lt_one, thm:pow_decomp,
+        thm:ground_space_gram_eq_gram_reshuffle, thm:gram_reshuffle_sub,
+        thm:gram_reshuffle_norm_sq_le_card_cube_mul_operator_norm_sq}
+    Write $N=\mathcal E_A-P_\rho$.  The power decomposition gives
+    $\mathcal E_A^n=P_\rho+N^n$ for $n\geq1$, while
+    Theorem~\ref{thm:geometric_bound_of_spectral_radius_lt_one} gives
+    $\lVert N^n\rVert\leq Cr^n$.  Use the exact Gram reshuffling identity and
+    Theorem~\ref{thm:gram_reshuffle_sub} to rewrite the left-hand side as
+    $\lVert\mathscr R(N^n)\rVert^2$, then apply
+    Theorem~\ref{thm:gram_reshuffle_norm_sq_le_card_cube_mul_operator_norm_sq}.
+\end{proof}
+
+\begin{theorem}[Ground-space Gram convergence]
+    \label{thm:ground_space_gram_tendsto_fixed_point}
+    \lean{MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj}
+    \leanok
+    \uses{def:ground_space_gram, def:gram_reshuffle, def:transfer_map,
+        def:fixed_point_proj, def:trace_preserving}
+    Let $A$ be an MPS tensor of bond dimension $D$, let $\rho\in\MN{D}$ satisfy
+    $\tr(\rho)\neq0$, and let $P_\rho$ be the corresponding fixed-point
+    projection.  If $\mathcal E_A$ is trace-preserving,
+    $\mathcal E_A(\rho)=\rho$, and
+    $\rho_{\mathrm{spec}}(\mathcal E_A-P_\rho)<1$, then
+    \begin{align}
+      \mathcal K_n&\longrightarrow\mathscr R(P_\rho)
+      \label{eq:ground_space_gram_tendsto_fixed_point}
+    \end{align}
+    in operator norm as $n\to\infty$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_gram_geometric_fixed_point}
+    The right-hand side of
+    (\ref{eq:ground_space_gram_geometric_fixed_point}) tends to zero because
+    $0<r<1$.  Taking square roots gives the asserted norm convergence.
+\end{proof}
+
+The limit in Theorem~\ref{thm:ground_space_gram_tendsto_fixed_point} is the
+reshuffled fixed-point projection $\mathscr R(P_\rho)$, not the identity in
+unweighted Frobenius coordinates.  These theorems therefore do not yet provide
+an inverse-Gram estimate around the identity or compare the physical range
+projectors on overlapping windows.
 
 \begin{definition}[Inverse Gram operator]
     \label{def:inverse_gram}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -622,6 +622,30 @@ orthogonal projector is the canonical representative used here.
     Theorem~\ref{thm:gram_reshuffle_norm_sq_le_card_cube_mul_operator_norm_sq}.
 \end{proof}
 
+\begin{theorem}[Primitive-MPS geometric Gram convergence]
+    \label{thm:primitive_ground_space_gram_geometric_fixed_point}
+    \lean{MPSTensor.IsPrimitiveMPS.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric}
+    \leanok
+    \uses{def:primitive_mps, thm:ground_space_gram_geometric_fixed_point}
+    Let $A$ be a primitive MPS tensor with fixed-point witness $\rho$. Then there
+    are real constants $C,r$ with $C>0$ and $0<r<1$ such that, for every
+    $n\geq1$,
+    \begin{align}
+      \bigl\lVert\mathcal K_n-\mathscr R(P_\rho)\bigr\rVert^2
+      &\leq D^3\bigl(Cr^n\bigr)^2.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_gram_geometric_fixed_point}
+    Positive semidefiniteness and nonvanishing of $\rho$ imply
+    $\tr(\rho)\neq0$. The trace-preserving identity, fixed-point equation, and
+    complementary spectral-radius bound are the remaining fields of the
+    primitive-MPS hypothesis, so
+    Theorem~\ref{thm:ground_space_gram_geometric_fixed_point} applies.
+\end{proof}
+
 \begin{theorem}[Ground-space Gram convergence]
     \label{thm:ground_space_gram_tendsto_fixed_point}
     \lean{MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj}
@@ -646,6 +670,26 @@ orthogonal projector is the canonical representative used here.
     The right-hand side of
     (\ref{eq:ground_space_gram_geometric_fixed_point}) tends to zero because
     $0<r<1$.  Taking square roots gives the asserted norm convergence.
+\end{proof}
+
+\begin{theorem}[Primitive-MPS ground-space Gram convergence]
+    \label{thm:primitive_ground_space_gram_tendsto_fixed_point}
+    \lean{MPSTensor.IsPrimitiveMPS.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj}
+    \leanok
+    \uses{def:primitive_mps, thm:ground_space_gram_tendsto_fixed_point}
+    If $A$ is a primitive MPS tensor with fixed-point witness $\rho$, then
+    \begin{align}
+      \mathcal K_n&\longrightarrow\mathscr R(P_\rho)
+    \end{align}
+    in operator norm as $n\to\infty$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_gram_tendsto_fixed_point}
+    The primitive-MPS data supply the nonzero trace, trace preservation,
+    fixed-point equation, and complementary spectral-radius hypothesis of
+    Theorem~\ref{thm:ground_space_gram_tendsto_fixed_point}.
 \end{proof}
 
 The limit in Theorem~\ref{thm:ground_space_gram_tendsto_fixed_point} is the

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -561,13 +561,43 @@ identity to the exact operator equality
 \end{align}
 The ordering is a Choi reshuffling.  It must not be replaced by the generally
 false Hilbert--Schmidt expression
-$\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.  In the current
-unweighted Frobenius coordinates, a primitive trace-preserving transfer map
-converges to the fixed-point projection $P_{\mathrm{fix}}$, represented by
-\leanid{fixedPointProj}.  The limiting Gram operator is therefore
-$\mathscr R(P_{\mathrm{fix}})$, generally not the identity.  Thus the
-completed generic inequalities do not by themselves provide a Neumann-series
-estimate for $1-\mathcal K_L$.
+$\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.  Reshuffling commutes with subtraction by
+\leanid{Matrix.gramReshuffle_sub}.  Physical Gram convergence in these
+coordinates is now complete under the exact complementary spectral hypothesis.
+Let $\rho\in\mathbb C^{D\times D}$ have nonzero trace, let
+$P_{\mathrm{fix}}(X)=\operatorname{tr}(X)\rho/\operatorname{tr}(\rho)$, and
+suppose that $\mathcal E_A$ is trace-preserving,
+$\mathcal E_A(\rho)=\rho$, and
+\begin{align}
+  \rho_{\mathrm{spec}}(\mathcal E_A-P_{\mathrm{fix}})&<1.
+\end{align}
+The generic prerequisite
+\leanid{MPSTensor.geometric_bound_of_spectralRadius_lt_one} gives constants
+$C>0$ and $0<r<1$ with
+$\lVert(\mathcal E_A-P_{\mathrm{fix}})^n\rVert\le Cr^n$ for every $n$.
+Combining the transfer-power decomposition, the exact Gram reshuffling identity,
+subtraction compatibility, and the $D^3$ squared norm conversion gives
+\leanid{MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric}:
+\begin{align}
+  \bigl\lVert\mathcal K_n-\mathscr R(P_{\mathrm{fix}})\bigr\rVert^2
+  &\le D^3\bigl(Cr^n\bigr)^2,
+  \qquad n\ge1.
+\end{align}
+Consequently,
+\leanid{MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj}
+proves
+\begin{align}
+  \mathcal K_n&\longrightarrow\mathscr R(P_{\mathrm{fix}})
+\end{align}
+in operator norm.  These theorems require exactly nonzero trace,
+trace preservation, the fixed-point equation, and complementary spectral radius
+strictly below one.  They impose no positivity, injectivity, or uniqueness
+hypothesis.
+
+The limiting Gram operator is $\mathscr R(P_{\mathrm{fix}})$, generally not the
+identity in the current unweighted Frobenius coordinates.  Thus this completed
+convergence theorem does not provide a Neumann-series estimate for
+$1-\mathcal K_L$.
 
 The generic identity
 \begin{align}
@@ -624,7 +654,18 @@ and generic prerequisites now include:
 \begin{itemize}
   \item The Choi reshuffling is packaged as the exact operator identity
     \leanid{MPSTensor.groundSpaceGram_eq_gramReshuffle} (module
-    \path{TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean}).
+    \path{TNLean/MPS/ParentHamiltonian/GroundSpaceGram.lean}), and subtraction
+    compatibility is \leanid{Matrix.gramReshuffle_sub}.
+  \item The generic geometric power estimate is
+    \leanid{MPSTensor.geometric_bound_of_spectralRadius_lt_one}.  Under nonzero
+    trace, trace preservation, the fixed-point equation, and complementary
+    spectral radius below one, the quantitative and limiting physical Gram
+    theorems are
+    \leanid{MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric}
+    and
+    \leanid{MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj}.
+    Their limit is $\mathscr R(P_{\mathrm{fix}})$, and the quantitative squared
+    estimate has factor $D^3(Cr^n)^2$.
   \item The generic operator-norm--to--entrywise-Frobenius estimate, its
     reshuffled-Choi corollary, and the safe dimension conversion are
     \leanid{Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq},
@@ -683,24 +724,31 @@ The two ranges are transported into this common ambient by
 \leanid{MPSTensor.leftBoundaryMap_range_map_symm_eq_openChainLeftGroundSpaceES}
 (specialized to \((K+L_0, 1)\)).
 
-The present formal development does not yet
-bound \(\|1-\mathcal K_L\|\) (the deviation of the Gram operator from the
-correctly normalized limiting Gram) by the transfer-mixing rate, so the
-inverse-Gram estimate cannot yet be instantiated; the bound on the displayed
-projector defect is therefore conditional on both the transfer spectral
-estimate and the Gram-deviation control.  The development does not
-prove the contraction
+The present formal development now controls the deviation from the correct
+limiting Gram operator:
+\begin{align}
+  \bigl\lVert\mathcal K_n-\mathscr R(P_{\mathrm{fix}})\bigr\rVert^2
+  &\le D^3\bigl(Cr^n\bigr)^2.
+\end{align}
+It does not control $\lVert1-\mathcal K_n\rVert$ in these unweighted
+coordinates, because $\mathscr R(P_{\mathrm{fix}})$ is generally not the
+identity.  Hence it does not yet bound an inverse Gram operator around the
+identity.  It also does not compare the physical range projectors on the two
+overlapping windows.
+
+In particular, the development does not prove the overlapping-window FNW
+contraction
 \begin{align}
   c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},
   \qquad c\lambda^l<1,
 \end{align}
 which appears as equation \path{boundAm} in
-\cite[Section~6]{Nachtergaele1996Spectral}; it does not identify the physical
-projector with a transfer fixed-point projector, and it does not establish the
-final numerical overlap or spectral-gap bound.  That overlapping-window
-estimate remains open; both boundary maps are unweighted (Frobenius) and the
-Gram identities are normalization-neutral, so the contraction estimate may
-require a second fixed-point metric or weighted boundary coordinates.
+\cite[Section~6]{Nachtergaele1996Spectral}, and it does not reconstruct the
+source constants.  It does not identify a physical range projector with the
+transfer fixed-point projector, nor does it establish the final numerical
+overlap or spectral-gap bound.  That overlapping-window estimate remains open;
+both boundary maps are unweighted (Frobenius), so the contraction estimate may
+require a fixed-point metric or weighted boundary coordinates.
 
 \textbf{Verdict:} open gap.
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -565,21 +565,21 @@ $\langle E_{ab},\mathcal E_A^L(E_{ce})\rangle_{\mathrm{HS}}$.  Reshuffling commu
 \leanid{Matrix.gramReshuffle_sub}.  Physical Gram convergence in these
 coordinates is now complete under the exact complementary spectral hypothesis.
 Let $\rho\in\mathbb C^{D\times D}$ have nonzero trace, let
-$P_{\mathrm{fix}}(X)=\operatorname{tr}(X)\rho/\operatorname{tr}(\rho)$, and
+$P_\rho(X)=\operatorname{tr}(X)\rho/\operatorname{tr}(\rho)$, and
 suppose that $\mathcal E_A$ is trace-preserving,
 $\mathcal E_A(\rho)=\rho$, and
 \begin{align}
-  \rho_{\mathrm{spec}}(\mathcal E_A-P_{\mathrm{fix}})&<1.
+  \rho_{\mathrm{spec}}(\mathcal E_A-P_\rho)&<1.
 \end{align}
 The generic prerequisite
 \leanid{MPSTensor.geometric_bound_of_spectralRadius_lt_one} gives constants
 $C>0$ and $0<r<1$ with
-$\lVert(\mathcal E_A-P_{\mathrm{fix}})^n\rVert\le Cr^n$ for every $n$.
+$\lVert(\mathcal E_A-P_\rho)^n\rVert\le Cr^n$ for every $n$.
 Combining the transfer-power decomposition, the exact Gram reshuffling identity,
 subtraction compatibility, and the $D^3$ squared norm conversion gives
 \leanid{MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric}:
 \begin{align}
-  \bigl\lVert\mathcal K_n-\mathscr R(P_{\mathrm{fix}})\bigr\rVert^2
+  \bigl\lVert\mathcal K_n-\mathscr R(P_\rho)\bigr\rVert^2
   &\le D^3\bigl(Cr^n\bigr)^2,
   \qquad n\ge1.
 \end{align}
@@ -587,14 +587,14 @@ Consequently,
 \leanid{MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj}
 proves
 \begin{align}
-  \mathcal K_n&\longrightarrow\mathscr R(P_{\mathrm{fix}})
+  \mathcal K_n&\longrightarrow\mathscr R(P_\rho)
 \end{align}
 in operator norm.  These theorems require exactly nonzero trace,
 trace preservation, the fixed-point equation, and complementary spectral radius
 strictly below one.  They impose no positivity, injectivity, or uniqueness
 hypothesis.
 
-The limiting Gram operator is $\mathscr R(P_{\mathrm{fix}})$, generally not the
+The limiting Gram operator is $\mathscr R(P_\rho)$, generally not the
 identity in the current unweighted Frobenius coordinates.  Thus this completed
 convergence theorem does not provide a Neumann-series estimate for
 $1-\mathcal K_L$.
@@ -664,7 +664,7 @@ and generic prerequisites now include:
     \leanid{MPSTensor.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric}
     and
     \leanid{MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj}.
-    Their limit is $\mathscr R(P_{\mathrm{fix}})$, and the quantitative squared
+    Their limit is $\mathscr R(P_\rho)$, and the quantitative squared
     estimate has factor $D^3(Cr^n)^2$.
   \item The generic operator-norm--to--entrywise-Frobenius estimate, its
     reshuffled-Choi corollary, and the safe dimension conversion are
@@ -727,11 +727,11 @@ The two ranges are transported into this common ambient by
 The present formal development now controls the deviation from the correct
 limiting Gram operator:
 \begin{align}
-  \bigl\lVert\mathcal K_n-\mathscr R(P_{\mathrm{fix}})\bigr\rVert^2
+  \bigl\lVert\mathcal K_n-\mathscr R(P_\rho)\bigr\rVert^2
   &\le D^3\bigl(Cr^n\bigr)^2.
 \end{align}
 It does not control $\lVert1-\mathcal K_n\rVert$ in these unweighted
-coordinates, because $\mathscr R(P_{\mathrm{fix}})$ is generally not the
+coordinates, because $\mathscr R(P_\rho)$ is generally not the
 identity.  Hence it does not yet bound an inverse Gram operator around the
 identity.  It also does not compare the physical range projectors on the two
 overlapping windows.

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1198, 1240 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1242, 1284 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1085, 1127 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1198, 1240 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- proves geometric convergence of the physical finite-volume MPS Gram operator to the reshuffled fixed-point projection, with the safe squared bound
  $$
  \|\mathcal K_n-\mathscr R(P_\rho)\|^2\le D^3(Cr^n)^2;
  $$
- exposes the generic spectral-radius geometric power estimate and reshuffle subtraction identity used in the proof;
- adds generic norm-convergence and `IsPrimitiveMPS` quantitative/convergence wrappers;
- synchronizes Chapter 13 and the martingale paper-gap note with the exact limit and remaining obstruction.

## Mathematical scope

The limit is `Matrix.gramReshuffle (fixedPointProj ρ htr)`, not the identity in unweighted Frobenius coordinates. The proof uses the exact transfer/Gram reshuffling identity and the dimension-explicit reshuffle norm conversion from #5876. It does not claim operator-norm invariance under reshuffling, an inverse-Gram estimate, or the FNW overlapping-window contraction.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.GramConvergence TNLean.MPS.ParentHamiltonian`
- generated import aggregator check
- `git diff --check`
- full build/blueprint validation initiated after rebasing onto current `main`

Closes #5883
Refs #5752, #5876, #5759, #5455, #5922

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization and documentation with no runtime or security impact; mathematical claims are explicitly scoped to avoid overstating inverse-Gram or FNW overlap results.
> 
> **Overview**
> Adds **formal proofs** that finite-volume MPS ground-space Gram operators converge to the reshuffled fixed-point projection `Matrix.gramReshuffle (fixedPointProj ρ)`, not the identity in unweighted Frobenius coordinates.
> 
> New module `GramConvergence.lean` chains transfer-power decomposition, the exact Gram–Choi reshuffling identity, and a **$D^3(Cr^n)^2$** squared operator-norm bound when the complementary transfer map has spectral radius below 1. Generic and `IsPrimitiveMPS` quantitative and limiting theorems are included.
> 
> Supporting changes: **`Matrix.gramReshuffle_sub`** (reshuffling commutes with subtraction) and relocation of **`geometric_bound_of_spectralRadius_lt_one`** from `QuantitativeGap` to **`TransferOperatorGapCommon`** for shared use. Chapter 13 blueprint and the martingale paper-gap note are updated to state the exact limit and that inverse-Gram / overlapping-window FNW estimates remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c2953a72629175c8768dafefb3ecbc8eda4938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->