### PR TITLE
feat(ParentHamiltonian): factor the centered C3 overlap residual

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -32,6 +32,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities
 import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.BoundaryStripping
+import TNLean.MPS.ParentHamiltonian.CenteredOverlapFactor
 import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration

--- a/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
+++ b/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
@@ -10,16 +10,21 @@ import TNLean.MPS.ParentHamiltonian.TailVirtualGram
 /-!
 # Direct-sum factors for the centered overlap residual
 
-This file packages the two boundary multiplications in the centered overlapping
+This file defines the two boundary multiplications in the centered overlapping
 Gram as maps into a common direct sum indexed by a prefix and one final site.
 Their norms are controlled by the corresponding virtual word maps without a
 factor depending on the number of prefix configurations.  The construction and
 factorization are exact algebraic consequences of the boundary-map formulas.
 
-## Main results
+## Main definitions
 
 * `MPSTensor.c3LeftOverlapFactorES` and `MPSTensor.c3RightOverlapFactorES` are the two common
   direct-sum factors.
+* `MPSTensor.c3CenteredVirtualResidualES` is the centered virtual residual in the
+  tail-after-left overlap orientation.
+
+## Main results
+
 * `MPSTensor.c3LeftOverlapFactorES_norm_le` and
   `MPSTensor.c3RightOverlapFactorES_norm_le` give
   bounds uniform in the spectator configuration type.

