### PR TITLE
feat(MPS/MPU): expose reflected source-u kernel

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalAdjoint.lean
+++ b/TNLean/MPS/MPDO/PhysicalAdjoint.lean
@@ -35,7 +35,7 @@ For `ab = (a, b)`, this is `bondPairSwap ab = (b, a)`.
 
 This is the bond-index exchange under adjunction in the first diagram of the
 proof of Proposition 4.13 of arXiv:1606.00608, lines 1909--1913, and the
-virtual-pair reflection used in the proof of Lemma III.5 in Section III.B of
+virtual-pair reflection used in the proof of Lemma III.7 in Section III.B of
 arXiv:1703.09188, lines 536--557. -/
 def bondPairSwap (ab : Fin (D * D)) : Fin (D * D) :=
   finProdFinEquiv (ab.modNat, ab.divNat)

--- a/TNLean/MPS/MPDO/PhysicalAdjoint.lean
+++ b/TNLean/MPS/MPDO/PhysicalAdjoint.lean
@@ -14,8 +14,8 @@ proves the corresponding word and periodic-operator identities.
 
 ## Main definitions
 
-* `MPOTensor.bondPairSwap` — exchange of the two entries of a doubled bond index.
-* `MPOTensor.bondPairSwapEquiv` — the doubled-bond exchange as an equivalence.
+* `MPOTensor.bondPairSwap` — exchange of the two doubled virtual-bond indices.
+* `MPOTensor.bondPairSwapEquiv` — the corresponding doubled-bond equivalence.
 * `MPOTensor.physicalAdjointTensor` — physical adjoint without virtual reflection.
 
 ## Main results
@@ -35,7 +35,8 @@ For `ab = (a, b)`, this is `bondPairSwap ab = (b, a)`.
 
 This is the bond-index exchange under adjunction in the first diagram of the
 proof of Proposition 4.13 of arXiv:1606.00608, lines 1909--1913, and the
-virtual-pair reflection in arXiv:1703.09188, Section III, lines 536--557. -/
+virtual-pair reflection used in the proof of Lemma III.5 in Section III.B of
+arXiv:1703.09188, lines 536--557. -/
 def bondPairSwap (ab : Fin (D * D)) : Fin (D * D) :=
   finProdFinEquiv (ab.modNat, ab.divNat)
 

--- a/TNLean/MPS/MPDO/PhysicalAdjoint.lean
+++ b/TNLean/MPS/MPDO/PhysicalAdjoint.lean
@@ -12,8 +12,10 @@ This file defines the physical adjoint, which exchanges and conjugates the
 physical indices of an MPO tensor without reversing its virtual chain, and
 proves the corresponding word and periodic-operator identities.
 
-## Main definition
+## Main definitions
 
+* `MPOTensor.bondPairSwap` — exchange of the two entries of a doubled bond index.
+* `MPOTensor.bondPairSwapEquiv` — the doubled-bond exchange as an equivalence.
 * `MPOTensor.physicalAdjointTensor` — physical adjoint without virtual reflection.
 
 ## Main results
@@ -33,8 +35,7 @@ For `ab = (a, b)`, this is `bondPairSwap ab = (b, a)`.
 
 This is the bond-index exchange under adjunction in the first diagram of the
 proof of Proposition 4.13 of arXiv:1606.00608, lines 1909--1913, and the
-virtual-pair reflection in Figure `II_uUnitary.png` of arXiv:1703.09188,
-lines 536--557. -/
+virtual-pair reflection in arXiv:1703.09188, Section III, lines 536--557. -/
 def bondPairSwap (ab : Fin (D * D)) : Fin (D * D) :=
   finProdFinEquiv (ab.modNat, ab.divNat)
 

--- a/TNLean/MPS/MPDO/PhysicalAdjoint.lean
+++ b/TNLean/MPS/MPDO/PhysicalAdjoint.lean
@@ -28,6 +28,40 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
+/-- Exchange the two oriented bond indices of a doubled virtual index.
+For `ab = (a, b)`, this is `bondPairSwap ab = (b, a)`.
+
+This is the bond-index exchange under adjunction in the first diagram of the
+proof of Proposition 4.13 of arXiv:1606.00608, lines 1909--1913, and the
+virtual-pair reflection in Figure `II_uUnitary.png` of arXiv:1703.09188,
+lines 536--557. -/
+def bondPairSwap (ab : Fin (D * D)) : Fin (D * D) :=
+  finProdFinEquiv (ab.modNat, ab.divNat)
+
+@[simp] theorem bondPairSwap_finProdFinEquiv (a b : Fin D) :
+    bondPairSwap (finProdFinEquiv (a, b)) = finProdFinEquiv (b, a) := by
+  simp [bondPairSwap]
+
+@[simp] theorem bondPairSwap_involutive (ab : Fin (D * D)) :
+    bondPairSwap (bondPairSwap ab) = ab := by
+  rw [show ab = finProdFinEquiv (ab.divNat, ab.modNat) by
+    exact (finProdFinEquiv.apply_symm_apply ab).symm]
+  simp
+
+/-- The equivalence exchanging the two entries of a doubled virtual index. -/
+def bondPairSwapEquiv (D : ℕ) : Fin (D * D) ≃ Fin (D * D) where
+  toFun := bondPairSwap
+  invFun := bondPairSwap
+  left_inv := bondPairSwap_involutive
+  right_inv := bondPairSwap_involutive
+
+@[simp] theorem bondPairSwapEquiv_apply (ab : Fin (D * D)) :
+    bondPairSwapEquiv D ab = bondPairSwap ab := rfl
+
+@[simp] theorem bondPairSwapEquiv_symm :
+    (bondPairSwapEquiv D).symm = bondPairSwapEquiv D := by
+  rfl
+
 /-- The physical adjoint of an MPO tensor swaps its ket and bra indices and conjugates each
 virtual matrix entry, without transposing the virtual indices:
 $$(K^\sharp)^{ij}_{\beta\alpha} = \overline{K^{ji}_{\beta\alpha}}.$$

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.HermitianHelpers
 import TNLean.MPS.BNT.Basic
-import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.MPDO.PhysicalAdjoint
 import TNLean.MPS.SharedInfra.BlockAssembly
 
 /-!
@@ -376,24 +376,6 @@ the vertical direction, and the vertical canonical form of
 arXiv:1606.00608, Proposition 4.13, is a statement about this tensor. -/
 def verticalTensor (M : MPOTensor d D) : MPSTensor (D * D) d :=
   fun ab i j => M i j ab.divNat ab.modNat
-
-/-- Exchange the two oriented horizontal bond indices of a vertical letter.
-For `ab = (a,b)`, this is `bondPairSwap ab = (b,a)`.
-
-This is the bond-index exchange under adjunction in the first diagram of the
-proof of Proposition 4.13 of arXiv:1606.00608, lines 1909--1913. -/
-def bondPairSwap (ab : Fin (D * D)) : Fin (D * D) :=
-  finProdFinEquiv (ab.modNat, ab.divNat)
-
-@[simp] theorem bondPairSwap_finProdFinEquiv (a b : Fin D) :
-    bondPairSwap (finProdFinEquiv (a, b)) = finProdFinEquiv (b, a) := by
-  simp [bondPairSwap]
-
-@[simp] theorem bondPairSwap_involutive (ab : Fin (D * D)) :
-    bondPairSwap (bondPairSwap ab) = ab := by
-  rw [show ab = finProdFinEquiv (ab.divNat, ab.modNat) by
-    exact (finProdFinEquiv.apply_symm_apply ab).symm]
-  simp
 
 @[simp] lemma verticalTensor_apply (M : MPOTensor d D) (ab : Fin (D * D))
     (i j : Fin d) : verticalTensor M ab i j = M i j ab.divNat ab.modNat :=

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -25,6 +25,7 @@ import TNLean.MPS.MPU.SourceUClosedNetwork
 import TNLean.MPS.MPU.SourceUContraction
 import TNLean.MPS.MPU.SourceUOpenTail
 import TNLean.MPS.MPU.SourceURangeTransport
+import TNLean.MPS.MPU.SourceUReflectedKernel
 import TNLean.MPS.MPU.SourceUSecondCutMetric
 import TNLean.MPS.MPU.SourceUV
 import TNLean.MPS.MPU.SuppliedFixedWitnesses

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -13,9 +13,9 @@ import TNLean.MPS.MPU.SuppliedWitnessReblocking
 This file exposes the doubled-bond reflection and an independent spatial
 reindexing of blocked words, then transports the supplied transfer witnesses
 to the output-layer insertion used by the sandwiched open-tail coefficient in
-arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma `lemuisometry`
-(lines 536--557).  The transfer proof uses the doubled-bond swap; the blocked-word
-reversal records a separate spatial coordinate and is not used in that proof.
+arXiv:1703.09188, Section III, lines 536--557.  The transfer proof uses the
+doubled-bond swap; the blocked-word reversal records a separate spatial
+coordinate and is not used in that proof.
 The final sandwiched finite-sum collapse is separate from these transport
 identities.
 -/
@@ -30,7 +30,7 @@ variable {d D : ℕ}
 /-- Reverse the word encoded by a blocked physical index.
 
 This is an independent spatial reindexing coordinate for the graphical
-reflection in arXiv:1703.09188, Figure `II_uUnitary.png`, lines 536--557.
+reflection in arXiv:1703.09188, Section III, lines 536--557.
 It is distinct from the reversal of two blocked letters caused by conjugate
 transposition in the supplied-contraction transport below. -/
 noncomputable def blockWordReverseEquiv (d K : ℕ) :
@@ -160,7 +160,7 @@ theorem conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec
   simp [eq_comm]
 
 /-- Reflection transports the supplied transfer power to the transpose of the
