### PR TITLE
docs(rfp): correct product-pair source citation

### DIFF
--- a/docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
+++ b/docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
@@ -32,7 +32,7 @@ The first parent-Hamiltonian follow-up added two theorem wrappers to
 - `MPSTensor.ProductPairBridge.isNNCPH`
 
 Those results are immediate from the already-proved unfolded commutation theorem in
-`TNLean/MPS/RFP/AppendixBStructuralData.lean`, but they matter conceptually: they isolate the internal
+`TNLean/MPS/ParentHamiltonian/ProductPair.lean`, but they matter conceptually: they isolate the internal
 `RFP ⟹ NNCPH` task to **constructing the product-pair witness**, rather than reproving the NNCPH
 wrapper each time.
 


### PR DESCRIPTION
## What changed
- Corrected the remaining unfolded product-pair commutation theorem citation to `TNLean/MPS/ParentHamiltonian/ProductPair.lean`.
- Kept the two Appendix B structural-data citations on `TNLean/MPS/RFP/AppendixBStructuralData.lean`.

## Validation
- Confirmed both cited commutation theorems are declared in `ProductPair.lean`.
- Focused path scan finds one ProductPair citation, two AppendixBStructuralData citations, and no stale CommutingBridge citation.
- Standalone paper-gap TeX compilation passed.
- `git diff --check` passed.

Closes #6036
Advances #5995

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only citation fix with no changes to formal proofs or runtime code.
> 
> **Overview**
> Updates the issue #234 audit note so the **unfolded product-pair commutation theorem** is cited to `TNLean/MPS/ParentHamiltonian/ProductPair.lean` instead of `TNLean/MPS/RFP/AppendixBStructuralData.lean`.
> 
> That line explains why the `Commuting.lean` wrappers `HasProductPairLocalProjectors.isNNCPH` and `ProductPairBridge.isNNCPH` are thin: they follow the commutation results proved in `ProductPair.lean`, not Appendix B structural data. **No Lean or proof changes**—documentation alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58feace39621139d349b8076153e188e94a86429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->