### PR TITLE
feat(ParentHamiltonian): prove Gram inverse convergence

### DIFF
--- a/TNLean/Analysis/NeumannInverse.lean
+++ b/TNLean/Analysis/NeumannInverse.lean
@@ -15,6 +15,18 @@ under a relatively small perturbation.
 
 namespace NormedRing
 
+variable {R α : Type*} [NormedRing R] [HasSummableGeomSeries R]
+
+/-- Ring inversion preserves convergence at an invertible limit. -/
+theorem inverse_tendsto_of_tendsto_of_isUnit {f : α → R} {l : Filter α} {K₀ : R}
+    (hK₀ : IsUnit K₀) (h : Filter.Tendsto f l (nhds K₀)) :
+    Filter.Tendsto (fun x => Ring.inverse (f x)) l (nhds (Ring.inverse K₀)) := by
+  rw [← hK₀.unit_spec, Ring.inverse_unit]
+  have hinv := (inverse_continuousAt hK₀.unit).tendsto.comp h
+  change Filter.Tendsto (fun x => Ring.inverse (f x)) l
+    (nhds (Ring.inverse (hK₀.unit : R))) at hinv
+  simpa only [Ring.inverse_unit] using hinv
+
 variable {R : Type*} [NormedRing R] [NormOneClass R] [HasSummableGeomSeries R]
 
 /-- Quantitative Neumann bound.  If \(\lVert t\rVert\le a<1\), then

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -42,6 +42,7 @@ import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.GramConvergence
+import TNLean.MPS.ParentHamiltonian.GramInverseConvergence
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning

--- a/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
@@ -33,14 +33,14 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- For every relative tolerance `a` strictly between zero and one, the
+/-- For every relative tolerance \(a\) strictly between zero and one, the
 finite-volume Gram operator of a primitive MPS tensor is eventually a unit.
 Its ring inverse differs from the inverse of the reshuffled fixed-point
 projection by at most
 \((1-a)^{-1}a\lVert K_\infty^{-1}\rVert\), where
-`Kinf` is `Matrix.gramReshuffle (fixedPointProj ρ _)`.
+\(K_\infty\) is `Matrix.gramReshuffle (fixedPointProj ρ _)`.
 
-Positive definiteness of `ρ` is explicit: primitivity alone only supplies a
+Positive definiteness of \(\rho\) is explicit: primitivity alone only supplies a
 positive-semidefinite fixed point and does not justify invertibility of the
 limiting Gram operator. -/
 theorem IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound
@@ -96,7 +96,7 @@ theorem IsPrimitiveMPS.groundSpaceGram_ringInverse_tendsto
   simpa only [Ring.inverse_unit] using hinv
 
 /-- Eventually the Hilbert-space boundary map is injective. For any relative
-tolerance `a` in `(0, 1)`, one may choose an injectivity proof so that its
+tolerance \(a\in(0,1)\), one may choose an injectivity proof so that its
 inverse-Gram operator is exactly the ring inverse of the finite-volume Gram
 operator and satisfies the same arbitrary-base Neumann estimate around the
 reshuffled fixed-point projection.

--- a/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
@@ -86,14 +86,7 @@ theorem IsPrimitiveMPS.groundSpaceGram_ringInverse_tendsto
   have hKinf : IsUnit Kinf := Matrix.gramReshuffle_fixedPointProj_isUnit hρ
   have hconv : Filter.Tendsto (fun n => groundSpaceGram A n) Filter.atTop (nhds Kinf) := by
     simpa only [Kinf] using hP.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
-  change Filter.Tendsto (fun n => Ring.inverse (groundSpaceGram A n)) Filter.atTop
-    (nhds (Ring.inverse Kinf))
-  rw [← hKinf.unit_spec, Ring.inverse_unit]
-  have hinv := (NormedRing.inverse_continuousAt hKinf.unit).tendsto.comp hconv
-  change Filter.Tendsto (fun n => Ring.inverse (groundSpaceGram A n)) Filter.atTop
-    (nhds (Ring.inverse (hKinf.unit :
-      EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ] EuclideanSpace ℂ (Fin D × Fin D)))) at hinv
-  simpa only [Ring.inverse_unit] using hinv
+  exact NormedRing.inverse_tendsto_of_tendsto_of_isUnit hKinf hconv
 
 /-- Eventually the Hilbert-space boundary map is injective. For any relative
 tolerance \(a\in(0,1)\), one may choose an injectivity proof so that its

