### PR TITLE
feat(QCA): complete the quasi-local C-star algebra

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.Analysis
 
 import TNLean.Analysis.Birkhoff
+import TNLean.Analysis.CStarCompletion
 import TNLean.Analysis.CStarMatrixKronecker
 import TNLean.Analysis.CfcConjugation
 import TNLean.Analysis.CfcKronecker

--- a/TNLean/Analysis/CStarCompletion.lean
+++ b/TNLean/Analysis/CStarCompletion.lean
@@ -19,7 +19,8 @@ both are imported together.
 
 ## Main definitions
 
-* `UniformSpace.Completion.toComplAlgHom` — the canonical algebra homomorphism into the completion.
+* `UniformSpace.Completion.toComplAlgHom` — the canonical algebra homomorphism into the
+  completion.
 * `UniformSpace.Completion.toComplStarAlgHom` — its star-preserving version.
 
 ## Main results
@@ -31,12 +32,19 @@ noncomputable section
 
 namespace UniformSpace.Completion
 
-variable {A : Type*} [NormedRing A] [StarRing A] [CStarRing A]
+variable {A : Type*} [NormedRing A] [StarRing A]
 
-/-- The involution on the completion is the uniformly continuous extension of the original
-involution. -/
+/-- The involution on the completion is defined by applying the completion functor to the
+original involution. For a normed star group, `coe_star` identifies it with the continuous
+extension of the original involution. -/
 instance instStar : Star (Completion A) where
   star := Completion.map star
+
+section NormedStar
+
+variable [normedStar : NormedStarGroup A]
+
+include normedStar
 
 /-- The canonical inclusion into the completion preserves the involution. -/
 @[simp, norm_cast]
@@ -62,7 +70,13 @@ instance instStarRing : StarRing (Completion A) where
     | hp => exact isClosed_eq (by fun_prop) (by fun_prop)
     | ih a b => simp only [← coe_add, ← coe_star, star_add]
 
-/-- The C-star inequality passes from a normed star ring to its completion. -/
+end NormedStar
+
+section CStar
+
+variable [CStarRing A]
+
+/-- The C-star inequality passes to the norm completion. -/
 instance instCStarRing : CStarRing (Completion A) where
   norm_mul_self_le x := by
     induction x using Completion.induction_on with
@@ -71,9 +85,13 @@ instance instCStarRing : CStarRing (Completion A) where
         simpa only [← coe_star, ← coe_mul, norm_coe] using
           (CStarRing.norm_mul_self_le (x := a))
 
+end CStar
+
 section Complex
 
-variable [NormedAlgebra ℂ A] [StarModule ℂ A]
+variable [normedStar : NormedStarGroup A] [NormedAlgebra ℂ A] [StarModule ℂ A]
+
+include normedStar
 
 /-- The completed involution is conjugate-linear over the complex numbers. -/
 instance instStarModule : StarModule ℂ (Completion A) where
@@ -84,10 +102,6 @@ instance instStarModule : StarModule ℂ (Completion A) where
           (continuous_star.comp (ContinuousConstSMul.continuous_const_smul c))
           ((ContinuousConstSMul.continuous_const_smul (star c)).comp continuous_star)
     | ih a => simp only [← coe_smul, ← coe_star, star_smul]
-
-/-- The norm completion of a complex normed C-star algebra is a C-star algebra. -/
-instance instCStarAlgebra : CStarAlgebra (Completion A) where
-  norm_smul_le := norm_smul_le
 
 /-- The canonical complex algebra homomorphism into the norm completion. -/
 def toComplAlgHom : A →ₐ[ℂ] Completion A where
@@ -113,5 +127,15 @@ theorem denseRange_toComplStarAlgHom :
   Completion.denseRange_coe
 
 end Complex
+
+section ComplexCStar
+
+variable [CStarRing A] [NormedAlgebra ℂ A] [StarModule ℂ A]
+
+/-- The norm completion of a complex normed C-star algebra is a C-star algebra. -/
+instance instCStarAlgebra : CStarAlgebra (Completion A) where
+  norm_smul_le := norm_smul_le
+
+end ComplexCStar
 
 end UniformSpace.Completion

