### PR TITLE
refactor(matrix): single-source MPDO helper identities

### DIFF
--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Data.Complex.Basic
+import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.LinearIndependent.Defs
 import Mathlib.Order.Fin.Tuple
 
@@ -17,6 +18,17 @@ This file collects small finite-sum identities.
 -/
 
 open scoped BigOperators
+
+namespace Matrix
+
+/-- Taking a submatrix commutes with a finite sum. -/
+theorem submatrix_sum {ι l m p q R : Type*} [AddCommMonoid R]
+    (s : Finset ι) (M : ι → Matrix m p R) (f : l → m) (g : q → p) :
+    (∑ i ∈ s, M i).submatrix f g = ∑ i ∈ s, (M i).submatrix f g := by
+  ext a b
+  simp only [Matrix.submatrix_apply, Matrix.sum_apply]
+
+end Matrix
 
 namespace Fintype
 

--- a/TNLean/Channel/SingleKrausPositivity.lean
+++ b/TNLean/Channel/SingleKrausPositivity.lean
@@ -8,16 +8,41 @@ import TNLean.Channel.KrausCPTP
 /-!
 # Positivity under single-Kraus isometries
 
-This file records the order-reflection property of conjugation by a rectangular
+This file records algebraic and order properties of conjugation by a rectangular
 isometry.
 
 ## Main declarations
 
+* `Matrix.singleKrausMap_kronecker`: single-Kraus conjugation distributes over
+  Kronecker products.
+* `Matrix.singleKrausMap_mul_of_isometry`: isometric single-Kraus conjugation
+  preserves multiplication.
 * `Matrix.posSemidef_of_singleKraus_isometry`: positivity can be read back
   through an isometric single-Kraus conjugation.
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix ComplexOrder Kronecker
+
+/-- Single-Kraus conjugation distributes over Kronecker products. -/
+theorem Matrix.singleKrausMap_kronecker
+    {a b c f : Type*} [Fintype a] [Fintype b] [Fintype c] [Fintype f]
+    (A : Matrix a b ℂ) (C : Matrix c f ℂ)
+    (X : Matrix b b ℂ) (Y : Matrix f f ℂ) :
+    singleKrausMap (A ⊗ₖ C) (X ⊗ₖ Y) =
+      singleKrausMap A X ⊗ₖ singleKrausMap C Y := by
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker]
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+
+/-- Single-Kraus conjugation by an isometry preserves multiplication. -/
+theorem Matrix.singleKrausMap_mul_of_isometry
+    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
+    (V : Matrix a b ℂ) (hV : Vᴴ * V = 1)
+    (X Y : Matrix b b ℂ) :
+    singleKrausMap V (X * Y) =
+      singleKrausMap V X * singleKrausMap V Y := by
+  simp only [singleKrausMap_apply, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc Vᴴ V, hV]
+  simp
 
 /-- Positivity can be read back through an isometric single-Kraus
 conjugation. -/

--- a/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
+++ b/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.SingleKrausPositivity
 import TNLean.MPS.MPDO.PhysicalSupportBondTransport
 
 /-!
@@ -32,15 +33,6 @@ namespace MPOTensor
 variable {d e : ℕ}
 
 open MPOTensor.PhysicalSectorFactorization
-
-private theorem singleKrausMap_kronecker
-    {a b c f : Type*} [Fintype a] [Fintype b] [Fintype c] [Fintype f]
-    (A : Matrix a b ℂ) (C : Matrix c f ℂ)
-    (X : Matrix b b ℂ) (Y : Matrix f f ℂ) :
-    singleKrausMap (A ⊗ₖ C) (X ⊗ₖ Y) =
-      singleKrausMap A X ⊗ₖ singleKrausMap C Y := by
-  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker]
-  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
 
 private theorem reindex_kronecker_assoc
     (V : Matrix (Fin d) (Fin e) ℂ) :
