### PR TITLE
refactor(MPDO): extract physical closure API

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -191,6 +191,7 @@ import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.PhysicalAdjoint
 import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPDO.PhysicalClosure
 import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
 import TNLean.MPS.MPDO.PhysicalSectorActiveBond
 import TNLean.MPS.MPDO.PhysicalSectorActiveFactorSupport

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -4,10 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
+import TNLean.Channel.KrausCPTP
 import TNLean.MPS.Core.CyclicTrace
 import TNLean.MPS.Core.PhysicalReindexTransport
 import TNLean.MPS.MPDO.OperatorProduct
-import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.PhysicalClosure
 
 /-!
 # Physical blocking of MPO tensors

--- a/TNLean/MPS/MPDO/PhysicalClosure.lean
+++ b/TNLean/MPS/MPDO/PhysicalClosure.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinTupleEquiv
+import TNLean.MPS.MPDO.ZCL
+
+/-!
+# Physical closures of MPO tensors
+
+This file defines the length-$N$ physical operator obtained by contracting an
+arbitrary virtual operator into a chain of MPO tensors while leaving the
+physical legs open. It also provides the one-site, two-site, and three-site
+specializations used in arXiv:1606.00608.
+
+Physical closure is an algebraic construction. It does not assert literal
+idempotence of the physical-trace transfer, source zero correlation length
+(`MPOTensor.IsSourceZCL`), or doubled-index zero correlation length
+(`MPOTensor.IsZCL`).
+
+## Main definitions
+
+* `MPOTensor.physCloseN`: the length-$N$ physical closure.
+* `MPOTensor.physClose1`, `MPOTensor.physClose2`, `MPOTensor.physClose3`: the
+  one-site, two-site, and three-site specializations.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  lines 638--657 and Proposition C.7
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-! ### Physical operators of arbitrary length -/
+
+/-- The length-$N$ physical operator obtained by contracting an arbitrary
+virtual operator $X$ into a chain of $N$ copies of an MPO tensor while leaving
+the physical legs open:
+
+For configurations $\sigma$ and $\tau$, its coefficient is
+$\operatorname{tr}(M^{\sigma_0\tau_0}\cdots
+M^{\sigma_{N-1}\tau_{N-1}}X)$.
+
+The displayed order chooses the cut of the cyclic virtual contraction just
+before the first site, so that $X$ follows the last site. For $N=1,2$, this is
+the physical closure constructed in arXiv:1606.00608, lines 638--654 and used
+in Definition 4.1, line 657. When $M=\mathcal K$, the cases $N=2,3$ are the
+operators $\mathcal K_2(X)$ and $\mathcal K_3(X)$ in Proposition C.7,
+lines 1510--1516. -/
+noncomputable def physCloseN (M : MPOTensor d D) (N : ℕ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ where
+  toFun X := Matrix.of fun σ τ =>
+    Matrix.trace (evalWord M (List.ofFn σ) (List.ofFn τ) * X)
+  map_add' X Y := by
+    ext σ τ
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext σ τ
+    simp [Matrix.trace_smul]
+
+@[simp] lemma physCloseN_apply (M : MPOTensor d D) (N : ℕ)
+    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin N → Fin d) :
+    physCloseN M N X σ τ =
+      Matrix.trace (evalWord M (List.ofFn σ) (List.ofFn τ) * X) :=
+  rfl
+
+/-- Closing the virtual boundary by the identity matrix gives the periodic MPO
+operator.
+
+Source: arXiv:1606.00608, lines 638--654 and Definition 4.1. -/
+theorem physCloseN_identity_eq_mpo (M : MPOTensor d D) (N : ℕ) :
+    physCloseN M N (1 : Matrix (Fin D) (Fin D) ℂ) = mpo M N := by
+  ext σ τ
+  simp [mpoMatrixEntry]
+
+/-- The general length-three physical closure has the coefficient formula for
+$M_3(X)$. When $M=\mathcal K$, it is the operator $\mathcal K_3(X)$ in
+arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
+lemma physCloseN_three_apply (M : MPOTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin 3 → Fin d) :
+    physCloseN M 3 X σ τ =
+      Matrix.trace
+        (M (σ 0) (τ 0) * M (σ 1) (τ 1) * M (σ 2) (τ 2) * X) := by
+  simp [physCloseN, List.ofFn_succ, evalWord_cons, Matrix.mul_assoc]
+
+/-! ### The one-site physical operator -/
+
+/-- The **one-site physical operator** as a linear map in the virtual operator
+`X`: contract `X : D × D` into a single copy of the tensor with the physical legs
+open, giving `(physClose1 M X) i j = tr(M^{ij} X)` (figure MPDO_XM of
+arXiv:1606.00608). -/
+noncomputable def physClose1 (M : MPOTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ where
+  toFun X := Matrix.of fun i j => Matrix.trace (M i j * X)
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext i j
+    simp [Matrix.trace_smul]
+
+@[simp] lemma physClose1_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
+    (i j : Fin d) : physClose1 M X i j = Matrix.trace (M i j * X) := rfl
+
+/-- The trace of the one-site physical closure is the trace pairing with the
+physical-trace transfer.
+
+Source: arXiv:1606.00608, Definition 4.1, line 657, and lines 1333--1340. -/
+theorem trace_physClose1_eq (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (physClose1 M X) = Matrix.trace (physTraceTransfer M * X) := by
+  rw [physTraceTransfer, Finset.sum_mul, Matrix.trace_sum]
+  rfl
+
+/-- Under the canonical equivalence between one-site configurations and
+physical indices, the length-one closure is `physClose1`. This is the one-site
+operator in arXiv:1606.00608, Definition 4.1, line 657 and figure MPDO_XM. -/
+theorem physCloseN_one_eq_physClose1 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (Equiv.funUnique (Fin 1) (Fin d))
+        (Equiv.funUnique (Fin 1) (Fin d))).toLinearMap ∘ₗ physCloseN M 1 =
+      physClose1 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv]
+
+/-! ### The two-site physical operator -/
+
+/-- The **two-site physical operator** as a linear map in the virtual operator
+`X`: contract `X : D × D` into two copies of the tensor with all four physical
+legs open, giving `(physClose2 M X) (i₁,i₂) (j₁,j₂) = tr(M^{i₁j₁} M^{i₂j₂} X)`
+(figure MPDO_XMM of arXiv:1606.00608). -/
+noncomputable def physClose2 (M : MPOTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ where
+  toFun X := Matrix.of fun i j => Matrix.trace (M i.1 j.1 * M i.2 j.2 * X)
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext i j
+    simp [Matrix.trace_smul]
+
+@[simp] lemma physClose2_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
+    (i j : Fin d × Fin d) :
+    physClose2 M X i j = Matrix.trace (M i.1 j.1 * M i.2 j.2 * X) := rfl
+
+/-- The trace of the two-site physical closure is the trace pairing with the
+square of the physical-trace transfer.
+
+Source: arXiv:1606.00608, Definition 4.1, line 657, and lines 1333--1340. -/
+theorem trace_physClose2_eq (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (physClose2 M X) =
+      Matrix.trace (physTraceTransfer M * physTraceTransfer M * X) := by
+  change (∑ p : Fin d × Fin d, Matrix.trace (M p.1 p.1 * M p.2 p.2 * X)) = _
+  rw [Fintype.sum_prod_type]
+  simp only [physTraceTransfer, Finset.sum_mul, Matrix.mul_sum, Matrix.trace_sum]
+
+/-- Under the canonical equivalence between two-site configurations and pairs
+of physical indices, the length-two closure is `physClose2`. This is the
+two-site operator constructed in arXiv:1606.00608, lines 638--654 and used in
+Definition 4.1, line 657. When $M=\mathcal K$, it is $\mathcal K_2(X)$ in
+Proposition C.7, lines 1510--1516. -/
+theorem physCloseN_two_eq_physClose2 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+        (finTwoArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 2 =
+      physClose2 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv, finTwoArrowEquiv_symm_apply]
+
+/-! ### The three-site physical operator -/
+
+/-- The **three-site physical operator** as a linear map in the virtual operator
+$X$. Its physical indices are right-associated as
+$\operatorname{Fin}(d) \times (\operatorname{Fin}(d) \times \operatorname{Fin}(d))$,
+and its coefficients are
+\[
+  M_3(X)_{(i_0,(i_1,i_2)),(j_0,(j_1,j_2))}
+  = \operatorname{tr}(M^{i_0j_0}M^{i_1j_1}M^{i_2j_2}X).
+\]
+
+When $M=\mathcal K$, this is the operator $\mathcal K_3(X)$ of
+arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
+noncomputable def physClose3 (M : MPOTensor d D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin d × (Fin d × Fin d)) (Fin d × (Fin d × Fin d)) ℂ where
+  toFun X := Matrix.of fun i j =>
+    Matrix.trace (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2 j.2.2 * X)
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.mul_add, Matrix.trace_add]
+  map_smul' c X := by
+    ext i j
+    simp [Matrix.trace_smul]
+
+/-- Coefficient formula for the right-associated three-site physical closure.
+For $M=\mathcal K$, this is $\mathcal K_3(X)$ in arXiv:1606.00608,
+Proposition C.7, lines 1510--1516. -/
+@[simp] lemma physClose3_apply (M : MPOTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (i j : Fin d × (Fin d × Fin d)) :
+    physClose3 M X i j =
+      Matrix.trace (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2 j.2.2 * X) :=
+  rfl
+
+/-- Under the canonical right-associated identification of three-site
+configurations with triples of physical indices, the general length-three
+closure is `physClose3`. For $M=\mathcal K$, this identifies the two forms of
+$\mathcal K_3(X)$ in arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
+theorem physCloseN_three_eq_physClose3 (M : MPOTensor d D) :
+    (Matrix.reindexLinearEquiv ℂ ℂ (_root_.finThreeArrowEquiv (Fin d))
+        (_root_.finThreeArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 3 =
+      physClose3 M := by
+  ext X i j
+  simp [Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/PhysicalClosure.lean
+++ b/TNLean/MPS/MPDO/PhysicalClosure.lean
@@ -174,8 +174,7 @@ theorem physCloseN_two_eq_physClose2 (M : MPOTensor d D) :
 /-! ### The three-site physical operator -/
 
 /-- The **three-site physical operator** as a linear map in the virtual operator
-$X$. Its physical indices are right-associated as
-$\operatorname{Fin}(d) \times (\operatorname{Fin}(d) \times \operatorname{Fin}(d))$,
+$X$. Its physical indices are right-associated as `Fin d × (Fin d × Fin d)`,
 and its coefficients are
 \[
   M_3(X)_{(i_0,(i_1,i_2)),(j_0,(j_1,j_2))}

--- a/TNLean/MPS/MPDO/PhysicalSectorBlockedRFP.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBlockedRFP.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps
+import TNLean.MPS.MPDO.RFPViaTS
 
 /-!
 # Two-site blocked renormalization of the physical-sector tensor

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureThree.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureThree.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
-import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.PhysicalClosure
 
 /-!
 # Three-site closure in fixed physical sectors

--- a/TNLean/MPS/MPDO/PhysicalSectorClosureTwo.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorClosureTwo.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
-import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.PhysicalClosure
 
 /-!
 # Two-site closures in fixed physical sectors

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.VerticalProductFusionDecomposition
 import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.VerticalProductFusionDecomposition
 
 /-!
 # Positive vertical fusion from the renormalization fixed-point condition

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.VerticalProductFusionDecomposition
+import TNLean.MPS.MPDO.RFPViaTS
 
 /-!
 # Positive vertical fusion from the renormalization fixed-point condition

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.TracePairing
 import TNLean.Channel.KrausCPTP
+import TNLean.MPS.MPDO.PhysicalClosure
 import TNLean.MPS.MPDO.ZCL
 
 /-!
@@ -42,10 +42,6 @@ the predicate.
 
 * `IsKrausCPTP`: the rectangular Kraus-form predicate for trace-preserving
   completely positive maps used in Definition 4.1.
-* `MPOTensor.physCloseN`: the length-$N$ physical operator as a linear map in
-  the virtual operator $X$.
-* `MPOTensor.physClose1`, `MPOTensor.physClose2`, `MPOTensor.physClose3`: the
-  one-site, two-site, and three-site specializations.
 * `MPOTensor.IsRFPViaTS`: Definition 4.1, the tp-CP-map renormalization
   fixed point.
 * `MPOTensor.physTraceTransfer_sq_of_isRFPViaTS`: Definition 4.1 implies
@@ -64,186 +60,6 @@ open scoped Matrix BigOperators
 namespace MPOTensor
 
 variable {d D : ℕ}
-
-/-! ### Physical operators of arbitrary length -/
-
-/-- The length-$N$ physical operator obtained by contracting an arbitrary
-virtual operator $X$ into a chain of $N$ copies of an MPO tensor while leaving
-the physical legs open:
-
-For configurations $\sigma$ and $\tau$, its coefficient is
-$\operatorname{tr}(M^{\sigma_0\tau_0}\cdots
-M^{\sigma_{N-1}\tau_{N-1}}X)$.
-
-The displayed order chooses the cut of the cyclic virtual contraction just
-before the first site, so that $X$ follows the last site. For $N=1,2$, this is
-the physical closure constructed in arXiv:1606.00608, lines 638--654 and used
-in Definition 4.1, line 657. When $M=\mathcal K$, the cases $N=2,3$ are the
-operators $\mathcal K_2(X)$ and $\mathcal K_3(X)$ in Proposition C.7,
-lines 1510--1516. -/
-noncomputable def physCloseN (M : MPOTensor d D) (N : ℕ) :
-    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
-      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ where
-  toFun X := Matrix.of fun σ τ =>
-    Matrix.trace (evalWord M (List.ofFn σ) (List.ofFn τ) * X)
-  map_add' X Y := by
-    ext σ τ
-    simp [Matrix.mul_add, Matrix.trace_add]
-  map_smul' c X := by
-    ext σ τ
-    simp [Matrix.trace_smul]
-
-@[simp] lemma physCloseN_apply (M : MPOTensor d D) (N : ℕ)
-    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin N → Fin d) :
-    physCloseN M N X σ τ =
-      Matrix.trace (evalWord M (List.ofFn σ) (List.ofFn τ) * X) :=
-  rfl
-
-/-- Closing the virtual boundary by the identity matrix gives the periodic MPO
-operator.
-
-Source: arXiv:1606.00608, lines 638--654 and Definition 4.1. -/
-theorem physCloseN_identity_eq_mpo (M : MPOTensor d D) (N : ℕ) :
-    physCloseN M N (1 : Matrix (Fin D) (Fin D) ℂ) = mpo M N := by
-  ext σ τ
-  simp [mpoMatrixEntry]
-
-/-- The general length-three physical closure has the coefficient formula for
-$M_3(X)$. When $M=\mathcal K$, it is the operator $\mathcal K_3(X)$ in
-arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
-lemma physCloseN_three_apply (M : MPOTensor d D)
-    (X : Matrix (Fin D) (Fin D) ℂ) (σ τ : Fin 3 → Fin d) :
-    physCloseN M 3 X σ τ =
-      Matrix.trace
-        (M (σ 0) (τ 0) * M (σ 1) (τ 1) * M (σ 2) (τ 2) * X) := by
-  simp [physCloseN, List.ofFn_succ, evalWord_cons, Matrix.mul_assoc]
-
-/-! ### The one-site physical operator -/
-
-/-- The **one-site physical operator** as a linear map in the virtual operator
-`X`: contract `X : D × D` into a single copy of the tensor with the physical legs
-open, giving `(physClose1 M X) i j = tr(M^{ij} X)` (figure MPDO_XM of
-arXiv:1606.00608). -/
-noncomputable def physClose1 (M : MPOTensor d D) :
-    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ where
-  toFun X := Matrix.of fun i j => Matrix.trace (M i j * X)
-  map_add' X Y := by
-    ext i j
-    simp [Matrix.mul_add, Matrix.trace_add]
-  map_smul' c X := by
-    ext i j
-    simp [Matrix.trace_smul]
-
-@[simp] lemma physClose1_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
-    (i j : Fin d) : physClose1 M X i j = Matrix.trace (M i j * X) := rfl
-
-/-- The trace of the one-site physical closure is the trace pairing with the
-physical-trace transfer.
-
-Source: arXiv:1606.00608, Definition 4.1, line 657, and lines 1333--1340. -/
-theorem trace_physClose1_eq (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
-    Matrix.trace (physClose1 M X) = Matrix.trace (physTraceTransfer M * X) := by
-  rw [physTraceTransfer, Finset.sum_mul, Matrix.trace_sum]
-  rfl
-
-/-- Under the canonical equivalence between one-site configurations and
-physical indices, the length-one closure is `physClose1`. This is the one-site
-operator in arXiv:1606.00608, Definition 4.1, line 657 and figure MPDO_XM. -/
-theorem physCloseN_one_eq_physClose1 (M : MPOTensor d D) :
-    (Matrix.reindexLinearEquiv ℂ ℂ (Equiv.funUnique (Fin 1) (Fin d))
-        (Equiv.funUnique (Fin 1) (Fin d))).toLinearMap ∘ₗ physCloseN M 1 =
-      physClose1 M := by
-  ext X i j
-  simp [Matrix.coe_reindexLinearEquiv]
-
-/-! ### The two-site physical operator -/
-
-/-- The **two-site physical operator** as a linear map in the virtual operator
-`X`: contract `X : D × D` into two copies of the tensor with all four physical
-legs open, giving `(physClose2 M X) (i₁,i₂) (j₁,j₂) = tr(M^{i₁j₁} M^{i₂j₂} X)`
-(figure MPDO_XMM of arXiv:1606.00608). -/
-noncomputable def physClose2 (M : MPOTensor d D) :
-    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ where
-  toFun X := Matrix.of fun i j => Matrix.trace (M i.1 j.1 * M i.2 j.2 * X)
-  map_add' X Y := by
-    ext i j
-    simp [Matrix.mul_add, Matrix.trace_add]
-  map_smul' c X := by
-    ext i j
-    simp [Matrix.trace_smul]
-
-@[simp] lemma physClose2_apply (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
-    (i j : Fin d × Fin d) :
-    physClose2 M X i j = Matrix.trace (M i.1 j.1 * M i.2 j.2 * X) := rfl
-
-/-- The trace of the two-site physical closure is the trace pairing with the
-square of the physical-trace transfer.
-
-Source: arXiv:1606.00608, Definition 4.1, line 657, and lines 1333--1340. -/
-theorem trace_physClose2_eq (M : MPOTensor d D) (X : Matrix (Fin D) (Fin D) ℂ) :
-    Matrix.trace (physClose2 M X) =
-      Matrix.trace (physTraceTransfer M * physTraceTransfer M * X) := by
-  change (∑ p : Fin d × Fin d, Matrix.trace (M p.1 p.1 * M p.2 p.2 * X)) = _
-  rw [Fintype.sum_prod_type]
-  simp only [physTraceTransfer, Finset.sum_mul, Matrix.mul_sum, Matrix.trace_sum]
-
-/-- Under the canonical equivalence between two-site configurations and pairs
-of physical indices, the length-two closure is `physClose2`. This is the
-two-site operator constructed in arXiv:1606.00608, lines 638--654 and used in
-Definition 4.1, line 657. When $M=\mathcal K$, it is $\mathcal K_2(X)$ in
-Proposition C.7, lines 1510--1516. -/
-theorem physCloseN_two_eq_physClose2 (M : MPOTensor d D) :
-    (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
-        (finTwoArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 2 =
-      physClose2 M := by
-  ext X i j
-  simp [Matrix.coe_reindexLinearEquiv, finTwoArrowEquiv_symm_apply]
-
-/-! ### The three-site physical operator -/
-
-/-- The **three-site physical operator** as a linear map in the virtual operator
-$X$. Its physical indices are right-associated as
-$\operatorname{Fin}(d) \times (\operatorname{Fin}(d) \times \operatorname{Fin}(d))$,
-and its coefficients are
-\[
-  M_3(X)_{(i_0,(i_1,i_2)),(j_0,(j_1,j_2))}
-  = \operatorname{tr}(M^{i_0j_0}M^{i_1j_1}M^{i_2j_2}X).
-\]
-
-When $M=\mathcal K$, this is the operator $\mathcal K_3(X)$ of
-arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
-noncomputable def physClose3 (M : MPOTensor d D) :
-    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
-      Matrix (Fin d × (Fin d × Fin d)) (Fin d × (Fin d × Fin d)) ℂ where
-  toFun X := Matrix.of fun i j =>
-    Matrix.trace (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2 j.2.2 * X)
-  map_add' X Y := by
-    ext i j
-    simp [Matrix.mul_add, Matrix.trace_add]
-  map_smul' c X := by
-    ext i j
-    simp [Matrix.trace_smul]
-
-/-- Coefficient formula for the right-associated three-site physical closure.
-For $M=\mathcal K$, this is $\mathcal K_3(X)$ in arXiv:1606.00608,
-Proposition C.7, lines 1510--1516. -/
-@[simp] lemma physClose3_apply (M : MPOTensor d D)
-    (X : Matrix (Fin D) (Fin D) ℂ)
-    (i j : Fin d × (Fin d × Fin d)) :
-    physClose3 M X i j =
-      Matrix.trace (M i.1 j.1 * M i.2.1 j.2.1 * M i.2.2 j.2.2 * X) :=
-  rfl
-
-/-- Under the canonical right-associated identification of three-site
-configurations with triples of physical indices, the general length-three
-closure is `physClose3`. For $M=\mathcal K$, this identifies the two forms of
-$\mathcal K_3(X)$ in arXiv:1606.00608, Proposition C.7, lines 1510--1516. -/
-theorem physCloseN_three_eq_physClose3 (M : MPOTensor d D) :
-    (Matrix.reindexLinearEquiv ℂ ℂ (_root_.finThreeArrowEquiv (Fin d))
-        (_root_.finThreeArrowEquiv (Fin d))).toLinearMap ∘ₗ physCloseN M 3 =
-      physClose3 M := by
-  ext X i j
-  simp [Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]
 
 /-! ### MPDO renormalization fixed point (Definition 4.1) -/
 

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.TracePairing
 import TNLean.Channel.KrausCPTP
 import TNLean.MPS.MPDO.PhysicalClosure

--- a/TNLean/MPS/MPDO/StrongRFP.lean
+++ b/TNLean/MPS/MPDO/StrongRFP.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.PhysicalClosure
 
 /-!
 # The unnormalized structural Strong-RFP relation

--- a/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
+++ b/TNLean/MPS/MPDO/VerticalBoundaryContraction.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.PhysicalClosure
 import TNLean.MPS.MPDO.VerticalCF
 
 /-!


### PR DESCRIPTION
## What changed

- move the generic physical closure maps and their one-, two-, and three-site formulas into `MPDO/PhysicalClosure.lean`;
- keep `IsRFPViaTS` and its physical-trace consequences in `RFPViaTS.lean`;
- retarget closure-only consumers to the narrow module and make genuine RFP dependencies explicit;
- regenerate the MPDO import aggregator.

All moved declarations are byte-identical. Their names, statements, proofs, attributes, and Blueprint tags are unchanged. Physical closure remains distinct from literal physical-trace idempotence, `IsSourceZCL`, and doubled-transfer `IsZCL`.

## Validation

- changed handwritten modules: 3,368 jobs;
- downstream RFP consumers: 9,174 jobs;
- MPDO aggregator: 9,472 jobs;
- generated imports: 52 files covering 1,349 modules, current;
- Blueprint sync/checkdecls: 7,231/7,231;
- integrity grep and `git diff --check`;
- independent exact-tree review: approved;
- three development commits squashed to one atomic commit with a byte-identical final tree.

Closes #6098
Advances #6096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical module split and import rewiring with no changes to theorem statements or proofs; behavior of the formalized API is unchanged.
> 
> **Overview**
> **Extracts** the MPO physical closure API (`physCloseN`, `physClose1`–`3`, trace/reindex lemmas) from `RFPViaTS.lean` into a new **`PhysicalClosure.lean`** module. Declarations are moved **byte-identically**; `RFPViaTS.lean` now imports that module and keeps only **`IsRFPViaTS`** and its physical-trace consequences.
> 
> **Import graph** is retargeted so closure-only files (`PhysicalBlocking`, sector closure two/three, `StrongRFP`, `VerticalBoundaryContraction`) depend on **`PhysicalClosure`** instead of pulling in the full RFP stack; **`PhysicalSectorBlockedRFP`** and **`RFPPositiveFusionDecomposition`** add explicit **`RFPViaTS`** imports where the RFP predicate is actually needed. The **`MPDO`** import aggregator registers **`PhysicalClosure`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e634b4185b80eefb9afe037f1722cac50eba0dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->