-positive fixed matrix. This is the raw orientation whose conjugate transpose
+supplied matrix. This is the raw orientation whose conjugate transpose
 has boundary order $|1)(\rho|$. -/
 theorem reflected_transfer_power_eq_vecMulVec_transpose [NeZero d]
     (U : MPOTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) (J : ℕ)
@@ -214,12 +214,12 @@ theorem IsMPU.reflected_blockTensor_mul_sq_simple_contractions_of_transfer_power
     let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
     let Φ' : Fin (D * D) → ℂ := fun x ↦
       (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
-    (∀ I J, ρ' ⬝ᵥ ((doubleLayerTensor W I J)ᴴ *ᵥ Φ') =
-      if I = J then 1 else 0) ∧
-    (∀ I J L M,
-      (doubleLayerTensor W L M)ᴴ * (doubleLayerTensor W I J)ᴴ =
+    (∀ I J₁, ρ' ⬝ᵥ ((doubleLayerTensor W I J₁)ᴴ *ᵥ Φ') =
+      if I = J₁ then 1 else 0) ∧
+    (∀ I J₁ L M,
+      (doubleLayerTensor W L M)ᴴ * (doubleLayerTensor W I J₁)ᴴ =
         (doubleLayerTensor W L M)ᴴ * Matrix.vecMulVec Φ' ρ' *
-          (doubleLayerTensor W I J)ᴴ) := by
+          (doubleLayerTensor W I J₁)ᴴ) := by
   classical
   let K := J * (D * D)
   let W := MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U) K
