### PR TITLE
feat(MPS/MPU): add independent tensor products

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -29,6 +29,7 @@ import TNLean.MPS.MPU.SourceUSecondCutMetric
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SuppliedFixedWitnesses
 import TNLean.MPS.MPU.SuppliedWitnessReblocking
+import TNLean.MPS.MPU.TensorProduct
 import TNLean.MPS.MPU.ThreeFormSpan
 import TNLean.MPS.MPU.TransferMatrix
 import TNLean.MPS.MPU.TransferStabilization

--- a/TNLean/MPS/MPU/TensorProduct.lean
+++ b/TNLean/MPS/MPU/TensorProduct.lean
@@ -75,7 +75,7 @@ private theorem evalWord_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E)
           evalWord V (is.map Fin.modNat) (js.map Fin.modNat)) := by
   induction is generalizing js with
   | nil =>
-      cases js <;> simp [evalWord, Matrix.one_kronecker_one]
+      cases js <;> simp [evalWord]
   | cons i is ih =>
       cases js with
       | nil => simp [evalWord]
@@ -123,7 +123,10 @@ def tensorProductCutShuffle (a b c f : ℕ) :
     (((finProdFinEquiv.symm x.1).1, (finProdFinEquiv.symm x.2).1),
       ((finProdFinEquiv.symm x.1).2, (finProdFinEquiv.symm x.2).2))
   left_inv x := by simp
-  right_inv x := by simp
+  right_inv x := by
+    apply Prod.ext
+    · exact finProdFinEquiv.apply_symm_apply x.1
+    · exact finProdFinEquiv.apply_symm_apply x.2
 
 /-- The first source cut of an independent tensor product is the reindexed
 Kronecker product of the first source cuts. Its row shuffle is
@@ -136,13 +139,9 @@ theorem sourceCutM₁_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
       Matrix.reindex (tensorProductCutShuffle D d E e)
         (tensorProductCutShuffle d D e E) (sourceCutM₁ U ⊗ₖ sourceCutM₁ V) := by
   ext row col
-  obtain ⟨αγ, jl⟩ := row
-  obtain ⟨ik, βδ⟩ := col
-  obtain ⟨α, γ⟩ := finProdFinEquiv.symm αγ
-  obtain ⟨j, l⟩ := finProdFinEquiv.symm jl
-  obtain ⟨i, k⟩ := finProdFinEquiv.symm ik
-  obtain ⟨β, δ⟩ := finProdFinEquiv.symm βδ
-  simp [tensorProductCutShuffle, Matrix.reindex_apply]
+  rcases row with ⟨αγ, jl⟩
+  rcases col with ⟨ik, βδ⟩
+  simp [sourceCutM₁, tensorProduct, tensorProductCutShuffle, Matrix.reindex_apply]
 
 /-- The second source cut of an independent tensor product is the reindexed
 Kronecker product of the second source cuts. Its row shuffle is
@@ -155,13 +154,9 @@ theorem sourceCutM₂_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
       Matrix.reindex (tensorProductCutShuffle D d E e)
         (tensorProductCutShuffle d D e E) (sourceCutM₂ U ⊗ₖ sourceCutM₂ V) := by
   ext row col
-  obtain ⟨αγ, ik⟩ := row
-  obtain ⟨jl, βδ⟩ := col
-  obtain ⟨α, γ⟩ := finProdFinEquiv.symm αγ
-  obtain ⟨i, k⟩ := finProdFinEquiv.symm ik
-  obtain ⟨j, l⟩ := finProdFinEquiv.symm jl
-  obtain ⟨β, δ⟩ := finProdFinEquiv.symm βδ
-  simp [tensorProductCutShuffle, Matrix.reindex_apply]
+  rcases row with ⟨αγ, ik⟩
+  rcases col with ⟨jl, βδ⟩
+  simp [sourceCutM₂, tensorProduct, tensorProductCutShuffle, Matrix.reindex_apply]
 
 /-- The right source rank is multiplicative under independent tensor products.
 The first source cut retains the paper's right orientation.

