### PR TITLE
feat(parent-hamiltonian): prove limiting Gram intertwining

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean
+++ b/TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean
@@ -23,9 +23,11 @@ is right multiplication by the fixed point, divided by its trace.
 * `Matrix.gramReshuffleMatrix_fixedPointProj_posDef` proves positive definiteness.
 * `Matrix.gramReshuffle_fixedPointProj_isUnit` proves invertibility.
 * `Matrix.gramReshuffle_fixedPointProj_injective` proves injectivity.
+* `Matrix.inverse_gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply`
+  computes the inverse action.
 -/
 
-open scoped ComplexOrder Kronecker Matrix
+open scoped ComplexOrder Kronecker Matrix Matrix.Norms.Frobenius
 
 namespace Matrix
 
@@ -98,5 +100,34 @@ theorem gramReshuffle_fixedPointProj_injective [NeZero D]
       (gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))) := by
   exact (ContinuousLinearMap.isUnit_iff_bijective.mp
     (gramReshuffle_fixedPointProj_isUnit hρ)).1
+
+/-- The inverse limiting Gram operator is right multiplication by the
+nonsingular inverse of the fixed point, with the reciprocal normalization
+cancelled. -/
+theorem inverse_gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply [NeZero D]
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Ring.inverse (gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))
+        (frobeniusEquivEuclidean (Fin D) (Fin D) X) =
+      frobeniusEquivEuclidean (Fin D) (Fin D)
+        ((trace ρ) • (X * ρ⁻¹)) := by
+  let K := gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  have hK : IsUnit K := gramReshuffle_fixedPointProj_isUnit hρ
+  apply gramReshuffle_fixedPointProj_injective hρ
+  change K (Ring.inverse K (frobeniusEquivEuclidean (Fin D) (Fin D) X)) =
+    K (frobeniusEquivEuclidean (Fin D) (Fin D) ((trace ρ) • (X * ρ⁻¹)))
+  rw [← ContinuousLinearMap.comp_apply]
+  have hcancel : K.comp (Ring.inverse K) = 1 :=
+    Ring.isUnit_iff_mul_inverse_cancel.mp hK
+  rw [hcancel]
+  rw [gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply]
+  change frobeniusEquivEuclidean (Fin D) (Fin D) X =
+    frobeniusEquivEuclidean (Fin D) (Fin D)
+      ((trace ρ)⁻¹ • ((trace ρ) • (X * ρ⁻¹) * ρ))
+  congr 1
+  rw [Matrix.smul_mul, Matrix.mul_assoc,
+    Matrix.nonsing_inv_mul ρ (ρ.isUnit_iff_isUnit_det.mp hρ.isUnit),
+    Matrix.mul_one, smul_smul, inv_mul_cancel₀ (ne_of_gt hρ.trace_pos), one_smul]
+
 
 end Matrix

--- a/TNLean/MPS/ParentHamiltonian/ProjectorCancellation.lean
+++ b/TNLean/MPS/ParentHamiltonian/ProjectorCancellation.lean
@@ -24,11 +24,12 @@ arXiv:cond-mat/9410110, after equation (2.4) and in equation (6.1).
 ## Main results
 
 * `c3_virtualResidual_eq_centered_sub_gramErrors`
+* `inner_limitingMixedGramIntertwining`
 * `inner_c3_centeredVirtualResidual_eq_gramError`
 * `c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors`
 -/
 
-open scoped ComplexOrder Matrix
+open scoped ComplexOrder Matrix Matrix.Norms.Frobenius
 
 namespace MPSTensor
 
@@ -78,38 +79,88 @@ theorem c3_virtualResidual_eq_centered_sub_gramErrors [NeZero D]
   simp only [ContinuousLinearMap.comp_sub, ContinuousLinearMap.sub_comp]
   abel
 
-/-- Reduction of the leading centered operator to the length-\(l\) Gram
-error.  The hypothesis is the remaining limiting intertwining identity: it says
-that the product of the two limiting spectator Grams, the limiting inverse, and
-the virtual word maps has the explicit limiting pairing computed in
-`inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered`.
+/-- Exact limiting mixed-Gram intertwining in the tail-after-left C3
+orientation.  The limiting Gram acts by normalized right multiplication by
+\(ρ\); its inverse cancels that right multiplication after the adjoint of the
+left virtual word map has summed the left-adjointed one-site words.
 
