### PR TITLE
feat(MPS/MPU): expose the second-cut source metric

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -23,6 +23,7 @@ import TNLean.MPS.MPU.SourceUClosedNetwork
 import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SourceUOpenTail
 import TNLean.MPS.MPU.SourceURangeTransport
+import TNLean.MPS.MPU.SourceUSecondCutMetric
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.ThreeFormSpan

--- a/TNLean/MPS/MPU/SourceUSecondCutMetric.lean
+++ b/TNLean/MPS/MPU/SourceUSecondCutMetric.lean
@@ -14,7 +14,7 @@ Gram entry. The metric is $H_2=Z_2Z_2^\dagger$; no result identifies $H_2$
 with the identity or asserts an ambient coisometry.
 
 These are the exact second-cut identities used in the closed contraction of
-arXiv:1703.09188, equation `uUnitary`, lines 545--556.
+arXiv:1703.09188, equation `uUnitary`, lines 545--557.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -45,7 +45,7 @@ theorem sourceX₂_mul_conjTranspose_eq_sourceCutM₂_mul_secondCutMetric
 /-- The ordinary source-u Gram entry with the exact second-cut metric
 $H_2=Z_2Z_2^\dagger$ and all eight virtual and physical indices explicit.
 
-Source: arXiv:1703.09188, equation `uUnitary`, lines 545--556. -/
+Source: arXiv:1703.09188, equation `uUnitary`, lines 545--557. -/
 theorem sourceU_gram_apply_eq_secondCutMetric
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
     (p q : Fin d × Fin d) :

