### PR TITLE
feat(mpdo): add Fibonacci transition obstruction slice

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -139,6 +139,7 @@ import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.DiagonalCutRank
 import TNLean.MPS.MPDO.DiagonalFiniteChain
 import TNLean.MPS.MPDO.EtaPreparation
+import TNLean.MPS.MPDO.FibonacciBoundaryRank
 import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.FirstSite
 import TNLean.MPS.MPDO.FirstSiteBlocking

--- a/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
+++ b/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PureRecovery
+import Mathlib.Tactic.FinCases
+
+/-!
+# Fibonacci boundary rank calculation
+
+This file formalizes the concrete vacuum-sector calculation in CPSV16 Appendix D.
+The three binary physical labels are written `i,j,k`, the fusion weights are
+`N_{ijk}`, and the virtual labels are `α,β`.  The local tensor is
+`A^{ijk}_{αβ} = δ_{i,α} δ_{k,β} N_{ijk}`.  We do not define the diagrammatic
+``Strong-RFP`` condition.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix D, lines 2116--2176, labels `rank-Fibonacci` and `eq:1`.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+open Matrix Finset
+
+namespace MPSTensor
+namespace FibonacciBoundary
+
+/-- Exactly two of the three Fibonacci fusion labels are zero.
+
+Source: arXiv:1606.00608, Appendix D, lines 2133--2135. -/
+def ExactlyTwoZero (i j k : Fin 2) : Prop :=
+  (i = 0 ∧ j = 0 ∧ k = 1) ∨ (i = 0 ∧ j = 1 ∧ k = 0) ∨
+    (i = 1 ∧ j = 0 ∧ k = 0)
+
+/-- Positive fusion weights `N_{ijk}` with exactly the support prescribed by the
+Fibonacci fusion rules.
+
+Source: arXiv:1606.00608, Appendix D, lines 2131--2135. -/
+structure FusionWeights where
+  N : Fin 2 → Fin 2 → Fin 2 → ℝ
+  zero_iff : ∀ i j k, N i j k = 0 ↔ ExactlyTwoZero i j k
+  pos_of_not_exactlyTwoZero : ∀ i j k, ¬ExactlyTwoZero i j k → 0 < N i j k
+
+/-- The canonical `0/1` Fibonacci fusion weights. -/
+noncomputable def canonicalFusionWeights : FusionWeights := by
+  classical
+  exact {
+    N := fun i j k ↦ if ExactlyTwoZero i j k then 0 else 1
+    zero_iff := fun i j k ↦ by simp
+    pos_of_not_exactlyTwoZero := fun i j k h ↦ by simp [h] }
+
+/-- Decode the physical label into the paper's three binary labels `(i,j,k)`. -/
+def physicalTriple (p : Fin 8) : Fin 2 × Fin 2 × Fin 2 :=
+  (⟨p.val / 4, by omega⟩, ⟨(p.val / 2) % 2, Nat.mod_lt _ (by omega)⟩,
+    ⟨p.val % 2, Nat.mod_lt _ (by omega)⟩)
+
+/-- The source tensor `A^{ijk}_{αβ} = δ_{i,α}δ_{k,β}N_{ijk}`.
+
+Source: arXiv:1606.00608, Appendix D, lines 2119--2135. -/
+noncomputable def tensor (W : FusionWeights) : MPSTensor 8 2 := fun p α β =>
+  let ijk := physicalTriple p
+  if ijk.1 = α ∧ ijk.2.2 = β then (W.N ijk.1 ijk.2.1 ijk.2.2 : ℂ) else 0
+
+/-- The canonical support tensor, with every allowed `N_{ijk}` equal to one. -/
+noncomputable abbrev canonicalTensor : MPSTensor 8 2 := tensor canonicalFusionWeights
+
+/-- The two-state transfer matrix `B = [[1,1],[1,2]]` from the source calculation.
+
+Source: arXiv:1606.00608, Appendix D, lines 2154--2164. -/
+def B : Matrix (Fin 2) (Fin 2) ℕ := !![1, 1; 1, 2]
+
+/-- The transition counts `x^n_{αβ}` from the source open-boundary recurrence.
+Their identification with the ranks of the concrete open-boundary operators is
+left to the remaining rank bridge.
+
+Source: arXiv:1606.00608, Appendix D, lines 2139--2164. -/
+def x (n : ℕ) (α β : Fin 2) : ℕ := (B ^ n) α β
+
+/-- The source initial value `x¹ = (1,1,1,2)`. -/
+theorem x_one :
+    (x 1 0 0, x 1 0 1, x 1 1 0, x 1 1 1) = (1, 1, 1, 2) := by
+  norm_num [x, B]
+
+/-- The source recurrence `xⁿ = xⁿ⁻¹ B`, simultaneously for all boundary
+conditions.
+
+Source: arXiv:1606.00608, Appendix D, lines 2146--2164. -/
+theorem x_succ (n : ℕ) (α : Fin 2) :
+    x (n + 1) α 0 = x n α 0 + x n α 1 ∧
+      x (n + 1) α 1 = x n α 0 + 2 * x n α 1 := by
+  fin_cases α <;>
+    simp [x, pow_succ, B, Matrix.mul_apply, Fin.sum_univ_two] <;> omega
+
+/-- The periodic transition count is extracted by closing the two boundary
+labels, `a_N = x^N_{00} + x^N_{11}`.  The source identifies this count with
+`rank ρ^(N)`; that operator-rank bridge remains separate.
+
+Source: arXiv:1606.00608, Appendix D, lines 2164--2176. -/
+def periodicRank (N : ℕ) : ℕ := x N 0 0 + x N 1 1
+
+/-- The first periodic rank is three. -/
+@[simp] theorem periodicRank_one : periodicRank 1 = 3 := by
+  norm_num [periodicRank, x, B]
+
+/-- The second periodic rank is seven. -/
+@[simp] theorem periodicRank_two : periodicRank 2 = 7 := by
+  rw [periodicRank, (x_succ 1 0).1, (x_succ 1 1).2]
+  norm_num [x, B]
+
+/-- The Fibonacci periodic ranks cannot have geometric growth `r s^(N-1)`.
+The contradiction is already forced by ranks three and seven.
+
+Source: arXiv:1606.00608, Appendix D, lines 2136--2140. -/
+theorem periodicRank_not_geometric :
+    ¬∃ r s : ℕ, ∀ N : ℕ, 0 < N → periodicRank N = r * s ^ (N - 1) := by
+  rintro ⟨r, s, h⟩
+  have h1 := h 1 (by omega)
+  have h2 := h 2 (by omega)
+  simp only [periodicRank_one, periodicRank_two, Nat.reduceSubDiff, pow_zero, pow_one,
+    mul_one] at h1 h2
+  subst r
+  omega
+
+end FibonacciBoundary
+end MPSTensor

