### PR TITLE
feat(MPS/MPU): preserve supplied witnesses under reblocking

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -26,6 +26,7 @@ import TNLean.MPS.MPU.SourceURangeTransport
 import TNLean.MPS.MPU.SourceUSecondCutMetric
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
+import TNLean.MPS.MPU.SuppliedWitnessReblocking
 import TNLean.MPS.MPU.ThreeFormSpan
 import TNLean.MPS.MPU.TransferMatrix
 import TNLean.MPS.MPU.TransferStabilization

--- a/TNLean/MPS/MPU/SimpleBlocking.lean
+++ b/TNLean/MPS/MPU/SimpleBlocking.lean
@@ -370,22 +370,23 @@ private theorem trace_listProd_local {n : Type*} [Fintype n] [DecidableEq n]
       rw [← hprod, sandwich_listProd_local a b P hpair _ (by simp) hrot]
       simp [mul_comm, mul_left_comm]
 
-/-- For an MPU, witnesses satisfying `simple2` automatically satisfy
-`simple1` with the same witnesses.
+/-- For specified witnesses, MPU unitarity and `simple2` recover `simple1`
+without changing either witness.
 
 The two- and three-site constant physical configurations give respectively
 $x^2=\delta_{ij}$ and $x^3=\delta_{ij}$ for
 $x=(a|W^{ij}|b)$.  These identities force $x=\delta_{ij}$.
 
-Source: arXiv:1703.09188, corollary following Proposition III.3,
-lines 442--446. -/
-theorem IsMPU.isMPUSimple_of_simple2 {U : MPOTensor d D} (hU : IsMPU U)
+Source: arXiv:1703.09188, Definition III.2 and the corollary following
+Proposition III.3, lines 363--374 and 442--446. -/
+theorem IsMPU.simple1_of_simple2_supplied {U : MPOTensor d D} (hU : IsMPU U)
     (a b : Fin (D * D) → ℂ)
     (h₂ : ∀ i j k l : Fin d,
       doubleLayerTensor U i j * doubleLayerTensor U k l =
         doubleLayerTensor U i j * Matrix.vecMulVec b a *
           doubleLayerTensor U k l) :
-    IsMPUSimple U := by
+    ∀ i j : Fin d,
+      a ⬝ᵥ (doubleLayerTensor U i j *ᵥ b) = if i = j then 1 else 0 := by
   classical
   let P : Matrix (Fin (D * D)) (Fin (D * D)) ℂ → Prop :=
     fun A ↦ ∃ i j, A = doubleLayerTensor U i j
@@ -419,7 +420,6 @@ theorem IsMPU.isMPUSimple_of_simple2 {U : MPOTensor d D} (hU : IsMPU U)
         subst j
         rfl
     simpa [l, σ, τ, List.map_ofFn, List.prod_ofFn, Matrix.one_apply, hστ] using hentry
-  refine ⟨a, b, ?_, h₂⟩
   intro i j
   let x := a ⬝ᵥ (doubleLayerTensor U i j *ᵥ b)
   have hx2 : x ^ 2 = if i = j then 1 else 0 := hpower 2 (by omega) i j
@@ -431,6 +431,20 @@ theorem IsMPU.isMPUSimple_of_simple2 {U : MPOTensor d D} (hU : IsMPU U)
     exact hx3'
   · rw [if_neg hij] at hx2 hx3 ⊢
     exact sq_eq_zero_iff.mp hx2
+
+/-- For an MPU, witnesses satisfying `simple2` automatically satisfy
+`simple1` with the same witnesses.
+
+Source: arXiv:1703.09188, corollary following Proposition III.3,
+lines 442--446. -/
+theorem IsMPU.isMPUSimple_of_simple2 {U : MPOTensor d D} (hU : IsMPU U)
+    (a b : Fin (D * D) → ℂ)
+    (h₂ : ∀ i j k l : Fin d,
+      doubleLayerTensor U i j * doubleLayerTensor U k l =
+        doubleLayerTensor U i j * Matrix.vecMulVec b a *
+          doubleLayerTensor U k l) :
+    IsMPUSimple U :=
+  ⟨a, b, hU.simple1_of_simple2_supplied a b h₂, h₂⟩
 
 /-- MPU simplicity is preserved by blocking an already simple tensor by any
 positive factor.
@@ -494,21 +508,25 @@ theorem IsMPUSimple.blockTensor {U : MPOTensor d D} (hU : IsMPUSimple U)
       obtain ⟨k, rfl⟩ := hA
       exact ⟨_, _, rfl⟩
 
-/-- If a positive direct block of an MPU is simple, then the direct block one
-site longer is simple with the same witnesses.
+/-- Supplied `simple2` witnesses persist when a direct block is extended by
+one site; the suffix/prefix windows preserve the exact witnesses.
 
-The `simple2` contraction is applied to the suffix of the first blocked word
-and the prefix of the second blocked word, so the original order of all local
-letters is preserved.  MPU unitarity then recovers `simple1` for those same
-witnesses.
-
-Source: arXiv:1703.09188, corollary following Proposition III.3,
-lines 442--446. -/
-theorem IsMPU.blockTensor_succ_isMPUSimple {U : MPOTensor d D} (hU : IsMPU U)
-    {k : ℕ} (hk : 0 < k) (hsimple : IsMPUSimple (MPOTensor.blockTensor U k)) :
-    IsMPUSimple (MPOTensor.blockTensor U (k + 1)) := by
+Source: arXiv:1703.09188, corollary following Proposition III.3, lines
+442--446. -/
+theorem blockTensor_succ_simple2_of_supplied
+    {d D : ℕ} {U : MPOTensor d D} {k : ℕ}
+    (a b : Fin (D * D) → ℂ)
+    (h₂ : ∀ i j m l : Fin (MPSTensor.blockPhysDim d k),
+      doubleLayerTensor (blockTensor U k) i j *
+          doubleLayerTensor (blockTensor U k) m l =
+        doubleLayerTensor (blockTensor U k) i j * Matrix.vecMulVec b a *
+          doubleLayerTensor (blockTensor U k) m l) :
+    ∀ I J K L : Fin (MPSTensor.blockPhysDim d (k + 1)),
+      doubleLayerTensor (blockTensor U (k + 1)) I J *
+          doubleLayerTensor (blockTensor U (k + 1)) K L =
+        doubleLayerTensor (blockTensor U (k + 1)) I J * Matrix.vecMulVec b a *
+          doubleLayerTensor (blockTensor U (k + 1)) K L := by
   classical
