### PR TITLE
feat(MPS/MPDO): prove Strong-RFP periodic rank growth

### DIFF
--- a/TNLean/Channel/SingleKrausPositivity.lean
+++ b/TNLean/Channel/SingleKrausPositivity.lean
@@ -12,7 +12,7 @@ import Mathlib.LinearAlgebra.Matrix.Rank
 This file records algebraic and order properties of conjugation by a rectangular
 isometry.
 
-## Main declarations
+## Main results
 
 * `Matrix.rank_singleKrausMap_of_mem_unitaryGroup`: unitary single-Kraus
   conjugation preserves rank.

--- a/TNLean/Channel/SingleKrausPositivity.lean
+++ b/TNLean/Channel/SingleKrausPositivity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.KrausCPTP
+import Mathlib.LinearAlgebra.Matrix.Rank
 
 /-!
 # Positivity under single-Kraus isometries
@@ -13,6 +14,8 @@ isometry.
 
 ## Main declarations
 
+* `Matrix.rank_singleKrausMap_of_mem_unitaryGroup`: unitary single-Kraus
+  conjugation preserves rank.
 * `Matrix.singleKrausMap_kronecker`: single-Kraus conjugation distributes over
   Kronecker products.
 * `Matrix.singleKrausMap_mul_of_isometry`: isometric single-Kraus conjugation
@@ -22,6 +25,22 @@ isometry.
 -/
 
 open scoped Matrix ComplexOrder Kronecker
+
+/-- A unitary single-Kraus conjugation preserves ordinary matrix rank. -/
+theorem Matrix.rank_singleKrausMap_of_mem_unitaryGroup
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (U A : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    (singleKrausMap U A).rank = A.rank := by
+  have hUdet : IsUnit U.det := Matrix.UnitaryGroup.det_isUnit ⟨U, hU⟩
+  have hUh : Uᴴ ∈ Matrix.unitaryGroup n ℂ := by
+    exact ⟨by simpa only [Matrix.star_eq_conjTranspose,
+        Matrix.conjTranspose_conjTranspose] using hU.2,
+      by simpa only [Matrix.star_eq_conjTranspose,
+        Matrix.conjTranspose_conjTranspose] using hU.1⟩
+  have hUhdet : IsUnit Uᴴ.det := Matrix.UnitaryGroup.det_isUnit ⟨Uᴴ, hUh⟩
+  rw [singleKrausMap_apply,
+    Matrix.rank_mul_eq_left_of_isUnit_det Uᴴ (U * A) hUhdet,
+    Matrix.rank_mul_eq_right_of_isUnit_det U A hUdet]
 
 /-- Single-Kraus conjugation distributes over Kronecker products. -/
 theorem Matrix.singleKrausMap_kronecker

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -287,6 +287,7 @@ import TNLean.MPS.MPDO.SourceBNTBlocking
 import TNLean.MPS.MPDO.SourceZCLMarginal
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.StrongRFP
+import TNLean.MPS.MPDO.StrongRFPRankGrowth
 import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
 import TNLean.MPS.MPDO.TopologicalDensityDecomposition
 import TNLean.MPS.MPDO.TopologicalGibbsHamiltonian

--- a/TNLean/MPS/MPDO/StrongRFPRankGrowth.lean
+++ b/TNLean/MPS/MPDO/StrongRFPRankGrowth.lean
@@ -24,6 +24,26 @@ multiplied by `rank P`.
 
 open scoped Matrix Kronecker ComplexOrder
 
+namespace Matrix
+
+/-- A unitary single-Kraus conjugation preserves ordinary matrix rank. -/
+theorem rank_singleKrausMap_of_mem_unitaryGroup
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (U A : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    (singleKrausMap U A).rank = A.rank := by
+  have hUdet : IsUnit U.det := Matrix.UnitaryGroup.det_isUnit ⟨U, hU⟩
+  have hUh : Uᴴ ∈ Matrix.unitaryGroup n ℂ := by
+    exact ⟨by simpa only [Matrix.star_eq_conjTranspose,
+        Matrix.conjTranspose_conjTranspose] using hU.2,
+      by simpa only [Matrix.star_eq_conjTranspose,
+        Matrix.conjTranspose_conjTranspose] using hU.1⟩
+  have hUhdet : IsUnit Uᴴ.det := Matrix.UnitaryGroup.det_isUnit ⟨Uᴴ, hUh⟩
+  rw [singleKrausMap_apply,
+    Matrix.rank_mul_eq_left_of_isUnit_det Uᴴ (U * A) hUhdet,
+    Matrix.rank_mul_eq_right_of_isUnit_det U A hUdet]
+
+end Matrix
+
 namespace MPOTensor
 
 variable {d D : ℕ}
@@ -51,25 +71,9 @@ theorem tensorMapId_preparationMap_eq_reindex_kronecker
   simp [Matrix.tensorMapId_apply, Matrix.preparationMap, Matrix.bipartiteSlice,
     Matrix.reindex_apply, firstSitePreparationEquiv]
 
-/-- A unitary single-Kraus conjugation preserves ordinary matrix rank. -/
-theorem Matrix.rank_singleKrausMap_of_mem_unitaryGroup
-    {n : Type*} [Fintype n] [DecidableEq n]
-    (U A : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
-    (singleKrausMap U A).rank = A.rank := by
-  have hUdet : IsUnit U.det := Matrix.UnitaryGroup.det_isUnit ⟨U, hU⟩
-  have hUh : Uᴴ ∈ Matrix.unitaryGroup n ℂ := by
-    exact ⟨by simpa only [Matrix.star_eq_conjTranspose,
-        Matrix.conjTranspose_conjTranspose] using hU.2,
-      by simpa only [Matrix.star_eq_conjTranspose,
-        Matrix.conjTranspose_conjTranspose] using hU.1⟩
-  have hUhdet : IsUnit Uᴴ.det := Matrix.UnitaryGroup.det_isUnit ⟨Uᴴ, hUh⟩
-  rw [singleKrausMap_apply,
-    Matrix.rank_mul_eq_left_of_isUnit_det Uᴴ (U * A) hUhdet,
-    Matrix.rank_mul_eq_right_of_isUnit_det U A hUdet]
-
 /-- Applying a unitary conjugation to the first factor is conjugation by the
 Kronecker product of that unitary with the identity. -/
-theorem tensorMapId_singleKrausMap
+private theorem tensorMapId_singleKrausMap
     {α δ : Type*} [Fintype α] [Fintype δ] [DecidableEq δ]
     (U : Matrix α α ℂ) (X : Matrix (α × δ) (α × δ) ℂ) :
     Matrix.tensorMapId (singleKrausMap U) X =
@@ -85,23 +89,6 @@ theorem tensorMapId_singleKrausMap
   · intro w _ hw
     simp [Ne.symm hw]
   · simp
-
-/-- Tensoring a unitary matrix with the identity gives a unitary matrix. -/
-theorem Matrix.kronecker_one_mem_unitaryGroup
-    {α δ : Type*} [Fintype α] [DecidableEq α] [Fintype δ] [DecidableEq δ]
-    (U : Matrix α α ℂ) (hU : U ∈ Matrix.unitaryGroup α ℂ) :
-    U ⊗ₖ (1 : Matrix δ δ ℂ) ∈ Matrix.unitaryGroup (α × δ) ℂ := by
-  constructor
-  · rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
-      Matrix.conjTranspose_one, ← Matrix.mul_kronecker_mul]
-    rw [show Uᴴ * U = 1 by
-      simpa only [Matrix.star_eq_conjTranspose] using hU.1]
-    simp
-  · rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
-      Matrix.conjTranspose_one, ← Matrix.mul_kronecker_mul]
-    rw [show U * Uᴴ = 1 by
-      simpa only [Matrix.star_eq_conjTranspose] using hU.2]
-    simp
 
 /-- The fixed Strong-RFP witnesses give the global closure identity. The
 canonical regroupings expose the operation as first adjoining `P`, then
@@ -212,7 +199,7 @@ theorem strongRFP_rank_mpo_add_two
   simp only [LinearMap.comp_apply, Matrix.tensorMapIdLM_apply]
   rw [tensorMapId_singleKrausMap]
   rw [Matrix.rank_singleKrausMap_of_mem_unitaryGroup _ _
-    (Matrix.kronecker_one_mem_unitaryGroup U hU)]
+    (Matrix.kronecker_mem_unitary hU (one_mem _))]
   rw [tensorMapId_preparationMap_eq_reindex_kronecker, Matrix.rank_reindex,
     Matrix.rank_kronecker]
   change (Matrix.reindex _ _ _).rank * P.rank = _

