### PR TITLE
feat(MPS/RFP): formalize CPSV16 Example 3.4

### DIFF
--- a/TNLean/MPS/RFP.lean
+++ b/TNLean/MPS/RFP.lean
@@ -27,8 +27,8 @@ import TNLean.MPS.RFP.BeigiSectorGraph
 import TNLean.MPS.RFP.BeigiSectorGraphConstruction
 import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.BellPairCIDObstruction
+import TNLean.MPS.RFP.CPSVCIDNotRFPExample
 import TNLean.MPS.RFP.CPSVCanonicalForm
-import TNLean.MPS.RFP.CPSVExample34
 import TNLean.MPS.RFP.CommutingBridge
 import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Decorrelation

--- a/TNLean/MPS/RFP.lean
+++ b/TNLean/MPS/RFP.lean
@@ -28,6 +28,7 @@ import TNLean.MPS.RFP.BeigiSectorGraphConstruction
 import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.BellPairCIDObstruction
 import TNLean.MPS.RFP.CPSVCanonicalForm
+import TNLean.MPS.RFP.CPSVExample34
 import TNLean.MPS.RFP.CommutingBridge
 import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Decorrelation

--- a/TNLean/MPS/RFP/CPSVCIDNotRFPExample.lean
+++ b/TNLean/MPS/RFP/CPSVCIDNotRFPExample.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.Core.Blocking
 import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.RFP.ZeroCorrelationLength
 
@@ -18,7 +17,7 @@ entrywise multipliers. Its transfer map is not idempotent, so it has no
 physical blocking isometry and is not a renormalization fixed point.
 -/
 
-open scoped Matrix BigOperators InnerProductSpace
+open scoped Matrix BigOperators
 
 namespace MPSTensor
 
@@ -33,13 +32,15 @@ noncomputable def cpsvExample34Tensor : MPSTensor 2 2
   | 0 => !![(1 : ℂ), 0; 0, cpsvExample34InvSqrtTwo]
   | 1 => !![(0 : ℂ), 0; 0, cpsvExample34InvSqrtTwo]
 
-@[simp] theorem cpsvExample34Tensor_zero :
-    cpsvExample34Tensor 0 =
-      !![(1 : ℂ), 0; 0, cpsvExample34InvSqrtTwo] := rfl
+/-- The bond-dimension-one $|0\rangle$ component obtained from the first
+virtual diagonal entry of `cpsvExample34Tensor`. -/
+noncomputable def cpsvExample34ZeroTensor : MPSTensor 2 1 :=
+  fun i _ _ => cpsvExample34Tensor i 0 0
 
-@[simp] theorem cpsvExample34Tensor_one :
-    cpsvExample34Tensor 1 =
-      !![(0 : ℂ), 0; 0, cpsvExample34InvSqrtTwo] := rfl
+/-- The bond-dimension-one $|+\rangle$ component obtained from the second
+virtual diagonal entry of `cpsvExample34Tensor`. -/
+noncomputable def cpsvExample34PlusTensor : MPSTensor 2 1 :=
+  fun i _ _ => cpsvExample34Tensor i 1 1
 
 private noncomputable def cpsvExample34WordDiag (w : List (Fin 2)) : Fin 2 → ℂ
   | 0 => if w.Forall (· = 0) then 1 else 0
@@ -51,7 +52,7 @@ private theorem cpsvExample34_evalWord (w : List (Fin 2)) :
   | nil =>
       ext a b
       fin_cases a <;> fin_cases b <;>
-        simp [cpsvExample34WordDiag, Matrix.diagonal_apply]
+        simp [cpsvExample34WordDiag]
   | cons i w ih =>
       rw [evalWord_cons, ih]
       fin_cases i <;>