-Separating this hypothesis makes the current dependency boundary explicit.  A
-subsequent result must derive it from the transfer fixed-point equations; it
-must not identify either physical projector with `fixedPointProj`. -/
+No transfer fixed-point equation is needed for this zeroth-order identity: the
+only data used are positive definiteness, which supplies the nonsingular
+right-multiplication metric, and the explicit Frobenius adjoint formulas. -/
+theorem inner_limitingMixedGramIntertwining [NeZero D]
+    (A : MPSTensor d D) (K : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (x : BoundaryFamilySpace (D := D) (Cfg d K))
+    (y : BoundaryFamilySpace (D := D) (Cfg d 1)) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+    let Kinfleft := boundaryFiberwiseMap (D := D) (Cfg d 1) Kinf
+    let Iinf := Ring.inverse Kinf
+    inner ℂ x
+        (Kinftail.comp ((tailVirtualMapES A K).comp
+          (Iinf.comp ((leftVirtualMapES A 1).adjoint.comp Kinfleft))) y) =
+      ∑ u : Cfg d K, ∑ j : Cfg d 1,
+        inner ℂ
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+            (evalWord A (List.ofFn j) *
+              boundaryFamilyEquiv (D := D) (Cfg d K) x u))
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+            ((Matrix.trace ρ)⁻¹ •
+              ((boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
+                evalWord A (List.ofFn u)) * ρ))) := by
+  dsimp only
+  simp only [ContinuousLinearMap.comp_apply]
+  have hKfiber (j : Cfg d 1) :
+      boundaryFamilyEquiv (D := D) (Cfg d 1)
+          (boundaryFiberwiseMap (D := D) (Cfg d 1)
+            (Matrix.gramReshuffle
+              (fixedPointProj ρ (ne_of_gt hρ.trace_pos))) y) j =
+        (Matrix.trace ρ)⁻¹ •
+          (boundaryFamilyEquiv (D := D) (Cfg d 1) y j * ρ) := by
+    rw [boundaryFamilyEquiv_boundaryFiberwiseMap_apply,
+      Matrix.gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply,
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm_apply_apply]
+  rw [leftVirtualMapES_adjoint_apply]
+  have hsum :
+      (∑ j : Cfg d 1, (evalWord A (List.ofFn j))ᴴ *
+        boundaryFamilyEquiv (D := D) (Cfg d 1)
+          (boundaryFiberwiseMap (D := D) (Cfg d 1)
+            (Matrix.gramReshuffle
+              (fixedPointProj ρ (ne_of_gt hρ.trace_pos))) y) j) =
+        ∑ j : Cfg d 1, (evalWord A (List.ofFn j))ᴴ *
+          ((Matrix.trace ρ)⁻¹ •
+            (boundaryFamilyEquiv (D := D) (Cfg d 1) y j * ρ)) := by
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [hKfiber j]
+  rw [hsum]
+  rw [Matrix.inverse_gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply
+    (hρ := hρ)]
+  simp only [Finset.sum_mul, Finset.smul_sum, Matrix.smul_mul,
+    Matrix.mul_smul, smul_smul, mul_inv_cancel₀ (ne_of_gt hρ.trace_pos),
+    Matrix.mul_assoc,
+    Matrix.mul_nonsing_inv ρ (ρ.isUnit_iff_isUnit_det.mp hρ.isUnit),
+    Matrix.mul_one, one_smul]
+  rw [inner_boundaryFiberwiseMap]
+  simp_rw [boundaryFamilyFiber_eq_frobeniusEquivEuclidean]
+  simp_rw [Matrix.gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply]
+  simp_rw [boundaryFamilyEquiv_tailVirtualMapES_apply]
+  simp only [(Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm_apply_apply,
+    Matrix.sum_mul, Matrix.mul_sum, Matrix.mul_smul, Finset.smul_sum,
+    Matrix.trace_sum,
+    Matrix.inner_frobeniusEquivEuclidean, Matrix.conjTranspose_mul,
+    Matrix.mul_assoc]
+
+/-- Reduction of the leading centered operator to the length-\(l\) Gram
+error.  The limiting product is identified by
+`inner_limitingMixedGramIntertwining`; subtracting it from the exact mixed Gram
+therefore leaves precisely the finite length-\(l\) Gram error. -/
 theorem inner_c3_centeredVirtualResidual_eq_gramError [NeZero D]
     (A : MPSTensor d D) (K l : ℕ)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (x : BoundaryFamilySpace (D := D) (Cfg d K))
-    (y : BoundaryFamilySpace (D := D) (Cfg d 1))
-    (hCenter :
-      let Kinf := Matrix.gramReshuffle
-        (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
-      let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
-      let Kinfleft := boundaryFiberwiseMap (D := D) (Cfg d 1) Kinf
-      let Iinf := Ring.inverse Kinf
-      inner ℂ x
-          (Kinftail.comp ((tailVirtualMapES A K).comp
-            (Iinf.comp ((leftVirtualMapES A 1).adjoint.comp Kinfleft))) y) =
-        ∑ u : Cfg d K, ∑ j : Cfg d 1,
-          inner ℂ
-            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
-              (evalWord A (List.ofFn j) *
-                boundaryFamilyEquiv (D := D) (Cfg d K) x u))
-            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
-              ((Matrix.trace ρ)⁻¹ •
-                ((boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
-                  evalWord A (List.ofFn u)) * ρ)))) :
+    (y : BoundaryFamilySpace (D := D) (Cfg d 1)) :
     let Kinf := Matrix.gramReshuffle
       (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
     let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
@@ -129,8 +180,9 @@ theorem inner_c3_centeredVirtualResidual_eq_gramError [NeZero D]
             (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
               (boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
                 evalWord A (List.ofFn u)))) := by