-  obtain ⟨a, b, _, h₂⟩ := hsimple
   let W := doubleLayerTensor U
   let suffixIndex (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
       Fin (MPSTensor.blockPhysDim d k) :=
@@ -556,22 +574,33 @@ theorem IsMPU.blockTensor_succ_isMPUSimple {U : MPOTensor d D} (hU : IsMPU U)
     rw [List.ofFn_succ', List.ofFn_succ', List.concat_eq_append,
       List.concat_eq_append, evalWord_append W _ _ _ _ (by simp)]
     simp
-  have h₂succ (I J K L : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      doubleLayerTensor (MPOTensor.blockTensor U (k + 1)) I J *
-          doubleLayerTensor (MPOTensor.blockTensor U (k + 1)) K L =
-        doubleLayerTensor (MPOTensor.blockTensor U (k + 1)) I J *
-          Matrix.vecMulVec b a *
-            doubleLayerTensor (MPOTensor.blockTensor U (k + 1)) K L := by
-    simp only [doubleLayerTensor_blockTensor, blockTensor_apply,
-      MPSTensor.wordOfBlock]
-    rw [hfirst I J, hlast K L]
-    have h := congrArg
-      (fun X ↦ W (MPSTensor.decodeBlock d (k + 1) I 0)
-          (MPSTensor.decodeBlock d (k + 1) J 0) * X *
-        W (MPSTensor.decodeBlock d (k + 1) K (Fin.last k))
-          (MPSTensor.decodeBlock d (k + 1) L (Fin.last k)))
-      (hmiddle I J K L)
-    simpa only [Matrix.mul_assoc] using h
+  intro I J K L
+  simp only [doubleLayerTensor_blockTensor, blockTensor_apply,
+    MPSTensor.wordOfBlock]
+  rw [hfirst I J, hlast K L]
+  have h := congrArg
+    (fun X ↦ W (MPSTensor.decodeBlock d (k + 1) I 0)
+        (MPSTensor.decodeBlock d (k + 1) J 0) * X *
+      W (MPSTensor.decodeBlock d (k + 1) K (Fin.last k))
+        (MPSTensor.decodeBlock d (k + 1) L (Fin.last k)))
+    (hmiddle I J K L)
+  simpa only [Matrix.mul_assoc] using h
+
+/-- If a positive direct block of an MPU is simple, then the direct block one
+site longer is simple with the same witnesses.
+
+The `simple2` contraction is applied to the suffix of the first blocked word
+and the prefix of the second blocked word, so the original order of all local
+letters is preserved.  MPU unitarity then recovers `simple1` for those same
+witnesses.
+
+Source: arXiv:1703.09188, corollary following Proposition III.3,
+lines 442--446. -/
+theorem IsMPU.blockTensor_succ_isMPUSimple {U : MPOTensor d D} (hU : IsMPU U)
+    {k : ℕ} (hk : 0 < k) (hsimple : IsMPUSimple (MPOTensor.blockTensor U k)) :
+    IsMPUSimple (MPOTensor.blockTensor U (k + 1)) := by
+  obtain ⟨a, b, _, h₂⟩ := hsimple
+  have h₂succ := blockTensor_succ_simple2_of_supplied (a := a) (b := b) h₂
   exact (hU.blockTensor (k + 1) (by omega)).isMPUSimple_of_simple2 a b h₂succ
 
 /-- Once a positive direct blocking of an MPU is simple, every longer direct

--- a/TNLean/MPS/MPU/SuppliedWitnessReblocking.lean
+++ b/TNLean/MPS/MPU/SuppliedWitnessReblocking.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.MPU.SimpleBlocking
 # Reblocking supplied MPU-simple witnesses
 
 This file preserves specified `simple1` and `simple2` witnesses when a direct
-physical block is extended by two sites. The proof uses the suffix of the
+physical block is extended by one or two sites. The proof uses the suffix of the
 first word and prefix of the second word, so no existentially chosen witnesses
 replace the supplied pair.
 
@@ -22,8 +22,11 @@ open Matrix
 
 namespace MPOTensor
 
-/-- Supplied `simple2` witnesses persist when a positive direct block is
-extended by one site; the suffix/prefix windows preserve the exact witnesses. -/
+/-- Supplied `simple2` witnesses persist when a direct block is extended by
+one site; the suffix/prefix windows preserve the exact witnesses.
+
+Source: arXiv:1703.09188, corollary following Proposition III.3, lines
+442--446. -/
 theorem blockTensor_succ_simple2_of_supplied
     {d D : ℕ} {U : MPOTensor d D} {k : ℕ}
     (a b : Fin (D * D) → ℂ)
@@ -99,7 +102,7 @@ theorem blockTensor_succ_simple2_of_supplied
 
 /-- Supplied `simple2` witnesses persist at the common direct block two sites
 longer, by two exact suffix/prefix window extensions. -/
-private theorem blockTensor_add_two_simple2
+private lemma blockTensor_add_two_simple2
     {d D : ℕ} {U : MPOTensor d D} {k : ℕ}
     (a b : Fin (D * D) → ℂ)
     (h₂ : ∀ i j m l : Fin (MPSTensor.blockPhysDim d k),
@@ -116,7 +119,7 @@ private theorem blockTensor_add_two_simple2
   have h₂₂ := blockTensor_succ_simple2_of_supplied (a := a) (b := b) h₂₁
   simpa only [Nat.add_assoc, Nat.reduceAdd] using h₂₂
 
-private theorem trace_mul_rankOne_mul_supplied {n : Type*} [Fintype n]
+private lemma trace_mul_rankOne_mul_supplied {n : Type*} [Fintype n]
     (a b : n → ℂ) (A X : Matrix n n ℂ) :
     Matrix.trace (A * Matrix.vecMulVec b a * X) =
       a ⬝ᵥ ((X * A) *ᵥ b) := by
@@ -125,7 +128,10 @@ private theorem trace_mul_rankOne_mul_supplied {n : Type*} [Fintype n]
   simp [dotProduct, mul_comm]
 
 /-- For specified witnesses, MPU unitarity and `simple2` recover `simple1`
-without changing either witness. -/
+without changing either witness.
+
+Source: arXiv:1703.09188, Definition III.2 and the corollary following
+Proposition III.3, lines 363--374 and 442--446. -/
 theorem IsMPU.simple1_of_simple2_supplied
     {d D : ℕ} {U : MPOTensor d D} (hU : IsMPU U)
     (a b : Fin (D * D) → ℂ)
@@ -202,8 +208,12 @@ theorem IsMPU.simple1_of_simple2_supplied
   · rw [if_neg hij] at hx2 hx3 ⊢
     exact sq_eq_zero_iff.mp hx2
 
-/-- Exact supplied witnesses extend from a direct block of length `k` to the
-common overlapping-window block of length `k+2`, without existential repackaging. -/
+/-- Exact supplied witnesses extend from a direct block of length $k$ to the
+common overlapping-window block of length $k+2$, without replacing them by
+existentially chosen witnesses.
+
+Source: arXiv:1703.09188, corollary following Proposition III.3, lines
+442--446. -/
 theorem IsMPU.blockTensor_add_two_simple_contractions_of_supplied
     {d D : ℕ} {U : MPOTensor d D} (hU : IsMPU U) {k : ℕ}
     (a b : Fin (D * D) → ℂ)

--- a/TNLean/MPS/MPU/SuppliedWitnessReblocking.lean
+++ b/TNLean/MPS/MPU/SuppliedWitnessReblocking.lean
@@ -6,102 +6,20 @@ Authors: TNLean contributors
 import TNLean.MPS.MPU.SimpleBlocking
 
 /-!
-# Reblocking supplied MPU-simple witnesses
+# Two-step reblocking of supplied MPU-simple witnesses
 
-This file preserves specified `simple1` and `simple2` witnesses when a direct
-physical block is extended by one or two sites. The proof uses the suffix of the
-first word and prefix of the second word, so no existentially chosen witnesses
-replace the supplied pair.
+This file applies the shared supplied-witness reblocking machinery twice, preserving the
+specified `simple2` witnesses at a direct block two sites longer, and combines the result with
+`simple1` for the same witnesses.
 
 Source: arXiv:1703.09188, corollary following Proposition III.3, lines
 442--446.
 -/
 
-open scoped Matrix BigOperators ComplexOrder
-open Matrix
+open scoped Matrix
 
 namespace MPOTensor
 
-/-- Supplied `simple2` witnesses persist when a direct block is extended by
-one site; the suffix/prefix windows preserve the exact witnesses.
-
-Source: arXiv:1703.09188, corollary following Proposition III.3, lines
-442--446. -/
-theorem blockTensor_succ_simple2_of_supplied
-    {d D : ℕ} {U : MPOTensor d D} {k : ℕ}
-    (a b : Fin (D * D) → ℂ)
-    (h₂ : ∀ i j m l : Fin (MPSTensor.blockPhysDim d k),
-      doubleLayerTensor (blockTensor U k) i j *
-          doubleLayerTensor (blockTensor U k) m l =
-        doubleLayerTensor (blockTensor U k) i j * Matrix.vecMulVec b a *
-          doubleLayerTensor (blockTensor U k) m l) :
-    ∀ I J K L : Fin (MPSTensor.blockPhysDim d (k + 1)),
-      doubleLayerTensor (blockTensor U (k + 1)) I J *
-          doubleLayerTensor (blockTensor U (k + 1)) K L =
-        doubleLayerTensor (blockTensor U (k + 1)) I J * Matrix.vecMulVec b a *
-          doubleLayerTensor (blockTensor U (k + 1)) K L := by
-  classical
-  let W := doubleLayerTensor U
-  let suffixIndex (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      Fin (MPSTensor.blockPhysDim d k) :=
-    (MPSTensor.decodeBlockEquiv d k).symm
-      (fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
-  let prefixIndex (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      Fin (MPSTensor.blockPhysDim d k) :=
-    (MPSTensor.decodeBlockEquiv d k).symm
-      (fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.castSucc)
-  have hmiddle (I J K L : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      evalWord W
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) *
-        evalWord W
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) K x.castSucc)
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) L x.castSucc) =
-      evalWord W
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
-          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) *
-        Matrix.vecMulVec b a *
-          evalWord W
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) K x.castSucc)
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) L x.castSucc) := by
-    have h := h₂ (suffixIndex I) (suffixIndex J) (prefixIndex K) (prefixIndex L)
-    simpa only [doubleLayerTensor_blockTensor, blockTensor_apply,
-      MPSTensor.wordOfBlock, MPSTensor.decodeBlock_decodeBlockEquiv_symm,
-      W, suffixIndex, prefixIndex] using h
-  have hfirst (I J : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      evalWord W (List.ofFn (MPSTensor.decodeBlock d (k + 1) I))
-          (List.ofFn (MPSTensor.decodeBlock d (k + 1) J)) =
-        W (MPSTensor.decodeBlock d (k + 1) I 0)
-            (MPSTensor.decodeBlock d (k + 1) J 0) *
-          evalWord W
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) := by
-    rw [List.ofFn_succ, List.ofFn_succ, evalWord_cons]
-  have hlast (I J : Fin (MPSTensor.blockPhysDim d (k + 1))) :
-      evalWord W (List.ofFn (MPSTensor.decodeBlock d (k + 1) I))
-          (List.ofFn (MPSTensor.decodeBlock d (k + 1) J)) =
-        evalWord W
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.castSucc)
-            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.castSucc) *
-          W (MPSTensor.decodeBlock d (k + 1) I (Fin.last k))
-            (MPSTensor.decodeBlock d (k + 1) J (Fin.last k)) := by
-    rw [List.ofFn_succ', List.ofFn_succ', List.concat_eq_append,
-      List.concat_eq_append, evalWord_append W _ _ _ _ (by simp)]
-    simp
-  intro I J K L
-  simp only [doubleLayerTensor_blockTensor, blockTensor_apply,
-    MPSTensor.wordOfBlock]
-  rw [hfirst I J, hlast K L]
-  have h := congrArg
-    (fun X ↦ W (MPSTensor.decodeBlock d (k + 1) I 0)
-        (MPSTensor.decodeBlock d (k + 1) J 0) * X *
-      W (MPSTensor.decodeBlock d (k + 1) K (Fin.last k))
-        (MPSTensor.decodeBlock d (k + 1) L (Fin.last k)))
-    (hmiddle I J K L)
-  simpa only [Matrix.mul_assoc] using h
-
-/-- Supplied `simple2` witnesses persist at the common direct block two sites
-longer, by two exact suffix/prefix window extensions. -/
 private lemma blockTensor_add_two_simple2
     {d D : ℕ} {U : MPOTensor d D} {k : ℕ}
     (a b : Fin (D * D) → ℂ)
