### PR TITLE
refactor(Channel): share Kraus corner-map compression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,3 +310,4 @@ follow-up, not against the temporary `sorry` count.
 | Name | Kind | Use when | Defined in |
 |---|---|---|---|
 | `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_of_openBoundary` | helper theorem | Closing block-diagonal boundaries from an open-boundary representation and a simultaneous span across the complementary global cut | `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean` |
+| `map_compressed_fixedPoint` | helper theorem | Preserving a supported fixed point under finite-Kraus compression along an isometry | `TNLean/Channel/KrausCornerCompression.lean` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,4 +310,4 @@ follow-up, not against the temporary `sorry` count.
 | Name | Kind | Use when | Defined in |
 |---|---|---|---|
 | `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_of_openBoundary` | helper theorem | Closing block-diagonal boundaries from an open-boundary representation and a simultaneous span across the complementary global cut | `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean` |
-| `map_compressed_fixedPoint` | helper theorem | Preserving a supported fixed point under finite-Kraus compression along an isometry | `TNLean/Channel/KrausCornerCompression.lean` |
+| `Kraus.map_compressed_fixedPoint` | helper theorem | Preserving a supported fixed point under finite-Kraus compression along an isometry | `TNLean/Channel/KrausCornerCompression.lean` |

--- a/TNLean/Channel/FixedPoint/CornerBlockForm.lean
+++ b/TNLean/Channel/FixedPoint/CornerBlockForm.lean
@@ -116,30 +116,11 @@ theorem cornerFixedPoints_blockDiagonal_iff
   have hσfix : map C σ = σ := by
     have hmapA : map A ρ = ρ := by
       have heq : map A ρ = Q * map K ρ * Q := by
-        rw [hAdef]; exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
+        rw [hAdef]
+        exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
       rw [heq, hρ_fix, hQρQ]
-    have hterm : ∀ i : Fin d,
-        C i * σ * (C i)ᴴ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by
-      intro i
-      have hCiH : (C i)ᴴ = Vᴴ * (A i)ᴴ * V := by
-        rw [hCi i]
-        simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
-      rw [hCiH, hCi i, hσdef]
-      calc
-        Vᴴ * A i * V * (Vᴴ * ρ * V) * (Vᴴ * (A i)ᴴ * V)
-            = Vᴴ * (A i * (V * Vᴴ) * ρ * (V * Vᴴ) * (A i)ᴴ) * V := by
-              simp [Matrix.mul_assoc]
-        _ = Vᴴ * (A i * Q * ρ * Q * (A i)ᴴ) * V := by rw [hVVt]
-        _ = Vᴴ * (A i * (Q * ρ * Q) * (A i)ᴴ) * V := by simp [Matrix.mul_assoc]
-        _ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by rw [hQρQ]
-    calc
-      map C σ = ∑ i : Fin d, C i * σ * (C i)ᴴ := by rw [map_apply]
-      _ = ∑ i : Fin d, Vᴴ * (A i * ρ * (A i)ᴴ) * V :=
-          Finset.sum_congr rfl (fun i _ => hterm i)
-      _ = Vᴴ * (∑ i : Fin d, A i * ρ * (A i)ᴴ) * V := by
-          rw [Matrix.mul_sum, Matrix.sum_mul]
-      _ = Vᴴ * map A ρ * V := by rw [map_apply]
-      _ = σ := by rw [hmapA, hσdef]
+    rw [hσdef]
+    exact map_compressed_fixedPoint A C V Q ρ hCi hVVt hQρQ hmapA
   -- The corner fixed-point condition corresponds to the compressed one along `φ`.
   have hcorr : ∀ X : Matrix (Fin r) (Fin r) ℂ,
       Q * adjointMap K (φ X).1 * Q = (φ X).1 ↔ adjointMap C X = X := by

--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -237,30 +237,11 @@ theorem cornerFixed_mul
   have hσfix : map C σ = σ := by
     have hmapA : map A ρ = ρ := by
       have heq : map A ρ = Q * map K ρ * Q := by
-        rw [hAdef]; exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
+        rw [hAdef]
+        exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
       rw [heq, hρ_fix, hQρQ]