--- a/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.NeumannInverse
+import TNLean.MPS.ParentHamiltonian.GramConvergence
+import TNLean.MPS.ParentHamiltonian.LimitingGramMetric
+
+/-!
+# Convergence of inverse MPS Gram operators
+
+For a primitive MPS tensor with a positive-definite transfer fixed point, the
+finite-volume ground-space Gram operators are eventually invertible. Their
+ring inverses satisfy the arbitrary-base Neumann perturbation estimate and
+converge to the inverse of the nonidentity limiting Gram operator
+`Matrix.gramReshuffle (fixedPointProj ρ _)`.
+
+The same eventual invertibility makes the Hilbert-space boundary maps
+injective. Consequently, their `ContinuousLinearMap.inverseGram` operators
+agree with the ring inverses and obey the same estimate.
+
+## Main results
+
+* `MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound`
+* `MPSTensor.IsPrimitiveMPS.groundSpaceGram_ringInverse_tendsto`
+* `MPSTensor.IsPrimitiveMPS.eventually_groundSpaceMapES_injective_and_inverseGram_bound`
+-/
+
+open scoped ComplexOrder Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- For every relative tolerance `a` strictly between zero and one, the
+finite-volume Gram operator of a primitive MPS tensor is eventually a unit.
+Its ring inverse differs from the inverse of the reshuffled fixed-point
+projection by at most
+\((1-a)^{-1}a\lVert K_\infty^{-1}\rVert\), where
+`Kinf` is `Matrix.gramReshuffle (fixedPointProj ρ _)`.
+
+Positive definiteness of `ρ` is explicit: primitivity alone only supplies a
+positive-semidefinite fixed point and does not justify invertibility of the
+limiting Gram operator. -/
+theorem IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) {a : ℝ} (ha_pos : 0 < a)
+    (ha_lt_one : a < 1) :
+    ∀ᶠ n in Filter.atTop,
+      IsUnit (groundSpaceGram A n) ∧
+        ‖Ring.inverse (groundSpaceGram A n) -
+            Ring.inverse (Matrix.gramReshuffle
+              (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))‖ ≤
+          (1 - a)⁻¹ * a *
+            ‖Ring.inverse (Matrix.gramReshuffle
+              (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))‖ := by
+  let Kinf := Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  have hKinf : IsUnit Kinf := Matrix.gramReshuffle_fixedPointProj_isUnit hρ
+  have hconv : Filter.Tendsto (fun n => groundSpaceGram A n) Filter.atTop (nhds Kinf) := by
+    simpa only [Kinf] using hP.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
+  have hpert_tendsto : Filter.Tendsto
+      (fun n => ‖Ring.inverse Kinf‖ * ‖groundSpaceGram A n - Kinf‖)
+      Filter.atTop (nhds 0) := by
+    simpa only [mul_zero] using
+      (tendsto_const_nhds.mul (tendsto_iff_norm_sub_tendsto_zero.mp hconv))
+  filter_upwards [(tendsto_order.1 hpert_tendsto).2 a ha_pos] with n hn
+  have hunit := NormedRing.isUnit_and_norm_inverse_le_of_norm_mul_norm_sub_le
+    Kinf (groundSpaceGram A n) hKinf hn.le ha_lt_one
+  refine ⟨hunit.1, ?_⟩
+  simpa only [Kinf] using
+    NormedRing.norm_inverse_sub_inverse_le_of_norm_mul_norm_sub_le
+      Kinf (groundSpaceGram A n) hKinf hn.le ha_lt_one
+
+/-- The ring inverses of the finite-volume Gram operators of a primitive MPS
+tensor converge to the inverse of the nonidentity limiting Gram operator.
+Positive definiteness of the fixed point is required to place the limit in the
+open set of units. -/
+theorem IsPrimitiveMPS.groundSpaceGram_ringInverse_tendsto
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    Filter.Tendsto (fun n => Ring.inverse (groundSpaceGram A n)) Filter.atTop
+      (nhds (Ring.inverse (Matrix.gramReshuffle
+        (fixedPointProj ρ (ne_of_gt hρ.trace_pos))))) := by
+  let Kinf := Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  have hKinf : IsUnit Kinf := Matrix.gramReshuffle_fixedPointProj_isUnit hρ
+  have hconv : Filter.Tendsto (fun n => groundSpaceGram A n) Filter.atTop (nhds Kinf) := by
+    simpa only [Kinf] using hP.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj
+  change Filter.Tendsto (fun n => Ring.inverse (groundSpaceGram A n)) Filter.atTop
+    (nhds (Ring.inverse Kinf))
+  rw [← hKinf.unit_spec, Ring.inverse_unit]
+  have hinv := (NormedRing.inverse_continuousAt hKinf.unit).tendsto.comp hconv
+  change Filter.Tendsto (fun n => Ring.inverse (groundSpaceGram A n)) Filter.atTop
+    (nhds (Ring.inverse (hKinf.unit :
+      EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ] EuclideanSpace ℂ (Fin D × Fin D)))) at hinv
+  simpa only [Ring.inverse_unit] using hinv
+
+/-- Eventually the Hilbert-space boundary map is injective. For any relative
+tolerance `a` in `(0, 1)`, one may choose an injectivity proof so that its
+inverse-Gram operator is exactly the ring inverse of the finite-volume Gram
+operator and satisfies the same arbitrary-base Neumann estimate around the
+reshuffled fixed-point projection.
+
+The equality is independent of the chosen injectivity proof by proof
+irrelevance. -/
+theorem IsPrimitiveMPS.eventually_groundSpaceMapES_injective_and_inverseGram_bound
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) {a : ℝ} (ha_pos : 0 < a)
+    (ha_lt_one : a < 1) :
+    ∀ᶠ n in Filter.atTop,
+      ∃ hInj : Function.Injective (groundSpaceMapES A n),
+        ContinuousLinearMap.inverseGram (groundSpaceMapES A n) hInj =
+            Ring.inverse (groundSpaceGram A n) ∧
+          ‖ContinuousLinearMap.inverseGram (groundSpaceMapES A n) hInj -
+              Ring.inverse (Matrix.gramReshuffle
+                (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))‖ ≤
+            (1 - a)⁻¹ * a *
+              ‖Ring.inverse (Matrix.gramReshuffle
+                (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))‖ := by
+  filter_upwards [hP.eventually_groundSpaceGram_isUnit_and_inverse_bound
+    hρ ha_pos ha_lt_one] with n hn
+  have hGramInj : Function.Injective (groundSpaceGram A n) :=
+    (ContinuousLinearMap.isUnit_iff_bijective.mp hn.1).1
+  have hInj : Function.Injective (groundSpaceMapES A n) := by
+    apply (groundSpaceMapES A n).adjoint_comp_self_injective_iff.mp
+    intro x y hxy
+    apply hGramInj
+    change (groundSpaceMapES A n).adjoint (groundSpaceMapES A n x) =
+      (groundSpaceMapES A n).adjoint (groundSpaceMapES A n y)
+    exact hxy
+  refine ⟨hInj, ?_, ?_⟩
+  · simpa only [groundSpaceGram] using
+      ContinuousLinearMap.inverseGram_eq_ringInverse (groundSpaceMapES A n) hInj
+  · rw [ContinuousLinearMap.inverseGram_eq_ringInverse]
+    simpa only [groundSpaceGram] using hn.2
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -887,8 +887,7 @@ windows.
     \lean{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound}
     \leanok
     \uses{def:primitive_mps,
-        thm:primitive_ground_space_gram_tendsto_fixed_point,
-        thm:inverse_gram_identities}
+        thm:primitive_ground_space_gram_tendsto_fixed_point}
     Let $A$ be a primitive MPS tensor whose fixed-point witness $\rho$ is
     positive definite, and put
     $\mathcal K_\infty=\mathscr R(P_\rho)$.  For every $0<a<1$, all

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -692,12 +692,152 @@ orthogonal projector is the canonical representative used here.
     Theorem~\ref{thm:ground_space_gram_tendsto_fixed_point}.
 \end{proof}
 
