### PR TITLE
feat(MPS/MPDO): prove the Fibonacci transition-count formula

### DIFF
--- a/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
+++ b/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.PureRecovery
+import TNLean.MPS.Defs
 import Mathlib.NumberTheory.Real.GoldenRatio
 import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.LinearCombination
 
 /-!
 # Fibonacci boundary transition calculation
@@ -26,7 +27,7 @@ In particular, its golden-ratio formula is not an operator-rank theorem.
   Appendix D, lines 2116--2176.
 -/
 
-open scoped Matrix ComplexOrder BigOperators
+open scoped Matrix
 open Matrix Finset
 
 namespace MPSTensor
@@ -44,6 +45,7 @@ Fibonacci fusion rules.
 
 Source: arXiv:1606.00608, Appendix D, lines 2120--2121. -/
 structure FusionWeights where
+  /-- The fusion coefficient assigned to the labels \((i,j,k)\). -/
   N : Fin 2 → Fin 2 → Fin 2 → ℝ
   zero_iff : ∀ i j k, N i j k = 0 ↔ ExactlyTwoZero i j k
   pos_of_not_exactlyTwoZero : ∀ i j k, ¬ExactlyTwoZero i j k → 0 < N i j k

--- a/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
+++ b/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PureRecovery
+import Mathlib.NumberTheory.Real.GoldenRatio
 import Mathlib.Tactic.FinCases
 
 /-!
@@ -15,9 +16,9 @@ The three binary physical labels are written \(i,j,k\), the fusion weights are
 \(A^{ijk}_{αβ} = δ_{i,α} δ_{k,β} N_{ijk}\).  The structural strong fixed-point
 relation is defined separately in `MPOTensor.IsStrongRFP`.
 
-**Scope restriction (transition-count slice):** This file does not identify the
-transition counts with the open-boundary or periodic operator ranks, and it does
-not prove the golden-ratio formula for the periodic rank.
+**Scope restriction (transition-count slice):** This file computes the transition
+counts but does not identify them with the open-boundary or periodic operator ranks.
+In particular, its golden-ratio formula is not an operator-rank theorem.
 
 ## References
 
@@ -116,6 +117,54 @@ def periodicTransitionCount (N : ℕ) : ℕ := x N 0 0 + x N 1 1
 @[simp] theorem periodicTransitionCount_two : periodicTransitionCount 2 = 7 := by
   rw [periodicTransitionCount, (x_succ 1 0).1, (x_succ 1 1).2]
   norm_num [x, B]
+
+/-- The periodic transition counts satisfy the characteristic recurrence of
+\(B=\left(\begin{smallmatrix}1&1\\1&2\end{smallmatrix}\right)\). -/
+theorem periodicTransitionCount_add_two_add (N : ℕ) :
+    periodicTransitionCount (N + 2) + periodicTransitionCount N =
+      3 * periodicTransitionCount (N + 1) := by
+  simp [periodicTransitionCount, x, show N + 2 = N + 1 + 1 by omega, pow_succ, B,
+    Matrix.mul_apply, Fin.sum_univ_two]
+  ring
+
+/-- The exact closed formula for the periodic transition count is the sum of the
+\(2N\)-th powers of the golden ratio and its conjugate. This is only the
+transition-count slice of the calculation and does not identify these counts with
+MPO operator ranks.
+
+Source: CPSV16, arXiv:1606.00608v4, Appendix D, lines 2146--2176. -/
+theorem periodicTransitionCount_eq_goldenRatio (N : ℕ) :
+    (periodicTransitionCount N : ℝ) =
+      Real.goldenRatio ^ (2 * N) + Real.goldenConj ^ (2 * N) := by
+  induction N using Nat.twoStepInduction with
+  | zero => norm_num [periodicTransitionCount, x, B]
+  | one =>
+      norm_num [periodicTransitionCount, x, B]
+      nlinarith [Real.goldenRatio_sq, Real.goldenConj_sq,
+        Real.goldenRatio_add_goldenConj]
+  | more N hN hN1 =>
+      have hCount := congrArg (fun n : ℕ ↦ (n : ℝ)) (periodicTransitionCount_add_two_add N)
+      push_cast at hCount
+      have hRatioQuartic : Real.goldenRatio ^ 4 + 1 = 3 * Real.goldenRatio ^ 2 := by
+        linear_combination
+          (Real.goldenRatio ^ 2 + Real.goldenRatio - 1) * Real.goldenRatio_sq
+      have hRatio :
+          Real.goldenRatio ^ (2 * (N + 2)) + Real.goldenRatio ^ (2 * N) =
+            3 * Real.goldenRatio ^ (2 * (N + 1)) := by
+        rw [show 2 * (N + 2) = 2 * N + 4 by omega,
+          show 2 * (N + 1) = 2 * N + 2 by omega, pow_add, pow_add]
+        linear_combination Real.goldenRatio ^ (2 * N) * hRatioQuartic
+      have hConjQuartic : Real.goldenConj ^ 4 + 1 = 3 * Real.goldenConj ^ 2 := by
+        linear_combination
+          (Real.goldenConj ^ 2 + Real.goldenConj - 1) * Real.goldenConj_sq
+      have hConj :
+          Real.goldenConj ^ (2 * (N + 2)) + Real.goldenConj ^ (2 * N) =
+            3 * Real.goldenConj ^ (2 * (N + 1)) := by
+        rw [show 2 * (N + 2) = 2 * N + 4 by omega,
+          show 2 * (N + 1) = 2 * N + 2 by omega, pow_add, pow_add]
+        linear_combination Real.goldenConj ^ (2 * N) * hConjQuartic
+      rw [hN, hN1] at hCount
+      linarith
 
 /-- The periodic transition counts cannot have geometric growth \(r s^{N-1}\).
 The contradiction is already forced by the values three and seven.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -823,6 +823,7 @@ the remaining sites unchanged.
 \begin{proof}
     \leanok
     \uses{def:cpsv_fibonacci_transition_matrix,
+      def:cpsv_fibonacci_boundary_counts,
       def:cpsv_fibonacci_periodic_count}
     Expand $B^{N+2}=B^{N+1}B$ and $B^{N+1}=B^NB$. Substitution of
     $B=\left(\begin{smallmatrix}1&1\\1&2\end{smallmatrix}\right)$ into the
