### PR TITLE
feat(MPS/MPU): expand the source-v four-U contractions

### DIFF
--- a/TNLean/MPS/MPU/SourceVIsometry.lean
+++ b/TNLean/MPS/MPU/SourceVIsometry.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.MatrixUnitaryBetween
+import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SourceUV
 
 /-!
@@ -65,6 +66,121 @@ theorem sourceY₂_gram_eq_rotated_sourceCutM₂_gram
         mul_one, mul_zero, ite_mul, zero_mul, Finset.sum_ite_eq, Finset.mem_univ,
         reduceIte]
 
+/-- The weighted first source-cut Gram contraction with the physical index $p$
+and virtual index $a$ in the starred factor.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--601). -/
+theorem sourceY₁_gram_eq_weighted_sourceCutM₁_gram
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (p q : Fin d) (a b : Fin D) :
+    (∑ r : Fin r[U],
+      star (sourceY₁ U ρ hρ r (p, a)) * sourceY₁ U ρ hρ r (q, b)) =
+      ∑ α : Fin D, ∑ α' : Fin D, ∑ j : Fin d,
+        star (U p j α a) * ρ α α' * U q j α' b := by
+  have hgram :
+      (sourceY₁ U ρ hρ)ᴴ * sourceY₁ U ρ hρ =
+        (sourceCutM₁ U)ᴴ * sourceWeight (d := d) ρ * sourceCutM₁ U := by
+    calc
+      (sourceY₁ U ρ hρ)ᴴ * sourceY₁ U ρ hρ =
+          (sourceY₁ U ρ hρ)ᴴ *
+            ((sourceX₁ U ρ hρ)ᴴ * sourceWeight (d := d) ρ *
+              sourceX₁ U ρ hρ) * sourceY₁ U ρ hρ := by
+        rw [sourceX₁_weighted_isometry]
+        simp only [Matrix.mul_one]
+      _ = (sourceX₁ U ρ hρ * sourceY₁ U ρ hρ)ᴴ *
+          sourceWeight (d := d) ρ *
+            (sourceX₁ U ρ hρ * sourceY₁ U ρ hρ) := by
+        simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+      _ = _ := by rw [← sourceCutM₁_eq_sourceX₁_mul_sourceY₁]
+  have hentry := congrArg (fun M ↦ M (p, a) (q, b)) hgram
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, sourceWeight,
+    Matrix.kronecker_apply, Matrix.one_apply, mul_ite, mul_one, mul_zero,
+    Finset.sum_ite_eq', Finset.mem_univ, if_true, sourceCutM₁_apply,
+    Fintype.sum_prod_type] at hentry
+  simp_rw [Finset.sum_mul] at hentry
+  conv_rhs at hentry => arg 2; ext j; rw [Finset.sum_comm]
+  rw [Finset.sum_comm] at hentry
+  exact hentry
+
+/-- Entry expansion of two ordinary double-layer letters. The physical pair $p$
+is starred, $q$ is unstarred, and the doubled-bond row and column are
+`(a.1, b.1)` and `(a.2, b.2)`.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--601). -/
+theorem doubleLayerTensor_mul_apply_four_u
+    (p q : Fin d × Fin d) (a b : Fin D × Fin D) :
+    (doubleLayerTensor U p.1 q.1 * doubleLayerTensor U p.2 q.2)
+        (finProdFinEquiv (a.1, b.1)) (finProdFinEquiv (a.2, b.2)) =
+      ∑ α : Fin D, ∑ β : Fin D, ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+        star (U j₁ p.1 a.1 α) * U j₁ q.1 b.1 β *
+          (star (U j₂ p.2 α a.2) * U j₂ q.2 β b.2) := by
+  classical
+  simp only [Matrix.mul_apply]
+  rw [← Equiv.sum_comp finProdFinEquiv]
+  simp only [doubleLayerTensor_apply, Matrix.submatrix_apply,
+    Equiv.symm_apply_apply, Matrix.sum_apply, kroneckerMap_apply,
+    physicalAdjointTensor_apply, RCLike.star_def]
+  simp_rw [Finset.sum_mul_sum]
+  rw [Fintype.sum_prod_type]
+
+/-- Entry expansion of two double-layer letters with the supplied rank-one
+matrix inserted between them. The vectors use the source order fixed by
+`Matrix.vec` and `finProdFinEquiv`.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--601). -/
+theorem doubleLayerTensor_rankOne_mul_apply_four_u
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (p q : Fin d × Fin d)
+    (a b : Fin D × Fin D) :
+    (doubleLayerTensor U p.1 q.1 *
+        Matrix.vecMulVec
+          (fun x ↦ ρ.vec (finProdFinEquiv.symm x))
+          (fun x ↦ (1 : Matrix (Fin D) (Fin D) ℂ).vec
+            (finProdFinEquiv.symm x)) *
+        doubleLayerTensor U p.2 q.2)
+        (finProdFinEquiv (a.1, b.1)) (finProdFinEquiv (a.2, b.2)) =
+      ∑ α : Fin D, ∑ α' : Fin D, ∑ β : Fin D,
+      ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+        star (U j₁ p.1 a.1 α) * U j₁ q.1 b.1 α' * ρ α' α *
+          (star (U j₂ p.2 β a.2) * U j₂ q.2 β b.2) := by
+  classical
+  let ρ' : Fin (D * D) → ℂ := fun x ↦ ρ.vec (finProdFinEquiv.symm x)
+  let Φ' : Fin (D * D) → ℂ := fun x ↦
+    (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm x)
+  have hleft :
+      (doubleLayerTensor U p.1 q.1 *ᵥ ρ') (finProdFinEquiv (a.1, b.1)) =
+        ∑ α : Fin D, ∑ α' : Fin D, ∑ j₁ : Fin d,
+          star (U j₁ p.1 a.1 α) * U j₁ q.1 b.1 α' * ρ α' α := by
+    simp only [Matrix.mulVec, dotProduct]
+    rw [← Equiv.sum_comp finProdFinEquiv]
+    simp only [ρ', Matrix.vec, doubleLayerTensor_apply, Matrix.submatrix_apply,
+      Equiv.symm_apply_apply, Matrix.sum_apply, kroneckerMap_apply,
+      physicalAdjointTensor_apply, RCLike.star_def]
+    simp_rw [Finset.sum_mul]
+    rw [Fintype.sum_prod_type]
+  have hright :
+      Matrix.vecMul Φ' (doubleLayerTensor U p.2 q.2)
+          (finProdFinEquiv (a.2, b.2)) =
+        ∑ β : Fin D, ∑ j₂ : Fin d,
+          star (U j₂ p.2 β a.2) * U j₂ q.2 β b.2 := by
+    simp only [Matrix.vecMul, dotProduct]
+    rw [← Equiv.sum_comp finProdFinEquiv]
+    simp only [Φ', Matrix.vec, Matrix.one_apply, doubleLayerTensor_apply,
+      Matrix.submatrix_apply, Equiv.symm_apply_apply, Matrix.sum_apply,
+      kroneckerMap_apply, physicalAdjointTensor_apply, RCLike.star_def,
+      ite_mul, one_mul, zero_mul]
+    rw [Fintype.sum_prod_type]
+    simp_rw [Finset.sum_ite_eq', Finset.mem_univ, if_true]
+  change (doubleLayerTensor U p.1 q.1 * Matrix.vecMulVec ρ' Φ' *
+      doubleLayerTensor U p.2 q.2)
+      (finProdFinEquiv (a.1, b.1)) (finProdFinEquiv (a.2, b.2)) = _
+  rw [Matrix.mul_vecMulVec, Matrix.vecMulVec_mul, Matrix.vecMulVec_apply,
+    hleft, hright]
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  conv_lhs => arg 2; ext α; arg 2; ext α'; rw [Finset.sum_comm]
+
 /-- The tensor product $Y_1\otimes Y_2$ in the source-bond order $(r,\ell)$.
 
 Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
@@ -94,6 +210,46 @@ Source: arXiv:1703.09188, equation `vUnitary`, lines 577--588. -/
     (x₁ x₂ : Fin d × Fin D) :
     sourceYTensor U ρ hρ (r, l) (x₁, x₂) =
       sourceY₁ U ρ hρ r x₁ * sourceY₂ U l x₂ := rfl
+
+/-- Complete expansion of the $Y_1\otimes Y_2$ Gram entry into four local
+$U$ entries. The first cut retains the source weight, while the second cut is
+rotated using its column-isometry normalization.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--601). -/
+theorem sourceYTensor_gram_eq_four_u_weighted
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (p q : Fin d × Fin d) (a b : Fin D × Fin D) :
+    (∑ t : Fin r[U] × Fin ℓ[U],
+      star (sourceYTensor U ρ hρ t ((p.1, a.1), (p.2, a.2))) *
+        sourceYTensor U ρ hρ t ((q.1, b.1), (q.2, b.2))) =
+      ∑ α : Fin D, ∑ α' : Fin D, ∑ β : Fin D,
+      ∑ j₁ : Fin d, ∑ j₂ : Fin d,
+        star (U p.1 j₁ α a.1) * ρ α α' * U q.1 j₁ α' b.1 *
+          (star (U j₂ p.2 β a.2) * U j₂ q.2 β b.2) := by
+  rw [Fintype.sum_prod_type]
+  simp only [sourceYTensor_apply, star_mul]
+  calc
+    _ = (∑ r : Fin r[U],
+          star (sourceY₁ U ρ hρ r (p.1, a.1)) *
+            sourceY₁ U ρ hρ r (q.1, b.1)) *
+        (∑ l : Fin ℓ[U],
+          star (sourceY₂ U l (p.2, a.2)) * sourceY₂ U l (q.2, b.2)) := by
+      simp_rw [Finset.sum_mul_sum]
+      apply Finset.sum_congr rfl
+      intro r _
+      apply Finset.sum_congr rfl
+      intro l _
+      ring
+    _ = (∑ α : Fin D, ∑ α' : Fin D, ∑ j₁ : Fin d,
+          star (U p.1 j₁ α a.1) * ρ α α' * U q.1 j₁ α' b.1) *
+        (∑ β : Fin D, ∑ j₂ : Fin d,
+          star (U j₂ p.2 β a.2) * U j₂ q.2 β b.2) := by
+      rw [sourceY₁_gram_eq_weighted_sourceCutM₁_gram,
+        sourceY₂_gram_eq_rotated_sourceCutM₂_gram]
+    _ = _ := by
+      simp_rw [Finset.sum_mul, Finset.mul_sum]
+      conv_lhs => arg 2; ext α; arg 2; ext α'; rw [Finset.sum_comm]
 
 /-- Entry formula for $Z_1\otimes Z_2$ in dotted/solid source-bond order.
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2727,6 +2727,71 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
 \end{definition}
 
+\begin{theorem}[Four-letter source contractions]
+    \label{thm:mpu_source_v_four_u_expansions}
+    \lean{MPOTensor.sourceY₁_gram_eq_weighted_sourceCutM₁_gram,
+        MPOTensor.doubleLayerTensor_mul_apply_four_u,
+        MPOTensor.doubleLayerTensor_rankOne_mul_apply_four_u,
+        MPOTensor.sourceYTensor_gram_eq_four_u_weighted}
+    \leanok
+    \uses{def:mpu_source_v_dressing,def:mpu_double_layer,
+        thm:mpu_source_factorizations,
+        thm:mpu_source_factor_normalizations,
+        thm:mpu_source_y_two_rotated_gram}
+    Let $p=(p_1,p_2)$ be the starred physical pair,
+    $q=(q_1,q_2)$ the unstarred pair, and let $a=(a_1,a_2)$ and
+    $b=(b_1,b_2)$ be virtual paths. The weighted first-cut contraction is
+    \begin{align}
+      \sum_r \overline{(Y_1)_{r,(p_1,a_1)}}(Y_1)_{r,(q_1,b_1)}
+      &=\sum_{\alpha,\alpha',j_1}
+        \overline{U^{p_1j_1}_{\alpha a_1}}
+        \rho_{\alpha\alpha'}U^{q_1j_1}_{\alpha'b_1}.
+    \end{align}
+    The entry of two ordinary double-layer letters from row $(a_1,b_1)$ to
+    column $(a_2,b_2)$ is
+    \begin{align}
+      \sum_{\alpha,\beta,j_1,j_2}
+        \overline{U^{p_1j_1}_{a_1\alpha}}
+        U^{q_1j_1}_{b_1\beta}
+        \overline{U^{p_2j_2}_{\alpha a_2}}
+        U^{q_2j_2}_{\beta b_2}.
+    \end{align}
+    Set
+    \begin{align}
+      \rho'_x&=\operatorname{vec}(\rho)_{\operatorname{flat}^{-1}(x)}, &
+      \Phi'_x&=\operatorname{vec}(\Id_D)_{\operatorname{flat}^{-1}(x)}.
+    \end{align}
+    Inserting $\ket{\rho'}\!\bra{\Phi'}$ between the two letters gives
+    \begin{align}
+      &\bigl(W^{p_1q_1}\ket{\rho'}\!\bra{\Phi'}W^{p_2q_2}\bigr)
+        _{(a_1,b_1),(a_2,b_2)} \\
+      &\quad=\sum_{\alpha,\alpha',\beta,j_1,j_2}
+        \overline{U^{j_1p_1}_{a_1\alpha}}
+        U^{j_1q_1}_{b_1\alpha'}\rho_{\alpha'\alpha}
+        \overline{U^{j_2p_2}_{\beta a_2}}U^{j_2q_2}_{\beta b_2}.
+    \end{align}
+    Finally, the Gram entry of $Y_1\otimes Y_2$ expands as
+    \begin{align}
+      \sum_{\alpha,\alpha',\beta,j_1,j_2}
+        \overline{U^{p_1j_1}_{\alpha a_1}}
+        \rho_{\alpha\alpha'}U^{q_1j_1}_{\alpha'b_1}
+        \overline{U^{j_2p_2}_{\beta a_2}}
+        U^{j_2q_2}_{\beta b_2}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpu_source_factorizations,
+        thm:mpu_source_factor_normalizations,
+        thm:mpu_source_y_two_rotated_gram}
+    Expand the ordinary and rank-one-inserted matrix products entrywise.
+    For the tensorized Gram entry, use
+    $X_1^\dagger(\rho\otimes\Id_d)X_1=\Id_r$ on the first cut and
+    $X_2^\dagger X_2=\Id_\ell$ on the second cut, then reorder the finite
+    sums. No ambient identity $X_2X_2^\dagger=\Id$ is used.
+\end{proof}
+
 \begin{theorem}[Tensorized source right inverse]
     \label{thm:mpu_source_yz_tensor}
     \lean{MPOTensor.sourceYTensor_mul_sourceZTensor}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2751,10 +2751,10 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     column $(a_2,b_2)$ is
     \begin{align}
       \sum_{\alpha,\beta,j_1,j_2}
-        \overline{U^{p_1j_1}_{a_1\alpha}}
-        U^{q_1j_1}_{b_1\beta}
-        \overline{U^{p_2j_2}_{\alpha a_2}}
-        U^{q_2j_2}_{\beta b_2}.
+        \overline{U^{j_1p_1}_{a_1\alpha}}
+        U^{j_1q_1}_{b_1\beta}
+        \overline{U^{j_2p_2}_{\alpha a_2}}
+        U^{j_2q_2}_{\beta b_2}.
     \end{align}
     Set
     \begin{align}
@@ -2782,7 +2782,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}
     \leanok
-    \uses{thm:mpu_source_factorizations,
+    \uses{def:mpu_source_v_dressing,def:mpu_double_layer,
+        thm:mpu_source_factorizations,
         thm:mpu_source_factor_normalizations,
         thm:mpu_source_y_two_rotated_gram}
     Expand the ordinary and rank-one-inserted matrix products entrywise.


### PR DESCRIPTION
## What changed

- expose the weighted first source-cut Gram as its exact entrywise three-sum contraction
- expand the ordinary and supplied-rank-one two-letter double-layer entries into the source-faithful four-$\mathcal U$ networks
- expand the full $Y_1\otimes Y_2$ Gram entry while retaining the first-cut source weight and using only the valid second-cut rotation
- synchronize Chapter 28 with all four formulas and their exact starred/unstarred and virtual-leg orientation

This is a focused partial checkpoint for #6071. It does not claim the remaining complete-network first-cut rotation or the final source-$v$ isometry. In particular, it does not introduce the false standalone weighted first-cut rotation ruled out by #6077.

## Validation

- `lake build TNLean.MPS.MPU.SourceVIsometry`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- focused proof-integrity scan of `TNLean/MPS/MPU/SourceVIsometry.lean`
- two LuaLaTeX blueprint passes with no undefined cross-references
- `git diff --check origin/main...HEAD`

Advances #6071 and #6067

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint sync in MPU source-v algebra; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Adds **entrywise four-$\mathcal U$ expansions** for the dressed source-$v$ Gram algebra (Cirac et al. Thm III.8, eqs. (31)--(32)), as a partial checkpoint toward source-$v$ isometry—not the full network rotation or final isometry claim.
> 
> In **`SourceVIsometry.lean`**, four theorems spell out: the weighted first-cut `Y₁` Gram as a three-sum in `U` with `ρ`; ordinary and rank-one-inserted two-letter double-layer products as four-local-`U` networks; and the full `Y₁⊗Y₂` Gram keeping **ρ on the first cut** and using only the **valid second-cut rotation** (`X₂†X₂`), without ambient `X₂X₂†`.
> 
> Chapter **28** adds theorem `mpu_source_v_four_u_expansions` with the same four formulas and starred/unstarred leg conventions, synced to the Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a92e7b94ea617bd39d10b4cd75b5168e95763400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->