### PR TITLE
feat(QCA): add algebraic local observable limit

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -9,3 +9,4 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.QCA
 
 import TNLean.QCA.LocalAlgebra
+import TNLean.QCA.LocalLimit

--- a/TNLean/QCA/LocalLimit.lean
+++ b/TNLean/QCA/LocalLimit.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.LocalAlgebra
+import Mathlib.Algebra.Colimit.DirectLimit
+
+/-!
+# The algebraic local algebra of a one-dimensional spin chain
+
+The finite-region local observable algebras form a directed system under the canonical
+identity-tensor inclusions.  This file defines their concrete algebraic direct limit and the
+finite-support API for local observables.  It does not take the norm completion, so the
+quasi-local C⋆-algebra is not defined here.
+
+## Main definitions
+
+* `SpinChain.AlgebraicLocalAlgebra` — the algebraic local algebra.
+* `SpinChain.localObservable` — the canonical inclusion of a finite-region local algebra.
+* `SpinChain.SupportedIn` — a local observable represented on a specified finite region.
+* `SpinChain.algebraicLocalAlgebraLift` — the star-preserving universal map from the limit.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2285--2300.
+* Schumacher--Werner, quant-ph/0405174, Definition 1.
+-/
+
+namespace SpinChain
+
+/-- The transition map in the directed system of finite-region local algebras. -/
+noncomputable abbrev localAlgebraMap (d : ℕ) (Λ Γ : Finset ℤ) (h : Λ ⊆ Γ) :
+    LocalAlgebra d Λ →⋆ₐ[ℂ] LocalAlgebra d Γ :=
+  localInclusion h
+
+/-- The finite-region local algebras and their canonical inclusions form a directed system.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2295. -/
+instance instDirectedSystemLocalAlgebra (d : ℕ) :
+    DirectedSystem (LocalAlgebra d) (localAlgebraMap d · · ·) where
+  map_self {Λ} A := by
+    change localInclusion (show Λ ⊆ Λ from le_rfl) A = A
+    rw [localInclusion_refl]
+    rfl
+  map_map {k} {j} {i} hΛΓ hΓΔ A := by
+    change localInclusion hΓΔ (localInclusion hΛΓ A) =
+      localInclusion (hΛΓ.trans hΓΔ) A
+    exact DFunLike.congr_fun (localInclusion_trans hΛΓ hΓΔ) A
+
+/-- The algebraic local algebra of a spin chain is the direct limit of the local observable
+algebras over finite regions.
+
+This is \(\mathcal A_{\mathrm{loc}}=\bigcup_\Lambda^\infty \mathcal A_\Lambda\) in the
+paper.  No norm completion is taken.
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+abbrev AlgebraicLocalAlgebra (d : ℕ) :=
+  DirectLimit (LocalAlgebra d) (localAlgebraMap d)
+
+/-- The canonical inclusion of the local algebra on the finite region \(\Lambda\) into the
+algebraic local algebra.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2295. -/
+noncomputable def localObservable (d : ℕ) (Λ : Finset ℤ) :
+    LocalAlgebra d Λ →⋆ₐ[ℂ] AlgebraicLocalAlgebra d where
+  __ := DirectLimit.Algebra.of (LocalAlgebra d) (localAlgebraMap d) Λ
+  map_star' A := (DirectLimit.star_def Λ A).symm
+
+/-- Canonical inclusions agree after enlarging the finite region. -/
+@[simp]
+lemma localObservable_localInclusion (d : ℕ) {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
+    (A : LocalAlgebra d Λ) :
+    localObservable d Γ (localInclusion h A) = localObservable d Λ A :=
+  DirectLimit.Algebra.of_f h A
+
+/-- For positive on-site dimension, every canonical finite-region inclusion into the
+algebraic local algebra is injective. -/
+lemma localObservable_injective (d : ℕ) [NeZero d] (Λ : Finset ℤ) :
+    Function.Injective (localObservable d Λ) := by
+  apply DirectLimit.mk_injective (f := localAlgebraMap d)
+  intro i j h
+  exact localInclusion_injective (d := d) h
+
+section UniversalProperty
+
+variable {d : ℕ} {B : Type*} [Semiring B] [Star B] [Algebra ℂ B]
+
+/-- A compatible family of star-algebra homomorphisms from all finite-region local algebras
+induces a star-algebra homomorphism from the algebraic local algebra. -/
+noncomputable def algebraicLocalAlgebraLift
+    (g : (Λ : Finset ℤ) → LocalAlgebra d Λ →⋆ₐ[ℂ] B)
+    (hg : ∀ (Λ Γ : Finset ℤ) (h : Λ ⊆ Γ) (A : LocalAlgebra d Λ),
+      g Γ (localInclusion h A) = g Λ A) :
+    AlgebraicLocalAlgebra d →⋆ₐ[ℂ] B where
+  __ := DirectLimit.Algebra.lift (LocalAlgebra d) (localAlgebraMap d) B
+    (fun Λ ↦ (g Λ).toAlgHom) hg
+  map_star' x := by
+    induction x using DirectLimit.induction with
+    | _ Λ A => exact map_star (g Λ) A
+
+/-- The universal map agrees with the supplied map on every finite-region local algebra. -/
+@[simp]
+lemma algebraicLocalAlgebraLift_localObservable
+    (g : (Λ : Finset ℤ) → LocalAlgebra d Λ →⋆ₐ[ℂ] B)
+    (hg : ∀ (Λ Γ : Finset ℤ) (h : Λ ⊆ Γ) (A : LocalAlgebra d Λ),
+      g Γ (localInclusion h A) = g Λ A)
+    (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    algebraicLocalAlgebraLift g hg (localObservable d Λ A) = g Λ A :=
+  rfl
+
+/-- Star-algebra homomorphisms from the algebraic local algebra are equal when they agree on
+all finite-region local observables. -/
+@[ext]
+lemma algebraicLocalAlgebra_starAlgHom_ext {f g : AlgebraicLocalAlgebra d →⋆ₐ[ℂ] B}
+    (h : ∀ Λ, f.comp (localObservable d Λ) = g.comp (localObservable d Λ)) : f = g := by
+  ext x
+  induction x using DirectLimit.induction with
+  | _ Λ A => exact DFunLike.congr_fun (h Λ) A
+
+/-- The star-preserving lift is the unique homomorphism extending a compatible family of
+finite-region maps. -/
+lemma algebraicLocalAlgebraLift_unique
+    (g : (Λ : Finset ℤ) → LocalAlgebra d Λ →⋆ₐ[ℂ] B)
+    (hg : ∀ (Λ Γ : Finset ℤ) (h : Λ ⊆ Γ) (A : LocalAlgebra d Λ),
+      g Γ (localInclusion h A) = g Λ A)
+    (f : AlgebraicLocalAlgebra d →⋆ₐ[ℂ] B)
+    (hf : ∀ Λ, f.comp (localObservable d Λ) = g Λ) :
+    f = algebraicLocalAlgebraLift g hg := by
+  apply algebraicLocalAlgebra_starAlgHom_ext
+  intro Λ
+  rw [hf]
+  ext A
+  exact (algebraicLocalAlgebraLift_localObservable g hg Λ A).symm
+
+end UniversalProperty
+
+/-- A local observable is supported in the finite region \(\Lambda\) when it has a
+representative in \(\mathcal A_\Lambda\).
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+def SupportedIn {d : ℕ} (A : AlgebraicLocalAlgebra d) (Λ : Finset ℤ) : Prop :=
+  ∃ a : LocalAlgebra d Λ, localObservable d Λ a = A
+
+namespace SupportedIn
+
+variable {d : ℕ} {A B : AlgebraicLocalAlgebra d} {Λ Γ : Finset ℤ}
+
+/-- Support is monotone under enlargement of the finite region. -/
+lemma mono (hA : SupportedIn A Λ) (hΛΓ : Λ ⊆ Γ) : SupportedIn A Γ := by
+  obtain ⟨a, rfl⟩ := hA
+  exact ⟨localInclusion hΛΓ a, localObservable_localInclusion d hΛΓ a⟩
+
+/-- A support remains a support after adjoining another finite region. -/
+lemma union_left (hA : SupportedIn A Λ) : SupportedIn A (Λ ∪ Γ) :=
+  hA.mono Finset.subset_union_left
+
+/-- A support remains a support when it is the right member of a finite union. -/
+lemma union_right (hA : SupportedIn A Γ) : SupportedIn A (Λ ∪ Γ) :=
+  hA.mono Finset.subset_union_right
+
+/-- The sum of local observables is supported in the union of their finite regions. -/
+lemma add (hA : SupportedIn A Λ) (hB : SupportedIn B Γ) :
+    SupportedIn (A + B) (Λ ∪ Γ) := by
+  obtain ⟨a, ha⟩ := hA.union_left (Γ := Γ)
+  obtain ⟨b, hb⟩ := hB.union_right (Λ := Λ)
+  exact ⟨a + b, by rw [map_add, ha, hb]⟩
+
+/-- The product of local observables is supported in the union of their finite regions. -/
+lemma mul (hA : SupportedIn A Λ) (hB : SupportedIn B Γ) :
+    SupportedIn (A * B) (Λ ∪ Γ) := by
+  obtain ⟨a, ha⟩ := hA.union_left (Γ := Γ)
+  obtain ⟨b, hb⟩ := hB.union_right (Λ := Λ)
+  exact ⟨a * b, by rw [map_mul, ha, hb]⟩
+
+/-- Taking the adjoint does not enlarge the support of a local observable. -/
+lemma star (hA : SupportedIn A Λ) : SupportedIn (star A) Λ := by
+  obtain ⟨a, rfl⟩ := hA
+  exact ⟨star a, map_star (localObservable d Λ) a⟩
+
+/-- The zero local observable is supported in every finite region. -/
+lemma zero (d : ℕ) (Λ : Finset ℤ) : SupportedIn (0 : AlgebraicLocalAlgebra d) Λ :=
+  ⟨0, map_zero (localObservable d Λ)⟩
+
+/-- The unit local observable is supported in every finite region. -/
+lemma one (d : ℕ) (Λ : Finset ℤ) : SupportedIn (1 : AlgebraicLocalAlgebra d) Λ :=
+  ⟨1, map_one (localObservable d Λ)⟩
+
+end SupportedIn
+
+/-- Every element of the algebraic local algebra is a local observable with some finite
+support. -/
+lemma exists_supportedIn (A : AlgebraicLocalAlgebra d) :
+    ∃ Λ : Finset ℤ, SupportedIn A Λ := by
+  obtain ⟨Λ, a, rfl⟩ := DirectLimit.exists_eq_mk (localAlgebraMap d) A
+  exact ⟨Λ, a, rfl⟩
+
+end SpinChain

--- a/TNLean/QCA/LocalLimit.lean
+++ b/TNLean/QCA/LocalLimit.lean
@@ -10,8 +10,8 @@ import Mathlib.Algebra.Colimit.DirectLimit
 # The algebraic local algebra of a one-dimensional spin chain
 
 The finite-region local observable algebras form a directed system under the canonical
-identity-tensor inclusions.  This file defines their concrete algebraic direct limit and the
-finite-support API for local observables.  It does not take the norm completion, so the
+identity-tensor inclusions. This file defines their concrete algebraic direct limit and the
+finite-support properties of local observables. It does not take the norm completion, so the
 quasi-local C⋆-algebra is not defined here.
 
 ## Main definitions
@@ -94,9 +94,7 @@ noncomputable def algebraicLocalAlgebraLift
     AlgebraicLocalAlgebra d →⋆ₐ[ℂ] B where
   __ := DirectLimit.Algebra.lift (LocalAlgebra d) (localAlgebraMap d) B
     (fun Λ ↦ (g Λ).toAlgHom) hg
-  map_star' x := by
-    induction x using DirectLimit.induction with
-    | _ Λ A => exact map_star (g Λ) A
+  map_star' := DirectLimit.lift_star g fun i j h A ↦ (hg i j h A).symm
 
 /-- The universal map agrees with the supplied map on every finite-region local algebra. -/
 @[simp]

--- a/TNLean/QCA/LocalLimit.lean
+++ b/TNLean/QCA/LocalLimit.lean
@@ -21,6 +21,14 @@ quasi-local C⋆-algebra is not defined here.
 * `SpinChain.SupportedIn` — a local observable represented on a specified finite region.
 * `SpinChain.algebraicLocalAlgebraLift` — the star-preserving universal map from the limit.
 
+## Main results
+
+* `SpinChain.localObservable_injective` — finite-region observables embed faithfully.
+* `SpinChain.algebraicLocalAlgebraLift_unique` — the star-algebra universal property.
+* `SpinChain.exists_supportedIn` — every local observable has finite support.
+* `SpinChain.SupportedIn.add`, `SpinChain.SupportedIn.mul`, `SpinChain.SupportedIn.star` —
+  finite supports are closed under the star-algebra operations.
+
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2285--2300.
@@ -187,7 +195,7 @@ end SupportedIn
 
 /-- Every element of the algebraic local algebra is a local observable with some finite
 support. -/
-lemma exists_supportedIn (A : AlgebraicLocalAlgebra d) :
+lemma exists_supportedIn {d : ℕ} (A : AlgebraicLocalAlgebra d) :
     ∃ Λ : Finset ℤ, SupportedIn A Λ := by
   obtain ⟨Λ, a, rfl⟩ := DirectLimit.exists_eq_mk (localAlgebraMap d) A
   exact ⟨Λ, a, rfl⟩

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3150,7 +3150,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{definition}[Algebraic local algebra]
   \label{def:qca_algebraic_local_algebra}
   \lean{SpinChain.instDirectedSystemLocalAlgebra,
-    SpinChain.AlgebraicLocalAlgebra,SpinChain.localObservable}
+    SpinChain.AlgebraicLocalAlgebra,SpinChain.localObservable,
+    SpinChain.localObservable_localInclusion}
   \leanok
   \uses{def:qca_local_algebra,def:qca_local_inclusion,
     lem:qca_local_inclusion_refl,lem:qca_local_inclusion_trans}
@@ -3163,13 +3164,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
   For every finite region $\Lambda$, write
   $\iota_\Lambda\colon\mathcal A_\Lambda\to\mathcal A_{\mathrm{loc}}$
-  for the canonical inclusion.  These inclusions satisfy
+  for the canonical inclusion.  Whenever $\Lambda\subseteq\Gamma$, these
+  inclusions satisfy
   \begin{align}
-    \iota_\Gamma\circ\iota_{\Lambda,\Gamma}&=\iota_\Lambda
-    &&(\Lambda\subseteq\Gamma).
+    \iota_\Gamma\circ\iota_{\Lambda,\Gamma}&=\iota_\Lambda.
   \end{align}
-  This is the union $\bigcup_\Lambda^\infty\mathcal A_\Lambda$ in the
-  Appendix of \cite{Cirac2017MPU}.  No norm completion is taken.
+  This is the union
+  $\bigcup_{\Lambda\Subset\mathbb Z}\mathcal A_\Lambda$ in the Appendix of
+  \cite{Cirac2017MPU}.  No norm completion is taken.
 \end{definition}
 
 \begin{theorem}[Star-algebra universal property]
@@ -3182,10 +3184,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:qca_algebraic_local_algebra}
   Let $B$ be a complex star algebra.  Suppose that for every finite region
   $\Lambda$ there is a star-algebra homomorphism
