### PR TITLE
feat(MPS/MPU): package forward source-u tail support

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -21,6 +21,7 @@ import TNLean.MPS.MPU.SourceFactors
 import TNLean.MPS.MPU.SourceUBoundary
 import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SourceUOpenTail
+import TNLean.MPS.MPU.SourceURangeTransport
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.ThreeFormSpan

--- a/TNLean/MPS/MPU/SourceURangeTransport.lean
+++ b/TNLean/MPS/MPU/SourceURangeTransport.lean
@@ -8,9 +8,9 @@ import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.SourceUOpenTail
 
 /-!
-# Forward open-tail packaging for the source tensor u
+# Forward open-tail identities for the source tensor u
 
-This file packages the forward kernel occurring inside the complete source-$u$
+This file defines the forward kernel occurring inside the complete source-$u$
 network in arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma
 `lemuisometry` (lines 536--557). The normalized internal sum is an output-first
 double-layer letter followed by a power of its normalized diagonal. It also
@@ -35,16 +35,16 @@ namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)
 
-private lemma sum_rotate_five {A B C D E R : Type*}
-    [Fintype A] [Fintype B] [Fintype C] [Fintype D] [Fintype E]
-    [AddCommMonoid R] (f : A → B → C → D → E → R) :
-    (∑ a, ∑ b, ∑ c, ∑ d, ∑ e, f a b c d e) =
-      ∑ d, ∑ e, ∑ a, ∑ b, ∑ c, f a b c d e := by
-  let equiv : ((((A × B) × C) × D) × E) ≃ ((((D × E) × A) × B) × C) := {
+private lemma sum_rotate_five {A B C P Q R : Type*}
+    [Fintype A] [Fintype B] [Fintype C] [Fintype P] [Fintype Q]
+    [AddCommMonoid R] (f : A → B → C → P → Q → R) :
+    (∑ a, ∑ b, ∑ c, ∑ p, ∑ q, f a b c p q) =
+      ∑ p, ∑ q, ∑ a, ∑ b, ∑ c, f a b c p q := by
+  let equiv : ((((A × B) × C) × P) × Q) ≃ ((((P × Q) × A) × B) × C) := {
     toFun := fun x ↦ ((((x.1.2, x.2), x.1.1.1.1), x.1.1.1.2), x.1.1.2)
     invFun := fun x ↦ ((((x.1.1.2, x.1.2), x.2), x.1.1.1.1), x.1.1.1.2)
-    left_inv := by rintro ⟨⟨⟨⟨a, b⟩, c⟩, d⟩, e⟩; rfl
-    right_inv := by rintro ⟨⟨⟨⟨d, e⟩, a⟩, b⟩, c⟩; rfl
+    left_inv := by rintro ⟨⟨⟨⟨a, b⟩, c⟩, p⟩, q⟩; rfl
+    right_inv := by rintro ⟨⟨⟨⟨p, q⟩, a⟩, b⟩, c⟩; rfl
   }
   have h := Fintype.sum_equiv equiv
     (fun x ↦ f x.1.1.1.1 x.1.1.1.2 x.1.1.2 x.1.2 x.2)

--- a/TNLean/MPS/MPU/SourceURangeTransport.lean
+++ b/TNLean/MPS/MPU/SourceURangeTransport.lean
@@ -143,7 +143,7 @@ theorem sourceUForwardKernel_eq_outputLayer_mul_normalizedDiagonal_pow
 matrix. This is a range identity on $M_1$, not an ambient coisometry.
 
 Source: arXiv:1703.09188, equations `SVDforms2`, `Y1Y1X1X1`, and `X1X2b`,
-lines 479--526. -/
+lines 479--528. -/
 theorem sourceX₁_mul_conjTranspose_mul_weight_mul_sourceCutM₁
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
     sourceX₁ U ρ hρ * (sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ *
@@ -161,7 +161,7 @@ is a range identity on $M_2$, not the false ambient equation
 $X_2X_2^\dagger=1$.
 
 Source: arXiv:1703.09188, equations `SVDforms2`, `Y1Y1X1X1`, and `X1X2b`,
-lines 479--526. -/
+lines 479--528. -/
 theorem sourceX₂_mul_conjTranspose_mul_sourceCutM₂ :
     sourceX₂ U * (sourceX₂ U)ᴴ * sourceCutM₂ U = sourceCutM₂ U := by
   rw [Matrix.mul_assoc, ← sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂]

--- a/TNLean/MPS/MPU/SourceURangeTransport.lean
+++ b/TNLean/MPS/MPU/SourceURangeTransport.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.MatchingContractions
-import TNLean.MPS.MPU.SourceUBoundary
+import TNLean.MPS.MPU.SourceUOpenTail
 
 /-!
 # Forward open-tail packaging for the source tensor u
@@ -21,8 +21,10 @@ No declaration identifies the ambient open-tail coefficient with the identity
 or asserts an ambient coisometry. In particular, the range projections below
 apply only to the source-cut matrices $M_1$ and $M_2$.
 
-**Graphical-proof clarification:** the hidden range restriction and the
-remaining closed-network obligation are recorded in
+**Local fix (range-restricted graphical contraction):** the source diagram
+is read as a contraction of the complete external network, not as an ambient
+matrix identity. This clarification and the remaining closed-network
+obligation are recorded in
 `docs/paper-gaps/mpu_sourceu_range_restriction.tex`.
 -/
 
@@ -33,7 +35,7 @@ namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)
 
-private theorem sum_rotate_five {A B C D E R : Type*}
+private lemma sum_rotate_five {A B C D E R : Type*}
     [Fintype A] [Fintype B] [Fintype C] [Fintype D] [Fintype E]
     [AddCommMonoid R] (f : A → B → C → D → E → R) :
     (∑ a, ∑ b, ∑ c, ∑ d, ∑ e, f a b c d e) =
@@ -169,7 +171,9 @@ theorem sourceX₂_mul_conjTranspose_mul_sourceCutM₂ :
 $X_2$, and the forward open tail gives the normalized source-$u$ metric. MPU
 output coisometry evaluates this complete expression to the retained physical
 Kronecker delta. The entry indexed by $q$ is unstarred and the entry indexed by
-$p$ is starred.
+$p$ is starred. The theorem evaluates the displayed expansion directly; it
+does not fold the sum through the separately defined open-tail coefficient
+or identify the ordinary Gram matrix `sourceUᴴ * sourceU`.
 
 Source: arXiv:1703.09188, Figure `II_uUnitary.png`, equation `uUnitary`, and
 Lemma `lemuisometry`, lines 536--557. -/
@@ -223,6 +227,5 @@ theorem IsMPU.normalized_sourceU_openTail_metric [NeZero d]
   apply Finset.sum_congr rfl
   intro τ _
   exact hreindex τ
-
 
 end MPOTensor

--- a/TNLean/MPS/MPU/SourceURangeTransport.lean
+++ b/TNLean/MPS/MPU/SourceURangeTransport.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.DoubleLayerContraction
+import TNLean.MPS.MPU.MatchingContractions
+import TNLean.MPS.MPU.SourceUBoundary
+
+/-!
+# Forward open-tail packaging for the source tensor u
+
+This file packages the forward kernel occurring inside the complete source-$u$
+network in arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma
+`lemuisometry` (lines 536--557). The normalized internal sum is an output-first
+double-layer letter followed by a power of its normalized diagonal. It also
+records the two source-cut range projections used when moving the cut in the
+closed network.
+
+No declaration identifies the ambient open-tail coefficient with the identity
+or asserts an ambient coisometry. In particular, the range projections below
+apply only to the source-cut matrices $M_1$ and $M_2$.
+
+**Graphical-proof clarification:** the hidden range restriction and the
+remaining closed-network obligation are recorded in
+`docs/paper-gaps/mpu_sourceu_range_restriction.tex`.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+private theorem sum_rotate_five {A B C D E R : Type*}
+    [Fintype A] [Fintype B] [Fintype C] [Fintype D] [Fintype E]
+    [AddCommMonoid R] (f : A → B → C → D → E → R) :
+    (∑ a, ∑ b, ∑ c, ∑ d, ∑ e, f a b c d e) =
+      ∑ d, ∑ e, ∑ a, ∑ b, ∑ c, f a b c d e := by
+  let equiv : ((((A × B) × C) × D) × E) ≃ ((((D × E) × A) × B) × C) := {
+    toFun := fun x ↦ ((((x.1.2, x.2), x.1.1.1.1), x.1.1.1.2), x.1.1.2)
+    invFun := fun x ↦ ((((x.1.1.2, x.1.2), x.2), x.1.1.1.1), x.1.1.1.2)
+    left_inv := by rintro ⟨⟨⟨⟨a, b⟩, c⟩, d⟩, e⟩; rfl
+    right_inv := by rintro ⟨⟨⟨⟨d, e⟩, a⟩, b⟩, c⟩; rfl
+  }
+  have h := Fintype.sum_equiv equiv
+    (fun x ↦ f x.1.1.1.1 x.1.1.1.2 x.1.1.2 x.1.2 x.2)
+    (fun x ↦ f x.1.1.2 x.1.2 x.2 x.1.1.1.1 x.1.1.1.2)
+    (fun _ ↦ rfl)
+  simpa only [Fintype.sum_prod_type] using h
+
+/-- The normalized forward kernel before applying the outer $X_1$ and $X_2$
+factors. It contains exactly one factor $d^{-K}$.
+
+Source: arXiv:1703.09188, equation `uUnitary`, lines 545--556. -/
+noncomputable def sourceUForwardKernel (K : ℕ) (i i' : Fin d)
+    (β β' α α' : Fin D) : ℂ :=
+  ((d : ℂ)⁻¹) ^ K *
+    ∑ τ : Fin K → Fin d, ∑ ζ : Fin K → Fin d, ∑ j₂ : Fin d,
+      (U i j₂ * evalWord U (List.ofFn τ) (List.ofFn ζ)) β α *
+        star ((U i' j₂ * evalWord U (List.ofFn τ) (List.ofFn ζ)) β' α')
+
+/-- An entry of the $K$th normalized output-layer diagonal is the normalized
+sum over a common output word and an arbitrary contracted input word.
+
+Source: arXiv:1703.09188, Figure `II_uUnitary.png` and equation `uUnitary`,
+lines 545--556. -/
+theorem normalizedDiagonal_outputLayer_pow_apply [NeZero d]
+    (K : ℕ) (γ γ' α α' : Fin D) :
+    (normalizedDiagonal (doubleLayerTensor (physicalAdjointTensor U)) ^ K)
+        (finProdFinEquiv (γ, γ')) (finProdFinEquiv (α, α')) =
+      ((d : ℂ)⁻¹) ^ K * ∑ τ : Fin K → Fin d, ∑ ζ : Fin K → Fin d,
+        evalWord U (List.ofFn τ) (List.ofFn ζ) γ α *
+          star (evalWord U (List.ofFn τ) (List.ofFn ζ) γ' α') := by
+  classical
+  rw [← normalizedDiagonal_blockTensor K]
+  simp only [normalizedDiagonal, contractPhysical, Matrix.one_apply, ite_smul,
+    one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true,
+    blockTensor_apply, Matrix.smul_apply, smul_eq_mul]
+  have hdim : (MPSTensor.blockPhysDim d K : ℂ)⁻¹ = ((d : ℂ)⁻¹) ^ K := by
+    rw [MPSTensor.blockPhysDim_eq_pow, Nat.cast_pow, inv_pow]
+  rw [hdim]
+  congr 1
+  have hsum := (MPSTensor.decodeBlockEquiv d K).sum_comp
+    (fun τ ↦ evalWord (doubleLayerTensor (physicalAdjointTensor U))
+      (List.ofFn τ) (List.ofFn τ))
+  simp only [MPSTensor.decodeBlockEquiv_apply] at hsum
+  simp only [MPSTensor.wordOfBlock]
+  rw [hsum]
+  simp only [Matrix.sum_apply]
+  apply Finset.sum_congr rfl
+  intro τ _
+  rw [doubleLayerTensor, evalWord_mulTensor]
+  simp only [Matrix.submatrix_apply, Equiv.symm_apply_apply,
+    Matrix.sum_apply, Matrix.kronecker_apply]
+  apply Finset.sum_congr rfl
+  intro ζ _
+  rw [evalWord_physicalAdjointTensor, evalWord_physicalAdjointTensor]
+  · change star (star (evalWord U (List.ofFn τ) (List.ofFn ζ) γ α)) *
+        star (evalWord U (List.ofFn τ) (List.ofFn ζ) γ' α') = _
+    rw [star_star]
+  · simp
+  · simp
+
+/-- The forward internal sum is an output-first double-layer letter followed
+by the $K$th power of its normalized diagonal.
+
+The unstarred bond component precedes the starred component in both doubled
+bond indices. This is the forward, rather than conjugate-transpose-reversed,
+chain needed inside the complete source-$u$ network.
+
+Source: arXiv:1703.09188, Figure `II_uUnitary.png` and equation `uUnitary`,
+lines 545--556. -/
+theorem sourceUForwardKernel_eq_outputLayer_mul_normalizedDiagonal_pow
+    [NeZero d] (K : ℕ) (i i' : Fin d) (β β' α α' : Fin D) :
+    sourceUForwardKernel U K i i' β β' α α' =
+      (doubleLayerTensor (physicalAdjointTensor U) i i' *
+        normalizedDiagonal (doubleLayerTensor (physicalAdjointTensor U)) ^ K)
+          (finProdFinEquiv (β, β')) (finProdFinEquiv (α, α')) := by
+  classical
+  unfold sourceUForwardKernel
+  rw [Matrix.mul_apply, ← finProdFinEquiv.sum_comp, Fintype.sum_prod_type]
+  simp_rw [normalizedDiagonal_outputLayer_pow_apply U K]
+  simp only [doubleLayerTensor_physicalAdjointTensor_apply, Matrix.mul_apply,
+    star_sum, star_mul', Finset.sum_mul, Finset.mul_sum]
+  rw [sum_rotate_five, Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro γ _
+  apply Finset.sum_congr rfl
+  intro γ' _
+  apply Finset.sum_congr rfl
+  intro τ _
+  apply Finset.sum_congr rfl
+  intro ζ _
+  apply Finset.sum_congr rfl
+  intro j₂ _
+  ring
+
+/-- The weighted $X_1X_1^\dagger$ projection fixes the first source-cut
+matrix. This is a range identity on $M_1$, not an ambient coisometry.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `Y1Y1X1X1`, and `X1X2b`,
+lines 479--526. -/
+theorem sourceX₁_mul_conjTranspose_mul_weight_mul_sourceCutM₁
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    sourceX₁ U ρ hρ * (sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ *
+        sourceCutM₁ U = sourceCutM₁ U := by
+  calc
+    _ = sourceX₁ U ρ hρ *
+        ((sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U) := by
+      simp only [Matrix.mul_assoc]
+    _ = sourceX₁ U ρ hρ * sourceY₁ U ρ hρ := by
+      rw [sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁]
+    _ = _ := (sourceCutM₁_eq_sourceX₁_mul_sourceY₁ U ρ hρ).symm
+
+/-- The $X_2X_2^\dagger$ projection fixes the second source-cut matrix. This
+is a range identity on $M_2$, not the false ambient equation
+$X_2X_2^\dagger=1$.
+
+Source: arXiv:1703.09188, equations `SVDforms2`, `Y1Y1X1X1`, and `X1X2b`,
+lines 479--526. -/
+theorem sourceX₂_mul_conjTranspose_mul_sourceCutM₂ :
+    sourceX₂ U * (sourceX₂ U)ᴴ * sourceCutM₂ U = sourceCutM₂ U := by
+  rw [Matrix.mul_assoc, ← sourceY₂_eq_sourceX₂_conjTranspose_mul_sourceCutM₂]
+  exact (sourceCutM₂_eq_sourceX₂_mul_sourceY₂ U).symm
+
+/-- Expanding both periodic MPO entries through $X_1$, the source tensor $u$,
+$X_2$, and the forward open tail gives the normalized source-$u$ metric. MPU
+output coisometry evaluates this complete expression to the retained physical
+Kronecker delta. The entry indexed by $q$ is unstarred and the entry indexed by
+$p$ is starred.
+
+Source: arXiv:1703.09188, Figure `II_uUnitary.png`, equation `uUnitary`, and
+Lemma `lemuisometry`, lines 536--557. -/
+theorem IsMPU.normalized_sourceU_openTail_metric [NeZero d]
+    {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) (K : ℕ)
+    (p q : Fin d × Fin d) :
+    ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ j : Fin d × Fin d, ∑ ζ : Fin K → Fin d,
+          (∑ α : Fin D, ∑ r : Fin r[U], ∑ l : Fin ℓ[U],
+            ∑ β : Fin D, ∑ i : Fin d,
+              sourceX₁ U ρ hρ (α, j.1) r * sourceU U ρ hρ (l, r) q *
+                star (sourceX₂ U (β, i) l) *
+                  (U i j.2 * evalWord U (List.ofFn τ) (List.ofFn ζ)) β α) *
+          star (∑ α' : Fin D, ∑ r' : Fin r[U], ∑ l' : Fin ℓ[U],
+            ∑ β' : Fin D, ∑ i' : Fin d,
+              sourceX₁ U ρ hρ (α', j.1) r' * sourceU U ρ hρ (l', r') p *
+                star (sourceX₂ U (β', i') l') *
+                  (U i' j.2 * evalWord U (List.ofFn τ) (List.ofFn ζ)) β' α') =
+      if p = q then 1 else 0 := by
+  classical
+  simp_rw [← mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail
+    U ρ hρ K q, ← mpo_finAddTwo_eq_sum_sourceX₁_sourceU_sourceX₂_openTail
+    U ρ hρ K p]
+  have hreindex (τ : Fin K → Fin d) :
+      (∑ j : Fin d × Fin d, ∑ ζ : Fin K → Fin d,
+        mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ))
+            ((finAddTwoArrowEquiv (Fin d) K).symm (j, ζ)) *
+          star (mpo U (K + 2)
+            ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))
+            ((finAddTwoArrowEquiv (Fin d) K).symm (j, ζ)))) =
+        ∑ η : Fin (K + 2) → Fin d,
+          mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) η *
+            star (mpo U (K + 2)
+              ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ)) η) := by
+    let f : (Fin d × Fin d) × (Fin K → Fin d) → ℂ := fun x ↦
+      mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ))
+          ((finAddTwoArrowEquiv (Fin d) K).symm x) *
+        star (mpo U (K + 2)
+          ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))
+          ((finAddTwoArrowEquiv (Fin d) K).symm x))
+    calc
+      _ = ∑ x, f x := (Fintype.sum_prod_type f).symm
+      _ = _ := (finAddTwoArrowEquiv (Fin d) K).symm.sum_comp
+        (fun η : Fin (K + 2) → Fin d ↦
+          mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) η *
+            star (mpo U (K + 2)
+              ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ)) η))
+  rw [← hU.normalized_mpo_tail_coisometry K p q]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro τ _
+  exact hreindex τ
+
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1796,6 +1796,132 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     coefficient contains the unique normalization factor $d^{-K}$.
 \end{definition}
 