@@ -864,6 +865,7 @@ the remaining sites unchanged.
 \begin{proof}
     \leanok
     \uses{def:cpsv_fibonacci_transition_matrix,
+      def:cpsv_fibonacci_boundary_counts,
       def:cpsv_fibonacci_periodic_count,
       thm:cpsv_fibonacci_periodic_count_recurrence}
     Use two-step induction on $N$. The cases $N=0$ and $N=1$ follow by direct
@@ -926,9 +928,9 @@ the remaining sites unchanged.
          =\tau_+^{2N}+\tau_-^{2N}.
         \notag
     \end{align}
-    Theorem~\ref{thm:cpsv_fibonacci_periodic_count_golden_ratio} proves the
-    final equality for transition counts. The identification of $a_N$ with the
-    periodic operator rank is not yet established. This is
+    Theorem~\ref{thm:cpsv_fibonacci_periodic_count_golden_ratio} gives the
+    final equality for transition counts. Thus the operator-rank formula reduces
+    to the identity $\operatorname{rank}\rho^{(N)}(A)=a_N$. This is
     \cite[Appendix~D, lines~2122--2125 and
     2157--2176]{Cirac2016MPDO_arXiv}.
 \end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -808,6 +808,27 @@ the remaining sites unchanged.
     % The equality with the periodic operator rank remains tracked by issue #5921.
 \end{definition}
 
+\begin{theorem}[Characteristic recurrence for periodic Fibonacci transition counts]
+    \label{thm:cpsv_fibonacci_periodic_count_recurrence}
+    \lean{MPSTensor.FibonacciBoundary.periodicTransitionCount_add_two_add}
+    \leanok
+    \uses{def:cpsv_fibonacci_periodic_count}
+    For every $N\in\N$,
+    \begin{align}
+        a_{N+2}+a_N&=3a_{N+1}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:cpsv_fibonacci_transition_matrix,
+      def:cpsv_fibonacci_periodic_count}
+    Expand $B^{N+2}=B^{N+1}B$ and $B^{N+1}=B^NB$. Substitution of
+    $B=\left(\begin{smallmatrix}1&1\\1&2\end{smallmatrix}\right)$ into the
+    diagonal sums gives $a_{N+2}+a_N=3a_{N+1}$.
+\end{proof}
+
 \begin{theorem}[First periodic Fibonacci transition counts]
     \label{thm:cpsv_fibonacci_periodic_count_values}
     \lean{MPSTensor.FibonacciBoundary.periodicTransitionCount_one,
@@ -823,6 +844,33 @@ the remaining sites unchanged.
     \uses{thm:cpsv_fibonacci_boundary_recurrence}
     Substitute $x^1=(1,1,1,2)$ into the recurrence once and close the two
     diagonal boundary labels.
+\end{proof}
+
+\begin{theorem}[Golden-ratio formula for periodic Fibonacci transition counts]
+    \label{thm:cpsv_fibonacci_periodic_count_golden_ratio}
+    \lean{MPSTensor.FibonacciBoundary.periodicTransitionCount_eq_goldenRatio}
+    \leanok
+    \uses{def:cpsv_fibonacci_periodic_count}
+    Set $\tau_+=(1+\sqrt5)/2$ and $\tau_-=(1-\sqrt5)/2$. For every
+    $N\in\N$,
+    \begin{align}
+        a_N&=\tau_+^{2N}+\tau_-^{2N}.
+        \notag
+    \end{align}
+    This is the transition-count formula in
+    \cite[Appendix~D, lines~2146--2176]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:cpsv_fibonacci_transition_matrix,
+      def:cpsv_fibonacci_periodic_count,
+      thm:cpsv_fibonacci_periodic_count_recurrence}
+    Use two-step induction on $N$. The cases $N=0$ and $N=1$ follow by direct
+    calculation. Since $\tau_\pm^2=\tau_\pm+1$, each sequence
+    $\tau_\pm^{2N}$ satisfies
+    $\tau_\pm^{2(N+2)}+\tau_\pm^{2N}=3\tau_\pm^{2(N+1)}$. The induction step
+    now follows from the same recurrence for $a_N$.
 \end{proof}
 
 \begin{theorem}[Periodic Fibonacci transition counts are not geometric]
