### PR TITLE
feat(MPS/MPU): expose closed source-u networks

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -19,6 +19,7 @@ import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
 import TNLean.MPS.MPU.SourceUBoundary
+import TNLean.MPS.MPU.SourceUClosedNetwork
 import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SourceUOpenTail
 import TNLean.MPS.MPU.SourceURangeTransport

--- a/TNLean/MPS/MPU/SourceUClosedNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUClosedNetwork.lean
@@ -10,14 +10,14 @@ import TNLean.MPS.MPU.SourceURangeTransport
 # Closed source-u networks
 
 This file gives two exact closed-network formulas used in the proof of
-`lemuisometry` from arXiv:1703.09188, lines 545--557. The first writes an
+lemuisometry from arXiv:1703.09188, lines 545--557. The first writes an
 ordinary source-u Gram entry as an output-first double-layer letter whose
 remaining bond is closed by the second-cut range projector. The second writes
-the normalized `(K+2)`-site output-tail contraction as a trace of two retained
+the normalized $(K+2)$-site output-tail contraction as a trace of two retained
 output-first letters followed by the Kth normalized-diagonal power.
 
-The retained output pair `q` is unstarred and `p` is starred. Doubled bonds are
-ordered `(ket, bra)`. These formulas do not identify the two closed networks,
+The retained output pair $q$ is unstarred and $p$ is starred. Doubled bonds are
+ordered $(\text{ket}, \text{bra})$. These formulas do not identify the two closed networks,
 insert a rank-one tail projector, or assert an ambient coisometry.
 -/
 
@@ -28,7 +28,7 @@ namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)
 
-/-- The weighted cut recovery identifies the Gram of `Y₁` with the weighted raw cut Gram. -/
+/-- The weighted cut recovery identifies the Gram of $Y_1$ with the weighted raw cut Gram. -/
 private lemma sourceY₁_conjTranspose_mul_self
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
     (sourceY₁ U ρ hρ)ᴴ * sourceY₁ U ρ hρ =
@@ -104,9 +104,9 @@ private lemma sourceU_gram_eq_closed_cut
 
 /-- The source-u Gram as one output-first double-layer letter closed by the
 weighted left boundary and the range projector of the second source cut.
-The doubled bonds have order `(ket, bra)`.
+The doubled bonds have order $(\text{ket}, \text{bra})$.
 
-Source: arXiv:1703.09188, equation `uUnitary`, lines 545--556. -/
+Source: arXiv:1703.09188, equation uUnitary, lines 545--556. -/
 theorem sourceU_gram_apply_eq_closed_output_letter
     {d D : ℕ} (U : MPOTensor d D)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
@@ -158,9 +158,9 @@ private lemma normalizedDiagonal_pow_eq_sum_evalWord
     (List.prod_ofFn_sum (fun _ : Fin K ↦ fun i : Fin d ↦ W i i))
 
 /-- The normalized output-tail contraction is a fully closed output-first
-double-layer trace, with retained letters in `(q,p)` order.
+double-layer trace, with retained letters in $(q,p)$ order.
 
-Source: arXiv:1703.09188, equation `uUnitary`, lines 550--556. -/
+Source: arXiv:1703.09188, equation uUnitary, lines 550--556. -/
 theorem normalized_mpo_output_tail_eq_closed_doubleLayer_trace
     [NeZero d] (U : MPOTensor d D) (K : ℕ) (p q : Fin d × Fin d) :
     ((d : ℂ)⁻¹) ^ K *

--- a/TNLean/MPS/MPU/SourceUClosedNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUClosedNetwork.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPU.MatchingContractions
-import TNLean.MPS.MPU.SourceUBoundary
+import TNLean.MPS.MPU.Simple
+import TNLean.MPS.MPU.SourceURangeTransport
 
 /-!
 # Closed source-u networks
@@ -28,21 +28,8 @@ namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)
 