+
+\begin{definition}[Forward source-$u$ kernel]
+    \label{def:mpu_source_u_forward_kernel}
+    \lean{MPOTensor.sourceUForwardKernel}
+    \leanok
+    \uses{thm:mpu_source_u_open_periodic_tail}
+    For a tail of length $K$, define
+    \begin{align}
+      F^{(K)}_{ii';\beta\beta',\alpha\alpha'}
+      =d^{-K}\sum_{\tau,\zeta,j_2}
+        &(\mathcal U^{ij_2}T_{\tau,\zeta})_{\beta,\alpha}
+        \overline{(\mathcal U^{i'j_2}T_{\tau,\zeta})_{\beta',\alpha'}}.
+    \end{align}
+    The expression contains exactly one normalization factor $d^{-K}$.
+\end{definition}
+
+\begin{theorem}[Normalized output-layer tail entry]
+    \label{thm:mpu_source_u_output_layer_tail_entry}
+    \lean{MPOTensor.normalizedDiagonal_outputLayer_pow_apply}
+    \leanok
+    \uses{def:mpu_double_layer,thm:mpu_double_layer_blocking}
+    Let $W_{\mathrm{out}}$ be the output-first double layer. Then
+    \begin{align}
+      (E_{\mathrm{out}}^K)_{(\gamma,\gamma'),(\alpha,\alpha')}
+      =d^{-K}\sum_{\tau,\zeta}
+        (T_{\tau,\zeta})_{\gamma,\alpha}
+        \overline{(T_{\tau,\zeta})_{\gamma',\alpha'}}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_double_layer_blocking}
+    Expand the normalized diagonal of the blocked output layer, reindex a
+    blocked physical index by its decoded word, and evaluate the product
+    double layer.  The physical adjoint contributes the conjugated second
+    word, while the blocked physical dimension supplies $d^{-K}$.
+\end{proof}
+
+\begin{theorem}[Forward-kernel double-layer packaging]
+    \label{thm:mpu_source_u_forward_kernel_packaging}
+    \lean{MPOTensor.sourceUForwardKernel_eq_outputLayer_mul_normalizedDiagonal_pow}
+    \leanok
+    \uses{def:mpu_source_u_forward_kernel,
+        thm:mpu_source_u_output_layer_tail_entry,
+        thm:mpu_output_first_double_layer_entry}
+    The forward kernel is
+    \begin{align}
+      F^{(K)}_{ii'}
+        =W_{\mathrm{out}}^{ii'}E_{\mathrm{out}}^K.
+    \end{align}
+    Both doubled bond indices put the unstarred component before the starred
+    component.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_output_layer_tail_entry,
+        thm:mpu_output_first_double_layer_entry}
+    Expand the matrix product over its doubled bond index.  The first
+    output-layer letter supplies the sum over $j_2$, and the normalized
+    diagonal power supplies the common output word and contracted input word.
+    Reordering finite sums gives the defining forward kernel without reversing
+    the virtual chain.
+\end{proof}
+
+\begin{theorem}[First source-cut range projection]
+    \label{thm:mpu_source_x1_range_projection}
+    \lean{MPOTensor.sourceX₁_mul_conjTranspose_mul_weight_mul_sourceCutM₁}
+    \leanok
+    \uses{thm:mpu_source_factor_recovery}
+    On the range of the first source cut,
+    \begin{align}
+      X_1X_1^\dagger W_\rho M_1=M_1,
+      \qquad W_\rho=\rho\otimes 1_d.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_factor_recovery}
+    Substitute $X_1^\dagger W_\rho M_1=Y_1$ and then use $M_1=X_1Y_1$.
+\end{proof}
+
+\begin{theorem}[Second source-cut range projection]
+    \label{thm:mpu_source_x2_range_projection}
+    \lean{MPOTensor.sourceX₂_mul_conjTranspose_mul_sourceCutM₂}
+    \leanok
+    \uses{thm:mpu_source_factor_recovery}
+    On the range of the second source cut,
+    \begin{align}
+      X_2X_2^\dagger M_2=M_2.
+    \end{align}
+    This does not assert $X_2X_2^\dagger=1$ on the ambient product-index
+    space.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_factor_recovery}
+    Substitute $X_2^\dagger M_2=Y_2$ and then use $M_2=X_2Y_2$.
+\end{proof}
+
+\begin{theorem}[Expanded normalized source-$u$ metric]
+    \label{thm:mpu_source_u_expanded_metric}
+    \lean{MPOTensor.IsMPU.normalized_sourceU_openTail_metric}
+    \leanok
+    \uses{thm:mpu_source_u_open_periodic_tail,
+        thm:mpu_normalized_output_tail_coisometry}
+    Expanding both $(K+2)$-site periodic entries through $X_1,u,X_2$ and the
+    open tail gives
+    \begin{align}
+      d^{-K}\sum_{\tau,j,\zeta}
+        \mathcal A_{q;\tau,j,\zeta}
+        \overline{\mathcal A_{p;\tau,j,\zeta}}
+      =\delta_{p,q},
+    \end{align}
+    where $\mathcal A_{q;\tau,j,\zeta}$ is the full source-$u$ expansion with
+    the $q$ entry unstarred.  This is the coefficient-weighted metric; it does
+    not identify the ambient coefficient with the identity.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_u_open_periodic_tail,
+        thm:mpu_normalized_output_tail_coisometry}
+    Replace each source-factor sum by its periodic MPO entry. Reindex the input
+    configuration into its first two coordinates and its length-$K$ tail, then
+    apply normalized output-first MPU coisometry.
+\end{proof}
+
 \begin{theorem}[Terminal source-factor boundary contraction]
     \label{thm:mpu_source_u_terminal_boundary}
     \lean{MPOTensor.sourceU_boundary_sandwich}
@@ -1833,12 +1959,12 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{proof}
 
 \begin{remark}[Scope of the open-tail algebra]
-    The preceding results do not identify the forward open-tail coefficient
-    with the reflected blocked contraction.  In particular, they prove
-    neither $u^\dagger u=\Id$ nor a rank bound for $u$, and they do not use
-    $X_2X_2^\dagger=\Id$, $M_2M_2^\dagger=\Id$, or
-    $Y_2Y_2^\dagger=\Id$.  The missing step must transport the internal tail
-    only inside the complete $X_1$--$X_2$ sandwich.
+    The preceding results identify the normalized coefficient-weighted metric,
+    but not the ordinary Gram matrix $u^\dagger u$.  The remaining independent
+    equality is between that ordinary Gram matrix and the normalized closed
+    $(K+2)$-site output tail, with both external source-$u$ tensors retained
+    before moving the cut.  No result uses $X_2X_2^\dagger=\Id$,
+    $M_2M_2^\dagger=\Id$, or $Y_2Y_2^\dagger=\Id$.
 \end{remark}
 
 \begin{theorem}[Right-rank bound]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1796,7 +1796,6 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     coefficient contains the unique normalization factor $d^{-K}$.
 \end{definition}
 
-
 \begin{definition}[Forward source-$u$ kernel]
     \label{def:mpu_source_u_forward_kernel}
     \lean{MPOTensor.sourceUForwardKernel}
@@ -1910,8 +1909,10 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
       =\delta_{p,q},
     \end{align}
     where $\mathcal A_{q;\tau,j,\zeta}$ is the full source-$u$ expansion with
-    the $q$ entry unstarred.  This is the coefficient-weighted metric; it does
-    not identify the ambient coefficient with the identity.
+    the $q$ entry unstarred.  This theorem evaluates the displayed expansion
+    directly.  It neither regroups the sum through
+    $C^{(K)}_{lr,l'r'}$ nor identifies it with the ordinary Gram matrix
+    $u^\dagger u$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1959,12 +1960,13 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{proof}
 
 \begin{remark}[Scope of the open-tail algebra]
-    The preceding results identify the normalized coefficient-weighted metric,
-    but not the ordinary Gram matrix $u^\dagger u$.  The remaining independent
-    equality is between that ordinary Gram matrix and the normalized closed
-    $(K+2)$-site output tail, with both external source-$u$ tensors retained
-    before moving the cut.  No result uses $X_2X_2^\dagger=\Id$,
-    $M_2M_2^\dagger=\Id$, or $Y_2Y_2^\dagger=\Id$.
+    The preceding results evaluate the fully expanded normalized metric, but
+    do not prove that regrouping it through $C^{(K)}_{lr,l'r'}$ gives the
+    ordinary Gram matrix $u^\dagger u$.  The remaining independent equality is
+    between that Gram matrix and the normalized closed $(K+2)$-site output
+    tail, with both external source-$u$ tensors retained before moving the cut.
+    No result uses $X_2X_2^\dagger=\Id$, $M_2M_2^\dagger=\Id$, or
+    $Y_2Y_2^\dagger=\Id$.
 \end{remark}
 
 \begin{theorem}[Right-rank bound]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1826,7 +1826,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_double_layer_blocking}
