### PR TITLE
feat(parent-hamiltonian): center overlapping mixed Gram

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.ParentHamiltonian.LimitingGramMetric
 import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
 
 /-!
@@ -20,6 +21,11 @@ Nachtergaele. The sourced target is the projector defect in Nachtergaele,
 arXiv:cond-mat/9410110, equation (2.4); the rational numerical estimate is quoted
 after that equation and in Section 6, equation (6.1). No numerical estimate is
 asserted here.
+
+## Main results
+
+* `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES`
+* `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered`
 -/
 
 open scoped Matrix
@@ -151,5 +157,48 @@ theorem inner_tailBoundaryMapES_adjoint_leftBoundaryMapES
     rw [hEvalAppend, hTailTrace]
     simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil,
       Matrix.mul_one]
+
+/-- Exact centering of the overlapping mixed Gram at the nonidentity limiting
+Gram metric.
+
+The limiting term acts by right multiplication: on the fiber indexed by
+\((u,j)\), it sends \(Y_jA^u\) to
+\((\operatorname{tr}\rho)^{-1}Y_jA^u\rho\). Hence subtracting this term leaves
+exactly the same mixed pairing with the finite Gram operator minus its limiting
+metric.
+
+This identity is reconstructed algebraically from the mixed-Gram formula and
+the limiting-metric computation. It is not attributed to FNW or Nachtergaele,
+and it asserts no convergence or norm estimate. -/
+theorem inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (htr : Matrix.trace ρ ≠ 0)
+    (x : BoundaryFamilySpace (D := D) (Cfg d K))
+    (y : BoundaryFamilySpace (D := D) (Cfg d 1)) :
+    inner ℂ x ((tailBoundaryMapES A K (l + 1)).adjoint
+        (leftBoundaryMapES A (K + l) 1 y)) -
+      ∑ u : Cfg d K, ∑ j : Cfg d 1,
+        inner ℂ
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+            (evalWord A (List.ofFn j) *
+              boundaryFamilyEquiv (D := D) (Cfg d K) x u))
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+            ((Matrix.trace ρ)⁻¹ •
+              ((boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
+                evalWord A (List.ofFn u)) * ρ))) =
+      ∑ u : Cfg d K, ∑ j : Cfg d 1,
+        inner ℂ
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+            (evalWord A (List.ofFn j) *
+              boundaryFamilyEquiv (D := D) (Cfg d K) x u))
+          ((groundSpaceGram A l -
+              Matrix.gramReshuffle (fixedPointProj ρ htr))
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+              (boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
+                evalWord A (List.ofFn u)))) := by
+  rw [inner_tailBoundaryMapES_adjoint_leftBoundaryMapES]
+  simp_rw [sub_apply, inner_sub_right,
+    Matrix.gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply,
+    Finset.sum_sub_distrib]
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
@@ -24,6 +24,7 @@ and the fiberwise Gram identities. No contraction estimate is asserted.
 
 * `range_tailBoundaryMapES` and `range_leftBoundaryMapES_one` identify the physical ranges.
 * `c3_injectiveRangeProjector_residual_eq` is the exact C3 common-factorization identity.
+* `norm_boundaryFiberwiseMap_le` bounds a fiberwise map uniformly in its spectator type.
 * `tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram` and
   `leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram` identify the Grams.
 * `inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram` and
@@ -420,6 +421,38 @@ theorem inner_boundaryFiberwiseMap (S : Type*) [Fintype S]
   rw [PiLp.inner_apply]
   simp only [boundaryFiberwiseMap_apply_apply, Fintype.sum_prod_type,
     boundaryFamilyFiber, PiLp.inner_apply]
