### PR TITLE
refactor(parent-hamiltonian): deduplicate word proofs

### DIFF
--- a/TNLean/MPS/Core.lean
+++ b/TNLean/MPS/Core.lean
@@ -24,3 +24,4 @@ import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.Core.TransferMatrix
+import TNLean.MPS.Core.WordFactor

--- a/TNLean/MPS/Core/WordFactor.lean
+++ b/TNLean/MPS/Core/WordFactor.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Defs
+
+/-!
+# Word-factor identities for matrix product tensors
+
+This file records the elementary extension of a one-letter matrix-factor identity
+to a nonempty physical word.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Letter compatibility extends to every nonempty word. The left and right
+matrix families may be indexed by an arbitrary type. -/
+theorem exists_evalWord_factor_of_letter_compatibility
+    {A : MPSTensor d D} {α : Type*} {F Z : α → Matrix (Fin D) (Fin D) ℂ}
+    (hCompat : ∀ i : Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      ∀ a : α, Z a * A i = F a * Y)
+    (w : List (Fin d)) (hw : w ≠ []) :
+    ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      ∀ a : α, Z a * evalWord A w = F a * Y := by
+  cases w with
+  | nil => cases hw rfl
+  | cons i w =>
+      obtain ⟨Y, hY⟩ := hCompat i
+      refine ⟨Y * evalWord A w, ?_⟩
+      intro a
+      calc
+        Z a * evalWord A (i :: w)
+            = Z a * (A i * evalWord A w) := by simp [evalWord]
+        _ = (Z a * A i) * evalWord A w := by rw [Matrix.mul_assoc]
+        _ = (F a * Y) * evalWord A w := by rw [hY a]
+        _ = F a * (Y * evalWord A w) := by rw [Matrix.mul_assoc]
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -339,6 +339,39 @@ theorem
     blockDiagonal_boundary_last_cyclicRestrict_component_mem_groundSpace_of_sum_mem_iSup
       μ A hLen X τ hSpan hmem j
 
+/-- A local word at a boundary-crossing interval is the segment before the
+cut followed by the segment after the cut. -/
+theorem ofFn_eq_boundary_crossing_tail_append_head {α : Type*} {L N : ℕ}
+    (i : Fin N) (hi : N < i.val + L) (σ : Fin L → α) :
+    List.ofFn σ =
+      List.ofFn (fun k : Fin (N - i.val) => σ ⟨k.val, by omega⟩) ++
+        List.ofFn (fun k : Fin (i.val + L - N) =>
+          σ ⟨N - i.val + k.val, by omega⟩) := by
+  apply List.ext_getElem
+  · simp [List.length_ofFn]
+    omega
+  · intro k hk₁ hk₂
+    have hkL : k < L := by
+      simpa only [List.length_ofFn] using hk₁
+    simp only [List.getElem_ofFn]
+    by_cases hkTail : k < N - i.val
+    · rw [List.getElem_append_left]
+      · have htail :
+            (List.ofFn (fun k : Fin (N - i.val) =>
+              σ ⟨k.val, by omega⟩))[k]'(by
+                simpa [List.length_ofFn] using hkTail) = σ ⟨k, hkL⟩ := by
+            simp only [List.getElem_ofFn]
+        rw [htail]
+      · simpa [List.length_ofFn] using hkTail
+    · rw [List.getElem_append_right]
+      · simp only [List.getElem_ofFn]
+        congr 1
+        ext
+        simp [List.length_ofFn]
+        omega
+      · simpa [List.length_ofFn] using
+          (show N - i.val ≤ k by omega)
+
 /-- Coefficients of a boundary-crossing cyclic restriction.
 
 Let a cyclic interval of length \(L\) begin at \(i\), and suppose it crosses the
@@ -516,35 +549,8 @@ theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_cross
     σ ⟨k.val, by omega⟩
   let Xj : Matrix (Fin (dim j)) (Fin (dim j)) ℂ := (μ j) ^ N • X j
   have hσ : List.ofFn σ = tailWord ++ headWord := by