+    \uses{thm:mpu_blocked_double_layer_diagonal}
     Expand the normalized diagonal of the blocked output layer, reindex a
     blocked physical index by its decoded word, and evaluate the product
     double layer.  The physical adjoint contributes the conjugated second
@@ -1872,7 +1872,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_source_factor_recovery}
+    \uses{thm:mpu_source_factor_recovery,thm:mpu_source_factorizations}
     Substitute $X_1^\dagger W_\rho M_1=Y_1$ and then use $M_1=X_1Y_1$.
 \end{proof}
 
@@ -1890,7 +1890,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_source_factor_recovery}
+    \uses{thm:mpu_source_factor_recovery,thm:mpu_source_factorizations}
     Substitute $X_2^\dagger M_2=Y_2$ and then use $M_2=X_2Y_2$.
 \end{proof}
 
@@ -1900,8 +1900,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \leanok
     \uses{thm:mpu_source_u_open_periodic_tail,
         thm:mpu_normalized_output_tail_coisometry}
-    Expanding both $(K+2)$-site periodic entries through $X_1,u,X_2$ and the
-    open tail gives
+    Assume $d>0$, let $\mathcal U$ be an MPU, and let $\rho$ be positive
+    definite.  Expanding both $(K+2)$-site periodic entries through
+    $X_1,u,X_2$ and the open tail gives
     \begin{align}
       d^{-K}\sum_{\tau,j,\zeta}
         \mathcal A_{q;\tau,j,\zeta}

