### PR TITLE
refactor(Lean): simplify measured compilation hotspots

### DIFF
--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -111,30 +111,18 @@ theorem mul_mem_cumulativeSpan_add (A : MPSTensor d D) {m n : ℕ}
     {x y : Matrix (Fin D) (Fin D) ℂ}
     (hx : x ∈ cumulativeSpan A m) (hy : y ∈ cumulativeSpan A n) :
     x * y ∈ cumulativeSpan A (m + n) := by
-  -- `cumulativeSpan` is defined as a `span`, so we can use binary span induction.
-  refine Submodule.span_induction₂
-      (s := {M | ∃ w : List (Fin d), w.length ≤ m ∧ M = evalWord A w})
-      (t := {M | ∃ w : List (Fin d), w.length ≤ n ∧ M = evalWord A w})
-      (p := fun x y _ _ => x * y ∈ cumulativeSpan A (m + n))
-      ?_ ?_ ?_ ?_ ?_ ?_ ?_
-      (by simpa [cumulativeSpan] using hx)
-      (by simpa [cumulativeSpan] using hy)
-  · intro x y hx hy
+  -- Matrix multiplication is bilinear, so generator closure extends to both spans.
+  apply LinearMap.BilinMap.apply_apply_mem_of_mem_span
+    (P' := cumulativeSpan A (m + n))
+    (s := {M | ∃ w : List (Fin d), w.length ≤ m ∧ M = evalWord A w})
+    (t := {M | ∃ w : List (Fin d), w.length ≤ n ∧ M = evalWord A w})
+    (B := LinearMap.mul ℂ (Matrix (Fin D) (Fin D) ℂ))
+  · intro x hx y hy
     rcases hx with ⟨w₁, hw₁, rfl⟩
     rcases hy with ⟨w₂, hw₂, rfl⟩
     exact evalWord_mul_evalWord_mem_cumulativeSpan A hw₁ hw₂
-  · intro y _hy
-    simp [zero_mul]
-  · intro x _hx
-    simp [mul_zero]
-  · intro x₁ x₂ y _ _ _ hx₁ hx₂
-    simpa [add_mul] using (cumulativeSpan A (m + n)).add_mem hx₁ hx₂
-  · intro x y₁ y₂ _ _ _ hy₁ hy₂
-    simpa [mul_add] using (cumulativeSpan A (m + n)).add_mem hy₁ hy₂
-  · intro r x y _ _ hxy
-    simpa [smul_mul_assoc] using (cumulativeSpan A (m + n)).smul_mem r hxy
-  · intro r x y _ _ hxy
-    simpa [mul_smul_comm] using (cumulativeSpan A (m + n)).smul_mem r hxy
+  · exact hx
+  · exact hy
 
 /-- Every element of the algebra span lies in some cumulative span.
 
@@ -146,12 +134,12 @@ theorem mem_cumulativeSpan_of_mem_algSpan (A : MPSTensor d D)
   | mem x hxS =>
     rcases hxS with ⟨i, rfl⟩
     refine ⟨1, ?_⟩
-    simpa [evalWord] using
+    simpa only [evalWord, Matrix.mul_one] using
       (mem_cumulativeSpan_generator (A := A) (n := 1) (w := [i]) (by simp))
   | algebraMap r =>
     refine ⟨0, ?_⟩
-    simpa [Algebra.algebraMap_eq_smul_one] using
-      (cumulativeSpan A 0).smul_mem r (one_mem_cumulativeSpan A 0)
+    rw [Algebra.algebraMap_eq_smul_one]
+    exact (cumulativeSpan A 0).smul_mem r (one_mem_cumulativeSpan A 0)
   | add x y _ _ ihx ihy =>
     rcases ihx with ⟨Nx, hNx⟩
     rcases ihy with ⟨Ny, hNy⟩

--- a/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
@@ -451,6 +451,30 @@ private theorem pairToRightAssoc_mul_rightAssocToPairInverse
 
 /-! ### Fourfold F-move identities -/
 
+private theorem rightTripleSynthesis_mul_printedFMatrix_entry
+    (a b c d e : Λ)
+    (xa : Fin (Fus.bondDim a)) (xb : Fin (Fus.bondDim b))
+    (xc : Fin (Fus.bondDim c))
+    (mu : Fin (Fus.fusionMultiplicity a b e))
+    (nu : Fin (Fus.fusionMultiplicity e c d))
+    (z : Fin (Fus.bondDim d)) :
+    (∑ f : Λ, ∑ lambda : Fin (Fus.fusionMultiplicity b c f),
+      ∑ sigma : Fin (Fus.fusionMultiplicity a f d),
+        (∑ y : Fin (Fus.bondDim f),
+          Fus.fusionTensor b c f lambda (xb, xc) y *
+            Fus.fusionTensor a f d sigma (xa, y) z) *
+          Fus.printedFMatrix a b c d ⟨f, lambda, sigma⟩ ⟨e, mu, nu⟩) =
+      ∑ y : Fin (Fus.bondDim e),
+        Fus.fusionTensor a b e mu (xa, xb) y *
+          Fus.fusionTensor e c d nu (y, xc) z := by
+  have h := congrArg
+    (fun M => M ⟨⟨xa, xb⟩, xc⟩ ⟨⟨e, mu, nu⟩, z⟩)
+      (Fus.rightTripleSynthesis_mul_printedFMatrix a b c d)
+  simpa only [Matrix.mul_apply, rightTripleSynthesis, kroneckerMap_apply,
+    Matrix.one_apply, mul_ite, mul_one, mul_zero, Fintype.sum_prod_type,
+    Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
+    leftTripleSynthesis] using h
+
 /-- The first edge of the three-edge path is the printed F-move on the first
 three tensor factors, with the last fusion multiplicity and final bond
 coordinate unchanged.
@@ -475,13 +499,8 @@ theorem leftInnerFourfoldSynthesis_mul_leftAssocToLeftInnerPrintedFMatrix
     Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
     Finset.sum_dite_irrel, Finset.sum_const_zero, Finset.sum_dite_eq',
     cast_eq, leftAssocFourfoldSynthesis]