-/-- The weighted first-cut projector acts identically on the first source cut. -/
-private theorem sourceX₁_range_weighted_sourceCutM₁
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
-    sourceX₁ U ρ hρ * (sourceX₁ U ρ hρ)ᴴ *
-        sourceWeight (d := d) ρ * sourceCutM₁ U = sourceCutM₁ U := by
-  rw [show sourceX₁ U ρ hρ * (sourceX₁ U ρ hρ)ᴴ *
-      sourceWeight (d := d) ρ * sourceCutM₁ U =
-      sourceX₁ U ρ hρ * ((sourceX₁ U ρ hρ)ᴴ *
-        sourceWeight (d := d) ρ * sourceCutM₁ U) by
-    simp only [Matrix.mul_assoc]]
-  rw [← sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁ U ρ hρ]
-  exact (sourceCutM₁_eq_sourceX₁_mul_sourceY₁ U ρ hρ).symm
-
 /-- The weighted cut recovery identifies the Gram of `Y₁` with the weighted raw cut Gram. -/
-private theorem sourceY₁_conjTranspose_mul_self
+private lemma sourceY₁_conjTranspose_mul_self
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
     (sourceY₁ U ρ hρ)ᴴ * sourceY₁ U ρ hρ =
       (sourceCutM₁ U)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U := by
@@ -53,11 +40,11 @@ private theorem sourceY₁_conjTranspose_mul_self
   have hrange : sourceX₁ U ρ hρ * ((sourceX₁ U ρ hρ)ᴴ *
       (sourceWeight (d := d) ρ * sourceCutM₁ U)) = sourceCutM₁ U := by
     simpa only [Matrix.mul_assoc] using
-      sourceX₁_range_weighted_sourceCutM₁ U ρ hρ
+      sourceX₁_mul_conjTranspose_mul_weight_mul_sourceCutM₁ U ρ hρ
   simp only [Matrix.mul_assoc, hrange]
 
 /-- Exact closed cut-projector formula for the ordinary source-u Gram entry. -/
-private theorem sourceU_gram_eq_closed_cut
+private lemma sourceU_gram_eq_closed_cut
     {d D : ℕ} (U : MPOTensor d D)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (p q : Fin d × Fin d) :
@@ -156,7 +143,7 @@ theorem sourceU_gram_apply_eq_closed_output_letter
   ring
 
 /-- A normalized diagonal power is the normalized sum of diagonal open words. -/
-private theorem normalizedDiagonal_pow_eq_sum_evalWord
+private lemma normalizedDiagonal_pow_eq_sum_evalWord
     [NeZero d] (W : MPOTensor d D) (K : ℕ) :
     normalizedDiagonal W ^ K =
       ((d : ℂ)⁻¹) ^ K •

