### PR TITLE
docs(rfp): retarget Appendix B source citations

### DIFF
--- a/docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
+++ b/docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
@@ -32,7 +32,7 @@ The first parent-Hamiltonian follow-up added two theorem wrappers to
 - `MPSTensor.ProductPairBridge.isNNCPH`
 
 Those results are immediate from the already-proved unfolded commutation theorem in
-`TNLean/MPS/RFP/CommutingBridge.lean`, but they matter conceptually: they isolate the internal
+`TNLean/MPS/RFP/AppendixBStructuralData.lean`, but they matter conceptually: they isolate the internal
 `RFP ⟹ NNCPH` task to **constructing the product-pair witness**, rather than reproving the NNCPH
 wrapper each time.
 
@@ -90,7 +90,7 @@ After the wrappers and Appendix B structural data above, the missing internal th
 
 - `TNLean/MPS/RFP/StructuralFull.lean` proves the full Appendix B structural form
   `rfp_nt_structural_full`.
-- `TNLean/MPS/RFP/CommutingBridge.lean` now records this output as
+- `TNLean/MPS/RFP/AppendixBStructuralData.lean` now records this output as
   `AppendixBStructuralData` and names the remaining chain-space extraction as
   `AppendixBProductPairExtraction`.
 - `Commuting.lean` exposes both the final wrapper `ProductPairBridge.isNNCPH` and the conditional

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -175,7 +175,7 @@ projector onto \(G_2(A)^\perp\), these coefficient-space maps are orthogonal.
 They are not, by themselves, constructions of the source projectors on
 \(\mathcal H_A\otimes\mathcal H_X\) and
 \(\mathcal H_X\otimes\mathcal H_B\), as stated in their defining docstrings in
-\texttt{TNLean/MPS/RFP/CommutingBridge.lean}.  The additional identification,
+\texttt{TNLean/MPS/RFP/AppendixBStructuralData.lean}.  The additional identification,
 after transporting the source projectors to coefficient space, is the explicit
 hypothesis of
 \leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}


### PR DESCRIPTION
## What changed

- Retargeted the Appendix B structural-data citation in the standalone CPSV16 parent commuting Hamiltonian note.
- Retargeted the audit citations for `AppendixBStructuralData`, `AppendixBProductPairExtraction`, and the unfolded commutation theorem.
- Preserved the mathematical prose and claims unchanged.

## Validation

- `rg -n 'TNLean/MPS/RFP/CommutingBridge\.lean' docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md` returns no matches.
- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_parent_commuting_hamiltonian_scope.tex` passes.
- `git diff --check` passes.
- Only the two requested documentation files changed.

Closes #6036.
Advances #5995.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only path updates with no code or mathematical claim changes.
> 
> **Overview**
> Documentation citations for Appendix B structural data are updated to point at **`TNLean/MPS/RFP/AppendixBStructuralData.lean`** instead of **`CommutingBridge.lean`**, in the CPSV16 parent commuting Hamiltonian scope note and the issue #234 commuting-parent-Hamiltonian audit.
> 
> The audit retargets references to the unfolded commutation theorem, **`AppendixBStructuralData`**, and **`AppendixBProductPairExtraction`**. The LaTeX note retargets the docstring path for the Appendix B coefficient-space projector representatives. **Mathematical prose and claims are unchanged**—only Lean file paths in citations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9764cf92bd1d7d41bbf3f59999f93ab0f702126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->