### PR TITLE
docs(ParentHamiltonian): list tail virtual Gram results

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
@@ -14,8 +14,8 @@ operator norm of the tail virtual map by the squared entrywise mass of that valu
 
 ## Main results
 
-- `MPSTensor.tailVirtualMapES_adjoint_comp_self_apply`
-- `MPSTensor.tailVirtualMapES_norm_four_pow_le_transferMap_pow_one_entry_norm_sq`
+* `MPSTensor.tailVirtualMapES_adjoint_comp_self_apply`
+* `MPSTensor.tailVirtualMapES_norm_four_pow_le_transferMap_pow_one_entry_norm_sq`
 -/
 
 open scoped Matrix

--- a/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
@@ -11,6 +11,11 @@ import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
 This file identifies the adjoint-self composition of the tail virtual map with right
 multiplication by an iterated transfer-map value. It also bounds the fourth power of the
 operator norm of the tail virtual map by the squared entrywise mass of that value.
+
+## Main results
+
+- `MPSTensor.tailVirtualMapES_adjoint_comp_self_apply`
+- `MPSTensor.tailVirtualMapES_norm_four_pow_le_transferMap_pow_one_entry_norm_sq`
 -/
 
 open scoped Matrix


### PR DESCRIPTION
Follow-up to #5974. Adds the repository-standard `## Main results` declaration list to `TailVirtualGram.lean`, addressing the late Cursor review finding on #5974.

Verification:
- `lake env lean TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only change with no impact on proofs, definitions, or build behavior beyond existing module content.
> 
> **Overview**
> Adds the repository-standard **`## Main results`** block to the module docstring in `TailVirtualGram.lean`, listing `tailVirtualMapES_adjoint_comp_self_apply` and `tailVirtualMapES_norm_four_pow_le_transferMap_pow_one_entry_norm_sq`. No theorem or proof changes—documentation-only follow-up to align with other ParentHamiltonian files and address review on #5974.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b7ad7c9b0a3b91742b605e86bb9f575ff138a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->