### PR TITLE
feat(parent-hamiltonian): bound finite-Gram C3 corrections

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -33,6 +33,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities
 import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.BoundaryStripping
+import TNLean.MPS.ParentHamiltonian.C3CorrectionBounds
 import TNLean.MPS.ParentHamiltonian.CenteredOverlapFactor
 import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.Commuting

--- a/TNLean/MPS/ParentHamiltonian/C3CorrectionBounds.lean
+++ b/TNLean/MPS/ParentHamiltonian/C3CorrectionBounds.lean
@@ -1,0 +1,565 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.ProjectorCancellation
+
+/-!
+# Finite-Gram correction bounds in the C3 projector residual
+
+This file factors the three finite-Gram correction sandwiches in the exact C3
+projector-residual telescope.  The formulas are reconstructed from TNLean's
+boundary-map and Gram identities.  They are not quoted from FNW,
+Nachtergaele, or CPGSV21.
+
+The orientation is always the tail projector after the left projector.  The
+limiting Gram \(K_\infty\) is the nonidentity operator
+\(\operatorname{gramReshuffle}(\operatorname{fixedPointProj}(\rho))\), and
+positive definiteness of \(\rho\) is kept explicit.
+
+## Main definitions
+
+* `c3TailFiniteGramCorrectionES`
+* `c3FullInverseGramCorrectionES`
+* `c3LeftFiniteGramCorrectionES`
+
+## Main results
+
+* `inverseGram_sub_limitingInverse_eq_resolvent`
+* `leftFiniteGramCancellation_eq_groundSpaceMapES_adjoint`
+* `c3TailFiniteGramCorrectionES_eq_factored`
+* `c3FullInverseGramCorrectionES_eq_factored`
+* `c3LeftFiniteGramCorrectionES_eq_factored`
+* `c3TailFiniteGramCorrectionES_norm_le`
+* `c3FullInverseGramCorrectionES_norm_le`
+* `c3LeftFiniteGramCorrectionES_norm_le`
+-/
+
+open scoped ComplexOrder Matrix Matrix.Norms.Frobenius
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Fiberwise lifting preserves subtraction. -/
+theorem boundaryFiberwiseMap_sub (S : Type*) [Fintype S]
+    (G H : EuclideanSpace ℂ (Fin D × Fin D) →L[ℂ]
+      EuclideanSpace ℂ (Fin D × Fin D)) :
+    boundaryFiberwiseMap (D := D) S (G - H) =
+      boundaryFiberwiseMap (D := D) S G - boundaryFiberwiseMap (D := D) S H := by
+  apply ContinuousLinearMap.coe_injective
+  apply DFunLike.ext _ _
+  intro x
+  rfl
+
+/-- Injectivity of the finite-volume ground-space map makes its Gram a unit. -/
+theorem groundSpaceGram_isUnit_of_groundSpaceMapES_injective
+    {A : MPSTensor d D} {n : ℕ}
+    (h : Function.Injective (groundSpaceMapES A n)) :
+    IsUnit (groundSpaceGram A n) := by
+  have hinj : Function.Injective (groundSpaceGram A n) := by
+    rw [groundSpaceGram]
+    exact (groundSpaceMapES A n).adjoint_comp_self_injective_iff.mpr h
+  rw [ContinuousLinearMap.isUnit_iff_bijective]
+  exact ⟨hinj,
+    (LinearMap.injective_iff_surjective_of_finrank_eq_finrank rfl).mp hinj⟩
+
+/-- The right-oriented finite/limiting resolvent identity.  This orientation
+keeps the finite inverse next to the finite boundary-map adjoint. -/
+theorem inverseGram_sub_limitingInverse_eq_resolvent [NeZero D]
+    (A : MPSTensor d D) (n : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (h : Function.Injective (groundSpaceMapES A n)) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Ifin := ContinuousLinearMap.inverseGram (groundSpaceMapES A n) h
+    let Iinf := Ring.inverse Kinf
+    Ifin - Iinf = Iinf.comp
+      ((Kinf - groundSpaceGram A n).comp Ifin) := by
+  dsimp only
+  rw [ContinuousLinearMap.inverseGram_eq_ringInverse]
+  simp only [groundSpaceGram]
+  let Kfin := groundSpaceGram A n
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  change Ring.inverse Kfin - Ring.inverse Kinf =
+    (Ring.inverse Kinf).comp ((Kinf - Kfin).comp (Ring.inverse Kfin))
+  have hfin : IsUnit Kfin := by
+    simpa only [Kfin] using groundSpaceGram_isUnit_of_groundSpaceMapES_injective h
+  have hinf : IsUnit Kinf := by
+    simpa only [Kinf] using Matrix.gramReshuffle_fixedPointProj_isUnit hρ
+  have hres : Ring.inverse Kinf - Ring.inverse Kfin =
+      (Ring.inverse Kinf).comp ((Kfin - Kinf).comp (Ring.inverse Kfin)) := by
+    simpa only [ContinuousLinearMap.mul_def, ContinuousLinearMap.comp_assoc] using
+      Ring.inverse_sub_inverse (a := Kinf) (b := Kfin) (by simp [hfin, hinf])
+  calc
+    Ring.inverse Kfin - Ring.inverse Kinf =
+        -(Ring.inverse Kinf - Ring.inverse Kfin) := by abel
+    _ = -((Ring.inverse Kinf).comp
+        ((Kfin - Kinf).comp (Ring.inverse Kfin))) := by rw [hres]
+    _ = (Ring.inverse Kinf).comp
+        ((Kinf - Kfin).comp (Ring.inverse Kfin)) := by
+      ext x
+      simp
+
+/-- The tail finite-Gram correction sandwich, before taking norms. -/
+noncomputable def c3TailFiniteGramCorrectionES [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l)))
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    EuclideanSpace ℂ (Cfg d (K + l + 1)) →L[ℂ]
+      EuclideanSpace ℂ (Cfg d (K + l + 1)) :=
+  let Ttail := tailBoundaryMapES A K (l + 1)
+  let Tleft := leftBoundaryMapES A (K + l) 1
+  let Itail := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (l + 1)) hLocalTail
+  let Ileft := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (K + l)) hLocalLeft
+  let Ifull := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (K + l + 1)) hFull
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Ktail := boundaryFiberwiseMap (D := D) (Cfg d K)
+    (groundSpaceGram A (l + 1))
+  let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+  let Kleft := boundaryFiberwiseMap (D := D) (Cfg d 1)
+    (groundSpaceGram A (K + l))
+  Ttail.comp ((boundaryFiberwiseMap (D := D) (Cfg d K) Itail).comp
+    ((Ktail - Kinftail).comp ((tailVirtualMapES A K).comp
+      (Ifull.comp ((leftVirtualMapES A 1).adjoint.comp
+        (Kleft.comp ((boundaryFiberwiseMap (D := D) (Cfg d 1) Ileft).comp
+          Tleft.adjoint)))))))
+
+/-- The full inverse-Gram correction sandwich, before taking norms. -/
+noncomputable def c3FullInverseGramCorrectionES [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l)))
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    EuclideanSpace ℂ (Cfg d (K + l + 1)) →L[ℂ]
+      EuclideanSpace ℂ (Cfg d (K + l + 1)) :=
+  let Ttail := tailBoundaryMapES A K (l + 1)
+  let Tleft := leftBoundaryMapES A (K + l) 1
+  let Itail := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (l + 1)) hLocalTail
+  let Ileft := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (K + l)) hLocalLeft
+  let Ifull := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (K + l + 1)) hFull
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Iinf := Ring.inverse Kinf
+  let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+  let Kleft := boundaryFiberwiseMap (D := D) (Cfg d 1)
+    (groundSpaceGram A (K + l))
+  Ttail.comp ((boundaryFiberwiseMap (D := D) (Cfg d K) Itail).comp
+    (Kinftail.comp ((tailVirtualMapES A K).comp
+      ((Ifull - Iinf).comp ((leftVirtualMapES A 1).adjoint.comp
+        (Kleft.comp ((boundaryFiberwiseMap (D := D) (Cfg d 1) Ileft).comp
+          Tleft.adjoint)))))))
+
+/-- The left finite-Gram correction sandwich, before taking norms. -/
+noncomputable def c3LeftFiniteGramCorrectionES [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l))) :
+    EuclideanSpace ℂ (Cfg d (K + l + 1)) →L[ℂ]
+      EuclideanSpace ℂ (Cfg d (K + l + 1)) :=
+  let Ttail := tailBoundaryMapES A K (l + 1)
+  let Tleft := leftBoundaryMapES A (K + l) 1
+  let Itail := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (l + 1)) hLocalTail
+  let Ileft := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (K + l)) hLocalLeft
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Iinf := Ring.inverse Kinf
+  let Kinftail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+  let Kleft := boundaryFiberwiseMap (D := D) (Cfg d 1)
+    (groundSpaceGram A (K + l))
+  let Kinfleft := boundaryFiberwiseMap (D := D) (Cfg d 1) Kinf
+  Ttail.comp ((boundaryFiberwiseMap (D := D) (Cfg d K) Itail).comp
+    (Kinftail.comp ((tailVirtualMapES A K).comp
+      (Iinf.comp ((leftVirtualMapES A 1).adjoint.comp
+        ((Kleft - Kinfleft).comp
+          ((boundaryFiberwiseMap (D := D) (Cfg d 1) Ileft).comp
+            Tleft.adjoint)))))))
+
+/-- The left fiberwise finite Gram cancels its inverse before the boundary
+adjoint, and the remaining virtual/boundary composition reconstructs the
+adjoint of the full ground-space map. -/
+theorem leftFiniteGramCancellation_eq_groundSpaceMapES_adjoint
+    (A : MPSTensor d D) (K L : ℕ)
+    (h : Function.Injective (groundSpaceMapES A K)) :
+    (leftVirtualMapES A L).adjoint.comp
+      ((boundaryFiberwiseMap (D := D) (Cfg d L)
+        (groundSpaceGram A K)).comp
+      ((boundaryFiberwiseMap (D := D) (Cfg d L)
+        (ContinuousLinearMap.inverseGram (groundSpaceMapES A K) h)).comp
+        (leftBoundaryMapES A K L).adjoint)) =
+      (groundSpaceMapES A (K + L)).adjoint := by
+  have hcancel : (boundaryFiberwiseMap (D := D) (Cfg d L)
+      (groundSpaceGram A K)).comp
+      (boundaryFiberwiseMap (D := D) (Cfg d L)
+        (ContinuousLinearMap.inverseGram (groundSpaceMapES A K) h)) =
+      ContinuousLinearMap.id ℂ _ := by
+    rw [boundaryFiberwiseMap_comp, groundSpaceGram,
+      ContinuousLinearMap.adjoint_comp_self_comp_inverseGram,
+      boundaryFiberwiseMap_id]
+  change ((leftVirtualMapES A L).adjoint.comp
+    ((boundaryFiberwiseMap (D := D) (Cfg d L)
+      (groundSpaceGram A K)).comp
+    (boundaryFiberwiseMap (D := D) (Cfg d L)
+      (ContinuousLinearMap.inverseGram (groundSpaceMapES A K) h)))).comp
+      (leftBoundaryMapES A K L).adjoint = _
+  rw [hcancel, ContinuousLinearMap.comp_id,
+    ← ContinuousLinearMap.adjoint_comp,
+    leftBoundaryMapES_comp_leftVirtualMapES]
+
+/-- Exact factorization of the tail finite-Gram correction.  Both exterior
+pseudoinverse factors remain adjacent to their boundary maps. -/
+theorem c3TailFiniteGramCorrectionES_eq_factored [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l)))
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    let hTail := tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+      A K (l + 1) hLocalTail
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Ifull := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l + 1)) hFull
+    c3TailFiniteGramCorrectionES A K l ρ hρ hLocalTail hLocalLeft hFull =
+      ((tailBoundaryMapES A K (l + 1)).comp
+        (ContinuousLinearMap.inverseGram (tailBoundaryMapES A K (l + 1)) hTail)).comp
+      ((boundaryFiberwiseMap (D := D) (Cfg d K)
+        (groundSpaceGram A (l + 1) - Kinf)).comp
+      ((tailVirtualMapES A K).comp
+        (Ifull.comp (groundSpaceMapES A (K + l + 1)).adjoint))) := by
+  dsimp only
+  simp only [c3TailFiniteGramCorrectionES]
+  rw [inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram
+    A K (l + 1) hLocalTail]
+  rw [boundaryFiberwiseMap_sub]
+  rw [leftFiniteGramCancellation_eq_groundSpaceMapES_adjoint
+    A (K + l) 1 hLocalLeft]
+  simp only [ContinuousLinearMap.comp_assoc]
+
+/-- Exact factorization of the full inverse-Gram correction using the
+right-oriented resolvent identity. -/
+theorem c3FullInverseGramCorrectionES_eq_factored [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l)))
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    let hTail := tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+      A K (l + 1) hLocalTail
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Iinf := Ring.inverse Kinf
+    let Ifull := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l + 1)) hFull
+    c3FullInverseGramCorrectionES A K l ρ hρ hLocalTail hLocalLeft hFull =
+      ((tailBoundaryMapES A K (l + 1)).comp
+        (ContinuousLinearMap.inverseGram (tailBoundaryMapES A K (l + 1)) hTail)).comp
+      ((boundaryFiberwiseMap (D := D) (Cfg d K) Kinf).comp
+      ((tailVirtualMapES A K).comp
+      (Iinf.comp
+      ((Kinf - groundSpaceGram A (K + l + 1)).comp
+        (Ifull.comp (groundSpaceMapES A (K + l + 1)).adjoint))))) := by
+  dsimp only
+  simp only [c3FullInverseGramCorrectionES]
+  rw [inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram
+    A K (l + 1) hLocalTail]
+  rw [inverseGram_sub_limitingInverse_eq_resolvent A (K + l + 1) ρ hρ hFull]
+  rw [leftFiniteGramCancellation_eq_groundSpaceMapES_adjoint
+    A (K + l) 1 hLocalLeft]
+  simp only [ContinuousLinearMap.comp_assoc]
+
+/-- Exact factorization of the left finite-Gram correction.  The inverse Gram
+of the left spectator boundary map stays adjacent to its adjoint. -/
+theorem c3LeftFiniteGramCorrectionES_eq_factored [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l))) :
+    let hTail := tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+      A K (l + 1) hLocalTail
+    let hLeft := leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+      A (K + l) 1 hLocalLeft
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Iinf := Ring.inverse Kinf
+    c3LeftFiniteGramCorrectionES A K l ρ hρ hLocalTail hLocalLeft =
+      ((tailBoundaryMapES A K (l + 1)).comp
+        (ContinuousLinearMap.inverseGram (tailBoundaryMapES A K (l + 1)) hTail)).comp
+      ((boundaryFiberwiseMap (D := D) (Cfg d K) Kinf).comp
+      ((tailVirtualMapES A K).comp
+      (Iinf.comp
+      ((leftVirtualMapES A 1).adjoint.comp
+      ((boundaryFiberwiseMap (D := D) (Cfg d 1)
+        (groundSpaceGram A (K + l) - Kinf)).comp
+      ((ContinuousLinearMap.inverseGram
+        (leftBoundaryMapES A (K + l) 1) hLeft).comp
+          (leftBoundaryMapES A (K + l) 1).adjoint)))))) := by
+  dsimp only
+  simp only [c3LeftFiniteGramCorrectionES]
+  rw [inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram
+    A K (l + 1) hLocalTail]
+  rw [inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram
+    A (K + l) 1 hLocalLeft]
+  rw [boundaryFiberwiseMap_sub]
+  simp only [ContinuousLinearMap.comp_assoc]
+
+/-- The tail spectator pseudoinverse factor is controlled by the inverse
+finite Gram, with no spectator-cardinality factor. -/
+theorem norm_tailBoundaryMapES_comp_inverseGram_le_sqrt
+    (A : MPSTensor d D) (K L : ℕ)
+    (h : Function.Injective (groundSpaceMapES A L)) :
+    let hTail := tailBoundaryMapES_injective_of_groundSpaceMapES_injective A K L h
+    ‖(tailBoundaryMapES A K L).comp
+      (ContinuousLinearMap.inverseGram (tailBoundaryMapES A K L) hTail)‖ ≤
+      Real.sqrt ‖ContinuousLinearMap.inverseGram (groundSpaceMapES A L) h‖ := by
+  dsimp only
+  rw [ContinuousLinearMap.norm_T_comp_inverseGram_eq_sqrt]
+  apply Real.sqrt_le_sqrt
+  rw [inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram A K L h]
+  exact norm_boundaryFiberwiseMap_le _ _
+
+/-- The adjoint-side left spectator pseudoinverse factor is controlled by the
+inverse finite Gram, with no spectator-cardinality factor. -/
+theorem norm_inverseGram_comp_leftBoundaryMapES_adjoint_le_sqrt
+    (A : MPSTensor d D) (K L : ℕ)
+    (h : Function.Injective (groundSpaceMapES A K)) :
+    let hLeft := leftBoundaryMapES_injective_of_groundSpaceMapES_injective A K L h
+    ‖(ContinuousLinearMap.inverseGram (leftBoundaryMapES A K L) hLeft).comp
+      (leftBoundaryMapES A K L).adjoint‖ ≤
+      Real.sqrt ‖ContinuousLinearMap.inverseGram (groundSpaceMapES A K) h‖ := by
+  dsimp only
+  rw [ContinuousLinearMap.norm_inverseGram_comp_adjoint_eq_sqrt]
+  apply Real.sqrt_le_sqrt
+  rw [inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram A K L h]
+  exact norm_boundaryFiberwiseMap_le _ _
+
+/-- Raw operator-norm bound for the tail finite-Gram correction. -/
+theorem c3TailFiniteGramCorrectionES_norm_le [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l)))
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Itail := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (l + 1)) hLocalTail
+    let Ifull := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l + 1)) hFull
+    ‖c3TailFiniteGramCorrectionES A K l ρ hρ
+      hLocalTail hLocalLeft hFull‖ ≤
+      Real.sqrt ‖Itail‖ * ‖groundSpaceGram A (l + 1) - Kinf‖ *
+        ‖tailVirtualMapES A K‖ * Real.sqrt ‖Ifull‖ := by
+  dsimp only
+  rw [c3TailFiniteGramCorrectionES_eq_factored A K l ρ hρ
+    hLocalTail hLocalLeft hFull]
+  let Ptail := (tailBoundaryMapES A K (l + 1)).comp
+    (ContinuousLinearMap.inverseGram (tailBoundaryMapES A K (l + 1))
+      (tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+        A K (l + 1) hLocalTail))
+  let E := boundaryFiberwiseMap (D := D) (Cfg d K)
+    (groundSpaceGram A (l + 1) - Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos)))
+  let J := tailVirtualMapES A K
+  let Pfull := (ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (K + l + 1)) hFull).comp
+      (groundSpaceMapES A (K + l + 1)).adjoint
+  change ‖Ptail.comp (E.comp (J.comp Pfull))‖ ≤ _
+  calc
+    ‖Ptail.comp (E.comp (J.comp Pfull))‖ ≤
+        ‖Ptail‖ * ‖E.comp (J.comp Pfull)‖ :=
+      ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖E‖ * ‖J.comp Pfull‖) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖E‖ * (‖J‖ * ‖Pfull‖)) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ = ‖Ptail‖ * ‖E‖ * ‖J‖ * ‖Pfull‖ := by ring
+    _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+        ‖groundSpaceGram A (l + 1) - Matrix.gramReshuffle
+          (fixedPointProj ρ (ne_of_gt hρ.trace_pos))‖ *
+        ‖tailVirtualMapES A K‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + l + 1)) hFull‖ := by
+      dsimp only [Ptail, E, J, Pfull]
+      rw [ContinuousLinearMap.norm_inverseGram_comp_adjoint_eq_sqrt]
+      gcongr
+      · exact norm_tailBoundaryMapES_comp_inverseGram_le_sqrt
+          A K (l + 1) hLocalTail
+      · exact norm_boundaryFiberwiseMap_le _ _
+    _ = _ := by ring
+
+/-- Raw operator-norm bound for the full inverse-Gram correction. -/
+theorem c3FullInverseGramCorrectionES_norm_le [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l)))
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Iinf := Ring.inverse Kinf
+    let Itail := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (l + 1)) hLocalTail
+    let Ifull := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l + 1)) hFull
+    ‖c3FullInverseGramCorrectionES A K l ρ hρ
+      hLocalTail hLocalLeft hFull‖ ≤
+      Real.sqrt ‖Itail‖ * ‖Kinf‖ * ‖tailVirtualMapES A K‖ * ‖Iinf‖ *
+        ‖groundSpaceGram A (K + l + 1) - Kinf‖ * Real.sqrt ‖Ifull‖ := by
+  dsimp only
+  rw [c3FullInverseGramCorrectionES_eq_factored A K l ρ hρ
+    hLocalTail hLocalLeft hFull]
+  let Ptail := (tailBoundaryMapES A K (l + 1)).comp
+    (ContinuousLinearMap.inverseGram (tailBoundaryMapES A K (l + 1))
+      (tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+        A K (l + 1) hLocalTail))
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Ktail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+  let J := tailVirtualMapES A K
+  let Iinf := Ring.inverse Kinf
+  let Efull := Kinf - groundSpaceGram A (K + l + 1)
+  let Pfull := (ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (K + l + 1)) hFull).comp
+      (groundSpaceMapES A (K + l + 1)).adjoint
+  change ‖Ptail.comp (Ktail.comp (J.comp (Iinf.comp
+    (Efull.comp Pfull))))‖ ≤ _
+  calc
+    _ ≤ ‖Ptail‖ * ‖Ktail.comp (J.comp (Iinf.comp
+          (Efull.comp Pfull)))‖ :=
+      ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * ‖J.comp (Iinf.comp
+          (Efull.comp Pfull))‖) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * (‖J‖ * ‖Iinf.comp
+          (Efull.comp Pfull)‖)) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * (‖J‖ * (‖Iinf‖ *
+          ‖Efull.comp Pfull‖))) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * (‖J‖ * (‖Iinf‖ *
+          (‖Efull‖ * ‖Pfull‖)))) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ = ‖Ptail‖ * ‖Ktail‖ * ‖J‖ * ‖Iinf‖ * ‖Efull‖ * ‖Pfull‖ := by ring
+    _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (l + 1)) hLocalTail‖ * ‖Kinf‖ *
+        ‖tailVirtualMapES A K‖ * ‖Ring.inverse Kinf‖ *
+        ‖groundSpaceGram A (K + l + 1) - Kinf‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + l + 1)) hFull‖ := by
+      dsimp only [Ptail, Ktail, J, Iinf, Efull, Pfull]
+      -- Reverse the Gram difference only inside its norm to match the stated error.
+      rw [norm_sub_rev, ContinuousLinearMap.norm_inverseGram_comp_adjoint_eq_sqrt]
+      gcongr
+      · exact norm_tailBoundaryMapES_comp_inverseGram_le_sqrt
+          A K (l + 1) hLocalTail
+      · exact norm_boundaryFiberwiseMap_le _ _
+    _ = _ := by ring
+
+/-- Raw operator-norm bound for the left finite-Gram correction. -/
+theorem c3LeftFiniteGramCorrectionES_norm_le [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l))) :
+    let Kinf := Matrix.gramReshuffle
+      (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+    let Iinf := Ring.inverse Kinf
+    let Itail := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (l + 1)) hLocalTail
+    let Ileft := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l)) hLocalLeft
+    ‖c3LeftFiniteGramCorrectionES A K l ρ hρ
+      hLocalTail hLocalLeft‖ ≤
+      Real.sqrt ‖Itail‖ * ‖Kinf‖ * ‖tailVirtualMapES A K‖ * ‖Iinf‖ *
+        ‖leftVirtualMapES A 1‖ * ‖groundSpaceGram A (K + l) - Kinf‖ *
+          Real.sqrt ‖Ileft‖ := by
+  dsimp only
+  rw [c3LeftFiniteGramCorrectionES_eq_factored A K l ρ hρ
+    hLocalTail hLocalLeft]
+  let Ptail := (tailBoundaryMapES A K (l + 1)).comp
+    (ContinuousLinearMap.inverseGram (tailBoundaryMapES A K (l + 1))
+      (tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+        A K (l + 1) hLocalTail))
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Ktail := boundaryFiberwiseMap (D := D) (Cfg d K) Kinf
+  let Jtail := tailVirtualMapES A K
+  let Iinf := Ring.inverse Kinf
+  let JleftAdj := (leftVirtualMapES A 1).adjoint
+  let Eleft := boundaryFiberwiseMap (D := D) (Cfg d 1)
+    (groundSpaceGram A (K + l) - Kinf)
+  let Pleft := (ContinuousLinearMap.inverseGram
+    (leftBoundaryMapES A (K + l) 1)
+      (leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+        A (K + l) 1 hLocalLeft)).comp
+          (leftBoundaryMapES A (K + l) 1).adjoint
+  change ‖Ptail.comp (Ktail.comp (Jtail.comp (Iinf.comp
+    (JleftAdj.comp (Eleft.comp Pleft)))))‖ ≤ _
+  calc
+    _ ≤ ‖Ptail‖ * ‖Ktail.comp (Jtail.comp (Iinf.comp
+          (JleftAdj.comp (Eleft.comp Pleft))))‖ :=
+      ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * ‖Jtail.comp (Iinf.comp
+          (JleftAdj.comp (Eleft.comp Pleft)))‖) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * (‖Jtail‖ * ‖Iinf.comp
+          (JleftAdj.comp (Eleft.comp Pleft))‖)) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * (‖Jtail‖ * (‖Iinf‖ *
+          ‖JleftAdj.comp (Eleft.comp Pleft)‖))) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * (‖Jtail‖ * (‖Iinf‖ *
+          (‖JleftAdj‖ * ‖Eleft.comp Pleft‖)))) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖Ktail‖ * (‖Jtail‖ * (‖Iinf‖ *
+          (‖JleftAdj‖ * (‖Eleft‖ * ‖Pleft‖))))) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ = ‖Ptail‖ * ‖Ktail‖ * ‖Jtail‖ * ‖Iinf‖ * ‖JleftAdj‖ *
+        ‖Eleft‖ * ‖Pleft‖ := by ring
+    _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (l + 1)) hLocalTail‖ * ‖Kinf‖ *
+        ‖tailVirtualMapES A K‖ * ‖Ring.inverse Kinf‖ *
+        ‖leftVirtualMapES A 1‖ * ‖groundSpaceGram A (K + l) - Kinf‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + l)) hLocalLeft‖ := by
+      dsimp only [Ptail, Ktail, Jtail, Iinf, JleftAdj, Eleft, Pleft]
+      rw [LinearIsometryEquiv.norm_map
+        (ContinuousLinearMap.adjoint (𝕜 := ℂ))]
+      gcongr
+      · exact norm_tailBoundaryMapES_comp_inverseGram_le_sqrt
+          A K (l + 1) hLocalTail
+      · exact norm_boundaryFiberwiseMap_le _ _
+      · exact norm_boundaryFiberwiseMap_le _ _
+      · exact norm_inverseGram_comp_leftBoundaryMapES_adjoint_le_sqrt
+          A (K + l) 1 hLocalLeft
+    _ = _ := by ring
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex
@@ -857,6 +857,8 @@ windows.
     \lean{ContinuousLinearMap.adjoint_comp_self_comp_inverseGram}
     \lean{ContinuousLinearMap.inverseGram_eq_inverse}
     \lean{ContinuousLinearMap.inverseGram_eq_ringInverse}
