### PR TITLE
docs(blueprint): align local C-star identity environment

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3956,8 +3956,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   algebra.
 \end{proof}
 
-\begin{theorem}[C-star identity for local observables]
-  \label{thm:qca_algebraic_local_norm_star_mul_self}
+\begin{lemma}[C-star identity for local observables]
+  \label{lem:qca_algebraic_local_norm_star_mul_self}
   \lean{SpinChain.norm_star_mul_self}
   \leanok
   \uses{def:qca_algebraic_local_normed_star_algebra}
@@ -3965,7 +3965,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \begin{align}
     \lVert A^*A\rVert&=\lVert A\rVert^2.
   \end{align}
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
   Choose a finite region $\Lambda$ and a representative
@@ -3982,7 +3982,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{def:qca_algebraic_local_cstar_ring}
   \lean{SpinChain.instCStarRingAlgebraicLocalAlgebra}
   \leanok
-  \uses{thm:qca_algebraic_local_norm_star_mul_self}
+  \uses{lem:qca_algebraic_local_norm_star_mul_self}
   The normed star algebra of local observables satisfies the C-star axiom.
   This structure does not include completeness.
 \end{definition}


### PR DESCRIPTION
## What changed

- change the `SpinChain.norm_star_mul_self` blueprint entry from a theorem to a lemma
- rename its label from `thm:` to `lem:` and update the downstream dependency

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- two LuaLaTeX blueprint passes with no undefined cross-references
- `git diff --check`

Closes #6060

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint-only label and environment changes with a single downstream `\uses` update; no runtime or formal proof logic is modified in the diff.
> 
> **Overview**
> Reclassifies the blueprint entry for `SpinChain.norm_star_mul_self` from a **theorem** to a **lemma**, renaming its label from `thm:qca_algebraic_local_norm_star_mul_self` to `lem:qca_algebraic_local_norm_star_mul_self`.
> 
> The downstream **C-star axiom structure** definition updates its `\uses` dependency to cite the new lemma label. No mathematical content or proof text changes—only LaTeX environment and cross-reference alignment with the Lean formalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d027ba034a2f8f6bdc4900b0f0bf21419ef9ffae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->