--- a/docs/paper-gaps/mpu_sourceu_range_restriction.tex
+++ b/docs/paper-gaps/mpu_sourceu_range_restriction.tex
@@ -47,12 +47,15 @@ tail, proved with the full external network retained.
 
 \section{Classification}
 
-\textbf{Verdict: graphical-proof clarification.}  The source argument is read
-as a range-restricted closed-network contraction, not as an identity on the
-ambient product-index space.  The formal development records the forward
-kernel, the normalized coefficient-weighted metric, and the two valid
-source-cut range projections.  The final closed-network equality remains a
-separate obligation.
+\textbf{Verdict: local graphical clarification.}  The source argument is
+read as a range-restricted closed-network contraction, not as an identity on
+the ambient product-index space.  This does not classify the source lemma as
+false: its diagram retains the external network, but that restriction must not
+be discarded when translating the argument into indexed formulas.  The formal
+development records the forward kernel, the fully expanded normalized metric,
+and the two valid source-cut range projections.  It does not identify that
+metric with the ordinary source-$u$ Gram matrix; the final closed-network
+equality remains a separate obligation.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/mpu_sourceu_range_restriction.tex
+++ b/docs/paper-gaps/mpu_sourceu_range_restriction.tex
@@ -1,0 +1,60 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Hidden Range Restriction in the Source-$u$ Contraction}
+\author{}
+\date{2026-08-10}
+
+\begin{document}
+\maketitle
+
+\section{The graphical step}
+
+The proof of the source-tensor isometry in
+\cite[lines~536--557]{Cirac2017MPU} contracts a normalized open tail between
+source-cut factors and then simplifies the resulting diagram.  Read as an
+ambient matrix identity, the displayed simplification would identify the
+open-tail coefficient with the identity on the full product-index space.
+That statement is false in general: the source factors need not be onto, and
+only $X_2^\dagger X_2=1$ is available.
+
+\section{Range-restricted interpretation}
+
+The valid interpretation keeps the external source-$u$ tensors and closes the
+complete network before moving the cut.  The two elementary projection steps
+are only
+\begin{align}
+ X_1X_1^\dagger W_\rho M_1 &= M_1,
+ & X_2X_2^\dagger M_2 &= M_2,
+\end{align}
+where $W_\rho=\rho\otimes 1_d$.  They follow from the source-cut
+factorizations and the recovery formulas for $Y_1$ and $Y_2$.  Neither formula
+asserts an ambient coisometry.
+
+The forward internal kernel is also orientation-sensitive.  It is an
+output-first double-layer letter followed by the $K$th power of its normalized
+diagonal.  Conjugate transposition reverses the virtual chain, so the reflected
+simple-contraction equations cannot be inserted into this coefficient
+pointwise.  The remaining independent obligation is the equality between the
+ordinary source-$u$ Gram matrix and the normalized closed $(K+2)$-site output
+tail, proved with the full external network retained.
+
+\section{Classification}
+
+\textbf{Verdict: graphical-proof clarification.}  The source argument is read
+as a range-restricted closed-network contraction, not as an identity on the
+ambient product-index space.  The formal development records the forward
+kernel, the normalized coefficient-weighted metric, and the two valid
+source-cut range projections.  The final closed-network equality remains a
+separate obligation.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/mpu_sourceu_range_restriction.tex
+++ b/docs/paper-gaps/mpu_sourceu_range_restriction.tex
@@ -45,17 +45,25 @@ pointwise.  The remaining independent obligation is the equality between the
 ordinary source-$u$ Gram matrix and the normalized closed $(K+2)$-site output
 tail, proved with the full external network retained.
 
