### PR TITLE
feat(MPS/MPU): add physical identity ancillas

### DIFF
--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -88,6 +88,11 @@ identifying `Fin d × Fin d` with `Fin (d * d)` via the standard product encodin
 def toMPSTensor (M : MPOTensor d D) : MPSTensor (d * d) D :=
   fun ij => M (ij.divNat) (ij.modNat)
 
+/-- Reindex both physical legs of an MPO tensor by the same equivalence. -/
+def reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d)
+    (U : MPOTensor d D) : MPOTensor d' D :=
+  fun i j ↦ U (e i) (e j)
+
 /-- The physical matrix obtained from a fixed pair of virtual indices of an
 MPO tensor.
 

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -14,6 +14,7 @@ import TNLean.MPS.MPU.BlockingRanks
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.MatchingContractions
+import TNLean.MPS.MPU.PhysicalAncilla
 import TNLean.MPS.MPU.ResidualAlgebra
 import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking

--- a/TNLean/MPS/MPU/PhysicalAncilla.lean
+++ b/TNLean/MPS/MPU/PhysicalAncilla.lean
@@ -10,14 +10,17 @@ import TNLean.MPS.MPU.Basic
 
 This file formalizes the local tensor operation
 $\mathcal U^{(x)} = \mathcal U \otimes I_x$ from arXiv:1703.09188,
-lines 706--724.  It enlarges only the physical alphabet, from `d` to `d * x`;
-the virtual bond dimension remains `D`.
+lines 706--724.  It enlarges only the physical alphabet, from \(d\) to \(d x\);
+the virtual bond dimension remains \(D\).
 
 ## Main definitions
 
 * `MPOTensor.tensorPhysicalId`: attach an identity ancilla at each physical site.
 * `MPOTensor.physicalAncillaConfigEquiv`: split every enlarged physical configuration
   into its original and ancilla configurations.
+
+## Main results
+
 * `MPOTensor.mpo_tensorPhysicalId`: the generated MPO is the reindexed Kronecker
   product of the original MPO and the ancilla identity.
 * `MPOTensor.IsMPU.tensorPhysicalId`: identity-ancilla attachment preserves the MPU
@@ -30,8 +33,8 @@ namespace MPOTensor
 
 variable {d D x : ℕ}
 
-/-- Attach a physical identity ancilla of dimension `x` to an MPO tensor, without
-changing its virtual bond dimension.
+/-- Attach a physical identity ancilla of dimension \(x\) to an MPO tensor, without
+changing its virtual bond dimension \(D\).
 
 In coordinates, the enlarged physical indices are pairs `(i, a)` and `(j, b)`, and
 $\mathcal U^{(x)}_{(i,a),(j,b);\beta,\alpha}