--- a/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
+++ b/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
@@ -7,7 +7,7 @@ import TNLean.MPS.MPDO.PureRecovery
 import Mathlib.Tactic.FinCases
 
 /-!
-# Fibonacci boundary rank calculation
+# Fibonacci boundary transition calculation
 
 This file formalizes the concrete vacuum-sector calculation in CPSV16 Appendix D.
 The three binary physical labels are written \(i,j,k\), the fusion weights are
@@ -15,10 +15,14 @@ The three binary physical labels are written \(i,j,k\), the fusion weights are
 \(A^{ijk}_{αβ} = δ_{i,α} δ_{k,β} N_{ijk}\).  The structural strong fixed-point
 relation is defined separately in `MPOTensor.IsStrongRFP`.
 
+**Scope restriction (transition-count slice):** This file does not identify the
+transition counts with the open-boundary or periodic operator ranks, and it does
+not prove the golden-ratio formula for the periodic rank.
+
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Appendix D, lines 2116--2176, labels `rank-Fibonacci` and `eq:1`.
+  Appendix D, lines 2116--2176.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -74,8 +78,8 @@ Source: arXiv:1606.00608, Appendix D, lines 2146--2149. -/
 def B : Matrix (Fin 2) (Fin 2) ℕ := !![1, 1; 1, 2]
 
 /-- The transition counts \(x^n_{αβ}\) satisfying the source open-boundary
-recurrence.  Their equality with the ranks of the concrete open-boundary
-operators remains to be proved.
+recurrence.  This definition records the matrix-power counts only; it makes no
+identification with the ranks of open-boundary operators.
 
 Source: arXiv:1606.00608, Appendix D, lines 2127--2149. -/
 def x (n : ℕ) (α β : Fin 2) : ℕ := (B ^ n) α β
@@ -97,9 +101,9 @@ theorem x_succ (n : ℕ) (α : Fin 2) :
   fin_cases α <;>
     simp [x, pow_succ, B, Matrix.mul_apply, Fin.sum_univ_two] <;> omega
 
-/-- The periodic transition count is obtained by closing the two boundary
-labels, \(a_N=x^N_{00}+x^N_{11}\).  The source identifies this count with
-\(\operatorname{rank}\rho^{(N)}\); that equality remains to be proved.
+/-- The periodic transition count obtained by closing the two boundary labels,
+\(a_N=x^N_{00}+x^N_{11}\).  This definition asserts only the transition count,
+not an operator-rank identity.
 
 Source: arXiv:1606.00608, Appendix D, lines 2157--2176. -/
 def periodicTransitionCount (N : ℕ) : ℕ := x N 0 0 + x N 1 1

--- a/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
+++ b/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
@@ -10,10 +10,10 @@ import Mathlib.Tactic.FinCases
 # Fibonacci boundary rank calculation
 
 This file formalizes the concrete vacuum-sector calculation in CPSV16 Appendix D.
-The three binary physical labels are written `i,j,k`, the fusion weights are
-`N_{ijk}`, and the virtual labels are `α,β`.  The local tensor is
-`A^{ijk}_{αβ} = δ_{i,α} δ_{k,β} N_{ijk}`.  We do not define the diagrammatic
-``Strong-RFP`` condition.
+The three binary physical labels are written \(i,j,k\), the fusion weights are
+\(N_{ijk}\), and the virtual labels are \(α,β\).  The local tensor is
+\(A^{ijk}_{αβ} = δ_{i,α} δ_{k,β} N_{ijk}\).  The structural strong fixed-point
+relation is defined separately in `MPOTensor.IsStrongRFP`.
 
 ## References
 
@@ -29,21 +29,21 @@ namespace FibonacciBoundary
 
 /-- Exactly two of the three Fibonacci fusion labels are zero.
 
-Source: arXiv:1606.00608, Appendix D, lines 2133--2135. -/
+Source: arXiv:1606.00608, Appendix D, lines 2120--2121. -/
 def ExactlyTwoZero (i j k : Fin 2) : Prop :=
   (i = 0 ∧ j = 0 ∧ k = 1) ∨ (i = 0 ∧ j = 1 ∧ k = 0) ∨
     (i = 1 ∧ j = 0 ∧ k = 0)
 
-/-- Positive fusion weights `N_{ijk}` with exactly the support prescribed by the
+/-- Positive fusion weights \(N_{ijk}\) with exactly the support prescribed by the
 Fibonacci fusion rules.
 
-Source: arXiv:1606.00608, Appendix D, lines 2131--2135. -/
+Source: arXiv:1606.00608, Appendix D, lines 2120--2121. -/
 structure FusionWeights where
   N : Fin 2 → Fin 2 → Fin 2 → ℝ
   zero_iff : ∀ i j k, N i j k = 0 ↔ ExactlyTwoZero i j k
   pos_of_not_exactlyTwoZero : ∀ i j k, ¬ExactlyTwoZero i j k → 0 < N i j k
 
-/-- The canonical `0/1` Fibonacci fusion weights. -/
+/-- The canonical \(0/1\) Fibonacci fusion weights. -/
 noncomputable def canonicalFusionWeights : FusionWeights := by
   classical
   exact {
@@ -51,75 +51,79 @@ noncomputable def canonicalFusionWeights : FusionWeights := by
     zero_iff := fun i j k ↦ by simp
     pos_of_not_exactlyTwoZero := fun i j k h ↦ by simp [h] }
 
