### PR TITLE
refactor(Analysis): address post-merge review cleanup

### DIFF
--- a/TNLean/Analysis/NeumannInverse.lean
+++ b/TNLean/Analysis/NeumannInverse.lean
@@ -37,7 +37,7 @@ variable {R : Type*} [NormedRing R] [HasSummableGeomSeries R]
 \(\lVert K_0^{-1}(K-K_0)\rVert\le a<1\), \(K\) is invertible and its inverse factors
 through the perturbation \(E:=K_0^{-1}(K-K_0)\).  Returns \(E\) and its norm bounds,
 that \(1+E\) is a unit, and the factorization \(K^{-1}=(1+E)^{-1}K_0^{-1}\). -/
-private lemma perturbation_setup [NormOneClass R] {a : ℝ} (K₀ K : R) (hK₀ : IsUnit K₀)
+private lemma perturbation_setup {a : ℝ} (K₀ K : R) (hK₀ : IsUnit K₀)
     (h : ‖Ring.inverse K₀ * (K - K₀)‖ ≤ a) (ha : a < 1) :
     IsUnit K ∧
     (∃ E : R, ‖E‖ ≤ a ∧ ‖E‖ < 1 ∧ IsUnit (1 - -E) ∧
@@ -126,9 +126,8 @@ theorem norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le (K₀ K : R) {a :
     _ ≤ (‖Ring.inverse (1 - -E)‖ * ‖E‖) * ‖Ring.inverse K₀‖ := by
       gcongr
       simpa only [norm_neg] using norm_mul_le (Ring.inverse (1 - -E)) E
-    _ ≤ ((1 - a)⁻¹ * a) * ‖Ring.inverse K₀‖ := by
+    _ ≤ (1 - a)⁻¹ * a * ‖Ring.inverse K₀‖ := by
       gcongr
-    _ = (1 - a)⁻¹ * a * ‖Ring.inverse K₀‖ := rfl
 
 /-- A product-form inverse-displacement estimate, obtained from
 \(\lVert K_0^{-1}(K-K_0)\rVert\le

--- a/TNLean/Analysis/UpperTriangularBound.lean
+++ b/TNLean/Analysis/UpperTriangularBound.lean
@@ -193,6 +193,13 @@ variable {D : ℕ} {R : Type*} [Semiring R]
 def countN {n : ℕ} (w : Fin n → Bool) : ℕ :=
   ((Finset.univ : Finset (Fin n)).filter (fun i => w i = true)).card
 
+private lemma countN_le {n : ℕ} (w : Fin n → Bool) : countN w ≤ n := by
+  dsimp [countN]
+  calc
+    ((Finset.univ : Finset (Fin n)).filter (fun i => w i = true)).card ≤
+        (Finset.univ : Finset (Fin n)).card := Finset.card_filter_le _ _
+    _ = n := Finset.card_fin n
+
 @[simp] lemma countN_zero {n : ℕ} : countN (fun _ : Fin n => false) = 0 := by simp [countN]
 
 private lemma countN_snoc_false_aux {n : ℕ} (w : Fin n → Bool) (i : Fin (n+1)) :
@@ -429,18 +436,13 @@ lemma wordProd_seminorm_le (f : Matrix (Fin D) (Fin D) R → ℝ)
   · let w' := Fin.init w; let b := w (Fin.last n)
     have hw_eq : w = Fin.snoc w' b := (Fin.snoc_init_self w).symm
     rw [hw_eq, wordProd_snoc']
-    have h_le : countN w' ≤ n := by
-      dsimp [countN]
-      calc
-        ((Finset.univ : Finset (Fin n)).filter (fun i => w' i = true)).card
-            ≤ (Finset.univ : Finset (Fin n)).card := Finset.card_filter_le _ _
-        _ = n := Finset.card_fin n
     rcases b with (rfl | rfl)
     · have hpos_w' : 1 ≤ countN w' := by
         have h_snoc_eq : countN (Fin.snoc w' false) = countN w' := countN_snoc_false w'
         rw [hw_eq] at hpos; rw [h_snoc_eq] at hpos; exact hpos
       simp
-      have h_exp : (n - countN w') + 1 = (n + 1) - countN w' := by omega
+      have h_exp : (n - countN w') + 1 = (n + 1) - countN w' :=
+        (Nat.sub_add_comm (countN_le w')).symm
       have h_rearrange : ((f Λ) ^ (n - countN w') * (f N) ^ (countN w')) * f Λ
           = (f Λ) ^ ((n - countN w') + 1) * (f N) ^ (countN w') := by ring
       calc
@@ -600,12 +602,7 @@ theorem wolf_eq_105 (f : Matrix (Fin D) (Fin D) R → ℝ)
       ext w; constructor
       · intro hw
         rw [Finset.mem_filter] at hw; rcases hw with ⟨hw_univ, ⟨hk_pos, hk_ltD⟩⟩
-        have hk_val_le_n : countN w ≤ n := by
-          dsimp [countN]
-          calc
-            ((Finset.univ : Finset (Fin n)).filter (fun i => w i = true)).card
-                ≤ (Finset.univ : Finset (Fin n)).card := Finset.card_filter_le _ _
-            _ = n := Finset.card_fin n
+        have hk_val_le_n : countN w ≤ n := countN_le w
         have hk_mem_keys : countN w ∈ keys := by
           rw [Finset.mem_Icc]
           exact ⟨hk_pos, Nat.le_min.mpr ⟨hk_val_le_n, by omega⟩⟩


### PR DESCRIPTION
## Summary

This is an explicitly post-merge, low-risk cleanup for late review findings on #5891 and #5934.

- remove the unnecessary `NormOneClass` assumption from private `perturbation_setup`
- collapse the trailing no-op `rfl` step in the inverse-displacement estimate
- replace the locally duplicated Boolean-word count bound with a tiny private `countN_le` helper, used explicitly in `wordProd_seminorm_le` and reused in `wolf_eq_105`

Deliberately out of scope:

- the larger near-duplicate `wolf_eq_103` / `wolf_eq_103_refined` proof refactor; this is a non-correctness modularity follow-up best handled separately by extracting the shared coefficient-parametric summation argument
- moving public `Matrix.countN`, which would be a public API change

## Verification

- `lake env lean TNLean/Analysis/NeumannInverse.lean`
- `lake env lean TNLean/Analysis/UpperTriangularBound.lean`
- changed-line 100-character check
- proof-integrity/debug-token scan on added lines
- `git diff --check`

No broad build, clean, or cache command was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactors with no API or behavioral changes; assumptions are weakened or duplicated steps removed without altering theorem statements.
> 
> **Overview**
> Post-merge cleanup in **Neumann inverse** and **upper-triangular** analysis proofs: weaker assumptions, tidier `calc` steps, and a shared `countN` bound.
> 
> In `NeumannInverse.lean`, private `perturbation_setup` no longer requires `NormOneClass` (the proof did not use it). The inverse-displacement `calc` chain drops a redundant `rfl` step so the bound is written directly as `(1 - a)⁻¹ * a * ‖Ring.inverse K₀‖`.
> 
> In `UpperTriangularBound.lean`, a private `countN_le` lemma proves `countN w ≤ n` once; `wordProd_seminorm_le` uses `Nat.sub_add_comm` with that bound instead of `omega`, and `wolf_eq_105` reuses `countN_le` where the same filter-card argument was duplicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee4cef1b16cbe0437fb08ae35ec39cc57d3731c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->