### PR TITLE
feat(MPS/MPU): cancel dressed source-v Gram equation

### DIFF
--- a/TNLean/Algebra/MatrixUnitaryBetween.lean
+++ b/TNLean/Algebra/MatrixUnitaryBetween.lean
@@ -42,6 +42,8 @@ lines 534--605.
   coordinate-change and composition compatibility.
 * `Matrix.IsUnitaryBetween.of_mul_left` and `Matrix.IsUnitaryBetween.of_mul_right`
   cancel unitary-between factors from a unitary-between product.
+* `Matrix.conjTranspose_mul_mul_eq_conjTranspose_mul_iff_of_mul_eq_one` removes
+  a Gram dressing whose matrix has a right inverse.
 * `Matrix.isUnitaryBetween_iff_mem_unitaryGroup` identifies the square case with
   Mathlib's unitary group.
 -/
@@ -63,6 +65,29 @@ isometry and a coisometry. -/
 def IsUnitaryBetween [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
     (A : Matrix m n ℂ) : Prop :=
   A.IsIsometry ∧ A.IsCoisometry
+
+/-- If $YZ=1$, then the dressed Gram equation
+$Y^\dagger GY=Y^\dagger Y$ is equivalent to $G=1$.
+
+This is the right-inverse cancellation used in arXiv:1703.09188, equation
+`vUnitary`, lines 583--588. -/
+theorem conjTranspose_mul_mul_eq_conjTranspose_mul_iff_of_mul_eq_one
+    {a b : Type*} [Fintype a] [Fintype b] [DecidableEq a]
+    (Y : Matrix a b ℂ) (Z : Matrix b a ℂ) (G : Matrix a a ℂ)
+    (hYZ : Y * Z = 1) :
+    Yᴴ * G * Y = Yᴴ * Y ↔ G = 1 := by
+  have hZY : Zᴴ * Yᴴ = 1 := by
+    rw [← Matrix.conjTranspose_mul, hYZ, Matrix.conjTranspose_one]
+  constructor
+  · intro h
+    calc
+      G = (Zᴴ * Yᴴ) * G * (Y * Z) := by rw [hZY, hYZ, Matrix.one_mul, Matrix.mul_one]
+      _ = Zᴴ * (Yᴴ * G * Y) * Z := by simp only [Matrix.mul_assoc]
+      _ = Zᴴ * (Yᴴ * Y) * Z := by rw [h]
+      _ = (Zᴴ * Yᴴ) * (Y * Z) := by simp only [Matrix.mul_assoc]
+      _ = 1 := by rw [hZY, hYZ, Matrix.one_mul]
+  · rintro rfl
+    simp
 
 namespace IsIsometry
 

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -27,6 +27,7 @@ import TNLean.MPS.MPU.SourceUOpenTail
 import TNLean.MPS.MPU.SourceURangeTransport
 import TNLean.MPS.MPU.SourceUSecondCutMetric
 import TNLean.MPS.MPU.SourceUV
+import TNLean.MPS.MPU.SourceVIsometry
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.SuppliedWitnessReblocking
 import TNLean.MPS.MPU.ThreeFormSpan

--- a/TNLean/MPS/MPU/SourceVIsometry.lean
+++ b/TNLean/MPS/MPU/SourceVIsometry.lean
@@ -78,8 +78,7 @@ theorem sourceYTensor_mul_sourceZTensor
     sourceY₁_mul_sourceZ₁, sourceY₂_mul_sourceZ₂, Matrix.one_kronecker_one]
 
 /-- Regroup the two source-cut output indices into the two physical indices
-and the canonically flattened pair of virtual indices.  No nested product type
-is identified definitionally.
+and the canonically flattened pair of virtual indices.
 
 Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
 def sourceVRegroupEquiv :

