### PR TITLE
feat(MPS/MPU): bound source-cut ranks under blocking

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -10,6 +10,7 @@ Authors: TNLean contributors
 
 import TNLean.MPS.MPU.ActiveTransferMultiplicity
 import TNLean.MPS.MPU.Basic
+import TNLean.MPS.MPU.BlockingRanks
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.MatchingContractions

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -71,7 +71,8 @@ private theorem sourceCutM₁_blockTensor_succ_factorization
       rightSuccLeft U k * rightSuccRight U k := by
   classical
   let S := sourceSVD₁ (blockTensor U k)
-  have hfactor : sourceCutM₁ (blockTensor U k) = Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
+  have hfactor : sourceCutM₁ (blockTensor U k) =
+      Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
     simpa [S, Matrix.mul_assoc] using S.factorization
   have hfactor_apply (row : Fin D × Fin (MPSTensor.blockPhysDim d k))
       (col : Fin (MPSTensor.blockPhysDim d k) × Fin D) :
@@ -135,7 +136,8 @@ private theorem sourceCutM₂_blockTensor_succ_factorization
       leftSuccLeft U k * leftSuccRight U k := by
   classical
   let S := sourceSVD₂ (blockTensor U k)
-  have hfactor : sourceCutM₂ (blockTensor U k) = Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
+  have hfactor : sourceCutM₂ (blockTensor U k) =
+      Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
     simpa [S, Matrix.mul_assoc] using S.factorization
   have hfactor_apply (row : Fin D × Fin (MPSTensor.blockPhysDim d k))
       (col : Fin (MPSTensor.blockPhysDim d k) × Fin D) :

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -18,6 +18,13 @@ the factor $d^{k-k_0}$ between any two direct blocking lengths $k_0 \leq k$.
 The orientations follow the paper: the right rank $r$ is the rank of
 $\mathcal M_1$, while the left rank $\ell$ is the rank of $\mathcal M_2$.
 No simplicity or MPU hypothesis is needed for these rank inequalities.
+
+## Main results
+
+* `rightRank_blockTensor_succ_le`: one-site right-rank bound.
+* `leftRank_blockTensor_succ_le`: one-site left-rank bound.
+* `rightRank_blockTensor_le_pow_mul`: iterated right-rank bound.
+* `leftRank_blockTensor_le_pow_mul`: iterated left-rank bound.
 -/
 
 open scoped BigOperators

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.MPU.SourceFactors
 # Source-cut ranks under physical blocking
 
 This module proves the blocking upper bounds for the right and left source-cut
-ranks in the proof of Proposition `index-well-defined` of
+ranks in the proof of Proposition IV.2 (`index-well-defined`) of
 [Cirac--Perez-Garcia--Schuch--Verstraete 2017, arXiv:1703.09188], lines 697--703.
 The first pair of results bounds a direct block one site longer. Iteration gives
 the factor $d^{k-k_0}$ between any two direct blocking lengths $k_0 \leq k$.
@@ -49,6 +49,15 @@ private lemma blockTensor_succ_apply (U : MPOTensor d D) (k : ℕ)
         blockTensor U k (blockTail k I) (blockTail k J) := by
   simp only [blockTensor_apply, wordOfBlock_succ, evalWord_cons]
 
+private lemma sourceCutSVD_factorization_apply
+    {α β : Type*} [Fintype α] [Fintype β] {M : Matrix α β ℂ} {r : ℕ}
+    (S : SourceCutSVD M r) (row : α) (col : β) :
+    ∑ q, Matrix.conjTranspose S.V row q * (S.diagonal * S.U) q col = M row col := by
+  have hfactor : M = Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
+    simpa only [Matrix.mul_assoc] using S.factorization
+  have h := congrArg (fun A => A row col) hfactor
+  simpa only [Matrix.mul_apply] using h.symm
+
 private noncomputable def rightSuccLeft (U : MPOTensor d D) (k : ℕ) :
     Matrix (Fin D × Fin (MPSTensor.blockPhysDim d (k + 1)))
       (Fin d × Fin r[blockTensor U k]) ℂ :=
@@ -71,15 +80,6 @@ private theorem sourceCutM₁_blockTensor_succ_factorization
       rightSuccLeft U k * rightSuccRight U k := by
   classical
   let S := sourceSVD₁ (blockTensor U k)