-  dsimp only at hCenter ⊢
-  rw [sub_apply, inner_sub_right, hCenter]
+  dsimp only
+  rw [sub_apply, inner_sub_right,
+    inner_limitingMixedGramIntertwining A K ρ hρ x y]
   exact inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered
     A K l ρ (ne_of_gt hρ.trace_pos) x y
 

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
@@ -24,6 +24,8 @@ and the fiberwise Gram identities. No contraction estimate is asserted.
 
 * `range_tailBoundaryMapES` and `range_leftBoundaryMapES_one` identify the physical ranges.
 * `c3_injectiveRangeProjector_residual_eq` is the exact C3 common-factorization identity.
+* `tailVirtualMapES_adjoint_apply` and `leftVirtualMapES_adjoint_apply` compute the
+  virtual-map adjoints.
 * `norm_boundaryFiberwiseMap_le` bounds a fiberwise map uniformly in its spectator type.
 * `tailBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram` and
   `leftBoundaryMapES_adjoint_comp_self_eq_fiberwise_groundSpaceGram` identify the Grams.
@@ -198,6 +200,61 @@ theorem boundaryFamilyEquiv_leftVirtualMapES_apply
   rw [(boundaryFamilyEquiv (D := D) (Cfg d L)).apply_symm_apply]
   rfl
 