@@ -339,12 +339,12 @@ theorem IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions
     let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
     let Φ' : Fin (D * D) → ℂ := fun x ↦
       (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
-    (∀ I J, ρ' ⬝ᵥ ((doubleLayerTensor W I J)ᴴ *ᵥ Φ') =
-      if I = J then 1 else 0) ∧
-    (∀ I J L M,
-      (doubleLayerTensor W L M)ᴴ * (doubleLayerTensor W I J)ᴴ =
+    (∀ I J₁, ρ' ⬝ᵥ ((doubleLayerTensor W I J₁)ᴴ *ᵥ Φ') =
+      if I = J₁ then 1 else 0) ∧
+    (∀ I J₁ L M,
+      (doubleLayerTensor W L M)ᴴ * (doubleLayerTensor W I J₁)ᴴ =
         (doubleLayerTensor W L M)ᴴ * Matrix.vecMulVec Φ' ρ' *
-          (doubleLayerTensor W I J)ᴴ) := by
+          (doubleLayerTensor W I J₁)ᴴ) := by
   classical
   let K := J * (D * D)
   let ρT : Fin (D * D) → ℂ := fun x ↦

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -1,0 +1,424 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.MatchingContractions
+import TNLean.MPS.MPU.SuppliedWitnessReblocking
+import TNLean.MPS.MPU.SourceUContraction
+
+/-!
+# Reflected open-tail contraction for the source tensor u
+
+This file exposes the index reflections and transports the supplied transfer
+witnesses to the output-layer insertion used by the sandwiched open-tail
+coefficient in arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma
+`lemuisometry` (lines 536--557).  The final sandwiched finite-sum collapse is
+separate from these transport identities.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Swap the two entries of a doubled bond index.
+
+This is the virtual-pair reflection in arXiv:1703.09188, Figure
+`II_uUnitary.png`, lines 536--557. -/
+noncomputable def doubledBondSwap (D : ℕ) : Fin (D * D) ≃ Fin (D * D) :=
+  finProdFinEquiv.symm |>.trans
+    ((Equiv.prodComm (Fin D) (Fin D)).trans finProdFinEquiv)
+
+@[simp] theorem doubledBondSwap_apply (a b : Fin D) :
+    doubledBondSwap D (finProdFinEquiv (a, b)) = finProdFinEquiv (b, a) := by
+  simp [doubledBondSwap]
+
+@[simp] theorem doubledBondSwap_symm : (doubledBondSwap D).symm = doubledBondSwap D := by
+  ext i
+  obtain ⟨⟨a, b⟩, rfl⟩ := finProdFinEquiv.surjective i
+  rfl
+
+/-- Reverse the word encoded by a blocked physical index.
+
+This is the block-word reflection needed when matrix transposition reverses
+an ordered virtual product in arXiv:1703.09188, Figure `II_uUnitary.png`,
+lines 536--557. -/
+noncomputable def blockWordReverseEquiv (d K : ℕ) :
+    Fin (MPSTensor.blockPhysDim d K) ≃ Fin (MPSTensor.blockPhysDim d K) :=
+  (MPSTensor.decodeBlockEquiv d K).trans
+    ((Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))).trans
+      (MPSTensor.decodeBlockEquiv d K).symm)
+
+@[simp] theorem decodeBlock_blockWordReverseEquiv
+    (i : Fin (MPSTensor.blockPhysDim d K)) (k : Fin K) :
+    MPSTensor.decodeBlock d K (blockWordReverseEquiv d K i) k =
+      MPSTensor.decodeBlock d K i (Fin.rev k) := by
+  simp [blockWordReverseEquiv, MPSTensor.decodeBlockEquiv_apply]
+
+@[simp] theorem wordOfBlock_blockWordReverseEquiv
+    (i : Fin (MPSTensor.blockPhysDim d K)) :
+    MPSTensor.wordOfBlock d K (blockWordReverseEquiv d K i) =
+      (MPSTensor.wordOfBlock d K i).reverse := by
+  simp only [MPSTensor.wordOfBlock]
+  calc
+    List.ofFn (MPSTensor.decodeBlock d K (blockWordReverseEquiv d K i)) =
+        List.ofFn (MPSTensor.decodeBlock d K i ∘ Fin.rev) := by
+      congr 1
+      funext k
+      simp
+    _ = List.map (MPSTensor.decodeBlock d K i ∘ Fin.rev) (List.finRange K) := by
+      simp [List.ofFn_eq_map]
+    _ = List.map (MPSTensor.decodeBlock d K i) (List.finRange K).reverse := by
+      simp [List.map_map, Function.comp_def, List.finRange_reverse]
+    _ = (List.ofFn (MPSTensor.decodeBlock d K i)).reverse := by
+      simp [List.ofFn_eq_map, List.map_reverse]
+
+@[simp] theorem blockWordReverseEquiv_involutive
+    (i : Fin (MPSTensor.blockPhysDim d K)) :
+    blockWordReverseEquiv d K (blockWordReverseEquiv d K i) = i := by
+  apply (MPSTensor.decodeBlockEquiv d K).injective
+  funext k
+  simp
+
+/-- The normalized reflected double layer is the original normalized
+double layer with the two doubled-bond components exchanged. -/
+theorem normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor [NeZero d]
+    (W : MPOTensor d D) :
+    normalizedDiagonal (doubleLayerTensor (physicalAdjointTensor W)) =
+      (normalizedDiagonal (doubleLayerTensor W)).submatrix
+        (doubledBondSwap D) (doubledBondSwap D) := by
+  classical
+  ext x y
+  obtain ⟨⟨a, c⟩, rfl⟩ := finProdFinEquiv.surjective x
+  obtain ⟨⟨b, e⟩, rfl⟩ := finProdFinEquiv.surjective y
+  simp only [normalizedDiagonal, contractPhysical, Matrix.one_apply, ite_smul,
+    one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true,
+    Matrix.submatrix_apply, doubledBondSwap_apply, Matrix.smul_apply,
+    Matrix.sum_apply, doubleLayerTensor_apply, kroneckerMap_apply,
+    physicalAdjointTensor_apply, star_star]
+  rw [Finset.sum_comm]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  simp
+  ring
+
+/-- The supplied normalized transfer power remains the same rank-one
+projector after the additional positive $D^2$ blocking. -/
+theorem normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
+    [NeZero d] [NeZero D] (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρtrace : Matrix.trace ρ = 1)
+    (J : ℕ)
+    (hpower : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    normalizedDiagonal (doubleLayerTensor (blockTensor U (J * (D * D)))) =
+      Matrix.vecMulVec
+        (fun x : Fin (D * D) ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x : Fin (D * D) ↦
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)) := by
+  let R := Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec
+  have hpair : (1 : Matrix (Fin D) (Fin D) ℂ).vec ⬝ᵥ ρ.vec = 1 := by
+    rw [Matrix.vec_one_dotProduct_vec_eq_trace, hρtrace]
+  have hRidem : R * R = R := by
+    simp only [R, Matrix.vecMulVec_mul_vecMulVec, hpair, one_smul]
+  have hDsq : 0 < D * D := Nat.mul_pos (NeZero.pos D) (NeZero.pos D)
+  have hpowpos : ∀ n : ℕ, 0 < n → R ^ n = R := by
+    intro n hn
+    obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hn)
+    clear hn
+    induction m with
+    | zero => simp
+    | succ m ih => rw [pow_succ, ih, hRidem]
+  have hRpow : R ^ (D * D) = R := hpowpos _ hDsq
+  have hpowerR :
+      transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J = R := hpower
+  rw [normalizedDiagonal_doubleLayerTensor_blockTensor, pow_mul, hpowerR, hRpow]
+  rfl
+
+/-- After conjugate transposition, reflected normalized transfer witnesses
+have the boundary orientation $|1)(\rho|$ used by the output-first tail.
+The doubled-bond swap is essential for the column-stacking convention
+`Matrix.vec ρ (a,b) = ρ b a`. -/
+theorem conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec
+    [NeZero d] (U : MPOTensor d D) (K : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hE : normalizedDiagonal (doubleLayerTensor (blockTensor U K)) =
+      Matrix.vecMulVec
+        (fun x : Fin (D * D) ↦ ρ.vec (finProdFinEquiv.symm x))
+        (fun x : Fin (D * D) ↦
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))) :
+    (normalizedDiagonal
+      (doubleLayerTensor (blockTensor (physicalAdjointTensor U) K)))ᴴ =
+      Matrix.vecMulVec
+        (fun x : Fin (D * D) ↦
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))
+        (fun x : Fin (D * D) ↦ ρ.vec (finProdFinEquiv.symm x)) := by
+  letI : NeZero (MPSTensor.blockPhysDim d K) := ⟨by
+    rw [MPSTensor.blockPhysDim_eq_pow]
+    exact pow_ne_zero K (NeZero.ne d)⟩
+  rw [← physicalAdjointTensor_blockTensor]
+  rw [normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor, hE]
+  ext x y
+  obtain ⟨⟨a, c⟩, rfl⟩ := finProdFinEquiv.surjective x
+  obtain ⟨⟨b, e⟩, rfl⟩ := finProdFinEquiv.surjective y
+  simp only [Matrix.conjTranspose_apply, Matrix.submatrix_apply,
+    doubledBondSwap_apply, Matrix.vecMulVec_apply, Matrix.vec,
+    Equiv.symm_apply_apply, Matrix.one_apply, star_mul']
+  rw [hρ.isHermitian.apply]
+  simp [eq_comm]
+
+private theorem submatrix_equiv_injective {α β R : Type*} (e : α ≃ β) :
+    Function.Injective (fun A : Matrix β β R ↦ A.submatrix e e) := by
+  intro A B h
+  ext i j
+  simpa only [Matrix.submatrix_apply, Equiv.apply_symm_apply] using
+    congrFun (congrFun h (e.symm i)) (e.symm j)
+
+/-- Reflection transports the supplied transfer power to the transpose of the
+positive fixed matrix. This is the raw orientation whose conjugate transpose
+has boundary order $|1)(\rho|$. -/
+theorem reflected_transfer_power_eq_vecMulVec_transpose [NeZero d]
+    (U : MPOTensor d D) (ρ : Matrix (Fin D) (Fin D) ℂ) (J : ℕ)
+    (hpower : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    transferMatrix
+        (MPSTensor.transferMap (physicalAdjointTensor U).normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.transpose.vec
+        (1 : Matrix (Fin D) (Fin D) ℂ).vec := by
+  letI : NeZero (MPSTensor.blockPhysDim d J) := ⟨by
+    simpa only [MPSTensor.blockPhysDim_eq_pow] using
+      pow_ne_zero J (NeZero.ne d)⟩
+  apply submatrix_equiv_injective finProdFinEquiv.symm
+  change (transferMatrix
+      (MPSTensor.transferMap (physicalAdjointTensor U).normalizedFlattening) ^ J).submatrix
+        finProdFinEquiv.symm finProdFinEquiv.symm = _
+  rw [← normalizedDiagonal_doubleLayerTensor_blockTensor,
+    ← physicalAdjointTensor_blockTensor,
+    normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor,
+    normalizedDiagonal_doubleLayerTensor_blockTensor, hpower]
+  apply Matrix.ext fun x y ↦ ?_
+  rcases finProdFinEquiv.surjective x with ⟨⟨a, c⟩, rfl⟩
+  rcases finProdFinEquiv.surjective y with ⟨⟨b, e⟩, rfl⟩
+  by_cases hbe : b = e
+  · subst e
+    simp [Matrix.submatrix_apply, Matrix.vecMulVec_apply, Matrix.vec,
+      Matrix.transpose_apply]
+  · simp [Matrix.submatrix_apply, Matrix.vecMulVec_apply, Matrix.vec,
+      Matrix.transpose_apply, hbe, Ne.symm hbe]
+
+private theorem star_dotProduct_mulVec {n : Type*} [Fintype n]
+    (a b : n → ℂ) (M : Matrix n n ℂ) :
+    star (a ⬝ᵥ (M *ᵥ b)) = star b ⬝ᵥ (Mᴴ *ᵥ star a) := by
+  symm
+  rw [Matrix.dotProduct_mulVec, ← Matrix.star_mulVec]
+  exact Matrix.star_dotProduct_star (M *ᵥ b) a
+
+/-- The supplied `simple1` and `simple2` contractions at the exact direct
+block length, transported to the conjugate-transposed reflected output layer.
+The insertion is $|1)(\rho|$, with the order of the two blocked letters
+reversed by conjugate transposition. -/
+theorem IsMPU.reflected_blockTensor_mul_sq_simple_contractions_of_transfer_power
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hρtrace : Matrix.trace ρ = 1) (J : ℕ) (hJ : 0 < J)
+    (hpower : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    let K := J * (D * D)
+    let W := MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U) K
+    let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
+    let Φ' : Fin (D * D) → ℂ := fun x ↦
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+    (∀ I J, ρ' ⬝ᵥ ((doubleLayerTensor W I J)ᴴ *ᵥ Φ') =
+      if I = J then 1 else 0) ∧
+    (∀ I J L M,
+      (doubleLayerTensor W L M)ᴴ * (doubleLayerTensor W I J)ᴴ =
+        (doubleLayerTensor W L M)ᴴ * Matrix.vecMulVec Φ' ρ' *
+          (doubleLayerTensor W I J)ᴴ) := by
+  classical
+  let K := J * (D * D)
+  let W := MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U) K
+  let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
+  let Φ' : Fin (D * D) → ℂ := fun x ↦
+    (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+  have hpowerRef := reflected_transfer_power_eq_vecMulVec_transpose U ρ J hpower
+  have htraceT : Matrix.trace ρ.transpose = 1 := by
+    rw [Matrix.trace_transpose, hρtrace]
+  have hs := hU.physicalAdjointTensor.blockTensor_mul_sq_simple_contractions_of_transfer_power
+      ρ.transpose htraceT J hJ hpowerRef
+  dsimp only at hs ⊢
+  have hstarρ : star (fun x : Fin (D * D) ↦
+      ρ.transpose.vec (finProdFinEquiv.symm x)) = ρ' := by
+    funext x
+    obtain ⟨⟨a, c⟩, rfl⟩ := finProdFinEquiv.surjective x
+    simp only [Pi.star_apply, Matrix.vec, Equiv.symm_apply_apply,
+      Matrix.transpose_apply]
+    dsimp only [ρ']
+    simp only [Equiv.symm_apply_apply, Matrix.vec]
+    exact hρ.isHermitian.apply c a
+  have hstarΦ : star Φ' = Φ' := by
+    funext x
+    obtain ⟨⟨a, c⟩, rfl⟩ := finProdFinEquiv.surjective x
+    dsimp only [Φ']
+    simp only [Pi.star_apply, Equiv.symm_apply_apply, Matrix.vec, Matrix.one_apply]
+    simp
+  constructor
+  · intro I J'
+    calc
+      ρ' ⬝ᵥ ((doubleLayerTensor (MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U)
+          (J * (D * D))) I J')ᴴ *ᵥ Φ') =
+          star ((fun x : Fin (D * D) ↦
+            (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)) ⬝ᵥ
+              (doubleLayerTensor (MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U)
+                (J * (D * D))) I J' *ᵥ
+                fun x : Fin (D * D) ↦
+                  ρ.transpose.vec (finProdFinEquiv.symm x))) := by
+            rw [star_dotProduct_mulVec, hstarρ, hstarΦ]
+      _ = if I = J' then 1 else 0 := by rw [hs.1 I J']; simp
+  · intro I J' L M
+    have hRank :
+        (Matrix.vecMulVec
+          (fun x : Fin (D * D) ↦ ρ.transpose.vec (finProdFinEquiv.symm x)) Φ')ᴴ =
+          Matrix.vecMulVec Φ' ρ' := by
+      rw [Matrix.conjTranspose_vecMulVec, hstarρ, hstarΦ]
+    have h := congrArg Matrix.conjTranspose (hs.2 I J' L M)
+    repeat' rw [Matrix.conjTranspose_mul] at h
+    rw [hRank] at h
+    simpa only [Matrix.mul_assoc] using h
+
+/-- The raw transfer witnesses at the exact $J D^2$ block transport
+through output reflection to the insertion $|1)(\rho|$. -/
+theorem conjTranspose_normalizedDiagonal_reflected_blockTensor_eq_vecMulVec
+    [NeZero d] [NeZero D] (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hρtrace : Matrix.trace ρ = 1) (J : ℕ)
+    (hpower : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    (normalizedDiagonal (doubleLayerTensor
+      (blockTensor (physicalAdjointTensor U) (J * (D * D)))))ᴴ =
+      Matrix.vecMulVec
+        (fun x : Fin (D * D) ↦
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x))
+        (fun x : Fin (D * D) ↦ ρ.vec (finProdFinEquiv.symm x)) := by
+  apply conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec U (J * (D * D)) ρ hρ
+  exact normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
+    U ρ hρtrace J hpower
+
+end MPOTensor
+
+namespace MPOTensor
+
+/-- The output-first normalized-diagonal power has the transported
+transpose-weight orientation before cyclic trace movement. -/
+theorem outputLayer_normalizedDiagonal_pow_eq_vecMulVec
+    [NeZero d] [NeZero D] (U : MPOTensor d D)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hρtrace : Matrix.trace ρ = 1) (J : ℕ)
+    (hpower : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    normalizedDiagonal (doubleLayerTensor (physicalAdjointTensor U)) ^ (J * (D * D)) =
+      Matrix.vecMulVec
+        (fun x : Fin (D * D) ↦ ρ.transpose.vec (finProdFinEquiv.symm x))
+        (fun x : Fin (D * D) ↦
+          (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)) := by
+  have h := conjTranspose_normalizedDiagonal_reflected_blockTensor_eq_vecMulVec
+    U ρ hρ hρtrace J hpower
+  rw [doubleLayerTensor_blockTensor, normalizedDiagonal_blockTensor] at h
+  have h' := congrArg Matrix.conjTranspose h
+  rw [Matrix.conjTranspose_conjTranspose,
+    Matrix.conjTranspose_vecMulVec] at h'
+  have hstarρ : star (fun x : Fin (D * D) ↦
+      ρ.vec (finProdFinEquiv.symm x)) =
+      fun x ↦ ρ.transpose.vec (finProdFinEquiv.symm x) := by
+    funext x
+    obtain ⟨⟨a, b⟩, rfl⟩ := finProdFinEquiv.surjective x
+    simp only [Pi.star_apply, Matrix.vec, Matrix.transpose_apply,
+      Equiv.symm_apply_apply]
+    exact hρ.isHermitian.apply a b
+  have hstarΦ : star (fun x : Fin (D * D) ↦
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)) =
+      fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x) := by
+    funext x
+    obtain ⟨⟨a, b⟩, rfl⟩ := finProdFinEquiv.surjective x
+    simp only [Pi.star_apply, Matrix.vec, Matrix.one_apply,
+      Equiv.symm_apply_apply]
+    simp
+  simpa only [hstarρ, hstarΦ] using h'
+
+end MPOTensor
+
+
+namespace MPOTensor
+
+/-- The exact reflected witnesses persist on the common `(J D² + 2)` block,
+with the same `|1)(ρ|` insertion and conjugate-transposed product order. -/
+theorem IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hρtrace : Matrix.trace ρ = 1) (J : ℕ) (hJ : 0 < J)
+    (hpower : transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ J =
+      Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec) :
+    let K := J * (D * D)
+    let W := MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U) (K + 2)
+    let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
+    let Φ' : Fin (D * D) → ℂ := fun x ↦
+      (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+    (∀ I J, ρ' ⬝ᵥ ((doubleLayerTensor W I J)ᴴ *ᵥ Φ') =
+      if I = J then 1 else 0) ∧
+    (∀ I J L M,
+      (doubleLayerTensor W L M)ᴴ * (doubleLayerTensor W I J)ᴴ =
+        (doubleLayerTensor W L M)ᴴ * Matrix.vecMulVec Φ' ρ' *
+          (doubleLayerTensor W I J)ᴴ) := by
+  classical
+  let K := J * (D * D)
+  let ρT : Fin (D * D) → ℂ := fun x ↦
+    ρ.transpose.vec (finProdFinEquiv.symm x)
+  let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
+  let Φ' : Fin (D * D) → ℂ := fun x ↦
+    (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+  have hpowerRef := reflected_transfer_power_eq_vecMulVec_transpose U ρ J hpower
+  have htraceT : Matrix.trace ρ.transpose = 1 := by
+    rw [Matrix.trace_transpose, hρtrace]
+  have hs := hU.physicalAdjointTensor.blockTensor_mul_sq_simple_contractions_of_transfer_power
+    ρ.transpose htraceT J hJ hpowerRef
+  dsimp only at hs
+  have hsadd := blockTensor_add_two_simple_contractions_of_supplied
+    hU.physicalAdjointTensor Φ' ρT hs.2
+  have hstarρ : star ρT = ρ' := by
+    funext x
+    obtain ⟨⟨a, c⟩, rfl⟩ := finProdFinEquiv.surjective x
+    simp only [Pi.star_apply, Matrix.vec, Matrix.transpose_apply,
+      Equiv.symm_apply_apply, ρT, ρ']
+    exact hρ.isHermitian.apply c a
+  have hstarΦ : star Φ' = Φ' := by
+    funext x
+    obtain ⟨⟨a, c⟩, rfl⟩ := finProdFinEquiv.surjective x
+    simp only [Pi.star_apply, Equiv.symm_apply_apply, Matrix.vec,
+      Matrix.one_apply, Φ']
+    simp
+  dsimp only [K] at hsadd ⊢
+  constructor
+  · intro I J'
+    calc
+      ρ' ⬝ᵥ ((doubleLayerTensor
+          (MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U)
+            (J * (D * D) + 2)) I J')ᴴ *ᵥ Φ') =
+          star (Φ' ⬝ᵥ (doubleLayerTensor
+            (MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U)
+              (J * (D * D) + 2)) I J' *ᵥ ρT)) := by
+              rw [star_dotProduct_mulVec, hstarρ, hstarΦ]
+      _ = if I = J' then 1 else 0 := by rw [hsadd.1 I J']; simp
+  · intro I J' L M
+    have hRank : (Matrix.vecMulVec ρT Φ')ᴴ =
+        Matrix.vecMulVec Φ' ρ' := by
+      rw [Matrix.conjTranspose_vecMulVec, hstarρ, hstarΦ]
+    have h := congrArg Matrix.conjTranspose (hsadd.2 I J' L M)
+    repeat' rw [Matrix.conjTranspose_mul] at h
+    rw [hRank] at h
+    simpa only [Matrix.mul_assoc] using h
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -13,9 +13,9 @@ import TNLean.MPS.MPU.SuppliedWitnessReblocking
 This file exposes the doubled-bond reflection and an independent spatial
 reindexing of blocked words, then transports the supplied transfer witnesses
 to the output-layer insertion used by the sandwiched open-tail coefficient in
-arXiv:1703.09188, Section III, lines 536--557.  The transfer proof uses the
-doubled-bond swap; the blocked-word reversal records a separate spatial
-coordinate and is not used in that proof.
+arXiv:1703.09188, Lemma III.5 and its proof in Section III.B
+(lines 536--557).  The transfer proof uses the doubled-bond swap; the blocked-word
+reversal records a separate spatial coordinate and is not used in that proof.
 The final sandwiched finite-sum collapse is separate from these transport
 identities.
 -/
@@ -30,7 +30,8 @@ variable {d D : ℕ}
 /-- Reverse the word encoded by a blocked physical index.
 
 This is an independent spatial reindexing coordinate for the graphical
-reflection in arXiv:1703.09188, Section III, lines 536--557.
+reflection in arXiv:1703.09188, Lemma III.5 and its proof in Section III.B,
+lines 536--557.
 It is distinct from the reversal of two blocked letters caused by conjugate
 transposition in the supplied-contraction transport below. -/
 noncomputable def blockWordReverseEquiv (d K : ℕ) :
@@ -214,12 +215,12 @@ theorem IsMPU.reflected_blockTensor_mul_sq_simple_contractions_of_transfer_power
     let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
     let Φ' : Fin (D * D) → ℂ := fun x ↦
       (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
-    (∀ I J₁, ρ' ⬝ᵥ ((doubleLayerTensor W I J₁)ᴴ *ᵥ Φ') =
-      if I = J₁ then 1 else 0) ∧
-    (∀ I J₁ L M,
-      (doubleLayerTensor W L M)ᴴ * (doubleLayerTensor W I J₁)ᴴ =
-        (doubleLayerTensor W L M)ᴴ * Matrix.vecMulVec Φ' ρ' *
-          (doubleLayerTensor W I J₁)ᴴ) := by
+    (∀ I₁ J₁, ρ' ⬝ᵥ ((doubleLayerTensor W I₁ J₁)ᴴ *ᵥ Φ') =
+      if I₁ = J₁ then 1 else 0) ∧
+    (∀ I₁ J₁ L₁ M₁,
+      (doubleLayerTensor W L₁ M₁)ᴴ * (doubleLayerTensor W I₁ J₁)ᴴ =
+        (doubleLayerTensor W L₁ M₁)ᴴ * Matrix.vecMulVec Φ' ρ' *
+          (doubleLayerTensor W I₁ J₁)ᴴ) := by
   classical
   let K := J * (D * D)
   let W := MPOTensor.blockTensor (MPOTensor.physicalAdjointTensor U) K
@@ -339,12 +340,12 @@ theorem IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions
     let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
     let Φ' : Fin (D * D) → ℂ := fun x ↦
       (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
-    (∀ I J₁, ρ' ⬝ᵥ ((doubleLayerTensor W I J₁)ᴴ *ᵥ Φ') =
-      if I = J₁ then 1 else 0) ∧
-    (∀ I J₁ L M,
-      (doubleLayerTensor W L M)ᴴ * (doubleLayerTensor W I J₁)ᴴ =
-        (doubleLayerTensor W L M)ᴴ * Matrix.vecMulVec Φ' ρ' *
-          (doubleLayerTensor W I J₁)ᴴ) := by
+    (∀ I₁ J₁, ρ' ⬝ᵥ ((doubleLayerTensor W I₁ J₁)ᴴ *ᵥ Φ') =
+      if I₁ = J₁ then 1 else 0) ∧
+    (∀ I₁ J₁ L₁ M₁,
+      (doubleLayerTensor W L₁ M₁)ᴴ * (doubleLayerTensor W I₁ J₁)ᴴ =
+        (doubleLayerTensor W L₁ M₁)ᴴ * Matrix.vecMulVec Φ' ρ' *
+          (doubleLayerTensor W I₁ J₁)ᴴ) := by
   classical
   let K := J * (D * D)
   let ρT : Fin (D * D) → ℂ := fun x ↦

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPU.MatchingContractions
-import TNLean.MPS.MPU.SuppliedWitnessReblocking
 import TNLean.MPS.MPU.SourceUContraction