-  have hfactor : sourceCutM₁ (blockTensor U k) =
-      Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
-    simpa [S, Matrix.mul_assoc] using S.factorization
-  have hfactor_apply (row : Fin D × Fin (MPSTensor.blockPhysDim d k))
-      (col : Fin (MPSTensor.blockPhysDim d k) × Fin D) :
-      ∑ q, Matrix.conjTranspose S.V row q * (S.diagonal * S.U) q col =
-        sourceCutM₁ (blockTensor U k) row col := by
-    have h := congrArg (fun M => M row col) hfactor
-    simpa only [Matrix.mul_apply] using h.symm
   ext ⟨α, J⟩ ⟨I, β⟩
   symm
   simp only [sourceCutM₁_apply, Matrix.mul_apply, rightSuccLeft, rightSuccRight]
@@ -105,7 +105,7 @@ private theorem sourceCutM₁_blockTensor_succ_factorization
               (blockTail k I, β) := by
             apply Finset.sum_congr rfl
             intro γ _
-            rw [hfactor_apply]
+            rw [sourceCutSVD_factorization_apply S]
       _ = (U (blockHead k I) (blockHead k J) *
             blockTensor U k (blockTail k I) (blockTail k J)) α β := by
             simp only [sourceCutM₁_apply, Matrix.mul_apply]
@@ -136,15 +136,6 @@ private theorem sourceCutM₂_blockTensor_succ_factorization
       leftSuccLeft U k * leftSuccRight U k := by
   classical
   let S := sourceSVD₂ (blockTensor U k)
-  have hfactor : sourceCutM₂ (blockTensor U k) =
-      Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
-    simpa [S, Matrix.mul_assoc] using S.factorization
-  have hfactor_apply (row : Fin D × Fin (MPSTensor.blockPhysDim d k))
-      (col : Fin (MPSTensor.blockPhysDim d k) × Fin D) :
-      ∑ q, Matrix.conjTranspose S.V row q * (S.diagonal * S.U) q col =
-        sourceCutM₂ (blockTensor U k) row col := by
-    have h := congrArg (fun M => M row col) hfactor
-    simpa only [Matrix.mul_apply] using h.symm
   ext ⟨α, I⟩ ⟨J, β⟩
   symm
   simp only [sourceCutM₂_apply, Matrix.mul_apply, leftSuccLeft, leftSuccRight]
@@ -170,7 +161,7 @@ private theorem sourceCutM₂_blockTensor_succ_factorization
               (blockTail k J, β) := by
             apply Finset.sum_congr rfl
             intro γ _
-            rw [hfactor_apply]
+            rw [sourceCutSVD_factorization_apply S]
       _ = (U (blockHead k I) (blockHead k J) *
             blockTensor U k (blockTail k I) (blockTail k J)) α β := by
             simp only [sourceCutM₂_apply, Matrix.mul_apply]
@@ -182,7 +173,7 @@ private theorem sourceCutM₂_blockTensor_succ_factorization
 /-- Blocking one additional site multiplies the right source-cut rank by at most $d$.
 
 This is the one-site form of the right-rank upper bound in the proof of
-arXiv:1703.09188, Proposition `index-well-defined`, lines 697--703. -/
+arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), lines 697--703. -/
 theorem rightRank_blockTensor_succ_le (U : MPOTensor d D) (k : ℕ) :
     r[blockTensor U (k + 1)] ≤ d * r[blockTensor U k] := by
   rw [rightRank, sourceCutM₁_blockTensor_succ_factorization]
@@ -192,7 +183,7 @@ theorem rightRank_blockTensor_succ_le (U : MPOTensor d D) (k : ℕ) :
 /-- Blocking one additional site multiplies the left source-cut rank by at most $d$.
 
 This is the one-site form of the left-rank upper bound in the proof of
-arXiv:1703.09188, Proposition `index-well-defined`, lines 697--703. -/
+arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), lines 697--703. -/
 theorem leftRank_blockTensor_succ_le (U : MPOTensor d D) (k : ℕ) :
     ℓ[blockTensor U (k + 1)] ≤ d * ℓ[blockTensor U k] := by
   rw [leftRank, sourceCutM₂_blockTensor_succ_factorization]
@@ -203,7 +194,7 @@ theorem leftRank_blockTensor_succ_le (U : MPOTensor d D) (k : ℕ) :
 $d^{k-k_0}$.
 
 This is the right-rank inequality in the proof of arXiv:1703.09188,
-Proposition `index-well-defined`, lines 697--703. -/
+Proposition IV.2 (`index-well-defined`), lines 697--703. -/
 theorem rightRank_blockTensor_le_pow_mul (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) :
     r[blockTensor U k] ≤ d ^ (k - k₀) * r[blockTensor U k₀] := by
