### PR TITLE
refactor(MPS/MPDO): single-source sector helpers

### DIFF
--- a/TNLean/Entropy/MutualInformationBasic.lean
+++ b/TNLean/Entropy/MutualInformationBasic.lean
@@ -12,10 +12,12 @@ This module exposes the bipartite mutual information defined in
 `TNLean.Analysis.Entropy` under the `Entropy` namespace without importing
 strong subadditivity or its consequences.
 
-## Main declaration
+## Main declarations
 
 * `Entropy.mutualInformation` is the namespaced alias of
   `_root_.mutualInformation`.
+* `Entropy.mutualInformation_congr` shows that mutual information respects
+  equality of the matrix independently of its Hermiticity witness.
 -/
 
 namespace Entropy
@@ -28,5 +30,15 @@ between A and B. Definitionally equal to `_root_.mutualInformation`.
 
 Source: blueprint `def:entropy_mutual_information`. -/
 noncomputable alias mutualInformation := _root_.mutualInformation
+
+/-- Mutual information is independent of the Hermiticity witness and respects
+equality of the underlying bipartite matrix. -/
+theorem mutualInformation_congr
+    {dA dB : ℕ}
+    {ρ σ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
+    (h : ρ = σ) (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian) :
+    mutualInformation ρ hρ = mutualInformation σ hσ := by
+  subst σ
+  rfl
 
 end Entropy

--- a/TNLean/Entropy/MutualInformationBasic.lean
+++ b/TNLean/Entropy/MutualInformationBasic.lean
@@ -12,10 +12,13 @@ This module exposes the bipartite mutual information defined in
 `TNLean.Analysis.Entropy` under the `Entropy` namespace without importing
 strong subadditivity or its consequences.
 
-## Main declarations
+## Main definitions
 
 * `Entropy.mutualInformation` is the namespaced alias of
   `_root_.mutualInformation`.
+
+## Main results
+
 * `Entropy.mutualInformation_congr` shows that mutual information respects
   equality of the matrix independently of its Hermiticity witness.
 -/

--- a/TNLean/Entropy/MutualInformationDataProcessing.lean
+++ b/TNLean/Entropy/MutualInformationDataProcessing.lean
@@ -179,16 +179,6 @@ private theorem traceLeft_submatrix_swap
   simp only [Matrix.traceLeft_apply, Matrix.traceRight_apply,
     Matrix.submatrix_apply, Prod.swap_prod_mk]
 
-/-- Mutual information is independent of the proof of Hermiticity and is
-congruent under equality of the underlying bipartite matrices. -/
-private theorem mutualInformation_congr
-    {dA dB : ℕ}
-    {ρ σ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
-    (h : ρ = σ) (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian) :
-    Entropy.mutualInformation ρ hρ = Entropy.mutualInformation σ hσ := by
-  subst σ
-  rfl
-
 /-- Bipartite mutual information is invariant under exchanging the two tensor
 factors. -/
 private theorem mutualInformation_submatrix_swap
@@ -364,7 +354,7 @@ theorem IsKrausCPTP.mutualInformation_tensorMapId_le
           Entropy.mutualInformation
             ((Matrix.tensorMapId S ρ).submatrix Prod.swap Prod.swap)
             (hσ.isHermitian.submatrix Prod.swap) := by
-        exact mutualInformation_congr hC _ _
+        exact Entropy.mutualInformation_congr hC _ _
       _ = Entropy.mutualInformation (Matrix.tensorMapId S ρ)
           hσ.isHermitian :=
         mutualInformation_submatrix_swap

--- a/TNLean/MPS/MPDO/CommutingForm.lean
+++ b/TNLean/MPS/MPDO/CommutingForm.lean
@@ -90,6 +90,15 @@ noncomputable def embedLocalOperator (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
       else 0 :=
   rfl
 
+/-- Embedding a local operator preserves complex scalar multiplication. -/
+theorem embedLocalOperator_smul
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (c : ℂ)
+    (A : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    embedLocalOperator (d := d) L N hLN i (c • A) =
+      c • embedLocalOperator L N hLN i A := by
+  ext σ τ
+  simp [embedLocalOperator_apply]
+
 /-- Two configurations agree outside a cyclic window exactly when their values
 coincide at every site outside that window. -/
 theorem agreesOutsideWindow_iff (L : ℕ) {N : ℕ} (hLN : L ≤ N)

--- a/TNLean/MPS/MPDO/CyclicActiveCutRegrouping.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveCutRegrouping.lean
@@ -25,20 +25,6 @@ universe u
 
 variable {d D : ℕ} {K : MPOTensor d D}
 
-private theorem sectorIndex_fst_heq_of_heq
-    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
-    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
-    (hxy : x ≍ y) : x.1 ≍ y.1 := by
-  subst h
-  exact heq_of_eq (congrArg Prod.fst (eq_of_heq hxy))
-
-private theorem sectorIndex_snd_heq_of_heq
-    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
-    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
-    (hxy : x ≍ y) : x.2 ≍ y.2 := by
-  subst h
-  exact heq_of_eq (congrArg Prod.snd (eq_of_heq hxy))
-
 private theorem neighboringOperator_entry_eq_of_heq
     (F : PhysicalSectorFactorization K)
     {k k' h h' : Fin F.sectorCount} (hk : k = k') (hh : h = h')

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean
@@ -149,20 +149,6 @@ private theorem neighboringOperator_trace_eq_of_eq
   subst h'
   rfl
 
-private theorem sectorIndex_fst_heq_of_heq
-    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
-    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
-    (hxy : x ≍ y) : x.1 ≍ y.1 := by
-  subst h
-  exact heq_of_eq (congrArg Prod.fst (eq_of_heq hxy))
-
-private theorem sectorIndex_snd_heq_of_heq
-    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
-    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
-    (hxy : x ≍ y) : x.2 ≍ y.2 := by
-  subst h
-  exact heq_of_eq (congrArg Prod.snd (eq_of_heq hxy))
-
 private theorem dependent_prod_fst_heq {ι : Type*} {α β : ι → Type*}
     (f : (i : ι) → α i × β i) {i j : ι} (h : i = j) :
     (f i).1 ≍ (f j).1 := by

--- a/TNLean/MPS/MPDO/GSNNCHSectorRescaling.lean
+++ b/TNLean/MPS/MPDO/GSNNCHSectorRescaling.lean
@@ -39,14 +39,6 @@ Source: arXiv:1606.00608, Definition 4.8, lines 829--850. -/
 noncomputable def coefficientRoot (multiplicity N : ℕ) (c : ℝ) : ℝ :=
   (c / multiplicity) ^ (N : ℝ)⁻¹
 
-private theorem embedLocalOperator_smul
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (c : ℂ)
-    (A : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
-    embedLocalOperator (d := d) L N hLN i (c • A) =
-      c • embedLocalOperator L N hLN i A := by
-  ext σ τ
-  simp [embedLocalOperator_apply]
-
 /-- At a fixed chain length, rescale every sector bond so that its
 multiplicity-weighted periodic product acquires a prescribed nonnegative real
 coefficient.

--- a/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationAreaLaw.lean
@@ -64,15 +64,6 @@ namespace MPOTensor
 
 variable {d dP D D' : ℕ}
 
-/-- Mutual information is congruent under equality of the density matrix. -/
-private theorem mutualInformation_congr
-    {dA dB : ℕ}
-    {rho sigma : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
-    (h : rho = sigma) (hrho : rho.IsHermitian) (hsigma : sigma.IsHermitian) :
-    Entropy.mutualInformation rho hrho = Entropy.mutualInformation sigma hsigma := by
-  subst sigma
-  rfl
-
 /-- Regroup a block of spin--ancilla indices into its spin configuration and
 its ancillary configuration. -/
 noncomputable def blockSpinAncillaEquiv (d dK L : ℕ) :
@@ -370,7 +361,7 @@ theorem mutualInfoChain_le_of_bipartitioned_channel_image
             (Matrix.tensorMapBoth S T
               (bipartitionedNormalizedMPO
                 (doubledTensor A) N L (N - L) (by omega))) _ := by
-          apply mutualInformation_congr himage
+          apply Entropy.mutualInformation_congr himage
     Entropy.mutualInformation
           (Matrix.tensorMapBoth S T
             (bipartitionedNormalizedMPO (doubledTensor A) N L (N - L) (by omega))) _

--- a/TNLean/MPS/MPDO/PhysicalGibbsEmbedding.lean
+++ b/TNLean/MPS/MPDO/PhysicalGibbsEmbedding.lean
@@ -177,15 +177,6 @@ private theorem embedLocalOperator_add
   simp only [embedLocalOperator_apply, Matrix.add_apply]
   by_cases h : AgreesOutsideWindow (d := d) L hLN i σ τ <;> simp [h]
 
-/-- Embedding preserves complex scalar multiplication. -/
-private theorem embedLocalOperator_smul
-    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (c : ℂ)
-    (A : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
-    embedLocalOperator (d := d) L N hLN i (c • A) =
-      c • embedLocalOperator L N hLN i A := by
-  ext σ τ
-  simp [embedLocalOperator_apply]
-
 /-- Embedding the local identity gives the chain identity. -/
 @[simp]
 private theorem embedLocalOperator_one

--- a/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorFactorization.lean
@@ -91,6 +91,22 @@ abbrev SectorIndex (F : PhysicalSectorFactorization K)
     (k : Fin F.sectorCount) :=
   Fin (F.leftDim k) × Fin (F.rightDim k)
 
+/-- Heterogeneous equality of sector indices preserves their left components. -/
+theorem sectorIndex_fst_heq_of_heq
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
+    (hxy : x ≍ y) : x.1 ≍ y.1 := by
+  subst h
+  exact heq_of_eq (congrArg Prod.fst (eq_of_heq hxy))
+
+/-- Heterogeneous equality of sector indices preserves their right components. -/
+theorem sectorIndex_snd_heq_of_heq
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
+    (hxy : x ≍ y) : x.2 ≍ y.2 := by
+  subst h
+  exact heq_of_eq (congrArg Prod.snd (eq_of_heq hxy))
+
 /-- The index space supporting the neighboring operator between sectors `k`
 and `h`. -/
 abbrev NeighborIndex (F : PhysicalSectorFactorization K)

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -82,16 +82,6 @@ theorem coarsenFirstBlock_isKrausCPTP
       (coarsenFirstTwoSites_isKrausCPTP hS n))
     (Matrix.equivReindexMap_isKrausCPTP finFunctionFinEquiv)
 
-/-- Mutual information is congruent under equality of the bipartite density
-matrix; the Hermiticity witnesses carry no additional data. -/
-private theorem mutualInformation_congr
-    {dA dB : ℕ}
-    {ρ σ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
-    (h : ρ = σ) (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian) :
-    Entropy.mutualInformation ρ hρ = Entropy.mutualInformation σ hσ := by
-  subst σ
-  rfl
-
 /-- Fixing the second block of a flattened bipartition leaves the first-block
 physical closure, with the fixed word inserted as its virtual boundary. -/
 private theorem splitMPO_slice
@@ -317,7 +307,7 @@ theorem mutualInformation_bipartition_eq_of_local_transfers
             (bipartitionedNormalizedMPO M N (a + 1) (b + 2) hIn))
           ((refineFirstBlock_isKrausCPTP hT a).tensorMapBoth_posSemidef
             (coarsenFirstBlock_isKrausCPTP hS b) hρ).isHermitian :=
-        (mutualInformation_congr hforward _ _).symm
+        (Entropy.mutualInformation_congr hforward _ _).symm
       _ ≤ _ := hforward_le
   have hρσ :
       Entropy.mutualInformation
@@ -330,7 +320,7 @@ theorem mutualInformation_bipartition_eq_of_local_transfers
             (bipartitionedNormalizedMPO M N (a + 2) (b + 1) hOut))
           ((coarsenFirstBlock_isKrausCPTP hS a).tensorMapBoth_posSemidef
             (refineFirstBlock_isKrausCPTP hT b) hσ).isHermitian :=
-        (mutualInformation_congr hbackward _ _).symm
+        (Entropy.mutualInformation_congr hbackward _ _).symm
       _ ≤ _ := hbackward_le
   exact le_antisymm hρσ hσρ
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -399,6 +399,21 @@ abstracted — record why, so it is not re-proposed).
 - **Result:** the crossing-matrix and crossing-trace proofs call the shared list
   identity. Their theorem statements and the Chapter 13 endpoints are unchanged.
 
+### Dependent sector projections and structural map congruences
+- **Pattern:** cyclic-sector proofs duplicated the same heterogeneous projection lemmas,
+  local-operator constructions duplicated scalar compatibility, and three entropy modules
+  wrapped equality rewriting solely to erase Hermiticity witnesses.
+- **Reuse:** `PhysicalSectorFactorization.sectorIndex_fst_heq_of_heq` and
+  `PhysicalSectorFactorization.sectorIndex_snd_heq_of_heq` now belong to the neutral
+  sector-index API, while `MPOTensor.embedLocalOperator_smul` belongs to the defining
+  local-embedding module. `Entropy.mutualInformation_congr` in the basic entropy API
+  handles the proof-dependent Hermiticity witnesses for all mutual-information callers.
+- **Result:** the two cyclic-active modules and the two local-embedding consumers retain their
+  existing propositions and declaration names with one proof body per shared fact. The local
+  wrappers in `LocalPurificationAreaLaw.lean` and `RFPViaTSSAL.lean` were removed, and the
+  pre-existing third wrapper in `MutualInformationDataProcessing.lean` now also uses
+  `Entropy.mutualInformation_congr`.
+
 ### MPDO pair-trace separation duality
 - **Pattern:** use Hahn--Banach separation for a proper pair-matrix submodule,
   represent the separating functional as a pair trace, and contradict trace
@@ -1178,16 +1193,3 @@ spectral split → block extraction → MPV calculation → strict bounds
   steps rather than remove duplication.
 - **Counts:** declarations 2 → 0; annotations 18 → 0; invocations 0 → 0;
   proof-body lines changed 0.
-
-### Dependent sector projections and structural map congruences
-- **Pattern:** cyclic-sector proofs duplicated the same heterogeneous projection lemmas,
-  local-operator constructions duplicated scalar compatibility, and two entropy arguments
-  wrapped equality rewriting solely to erase Hermiticity witnesses.
-- **Reuse:** `PhysicalSectorFactorization.sectorIndex_fst_heq_of_heq` and
-  `PhysicalSectorFactorization.sectorIndex_snd_heq_of_heq` now belong to the neutral
-  sector-index API, while `MPOTensor.embedLocalOperator_smul` belongs to the defining
-  local-embedding module. `Entropy.mutualInformation_congr` in the basic entropy API
-  handles the proof-dependent Hermiticity witnesses for all mutual-information callers.
-- **Result:** the two cyclic-active modules and the two local-embedding consumers retain their
-  existing propositions and declaration names with one proof body per shared fact; the two
-  terminal entropy modules no longer carry trivial local congruence wrappers.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1178,3 +1178,16 @@ spectral split → block extraction → MPV calculation → strict bounds
   steps rather than remove duplication.
 - **Counts:** declarations 2 → 0; annotations 18 → 0; invocations 0 → 0;
   proof-body lines changed 0.
+
+### Dependent sector projections and structural map congruences
+- **Pattern:** cyclic-sector proofs duplicated the same heterogeneous projection lemmas,
+  local-operator constructions duplicated scalar compatibility, and two entropy arguments
+  wrapped equality rewriting solely to erase Hermiticity witnesses.
+- **Reuse:** `PhysicalSectorFactorization.sectorIndex_fst_heq_of_heq` and
+  `PhysicalSectorFactorization.sectorIndex_snd_heq_of_heq` now belong to the neutral
+  sector-index API, while `MPOTensor.embedLocalOperator_smul` belongs to the defining
+  local-embedding module. `Entropy.mutualInformation_congr` in the basic entropy API
+  handles the proof-dependent Hermiticity witnesses for all mutual-information callers.
+- **Result:** the two cyclic-active modules and the two local-embedding consumers retain their
+  existing propositions and declaration names with one proof body per shared fact; the two
+  terminal entropy modules no longer carry trivial local congruence wrappers.


### PR DESCRIPTION
## What changed

- single-source dependent sector-index projection lemmas in the neutral sector API
- place scalar compatibility beside `embedLocalOperator`
- add `Entropy.mutualInformation_congr` and route all three proof-irrelevance wrappers through it
- preserve every existing public proposition and source-facing declaration

## Validation

- targeted build of all affected modules (9,272 jobs)
- full `lake build` (10,036 jobs)
- Blueprint synchronization (7,061/7,061 entries)
- exact-head review approved `df58a175c3182c895e1db8b3e996c8c7044c412c`
- proof-integrity, import, and deprecated-alias scans
- `git diff --check`

Closes #5998
Advances #5995

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only deduplication with no API or behavioral changes beyond routing through shared lemmas; risk is low import/namespace wiring in the affected Lean modules.
> 
> **Overview**
> This refactor **deduplicates** several proof helpers that were copied across MPDO and entropy modules, without changing public theorem statements or source-facing names.
> 
> **Entropy:** `Entropy.mutualInformation_congr` is added in `MutualInformationBasic.lean` so mutual information respects matrix equality independent of Hermiticity witnesses. Local private copies in `MutualInformationDataProcessing`, `LocalPurificationAreaLaw`, and `RFPViaTSSAL` are removed; callers now use `Entropy.mutualInformation_congr`.
> 
> **Local embedding:** `embedLocalOperator_smul` moves from private duplicates in `PhysicalGibbsEmbedding` and `GSNNCHSectorRescaling` into `CommutingForm.lean` beside `embedLocalOperator`.
> 
> **Sector indices:** `sectorIndex_fst_heq_of_heq` and `sectorIndex_snd_heq_of_heq` are promoted to public theorems on `PhysicalSectorFactorization` in `PhysicalSectorFactorization.lean`, replacing identical private lemmas in `CyclicActiveCutRegrouping` and `CyclicActiveFourthRegionContraction`.
> 
> `docs/tactic_patterns.md` records the consolidation pattern for future reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4840f00b51a61bdfcc681b58942a161d0a54fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->