+import TNLean.MPS.MPU.SuppliedWitnessReblocking
 
 /-!
 # Reflected open-tail contraction for the source tensor u
@@ -26,23 +26,6 @@ open Matrix
 namespace MPOTensor
 
 variable {d D : ℕ}
-
-/-- Swap the two entries of a doubled bond index.
-
-This is the virtual-pair reflection in arXiv:1703.09188, Figure
-`II_uUnitary.png`, lines 536--557. -/
-noncomputable def doubledBondSwap (D : ℕ) : Fin (D * D) ≃ Fin (D * D) :=
-  finProdFinEquiv.symm |>.trans
-    ((Equiv.prodComm (Fin D) (Fin D)).trans finProdFinEquiv)
-
-@[simp] theorem doubledBondSwap_apply (a b : Fin D) :
-    doubledBondSwap D (finProdFinEquiv (a, b)) = finProdFinEquiv (b, a) := by
-  simp [doubledBondSwap]
-
-@[simp] theorem doubledBondSwap_symm : (doubledBondSwap D).symm = doubledBondSwap D := by
-  ext i
-  obtain ⟨⟨a, b⟩, rfl⟩ := finProdFinEquiv.surjective i
-  rfl
 
 /-- Reverse the word encoded by a blocked physical index.
 
@@ -93,14 +76,14 @@ theorem normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor
     (W : MPOTensor d D) :
     normalizedDiagonal (doubleLayerTensor (physicalAdjointTensor W)) =
       (normalizedDiagonal (doubleLayerTensor W)).submatrix
-        (doubledBondSwap D) (doubledBondSwap D) := by
+        (bondPairSwapEquiv D) (bondPairSwapEquiv D) := by
   classical
   ext x y
   obtain ⟨⟨a, c⟩, rfl⟩ := finProdFinEquiv.surjective x
   obtain ⟨⟨b, e⟩, rfl⟩ := finProdFinEquiv.surjective y
   simp only [normalizedDiagonal, contractPhysical, Matrix.one_apply, ite_smul,
     one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true,
-    Matrix.submatrix_apply, doubledBondSwap_apply, Matrix.smul_apply,
+    Matrix.submatrix_apply, Matrix.smul_apply,
     Matrix.sum_apply, doubleLayerTensor_apply, kroneckerMap_apply,
     physicalAdjointTensor_apply, star_star]
   rw [Finset.sum_comm]