--- a/TNLean/Analysis/CStarCompletion.lean
+++ b/TNLean/Analysis/CStarCompletion.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.CStarAlgebra.Classes
+import Mathlib.Analysis.Normed.Module.Completion
+
+/-!
+# C-star structures on norm completions
+
+This file extends the involution of a C-star ring to its norm completion. The extension is
+`UniformSpace.Completion.map star`; its algebraic laws and the C-star identity follow from the
+density of the original ring.
+
+The generic instances are isolated here because they are global orphan instances. If Mathlib adds
+completion instances for star rings, this module should be compared with that implementation before
+both are imported together.
+
+## Main definitions
+
+* `UniformSpace.Completion.toComplAlgHom` — the canonical algebra homomorphism into the completion.
+* `UniformSpace.Completion.toComplStarAlgHom` — its star-preserving version.
+
+## Main results
+
+* `UniformSpace.Completion.denseRange_toComplStarAlgHom` — the canonical map has dense range.
+-/
+
+noncomputable section
+
+namespace UniformSpace.Completion
+
+variable {A : Type*} [NormedRing A] [StarRing A] [CStarRing A]
+
+/-- The involution on the completion is the uniformly continuous extension of the original
+involution. -/
+instance instStar : Star (Completion A) where
+  star := Completion.map star
+
+/-- The canonical inclusion into the completion preserves the involution. -/
+@[simp, norm_cast]
+theorem coe_star (a : A) : ((star a : A) : Completion A) = star (a : Completion A) :=
+  (Completion.map_coe star_isometry.uniformContinuous a).symm
+
+/-- The extended involution is continuous. -/
+instance instContinuousStar : ContinuousStar (Completion A) where
+  continuous_star := Completion.continuous_map
+
+/-- The extended involution makes the completion a star ring. -/
+instance instStarRing : StarRing (Completion A) where
+  star_involutive x := by
+    induction x using Completion.induction_on with
+    | hp => exact isClosed_eq (by fun_prop) continuous_id
+    | ih a => simp only [← coe_star, star_star]
+  star_mul x y := by
+    induction x, y using Completion.induction_on₂ with
+    | hp => exact isClosed_eq (by fun_prop) (by fun_prop)
+    | ih a b => simp only [← coe_mul, ← coe_star, star_mul]
+  star_add x y := by
+    induction x, y using Completion.induction_on₂ with
+    | hp => exact isClosed_eq (by fun_prop) (by fun_prop)
+    | ih a b => simp only [← coe_add, ← coe_star, star_add]
+
+/-- The C-star inequality passes from a normed star ring to its completion. -/
+instance instCStarRing : CStarRing (Completion A) where
+  norm_mul_self_le x := by
+    induction x using Completion.induction_on with
+    | hp => exact isClosed_le (by fun_prop) (by fun_prop)
+    | ih a =>
+        simpa only [← coe_star, ← coe_mul, norm_coe] using
+          (CStarRing.norm_mul_self_le (x := a))
+
+section Complex
+
+variable [NormedAlgebra ℂ A] [StarModule ℂ A]
+
+/-- The completed involution is conjugate-linear over the complex numbers. -/
+instance instStarModule : StarModule ℂ (Completion A) where
+  star_smul c x := by
+    induction x using Completion.induction_on with
+    | hp =>
+        exact isClosed_eq
+          (continuous_star.comp (ContinuousConstSMul.continuous_const_smul c))
+          ((ContinuousConstSMul.continuous_const_smul (star c)).comp continuous_star)
+    | ih a => simp only [← coe_smul, ← coe_star, star_smul]
+
+/-- The norm completion of a complex normed C-star algebra is a C-star algebra. -/
+instance instCStarAlgebra : CStarAlgebra (Completion A) where
+  norm_smul_le := norm_smul_le
+
+/-- The canonical complex algebra homomorphism into the norm completion. -/
+def toComplAlgHom : A →ₐ[ℂ] Completion A where
+  __ := Completion.coeRingHom
+  commutes' _ := rfl
+
+/-- The canonical complex star-algebra homomorphism into the norm completion. -/
+def toComplStarAlgHom : A →⋆ₐ[ℂ] Completion A where
+  __ := toComplAlgHom
+  map_star' := coe_star
+
+omit [StarModule ℂ A] in
+/-- The canonical star-algebra homomorphism acts by the completion coercion. -/
+@[simp]
+theorem coe_toComplStarAlgHom : ⇑(toComplStarAlgHom : A →⋆ₐ[ℂ] Completion A) =
+    ((↑) : A → Completion A) :=
+  rfl
+
+omit [StarModule ℂ A] in
+/-- The original algebra is dense in its norm completion. -/
+theorem denseRange_toComplStarAlgHom :
+    DenseRange (toComplStarAlgHom : A →⋆ₐ[ℂ] Completion A) :=
+  Completion.denseRange_coe
+
+end Complex
+
+end UniformSpace.Completion