+/-- The adjoint of the tail virtual word map sums right-adjointed word
+multiplication over the spectator fibers. -/
+theorem tailVirtualMapES_adjoint_apply
+    (A : MPSTensor d D) (K : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg d K)) :
+    (tailVirtualMapES A K).adjoint x =
+      Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (∑ u : Cfg d K,
+          boundaryFamilyEquiv (D := D) (Cfg d K) x u *
+            (evalWord A (List.ofFn u))ᴴ) := by
+  apply ext_inner_left ℂ
+  intro z
+  obtain ⟨Z, rfl⟩ :=
+    (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).surjective z
+  rw [ContinuousLinearMap.adjoint_inner_right,
+    Matrix.inner_frobeniusEquivEuclidean, PiLp.inner_apply,
+    Fintype.sum_prod_type]
+  change (∑ u : Cfg d K, inner ℂ
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (Z * evalWord A (List.ofFn u)))
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (boundaryFamilyEquiv (D := D) (Cfg d K) x u))) = _
+  simp only [Matrix.inner_frobeniusEquivEuclidean,
+    Matrix.conjTranspose_mul, Matrix.mul_sum, Matrix.trace_sum, Matrix.mul_assoc]
+  apply Finset.sum_congr rfl
+  intro u _
+  simpa only [Matrix.mul_assoc] using Matrix.trace_mul_comm
+    (evalWord A (List.ofFn u))ᴴ
+    (Zᴴ * boundaryFamilyEquiv (D := D) (Cfg d K) x u)
+
+/-- The adjoint of the left virtual word map sums left-adjointed word
+multiplication over the spectator fibers. -/
+theorem leftVirtualMapES_adjoint_apply
+    (A : MPSTensor d D) (L : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg d L)) :
+    (leftVirtualMapES A L).adjoint x =
+      Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (∑ τ : Cfg d L,
+          (evalWord A (List.ofFn τ))ᴴ *
+            boundaryFamilyEquiv (D := D) (Cfg d L) x τ) := by
+  apply ext_inner_left ℂ
+  intro z
+  obtain ⟨Z, rfl⟩ :=
+    (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).surjective z
+  rw [ContinuousLinearMap.adjoint_inner_right,
+    Matrix.inner_frobeniusEquivEuclidean, PiLp.inner_apply,
+    Fintype.sum_prod_type]
+  change (∑ τ : Cfg d L, inner ℂ
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (evalWord A (List.ofFn τ) * Z))
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (boundaryFamilyEquiv (D := D) (Cfg d L) x τ))) = _
+  simp only [Matrix.inner_frobeniusEquivEuclidean,
+    Matrix.conjTranspose_mul, Matrix.mul_sum, Matrix.trace_sum, Matrix.mul_assoc]
+
 /-- The ordinary Euclidean boundary map factors through the tail spectator map. -/
 theorem tailBoundaryMapES_comp_tailVirtualMapES
     (A : MPSTensor d D) (K L : ℕ) :
@@ -347,6 +404,18 @@ noncomputable def boundaryFamilyFiber {S : Type*} [Fintype S]
     EuclideanSpace ℂ (Fin D × Fin D) :=
   WithLp.toLp 2 fun p => x (s, p)
 