-The limit in Theorem~\ref{thm:ground_space_gram_tendsto_fixed_point} is the
-reshuffled fixed-point projection $\mathscr R(P_\rho)$, not the identity in
-unweighted Frobenius coordinates.  The limiting metric is generally nonidentity.  Under a positive-definite
-fixed-point hypothesis, the inverse estimates below perturb around
-$\mathscr R(P_\rho)$ rather than around the identity.  They do not yet compare
-the physical range projectors on overlapping windows.
+The limit in Theorem~\ref{thm:ground_space_gram_tendsto_fixed_point} is
+the reshuffled fixed-point projection $\mathscr R(P_\rho)$, not the
+identity in unweighted Frobenius coordinates.  The limiting metric is
+generally nonidentity.
+Under a positive-definite fixed-point hypothesis, the inverse estimates
+below perturb around $\mathscr R(P_\rho)$ rather than around the identity.
+They do not yet compare the physical range projectors on overlapping
+windows.
+
+\begin{theorem}[Exact limiting Gram metric]
+    \label{thm:fixed_point_gram_metric_exact}
+    \lean{Matrix.gramReshuffleMatrix_fixedPointProj_apply}
+    \lean{Matrix.gramReshuffleMatrix_fixedPointProj}
+    \lean{Matrix.gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply}
+    \leanok
+    \uses{def:gram_reshuffle, def:frobenius_vectorization}
+    Let $\rho\in\MN{D}$ have nonzero trace and define
+    $P_\rho(X):=(\tr X/\tr\rho)\rho$.  Then
+    \begin{align}
+      R(P_\rho)
+      &=(\tr\rho)^{-1}(\rho^{\mathsf T}\otimes I_D),
+      \label{eq:fixed_point_gram_metric_matrix}\\
+      \mathscr R(P_\rho)U(X)
+      &=U\!\left((\tr\rho)^{-1}X\rho\right).
+      \label{eq:fixed_point_gram_metric_action}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For matrix units $E_{ca}$, direct evaluation gives
+    \begin{align}
+      R(P_\rho)_{(b,a),(e,c)}
+      &=(\tr\rho)^{-1}\rho_{eb}\,\delta_{ca}.
+    \end{align}
+    These are exactly the entries in
+    (\ref{eq:fixed_point_gram_metric_matrix}).  Applying that Kronecker product
+    to the column--row vectorization of $X$ gives
+    (\ref{eq:fixed_point_gram_metric_action}).
+\end{proof}
+
+\begin{theorem}[Invertibility of the limiting Gram metric]
+    \label{thm:fixed_point_gram_metric_is_unit}
+    \lean{Matrix.gramReshuffleMatrix_fixedPointProj_posDef}
+    \lean{Matrix.gramReshuffle_fixedPointProj_isUnit}
+    \leanok
+    \uses{def:gram_reshuffle}
+    If $D>0$ and $\rho\in\MN{D}$ is positive definite, then
+    $R(P_\rho)$ is positive definite and $\mathscr R(P_\rho)$ is invertible.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:fixed_point_gram_metric_exact}
+    Positive definiteness gives $\tr\rho>0$.  By
+    (\ref{eq:fixed_point_gram_metric_matrix}),
+    \begin{align}
+      R(P_\rho)
+      &=(\tr\rho)^{-1}(\rho^{\mathsf T}\otimes I_D)>0.
+    \end{align}
+    Hence its associated operator $\mathscr R(P_\rho)$ is invertible.
+\end{proof}
+
+\begin{theorem}[Arbitrary-base Neumann inverse bound]
+    \label{thm:arbitrary_base_neumann_inverse_bound}
+    \lean{NormedRing.isUnit_and_norm_inverse_le_of_norm_inverse_mul_sub_le}
+    \lean{NormedRing.isUnit_and_norm_inverse_le_of_norm_mul_norm_sub_le}
+    \leanok
+    Let $K_0$ be invertible in a normed ring with convergent geometric series
+    and $\lVert I\rVert=1$.  If $a<1$ and
+    \begin{align}
+      \lVert K_0^{-1}(K-K_0)\rVert&\le a,
+      \label{eq:arbitrary_base_relative_perturbation}
+    \end{align}
+    then $K$ is invertible and
+    \begin{align}
+      \lVert K^{-1}\rVert
+      &\le(1-a)^{-1}\lVert K_0^{-1}\rVert.
+      \label{eq:arbitrary_base_inverse_bound}
+    \end{align}
+    The same conclusion follows from
+    $\lVert K_0^{-1}\rVert\,\lVert K-K_0\rVert\le a$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:neumann_inverse_norm_bound}
+    Put $E:=K_0^{-1}(K-K_0)$.  Then
+    $K=K_0(I+E)$ and $\lVert E\rVert<1$, so
+    \begin{align}
+      K^{-1}&=(I+E)^{-1}K_0^{-1},\\
+      \lVert K^{-1}\rVert
+      &\le\lVert(I+E)^{-1}\rVert\,\lVert K_0^{-1}\rVert
+       \le(1-a)^{-1}\lVert K_0^{-1}\rVert.
+    \end{align}
+    Submultiplicativity reduces the product-form hypothesis to
+    (\ref{eq:arbitrary_base_relative_perturbation}).
+\end{proof}
+
+\begin{theorem}[Arbitrary-base inverse-displacement bound]
+    \label{thm:arbitrary_base_neumann_inverse_displacement}
+    \lean{NormedRing.norm_inverse_sub_inverse_le_of_norm_inverse_mul_sub_le}
+    \lean{NormedRing.norm_inverse_sub_inverse_le_of_norm_mul_norm_sub_le}
+    \leanok
+    Let $K_0$ be invertible in a normed ring with convergent geometric series
+    and $\lVert I\rVert=1$.  If $a<1$ and
+    (\ref{eq:arbitrary_base_relative_perturbation}) holds, then
+    \begin{align}
+      \lVert K^{-1}-K_0^{-1}\rVert
+      &\le(1-a)^{-1}a\,\lVert K_0^{-1}\rVert.
+      \label{eq:arbitrary_base_inverse_displacement}
+    \end{align}
+    The same estimate follows from
+    $\lVert K_0^{-1}\rVert\,\lVert K-K_0\rVert\le a$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:neumann_inverse_norm_bound}
+    With $E:=K_0^{-1}(K-K_0)$, the resolvent identity is
+    \begin{align}
+      K^{-1}-K_0^{-1}
+      &=-(I+E)^{-1}E K_0^{-1}.
+    \end{align}
+    Since $\lVert(I+E)^{-1}\rVert\le(1-a)^{-1}$ and
+    $\lVert E\rVert\le a$, taking norms gives
+    (\ref{eq:arbitrary_base_inverse_displacement}).  Submultiplicativity again
+    gives the product-form variant.
+\end{proof}
+
+\begin{theorem}[Continuity of inversion at an invertible limit]
+    \label{thm:inverse_tendsto_at_unit}
+    \lean{NormedRing.inverse_tendsto_of_tendsto_of_isUnit}
+    \leanok
+    Let $K_i$ be a net in a normed ring with convergent geometric series.  If
+    $K_i\to K_0$ and $K_0$ is invertible, then
+    \begin{align}
+      K_i^{-1}&\longrightarrow K_0^{-1}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write $K_0$ as the image of a unit.  Continuity of inversion on the unit
+    group, followed by the convergence $K_i\to K_0$, gives the result.
+\end{proof}
 
 \begin{definition}[Inverse Gram operator]
     \label{def:inverse_gram}
