### PR TITLE
refactor(ParentHamiltonian): share boundary assembly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,4 +310,5 @@ follow-up, not against the temporary `sorry` count.
 | Name | Kind | Use when | Defined in |
 |---|---|---|---|
 | `exists_blockDiagonal_boundary_chainGroundSpace_of_global_cut_of_openBoundary` | helper theorem | Closing block-diagonal boundaries from an open-boundary representation and a simultaneous span across the complementary global cut | `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalBoundaryClosing.lean` |
+| `BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace` | helper theorem | Assembling membership in the sum of open-boundary block spaces into one weighted block-diagonal boundary matrix | `TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean` |
 | `Kraus.map_compressed_fixedPoint` | helper theorem | Preserving a supported fixed point under finite-Kraus compression along an isometry | `TNLean/Channel/KrausCornerCompression.lean` |

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -325,28 +325,11 @@ theorem
         ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
       ∀ j : Fin r,
         groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ groundSpace (A j) N := by
-  classical
-  obtain ⟨φ, hφ, hψφ, _huniq⟩ :=
-    exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+  have hOpen : ψ ∈ ⨆ j : Fin r, groundSpace (A j) N :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
-  have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) N).range := by
-    intro j
-    simpa [groundSpace] using hφ j
-  choose Y hY using hφRange
-  let X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
-    fun j => ((μ j) ^ N)⁻¹ • Y j
-  refine ⟨X, ?_, ?_⟩
-  · rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
-    calc
-      ψ = ∑ j : Fin r, φ j := hψφ
-      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
-            refine Finset.sum_congr rfl ?_
-            intro j _
-            have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
-            simp [X, hY j, hpow]
-  · intro j
-    have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
-    simpa [X, hY j, hpow] using hφ j
+  exact BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace
+    μ A hμ hOpen
 
 /-- In the PGVWC07 source range, a block-diagonal periodic vector has
 block-diagonal open-boundary matrices.
@@ -387,35 +370,11 @@ theorem
         ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
       ∀ j : Fin r,
         groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ groundSpace (A j) N := by
-  classical
-  have hLe :
-      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
-        ⨆ j : Fin r, groundSpace (A j) N :=
+  have hOpen : ψ ∈ ⨆ j : Fin r, groundSpace (A j) N :=
     chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07
-      μ A hr hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
-  obtain ⟨φ, hφ, hφsum⟩ :=
-    (Submodule.mem_iSup_iff_exists_finsupp
-      (fun j : Fin r => groundSpace (A j) N) ψ).mp (hLe hψ)
-  have hψφ : ψ = ∑ j : Fin r, φ j := by
-    simpa [Finsupp.sum_fintype] using hφsum.symm
-  have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) N).range := by
-    intro j
-    simpa [groundSpace] using hφ j
-  choose Y hY using hφRange
-  let X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
-    fun j => ((μ j) ^ N)⁻¹ • Y j
-  refine ⟨X, ?_, ?_⟩
-  · rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
-    calc
-      ψ = ∑ j : Fin r, φ j := hψφ
-      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
-            refine Finset.sum_congr rfl ?_
-            intro j _
-            have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
-            simp [X, hY j, hpow]
-  · intro j
-    have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
-    simpa [X, hY j, hpow] using hφ j
+      μ A hr hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
+  exact BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace
+    μ A hμ hOpen
 
 /-- For normalized BNT blocks, the block-diagonal periodic chain space satisfies
 two inclusions.

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalSourceNormalization.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalSourceNormalization.lean
@@ -185,28 +185,11 @@ theorem
         ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
       ∀ j : Fin r,
         groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ groundSpace (A j) N := by
-  classical
-  obtain ⟨φ, hφ, hψφ, _huniq⟩ :=
-    exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1_pgvwc07_of_dualFixedPoint
+  have hOpen : ψ ∈ ⨆ j : Fin r, groundSpace (A j) N :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1_pgvwc07_of_dualFixedPoint
       μ A hr hμ hIrr hBlocks Λ hΛ hDualFixed hBlk hL₀ hUnital
         hN hL hLN hRange hψ
-  have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) N).range := by
-    intro j
-    simpa [groundSpace] using hφ j
-  choose Y hY using hφRange
-  let X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
-    fun j => ((μ j) ^ N)⁻¹ • Y j
-  refine ⟨X, ?_, ?_⟩
-  · rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
-    calc
-      ψ = ∑ j : Fin r, φ j := hψφ
-      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
-            refine Finset.sum_congr rfl ?_
-            intro j _
-            have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
-            simp [X, hY j, hpow]
-  · intro j
-    have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
-    simpa [X, hY j, hpow] using hφ j
+  exact BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace
+    μ A hμ hOpen
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -117,6 +117,45 @@ theorem groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal
   ext a b
   simp [diagonalBlock, sigmaDiagonalBlock]
 