+
+/-- Applying the same operator independently on each boundary fiber does not
+increase its operator norm. This estimate is uniform in the finite spectator
+type and remains valid when that type is empty. -/
+theorem norm_boundaryFiberwiseMap_le (S : Type*) [Fintype S]
+    (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      EuclideanSpace ℂ (Fin D × Fin D)) :
+    ‖boundaryFiberwiseMap (D := D) S G‖ ≤ ‖G‖ := by
+  refine ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg G) fun x ↦ ?_
+  rw [← sq_le_sq₀ (norm_nonneg _) (mul_nonneg (norm_nonneg G) (norm_nonneg x)),
+    mul_pow, EuclideanSpace.norm_sq_eq, EuclideanSpace.norm_sq_eq]
+  calc
+    ∑ sp : S × (Fin D × Fin D),
+        ‖boundaryFiberwiseMap (D := D) S G x sp‖ ^ 2 =
+        ∑ s, ∑ p, ‖G (boundaryFamilyFiber (D := D) x s) p‖ ^ 2 := by
+      rw [Fintype.sum_prod_type]
+      rfl
+    _ = ∑ s, ‖G (boundaryFamilyFiber (D := D) x s)‖ ^ 2 := by
+      apply Finset.sum_congr rfl
+      intro s _
+      rw [EuclideanSpace.norm_sq_eq]
+    _ ≤ ∑ s, (‖G‖ * ‖boundaryFamilyFiber (D := D) x s‖) ^ 2 := by
+      apply Finset.sum_le_sum
+      intro s _
+      exact (sq_le_sq₀ (norm_nonneg _)
+        (mul_nonneg (norm_nonneg G) (norm_nonneg _))).mpr (G.le_opNorm _)
+    _ = ‖G‖ ^ 2 * ∑ sp : S × (Fin D × Fin D), ‖x sp‖ ^ 2 := by
+      rw [Fintype.sum_prod_type, Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro s _
+      rw [mul_pow, EuclideanSpace.norm_sq_eq]
+      simp only [boundaryFamilyFiber, Finset.mul_sum]
 
 /-- The tail Gram is the direct sum, over prefix spectators, of copies of the
 length-`L` MPS Gram. This bilinear identity remains valid for empty spectator types. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -385,6 +385,26 @@ norm estimate is derived here.
     inverse formulas.
 \end{proof}
 
+\begin{lemma}[Norm of a fiberwise boundary operator]%
+    \label{lem:boundary_fiberwise_map_norm}
+    \lean{MPSTensor.norm_boundaryFiberwiseMap_le}
+    \leanok
+    Let $S$ be a finite spectator index set, let $V$ be the Euclidean virtual
+    matrix space, and let $G:V\to V$ be linear.  If $G^{\oplus S}$ acts on a
+    boundary family $x=(x_s)_{s\in S}$ by
+    $(G^{\oplus S}x)_s=Gx_s$, then
+    \begin{align}
+      \lVert G^{\oplus S}\rVert\leq \lVert G\rVert .
+    \end{align}
+    This estimate also holds when $S$ is empty.
+\end{lemma}
+\begin{proof}
+    \leanok
+    Square both sides of the pointwise estimate
+    $\lVert Gx_s\rVert\leq\lVert G\rVert\lVert x_s\rVert$, sum over $s\in S$,
+    and use the Euclidean direct-sum norm identity.
+\end{proof}
+
 \begin{theorem}[Exact C3 projector residual identity]%
     \label{thm:c3_spectator_projector_residual}
     \lean{MPSTensor.c3_injectiveRangeProjector_residual_eq}
@@ -412,8 +432,7 @@ norm estimate is derived here.
     \label{thm:spectator_boundary_mixed_gram}
     \lean{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}
     \leanok
-    \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram,
-        lem:eval_word_append,thm:ground_space_map_es_frobenius}
+    \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram}
     Let $X=(X_u)_{u\in\Fin d^K}$ and
     $Z=(Z_j)_{j\in\Fin d^1}$ be virtual boundary-matrix families.  For the
     tail window of length $l+1$ and the left window of length $K+l$, their
@@ -454,6 +473,38 @@ norm estimate is derived here.
     exactly the boundary-map Gram pairing
     $\langle U(A^jX_u),\mathcal K_l U(Z_jA^u)\rangle$.  Summing over $u$ and
     $j$ proves the identity.
