### PR TITLE
feat(MPS/MPU): define fixed-bond tensor equivalence

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -13,6 +13,7 @@ import TNLean.MPS.MPU.Basic
 import TNLean.MPS.MPU.BlockingRanks
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.DoubleLayerContraction
+import TNLean.MPS.MPU.Equivalence
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.PhysicalAncilla
 import TNLean.MPS.MPU.ResidualAlgebra

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -14,6 +14,7 @@ import TNLean.MPS.MPU.BlockingRanks
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.Equivalence
+import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.PhysicalAncilla
 import TNLean.MPS.MPU.ResidualAlgebra

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -33,7 +33,7 @@ variable {da db D : ℕ}
 after explicitly identifying their physical dimensions, they are joined by a
 continuous path all of whose points generate MPUs.
 
-Canonical form is required only at the endpoints. The bond dimension `D` is
+Canonical form is required only at the endpoints. The bond dimension \(D\) is
 fixed throughout.
 
 **Scope restriction (arXiv:1703.09188, lines 706--724):** the paper does not
@@ -57,16 +57,16 @@ private theorem blockedAncillaPhysicalDim_eq (k : ℕ) {pa pb : ℕ}
   rw [Nat.mul_comm da pa, Nat.mul_comm db pb, hphys]
 
 /-- Two fixed-bond MPU tensors are equivalent when positive coprime ancilla
-sizes `pa` and `pb` make their enlarged physical dimensions equal and, after
-attaching those ancillas, a common positive blocking length makes the resulting
-tensors strictly equivalent.
+sizes \(p_a\) and \(p_b\) make their enlarged physical dimensions equal and,
+after attaching those ancillas, a common positive blocking length makes the
+resulting tensors strictly equivalent.
 
 Ancillas are attached before blocking. The physical-size condition is the source
-equation `pa * da = pb * db`; it supplies the explicit reindexing witness needed
-by `StrictlyEquivalent` after blocking.
+equation \(p_a d_a = p_b d_b\); it supplies the explicit reindexing witness
+needed by `StrictlyEquivalent` after blocking.
 
-**Scope restriction (arXiv:1703.09188, lines 706--724):** the bond dimension `D`
-is fixed. No heterogeneous raw-bond stabilization is asserted. See
+**Scope restriction (arXiv:1703.09188, lines 706--724):** the bond dimension
+\(D\) is fixed. No heterogeneous raw-bond stabilization is asserted. See
 `docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
 
 Source: arXiv:1703.09188, Definition `def:equivalent-tensors`, lines 716--724. -/

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Topology.Connected.PathConnected
+import TNLean.MPS.MPU.PhysicalAncilla
+
+/-!
+# Equivalence of matrix product unitary tensors
+
+This file formalizes strict equivalence and equivalence after attaching physical
+identity ancillas and then blocking, following arXiv:1703.09188, lines 706--724.
+
+The virtual bond dimension is fixed along every path. The source does not specify
+a stabilization that compares tensors of different virtual bond dimensions, so
+no such relation is introduced here. Strict paths remain inside the MPU locus;
+only the canonical-form condition from the paper is omitted along the path.
+
+## Main definitions
+
+* `MPOTensor.StrictlyEquivalent`: path connectedness inside the fixed-bond MPU locus.
+* `MPOTensor.Equivalent`: strict equivalence after positive identity-ancilla
+  attachment and a common positive blocking length.
+-/
+
+namespace MPOTensor
+
+variable {da db D : ℕ}
+
+/-- Two fixed-bond MPU tensors are strictly equivalent when, after explicitly
+identifying their physical dimensions, they are joined by a continuous path all
+of whose points generate MPUs.
+
+The path is not required to remain in canonical form. The bond dimension `D` is
+fixed throughout.
+
+**Scope restriction (arXiv:1703.09188, lines 706--724):** the paper does not
+specify a stabilization for unequal raw virtual bond dimensions, so this
+definition only compares tensors in one fixed ambient bond dimension.
+
+Source: arXiv:1703.09188, Definition `def:strictly-equivalent-tensors`,
+lines 708--714. -/
+def StrictlyEquivalent (U : MPOTensor da D) (V : MPOTensor db D)
+    (hphys : da = db) : Prop :=
+  JoinedIn {W : MPOTensor db D | IsMPU W}
+    (reindexPhysical (finCongr hphys).symm U) V
+
+private theorem blockedAncillaPhysicalDim_eq (k : ℕ) {pa pb : ℕ}
+    (hphys : pa * da = pb * db) :
+    MPSTensor.blockPhysDim (da * pa) k = MPSTensor.blockPhysDim (db * pb) k := by
+  simp only [MPSTensor.blockPhysDim_eq_pow]
+  rw [Nat.mul_comm da pa, Nat.mul_comm db pb, hphys]
+
+/-- Two fixed-bond MPU tensors are equivalent when positive coprime ancilla
+sizes `pa` and `pb` make their enlarged physical dimensions equal and, after
+attaching those ancillas, a common positive blocking length makes the resulting
+tensors strictly equivalent.
+
+Ancillas are attached before blocking. The physical-size condition is the source
+equation `pa * da = pb * db`; it supplies the explicit reindexing witness needed
+by `StrictlyEquivalent` after blocking.
+
+**Scope restriction (arXiv:1703.09188, lines 706--724):** the bond dimension `D`
+is fixed. No heterogeneous raw-bond stabilization is asserted.
+
+Source: arXiv:1703.09188, Definition `def:equivalent-tensors`, lines 716--724. -/
+def Equivalent (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=
+  ∃ k pa pb : ℕ,
+    0 < k ∧ 0 < pa ∧ 0 < pb ∧ Nat.Coprime pa pb ∧
+      ∃ hphys : pa * da = pb * db,
+        StrictlyEquivalent
+          (blockTensor (tensorPhysicalId U pa) k)
+          (blockTensor (tensorPhysicalId V pb) k)
+          (blockedAncillaPhysicalDim_eq k hphys)
+
+end MPOTensor

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Topology.Connected.PathConnected
+import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.MPU.PhysicalAncilla
 
 /-!
@@ -28,23 +29,26 @@ namespace MPOTensor
 
 variable {da db D : ℕ}
 
-/-- Two fixed-bond MPU tensors are strictly equivalent when, after explicitly
-identifying their physical dimensions, they are joined by a continuous path all
-of whose points generate MPUs.
+/-- Two fixed-bond MPU tensors in canonical form are strictly equivalent when,
+after explicitly identifying their physical dimensions, they are joined by a
+continuous path all of whose points generate MPUs.
 
-The path is not required to remain in canonical form. The bond dimension `D` is
+Canonical form is required only at the endpoints. The bond dimension `D` is
 fixed throughout.
 
 **Scope restriction (arXiv:1703.09188, lines 706--724):** the paper does not
 specify a stabilization for unequal raw virtual bond dimensions, so this
-definition only compares tensors in one fixed ambient bond dimension.
+definition only compares tensors in one fixed ambient bond dimension. See
+`docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
 
 Source: arXiv:1703.09188, Definition `def:strictly-equivalent-tensors`,
 lines 708--714. -/
 def StrictlyEquivalent (U : MPOTensor da D) (V : MPOTensor db D)
     (hphys : da = db) : Prop :=