@@ -223,7 +214,7 @@ theorem rightRank_blockTensor_le_pow_mul (U : MPOTensor d D) {k₀ k : ℕ}
 $d^{k-k_0}$.
 
 This is the left-rank inequality in the proof of arXiv:1703.09188,
-Proposition `index-well-defined`, lines 697--703. -/
+Proposition IV.2 (`index-well-defined`), lines 697--703. -/
 theorem leftRank_blockTensor_le_pow_mul (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) :
     ℓ[blockTensor U k] ≤ d ^ (k - k₀) * ℓ[blockTensor U k₀] := by

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPU.SourceFactors
+
+/-!
+# Source-cut ranks under physical blocking
+
+This module proves the blocking upper bounds for the right and left source-cut
+ranks in the proof of Proposition `index-well-defined` of
+[Cirac--Perez-Garcia--Schuch--Verstraete 2017, arXiv:1703.09188], lines 697--703.
+The first pair of results bounds a direct block one site longer. Iteration gives
+the factor $d^{k-k_0}$ between any two direct blocking lengths $k_0 \leq k$.
+
+The orientations follow the paper: the right rank $r$ is the rank of
+$\mathcal M_1$, while the left rank $\ell$ is the rank of $\mathcal M_2$.
+No simplicity or MPU hypothesis is needed for these rank inequalities.
+-/
+
+open scoped BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+private noncomputable def blockHead (k : ℕ)
+    (I : Fin (MPSTensor.blockPhysDim d (k + 1))) : Fin d :=
+  MPSTensor.decodeBlock d (k + 1) I 0
+
+private noncomputable def blockTail (k : ℕ)
+    (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+    Fin (MPSTensor.blockPhysDim d k) :=
+  (MPSTensor.decodeBlockEquiv d k).symm
+    (fun q : Fin k => MPSTensor.decodeBlock d (k + 1) I q.succ)
+
+private lemma wordOfBlock_succ (k : ℕ)
+    (I : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+    MPSTensor.wordOfBlock d (k + 1) I =
+      blockHead k I :: MPSTensor.wordOfBlock d k (blockTail k I) := by
+  simp [MPSTensor.wordOfBlock, blockHead, blockTail, List.ofFn_succ]
+
+private lemma blockTensor_succ_apply (U : MPOTensor d D) (k : ℕ)
+    (I J : Fin (MPSTensor.blockPhysDim d (k + 1))) :
+    blockTensor U (k + 1) I J =
+      U (blockHead k I) (blockHead k J) *
+        blockTensor U k (blockTail k I) (blockTail k J) := by
+  simp only [blockTensor_apply, wordOfBlock_succ, evalWord_cons]
+
+private noncomputable def rightSuccLeft (U : MPOTensor d D) (k : ℕ) :
+    Matrix (Fin D × Fin (MPSTensor.blockPhysDim d (k + 1)))
+      (Fin d × Fin r[blockTensor U k]) ℂ :=
+  fun (α, J) (i, q) =>
+    ∑ γ : Fin D, U i (blockHead k J) α γ *
+      Matrix.conjTranspose (sourceSVD₁ (blockTensor U k)).V (γ, blockTail k J) q
+
+private noncomputable def rightSuccRight (U : MPOTensor d D) (k : ℕ) :
+    Matrix (Fin d × Fin r[blockTensor U k])
+      (Fin (MPSTensor.blockPhysDim d (k + 1)) × Fin D) ℂ :=
+  fun (i, q) (I, β) =>
+    if i = blockHead k I then
+      ((sourceSVD₁ (blockTensor U k)).diagonal *
+        (sourceSVD₁ (blockTensor U k)).U) q (blockTail k I, β)
+    else 0
+
+private theorem sourceCutM₁_blockTensor_succ_factorization
+    (U : MPOTensor d D) (k : ℕ) :
+    sourceCutM₁ (blockTensor U (k + 1)) =
+      rightSuccLeft U k * rightSuccRight U k := by
+  classical
+  let S := sourceSVD₁ (blockTensor U k)
+  have hfactor : sourceCutM₁ (blockTensor U k) = Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
+    simpa [S, Matrix.mul_assoc] using S.factorization
+  have hfactor_apply (row : Fin D × Fin (MPSTensor.blockPhysDim d k))
+      (col : Fin (MPSTensor.blockPhysDim d k) × Fin D) :
+      ∑ q, Matrix.conjTranspose S.V row q * (S.diagonal * S.U) q col =
+        sourceCutM₁ (blockTensor U k) row col := by
+    have h := congrArg (fun M => M row col) hfactor
+    simpa only [Matrix.mul_apply] using h.symm
+  ext ⟨α, J⟩ ⟨I, β⟩
+  symm
+  simp only [sourceCutM₁_apply, Matrix.mul_apply, rightSuccLeft, rightSuccRight]
+  rw [Fintype.sum_prod_type, Fintype.sum_eq_single (blockHead k I)]
+  · simp only [if_pos]
+    change (∑ q, (∑ γ, U (blockHead k I) (blockHead k J) α γ *
+      Matrix.conjTranspose S.V (γ, blockTail k J) q) *
+        (S.diagonal * S.U) q (blockTail k I, β)) = _
+    calc
+      ∑ q, (∑ γ, U (blockHead k I) (blockHead k J) α γ *
+          Matrix.conjTranspose S.V (γ, blockTail k J) q) *
+          (S.diagonal * S.U) q (blockTail k I, β) =
+          ∑ γ, U (blockHead k I) (blockHead k J) α γ *
+            ∑ q, Matrix.conjTranspose S.V (γ, blockTail k J) q *
+              (S.diagonal * S.U) q (blockTail k I, β) := by
+            simp only [Finset.sum_mul, mul_assoc]
+            rw [Finset.sum_comm]
+            apply Finset.sum_congr rfl
+            intro γ _
+            rw [Finset.mul_sum]
+      _ = ∑ γ, U (blockHead k I) (blockHead k J) α γ *
+            sourceCutM₁ (blockTensor U k) (γ, blockTail k J)
+              (blockTail k I, β) := by
+            apply Finset.sum_congr rfl
+            intro γ _
+            rw [hfactor_apply]
+      _ = (U (blockHead k I) (blockHead k J) *
+            blockTensor U k (blockTail k I) (blockTail k J)) α β := by
+            simp only [sourceCutM₁_apply, Matrix.mul_apply]
+      _ = blockTensor U (k + 1) I J α β := by
+            rw [blockTensor_succ_apply]
+  · intro i hi
+    simp [hi]
+
+private noncomputable def leftSuccLeft (U : MPOTensor d D) (k : ℕ) :
+    Matrix (Fin D × Fin (MPSTensor.blockPhysDim d (k + 1)))
+      (Fin d × Fin ℓ[blockTensor U k]) ℂ :=
+  fun (α, I) (j, q) =>
+    ∑ γ : Fin D, U (blockHead k I) j α γ *
+      Matrix.conjTranspose (sourceSVD₂ (blockTensor U k)).V (γ, blockTail k I) q
+
+private noncomputable def leftSuccRight (U : MPOTensor d D) (k : ℕ) :
+    Matrix (Fin d × Fin ℓ[blockTensor U k])
+      (Fin (MPSTensor.blockPhysDim d (k + 1)) × Fin D) ℂ :=
+  fun (j, q) (J, β) =>
+    if j = blockHead k J then
+      ((sourceSVD₂ (blockTensor U k)).diagonal *
+        (sourceSVD₂ (blockTensor U k)).U) q (blockTail k J, β)
+    else 0
+
+private theorem sourceCutM₂_blockTensor_succ_factorization
+    (U : MPOTensor d D) (k : ℕ) :
+    sourceCutM₂ (blockTensor U (k + 1)) =
+      leftSuccLeft U k * leftSuccRight U k := by
+  classical
+  let S := sourceSVD₂ (blockTensor U k)
+  have hfactor : sourceCutM₂ (blockTensor U k) = Matrix.conjTranspose S.V * (S.diagonal * S.U) := by
+    simpa [S, Matrix.mul_assoc] using S.factorization
+  have hfactor_apply (row : Fin D × Fin (MPSTensor.blockPhysDim d k))
+      (col : Fin (MPSTensor.blockPhysDim d k) × Fin D) :
+      ∑ q, Matrix.conjTranspose S.V row q * (S.diagonal * S.U) q col =
+        sourceCutM₂ (blockTensor U k) row col := by
+    have h := congrArg (fun M => M row col) hfactor
+    simpa only [Matrix.mul_apply] using h.symm
+  ext ⟨α, I⟩ ⟨J, β⟩
+  symm
+  simp only [sourceCutM₂_apply, Matrix.mul_apply, leftSuccLeft, leftSuccRight]
+  rw [Fintype.sum_prod_type, Fintype.sum_eq_single (blockHead k J)]
+  · simp only [if_pos]
+    change (∑ q, (∑ γ, U (blockHead k I) (blockHead k J) α γ *
+      Matrix.conjTranspose S.V (γ, blockTail k I) q) *
+        (S.diagonal * S.U) q (blockTail k J, β)) = _
+    calc
+      ∑ q, (∑ γ, U (blockHead k I) (blockHead k J) α γ *
+          Matrix.conjTranspose S.V (γ, blockTail k I) q) *
+          (S.diagonal * S.U) q (blockTail k J, β) =
+          ∑ γ, U (blockHead k I) (blockHead k J) α γ *
+            ∑ q, Matrix.conjTranspose S.V (γ, blockTail k I) q *
+              (S.diagonal * S.U) q (blockTail k J, β) := by
+            simp only [Finset.sum_mul, mul_assoc]
+            rw [Finset.sum_comm]
+            apply Finset.sum_congr rfl
+            intro γ _
+            rw [Finset.mul_sum]
+      _ = ∑ γ, U (blockHead k I) (blockHead k J) α γ *
+            sourceCutM₂ (blockTensor U k) (γ, blockTail k I)
+              (blockTail k J, β) := by
+            apply Finset.sum_congr rfl
+            intro γ _
+            rw [hfactor_apply]
+      _ = (U (blockHead k I) (blockHead k J) *
+            blockTensor U k (blockTail k I) (blockTail k J)) α β := by
+            simp only [sourceCutM₂_apply, Matrix.mul_apply]
+      _ = blockTensor U (k + 1) I J α β := by
+            rw [blockTensor_succ_apply]
+  · intro j hj
+    simp [hj]
+
+/-- Blocking one additional site multiplies the right source-cut rank by at most $d$.
+
+This is the one-site form of the right-rank upper bound in the proof of
+arXiv:1703.09188, Proposition `index-well-defined`, lines 697--703. -/
+theorem rightRank_blockTensor_succ_le (U : MPOTensor d D) (k : ℕ) :
+    r[blockTensor U (k + 1)] ≤ d * r[blockTensor U k] := by
+  rw [rightRank, sourceCutM₁_blockTensor_succ_factorization]
+  exact (Matrix.rank_mul_le_left _ _).trans
+    ((Matrix.rank_le_card_width (rightSuccLeft U k)).trans_eq (by simp))
+
+/-- Blocking one additional site multiplies the left source-cut rank by at most $d$.
+
+This is the one-site form of the left-rank upper bound in the proof of
+arXiv:1703.09188, Proposition `index-well-defined`, lines 697--703. -/
+theorem leftRank_blockTensor_succ_le (U : MPOTensor d D) (k : ℕ) :
+    ℓ[blockTensor U (k + 1)] ≤ d * ℓ[blockTensor U k] := by
+  rw [leftRank, sourceCutM₂_blockTensor_succ_factorization]
+  exact (Matrix.rank_mul_le_left _ _).trans
+    ((Matrix.rank_le_card_width (leftSuccLeft U k)).trans_eq (by simp))
+
+/-- Between direct blocking lengths $k_0 \leq k$, the right rank grows by at most
+$d^{k-k_0}$.
+
+This is the right-rank inequality in the proof of arXiv:1703.09188,
+Proposition `index-well-defined`, lines 697--703. -/
+theorem rightRank_blockTensor_le_pow_mul (U : MPOTensor d D) {k₀ k : ℕ}
+    (h : k₀ ≤ k) :
+    r[blockTensor U k] ≤ d ^ (k - k₀) * r[blockTensor U k₀] := by
+  induction k, h using Nat.le_induction with
+  | base => simp
+  | succ k _ ih =>
+      calc
+        r[blockTensor U (k + 1)] ≤ d * r[blockTensor U k] :=
+          rightRank_blockTensor_succ_le U k
+        _ ≤ d * (d ^ (k - k₀) * r[blockTensor U k₀]) :=
+          Nat.mul_le_mul_left d ih
+        _ = d ^ (k + 1 - k₀) * r[blockTensor U k₀] := by
+          rw [Nat.succ_sub (by omega), pow_succ]
+          simp [Nat.mul_assoc, Nat.mul_comm]
+
+/-- Between direct blocking lengths $k_0 \leq k$, the left rank grows by at most
+$d^{k-k_0}$.
+
+This is the left-rank inequality in the proof of arXiv:1703.09188,
+Proposition `index-well-defined`, lines 697--703. -/
+theorem leftRank_blockTensor_le_pow_mul (U : MPOTensor d D) {k₀ k : ℕ}
+    (h : k₀ ≤ k) :
+    ℓ[blockTensor U k] ≤ d ^ (k - k₀) * ℓ[blockTensor U k₀] := by
+  induction k, h using Nat.le_induction with
+  | base => simp
+  | succ k _ ih =>
+      calc
+        ℓ[blockTensor U (k + 1)] ≤ d * ℓ[blockTensor U k] :=
+          leftRank_blockTensor_succ_le U k
+        _ ≤ d * (d ^ (k - k₀) * ℓ[blockTensor U k₀]) :=
+          Nat.mul_le_mul_left d ih
+        _ = d ^ (k + 1 - k₀) * ℓ[blockTensor U k₀] := by
+          rw [Nat.succ_sub (by omega), pow_succ]
+          simp [Nat.mul_assoc, Nat.mul_comm]
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1361,6 +1361,66 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{definition}
 
+\begin{theorem}[One-site blocking bounds for the source-cut ranks]
+    \label{thm:mpu_source_cut_rank_blocking_succ}
+    \lean{MPOTensor.rightRank_blockTensor_succ_le,
+        MPOTensor.leftRank_blockTensor_succ_le}
+    \leanok
+    \uses{thm:mpu_compact_svd,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank,
+        thm:mpdo_closed_chain_physical_blocking}
+    Let $\mathcal U^{[k]}$ denote the direct blocking of $k$ sites of a tensor
+    $\mathcal U$ with physical dimension $d$, and let $r_k$ and $\ell_k$ be
+    its right and left source-cut ranks. Then
+    \begin{align}
+        r_{k+1}&\leq d\,r_k.
+    \end{align}
+    Moreover,
+    \begin{align}
+        \ell_{k+1}&\leq d\,\ell_k.
+    \end{align}
+    These are the one-site forms of the two upper bounds in the proof of
+    \cite[Proposition~\texttt{index-well-defined}]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    For the first cut, choose a compact factorization of the source matrix of
+    $\mathcal U^{[k]}$ through a space of dimension $r_k$. Split each physical
+    word of length $k+1$ into its first letter and its remaining word of length
+    $k$. The source matrix of $\mathcal U^{[k+1]}$ then factors through
+    \begin{align}
+        \mathbb C^d\otimes\mathbb C^{r_k}.
+    \end{align}
+    Its rank is therefore at most $d r_k$. Repeating the same argument with the
+    upper and lower physical indices interchanged factors the second source
+    matrix through $\mathbb C^d\otimes\mathbb C^{\ell_k}$ and gives the left
+    bound.
+\end{proof}
+
+\begin{theorem}[Source-cut rank bounds between two blocking lengths]
+    \label{thm:mpu_source_cut_rank_blocking}
+    \lean{MPOTensor.rightRank_blockTensor_le_pow_mul,
+        MPOTensor.leftRank_blockTensor_le_pow_mul}
+    \leanok
+    \uses{thm:mpu_source_cut_rank_blocking_succ}
+    If $k_0\leq k$, then
+    \begin{align}
+        r_k&\leq d^{k-k_0}r_{k_0}.
+    \end{align}
+    Likewise,
+    \begin{align}
+        \ell_k&\leq d^{k-k_0}\ell_{k_0}.
+    \end{align}
+    These are precisely the two blocking upper bounds used in the proof of
+    \cite[Proposition~\texttt{index-well-defined}]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Induct on $k-k_0$. The case $k=k_0$ is equality. At each successor step,
+    apply the corresponding one-site bound and multiply the preceding estimate
+    by $d$.
+\end{proof}
+
 \begin{definition}[Product-index source weight]
     \label{def:mpu_source_weight}
     \lean{MPOTensor.sourceWeight}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1366,34 +1366,28 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.rightRank_blockTensor_succ_le,
         MPOTensor.leftRank_blockTensor_succ_le}
     \leanok
-    \uses{thm:mpu_compact_svd,def:mpu_source_matrix_one,
-        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank,
-        thm:mpdo_closed_chain_physical_blocking}
-    Let $\mathcal U^{[k]}$ denote the direct blocking of $k$ sites of a tensor
-    $\mathcal U$ with physical dimension $d$, and let $r_k$ and $\ell_k$ be
+    \uses{def:mpdo_positive_physical_blocking,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank}
+    Let $\mathcal U^{[L]}$ denote the direct blocking of $L$ sites of a tensor
+    $\mathcal U$ with physical dimension $d$, and let $r_L$ and $\ell_L$ be
     its right and left source-cut ranks. Then
     \begin{align}
-        r_{k+1}&\leq d\,r_k.
-    \end{align}
-    Moreover,
-    \begin{align}
-        \ell_{k+1}&\leq d\,\ell_k.
+        r_{L+1}&\leq d\,r_L,\\
+        \ell_{L+1}&\leq d\,\ell_L.
     \end{align}
     These are the one-site forms of the two upper bounds in the proof of
-    \cite[Proposition~\texttt{index-well-defined}]{Cirac2017MPU}.
+    \cite[Proposition~IV.2]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_compact_svd}
     For the first cut, choose a compact factorization of the source matrix of
