### PR TITLE
refactor(MPS/MPDO): share vertical canonical kernels

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -297,7 +297,7 @@ import TNLean.MPS.MPDO.VerticalBlockedOperatorRepresentations
 import TNLean.MPS.MPDO.VerticalBoundaryContraction
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.VerticalCanonicalForm
-import TNLean.MPS.MPDO.VerticalCanonicalFormAssembly
+import TNLean.MPS.MPDO.VerticalCanonicalFormConstruction
 import TNLean.MPS.MPDO.VerticalCoisometry
 import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.VerticalProductCornerComparison

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -153,6 +153,7 @@ import TNLean.MPS.MPDO.GSNNCHSectorSum
 import TNLean.MPS.MPDO.GroupedFigure8
 import TNLean.MPS.MPDO.GroupedGramNormalization
 import TNLean.MPS.MPDO.GroupedReferenceCorner
+import TNLean.MPS.MPDO.GroupedSectorGram
 import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.HayashiSectorProjector
 import TNLean.MPS.MPDO.HorizontalBNT
@@ -296,6 +297,7 @@ import TNLean.MPS.MPDO.VerticalBlockedOperatorRepresentations
 import TNLean.MPS.MPDO.VerticalBoundaryContraction
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.VerticalCanonicalForm
+import TNLean.MPS.MPDO.VerticalCanonicalFormAssembly
 import TNLean.MPS.MPDO.VerticalCoisometry
 import TNLean.MPS.MPDO.VerticalMapTransport
 import TNLean.MPS.MPDO.VerticalProductCornerComparison

--- a/TNLean/MPS/MPDO/CPSVGroupedFigureEight.lean
+++ b/TNLean/MPS/MPDO/CPSVGroupedFigureEight.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.CPSVFigureEight
 import TNLean.MPS.MPDO.CPSVVerticalBNT
-import TNLean.MPS.MPDO.GroupedReferenceCorner
+import TNLean.MPS.MPDO.GroupedSectorGram
 
 /-!
 # Figure 8 for actual grouped sectors under literal CPSV canonical form