+/-- A flattened family fiber is the Frobenius coordinate vector of the
+corresponding matrix in `boundaryFamilyEquiv`. -/
+theorem boundaryFamilyFiber_eq_frobeniusEquivEuclidean
+    {S : Type*} [Fintype S]
+    (x : BoundaryFamilySpace (D := D) S) (s : S) :
+    boundaryFamilyFiber (D := D) x s =
+      Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (boundaryFamilyEquiv (D := D) S x s) := by
+  rw [boundaryFamilyEquiv_apply_apply,
+    (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).apply_symm_apply]
+  rfl
+
 /-- Apply an endomorphism independently to every virtual-matrix fiber. -/
 noncomputable def boundaryFiberwiseMap (S : Type*) [Fintype S]
     (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
@@ -385,6 +454,39 @@ theorem boundaryFiberwiseMap_apply_apply (S : Type*) [Fintype S]
     (x : BoundaryFamilySpace (D := D) S) (s : S) (p : Fin D × Fin D) :
     boundaryFiberwiseMap (D := D) S G x (s, p) =
       G (boundaryFamilyFiber (D := D) x s) p := rfl
+
+/-- The fiber of a fiberwise map is the original fiber acted on by the
+virtual endomorphism. -/
+@[simp]
+theorem boundaryFamilyFiber_boundaryFiberwiseMap
+    (S : Type*) [Fintype S]
+    (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      EuclideanSpace ℂ (Fin D × Fin D))
+    (x : BoundaryFamilySpace (D := D) S) (s : S) :
+    boundaryFamilyFiber (D := D) (boundaryFiberwiseMap (D := D) S G x) s =
+      G (boundaryFamilyFiber (D := D) x s) := by
+  apply PiLp.ext
+  intro p
+  rfl
+
+/-- In matrix coordinates, a fiberwise map acts on the Frobenius coordinate
+vector of each matrix fiber. -/
+@[simp]
+theorem boundaryFamilyEquiv_boundaryFiberwiseMap_apply
+    (S : Type*) [Fintype S]
+    (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      EuclideanSpace ℂ (Fin D × Fin D))
+    (x : BoundaryFamilySpace (D := D) S) (s : S) :
+    boundaryFamilyEquiv (D := D) S
+        (boundaryFiberwiseMap (D := D) S G x) s =
+      (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm
+        (G (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+          (boundaryFamilyEquiv (D := D) S x s))) := by
+  apply (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).injective
+  rw [(Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).apply_symm_apply,
+    ← boundaryFamilyFiber_eq_frobeniusEquivEuclidean,
+    boundaryFamilyFiber_boundaryFiberwiseMap,
+    boundaryFamilyFiber_eq_frobeniusEquivEuclidean]
 
 /-- Fiberwise maps preserve composition. -/
 theorem boundaryFiberwiseMap_comp (S : Type*) [Fintype S]

--- a/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean
@@ -458,7 +458,7 @@ theorem boundaryFiberwiseMap_apply_apply (S : Type*) [Fintype S]
 /-- The fiber of a fiberwise map is the original fiber acted on by the
 virtual endomorphism. -/
 @[simp]
-theorem boundaryFamilyFiber_boundaryFiberwiseMap
+private theorem boundaryFamilyFiber_boundaryFiberwiseMap
     (S : Type*) [Fintype S]
     (G : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
       EuclideanSpace ℂ (Fin D × Fin D))

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -738,10 +738,12 @@ windows.
     \label{thm:fixed_point_gram_metric_is_unit}
     \lean{Matrix.gramReshuffleMatrix_fixedPointProj_posDef}
     \lean{Matrix.gramReshuffle_fixedPointProj_isUnit}
+    \lean{Matrix.gramReshuffle_fixedPointProj_injective}
     \leanok
     \uses{def:fixed_point_proj, def:gram_reshuffle}
     If $D>0$ and $\rho\in\MN{D}$ is positive definite, then
-    $R(P_\rho)$ is positive definite and $\mathscr R(P_\rho)$ is invertible.
+    $R(P_\rho)$ is positive definite and $\mathscr R(P_\rho)$ is invertible,
+    hence injective.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -510,13 +510,14 @@ norm estimate is derived here.
 \begin{theorem}[Exact limiting-metric telescope for the C3 residual]%
     \label{thm:c3_projector_gram_error_telescope}
     \lean{MPSTensor.c3_virtualResidual_eq_centered_sub_gramErrors}
+    \lean{MPSTensor.inner_limitingMixedGramIntertwining}
     \lean{MPSTensor.inner_c3_centeredVirtualResidual_eq_gramError}
     \lean{MPSTensor.c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors}
     \leanok
     \uses{thm:c3_spectator_projector_residual,
-        thm:spectator_boundary_direct_sum_gram,
-        thm:spectator_boundary_mixed_gram_centered,
-        thm:fixed_point_gram_metric_exact}
+        def:ground_space_gram,
+        def:fixed_point_proj,
+        def:gram_reshuffle}
     Let $\rho\in\MN{D}$ be positive definite and set
     $\mathcal K_\infty=\mathscr R(P_\rho)$ and
     $S_\infty=\mathcal K_\infty^{-1}$.  Write $J_{\rm t}$ and $J_{\rm l}$
@@ -547,28 +548,59 @@ norm estimate is derived here.
     the physical projector residual, sandwiched between the tail boundary map,
     the two local fiberwise inverse Grams, and the adjoint left boundary map.
 
-    If the limiting product in the first parenthesis has the explicit limiting
-    mixed pairing from the preceding centered mixed-Gram theorem, then its
-    pairing against boundary families is exactly the same finite sum with
+    The limiting product in the first parenthesis has, without an additional
+    hypothesis, the explicit limiting mixed pairing
+    \begin{align}
+      &\left\langle X,
+        \mathcal K_\infty^{\oplus K}J_{\rm t}S_\infty
+          J_{\rm l}^\dagger\mathcal K_\infty^{\oplus 1}Z
+        \right\rangle \\
+      &\qquad=\sum_{u,j}\left\langle
+        U(A^jX_u),\mathcal K_\infty U(Z_jA^u)\right\rangle .
+    \end{align}
+    Consequently, pairing the first parenthesis against boundary families is
+    exactly the same finite sum with
     $\mathcal K_l-\mathcal K_\infty$ in place of $\mathcal K_l$.
-    This last implication records the exact remaining intertwining hypothesis;
-    it does not assert that hypothesis.
 
     These identities are reconstructed operator algebra.  They assert neither
-    the numerical FNW contraction nor any identification of a physical ground
-    projector with $P_\rho$.
+    the numerical FNW/Nachtergaele contraction nor any identification of a
+    physical ground projector with $P_\rho$.
 \end{theorem}
 \begin{proof}
     \leanok
     \uses{thm:c3_spectator_projector_residual,
         thm:spectator_boundary_direct_sum_gram,
-        thm:spectator_boundary_mixed_gram_centered}
+        thm:spectator_boundary_mixed_gram_centered,
+        thm:fixed_point_gram_metric_exact,
+        thm:fixed_point_gram_metric_is_unit}
     Add and subtract the product in which all three finite Gram factors are
     replaced by their limiting values, and telescope the resulting product
     from left to right.  Substitute the direct-sum Gram and inverse-Gram
