### PR TITLE
feat(ParentHamiltonian): compute overlapping mixed Gram

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -58,6 +58,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
+import TNLean.MPS.ParentHamiltonian.MixedGram
 import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities
 import TNLean.MPS.ParentHamiltonian.RestrictTransport

--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
+
+/-!
+# Mixed Gram of overlapping spectator boundary maps
+
+This file computes the mixed Gram between the tail and left spectator boundary
+maps in the common ambient space used by Nachtergaele's martingale condition C3.
+The calculation is exact: after fixing the prefix spectator `u` and final-site
+spectator `j`, the overlap is the length-`l` MPS Gram pairing of the two virtual
+matrices obtained at the ends of the overlap.
+
+The identity below is reconstructed directly from the boundary-map definitions,
+word factorization, and trace cyclicity. It is not stated in this form by FNW or
+Nachtergaele. The sourced target is the projector defect in Nachtergaele,
+arXiv:cond-mat/9410110, equation (2.4); the rational numerical estimate is quoted
+after that equation and in Section 6, equation (6.1). No numerical estimate is
+asserted here.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+open scoped Matrix.Norms.Frobenius
+
+/-- Three consecutive configuration blocks are equivalent to a configuration on
+their concatenated chain. -/
+def cfgAppendThreeEquiv (d K l R : ℕ) :
+    Cfg d K × (Cfg d l × Cfg d R) ≃ Cfg d (K + (l + R)) :=
+  (Equiv.prodCongr (Equiv.refl (Cfg d K)) (cfgAppendEquiv d l R)).trans
+    (cfgAppendEquiv d K (l + R))
+
+@[simp]
+theorem cfgAppendThreeEquiv_apply (d K l R : ℕ)
+    (u : Cfg d K) (τ : Cfg d l) (j : Cfg d R) :
+    cfgAppendThreeEquiv d K l R (u, (τ, j)) = Fin.append u (Fin.append τ j) := rfl
+
+/-- Exact mixed-Gram identity for the overlapping windows in Nachtergaele's C3
+geometry (arXiv:cond-mat/9410110, equation (2.4)).
+
+For a prefix spectator `u` and a one-site spectator `j`, the tail boundary
+matrix entering the `l`-site overlap is `A^j X_u`, while the left boundary
+matrix is `Z_j A^u`. Thus the mixed Gram is a sum of length-`l` ground-space
+Gram pairings with exactly this multiplication order.
+
+This is an algebraic identity reconstructed from the definitions, not the FNW
+contraction estimate quoted by Nachtergaele after equation (2.4) and in equation
+(6.1). -/
+theorem inner_tailBoundaryMapES_adjoint_leftBoundaryMapES
+    (A : MPSTensor d D) (K l : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg d K))
+    (y : BoundaryFamilySpace (D := D) (Cfg d 1)) :
+    inner ℂ x ((tailBoundaryMapES A K (l + 1)).adjoint
+      (leftBoundaryMapES A (K + l) 1 y)) =
+      ∑ u : Cfg d K, ∑ j : Cfg d 1,
+        inner ℂ
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+            (evalWord A (List.ofFn j) *
+              boundaryFamilyEquiv (D := D) (Cfg d K) x u))
+          (groundSpaceGram A l
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+              (boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
+                evalWord A (List.ofFn u)))) := by
+  rw [ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
+  trans ∑ p : Cfg d K × (Cfg d l × Cfg d 1),
+      inner ℂ
+        ((tailBoundaryMapES A K (l + 1) x) (cfgAppendThreeEquiv d K l 1 p))
+        ((leftBoundaryMapES A (K + l) 1 y) (cfgAppendThreeEquiv d K l 1 p))
+  · symm
+    apply Fintype.sum_equiv (cfgAppendThreeEquiv d K l 1)
+    intro p
+    rfl
+  · simp only [Fintype.sum_prod_type]
+    apply Finset.sum_congr rfl
+    intro u _
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [groundSpaceGram, ContinuousLinearMap.comp_apply,
+      ContinuousLinearMap.adjoint_inner_right,
+      groundSpaceMapES_frobeniusEquivEuclidean_apply,
+      groundSpaceMapES_frobeniusEquivEuclidean_apply, PiLp.inner_apply]
+    apply Finset.sum_congr rfl
+    intro τ _
+    have hTailPrefix :
+        Fin.append u (Fin.append τ j) ∘ Fin.castAdd (l + 1) = u := by
+      ext i
+      simp [Fin.append_left]
+    have hTailSuffix :
+        Fin.append u (Fin.append τ j) ∘ Fin.natAdd K = Fin.append τ j := by
+      ext i
+      simp [Fin.append_right]
+    have hLeftPrefix :
+        Fin.append u (Fin.append τ j) ∘ Fin.castAdd 1 = Fin.append u τ := by
+      ext i
+      have hi := congrFun (Fin.append_assoc u τ j) (Fin.castAdd 1 i)
+      apply congrArg Fin.val
+      simpa using hi.symm
+    have hLeftSuffix :
+        Fin.append u (Fin.append τ j) ∘ Fin.natAdd (K + l) = j := by
+      ext i
+      have hi := congrFun (Fin.append_assoc u τ j) (Fin.natAdd (K + l) i)
+      apply congrArg Fin.val
+      simpa using hi.symm
+    have hTailTrace :
+        Matrix.trace
+            (evalWord A (List.ofFn (Fin.append τ j)) *
+              boundaryFamilyEquiv (D := D) (Cfg d K) x u) =
+          Matrix.trace
+            (evalWord A (List.ofFn τ) *
+              (evalWord A (List.ofFn j) *
+                boundaryFamilyEquiv (D := D) (Cfg d K) x u)) := by
+      rw [List.ofFn_fin_append, evalWord_append]
+      simp only [Matrix.mul_assoc]
+    have hLeftTrace :
+        Matrix.trace
+            (evalWord A (List.ofFn (Fin.append u τ)) *
+              boundaryFamilyEquiv (D := D) (Cfg d 1) y j) =
+          Matrix.trace
+            (evalWord A (List.ofFn τ) *
+              (boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
+                evalWord A (List.ofFn u))) := by
+      rw [List.ofFn_fin_append, evalWord_append]
+      symm
+      simpa only [Matrix.mul_assoc] using Matrix.trace_mul_cycle
+        (evalWord A (List.ofFn τ))
+        (boundaryFamilyEquiv (D := D) (Cfg d 1) y j)
+        (evalWord A (List.ofFn u))
+    simp only [tailBoundaryMapES_apply, WithLp.linearEquiv_symm_apply,
+      AddEquiv.toEquiv_eq_coe, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
+      WithLp.addEquiv_symm_apply, cfgAppendThreeEquiv_apply,
+      tailBoundaryMap_apply, List.ofFn_succ, evalWord_cons,
+      boundaryFamilyEquiv_apply_apply,
+      leftBoundaryMapES_apply, leftBoundaryMap_apply, RCLike.inner_apply,
+      Fin.isValue, List.ofFn_zero, evalWord_nil, Matrix.mul_one,
+      groundSpaceMap_apply, hTailPrefix, hTailSuffix, hLeftPrefix, hLeftSuffix]
+    simp only [boundaryFamilyEquiv_apply_apply] at hTailTrace hLeftTrace
+    rw [hLeftTrace]
+    have hEvalAppend :
+        A (Fin.append τ j 0) *
+            evalWord A (List.ofFn fun i => Fin.append τ j i.succ) =
+          evalWord A (List.ofFn (Fin.append τ j)) := by
+      rw [List.ofFn_succ, evalWord_cons]
+    rw [hEvalAppend, hTailTrace]
+    simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil,
+      Matrix.mul_one]
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -10,8 +10,8 @@ import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
 
 This file computes the mixed Gram between the tail and left spectator boundary
 maps in the common ambient space used by Nachtergaele's martingale condition C3.