-/-- Decode the physical label into the paper's three binary labels `(i,j,k)`. -/
+/-- Decode the physical label into the paper's three binary labels \((i,j,k)\). -/
 def physicalTriple (p : Fin 8) : Fin 2 × Fin 2 × Fin 2 :=
   (⟨p.val / 4, by omega⟩, ⟨(p.val / 2) % 2, Nat.mod_lt _ (by omega)⟩,
     ⟨p.val % 2, Nat.mod_lt _ (by omega)⟩)
 
-/-- The source tensor `A^{ijk}_{αβ} = δ_{i,α}δ_{k,β}N_{ijk}`.
+/-- The source tensor \(A^{ijk}_{αβ} = δ_{i,α}δ_{k,β}N_{ijk}\).
 
-Source: arXiv:1606.00608, Appendix D, lines 2119--2135. -/
+Source: arXiv:1606.00608, Appendix D, lines 2116--2121. -/
 noncomputable def tensor (W : FusionWeights) : MPSTensor 8 2 := fun p α β =>
   let ijk := physicalTriple p
   if ijk.1 = α ∧ ijk.2.2 = β then (W.N ijk.1 ijk.2.1 ijk.2.2 : ℂ) else 0
 
-/-- The canonical support tensor, with every allowed `N_{ijk}` equal to one. -/
+/-- The canonical support tensor, with every allowed \(N_{ijk}\) equal to one. -/
 noncomputable abbrev canonicalTensor : MPSTensor 8 2 := tensor canonicalFusionWeights
 
-/-- The two-state transfer matrix `B = [[1,1],[1,2]]` from the source calculation.
+/-- The two-state transition matrix
+\(B=\left(\begin{smallmatrix}1&1\\1&2\end{smallmatrix}\right)\) from the source
+calculation.
 
-Source: arXiv:1606.00608, Appendix D, lines 2154--2164. -/
+Source: arXiv:1606.00608, Appendix D, lines 2146--2149. -/
 def B : Matrix (Fin 2) (Fin 2) ℕ := !![1, 1; 1, 2]
 
-/-- The transition counts `x^n_{αβ}` from the source open-boundary recurrence.
-Their identification with the ranks of the concrete open-boundary operators is
-left to the remaining rank bridge.
+/-- The transition counts \(x^n_{αβ}\) satisfying the source open-boundary
+recurrence.  Their equality with the ranks of the concrete open-boundary
+operators remains to be proved.
 
-Source: arXiv:1606.00608, Appendix D, lines 2139--2164. -/
+Source: arXiv:1606.00608, Appendix D, lines 2127--2149. -/
 def x (n : ℕ) (α β : Fin 2) : ℕ := (B ^ n) α β
 
-/-- The source initial value `x¹ = (1,1,1,2)`. -/
+/-- The source initial value \(x^1=(1,1,1,2)\).
+
+Source: arXiv:1606.00608, Appendix D, lines 2138--2145. -/
 theorem x_one :
     (x 1 0 0, x 1 0 1, x 1 1 0, x 1 1 1) = (1, 1, 1, 2) := by
   norm_num [x, B]
 
-/-- The source recurrence `xⁿ = xⁿ⁻¹ B`, simultaneously for all boundary
+/-- The source recurrence \(x^n=x^{n-1}B\), simultaneously for all boundary
 conditions.
 
-Source: arXiv:1606.00608, Appendix D, lines 2146--2164. -/
+Source: arXiv:1606.00608, Appendix D, lines 2131--2149. -/
 theorem x_succ (n : ℕ) (α : Fin 2) :
     x (n + 1) α 0 = x n α 0 + x n α 1 ∧
       x (n + 1) α 1 = x n α 0 + 2 * x n α 1 := by
   fin_cases α <;>
     simp [x, pow_succ, B, Matrix.mul_apply, Fin.sum_univ_two] <;> omega
 
-/-- The periodic transition count is extracted by closing the two boundary
-labels, `a_N = x^N_{00} + x^N_{11}`.  The source identifies this count with
-`rank ρ^(N)`; that operator-rank bridge remains separate.
+/-- The periodic transition count is obtained by closing the two boundary
+labels, \(a_N=x^N_{00}+x^N_{11}\).  The source identifies this count with
+\(\operatorname{rank}\rho^{(N)}\); that equality remains to be proved.
 
-Source: arXiv:1606.00608, Appendix D, lines 2164--2176. -/
-def periodicRank (N : ℕ) : ℕ := x N 0 0 + x N 1 1
+Source: arXiv:1606.00608, Appendix D, lines 2157--2176. -/
+def periodicTransitionCount (N : ℕ) : ℕ := x N 0 0 + x N 1 1
 
-/-- The first periodic rank is three. -/
-@[simp] theorem periodicRank_one : periodicRank 1 = 3 := by
-  norm_num [periodicRank, x, B]
+/-- The first periodic transition count is three. -/
+@[simp] theorem periodicTransitionCount_one : periodicTransitionCount 1 = 3 := by
+  norm_num [periodicTransitionCount, x, B]
 
-/-- The second periodic rank is seven. -/
-@[simp] theorem periodicRank_two : periodicRank 2 = 7 := by
-  rw [periodicRank, (x_succ 1 0).1, (x_succ 1 1).2]
+/-- The second periodic transition count is seven. -/
+@[simp] theorem periodicTransitionCount_two : periodicTransitionCount 2 = 7 := by
+  rw [periodicTransitionCount, (x_succ 1 0).1, (x_succ 1 1).2]
   norm_num [x, B]
 
-/-- The Fibonacci periodic ranks cannot have geometric growth `r s^(N-1)`.
-The contradiction is already forced by ranks three and seven.
+/-- The periodic transition counts cannot have geometric growth \(r s^{N-1}\).
+The contradiction is already forced by the values three and seven.
 
-Source: arXiv:1606.00608, Appendix D, lines 2136--2140. -/
-theorem periodicRank_not_geometric :
-    ¬∃ r s : ℕ, ∀ N : ℕ, 0 < N → periodicRank N = r * s ^ (N - 1) := by
+Source: arXiv:1606.00608, Appendix D, line 2125. -/
+theorem periodicTransitionCount_not_geometric :
+    ¬∃ r s : ℕ, ∀ N : ℕ, 0 < N → periodicTransitionCount N = r * s ^ (N - 1) := by
   rintro ⟨r, s, h⟩
   have h1 := h 1 (by omega)
   have h2 := h 2 (by omega)
