### PR TITLE
Blueprint: expose grouped Gram construction kernels

### DIFF
--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -285,7 +285,8 @@ single family.
     (\ref{eq:cpsv_active_refinement_regroup}); substitution into
     (\ref{eq:cpsv_active_refinement_original}) gives
     (\ref{eq:cpsv_active_refinement_reconstruction}) with the original
-    coisometry $U$. In the notation used in Proposition~4.13, these identities
+    coisometry $U$. In the notation of
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, these identities
     are
     \begin{align}
         \bigoplus_{k=1}^{r}\mu_kA_k^i

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -285,7 +285,19 @@ single family.
     (\ref{eq:cpsv_active_refinement_regroup}); substitution into
     (\ref{eq:cpsv_active_refinement_original}) gives
     (\ref{eq:cpsv_active_refinement_reconstruction}) with the original
-    coisometry $U$.
+    coisometry $U$. In the notation used in Proposition~4.13, these identities
+    are
+    \begin{align}
+        \bigoplus_{k=1}^{r}\mu_kA_k^i
+        &=GT_{\mathrm{grp}}^iG^{-1},
+        \label{eq:cpsv_prop_4_13_active_bnt}\\
+        A^i
+        &=U^\dagger GT_{\mathrm{grp}}^iG^{-1}U,
+        \label{eq:cpsv_prop_4_13_active_reconstruction}\\
+        UU^\dagger
+        &=\Id.
+        \label{eq:cpsv_prop_4_13_original_coisometry}
+    \end{align}
 \end{proof}
 
 % Source anchors: CPSV16 lines 265--301, 317--345, and Appendix C.3,

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -308,8 +308,8 @@
         thm:mpdo_sector_trace_identity,
         thm:mpdo_sector_compression_trace_pos}
     Let $M$ generate an MPDO, let $Q$ and $P$ be sector projectors for the
-    weights $\mu_{\alpha,1}$ and $\mu_{\alpha,k}$ and a common matrix
-    $E_\alpha$, and suppose $\mu_{\alpha,1}>0$. If the compression of
+    weights $\mu_{\alpha,0}$ and $\mu_{\alpha,k}$ and a common matrix
+    $E_\alpha$, and suppose $\mu_{\alpha,0}>0$. If the compression of
     $H^{(N+1)}$ by $P$ at the first site is nonzero, then
     \begin{align}
         \mu_{\alpha,k}\,d_\alpha^{(N+1)}&>0,
@@ -322,7 +322,7 @@
     Granted such sector projectors, this yields the conclusion of the trace
     argument in the proof of
     \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}: since w.l.o.g.\
-    $\mu_{\alpha,1}>0$, the positive trace forces $d_\alpha>0$ and hence
+    $\mu_{\alpha,0}>0$, the positive trace forces $d_\alpha>0$ and hence
     $\mu_{\alpha,k}>0$.
 \end{theorem}
 
@@ -334,10 +334,10 @@
     Theorem~\ref{thm:mpdo_sector_trace_identity} identifies with
     $\mu_{\alpha,k}d_\alpha^{(N+1)}$. In particular
     $d_\alpha^{(N+1)}\ne 0$, so the trace of the compression by the sector
-    projector of $(\alpha,1)$ at the same length equals
-    $\mu_{\alpha,1}d_\alpha^{(N+1)}\ne 0$; that compression is therefore
+    projector of $(\alpha,0)$ at the same length equals
+    $\mu_{\alpha,0}d_\alpha^{(N+1)}\ne 0$; that compression is therefore
     also nonzero, and its trace is a positive real. Dividing by
-    $\mu_{\alpha,1}>0$ gives $d_\alpha^{(N+1)}>0$, and dividing the first
+    $\mu_{\alpha,0}>0$ gives $d_\alpha^{(N+1)}>0$, and dividing the first
     inequality by $d_\alpha^{(N+1)}$ gives $\mu_{\alpha,k}>0$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -548,13 +548,13 @@
         &=c_{\alpha,q}X_{\alpha,q}A_{\alpha,q}^vX_{\alpha,q}^{-1},
         \notag
     \end{align}
-    and distinguished gauges $X_{\alpha,1}=\Id$. Fix a class $\alpha$ and a
+    and distinguished gauges $X_{\alpha,0}=\Id$. Fix a class $\alpha$ and a
     copy $q$. After identifying the representative bond space with that of
     copy $q$, there are a physical map $W_{\alpha,q}$ and a scalar
-    $c_{\alpha,1}>0$ such that
+    $c_{\alpha,0}>0$ such that
     \begin{align}
         W_{\alpha,q}^\dagger\widetilde M^vW_{\alpha,q}
-        &=c_{\alpha,1}A_{\alpha,q}^v
+        &=c_{\alpha,0}A_{\alpha,q}^v
         \label{eq:distinguished_grouped_reference_corner}
     \end{align}
     for every vertical letter $v$.
@@ -564,17 +564,17 @@
     Identify the distinguished bond space with that of copy $q$ and define
     the transported physical map by
     \begin{align}
-        W_{\alpha,q}&=V_{\alpha,1}.
+        W_{\alpha,q}&=V_{\alpha,0}.
         \notag
     \end{align}
     The distinguished gauge is the identity, so its corner equation becomes
     \begin{align}
         W_{\alpha,q}^\dagger\widetilde M^vW_{\alpha,q}
-        &=c_{\alpha,1}A_{\alpha,q}^v.
+        &=c_{\alpha,0}A_{\alpha,q}^v.
         \notag
     \end{align}
     Positivity of the distinguished effective coefficient gives
-    $c_{\alpha,1}>0$, and the second displayed identity is
+    $c_{\alpha,0}>0$, and the second displayed identity is
     (\ref{eq:distinguished_grouped_reference_corner}).
 \end{proof}
 
@@ -617,8 +617,7 @@
     \label{thm:mpdo_grouped_sector_gram_conjugation}
     \lean{MPOTensor.IsMPDO.grouped_sector_gram_conj_eq}
     \leanok
-    \uses{thm:grouped_sector_gram_conj_of_dressing,
-        thm:mpdo_pairwise_vertical_gram_conjugation,
+    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
     Consider the grouped vertical decomposition furnished by
     Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries}. For a
@@ -651,8 +650,7 @@
     \label{thm:cpsv_literal_grouped_sector_gram_conjugation}
     \lean{MPSTensor.IsCPSVCanonicalForm.grouped_sector_gram_conj_eq}
     \leanok