--- a/TNLean/MPS/MPU/TensorProduct.lean
+++ b/TNLean/MPS/MPU/TensorProduct.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixRankKronecker
+import TNLean.Algebra.TraceReindex
+import TNLean.MPS.MPU.Basic
+import TNLean.MPS.MPU.SourceCuts
+
+/-!
+# Independent tensor products of matrix product unitaries
+
+This file defines the independent tensor product of two MPO tensors. Both physical
+spaces and both virtual spaces are tensored, so tensors of dimensions `(d, D)` and
+`(e, E)` produce one of dimensions `(d * e, D * E)`. This operation is distinct
+from contraction-based MPO multiplication.
+
+The construction is the tensoring operation in the proof of part (ii) of the Index
+Theorem in arXiv:1703.09188, lines 824--847.
+
+## Main definitions
+
+* `MPOTensor.tensorProduct`: the local Kronecker product with standard finite-product
+  coordinates.
+* `MPOTensor.tensorProductConfigEquiv`: the sitewise splitting of product physical
+  configurations.
+* `MPOTensor.tensorProductCutShuffle`: the shuffle relating a Kronecker product of
+  source cuts to the source cut of a tensor product.
+
+## Main results
+
+* `MPOTensor.mpo_tensorProduct`: the exact finite-size reindexed-Kronecker formula.
+* `MPOTensor.IsMPU.tensorProduct`: independent tensor products preserve the MPU property.
+* `MPOTensor.sourceCutM₁_tensorProduct`, `MPOTensor.sourceCutM₂_tensorProduct`: the two
+  source-cut identities, with the right and left orientations unchanged.
+* `MPOTensor.rightRank_tensorProduct`, `MPOTensor.leftRank_tensorProduct`: multiplicativity
+  of the two source ranks.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor
+
+variable {d D e E : ℕ}
+
+/-- The independent tensor product of two MPO tensors, using `finProdFinEquiv` on
+both physical and virtual indices.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+def tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
+    MPOTensor (d * e) (D * E) :=
+  fun ij kl ↦ Matrix.reindex finProdFinEquiv finProdFinEquiv
+    (U ij.divNat kl.divNat ⊗ₖ V ij.modNat kl.modNat)
+
+/-- Entry formula for the independent tensor product. -/
+@[simp] theorem tensorProduct_apply (U : MPOTensor d D) (V : MPOTensor e E)
+    (i j : Fin d) (k l : Fin e) (α β : Fin D) (γ δ : Fin E) :
+    tensorProduct U V (finProdFinEquiv (i, k)) (finProdFinEquiv (j, l))
+        (finProdFinEquiv (α, γ)) (finProdFinEquiv (β, δ)) =
+      U i j α β * V k l γ δ := by
+  simp [tensorProduct, Matrix.reindex_apply]
+
+/-- Split a product-valued physical configuration site by site. -/
+def tensorProductConfigEquiv (N d e : ℕ) :
+    (Fin N → Fin (d * e)) ≃ (Fin N → Fin d) × (Fin N → Fin e) :=
+  (Equiv.arrowCongr (Equiv.refl (Fin N)) finProdFinEquiv.symm).trans
+    (Equiv.arrowProdEquivProdArrow (Fin N) (fun _ ↦ Fin d) (fun _ ↦ Fin e))
+
+private theorem evalWord_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E)
+    (is js : List (Fin (d * e))) :
+    evalWord (tensorProduct U V) is js =
+      Matrix.reindex finProdFinEquiv finProdFinEquiv
+        (evalWord U (is.map Fin.divNat) (js.map Fin.divNat) ⊗ₖ
+          evalWord V (is.map Fin.modNat) (js.map Fin.modNat)) := by
+  induction is generalizing js with
+  | nil =>
+      cases js <;> simp [evalWord, Matrix.one_kronecker_one]
+  | cons i is ih =>
+      cases js with
+      | nil => simp [evalWord]
+      | cons j js =>
+          simp only [evalWord_cons, List.map_cons, tensorProduct]
+          rw [ih]
+          rw [← Matrix.coe_reindexRingEquiv ℂ finProdFinEquiv]
+          rw [← map_mul, Matrix.mul_kronecker_mul]
+
+/-- The closed MPO of an independent tensor product is the Kronecker product of
+the two closed MPOs, in sitewise product coordinates.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem mpo_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) (N : ℕ) :
+    mpo (tensorProduct U V) N =
+      Matrix.reindex (tensorProductConfigEquiv N d e).symm
+        (tensorProductConfigEquiv N d e).symm (mpo U N ⊗ₖ mpo V N) := by
+  ext σ τ
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.kroneckerMap_apply,
+    mpo_apply, mpoMatrixEntry]
+  rw [evalWord_tensorProduct, Matrix.trace_reindex, Matrix.trace_kronecker]
+  simp [tensorProductConfigEquiv, Equiv.arrowCongr, Function.comp_def]
+
+/-- Independent tensor products of matrix product unitaries are matrix product
+unitaries.
+
+Source: arXiv:1703.09188, Theorem `IndexTh` (ii), lines 824--847. -/
+theorem IsMPU.tensorProduct {U : MPOTensor d D} {V : MPOTensor e E}
+    (hU : IsMPU U) (hV : IsMPU V) : IsMPU (tensorProduct U V) := by
+  intro N hN
+  rw [mpo_tensorProduct]
+  apply Matrix.reindex_mem_unitaryGroup
+  rw [Matrix.mem_unitaryGroup_iff]
+  simp only [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker]
+  rw [← Matrix.mul_kronecker_mul, hU.mpo_mul_conjTranspose_mpo hN,
+    hV.mpo_mul_conjTranspose_mpo hN, Matrix.one_kronecker_one]
+
+/-- Shuffle `((α, j), (α', j'))` to `((α, α'), (j, j'))`, encoding each
+new pair by `finProdFinEquiv`. This is the coordinate change between a
+Kronecker product of source cuts and the source cut of a tensor product. -/
+def tensorProductCutShuffle (a b c f : ℕ) :
+    ((Fin a × Fin b) × (Fin c × Fin f)) ≃ (Fin (a * c) × Fin (b * f)) where
+  toFun x := (finProdFinEquiv (x.1.1, x.2.1), finProdFinEquiv (x.1.2, x.2.2))
+  invFun x :=
+    (((finProdFinEquiv.symm x.1).1, (finProdFinEquiv.symm x.2).1),
+      ((finProdFinEquiv.symm x.1).2, (finProdFinEquiv.symm x.2).2))
+  left_inv x := by simp
+  right_inv x := by simp
+
+/-- The first source cut of an independent tensor product is the reindexed
+Kronecker product of the first source cuts. Its row shuffle is
+`((α,j),(α',j')) ↦ ((α,α'),(j,j'))`, so the paper's right orientation is
+preserved without a swap.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem sourceCutM₁_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
+    sourceCutM₁ (tensorProduct U V) =
+      Matrix.reindex (tensorProductCutShuffle D d E e)
+        (tensorProductCutShuffle d D e E) (sourceCutM₁ U ⊗ₖ sourceCutM₁ V) := by
+  ext row col
+  obtain ⟨αγ, jl⟩ := row
+  obtain ⟨ik, βδ⟩ := col
+  obtain ⟨α, γ⟩ := finProdFinEquiv.symm αγ
+  obtain ⟨j, l⟩ := finProdFinEquiv.symm jl
+  obtain ⟨i, k⟩ := finProdFinEquiv.symm ik
+  obtain ⟨β, δ⟩ := finProdFinEquiv.symm βδ
+  simp [tensorProductCutShuffle, Matrix.reindex_apply]
+
+/-- The second source cut of an independent tensor product is the reindexed
+Kronecker product of the second source cuts. Its row shuffle is
+`((α,i),(α',i')) ↦ ((α,α'),(i,i'))`, so the paper's left orientation is
+preserved without a swap.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem sourceCutM₂_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
+    sourceCutM₂ (tensorProduct U V) =
+      Matrix.reindex (tensorProductCutShuffle D d E e)
+        (tensorProductCutShuffle d D e E) (sourceCutM₂ U ⊗ₖ sourceCutM₂ V) := by
+  ext row col
+  obtain ⟨αγ, ik⟩ := row
+  obtain ⟨jl, βδ⟩ := col
+  obtain ⟨α, γ⟩ := finProdFinEquiv.symm αγ
+  obtain ⟨i, k⟩ := finProdFinEquiv.symm ik
+  obtain ⟨j, l⟩ := finProdFinEquiv.symm jl
+  obtain ⟨β, δ⟩ := finProdFinEquiv.symm βδ
+  simp [tensorProductCutShuffle, Matrix.reindex_apply]
+
+/-- The right source rank is multiplicative under independent tensor products.
+The first source cut retains the paper's right orientation.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem rightRank_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
+    r[tensorProduct U V] = r[U] * r[V] := by
+  rw [rightRank, sourceCutM₁_tensorProduct, Matrix.rank_reindex,
+    Matrix.rank_kronecker]
+  rfl
+
+/-- The left source rank is multiplicative under independent tensor products.
+The second source cut retains the paper's left orientation.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem leftRank_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) :
+    ℓ[tensorProduct U V] = ℓ[U] * ℓ[V] := by
+  rw [leftRank, sourceCutM₂_tensorProduct, Matrix.rank_reindex,
+    Matrix.rank_kronecker]
+  rfl
+
+end MPOTensor

