### PR TITLE
docs(CPSV16): correct fundamental theorem numbering

### DIFF
--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -30,7 +30,7 @@ We also provide a convenient lemma: if pairwise overlaps of a finite family of M
 converge to the Kronecker delta (i.e. the Gram matrix tends to the identity), then the
 states are eventually linearly independent.
 The finite-index and two-family forms of this criterion are the linear-independence
-conditions used in the CPSV proof of arXiv:1606.00608, Theorem II.1.
+conditions used in the CPSV proof of arXiv:1606.00608, Theorem 2.10.
 
 ## Part 2: BNT matching theory (from `BNTMatching`)
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -662,7 +662,7 @@ private theorem ft_sector_bnt_equal_mps_unitaryGauge_literal
 /-- **Restricted equal-case fundamental theorem.**
 
 This is the active, nonzero, converse-covered correction of CPSV16 Corollary
-II.2.  The CPSV16 convention permits an unrelated normal summand whose
+2.11.  The CPSV16 convention permits an unrelated normal summand whose
 coefficient vanishes at every positive length; such a summand can change the
 ambient bond dimension while preserving all positive-length MPVs.
 
@@ -731,7 +731,7 @@ theorem fundamentalTheorem_equal_canonicalForm_unitary
 
 /-- **Restricted proportional multi-block fundamental theorem.**
 
-This is the active, nonzero, converse-covered correction of CPSV16 Theorem II.1
+This is the active, nonzero, converse-covered correction of CPSV16 Theorem 2.10
 and CPSV21 Theorem 4.4.  Their literal BNT definitions permit an unrelated
 normal representative whose coefficient vanishes at every length, so the
 unrestricted equality of BNT cardinalities is false.  In the CPSV21

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -661,8 +661,8 @@ private theorem ft_sector_bnt_equal_mps_unitaryGauge_literal
 
 /-- **Restricted equal-case fundamental theorem.**
 
-This is the active, nonzero, converse-covered correction of CPSV16 Corollary
-2.11.  The CPSV16 convention permits an unrelated normal summand whose
+This is the active, nonzero, converse-covered correction of
+CPSV16 Corollary 2.11.  The CPSV16 convention permits an unrelated normal summand whose
 coefficient vanishes at every positive length; such a summand can change the
 ambient bond dimension while preserving all positive-length MPVs.
 

--- a/TNLean/MPS/Overlap/Basic.lean
+++ b/TNLean/MPS/Overlap/Basic.lean
@@ -70,7 +70,7 @@ lemma mpvOverlap_eq_star_mpvInner {d D₁ D₂ : ℕ} (A : MPSTensor d D₁) (B 
 state vectors.
 
 This algebraic identity is used in the proof of arXiv:1606.00608,
-Theorem II.1, Appendix MPV proof line 1182, to lift the BNT decomposition to a
+Theorem 2.10, Appendix MPV proof line 1182, to lift the BNT decomposition to a
 state-vector identity before taking inner products with individual blocks. -/
 lemma mpvState_eq_sum_of_decomp
     {d g Dtot : ℕ} {dim : Fin g → ℕ}
@@ -92,7 +92,7 @@ lemma mpvState_eq_sum_of_decomp
 decomposition.
 
 This algebraic identity is used in the proof of arXiv:1606.00608,
-Theorem II.1, Appendix MPV proof line 1182, when projecting the full
+Theorem 2.10, Appendix MPV proof line 1182, when projecting the full
 proportionality relation onto one block MPV. -/
 lemma mpvInner_eq_sum_of_decomp_right
     {d g D Dtot : ℕ} {dim : Fin g → ℕ}

--- a/TNLean/MPS/SharedInfra/BlockGauge.lean
+++ b/TNLean/MPS/SharedInfra/BlockGauge.lean
@@ -33,7 +33,7 @@ statements of the fundamental theorem itself.
 
 ## Reference
 
-* arXiv:1606.00608, Corollary II.2 (`eq:II_auxcor`, lines 1172--1178)
+* arXiv:1606.00608, Corollary 2.11 (`eq:II_auxcor`, lines 1172--1178)
   and its block-diagonal gauge construction in lines 1189--1192.
 * arXiv:1708.00029, equation `eq:bdnr`, lines 286--305, and the sectorwise
   normalization similarities at lines 313--332.
@@ -98,7 +98,7 @@ noncomputable def blockDiagonalGL (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
 canonical `Fin (∑ k, dim k)` bond index, naming the global gauge `X = ⊕ₖ X k`
 that arises after the BNT block matching.
 
-Reference: arXiv:1606.00608, Corollary II.2 (`eq:II_auxcor`, lines 1172--1178)
+Reference: arXiv:1606.00608, Corollary 2.11 (`eq:II_auxcor`, lines 1172--1178)
 and the block-diagonal gauge construction in lines 1189--1192. -/
 noncomputable def globalGaugeOfBlocks (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
     GL (Fin (∑ k : Fin r, dim k)) ℂ :=
@@ -144,7 +144,7 @@ If `B k i = X k * A k i * (X k)⁻¹` for every `k, i`, then for every `i`,
 `toTensorFromBlocks μ B i = (⊕ X) * toTensorFromBlocks μ A i * (⊕ X)⁻¹`,
 where `⊕ X = globalGaugeOfBlocks X` is the reindexed block-diagonal gauge.
 
-Reference: arXiv:1606.00608, Corollary II.2 (`eq:II_auxcor`, lines 1172--1178)
+Reference: arXiv:1606.00608, Corollary 2.11 (`eq:II_auxcor`, lines 1172--1178)
 and the block-diagonal gauge construction in lines 1189--1192. -/
 theorem toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
     (X : (k : Fin r) → GL (Fin (dim k)) ℂ)


### PR DESCRIPTION
## What changed

- update four stale `Theorem II.1` docstring references to `Theorem 2.10`
- update four stale `Corollary II.2` docstring references to `Corollary 2.11`
- preserve the stable source labels `thm1`, `II_cor2`, and `eq:II_auxcor`

## Validation

- exact-head source audit review: approved
- `lake build TNLean.MPS.BNT.Basic TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord TNLean.MPS.Overlap.Basic TNLean.MPS.SharedInfra.BlockGauge`
- `git diff --check`
- repository-wide stale-numbering grep

Closes #5955

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits with no changes to proofs, definitions, or behavior; risk is limited to citation accuracy in docstrings.
> 
> **Overview**
> Updates **documentation-only** references to Cirac et al. (arXiv:1606.00608) so theorem labels match the paper’s numbering: **`Theorem II.1` → `Theorem 2.10`** and **`Corollary II.2` → `Corollary 2.11`**.
> 
> Changes are confined to module and lemma docstrings in `BNT/Basic.lean`, `FundamentalTheorem/SectorBNT/FundamentalCoord.lean`, `Overlap/Basic.lean`, and `SharedInfra/BlockGauge.lean`. Stable internal labels (`thm1`, `II_cor2`, `eq:II_auxcor`) are unchanged, as noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c586af564521a034dd830450123721bf306897df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->