+    \lean{ContinuousLinearMap.norm_T_comp_inverseGram_eq_sqrt}
+    \lean{ContinuousLinearMap.norm_inverseGram_comp_adjoint_eq_sqrt}
     \leanok
     \uses{def:inverse_gram}
     Let $\mathbb K$ be a real or complex scalar field, let $E$ be a
@@ -871,7 +873,11 @@ windows.
       \label{eq:inverse_gram_right}
     \end{align}
     Consequently, $S_T$ is both the canonical inverse and the ring inverse of
-    $T^\dagger T$.
+    $T^\dagger T$.  The two pseudoinverse factors satisfy
+    \begin{align}
+      \lVert TS_T\rVert&=\sqrt{\lVert S_T\rVert},\\
+      \lVert S_TT^\dagger\rVert&=\sqrt{\lVert S_T\rVert}.
+    \end{align}
 \end{theorem}
 
 \begin{proof}
@@ -882,7 +888,9 @@ windows.
     give (\ref{eq:inverse_gram_left}) and
     (\ref{eq:inverse_gram_right}).  Together these equations characterize the
     canonical inverse of a continuous linear endomorphism, which agrees with
-    its inverse in the endomorphism ring.
+    its inverse in the endomorphism ring.  For the norm identities, use the
+    $C^*$-identity and the two inverse equations to compute the squares of
+    $\lVert TS_T\rVert$ and $\lVert S_TT^\dagger\rVert$.
 \end{proof}
 
 The next three results give quantitative inverse bounds for the nonidentity

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -929,19 +929,281 @@ norm estimate is derived here.
     the fixed norm of $J^{\mathrm{left}}_1$ into the constant.
 \end{proof}
 