--- a/TNLean/MPS/MPU/TensorProduct.lean
+++ b/TNLean/MPS/MPU/TensorProduct.lean
@@ -12,9 +12,9 @@ import TNLean.MPS.MPU.SourceCuts
 # Independent tensor products of matrix product unitaries
 
 This file defines the independent tensor product of two MPO tensors. Both physical
-spaces and both virtual spaces are tensored, so tensors of dimensions `(d, D)` and
-`(e, E)` produce one of dimensions `(d * e, D * E)`. This operation is distinct
-from contraction-based MPO multiplication.
+spaces and both virtual spaces are tensored, so tensors of dimensions \((d, D)\) and
+\((e, E)\) produce one of dimensions \((de, DE)\). This operation is distinct from
+contraction-based MPO multiplication.
 
 The construction is the tensoring operation in the proof of part (ii) of the Index
 Theorem in arXiv:1703.09188, lines 824--847.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1364,10 +1364,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{definition}[Independent tensor product of matrix product operator tensors]
     \label{def:mpu_independent_tensor_product}
     \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply,
-        MPOTensor.tensorProductConfigEquiv, MPOTensor.mpo_tensorProduct,
-        MPOTensor.IsMPU.tensorProduct}
+        MPOTensor.tensorProductConfigEquiv}
     \leanok