@@ -765,7 +905,10 @@ the physical range projectors on overlapping windows.
 
 \begin{proof}
     \leanok
-    \uses{thm:primitive_ground_space_gram_tendsto_fixed_point}
+    \uses{thm:primitive_ground_space_gram_tendsto_fixed_point,
+        thm:fixed_point_gram_metric_is_unit,
+        thm:arbitrary_base_neumann_inverse_bound,
+        thm:arbitrary_base_neumann_inverse_displacement}
     The positive-definite fixed point makes
     $\mathcal K_\infty$ invertible.  Gram convergence implies that eventually
     \begin{align}
@@ -793,7 +936,9 @@ the physical range projectors on overlapping windows.
 
 \begin{proof}
     \leanok
-    \uses{thm:primitive_ground_space_gram_tendsto_fixed_point}
+    \uses{thm:primitive_ground_space_gram_tendsto_fixed_point,
+        thm:fixed_point_gram_metric_is_unit,
+        thm:inverse_tendsto_at_unit}
     Inversion is continuous at the invertible operator
     $\mathcal K_\infty$, so the claim follows from
     $\mathcal K_n\to\mathcal K_\infty$.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -696,7 +696,7 @@ The limit in Theorem~\ref{thm:ground_space_gram_tendsto_fixed_point} is the
 reshuffled fixed-point projection $\mathscr R(P_\rho)$, not the identity in
 unweighted Frobenius coordinates.  The limiting metric is generally nonidentity.  Under a positive-definite
 fixed-point hypothesis, the inverse estimates below perturb around