-    have hterm : ∀ i : Fin d,
-        C i * σ * (C i)ᴴ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by
-      intro i
-      have hCiH : (C i)ᴴ = Vᴴ * (A i)ᴴ * V := by
-        rw [hCi i]
-        simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
-      rw [hCiH, hCi i, hσdef]
-      calc
-        Vᴴ * A i * V * (Vᴴ * ρ * V) * (Vᴴ * (A i)ᴴ * V)
-            = Vᴴ * (A i * (V * Vᴴ) * ρ * (V * Vᴴ) * (A i)ᴴ) * V := by
-              simp [Matrix.mul_assoc]
-        _ = Vᴴ * (A i * Q * ρ * Q * (A i)ᴴ) * V := by rw [hVVt]
-        _ = Vᴴ * (A i * (Q * ρ * Q) * (A i)ᴴ) * V := by simp [Matrix.mul_assoc]
-        _ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by rw [hQρQ]
-    calc
-      map C σ = ∑ i : Fin d, C i * σ * (C i)ᴴ := by rw [map_apply]
-      _ = ∑ i : Fin d, Vᴴ * (A i * ρ * (A i)ᴴ) * V := by
-          exact Finset.sum_congr rfl (fun i _ => hterm i)
-      _ = Vᴴ * (∑ i : Fin d, A i * ρ * (A i)ᴴ) * V := by
-          rw [Matrix.mul_sum, Matrix.sum_mul]
-      _ = Vᴴ * map A ρ * V := by rw [map_apply]
-      _ = σ := by rw [hmapA, hσdef]
+    rw [hσdef]
+    exact map_compressed_fixedPoint A C V Q ρ hCi hVVt hQρQ hmapA
   -- Membership equivalence between the compressed and ambient fixed-point conditions.
   have hcorr : ∀ X : Matrix (Fin n) (Fin n) ℂ,
       Q * adjointMap K (φ X).1 * Q = (φ X).1 ↔ adjointMap C X = X := by

--- a/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean
@@ -173,30 +173,11 @@ private theorem exists_weighted_compression
   have hσfix : map C σ = σ := by
     have hmapA : map A ρ = ρ := by
       have heq : map A ρ = Q * map K ρ * Q := by
-        rw [hAdef]; exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
+        rw [hAdef]
+        exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
       rw [heq, hρ_fix, hQρQ]
-    have hterm : ∀ i : Fin d,
-        C i * σ * (C i)ᴴ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by
-      intro i
-      have hCiH : (C i)ᴴ = Vᴴ * (A i)ᴴ * V := by
-        rw [hCi i]
-        simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
-      rw [hCiH, hCi i, hσdef]
-      calc
-        Vᴴ * A i * V * (Vᴴ * ρ * V) * (Vᴴ * (A i)ᴴ * V)
-            = Vᴴ * (A i * (V * Vᴴ) * ρ * (V * Vᴴ) * (A i)ᴴ) * V := by
-              simp [Matrix.mul_assoc]
-        _ = Vᴴ * (A i * Q * ρ * Q * (A i)ᴴ) * V := by rw [hVVt]
-        _ = Vᴴ * (A i * (Q * ρ * Q) * (A i)ᴴ) * V := by simp [Matrix.mul_assoc]
-        _ = Vᴴ * (A i * ρ * (A i)ᴴ) * V := by rw [hQρQ]
-    calc
-      map C σ = ∑ i : Fin d, C i * σ * (C i)ᴴ := by rw [map_apply]
-      _ = ∑ i : Fin d, Vᴴ * (A i * ρ * (A i)ᴴ) * V :=
-          Finset.sum_congr rfl (fun i _ => hterm i)
-      _ = Vᴴ * (∑ i : Fin d, A i * ρ * (A i)ᴴ) * V := by
-          rw [Matrix.mul_sum, Matrix.sum_mul]
-      _ = Vᴴ * map A ρ * V := by rw [map_apply]
-      _ = σ := by rw [hmapA, hσdef]
+    rw [hσdef]
+    exact map_compressed_fixedPoint A C V Q ρ hCi hVVt hQρQ hmapA
   -- The square root compresses along the isometry.
   have hs : CFC.sqrt σ = Vᴴ * CFC.sqrt ρ * V := by
     rw [hσdef]
@@ -250,20 +231,8 @@ private theorem exists_weighted_compression
           Finset.sum_congr rfl fun i _ => (hterm i).symm
       _ = map K W := by rw [map_apply]
   have hmapC : ∀ Z : Matrix (Fin r) (Fin r) ℂ,
