### PR TITLE
feat(MPS/MPU): expose source-u open-tail algebra

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -19,6 +19,7 @@ import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
 import TNLean.MPS.MPU.SourceUContraction
+import TNLean.MPS.MPU.SourceUOpenTail
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.ThreeFormSpan

--- a/TNLean/MPS/MPU/SourceUOpenTail.lean
+++ b/TNLean/MPS/MPU/SourceUOpenTail.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
+import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SourceUV
 
 /-!
@@ -102,8 +103,8 @@ theorem mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂
   intro β _
   ring
 
-/-- Pair-index wrapper for the open two-site factorization. The output pair is
-`q`, while `j` is the input pair. The name `p` remains reserved for the
+/-- Pair-index reformulation of the open two-site factorization. The output
+pair is `q`, while `j` is the input pair. The name `p` remains reserved for the
 retained output pair in the conjugated factor of a later Gram contraction.
 
 Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 526--537. -/
@@ -146,26 +147,11 @@ theorem mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord
       simp_rw [mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair U ρ hρ]
       simp only [Finset.sum_mul, mul_assoc]
 
-/-- The second source-cut factor $Y_2$ is reconstructed from the column
-isometry $X_2$ and the raw source-cut matrix.
-
-Source: arXiv:1703.09188, equations `Y2Y2X2X2` and `eq:sf-svd`, lines
-479--494. -/
-theorem sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂ :
-    sourceY₂ U = (sourceX₂ U)ᴴ * sourceCutM₂ U := by
-  calc
-    sourceY₂ U = (1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ) * sourceY₂ U := by simp
-    _ = ((sourceX₂ U)ᴴ * sourceX₂ U) * sourceY₂ U := by
-      rw [sourceX₂_isometry U]
-    _ = (sourceX₂ U)ᴴ * (sourceX₂ U * sourceY₂ U) := by
-      simp only [Matrix.mul_assoc]
-    _ = _ := by rw [← sourceCutM₂_eq_sourceX₂_mul_sourceY₂]
-
 /-- Entrywise reconstruction of $Y_2$ through $X_2^\dagger$ and one raw
 tensor letter.
 
-Source: arXiv:1703.09188, equations `Y2Y2X2X2` and `eq:sf-svd`, lines
-479--494. -/
+Source: arXiv:1703.09188, equations `Y1Y1X1X1`--`X1X2b` and
+`eq:sf-svd`, lines 479--526. -/
 theorem sourceY₂_eq_sum_star_sourceX₂_mul_apply
     (l : Fin ℓ[U]) (j : Fin d) (γ : Fin D) :
     sourceY₂ U l (j, γ) =

