### PR TITLE
feat(MPS/MPU): commute independent tensor products with blocking

### DIFF
--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -93,6 +93,13 @@ def reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d)
     (U : MPOTensor d D) : MPOTensor d' D :=
   fun i j ↦ U (e i) (e j)
 
+/-- Apply a physical-index equivalence sitewise to a finite configuration.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+def reindexPhysicalConfigEquiv {d' : ℕ} (N : ℕ) (e : Fin d' ≃ Fin d) :
+    (Fin N → Fin d') ≃ (Fin N → Fin d) :=
+  Equiv.arrowCongr (Equiv.refl (Fin N)) e
+
 /-- The physical matrix obtained from a fixed pair of virtual indices of an
 MPO tensor.
 
@@ -117,6 +124,21 @@ noncomputable def evalWord (M : MPOTensor d D) :
 @[simp] lemma evalWord_cons (M : MPOTensor d D)
     (i j : Fin d) (is js : List (Fin d)) :
     evalWord M (i :: is) (j :: js) = M i j * evalWord M is js := rfl
+
+/-- Word evaluation after physical reindexing is word evaluation on the two
+mapped words.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem evalWord_reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d)
+    (U : MPOTensor d D) (is js : List (Fin d')) :
+    evalWord (reindexPhysical e U) is js =
+      evalWord U (is.map e) (js.map e) := by
+  induction is generalizing js with
+  | nil => cases js <;> simp [evalWord]
+  | cons i is ih =>
+      cases js with
+      | nil => simp [evalWord]
+      | cons j js => simp [evalWord, reindexPhysical, ih]
 
 /-- Word evaluation on `List.ofFn` equals a non-commutative product:
 `evalWord M (ofFn σ) (ofFn τ) = (ofFn (fun i => M (σ i) (τ i))).prod`. -/
@@ -183,6 +205,19 @@ noncomputable def mpo (M : MPOTensor d D) (N : ℕ) :
 @[simp] lemma mpo_apply (M : MPOTensor d D) (N : ℕ)
     (σ τ : Fin N → Fin d) :
     mpo M N σ τ = mpoMatrixEntry M σ τ := rfl
+
+/-- Physical reindexing of a tensor simultaneously reindexes the row and column
+configurations of every finite-size MPO.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem mpo_reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d)
+    (U : MPOTensor d D) (N : ℕ) :
+    mpo (reindexPhysical e U) N =
+      Matrix.reindex (reindexPhysicalConfigEquiv N e).symm
+        (reindexPhysicalConfigEquiv N e).symm (mpo U N) := by
+  ext σ τ
+  simp [mpoMatrixEntry, evalWord_reindexPhysical, reindexPhysicalConfigEquiv,
+    Equiv.arrowCongr, List.map_ofFn, Function.comp_def]
 
 /-- The **normalized density operator** of the MPO for system size `N`:
 

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -31,6 +31,9 @@ Verstraete):
 * `MPOTensor.evalWord`: word evaluation for MPO tensors (product of 4-index
   matrices along a pair of ket/bra words).
 * `MPOTensor.mpo`: the MPO operator family for system size `N`.
+* `MPOTensor.reindexPhysical`: relabel both physical indices by an equivalence.
+* `MPOTensor.reindexPhysicalConfigEquiv`: the induced sitewise equivalence on
+  physical configurations.
 * `MPOTensor.normalizedMPO`: the operator family divided by its trace.
 * `MPOTensor.transferMap`: the MPO transfer map
   `E_M(X) = ∑_{i,j} M^{ij} X (M^{ij})†`.
@@ -42,6 +45,13 @@ Verstraete):
 * `MPOTensor.toMPSTensor`: view an MPO tensor as an MPS tensor with doubled
   physical index `Fin (d * d)`.
 * `MPOTensor.physicalSlice`: the physical matrix at fixed virtual indices.
+
+## Main results
+
+* `MPOTensor.evalWord_reindexPhysical`: word evaluation commutes with physical
+  reindexing.
+* `MPOTensor.mpo_reindexPhysical`: finite-size MPOs are related by simultaneous
+  row and column reindexing.
 
 ## References
 

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -53,6 +53,10 @@ definition `defnrl` and lines 697–704 of the paper.
 
 * `rightRank_bound`, `leftRank_bound`: rank bounds
   $r \le \min(Dd, dD) = Dd$ and similarly $\ell \le Dd$.