-  have hF (yg : Fin (Fus.bondDim g)) := congrArg
-    (fun M => M ⟨⟨xa, xb⟩, xc⟩ ⟨⟨f, mu, nu⟩, yg⟩)
-      (Fus.rightTripleSynthesis_mul_printedFMatrix a b c g)
-  simp only [Matrix.mul_apply, rightTripleSynthesis, kroneckerMap_apply,
-    Matrix.one_apply, mul_ite, mul_one, mul_zero, Fintype.sum_prod_type,
-    Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
-    leftTripleSynthesis] at hF
+  have hF (yg : Fin (Fus.bondDim g)) :=
+    Fus.rightTripleSynthesis_mul_printedFMatrix_entry a b c g f xa xb xc mu nu yg
   have hSum := congrArg
     (fun q => ∑ yg, q yg * Fus.fusionTensor g d e rho (yg, xd) z)
     (funext hF)
@@ -532,13 +551,8 @@ theorem middleFourfoldSynthesis_mul_leftInnerToMiddlePrintedFMatrix
     Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
     Finset.sum_dite_irrel, Finset.sum_const_zero, Finset.sum_dite_eq',
     cast_eq, Finset.sum_ite_irrel, leftInnerFourfoldSynthesis]
-  have hF (yh : Fin (Fus.bondDim h)) := congrArg
-    (fun M => M ⟨⟨xa, yh⟩, xd⟩ ⟨⟨g, lambda, rho⟩, z⟩)
-      (Fus.rightTripleSynthesis_mul_printedFMatrix a h d e)
-  simp only [Matrix.mul_apply, rightTripleSynthesis, kroneckerMap_apply,
-    Matrix.one_apply, mul_ite, mul_one, mul_zero, Fintype.sum_prod_type,
-    Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
-    leftTripleSynthesis] at hF
+  have hF (yh : Fin (Fus.bondDim h)) :=
+    Fus.rightTripleSynthesis_mul_printedFMatrix_entry a h d e g xa yh xd lambda rho z
   have hSum := congrArg
     (fun q => ∑ yh, Fus.fusionTensor b c h sigma (xb, xc) yh * q yh)
     (funext hF)
@@ -591,13 +605,8 @@ theorem rightAssocFourfoldSynthesis_mul_middleToRightAssocPrintedFMatrix
     Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
     Finset.sum_dite_irrel, Finset.sum_const_zero, Finset.sum_dite_eq',
     cast_eq, middleFourfoldSynthesis]