-$\mathscr R(P_ho)$ rather than around the identity.  They do not yet compare
+$\mathscr R(P_\rho)$ rather than around the identity.  They do not yet compare
 the physical range projectors on overlapping windows.
 
 \begin{definition}[Inverse Gram operator]
@@ -747,8 +747,7 @@ the physical range projectors on overlapping windows.
     \lean{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound}
     \leanok
     \uses{def:primitive_mps,
-        thm:primitive_ground_space_gram_tendsto_fixed_point,
-        thm:inverse_gram_identities}
+        thm:primitive_ground_space_gram_tendsto_fixed_point}
     Let $A$ be a primitive MPS tensor whose fixed-point witness $\rho$ is
     positive definite, and put
     $\mathcal K_\infty=\mathscr R(P_\rho)$.  For every $0<a<1$, all

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -694,9 +694,10 @@ orthogonal projector is the canonical representative used here.
 
 The limit in Theorem~\ref{thm:ground_space_gram_tendsto_fixed_point} is the
 reshuffled fixed-point projection $\mathscr R(P_\rho)$, not the identity in
-unweighted Frobenius coordinates.  These theorems therefore do not yet provide
-an inverse-Gram estimate around the identity or compare the physical range
-projectors on overlapping windows.
+unweighted Frobenius coordinates.  The limiting metric is generally nonidentity.  Under a positive-definite
+fixed-point hypothesis, the inverse estimates below perturb around
+$\mathscr R(P_ho)$ rather than around the identity.  They do not yet compare
+the physical range projectors on overlapping windows.
 
 \begin{definition}[Inverse Gram operator]
     \label{def:inverse_gram}