-\section{Classification}
+\section{Verdict}
 
-\textbf{Verdict: local graphical clarification.}  The source argument is
-read as a range-restricted closed-network contraction, not as an identity on
-the ambient product-index space.  This does not classify the source lemma as
-false: its diagram retains the external network, but that restriction must not
-be discarded when translating the argument into indexed formulas.  The formal
-development records the forward kernel, the fully expanded normalized metric,
-and the two valid source-cut range projections.  It does not identify that
-metric with the ordinary source-$u$ Gram matrix; the final closed-network
-equality remains a separate obligation.
+\textbf{Classification: local fix (graphical clarification).}  The source
+argument is read as a range-restricted closed-network contraction, not as an
+identity on the ambient product-index space.  This does not classify the
+source lemma as false: its diagram retains the external network, but that
+restriction must not be discarded when translating the argument into indexed
+formulas.
+
+The forward kernel and its output-layer expression are formalized by
+\leanid{MPOTensor.sourceUForwardKernel} and
+\leanid{MPOTensor.sourceUForwardKernel_eq_outputLayer_mul_normalizedDiagonal_pow}.
+The range identities are
+\leanid{MPOTensor.sourceX₁_mul_conjTranspose_mul_weight_mul_sourceCutM₁} and
+\leanid{MPOTensor.sourceX₂_mul_conjTranspose_mul_sourceCutM₂}.  The fully
+expanded normalized metric is
+\leanid{MPOTensor.IsMPU.normalized_sourceU_openTail_metric}.  This last
+theorem does not identify that metric with the ordinary source-$u$ Gram
+matrix; the final closed-network equality remains a separate obligation.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- package the exact normalized forward source-$u$ kernel and identify it with one output-first double-layer letter followed by the normalized-diagonal tail power
- prove the two valid source-cut range projections on $M_1$ and $M_2$
- expose the fully expanded normalized open-tail metric with q unstarred and p starred
- document the local graphical clarification and keep the genuine closed-network Gram transport open in #5971