@@ -170,8 +153,8 @@ theorem conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec
   ext x y
   obtain ⟨⟨a, c⟩, rfl⟩ := finProdFinEquiv.surjective x
   obtain ⟨⟨b, e⟩, rfl⟩ := finProdFinEquiv.surjective y
-  simp only [Matrix.conjTranspose_apply, Matrix.submatrix_apply,
-    doubledBondSwap_apply, Matrix.vecMulVec_apply, Matrix.vec,
+  simp only [Matrix.conjTranspose_apply, Matrix.submatrix_apply, Matrix.vecMulVec_apply,
+    Matrix.vec,
     Equiv.symm_apply_apply, Matrix.one_apply, star_mul']
   rw [hρ.isHermitian.apply]
   simp [eq_comm]
@@ -306,10 +289,6 @@ theorem conjTranspose_normalizedDiagonal_reflected_blockTensor_eq_vecMulVec
   exact normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power
     U ρ hρtrace J hpower
 
-end MPOTensor
-
-namespace MPOTensor
-
 /-- The output-first normalized-diagonal power has the transported
 transpose-weight orientation before cyclic trace movement. -/
 theorem outputLayer_normalizedDiagonal_pow_eq_vecMulVec
@@ -346,11 +325,6 @@ theorem outputLayer_normalizedDiagonal_pow_eq_vecMulVec
       Equiv.symm_apply_apply]
     simp
   simpa only [hstarρ, hstarΦ] using h'
-
-end MPOTensor
-
-
-namespace MPOTensor
 
 /-- The exact reflected witnesses persist on the common `(J D² + 2)` block,
 with the same `|1)(ρ|` insertion and conjugate-transposed product order. -/

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -10,11 +10,14 @@ import TNLean.MPS.MPU.SourceUContraction
 /-!
 # Reflected open-tail contraction for the source tensor u
 
-This file exposes the index reflections and transports the supplied transfer
-witnesses to the output-layer insertion used by the sandwiched open-tail
-coefficient in arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma
-`lemuisometry` (lines 536--557).  The final sandwiched finite-sum collapse is
-separate from these transport identities.
+This file exposes the doubled-bond reflection and an independent spatial
+reindexing of blocked words, then transports the supplied transfer witnesses
+to the output-layer insertion used by the sandwiched open-tail coefficient in
+arXiv:1703.09188, Figure `II_uUnitary.png` and Lemma `lemuisometry`
+(lines 536--557).  The transfer proof uses the doubled-bond swap; the blocked-word
+reversal records a separate spatial coordinate and is not used in that proof.
+The final sandwiched finite-sum collapse is separate from these transport
+identities.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -43,9 +46,10 @@ noncomputable def doubledBondSwap (D : ℕ) : Fin (D * D) ≃ Fin (D * D) :=
 
 /-- Reverse the word encoded by a blocked physical index.
 
-This is the block-word reflection needed when matrix transposition reverses
-an ordered virtual product in arXiv:1703.09188, Figure `II_uUnitary.png`,
-lines 536--557. -/
+This is an independent spatial reindexing coordinate for the graphical
+reflection in arXiv:1703.09188, Figure `II_uUnitary.png`, lines 536--557.
+It is distinct from the reversal of two blocked letters caused by conjugate
+transposition in the supplied-contraction transport below. -/
 noncomputable def blockWordReverseEquiv (d K : ℕ) :
     Fin (MPSTensor.blockPhysDim d K) ≃ Fin (MPSTensor.blockPhysDim d K) :=
   (MPSTensor.decodeBlockEquiv d K).trans
@@ -85,7 +89,7 @@ noncomputable def blockWordReverseEquiv (d K : ℕ) :
 
 /-- The normalized reflected double layer is the original normalized
 double layer with the two doubled-bond components exchanged. -/
-theorem normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor [NeZero d]
+theorem normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor
     (W : MPOTensor d D) :
     normalizedDiagonal (doubleLayerTensor (physicalAdjointTensor W)) =
       (normalizedDiagonal (doubleLayerTensor W)).submatrix
@@ -172,13 +176,6 @@ theorem conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec
   rw [hρ.isHermitian.apply]
   simp [eq_comm]
 
-private theorem submatrix_equiv_injective {α β R : Type*} (e : α ≃ β) :
-    Function.Injective (fun A : Matrix β β R ↦ A.submatrix e e) := by
-  intro A B h
-  ext i j
-  simpa only [Matrix.submatrix_apply, Equiv.apply_symm_apply] using
-    congrFun (congrFun h (e.symm i)) (e.symm j)
-
 /-- Reflection transports the supplied transfer power to the transpose of the
 positive fixed matrix. This is the raw orientation whose conjugate transpose
 has boundary order $|1)(\rho|$. -/
@@ -193,7 +190,8 @@ theorem reflected_transfer_power_eq_vecMulVec_transpose [NeZero d]
   letI : NeZero (MPSTensor.blockPhysDim d J) := ⟨by
     simpa only [MPSTensor.blockPhysDim_eq_pow] using
       pow_ne_zero J (NeZero.ne d)⟩
-  apply submatrix_equiv_injective finProdFinEquiv.symm
+  rw [← Equiv.apply_eq_iff_eq
+    (Matrix.reindex finProdFinEquiv finProdFinEquiv)]
   change (transferMatrix
       (MPSTensor.transferMap (physicalAdjointTensor U).normalizedFlattening) ^ J).submatrix
         finProdFinEquiv.symm finProdFinEquiv.symm = _

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -327,8 +327,8 @@ theorem outputLayer_normalizedDiagonal_pow_eq_vecMulVec
     simp
   simpa only [hstarρ, hstarΦ] using h'
 
-/-- The exact reflected witnesses persist on the common `(J D² + 2)` block,
-with the same `|1)(ρ|` insertion and conjugate-transposed product order. -/
+/-- The exact reflected witnesses persist on the common $J D^2 + 2$ block,
+with the same $|1)(\rho|$ insertion and conjugate-transposed product order. -/
 theorem IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions
     [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)

--- a/TNLean/MPS/MPU/SourceUReflectedKernel.lean
+++ b/TNLean/MPS/MPU/SourceUReflectedKernel.lean
@@ -13,7 +13,7 @@ import TNLean.MPS.MPU.SuppliedWitnessReblocking
 This file exposes the doubled-bond reflection and an independent spatial
 reindexing of blocked words, then transports the supplied transfer witnesses
 to the output-layer insertion used by the sandwiched open-tail coefficient in
-arXiv:1703.09188, Lemma III.5 and its proof in Section III.B
+arXiv:1703.09188, Lemma III.7 and its proof in Section III.B
 (lines 536--557).  The transfer proof uses the doubled-bond swap; the blocked-word
 reversal records a separate spatial coordinate and is not used in that proof.
 The final sandwiched finite-sum collapse is separate from these transport
@@ -30,7 +30,7 @@ variable {d D : ℕ}
 /-- Reverse the word encoded by a blocked physical index.
 
 This is an independent spatial reindexing coordinate for the graphical
-reflection in arXiv:1703.09188, Lemma III.5 and its proof in Section III.B,
+reflection in arXiv:1703.09188, Lemma III.7 and its proof in Section III.B,
 lines 536--557.
 It is distinct from the reversal of two blocked letters caused by conjugate
 transposition in the supplied-contraction transport below. -/

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2288,8 +2288,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     original supplied witnesses.
 \end{proof}
 
-\begin{theorem}[Reflected blocked-transfer coordinates]
-    \label{thm:mpu_reflected_blocked_transfer_coordinates}
+\begin{definition}[Reflected blocked-transfer coordinates]
+    \label{def:mpu_reflected_blocked_transfer_coordinates}
     \lean{MPOTensor.bondPairSwapEquiv,
         MPOTensor.bondPairSwapEquiv_apply,
         MPOTensor.bondPairSwapEquiv_symm,
@@ -2298,8 +2298,6 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.wordOfBlock_blockWordReverseEquiv,
         MPOTensor.blockWordReverseEquiv_involutive}
     \leanok
-    \uses{lem:vertical_tensor_adjoint_reflection,
-        def:mpu_double_layer,def:mpdo_positive_physical_blocking}
     The doubled-bond coordinate reflection exchanges the two virtual factors,
     \begin{align}
       (a,b)&\longmapsto(b,a).
@@ -2309,12 +2307,12 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
       (i_0,\ldots,i_{K-1})&\longmapsto(i_{K-1},\ldots,i_0).
     \end{align}
     Both reindexings are involutions.  These are support coordinates for the
-    graphical proof of \cite[Lemma~\texttt{lemuisometry}, Figure~
-    \texttt{II\_uUnitary.png}]{Cirac2017MPU}, rather than a separate theorem
-    printed there.  The blocked-word reversal is not used in the transfer
+    graphical proof in \cite[Section~III, lines 536--557]{Cirac2017MPU},
+    rather than a separate theorem printed there.  The blocked-word reversal
+    is not used in the transfer
     transport below; conjugate transposition there reverses only the order of
     the two blocked letters.
-\end{theorem}
+\end{definition}
 
 \begin{proof}\leanok
     Decode the doubled bond, apply the product swap, and encode it again.
@@ -2336,12 +2334,12 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
     This identity requires neither the MPU property nor a positivity or
     positive-dimension hypothesis.  It is a coordinate identity supporting
-    the graphical reflection in \cite[Figure~\texttt{II\_uUnitary.png}]
+    the graphical reflection in \cite[Section~III, lines 536--557]
     {Cirac2017MPU}, not a separate theorem printed there.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_reflected_blocked_transfer_coordinates}