--- a/TNLean/Analysis/CStarCompletion.lean
+++ b/TNLean/Analysis/CStarCompletion.lean
@@ -37,7 +37,8 @@ variable {A : Type*} [NormedRing A] [StarRing A]
 /-- The involution on the completion is defined by applying the completion functor to the
 original involution. For a normed star group, `coe_star` identifies it with the continuous
 extension of the original involution. -/
-instance instStar : Star (Completion A) where
+@[nolint unusedArguments]
+instance instStar [NormedStarGroup A] : Star (Completion A) where
   star := Completion.map star
 
 section NormedStar

--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -11,3 +11,4 @@ Authors: TNLean contributors
 import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit
 import TNLean.QCA.LocalNorm
+import TNLean.QCA.QuasiLocal

--- a/TNLean/QCA/QuasiLocal.lean
+++ b/TNLean/QCA/QuasiLocal.lean
@@ -13,7 +13,8 @@ The quasi-local algebra is the norm completion of the algebraic local observable
 canonical algebraic and finite-region maps preserve the operator norm. The algebraic map has dense
 range, and the union of the ranges of all finite-region maps is dense.
 
-No single finite-region algebra has dense image in the quasi-local algebra.
+The finite-region density result concerns the union of all finite-region images; it makes no
+claim about the image of a fixed region.
 
 ## Main definitions
 

--- a/TNLean/QCA/QuasiLocal.lean
+++ b/TNLean/QCA/QuasiLocal.lean
@@ -25,7 +25,8 @@ No single finite-region algebra has dense image in the quasi-local algebra.
 
 * `SpinChain.quasiLocalObservable_isometry` — finite-region maps preserve distance.
 * `SpinChain.denseRange_algebraicToQuasiLocal` — algebraic local observables are dense.
-* `SpinChain.dense_iUnion_range_quasiLocalObservable` — the union over all finite regions is dense.
+* `SpinChain.dense_iUnion_range_quasiLocalObservable` — all finite-region images have dense
+  union.
 
 ## References
 