+/-- A vector in the sum of the open-boundary block spaces has one
+block-diagonal boundary matrix for the weighted direct-sum tensor. The
+component represented by each diagonal block remains in its corresponding
+open-boundary space. -/
+theorem exists_blockDiagonal_boundary_of_mem_iSup_groundSpace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0) {L : ℕ} {ψ : NSiteSpace d L}
+    (hψ : ψ ∈ ⨆ j : Fin r, groundSpace (A j) L) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) L
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) L ((μ j) ^ L • X j) ∈ groundSpace (A j) L := by
+  classical
+  obtain ⟨φ, hφ, hφsum⟩ :=
+    (Submodule.mem_iSup_iff_exists_finsupp
+      (fun j : Fin r => groundSpace (A j) L) ψ).mp hψ
+  have hψφ : ψ = ∑ j : Fin r, φ j := by
+    simpa [Finsupp.sum_fintype] using hφsum.symm
+  have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) L).range := by
+    intro j
+    simpa [groundSpace] using hφ j
+  choose Y hY using hφRange
+  let X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j => ((μ j) ^ L)⁻¹ • Y j
+  refine ⟨X, ?_, ?_⟩
+  · rw [groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+    calc
+      ψ = ∑ j : Fin r, φ j := hψφ
+      _ = ∑ j : Fin r, groundSpaceMap (A j) L ((μ j) ^ L • X j) := by
+        refine Finset.sum_congr rfl ?_
+        intro j _
+        have hpow : (μ j) ^ L ≠ 0 := pow_ne_zero L (hμ j)
+        simp [X, hY j, hpow]
+  · intro j
+    have hpow : (μ j) ^ L ≠ 0 := pow_ne_zero L (hμ j)
+    simpa [X, hY j, hpow] using hφ j
+
 end BlockSumGroundSpace
 
 open BlockSumGroundSpace

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -235,30 +235,13 @@ theorem exists_blockDiagonal_boundary_of_chainGroundSpace_of_wordTupleSpanTop_on
       ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
         ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
           (Matrix.blockDiagonal' X)) := by
-  classical
   have hOpen : ψ ∈ ⨆ j : Fin r, groundSpace (A j) N :=
     chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_wordTupleSpanTop_one
       μ A hμ hOne hN hψ
-  obtain ⟨φ, hφ, hφsum⟩ :=
-    (Submodule.mem_iSup_iff_exists_finsupp
-      (fun j : Fin r ↦ groundSpace (A j) N) ψ).mp hOpen
-  have hψφ : ψ = ∑ j : Fin r, φ j := by
-    simpa [Finsupp.sum_fintype] using hφsum.symm
-  have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) N).range := by
-    intro j
-    simpa [groundSpace] using hφ j
-  choose Y hY using hφRange
-  let X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
-    fun j ↦ ((μ j) ^ N)⁻¹ • Y j
-  refine ⟨X, ?_⟩
-  rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
-  calc
-    ψ = ∑ j : Fin r, φ j := hψφ
-    _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
-      apply Finset.sum_congr rfl
-      intro j _
-      have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
-      simp [X, hY j, hpow]
+  obtain ⟨X, hX, _⟩ :=
+    BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace
+      μ A hμ hOpen
+  exact ⟨X, hX⟩
 
 /-- A global one-site change of cut closes the block-diagonal boundary
 matrices of a nearest-neighbor chain vector. This is the boundary-closing step

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -113,6 +113,51 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     giving the displayed sum.
 \end{proof}
 
