### PR TITLE
feat(ParentHamiltonian): bound tail virtual maps uniformly

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
 
 /-!
@@ -16,6 +17,7 @@ operator norm of the tail virtual map by the squared entrywise mass of that valu
 
 * `MPSTensor.tailVirtualMapES_adjoint_comp_self_apply`
 * `MPSTensor.tailVirtualMapES_norm_four_pow_le_transferMap_pow_one_entry_norm_sq`
+* `MPSTensor.IsPrimitiveMPS.tailVirtualMapES_norm_uniform`
 -/
 
 open scoped Matrix
@@ -47,26 +49,16 @@ theorem tailVirtualMapES_adjoint_comp_self_apply (A : MPSTensor d D) (K : ℕ)
   simpa only [Matrix.mul_assoc, Matrix.mul_sum] using
     congrArg (fun M => Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) (X * M)) hsum
 
-/-! ### Entrywise Cauchy–Schwarz for Frobenius-vectorised matrix product -/
+/-! ### Frobenius-isometric matrix product bound -/
 
 /-- The squared norm of a Frobenius-vectorized matrix is the sum of its squared entry
 norms. -/
 private lemma frobeniusEquivEuclidean_norm_sq (X : Matrix (Fin D) (Fin D) ℂ) :
     ‖Matrix.frobeniusEquivEuclidean (Fin D) (Fin D) X‖ ^ 2 =
       ∑ i : Fin D, ∑ j : Fin D, ‖X i j‖ ^ 2 := by
-  let U := Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
-  calc
-    ‖U X‖ ^ 2 = (∑ p : (Fin D × Fin D), ‖(U X) p‖ ^ 2) := by
-      rw [EuclideanSpace.norm_sq_eq]
-    _ = (∑ p : (Fin D × Fin D), ‖X p.2 p.1‖ ^ 2) := by
-      dsimp [U, Matrix.frobeniusEquivEuclidean]
-    _ = (∑ j : Fin D, ∑ i : Fin D, ‖X i j‖ ^ 2) := by
-      simpa only [Finset.univ_product_univ] using
-        (Finset.sum_product'
-          (s := (Finset.univ : Finset (Fin D)))
-          (t := (Finset.univ : Finset (Fin D)))
-          (f := fun j i ↦ ‖X i j‖ ^ 2))
-    _ = ∑ i : Fin D, ∑ j : Fin D, ‖X i j‖ ^ 2 := Finset.sum_comm
+  rw [LinearIsometryEquiv.norm_map, Matrix.frobenius_norm_def, ← Real.sqrt_eq_rpow,
+    Real.sq_sqrt (by positivity)]
+  simp only [Real.rpow_two]
 
 /-- The squared Frobenius-vector norm of a matrix product is at most the product of the
 squared Frobenius-vector norms. -/
@@ -74,48 +66,9 @@ private lemma frobenius_vec_mul_norm_sq_le (X M : Matrix (Fin D) (Fin D) ℂ) :
     ‖(Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)) (X * M)‖ ^ 2 ≤
     ‖(Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)) X‖ ^ 2 *
     ‖(Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)) M‖ ^ 2 := by