--- a/TNLean/MPS/MPDO/StrongRFPRankGrowth.lean
+++ b/TNLean/MPS/MPDO/StrongRFPRankGrowth.lean
@@ -1,0 +1,256 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixRankKronecker
+import TNLean.MPS.MPDO.RFPViaTSGlobal
+import TNLean.MPS.MPDO.StrongRFP
+
+/-!
+# Periodic rank growth of a strong renormalization fixed point
+
+CPSV16 Appendix D observes that the local Strong-RFP relation
+`M₂ = U (M₁ ⊗ P) U†` iterates around a periodic chain. Thus adjoining one
+site tensors the periodic operator with the same positive matrix `P`, up to a
+unitary change of physical coordinates, and its ordinary matrix rank is
+multiplied by `rank P`.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Appendix D,
+  lines 2109--2117 (labels `Strong-RFP` and the paragraph following it).
+-/
+
+open scoped Matrix Kronecker ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The canonical shuffle which places the newly prepared physical coordinate
+next to the first coordinate of a chain.
+
+Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2109--2117. -/
+def firstSitePreparationEquiv (N : ℕ) :
+    ((Fin d × (Fin N → Fin d)) × Fin d) ≃ ((Fin d × Fin d) × (Fin N → Fin d)) where
+  toFun x := ((x.1.1, x.2), x.1.2)
+  invFun x := ((x.1.1, x.2), x.1.2)
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- Localizing a preparation map at the first site is, after the canonical
+shuffle, the Kronecker product with the prepared matrix. -/
+theorem tensorMapId_preparationMap_eq_reindex_kronecker
+    (P : Matrix (Fin d) (Fin d) ℂ) (N : ℕ)
+    (A : Matrix (Fin d × (Fin N → Fin d)) (Fin d × (Fin N → Fin d)) ℂ) :
+    Matrix.tensorMapId (Matrix.preparationMap P) A =
+      Matrix.reindex (firstSitePreparationEquiv (d := d) N)
+        (firstSitePreparationEquiv (d := d) N) (A ⊗ₖ P) := by
+  ext ⟨⟨i, j⟩, u⟩ ⟨⟨k, l⟩, v⟩
+  simp [Matrix.tensorMapId_apply, Matrix.preparationMap, Matrix.bipartiteSlice,
+    Matrix.reindex_apply, firstSitePreparationEquiv]
+
+/-- A unitary single-Kraus conjugation preserves ordinary matrix rank. -/
+theorem Matrix.rank_singleKrausMap_of_mem_unitaryGroup
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (U A : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    (singleKrausMap U A).rank = A.rank := by
+  have hUdet : IsUnit U.det := Matrix.UnitaryGroup.det_isUnit ⟨U, hU⟩
+  have hUh : Uᴴ ∈ Matrix.unitaryGroup n ℂ := by
+    exact ⟨by simpa only [Matrix.star_eq_conjTranspose,
+        Matrix.conjTranspose_conjTranspose] using hU.2,
+      by simpa only [Matrix.star_eq_conjTranspose,
+        Matrix.conjTranspose_conjTranspose] using hU.1⟩
+  have hUhdet : IsUnit Uᴴ.det := Matrix.UnitaryGroup.det_isUnit ⟨Uᴴ, hUh⟩
+  rw [singleKrausMap_apply,
+    Matrix.rank_mul_eq_left_of_isUnit_det Uᴴ (U * A) hUhdet,
+    Matrix.rank_mul_eq_right_of_isUnit_det U A hUdet]
+
+/-- Applying a unitary conjugation to the first factor is conjugation by the
+Kronecker product of that unitary with the identity. -/
+theorem tensorMapId_singleKrausMap
+    {α δ : Type*} [Fintype α] [Fintype δ] [DecidableEq δ]
+    (U : Matrix α α ℂ) (X : Matrix (α × δ) (α × δ) ℂ) :
+    Matrix.tensorMapId (singleKrausMap U) X =
+      singleKrausMap (U ⊗ₖ (1 : Matrix δ δ ℂ)) X := by
+  ext ⟨i, u⟩ ⟨j, v⟩
+  simp only [Matrix.tensorMapId_apply, singleKrausMap_apply, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, Matrix.kroneckerMap_apply, Fintype.sum_prod_type,
+    Matrix.one_apply, Matrix.bipartiteSlice]
+  apply Finset.sum_congr rfl
+  intro k _
+  rw [Finset.sum_eq_single v]
+  · simp
+  · intro w _ hw
+    simp [Ne.symm hw]
+  · simp
+
+/-- Tensoring a unitary matrix with the identity gives a unitary matrix. -/
+theorem Matrix.kronecker_one_mem_unitaryGroup
+    {α δ : Type*} [Fintype α] [DecidableEq α] [Fintype δ] [DecidableEq δ]
+    (U : Matrix α α ℂ) (hU : U ∈ Matrix.unitaryGroup α ℂ) :
+    U ⊗ₖ (1 : Matrix δ δ ℂ) ∈ Matrix.unitaryGroup (α × δ) ℂ := by
+  constructor
+  · rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, ← Matrix.mul_kronecker_mul]
+    rw [show Uᴴ * U = 1 by
+      simpa only [Matrix.star_eq_conjTranspose] using hU.1]
+    simp
+  · rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, ← Matrix.mul_kronecker_mul]
+    rw [show U * Uᴴ = 1 by
+      simpa only [Matrix.star_eq_conjTranspose] using hU.2]
+    simp
+
+/-- The fixed Strong-RFP witnesses give the global closure identity. The
+canonical regroupings expose the operation as first adjoining `P`, then
+conjugating the first two coordinates by `U`.
+
+Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2109--2117. -/
+theorem strongRFP_physCloseN_eq_localized_preparation
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (U : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hrel : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      physClose2 M X = U * (physClose1 M X ⊗ₖ P) * Uᴴ)
+    (N : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    physCloseN M (N + 2) X =
+      refineFirstSite ((singleKrausMap U).comp (Matrix.preparationMap P)) N
+        (physCloseN M (N + 1) X) := by
+  symm
+  apply refineFirstSite_physCloseN
+  intro Y
+  simp only [LinearMap.comp_apply, singleKrausMap_apply]
+  exact (hrel Y).symm
+
+/-- Written with all canonical regroupings visible, the global closure is
+unitarily equivalent to the Kronecker product of the shorter closure with
+`P`. This is the fixed-witness operator identity used for rank growth.
+
+Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2109--2117. -/
+theorem strongRFP_physCloseN_eq_reindex_singleKrausMap_kronecker
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (U : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hrel : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      physClose2 M X = U * (physClose1 M X ⊗ₖ P) * Uᴴ)
+    (N : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    physCloseN M (N + 2) X =
+      Matrix.reindex (finAddTwoArrowEquiv (Fin d) N).symm
+        (finAddTwoArrowEquiv (Fin d) N).symm
+        (singleKrausMap (U ⊗ₖ (1 : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ))
+          (Matrix.reindex (firstSitePreparationEquiv (d := d) N)
+            (firstSitePreparationEquiv (d := d) N)
+            (Matrix.reindex (finSuccArrowEquiv (Fin d) N)
+              (finSuccArrowEquiv (Fin d) N) (physCloseN M (N + 1) X) ⊗ₖ P))) := by
+  rw [strongRFP_physCloseN_eq_localized_preparation M P U hrel N]
+  simp only [refineFirstSite, LinearMap.comp_apply, Matrix.equivReindexMap,
+    Matrix.tensorMapIdLM_apply]
+  change Matrix.reindex _ _ (Matrix.tensorMapId _ (Matrix.reindex _ _ _)) = _
+  change Matrix.reindex _ _
+    (Matrix.tensorMapId (singleKrausMap U)
+      (Matrix.tensorMapId (Matrix.preparationMap P) (Matrix.reindex _ _ _))) = _
+  rw [tensorMapId_singleKrausMap,
+    tensorMapId_preparationMap_eq_reindex_kronecker]
+
+/-- The fixed Strong-RFP witnesses give the corresponding identity for the
+ordinary periodic MPO operator.
+
+Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2109--2117. -/
+theorem strongRFP_mpo_eq_localized_preparation
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (U : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hrel : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      physClose2 M X = U * (physClose1 M X ⊗ₖ P) * Uᴴ)
+    (N : ℕ) :
+    mpo M (N + 2) =
+      refineFirstSite ((singleKrausMap U).comp (Matrix.preparationMap P)) N
+        (mpo M (N + 1)) := by
+  rw [← physCloseN_identity_eq_mpo M (N + 2),
+    strongRFP_physCloseN_eq_localized_preparation M P U hrel N,
+    physCloseN_identity_eq_mpo]
+
+/-- With the same canonical regroupings, the ordinary periodic operator on
+`N+2` sites is unitarily equivalent to `mpo M (N+1) ⊗ₖ P`.
+
+Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2109--2117. -/
+theorem strongRFP_mpo_eq_reindex_singleKrausMap_kronecker
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (U : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hrel : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      physClose2 M X = U * (physClose1 M X ⊗ₖ P) * Uᴴ)
+    (N : ℕ) :
+    mpo M (N + 2) =
+      Matrix.reindex (finAddTwoArrowEquiv (Fin d) N).symm
+        (finAddTwoArrowEquiv (Fin d) N).symm
+        (singleKrausMap (U ⊗ₖ (1 : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ))
+          (Matrix.reindex (firstSitePreparationEquiv (d := d) N)
+            (firstSitePreparationEquiv (d := d) N)
+            (Matrix.reindex (finSuccArrowEquiv (Fin d) N)
+              (finSuccArrowEquiv (Fin d) N) (mpo M (N + 1)) ⊗ₖ P))) := by
+  rw [← physCloseN_identity_eq_mpo M (N + 2),
+    strongRFP_physCloseN_eq_reindex_singleKrausMap_kronecker M P U hrel N,
+    physCloseN_identity_eq_mpo]
+
+/-- The fixed Strong-RFP witnesses force the ordinary periodic MPO rank to
+obey the one-step recurrence
+`rank (mpo M (N+2)) = rank (mpo M (N+1)) * rank P`.
+
+Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2114--2117. -/
+theorem strongRFP_rank_mpo_add_two
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (U : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin d × Fin d) ℂ)
+    (hrel : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      physClose2 M X = U * (physClose1 M X ⊗ₖ P) * Uᴴ)
+    (N : ℕ) :
+    (mpo M (N + 2)).rank = (mpo M (N + 1)).rank * P.rank := by
+  rw [strongRFP_mpo_eq_localized_preparation M P U hrel N]
+  simp only [refineFirstSite, LinearMap.comp_apply, Matrix.equivReindexMap]
+  change (Matrix.reindex _ _ _).rank = _
+  rw [Matrix.rank_reindex]
+  rw [Matrix.tensorMapIdLM_comp]
+  simp only [LinearMap.comp_apply, Matrix.tensorMapIdLM_apply]
+  rw [tensorMapId_singleKrausMap]
+  rw [Matrix.rank_singleKrausMap_of_mem_unitaryGroup _ _
+    (Matrix.kronecker_one_mem_unitaryGroup U hU)]
+  rw [tensorMapId_preparationMap_eq_reindex_kronecker, Matrix.rank_reindex,
+    Matrix.rank_kronecker]
+  change (Matrix.reindex _ _ _).rank * P.rank = _
+  rw [Matrix.rank_reindex]
+
+/-- Iterating the fixed-witness recurrence from chain length one gives the
+geometric rank formula.
+
+Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2114--2117. -/
+theorem strongRFP_rank_mpo_add_one
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (U : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin d × Fin d) ℂ)
+    (hrel : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      physClose2 M X = U * (physClose1 M X ⊗ₖ P) * Uᴴ) :
+    ∀ N : ℕ,
+      (mpo M (N + 1)).rank = (mpo M 1).rank * P.rank ^ N := by
+  intro N
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      simpa [pow_succ, ih, mul_assoc] using
+        strongRFP_rank_mpo_add_two M P U hU hrel N
+
+/-- A Strong-RFP tensor exposes a single positive witness `P` whose rank is
+the factor in both the periodic rank recurrence and its geometric solution.
+No trace normalization, virtual gauge, or MPDO hypothesis is used.
+
+Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2109--2117. -/
+theorem IsStrongRFP.exists_periodic_rank_factor
+    {M : MPOTensor d D} (h : IsStrongRFP M) :
+    ∃ P : Matrix (Fin d) (Fin d) ℂ,
+      P.PosSemidef ∧
+      (∀ N : ℕ, (mpo M (N + 2)).rank = (mpo M (N + 1)).rank * P.rank) ∧
+      (∀ N : ℕ, (mpo M (N + 1)).rank = (mpo M 1).rank * P.rank ^ N) := by
+  rw [isStrongRFP_iff_physClose] at h
+  obtain ⟨P, U, hP, hU, hrel⟩ := h
+  exact ⟨P, hP, strongRFP_rank_mpo_add_two M P U hU hrel,
+    strongRFP_rank_mpo_add_one M P U hU hrel⟩
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/StrongRFPRankGrowth.lean
+++ b/TNLean/MPS/MPDO/StrongRFPRankGrowth.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.MatrixRankKronecker
+import TNLean.Channel.SingleKrausPositivity
 import TNLean.MPS.MPDO.RFPViaTSGlobal
 import TNLean.MPS.MPDO.StrongRFP
 