@@ -118,95 +36,6 @@ private lemma blockTensor_add_two_simple2
   have h₂₁ := blockTensor_succ_simple2_of_supplied (a := a) (b := b) h₂
   have h₂₂ := blockTensor_succ_simple2_of_supplied (a := a) (b := b) h₂₁
   simpa only [Nat.add_assoc, Nat.reduceAdd] using h₂₂
-
-private lemma trace_mul_rankOne_mul_supplied {n : Type*} [Fintype n]
-    (a b : n → ℂ) (A X : Matrix n n ℂ) :
-    Matrix.trace (A * Matrix.vecMulVec b a * X) =
-      a ⬝ᵥ ((X * A) *ᵥ b) := by
-  rw [Matrix.trace_mul_comm (A * Matrix.vecMulVec b a) X, ← Matrix.mul_assoc,
-    Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, ← Matrix.mulVec_mulVec]
-  simp [dotProduct, mul_comm]
-
-/-- For specified witnesses, MPU unitarity and `simple2` recover `simple1`
-without changing either witness.
-
-Source: arXiv:1703.09188, Definition III.2 and the corollary following
-Proposition III.3, lines 363--374 and 442--446. -/
-theorem IsMPU.simple1_of_simple2_supplied
-    {d D : ℕ} {U : MPOTensor d D} (hU : IsMPU U)
-    (a b : Fin (D * D) → ℂ)
-    (h₂ : ∀ i j k l : Fin d,
-      doubleLayerTensor U i j * doubleLayerTensor U k l =
-        doubleLayerTensor U i j * Matrix.vecMulVec b a *
-          doubleLayerTensor U k l) :
-    ∀ i j : Fin d,
-      a ⬝ᵥ (doubleLayerTensor U i j *ᵥ b) = if i = j then 1 else 0 := by
-  classical
-  intro i j
-  let A := doubleLayerTensor U i j
-  let x := a ⬝ᵥ (A *ᵥ b)
-  have hclosed (N : ℕ) (hN : 1 < N) :
-      Matrix.trace (evalWord (doubleLayerTensor U)
-        (List.ofFn (fun _ : Fin N ↦ i)) (List.ofFn (fun _ : Fin N ↦ j))) =
-        if i = j then 1 else 0 := by
-    let σ : Fin N → Fin d := fun _ ↦ i
-    let τ : Fin N → Fin d := fun _ ↦ j
-    have hentry := congrArg (fun M ↦ M σ τ)
-      (show mpo (doubleLayerTensor U) N =
-          (1 : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) by
-        rw [mpo_doubleLayerTensor, hU.conjTranspose_mpo_mul_mpo hN])
-    rw [mpo_apply, mpoMatrixEntry] at hentry
-    have hστ : σ = τ ↔ i = j := by
-      constructor
-      · intro h
-        exact congrFun h ⟨0, by omega⟩
-      · intro h
-        subst j
-        rfl
-    simpa only [Matrix.one_apply, hστ, σ, τ] using hentry
-  have hA2 : A * A = A * Matrix.vecMulVec b a * A := by
-    exact h₂ i j i j
-  have hx2 : x ^ 2 = if i = j then 1 else 0 := by
-    have h := hclosed 2 (by omega)
-    simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil,
-      Matrix.mul_one] at h
-    change Matrix.trace (A * A) = _ at h
-    rw [hA2, trace_mul_rankOne_mul_supplied, hA2] at h
-    change x ^ 2 = _
-    simpa [x, Matrix.mul_vecMulVec, Matrix.vecMulVec_mul,
-      Matrix.vecMulVec_mulVec, dotProduct_smul, Matrix.dotProduct_mulVec,
-      pow_two] using h
-  have hx3 : x ^ 3 = if i = j then 1 else 0 := by
-    have h := hclosed 3 (by omega)
-    simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil,
-      Matrix.mul_one] at h
-    change Matrix.trace (A * (A * A)) = _ at h
-    have hA3 : A * (A * A) =
-        A * Matrix.vecMulVec b a * (A * Matrix.vecMulVec b a * A) := by
-      calc
-        A * (A * A) = A * (A * Matrix.vecMulVec b a * A) := by rw [hA2]
-        _ = (A * A) * Matrix.vecMulVec b a * A := by
-          simp only [Matrix.mul_assoc]
-        _ = (A * Matrix.vecMulVec b a * A) *
-            Matrix.vecMulVec b a * A := by rw [hA2]
-        _ = _ := by simp only [Matrix.mul_assoc]
-    rw [hA3, trace_mul_rankOne_mul_supplied] at h
-    have hreassoc : A * Matrix.vecMulVec b a * A * A =
-        A * Matrix.vecMulVec b a * (A * A) := by
-      simp only [Matrix.mul_assoc]
-    rw [hreassoc, hA2] at h
-    change x ^ 3 = _
-    simpa [x, Matrix.mul_vecMulVec, Matrix.vecMulVec_mul,
-      Matrix.vecMulVec_mulVec, Matrix.vecMul_smul, Matrix.vecMul_vecMulVec,
-      dotProduct_smul, Matrix.dotProduct_mulVec, smul_eq_mul,
-      pow_succ, pow_two, mul_assoc] using h
-  by_cases hij : i = j
-  · rw [if_pos hij] at hx2 hx3 ⊢
-    have hx3' : x ^ 2 * x = 1 := by simpa [pow_succ] using hx3
-    rw [hx2, one_mul] at hx3'
-    exact hx3'
-  · rw [if_neg hij] at hx2 hx3 ⊢
-    exact sq_eq_zero_iff.mp hx2
 
 /-- Exact supplied witnesses extend from a direct block of length $k$ to the
 common overlapping-window block of length $k+2$, without replacing them by