--- a/TNLean/MPS/MPU/SourceUOpenTail.lean
+++ b/TNLean/MPS/MPU/SourceUOpenTail.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinTupleEquiv
+import TNLean.MPS.MPU.SourceUV
+
+/-!
+# Open-tail expansions through the source tensor u
+
+This file develops the open-tail source-factor algebra used in the proof of
+`lemuisometry` from arXiv:1703.09188, lines 536--557. It factors an open
+periodic MPO through $X_1$, the source tensor $u$, and $X_2$, without closing
+the remaining virtual tail.
+
+The retained output pair is consistently denoted by `q`; the corresponding
+pair in a conjugated expression is denoted by `p`. Thus later contractions
+have the paper's order: the `q` term is unstarred and the `p` term is starred.
+
+**Scope boundary:** no result here collapses the sandwiched open tail, proves
+that `sourceU` is an isometry, or derives its rank bound. In particular, the
+proofs use only the valid identity $X_2^\dagger X_2=1$ and never assert the
+false ambient identity $X_2X_2^\dagger=1$.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- Entrywise weighted normalization of the first source-cut factor $X_1$.
+
+Source: arXiv:1703.09188, equation `Y1Y1X1X1`, lines 479--494. -/
+theorem sourceX₁_weighted_isometry_apply
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (r r' : Fin r[U]) :
+    (∑ y : Fin D × Fin d, ∑ x : Fin D × Fin d,
+      star (sourceX₁ U ρ hρ x r) * sourceWeight (d := d) ρ x y *
+        sourceX₁ U ρ hρ y r') = if r = r' then 1 else 0 := by
+  have h := congrArg (fun M ↦ M r r') (sourceX₁_weighted_isometry U ρ hρ)
+  simpa only [Matrix.mul_apply, Matrix.one_apply, Matrix.conjTranspose_apply,
+    Finset.sum_mul] using h
+
+/-- Contracting the right source leg of $X_1$ with $u$ leaves the open $X_2$
+leg of the first raw tensor letter.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 515--537. -/
+theorem sum_sourceX₁_mul_sourceU
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i₁ j₁ i₂ : Fin d) (α : Fin D) (l : Fin ℓ[U]) :
+    (∑ r : Fin r[U],
+      sourceX₁ U ρ hρ (α, j₁) r * sourceU U ρ hρ (l, r) (i₁, i₂)) =
+      ∑ β : Fin D, U i₁ j₁ α β * sourceX₂ U (β, i₂) l := by
+  classical
+  simp only [sourceU_apply, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro β _
+  calc
+    _ = (∑ r : Fin r[U], sourceX₁ U ρ hρ (α, j₁) r *
+          sourceY₁ U ρ hρ r (i₁, β)) * sourceX₂ U (β, i₂) l := by
+      rw [Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro r _
+      ring
+    _ = _ := by
+      rw [← Matrix.mul_apply, sourceX₁_mul_sourceY₁_apply]
+
+/-- The open two-site matrix product factors through $X_1$, $u$, and $Y_2$.
+
+Source: arXiv:1703.09188, equation `SVDforms2`, lines 526--530, and equation
+`uu`, lines 536--537. -/
+theorem mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (i₁ j₁ i₂ j₂ : Fin d) (α γ : Fin D) :
+    (U i₁ j₁ * U i₂ j₂) α γ =
+      ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+        sourceX₁ U ρ hρ (α, j₁) r * sourceU U ρ hρ (l, r) (i₁, i₂) *
+          sourceY₂ U l (j₂, γ) := by
+  classical
+  simp only [Matrix.mul_apply]
+  have h₁ (β : Fin D) : U i₁ j₁ α β =
+      ∑ r : Fin r[U], sourceX₁ U ρ hρ (α, j₁) r *
+        sourceY₁ U ρ hρ r (i₁, β) := by
+    simpa only [Matrix.mul_apply] using
+      (sourceX₁_mul_sourceY₁_apply U ρ hρ α j₁ i₁ β).symm
+  have h₂ (β : Fin D) : U i₂ j₂ β γ =
+      ∑ l : Fin ℓ[U], sourceX₂ U (β, i₂) l * sourceY₂ U l (j₂, γ) := by
+    simpa only [Matrix.mul_apply] using
+      (sourceX₂_mul_sourceY₂_apply U β i₂ j₂ γ).symm
+  simp_rw [h₁, h₂, Finset.sum_mul_sum]
+  simp_rw [sourceU_apply, Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro r _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro l _
+  apply Finset.sum_congr rfl
+  intro β _
+  ring
+
+/-- Pair-index wrapper for the open two-site factorization. The output pair is
+`q`, while `j` is the input pair. The name `p` remains reserved for the
+retained output pair in the conjugated factor of a later Gram contraction.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 526--537. -/
+theorem mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (q j : Fin d × Fin d) (α γ : Fin D) :
+    (U q.1 j.1 * U q.2 j.2) α γ =
+      ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+        sourceX₁ U ρ hρ (α, j.1) r * sourceU U ρ hρ (l, r) q *
+          sourceY₂ U l (j.2, γ) := by
+  exact mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂ U ρ hρ
+    q.1 j.1 q.2 j.2 α γ
+
+/-- An open periodic MPO, reindexed into its first two sites and tail, factors
+through $X_1$, $u$, $Y_2$, and the unevaluated virtual tail.
+
+The retained output pair is `q`; the pair `j` belongs to the input word.
+Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 515--537. -/
+theorem mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)
+    (q j : Fin d × Fin d) (τ ζ : Fin K → Fin d) :
+    mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ))
+        ((finAddTwoArrowEquiv (Fin d) K).symm (j, ζ)) =
+      ∑ α : Fin D, ∑ γ : Fin D, ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+        sourceX₁ U ρ hρ (α, j.1) r * sourceU U ρ hρ (l, r) q *
+          sourceY₂ U l (j.2, γ) * evalWord U (List.ofFn τ) (List.ofFn ζ) γ α := by
+  classical
+  simp only [finAddTwoArrowEquiv_symm_apply]
+  calc
+    _ = Matrix.trace ((U q.1 j.1 * U q.2 j.2) *
+        evalWord U (List.ofFn τ) (List.ofFn ζ)) := by
+      rw [mpo_apply, mpoMatrixEntry]
+      simp only [List.ofFn_succ, evalWord_cons, Fin.cons_zero, Fin.cons_succ]
+      rw [← Matrix.mul_assoc]
+    _ = ∑ α : Fin D, ∑ γ : Fin D,
+        (U q.1 j.1 * U q.2 j.2) α γ *
+          evalWord U (List.ofFn τ) (List.ofFn ζ) γ α := by
+      simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply]
+    _ = _ := by
+      simp_rw [mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair U ρ hρ]
+      simp only [Finset.sum_mul, mul_assoc]
+
+/-- The second source-cut factor $Y_2$ is reconstructed from the column
+isometry $X_2$ and the raw source-cut matrix.
+
+Source: arXiv:1703.09188, equations `Y2Y2X2X2` and `eq:sf-svd`, lines
+479--494. -/
+theorem sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂ :
+    sourceY₂ U = (sourceX₂ U)ᴴ * sourceCutM₂ U := by
+  calc
+    sourceY₂ U = (1 : Matrix (Fin ℓ[U]) (Fin ℓ[U]) ℂ) * sourceY₂ U := by simp
+    _ = ((sourceX₂ U)ᴴ * sourceX₂ U) * sourceY₂ U := by
+      rw [sourceX₂_isometry U]
+    _ = (sourceX₂ U)ᴴ * (sourceX₂ U * sourceY₂ U) := by
+      simp only [Matrix.mul_assoc]
+    _ = _ := by rw [← sourceCutM₂_eq_sourceX₂_mul_sourceY₂]
+
+/-- Entrywise reconstruction of $Y_2$ through $X_2^\dagger$ and one raw
+tensor letter.
+
+Source: arXiv:1703.09188, equations `Y2Y2X2X2` and `eq:sf-svd`, lines
+479--494. -/
+theorem sourceY₂_eq_sum_star_sourceX₂_mul_apply
+    (l : Fin ℓ[U]) (j : Fin d) (γ : Fin D) :
+    sourceY₂ U l (j, γ) =
+      ∑ β : Fin D, ∑ i : Fin d, star (sourceX₂ U (β, i) l) * U i j β γ := by
+  have h := congrArg (fun M ↦ M l (j, γ))
+    (sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂ U)
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply] at h
+  rw [Fintype.sum_prod_type] at h
+  exact h
+
+/-- The fully reconstructed open periodic MPO expansion through $X_1$, $u$,
+$X_2$, and the open $K$-site virtual tail.
+
+There is no normalization factor in this algebraic expansion. The unique
+factor $d^{-K}$ enters only when the future normalized output-tail contraction
+is formed.
+
+Source: arXiv:1703.09188, equations `SVDforms2` and `uUnitary`, lines
+515--554. -/
+theorem mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)
+    (q j : Fin d × Fin d) (τ ζ : Fin K → Fin d) :
+    mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ))
+        ((finAddTwoArrowEquiv (Fin d) K).symm (j, ζ)) =
+      ∑ α : Fin D, ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+        ∑ β : Fin D, ∑ i : Fin d,
+          sourceX₁ U ρ hρ (α, j.1) r * sourceU U ρ hρ (l, r) q *
+            star (sourceX₂ U (β, i) l) *
+              (U i j.2 * evalWord U (List.ofFn τ) (List.ofFn ζ)) β α := by
+  classical
+  rw [mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord U ρ hρ K q j τ ζ]
+  simp_rw [sourceY₂_eq_sum_star_sourceX₂_mul_apply U]
+  simp only [Finset.mul_sum, Finset.sum_mul, Matrix.mul_apply, mul_assoc]
+  apply Finset.sum_congr rfl
+  intro α _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro r _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro l _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro β _
+  rw [Finset.sum_comm]
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceUOpenTail.lean
+++ b/TNLean/MPS/MPU/SourceUOpenTail.lean
@@ -147,21 +147,6 @@ theorem mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord
       simp_rw [mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair U ρ hρ]
       simp only [Finset.sum_mul, mul_assoc]
 