-  $g_\Lambda\colon\mathcal A_\Lambda\to B$ and that
+  $g_\Lambda\colon\mathcal A_\Lambda\to B$.  Whenever
+  $\Lambda\subseteq\Gamma$, suppose that
   \begin{align}
-    g_\Gamma\circ\iota_{\Lambda,\Gamma}&=g_\Lambda
-    &&(\Lambda\subseteq\Gamma).
+    g_\Gamma\circ\iota_{\Lambda,\Gamma}&=g_\Lambda.
   \end{align}
   Then there is a unique star-algebra homomorphism
   $g\colon\mathcal A_{\mathrm{loc}}\to B$ satisfying
@@ -3213,8 +3215,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Finite supports of local observables]
   \label{thm:qca_local_observable_finite_support}
-  \lean{SpinChain.localObservable_localInclusion,
-    SpinChain.localObservable_injective,SpinChain.SupportedIn.mono,
+  \lean{SpinChain.localObservable_injective,SpinChain.SupportedIn.mono,
     SpinChain.SupportedIn.union_left,SpinChain.SupportedIn.union_right,
     SpinChain.SupportedIn.add,SpinChain.SupportedIn.mul,
     SpinChain.SupportedIn.star,SpinChain.SupportedIn.zero,
@@ -3231,10 +3232,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{lem:qca_local_inclusion_injective}
   Enlarge representatives by tensoring with the identity on the added sites.
   Two representatives can therefore be moved to the finite union of their
   regions, where sums and products are formed.  The canonical inclusions are
   unital star-algebra homomorphisms, so they preserve the adjoint, zero, and
-  the unit.  Finally, every element of an algebraic direct limit has a
-  representative in one member of the directed system.
+  the unit.  For $d>0$, every transition map between finite-region algebras is
+  injective; the canonical map from each member of such a directed system to
+  its direct limit is therefore injective.  Finally, every element of an
+  algebraic direct limit has a representative in one member of the directed
+  system.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3232,7 +3232,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{lem:qca_local_inclusion_injective}
+  \uses{def:qca_algebraic_local_algebra,lem:qca_local_inclusion_injective}
   Enlarge representatives by tensoring with the identity on the added sites.
   Two representatives can therefore be moved to the finite union of their
   regions, where sums and products are formed.  The canonical inclusions are

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3146,3 +3146,95 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
       &=\iota_{\Lambda,\Delta}(A).
   \end{align}
 \end{proof}
+
+\begin{definition}[Algebraic local algebra]
+  \label{def:qca_algebraic_local_algebra}
+  \lean{SpinChain.instDirectedSystemLocalAlgebra,
+    SpinChain.AlgebraicLocalAlgebra,SpinChain.localObservable}
+  \leanok
+  \uses{def:qca_local_algebra,def:qca_local_inclusion,
+    lem:qca_local_inclusion_refl,lem:qca_local_inclusion_trans}
+  The finite-region local algebras form a directed system under the maps
+  $\iota_{\Lambda,\Gamma}$.  Its algebraic direct limit is the algebraic
+  local algebra
+  \begin{align}
+    \mathcal A_{\mathrm{loc}}
+      &=\varinjlim_{\Lambda\Subset\mathbb Z}\mathcal A_\Lambda.
+  \end{align}
+  For every finite region $\Lambda$, write
+  $\iota_\Lambda\colon\mathcal A_\Lambda\to\mathcal A_{\mathrm{loc}}$
+  for the canonical inclusion.  These inclusions satisfy
+  \begin{align}
+    \iota_\Gamma\circ\iota_{\Lambda,\Gamma}&=\iota_\Lambda
+    &&(\Lambda\subseteq\Gamma).
+  \end{align}
+  This is the union $\bigcup_\Lambda^\infty\mathcal A_\Lambda$ in the
+  Appendix of \cite{Cirac2017MPU}.  No norm completion is taken.
+\end{definition}
+
+\begin{theorem}[Star-algebra universal property]
+  \label{thm:qca_algebraic_local_algebra_universal}
+  \lean{SpinChain.algebraicLocalAlgebraLift,
+    SpinChain.algebraicLocalAlgebraLift_localObservable,
+    SpinChain.algebraicLocalAlgebra_starAlgHom_ext,
+    SpinChain.algebraicLocalAlgebraLift_unique}
+  \leanok
+  \uses{def:qca_algebraic_local_algebra}
+  Let $B$ be a complex star algebra.  Suppose that for every finite region
+  $\Lambda$ there is a star-algebra homomorphism
+  $g_\Lambda\colon\mathcal A_\Lambda\to B$ and that
+  \begin{align}
+    g_\Gamma\circ\iota_{\Lambda,\Gamma}&=g_\Lambda
+    &&(\Lambda\subseteq\Gamma).
+  \end{align}
+  Then there is a unique star-algebra homomorphism
+  $g\colon\mathcal A_{\mathrm{loc}}\to B$ satisfying
+  $g\circ\iota_\Lambda=g_\Lambda$ for every finite region $\Lambda$.
+\end{theorem}
+
+\begin{proof}\leanok
+  Define $g$ on a local observable represented by
+  $A\in\mathcal A_\Lambda$ as $g_\Lambda(A)$.  Compatibility makes this
+  independent of the representing region.  Since each $g_\Lambda$ preserves
+  addition, multiplication, the unit, scalar multiplication, and the star
+  operation, so does $g$.  Every element of the direct limit has a
+  finite-region representative, which also proves uniqueness.
+\end{proof}
+
+\begin{definition}[Support of a local observable]
+  \label{def:qca_supported_in}
+  \lean{SpinChain.SupportedIn}
+  \leanok
+  \uses{def:qca_algebraic_local_algebra}
+  A local observable $A\in\mathcal A_{\mathrm{loc}}$ is supported in the
+  finite region $\Lambda$ if it lies in the image of
+  $\iota_\Lambda\colon\mathcal A_\Lambda\to\mathcal A_{\mathrm{loc}}$.
+\end{definition}
+
+\begin{theorem}[Finite supports of local observables]
+  \label{thm:qca_local_observable_finite_support}
+  \lean{SpinChain.localObservable_localInclusion,
+    SpinChain.localObservable_injective,SpinChain.SupportedIn.mono,
+    SpinChain.SupportedIn.union_left,SpinChain.SupportedIn.union_right,
+    SpinChain.SupportedIn.add,SpinChain.SupportedIn.mul,
+    SpinChain.SupportedIn.star,SpinChain.SupportedIn.zero,
+    SpinChain.SupportedIn.one,SpinChain.exists_supportedIn}
+  \leanok
+  \uses{def:qca_supported_in,lem:qca_local_inclusion_injective}
+  Every local observable is supported in some finite region.  If $A$ is
+  supported in $\Lambda$ and $\Lambda\subseteq\Gamma$, then $A$ is supported
+  in $\Gamma$.  If $A$ and $B$ are supported in $\Lambda$ and $\Gamma$,
+  respectively, then $A+B$ and $AB$ are supported in $\Lambda\cup\Gamma$.
+  The adjoint $A^*$ is supported in $\Lambda$, and both $0$ and $1$ are
+  supported in every finite region.  For positive on-site dimension, each
+  map $\iota_\Lambda$ is injective.
+\end{theorem}
+
+\begin{proof}\leanok
+  Enlarge representatives by tensoring with the identity on the added sites.
+  Two representatives can therefore be moved to the finite union of their
+  regions, where sums and products are formed.  The canonical inclusions are
+  unital star-algebra homomorphisms, so they preserve the adjoint, zero, and
+  the unit.  Finally, every element of an algebraic direct limit has a
+  representative in one member of the directed system.
+\end{proof}


### PR DESCRIPTION
### Motivation

- Formalize the algebraic local observable algebra used in the Appendix of arXiv:1703.09188, lines 2285--2300.
- Continue the finite-region system from #5790 without conflating periodic finite-chain operators with a QCA or adding an unjustified norm completion.

### Description

- Added the directed system of finite-region local algebras and its algebraic direct limit `SpinChain.AlgebraicLocalAlgebra`.
- Added canonical star-algebra inclusions, their compatibility and injectivity, and a star-preserving universal lift with extensionality and uniqueness.
- Added `SpinChain.SupportedIn`, support monotonicity and finite-union closure under addition and multiplication, star/unit/zero closure, and existence of finite support for every local observable.
- Added the QCA aggregator import and source-faithful Chapter 28 entries. No quasi-local completion or QCA definition is claimed.

### Testing

- `lake build TNLean.QCA.LocalLimit TNLean.QCA` (2972/2972)
- `python3 scripts/generate_import_aggregators.py --root . --check` (52 aggregators, 1327 production modules)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls` (7080/7080; Chapter 28: 241/241)
- Two direct `lualatex` passes with `TEXINPUTS="../../tex/tenkz//:"` (no undefined references)
- `git diff --check origin/main..HEAD`
- Changed-file proof-integrity scan found no `sorry`, `axiom`, `admit`, or `unsafe`

---
Closes #5793

### Agent assistance

- OpenAI gpt-5.6 Lean specialist implemented the direct-limit and blueprint slice.
- OpenAI gpt-5.6 Lean simplifier reviewed the code and replaced the bespoke star-preservation induction with Mathlib's `DirectLimit.lift_star`.
- OpenAI gpt-5.6 Lean search specialist verified the installed direct-limit API and non-duplication boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization on top of existing `LocalAlgebra` infrastructure; no runtime, auth, or completion/C⋆ changes. Risk is limited to Mathlib direct-limit API correctness and blueprint–Lean sync.
> 
> **Overview**
> Adds **`TNLean/QCA/LocalLimit.lean`**, defining the **algebraic** quasi-local algebra as Mathlib’s `DirectLimit` of finite-region `LocalAlgebra`s under `localInclusion`, without norm completion.
> 
> **New API:** `AlgebraicLocalAlgebra`, canonical `localObservable` inclusions (compatibility, injectivity for `NeZero d`), star-algebra `algebraicLocalAlgebraLift` with extensionality and uniqueness, and `SupportedIn` with monotonicity, closure under `+`, `*`, `star`, and `exists_supportedIn`.
> 
> **Integration:** `TNLean/QCA.lean` imports `LocalLimit`; Chapter 28 blueprint entries (`def:qca_algebraic_local_algebra`, universal property, finite supports) are linked to the Lean declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 446e5ae06c39143cdd952c30a1df3cffb0a1f158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->