-    formulas into the exact projector factorization.  Under the displayed
-    limiting-pairing hypothesis, apply the centered mixed-Gram identity to the
-    leading term.
+    formulas into the exact projector factorization.
+
+    It remains to identify the leading limiting product.  In Frobenius
+    coordinates the limiting metric and its inverse act by
+    \begin{align}
+      \mathcal K_\infty U(X)
+        &=U\!\left((\tr\rho)^{-1}X\rho\right),&
+      S_\infty U(X)
+        &=U\!\left((\tr\rho)X\rho^{-1}\right).
+    \end{align}
+    The adjoint left virtual map sends a family $W=(W_j)_j$ to
+    $U(\sum_j(A^j)^\dagger W_j)$.  For
+    $W_j=(\tr\rho)^{-1}Z_j\rho$, the right multiplication by $\rho$ and
+    the factor $(\tr\rho)^{-1}$ supplied by the left limiting spectator
+    metric cancel exactly through $S_\infty$.  Applying the tail virtual map and the
+    tail limiting spectator metric leaves, in the fiber indexed by $u$,
+    \begin{align}
+      U\!\left((\tr\rho)^{-1}
+        \sum_j (A^j)^\dagger Z_jA^u\rho\right).
+    \end{align}
+    Its inner product with $X_u$, followed by summation over $u$, is the
+    displayed limiting mixed pairing by the Frobenius trace identity.  No
+    transfer fixed-point equation is needed for this zeroth-order
+    cancellation.  The centered mixed-Gram identity then turns the leading
+    term into the pairing with $\mathcal K_l-\mathcal K_\infty$.
 \end{proof}
 
 \subsection{Martingale gap consequences}\label{subsec:spectral_gap_martingale}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -507,8 +507,8 @@ norm estimate is derived here.
     sums and the second argument of the inner product.
 \end{proof}
 
-\begin{lemma}[Limiting metric inverse and virtual-map adjoints]%
-    \label{lem:limiting_metric_inverse_virtual_adjoints}
+\begin{theorem}[Limiting metric inverse and virtual-map adjoints]%
+    \label{thm:limiting_metric_inverse_virtual_adjoints}
     \lean{Matrix.inverse_gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply}
     \lean{MPSTensor.tailVirtualMapES_adjoint_apply}
     \lean{MPSTensor.leftVirtualMapES_adjoint_apply}
@@ -517,34 +517,28 @@ norm estimate is derived here.
         def:gram_reshuffle,
         def:frobenius_vectorization,
         thm:spectator_boundary_hilbert_factorization}
-    Suppose that $D>0$ and $\rho\in\MN{D}$ is positive definite.  For
-    $\mathcal K_\infty=\mathscr R(P_\rho)$ and
-    $S_\infty=\mathcal K_\infty^{-1}$,
-    \begin{align}
-      \mathcal K_\infty U(X)
-        &=U\!\left((\tr\rho)^{-1}X\rho\right),&
-      S_\infty U(X)
-        &=U\!\left((\tr\rho)X\rho^{-1}\right).
-    \end{align}
-    Moreover, the adjoints of the tail and left virtual maps are
+    For arbitrary virtual dimension, the adjoints of the tail and left virtual
+    maps are
     \begin{align}
       (J^{\mathrm{tail}}_K)^\dagger(X_u)_u
         &=U\!\left(\sum_u X_u(A^u)^\dagger\right),&
       (J^{\mathrm{left}}_L)^\dagger(Z_\tau)_\tau
         &=U\!\left(\sum_\tau(A^\tau)^\dagger Z_\tau\right).
     \end{align}