+    \uses{def:mpu_reflected_blocked_transfer_coordinates}
     Expand the two normalized diagonals.  Physical adjunction exchanges the
     two physical indices, and exchanging the two finite physical sums leaves
     precisely the simultaneous doubled-bond swap on the row and column.
@@ -2445,9 +2443,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     order of the two blocked letters.  Overlapping-window reblocking preserves
     these witnesses through the two additional sites.  These contractions are
     support identities for the graphical proof of
-    \cite[Lemma~\texttt{lemuisometry}, Figure~
-    \texttt{II\_uUnitary.png}]{Cirac2017MPU}; they are not asserted as a
-    separate printed theorem of that paper.
+    \cite[Section~III, lines 536--557]{Cirac2017MPU}; they are not asserted
+    as a separate printed theorem of that paper.
 \end{proof}
 
 % The equality and range-insertion step remains tracked by parent issue #5982.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2288,15 +2288,11 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     original supplied witnesses.
 \end{proof}
 
-\begin{definition}[Reflected blocked-transfer coordinates]
+\begin{definition}[Reflected blocked-transfer coordinate maps]
     \label{def:mpu_reflected_blocked_transfer_coordinates}
-    \lean{MPOTensor.bondPairSwapEquiv,
-        MPOTensor.bondPairSwapEquiv_apply,
-        MPOTensor.bondPairSwapEquiv_symm,
-        MPOTensor.blockWordReverseEquiv,
-        MPOTensor.decodeBlock_blockWordReverseEquiv,
-        MPOTensor.wordOfBlock_blockWordReverseEquiv,
-        MPOTensor.blockWordReverseEquiv_involutive}
+    \lean{MPOTensor.bondPairSwap,
+        MPOTensor.bondPairSwapEquiv,
+        MPOTensor.blockWordReverseEquiv}
     \leanok
     The doubled-bond coordinate reflection exchanges the two virtual factors,
     \begin{align}
@@ -2306,13 +2302,28 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \begin{align}
       (i_0,\ldots,i_{K-1})&\longmapsto(i_{K-1},\ldots,i_0).
     \end{align}
-    Both reindexings are involutions.  These are support coordinates for the
-    graphical proof in \cite[Section~III, lines 536--557]{Cirac2017MPU},
-    rather than a separate theorem printed there.  The blocked-word reversal
-    is not used in the transfer
-    transport below; conjugate transposition there reverses only the order of
-    the two blocked letters.
+    These are support coordinates for the proof of
+    \cite[Lemma~III.5 in Section~III.B]{Cirac2017MPU}, rather than separate
+    definitions printed there.  The blocked-word reversal is not used in the
+    transfer transport below; conjugate transposition there reverses only the
+    order of the two blocked letters.
 \end{definition}
+
+\begin{theorem}[Reflected blocked-transfer coordinate identities]
+    \label{thm:mpu_reflected_blocked_transfer_coordinate_identities}
+    \lean{MPOTensor.bondPairSwap_finProdFinEquiv,
+        MPOTensor.bondPairSwap_involutive,
+        MPOTensor.bondPairSwapEquiv_apply,
+        MPOTensor.bondPairSwapEquiv_symm,
+        MPOTensor.decodeBlock_blockWordReverseEquiv,
+        MPOTensor.wordOfBlock_blockWordReverseEquiv,
+        MPOTensor.blockWordReverseEquiv_involutive}
+    \leanok
+    \uses{def:mpu_reflected_blocked_transfer_coordinates}
+    The doubled-bond swap and the blocked-word reversal are involutions.  The
+    latter sends the letter in position $k$ to the letter in position $K-1-k$
+    and reverses the encoded word.
+\end{theorem}
 
 \begin{proof}\leanok
     Decode the doubled bond, apply the product swap, and encode it again.
@@ -2334,12 +2345,13 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
     This identity requires neither the MPU property nor a positivity or
     positive-dimension hypothesis.  It is a coordinate identity supporting
-    the graphical reflection in \cite[Section~III, lines 536--557]
-    {Cirac2017MPU}, not a separate theorem printed there.
+    the calculation in the proof of
+    \cite[Lemma~III.5 in Section~III.B]{Cirac2017MPU}, not a separate theorem
+    printed there.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpu_reflected_blocked_transfer_coordinates}
+    \uses{thm:mpu_reflected_blocked_transfer_coordinate_identities}
     Expand the two normalized diagonals.  Physical adjunction exchanges the
     two physical indices, and exchanging the two finite physical sums leaves
     precisely the simultaneous doubled-bond swap on the row and column.
@@ -2443,8 +2455,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     order of the two blocked letters.  Overlapping-window reblocking preserves
     these witnesses through the two additional sites.  These contractions are
     support identities for the graphical proof of
-    \cite[Section~III, lines 536--557]{Cirac2017MPU}; they are not asserted
-    as a separate printed theorem of that paper.
+    \cite[Lemma~III.5 and its proof in Section~III.B]{Cirac2017MPU}; they
+    are not asserted as a separate printed theorem of that paper.
 \end{proof}
 
 % The equality and range-insertion step remains tracked by parent issue #5982.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2290,15 +2290,16 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Reflected blocked-transfer coordinates]
     \label{thm:mpu_reflected_blocked_transfer_coordinates}
-    \lean{MPOTensor.doubledBondSwap,
-        MPOTensor.doubledBondSwap_apply,
-        MPOTensor.doubledBondSwap_symm,
+    \lean{MPOTensor.bondPairSwapEquiv,
+        MPOTensor.bondPairSwapEquiv_apply,
+        MPOTensor.bondPairSwapEquiv_symm,
         MPOTensor.blockWordReverseEquiv,
         MPOTensor.decodeBlock_blockWordReverseEquiv,
         MPOTensor.wordOfBlock_blockWordReverseEquiv,
         MPOTensor.blockWordReverseEquiv_involutive}
     \leanok
-    \uses{def:mpu_double_layer,def:mpdo_positive_physical_blocking}
+    \uses{lem:vertical_tensor_adjoint_reflection,
+        def:mpu_double_layer,def:mpdo_positive_physical_blocking}
     The doubled-bond coordinate reflection exchanges the two virtual factors,
     \begin{align}
       (a,b)&\longmapsto(b,a).

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2290,8 +2290,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{definition}[Reflected blocked-transfer coordinate maps]
     \label{def:mpu_reflected_blocked_transfer_coordinates}
-    \lean{MPOTensor.bondPairSwap,
-        MPOTensor.bondPairSwapEquiv,
+    \lean{MPOTensor.bondPairSwapEquiv,
         MPOTensor.blockWordReverseEquiv}
     \leanok
     The doubled-bond coordinate reflection exchanges the two virtual factors,
@@ -2303,7 +2302,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
       (i_0,\ldots,i_{K-1})&\longmapsto(i_{K-1},\ldots,i_0).
     \end{align}
     These are support coordinates for the proof of
-    \cite[Lemma~III.5 in Section~III.B]{Cirac2017MPU}, rather than separate
+    \cite[Lemma~III.7 in Section~III.B]{Cirac2017MPU}, rather than separate
     definitions printed there.  The blocked-word reversal is not used in the
     transfer transport below; conjugate transposition there reverses only the
     order of the two blocked letters.
@@ -2311,18 +2310,16 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Reflected blocked-transfer coordinate identities]
     \label{thm:mpu_reflected_blocked_transfer_coordinate_identities}
-    \lean{MPOTensor.bondPairSwap_finProdFinEquiv,
-        MPOTensor.bondPairSwap_involutive,
-        MPOTensor.bondPairSwapEquiv_apply,
+    \lean{MPOTensor.bondPairSwapEquiv_apply,
         MPOTensor.bondPairSwapEquiv_symm,
         MPOTensor.decodeBlock_blockWordReverseEquiv,
         MPOTensor.wordOfBlock_blockWordReverseEquiv,
         MPOTensor.blockWordReverseEquiv_involutive}
     \leanok
     \uses{def:mpu_reflected_blocked_transfer_coordinates}
-    The doubled-bond swap and the blocked-word reversal are involutions.  The
-    latter sends the letter in position $k$ to the letter in position $K-1-k$
-    and reverses the encoded word.
+    The doubled-bond equivalence and the blocked-word reversal are
+    involutions.  The latter sends the letter in position $k$ to the letter in
+    position $K-1-k$ and reverses the encoded word.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2346,7 +2343,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     This identity requires neither the MPU property nor a positivity or
     positive-dimension hypothesis.  It is a coordinate identity supporting
     the calculation in the proof of
-    \cite[Lemma~III.5 in Section~III.B]{Cirac2017MPU}, not a separate theorem
+    \cite[Lemma~III.7 in Section~III.B]{Cirac2017MPU}, not a separate theorem
     printed there.
 \end{theorem}
 
@@ -2455,7 +2452,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     order of the two blocked letters.  Overlapping-window reblocking preserves
     these witnesses through the two additional sites.  These contractions are
     support identities for the graphical proof of
-    \cite[Lemma~III.5 and its proof in Section~III.B]{Cirac2017MPU}; they
+    \cite[Lemma~III.7 and its proof in Section~III.B]{Cirac2017MPU}; they
     are not asserted as a separate printed theorem of that paper.
 \end{proof}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2298,20 +2298,28 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.wordOfBlock_blockWordReverseEquiv,
         MPOTensor.blockWordReverseEquiv_involutive}
     \leanok
-    \uses{def:mpu_double_layer,def:mpdo_physical_adjoint}
-    Reflection exchanges the two factors of a doubled virtual bond and
-    reverses the decoded physical word:
+    \uses{def:mpu_double_layer,def:mpdo_positive_physical_blocking}
+    The doubled-bond coordinate reflection exchanges the two virtual factors,
     \begin{align}
-      (a,b)&\longmapsto(b,a),&
+      (a,b)&\longmapsto(b,a).
+    \end{align}
+    Independently, spatial reflection reverses a blocked word of length $K$,
+    \begin{align}
       (i_0,\ldots,i_{K-1})&\longmapsto(i_{K-1},\ldots,i_0).
     \end{align}
-    Both reindexings are involutions.
+    Both reindexings are involutions.  These are support coordinates for the
+    graphical proof of \cite[Lemma~\texttt{lemuisometry}, Figure~
+    \texttt{II\_uUnitary.png}]{Cirac2017MPU}, rather than a separate theorem
+    printed there.  The blocked-word reversal is not used in the transfer
+    transport below; conjugate transposition there reverses only the order of
+    the two blocked letters.
 \end{theorem}
 
 \begin{proof}\leanok
     Decode the doubled bond, apply the product swap, and encode it again.
-    Decode a blocked index as a function on $\Fin K$, precompose with
-    $k\mapsto K-1-k$, and use reversal of the corresponding finite list.
+    Regard a blocked index as a word indexed by the $K$ ordered positions,
+    precompose with $k\mapsto K-1-k$, and reverse the corresponding finite
+    list.
 \end{proof}
 
 \begin{theorem}[Reflected supplied transfer insertion]
@@ -2325,14 +2333,14 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.IsMPU.reflected_blockTensor_mul_sq_simple_contractions_of_transfer_power,
         MPOTensor.IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions}
     \leanok