--- a/TNLean/QCA/QuasiLocal.lean
+++ b/TNLean/QCA/QuasiLocal.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.CStarCompletion
+import TNLean.QCA.LocalNorm
+
+/-!
+# The quasi-local algebra of a one-dimensional spin chain
+
+The quasi-local algebra is the norm completion of the algebraic local observable algebra. Its
+canonical algebraic and finite-region maps preserve the operator norm. The algebraic map has dense
+range, and the union of the ranges of all finite-region maps is dense.
+
+No single finite-region algebra has dense image in the quasi-local algebra.
+
+## Main definitions
+
+* `SpinChain.QuasiLocalAlgebra` — the completed local observable C-star algebra.
+* `SpinChain.algebraicToQuasiLocal` — the dense algebraic star-algebra map.
+* `SpinChain.quasiLocalObservable` — the canonical map from a finite region.
+
+## Main results
+
+* `SpinChain.quasiLocalObservable_isometry` — finite-region maps preserve distance.
+* `SpinChain.denseRange_algebraicToQuasiLocal` — algebraic local observables are dense.
+* `SpinChain.dense_iUnion_range_quasiLocalObservable` — the union over all finite regions is dense.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2285--2300.
+-/
+
+open scoped ComplexOrder
+
+namespace SpinChain
+
+attribute [local instance] CStarMatrix.instNorm CStarMatrix.instNormedAddCommGroup
+  CStarMatrix.instNormedRing CStarMatrix.instCStarRing
+
+/-- The quasi-local observable algebra is the operator-norm completion of the algebraic local
+algebra.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2300. -/
+abbrev QuasiLocalAlgebra (d : ℕ) [NeZero d] :=
+  UniformSpace.Completion (AlgebraicLocalAlgebra d)
+
+/-- The canonical star-algebra homomorphism from algebraic local observables to quasi-local
+observables.
+
+Source: arXiv:1703.09188, Appendix, lines 2296--2300. -/
+noncomputable def algebraicToQuasiLocal (d : ℕ) [NeZero d] :
+    AlgebraicLocalAlgebra d →⋆ₐ[ℂ] QuasiLocalAlgebra d :=
+  UniformSpace.Completion.toComplStarAlgHom
+
+/-- The canonical map from the finite-region observable algebra into the quasi-local algebra.
+
+Source: arXiv:1703.09188, Appendix, lines 2285--2300. -/
+noncomputable def quasiLocalObservable (d : ℕ) [NeZero d] (Λ : Finset ℤ) :
+    LocalAlgebra d Λ →⋆ₐ[ℂ] QuasiLocalAlgebra d :=
+  (algebraicToQuasiLocal d).comp (localObservable d Λ)
+
+/-- The algebraic embedding into the quasi-local algebra preserves norm. -/
+@[simp]
+theorem norm_algebraicToQuasiLocal (d : ℕ) [NeZero d] (A : AlgebraicLocalAlgebra d) :
+    ‖algebraicToQuasiLocal d A‖ = ‖A‖ :=
+  UniformSpace.Completion.norm_coe A
+
+/-- Every finite-region map into the quasi-local algebra preserves the operator norm.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2300. -/
+@[simp]
+theorem norm_quasiLocalObservable (d : ℕ) [NeZero d] (Λ : Finset ℤ)
+    (A : LocalAlgebra d Λ) :
+    ‖quasiLocalObservable d Λ A‖ = ‖A‖ := by
+  rw [quasiLocalObservable, StarAlgHom.comp_apply, norm_algebraicToQuasiLocal,
+    norm_localObservable]
+
+/-- Every finite-region map into the quasi-local algebra is an isometry.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2300. -/
+theorem quasiLocalObservable_isometry (d : ℕ) [NeZero d] (Λ : Finset ℤ) :
+    Isometry (quasiLocalObservable d Λ) := by
+  rw [isometry_iff_dist_eq]
+  intro A B
+  rw [dist_eq_norm, dist_eq_norm, ← map_sub, norm_quasiLocalObservable]
+
+/-- Every finite-region map into the quasi-local algebra is injective. -/
+theorem quasiLocalObservable_injective (d : ℕ) [NeZero d] (Λ : Finset ℤ) :
+    Function.Injective (quasiLocalObservable d Λ) :=
+  (quasiLocalObservable_isometry d Λ).injective
+
+/-- Enlarging a finite region does not change the associated quasi-local observable. -/
+@[simp]
+theorem quasiLocalObservable_localInclusion (d : ℕ) [NeZero d]
+    {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ) (A : LocalAlgebra d Λ) :
+    quasiLocalObservable d Γ (localInclusion h A) = quasiLocalObservable d Λ A := by
+  simp only [quasiLocalObservable, StarAlgHom.comp_apply,
+    localObservable_localInclusion]
+
+/-- Algebraic local observables have dense image in the quasi-local algebra.
+
+Source: arXiv:1703.09188, Appendix, lines 2296--2300. -/
+theorem denseRange_algebraicToQuasiLocal (d : ℕ) [NeZero d] :
+    DenseRange (algebraicToQuasiLocal d) :=
+  UniformSpace.Completion.denseRange_toComplStarAlgHom
+
+/-- The union of the images of all finite-region observable algebras is dense in the quasi-local
+algebra.
+
+The union ranges over every finite region; no fixed finite-region image is asserted to be dense.
+Source: arXiv:1703.09188, Appendix, lines 2285--2300. -/
+theorem dense_iUnion_range_quasiLocalObservable (d : ℕ) [NeZero d] :
+    Dense (⋃ Λ : Finset ℤ, Set.range (quasiLocalObservable d Λ)) := by
+  apply Dense.mono _ (denseRange_algebraicToQuasiLocal d)
+  rintro x ⟨A, rfl⟩
+  obtain ⟨Λ, a, ha⟩ := exists_supportedIn A
+  rw [← ha]
+  exact Set.mem_iUnion.2 ⟨Λ, ⟨a, rfl⟩⟩
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4088,6 +4088,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \lean{SpinChain.QuasiLocalAlgebra,SpinChain.algebraicToQuasiLocal,
     UniformSpace.Completion.toComplAlgHom,
     UniformSpace.Completion.toComplStarAlgHom,
+    UniformSpace.Completion.coe_toComplStarAlgHom,
     UniformSpace.Completion.instStar,UniformSpace.Completion.coe_star,
     UniformSpace.Completion.instContinuousStar,
     UniformSpace.Completion.instStarRing,
@@ -4155,8 +4156,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}\leanok
-  \uses{def:qca_algebraic_local_operator_norm,
-    def:qca_algebraic_local_algebra}
+  \uses{def:qca_quasi_local_observable,
+    def:qca_algebraic_local_operator_norm,def:qca_algebraic_local_algebra}
   The algebraic inclusion $\iota_\Lambda$ and the completion map $j$ both
   preserve the norm.  Their composite is therefore an isometry and hence
   injective.  Compatibility follows from