-  JoinedIn {W : MPOTensor db D | IsMPU W}
-    (reindexPhysical (finCongr hphys).symm U) V
+  MPSTensor.IsCPSVCanonicalForm U.toMPSTensor ∧
+    MPSTensor.IsCPSVCanonicalForm V.toMPSTensor ∧
+      JoinedIn {W : MPOTensor db D | IsMPU W}
+        (reindexPhysical (finCongr hphys).symm U) V
 
 private theorem blockedAncillaPhysicalDim_eq (k : ℕ) {pa pb : ℕ}
     (hphys : pa * da = pb * db) :
@@ -62,7 +66,8 @@ equation `pa * da = pb * db`; it supplies the explicit reindexing witness needed
 by `StrictlyEquivalent` after blocking.
 
 **Scope restriction (arXiv:1703.09188, lines 706--724):** the bond dimension `D`
-is fixed. No heterogeneous raw-bond stabilization is asserted.
+is fixed. No heterogeneous raw-bond stabilization is asserted. See
+`docs/paper-gaps/mpu_equivalence_fixed_bond.tex`.
 
 Source: arXiv:1703.09188, Definition `def:equivalent-tensors`, lines 716--724. -/
 def Equivalent (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -71,12 +71,13 @@ is fixed. No heterogeneous raw-bond stabilization is asserted. See
 
 Source: arXiv:1703.09188, Definition `def:equivalent-tensors`, lines 716--724. -/
 def Equivalent (U : MPOTensor da D) (V : MPOTensor db D) : Prop :=
-  ∃ k pa pb : ℕ,
-    0 < k ∧ 0 < pa ∧ 0 < pb ∧ Nat.Coprime pa pb ∧
-      ∃ hphys : pa * da = pb * db,
-        StrictlyEquivalent
-          (blockTensor (tensorPhysicalId U pa) k)
-          (blockTensor (tensorPhysicalId V pb) k)
-          (blockedAncillaPhysicalDim_eq k hphys)
+  IsMPU U ∧ IsMPU V ∧
+    ∃ k pa pb : ℕ,
+      0 < k ∧ 0 < pa ∧ 0 < pb ∧ Nat.Coprime pa pb ∧
+        ∃ hphys : pa * da = pb * db,
+          StrictlyEquivalent
+            (blockTensor (tensorPhysicalId U pa) k)
+            (blockTensor (tensorPhysicalId V pb) k)
+            (blockedAncillaPhysicalDim_eq k hphys)
 
 end MPOTensor

--- a/TNLean/MPS/MPU/Equivalence.lean
+++ b/TNLean/MPS/MPU/Equivalence.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Topology.Connected.PathConnected
-import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.PhysicalAncilla
 
 /-!
@@ -45,8 +45,8 @@ Source: arXiv:1703.09188, Definition `def:strictly-equivalent-tensors`,
 lines 708--714. -/
 def StrictlyEquivalent (U : MPOTensor da D) (V : MPOTensor db D)
     (hphys : da = db) : Prop :=
-  MPSTensor.IsCPSVCanonicalForm U.toMPSTensor ∧
-    MPSTensor.IsCPSVCanonicalForm V.toMPSTensor ∧
+  MPSTensor.IsMPUCanonicalForm U.toMPSTensor ∧
+    MPSTensor.IsMPUCanonicalForm V.toMPSTensor ∧
       JoinedIn {W : MPOTensor db D | IsMPU W}
         (reindexPhysical (finCongr hphys).symm U) V
 

--- a/TNLean/MPS/MPU/MPUCanonicalForm.lean
+++ b/TNLean/MPS/MPU/MPUCanonicalForm.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.Definitions
+
+/-!
+# Canonical form for matrix product unitaries
+
+This file records the canonical form used by arXiv:1703.09188, lines 259--267.
+Unlike the stronger CPSV normal-block canonical form, it permits irreducible
+periodic blocks. The existing coisometric retained-block reconstruction supplies
+the ambient zero-coordinate convention.
+
+## Main definitions
+
+* `MPSTensor.IsMPUCanonicalBlock`: irreducibility and transfer spectral radius one.
+* `MPSTensor.MPUCanonicalFormData`: a weighted retained-block reconstruction.
+* `MPSTensor.IsMPUCanonicalForm`: existence of such reconstruction data.
+-/
+
+open scoped Matrix BigOperators Matrix.Norms.Operator ComplexOrder MatrixOrder
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A canonical block for an MPU endpoint is irreducible and has transfer
+spectral radius one. Peripheral eigenvalues other than one are allowed.
+
+Source: arXiv:1703.09188, lines 259--267. -/
+structure IsMPUCanonicalBlock (A : MPSTensor d D) : Prop where
+  /-- The block admits no nontrivial invariant orthogonal projection. -/
+  irreducible : IsIrreducibleTensor A
+  /-- The block transfer map has spectral radius one. -/
+  spectral_radius_one :
+    spectralRadius ℂ
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+        (transferMap (d := d) (D := D) A)) = 1
+
+/-- Witness data for the MPU canonical form, using irreducible
+spectral-radius-one blocks and an exact coisometric retained-block
+reconstruction in the ambient bond space.
+
+Source: arXiv:1703.09188, lines 259--267. -/
+structure MPUCanonicalFormData (A : MPSTensor d D) where
+  /-- Number of retained canonical blocks. -/
+  r : ℕ
+  /-- Bond dimension of each retained block. -/
+  dim : Fin r → ℕ
+  /-- Every retained block has positive bond dimension. -/
+  dim_pos : ∀ k, 0 < dim k
+  /-- Scalar weight of each retained block. -/
+  weights : Fin r → ℂ
+  /-- Retained canonical blocks. -/
+  blocks : (k : Fin r) → MPSTensor d (dim k)
+  /-- Every retained block is irreducible and has transfer spectral radius one. -/
+  blocks_canonical : ∀ k, IsMPUCanonicalBlock (blocks k)
+  /-- The retained direct sum fits inside the original bond space. -/
+  total_dim_le : ∑ k : Fin r, dim k ≤ D
+  /-- Coisometric inclusion of the retained coordinates into the ambient bond space. -/
+  ambient_coisometry : Matrix (Fin (∑ k : Fin r, dim k)) (Fin D) ℂ
+  /-- The retained coordinates embed coisometrically. -/
+  coisometric : ambient_coisometry * ambient_coisometryᴴ = 1
+  /-- Exact reconstruction from the weighted retained blocks. -/
+  reconstruct : ∀ i,
+    A i = ambient_coisometryᴴ * toTensorFromBlocks (d := d) weights blocks i *
+      ambient_coisometry
+
+/-- An MPS tensor is in MPU canonical form when it has an exact retained-block
+reconstruction whose blocks are irreducible and transfer-normalized.
+
+Source: arXiv:1703.09188, lines 259--267. -/
+def IsMPUCanonicalForm (A : MPSTensor d D) : Prop :=
+  Nonempty (MPUCanonicalFormData A)
+
+namespace CPSVCanonicalFormData
+
+/-- The stronger CPSV normal-block data gives MPU canonical-form data by
+forgetting peripheral-spectrum uniqueness and retaining the reconstruction.
+
+There is intentionally no converse: MPU canonical blocks may be periodic.
+
+Source: arXiv:1703.09188, lines 259--267. -/
+def toMPUCanonicalFormData {A : MPSTensor d D} (data : CPSVCanonicalFormData A) :
+    MPUCanonicalFormData A where
+  r := data.r
+  dim := data.dim
+  dim_pos := data.dim_pos
+  weights := data.weights
+  blocks := data.blocks
+  blocks_canonical := fun k ↦
+    ⟨(data.blocks_normal k).no_invariant_proj,
+      (data.blocks_normal k).spectral_radius_one⟩
+  total_dim_le := data.total_dim_le
+  ambient_coisometry := data.ambient_coisometry
+  coisometric := data.coisometric
+  reconstruct := data.reconstruct
+
+end CPSVCanonicalFormData
+
+namespace IsCPSVCanonicalForm
+
+/-- The CPSV normal-block canonical form implies the weaker MPU canonical form.
+No converse is asserted because the MPU predicate permits periodic blocks.
+
+Source: arXiv:1703.09188, lines 259--267. -/
+theorem toIsMPUCanonicalForm {A : MPSTensor d D} (hA : IsCPSVCanonicalForm A) :
+    IsMPUCanonicalForm A := by
+  obtain ⟨data⟩ := hA
+  exact ⟨data.toMPUCanonicalFormData⟩
+
+end IsCPSVCanonicalForm
+
+end MPSTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3259,9 +3259,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{def:equivalent-tensors}
   \lean{MPOTensor.Equivalent}
   \leanok