@@ -59,23 +60,58 @@ private theorem cpsvExample34_evalWord (w : List (Fin 2)) :
         simp [cpsvExample34Tensor, cpsvExample34WordDiag, Matrix.mul_apply,
           Fin.sum_univ_two, pow_succ']
 
+private theorem cpsvExample34_forall_ofFn_zero_iff {N : ℕ} (σ : Fin N → Fin 2) :
+    (List.ofFn σ).Forall (· = 0) ↔ ∀ k, σ k = 0 := by
+  rw [List.forall_iff_forall_mem, List.forall_mem_iff_get]
+  have hlen : (List.ofFn σ).length = N := List.length_ofFn
+  constructor
+  · intro h k
+    have hk : k.val < (List.ofFn σ).length := hlen.symm ▸ k.isLt
+    simpa using h ⟨k.val, hk⟩
+  · intro h k
+    have hk : k.val < N := by omega
+    simpa using h ⟨k.val, hk⟩
+
+private theorem cpsvExample34_component_evalWord (a : Fin 2) (w : List (Fin 2)) :
+    evalWord (fun i : Fin 2 => fun _ _ : Fin 1 => cpsvExample34Tensor i a a) w =
+      fun _ _ : Fin 1 => cpsvExample34WordDiag w a := by
+  induction w with
+  | nil =>
+      ext x y
+      fin_cases x
+      fin_cases y
+      fin_cases a <;> simp [cpsvExample34WordDiag]
+  | cons i w ih =>
+      rw [evalWord_cons, ih]
+      ext x y
+      fin_cases x
+      fin_cases y
+      fin_cases a <;> fin_cases i <;>
+        simp [cpsvExample34Tensor, cpsvExample34WordDiag, Matrix.mul_apply, pow_succ']
+
+private theorem cpsvExample34ZeroTensor_mpv {N : ℕ} (σ : Fin N → Fin 2) :
+    mpv cpsvExample34ZeroTensor σ = if ∀ k, σ k = 0 then 1 else 0 := by
+  rw [mpv, coeff]
+  change Matrix.trace (evalWord (fun i _ _ => cpsvExample34Tensor i 0 0) (List.ofFn σ)) = _
+  rw [cpsvExample34_component_evalWord]
+  simp [Matrix.trace, cpsvExample34WordDiag, cpsvExample34_forall_ofFn_zero_iff]
+
+private theorem cpsvExample34PlusTensor_mpv {N : ℕ} (σ : Fin N → Fin 2) :
+    mpv cpsvExample34PlusTensor σ = cpsvExample34InvSqrtTwo ^ N := by
+  rw [mpv, coeff]
+  change Matrix.trace (evalWord (fun i _ _ => cpsvExample34Tensor i 1 1) (List.ofFn σ)) = _
+  rw [cpsvExample34_component_evalWord]
+  simp [Matrix.trace, cpsvExample34WordDiag]
+
 /-- The exact positive-length amplitude formula in CPSV16, Example 3.4.
 For a nonempty configuration $\sigma$, the first summand is the amplitude of
 $|0,\ldots,0\rangle$ and the second is the amplitude of
 $|+,\ldots,+\rangle$. -/
-theorem cpsvExample34_mpv {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin 2) :
+theorem cpsvExample34_mpv {N : ℕ} (_hN : 0 < N) (σ : Fin N → Fin 2) :
     mpv cpsvExample34Tensor σ =
       (if ∀ k, σ k = 0 then 1 else 0) + cpsvExample34InvSqrtTwo ^ N := by
   rw [mpv, coeff, cpsvExample34_evalWord]
-  simp only [Matrix.trace, Matrix.diagonal_apply_eq, Fin.sum_univ_two,
-    cpsvExample34WordDiag, List.length_ofFn]
-  congr 2
-  simp only [List.forall_iff_forall_mem, List.mem_ofFn]
-  constructor
-  · intro h k
-    exact h (σ k) ⟨k, rfl⟩
-  · rintro h x ⟨k, rfl⟩
-    exact h k
+  simp [Matrix.trace, cpsvExample34WordDiag, cpsvExample34_forall_ofFn_zero_iff]
 
 private def IsEntrywiseMultiplier
     (F : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
@@ -93,6 +129,13 @@ private theorem isEntrywiseMultiplier_commute
   simp only [Module.End.mul_apply, hc, he]
   ring
 
+private theorem diagonal_sandwich_apply (u v : Fin 2 → ℂ)
+    (X : Matrix (Fin 2) (Fin 2) ℂ) (a b : Fin 2) :
+    (Matrix.diagonal u * (X * (Matrix.diagonal v)ᴴ)) a b =
+      u a * X a b * star (v b) := by
+  fin_cases a <;> fin_cases b <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two, mul_assoc]
+
 private theorem cpsvExample34_physicalObservableTransfer_isEntrywiseMultiplier
     (L : ℕ) (O : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) :
     IsEntrywiseMultiplier (physicalObservableTransfer cpsvExample34Tensor L O) := by
@@ -104,22 +147,38 @@ private theorem cpsvExample34_physicalObservableTransfer_isEntrywiseMultiplier
   intro X a b
   simp only [physicalObservableTransfer, LinearMap.sum_apply, LinearMap.smul_apply,
     LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
-  simp_rw [cpsvExample34_evalWord]
-  simp only [Matrix.conjTranspose_diagonal, Matrix.mul_apply, Matrix.diagonal_apply,
-    Finset.sum_ite_irrel, Finset.ite_sum, Finset.sum_const_zero, Finset.sum_ite_eq',
-    Finset.mem_univ, ↓reduceIte]
-  simp [c, mul_assoc, Finset.sum_mul]
+  simp_rw [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  simp_rw [cpsvExample34_evalWord, diagonal_sandwich_apply]
+  dsimp only [c]
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro σ _
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro τ _
+  ring
+
+private theorem cpsvExample34_letter_diagonal (i : Fin 2) :
+    cpsvExample34Tensor i =
+      Matrix.diagonal (cpsvExample34WordDiag [i]) := by
+  fin_cases i <;> ext a b <;> fin_cases a <;> fin_cases b <;>
+    simp [cpsvExample34Tensor, cpsvExample34WordDiag]
 
 private theorem cpsvExample34_transferMap_isEntrywiseMultiplier :
     IsEntrywiseMultiplier (transferMap cpsvExample34Tensor) := by
-  let O : Matrix (Fin 1 → Fin 2) (Fin 1 → Fin 2) ℂ := 1
-  have hPhys := cpsvExample34_physicalObservableTransfer_isEntrywiseMultiplier 1 O
-  rw [show physicalObservableTransfer cpsvExample34Tensor 1 O =
-      transferMap cpsvExample34Tensor by
-    apply LinearMap.ext
-    intro X
-    simp [physicalObservableTransfer, transferMap_apply, O, evalWord]] at hPhys
-  exact hPhys
+  let c : Matrix (Fin 2) (Fin 2) ℂ := fun a b =>
+    ∑ i : Fin 2, cpsvExample34WordDiag [i] a *
+      star (cpsvExample34WordDiag [i] b)
+  refine ⟨c, ?_⟩
+  intro X a b
+  change (∑ i : Fin 2, (cpsvExample34Tensor i *
+    (X * (cpsvExample34Tensor i)ᴴ)) a b) = c a b * X a b
+  simp_rw [cpsvExample34_letter_diagonal, diagonal_sandwich_apply]
+  dsimp only [c]
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro i _
+  ring
 
 private theorem cpsvExample34_transfer_commutes_physicalObservableTransfer
     (L : ℕ) (O : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) :
@@ -145,14 +204,20 @@ theorem cpsvExample34_isPhysicalCID :
     F₂ * E ^ n₂ * (F₁ * E ^ n₁) = F₂ * F₁ * (E ^ n₂ * E ^ n₁) :=
       (hComm₁.pow_left n₂).mul_mul_mul_comm F₂ (E ^ n₁)
     _ = F₂ * F₁ * E ^ (n₂ + n₁) := by rw [← pow_add]
-    _ = F₂ * F₁ * E ^ (m₂ + m₁) := by rw [Nat.add_comm n₂ n₁, Nat.add_comm m₂ m₁, hsum]
+    _ = F₂ * F₁ * E ^ (m₂ + m₁) := by
+      rw [Nat.add_comm n₂ n₁, Nat.add_comm m₂ m₁, hsum]
     _ = F₂ * F₁ * (E ^ m₂ * E ^ m₁) := by rw [← pow_add]
     _ = F₂ * E ^ m₂ * (F₁ * E ^ m₁) :=
       ((hComm₁.pow_left m₂).mul_mul_mul_comm F₂ (E ^ m₁)).symm
 
 private theorem cpsvExample34_invSqrtTwo_sq :
     cpsvExample34InvSqrtTwo ^ 2 = (1 / 2 : ℂ) := by
-  norm_num [cpsvExample34InvSqrtTwo, div_pow, Real.sq_sqrt]
+  have hsqrt_ne : Real.sqrt 2 ≠ 0 := Real.sqrt_ne_zero'.mpr (by norm_num)
+  have hreal : (1 / Real.sqrt 2) ^ 2 = (1 / 2 : ℝ) := by
+    field_simp [hsqrt_ne]
+    rw [Real.sq_sqrt (by norm_num)]
+  rw [cpsvExample34InvSqrtTwo, ← Complex.ofReal_pow]
+  exact (congrArg (fun x : ℝ => (x : ℂ)) hreal).trans (by norm_num)
 
 private theorem cpsvExample34_invSqrtTwo_ne_half :
     cpsvExample34InvSqrtTwo ≠ (1 / 2 : ℂ) := by
@@ -161,6 +226,10 @@ private theorem cpsvExample34_invSqrtTwo_ne_half :
   rw [h] at hsquare
   norm_num at hsquare
 
+private theorem star_cpsvExample34InvSqrtTwo :
+    star cpsvExample34InvSqrtTwo = cpsvExample34InvSqrtTwo := by
+  simp [cpsvExample34InvSqrtTwo]
+
 private def offDiagonalUnit : Matrix (Fin 2) (Fin 2) ℂ :=
   !![(0 : ℂ), 1; 0, 0]
 
@@ -168,9 +237,12 @@ private theorem cpsvExample34_transferMap_offDiagonalUnit :
     transferMap cpsvExample34Tensor offDiagonalUnit =
       cpsvExample34InvSqrtTwo • offDiagonalUnit := by
   ext a b
+  change (∑ i : Fin 2, (cpsvExample34Tensor i *
+    (offDiagonalUnit * (cpsvExample34Tensor i)ᴴ)) a b) =
+      (cpsvExample34InvSqrtTwo • offDiagonalUnit) a b
+  simp_rw [cpsvExample34_letter_diagonal, diagonal_sandwich_apply]
   fin_cases a <;> fin_cases b <;>
-    simp [transferMap_apply, cpsvExample34Tensor, offDiagonalUnit,
-      Matrix.mul_apply, Fin.sum_univ_two, cpsvExample34InvSqrtTwo]
+    simp [cpsvExample34WordDiag, offDiagonalUnit, star_cpsvExample34InvSqrtTwo]
 
 /-- The transfer map of the tensor in CPSV16, Example 3.4 is not idempotent.
 The off-diagonal matrix unit has transfer eigenvalue $1/\sqrt2$, whose square
@@ -182,24 +254,45 @@ theorem cpsvExample34_not_isTransferIdempotent :
   simp only [LinearMap.comp_apply, cpsvExample34_transferMap_offDiagonalUnit,
     map_smul] at h
   have h01 := congrFun (congrFun h 0) 1
-  simp [offDiagonalUnit, cpsvExample34_invSqrtTwo_sq] at h01
-  exact cpsvExample34_invSqrtTwo_ne_half h01.symm
+  have hscalar : cpsvExample34InvSqrtTwo * cpsvExample34InvSqrtTwo =
+      cpsvExample34InvSqrtTwo := by
+    simpa [offDiagonalUnit] using h01
+  rw [← pow_two, cpsvExample34_invSqrtTwo_sq] at hscalar
+  exact cpsvExample34_invSqrtTwo_ne_half hscalar.symm
 
 /-- The exact tensor in CPSV16, Example 3.4 has no physical blocking isometry,
 so it fails the source equation `AA=A` and is not a pure-state RFP. -/
 theorem cpsvExample34_not_hasPhysicalBlockingIsometry :
     ¬ HasPhysicalBlockingIsometry cpsvExample34Tensor := by
-  rwa [← isTransferIdempotent_iff_hasPhysicalBlockingIsometry]
+  intro hBlocking
+  exact cpsvExample34_not_isTransferIdempotent
+    ((isTransferIdempotent_iff_hasPhysicalBlockingIsometry _).mpr hBlocking)
 
-/-- The product-state overlap after blocking $n$ spins is
-$\langle 0^{\otimes n}|+^{\otimes n}\rangle=2^{-n/2}$, written as
-$(1/\sqrt2)^n$. -/
-theorem cpsvExample34_blocked_overlap (n : ℕ) :
+private theorem cpsvExample34_blocked_overlap_sum (n : ℕ) :
     ∑ σ : Fin n → Fin 2,
       (if ∀ k, σ k = 0 then (1 : ℂ) else 0) * cpsvExample34InvSqrtTwo ^ n =
         cpsvExample34InvSqrtTwo ^ n := by
   classical
-  rw [Finset.sum_ite_irrel]
-  simp
+  let zeroConfig : Fin n → Fin 2 := fun _ => 0
+  rw [Fintype.sum_eq_single zeroConfig]
+  · simp [zeroConfig]
+  · intro σ hσ
+    have hnot : ¬ ∀ k, σ k = 0 := by
+      intro hzero
+      apply hσ
+      funext k
+      exact hzero k
+    simp [hnot]
+
+/-- The formal overlap between the two product-state components of the tensor
+in CPSV16, Example 3.4 is
+$\langle 0^{\otimes n}|+^{\otimes n}\rangle=(1/\sqrt2)^n$. -/
+theorem cpsvExample34_blocked_overlap (n : ℕ) :
+    mpvOverlap cpsvExample34ZeroTensor cpsvExample34PlusTensor n =
+      cpsvExample34InvSqrtTwo ^ n := by
+  rw [mpvOverlap]
+  simp_rw [cpsvExample34ZeroTensor_mpv, cpsvExample34PlusTensor_mpv,
+    star_pow, star_cpsvExample34InvSqrtTwo]
+  exact cpsvExample34_blocked_overlap_sum n
 
 end MPSTensor

--- a/TNLean/MPS/RFP/CPSVCIDNotRFPExample.lean
+++ b/TNLean/MPS/RFP/CPSVCIDNotRFPExample.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.RFP.ZeroCorrelationLength
+import TNLean.MPS.Tactic.Basic
 
 /-!
 # CPSV16 Example 3.4: correlation independence without an RFP
@@ -136,6 +138,13 @@ private theorem diagonal_sandwich_apply (u v : Fin 2 → ℂ)
   fin_cases a <;> fin_cases b <;>
     simp [Matrix.mul_apply, Fin.sum_univ_two, mul_assoc]
 
+private theorem diagonal_sandwich_apply_left (u v : Fin 2 → ℂ)
+    (X : Matrix (Fin 2) (Fin 2) ℂ) (a b : Fin 2) :
+    (Matrix.diagonal u * X * (Matrix.diagonal v)ᴴ) a b =
+      u a * X a b * star (v b) := by
+  rw [Matrix.mul_assoc]
+  exact diagonal_sandwich_apply u v X a b
+
 private theorem cpsvExample34_physicalObservableTransfer_isEntrywiseMultiplier
     (L : ℕ) (O : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) :
     IsEntrywiseMultiplier (physicalObservableTransfer cpsvExample34Tensor L O) := by
@@ -150,13 +159,11 @@ private theorem cpsvExample34_physicalObservableTransfer_isEntrywiseMultiplier
   simp_rw [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
   simp_rw [cpsvExample34_evalWord, diagonal_sandwich_apply]
   dsimp only [c]
-  rw [Finset.sum_mul]
-  apply Finset.sum_congr rfl
-  intro σ _
-  rw [Finset.sum_mul]
-  apply Finset.sum_congr rfl
-  intro τ _
-  ring
+  simpa only [Fintype.sum_prod_type, mul_comm, mul_left_comm, mul_assoc] using
+    (Fintype.sum_mul_mul_eq_mul_sum_mul (X a b)
+      (fun p : (Fin L → Fin 2) × (Fin L → Fin 2) =>
+        O p.2 p.1 * cpsvExample34WordDiag (List.ofFn p.1) a)
+      (fun p => star (cpsvExample34WordDiag (List.ofFn p.2) b)))
 
 private theorem cpsvExample34_letter_diagonal (i : Fin 2) :
     cpsvExample34Tensor i =
@@ -171,14 +178,15 @@ private theorem cpsvExample34_transferMap_isEntrywiseMultiplier :
       star (cpsvExample34WordDiag [i] b)
   refine ⟨c, ?_⟩
   intro X a b
-  change (∑ i : Fin 2, (cpsvExample34Tensor i *
-    (X * (cpsvExample34Tensor i)ᴴ)) a b) = c a b * X a b
-  simp_rw [cpsvExample34_letter_diagonal, diagonal_sandwich_apply]
+  transfer_simp
+  change (∑ i : Fin 2, (cpsvExample34Tensor i * X *
+    (cpsvExample34Tensor i)ᴴ) a b) = c a b * X a b
+  simp_rw [cpsvExample34_letter_diagonal, diagonal_sandwich_apply_left]
   dsimp only [c]
-  rw [Finset.sum_mul]
-  apply Finset.sum_congr rfl
-  intro i _
-  ring
+  simpa only [mul_comm, mul_left_comm, mul_assoc] using
+    (Fintype.sum_mul_mul_eq_mul_sum_mul (X a b)
+      (fun i : Fin 2 => cpsvExample34WordDiag [i] a)
+      (fun i => star (cpsvExample34WordDiag [i] b)))
 
 private theorem cpsvExample34_transfer_commutes_physicalObservableTransfer
     (L : ℕ) (O : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) :
@@ -237,10 +245,11 @@ private theorem cpsvExample34_transferMap_offDiagonalUnit :
     transferMap cpsvExample34Tensor offDiagonalUnit =
       cpsvExample34InvSqrtTwo • offDiagonalUnit := by
   ext a b
-  change (∑ i : Fin 2, (cpsvExample34Tensor i *
-    (offDiagonalUnit * (cpsvExample34Tensor i)ᴴ)) a b) =
+  transfer_simp
+  change (∑ i : Fin 2, (cpsvExample34Tensor i * offDiagonalUnit *
+    (cpsvExample34Tensor i)ᴴ) a b) =
       (cpsvExample34InvSqrtTwo • offDiagonalUnit) a b
-  simp_rw [cpsvExample34_letter_diagonal, diagonal_sandwich_apply]
+  simp_rw [cpsvExample34_letter_diagonal, diagonal_sandwich_apply_left]
   fin_cases a <;> fin_cases b <;>
     simp [cpsvExample34WordDiag, offDiagonalUnit, star_cpsvExample34InvSqrtTwo]
 

--- a/TNLean/MPS/RFP/CPSVExample34.lean
+++ b/TNLean/MPS/RFP/CPSVExample34.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Core.Blocking
+import TNLean.MPS.Overlap.Basic
+import TNLean.MPS.RFP.ZeroCorrelationLength
+
+/-!
+# CPSV16 Example 3.4: correlation independence without an RFP
+
+This file formalizes the tensor displayed in arXiv:1606.00608, Example 3.4
+(`Ex:ZCL`, lines 450--465). Its positive-length MPV is
+$|0,\ldots,0\rangle+|+,\ldots,+\rangle$. The state has physical correlation
+independence because all of its diagonal word operators induce commuting
+entrywise multipliers. Its transfer map is not idempotent, so it has no
+physical blocking isometry and is not a renormalization fixed point.
+-/
+
+open scoped Matrix BigOperators InnerProductSpace
+
+namespace MPSTensor
+
+/-- The scalar $1/\sqrt 2$, viewed as a complex number. -/
+noncomputable def cpsvExample34InvSqrtTwo : ℂ :=
+  (↑(1 / Real.sqrt 2) : ℂ)
+
+/-- The exact tensor from CPSV16, Example 3.4:
+$A^0=\operatorname{diag}(1,1/\sqrt2)$ and
+$A^1=\operatorname{diag}(0,1/\sqrt2)$. -/
+noncomputable def cpsvExample34Tensor : MPSTensor 2 2
+  | 0 => !![(1 : ℂ), 0; 0, cpsvExample34InvSqrtTwo]
+  | 1 => !![(0 : ℂ), 0; 0, cpsvExample34InvSqrtTwo]
+
+@[simp] theorem cpsvExample34Tensor_zero :
+    cpsvExample34Tensor 0 =
+      !![(1 : ℂ), 0; 0, cpsvExample34InvSqrtTwo] := rfl
+
+@[simp] theorem cpsvExample34Tensor_one :
+    cpsvExample34Tensor 1 =
+      !![(0 : ℂ), 0; 0, cpsvExample34InvSqrtTwo] := rfl
+
+private noncomputable def cpsvExample34WordDiag (w : List (Fin 2)) : Fin 2 → ℂ
+  | 0 => if w.Forall (· = 0) then 1 else 0
+  | 1 => cpsvExample34InvSqrtTwo ^ w.length
+
+private theorem cpsvExample34_evalWord (w : List (Fin 2)) :
+    evalWord cpsvExample34Tensor w = Matrix.diagonal (cpsvExample34WordDiag w) := by
+  induction w with
+  | nil =>
+      ext a b
+      fin_cases a <;> fin_cases b <;>
+        simp [cpsvExample34WordDiag, Matrix.diagonal_apply]
+  | cons i w ih =>
+      rw [evalWord_cons, ih]
+      fin_cases i <;>
+        ext a b <;> fin_cases a <;> fin_cases b <;>
+        simp [cpsvExample34Tensor, cpsvExample34WordDiag, Matrix.mul_apply,
+          Fin.sum_univ_two, pow_succ']
+
+/-- The exact positive-length amplitude formula in CPSV16, Example 3.4.
+For a nonempty configuration $\sigma$, the first summand is the amplitude of
+$|0,\ldots,0\rangle$ and the second is the amplitude of
+$|+,\ldots,+\rangle$. -/
+theorem cpsvExample34_mpv {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin 2) :
+    mpv cpsvExample34Tensor σ =
+      (if ∀ k, σ k = 0 then 1 else 0) + cpsvExample34InvSqrtTwo ^ N := by
+  rw [mpv, coeff, cpsvExample34_evalWord]
+  simp only [Matrix.trace, Matrix.diagonal_apply_eq, Fin.sum_univ_two,
+    cpsvExample34WordDiag, List.length_ofFn]
+  congr 2
+  simp only [List.forall_iff_forall_mem, List.mem_ofFn]
+  constructor
+  · intro h k
+    exact h (σ k) ⟨k, rfl⟩
+  · rintro h x ⟨k, rfl⟩
+    exact h k
+
+private def IsEntrywiseMultiplier
+    (F : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) : Prop :=
+  ∃ c : Matrix (Fin 2) (Fin 2) ℂ, ∀ X a b, F X a b = c a b * X a b
+
+private theorem isEntrywiseMultiplier_commute
+    {F G : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ}
+    (hF : IsEntrywiseMultiplier F) (hG : IsEntrywiseMultiplier G) :
+    Commute F G := by
+  obtain ⟨c, hc⟩ := hF
+  obtain ⟨e, he⟩ := hG
+  apply LinearMap.ext
+  intro X
+  ext a b
+  simp only [Module.End.mul_apply, hc, he]
+  ring
+
+private theorem cpsvExample34_physicalObservableTransfer_isEntrywiseMultiplier
+    (L : ℕ) (O : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) :
+    IsEntrywiseMultiplier (physicalObservableTransfer cpsvExample34Tensor L O) := by
+  let c : Matrix (Fin 2) (Fin 2) ℂ := fun a b =>
+    ∑ σ : Fin L → Fin 2, ∑ τ : Fin L → Fin 2,
+      O τ σ * cpsvExample34WordDiag (List.ofFn σ) a *
+        star (cpsvExample34WordDiag (List.ofFn τ) b)
+  refine ⟨c, ?_⟩
+  intro X a b
+  simp only [physicalObservableTransfer, LinearMap.sum_apply, LinearMap.smul_apply,
+    LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
+  simp_rw [cpsvExample34_evalWord]
+  simp only [Matrix.conjTranspose_diagonal, Matrix.mul_apply, Matrix.diagonal_apply,
+    Finset.sum_ite_irrel, Finset.ite_sum, Finset.sum_const_zero, Finset.sum_ite_eq',
+    Finset.mem_univ, ↓reduceIte]
+  simp [c, mul_assoc, Finset.sum_mul]
+
+private theorem cpsvExample34_transferMap_isEntrywiseMultiplier :
+    IsEntrywiseMultiplier (transferMap cpsvExample34Tensor) := by
+  let O : Matrix (Fin 1 → Fin 2) (Fin 1 → Fin 2) ℂ := 1
+  have hPhys := cpsvExample34_physicalObservableTransfer_isEntrywiseMultiplier 1 O
+  rw [show physicalObservableTransfer cpsvExample34Tensor 1 O =
+      transferMap cpsvExample34Tensor by
+    apply LinearMap.ext
+    intro X
+    simp [physicalObservableTransfer, transferMap_apply, O, evalWord]] at hPhys
+  exact hPhys
+
+private theorem cpsvExample34_transfer_commutes_physicalObservableTransfer
+    (L : ℕ) (O : Matrix (Fin L → Fin 2) (Fin L → Fin 2) ℂ) :
+    Commute (transferMap cpsvExample34Tensor)
+      (physicalObservableTransfer cpsvExample34Tensor L O) :=
+  isEntrywiseMultiplier_commute cpsvExample34_transferMap_isEntrywiseMultiplier
+    (cpsvExample34_physicalObservableTransfer_isEntrywiseMultiplier L O)
+
+/-- The literal physical correlation-independence claim of CPSV16,
+Example 3.4. The result uses `IsPhysicalCID`, not the stronger BNT local
+orthogonality, ZCL, or RFP predicates. -/
+theorem cpsvExample34_isPhysicalCID :
+    IsPhysicalCID cpsvExample34Tensor := by
+  intro L₁ L₂ O₁ O₂ n₁ n₂ m₁ m₂ _ _ hsum
+  let E := transferMap cpsvExample34Tensor
+  let F₁ := physicalObservableTransfer cpsvExample34Tensor L₁ O₁
+  let F₂ := physicalObservableTransfer cpsvExample34Tensor L₂ O₂
+  have hComm₁ : Commute E F₁ :=
+    cpsvExample34_transfer_commutes_physicalObservableTransfer L₁ O₁
+  simp only [physicalTwoPointExpectation, ← Module.End.mul_eq_comp]
+  congr 1
+  calc
+    F₂ * E ^ n₂ * (F₁ * E ^ n₁) = F₂ * F₁ * (E ^ n₂ * E ^ n₁) :=
+      (hComm₁.pow_left n₂).mul_mul_mul_comm F₂ (E ^ n₁)
+    _ = F₂ * F₁ * E ^ (n₂ + n₁) := by rw [← pow_add]
+    _ = F₂ * F₁ * E ^ (m₂ + m₁) := by rw [Nat.add_comm n₂ n₁, Nat.add_comm m₂ m₁, hsum]
+    _ = F₂ * F₁ * (E ^ m₂ * E ^ m₁) := by rw [← pow_add]
+    _ = F₂ * E ^ m₂ * (F₁ * E ^ m₁) :=
+      ((hComm₁.pow_left m₂).mul_mul_mul_comm F₂ (E ^ m₁)).symm
+
+private theorem cpsvExample34_invSqrtTwo_sq :
+    cpsvExample34InvSqrtTwo ^ 2 = (1 / 2 : ℂ) := by
+  norm_num [cpsvExample34InvSqrtTwo, div_pow, Real.sq_sqrt]
+
+private theorem cpsvExample34_invSqrtTwo_ne_half :
+    cpsvExample34InvSqrtTwo ≠ (1 / 2 : ℂ) := by
+  intro h
+  have hsquare := cpsvExample34_invSqrtTwo_sq
+  rw [h] at hsquare
+  norm_num at hsquare
+
+private def offDiagonalUnit : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![(0 : ℂ), 1; 0, 0]
+
+private theorem cpsvExample34_transferMap_offDiagonalUnit :
+    transferMap cpsvExample34Tensor offDiagonalUnit =
+      cpsvExample34InvSqrtTwo • offDiagonalUnit := by
+  ext a b
+  fin_cases a <;> fin_cases b <;>
+    simp [transferMap_apply, cpsvExample34Tensor, offDiagonalUnit,
+      Matrix.mul_apply, Fin.sum_univ_two, cpsvExample34InvSqrtTwo]
+
+/-- The transfer map of the tensor in CPSV16, Example 3.4 is not idempotent.
+The off-diagonal matrix unit has transfer eigenvalue $1/\sqrt2$, whose square
+is $1/2$, so the second transfer application differs from the first. -/
+theorem cpsvExample34_not_isTransferIdempotent :
+    ¬ IsTransferIdempotent cpsvExample34Tensor := by
+  intro hIdem
+  have h := congr_fun (congr_arg DFunLike.coe hIdem) offDiagonalUnit
+  simp only [LinearMap.comp_apply, cpsvExample34_transferMap_offDiagonalUnit,
+    map_smul] at h
+  have h01 := congrFun (congrFun h 0) 1
+  simp [offDiagonalUnit, cpsvExample34_invSqrtTwo_sq] at h01
+  exact cpsvExample34_invSqrtTwo_ne_half h01.symm
+
+/-- The exact tensor in CPSV16, Example 3.4 has no physical blocking isometry,
+so it fails the source equation `AA=A` and is not a pure-state RFP. -/
+theorem cpsvExample34_not_hasPhysicalBlockingIsometry :
+    ¬ HasPhysicalBlockingIsometry cpsvExample34Tensor := by
+  rwa [← isTransferIdempotent_iff_hasPhysicalBlockingIsometry]
+
+/-- The product-state overlap after blocking $n$ spins is
+$\langle 0^{\otimes n}|+^{\otimes n}\rangle=2^{-n/2}$, written as
+$(1/\sqrt2)^n$. -/
+theorem cpsvExample34_blocked_overlap (n : ℕ) :
+    ∑ σ : Fin n → Fin 2,
+      (if ∀ k, σ k = 0 then (1 : ℂ) else 0) * cpsvExample34InvSqrtTwo ^ n =
+        cpsvExample34InvSqrtTwo ^ n := by
+  classical
+  rw [Finset.sum_ite_irrel]
+  simp
+
+end MPSTensor

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -12,4 +12,5 @@ symmetry) are stated for each tensor.
 \input{chapter/ch15_examples_majumdar_ghosh}
 \input{chapter/ch15_examples_w_state}
 \input{chapter/ch15_examples_cluster_state}
+\input{chapter/ch15_examples_cpsv16_example_34}
 \input{chapter/ch15_examples_parent_hamiltonians}

--- a/blueprint/src/chapter/ch15_examples_cpsv16_example_34.tex
+++ b/blueprint/src/chapter/ch15_examples_cpsv16_example_34.tex
@@ -28,7 +28,7 @@ the stronger basis-of-normal-tensors sense.
     \label{thm:cpsv16_example_34_mpv}
     \lean{MPSTensor.cpsvExample34_mpv}
     \leanok
-    \uses{def:cpsv16_example_34_tensor}
+    \uses{def:cpsv16_example_34_tensor, def:mpv}
     For $N>0$ and $\boldsymbol i=(i_1,\ldots,i_N)\in\{0,1\}^N$,
     \begin{align}
         \Tr(A^{i_1}\cdots A^{i_N})
@@ -43,6 +43,7 @@ the stronger basis-of-normal-tensors sense.
 
 \begin{proof}
     \leanok
+    \uses{def:mpv}
     Both matrices are diagonal. The first diagonal entry contributes $1$ only
     to the all-zero word, while the second contributes
     $(1/\sqrt2)^N$ to every word.
@@ -72,8 +73,7 @@ the stronger basis-of-normal-tensors sense.
         MPSTensor.cpsvExample34_not_hasPhysicalBlockingIsometry}
     \leanok
     \uses{def:cpsv16_example_34_tensor, def:mps_transfer_idempotence,
-        def:physical_blocking_isometry,
-        thm:physical_blocking_isometry_iff_transfer_idempotence}
+        def:physical_blocking_isometry}
     The transfer map is not idempotent, and the tensor has no physical blocking
     isometry. Thus it does not satisfy the pure-state renormalization
     fixed-point equation.
@@ -81,6 +81,7 @@ the stronger basis-of-normal-tensors sense.
 
 \begin{proof}
     \leanok
+    \uses{thm:physical_blocking_isometry_iff_transfer_idempotence}
     Let $E_{01}=\ketbra0{1}$. The transfer map obeys
     \begin{align}
         \E_A(E_{01})&=\frac{1}{\sqrt2}E_{01},
@@ -96,12 +97,12 @@ the stronger basis-of-normal-tensors sense.
     \label{thm:cpsv16_example_34_blocked_overlap}
     \lean{MPSTensor.cpsvExample34_blocked_overlap}
     \leanok
-    \uses{def:cpsv16_example_34_tensor}
+    \uses{def:cpsv16_example_34_tensor, def:mpv_overlap}
     Let $A_0$ and $A_+$ be the bond-dimension-one product tensors obtained
     from the first and second virtual diagonal entries of $A$. Their formal MPV
     overlap at length $n$ is
     \begin{align}
-        \operatorname{Overlap}_n(A_0,A_+)
+        O_{A_0A_+}(n)
         &=\left(\frac{1}{\sqrt2}\right)^n.
         \notag
     \end{align}
@@ -109,6 +110,7 @@ the stronger basis-of-normal-tensors sense.
 
 \begin{proof}
     \leanok
+    \uses{def:mpv_overlap}
     Only the all-zero configuration contributes, with amplitude
     $(1/\sqrt2)^n$.
 \end{proof}

--- a/blueprint/src/chapter/ch15_examples_cpsv16_example_34.tex
+++ b/blueprint/src/chapter/ch15_examples_cpsv16_example_34.tex
@@ -8,7 +8,9 @@ the stronger basis-of-normal-tensors sense.
 
 \begin{definition}[The tensor of CPSV16 Example 3.4]
     \label{def:cpsv16_example_34_tensor}
-    \lean{MPSTensor.cpsvExample34Tensor}
+    \lean{MPSTensor.cpsvExample34Tensor,
+        MPSTensor.cpsvExample34ZeroTensor,
+        MPSTensor.cpsvExample34PlusTensor}
     \leanok
     \uses{def:mps_tensor}
     Set $d=D=2$ and
@@ -18,6 +20,8 @@ the stronger basis-of-normal-tensors sense.
         A^1&=\diag\!\left(0,\frac{1}{\sqrt2}\right).
         \notag
     \end{align}
+    The first and second virtual diagonal entries define the bond-dimension-one
+    product tensors for $\ket0$ and $\ket+$, respectively.
 \end{definition}
 
 \begin{theorem}[Positive-length amplitudes]
@@ -93,10 +97,12 @@ the stronger basis-of-normal-tensors sense.
     \lean{MPSTensor.cpsvExample34_blocked_overlap}
     \leanok
     \uses{def:cpsv16_example_34_tensor}
-    After blocking $n$ spins, the two product vectors satisfy
+    Let $A_0$ and $A_+$ be the bond-dimension-one product tensors obtained
+    from the first and second virtual diagonal entries of $A$. Their formal MPV
+    overlap at length $n$ is
     \begin{align}
-        \left\langle 0^{\otimes n}\middle|+^{\otimes n}\right\rangle
-        &=\left(\frac{1}{\sqrt2}\right)^n=2^{-n/2}.
+        \operatorname{Overlap}_n(A_0,A_+)
+        &=\left(\frac{1}{\sqrt2}\right)^n.
         \notag
     \end{align}
 \end{theorem}

--- a/blueprint/src/chapter/ch15_examples_cpsv16_example_34.tex
+++ b/blueprint/src/chapter/ch15_examples_cpsv16_example_34.tex
@@ -1,0 +1,108 @@
+\section{Correlation independence without a renormalization fixed point}
+\label{sec:cpsv16_example_34}
+
+The following example is \cite[Example~3.4]{Cirac2016MPDO_arXiv}. It separates
+physical correlation independence from the renormalization fixed-point
+condition. It does not assert local orthogonality or zero correlation length in
+the stronger basis-of-normal-tensors sense.
+
+\begin{definition}[The tensor of CPSV16 Example 3.4]
+    \label{def:cpsv16_example_34_tensor}
+    \lean{MPSTensor.cpsvExample34Tensor}
+    \leanok
+    \uses{def:mps_tensor}
+    Set $d=D=2$ and
+    \begin{align}
+        A^0&=\diag\!\left(1,\frac{1}{\sqrt2}\right),
+        &
+        A^1&=\diag\!\left(0,\frac{1}{\sqrt2}\right).
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Positive-length amplitudes]
+    \label{thm:cpsv16_example_34_mpv}
+    \lean{MPSTensor.cpsvExample34_mpv}
+    \leanok
+    \uses{def:cpsv16_example_34_tensor}
+    For $N>0$ and $\boldsymbol i=(i_1,\ldots,i_N)\in\{0,1\}^N$,
+    \begin{align}
+        \Tr(A^{i_1}\cdots A^{i_N})
+        &=\mathbf 1_{\{\boldsymbol i=(0,\ldots,0)\}}
+          +\left(\frac{1}{\sqrt2}\right)^N.
+        \notag
+    \end{align}
+    Hence the generated MPV is
+    $\ket{0}^{\otimes N}+\ket{+}^{\otimes N}$, where
+    $\ket{+}=(\ket0+\ket1)/\sqrt2$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Both matrices are diagonal. The first diagonal entry contributes $1$ only
+    to the all-zero word, while the second contributes
+    $(1/\sqrt2)^N$ to every word.
+\end{proof}
+
+\begin{theorem}[Physical correlations are independent of distance]
+    \label{thm:cpsv16_example_34_cid}
+    \lean{MPSTensor.cpsvExample34_isPhysicalCID}
+    \leanok
+    \uses{def:cpsv16_example_34_tensor, def:source_physical_cid}
+    The tensor in Definition~\ref{def:cpsv16_example_34_tensor} satisfies
+    physical correlation independence for arbitrary disjoint physical regions,
+    including adjacent regions.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Every word matrix is diagonal. Consequently every observable-inserted
+    transfer operator and the ordinary transfer operator act entrywise on bond
+    matrices, so they commute. The two-region expectation therefore depends on
+    the two complementary gap lengths only through their sum.
+\end{proof}
+
+\begin{theorem}[Failure of the renormalization fixed-point equation]
+    \label{thm:cpsv16_example_34_not_rfp}
+    \lean{MPSTensor.cpsvExample34_not_isTransferIdempotent,
+        MPSTensor.cpsvExample34_not_hasPhysicalBlockingIsometry}
+    \leanok
+    \uses{def:cpsv16_example_34_tensor, def:mps_transfer_idempotence,
+        def:physical_blocking_isometry,
+        thm:physical_blocking_isometry_iff_transfer_idempotence}
+    The transfer map is not idempotent, and the tensor has no physical blocking
+    isometry. Thus it does not satisfy the pure-state renormalization
+    fixed-point equation.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Let $E_{01}=\ketbra0{1}$. The transfer map obeys
+    \begin{align}
+        \E_A(E_{01})&=\frac{1}{\sqrt2}E_{01},
+        &
+        \E_A^2(E_{01})&=\frac12E_{01}.
+        \notag
+    \end{align}
+    Hence $\E_A^2\ne\E_A$. The equivalence between transfer idempotence and a
+    physical blocking isometry gives the second conclusion.
+\end{proof}
+
+\begin{theorem}[Blocked product-state overlap]
+    \label{thm:cpsv16_example_34_blocked_overlap}
+    \lean{MPSTensor.cpsvExample34_blocked_overlap}
+    \leanok
+    \uses{def:cpsv16_example_34_tensor}
+    After blocking $n$ spins, the two product vectors satisfy
+    \begin{align}
+        \left\langle 0^{\otimes n}\middle|+^{\otimes n}\right\rangle
+        &=\left(\frac{1}{\sqrt2}\right)^n=2^{-n/2}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Only the all-zero configuration contributes, with amplitude
+    $(1/\sqrt2)^n$.
+\end{proof}


### PR DESCRIPTION
## What changed

- formalize the exact CPSV16 Example 3.4 tensor with $A^0=\operatorname{diag}(1,1/\sqrt2)$ and $A^1=\operatorname{diag}(0,1/\sqrt2)$
- prove its positive-length MPV is $|0\rangle^{\otimes N}+|+\rangle^{\otimes N}$
- prove the full physical CID predicate and show the transfer map is not idempotent, hence no physical blocking isometry exists
- identify the two bond-dimension-one components and prove their actual MPV overlap is $(1/\sqrt2)^n$
- add a source-specific Blueprint example while keeping CID distinct from LO, ZCL, and RFP

## Validation

- focused build: 8758 jobs
- full `lake build`: 10013 jobs
- generated imports current: 51 aggregators / 1303 modules
- Blueprint synchronization: 6946/6946 entries
- `leanblueprint checkdecls`
- two LuaLaTeX passes with zero undefined cross-references
- independent exact-head review approved `5f0d7e8ce326c3b88acaf0f3d78ed1f6189f315b`

Closes #5916

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new proofs and documentation only; no changes to existing RFP or transfer definitions beyond a new import.
> 
> **Overview**
> Adds a **Lean formalization** and **Blueprint section** for Cirac et al. (CPSV16) Example 3.4: a \(d=D=2\) diagonal MPS tensor whose MPV is \(|0\rangle^{\otimes N}+|+\rangle^{\otimes N}\).
> 
> The new module proves the **positive-length amplitude formula**, **`IsPhysicalCID`** via commuting entrywise transfer and observable-inserted maps on diagonal word matrices, and **failure of RFP**: transfer is not idempotent on an off-diagonal unit (eigenvalue \(1/\sqrt2\)), hence no physical blocking isometry. It also defines the two bond-dimension-one components and proves their **MPV overlap** is \((1/\sqrt2)^n\).
> 
> The example is wired into the RFP aggregator import and documents that physical CID does not imply LO, ZCL, or RFP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5d9175cb7124ec68b4a25af0d3ec1c45b6a43c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->