### PR TITLE
feat(MPS/MPU): expose matching blocked contractions

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -12,6 +12,7 @@ import TNLean.MPS.MPU.ActiveTransferMultiplicity
 import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.DoubleLayerContraction
+import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.ResidualAlgebra
 import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.MPU.SimpleBlocking
 
 These results supply the two contraction ingredients for the later source-u
 Gram calculation. They do not identify that Gram matrix; the finite-sum
-source-factor bridge is treated separately.
+reduction to the source factors is treated separately.
 
 These are the blocked matching and global coisometry contractions used in
 arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma `lemuisometry` (lines
@@ -27,8 +27,8 @@ namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)
 
-/-- Output-first MPU coisometry, with a common length-`K` output tail traced
-out and normalized by `d⁻ᴷ`, leaves the identity on the first two output sites.
+/-- Output-first MPU coisometry, with a common output tail of length \(K\)
+traced out and normalized by \(d^{-K}\), leaves the identity on the first two output sites.
 The retained arguments occur in reversed matrix order, as required by the
 transpose in Figure `II_uUnitary.png`.
 
@@ -67,14 +67,14 @@ theorem IsMPU.normalized_mpo_tail_coisometry [NeZero d]
   · rw [if_neg hpq, if_neg (Ne.symm hpq)]
     simp
 
-/-- The stabilized first block followed by the corrected `D²` block has the
-exact `simple1` and `simple2` witnesses obtained from the supplied fixed
-matrix and the identity left vector.
+/-- The stabilized first block followed by the corrected \(D^2\) block has the
+exact simple contractions obtained from the supplied fixed matrix and the
+identity left vector.
 
 Source: arXiv:1703.09188, equations `Erightleft`, `simple1`, and `simple2`,
 lines 397--427.
 