--- a/TNLean/MPS/MPU/PhysicalAncilla.lean
+++ b/TNLean/MPS/MPU/PhysicalAncilla.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.Basic
+
+/-!
+# Attaching a physical identity ancilla to a matrix product unitary
+
+This file formalizes the local tensor operation
+$\mathcal U^{(x)} = \mathcal U \otimes I_x$ from arXiv:1703.09188,
+lines 706--724.  It enlarges only the physical alphabet, from `d` to `d * x`;
+the virtual bond dimension remains `D`.
+
+## Main definitions
+
+* `MPOTensor.tensorPhysicalId`: attach an identity ancilla at each physical site.
+* `MPOTensor.physicalAncillaConfigEquiv`: split every enlarged physical configuration
+  into its original and ancilla configurations.
+* `MPOTensor.mpo_tensorPhysicalId`: the generated MPO is the reindexed Kronecker
+  product of the original MPO and the ancilla identity.
+* `MPOTensor.IsMPU.tensorPhysicalId`: identity-ancilla attachment preserves the MPU
+  property.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor
+
+variable {d D x : ℕ}
+
+/-- Attach a physical identity ancilla of dimension `x` to an MPO tensor, without
+changing its virtual bond dimension.
+
+In coordinates, the enlarged physical indices are pairs `(i, a)` and `(j, b)`, and
+$\mathcal U^{(x)}_{(i,a),(j,b);\beta,\alpha}
+  = \mathcal U_{i,j;\beta,\alpha}\,\delta_{a,b}$.
+
+Source: arXiv:1703.09188, lines 706--724. -/
+def tensorPhysicalId (U : MPOTensor d D) (x : ℕ) : MPOTensor (d * x) D :=
+  fun ia jb ↦ if ia.modNat = jb.modNat then U ia.divNat jb.divNat else 0
+
+/-- Coordinate formula for physical identity-ancilla attachment. -/
+@[simp] theorem tensorPhysicalId_apply (U : MPOTensor d D) (i j : Fin d)
+    (a b : Fin x) (β α : Fin D) :
+    tensorPhysicalId U x (finProdFinEquiv (i, a)) (finProdFinEquiv (j, b)) β α =
+      U i j β α * if a = b then 1 else 0 := by
+  by_cases h : a = b <;> simp [tensorPhysicalId, h]
+
+/-- Each fixed-virtual physical slice is the Kronecker product with the ancilla
+identity, reindexed from pairs to the standard `Fin (d * x)` product encoding. -/
+theorem physicalSlice_tensorPhysicalId (U : MPOTensor d D) (x : ℕ) (β α : Fin D) :
+    physicalSlice (tensorPhysicalId U x) β α =
+      Matrix.reindex finProdFinEquiv finProdFinEquiv
+        (physicalSlice U β α ⊗ₖ (1 : Matrix (Fin x) (Fin x) ℂ)) := by
+  ext ia jb
+  by_cases h : ia.modNat = jb.modNat <;>
+    simp [physicalSlice, tensorPhysicalId, Matrix.reindex_apply, h]
+
+/-- Split a sitewise enlarged physical configuration into its original and
+ancilla configurations. -/
+def physicalAncillaConfigEquiv (N d x : ℕ) :
+    (Fin N → Fin (d * x)) ≃ (Fin N → Fin d) × (Fin N → Fin x) :=
+  (Equiv.arrowCongr (Equiv.refl (Fin N)) finProdFinEquiv.symm).trans
+    (Equiv.arrowProdEquivProdArrow (Fin N) (fun _ ↦ Fin d) (fun _ ↦ Fin x))
+
+private theorem evalWord_tensorPhysicalId (U : MPOTensor d D) (x : ℕ)
+    (is js : List (Fin (d * x))) :
+    evalWord (tensorPhysicalId U x) is js =
+      if is.length = js.length ∧ is.map Fin.modNat = js.map Fin.modNat then
+        evalWord U (is.map Fin.divNat) (js.map Fin.divNat)
+      else 0 := by
+  induction is generalizing js with
+  | nil => cases js <;> simp [evalWord]
+  | cons i is ih =>
+      cases js with
+      | nil => simp [evalWord]
+      | cons j js =>
+          by_cases h : i.modNat = j.modNat
+          · simp [evalWord, tensorPhysicalId, h, ih]
+          · simp [evalWord, tensorPhysicalId, h]
+
+/-- The closed MPO generated after identity-ancilla attachment is the Kronecker
+product of the original closed MPO and the ancilla identity, in the canonical
+sitewise product coordinates.
+
+Source: arXiv:1703.09188, lines 706--724. -/
+theorem mpo_tensorPhysicalId (U : MPOTensor d D) (x N : ℕ) :
+    mpo (tensorPhysicalId U x) N =
+      Matrix.reindex (physicalAncillaConfigEquiv N d x).symm
+        (physicalAncillaConfigEquiv N d x).symm
+        (mpo U N ⊗ₖ (1 : Matrix (Fin N → Fin x) (Fin N → Fin x) ℂ)) := by
+  ext σ τ
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.kroneckerMap_apply,
+    Matrix.one_apply, mpo_apply, mpoMatrixEntry]
+  rw [evalWord_tensorPhysicalId]
+  simp only [List.length_ofFn, true_and, List.map_ofFn]
+  by_cases h : (fun c ↦ (σ c).modNat) = (fun c ↦ (τ c).modNat) <;>
+    simp [physicalAncillaConfigEquiv, Equiv.arrowCongr, Function.comp_def, h]
+
+/-- Attaching a nonempty physical identity ancilla preserves the matrix product
+unitary property.
+
+Source: arXiv:1703.09188, lines 706--724. -/
+theorem IsMPU.tensorPhysicalId {U : MPOTensor d D} (hU : IsMPU U)
+    (x : ℕ) (_hx : 0 < x) : IsMPU (tensorPhysicalId U x) := by
+  intro N hN
+  rw [mpo_tensorPhysicalId]
+  apply Matrix.reindex_mem_unitaryGroup
+  rw [Matrix.mem_unitaryGroup_iff]
+  simp only [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+    Matrix.conjTranspose_one]
+  rw [← Matrix.mul_kronecker_mul, hU.mpo_mul_conjTranspose_mpo hN,
+    Matrix.one_mul, Matrix.one_kronecker_one]
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SimpleBlocking.lean
+++ b/TNLean/MPS/MPU/SimpleBlocking.lean
@@ -743,11 +743,6 @@ theorem IsMPU.simple1 [NeZero d] [NeZero D] {U : MPOTensor d D}
   obtain ⟨Φ, ρ, _, _, _, hsimple1⟩ := hU.exists_normalized_fixed_points_simple1
   exact ⟨Φ, ρ, hsimple1⟩
 