-    $\mathcal U^{[k]}$ through a space of dimension $r_k$. Split each physical
-    word of length $k+1$ into its first letter and its remaining word of length
-    $k$. The source matrix of $\mathcal U^{[k+1]}$ then factors through
-    \begin{align}
-        \mathbb C^d\otimes\mathbb C^{r_k}.
-    \end{align}
-    Its rank is therefore at most $d r_k$. Repeating the same argument with the
-    upper and lower physical indices interchanged factors the second source
-    matrix through $\mathbb C^d\otimes\mathbb C^{\ell_k}$ and gives the left
+    $\mathcal U^{[L]}$ through a space of dimension $r_L$. Split each physical
+    word of length $L+1$ into its first letter and its remaining word of length
+    $L$. The source matrix of $\mathcal U^{[L+1]}$ then factors through
+    $\mathbb C^d\otimes\mathbb C^{r_L}$, so its rank is at most $d r_L$.
+    Interchanging the upper and lower physical indices factors the second source
+    matrix through $\mathbb C^d\otimes\mathbb C^{\ell_L}$ and gives the left
     bound.
 \end{proof}
 
@@ -1403,20 +1397,17 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.leftRank_blockTensor_le_pow_mul}
     \leanok
     \uses{thm:mpu_source_cut_rank_blocking_succ}