@@ -23,26 +24,6 @@ multiplied by `rank P`.
 -/
 
 open scoped Matrix Kronecker ComplexOrder
-
-namespace Matrix
-
-/-- A unitary single-Kraus conjugation preserves ordinary matrix rank. -/
-theorem rank_singleKrausMap_of_mem_unitaryGroup
-    {n : Type*} [Fintype n] [DecidableEq n]
-    (U A : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
-    (singleKrausMap U A).rank = A.rank := by
-  have hUdet : IsUnit U.det := Matrix.UnitaryGroup.det_isUnit ⟨U, hU⟩
-  have hUh : Uᴴ ∈ Matrix.unitaryGroup n ℂ := by
-    exact ⟨by simpa only [Matrix.star_eq_conjTranspose,
-        Matrix.conjTranspose_conjTranspose] using hU.2,
-      by simpa only [Matrix.star_eq_conjTranspose,
-        Matrix.conjTranspose_conjTranspose] using hU.1⟩
-  have hUhdet : IsUnit Uᴴ.det := Matrix.UnitaryGroup.det_isUnit ⟨Uᴴ, hUh⟩
-  rw [singleKrausMap_apply,
-    Matrix.rank_mul_eq_left_of_isUnit_det Uᴴ (U * A) hUhdet,
-    Matrix.rank_mul_eq_right_of_isUnit_det U A hUdet]
-
-end Matrix
 
 namespace MPOTensor
 

--- a/TNLean/MPS/MPDO/StrongRFPRankGrowth.lean
+++ b/TNLean/MPS/MPDO/StrongRFPRankGrowth.lean
@@ -12,10 +12,10 @@ import TNLean.MPS.MPDO.StrongRFP
 # Periodic rank growth of a strong renormalization fixed point
 
 CPSV16 Appendix D observes that the local Strong-RFP relation
-`M₂ = U (M₁ ⊗ P) U†` iterates around a periodic chain. Thus adjoining one
-site tensors the periodic operator with the same positive matrix `P`, up to a
+\(M₂ = U (M₁ ⊗ P) U†\) iterates around a periodic chain. Thus adjoining one
+site tensors the periodic operator with the same positive matrix \(P\), up to a
 unitary change of physical coordinates, and its ordinary matrix rank is
-multiplied by `rank P`.
+multiplied by \(\operatorname{rank} P\).
 
 ## References
 
@@ -72,8 +72,8 @@ private theorem tensorMapId_singleKrausMap
   · simp
 
 /-- The fixed Strong-RFP witnesses give the global closure identity. The
-canonical regroupings expose the operation as first adjoining `P`, then
-conjugating the first two coordinates by `U`.
+canonical regroupings expose the operation as first adjoining \(P\), then
+conjugating the first two coordinates by \(U\).
 
 Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2109--2117. -/
 theorem strongRFP_physCloseN_eq_localized_preparation
@@ -93,7 +93,7 @@ theorem strongRFP_physCloseN_eq_localized_preparation
 
 /-- Written with all canonical regroupings visible, the global closure is
 unitarily equivalent to the Kronecker product of the shorter closure with
-`P`. This is the fixed-witness operator identity used for rank growth.
+\(P\). This is the fixed-witness operator identity used for rank growth.
 
 Source: CPSV16, arXiv:1606.00608, Appendix D, lines 2109--2117. -/
 theorem strongRFP_physCloseN_eq_reindex_singleKrausMap_kronecker
@@ -205,7 +205,7 @@ theorem strongRFP_rank_mpo_add_one
       simpa [pow_succ, ih, mul_assoc] using
         strongRFP_rank_mpo_add_two M P U hU hrel N
 
-/-- A Strong-RFP tensor exposes a single positive witness `P` whose rank is
+/-- A Strong-RFP tensor exposes a single positive witness \(P\) whose rank is
 the factor in both the periodic rank recurrence and its geometric solution.
 No trace normalization, virtual gauge, or MPDO hypothesis is used.
 

--- a/blueprint/.chktexrc
+++ b/blueprint/.chktexrc
@@ -26,5 +26,6 @@ CmdLine
   -n 39  # Double-space heuristic.
   -n 26  # Space-before-punctuation heuristic; false positive on tenkz range syntax `..`.
   -n 40  # Punctuation around inline math heuristic.
+  -n 44  # User Regex; false positive on math-mode nested brackets like `R_1[M_{N+1}(X)]`.
   -n 45  # Display-math delimiter heuristic.
 }