-    \uses{def:mpu,def:mpo_tensor}
+    \uses{def:mpo_tensor}
     Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d,e$ and
     auxiliary dimensions $D,E$, respectively. Their independent tensor
     product $\mathcal U\boxtimes\mathcal V$ has dimensions $de$ and $DE$ and
@@ -1376,50 +1375,99 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         (\mathcal U\boxtimes\mathcal V)^{(i,k),(j,l)}_{(\alpha,\gamma),(\beta,\delta)}
         &=\mathcal U^{i,j}_{\alpha,\beta}\mathcal V^{k,l}_{\gamma,\delta}.
     \end{align}
-    Splitting every product-valued physical configuration into its two
-    components identifies the finite-size operator with
+    A product-valued physical configuration splits sitewise into one
+    configuration for $\mathcal U$ and one for $\mathcal V$.
+\end{definition}
+
+\begin{theorem}[Finite-size operator of an independent tensor product]
+    \label{thm:mpu_finite_tensor_product}
+    \lean{MPOTensor.mpo_tensorProduct}
+    \leanok
+    \uses{def:mpu_independent_tensor_product,def:mpo_family}
+    For every system size $N$, the sitewise configuration bijection identifies
+    the finite-size operator with
     \begin{align}
         (\mathcal U\boxtimes\mathcal V)^{(N)}
         &\cong \mathcal U^{(N)}\otimes\mathcal V^{(N)}.
     \end{align}
-    In particular, the independent tensor product of two matrix product
-    unitary tensors is again a matrix product unitary tensor. This is the
-    tensoring operation in the proof of
-    \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
-\end{definition}
+\end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpu_independent_tensor_product,def:mpo_family}
     At each site, multiply the two local matrix entries and group the two
     auxiliary indices. Closing the auxiliary chain turns the trace of the
-    Kronecker product into the product of the two traces. The resulting
-    finite-size matrix is the Kronecker product after the sitewise
-    configuration bijection. A Kronecker product of unitary matrices is
-    unitary.
+    Kronecker product into the product of the two traces. The resulting matrix
+    is the Kronecker product after the sitewise configuration bijection.
 \end{proof}
 
-\begin{theorem}[Source-cut ranks of an independent tensor product]
-    \label{thm:mpu_tensor_product_source_ranks}
-    \lean{Matrix.rank_kronecker, MPOTensor.tensorProductCutShuffle,
-        MPOTensor.sourceCutM₁_tensorProduct,
-        MPOTensor.sourceCutM₂_tensorProduct,
-        MPOTensor.rightRank_tensorProduct,
-        MPOTensor.leftRank_tensorProduct}
+\begin{theorem}[Independent tensor products preserve matrix product unitarity]
+    \label{thm:mpu_tensor_product}
+    \lean{MPOTensor.IsMPU.tensorProduct}
     \leanok