--- a/TNLean/MPS/MPU/SuppliedWitnessReblocking.lean
+++ b/TNLean/MPS/MPU/SuppliedWitnessReblocking.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SimpleBlocking
+
+/-!
+# Reblocking supplied MPU-simple witnesses
+
+This file preserves specified `simple1` and `simple2` witnesses when a direct
+physical block is extended by two sites. The proof uses the suffix of the
+first word and prefix of the second word, so no existentially chosen witnesses
+replace the supplied pair.
+
+Source: arXiv:1703.09188, corollary following Proposition III.3, lines
+442--446.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+/-- Supplied `simple2` witnesses persist when a positive direct block is
+extended by one site; the suffix/prefix windows preserve the exact witnesses. -/
+theorem blockTensor_succ_simple2_of_supplied
+    {d D : ℕ} {U : MPOTensor d D} {k : ℕ}
+    (a b : Fin (D * D) → ℂ)
+    (h₂ : ∀ i j m l : Fin (MPSTensor.blockPhysDim d k),
+      doubleLayerTensor (blockTensor U k) i j *
+          doubleLayerTensor (blockTensor U k) m l =
+        doubleLayerTensor (blockTensor U k) i j * Matrix.vecMulVec b a *
+          doubleLayerTensor (blockTensor U k) m l) :
+    ∀ I J K L : Fin (MPSTensor.blockPhysDim d (k + 1)),
+      doubleLayerTensor (blockTensor U (k + 1)) I J *
+          doubleLayerTensor (blockTensor U (k + 1)) K L =
+        doubleLayerTensor (blockTensor U (k + 1)) I J * Matrix.vecMulVec b a *
+          doubleLayerTensor (blockTensor U (k + 1)) K L := by
+  classical
+  let W := doubleLayerTensor U
+  let suffixIndex (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+      Fin (MPSTensor.blockPhysDim d k) :=
+    (MPSTensor.decodeBlockEquiv d k).symm
+      (fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
+  let prefixIndex (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+      Fin (MPSTensor.blockPhysDim d k) :=
+    (MPSTensor.decodeBlockEquiv d k).symm
+      (fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.castSucc)
+  have hmiddle (I J K L : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+      evalWord W
+          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
+          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) *
+        evalWord W
+          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) K x.castSucc)
+          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) L x.castSucc) =
+      evalWord W
+          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
+          (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) *
+        Matrix.vecMulVec b a *
+          evalWord W
+            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) K x.castSucc)
+            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) L x.castSucc) := by
+    have h := h₂ (suffixIndex I) (suffixIndex J) (prefixIndex K) (prefixIndex L)
+    simpa only [doubleLayerTensor_blockTensor, blockTensor_apply,
+      MPSTensor.wordOfBlock, MPSTensor.decodeBlock_decodeBlockEquiv_symm,
+      W, suffixIndex, prefixIndex] using h
+  have hfirst (I J : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+      evalWord W (List.ofFn (MPSTensor.decodeBlock d (k + 1) I))
+          (List.ofFn (MPSTensor.decodeBlock d (k + 1) J)) =
+        W (MPSTensor.decodeBlock d (k + 1) I 0)
+            (MPSTensor.decodeBlock d (k + 1) J 0) *
+          evalWord W
+            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.succ)
+            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.succ) := by
+    rw [List.ofFn_succ, List.ofFn_succ, evalWord_cons]
+  have hlast (I J : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+      evalWord W (List.ofFn (MPSTensor.decodeBlock d (k + 1) I))
+          (List.ofFn (MPSTensor.decodeBlock d (k + 1) J)) =
+        evalWord W
+            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) I x.castSucc)
+            (List.ofFn fun x : Fin k ↦ MPSTensor.decodeBlock d (k + 1) J x.castSucc) *
+          W (MPSTensor.decodeBlock d (k + 1) I (Fin.last k))
+            (MPSTensor.decodeBlock d (k + 1) J (Fin.last k)) := by
+    rw [List.ofFn_succ', List.ofFn_succ', List.concat_eq_append,
+      List.concat_eq_append, evalWord_append W _ _ _ _ (by simp)]
+    simp
+  intro I J K L
+  simp only [doubleLayerTensor_blockTensor, blockTensor_apply,
+    MPSTensor.wordOfBlock]
+  rw [hfirst I J, hlast K L]
+  have h := congrArg
+    (fun X ↦ W (MPSTensor.decodeBlock d (k + 1) I 0)
+        (MPSTensor.decodeBlock d (k + 1) J 0) * X *
+      W (MPSTensor.decodeBlock d (k + 1) K (Fin.last k))
+        (MPSTensor.decodeBlock d (k + 1) L (Fin.last k)))
+    (hmiddle I J K L)
+  simpa only [Matrix.mul_assoc] using h
+
+/-- Supplied `simple2` witnesses persist at the common direct block two sites
+longer, by two exact suffix/prefix window extensions. -/
+private theorem blockTensor_add_two_simple2
+    {d D : ℕ} {U : MPOTensor d D} {k : ℕ}
+    (a b : Fin (D * D) → ℂ)
+    (h₂ : ∀ i j m l : Fin (MPSTensor.blockPhysDim d k),
+      doubleLayerTensor (blockTensor U k) i j *
+          doubleLayerTensor (blockTensor U k) m l =
+        doubleLayerTensor (blockTensor U k) i j * Matrix.vecMulVec b a *
+          doubleLayerTensor (blockTensor U k) m l) :
+    ∀ I J K L : Fin (MPSTensor.blockPhysDim d (k + 2)),
+      doubleLayerTensor (blockTensor U (k + 2)) I J *
+          doubleLayerTensor (blockTensor U (k + 2)) K L =
+        doubleLayerTensor (blockTensor U (k + 2)) I J * Matrix.vecMulVec b a *
+          doubleLayerTensor (blockTensor U (k + 2)) K L := by
+  have h₂₁ := blockTensor_succ_simple2_of_supplied (a := a) (b := b) h₂
+  have h₂₂ := blockTensor_succ_simple2_of_supplied (a := a) (b := b) h₂₁
+  simpa only [Nat.add_assoc, Nat.reduceAdd] using h₂₂
+
+private theorem trace_mul_rankOne_mul_supplied {n : Type*} [Fintype n]
+    (a b : n → ℂ) (A X : Matrix n n ℂ) :
+    Matrix.trace (A * Matrix.vecMulVec b a * X) =
+      a ⬝ᵥ ((X * A) *ᵥ b) := by
+  rw [Matrix.trace_mul_comm (A * Matrix.vecMulVec b a) X, ← Matrix.mul_assoc,
+    Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, ← Matrix.mulVec_mulVec]
+  simp [dotProduct, mul_comm]
+
+/-- For specified witnesses, MPU unitarity and `simple2` recover `simple1`
+without changing either witness. -/
+theorem IsMPU.simple1_of_simple2_supplied
+    {d D : ℕ} {U : MPOTensor d D} (hU : IsMPU U)
+    (a b : Fin (D * D) → ℂ)
+    (h₂ : ∀ i j k l : Fin d,
+      doubleLayerTensor U i j * doubleLayerTensor U k l =
+        doubleLayerTensor U i j * Matrix.vecMulVec b a *
+          doubleLayerTensor U k l) :
+    ∀ i j : Fin d,
+      a ⬝ᵥ (doubleLayerTensor U i j *ᵥ b) = if i = j then 1 else 0 := by
+  classical
+  intro i j
+  let A := doubleLayerTensor U i j
+  let x := a ⬝ᵥ (A *ᵥ b)
+  have hclosed (N : ℕ) (hN : 1 < N) :
+      Matrix.trace (evalWord (doubleLayerTensor U)
+        (List.ofFn (fun _ : Fin N ↦ i)) (List.ofFn (fun _ : Fin N ↦ j))) =
+        if i = j then 1 else 0 := by
+    let σ : Fin N → Fin d := fun _ ↦ i
+    let τ : Fin N → Fin d := fun _ ↦ j
+    have hentry := congrArg (fun M ↦ M σ τ)
+      (show mpo (doubleLayerTensor U) N =
+          (1 : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) by
+        rw [mpo_doubleLayerTensor, hU.conjTranspose_mpo_mul_mpo hN])
+    rw [mpo_apply, mpoMatrixEntry] at hentry
+    have hστ : σ = τ ↔ i = j := by
+      constructor
+      · intro h
+        exact congrFun h ⟨0, by omega⟩
+      · intro h
+        subst j
+        rfl
+    simpa only [Matrix.one_apply, hστ, σ, τ] using hentry
+  have hA2 : A * A = A * Matrix.vecMulVec b a * A := by
+    exact h₂ i j i j
+  have hx2 : x ^ 2 = if i = j then 1 else 0 := by
+    have h := hclosed 2 (by omega)
+    simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil,
+      Matrix.mul_one] at h
+    change Matrix.trace (A * A) = _ at h
+    rw [hA2, trace_mul_rankOne_mul_supplied, hA2] at h
+    change x ^ 2 = _
+    simpa [x, Matrix.mul_vecMulVec, Matrix.vecMulVec_mul,
+      Matrix.vecMulVec_mulVec, dotProduct_smul, Matrix.dotProduct_mulVec,
+      pow_two] using h
+  have hx3 : x ^ 3 = if i = j then 1 else 0 := by
+    have h := hclosed 3 (by omega)
+    simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil,
+      Matrix.mul_one] at h
+    change Matrix.trace (A * (A * A)) = _ at h
+    have hA3 : A * (A * A) =
+        A * Matrix.vecMulVec b a * (A * Matrix.vecMulVec b a * A) := by
+      calc
+        A * (A * A) = A * (A * Matrix.vecMulVec b a * A) := by rw [hA2]
+        _ = (A * A) * Matrix.vecMulVec b a * A := by
+          simp only [Matrix.mul_assoc]
+        _ = (A * Matrix.vecMulVec b a * A) *
+            Matrix.vecMulVec b a * A := by rw [hA2]
+        _ = _ := by simp only [Matrix.mul_assoc]
+    rw [hA3, trace_mul_rankOne_mul_supplied] at h
+    have hreassoc : A * Matrix.vecMulVec b a * A * A =
+        A * Matrix.vecMulVec b a * (A * A) := by
+      simp only [Matrix.mul_assoc]
+    rw [hreassoc, hA2] at h
+    change x ^ 3 = _
+    simpa [x, Matrix.mul_vecMulVec, Matrix.vecMulVec_mul,
+      Matrix.vecMulVec_mulVec, Matrix.vecMul_smul, Matrix.vecMul_vecMulVec,
+      dotProduct_smul, Matrix.dotProduct_mulVec, smul_eq_mul,
+      pow_succ, pow_two, mul_assoc] using h
+  by_cases hij : i = j
+  · rw [if_pos hij] at hx2 hx3 ⊢
+    have hx3' : x ^ 2 * x = 1 := by simpa [pow_succ] using hx3
+    rw [hx2, one_mul] at hx3'
+    exact hx3'
+  · rw [if_neg hij] at hx2 hx3 ⊢
+    exact sq_eq_zero_iff.mp hx2
+
+/-- Exact supplied witnesses extend from a direct block of length `k` to the
+common overlapping-window block of length `k+2`, without existential repackaging. -/
+theorem IsMPU.blockTensor_add_two_simple_contractions_of_supplied
+    {d D : ℕ} {U : MPOTensor d D} (hU : IsMPU U) {k : ℕ}
+    (a b : Fin (D * D) → ℂ)
+    (h₂ : ∀ i j m l : Fin (MPSTensor.blockPhysDim d k),
+      doubleLayerTensor (MPOTensor.blockTensor U k) i j *
+          doubleLayerTensor (MPOTensor.blockTensor U k) m l =
+        doubleLayerTensor (MPOTensor.blockTensor U k) i j * Matrix.vecMulVec b a *
+          doubleLayerTensor (MPOTensor.blockTensor U k) m l) :
+    (∀ I J : Fin (MPSTensor.blockPhysDim d (k + 2)),
+      a ⬝ᵥ (doubleLayerTensor (MPOTensor.blockTensor U (k + 2)) I J *ᵥ b) =
+        if I = J then 1 else 0) ∧
+    (∀ I J K L : Fin (MPSTensor.blockPhysDim d (k + 2)),
+      doubleLayerTensor (MPOTensor.blockTensor U (k + 2)) I J *
+          doubleLayerTensor (MPOTensor.blockTensor U (k + 2)) K L =
+        doubleLayerTensor (MPOTensor.blockTensor U (k + 2)) I J * Matrix.vecMulVec b a *
+          doubleLayerTensor (MPOTensor.blockTensor U (k + 2)) K L) := by
+  have h₂add := blockTensor_add_two_simple2 (a := a) (b := b) h₂
+  exact ⟨IsMPU.simple1_of_simple2_supplied (hU.blockTensor (k + 2) (by omega)) a b h₂add,
+    h₂add⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2040,6 +2040,31 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     finite sums gives the displayed eight-index expression.
 \end{proof}
 
