### PR TITLE
feat(Analysis): bound inverses around an invertible base

### DIFF
--- a/TNLean/Analysis/NeumannInverse.lean
+++ b/TNLean/Analysis/NeumannInverse.lean
@@ -8,7 +8,9 @@ import Mathlib.Analysis.Normed.Ring.Units
 /-!
 # A quantitative Neumann inverse bound
 
-This file records the denominator estimate used for inverse Gram operators.
+This file records quantitative Neumann bounds, both around the identity and around an
+arbitrary invertible base point.  The latter estimates control the inverse and its displacement
+under a relatively small perturbation.
 -/
 
 namespace NormedRing
@@ -27,5 +29,109 @@ theorem norm_inverse_one_sub_le (t : R) {a : ℝ} (ht : ‖t‖ ≤ a) (ha : a <
       simpa using tsum_geometric_le_of_norm_lt_one t ht_one
     _ ≤ (1 - a)⁻¹ := by
       exact (inv_le_inv₀ (sub_pos.mpr ht_one) (sub_pos.mpr ha)).2 (by linarith)
+
+/-- If `K₀` is a unit and its relative perturbation toward `K` has norm at most `a < 1`,
+then `K` is a unit and its inverse is bounded by
+`(1 - a)⁻¹ * ‖Ring.inverse K₀‖`. -/
+theorem isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a : ℝ}
+    (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
+    IsUnit K ∧ ‖Ring.inverse K‖ ≤ (1 - a)⁻¹ * ‖Ring.inverse K₀‖ := by
+  let E := Ring.inverse K₀ * (K - K₀)
+  have hE : ‖E‖ ≤ a := h
+  have hE_lt_one : ‖E‖ < 1 := hE.trans_lt ha
+  have hbase : IsUnit (1 - -E) :=
+    isUnit_one_sub_of_norm_lt_one (by simpa using hE_lt_one)
+  have hfactor : K = K₀ * (1 - -E) := by
+    dsimp [E]
+    rw [sub_neg_eq_add, mul_add, mul_one, ← mul_assoc,
+      Ring.mul_inverse_cancel K₀ hK₀, one_mul]
+    abel
+  have hinverse : Ring.inverse K = Ring.inverse (1 - -E) * Ring.inverse K₀ := by
+    rw [hfactor, Ring.inverse_mul (Or.inl hK₀)]
+  constructor
+  · rw [hfactor]
+    exact hK₀.mul hbase
+  · rw [hinverse]
+    calc
+      ‖Ring.inverse (1 - -E) * Ring.inverse K₀‖ ≤
+          ‖Ring.inverse (1 - -E)‖ * ‖Ring.inverse K₀‖ := norm_mul_le _ _
+      _ ≤ (1 - a)⁻¹ * ‖Ring.inverse K₀‖ := by
+        gcongr
+        exact norm_inverse_one_sub_le (-E) (by simpa using hE) ha
+
+/-- A product-form version of
+`isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le`.  This is convenient when the
+relative perturbation is estimated by submultiplicativity of the norm. -/
+theorem isUnit_and_norm_inverse_le_of_norm_mul_norm_sub_le (K₀ K : R) {a : ℝ}
+    (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀‖ * ‖K - K₀‖ ≤ a) (ha : a < 1) :
+    IsUnit K ∧ ‖Ring.inverse K‖ ≤ (1 - a)⁻¹ * ‖Ring.inverse K₀‖ := by
+  apply isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le K₀ K hK₀ _ ha
+  exact (norm_mul_le _ _).trans h
+
+/-- Under a relative perturbation of size at most `a < 1`, the displacement of the inverse
+from the base inverse is at most `(1 - a)⁻¹ * a * ‖Ring.inverse K₀‖`. -/
+theorem norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a : ℝ}
+    (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
+    ‖Ring.inverse K - Ring.inverse K₀‖ ≤
+      (1 - a)⁻¹ * a * ‖Ring.inverse K₀‖ := by
+  let E := Ring.inverse K₀ * (K - K₀)
+  have hE : ‖E‖ ≤ a := h
+  have hE_lt_one : ‖E‖ < 1 := hE.trans_lt ha
+  have hbase : IsUnit (1 - -E) :=
+    isUnit_one_sub_of_norm_lt_one (by simpa using hE_lt_one)
+  have hfactor : K = K₀ * (1 - -E) := by
+    dsimp [E]
+    rw [sub_neg_eq_add, mul_add, mul_one, ← mul_assoc,
+      Ring.mul_inverse_cancel K₀ hK₀, one_mul]
+    abel
+  have hinverse : Ring.inverse K = Ring.inverse (1 - -E) * Ring.inverse K₀ := by
+    rw [hfactor, Ring.inverse_mul (Or.inl hK₀)]
+  have hresolvent :
+      Ring.inverse K - Ring.inverse K₀ =
+        -(Ring.inverse (1 - -E) * E) * Ring.inverse K₀ := by
+    have hcancel :
+        Ring.inverse (1 - -E) + Ring.inverse (1 - -E) * E = 1 := by
+      calc
+        Ring.inverse (1 - -E) + Ring.inverse (1 - -E) * E =
+            Ring.inverse (1 - -E) * (1 - -E) := by
+          simp only [sub_neg_eq_add, mul_add, mul_one]
+        _ = 1 := Ring.inverse_mul_cancel (1 - -E) hbase
+    have hdifference :
+        Ring.inverse (1 - -E) - 1 = -(Ring.inverse (1 - -E) * E) := by
+      calc
+        Ring.inverse (1 - -E) - 1 =
+            Ring.inverse (1 - -E) -
+              (Ring.inverse (1 - -E) + Ring.inverse (1 - -E) * E) :=
+          congrArg (Ring.inverse (1 - -E) - ·) hcancel.symm
+        _ = -(Ring.inverse (1 - -E) * E) := by noncomm_ring
+    rw [hinverse]
+    calc
+      Ring.inverse (1 - -E) * Ring.inverse K₀ - Ring.inverse K₀ =
+          (Ring.inverse (1 - -E) - 1) * Ring.inverse K₀ := by noncomm_ring
+      _ = -(Ring.inverse (1 - -E) * E) * Ring.inverse K₀ := by rw [hdifference]
+  rw [hresolvent]
+  have hneumann : ‖Ring.inverse (1 - -E)‖ ≤ (1 - a)⁻¹ :=
+    norm_inverse_one_sub_le (-E) (by simpa using hE) ha
+  have ha_nonneg : 0 ≤ a := (norm_nonneg E).trans hE
+  have hdenom_nonneg : 0 ≤ (1 - a)⁻¹ :=
+    inv_nonneg.mpr (sub_nonneg.mpr ha.le)
+  calc
+    ‖-(Ring.inverse (1 - -E) * E) * Ring.inverse K₀‖ ≤
+        ‖-(Ring.inverse (1 - -E) * E)‖ * ‖Ring.inverse K₀‖ := norm_mul_le _ _
+    _ ≤ (‖Ring.inverse (1 - -E)‖ * ‖E‖) * ‖Ring.inverse K₀‖ := by
+      gcongr
+      simpa only [norm_neg] using norm_mul_le (Ring.inverse (1 - -E)) E
+    _ ≤ ((1 - a)⁻¹ * a) * ‖Ring.inverse K₀‖ := by
+      gcongr
+    _ = (1 - a)⁻¹ * a * ‖Ring.inverse K₀‖ := rfl
+
+/-- A product-form inverse-displacement estimate, obtained from
+`‖Ring.inverse K₀ * (K - K₀)‖ ≤ ‖Ring.inverse K₀‖ * ‖K - K₀‖`. -/
+theorem norm_inverse_sub_inverse_le_of_norm_mul_norm_sub_le (K₀ K : R) {a : ℝ}
+    (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀‖ * ‖K - K₀‖ ≤ a) (ha : a < 1) :
+    ‖Ring.inverse K - Ring.inverse K₀‖ ≤
+      (1 - a)⁻¹ * a * ‖Ring.inverse K₀‖ := by
+  apply norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le K₀ K hK₀ _ ha
+  exact (norm_mul_le _ _).trans h
 
 end NormedRing

--- a/TNLean/Analysis/NeumannInverse.lean
+++ b/TNLean/Analysis/NeumannInverse.lean
@@ -30,9 +30,9 @@ theorem norm_inverse_one_sub_le (t : R) {a : ℝ} (ht : ‖t‖ ≤ a) (ha : a <
     _ ≤ (1 - a)⁻¹ := by
       exact (inv_le_inv₀ (sub_pos.mpr ht_one) (sub_pos.mpr ha)).2 (by linarith)
 
-/-- If `K₀` is a unit and its relative perturbation toward `K` has norm at most `a < 1`,
-then `K` is a unit and its inverse is bounded by
-`(1 - a)⁻¹ * ‖Ring.inverse K₀‖`. -/
+/-- If \(K_0\) is a unit and its relative perturbation toward \(K\) has norm at most
+\(a<1\), then \(K\) is a unit and its inverse norm is at most
+\((1-a)^{-1}\lVert K_0^{-1}\rVert\). -/
 theorem isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a : ℝ}
     (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
     IsUnit K ∧ ‖Ring.inverse K‖ ≤ (1 - a)⁻¹ * ‖Ring.inverse K₀‖ := by
@@ -68,8 +68,8 @@ theorem isUnit_and_norm_inverse_le_of_norm_mul_norm_sub_le (K₀ K : R) {a : ℝ
   apply isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le K₀ K hK₀ _ ha
   exact (norm_mul_le _ _).trans h
 
-/-- Under a relative perturbation of size at most `a < 1`, the displacement of the inverse
-from the base inverse is at most `(1 - a)⁻¹ * a * ‖Ring.inverse K₀‖`. -/
+/-- Under a relative perturbation of size at most \(a<1\), the displacement of the inverse
+from the base inverse is at most \((1-a)^{-1}a\lVert K_0^{-1}\rVert\). -/
 theorem norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a : ℝ}
     (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
     ‖Ring.inverse K - Ring.inverse K₀‖ ≤
@@ -112,9 +112,6 @@ theorem norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a :
   rw [hresolvent]
   have hneumann : ‖Ring.inverse (1 - -E)‖ ≤ (1 - a)⁻¹ :=
     norm_inverse_one_sub_le (-E) (by simpa using hE) ha
-  have ha_nonneg : 0 ≤ a := (norm_nonneg E).trans hE
-  have hdenom_nonneg : 0 ≤ (1 - a)⁻¹ :=
-    inv_nonneg.mpr (sub_nonneg.mpr ha.le)
   calc
     ‖-(Ring.inverse (1 - -E) * E) * Ring.inverse K₀‖ ≤
         ‖-(Ring.inverse (1 - -E) * E)‖ * ‖Ring.inverse K₀‖ := norm_mul_le _ _
@@ -126,7 +123,8 @@ theorem norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a :
     _ = (1 - a)⁻¹ * a * ‖Ring.inverse K₀‖ := rfl
 
 /-- A product-form inverse-displacement estimate, obtained from
-`‖Ring.inverse K₀ * (K - K₀)‖ ≤ ‖Ring.inverse K₀‖ * ‖K - K₀‖`. -/
+\(\lVert K_0^{-1}(K-K_0)\rVert\le
+\lVert K_0^{-1}\rVert\,\lVert K-K_0\rVert\). -/
 theorem norm_inverse_sub_inverse_le_of_norm_mul_norm_sub_le (K₀ K : R) {a : ℝ}
     (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀‖ * ‖K - K₀‖ ≤ a) (ha : a < 1) :
     ‖Ring.inverse K - Ring.inverse K₀‖ ≤

--- a/TNLean/Analysis/NeumannInverse.lean
+++ b/TNLean/Analysis/NeumannInverse.lean
@@ -30,15 +30,17 @@ theorem norm_inverse_one_sub_le (t : R) {a : ℝ} (ht : ‖t‖ ≤ a) (ha : a <
     _ ≤ (1 - a)⁻¹ := by
       exact (inv_le_inv₀ (sub_pos.mpr ht_one) (sub_pos.mpr ha)).2 (by linarith)
 
-/-- If \(K_0\) is a unit and its relative perturbation toward \(K\) has norm at most
-\(a<1\), then \(K\) is a unit and its inverse norm is at most
-\((1-a)^{-1}\lVert K_0^{-1}\rVert\). -/
-theorem isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a : ℝ}
-    (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
-    IsUnit K ∧ ‖Ring.inverse K‖ ≤ (1 - a)⁻¹ * ‖Ring.inverse K₀‖ := by
+/-- For an invertible \(K_0\) and a perturbation \(K\) with
+\(\lVert K_0^{-1}(K-K_0)\rVert\le a<1\), \(K\) is invertible and its inverse factors
+through the perturbation \(E:=K_0^{-1}(K-K_0)\).  Returns \(E\) and its norm bounds,
+that \(1+E\) is a unit, and the factorization \(K^{-1}=(1+E)^{-1}K_0^{-1}\). -/
+private lemma perturbation_setup (K₀ K : R) (hK₀ : IsUnit K₀)
+    (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
+    IsUnit K ∧
+    (∃ E : R, ‖E‖ ≤ a ∧ ‖E‖ < 1 ∧ IsUnit (1 - -E) ∧
+      Ring.inverse K = Ring.inverse (1 - -E) * Ring.inverse K₀) := by
   let E := Ring.inverse K₀ * (K - K₀)
-  have hE : ‖E‖ ≤ a := h
-  have hE_lt_one : ‖E‖ < 1 := hE.trans_lt ha
+  have hE_lt_one : ‖E‖ < 1 := h.trans_lt ha
   have hbase : IsUnit (1 - -E) :=
     isUnit_one_sub_of_norm_lt_one (by simpa using hE_lt_one)
   have hfactor : K = K₀ * (1 - -E) := by
@@ -48,9 +50,21 @@ theorem isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a : 
     abel
   have hinverse : Ring.inverse K = Ring.inverse (1 - -E) * Ring.inverse K₀ := by
     rw [hfactor, Ring.inverse_mul (Or.inl hK₀)]
-  constructor
-  · rw [hfactor]
+  have hK_unit : IsUnit K := by
+    rw [hfactor]
     exact hK₀.mul hbase
+  refine ⟨hK_unit, E, h, hE_lt_one, hbase, hinverse⟩
+
+/-- If \(K_0\) is a unit and its relative perturbation toward \(K\) has norm at most
+\(a<1\), then \(K\) is a unit and its inverse norm is at most
+\((1-a)^{-1}\lVert K_0^{-1}\rVert\). -/
+theorem isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a : ℝ}
+    (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
+    IsUnit K ∧ ‖Ring.inverse K‖ ≤ (1 - a)⁻¹ * ‖Ring.inverse K₀‖ := by
+  obtain ⟨hK_unit, E, hE, hE_lt_one, hbase, hinverse⟩ :=
+    perturbation_setup K₀ K hK₀ h ha
+  constructor
+  · exact hK_unit
   · rw [hinverse]
     calc
       ‖Ring.inverse (1 - -E) * Ring.inverse K₀‖ ≤
@@ -74,18 +88,8 @@ theorem norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a :
     (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
     ‖Ring.inverse K - Ring.inverse K₀‖ ≤
       (1 - a)⁻¹ * a * ‖Ring.inverse K₀‖ := by
-  let E := Ring.inverse K₀ * (K - K₀)
-  have hE : ‖E‖ ≤ a := h
-  have hE_lt_one : ‖E‖ < 1 := hE.trans_lt ha
-  have hbase : IsUnit (1 - -E) :=
-    isUnit_one_sub_of_norm_lt_one (by simpa using hE_lt_one)
-  have hfactor : K = K₀ * (1 - -E) := by
-    dsimp [E]
-    rw [sub_neg_eq_add, mul_add, mul_one, ← mul_assoc,
-      Ring.mul_inverse_cancel K₀ hK₀, one_mul]
-    abel
-  have hinverse : Ring.inverse K = Ring.inverse (1 - -E) * Ring.inverse K₀ := by
-    rw [hfactor, Ring.inverse_mul (Or.inl hK₀)]
+  obtain ⟨hK_unit, E, hE, hE_lt_one, hbase, hinverse⟩ :=
+    perturbation_setup K₀ K hK₀ h ha
   have hresolvent :
       Ring.inverse K - Ring.inverse K₀ =
         -(Ring.inverse (1 - -E) * E) * Ring.inverse K₀ := by

--- a/TNLean/Analysis/NeumannInverse.lean
+++ b/TNLean/Analysis/NeumannInverse.lean
@@ -65,7 +65,7 @@ end perturbationSetup
 theorem isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a : ℝ}
     (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
     IsUnit K ∧ ‖Ring.inverse K‖ ≤ (1 - a)⁻¹ * ‖Ring.inverse K₀‖ := by
-  obtain ⟨hK_unit, E, hE, hE_lt_one, hbase, hinverse⟩ :=
+  obtain ⟨hK_unit, E, hE, _, _, hinverse⟩ :=
     perturbation_setup K₀ K hK₀ h ha
   constructor
   · exact hK_unit
@@ -92,7 +92,7 @@ theorem norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a :
     (hK₀ : IsUnit K₀) (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
     ‖Ring.inverse K - Ring.inverse K₀‖ ≤
       (1 - a)⁻¹ * a * ‖Ring.inverse K₀‖ := by
-  obtain ⟨hK_unit, E, hE, hE_lt_one, hbase, hinverse⟩ :=
+  obtain ⟨_, E, hE, _, hbase, hinverse⟩ :=
     perturbation_setup K₀ K hK₀ h ha
   have hresolvent :
       Ring.inverse K - Ring.inverse K₀ =

--- a/TNLean/Analysis/NeumannInverse.lean
+++ b/TNLean/Analysis/NeumannInverse.lean
@@ -30,11 +30,14 @@ theorem norm_inverse_one_sub_le (t : R) {a : ℝ} (ht : ‖t‖ ≤ a) (ha : a <
     _ ≤ (1 - a)⁻¹ := by
       exact (inv_le_inv₀ (sub_pos.mpr ht_one) (sub_pos.mpr ha)).2 (by linarith)
 
+section perturbationSetup
+variable {R : Type*} [NormedRing R] [HasSummableGeomSeries R]
+
 /-- For an invertible \(K_0\) and a perturbation \(K\) with
 \(\lVert K_0^{-1}(K-K_0)\rVert\le a<1\), \(K\) is invertible and its inverse factors
 through the perturbation \(E:=K_0^{-1}(K-K_0)\).  Returns \(E\) and its norm bounds,
 that \(1+E\) is a unit, and the factorization \(K^{-1}=(1+E)^{-1}K_0^{-1}\). -/
-private lemma perturbation_setup (K₀ K : R) (hK₀ : IsUnit K₀)
+private lemma perturbation_setup [NormOneClass R] {a : ℝ} (K₀ K : R) (hK₀ : IsUnit K₀)
     (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
     IsUnit K ∧
     (∃ E : R, ‖E‖ ≤ a ∧ ‖E‖ < 1 ∧ IsUnit (1 - -E) ∧
@@ -54,6 +57,7 @@ private lemma perturbation_setup (K₀ K : R) (hK₀ : IsUnit K₀)
     rw [hfactor]
     exact hK₀.mul hbase
   refine ⟨hK_unit, E, h, hE_lt_one, hbase, hinverse⟩
+end perturbationSetup
 
 /-- If \(K_0\) is a unit and its relative perturbation toward \(K\) has norm at most
 \(a<1\), then \(K\) is a unit and its inverse norm is at most


### PR DESCRIPTION
## Summary

- factors an arbitrary perturbation as
  $$K=K_0\bigl(1+K_0^{-1}(K-K_0)\bigr);$$
- derives invertibility and an explicit inverse-norm bound from
  $\|K_0^{-1}(K-K_0)\|\le a<1$;
- proves quantitative inverse-difference bounds and easier product-form corollaries using
  $\|K_0^{-1}\|\,\|K-K_0\|\le a$.

## Scope

This is generic normed-ring infrastructure for #5922. It enables perturbation around the nonidentity limiting physical Gram and does not introduce MPS-specific assumptions, an identity Gram limit, or any FNW projector-contraction claim.

## Verification

- direct Lean compilation of `TNLean/Analysis/NeumannInverse.lean`
- `lake build TNLean.Analysis.NeumannInverse`
- proof-integrity, line-length, and `git diff --check`

Refs #5922, #5752, #5759

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style analysis lemmas in a single file with no runtime or security surface; existing consumers like `InjectiveRangeProjector` still use only `norm_inverse_one_sub_le`.
> 
> **Overview**
> Extends `NeumannInverse.lean` beyond the existing identity Neumann bound with **generic normed-ring perturbation theory** around an invertible base \(K_0\).
> 
> A private `perturbation_setup` lemma factors \(K = K_0(1+E)\) when \(\|K_0^{-1}(K-K_0)\| \le a < 1\), yielding invertibility of \(K\) and \(K^{-1} = (1+E)^{-1}K_0^{-1}\). Public theorems bound \(\|K^{-1}\|\) by \((1-a)^{-1}\|K_0^{-1}\|\) and \(\|K^{-1} - K_0^{-1}\|\) by \((1-a)^{-1}a\|K_0^{-1}\|\), each with a **product-form** corollary via `norm_mul_le`. The module docstring is updated to describe both identity and base-point bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 019215d788ba65b3ab9f39d33502a9ac9ba4dad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->