--- a/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
+++ b/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.GramConvergence
+import TNLean.MPS.ParentHamiltonian.ProjectorCancellation
+import TNLean.MPS.ParentHamiltonian.TailVirtualGram
+
+/-!
+# Direct-sum factors for the centered overlapping Gram
+
+This file packages the two boundary multiplications in the centered overlapping
+Gram as maps into a common direct sum indexed by a prefix and one final site.
+Their norms are controlled by the corresponding virtual word maps without a
+factor depending on the number of prefix configurations.  The construction and
+factorization are exact algebraic consequences of the boundary-map formulas.
+
+## Main results
+
+* `c3LeftOverlapFactorES` and `c3RightOverlapFactorES` are the two common
+  direct-sum factors.
+* `c3LeftOverlapFactorES_norm_le` and `c3RightOverlapFactorES_norm_le` give
+  bounds uniform in the spectator configuration type.
+* `c3_centeredVirtualResidualES_eq_overlapFactors` factors the centered
+  overlapping Gram through its finite Gram error.
+* `c3_centeredVirtualResidualES_norm_le` is the resulting operator-norm bound.
+* `IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric` gives the
+  squared geometric estimate, uniformly in the prefix length.
+-/
+
+open scoped ComplexOrder Matrix Matrix.Norms.Frobenius
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The left direct-sum factor in the centered overlapping Gram.  On the
+fiber indexed by a prefix `u` and final-site configuration `j`, it sends the
+input matrix `X_u` to `A^j X_u`. -/
+noncomputable def c3LeftOverlapFactorES (A : MPSTensor d D) (K : ℕ) :
+    BoundaryFamilySpace (D := D) (Cfg d K) →L[ℂ]
+      BoundaryFamilySpace (D := D) (Cfg d K × Cfg d 1) :=
+  LinearMap.toContinuousLinearMap
+    { toFun := fun x => WithLp.toLp 2 fun sp =>
+        leftVirtualMapES A 1 (boundaryFamilyFiber (D := D) x sp.1.1) (sp.1.2, sp.2)
+      map_add' := by
+        intro x y
+        apply PiLp.ext
+        rintro ⟨⟨u, j⟩, p⟩
+        change leftVirtualMapES A 1
+          (boundaryFamilyFiber (D := D) (x + y) u) (j, p) = _
+        rw [show boundaryFamilyFiber (D := D) (x + y) u =
+            boundaryFamilyFiber (D := D) x u + boundaryFamilyFiber (D := D) y u by
+          apply PiLp.ext
+          intro q
+          rfl, map_add]
+        rfl
+      map_smul' := by
+        intro c x
+        apply PiLp.ext
+        rintro ⟨⟨u, j⟩, p⟩
+        change leftVirtualMapES A 1
+          (boundaryFamilyFiber (D := D) (c • x) u) (j, p) = _
+        rw [show boundaryFamilyFiber (D := D) (c • x) u =
+            c • boundaryFamilyFiber (D := D) x u by
+          apply PiLp.ext
+          intro q
+          rfl, map_smul]
+        rfl }
+
+/-- The right direct-sum factor in the centered overlapping Gram.  On the
+fiber indexed by a prefix `u` and final-site configuration `j`, it sends the
+input matrix `Z_j` to `Z_j A^u`. -/
+noncomputable def c3RightOverlapFactorES (A : MPSTensor d D) (K : ℕ) :
+    BoundaryFamilySpace (D := D) (Cfg d 1) →L[ℂ]
+      BoundaryFamilySpace (D := D) (Cfg d K × Cfg d 1) :=
+  LinearMap.toContinuousLinearMap
+    { toFun := fun y => WithLp.toLp 2 fun sp =>
+        tailVirtualMapES A K (boundaryFamilyFiber (D := D) y sp.1.2) (sp.1.1, sp.2)
+      map_add' := by
+        intro x y
+        apply PiLp.ext
+        rintro ⟨⟨u, j⟩, p⟩
+        change tailVirtualMapES A K
+          (boundaryFamilyFiber (D := D) (x + y) j) (u, p) = _
+        rw [show boundaryFamilyFiber (D := D) (x + y) j =
+            boundaryFamilyFiber (D := D) x j + boundaryFamilyFiber (D := D) y j by
+          apply PiLp.ext
+          intro q
+          rfl, map_add]
+        rfl
+      map_smul' := by
+        intro c x
+        apply PiLp.ext
+        rintro ⟨⟨u, j⟩, p⟩
+        change tailVirtualMapES A K
+          (boundaryFamilyFiber (D := D) (c • x) j) (u, p) = _
+        rw [show boundaryFamilyFiber (D := D) (c • x) j =
+            c • boundaryFamilyFiber (D := D) x j by
+          apply PiLp.ext
+          intro q
+          rfl, map_smul]
+        rfl }
+
+/-- Fiber formula for the left overlap factor. -/
+@[simp]
+theorem boundaryFamilyEquiv_c3LeftOverlapFactorES_apply
+    (A : MPSTensor d D) (K : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg d K))
+    (u : Cfg d K) (j : Cfg d 1) :
+    boundaryFamilyEquiv (D := D) (Cfg d K × Cfg d 1)
+        (c3LeftOverlapFactorES A K x) (u, j) =
+      evalWord A (List.ofFn j) *
+        boundaryFamilyEquiv (D := D) (Cfg d K) x u := by
+  apply (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).injective
+  rw [← boundaryFamilyFiber_eq_frobeniusEquivEuclidean]
+  calc
+    boundaryFamilyFiber (D := D) (c3LeftOverlapFactorES A K x) (u, j) =
+        boundaryFamilyFiber (D := D)
+          (leftVirtualMapES A 1 (boundaryFamilyFiber (D := D) x u)) j := by
+      apply PiLp.ext
+      intro p
+      rfl
+    _ = Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (boundaryFamilyEquiv (D := D) (Cfg d 1)
+          (leftVirtualMapES A 1 (boundaryFamilyFiber (D := D) x u)) j) :=
+      boundaryFamilyFiber_eq_frobeniusEquivEuclidean _ _
+    _ = _ := by
+      rw [boundaryFamilyEquiv_leftVirtualMapES_apply,
+        boundaryFamilyFiber_eq_frobeniusEquivEuclidean,
+        (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm_apply_apply]
+
+/-- Fiber formula for the right overlap factor. -/
+@[simp]
+theorem boundaryFamilyEquiv_c3RightOverlapFactorES_apply
+    (A : MPSTensor d D) (K : ℕ)
+    (y : BoundaryFamilySpace (D := D) (Cfg d 1))
+    (u : Cfg d K) (j : Cfg d 1) :
+    boundaryFamilyEquiv (D := D) (Cfg d K × Cfg d 1)
+        (c3RightOverlapFactorES A K y) (u, j) =
+      boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
+        evalWord A (List.ofFn u) := by
+  apply (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).injective
+  rw [← boundaryFamilyFiber_eq_frobeniusEquivEuclidean]
+  calc
+    boundaryFamilyFiber (D := D) (c3RightOverlapFactorES A K y) (u, j) =
+        boundaryFamilyFiber (D := D)
+          (tailVirtualMapES A K (boundaryFamilyFiber (D := D) y j)) u := by
+      apply PiLp.ext
+      intro p
+      rfl
+    _ = Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+        (boundaryFamilyEquiv (D := D) (Cfg d K)
+          (tailVirtualMapES A K (boundaryFamilyFiber (D := D) y j)) u) :=
+      boundaryFamilyFiber_eq_frobeniusEquivEuclidean _ _
+    _ = _ := by
+      rw [boundaryFamilyEquiv_tailVirtualMapES_apply,
+        boundaryFamilyFiber_eq_frobeniusEquivEuclidean,
+        (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm_apply_apply]
+
+/-- The left direct-sum factor has no spectator-cardinality loss. -/
+theorem c3LeftOverlapFactorES_norm_le (A : MPSTensor d D) (K : ℕ) :
+    ‖c3LeftOverlapFactorES A K‖ ≤ ‖leftVirtualMapES A 1‖ := by
+  refine ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg _) fun x => ?_
+  rw [← sq_le_sq₀ (norm_nonneg _)
+    (mul_nonneg (norm_nonneg _) (norm_nonneg _)), mul_pow,
+    EuclideanSpace.norm_sq_eq, EuclideanSpace.norm_sq_eq]
+  calc
+    ∑ sp : (Cfg d K × Cfg d 1) × (Fin D × Fin D),
+        ‖c3LeftOverlapFactorES A K x sp‖ ^ 2 =
+        ∑ u : Cfg d K, ‖leftVirtualMapES A 1
+          (boundaryFamilyFiber (D := D) x u)‖ ^ 2 := by
+      simp only [Fintype.sum_prod_type, EuclideanSpace.norm_sq_eq]
+      rfl
+    _ ≤ ∑ u : Cfg d K,
+        (‖leftVirtualMapES A 1‖ * ‖boundaryFamilyFiber (D := D) x u‖) ^ 2 := by
+      apply Finset.sum_le_sum
+      intro u _
+      exact (sq_le_sq₀ (norm_nonneg _)
+        (mul_nonneg (norm_nonneg _) (norm_nonneg _))).mpr
+          (ContinuousLinearMap.le_opNorm _ _)
+    _ = ‖leftVirtualMapES A 1‖ ^ 2 *
+        ∑ sp : Cfg d K × (Fin D × Fin D), ‖x sp‖ ^ 2 := by
+      rw [Fintype.sum_prod_type, Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro u _
+      rw [mul_pow, EuclideanSpace.norm_sq_eq]
+      simp only [boundaryFamilyFiber, Finset.mul_sum]
+
+/-- The right direct-sum factor has no spectator-cardinality loss. -/
+theorem c3RightOverlapFactorES_norm_le (A : MPSTensor d D) (K : ℕ) :
+    ‖c3RightOverlapFactorES A K‖ ≤ ‖tailVirtualMapES A K‖ := by
+  refine ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg _) fun y => ?_
+  rw [← sq_le_sq₀ (norm_nonneg _)
+    (mul_nonneg (norm_nonneg _) (norm_nonneg _)), mul_pow,
+    EuclideanSpace.norm_sq_eq, EuclideanSpace.norm_sq_eq]
+  calc
+    ∑ sp : (Cfg d K × Cfg d 1) × (Fin D × Fin D),
+        ‖c3RightOverlapFactorES A K y sp‖ ^ 2 =
+        ∑ j : Cfg d 1, ‖tailVirtualMapES A K
+          (boundaryFamilyFiber (D := D) y j)‖ ^ 2 := by
+      simp only [Fintype.sum_prod_type, EuclideanSpace.norm_sq_eq]
+      rw [Finset.sum_comm]
+      rfl
+    _ ≤ ∑ j : Cfg d 1,
+        (‖tailVirtualMapES A K‖ * ‖boundaryFamilyFiber (D := D) y j‖) ^ 2 := by
+      apply Finset.sum_le_sum
+      intro j _
+      exact (sq_le_sq₀ (norm_nonneg _)
+        (mul_nonneg (norm_nonneg _) (norm_nonneg _))).mpr
+          (ContinuousLinearMap.le_opNorm _ _)
+    _ = ‖tailVirtualMapES A K‖ ^ 2 *
+        ∑ sp : Cfg d 1 × (Fin D × Fin D), ‖y sp‖ ^ 2 := by
+      rw [Fintype.sum_prod_type, Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [mul_pow, EuclideanSpace.norm_sq_eq]
+      simp only [boundaryFamilyFiber, Finset.mul_sum]
+
+/-- The centered virtual residual in the tail-after-left overlap orientation. -/
+noncomputable def c3CenteredVirtualResidualES [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    BoundaryFamilySpace (D := D) (Cfg d 1) →L[ℂ]
+      BoundaryFamilySpace (D := D) (Cfg d K) :=
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+  let Kinfleft := boundaryFiberwiseMap (D := D) (Cfg d 1) Kinf
+  let Iinf := Ring.inverse Kinf
+  (tailBoundaryMapES A K (l + 1)).adjoint.comp
+      (leftBoundaryMapES A (K + l) 1) -
+    Kinftail.comp ((tailVirtualMapES A K).comp
+      (Iinf.comp ((leftVirtualMapES A 1).adjoint.comp Kinfleft)))
+
+/-- The centered overlap residual factors exactly through the length-`l` Gram
+error on the common direct sum. -/
+theorem c3_centeredVirtualResidualES_eq_overlapFactors [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    c3CenteredVirtualResidualES A K l ρ hρ =
+      (c3LeftOverlapFactorES A K).adjoint.comp
+        ((boundaryFiberwiseMap (D := D) (Cfg d K × Cfg d 1)
+          (groundSpaceGram A l - Kinf)).comp
+            (c3RightOverlapFactorES A K)) := by
+  dsimp only
+  apply ContinuousLinearMap.ext
+  intro y
+  apply ext_inner_left ℂ
+  intro x
+  simp only [c3CenteredVirtualResidualES]
+  rw [inner_c3_centeredVirtualResidual_eq_gramError A K l ρ hρ x y]
+  rw [ContinuousLinearMap.comp_apply, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.adjoint_inner_right,
+    inner_boundaryFiberwiseMap]
+  simp only [boundaryFamilyFiber_eq_frobeniusEquivEuclidean,
+    boundaryFamilyEquiv_c3LeftOverlapFactorES_apply,
+    boundaryFamilyEquiv_c3RightOverlapFactorES_apply,
+    Fintype.sum_prod_type]
+
+/-- Operator-norm bound for the exact centered overlap factorization. -/
+theorem c3_centeredVirtualResidualES_norm_le [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    ‖c3CenteredVirtualResidualES A K l ρ hρ‖ ≤
+      ‖leftVirtualMapES A 1‖ * ‖groundSpaceGram A l - Kinf‖ *
+        ‖tailVirtualMapES A K‖ := by
+  dsimp only
+  rw [c3_centeredVirtualResidualES_eq_overlapFactors A K l ρ hρ]
+  calc
+    _ ≤ ‖(c3LeftOverlapFactorES A K).adjoint‖ *
+        ‖boundaryFiberwiseMap (D := D) (Cfg d K × Cfg d 1)
+          (groundSpaceGram A l -
+            Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))‖ *
+          ‖c3RightOverlapFactorES A K‖ := by
+      calc
+        _ ≤ ‖(c3LeftOverlapFactorES A K).adjoint‖ *
+            ‖(boundaryFiberwiseMap (D := D) (Cfg d K × Cfg d 1)
+              (groundSpaceGram A l - Matrix.gramReshuffle
+                (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))).comp
+                (c3RightOverlapFactorES A K)‖ :=
+          ContinuousLinearMap.opNorm_comp_le _ _
+        _ ≤ ‖(c3LeftOverlapFactorES A K).adjoint‖ *
+            (‖boundaryFiberwiseMap (D := D) (Cfg d K × Cfg d 1)
+              (groundSpaceGram A l - Matrix.gramReshuffle
+                (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))‖ *
+              ‖c3RightOverlapFactorES A K‖) := by
+          gcongr
+          exact ContinuousLinearMap.opNorm_comp_le _ _
+        _ = _ := by ring
+    _ = ‖c3LeftOverlapFactorES A K‖ *
+        ‖boundaryFiberwiseMap (D := D) (Cfg d K × Cfg d 1)
+          (groundSpaceGram A l -
+            Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))‖ *
+          ‖c3RightOverlapFactorES A K‖ := by
+      rw [LinearIsometryEquiv.norm_map
+        (ContinuousLinearMap.adjoint (𝕜 := ℂ))]
+    _ ≤ ‖leftVirtualMapES A 1‖ *
+        ‖groundSpaceGram A l -
+          Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))‖ *
+          ‖tailVirtualMapES A K‖ := by
+      gcongr
+      · exact c3LeftOverlapFactorES_norm_le A K
+      · exact norm_boundaryFiberwiseMap_le _ _
+      · exact c3RightOverlapFactorES_norm_le A K
+
+/-- For a primitive MPS tensor with a positive-definite fixed point, the
+squared norm of the centered overlap residual decays geometrically in the
+overlap length, uniformly in the prefix length.  The prefactor retains the
+explicit dimension-cubed conversion from the Gram convergence estimate. -/
+theorem IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ C r : ℝ, 0 < C ∧ 0 < r ∧ r < 1 ∧ ∀ K l : ℕ, 1 ≤ l →
+      ‖c3CenteredVirtualResidualES A K l ρ hρ‖ ^ 2 ≤
+        (D : ℝ) ^ 3 * (C * r ^ l) ^ 2 := by
+  obtain ⟨C_G, r, hC_G, hr_pos, hr_lt_one, hGram⟩ :=
+    hP.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
+  obtain ⟨C_T, hC_T, hTail⟩ := hP.tailVirtualMapES_norm_uniform
+  refine ⟨C_G * C_T * (‖leftVirtualMapES A 1‖ + 1), r, by positivity,
+    hr_pos, hr_lt_one, ?_⟩
+  intro K l hl
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  have hCenter : ‖c3CenteredVirtualResidualES A K l ρ hρ‖ ≤
+      ‖leftVirtualMapES A 1‖ * ‖groundSpaceGram A l - Kinf‖ *
+        ‖tailVirtualMapES A K‖ := by
+    simpa only [Kinf] using c3_centeredVirtualResidualES_norm_le A K l ρ hρ
+  have hGram' : ‖groundSpaceGram A l - Kinf‖ ^ 2 ≤
+      (D : ℝ) ^ 3 * (C_G * r ^ l) ^ 2 := by
+    simpa only [Kinf] using hGram l hl
+  have hLeft : ‖leftVirtualMapES A 1‖ ^ 2 ≤
+      (‖leftVirtualMapES A 1‖ + 1) ^ 2 := by
+    exact (sq_le_sq₀ (norm_nonneg _)
+      (by positivity : 0 ≤ ‖leftVirtualMapES A 1‖ + 1)).mpr (by linarith)
+  have hTail' : ‖tailVirtualMapES A K‖ ^ 2 ≤ C_T ^ 2 := by
+    exact (sq_le_sq₀ (norm_nonneg _) hC_T.le).mpr (hTail K)
+  calc
+    ‖c3CenteredVirtualResidualES A K l ρ hρ‖ ^ 2 ≤
+        (‖leftVirtualMapES A 1‖ * ‖groundSpaceGram A l - Kinf‖ *
+          ‖tailVirtualMapES A K‖) ^ 2 :=
+      (sq_le_sq₀ (norm_nonneg _) (by positivity)).mpr hCenter
+    _ = ‖leftVirtualMapES A 1‖ ^ 2 *
+        ‖groundSpaceGram A l - Kinf‖ ^ 2 * ‖tailVirtualMapES A K‖ ^ 2 := by ring
+    _ ≤ (‖leftVirtualMapES A 1‖ + 1) ^ 2 *
+        ((D : ℝ) ^ 3 * (C_G * r ^ l) ^ 2) * C_T ^ 2 := by
+      gcongr
+    _ = (D : ℝ) ^ 3 *
+        (C_G * C_T * (‖leftVirtualMapES A 1‖ + 1) * r ^ l) ^ 2 := by ring
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
+++ b/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
@@ -37,8 +37,8 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-- The left direct-sum factor in the centered overlapping Gram.  On the
-fiber indexed by a prefix `u` and final-site configuration `j`, it sends the
-input matrix `X_u` to `A^j X_u`. -/
+fiber indexed by a prefix \(u\) and final-site configuration \(j\), it sends the
+input matrix \(X_u\) to \(A^j X_u\). -/
 noncomputable def c3LeftOverlapFactorES (A : MPSTensor d D) (K : ℕ) :
     BoundaryFamilySpace (D := D) (Cfg d K) →L[ℂ]
       BoundaryFamilySpace (D := D) (Cfg d K × Cfg d 1) :=
@@ -71,8 +71,8 @@ noncomputable def c3LeftOverlapFactorES (A : MPSTensor d D) (K : ℕ) :
         rfl }
 
 /-- The right direct-sum factor in the centered overlapping Gram.  On the