-  let U := Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
-  have hUX := frobeniusEquivEuclidean_norm_sq X
-  have hUM := frobeniusEquivEuclidean_norm_sq M
-  have hUprod := frobeniusEquivEuclidean_norm_sq (X * M)
-  rw [hUprod, hUX, hUM]
-  calc
-    (∑ i : Fin D, ∑ j : Fin D, ‖(X * M) i j‖ ^ 2) =
-        (∑ i : Fin D, ∑ j : Fin D, ‖∑ k : Fin D, X i k * M k j‖ ^ 2) := by
-      simp [Matrix.mul_apply]
-    _ ≤ (∑ i : Fin D, ∑ j : Fin D,
-        (∑ k : Fin D, ‖X i k‖ ^ 2) * (∑ k : Fin D, ‖M k j‖ ^ 2)) := by
-      refine Finset.sum_le_sum fun i _ => Finset.sum_le_sum fun j _ => ?_
-      calc
-        ‖∑ k : Fin D, X i k * M k j‖ ^ 2 ≤
-            (∑ k : Fin D, ‖X i k * M k j‖) ^ 2 := by
-          gcongr
-          exact norm_sum_le _ _
-        _ = (∑ k : Fin D, ‖X i k‖ * ‖M k j‖) ^ 2 := by
-          simp_rw [norm_mul]
-        _ ≤ (∑ k : Fin D, ‖X i k‖ ^ 2) * (∑ k : Fin D, ‖M k j‖ ^ 2) :=
-          Finset.sum_mul_sq_le_sq_mul_sq (R := ℝ) (s := Finset.univ)
-            (f := fun k => ‖X i k‖) (g := fun k => ‖M k j‖)
-    _ = (∑ i : Fin D, ∑ k : Fin D, ‖X i k‖ ^ 2) *
-        (∑ k : Fin D, ∑ j : Fin D, ‖M k j‖ ^ 2) := by
-      have htemp : (∑ i : Fin D, ∑ j : Fin D,
-          (∑ k : Fin D, ‖X i k‖ ^ 2) * (∑ k : Fin D, ‖M k j‖ ^ 2)) =
-          (∑ i : Fin D, ∑ k : Fin D, ‖X i k‖ ^ 2) *
-          (∑ k : Fin D, ∑ j : Fin D, ‖M k j‖ ^ 2) := by
-        calc
-          (∑ i : Fin D, ∑ j : Fin D,
-              (∑ k : Fin D, ‖X i k‖ ^ 2) * (∑ k : Fin D, ‖M k j‖ ^ 2))
-          = (∑ i : Fin D, (∑ k : Fin D, ‖X i k‖ ^ 2) *
-              (∑ j : Fin D, ∑ k : Fin D, ‖M k j‖ ^ 2)) := by
-            simp_rw [← Finset.mul_sum]
-          _ = (∑ i : Fin D, ∑ k : Fin D, ‖X i k‖ ^ 2) *
-              (∑ j : Fin D, ∑ k : Fin D, ‖M k j‖ ^ 2) := by
-            rw [← Finset.sum_mul]
-          _ = (∑ i : Fin D, ∑ k : Fin D, ‖X i k‖ ^ 2) *
-              (∑ k : Fin D, ∑ j : Fin D, ‖M k j‖ ^ 2) := by
-            congr 1
-            rw [Finset.sum_comm]
-      exact htemp
+  simp only [LinearIsometryEquiv.norm_map]
+  nlinarith [Matrix.frobenius_norm_mul X M, norm_nonneg X, norm_nonneg M,
+    norm_nonneg (X * M)]
 
 /-! ### Fourth-power operator-norm bound by entrywise mass -/
 
@@ -161,5 +114,120 @@ theorem tailVirtualMapES_norm_four_pow_le_transferMap_pow_one_entry_norm_sq
     _ = ∑ p : (Fin D × Fin D), ‖M p.1 p.2‖ ^ 2 := by rw [hRHS]
 
 end FrobeniusCoordinate
