### PR TITLE
feat(MPS): bridge normalized CPSV canonical forms to active SectorBNT

### DIFF
--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.MPS.CanonicalForm
 
 import TNLean.MPS.CanonicalForm.ActiveBNTRefinement
+import TNLean.MPS.CanonicalForm.ActiveBlocks
 import TNLean.MPS.CanonicalForm.BNTCharacterization
 import TNLean.MPS.CanonicalForm.BNTExistence
 import TNLean.MPS.CanonicalForm.BNTGrouping

--- a/TNLean/MPS/CanonicalForm/ActiveBNTRefinement.lean
+++ b/TNLean/MPS/CanonicalForm/ActiveBNTRefinement.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.CanonicalForm.ActiveBlocks
 import TNLean.MPS.CanonicalForm.BNTCharacterization
 import TNLean.MPS.SharedInfra.BlockGauge
 
@@ -35,26 +36,6 @@ namespace MPSTensor
 variable {d D : ℕ} {A : MPSTensor d D}
 
 namespace CPSVCanonicalFormData
-
-/-- A finite enumeration of the nonzero-weight displayed blocks. -/
-noncomputable def activeEquiv (data : CPSVCanonicalFormData A) :
-    Fin (Fintype.card data.Active) ≃ data.Active :=
-  (Fintype.equivFin data.Active).symm
-
-/-- Bond dimensions of the enumerated active blocks. -/
-noncomputable def activeDim (data : CPSVCanonicalFormData A) :
-    Fin (Fintype.card data.Active) → ℕ :=
-  fun k => data.dim (data.activeEquiv k)
-
-/-- Weights of the enumerated active blocks. -/
-noncomputable def activeWeight (data : CPSVCanonicalFormData A) :
-    Fin (Fintype.card data.Active) → ℂ :=
-  fun k => data.weights (data.activeEquiv k)
-
-/-- Normal tensors of the enumerated active blocks. -/
-noncomputable def activeBlocks (data : CPSVCanonicalFormData A) :
-    (k : Fin (Fintype.card data.Active)) → MPSTensor d (data.activeDim k) :=
-  fun k => data.blocks (data.activeEquiv k)
 
 /-- MPV phase classes of the active canonical-form blocks. -/
 noncomputable def activePhaseClasses (data : CPSVCanonicalFormData A) :