-  have hF (yi : Fin (Fus.bondDim i)) := congrArg
-    (fun M => M ⟨⟨xb, xc⟩, xd⟩ ⟨⟨h, sigma, omega⟩, yi⟩)
-      (Fus.rightTripleSynthesis_mul_printedFMatrix b c d i)
-  simp only [Matrix.mul_apply, rightTripleSynthesis, kroneckerMap_apply,
-    Matrix.one_apply, mul_ite, mul_one, mul_zero, Fintype.sum_prod_type,
-    Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
-    leftTripleSynthesis] at hF
+  have hF (yi : Fin (Fus.bondDim i)) :=
+    Fus.rightTripleSynthesis_mul_printedFMatrix_entry b c d i h xb xc xd sigma omega yi
   have hSum := congrArg
     (fun q => ∑ yi, q yi * Fus.fusionTensor a i e kappa (xa, yi) z)
     (funext hF)
@@ -648,13 +657,8 @@ theorem pairFourfoldSynthesis_mul_leftAssocToPairPrintedFMatrix
     Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
     Finset.sum_dite_irrel, Finset.sum_const_zero, Finset.sum_dite_eq',
     cast_eq, Finset.sum_ite_irrel, leftAssocFourfoldSynthesis]
-  have hF (yf : Fin (Fus.bondDim f)) := congrArg
-    (fun M => M ⟨⟨yf, xc⟩, xd⟩ ⟨⟨g, nu, rho⟩, z⟩)
-      (Fus.rightTripleSynthesis_mul_printedFMatrix f c d e)
-  simp only [Matrix.mul_apply, rightTripleSynthesis, kroneckerMap_apply,
-    Matrix.one_apply, mul_ite, mul_one, mul_zero, Fintype.sum_prod_type,
-    Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
-    leftTripleSynthesis] at hF
+  have hF (yf : Fin (Fus.bondDim f)) :=
+    Fus.rightTripleSynthesis_mul_printedFMatrix_entry f c d e g yf xc xd nu rho z
   have hSum := congrArg
     (fun q => ∑ yf, Fus.fusionTensor a b f mu (xa, xb) yf * q yf)
     (funext hF)
@@ -708,13 +712,8 @@ theorem rightAssocFourfoldSynthesis_mul_pairToRightAssocPrintedFMatrix
     Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
     Finset.sum_dite_irrel, Finset.sum_const_zero, Finset.sum_dite_eq',
     cast_eq, Finset.sum_ite_irrel, pairFourfoldSynthesis]
-  have hF (yj : Fin (Fus.bondDim j)) := congrArg
-    (fun M => M ⟨⟨xa, xb⟩, yj⟩ ⟨⟨f, mu, tau⟩, z⟩)
-      (Fus.rightTripleSynthesis_mul_printedFMatrix a b j e)
-  simp only [Matrix.mul_apply, rightTripleSynthesis, kroneckerMap_apply,
-    Matrix.one_apply, mul_ite, mul_one, mul_zero, Fintype.sum_prod_type,
-    Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte, Fintype.sum_sigma,
-    leftTripleSynthesis] at hF
+  have hF (yj : Fin (Fus.bondDim j)) :=
+    Fus.rightTripleSynthesis_mul_printedFMatrix_entry a b j e f xa xb yj mu tau z
   have hSum := congrArg
     (fun q => ∑ yj, Fus.fusionTensor c d j gamma (xc, xd) yj * q yj)
     (funext hF)

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -624,6 +624,17 @@ abstracted — record why, so it is not re-proposed).
   below one second in the declaration profiler, and a clean full-source check
   completes in 15.39 seconds.
 
+### Fourfold F-move entry normalization
+- **Pattern:** five fourfold synthesis proofs separately took one matrix entry of
+  `rightTripleSynthesis_mul_printedFMatrix` and ran the same dependent-sum
+  normalization.
+- **Reuse:** the private theorem
+  `rightTripleSynthesis_mul_printedFMatrix_entry` records the normalized scalar
+  identity once; each fourfold proof specializes it to the relevant subtree.
+- **Result:** the declaration profiler's cumulative `simp` time falls from
+  7.47 to 7.14 seconds. Across five forced isolated rebuilds on the same warm
+  dependency cache, median user CPU falls from 14.19 to 13.44 seconds.
+
 ### Positive-congruence similarity evaluation
 - **Pattern:** the spectral-radius proof repeatedly unfolded `similarityMap`
   and asked broad `simp` calls to rediscover the same inverse and Hermitian

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -631,9 +631,21 @@ abstracted — record why, so it is not re-proposed).
 - **Reuse:** the private theorem
   `rightTripleSynthesis_mul_printedFMatrix_entry` records the normalized scalar
   identity once; each fourfold proof specializes it to the relevant subtree.
