### PR TITLE
feat(ParentHamiltonian): compute limiting Gram metric

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -47,6 +47,7 @@ import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.LimitingGramMetric
 import TNLean.MPS.ParentHamiltonian.LocalSupport
 import TNLean.MPS.ParentHamiltonian.LocalSupportTransport
 import TNLean.MPS.ParentHamiltonian.Martingale

--- a/TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean
+++ b/TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean
@@ -21,6 +21,7 @@ is right multiplication by the fixed point, divided by its trace.
 * `Matrix.gramReshuffleMatrix_fixedPointProj` identifies the Kronecker-product matrix.
 * `Matrix.gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply` computes its action.
 * `Matrix.gramReshuffleMatrix_fixedPointProj_posDef` proves positive definiteness.
+* `Matrix.gramReshuffle_fixedPointProj_isUnit` proves invertibility.
 * `Matrix.gramReshuffle_fixedPointProj_injective` proves injectivity.
 -/
 
@@ -82,21 +83,20 @@ theorem gramReshuffleMatrix_fixedPointProj_posDef [NeZero D]
   rw [gramReshuffleMatrix_fixedPointProj]
   exact (hρ.transpose.kronecker PosDef.one).smul (inv_pos.mpr hρ.trace_pos)
 
+/-- A positive-definite fixed point makes the limiting Gram operator invertible. -/
+theorem gramReshuffle_fixedPointProj_isUnit [NeZero D]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef) :
+    IsUnit (gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))) := by
+  rw [gramReshuffle]
+  exact (gramReshuffleMatrix_fixedPointProj_posDef hρ).isUnit.map
+    (Matrix.toEuclideanCLM (n := Fin D × Fin D) (𝕜 := ℂ))
+
 /-- A positive-definite fixed point makes the limiting Gram operator injective. -/
 theorem gramReshuffle_fixedPointProj_injective [NeZero D]
     {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef) :
     Function.Injective
       (gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))) := by
-  rw [gramReshuffle]
-  intro x y hxy
-  have hmul :
-      (gramReshuffleMatrix (fixedPointProj ρ (ne_of_gt hρ.trace_pos))).mulVec
-          (WithLp.ofLp x) =
-        (gramReshuffleMatrix (fixedPointProj ρ (ne_of_gt hρ.trace_pos))).mulVec
-          (WithLp.ofLp y) := by
-    simpa only [Matrix.ofLp_toEuclideanCLM] using congrArg WithLp.ofLp hxy
-  have hofLp := Matrix.mulVec_injective_of_isUnit
-    (gramReshuffleMatrix_fixedPointProj_posDef hρ).isUnit hmul
-  simpa using congrArg (WithLp.toLp 2) hofLp
+  exact (ContinuousLinearMap.isUnit_iff_bijective.mp
+    (gramReshuffle_fixedPointProj_isUnit hρ)).1
 
 end Matrix

--- a/TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean
+++ b/TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FrobeniusHilbert
+import TNLean.Algebra.RectangularChoi
+import TNLean.Channel.Primitive
+
+/-!
+# The limiting Gram metric
+
+This file computes the reshuffled Choi matrix of the rank-one transfer
+fixed-point projection. With column vectorization
+`Matrix.vec X (j, i) = X i j`, the resulting unweighted Frobenius Gram operator
+is right multiplication by the fixed point, divided by its trace.
+
+## Main results
+
+* `gramReshuffleMatrix_fixedPointProj_apply` gives the four-index entry formula.
+* `gramReshuffleMatrix_fixedPointProj` identifies the Kronecker-product matrix.
+* `gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply` computes its action.
+* `gramReshuffleMatrix_fixedPointProj_posDef` proves positive definiteness.
+* `gramReshuffle_fixedPointProj_injective` proves injectivity.
+-/
+
+open scoped ComplexOrder Kronecker Matrix
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- Entries of the limiting Gram matrix in column-vectorized coordinates. -/
+@[simp]
+theorem gramReshuffleMatrix_fixedPointProj_apply
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (htr : trace ρ ≠ 0)
+    (a b c e : Fin D) :
+    gramReshuffleMatrix (fixedPointProj ρ htr) (b, a) (e, c) =
+      (trace ρ)⁻¹ * ρ e b * if c = a then 1 else 0 := by
+  rw [gramReshuffleMatrix, rectangularChoi_apply]
+  change ((trace (single c a 1) / trace ρ) • ρ) e b = _
+  by_cases hca : c = a
+  · subst c
+    simp [Matrix.trace_single_eq_same, div_eq_mul_inv]
+  · simp [Matrix.trace_single_eq_of_ne c a (1 : ℂ) hca, hca]
+
+/-- The limiting Gram matrix is a Kronecker product of the transposed fixed
+point with the identity, with normalization by the trace. -/
+theorem gramReshuffleMatrix_fixedPointProj
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (htr : trace ρ ≠ 0) :
+    gramReshuffleMatrix (fixedPointProj ρ htr) =
+      (trace ρ)⁻¹ • ((ρᵀ) ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+  ext ⟨b, a⟩ ⟨e, c⟩
+  rw [gramReshuffleMatrix_fixedPointProj_apply]
+  change (trace ρ)⁻¹ * ρ e b * (if c = a then 1 else 0) =
+    (trace ρ)⁻¹ * (ρ e b * if a = c then 1 else 0)
+  by_cases hca : c = a
+  · subst c
+    simp
+  · simp [hca, Ne.symm hca]
+
+/-- In column-vectorized Frobenius coordinates, the limiting Gram operator is
+right multiplication by the fixed point, normalized by its trace. -/
+theorem gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (htr : trace ρ ≠ 0)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    gramReshuffle (fixedPointProj ρ htr)
+        (frobeniusEquivEuclidean (Fin D) (Fin D) X) =
+      frobeniusEquivEuclidean (Fin D) (Fin D) ((trace ρ)⁻¹ • (X * ρ)) := by
+  rw [gramReshuffle, gramReshuffleMatrix_fixedPointProj,
+    frobeniusEquivEuclidean_apply, Matrix.toEuclideanCLM_toLp]
+  congr 1
+  rw [Matrix.smul_mulVec, Matrix.kronecker_mulVec_vec,
+    Matrix.transpose_transpose, Matrix.one_mul, Matrix.vec_smul]
+
+/-- A positive-definite fixed point induces a positive-definite limiting Gram
+matrix. -/
+theorem gramReshuffleMatrix_fixedPointProj_posDef [NeZero D]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef) :
+    (gramReshuffleMatrix
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))).PosDef := by
+  rw [gramReshuffleMatrix_fixedPointProj]
+  exact (hρ.transpose.kronecker PosDef.one).smul (inv_pos.mpr hρ.trace_pos)
+
+/-- A positive-definite fixed point makes the limiting Gram operator injective. -/
+theorem gramReshuffle_fixedPointProj_injective [NeZero D]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef) :
+    Function.Injective
+      (gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))) := by
+  rw [gramReshuffle]
+  intro x y hxy
+  have hmul :
+      (gramReshuffleMatrix (fixedPointProj ρ (ne_of_gt hρ.trace_pos))).mulVec
+          (WithLp.ofLp x) =
+        (gramReshuffleMatrix (fixedPointProj ρ (ne_of_gt hρ.trace_pos))).mulVec
+          (WithLp.ofLp y) := by
+    simpa only [Matrix.ofLp_toEuclideanCLM] using congrArg WithLp.ofLp hxy
+  have hofLp := Matrix.mulVec_injective_of_isUnit
+    (gramReshuffleMatrix_fixedPointProj_posDef hρ).isUnit hmul
+  simpa using congrArg (WithLp.toLp 2) hofLp
+
+end Matrix

