### PR TITLE
doc(tenkz): strike the slop from the manual prose

### DIFF
--- a/docs/tenkz/chapters2/ch-compatibility.tex
+++ b/docs/tenkz/chapters2/ch-compatibility.tex
@@ -23,6 +23,6 @@ authoritative for benchmark cases: replace an alias instead of adding a
 manifest exception.  Historical records in \tnfile{docs/tenkz/history/} do not
 define supported aliases.
 
-There is no compatibility form of \tncmd{tndefine}: it was an aspirational
-promise, not a shipped public grammar.  Typed custom atoms use
+There is no compatibility form of \tncmd{tndefine}: it was promised and
+never implemented, so there is nothing to alias.  Typed custom atoms use
 \tncmd{tndeclareatom}.

--- a/docs/tenkz/chapters2/ch-modes.tex
+++ b/docs/tenkz/chapters2/ch-modes.tex
@@ -1,7 +1,7 @@
 % One-page environment chooser.
 \section{Which environment?}\label{ch:chooser}
 
-Choose from topology, not from the desired appearance.
+Choose from topology, not appearance.
 
 \medskip
 {\small

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -13,8 +13,8 @@ and the public-symbol census.
   \begin{quote}\small
   The generated reference is not present in this checkout.  Generate it from
   the executable language registry.  The semantic rules in
-  Chapters~\ref{ch:install}--\ref{ch:recipes} remain available, but this
-  fallback is not an API inventory.
+  Chapters~\ref{ch:install}--\ref{ch:recipes} still hold, but only the
+  generated tables inventory the grammar.
   \end{quote}
 }
 

--- a/docs/tenkz/chapters2/ch-rmp.tex
+++ b/docs/tenkz/chapters2/ch-rmp.tex
@@ -19,7 +19,7 @@ source.  The recto page gives the vector rendering, audited boundary
 signature, dimensions, digests, and print/web verdict.  Digest changes make a
 prior verdict stale automatically.
 
-Use the shared frontend:
+One script drives every check:
 
 \begin{Verbatim}[fontsize=\footnotesize,frame=leftline]
 python3 scripts/tenkz_rmp.py check --id <target>

--- a/docs/tenkz/chapters2/ch-worked.tex
+++ b/docs/tenkz/chapters2/ch-worked.tex
@@ -170,8 +170,8 @@ box and sits directly in a tikz-cd cell.
 
 \subsection{Put a picture in a sentence}
 
-A picture enters surrounding TeX as a displayed term today.  The inline
-composition wrapper -- one picture behaving as a running-math atom, with the
-metric sensing its mathematical context -- is contract work that has not
-landed; when it does, it will be a composition spelling, not a key: no
-record inside the picture acquires an ``inline'' property.
+A picture enters surrounding TeX as a displayed term; there is no inline
+spelling yet.  When one arrives it will be a composition spelling -- one
+picture standing as a running-math atom, its metric sensing the
+mathematical context -- not a key: no record inside the picture acquires
+an ``inline'' property.


### PR DESCRIPTION
Prose-only pass over the authored manual chapters, applying `docs/prose_style.md` §2/§3 in spirit, Strunk & White, and the TeXbook voice the tutorial sets. No example bodies, keys, labels, or technical claims changed.

## Per-chapter removals/rewrites

| File | Rewrites | What went |
|---|---|---|
| `ch-mathematics.tex` | 0 | already clean |
| `ch-modes.tex` | 1 | "not from the desired appearance" -> "not appearance" |
| `ch-tutorial.tex` | 0 | already in TeXbook voice (just merged) |
| `ch-worked.tex` | 1 | "wrapper", "contract work that has not landed", "today" -> direct statement of what exists and what will |
| `ch-reference.tex` | 1 | "not an API inventory", "remain available" -> "still hold" / "only the generated tables inventory the grammar" |
| `ch-house.tex` | 0 | already clean |
| `ch-rmp.tex` | 1 | "Use the shared frontend:" -> "One script drives every check:" |
| `ch-trouble.tex` | 0 | "Maintainer pipeline" kept: literal architecture term matching ARCHITECTURE.md |
| `ch-compatibility.tex` | 1 | "aspirational promise, not a shipped public grammar" -> "promised and never implemented, so there is nothing to alias" |
| `manual2.tex` | 0 | already clean |
| `scripts/tenkz_language.py` | 0 | generated-file templates are table headers only; no slop |

Kept as load-bearing: "Open ink is mathematical data" (established mathematical sense), "honest result" in ch-modes (GOAL.md doctrine language), "web/SVG pipeline" (names real machinery).

## Before/after

1. `ch-worked.tex`: "The inline composition wrapper ... is contract work that has not landed; when it does, it will be a composition spelling" -> "there is no inline spelling yet. When one arrives it will be a composition spelling"
2. `ch-rmp.tex`: "Use the shared frontend:" -> "One script drives every check:"
3. `ch-compatibility.tex`: "it was an aspirational promise, not a shipped public grammar" -> "it was promised and never implemented, so there is nothing to alias"

## Gates

- `python3 scripts/tenkz_manual_doctest.py`: PASS before and after — 20 displayed manual examples and 12 reference examples, counts unmoved.
- Three-pass `TEXINPUTS="../../tex/tenkz//:" xelatex manual2.tex`: zero errors. Page count 21 before, 21 after.
- Rendered pages 3, 12, 18, 20 (all edited passages) with pdftocairo at 150 DPI and inspected: no layout breakage.

Part of #4708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes in manual chapters; no code, registry, or example bodies touched.
> 
> **Overview**
> Prose-only edits across five **tenkz** manual chapters (`ch-modes`, `ch-worked`, `ch-reference`, `ch-rmp`, `ch-compatibility`). Example bodies, keys, labels, and technical claims are unchanged.
> 
> **`ch-modes`** shortens the environment-chooser line to “topology, not appearance.” **`ch-worked`** states inline composition plainly: no inline spelling today; a future composition spelling would be metric-aware, not a per-record key. **`ch-reference`** clarifies the missing generated-reference fallback: semantic chapters still apply, but only generated tables list the grammar. **`ch-rmp`** reframes the RMP tooling intro as one script driving every check. **`ch-compatibility`** replaces vague “aspirational promise” language with “promised and never implemented, so there is nothing to alias” for `\tncmd{tndefine}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e656507e8b13b5f1a9c4730f0642158effe389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->