--- a/TNLean/MPS/CanonicalForm/ActiveBlocks.lean
+++ b/TNLean/MPS/CanonicalForm/ActiveBlocks.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinSum
+import TNLean.MPS.CanonicalForm.Definitions
+
+/-!
+# Active blocks of a CPSV canonical form
+
+This module restricts a literal CPSV canonical-form decomposition to the displayed blocks with
+nonzero weight. Zero-weight blocks do not contribute to any positive-length matrix product
+vector.
+
+Source: arXiv:1606.00608, lines 237--301 and 1135--1146; arXiv:2011.12127,
+lines 1831--1885.
+-/
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+namespace CPSVCanonicalFormData
+
+/-- A finite enumeration of the nonzero-weight displayed blocks. -/
+noncomputable def activeEquiv (data : CPSVCanonicalFormData A) :
+    Fin (Fintype.card data.Active) ≃ data.Active :=
+  (Fintype.equivFin data.Active).symm
+
+/-- Bond dimensions of the enumerated active blocks. -/
+noncomputable def activeDim (data : CPSVCanonicalFormData A) :
+    Fin (Fintype.card data.Active) → ℕ :=
+  fun k => data.dim (data.activeEquiv k)
+
+/-- Weights of the enumerated active blocks. -/
+noncomputable def activeWeight (data : CPSVCanonicalFormData A) :
+    Fin (Fintype.card data.Active) → ℂ :=
+  fun k => data.weights (data.activeEquiv k)
+
+/-- Normal tensors of the enumerated active blocks. -/
+noncomputable def activeBlocks (data : CPSVCanonicalFormData A) :
+    (k : Fin (Fintype.card data.Active)) → MPSTensor d (data.activeDim k) :=
+  fun k => data.blocks (data.activeEquiv k)
+
+end CPSVCanonicalFormData
+
+/-- Removing zero-weight blocks preserves every positive-length matrix product vector.
+
+Source: arXiv:1606.00608, eq. `II_CF1`, lines 237--246 and 271--301. -/
+theorem sameMPV₂Pos_toTensorFromBlocks_active
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (e : Fin (Fintype.card {k : Fin r // μ k ≠ 0}) ≃ {k : Fin r // μ k ≠ 0}) :
+    SameMPV₂Pos (toTensorFromBlocks (d := d) μ blocks)
+      (toTensorFromBlocks (d := d) (fun k => μ (e k)) (fun k => blocks (e k))) := by
+  classical
+  intro N hN σ
+  rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+  simp only [smul_eq_mul]
+  let f : Fin r → ℂ := fun k => μ k ^ N * mpv (blocks k) σ
+  have hInactive : ∑ k : {k : Fin r // ¬ μ k ≠ 0}, f k = 0 := by
+    apply Fintype.sum_eq_zero
+    intro k
+    simp [f, not_ne_iff.mp k.property, Nat.ne_of_gt hN]
+  have hSplit :=
+    Fintype.sum_subtype_add_sum_subtype (fun k : Fin r => μ k ≠ 0) f
+  have hActiveSum : (∑ k : Fin r, f k) = ∑ k : {k : Fin r // μ k ≠ 0}, f k := by
+    rw [hInactive, add_zero] at hSplit
+    exact hSplit.symm
+  change (∑ k : Fin r, f k) =
+    ∑ k : Fin (Fintype.card {k : Fin r // μ k ≠ 0}), f (e k)
+  rw [hActiveSum]
+  exact (e.sum_comp (fun k : {k : Fin r // μ k ≠ 0} => f k)).symm
+
+namespace CPSVCanonicalFormData
+
+/-- Literal CPSV canonical-form data agree at every positive length with their active weighted
+block sum.
+
+This is the active part of the canonical-form and BNT decompositions in arXiv:1606.00608,
+lines 237--301 and 1135--1146, and arXiv:2011.12127, lines 1831--1885. -/
+theorem sameMPV₂Pos_activeBlocks (data : CPSVCanonicalFormData A) :
+    SameMPV₂Pos A
+      (toTensorFromBlocks (d := d) data.activeWeight data.activeBlocks) :=
+  data.sameMPV₂Pos_toTensorFromBlocks.trans <| by
+    change SameMPV₂Pos (toTensorFromBlocks (d := d) data.weights data.blocks)
+      (toTensorFromBlocks (d := d) (fun k => data.weights (data.activeEquiv k))
+        (fun k => data.blocks (data.activeEquiv k)))
+    exact sameMPV₂Pos_toTensorFromBlocks_active data.weights data.blocks data.activeEquiv
+
+end CPSVCanonicalFormData
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
+++ b/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.FinSum
+import TNLean.MPS.CanonicalForm.ActiveBlocks
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
 import TNLean.MPS.FundamentalTheorem.SectorWeightComparison
@@ -429,25 +429,10 @@ theorem isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal
     intro k
     exact (activeEquiv k).property
   have hActiveCF :
-      SameMPV₂Pos A (toTensorFromBlocks (d := d) μActive blocksActive) := by
-    intro N hN σ
-    rw [hCF N hN σ]
-    rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
-    simp only [smul_eq_mul]
-    let f : Fin r → ℂ := fun k ↦ μ k ^ N * mpv (blocks k) σ
-    have hInactive : ∑ k : {k : Fin r // ¬ μ k ≠ 0}, f k = 0 := by
-      apply Fintype.sum_eq_zero
-      intro k
-      simp [f, not_ne_iff.mp k.property, Nat.ne_of_gt hN]
-    have hSplit :=
-      Fintype.sum_subtype_add_sum_subtype (fun k : Fin r ↦ μ k ≠ 0) f
-    have hActiveSum : (∑ k : Fin r, f k) = ∑ k : Active, f k := by
-      rw [hInactive, add_zero] at hSplit
-      exact hSplit.symm
-    change (∑ k : Fin r, f k) =
-      ∑ k : Fin (Fintype.card Active), f (activeEquiv k)
-    rw [hActiveSum]
-    exact (activeEquiv.sum_comp (fun k : Active ↦ f k)).symm
+      SameMPV₂Pos A (toTensorFromBlocks (d := d) μActive blocksActive) :=
+    hCF.trans <| by
+      simpa only [μActive, blocksActive, dimActive] using
+        sameMPV₂Pos_toTensorFromBlocks_active μ blocks activeEquiv
   have hCharacterization :=
     isCPSVBasisOfNormalTensors_iff_active_blocks_covered_and_minimal
       A μActive blocksActive basis hActiveNormal hμActive hActiveCF

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Api
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Blocking
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormBridge
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
 import TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormBridge.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormBridge.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.ActiveBlocks
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.FundamentalTheorem.Multi
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier
+
+/-!
+# CPSV canonical forms as SectorBNT decompositions
+
+A normalized nonzero CPSV canonical form determines a SectorBNT decomposition of its active
+blocks. Each active normal block is first put into a trace-preserving gauge, after which the
+prepared-block constructor groups phase-equivalent copies into BNT sectors.
+
+Source: arXiv:2011.12127, lines 1831--1885; arXiv:1606.00608, lines 237--301 and
+1135--1146.
+-/
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+namespace CPSVCanonicalFormData
+
+/-- A normalized nonzero CPSV canonical form has a SectorBNT decomposition whose total bond
+dimension is the sum of its active block dimensions.
+
+The conclusion concerns only the active direct sum. Zero-weight displayed blocks and unused
+ambient coordinates do not contribute to this dimension.
+
+Source: arXiv:2011.12127, lines 1831--1885; arXiv:1606.00608, lines 237--301 and
+1135--1146. -/
+theorem exists_active_isBNTCanonicalForm
+    (data : CPSVCanonicalFormData A)
+    (hNorm : data.IsWeightNormalized)
+    (hA : A ≠ 0) :
+    ∃ P : SectorDecomposition d,
+      IsBNTCanonicalForm P ∧
+      SameMPV₂Pos A P.toTensor ∧
+      P.totalDim = ∑ k : data.Active, data.dim k.1 := by
+  classical
+  haveI : ∀ k, NeZero (data.activeDim k) :=
+    fun k => ⟨(data.dim_pos (data.activeEquiv k)).ne'⟩
+  choose σ hσ hσfix hTP hGauge hPrim hIrr using
+    fun k => (data.blocks_normal (data.activeEquiv k)).exists_tpGauge
+  let prepared := fun k => tpGauge (data.blocks (data.activeEquiv k)) (σ k)
+  have hDim : ∀ k, 0 < data.dim (data.activeEquiv k) := by
+    intro k
+    exact data.dim_pos (data.activeEquiv k)
+  have hPreparedTP : ∀ k, IsLeftCanonical (prepared k) := hTP
+  have hPreparedPrim : ∀ k, _root_.IsPrimitive (transferMap (prepared k)) := hPrim
+  have hPreparedIrr : ∀ k, IsIrreducibleTensor (prepared k) := hIrr
+  have hWeightNe : ∀ k, data.activeWeight k ≠ 0 := by
+    intro k
+    exact (data.activeEquiv k).property
+  have hWeightLe : ∀ k, ‖data.activeWeight k‖ ≤ 1 := by
+    intro k
+    exact hNorm.weight_norm_le_one (data.activeEquiv k)
+  have hWeightUnit : ∃ k, ‖data.activeWeight k‖ = 1 := by
+    obtain ⟨k, hk⟩ := hNorm.weight_unit_exists hA
+    have hkNe : data.weights k ≠ 0 := by
+      intro hkZero
+      simp [hkZero] at hk
+    let ka : data.Active := ⟨k, hkNe⟩
+    let l := data.activeEquiv.symm ka
+    refine ⟨l, ?_⟩
+    change ‖data.weights (data.activeEquiv l)‖ = 1
+    rw [show data.activeEquiv l = ka by simp [l]]
+    exact hk
+  have hDirectGauge :
+      GaugeEquiv
+        (toTensorFromBlocks (d := d) data.activeWeight data.activeBlocks)
+        (toTensorFromBlocks (d := d) data.activeWeight prepared) := by
+    apply gaugeEquiv_toTensorFromBlocks_of_blockGauge
+    intro k
+    simpa only [prepared, activeBlocks, activeDim] using hGauge k
+  have hActivePrepared :
+      SameMPV₂Pos
+        (toTensorFromBlocks (d := d) data.activeWeight data.activeBlocks)
+        (toTensorFromBlocks (d := d) data.activeWeight prepared) :=
+    fun N _hN w => GaugeEquiv.sameMPV hDirectGauge N w
+  obtain ⟨P, hPSame, hBNT, hTotal⟩ :=
+    exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks_and_totalDim
+      data.activeWeight prepared hDim hPreparedTP hPreparedPrim hPreparedIrr
+        hWeightNe hWeightLe hWeightUnit
+  refine ⟨P, hBNT, data.sameMPV₂Pos_activeBlocks.trans <|
+    hActivePrepared.trans hPSame.symm, ?_⟩
+  rw [hTotal]
+  exact data.activeEquiv.sum_comp (fun k : data.Active => data.dim k.1)
+
+end CPSVCanonicalFormData
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -290,15 +290,14 @@ theorem collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr
 **Prepared-block SectorBNT constructor.**
 
 Given a finite family of TP, primitive, irreducible blocks with nonzero weights
-satisfying the SectorBNT normalization conditions, produce a
-`SectorDecomposition P` and a proof that `IsBNTCanonicalForm P` and the
-assembled tensor agrees with the original direct sum.
+satisfying the SectorBNT normalization conditions, the phase-class-collapsed
+sector decomposition is in BNT canonical form.
 
 Paper anchor: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 271-279 and
 1135-1148 for prop:char-BNT, and lines 283-301 for the two-layer BNT/copy
 expansion.
 -/
-theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
+theorem isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor d (dim k))
@@ -309,9 +308,7 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
     (hμne : ∀ k, μ k ≠ 0)
     (hμLe : ∀ k, ‖μ k‖ ≤ 1)
     (hμUnit : ∃ k, ‖μ k‖ = 1) :
-    ∃ P : SectorDecomposition d,
-      SameMPV₂Pos P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
-      IsBNTCanonicalForm P := by
+    IsBNTCanonicalForm (collapsedBntSectorDecomp (d := d) μ blocks hμne) := by
   classical
   -- Promote `0 < dim k` to a `NeZero (dim k)` typeclass instance.
   haveI : ∀ k, NeZero (dim k) := fun k => ⟨(hDim k).ne'⟩
@@ -337,9 +334,6 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
         (hPrim (classes.repr j)) (hPrim (classes.enum j q))
         (hIrr (classes.repr j)) (hIrr (classes.enum j q))
         hPE
-  -- Same-MPV with the original direct-sum tensor.
-  have hSame : SameMPV₂Pos P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) :=
-    collapsedBntSectorDecomp_sameMPV₂Pos (d := d) μ blocks hμne
   -- HasBNTSectorData.
   have hBNT : HasBNTSectorData (d := d) P :=
     collapsedBntSectorDecomp_hasBNT (d := d) μ blocks hTP hIrr hPrim hμne
@@ -392,7 +386,6 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
     change ‖ζFn j q * μ (classes.enum j q)‖ = 1
     rw [hjq]
     rw [norm_mul, hζ_unit j q, one_mul, hk0]
-  refine ⟨P, hSame, ?_⟩
   exact
     { basis_dim_pos := h_dim_pos
       basis_irreducible := h_irr
@@ -402,6 +395,56 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
       basis_distinct := h_distinct
       weight_norm_le_one := h_weight_le
       weight_unit_exists := h_weight_unit }
+
+/-- Prepared TP, primitive, irreducible blocks admit a BNT canonical-form sector decomposition
+with the same positive-length matrix product vectors.
+
+Source: arXiv:1606.00608, lines 237--301 and 1135--1148; arXiv:2011.12127,
+lines 1831--1885. -/
+theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hDim : ∀ k, 0 < dim k)
+    (hTP : ∀ k, IsLeftCanonical (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (blocks k)))
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hμLe : ∀ k, ‖μ k‖ ≤ 1)
+    (hμUnit : ∃ k, ‖μ k‖ = 1) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂Pos P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      IsBNTCanonicalForm P := by
+  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+  refine ⟨P, collapsedBntSectorDecomp_sameMPV₂Pos (d := d) μ blocks hμne, ?_⟩
+  exact isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks
+    μ blocks hDim hTP hPrim hIrr hμne hμLe hμUnit
+
+/-- Prepared TP, primitive, irreducible blocks admit a dimension-preserving BNT canonical-form
+sector decomposition.
+
+Source: arXiv:1606.00608, lines 237--301 and 1135--1148; arXiv:2011.12127,
+lines 1831--1885. -/
+theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks_and_totalDim
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hDim : ∀ k, 0 < dim k)
+    (hTP : ∀ k, IsLeftCanonical (blocks k))
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (blocks k)))
+    (hIrr : ∀ k, IsIrreducibleTensor (blocks k))
+    (hμne : ∀ k, μ k ≠ 0)
+    (hμLe : ∀ k, ‖μ k‖ ≤ 1)
+    (hμUnit : ∃ k, ‖μ k‖ = 1) :
+    ∃ P : SectorDecomposition d,
+      SameMPV₂Pos P.toTensor (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      IsBNTCanonicalForm P ∧ P.totalDim = ∑ k : Fin r, dim k := by
+  let P := collapsedBntSectorDecomp (d := d) μ blocks hμne
+  refine ⟨P, collapsedBntSectorDecomp_sameMPV₂Pos (d := d) μ blocks hμne, ?_, ?_⟩
+  · exact isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks
+      μ blocks hDim hTP hPrim hIrr hμne hμLe hμUnit
+  · exact collapsedBntSectorDecomp_totalDim_eq_sum_dim_of_tp_primitive_irr
+      μ blocks hDim hTP hPrim hIrr hμne
 
 /-! ### Arbitrary-input prepared-block supplier
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -396,8 +396,8 @@ theorem isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks
       weight_norm_le_one := h_weight_le
       weight_unit_exists := h_weight_unit }
 
-/-- Prepared TP, primitive, irreducible blocks admit a BNT canonical-form sector decomposition
-with the same positive-length matrix product vectors.
+/-- Prepared TP, primitive, irreducible blocks determine a BNT canonical-form sector
+decomposition with the same positive-length matrix product vectors.
 
 Source: arXiv:1606.00608, lines 237--301 and 1135--1148; arXiv:2011.12127,
 lines 1831--1885. -/
@@ -420,8 +420,8 @@ theorem exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks
   exact isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks
     μ blocks hDim hTP hPrim hIrr hμne hμLe hμUnit
 
-/-- Prepared TP, primitive, irreducible blocks admit a dimension-preserving BNT canonical-form
-sector decomposition.
+/-- Prepared TP, primitive, irreducible blocks determine a dimension-preserving BNT
+canonical-form sector decomposition.
 
 Source: arXiv:1606.00608, lines 237--301 and 1135--1148; arXiv:2011.12127,
 lines 1831--1885. -/

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -385,6 +385,66 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     Definition~\ref{def:bnt}; it is not part of canonical form itself.
 \end{definition}
 
+\begin{theorem}[Removing zero-weight blocks at positive length]%
+    \label{thm:cpsv_remove_zero_weight_blocks}
+    \lean{MPSTensor.sameMPV₂Pos_toTensorFromBlocks_active}
+    \leanok
+    \uses{def:same_mpv2_pos, def:block_diagonal_tensor,
+        thm:mpv_decomposition}
+    Let $(A_k)_{k=1}^r$ be blocks with weights $(\mu_k)_{k=1}^r$, and put
+    $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$. Then the full weighted direct sum and
+    the direct sum over $K_{\mathrm{act}}$ have the same matrix product vectors
+    at every positive length. Equivalently, for $N>0$ and every configuration
+    $\sigma$,
+    \begin{align}
+        \sum_{k=1}^r \mu_k^N V^{(N)}(A_k)_\sigma
+        &=\sum_{k\in K_{\mathrm{act}}}
+            \mu_k^N V^{(N)}(A_k)_\sigma.
+        \label{eq:cpsv_remove_zero_weight_blocks}
+    \end{align}
+    The restriction to positive lengths is essential: at length zero, a
+    zero-weight block contributes through $\mu_k^0=1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpv_decomposition}
+    Expand both matrix product vectors using
+    Theorem~\ref{thm:mpv_decomposition}. If $\mu_k=0$ and $N>0$, then
+    $\mu_k^N=0$. The inactive part of the finite sum therefore vanishes, and
+    reindexing the remaining terms by $K_{\mathrm{act}}$ gives
+    (\ref{eq:cpsv_remove_zero_weight_blocks}).
+\end{proof}
+
+\begin{theorem}[Active part of CPSV canonical form]%
+    \label{thm:cpsv_canonical_form_active_blocks}
+    \lean{MPSTensor.CPSVCanonicalFormData.activeEquiv,
+        MPSTensor.CPSVCanonicalFormData.activeDim,
+        MPSTensor.CPSVCanonicalFormData.activeWeight,
+        MPSTensor.CPSVCanonicalFormData.activeBlocks}
+    \lean{MPSTensor.CPSVCanonicalFormData.sameMPV₂Pos_activeBlocks}
+    \leanok
+    \uses{def:cpsv_canonical_form, thm:cpsv_remove_zero_weight_blocks}
+    Let $A$ have canonical-form data as in~(\ref{eq:cpsv_canonical_form}), and
+    put $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$. Then
+    \begin{align}
+        \mc{V}^+(A)
+        &=\mc{V}^+\!\left(
+            \bigoplus_{k\in K_{\mathrm{act}}}\mu_kA_k\right).
+        \label{eq:cpsv_active_blocks_same_mpv}
+    \end{align}
+    This conclusion uses no weight normalization. The bounds and unit-modulus
+    condition in~(\ref{eq:cpsv_weight_normalization}) remain separate
+    assumptions on the canonical-form data.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:cpsv_canonical_form, thm:cpsv_remove_zero_weight_blocks}
+    The canonical-form reconstruction first identifies the positive-length
+    matrix product vectors of $A$ with those of the full weighted block sum.
+    Theorem~\ref{thm:cpsv_remove_zero_weight_blocks} then removes precisely the
+    zero-weight summands.
+\end{proof}
+
 \begin{theorem}[Physical relabeling preserves CPSV normal and canonical form]
     \label{thm:cpsv_physical_reindexing}
     \lean{MPSTensor.IsNormalTensor.reindexPhysical}

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -730,37 +730,26 @@ form by quotienting gauge-phase-equivalent blocks into sectors.
     \label{thm:paperbnt_collapsed_prepared}
     \lean{MPSTensor.isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks}
     \leanok
-    \uses{def:mpv_phase_class_data, def:sector_bnt_cf,
-        thm:normal_tp_primitive_irred, thm:cpsv_normal_mpv_phase_gauge,
-        lem:sector_bnt_cross_overlap_basis_tendsto_zero}
+    \uses{def:mpv_phase_class_data, def:sector_bnt_cf}
     Let $(B_k)_{k=1}^r$ have positive bond dimensions and suppose that every
-    $B_k$ is trace-preserving, primitive, and irreducible. Let the weights
-    satisfy
-    \begin{align}
-        \mu_k&\ne0,
-        &|\mu_k|&\le1,
-        &\exists k_*,\ |\mu_{k_*}|&=1.
-        \notag
-    \end{align}
-    Partition the blocks into matrix-product-vector phase classes, choose one
+    $B_k$ is trace-preserving, primitive, and irreducible. Assume
+    $\mu_k\ne0$ and $|\mu_k|\le1$ for every $k$, and
+    $|\mu_{k_*}|=1$ for some $k_*$. Partition the blocks into
+    matrix-product-vector phase classes, choose one
     representative from each class, and retain every class member as a copy of
     its representative with the corresponding phase-adjusted weight. The
     resulting sector decomposition is in BNT canonical form.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpv_phase_class_data, def:sector_bnt_cf,
-        thm:normal_tp_primitive_irred, thm:cpsv_normal_mpv_phase_gauge,
-        lem:sector_bnt_cross_overlap_basis_tendsto_zero}
-    Trace preservation, primitivity, and irreducibility make every block
-    normal. Phase-equivalent blocks consequently have equal bond dimension,
-    and their phase scalar has unit modulus. Thus the phase adjustment preserves
-    the modulus of each weight. Distinct representatives are not
-    gauge-phase equivalent, their self-overlaps converge to $1$, and their
-    cross-overlaps tend to $0$. The resulting representative family is
-    eventually linearly independent, while the assumed weight bounds and the
-    maximizing block give the two normalization conditions in
-    Definition~\ref{def:sector_bnt_cf}.
+    \uses{def:mpv_phase_class_data, def:sector_bnt_cf}
+    The chosen representatives inherit irreducibility and trace preservation,
+    while primitivity gives normalized self-overlap. Distinct phase classes
+    give gauge-phase-distinct representatives. The collapsed phase-class
+    construction supplies the eventual linear independence and retains every
+    original block as one copy. Its phase multipliers have unit modulus, so the
+    adjusted weights preserve the assumed bounds and unit witness. These are
+    precisely the fields of Definition~\ref{def:sector_bnt_cf}.
 \end{proof}
 
 \begin{theorem}[BNT from normal blocks with normalized weights]%

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -898,8 +898,8 @@ give $O_{YX}(N)\to 0$, a contradiction.
     \end{align}
     Thus the dimension is the total dimension of the active blocks, not the
     ambient bond dimension $D$. No gauge equivalence on the original ambient
-    bond space is asserted; constructing such an ambient gauge is a separate
-    step in the renormalization-fixed-point argument.
+    bond space is asserted; such a gauge requires a separate extension over the
+    zero-weight blocks and unused ambient coordinates.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -726,6 +726,43 @@ form of Definition~\ref{def:sector_bnt_cf}.
 With the prepared blocks in hand, normalized weights produce a BNT canonical
 form by quotienting gauge-phase-equivalent blocks into sectors.
 
+\begin{theorem}[BNT canonical form of the phase-class quotient]%
+    \label{thm:paperbnt_collapsed_prepared}
+    \lean{MPSTensor.isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks}
+    \leanok
+    \uses{def:mpv_phase_class_data, def:sector_bnt_cf,
+        thm:normal_tp_primitive_irred, thm:cpsv_normal_mpv_phase_gauge,
+        lem:sector_bnt_cross_overlap_basis_tendsto_zero}
+    Let $(B_k)_{k=1}^r$ have positive bond dimensions and suppose that every
+    $B_k$ is trace-preserving, primitive, and irreducible. Let the weights
+    satisfy
+    \begin{align}
+        \mu_k&\ne0,
+        &|\mu_k|&\le1,
+        &\exists k_*,\ |\mu_{k_*}|&=1.
+        \notag
+    \end{align}
+    Partition the blocks into matrix-product-vector phase classes, choose one
+    representative from each class, and retain every class member as a copy of
+    its representative with the corresponding phase-adjusted weight. The
+    resulting sector decomposition is in BNT canonical form.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpv_phase_class_data, def:sector_bnt_cf,
+        thm:normal_tp_primitive_irred, thm:cpsv_normal_mpv_phase_gauge,
+        lem:sector_bnt_cross_overlap_basis_tendsto_zero}
+    Trace preservation, primitivity, and irreducibility make every block
+    normal. Phase-equivalent blocks consequently have equal bond dimension,
+    and their phase scalar has unit modulus. Thus the phase adjustment preserves
+    the modulus of each weight. Distinct representatives are not
+    gauge-phase equivalent, their self-overlaps converge to $1$, and their
+    cross-overlaps tend to $0$. The resulting representative family is
+    eventually linearly independent, while the assumed weight bounds and the
+    maximizing block give the two normalization conditions in
+    Definition~\ref{def:sector_bnt_cf}.
+\end{proof}
+
 \begin{theorem}[BNT from normal blocks with normalized weights]%
     \label{thm:paperbnt_supplier_prepared}
     \lean{MPSTensor.exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks}