+\begin{lemma}[Boundary matrices for a sum of open-boundary block spaces]
+    \label{lem:block_diagonal_boundary_of_open_boundary_sum}
+    \lean{MPSTensor.BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace}
+    \leanok
+    \uses{def:ground_space_parent, lem:block_diagonal_boundary_condition_sum}
+    Let $B=\bigoplus_{j=1}^g\mu_jA_j$, where $\mu_j\ne0$ for every $j$.
+    For every length $L$ and every
+    $\psi\in\bigvee_{j=1}^gG_L(A_j)$, there are boundary matrices $X_j$ such
+    that
+    \begin{align}
+        \psi
+        &=\Gamma_L^B\!\left(\bigoplus_{j=1}^gX_j\right).
+        \notag
+    \end{align}
+    For every $j$, one also has
+    $\Gamma_L^{A_j}(\mu_j^LX_j)\in G_L(A_j)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:ground_space_parent, lem:block_diagonal_boundary_condition_sum}
+    Choose $\phi_j\in G_L(A_j)$ such that
+    \begin{align}
+        \psi
+        &=\sum_{j=1}^g\phi_j.
+        \notag
+    \end{align}
+    Choose $Y_j$ with $\phi_j=\Gamma_L^{A_j}(Y_j)$, and set
+    $X_j=\mu_j^{-L}Y_j$. Since
+    $\mu_j\ne0$, one has, for every $j$,
+    \begin{align}
+        \Gamma_L^{A_j}(\mu_j^LX_j)
+        &=\phi_j.
+        \notag
+    \end{align}
+    Lemma~\ref{lem:block_diagonal_boundary_condition_sum} now gives
+    \begin{align}
+        \Gamma_L^B\!\left(\bigoplus_{j=1}^gX_j\right)
+        &=\sum_{j=1}^g\Gamma_L^{A_j}(\mu_j^LX_j)
+         =\sum_{j=1}^g\phi_j
+         =\psi.
+        \notag
+    \end{align}
+\end{proof}
+
 \begin{lemma}[One block lies in the local parent space of the direct-sum tensor]
     \label{lem:local_ground_space_block_le_assembled}
     \lean{MPSTensor.groundSpace_block_le_toTensorFromBlocks}
@@ -296,7 +341,8 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     \label{lem:bnt_block_diagonal_open_boundary_matrices}
     \lean{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
     \leanok
-    \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}
+    \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
+        lem:block_diagonal_boundary_of_open_boundary_sum}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum},
     every vector
@@ -316,22 +362,20 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
 \begin{proof}
     \leanok
     \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
+        lem:block_diagonal_boundary_of_open_boundary_sum,
         lem:block_diagonal_boundary_condition_sum}
-    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum} gives
-    \[
-        \psi\in\bigvee_{j=1}^gG_N(A_j).
-    \]
-    The block-diagonal boundary construction decomposes this membership as
-    $\psi=\sum_{j=1}^g\phi_j$ with $\phi_j\in G_N(A_j)$.
-    Choose $Y_j$ with $\phi_j=\Gamma_N^{A_j}(Y_j)$, and set
-    $X_j=\mu_j^{-N}Y_j$. Since $\mu_j\ne0$,
-    $\Gamma_N^{A_j}(\mu_j^NX_j)=\phi_j$. The block-diagonal boundary formula
-    then gives
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}
+    places $\psi$ in $\bigvee_{j=1}^gG_N(A_j)$. Applying
+    Lemma~\ref{lem:block_diagonal_boundary_of_open_boundary_sum} gives
+    boundary matrices $X_j$ for which, for every $j$,
+    $\Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j)$, and
     \begin{align}
-        \Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right)
-        &=\sum_{j=1}^g\Gamma_N^{A_j}(\mu_j^NX_j) =\psi.
+        \psi
+        &=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right).
         \notag
     \end{align}
+    The equality is the block-diagonal identity of
+    Lemma~\ref{lem:block_diagonal_boundary_condition_sum}.
 \end{proof}
 
 \begin{lemma}[Block-diagonal boundary conditions at the source length]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -315,15 +315,14 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
 
 \begin{proof}
     \leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_decomposition,
+    \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
         lem:block_diagonal_boundary_condition_sum}
-    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_decomposition} gives
-    \begin{align}
-        \psi&=\sum_{j=1}^g\phi_j,
-        \notag\\
-        \phi_j&\in G_N(A_j).
-        \notag
-    \end{align}
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum} gives
+    \[
+        \psi\in\bigvee_{j=1}^gG_N(A_j).
+    \]
+    The block-diagonal boundary construction decomposes this membership as
+    $\psi=\sum_{j=1}^g\phi_j$ with $\phi_j\in G_N(A_j)$.
     Choose $Y_j$ with $\phi_j=\Gamma_N^{A_j}(Y_j)$, and set
     $X_j=\mu_j^{-N}Y_j$. Since $\mu_j\ne0$,
     $\Gamma_N^{A_j}(\mu_j^NX_j)=\phi_j$. The block-diagonal boundary formula

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -362,8 +362,7 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
 \begin{proof}
     \leanok
     \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
-        lem:block_diagonal_boundary_of_open_boundary_sum,
-        lem:block_diagonal_boundary_condition_sum}
+        lem:block_diagonal_boundary_of_open_boundary_sum}
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}
     places $\psi$ in $\bigvee_{j=1}^gG_N(A_j)$. Applying
     Lemma~\ref{lem:block_diagonal_boundary_of_open_boundary_sum} gives
@@ -374,8 +373,6 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
         &=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right).
         \notag
     \end{align}