--- a/blueprint/.chktexrc
+++ b/blueprint/.chktexrc
@@ -26,6 +26,5 @@ CmdLine
   -n 39  # Double-space heuristic.
   -n 26  # Space-before-punctuation heuristic; false positive on tenkz range syntax `..`.
   -n 40  # Punctuation around inline math heuristic.
-  -n 44  # User Regex; false positive on math-mode nested brackets like `R_1[M_{N+1}(X)]`.
   -n 45  # Display-math delimiter heuristic.
 }

--- a/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
@@ -149,7 +149,7 @@ change of basis. The matrix is not assumed to have trace one.
     equality. Expanding the regroupings $R_1$ and $R_2$, localized unitary
     conjugation is conjugation by $U\otimes\Id$, while
     Lemma~\ref{lem:mpdo_localized_first_site_preparation} gives the middle
-    factor $\Sigma_N[R_1[M_{N+1}(X)]\otimes P]$. The identity closure from
+    factor $\Sigma_N\!\left(R_1[M_{N+1}(X)]\otimes P\right)$. The identity closure from
     Lemma~\ref{lem:phys_close_identity} gives the periodic formula.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
@@ -64,6 +64,36 @@ change of basis. The matrix is not assumed to have trace one.
     difference zero.
 \end{proof}
 