--- a/TNLean/MPS/MPU/SourceUClosedNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUClosedNetwork.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.MatchingContractions
+import TNLean.MPS.MPU.SourceUBoundary
+
+/-!
+# Closed source-u networks
+
+This file gives two exact closed-network formulas used in the proof of
+`lemuisometry` from arXiv:1703.09188, lines 545--557. The first writes an
+ordinary source-u Gram entry as an output-first double-layer letter whose
+remaining bond is closed by the second-cut range projector. The second writes
+the normalized `(K+2)`-site output-tail contraction as a trace of two retained
+output-first letters followed by the Kth normalized-diagonal power.
+
+The retained output pair `q` is unstarred and `p` is starred. Doubled bonds are
+ordered `(ket, bra)`. These formulas do not identify the two closed networks,
+insert a rank-one tail projector, or assert an ambient coisometry.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- The weighted first-cut projector acts identically on the first source cut. -/
+private theorem sourceX₁_range_weighted_sourceCutM₁
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    sourceX₁ U ρ hρ * (sourceX₁ U ρ hρ)ᴴ *
+        sourceWeight (d := d) ρ * sourceCutM₁ U = sourceCutM₁ U := by
+  rw [show sourceX₁ U ρ hρ * (sourceX₁ U ρ hρ)ᴴ *
+      sourceWeight (d := d) ρ * sourceCutM₁ U =
+      sourceX₁ U ρ hρ * ((sourceX₁ U ρ hρ)ᴴ *
+        sourceWeight (d := d) ρ * sourceCutM₁ U) by
+    simp only [Matrix.mul_assoc]]
+  rw [← sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁ U ρ hρ]
+  exact (sourceCutM₁_eq_sourceX₁_mul_sourceY₁ U ρ hρ).symm
+
+/-- The weighted cut recovery identifies the Gram of `Y₁` with the weighted raw cut Gram. -/
+private theorem sourceY₁_conjTranspose_mul_self
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    (sourceY₁ U ρ hρ)ᴴ * sourceY₁ U ρ hρ =
+      (sourceCutM₁ U)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U := by
+  rw [sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁ U ρ hρ,
+    Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+    Matrix.conjTranspose_conjTranspose,
+    (sourceWeight_posDef (d := d) hρ).isHermitian.eq]
+  have hrange : sourceX₁ U ρ hρ * ((sourceX₁ U ρ hρ)ᴴ *
+      (sourceWeight (d := d) ρ * sourceCutM₁ U)) = sourceCutM₁ U := by
+    simpa only [Matrix.mul_assoc] using
+      sourceX₁_range_weighted_sourceCutM₁ U ρ hρ
+  simp only [Matrix.mul_assoc, hrange]
+
+/-- Exact closed cut-projector formula for the ordinary source-u Gram entry. -/
+private theorem sourceU_gram_eq_closed_cut
+    {d D : ℕ} (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (p q : Fin d × Fin d) :
+    (∑ lr : Fin ℓ[U] × Fin r[U],
+      sourceU U ρ hρ lr q * star (sourceU U ρ hρ lr p)) =
+      ∑ β : Fin D, ∑ δ : Fin D,
+        ((sourceCutM₁ U)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U)
+            (p.1, δ) (q.1, β) *
+          (sourceX₂ U * (sourceX₂ U)ᴴ) (β, q.2) (δ, p.2) := by
+  classical
+  rw [Fintype.sum_prod_type]
+  change (∑ l : Fin ℓ[U], ∑ r : Fin r[U],
+    (∑ β : Fin D, sourceY₁ U ρ hρ r (q.1, β) * sourceX₂ U (β, q.2) l) *
+      star (∑ δ : Fin D,
+        sourceY₁ U ρ hρ r (p.1, δ) * sourceX₂ U (δ, p.2) l)) = _
+  simp_rw [star_sum, star_mul]
+  simp_rw [Finset.sum_mul_sum]
+  rw [← sourceY₁_conjTranspose_mul_self U ρ hρ]
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply]
+  simp_rw [Finset.sum_mul_sum]
+  have hreorder (l : Fin ℓ[U]) (r : Fin r[U]) (β δ : Fin D) :
+      sourceY₁ U ρ hρ r (q.1, β) * sourceX₂ U (β, q.2) l *
+          (star (sourceX₂ U (δ, p.2) l) *
+            star (sourceY₁ U ρ hρ r (p.1, δ))) =
+        star (sourceY₁ U ρ hρ r (p.1, δ)) * sourceY₁ U ρ hρ r (q.1, β) *
+          (sourceX₂ U (β, q.2) l * star (sourceX₂ U (δ, p.2) l)) := by
+    ring
+  simp_rw [← hreorder]
+  let f := fun (l : Fin ℓ[U]) (r : Fin r[U]) (β δ : Fin D) ↦
+    sourceY₁ U ρ hρ r (q.1, β) * sourceX₂ U (β, q.2) l *
+      (star (sourceX₂ U (δ, p.2) l) *
+        star (sourceY₁ U ρ hρ r (p.1, δ)))
+  change (∑ l, ∑ r, ∑ β, ∑ δ, f l r β δ) =
+    ∑ β, ∑ δ, ∑ r, ∑ l, f l r β δ
+  calc
+    _ = ∑ l, ∑ β, ∑ r, ∑ δ, f l r β δ := by
+      apply Finset.sum_congr rfl
+      intro l _
+      exact Finset.sum_comm
+    _ = ∑ β, ∑ l, ∑ r, ∑ δ, f l r β δ := Finset.sum_comm
+    _ = ∑ β, ∑ l, ∑ δ, ∑ r, f l r β δ := by
+      apply Finset.sum_congr rfl
+      intro β _
+      apply Finset.sum_congr rfl
+      intro l _
+      exact Finset.sum_comm
+    _ = ∑ β, ∑ δ, ∑ l, ∑ r, f l r β δ := by
+      apply Finset.sum_congr rfl
+      intro β _
+      exact Finset.sum_comm
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro β _
+      apply Finset.sum_congr rfl
+      intro δ _
+      exact Finset.sum_comm
+
+/-- The source-u Gram as one output-first double-layer letter closed by the
+weighted left boundary and the range projector of the second source cut.
+The doubled bonds have order `(ket, bra)`.
+
+Source: arXiv:1703.09188, equation `uUnitary`, lines 545--556. -/
+theorem sourceU_gram_apply_eq_closed_output_letter
+    {d D : ℕ} (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (p q : Fin d × Fin d) :
+    (∑ lr : Fin ℓ[U] × Fin r[U],
+      sourceU U ρ hρ lr q * star (sourceU U ρ hρ lr p)) =
+      ∑ β : Fin D, ∑ δ : Fin D, ∑ γ : Fin D, ∑ α : Fin D,
+        ρ α γ *
+          doubleLayerTensor (physicalAdjointTensor U) q.1 p.1
+            (finProdFinEquiv (γ, α)) (finProdFinEquiv (β, δ)) *
+          (sourceX₂ U * (sourceX₂ U)ᴴ) (β, q.2) (δ, p.2) := by
+  rw [sourceU_gram_eq_closed_cut U ρ hρ p q]
+  apply Finset.sum_congr rfl
+  intro β _
+  apply Finset.sum_congr rfl
+  intro δ _
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, sourceWeight,
+    Matrix.kronecker_apply, Matrix.one_apply, mul_ite, mul_one, mul_zero,
+    Finset.sum_ite_eq', Finset.mem_univ, if_true, Fintype.sum_prod_type,
+    sourceCutM₁_apply,
+    doubleLayerTensor_physicalAdjointTensor_apply]
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro γ _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro α _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro l _
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro j _
+  ring
+
+/-- A normalized diagonal power is the normalized sum of diagonal open words. -/
+private theorem normalizedDiagonal_pow_eq_sum_evalWord
+    [NeZero d] (W : MPOTensor d D) (K : ℕ) :
+    normalizedDiagonal W ^ K =
+      ((d : ℂ)⁻¹) ^ K •
+        ∑ τ : Fin K → Fin d, evalWord W (List.ofFn τ) (List.ofFn τ) := by
+  classical
+  simp only [normalizedDiagonal, contractPhysical, Matrix.one_apply, ite_smul,
+    one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true,
+    evalWord_ofFn]
+  rw [smul_pow]
+  congr 1
+  simpa [List.ofFn_const] using
+    (List.prod_ofFn_sum (fun _ : Fin K ↦ fun i : Fin d ↦ W i i))
+
+/-- The normalized output-tail contraction is a fully closed output-first
+double-layer trace, with retained letters in `(q,p)` order.
+
+Source: arXiv:1703.09188, equation `uUnitary`, lines 550--556. -/
+theorem normalized_mpo_output_tail_eq_closed_doubleLayer_trace
+    [NeZero d] (U : MPOTensor d D) (K : ℕ) (p q : Fin d × Fin d) :
+    ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ η : Fin (K + 2) → Fin d,
+          mpo U (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) η *
+            star (mpo U (K + 2)
+              ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ)) η) =
+      Matrix.trace
+        (doubleLayerTensor (physicalAdjointTensor U) q.1 p.1 *
+          doubleLayerTensor (physicalAdjointTensor U) q.2 p.2 *
+            normalizedDiagonal (doubleLayerTensor (physicalAdjointTensor U)) ^ K) := by
+  classical
+  let W := doubleLayerTensor (physicalAdjointTensor U)
+  have hη (σ τ : Fin (K + 2) → Fin d) :
+      (∑ η : Fin (K + 2) → Fin d,
+        mpo U (K + 2) σ η * star (mpo U (K + 2) τ η)) =
+        mpo W (K + 2) σ τ := by
+    have h := congrArg (fun M ↦ M σ τ)
+      (mpo_doubleLayerTensor (physicalAdjointTensor U) (K + 2))
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      mpo_physicalAdjointTensor, star_star] at h
+    exact h.symm
+  simp_rw [hη]
+  have hword (τ : Fin K → Fin d) :
+      mpo W (K + 2) ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ))
+          ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ)) =
+        Matrix.trace (W q.1 p.1 * W q.2 p.2 *
+          evalWord W (List.ofFn τ) (List.ofFn τ)) := by
+    rw [mpo_apply, mpoMatrixEntry]
+    simp only [finAddTwoArrowEquiv_symm_apply, List.ofFn_succ, evalWord_cons,
+      Fin.cons_zero, Fin.cons_succ]
+    rw [← Matrix.mul_assoc]
+  simp_rw [hword]
+  change ((d : ℂ)⁻¹) ^ K *
+      ∑ τ : Fin K → Fin d,
+        Matrix.trace (W q.1 p.1 * W q.2 p.2 *
+          evalWord W (List.ofFn τ) (List.ofFn τ)) =
+    Matrix.trace (W q.1 p.1 * W q.2 p.2 * normalizedDiagonal W ^ K)
+  rw [normalizedDiagonal_pow_eq_sum_evalWord W K]
+  simp only [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul,
+    Matrix.mul_sum, Matrix.trace_sum]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1924,6 +1924,84 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     apply normalized output-first MPU coisometry.
 \end{proof}
 