@@ -75,19 +67,9 @@ private theorem lift_leftPairMatrix
       (Equiv.prodAssoc (Fin e) (Fin e) (Fin e)).symm
       (Equiv.prodAssoc (Fin d) (Fin d) (Fin d)).symm,
     reindex_kronecker_assoc, reindex_leftPairMatrix,
-    singleKrausMap_kronecker]
+    Matrix.singleKrausMap_kronecker]
   ext
   simp [Matrix.reindex_apply]
-
-private theorem singleKrausMap_mul
-    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
-    (V : Matrix a b ℂ) (hV : Vᴴ * V = 1)
-    (X Y : Matrix b b ℂ) :
-    singleKrausMap V (X * Y) =
-      singleKrausMap V X * singleKrausMap V Y := by
-  simp only [singleKrausMap_apply, Matrix.mul_assoc]
-  rw [← Matrix.mul_assoc Vᴴ V, hV]
-  simp
 
 private theorem kronecker_isometry
     {a b c f : Type*} [Fintype a] [Fintype c]
@@ -141,7 +123,7 @@ private theorem lift_rightPairMatrix
     (B : Matrix (Fin e × Fin e) (Fin e × Fin e) ℂ) :
     singleKrausMap (V ⊗ₖ (V ⊗ₖ V)) (rightPairMatrix B) =
       singleKrausMap V 1 ⊗ₖ singleKrausMap (V ⊗ₖ V) B := by
-  rw [rightPairMatrix, singleKrausMap_kronecker]
+  rw [rightPairMatrix, Matrix.singleKrausMap_kronecker]
 
 private theorem leftPair_mul_lastProjection
     (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
@@ -277,7 +259,7 @@ private theorem pair_product_transport
     singleKrausMap W₃ (leftPairMatrix B * rightPairMatrix C) =
         singleKrausMap W₃ (leftPairMatrix B) *
           singleKrausMap W₃ (rightPairMatrix C) :=
-      singleKrausMap_mul W₃ hW₃ _ _
+      Matrix.singleKrausMap_mul_of_isometry W₃ hW₃ _ _
     _ = (leftPairMatrix B' * Q₂) * (Q₀ * rightPairMatrix C') := by
       rw [hleft, hright]
     _ = leftPairMatrix B' * (Q₂ * Q₀) * rightPairMatrix C' := by
@@ -511,7 +493,7 @@ theorem singleKrausMap_crossedTwoSiteBondProduct
       (_root_.finTwoArrowEquiv (Fin e))
       (_root_.finTwoArrowEquiv (Fin d)),
     reindex_sitewisePhysicalMatrix_two]
-  rw [singleKrausMap_mul _ (kronecker_isometry V V hV hV)]
+  rw [Matrix.singleKrausMap_mul_of_isometry _ (kronecker_isometry V V hV hV)]
   have hswap := swapPairMatrix_singleKraus_kronecker_self Vᴴ
     (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
       (_root_.finTwoArrowEquiv (Fin e)) C)

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.ListProduct
 import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorProductRealization
+import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 
 /-!
@@ -96,22 +97,6 @@ private def braKetFunctionsEquiv {i a b : Type*} :
     ((i → b) × (i → a)) ≃ (i → a × b) :=
   (Equiv.prodComm _ _).trans (Equiv.arrowProdEquivProdArrow i (fun _ ↦ a) (fun _ ↦ b)).symm
 
-private theorem evalWord_changePhysicalBasis_ofFn {e : ℕ}
-    (V : Matrix (Fin e) (Fin d) ℂ) (M : MPOTensor d D) {N : ℕ}
-    (s t : Fin N → Fin e) :
-    MPOTensor.evalWord (changePhysicalBasis V M) (List.ofFn s) (List.ofFn t) =
-      ∑ x : Fin N → Fin d × Fin d,
-        (∏ i : Fin N, V (s i) (x i).1 * star (V (t i) (x i).2)) •
-          MPOTensor.evalWord M
-            (List.ofFn fun i : Fin N ↦ (x i).1)
-            (List.ofFn fun i : Fin N ↦ (x i).2) := by
-  rw [MPOTensor.evalWord_ofFn]
-  simp_rw [changePhysicalBasis_apply_eq_sum]
-  rw [List.prod_ofFn_sum]
-  apply Finset.sum_congr rfl
-  intro x _
-  rw [List.prod_ofFn_smul, MPOTensor.evalWord_ofFn]
-
 /-- The length-`N` MPO transforms by the sitewise physical coordinate
 matrix.
 