-    \uses{def:mpu_independent_tensor_product,def:mpu_source_matrix_one,
-        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank}
-    For the independent tensor product, shuffle the row indices by
+    \uses{def:mpu,def:mpu_independent_tensor_product,
+        thm:mpu_finite_tensor_product}
+    The independent tensor product of two matrix product unitary tensors is a
+    matrix product unitary tensor. This is the tensoring operation in the proof
+    of \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_independent_tensor_product,thm:mpu_finite_tensor_product,
+        thm:mpu_reindex_unitary,lem:mpu_mul_adjoint}
+    The finite-size operator is a reindexed Kronecker product. Its product with
+    its adjoint is the Kronecker product of the corresponding two unitarity
+    equations, hence the identity. Simultaneous reindexing preserves
+    unitarity.
+\end{proof}
+
+\begin{definition}[Source-cut shuffle for an independent tensor product]
+    \label{def:mpu_tensor_product_cut_shuffle}
+    \lean{MPOTensor.tensorProductCutShuffle}
+    \leanok
+    The source-cut shuffle sends
     \begin{align}
         ((\alpha,j),(\alpha',j'))
-        &\longmapsto ((\alpha,\alpha'),(j,j'))
+        &\longmapsto ((\alpha,\alpha'),(j,j')).
     \end{align}
-    and use the analogous shuffle on the columns. Then
+    The analogous map applies to column indices.
+\end{definition}
+
+\begin{theorem}[Source cuts of an independent tensor product]
+    \label{thm:mpu_tensor_product_source_cuts}
+    \lean{MPOTensor.sourceCutM₁_tensorProduct,
+        MPOTensor.sourceCutM₂_tensorProduct}
+    \leanok
+    \uses{def:mpu_independent_tensor_product,
+        def:mpu_tensor_product_cut_shuffle,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two}
+    The source cuts satisfy
     \begin{align}
         M_1(\mathcal U\boxtimes\mathcal V)
         &\cong M_1(\mathcal U)\otimes M_1(\mathcal V),\\
         M_2(\mathcal U\boxtimes\mathcal V)
         &\cong M_2(\mathcal U)\otimes M_2(\mathcal V).
     \end{align}
-    Thus the right and left orientations are unchanged, and
+    Thus the paper's right and left orientations are unchanged.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_independent_tensor_product,
+        def:mpu_tensor_product_cut_shuffle,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two}
+    Evaluate both source cuts entry by entry after the displayed row and column
+    shuffles. Each entry is the product of the corresponding entries of the
+    two source cuts.
+\end{proof}
+
+\begin{theorem}[Source-cut ranks of an independent tensor product]
+    \label{thm:mpu_tensor_product_source_ranks}
+    \lean{MPOTensor.rightRank_tensorProduct,
+        MPOTensor.leftRank_tensorProduct}
+    \leanok
+    \uses{def:mpu_independent_tensor_product,
+        thm:mpu_tensor_product_source_cuts,def:mpu_right_rank,
+        def:mpu_left_rank,thm:mpu_kronecker_rank}
+    The right and left source-cut ranks are multiplicative:
     \begin{align}
         r(\mathcal U\boxtimes\mathcal V)
         &=r(\mathcal U)r(\mathcal V),\\
@@ -1431,9 +1479,10 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    Evaluate both source cuts entry by entry after the displayed shuffle.
-    Each entry is the product of the corresponding entries of the two source
-    cuts. Matrix rank is unchanged by row and column bijections and satisfies
+    \uses{def:mpu_independent_tensor_product,
+        thm:mpu_tensor_product_source_cuts,def:mpu_right_rank,
+        def:mpu_left_rank,thm:mpu_kronecker_rank}
+    Matrix rank is unchanged by row and column bijections and satisfies
     $\operatorname{rank}(A\otimes B)=\operatorname{rank}(A)
     \operatorname{rank}(B)$.
 \end{proof}
@@ -3241,16 +3290,21 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   $z$ and on their source legs by $x$ and $y$.
 \end{theorem}
 
-\begin{lemma}[Rank of a Kronecker product]
-  \label{lem:mpu_kronecker_rank}
-  \notready
-  \discussion{6040}
+\begin{theorem}[Rank of a Kronecker product]
+  \label{thm:mpu_kronecker_rank}
+  \lean{Matrix.rank_kronecker}
+  \leanok
   Let $A$ and $B$ be finite matrices over a field. Then
   \begin{align}
     \operatorname{rank}(A\otimes B)
       &=\operatorname{rank}(A)\operatorname{rank}(B).
   \end{align}