@@ -808,6 +845,77 @@ give $O_{YX}(N)\to 0$, a contradiction.
     Theorem~\ref{thm:not_gauge_phase_eventually_not_proportional} would give a
     positive length $N$ at which the two MPV states are not proportional. This
     contradicts the assumed scalar-power identity at every positive length.
+\end{proof}
+
+\begin{theorem}[Dimension-preserving BNT form of prepared blocks]%
+    \label{thm:paperbnt_supplier_prepared_total_dim}
+    \lean{MPSTensor.exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks_and_totalDim}
+    \leanok
+    \uses{thm:paperbnt_collapsed_prepared,
+        thm:prepared_phase_equiv_gauge, def:sector_weight_data}
+    Under the hypotheses of
+    Theorem~\ref{thm:paperbnt_collapsed_prepared}, there is a BNT canonical-form
+    sector decomposition $P$ such that
+    \begin{align}
+        \mc{V}^+(P)
+        &=\mc{V}^+\!\left(\bigoplus_{k=1}^r\mu_kB_k\right),
+        \notag\\
+        D_{\mathrm{tot}}(P)
+        &=\sum_{k=1}^r D_k.
+        \label{eq:paperbnt_prepared_total_dim}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:paperbnt_collapsed_prepared,
+        thm:prepared_phase_equiv_gauge}
+    Use the phase-class sector decomposition from
+    Theorem~\ref{thm:paperbnt_collapsed_prepared}. Its flattened copies are in
+    bijection with the original blocks, and phase-equivalent blocks have equal
+    bond dimension by Theorem~\ref{thm:prepared_phase_equiv_gauge}. Summing the
+    copy dimensions over this bijection gives
+    (\ref{eq:paperbnt_prepared_total_dim}).
+\end{proof}
+
+\begin{theorem}[Active-sector BNT form of normalized CPSV canonical data]%
+    \label{thm:cpsv_active_sector_bnt}
+    \lean{MPSTensor.CPSVCanonicalFormData.exists_active_isBNTCanonicalForm}
+    \leanok
+    \uses{def:cpsv_canonical_form,
+        thm:cpsv_canonical_form_active_blocks,
+        thm:cpsv_normal_tp_gauge,
+        thm:paperbnt_supplier_prepared_total_dim}
+    Let $A$ have CPSV canonical-form data satisfying the separate normalization
+    condition~(\ref{eq:cpsv_weight_normalization}), and assume $A\ne0$. Put
+    $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$. Then there is a BNT canonical-form
+    sector decomposition $P$ such that
+    \begin{align}
+        \mc{V}^+(A)&=\mc{V}^+(P),
+        \notag\\
+        D_{\mathrm{tot}}(P)
+        &=\sum_{k\in K_{\mathrm{act}}}D_k.
+        \label{eq:cpsv_active_sector_total_dim}
+    \end{align}
+    Thus the dimension is the total dimension of the active blocks, not the
+    ambient bond dimension $D$. No gauge equivalence on the original ambient
+    bond space is asserted; constructing such an ambient gauge is a separate
+    step in the renormalization-fixed-point argument.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_canonical_form_active_blocks,
+        thm:cpsv_normal_tp_gauge,
+        thm:paperbnt_supplier_prepared_total_dim}
+    Put every active normal block into a trace-preserving primitive irreducible
+    gauge. Their direct sum has the same positive-length matrix product vectors
+    as the active block sum. The normalization bounds restrict to the active
+    weights. Since $A\ne0$, the separate normalization condition supplies an
+    index $k$ with $|\mu_k|=1$; this weight is nonzero, so $k\in
+    K_{\mathrm{act}}$. Apply
+    Theorem~\ref{thm:paperbnt_supplier_prepared_total_dim} to the gauged active
+    family, compose the positive-length MPV equalities with
+    Theorem~\ref{thm:cpsv_canonical_form_active_blocks}, and reindex the finite
+    dimension sum by the active indices.
 \end{proof}
 
 Combining the after-blocking preparation with the normalized-weight construction


