### PR TITLE
doc(tenkz): rewrite the tutorial on the kernel surface

### DIFF
--- a/docs/tenkz/chapters2/ch-tutorial.tex
+++ b/docs/tenkz/chapters2/ch-tutorial.tex
@@ -1,12 +1,28 @@
-% Five examples, designed to be completed in about fifteen minutes.
+% Five examples in the manner of The TeXbook: each adds one idea to the
+% one before it, dangerous bends mark skippable depth, one refusal is
+% shown on purpose, and the exercises' answers close the chapter.
 \section{A fifteen-minute tutorial}\label{ch:tutorial}
 
-The five examples use the same reading order: layout, picture policy, then
-body declarations.  Each source is complete and uses canonical public syntax.
+Everything you will type here is the kernel surface: the one language the
+package binds the moment it loads.  If you have met an older tenkz
+document, two sentences make you current.  \tncmd{tenkzkernel} is an inert
+word --- it rebinds what loading already bound --- and the spellings it
+once switched on are dead, tombstoned in Appendix~\ref{ch:compatibility}.
+New sources need neither.
 
-\subsection{An MPS word}
+Five examples take you from one word of tensors to an audited equation
+identity, and each adds exactly one idea to the one before it.  Every
+source is complete: paste it into any document that loads the package and
+it compiles as printed.  Read each one in the same order --- layout,
+picture policy, then body declarations.  This tutorial needs only
+\tnenv{tenkz} and, at the last step, \tnenv{tenkzeq}; when a figure of
+your own wants a lattice, a sheet, or a ring, the chooser in
+Section~\ref{ch:chooser} decides by topology.
+
+\subsection{A word of tensors}
 
 \begin{tnexample}[
+  label={tnex:tut-word},
   formula={(A^{i_1}A^{i_2}A^{i_3})_{\alpha\beta}},
   caption={a regular contraction},
   index={The horizontal bonds are summed virtual indices.  The two stubs are
@@ -21,20 +37,30 @@ body declarations.  Each source is complete and uses canonical public syntax.
 \end{tenkz}
 \end{tnexample}
 
-The environment is one typed tensor network in one frame.  Each \tncmd{tn}
-declares an atom; \verb|&| advances one site.  \tnkey{ports=} types each
-face and may label it, and a typed port with no partner is an open index:
-open ink is declared content, so the picture exposes exactly the indices its
-atoms state.
+You have drawn a matrix-product word.  \tnenv{tenkz} holds one typed
+tensor network in one frame: \tnkey{cols=3} lays three cells on a wire,
+each \tncmd{tn} declares an atom in the next cell, and \verb|&| advances
+one site.  Adjacent cells contract by default --- those are the horizontal
+bonds --- so the only indices you declare are the open ones.
+\tnkey{ports=} types each face and may label it, and a typed port with no
+partner is an open index.  Open ink is declared content: the picture
+exposes exactly the indices its atoms state, and the margin quotes the
+boundary signature the compiler wrote to the \tnfile{.tnlog} event stream
+--- two virtual stubs, three physical legs, nothing you did not say.
 
-Beamer reads a frame's body before typesetting it, so a chained picture
-reaches the environment with its \verb|&| already an ordinary alignment tab,
-and an equation reaches the wrapper with its relation glyph already an
-ordinary character.  Both read their bodies as captured tokens and find the
-tab and the glyph there themselves, so a chained picture and an equation
-each compile in a plain frame; no \texttt{[fragile]} marking is needed.
+\dbendpar Beamer reads a frame's body before typesetting it, so a chained
+picture reaches the environment with its \verb|&| already an ordinary
+alignment tab.  The picture reads its body as captured tokens and finds
+the tab there itself, so it compiles in a plain frame; no
+\texttt{[fragile]} marking is needed.
 
-\subsection{A channel sandwich}
+\tnexercise{ex:tut-matrix} Draw the plain matrix $M$ --- one atom, both
+virtual indices open, no physical leg --- and say what boundary signature
+it writes.
+
+\subsection{Layers and side policy}
+
+One new idea: rows are layers.
 
 \begin{tnexample}[
   formula={\mathcal E_A(X)=\sum_i A^i X A^{i\dagger}},
@@ -51,32 +77,258 @@ each compile in a plain frame; no \texttt{[fragile]} marking is needed.
 \end{tenkz}
 \end{tnexample}
 
-\tnkey{rows=} declares ket over bra and pairs their physical legs; the
-conjugate is label mathematics.  A cup connects adjacent layers; it is not a
-same-row trace.
+\tnkey{rows=} declares a ket layer over a bra layer, and the frame
+contracts their facing physical ports --- the vertical bond that sums $i$.
+The conjugate is label mathematics: $\overline{A}$ is a name, not a flag.
+The sides then state policy from a four-word alphabet.  \tnval{open} mints
+legs and puts them in the signature; \tnval{none}, the default, is a side
+with no indices at all; \tnval{trace} returns a row to itself; \tnval{cup}
+closes adjacent layers onto each other.  Here \tnkey{east=}\tnval{\{cup=\$X\$\}}
+closes the pair through the matrix $X$, and the west pair stays open, so
+the picture is a map --- which is exactly what its two-entry signature
+says.
 
-\subsection{Compose an equation}
+\dbendpar The labelled cup is sugar: it expands to the side word
+\tnval{cup} plus a ring atom standing halfway along the generated cup
+wire, so the kernel record stream never contains a ``labelled cup'',
+only a wire named \tnval{cup-1-2} and an atom on it.  Every sugar row in
+the registry states its expansion this way, and \tncmd{tnset}\tnval{\{strict\}}
+rejects sugar outright.
+
+\tnexercise{ex:tut-transfer} Draw the transfer matrix
+$E=\sum_i A^i\otimes\overline{A^i}$: ket over bra, the physical pair
+contracted, all four virtual ends open.
+
+\tnexercise{ex:tut-closed} The spelling
+\verb|\tnwire[closed]{(1,1)}{(2,1)}| refuses to compile.  Why?
+
+\subsection{The boundary alphabet, three ways}
+
+The pair spelling \tnkey{boundary=} states \tnkey{west=} and \tnkey{east=}
+at once, and its three words draw three different objects from one row of
+matrices:
+
+\begin{tnmultiples}[
+  formula={(M_1M_2M_3)_{\alpha\beta}},
+  caption={one row, three side policies},
+  index={Left to right: the outer bonds close trivially and nothing is
+    exposed; both ends open and the row is a matrix; the trace returns the
+    row to itself and the picture is a scalar.  The quoted signature is the
+    open panel's; the other two are empty.},
+  signature={kernel-boundary|signature=open:e, open:w},
+  variants={{boundary=none}{boundary=none},
+            {boundary=open}{boundary=open},
+            {boundary=periodic}{boundary=periodic}}]
+% Formula: M_1 M_2 M_3 under three side policies.
+\begin{tenkz}[rows={wire}, cols=3, variant]
+  \tn{$M_1$} & \tn{$M_2$} & \tn{$M_3$}
+\end{tenkz}
+\end{tnmultiples}
+
+One family, one figure: the three panels share every token except the
+word under them.  \tnval{none} is the explicit spelling of the default
+--- a side that says nothing exposes nothing, the way a bond that closes
+trivially at the chain's outer ends deserves no ink.  \tnval{open} turns
+the row into the matrix $M_1M_2M_3$, and \tnval{periodic} (sugar for
+\tnkey{west=}\tnval{trace}, \tnkey{east=}\tnval{trace}) closes the row on
+itself.  Same atoms, same bonds; only the boundary signature moves.
+
+\dbendpar The default is a statement, not an omission.  The deleted
+0.7 dialect drew west and east stubs unbidden and sealed them with
+\tnval{none}; the kernel mints a leg only on declaration, so
+\tnval{none} now changes nothing and merely says so.  That reading died
+with the old front end --- if you sealed stubs once, stop: there are no
+stubs to seal.
+
+\tnexercise{ex:tut-trace} Draw the scalar
+$\operatorname{tr}(M_1M_2M_3)$ and say what its boundary signature is.
+
+\subsection{A mark over a run}
 
 \begin{tnexample}[
+  formula={A^{[3]}=A^{i_1}A^{i_2}A^{i_3}},
+  caption={a bracket over a cell range},
+  index={The bracket speaks from the south, past the site names and their
+    ink.  The signature is Example \ref{tnex:tut-word}'s, unchanged: a
+    mark owns no topology.},
+  signature={kernel-boundary|signature=open:e, open:w, phys:n, phys:n, phys:n}]
+% Formula: the blocked word A^{[3]}; the mark adds no index.
+\begin{tenkz}[cols=3]
+  \tn[ports={180:virtual:$\alpha$, 0:virtual, 90:physical:$i_1$}]{A} &
+  \tn[ports={180:virtual, 0:virtual, 90:physical:$i_2$}]{A} &
+  \tn[ports={180:virtual, 0:virtual:$\beta$, 90:physical:$i_3$}]{A}
+  \tnmark[form=bracket]{(1,1) .. (1,3)}{$A^{[3]}$}
+\end{tenkz}
+\end{tnexample}
+
+\tncmd{tnmark} annotates a target without touching the contraction.  The
+target here is a selector: \tnval{(1,1)} names a cell of the frame, and
+the two-dot range \tnval{(1,1) .. (1,3)} names the records between two
+cells in the frame's own order.  A bracket that names no side speaks from
+the south, where a brace under a span belongs.  Compare the margin with
+Example~\ref{tnex:tut-word}: the signature has not moved, because marks
+never own topology --- delete every mark and no contraction changes.
+
+\dbendpar The range is written with two dots, never a hyphen, because
+generated record names carry hyphens of their own: a cluster member is
+named \tnval{a-2-2}, and a hyphen range could not be told from it.
+
+\tnexercise{ex:tut-enclosure} Restate the same run as a tinted enclosure
+whose label sits below the contour.
+
+\subsection{An equation under audit}
+
+The fifth idea is the one the others were preparing: whole pictures
+compose into an equation, and the equation is an audit scope.
+
+\begin{tnexample}[
+  label={tnex:tut-eq},
   formula={B^i=XA^iX^{-1}},
-  caption={pictures compose as mathematical atoms},
-  index={The capsules are matrices on the wire and add no indices.  Both
-    sides expose one west stub, one east stub, and one physical leg.},
-  signature={kernel-boundary|signature=open:e, open:w, phys:n}]
-% Formula: B^i = X A^i X^{-1}; both boundary signatures agree.
+  caption={a gauge identity, audited},
+  index={The rings are matrices on the wire and add no indices.  Both
+    panels expose one west stub, one east stub, and one physical leg, so
+    the audit records the relation as equal.},
+  signature={check|scope=1|relation=1|result=equal|signature=open:e, open:w, phys:n}]
+% Formula: B^i = X A^i X^{-1}; one relation, audited.
 \[
- \begin{tenkz}[cols=1]
-   \tn[ports={180:virtual, 0:virtual, 90:physical:$i$}]{B}
- \end{tenkz}
- =
- \begin{tenkz}[cols=3]
-   \tn[skin=ring, ports={180:virtual, 0:virtual}]{X} &
-   \tn[ports={180:virtual, 0:virtual, 90:physical:$i$}]{A} &
-   \tn[skin=ring, ports={180:virtual, 0:virtual}]{X^{-1}}
- \end{tenkz}
+\begin{tenkzeq}[check=signature]
+  \begin{tenkz}[cols=1]
+    \tn[ports={180:virtual, 0:virtual, 90:physical:$i$}]{B}
+  \end{tenkz}
+  =
+  \begin{tenkz}[cols=3]
+    \tn[skin=ring, ports={180:virtual, 0:virtual}]{X} &
+    \tn[ports={180:virtual, 0:virtual, 90:physical:$i$}]{A} &
+    \tn[skin=ring, ports={180:virtual, 0:virtual}]{X^{-1}}
+  \end{tenkz}
+\end{tenkzeq}
 \]
 \end{tnexample}
 
-Ordinary TeX owns the equals sign.  Each picture remains an independent
-model and event stream; the audit compares their boundary signatures.
+\tnenv{tenkzeq} places its panels around the mathematics between them ---
+the equals sign is ordinary TeX --- under one shared metric, so a glyph
+is one size on both sides of an equality.  Then it audits: every panel
+carries a boundary signature, and a relation requires its two sides to
+expose the same one.  \tnkey{check=}\tnval{signature} names that audit
+(it is also the default: writing it states what is already running), and
+the margin quotes the \tnval{check} event the equation wrote beside each
+panel's boundary line.  A diagrammatic identity in this language is not a
+juxtaposition that looks right; it is a comparison that ran.
 
+What does a failed comparison look like?  Drop the physical leg of $B$
+and the compiler answers:
+
+\begin{tnrefusal}[
+  caption={the audit catches a dropped leg},
+  index={The left panel now exposes two indices, the right three.  The
+    correction is one token: restore the port 90:physical:$i$ on $B$.},
+  diagnostic={[TKZ-EQ-SIGNATURE] sides 1 and 2 expose unequal boundaries:
+    (open:e, open:w) versus (open:e, open:w, phys:n).}]
+% Refused: B lost its physical leg, so the relation's two
+% sides no longer expose the same boundary.
+\[
+\begin{tenkzeq}[check=signature]
+  \begin{tenkz}[cols=1]
+    \tn[ports={180:virtual, 0:virtual}]{B}
+  \end{tenkz}
+  =
+  \begin{tenkz}[cols=3]
+    \tn[skin=ring, ports={180:virtual, 0:virtual}]{X} &
+    \tn[ports={180:virtual, 0:virtual, 90:physical:$i$}]{A} &
+    \tn[skin=ring, ports={180:virtual, 0:virtual}]{X^{-1}}
+  \end{tenkz}
+\end{tenkzeq}
+\]
+\end{tnrefusal}
+
+Read refusals as language, not as accidents: the code names the check
+that failed, and the message prints both signatures so the missing entry
+is visible at once.  The correction is the port list of
+Example~\ref{tnex:tut-eq}'s~$B$.
+
+\ddbendpar Relations are one of three joiner classes.  A sum also
+requires equal signatures; a product instead contracts the facing cut,
+east entries of the left factor cancelling west entries of the right,
+and exposes the rest.  The comparison can be taken up to bundling ---
+\tnkey{check=}\tnval{\{signature, modulo=bundles\}} reads a bundled index
+and its members as one entry --- and a relation whose two sides are
+known, unequal, and equal anyway for a reason the diagram does not draw
+carries a recorded opt-out,
+\tnval{off=\{<relation>: <reason>\}}, written to the event stream beside
+the waiver.  The audit cannot be switched off silently.
+
+\tnexercise{ex:tut-checkword} Why does
+\tnkey{check=}\tnval{\{signature, modulo=member\}} refuse?
+
+\subsection{Answers to the exercises}
+
+\begin{tnexample}[
+  answer={ex:tut-matrix},
+  formula={M_{\alpha\beta}},
+  index={Two typed ports with no partners: the matrix keeps two open
+    virtual indices and nothing else.},
+  signature={kernel-boundary|signature=open:e, open:w}]
+% Formula: the matrix M with both virtual indices open.
+\begin{tenkz}[cols=1]
+  \tn[ports={180:virtual:$\alpha$, 0:virtual:$\beta$}]{M}
+\end{tenkz}
+\end{tnexample}
+
+\begin{tnexample}[
+  answer={ex:tut-transfer},
+  formula={E=\sum_i A^i\otimes\overline{A^i}},
+  index={The frame contracts the ket-bra physical pair; all four virtual
+    ends stay open, so $E$ is a map on the doubled space.},
+  signature={kernel-boundary|signature=open:e, open:e, open:w, open:w}]
+% Formula: E = sum_i A^i tensor conj(A^i).
+\begin{tenkz}[rows={ket,bra}, cols=1, west=open, east=open]
+  \tn[label pos=180]{A} \\
+  \tn[label pos=180]{$\overline{A}$}
+\end{tenkz}
+\end{tnexample}
+
+\tnanswer{ex:tut-closed} A closed wire is a smooth cycle, so it has no
+ends to give; every other wire has exactly two.  The spelling states
+both at once and is refused with the coded error
+\tnval{[TKZ-LANG-WIRE-ARITY]}: \emph{a closed wire takes no positional
+ends; every other wire takes exactly two}.  Keep \tnval{closed} for a
+free loop, or keep the two ends for a bond.
+
+\begin{tnexample}[
+  answer={ex:tut-trace},
+  formula={\operatorname{tr}(M_1M_2M_3)},
+  index={The trace returns the row to itself; no index is left open, and
+    the empty signature says scalar.},
+  signature={kernel-boundary|signature=}]
+% Formula: tr(M_1 M_2 M_3); sugar: boundary=periodic
+% expands to west=trace, east=trace.
+\begin{tenkz}[rows={wire}, cols=3, boundary=periodic]
+  \tn{$M_1$} & \tn{$M_2$} & \tn{$M_3$}
+\end{tenkz}
+\end{tnexample}
+
+\begin{tnexample}[
+  answer={ex:tut-enclosure},
+  formula={A^{[3]}},
+  index={The enclosure strokes the offset hull of the selection and tint
+    lays ink over the paper inside it; the physical legs pierce the
+    contour, and the signature still does not move.},
+  signature={kernel-boundary|signature=open:e, open:w, phys:n, phys:n, phys:n}]
+% Formula: the blocked word inside one tinted contour.
+\begin{tenkz}[cols=3]
+  \tn[ports={180:virtual:$\alpha$, 0:virtual, 90:physical:$i_1$}]{A} &
+  \tn[ports={180:virtual, 0:virtual, 90:physical:$i_2$}]{A} &
+  \tn[ports={180:virtual, 0:virtual:$\beta$, 90:physical:$i_3$}]{A}
+  \tnmark[form=enclosure, tint,
+          label pos=270]{(1,1) .. (1,3)}{$A^{[3]}$}
+\end{tenkz}
+\end{tnexample}
+
+\tnanswer{ex:tut-checkword} The audit refuses words it does not know
+rather than passing over them, because a spelling the audit ignores is a
+comparison you believe is running and is not.  The coded error is
+\tnval{[TKZ-EQ-CHECK-WORD]}: \emph{the audit does not know
+`modulo=member'; check= states the audit (signature), the equivalence it
+is taken up to (modulo=bundles), and its recorded opt-outs
+(off=\{<relation>: <reason>\})}.  The one admitted equivalence word is
+\tnval{bundles}.

--- a/docs/tenkz/tenkzmanual2.sty
+++ b/docs/tenkz/tenkzmanual2.sty
@@ -329,16 +329,20 @@
 % The refusal unit: head, printed source, and the coded diagnostic the
 % source raises — no rendered output, because the source does not compile.
 % The doctest compiles the body, requires the failure, and requires the
-% diagnostic's bracketed code in the transcript.
+% diagnostic's bracketed code in the transcript.  Refusals get their own
+% counter, stepped before the header prints (mirroring \mtwo_unit_head:'s
+% \refstepcounter{tnexample}), so label= attaches to the refusal itself
+% rather than to whatever counter was last stepped.
 \cs_new_protected:Npn \mtwo_refusal_render:
   {
     \par \addvspace{\mtwo@unitsep}
     \mtwo@thinrule
     \nobreak \vspace{\mtwo@unitseam}
+    \refstepcounter{tnrefusal}
     \noindent
     {
       \small
-      {\scshape a~deliberate~refusal}
+      {\scshape a~deliberate~refusal~\thetnrefusal}
       \tl_if_empty:NF \l_mtwo_caption_tl
         { ~~\textcolor{mquiet}{$\cdot$}~~ \tl_use:N \l_mtwo_caption_tl }
     }
@@ -446,6 +450,14 @@
   {\end{VerbatimOut}%
    \mtwoExampleRender}
 
+% refusal numbering restarts with each section, mirroring tnexample's
+% counter above; the two counters are independent, so a refusal and an
+% example in the same section can both read "2.1".
+\newcounter{tnrefusal}[section]
+\renewcommand{\thetnrefusal}{\arabic{section}.\arabic{tnrefusal}}
+\providecommand*{\theHtnrefusal}{}
+\renewcommand*{\theHtnrefusal}{\thetnrefusal}
+
 % ----- tnrefusal -----------------------------------------------------------
 % \begin{tnrefusal}[<keys>, diagnostic={<coded message>}]
 %   <tenkz source, verbatim>
@@ -455,8 +467,9 @@
 % beneath it, and nothing renders, because the source does not compile.
 % The diagnostic key quotes the coded message text; the doctest compiles
 % the body standalone, requires the failure, and requires the bracketed
-% code in the transcript, so the quoted message cannot rot.  The caption,
-% index, and label keys apply as in tnexample.
+% code in the transcript, so the quoted message cannot rot.  The caption
+% and index keys apply as in tnexample; label applies as in tnexample too,
+% referenced as Refusal \ref{...} against the refusal's own counter.
 \newenvironment{tnrefusal}[1][]
   {\mtwoUnitSetup{#1}%
    \VerbatimEnvironment

--- a/docs/tenkz/tenkzmanual2.sty
+++ b/docs/tenkz/tenkzmanual2.sty
@@ -7,9 +7,11 @@
 % quiet block.  Every example is live-compiled: the body of a tnexample or
 % tnmultiples environment is written verbatim to an auxiliary file and read
 % back, so the rendered output is produced by the exact source shown.  If an
-% example stops compiling, the manual stops compiling.
+% example stops compiling, the manual stops compiling.  A tnrefusal body is
+% the deliberate exception: it prints without rendering, and the doctest
+% requires it to fail with the diagnostic the manual quotes.
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{tenkzmanual2}[2026/07/22 v2.1 compact tenkz manual typography]
+\ProvidesPackage{tenkzmanual2}[2026/08/10 v2.2 compact tenkz manual typography]
 
 % ---------------------------------------------------------------------------
 %  Page grid (Tufte-lite, one-sided; margin column on the right)
@@ -101,6 +103,29 @@
 \newcommand{\tnlogline}[1]{{\ttfamily\scriptsize #1}}
 
 % ---------------------------------------------------------------------------
+%  Dangerous bends and exercises (the TeXbook devices)
+% ---------------------------------------------------------------------------
+\RequirePackage{manfnt}% \dbend, the road sign
+% \dbendpar / \ddbendpar — open a paragraph a first reading may skip: one
+% bend marks advanced or trap material, two bends the truly advanced.  The
+% sign stands in the margin; the paragraph itself is ordinary text.
+\newcommand*{\dbendpar}{\marginnote{\dbend}}
+\newcommand*{\ddbendpar}{\marginnote{\dbend\kern 2pt\dbend}}
+
+% \tnexercise{<label>} — an exercise, numbered per section; its answer
+% opens with \tnanswer{<label>} in the chapter's closing answers block,
+% and a pictured answer carries answer=<label> on its tnexample instead.
+\newcounter{tnexercise}[section]
+\renewcommand{\thetnexercise}{\arabic{section}.\arabic{tnexercise}}
+\providecommand*{\theHtnexercise}{}
+\renewcommand*{\theHtnexercise}{\thetnexercise}
+\newcommand{\tnexercise}[1]{\par\addvspace{0.52\baselineskip}%
+  \refstepcounter{tnexercise}\label{#1}%
+  \noindent{\small\scshape exercise~\thetnexercise}\enspace\ignorespaces}
+\newcommand{\tnanswer}[1]{\par\addvspace{0.52\baselineskip}%
+  \noindent{\small\scshape answer~\ref{#1}}\enspace\ignorespaces}
+
+% ---------------------------------------------------------------------------
 %  Inline markup
 % ---------------------------------------------------------------------------
 \newcommand{\meta}[1]{{\normalfont\itshape$\langle$#1$\rangle$}}
@@ -164,6 +189,8 @@
 \tl_new:N  \l_mtwo_index_tl
 \tl_new:N  \l_mtwo_signature_tl
 \tl_new:N  \l_mtwo_label_tl
+\tl_new:N  \l_mtwo_answer_tl
+\tl_new:N  \l_mtwo_diagnostic_tl
 \tl_new:N  \l_mtwo_variants_tl
 \bool_new:N \l_mtwo_wide_bool
 \bool_new:N \l_mtwo_source_bool
@@ -177,6 +204,8 @@
     index     .tl_set:N   = \l_mtwo_index_tl,
     signature .tl_set:N   = \l_mtwo_signature_tl,
     label     .tl_set:N   = \l_mtwo_label_tl,
+    answer    .tl_set:N   = \l_mtwo_answer_tl,
+    diagnostic .tl_set:N  = \l_mtwo_diagnostic_tl,
     variants  .tl_set:N   = \l_mtwo_variants_tl,
     wide      .bool_set:N = \l_mtwo_wide_bool,
     wide      .default:n  = { true },
@@ -190,6 +219,8 @@
     \tl_clear:N \l_mtwo_index_tl
     \tl_clear:N \l_mtwo_signature_tl
     \tl_clear:N \l_mtwo_label_tl
+    \tl_clear:N \l_mtwo_answer_tl
+    \tl_clear:N \l_mtwo_diagnostic_tl
     \tl_clear:N \l_mtwo_variants_tl
     \bool_set_false:N \l_mtwo_wide_bool
     \bool_set_true:N  \l_mtwo_source_bool
@@ -198,16 +229,20 @@
 
 % The caption line: rule, "example <n> . <caption>", label, sidenote mark,
 % and the combined margin block (formula over legend over signature).
+% A unit carrying answer=<exercise label> is an exercise answer: it heads
+% "answer <n>" from that exercise's number and steps no example counter.
 \cs_new_protected:Npn \mtwo_unit_head:
   {
     \par \addvspace{\mtwo@unitsep}
     \mtwo@thinrule
     \nobreak \vspace{\mtwo@unitseam}
-    \refstepcounter{tnexample}
+    \tl_if_empty:NT \l_mtwo_answer_tl { \refstepcounter{tnexample} }
     \noindent
     {
       \small
-      {\scshape example~\thetnexample}
+      \tl_if_empty:NTF \l_mtwo_answer_tl
+        { {\scshape example~\thetnexample} }
+        { {\scshape answer~\exp_args:NV \ref \l_mtwo_answer_tl} }
       \tl_if_empty:NF \l_mtwo_caption_tl
         { ~~\textcolor{mquiet}{$\cdot$}~~ \tl_use:N \l_mtwo_caption_tl }
     }
@@ -291,15 +326,55 @@
       { \mtwo_unit_source:n { \jobname.exa } }
   }
 
-% One small-multiples panel: define the `variant' style at grid and cell
-% level, render the shared body, set the variant keys beneath it.  The
-% panel's reference point is the render's own baseline (the wire axis),
-% so the wires of all panels in a row are collinear.
+% The refusal unit: head, printed source, and the coded diagnostic the
+% source raises — no rendered output, because the source does not compile.
+% The doctest compiles the body, requires the failure, and requires the
+% diagnostic's bracketed code in the transcript.
+\cs_new_protected:Npn \mtwo_refusal_render:
+  {
+    \par \addvspace{\mtwo@unitsep}
+    \mtwo@thinrule
+    \nobreak \vspace{\mtwo@unitseam}
+    \noindent
+    {
+      \small
+      {\scshape a~deliberate~refusal}
+      \tl_if_empty:NF \l_mtwo_caption_tl
+        { ~~\textcolor{mquiet}{$\cdot$}~~ \tl_use:N \l_mtwo_caption_tl }
+    }
+    \tl_if_empty:NF \l_mtwo_label_tl
+      { \exp_args:NV \label \l_mtwo_label_tl }
+    \tl_if_empty:NF \l_mtwo_index_tl
+      { \refstepcounter{sidenote} \, \msidemark }
+    \mtwo_unit_margin:
+    \par \nobreak
+    \mtwo_unit_source:n { \jobname.exa }
+    \par \nobreak \vspace{-0.45\baselineskip}
+    {
+      \noindent \footnotesize \ttfamily \color{mcmd}
+      \tl_use:N \l_mtwo_diagnostic_tl \par
+    }
+    \par \addvspace{\mtwo@unitsep}
+  }
+
+% One small-multiples panel: define the `variant' key at picture and atom
+% scope in the kernel's own key families, render the shared body, set the
+% variant keys beneath it.  The panel's reference point is the render's
+% own baseline (the wire axis), so the wires of all panels in a row are
+% collinear.
 \cs_new_protected:Npn \mtwo_variant_panel:nn #1 #2
   {
     \mode_leave_vertical:
-    \pgfqkeys{/tenkz/grid}{ variant/.style = {#2} }
-    \pgfqkeys{/tenkz/cell}{ variant/.style = {#2} }
+    \keys_define:nn { tenkz-kernel-picture }
+      {
+        variant .code:n    = { \keys_set:nn { tenkz-kernel-picture } {#2} },
+        variant .default:n = { },
+      }
+    \keys_define:nn { tenkz-kernel-atom }
+      {
+        variant .code:n    = { \keys_set:nn { tenkz-kernel-atom } {#2} },
+        variant .default:n = { },
+      }
     \hbox_set:Nn \l_mtwo_panel_box { \input{\jobname.exm} \unskip }
     \hbox_set:Nn \l_mtwo_panellab_box { \scriptsize \ttfamily #1 }
     \dim_set:Nn \l_mtwo_panel_dim
@@ -338,6 +413,7 @@
 
 \NewDocumentCommand{\mtwoUnitSetup}{m}{\mtwo_unit_setup:n {#1}}
 \NewDocumentCommand{\mtwoExampleRender}{}{\mtwo_example_render:}
+\NewDocumentCommand{\mtwoRefusalRender}{}{\mtwo_refusal_render:}
 \NewDocumentCommand{\mtwoMultiplesRender}{}{\mtwo_multiples_render:}
 \ExplSyntaxOff
 
@@ -369,6 +445,24 @@
    \begin{VerbatimOut}{\jobname.exa}}
   {\end{VerbatimOut}%
    \mtwoExampleRender}
+
+% ----- tnrefusal -----------------------------------------------------------
+% \begin{tnrefusal}[<keys>, diagnostic={<coded message>}]
+%   <tenkz source, verbatim>
+% \end{tnrefusal}
+%
+% A deliberate refusal: the source prints, the diagnostic it raises prints
+% beneath it, and nothing renders, because the source does not compile.
+% The diagnostic key quotes the coded message text; the doctest compiles
+% the body standalone, requires the failure, and requires the bracketed
+% code in the transcript, so the quoted message cannot rot.  The caption,
+% index, and label keys apply as in tnexample.
+\newenvironment{tnrefusal}[1][]
+  {\mtwoUnitSetup{#1}%
+   \VerbatimEnvironment
+   \begin{VerbatimOut}{\jobname.exa}}
+  {\end{VerbatimOut}%
+   \mtwoRefusalRender}
 
 % ----- tnmultiples ---------------------------------------------------------
 % \begin{tnmultiples}[<keys>, variants={{<lab>}{<opts>}, ...}]

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -182,7 +182,12 @@ def _refusal_diagnostic(options: str | None) -> str:
             continue
         value = value.strip()
         if value.startswith("{"):
-            end, value = _read_braced(value, 0)
+            braced_value = value
+            end, value = _read_braced(braced_value, 0)
+            if braced_value[end:].strip():
+                raise ValueError(
+                    "unexpected text after tnrefusal diagnostic brace"
+                )
         code = re.search(r"\[TKZ-[A-Z0-9-]+\]", value)
         if code is None:
             raise ValueError(

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -22,7 +22,7 @@ MANUAL = MANUAL_DIR / "manual2.tex"
 CHAPTERS = ROOT / "docs" / "tenkz" / "chapters2"
 REGISTRY = ROOT / "tex" / "tenkz" / "tenkz-language-registry.tex"
 REFERENCE = CHAPTERS / "generated-language-reference.tex"
-DISPLAY_ENVIRONMENTS = ("tnexample", "tnmultiples", "Verbatim")
+DISPLAY_ENVIRONMENTS = ("tnexample", "tnmultiples", "tnrefusal", "Verbatim")
 TEX_PRIMITIVE_CONDITIONALS = (
     "if", "ifcat", "ifnum", "ifdim", "ifodd", "ifvmode", "ifhmode",
     "ifmmode", "ifinner", "ifvoid", "ifhbox", "ifvbox", "ifx", "ifeof",
@@ -100,6 +100,7 @@ class Example:
     line: int
     document: str
     coverage_marker: str | None = None
+    expected_failure: str | None = None
 
 
 def _is_escaped(text: str, offset: int) -> bool:
@@ -169,6 +170,26 @@ def _read_braced(text: str, offset: int) -> tuple[int, str]:
     if end < 0:
         raise ValueError("unterminated braced group")
     return end, text[offset + 1 : end - 1]
+
+
+def _refusal_diagnostic(options: str | None) -> str:
+    """The bracketed code a tnrefusal block's quoted diagnostic pins."""
+    if options is None:
+        raise ValueError("tnrefusal requires a diagnostic option")
+    for option in _split_top_level(options):
+        key, separator, value = option.partition("=")
+        if not separator or key.strip() != "diagnostic":
+            continue
+        value = value.strip()
+        if value.startswith("{"):
+            end, value = _read_braced(value, 0)
+        code = re.search(r"\[TKZ-[A-Z0-9-]+\]", value)
+        if code is None:
+            raise ValueError(
+                "tnrefusal diagnostic quotes no bracketed [TKZ-*] code"
+            )
+        return code.group(0)
+    raise ValueError("tnrefusal requires a diagnostic option")
 
 
 def _multiple_variants(options: str | None) -> list[tuple[str, str]]:
@@ -694,10 +715,15 @@ def _source_label(path: Path) -> str:
 
 
 def _variant_definitions(variant_style: str) -> list[str]:
-    return [
-        rf"\pgfqkeys{{/tenkz/grid}}{{variant/.style={{{variant_style}}}}}",
-        rf"\pgfqkeys{{/tenkz/cell}}{{variant/.style={{{variant_style}}}}}",
-    ]
+    lines = [r"\ExplSyntaxOn"]
+    for scope in ("tenkz-kernel-picture", "tenkz-kernel-atom"):
+        lines.append(
+            rf"\keys_define:nn {{ {scope} }} {{ variant .code:n = "
+            rf"{{ \keys_set:nn {{ {scope} }} {{ {variant_style} }} }}, "
+            r"variant .default:n = { }, }"
+        )
+    lines.append(r"\ExplSyntaxOff")
+    return lines
 
 
 def _standalone_document(
@@ -770,6 +796,9 @@ def extract_displayed_examples(
         ):
             continue
         line = text.count("\n", 0, match.start()) + 1
+        expected_failure = (
+            _refusal_diagnostic(options) if environment == "tnrefusal" else None
+        )
         variants = (
             _multiple_variants(options)
             if environment == "tnmultiples"
@@ -786,6 +815,7 @@ def extract_displayed_examples(
                     document=_standalone_document(
                         body, path.parent, variant_style
                     ),
+                    expected_failure=expected_failure,
                 )
             )
     return examples
@@ -977,6 +1007,19 @@ def compile_example(example: Example, engine: str, work: Path) -> None:
         stderr=subprocess.STDOUT,
         timeout=120,
     )
+    if example.expected_failure:
+        if run.returncode == 0:
+            raise RuntimeError(
+                f"{example.source}:{example.line}: {example.label} compiled, "
+                "but the manual displays it as a refusal"
+            )
+        if example.expected_failure not in run.stdout:
+            tail = "\n".join(run.stdout.splitlines()[-60:])
+            raise RuntimeError(
+                f"{example.source}:{example.line}: {example.label} failed "
+                f"without the quoted diagnostic {example.expected_failure}\n{tail}"
+            )
+        return
     if run.returncode:
         tail = "\n".join(run.stdout.splitlines()[-60:])
         raise RuntimeError(

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -22,8 +22,11 @@ SPEC.loader.exec_module(DOCTEST)
 def main() -> int:
     manual = DOCTEST.displayed_examples()
     reference = DOCTEST.reference_examples()
-    if len(manual) != 11:
-        raise AssertionError(f"expected 11 displayed TeX examples, found {len(manual)}")
+    if len(manual) != 20:
+        raise AssertionError(f"expected 20 displayed TeX examples, found {len(manual)}")
+    refusals = [example for example in manual if example.expected_failure]
+    if [example.expected_failure for example in refusals] != ["[TKZ-EQ-SIGNATURE]"]:
+        raise AssertionError("the tutorial's refusal block was not pinned to its diagnostic")
     if len(reference) != 12:
         raise AssertionError(f"expected 12 reference examples, found {len(reference)}")
     if any(r"\begin{document}" not in example.document for example in manual):
@@ -126,7 +129,7 @@ shell command % \tntree{commented}
         r"\begin{tenkz}" not in example.document for example in extracted[:2]
     ):
         raise AssertionError("nested tnmultiple options confused body extraction")
-    if not all("variant/.style" in example.document for example in extracted[:2]):
+    if not all("variant .code:n" in example.document for example in extracted[:2]):
         raise AssertionError("tnmultiples variants were not installed independently")
     if r"\tntree" not in extracted[2].document:
         raise AssertionError("a registry command in Verbatim was not recognized as TeX")

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -25,8 +25,15 @@ def main() -> int:
     if len(manual) != 20:
         raise AssertionError(f"expected 20 displayed TeX examples, found {len(manual)}")
     refusals = [example for example in manual if example.expected_failure]
-    if [example.expected_failure for example in refusals] != ["[TKZ-EQ-SIGNATURE]"]:
-        raise AssertionError("the tutorial's refusal block was not pinned to its diagnostic")
+    if len(refusals) != 1:
+        raise AssertionError(
+            f"expected exactly one refusal block in the tutorial, found {len(refusals)}"
+        )
+    if refusals[0].expected_failure != "[TKZ-EQ-SIGNATURE]":
+        raise AssertionError(
+            "the tutorial's refusal block was not pinned to its diagnostic: "
+            f"found {refusals[0].expected_failure!r}"
+        )
     if len(reference) != 12:
         raise AssertionError(f"expected 12 reference examples, found {len(reference)}")
     if any(r"\begin{document}" not in example.document for example in manual):


### PR DESCRIPTION
Executes worklist item 1 (tutorial track) of `docs/tenkz/MANUAL-AUDIT-QUANTIKZ.md`: the tutorial is rewritten on the kernel surface in the TeXbook manner, with the Tufte margin apparatus kept throughout — every rendered example carries its formula, ink-to-index legend, and audited boundary signature in the margin.

## The five examples

1. **3.1 A word of tensors** — `tenkz`, `\tn`, `&`, typed and labelled `ports=`; open ink is declared content, and the margin quotes the five-entry signature.
2. **3.2 Layers and side policy** — `rows={ket,bra}`, the four-word side alphabet, `east={cup=$X$}` closing the channel input through `X`; the map's two-entry signature.
3. **3.3 The boundary alphabet, three ways** — the first use of the `tnmultiples` small-multiples environment: one row of matrices under `boundary=none`/`open`/`periodic`, one family per figure, only the signature moving.
4. **3.4 A mark over a run** — `\tnmark[form=bracket]` over the two-dot range `(1,1) .. (1,3)`; the margin shows Example 3.1's signature unchanged, because marks own no topology.
5. **3.5 An equation under audit** — the `tenkzeq` gauge identity `B^i = X A^i X^{-1}` with `check=signature`, the audited `check|…|result=equal|signature=…` event quoted in the margin. This closes F2's tutorial half: the fifth announced example now exists and is the equation story.

## TeXbook devices added

- **Dangerous bends**: `\dbendpar`/`\ddbendpar` margin signs (manfnt's road sign) in `tenkzmanual2.sty`; five single bends (beamer capture, cup sugar expansion, the kernel side default's history, hyphen-vs-two-dots, …) and one double bend (joiner classes, `modulo=bundles`, recorded opt-outs). A first reading can skip every bend and lose nothing.
- **A refusal on purpose**: a new `tnrefusal` environment displays the tenkzeq identity with `B`'s physical leg dropped, followed by the exact coded diagnostic the kernel raises — `[TKZ-EQ-SIGNATURE] sides 1 and 2 expose unequal boundaries: (open:e, open:w) versus (open:e, open:w, phys:n).` — and its one-token correction. The doctest compiles the block, **requires the failure**, and requires the bracketed code in the transcript, so the quoted message cannot rot. Two further diagnostics are quoted verbatim in exercise answers (`[TKZ-LANG-WIRE-ARITY]`, `[TKZ-EQ-CHECK-WORD]`), both verified against the live kernel.
- **Exercises with answers**: six exercises (one or two per section: transfer matrix, a trace scalar, a tinted enclosure, two "why does this refuse?" questions, …), answers collected in §3.6; the four pictured answers are `tnexample` blocks with a new `answer=` head, so they render and pass the doctest.
- **One-surface story**: the chapter opens with three sentences — the kernel is the surface, `\tenkzkernel` is an inert sunset word, dead spellings live in the compatibility appendix — and points to the ch-modes chooser instead of duplicating it.

## Apparatus changes (minimal, tutorial-serving)

- `tenkzmanual2.sty`: bend signs, exercise/answer commands, `answer=` and `diagnostic=` unit keys, `tnrefusal`; the `tnmultiples` variant hook is ported from the deleted grid front end's pgfkeys families (`/tenkz/grid`, `/tenkz/cell`) to the kernel's l3keys families (`tenkz-kernel-picture`, `tenkz-kernel-atom`), which is what puts the previously idle small-multiples instrument (F19's instrument, used here for F1) into service on the kernel surface.
- `scripts/tenkz_manual_doctest.py`: collects `tnrefusal` blocks and compiles them expecting failure plus the pinned `[TKZ-*]` code; `_variant_definitions` emits the l3keys form.
- `scripts/test_tenkz_manual_doctest.py`: pinned displayed-example count 11 → 20; asserts the refusal is pinned to `[TKZ-EQ-SIGNATURE]`; variant-injection assertion updated to the l3keys spelling.

## Findings discharged

- **F1 (tutorial half)** — every tutorial example is a rendered kernel-surface picture; zero raw coordinates, zero 0.7 spellings.
- **F2 (tutorial half)** — `tenkzeq` with `check=` is taught as the equation story, rendered, with the audit event in the margin. (F2's chapter half — the composition-and-metric chapter — is worklist item 3, another track.)
- **F11** — the tutorial now carries eight rendered diagrams plus three rendered answer pictures across §3; pictures no longer stop at page 6.
- **F12** — the two-surface story opens the chapter, where the reader first needs it.
- **F13** — five examples announced, five delivered (the fifth is the `tenkzeq` identity).
- **F14 (tutorial-adjacent)** — the tutorial demonstrates instead of narrating; the recipes chapter itself remains worklist item 1's recipes track, untouched here.

## Gates

- `python3 scripts/test_tenkz_manual_doctest.py` — PASS.
- `python3 scripts/tenkz_manual_doctest.py` — **PASS: 20 displayed manual examples and 12 reference examples** (includes the refusal compiled to expected failure and the three multiples variants compiled per panel).
- Full manual build from `docs/tenkz/`: `TEXINPUTS="../../tex/tenkz//:" xelatex manual2.tex`, three passes, rc=0 each, zero errors, zero LaTeX warnings — **21 pages** (was 17).
- Render evidence: tutorial pages inspected as PNG at **150 DPI** (`pdftocairo -png -r 150`, pages 3–9 of `manual2.pdf`): first picture within the first half page of the chapter; small-multiples panels, bracket, refusal diagnostic line, bend glyphs, and answer blocks all verified visually. Every example body was additionally compiled standalone and inspected at 150 DPI during drafting (probe renders of the mark, enclosure, trace, transfer, equation, and variant bodies).

## Left for other tracks

- Recipes chapter rewrite (worklist item 1's second half: the six `Verbatim` recipes → `tnexample`), reference regeneration (item 2), metric chapter (item 3), styling catalogue (item 4), migration spread (item 5), diagnostic phrasebook (item 6, though the tutorial now quotes three coded messages), the §1 doctest-promise/citation sentences (item 7), and the stale `tenkz_rmp.sh` quick-reference row (item 7).

Part of #4708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and manual build/test harness only; no runtime tenkz kernel or package behavior changes beyond how the manual compiles examples.
> 
> **Overview**
> **Tutorial (`ch-tutorial.tex`)** is rebuilt as five kernel-surface examples (tensor word → ket/bra sides → `tnmultiples` boundary policies → `\tnmark` → `tenkzeq` audit), with opening notes that `\tenkzkernel` is inert and legacy spellings live in the compatibility appendix. **Pedagogy** adds `\dbendpar`/`\ddbendpar`, six `\tnexercise` prompts, a §3.6 answer block (pictured answers via `tnexample` `answer=`), and one **`tnrefusal`** showing `[TKZ-EQ-SIGNATURE]` when a physical leg is dropped.
> 
> **Manual style (`tenkzmanual2.sty` v2.2)** implements bends, exercise/answer counters, `answer=` / `diagnostic=` keys, the **`tnrefusal`** environment (source + quoted diagnostic, no render), and switches **`tnmultiples`** variant injection from pgfkeys `/tenkz/grid`/`cell` to kernel **`tenkz-kernel-picture`** / **`tenkz-kernel-atom`** l3keys.
> 
> **Doctest** (`tenkz_manual_doctest.py`) treats `tnrefusal` like other display envs, pins **`expected_failure`** from the `diagnostic=` `[TKZ-*]` code, and emits l3keys variant definitions; **`test_tenkz_manual_doctest.py`** expects **20** displayed examples and exactly one refusal pinned to **`[TKZ-EQ-SIGNATURE]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7a7d817f44818912f80cb8cc0a48e8be833e395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->