## Mathematical scope

This PR intentionally does **not** prove the ordinary source-$u$ Gram identity, source-$u$ isometry/rank, or $u^\dagger C_K^{\mathsf T}u=u^\dagger u$. It asserts no ambient coefficient identity, mixed pointwise insertion, $X_2X_2^\dagger=1$, $M_2M_2^\dagger=1$, or $Y_2Y_2^\dagger=1$.

The displayed metric theorem is the literal fully expanded normalized expression. It is not formally regrouped through `sourceUOpenTailCoefficient` and is not identified with `sourceUᴴ * sourceU`.

## Validation

- `lake env lean TNLean/MPS/MPU/SourceURangeTransport.lean`
- `lake build TNLean.MPS.MPU.SourceURangeTransport TNLean.MPS.MPU`
- generated import aggregators current
- blueprint/Lean sync: Chapter 28, 215/215
- reverse coverage, prose policy, standalone gap-note LaTeX, integrity, line-length, and whitespace checks
- exact-head LeanSimplifier review: APPROVE

Closes #5975.
Leaves #5971 open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of MPU tensor-network algebra with explicit scope limits; no runtime, auth, or data-path changes. Risk is mainly proof-maintenance and ensuring readers do not misread partial results as full source-$u$ isometry.
> 
> **Overview**
> Adds **`SourceURangeTransport.lean`** and matching Chapter 28 blueprint material for the Cirac MPU source-$u$ open-tail step, without closing the full Gram transport in #5971.
> 
> **Forward tail algebra:** introduces `sourceUForwardKernel` and proves it equals one **output-first** double-layer letter times the $K$th power of its normalized diagonal (`sourceUForwardKernel_eq_outputLayer_mul_normalizedDiagonal_pow`), plus the normalized output-layer diagonal entry formula. A small `sum_rotate_five` lemma handles finite-sum reordering.
> 
> **Source-cut range identities:** proves the valid projections $X_1 X_1^\dagger W_\rho M_1 = M_1$ and $X_2 X_2^\dagger M_2 = M_2$ on the cut matrices—not ambient coisometries.
> 
> **Expanded metric:** `IsMPU.normalized_sourceU_openTail_metric` shows the fully expanded, $d^{-K}$-normalized contraction through $X_1$, $u$, $X_2$, and the open tail is $\delta_{p,q}$, by rewriting to periodic MPO entries and `normalized_mpo_tail_coisometry`. It does **not** regroup through `sourceUOpenTailCoefficient` or identify `sourceUᴴ * sourceU`.
> 
> **Documentation:** new gap note `docs/paper-gaps/mpu_sourceu_range_restriction.tex` and an updated blueprint remark that the remaining obligation is Gram matrix vs. closed $(K+2)$-site tail with the external network kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5ec2ba3a44a1ff55974b7d60c44c991b55f45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->