@@ -739,6 +740,92 @@ projectors on overlapping windows.
     (\ref{eq:inverse_gram_right}).  Together these equations characterize the
     canonical inverse of a continuous linear endomorphism, which agrees with
     its inverse in the endomorphism ring.
+\end{proof}
+
+\begin{theorem}[Eventual inverse-Gram control in the limiting metric]
+    \label{thm:primitive_ground_space_gram_eventual_inverse_bound}
+    \lean{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound}
+    \leanok
+    \uses{def:primitive_mps,
+        thm:primitive_ground_space_gram_tendsto_fixed_point,
+        thm:inverse_gram_identities}
+    Let $A$ be a primitive MPS tensor whose fixed-point witness $\rho$ is
+    positive definite, and put
+    $\mathcal K_\infty=\mathscr R(P_\rho)$.  For every $0<a<1$, all
+    sufficiently large $n$ satisfy
+    \begin{align}
+      \mathcal K_n&\in\operatorname{GL},
+      \notag\\
+      \bigl\lVert\mathcal K_n^{-1}-\mathcal K_\infty^{-1}\bigr\rVert
+      &\leq
+      \frac{a}{1-a}\,\bigl\lVert\mathcal K_\infty^{-1}\bigr\rVert.
+      \label{eq:primitive_ground_space_gram_eventual_inverse_bound}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:primitive_ground_space_gram_tendsto_fixed_point}
+    The positive-definite fixed point makes
+    $\mathcal K_\infty$ invertible.  Gram convergence implies that eventually
+    \begin{align}
+      \bigl\lVert\mathcal K_\infty^{-1}\bigr\rVert
+      \bigl\lVert\mathcal K_n-\mathcal K_\infty\bigr\rVert&\leq a.
+    \end{align}
+    Factoring $\mathcal K_n$ around the invertible base
+    $\mathcal K_\infty$ and applying the arbitrary-base Neumann estimate gives
+    (\ref{eq:primitive_ground_space_gram_eventual_inverse_bound}).
+\end{proof}
+
+\begin{theorem}[Convergence of finite-volume inverse Gram operators]
+    \label{thm:primitive_ground_space_gram_inverse_tendsto}
+    \lean{MPSTensor.IsPrimitiveMPS.groundSpaceGram_ringInverse_tendsto}
+    \leanok
+    \uses{def:primitive_mps,
+        thm:primitive_ground_space_gram_tendsto_fixed_point}
+    Under the same primitive-MPS and positive-definite fixed-point hypotheses,
+    \begin{align}
+      \mathcal K_n^{-1}&\longrightarrow\mathcal K_\infty^{-1}
+      \label{eq:primitive_ground_space_gram_inverse_tendsto}
+    \end{align}
+    in operator norm.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:primitive_ground_space_gram_tendsto_fixed_point}
+    Inversion is continuous at the invertible operator
+    $\mathcal K_\infty$, so the claim follows from
+    $\mathcal K_n\to\mathcal K_\infty$.
+\end{proof}
+
+\begin{theorem}[Eventual injectivity and inverse-Gram control]
+    \label{thm:primitive_ground_space_map_eventual_inverse_gram_bound}
+    \lean{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceMapES_injective_and_inverseGram_bound}
+    \leanok
+    \uses{def:ground_space_map_es, def:inverse_gram,
+        thm:primitive_ground_space_gram_eventual_inverse_bound,
+        thm:inverse_gram_identities}
+    Under the same hypotheses, for every $0<a<1$ and all sufficiently large
+    $n$, the physical boundary map $\Gamma_n^{\mathrm{ES}}$ is injective and
+    its inverse Gram operator is $\mathcal K_n^{-1}$.  Moreover,
+    \begin{align}
+      \bigl\lVert S_{\Gamma_n^{\mathrm{ES}}}
+        -\mathcal K_\infty^{-1}\bigr\rVert
+      &\leq
+      \frac{a}{1-a}\,\bigl\lVert\mathcal K_\infty^{-1}\bigr\rVert.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:primitive_ground_space_gram_eventual_inverse_bound,
+        thm:inverse_gram_identities}
+    Eventual invertibility of
+    $(\Gamma_n^{\mathrm{ES}})^\dagger\Gamma_n^{\mathrm{ES}}$ implies eventual
+    injectivity of $\Gamma_n^{\mathrm{ES}}$.  The inverse-Gram identities then
+    identify $S_{\Gamma_n^{\mathrm{ES}}}$ with $\mathcal K_n^{-1}$, and the
+    preceding estimate applies.
 \end{proof}
 
 \begin{definition}[Injective range-projector candidate]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -747,7 +747,8 @@ the physical range projectors on overlapping windows.
     \lean{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound}
     \leanok
     \uses{def:primitive_mps,
-        thm:primitive_ground_space_gram_tendsto_fixed_point}
+        thm:primitive_ground_space_gram_tendsto_fixed_point,
+        thm:inverse_gram_identities}
     Let $A$ be a primitive MPS tensor whose fixed-point witness $\rho$ is
     positive definite, and put
     $\mathcal K_\infty=\mathscr R(P_\rho)$.  For every $0<a<1$, all

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -707,7 +707,7 @@ windows.
     \lean{Matrix.gramReshuffleMatrix_fixedPointProj}
     \lean{Matrix.gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply}
     \leanok