-The calculation is exact: after fixing the prefix spectator `u` and final-site
-spectator `j`, the overlap is the length-`l` MPS Gram pairing of the two virtual
+The calculation is exact: after fixing the prefix spectator \(u\) and final-site
+spectator \(j\), the overlap is the length-\(l\) MPS Gram pairing of the two virtual
 matrices obtained at the ends of the overlap.
 
 The identity below is reconstructed directly from the boundary-map definitions,

--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -32,13 +32,13 @@ open scoped Matrix.Norms.Frobenius
 
 /-- Three consecutive configuration blocks are equivalent to a configuration on
 their concatenated chain. -/
-def cfgAppendThreeEquiv (d K l R : ℕ) :
+private def cfgAppendThreeEquiv (d K l R : ℕ) :
     Cfg d K × (Cfg d l × Cfg d R) ≃ Cfg d (K + (l + R)) :=
-  (Equiv.prodCongr (Equiv.refl (Cfg d K)) (cfgAppendEquiv d l R)).trans
-    (cfgAppendEquiv d K (l + R))
+  (Equiv.prodCongr (Equiv.refl (Cfg d K)) (Fin.appendEquiv l R)).trans
+    (Fin.appendEquiv K (l + R))
 
 @[simp]
-theorem cfgAppendThreeEquiv_apply (d K l R : ℕ)
+private theorem cfgAppendThreeEquiv_apply (d K l R : ℕ)
     (u : Cfg d K) (τ : Cfg d l) (j : Cfg d R) :
     cfgAppendThreeEquiv d K l R (u, (τ, j)) = Fin.append u (Fin.append τ j) := rfl
 