-    \uses{thm:mpu_matching_direct_block_contractions,
-        thm:mpu_physical_adjoint_identities,
-        thm:mpu_reflected_blocked_transfer_coordinates,
-        thm:mpu_supplied_witness_overlapping_reblocking}
-    Let $E^J=|\rho)(1|$, where $\rho>0$, $\tr(\rho)=1$, and $J>0$, and set
-    $K=JD^2$.  Reflection and conjugate transposition give the insertion
-    $|1)(\rho|$.  At both lengths $K$ and $K+2$, the same reflected vectors
-    satisfy
+    \uses{def:mpu,def:mpu_double_layer,def:mpdo_physical_adjoint,
+        def:mpdo_positive_physical_blocking,def:mpu_normalized_flattening,
+        def:mpu_transfer_matrix}
+    Let $\mathcal U$ be an MPU with positive physical dimension $d$ and
+    positive bond dimension $D$.  Suppose $E^J=|\rho)(1|$, where $\rho>0$,
+    $\tr(\rho)=1$, and $J>0$, and set $K=JD^2$.  Doubled-bond reflection and
+    conjugate transposition give the insertion $|1)(\rho|$.  At both lengths
+    $K$ and $K+2$, the same reflected vectors satisfy
     \begin{align}
       (\rho|\widehat W^{IJ\dagger}|1)&=\delta_{I,J},\\
       \widehat W^{LM\dagger}\widehat W^{IJ\dagger}
@@ -2343,15 +2351,24 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_blocked_double_layer_diagonal,
+        thm:mpu_double_layer_blocking,
+        thm:mpu_matching_direct_block_contractions,
+        thm:mpu_physical_adjoint_identities,
+        thm:mpu_reflected_blocked_transfer_coordinates,
+        thm:mpu_supplied_witness_overlapping_reblocking}
     Reindex the normalized reflected diagonal by the doubled-bond swap and
     transport the stabilized power to $\rho^{\mathsf T}$.  Positivity gives
     the Hermitian symmetry that converts its conjugate transpose to
     $|1)(\rho|$.  Conjugate transposition reverses the two blocked letters;
     supplied-witness overlapping reblocking preserves the same insertion at
-    length $K+2$.
+    length $K+2$.  Thus these identities supply coordinates for the graphical
+    proof of \cite[Lemma~\texttt{lemuisometry}, Figure~
+    \texttt{II\_uUnitary.png}]{Cirac2017MPU}; they are not asserted as a
+    separate printed theorem of that paper.
 \end{proof}
 
-% The equality and range-insertion step remains tracked by issue #5971.
+% The equality and range-insertion step remains tracked by parent issue #5982.
 \begin{remark}[Scope of the closed source-$u$ formulas]
     The first theorem rewrites the ordinary source-$u$ Gram entry, while the
     second independently rewrites the normalized closed output tail.  They do

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2334,7 +2334,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_reflected_normalized_diagonal}
     \lean{MPOTensor.normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor}
     \leanok
-    \uses{def:mpu_double_layer,def:mpdo_physical_adjoint}
+    \uses{def:mpu_double_layer,def:mpdo_physical_adjoint,
+        def:mpu_reflected_blocked_transfer_coordinates}
     Let $R(\mathcal U)$ denote the normalized physical diagonal of the double
     layer of an MPO tensor $\mathcal U$, and let $s(a,b)=(b,a)$ be the
     doubled-bond swap.  Then

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2322,48 +2322,129 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     list.
 \end{proof}
 
-\begin{theorem}[Reflected supplied transfer insertion]
-    \label{thm:mpu_reflected_supplied_transfer_insertion}
-    \lean{MPOTensor.normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor,
-        MPOTensor.normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power,
-        MPOTensor.conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec,
-        MPOTensor.conjTranspose_normalizedDiagonal_reflected_blockTensor_eq_vecMulVec,
-        MPOTensor.reflected_transfer_power_eq_vecMulVec_transpose,
-        MPOTensor.outputLayer_normalizedDiagonal_pow_eq_vecMulVec,
-        MPOTensor.IsMPU.reflected_blockTensor_mul_sq_simple_contractions_of_transfer_power,
-        MPOTensor.IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions}
+\begin{theorem}[Normalized diagonal under output reflection]
+    \label{thm:mpu_reflected_normalized_diagonal}
+    \lean{MPOTensor.normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor}
     \leanok
-    \uses{def:mpu,def:mpu_double_layer,def:mpdo_physical_adjoint,
+    \uses{def:mpu_double_layer,def:mpdo_physical_adjoint}
+    Let $R(\mathcal U)$ denote the normalized physical diagonal of the double
+    layer of an MPO tensor $\mathcal U$, and let $s(a,b)=(b,a)$ be the
+    doubled-bond swap.  Then
+    \begin{align}
+      R(\mathcal U^\sharp)_{x,y}=R(\mathcal U)_{s(x),s(y)}.
+    \end{align}
+    This identity requires neither the MPU property nor a positivity or
+    positive-dimension hypothesis.  It is a coordinate identity supporting
+    the graphical reflection in \cite[Figure~\texttt{II\_uUnitary.png}]
+    {Cirac2017MPU}, not a separate theorem printed there.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_reflected_blocked_transfer_coordinates}
+    Expand the two normalized diagonals.  Physical adjunction exchanges the
+    two physical indices, and exchanging the two finite physical sums leaves
+    precisely the simultaneous doubled-bond swap on the row and column.
+\end{proof}
+
+\begin{theorem}[Reflected transfer-power identities]
+    \label{thm:mpu_reflected_transfer_power}
+    \lean{MPOTensor.normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power,
+        MPOTensor.conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec,
+        MPOTensor.reflected_transfer_power_eq_vecMulVec_transpose,
+        MPOTensor.conjTranspose_normalizedDiagonal_reflected_blockTensor_eq_vecMulVec,
+        MPOTensor.outputLayer_normalizedDiagonal_pow_eq_vecMulVec}
+    \leanok
+    \uses{def:mpu_double_layer,def:mpdo_physical_adjoint,
         def:mpdo_positive_physical_blocking,def:mpu_normalized_flattening,
         def:mpu_transfer_matrix}
-    Let $\mathcal U$ be an MPU with positive physical dimension $d$ and
-    positive bond dimension $D$.  Suppose $E^J=|\rho)(1|$, where $\rho>0$,
-    $\tr(\rho)=1$, and $J>0$, and set $K=JD^2$.  Doubled-bond reflection and
-    conjugate transposition give the insertion $|1)(\rho|$.  At both lengths
-    $K$ and $K+2$, the same reflected vectors satisfy
+    Let $\mathcal U$ be an MPO tensor.  Write $E$ for the transfer matrix of
+    its normalized flattening, $E^\sharp$ for that of $\mathcal U^\sharp$,
+    and $E_{\mathrm{out}}$ for the normalized diagonal of the double layer of
+    $\mathcal U^\sharp$.  If $d>0$ and
     \begin{align}
-      (\rho|\widehat W^{IJ\dagger}|1)&=\delta_{I,J},\\
-      \widehat W^{LM\dagger}\widehat W^{IJ\dagger}
-        &=\widehat W^{LM\dagger}|1)(\rho|\widehat W^{IJ\dagger}.
+      E^J=|\rho)(1|,
     \end{align}
-    The common $K+2$ block is obtained by the overlapping-window theorem,
-    without replacing the supplied witnesses by existentially chosen ones.
+    then
+    \begin{align}
+      (E^\sharp)^J=|\rho^{\mathsf T})(1|.
+    \end{align}
+    No MPU, positivity, trace, positive bond-dimension, or positivity of $J$
+    is needed for this implication.
+
+    Suppose in addition that $D>0$ and $\tr(\rho)=1$, and set $K=JD^2$.
+    Then the normalized diagonal $R_K$ of the double layer of the $K$-site
+    block of $\mathcal U$ satisfies
+    \begin{align}
+      R_K=|\rho)(1|.
+    \end{align}
+    More generally, if $d>0$, $\rho>0$, and the normalized diagonal $R_L$ of
+    an $L$-site block satisfies $R_L=|\rho)(1|$, write $R_L^\sharp$ for the
+    normalized diagonal of the corresponding block of $\mathcal U^\sharp$.
+    Then
+    \begin{align}
+      R_L^{\sharp\dagger}=|1)(\rho|.
+    \end{align}
+    Consequently, under the combined assumptions $d,D>0$, $\rho>0$,
+    $\tr(\rho)=1$, and $E^J=|\rho)(1|$,
+    \begin{align}
+      R_K^{\sharp\dagger}&=|1)(\rho|, &
+      E_{\mathrm{out}}^K&=|\rho^{\mathsf T})(1|.
+    \end{align}
+    Here all rank-one operators use the column-stacking identification
+    $M_D(\mathbb C)\cong\mathbb C^{D^2}$.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpu_blocked_double_layer_diagonal,
         thm:mpu_double_layer_blocking,
-        thm:mpu_matching_direct_block_contractions,
+        thm:mpu_reflected_normalized_diagonal}
+    The blocked normalized diagonal is the corresponding transfer power.
+    Reindex the reflected diagonal by the doubled-bond swap to obtain the
+    transpose weight.  When $\rho$ is positive definite, its Hermitian
+    symmetry converts the conjugate-transposed reflected diagonal to
+    $|1)(\rho|$.  The trace-one condition makes $|\rho)(1|$ idempotent, so the
+    additional positive $D^2$ power leaves it unchanged.  Conjugating once
+    more gives the stated output-layer orientation.
+\end{proof}
+
+\begin{theorem}[Reflected supplied contractions]
+    \label{thm:mpu_reflected_supplied_contractions}
+    \lean{MPOTensor.IsMPU.reflected_blockTensor_mul_sq_simple_contractions_of_transfer_power,
+        MPOTensor.IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions}
+    \leanok
+    \uses{def:mpu,def:mpu_double_layer,def:mpdo_physical_adjoint,
+        def:mpdo_positive_physical_blocking,def:mpu_normalized_flattening,
+        def:mpu_transfer_matrix}
+    Let $\mathcal U$ be an MPU with $d,D>0$.  Let $E$ be the transfer matrix
+    of its normalized flattening, and suppose
+    \begin{align}
+      E^J=|\rho)(1|,
+    \end{align}
+    where $\rho>0$, $\tr(\rho)=1$, and $J>0$.  Set $K=JD^2$.  For
+    $n\in\{K,K+2\}$, let $\widehat W_n$ be the double layer of the $n$-site
+    block of $\mathcal U^\sharp$.  Then, for all blocked physical indices,
+    \begin{align}
+      (\rho|\widehat W_n^{IJ\dagger}|1)&=\delta_{I,J},\\
+      \widehat W_n^{LM\dagger}\widehat W_n^{IJ\dagger}
+        &=\widehat W_n^{LM\dagger}|1)(\rho|
+          \widehat W_n^{IJ\dagger}.
+    \end{align}
+    The same supplied vectors occur at both lengths; the $K+2$ identities do
+    not replace them by existentially chosen witnesses.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_matching_direct_block_contractions,
         thm:mpu_physical_adjoint_identities,
-        thm:mpu_reflected_blocked_transfer_coordinates,
+        thm:mpu_reflected_transfer_power,
         thm:mpu_supplied_witness_overlapping_reblocking}