-/-- Reindex both physical legs of an MPO tensor by the same equivalence. -/
-def reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d)
-    (U : MPOTensor d D) : MPOTensor d' D :=
-  fun i j ↦ U (e i) (e j)
-
 /-- Simultaneous reindexing of both physical coordinates commutes entrywise with
 formation of the double layer. This is the local coordinate identity used to compare
 iterated and direct physical blockings. -/


### PR DESCRIPTION
## What changed

- define the paper's physical identity ancilla `MPOTensor.tensorPhysicalId : MPOTensor d D → MPOTensor (d * x) D`
- prove the coordinate and physical-slice Kronecker formulas
- identify the generated finite-size MPO with `U^(N) ⊗ Id_x^⊗N` after sitewise configuration reindexing
- prove positive-dimensional physical ancillas preserve `MPOTensor.IsMPU`
- move the existing `MPOTensor.reindexPhysical` declaration to the lower MPDO definitions layer without changing its public name

The construction leaves the virtual bond dimension unchanged and supplies the missing prerequisite for the paper's equivalence definition.

## Validation

- `lake build TNLean.MPS.MPDO.Defs TNLean.MPS.MPU.PhysicalAncilla TNLean.MPS.MPU.SimpleBlocking TNLean.MPS.MPU`
- focused Mathlib lint of the six new declarations
- generated import-aggregator check and regression tests
- proof-integrity, file-policy, prose, and style checks
- `git diff --check origin/main...HEAD`

Closes #6049

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean formalization and a definition move with no runtime or security surface; risk is mainly proof correctness and import layering.
> 
> **Overview**
> Adds formalization of **physical identity ancilla attachment** \(\mathcal U^{(x)} = \mathcal U \otimes I_x\) (arXiv:1703.09188), enlarging the physical alphabet from \(d\) to \(d \cdot x\) while keeping virtual bond dimension \(D\).
> 
> **`tensorPhysicalId`** is defined on `MPOTensor` with coordinate, physical-slice Kronecker, and closed **`mpo`** identities via `physicalAncillaConfigEquiv`. **`IsMPU.tensorPhysicalId`** shows positive ancilla dimension preserves matrix-product unitarity.
> 
> **`MPOTensor.reindexPhysical`** is relocated from `SimpleBlocking` to **`TNLean/MPS/MPDO/Defs`** (same API); `SimpleBlocking` still uses it for `doubleLayerTensor_reindexPhysical`. New module **`TNLean.MPS.MPU.PhysicalAncilla`** is wired into the MPU import aggregator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ec4cd67a7f2ace476924bc203af21b6a6f2ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->