### PR TITLE
feat(parent-hamiltonian): telescope projector Gram errors

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -61,6 +61,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 import TNLean.MPS.ParentHamiltonian.MixedGram
 import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities
+import TNLean.MPS.ParentHamiltonian.ProjectorCancellation
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
 import TNLean.MPS.ParentHamiltonian.SpectatorBoundary
 import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram

--- a/TNLean/MPS/ParentHamiltonian/ProjectorCancellation.lean
+++ b/TNLean/MPS/ParentHamiltonian/ProjectorCancellation.lean
@@ -21,7 +21,7 @@ The decomposition is reconstructed algebraically from the exact projector
 factorization.  It is not the FNW numerical estimate quoted by Nachtergaele,
 arXiv:cond-mat/9410110, after equation (2.4) and in equation (6.1).
 
-## Main result
+## Main results
 
 * `c3_virtualResidual_eq_centered_sub_gramErrors`
 * `inner_c3_centeredVirtualResidual_eq_gramError`

--- a/TNLean/MPS/ParentHamiltonian/ProjectorCancellation.lean
+++ b/TNLean/MPS/ParentHamiltonian/ProjectorCancellation.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.GramInverseConvergence
+import TNLean.MPS.ParentHamiltonian.MixedGram
+
+/-!
+# Cancellation in the overlapping-window projector residual
+
+This file isolates the finite-volume Gram errors in the virtual residual that
+appears in the exact C3 projector factorization.  The center is the nonidentity
+limiting Gram metric
+\[
+  K_\infty=\operatorname{gramReshuffle}(\operatorname{fixedPointProj}(\rho)).
+\]
+No physical projector is identified with the transfer fixed-point projection.
+
+The decomposition is reconstructed algebraically from the exact projector
+factorization.  It is not the FNW numerical estimate quoted by Nachtergaele,
+arXiv:cond-mat/9410110, after equation (2.4) and in equation (6.1).
+
+## Main result
+
+* `c3_virtualResidual_eq_centered_sub_gramErrors`
+* `inner_c3_centeredVirtualResidual_eq_gramError`
+* `c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors`
+-/
+
+open scoped ComplexOrder Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The virtual residual inside the exact C3 projector factorization, expanded
+around the limiting Gram metric.  The three correction terms isolate,
+respectively, the errors at lengths \(l+1\), \(K+l+1\) after inversion, and
+\(K+l\).  The leading centered mixed Gram is the remaining length-\(l\) error
+characterized by
+`inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered` once its explicit
+limiting pairing is identified with the displayed limiting product.
+
+This is an exact telescoping identity.  Positive definiteness is used only to
+supply the invertible center \(K_\infty\); no rational contraction coefficient
+is asserted. -/
+theorem c3_virtualResidual_eq_centered_sub_gramErrors [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Ktail := boundaryFiberwiseMap (D := D) (Cfg d K)
+      (groundSpaceGram A (l + 1))
+    let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+    let Kleft := boundaryFiberwiseMap (D := D) (Cfg d 1)
+      (groundSpaceGram A (K + l))
+    let Kinfleft := boundaryFiberwiseMap (D := D) (Cfg d 1) Kinf
+    let Ifull := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l + 1)) hFull
+    let Iinf := Ring.inverse Kinf
+    let Jtail := tailVirtualMapES A K
+    let JleftAdj := (leftVirtualMapES A 1).adjoint
+    (tailBoundaryMapES A K (l + 1)).adjoint.comp
+          (leftBoundaryMapES A (K + l) 1) -
+        Ktail.comp (Jtail.comp (Ifull.comp (JleftAdj.comp Kleft))) =
+      ((tailBoundaryMapES A K (l + 1)).adjoint.comp
+          (leftBoundaryMapES A (K + l) 1) -
+        Kinftail.comp (Jtail.comp (Iinf.comp (JleftAdj.comp Kinfleft)))) -
+      (Ktail - Kinftail).comp
+        (Jtail.comp (Ifull.comp (JleftAdj.comp Kleft))) -
+      Kinftail.comp
+        (Jtail.comp ((Ifull - Iinf).comp (JleftAdj.comp Kleft))) -
+      Kinftail.comp
+        (Jtail.comp (Iinf.comp (JleftAdj.comp (Kleft - Kinfleft)))) := by
+  dsimp only
+  simp only [ContinuousLinearMap.comp_sub, ContinuousLinearMap.sub_comp]
+  abel
+
+/-- Reduction of the leading centered operator to the length-\(l\) Gram
+error.  The hypothesis is the remaining limiting intertwining identity: it says
+that the product of the two limiting spectator Grams, the limiting inverse, and
+the virtual word maps has the explicit limiting pairing computed in
+`inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered`.
+
+Separating this hypothesis makes the current dependency boundary explicit.  A
+subsequent result must derive it from the transfer fixed-point equations; it
+must not identify either physical projector with `fixedPointProj`. -/
+theorem inner_c3_centeredVirtualResidual_eq_gramError [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (x : BoundaryFamilySpace (D := D) (Cfg d K))
+    (y : BoundaryFamilySpace (D := D) (Cfg d 1))
+    (hCenter :
+      let Kinf := Matrix.gramReshuffle
+        (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+      let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+      let Kinfleft := boundaryFiberwiseMap (D := D) (Cfg d 1) Kinf
+      let Iinf := Ring.inverse Kinf
+      inner ℂ x
+          (Kinftail.comp ((tailVirtualMapES A K).comp
+            (Iinf.comp ((leftVirtualMapES A 1).adjoint.comp Kinfleft))) y) =
+        ∑ u : Cfg d K, ∑ j : Cfg d 1,
+          inner ℂ
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+              (evalWord A (List.ofFn j) *
+                boundaryFamilyEquiv (D := D) (Cfg d K) x u))
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+              ((Matrix.trace ρ)⁻¹ •
+                ((boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
+                  evalWord A (List.ofFn u)) * ρ)))) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+    let Kinfleft := boundaryFiberwiseMap (D := D) (Cfg d 1) Kinf
+    let Iinf := Ring.inverse Kinf
+    inner ℂ x
+        (((tailBoundaryMapES A K (l + 1)).adjoint.comp
+            (leftBoundaryMapES A (K + l) 1) -
+          Kinftail.comp ((tailVirtualMapES A K).comp
+            (Iinf.comp ((leftVirtualMapES A 1).adjoint.comp Kinfleft)))) y) =
+      ∑ u : Cfg d K, ∑ j : Cfg d 1,
+        inner ℂ
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+            (evalWord A (List.ofFn j) *
+              boundaryFamilyEquiv (D := D) (Cfg d K) x u))
+          ((groundSpaceGram A l - Kinf)
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+              (boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
+                evalWord A (List.ofFn u)))) := by
+  dsimp only at hCenter ⊢
+  rw [sub_apply, inner_sub_right, hCenter]
+  exact inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered
+    A K l ρ (ne_of_gt hρ.trace_pos) x y
+
+/-- The exact C3 projector defect with the virtual residual replaced by the
+centered telescoping decomposition above.  The tail inverse Gram is the
+fiberwise inverse at length \(l+1\), the left inverse Gram is the fiberwise
+inverse at length \(K+l\), and the full inverse Gram occurs only through its
+difference from \(K_\infty^{-1}\).
+
+The order is the C3 tail projector after the left projector.  This statement is
+purely algebraic and asserts no uniform norm bound. -/
+theorem c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l)))
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    let hTail := tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+      A K (l + 1) hLocalTail
+    let hLeft := leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+      A (K + l) 1 hLocalLeft
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Ktail := boundaryFiberwiseMap (D := D) (Cfg d K)
+      (groundSpaceGram A (l + 1))
+    let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+    let Kleft := boundaryFiberwiseMap (D := D) (Cfg d 1)
+      (groundSpaceGram A (K + l))
+    let Kinfleft := boundaryFiberwiseMap (D := D) (Cfg d 1) Kinf
+    let IlocalTail := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (l + 1)) hLocalTail
+    let IlocalLeft := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l)) hLocalLeft
+    let Ifull := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l + 1)) hFull
+    let Iinf := Ring.inverse Kinf
+    let Jtail := tailVirtualMapES A K
+    let JleftAdj := (leftVirtualMapES A 1).adjoint
+    let centeredErrors :=
+      ((tailBoundaryMapES A K (l + 1)).adjoint.comp
+          (leftBoundaryMapES A (K + l) 1) -
+        Kinftail.comp (Jtail.comp (Iinf.comp (JleftAdj.comp Kinfleft)))) -
+      (Ktail - Kinftail).comp
+        (Jtail.comp (Ifull.comp (JleftAdj.comp Kleft))) -
+      Kinftail.comp
+        (Jtail.comp ((Ifull - Iinf).comp (JleftAdj.comp Kleft))) -
+      Kinftail.comp
+        (Jtail.comp (Iinf.comp (JleftAdj.comp (Kleft - Kinfleft))))
+    (ContinuousLinearMap.injectiveRangeProjector
+        (tailBoundaryMapES A K (l + 1)) hTail).comp
+        (ContinuousLinearMap.injectiveRangeProjector
+          (leftBoundaryMapES A (K + l) 1) hLeft) -
+      ContinuousLinearMap.injectiveRangeProjector
+        (groundSpaceMapES A (K + l + 1)) hFull =
+      (tailBoundaryMapES A K (l + 1)).comp
+        ((boundaryFiberwiseMap (D := D) (Cfg d K) IlocalTail).comp
+          (centeredErrors.comp
+            ((boundaryFiberwiseMap (D := D) (Cfg d 1) IlocalLeft).comp
+              (leftBoundaryMapES A (K + l) 1).adjoint))) := by
+  dsimp only
+  rw [c3_injectiveRangeProjector_residual_eq]
+  rw [inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram,
+    inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram,
+    tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram,
+    leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram,
+    c3_virtualResidual_eq_centered_sub_gramErrors A K l ρ hρ hFull]
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -507,6 +507,70 @@ norm estimate is derived here.
     sums and the second argument of the inner product.
 \end{proof}
 