--- a/TNLean/MPS/MPU/SourceVIsometry.lean
+++ b/TNLean/MPS/MPU/SourceVIsometry.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceUV
+
+/-!
+# The dressed source-v Gram equation
+
+This file formalizes the algebraic cancellation surrounding the source tensor
+$v$ in arXiv:1703.09188, equation `vUnitary` (lines 577--600).  The right source
+factors are tensorized in the exact dotted/solid leg order, and their explicit
+right inverse removes the dressing from
+$Y^\dagger(v^\dagger v)Y=Y^\dagger Y$.
+
+The separate identification of this dressed equation with the supplied
+fixed-witness `simple2` contraction is not asserted here.
+-/
+
+open scoped Matrix BigOperators Kronecker ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ} (U : MPOTensor d D)
+
+/-- The tensor product $Y_1\otimes Y_2$ in the source-bond order $(r,\ell)$.
+
+Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
+noncomputable def sourceYTensor
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    Matrix (Fin r[U] × Fin ℓ[U])
+      ((Fin d × Fin D) × (Fin d × Fin D)) ℂ :=
+  sourceY₁ U ρ hρ ⊗ₖ sourceY₂ U
+
+/-- The tensor product $Z_1\otimes Z_2$, the explicit right inverse of
+`sourceYTensor`.
+
+Source: arXiv:1703.09188, equations `YZ=1` and `vUnitary`, lines 495--506 and
+577--588. -/
+noncomputable def sourceZTensor
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    Matrix ((Fin d × Fin D) × (Fin d × Fin D))
+      (Fin r[U] × Fin ℓ[U]) ℂ :=
+  sourceZ₁ U ρ hρ ⊗ₖ sourceZ₂ U
+
+/-- Entry formula for $Y_1\otimes Y_2$ in dotted/solid source-bond order.
+
+Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
+@[simp] theorem sourceYTensor_apply
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (r : Fin r[U]) (l : Fin ℓ[U])
+    (x₁ x₂ : Fin d × Fin D) :
+    sourceYTensor U ρ hρ (r, l) (x₁, x₂) =
+      sourceY₁ U ρ hρ r x₁ * sourceY₂ U l x₂ := rfl
+
+/-- Entry formula for $Z_1\otimes Z_2$ in dotted/solid source-bond order.
+
+Source: arXiv:1703.09188, equations `YZ=1` and `vUnitary`, lines 495--506 and
+577--588. -/
+@[simp] theorem sourceZTensor_apply
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (x₁ x₂ : Fin d × Fin D) (r : Fin r[U]) (l : Fin ℓ[U]) :
+    sourceZTensor U ρ hρ (x₁, x₂) (r, l) =
+      sourceZ₁ U ρ hρ x₁ r * sourceZ₂ U x₂ l := rfl
+
+/-- The two source right inverses tensorize to
+$(Y_1\otimes Y_2)(Z_1\otimes Z_2)=1$.
+
+Source: arXiv:1703.09188, equations `YZ=1` and `vUnitary`, lines 495--506 and
+577--588. -/
+theorem sourceYTensor_mul_sourceZTensor
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    sourceYTensor U ρ hρ * sourceZTensor U ρ hρ = 1 := by
+  rw [sourceYTensor, sourceZTensor, ← Matrix.mul_kronecker_mul,
+    sourceY₁_mul_sourceZ₁, sourceY₂_mul_sourceZ₂, Matrix.one_kronecker_one]
+
+/-- Regroup the two source-cut output indices into the two physical indices
+and the canonically flattened pair of virtual indices.  No nested product type
+is identified definitionally.
+
+Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
+def sourceVRegroupEquiv :
+    ((Fin d × Fin D) × (Fin d × Fin D)) ≃
+      ((Fin d × Fin d) × Fin (D * D)) where
+  toFun x := ((x.1.1, x.2.1), finProdFinEquiv (x.1.2, x.2.2))
+  invFun x := ((x.1.1, (finProdFinEquiv.symm x.2).1),
+    (x.1.2, (finProdFinEquiv.symm x.2).2))
+  left_inv x := by
+    rcases x with ⟨⟨i, a⟩, ⟨j, b⟩⟩
+    simp
+  right_inv x := by
+    rcases x with ⟨⟨i, j⟩, a⟩
+    change ((i, j), finProdFinEquiv (finProdFinEquiv.symm a)) = ((i, j), a)
+    rw [finProdFinEquiv.apply_symm_apply]
+
+@[simp] theorem sourceVRegroupEquiv_apply
+    (x₁ x₂ : Fin d × Fin D) :
+    sourceVRegroupEquiv (d := d) (D := D) (x₁, x₂) =
+      ((x₁.1, x₂.1), finProdFinEquiv (x₁.2, x₂.2)) := rfl
+
+@[simp] theorem sourceVRegroupEquiv_symm_apply
+    (p : Fin d × Fin d) (a : Fin (D * D)) :
+    (sourceVRegroupEquiv (d := d) (D := D)).symm (p, a) =
+      ((p.1, (finProdFinEquiv.symm a).1),
+        (p.2, (finProdFinEquiv.symm a).2)) := rfl
+
+/-- The equation $Y^\dagger(v^\dagger v)Y=Y^\dagger Y$, where
+$Y=Y_1\otimes Y_2$ has source-bond order $(r,\ell)$.
+
+Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
+def SourceVDressedGram
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) : Prop :=
+  let Y := sourceYTensor U ρ hρ
+  Yᴴ * ((sourceV U ρ hρ)ᴴ * sourceV U ρ hρ) * Y = Yᴴ * Y
+
+/-- Entrywise characterization of the dressed source-v Gram equation after the
+explicit physical/virtual regrouping.  This is the finite-sum orientation to
+which the supplied `simple2` contraction must be compared.
+
+Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
+theorem sourceVDressedGram_iff_regrouped_entries
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    SourceVDressedGram U ρ hρ ↔
+      ∀ p q : Fin d × Fin d, ∀ a b : Fin (D * D),
+        let x := (sourceVRegroupEquiv (d := d) (D := D)).symm (p, a)
+        let y := (sourceVRegroupEquiv (d := d) (D := D)).symm (q, b)
+        ∑ t,
+            (∑ s, star (sourceYTensor U ρ hρ s x) *
+              ∑ z, star (sourceV U ρ hρ z s) * sourceV U ρ hρ z t) *
+              sourceYTensor U ρ hρ t y =
+          ∑ t, star (sourceYTensor U ρ hρ t x) * sourceYTensor U ρ hρ t y := by
+  constructor
+  · intro h p q a b
+    have hentry := congrArg (fun M ↦ M
+      ((sourceVRegroupEquiv (d := d) (D := D)).symm (p, a))
+      ((sourceVRegroupEquiv (d := d) (D := D)).symm (q, b))) h
+    simpa only [SourceVDressedGram, Matrix.mul_apply, Matrix.conjTranspose_apply]
+      using hentry
+  · intro h
+    unfold SourceVDressedGram
+    ext x y
+    let px := sourceVRegroupEquiv (d := d) (D := D) x
+    let py := sourceVRegroupEquiv (d := d) (D := D) y
+    have hentry := h px.1 py.1 px.2 py.2
+    have hx : (sourceVRegroupEquiv (d := d) (D := D)).symm (px.1, px.2) = x := by
+      change (sourceVRegroupEquiv (d := d) (D := D)).symm px = x
+      exact Equiv.symm_apply_apply _ x
+    have hy : (sourceVRegroupEquiv (d := d) (D := D)).symm (py.1, py.2) = y := by
+      change (sourceVRegroupEquiv (d := d) (D := D)).symm py = y
+      exact Equiv.symm_apply_apply _ y
+    rw [hx, hy] at hentry
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply] using hentry
+
+/-- Removing the $Y_1\otimes Y_2$ dressing with $Z_1\otimes Z_2$ gives
+$v^\dagger v=1$.
+
+Source: arXiv:1703.09188, equation `vUnitary`, lines 583--588. -/
+theorem sourceVDressedGram_iff_isIsometry
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef) :
+    SourceVDressedGram U ρ hρ ↔ (sourceV U ρ hρ).IsIsometry := by
+  apply Matrix.conjTranspose_mul_mul_eq_conjTranspose_mul_iff_of_mul_eq_one
+  exact sourceYTensor_mul_sourceZTensor U ρ hρ
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceVIsometry.lean
+++ b/TNLean/MPS/MPU/SourceVIsometry.lean
@@ -95,11 +95,19 @@ def sourceVRegroupEquiv :
     change ((i, j), finProdFinEquiv (finProdFinEquiv.symm a)) = ((i, j), a)
     rw [finProdFinEquiv.apply_symm_apply]
 