+\begin{theorem}[Fiberwise subtraction]
+    \label{thm:boundary_fiberwise_map_sub}
+    \lean{MPSTensor.boundaryFiberwiseMap_sub}
+    \leanok
+    Let $S$ be a finite set and let $G,H\colon V\to V$ be continuous linear
+    endomorphisms of the virtual Euclidean space.  Then
+    \begin{align}
+      (G-H)^{\oplus S}&=G^{\oplus S}-H^{\oplus S}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Evaluate both sides on each fiber indexed by $s\in S$.
+\end{proof}
+
+\begin{theorem}[Invertibility of the finite ground-space Gram]
+    \label{thm:ground_space_gram_is_unit_of_injective}
+    \lean{MPSTensor.groundSpaceGram_isUnit_of_groundSpaceMapES_injective}
+    \leanok
+    \uses{def:ground_space_gram}
+    If the ground-space map $\Gamma_n^{\mathrm{ES}}$ is injective, then its Gram
+    endomorphism $\mathcal K_n=(\Gamma_n^{\mathrm{ES}})^\dagger
+    \Gamma_n^{\mathrm{ES}}$ is invertible.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:ground_space_gram}
+    The equality
+    $\langle X,\mathcal K_nX\rangle=\lVert\Gamma_n^{\mathrm{ES}}X\rVert^2$
+    shows that $\mathcal K_n$ is injective.  An injective endomorphism of a
+    finite-dimensional space is bijective and hence invertible.
+\end{proof}
+
+\begin{theorem}[Finite-to-limiting inverse resolvent identity]
+    \label{thm:inverse_gram_limiting_resolvent}
+    \lean{MPSTensor.inverseGram_sub_limitingInverse_eq_resolvent}
+    \leanok
+    \uses{def:ground_space_gram, def:inverse_gram, def:fixed_point_proj,
+        def:gram_reshuffle}
+    Assume $D\geq1$ and let $\rho\in\MN{D}$ be positive definite.  Set
+    $\mathcal K_\infty=\mathscr R(P_\rho)$ and
+    $S_\infty=\mathcal K_\infty^{-1}$.  If
+    $\Gamma_n^{\mathrm{ES}}$ is injective and
+    $S_n=\mathcal K_n^{-1}$, then
+    \begin{align}
+      S_n-S_\infty
+      &=S_\infty(\mathcal K_\infty-\mathcal K_n)S_n.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:ground_space_gram_is_unit_of_injective,
+        thm:fixed_point_gram_metric_is_unit, thm:inverse_gram_identities}
+    Both Gram endomorphisms are invertible.  Apply the identity
+    $A^{-1}-B^{-1}=B^{-1}(B-A)A^{-1}$ with
+    $A=\mathcal K_n$ and $B=\mathcal K_\infty$.
+\end{proof}
+
+\begin{theorem}[Left finite-Gram cancellation]
+    \label{thm:left_finite_gram_cancellation}
+    \lean{MPSTensor.leftFiniteGramCancellation_eq_groundSpaceMapES_adjoint}
+    \leanok
+    \uses{def:left_boundary_map, def:ground_space_gram, def:inverse_gram}
+    Suppose that $\Gamma_K^{\mathrm{ES}}$ is injective and write
+    $S_K=\mathcal K_K^{-1}$.  Then
+    \begin{align}
+      (J_L^{\mathrm{left}})^\dagger
+      \mathcal K_K^{\oplus\Omega_L}S_K^{\oplus\Omega_L}
+      (\Gamma_{K,L}^{\mathrm{left}})^\dagger
+      &=(\Gamma_{K+L}^{\mathrm{ES}})^\dagger.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:inverse_gram_identities,
+        thm:spectator_boundary_hilbert_factorization}
+    The direct-sum Gram and inverse Gram cancel fiberwise.  The remaining
+    composition is the adjoint of
+    $\Gamma_{K,L}^{\mathrm{left}}J_L^{\mathrm{left}}
+      =\Gamma_{K+L}^{\mathrm{ES}}$.
+\end{proof}
+
+\begin{theorem}[Tail spectator pseudoinverse bound]
+    \label{thm:tail_spectator_pseudoinverse_bound}
+    \lean{MPSTensor.norm_tailBoundaryMapES_comp_inverseGram_le_sqrt}
+    \leanok
+    \uses{def:tail_boundary_map, def:inverse_gram}
+    If $\Gamma_L^{\mathrm{ES}}$ is injective, then
+    \begin{align}
+      \left\lVert\Gamma_{K,L}^{\mathrm{tail}}
+        S_{\Gamma_{K,L}^{\mathrm{tail}}}\right\rVert
+      &\leq\sqrt{\lVert S_L\rVert}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:inverse_gram_identities,
+        thm:spectator_boundary_direct_sum_gram,
+        thm:boundary_fiberwise_map_norm}
+    The square-root pseudoinverse identity gives the left-hand side as the
+    square root of the norm of the tail boundary inverse Gram.  This inverse
+    Gram is the fiberwise lift of $S_L$, whose norm is at most
+    $\lVert S_L\rVert$.
+\end{proof}
+
+\begin{theorem}[Left spectator pseudoinverse bound]
+    \label{thm:left_spectator_pseudoinverse_bound}
+    \lean{MPSTensor.norm_inverseGram_comp_leftBoundaryMapES_adjoint_le_sqrt}
+    \leanok
+    \uses{def:left_boundary_map, def:inverse_gram}
+    If $\Gamma_K^{\mathrm{ES}}$ is injective, then
+    \begin{align}
+      \left\lVert S_{\Gamma_{K,L}^{\mathrm{left}}}
+        (\Gamma_{K,L}^{\mathrm{left}})^\dagger\right\rVert
+      &\leq\sqrt{\lVert S_K\rVert}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:inverse_gram_identities,
+        thm:spectator_boundary_direct_sum_gram,
+        thm:boundary_fiberwise_map_norm}
+    The adjoint-side square-root identity reduces the left-hand side to the
+    norm of the left boundary inverse Gram.  The direct-sum inverse-Gram formula
+    and the fiberwise norm estimate give the result.
+\end{proof}
+
+\begin{definition}[Finite-Gram corrections in the C3 residual]
+    \label{def:c3_correction_sandwiches}
+    \lean{MPSTensor.c3TailFiniteGramCorrectionES}
+    \lean{MPSTensor.c3FullInverseGramCorrectionES}
+    \lean{MPSTensor.c3LeftFiniteGramCorrectionES}
+    \leanok
+    \uses{def:ground_space_gram, def:inverse_gram, def:fixed_point_proj,
+        def:gram_reshuffle, def:tail_boundary_map, def:left_boundary_map,
+        thm:c3_projector_gram_error_telescope}
+    Assume $D\geq1$ and let $\rho\in\MN{D}$ be positive definite.  Set
+    $\mathcal K_\infty=\mathscr R(P_\rho)$ and
+    $S_\infty=\mathcal K_\infty^{-1}$.  Suppose that
+    $\Gamma_{l+1}^{\mathrm{ES}}$, $\Gamma_{K+l}^{\mathrm{ES}}$, and
+    $\Gamma_{K+l+1}^{\mathrm{ES}}$ are injective, and write
+    \begin{align}
+      T&=\Gamma^{\mathrm{tail}}_{K,l+1},\\
+      L&=\Gamma^{\mathrm{left}}_{K+l,1},\\
+      C&=\Gamma_{K+l+1}^{\mathrm{ES}}.
+    \end{align}
+    The three correction sandwiches in
+    Theorem~\ref{thm:c3_projector_gram_error_telescope} are
+    \begin{align}
+      Q_1={}&T S_{l+1}^{\oplus\Omega_K}
+        (\mathcal K_{l+1}-\mathcal K_\infty)^{\oplus\Omega_K}
+        J_K^{\mathrm{tail}}S_{K+l+1}(J_1^{\mathrm{left}})^\dagger
+        \mathcal K_{K+l}^{\oplus\Omega_1}
+        S_{K+l}^{\oplus\Omega_1}L^\dagger,\\
+      Q_2={}&T S_{l+1}^{\oplus\Omega_K}
+        \mathcal K_\infty^{\oplus\Omega_K}J_K^{\mathrm{tail}}
+        (S_{K+l+1}-S_\infty)(J_1^{\mathrm{left}})^\dagger
+        \mathcal K_{K+l}^{\oplus\Omega_1}
+        S_{K+l}^{\oplus\Omega_1}L^\dagger,\\
+      Q_3={}&T S_{l+1}^{\oplus\Omega_K}
+        \mathcal K_\infty^{\oplus\Omega_K}J_K^{\mathrm{tail}}S_\infty
+        (J_1^{\mathrm{left}})^\dagger
+        (\mathcal K_{K+l}-\mathcal K_\infty)^{\oplus\Omega_1}
+        S_{K+l}^{\oplus\Omega_1}L^\dagger.
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Exact factorizations of the C3 corrections]
+    \label{thm:c3_correction_factorizations}
+    \lean{MPSTensor.c3TailFiniteGramCorrectionES_eq_factored}
+    \lean{MPSTensor.c3FullInverseGramCorrectionES_eq_factored}
+    \lean{MPSTensor.c3LeftFiniteGramCorrectionES_eq_factored}
+    \leanok
+    \uses{def:c3_correction_sandwiches}
+    Under the hypotheses of
+    Definition~\ref{def:c3_correction_sandwiches}, the three corrections have
+    the exact factorizations
+    \begin{align}
+      Q_1={}&T S_{l+1}^{\oplus\Omega_K}
+        (\mathcal K_{l+1}-\mathcal K_\infty)^{\oplus\Omega_K}
+        J_K^{\mathrm{tail}}S_{K+l+1}C^\dagger,\\
+      Q_2={}&T S_{l+1}^{\oplus\Omega_K}
+        \mathcal K_\infty^{\oplus\Omega_K}J_K^{\mathrm{tail}}S_\infty
+        (\mathcal K_\infty-\mathcal K_{K+l+1})
+        S_{K+l+1}C^\dagger,\\
+      Q_3={}&T S_{l+1}^{\oplus\Omega_K}
+        \mathcal K_\infty^{\oplus\Omega_K}J_K^{\mathrm{tail}}S_\infty
+        (J_1^{\mathrm{left}})^\dagger
+        (\mathcal K_{K+l}-\mathcal K_\infty)^{\oplus\Omega_1}
+        S_{\Gamma_{K+l,1}^{\mathrm{left}}}L^\dagger.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:boundary_fiberwise_map_sub,
+        thm:inverse_gram_limiting_resolvent,
+        thm:left_finite_gram_cancellation,
+        thm:spectator_boundary_direct_sum_gram}
+    The direct-sum inverse-Gram formula identifies the initial factor with the
+    pseudoinverse factor of $T$.  Theorem~\ref{thm:left_finite_gram_cancellation}
+    replaces the final product in $Q_1$ and $Q_2$ by $C^\dagger$.
+    For $Q_2$, apply the resolvent identity
+    \begin{align}
+      S_{K+l+1}-S_\infty
+      &=S_\infty(\mathcal K_\infty-\mathcal K_{K+l+1})S_{K+l+1}.
+    \end{align}
+    Fiberwise subtraction gives the displayed Gram differences.  The
+    factorization of $Q_3$ leaves the left pseudoinverse adjacent to
+    $L^\dagger$.
+\end{proof}
+
+% These raw bounds are reconstructed from the inverse-Gram projector formulas.
+% They do not assert the rational coefficient in Nachtergaele's equation (6.1).
+\begin{theorem}[Raw norm bounds for the C3 corrections]
+    \label{thm:c3_correction_bounds}
+    \lean{MPSTensor.c3TailFiniteGramCorrectionES_norm_le}
+    \lean{MPSTensor.c3FullInverseGramCorrectionES_norm_le}
+    \lean{MPSTensor.c3LeftFiniteGramCorrectionES_norm_le}
+    \leanok
+    \uses{def:c3_correction_sandwiches}
+    Under the hypotheses of
+    Definition~\ref{def:c3_correction_sandwiches},
+    \begin{align}
+      \lVert Q_1\rVert
+      &\leq \sqrt{\lVert S_{l+1}\rVert}
+        \lVert\mathcal K_{l+1}-\mathcal K_\infty\rVert
+        \lVert J_K^{\mathrm{tail}}\rVert
+        \sqrt{\lVert S_{K+l+1}\rVert},\\
+      \lVert Q_2\rVert
+      &\leq \sqrt{\lVert S_{l+1}\rVert}
+        \lVert\mathcal K_\infty\rVert
+        \lVert J_K^{\mathrm{tail}}\rVert
+        \lVert S_\infty\rVert
+        \lVert\mathcal K_{K+l+1}-\mathcal K_\infty\rVert
+        \sqrt{\lVert S_{K+l+1}\rVert},\\
+      \lVert Q_3\rVert
+      &\leq \sqrt{\lVert S_{l+1}\rVert}
+        \lVert\mathcal K_\infty\rVert
+        \lVert J_K^{\mathrm{tail}}\rVert
+        \lVert S_\infty\rVert
+        \lVert J_1^{\mathrm{left}}\rVert
+        \lVert\mathcal K_{K+l}-\mathcal K_\infty\rVert
+        \sqrt{\lVert S_{K+l}\rVert}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:c3_correction_factorizations,
+        thm:tail_spectator_pseudoinverse_bound,
+        thm:left_spectator_pseudoinverse_bound,
+        thm:boundary_fiberwise_map_norm,
+        thm:inverse_gram_identities}
+    Apply submultiplicativity to the factorizations in
+    Theorem~\ref{thm:c3_correction_factorizations}.  The two spectator
+    pseudoinverse estimates control the exterior factors, and
+    Theorem~\ref{thm:boundary_fiberwise_map_norm} controls every fiberwise Gram
+    factor without a term depending on $|\Omega_K|$.  The square-root
+    pseudoinverse identity controls $S_{K+l+1}C^\dagger$.
+\end{proof}
+
+% The exact centered and correction estimates are formalized separately.  Their
+% uniform combination and comparison with the coefficient below remain open.
 \begin{lemma}[Uniform FNW overlapping-window contraction]
     \label{lem:fnw_overlapping_window_contraction}
     \notready
     \discussion{5923}