+\begin{definition}[First-site preparation shuffle]
+    \label{def:mpdo_first_site_preparation_shuffle}
+    \lean{MPOTensor.firstSitePreparationEquiv,
+      MPOTensor.tensorMapId_preparationMap_eq_reindex_kronecker}
+    \leanok
+    \uses{def:finite_tuple_regroupings,
+      def:mpdo_state_preparation_map}
+    After $R_1$ separates the first physical coordinate from the $N$
+    spectator coordinates, define
+    \begin{align}
+      \Sigma_N:\bigl((i,u),p\bigr)&\longmapsto\bigl((i,p),u\bigr),
+      \label{eq:mpdo_first_site_preparation_shuffle}
+    \end{align}
+    where $i,p\in\{1,\ldots,d\}$ and
+    $u\in\{1,\ldots,d\}^N$. Thus, for a matrix $Z$ indexed by
+    $((i,u),p)$,
+    \begin{align}
+      \bigl(\Sigma_N[Z]\bigr)_{((i,p),u),((j,q),v)}
+        &=Z_{((i,u),p),((j,v),q)}.
+      \label{eq:mpdo_first_site_preparation_shuffle_matrix}
+    \end{align}
+    In particular, localizing the preparation $Y\mapsto Y\otimes P$ at the
+    first site gives
+    \begin{align}
+      (\operatorname{prep}_P\otimes\id)[Y]
+        &=\Sigma_N[Y\otimes P].
+      \label{eq:mpdo_localized_preparation_shuffle}
+    \end{align}
+\end{definition}
+
 \begin{theorem}[Global operator identity for fixed strong fixed-point witnesses]
     \label{thm:mpdo_strong_rfp_global_operator_identity}
     \lean{MPOTensor.strongRFP_physCloseN_eq_localized_preparation,
@@ -72,65 +102,68 @@ change of basis. The matrix is not assumed to have trace one.
       MPOTensor.strongRFP_mpo_eq_reindex_singleKrausMap_kronecker}
     \leanok
     \uses{thm:mpdo_strong_rfp_phys_close,
-      def:finite_tuple_regroupings, def:mpdo_global_renormalization_maps,
-      def:mpdo_state_preparation_map, def:mpdo_single_kraus_map}
+      thm:mpdo_global_renormalization_maps,
+      def:mpdo_first_site_preparation_shuffle,
+      lem:phys_close_identity}
     Fix witnesses $P$ and $U$ in
     (\ref{eq:mpdo_strong_rfp_closure}). For every $N\geq0$ and every virtual
-    matrix $X$, the $(N+2)$-site closure is obtained from the $(N+1)$-site
-    closure by adjoining $P$ to the first physical coordinate and conjugating
-    the first two physical coordinates by $U$. More explicitly, after the
-    canonical identifications
+    matrix $X$, write $R_1$ and $R_2$ for the initial-coordinate regroupings
+    of lengths $N+1$ and $N+2$. Then
     \begin{align}