+
+section UniformBound
+
+open scoped Matrix.Norms.L2Operator
+
+/-! ### Uniform bound for primitive tensors -/
+
+/-- The fourth powers of the tail virtual-map norms are uniformly bounded for a primitive
+MPS tensor. Positive transfer-map powers split into the fixed-point projection and a
+geometrically bounded complementary power. The entrywise mass from the Gram estimate is
+then controlled by the L² operator norm with an explicit bond-dimension factor. No
+positive-definiteness assumption on the fixed point is needed. -/
+theorem IsPrimitiveMPS.tailVirtualMapES_norm_four_pow_uniform
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) :
+    ∃ C : ℝ, 0 < C ∧ ∀ K : ℕ, ‖tailVirtualMapES A K‖ ^ 4 ≤ C := by
+  letI : NormedRing (Matrix (Fin D) (Fin D) ℂ) := Matrix.instL2OpNormedRing
+  let E := transferMap (d := d) (D := D) A
+  have htr : Matrix.trace ρ ≠ 0 := by
+    intro h
+    exact hP.fixedPoint_ne_zero
+      ((Matrix.PosSemidef.trace_eq_zero_iff hP.fixedPoint_psd).1 h)
+  let P := fixedPointProj (D := D) ρ htr
+  let N := E - P
+  let T := (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) N
+  have hTP : IsTracePreservingMap E := by
+    intro X
+    exact trace_transferMap A X hP.norm
+  have hgap : spectralRadius ℂ T < 1 := by
+    dsimp only [T, N, E, P]
+    convert hP.complementary_transfer_map_gap using 1
+    congr 2
+  obtain ⟨C, r, hC, hr_pos, hr_lt_one, hgeom⟩ :=
+    geometric_bound_of_spectralRadius_lt_one T hgap
+  let B := ‖P 1‖ + C * ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖
+  let Q := (D : ℝ) * (‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ ^ 2 + B ^ 2) + 1
+  have hD : 0 ≤ (D : ℝ) := Nat.cast_nonneg D
+  have hQ : 0 < Q := by
+    dsimp [Q]
+    positivity
+  refine ⟨Q, hQ, ?_⟩
+  intro K
+  let M := (E ^ K) 1
+  have hentry :
+      (∑ p : Fin D × Fin D, ‖M p.1 p.2‖ ^ 2) ≤ (D : ℝ) * ‖M‖ ^ 2 := by
+    simpa only [Fintype.card_fin] using Matrix.sum_entry_norm_sq_le_card_mul_norm_sq M
+  refine (tailVirtualMapES_norm_four_pow_le_transferMap_pow_one_entry_norm_sq A K).trans ?_
+  change (∑ p : Fin D × Fin D, ‖M p.1 p.2‖ ^ 2) ≤ Q
+  refine hentry.trans ?_
+  by_cases hK : K = 0
+  · subst K
+    simp only [M, E, pow_zero, Module.End.one_apply]
+    dsimp [Q]
+    exact (mul_le_mul_of_nonneg_left
+      (le_add_of_nonneg_right (sq_nonneg B)) hD).trans
+      (le_add_of_nonneg_right zero_le_one)
+  · have hK1 : 1 ≤ K := Nat.one_le_iff_ne_zero.mpr hK
+    have hpow : E ^ K = P + N ^ K := by
+      simpa [N, E, P] using
+        pow_eq_fixedPointProj_add_compl_pow (E := E) (ρ := ρ) htr hTP
+          hP.fixedPoint_is_fixed hK1
+    have hN_apply : ‖(N ^ K) 1‖ ≤ C * ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ := by
+      calc
+        ‖(N ^ K) 1‖ = ‖((Module.End.toContinuousLinearMap
+            (Matrix (Fin D) (Fin D) ℂ)) (N ^ K)) 1‖ := rfl
+        _ ≤ ‖(Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+            (N ^ K)‖ * ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ :=
+          ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+            (N ^ K)).le_opNorm (1 : Matrix (Fin D) (Fin D) ℂ)
+        _ = ‖T ^ K‖ * ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ := by
+          rw [map_pow (Module.End.toContinuousLinearMap
+            (Matrix (Fin D) (Fin D) ℂ)) N K]
+        _ ≤ (C * r ^ K) * ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ := by
+          gcongr
+          exact hgeom K
+        _ ≤ C * ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ := by
+          exact mul_le_mul_of_nonneg_right
+            (mul_le_of_le_one_right hC.le
+              (pow_le_one₀ (le_of_lt hr_pos) (le_of_lt hr_lt_one))) (norm_nonneg _)
+    have hM : M = P 1 + (N ^ K) 1 := by
+      have happ := congrArg
+        (fun F : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ) => F 1) hpow
+      simpa only [M, LinearMap.add_apply] using happ
+    have hB : 0 ≤ B := by
+      dsimp [B]
+      positivity
+    have hM_norm : ‖M‖ ≤ B := by
+      rw [hM]
+      exact (norm_add_le _ _).trans (by
+        simpa only [B] using add_le_add_right hN_apply ‖P 1‖)
+    have hM_sq : ‖M‖ ^ 2 ≤ B ^ 2 :=
+      (sq_le_sq₀ (norm_nonneg _) hB).2 hM_norm
+    dsimp [Q]
+    exact (mul_le_mul_of_nonneg_left
+      (hM_sq.trans (le_add_of_nonneg_left (sq_nonneg ‖(1 : Matrix
+        (Fin D) (Fin D) ℂ)‖))) hD).trans (le_add_of_nonneg_right zero_le_one)
+
+/-- For a primitive MPS tensor, the tail virtual maps have a uniform operator-norm bound,
+independent of the tail length. The proof preserves the fourth-power Gram normalization:
+it first bounds the fourth powers uniformly and then chooses a strictly positive bound for
+the norms themselves. No positive-definiteness assumption on the fixed point is required. -/
+theorem IsPrimitiveMPS.tailVirtualMapES_norm_uniform
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) :
+    ∃ C : ℝ, 0 < C ∧ ∀ K : ℕ, ‖tailVirtualMapES A K‖ ≤ C := by
+  obtain ⟨Q, hQ, hbound⟩ := hP.tailVirtualMapES_norm_four_pow_uniform
+  refine ⟨Q + 1, by positivity, ?_⟩
+  intro K
+  by_cases hnorm : ‖tailVirtualMapES A K‖ ≤ 1
+  · exact hnorm.trans (by linarith)
+  · exact (le_self_pow₀ (lt_of_not_ge hnorm).le (by norm_num : 4 ≠ 0)).trans
+      ((hbound K).trans (by linarith))
+
+end UniformBound
+
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -785,9 +785,10 @@ norm estimate is derived here.
     \leanok
     \uses{def:primitive_mps, thm:spectator_boundary_hilbert_factorization}
     Let $A$ be a primitive MPS tensor with nonzero virtual dimension, and let