+* `sourceCutM₁_reindexPhysical`, `sourceCutM₂_reindexPhysical`: physical reindexing
+  formulas for the two cuts.
+* `rightRank_reindexPhysical`, `leftRank_reindexPhysical`: invariance of both ranks
+  under bijective physical reindexing.
 * `sourceCutM₁_apply`, `sourceCutM₂_apply`, `sourceCutM₁Fin_apply`,
   `sourceCutM₂Fin_apply`: `[simp]` entry formulas for both cuts and both index forms.
 
@@ -92,6 +96,32 @@ def sourceCutM₂ : Matrix (Fin D × Fin d) (Fin d × Fin D) ℂ :=
 
 @[simp] lemma sourceCutM₂_apply (α : Fin D) (i : Fin d) (j : Fin d) (β : Fin D) :
     sourceCutM₂ U (α, i) (j, β) = U i j α β := rfl
+
+/-- Physical reindexing acts on the down leg of each row and the up leg of
+each column of the first source cut.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem sourceCutM₁_reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d) :
+    sourceCutM₁ (reindexPhysical e U) =
+      Matrix.reindex (Equiv.prodCongr (Equiv.refl (Fin D)) e.symm)
+        (Equiv.prodCongr e.symm (Equiv.refl (Fin D))) (sourceCutM₁ U) := by
+  ext row col
+  rcases row with ⟨α, j⟩
+  rcases col with ⟨i, β⟩
+  simp [sourceCutM₁, reindexPhysical, Matrix.reindex_apply]
+
+/-- Physical reindexing acts on the up leg of each row and the down leg of
+each column of the second source cut.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem sourceCutM₂_reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d) :
+    sourceCutM₂ (reindexPhysical e U) =
+      Matrix.reindex (Equiv.prodCongr (Equiv.refl (Fin D)) e.symm)
+        (Equiv.prodCongr e.symm (Equiv.refl (Fin D))) (sourceCutM₂ U) := by
+  ext row col
+  rcases row with ⟨α, i⟩
+  rcases col with ⟨j, β⟩
+  simp [sourceCutM₂, reindexPhysical, Matrix.reindex_apply]
 
 /-! ### Reindexing to `Fin (D * d)` and `Fin (d * D)` (reindexed formulations) -/
 
@@ -161,6 +191,22 @@ noncomputable def leftRank : ℕ := (sourceCutM₂ U).rank
 lemma rightRank_eq : r[U] = (sourceCutM₁ U).rank := rfl
 
 lemma leftRank_eq : ℓ[U] = (sourceCutM₂ U).rank := rfl
+
+/-- Bijective physical reindexing preserves the right source rank.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem rightRank_reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d) :
+    r[reindexPhysical e U] = r[U] := by
+  rw [rightRank, sourceCutM₁_reindexPhysical, Matrix.rank_reindex]
+  rfl
+
+/-- Bijective physical reindexing preserves the left source rank.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem leftRank_reindexPhysical {d' : ℕ} (e : Fin d' ≃ Fin d) :
+    ℓ[reindexPhysical e U] = ℓ[U] := by
+  rw [leftRank, sourceCutM₂_reindexPhysical, Matrix.rank_reindex]
+  rfl
 
 /-! ### Rank bounds -/
 

--- a/TNLean/MPS/MPU/TensorProduct.lean
+++ b/TNLean/MPS/MPU/TensorProduct.lean
@@ -25,11 +25,15 @@ Theorem in arXiv:1703.09188, lines 824--847.
   coordinates.
 * `MPOTensor.tensorProductConfigEquiv`: the sitewise splitting of product physical
   configurations.
+* `MPOTensor.tensorProductBlockEquiv`: the splitting of blocked product letters into
+  the two component blocked letters.
 * `MPOTensor.tensorProductCutShuffle`: the shuffle relating a Kronecker product of
   source cuts to the source cut of a tensor product.
 
 ## Main results
 