-\end{lemma}
+\end{theorem}
+
+\begin{proof}\leanok
+  Identify the image of the Kronecker product with the tensor product of the
+  two images and multiply their dimensions.
+\end{proof}
 
 \begin{definition}[Index]
   \label{def:index}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3290,7 +3290,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{lem:mpu_index_tensor}
   \notready
   \discussion{6015}
-  \uses{def:index,index-well-defined,lem:mpu_kronecker_rank}
+  \uses{def:index,index-well-defined,thm:mpu_tensor_product_source_ranks}
   For MPU tensors $\mathcal U$ and $\mathcal V$,
   \begin{align}
     \operatorname{ind}(\mathcal U\otimes\mathcal V)

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1361,6 +1361,83 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{definition}
 
+\begin{definition}[Independent tensor product of matrix product operator tensors]
+    \label{def:mpu_independent_tensor_product}
+    \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply,
+        MPOTensor.tensorProductConfigEquiv, MPOTensor.mpo_tensorProduct,
+        MPOTensor.IsMPU.tensorProduct}
+    \leanok
+    \uses{def:mpu,def:mpo_tensor}
+    Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d,e$ and
+    auxiliary dimensions $D,E$, respectively. Their independent tensor
+    product $\mathcal U\boxtimes\mathcal V$ has dimensions $de$ and $DE$ and
+    entries
+    \begin{align}
+        (\mathcal U\boxtimes\mathcal V)^{(i,k),(j,l)}_{(\alpha,\gamma),(\beta,\delta)}
+        &=\mathcal U^{i,j}_{\alpha,\beta}\mathcal V^{k,l}_{\gamma,\delta}.
+    \end{align}
+    Splitting every product-valued physical configuration into its two
+    components identifies the finite-size operator with
+    \begin{align}
+        (\mathcal U\boxtimes\mathcal V)^{(N)}
+        &\cong \mathcal U^{(N)}\otimes\mathcal V^{(N)}.
+    \end{align}
+    In particular, the independent tensor product of two matrix product
+    unitary tensors is again a matrix product unitary tensor. This is the
+    tensoring operation in the proof of
+    \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+\end{definition}
+
+\begin{proof}\leanok
+    At each site, multiply the two local matrix entries and group the two
+    auxiliary indices. Closing the auxiliary chain turns the trace of the
+    Kronecker product into the product of the two traces. The resulting
+    finite-size matrix is the Kronecker product after the sitewise
+    configuration bijection. A Kronecker product of unitary matrices is
+    unitary.
+\end{proof}
+
+\begin{theorem}[Source-cut ranks of an independent tensor product]
+    \label{thm:mpu_tensor_product_source_ranks}
+    \lean{Matrix.rank_kronecker, MPOTensor.tensorProductCutShuffle,
+        MPOTensor.sourceCutM₁_tensorProduct,
+        MPOTensor.sourceCutM₂_tensorProduct,
+        MPOTensor.rightRank_tensorProduct,
+        MPOTensor.leftRank_tensorProduct}
+    \leanok
+    \uses{def:mpu_independent_tensor_product,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank}
+    For the independent tensor product, shuffle the row indices by
+    \begin{align}
+        ((\alpha,j),(\alpha',j'))
+        &\longmapsto ((\alpha,\alpha'),(j,j'))
+    \end{align}
+    and use the analogous shuffle on the columns. Then
+    \begin{align}
+        M_1(\mathcal U\boxtimes\mathcal V)
+        &\cong M_1(\mathcal U)\otimes M_1(\mathcal V),\\
+        M_2(\mathcal U\boxtimes\mathcal V)
+        &\cong M_2(\mathcal U)\otimes M_2(\mathcal V).
+    \end{align}
+    Thus the right and left orientations are unchanged, and
+    \begin{align}
+        r(\mathcal U\boxtimes\mathcal V)
+        &=r(\mathcal U)r(\mathcal V),\\
+        \ell(\mathcal U\boxtimes\mathcal V)
+        &=\ell(\mathcal U)\ell(\mathcal V).
+    \end{align}
+    This is the rank-multiplication ingredient for the tensoring case in the
+    proof of \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Evaluate both source cuts entry by entry after the displayed shuffle.
+    Each entry is the product of the corresponding entries of the two source
+    cuts. Matrix rank is unchanged by row and column bijections and satisfies
+    $\operatorname{rank}(A\otimes B)=\operatorname{rank}(A)
+    \operatorname{rank}(B)$.
+\end{proof}
+
 \begin{theorem}[One-site blocking bounds for the source-cut ranks]
     \label{thm:mpu_source_cut_rank_blocking_succ}
     \lean{MPOTensor.rightRank_blockTensor_succ_le,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1394,10 +1394,13 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}\leanok
     \uses{def:mpu_independent_tensor_product,def:mpo_family}