+\begin{theorem}[Closed output-letter formula for source-$u$ Gram entries]
+    \label{thm:mpu_source_u_gram_closed_output_letter}
+    \lean{MPOTensor.sourceU_gram_apply_eq_closed_output_letter}
+    \leanok
+    \uses{def:mpu_source_uv,def:mpu_double_layer,
+        def:mpu_weighted_source_factors}
+    Let $\mathcal U$ be an MPO tensor, let $\rho$ be positive definite, and
+    let $p,q\in\Fin d\times\Fin d$.  Write $W_{\mathrm{out}}$ for the
+    output-first double layer of $\mathcal U$.  Then
+    \begin{align}
+      \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+      =\sum_{\beta,\delta,\gamma,\alpha}
+        &\rho_{\alpha,\gamma}
+        (W_{\mathrm{out}}^{q_1p_1})_{(\gamma,\alpha),(\beta,\delta)}\\
+        &\qquad\cdot
+        (X_2X_2^\dagger)_{(\beta,q_2),(\delta,p_2)}.
+    \end{align}
+    Thus $q$ is the unstarred ket index, $p$ is the starred bra index, and
+    each doubled bond is ordered as $(\text{ket},\text{bra})$.
+    This is the first closed network in
+    \cite[Eq.~\texttt{uUnitary} and lines~545--556]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_source_matrix_one,thm:mpu_source_weight_posdef,
+        thm:mpu_source_factor_recovery,thm:mpu_source_x1_range_projection,
+        thm:mpu_output_first_double_layer_entry}
+    Expand both source-$u$ entries and contract their common source indices.
+    Weighted recovery of $Y_1$, followed by the first source-cut range
+    identity, replaces $Y_1^\dagger Y_1$ by
+    $M_1^\dagger W_\rho M_1$.  Expanding $M_1$ and the output-first double
+    layer gives the displayed $\rho$-weighted letter, while the remaining
+    $X_2$ factors form the stated range projector.
+\end{proof}
+
+\begin{theorem}[Closed double-layer trace for the normalized output tail]
+    \label{thm:mpu_normalized_output_tail_closed_trace}
+    \lean{MPOTensor.normalized_mpo_output_tail_eq_closed_doubleLayer_trace}
+    \leanok
+    \uses{def:mpo_family,def:mpu_double_layer}
+    Assume $d>0$.  For any MPO tensor $\mathcal U$, tail length $K$, and
+    $p,q\in\Fin d\times\Fin d$, let $W_{\mathrm{out}}$ be its output-first
+    double layer and let $E_{\mathrm{out}}$ be the normalized physical
+    diagonal of $W_{\mathrm{out}}$.  Then
+    \begin{align}
+      d^{-K}\sum_{\tau,\eta}
+        U^{(K+2)}_{(q,\tau),\eta}
+        \overline{U^{(K+2)}_{(p,\tau),\eta}}
+      =\tr\!\left[
+        W_{\mathrm{out}}^{q_1p_1}
+        W_{\mathrm{out}}^{q_2p_2}E_{\mathrm{out}}^K\right].
+    \end{align}
+    The retained letters occur in $(q,p)$ order, so $q$ is unstarred and
+    $p$ is starred; their doubled bonds are in $(\text{ket},\text{bra})$
+    order.  This is the normalized closed output tail in
+    \cite[Eq.~\texttt{uUnitary} and lines~550--556]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_physical_adjoint,thm:mpu_closed_double_layer}
+    Close the contracted input configuration as the periodic MPO of the
+    output-first double layer.  Splitting off the two retained sites leaves a
+    common diagonal word of length $K$.  Expanding the normalized diagonal
+    power as the normalized sum of those words and using linearity of the
+    trace gives the displayed closed trace.
+\end{proof}
+
+% The equality and range-insertion step remains tracked by issue #5971.
+\begin{remark}[Scope of the closed source-$u$ formulas]
+    The first theorem rewrites the ordinary source-$u$ Gram entry, while the
+    second independently rewrites the normalized closed output tail.  They do
+    not identify these two expressions or justify inserting the source-cut
+    range projections through the intervening chain.  That range-restricted
+    equality remains separate.  Neither theorem asserts an ambient
+    $X_2X_2^\dagger=\Id$, $M_2M_2^\dagger=\Id$, or
+    $Y_2Y_2^\dagger=\Id$ identity.
+\end{remark}
+
 \begin{theorem}[Terminal source-factor boundary contraction]
     \label{thm:mpu_source_u_terminal_boundary}
     \lean{MPOTensor.sourceU_boundary_sandwich}