@@ -4165,13 +4166,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Density of finite-region observables]
   \label{thm:qca_quasi_local_density}
-  \lean{UniformSpace.Completion.coe_toComplStarAlgHom,
-    UniformSpace.Completion.denseRange_toComplStarAlgHom,
+  \lean{UniformSpace.Completion.denseRange_toComplStarAlgHom,
     SpinChain.denseRange_algebraicToQuasiLocal,
     SpinChain.dense_iUnion_range_quasiLocalObservable}
   \leanok
   \uses{def:qca_quasi_local_algebra,def:qca_quasi_local_observable,
-    lem:qca_quasi_local_observable,thm:qca_local_observable_finite_support}
+    thm:qca_local_observable_finite_support}
   Algebraic local observables are dense in the quasi-local algebra.  Equivalently,
   \begin{align}
     \overline{j(\mathcal A_{\mathrm{loc}})}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4082,3 +4082,101 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   algebraic direct limit has a representative in one member of the directed
   system.
 \end{proof}
+
+\begin{definition}[Quasi-local observable algebra]
+  \label{def:qca_quasi_local_algebra}
+  \lean{SpinChain.QuasiLocalAlgebra,SpinChain.algebraicToQuasiLocal,
+    UniformSpace.Completion.instStar,UniformSpace.Completion.coe_star,
+    UniformSpace.Completion.instContinuousStar,
+    UniformSpace.Completion.instStarRing,
+    UniformSpace.Completion.instCStarRing,
+    UniformSpace.Completion.instStarModule,
+    UniformSpace.Completion.instCStarAlgebra}
+  \leanok
+  \uses{def:qca_algebraic_local_cstar_ring,
+    def:qca_algebraic_local_normed_star_algebra}
+  For $d>0$, the quasi-local observable algebra is the operator-norm
+  completion
+  \begin{align}
+    \mathcal A
+      &=\overline{\mathcal A_{\mathrm{loc}}}^{\lVert\cdot\rVert}.
+  \end{align}
+  The involution on $\mathcal A$ is the unique continuous extension of the
+  involution on $\mathcal A_{\mathrm{loc}}$.  It makes $\mathcal A$ a complex
+  C-star algebra, and the canonical star-algebra homomorphism
+  \begin{align}
+    j\colon\mathcal A_{\mathrm{loc}}&\longrightarrow\mathcal A
+  \end{align}
+  is the completion map.
+\end{definition}
+
+\begin{proof}\leanok
+  The involution is isometric on $\mathcal A_{\mathrm{loc}}$, hence extends
+  continuously to the completion.  The identities
+  $(A+B)^*=A^*+B^*$, $(AB)^*=B^*A^*$, and $(A^*)^*=A$
+  hold on the dense subalgebra $j(\mathcal A_{\mathrm{loc}})$ and therefore
+  on $\mathcal A$.  The same density argument extends
+  \begin{align}
+    \lVert A^*A\rVert&=\lVert A\rVert^2,
+  \end{align}
+  so the completed algebra satisfies the C-star identity.
+\end{proof}
+
+\begin{lemma}[Finite-region observables in the quasi-local algebra]
+  \label{lem:qca_quasi_local_observable}
+  \lean{SpinChain.quasiLocalObservable,
+    SpinChain.norm_algebraicToQuasiLocal,
+    SpinChain.norm_quasiLocalObservable,
+    SpinChain.quasiLocalObservable_isometry,
+    SpinChain.quasiLocalObservable_injective,
+    SpinChain.quasiLocalObservable_localInclusion}
+  \leanok
+  \uses{def:qca_quasi_local_algebra,lem:qca_local_observable_isometry}
+  For every finite region $\Lambda$, the map
+  \begin{align}
+    j_\Lambda\colon\mathcal A_\Lambda&\longrightarrow\mathcal A
+  \end{align}
+  defined by $j_\Lambda=j\circ\iota_\Lambda$ is an injective isometry.  If $\Lambda\subseteq\Gamma$, then
+  \begin{align}
+    j_\Gamma\circ\iota_{\Lambda,\Gamma}&=j_\Lambda.
+  \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+  The algebraic inclusion $\iota_\Lambda$ and the completion map $j$ both
+  preserve the norm.  Their composite is therefore an isometry and hence
+  injective.  Compatibility follows from
+  $\iota_\Gamma\circ\iota_{\Lambda,\Gamma}=\iota_\Lambda$.
+\end{proof}
+
+\begin{theorem}[Density of finite-region observables]
+  \label{thm:qca_quasi_local_density}
+  \lean{UniformSpace.Completion.toComplAlgHom,
+    UniformSpace.Completion.toComplStarAlgHom,
+    UniformSpace.Completion.coe_toComplStarAlgHom,
+    UniformSpace.Completion.denseRange_toComplStarAlgHom,
+    SpinChain.denseRange_algebraicToQuasiLocal,
+    SpinChain.dense_iUnion_range_quasiLocalObservable}
+  \leanok
+  \uses{def:qca_quasi_local_algebra,lem:qca_quasi_local_observable,
+    thm:qca_local_observable_finite_support}
+  Algebraic local observables are dense in the quasi-local algebra.  Equivalently,
+  \begin{align}
+    \overline{j(\mathcal A_{\mathrm{loc}})}
+      &=\overline{\bigcup_{\Lambda\Subset\mathbb Z}
+        j_\Lambda(\mathcal A_\Lambda)}
+       =\mathcal A.
+  \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+  Density of $j(\mathcal A_{\mathrm{loc}})$ is the defining density property
+  of the completion.  Every algebraic local observable has a representative
+  in some finite region, so
+  \begin{align}
+    j(\mathcal A_{\mathrm{loc}})
+      &=\bigcup_{\Lambda\Subset\mathbb Z}j_\Lambda(\mathcal A_\Lambda).
+  \end{align}
+  Taking closures proves the second equality.  The union over all finite
+  regions is essential; no single finite-region image is claimed to be dense.
+\end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4086,6 +4086,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{definition}[Quasi-local observable algebra]
   \label{def:qca_quasi_local_algebra}
   \lean{SpinChain.QuasiLocalAlgebra,SpinChain.algebraicToQuasiLocal,
+    UniformSpace.Completion.toComplAlgHom,
+    UniformSpace.Completion.toComplStarAlgHom,
     UniformSpace.Completion.instStar,UniformSpace.Completion.coe_star,
     UniformSpace.Completion.instContinuousStar,
     UniformSpace.Completion.instStarRing,
@@ -4115,35 +4117,46 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   continuously to the completion.  The identities
   $(A+B)^*=A^*+B^*$, $(AB)^*=B^*A^*$, and $(A^*)^*=A$
   hold on the dense subalgebra $j(\mathcal A_{\mathrm{loc}})$ and therefore
-  on $\mathcal A$.  The same density argument extends
+  on $\mathcal A$.  The conjugate-linear identity
+  $(cA)^*=\overline cA^*$ extends by the same argument.  Density also extends
   \begin{align}
     \lVert A^*A\rVert&=\lVert A\rVert^2,
   \end{align}
   so the completed algebra satisfies the C-star identity.
 \end{proof}
 
+\begin{definition}[Finite-region quasi-local observable]
+  \label{def:qca_quasi_local_observable}
+  \lean{SpinChain.quasiLocalObservable}
+  \leanok
+  \uses{def:qca_quasi_local_algebra,def:qca_algebraic_local_algebra}
+  For every finite region $\Lambda$, define
+  \begin{align}
+    j_\Lambda\colon\mathcal A_\Lambda&\longrightarrow\mathcal A,
+    &j_\Lambda&=j\circ\iota_\Lambda.
+  \end{align}
+\end{definition}
+
 \begin{lemma}[Finite-region observables in the quasi-local algebra]
   \label{lem:qca_quasi_local_observable}
-  \lean{SpinChain.quasiLocalObservable,
-    SpinChain.norm_algebraicToQuasiLocal,
+  \lean{SpinChain.norm_algebraicToQuasiLocal,
     SpinChain.norm_quasiLocalObservable,
     SpinChain.quasiLocalObservable_isometry,
     SpinChain.quasiLocalObservable_injective,
     SpinChain.quasiLocalObservable_localInclusion}
   \leanok
-  \uses{def:qca_quasi_local_algebra,lem:qca_local_observable_isometry}
-  For every finite region $\Lambda$, the map
-  \begin{align}
-    j_\Lambda\colon\mathcal A_\Lambda&\longrightarrow\mathcal A
-  \end{align}
-  defined by $j_\Lambda=j\circ\iota_\Lambda$ is an injective isometry.  If
-  $\Lambda\subseteq\Gamma$, then
+  \uses{def:qca_quasi_local_observable,
+    def:qca_algebraic_local_operator_norm,def:qca_algebraic_local_algebra}
+  For every finite region $\Lambda$, the map $j_\Lambda$ is an injective
+  isometry.  If $\Lambda\subseteq\Gamma$, then
   \begin{align}
     j_\Gamma\circ\iota_{\Lambda,\Gamma}&=j_\Lambda.
   \end{align}
 \end{lemma}
 
 \begin{proof}\leanok
+  \uses{def:qca_algebraic_local_operator_norm,
+    def:qca_algebraic_local_algebra}
   The algebraic inclusion $\iota_\Lambda$ and the completion map $j$ both
   preserve the norm.  Their composite is therefore an isometry and hence
   injective.  Compatibility follows from
@@ -4152,15 +4165,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Density of finite-region observables]
   \label{thm:qca_quasi_local_density}
-  \lean{UniformSpace.Completion.toComplAlgHom,
-    UniformSpace.Completion.toComplStarAlgHom,
-    UniformSpace.Completion.coe_toComplStarAlgHom,
+  \lean{UniformSpace.Completion.coe_toComplStarAlgHom,
     UniformSpace.Completion.denseRange_toComplStarAlgHom,
     SpinChain.denseRange_algebraicToQuasiLocal,
     SpinChain.dense_iUnion_range_quasiLocalObservable}
   \leanok
-  \uses{def:qca_quasi_local_algebra,lem:qca_quasi_local_observable,
-    thm:qca_local_observable_finite_support}
+  \uses{def:qca_quasi_local_algebra,def:qca_quasi_local_observable,
+    lem:qca_quasi_local_observable,thm:qca_local_observable_finite_support}
   Algebraic local observables are dense in the quasi-local algebra.  Equivalently,
   \begin{align}
     \overline{j(\mathcal A_{\mathrm{loc}})}
@@ -4171,6 +4182,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{thm:qca_local_observable_finite_support}
   Density of $j(\mathcal A_{\mathrm{loc}})$ is the defining density property
   of the completion.  Every algebraic local observable has a representative
   in some finite region, so
@@ -4178,6 +4190,6 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     j(\mathcal A_{\mathrm{loc}})
       &=\bigcup_{\Lambda\Subset\mathbb Z}j_\Lambda(\mathcal A_\Lambda).
   \end{align}
-  Taking closures proves the second equality.  The union over all finite
-  regions is essential; no single finite-region image is claimed to be dense.
+  Taking closures proves the second equality.  This theorem concerns the union
+  over all finite regions and makes no claim about the image of a fixed region.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4136,7 +4136,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \begin{align}
     j_\Lambda\colon\mathcal A_\Lambda&\longrightarrow\mathcal A
   \end{align}
-  defined by $j_\Lambda=j\circ\iota_\Lambda$ is an injective isometry.  If $\Lambda\subseteq\Gamma$, then
+  defined by $j_\Lambda=j\circ\iota_\Lambda$ is an injective isometry.  If
+  $\Lambda\subseteq\Gamma$, then
   \begin{align}
     j_\Gamma\circ\iota_{\Lambda,\Gamma}&=j_\Lambda.
   \end{align}


### PR DESCRIPTION
## What changed

- extend involution, star-ring, star-module, C-star-ring, and C-star-algebra structures to the norm completion
- define the quasi-local spin-chain C-star algebra with canonical finite-region maps
- prove those maps are isometric and compatible with inclusions, and that their union has dense range
- synchronize the Chapter 28 blueprint with the completed Appendix construction

## Validation

- `lake build TNLean.Analysis.CStarCompletion TNLean.QCA.QuasiLocal`
- focused Mathlib declaration lint and proof-dependency audit
- generated-import, style, policy, and forbidden-token checks
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- two LuaLaTeX blueprint passes with no undefined cross-references

Closes #6042
Advances #6025 and #5710

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New global completion instances could interact with future Mathlib imports; the QCA layer is foundational for later operator-algebra formalization but changes are additive proofs on existing local-algebra infrastructure.
> 
> **Overview**
> This PR **completes the quasi-local observable algebra** for the spin-chain QCA appendix by taking the operator-norm completion of the existing algebraic local algebra, and wires that construction through new completion infrastructure and blueprint entries.
> 
> **`TNLean.Analysis.CStarCompletion`** adds global instances so a normed star ring’s **norm completion** carries star, continuous star, star ring, C-star ring, star module, and C-star algebra structure, plus **`toComplStarAlgHom`** and density of the canonical coercion. That isolates orphan completion instances until Mathlib may supply equivalents.
> 
> **`TNLean.QCA.QuasiLocal`** defines **`QuasiLocalAlgebra`** as `Completion (AlgebraicLocalAlgebra d)`, **`algebraicToQuasiLocal`**, and per-region **`quasiLocalObservable`**, and proves norm preservation, isometry, inclusion compatibility, dense range of the algebraic map, and density of the union of all finite-region images (not density of a single region’s image).
> 
> Chapter 28 blueprint material is synchronized with definitions, lemmas, and the density theorem for the quasi-local construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d833c67d995f955fe42c0a1e7f00949911eddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->