### PR TITLE
feat(ParentHamiltonian): compute spectator boundary Grams

### DIFF
--- a/TNLean/Analysis/InjectiveRangeProjector.lean
+++ b/TNLean/Analysis/InjectiveRangeProjector.lean
@@ -117,4 +117,56 @@ theorem injectiveRangeProjector_eq_starProjection (T : E →L[𝕜] F)
       rfl
     rw [hGram, sub_self]
 
+/-- Exact residual identity for three injective maps with a common factorization.
+If `C = T ∘ J₁ = L ∘ J₂`, the difference of the range projectors of `T` and `L`,
+after composition, factors through the mixed-Gram residual
+\[
+  T^†L-(T^†T)J₁(C^†C)^{-1}J₂^†(L^†L).
+\]
+This identity is purely algebraic and does not assert a norm bound. -/
+theorem injectiveRangeProjector_comp_sub_of_factorizations
+    {G H : Type*}
+    [NormedAddCommGroup G] [InnerProductSpace 𝕜 G] [FiniteDimensional 𝕜 G]
+      [CompleteSpace G]
+    [NormedAddCommGroup H] [InnerProductSpace 𝕜 H] [FiniteDimensional 𝕜 H]
+      [CompleteSpace H]
+    (T : E →L[𝕜] F) (L : G →L[𝕜] F) (C : H →L[𝕜] F)
+    (J₁ : H →L[𝕜] E) (J₂ : H →L[𝕜] G)
+    (hT : Function.Injective T) (hL : Function.Injective L)
+    (hC : Function.Injective C)
+    (hTC : T.comp J₁ = C) (hLC : L.comp J₂ = C) :
+    (injectiveRangeProjector T hT).comp (injectiveRangeProjector L hL) -
+        injectiveRangeProjector C hC =
+      T.comp ((inverseGram T hT).comp
+        ((T.adjoint.comp L -
+          (T.adjoint.comp T).comp (J₁.comp ((inverseGram C hC).comp
+            (J₂.adjoint.comp (L.adjoint.comp L))))).comp
+          ((inverseGram L hL).comp L.adjoint))) := by
+  have hLCadj : J₂.adjoint.comp L.adjoint = C.adjoint := by
+    rw [← ContinuousLinearMap.adjoint_comp, hLC]
+  have hTGram (x : E) :
+      inverseGram T hT (T.adjoint (T x)) = x := by
+    exact congrArg (fun Q : E →L[𝕜] E => Q x)
+      (inverseGram_comp_adjoint_comp_self T hT)
+  have hLGram (x : G) :
+      L.adjoint (L (inverseGram L hL x)) = x := by
+    exact congrArg (fun Q : G →L[𝕜] G => Q x)
+      (adjoint_comp_self_comp_inverseGram L hL)
+  have hsecond :
+      T.comp ((inverseGram T hT).comp
+        (((T.adjoint.comp T).comp (J₁.comp ((inverseGram C hC).comp
+          (J₂.adjoint.comp (L.adjoint.comp L))))).comp
+            ((inverseGram L hL).comp L.adjoint))) =
+        C.comp ((inverseGram C hC).comp C.adjoint) := by
+    ext x
+    simp only [comp_apply, hTGram, hLGram]
+    rw [show J₂.adjoint (L.adjoint x) = C.adjoint x by
+      exact congrArg (fun Q : F →L[𝕜] H => Q x) hLCadj]
+    exact congrArg (fun Q : H →L[𝕜] F =>
+      Q (inverseGram C hC (C.adjoint x))) hTC
+  rw [injectiveRangeProjector, injectiveRangeProjector, injectiveRangeProjector]
+  simp only [comp_sub, sub_comp]
+  rw [hsecond]
+  simp only [comp_assoc]
+
 end ContinuousLinearMap