-      map C Z = Vᴴ * map A (V * Z * Vᴴ) * V := by
-    intro Z
-    calc map C Z = ∑ i : Fin d, C i * Z * (C i)ᴴ := by rw [map_apply]
-      _ = ∑ i : Fin d, Vᴴ * (A i * (V * Z * Vᴴ) * (A i)ᴴ) * V := by
-          refine Finset.sum_congr rfl fun i _ => ?_
-          have hCiH : (C i)ᴴ = Vᴴ * (A i)ᴴ * V := by
-            rw [hCi i]
-            simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose,
-              Matrix.mul_assoc]
-          rw [hCiH, hCi i]
-          simp [Matrix.mul_assoc]
-      _ = Vᴴ * (∑ i : Fin d, A i * (V * Z * Vᴴ) * (A i)ᴴ) * V := by
-          rw [Matrix.mul_sum, Matrix.sum_mul]
-      _ = Vᴴ * map A (V * Z * Vᴴ) * V := by rw [map_apply]
+      map C Z = Vᴴ * map A (V * Z * Vᴴ) * V :=
+    map_compressed_eq_conj A C V hCi
   have hcorrS : ∀ W : Mat, Q * W * Q = W →
       (map K W = W ↔ map C (Vᴴ * W * V) = Vᴴ * W * V) := by
     intro W hW

--- a/TNLean/Channel/KrausCornerCompression.lean
+++ b/TNLean/Channel/KrausCornerCompression.lean
@@ -16,6 +16,9 @@ and adjoint map with the corresponding ambient corner actions.
 
 ## Main results
 
+* `Kraus.map_compressed_eq_conj`: Schrödinger-map intertwining for a compressed family.
+* `Kraus.map_compressed_fixedPoint`: preservation of a supported fixed point under
+  compression.
 * `Kraus.exists_corner_compression_of_supported_projection`: compression of a supported
   finite Kraus family to the support matrix algebra.
 -/
@@ -26,6 +29,48 @@ open Matrix Finset Complex
 namespace Kraus
 
 variable {d D : ℕ}
+
+/-- The Schrödinger map of a Kraus family compressed along `V` is the compression of the
+ambient Schrödinger map after expanding its argument along `V`. -/
+theorem map_compressed_eq_conj {n : ℕ}
+    (A : Fin d → MatrixAlg D) (C : Fin d → MatrixAlg n)
+    (V : Matrix (Fin D) (Fin n) ℂ)
+    (hC : ∀ i : Fin d, C i = Vᴴ * A i * V) (Z : MatrixAlg n) :
+    map C Z = Vᴴ * map A (V * Z * Vᴴ) * V := by
+  classical
+  calc
+    map C Z = ∑ i : Fin d, C i * Z * (C i)ᴴ := by rw [map_apply]
+    _ = ∑ i : Fin d, Vᴴ * (A i * (V * Z * Vᴴ) * (A i)ᴴ) * V := by
+      refine Finset.sum_congr rfl fun i _ => ?_
+      have hCiH : (C i)ᴴ = Vᴴ * (A i)ᴴ * V := by
+        rw [hC i]
+        simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose,
+          Matrix.mul_assoc]
+      rw [hCiH, hC i]
+      simp [Matrix.mul_assoc]
+    _ = Vᴴ * (∑ i : Fin d, A i * (V * Z * Vᴴ) * (A i)ᴴ) * V := by
+      rw [Matrix.mul_sum, Matrix.sum_mul]
+    _ = Vᴴ * map A (V * Z * Vᴴ) * V := by rw [map_apply]
+
+/-- Compression along `V` preserves a fixed point supported on the range projection
+`V * Vᴴ`. -/
+theorem map_compressed_fixedPoint {n : ℕ}
+    (A : Fin d → MatrixAlg D) (C : Fin d → MatrixAlg n)
+    (V : Matrix (Fin D) (Fin n) ℂ) (P X : MatrixAlg D)
+    (hC : ∀ i : Fin d, C i = Vᴴ * A i * V) (hVVt : V * Vᴴ = P)
+    (hXmem : P * X * P = X) (hXfix : map A X = X) :
+    map C (Vᴴ * X * V) = Vᴴ * X * V := by
+  calc
+    map C (Vᴴ * X * V) = Vᴴ * map A (V * (Vᴴ * X * V) * Vᴴ) * V :=
+      map_compressed_eq_conj A C V hC _
+    _ = Vᴴ * map A X * V := by
+      rw [show V * (Vᴴ * X * V) * Vᴴ = X by
+        calc
+          V * (Vᴴ * X * V) * Vᴴ = (V * Vᴴ) * X * (V * Vᴴ) := by
+            simp [Matrix.mul_assoc]
+          _ = P * X * P := by rw [hVVt]
+          _ = X := hXmem]
+    _ = Vᴴ * X * V := by rw [hXfix]
 
 /-- Compress a finite matrix family supported on an orthogonal projection to the support
 matrix algebra. The result includes the corner equivalence, its support isometry, the