-    $J_K=J^{\mathrm{tail}}_K$ be its length-$K$ tail virtual map.  Then
+    $J_K=J^{\mathrm{tail}}_K$ be its length-$K$ tail virtual map.  Then there is
+    a constant $C>0$ such that, for every $K\in\N$,
     \begin{align}
-        \exists C>0,\quad \forall K\in\N,\quad \lVert J_K\rVert&\leq C.
+        \lVert J_K\rVert&\leq C.
     \end{align}
     No positive-definiteness hypothesis on the fixed point is required.
 \end{theorem}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -778,11 +778,53 @@ norm estimate is derived here.
     anticommutator inequality.
 \end{proof}
 
+\begin{theorem}[Uniform tail virtual-map bound]
+    \label{thm:primitive_tail_virtual_map_norm_uniform}
+    \lean{MPSTensor.IsPrimitiveMPS.tailVirtualMapES_norm_four_pow_uniform}
+    \lean{MPSTensor.IsPrimitiveMPS.tailVirtualMapES_norm_uniform}
+    \leanok
+    \uses{def:primitive_mps, thm:spectator_boundary_hilbert_factorization}
+    Let $A$ be a primitive MPS tensor with nonzero virtual dimension, and let
+    $J_K=J^{\mathrm{tail}}_K$ be its length-$K$ tail virtual map.  Then
+    \begin{align}
+        \exists C>0,\quad \forall K\in\N,\quad \lVert J_K\rVert&\leq C.
+    \end{align}
+    No positive-definiteness hypothesis on the fixed point is required.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:geometric_bound_of_spectral_radius_lt_one, thm:pow_decomp,
+        thm:sum_entry_norm_sq_le_card_mul_l2_operator_norm_sq}
+    Reconstruct the norm infrastructure from the exact adjoint--self identity
+    \begin{align}
+        J_K^\dagger J_K U(X)
+        &=U\!\left(X\,\mathcal E_A^K(\mathbf 1)\right).
+    \end{align}
+    The Hilbert--Schmidt product estimate then gives the fourth-power bound
+    \begin{align}
+        \lVert J_K\rVert^4
+        &\leq \sum_{i,j}\left\lvert
+          \mathcal E_A^K(\mathbf 1)_{ij}\right\rvert^2.
+    \end{align}
+    For $K\geq1$, decompose the transfer power into its fixed-point projection
+    and the $K$-th power of the complementary map.  The complementary powers
+    are geometrically bounded by
+    Theorem~\ref{thm:geometric_bound_of_spectral_radius_lt_one}, while the
+    entrywise mass is controlled by the $L^2$ operator norm with the virtual
+    dimension factor from
+    Theorem~\ref{thm:sum_entry_norm_sq_le_card_mul_l2_operator_norm_sq}.
+    The case $K=0$ is bounded directly.  This first gives a uniform bound for
+    $\lVert J_K\rVert^4$ and hence a strictly positive uniform bound for
+    $\lVert J_K\rVert$.  No FNW or Nachtergaele contraction estimate enters.
+\end{proof}
+
 \begin{lemma}[Uniform FNW overlapping-window contraction]
     \label{lem:fnw_overlapping_window_contraction}
     \notready
     \discussion{5923}