-    \uses{thm:primitive_tail_virtual_map_norm_uniform,
-        thm:c3_centered_overlap_factorization_geometric,
-        thm:fixed_point_gram_metric_exact,
-        thm:fixed_point_gram_metric_is_unit,
-        thm:primitive_ground_space_map_eventual_inverse_gram_bound,
-        thm:ground_space_es_projection_inverse_gram,
-        thm:tail_boundary_map_factorization, thm:left_boundary_map_factorization,
-        thm:tail_boundary_map_range_es_transport,
-        thm:left_boundary_map_range_es_transport}
+    \uses{def:primitive_mps, def:open_chain_ground_subspaces_es}
     Let $A$ be a primitive blocked tensor with a positive-definite fixed point,
     and let $P^{\mathrm{tail}}_{K,l+1}$ and
     $P^{\mathrm{left}}_{K+l}$ be the tail and left ground-space projectors in
@@ -957,17 +1219,34 @@ norm estimate is derived here.
         c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l}.
         \notag
     \end{align}
-    The displayed coefficient is the commutation bound of
-    \cite[Eq.~(6.1)]{Nachtergaele1996Spectral}, derived there from the
-    Fannes--Nachtergaele--Werner estimates.  The remaining task is to realize
-    that source estimate for the two physical boundary-map projectors above.
-    Theorem~\ref{thm:c3_centered_overlap_factorization_geometric} controls only
-    the centered term in the exact residual telescope.  The three correction
-    terms, their assembly into the full projector defect, the denominator, and
-    the coefficient in equation~(6.1) remain open.  The final argument must use
-    the exact inverse-Gram range-projector formulas in the limiting fixed-point
-    metric before applying transfer mixing.
+    This is the commutation bound of
+    \cite[Eq.~(6.1)]{Nachtergaele1996Spectral}, obtained there from the
+    Fannes--Nachtergaele--Werner estimates.
 \end{lemma}