-**Local fix:** the second blocking uses `D²`; see
+**Local fix (nil-matrix length):** the second blocking uses \(D^2\); see
 `docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
 theorem IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -9,12 +9,12 @@ import TNLean.MPS.MPU.SimpleBlocking
 # Matching blocked contractions and output-tail coisometry
 
 These results supply the two contraction ingredients for the later source-u
-Gram calculation.  They do not identify that Gram matrix; the finite-sum
-source-factor bridge is tracked separately in issue #5835.
+Gram calculation. They do not identify that Gram matrix; the finite-sum
+source-factor bridge is treated separately.
 
 These are the blocked matching and global coisometry contractions used in
 arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma `lemuisometry` (lines
-536--554).  The output-tail proof keeps the paper's output-first coisometry
+536--556).  The output-tail proof keeps the paper's output-first coisometry
 orientation: in the present open-leg conventions the global unitary equation
 is `U Uᴴ = 1`, and the retained physical matrix is transposed relative to the
 graphical display.
@@ -33,7 +33,7 @@ The retained arguments occur in reversed matrix order, as required by the
 transpose in Figure `II_uUnitary.png`.
 
 Source: arXiv:1703.09188, equation `UisUnitary` and Figure
-`II_uUnitary.png`, lines 327--335 and 536--554. -/
+`II_uUnitary.png`, lines 327--335 and 536--556. -/
 theorem IsMPU.normalized_mpo_tail_coisometry [NeZero d]
     {U : MPOTensor d D} (hU : IsMPU U) (K : ℕ)
     (p q : Fin d × Fin d) :

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SimpleBlocking
+
+/-!
+# Matching blocked contractions and output-tail coisometry
+
+These results supply the two contraction ingredients for the later source-u
+Gram calculation.  They do not identify that Gram matrix; the finite-sum
+source-factor bridge is tracked separately in issue #5835.
+
+These are the blocked matching and global coisometry contractions used in
+arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma `lemuisometry` (lines
+536--554).  The output-tail proof keeps the paper's output-first coisometry
+orientation: in the present open-leg conventions the global unitary equation
+is `U Uᴴ = 1`, and the retained physical matrix is transposed relative to the
+graphical display.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- Output-first MPU coisometry, with a common length-`K` output tail traced
+out and normalized by `d⁻ᴷ`, leaves the identity on the first two output sites.
+The retained arguments occur in reversed matrix order, as required by the
+transpose in Figure `II_uUnitary.png`.
+
+Source: arXiv:1703.09188, equation `UisUnitary` and Figure
+`II_uUnitary.png`, lines 327--335 and 536--554. -/
+theorem IsMPU.normalized_mpo_tail_coisometry [NeZero d]
+    {U : MPOTensor d D} (hU : IsMPU U) (K : ℕ)
+    (p q : Fin d × Fin d) :
+    ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ η : Fin (K + 2) → Fin d,
+          mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) η *
+            star (mpo U (K + 2)
+              ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ)) η) =
+      if p = q then 1 else 0 := by
+  classical
+  have hco := hU.mpo_mul_conjTranspose_mpo (N := K + 2) (by omega)
+  have hentry (τ : Fin K → Fin d) :
+      (∑ η : Fin (K + 2) → Fin d,
+        mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) η *
+          star (mpo U (K + 2)
+            ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ)) η)) =
+        if q = p then 1 else 0 := by
+    have := congrArg (fun M ↦ M
+      ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ))
+      ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))) hco
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
+      (finAddTwoArrowEquiv (Fin d) K).symm.injective.eq_iff, Prod.mk.injEq,
+      and_true] using this
+  simp_rw [hentry]
+  by_cases hpq : p = q
+  · subst q
+    simp only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul,
+      Fintype.card_pi_const, Fintype.card_fin, Nat.cast_pow, if_pos]
+    have hd : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+    rw [inv_pow, ← mul_assoc, inv_mul_cancel₀ (pow_ne_zero K hd), one_mul]
+  · rw [if_neg hpq, if_neg (Ne.symm hpq)]
+    simp
+
+/-- The stabilized first block followed by the corrected `D²` block has the
+exact `simple1` and `simple2` witnesses obtained from the supplied fixed
+matrix and the identity left vector.
+
+Source: arXiv:1703.09188, equations `Erightleft`, `simple1`, and `simple2`,
+lines 397--427.
+
+**Local fix:** the second blocking uses `D²`; see
+`docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+theorem IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρtrace : Matrix.trace ρ = 1)
+    (J : ℕ) (hJ : 0 < J)
+    (hpower : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    let ρ' : Fin (D * D) → ℂ := fun i ↦ ρ.vec (finProdFinEquiv.symm i)
+    let Φ' : Fin (D * D) → ℂ := fun i ↦
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm i)
+    (∀ i j : Fin (MPSTensor.blockPhysDim d (J * (D * D))),
+      Φ' ⬝ᵥ (doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *ᵥ ρ') =
+        if i = j then 1 else 0) ∧
+    (∀ i j k l : Fin (MPSTensor.blockPhysDim d (J * (D * D))),
+      doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *
+          doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l =
+        doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *
+          Matrix.vecMulVec ρ' Φ' *
+            doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l) := by
+  classical
+  let V := MPOTensor.blockTensor U J
+  let ρ' : Fin (D * D) → ℂ := fun i ↦ ρ.vec (finProdFinEquiv.symm i)
+  let Φ' : Fin (D * D) → ℂ := fun i ↦
+    (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm i)
+  have hpair : Φ' ⬝ᵥ ρ' = 1 := by
+    change (∑ i : Fin (D * D),
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm i) *
+        ρ.vec (finProdFinEquiv.symm i)) = 1
+    calc
+      _ = (1 : Matrix (Fin D) (Fin D) ℂ).vec ⬝ᵥ ρ.vec := by
+        exact Fintype.sum_equiv finProdFinEquiv.symm _ _ (fun _ ↦ rfl)
+      _ = Matrix.trace ρ := Matrix.vec_one_dotProduct_vec_eq_trace ρ
+      _ = 1 := hρtrace
+  have hVmpu : IsMPU V := hU.blockTensor J hJ
+  have hVE : normalizedDiagonal (doubleLayerTensor V) = Matrix.vecMulVec ρ' Φ' := by
+    change normalizedDiagonal (doubleLayerTensor (MPOTensor.blockTensor U J)) = _
+    rw [normalizedDiagonal_doubleLayerTensor_blockTensor, hpower]
+    rfl
+  letI : NeZero (MPSTensor.blockPhysDim d J) := ⟨by
+    rw [MPSTensor.blockPhysDim_eq_pow]
+    exact pow_ne_zero J (NeZero.ne d)⟩
+  have hs := hVmpu.blockTensor_sq_simple_contractions_of_normalizedDiagonal_eq_vecMulVec
+    ρ' Φ' hpair hVE
+  let e := MPSTensor.directIteratedBlockEquiv d J (D * D)
+  have htensor := reindexPhysical_blockTensor_blockTensor U J (D * D)
+  constructor
+  · intro i j
+    have hij := hs.1 (e i) (e j)
+    simpa only [e, ← htensor, doubleLayerTensor_reindexPhysical,
+      (MPSTensor.directIteratedBlockEquiv d J (D * D)).injective.eq_iff] using hij
+  · intro i j k l
+    have hijkl := hs.2 (e i) (e j) (e k) (e l)
+    simpa only [e, ← htensor, doubleLayerTensor_reindexPhysical] using hijkl
+
+end MPOTensor

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -25,7 +25,7 @@ open Matrix
 
 namespace MPOTensor
 
