### PR TITLE
feat(MPS/MPU): expose source-u contraction identities

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -18,6 +18,7 @@ import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
+import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.ThreeFormSpan

--- a/TNLean/MPS/MPU/SourceUContraction.lean
+++ b/TNLean/MPS/MPU/SourceUContraction.lean
@@ -45,7 +45,7 @@ output-layer reflection used in arXiv:1703.09188, Lemma `lemuisometry` (lines 54
 @[simp] theorem physicalAdjointTensor_physicalAdjointTensor (U : MPOTensor d D) :
     physicalAdjointTensor (physicalAdjointTensor U) = U := by
   ext i j α β
-  simp
+  simp only [physicalAdjointTensor_apply, star_star]
 
 /-- Passing to the physical adjoint preserves the MPU property. The proof transposes the
 periodic unitarity equation from arXiv:1703.09188, equation `UisUnitary` (lines 327--335). -/
@@ -84,7 +84,8 @@ theorem sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁
       (sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U := by
   calc
     sourceY₁ U ρ hρ =
-        (1 : Matrix (Fin r[U]) (Fin r[U]) ℂ) * sourceY₁ U ρ hρ := by simp
+        (1 : Matrix (Fin r[U]) (Fin r[U]) ℂ) * sourceY₁ U ρ hρ := by
+      rw [Matrix.one_mul]
     _ = ((sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ * sourceX₁ U ρ hρ) *
           sourceY₁ U ρ hρ := by rw [sourceX₁_weighted_isometry]
     _ = (sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ *
@@ -98,7 +99,8 @@ theorem sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁
 theorem sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂ :
     sourceY₂ U = (sourceX₂ U)ᴴ * sourceCutM₂ U := by
   calc
-    sourceY₂ U = (1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ) * sourceY₂ U := by simp
+    sourceY₂ U = (1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ) * sourceY₂ U := by
+      rw [Matrix.one_mul]
     _ = ((sourceX₂ U)ᴴ * sourceX₂ U) * sourceY₂ U := by
       rw [sourceX₂_isometry]
     _ = (sourceX₂ U)ᴴ * (sourceX₂ U * sourceY₂ U) := by

--- a/TNLean/MPS/MPU/SourceUContraction.lean
+++ b/TNLean/MPS/MPU/SourceUContraction.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.MPU.SourceFactors
 /-!
 # Algebraic identities for the source-u contraction
 
-This module packages the algebraic identities used before the finite-sum contraction in
+This module records the algebraic identities used before the finite-sum contraction in
 arXiv:1703.09188, Lemma `lemuisometry` (lines 545--557). It records how the physical adjoint
 acts on MPU tensors and their periodic operators, gives the exact output-first double-layer
 entry with its bond-pair order, and recovers the two right source factors from the source cuts.

--- a/TNLean/MPS/MPU/SourceUContraction.lean
+++ b/TNLean/MPS/MPU/SourceUContraction.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Simple
+import TNLean.MPS.MPU.SourceFactors
+
+/-!
+# Algebraic identities for the source-u contraction
+
+This module packages the algebraic identities used before the finite-sum contraction in
+arXiv:1703.09188, Lemma `lemuisometry` (lines 545--557). It records how the physical adjoint
+acts on MPU tensors and their periodic operators, gives the exact output-first double-layer
+entry with its bond-pair order, and recovers the two right source factors from the source cuts.
+
+The first source cut uses rows `(left virtual, down physical)`, so its weight is literally
+`ρ ⊗ₖ 1` in product-index order. The output-first double layer uses `(α, γ)` for its
+left bond
+pair and `(β, δ)` for its right bond pair.
+
+This module does not identify the resulting finite sum with `sourceUᴴ * sourceU` and proves no
+isometry or rank theorem. The finite-sum source-u Gram contraction is not established here.
+
+## Main results
+
+* `physicalAdjointTensor_physicalAdjointTensor` -- physical adjoint is involutive.
+* `IsMPU.physicalAdjointTensor` -- physical adjoint preserves the MPU property.
+* `doubleLayerTensor_physicalAdjointTensor_apply` -- output-first double-layer entry formula.
+* `sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁` -- weighted recovery
+  of `Y₁`.
+* `sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂` -- unweighted recovery of `Y₂`.
+* `mpo_physicalAdjointTensor_eq_conjTranspose` -- periodic MPO conjugate-transpose identity.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- Physical adjoint is an involution. This is the local algebraic involution underlying the
+output-layer reflection used in arXiv:1703.09188, Lemma `lemuisometry` (lines 545--557). -/
+@[simp] theorem physicalAdjointTensor_physicalAdjointTensor (U : MPOTensor d D) :
+    physicalAdjointTensor (physicalAdjointTensor U) = U := by
+  ext i j α β
+  simp
+
+/-- Passing to the physical adjoint preserves the MPU property. The proof transposes the
+periodic unitarity equation from arXiv:1703.09188, equation `UisUnitary` (lines 327--335). -/
+theorem IsMPU.physicalAdjointTensor {U : MPOTensor d D} (hU : IsMPU U) :
+    IsMPU (physicalAdjointTensor U) := by
+  intro N hN
+  rw [Matrix.mem_unitaryGroup_iff']
+  simp only [Matrix.star_eq_conjTranspose]
+  ext σ τ
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    mpo_physicalAdjointTensor]
+  have h := congrArg (fun M ↦ M σ τ) (hU.mpo_mul_conjTranspose_mpo hN)
+  simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
+    star_star] using h
+
+/-- Entrywise output-layer form of the physical-adjoint double layer.
+
+The left doubled bond is ordered `(α, γ)` and the right doubled bond is ordered `(β, δ)`.
+Thus the first factor is `U i j α β`, while the reflected output factor is
+`star (U k j γ δ)`. This is the orientation used before the contraction in
+arXiv:1703.09188, Lemma `lemuisometry` (lines 545--557). -/
+theorem doubleLayerTensor_physicalAdjointTensor_apply
+    (U : MPOTensor d D) (i k : Fin d) (α γ β δ : Fin D) :
+    doubleLayerTensor (physicalAdjointTensor U) i k
+        (finProdFinEquiv (α, γ)) (finProdFinEquiv (β, δ)) =
+      ∑ j : Fin d, U i j α β * star (U k j γ δ) := by
+  simp [doubleLayerTensor, mulTensor_apply, Matrix.sum_apply, kroneckerMap_apply]
+
+/-- Recover the first right source factor by applying the weighted left inverse of `X₁` to
+`M₁ = X₁Y₁`. The product-index weight is `ρ ⊗ₖ I_d`, corresponding to the graphically
+written
+`I_d ⊗ ρ` in arXiv:1703.09188, equations `Y1Y1X1X1`--`X1X2b` (lines 487--526). -/
+theorem sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    sourceY₁ U ρ hρ =
+      (sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U := by
+  calc
+    sourceY₁ U ρ hρ =
+        (1 : Matrix (Fin r[U]) (Fin r[U]) ℂ) * sourceY₁ U ρ hρ := by simp
+    _ = ((sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ * sourceX₁ U ρ hρ) *
+          sourceY₁ U ρ hρ := by rw [sourceX₁_weighted_isometry]
+    _ = (sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ *
+          (sourceX₁ U ρ hρ * sourceY₁ U ρ hρ) := by
+      simp only [Matrix.mul_assoc]
+    _ = _ := by rw [← sourceCutM₁_eq_sourceX₁_mul_sourceY₁]
+
+/-- Recover the second right source factor by applying the ordinary left inverse of `X₂` to
+`M₂ = X₂Y₂`. This is the unweighted normalization in arXiv:1703.09188, equations
+`Y1Y1X1X1`--`X1X2b` (lines 487--526). -/
+theorem sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂ :
+    sourceY₂ U = (sourceX₂ U)ᴴ * sourceCutM₂ U := by
+  calc
+    sourceY₂ U = (1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ) * sourceY₂ U := by simp
+    _ = ((sourceX₂ U)ᴴ * sourceX₂ U) * sourceY₂ U := by
+      rw [sourceX₂_isometry]
+    _ = (sourceX₂ U)ᴴ * (sourceX₂ U * sourceY₂ U) := by
+      simp only [Matrix.mul_assoc]
+    _ = _ := by rw [← sourceCutM₂_eq_sourceX₂_mul_sourceY₂]
+
+/-- The periodic MPO of the physical adjoint is the matrix conjugate transpose. This is the
+matrix-level form of the output-layer identity used in arXiv:1703.09188, Lemma `lemuisometry`
+(lines 545--557). -/
+theorem mpo_physicalAdjointTensor_eq_conjTranspose (U : MPOTensor d D) (N : ℕ) :
+    mpo (physicalAdjointTensor U) N = (mpo U N)ᴴ := by
+  ext σ τ
+  exact mpo_physicalAdjointTensor U N σ τ
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -207,6 +207,57 @@ closing a chain of $N$ copies of $\mathcal U$.
     the chain.
 \end{proof}
 
+\begin{theorem}[Physical-adjoint identities for matrix product unitaries]
+    \label{thm:mpu_physical_adjoint_identities}
+    \lean{MPOTensor.physicalAdjointTensor_physicalAdjointTensor,
+        MPOTensor.IsMPU.physicalAdjointTensor,
+        MPOTensor.mpo_physicalAdjointTensor_eq_conjTranspose}
+    \leanok
+    \uses{def:mpu,def:mpdo_physical_adjoint}
+    The physical adjoint is involutive. If $\mathcal U$ generates matrix
+    product unitaries, then so does $\mathcal U^\sharp$, and for every chain
+    length $N$,
+    \begin{align}
+        (\mathcal U^\sharp)^\sharp&=\mathcal U,
+        &(\mathcal U^\sharp)^{(N)}&=\bigl(\mathcal U^{(N)}\bigr)^\dagger.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu,def:mpdo_physical_adjoint}
+    Applying the physical adjoint twice conjugates every entry twice and
+    exchanges the physical indices twice. Closing a physical-adjoint tensor
+    exchanges the two physical configurations and conjugates the resulting
+    scalar. Hence its periodic operator is the conjugate transpose. The first
+    MPU unitarity equation for $U^{(N)}$ is therefore the second unitarity
+    equation for $(U^\sharp)^{(N)}$.
+\end{proof}
+
+\begin{theorem}[Output-first double-layer entry]
+    \label{thm:mpu_output_first_double_layer_entry}
+    \lean{MPOTensor.doubleLayerTensor_physicalAdjointTensor_apply}
+    \leanok
+    \uses{def:mpu_double_layer,def:mpdo_physical_adjoint}
+    Order the left doubled bond as $(\alpha,\gamma)$ and the right doubled
+    bond as $(\beta,\delta)$. Then the double layer whose lower tensor is
+    $\mathcal U^\sharp$ has entries
+    \begin{align}
+        \mathcal W(\mathcal U^\sharp)^{ik}_{(\alpha,\gamma),(\beta,\delta)}
+        &=\sum_j
+          \mathcal U^{ij}_{\alpha,\beta}\,
+          \overline{\mathcal U^{kj}_{\gamma,\delta}}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_double_layer,def:mpdo_physical_adjoint}
+    Expand the double layer and then apply the physical adjoint to its upper
+    factor. The two exchanges of physical indices leave the contracted index
+    $j$ in the second physical position of both factors. The product-index
+    convention keeps $(\alpha,\gamma)$ and $(\beta,\delta)$ in the displayed
+    order.
+\end{proof}
+
 \begin{definition}[Simple matrix product unitary tensor]
     \label{def:mpu_simple}
     \lean{MPOTensor.IsMPUSimple,
@@ -1496,6 +1547,31 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     $X_1^\dagger W_\rho X_1=\Id_r$. Since $X_2=V_2^\dagger$, the
     coisometry identity $V_2V_2^\dagger=\Id_\ell$ gives
     $X_2^\dagger X_2=\Id_\ell$.
+\end{proof}
+
+\begin{theorem}[Recovery of the right source factors]
+    \label{thm:mpu_source_factor_recovery}
+    \lean{MPOTensor.sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁,
+        MPOTensor.sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂}
+    \leanok
+    \uses{def:mpu_source_weight,def:mpu_weighted_source_factors,
+        def:mpu_source_matrix_one,def:mpu_source_matrix_two}
+    The right source factors are recovered from the two source matrices by
+    \begin{align}
+        Y_1&=X_1^\dagger W_\rho M_1,
+        &Y_2&=X_2^\dagger M_2.
+    \end{align}
+    Here $W_\rho=\rho\otimes I_d$ in the product-index order
+    $(\text{left virtual},\text{physical})$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_factorizations,
+        thm:mpu_source_factor_normalizations}
+    Multiply $M_1=X_1Y_1$ on the left by $X_1^\dagger W_\rho$ and use
+    $X_1^\dagger W_\rho X_1=I_r$. Similarly, multiply
+    $M_2=X_2Y_2$ on the left by $X_2^\dagger$ and use
+    $X_2^\dagger X_2=I_\ell$.
 \end{proof}
 
 \begin{theorem}[Right inverses of the source factors]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -224,7 +224,7 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpu,def:mpdo_physical_adjoint}
+    \uses{def:mpu,def:mpdo_physical_adjoint,lem:mpu_mul_adjoint}
     Applying the physical adjoint twice conjugates every entry twice and
     exchanges the physical indices twice. Closing a physical-adjoint tensor
     exchanges the two physical configurations and conjugates the resulting


### PR DESCRIPTION
## Summary

- prove physical-adjoint involution and preservation of the MPU property
- expose the audited output-first double-layer entry and periodic MPO conjugate-transpose identity
- recover the paper's weighted $Y_1$ and unweighted $Y_2$ factors from the source-cut normalizations
- synchronize Chapter 28 without asserting the still-separate source-$u$ Gram/isometry theorem

This is the source-faithful prerequisite requested by #5835. It deliberately does **not** claim that these identities alone prove `sourceUᴴ * sourceU = 1`.

## Verification

- `lake env lean TNLean/MPS/MPU/SourceUContraction.lean`
- targeted build of `TNLean.MPS.MPU.SourceUContraction` and `TNLean.MPS.MPU`
- generated import-aggregator check
- blueprint synchronization and reverse coverage (Chapter 28: 192/192)
- proof-integrity and `git diff --check` scans

Closes #5870

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Lean lemmas built from existing source-factor and physical-adjoint definitions; blueprint documentation only. No auth, runtime, or data-path changes.
> 
> **Overview**
> Adds **`TNLean/MPS/MPU/SourceUContraction.lean`** and wires it into the MPU import aggregator. The module proves the algebraic identities used *before* the finite-sum contraction in Cirac et al. Lemma `lemuisometry`: physical adjoint is an involution, preserves **IsMPU**, and satisfies **`mpo (physicalAdjointTensor U) N = (mpo U N)ᴴ`**; the output-first double-layer entry with bond order `(α,γ)` / `(β,δ)`; and recovery **`Y₁ = X₁ᴴ Wρ M₁`** and **`Y₂ = X₂ᴴ M₂`** from existing source-cut isometry identities.
> 
> Chapter 28 blueprint is synchronized with three new theorems (physical-adjoint identities, output-first double-layer entry, right source-factor recovery) without claiming **`sourceUᴴ * sourceU = 1`** or any isometry/rank conclusion—that remains separate work (#5835).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5789e3270cd439531def4428809d79125d7ca6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->