+
+\begin{proof}
+    \uses{thm:c3_projector_gram_error_telescope,
+        thm:primitive_tail_virtual_map_norm_uniform,
+        thm:c3_centered_overlap_factorization_geometric,
+        thm:c3_correction_bounds,
+        thm:fixed_point_gram_metric_exact,
+        thm:fixed_point_gram_metric_is_unit,
+        thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
+        thm:geometric_smallness_at_c3_lengths,
+        thm:ground_space_es_projection_inverse_gram,
+        thm:tail_boundary_map_factorization, thm:left_boundary_map_factorization,
+        thm:tail_boundary_map_range_es_transport,
+        thm:left_boundary_map_range_es_transport}
+    Insert the limiting-metric telescope into the exact inverse-Gram formulas
+    for the three physical projectors.  Bound the centered summand by
+    Theorem~\ref{thm:c3_centered_overlap_factorization_geometric} and the three
+    finite-Gram summands by Theorem~\ref{thm:c3_correction_bounds}.  The
+    geometric inverse-Gram estimates and the common smallness condition control
+    every inverse at the lengths $l+1$, $K+l$, and $K+l+1$.  The boundary-map
+    factorizations and range identities identify the resulting operator with
+    the overlapping ground-space projector defect.  The FNW finite-volume
+    comparison then gives the stated rational expression.
+\end{proof}
 
 \begin{lemma}[Uniform open-chain projector-defect threshold]
     \label{lem:nachtergaele_c3_blocked_length}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -876,30 +876,98 @@ and generic prerequisites now include:
     \leanid{MPSTensor.c3_virtualResidual_eq_centered_sub_gramErrors} into its
     limiting-center residual and three corrections containing, in order,
     \begin{align}