-variable {d D : ℕ} (U : MPOTensor d D)
+variable {d D : ℕ}
 
 /-- Output-first MPU coisometry, with a common output tail of length \(K\)
 traced out and normalized by \(d^{-K}\), leaves the identity on the first two output sites.

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -14,10 +14,10 @@ reduction to the source factors is treated separately.
 
 These are the blocked matching and global coisometry contractions used in
 arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma `lemuisometry` (lines
-536--556).  The output-tail proof keeps the paper's output-first coisometry
-orientation: in the present open-leg conventions the global unitary equation
-is `U Uᴴ = 1`, and the retained physical matrix is transposed relative to the
-graphical display.
+536--556). In the present open-leg conventions, the output-tail proof keeps the
+first two sites and traces the remaining tail using the global unitary equation
+`U Uᴴ = 1`; the figure instead traces the first tail and keeps the final two
+sites in the `Uᴴ U = 1` orientation.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -29,8 +29,8 @@ variable {d D : ℕ} (U : MPOTensor d D)
 
 /-- Output-first MPU coisometry, with a common output tail of length \(K\)
 traced out and normalized by \(d^{-K}\), leaves the identity on the first two output sites.
-The retained arguments occur in reversed matrix order, as required by the
-transpose in Figure `II_uUnitary.png`.
+The retained arguments occur in reversed matrix order because this convention
+keeps the first two sites and uses the output-first equation `U Uᴴ = 1`.
 
 Source: arXiv:1703.09188, equation `UisUnitary` and Figure
 `II_uUnitary.png`, lines 327--335 and 536--556. -/

--- a/TNLean/MPS/MPU/SimpleBlocking.lean
+++ b/TNLean/MPS/MPU/SimpleBlocking.lean
@@ -719,11 +719,9 @@ def reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d)
     (U : MPOTensor d D) : MPOTensor d' D :=
   fun i j ↦ U (e i) (e j)
 
-/-- Simultaneous physical reindexing commutes entrywise with formation of the
-double layer.
-
-Source: arXiv:1703.09188, Proposition III.3, lines 405--426, where iterated
-and direct physical blocking are identified by the canonical grouping map. -/
+/-- Simultaneous reindexing of both physical coordinates commutes entrywise with
+formation of the double layer. This is the local coordinate identity used to compare
+iterated and direct physical blockings. -/
 theorem doubleLayerTensor_reindexPhysical {d' : ℕ}
     (e : Fin d' ≃ Fin d) (U : MPOTensor d D) (i j : Fin d') :
     doubleLayerTensor (reindexPhysical e U) i j = doubleLayerTensor U (e i) (e j) := by

--- a/TNLean/MPS/MPU/SimpleBlocking.lean
+++ b/TNLean/MPS/MPU/SimpleBlocking.lean
@@ -719,7 +719,12 @@ def reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d)
     (U : MPOTensor d D) : MPOTensor d' D :=
   fun i j ↦ U (e i) (e j)
 