-  \uses{def:strictly-equivalent-tensors,lem:mpu_blocking}
-  Fix a virtual bond dimension $D$. Let $\mathcal U$ and $\mathcal V$ have
-  physical dimensions $d_a$ and $d_b$. They are equivalent if there are a
+  \uses{def:mpu,def:strictly-equivalent-tensors,lem:mpu_blocking}
+  Fix a virtual bond dimension $D$. Let $\mathcal U$ and $\mathcal V$ be MPU
+  tensors with physical dimensions $d_a$ and $d_b$. They are equivalent if
+  there are a
   positive blocking length $k$ and coprime positive integers $p_a,p_b$ with
   \begin{align}
     p_a d_a&=p_b d_b

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3238,7 +3238,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{def:strictly-equivalent-tensors}
   \lean{MPOTensor.StrictlyEquivalent}
   \leanok
-  \uses{def:mpu,def:cpsv_canonical_form}
+  \uses{def:mpu,def:mpu_physical_reindexing,def:cpsv_canonical_form}
   Fix a virtual bond dimension $D$. Let $\mathcal U$ and $\mathcal V$ be
   canonical-form MPU tensors with physical dimensions $d_a$ and $d_b$. Given
   an equality $h\colon d_a=d_b$, reindex $\mathcal U$ from $d_a$ to $d_b$

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -166,6 +166,47 @@ closing a chain of $N$ copies of $\mathcal U$.
     unitary.  Simultaneous reindexing preserves unitarity.
 \end{proof}
 