--- a/TNLean/MPS/MPU/SourceUSecondCutMetric.lean
+++ b/TNLean/MPS/MPU/SourceUSecondCutMetric.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceUClosedNetwork
+
+/-!
+# The second-cut metric in the closed source-u network
+
+This file factors the second-cut range projector through the right inverse
+$Z_2$ and exposes the resulting eight-index formula for the ordinary source-u
+Gram entry. The metric is $H_2=Z_2Z_2^\dagger$; no result identifies $H_2$
+with the identity or asserts an ambient coisometry.
+
+These are the exact second-cut identities used in the closed contraction of
+arXiv:1703.09188, equation `uUnitary`, lines 545--556.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- Exact second-cut range-projector factorization through the right inverse.
+
+Source: arXiv:1703.09188, equations `Z1Z2` and `YZ=1`, lines 495--506. -/
+theorem sourceX₂_mul_conjTranspose_eq_sourceCutM₂_mul_secondCutMetric
+    : sourceX₂ U * (sourceX₂ U)ᴴ =
+      sourceCutM₂ U * (sourceZ₂ U * (sourceZ₂ U)ᴴ) * (sourceCutM₂ U)ᴴ := by
+  have hXZ : sourceCutM₂ U * sourceZ₂ U = sourceX₂ U := by
+    rw [sourceCutM₂_eq_sourceX₂_mul_sourceY₂, Matrix.mul_assoc,
+      sourceY₂_mul_sourceZ₂, Matrix.mul_one]
+  calc
+    sourceX₂ U * (sourceX₂ U)ᴴ =
+        (sourceCutM₂ U * sourceZ₂ U) * (sourceCutM₂ U * sourceZ₂ U)ᴴ := by
+      rw [hXZ]
+    _ = sourceCutM₂ U * (sourceZ₂ U * (sourceZ₂ U)ᴴ) * (sourceCutM₂ U)ᴴ := by
+      rw [Matrix.conjTranspose_mul]
+      simp only [Matrix.mul_assoc]
+
+
+/-- The ordinary source-u Gram entry with the exact second-cut metric
+$H_2=Z_2Z_2^\dagger$ and all eight virtual and physical indices explicit.
+
+Source: arXiv:1703.09188, equation `uUnitary`, lines 545--556. -/
+theorem sourceU_gram_apply_eq_secondCutMetric
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (p q : Fin d × Fin d) :
+    (∑ lr : Fin ℓ[U] × Fin r[U],
+      sourceU U ρ hρ lr q * star (sourceU U ρ hρ lr p)) =
+      ∑ β : Fin D, ∑ δ : Fin D, ∑ γ : Fin D, ∑ α : Fin D,
+      ∑ j : Fin d, ∑ a : Fin D, ∑ k : Fin d, ∑ c : Fin D,
+        ρ α γ *
+          doubleLayerTensor (physicalAdjointTensor U) q.1 p.1
+            (finProdFinEquiv (γ, α)) (finProdFinEquiv (β, δ)) *
+          (U q.2 j β a *
+            (sourceZ₂ U * (sourceZ₂ U)ᴴ) (j, a) (k, c) *
+              star (U p.2 k δ c)) := by
+  rw [sourceU_gram_apply_eq_closed_output_letter]
+  simp_rw [sourceX₂_mul_conjTranspose_eq_sourceCutM₂_mul_secondCutMetric U]
+  let H := sourceZ₂ U * (sourceZ₂ U)ᴴ
+  have hentry (β δ : Fin D) (i i' : Fin d) :
+      (sourceCutM₂ U * H * (sourceCutM₂ U)ᴴ) (β, i) (δ, i') =
+        ∑ j : Fin d, ∑ a : Fin D, ∑ k : Fin d, ∑ c : Fin D,
+          U i j β a * H (j, a) (k, c) * star (U i' k δ c) := by
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Fintype.sum_prod_type, sourceCutM₂_apply]
+    simp_rw [Finset.sum_mul]
+    let f := fun (j : Fin d) (a : Fin D) (k : Fin d) (c : Fin D) ↦
+      U i j β a * H (j, a) (k, c) * star (U i' k δ c)
+    change (∑ k, ∑ c, ∑ j, ∑ a, f j a k c) =
+      ∑ j, ∑ a, ∑ k, ∑ c, f j a k c
+    calc
+      _ = ∑ k, ∑ j, ∑ c, ∑ a, f j a k c := by
+        apply Finset.sum_congr rfl
+        intro k _
+        exact Finset.sum_comm
+      _ = ∑ j, ∑ k, ∑ c, ∑ a, f j a k c := Finset.sum_comm
+      _ = ∑ j, ∑ k, ∑ a, ∑ c, f j a k c := by
+        apply Finset.sum_congr rfl
+        intro j _
+        apply Finset.sum_congr rfl
+        intro k _
+        exact Finset.sum_comm
+      _ = _ := by
+        apply Finset.sum_congr rfl
+        intro j _
+        exact Finset.sum_comm
+  apply Finset.sum_congr rfl
+  intro β _
+  apply Finset.sum_congr rfl
+  intro δ _
+  apply Finset.sum_congr rfl
+  intro γ _
+  apply Finset.sum_congr rfl
+  intro α _
+  rw [hentry]
+  dsimp only [H]
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro a _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  rw [Finset.mul_sum]
+
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1991,6 +1991,49 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     trace gives the displayed closed trace.
 \end{proof}
 
+\begin{theorem}[Second-cut metric factorization]
+    \label{thm:mpu_source_u_second_cut_metric}
+    \lean{MPOTensor.sourceX₂_mul_conjTranspose_eq_sourceCutM₂_mul_secondCutMetric}
+    \leanok
+    \uses{thm:mpu_source_factorizations,thm:mpu_source_factor_right_inverses}
+    Define the second-cut metric by $H_2=Z_2Z_2^\dagger$.  Then the range
+    projector of the second source cut factors as
+    \begin{align}
+      X_2X_2^\dagger=M_2H_2M_2^\dagger.
+    \end{align}
+    This is a factorization through the chosen right inverse; it does not
+    assert that $H_2$, $X_2X_2^\dagger$, or $M_2M_2^\dagger$ is the identity.
+\end{theorem}
+
+\begin{proof}\leanok
+    From $M_2=X_2Y_2$ and $Y_2Z_2=1$ one obtains $M_2Z_2=X_2$.
+    Multiply this identity by its adjoint and reassociate the three factors.
+\end{proof}
+
+\begin{theorem}[Source-$u$ Gram entry with the second-cut metric]
+    \label{thm:mpu_source_u_gram_second_cut_metric}
+    \lean{MPOTensor.sourceU_gram_apply_eq_secondCutMetric}
+    \leanok
+    \uses{thm:mpu_source_u_gram_closed_output_letter,
+        thm:mpu_source_u_second_cut_metric}
+    With $H_2=Z_2Z_2^\dagger$, the ordinary source-$u$ Gram entry is
+    \begin{align}
+      \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+      =\sum_{\beta,\delta,\gamma,\alpha,j,a,k,c}
+        &\rho_{\alpha,\gamma}
+        (W_{\mathrm{out}}^{q_1p_1})_{(\gamma,\alpha),(\beta,\delta)}\\
+        &\quad\cdot U^{q_2j}_{\beta,a}
+        (H_2)_{(j,a),(k,c)}\overline{U^{p_2k}_{\delta,c}}.
+    \end{align}
+    The $q$ factors are unstarred and the $p$ factors are starred.
+\end{theorem}
+
+\begin{proof}\leanok
+    Substitute the second-cut metric factorization into the closed
+    output-letter formula and expand both matrix products.  Reordering the
+    finite sums gives the displayed eight-index expression.
+\end{proof}
+
 % The equality and range-insertion step remains tracked by issue #5971.
 \begin{remark}[Scope of the closed source-$u$ formulas]
     The first theorem rewrites the ordinary source-$u$ Gram entry, while the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2006,6 +2006,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_source_factorizations,thm:mpu_source_factor_right_inverses}
     From $M_2=X_2Y_2$ and $Y_2Z_2=1$ one obtains $M_2Z_2=X_2$.
     Multiply this identity by its adjoint and reassociate the three factors.
 \end{proof}
@@ -2016,7 +2017,10 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \leanok
     \uses{thm:mpu_source_u_gram_closed_output_letter,
         thm:mpu_source_u_second_cut_metric}
-    With $H_2=Z_2Z_2^\dagger$, the ordinary source-$u$ Gram entry is
+    Let $\mathcal U$ be an MPO tensor, let $\rho$ be positive definite,
+    and let $p,q\in\Fin d\times\Fin d$ be the retained physical pairs.
+    No MPU or positive-dimension hypothesis is required.  With
+    $H_2=Z_2Z_2^\dagger$, the ordinary source-$u$ Gram entry is
     \begin{align}
       \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
       =\sum_{\beta,\delta,\gamma,\alpha,j,a,k,c}
@@ -2029,6 +2033,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_source_u_gram_closed_output_letter,
+        thm:mpu_source_u_second_cut_metric}
     Substitute the second-cut metric factorization into the closed
     output-letter formula and expand both matrix products.  Reordering the
     finite sums gives the displayed eight-index expression.


### PR DESCRIPTION
## Summary

- prove the exact range-projector factorization
  \[
  X_2X_2^\dagger=M_2(Z_2Z_2^\dagger)M_2^\dagger
  \]
- expand the ordinary source-$u$ Gram entry into the exact eight-index closed formula with $H_2=Z_2Z_2^\dagger$
- add focused Chapter 28 entries with exact q-unstarred/p-starred and doubled-bond orientation

## Mathematical scope

This PR exposes the nontrivial second-cut metric but does not replace it by the identity. It asserts no ambient $H_2=1$, $X_2X_2^\dagger=1$, $M_2M_2^\dagger=1$, $Y_2Y_2^\dagger=1$, coefficient identity, or source-$u$ isometry/rank. The final sandwiched replacement remains #5982.

## Validation

- direct Lean and targeted module/MPU builds
- generated imports current
- intermediate blueprint sync/reverse coverage pass with no forward references
- prose, integrity, line-length, whitespace, and diff checks

Closes #5986.
Leaves #5982 open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive formalization and documentation in the MPU source-u algebra layer; no changes to runtime behavior, auth, or data paths.
> 
> **Overview**
> Adds formal proofs and Chapter 28 blueprint text for the **second-cut metric** \(H_2 = Z_2 Z_2^\dagger\) in the closed source-\(u\) network.
> 
> The new Lean module proves **\(X_2 X_2^\dagger = M_2 H_2 M_2^\dagger\)** (range projector factored through the right inverse \(Z_2\)) and rewrites the ordinary source-\(u\) Gram entry from the existing closed output-letter formula into an **eight-index** sum with \(H_2\) and explicit virtual/physical indices. The MPU aggregate import is updated accordingly.
> 
> The exposition stresses that these are **exact factorizations**, not claims that \(H_2\) or the range projectors equal the identity; downstream sandwiched replacement stays out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211e33d9989bf29f559a94b6d2548fe67efc2b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->