### PR TITLE
feat(QCA): norm the algebraic local observable algebra

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -10,3 +10,4 @@ Authors: TNLean contributors
 
 import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit
+import TNLean.QCA.LocalNorm

--- a/TNLean/QCA/LocalNorm.lean
+++ b/TNLean/QCA/LocalNorm.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.LocalLimit
+
+/-!
+# The operator norm on the algebraic local algebra
+
+The operator norm of a local observable is the operator norm of any finite-region
+representative. The identity-tensor inclusions preserve this norm, so the actual `DirectLimit`
+quotient relation makes the definition independent of the representative.
+
+For positive on-site dimension, this gives the algebraic local algebra its natural normed
+star-algebra structure and the C-star identity. The algebraic local algebra is not asserted to be
+complete, and no quasi-local C-star algebra or quantum cellular automaton is defined here.
+
+## Main definitions
+
+* `SpinChain.algebraicLocalOperatorNorm` — the representative operator norm.
+
+## Main results
+
+* `SpinChain.norm_localObservable` — the canonical inclusion of each finite region preserves norm.
+* `SpinChain.localObservable_isometry` — every local observable inclusion is an isometry.
+* `SpinChain.norm_star_mul_self` — the C-star identity before completion.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2285--2300.
+-/
+
+open scoped ComplexOrder
+
+namespace SpinChain
+
+-- These aliases keep finite-region norm synthesis within the project's pending-depth limit.
+noncomputable local instance (d : ℕ) (Λ : Finset ℤ) : Norm (LocalAlgebra d Λ) :=
+  CStarMatrix.instNorm
+
+noncomputable local instance (d : ℕ) (Λ : Finset ℤ) :
+    NormedAddCommGroup (LocalAlgebra d Λ) :=
+  CStarMatrix.instNormedAddCommGroup
+
+noncomputable local instance (d : ℕ) (Λ : Finset ℤ) : NormedRing (LocalAlgebra d Λ) :=
+  CStarMatrix.instNormedRing
+
+local instance (d : ℕ) (Λ : Finset ℤ) : CStarRing (LocalAlgebra d Λ) :=
+  CStarMatrix.instCStarRing
+
+/-- The operator norm of a local observable, defined from any finite-region representative.
+
+Representative independence follows from `SpinChain.localInclusion_norm` and the defining
+`DirectLimit` quotient relation: two representatives agree after inclusion into a common finite
+region, where their operator norms agree.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+noncomputable def algebraicLocalOperatorNorm (d : ℕ) [NeZero d] :
+    AlgebraicLocalAlgebra d → ℝ :=
+  DirectLimit.lift (localAlgebraMap d) (fun _ A ↦ ‖A‖)
+    (fun _ _ h A ↦ (localInclusion_norm h A).symm)
+
+/-- The operator norm of a canonical finite-region representative is its matrix operator norm.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+@[simp]
+lemma algebraicLocalOperatorNorm_localObservable (d : ℕ) [NeZero d]
+    (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    algebraicLocalOperatorNorm d (localObservable d Λ A) = ‖A‖ :=
+  rfl
+
+noncomputable instance instNormAlgebraicLocalAlgebra (d : ℕ) [NeZero d] :
+    Norm (AlgebraicLocalAlgebra d) where
+  norm := algebraicLocalOperatorNorm d
+
+/-- The canonical inclusion of a finite-region local algebra preserves the operator norm.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+@[simp]
+lemma norm_localObservable (d : ℕ) [NeZero d] (Λ : Finset ℤ)
+    (A : LocalAlgebra d Λ) :
+    ‖localObservable d Λ A‖ = ‖A‖ :=
+  rfl
+
+private lemma algebraicLocalOperatorNorm_nonneg (d : ℕ) [NeZero d]
+    (A : AlgebraicLocalAlgebra d) : 0 ≤ ‖A‖ := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      change 0 ≤ ‖A‖
+      exact norm_nonneg A
+
+private lemma algebraicLocalOperatorNorm_smul (d : ℕ) [NeZero d]
+    (c : ℂ) (A : AlgebraicLocalAlgebra d) : ‖c • A‖ = ‖c‖ * ‖A‖ := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      change ‖c • A‖ = ‖c‖ * ‖A‖
+      exact norm_smul c A
+
+private lemma algebraicLocalOperatorNorm_add_le (d : ℕ) [NeZero d]
+    (A B : AlgebraicLocalAlgebra d) : ‖A + B‖ ≤ ‖A‖ + ‖B‖ := by
+  induction A, B using DirectLimit.induction₂ with
+  | _ Λ A B =>
+      rw [DirectLimit.add_def]
+      change ‖A + B‖ ≤ ‖A‖ + ‖B‖
+      exact norm_add_le A B
+
+private lemma algebraicLocalOperatorNorm_eq_zero_iff (d : ℕ) [NeZero d]
+    (A : AlgebraicLocalAlgebra d) : ‖A‖ = 0 ↔ A = 0 := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      change ‖A‖ = 0 ↔ localObservable d Λ A = 0
+      rw [norm_eq_zero]
+      constructor
+      · rintro rfl
+        exact map_zero (localObservable d Λ)
+      · intro hA
+        apply localObservable_injective d Λ
+        simpa using hA
+
+private theorem algebraicLocalNormedSpaceCore (d : ℕ) [NeZero d] :
+    NormedSpace.Core ℂ (AlgebraicLocalAlgebra d) where
+  norm_nonneg := algebraicLocalOperatorNorm_nonneg d
+  norm_smul := algebraicLocalOperatorNorm_smul d
+  norm_triangle := algebraicLocalOperatorNorm_add_le d
+  norm_eq_zero_iff := algebraicLocalOperatorNorm_eq_zero_iff d
+
+noncomputable instance instNormedAddCommGroupAlgebraicLocalAlgebra (d : ℕ) [NeZero d] :
+    NormedAddCommGroup (AlgebraicLocalAlgebra d) :=
+  NormedAddCommGroup.ofCore (algebraicLocalNormedSpaceCore d)
+
+private lemma algebraicLocalOperatorNorm_mul_le (d : ℕ) [NeZero d]
+    (A B : AlgebraicLocalAlgebra d) : ‖A * B‖ ≤ ‖A‖ * ‖B‖ := by
+  induction A, B using DirectLimit.induction₂ with
+  | _ Λ A B =>
+      rw [DirectLimit.mul_def]
+      change ‖A * B‖ ≤ ‖A‖ * ‖B‖
+      exact norm_mul_le A B
+
+/-- The algebraic local algebra with its representative operator norm is a normed ring.
+
+No completeness claim is made.
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+noncomputable instance instNormedRingAlgebraicLocalAlgebra (d : ℕ) [NeZero d] :
+    NormedRing (AlgebraicLocalAlgebra d) where
+  dist_eq _ _ := rfl
+  norm_mul_le := algebraicLocalOperatorNorm_mul_le d
+
+/-- The algebraic local algebra with its representative operator norm is a normed complex
+algebra.
+
+No completeness claim is made.
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+noncomputable instance instNormedAlgebraAlgebraicLocalAlgebra (d : ℕ) [NeZero d] :
+    NormedAlgebra ℂ (AlgebraicLocalAlgebra d) where
+  norm_smul_le c A := by
+    induction A using DirectLimit.induction with
+    | _ Λ A =>
+        rw [DirectLimit.smul_def]
+        change ‖c • A‖ ≤ ‖c‖ * ‖A‖
+        exact (norm_smul c A).le
+
+/-- The algebraic local algebra is a star ring. This explicit instance keeps synthesis within
+the project's pending-depth limit. -/
+noncomputable instance instStarRingAlgebraicLocalAlgebra (d : ℕ) :
+    StarRing (AlgebraicLocalAlgebra d) where
+  star_involutive A := by
+    induction A using DirectLimit.induction with
+    | _ Λ A => rw [DirectLimit.star_def, DirectLimit.star_def, star_star]
+  star_mul A B := by
+    induction A, B using DirectLimit.induction₂ with
+    | _ Λ A B =>
+        rw [DirectLimit.mul_def, DirectLimit.star_def, DirectLimit.star_def,
+          DirectLimit.star_def, star_mul, DirectLimit.mul_def]
+  star_add A B := by
+    induction A, B using DirectLimit.induction₂ with
+    | _ Λ A B =>
+        rw [DirectLimit.add_def, DirectLimit.star_def, DirectLimit.star_def,
+          DirectLimit.star_def, star_add, DirectLimit.add_def]
+
+/-- The representative operator norm satisfies the C-star identity on the algebraic local
+algebra, before completion.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+lemma norm_star_mul_self (d : ℕ) [NeZero d] (A : AlgebraicLocalAlgebra d) :
+    ‖star A * A‖ = ‖A‖ * ‖A‖ := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      rw [DirectLimit.star_def, DirectLimit.mul_def]
+      change ‖star A * A‖ = ‖A‖ * ‖A‖
+      exact CStarRing.norm_star_mul_self
+
+/-- The normed star ring underlying the algebraic local algebra satisfies the C-star axiom.
+It need not be complete.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+instance instCStarRingAlgebraicLocalAlgebra (d : ℕ) [NeZero d] :
+    CStarRing (AlgebraicLocalAlgebra d) where
+  norm_mul_self_le A := (norm_star_mul_self d A).ge
+
+/-- Every canonical map from a finite region into the local algebra is an operator-norm
+isometry.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2296. -/
+lemma localObservable_isometry (d : ℕ) [NeZero d] (Λ : Finset ℤ) :
+    Isometry (localObservable d Λ) := by
+  rw [isometry_iff_dist_eq]
+  intro A B
+  rw [dist_eq_norm, dist_eq_norm]
+  change ‖(localObservable d Λ).toAlgHom.toRingHom A -
+    (localObservable d Λ).toAlgHom.toRingHom B‖ = ‖A - B‖
+  rw [← (localObservable d Λ).toAlgHom.toRingHom.map_sub]
+  change ‖localObservable d Λ (A - B)‖ = ‖A - B‖
+  exact norm_localObservable d Λ (A - B)
+
+end SpinChain

--- a/TNLean/QCA/LocalNorm.lean
+++ b/TNLean/QCA/LocalNorm.lean
@@ -35,7 +35,6 @@ open scoped ComplexOrder
 
 namespace SpinChain
 
--- These aliases keep finite-region norm synthesis within the project's pending-depth limit.
 noncomputable local instance (d : ℕ) (Λ : Finset ℤ) : Norm (LocalAlgebra d Λ) :=
   CStarMatrix.instNorm
 
@@ -160,8 +159,7 @@ noncomputable instance instNormedAlgebraAlgebraicLocalAlgebra (d : ℕ) [NeZero 
         change ‖c • A‖ ≤ ‖c‖ * ‖A‖
         exact (norm_smul c A).le
 
-/-- The algebraic local algebra is a star ring. This explicit instance keeps synthesis within
-the project's pending-depth limit. -/
+/-- The algebraic local algebra is a star ring. -/
 noncomputable instance instStarRingAlgebraicLocalAlgebra (d : ℕ) :
     StarRing (AlgebraicLocalAlgebra d) where
   star_involutive A := by

--- a/TNLean/QCA/LocalNorm.lean
+++ b/TNLean/QCA/LocalNorm.lean
@@ -35,18 +35,8 @@ open scoped ComplexOrder
 
 namespace SpinChain
 
-noncomputable local instance (d : ℕ) (Λ : Finset ℤ) : Norm (LocalAlgebra d Λ) :=
-  CStarMatrix.instNorm
-
-noncomputable local instance (d : ℕ) (Λ : Finset ℤ) :
-    NormedAddCommGroup (LocalAlgebra d Λ) :=
-  CStarMatrix.instNormedAddCommGroup
-
-noncomputable local instance (d : ℕ) (Λ : Finset ℤ) : NormedRing (LocalAlgebra d Λ) :=
-  CStarMatrix.instNormedRing
-
-local instance (d : ℕ) (Λ : Finset ℤ) : CStarRing (LocalAlgebra d Λ) :=
-  CStarMatrix.instCStarRing
+attribute [local instance] CStarMatrix.instNorm CStarMatrix.instNormedAddCommGroup
+  CStarMatrix.instNormedRing CStarMatrix.instCStarRing
 
 /-- The operator norm of a local observable, defined from any finite-region representative.
 
@@ -69,6 +59,7 @@ lemma algebraicLocalOperatorNorm_localObservable (d : ℕ) [NeZero d]
     algebraicLocalOperatorNorm d (localObservable d Λ A) = ‖A‖ :=
   rfl
 
+/-- The operator norm on the algebraic local algebra. -/
 noncomputable instance instNormAlgebraicLocalAlgebra (d : ℕ) [NeZero d] :
     Norm (AlgebraicLocalAlgebra d) where
   norm := algebraicLocalOperatorNorm d
@@ -109,13 +100,17 @@ private lemma algebraicLocalOperatorNorm_eq_zero_iff (d : ℕ) [NeZero d]
   induction A using DirectLimit.induction with
   | _ Λ A =>
       change ‖A‖ = 0 ↔ localObservable d Λ A = 0
-      rw [norm_eq_zero]
       constructor
-      · rintro rfl
+      · rw [norm_eq_zero]
+        rintro rfl
         exact map_zero (localObservable d Λ)
       · intro hA
-        apply localObservable_injective d Λ
-        simpa using hA
+        calc
+          ‖A‖ = ‖localObservable d Λ A‖ := rfl
+          _ = ‖(0 : AlgebraicLocalAlgebra d)‖ := congrArg norm hA
+          _ = ‖localObservable d Λ (0 : LocalAlgebra d Λ)‖ := by rw [map_zero]
+          _ = ‖(0 : LocalAlgebra d Λ)‖ := rfl
+          _ = 0 := norm_zero
 
 private theorem algebraicLocalNormedSpaceCore (d : ℕ) [NeZero d] :
     NormedSpace.Core ℂ (AlgebraicLocalAlgebra d) where
@@ -158,23 +153,6 @@ noncomputable instance instNormedAlgebraAlgebraicLocalAlgebra (d : ℕ) [NeZero 
         rw [DirectLimit.smul_def]
         change ‖c • A‖ ≤ ‖c‖ * ‖A‖
         exact (norm_smul c A).le
-
-/-- The algebraic local algebra is a star ring. -/
-noncomputable instance instStarRingAlgebraicLocalAlgebra (d : ℕ) :
-    StarRing (AlgebraicLocalAlgebra d) where
-  star_involutive A := by
-    induction A using DirectLimit.induction with
-    | _ Λ A => rw [DirectLimit.star_def, DirectLimit.star_def, star_star]
-  star_mul A B := by
-    induction A, B using DirectLimit.induction₂ with
-    | _ Λ A B =>
-        rw [DirectLimit.mul_def, DirectLimit.star_def, DirectLimit.star_def,
-          DirectLimit.star_def, star_mul, DirectLimit.mul_def]
-  star_add A B := by
-    induction A, B using DirectLimit.induction₂ with
-    | _ Λ A B =>
-        rw [DirectLimit.add_def, DirectLimit.star_def, DirectLimit.star_def,
-          DirectLimit.star_def, star_add, DirectLimit.add_def]
 
 /-- The representative operator norm satisfies the C-star identity on the algebraic local
 algebra, before completion.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3253,6 +3253,87 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \cite{Cirac2017MPU}.  No norm completion is taken.
 \end{definition}
 
+\begin{definition}[Operator norm on the local algebra]
+  \label{def:qca_algebraic_local_operator_norm}
+  \lean{SpinChain.algebraicLocalOperatorNorm,
+    SpinChain.algebraicLocalOperatorNorm_localObservable,
+    SpinChain.norm_localObservable}
+  \leanok
+  \uses{def:qca_algebraic_local_algebra,lem:qca_local_inclusion_norm}
+  Assume $d>0$.  If a local observable $A\in\mathcal A_{\mathrm{loc}}$
+  is represented by $A_\Lambda\in\mathcal A_\Lambda$ on a finite region
+  $\Lambda$, define its operator norm by
+  \begin{align}
+    \lVert A\rVert&=\lVert A_\Lambda\rVert.
+  \end{align}
+  This does not depend on the finite region or representative.
+\end{definition}
+
+\begin{proof}\leanok
+  If $A_\Lambda$ and $A_\Gamma$ represent the same local observable, then
+  the defining relation for the inductive limit gives a finite region
+  $\Delta\supseteq\Lambda\cup\Gamma$ such that
+  \begin{align}
+    \iota_{\Lambda,\Delta}(A_\Lambda)
+      &=\iota_{\Gamma,\Delta}(A_\Gamma).
+  \end{align}
+  Both inclusions preserve the operator norm, so
+  $\lVert A_\Lambda\rVert=\lVert A_\Gamma\rVert$.
+\end{proof}
+
+\begin{theorem}[Normed star algebra of local observables]
+  \label{thm:qca_algebraic_local_normed_star_algebra}
+  \lean{SpinChain.instNormedAddCommGroupAlgebraicLocalAlgebra,
+    SpinChain.instNormedRingAlgebraicLocalAlgebra,
+    SpinChain.instNormedAlgebraAlgebraicLocalAlgebra,
+    SpinChain.instStarRingAlgebraicLocalAlgebra,
+    SpinChain.instCStarRingAlgebraicLocalAlgebra,
+    SpinChain.norm_star_mul_self}
+  \leanok
+  \uses{def:qca_algebraic_local_operator_norm}
+  For $d>0$, the local algebra with the operator norm is a normed complex
+  star algebra.  For every local observable $A$ it satisfies the C-star
+  identity
+  \begin{align}
+    \lVert A^*A\rVert&=\lVert A\rVert^2.
+  \end{align}
+  No completeness assertion is made.
+\end{theorem}
+
+\begin{proof}\leanok
+  Choose a finite region $\Lambda$ and a representative
+  $A_\Lambda\in\mathcal A_\Lambda$.  Addition, multiplication, scalar
+  multiplication, and adjoints are computed on finite-region
+  representatives.  Their norm inequalities therefore follow from those
+  in $\mathcal A_\Lambda$.  In particular,
+  \begin{align}
+    \lVert A^*A\rVert
+      &=\lVert A_\Lambda^*A_\Lambda\rVert
+       =\lVert A_\Lambda\rVert^2
+       =\lVert A\rVert^2.
+  \end{align}
+\end{proof}
+
+\begin{lemma}[Local observables embed isometrically]
+  \label{lem:qca_local_observable_isometry}
+  \lean{SpinChain.localObservable_isometry}
+  \leanok
+  \uses{def:qca_algebraic_local_operator_norm}
+  For $d>0$ and every finite region $\Lambda$, the canonical map
+  \begin{align}
+    \iota_\Lambda\colon\mathcal A_\Lambda
+      &\longrightarrow\mathcal A_{\mathrm{loc}}
+  \end{align}
+  is an operator-norm isometry.
+\end{lemma}
+
+\begin{proof}\leanok
+  The norm of $\iota_\Lambda(A)$ is defined to be the operator norm of its
+  representative $A\in\mathcal A_\Lambda$.  Hence
+  $\lVert\iota_\Lambda(A)\rVert=\lVert A\rVert$; applying this equality to
+  differences proves preservation of distance.
+\end{proof}
+
 \begin{theorem}[Star-algebra universal property]
   \label{thm:qca_algebraic_local_algebra_universal}
   \lean{SpinChain.algebraicLocalAlgebraLift,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3284,36 +3284,59 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   $\lVert A_\Lambda\rVert=\lVert A_\Gamma\rVert$.
 \end{proof}
 
-\begin{theorem}[Normed star algebra of local observables]
-  \label{thm:qca_algebraic_local_normed_star_algebra}
+\begin{definition}[Normed star algebra of local observables]
+  \label{def:qca_algebraic_local_normed_star_algebra}
   \lean{SpinChain.instNormedAddCommGroupAlgebraicLocalAlgebra,
     SpinChain.instNormedRingAlgebraicLocalAlgebra,
-    SpinChain.instNormedAlgebraAlgebraicLocalAlgebra,
-    SpinChain.instCStarRingAlgebraicLocalAlgebra,
-    SpinChain.norm_star_mul_self}
+    SpinChain.instNormedAlgebraAlgebraicLocalAlgebra}
   \leanok
   \uses{def:qca_algebraic_local_operator_norm}
   For $d>0$, the local algebra with the operator norm is a normed complex
-  star algebra.  For every local observable $A$ it satisfies the C-star
-  identity
+  star algebra.  No completeness assertion is made.
+\end{definition}
+
+\begin{proof}\leanok
+  Choose finite-region representatives of the local observables and enlarge
+  their regions to a common finite region.  The norm axioms, the product
+  inequality, and compatibility with complex scalar multiplication then
+  follow from the corresponding properties of the finite-region matrix
+  algebra.
+\end{proof}
+
+\begin{theorem}[C-star identity for local observables]
+  \label{thm:qca_algebraic_local_norm_star_mul_self}
+  \lean{SpinChain.norm_star_mul_self}
+  \leanok
+  \uses{def:qca_algebraic_local_normed_star_algebra}
+  For $d>0$ and every local observable $A$,
   \begin{align}
     \lVert A^*A\rVert&=\lVert A\rVert^2.
   \end{align}
-  No completeness assertion is made.
 \end{theorem}
 
 \begin{proof}\leanok
   Choose a finite region $\Lambda$ and a representative
-  $A_\Lambda\in\mathcal A_\Lambda$.  Addition, multiplication, scalar
-  multiplication, and adjoints are computed on finite-region
-  representatives.  Their norm inequalities therefore follow from those
-  in $\mathcal A_\Lambda$.  In particular,
+  $A_\Lambda\in\mathcal A_\Lambda$.  Then
   \begin{align}
     \lVert A^*A\rVert
       &=\lVert A_\Lambda^*A_\Lambda\rVert
        =\lVert A_\Lambda\rVert^2
        =\lVert A\rVert^2.
   \end{align}
+\end{proof}
+
+\begin{definition}[C-star axiom structure on local observables]
+  \label{def:qca_algebraic_local_cstar_ring}
+  \lean{SpinChain.instCStarRingAlgebraicLocalAlgebra}
+  \leanok
+  \uses{thm:qca_algebraic_local_norm_star_mul_self}
+  The normed star algebra of local observables satisfies the C-star axiom.
+  This structure does not include completeness.
+\end{definition}
+
+\begin{proof}\leanok
+  The C-star identity gives the required norm inequality in the reverse
+  direction; submultiplicativity gives the other direction.
 \end{proof}
 
 \begin{lemma}[Local observables embed isometrically]
@@ -3330,6 +3353,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}\leanok
+  \uses{def:qca_algebraic_local_operator_norm}
   The norm of $\iota_\Lambda(A)$ is defined to be the operator norm of its
   representative $A\in\mathcal A_\Lambda$.  Hence
   $\lVert\iota_\Lambda(A)\rVert=\lVert A\rVert$; applying this equality to

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3266,7 +3266,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \begin{align}
     \lVert A\rVert&=\lVert A_\Lambda\rVert.
   \end{align}
-  This does not depend on the finite region or representative.
+  This does not depend on the finite region or representative.  It is the
+  norm whose topology is completed in the Appendix of
+  \cite{Cirac2017MPU} to obtain the quasi-local algebra.
 \end{definition}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3257,6 +3257,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{def:qca_algebraic_local_operator_norm}
   \lean{SpinChain.algebraicLocalOperatorNorm,
     SpinChain.algebraicLocalOperatorNorm_localObservable,
+    SpinChain.instNormAlgebraicLocalAlgebra,
     SpinChain.norm_localObservable}
   \leanok
   \uses{def:qca_algebraic_local_algebra,lem:qca_local_inclusion_norm}
@@ -3288,7 +3289,6 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \lean{SpinChain.instNormedAddCommGroupAlgebraicLocalAlgebra,
     SpinChain.instNormedRingAlgebraicLocalAlgebra,
     SpinChain.instNormedAlgebraAlgebraicLocalAlgebra,
-    SpinChain.instStarRingAlgebraicLocalAlgebra,
     SpinChain.instCStarRingAlgebraicLocalAlgebra,
     SpinChain.norm_star_mul_self}
   \leanok


### PR DESCRIPTION
## What changed

- define the operator norm on `SpinChain.AlgebraicLocalAlgebra d` from finite-region representatives
- prove representative compatibility from the isometric local inclusions
- install the natural normed complex algebra and C-star ring structures before completion
- prove the C-star identity and that every `localObservable` map is an isometry
- add source-facing Chapter 28 entries for the normed algebraic local algebra

This PR makes no completeness, quasi-local algebra, or QCA claim.

## Validation

- `lake build TNLean.QCA.LocalNorm TNLean.QCA`
- in-file Mathlib lint: 0 errors
- generated import-aggregator checks
- focused Chapter 28 declaration synchronization: 255/255
- two LuaLaTeX passes with no undefined non-citation references
- `git diff --check origin/main...HEAD`

Closes #6041

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces normed and C⋆ structure on the algebraic local algebra used in the QCA formalization; scope is limited to pre-completion algebra with proofs tied to existing inclusion isometry lemmas, so risk is moderate rather than high.
> 
> **Overview**
> Adds the **operator norm** on `SpinChain.AlgebraicLocalAlgebra d` by lifting finite-region matrix norms through the direct limit, using existing **isometric** local inclusions for representative independence.
> 
> The PR installs **normed** complex algebra and **C⋆-ring** instances (without completeness), proves **`norm_star_mul_self`**, and shows each **`localObservable`** map is an **isometry**. Chapter 28 blueprint entries are synchronized to these Lean declarations.
> 
> Explicitly **no** quasi-local completion, QCA, or completeness claims in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d1362cd8c3995970895aeb4ea6c7779ec2daed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->