-/-- Entrywise reconstruction of $Y_2$ through $X_2^\dagger$ and one raw
-tensor letter.
-
-Source: arXiv:1703.09188, equations `Y1Y1X1X1`--`X1X2b` and
-`eq:sf-svd`, lines 479--526. -/
-theorem sourceY₂_eq_sum_star_sourceX₂_mul_apply
-    (l : Fin ℓ[U]) (j : Fin d) (γ : Fin D) :
-    sourceY₂ U l (j, γ) =
-      ∑ β : Fin D, ∑ i : Fin d, star (sourceX₂ U (β, i) l) * U i j β γ := by
-  have h := congrArg (fun M ↦ M l (j, γ))
-    (sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂ U)
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply] at h
-  rw [Fintype.sum_prod_type] at h
-  exact h
-
 /-- The fully reconstructed open periodic MPO expansion through $X_1$, $u$,
 $X_2$, and the open $K$-site virtual tail.
 
@@ -182,8 +167,16 @@ theorem mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail
             star (sourceX₂ U (β, i) l) *
               (U i j.2 * evalWord U (List.ofFn τ) (List.ofFn ζ)) β α := by
   classical
+  have sourceY₂_apply (l : Fin ℓ[U]) (j : Fin d) (γ : Fin D) :
+      sourceY₂ U l (j, γ) =
+        ∑ β : Fin D, ∑ i : Fin d, star (sourceX₂ U (β, i) l) * U i j β γ := by
+    have h := congrArg (fun M ↦ M l (j, γ))
+      (sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂ U)
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply] at h
+    rw [Fintype.sum_prod_type] at h
+    exact h
   rw [mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord U ρ hρ K q j τ ζ]