-- **Result:** the declaration profiler's cumulative `simp` time falls from
-  7.47 to 7.14 seconds. Across five forced isolated rebuilds on the same warm
-  dependency cache, median user CPU falls from 14.19 to 13.44 seconds.
+- **Result:** across five forced isolated rebuilds on one warm dependency cache,
+  median Lake time falls from 5.60 to 5.50 seconds, wall time from 7.37 to
+  7.24 seconds, and user CPU from 15.23 to 14.91 seconds.
+
+### Bilinear closure of cumulative word spans
+- **Pattern:** the cumulative-span multiplication proof expanded binary span
+  induction into seven branches, then normalized linearity with broad `simp`
+  calls.
+- **Reuse:** `LinearMap.BilinMap.apply_apply_mem_of_mem_span` extends matrix
+  multiplication from pairs of word generators to both spans; only the
+  generator-product lemma remains local.
+- **Result:** across five forced isolated rebuilds on one warm dependency cache,
+  median Lake time falls from 4.40 to 2.80 seconds, wall time from 6.74 to
+  4.55 seconds, and user CPU from 6.54 to 3.17 seconds. No event in the optimized
+  file exceeds the profiler's 100-millisecond reporting threshold.
 
 ### Positive-congruence similarity evaluation
 - **Pattern:** the spectral-radius proof repeatedly unfolded `similarityMap`


### PR DESCRIPTION
## What changed

- extract one private scalar-entry form of `rightTripleSynthesis_mul_printedFMatrix` and reuse it in five fourfold F-move proofs
- replace the seven-branch cumulative-span multiplication induction with Mathlib's compiled bilinear span-closure theorem
- narrow two broad simplifications in the algebra-adjoin induction
- record both promoted patterns and controlled timing evidence

Public theorem names, signatures, imports, and mathematical statements are unchanged.

## Measured impact

Each comparison uses five forced isolated rebuilds on the same commit and warm dependency cache.

### `Algebra.BurnsideMatrix`

| Metric | Baseline median | Optimized median | Change |
| --- | ---: | ---: | ---: |
| Lake job time | 4.40 s | 2.80 s | -36.4% |
| command wall time | 6.74 s | 4.55 s | -32.5% |
| user CPU | 6.54 s | 3.17 s | -51.5% |

No event in the optimized file exceeds the profiler's 100 ms reporting threshold.

### `MPDO.CompleteZipperFusionPentagon`

| Metric | Baseline median | Optimized median | Change |
| --- | ---: | ---: | ---: |
| Lake job time | 5.60 s | 5.50 s | -1.8% |
| command wall time | 7.37 s | 7.24 s | -1.8% |
| user CPU | 15.23 s | 14.91 s | -2.1% |

## Validation

- targeted builds for both changed Lean modules
- source-positioned Lean profiler checks
- `lake build` (10,038 jobs)
- `lake build lint_style` (141 jobs)
- `git diff --check`
- proof-integrity greps for `sorry`, `admit`, and `axiom`
- two independent read-only Lean reviews: no findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are internal proof structure and documentation only; no API or mathematical statement changes, with modest compile-time wins on affected proofs.
> 
> **Overview**
> This is a **proof refactor** with no change to public theorem names, signatures, or mathematical statements.
> 
> In **CompleteZipperFusionPentagon**, a private lemma **`rightTripleSynthesis_mul_printedFMatrix_entry`** centralizes the scalar matrix-entry identity that five fourfold F-move synthesis proofs previously derived by taking one entry of **`rightTripleSynthesis_mul_printedFMatrix`** and repeating the same dependent-sum normalization. Each consumer now specializes that lemma instead of duplicating the **`congrArg` + `simp`** block.
> 
> In **BurnsideMatrix**, **`mul_mem_cumulativeSpan_add`** no longer uses seven-case **`span_induction₂`** and broad **`simp`** for linearity. It applies **`LinearMap.BilinMap.apply_apply_mem_of_mem_span`** for matrix multiplication on the two cumulative word spans, leaving only the generator product case local.
> 
> **`docs/tactic_patterns.md`** documents both patterns and records measured build/profiler improvements on warm-cache isolated rebuilds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b809cc149ea8dcc0341f06e10cf48e707ae3e28d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->