+\begin{theorem}[Exact limiting-metric telescope for the C3 residual]%
+    \label{thm:c3_projector_gram_error_telescope}
+    \lean{MPSTensor.c3_virtualResidual_eq_centered_sub_gramErrors}
+    \lean{MPSTensor.inner_c3_centeredVirtualResidual_eq_gramError}
+    \lean{MPSTensor.c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors}
+    \leanok
+    \uses{thm:c3_spectator_projector_residual,
+        thm:spectator_boundary_direct_sum_gram,
+        thm:spectator_boundary_mixed_gram_centered,
+        thm:fixed_point_gram_metric_exact}
+    Let $\rho\in\MN{D}$ be positive definite and set
+    $\mathcal K_\infty=\mathscr R(P_\rho)$ and
+    $S_\infty=\mathcal K_\infty^{-1}$.  Write $J_{\rm t}$ and $J_{\rm l}$
+    for the tail and left virtual maps, and write $S_n=\mathcal K_n^{-1}$
+    whenever the length-$n$ boundary map is injective.  The virtual residual
+    in the exact tail-after-left C3 projector factorization has the telescoping
+    decomposition
+    \begin{align}
+      &M_l-\mathcal K_{l+1}^{\oplus K}J_{\rm t}S_{K+l+1}
+          J_{\rm l}^\dagger\mathcal K_{K+l}^{\oplus 1} \\
+      &=\left(M_l-\mathcal K_\infty^{\oplus K}J_{\rm t}S_\infty
+          J_{\rm l}^\dagger\mathcal K_\infty^{\oplus 1}\right) \\
+      &\quad-(\mathcal K_{l+1}^{\oplus K}
+          -\mathcal K_\infty^{\oplus K})J_{\rm t}S_{K+l+1}
+          J_{\rm l}^\dagger\mathcal K_{K+l}^{\oplus 1} \\
+      &\quad-\mathcal K_\infty^{\oplus K}J_{\rm t}
+          (S_{K+l+1}-S_\infty)J_{\rm l}^\dagger
+          \mathcal K_{K+l}^{\oplus 1} \\
+      &\quad-\mathcal K_\infty^{\oplus K}J_{\rm t}S_\infty
+          J_{\rm l}^\dagger(\mathcal K_{K+l}^{\oplus 1}
+          -\mathcal K_\infty^{\oplus 1}),
+    \end{align}
+    where
+    $M_l=(\Gamma^{\rm tail}_{K,l+1})^\dagger
+      \Gamma^{\rm left}_{K+l,1}$ and the superscript $\oplus$ denotes the
+    corresponding fiberwise spectator operator.  Substituting this equality
+    into the exact inverse-Gram factorization gives the same decomposition of
+    the physical projector residual, sandwiched between the tail boundary map,
+    the two local fiberwise inverse Grams, and the adjoint left boundary map.
+
+    If the limiting product in the first parenthesis has the explicit limiting
+    mixed pairing from the preceding centered mixed-Gram theorem, then its
+    pairing against boundary families is exactly the same finite sum with
+    $\mathcal K_l-\mathcal K_\infty$ in place of $\mathcal K_l$.
+    This last implication records the exact remaining intertwining hypothesis;
+    it does not assert that hypothesis.
+
+    These identities are reconstructed operator algebra.  They assert neither
+    the numerical FNW contraction nor any identification of a physical ground
+    projector with $P_\rho$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:c3_spectator_projector_residual,
+        thm:spectator_boundary_direct_sum_gram,
+        thm:spectator_boundary_mixed_gram_centered}
+    Add and subtract the product in which all three finite Gram factors are
+    replaced by their limiting values, and telescope the resulting product
+    from left to right.  Substitute the direct-sum Gram and inverse-Gram
+    formulas into the exact projector factorization.  Under the displayed
+    limiting-pairing hypothesis, apply the centered mixed-Gram identity to the
+    leading term.
+\end{proof}
+
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}
 
 \begin{theorem}[Martingale criterion for spectral gap]\label{thm:martingale_criterion}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -742,9 +742,10 @@ and generic prerequisites now include:
     three injectivity assumptions are explicit.  This is an algebraic identity
     only; a source-specific estimate of the mixed-Gram residual is still
     required.