-    \uses{def:gram_reshuffle, def:frobenius_vectorization}
+    \uses{def:fixed_point_proj, def:gram_reshuffle, def:frobenius_vectorization}
     Let $\rho\in\MN{D}$ have nonzero trace and define
     $P_\rho(X):=(\tr X/\tr\rho)\rho$.  Then
     \begin{align}
@@ -722,6 +722,7 @@ windows.
 
 \begin{proof}
     \leanok
+    \uses{def:fixed_point_proj, def:gram_reshuffle, def:frobenius_vectorization}
     For matrix units $E_{ca}$, direct evaluation gives
     \begin{align}
       R(P_\rho)_{(b,a),(e,c)}
@@ -738,14 +739,14 @@ windows.
     \lean{Matrix.gramReshuffleMatrix_fixedPointProj_posDef}
     \lean{Matrix.gramReshuffle_fixedPointProj_isUnit}
     \leanok
-    \uses{def:gram_reshuffle}
+    \uses{def:fixed_point_proj, def:gram_reshuffle}
     If $D>0$ and $\rho\in\MN{D}$ is positive definite, then
     $R(P_\rho)$ is positive definite and $\mathscr R(P_\rho)$ is invertible.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:fixed_point_gram_metric_exact}
+    \uses{def:gram_reshuffle, thm:fixed_point_gram_metric_exact}
     Positive definiteness gives $\tr\rho>0$.  By
     (\ref{eq:fixed_point_gram_metric_matrix}),
     \begin{align}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -595,9 +595,14 @@ strictly below one.  They impose no positivity, injectivity, or uniqueness
 hypothesis.
 
 The limiting Gram operator is $\mathscr R(P_\rho)$, generally not the
-identity in the current unweighted Frobenius coordinates.  Thus this completed
-convergence theorem does not provide a Neumann-series estimate for
-$1-\mathcal K_L$.
+identity in the current unweighted Frobenius coordinates.  Its exact action is
+right multiplication,
+\begin{align}
+  \mathscr R(P_\rho)\operatorname{vec}(X)
+  &=\operatorname{vec}\!\left(\frac{X\rho}{\operatorname{tr}\rho}\right).
+\end{align}
+Hence a positive-definite fixed point makes the limiting Gram invertible.  The
+correct perturbation is around $\mathscr R(P_\rho)$, not around the identity.
 
 The generic identity
 \begin{align}
@@ -731,10 +736,20 @@ limiting Gram operator:
   &\le D^3\bigl(Cr^n\bigr)^2.
 \end{align}
 It does not control $\lVert1-\mathcal K_n\rVert$ in these unweighted