-      (\mathbb C^d)^{\otimes(N+1)}
-        &\cong \mathbb C^d\otimes(\mathbb C^d)^{\otimes N},
-        \notag\\
-      (\mathbb C^d)^{\otimes(N+2)}
-        &\cong (\mathbb C^d\otimes\mathbb C^d)
-          \otimes(\mathbb C^d)^{\otimes N},
-        \notag
-    \end{align}
-    one has
-    \begin{align}
-      M_{N+2}(X)
-        &=(U\otimes\Id)\bigl(M_{N+1}(X)\otimes P\bigr)
+      R_2[M_{N+2}(X)]
+        &=(U\otimes\Id)\,
+          \Sigma_N\!\left[R_1[M_{N+1}(X)]\otimes P\right]
           (U^\dagger\otimes\Id).
-        \label{eq:mpdo_strong_rfp_global_closure}
+      \label{eq:mpdo_strong_rfp_global_closure}
     \end{align}
-    The same identity holds for the ordinary periodic operators
-    $\rho^{(N)}(M)$.
+    Equivalently, applying $R_2^{-1}$ to the right-hand side gives the
+    $(N+2)$-site closure in its original physical coordinates. The same
+    formula with $M_k(X)$ replaced by the ordinary periodic operator
+    $\rho^{(k)}(M)$ holds after closing the virtual indices with the identity.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Localize the one-to-two map
-    $Y\mapsto U(Y\otimes P)U^\dagger$ at the first site and use
-    (\ref{eq:mpdo_strong_rfp_closure}) on each matrix slice. The canonical
-    regroupings identify localized preparation with the Kronecker product by
-    $P$, and localized unitary conjugation with conjugation by
-    $U\otimes\Id$. Closing the virtual indices with the identity gives the
-    periodic-operator statement.
+    \uses{thm:mpdo_global_renormalization_maps,
+      def:mpdo_first_site_preparation_shuffle,
+      lem:phys_close_identity}
+    Fix spectator words $u,v$ of length $N$. The $(u,v)$ block of the
+    regrouped $(N+1)$-site closure is a one-site closure, with the spectator
+    word product absorbed into the virtual matrix. The local strong
+    fixed-point identity sends this block to its two-site closure. Equation
+    (\ref{eq:mpdo_localized_preparation_shuffle}) places the new $P$ coordinate
+    beside the first coordinate, and conjugation by $U\otimes\Id$ acts on
+    those two coordinates. This proves the closure formula block by block.
+    The identity closure from Lemma~\ref{lem:phys_close_identity} gives the
+    periodic formula.
 \end{proof}
 
 \begin{theorem}[Geometric periodic rank growth of a strong fixed point]
     \label{thm:mpdo_strong_rfp_periodic_rank_growth}