+* `MPOTensor.blockTensor_tensorProduct`: blocking commutes with independent tensor
+  products after the canonical physical reindexing.
 * `MPOTensor.mpo_tensorProduct`: the exact finite-size reindexed-Kronecker formula.
 * `MPOTensor.IsMPU.tensorProduct`: independent tensor products preserve the MPU property.
 * `MPOTensor.sourceCutM₁_tensorProduct`, `MPOTensor.sourceCutM₂_tensorProduct`: the two
@@ -67,6 +71,38 @@ def tensorProductConfigEquiv (N d e : ℕ) :
   (Equiv.arrowCongr (Equiv.refl (Fin N)) finProdFinEquiv.symm).trans
     (Equiv.arrowProdEquivProdArrow (Fin N) (fun _ ↦ Fin d) (fun _ ↦ Fin e))
 
+/-- Split every letter of a blocked product alphabet and re-encode the two
+component words as a pair of blocked letters.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+noncomputable def tensorProductBlockEquiv (d e L : ℕ) :
+    Fin (MPSTensor.blockPhysDim (d * e) L) ≃
+      Fin (MPSTensor.blockPhysDim d L * MPSTensor.blockPhysDim e L) :=
+  (MPSTensor.decodeBlockEquiv (d * e) L).trans
+    ((Equiv.arrowCongr (Equiv.refl (Fin L)) finProdFinEquiv.symm).trans
+      (Equiv.arrowProdEquivProdArrow (Fin L) (fun _ ↦ Fin d) (fun _ ↦ Fin e))) |>.trans
+    (Equiv.prodCongr (MPSTensor.decodeBlockEquiv d L).symm
+      (MPSTensor.decodeBlockEquiv e L).symm) |>.trans
+    finProdFinEquiv
+
+/-- Decoding the first blocked component gives the pointwise quotient of the
+blocked product letters. -/
+@[simp] theorem decodeBlock_tensorProductBlockEquiv_divNat (d e L : ℕ)
+    (I : Fin (MPSTensor.blockPhysDim (d * e) L)) (k : Fin L) :
+    MPSTensor.decodeBlock d L ((tensorProductBlockEquiv d e L I).divNat) k =
+      (MPSTensor.decodeBlock (d * e) L I k).divNat := by
+  simp [tensorProductBlockEquiv, Equiv.arrowCongr,
+    MPSTensor.decodeBlockEquiv_apply]
+
+/-- Decoding the second blocked component gives the pointwise remainder of the
+blocked product letters. -/
+@[simp] theorem decodeBlock_tensorProductBlockEquiv_modNat (d e L : ℕ)
+    (I : Fin (MPSTensor.blockPhysDim (d * e) L)) (k : Fin L) :
+    MPSTensor.decodeBlock e L ((tensorProductBlockEquiv d e L I).modNat) k =
+      (MPSTensor.decodeBlock (d * e) L I k).modNat := by
+  simp [tensorProductBlockEquiv, Equiv.arrowCongr,
+    MPSTensor.decodeBlockEquiv_apply]
+
 private theorem evalWord_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E)
     (is js : List (Fin (d * e))) :
     evalWord (tensorProduct U V) is js =
@@ -84,6 +120,34 @@ private theorem evalWord_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E)
           rw [ih]
           rw [← Matrix.coe_reindexRingEquiv ℂ finProdFinEquiv]
           rw [← map_mul, Matrix.mul_kronecker_mul]