-  simp_rw [sourceY₂_eq_sum_star_sourceX₂_mul_apply U]
+  simp_rw [sourceY₂_apply]
   simp only [Finset.mul_sum, Finset.sum_mul, Matrix.mul_apply, mul_assoc]
   apply Finset.sum_congr rfl
   intro α _

--- a/TNLean/MPS/MPU/SourceUOpenTail.lean
+++ b/TNLean/MPS/MPU/SourceUOpenTail.lean
@@ -17,7 +17,7 @@ the remaining virtual tail.
 
 The retained output pair is consistently denoted by \(q\); the corresponding
 pair in a conjugated expression is denoted by \(p\). Thus later contractions
-have the paper's order: the `q` term is unstarred and the `p` term is starred.
+have the paper's order: the \(q\) term is unstarred and the \(p\) term is starred.
 
 **Scope boundary:** no result here collapses the sandwiched open tail, proves
 that `sourceU` is an isometry, or derives its rank bound. In particular, the

--- a/TNLean/MPS/MPU/SourceUOpenTail.lean
+++ b/TNLean/MPS/MPU/SourceUOpenTail.lean
@@ -15,8 +15,8 @@ This file develops the open-tail source-factor algebra used in the proof of
 periodic MPO through $X_1$, the source tensor $u$, and $X_2$, without closing
 the remaining virtual tail.
 
-The retained output pair is consistently denoted by `q`; the corresponding
-pair in a conjugated expression is denoted by `p`. Thus later contractions
+The retained output pair is consistently denoted by \(q\); the corresponding
+pair in a conjugated expression is denoted by \(p\). Thus later contractions
 have the paper's order: the `q` term is unstarred and the `p` term is starred.
 
 **Scope boundary:** no result here collapses the sandwiched open tail, proves
@@ -104,7 +104,7 @@ theorem mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂
   ring
 
 /-- Pair-index reformulation of the open two-site factorization. The output
-pair is `q`, while `j` is the input pair. The name `p` remains reserved for the
+pair is \(q\), while \(j\) is the input pair. The name \(p\) remains reserved for the
 retained output pair in the conjugated factor of a later Gram contraction.
 
 Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 526--537. -/
@@ -121,7 +121,7 @@ theorem mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair
 /-- An open periodic MPO, reindexed into its first two sites and tail, factors
 through $X_1$, $u$, $Y_2$, and the unevaluated virtual tail.
 
-The retained output pair is `q`; the pair `j` belongs to the input word.
+The retained output pair is \(q\); the pair \(j\) belongs to the input word.
 Source: arXiv:1703.09188, equations `SVDforms2` and `uu`, lines 515--537. -/
 theorem mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)

--- a/TNLean/MPS/MPU/SourceUOpenTail.lean
+++ b/TNLean/MPS/MPU/SourceUOpenTail.lean
@@ -167,7 +167,7 @@ theorem mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail
             star (sourceX₂ U (β, i) l) *
               (U i j.2 * evalWord U (List.ofFn τ) (List.ofFn ζ)) β α := by
   classical
-  have sourceY₂_apply (l : Fin ℓ[U]) (j : Fin d) (γ : Fin D) :
+  have hY₂ (l : Fin ℓ[U]) (j : Fin d) (γ : Fin D) :
       sourceY₂ U l (j, γ) =
         ∑ β : Fin D, ∑ i : Fin d, star (sourceX₂ U (β, i) l) * U i j β γ := by
     have h := congrArg (fun M ↦ M l (j, γ))
@@ -176,7 +176,7 @@ theorem mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail
     rw [Fintype.sum_prod_type] at h
     exact h
   rw [mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord U ρ hρ K q j τ ζ]
-  simp_rw [sourceY₂_apply]
+  simp_rw [hY₂]
   simp only [Finset.mul_sum, Finset.sum_mul, Matrix.mul_apply, mul_assoc]
   apply Finset.sum_congr rfl
   intro α _

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1671,7 +1671,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.sourceX₁_weighted_isometry_apply,
         MPOTensor.sourceY₂_eq_sum_star_sourceX₂_mul_apply}
     \leanok
