### PR TITLE
feat(parent-hamiltonian): add pointwise geometric inverse Gram bounds

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
@@ -11,17 +11,23 @@ import TNLean.MPS.ParentHamiltonian.LimitingGramMetric
 # Convergence of inverse MPS Gram operators
 
 For a primitive MPS tensor with a positive-definite transfer fixed point, the
-finite-volume ground-space Gram operators are eventually invertible. Their
-ring inverses satisfy the arbitrary-base Neumann perturbation estimate and
-converge to the inverse of the nonidentity limiting Gram operator
-`Matrix.gramReshuffle (fixedPointProj ρ _)`.
+finite-volume ground-space Gram operators converge geometrically to the
+nonidentity limiting Gram operator
+`Matrix.gramReshuffle (fixedPointProj ρ _)`. Pointwise Neumann estimates give
+invertibility, inverse-norm control, and inverse displacement whenever the
+geometric relative error is less than one. The same estimates apply uniformly
+at the three C3 correction lengths once they hold at the base length.
 
-The same eventual invertibility makes the Hilbert-space boundary maps
-injective. Consequently, their `ContinuousLinearMap.inverseGram` operators
-agree with the ring inverses and obey the same estimate.
+The corresponding Hilbert-space boundary maps are injective under the same
+pointwise condition. Their `ContinuousLinearMap.inverseGram` operators agree
+with the ring inverses and obey the same bounds. Eventual invertibility and
+convergence of the ring inverses are also recorded.
 
 ## Main results
 
+* `MPSTensor.IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds`
+* `MPSTensor.IsPrimitiveMPS.groundSpaceMapES_geometric_inverseGram_bounds`
+* `MPSTensor.geometric_smallness_at_c3_lengths`
 * `MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound`
 * `MPSTensor.IsPrimitiveMPS.groundSpaceGram_ringInverse_tendsto`
 * `MPSTensor.IsPrimitiveMPS.eventually_groundSpaceMapES_injective_and_inverseGram_bound`
@@ -32,6 +38,139 @@ open scoped ComplexOrder Matrix
 namespace MPSTensor
 
 variable {d D : ℕ}