-fiber indexed by a prefix `u` and final-site configuration `j`, it sends the
-input matrix `Z_j` to `Z_j A^u`. -/
+fiber indexed by a prefix \(u\) and final-site configuration \(j\), it sends the
+input matrix \(Z_j\) to \(Z_j A^u\). -/
 noncomputable def c3RightOverlapFactorES (A : MPSTensor d D) (K : ℕ) :
     BoundaryFamilySpace (D := D) (Cfg d 1) →L[ℂ]
       BoundaryFamilySpace (D := D) (Cfg d K × Cfg d 1) :=

--- a/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
+++ b/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.ParentHamiltonian.ProjectorCancellation
 import TNLean.MPS.ParentHamiltonian.TailVirtualGram
 
 /-!
-# Direct-sum factors for the centered overlapping Gram
+# Direct-sum factors for the centered overlap residual
 
 This file packages the two boundary multiplications in the centered overlapping
 Gram as maps into a common direct sum indexed by a prefix and one final site.
@@ -18,14 +18,15 @@ factorization are exact algebraic consequences of the boundary-map formulas.
 
 ## Main results
 
-* `c3LeftOverlapFactorES` and `c3RightOverlapFactorES` are the two common
+* `MPSTensor.c3LeftOverlapFactorES` and `MPSTensor.c3RightOverlapFactorES` are the two common
   direct-sum factors.