-    If $k_0\leq k$, then
+    If $L_0\leq L$, then
     \begin{align}
-        r_k&\leq d^{k-k_0}r_{k_0}.
+        r_L&\leq d^{L-L_0}r_{L_0},\\
+        \ell_L&\leq d^{L-L_0}\ell_{L_0}.
     \end{align}
-    Likewise,
-    \begin{align}
-        \ell_k&\leq d^{k-k_0}\ell_{k_0}.
-    \end{align}
-    These are precisely the two blocking upper bounds used in the proof of
-    \cite[Proposition~\texttt{index-well-defined}]{Cirac2017MPU}.
+    These are the two blocking upper bounds used in the proof of
+    \cite[Proposition~IV.2]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok
-    Induct on $k-k_0$. The case $k=k_0$ is equality. At each successor step,
+    Induct on $L-L_0$. The case $L=L_0$ is equality. At each successor step,
     apply the corresponding one-site bound and multiply the preceding estimate
     by $d$.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1380,15 +1380,31 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_compact_svd}
+    \uses{def:mpu_source_svd_data}
     For the first cut, choose a compact factorization of the source matrix of
     $\mathcal U^{[L]}$ through a space of dimension $r_L$. Split each physical
     word of length $L+1$ into its first letter and its remaining word of length