--- a/TNLean/Analysis/InjectiveRangeProjector.lean
+++ b/TNLean/Analysis/InjectiveRangeProjector.lean
@@ -69,8 +69,8 @@ theorem inverseGram_eq_ringInverse (T : E →L[𝕜] F) (hT : Function.Injective
   rw [ContinuousLinearMap.ringInverse_eq_inverse]
   exact inverseGram_eq_inverse T hT
 
-/-- If the Gram operator is within norm `a < 1` of the identity, then its inverse
-has norm at most `(1 - a)⁻¹`. The denominator is the Neumann inverse bound. -/
+/-- If the Gram operator is within norm \(a<1\) of the identity, then its inverse
+has norm at most \((1-a)^{-1}\). The denominator is the Neumann inverse bound. -/
 theorem norm_inverseGram_le_of_norm_one_sub_adjoint_comp_self_le
     (T : E →L[𝕜] F) (hT : Function.Injective T) {a : ℝ}
     (ha : ‖1 - T.adjoint.comp T‖ ≤ a) (ha_lt_one : a < 1) :
@@ -118,7 +118,7 @@ theorem injectiveRangeProjector_eq_starProjection (T : E →L[𝕜] F)
     rw [hGram, sub_self]
 
 /-- Exact residual identity for three injective maps with a common factorization.
-If `C = T ∘ J₁ = L ∘ J₂`, the difference of the range projectors of `T` and `L`,
+If \(C=T\circ J₁=L\circ J₂\), the difference of the range projectors of \(T\) and \(L\),
 after composition, factors through the mixed-Gram residual
 \[
   T^†L-(T^†T)J₁(C^†C)^{-1}J₂^†(L^†L).

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -62,6 +62,7 @@ import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
 import TNLean.MPS.ParentHamiltonian.SpectatorBoundary
+import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.TripartiteDecorrelation
 import TNLean.MPS.ParentHamiltonian.UniqueGroundState

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
@@ -13,6 +13,18 @@ This file realizes the spectator-indexed boundary maps in finite-dimensional
 unweighted Frobenius/Euclidean coordinates. It records their physical ranges,
 the exact virtual factorizations of the ordinary MPS boundary map, injectivity,
 and the fiberwise Gram identities. No contraction estimate is asserted.
+
+## Main definitions
+
+* `tailBoundaryMapES` and `leftBoundaryMapES` are the Euclidean spectator maps.
+* `tailVirtualMapES` and `leftVirtualMapES` are their virtual common-factorization maps.
+* `boundaryFiberwiseMap` applies a virtual endomorphism independently on every fiber.
+
+## Main results
+
+* `range_tailBoundaryMapES` and `range_leftBoundaryMapES_one` identify the physical ranges.
+* `c3_injectiveRangeProjector_residual_eq` is the exact C3 common-factorization identity.
+* The tail and left Gram and inverse-Gram theorems identify their fiberwise actions.
 -/
 
 open scoped Matrix
@@ -49,6 +61,7 @@ noncomputable def boundaryFamilyEquiv (S : Type*) [Fintype S] :
     ext s a b
     simp
 
+/-- Evaluation of `boundaryFamilyEquiv` at one family index. -/
 @[simp]
 theorem boundaryFamilyEquiv_apply_apply (S : Type*) [Fintype S]
     (x : BoundaryFamilySpace (D := D) S) (s : S) :
@@ -70,6 +83,7 @@ noncomputable def leftBoundaryMapES (A : MPSTensor d D) (K L : ℕ) :
     (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm.toLinearMap.comp
       ((leftBoundaryMap A K L).comp (boundaryFamilyEquiv (D := D) (Cfg d L)).toLinearMap)
 
+/-- Evaluation of the Euclidean tail boundary map in the underlying site-space coordinates. -/
 @[simp]
 theorem tailBoundaryMapES_apply (A : MPSTensor d D) (K L : ℕ)
     (x : BoundaryFamilySpace (D := D) (Cfg d K)) :
@@ -77,6 +91,7 @@ theorem tailBoundaryMapES_apply (A : MPSTensor d D) (K L : ℕ)
       (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm
         (tailBoundaryMap A K L (boundaryFamilyEquiv (D := D) (Cfg d K) x)) := rfl
 
+/-- Evaluation of the Euclidean left boundary map in the underlying site-space coordinates. -/
 @[simp]
 theorem leftBoundaryMapES_apply (A : MPSTensor d D) (K L : ℕ)
     (x : BoundaryFamilySpace (D := D) (Cfg d L)) :
@@ -111,8 +126,8 @@ theorem range_leftBoundaryMapES_one (A : MPSTensor d D) (K : ℕ) :
 
 /-! ### Virtual factorizations -/
 
-/-- The virtual tail family before flattening, with fibers \(X * evalWord A u\). -/
-noncomputable def tailVirtualFamilyMap (A : MPSTensor d D) (K : ℕ) :
+/-- The virtual tail family before flattening, with fibers \(X A^u\). -/
+private noncomputable def tailVirtualFamilyMap (A : MPSTensor d D) (K : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →ₗ[ℂ]
       (Cfg d K → Matrix (Fin D) (Fin D) ℂ) where
   toFun x u := (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm x *
@@ -124,7 +139,7 @@ noncomputable def tailVirtualFamilyMap (A : MPSTensor d D) (K : ℕ) :
     funext u
     simp only [map_smul, RingHom.id_apply, Pi.smul_apply, Matrix.smul_mul]
 
-/-- The virtual tail map with fibers \(X * evalWord A u\). -/
+/-- The virtual tail map with fibers \(X A^u\). -/
 noncomputable def tailVirtualMapES (A : MPSTensor d D) (K : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
       BoundaryFamilySpace (D := D) (Cfg d K) :=
@@ -132,8 +147,8 @@ noncomputable def tailVirtualMapES (A : MPSTensor d D) (K : ℕ) :
     (boundaryFamilyEquiv (D := D) (Cfg d K)).symm.toLinearMap.comp
       (tailVirtualFamilyMap A K)
 
-/-- The virtual left family before flattening, with fibers \(evalWord A τ * X\). -/
-noncomputable def leftVirtualFamilyMap (A : MPSTensor d D) (L : ℕ) :
+/-- The virtual left family before flattening, with fibers \(A^\tau X\). -/
+private noncomputable def leftVirtualFamilyMap (A : MPSTensor d D) (L : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →ₗ[ℂ]
       (Cfg d L → Matrix (Fin D) (Fin D) ℂ) where
   toFun x τ := evalWord A (List.ofFn τ) *
@@ -145,7 +160,7 @@ noncomputable def leftVirtualFamilyMap (A : MPSTensor d D) (L : ℕ) :
     funext τ
     simp only [map_smul, RingHom.id_apply, Pi.smul_apply, Matrix.mul_smul]
 
-/-- The virtual left map with fibers \(evalWord A τ * X\). -/
+/-- The virtual left map with fibers \(A^\tau X\). -/
 noncomputable def leftVirtualMapES (A : MPSTensor d D) (L : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
       BoundaryFamilySpace (D := D) (Cfg d L) :=
@@ -153,6 +168,7 @@ noncomputable def leftVirtualMapES (A : MPSTensor d D) (L : ℕ) :
     (boundaryFamilyEquiv (D := D) (Cfg d L)).symm.toLinearMap.comp
       (leftVirtualFamilyMap A L)
 
+/-- A tail virtual vector has fiber \(X A^u\) at the prefix \(u\). -/
 @[simp]
 theorem boundaryFamilyEquiv_tailVirtualMapES_apply
     (A : MPSTensor d D) (K : ℕ) (x : EuclideanSpace ℂ (Fin D × Fin D))
@@ -165,6 +181,7 @@ theorem boundaryFamilyEquiv_tailVirtualMapES_apply
   rw [(boundaryFamilyEquiv (D := D) (Cfg d K)).apply_symm_apply]
   rfl
 
+/-- A left virtual vector has fiber \(A^\tau X\) at the suffix \(\tau\). -/
 @[simp]
 theorem boundaryFamilyEquiv_leftVirtualMapES_apply
     (A : MPSTensor d D) (L : ℕ) (x : EuclideanSpace ℂ (Fin D × Fin D))
@@ -235,7 +252,7 @@ theorem leftBoundaryMapES_comp_leftVirtualMapES
 
 /-! ### Injectivity -/
 
-/-- Injectivity of the local length-`L` boundary map implies injectivity of the
+/-- Injectivity of the local length-\(L\) boundary map implies injectivity of the
 tail spectator boundary map, including when the spectator configuration type is empty. -/
 theorem tailBoundaryMapES_injective_of_groundSpaceMapES_injective
     (A : MPSTensor d D) (K L : ℕ)
@@ -255,7 +272,7 @@ theorem tailBoundaryMapES_injective_of_groundSpaceMapES_injective
     exact (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm.injective hxy
   simpa using congrArg (tailRestrictₗ u) hraw
 
-/-- Injectivity of the local length-`K` boundary map implies injectivity of the
+/-- Injectivity of the local length-\(K\) boundary map implies injectivity of the
 left spectator boundary map, including when the spectator configuration type is empty. -/
 theorem leftBoundaryMapES_injective_of_groundSpaceMapES_injective
     (A : MPSTensor d D) (K L : ℕ)
@@ -275,6 +292,49 @@ theorem leftBoundaryMapES_injective_of_groundSpaceMapES_injective
     exact (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm.injective hxy
   simpa using congrArg (prefixRestrictₗ τ) hraw
 
+/-! ### C3 overlapping-window projector identity -/
+
+/-- Exact C3-window specialization of the common-factorization projector residual.
+The three ranges are, respectively, the open-chain tail space for \((K,L₀+1)\),
+the open-chain left space for \(K+L₀\), and the full \((K+L₀+1)\)-site MPS
+ground space, by `range_tailBoundaryMapES`, `range_leftBoundaryMapES_one`, and
+`range_groundSpaceMapES`. All three map injectivity assumptions are explicit.
+This identity is purely algebraic and asserts no norm estimate. -/
+theorem c3_injectiveRangeProjector_residual_eq
+    (A : MPSTensor d D) (K L₀ : ℕ)
+    (hTail : Function.Injective (tailBoundaryMapES A K (L₀ + 1)))
+    (hLeft : Function.Injective (leftBoundaryMapES A (K + L₀) 1))
+    (hFull : Function.Injective (groundSpaceMapES A (K + L₀ + 1))) :
+    (ContinuousLinearMap.injectiveRangeProjector
+        (tailBoundaryMapES A K (L₀ + 1)) hTail).comp
+        (ContinuousLinearMap.injectiveRangeProjector
+          (leftBoundaryMapES A (K + L₀) 1) hLeft) -
+      ContinuousLinearMap.injectiveRangeProjector
+        (groundSpaceMapES A (K + L₀ + 1)) hFull =
+        (tailBoundaryMapES A K (L₀ + 1)).comp
+          ((ContinuousLinearMap.inverseGram (tailBoundaryMapES A K (L₀ + 1)) hTail).comp
+            (((tailBoundaryMapES A K (L₀ + 1)).adjoint.comp
+                (leftBoundaryMapES A (K + L₀) 1) -
+              ((tailBoundaryMapES A K (L₀ + 1)).adjoint.comp
+                (tailBoundaryMapES A K (L₀ + 1))).comp
+                ((tailVirtualMapES A K).comp
+                  ((ContinuousLinearMap.inverseGram
+                    (groundSpaceMapES A (K + L₀ + 1)) hFull).comp
+                    ((leftVirtualMapES A 1).adjoint.comp
+                      ((leftBoundaryMapES A (K + L₀) 1).adjoint.comp
+                        (leftBoundaryMapES A (K + L₀) 1)))))).comp
+              ((ContinuousLinearMap.inverseGram
+                (leftBoundaryMapES A (K + L₀) 1) hLeft).comp
+                (leftBoundaryMapES A (K + L₀) 1).adjoint))) :=
+  ContinuousLinearMap.injectiveRangeProjector_comp_sub_of_factorizations
+    (T := tailBoundaryMapES A K (L₀ + 1))
+    (L := leftBoundaryMapES A (K + L₀) 1)
+    (C := groundSpaceMapES A (K + L₀ + 1))
+    (J₁ := tailVirtualMapES A K) (J₂ := leftVirtualMapES A 1)
+    hTail hLeft hFull
+    (tailBoundaryMapES_comp_tailVirtualMapES A K (L₀ + 1))
+    (leftBoundaryMapES_comp_leftVirtualMapES A (K + L₀) 1)
+
 /-! ### Fiberwise Gram identities -/
 
 /-- The Euclidean virtual-matrix fiber at a spectator configuration. -/
@@ -282,16 +342,6 @@ noncomputable def boundaryFamilyFiber {S : Type*} [Fintype S]
     (x : BoundaryFamilySpace (D := D) S) (s : S) :
     EuclideanSpace ℂ (Fin D × Fin D) :=
   WithLp.toLp 2 fun p => x (s, p)
-
-/-- Prefix-suffix configurations are equivalent to configurations on the concatenated chain. -/
-def cfgAppendEquiv (d K L : ℕ) : Cfg d K × Cfg d L ≃ Cfg d (K + L) where
-  toFun p := Fin.append p.1 p.2
-  invFun σ := (σ ∘ Fin.castAdd L, σ ∘ Fin.natAdd K)
-  left_inv p := by
-    ext i
-    · simp [Fin.append_left]
-    · simp [Fin.append_right]
-  right_inv σ := Fin.append_castAdd_natAdd
 
 /-- Apply an endomorphism independently to every virtual-matrix fiber. -/
 noncomputable def boundaryFiberwiseMap (S : Type*) [Fintype S]
@@ -323,6 +373,7 @@ noncomputable def boundaryFiberwiseMap (S : Type*) [Fintype S]
           rfl, map_smul]
         rfl }
 
+/-- Evaluation of a fiberwise map at one family and matrix index. -/
 @[simp]
 theorem boundaryFiberwiseMap_apply_apply (S : Type*) [Fintype S]
     (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
@@ -377,13 +428,13 @@ theorem inner_tailBoundaryMapES_adjoint_comp_self
         (groundSpaceGram A L (boundaryFamilyFiber (D := D) x u)) := by
   rw [ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
   trans ∑ p : Cfg d K × Cfg d L,
-      inner ℂ ((tailBoundaryMapES A K L y) (cfgAppendEquiv d K L p))
-        ((tailBoundaryMapES A K L x) (cfgAppendEquiv d K L p))
+      inner ℂ ((tailBoundaryMapES A K L y) (Fin.appendEquiv K L p))
+        ((tailBoundaryMapES A K L x) (Fin.appendEquiv K L p))
   · symm
-    apply Fintype.sum_equiv (cfgAppendEquiv d K L)
+    apply Fintype.sum_equiv (Fin.appendEquiv K L)
     intro p
     rfl
-  · simp only [cfgAppendEquiv, Equiv.coe_fn_mk, Fintype.sum_prod_type]
+  · simp only [Fin.appendEquiv, Fintype.sum_prod_type]
     apply Finset.sum_congr rfl
     intro u _
     rw [groundSpaceGram, ContinuousLinearMap.comp_apply,
@@ -409,13 +460,13 @@ theorem inner_leftBoundaryMapES_adjoint_comp_self
         (groundSpaceGram A K (boundaryFamilyFiber (D := D) x τ)) := by
   rw [ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
   trans ∑ p : Cfg d K × Cfg d L,
-      inner ℂ ((leftBoundaryMapES A K L y) (cfgAppendEquiv d K L p))
-        ((leftBoundaryMapES A K L x) (cfgAppendEquiv d K L p))
+      inner ℂ ((leftBoundaryMapES A K L y) (Fin.appendEquiv K L p))
+        ((leftBoundaryMapES A K L x) (Fin.appendEquiv K L p))
   · symm
-    apply Fintype.sum_equiv (cfgAppendEquiv d K L)
+    apply Fintype.sum_equiv (Fin.appendEquiv K L)
     intro p
     rfl
-  · simp only [cfgAppendEquiv, Equiv.coe_fn_mk, Fintype.sum_prod_type]
+  · simp only [Fin.appendEquiv, Fintype.sum_prod_type]
     rw [Finset.sum_comm]
     apply Finset.sum_congr rfl
     intro τ _

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
@@ -111,7 +111,7 @@ theorem range_leftBoundaryMapES_one (A : MPSTensor d D) (K : ℕ) :
 
 /-! ### Virtual factorizations -/
 
-/-- The virtual tail family before flattening, with fibers `X * evalWord A u`. -/
+/-- The virtual tail family before flattening, with fibers \(X * evalWord A u\). -/
 noncomputable def tailVirtualFamilyMap (A : MPSTensor d D) (K : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →ₗ[ℂ]
       (Cfg d K → Matrix (Fin D) (Fin D) ℂ) where
@@ -124,7 +124,7 @@ noncomputable def tailVirtualFamilyMap (A : MPSTensor d D) (K : ℕ) :
     funext u
     simp only [map_smul, RingHom.id_apply, Pi.smul_apply, Matrix.smul_mul]
 
-/-- The virtual tail map with fibers `X * evalWord A u`. -/
+/-- The virtual tail map with fibers \(X * evalWord A u\). -/
 noncomputable def tailVirtualMapES (A : MPSTensor d D) (K : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
       BoundaryFamilySpace (D := D) (Cfg d K) :=
@@ -132,7 +132,7 @@ noncomputable def tailVirtualMapES (A : MPSTensor d D) (K : ℕ) :
     (boundaryFamilyEquiv (D := D) (Cfg d K)).symm.toLinearMap.comp
       (tailVirtualFamilyMap A K)
 
-/-- The virtual left family before flattening, with fibers `evalWord A τ * X`. -/
+/-- The virtual left family before flattening, with fibers \(evalWord A τ * X\). -/
 noncomputable def leftVirtualFamilyMap (A : MPSTensor d D) (L : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →ₗ[ℂ]
       (Cfg d L → Matrix (Fin D) (Fin D) ℂ) where
@@ -145,7 +145,7 @@ noncomputable def leftVirtualFamilyMap (A : MPSTensor d D) (L : ℕ) :
     funext τ
     simp only [map_smul, RingHom.id_apply, Pi.smul_apply, Matrix.mul_smul]
 
-/-- The virtual left map with fibers `evalWord A τ * X`. -/
+/-- The virtual left map with fibers \(evalWord A τ * X\). -/
 noncomputable def leftVirtualMapES (A : MPSTensor d D) (L : ℕ) :
     EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
       BoundaryFamilySpace (D := D) (Cfg d L) :=

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
@@ -1,0 +1,505 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.GroundSpaceGram
+import TNLean.MPS.ParentHamiltonian.SpectatorBoundary
+
+/-!
+# Hilbert-space spectator boundary maps and their Gram operators
+
+This file realizes the spectator-indexed boundary maps in finite-dimensional
+unweighted Frobenius/Euclidean coordinates. It records their physical ranges,
+the exact virtual factorizations of the ordinary MPS boundary map, injectivity,
+and the fiberwise Gram identities. No contraction estimate is asserted.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+open scoped Matrix.Norms.Frobenius
+
+/-- Flattened Euclidean coordinates for a finite family of virtual matrices. -/
+abbrev BoundaryFamilySpace (S : Type*) [Fintype S] :=
+  EuclideanSpace ℂ (S × (Fin D × Fin D))
+
+/-- The canonical linear equivalence between flattened Euclidean coordinates and a
+finite family of matrices with the unweighted Frobenius coordinates. -/
+noncomputable def boundaryFamilyEquiv (S : Type*) [Fintype S] :
+    BoundaryFamilySpace (D := D) S ≃ₗ[ℂ] (S → Matrix (Fin D) (Fin D) ℂ) where
+  toFun x s := (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm
+    (WithLp.toLp 2 fun p => x (s, p))
+  invFun Y := WithLp.toLp 2 fun sp =>
+    Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) (Y sp.1) sp.2
+  map_add' x y := by
+    ext s a b
+    simp
+  map_smul' c x := by
+    ext s a b
+    simp
+  left_inv x := by
+    apply PiLp.ext
+    rintro ⟨s, p⟩
+    simp
+  right_inv Y := by
+    ext s a b
+    simp
+
+@[simp]
+theorem boundaryFamilyEquiv_apply_apply (S : Type*) [Fintype S]
+    (x : BoundaryFamilySpace (D := D) S) (s : S) :
+    boundaryFamilyEquiv (D := D) S x s =
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm
+        (WithLp.toLp 2 fun p => x (s, p)) := rfl
+
+/-- The tail spectator boundary map as a continuous map between Euclidean Hilbert spaces. -/
+noncomputable def tailBoundaryMapES (A : MPSTensor d D) (K L : ℕ) :
+    BoundaryFamilySpace (D := D) (Cfg d K) →L[ℂ] EuclideanSpace ℂ (Cfg d (K + L)) :=
+  LinearMap.toContinuousLinearMap <|
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm.toLinearMap.comp
+      ((tailBoundaryMap A K L).comp (boundaryFamilyEquiv (D := D) (Cfg d K)).toLinearMap)
+
+/-- The left spectator boundary map as a continuous map between Euclidean Hilbert spaces. -/
+noncomputable def leftBoundaryMapES (A : MPSTensor d D) (K L : ℕ) :
+    BoundaryFamilySpace (D := D) (Cfg d L) →L[ℂ] EuclideanSpace ℂ (Cfg d (K + L)) :=
+  LinearMap.toContinuousLinearMap <|
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm.toLinearMap.comp
+      ((leftBoundaryMap A K L).comp (boundaryFamilyEquiv (D := D) (Cfg d L)).toLinearMap)
+
+@[simp]
+theorem tailBoundaryMapES_apply (A : MPSTensor d D) (K L : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg d K)) :
+    tailBoundaryMapES A K L x =
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm
+        (tailBoundaryMap A K L (boundaryFamilyEquiv (D := D) (Cfg d K) x)) := rfl
+
+@[simp]
+theorem leftBoundaryMapES_apply (A : MPSTensor d D) (K L : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg d L)) :
+    leftBoundaryMapES A K L x =
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm
+        (leftBoundaryMap A K L (boundaryFamilyEquiv (D := D) (Cfg d L) x)) := rfl
+
+/-- The Hilbert-space tail boundary map has exactly the open-chain tail ground space as range. -/
+theorem range_tailBoundaryMapES (A : MPSTensor d D) (K L : ℕ) :
+    (tailBoundaryMapES A K L).range = openChainTailGroundSpaceES A K L := by
+  rw [← tailBoundaryMap_range_map_symm_eq_openChainTailGroundSpaceES A K L]
+  ext v
+  constructor
+  · rintro ⟨x, rfl⟩
+    exact ⟨tailBoundaryMap A K L (boundaryFamilyEquiv (D := D) (Cfg d K) x),
+      ⟨boundaryFamilyEquiv (D := D) (Cfg d K) x, rfl⟩, rfl⟩
+  · rintro ⟨v, ⟨Y, rfl⟩, rfl⟩
+    exact ⟨(boundaryFamilyEquiv (D := D) (Cfg d K)).symm Y, by simp⟩
+
+/-- At suffix length one, the Hilbert-space left boundary map has exactly the
+open-chain left ground space as range. -/
+theorem range_leftBoundaryMapES_one (A : MPSTensor d D) (K : ℕ) :
+    (leftBoundaryMapES A K 1).range = openChainLeftGroundSpaceES A K := by
+  rw [← leftBoundaryMap_range_map_symm_eq_openChainLeftGroundSpaceES A K]
+  ext v
+  constructor
+  · rintro ⟨x, rfl⟩
+    exact ⟨leftBoundaryMap A K 1 (boundaryFamilyEquiv (D := D) (Cfg d 1) x),
+      ⟨boundaryFamilyEquiv (D := D) (Cfg d 1) x, rfl⟩, rfl⟩
+  · rintro ⟨v, ⟨Y, rfl⟩, rfl⟩
+    exact ⟨(boundaryFamilyEquiv (D := D) (Cfg d 1)).symm Y, by simp⟩
+
+/-! ### Virtual factorizations -/
+
+/-- The virtual tail family before flattening, with fibers `X * evalWord A u`. -/
+noncomputable def tailVirtualFamilyMap (A : MPSTensor d D) (K : ℕ) :
+    EuclideanSpace ℂ (Fin D × Fin D) →ₗ[ℂ]
+      (Cfg d K → Matrix (Fin D) (Fin D) ℂ) where
+  toFun x u := (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm x *
+    evalWord A (List.ofFn u)
+  map_add' x y := by
+    funext u
+    simp [Matrix.add_mul]
+  map_smul' c x := by
+    funext u
+    simp only [map_smul, RingHom.id_apply, Pi.smul_apply, Matrix.smul_mul]
+
+/-- The virtual tail map with fibers `X * evalWord A u`. -/
+noncomputable def tailVirtualMapES (A : MPSTensor d D) (K : ℕ) :
+    EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      BoundaryFamilySpace (D := D) (Cfg d K) :=
+  LinearMap.toContinuousLinearMap <|
+    (boundaryFamilyEquiv (D := D) (Cfg d K)).symm.toLinearMap.comp
+      (tailVirtualFamilyMap A K)
+
+/-- The virtual left family before flattening, with fibers `evalWord A τ * X`. -/
+noncomputable def leftVirtualFamilyMap (A : MPSTensor d D) (L : ℕ) :
+    EuclideanSpace ℂ (Fin D × Fin D) →ₗ[ℂ]
+      (Cfg d L → Matrix (Fin D) (Fin D) ℂ) where
+  toFun x τ := evalWord A (List.ofFn τ) *
+    (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm x
+  map_add' x y := by
+    funext τ
+    simp [Matrix.mul_add]
+  map_smul' c x := by
+    funext τ
+    simp only [map_smul, RingHom.id_apply, Pi.smul_apply, Matrix.mul_smul]
+
+/-- The virtual left map with fibers `evalWord A τ * X`. -/
+noncomputable def leftVirtualMapES (A : MPSTensor d D) (L : ℕ) :
+    EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      BoundaryFamilySpace (D := D) (Cfg d L) :=
+  LinearMap.toContinuousLinearMap <|
+    (boundaryFamilyEquiv (D := D) (Cfg d L)).symm.toLinearMap.comp
+      (leftVirtualFamilyMap A L)
+
+@[simp]
+theorem boundaryFamilyEquiv_tailVirtualMapES_apply
+    (A : MPSTensor d D) (K : ℕ) (x : EuclideanSpace ℂ (Fin D × Fin D))
+    (u : Cfg d K) :
+    boundaryFamilyEquiv (D := D) (Cfg d K) (tailVirtualMapES A K x) u =
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm x *
+        evalWord A (List.ofFn u) := by
+  change boundaryFamilyEquiv (D := D) (Cfg d K)
+    ((boundaryFamilyEquiv (D := D) (Cfg d K)).symm (tailVirtualFamilyMap A K x)) u = _
+  rw [(boundaryFamilyEquiv (D := D) (Cfg d K)).apply_symm_apply]
+  rfl
+
+@[simp]
+theorem boundaryFamilyEquiv_leftVirtualMapES_apply
+    (A : MPSTensor d D) (L : ℕ) (x : EuclideanSpace ℂ (Fin D × Fin D))
+    (τ : Cfg d L) :
+    boundaryFamilyEquiv (D := D) (Cfg d L) (leftVirtualMapES A L x) τ =
+      evalWord A (List.ofFn τ) *
+        (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm x := by
+  change boundaryFamilyEquiv (D := D) (Cfg d L)
+    ((boundaryFamilyEquiv (D := D) (Cfg d L)).symm (leftVirtualFamilyMap A L x)) τ = _
+  rw [(boundaryFamilyEquiv (D := D) (Cfg d L)).apply_symm_apply]
+  rfl
+
+/-- The ordinary Euclidean boundary map factors through the tail spectator map. -/
+theorem tailBoundaryMapES_comp_tailVirtualMapES
+    (A : MPSTensor d D) (K L : ℕ) :
+    (tailBoundaryMapES A K L).comp (tailVirtualMapES A K) =
+      groundSpaceMapES A (K + L) := by
+  apply ContinuousLinearMap.coe_injective
+  apply DFunLike.ext _ _
+  intro x
+  obtain ⟨X, rfl⟩ :=
+    (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).surjective x
+  change (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm
+      (tailBoundaryMap A K L
+        (boundaryFamilyEquiv (D := D) (Cfg d K)
+          (tailVirtualMapES A K
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X)))) =
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm
+      (groundSpaceMap A (K + L) X)
+  refine congrArg (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm ?_
+  have hfamily :
+      boundaryFamilyEquiv (D := D) (Cfg d K)
+          (tailVirtualMapES A K
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X)) =
+        fun u => X * evalWord A (List.ofFn u) := by
+    funext u
+    rw [boundaryFamilyEquiv_tailVirtualMapES_apply,
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm_apply_apply]
+  rw [hfamily, tailBoundaryMap_factorization]
+
+/-- The ordinary Euclidean boundary map factors through the left spectator map. -/
+theorem leftBoundaryMapES_comp_leftVirtualMapES
+    (A : MPSTensor d D) (K L : ℕ) :
+    (leftBoundaryMapES A K L).comp (leftVirtualMapES A L) =
+      groundSpaceMapES A (K + L) := by
+  apply ContinuousLinearMap.coe_injective
+  apply DFunLike.ext _ _
+  intro x
+  obtain ⟨X, rfl⟩ :=
+    (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).surjective x
+  change (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm
+      (leftBoundaryMap A K L
+        (boundaryFamilyEquiv (D := D) (Cfg d L)
+          (leftVirtualMapES A L
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X)))) =
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm
+      (groundSpaceMap A (K + L) X)
+  refine congrArg (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm ?_
+  have hfamily :
+      boundaryFamilyEquiv (D := D) (Cfg d L)
+          (leftVirtualMapES A L
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X)) =
+        fun τ => evalWord A (List.ofFn τ) * X := by
+    funext τ
+    rw [boundaryFamilyEquiv_leftVirtualMapES_apply,
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm_apply_apply]
+  rw [hfamily, leftBoundaryMap_factorization]
+
+/-! ### Injectivity -/
+
+/-- Injectivity of the local length-`L` boundary map implies injectivity of the
+tail spectator boundary map, including when the spectator configuration type is empty. -/
+theorem tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+    (A : MPSTensor d D) (K L : ℕ)
+    (h : Function.Injective (groundSpaceMapES A L)) :
+    Function.Injective (tailBoundaryMapES A K L) := by
+  intro x y hxy
+  apply (boundaryFamilyEquiv (D := D) (Cfg d K)).injective
+  funext u
+  apply (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).injective
+  apply h
+  rw [groundSpaceMapES_frobeniusEquivEuclidean_apply,
+    groundSpaceMapES_frobeniusEquivEuclidean_apply]
+  apply congrArg (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm
+  have hraw :
+      tailBoundaryMap A K L (boundaryFamilyEquiv (D := D) (Cfg d K) x) =
+        tailBoundaryMap A K L (boundaryFamilyEquiv (D := D) (Cfg d K) y) := by
+    exact (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm.injective hxy
+  simpa using congrArg (tailRestrictₗ u) hraw
+
+/-- Injectivity of the local length-`K` boundary map implies injectivity of the
+left spectator boundary map, including when the spectator configuration type is empty. -/
+theorem leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+    (A : MPSTensor d D) (K L : ℕ)
+    (h : Function.Injective (groundSpaceMapES A K)) :
+    Function.Injective (leftBoundaryMapES A K L) := by
+  intro x y hxy
+  apply (boundaryFamilyEquiv (D := D) (Cfg d L)).injective
+  funext τ
+  apply (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).injective
+  apply h
+  rw [groundSpaceMapES_frobeniusEquivEuclidean_apply,
+    groundSpaceMapES_frobeniusEquivEuclidean_apply]
+  apply congrArg (WithLp.linearEquiv 2 ℂ (NSiteSpace d K)).symm
+  have hraw :
+      leftBoundaryMap A K L (boundaryFamilyEquiv (D := D) (Cfg d L) x) =
+        leftBoundaryMap A K L (boundaryFamilyEquiv (D := D) (Cfg d L) y) := by
+    exact (WithLp.linearEquiv 2 ℂ (NSiteSpace d (K + L))).symm.injective hxy
+  simpa using congrArg (prefixRestrictₗ τ) hraw
+
+/-! ### Fiberwise Gram identities -/
+
+/-- The Euclidean virtual-matrix fiber at a spectator configuration. -/
+noncomputable def boundaryFamilyFiber {S : Type*} [Fintype S]
+    (x : BoundaryFamilySpace (D := D) S) (s : S) :
+    EuclideanSpace ℂ (Fin D × Fin D) :=
+  WithLp.toLp 2 fun p => x (s, p)
+
+/-- Prefix-suffix configurations are equivalent to configurations on the concatenated chain. -/
+def cfgAppendEquiv (d K L : ℕ) : Cfg d K × Cfg d L ≃ Cfg d (K + L) where
+  toFun p := Fin.append p.1 p.2
+  invFun σ := (σ ∘ Fin.castAdd L, σ ∘ Fin.natAdd K)
+  left_inv p := by
+    ext i
+    · simp [Fin.append_left]
+    · simp [Fin.append_right]
+  right_inv σ := Fin.append_castAdd_natAdd
+
+/-- Apply an endomorphism independently to every virtual-matrix fiber. -/
+noncomputable def boundaryFiberwiseMap (S : Type*) [Fintype S]
+    (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      EuclideanSpace ℂ (Fin D × Fin D)) :
+    BoundaryFamilySpace (D := D) S →L[ℂ] BoundaryFamilySpace (D := D) S :=
+  LinearMap.toContinuousLinearMap
+    { toFun := fun x => WithLp.toLp 2 fun sp => G (boundaryFamilyFiber (D := D) x sp.1) sp.2
+      map_add' := by
+        intro x y
+        apply PiLp.ext
+        rintro ⟨s, p⟩
+        change (G (boundaryFamilyFiber (D := D) (x + y) s)) p = _
+        rw [show boundaryFamilyFiber (D := D) (x + y) s =
+            boundaryFamilyFiber (D := D) x s + boundaryFamilyFiber (D := D) y s by
+          apply PiLp.ext
+          intro q
+          rfl, map_add]
+        rfl
+      map_smul' := by
+        intro c x
+        apply PiLp.ext
+        rintro ⟨s, p⟩
+        change (G (boundaryFamilyFiber (D := D) (c • x) s)) p = _
+        rw [show boundaryFamilyFiber (D := D) (c • x) s =
+            c • boundaryFamilyFiber (D := D) x s by
+          apply PiLp.ext
+          intro q
+          rfl, map_smul]
+        rfl }
+
+@[simp]
+theorem boundaryFiberwiseMap_apply_apply (S : Type*) [Fintype S]
+    (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      EuclideanSpace ℂ (Fin D × Fin D))
+    (x : BoundaryFamilySpace (D := D) S) (s : S) (p : Fin D × Fin D) :
+    boundaryFiberwiseMap (D := D) S G x (s, p) =
+      G (boundaryFamilyFiber (D := D) x s) p := rfl
+
+/-- Fiberwise maps preserve composition. -/
+theorem boundaryFiberwiseMap_comp (S : Type*) [Fintype S]
+    (G H : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      EuclideanSpace ℂ (Fin D × Fin D)) :
+    (boundaryFiberwiseMap (D := D) S G).comp (boundaryFiberwiseMap (D := D) S H) =
+      boundaryFiberwiseMap (D := D) S (G.comp H) := by
+  apply ContinuousLinearMap.coe_injective
+  apply DFunLike.ext _ _
+  intro x
+  apply PiLp.ext
+  rintro ⟨s, p⟩
+  rfl
+
+/-- The fiberwise identity is the identity on the flattened family space. -/
+theorem boundaryFiberwiseMap_id (S : Type*) [Fintype S] :
+    boundaryFiberwiseMap (D := D) S (ContinuousLinearMap.id ℂ _) =
+      ContinuousLinearMap.id ℂ (BoundaryFamilySpace (D := D) S) := by
+  apply ContinuousLinearMap.coe_injective
+  apply DFunLike.ext _ _
+  intro x
+  apply PiLp.ext
+  rintro ⟨s, p⟩
+  rfl
+
+/-- Inner products against a fiberwise map split exactly as a finite direct sum. -/
+theorem inner_boundaryFiberwiseMap (S : Type*) [Fintype S]
+    (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      EuclideanSpace ℂ (Fin D × Fin D))
+    (x y : BoundaryFamilySpace (D := D) S) :
+    inner ℂ y (boundaryFiberwiseMap (D := D) S G x) =
+      ∑ s : S, inner ℂ (boundaryFamilyFiber (D := D) y s)
+        (G (boundaryFamilyFiber (D := D) x s)) := by
+  rw [PiLp.inner_apply]
+  simp only [boundaryFiberwiseMap_apply_apply, Fintype.sum_prod_type,
+    boundaryFamilyFiber, PiLp.inner_apply]
+
+/-- The tail Gram is the direct sum, over prefix spectators, of copies of the
+length-`L` MPS Gram. This bilinear identity remains valid for empty spectator types. -/
+theorem inner_tailBoundaryMapES_adjoint_comp_self
+    (A : MPSTensor d D) (K L : ℕ)
+    (x y : BoundaryFamilySpace (D := D) (Cfg d K)) :
+    inner ℂ y ((tailBoundaryMapES A K L).adjoint (tailBoundaryMapES A K L x)) =
+      ∑ u : Cfg d K, inner ℂ (boundaryFamilyFiber (D := D) y u)
+        (groundSpaceGram A L (boundaryFamilyFiber (D := D) x u)) := by
+  rw [ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
+  trans ∑ p : Cfg d K × Cfg d L,
+      inner ℂ ((tailBoundaryMapES A K L y) (cfgAppendEquiv d K L p))
+        ((tailBoundaryMapES A K L x) (cfgAppendEquiv d K L p))
+  · symm
+    apply Fintype.sum_equiv (cfgAppendEquiv d K L)
+    intro p
+    rfl
+  · simp only [cfgAppendEquiv, Equiv.coe_fn_mk, Fintype.sum_prod_type]
+    apply Finset.sum_congr rfl
+    intro u _
+    rw [groundSpaceGram, ContinuousLinearMap.comp_apply,
+      ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
+    apply Finset.sum_congr rfl
+    intro τ _
+    have hp : Fin.append u τ ∘ Fin.castAdd L = u := by
+      ext i
+      simp [Fin.append_left]
+    have hs : Fin.append u τ ∘ Fin.natAdd K = τ := by
+      ext i
+      simp [Fin.append_right]
+    simp [boundaryFamilyFiber, tailBoundaryMapES, groundSpaceMapES,
+      groundSpaceMap_apply, hp, hs]
+
+/-- The left Gram is the direct sum, over suffix spectators, of copies of the
+length-`K` MPS Gram. This bilinear identity remains valid for empty spectator types. -/
+theorem inner_leftBoundaryMapES_adjoint_comp_self
+    (A : MPSTensor d D) (K L : ℕ)
+    (x y : BoundaryFamilySpace (D := D) (Cfg d L)) :
+    inner ℂ y ((leftBoundaryMapES A K L).adjoint (leftBoundaryMapES A K L x)) =
+      ∑ τ : Cfg d L, inner ℂ (boundaryFamilyFiber (D := D) y τ)
+        (groundSpaceGram A K (boundaryFamilyFiber (D := D) x τ)) := by
+  rw [ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
+  trans ∑ p : Cfg d K × Cfg d L,
+      inner ℂ ((leftBoundaryMapES A K L y) (cfgAppendEquiv d K L p))
+        ((leftBoundaryMapES A K L x) (cfgAppendEquiv d K L p))
+  · symm
+    apply Fintype.sum_equiv (cfgAppendEquiv d K L)
+    intro p
+    rfl
+  · simp only [cfgAppendEquiv, Equiv.coe_fn_mk, Fintype.sum_prod_type]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro τ _
+    rw [groundSpaceGram, ContinuousLinearMap.comp_apply,
+      ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
+    apply Finset.sum_congr rfl
+    intro u _
+    have hp : Fin.append u τ ∘ Fin.castAdd L = u := by
+      ext i
+      simp [Fin.append_left]
+    have hs : Fin.append u τ ∘ Fin.natAdd K = τ := by
+      ext i
+      simp [Fin.append_right]
+    simp [boundaryFamilyFiber, leftBoundaryMapES, groundSpaceMapES,
+      groundSpaceMap_apply, hp, hs]
+
+/-- Operator form of the exact tail direct-sum Gram identity. -/
+theorem tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram
+    (A : MPSTensor d D) (K L : ℕ) :
+    (tailBoundaryMapES A K L).adjoint.comp (tailBoundaryMapES A K L) =
+      boundaryFiberwiseMap (D := D) (Cfg d K) (groundSpaceGram A L) := by
+  apply ContinuousLinearMap.coe_injective
+  apply DFunLike.ext _ _
+  intro x
+  apply ext_inner_left ℂ
+  intro y
+  change inner ℂ y ((tailBoundaryMapES A K L).adjoint (tailBoundaryMapES A K L x)) =
+    inner ℂ y (boundaryFiberwiseMap (D := D) (Cfg d K) (groundSpaceGram A L) x)
+  rw [inner_tailBoundaryMapES_adjoint_comp_self,
+    inner_boundaryFiberwiseMap]
+
+/-- The inverse Gram of the tail spectator map acts independently by the inverse
+length-`L` Gram on every prefix fiber. -/
+theorem inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram
+    (A : MPSTensor d D) (K L : ℕ)
+    (h : Function.Injective (groundSpaceMapES A L)) :
+    ContinuousLinearMap.inverseGram (tailBoundaryMapES A K L)
+        (tailBoundaryMapES_injective_of_groundSpaceMapES_injective A K L h) =
+      boundaryFiberwiseMap (D := D) (Cfg d K)
+        (ContinuousLinearMap.inverseGram (groundSpaceMapES A L) h) := by
+  rw [ContinuousLinearMap.inverseGram_eq_inverse]
+  apply ContinuousLinearMap.inverse_eq
+  · rw [tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram,
+      groundSpaceGram, boundaryFiberwiseMap_comp,
+      ContinuousLinearMap.adjoint_comp_self_comp_inverseGram,
+      boundaryFiberwiseMap_id]
+  · rw [tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram,
+      groundSpaceGram, boundaryFiberwiseMap_comp,
+      ContinuousLinearMap.inverseGram_comp_adjoint_comp_self,
+      boundaryFiberwiseMap_id]
+
+/-- Operator form of the exact left direct-sum Gram identity. -/
+theorem leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram
+    (A : MPSTensor d D) (K L : ℕ) :
+    (leftBoundaryMapES A K L).adjoint.comp (leftBoundaryMapES A K L) =
+      boundaryFiberwiseMap (D := D) (Cfg d L) (groundSpaceGram A K) := by
+  apply ContinuousLinearMap.coe_injective
+  apply DFunLike.ext _ _
+  intro x
+  apply ext_inner_left ℂ
+  intro y
+  change inner ℂ y ((leftBoundaryMapES A K L).adjoint (leftBoundaryMapES A K L x)) =
+    inner ℂ y (boundaryFiberwiseMap (D := D) (Cfg d L) (groundSpaceGram A K) x)
+  rw [inner_leftBoundaryMapES_adjoint_comp_self,
+    inner_boundaryFiberwiseMap]
+
+/-- The inverse Gram of the left spectator map acts independently by the inverse
+length-`K` Gram on every suffix fiber. -/
+theorem inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram
+    (A : MPSTensor d D) (K L : ℕ)
+    (h : Function.Injective (groundSpaceMapES A K)) :
+    ContinuousLinearMap.inverseGram (leftBoundaryMapES A K L)
+        (leftBoundaryMapES_injective_of_groundSpaceMapES_injective A K L h) =
+      boundaryFiberwiseMap (D := D) (Cfg d L)
+        (ContinuousLinearMap.inverseGram (groundSpaceMapES A K) h) := by
+  rw [ContinuousLinearMap.inverseGram_eq_inverse]
+  apply ContinuousLinearMap.inverse_eq
+  · rw [leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram,
+      groundSpaceGram, boundaryFiberwiseMap_comp,
+      ContinuousLinearMap.adjoint_comp_self_comp_inverseGram,
+      boundaryFiberwiseMap_id]
+  · rw [leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram,
+      groundSpaceGram, boundaryFiberwiseMap_comp,
+      ContinuousLinearMap.inverseGram_comp_adjoint_comp_self,
+      boundaryFiberwiseMap_id]
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
@@ -24,7 +24,10 @@ and the fiberwise Gram identities. No contraction estimate is asserted.
 
 * `range_tailBoundaryMapES` and `range_leftBoundaryMapES_one` identify the physical ranges.
 * `c3_injectiveRangeProjector_residual_eq` is the exact C3 common-factorization identity.
-* The tail and left Gram and inverse-Gram theorems identify their fiberwise actions.
+* `tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram` and
+  `leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram` identify the Grams.
+* `inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram` and
+  `inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram` identify the inverse Grams.
 -/
 
 open scoped Matrix

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -332,6 +332,43 @@ norm estimate is derived here.
     unfolding Definition~\ref{def:open_chain_ground_subspaces_es} gives
     $\mathcal U_K(A)$.
 \end{proof}
+
+\begin{theorem}[Euclidean spectator boundary ranges and factorizations]%
+    \label{thm:spectator_boundary_hilbert_factorization}
+    \lean{MPSTensor.range_tailBoundaryMapES}
+    \lean{MPSTensor.range_leftBoundaryMapES_one}
+    \lean{MPSTensor.tailBoundaryMapES_comp_tailVirtualMapES}
+    \lean{MPSTensor.leftBoundaryMapES_comp_leftVirtualMapES}
+    \leanok
+    \uses{thm:tail_boundary_map_range_es_transport,thm:left_boundary_map_range_es_transport}
+    Equip each virtual matrix fiber with the unweighted Hilbert--Schmidt inner
+    product and flatten the finite family of fibers into a Euclidean space.
+    The resulting continuous tail and left boundary maps have ranges
+    $\mathcal V_{K,L}(A)$ and, at suffix length one, $\mathcal U_K(A)$.
+    Moreover, if $J^{\mathrm{tail}}_K(X)_u=XA^u$ and
+    $J^{\mathrm{left}}_L(X)_\tau=A^\tau X$, then
+    \begin{align}
+      \Gamma^{\mathrm{tail}}_{K,L}J^{\mathrm{tail}}_K&=\Gamma_{K+L},&
+      \Gamma^{\mathrm{left}}_{K,L}J^{\mathrm{left}}_L&=\Gamma_{K+L}.
+    \end{align}
+\end{theorem}
+
+\begin{theorem}[Direct-sum spectator Gram operators]%
+    \label{thm:spectator_boundary_direct_sum_gram}
+    \lean{MPSTensor.tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram}
+    \lean{MPSTensor.leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram}
+    \lean{MPSTensor.inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram}
+    \lean{MPSTensor.inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram}
+    \leanok
+    \uses{thm:spectator_boundary_hilbert_factorization}
+    The tail Gram is the direct sum over prefix configurations of copies of
+    $\Gamma_L^\dagger\Gamma_L$, and the left Gram is the direct sum over suffix
+    configurations of copies of $\Gamma_K^\dagger\Gamma_K$.  Whenever the
+    corresponding local boundary map is injective, the inverse Gram is the
+    direct sum of the local inverse Grams.  These identities include empty
+    spectator index types and assert no norm estimate.
+\end{theorem}
+
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -355,6 +355,8 @@ norm estimate is derived here.
 \end{theorem}
 \begin{proof}
     \leanok
+    \uses{thm:tail_boundary_map_range_es_transport,thm:left_boundary_map_range_es_transport,
+      thm:tail_boundary_map_factorization,thm:left_boundary_map_factorization}
     Transport the algebraic range descriptions through the Euclidean
     identification.  The two factorization identities follow by evaluating a
     virtual matrix \(X\) fiberwise and applying the corresponding algebraic
@@ -400,6 +402,7 @@ norm estimate is derived here.
 \end{theorem}
 \begin{proof}
     \leanok
+    \uses{thm:spectator_boundary_hilbert_factorization}
     Apply the common-factorization projector identity to the two spectator
     boundary maps, the full boundary map, and their tail and left virtual maps.
     The preceding range equalities identify the three physical ranges.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -340,7 +340,8 @@ norm estimate is derived here.
     \lean{MPSTensor.tailBoundaryMapES_comp_tailVirtualMapES}
     \lean{MPSTensor.leftBoundaryMapES_comp_leftVirtualMapES}
     \leanok
-    \uses{thm:tail_boundary_map_range_es_transport,thm:left_boundary_map_range_es_transport}
+    \uses{thm:tail_boundary_map_range_es_transport,thm:left_boundary_map_range_es_transport,
+      thm:tail_boundary_map_factorization,thm:left_boundary_map_factorization}
     Equip each virtual matrix fiber with the unweighted Hilbert--Schmidt inner
     product and flatten the finite family of fibers into a Euclidean space.
     The resulting continuous tail and left boundary maps have ranges
@@ -352,6 +353,13 @@ norm estimate is derived here.
       \Gamma^{\mathrm{left}}_{K,L}J^{\mathrm{left}}_L&=\Gamma_{K+L}.
     \end{align}
 \end{theorem}
+\begin{proof}
+    \leanok
+    Transport the algebraic range descriptions through the Euclidean
+    identification.  The two factorization identities follow by evaluating a
+    virtual matrix \(X\) fiberwise and applying the corresponding algebraic
+    tail or left factorization.
+\end{proof}
 
 \begin{theorem}[Direct-sum spectator Gram operators]%
     \label{thm:spectator_boundary_direct_sum_gram}
@@ -360,14 +368,42 @@ norm estimate is derived here.
     \lean{MPSTensor.inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram}
     \lean{MPSTensor.inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram}
     \leanok
-    \uses{thm:spectator_boundary_hilbert_factorization}
     The tail Gram is the direct sum over prefix configurations of copies of
-    $\Gamma_L^\dagger\Gamma_L$, and the left Gram is the direct sum over suffix
-    configurations of copies of $\Gamma_K^\dagger\Gamma_K$.  Whenever the
+    $\mathcal K_L$, and the left Gram is the direct sum over suffix
+    configurations of copies of $\mathcal K_K$.  Whenever the
     corresponding local boundary map is injective, the inverse Gram is the
     direct sum of the local inverse Grams.  These identities include empty
     spectator index types and assert no norm estimate.
 \end{theorem}
+\begin{proof}
+    \leanok
+    Reindex the physical inner product by prefix--suffix configurations and
+    evaluate each fiber.  This gives the direct-sum Gram identities.  Composing
+    fiberwise with the local inverse Gram on either side gives the stated
+    inverse formulas.
+\end{proof}
+
+\begin{theorem}[Exact C3 projector residual identity]%
+    \label{thm:c3_spectator_projector_residual}
+    \lean{MPSTensor.c3_injectiveRangeProjector_residual_eq}
+    \leanok
+    \uses{thm:spectator_boundary_hilbert_factorization}
+    Fix $K,L_0\in\mathbb N$.  Suppose that the tail boundary map for
+    $(K,L_0+1)$, the left boundary map for $(K+L_0,1)$, and
+    $\Gamma_{K+L_0+1}$ are injective.  The difference between the product of
+    the first two inverse-Gram range projectors and the third inverse-Gram range
+    projector is exactly the common-factorization residual obtained from the
+    tail and left virtual maps.  Their ranges are, respectively,
+    $\mathcal V_{K,L_0+1}(A)$, $\mathcal U_{K+L_0}(A)$, and
+    $\mathcal G_{K+L_0+1}(A)$.  This identity asserts no numerical contraction
+    estimate.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Apply the common-factorization projector identity to the two spectator
+    boundary maps, the full boundary map, and their tail and left virtual maps.
+    The preceding range equalities identify the three physical ranges.
+\end{proof}
 
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -683,15 +683,35 @@ and generic prerequisites now include:
     For $I=\Fin D$ this is norm factor $D^{3/2}$; it is not claimed sharp and
     is not the FNW prefactor $c=D^2$.
   \item The spectator-indexed boundary maps for the tail and left windows are
-    defined in \path{TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean},
-    together with their exact range equalities
-    (\leanid{MPSTensor.tailBoundaryMap_range_eq},
-     \leanid{MPSTensor.leftBoundaryMap_range_eq})
-    and word-factorization identities
-    (\leanid{MPSTensor.tailBoundaryMap_factorization},
-     \leanid{MPSTensor.leftBoundaryMap_factorization}).
-    These give exact range models in the physical space
-    \(\mathcal H_{K+L}\); the C3 specializations are stated next.
+    defined algebraically in
+    \path{TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean}.  Their
+    finite-dimensional Hilbert realizations are
+    \leanid{MPSTensor.tailBoundaryMapES} and
+    \leanid{MPSTensor.leftBoundaryMapES} in
+    \path{TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean}.  The latter
+    module proves the exact physical ranges, the factorizations through
+    \(\Gamma_{K+L}^{\mathrm{ES}}\), and injectivity from the corresponding local
+    boundary map.  It also computes the Grams as direct sums of
+    \(\mathcal K_L\) on tail fibers and \(\mathcal K_K\) on left fibers:
+    \leanid{MPSTensor.tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram}
+    and
+    \leanid{MPSTensor.leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram}.
+    The inverse Grams are likewise fiberwise by
+    \leanid{MPSTensor.inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram}
+    and
+    \leanid{MPSTensor.inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram}.
+    These are exact unweighted identities, including empty spectator types;
+    they assert no direct-sum norm estimate.  The C3 specializations are stated
+    next.
+  \item For injective maps with common factorizations
+    \(T J_1=C=L J_2\),
+    \leanid{ContinuousLinearMap.injectiveRangeProjector_comp_sub_of_factorizations}
+    factors the exact projector residual through
+    \begin{align}
+      T^\dagger L-(T^\dagger T)J_1S_CJ_2^\dagger(L^\dagger L).
+    \end{align}
+    This is an algebraic identity only; a source-specific estimate of this
+    mixed-Gram residual is still required.
 \end{itemize}
 Fix \(K,L_0\in\mathbb N\) and let
 \(\mathcal H_{K+L_0+1}\) be the \((K+L_0+1)\)-site Euclidean space

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -710,8 +710,15 @@ and generic prerequisites now include:
     \begin{align}
       T^\dagger L-(T^\dagger T)J_1S_CJ_2^\dagger(L^\dagger L).
     \end{align}
-    This is an algebraic identity only; a source-specific estimate of this
-    mixed-Gram residual is still required.
+    The concrete specialization
+    \leanid{MPSTensor.c3_injectiveRangeProjector_residual_eq} uses the tail map
+    at $(K,L_0+1)$, the left map at $(K+L_0,1)$, the common map
+    $\Gamma_{K+L_0+1}^{\mathrm{ES}}$, and the corresponding virtual maps.  Its
+    three inverse-Gram range projectors have the open-chain tail, open-chain
+    left, and full ground-space ranges by the exact range theorems above.  All
+    three injectivity assumptions are explicit.  This is an algebraic identity
+    only; a source-specific estimate of the mixed-Gram residual is still
+    required.
 \end{itemize}
 Fix \(K,L_0\in\mathbb N\) and let
 \(\mathcal H_{K+L_0+1}\) be the \((K+L_0+1)\)-site Euclidean space


### PR DESCRIPTION
## Summary

- realizes the tail and left spectator boundary maps as continuous maps in the project’s unweighted Frobenius/Euclidean coordinates;
- identifies their physical ranges, bundles the exact virtual word factorizations through the finite-volume boundary map, and proves injectivity under the corresponding block-injectivity hypotheses;
- computes both Gram operators fiberwise as direct sums of `groundSpaceGram` and proves exact fiberwise inverse-Gram formulas, including empty spectator types;
- adds the generic common-factorization identity for the residual of two injective range projectors in a common ambient Hilbert space;
- synchronizes the Chapter 13 roadmap and martingale paper-gap note without claiming the remaining FNW mixed-Gram numerical contraction.

## Source and scope

This is the exact Hilbert/Gram infrastructure required by the common-ambient overlapping-window route in #5923. It keeps the raw spectator maps and unweighted coordinates already used by the parent-Hamiltonian development. No finite-volume Gram is replaced by the identity, no physical range projector is identified with the transfer fixed-point projector, and no operator-norm invariance under reshuffling or nonunitary coordinate changes is assumed.

The new projector lemma is an exact algebraic identity. The analytic estimate of its mixed middle operator remains the source-dependent remainder of #5923/#5752.

## Verification

- `lake env lean TNLean/Analysis/InjectiveRangeProjector.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean`
- targeted dependency refresh via `lake build TNLean.MPS.ParentHamiltonian.GramInverseConvergence`, followed by `lake env lean TNLean/MPS/ParentHamiltonian.lean`
- proof-integrity scan and `git diff --check`

Closes #5940
Refs #5923, #5922, #5752, #5455

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are formal Lean proofs and documentation for parent-Hamiltonian martingale infrastructure; no runtime, auth, or production paths. Residual analytic risk is explicitly deferred to follow-up work rather than introduced here.
> 
> **Overview**
> Adds **Hilbert-space realizations** of tail/left spectator boundary maps (`tailBoundaryMapES`, `leftBoundaryMapES`) in unweighted Frobenius/Euclidean coordinates, with virtual factorization maps and fiberwise Gram machinery in `SpectatorBoundaryGram.lean`.
> 
> The new Lean work proves **exact** physical range equalities, factorizations through `groundSpaceMapES`, injectivity from local boundary injectivity, **direct-sum Gram identities** (and matching inverse Grams on each fiber), and the **C3 overlapping-window projector residual** `c3_injectiveRangeProjector_residual_eq`—all **algebraic**, with **no** contraction or norm estimates claimed.
> 
> In `InjectiveRangeProjector.lean`, adds the generic **`injectiveRangeProjector_comp_sub_of_factorizations`** identity for three injective maps sharing a common factorization \(C = T J_1 = L J_2\), which the C3 theorem instantiates.
> 
> Blueprint Chapter 13 and `docs/paper-gaps/cpgsv21_martingale_overlap.tex` are updated to point at the new theorems and to note that the **mixed-Gram numerical estimate** remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf190bbe7ecb0dfa9b448d7d82e3a072b2a10879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->