-      \mathcal K_{l+1}-\mathcal K_\infty,\qquad
-      S_{K+l+1}-S_\infty,\qquad
+      \mathcal K_{l+1}-\mathcal K_\infty,\\
+      S_{K+l+1}-S_\infty,\\
       \mathcal K_{K+l}-\mathcal K_\infty.
     \end{align}
-    The spectator occurrences of the first and third differences are
-    fiberwise, so their norms are uniform in the spectator type.  The theorem
+    The theorem
     \leanid{MPSTensor.c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors}
-    substitutes this telescope into the full tail-after-left projector
-    factorization.  The inverse convergence theorem controls the middle
-    correction eventually.
+    places this identity between the two local pseudoinverse factors in the
+    exact tail-after-left physical projector residual.
 
     Under the explicit hypotheses that the virtual dimension is nonzero and
     \(\rho\) is positive definite,
     \leanid{MPSTensor.inner_limitingMixedGramIntertwining} proves the limiting
     intertwining identity.  Under the same hypotheses,
     \leanid{MPSTensor.inner_c3_centeredVirtualResidual_eq_gramError}
-    unconditionally identifies the centered residual pairing with the
-    length-\(l\) Gram error.  The zeroth-order cancellation uses the explicit
-    limiting metric, its inverse, and the virtual-map adjoints; no transfer
-    fixed-point equation is needed.  These identities are reconstructed
-    algebra.  The remaining norm argument must assemble all three correction
-    terms with the centered bound.  The resulting full projector defect, the
-    denominator $1-c\lambda^l$, and the coefficient in equation~(6.1) remain
-    open.
+    identifies the centered residual pairing with the length-\(l\) Gram
+    error.  The cancellation uses the nonidentity limiting metric, its inverse,
+    and the virtual-map adjoints; no transfer fixed-point equation is needed.
+
+  \item The three physical correction sandwiches are
+    \leanid{MPSTensor.c3TailFiniteGramCorrectionES},
+    \leanid{MPSTensor.c3FullInverseGramCorrectionES}, and
+    \leanid{MPSTensor.c3LeftFiniteGramCorrectionES}.  Write
+    \begin{align}
+      T&=\Gamma^{\mathrm{tail}}_{K,l+1},\\
+      L&=\Gamma^{\mathrm{left}}_{K+l,1},\\
+      C&=\Gamma_{K+l+1}^{\mathrm{ES}}.
+    \end{align}
+    The exact factorizations
+    \leanid{MPSTensor.c3TailFiniteGramCorrectionES_eq_factored},
+    \leanid{MPSTensor.c3FullInverseGramCorrectionES_eq_factored}, and
+    \leanid{MPSTensor.c3LeftFiniteGramCorrectionES_eq_factored} give
+    \begin{align}
+      Q_1={}&T S_{l+1}^{\oplus\Omega_K}
+        (\mathcal K_{l+1}-\mathcal K_\infty)^{\oplus\Omega_K}
+        J_K^{\mathrm{tail}}S_{K+l+1}C^\dagger,\\
+      Q_2={}&T S_{l+1}^{\oplus\Omega_K}
+        \mathcal K_\infty^{\oplus\Omega_K}J_K^{\mathrm{tail}}S_\infty
+        (\mathcal K_\infty-\mathcal K_{K+l+1})
+        S_{K+l+1}C^\dagger,\\
+      Q_3={}&T S_{l+1}^{\oplus\Omega_K}
+        \mathcal K_\infty^{\oplus\Omega_K}J_K^{\mathrm{tail}}S_\infty
+        (J_1^{\mathrm{left}})^\dagger
+        (\mathcal K_{K+l}-\mathcal K_\infty)^{\oplus\Omega_1}
+        S_{K+l}^{\oplus\Omega_1}L^\dagger.
+    \end{align}
+    The middle equality uses the right-oriented identity
+    \leanid{MPSTensor.inverseGram_sub_limitingInverse_eq_resolvent},
+    \begin{align}
+      S_{K+l+1}-S_\infty
+      &=S_\infty(\mathcal K_\infty-\mathcal K_{K+l+1})S_{K+l+1}.
+    \end{align}
+    The fiberwise subtraction identity is
+    \leanid{MPSTensor.boundaryFiberwiseMap_sub}, and invertibility of a finite
+    Gram follows from injectivity by
+    \leanid{MPSTensor.groundSpaceGram_isUnit_of_groundSpaceMapES_injective}.
+
+    The spectator pseudoinverse estimates
+    \leanid{MPSTensor.norm_tailBoundaryMapES_comp_inverseGram_le_sqrt} and
+    \leanid{MPSTensor.norm_inverseGram_comp_leftBoundaryMapES_adjoint_le_sqrt},
+    together with the uniform fiberwise norm bound, yield
+    \leanid{MPSTensor.c3TailFiniteGramCorrectionES_norm_le},
+    \leanid{MPSTensor.c3FullInverseGramCorrectionES_norm_le}, and
+    \leanid{MPSTensor.c3LeftFiniteGramCorrectionES_norm_le}:
+    \begin{align}
+      \lVert Q_1\rVert
+      &\leq \sqrt{\lVert S_{l+1}\rVert}
+        \lVert\mathcal K_{l+1}-\mathcal K_\infty\rVert
+        \lVert J_K^{\mathrm{tail}}\rVert
+        \sqrt{\lVert S_{K+l+1}\rVert},\\
+      \lVert Q_2\rVert
+      &\leq \sqrt{\lVert S_{l+1}\rVert}
+        \lVert\mathcal K_\infty\rVert
+        \lVert J_K^{\mathrm{tail}}\rVert
+        \lVert S_\infty\rVert
+        \lVert\mathcal K_{K+l+1}-\mathcal K_\infty\rVert
+        \sqrt{\lVert S_{K+l+1}\rVert},\\
+      \lVert Q_3\rVert
+      &\leq \sqrt{\lVert S_{l+1}\rVert}
+        \lVert\mathcal K_\infty\rVert
+        \lVert J_K^{\mathrm{tail}}\rVert
+        \lVert S_\infty\rVert
+        \lVert J_1^{\mathrm{left}}\rVert
+        \lVert\mathcal K_{K+l}-\mathcal K_\infty\rVert
+        \sqrt{\lVert S_{K+l}\rVert}.
+    \end{align}
+    No spectator-cardinality factor appears.  These factorizations and bounds
+    are exact consequences of the inverse-Gram formulas for the physical range
+    projectors.  FNW and Nachtergaele state overlapping-projector estimates,
+    while Cirac--Perez-Garcia--Schuch--Verstraete state the martingale
+    anticommutator criterion and its principal-angle interpretation.  None of
+    those sources gives the three displayed correction formulas.  Their uniform
+    combination and comparison with Nachtergaele's equation~(6.1) remain open.
 \end{itemize}
 Fix \(K,L_0\in\mathbb N\) and let
 \(\mathcal H_{K+L_0+1}\) be the \((K+L_0+1)\)-site Euclidean space