-    At each site, multiply the two local matrix entries and group the two
-    auxiliary indices. Closing the auxiliary chain turns the trace of the
-    Kronecker product into the product of the two traces. The resulting matrix
-    is the Kronecker product after the sitewise configuration bijection.
+    Grouping the two auxiliary indices makes every closed-word matrix a
+    Kronecker product. The identity
+    \begin{align}
+        \Tr(A\otimes B)&=\Tr(A)\Tr(B)
+    \end{align}
+    then gives the stated finite-size operator after the sitewise
+    configuration bijection.
 \end{proof}
 
 \begin{theorem}[Independent tensor products preserve matrix product unitarity]
@@ -1414,10 +1417,15 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}\leanok
     \uses{def:mpu_independent_tensor_product,thm:mpu_finite_tensor_product,
         thm:mpu_reindex_unitary,lem:mpu_mul_adjoint}
-    The finite-size operator is a reindexed Kronecker product. Its product with
-    its adjoint is the Kronecker product of the corresponding two unitarity
-    equations, hence the identity. Simultaneous reindexing preserves
-    unitarity.
+    The multiplication rule $(A\otimes B)(C\otimes D)=AC\otimes BD$ gives
+    \begin{align}
+        &(\mathcal U^{(N)}\otimes\mathcal V^{(N)})
+            (\mathcal U^{(N)}\otimes\mathcal V^{(N)})^\dagger \\
+        &\quad=\mathcal U^{(N)}(\mathcal U^{(N)})^\dagger
+            \otimes\mathcal V^{(N)}(\mathcal V^{(N)})^\dagger
+         =\Id\otimes\Id=\Id.
+    \end{align}
+    Simultaneous reindexing preserves this unitarity equation.
 \end{proof}
 
 \begin{definition}[Source-cut shuffle for an independent tensor product]


### PR DESCRIPTION
## What changed

- define the independent tensor product of two MPU tensors by local Kronecker products
- prove the finite-size MPO is the correctly reindexed Kronecker product
- prove independent tensor products preserve `IsMPU`
- identify both source cuts through explicit product-index shuffles
- prove right and left source-cut ranks multiply using `Matrix.rank_kronecker`
- add focused Chapter 28 entries without claiming blocking compatibility or final index additivity

## Validation

- `lake build TNLean.MPS.MPU.TensorProduct`
- `lake build TNLean.MPS.MPU`
- Mathlib lint: 0 errors across all 10 new declarations
- generated aggregator, style, proof-integrity, and file-policy checks
- focused blueprint reverse coverage and `leanblueprint checkdecls`
- two LuaLaTeX passes with zero undefined references
- `git diff --check origin/main...HEAD`

Closes #6058

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and blueprint sync in MPU/tensor algebra; no runtime, auth, or data paths. Residual index additivity remains explicitly not claimed in the PR scope.
> 
> **Overview**
> Adds **independent tensor products** (`MPOTensor.tensorProduct`, ⊗ on physical and virtual legs) for MPU tensors, aligned with Cirac et al. Index Theorem part (ii). The new `TensorProduct.lean` proves the finite-size MPO is a reindexed Kronecker product, `IsMPU` is preserved, both source cuts match Kronecker products after explicit shuffles, and right/left source ranks multiply via `Matrix.rank_kronecker`.
> 
> Chapter 28 blueprint gains matching definitions and theorems (finite-size operator, MPU preservation, source cuts, rank multiplicativity). The Kronecker rank fact is promoted from a not-ready lemma to **`thm:mpu_kronecker_rank`** linked to `Matrix.rank_kronecker`; the index tensor-product lemma now cites the new source-rank theorem instead of the old lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de604ee291acc9494ec1aea5312d580df6bcb7e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->