+\begin{theorem}[Supplied-witness overlapping reblocking]
+    \label{thm:mpu_supplied_witness_overlapping_reblocking}
+    \lean{MPOTensor.blockTensor_succ_simple2_of_supplied,
+        MPOTensor.IsMPU.simple1_of_simple2_supplied,
+        MPOTensor.IsMPU.blockTensor_add_two_simple_contractions_of_supplied}
+    \leanok
+    \uses{thm:mpu_all_later_simple_blockings,def:mpu_simple}
+    Suppose a direct block of length $K$ satisfies the two-letter simple
+    contraction with specified vectors $(a|$ and $|b)$.  At direct length
+    $K+2$, the suffix of the first blocked word and the prefix of the second
+    blocked word preserve the same insertion $|b)(a|$.  MPU unitarity at
+    lengths two and three then gives, with the same vectors,
+    \begin{align}
+      (a|W^{IJ}|b)&=\delta_{I,J},\\
+      W^{IJ}W^{LM}&=W^{IJ}|b)(a|W^{LM}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Extend the supplied two-letter identity twice by overlapping suffix and
+    prefix windows.  For $x=(a|W^{IJ}|b)$, the constant configurations of
+    lengths two and three give $x^2=\delta_{I,J}$ and
+    $x^3=\delta_{I,J}$, which force $x=\delta_{I,J}$.
+\end{proof}
+
 % The equality and range-insertion step remains tracked by issue #5971.
 \begin{remark}[Scope of the closed source-$u$ formulas]
     The first theorem rewrites the ordinary source-$u$ Gram entry, while the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2046,23 +2046,34 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.IsMPU.simple1_of_simple2_supplied,
         MPOTensor.IsMPU.blockTensor_add_two_simple_contractions_of_supplied}
     \leanok