-    apply List.ext_getElem
-    · simp [tailWord, headWord, List.length_ofFn]
-      omega
-    · intro k hk₁ hk₂
-      have hkL : k < L := by
-        simpa only [List.length_ofFn] using hk₁
-      simp only [List.getElem_ofFn]
-      by_cases hkTail : k < N - i.val
-      · rw [List.getElem_append_left]
-        · have htail :
-              tailWord[k]'(by simpa [tailWord, List.length_ofFn] using hkTail) =
-                σ ⟨k, hkL⟩ := by
-            simp only [tailWord, List.getElem_ofFn]
-          rw [htail]
-        · simpa [tailWord, List.length_ofFn] using hkTail
-      · rw [List.getElem_append_right]
-        · have hidx : k - tailWord.length < headWord.length := by
-            simp [tailWord, headWord, List.length_ofFn]
-            omega
-          have hhead :
-              headWord[k - tailWord.length]'hidx = σ ⟨k, hkL⟩ := by
-            simp only [headWord, List.getElem_ofFn]
-            congr 1
-            ext
-            simp [tailWord, List.length_ofFn]
-            omega
-          rw [hhead]
-        · simpa [tailWord, List.length_ofFn] using
-            (show tailWord.length ≤ k by simp [tailWord, List.length_ofFn]; omega)
+    simpa [tailWord, headWord] using
+      ofFn_eq_boundary_crossing_tail_append_head i hi σ
   have hIdentityσ :
       (Xj * evalWord (A j) headWord) * evalWord (A j) middleWord =
         evalWord (A j) headWord * E := by

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -106,35 +106,8 @@ theorem blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
   let tailWord : List (Fin d) := List.ofFn fun k : Fin (N - i.val) =>
     σ ⟨k.val, by omega⟩
   have hσ : List.ofFn σ = tailWord ++ headWord := by
-    apply List.ext_getElem
-    · simp [tailWord, headWord, List.length_ofFn]
-      omega
-    · intro k hk₁ hk₂
-      have hkL : k < L := by
-        simpa only [List.length_ofFn] using hk₁
-      simp only [List.getElem_ofFn]
-      by_cases hkTail : k < N - i.val
-      · rw [List.getElem_append_left]
-        · have htail :
-              tailWord[k]'(by simpa [tailWord, List.length_ofFn] using hkTail) =
-                σ ⟨k, hkL⟩ := by
-            simp only [tailWord, List.getElem_ofFn]
-          rw [htail]
-        · simpa [tailWord, List.length_ofFn] using hkTail
-      · rw [List.getElem_append_right]
-        · have hidx : k - tailWord.length < headWord.length := by
-            simp [tailWord, headWord, List.length_ofFn]
-            omega
-          have hhead :
-              headWord[k - tailWord.length]'hidx = σ ⟨k, hkL⟩ := by
-            simp only [headWord, List.getElem_ofFn]
-            congr 1
-            ext
-            simp [tailWord, List.length_ofFn]
-            omega
-          rw [hhead]
-        · simpa [tailWord, List.length_ofFn] using
-            (show tailWord.length ≤ k by simp [tailWord, List.length_ofFn]; omega)
+    simpa [tailWord, headWord] using
+      ofFn_eq_boundary_crossing_tail_append_head i hi σ
   have hLeft :
       (∑ j : Fin r,
           Matrix.trace

--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Core.WordFactor
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.FundamentalTheorem.FiniteLength
 import TNLean.Algebra.TracePairing
@@ -78,29 +79,6 @@ theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D}
     Function.Injective (groundSpaceMap A L₀) := by
   apply groundSpaceMap_injective_of_wordSpan_eq_top
   exact (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
-
-/-- Letter compatibility extends to every nonempty word.  The left family \(Z\) and
-right family \(F\) can be indexed by any finite type; only the physical word lies
-in the MPS alphabet. -/
-private theorem exists_evalWord_factor_of_letter_compatibility
-    {A : MPSTensor d D} {α : Type*} {F Z : α → Matrix (Fin D) (Fin D) ℂ}
-    (hCompat : ∀ i : Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
-      ∀ a : α, Z a * A i = F a * Y)
-    (w : List (Fin d)) (hw : w ≠ []) :
-    ∃ Y : Matrix (Fin D) (Fin D) ℂ,
-      ∀ a : α, Z a * evalWord A w = F a * Y := by
-  cases w with
-  | nil => cases hw rfl
-  | cons i w =>
-      obtain ⟨Y, hY⟩ := hCompat i
-      refine ⟨Y * evalWord A w, ?_⟩
-      intro a
-      calc
-        Z a * evalWord A (i :: w)
-            = Z a * (A i * evalWord A w) := by simp [evalWord]
-        _ = (Z a * A i) * evalWord A w := by rw [Matrix.mul_assoc]
-        _ = (F a * Y) * evalWord A w := by rw [hY a]
-        _ = F a * (Y * evalWord A w) := by rw [Matrix.mul_assoc]
 
 /-- If a family indexed by length-\(L₀\) words is compatible with multiplication by
 single physical letters, then block injectivity strips the letter and produces a

--- a/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
+++ b/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.Core.WordFactor
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
 
 /-!
@@ -35,28 +36,6 @@ open scoped Matrix
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-- Letter compatibility extends to every nonempty word by multiplying the
-corresponding boundary matrix on the right by the remaining suffix product. -/
-private theorem exists_evalWord_factor_of_letter_compatibility {A : MPSTensor d D}
-    {Z : Fin d → Matrix (Fin D) (Fin D) ℂ}
-    (hCompat : ∀ i : Fin d, ∃ Y : Matrix (Fin D) (Fin D) ℂ,
-      ∀ j : Fin d, Z j * A i = A j * Y)
-    (w : List (Fin d)) (hw : w ≠ []) :
-    ∃ Y : Matrix (Fin D) (Fin D) ℂ,
-      ∀ j : Fin d, Z j * evalWord A w = A j * Y := by
-  cases w with
-  | nil => cases hw rfl
-  | cons i w =>
-      obtain ⟨Y, hY⟩ := hCompat i
-      refine ⟨Y * evalWord A w, ?_⟩
-      intro j
-      calc
-        Z j * evalWord A (i :: w)
-            = Z j * (A i * evalWord A w) := by simp [evalWord]
-        _ = (Z j * A i) * evalWord A w := by rw [Matrix.mul_assoc]
-        _ = (A j * Y) * evalWord A w := by rw [hY j]
-        _ = A j * (Y * evalWord A w) := by rw [Matrix.mul_assoc]
 
 /-- If the compatibility identity is available for every single physical letter,
 then block injectivity yields a common right factor. -/

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -380,6 +380,25 @@ abstracted — record why, so it is not re-proposed).
   retains its selected eventually nonzero scalar. The two public theorem names and statements
   are unchanged, and the Lean source loses 58 lines net.
 