@@ -78,25 +78,12 @@ theorem grouped_sector_gram_conj_eq
     let G := (X j q : Matrix (Fin (dim ((C).enum j q)))
       (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q
     G * A v * G⁻¹ = A v := by
-  classical
-  let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
-    (blocks ((C).repr j))
-  let cq := μ ((C).enum j q) * ζ j q
-  obtain ⟨W, c0, hc0, hCorner0⟩ :=
-    exists_distinguished_grouped_reference_corner blocks μ V hdim X ζ
-      hXDist hCoeffPos hCorner j q
-  have hCornerq : ∀ w,
-      (V ((C).enum j q))ᴴ * verticalTensor M w * V ((C).enum j q) =
-        cq • ((X j q : Matrix (Fin (dim ((C).enum j q)))
-            (Fin (dim ((C).enum j q))) ℂ) * A w *
-          (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
-            (Fin (dim ((C).enum j q))) ℂ)) := by
-    intro w
-    simpa [cq, A] using (hCorner j q w).symm
-  have hGram := hCanonical.gramDressing_eq_of_two_grouped_corners
-    M hM A (V ((C).enum j q)) W (X j q) 1 cq c0
-    (hCoeffPos j q) hc0 hCornerq (by intro w; simpa [A] using hCorner0 w)
-  simpa [gramDressing, A] using congrFun hGram v
+  apply MPOTensor.grouped_sector_gram_conj_eq_of_dressing blocks
+    (M := M) (μ := μ) (V := V) (hdim := hdim) (X := X) (ζ := ζ)
+      (hXDist := hXDist) (hCoeffPos := hCoeffPos) (hCorner := hCorner)
+  intro n A VX VY X' Y cX cY hcX hcY hcornerX hcornerY
+  exact hCanonical.gramDressing_eq_of_two_grouped_corners M hM
+    A VX VY X' Y cX cY hcX hcY hcornerX hcornerY
 
 end GroupedSectors
 

--- a/TNLean/MPS/MPDO/CPSVGroupedGramNormalization.lean
+++ b/TNLean/MPS/MPDO/CPSVGroupedGramNormalization.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.CanonicalForm.NormalCommutant
 import TNLean.MPS.MPDO.CPSVGroupedFigureEight
+import TNLean.MPS.MPDO.GroupedSectorGram
 
 /-!
 # Gram and unitary normalization of literal grouped vertical sectors
@@ -72,22 +72,16 @@ theorem grouped_sector_gram_eq_pos_smul_one
     ∃ ω : ℝ, 0 < ω ∧
       (X j q : Matrix (Fin (dim ((C).enum j q)))
         (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q = (ω : ℂ) • 1 := by
-  letI : NeZero (dim ((C).enum j q)) := ⟨(_hDimPos _).ne'⟩
-  let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
-    (blocks ((C).repr j))
-  have hNormalA : MPSTensor.IsNormal A :=
-    ((MPSTensor.isNormalTensor_cast_iff (hdim j q)
-      (blocks ((C).repr j))).2 (hNormal ((C).repr j))).isNormal
-  have hGramConj : ∀ v,
-      (X j q : Matrix (Fin (dim ((C).enum j q)))
-          (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q * A v *
-          (((X j q : Matrix (Fin (dim ((C).enum j q)))
-            (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q)⁻¹) = A v := by
-    intro v
-    simpa [A] using hCanonical.grouped_sector_gram_conj_eq blocks hM
-      μ V hdim X ζ hXDist hCoeffPos hCorner j q v
-  exact hNormalA.gram_eq_pos_smul_one_of_gram_conj_eq
-    (Matrix.isUnits_det_units (X j q)) hGramConj
+  apply MPOTensor.grouped_sector_gram_eq_pos_smul_one_of_dressing blocks
+    (M := M) (μ := μ) (V := V) (_hDimPos := _hDimPos) (hdim := hdim)
+      (X := X) (ζ := ζ) (hXDist := hXDist) (hCoeffPos := hCoeffPos)
+      (hCorner := hCorner)
+  · intro n A VX VY X' Y cX cY hcX hcY hcornerX hcornerY
+    exact hCanonical.gramDressing_eq_of_two_grouped_corners M hM
+      A VX VY X' Y cX cY hcX hcY hcornerX hcornerY
+  · intro l p
+    exact ((MPSTensor.isNormalTensor_cast_iff (hdim l p)
+      (blocks ((C).repr l))).2 (hNormal ((C).repr l))).isNormal
 
 /-- Every actual grouped vertical-sector gauge becomes unitary after division
 by the square root of its positive Gram scalar.

--- a/TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.CPSVFigureEight
 import TNLean.MPS.MPDO.CPSVVerticalBNT
-import TNLean.MPS.MPDO.VerticalCanonicalFormAssembly
+import TNLean.MPS.MPDO.VerticalCanonicalFormConstruction
 
 /-!
 # Vertical canonical form from literal CPSV canonical form

--- a/TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean
@@ -3,10 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.CPSVNormalizedGroupedSectors
+import TNLean.MPS.MPDO.CPSVFigureEight
 import TNLean.MPS.MPDO.CPSVVerticalBNT
-import TNLean.MPS.MPDO.VerticalBNTConstruction
-import TNLean.MPS.MPDO.VerticalCoisometry
+import TNLean.MPS.MPDO.VerticalCanonicalFormAssembly
 
 /-!
 # Vertical canonical form from literal CPSV canonical form
@@ -47,32 +46,10 @@ theorem verticalCF_of_cpsvCanonicalForm (M : MPOTensor d D)
     (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
     (hM : IsMPDO M) :
     IsVerticalCF M := by
-  classical
-  obtain ⟨r, dim, mu, blocks, V, hDimPos, _, hNormal, hIso, _, _, hInterStar,
-    _, hReconstruct, hdim, X, zeta, _, _, hXDist, _, _, hSpectralBNT, _, _, _, _,
-    hCoeffPos, hGroupedIso, hGroupedOrth, hGroupedInter, _, hGroupedCorner,
-    hGroupedReconstruct⟩ :=
-      hCanonical.exists_verticalBNTGrouping_with_isometry M hM
-  let C := MPSTensor.mpvPhaseClassData blocks
-  have hBNT : MPSTensor.IsBNT (verticalTensor M) C.g
-      (fun j ↦ dim (C.repr j)) (fun j ↦ blocks (C.repr j)) :=
-    isBNT_verticalTensor_of_grouping M mu blocks V hIso
-      hInterStar hReconstruct hSpectralBNT
-  obtain ⟨_, W, _, hWIso, hWOrth, hWInter, hWReconstruct⟩ :=
-    hCanonical.exists_normalized_grouped_sector_maps blocks hM mu V hDimPos
-      hNormal hdim X zeta hXDist hCoeffPos hGroupedIso hGroupedOrth
-      hGroupedInter hGroupedCorner hGroupedReconstruct
-  apply isVerticalCF_of_grouped_orthogonal_sectors M
-    (fun j ↦ dim (C.repr j)) C.copies C.copies_pos
-    (fun j q ↦ mu (C.enum j q) * zeta j q) hCoeffPos
-    (fun j ↦ blocks (C.repr j)) hBNT W hWIso hWOrth hWInter
-  intro v
-  rw [hWReconstruct v]
-  let f : ((j : Fin C.g) × Fin (C.copies j)) → Matrix (Fin d) (Fin d) ℂ :=
-    fun p ↦ W p *
-      ((mu (C.enum p.1 p.2) * zeta p.1 p.2) • blocks (C.repr p.1) v) *
-      (W p)ᴴ
-  change (∑ j, ∑ q, f ⟨j, q⟩) = ∑ q, f (finSigmaFinEquiv.symm q)
-  exact (Fintype.sum_finSigmaFinEquiv f).symm
+  apply verticalCF_of_grouping_and_gramDressing M
+  · exact hCanonical.exists_verticalBNTGrouping_with_isometry M hM
+  · intro n A VX VY X Y cX cY hcX hcY hcornerX hcornerY
+    exact hCanonical.gramDressing_eq_of_two_grouped_corners M hM
+      A VX VY X Y cX cY hcX hcY hcornerX hcornerY
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/GroupedFigure8.lean
+++ b/TNLean/MPS/MPDO/GroupedFigure8.lean
@@ -3,8 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.FigureEightPairwise
-import TNLean.MPS.MPDO.GroupedReferenceCorner
+import TNLean.MPS.MPDO.GroupedSectorGram
 import TNLean.MPS.MPDO.VerticalBNT
 
 /-!
@@ -81,25 +80,12 @@ theorem IsMPDO.grouped_sector_gram_conj_eq
     let G := (X j q : Matrix (Fin (dim ((C).enum j q)))
       (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q
     G * A v * G⁻¹ = A v := by
-  classical
-  let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
-    (blocks ((C).repr j))
-  let cq := μ ((C).enum j q) * ζ j q
-  obtain ⟨W, c0, hc0, hCorner0⟩ :=
-    exists_distinguished_grouped_reference_corner blocks μ V hdim X ζ
-      hXDist hCoeffPos hCorner j q
-  have hCornerq : ∀ w,
-      (V ((C).enum j q))ᴴ * verticalTensor M w * V ((C).enum j q) =
-        cq • ((X j q : Matrix (Fin (dim ((C).enum j q)))
-            (Fin (dim ((C).enum j q))) ℂ) * A w *
-          (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
-            (Fin (dim ((C).enum j q))) ℂ)) := by
-    intro w
-    simpa [cq, A] using (hCorner j q w).symm
-  have hGram := hHorizontal.gramDressing_eq_of_two_grouped_corners
-    M hM A (V ((C).enum j q)) W (X j q) 1 cq c0
-    (hCoeffPos j q) hc0 hCornerq (by intro w; simpa [A] using hCorner0 w)
-  simpa [gramDressing, A] using congrFun hGram v
+  apply grouped_sector_gram_conj_eq_of_dressing blocks
+    (M := M) (μ := μ) (V := V) (hdim := hdim) (X := X) (ζ := ζ)
+      (hXDist := hXDist) (hCoeffPos := hCoeffPos) (hCorner := hCorner)
+  intro n A VX VY X' Y cX cY hcX hcY hcornerX hcornerY
+  exact hHorizontal.gramDressing_eq_of_two_grouped_corners M hM
+    A VX VY X' Y cX cY hcX hcY hcornerX hcornerY
 
 end GroupedSectors
 

--- a/TNLean/MPS/MPDO/GroupedGramNormalization.lean
+++ b/TNLean/MPS/MPDO/GroupedGramNormalization.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.CanonicalForm.NormalCommutant
 import TNLean.MPS.MPDO.GroupedFigure8
+import TNLean.MPS.MPDO.GroupedSectorGram
 
 /-!
 # Gram and unitary normalization of grouped vertical sectors
@@ -75,22 +75,16 @@ theorem IsMPDO.grouped_sector_gram_eq_pos_smul_one
     ∃ ω : ℝ, 0 < ω ∧
       (X j q : Matrix (Fin (dim ((C).enum j q)))
         (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q = (ω : ℂ) • 1 := by
-  letI : NeZero (dim ((C).enum j q)) := ⟨(_hDimPos _).ne'⟩
-  let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
-    (blocks ((C).repr j))
-  have hNormalA : MPSTensor.IsNormal A :=
-    ((MPSTensor.isNormalTensor_cast_iff (hdim j q)
-      (blocks ((C).repr j))).2 (hNormal ((C).repr j))).isNormal
-  have hGramConj : ∀ v,
-      (X j q : Matrix (Fin (dim ((C).enum j q)))
-          (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q * A v *
-          (((X j q : Matrix (Fin (dim ((C).enum j q)))
-            (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q)⁻¹) = A v := by
-    intro v
-    simpa [A] using IsMPDO.grouped_sector_gram_conj_eq blocks hM hHorizontal
-      μ V hdim X ζ hXDist hCoeffPos hCorner j q v
-  exact hNormalA.gram_eq_pos_smul_one_of_gram_conj_eq
-    (Matrix.isUnits_det_units (X j q)) hGramConj
+  apply grouped_sector_gram_eq_pos_smul_one_of_dressing blocks
+    (M := M) (μ := μ) (V := V) (_hDimPos := _hDimPos) (hdim := hdim)
+      (X := X) (ζ := ζ) (hXDist := hXDist) (hCoeffPos := hCoeffPos)
+      (hCorner := hCorner)
+  · intro n A VX VY X' Y cX cY hcX hcY hcornerX hcornerY
+    exact hHorizontal.gramDressing_eq_of_two_grouped_corners M hM
+      A VX VY X' Y cX cY hcX hcY hcornerX hcornerY
+  · intro l p
+    exact ((MPSTensor.isNormalTensor_cast_iff (hdim l p)
+      (blocks ((C).repr l))).2 (hNormal ((C).repr l))).isNormal
 
 /-- Every actual grouped vertical-sector gauge becomes unitary after division
 by the square root of its positive Gram scalar.

--- a/TNLean/MPS/MPDO/GroupedSectorGram.lean
+++ b/TNLean/MPS/MPDO/GroupedSectorGram.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.MPDO.GroupedReferenceCorner
 # Gram kernels for grouped vertical sectors
 
 This file isolates the canonical-form-independent part of the grouped Figure 8
-argument. A grouped-corner Gram-dressing interface compares any two positive
+argument. A grouped-corner Gram-dressing hypothesis compares any two positive
 corners of one representative. The distinguished reference corner then makes
 each grouped Gram conjugation trivial, and normality forces the Gram matrix to
 be a positive scalar multiple of the identity.
@@ -68,7 +68,7 @@ variable (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
 
 local notation "C" => MPSTensor.mpvPhaseClassData blocks
 
-/-- The pairwise Gram-dressing interface and the distinguished identity-gauge
+/-- The pairwise Gram-dressing hypothesis and the distinguished identity-gauge
 corner imply that each grouped Gram conjugation fixes its representative.
 
 The hypotheses after `hDressing` are clauses of

--- a/TNLean/MPS/MPDO/GroupedSectorGram.lean
+++ b/TNLean/MPS/MPDO/GroupedSectorGram.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalCommutant
+import TNLean.MPS.MPDO.FigureEightPairwise
+import TNLean.MPS.MPDO.GroupedReferenceCorner
+
+/-!
+# Gram kernels for grouped vertical sectors
+
+This file isolates the canonical-form-independent part of the grouped Figure 8
+argument. A grouped-corner Gram-dressing interface compares any two positive
+corners of one representative. The distinguished reference corner then makes
+each grouped Gram conjugation trivial, and normality forces the Gram matrix to
+be a positive scalar multiple of the identity.
+
+## Main definitions
+
+* `MPOTensor.HasGroupedCornerGramDressing`: the pairwise Figure 8 input used by
+  the grouped-sector argument.
+
+## Main results
+
+* `MPOTensor.grouped_sector_gram_conj_eq_of_dressing`: the distinguished
+  identity-gauge corner makes a grouped Gram conjugation fix its representative.
+* `MPOTensor.grouped_sector_gram_eq_pos_smul_one_of_dressing`: normality makes
+  the grouped Gram matrix a positive scalar multiple of the identity.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, Figures 7--8 and lines 1903--1921.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Pairwise equality of Gram dressings for two positive vertical corners of a
+common representative.
+
+This is the exact canonical-form-specific input used by the grouped Figure 8
+argument. Both literal CPSV canonical form and normalized BNT-refined
+horizontal form provide this statement independently.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, Figures 7--8 and lines
+1909--1919. -/
+def HasGroupedCornerGramDressing (M : MPOTensor d D) : Prop :=
+  ∀ {n : ℕ} (A : MPSTensor (D * D) n)
+    (VX VY : Matrix (Fin d) (Fin n) ℂ) (X Y : GL (Fin n) ℂ)
+    (cX cY : ℂ), (0 : ℂ) < cX → (0 : ℂ) < cY →
+    (∀ v, VXᴴ * verticalTensor M v * VX =
+      cX • ((X : Matrix (Fin n) (Fin n) ℂ) * A v *
+        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ))) →
+    (∀ v, VYᴴ * verticalTensor M v * VY =
+      cY • ((Y : Matrix (Fin n) (Fin n) ℂ) * A v *
+        (↑(Y⁻¹) : Matrix (Fin n) (Fin n) ℂ))) →
+    gramDressing X A = gramDressing Y A
+
+section GroupedSectors
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+variable (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
+
+local notation "C" => MPSTensor.mpvPhaseClassData blocks
+
+/-- The pairwise Gram-dressing interface and the distinguished identity-gauge
+corner imply that each grouped Gram conjugation fixes its representative.
+
+The hypotheses after `hDressing` are clauses of
+`HasVerticalBNTGroupingWithIsometry`.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, Figures 7--8 and lines
+1903--1919. -/
+theorem grouped_sector_gram_conj_eq_of_dressing
+    {M : MPOTensor d D} (hDressing : HasGroupedCornerGramDressing M)
+    (μ : Fin r → ℂ) (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (hdim : ∀ j q, dim ((C).repr j) = dim ((C).enum j q))
+    (X : (j : Fin (C).g) → (q : Fin ((C).copies j)) →
+      GL (Fin (dim ((C).enum j q))) ℂ)
+    (ζ : (j : Fin (C).g) → Fin ((C).copies j) → ℂ)
+    (hXDist : ∀ j, X j ⟨0, (C).copies_pos j⟩ = 1)
+    (hCoeffPos : ∀ j q, (0 : ℂ) < μ ((C).enum j q) * ζ j q)
+    (hCorner : ∀ j q v,
+      (μ ((C).enum j q) * ζ j q) •
+          ((X j q : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ) *
+            (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+              (blocks ((C).repr j))) v *
+            (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ)) =
+        (V ((C).enum j q))ᴴ * verticalTensor M v * V ((C).enum j q))
+    (j : Fin (C).g) (q : Fin ((C).copies j))
+    (v : Fin (D * D)) :
+    let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
+      (blocks ((C).repr j))
+    let G := (X j q : Matrix (Fin (dim ((C).enum j q)))
+      (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q
+    G * A v * G⁻¹ = A v := by
+  classical
+  let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
+    (blocks ((C).repr j))
+  let cq := μ ((C).enum j q) * ζ j q
+  obtain ⟨W, c0, hc0, hCorner0⟩ :=
+    exists_distinguished_grouped_reference_corner blocks μ V hdim X ζ
+      hXDist hCoeffPos hCorner j q
+  have hCornerq : ∀ w,
+      (V ((C).enum j q))ᴴ * verticalTensor M w * V ((C).enum j q) =
+        cq • ((X j q : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ) * A w *
+          (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ)) := by
+    intro w
+    simpa [cq, A] using (hCorner j q w).symm
+  have hGram := hDressing A (V ((C).enum j q)) W (X j q) 1 cq c0
+    (hCoeffPos j q) hc0 hCornerq (by intro w; simpa [A] using hCorner0 w)
+  simpa [gramDressing, A] using congrFun hGram v
+
+/-- Normality and the grouped Figure 8 comparison force a grouped gauge Gram
+matrix to be a positive scalar multiple of the identity.
+
+Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1903--1921. -/
+theorem grouped_sector_gram_eq_pos_smul_one_of_dressing
+    {M : MPOTensor d D} (hDressing : HasGroupedCornerGramDressing M)
+    (μ : Fin r → ℂ) (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
+    (_hDimPos : ∀ k, 0 < dim k)
+    (hdim : ∀ j q, dim ((C).repr j) = dim ((C).enum j q))
+    (hNormal : ∀ j q, MPSTensor.IsNormal
+      (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+        (blocks ((C).repr j))))
+    (X : (j : Fin (C).g) → (q : Fin ((C).copies j)) →
+      GL (Fin (dim ((C).enum j q))) ℂ)
+    (ζ : (j : Fin (C).g) → Fin ((C).copies j) → ℂ)
+    (hXDist : ∀ j, X j ⟨0, (C).copies_pos j⟩ = 1)
+    (hCoeffPos : ∀ j q, (0 : ℂ) < μ ((C).enum j q) * ζ j q)
+    (hCorner : ∀ j q v,
+      (μ ((C).enum j q) * ζ j q) •
+          ((X j q : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ) *
+            (cast (congrArg (MPSTensor (D * D)) (hdim j q))
+              (blocks ((C).repr j))) v *
+            (↑((X j q)⁻¹) : Matrix (Fin (dim ((C).enum j q)))
+              (Fin (dim ((C).enum j q))) ℂ)) =
+        (V ((C).enum j q))ᴴ * verticalTensor M v * V ((C).enum j q))
+    (j : Fin (C).g) (q : Fin ((C).copies j)) :
+    ∃ ω : ℝ, 0 < ω ∧
+      (X j q : Matrix (Fin (dim ((C).enum j q)))
+        (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q = (ω : ℂ) • 1 := by
+  letI : NeZero (dim ((C).enum j q)) :=
+    ⟨(_hDimPos ((C).enum j q)).ne'⟩
+  let A := cast (congrArg (MPSTensor (D * D)) (hdim j q))
+    (blocks ((C).repr j))
+  have hNormalA : MPSTensor.IsNormal A := hNormal j q
+  have hGramConj : ∀ v,
+      (X j q : Matrix (Fin (dim ((C).enum j q)))
+          (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q * A v *
+          (((X j q : Matrix (Fin (dim ((C).enum j q)))
+            (Fin (dim ((C).enum j q))) ℂ)ᴴ * X j q)⁻¹) = A v := by
+    intro v
+    simpa [A] using grouped_sector_gram_conj_eq_of_dressing blocks hDressing
+      μ V hdim X ζ hXDist hCoeffPos hCorner j q v
+  exact hNormalA.gram_eq_pos_smul_one_of_gram_conj_eq
+    (Matrix.isUnits_det_units (X j q)) hGramConj
+
+end GroupedSectors
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.VerticalBNT
-import TNLean.MPS.MPDO.VerticalCanonicalFormAssembly
+import TNLean.MPS.MPDO.VerticalCanonicalFormConstruction
 
 /-!
 # Vertical canonical form of matrix product density operators

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.NormalizedGroupedSectors
-import TNLean.MPS.MPDO.VerticalBNTConstruction
-import TNLean.MPS.MPDO.VerticalCoisometry
+import TNLean.MPS.MPDO.FigureEightPairwise
+import TNLean.MPS.MPDO.VerticalBNT
+import TNLean.MPS.MPDO.VerticalCanonicalFormAssembly
 
 /-!
 # Vertical canonical form of matrix product density operators
@@ -53,32 +53,10 @@ Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem verticalCF_of_horizontalCF (M : MPOTensor d D)
     (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
     IsVerticalCF M := by
-  classical
-  obtain ⟨r, dim, mu, blocks, V, hDimPos, _, hNormal, hIso, _, _, hInterStar,
-    _, hReconstruct, hdim, X, zeta, _, _, hXDist, _, _, hSpectralBNT, _, _, _, _,
-    hCoeffPos, hGroupedIso, hGroupedOrth, hGroupedInter, _, hGroupedCorner,
-    hGroupedReconstruct⟩ :=
-      hHorizontal.exists_verticalBNTGrouping_with_isometry M hM
-  let C := MPSTensor.mpvPhaseClassData blocks
-  have hBNT : MPSTensor.IsBNT (verticalTensor M) C.g
-      (fun j ↦ dim (C.repr j)) (fun j ↦ blocks (C.repr j)) :=
-    isBNT_verticalTensor_of_grouping M mu blocks V hIso
-      hInterStar hReconstruct hSpectralBNT
-  obtain ⟨_, W, _, hWIso, hWOrth, hWInter, hWReconstruct⟩ :=
-    hM.exists_normalized_grouped_sector_maps blocks hHorizontal mu V hDimPos
-      hNormal hdim X zeta hXDist hCoeffPos hGroupedIso hGroupedOrth
-      hGroupedInter hGroupedCorner hGroupedReconstruct
-  apply isVerticalCF_of_grouped_orthogonal_sectors M
-    (fun j ↦ dim (C.repr j)) C.copies C.copies_pos
-    (fun j q ↦ mu (C.enum j q) * zeta j q) hCoeffPos
-    (fun j ↦ blocks (C.repr j)) hBNT W hWIso hWOrth hWInter
-  intro v
-  rw [hWReconstruct v]
-  let f : ((j : Fin C.g) × Fin (C.copies j)) → Matrix (Fin d) (Fin d) ℂ :=
-    fun p ↦ W p *
-      ((mu (C.enum p.1 p.2) * zeta p.1 p.2) • blocks (C.repr p.1) v) *
-      (W p)ᴴ
-  change (∑ j, ∑ q, f ⟨j, q⟩) = ∑ q, f (finSigmaFinEquiv.symm q)
-  exact (Fintype.sum_finSigmaFinEquiv f).symm
+  apply verticalCF_of_grouping_and_gramDressing M
+  · exact hHorizontal.exists_verticalBNTGrouping_with_isometry M hM
+  · intro n A VX VY X Y cX cY hcX hcY hcornerX hcornerY
+    exact hHorizontal.gramDressing_eq_of_two_grouped_corners M hM
+      A VX VY X Y cX cY hcX hcY hcornerX hcornerY
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalCanonicalFormAssembly.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalFormAssembly.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.GroupedSectorGram
+import TNLean.MPS.MPDO.NormalizedGroupedSectorMaps
+import TNLean.MPS.MPDO.VerticalBNT
+import TNLean.MPS.MPDO.VerticalBNTConstruction
+import TNLean.MPS.MPDO.VerticalCoisometry
+
+/-!
+# Predicate-neutral vertical canonical-form assembly
+
+A grouped vertical BNT decomposition and pairwise grouped-corner Gram dressing
+supply all data needed for vertical canonical form. The grouped representatives
+form a BNT, Gram rigidity normalizes the physical sector maps, and their block
+row gives the required coisometry and exact reconstruction.
+
+## Main result
+
+* `MPOTensor.verticalCF_of_grouping_and_gramDressing`: grouped vertical BNT
+  data and the pairwise Figure 8 interface imply vertical canonical form.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, lines 1863--1921.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Grouped vertical BNT data with pairwise Figure 8 comparison assemble into
+vertical canonical form.
+
+The grouping contains the normal representatives, positive grouped weights,
+orthogonal physical corners, and exact reconstruction. The Gram-dressing
+interface is the only canonical-form-specific input.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
+theorem verticalCF_of_grouping_and_gramDressing (M : MPOTensor d D)
+    (hGrouping : HasVerticalBNTGroupingWithIsometry M)
+    (hDressing : HasGroupedCornerGramDressing M) :
+    IsVerticalCF M := by
+  classical
+  obtain ⟨r, dim, mu, blocks, V, hDimPos, _, hNormal, hIso, _, _, hInterStar,
+    _, hReconstruct, hdim, X, zeta, _, _, hXDist, _, _, hSpectralBNT, _, _, _, _,
+    hCoeffPos, hGroupedIso, hGroupedOrth, hGroupedInter, _, hGroupedCorner,
+    hGroupedReconstruct⟩ := hGrouping
+  let C := MPSTensor.mpvPhaseClassData blocks
+  have hBNT : MPSTensor.IsBNT (verticalTensor M) C.g
+      (fun j ↦ dim (C.repr j)) (fun j ↦ blocks (C.repr j)) :=
+    isBNT_verticalTensor_of_grouping M mu blocks V hIso
+      hInterStar hReconstruct hSpectralBNT
+  have hGram : ∀ j q, ∃ omega : ℝ, 0 < omega ∧
+      (X j q : Matrix (Fin (dim (C.enum j q))) (Fin (dim (C.enum j q))) ℂ)ᴴ *
+          X j q = (omega : ℂ) • 1 := by
+    intro j q
+    apply grouped_sector_gram_eq_pos_smul_one_of_dressing blocks
+      (M := M) (μ := mu) (V := V) (_hDimPos := hDimPos) (hdim := hdim)
+        (X := X) (ζ := zeta) (hXDist := hXDist) (hCoeffPos := hCoeffPos)
+        (hCorner := hGroupedCorner) (j := j) (q := q)
+    · exact hDressing
+    · intro l p
+      exact ((MPSTensor.isNormalTensor_cast_iff (hdim l p)
+        (blocks (C.repr l))).2 (hNormal (C.repr l))).isNormal
+  obtain ⟨_, W, _, hWIso, hWOrth, hWInter, hWReconstruct⟩ :=
+    exists_normalized_grouped_sector_maps_of_gram blocks mu V hdim X zeta
+      hGram hGroupedIso hGroupedOrth hGroupedInter hGroupedReconstruct
+  apply isVerticalCF_of_grouped_orthogonal_sectors M
+    (fun j ↦ dim (C.repr j)) C.copies C.copies_pos
+    (fun j q ↦ mu (C.enum j q) * zeta j q) hCoeffPos
+    (fun j ↦ blocks (C.repr j)) hBNT W hWIso hWOrth hWInter
+  intro v
+  rw [hWReconstruct v]
+  let f : ((j : Fin C.g) × Fin (C.copies j)) → Matrix (Fin d) (Fin d) ℂ :=
+    fun p ↦ W p *
+      ((mu (C.enum p.1 p.2) * zeta p.1 p.2) • blocks (C.repr p.1) v) *
+      (W p)ᴴ
+  change (∑ j, ∑ q, f ⟨j, q⟩) = ∑ q, f (finSigmaFinEquiv.symm q)
+  exact (Fintype.sum_finSigmaFinEquiv f).symm
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalCanonicalFormConstruction.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalFormConstruction.lean
@@ -10,17 +10,17 @@ import TNLean.MPS.MPDO.VerticalBNTConstruction
 import TNLean.MPS.MPDO.VerticalCoisometry
 
 /-!
-# Predicate-neutral vertical canonical-form assembly
+# Predicate-neutral vertical canonical form
 
 A grouped vertical BNT decomposition and pairwise grouped-corner Gram dressing
 supply all data needed for vertical canonical form. The grouped representatives
 form a BNT, Gram rigidity normalizes the physical sector maps, and their block
 row gives the required coisometry and exact reconstruction.
 
-## Main result
+## Main results
 
 * `MPOTensor.verticalCF_of_grouping_and_gramDressing`: grouped vertical BNT
-  data and the pairwise Figure 8 interface imply vertical canonical form.
+  data and the pairwise Figure 8 hypothesis imply vertical canonical form.
 
 ## References
 
@@ -34,12 +34,12 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- Grouped vertical BNT data with pairwise Figure 8 comparison assemble into
+/-- Grouped vertical BNT data with pairwise Figure 8 comparison determine a
 vertical canonical form.
 
 The grouping contains the normal representatives, positive grouped weights,
 orthogonal physical corners, and exact reconstruction. The Gram-dressing
-interface is the only canonical-form-specific input.
+hypothesis is the only canonical-form-specific input.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem verticalCF_of_grouping_and_gramDressing (M : MPOTensor d D)

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -712,7 +712,7 @@
     \lean{MPOTensor.IsMPDO.grouped_sector_gram_eq_pos_smul_one}
     \lean{MPOTensor.IsMPDO.grouped_sector_exists_unitary_normalization}
     \leanok
-    \uses{thm:mpdo_grouped_sector_gram_conjugation,
+    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:eq3_of_dressed_adjoint,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
     In the grouped vertical decomposition of a matrix-product density
@@ -740,12 +740,13 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_grouped_sector_gram_conjugation,
-        thm:eq3_of_dressed_adjoint}
+    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
+        thm:eq3_of_dressed_adjoint,
+        thm:mpdo_vertical_bnt_grouping_with_isometries}
     Transport the normal representative to the bond space of the chosen
-    copy. Theorem~\ref{thm:mpdo_grouped_sector_gram_conjugation} states that
-    conjugation by $X_{\alpha,k}^\dagger X_{\alpha,k}$ fixes every letter of
-    the transported tensor. Apply
+    copy. Compare its positive corner with the distinguished identity-gauge
+    corner using
+    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation}. Then apply
     Theorem~\ref{thm:eq3_of_dressed_adjoint} with the second gauge equal to
     the identity. The resulting Gram identity has a positive real scalar,
     and division by its positive square root gives the stated unitary.
@@ -756,7 +757,7 @@
     \lean{MPSTensor.IsCPSVCanonicalForm.grouped_sector_gram_eq_pos_smul_one}
     \lean{MPSTensor.IsCPSVCanonicalForm.grouped_sector_exists_unitary_normalization}
     \leanok
-    \uses{thm:cpsv_literal_grouped_sector_gram_conjugation,
+    \uses{thm:cpsv_literal_pairwise_vertical_gram_conjugation,
         thm:eq3_of_dressed_adjoint,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
     In the actual phase-class grouping under literal CPSV canonical form,
@@ -776,14 +777,16 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_literal_grouped_sector_gram_conjugation,
-        thm:eq3_of_dressed_adjoint}
-    The representative on this bond space is normal.  Apply normal Gram
-    rigidity to
-    (\ref{eq:cpsv_literal_grouped_gram_conj}) with the distinguished gauge
-    equal to the identity.  This gives
+    \uses{thm:cpsv_literal_pairwise_vertical_gram_conjugation,
+        thm:eq3_of_dressed_adjoint,
+        thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
+    The representative on this bond space is normal. Compare its positive
+    corner with the distinguished identity-gauge corner using the literal
+    pairwise Figure~8 theorem. Then apply
+    Theorem~\ref{thm:eq3_of_dressed_adjoint} with the second gauge equal to
+    the identity. This gives
     (\ref{eq:cpsv_literal_grouped_gram_scalar}) with
-    $\omega_{\alpha,q}>0$.  Dividing by its positive square root gives a
+    $\omega_{\alpha,q}>0$. Dividing by its positive square root gives a
     unitary matrix.
 \end{proof}
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -602,12 +602,12 @@ abstracted — record why, so it is not re-proposed).
   separate public wrappers, each supplying its own Gram theorem without adapting
   one canonical-form hypothesis to the other.
 
-### Vertical canonical-form assembly from grouped sectors
+### Vertical canonical form from grouped sectors
 - **Pattern:** the literal CPSV and horizontal capstones both unpacked the same grouped BNT
   witness, built the vertical BNT, normalized its sector maps, and reindexed the same dependent
   double sum before applying the grouped-sector coisometry theorem.
 - **Reuse:** `MPOTensor.verticalCF_of_grouping_and_gramDressing` in
-  `TNLean/MPS/MPDO/VerticalCanonicalFormAssembly.lean` takes
+  `TNLean/MPS/MPDO/VerticalCanonicalFormConstruction.lean` takes
   `HasVerticalBNTGroupingWithIsometry M` and `HasGroupedCornerGramDressing M`; it does not require
   an unused `IsMPDO M` hypothesis.
 - **Result:** `verticalCF_of_cpsvCanonicalForm` and `verticalCF_of_horizontalCF` are thin,

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -575,8 +575,20 @@ abstracted — record why, so it is not re-proposed).
   pairwise marked-separation result.
 - **Result:** the existing horizontal theorem keeps its statement, the literal theorem uses
   the same dimension-dependent construction, and neither canonical-form surface is adapted
-  to the other. Identity-reference Gram rigidity is shared through
-  `MPSTensor.IsNormal.gram_eq_pos_smul_one_of_gram_conj_eq`.
+  to the other.
+
+### Grouped-sector Figure Eight and Gram rigidity
+- **Pattern:** the horizontal BNT-refined and literal CPSV grouped-sector proofs repeated the
+  distinguished-corner comparison and the subsequent normal-commutant argument, differing
+  only in the theorem that equates two positive-corner Gram dressings.
+- **Reuse:** `MPOTensor.HasGroupedCornerGramDressing`,
+  `grouped_sector_gram_conj_eq_of_dressing`, and
+  `grouped_sector_gram_eq_pos_smul_one_of_dressing` in
+  `TNLean/MPS/MPDO/GroupedSectorGram.lean` isolate the predicate-neutral Figure Eight and
+  Gram-rigidity steps.
+- **Result:** both Figure Eight and Gram-normalization theorem families keep their exact public
+  statements and independently supply their literal-CPSV or horizontal Gram-dressing theorem.
+  No implication between the two canonical-form predicates is used.
 
 ### Positive-Gram provider for normalized grouped sectors
 - **Pattern:** the horizontal BNT-refined and literal CPSV grouped-sector theorems
@@ -589,6 +601,18 @@ abstracted — record why, so it is not re-proposed).
   `MPSTensor.IsCPSVCanonicalForm.exists_normalized_grouped_sector_maps` remain
   separate public wrappers, each supplying its own Gram theorem without adapting
   one canonical-form hypothesis to the other.
+
+### Vertical canonical-form assembly from grouped sectors
+- **Pattern:** the literal CPSV and horizontal capstones both unpacked the same grouped BNT
+  witness, built the vertical BNT, normalized its sector maps, and reindexed the same dependent
+  double sum before applying the grouped-sector coisometry theorem.
+- **Reuse:** `MPOTensor.verticalCF_of_grouping_and_gramDressing` in
+  `TNLean/MPS/MPDO/VerticalCanonicalFormAssembly.lean` takes
+  `HasVerticalBNTGroupingWithIsometry M` and `HasGroupedCornerGramDressing M`; it does not require
+  an unused `IsMPDO M` hypothesis.
+- **Result:** `verticalCF_of_cpsvCanonicalForm` and `verticalCF_of_horizontalCF` are thin,
+  source-facing wrappers. Each independently supplies its own grouping theorem and pairwise
+  Figure Eight theorem, preserving the strict separation of their canonical-form predicates.
 
 ### Canonical-form sector-compression separation
 - **Pattern:** the horizontal BNT-refined and literal CPSV surfaces separately turned


### PR DESCRIPTION
## What changed

- add a predicate-neutral grouped-corner Gram-dressing interface
- share the grouped-sector Gram conjugation and rigidity proofs
- add one vertical-canonical-form capstone from grouping and Gram dressing
- keep literal CPSV canonical form and stronger horizontal canonical form independent
- preserve all 10 existing public theorem signatures and Blueprint tags

## Validation

- targeted builds for both theorem families and both normalized wrappers (9,005 jobs)
- full `lake build` (10,039 jobs)
- import graph cycle check across 1,379 modules
- Blueprint synchronization (7,061/7,061 entries)
- generated import-aggregator check
- exact-head review approved `4a8e062ec4338d42f481a8e15d0a7de3f0603d5a`
- `git diff --check`

Closes #6000
Advances #5995

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactoring with duplicated logic consolidated behind new interfaces; public theorem statements unchanged and validation (builds, blueprint sync) reported in the PR.
> 
> **Overview**
> Extracts the **predicate-neutral** grouped-sector Figure 8 and Gram-rigidity steps that were duplicated between literal CPSV and horizontal BNT-refined proofs into `GroupedSectorGram.lean`, parameterized by `HasGroupedCornerGramDressing`.
> 
> **Figure 8 and Gram normalization** in the CPSV and horizontal grouped-sector files now call `grouped_sector_gram_conj_eq_of_dressing` and `grouped_sector_gram_eq_pos_smul_one_of_dressing`; each surface still supplies its own `gramDressing_eq_of_two_grouped_corners` witness—no cross-implication between canonical-form predicates.
> 
> **Vertical canonical form capstone:** `verticalCF_of_grouping_and_gramDressing` in `VerticalCanonicalFormConstruction.lean` centralizes the grouped BNT unpack, Gram normalization, and sum reindexing; `verticalCF_of_cpsvCanonicalForm` and `verticalCF_of_horizontalCF` become thin wrappers.
> 
> Blueprint normalization proofs and `docs/tactic_patterns.md` are updated to match the shared proof structure. **All existing public theorem signatures and Blueprint tags are preserved.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8a8ef7c8ba14d9885e54bf4778619bf6540df5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->