-    $L$. The source matrix of $\mathcal U^{[L+1]}$ then factors through
-    $\mathbb C^d\otimes\mathbb C^{r_L}$, so its rank is at most $d r_L$.
-    Interchanging the upper and lower physical indices factors the second source
-    matrix through $\mathbb C^d\otimes\mathbb C^{\ell_L}$ and gives the left
-    bound.
+    $L$. For suitable rectangular matrices $A_{1,L}$ and $B_{1,L}$, the
+    successor source matrix factors as
+    \begin{align}
+        M_{1,L+1}&=A_{1,L}B_{1,L}.
+    \end{align}
+    The intermediate space is $\mathbb C^d\otimes\mathbb C^{r_L}$, and hence
+    \begin{align}
+        \operatorname{rank}(M_{1,L+1})
+        &\leq \dim\bigl(\mathbb C^d\otimes\mathbb C^{r_L}\bigr)=d r_L.
+    \end{align}
+    Interchanging the upper and lower physical indices gives matrices
+    $A_{2,L}$ and $B_{2,L}$ with
+    \begin{align}
+        M_{2,L+1}&=A_{2,L}B_{2,L}.
+    \end{align}
+    This factorization passes through
+    $\mathbb C^d\otimes\mathbb C^{\ell_L}$, so
+    \begin{align}
+        \operatorname{rank}(M_{2,L+1})
+        &\leq \dim\bigl(\mathbb C^d\otimes\mathbb C^{\ell_L}\bigr)=d\ell_L.
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Source-cut rank bounds between two blocking lengths]
@@ -1396,7 +1412,6 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.rightRank_blockTensor_le_pow_mul,
         MPOTensor.leftRank_blockTensor_le_pow_mul}
     \leanok