-    \uses{thm:mpu_all_later_simple_blockings,def:mpu_simple}
-    Suppose a direct block of length $K$ satisfies the two-letter simple
-    contraction with specified vectors $(a|$ and $|b)$.  At direct length
-    $K+2$, the suffix of the first blocked word and the prefix of the second
-    blocked word preserve the same insertion $|b)(a|$.  MPU unitarity at
-    lengths two and three then gives, with the same vectors,
+    \uses{def:mpu,def:mpu_double_layer,
+        thm:mpdo_closed_chain_physical_blocking}
+    Suppose a direct block of length $K$ satisfies the two-letter contraction
+    with specified vectors $(a|$ and $|b)$.  For an arbitrary MPO tensor, one
+    suffix/prefix extension preserves the same insertion $|b)(a|$ at direct
+    length $K+1$.  For any MPU tensor, specified vectors satisfying this
+    two-letter identity also satisfy the one-letter identity with the same
+    vectors.  Applying that implication after two extensions gives, at direct
+    length $K+2$,
     \begin{align}
       (a|W^{IJ}|b)&=\delta_{I,J},\\
       W^{IJ}W^{LM}&=W^{IJ}|b)(a|W^{LM}.
     \end{align}
+    No positivity or nonzero-dimension hypothesis is required.  This is the
+    corollary following Proposition~III.3 in
+    \cite[lines~442--446]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{lem:mpu_blocking,thm:mpu_closed_double_layer,
+        thm:mpu_double_layer_blocking,lem:mpu_mul_adjoint}
     Extend the supplied two-letter identity twice by overlapping suffix and
     prefix windows.  For $x=(a|W^{IJ}|b)$, the constant configurations of
     lengths two and three give $x^2=\delta_{I,J}$ and
-    $x^3=\delta_{I,J}$, which force $x=\delta_{I,J}$.
+    $x^3=\delta_{I,J}$, which force $x=\delta_{I,J}$.  Physical blocking
+    preserves MPU unitarity, so this one-letter identity and the twice-extended
+    two-letter identity hold simultaneously at direct length $K+2$ with the
+    original supplied witnesses.
 \end{proof}
 
 % The equality and range-insertion step remains tracked by issue #5971.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2060,13 +2060,12 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
       W^{IJ}W^{LM}&=W^{IJ}|b)(a|W^{LM}.
     \end{align}
     No positivity or nonzero-dimension hypothesis is required.  This is the
-    corollary following Proposition~III.3 in
-    \cite[lines~442--446]{Cirac2017MPU}.
+    corollary following \cite[Proposition~III.3]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{lem:mpu_blocking,thm:mpu_closed_double_layer,
-        thm:mpu_double_layer_blocking,lem:mpu_mul_adjoint}
+        thm:mpu_double_layer_blocking,lem:mpu_adjoint_mul}
     Extend the supplied two-letter identity twice by overlapping suffix and
     prefix windows.  For $x=(a|W^{IJ}|b)$, the constant configurations of
     lengths two and three give $x^2=\delta_{I,J}$ and