### PR DESCRIPTION
## Summary

- express the ordinary source-$u$ Gram entry as one output-first double-layer letter with the weighted left boundary and second-cut range projector
- express the normalized $(K+2)$-site output-tail contraction as the fully closed trace
  \[
  \operatorname{tr}(W_{\rm out}^{q_1p_1}W_{\rm out}^{q_2p_2}E_{\rm out}^K)
  \]
- track both formulas in Chapter 28 with exact orientation, normalization, hypotheses, and dependencies

## Mathematical scope

This PR deliberately exposes the two fully closed sides without identifying them. The supplied reflected rank-one insertion that equates them remains #5971.

It preserves q-unstarred/p-starred and `(ket,bra)` doubled-bond order, reuses the public first-cut range theorem from #5975, and asserts no ambient coefficient identity, mixed pointwise insertion, $X_2X_2^\dagger=1$, $M_2M_2^\dagger=1$, or $Y_2Y_2^\dagger=1$.

## Validation

- direct Lean compilation of `SourceUClosedNetwork.lean`
- targeted `TNLean.MPS.MPU.SourceUClosedNetwork` and MPU aggregator builds
- clean diagnostics and generated imports
- blueprint synchronization/reverse coverage: 7044/7044
- prose, integrity, added-line length, whitespace, and diff checks
- focused LeanSimplifier review: APPROVE