-    \uses{thm:fixed_point_gram_metric_exact,
+    \uses{thm:primitive_tail_virtual_map_norm_uniform,
+        thm:fixed_point_gram_metric_exact,
         thm:fixed_point_gram_metric_is_unit,
         thm:primitive_ground_space_map_eventual_inverse_gram_bound,
         thm:ground_space_es_projection_inverse_gram,

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -755,16 +755,16 @@ and generic prerequisites now include:
     \leanid{ContinuousLinearMap.norm_T_comp_inverseGram_eq_sqrt} and
     \leanid{ContinuousLinearMap.norm_inverseGram_comp_adjoint_eq_sqrt}.
   \item If \(A\) is a primitive MPS tensor with nonzero virtual dimension,
-    then
+    write \(J^{\mathrm{tail}}_K\) for its length-\(K\) tail virtual map.  Then
     \leanid{MPSTensor.IsPrimitiveMPS.tailVirtualMapES_norm_uniform} gives a
     constant \(C>0\), independent of \(K\), such that
     \begin{align}
-      \lVert J_K^{\mathrm{tail}}\rVert&\le C
+      \lVert J^{\mathrm{tail}}_K\rVert&\le C
     \end{align}
     for every \(K\in\mathbb N\).  No positive-definiteness assumption on
     \(\rho\) is used.  The proof preserves the fourth-power intermediate
     normalization, first establishing a uniform bound for
-    \(\lVert J_K^{\mathrm{tail}}\rVert^4\), and then obtains the norm bound.
+    \(\lVert J^{\mathrm{tail}}_K\rVert^4\), and then obtains the norm bound.
     It reconstructs the required norm infrastructure from the exact
     tail adjoint--self estimate, the fixed-point/complementary-power
     decomposition, the geometric power bound, and the dimension conversion

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -742,6 +742,34 @@ and generic prerequisites now include:
     three injectivity assumptions are explicit.  This is an algebraic identity
     only; a source-specific estimate of the mixed-Gram residual is still
     required.
+  \item For an injective finite-dimensional map \(T\), with
+    \(S_T=(T^\dagger T)^{-1}\), the two pseudoinverse factors in its exact
+    range projector satisfy
+    \begin{align}
+      \lVert TS_T\rVert
+        &=\sqrt{\lVert S_T\rVert},&
+      \lVert S_TT^\dagger\rVert
+        &=\sqrt{\lVert S_T\rVert}.
+    \end{align}
+    These identities are
+    \leanid{ContinuousLinearMap.norm_T_comp_inverseGram_eq_sqrt} and
+    \leanid{ContinuousLinearMap.norm_inverseGram_comp_adjoint_eq_sqrt}.
+  \item If \(A\) is a primitive MPS tensor with nonzero virtual dimension,
+    then
+    \leanid{MPSTensor.IsPrimitiveMPS.tailVirtualMapES_norm_uniform} gives a
+    constant \(C>0\), independent of \(K\), such that
+    \begin{align}
+      \lVert J_K^{\mathrm{tail}}\rVert&\le C
+    \end{align}
+    for every \(K\in\mathbb N\).  No positive-definiteness assumption on
+    \(\rho\) is used.  The proof preserves the fourth-power intermediate
+    normalization, first establishing a uniform bound for
+    \(\lVert J_K^{\mathrm{tail}}\rVert^4\), and then obtains the norm bound.
+    It reconstructs the required norm infrastructure from the exact
+    tail adjoint--self estimate, the fixed-point/complementary-power
+    decomposition, the geometric power bound, and the dimension conversion
+    from the \(L^2\) operator norm to entrywise mass.  This is not an FNW or
+    Nachtergaele contraction estimate.
   \item For each length \(n\), let \(\mathcal K_n\) be the ground-space
     Gram, and whenever it is invertible set \(S_n=\mathcal K_n^{-1}\).  Let
     \(\mathcal K_\infty=\mathscr R(P_\rho)\), with \(\rho\) positive
@@ -761,16 +789,17 @@ and generic prerequisites now include:
     factorization.  The inverse convergence theorem controls the middle
     correction eventually.
 
-    The length-\(l\) error is isolated conditionally by
-    \leanid{MPSTensor.inner_c3_centeredVirtualResidual_eq_gramError}.  The
-    remaining exact algebraic dependency is the limiting intertwining identity
-    that equates the product of the two limiting spectator Grams, the limiting
-    inverse, and the two virtual word maps with the explicit limiting pairing
-    in the centered mixed-Gram formula.  This identity must be derived from the
-    transfer fixed-point equations.  It cannot be replaced by identifying a
-    physical ground projector with \(P_\rho\).  These decompositions are
-    reconstructed algebra and assert neither the FNW rational coefficient nor
-    a uniform contraction estimate.
+    Under the explicit hypotheses that the virtual dimension is nonzero and
+    \(\rho\) is positive definite,
+    \leanid{MPSTensor.inner_limitingMixedGramIntertwining} proves the limiting
+    intertwining identity.  Under the same hypotheses,
+    \leanid{MPSTensor.inner_c3_centeredVirtualResidual_eq_gramError}
+    unconditionally identifies the centered residual pairing with the
+    length-\(l\) Gram error.  The zeroth-order cancellation uses the explicit
+    limiting metric, its inverse, and the virtual-map adjoints; no transfer
+    fixed-point equation is needed.  These identities are reconstructed
+    algebra.  The final projector-defect estimate and the FNW--Nachtergaele
+    rational contraction remain open.
 \end{itemize}
 Fix \(K,L_0\in\mathbb N\) and let
 \(\mathcal H_{K+L_0+1}\) be the \((K+L_0+1)\)-site Euclidean space


### PR DESCRIPTION
## Summary

- refactor the tail virtual Gram proof to reuse `LinearIsometryEquiv.norm_map`,
  `Matrix.frobenius_norm_def`, and `Matrix.frobenius_norm_mul`, resolving the late
  duplication review on merged PR #5974;
- prove `MPSTensor.IsPrimitiveMPS.tailVirtualMapES_norm_four_pow_uniform`;
- prove the source-facing capstone
  `MPSTensor.IsPrimitiveMPS.tailVirtualMapES_norm_uniform`:
  `∃ C > 0, ∀ K, ‖tailVirtualMapES A K‖ ≤ C`;
- synchronize the Chapter 13 dependency node and martingale paper-gap inventory.

## Proof scope

The proof keeps the exact fourth-power normalization. For `K ≥ 1`, it decomposes
`E^K = P_ρ + N^K`, applies the existing complementary spectral-radius geometric
bound in the matrix L² operator norm, converts entrywise mass using the safe factor
`D`, and treats `K = 0` separately. The final positive norm constant is obtained only
after the uniform fourth-power estimate.

The theorem requires `[NeZero D]` and `IsPrimitiveMPS A ρ`; it does **not** require
`ρ.PosDef`. This is reconstructed norm infrastructure for the C3 assembly, not an
FNW/Nachtergaele projector contraction and not the rational estimate of
Nachtergaele Eq. (6.1).

Closes #5963
Parent #5923

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/TailVirtualGram.lean`
- blueprint declaration synchronization
- reader-facing prose check
- targeted tenkz lint
- `git diff --check main...HEAD`
- no `sorry`, `admit`, or new axioms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formal norm infrastructure on the parent-Hamiltonian martingale path; proofs are localized but rely on primitive transfer geometry and several library norm lemmas, so regressions would affect downstream C3 assembly rather than runtime behavior.
> 
> **Overview**
> Adds **uniform operator-norm control** for primitive MPS tail virtual maps `tailVirtualMapES`, and **shortens** the Frobenius Gram estimates that feed the fourth-power bound.
> 
> In `TailVirtualGram.lean`, the hand-built Frobenius Cauchy–Schwarz chain is replaced by `LinearIsometryEquiv.norm_map`, `Matrix.frobenius_norm_def`, and `Matrix.frobenius_norm_mul`. New results under `IsPrimitiveMPS` (with `[NeZero D]`, no `ρ.PosDef`): a uniform bound on `‖tailVirtualMapES A K‖^4` via fixed-point plus complementary transfer decomposition, geometric complementary decay, and entrywise mass versus L² operator norm; then `∃ C > 0` with `‖tailVirtualMapES A K‖ ≤ C` for all `K`.
> 
> Chapter 13 blueprint gains **Theorem** `primitive_tail_virtual_map_norm_uniform` and wires it into the FNW overlapping-window lemma dependencies. The martingale paper-gap note records the uniform tail bound and updates the C3 inventory so limiting mixed-Gram intertwining and centered residual identification are treated as proved algebra under explicit hypotheses, while the FNW projector contraction stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45dc9cea0374fa84387ef0a9f1a68329f26f46be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->