+\begin{definition}[Strict equivalence of matrix product unitary tensors]
+    \label{def:strictly-equivalent-tensors}
+    \lean{MPOTensor.StrictlyEquivalent}
+    \leanok
+    \uses{def:mpu}
+    Fix a virtual bond dimension $D$.  Let $\mathcal U$ and $\mathcal V$ be in
+    canonical form, with physical dimensions $d_a$ and $d_b$, respectively,
+    and let $h\colon d_a=d_b$ identify their physical indices.  They are
+    strictly equivalent if the tensor obtained from $\mathcal U$ by this
+    reindexing and $\mathcal V$ are joined by a continuous path
+    $\mathcal W(t)$ such that $\mathcal W(t)$ generates matrix product
+    unitaries for every $t\in[0,1]$.  The path need not remain in canonical
+    form.
+
+    The bond dimension is the same $D$ at both endpoints and along the path.
+    This is the fixed-bond case of
+    \cite[Definition~\texttt{def:strictly-equivalent-tensors}]{Cirac2017MPU};
+    no relation between unequal raw bond dimensions is imposed.
+\end{definition}
+
+\begin{definition}[Equivalence after ancilla attachment and blocking]
+    \label{def:equivalent-tensors}
+    \lean{MPOTensor.Equivalent}
+    \leanok
+    \uses{def:strictly-equivalent-tensors}
+    Fix a virtual bond dimension $D$.  Tensors $\mathcal U$ and $\mathcal V$
+    of physical dimensions $d_a$ and $d_b$ are equivalent if there are
+    positive integers $k,p_a,p_b$, with $p_a$ and $p_b$ coprime, such that
+    \begin{align}
+        p_a d_a &= p_b d_b
+    \end{align}
+    and the tensors obtained by first attaching physical identity ancillas of
+    dimensions $p_a$ and $p_b$, respectively, and then blocking the same $k$
+    sites are strictly equivalent.  Thus the compared tensors are
+    $\bigl(\mathcal U\otimes\Id_{p_a}\bigr)^{[k]}$ and
+    $\bigl(\mathcal V\otimes\Id_{p_b}\bigr)^{[k]}$.
+
+    This is \cite[Definition~\texttt{def:equivalent-tensors}]{Cirac2017MPU}
+    with one fixed ambient bond dimension $D$.  The definition does not add a
+    stabilization relation for unequal raw bond dimensions.
+\end{definition}
 
 \section{Simple matrix product unitary tensors}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3240,7 +3240,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     MPSTensor.MPUCanonicalFormData,
     MPSTensor.IsMPUCanonicalForm}
   \leanok