-private theorem doubleLayerTensor_reindexPhysical {d' : ℕ}
+/-- Simultaneous physical reindexing commutes entrywise with formation of the
+double layer.
+
+Source: arXiv:1703.09188, Proposition III.3, lines 405--426, where iterated
+and direct physical blocking are identified by the canonical grouping map. -/
+theorem doubleLayerTensor_reindexPhysical {d' : ℕ}
     (e : Fin d' ≃ Fin d) (U : MPOTensor d D) (i j : Fin d') :
     doubleLayerTensor (reindexPhysical e U) i j = doubleLayerTensor U (e i) (e j) := by
   classical

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -672,6 +672,22 @@ closing a chain of $N$ copies of $\mathcal U$.
     \end{align}
 \end{definition}
 
+\begin{lemma}[Double layer under physical reindexing]
+    \label{lem:mpu_double_layer_physical_reindexing}
+    \lean{MPOTensor.doubleLayerTensor_reindexPhysical}
+    \leanok
+    \uses{def:mpu_physical_reindexing}
+    For every physical-index bijection $e$, taking the double layer commutes
+    with physical reindexing:
+    \begin{align}
+        W(e^*\mathcal U)^{ij}&=W(\mathcal U)^{e(i)e(j)}.
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    This follows entrywise from the definition of physical reindexing.
+\end{proof}
+
 \begin{theorem}[Bounded blocking to simplicity]
     \label{thm:mpu_bounded_simple_blocking}
     \lean{MPOTensor.IsMPU.exists_blockTensor_isMPUSimple_of_one_lt,
@@ -722,8 +738,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 
 \begin{theorem}[Matching contractions at the direct stabilized block]
     \label{thm:mpu_matching_direct_block_contractions}
-    \lean{MPOTensor.IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power,
-        MPOTensor.doubleLayerTensor_reindexPhysical}
+    \lean{MPOTensor.IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power}
     \leanok
     Let $\mathcal U$ be an MPU of positive physical and bond dimensions.
     Suppose that $\rho$ has trace one and that, for some positive integer $J$,
@@ -740,7 +755,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \begin{proof}\leanok
     \uses{thm:mpu_blocked_double_layer_diagonal,
         thm:mpu_second_block_simple, thm:mpu_bounded_simple_blocking,
-        lem:mpu_blocking}
+        lem:mpu_blocking, lem:mpu_double_layer_physical_reindexing}
     First block $J$ sites.  The normalized diagonal of this block is the
     reindexed rank-one matrix $|\rho)(\Id|$, and the trace-one condition is
     exactly $(\Id|\rho)=1$.  The exact second-block contraction theorem then
@@ -754,8 +769,9 @@ closing a chain of $N$ copies of $\mathcal U$.
     \label{thm:mpu_normalized_output_tail_coisometry}
     \lean{MPOTensor.IsMPU.normalized_mpo_tail_coisometry}
     \leanok
-    Let $K\geq0$, let $p,q\in\Fin d\times\Fin d$, and separate the first two
-    output sites from a tail $\tau\in\Fin K\to\Fin d$.  Then
+    Let $d>0$, let $\mathcal U$ be an MPU, and let $K\geq0$. For
+    $p,q\in\Fin d\times\Fin d$, separate the first two output sites from a
+    tail $\tau\in\Fin K\to\Fin d$. Then
     \begin{align}
         d^{-K}\sum_{\tau}\sum_{\eta}
         U^{(K+2)}_{(q,\tau),\eta}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -682,7 +682,7 @@ closing a chain of $N$ copies of $\mathcal U$.
     \begin{align}
         W(e^*\mathcal U)^{ij}&=W(\mathcal U)^{e(i)e(j)}.
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpu_physical_reindexing,def:mpu_double_layer}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -726,14 +726,15 @@ closing a chain of $N$ copies of $\mathcal U$.
         MPOTensor.doubleLayerTensor_reindexPhysical}
     \leanok
     \uses{thm:mpu_blocked_double_layer_diagonal,
-        thm:mpu_second_block_simple,thm:mpu_bounded_simple_blocking}
+        thm:mpu_second_block_simple, thm:mpu_bounded_simple_blocking}
+    Let $\mathcal U$ be an MPU of positive physical and bond dimensions.
     Suppose that $\rho$ has trace one and that the normalized transfer matrix
     satisfies
     \begin{align}
         E^J&=|\rho)(\Id|,
         &J&>0.
     \end{align}
-    Put $K=JD^2$.  After the standard product reindexing of the virtual
+    Put $K=JD^2$. After the standard product reindexing of the physical
     coordinates, the direct length-$K$ block satisfies \texttt{simple1} and
     \texttt{simple2} with the specific witnesses $\rho$ and $\Id$ from this
     transfer-power identity.
@@ -778,7 +779,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{proof}
 
 % Formalization scope: identifying this normalized scalar with
-% $(\texttt{sourceU})^\dagger\texttt{sourceU}$ remains issue \#5835.
+% $(\texttt{sourceU})^\dagger\texttt{sourceU}$ is treated separately.
 
 
 \begin{theorem}[Simplicity at every later direct blocking]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -672,11 +672,11 @@ closing a chain of $N$ copies of $\mathcal U$.
     \end{align}
 \end{definition}
 
-\begin{lemma}[Double layer under physical reindexing]
-    \label{lem:mpu_double_layer_physical_reindexing}
+\begin{theorem}[Double layer under physical reindexing]
+    \label{thm:mpu_double_layer_physical_reindexing}
     \lean{MPOTensor.doubleLayerTensor_reindexPhysical}
     \leanok
-    \uses{def:mpu_physical_reindexing}
+    \uses{def:mpu_physical_reindexing,def:mpu_double_layer}
     For every physical-index bijection $e$, taking the double layer commutes
     with physical reindexing:
     \begin{align}
@@ -685,7 +685,9 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{lemma}
 
 \begin{proof}\leanok
-    This follows entrywise from the definition of physical reindexing.
+    \uses{def:mpu_physical_reindexing,def:mpu_double_layer}
+    This follows entrywise from the definitions of physical reindexing and the
+    double layer.
 \end{proof}
 
 \begin{theorem}[Bounded blocking to simplicity]
@@ -755,7 +757,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \begin{proof}\leanok
     \uses{thm:mpu_blocked_double_layer_diagonal,
         thm:mpu_second_block_simple, thm:mpu_bounded_simple_blocking,
-        lem:mpu_blocking, lem:mpu_double_layer_physical_reindexing}
+        lem:mpu_blocking, thm:mpu_double_layer_physical_reindexing}
     First block $J$ sites.  The normalized diagonal of this block is the
     reindexed rank-one matrix $|\rho)(\Id|$, and the trace-one condition is
     exactly $(\Id|\rho)=1$.  The exact second-block contraction theorem then

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -720,6 +720,67 @@ closing a chain of $N$ copies of $\mathcal U$.
     The second identity multiplies the sitewise Kronecker deltas.
 \end{proof}
 
+\begin{theorem}[Matching contractions at the direct stabilized block]
+    \label{thm:mpu_matching_direct_block_contractions}
+    \lean{MPOTensor.IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power,
+        MPOTensor.doubleLayerTensor_reindexPhysical}
+    \leanok
+    \uses{thm:mpu_blocked_double_layer_diagonal,
+        thm:mpu_second_block_simple,thm:mpu_bounded_simple_blocking}
+    Suppose that $\rho$ has trace one and that the normalized transfer matrix
+    satisfies
+    \begin{align}
+        E^J&=|\rho)(\Id|,
+        &J&>0.
+    \end{align}
+    Put $K=JD^2$.  After the standard product reindexing of the virtual
+    coordinates, the direct length-$K$ block satisfies \texttt{simple1} and
+    \texttt{simple2} with the specific witnesses $\rho$ and $\Id$ from this
+    transfer-power identity.
+\end{theorem}
+
+\begin{proof}\leanok
+    First block $J$ sites.  The normalized diagonal of this block is the
+    reindexed rank-one matrix $|\rho)(\Id|$, and the trace-one condition is
+    exactly $(\Id|\rho)=1$.  The exact second-block contraction theorem then
+    supplies both identities after a further $D^2$ sites.  The canonical
+    equivalence between iterated blocking and direct length-$JD^2$ blocking
+    transports each double-layer coefficient without changing either virtual
+    witness.
+\end{proof}
+
+\begin{theorem}[Normalized output-tail coisometry]
+    \label{thm:mpu_normalized_output_tail_coisometry}
+    \lean{MPOTensor.IsMPU.normalized_mpo_tail_coisometry}
+    \leanok
+    \uses{lem:mpu_mul_adjoint}
+    Let $K\geq0$, let $p,q\in\Fin d\times\Fin d$, and separate the first two
+    output sites from a tail $\tau\in\Fin K\to\Fin d$.  Then
+    \begin{align}
+        d^{-K}\sum_{\tau}\sum_{\eta}
+        U^{(K+2)}_{(q,\tau),\eta}
+        \overline{U^{(K+2)}_{(p,\tau),\eta}}
+        &=\delta_{p,q}.
+    \end{align}
+    The retained matrix entry has the reversed order $(q,p)$, and the global
+    contraction is the output-first equation
+    $U^{(K+2)}(U^{(K+2)})^\dagger=\Id$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply output-first unitarity before performing any source-factor
+    rearrangement.  For each fixed tail, the inner sum is the corresponding
+    identity-matrix entry, hence it is $\delta_{p,q}$.  There are exactly
+    \begin{align}
+        |\Fin K\to\Fin d|=d^K
+    \end{align}
+    tails, and $d^{-K}d^K=1$ because $d>0$.
+\end{proof}
+
+% Formalization scope: identifying this normalized scalar with
+% $(\texttt{sourceU})^\dagger\texttt{sourceU}$ remains issue \#5835.
+
+
 \begin{theorem}[Simplicity at every later direct blocking]
     \label{thm:mpu_all_later_simple_blockings}
     \lean{MPOTensor.IsMPU.isMPUSimple_of_simple2,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -725,22 +725,22 @@ closing a chain of $N$ copies of $\mathcal U$.
     \lean{MPOTensor.IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power,
         MPOTensor.doubleLayerTensor_reindexPhysical}
     \leanok
-    \uses{thm:mpu_blocked_double_layer_diagonal,
-        thm:mpu_second_block_simple, thm:mpu_bounded_simple_blocking}
     Let $\mathcal U$ be an MPU of positive physical and bond dimensions.
-    Suppose that $\rho$ has trace one and that the normalized transfer matrix
-    satisfies
+    Suppose that $\rho$ has trace one and that, for some positive integer $J$,
+    the normalized transfer matrix satisfies
     \begin{align}
-        E^J&=|\rho)(\Id|,
-        &J&>0.
+        E^J&=|\rho)(\Id|.
     \end{align}
     Put $K=JD^2$. After the standard product reindexing of the physical
-    coordinates, the direct length-$K$ block satisfies \texttt{simple1} and
-    \texttt{simple2} with the specific witnesses $\rho$ and $\Id$ from this
-    transfer-power identity.
+    coordinates, the direct length-$K$ block satisfies the contractions
+    \ref{eq:mpu_simple1} and \ref{eq:mpu_simple2} with the specific witnesses
+    $\rho$ and $\Id$ from this transfer-power identity.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_blocked_double_layer_diagonal,
+        thm:mpu_second_block_simple, thm:mpu_bounded_simple_blocking,
+        lem:mpu_blocking}
     First block $J$ sites.  The normalized diagonal of this block is the
     reindexed rank-one matrix $|\rho)(\Id|$, and the trace-one condition is
     exactly $(\Id|\rho)=1$.  The exact second-block contraction theorem then
@@ -754,7 +754,6 @@ closing a chain of $N$ copies of $\mathcal U$.
     \label{thm:mpu_normalized_output_tail_coisometry}
     \lean{MPOTensor.IsMPU.normalized_mpo_tail_coisometry}
     \leanok
-    \uses{lem:mpu_mul_adjoint}
     Let $K\geq0$, let $p,q\in\Fin d\times\Fin d$, and separate the first two
     output sites from a tail $\tau\in\Fin K\to\Fin d$.  Then
     \begin{align}
@@ -769,6 +768,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:mpu_mul_adjoint}
     Apply output-first unitarity before performing any source-factor
     rearrangement.  For each fixed tail, the inner sum is the corresponding
     identity-matrix entry, hence it is $\delta_{p,q}$.  There are exactly

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -733,7 +733,7 @@ closing a chain of $N$ copies of $\mathcal U$.
     \end{align}
     Put $K=JD^2$. After the standard product reindexing of the physical
     coordinates, the direct length-$K$ block satisfies the contractions