-  simp only [periodicRank_one, periodicRank_two, Nat.reduceSubDiff, pow_zero, pow_one,
-    mul_one] at h1 h2
+  simp only [periodicTransitionCount_one, periodicTransitionCount_two, Nat.reduceSubDiff,
+    pow_zero, pow_one, mul_one] at h1 h2
   subst r
   omega
 

--- a/TNLean/MPS/MPDO/PureRecovery.lean
+++ b/TNLean/MPS/MPDO/PureRecovery.lean
@@ -34,6 +34,45 @@ def toMPOTensor (A : MPSTensor d D) : MPOTensor d D :=
     A.toMPOTensor i j = 0 := by
   simp [toMPOTensor, hij]
 
+/-- Word evaluation for the diagonal embedding vanishes unless the ket and
+bra words agree, and then recovers the original MPS word evaluation. -/
+theorem evalWord_toMPOTensor (A : MPSTensor d D) : ∀ l k : List (Fin d),
+    MPOTensor.evalWord A.toMPOTensor l k = if l = k then evalWord A l else 0 := by
+  intro l
+  induction l with
+  | nil => intro k; cases k <;> simp [MPOTensor.evalWord, evalWord]
+  | cons i is ih =>
+      intro k
+      cases k with
+      | nil => simp [MPOTensor.evalWord]
+      | cons j js =>
+          by_cases hij : i = j
+          · subst j
+            simp only [MPOTensor.evalWord_cons, toMPOTensor_apply_same, ih]
+            by_cases his : is = js
+            · subst js
+              simp [evalWord]
+            · simp [his]
+          · simp [MPOTensor.evalWord, toMPOTensor, hij]
+
+/-- The MPO of the diagonal pure-state embedding is the diagonal matrix whose
+entries are the periodic MPV coefficients. -/
+theorem mpo_toMPOTensor (A : MPSTensor d D) (N : ℕ) :
+    mpo A.toMPOTensor N = Matrix.diagonal (mpv A) := by
+  classical
+  ext σ τ
+  by_cases h : σ = τ
+  · subst τ
+    simp [mpo, mpoMatrixEntry, mpv, coeff, evalWord_toMPOTensor]
+  · simp [mpo, mpoMatrixEntry, evalWord_toMPOTensor, h]
+
+/-- The rank of a diagonally embedded pure tensor is the number of nonzero MPV
+coefficients. -/
+theorem rank_mpo_toMPOTensor (A : MPSTensor d D) (N : ℕ) :
+    (mpo A.toMPOTensor N).rank = Fintype.card {σ : Fin N → Fin d // mpv A σ ≠ 0} := by
+  classical
+  rw [mpo_toMPOTensor, Matrix.rank_diagonal]
+
 /-- The transfer map of the diagonal pure-state embedding is exactly the
 original MPS transfer map. -/
 @[simp] theorem toMPOTensor_transferMap (A : MPSTensor d D) :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -765,10 +765,9 @@ the remaining sites unchanged.
         \label{eq:cpsv_fib_counts}
     \end{align}
     These are the transition counts governed by the recurrence in
-    \cite[Appendix~D, lines~2131--2149]{Cirac2016MPDO_arXiv}.  Their equality
-    with the open-boundary operator ranks in
-    \cite[Appendix~D, lines~2127--2130]{Cirac2016MPDO_arXiv} remains to be
-    proved.
+    \cite[Appendix~D, lines~2131--2149]{Cirac2016MPDO_arXiv}.
+    % Their identification with the open-boundary ranks at lines 2127--2130
+    % remains tracked by issue #5921.
 \end{definition}
 
 \begin{theorem}[Fibonacci boundary transition recurrence]
@@ -804,9 +803,9 @@ the remaining sites unchanged.
         a_N&=x^N_{00}+x^N_{11}=\tr(B^N).
         \notag
     \end{align}
-    The source identifies this number with the periodic operator rank at
-    \cite[Appendix~D, line~2157]{Cirac2016MPDO_arXiv}; that identification is
-    retained separately below.
+    This is the boundary-label closure used in
+    \cite[Appendix~D, line~2157]{Cirac2016MPDO_arXiv}.
+    % The equality with the periodic operator rank remains tracked by issue #5921.
 \end{definition}
 
 \begin{theorem}[First periodic Fibonacci transition counts]
@@ -854,7 +853,7 @@ the remaining sites unchanged.
     For $n>0$ and $\alpha,\beta\in\{0,1\}$, let
     $\rho^{(n)}_{\alpha\beta}(A)$ be the diagonal open-boundary operator whose
     coefficient at a physical word is
-    $(\alpha|A^{i_1j_1k_1}\cdots A^{i_nj_nk_n}|\beta)$.  Prove
+    $(\alpha|A^{i_1j_1k_1}\cdots A^{i_nj_nk_n}|\beta)$.  Then
     \begin{align}
         x^n_{\alpha\beta}
         &=\operatorname{rank}\rho^{(n)}_{\alpha\beta}(A).
@@ -871,7 +870,7 @@ the remaining sites unchanged.
       thm:cpsv_fibonacci_open_boundary_rank_status,
       thm:to_mpo_diagonal_rank}
     Set $\tau_\pm=(1\pm\sqrt5)/2$, as in
-    \cite[Appendix~D, line~2125]{Cirac2016MPDO_arXiv}.  For every $N>0$, prove
+    \cite[Appendix~D, line~2125]{Cirac2016MPDO_arXiv}.  For every $N>0$,
     \begin{align}
         \operatorname{rank}\rho^{(N)}(A)
         &=x^N_{00}+x^N_{11}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -711,9 +711,9 @@ the remaining sites unchanged.
     $\E_A^2=\E_A$. The physical-isometry formulation follows from
     Theorem~\ref{thm:physical_blocking_isometry_iff_transfer_idempotence}.
 \end{proof}