+/-- The regrouping equivalence sends two source-cut indices to their physical pair and
+flattened virtual pair.
+
+Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
 @[simp] theorem sourceVRegroupEquiv_apply
     (x₁ x₂ : Fin d × Fin D) :
     sourceVRegroupEquiv (d := d) (D := D) (x₁, x₂) =
       ((x₁.1, x₂.1), finProdFinEquiv (x₁.2, x₂.2)) := rfl
 
+/-- The inverse regrouping equivalence separates a physical pair and flattened virtual pair
+into two source-cut indices.
+
+Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
 @[simp] theorem sourceVRegroupEquiv_symm_apply
     (p : Fin d × Fin d) (a : Fin (D * D)) :
     (sourceVRegroupEquiv (d := d) (D := D)).symm (p, a) =

--- a/TNLean/MPS/MPU/SourceVIsometry.lean
+++ b/TNLean/MPS/MPU/SourceVIsometry.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixUnitaryBetween
 import TNLean.MPS.MPU.SourceUV
 
 /-!

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2211,6 +2211,123 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     $Y_2Y_2^\dagger=\Id$.
 \end{remark}
 
+\begin{definition}[Tensorized source dressing]
+    \label{def:mpu_source_v_dressing}
+    \lean{MPOTensor.sourceYTensor,MPOTensor.sourceZTensor,
+        MPOTensor.sourceYTensor_apply,MPOTensor.sourceZTensor_apply,
+        MPOTensor.sourceVRegroupEquiv,
+        MPOTensor.sourceVRegroupEquiv_apply,
+        MPOTensor.sourceVRegroupEquiv_symm_apply,
+        MPOTensor.SourceVDressedGram}
+    \leanok
+    \uses{def:mpu_weighted_source_factors,def:mpu_source_uv}
+    Put
+    \begin{align}
+        Y&=Y_1\otimes Y_2,
+        &Z&=Z_1\otimes Z_2,
+    \end{align}
+    with source-bond order $r\times\ell$. Thus $Y$ maps
+    $(\C^d\otimes\C^D)^{\otimes 2}$ to
+    $\C^r\otimes\C^\ell$, and $Z$ maps in the opposite direction. The
+    regrouping of the open indices is
+    \begin{align}
+        R\bigl((i,a),(j,b)\bigr)
+          &=\bigl((i,j),\operatorname{flat}(a,b)\bigr),
+    \end{align}
+    where $\operatorname{flat}:\Fin D\times\Fin D\simeq\Fin(D^2)$ is the
+    canonical product enumeration. The dressed source-$v$ Gram equation is
+    \begin{align}
+        Y^\dagger(v^\dagger v)Y&=Y^\dagger Y.
+    \end{align}
+    These are the tensorized factors surrounding $v^\dagger v$ in
+    \cite[Section~III, equation \texttt{vUnitary}]{Cirac2017MPU}.
+\end{definition}
+
+\begin{theorem}[Tensorized source right inverse]
+    \label{thm:mpu_source_yz_tensor}
+    \lean{MPOTensor.sourceYTensor_mul_sourceZTensor}
+    \leanok
+    \uses{def:mpu_source_v_dressing}
+    The tensorized source factors satisfy
+    \begin{align}
+        YZ&=\Id_{r\ell}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpu_source_factor_right_inverses}
+    Multiplicativity of the Kronecker product gives
+    \begin{align}
+        YZ&=(Y_1Z_1)\otimes(Y_2Z_2)
+            =\Id_r\otimes\Id_\ell=\Id_{r\ell}.
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Regrouped entries of the dressed Gram equation]
+    \label{thm:mpu_source_v_dressed_entries}
+    \lean{MPOTensor.sourceVDressedGram_iff_regrouped_entries}
+    \leanok
+    \uses{def:mpu_source_v_dressing}
+    For $x=R^{-1}(p,a)$ and $y=R^{-1}(q,b)$, the dressed Gram equation is
+    equivalent to
+    \begin{align}
+        \sum_t\left(\sum_s\overline{Y_{s,x}}
+            \sum_z\overline{v_{z,s}}v_{z,t}\right)Y_{t,y}
+          &=\sum_t\overline{Y_{t,x}}Y_{t,y}.
+    \end{align}
+    Here $p,q\in\Fin d\times\Fin d$, $a,b\in\Fin(D^2)$, the indices $s,t$
+    range over $\Fin r\times\Fin\ell$, and $z$ ranges over
+    $\Fin d\times\Fin d$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpu_source_v_dressing}
+    Evaluate both sides of $Y^\dagger(v^\dagger v)Y=Y^\dagger Y$ at
+    $(x,y)$ and expand the three matrix products. Conversely, apply the
+    displayed equality after regrouping each pair of open source-cut indices
+    by $R$.
+\end{proof}
+
+\begin{theorem}[Right-inverse cancellation of a dressed Gram equation]
+    \label{thm:mpu_dressed_gram_cancel}
+    \lean{Matrix.conjTranspose_mul_mul_eq_conjTranspose_mul_iff_of_mul_eq_one}
+    \leanok
+    If $Y$ has a right inverse $Z$, so that $YZ=\Id$, then for every square
+    matrix $G$ on the row space of $Y$,
+    \begin{align}
+        Y^\dagger GY=Y^\dagger Y
+        &\quad\Longleftrightarrow\quad G=\Id.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Conjugate the first equality by $Z^\dagger$ on the left and $Z$ on the
+    right. Since $Z^\dagger Y^\dagger=(YZ)^\dagger=\Id$, both outer factors
+    cancel. The reverse implication follows by substituting $G=\Id$.
+\end{proof}
+
+\begin{theorem}[Cancellation of the source-$v$ dressing]
+    \label{thm:mpu_source_v_dressed_gram_cancel}
+    \lean{MPOTensor.sourceVDressedGram_iff_isIsometry}
+    \leanok
+    \uses{def:mpu_source_v_dressing,def:mpu_source_uv}
+    For every positive definite source weight $\rho$,
+    \begin{align}
+        Y^\dagger(v^\dagger v)Y=Y^\dagger Y
+        &\quad\Longleftrightarrow\quad v^\dagger v=\Id_{r\ell}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpu_source_yz_tensor,thm:mpu_dressed_gram_cancel}
+    Apply right-inverse cancellation with $G=v^\dagger v$ and
+    $Z=Z_1\otimes Z_2$.
+\end{proof}
+
 \begin{theorem}[Right-rank bound]
     \label{thm:mpu_right_rank_bound}
     \lean{MPOTensor.rightRank_bound}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2268,8 +2268,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_source_v_dressed_entries}
     \lean{MPOTensor.sourceVDressedGram_iff_regrouped_entries}
     \leanok