-    \lean{MPOTensor.strongRFP_rank_mpo_add_two,
+    \lean{Matrix.rank_singleKrausMap_of_mem_unitaryGroup,
+      MPOTensor.strongRFP_rank_mpo_add_two,
       MPOTensor.strongRFP_rank_mpo_add_one,
       MPOTensor.IsStrongRFP.exists_periodic_rank_factor}
     \leanok
     \uses{def:mpdo_strong_rfp,
+      thm:mpdo_strong_rfp_phys_close,
       thm:mpdo_strong_rfp_global_operator_identity}
-    Fix witnesses $P\geq0$ and $U$ for the strong fixed-point relation. Then
-    the ordinary full periodic MPO matrix ranks satisfy
+    Fix witnesses $P\geq0$ and $U$ for the strong fixed-point relation. For
+    every $N\geq0$, the ordinary full periodic MPO matrix ranks satisfy
     \begin{align}
       \operatorname{rank}\rho^{(N+2)}(M)
         &=\operatorname{rank}\rho^{(N+1)}(M)\,
-          \operatorname{rank}P
-          \qquad(N\geq0),
+          \operatorname{rank}P,
         \label{eq:mpdo_strong_rfp_rank_recurrence}\\
       \operatorname{rank}\rho^{(N+1)}(M)
         &=\operatorname{rank}\rho^{(1)}(M)\,
           (\operatorname{rank}P)^N.
         \label{eq:mpdo_strong_rfp_rank_geometric}
+    \end{align}
+    More generally, if $V$ is unitary, then
+    \begin{align}
+      \operatorname{rank}(VAV^\dagger)&=\operatorname{rank}A.
+      \label{eq:unitary_single_kraus_rank}
     \end{align}
     Consequently every strong fixed point admits a single positive witness
     $P$ whose matrix rank is the factor in both formulas. No normalization of
@@ -140,8 +173,13 @@ change of basis. The matrix is not assumed to have trace one.
 
 \begin{proof}
     \leanok
+    \uses{thm:mpdo_strong_rfp_phys_close,
+      thm:mpdo_strong_rfp_global_operator_identity}
     Unitary conjugation and relabelling of matrix coordinates preserve rank,
     while rank is multiplicative under Kronecker products. Applying these
     facts to (\ref{eq:mpdo_strong_rfp_global_closure}) gives the recurrence.
-    Induction from chain length one gives the geometric formula.
+    Induction from chain length one gives the geometric formula. Finally,
+    Theorem~\ref{thm:mpdo_strong_rfp_phys_close} exposes the same positive
+    witness $P$ for any tensor satisfying the existential strong fixed-point
+    relation.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
@@ -63,3 +63,85 @@ change of basis. The matrix is not assumed to have trace one.
     has trace zero. Nondegeneracy of the matrix trace pairing makes the
     difference zero.
 \end{proof}
+
+\begin{theorem}[Global operator identity for fixed strong fixed-point witnesses]
+    \label{thm:mpdo_strong_rfp_global_operator_identity}
+    \lean{MPOTensor.strongRFP_physCloseN_eq_localized_preparation,
+      MPOTensor.strongRFP_physCloseN_eq_reindex_singleKrausMap_kronecker,
+      MPOTensor.strongRFP_mpo_eq_localized_preparation,
+      MPOTensor.strongRFP_mpo_eq_reindex_singleKrausMap_kronecker}
+    \leanok
+    \uses{thm:mpdo_strong_rfp_phys_close,
+      def:finite_tuple_regroupings, def:mpdo_global_renormalization_maps,
+      def:mpdo_state_preparation_map, def:mpdo_single_kraus_map}
+    Fix witnesses $P$ and $U$ in
+    (\ref{eq:mpdo_strong_rfp_closure}). For every $N\geq0$ and every virtual
+    matrix $X$, the $(N+2)$-site closure is obtained from the $(N+1)$-site
+    closure by adjoining $P$ to the first physical coordinate and conjugating
+    the first two physical coordinates by $U$. More explicitly, after the
+    canonical identifications
+    \begin{align}
+      (\mathbb C^d)^{\otimes(N+1)}
+        &\cong \mathbb C^d\otimes(\mathbb C^d)^{\otimes N},
+        \notag\\
+      (\mathbb C^d)^{\otimes(N+2)}
+        &\cong (\mathbb C^d\otimes\mathbb C^d)
+          \otimes(\mathbb C^d)^{\otimes N},
+        \notag
+    \end{align}
+    one has
+    \begin{align}
+      M_{N+2}(X)
+        &=(U\otimes\Id)\bigl(M_{N+1}(X)\otimes P\bigr)
+          (U^\dagger\otimes\Id).
+        \label{eq:mpdo_strong_rfp_global_closure}
+    \end{align}
+    The same identity holds for the ordinary periodic operators
+    $\rho^{(N)}(M)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Localize the one-to-two map
+    $Y\mapsto U(Y\otimes P)U^\dagger$ at the first site and use
+    (\ref{eq:mpdo_strong_rfp_closure}) on each matrix slice. The canonical
+    regroupings identify localized preparation with the Kronecker product by
+    $P$, and localized unitary conjugation with conjugation by
+    $U\otimes\Id$. Closing the virtual indices with the identity gives the
+    periodic-operator statement.
+\end{proof}
+
+\begin{theorem}[Geometric periodic rank growth of a strong fixed point]
+    \label{thm:mpdo_strong_rfp_periodic_rank_growth}
+    \lean{MPOTensor.strongRFP_rank_mpo_add_two,
+      MPOTensor.strongRFP_rank_mpo_add_one,
+      MPOTensor.IsStrongRFP.exists_periodic_rank_factor}
+    \leanok
+    \uses{def:mpdo_strong_rfp,
+      thm:mpdo_strong_rfp_global_operator_identity}
+    Fix witnesses $P\geq0$ and $U$ for the strong fixed-point relation. Then
+    the ordinary full periodic MPO matrix ranks satisfy
+    \begin{align}
+      \operatorname{rank}\rho^{(N+2)}(M)
+        &=\operatorname{rank}\rho^{(N+1)}(M)\,
+          \operatorname{rank}P
+          \qquad(N\geq0),
+        \label{eq:mpdo_strong_rfp_rank_recurrence}\\
+      \operatorname{rank}\rho^{(N+1)}(M)
+        &=\operatorname{rank}\rho^{(1)}(M)\,
+          (\operatorname{rank}P)^N.
+        \label{eq:mpdo_strong_rfp_rank_geometric}
+    \end{align}
+    Consequently every strong fixed point admits a single positive witness
+    $P$ whose matrix rank is the factor in both formulas. No normalization of
+    $P$ and no positivity or normalization assumption on the periodic
+    operators is required.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Unitary conjugation and relabelling of matrix coordinates preserve rank,
+    while rank is multiplicative under Kronecker products. Applying these
+    facts to (\ref{eq:mpdo_strong_rfp_global_closure}) gives the recurrence.
+    Induction from chain length one gives the geometric formula.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
@@ -66,33 +66,46 @@ change of basis. The matrix is not assumed to have trace one.
 
 \begin{definition}[First-site preparation shuffle]
     \label{def:mpdo_first_site_preparation_shuffle}
-    \lean{MPOTensor.firstSitePreparationEquiv,
-      MPOTensor.tensorMapId_preparationMap_eq_reindex_kronecker}
+    \lean{MPOTensor.firstSitePreparationEquiv}
     \leanok
-    \uses{def:finite_tuple_regroupings,
-      def:mpdo_state_preparation_map}
+    \uses{def:finite_tuple_regroupings}
     After $R_1$ separates the first physical coordinate from the $N$
     spectator coordinates, define
     \begin{align}
       \Sigma_N:\bigl((i,u),p\bigr)&\longmapsto\bigl((i,p),u\bigr),
       \label{eq:mpdo_first_site_preparation_shuffle}
     \end{align}
-    where $i,p\in\{1,\ldots,d\}$ and
-    $u\in\{1,\ldots,d\}^N$. Thus, for a matrix $Z$ indexed by
+    where $i,p\in\{0,\ldots,d-1\}$ and
+    $u\in\{0,\ldots,d-1\}^N$. Thus, for a matrix $Z$ indexed by
     $((i,u),p)$,
     \begin{align}
       \bigl(\Sigma_N[Z]\bigr)_{((i,p),u),((j,q),v)}
         &=Z_{((i,u),p),((j,v),q)}.
       \label{eq:mpdo_first_site_preparation_shuffle_matrix}
     \end{align}
-    In particular, localizing the preparation $Y\mapsto Y\otimes P$ at the
-    first site gives
+\end{definition}
+
+\begin{lemma}[Localized first-site preparation]
+    \label{lem:mpdo_localized_first_site_preparation}
+    \lean{MPOTensor.tensorMapId_preparationMap_eq_reindex_kronecker}
+    \leanok
+    \uses{def:mpdo_first_site_preparation_shuffle,
+      def:mpdo_state_preparation_map}
+    Localizing the preparation $Y\mapsto Y\otimes P$ at the first site gives
     \begin{align}
       (\operatorname{prep}_P\otimes\id)[Y]
         &=\Sigma_N[Y\otimes P].
       \label{eq:mpdo_localized_preparation_shuffle}
     \end{align}
-\end{definition}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_first_site_preparation_shuffle,
+      def:mpdo_state_preparation_map}
+    At row $((i,p),u)$ and column $((j,q),v)$, both sides equal
+    $Y_{(i,u),(j,v)}P_{p,q}$.
+\end{proof}
 
 \begin{theorem}[Global operator identity for fixed strong fixed-point witnesses]
     \label{thm:mpdo_strong_rfp_global_operator_identity}