--- a/TNLean/Channel/KrausCornerCompression.lean
+++ b/TNLean/Channel/KrausCornerCompression.lean
@@ -37,7 +37,6 @@ theorem map_compressed_eq_conj {n : ℕ}
     (V : Matrix (Fin D) (Fin n) ℂ)
     (hC : ∀ i : Fin d, C i = Vᴴ * A i * V) (Z : MatrixAlg n) :
     map C Z = Vᴴ * map A (V * Z * Vᴴ) * V := by
-  classical
   calc
     map C Z = ∑ i : Fin d, C i * Z * (C i)ᴴ := by rw [map_apply]
     _ = ∑ i : Fin d, Vᴴ * (A i * (V * Z * Vᴴ) * (A i)ᴴ) * V := by


### PR DESCRIPTION
## What changed

- adds `Kraus.map_compressed_eq_conj`, the generic Schrödinger-map intertwining identity for a compressed finite Kraus family;
- adds `Kraus.map_compressed_fixedPoint`, which preserves a supported fixed point under the same compression;
- replaces the three repeated compressed fixed-point calculations in `CornerFixedPoints`, `CornerBlockForm`, and `WeightedCornerFixedPoints` with the shared theorem;
- replaces the remaining local intertwining calculation in `WeightedCornerFixedPoints` with the generic identity;
- records the promoted fixed-point theorem in the proof-automation ledger. Existing public Channel and MPS statements are unchanged.

## Dependency impact

No imports changed. Exact `origin/main` to PR-head measurements remain:

- direct Channel modules importing MPS: **5 -> 5**;
- direct Channel-to-MPS edges: **7 -> 7**;
- transitively MPS-dependent Channel modules: **35 -> 35**.

## Validation

- affected modules: `lake build TNLean.Channel.KrausCornerCompression TNLean.Channel.FixedPoint.CornerFixedPoints TNLean.Channel.FixedPoint.CornerBlockForm TNLean.Channel.FixedPoint.WeightedCornerFixedPoints` (**3085 jobs**)
- Channel and MPS compatibility: `lake build TNLean.Channel TNLean.MPS.CanonicalForm.CyclicSectors` (**9109 jobs**)
- full warm-cache `lake build` (**10026 jobs**)
- `python3 scripts/generate_import_aggregators.py --check` (**52 generated files / 1315 modules**)
- Blueprint sync and `leanblueprint checkdecls` (**6997/6997**)
- style, reader-facing prose, source-integrity, and whitespace checks
- exact-patch Lean/style review approved with no substantive findings

Closes LionSR/QICLean#316.
Advances LionSR/TNLean#5679.

## Review follow-up (b37ff9da9b79835e566bffc7760f0e585a5fb453)

- fully qualifies the proof-automation ledger entry as
  `Kraus.map_compressed_fixedPoint`;
- removes the unnecessary local `classical` from `Kraus.map_compressed_eq_conj`;
- exact builds and direct diagnostics pass for `KrausCornerCompression` and its three changed
  fixed-point consumers;
- no-gap, reader-facing prose, focused Lean policy/import-aggregator tests, ledger, line-length,
  and whitespace checks pass.

The broad Channel/MPS aggregate was not used as the cleanup gate under the hot-main protocol:
a fresh isolated cache exceeded the command window without a source diagnostic. The direct changed
module and consumer gates above completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactoring inside Channel fixed-point theory; lemmas are reused without altering external signatures or dependencies.
> 
> **Overview**
> Introduces shared lemmas **`Kraus.map_compressed_eq_conj`** and **`Kraus.map_compressed_fixedPoint`** in `KrausCornerCompression.lean` for Schrödinger-map intertwining and fixed-point preservation when compressing a finite Kraus family along an isometry.
> 
> **Corner fixed-point modules** (`CornerBlockForm`, `CornerFixedPoints`, `WeightedCornerFixedPoints`) drop long duplicated `calc` proofs and call these lemmas instead; `WeightedCornerFixedPoints` also uses `map_compressed_eq_conj` for its local `hmapC` intertwining identity.
> 
> The proof-automation ledger in `CLAUDE.md` records `map_compressed_fixedPoint` for reuse. **No changes** to public theorem statements or import edges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b37ff9da9b79835e566bffc7760f0e585a5fb453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