-  \uses{def:transfer_map}
+  \uses{def:transfer_map,def:block_diagonal_tensor}
   A tensor $A$ of physical dimension $d$ and bond dimension $D$ is in MPU
   canonical form if there are positive block dimensions $D_k$, weights
   $\mu_k\in\mathbb C$, tensors $A_k$ of bond dimension $D_k$, and a
@@ -3248,11 +3248,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \begin{align}
     C\colon\mathbb C^D&\longrightarrow
       \bigoplus_{k=1}^r\mathbb C^{D_k},&
-    CC^*&=\Id,
+    CC^\dagger&=\Id,
   \end{align}
   such that
   \begin{align}
-    A^i=C^*\left(\bigoplus_{k=1}^r\mu_k A_k^i\right)C.
+    A^i=C^\dagger\left(\bigoplus_{k=1}^r\mu_k A_k^i\right)C.
   \end{align}
   Every $A_k$ is irreducible and the spectral radius of its transfer map is
   one. The blocks may be periodic, so no uniqueness condition is imposed on

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -166,49 +166,6 @@ closing a chain of $N$ copies of $\mathcal U$.
     unitary.  Simultaneous reindexing preserves unitarity.
 \end{proof}
 
-\begin{definition}[Strict equivalence of matrix product unitary tensors]
-    \label{def:strictly-equivalent-tensors}
-    \lean{MPOTensor.StrictlyEquivalent}
-    \leanok
-    \uses{def:mpu}
-    Fix a virtual bond dimension $D$.  Let $\mathcal U$ and $\mathcal V$ be in
-    canonical form, with physical dimensions $d_a$ and $d_b$, respectively,
-    and let $h\colon d_a=d_b$ identify their physical indices.  They are
-    strictly equivalent if the tensor obtained from $\mathcal U$ by this
-    reindexing and $\mathcal V$ are joined by a continuous path
-    $\mathcal W(t)$ such that $\mathcal W(t)$ generates matrix product
-    unitaries for every $t\in[0,1]$.  The path need not remain in canonical
-    form.
-
-    The bond dimension is the same $D$ at both endpoints and along the path.
-    This is the fixed-bond case of the strict-equivalence definition in
-    \cite[lines~708--714]{Cirac2017MPU}; no relation between unequal raw bond
-    dimensions is imposed.
-\end{definition}
-
-\begin{definition}[Equivalence after ancilla attachment and blocking]
-    \label{def:equivalent-tensors}
-    \lean{MPOTensor.Equivalent}
-    \leanok
-    \uses{def:strictly-equivalent-tensors}
-    Fix a virtual bond dimension $D$.  Tensors $\mathcal U$ and $\mathcal V$
-    of physical dimensions $d_a$ and $d_b$ are equivalent if there are
-    positive integers $k,p_a,p_b$, with $p_a$ and $p_b$ coprime, such that
-    \begin{align}
-        p_a d_a &= p_b d_b
-    \end{align}
-    and the tensors obtained by first attaching physical identity ancillas of
-    dimensions $p_a$ and $p_b$, respectively, and then blocking the same $k$
-    sites are strictly equivalent.  Thus the compared tensors are
-    $\bigl(\mathcal U\otimes\Id_{p_a}\bigr)^{[k]}$ and
-    $\bigl(\mathcal V\otimes\Id_{p_b}\bigr)^{[k]}$.
-
-    This is the equivalence definition in
-    \cite[lines~716--724]{Cirac2017MPU} with one fixed ambient bond dimension
-    $D$.  The definition does not add a stabilization relation for unequal raw
-    bond dimensions.
-\end{definition}
-
 \section{Simple matrix product unitary tensors}
 
 \begin{definition}[Double layer]