-coordinates, because $\mathscr R(P_\rho)$ is generally not the
-identity.  Hence it does not yet bound an inverse Gram operator around the
-identity.  It also does not compare the physical range projectors on the two
-overlapping windows.
+coordinates, because $\mathscr R(P_\rho)$ is generally not the identity.
+Under the additional hypothesis $\rho>0$, the limiting Gram is invertible and
+\leanid{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound}
+proves eventual finite-volume invertibility with an arbitrary-base Neumann
+estimate.  Furthermore,
+\leanid{MPSTensor.IsPrimitiveMPS.groundSpaceGram_ringInverse_tendsto} proves
+\begin{align}
+  \mathcal K_n^{-1}&\longrightarrow\mathscr R(P_\rho)^{-1},
+\end{align}
+and
+\leanid{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceMapES_injective_and_inverseGram_bound}
+transfers the quantitative estimate to the inverse Gram of the physical
+boundary map.  The remaining gap is the comparison of the two physical range
+projectors on overlapping windows.
 
 In particular, the development does not prove the overlapping-window FNW
 contraction

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -596,11 +596,13 @@ hypothesis.
 
 The limiting Gram operator is $\mathscr R(P_\rho)$, generally not the
 identity in the current unweighted Frobenius coordinates.  Its exact action is
-right multiplication,
+right multiplication in the Frobenius vectorization $U$ defined above,
 \begin{align}
-  \mathscr R(P_\rho)\operatorname{vec}(X)
-  &=\operatorname{vec}\!\left(\frac{X\rho}{\operatorname{tr}\rho}\right).
+  \mathscr R(P_\rho)U(X)
+  &=U\!\left(\frac{X\rho}{\operatorname{tr}\rho}\right).
 \end{align}
+This identity is
+\leanid{Matrix.gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply}.
 Hence a positive-definite fixed point makes the limiting Gram invertible.  The
 correct perturbation is around $\mathscr R(P_\rho)$, not around the identity.
 

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1242, 1284 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1329, 1371 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1474, 1516 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1473, 1515 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1329, 1371 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1328, 1370 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1328, 1370 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1474, 1516 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1473, 1515 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1474, 1516 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- proves eventual invertibility of finite-volume physical Gram operators for a primitive MPS with an explicitly positive-definite fixed point;
- applies the arbitrary-base Neumann estimates around the nonidentity limit
  $$K_\infty=\mathscr R(P_\rho);$$
- proves convergence of ring inverses and transfers the quantitative estimate to `inverseGram` for the eventually injective physical boundary maps;
- synchronizes Chapter 13, the martingale paper-gap note, and tenkz line dispositions.

## Scope

`IsPrimitiveMPS` alone is not used to infer faithfulness: `ρ.PosDef` is an explicit hypothesis. The proof perturbs around `gramReshuffle (fixedPointProj ρ ...)`, not the identity. It does not compare the two overlapping-window range projectors and does not claim the FNW contraction.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.GramInverseConvergence TNLean.MPS.ParentHamiltonian`
- direct Lean compilation after documentation cleanup
- generated import aggregator check
- reader-facing prose check
- `git diff --check`

Refs #5922, #5923, #5752, #5883, #5934, #5935

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New proofs in the parent-Hamiltonian Gram chain depend on explicit `PosDef` and Neumann perturbation estimates; errors could affect downstream inverse-Gram arguments but do not change runtime auth or data paths.
> 
> **Overview**
> Adds **formal control of finite-volume Gram inverses** for primitive MPS when the fixed point is explicitly **positive definite** (`ρ.PosDef`), perturbing around the non-identity limit `K_∞ = \mathscr R(P_ρ)` rather than the identity.
> 
> A new `GramInverseConvergence` module proves that `groundSpaceGram` is eventually a unit, that ring inverses satisfy the arbitrary-base Neumann displacement bound, and that they converge to `Ring.inverse K_∞`. The same estimates transfer to `inverseGram` once `groundSpaceMapES` is eventually injective. **`inverse_tendsto_of_tendsto_of_isUnit`** in `NeumannInverse` supplies continuity of ring inversion at an invertible limit.
> 
> Chapter 13 blueprint prose, the martingale overlap gap note, and tenkz disposition line refs are aligned with these Lean names and with the clarified scope (no overlapping-window range-projector comparison / FNW contraction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d897e1dba13c0e99aa69b43c408f7020550ae375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->