-% CPSV16 Appendix D, lines 2116--2176.  The paper's label `eq:1` is an
-% internal calculation.  Issue #5921 retains the missing identification of the
-% transition counts with the ranks of the concrete MPO.
+% CPSV16 Appendix D, lines 2116--2176.  The labels `rank-Fibonacci` and
+% `eq:1` refer respectively to the rank formula and its internal calculation.
+% Issue #5921 retains the two operator-rank identifications below.
 \begin{definition}[Fibonacci vacuum-sector support tensor]
     \label{def:cpsv_fibonacci_support_tensor}
     \lean{MPSTensor.FibonacciBoundary.ExactlyTwoZero,
@@ -725,17 +725,15 @@ the remaining sites unchanged.
     \leanok
     \uses{def:mps_tensor}
     This is the concrete tensor in
-    \cite[Appendix~D, lines~2118--2135]{Cirac2016MPDO_arXiv}.  Its physical
+    \cite[Appendix~D, lines~2116--2121]{Cirac2016MPDO_arXiv}.  Its physical
     labels are triples $i,j,k\in\{0,1\}$ and its virtual labels are
-    $\alpha,\beta\in\{0,1\}$.  Choose weights $N_{ijk}$ satisfying
+    $\alpha,\beta\in\{0,1\}$.  The fusion weights satisfy
     \begin{align}
-        N_{ijk}=0&\iff
-        (i,j,k)\in\{(0,0,1),(0,1,0),(1,0,0)\},
-        \label{eq:cpsv_fib_support}\\
-        N_{ijk}&>0 &&\text{otherwise}.
-        \notag
+        N_{ijk}=0
+        &\iff (i,j,k)\in\{(0,0,1),(0,1,0),(1,0,0)\}.
+        \label{eq:cpsv_fib_support}
     \end{align}
-    Then
+    Every weight outside this zero set is positive, and
     \begin{align}
         A^{ijk}_{\alpha\beta}
         &=\delta_{i,\alpha}\delta_{k,\beta}N_{ijk}.
@@ -744,74 +742,160 @@ the remaining sites unchanged.
     The canonical support tensor takes every nonzero $N_{ijk}$ to be one.
 \end{definition}
 
-\begin{theorem}[Fibonacci open-boundary transition recurrence]
+\begin{definition}[Fibonacci transition matrix]
+    \label{def:cpsv_fibonacci_transition_matrix}
+    \lean{MPSTensor.FibonacciBoundary.B}
+    \leanok
+    The transition matrix from
+    \cite[Appendix~D, lines~2146--2149]{Cirac2016MPDO_arXiv} is
+    \begin{align}
+        B&=\begin{pmatrix}1&1\\1&2\end{pmatrix}.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{definition}[Fibonacci boundary transition counts]
+    \label{def:cpsv_fibonacci_boundary_counts}
+    \lean{MPSTensor.FibonacciBoundary.x}
+    \leanok
+    \uses{def:cpsv_fibonacci_transition_matrix}
+    For $n\in\N$ and $\alpha,\beta\in\{0,1\}$, define
+    \begin{align}
+        x^n_{\alpha\beta}&=(B^n)_{\alpha\beta}.
+        \label{eq:cpsv_fib_counts}
+    \end{align}
+    These are the transition counts governed by the recurrence in
+    \cite[Appendix~D, lines~2131--2149]{Cirac2016MPDO_arXiv}.  Their equality
+    with the open-boundary operator ranks in
+    \cite[Appendix~D, lines~2127--2130]{Cirac2016MPDO_arXiv} remains to be
+    proved.
+\end{definition}
+
+\begin{theorem}[Fibonacci boundary transition recurrence]
     \label{thm:cpsv_fibonacci_boundary_recurrence}
-    \lean{MPSTensor.FibonacciBoundary.B,
-      MPSTensor.FibonacciBoundary.x,
-      MPSTensor.FibonacciBoundary.x_one,
+    \lean{MPSTensor.FibonacciBoundary.x_one,
       MPSTensor.FibonacciBoundary.x_succ}
     \leanok
-    Let
-    \begin{align}
-        B&=\begin{pmatrix}1&1\\1&2\end{pmatrix},&
-        x^n_{\alpha\beta}&=(B^n)_{\alpha\beta}.
-        \label{eq:cpsv_fib_recurrence}
-    \end{align}
-    Then $x^1=(1,1,1,2)$ in the order $(00,01,10,11)$, and
+    \uses{def:cpsv_fibonacci_boundary_counts}
+    In the order $(00,01,10,11)$, one has $x^1=(1,1,1,2)$ and
     \begin{align}
         x^{n+1}_{\alpha0}&=x^n_{\alpha0}+x^n_{\alpha1},&
         x^{n+1}_{\alpha1}&=x^n_{\alpha0}+2x^n_{\alpha1}.
         \notag
     \end{align}
-    These are the transition counts appearing in
-    \cite[Appendix~D, lines~2139--2164]{Cirac2016MPDO_arXiv}.
+    This is the recurrence in
+    \cite[Appendix~D, lines~2131--2145]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}
     \leanok
+    \uses{def:cpsv_fibonacci_transition_matrix,
+      def:cpsv_fibonacci_boundary_counts}
     Multiply the row indexed by $\alpha$ in $B^n$ by the two columns of $B$.
 \end{proof}
 
-\begin{theorem}[First periodic Fibonacci transition counts are not geometric]
-    \label{thm:cpsv_fibonacci_transition_not_geometric}
-    \lean{MPSTensor.FibonacciBoundary.periodicRank,
-      MPSTensor.FibonacciBoundary.periodicRank_one,
-      MPSTensor.FibonacciBoundary.periodicRank_two,
-      MPSTensor.FibonacciBoundary.periodicRank_not_geometric}
+\begin{definition}[Periodic Fibonacci transition count]
+    \label{def:cpsv_fibonacci_periodic_count}
+    \lean{MPSTensor.FibonacciBoundary.periodicTransitionCount}
     \leanok
-    \uses{thm:cpsv_fibonacci_boundary_recurrence}
-    Closing the boundary labels gives
-    $a_N=x^N_{00}+x^N_{11}=\tr(B^N)$.  In particular $a_1=3$ and $a_2=7$,
-    and there are no $r,s\in\N$ such that $a_N=rs^{N-1}$ for every $N>0$.
+    \uses{def:cpsv_fibonacci_boundary_counts}
+    Closing the two boundary labels gives the transition count
+    \begin{align}
+        a_N&=x^N_{00}+x^N_{11}=\tr(B^N).
+        \notag
+    \end{align}
+    The source identifies this number with the periodic operator rank at
+    \cite[Appendix~D, line~2157]{Cirac2016MPDO_arXiv}; that identification is
+    retained separately below.
+\end{definition}
+
+\begin{theorem}[First periodic Fibonacci transition counts]
+    \label{thm:cpsv_fibonacci_periodic_count_values}
+    \lean{MPSTensor.FibonacciBoundary.periodicTransitionCount_one,
+      MPSTensor.FibonacciBoundary.periodicTransitionCount_two}
+    \leanok
+    \uses{def:cpsv_fibonacci_periodic_count,
+      thm:cpsv_fibonacci_boundary_recurrence}
+    The first two periodic transition counts are $a_1=3$ and $a_2=7$.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:cpsv_fibonacci_boundary_recurrence}
-    If $a_N=rs^{N-1}$, then $r=a_1=3$ and $7=a_2=3s$, which is impossible
+    Substitute $x^1=(1,1,1,2)$ into the recurrence once and close the two
+    diagonal boundary labels.
+\end{proof}
+
+\begin{theorem}[Periodic Fibonacci transition counts are not geometric]
+    \label{thm:cpsv_fibonacci_transition_not_geometric}
+    \lean{MPSTensor.FibonacciBoundary.periodicTransitionCount_not_geometric}
+    \leanok
+    \uses{def:cpsv_fibonacci_periodic_count,
+      thm:cpsv_fibonacci_periodic_count_values}
+    There are no $r,s\in\N$ such that $a_N=rs^{N-1}$ for every $N>0$.
+    This is the non-geometricity assertion at
+    \cite[Appendix~D, line~2125]{Cirac2016MPDO_arXiv} for the transition-count
+    sequence.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_fibonacci_periodic_count_values}
+    Such a formula would give $r=a_1=3$ and $7=a_2=3s$, which is impossible
     in $\N$.
 \end{proof}
 