@@ -964,9 +1032,10 @@ Furthermore,
 \begin{align}
   \mathcal K_n^{-1}&\longrightarrow\mathscr R(P_\rho)^{-1}.
 \end{align}
-These results are quantitative inverse infrastructure.  They do not prove the
-full overlapping-window projector contraction or Nachtergaele's
-Equation~(6.1); that physical projector comparison remains open.
+Together with the three raw correction bounds above, these inverse estimates
+control the centered term and all three finite-Gram corrections without
+spectator-cardinality loss.  Their uniform combination and the comparison with
+Nachtergaele's equation~(6.1) remain open.
 
 In particular, the development does not prove the overlapping-window FNW
 contraction

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,18 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### left finite-Gram cancellation in spectator coordinates — promoted
+- **Pattern:** cancel the fiberwise finite Gram against its inverse Gram, then use
+  the left-boundary common-map identity to recover the adjoint of the full
+  ground-space map.
+- **Seen:** duplicate 28-line arguments in the tail and full inverse-Gram C3
+  correction factorizations before promotion (2026-08-10).
+- **Abstraction:** `MPSTensor.leftFiniteGramCancellation_eq_groundSpaceMapES_adjoint`
+  in `TNLean/MPS/ParentHamiltonian/C3CorrectionBounds.lean`.
+- **Notes:** both factorizations retain their statements and tail-after-left
+  orientation; the shared theorem records only the exact finite-dimensional
+  cancellation and makes no FNW or Nachtergaele numerical claim.
+
 ### single-Kraus Kronecker and isometric multiplication identities — promoted
 - **Pattern:** unfold `singleKrausMap`, reassociate matrix products, and use
   Kronecker multiplication or the identity `Vᴴ * V = 1`.

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -70,7 +70,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1587, 1629 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1595, 1637 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- factor the three finite-Gram correction sandwiches in the exact tail-after-left C3 projector residual;
- prove the right-oriented resolvent identity
  \(S_n-S_\infty=S_\infty(\mathcal K_\infty-\mathcal K_n)S_n\), keeping the finite inverse adjacent to the boundary-map adjoint;