Closes #5978.
Leaves #5971 open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal lemmas and blueprint prose in the MPU proof chain; no runtime or security impact, and scope is explicitly limited to exposing formulas rather than new equational steps.
> 
> **Overview**
> Adds **`SourceUClosedNetwork.lean`** with two exact closed-network identities from Cirac et al. (uUnitary, lines 545–557), wired into the MPU aggregator.
> 
> **`sourceU_gram_apply_eq_closed_output_letter`** rewrites a source-$u$ Gram entry $\sum_{l,r} u_{(l,r),q}\overline{u_{(l,r),p}}$ as a $\rho$-weighted output-first double-layer letter closed by the second-cut range projector `sourceX₂ * (sourceX₂)ᴴ`, with doubled bonds in $(\text{ket},\text{bra})$ order and $q$ unstarred / $p$ starred.
> 
> **`normalized_mpo_output_tail_eq_closed_doubleLayer_trace`** rewrites the normalized $(K+2)$-site output-tail contraction as $\operatorname{tr}(W_{\mathrm{out}}^{q_1p_1} W_{\mathrm{out}}^{q_2p_2} E_{\mathrm{out}}^K)$, via closing to the double-layer MPO and expanding `normalizedDiagonal` as a sum of diagonal words.
> 
> Chapter 28 blueprint adds matching theorems, proof sketches, and a **scope remark**: these lemmas expose the two closed sides separately—they do **not** equate them, insert rank-one tail projectors, or assert ambient coisometry identities (tracked separately in #5971).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5b4165e6a182e31eba476c51071f0a30783b44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->