### PR TITLE
feat(algebra): prove Kronecker rank multiplicativity

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -48,6 +48,7 @@ import TNLean.Algebra.MatrixOperatorSpace
 import TNLean.Algebra.MatrixPosDefTransport
 import TNLean.Algebra.MatrixRankBaseChange
 import TNLean.Algebra.MatrixRankClosed
+import TNLean.Algebra.MatrixRankKronecker
 import TNLean.Algebra.MatrixReindexUnitary
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixStabilization

--- a/TNLean/Algebra/MatrixRankKronecker.lean
+++ b/TNLean/Algebra/MatrixRankKronecker.lean
@@ -17,7 +17,6 @@ This file proves that matrix rank is multiplicative under the Kronecker product 
 * `Matrix.rank_kronecker`: the rank of `A ⊗ₖ B` is the product of the ranks of `A` and `B`.
 -/
 
-open Module
 open scoped Kronecker
 
 namespace Matrix

--- a/TNLean/Algebra/MatrixRankKronecker.lean
+++ b/TNLean/Algebra/MatrixRankKronecker.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Matrix.Rank
+import Mathlib.LinearAlgebra.TensorProduct.Matrix
+import Mathlib.RingTheory.Flat.Basic
+
+/-!
+# Rank of a Kronecker product
+
+This file proves that matrix rank is multiplicative under the Kronecker product over a field.
+
+## Main result
+
+* `Matrix.rank_kronecker`: the rank of `A ⊗ₖ B` is the product of the ranks of `A` and `B`.
+-/
+
+open Module
+open scoped Kronecker
+
+namespace Matrix
+
+variable {K m n p q : Type*} [Field K] [Finite m] [Fintype n] [Finite p] [Fintype q]
+
+/-- Matrix rank is multiplicative under the Kronecker product over a field. -/
+theorem rank_kronecker (A : Matrix m n K) (B : Matrix p q K) :
+    (A ⊗ₖ B).rank = A.rank * B.rank := by
+  classical
+  rw [Matrix.rank_eq_finrank_range_toLin (A ⊗ₖ B)
+      ((Pi.basisFun K m).tensorProduct (Pi.basisFun K p))
+      ((Pi.basisFun K n).tensorProduct (Pi.basisFun K q)),
+    Matrix.toLin_kronecker,
+    TensorProduct.range_map,
+    ← TensorProduct.range_mapIncl,
+    LinearMap.finrank_range_of_inj
+      (Module.Flat.tensorProduct_mapIncl_injective_of_left
+        (LinearMap.range (Matrix.toLin (Pi.basisFun K n) (Pi.basisFun K m) A))
+        (LinearMap.range (Matrix.toLin (Pi.basisFun K q) (Pi.basisFun K p) B))),
+    Module.finrank_tensorProduct,
+    ← Matrix.rank_eq_finrank_range_toLin A (Pi.basisFun K m) (Pi.basisFun K n),
+    ← Matrix.rank_eq_finrank_range_toLin B (Pi.basisFun K p) (Pi.basisFun K q)]
+
+end Matrix

--- a/TNLean/Algebra/MatrixRankKronecker.lean
+++ b/TNLean/Algebra/MatrixRankKronecker.lean
@@ -12,7 +12,7 @@ import Mathlib.RingTheory.Flat.Basic
 
 This file proves that matrix rank is multiplicative under the Kronecker product over a field.
 
-## Main result
+## Main results
 
 * `Matrix.rank_kronecker`: the rank of `A ⊗ₖ B` is the product of the ranks of `A` and `B`.
 -/


### PR DESCRIPTION
## What changed

- add `Matrix.rank_kronecker` for finite rectangular matrices over a field
- identify the Kronecker linear map with the tensor product of the two matrix linear maps
- compute the range dimension using tensor-product finrank multiplicativity
- export the new algebra module through the generated aggregator

This supplies the missing algebraic prerequisite for the tensor-product clause of the MPU Index Theorem.

## Validation

- `lake build TNLean.Algebra.MatrixRankKronecker`
- `lake build TNLean.Algebra`
- `python3 scripts/generate_import_aggregators.py --check`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `lake exe lint_style`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`

Closes #6040

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib-style algebra lemma and import wiring only; no changes to runtime or security-sensitive paths.
> 
> **Overview**
> Adds **`Matrix.rank_kronecker`**: for matrices over a field, `(A ⊗ₖ B).rank = A.rank * B.rank`.
> 
> The proof rewrites rank via `toLin` on tensor-product bases, uses **`Matrix.toLin_kronecker`** to match the Kronecker map with a tensor product of linear maps, then applies range/finrank lemmas for tensor products (including injectivity from **`Module.Flat.tensorProduct_mapIncl_injective_of_left`** on the two matrix ranges).
> 
> Registers the new module in the generated **`TNLean.Algebra`** aggregator so downstream work (e.g. MPU Index Theorem tensor-product clause) can import it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f314749fc163e902f36c02c813d0c8f83e12c60a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->