### PR DESCRIPTION
## Summary

- expose the positive-length MPV equality obtained by deleting zero-weight canonical-form blocks
- replace the duplicate local active-block summation proof in the BNT characterization
- factor the prepared-block `SectorBNT` supplier into an explicit collapsed-decomposition theorem and add a total-dimension variant
- construct an active `IsBNTCanonicalForm` decomposition from normalized nonzero `CPSVCanonicalFormData`
- prove the resulting total dimension is exactly the sum of active block dimensions
- synchronize Chapters 9 and 10 with the normalization, nonzero-family, and ambient-coordinate boundaries

The capstone keeps `data.IsWeightNormalized` and `A ≠ 0` explicit. It does not claim equality with the original ambient bond dimension and does not restore any retired one-copy BNT surface.

## Verification

- targeted builds for all changed canonical-form, supplier, bridge, and aggregator modules (8950 jobs)
- full `lake build` (10061 jobs)
- diagnostics and package lint on all proof-bearing changed modules
- `python3 scripts/generate_import_aggregators.py --check`
- changed-declaration blueprint coverage: no missing declarations
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- double `lualatex` from `blueprint/src` with `TEXINPUTS="../../tex/tenkz//:"`; zero undefined cross-references
- `git diff --check`
- axiom inspection of new declarations reports only `propext`, `Classical.choice`, and `Quot.sound`