+
+/-- Blocking commutes with independent tensor products after splitting each
+blocked product letter into its two component blocked letters.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 824--847. -/
+theorem blockTensor_tensorProduct (U : MPOTensor d D) (V : MPOTensor e E) (L : ℕ) :
+    blockTensor (tensorProduct U V) L =
+      reindexPhysical (tensorProductBlockEquiv d e L)
+        (tensorProduct (blockTensor U L) (blockTensor V L)) := by
+  funext I J
+  simp only [blockTensor_apply, reindexPhysical, tensorProduct]
+  rw [evalWord_tensorProduct]
+  simp only [MPSTensor.wordOfBlock, List.map_ofFn]
+  congr 2
+  · apply congrArg₂ (evalWord U)
+    · apply congrArg List.ofFn
+      funext k
+      exact (decodeBlock_tensorProductBlockEquiv_divNat d e L I k).symm
+    · apply congrArg List.ofFn
+      funext k
+      exact (decodeBlock_tensorProductBlockEquiv_divNat d e L J k).symm
+  · apply congrArg₂ (evalWord V)
+    · apply congrArg List.ofFn
+      funext k
+      exact (decodeBlock_tensorProductBlockEquiv_modNat d e L I k).symm
+    · apply congrArg List.ofFn
+      funext k
+      exact (decodeBlock_tensorProductBlockEquiv_modNat d e L J k).symm
 
 /-- The closed MPO of an independent tensor product is the Kronecker product of
 the two closed MPOs, in sitewise product coordinates.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1565,7 +1565,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}\leanok
     \uses{def:mpdo_positive_physical_blocking,
-        def:mpu_independent_tensor_product,
+        def:mpu_physical_reindexing,def:mpu_independent_tensor_product,
         thm:mpu_tensor_product_block_decoding}
     Evaluate both sides on blocked ket and bra letters. Word multiplication of
     local Kronecker products gives

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -755,7 +755,8 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_eval_word_physical_reindexing}
+    \uses{def:mpu_physical_reindexing,def:mpo_family,
+        thm:mpu_eval_word_physical_reindexing}
     Apply the word identity to every pair of configurations and take the
     virtual trace. This is simultaneous row and column reindexing by $e_*$.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -713,14 +713,52 @@ closing a chain of $N$ copies of $\mathcal U$.
 
 \begin{definition}[Physical-basis reindexing]
     \label{def:mpu_physical_reindexing}
-    \lean{MPOTensor.reindexPhysical}
+    \lean{MPOTensor.reindexPhysical,
+        MPOTensor.reindexPhysicalConfigEquiv}
     \leanok
     For a bijection $e$ between two physical index sets, the reindexed tensor
-    is defined by
+    and its action on length-$N$ configurations are
     \begin{align}
-        (e^*\mathcal U)^{ij}=\mathcal U^{e(i)e(j)}.
+        (e^*\mathcal U)^{ij}&=\mathcal U^{e(i)e(j)},
+        &(e_*\sigma)(n)&=e(\sigma(n)).
     \end{align}
 \end{definition}
+
+\begin{theorem}[Words under physical reindexing]
+    \label{thm:mpu_eval_word_physical_reindexing}
+    \lean{MPOTensor.evalWord_reindexPhysical}
+    \leanok
+    \uses{def:mpu_physical_reindexing,def:mpo_eval_word}
+    For ket and bra words $i,j$, physical reindexing gives
+    \begin{align}
+        (e^*\mathcal U)[i,j]&=\mathcal U[e_*i,e_*j].
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_physical_reindexing,def:mpo_eval_word}
+    Induct simultaneously along the two words. The empty pair gives the
+    identity matrix, mismatched lengths give zero, and the nonempty case
+    applies the defining equality to the first letters and the induction
+    hypothesis to the tails.
+\end{proof}
+
+\begin{theorem}[Finite-size operators under physical reindexing]
+    \label{thm:mpu_finite_size_physical_reindexing}
+    \lean{MPOTensor.mpo_reindexPhysical}
+    \leanok
+    \uses{def:mpu_physical_reindexing,def:mpo_family}
+    At every length $N$, the sitewise configuration bijection identifies
+    \begin{align}
+        (e^*\mathcal U)^{(N)}&\cong\mathcal U^{(N)}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_eval_word_physical_reindexing}
+    Apply the word identity to every pair of configurations and take the
+    virtual trace. This is simultaneous row and column reindexing by $e_*$.
+\end{proof}
 
 \begin{theorem}[Double layer under physical reindexing]
     \label{thm:mpu_double_layer_physical_reindexing}
@@ -1360,6 +1398,52 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{definition}
 