-  \item Let
-    \(\mathcal K_\infty=\operatorname{gramReshuffle}(P_\rho)\), with
-    \(\rho\) positive definite, and let \(S_\infty=\mathcal K_\infty^{-1}\).
+  \item For each length \(n\), let \(\mathcal K_n\) be the ground-space
+    Gram, and whenever it is invertible set \(S_n=\mathcal K_n^{-1}\).  Let
+    \(\mathcal K_\infty=\mathscr R(P_\rho)\), with \(\rho\) positive
+    definite, and set \(S_\infty=\mathcal K_\infty^{-1}\).
     The exact C3 virtual residual is telescoped by
     \leanid{MPSTensor.c3_virtualResidual_eq_centered_sub_gramErrors} into its
     limiting-center residual and three corrections containing, in order,

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -742,6 +742,34 @@ and generic prerequisites now include:
     three injectivity assumptions are explicit.  This is an algebraic identity
     only; a source-specific estimate of the mixed-Gram residual is still
     required.
+  \item Let
+    \(\mathcal K_\infty=\operatorname{gramReshuffle}(P_\rho)\), with
+    \(\rho\) positive definite, and let \(S_\infty=\mathcal K_\infty^{-1}\).
+    The exact C3 virtual residual is telescoped by
+    \leanid{MPSTensor.c3_virtualResidual_eq_centered_sub_gramErrors} into its
+    limiting-center residual and three corrections containing, in order,
+    \begin{align}
+      \mathcal K_{l+1}-\mathcal K_\infty,\qquad
+      S_{K+l+1}-S_\infty,\qquad
+      \mathcal K_{K+l}-\mathcal K_\infty.
+    \end{align}
+    The spectator occurrences of the first and third differences are
+    fiberwise, so their norms are uniform in the spectator type.  The theorem
+    \leanid{MPSTensor.c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors}
+    substitutes this telescope into the full tail-after-left projector
+    factorization.  The inverse convergence theorem controls the middle
+    correction eventually.
+
+    The length-\(l\) error is isolated conditionally by
+    \leanid{MPSTensor.inner_c3_centeredVirtualResidual_eq_gramError}.  The
+    remaining exact algebraic dependency is the limiting intertwining identity
+    that equates the product of the two limiting spectator Grams, the limiting
+    inverse, and the two virtual word maps with the explicit limiting pairing
+    in the centered mixed-Gram formula.  This identity must be derived from the
+    transfer fixed-point equations.  It cannot be replaced by identifying a
+    physical ground projector with \(P_\rho\).  These decompositions are
+    reconstructed algebra and assert neither the FNW rational coefficient nor
+    a uniform contraction estimate.
 \end{itemize}
 Fix \(K,L_0\in\mathbb N\) and let
 \(\mathcal H_{K+L_0+1}\) be the \((K+L_0+1)\)-site Euclidean space