-    \ref{eq:mpu_simple1} and \ref{eq:mpu_simple2} with the specific witnesses
+    (\ref{eq:mpu_simple1}) and (\ref{eq:mpu_simple2}) with the specific witnesses
     $\rho$ and $\Id$ from this transfer-power identity.
 \end{theorem}
 


### PR DESCRIPTION
## Summary

- expose the supplied-witness `simple1` and `simple2` contractions used by bounded MPU blocking
- transport those contractions to the direct block of length `J * D^2`, including the physical reindex bridge
- prove the normalized output-side open-tail coisometry with retained `(q,p)` order and exact normalization
- synchronize Chapter 28 with the source proof and the corrected `J′ = D²` local bound

This is algebraic support for the later source-`u` Gram bridge. It does **not** identify that tail with `sourceUᴴ * sourceU`, assert source-`u` isometry, or use the false identity `X₂ * X₂ᴴ = 1`.

## Verification

- direct Lean checks for `SimpleBlocking.lean` and `MatchingContractions.lean`
- targeted builds of `TNLean.MPS.MPU.MatchingContractions` and `TNLean.MPS.MPU`
- generated-import consistency
- proof-integrity and reader-facing prose scans
- blueprint synchronization and reverse declaration coverage (Chapter 28: 186/186)
- independent Mathlib-quality/source-faithfulness review