+\begin{theorem}[Source cuts under physical reindexing]
+    \label{thm:mpu_source_cuts_physical_reindexing}
+    \lean{MPOTensor.sourceCutM₁_reindexPhysical,
+        MPOTensor.sourceCutM₂_reindexPhysical}
+    \leanok
+    \uses{def:mpu_physical_reindexing,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two}
+    A bijective relabeling of the physical basis simultaneously relabels the
+    physical component of every source-cut row and column. Hence
+    \begin{align}
+        M_1(e^*\mathcal U)&\cong M_1(\mathcal U),
+        &M_2(e^*\mathcal U)&\cong M_2(\mathcal U),
+    \end{align}
+    with the right and left orientations unchanged.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_physical_reindexing,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two}
+    Evaluate each cut after relabeling. In $M_1$, the lower physical index lies
+    in the row and the upper physical index lies in the column; in $M_2$ these
+    roles are exchanged. Applying $e$ to both entries gives the two displayed
+    row-and-column equivalences.
+\end{proof}
+
+\begin{theorem}[Source ranks under physical reindexing]
+    \label{thm:mpu_source_ranks_physical_reindexing}
+    \lean{MPOTensor.rightRank_reindexPhysical,
+        MPOTensor.leftRank_reindexPhysical}
+    \leanok
+    \uses{def:mpu_physical_reindexing,def:mpu_right_rank,
+        def:mpu_left_rank}
+    Bijective physical relabeling preserves both source ranks:
+    \begin{align}
+        r(e^*\mathcal U)&=r(\mathcal U),
+        &\ell(e^*\mathcal U)&=\ell(\mathcal U).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_source_cuts_physical_reindexing,
+        def:mpu_right_rank,def:mpu_left_rank}
+    Matrix rank is unchanged by bijective row and column relabelings. Apply this
+    fact to the two source-cut identities.
+\end{proof}
+
 \begin{definition}[Independent tensor product of matrix product operator tensors]
     \label{def:mpu_independent_tensor_product}
     \lean{MPOTensor.tensorProduct, MPOTensor.tensorProduct_apply,
@@ -1377,6 +1461,42 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     A product-valued physical configuration splits sitewise into one
     configuration for $\mathcal U$ and one for $\mathcal V$.
 \end{definition}
+
+\begin{definition}[Blocked product-alphabet equivalence]
+    \label{def:mpu_tensor_product_block_equiv}
+    \lean{MPOTensor.tensorProductBlockEquiv}
+    \leanok
+    \uses{def:mpdo_positive_physical_blocking}
+    A blocked word of $L$ product letters separates canonically into two
+    blocked words:
+    \begin{align}
+        \Fin{(de)^L}&\simeq\Fin{d^L e^L}.
+    \end{align}
+    The map decodes the length-$L$ word, splits every letter into its $d$ and
+    $e$ components, and re-encodes the two resulting words.
+\end{definition}
+
+\begin{theorem}[Decoding the blocked product alphabet]
+    \label{thm:mpu_tensor_product_block_decoding}
+    \lean{MPOTensor.decodeBlock_tensorProductBlockEquiv_divNat,
+        MPOTensor.decodeBlock_tensorProductBlockEquiv_modNat}
+    \leanok
+    \uses{def:mpu_tensor_product_block_equiv}
+    If $q$ denotes the blocked product-alphabet equivalence, then each site
+    $s$ satisfies
+    \begin{align}
+        \operatorname{dec}_d(q(I)_{1},s)
+            &=\operatorname{dec}_{de}(I,s)_{1},\\
+        \operatorname{dec}_e(q(I)_{2},s)
+            &=\operatorname{dec}_{de}(I,s)_{2}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_tensor_product_block_equiv}
+    Each equality follows by composing the inverse product encoding at every
+    site with the corresponding projection.
+\end{proof}
 
 \begin{theorem}[Finite-size operator of an independent tensor product]
     \label{thm:mpu_finite_tensor_product}
@@ -1406,8 +1526,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_tensor_product}
     \lean{MPOTensor.IsMPU.tensorProduct}
     \leanok
-    \uses{def:mpu,def:mpu_independent_tensor_product,
-        thm:mpu_finite_tensor_product}
+    \uses{def:mpu,def:mpu_independent_tensor_product}
     The independent tensor product of two matrix product unitary tensors is a
     matrix product unitary tensor. This is the tensoring operation in the proof
     of \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
@@ -1425,6 +1544,37 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
          =\Id\otimes\Id=\Id.
     \end{align}
     Simultaneous reindexing preserves this unitarity equation.