@@ -3279,33 +3236,45 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{definition}[Strict equivalence]
   \label{def:strictly-equivalent-tensors}
-  \notready
-  \discussion{6021}
-  \uses{def:mpu,lem:mpu_blocking}
-  Two canonical-form MPU tensors $\mathcal U$ and $\mathcal V$ are strictly
-  equivalent if they have the same physical dimension and there is a
-  continuous path $\mathcal W(p)$, $p\in[0,1]$, such that every
-  $\mathcal W(p)$ generates an MPU and
+  \lean{MPOTensor.StrictlyEquivalent}
+  \leanok
+  \uses{def:mpu,def:cpsv_canonical_form}
+  Fix a virtual bond dimension $D$. Let $\mathcal U$ and $\mathcal V$ be
+  canonical-form MPU tensors with physical dimensions $d_a$ and $d_b$. Given
+  an equality $h\colon d_a=d_b$, reindex $\mathcal U$ from $d_a$ to $d_b$
+  along $h^{-1}$. The tensors are strictly equivalent with respect to $h$ if
+  there is a continuous path $\mathcal W(p)$, $p\in[0,1]$, in the fixed-bond
+  MPU locus such that
   \begin{align}
-    \mathcal W(0)&=\mathcal U,&
+    \mathcal W(0)&=\operatorname{reind}_{h^{-1}}(\mathcal U),\\
     \mathcal W(1)&=\mathcal V.
   \end{align}
-  Only the requirement of canonical form is relaxed along the path.
+  Only the canonical-form requirement is relaxed along the path. This is the
+  fixed-bond interpretation of
+  \cite[lines~708--714]{Cirac2017MPU}; it does not compare unequal raw bond
+  dimensions.
 \end{definition}
 
 \begin{definition}[Equivalence after blocking and ancillas]
   \label{def:equivalent-tensors}
-  \notready
-  \discussion{6021}
+  \lean{MPOTensor.Equivalent}
+  \leanok
   \uses{def:strictly-equivalent-tensors,lem:mpu_blocking}
-  Let $\mathcal U$ and $\mathcal V$ have physical dimensions $d_a$ and
-  $d_b$. They are equivalent if there are a positive blocking length $k$ and
-  coprime positive integers $p_a,p_b$ with $p_ad_a=p_bd_b$ such that
-  $(\mathcal U^{(p_a)})_k$ and $(\mathcal V^{(p_b)})_k$ are strictly
-  equivalent, where the ancilla is attached before blocking and
+  Fix a virtual bond dimension $D$. Let $\mathcal U$ and $\mathcal V$ have
+  physical dimensions $d_a$ and $d_b$. They are equivalent if there are a
+  positive blocking length $k$ and coprime positive integers $p_a,p_b$ with
+  \begin{align}
+    p_a d_a&=p_b d_b
+  \end{align}
+  such that $(\mathcal U^{(p_a)})_k$ and $(\mathcal V^{(p_b)})_k$ are strictly
+  equivalent. Here the positive-dimensional identity ancillas are attached
+  before the common blocking, and
   \begin{align}
     \mathcal U^{(p)}&=\mathcal U\otimes\Id_p.
   \end{align}
+  This is the fixed-bond interpretation of
+  \cite[lines~716--724]{Cirac2017MPU}; it does not introduce a stabilization
+  relation for unequal raw bond dimensions.
 \end{definition}
 
 \begin{proposition}[Constancy of the source ranks]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -181,9 +181,9 @@ closing a chain of $N$ copies of $\mathcal U$.
     form.
 
     The bond dimension is the same $D$ at both endpoints and along the path.
-    This is the fixed-bond case of
-    \cite[Definition~\texttt{def:strictly-equivalent-tensors}]{Cirac2017MPU};
-    no relation between unequal raw bond dimensions is imposed.
+    This is the fixed-bond case of the strict-equivalence definition in
+    \cite[lines~708--714]{Cirac2017MPU}; no relation between unequal raw bond
+    dimensions is imposed.
 \end{definition}
 
 \begin{definition}[Equivalence after ancilla attachment and blocking]
@@ -203,9 +203,10 @@ closing a chain of $N$ copies of $\mathcal U$.
     $\bigl(\mathcal U\otimes\Id_{p_a}\bigr)^{[k]}$ and
     $\bigl(\mathcal V\otimes\Id_{p_b}\bigr)^{[k]}$.
 