-\end{lemma}
+    If, in addition, $D>0$ and $\rho\in\MN{D}$ is positive definite, set
+    $\mathcal K_\infty=\mathscr R(P_\rho)$ and
+    $S_\infty=\mathcal K_\infty^{-1}$.  Then
+    \begin{align}
+      \mathcal K_\infty U(X)
+        &=U\!\left((\tr\rho)^{-1}X\rho\right),&
+      S_\infty U(X)
+        &=U\!\left((\tr\rho)X\rho^{-1}\right).
+    \end{align}
+\end{theorem}
 \begin{proof}
     \leanok
     \uses{thm:fixed_point_gram_metric_exact,
-        thm:fixed_point_gram_metric_is_unit,
-        thm:spectator_boundary_hilbert_factorization}
-    The forward action of $\mathcal K_\infty$ is the exact limiting-metric
-    formula.  Positive definiteness makes this operator invertible.  Applying
-    the forward formula to
-    $U((\tr\rho)X\rho^{-1})$ cancels both scalar factors and the two right
-    matrix factors, which gives the displayed inverse action.
-
+        thm:fixed_point_gram_metric_is_unit}
     For the tail adjoint, test against an arbitrary matrix $Y$ and use the
     Hilbert--Schmidt trace pairing fiberwise:
     \begin{align}
@@ -555,6 +549,12 @@ norm estimate is derived here.
     The left formula follows in the same way from
     $\langle U(A^\tau Y),U(Z_\tau)\rangle
       =\langle U(Y),U((A^\tau)^\dagger Z_\tau)\rangle$.
+
+    Under the additional positive-definiteness hypothesis, the forward action
+    of $\mathcal K_\infty$ is the exact limiting-metric formula and the
+    operator is invertible.  Applying the forward formula to
+    $U((\tr\rho)X\rho^{-1})$ cancels both scalar factors and the two right
+    matrix factors, which gives the displayed inverse action.
 \end{proof}
 
 \begin{theorem}[Exact limiting-metric telescope for the C3 residual]%
@@ -621,7 +621,8 @@ norm estimate is derived here.
     \uses{thm:c3_spectator_projector_residual,
         thm:spectator_boundary_direct_sum_gram,
         thm:spectator_boundary_mixed_gram_centered,
-        lem:limiting_metric_inverse_virtual_adjoints}
+        thm:fixed_point_gram_metric_exact,
+        thm:limiting_metric_inverse_virtual_adjoints}
     Add and subtract the product in which all three finite Gram factors are
     replaced by their limiting values, and telescope the resulting product
     from left to right.  Substitute the direct-sum Gram and inverse-Gram

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -507,6 +507,56 @@ norm estimate is derived here.
     sums and the second argument of the inner product.
 \end{proof}
 
+\begin{lemma}[Limiting metric inverse and virtual-map adjoints]%
+    \label{lem:limiting_metric_inverse_virtual_adjoints}
+    \lean{Matrix.inverse_gramReshuffle_fixedPointProj_frobeniusEquivEuclidean_apply}
+    \lean{MPSTensor.tailVirtualMapES_adjoint_apply}
+    \lean{MPSTensor.leftVirtualMapES_adjoint_apply}
+    \leanok
+    \uses{def:fixed_point_proj,
+        def:gram_reshuffle,
+        def:frobenius_vectorization,
+        thm:spectator_boundary_hilbert_factorization}
+    Suppose that $D>0$ and $\rho\in\MN{D}$ is positive definite.  For
+    $\mathcal K_\infty=\mathscr R(P_\rho)$ and
+    $S_\infty=\mathcal K_\infty^{-1}$,
+    \begin{align}
+      \mathcal K_\infty U(X)
+        &=U\!\left((\tr\rho)^{-1}X\rho\right),&
+      S_\infty U(X)
+        &=U\!\left((\tr\rho)X\rho^{-1}\right).
+    \end{align}
+    Moreover, the adjoints of the tail and left virtual maps are
+    \begin{align}
+      (J^{\mathrm{tail}}_K)^\dagger(X_u)_u
+        &=U\!\left(\sum_u X_u(A^u)^\dagger\right),&
+      (J^{\mathrm{left}}_L)^\dagger(Z_\tau)_\tau
+        &=U\!\left(\sum_\tau(A^\tau)^\dagger Z_\tau\right).
+    \end{align}
+\end{lemma}
+\begin{proof}
+    \leanok
+    \uses{thm:fixed_point_gram_metric_exact,
+        thm:fixed_point_gram_metric_is_unit,
+        thm:spectator_boundary_hilbert_factorization}
+    The forward action of $\mathcal K_\infty$ is the exact limiting-metric
+    formula.  Positive definiteness makes this operator invertible.  Applying
+    the forward formula to
+    $U((\tr\rho)X\rho^{-1})$ cancels both scalar factors and the two right
+    matrix factors, which gives the displayed inverse action.
+
+    For the tail adjoint, test against an arbitrary matrix $Y$ and use the
+    Hilbert--Schmidt trace pairing fiberwise:
+    \begin{align}
+      \sum_u\langle U(YA^u),U(X_u)\rangle
+        =\left\langle U(Y),
+          U\!\left(\sum_uX_u(A^u)^\dagger\right)\right\rangle.
+    \end{align}
+    The left formula follows in the same way from
+    $\langle U(A^\tau Y),U(Z_\tau)\rangle
+      =\langle U(Y),U((A^\tau)^\dagger Z_\tau)\rangle$.
+\end{proof}
+
 \begin{theorem}[Exact limiting-metric telescope for the C3 residual]%
     \label{thm:c3_projector_gram_error_telescope}
     \lean{MPSTensor.c3_virtualResidual_eq_centered_sub_gramErrors}