+### MPS word-factor extension
+- **Pattern:** extend a one-letter identity `Z a * A i = F a * Y` to a nonempty
+  physical word by multiplying the witness by the remaining suffix product.
+- **Reuse:** `MPSTensor.exists_evalWord_factor_of_letter_compatibility` in
+  `TNLean/MPS/Core/WordFactor.lean` handles arbitrary index types and matrix families.
+- **Result:** `ParentHamiltonian/BlockStrip.lean` and
+  `ParentHamiltonian/ExtendRight.lean` use the neutral shared theorem instead of
+  maintaining specialized inductions. The existing public parent-Hamiltonian statements
+  are unchanged, and `ExtendRight.lean` does not import the larger `BlockStrip.lean` cone.
+
+### Boundary-crossing word split
+- **Pattern:** split `List.ofFn σ` at the boundary-crossing index `N - i` into the
+  segment before the cut followed by the wrapped segment after the cut.
+- **Reuse:** `MPSTensor.ofFn_eq_boundary_crossing_tail_append_head` in
+  `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean` records the index
+  arithmetic once.
+- **Result:** the crossing-matrix and crossing-trace proofs call the shared list
+  identity. Their theorem statements and the Chapter 13 endpoints are unchanged.
+
 ### MPDO pair-trace separation duality
 - **Pattern:** use Hahn--Banach separation for a proper pair-matrix submodule,
   represent the separating functional as a pair trace, and contradict trace


### PR DESCRIPTION
## What changed

- extract a neutral `MPS.Core.WordFactor` theorem for eval-word factorization
- route both ParentHamiltonian factor theorems through the shared induction
- single-source the boundary-crossing `List.ofFn` decomposition
- preserve all public declarations and Chapter 13 endpoints

## Validation

- targeted builds for the five changed Lean modules
- `lake build TNLean.MPS.ParentHamiltonian TNLean.MPS.Core` (9,038 jobs)
- generated import-aggregator check
- exact-head review approved `ab1a495d4ffdaaa99780ccc8096d4573f45c23b6`
- proof-integrity and deprecated-alias scans
- `git diff --check`

Closes #5999
Advances #5995

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactor and lemma extraction; public declarations and mathematical conclusions are preserved, with no auth, runtime, or data-handling changes.
> 
> **Overview**
> This PR **deduplicates** parent-Hamiltonian proof machinery by moving repeated inductions and list index proofs into shared lemmas, without changing public theorem statements or Chapter 13 endpoints.
> 
> **Word-factor extension:** A new `TNLean/MPS/Core/WordFactor` module defines `exists_evalWord_factor_of_letter_compatibility`, which lifts a one-letter identity `Z a * A i = F a * Y` to every nonempty physical word. `BlockStrip.lean` and `ExtendRight.lean` drop their private copies and import this neutral theorem instead (so `ExtendRight` does not need the larger `BlockStrip` import cone).
> 
> **Boundary-crossing split:** `ofFn_eq_boundary_crossing_tail_append_head` in `BNTBlockDiagonalCrossing.lean` records once that `List.ofFn σ` splits at `N - i` into tail-before-cut plus head-after-cut. The crossing-matrix and crossing-trace proofs replace long `List.ext_getElem` blocks with one-line calls to that lemma.
> 
> `docs/tactic_patterns.md` documents both patterns as completed refactors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c3119477397e773ade749e747cf1c7b171e9be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->