### PR DESCRIPTION
## Summary

- preserve exact supplied `simple2` witnesses under the paper's overlapping suffix/prefix reblocking from $K$ to $K+1$
- apply the construction twice to retain the same witnesses at $K+2$
- recover supplied `simple1` with those same witnesses from the $N=2$ and $N=3$ MPU identities
- synchronize the focused Chapter 28 theorem and proof dependencies

## Mathematical scope

This PR does not choose new witnesses, hide them existentially, or impose positivity/nonzero-dimension hypotheses. It preserves the supplied witnesses exactly. The reflected output-kernel transport remains dependent issue #5988, and the final second-cut metric replacement remains #5982.

## Validation

- direct Lean and targeted module/MPU builds
- clean diagnostics and generated imports
- blueprint sync/reverse coverage: 7061/7061
- prose, integrity, line-length, whitespace, and diff checks
- focused LeanSimplifier review: APPROVE

Closes #5987.
Leaves #5988 and #5982 open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and refactoring in MPU blocking lemmas with blueprint sync; no runtime, auth, or data-path changes.
> 
> **Overview**
> Formalizes **supplied-witness** MPU reblocking: given explicit `a`, `b` and a `simple2` identity at direct block length \(K\), the same witnesses are kept through overlapping suffix/prefix extensions rather than existential `IsMPUSimple` witnesses.
> 
> **`SimpleBlocking.lean`** extracts `IsMPU.simple1_of_simple2_supplied` (MPU unitarity plus `simple2` forces `simple1` for those vectors) and `blockTensor_succ_simple2_of_supplied` (one-site extension preserves `simple2` with the same `|b)(a|` insertion). `isMPUSimple_of_simple2` and `blockTensor_succ_isMPUSimple` are thin wrappers over these lemmas.
> 
> **`SuppliedWitnessReblocking.lean`** applies the one-site step twice to get both `simple1` and `simple2` at length \(K+2\) via `IsMPU.blockTensor_add_two_simple_contractions_of_supplied`, using blocked MPU unitarity for the one-letter contraction.
> 
> Chapter 28 blueprint adds theorem **Supplied-witness overlapping reblocking** with matching Lean labels and proof dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59cbe11c3d57809f36c8ef8f216b036b0d0e5bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->