### PR TITLE
feat(MPS/MPU): rotate the second source-cut Gram

### DIFF
--- a/TNLean/MPS/MPU/SourceFactors.lean
+++ b/TNLean/MPS/MPU/SourceFactors.lean
@@ -46,8 +46,9 @@ normalized for the ordinary inner product.
   `MPOTensor.sourceCutM₂_eq_sourceX₂_mul_sourceY₂`: the exact source-cut factorizations.
 * `MPOTensor.sourceX₁_mul_sourceY₁_apply`, `MPOTensor.sourceX₂_mul_sourceY₂_apply`: the
   entry formulas identifying the two graphical source decompositions with the tensor entries.
-* `MPOTensor.sourceX₁_weighted_isometry`, `MPOTensor.sourceX₂_isometry`: the two left-factor
-  normalizations.
+* `MPOTensor.sourceX₁_weighted_isometry`, `MPOTensor.sourceX₂_isometry`,
+  `MPOTensor.sourceX₂_isometry_apply`: the two left-factor normalizations and the entrywise
+  second-cut identity.
 * `MPOTensor.sourceY₁_mul_sourceZ₁`, `MPOTensor.sourceY₂_mul_sourceZ₂`: the two right-inverse
   identities.
 

--- a/TNLean/MPS/MPU/SourceFactors.lean
+++ b/TNLean/MPS/MPU/SourceFactors.lean
@@ -455,6 +455,17 @@ theorem sourceX₁_weighted_isometry
 theorem sourceX₂_isometry : (sourceX₂ U).IsIsometry := by
   exact (sourceSVD₂ U).V_coisometry.conjTranspose (sourceSVD₂ U).V
 