-    \uses{thm:mpu_source_factorizations,
+    \uses{thm:mpu_source_factor_recovery,
         thm:mpu_source_factor_normalizations}
     The weighted normalization of $X_1$ has entries
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1669,7 +1669,6 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{theorem}[Entrywise source-factor reconstructions]
     \label{thm:mpu_source_open_factor_reconstructions}
     \lean{MPOTensor.sourceX₁_weighted_isometry_apply,
-        MPOTensor.sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂,
         MPOTensor.sourceY₂_eq_sum_star_sourceX₂_mul_apply}
     \leanok
     \uses{thm:mpu_source_factorizations,
@@ -1679,10 +1678,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         \sum_{x,y}\overline{(X_1)_{x,r}}(W_\rho)_{x,y}(X_1)_{y,r'}
         &=\delta_{r,r'}.
     \end{align}
-    Moreover, the second right factor can be reconstructed without closing
-    its ambient source space:
+    Applying the preceding reconstruction of the second right factor gives
+    the entry identity
     \begin{align}
-        Y_2&=X_2^\dagger M_2,\\
         (Y_2)_{l,(j,\gamma)}
           &=\sum_{\beta,i}\overline{(X_2)_{(\beta,i),l}}
               \mathcal U^i_{j,\beta,\gamma}.
@@ -1692,9 +1690,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}\leanok
     \uses{thm:mpu_source_factor_normalizations,
         thm:mpu_source_factor_recovery}
-    Evaluate $X_1^\dagger W_\rho X_1=\Id_r$ entrywise.  For the second
-    identity, insert $X_2^\dagger X_2=\Id_\ell$ to the left of $Y_2$ and use
-    $M_2=X_2Y_2$.  Evaluation at $(l,(j,\gamma))$ gives the finite sum.
+    Evaluate $X_1^\dagger W_\rho X_1=\Id_r$ entrywise.  Apply the preceding
+    recovery identity $Y_2=X_2^\dagger M_2$ and evaluate it at
+    $(l,(j,\gamma))$ to obtain the finite sum.
 \end{proof}
 
 \begin{theorem}[Open two-site source factorization]
@@ -1731,7 +1729,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord,
         MPOTensor.mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail}
     \leanok
-    \uses{thm:mpu_source_u_open_two_site,
+    \uses{def:mpo_family,thm:mpu_source_u_open_two_site,
         thm:mpu_source_open_factor_reconstructions}
     Separate the first two physical sites of a length-$(K+2)$ configuration.
     For an output pair $q$, an input pair $j$, and tails $\tau,\zeta$, the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1693,10 +1693,19 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}\leanok
     \uses{def:mpu_source_uv,thm:mpu_source_factorization_entries}
-    Substitute the definition of $u$.  The first source-cut factorization
-    contracts $X_1Y_1$ to the first raw tensor letter.  Expanding the second
-    raw letter as $X_2Y_2$ then gives the untraced two-site identity, with its
-    left and right virtual indices left open.
+    Use the three identities
+    \begin{align}
+      u_{(l,r),q}
+        &=\sum_\beta (Y_1)_{r,(q_1,\beta)}
+            (X_2)_{(\beta,q_2),l},\\
+      (X_1Y_1)_{(\alpha,j_1),(q_1,\beta)}
+        &=\mathcal U^{q_1}_{j_1,\alpha,\beta},\\
+      (X_2Y_2)_{(\beta,q_2),(j_2,\gamma)}
+        &=\mathcal U^{q_2}_{j_2,\beta,\gamma}.
+    \end{align}
+    Substitution and reordering of the scalar finite sums give the displayed
+    partial contraction and the untraced two-site identity, with the virtual
+    indices $\alpha$ and $\gamma$ left open.
 \end{proof}
 
 \begin{theorem}[Open periodic-tail source expansion]
@@ -1731,11 +1740,25 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}\leanok
     \uses{thm:mpu_source_u_open_two_site,
         thm:mpu_source_factor_recovery}
-    Reindex each configuration into its first two coordinates and its tail,
-    apply the open two-site factorization inside the periodic trace, and leave
-    the remaining virtual word unevaluated.  Substitute the entrywise
-    reconstruction of $Y_2$ and combine its raw tensor letter with that word
-    by ordinary matrix multiplication.
+    Reindexing each configuration into its first two coordinates and its tail
+    gives
+    \begin{align}
+      U^{(K+2)}_{(q,\tau),(j,\zeta)}
+        &=\tr\!\left[
+          (\mathcal U^{q_1j_1}\mathcal U^{q_2j_2})
+          T_{\tau,\zeta}\right].
+    \end{align}
+    Insert the open two-site factorization from the preceding theorem.  The
+    recovery identity and its entrywise evaluation are
+    \begin{align}
+      Y_2&=X_2^\dagger M_2,\\
+      (Y_2)_{l,(j_2,\gamma)}
+        &=\sum_{\beta,i}\overline{(X_2)_{(\beta,i),l}}
+          \mathcal U^i_{j_2,\beta,\gamma}.
+    \end{align}
+    Substitution combines the last raw tensor letter with
+    $T_{\tau,\zeta}$ by matrix multiplication and gives the second displayed
+    expansion.
 \end{proof}
 
 \begin{remark}[Scope of the open-tail algebra]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1665,6 +1665,111 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     $(r,l)$ to $(l,r)$ gives the matrix identity.
 \end{proof}
 
+
+\begin{theorem}[Entrywise source-factor reconstructions]
+    \label{thm:mpu_source_open_factor_reconstructions}
+    \lean{MPOTensor.sourceX₁_weighted_isometry_apply,
+        MPOTensor.sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂,
+        MPOTensor.sourceY₂_eq_sum_star_sourceX₂_mul_apply}
+    \leanok
+    \uses{thm:mpu_source_factorizations,
+        thm:mpu_source_factor_normalizations}
+    The weighted normalization of $X_1$ has entries
+    \begin{align}
+        \sum_{x,y}\overline{(X_1)_{x,r}}(W_\rho)_{x,y}(X_1)_{y,r'}
+        &=\delta_{r,r'}.
+    \end{align}
+    Moreover, the second right factor can be reconstructed without closing
+    its ambient source space:
+    \begin{align}
+        Y_2&=X_2^\dagger M_2,\\
+        (Y_2)_{l,(j,\gamma)}
+          &=\sum_{\beta,i}\overline{(X_2)_{(\beta,i),l}}
+              \mathcal U^i_{j,\beta,\gamma}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Evaluate $X_1^\dagger W_\rho X_1=\Id_r$ entrywise.  For the second
+    identity, insert $X_2^\dagger X_2=\Id_\ell$ to the left of $Y_2$ and use
+    $M_2=X_2Y_2$.  Evaluation at $(l,(j,\gamma))$ gives the finite sum.
+\end{proof}
+
+\begin{theorem}[Open two-site source factorization]
+    \label{thm:mpu_source_u_open_two_site}
+    \lean{MPOTensor.sum_sourceX₁_mul_sourceU,
+        MPOTensor.mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂,
+        MPOTensor.mul_apply_eq_sum_sourceX₁_mul_sourceU_mul_sourceY₂_pair}
+    \leanok
+    \uses{def:mpu_source_uv,thm:mpu_source_factorization_entries}
+    For $q=(q_1,q_2)$ and $j=(j_1,j_2)$, the untraced two-site product is
+    \begin{align}
+        (\mathcal U^{q_1j_1}\mathcal U^{q_2j_2})_{\alpha,\gamma}
+        =\sum_{r,l}(X_1)_{(\alpha,j_1),r}
+          u_{(l,r),q}(Y_2)_{l,(j_2,\gamma)}.
+    \end{align}
+    The intermediate partial contraction is
+    \begin{align}
+        \sum_r (X_1)_{(\alpha,j_1),r}u_{(l,r),(q_1,q_2)}
+        =\sum_\beta \mathcal U^{q_1}_{j_1,\alpha,\beta}
+          (X_2)_{(\beta,q_2),l}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Substitute the definition of $u$.  The first source-cut factorization
+    contracts $X_1Y_1$ to the first raw tensor letter.  Expanding the second
+    raw letter as $X_2Y_2$ then gives the untraced two-site identity, with its
+    left and right virtual indices left open.
+\end{proof}
+
+\begin{theorem}[Open periodic-tail source expansion]
+    \label{thm:mpu_source_u_open_periodic_tail}
+    \lean{MPOTensor.mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceY₂_evalWord,
+        MPOTensor.mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail}
+    \leanok
+    \uses{thm:mpu_source_u_open_two_site,
+        thm:mpu_source_open_factor_reconstructions}
+    Separate the first two physical sites of a length-$(K+2)$ configuration.
+    For an output pair $q$, an input pair $j$, and tails $\tau,\zeta$, the
+    periodic entry first expands as
+    \begin{align}
+      U^{(K+2)}_{(q,\tau),(j,\zeta)}
+      =\sum_{\alpha,\gamma,r,l}
+        &(X_1)_{(\alpha,j_1),r}u_{(l,r),q}
+        (Y_2)_{l,(j_2,\gamma)}
+        (T_{\tau,\zeta})_{\gamma,\alpha},
+    \end{align}
+    where $T_{\tau,\zeta}$ is the open $K$-site virtual word.  Reconstructing
+    $Y_2$ gives
+    \begin{align}
+      U^{(K+2)}_{(q,\tau),(j,\zeta)}
+      =\sum_{\alpha,r,l,\beta,i}
+        &(X_1)_{(\alpha,j_1),r}u_{(l,r),q}
+        \overline{(X_2)_{(\beta,i),l}}
+        (\mathcal U^{ij_2}T_{\tau,\zeta})_{\beta,\alpha}.
+    \end{align}
+    No power of $d$ occurs in either algebraic expansion.
+\end{theorem}
+
+\begin{proof}\leanok
+    Reindex each configuration into its first two coordinates and its tail,
+    apply the open two-site factorization inside the periodic trace, and leave
+    the remaining virtual word unevaluated.  Substitute the entrywise
+    reconstruction of $Y_2$ and combine its raw tensor letter with that word
+    by ordinary matrix multiplication.
+\end{proof}
+
+\begin{remark}[Scope of the open-tail algebra]
+    The preceding theorem does not collapse the open virtual tail.  In
+    particular, it proves neither $u^\dagger u=\Id$ nor a rank bound for $u$,
+    and it does not use the false ambient equation $X_2X_2^\dagger=\Id$.
+    The remaining contraction must retain the surrounding $X_1$ and $X_2$
+    factors.  In the eventual Gram contraction the retained pair $q$ is
+    unstarred and the retained pair $p$ is starred, with exactly one factor
+    $d^{-K}$ supplied by the normalized periodic tail.
+\end{remark}
+
 \begin{theorem}[Right-rank bound]
     \label{thm:mpu_right_rank_bound}
     \lean{MPOTensor.rightRank_bound}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1529,13 +1529,16 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{theorem}[Source-factor normalizations]
     \label{thm:mpu_source_factor_normalizations}
     \lean{MPOTensor.sourceX₁_weighted_isometry,
+        MPOTensor.sourceX₁_weighted_isometry_apply,
         MPOTensor.sourceX₂_isometry}
     \leanok
     \uses{def:mpu_weighted_source_factors,def:mpu_source_weight}
     The left factors satisfy
     \begin{align}
         X_1^\dagger W_\rho X_1&=\Id_r,
-        &X_2^\dagger X_2&=\Id_\ell.
+        &X_2^\dagger X_2&=\Id_\ell,\\
+        \sum_{x,y}\overline{(X_1)_{x,r}}(W_\rho)_{x,y}(X_1)_{y,r'}
+          &=\delta_{r,r'}.
     \end{align}
     These are \cite[Section~III]{Cirac2017MPU}.
 \end{theorem}
@@ -1544,7 +1547,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \leanok
     \uses{def:mpu_weighted_source_factors,def:mpu_source_svd_data}
     The source-factor construction supplies
-    $X_1^\dagger W_\rho X_1=\Id_r$. Since $X_2=V_2^\dagger$, the
+    $X_1^\dagger W_\rho X_1=\Id_r$; evaluating at $(r,r')$ gives the displayed
+    weighted sum. Since $X_2=V_2^\dagger$, the
     coisometry identity $V_2V_2^\dagger=\Id_\ell$ gives
     $X_2^\dagger X_2=\Id_\ell$.
 \end{proof}
@@ -1666,35 +1670,6 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{proof}
 
 
-\begin{theorem}[Entrywise source-factor reconstructions]
-    \label{thm:mpu_source_open_factor_reconstructions}
-    \lean{MPOTensor.sourceX₁_weighted_isometry_apply,
-        MPOTensor.sourceY₂_eq_sum_star_sourceX₂_mul_apply}
-    \leanok
-    \uses{thm:mpu_source_factor_recovery,
-        thm:mpu_source_factor_normalizations}
-    The weighted normalization of $X_1$ has entries
-    \begin{align}
-        \sum_{x,y}\overline{(X_1)_{x,r}}(W_\rho)_{x,y}(X_1)_{y,r'}
-        &=\delta_{r,r'}.
-    \end{align}
-    Applying the preceding reconstruction of the second right factor gives
-    the entry identity
-    \begin{align}
-        (Y_2)_{l,(j,\gamma)}
-          &=\sum_{\beta,i}\overline{(X_2)_{(\beta,i),l}}
-              \mathcal U^i_{j,\beta,\gamma}.
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:mpu_source_factor_normalizations,
-        thm:mpu_source_factor_recovery}
-    Evaluate $X_1^\dagger W_\rho X_1=\Id_r$ entrywise.  Apply the preceding
-    recovery identity $Y_2=X_2^\dagger M_2$ and evaluate it at
-    $(l,(j,\gamma))$ to obtain the finite sum.
-\end{proof}
-
 \begin{theorem}[Open two-site source factorization]
     \label{thm:mpu_source_u_open_two_site}
     \lean{MPOTensor.sum_sourceX₁_mul_sourceU,
@@ -1730,7 +1705,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail}
     \leanok
     \uses{def:mpo_family,thm:mpu_source_u_open_two_site,
-        thm:mpu_source_open_factor_reconstructions}
+        thm:mpu_source_factor_recovery}
     Separate the first two physical sites of a length-$(K+2)$ configuration.
     For an output pair $q$, an input pair $j$, and tails $\tau,\zeta$, the
     periodic entry first expands as
@@ -1755,7 +1730,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}\leanok
     \uses{thm:mpu_source_u_open_two_site,
-        thm:mpu_source_open_factor_reconstructions}
+        thm:mpu_source_factor_recovery}
     Reindex each configuration into its first two coordinates and its tail,
     apply the open two-site factorization inside the periodic trace, and leave
     the remaining virtual word unevaluated.  Substitute the entrywise

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1690,6 +1690,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_source_factor_normalizations,
+        thm:mpu_source_factor_recovery}
     Evaluate $X_1^\dagger W_\rho X_1=\Id_r$ entrywise.  For the second
     identity, insert $X_2^\dagger X_2=\Id_\ell$ to the left of $Y_2$ and use
     $M_2=X_2Y_2$.  Evaluation at $(l,(j,\gamma))$ gives the finite sum.
@@ -1717,6 +1719,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpu_source_uv,thm:mpu_source_factorization_entries}
     Substitute the definition of $u$.  The first source-cut factorization
     contracts $X_1Y_1$ to the first raw tensor letter.  Expanding the second
     raw letter as $X_2Y_2$ then gives the untraced two-site identity, with its
@@ -1753,6 +1756,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_source_u_open_two_site,
+        thm:mpu_source_open_factor_reconstructions}
     Reindex each configuration into its first two coordinates and its tail,
     apply the open two-site factorization inside the periodic trace, and leave
     the remaining virtual word unevaluated.  Substitute the entrywise


### PR DESCRIPTION
## Summary

- expose weighted $X_1$ normalization entries and the partial $X_1$–$u$–$X_2$ contraction
- derive scalar and pair-indexed open two-site factorizations and the exact periodic-tail expansion
- reconstruct $Y_2=X_2^\dagger M_2$ and expand the full open $K$-site tail through $X_1,u,X_2$
- synchronize Chapter 28 while keeping the sandwiched-tail collapse and source-$u$ isometry separate

The retained output pair stays unstarred and the conjugated pair stays starred, matching the paper's contraction order. The proofs use $X_2^\dagger X_2=1$ only; they do not assert the false ambient identity $X_2X_2^\dagger=1$.

## Verification

- direct Lean check of `TNLean/MPS/MPU/SourceUOpenTail.lean`
- targeted builds of `TNLean.MPS.MPU.SourceUOpenTail` and `TNLean.MPS.MPU`
- generated import validation
- blueprint synchronization and reverse coverage (Chapter 28: 200/200)
- proof-integrity, scope, and `git diff --check` scans

Closes #5890

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation of existing MPU source-factor theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TNLean/MPS/MPU/SourceUOpenTail.lean`** and wires it into the MPU import graph, formalizing open-tail expansions through the source tensor \(u\) for the `lemuisometry` line of the Cirac et al. proof—without closing the virtual tail or claiming \(u\) is an isometry.
> 
> The new lemmas include an **entrywise** weighted \(X_1\) normalization (`sourceX₁_weighted_isometry_apply`), partial \(X_1\)–\(u\)–\(X_2\) contraction, scalar and pair-indexed **open two-site** factorizations, and periodic MPO entries expanded through \(X_1\), \(u\), \(Y_2\) or reconstructed \(X_2\) on an open \(K\)-site tail (explicitly **no** \(d^{-K}\) in these algebraic identities).
> 
> **Chapter 28** (`ch28_mpu.tex`) is synchronized: source-factor normalization cites the apply lemma, plus new theorems for open two-site factorization, open periodic-tail expansion, and a remark on scope (no tail collapse, \(q\) unstarred / \(p\) starred, only \(X_2^\dagger X_2 = 1\)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c71d28bc69229d7d7e552cb013728b4570330c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->