Closes #5839

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of MPU blocking algebra with no runtime, auth, or data-path changes; risk is limited to proof maintenance and blueprint/Lean linkage correctness.
> 
> **Overview**
> Adds **algebraic lemmas** for the later source-`u` Gram bridge: a normalized output-tail coisometry and **simple1/simple2** contractions on the direct block of length `J * D²` when the transfer matrix satisfies `E^J = |ρ)(Id|`.
> 
> **`MatchingContractions.lean`** proves `IsMPU.normalized_mpo_tail_coisometry` (output-first `U Uᴴ = 1`, `d^{-K}` normalization, retained `(q,p)` order) and `IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power`, which pulls the existing `D²` second-block argument from `SimpleBlocking` and **reindexes** to `J * D²` via `directIteratedBlockEquiv` and `reindexPhysical_blockTensor_blockTensor`.
> 
> **`SimpleBlocking.lean`** promotes `doubleLayerTensor_reindexPhysical` from private to a public theorem so the transport step can cite it.
> 
> Aggregator import and **Chapter 28** blueprint entries (`thm:mpu_double_layer_physical_reindexing`, matching direct-block contractions, normalized output-tail coisometry) are aligned with the Lean proofs. This does **not** identify the source-`u` Gram matrix or assert source-`u` isometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a7d880d86b34fa350c883a3cf31ba95e68b1eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->