### PR DESCRIPTION
## Summary

- telescope the exact C3 virtual projector residual at the nonidentity limiting Gram metric
  \(K_\infty=\operatorname{gramReshuffle}(\operatorname{fixedPointProj}(\rho))\)
- isolate the finite-volume errors at lengths \(l+1\), \(K+l\), and the inverse error at \(K+l+1\), while preserving the tail-after-left projector order
- substitute the telescope into the full inverse-Gram projector factorization
- connect the leading centered operator conditionally to the length-\(l\) error from the exact centered mixed-Gram identity, and record the precise remaining limiting intertwining identity

This is reconstructed operator algebra, not an attribution to FNW or Nachtergaele. It does not identify physical projectors with `fixedPointProj`, and it does not claim the FNW rational coefficient or a uniform contraction bound.

## Dependency boundary

The remaining exact algebraic step is to prove that the product of the two limiting spectator Grams, the limiting inverse, and the virtual word maps equals the explicit limiting mixed pairing. That identity must come from the transfer fixed-point equations. Once available, the leading term is exactly the \(K_l-K_\infty\) pairing; the existing finite-volume Gram and inverse-Gram convergence results control the other three displayed errors.

## Verification

- `lake build TNLean.MPS.ParentHamiltonian.ProjectorCancellation TNLean.MPS.ParentHamiltonian`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/agent/issue-5923-centered-mixed-gram`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/agent/issue-5923-centered-mixed-gram`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --cached --check`

Addresses #5923

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are new formal proofs and documentation in the parent-Hamiltonian martingale chain; they are explicit algebra with stated hypotheses and do not alter runtime or security-sensitive code.
> 
> **Overview**
> Adds **`ProjectorCancellation.lean`** with exact algebra that expands the C3 overlapping-window **virtual residual** around the limiting Gram metric \(K_\infty=\operatorname{gramReshuffle}(\operatorname{fixedPointProj}(\rho))\), not around the identity.
> 
> **`c3_virtualResidual_eq_centered_sub_gramErrors`** telescopes that residual into a centered term at \(K_\infty\) plus three finite-volume corrections: \(\mathcal K_{l+1}-\mathcal K_\infty\), \(S_{K+l+1}-S_\infty\), and \(\mathcal K_{K+l}-\mathcal K_\infty\) (with fiberwise spectator Grams where needed).
> 
> **`c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors`** plugs the same decomposition into the existing tail-after-left inverse-Gram projector factorization, sandwiched by local fiberwise inverse Grams.
> 
> **`inner_c3_centeredVirtualResidual_eq_gramError`** shows that, under an explicit **limiting intertwining** hypothesis (product of limiting spectator Grams, limiting inverse, and virtual maps equals the displayed limiting mixed pairing), the leading centered piece pairs as the length-\(l\) error \((\mathcal K_l-\mathcal K_\infty)\) via the centered mixed-Gram identity. The hypothesis is recorded as the remaining algebraic step; it is **not** proved here and must not be replaced by identifying physical projectors with `fixedPointProj`.
> 
> The parent-hamiltonian aggregator imports the new module; **ch13** blueprint and **`cpgsv21_martingale_overlap.tex`** document the telescope and dependency boundary. No FNW rational coefficient or uniform contraction bound is claimed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af29cfdc235fb6ef23df0f3a13ac037e88a917f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->