@@ -124,7 +109,7 @@ private theorem physicalCoordinateMatrixN_mpo
   ext s t
   simp only [singleKrausMap_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
     physicalCoordinateMatrixN, mpo_apply, mpoMatrixEntry,
-    evalWord_changePhysicalBasis_ofFn, Matrix.trace_sum, Matrix.trace_smul,
+    MPOTensor.evalWord_changePhysicalBasis_ofFn, Matrix.trace_sum, Matrix.trace_smul,
     smul_eq_mul, star_prod]
   have hexpand :
       (∑ q : Fin N → Fin d,

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.KroneckerFactorPositivity
+import TNLean.Channel.SingleKrausPositivity
 import TNLean.MPS.MPDO.PhysicalSupportBondCommutativity
 import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 
@@ -30,25 +31,6 @@ namespace MPOTensor
 variable {d e D : ℕ}
 
 open PhysicalSectorFactorization
-
-private theorem singleKrausMap_kronecker
-    {a b c f : Type*} [Fintype a] [Fintype b] [Fintype c] [Fintype f]
-    (A : Matrix a b ℂ) (C : Matrix c f ℂ)
-    (X : Matrix b b ℂ) (Y : Matrix f f ℂ) :
-    singleKrausMap (A ⊗ₖ C) (X ⊗ₖ Y) =
-      singleKrausMap A X ⊗ₖ singleKrausMap C Y := by
-  simp only [singleKrausMap_apply, Matrix.conjTranspose_kronecker]
-  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
-
-private theorem singleKrausMap_mul_isometry
-    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq b]
-    (V : Matrix a b ℂ) (hV : Vᴴ * V = 1)
-    (X Y : Matrix b b ℂ) :
-    singleKrausMap V (X * Y) =
-      singleKrausMap V X * singleKrausMap V Y := by
-  simp only [singleKrausMap_apply, Matrix.mul_assoc]
-  rw [← Matrix.mul_assoc Vᴴ V, hV]
-  simp
 
 private theorem finKronecker_mul {N : ℕ}
     (A B : Fin N → Matrix (Fin d) (Fin d) ℂ) :
@@ -78,7 +60,7 @@ theorem singleKrausMap_list_prod_of_ne_nil
       | nil => simp
       | cons Y l =>
           rw [List.prod_cons, List.map_cons, List.prod_cons,
-            singleKrausMap_mul_isometry V hV]
+            Matrix.singleKrausMap_mul_of_isometry V hV]
           exact congrArg (singleKrausMap V X * ·)
             (ih (by simp))
 
@@ -436,7 +418,7 @@ theorem singleKrausMap_embedLocalOperator_eq_range_mul_lift
       (sitewisePhysicalMatrix V 2 ⊗ₖ sitewisePhysicalMatrix V (N - 2))
         (B ⊗ₖ (1 : Matrix (Fin (N - 2) → Fin e)
           (Fin (N - 2) → Fin e) ℂ)) = _
-  rw [singleKrausMap_kronecker]
+  rw [Matrix.singleKrausMap_kronecker]
   have hone : Matrix.reindex ee ee
       (1 : Matrix (Fin N → Fin e) (Fin N → Fin e) ℂ) = 1 := by
     ext x y
@@ -521,7 +503,7 @@ theorem singleKrausMap_bondProduct_eq_liftedBondProduct
   have hQ : Q * Q = Q := by
     calc
       Q * Q = singleKrausMap W (1 * 1) :=