-\begin{theorem}[Fibonacci MPO rank formula]
+\begin{theorem}[Open-boundary Fibonacci operator ranks]
+    \label{thm:cpsv_fibonacci_open_boundary_rank_status}
+    \notready
+    \uses{def:cpsv_fibonacci_support_tensor,
+      def:cpsv_fibonacci_boundary_counts,
+      thm:to_mpo_diagonal_rank}
+    For $n>0$ and $\alpha,\beta\in\{0,1\}$, let
+    $\rho^{(n)}_{\alpha\beta}(A)$ be the diagonal open-boundary operator whose
+    coefficient at a physical word is
+    $(\alpha|A^{i_1j_1k_1}\cdots A^{i_nj_nk_n}|\beta)$.  Prove
+    \begin{align}
+        x^n_{\alpha\beta}
+        &=\operatorname{rank}\rho^{(n)}_{\alpha\beta}(A).
+        \notag
+    \end{align}
+    This is \cite[Appendix~D, lines~2127--2130]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{theorem}[Fibonacci periodic operator-rank formula]
     \label{thm:cpsv_fibonacci_rank_obstruction_status}
     \notready
     \uses{def:cpsv_fibonacci_support_tensor,
-      thm:cpsv_fibonacci_boundary_recurrence,
-      thm:cpsv_fibonacci_transition_not_geometric}
-    For the tensor in Definition~\ref{def:cpsv_fibonacci_support_tensor} and
-    every $N>0$, identify the transition count with the operator rank and prove
+      def:cpsv_fibonacci_periodic_count,
+      thm:cpsv_fibonacci_open_boundary_rank_status,
+      thm:to_mpo_diagonal_rank}
+    Set $\tau_\pm=(1\pm\sqrt5)/2$, as in
+    \cite[Appendix~D, line~2125]{Cirac2016MPDO_arXiv}.  For every $N>0$, prove
     \begin{align}
         \operatorname{rank}\rho^{(N)}(A)
         &=x^N_{00}+x^N_{11}
-         =\tau_+^{2N}+\tau_-^{2N},&
-        \tau_\pm&=\frac{1\pm\sqrt5}{2}.
+         =\tau_+^{2N}+\tau_-^{2N}.
         \notag
     \end{align}
-    This is \cite[Appendix~D, lines~2136--2176]{Cirac2016MPDO_arXiv}.
-    The structural relation in Definition~\ref{def:mpdo_strong_rfp} gives the
-    algebraic meaning of the source diagram; this theorem concerns only the
-    concrete Fibonacci rank sequence.
+    This is \cite[Appendix~D, lines~2122--2125 and
+    2157--2176]{Cirac2016MPDO_arXiv}.
+\end{theorem}
 
+\begin{theorem}[Fibonacci periodic operator ranks are not geometric]
+    \label{thm:cpsv_fibonacci_operator_rank_not_geometric_status}
+    \notready
+    \uses{thm:cpsv_fibonacci_rank_obstruction_status,
+      thm:cpsv_fibonacci_transition_not_geometric}
+    For the concrete Fibonacci tensor, there are no $r,s\in\N$ such that
+    \begin{align}
+        \operatorname{rank}\rho^{(N)}(A)&=rs^{N-1}
+        \notag
+    \end{align}
+    for every $N>0$.  This is the operator-level conclusion in
+    \cite[Appendix~D, line~2125]{Cirac2016MPDO_arXiv}.  The structural strong
+    fixed-point relation itself is Definition~\ref{def:mpdo_strong_rfp}; its
+    general geometric-rank consequence is a separate statement.
 \end{theorem}
 
 \begin{definition}[Initial-coordinate regroupings]
@@ -986,7 +1070,7 @@ the remaining sites unchanged.
       MPSTensor.mpo_toMPOTensor,
       MPSTensor.rank_mpo_toMPOTensor}
     \leanok
-    \uses{def:to_mpo_tensor, def:mpo_family}
+    \uses{def:to_mpo_tensor, def:mpo_family, def:mpv}
     For every $N$, the embedded MPO is diagonal with diagonal
     $V^{(N)}(A)$, and hence
     \begin{align}
@@ -1000,7 +1084,7 @@ the remaining sites unchanged.
 
 \begin{proof}
     \leanok