@@ -571,8 +621,7 @@ norm estimate is derived here.
     \uses{thm:c3_spectator_projector_residual,
         thm:spectator_boundary_direct_sum_gram,
         thm:spectator_boundary_mixed_gram_centered,
-        thm:fixed_point_gram_metric_exact,
-        thm:fixed_point_gram_metric_is_unit}
+        lem:limiting_metric_inverse_virtual_adjoints}
     Add and subtract the product in which all three finite Gram factors are
     replaced by their limiting values, and telescope the resulting product
     from left to right.  Substitute the direct-sum Gram and inverse-Gram

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1474, 1516 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1476, 1518 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- compute the inverse limiting Gram explicitly as right multiplication by
  \((\operatorname{tr}\rho)\rho^{-1}\) in Frobenius coordinates
- derive the tail and left virtual-word-map adjoints with the project's complex
  Frobenius inner-product convention
- prove the exact tail-after-left limiting mixed-Gram intertwining and use it to
  remove the conditional `hCenter` premise from the centered projector residual
- retain the explicit `ρ.PosDef` and nonzero-dimension hypotheses; no physical
  projector is identified with `fixedPointProj`

The calculation shows that no transfer fixed-point equation is required for this
zeroth-order identity: the right multiplication by \(\rho\) from the left
spectator Gram is cancelled by \(K_\infty^{-1}\), and the final tail spectator
Gram supplies exactly the normalized right multiplication appearing in the
centered mixed pairing. Positivity is used to make this cancellation
nonsingular. This is reconstructed exact algebra and does not assert the FNW
numerical estimate.

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/LimitingGramMetric.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/SpectatorBoundaryGram.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/ProjectorCancellation.lean`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref 68058752e`
- `python3 scripts/check_reader_facing_prose.py --diff-base 68058752e`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`

Closes #5954

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are formal Lean proofs on the parent-Hamiltonian spectral-gap chain; risk is proof correctness and dependency on PosDef \(\rho\) hypotheses, not production runtime behavior.
> 
> **Overview**
> Proves the **exact tail-after-left limiting mixed-Gram pairing** (`inner_limitingMixedGramIntertwining`) and uses it to drop the conditional `hCenter` premise from `inner_c3_centeredVirtualResidual_eq_gramError`, so the C3 centered residual is identified with the length-\(l\) Gram error **(\(\mathcal K_l - \mathcal K_\infty\)**) without assuming that intertwining separately.
> 
> Supporting lemmas: inverse limiting Gram action as **\((\operatorname{tr}\rho)\,X\rho^{-1}\)** in Frobenius coordinates, tail/left **virtual-map adjoints**, and fiberwise **boundaryFamilyEquiv** identities. Blueprint chapter 13 is updated to record injectivity of the limiting metric, the inverse/adjoint formulas, and that the zeroth-order cancellation needs **PosDef \(\rho\)** but not a transfer fixed-point equation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a57d07c80b7bcf9b4674cef08df176449a37123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->