-    Reindex the normalized reflected diagonal by the doubled-bond swap and
-    transport the stabilized power to $\rho^{\mathsf T}$.  Positivity gives
-    the Hermitian symmetry that converts its conjugate transpose to
-    $|1)(\rho|$.  Conjugate transposition reverses the two blocked letters;
-    supplied-witness overlapping reblocking preserves the same insertion at
-    length $K+2$.  Thus these identities supply coordinates for the graphical
-    proof of \cite[Lemma~\texttt{lemuisometry}, Figure~
+    Apply the direct-block simple contractions to the reflected transfer power
+    $|\rho^{\mathsf T})(1|$.  Positivity identifies the conjugate-transposed
+    vectors with $(\rho|$ and $|1)$, while conjugate transposition reverses the
+    order of the two blocked letters.  Overlapping-window reblocking preserves
+    these witnesses through the two additional sites.  These contractions are
+    support identities for the graphical proof of
+    \cite[Lemma~\texttt{lemuisometry}, Figure~
     \texttt{II\_uUnitary.png}]{Cirac2017MPU}; they are not asserted as a
     separate printed theorem of that paper.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2288,6 +2288,69 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     original supplied witnesses.
 \end{proof}
 
+\begin{theorem}[Reflected blocked-transfer coordinates]
+    \label{thm:mpu_reflected_blocked_transfer_coordinates}
+    \lean{MPOTensor.doubledBondSwap,
+        MPOTensor.doubledBondSwap_apply,
+        MPOTensor.doubledBondSwap_symm,
+        MPOTensor.blockWordReverseEquiv,
+        MPOTensor.decodeBlock_blockWordReverseEquiv,
+        MPOTensor.wordOfBlock_blockWordReverseEquiv,
+        MPOTensor.blockWordReverseEquiv_involutive}
+    \leanok
+    \uses{def:mpu_double_layer,def:mpdo_physical_adjoint}
+    Reflection exchanges the two factors of a doubled virtual bond and
+    reverses the decoded physical word:
+    \begin{align}
+      (a,b)&\longmapsto(b,a),&
+      (i_0,\ldots,i_{K-1})&\longmapsto(i_{K-1},\ldots,i_0).
+    \end{align}
+    Both reindexings are involutions.
+\end{theorem}
+
+\begin{proof}\leanok
+    Decode the doubled bond, apply the product swap, and encode it again.
+    Decode a blocked index as a function on $\Fin K$, precompose with
+    $k\mapsto K-1-k$, and use reversal of the corresponding finite list.
+\end{proof}
+
+\begin{theorem}[Reflected supplied transfer insertion]
+    \label{thm:mpu_reflected_supplied_transfer_insertion}
+    \lean{MPOTensor.normalizedDiagonal_doubleLayerTensor_physicalAdjointTensor,
+        MPOTensor.normalizedDiagonal_blockTensor_mul_sq_eq_vecMulVec_of_transfer_power,
+        MPOTensor.conjTranspose_normalizedDiagonal_reflected_eq_vecMulVec,
+        MPOTensor.conjTranspose_normalizedDiagonal_reflected_blockTensor_eq_vecMulVec,
+        MPOTensor.reflected_transfer_power_eq_vecMulVec_transpose,
+        MPOTensor.outputLayer_normalizedDiagonal_pow_eq_vecMulVec,
+        MPOTensor.IsMPU.reflected_blockTensor_mul_sq_simple_contractions_of_transfer_power,
+        MPOTensor.IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions}
+    \leanok
+    \uses{thm:mpu_matching_direct_block_contractions,
+        thm:mpu_physical_adjoint_identities,
+        thm:mpu_reflected_blocked_transfer_coordinates,
+        thm:mpu_supplied_witness_overlapping_reblocking}
+    Let $E^J=|\rho)(1|$, where $\rho>0$, $\tr(\rho)=1$, and $J>0$, and set
+    $K=JD^2$.  Reflection and conjugate transposition give the insertion
+    $|1)(\rho|$.  At both lengths $K$ and $K+2$, the same reflected vectors
+    satisfy
+    \begin{align}
+      (\rho|\widehat W^{IJ\dagger}|1)&=\delta_{I,J},\\
+      \widehat W^{LM\dagger}\widehat W^{IJ\dagger}
+        &=\widehat W^{LM\dagger}|1)(\rho|\widehat W^{IJ\dagger}.
+    \end{align}
+    The common $K+2$ block is obtained by the overlapping-window theorem,
+    without replacing the supplied witnesses by existentially chosen ones.
+\end{theorem}
+
+\begin{proof}\leanok
+    Reindex the normalized reflected diagonal by the doubled-bond swap and
+    transport the stabilized power to $\rho^{\mathsf T}$.  Positivity gives
+    the Hermitian symmetry that converts its conjugate transpose to
+    $|1)(\rho|$.  Conjugate transposition reverses the two blocked letters;
+    supplied-witness overlapping reblocking preserves the same insertion at
+    length $K+2$.
+\end{proof}
+
 % The equality and range-insertion step remains tracked by issue #5971.
 \begin{remark}[Scope of the closed source-$u$ formulas]
     The first theorem rewrites the ordinary source-$u$ Gram entry, while the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2323,6 +2323,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpu_reflected_blocked_transfer_coordinates}
     Decode the doubled bond, apply the product swap, and encode it again.
     Regard a blocked index as a word indexed by the $K$ ordered positions,
     precompose with $k\mapsto K-1-k$, and reverse the corresponding finite


### PR DESCRIPTION
## Summary

- expose the doubled-bond swap and an explicitly separate blocked-word spatial reversal coordinate
- transport the normalized transfer power through the physical adjoint to the exact $|1)(\rho|$ output insertion
- provide supplied reflected `simple1`/`simple2` contractions at $K=JD^2$ and preserve the same witnesses at $K+2$
- synchronize the focused Chapter 28 support nodes with the paper’s graphical proof

## Mathematical scope

This PR formalizes support coordinates implicit in Cirac--Pérez-García--Schuch--Verstraete, Lemma `lemuisometry` and Figure `II_uUnitary.png` (arXiv:1703.09188, lines 536--557). The transfer proof uses the doubled-bond swap; blocked-word reversal is recorded separately as a spatial coordinate. Conjugate transposition reverses the order of the two blocked letters and converts the transported transpose witness to $|1)(\rho|$ using positivity/Hermiticity.

It does **not** prove the final source-$u$ Gram equality, an ambient coefficient identity, or an ambient coisometry. Those remain in parent #5982.

## Validation

- direct focused Lean check for `SourceUReflectedKernel.lean`
- targeted reflected-kernel and MPU aggregator build
- proof-integrity, whitespace, line-length, and focused-diff checks
- independent TNLean/Mathlib overlap and source-orientation audit
- independent blueprint/source-faithfulness review

Closes #5988.
Leaves #5982 open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal mathematics only—no runtime or security surface. Risk is mainly proof maintenance and import-graph coupling around the new reflected-kernel file and the `bondPairSwap` relocation.
> 
> **Overview**
> Adds **reflected open-tail support** for the source-$u$ Gram argument (Cirac et al., Lemma III.7): doubled-bond swap and blocked-word reversal coordinates, transport of supplied transfer powers through `physicalAdjointTensor` to the $|1)(\rho|$ output insertion, and reflected `simple1`/`simple2` contractions at $K=JD^2$ and $K+2$.
> 
> **`bondPairSwap` / `bondPairSwapEquiv`** are centralized in `PhysicalAdjoint.lean` (removed from `VerticalCF.lean`), with `VerticalCF` importing that module.
> 
> New **`SourceUReflectedKernel.lean`** proves normalized-diagonal reflection, transpose transfer powers, conjugate-transposed rank-one witnesses, and MPU reflected block contractions. Chapter 28 blueprint nodes are aligned with these Lean names; the final Gram equality remains out of scope (#5982).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4b951155ce8a1189d4f2a9c081ff6114f2452e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->