### PR TITLE
fix(docs): restore martingale note preamble

### DIFF
--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1,11 +1,13 @@
 \documentclass{article}
 
 \usepackage{amsmath,amssymb}
+\usepackage{mathrsfs}
 \usepackage{xurl}
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
 \input{command}
+\providecommand{\Fin}[1]{\{0,\ldots,#1{-}1\}}
 
 \title{The Martingale Principal-Angle Estimate for MPS Parent Hamiltonians}
 \author{}


### PR DESCRIPTION
## Summary
- load the repository-established `mathrsfs` package for `\mathscr`
- provide the blueprint-standard `\Fin` notation locally, which was the next undefined preamble command exposed after fixing `\mathscr`
- keep the fix preamble-only; no mathematical prose, formulas, or claims change

## Validation
- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv21_martingale_overlap.tex`
- `git diff --check`

The standalone build completes with bibliography and references resolved. Existing duplicate equation-destination and long-identifier box warnings remain unchanged and are unrelated to this preamble repair.

Closes #6050

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX preamble fix with no changes to Lean code or mathematical content in the note.
> 
> **Overview**
> Repairs the **preamble-only** setup for `cpgsv21_martingale_overlap.tex` so the martingale overlap note compiles standalone again. No mathematical prose, formulas, or claims in the body are changed.
> 
> Adds `\usepackage{mathrsfs}` so existing `\mathscr` notation (e.g. `\mathscr R(\mathcal L)`) is defined. Adds a local `\providecommand{\Fin}` for blueprint-style finite index sets (e.g. `I=\Fin D`), which was the next undefined command after fixing `\mathscr`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e1a7a0c446ecc83d5a75cf4d7f9e645ff25156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->