-    \uses{def:to_mpo_tensor, def:mpo_family}
+    \uses{def:to_mpo_tensor, def:mpo_family, def:mpv}
     A ket--bra word evaluation vanishes at the first unequal pair of physical
     labels.  Equal words recover the original MPS word evaluation.  The rank
     formula follows by counting the nonzero entries of a diagonal matrix.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -711,47 +711,107 @@ the remaining sites unchanged.
     $\E_A^2=\E_A$. The physical-isometry formulation follows from
     Theorem~\ref{thm:physical_blocking_isometry_iff_transfer_idempotence}.
 \end{proof}
-% CPSV16 Appendix D (`Strong-RFP`, `rank-Fibonacci`, and `eq:1`),
-% lines 2109--2176.  The final label names an internal diagonalization step.
-% Tracking: issue #5921.
-\begin{theorem}[Fibonacci rank obstruction cited against strong fixed points]
-    \label{thm:cpsv_fibonacci_rank_obstruction_status}
-    \notready
-    \uses{def:mpo_family}
-    Let $A$ be the vacuum-sector boundary tensor described in
-    \cite[Appendix~D, lines~2118--2176]{Cirac2016MPDO_arXiv}.  Its bond
-    indices $\alpha,\beta$ and its three physical indices $i,j,k$ lie in
-    $\{0,1\}$, and its components are
+% CPSV16 Appendix D, lines 2116--2176.  The paper's label `eq:1` is an
+% internal calculation.  Issue #5921 retains the missing identification of the
+% transition counts with the ranks of the concrete MPO.
+\begin{definition}[Fibonacci vacuum-sector support tensor]
+    \label{def:cpsv_fibonacci_support_tensor}
+    \lean{MPSTensor.FibonacciBoundary.ExactlyTwoZero,
+      MPSTensor.FibonacciBoundary.FusionWeights,
+      MPSTensor.FibonacciBoundary.canonicalFusionWeights,
+      MPSTensor.FibonacciBoundary.physicalTriple,
+      MPSTensor.FibonacciBoundary.tensor,
+      MPSTensor.FibonacciBoundary.canonicalTensor}
+    \leanok
+    \uses{def:mps_tensor}
+    This is the concrete tensor in
+    \cite[Appendix~D, lines~2118--2135]{Cirac2016MPDO_arXiv}.  Its physical
+    labels are triples $i,j,k\in\{0,1\}$ and its virtual labels are
+    $\alpha,\beta\in\{0,1\}$.  Choose weights $N_{ijk}$ satisfying
     \begin{align}
-        A^{ijk}_{\alpha,\beta}
-        &=\delta_{i,\alpha}\delta_{k,\beta}N_{ijk},
+        N_{ijk}=0&\iff
+        (i,j,k)\in\{(0,0,1),(0,1,0),(1,0,0)\},
+        \label{eq:cpsv_fib_support}\\
+        N_{ijk}&>0 &&\text{otherwise}.
         \notag
     \end{align}
-    where $N_{ijk}=0$ if and only if exactly two of $i,j,k$ are zero, and
-    $N_{ijk}>0$ otherwise.  Set
+    Then
     \begin{align}
+        A^{ijk}_{\alpha\beta}
+        &=\delta_{i,\alpha}\delta_{k,\beta}N_{ijk}.
+        \notag
+    \end{align}
+    The canonical support tensor takes every nonzero $N_{ijk}$ to be one.
+\end{definition}
+
+\begin{theorem}[Fibonacci open-boundary transition recurrence]
+    \label{thm:cpsv_fibonacci_boundary_recurrence}
+    \lean{MPSTensor.FibonacciBoundary.B,
+      MPSTensor.FibonacciBoundary.x,
+      MPSTensor.FibonacciBoundary.x_one,
+      MPSTensor.FibonacciBoundary.x_succ}
+    \leanok
+    Let
+    \begin{align}
+        B&=\begin{pmatrix}1&1\\1&2\end{pmatrix},&
+        x^n_{\alpha\beta}&=(B^n)_{\alpha\beta}.
+        \label{eq:cpsv_fib_recurrence}
+    \end{align}
+    Then $x^1=(1,1,1,2)$ in the order $(00,01,10,11)$, and
+    \begin{align}
+        x^{n+1}_{\alpha0}&=x^n_{\alpha0}+x^n_{\alpha1},&
+        x^{n+1}_{\alpha1}&=x^n_{\alpha0}+2x^n_{\alpha1}.
+        \notag
+    \end{align}
+    These are the transition counts appearing in
+    \cite[Appendix~D, lines~2139--2164]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Multiply the row indexed by $\alpha$ in $B^n$ by the two columns of $B$.
+\end{proof}
+
+\begin{theorem}[First periodic Fibonacci transition counts are not geometric]
+    \label{thm:cpsv_fibonacci_transition_not_geometric}
+    \lean{MPSTensor.FibonacciBoundary.periodicRank,
+      MPSTensor.FibonacciBoundary.periodicRank_one,
+      MPSTensor.FibonacciBoundary.periodicRank_two,
+      MPSTensor.FibonacciBoundary.periodicRank_not_geometric}
+    \leanok
+    \uses{thm:cpsv_fibonacci_boundary_recurrence}
+    Closing the boundary labels gives
+    $a_N=x^N_{00}+x^N_{11}=\tr(B^N)$.  In particular $a_1=3$ and $a_2=7$,
+    and there are no $r,s\in\N$ such that $a_N=rs^{N-1}$ for every $N>0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_fibonacci_boundary_recurrence}
+    If $a_N=rs^{N-1}$, then $r=a_1=3$ and $7=a_2=3s$, which is impossible
+    in $\N$.
+\end{proof}
+
+\begin{theorem}[Fibonacci MPO rank formula]
+    \label{thm:cpsv_fibonacci_rank_obstruction_status}
+    \notready
+    \uses{def:cpsv_fibonacci_support_tensor,
+      thm:cpsv_fibonacci_boundary_recurrence,
+      thm:cpsv_fibonacci_transition_not_geometric}
+    For the tensor in Definition~\ref{def:cpsv_fibonacci_support_tensor} and
+    every $N>0$, identify the transition count with the operator rank and prove
+    \begin{align}
+        \operatorname{rank}\rho^{(N)}(A)
+        &=x^N_{00}+x^N_{11}
+         =\tau_+^{2N}+\tau_-^{2N},&
         \tau_\pm&=\frac{1\pm\sqrt5}{2}.
         \notag
     \end{align}
