### PR TITLE
docs(MPU): register the source-v counterexample

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3697,7 +3697,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         MPOTensor.SourceVCounterexample.leftWitness,
         MPOTensor.SourceVCounterexample.rightWitness}
     \leanok
-    \uses{def:mpu}
+    \uses{def:mpo_tensor}
     Take $d=1$, $D=2$, and
     \begin{align}
         U^{00}&=\begin{pmatrix}1&1\\0&0\end{pmatrix},
@@ -3719,9 +3719,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         MPOTensor.SourceVCounterexample.no_posDef_fixed,
         MPOTensor.SourceVCounterexample.not_hasFullActiveSupport}
     \leanok
-    \uses{def:mpu_source_v_gram_counterexample_data,def:mpu_simple,
-        def:mpu_source_v_dressing,thm:mpu_source_v_four_u_expansions,
-        thm:mpu_reduced_cfii_transfer_stabilization}
+    \uses{def:mpu_source_v_gram_counterexample_data,def:mpu,
+        def:mpu_simple,def:mpu_double_layer,def:mpu_source_v_dressing,
+        def:mpu_normalized_flattening,def:transfer_map,def:cpsv_cfii,
+        def:mpu_full_active_support}
     MPU unitarity, positive definiteness of an arbitrary source weight, and
     the exact fixed-witness contractions do not imply the proposed equality
     between the source-$Y$ Gram contraction and the rank-one-inserted double

--- a/docs/counterexamples.md
+++ b/docs/counterexamples.md
@@ -100,6 +100,20 @@ mathematical obstruction.
   statement for active phase-class representatives remains open at this stage;
   unused arbitrary-BNT members lie outside that corrected active statement.
 
+### MPU unitarity and simple contractions do not identify the source-v Gram contraction
+
+- Location: `TNLean/MPS/MPU/SourceVCounterexample.lean`
+- Main declaration:
+  `MPOTensor.SourceVCounterexample.sourceYTensor_gram_ne_inserted`
+- Statement refuted: MPU unitarity, a positive-definite source weight, and the
+  exact supplied simple contractions imply that the source-$Y$ Gram
+  contraction equals the rank-one-inserted double-layer contraction.
+- Corrected boundary: the witness has no positive-definite fixed point for its
+  normalized transfer map, so it admits no reduced canonical-form-II
+  presentation with full active support. The example therefore refutes only
+  the unrestricted source-$v$ Gram identification, not a statement under the
+  reduced-CFII and full-active-support hypotheses.
+
 ## Block Separation and Canonical Form
 
 ### Weighted MPV cancellation does not imply per-block SameMPV

--- a/docs/counterexamples.md
+++ b/docs/counterexamples.md
@@ -110,7 +110,7 @@ mathematical obstruction.
   contraction equals the rank-one-inserted double-layer contraction.
 - Corrected boundary: the witness has no positive-definite fixed point for its
   normalized transfer map, so it admits no reduced canonical-form-II
-  presentation with full active support. The example therefore refutes only
+  presentation with full-active-support. The example therefore refutes only
   the unrestricted source-$v$ Gram identification, not a statement under the
   reduced-CFII and full-active-support hypotheses.
 


### PR DESCRIPTION
## What changed

- register the source-$v$ Gram counterexample in `docs/counterexamples.md`, including its main declaration, the refuted unrestricted identification, and the reduced-CFII/full-active-support boundary
- make the Chapter 28 counterexample-data node depend directly on `def:mpo_tensor`
- separate theorem statement dependencies from proof-only four-$\mathcal U$ expansion and reduced-CFII stabilization dependencies

## Validation

- focused `SourceVCounterexample` and MPU aggregate builds
- blueprint synchronization, 7247/7247 declarations
- reverse declaration coverage for `SourceVCounterexample.lean`
- two LuaLaTeX passes with no undefined cross-references
- `git diff --check origin/main...HEAD`

Closes #6119
Follow-up to #6110

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint cross-reference updates only; no Lean proof or runtime logic changes in this diff.
> 
> **Overview**
> Documents the **source-$v$ Gram counterexample** in `docs/counterexamples.md`: main Lean declaration, the refuted unrestricted identification (MPU unitarity + positive weight + simple contractions ⇒ Gram equals rank-one-inserted double layer), and the boundary that it does **not** refute the reduced-CFII / full-active-support variant.
> 
> In Chapter 28 blueprint metadata, the counterexample-data definition now cites **`def:mpo_tensor`** instead of **`def:mpu`**, and the counterexample theorem’s `\uses` list is trimmed to **statement-level** dependencies (dropping proof-only four-$\mathcal U$ expansion and reduced-CFII stabilization lemmas).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7aaec005ad69e236742ab3ee34f187edfdc25d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->