+/-- Entrywise form of the column-isometry identity $X_2^\dagger X_2=1$.
+
+Source: arXiv:1703.09188, equation `Y1Y1X1X1`, lines 479--494. -/
+theorem sourceX₂_isometry_apply (l l' : Fin ℓ[U]) :
+    (∑ β : Fin D, ∑ i : Fin d,
+      star (sourceX₂ U (β, i) l) * sourceX₂ U (β, i) l') =
+      if l = l' then 1 else 0 := by
+  have h := congrArg (fun M ↦ M l l') (sourceX₂_isometry U)
+  simpa only [Matrix.mul_apply, Matrix.one_apply, Matrix.conjTranspose_apply,
+    Fintype.sum_prod_type] using h
+
 /-- The weighted right-inverse identity $Y_1Z_1=I$ from arXiv:1703.09188,
 `YZ=1` (lines 503--506). -/
 theorem sourceY₁_mul_sourceZ₁

--- a/TNLean/MPS/MPU/SourceUBoundary.lean
+++ b/TNLean/MPS/MPU/SourceUBoundary.lean
@@ -54,17 +54,6 @@ noncomputable def sourceUOpenTailCoefficient
         (U i j₂ * evalWord U (List.ofFn τ) (List.ofFn ζ)) β α *
         star ((U i' j₂ * evalWord U (List.ofFn τ) (List.ofFn ζ)) β' α')
 
-/-- Entrywise form of the column-isometry identity $X_2^\dagger X_2=1$.
-
-Source: arXiv:1703.09188, equation `Y1Y1X1X1`, lines 479--494. -/
-theorem sourceX₂_isometry_apply (l l' : Fin ℓ[U]) :
-    (∑ β : Fin D, ∑ i : Fin d,
-      star (sourceX₂ U (β, i) l) * sourceX₂ U (β, i) l') =
-      if l = l' then 1 else 0 := by
-  have h := congrArg (fun M ↦ M l l') (sourceX₂_isometry U)
-  simpa only [Matrix.mul_apply, Matrix.one_apply, Matrix.conjTranspose_apply,
-    Fintype.sum_prod_type] using h
-
 /-- If the internal open tail has kernel
 $\rho_{\alpha',\alpha}\delta_{\beta,\beta'}\delta_{i,i'}$, then its weighted
 $X_1$ and unweighted $X_2$ boundary is

--- a/TNLean/MPS/MPU/SourceVIsometry.lean
+++ b/TNLean/MPS/MPU/SourceVIsometry.lean
@@ -26,6 +26,44 @@ namespace MPOTensor
 
 variable {d D : ℕ} (U : MPOTensor d D)
 
+/-- Rotating the second source cut by $90^\circ$ identifies its physical/virtual
+Gram contraction with the ordinary Gram contraction of $Y_2$.
+
+The physical index `p` and virtual index `a` occur in the starred factor, while
+`q` and `b` occur in the unstarred factor.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--601). -/
+theorem sourceY₂_gram_eq_rotated_sourceCutM₂_gram
+    (p q : Fin d) (a b : Fin D) :
+    (∑ β : Fin D, ∑ z : Fin d,
+      star (U z p β a) * U z q β b) =
+      ∑ l : Fin ℓ[U],
+        star (sourceY₂ U l (p, a)) * sourceY₂ U l (q, b) := by
+  simp_rw [← sourceX₂_mul_sourceY₂_apply U]
+  simp only [Matrix.mul_apply, star_sum, star_mul, Finset.sum_mul, Finset.mul_sum]
+  -- Move the two source indices outside the physical/virtual contraction.
+  conv_lhs => arg 2; ext β; arg 2; ext z; rw [Finset.sum_comm]
+  conv_lhs => arg 2; ext β; rw [Finset.sum_comm]
+  rw [Finset.sum_comm]
+  conv_lhs => arg 2; ext l; arg 2; ext β; rw [Finset.sum_comm]
+  conv_lhs => arg 2; ext l; rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun l _ ↦ ?_
+  calc
+    _ = ∑ l' : Fin ℓ[U],
+        star (sourceY₂ U l (p, a)) *
+          (∑ β : Fin D, ∑ z : Fin d,
+            star (sourceX₂ U (β, z) l) * sourceX₂ U (β, z) l') *
+          sourceY₂ U l' (q, b) := by
+      apply Finset.sum_congr rfl
+      intro l' _
+      simp only [Finset.mul_sum, Finset.sum_mul, mul_assoc]
+    _ = _ := by
+      simp_rw [sourceX₂_isometry_apply U]
+      simp only [sourceY₂_apply, star_sum, star_mul', RCLike.star_def, mul_ite,
+        mul_one, mul_zero, ite_mul, zero_mul, Finset.sum_ite_eq, Finset.mem_univ,
+        reduceIte]
+
 /-- The tensor product $Y_1\otimes Y_2$ in the source-bond order $(r,\ell)$.
 
 Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/

--- a/TNLean/MPS/MPU/SourceVIsometry.lean
+++ b/TNLean/MPS/MPU/SourceVIsometry.lean
@@ -10,7 +10,8 @@ import TNLean.MPS.MPU.SourceUV
 # The dressed source-v Gram equation
 
 This file formalizes the algebraic cancellation surrounding the source tensor
-$v$ in arXiv:1703.09188, equation `vUnitary` (lines 577--600).  The right source
+$v$ in arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--601).  The right source
 factors are tensorized in the exact dotted/solid leg order, and their explicit
 right inverse removes the dressing from
 $Y^\dagger(v^\dagger v)Y=Y^\dagger Y$.
@@ -29,8 +30,8 @@ variable {d D : ℕ} (U : MPOTensor d D)
 /-- Rotating the second source cut by $90^\circ$ identifies its physical/virtual
 Gram contraction with the ordinary Gram contraction of $Y_2$.
 
-The physical index `p` and virtual index `a` occur in the starred factor, while
-`q` and `b` occur in the unstarred factor.
+The physical index $p$ and virtual index $a$ occur in the starred factor, while
+$q$ and $b$ occur in the unstarred factor.
 
 Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
 (lines 563--601). -/

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1769,6 +1769,36 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     displayed entry sum.
 \end{proof}
 
+\begin{theorem}[Rotated second source-cut Gram]
+    \label{thm:mpu_source_y_two_rotated_gram}
+    \lean{MPOTensor.sourceY₂_gram_eq_rotated_sourceCutM₂_gram}
+    \leanok
+    \uses{def:mpu_source_matrix_two,def:mpu_weighted_source_factors}
+    For every tensor $\mathcal U$, physical indices $p,q$, and auxiliary
+    indices $a,b$,
+    \begin{align}
+        \sum_{\beta,z}
+          \overline{\mathcal U^z_{p,\beta,a}}\,
+          \mathcal U^z_{q,\beta,b}
+        &=\sum_l \overline{(Y_2)_{l,(p,a)}}(Y_2)_{l,(q,b)}.
+    \end{align}
+    Thus the factor indexed by $(p,a)$ is starred and the factor indexed by
+    $(q,b)$ is unstarred. This is the second-cut rotation used in
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
+    The identity requires no Matrix Product Unitary, dimension, positivity, or
+    simple-tensor hypothesis.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpu_source_factorization_entries,
+        thm:mpu_source_factor_normalizations}
+    Substitute the entry factorization $M_2=X_2Y_2$ into the left-hand side
+    and reorder the finite sums. The contraction of the two $X_2$ factors is
+    $X_2^\dagger X_2=\Id_\ell$, so the two source indices coincide and the
+    remaining sum is the displayed Gram matrix of $Y_2$.
+\end{proof}
+
 \begin{theorem}[Recovery of the right source factors]
     \label{thm:mpu_source_factor_recovery}
     \lean{MPOTensor.sourceY₁_eq_sourceX₁_conjTranspose_mul_weight_mul_sourceCutM₁,
@@ -2543,7 +2573,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         Y^\dagger(v^\dagger v)Y&=Y^\dagger Y.
     \end{align}
     These are the tensorized factors surrounding $v^\dagger v$ in
-    \cite[Section~III, equation \texttt{vUnitary}]{Cirac2017MPU}.
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
 \end{definition}
 
 \begin{theorem}[Tensorized source right inverse]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1773,7 +1773,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_source_y_two_rotated_gram}
     \lean{MPOTensor.sourceY₂_gram_eq_rotated_sourceCutM₂_gram}
     \leanok
-    \uses{def:mpu_source_matrix_two,def:mpu_weighted_source_factors}
+    \uses{def:mpu_weighted_source_factors}
     For every tensor $\mathcal U$, physical indices $p,q$, and auxiliary
     indices $a,b$,
     \begin{align}
@@ -1791,7 +1791,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}
     \leanok
-    \uses{thm:mpu_source_factorization_entries,
+    \uses{def:mpu_weighted_source_factors,
+        thm:mpu_source_factorization_entries,
         thm:mpu_source_factor_normalizations}
     Substitute the entry factorization $M_2=X_2Y_2$ into the left-hand side
     and reorder the finite sums. The contraction of the two $X_2$ factors is


### PR DESCRIPTION
## Summary
- prove the exact second source-cut $90^\circ$ Gram rotation with the paper's starred/unstarred orientation
- move the reusable entrywise $X_2^\dagger X_2$ identity to the low-level source-factor module
- synchronize Chapter 28 and published Theorem III.8 / equations (31)–(32) citations

## Scope
This is the valid independent second-cut component of #6071. It assumes neither MPU, positivity, simple contractions, nor positive dimensions. It does not assert the false standalone first-cut rotation closed in #6077 and does not complete the four-$\mathcal U$ bridge in #6067.

## Verification
- `lake env lean TNLean/MPS/MPU/SourceFactors.lean`
- `lake env lean TNLean/MPS/MPU/SourceUBoundary.lean`
- `lake env lean TNLean/MPS/MPU/SourceVIsometry.lean`
- `git diff --check`
- proof-integrity scan

Closes #6076
Parent: #6071

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure algebraic lemmas on source factors with no MPU, positivity, or dimension hypotheses; localized file moves and blueprint text only.
> 
> **Overview**
> Adds the **second-cut $90^\circ$ Gram rotation**: a contraction over raw tensor entries with starred $(p,a)$ and unstarred $(q,b)$ matches the **$Y_2$ Gram** $\sum_l \overline{Y_2} Y_2$. The proof uses $M_2=X_2Y_2$, reorders sums, and collapses $X_2^\dagger X_2$ via the entrywise isometry identity.
> 
> **`sourceX₂_isometry_apply`** is moved from `SourceUBoundary` to **`SourceFactors`** so downstream proofs (including the new rotation) share one definition; `sourceU_boundary_sandwich` still calls it from there.
> 
> Chapter 28 gains theorem **`mpu_source_y_two_rotated_gram`** and citations are aligned with **Theorem III.8, equations (31)–(32)** instead of generic `vUnitary` labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed6028203c485643c621730e50a5ee022eacc94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->