-    For every $N>0$,
-    \begin{align}
-        \operatorname{rank}\rho^{(N)}(A)
-        &=\tau_+^{2N}+\tau_-^{2N}.
-        \notag
-    \end{align}
-    This sequence is not geometric: there do not exist natural numbers $r,s$
-    such that
-    \begin{align}
-        \operatorname{rank}\rho^{(N)}(A)&=rs^{N-1}
-        \notag
-    \end{align}
-    for every $N>0$.  The first two ranks are $3$ and $7$, which already
-    exclude such $r$ and $s$.  The structural relation in
-    Definition~\ref{def:mpdo_strong_rfp} gives the algebraic meaning of the
-    diagram labelled ``Strong-RFP''.  This theorem concerns only the Fibonacci
-    rank sequence and makes no assertion about periodic rank growth for a
-    general tensor satisfying Definition~\ref{def:mpdo_strong_rfp}.
-    % Tracked by issue #6047.
+    This is \cite[Appendix~D, lines~2136--2176]{Cirac2016MPDO_arXiv}.
+    The structural relation in Definition~\ref{def:mpdo_strong_rfp} gives the
+    algebraic meaning of the source diagram; this theorem concerns only the
+    concrete Fibonacci rank sequence.
+
 \end{theorem}
 
 \begin{definition}[Initial-coordinate regroupings]
@@ -919,6 +979,32 @@ the remaining sites unchanged.
     \end{align}
     Equivalently, $M^{ii}=A^i$ and $M^{ij}=0$ for $i\ne j$.
 \end{definition}
+
+\begin{theorem}[Operator and rank of the diagonal pure-state embedding]
+    \label{thm:to_mpo_diagonal_rank}
+    \lean{MPSTensor.evalWord_toMPOTensor,
+      MPSTensor.mpo_toMPOTensor,
+      MPSTensor.rank_mpo_toMPOTensor}
+    \leanok
+    \uses{def:to_mpo_tensor, def:mpo_family}
+    For every $N$, the embedded MPO is diagonal with diagonal
+    $V^{(N)}(A)$, and hence
+    \begin{align}
+        \rho^{(N)}(A^{\mathrm{MPO}})
+        &=\operatorname{diag}V^{(N)}(A),&
+        \operatorname{rank}\rho^{(N)}(A^{\mathrm{MPO}})
+        &=\#\{\sigma:V^{(N)}(A)_\sigma\ne0\}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:to_mpo_tensor, def:mpo_family}
+    A ket--bra word evaluation vanishes at the first unequal pair of physical
+    labels.  Equal words recover the original MPS word evaluation.  The rank
+    formula follows by counting the nonzero entries of a diagonal matrix.
+\end{proof}
 
 \begin{theorem}[Transfer map of the diagonal pure-state embedding]%
     \label{thm:to_mpo_transfer_map}


### PR DESCRIPTION
## Summary

Advances #5921 with a dependency-closed, source-faithful first slice of the CPSV16 Appendix D Fibonacci calculation.

- defines parameterized positive fusion weights `N_{ijk}` with exactly the paper's zero support and a canonical 0/1 instance
- defines the concrete tensor `A^{ijk}_{αβ} = δ_{i,α} δ_{k,β} N_{ijk}`
- formalizes `B = [[1,1],[1,2]]`, the four `x^n_{αβ}` transition counts, their recurrence, and periodic closure
- proves the first periodic counts are 3 and 7 and cannot have geometric growth `r s^(N-1)`
- adds generic diagonal-embedding identities `mpo A.toMPOTensor = diagonal (mpv A)` and the corresponding `Matrix.rank_diagonal` corollary
- splits the Blueprint into formula-driven tensor, recurrence, obstruction, and remaining-rank nodes with exact CPSV16 Appendix D citations

## Deliberately remaining in #5921

This PR does **not** claim the full source rank formula. The remaining Blueprint node explicitly retains:

1. the bridge identifying the concrete MPO/open-boundary operator ranks with the transition counts, and
2. the natural Fibonacci / golden-ratio equality `τ₊^(2N) + τ₋^(2N)`.

It also leaves the diagrammatic `Strong-RFP` predicate outside this PR, as required. The source label `eq:1` remains an internal calculation rather than a separate theorem.

## Verification

- `lake env lean TNLean/MPS/MPDO/PureRecovery.lean`
- `lake env lean TNLean/MPS/MPDO/FibonacciBoundaryRank.lean`
- `lake build TNLean.MPS.MPDO.FibonacciBoundaryRank`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Blueprint forward/reverse synchronization after refreshing `blueprint/lean_decls`: clean
- Blueprint web generation completed; full `checkdecls` then stopped because the isolated targeted build intentionally did not produce the root `TNLean.olean`
- `git diff --check`

No `sorry`, axioms, unsafe declarations, or `native_decide`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs and blueprint sync only; no auth, runtime, or API surface changes. Remaining rank claims are deliberately left not-ready.
> 
> **Overview**
> Adds a **first CPSV16 Appendix D slice** for the Fibonacci vacuum-sector calculation: fusion weights and support tensor, transition matrix `B`, boundary counts `x^n_{αβ}`, recurrence, periodic closure `a_N`, and proofs that `a_1=3`, `a_2=7`, and the sequence is **not** geometric `r s^{N-1}`. Operator-rank identifications and the golden-ratio formula stay explicitly **out of scope** (issue #5921).
> 
> In **PureRecovery**, new lemmas show the diagonal pure-state embedding gives a **diagonal periodic MPO** with entries `mpv A`, and rank equals the count of nonzero MPV coefficients—intended as infrastructure for later rank bridges.
> 
> The **blueprint** replaces a single not-ready obstruction theorem with linked definitions/theorems for the tensor, recurrence, transition non-geometricity, plus separate not-ready nodes for open-boundary and periodic operator ranks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c44ab786e1385b2427422cfcfc5b3952b34d594d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->