### PR TITLE
cleanup(MPDO): deduplicate utility proofs and imports

### DIFF
--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -137,21 +137,9 @@ theorem map_cornerCompressionKraus_eq
     (K : Fin d → Mat) {Q : Mat} (hQ : IsOrthogonalProjection Q)
     {Z : Mat} (hZ : Q * Z * Q = Z) :
     map (cornerCompressionKraus K Q) Z = Q * map K Z * Q := by
-  have hQherm : Qᴴ = Q := hQ.1.eq
-  calc
-    map (cornerCompressionKraus K Q) Z
-        = ∑ i : Fin d, (Q * K i * Q) * Z * (Q * K i * Q)ᴴ := by
-          simp only [map, cornerCompressionKraus]
-    _ = ∑ i : Fin d, Q * (K i * (Q * Z * Q) * (K i)ᴴ) * Q := by
-          refine Finset.sum_congr rfl (fun i _ => ?_)
-          simp only [Matrix.conjTranspose_mul, hQherm]
-          simp [Matrix.mul_assoc]
-    _ = ∑ i : Fin d, Q * (K i * Z * (K i)ᴴ) * Q := by
-          refine Finset.sum_congr rfl (fun i _ => ?_)
-          rw [hZ]
-    _ = Q * (∑ i : Fin d, K i * Z * (K i)ᴴ) * Q := by
-          rw [Finset.mul_sum, Finset.sum_mul]
-    _ = Q * map K Z * Q := by rw [map_apply]
+  rw [map_compressed_eq_conj K (cornerCompressionKraus K Q) Q
+      (fun i => by simp only [cornerCompressionKraus, hQ.1.eq]) Z,
+    hQ.1.eq, hZ]
 
 end Hypotheses
 

--- a/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
@@ -71,43 +71,6 @@ private theorem densityBlockLinearMap_injective
   have hpartial := congrArg Matrix.partialTraceLeft hk
   simpa only [Matrix.partialTraceLeft_kronecker, hσtrace, one_smul] using hpartial
 
-private theorem unitaryReindexLinearEquiv_one
-    {n H : Type*} [Fintype n] [DecidableEq n]
-    [Fintype H] [DecidableEq H] (e : H ≃ n)
-    (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
-    Matrix.unitaryReindexLinearEquiv e U hU 1 = 1 := by
-  rw [Matrix.unitaryReindexLinearEquiv_apply]
-  rw [Matrix.mul_one, Matrix.mem_unitaryGroup_iff'.mp hU]
-  exact Matrix.reindexLinearEquiv_one ℂ ℂ e.symm
-
-private theorem unitaryReindexLinearEquiv_mul
-    {n H : Type*} [Fintype n] [DecidableEq n]
-    [Fintype H] [DecidableEq H] (e : H ≃ n)
-    (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
-    (A B : Matrix n n ℂ) :
-    Matrix.unitaryReindexLinearEquiv e U hU (A * B) =
-      Matrix.unitaryReindexLinearEquiv e U hU A *
-        Matrix.unitaryReindexLinearEquiv e U hU B := by
-  rw [Matrix.unitaryReindexLinearEquiv_apply,
-    Matrix.unitaryReindexLinearEquiv_apply,
-    Matrix.unitaryReindexLinearEquiv_apply]
-  have hUright : U * star U = 1 := Matrix.mem_unitaryGroup_iff.mp hU
-  have hconj : star U * (A * B) * U =
-      (star U * A * U) * (star U * B * U) := by
-    calc
-      star U * (A * B) * U = star U * A * (U * star U) * B * U := by
-        rw [hUright]
-        simp only [Matrix.mul_one, Matrix.mul_assoc]
-      _ = (star U * A * U) * (star U * B * U) := by
-        simp only [Matrix.mul_assoc]
-  calc
-    Matrix.reindex e.symm e.symm (star U * (A * B) * U) =
-        Matrix.reindex e.symm e.symm
-          ((star U * A * U) * (star U * B * U)) := congrArg _ hconj
-    _ = Matrix.reindex e.symm e.symm (star U * A * U) *
-        Matrix.reindex e.symm e.symm (star U * B * U) :=
-      (Matrix.reindexLinearEquiv_mul ℂ ℂ e.symm e.symm e.symm _ _).symm
-
 private theorem unitaryReindexLinearEquiv_list_prod
     {n H : Type*} [Fintype n] [DecidableEq n]
     [Fintype H] [DecidableEq H] (e : H ≃ n)
@@ -118,10 +81,10 @@ private theorem unitaryReindexLinearEquiv_list_prod
   induction A with
   | nil =>
       simpa only [List.prod_nil, List.map_nil] using
-        unitaryReindexLinearEquiv_one e U hU
+        Matrix.unitaryReindexLinearEquiv_one e U hU
   | cons A l ih =>
       rw [List.prod_cons, List.map_cons, List.prod_cons,
-        unitaryReindexLinearEquiv_mul, ih]
+        Matrix.unitaryReindexLinearEquiv_mul, ih]
 
 private theorem densityBlockLinearMap_list_prod
     {K L : ℕ} {m d : Fin K → ℕ}

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.BoundaryClosing
-import TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingAuxiliary
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.Nonvanishing


### PR DESCRIPTION
## What changed

- reuse the public matrix unitary-reindex identity and multiplication lemmas instead of two private duplicates;
- derive `Kraus.map_cornerCompressionKraus_eq` from the generic compressed-map conjugation theorem;
- remove the redundant direct `BoundaryClosingStripping` import from `UniqueGroundState`.

All public names and statements are unchanged. This does not change any CPSV16 predicate or source-facing theorem surface.

## Validation

- targeted build of the three changed modules and representative consumers: 9,012 jobs;
- generated import aggregators: 52 files covering 1,348 production modules, current;
- changed-file safety grep: no `sorry`, `axiom`, or `unsafe`;
- `git diff --check`;
- independent exact-head Lean review: approved.

Closes #6102
Advances #6096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactors and import cleanup in MPDO/channel modules; no changes to CPSV16 predicates or public theorem surfaces.
> 
> **Overview**
> This PR **deduplicates proof logic** without changing any public theorem names or statements.
> 
> In `CornerFixedPoints`, `map_cornerCompressionKraus_eq` is no longer proved by a long `calc` over Kraus sums; it is a short rewrite through the generic **`map_compressed_eq_conj`** lemma, with the corner Kraus family `Q Kᵢ Q` as the compressed family.
> 
> In `VerticalSectorDensityBlocks`, two **private** lemmas for unitary reindexing (`unitaryReindexLinearEquiv_one` and `unitaryReindexLinearEquiv_mul`) are removed; `unitaryReindexLinearEquiv_list_prod` now calls the shared **`Matrix.unitaryReindexLinearEquiv_one`** and **`Matrix.unitaryReindexLinearEquiv_mul`**.
> 
> `UniqueGroundState` drops a **redundant direct import** of `BoundaryClosingStripping` that was already available through the import graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01700715ecf763ab610f7ceb446f287c57833e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->