--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -45,9 +45,9 @@ theorem cfgAppendThreeEquiv_apply (d K l R : ℕ)
 /-- Exact mixed-Gram identity for the overlapping windows in Nachtergaele's C3
 geometry (arXiv:cond-mat/9410110, equation (2.4)).
 
-For a prefix spectator `u` and a one-site spectator `j`, the tail boundary
-matrix entering the `l`-site overlap is `A^j X_u`, while the left boundary
-matrix is `Z_j A^u`. Thus the mixed Gram is a sum of length-`l` ground-space
+For a prefix spectator \(u\) and a one-site spectator \(j\), the tail boundary
+matrix entering the \(l\)-site overlap is \(A^j X_u\), while the left boundary
+matrix is \(Z_j A^u\). Thus the mixed Gram is a sum of length-\(l\) ground-space
 Gram pairings with exactly this multiplication order.
 
 This is an algebraic identity reconstructed from the definitions, not the FNW

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -412,7 +412,8 @@ norm estimate is derived here.
     \label{thm:spectator_boundary_mixed_gram}
     \lean{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}
     \leanok
-    \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram}
+    \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram,
+        lem:eval_word_append,thm:ground_space_map_es_frobenius}
     Let $X=(X_u)_{u\in\Fin d^K}$ and
     $Z=(Z_j)_{j\in\Fin d^1}$ be virtual boundary-matrix families.  For the
     tail window of length $l+1$ and the left window of length $K+l$, their
@@ -439,7 +440,7 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram,
-        lem:eval_word_append}
+        lem:eval_word_append,thm:ground_space_map_es_frobenius}
     Split a physical configuration into a prefix $u$, an overlap word $\tau$
     of length $l$, and a final-site configuration $j$.  The adjoint relation
     turns the mixed Gram into the physical inner product of the two boundary

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -433,8 +433,8 @@ norm estimate is derived here.
     $\tr(A^{\tau,j}X_u)=\tr(A^\tau(A^jX_u))$ and
     $\tr(A^{u,\tau}Z_j)=\tr(A^\tau(Z_jA^u))$.
     This exact identity is obtained from the definitions and trace cyclicity;
-    it is not the numerical FNW contraction quoted by Nachtergaele after
-    equation~(2.4) and in equation~(6.1).
+    it is not the numerical FNW contraction quoted in
+    \cite[after Equation~(2.4) and Equation~(6.1)]{Nachtergaele1996Spectral}.
 \end{theorem}
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -408,6 +408,36 @@ norm estimate is derived here.
     The preceding range equalities identify the three physical ranges.
 \end{proof}
 