-    \uses{thm:grouped_sector_gram_conj_of_dressing,
-        thm:cpsv_literal_pairwise_vertical_gram_conjugation,
+    \uses{thm:cpsv_literal_pairwise_vertical_gram_conjugation,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
     Consider the actual phase-class grouping furnished under literal CPSV
     canonical form.  For a class $\alpha$ and copy $q$, identify its normal
@@ -849,8 +847,7 @@
     \lean{MPOTensor.IsMPDO.grouped_sector_gram_eq_pos_smul_one}
     \lean{MPOTensor.IsMPDO.grouped_sector_exists_unitary_normalization}
     \leanok
-    \uses{thm:grouped_sector_gram_scalar_of_dressing,
-        thm:mpdo_pairwise_vertical_gram_conjugation,
+    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
     In the grouped vertical decomposition of a matrix-product density
     operator in normalized BNT-refined horizontal form, let $X_{\alpha,k}$ be
@@ -892,8 +889,7 @@
     \lean{MPSTensor.IsCPSVCanonicalForm.grouped_sector_gram_eq_pos_smul_one}
     \lean{MPSTensor.IsCPSVCanonicalForm.grouped_sector_exists_unitary_normalization}
     \leanok
-    \uses{thm:grouped_sector_gram_scalar_of_dressing,
-        thm:cpsv_literal_pairwise_vertical_gram_conjugation,
+    \uses{thm:cpsv_literal_pairwise_vertical_gram_conjugation,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
     In the actual phase-class grouping under literal CPSV canonical form,
     every gauge $X_{\alpha,q}$ has a positive real Gram scalar
@@ -928,26 +924,40 @@
     the unitary normalization.
 \end{proof}
 
+\begin{definition}[Normalized grouped-sector map]
+    \label{def:normalized_grouped_sector_map}
+    \lean{MPOTensor.normalizedGroupedSectorMap}
+    \leanok
+    \uses{def:mpv_phase_class_data}
+    After identifying the bond space of a copy with that of its representative,
+    define its normalized physical map by
+    \begin{align}
+        W_{\alpha,q}
+        &=V_{\alpha,q}\omega_{\alpha,q}^{-1/2}X_{\alpha,q}.
+        \notag
+    \end{align}
+\end{definition}
+
 \begin{theorem}[Normalized grouped-sector maps from Gram scalars]
     \label{thm:normalized_grouped_sector_maps_of_gram}
-    \lean{MPOTensor.normalizedGroupedSectorMap}
     \lean{MPOTensor.normalizedGroupedSectorMap_isometry}
     \lean{MPOTensor.normalizedGroupedSectorMap_orthogonal}
     \lean{MPOTensor.normalizedGroupedSectorMap_intertwining}
     \lean{MPOTensor.normalizedGroupedSectorMap_corner}
     \lean{MPOTensor.exists_normalized_grouped_sector_maps_of_gram}
     \leanok
-    \uses{def:mpv_phase_class_data, def:vertical_tensor_mpdo}
+    \uses{def:normalized_grouped_sector_map, def:mpv_phase_class_data,
+        def:vertical_tensor_mpdo}
     Let a phase-class grouping have gauges $X_{\alpha,q}$, physical maps
     $V_{\alpha,q}$, and effective coefficients $c_{\alpha,q}$.
-    Suppose
+    Suppose $\omega_{\alpha,q}>0$ and
     \begin{align}
         X_{\alpha,q}^\dagger X_{\alpha,q}
-        &=\omega_{\alpha,q}\Id,
-        &\omega_{\alpha,q}&>0,
+        &=\omega_{\alpha,q}\Id.
         \notag
     \end{align}
-    the maps $V_{\alpha,q}$ are isometries with pairwise orthogonal ranges,
+    for every class and copy. Suppose also that the maps $V_{\alpha,q}$
+    are isometries with pairwise orthogonal ranges,
     they intertwine $\widetilde M$ with the corresponding gauged
     representatives, and their grouped corner sum reconstructs every letter
     of $\widetilde M$. Then there are maps $W_{\alpha,q}$ such that
@@ -968,6 +978,9 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:normalized_grouped_sector_map,
+        thm:normal_tensor_gram_rigidity,
+        thm:mpdo_bnt_conditional_identity_marked_unitary_conjugacy}
     After identifying the copy bond space with the representative bond space,
     define
     \begin{align}
@@ -1020,8 +1033,7 @@
     \label{thm:mpdo_normalized_grouped_sector_maps}
     \lean{MPOTensor.IsMPDO.exists_normalized_grouped_sector_maps}
     \leanok
-    \uses{thm:normalized_grouped_sector_maps_of_gram,
-        thm:mpdo_grouped_sector_unitary_normalization,
+    \uses{thm:mpdo_grouped_sector_unitary_normalization,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
     In the grouped vertical decomposition, put
     \begin{align}
@@ -1078,8 +1090,7 @@
     \label{thm:cpsv_literal_normalized_grouped_sector_maps}
     \lean{MPSTensor.IsCPSVCanonicalForm.exists_normalized_grouped_sector_maps}
     \leanok
-    \uses{thm:normalized_grouped_sector_maps_of_gram,
-        thm:cpsv_literal_grouped_sector_unitary_normalization,
+    \uses{thm:cpsv_literal_grouped_sector_unitary_normalization,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
     In the phase-class grouping obtained from literal CPSV canonical form, let
     $Q_{\alpha,q}=\omega_{\alpha,q}^{-1/2}X_{\alpha,q}$ and

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -963,13 +963,19 @@
     are isometries with pairwise orthogonal ranges,
     they intertwine $\widetilde M$ with the corresponding gauged
     representatives, and their grouped corner sum reconstructs every letter
-    of $\widetilde M$. Then there are maps $W_{\alpha,q}$. For distinct pairs
-    $(\alpha,q)\ne(\beta,p)$, their ranges are orthogonal. These maps satisfy
+    of $\widetilde M$. Then there are maps $W_{\alpha,q}$ such that, for every
+    class $\alpha$ and copy $q$,
     \begin{align}
-        W_{\alpha,q}^\dagger W_{\alpha,q}&=\Id,
-        \notag\\
-        W_{\alpha,q}^\dagger W_{\beta,p}&=0,
-        \notag\\
+        W_{\alpha,q}^\dagger W_{\alpha,q}&=\Id.
+        \notag
+    \end{align}
+    For distinct pairs $(\alpha,q)\ne(\beta,p)$,
+    \begin{align}
+        W_{\alpha,q}^\dagger W_{\beta,p}&=0.
+        \notag
+    \end{align}
+    For every vertical letter $v$, these maps also satisfy
+    \begin{align}
         \widetilde M_vW_{\alpha,q}
         &=W_{\alpha,q}(c_{\alpha,q}M_\alpha^v),
         \notag\\

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -967,12 +967,10 @@
     class $\alpha$ and copy $q$,
     \begin{align}
         W_{\alpha,q}^\dagger W_{\alpha,q}&=\Id.
-        \notag
     \end{align}
     For distinct pairs $(\alpha,q)\ne(\beta,p)$,
     \begin{align}
         W_{\alpha,q}^\dagger W_{\beta,p}&=0.
-        \notag
     \end{align}
     For every vertical letter $v$, these maps also satisfy
     \begin{align}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -511,11 +511,70 @@
     letter.
 \end{proof}
 
+\begin{definition}[Pairwise Gram dressing for grouped corners]
+    \label{def:grouped_corner_gram_dressing}
+    \lean{MPOTensor.HasGroupedCornerGramDressing}
+    \leanok
+    \uses{def:mpdo, def:vertical_tensor_mpdo,
+        thm:mpdo_gram_dressed_reflected_marked_chain}
+    An MPO tensor $M$ has the \emph{grouped-corner Gram-dressing property} if
+    the following holds. Let $A$ be a tensor, let $V_X,V_Y$ be two physical
+    maps, let $X,Y$ be invertible matrices, and let $c_X,c_Y>0$. If
+    \begin{align}
+        V_X^\dagger\widetilde M^vV_X
+        &=c_X X A^vX^{-1},
+        \notag\\
+        V_Y^\dagger\widetilde M^vV_Y
+        &=c_Y Y A^vY^{-1}
+        \notag
+    \end{align}
+    for every vertical letter $v$, then
+    \begin{align}
+        (X^\dagger X)A^v(X^\dagger X)^{-1}
+        &=(Y^\dagger Y)A^v(Y^\dagger Y)^{-1}
+        \label{eq:grouped_corner_gram_dressing}
+    \end{align}
+    for every $v$.
+\end{definition}
+
+\begin{theorem}[Gram conjugation from grouped-corner dressing]
+    \label{thm:grouped_sector_gram_conj_of_dressing}
+    \lean{MPOTensor.grouped_sector_gram_conj_eq_of_dressing}
+    \leanok
+    \uses{def:grouped_corner_gram_dressing, def:mpv_phase_class_data}
+    Suppose a phase-class grouping has positive effective coefficients
+    $c_{\alpha,q}$ and corner identities
+    \begin{align}
+        V_{\alpha,q}^\dagger\widetilde M^vV_{\alpha,q}
+        &=c_{\alpha,q}X_{\alpha,q}A_{\alpha,q}^v
+          X_{\alpha,q}^{-1}.
+        \notag
+    \end{align}
+    Assume that the distinguished copy in each class has identity gauge and
+    that $M$ has the grouped-corner Gram-dressing property. Then
+    \begin{align}
+        (X_{\alpha,q}^\dagger X_{\alpha,q})A_{\alpha,q}^v
+        (X_{\alpha,q}^\dagger X_{\alpha,q})^{-1}
+        &=A_{\alpha,q}^v
+        \label{eq:grouped_sector_gram_conj_of_dressing}
+    \end{align}
+    for every class $\alpha$, copy $q$, and vertical letter $v$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:grouped_corner_gram_dressing}
+    Compare the corner indexed by $(\alpha,q)$ with the distinguished corner
+    of its phase class. The distinguished gauge is the identity, so its Gram
+    conjugation is trivial. Equation~(\ref{eq:grouped_corner_gram_dressing})
+    gives (\ref{eq:grouped_sector_gram_conj_of_dressing}).
+\end{proof}
+
 \begin{theorem}[Gram conjugation for an actual grouped sector]
     \label{thm:mpdo_grouped_sector_gram_conjugation}
     \lean{MPOTensor.IsMPDO.grouped_sector_gram_conj_eq}
     \leanok
-    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
+    \uses{thm:grouped_sector_gram_conj_of_dressing,
+        thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
     Consider the grouped vertical decomposition furnished by
     Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries}. For a
@@ -535,21 +594,21 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
+    \uses{thm:grouped_sector_gram_conj_of_dressing,
+        thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
-    Transport the distinguished corner of the phase class along the equality
-    of its bond dimension with that of the copy $q$. Its distinguished gauge
-    is the identity. Apply
-    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} to this corner
-    and the corner indexed by $q$. The Gram conjugation belonging to the
-    distinguished corner is the identity, which gives the stated equality.
+    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} supplies
+    the grouped-corner Gram-dressing property. Apply
+    Theorem~\ref{thm:grouped_sector_gram_conj_of_dressing} to the grouped
+    vertical decomposition.
 \end{proof}
 
 \begin{theorem}[Literal Gram conjugation for an actual grouped sector]
     \label{thm:cpsv_literal_grouped_sector_gram_conjugation}
     \lean{MPSTensor.IsCPSVCanonicalForm.grouped_sector_gram_conj_eq}
     \leanok
-    \uses{thm:cpsv_literal_pairwise_vertical_gram_conjugation,
+    \uses{thm:grouped_sector_gram_conj_of_dressing,
+        thm:cpsv_literal_pairwise_vertical_gram_conjugation,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
     Consider the actual phase-class grouping furnished under literal CPSV
     canonical form.  For a class $\alpha$ and copy $q$, identify its normal
@@ -567,13 +626,13 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_literal_pairwise_vertical_gram_conjugation,
+    \uses{thm:grouped_sector_gram_conj_of_dressing,
+        thm:cpsv_literal_pairwise_vertical_gram_conjugation,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
-    The distinguished copy has identity gauge.  Use the equality of bond
-    dimensions to regard its positive corner equation on the bond space of the
-    copy $q$.  The literal pairwise Figure~8 theorem compares the two
-    corners.  Its distinguished Gram conjugation is the identity, which gives
-    (\ref{eq:cpsv_literal_grouped_gram_conj}).
+    The literal pairwise Figure~8 theorem supplies the grouped-corner
+    Gram-dressing property. Apply
+    Theorem~\ref{thm:grouped_sector_gram_conj_of_dressing} to the literal
+    phase-class grouping.
 \end{proof}
 
 \begin{theorem}[Gram conjugation from the adjoint dressing]
@@ -707,13 +766,40 @@
     $\sqrt{\omega}$ makes it unitary.
 \end{proof}
 
+\begin{theorem}[Positive scalar Gram matrix from grouped-corner dressing]
+    \label{thm:grouped_sector_gram_scalar_of_dressing}
+    \lean{MPOTensor.grouped_sector_gram_eq_pos_smul_one_of_dressing}
+    \leanok
+    \uses{thm:grouped_sector_gram_conj_of_dressing,
+        thm:eq3_of_dressed_adjoint}
+    Under the hypotheses of
+    Theorem~\ref{thm:grouped_sector_gram_conj_of_dressing}, suppose in
+    addition that every representative $A_{\alpha,q}$ is normal and has
+    positive bond dimension. Then for every class $\alpha$ and copy $q$
+    there is a real number $\omega_{\alpha,q}>0$ such that
+    \begin{align}
+        X_{\alpha,q}^\dagger X_{\alpha,q}
+        &=\omega_{\alpha,q}\Id.
+        \label{eq:grouped_sector_gram_scalar_of_dressing}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:grouped_sector_gram_conj_of_dressing,
+        thm:eq3_of_dressed_adjoint}
+    Theorem~\ref{thm:grouped_sector_gram_conj_of_dressing} shows that
+    conjugation by $X_{\alpha,q}^\dagger X_{\alpha,q}$ fixes every letter of
+    the normal representative. Normal Gram rigidity makes this matrix a
+    positive real multiple of the identity.
+\end{proof}
+
 \begin{theorem}[Normalization of the grouped vertical gauges]
     \label{thm:mpdo_grouped_sector_unitary_normalization}
     \lean{MPOTensor.IsMPDO.grouped_sector_gram_eq_pos_smul_one}
     \lean{MPOTensor.IsMPDO.grouped_sector_exists_unitary_normalization}
     \leanok
-    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
-        thm:eq3_of_dressed_adjoint,
+    \uses{thm:grouped_sector_gram_scalar_of_dressing,
+        thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
     In the grouped vertical decomposition of a matrix-product density
     operator in normalized BNT-refined horizontal form, let $X_{\alpha,k}$ be
@@ -740,16 +826,14 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_pairwise_vertical_gram_conjugation,
-        thm:eq3_of_dressed_adjoint,
+    \uses{thm:grouped_sector_gram_scalar_of_dressing,
+        thm:mpdo_pairwise_vertical_gram_conjugation,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
-    Transport the normal representative to the bond space of the chosen
-    copy. Compare its positive corner with the distinguished identity-gauge
-    corner using
-    Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation}. Then apply
-    Theorem~\ref{thm:eq3_of_dressed_adjoint} with the second gauge equal to
-    the identity. The resulting Gram identity has a positive real scalar,
-    and division by its positive square root gives the stated unitary.
+    The pairwise Figure~8 theorem supplies the grouped-corner
+    Gram-dressing property. Apply
+    Theorem~\ref{thm:grouped_sector_gram_scalar_of_dressing} to the grouped
+    vertical decomposition, then divide each gauge by the positive square
+    root of its Gram scalar.
 \end{proof}
 
 \begin{theorem}[Literal normalization of the actual grouped vertical gauges]
@@ -757,8 +841,8 @@
     \lean{MPSTensor.IsCPSVCanonicalForm.grouped_sector_gram_eq_pos_smul_one}
     \lean{MPSTensor.IsCPSVCanonicalForm.grouped_sector_exists_unitary_normalization}
     \leanok
-    \uses{thm:cpsv_literal_pairwise_vertical_gram_conjugation,
-        thm:eq3_of_dressed_adjoint,
+    \uses{thm:grouped_sector_gram_scalar_of_dressing,
+        thm:cpsv_literal_pairwise_vertical_gram_conjugation,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
     In the actual phase-class grouping under literal CPSV canonical form,
     every gauge $X_{\alpha,q}$ has a positive real Gram scalar
@@ -777,17 +861,14 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_literal_pairwise_vertical_gram_conjugation,
-        thm:eq3_of_dressed_adjoint,
+    \uses{thm:grouped_sector_gram_scalar_of_dressing,
+        thm:cpsv_literal_pairwise_vertical_gram_conjugation,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
-    The representative on this bond space is normal. Compare its positive
-    corner with the distinguished identity-gauge corner using the literal
-    pairwise Figure~8 theorem. Then apply
-    Theorem~\ref{thm:eq3_of_dressed_adjoint} with the second gauge equal to
-    the identity. This gives
-    (\ref{eq:cpsv_literal_grouped_gram_scalar}) with
-    $\omega_{\alpha,q}>0$. Dividing by its positive square root gives a
-    unitary matrix.
+    The literal pairwise Figure~8 theorem supplies the grouped-corner
+    Gram-dressing property. Apply
+    Theorem~\ref{thm:grouped_sector_gram_scalar_of_dressing} to the literal
+    phase-class grouping, then divide each gauge by the positive square root
+    of its Gram scalar.
 \end{proof}
 
 \begin{theorem}[Normalized physical maps of the grouped vertical sectors]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -560,6 +560,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpv_phase_class_data}
     Identify the distinguished bond space with that of copy $q$ and define
     the transported physical map by
     \begin{align}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -518,7 +518,8 @@
     \uses{def:mpdo, def:vertical_tensor_mpdo}
     An MPO tensor $M$ has the \emph{grouped-corner Gram-dressing property} if
     the following holds. Let $A$ be a tensor, let $V_X,V_Y$ be two physical
-    maps, let $X,Y$ be invertible matrices, and let $c_X,c_Y>0$. If
+    maps, let $X,Y$ be invertible matrices, and let $c_X,c_Y>0$. For every
+    vertical letter $v$, if
     \begin{align}
         V_X^\dagger\widetilde M^vV_X
         &=c_X X A^vX^{-1},
@@ -527,13 +528,12 @@
         &=c_Y Y A^vY^{-1}
         \notag
     \end{align}
-    for every vertical letter $v$, then
+    then
     \begin{align}
         (X^\dagger X)A^v(X^\dagger X)^{-1}
-        &=(Y^\dagger Y)A^v(Y^\dagger Y)^{-1}
+        &=(Y^\dagger Y)A^v(Y^\dagger Y)^{-1}.
         \label{eq:grouped_corner_gram_dressing}
     \end{align}
-    for every $v$.
 \end{definition}
 
 \begin{theorem}[Distinguished reference corner of a grouped phase class]
@@ -551,13 +551,12 @@
     and distinguished gauges $X_{\alpha,0}=\Id$. Fix a class $\alpha$ and a
     copy $q$. After identifying the representative bond space with that of
     copy $q$, there are a physical map $W_{\alpha,q}$ and a scalar
-    $c_{\alpha,0}>0$ such that
+    $c_{\alpha,0}>0$ such that, for every vertical letter $v$,
     \begin{align}
         W_{\alpha,q}^\dagger\widetilde M^vW_{\alpha,q}
-        &=c_{\alpha,0}A_{\alpha,q}^v
+        &=c_{\alpha,0}A_{\alpha,q}^v.
         \label{eq:distinguished_grouped_reference_corner}
     \end{align}
-    for every vertical letter $v$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -592,24 +591,29 @@
         \notag
     \end{align}
     Assume that the distinguished copy in each class has identity gauge and
-    that $M$ has the grouped-corner Gram-dressing property. Then
+    that $M$ has the grouped-corner Gram-dressing property. Then for every
+    class $\alpha$, copy $q$, and vertical letter $v$,
     \begin{align}
         (X_{\alpha,q}^\dagger X_{\alpha,q})A_{\alpha,q}^v
         (X_{\alpha,q}^\dagger X_{\alpha,q})^{-1}
-        &=A_{\alpha,q}^v
+        &=A_{\alpha,q}^v.
         \label{eq:grouped_sector_gram_conj_of_dressing}
     \end{align}
-    for every class $\alpha$, copy $q$, and vertical letter $v$.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:grouped_corner_gram_dressing,
         thm:distinguished_grouped_reference_corner}
     Theorem~\ref{thm:distinguished_grouped_reference_corner} transports the
-    distinguished identity-gauge corner to the bond space of copy $q$.
-    Compare it with the corner indexed by $(\alpha,q)$ using the
-    grouped-corner Gram-dressing property. The distinguished Gram conjugation
-    is the identity, which gives
+    distinguished identity-gauge corner to the bond space of copy $q$. The
+    grouped-corner Gram-dressing property gives
+    \begin{align}
+        (X_{\alpha,0}^\dagger X_{\alpha,0})A_{\alpha,q}^v
+        (X_{\alpha,0}^\dagger X_{\alpha,0})^{-1}
+        &=(X_{\alpha,q}^\dagger X_{\alpha,q})A_{\alpha,q}^v
+          (X_{\alpha,q}^\dagger X_{\alpha,q})^{-1}.
+    \end{align}
+    The left side is $A_{\alpha,q}^v$ because $X_{\alpha,0}=\Id$. This gives
     (\ref{eq:grouped_sector_gram_conj_of_dressing}).
 \end{proof}
 
@@ -623,16 +627,15 @@
     Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries}. For a
     phase class $\alpha$ and a copy $q$, transport its representative tensor
     to the bond space of that copy. If $X_{\alpha,q}$ is the corresponding
-    gauge, then
+    gauge, then for every vertical letter $v$,
     \begin{align}
         (X_{\alpha,q}^\dagger X_{\alpha,q})
         A_{\alpha,q}^v
         (X_{\alpha,q}^\dagger X_{\alpha,q})^{-1}
-        &=A_{\alpha,q}^v,
+        &=A_{\alpha,q}^v.
         \label{eq:mpdo_grouped_gram_conj}
     \end{align}
-    for every vertical letter $v$. This is Figure~8 for the actual witnesses
-    of the grouped decomposition.
+    This is Figure~8 for the actual witnesses of the grouped decomposition.
 \end{theorem}
 
 \begin{proof}
@@ -655,15 +658,14 @@
     Consider the actual phase-class grouping furnished under literal CPSV
     canonical form.  For a class $\alpha$ and copy $q$, identify its normal
     representative with the bond space of that copy using the equality of
-    dimensions.  Then
+    dimensions. Then for every vertical letter $v$,
     \begin{align}
         (X_{\alpha,q}^\dagger X_{\alpha,q})
         A_{\alpha,q}^v
         (X_{\alpha,q}^\dagger X_{\alpha,q})^{-1}
-        &=A_{\alpha,q}^v
+        &=A_{\alpha,q}^v.
         \label{eq:cpsv_literal_grouped_gram_conj}
     \end{align}
-    for every vertical letter $v$.
 \end{theorem}
 
 \begin{proof}
@@ -948,14 +950,14 @@
     \uses{def:normalized_grouped_sector_map, def:mpv_phase_class_data,
         def:vertical_tensor_mpdo}
     Let a phase-class grouping have gauges $X_{\alpha,q}$, physical maps
-    $V_{\alpha,q}$, and effective coefficients $c_{\alpha,q}$.
-    Suppose $\omega_{\alpha,q}>0$ and
+    $V_{\alpha,q}$, and effective coefficients $c_{\alpha,q}$. Suppose that,
+    for every class $\alpha$ and copy $q$, $\omega_{\alpha,q}>0$ and
     \begin{align}
         X_{\alpha,q}^\dagger X_{\alpha,q}
         &=\omega_{\alpha,q}\Id.
         \notag
     \end{align}
-    for every class and copy. Suppose also that the maps $V_{\alpha,q}$
+    Suppose also that the maps $V_{\alpha,q}$
     are isometries with pairwise orthogonal ranges,
     they intertwine $\widetilde M$ with the corresponding gauged
     representatives, and their grouped corner sum reconstructs every letter

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -561,10 +561,21 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    Transport the physical map of the distinguished copy along the equality
-    of bond dimensions. Its gauge is the identity, so the transported corner
-    equation is (\ref{eq:distinguished_grouped_reference_corner}); positivity
-    of the distinguished effective coefficient gives $c_{\alpha,1}>0$.
+    Identify the distinguished bond space with that of copy $q$ and define
+    the transported physical map by
+    \begin{align}
+        W_{\alpha,q}&=V_{\alpha,1}.
+        \notag
+    \end{align}
+    The distinguished gauge is the identity, so its corner equation becomes
+    \begin{align}
+        W_{\alpha,q}^\dagger\widetilde M^vW_{\alpha,q}
+        &=c_{\alpha,1}A_{\alpha,q}^v.
+        \notag
+    \end{align}
+    Positivity of the distinguished effective coefficient gives
+    $c_{\alpha,1}>0$, and the second displayed identity is
+    (\ref{eq:distinguished_grouped_reference_corner}).
 \end{proof}
 
 \begin{theorem}[Gram conjugation from grouped-corner dressing]
@@ -665,7 +676,13 @@
     The literal pairwise Figure~8 theorem supplies the grouped-corner
     Gram-dressing property. Apply
     Theorem~\ref{thm:grouped_sector_gram_conj_of_dressing} to the literal
-    phase-class grouping.
+    phase-class grouping. This gives
+    \begin{align}
+        (X_{\alpha,q}^\dagger X_{\alpha,q})A_{\alpha,q}^v
+        (X_{\alpha,q}^\dagger X_{\alpha,q})^{-1}
+        &=A_{\alpha,q}^v.
+        \label{eq:cpsv_prop_4_13_gram_conjugation}
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Gram conjugation from the adjoint dressing]
@@ -803,8 +820,7 @@
     \label{thm:grouped_sector_gram_scalar_of_dressing}
     \lean{MPOTensor.grouped_sector_gram_eq_pos_smul_one_of_dressing}
     \leanok
-    \uses{thm:grouped_sector_gram_conj_of_dressing,
-        thm:eq3_of_dressed_adjoint}
+    \uses{thm:grouped_sector_gram_conj_of_dressing}
     Under the hypotheses of
     Theorem~\ref{thm:grouped_sector_gram_conj_of_dressing}, suppose in
     addition that every representative $A_{\alpha,q}$ is normal and has
@@ -902,12 +918,23 @@
     The literal pairwise Figure~8 theorem supplies the grouped-corner
     Gram-dressing property. Apply
     Theorem~\ref{thm:grouped_sector_gram_scalar_of_dressing} to the literal
-    phase-class grouping, then divide each gauge by the positive square root
-    of its Gram scalar.
+    phase-class grouping to obtain
+    \begin{align}
+        X_{\alpha,q}^\dagger X_{\alpha,q}
+        &=\omega_{\alpha,q}\Id.
+        \label{eq:cpsv_prop_4_13_gram}
+    \end{align}
+    Dividing each gauge by the positive square root of its Gram scalar gives
+    the unitary normalization.
 \end{proof}
 
 \begin{theorem}[Normalized grouped-sector maps from Gram scalars]
     \label{thm:normalized_grouped_sector_maps_of_gram}
+    \lean{MPOTensor.normalizedGroupedSectorMap}
+    \lean{MPOTensor.normalizedGroupedSectorMap_isometry}
+    \lean{MPOTensor.normalizedGroupedSectorMap_orthogonal}
+    \lean{MPOTensor.normalizedGroupedSectorMap_intertwining}
+    \lean{MPOTensor.normalizedGroupedSectorMap_corner}
     \lean{MPOTensor.exists_normalized_grouped_sector_maps_of_gram}
     \leanok
     \uses{def:mpv_phase_class_data, def:vertical_tensor_mpdo}
@@ -941,22 +968,47 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    Put
-    $W_{\alpha,q}=V_{\alpha,q}\omega_{\alpha,q}^{-1/2}X_{\alpha,q}$,
-    after identifying the copy bond space with the representative bond space.
-    The Gram equation gives the isometry property; orthogonality follows from
-    that of the original physical maps. The scalar normalization commutes with
-    every representative letter, so the gauge factors cancel in the
-    intertwining and reconstruction identities.
+    After identifying the copy bond space with the representative bond space,
+    define
+    \begin{align}
+        Q_{\alpha,q}
+        &=\omega_{\alpha,q}^{-1/2}X_{\alpha,q},
+        \notag\\
+        W_{\alpha,q}
+        &=V_{\alpha,q}Q_{\alpha,q}.
+        \notag
+    \end{align}
+    Since $\omega_{\alpha,q}>0$, the Gram identity implies
+    \begin{align}
+        X_{\alpha,q}^\dagger
+        &=\omega_{\alpha,q}X_{\alpha,q}^{-1},
+        \notag\\
+        Q_{\alpha,q}^\dagger Q_{\alpha,q}
+        &=\Id.
+        \notag
+    \end{align}
+    Hence $W_{\alpha,q}^\dagger W_{\alpha,q}=\Id$, and inserting the two
+    normalized gauges on either side of the original orthogonality equation
+    preserves pairwise orthogonality. The original intertwining identity gives
+    \begin{align}
+        \widetilde M_vW_{\alpha,q}
+        &=W_{\alpha,q}(c_{\alpha,q}M_\alpha^v).
+        \notag
+    \end{align}
+    The same Gram identity and the positive square-root normalization give
+    the corner equality
+    \begin{align}
+        Q_{\alpha,q}(c_{\alpha,q}M_\alpha^v)Q_{\alpha,q}^\dagger
+        &=c_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
+        \label{eq:normalized_grouped_sector_corner}
+    \end{align}
+    Thus conjugation by $W_{\alpha,q}$ reproduces the original grouped corner.
+    Summing (\ref{eq:normalized_grouped_sector_corner}) over all copies and
+    classes proves (\ref{eq:normalized_grouped_sector_maps_of_gram}).
 \end{proof}
 
 \begin{theorem}[Normalized physical maps of the grouped vertical sectors]
     \label{thm:mpdo_normalized_grouped_sector_maps}
-    \lean{MPOTensor.normalizedGroupedSectorMap}
-    \lean{MPOTensor.normalizedGroupedSectorMap_isometry}
-    \lean{MPOTensor.normalizedGroupedSectorMap_orthogonal}
-    \lean{MPOTensor.normalizedGroupedSectorMap_intertwining}
-    \lean{MPOTensor.normalizedGroupedSectorMap_corner}
     \lean{MPOTensor.IsMPDO.exists_normalized_grouped_sector_maps}
     \leanok
     \uses{thm:normalized_grouped_sector_maps_of_gram,
@@ -1017,7 +1069,8 @@
     \label{thm:cpsv_literal_normalized_grouped_sector_maps}
     \lean{MPSTensor.IsCPSVCanonicalForm.exists_normalized_grouped_sector_maps}
     \leanok
-    \uses{thm:cpsv_literal_grouped_sector_unitary_normalization,
+    \uses{thm:normalized_grouped_sector_maps_of_gram,
+        thm:cpsv_literal_grouped_sector_unitary_normalization,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
     In the phase-class grouping obtained from literal CPSV canonical form, let
     $Q_{\alpha,q}=\omega_{\alpha,q}^{-1/2}X_{\alpha,q}$ and
@@ -1046,35 +1099,13 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_literal_grouped_sector_unitary_normalization,
+    \uses{thm:normalized_grouped_sector_maps_of_gram,
+        thm:cpsv_literal_grouped_sector_unitary_normalization,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
-    For each copy, put
-    $Q_{\alpha,q}=\omega_{\alpha,q}^{-1/2}X_{\alpha,q}$ and
-    $W_{\alpha,q}=V_{\alpha,q}Q_{\alpha,q}$. Unitarity of
-    $Q_{\alpha,q}$ preserves the isometry equation and pairwise
-    orthogonality. Substituting $W_{\alpha,q}=V_{\alpha,q}Q_{\alpha,q}$
-    into the intertwining identity gives
-    \begin{align}
-        \widetilde M_vW_{\alpha,q}
-        &=V_{\alpha,q}\bigl(
-          c_{\alpha,q}\omega_{\alpha,q}^{-1/2}
-          X_{\alpha,q}M_\alpha^v
-          X_{\alpha,q}^{-1}X_{\alpha,q}\bigr)
-        \notag\\
-        &=W_{\alpha,q}(c_{\alpha,q}M_\alpha^v).
-        \notag
-    \end{align}
-    Thus the adjacent factors
-    $X_{\alpha,q}^{-1}X_{\alpha,q}$ cancel and leave the undressed
-    representative $M_\alpha^v$. The Gram identity
-    $X_{\alpha,q}^\dagger X_{\alpha,q}
-    =\omega_{\alpha,q}\Id$ also gives
-    \begin{align}
-        Q_{\alpha,q}(c_{\alpha,q}M_\alpha^v)Q_{\alpha,q}^\dagger
-        &=c_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
-        \notag
-    \end{align}
-    Hence conjugation by $W_{\alpha,q}$ reproduces the original grouped
-    corner. Summing these equalities gives
+    Theorem~\ref{thm:cpsv_literal_grouped_sector_unitary_normalization}
+    supplies the positive Gram scalars. Apply
+    Theorem~\ref{thm:normalized_grouped_sector_maps_of_gram} to the literal
+    phase-class grouping. Its corner identity preserves the original grouped
+    reconstruction and gives
     (\ref{eq:cpsv_literal_normalized_reconstruction}).
 \end{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -358,7 +358,7 @@
     $X_{\alpha,k}^\dagger X_{\alpha,k}=\omega_{\alpha,k}\Id$ of the
     Gram-matrix proportionality in the proof of
     \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, with
-    $X_{\alpha,1}=\Id$ and
+    $X_{\alpha,0}=\Id$ and
     $U_{\alpha,k}=\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$. Deriving the
     commutation from self-adjointness of the sector compressions is a
     separate step.
@@ -758,8 +758,8 @@
     vertical normal tensor:
     $(X_{\alpha,k}^{\dagger}X_{\alpha,k})M_\alpha
     (X_{\alpha,k}^{\dagger}X_{\alpha,k})^{-1}
-    =(X_{\alpha,1}^{\dagger}X_{\alpha,1})M_\alpha
-    (X_{\alpha,1}^{\dagger}X_{\alpha,1})^{-1}$.
+    =(X_{\alpha,0}^{\dagger}X_{\alpha,0})M_\alpha
+    (X_{\alpha,0}^{\dagger}X_{\alpha,0})^{-1}$.
     Theorem~\ref{thm:mpdo_pairwise_vertical_gram_conjugation} gives this
     equality from self-adjointness of the corresponding sector compressions
     and horizontal marked separation. Normality is used only in the
@@ -852,7 +852,7 @@
     In the grouped vertical decomposition of a matrix-product density
     operator in normalized BNT-refined horizontal form, let $X_{\alpha,k}$ be
     the gauge of a copy of the normal representative $M_\alpha$. Fix the
-    distinguished gauge to $X_{\alpha,1}=\Id$. Then there is a positive real
+    distinguished gauge to $X_{\alpha,0}=\Id$. Then there is a positive real
     number $\omega_{\alpha,k}$ such that
     \begin{align}
         X_{\alpha,k}^\dagger X_{\alpha,k}
@@ -1022,7 +1022,6 @@
         &=V_{\alpha,q}
           (c_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1})
           V_{\alpha,q}^\dagger.
-        \notag
     \end{align}
     Summing these physical-space identities over all copies and classes, then
     applying the original grouped reconstruction, proves

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -518,8 +518,8 @@
     \uses{def:mpdo, def:vertical_tensor_mpdo}
     An MPO tensor $M$ has the \emph{grouped-corner Gram-dressing property} if
     the following holds. Let $A$ be a tensor, let $V_X,V_Y$ be two physical
-    maps, let $X,Y$ be invertible matrices, and let $c_X,c_Y>0$. For every
-    vertical letter $v$, if
+    maps, let $X,Y$ be invertible matrices, and let $c_X,c_Y>0$. Suppose that,
+    for every vertical letter $v$, the following two corner identities hold:
     \begin{align}
         V_X^\dagger\widetilde M^vV_X
         &=c_X X A^vX^{-1},
@@ -528,7 +528,7 @@
         &=c_Y Y A^vY^{-1}
         \notag
     \end{align}
-    then
+    Then, for every vertical letter $v$,
     \begin{align}
         (X^\dagger X)A^v(X^\dagger X)^{-1}
         &=(Y^\dagger Y)A^v(Y^\dagger Y)^{-1}.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -1002,9 +1002,18 @@
         &=c_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
         \label{eq:normalized_grouped_sector_corner}
     \end{align}
-    Thus conjugation by $W_{\alpha,q}$ reproduces the original grouped corner.
-    Summing (\ref{eq:normalized_grouped_sector_corner}) over all copies and
-    classes proves (\ref{eq:normalized_grouped_sector_maps_of_gram}).
+    Multiplying (\ref{eq:normalized_grouped_sector_corner}) on the left by
+    $V_{\alpha,q}$ and on the right by $V_{\alpha,q}^\dagger$ gives
+    \begin{align}
+        W_{\alpha,q}(c_{\alpha,q}M_\alpha^v)W_{\alpha,q}^\dagger
+        &=V_{\alpha,q}
+          (c_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1})
+          V_{\alpha,q}^\dagger.
+        \notag
+    \end{align}
+    Summing these physical-space identities over all copies and classes, then
+    applying the original grouped reconstruction, proves
+    (\ref{eq:normalized_grouped_sector_maps_of_gram}).
 \end{proof}
 
 \begin{theorem}[Normalized physical maps of the grouped vertical sectors]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -515,8 +515,7 @@
     \label{def:grouped_corner_gram_dressing}
     \lean{MPOTensor.HasGroupedCornerGramDressing}
     \leanok
-    \uses{def:mpdo, def:vertical_tensor_mpdo,
-        thm:mpdo_gram_dressed_reflected_marked_chain}
+    \uses{def:mpdo, def:vertical_tensor_mpdo}
     An MPO tensor $M$ has the \emph{grouped-corner Gram-dressing property} if
     the following holds. Let $A$ be a tensor, let $V_X,V_Y$ be two physical
     maps, let $X,Y$ be invertible matrices, and let $c_X,c_Y>0$. If
@@ -536,6 +535,37 @@
     \end{align}
     for every $v$.
 \end{definition}
+
+\begin{theorem}[Distinguished reference corner of a grouped phase class]
+    \label{thm:distinguished_grouped_reference_corner}
+    \lean{MPOTensor.exists_distinguished_grouped_reference_corner}
+    \leanok
+    \uses{def:mpv_phase_class_data, def:vertical_tensor_mpdo}
+    Suppose a phase-class grouping has positive effective coefficients
+    $c_{\alpha,q}$, corner identities
+    \begin{align}
+        V_{\alpha,q}^\dagger\widetilde M^vV_{\alpha,q}
+        &=c_{\alpha,q}X_{\alpha,q}A_{\alpha,q}^vX_{\alpha,q}^{-1},
+        \notag
+    \end{align}
+    and distinguished gauges $X_{\alpha,1}=\Id$. Fix a class $\alpha$ and a
+    copy $q$. After identifying the representative bond space with that of
+    copy $q$, there are a physical map $W_{\alpha,q}$ and a scalar
+    $c_{\alpha,1}>0$ such that
+    \begin{align}
+        W_{\alpha,q}^\dagger\widetilde M^vW_{\alpha,q}
+        &=c_{\alpha,1}A_{\alpha,q}^v
+        \label{eq:distinguished_grouped_reference_corner}
+    \end{align}
+    for every vertical letter $v$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Transport the physical map of the distinguished copy along the equality
+    of bond dimensions. Its gauge is the identity, so the transported corner
+    equation is (\ref{eq:distinguished_grouped_reference_corner}); positivity
+    of the distinguished effective coefficient gives $c_{\alpha,1}>0$.
+\end{proof}
 
 \begin{theorem}[Gram conjugation from grouped-corner dressing]
     \label{thm:grouped_sector_gram_conj_of_dressing}
@@ -562,11 +592,14 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:grouped_corner_gram_dressing}
-    Compare the corner indexed by $(\alpha,q)$ with the distinguished corner
-    of its phase class. The distinguished gauge is the identity, so its Gram
-    conjugation is trivial. Equation~(\ref{eq:grouped_corner_gram_dressing})
-    gives (\ref{eq:grouped_sector_gram_conj_of_dressing}).
+    \uses{def:grouped_corner_gram_dressing,
+        thm:distinguished_grouped_reference_corner}
+    Theorem~\ref{thm:distinguished_grouped_reference_corner} transports the
+    distinguished identity-gauge corner to the bond space of copy $q$.
+    Compare it with the corner indexed by $(\alpha,q)$ using the
+    grouped-corner Gram-dressing property. The distinguished Gram conjugation
+    is the identity, which gives
+    (\ref{eq:grouped_sector_gram_conj_of_dressing}).
 \end{proof}
 
 \begin{theorem}[Gram conjugation for an actual grouped sector]
@@ -789,8 +822,10 @@
         thm:eq3_of_dressed_adjoint}
     Theorem~\ref{thm:grouped_sector_gram_conj_of_dressing} shows that
     conjugation by $X_{\alpha,q}^\dagger X_{\alpha,q}$ fixes every letter of
-    the normal representative. Normal Gram rigidity makes this matrix a
-    positive real multiple of the identity.
+    the normal representative. Apply the identity-gauge specialization of
+    Theorem~\ref{thm:eq3_of_dressed_adjoint}; it gives a real number
+    $\omega_{\alpha,q}>0$ with
+    $X_{\alpha,q}^\dagger X_{\alpha,q}=\omega_{\alpha,q}\Id$.
 \end{proof}
 
 \begin{theorem}[Normalization of the grouped vertical gauges]
@@ -871,6 +906,50 @@
     of its Gram scalar.
 \end{proof}
 
+\begin{theorem}[Normalized grouped-sector maps from Gram scalars]
+    \label{thm:normalized_grouped_sector_maps_of_gram}
+    \lean{MPOTensor.exists_normalized_grouped_sector_maps_of_gram}
+    \leanok
+    \uses{def:mpv_phase_class_data, def:vertical_tensor_mpdo}
+    Let a phase-class grouping have gauges $X_{\alpha,q}$, physical maps
+    $V_{\alpha,q}$, and effective coefficients $c_{\alpha,q}$.
+    Suppose
+    \begin{align}
+        X_{\alpha,q}^\dagger X_{\alpha,q}
+        &=\omega_{\alpha,q}\Id,
+        &\omega_{\alpha,q}&>0,
+        \notag
+    \end{align}
+    the maps $V_{\alpha,q}$ are isometries with pairwise orthogonal ranges,
+    they intertwine $\widetilde M$ with the corresponding gauged
+    representatives, and their grouped corner sum reconstructs every letter
+    of $\widetilde M$. Then there are maps $W_{\alpha,q}$ such that
+    \begin{align}
+        W_{\alpha,q}^\dagger W_{\alpha,q}&=\Id,
+        \notag\\
+        W_{\alpha,q}^\dagger W_{\beta,p}&=0
+        \quad((\alpha,q)\ne(\beta,p)),
+        \notag\\
+        \widetilde M_vW_{\alpha,q}
+        &=W_{\alpha,q}(c_{\alpha,q}M_\alpha^v),
+        \notag\\
+        \widetilde M_v
+        &=\sum_\alpha\sum_q
+          W_{\alpha,q}(c_{\alpha,q}M_\alpha^v)W_{\alpha,q}^\dagger.
+        \label{eq:normalized_grouped_sector_maps_of_gram}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Put
+    $W_{\alpha,q}=V_{\alpha,q}\omega_{\alpha,q}^{-1/2}X_{\alpha,q}$,
+    after identifying the copy bond space with the representative bond space.
+    The Gram equation gives the isometry property; orthogonality follows from
+    that of the original physical maps. The scalar normalization commutes with
+    every representative letter, so the gauge factors cancel in the
+    intertwining and reconstruction identities.
+\end{proof}
+
 \begin{theorem}[Normalized physical maps of the grouped vertical sectors]
     \label{thm:mpdo_normalized_grouped_sector_maps}
     \lean{MPOTensor.normalizedGroupedSectorMap}
@@ -880,7 +959,8 @@
     \lean{MPOTensor.normalizedGroupedSectorMap_corner}
     \lean{MPOTensor.IsMPDO.exists_normalized_grouped_sector_maps}
     \leanok
-    \uses{thm:mpdo_grouped_sector_unitary_normalization,
+    \uses{thm:normalized_grouped_sector_maps_of_gram,
+        thm:mpdo_grouped_sector_unitary_normalization,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
     In the grouped vertical decomposition, put
     \begin{align}
@@ -923,23 +1003,13 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_grouped_sector_unitary_normalization,
+    \uses{thm:normalized_grouped_sector_maps_of_gram,
+        thm:mpdo_grouped_sector_unitary_normalization,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
-    Each $Q_{\alpha,q}$ is unitary, so right multiplication by it preserves
-    the isometry equation and the pairwise orthogonality of the physical
-    sector maps. In the intertwining relation, the scalar normalization
-    commutes with every letter and the adjacent factors
-    $X_{\alpha,q}^{-1}X_{\alpha,q}$ cancel. The Gram identity gives
-    $X_{\alpha,q}^\dagger
-    =\omega_{\alpha,q}X_{\alpha,q}^{-1}$; hence
-    \begin{align}
-        Q_{\alpha,q}M_\alpha^vQ_{\alpha,q}^\dagger
-        &=X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
-        \notag
-    \end{align}
-    Substitution into every summand of the grouped reconstruction proves the
-    final identity. Transport along the equality of bond dimensions changes
-    only the coordinate labels.
+    Theorem~\ref{thm:mpdo_grouped_sector_unitary_normalization}
+    supplies the positive Gram scalars. Apply
+    Theorem~\ref{thm:normalized_grouped_sector_maps_of_gram} to the grouped
+    vertical decomposition.
 \end{proof}
 
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -515,7 +515,7 @@
     \label{def:grouped_corner_gram_dressing}
     \lean{MPOTensor.HasGroupedCornerGramDressing}
     \leanok
-    \uses{def:mpdo, def:vertical_tensor_mpdo}
+    \uses{def:vertical_tensor_mpdo}
     An MPO tensor $M$ has the \emph{grouped-corner Gram-dressing property} if
     the following holds. Let $A$ be a tensor, let $V_X,V_Y$ be two physical
     maps, let $X,Y$ be invertible matrices, and let $c_X,c_Y>0$. Suppose that,
@@ -878,7 +878,8 @@
     \leanok
     \uses{thm:grouped_sector_gram_scalar_of_dressing,
         thm:mpdo_pairwise_vertical_gram_conjugation,
-        thm:mpdo_vertical_bnt_grouping_with_isometries}
+        thm:mpdo_vertical_bnt_grouping_with_isometries,
+        thm:normal_tensor_gram_rigidity}
     The pairwise Figure~8 theorem supplies the grouped-corner
     Gram-dressing property. Apply
     Theorem~\ref{thm:grouped_sector_gram_scalar_of_dressing} to the grouped
@@ -912,7 +913,8 @@
     \leanok
     \uses{thm:grouped_sector_gram_scalar_of_dressing,
         thm:cpsv_literal_pairwise_vertical_gram_conjugation,
-        thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
+        thm:cpsv_literal_vertical_bnt_grouping_with_isometries,
+        thm:normal_tensor_gram_rigidity}
     The literal pairwise Figure~8 theorem supplies the grouped-corner
     Gram-dressing property. Apply
     Theorem~\ref{thm:grouped_sector_gram_scalar_of_dressing} to the literal
@@ -961,12 +963,12 @@
     are isometries with pairwise orthogonal ranges,
     they intertwine $\widetilde M$ with the corresponding gauged
     representatives, and their grouped corner sum reconstructs every letter
-    of $\widetilde M$. Then there are maps $W_{\alpha,q}$ such that
+    of $\widetilde M$. Then there are maps $W_{\alpha,q}$. For distinct pairs
+    $(\alpha,q)\ne(\beta,p)$, their ranges are orthogonal. These maps satisfy
     \begin{align}
         W_{\alpha,q}^\dagger W_{\alpha,q}&=\Id,
         \notag\\
-        W_{\alpha,q}^\dagger W_{\beta,p}&=0
-        \quad((\alpha,q)\ne(\beta,p)),
+        W_{\alpha,q}^\dagger W_{\beta,p}&=0,
         \notag\\
         \widetilde M_vW_{\alpha,q}
         &=W_{\alpha,q}(c_{\alpha,q}M_\alpha^v),

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -818,7 +818,7 @@
     \label{thm:grouped_sector_gram_scalar_of_dressing}
     \lean{MPOTensor.grouped_sector_gram_eq_pos_smul_one_of_dressing}
     \leanok
-    \uses{thm:grouped_sector_gram_conj_of_dressing}
+    \uses{def:normal, thm:grouped_sector_gram_conj_of_dressing}
     Under the hypotheses of
     Theorem~\ref{thm:grouped_sector_gram_conj_of_dressing}, suppose in
     addition that every representative $A_{\alpha,q}$ is normal and has
@@ -928,7 +928,6 @@
     \label{def:normalized_grouped_sector_map}
     \lean{MPOTensor.normalizedGroupedSectorMap}
     \leanok
-    \uses{def:mpv_phase_class_data}
     After identifying the bond space of a copy with that of its representative,
     define its normalized physical map by
     \begin{align}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_representative_marked.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_representative_marked.tex
@@ -280,7 +280,11 @@
     $P_{\mathrm{act}}$ because their matrix product vectors agree at every
     positive length. Applying
     Theorem~\ref{thm:representative_grouped_insert_eq} gives
-    (\ref{eq:cpsv_retained_first_site_action}).
+    (\ref{eq:cpsv_retained_first_site_action}), namely
+    \begin{align}
+        (YC_j)^i&=(ZC_j)^i.
+        \label{eq:cpsv_prop_4_13_active_separation}
+    \end{align}
 \end{proof}
 
 % Source anchors: CPSV16 Appendix C.3, lines 1835--1858, and

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -467,12 +467,67 @@
     formulas.
 \end{proof}
 
+\begin{definition}[Grouped vertical BNT decomposition with physical isometries]
+    \label{def:vertical_bnt_grouping_with_isometry}
+    \lean{MPOTensor.HasVerticalBNTGroupingWithIsometry}
+    \leanok
+    \uses{def:vertical_tensor_mpdo, def:mpv_phase_class_data,
+        def:bnt_cpsv, def:mpdo_sector_projector,
+        def:mpdo_vertical_loops}
+    An MPO tensor $M$ has a \emph{grouped vertical BNT decomposition with
+    physical isometries} if there are positive bond dimensions $d_k$, positive
+    weights $\mu_k$, normal tensors $B_k$, and isometries
+    $V_k\colon\C^{d_k}\to\C^d$ with pairwise orthogonal ranges such that
+    \begin{align}
+        \widetilde M_vV_k&=V_k(\mu_kB_k^v),
+        \notag\\
+        V_k^\dagger\widetilde M_v&=(\mu_kB_k^v)V_k^\dagger,
+        \notag\\
+        \mu_kB_k^v&=V_k^\dagger\widetilde M_vV_k,
+        \notag\\
+        \widetilde M_v&=\sum_kV_k(\mu_kB_k^v)V_k^\dagger.
+        \notag
+    \end{align}
+    Let $k=(\alpha,q)$ be the phase-class enumeration. There are equalities of
+    the representative and copy bond dimensions, invertible gauges
+    $X_{\alpha,q}$, and nonzero phases $\zeta_{\alpha,q}$ of unit modulus,
+    with $X_{\alpha,1}=\Id$ and $\zeta_{\alpha,1}=1$, such that
+    \begin{align}
+        B_{\alpha,q}^v
+        &=\zeta_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
+        \notag
+    \end{align}
+    The representatives $M_\alpha$ form a basis of normal tensors for the
+    weighted block tensor and are pairwise inequivalent up to gauge and phase.
+    Every effective coefficient
+    $c_{\alpha,q}=\mu_{\alpha,q}\zeta_{\alpha,q}$ is nonzero and positive.
+
+    For
+    $P_{\alpha,q}=V_{\alpha,q}V_{\alpha,q}^\dagger$, the triple consisting of
+    $P_{\alpha,q}$, $c_{\alpha,q}$, and the representative loop of $M_\alpha$
+    satisfies the sector-projector identity of
+    Definition~\ref{def:mpdo_sector_projector}. Moreover, for every
+    $(\alpha,q)$ there is a finite chain length for which the first-site
+    compression by $P_{\alpha,q}$ is nonzero.
+    Finally, the grouped physical maps remain isometries with pairwise
+    orthogonal ranges, satisfy both grouped intertwining identities and the
+    grouped corner identity, and reconstruct each vertical letter exactly:
+    \begin{align}
+        \widetilde M_v
+        &=\sum_\alpha\sum_q
+          V_{\alpha,q}
+          \bigl(c_{\alpha,q}X_{\alpha,q}M_\alpha^v
+          X_{\alpha,q}^{-1}\bigr)V_{\alpha,q}^\dagger.
+        \label{eq:vertical_bnt_grouping_with_isometry}
+    \end{align}
+\end{definition}
+
 \begin{theorem}[Vertical normal sectors grouped into BNT representatives]
     \label{thm:mpdo_vertical_bnt_grouping_with_isometries}
     \lean{MPOTensor.IsHorizontalCF.exists_verticalBNTGrouping_with_isometry}
     \leanok
-    \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
-        def:bnt_cpsv, def:mpv_phase_class_data}
+    \uses{def:mpdo, def:horizontal_cf_mpdo,
+        def:vertical_bnt_grouping_with_isometry}
     Under the same hypotheses, partition the normalized vertical sectors by
     equality of their matrix product vector families up to a fixed nonzero
     scalar per site. There are normal representatives $M_\alpha$, an enumeration
@@ -538,8 +593,8 @@
     \lean{MPSTensor.IsCPSVCanonicalForm.%
         exists_verticalBNTGrouping_with_isometry}
     \leanok
-    \uses{def:mpdo, def:cpsv_canonical_form, def:vertical_tensor_mpdo,
-        def:bnt_cpsv, def:mpv_phase_class_data}
+    \uses{def:mpdo, def:cpsv_canonical_form,
+        def:vertical_bnt_grouping_with_isometry}
     Under the same hypotheses, partition the normalized vertical sectors by
     equality of their matrix product vector families up to a fixed nonzero
     scalar per site. There are normal representatives $M_\alpha$, an enumeration
@@ -920,24 +975,20 @@
     \label{thm:vertical_cf_of_grouping_and_gram_dressing}
     \lean{MPOTensor.verticalCF_of_grouping_and_gramDressing}
     \leanok
-    \uses{def:grouped_corner_gram_dressing,
-        thm:grouped_sector_gram_scalar_of_dressing,
-        thm:mpdo_vertical_grouped_is_bnt,
-        thm:mpdo_normalized_grouped_sector_maps,
-        thm:vertical_cf_of_grouped_orthogonal_sectors}
-    Suppose the vertical tensor $\widetilde M$ has a phase-class grouping into
-    normal representatives $M_\alpha$, positive effective weights
-    $c_{\alpha,q}$, and pairwise orthogonal physical corners with exact
-    reconstruction. Assume that the representatives form a BNT, that the
-    distinguished gauge in each class is the identity, and that $M$ has the
-    grouped-corner Gram-dressing property. Then $M$ is in vertical canonical
-    form.
+    \uses{def:vertical_bnt_grouping_with_isometry,
+        def:grouped_corner_gram_dressing, def:vertical_cf_mpdo}
+    If $M$ has a grouped vertical BNT decomposition with physical isometries
+    in the sense of
+    Definition~\ref{def:vertical_bnt_grouping_with_isometry}, and $M$ has the
+    grouped-corner Gram-dressing property of
+    Definition~\ref{def:grouped_corner_gram_dressing}, then $M$ is in vertical
+    canonical form.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:grouped_sector_gram_scalar_of_dressing,
         thm:mpdo_vertical_grouped_is_bnt,
-        thm:mpdo_normalized_grouped_sector_maps,
+        thm:normalized_grouped_sector_maps_of_gram,
         thm:vertical_cf_of_grouped_orthogonal_sectors}
     Theorem~\ref{thm:grouped_sector_gram_scalar_of_dressing} gives
     $X_{\alpha,q}^\dagger X_{\alpha,q}=\omega_{\alpha,q}\Id$ with
@@ -992,72 +1043,22 @@
     \uses{thm:vertical_cf_of_grouping_and_gram_dressing,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries,
         thm:cpsv_literal_pairwise_vertical_gram_conjugation}
+    % Preserve the established source-facing anchors while the wrapper proof
+    % now follows the three declarations used by Lean.
+    \label{eq:cpsv_prop_4_13_active_bnt}
+    \label{eq:cpsv_prop_4_13_active_reconstruction}
+    \label{eq:cpsv_prop_4_13_original_coisometry}
+    \label{eq:cpsv_prop_4_13_first_site}
+    \label{eq:cpsv_prop_4_13_active_separation}
+    \label{eq:cpsv_prop_4_13_projector_closure}
+    \label{eq:cpsv_prop_4_13_normal_corners}
+    \label{eq:cpsv_prop_4_13_gram_conjugation}
+    \label{eq:cpsv_prop_4_13_gram}
     Theorem~\ref{thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
-    supplies normal representatives $C_\alpha$, positive grouped weights,
-    physical isometries, and invertible gauges. In the grouped coordinates,
-    \begin{align}
-        \bigoplus_\ell\mu_\ell A_\ell^i
-        &=GT_{\mathrm{grp}}^iG^{-1},
-        \label{eq:cpsv_prop_4_13_active_bnt}
-    \end{align}
-    while the original coordinates satisfy
-    \begin{align}
-        A^i&=V^\dagger GT_{\mathrm{grp}}^iG^{-1}V,
-        \label{eq:cpsv_prop_4_13_active_reconstruction}
-    \end{align}
-    and
-    \begin{align}
-        VV^\dagger&=\Id.
-        \label{eq:cpsv_prop_4_13_original_coisometry}
-    \end{align}
-    Let $P$ be an orthogonal projector satisfying
-    $P\widetilde M=P\widetilde MP$, and let $P_1$ act on the first site.
-    Positivity gives
-    \begin{align}
-        P_1H^{(N)}
-        &=P_1H^{(N)}P_1
-          =(P_1H^{(N)}P_1)^\dagger
-          =H^{(N)}P_1.
-        \label{eq:cpsv_prop_4_13_first_site}
-    \end{align}
-    The grouped separation statement is
-    \begin{align}
-        Y_R(P)C_\alpha^i&=Y_C(P)C_\alpha^i,
-        \label{eq:cpsv_prop_4_13_active_separation}
-    \end{align}
-    and hence
-    \begin{align}
-        \widetilde MP&=P\widetilde MP.
-        \label{eq:cpsv_prop_4_13_projector_closure}
-    \end{align}
-    Exclusion of periodic sectors therefore yields normal vertical corners
-    $B_k$ and orthogonal isometries $V_k$ with
-    \begin{align}
-        \widetilde M_vV_k&=V_k(\nu_kB_k^v),
-        \notag\\
-        V_k^\dagger\widetilde M_v&=(\nu_kB_k^v)V_k^\dagger,
-        \notag\\
-        \widetilde M_v&=\sum_kV_k(\nu_kB_k^v)V_k^\dagger.
-        \label{eq:cpsv_prop_4_13_normal_corners}
-    \end{align}
+    supplies the grouped vertical BNT decomposition with physical isometries.
     The literal pairwise Figure~8 theorem supplies the grouped-corner
-    Gram-dressing property. Thus
-    Theorem~\ref{thm:vertical_cf_of_grouping_and_gram_dressing} applies. In
-    particular, its Gram step gives
-    \begin{align}
-        (X_{\alpha,k}^\dagger X_{\alpha,k})M_\alpha^v
-        (X_{\alpha,k}^\dagger X_{\alpha,k})^{-1}
-        &=M_\alpha^v,
-        \label{eq:cpsv_prop_4_13_gram_conjugation}
-    \end{align}
-    and a real number $\omega_{\alpha,k}>0$ such that
-    \begin{align}
-        X_{\alpha,k}^\dagger X_{\alpha,k}
-        &=\omega_{\alpha,k}\Id.
-        \label{eq:cpsv_prop_4_13_gram}
-    \end{align}
-    Normalizing these gauges and assembling the orthogonal grouped sectors
-    gives the three identities in the statement.
+    Gram-dressing property. Apply
+    Theorem~\ref{thm:vertical_cf_of_grouping_and_gram_dressing}.
 \end{proof}
 
 % The literal theorem above and the stronger horizontal theorem below are

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -546,7 +546,7 @@
     scalar per site. There are normal representatives $M_\alpha$, an enumeration
     $k=(\alpha,q)$ of the original sectors, invertible matrices
     $X_{\alpha,q}$, and complex numbers $\zeta_{\alpha,q}$ of unit modulus,
-    with $X_{\alpha,1}=\Id$ and $\zeta_{\alpha,1}=1$, such that
+    with $X_{\alpha,0}=\Id$ and $\zeta_{\alpha,0}=1$, such that
     \begin{align}
         B_{\alpha,q}^v
         &=\zeta_{\alpha,q}X_{\alpha,q}
@@ -613,7 +613,7 @@
     scalar per site. There are normal representatives $M_\alpha$, an enumeration
     $k=(\alpha,q)$ of the original sectors, invertible matrices
     $X_{\alpha,q}$, and complex numbers $\zeta_{\alpha,q}$ of unit modulus,
-    with $X_{\alpha,1}=\Id$ and $\zeta_{\alpha,1}=1$, such that
+    with $X_{\alpha,0}=\Id$ and $\zeta_{\alpha,0}=1$, such that
     \begin{align}
         B_{\alpha,q}^v
         &=\zeta_{\alpha,q}X_{\alpha,q}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -504,7 +504,7 @@
     Let $k=(\alpha,q)$ be the phase-class enumeration. There are equalities of
     the representative and copy bond dimensions, invertible gauges
     $X_{\alpha,q}$, and nonzero phases $\zeta_{\alpha,q}$ of unit modulus,
-    with $X_{\alpha,1}=\Id$ and $\zeta_{\alpha,1}=1$, such that
+    with $X_{\alpha,0}=\Id$ and $\zeta_{\alpha,0}=1$, such that
     \begin{align}
         B_{\alpha,q}^v
         &=\zeta_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -916,6 +916,40 @@
 % Local fix (rectangular coisometry and reconstruction): the source calls U an
 % isometry and prints only the compressed identity. See
 % docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex.
+\begin{theorem}[Vertical canonical form from grouped sectors and Gram dressing]
+    \label{thm:vertical_cf_of_grouping_and_gram_dressing}
+    \lean{MPOTensor.verticalCF_of_grouping_and_gramDressing}
+    \leanok
+    \uses{def:grouped_corner_gram_dressing,
+        thm:grouped_sector_gram_scalar_of_dressing,
+        thm:mpdo_vertical_grouped_is_bnt,
+        thm:mpdo_normalized_grouped_sector_maps,
+        thm:vertical_cf_of_grouped_orthogonal_sectors}
+    Suppose the vertical tensor $\widetilde M$ has a phase-class grouping into
+    normal representatives $M_\alpha$, positive effective weights
+    $c_{\alpha,q}$, and pairwise orthogonal physical corners with exact
+    reconstruction. Assume that the representatives form a BNT, that the
+    distinguished gauge in each class is the identity, and that $M$ has the
+    grouped-corner Gram-dressing property. Then $M$ is in vertical canonical
+    form.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:grouped_sector_gram_scalar_of_dressing,
+        thm:mpdo_vertical_grouped_is_bnt,
+        thm:mpdo_normalized_grouped_sector_maps,
+        thm:vertical_cf_of_grouped_orthogonal_sectors}
+    Theorem~\ref{thm:grouped_sector_gram_scalar_of_dressing} gives
+    $X_{\alpha,q}^\dagger X_{\alpha,q}=\omega_{\alpha,q}\Id$ with
+    $\omega_{\alpha,q}>0$. Absorb
+    $\omega_{\alpha,q}^{-1/2}X_{\alpha,q}$ into the physical corner maps.
+    The normalized maps are isometries with orthogonal ranges, intertwine
+    $\widetilde M$ with the undressed representatives, and preserve the exact
+    reconstruction. The grouped representatives form a BNT, so
+    Theorem~\ref{thm:vertical_cf_of_grouped_orthogonal_sectors} gives the
+    vertical canonical form.
+\end{proof}
+
 \begin{theorem}[Vertical canonical form of a canonical MPDO]
     \label{thm:vertical_cf_of_cpsv_canonical_form}
     \lean{MPOTensor.verticalCF_of_cpsvCanonicalForm}
@@ -953,62 +987,30 @@
     including the permitted zero orthogonal complement.
 \end{theorem}
 
-\begin{proof}[Proof outline]
+\begin{proof}
     \leanok
-    \uses{thm:cpsv_canonical_form_active_bnt_refinement,
-        thm:cpsv_active_representative_sector_decomposition,
-        thm:cpsv_full_coordinate_marked_trace_identity,
-        thm:cpsv_retained_representative_grouped_lemma_l,
-        thm:cpsv_original_coordinate_marked_lemma_l,
-        thm:mpdo_vertical_projector_closure_literal_cpsv,
-        thm:mpdo_vertical_no_periodic_vectors_literal_cpsv,
-        thm:mpdo_literal_normal_vertical_corners,
+    \uses{thm:vertical_cf_of_grouping_and_gram_dressing,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries,
-        thm:cpsv_literal_grouped_sector_gram_conjugation,
-        thm:cpsv_literal_grouped_sector_unitary_normalization,
-        thm:cpsv_literal_normalized_grouped_sector_maps,
-        thm:mpdo_vertical_grouped_is_bnt,
-        thm:vertical_cf_of_grouped_orthogonal_sectors}
-    Write $A$ for the doubled-index MPS tensor of $M$. If $A=0$, take no
-    retained sectors; the unique map onto the zero-dimensional sector space
-    gives the conclusion. Suppose henceforth that $A\ne0$. Apply
-    Theorem~\ref{thm:cpsv_canonical_form_active_bnt_refinement} to its literal
-    canonical-form data. The active listed indices are identified with pairs
-    $(\alpha,k)$ consisting of a phase class and a copy, and every active copy
-    retains its original nonzero coefficient $\nu_{\alpha,k}$, its bond
-    dimension, a unit phase, and an invertible gauge $X_{\alpha,k}$. The
-    chosen tensors $C_\alpha$ form a basis of normal tensors. Adjoin the
-    inactive zero-weight indices to these pairs and call the resulting grouped
-    index set $\mathcal G$. There is an explicit equivalence from the dependent
-    coordinates of $\mathcal G$ to the original flattened listed coordinates.
-    If $T_{\mathrm{grp}}$ is the grouped direct sum, reindexed along this
-    equivalence, then there are a block-diagonal gauge $G$ and the original
-    coisometry $V$ such that
+        thm:cpsv_literal_pairwise_vertical_gram_conjugation}
+    Theorem~\ref{thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
+    supplies normal representatives $C_\alpha$, positive grouped weights,
+    physical isometries, and invertible gauges. In the grouped coordinates,
     \begin{align}
         \bigoplus_\ell\mu_\ell A_\ell^i
         &=GT_{\mathrm{grp}}^iG^{-1},
         \label{eq:cpsv_prop_4_13_active_bnt}
     \end{align}
-    and
+    while the original coordinates satisfy
     \begin{align}
-        A^i&=V^\dagger GT_{\mathrm{grp}}^iG^{-1}V.
+        A^i&=V^\dagger GT_{\mathrm{grp}}^iG^{-1}V,
         \label{eq:cpsv_prop_4_13_active_reconstruction}
     \end{align}
+    and
     \begin{align}
         VV^\dagger&=\Id.
         \label{eq:cpsv_prop_4_13_original_coisometry}
     \end{align}
-    The active summands of $T_{\mathrm{grp}}$ are
-    $\nu_{\alpha,k}\zeta_{\alpha,k}C_\alpha^i$, with
-    $|\zeta_{\alpha,k}|=1$. Every inactive summand is the original listed block
-    with coefficient zero. Thus the grouped coordinates are exact without
-    deleting the inactive complement or introducing a selecting coisometry.
-
-    Let $H^{(N)}$ be the positive operator generated horizontally by
-    $\widetilde M$. If
-    an orthogonal projector $P$ on the physical space satisfies
-    $P\widetilde M=P\widetilde MP$, and $P_1$ acts on the first site, then
-    self-adjointness gives
+    For a reducing projector $P$ on the first site, positivity gives
     \begin{align}
         P_1H^{(N)}
         &=P_1H^{(N)}P_1
@@ -1016,46 +1018,18 @@
           =H^{(N)}P_1.
         \label{eq:cpsv_prop_4_13_first_site}
     \end{align}
-    Write $Y_R(P)$ and $Y_C(P)$ for the right and central first-site
-    contractions determined by $P$. The active representative sector
-    decomposition has weights
-    $\lambda_{\alpha,k}=\nu_{\alpha,k}\zeta_{\alpha,k}$, all nonzero, and its
-    representatives have simultaneous word-tuple separation at every
-    sufficiently large length. It has the same matrix product vectors as
-    $T_{\mathrm{grp}}$ at every positive length. Hence
-    Theorem~\ref{thm:cpsv_retained_representative_grouped_lemma_l} gives
+    The grouped separation statement is
     \begin{align}
-        Y_R(P)C_\alpha^i&=Y_C(P)C_\alpha^i
+        Y_R(P)C_\alpha^i&=Y_C(P)C_\alpha^i,
         \label{eq:cpsv_prop_4_13_active_separation}
     \end{align}
-    on every active representative. Theorem~\ref{thm:cpsv_original_coordinate_marked_lemma_l}
-    then uses the listed block gauge and the ambient coisometry, with
-    $VV^\dagger=\Id$, to give the original-space inserted-tensor equality.
-    Theorem~\ref{thm:mpdo_vertical_projector_closure_literal_cpsv} therefore
-    yields
+    and hence
     \begin{align}
         \widetilde MP&=P\widetilde MP.
         \label{eq:cpsv_prop_4_13_projector_closure}
     \end{align}
-    Thus every one-sided invariant subspace is reducing. The inactive listed
-    coordinates remain present with weight zero throughout this argument; no
-    insertion identity is asserted for an individual inactive block.
-
-    % Local fix (periodic-sector quantifier): use one noncommuting chain length,
-    % not the all-length assertion printed in the source. See
-    % docs/paper-gaps/cpgsv17_periodic_sector_projector.tex.
-    Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors_literal_cpsv}
-    excludes nontrivial periodic vertical sectors. Its proof uses the
-    displaced cyclic projector $Q$ and one length $N+1$ for which
-    $Q_1H^{(N+1)}\ne H^{(N+1)}Q_1$; full-period invariance gives commutation
-    with $[H^{(N+1)}]^p$, and positivity gives the contradictory commutation
-    with $H^{(N+1)}$ itself.
-
-    Combining this exclusion with invariant-projector closure gives the
-    normal corners of
-    Theorem~\ref{thm:mpdo_literal_normal_vertical_corners}. Thus there are
-    positive weights $\nu_k$, normal tensors $B_k$, and isometries $V_k$ with
-    pairwise orthogonal ranges such that
+    Exclusion of periodic sectors therefore yields normal vertical corners
+    $B_k$ and orthogonal isometries $V_k$ with
     \begin{align}
         \widetilde M_vV_k&=V_k(\nu_kB_k^v),
         \notag\\
@@ -1064,55 +1038,24 @@
         \widetilde M_v&=\sum_kV_k(\nu_kB_k^v)V_k^\dagger.
         \label{eq:cpsv_prop_4_13_normal_corners}
     \end{align}
-    This completes periodic exclusion and the normal vertical block
-    decomposition under the literal canonical-form hypothesis.
-
-    Theorem~\ref{thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
-    groups these normal corners into actual vertical representative families
-    over tensors $M_\alpha$. It retains the physical isometries, both
-    intertwining identities, exact corner compression, and the literal
-    reconstruction. Every effective coefficient
-    $\mu_{\alpha,k}=\nu_{\alpha,k}\zeta_{\alpha,k}$ is positive. Thus the
-    phase-class grouping and the positivity argument of source
-    lines~1898--1902 are complete under the literal canonical-form hypothesis.
-
-    On these actual grouped corners,
-    Theorem~\ref{thm:cpsv_literal_grouped_sector_gram_conjugation} gives
+    The literal pairwise Figure~8 theorem supplies the grouped-corner
+    Gram-dressing property. Thus
+    Theorem~\ref{thm:vertical_cf_of_grouping_and_gram_dressing} applies. In
+    particular, its Gram step gives
     \begin{align}
         (X_{\alpha,k}^\dagger X_{\alpha,k})M_\alpha^v
         (X_{\alpha,k}^\dagger X_{\alpha,k})^{-1}
-        &=M_\alpha^v.
+        &=M_\alpha^v,
         \label{eq:cpsv_prop_4_13_gram_conjugation}
     \end{align}
-    Theorem~\ref{thm:cpsv_literal_grouped_sector_unitary_normalization}
-    then gives a real number $\omega_{\alpha,k}>0$ such that
+    and a real number $\omega_{\alpha,k}>0$ such that
     \begin{align}
         X_{\alpha,k}^\dagger X_{\alpha,k}
-        &=\omega_{\alpha,k}\Id,
+        &=\omega_{\alpha,k}\Id.
         \label{eq:cpsv_prop_4_13_gram}
     \end{align}
-    and $\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$ is unitary. These are the
-    actual-grouped Figure~8 and gauge-normalization conclusions of
-    Proposition~4.13. They are distinct from the tensor-attached two-site
-    marked problem in Appendix~C.4.
-
-    Theorem~\ref{thm:cpsv_literal_normalized_grouped_sector_maps} absorbs
-    these unitary bond gauges into the mutually orthogonal physical sector
-    maps. The resulting maps intertwine $\widetilde M$ with the undressed
-    representatives and reconstruct every vertical letter exactly.
-    Theorem~\ref{thm:mpdo_vertical_grouped_is_bnt} identifies the
-    representatives as a basis of normal tensors for
-    $\widetilde M$. Taking the adjoints of the normalized sector maps as the
-    block-row map $U$, Theorem~\ref{thm:vertical_cf_of_grouped_orthogonal_sectors}
-    gives
-    (\ref{eq:cpsv_prop_4_13_coisometry}), and the sector intertwinings give
-    (\ref{eq:cpsv_prop_4_13_vertical_form}). Invariant-projector closure makes
-    the retained support reducing, while the complement is the all-zero
-    sector. Summing the sector reconstructions therefore gives the exact
-    identity (\ref{eq:cpsv_prop_4_13_reconstruction}).
-
-    The preceding paragraphs recast the source proof on the active retained
-    coordinates required by the literal canonical-form definition.
+    Normalizing these gauges and assembling the orthogonal grouped sectors
+    gives the three identities in the statement.
 \end{proof}
 
 % The literal theorem above and the stronger horizontal theorem below are
@@ -1150,41 +1093,11 @@
 
 \begin{proof}
     \leanok
-    \uses{def:mpv_phase_class_data,
+    \uses{thm:vertical_cf_of_grouping_and_gram_dressing,
         thm:mpdo_vertical_bnt_grouping_with_isometries,
-        thm:mpdo_vertical_grouped_is_bnt,
-        thm:mpdo_normalized_grouped_sector_maps,
-        thm:vertical_cf_of_grouped_orthogonal_sectors}
-    Apply
-    Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries} once and keep
-    its representatives $M_\alpha$, multiplicities $r_\alpha$, exact
-    positive weights $\mu_{\alpha,q}$, and physical sector maps. For these
-    same witnesses,
-    Theorem~\ref{thm:mpdo_vertical_grouped_is_bnt} proves that
-    $\{M_\alpha\}_\alpha$ is a BNT for $\widetilde M$.
-
-    Theorem~\ref{thm:mpdo_normalized_grouped_sector_maps} absorbs each
-    normalized bond gauge into its physical map and gives maps
-    $W_{\alpha,q}$ such that
-    \begin{align}
-        W_{\alpha,q}^\dagger W_{\alpha,q}&=\Id,
-        \notag\\
-        W_{\alpha,q}^\dagger W_{\beta,p}&=0
-        \quad((\alpha,q)\ne(\beta,p)),
-        \notag\\
-        \widetilde M_vW_{\alpha,q}
-        &=W_{\alpha,q}(\mu_{\alpha,q}M_\alpha^v),
-        \notag\\
-        \widetilde M_v
-        &=\sum_\alpha\sum_q
-          W_{\alpha,q}(\mu_{\alpha,q}M_\alpha^v)
-          W_{\alpha,q}^\dagger.
-        \notag
-    \end{align}
-    The canonical equivalence between the dependent disjoint union
-    $\coprod_\alpha\{0,\ldots,r_\alpha-1\}$ and its standard finite index
-    set reindexes the nested reconstruction sum without changing any weight
-    or sector. The hypotheses of
-    Theorem~\ref{thm:vertical_cf_of_grouped_orthogonal_sectors} now hold, and
-    that theorem gives the vertical canonical form of $M$.
+        thm:mpdo_pairwise_vertical_gram_conjugation}
+    Theorem~\ref{thm:mpdo_vertical_bnt_grouping_with_isometries} supplies the
+    grouped vertical decomposition. The pairwise Figure~8 theorem supplies
+    its grouped-corner Gram-dressing property. Apply
+    Theorem~\ref{thm:vertical_cf_of_grouping_and_gram_dressing}.
 \end{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -262,10 +262,18 @@
     \end{align}
     The matrix coefficients of
     (\ref{eq:cpsv_literal_first_site_commutation}) give agreement of the
-    corresponding first-site actions. The original-coordinate marked
-    Lemma~L gives equality of their inserted tensors on the original bond
-    space. Reading this equality as a vertical one-site action yields
-    (\ref{eq:cpsv_literal_vertical_projector_closure}).
+    corresponding first-site actions. In particular,
+    \begin{align}
+        P_1H^{(N)}&=H^{(N)}P_1.
+        \label{eq:cpsv_prop_4_13_first_site}
+    \end{align}
+    The original-coordinate marked Lemma~L gives equality of their inserted
+    tensors on the original bond space. Reading this equality as a vertical
+    one-site action yields
+    \begin{align}
+        \widetilde M_vP&=P\widetilde M_vP.
+        \label{eq:cpsv_prop_4_13_projector_closure}
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Invariant vertical projections are reducing]
@@ -463,8 +471,13 @@
     its nontrivial periodic vectors. Applying
     Theorem~\ref{thm:projector_closure_canonical_form} then gives normal
     nonzero corners with positive spectral weights and orthogonal isometries,
-    together with the stated intertwining, compression, and reconstruction
-    formulas.
+    together with the stated intertwining and compression formulas. Their
+    reconstruction is
+    \begin{align}
+        \widetilde M_v
+        &=\sum_kV_k(\nu_kB_k^v)V_k^\dagger.
+        \label{eq:cpsv_prop_4_13_normal_corners}
+    \end{align}
 \end{proof}
 
 \begin{definition}[Grouped vertical BNT decomposition with physical isometries]
@@ -1043,17 +1056,6 @@
     \uses{thm:vertical_cf_of_grouping_and_gram_dressing,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries,
         thm:cpsv_literal_pairwise_vertical_gram_conjugation}
-    % Preserve the established source-facing anchors while the wrapper proof
-    % now follows the three declarations used by Lean.
-    \label{eq:cpsv_prop_4_13_active_bnt}
-    \label{eq:cpsv_prop_4_13_active_reconstruction}
-    \label{eq:cpsv_prop_4_13_original_coisometry}
-    \label{eq:cpsv_prop_4_13_first_site}
-    \label{eq:cpsv_prop_4_13_active_separation}
-    \label{eq:cpsv_prop_4_13_projector_closure}
-    \label{eq:cpsv_prop_4_13_normal_corners}
-    \label{eq:cpsv_prop_4_13_gram_conjugation}
-    \label{eq:cpsv_prop_4_13_gram}
     Theorem~\ref{thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
     supplies the grouped vertical BNT decomposition with physical isometries.
     The literal pairwise Figure~8 theorem supplies the grouped-corner

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -1010,7 +1010,9 @@
         VV^\dagger&=\Id.
         \label{eq:cpsv_prop_4_13_original_coisometry}
     \end{align}
-    For a reducing projector $P$ on the first site, positivity gives
+    Let $P$ be an orthogonal projector satisfying
+    $P\widetilde M=P\widetilde MP$, and let $P_1$ act on the first site.
+    Positivity gives
     \begin{align}
         P_1H^{(N)}
         &=P_1H^{(N)}P_1

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -76,7 +76,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L730, 736 `tenkz` → `P-grid` | — | — |
+| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L747, 753 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | L17, 126, 373, 377 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -76,7 +76,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L747, 753 `tenkz` → `P-grid` | — | — |
+| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L748, 754 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | L17, 126, 373, 377 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -76,7 +76,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L638, 644 `tenkz` → `P-grid` | — | — |
+| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L730, 736 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | L17, 126, 373, 377 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -76,7 +76,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L745, 751 `tenkz` → `P-grid` | — | — |
+| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L747, 753 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | L17, 126, 373, 377 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -76,7 +76,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |
-| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L747, 753 `tenkz` → `P-grid` | — | — |
+| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | L745, 751 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_foundations.tex` | L17, 126, 373, 377 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_algebra_tower.tex` | L79, 95 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | L19, 24 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- add Blueprint nodes for the shared grouped-corner Gram dressing predicate, conjugation theorem, scalar-rigidity theorem, and vertical canonical-form construction;
- move the common grouped-sector argument and dependencies to those nodes;
- shorten the literal CPSV and stronger horizontal wrappers to match their Lean proofs;
- state the literal wrapper with the noncircular one-sided invariant-projector premise.

All existing source-facing labels, statements, Lean tags, and readiness markers are preserved. Literal `IsCPSVCanonicalForm` and stronger `IsHorizontalCF` remain distinct.

## Validation

- fresh Blueprint declarations and `checkdecls`;
- CI-mode sync: 7,235/7,235 entries;
- Blueprint web build;
- LuaLaTeX: stable at 971 pages with zero undefined cross-references;
- source-label, tag-resolution, and `git diff --check` gates;
- independent exact-head Blueprint review: approved after correcting one circular phrase.

Closes #6103
Advances #6096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Blueprint TeX with preserved labels and Lean tags; no runtime or proof-code changes in the diff.
> 
> **Overview**
> The Blueprint **groups the shared Proposition 4.13 Gram argument** into reusable nodes that mirror the Lean `GroupedSectorGram` layer, instead of repeating the same steps inside each wrapper.
> 
> **New kernels:** `def:grouped_corner_gram_dressing`, conjugation and scalar-rigidity theorems, `def:normalized_grouped_sector_map`, normalized maps from Gram scalars, and `thm:vertical_cf_of_grouping_and_gram_dressing`. **Grouped vertical BNT data** is spelled out in `def:vertical_bnt_grouping_with_isometry`.
> 
> **Wrappers shortened:** literal CPSV and BNT-refined horizontal vertical-CF theorems now cite grouping + pairwise Figure 8 + the new construction theorem; long inlined proof outlines are removed. Gram conjugation, unitary normalization, and normalized sector maps delegate to the shared kernels.
> 
> **Notation:** distinguished copy index is **`X_{\alpha,0}`** (replacing `1`) in sector-weight and Figure 8 text. **Labels** for Cirac Prop. 4.13 identities are added where proofs were tightened. **tenkz** line refs in `DISPOSITIONS.md` are updated for the gram-normalization chapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb1f2ce9b26d6136523e5728e082194163184ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->