- bound all three corrections with square-root pseudoinverse factors and fiberwise norm control, with no spectator-cardinality factor;
- extract the repeated left finite-Gram cancellation into a shared theorem and record the refactor;
- synchronize Chapter 13 and the martingale paper-gap note with the exact declarations and remaining FNW/Nachtergaele comparison.

## Source boundary

The limiting Gram remains the generally nonidentity operator
\(\mathcal K_\infty=\operatorname{gramReshuffle}(P_\rho)\), and `ρ.PosDef` stays explicit. The three correction formulas are exact consequences of TNLean's inverse-Gram projector expressions. They are not quoted FNW, Nachtergaele, or CPGSV21 formulas, and this PR does not claim Nachtergaele's equation (6.1) coefficient or the full common-ambient projector contraction.

## Validation

- `lake build` (10047 jobs)
- `lake exe lint_style`
- `python3 scripts/generate_import_aggregators.py --root . --check` (52 aggregators, 1336 production modules)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7103/7103 theorem-like entries synchronized)
- `cd blueprint && leanblueprint checkdecls`
- two `lualatex` passes with `TEXINPUTS="../../tex/tenkz//:"`; zero undefined cross-references
- `git diff --check`
- no `sorry`, `axiom`, or `unsafe` in the changed Lean module or aggregator
- independent Lean and blueprint reviews approved the exact rebased head after their findings were addressed

Closes #5993
Advances #5923

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs on the spectral-gap martingale path; mistakes in Gram/resolvent orientation or norm bounds could block later FNW comparisons, though the PR does not claim the full physical contraction.
> 
> **Overview**
> Adds **`C3CorrectionBounds.lean`** and wires it into the parent-Hamiltonian aggregator, formalizing the three finite-Gram correction terms from the exact tail-after-left C3 projector-residual telescope.
> 
> The new module defines **`c3TailFiniteGramCorrectionES`**, **`c3FullInverseGramCorrectionES`**, and **`c3LeftFiniteGramCorrectionES`**, proves exact factorizations (via a right-oriented resolvent identity and shared **`leftFiniteGramCancellation_eq_groundSpaceMapES_adjoint`**), and gives raw operator-norm bounds with square-root pseudoinverse factors and fiberwise Gram control—**no spectator-cardinality factor**.
> 
> Blueprint Chapter 13 and the martingale paper-gap note are synced to these Lean declarations; inverse-Gram pseudoinverse norm identities are documented. The uniform FNW overlapping-window / Nachtergaele **(6.1)** projector contraction remains **open** (`\notready`); this PR supplies the correction-term algebra and bounds only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6325303115e4c8da080189f672064ff11ab3f78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->