@@ -867,17 +915,21 @@ the remaining sites unchanged.
     \notready
     \uses{def:cpsv_fibonacci_support_tensor,
       def:cpsv_fibonacci_periodic_count,
+      thm:cpsv_fibonacci_periodic_count_golden_ratio,
       thm:cpsv_fibonacci_open_boundary_rank_status,
       thm:to_mpo_diagonal_rank}
     Set $\tau_\pm=(1\pm\sqrt5)/2$, as in
-    \cite[Appendix~D, line~2125]{Cirac2016MPDO_arXiv}.  For every $N>0$,
+    \cite[Appendix~D, line~2125]{Cirac2016MPDO_arXiv}. For every $N>0$,
     \begin{align}
         \operatorname{rank}\rho^{(N)}(A)
-        &=x^N_{00}+x^N_{11}
+        &=a_N=x^N_{00}+x^N_{11}
          =\tau_+^{2N}+\tau_-^{2N}.
         \notag
     \end{align}
-    This is \cite[Appendix~D, lines~2122--2125 and
+    Theorem~\ref{thm:cpsv_fibonacci_periodic_count_golden_ratio} proves the
+    final equality for transition counts. The identification of $a_N$ with the
+    periodic operator rank is not yet established. This is
+    \cite[Appendix~D, lines~2122--2125 and
     2157--2176]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 


### PR DESCRIPTION
## Summary

- prove the characteristic recurrence
  \(a_{N+2}+a_N=3a_{N+1}\) for the Fibonacci transition count
- derive the exact CPSV16 Appendix D formula
  \(a_N=\tau_+^{2N}+\tau_-^{2N}\), using Mathlib's golden ratio and conjugate
- keep the theorem explicitly at the transition-count level, without claiming the still-missing MPO operator-rank identification
- synchronize Chapter 21 and retain `\notready` on the operator-rank theorem
- replace the broad MPDO recovery import with direct dependencies and clear the file lint

## Verification

- `lake build TNLean.MPS.MPDO.FibonacciBoundaryRank`
- full `lake build` (10059 jobs)
- Mathlib lint on `FibonacciBoundaryRank.lean`: all 14 linters pass
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --diff-base origin/main --changed-files TNLean/MPS/MPDO/FibonacciBoundaryRank.lean --warn-missing-blueprint`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- two `lualatex` passes from `blueprint/src` with `TEXINPUTS="../../tex/tenkz//:"`; zero undefined references
- `git diff --check`

Closes #6079.
Advances #5921.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation sync in a specialized MPS/MPDO file; no runtime, auth, or data-path changes. Residual risk is only mathematical scope (transition counts vs operator ranks), which the PR documents clearly.
> 
> **Overview**
> Formalizes the CPSV16 Appendix D **transition-count** slice: periodic Fibonacci counts \(a_N\) now satisfy the characteristic recurrence \(a_{N+2}+a_N=3a_{N+1}\) and the closed form \(a_N=\tau_+^{2N}+\tau_-^{2N}\) using Mathlib’s `Real.goldenRatio` / `goldenConj`.
> 
> **Lean (`FibonacciBoundaryRank.lean`):** adds `periodicTransitionCount_add_two_add` and `periodicTransitionCount_eq_goldenRatio` (two-step induction plus golden-ratio quartic identities). Scope comments and imports are tightened—`PureRecovery` is dropped in favor of `Defs` and golden-ratio imports; operator-rank identification remains explicitly **not** claimed.
> 
> **Blueprint (Chapter 21):** new `\leanok` theorems for the recurrence and golden-ratio formula; the still-`\notready` periodic operator-rank theorem now cites the transition-count golden-ratio result and states that full operator rank reduces to \(\operatorname{rank}\rho^{(N)}(A)=a_N\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2881afaaa9d62f1b0ea45f167cd2bc1239297a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->