-    This is \cite[Definition~\texttt{def:equivalent-tensors}]{Cirac2017MPU}
-    with one fixed ambient bond dimension $D$.  The definition does not add a
-    stabilization relation for unequal raw bond dimensions.
+    This is the equivalence definition in
+    \cite[lines~716--724]{Cirac2017MPU} with one fixed ambient bond dimension
+    $D$.  The definition does not add a stabilization relation for unequal raw
+    bond dimensions.
 \end{definition}
 
 \section{Simple matrix product unitary tensors}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3234,11 +3234,38 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
 \end{lemma}
 
+\begin{definition}[MPU canonical form]
+  \label{def:mpu_canonical_form}
+  \lean{MPSTensor.IsMPUCanonicalBlock,
+    MPSTensor.MPUCanonicalFormData,
+    MPSTensor.IsMPUCanonicalForm}
+  \leanok
+  \uses{def:transfer_map}
+  A tensor $A$ of physical dimension $d$ and bond dimension $D$ is in MPU
+  canonical form if there are positive block dimensions $D_k$, weights
+  $\mu_k\in\mathbb C$, tensors $A_k$ of bond dimension $D_k$, and a
+  coisometry
+  \begin{align}
+    C\colon\mathbb C^D&\longrightarrow
+      \bigoplus_{k=1}^r\mathbb C^{D_k},&
+    CC^*&=\Id,
+  \end{align}
+  such that
+  \begin{align}
+    A^i=C^*\left(\bigoplus_{k=1}^r\mu_k A_k^i\right)C.
+  \end{align}
+  Every $A_k$ is irreducible and the spectral radius of its transfer map is
+  one. The blocks may be periodic, so no uniqueness condition is imposed on
+  their peripheral eigenvalues. This is the canonical form of
+  \cite[lines~259--267]{Cirac2017MPU}; normal tensors form a strictly stronger
+  class.
+\end{definition}
+
 \begin{definition}[Strict equivalence]
   \label{def:strictly-equivalent-tensors}
   \lean{MPOTensor.StrictlyEquivalent}
   \leanok
-  \uses{def:mpu,def:mpu_physical_reindexing,def:cpsv_canonical_form}
+  \uses{def:mpu,def:mpu_physical_reindexing,def:mpu_canonical_form}
   Fix a virtual bond dimension $D$. Let $\mathcal U$ and $\mathcal V$ be
   canonical-form MPU tensors with physical dimensions $d_a$ and $d_b$. Given
   an equality $h\colon d_a=d_b$, reindex $\mathcal U$ from $d_a$ to $d_b$

--- a/docs/paper-gaps/mpu_equivalence_fixed_bond.tex
+++ b/docs/paper-gaps/mpu_equivalence_fixed_bond.tex
@@ -10,11 +10,13 @@
 \maketitle
 
 \section{Source definition}
-Cirac--P\'erez-Garc\'ia--Schuch--Verstraete define strict equivalence by a
-continuous path of matrix product unitary tensors and define equivalence by
-first attaching coprime identity ancillas and then applying a common blocking
-length \cite[lines~706--724]{Cirac2017MPU}. The source explicitly balances the
-physical dimensions through
+Let $\mathcal U$ and $\mathcal V$ be matrix product unitary tensors with
+physical dimensions $d_a$ and $d_b$, respectively, and let $p_a$ and $p_b$ be
+positive coprime ancilla dimensions. Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
+define strict equivalence by a continuous path of matrix product unitary
+tensors and define equivalence by first attaching the identity ancillas and
+then applying a common blocking length \cite[lines~706--724]{Cirac2017MPU}.
+The source balances the enlarged physical dimensions through
 \begin{align}
   p_a d_a &= p_b d_b.
 \end{align}
@@ -22,16 +24,25 @@ It does not give a corresponding stabilization or identification for unequal
 raw virtual bond dimensions.
 
 \section{Formal scope}
-A continuous path must lie in one ambient topological space. The formal
-definitions therefore fix a virtual bond dimension $D$ along the path and at
-both endpoints. Different physical dimensions are compared only through an
-explicit equality and the induced reindexing of their physical coordinates.
-For the weaker equivalence relation, identity ancillas are attached before
-blocking, exactly as in the source.
+The declarations \leanid{MPOTensor.StrictlyEquivalent} and
+\leanid{MPOTensor.Equivalent} formalize these two relations. A continuous path
+must lie in one ambient topological space, so both definitions fix a virtual
+bond dimension $D$ along the path and at both endpoints. Different physical
+dimensions are compared only through an explicit equality and the induced
+reindexing of their physical coordinates. For the weaker equivalence relation,
+identity ancillas are attached before blocking, exactly as in the source.
 