-    \uses{def:mpu_source_v_dressing}
-    For $x=R^{-1}(p,a)$ and $y=R^{-1}(q,b)$, the dressed Gram equation is
+    \uses{def:mpu_source_v_dressing,def:mpu_source_uv}
+    For every positive definite source weight $\rho$, and for
+    $x=R^{-1}(p,a)$ and $y=R^{-1}(q,b)$, the dressed Gram equation is
     equivalent to
     \begin{align}
         \sum_t\left(\sum_s\overline{Y_{s,x}}


### PR DESCRIPTION
## Summary

- define the tensorized source dressing $Y=Y_1\otimes Y_2$ and its explicit right inverse $Z=Z_1\otimes Z_2$
- expose the audited physical/virtual regrouping with source-bond order $r\times\ell$
- package the dressed source-$v$ Gram equation and its exact regrouped finite-sum characterization
- add a generic right-inverse cancellation theorem and deduce dressed Gram iff `sourceV.IsIsometry`
- synchronize the focused Chapter 28 definitions and theorem dependencies

## Mathematical scope

This is the algebraic source-$v$ support from Cirac--Pérez-García--Schuch--Verstraete, Section III, equations `sf-svd`--`YZ=1` (arXiv:1703.09188, lines 479--506) and the `vUnitary` reconstruction argument. The source-bond order is exactly $r\times\ell$.

This PR does **not** identify the supplied fixed `simple2` contraction with the dressed Gram equation. That separate four-$\mathcal U$ source-cut bridge remains parent issue #5854.

## Validation

- warm direct Lean check of `SourceVIsometry.lean`
- targeted `MatrixUnitaryBetween`, source-v, and MPU aggregator builds
- independent current-Mathlib/TNLean overlap search and source-orientation review
- independent exact-head blueprint/source review: APPROVE
- proof-integrity, whitespace, and focused-diff checks

Closes #5869.
Leaves #5854 open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formalization and algebra lemmas in MPU/MPS with no runtime, auth, or data-path changes; scope is explicitly limited to dressed Gram cancellation without the `simple2` bridge.
> 
> **Overview**
> Adds **algebraic support** for the dressed source-$v$ Gram equation from Cirac et al. (`vUnitary`): tensorized dressing $Y=Y_1\otimes Y_2$ with right inverse $Z$, a physical/virtual **regrouping** equivalence, and the proposition `SourceVDressedGram` ($Y^\dagger(v^\dagger v)Y=Y^\dagger Y$).
> 
> A new generic matrix lemma in `MatrixUnitaryBetween` shows that when $YZ=1$, the dressed equation $Y^\dagger GY=Y^\dagger Y$ is equivalent to $G=1$. Applied with $G=v^\dagger v$, this yields **`sourceVDressedGram_iff_isometry`**: the dressed Gram equation iff `sourceV` is an isometry ($v^\dagger v=\mathrm{Id}$). An entrywise **regrouped finite-sum** characterization is also proved for later comparison to the `simple2` contraction (not done in this PR).
> 
> Chapter 28 blueprint and the MPU aggregator import are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85ddf448b5a88083cce1f438a943042e830f6cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->