+\begin{theorem}[Mixed Gram of the overlapping spectator boundary maps]%
+    \label{thm:spectator_boundary_mixed_gram}
+    \lean{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}
+    \leanok
+    \uses{thm:spectator_boundary_hilbert_factorization,
+        thm:spectator_boundary_direct_sum_gram}
+    Let $X=(X_u)_{u\in\Fin d^K}$ and
+    $Z=(Z_j)_{j\in\Fin d^1}$ be virtual boundary-matrix families.  For the
+    tail window of length $l+1$ and the left window of length $K+l$, their
+    mixed Gram in the common $(K+l+1)$-site Hilbert space is
+    \begin{align}
+      \left\langle X,
+        (\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
+        \Gamma^{\mathrm{left}}_{K+l,1}Z\right\rangle
+      &=\sum_{u\in\Fin d^K}\sum_{j\in\Fin d^1}
+        \left\langle
+          U(A^jX_u),\,
+          \mathcal K_l\,U(Z_jA^u)
+        \right\rangle,
+    \end{align}
+    where $U$ is Frobenius vectorization and
+    $\mathcal K_l=\Gamma_l^\dagger\Gamma_l$.  The multiplication order is
+    fixed by
+    $\tr(A^{\tau,j}X_u)=\tr(A^\tau(A^jX_u))$ and
+    $\tr(A^{u,\tau}Z_j)=\tr(A^\tau(Z_jA^u))$.
+    This exact identity is obtained from the definitions and trace cyclicity;
+    it is not the numerical FNW contraction quoted by Nachtergaele after
+    equation~(2.4) and in equation~(6.1).
+\end{theorem}
+
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -438,7 +438,8 @@ norm estimate is derived here.
 \end{theorem}
 \begin{proof}
     \leanok
-    \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram}
+    \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram,
+        lem:eval_word_append}
     Split a physical configuration into a prefix $u$, an overlap word $\tau$
     of length $l$, and a final-site configuration $j$.  The adjoint relation
     turns the mixed Gram into the physical inner product of the two boundary

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -412,8 +412,7 @@ norm estimate is derived here.
     \label{thm:spectator_boundary_mixed_gram}
     \lean{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}
     \leanok
-    \uses{thm:spectator_boundary_hilbert_factorization,
-        thm:spectator_boundary_direct_sum_gram}
+    \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram}
     Let $X=(X_u)_{u\in\Fin d^K}$ and
     $Z=(Z_j)_{j\in\Fin d^1}$ be virtual boundary-matrix families.  For the
     tail window of length $l+1$ and the left window of length $K+l$, their
@@ -437,6 +436,23 @@ norm estimate is derived here.
     it is not the numerical FNW contraction quoted by Nachtergaele after
     equation~(2.4) and in equation~(6.1).
 \end{theorem}
+\begin{proof}
+    \leanok
+    \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram}
+    Split a physical configuration into a prefix $u$, an overlap word $\tau$
+    of length $l$, and a final-site configuration $j$.  The adjoint relation
+    turns the mixed Gram into the physical inner product of the two boundary
+    vectors.  For each $(u,\tau,j)$, word multiplicativity and trace cyclicity
+    give
+    \begin{align}
+      \tr(A^{\tau,j}X_u)&=\tr(A^\tau(A^jX_u)),&
+      \tr(A^{u,\tau}Z_j)&=\tr(A^\tau(Z_jA^u)).
+    \end{align}
+    For fixed $(u,j)$, summing the resulting inner products over $\tau$ is
+    exactly the boundary-map Gram pairing
+    $\langle U(A^jX_u),\mathcal K_l U(Z_jA^u)\rangle$.  Summing over $u$ and
+    $j$ proves the identity.
+\end{proof}
 
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -703,6 +703,25 @@ and generic prerequisites now include:
     These are exact unweighted identities, including empty spectator types;
     they assert no direct-sum norm estimate.  The C3 specializations are stated
     next.