+\end{proof}
+
+\begin{theorem}[Blocking an independent tensor product]
+    \label{thm:mpu_block_tensor_product}
+    \lean{MPOTensor.blockTensor_tensorProduct}
+    \leanok
+    \uses{def:mpdo_positive_physical_blocking,
+        def:mpu_physical_reindexing,def:mpu_independent_tensor_product,
+        def:mpu_tensor_product_block_equiv}
+    For every blocking length $L$, separating each blocked product letter by
+    the canonical equivalence $q$ gives the exact identity
+    \begin{align}
+        (\mathcal U\boxtimes\mathcal V)^{[L]}
+        &=q^*\bigl(\mathcal U^{[L]}\boxtimes\mathcal V^{[L]}\bigr).
+    \end{align}
+    The ordering of the two component words agrees with the independent
+    tensor-product convention.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_positive_physical_blocking,
+        def:mpu_independent_tensor_product,
+        thm:mpu_tensor_product_block_decoding}
+    Evaluate both sides on blocked ket and bra letters. Word multiplication of
+    local Kronecker products gives
+    \begin{align}
+        (\mathcal U\boxtimes\mathcal V)[I,J]
+        &=\mathcal U[I_1,J_1]\otimes\mathcal V[I_2,J_2].
+    \end{align}
+    The two decoding identities identify $I_1,I_2$ and $J_1,J_2$ with the
+    corresponding letters of $q(I)$ and $q(J)$.
 \end{proof}
 
 \begin{definition}[Source-cut shuffle for an independent tensor product]
@@ -1471,9 +1621,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.rightRank_tensorProduct,
         MPOTensor.leftRank_tensorProduct}
     \leanok
-    \uses{def:mpu_independent_tensor_product,
-        thm:mpu_tensor_product_source_cuts,def:mpu_right_rank,
-        def:mpu_left_rank,thm:mpu_kronecker_rank}
+    \uses{def:mpu_independent_tensor_product,def:mpu_right_rank,
+        def:mpu_left_rank}
     The right and left source-cut ranks are multiplicative:
     \begin{align}
         r(\mathcal U\boxtimes\mathcal V)


### PR DESCRIPTION
## What changed

- add physical-reindex configuration, word-evaluation, and finite-size MPO formulas
- prove both source cuts and both source ranks are invariant under physical reindexing
- define the canonical equivalence separating a blocked word of product letters into the two blocked words
- prove exact compatibility of physical blocking with the independent MPU tensor product
- synchronize Chapter 28 and correct the late statement/proof dependency placement from #6064

## Validation

- `lake build TNLean.MPS.MPU.TensorProduct TNLean.MPS.MPU`
- Mathlib lint on all three changed Lean modules
- generated-import, style, proof-integrity, and file-policy checks
- focused blueprint synchronization and declaration checks for all 11 new declarations
- two LuaLaTeX blueprint passes with zero undefined cross-references
- `git diff --check origin/main...HEAD`

Closes #6059
Advances #6015 and #5711

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal lemmas and blueprint sync in MPS/MPU theory; no auth, runtime, or data-path changes.
> 
> **Overview**
> Adds **physical reindexing** infrastructure for MPO tensors: sitewise configuration equivalence `reindexPhysicalConfigEquiv`, lemmas that **word evaluation** and **finite-size `mpo`** matrices commute with `reindexPhysical`, and matching identities for **both source cuts** and **both source ranks** (`sourceCutM₁/₂_reindexPhysical`, `rightRank/leftRank_reindexPhysical`).
> 
> For **independent tensor products**, introduces `tensorProductBlockEquiv` and decoding lemmas so a blocked product alphabet splits into two component blocked words, then proves **`blockTensor_tensorProduct`**: blocking commutes with `tensorProduct` after that canonical physical reindexing.
> 
> Chapter 28 blueprint (`ch28_mpu.tex`) is synchronized with the new Lean declarations (physical reindexing, source-cut/rank invariance, blocked product alphabet, blocking–tensor-product theorem); some proof dependency lists are trimmed where lemmas are no longer cited directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit effeca22d2018187f85ce84709016d1a4d198b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->