-        (singleKrausMap_mul_isometry W hW 1 1).symm
+        (Matrix.singleKrausMap_mul_of_isometry W hW 1 1).symm
       _ = Q := by simp [Q]
   have hmap : (List.ofFn X).map (singleKrausMap W) =
       List.ofFn (fun i ↦ Q * A i) := by

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexPhasePositivity
+import TNLean.Algebra.FinSum
 import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.MPS.Core.MultiBlock
 import TNLean.Spectral.TransferOperatorGapNT
@@ -61,13 +62,6 @@ space, `α ↦ ⟨k, α⟩`. -/
 def blockIncl (k : Fin r) (dim : Fin r → ℕ) :
     Fin (dim k) → (k : Fin r) × Fin (dim k) :=
   fun a => ⟨k, a⟩
-
-/-- Submatrices commute with finite sums. -/
-private lemma submatrix_sum' {ι l m p q : Type*}
-    (s : Finset ι) (M : ι → Matrix m p ℂ) (f : l → m) (g : q → p) :
-    (∑ i ∈ s, M i).submatrix f g = ∑ i ∈ s, (M i).submatrix f g := by
-  ext a b
-  simp only [Matrix.submatrix_apply, Matrix.sum_apply]
 
 /-- Left block-diagonal action on a bond block: the `(j, j')` bond block of
 $(\bigoplus_k L_k)\, X$ is $L_j X_{j,j'}$ (arXiv:1606.00608, line 551). -/
@@ -144,7 +138,7 @@ theorem blockDiagonal'_transferSum_toBlock
       mixedTransferMap₂ (B j) (B j')
         (X.submatrix (blockIncl j dim) (blockIncl j' dim)) := by
   classical
-  rw [mixedTransferMap₂_apply, submatrix_sum']
+  rw [mixedTransferMap₂_apply, Matrix.submatrix_sum]
   refine Finset.sum_congr rfl fun i _ => ?_
   rw [Matrix.blockDiagonal'_conjTranspose, blockDiagonal'_mul_mul_toBlock]
 
@@ -182,7 +176,7 @@ theorem transferMap_directSumTensor_reindex
   set e := finSigmaFinEquiv (m := r) (n := dim) with he
   rw [transferMap_apply, blockTransferSum]
   simp only [Matrix.reindex_apply]
-  rw [submatrix_sum']
+  rw [Matrix.submatrix_sum]
   refine Finset.sum_congr rfl fun i _ => ?_
   simp only [directSumTensor, Matrix.reindex_apply]
   rw [Matrix.conjTranspose_submatrix, Matrix.submatrix_mul_equiv _ _ _ e.symm _,

--- a/TNLean/MPS/RFP/PhysicalObservableRealization.lean
+++ b/TNLean/MPS/RFP/PhysicalObservableRealization.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.ZeroCorrelationLength
@@ -113,13 +114,6 @@ private theorem evalWord_directSumTensor
   rw [hDirect, evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal]
   simp
 
-/-- Submatrices commute with finite sums. -/
-private theorem submatrix_sum {ι l m p q : Type*}
-    (s : Finset ι) (M : ι → Matrix m p ℂ) (f : l → m) (g : q → p) :
-    (∑ i ∈ s, M i).submatrix f g = ∑ i ∈ s, (M i).submatrix f g := by
-  ext a b
-  simp only [Matrix.submatrix_apply, Matrix.sum_apply]
-
 /-- The inserted transfer map of a direct sum is the reindexing of the
 corresponding block-diagonal word sum. -/
 private theorem physicalObservableTransfer_directSum_reindex
@@ -138,10 +132,10 @@ private theorem physicalObservableTransfer_directSum_reindex
   classical
   rw [physicalObservableTransfer_apply]
   simp only [evalWord_directSumTensor, Matrix.reindex_apply]
-  rw [submatrix_sum]
+  rw [Matrix.submatrix_sum]
   apply Finset.sum_congr rfl
   intro σ _
-  rw [submatrix_sum]
+  rw [Matrix.submatrix_sum]
   apply Finset.sum_congr rfl
   intro τ _
   rw [Matrix.conjTranspose_submatrix,

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,29 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### single-Kraus Kronecker and isometric multiplication identities — promoted
+- **Pattern:** unfold `singleKrausMap`, reassociate matrix products, and use
+  Kronecker multiplication or the identity `Vᴴ * V = 1`.
+- **Seen:** duplicate 7-line and 8-line helpers in
+  `TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean` and
+  `TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean` before promotion
+  (2026-08-10).
+- **Abstraction:** `Matrix.singleKrausMap_kronecker` and
+  `Matrix.singleKrausMap_mul_of_isometry` in
+  `TNLean/Channel/SingleKrausPositivity.lean`.
+- **Notes:** both consumer modules now invoke the two matrix identities directly;
+  the private helper copies were removed.
+
+### finite-sum submatrix distribution — promoted
+- **Pattern:** prove that taking a submatrix commutes with a finite sum by
+  extensionality and entrywise simplification.
+- **Seen:** duplicate 6-line helpers in `TNLean/MPS/RFP/BNTOrthogonality.lean`
+  and `TNLean/MPS/RFP/PhysicalObservableRealization.lean` before promotion
+  (2026-08-10).
+- **Abstraction:** `Matrix.submatrix_sum` in `TNLean/Algebra/FinSum.lean`.
+- **Notes:** the theorem is polymorphic over the entry additive commutative
+  monoid. Its four motivating calls now share the neutral matrix identity.
+
 ### transfer-map irreducibility in Kraus-map notation — promoted
 - **Pattern:** use `Kraus.mapLM_eq_transferMap` to restate
   `IsIrreducibleMap (MPSTensor.transferMap F)` as


### PR DESCRIPTION
## What changed

- reuse the public sitewise physical-basis change theorem
- single-source Kronecker and isometry identities for single-Kraus maps
- add a neutral finite-sum `Matrix.submatrix_sum` theorem and remove both private variants
- preserve all existing public declarations and Blueprint tags

## Validation

- targeted build of all seven changed Lean modules (9,145 jobs)
- full `lake build` (10,036 jobs)
- Blueprint synchronization (7,061/7,061 entries)
- exact-head review approved `b2e761d5becd3cbd2e8f33524ee197af7e5ee6e0`
- generated import, proof-integrity, and duplicate scans
- `git diff --check`

Closes #5997
Advances #5995

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no API or proof-obligation changes beyond centralizing lemmas; validation described in the PR includes full build and Blueprint sync.
> 
> **Overview**
> This PR **deduplicates** repeated matrix and single-Kraus lemmas used across MPDO and RFP proofs by promoting them to shared declarations and wiring call sites to those APIs.
> 
> **`Matrix.submatrix_sum`** in `TNLean/Algebra/FinSum.lean` states that submatrices commute with finite sums; private copies in `BNTOrthogonality` and `PhysicalObservableRealization` are removed.
> 
> **`Matrix.singleKrausMap_kronecker`** and **`Matrix.singleKrausMap_mul_of_isometry`** live in `TNLean/Channel/SingleKrausPositivity.lean` (with expanded module docs). The same Kronecker and isometry multiplication proofs are deleted from `IsometricAdjacentBondTransport` and `PhysicalSupportProductTransport`; those files import the channel module and call the public names.
> 
> **`PhysicalSectorProductTransport`** drops a private `evalWord_changePhysicalBasis_ofFn` and uses **`MPOTensor.evalWord_changePhysicalBasis_ofFn`** from `SitewisePhysicalMatrix` (new import).
> 
> `docs/tactic_patterns.md` records both promotions. Public theorem statements and Blueprint tags are unchanged per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e761d5becd3cbd2e8f33524ee197af7e5ee6e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->