-* `c3LeftOverlapFactorES_norm_le` and `c3RightOverlapFactorES_norm_le` give
+* `MPSTensor.c3LeftOverlapFactorES_norm_le` and
+  `MPSTensor.c3RightOverlapFactorES_norm_le` give
   bounds uniform in the spectator configuration type.
-* `c3_centeredVirtualResidualES_eq_overlapFactors` factors the centered
+* `MPSTensor.c3_centeredVirtualResidualES_eq_overlapFactors` factors the centered
   overlapping Gram through its finite Gram error.
-* `c3_centeredVirtualResidualES_norm_le` is the resulting operator-norm bound.
-* `IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric` gives the
+* `MPSTensor.c3_centeredVirtualResidualES_norm_le` is the resulting operator-norm bound.
+* `MPSTensor.IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric` gives the
   squared geometric estimate, uniformly in the prefix length.
 -/
 

--- a/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
+++ b/TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean
@@ -235,7 +235,7 @@ noncomputable def c3CenteredVirtualResidualES [NeZero D]
     Kinftail.comp ((tailVirtualMapES A K).comp
       (Iinf.comp ((leftVirtualMapES A 1).adjoint.comp Kinfleft)))
 
-/-- The centered overlap residual factors exactly through the length-`l` Gram
+/-- The centered overlap residual factors exactly through the length-\(l\) Gram
 error on the common direct sum. -/
 theorem c3_centeredVirtualResidualES_eq_overlapFactors [NeZero D]
     (A : MPSTensor d D) (K l : ℕ)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -826,7 +826,7 @@ norm estimate is derived here.
     \lean{MPSTensor.c3RightOverlapFactorES}
     \lean{MPSTensor.c3CenteredVirtualResidualES}
     \leanok