+
+/-- Pointwise geometric control of the finite Gram operators and their ring inverses.
+
+Writing \(K_\infty\) for the reshuffled fixed-point projection and
+\(I_\infty=K_\infty^{-1}\), this theorem produces positive constants
+\(g,c,r\), with \(r<1\) and \(c=\lVert I_\infty\rVert g\), such that
+\(\lVert K_n-K_\infty\rVert\le g r^n\). Whenever \(c r^n<1\), the Gram
+operator is a unit and both its inverse norm and its displacement from
+\(I_\infty\) obey the corresponding Neumann bounds with denominator
+\(1-c r^n\).
+
+The choice of \(g\) preserves the dimension-cubed normalization in the
+available squared Gram estimate; in particular, its transfer-map constant is
+not reused without rescaling. -/
+theorem IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    let Kinf := Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Iinf := Ring.inverse Kinf
+    ∃ g c r : ℝ, 0 < g ∧ 0 < c ∧ 0 < r ∧ r < 1 ∧
+      c = ‖Iinf‖ * g ∧ ∀ n : ℕ, 1 ≤ n →
+        ‖groundSpaceGram A n - Kinf‖ ≤ g * r ^ n ∧
+        (c * r ^ n < 1 →
+          IsUnit (groundSpaceGram A n) ∧
+          ‖Ring.inverse (groundSpaceGram A n)‖ ≤
+            (1 - c * r ^ n)⁻¹ * ‖Iinf‖ ∧
+          ‖Ring.inverse (groundSpaceGram A n) - Iinf‖ ≤
+            (1 - c * r ^ n)⁻¹ * (c * r ^ n) * ‖Iinf‖) := by
+  let Kinf := Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Iinf := Ring.inverse Kinf
+  obtain ⟨C_G, r, hC_G, hr_pos, hr_lt_one, hGramSq⟩ :=
+    hP.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
+  let g := (D : ℝ) ^ 3 * C_G
+  let c := ‖Iinf‖ * g
+  have hD_nat : 1 ≤ D := Nat.one_le_iff_ne_zero.mpr (NeZero.ne D)
+  have hD : 1 ≤ (D : ℝ) ^ 3 := by
+    apply one_le_pow₀
+    exact_mod_cast hD_nat
+  have hg : 0 < g := mul_pos (lt_of_lt_of_le zero_lt_one hD) hC_G
+  have hKinf : IsUnit Kinf := by
+    simpa only [Kinf] using Matrix.gramReshuffle_fixedPointProj_isUnit hρ
+  have hIinf : IsUnit Iinf := by
+    simpa only [Iinf] using hKinf.ringInverse
+  have hIinf_norm : 0 < ‖Iinf‖ := norm_pos_iff.mpr hIinf.ne_zero
+  refine ⟨g, c, r, hg, mul_pos hIinf_norm hg, hr_pos, hr_lt_one, rfl, ?_⟩
+  intro n hn
+  have hGramSq' : ‖groundSpaceGram A n - Kinf‖ ^ 2 ≤
+      (D : ℝ) ^ 3 * (C_G * r ^ n) ^ 2 := by
+    simpa only [Kinf] using hGramSq n hn
+  have hgr_nonneg : 0 ≤ g * r ^ n := by positivity
+  have hGram : ‖groundSpaceGram A n - Kinf‖ ≤ g * r ^ n := by
+    apply (sq_le_sq₀ (norm_nonneg _) hgr_nonneg).1
+    calc
+      ‖groundSpaceGram A n - Kinf‖ ^ 2 ≤
+          (D : ℝ) ^ 3 * (C_G * r ^ n) ^ 2 := hGramSq'
+      _ ≤ ((D : ℝ) ^ 3 * (C_G * r ^ n)) ^ 2 := by
+        nlinarith [sq_nonneg (C_G * r ^ n)]
+      _ = (g * r ^ n) ^ 2 := by simp only [g]; ring
+  refine ⟨hGram, fun hsmall => ?_⟩
+  have hrelative : ‖Iinf‖ * ‖groundSpaceGram A n - Kinf‖ ≤ c * r ^ n := by
+    calc
+      ‖Iinf‖ * ‖groundSpaceGram A n - Kinf‖ ≤ ‖Iinf‖ * (g * r ^ n) :=
+        mul_le_mul_of_nonneg_left hGram (norm_nonneg Iinf)
+      _ = c * r ^ n := by simp only [c]; ring
+  have hunit := NormedRing.isUnit_and_norm_inverse_le_of_norm_mul_norm_sub_le
+    Kinf (groundSpaceGram A n) hKinf (by simpa only [Iinf] using hrelative) hsmall
+  refine ⟨hunit.1, ?_, ?_⟩
+  · simpa only [Iinf] using hunit.2
+  · simpa only [Iinf] using
+      NormedRing.norm_inverse_sub_inverse_le_of_norm_mul_norm_sub_le
+        Kinf (groundSpaceGram A n) hKinf
+          (by simpa only [Iinf] using hrelative) hsmall
+
+/-- Pointwise inverse-Gram bounds for the finite-volume boundary maps.
+
+With \(K_\infty\), \(I_\infty\), \(g\), \(c\), and \(r\) as in
+`groundSpaceGram_geometric_inverse_bounds`, every length \(n\ge 1\) satisfying
+\(c r^n<1\) has an injective boundary map. Its inverse Gram operator equals the
+ring inverse of the finite Gram operator and satisfies the same inverse-norm
+and inverse-displacement estimates. -/
+theorem IsPrimitiveMPS.groundSpaceMapES_geometric_inverseGram_bounds
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    let Kinf := Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Iinf := Ring.inverse Kinf
+    ∃ g c r : ℝ, 0 < g ∧ 0 < c ∧ 0 < r ∧ r < 1 ∧
+      c = ‖Iinf‖ * g ∧ ∀ n : ℕ, 1 ≤ n →
+        ‖groundSpaceGram A n - Kinf‖ ≤ g * r ^ n ∧
+        (c * r ^ n < 1 →
+          ∃ hInj : Function.Injective (groundSpaceMapES A n),
+            ContinuousLinearMap.inverseGram (groundSpaceMapES A n) hInj =
+                Ring.inverse (groundSpaceGram A n) ∧
+            ‖ContinuousLinearMap.inverseGram (groundSpaceMapES A n) hInj‖ ≤
+                (1 - c * r ^ n)⁻¹ * ‖Iinf‖ ∧
+            ‖ContinuousLinearMap.inverseGram (groundSpaceMapES A n) hInj - Iinf‖ ≤
+                (1 - c * r ^ n)⁻¹ * (c * r ^ n) * ‖Iinf‖) := by
+  let Kinf := Matrix.gramReshuffle (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Iinf := Ring.inverse Kinf
+  obtain ⟨g, c, r, hg, hc, hr_pos, hr_lt_one, hc_def, hbounds⟩ :=
+    hP.groundSpaceGram_geometric_inverse_bounds hρ
+  refine ⟨g, c, r, hg, hc, hr_pos, hr_lt_one, hc_def, ?_⟩
+  intro n hn
+  obtain ⟨hGram, hpointwise⟩ := hbounds n hn
+  refine ⟨hGram, fun hsmall => ?_⟩
+  obtain ⟨hGramUnit, hInvNorm, hInvSub⟩ := hpointwise hsmall
+  have hGramInj : Function.Injective (groundSpaceGram A n) :=
+    (ContinuousLinearMap.isUnit_iff_bijective.mp hGramUnit).1
+  have hInj : Function.Injective (groundSpaceMapES A n) := by
+    apply (groundSpaceMapES A n).adjoint_comp_self_injective_iff.mp
+    intro x y hxy
+    apply hGramInj
+    change (groundSpaceMapES A n).adjoint (groundSpaceMapES A n x) =
+      (groundSpaceMapES A n).adjoint (groundSpaceMapES A n y)
+    exact hxy
+  refine ⟨hInj, ?_, ?_, ?_⟩
+  · simpa only [groundSpaceGram] using
+      ContinuousLinearMap.inverseGram_eq_ringInverse (groundSpaceMapES A n) hInj
+  · rw [ContinuousLinearMap.inverseGram_eq_ringInverse]
+    simpa only [groundSpaceGram] using hInvNorm
+  · rw [ContinuousLinearMap.inverseGram_eq_ringInverse]
+    simpa only [groundSpaceGram] using hInvSub
+
+/-- A geometric smallness condition at length \(l\) propagates uniformly in
+\(K\) to the three C3 correction lengths \(l+1\), \(K+l\), and
+\(K+l+1\). -/
+theorem geometric_smallness_at_c3_lengths {c r : ℝ} (hc : 0 < c) (hr_pos : 0 < r)
+    (hr_lt_one : r < 1) {l : ℕ} (hsmall : c * r ^ l < 1) (K : ℕ) :
+    c * r ^ (l + 1) < 1 ∧ c * r ^ (K + l) < 1 ∧ c * r ^ (K + l + 1) < 1 := by
+  have hpow {m : ℕ} (hlm : l ≤ m) : r ^ m ≤ r ^ l :=
+    pow_le_pow_of_le_one hr_pos.le hr_lt_one.le hlm
+  have hsmall_of_le {m : ℕ} (hlm : l ≤ m) : c * r ^ m < 1 :=
+    (mul_le_mul_of_nonneg_left (hpow hlm) hc.le).trans_lt hsmall
+  exact ⟨hsmall_of_le (by omega), hsmall_of_le (by omega), hsmall_of_le (by omega)⟩
 
 /-- For every relative tolerance \(a\) strictly between zero and one, the
 finite-volume Gram operator of a primitive MPS tensor is eventually a unit.

--- a/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
+++ b/TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean
@@ -25,6 +25,7 @@ convergence of the ring inverses are also recorded.
 
 ## Main results
 
+* `MPSTensor.groundSpaceMapES_injective_of_isUnit_groundSpaceGram`
 * `MPSTensor.IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds`
 * `MPSTensor.IsPrimitiveMPS.groundSpaceMapES_geometric_inverseGram_bounds`
 * `MPSTensor.geometric_smallness_at_c3_lengths`
@@ -39,6 +40,20 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+/-- A unit finite-volume Gram operator implies injectivity of the corresponding
+Hilbert-space boundary map. -/
+theorem groundSpaceMapES_injective_of_isUnit_groundSpaceGram {A : MPSTensor d D} {n : ℕ}
+    (hGramUnit : IsUnit (groundSpaceGram A n)) :
+    Function.Injective (groundSpaceMapES A n) := by
+  have hGramInj : Function.Injective (groundSpaceGram A n) :=
+    (ContinuousLinearMap.isUnit_iff_bijective.mp hGramUnit).1
+  apply (groundSpaceMapES A n).adjoint_comp_self_injective_iff.mp
+  intro x y hxy
+  apply hGramInj
+  change (groundSpaceMapES A n).adjoint (groundSpaceMapES A n x) =
+    (groundSpaceMapES A n).adjoint (groundSpaceMapES A n y)
+  exact hxy
+
 /-- Pointwise geometric control of the finite Gram operators and their ring inverses.
 
 Writing \(K_\infty\) for the reshuffled fixed-point projection and
@@ -49,9 +64,8 @@ operator is a unit and both its inverse norm and its displacement from
 \(I_\infty\) obey the corresponding Neumann bounds with denominator
 \(1-c r^n\).
 
-The choice of \(g\) preserves the dimension-cubed normalization in the
-available squared Gram estimate; in particular, its transfer-map constant is
-not reused without rescaling. -/
+The direct choice \(g=\sqrt{D^3} C_G\) is obtained by taking square roots
+of the available squared Gram estimate, without an additional dimension loss. -/
 theorem IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds
     [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
@@ -70,13 +84,12 @@ theorem IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds
   let Iinf := Ring.inverse Kinf
   obtain ⟨C_G, r, hC_G, hr_pos, hr_lt_one, hGramSq⟩ :=
     hP.groundSpaceGram_sub_fixedPointProj_norm_sq_le_geometric
-  let g := (D : ℝ) ^ 3 * C_G
+  let g := Real.sqrt ((D : ℝ) ^ 3) * C_G
   let c := ‖Iinf‖ * g
-  have hD_nat : 1 ≤ D := Nat.one_le_iff_ne_zero.mpr (NeZero.ne D)
-  have hD : 1 ≤ (D : ℝ) ^ 3 := by
-    apply one_le_pow₀
-    exact_mod_cast hD_nat
-  have hg : 0 < g := mul_pos (lt_of_lt_of_le zero_lt_one hD) hC_G
+  have hD_pos : 0 < (D : ℝ) := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hD : 0 < (D : ℝ) ^ 3 := pow_pos hD_pos 3
+  have hg : 0 < g := mul_pos (Real.sqrt_pos.2 hD) hC_G
   have hKinf : IsUnit Kinf := by
     simpa only [Kinf] using Matrix.gramReshuffle_fixedPointProj_isUnit hρ
   have hIinf : IsUnit Iinf := by
@@ -93,8 +106,9 @@ theorem IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds
     calc
       ‖groundSpaceGram A n - Kinf‖ ^ 2 ≤
           (D : ℝ) ^ 3 * (C_G * r ^ n) ^ 2 := hGramSq'
-      _ ≤ ((D : ℝ) ^ 3 * (C_G * r ^ n)) ^ 2 := by
-        nlinarith [sq_nonneg (C_G * r ^ n)]
+      _ = Real.sqrt ((D : ℝ) ^ 3) ^ 2 * (C_G * r ^ n) ^ 2 := by
+        rw [Real.sq_sqrt hD.le]
+      _ = (Real.sqrt ((D : ℝ) ^ 3) * (C_G * r ^ n)) ^ 2 := by ring
       _ = (g * r ^ n) ^ 2 := by simp only [g]; ring
   refine ⟨hGram, fun hsmall => ?_⟩
   have hrelative : ‖Iinf‖ * ‖groundSpaceGram A n - Kinf‖ ≤ c * r ^ n := by
@@ -143,15 +157,8 @@ theorem IsPrimitiveMPS.groundSpaceMapES_geometric_inverseGram_bounds
   obtain ⟨hGram, hpointwise⟩ := hbounds n hn
   refine ⟨hGram, fun hsmall => ?_⟩
   obtain ⟨hGramUnit, hInvNorm, hInvSub⟩ := hpointwise hsmall
-  have hGramInj : Function.Injective (groundSpaceGram A n) :=
-    (ContinuousLinearMap.isUnit_iff_bijective.mp hGramUnit).1
-  have hInj : Function.Injective (groundSpaceMapES A n) := by
-    apply (groundSpaceMapES A n).adjoint_comp_self_injective_iff.mp
-    intro x y hxy
-    apply hGramInj
-    change (groundSpaceMapES A n).adjoint (groundSpaceMapES A n x) =
-      (groundSpaceMapES A n).adjoint (groundSpaceMapES A n y)
-    exact hxy
+  have hInj : Function.Injective (groundSpaceMapES A n) :=
+    groundSpaceMapES_injective_of_isUnit_groundSpaceGram hGramUnit
   refine ⟨hInj, ?_, ?_, ?_⟩
   · simpa only [groundSpaceGram] using
       ContinuousLinearMap.inverseGram_eq_ringInverse (groundSpaceMapES A n) hInj
@@ -251,15 +258,8 @@ theorem IsPrimitiveMPS.eventually_groundSpaceMapES_injective_and_inverseGram_bou
                 (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))‖ := by
   filter_upwards [hP.eventually_groundSpaceGram_isUnit_and_inverse_bound
     hρ ha_pos ha_lt_one] with n hn
-  have hGramInj : Function.Injective (groundSpaceGram A n) :=
-    (ContinuousLinearMap.isUnit_iff_bijective.mp hn.1).1
-  have hInj : Function.Injective (groundSpaceMapES A n) := by
-    apply (groundSpaceMapES A n).adjoint_comp_self_injective_iff.mp
-    intro x y hxy
-    apply hGramInj
-    change (groundSpaceMapES A n).adjoint (groundSpaceMapES A n x) =
-      (groundSpaceMapES A n).adjoint (groundSpaceMapES A n y)
-    exact hxy
+  have hInj : Function.Injective (groundSpaceMapES A n) :=
+    groundSpaceMapES_injective_of_isUnit_groundSpaceGram hn.1
   refine ⟨hInj, ?_, ?_⟩
   · simpa only [groundSpaceGram] using
       ContinuousLinearMap.inverseGram_eq_ringInverse (groundSpaceMapES A n) hInj

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -885,6 +885,121 @@ windows.
     its inverse in the endomorphism ring.
 \end{proof}
 
+The next three results are reconstructed quantitative inverse infrastructure.
+They retain the nonidentity limiting metric $\mathscr R(P_\rho)$, require the
+fixed-point witness $\rho$ to be positive definite, and preserve the
+squared-bound normalization of
+Theorem~\ref{thm:primitive_ground_space_gram_geometric_fixed_point}.  They do
+not estimate a contraction between physical projectors on overlapping
+windows.
+
+\begin{theorem}[Pointwise geometric Gram inverse bounds]
+    \label{thm:primitive_ground_space_gram_geometric_inverse_bounds}
+    \lean{MPSTensor.IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds}
+    \leanok
+    \uses{def:primitive_mps,
+        thm:primitive_ground_space_gram_geometric_fixed_point,
+        thm:fixed_point_gram_metric_is_unit,
+        thm:arbitrary_base_neumann_inverse_bound,
+        thm:arbitrary_base_neumann_inverse_displacement}
+    Let $A$ be a primitive MPS tensor of nonzero bond dimension whose
+    fixed-point witness $\rho$ is positive definite.  Put
+    \begin{align}
+      \mathcal K_\infty&=\mathscr R(P_\rho),&
+      \mathcal I_\infty&=\mathcal K_\infty^{-1}.
+    \end{align}
+    There are constants $g,c,r>0$ with $r<1$ and
+    $c=\lVert\mathcal I_\infty\rVert g$ such that, for every $n\geq1$,
+    \begin{align}
+      \lVert\mathcal K_n-\mathcal K_\infty\rVert
+      &\leq gr^n.
+      \label{eq:primitive_ground_space_gram_geometric_bound}
+    \end{align}
+    Whenever $cr^n<1$, the operator $\mathcal K_n$ is invertible and
+    \begin{align}
+      \lVert\mathcal K_n^{-1}\rVert
+      &\leq\frac{\lVert\mathcal I_\infty\rVert}{1-cr^n},
+      \label{eq:primitive_ground_space_gram_geometric_inverse_norm}\\
+      \lVert\mathcal K_n^{-1}-\mathcal I_\infty\rVert
+      &\leq\frac{cr^n}{1-cr^n}\,
+        \lVert\mathcal I_\infty\rVert.
+      \label{eq:primitive_ground_space_gram_geometric_inverse_displacement}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:primitive_ground_space_gram_geometric_fixed_point,
+        thm:fixed_point_gram_metric_is_unit,
+        thm:arbitrary_base_neumann_inverse_bound,
+        thm:arbitrary_base_neumann_inverse_displacement}
+    Start from the squared estimate
+    $\lVert\mathcal K_n-\mathcal K_\infty\rVert^2
+      \leq D^3(Cr^n)^2$.
+    Taking square roots gives
+    $g=\sqrt{D^3}\,C$ without any additional dimension loss, and hence
+    (\ref{eq:primitive_ground_space_gram_geometric_bound}).  Positive
+    definiteness makes $\mathcal K_\infty$ invertible.  The relative error is
+    at most $\lVert\mathcal I_\infty\rVert gr^n=cr^n$, so the two
+    arbitrary-base Neumann estimates give
+    (\ref{eq:primitive_ground_space_gram_geometric_inverse_norm}) and
+    (\ref{eq:primitive_ground_space_gram_geometric_inverse_displacement}).
+\end{proof}
+
+\begin{theorem}[Pointwise geometric inverse-Gram bounds]
+    \label{thm:primitive_ground_space_map_geometric_inverse_gram_bounds}
+    \lean{MPSTensor.IsPrimitiveMPS.groundSpaceMapES_geometric_inverseGram_bounds}
+    \leanok
+    \uses{def:ground_space_map_es, def:inverse_gram,
+        thm:primitive_ground_space_gram_geometric_inverse_bounds,
+        thm:inverse_gram_identities}
+    Under the hypotheses of
+    Theorem~\ref{thm:primitive_ground_space_gram_geometric_inverse_bounds},
+    there are constants $g,c,r>0$ with $r<1$ and
+    $c=\lVert\mathcal I_\infty\rVert g$ such that
+    (\ref{eq:primitive_ground_space_gram_geometric_bound}) holds for every
+    $n\geq1$.  If $cr^n<1$, then the physical boundary map
+    $\Gamma_n^{\mathrm{ES}}$ is injective, its inverse Gram operator equals
+    $\mathcal K_n^{-1}$, and
+    \begin{align}
+      \lVert S_{\Gamma_n^{\mathrm{ES}}}\rVert
+      &\leq\frac{\lVert\mathcal I_\infty\rVert}{1-cr^n},\\
+      \lVert S_{\Gamma_n^{\mathrm{ES}}}-\mathcal I_\infty\rVert
+      &\leq\frac{cr^n}{1-cr^n}\,
+        \lVert\mathcal I_\infty\rVert.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:primitive_ground_space_gram_geometric_inverse_bounds,
+        thm:inverse_gram_identities}
+    Invertibility of
+    $(\Gamma_n^{\mathrm{ES}})^\dagger\Gamma_n^{\mathrm{ES}}=\mathcal K_n$
+    implies injectivity of $\Gamma_n^{\mathrm{ES}}$.  The inverse-Gram
+    identities identify $S_{\Gamma_n^{\mathrm{ES}}}$ with
+    $\mathcal K_n^{-1}$, so the preceding pointwise bounds apply unchanged.
+\end{proof}
+
+\begin{theorem}[Geometric smallness at the C3 correction lengths]
+    \label{thm:geometric_smallness_at_c3_lengths}
+    \lean{MPSTensor.geometric_smallness_at_c3_lengths}
+    \leanok
+    Let $c>0$ and $0<r<1$.  If $cr^l<1$, then for every $K\geq0$,
+    \begin{align}
+      cr^{l+1}&<1,&
+      cr^{K+l}&<1,&
+      cr^{K+l+1}&<1.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $0<r<1$, the sequence $r^m$ is nonincreasing.  Each of
+    $l+1$, $K+l$, and $K+l+1$ is at least $l$, so every displayed inequality
+    follows from $cr^l<1$.
+\end{proof}
+
 \begin{theorem}[Eventual inverse-Gram control in the limiting metric]
     \label{thm:primitive_ground_space_gram_eventual_inverse_bound}
     \lean{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -885,10 +885,9 @@ windows.
     its inverse in the endomorphism ring.
 \end{proof}
 
-The next three results are reconstructed quantitative inverse infrastructure.
-They retain the nonidentity limiting metric $\mathscr R(P_\rho)$, require the
-fixed-point witness $\rho$ to be positive definite, and preserve the
-squared-bound normalization of
+The next three results give quantitative inverse bounds for the nonidentity
+limiting metric $\mathscr R(P_\rho)$.  They require the fixed-point witness
+$\rho$ to be positive definite and preserve the squared-bound normalization of
 Theorem~\ref{thm:primitive_ground_space_gram_geometric_fixed_point}.  They do
 not estimate a contraction between physical projectors on overlapping
 windows.
@@ -897,11 +896,7 @@ windows.
     \label{thm:primitive_ground_space_gram_geometric_inverse_bounds}
     \lean{MPSTensor.IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds}
     \leanok
-    \uses{def:primitive_mps,
-        thm:primitive_ground_space_gram_geometric_fixed_point,
-        thm:fixed_point_gram_metric_is_unit,
-        thm:arbitrary_base_neumann_inverse_bound,
-        thm:arbitrary_base_neumann_inverse_displacement}
+    \uses{def:primitive_mps}
     Let $A$ be a primitive MPS tensor of nonzero bond dimension whose
     fixed-point witness $\rho$ is positive definite.  Put
     \begin{align}
@@ -985,10 +980,11 @@ windows.
     \label{thm:geometric_smallness_at_c3_lengths}
     \lean{MPSTensor.geometric_smallness_at_c3_lengths}
     \leanok
-    Let $c>0$ and $0<r<1$.  If $cr^l<1$, then for every $K\geq0$,
+    Let $c>0$, let $0<r<1$, and let $l,K\in\mathbb N$.  If $cr^l<1$,
+    then
     \begin{align}
-      cr^{l+1}&<1,&
-      cr^{K+l}&<1,&
+      cr^{l+1}&<1,\\
+      cr^{K+l}&<1,\\
       cr^{K+l+1}&<1.
     \end{align}
 \end{theorem}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -673,6 +673,46 @@ and generic prerequisites now include:
     \leanid{MPSTensor.groundSpaceGram_tendsto_gramReshuffle_fixedPointProj}.
     Their limit is $\mathscr R(P_\rho)$, and the quantitative squared
     estimate has factor $D^3(Cr^n)^2$.
+  \item The reconstructed quantitative inverse infrastructure is
+    \leanid{MPSTensor.IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds}
+    and
+    \leanid{MPSTensor.IsPrimitiveMPS.groundSpaceMapES_geometric_inverseGram_bounds}.
+    Assume that the bond dimension is nonzero and that the primitive fixed-point
+    witness $\rho$ is explicitly positive definite.  Set
+    \begin{align}
+      \mathcal K_\infty&=\mathscr R(P_\rho),&
+      \mathcal I_\infty&=\mathcal K_\infty^{-1}.
+    \end{align}
+    Then there are $g,c,r>0$, with $r<1$ and
+    $c=\lVert\mathcal I_\infty\rVert g$, such that for every $n\geq1$,
+    \begin{align}
+      \lVert\mathcal K_n-\mathcal K_\infty\rVert&\leq gr^n.
+    \end{align}
+    If $cr^n<1$, then $\mathcal K_n$ is invertible and
+    \begin{align}
+      \lVert\mathcal K_n^{-1}\rVert
+      &\leq\frac{\lVert\mathcal I_\infty\rVert}{1-cr^n},\\
+      \lVert\mathcal K_n^{-1}-\mathcal I_\infty\rVert
+      &\leq\frac{cr^n}{1-cr^n}\lVert\mathcal I_\infty\rVert.
+    \end{align}
+    At the same lengths the physical boundary map is injective, its inverse
+    Gram is $\mathcal K_n^{-1}$, and it obeys the same two bounds.  The proof
+    retains the available squared estimate
+    $\lVert\mathcal K_n-\mathcal K_\infty\rVert^2
+      \leq D^3(Cr^n)^2$ and takes square roots directly, giving
+    $g=\sqrt{D^3}\,C$ without any additional dimension loss.  The base is the
+    generally nonidentity operator $\mathscr R(P_\rho)$, not the identity.
+  \item The elementary propagation theorem
+    \leanid{MPSTensor.geometric_smallness_at_c3_lengths} shows that
+    $cr^l<1$ implies
+    \begin{align}
+      cr^{l+1}<1,\qquad cr^{K+l}<1,\qquad cr^{K+l+1}<1
+    \end{align}
+    for every $K\in\mathbb N$.  Thus one base-length smallness hypothesis
+    supplies the three inverse conditions appearing in the C3 correction
+    telescope.  This is quantitative inverse infrastructure only: these
+    results do not prove contraction of the full physical projector defect or
+    the coefficient in Nachtergaele's equation~(6.1).
   \item The generic operator-norm--to--entrywise-Frobenius estimate, its
     reshuffled-Choi corollary, and the safe dimension conversion are
     \leanid{Matrix.toEuclideanCLM_norm_sq_le_sum_norm_sq},
@@ -905,19 +945,26 @@ limiting Gram operator:
 \end{align}
 It does not control $\lVert1-\mathcal K_n\rVert$ in these unweighted
 coordinates, because $\mathscr R(P_\rho)$ is generally not the identity.
-Under the additional hypothesis $\rho>0$, the limiting Gram is invertible and
-\leanid{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceGram_isUnit_and_inverse_bound}
-proves eventual finite-volume invertibility with an arbitrary-base Neumann
-estimate.  Furthermore,
+Under the explicit additional hypothesis that $\rho$ is positive definite,
+the limiting Gram is invertible.  The reconstructed pointwise estimates
+\leanid{MPSTensor.IsPrimitiveMPS.groundSpaceGram_geometric_inverse_bounds} and
+\leanid{MPSTensor.IsPrimitiveMPS.groundSpaceMapES_geometric_inverseGram_bounds}
+perturb around the nonidentity operator $\mathscr R(P_\rho)$ and give the
+inverse and inverse-Gram bounds with denominator $1-cr^n$ whenever
+$cr^n<1$.  The theorem
+\leanid{MPSTensor.geometric_smallness_at_c3_lengths} propagates the base
+condition $cr^l<1$ to the three correction lengths $l+1$, $K+l$, and
+$K+l+1$.  The normalization still descends from the squared estimate with
+factor $D^3$, yielding the norm constant $\sqrt{D^3}\,C$ without additional
+dimension loss; it is not replaced by an identity-centered source constant.
+Furthermore,
 \leanid{MPSTensor.IsPrimitiveMPS.groundSpaceGram_ringInverse_tendsto} proves
 \begin{align}
-  \mathcal K_n^{-1}&\longrightarrow\mathscr R(P_\rho)^{-1},
+  \mathcal K_n^{-1}&\longrightarrow\mathscr R(P_\rho)^{-1}.
 \end{align}
-and
-\leanid{MPSTensor.IsPrimitiveMPS.eventually_groundSpaceMapES_injective_and_inverseGram_bound}
-transfers the quantitative estimate to the inverse Gram of the physical
-boundary map.  The remaining gap is the comparison of the two physical range
-projectors on overlapping windows.
+These results are quantitative inverse infrastructure.  They do not prove the
+full overlapping-window projector contraction or Nachtergaele's
+Equation~(6.1); that physical projector comparison remains open.
 
 In particular, the development does not prove the overlapping-window FNW
 contraction

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1591, 1633 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1587, 1629 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1476, 1518 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1591, 1633 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Summary

- derive pointwise geometric finite-Gram, ring-inverse, and inverse-Gram bounds around the nonidentity limiting Gram `gramReshuffle (fixedPointProj ρ ...)`;
- use the sharp square-root conversion `g = sqrt(D^3) * C_G`, with moving denominator `(1 - c * r^n)⁻¹`;
- propagate one smallness condition uniformly to the C3 lengths `l+1`, `K+l`, and `K+l+1`;
- factor the repeated Gram-unit-to-boundary-map injectivity argument into a shared helper;
- synchronize Chapter 13 and the martingale paper-gap note, explicitly classifying this as reconstructed inverse infrastructure rather than the full FNW/Nachtergaele contraction.

## Guardrails

- the limiting physical Gram is never identified with the identity;
- `ρ.PosDef` remains explicit;
- the squared Gram estimate is converted with `sqrt(D^3)`, not by silently reusing its constant;
- no full projector defect or Nachtergaele Eq. (6.1) coefficient is claimed.

## Verification

- `lake env lean TNLean/MPS/ParentHamiltonian/GramInverseConvergence.lean`
- `git diff --check`
- targeted declaration, blueprint dependency, prose, environment-balance, and source-boundary checks
- independent exact-head mathematical review approved the implementation before the sharpening cleanup; the final head will receive a fresh review

Closes #5990
Refs #5923 #5752 #5993

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formal proofs and documentation in a specialized MPS Gram-convergence area, with no auth, runtime, or broad API surface; mathematical claims are scoped and guardrailed in the PR description.
> 
> **Overview**
> Adds **pointwise geometric inverse infrastructure** for primitive MPS finite-volume ground-space Gram operators, centered on the nonidentity limit `gramReshuffle (fixedPointProj ρ …)` rather than the identity.
> 
> In Lean, `GramInverseConvergence.lean` introduces `groundSpaceGram_geometric_inverse_bounds` and `groundSpaceMapES_geometric_inverseGram_bounds`: geometric displacement `‖K_n − K_∞‖ ≤ g r^n` with `g = √(D³)·C_G` from the existing squared estimate, and whenever `c r^n < 1`, Neumann-style bounds on ring inverses and `inverseGram` with denominator `(1 − c r^n)⁻¹`. **`geometric_smallness_at_c3_lengths`** propagates one base smallness condition to the C3 correction lengths `l+1`, `K+l`, and `K+l+1`. A shared lemma **`groundSpaceMapES_injective_of_isUnit_groundSpaceGram`** replaces duplicated injectivity arguments in the eventual inverse-Gram theorem.
> 
> Chapter 13 blueprint prose and the martingale paper-gap note are aligned with these declarations and **explicitly label the work as reconstructed inverse infrastructure**, not the full overlapping-window FNW/Nachtergaele projector contraction. A minor tenkz disposition line-number tweak reflects the expanded chapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8bb10558a81c2aafeaa754ab556b66d4c6fa016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->