@@ -103,7 +116,9 @@ change of basis. The matrix is not assumed to have trace one.
     \leanok
     \uses{thm:mpdo_strong_rfp_phys_close,
       thm:mpdo_global_renormalization_maps,
+      def:finite_tuple_regroupings,
       def:mpdo_first_site_preparation_shuffle,
+      lem:mpdo_localized_first_site_preparation,
       lem:phys_close_identity}
     Fix witnesses $P$ and $U$ in
     (\ref{eq:mpdo_strong_rfp_closure}). For every $N\geq0$ and every virtual
@@ -112,7 +127,7 @@ change of basis. The matrix is not assumed to have trace one.
     \begin{align}
       R_2[M_{N+2}(X)]
         &=(U\otimes\Id)\,
-          \Sigma_N\!\left[R_1[M_{N+1}(X)]\otimes P\right]
+          \Sigma_N\!\left(R_1[M_{N+1}(X)]\otimes P\right)
           (U^\dagger\otimes\Id).
       \label{eq:mpdo_strong_rfp_global_closure}
     \end{align}
@@ -125,17 +140,17 @@ change of basis. The matrix is not assumed to have trace one.
 \begin{proof}
     \leanok
     \uses{thm:mpdo_global_renormalization_maps,
-      def:mpdo_first_site_preparation_shuffle,
+      def:finite_tuple_regroupings,
+      lem:mpdo_localized_first_site_preparation,
       lem:phys_close_identity}
-    Fix spectator words $u,v$ of length $N$. The $(u,v)$ block of the
-    regrouped $(N+1)$-site closure is a one-site closure, with the spectator
-    word product absorbed into the virtual matrix. The local strong
-    fixed-point identity sends this block to its two-site closure. Equation
-    (\ref{eq:mpdo_localized_preparation_shuffle}) places the new $P$ coordinate
-    beside the first coordinate, and conjugation by $U\otimes\Id$ acts on
-    those two coordinates. This proves the closure formula block by block.
-    The identity closure from Lemma~\ref{lem:phys_close_identity} gives the
-    periodic formula.
+    Apply Theorem~\ref{thm:mpdo_global_renormalization_maps} to the local map
+    $Y\mapsto U(Y\otimes P)U^\dagger$ and the identity
+    (\ref{eq:mpdo_strong_rfp_closure}). This gives the localized closure
+    equality. Expanding the regroupings $R_1$ and $R_2$, localized unitary
+    conjugation is conjugation by $U\otimes\Id$, while
+    Lemma~\ref{lem:mpdo_localized_first_site_preparation} gives the middle
+    factor $\Sigma_N[R_1[M_{N+1}(X)]\otimes P]$. The identity closure from
+    Lemma~\ref{lem:phys_close_identity} gives the periodic formula.
 \end{proof}
 
 \begin{theorem}[Geometric periodic rank growth of a strong fixed point]
@@ -174,7 +189,8 @@ change of basis. The matrix is not assumed to have trace one.
 \begin{proof}
     \leanok
     \uses{thm:mpdo_strong_rfp_phys_close,
-      thm:mpdo_strong_rfp_global_operator_identity}
+      thm:mpdo_strong_rfp_global_operator_identity,
+      lem:mpdo_localized_first_site_preparation}
     Unitary conjugation and relabelling of matrix coordinates preserve rank,
     while rank is multiplicative under Kronecker products. Applying these
     facts to (\ref{eq:mpdo_strong_rfp_global_closure}) gives the recurrence.


### PR DESCRIPTION
## Summary

- globalize the fixed-witness CPSV16 Strong-RFP closure relation using the canonical first-site regroupings
- expose the periodic operator as a canonically reindexed unitary conjugate of `mpo M (N+1) ⊗ₖ P`
- prove the ordinary full-matrix rank recurrence and geometric formula from chain length one
- expose the positive Strong-RFP witness whose `Matrix.rank` is the common growth factor
- synchronize the Strong-RFP blueprint while keeping the concrete Fibonacci rank calculation independent of the still-missing operator-rank identification

The implementation follows CPSV16 Appendix D literally: it adds no trace normalization, virtual gauge, `IsRFPViaTS`, MPDO, or ZCL assumptions.

## Verification

- `lake build TNLean.MPS.MPDO.StrongRFPRankGrowth`
- `lake env lean TNLean/MPS/MPDO/StrongRFPRankGrowth.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --diff-base origin/main --changed-files TNLean/MPS/MPDO/StrongRFPRankGrowth.lean --warn-missing-blueprint`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the new module

The targeted Blueprint synchronization reports zero missing Lean declarations, zero invalid `\leanok` references, and complete public-declaration coverage for the changed module.

Closes #6047.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics additions with no runtime, auth, or data-path changes; risk is limited to proof correctness and import/aggregator wiring in the Lean library.
> 
> **Overview**
> Formalizes CPSV16 Appendix D’s observation that Strong-RFP closure iterates along the periodic chain: each extra site adjoins the same positive witness **P** (up to unitary regrouping), so full periodic MPO matrix rank multiplies by `rank P`.
> 
> Adds `StrongRFPRankGrowth.lean` with the first-site preparation shuffle, global closure identities for `physCloseN` and `mpo`, and the rank recurrence `rank ρ^(N+2) = rank ρ^(N+1) · rank P` plus the geometric formula from chain length one. **`IsStrongRFP.exists_periodic_rank_factor`** packages a positive **P** as the common growth factor without trace normalization, virtual gauge, or MPDO assumptions.
> 
> Adds **`Matrix.rank_singleKrausMap_of_mem_unitaryGroup`** in `SingleKrausPositivity.lean` so unitary conjugation preserves rank in the recurrence proof. Blueprint chapter `ch21_mpdo_rfp_strong` is synchronized with the new Lean declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 517af06b9608bd3ac36876367d55a9c37745f2fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->