Closes #6094.
Advances #6091.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are proof refactor and new existence theorems in canonical-form and SectorBNT layers; no runtime behavior, but incorrect MPV or dimension bookkeeping would undermine downstream fundamental-theorem arguments.
> 
> **Overview**
> Centralizes **active-block** handling for CPSV canonical forms and wires it into the SectorBNT supplier path, with matching blueprint theorems.
> 
> A new `ActiveBlocks` module defines `activeEquiv`, `activeDim`, `activeWeight`, and `activeBlocks`, proves that dropping zero-weight summands does not change positive-length MPVs (`sameMPV₂Pos_toTensorFromBlocks_active`), and shows literal canonical-form data match their active weighted sum (`sameMPV₂Pos_activeBlocks`). `ActiveBNTRefinement` and `BNTCharacterization` now import this layer instead of duplicating the summation argument.
> 
> On the supplier side, prepared-block BNT construction is split: `isBNTCanonicalForm_collapsedBntSectorDecomp_of_tp_primitive_irr_blocks` states that the phase-class collapsed decomposition is already in BNT form; existence theorems wrap it, and `exists_isBNTCanonicalForm_of_tp_primitive_irr_blocks_and_totalDim` adds **total dimension** `∑_k D_k`. **`CanonicalFormBridge`** proves that normalized nonzero `CPSVCanonicalFormData` yields an active `IsBNTCanonicalForm` decomposition with the same positive-length MPVs and `P.totalDim = ∑_{k ∈ K_act} D_k` (not ambient bond dimension `D`).
> 
> Chapters 9 and 10 document removing zero-weight blocks, active CPSV MPV equality, collapsed prepared BNT, dimension-preserving supplier, and the CPSV active-sector capstone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41b405e595bd1c69d868498f4da6b89def721c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->