--- a/TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean
+++ b/TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean
@@ -17,11 +17,11 @@ is right multiplication by the fixed point, divided by its trace.
 
 ## Main results
 
-* `gramReshuffleMatrix_fixedPointProj_apply` gives the four-index entry formula.
-* `gramReshuffleMatrix_fixedPointProj` identifies the Kronecker-product matrix.
-* `gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply` computes its action.
-* `gramReshuffleMatrix_fixedPointProj_posDef` proves positive definiteness.
-* `gramReshuffle_fixedPointProj_injective` proves injectivity.
+* `Matrix.gramReshuffleMatrix_fixedPointProj_apply` gives the four-index entry formula.
+* `Matrix.gramReshuffleMatrix_fixedPointProj` identifies the Kronecker-product matrix.
+* `Matrix.gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply` computes its action.
+* `Matrix.gramReshuffleMatrix_fixedPointProj_posDef` proves positive definiteness.
+* `Matrix.gramReshuffle_fixedPointProj_injective` proves injectivity.
 -/
 
 open scoped ComplexOrder Kronecker Matrix


### PR DESCRIPTION
## Summary

- compute the entries of the reshuffled rank-one fixed-point projection in TNLean's column-vectorized coordinates
- identify its matrix as
  `(Matrix.trace ρ)⁻¹ • (ρᵀ ⊗ₖ 1)`
- prove that its Euclidean action is the vectorization of
  `(Matrix.trace ρ)⁻¹ • (X * ρ)`
- derive positive definiteness and injectivity from the explicit hypothesis `ρ.PosDef`
- add the module to the parent-Hamiltonian aggregator

This is the dependency-closed limiting-metric slice of #5922. It does not claim that the unweighted limit is the identity, derive `ρ.PosDef` from `IsPrimitiveMPS` alone, or add the later inverse-Gram perturbation estimates.

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --cached --check` (before commit)
- 100-column line-length check on both changed files

No blueprint entry is added: this generic infrastructure does not directly discharge an existing source-level statement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs on generic Gram/reshuffle infrastructure; no changes to runtime behavior, auth, or existing theorem statements elsewhere.
> 
> **Overview**
> Adds **`LimitingGramMetric.lean`**, which gives an explicit closed form for the reshuffled Frobenius Gram operator attached to the rank-one transfer **fixed-point projection** `fixedPointProj ρ`, in TNLean’s column-vectorized coordinates.
> 
> The reshuffled Gram matrix is proved to equal `(trace ρ)⁻¹ • (ρᵀ ⊗ₖ 1)`, with a four-index entry formula and an operator action `(trace ρ)⁻¹ • (X * ρ)` on vectorized matrices. Under **`ρ.PosDef`**, the file derives **positive definiteness**, **invertibility**, and **injectivity** of the Gram operator.
> 
> **`ParentHamiltonian.lean`** is updated to import the new module in the parent-Hamiltonian aggregator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6ade69e0cdb1818e92cb1d0376109082cba465e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->