### PR TITLE
feat(MPS/MPU): expose source-u boundary contraction

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -18,6 +18,7 @@ import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
+import TNLean.MPS.MPU.SourceUBoundary
 import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SourceUOpenTail
 import TNLean.MPS.MPU.SourceUV

--- a/TNLean/MPS/MPU/SourceUBoundary.lean
+++ b/TNLean/MPS/MPU/SourceUBoundary.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceUOpenTail
+
+/-!
+# Boundary algebra for the source tensor u
+
+This file records the normalized open-tail coefficient occurring in the proof
+of `lemuisometry` from arXiv:1703.09188, lines 545--557, and closes its outer
+source-factor boundary once the internal tail has the rank-one kernel shown in
+equation `uUnitary`.
+
+The coefficient retains exactly one factor $d^{-K}$. In the surrounding Gram
+contraction the output pair $q$ is unstarred and the conjugated output pair $p$
+is starred; their source-$u$ entries are external to the coefficient defined
+here.
+
+**Scope boundary:** no result here identifies the forward open tail with a
+reflected contraction, proves that `sourceU` is an isometry, or derives a rank
+bound. The terminal contraction uses only $X_2^\dagger X_2=1$, never an ambient
+coisometry identity.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- The normalized coefficient of the fully sandwiched open $K$-site tail.
+
+The retained source-$u$ entry indexed by $q$ is unstarred and the entry indexed
+by $p$ is starred in the Gram contraction; these two external entries are not
+part of the coefficient. Thus the displayed expression contains exactly one
+normalization factor $d^{-K}$.
+
+Source: arXiv:1703.09188, equation `uUnitary`, lines 550--556. -/
+noncomputable def sourceUOpenTailCoefficient
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)
+    (l : Fin ℓ[U]) (r : Fin r[U]) (l' : Fin ℓ[U]) (r' : Fin r[U]) : ℂ :=
+  ((d : ℂ)⁻¹) ^ K *
+    ∑ τ : Fin K → Fin d, ∑ ζ : Fin K → Fin d,
+    ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+    ∑ α : Fin D, ∑ α' : Fin D,
+    ∑ β : Fin D, ∑ β' : Fin D,
+    ∑ i : Fin d, ∑ i' : Fin d,
+      sourceX₁ U ρ hρ (α, j₁) r *
+        star (sourceX₁ U ρ hρ (α', j₁) r') *
+        star (sourceX₂ U (β, i) l) * sourceX₂ U (β', i') l' *
+        (U i j₂ * evalWord U (List.ofFn τ) (List.ofFn ζ)) β α *
+        star ((U i' j₂ * evalWord U (List.ofFn τ) (List.ofFn ζ)) β' α')
+
+/-- Entrywise form of the column-isometry identity $X_2^\dagger X_2=1$.
+
+Source: arXiv:1703.09188, equation `Y1Y1X1X1`, lines 479--494. -/
+theorem sourceX₂_isometry_apply (l l' : Fin ℓ[U]) :
+    (∑ β : Fin D, ∑ i : Fin d,
+      star (sourceX₂ U (β, i) l) * sourceX₂ U (β, i) l') =
+      if l = l' then 1 else 0 := by
+  have h := congrArg (fun M ↦ M l l') (sourceX₂_isometry U)
+  simpa only [Matrix.mul_apply, Matrix.one_apply, Matrix.conjTranspose_apply,
+    Fintype.sum_prod_type] using h
+
+/-- If the internal open tail has kernel
+$\rho_{\alpha',\alpha}\delta_{\beta,\beta'}\delta_{i,i'}$, then its weighted
+$X_1$ and unweighted $X_2$ boundary is
+$\delta_{l,l'}\delta_{r,r'}$.
+
+This is the terminal boundary step in arXiv:1703.09188, equation `uUnitary`,
+lines 550--556. It uses the normalization identities in equation `Y1Y1X1X1`,
+lines 479--494. -/
+theorem sourceU_boundary_sandwich
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (l : Fin ℓ[U]) (r : Fin r[U]) (l' : Fin ℓ[U]) (r' : Fin r[U]) :
+    (∑ j : Fin d, ∑ α : Fin D, ∑ α' : Fin D,
+      ∑ β : Fin D, ∑ i : Fin d,
+        sourceX₁ U ρ hρ (α, j) r *
+          star (sourceX₁ U ρ hρ (α', j) r') *
+          star (sourceX₂ U (β, i) l) * sourceX₂ U (β, i) l' * ρ α' α) =
+      (if l = l' then 1 else 0) * (if r = r' then 1 else 0) := by
+  classical
+  have h₁ := sourceX₁_weighted_isometry_apply U ρ hρ r' r
+  simp only [sourceWeight, Matrix.kronecker_apply, Matrix.one_apply, mul_ite,
+    mul_one, mul_zero, ite_mul, zero_mul, Finset.sum_ite_eq',
+    Finset.mem_univ, if_true, Fintype.sum_prod_type] at h₁
+  rw [Finset.sum_comm] at h₁
+  have h₁' :
+      (∑ j : Fin d, ∑ α : Fin D,
+        (∑ α' : Fin D, star (sourceX₁ U ρ hρ (α', j) r') * ρ α' α) *
+          sourceX₁ U ρ hρ (α, j) r) = if r' = r then 1 else 0 := by
+    simpa only [Finset.sum_mul] using h₁
+  have h₂ := sourceX₂_isometry_apply U l l'
+  have hreorder (j : Fin d) (α α' β : Fin D) (i : Fin d) :
+      sourceX₁ U ρ hρ (α, j) r * star (sourceX₁ U ρ hρ (α', j) r') *
+          star (sourceX₂ U (β, i) l) * sourceX₂ U (β, i) l' * ρ α' α =
+        (star (sourceX₁ U ρ hρ (α', j) r') * ρ α' α *
+          sourceX₁ U ρ hρ (α, j) r) *
+        (star (sourceX₂ U (β, i) l) * sourceX₂ U (β, i) l') := by
+    ring
+  simp_rw [hreorder]
+  simp_rw [← Finset.mul_sum]
+  rw [h₂]
+  simp_rw [← Finset.sum_mul]
+  rw [h₁']
+  simp only [eq_comm, mul_comm]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1530,7 +1530,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_source_factor_normalizations}
     \lean{MPOTensor.sourceX₁_weighted_isometry,
         MPOTensor.sourceX₁_weighted_isometry_apply,
-        MPOTensor.sourceX₂_isometry}
+        MPOTensor.sourceX₂_isometry,
+        MPOTensor.sourceX₂_isometry_apply}
     \leanok
     \uses{def:mpu_weighted_source_factors,def:mpu_source_weight}
     The left factors satisfy
@@ -1538,7 +1539,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         X_1^\dagger W_\rho X_1&=\Id_r,
         &X_2^\dagger X_2&=\Id_\ell,\\
         \sum_{x,y}\overline{(X_1)_{x,r}}(W_\rho)_{x,y}(X_1)_{y,r'}
-          &=\delta_{r,r'}.
+          &=\delta_{r,r'},\\
+        \sum_{\beta,i}\overline{(X_2)_{(\beta,i),l}}(X_2)_{(\beta,i),l'}
+          &=\delta_{l,l'}.
     \end{align}
     These are \cite[Section~III]{Cirac2017MPU}.
 \end{theorem}
@@ -1550,7 +1553,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     $X_1^\dagger W_\rho X_1=\Id_r$; evaluating at $(r,r')$ gives the displayed
     weighted sum. Since $X_2=V_2^\dagger$, the
     coisometry identity $V_2V_2^\dagger=\Id_\ell$ gives
-    $X_2^\dagger X_2=\Id_\ell$.
+    $X_2^\dagger X_2=\Id_\ell$; evaluating at $(l,l')$ gives the second
+    displayed entry sum.
 \end{proof}
 
 \begin{theorem}[Recovery of the right source factors]
@@ -1761,14 +1765,80 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     expansion.
 \end{proof}
 
+\begin{definition}[Normalized open-tail coefficient]
+    \label{def:mpu_source_u_open_tail_coefficient}
+    \lean{MPOTensor.sourceUOpenTailCoefficient}
+    \leanok
+    \uses{thm:mpu_source_u_open_periodic_tail,
+        def:mpu_weighted_source_factors}
+    For
+    \begin{align}
+      A^{\tau,\zeta}_{i,j_2}
+        &=\mathcal U^{ij_2}T_{\tau,\zeta},
+    \end{align}
+    define the coefficient indexed by $l,r,l',r'$ to be
+    \begin{align}
+      C^{(K)}_{lr,l'r'}=d^{-K}
+      \sum_{\substack{\tau,\zeta,j_1,j_2,\alpha,\alpha',\\
+                      \beta,\beta',i,i'}}
+        &(X_1)_{(\alpha,j_1),r}
+        \overline{(X_1)_{(\alpha',j_1),r'}}
+        \overline{(X_2)_{(\beta,i),l}}
+        (X_2)_{(\beta',i'),l'}\\
+        &\mathrel{\phantom{=}}\cdot
+        (A^{\tau,\zeta}_{i,j_2})_{\beta,\alpha}
+        \overline{(A^{\tau,\zeta}_{i',j_2})_{\beta',\alpha'}}.
+    \end{align}
+    This is the coefficient obtained from the two open-tail expansions in the
+    normalized Gram contraction in the proof of the source-tensor isometry
+    lemma in \cite[Section~III]{Cirac2017MPU}.  The external factor $u_{(l,r),q}$ is
+    unstarred, while $u_{(l',r'),p}$ is starred.  Thus the displayed
+    coefficient contains the unique normalization factor $d^{-K}$.
+\end{definition}
+
+\begin{theorem}[Terminal source-factor boundary contraction]
+    \label{thm:mpu_source_u_terminal_boundary}
+    \lean{MPOTensor.sourceU_boundary_sandwich}
+    \leanok
+    \uses{def:mpu_source_u_open_tail_coefficient,
+        thm:mpu_source_factor_normalizations}
+    If the normalized internal tail supplies
+    \begin{align}
+      \rho_{\alpha',\alpha}\,
+      \delta_{\beta,\beta'}\delta_{i,i'},
+    \end{align}
+    then the remaining boundary sum is
+    \begin{align}
+      \sum_{\substack{j,\alpha,\alpha',\beta,i}}
+        &(X_1)_{(\alpha,j),r}
+        \overline{(X_1)_{(\alpha',j),r'}}
+        \overline{(X_2)_{(\beta,i),l}}
+        (X_2)_{(\beta,i),l'}\rho_{\alpha',\alpha}
+        =\delta_{l,l'}\delta_{r,r'}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_factor_normalizations}
+    Reorder the scalar factors so that the sum separates into the weighted
+    $X_1$ contraction and the unweighted $X_2$ contraction.  Evaluating
+    \begin{align}
+      X_1^\dagger(\Id_d\otimes\rho)X_1&=\Id_r, &
+      X_2^\dagger X_2&=\Id_\ell
+    \end{align}
+    at $(r',r)$ and $(l,l')$, respectively, gives the two Kronecker deltas.
+    This is precisely the terminal boundary simplification in
+    the proof of the source-tensor isometry lemma in
+    \cite[Section~III]{Cirac2017MPU}.
+\end{proof}
+
 \begin{remark}[Scope of the open-tail algebra]
-    The preceding theorem does not collapse the open virtual tail.  In
-    particular, it proves neither $u^\dagger u=\Id$ nor a rank bound for $u$,
-    and it does not use the false ambient equation $X_2X_2^\dagger=\Id$.
-    The remaining contraction must retain the surrounding $X_1$ and $X_2$
-    factors.  In the eventual Gram contraction the retained pair $q$ is
-    unstarred and the retained pair $p$ is starred, with exactly one factor
-    $d^{-K}$ supplied by the normalized periodic tail.
+    The preceding results do not identify the forward open-tail coefficient
+    with the reflected blocked contraction.  In particular, they prove
+    neither $u^\dagger u=\Id$ nor a rank bound for $u$, and they do not use
+    $X_2X_2^\dagger=\Id$, $M_2M_2^\dagger=\Id$, or
+    $Y_2Y_2^\dagger=\Id$.  The missing step must transport the internal tail
+    only inside the complete $X_1$--$X_2$ sandwich.
 \end{remark}
 
 \begin{theorem}[Right-rank bound]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1823,7 +1823,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     Reorder the scalar factors so that the sum separates into the weighted
     $X_1$ contraction and the unweighted $X_2$ contraction.  Evaluating
     \begin{align}
-      X_1^\dagger(\Id_d\otimes\rho)X_1&=\Id_r, &
+      X_1^\dagger W_\rho X_1&=\Id_r, &
       X_2^\dagger X_2&=\Id_\ell
     \end{align}
     at $(r',r)$ and $(l,l')$, respectively, gives the two Kronecker deltas.


### PR DESCRIPTION
## Summary

- define the exact normalized source-`u` open-tail coefficient with one factor $d^{-K}$ and audited primed/unprimed orientation
- expose the entrywise form of $X_2^\dagger X_2=1$
- prove the terminal weighted-$X_1$/unweighted-$X_2$ boundary contraction once the internal tail supplies $\rho_{\alpha',\alpha}\delta_{\beta,\beta'}\delta_{i,i'}$
- synchronize Chapter 28 with formula-driven statements and the explicit remaining scope boundary

This is the provable boundary child of #5893. It deliberately does **not** assert the missing forward-to-reflected transport, source-`u` isometry/rank, a pointwise insertion, or ambient $X_2X_2^\dagger$, $M_2M_2^\dagger$, or $Y_2Y_2^\dagger$ identities. The terminal proof calls `sourceX₁_weighted_isometry_apply U ρ hρ r' r` in the source-required order.

## Checks

- direct Lean compilation of `TNLean/MPS/MPU/SourceUBoundary.lean`
- targeted builds of `TNLean.MPS.MPU.SourceUBoundary` and `TNLean.MPS.MPU`
- generated import aggregator check and import-generator tests
- blueprint synchronization and reverse coverage (Chapter 28: 209/209)
- reader-facing prose, proof-integrity, whitespace, and added-line-length checks
- independent exact-head LeanSimplifier approval

Closes #5970.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes extend the formal MPU source-`u` isometry proof chain with new definitions and a boundary contraction that depends on correct index orientation and existing weighted-isometry lemmas; scope is intentionally limited and does not assert full isometry or rank bounds.
> 
> **Overview**
> Adds **`TNLean/MPS/MPU/SourceUBoundary.lean`** and wires it into the MPU import graph, formalizing the **terminal boundary step** for the source tensor `u` Gram contraction (Cirac et al. `uUnitary`).
> 
> **`sourceUOpenTailCoefficient`** is the normalized open **K**-site tail coefficient with a single **d⁻ᴷ** factor and audited primed/unprimed orientation; external **u** entries stay outside this sum.
> 
> **`sourceX₂_isometry_apply`** exposes the entrywise **X₂†X₂ = 1** identity (derived from existing `sourceX₂_isometry`).
> 
> **`sourceU_boundary_sandwich`** shows that once the internal tail supplies **ρ_{α',α} δ_{β,β'} δ_{i,i'}**, the weighted **X₁** / unweighted **X₂** boundary sum collapses to **δ_{l,l'} δ_{r,r'}** by separating sums and calling **`sourceX₁_weighted_isometry_apply`** and **`sourceX₂_isometry_apply`**.
> 
> Chapter 28 blueprint is synchronized with the new definition, terminal boundary theorem, expanded source-factor normalization display, and an explicit **scope** remark: no forward/reflected transport, no **u†u** or rank bound, and no ambient **X₂X₂†** / **M₂M₂†** / **Y₂Y₂†** identities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995bb4d2c9fb69eed9ee695136566046748ebd56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->