+\end{proof}
+
+\begin{theorem}[Centered mixed Gram at the limiting metric]%
+    \label{thm:spectator_boundary_mixed_gram_centered}
+    \lean{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered}
+    \leanok
+    \uses{thm:spectator_boundary_mixed_gram,thm:fixed_point_gram_metric_exact}
+    Let $\rho\in\MN{D}$ have nonzero trace, let
+    $\mathcal K_\infty=\mathscr R(P_\rho)$, and retain the boundary families
+    $X=(X_u)_u$ and $Z=(Z_j)_j$ from the preceding theorem.  Then
+    \begin{align}
+      &\left\langle X,
+        (\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
+        \Gamma^{\mathrm{left}}_{K+l,1}Z\right\rangle
+        -\sum_{u,j}\left\langle
+          U(A^jX_u),\mathcal K_\infty U(Z_jA^u)\right\rangle \\
+      &\qquad=\sum_{u,j}\left\langle
+          U(A^jX_u),(\mathcal K_l-\mathcal K_\infty)U(Z_jA^u)
+        \right\rangle .
+    \end{align}
+    Here
+    $\mathcal K_\infty U(Z_jA^u)
+      =U((\tr\rho)^{-1}Z_jA^u\rho)$,
+    so the limiting multiplication is on the right and is generally not the
+    identity.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:spectator_boundary_mixed_gram,thm:fixed_point_gram_metric_exact}
+    Substitute the exact mixed-Gram formula and the right-multiplication action
+    of $\mathcal K_\infty$, then distribute subtraction through the two finite
+    sums and the second argument of the inner product.
 \end{proof}
 
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -385,8 +385,8 @@ norm estimate is derived here.
     inverse formulas.
 \end{proof}
 
-\begin{lemma}[Norm of a fiberwise boundary operator]%
-    \label{lem:boundary_fiberwise_map_norm}
+\begin{theorem}[Norm of a fiberwise boundary operator]%
+    \label{thm:boundary_fiberwise_map_norm}
     \lean{MPSTensor.norm_boundaryFiberwiseMap_le}
     \leanok
     Let $S$ be a finite spectator index set, let $V$ be the Euclidean virtual
@@ -397,7 +397,7 @@ norm estimate is derived here.
       \lVert G^{\oplus S}\rVert\leq \lVert G\rVert .
     \end{align}
     This estimate also holds when $S$ is empty.
-\end{lemma}
+\end{theorem}
 \begin{proof}
     \leanok
     Square both sides of the pointwise estimate


### PR DESCRIPTION
## Summary

- center the exact overlapping mixed-Gram pairing at the nonidentity limit
  \(K_\infty = \operatorname{gramReshuffle}(\operatorname{fixedPointProj}(\rho))\)
- use the proved right-multiplication action
  \(X \mapsto (\operatorname{tr}\rho)^{-1}X\rho\), preserving the verified multiplication order
- bound the operator norm of a fiberwise boundary map by the norm of its fiber operator, uniformly over finite spectator types, including empty types

The centered identity is reconstructed algebraically and is not attributed to FNW or Nachtergaele. It assumes only \(\operatorname{tr}\rho \ne 0\); no faithfulness is inferred from primitivity.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram TNLean.MPS.ParentHamiltonian.MixedGram`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/agent/issue-5923-mixed-gram`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/agent/issue-5923-mixed-gram`
- `git diff --check`

Addresses #5923

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style algebraic proofs and blueprint documentation in the parent-Hamiltonian martingale layer; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds an **exact centered mixed-Gram identity** for overlapping tail/left spectator boundary maps: the mixed pairing minus the limiting-metric contribution equals the same pairing with **\(\mathcal K_l - \mathcal K_\infty\)** on the second argument, using right multiplication \((\operatorname{tr}\rho)^{-1}X\rho\) for \(\mathcal K_\infty\). `MixedGram.lean` now imports `LimitingGramMetric` and documents the new theorem `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered`.
> 
> Adds **`norm_boundaryFiberwiseMap_le`**: the operator norm of a fiberwise boundary map is bounded by the norm of the per-fiber operator, uniformly over finite spectator types (including empty).
> 
> Blueprint **ch13** adds matching theorems for the fiberwise norm bound and centered mixed Gram, and trims `\uses` on the mixed-Gram theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a8ab09e1d4f337ef0714525bb825bfda61bb1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->