-    \uses{thm:mpu_source_cut_rank_blocking_succ}
     If $L_0\leq L$, then
     \begin{align}
         r_L&\leq d^{L-L_0}r_{L_0},\\
@@ -1407,9 +1422,22 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    Induct on $L-L_0$. The case $L=L_0$ is equality. At each successor step,
-    apply the corresponding one-site bound and multiply the preceding estimate
-    by $d$.
+    \uses{thm:mpu_source_cut_rank_blocking_succ}
+    Induct on $L-L_0$. The case $L=L_0$ is equality. For the right rank, the
+    successor bound and the induction hypothesis give
+    \begin{align}
+        r_{L+1}
+        &\leq d r_L
+        \leq d\bigl(d^{L-L_0}r_{L_0}\bigr)
+        =d^{L+1-L_0}r_{L_0}.
+    \end{align}
+    The same multiplication by $d$ gives
+    \begin{align}
+        \ell_{L+1}
+        &\leq d\ell_L
+        \leq d\bigl(d^{L-L_0}\ell_{L_0}\bigr)
+        =d^{L+1-L_0}\ell_{L_0}.
+    \end{align}
 \end{proof}
 
 \begin{definition}[Product-index source weight]


### PR DESCRIPTION
### Motivation

- Formalize the rank upper bounds used in Proposition `index-well-defined` of arXiv:1703.09188, lines 697--703.
- Isolate the unblocked first half of the paper's proof while the assigned `lemuisometry` and `ThmFund1` work proceeds under #5708.