-    \uses{def:ground_space_gram, def:fixed_point_proj, def:gram_reshuffle,
+    \uses{def:fixed_point_proj, def:gram_reshuffle,
         thm:spectator_boundary_hilbert_factorization}
     Let $A$ be an MPS tensor, let $\Omega_K$ be the set of length-$K$ words
     in the physical alphabet, and let
@@ -868,7 +868,8 @@ norm estimate is derived here.
     \lean{MPSTensor.c3_centeredVirtualResidualES_norm_le}
     \lean{MPSTensor.IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric}
     \leanok
-    \uses{def:c3_centered_overlap_factors_residual, def:primitive_mps}
+    \uses{def:c3_centered_overlap_factors_residual, def:ground_space_gram,
+        def:primitive_mps}
     For every $K\in\N$, the common overlap factors have fiber formulas
     \begin{align}
         (F_KX)_{u,j}&=A^jX_u,&

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -820,31 +820,56 @@ norm estimate is derived here.
     $\lVert J_K\rVert$.  No FNW or Nachtergaele contraction estimate enters.
 \end{proof}
 
-\begin{theorem}[Centered overlap factorization and geometric bound]
-    \label{thm:c3_centered_overlap_factorization_geometric}
+\begin{definition}[Common overlap factors and centered residual]
+    \label{def:c3_centered_overlap_factors_residual}
     \lean{MPSTensor.c3LeftOverlapFactorES}
     \lean{MPSTensor.c3RightOverlapFactorES}
+    \lean{MPSTensor.c3CenteredVirtualResidualES}
+    \leanok
+    \uses{def:ground_space_gram, def:fixed_point_proj, def:gram_reshuffle,
+        thm:spectator_boundary_hilbert_factorization}
+    Let $A$ be an MPS tensor, let $\Omega_K$ be the set of length-$K$ words
+    in the physical alphabet, and let
+    $\mathcal B_K=\bigoplus_{u\in\Omega_K}\MN{D}$ with its
+    Hilbert--Schmidt direct-sum norm.  Define
+    \begin{align}
+        F_K&:\mathcal B_K\longrightarrow
+          \bigoplus_{(u,j)\in\Omega_K\times\Omega_1}\MN{D}
+    \end{align}
+    by applying the one-site left virtual map independently to each prefix
+    fiber.  Define
+    \begin{align}
+        G_K&:\mathcal B_1\longrightarrow
+          \bigoplus_{(u,j)\in\Omega_K\times\Omega_1}\MN{D}
+    \end{align}
+    by applying the length-$K$ tail virtual map independently to each
+    final-site fiber.  These definitions make sense without any nonemptiness
+    assumption on the virtual dimension or on either configuration set.
+
+    When $D\geq1$ and $\rho\in\MN{D}$ is positive definite, set
+    $\mathcal K_\infty=\mathscr R(P_\rho)$ and define the centered virtual
+    residual by
+    \begin{align}
+      R_{K,l}={}&(\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
+        \Gamma^{\mathrm{left}}_{K+l,1}
+        -\mathcal K_\infty^{\oplus\Omega_K}J^{\mathrm{tail}}_K
+        \mathcal K_\infty^{-1}(J^{\mathrm{left}}_1)^\dagger
+        \mathcal K_\infty^{\oplus\Omega_1}.
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Centered overlap factorization and geometric bound]
+    \label{thm:c3_centered_overlap_factorization_geometric}
     \lean{MPSTensor.boundaryFamilyEquiv_c3LeftOverlapFactorES_apply}
     \lean{MPSTensor.boundaryFamilyEquiv_c3RightOverlapFactorES_apply}
     \lean{MPSTensor.c3LeftOverlapFactorES_norm_le}
     \lean{MPSTensor.c3RightOverlapFactorES_norm_le}
-    \lean{MPSTensor.c3CenteredVirtualResidualES}
     \lean{MPSTensor.c3_centeredVirtualResidualES_eq_overlapFactors}
     \lean{MPSTensor.c3_centeredVirtualResidualES_norm_le}
     \lean{MPSTensor.IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric}
     \leanok
-    \uses{def:primitive_mps, def:ground_space_gram, def:fixed_point_proj,
-        def:gram_reshuffle, thm:spectator_boundary_hilbert_factorization}
-    Let $A$ be an MPS tensor, and let $\Omega_K$ be the set of length-$K$ words in the physical alphabet,
-    and let $\mathcal B_K=\bigoplus_{u\in\Omega_K}\MN{D}$ with its
-    Hilbert--Schmidt direct-sum norm.  For every $K\in\N$ there are maps
-    \begin{align}
-        F_K&:\mathcal B_K\longrightarrow
-          \bigoplus_{(u,j)\in\Omega_K\times\Omega_1}\MN{D},&
-        G_K&:\mathcal B_1\longrightarrow
-          \bigoplus_{(u,j)\in\Omega_K\times\Omega_1}\MN{D}
-    \end{align}
-    with fiber formulas
+    \uses{def:c3_centered_overlap_factors_residual, def:primitive_mps}
+    For every $K\in\N$, the common overlap factors have fiber formulas
     \begin{align}
         (F_KX)_{u,j}&=A^jX_u,&
         (G_KZ)_{u,j}&=Z_jA^u,
@@ -854,22 +879,12 @@ norm estimate is derived here.
         \lVert F_K\rVert&\leq\lVert J^{\mathrm{left}}_1\rVert,&
         \lVert G_K\rVert&\leq\lVert J^{\mathrm{tail}}_K\rVert.
     \end{align}
-    These maps and formulas require no nonemptiness assumption on the virtual
-    dimension or on either configuration set; in particular, they remain valid
-    for empty direct sums.
+    The formulas and bounds remain valid for empty direct sums and incur no
+    factor depending on the number of configurations.
 
-    Assume now that $D\geq1$ and that $\rho\in\MN{D}$ is positive definite.
-    Set $\mathcal K_\infty=\mathscr R(P_\rho)$, and define the centered virtual
-    residual by
-    \begin{align}
-      R_{K,l}={}&(\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
-        \Gamma^{\mathrm{left}}_{K+l,1}
-        -\mathcal K_\infty^{\oplus\Omega_K}J^{\mathrm{tail}}_K
-        \mathcal K_\infty^{-1}(J^{\mathrm{left}}_1)^\dagger
-        \mathcal K_\infty^{\oplus\Omega_1}.
-    \end{align}
-    Then the residual factors exactly at this generally nonidentity limiting
-    metric as
+    Assume $D\geq1$ and that $\rho\in\MN{D}$ is positive definite.  The
+    centered residual of Definition~\ref{def:c3_centered_overlap_factors_residual}
+    factors exactly at the generally nonidentity limiting metric as
     \begin{align}
       R_{K,l}
       &=F_K^\dagger
@@ -897,15 +912,17 @@ norm estimate is derived here.
 
 \begin{proof}
     \leanok
-    \uses{thm:spectator_boundary_mixed_gram_centered,
+    \uses{thm:c3_projector_gram_error_telescope,
         thm:boundary_fiberwise_map_norm,
         thm:primitive_ground_space_gram_geometric_fixed_point,
         thm:primitive_tail_virtual_map_norm_uniform}
     Evaluate the two factors on each common direct-sum fiber.  The direct-sum
     norm identity gives the two bounds without a factor counting spectator
     configurations.  Substitute these fiber formulas into the centered
-    mixed-Gram identity to obtain the exact factorization.  Submultiplicativity
-    and Theorem~\ref{thm:boundary_fiberwise_map_norm} give the product bound.
+    residual identity from
+    Theorem~\ref{thm:c3_projector_gram_error_telescope} to obtain the exact
+    factorization.  Submultiplicativity and
+    Theorem~\ref{thm:boundary_fiberwise_map_norm} give the product bound.
     Under primitivity, combine the uniform bound for
     $J^{\mathrm{tail}}_K$ with the squared geometric Gram estimate and absorb
     the fixed norm of $J^{\mathrm{left}}_1$ into the constant.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -820,11 +820,103 @@ norm estimate is derived here.
     $\lVert J_K\rVert$.  No FNW or Nachtergaele contraction estimate enters.
 \end{proof}
 
+\begin{theorem}[Centered overlap factorization and geometric bound]
+    \label{thm:c3_centered_overlap_factorization_geometric}
+    \lean{MPSTensor.c3LeftOverlapFactorES}
+    \lean{MPSTensor.c3RightOverlapFactorES}
+    \lean{MPSTensor.boundaryFamilyEquiv_c3LeftOverlapFactorES_apply}
+    \lean{MPSTensor.boundaryFamilyEquiv_c3RightOverlapFactorES_apply}
+    \lean{MPSTensor.c3LeftOverlapFactorES_norm_le}
+    \lean{MPSTensor.c3RightOverlapFactorES_norm_le}
+    \lean{MPSTensor.c3CenteredVirtualResidualES}
+    \lean{MPSTensor.c3_centeredVirtualResidualES_eq_overlapFactors}
+    \lean{MPSTensor.c3_centeredVirtualResidualES_norm_le}
+    \lean{MPSTensor.IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric}
+    \leanok
+    \uses{def:primitive_mps, def:ground_space_gram, def:fixed_point_proj,
+        def:gram_reshuffle, thm:spectator_boundary_hilbert_factorization}
+    Let $A$ be an MPS tensor, and let $\Omega_K$ be the set of length-$K$ words in the physical alphabet,
+    and let $\mathcal B_K=\bigoplus_{u\in\Omega_K}\MN{D}$ with its
+    Hilbert--Schmidt direct-sum norm.  For every $K\in\N$ there are maps
+    \begin{align}
+        F_K&:\mathcal B_K\longrightarrow
+          \bigoplus_{(u,j)\in\Omega_K\times\Omega_1}\MN{D},&
+        G_K&:\mathcal B_1\longrightarrow
+          \bigoplus_{(u,j)\in\Omega_K\times\Omega_1}\MN{D}
+    \end{align}
+    with fiber formulas
+    \begin{align}
+        (F_KX)_{u,j}&=A^jX_u,&
+        (G_KZ)_{u,j}&=Z_jA^u,
+    \end{align}
+    and norm bounds
+    \begin{align}
+        \lVert F_K\rVert&\leq\lVert J^{\mathrm{left}}_1\rVert,&
+        \lVert G_K\rVert&\leq\lVert J^{\mathrm{tail}}_K\rVert.
+    \end{align}
+    These maps and formulas require no nonemptiness assumption on the virtual
+    dimension or on either configuration set; in particular, they remain valid
+    for empty direct sums.
+
+    Assume now that $D\geq1$ and that $\rho\in\MN{D}$ is positive definite.
+    Set $\mathcal K_\infty=\mathscr R(P_\rho)$, and define the centered virtual
+    residual by
+    \begin{align}
+      R_{K,l}={}&(\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
+        \Gamma^{\mathrm{left}}_{K+l,1}
+        -\mathcal K_\infty^{\oplus\Omega_K}J^{\mathrm{tail}}_K
+        \mathcal K_\infty^{-1}(J^{\mathrm{left}}_1)^\dagger
+        \mathcal K_\infty^{\oplus\Omega_1}.
+    \end{align}
+    Then the residual factors exactly at this generally nonidentity limiting
+    metric as
+    \begin{align}
+      R_{K,l}
+      &=F_K^\dagger
+        (\mathcal K_l-\mathcal K_\infty)^{\oplus
+          (\Omega_K\times\Omega_1)}G_K,
+    \end{align}
+    and hence
+    \begin{align}
+      \lVert R_{K,l}\rVert
+      &\leq \lVert J^{\mathrm{left}}_1\rVert
+        \lVert\mathcal K_l-\mathcal K_\infty\rVert
+        \lVert J^{\mathrm{tail}}_K\rVert.
+    \end{align}
+    If, in addition, $A$ is primitive with fixed-point witness $\rho$, then
+    there are constants $C>0$ and $0<r<1$ such that, for every $K\in\N$ and
+    every $l\geq1$,
+    \begin{align}
+      \lVert R_{K,l}\rVert^2
+      &\leq D^3\bigl(Cr^l\bigr)^2.
+    \end{align}
+    All formulas in this theorem are reconstructed algebra.  They are not
+    sourced formulas and assert neither a full projector-defect estimate nor
+    the FNW--Nachtergaele rational coefficient.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:spectator_boundary_mixed_gram_centered,
+        thm:boundary_fiberwise_map_norm,
+        thm:primitive_ground_space_gram_geometric_fixed_point,
+        thm:primitive_tail_virtual_map_norm_uniform}
+    Evaluate the two factors on each common direct-sum fiber.  The direct-sum
+    norm identity gives the two bounds without a factor counting spectator
+    configurations.  Substitute these fiber formulas into the centered
+    mixed-Gram identity to obtain the exact factorization.  Submultiplicativity
+    and Theorem~\ref{thm:boundary_fiberwise_map_norm} give the product bound.
+    Under primitivity, combine the uniform bound for
+    $J^{\mathrm{tail}}_K$ with the squared geometric Gram estimate and absorb
+    the fixed norm of $J^{\mathrm{left}}_1$ into the constant.
+\end{proof}
+
 \begin{lemma}[Uniform FNW overlapping-window contraction]
     \label{lem:fnw_overlapping_window_contraction}
     \notready
     \discussion{5923}
     \uses{thm:primitive_tail_virtual_map_norm_uniform,
+        thm:c3_centered_overlap_factorization_geometric,
         thm:fixed_point_gram_metric_exact,
         thm:fixed_point_gram_metric_is_unit,
         thm:primitive_ground_space_map_eventual_inverse_gram_bound,
@@ -851,8 +943,12 @@ norm estimate is derived here.
     \cite[Eq.~(6.1)]{Nachtergaele1996Spectral}, derived there from the
     Fannes--Nachtergaele--Werner estimates.  The remaining task is to realize
     that source estimate for the two physical boundary-map projectors above.
-    It must use the exact inverse-Gram range-projector formulas in the limiting
-    fixed-point metric before applying transfer mixing.
+    Theorem~\ref{thm:c3_centered_overlap_factorization_geometric} controls only
+    the centered term in the exact residual telescope.  The three correction
+    terms, their assembly into the full projector defect, the denominator, and
+    the coefficient in equation~(6.1) remain open.  The final argument must use
+    the exact inverse-Gram range-projector formulas in the limiting fixed-point
+    metric before applying transfer mixing.
 \end{lemma}
 
 \begin{lemma}[Uniform open-chain projector-defect threshold]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -771,8 +771,11 @@ and generic prerequisites now include:
     from the \(L^2\) operator norm to entrywise mass.  This is not an FNW or
     Nachtergaele contraction estimate.
   \item Let $A$ be an MPS tensor, let $\Omega_K$ be the set of length-$K$
-    physical words, and let $\mathcal B_K=\bigoplus_{u\in\Omega_K}\MN{D}$.  The two common
-    direct-sum overlap factors
+    physical words, and let $\mathcal B_K=\bigoplus_{u\in\Omega_K}\MN{D}$.
+    Write $J^{\mathrm{left}}_1(X)=(A^jX)_{j\in\Omega_1}$ for the one-site
+    left virtual map and
+    $J^{\mathrm{tail}}_K(X)=(XA^u)_{u\in\Omega_K}$ for the length-$K$ tail
+    virtual map.  The two common direct-sum overlap factors
     \leanid{MPSTensor.c3LeftOverlapFactorES} and
     \leanid{MPSTensor.c3RightOverlapFactorES} have the exact fiber formulas
     \begin{align}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -770,6 +770,59 @@ and generic prerequisites now include:
     decomposition, the geometric power bound, and the dimension conversion
     from the \(L^2\) operator norm to entrywise mass.  This is not an FNW or
     Nachtergaele contraction estimate.
+  \item Let $A$ be an MPS tensor, let $\Omega_K$ be the set of length-$K$
+    physical words, and let $\mathcal B_K=\bigoplus_{u\in\Omega_K}\MN{D}$.  The two common
+    direct-sum overlap factors
+    \leanid{MPSTensor.c3LeftOverlapFactorES} and
+    \leanid{MPSTensor.c3RightOverlapFactorES} have the exact fiber formulas
+    \begin{align}
+      (F_KX)_{u,j}&=A^jX_u,&
+      (G_KZ)_{u,j}&=Z_jA^u,
+    \end{align}
+    recorded by
+    \leanid{MPSTensor.boundaryFamilyEquiv_c3LeftOverlapFactorES_apply} and
+    \leanid{MPSTensor.boundaryFamilyEquiv_c3RightOverlapFactorES_apply}.
+    Their definitions and fiber formulas are valid for arbitrary finite,
+    possibly empty, configuration sets and require no nonzero-cardinality
+    assumption.  Moreover,
+    \leanid{MPSTensor.c3LeftOverlapFactorES_norm_le} and
+    \leanid{MPSTensor.c3RightOverlapFactorES_norm_le} give
+    \begin{align}
+      \lVert F_K\rVert&\leq\lVert J^{\mathrm{left}}_1\rVert,&
+      \lVert G_K\rVert&\leq\lVert J^{\mathrm{tail}}_K\rVert,
+    \end{align}
+    with no loss depending on the number of prefix configurations.
+
+    When $D\geq1$ and $\rho$ is explicitly positive definite, set
+    $\mathcal K_\infty=\mathscr R(P_\rho)$.  The centered residual
+    \leanid{MPSTensor.c3CenteredVirtualResidualES} factors exactly as
+    \begin{align}
+      R_{K,l}
+      &=F_K^\dagger
+        (\mathcal K_l-\mathcal K_\infty)^{\oplus
+          (\Omega_K\times\Omega_1)}G_K
+    \end{align}
+    by
+    \leanid{MPSTensor.c3_centeredVirtualResidualES_eq_overlapFactors}, and
+    \leanid{MPSTensor.c3_centeredVirtualResidualES_norm_le} gives
+    \begin{align}
+      \lVert R_{K,l}\rVert
+      &\leq \lVert J^{\mathrm{left}}_1\rVert
+        \lVert\mathcal K_l-\mathcal K_\infty\rVert
+        \lVert J^{\mathrm{tail}}_K\rVert.
+    \end{align}
+    Thus, if $A$ is primitive with fixed-point witness $\rho$, if $\rho$ is
+    explicitly positive definite, and if $l\geq1$, then
+    \leanid{MPSTensor.IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric}
+    supplies constants $C>0$ and $0<r<1$, independent of $K$, for which
+    \begin{align}
+      \lVert R_{K,l}\rVert^2
+      &\leq D^3\bigl(Cr^l\bigr)^2
+    \end{align}
+    for every $K\in\mathbb N$.  These formulas are reconstructed algebra, not
+    formulas quoted from FNW or Nachtergaele.  They control only the centered
+    term and prove neither the full projector defect nor the rational
+    coefficient in equation~(6.1).
   \item For each length \(n\), let \(\mathcal K_n\) be the ground-space
     Gram, and whenever it is invertible set \(S_n=\mathcal K_n^{-1}\).  Let
     \(\mathcal K_\infty=\mathscr R(P_\rho)\), with \(\rho\) positive
@@ -798,8 +851,10 @@ and generic prerequisites now include:
     length-\(l\) Gram error.  The zeroth-order cancellation uses the explicit
     limiting metric, its inverse, and the virtual-map adjoints; no transfer
     fixed-point equation is needed.  These identities are reconstructed
-    algebra.  The final projector-defect estimate and the FNW--Nachtergaele
-    rational contraction remain open.
+    algebra.  The remaining norm argument must assemble all three correction
+    terms with the centered bound.  The resulting full projector defect, the
+    denominator $1-c\lambda^l$, and the coefficient in equation~(6.1) remain
+    open.
 \end{itemize}
 Fix \(K,L_0\in\mathbb N\) and let
 \(\mathcal H_{K+L_0+1}\) be the \((K+L_0+1)\)-site Euclidean space


### PR DESCRIPTION
## Summary

- define the two rectangular C3 overlap-factor maps with exact `(u,j)` fiber formulas;
- prove direct-sum norm bounds with no spectator-cardinality loss, including empty configurations;
- factor the centered C3 virtual residual exactly through the nonidentity limiting Gram error;
- derive the centered residual operator-norm product bound;
- combine the merged Gram and tail-map estimates into a squared geometric bound uniform in `K`;
- synchronize Chapter 13 and the martingale paper-gap inventory.

## Main declarations

- `MPSTensor.c3LeftOverlapFactorES`
- `MPSTensor.c3RightOverlapFactorES`
- `MPSTensor.c3LeftOverlapFactorES_norm_le`
- `MPSTensor.c3RightOverlapFactorES_norm_le`
- `MPSTensor.c3_centeredVirtualResidualES_eq_overlapFactors`
- `MPSTensor.c3_centeredVirtualResidualES_norm_le`
- `MPSTensor.IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric`

## Scope

The exact factorization is reconstructed algebra from the existing centered mixed-pairing identity. The primitive corollary assumes `[NeZero D]`, `IsPrimitiveMPS A ρ`, explicit `ρ.PosDef`, and `1 ≤ l`, and retains the factor `D^3` in the squared estimate. It is uniform in the spectator length `K` and introduces no factor such as `d^(K/2)`.

This controls only the centered term of the projector-residual telescope. The three correction-term norm assembly, full projector defect, denominator, and FNW/Nachtergaele Eq. (6.1) rational coefficient remain open.

Closes #5981
Parent #5923

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/CenteredOverlapFactor.lean`
- targeted aggregator/integrity check
- source-level blueprint declaration synchronization
- reader-facing prose and targeted tenkz lint
- `git diff --check main...HEAD`
- no `sorry`, `admit`, or new axioms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean algebra and documentation sync on an already-isolated ParentHamiltonian track; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`CenteredOverlapFactor.lean`** with the rectangular overlap factors **`c3LeftOverlapFactorES`** / **`c3RightOverlapFactorES`**, exact `(u,j)` fiber laws, and direct-sum norm bounds that do **not** scale with prefix configuration count (including empty index types).
> 
> Defines **`c3CenteredVirtualResidualES`** and proves it factors as **F_K† (K_l − K_∞) G_K**, with a product operator-norm bound and, for primitive MPS with explicit **`ρ.PosDef`**, a **squared geometric** estimate **‖R_{K,l}‖² ≤ D³(Cr^l)²** uniform in spectator length **K**.
> 
> Chapter 13 blueprint and **`cpgsv21_martingale_overlap.tex`** are updated to record these results and to state that only the **centered** telescope term is bounded—the three correction terms, full projector defect, and FNW/Nachtergaele Eq. (6.1) coefficient remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0cd7755231888193cf13345378f88d9acd0bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->