-    The equality is the block-diagonal identity of
-    Lemma~\ref{lem:block_diagonal_boundary_condition_sum}.
 \end{proof}
 
 \begin{lemma}[Block-diagonal boundary conditions at the source length]
@@ -422,8 +419,7 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     \leanok
     \uses{thm:pgvwc_direct_sum_intersection_source_length,
         thm:pgvwc_block_space_independence_source_length,
-        lem:block_diagonal_periodic_constraints_propagated_sum,
-        lem:block_diagonal_boundary_condition_sum}
+        lem:block_diagonal_boundary_of_open_boundary_sum}
     Put $S_M=\sum_jG_M(A_j)$. For every $M$ with $L\le M<N$,
     Theorem~\ref{thm:pgvwc_direct_sum_intersection_source_length} gives
     \begin{align}
@@ -441,11 +437,14 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     \end{align}
     Since $N\ge L\ge3(g-1)(L_0+1)+1$,
     Theorem~\ref{thm:pgvwc_block_space_independence_source_length} shows that
-    the spaces
-    $G_N(A_j)$ form an internal sum.
-    Decompose the vector into its block components, choose one boundary matrix
-    for each component, and absorb the nonzero factor $\mu_j^N$ into that
-    matrix.
+    the spaces $G_N(A_j)$ form an internal sum. Lemma~\ref{lem:block_diagonal_boundary_of_open_boundary_sum}
+    then supplies matrices $X_j$ such that
+    $\Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j)$ for every $j$ and
+    \begin{align}
+        \psi
+        &=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
+        \notag
+    \end{align}
 \end{proof}
 
 The lemma gives $\Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j)$. This is not enough for

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -403,6 +403,18 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Block-diagonal boundary assembly
+- **Pattern:** decompose membership in a finite supremum of open-boundary block spaces into
+  finitely supported components, choose one boundary matrix per component, rescale by the
+  inverse block weight, and reconstruct one block-diagonal boundary matrix.
+- **Reuse:** `BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace` in
+  `TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean` performs the construction without
+  any BNT, dual-fixed-point, or simultaneous-word-span hypotheses.
+- **Result:** four public wrappers in `BNTBlockDiagonalChain.lean`,
+  `BNTBlockDiagonalSourceNormalization.lean`, and `RFP/NNCPHMultiSector.lean` retain their
+  statements and specialized interfaces while delegating the shared construction to the
+  neutral theorem. The Lean source loses 36 lines net.
+
 ### Matched BNT coefficient comparison with an eventual scalar
 - **Pattern:** expand both sector decompositions in MPV state space, substitute a full matched
   `Q`-basis into the full `P`-basis, reindex along the basis equivalence, and compare exact


### PR DESCRIPTION
## What changed

- add a predicate-neutral theorem assembling membership in a finite supremum of block ground spaces into one weighted block-diagonal boundary matrix;
- route four PGVWC07, dual-fixed-point, and RFP wrappers through that theorem while preserving their distinct public interfaces;
- record the promoted proof pattern;
- synchronize the affected Chapter 13 proof dependency and narrative with the refactored Lean proof.

All existing public theorem names, statements, hypotheses, and Blueprint metadata are preserved. Lean source decreases by 36 lines.

## Validation

- exact-rebase targeted build of all changed Lean modules: 8,984 jobs;
- Blueprint sync/checkdecls: 7,231/7,231;
- two LuaLaTeX passes: zero undefined cross-references;
- changed-file integrity grep and `git diff --check`;
- pre/post-rebase patch ID identical;
- independent exact-head Lean and Blueprint review: approved after one dependency fix.

Closes #6097
Advances #6096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor with preserved public theorem names and statements; no change to auth, data, or proof semantics beyond deduplication.
> 
> **Overview**
> Introduces **`BlockSumGroundSpace.exists_blockDiagonal_boundary_of_mem_iSup_groundSpace`**, which builds one block-diagonal boundary matrix from membership in the supremum of open-boundary block ground spaces (decompose via finitely supported components, pick per-block boundary matrices, rescale by inverse block weights, reconstruct with the block-diagonal sum identity).
> 
> **Four specialized existence theorems** in `BNTBlockDiagonalChain`, `BNTBlockDiagonalSourceNormalization`, and `RFP/NNCPHMultiSector` keep their original statements and hypotheses; they now only establish the relevant `⨆` inclusion and delegate to the shared theorem instead of duplicating the construction.
> 
> Blueprint Chapter 13 adds **Lemma `block_diagonal_boundary_of_open_boundary_sum`** linked to the new Lean theorem and rewires two periodic-boundary lemmas to cite it instead of inline proof steps. `CLAUDE.md` and `docs/tactic_patterns.md` document the promoted pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4406e08e740501c8b3816029709eb59252c5446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->