+  \item The mixed Gram of the C3 tail map at
+    \((K,l+1)\) and left map at \((K+l,1)\) is computed exactly by
+    \leanid{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}:
+    \begin{align}
+      \left\langle x,
+        (\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
+        \Gamma^{\mathrm{left}}_{K+l,1}y\right\rangle
+      &=\sum_{u\in\Fin d^K}\sum_{j\in\Fin d^1}
+        \left\langle U(A^jX_u),
+          \mathcal K_l U(Z_jA^u)\right\rangle.
+    \end{align}
+    Here \(X_u\) and \(Z_j\) are the matrix fibers of \(x\) and \(y\).
+    This formula is reconstructed exact algebra from the boundary-map
+    definitions, word factorization, and trace cyclicity.  It is not stated in
+    this form by FNW or Nachtergaele and is not attributed to them.  The
+    sourced target remains the projector defect in Nachtergaele's equation
+    (2.4), while the rational estimate is quoted after that equation and in
+    equation (6.1).  No mixed-Gram norm estimate follows from this identity
+    alone.
   \item For injective maps with common factorizations
     \(T J_1=C=L J_2\),
     \leanid{ContinuousLinearMap.injectiveRangeProjector_comp_sub_of_factorizations}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -705,7 +705,11 @@ and generic prerequisites now include:
     next.
   \item The mixed Gram of the C3 tail map at
     \((K,l+1)\) and left map at \((K+l,1)\) is computed exactly by
-    \leanid{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}:
+    \leanid{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}.
+    Write \(\Gamma^{\mathrm{tail}}_{K,l+1}\) and
+    \(\Gamma^{\mathrm{left}}_{K+l,1}\) for these two Hilbert-space maps.
+    For boundary-family vectors \(x\) and \(y\), write \(X_u\) and \(Z_j\)
+    for their matrix fibers.  Then
     \begin{align}
       \left\langle x,
         (\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
@@ -714,9 +718,9 @@ and generic prerequisites now include:
         \left\langle U(A^jX_u),
           \mathcal K_l U(Z_jA^u)\right\rangle.
     \end{align}
-    Here \(X_u\) and \(Z_j\) are the matrix fibers of \(x\) and \(y\).
     This formula is an exact algebraic identity reconstructed from the
-    boundary-map definitions, word factorization, and trace cyclicity.  It is not stated in
+    boundary-map definitions, word factorization, and trace cyclicity.  It is
+    not stated in
     this form by FNW or Nachtergaele and is not attributed to them.  The
     sourced target remains the projector defect in Nachtergaele's equation
     (2.4), while the rational estimate is quoted after that equation and in

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -715,8 +715,8 @@ and generic prerequisites now include:
           \mathcal K_l U(Z_jA^u)\right\rangle.
     \end{align}
     Here \(X_u\) and \(Z_j\) are the matrix fibers of \(x\) and \(y\).
-    This formula is reconstructed exact algebra from the boundary-map
-    definitions, word factorization, and trace cyclicity.  It is not stated in
+    This formula is an exact algebraic identity reconstructed from the
+    boundary-map definitions, word factorization, and trace cyclicity.  It is not stated in
     this form by FNW or Nachtergaele and is not attributed to them.  The
     sourced target remains the projector defect in Nachtergaele's equation
     (2.4), while the rational estimate is quoted after that equation and in


### PR DESCRIPTION
> **Replacement for #5947:** GitHub auto-closed the stacked PR when its merged base branch was deleted, and refuses to reopen it after the required rebase/force-push. This PR carries the same MixedGram slice directly against `main`.


## Summary

- compute the exact mixed Gram between the C3 tail map at `(K, l + 1)` and left map at `(K + l, 1)`
- identify each prefix/final-site fiber with the length-`l` Gram pairing
  `⟪U(A^j X_u), groundSpaceGram A l (U(Z_j A^u))⟫`
- wire the focused module into the generated parent-Hamiltonian aggregator
- synchronize Chapter 13 and the martingale paper-gap note without claiming a numerical FNW contraction

The identity is reconstructed from the boundary-map definitions, word factorization, and trace cyclicity. It is not attributed to FNW or Nachtergaele. The sourced projector target is Nachtergaele, arXiv:cond-mat/9410110, equation (2.4); the rational estimate is quoted after that equation and in Section 6, equation (6.1).

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/MixedGram.lean`
- `lake build TNLean.MPS.ParentHamiltonian.MixedGram`
- `lake env lean TNLean/MPS/ParentHamiltonian.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- diff-scoped reader-facing prose and forbidden-token scans
- `leanblueprint web`

`leanblueprint checkdecls` still reports the repository's pre-existing stale declaration list (including declarations merged after the seeded root olean); the new declaration itself is verified by the targeted Lean checks above. No broad build or cache command was run.

Addresses #5923.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal verification and documentation only; no changes to runtime behavior, auth, or critical infrastructure.
> 
> **Overview**
> Adds a **formal Lean proof** of the exact mixed Gram between the C3 tail boundary map at `(K, l+1)` and the left boundary map at `(K+l, 1)`, decomposing the pairing into a double sum over prefix `u` and final-site `j` of length-`l` `groundSpaceGram` inner products on the virtual matrices `A^j X_u` and `Z_j A^u`.
> 
> The new module `MixedGram.lean` is wired into the parent-Hamiltonian aggregator; Chapter 13 and the martingale paper-gap note document the same identity and **explicitly distinguish** it from Nachtergaele’s numerical FNW contraction after equation (2.4) / (6.1)—no norm estimate is claimed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7d240d10ae4cb65f4a602e7cd7e053f61286b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

