### PR TITLE
Blueprint: sync boundary comparison dependencies

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing_comparisons.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing_comparisons.tex
@@ -366,18 +366,18 @@
         lem:fixed_complementary_word_boundary_compatibility_from_traces}
     Lemma~\ref{lem:block_diagonal_boundary_crossing_trace_decompositions_boundary}
     gives matrices $C^j_{i,\rho}$ such that, for every boundary-crossing start
-    $i$, outside word $\rho$, word $\beta$ before the cut, and word $w$ of
-    length $N-i$,
+    $i$, outside word $\rho$ of length $N-L$, word $\beta$ of length
+    $i+L-N$ before the cut, and wrapped tail word $\alpha$ of length $N-i$,
     \begin{align}
-        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_\alpha\right)
         &=
-        \sum_j\tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+        \sum_j\tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_\alpha\right).
         \notag
     \end{align}
     Apply
     Lemma~\ref{lem:fixed_complementary_word_boundary_compatibility_from_traces}
     with the stated product-algebra span at length $N-i$. Equality of the
-    traces for all $w$ then gives
+    traces for all $\alpha$ then gives
     $A^j_\beta C^j_{i,\rho}=((\mu_j^NX_j)A^j_\beta)A^j_\rho$ for every block
     $j$.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing_comparisons.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing_comparisons.tex
@@ -331,8 +331,8 @@
     \label{thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space}
     \lean{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace}
     \leanok
-    \uses{lem:block_diagonal_boundary_local_sum_mem,
-        thm:block_diagonal_boundary_crossing_pgvwc_comparison}
+    \uses{lem:block_diagonal_boundary_crossing_trace_decompositions_boundary,
+        lem:fixed_complementary_word_boundary_compatibility_from_traces}
     Let
     \begin{align}
         \psi
@@ -362,15 +362,24 @@
 
 \begin{proof}
     \leanok
-    \uses{lem:block_diagonal_boundary_local_sum_mem,
-        thm:block_diagonal_boundary_crossing_pgvwc_comparison}
-    For a boundary-crossing interval beginning at $i$ and an outside word
-    $\rho$, choose a configuration whose outside segment is $\rho$. The local
-    constraint on $\psi$ gives a vector in $\bigvee_jG_L(A_j)$ by
-    Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}.
-    Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison}
-    applied with the stated span at length $N-i$ gives the displayed
-    $C^j,D^j$ comparison for that interval and outside word.
+    \uses{lem:block_diagonal_boundary_crossing_trace_decompositions_boundary,
+        lem:fixed_complementary_word_boundary_compatibility_from_traces}
+    Lemma~\ref{lem:block_diagonal_boundary_crossing_trace_decompositions_boundary}
+    gives matrices $C^j_{i,\rho}$ such that, for every boundary-crossing start
+    $i$, outside word $\rho$, word $\beta$ before the cut, and word $w$ of
+    length $N-i$,
+    \begin{align}
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        &=
+        \sum_j\tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+        \notag
+    \end{align}
+    Apply
+    Lemma~\ref{lem:fixed_complementary_word_boundary_compatibility_from_traces}
+    with the stated product-algebra span at length $N-i$. Equality of the
+    traces for all $w$ then gives
+    $A^j_\beta C^j_{i,\rho}=((\mu_j^NX_j)A^j_\beta)A^j_\rho$ for every block
+    $j$.
 \end{proof}
 
 \begin{theorem}[Fixed boundary-crossing component in the local block space]


### PR DESCRIPTION
## What changed
- Updated the theorem and proof dependencies for the chain-ground-space boundary comparison to use the fixed-tail trace decomposition and complementary-word compatibility lemmas.
- Rewrote the proof sketch around the trace identity used by the refactored Lean proof.

## Validation
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (16,319 Lean declarations; 7,046 blueprint references; 7,084/7,084 entries formalized)
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7,084/7,084 entries formalized)
- `TEXINPUTS="../../tex/tenkz//:" lualatex -interaction=nonstopmode -halt-on-error print.tex` twice (0 non-citation undefined references)
- `git diff --check`

Closes #6033
Advances #5995

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint-only dependency and proof-text updates with no Lean or runtime code changes; low risk to production behavior.
> 
> **Overview**
> Updates the blueprint for **`thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space`** so its Lean dependency list and proof sketch match the refactored formalization.
> 
> The theorem’s `\uses` now cites **`lem:block_diagonal_boundary_crossing_trace_decompositions_boundary`** and **`lem:fixed_complementary_word_boundary_compatibility_from_traces`** instead of **`lem:block_diagonal_boundary_local_sum_mem`** and **`thm:block_diagonal_boundary_crossing_pgvwc_comparison`**. The proof is rewritten to obtain the summed trace identity from the trace-decompositions lemma, then promote it to the per-block **\(C^j,D^j\)** matrix relation via the complementary-word trace lemma—parallel to the local block-sum comparison theorem above it in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b245dd8c961ed5d2defb6735de53c2c073c43f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