### Description

- Factored the successor right and left source cuts through spaces of dimensions $d r_L$ and $d\ell_L$, preserving the paper's $\mathcal M_1/\mathcal M_2$ orientations.
- Proved the one-site bounds and their iterated forms
  \[
  r_L\le d^{L-L_0}r_{L_0},\qquad
  \ell_L\le d^{L-L_0}\ell_{L_0}.
  \]
- Added source-faithful Chapter 28 entries and the MPU aggregator import.
- Used no simplicity, MPU, or `ThmFund1` hypothesis. Exact growth remains #6014. The paper's later printed exponent typo is not encoded.

### Testing

- `lake build TNLean.MPS.MPU.BlockingRanks TNLean.MPS.MPU` (8858/8858)
- `python3 scripts/generate_import_aggregators.py --root . --check` (52 aggregators, 1328 production modules)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls` (7065/7065)
- Two direct `lualatex` passes with `TEXINPUTS="../../tex/tenkz//:"` (no undefined references)
- `git diff --check origin/main..HEAD`
- Changed-file scan found no `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`, or use of `ThmFund1`

---
Closes #6013
Advances #5711

### Agent assistance

- OpenAI gpt-5.6 Lean specialist implemented the source-cut factorizations, rank bounds, and blueprint entries.
- OpenAI gpt-5.6 Lean simplifier reviewed the proof, extracted the shared compact-SVD entry identity, and aligned the blueprint notation and dependencies with the paper.
- OpenAI gpt-5.6 Lean search specialist verified the Mathlib/TNLean overlap and identified this independent paper-proof slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New pure Lean proofs on rank inequalities and blueprint documentation; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TNLean.MPS.MPU.BlockingRanks`** with formal proofs that extending direct physical blocking by one site multiplies the right and left **source-cut ranks** (`r` from `sourceCutM₁`, `ℓ` from `sourceCutM₂`) by at most **d**, via explicit factorizations of the successor source matrices through intermediate spaces of dimension **d × r** and **d × ℓ**.
> 
> **Iterated bounds** `r_L ≤ d^{L-L₀} r_{L₀}` and `ℓ_L ≤ d^{L-L₀} ℓ_{L₀}` follow by induction. No simplicity, MPU, or `ThmFund1` hypotheses are used.
> 
> Chapter 28 blueprint gains matching theorems (`thm:mpu_source_cut_rank_blocking_succ`, `thm:mpu_source_cut_rank_blocking`) with `\leanok` links, and the MPU aggregator imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 529a104cb143e42949063ec434846ed08e73a292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->