-This is a scope restriction, not a proposed stable-bond relation. Extending the
-definition to unequal raw virtual bond dimensions would require an additional
-mathematical stabilization convention not supplied in the cited passage.
+Extending the definition to unequal raw virtual bond dimensions would require
+an additional mathematical stabilization convention not supplied in the cited
+passage.
+
+\section{Verdict}
+\textbf{Policy taxonomy classification: scope restriction.}
+The formal definitions are source-faithful in one fixed ambient virtual bond
+dimension. They neither assert nor require a relation between tensors of
+unequal raw virtual bond dimensions. Any such relation must be introduced as a
+separately named stabilization convention rather than folded into the source
+definitions.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/mpu_equivalence_fixed_bond.tex
+++ b/docs/paper-gaps/mpu_equivalence_fixed_bond.tex
@@ -37,7 +37,7 @@ an additional mathematical stabilization convention not supplied in the cited
 passage.
 
 \section{Verdict}
-\textbf{Policy taxonomy classification: scope restriction.}
+\textbf{Verdict: scope restriction.}
 The formal definitions are source-faithful in one fixed ambient virtual bond
 dimension. They neither assert nor require a relation between tensors of
 unequal raw virtual bond dimensions. Any such relation must be introduced as a

--- a/docs/paper-gaps/mpu_equivalence_fixed_bond.tex
+++ b/docs/paper-gaps/mpu_equivalence_fixed_bond.tex
@@ -1,0 +1,38 @@
+\documentclass{article}
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\input{command}
+\title{Fixed Virtual Bond Dimension in MPU Tensor Equivalence}
+\author{}
+\date{2026-08-10}
+\begin{document}
+\maketitle
+
+\section{Source definition}
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete define strict equivalence by a
+continuous path of matrix product unitary tensors and define equivalence by
+first attaching coprime identity ancillas and then applying a common blocking
+length \cite[lines~706--724]{Cirac2017MPU}. The source explicitly balances the
+physical dimensions through
+\begin{align}
+  p_a d_a &= p_b d_b.
+\end{align}
+It does not give a corresponding stabilization or identification for unequal
+raw virtual bond dimensions.
+
+\section{Formal scope}
+A continuous path must lie in one ambient topological space. The formal
+definitions therefore fix a virtual bond dimension $D$ along the path and at
+both endpoints. Different physical dimensions are compared only through an
+explicit equality and the induced reindexing of their physical coordinates.
+For the weaker equivalence relation, identity ancillas are attached before
+blocking, exactly as in the source.
+
+This is a scope restriction, not a proposed stable-bond relation. Extending the
+definition to unequal raw virtual bond dimensions would require an additional
+mathematical stabilization convention not supplied in the cited passage.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+\end{document}


### PR DESCRIPTION
## What changed

- define strict equivalence by a path inside the MPU-generating locus
- require canonical-form endpoints while allowing the path interior to leave canonical form
- define equivalence after positive physical identity ancillas and a common positive blocking length
- preserve the paper's coprimality and physical-dimension equation
- keep one fixed ambient virtual bond dimension and document the source's missing heterogeneous-bond convention
- complete the existing Chapter 28 nodes without duplicate labels

## Validation

- `lake build TNLean.MPS.MPU.Equivalence TNLean.MPS.MPU`
- diagnostics and proof-integrity checks
- focused blueprint synchronization and reverse coverage
- `leanblueprint checkdecls`
- two LuaLaTeX passes with zero undefined references and no duplicate labels
- standalone compilation of the fixed-bond scope note
- `git diff --check origin/main...HEAD`

Closes #6021

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New foundational definitions for MPU equivalence and canonical form affect downstream formal proofs (e.g. index theorem); scope is documented but misinterpretation of fixed-bond restriction could misguide later work.
> 
> **Overview**
> Adds Lean formalizations for MPU **canonical form** and **tensor equivalence** (Cirac et al., lines 259–267 and 706–724), and wires them into Chapter 28 of the blueprint.
> 
> **MPU canonical form** (`MPUCanonicalForm.lean`) is weaker than CPSV: retained blocks are irreducible with transfer spectral radius one, periodic blocks allowed, and coisometric retained-block reconstruction. CPSV canonical form implies MPU canonical form; no converse.
> 
> **Strict equivalence** requires canonical-form endpoints, fixed virtual bond dimension \(D\), physical reindexing when \(d_a = d_b\), and a continuous path in the MPU locus where interior points need not stay canonical.
> 
> **Equivalence** adds positive coprime physical identity ancillas, the balance \(p_a d_a = p_b d_b\), common blocking, then strict equivalence on the blocked tensors (ancillas before blocking).
> 
> Both relations intentionally **do not** compare unequal raw bond dimensions; a standalone scope note documents this as source-faithful rather than a stabilization convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f290040bf30f26662b69e20816b57759c421d865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->