### PR TITLE
feat(SectorBNT): derive active-core equal Fundamental Theorem

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT.lean
@@ -12,6 +12,7 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.Api
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Blocking
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormBridge
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormEqual
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
 import TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqual.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqual.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormBridge
+import TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord
+
+/-!
+# Equal fundamental theorem for active CPSV canonical forms
+
+Two normalized nonzero CPSV canonical-form tensors with equal positive-length matrix product
+vectors determine active SectorBNT tensors of the same total bond dimension. The active tensors are
+related by a single unitary gauge, and hence by an invertible gauge.
+
+The conclusions concern the extracted active tensors. They make no assertion about equality of the
+ambient bond dimensions or gauge equivalence of the original tensors.
+
+Source: arXiv:2011.12127v2, lines 1831--1906; arXiv:1606.00608, lines 354--361 and
+1172--1199.
+-/
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D₁ D₂ : ℕ}
+variable {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+
+namespace CPSVCanonicalFormData
+
+/-- **Active-core unitary equal fundamental theorem.**
+
+Normalized nonzero CPSV canonical-form tensors with equal positive-length matrix product vectors
+have active SectorBNT decompositions whose total dimensions agree. After identifying those active
+dimensions, one unitary matrix conjugates the first extracted tensor to the second.
+
+The common dimension is the sum of the dimensions of the nonzero-weight blocks. No equality of the
+ambient bond dimensions, and no gauge equivalence between the original tensors, is asserted.
+
+Source: arXiv:2011.12127v2, lines 1831--1906, especially Corollary IV.5 and the unitary
+note at lines 1905--1906; arXiv:1606.00608, lines 354--361 and 1172--1199. -/
+theorem exists_active_fundamentalTheorem_equal_canonicalForm_unitary
+    (dataA : CPSVCanonicalFormData A)
+    (dataB : CPSVCanonicalFormData B)
+    (hNormA : dataA.IsWeightNormalized)
+    (hNormB : dataB.IsWeightNormalized)
+    (hA : A ≠ 0) (hB : B ≠ 0)
+    (hEqual : SameMPV₂Pos A B) :
+    ∃ P Q : SectorDecomposition d,
+      IsBNTCanonicalForm P ∧
+      IsBNTCanonicalForm Q ∧
+      SameMPV₂Pos A P.toTensor ∧
+      SameMPV₂Pos B Q.toTensor ∧
+      P.totalDim = ∑ k : dataA.Active, dataA.dim k.1 ∧
+      Q.totalDim = ∑ k : dataB.Active, dataB.dim k.1 ∧
+      (∑ k : dataA.Active, dataA.dim k.1) =
+        ∑ k : dataB.Active, dataB.dim k.1 ∧
+      ∃ (hTotal : P.totalDim = Q.totalDim)
+          (Y : GL (Fin Q.totalDim) ℂ),
+        (Y : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) ∈
+          Matrix.unitaryGroup (Fin Q.totalDim) ℂ ∧
+        ∀ i : Fin d,
+          Q.toTensor i =
+            (Y : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+              cast (by rw [hTotal] :
+                  Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+                  Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+                (P.toTensor i) *
+              (((Y)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+                Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
+  obtain ⟨P, hPBNT, hAP, hPDim⟩ :=
+    dataA.exists_active_isBNTCanonicalForm hNormA hA
+  obtain ⟨Q, hQBNT, hBQ, hQDim⟩ :=
+    dataB.exists_active_isBNTCanonicalForm hNormB hB
+  have hPQ : SameMPV₂Pos P.toTensor Q.toTensor :=
+    hAP.symm.trans (hEqual.trans hBQ)
+  obtain ⟨hTotal, Y, hYUnitary, hGauge⟩ :=
+    fundamentalTheorem_equal_canonicalForm_unitary hPBNT hQBNT hPQ
+  have hActiveTotal :
+      (∑ k : dataA.Active, dataA.dim k.1) =
+        ∑ k : dataB.Active, dataB.dim k.1 :=
+    hPDim.symm.trans (hTotal.trans hQDim)
+  exact ⟨P, Q, hPBNT, hQBNT, hAP, hBQ, hPDim, hQDim, hActiveTotal,
+    hTotal, Y, hYUnitary, hGauge⟩
+
+/-- **Active-core equal fundamental theorem.**
+
+Normalized nonzero CPSV canonical-form tensors with equal positive-length matrix product vectors
+have active SectorBNT decompositions of equal total dimension, related by one invertible global
+gauge. This follows from the unitary active-core theorem by forgetting unitarity.
+
+The theorem concerns only the extracted nonzero-weight blocks. It does not identify the ambient bond
+dimensions and does not claim gauge equivalence of the original tensors.
+
+Source: arXiv:2011.12127v2, lines 1831--1900, especially Corollary IV.5;
+arXiv:1606.00608, lines 354--361 and 1172--1192. -/
+theorem exists_active_fundamentalTheorem_equal_canonicalForm
+    (dataA : CPSVCanonicalFormData A)
+    (dataB : CPSVCanonicalFormData B)
+    (hNormA : dataA.IsWeightNormalized)
+    (hNormB : dataB.IsWeightNormalized)
+    (hA : A ≠ 0) (hB : B ≠ 0)
+    (hEqual : SameMPV₂Pos A B) :
+    ∃ P Q : SectorDecomposition d,
+      IsBNTCanonicalForm P ∧
+      IsBNTCanonicalForm Q ∧
+      SameMPV₂Pos A P.toTensor ∧
+      SameMPV₂Pos B Q.toTensor ∧
+      P.totalDim = ∑ k : dataA.Active, dataA.dim k.1 ∧
+      Q.totalDim = ∑ k : dataB.Active, dataB.dim k.1 ∧
+      (∑ k : dataA.Active, dataA.dim k.1) =
+        ∑ k : dataB.Active, dataB.dim k.1 ∧
+      ∃ (hTotal : P.totalDim = Q.totalDim)
+          (Y : GL (Fin Q.totalDim) ℂ),
+        ∀ i : Fin d,
+          Q.toTensor i =
+            (Y : Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) *
+              cast (by rw [hTotal] :
+                  Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+                  Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ)
+                (P.toTensor i) *
+              (((Y)⁻¹ : GL (Fin Q.totalDim) ℂ) :
+                Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) := by
+  obtain ⟨P, Q, hPBNT, hQBNT, hAP, hBQ, hPDim, hQDim, hActiveTotal,
+      hTotal, Y, _hYUnitary, hGauge⟩ :=
+    dataA.exists_active_fundamentalTheorem_equal_canonicalForm_unitary
+      dataB hNormA hNormB hA hB hEqual
+  exact ⟨P, Q, hPBNT, hQBNT, hAP, hBQ, hPDim, hQDim, hActiveTotal,
+    hTotal, Y, hGauge⟩
+
+end CPSVCanonicalFormData
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqual.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqual.lean
@@ -37,6 +37,11 @@ dimensions, one unitary matrix conjugates the first extracted tensor to the seco
 The common dimension is the sum of the dimensions of the nonzero-weight blocks. No equality of the
 ambient bond dimensions, and no gauge equivalence between the original tensors, is asserted.
 
+**Scope restriction (active canonical-form tensors):** This is the active-only corrected form of the
+cited unitary theorem. It compares the extracted nonzero-weight SectorBNT tensors rather than the
+literal ambient canonical forms. The restricted source interpretation is recorded in
+`docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`.
+
 Source: arXiv:2011.12127v2, lines 1831--1906, especially Corollary IV.5 and the unitary
 note at lines 1905--1906; arXiv:1606.00608, lines 354--361 and 1172--1199. -/
 theorem exists_active_fundamentalTheorem_equal_canonicalForm_unitary
@@ -91,6 +96,11 @@ gauge. This follows from the unitary active-core theorem by forgetting unitarity
 
 The theorem concerns only the extracted nonzero-weight blocks. It does not identify the ambient bond
 dimensions and does not claim gauge equivalence of the original tensors.
+
+**Scope restriction (active canonical-form tensors):** This is the active-only corrected form of the
+cited equal fundamental theorem. It compares the extracted nonzero-weight SectorBNT tensors rather
+than the literal ambient canonical forms. The restricted source interpretation is recorded in
+`docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`.
 
 Source: arXiv:2011.12127v2, lines 1831--1900, especially Corollary IV.5;
 arXiv:1606.00608, lines 354--361 and 1172--1192. -/

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -907,6 +907,115 @@ give $O_{YX}(N)\to 0$, a contradiction.
     dimension sum by the active indices.
 \end{proof}
 
+% Source anchors: RMP arXiv:2011.12127v2, lines 1831--1906;
+% CPSV16 arXiv:1606.00608, lines 354--361 and 1172--1199.
+\begin{theorem}[Equal fundamental theorem for active CPSV canonical forms]%
+    \label{thm:cpsv_active_core_equal_ft}
+    \lean{MPSTensor.CPSVCanonicalFormData.exists_active_fundamentalTheorem_equal_canonicalForm}
+    \leanok
+    \uses{thm:cpsv_active_sector_bnt, thm:cpgsv_equal_case_source,
+        cor:cpsv_active_core_equal_ft_unitary}
+    Let $A$ and $B$ have CPSV canonical-form data with weights
+    $(\mu_k^A)_k$, $(\mu_k^B)_k$ and block dimensions
+    $(D_k^A)_k$, $(D_k^B)_k$. Assume that both data satisfy the separate
+    normalization condition~(\ref{eq:cpsv_weight_normalization}), that
+    $A\ne0$ and $B\ne0$, and that
+    $\mc{V}^+(A)=\mc{V}^+(B)$. Put
+    $K_A=\{k:\mu_k^A\ne0\}$ and $K_B=\{k:\mu_k^B\ne0\}$.
+    Then there are BNT canonical-form sector decompositions $P$ and $Q$ such
+    that
+    \begin{align}
+        \mc{V}^+(A)&=\mc{V}^+(P),
+        \notag\\
+        \mc{V}^+(B)&=\mc{V}^+(Q),
+        \notag\\
+        D_{\mathrm{tot}}(P)&=\sum_{k\in K_A}D_k^A,
+        \notag\\
+        D_{\mathrm{tot}}(Q)&=\sum_{k\in K_B}D_k^B,
+        \notag\\
+        D_{\mathrm{tot}}(P)&=D_{\mathrm{tot}}(Q),
+        \notag\\
+        \sum_{k\in K_A}D_k^A&=\sum_{k\in K_B}D_k^B.
+        \label{eq:cpsv_active_core_equal_dims}
+    \end{align}
+    After identifying the two total bond spaces by their equality, there is
+    an invertible matrix $X$ such that, for every physical index $i$,
+    \begin{align}
+        Q^i&=X P^iX^{-1}.
+        \label{eq:cpsv_active_core_equal_gauge}
+    \end{align}
+    The conclusion concerns the extracted active tensors $P$ and $Q$. It does
+    not assert equality of the ambient bond dimensions $D_A$ and $D_B$, and it
+    does not assert that $A$ and $B$ are gauge equivalent.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{cor:cpsv_active_core_equal_ft_unitary}
+    Apply Corollary~\ref{cor:cpsv_active_core_equal_ft_unitary} and retain its
+    extracted sector decompositions, dimension identities, and conjugating
+    matrix. Forget that the conjugating matrix is unitary.
+\end{proof}
+
+% The RMP unitary note is arXiv:2011.12127v2, lines 1905--1906.
+% The CPSV16 CFII refinement is arXiv:1606.00608, lines 1197--1199.
+\begin{corollary}[Unitary refinement for active CPSV canonical forms]%
+    \label{cor:cpsv_active_core_equal_ft_unitary}
+    \lean{MPSTensor.CPSVCanonicalFormData.exists_active_fundamentalTheorem_equal_canonicalForm_unitary}
+    \leanok
+    \uses{thm:cpsv_active_sector_bnt,
+        cor:sector_bnt_equal_unitary_global_gauge}
+    Let $A$ and $B$ have CPSV canonical-form data with weights
+    $(\mu_k^A)_k$, $(\mu_k^B)_k$ and block dimensions
+    $(D_k^A)_k$, $(D_k^B)_k$. Assume that both data satisfy the separate
+    normalization condition~(\ref{eq:cpsv_weight_normalization}), that
+    $A\ne0$ and $B\ne0$, and that
+    $\mc{V}^+(A)=\mc{V}^+(B)$. Put
+    $K_A=\{k:\mu_k^A\ne0\}$ and $K_B=\{k:\mu_k^B\ne0\}$.
+    Then there are BNT canonical-form sector decompositions $P$ and $Q$ such
+    that
+    \begin{align}
+        \mc{V}^+(A)&=\mc{V}^+(P),
+        \notag\\
+        \mc{V}^+(B)&=\mc{V}^+(Q),
+        \notag\\
+        D_{\mathrm{tot}}(P)&=\sum_{k\in K_A}D_k^A,
+        \notag\\
+        D_{\mathrm{tot}}(Q)&=\sum_{k\in K_B}D_k^B,
+        \notag\\
+        D_{\mathrm{tot}}(P)&=D_{\mathrm{tot}}(Q),
+        \notag\\
+        \sum_{k\in K_A}D_k^A&=\sum_{k\in K_B}D_k^B.
+        \label{eq:cpsv_active_core_unitary_dims}
+    \end{align}
+    After identifying the two total bond spaces, there is a unitary matrix $U$
+    such that, for every physical index $i$,
+    \begin{align}
+        Q^i&=U P^iU^\dagger.
+        \label{eq:cpsv_active_core_unitary_gauge}
+    \end{align}
+    This is the unitary choice noted in
+    \cite[lines~1905--1906]{Cirac2021Matrix} and the canonical-form-II
+    refinement of \cite[Corollary~A.6, lines~1197--1199]{Cirac2016MPDO_arXiv}.
+    Again, there is no claim that $D_A=D_B$, and no gauge equivalence between
+    $A$ and $B$ is asserted.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_active_sector_bnt,
+        cor:sector_bnt_equal_unitary_global_gauge}
+    Apply Theorem~\ref{thm:cpsv_active_sector_bnt} to $A$ and $B$. This gives
+    $P$ and $Q$, their BNT canonical-form properties, the first four identities
+    in~(\ref{eq:cpsv_active_core_unitary_dims}), and
+    \begin{align}
+        \mc{V}^+(P)&=\mc{V}^+(Q).
+        \notag
+    \end{align}
+    Corollary~\ref{cor:sector_bnt_equal_unitary_global_gauge} gives the fifth
+    identity and supplies $U$. Substituting the two active
+    dimension formulas gives the last equality in
+    (\ref{eq:cpsv_active_core_unitary_dims}).
+\end{proof}
+
 Combining the after-blocking preparation with the normalized-weight construction
 gives the arbitrary-input statement, conditional on the weight normalization.
 

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -913,8 +913,7 @@ give $O_{YX}(N)\to 0$, a contradiction.
     \label{thm:cpsv_active_core_equal_ft}
     \lean{MPSTensor.CPSVCanonicalFormData.exists_active_fundamentalTheorem_equal_canonicalForm}
     \leanok
-    \uses{thm:cpsv_active_sector_bnt, thm:cpgsv_equal_case_source,
-        cor:cpsv_active_core_equal_ft_unitary}
+    \uses{thm:cpsv_active_core_equal_ft_unitary}
     Let $A$ and $B$ have CPSV canonical-form data with weights
     $(\mu_k^A)_k$, $(\mu_k^B)_k$ and block dimensions
     $(D_k^A)_k$, $(D_k^B)_k$. Assume that both data satisfy the separate
@@ -947,19 +946,25 @@ give $O_{YX}(N)\to 0$, a contradiction.
     The conclusion concerns the extracted active tensors $P$ and $Q$. It does
     not assert equality of the ambient bond dimensions $D_A$ and $D_B$, and it
     does not assert that $A$ and $B$ are gauge equivalent.
+
+    \textbf{Scope restriction (active canonical-form tensors).} This is the
+    active-only, source-restricted form of the cited equal fundamental theorem:
+    the conclusion compares the extracted nonzero-weight tensors, not the
+    literal ambient canonical forms. See
+    \path{docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{cor:cpsv_active_core_equal_ft_unitary}
-    Apply Corollary~\ref{cor:cpsv_active_core_equal_ft_unitary} and retain its
+    \uses{thm:cpsv_active_core_equal_ft_unitary}
+    Apply Theorem~\ref{thm:cpsv_active_core_equal_ft_unitary} and retain its
     extracted sector decompositions, dimension identities, and conjugating
     matrix. Forget that the conjugating matrix is unitary.
 \end{proof}
 
 % The RMP unitary note is arXiv:2011.12127v2, lines 1905--1906.
 % The CPSV16 CFII refinement is arXiv:1606.00608, lines 1197--1199.
-\begin{corollary}[Unitary refinement for active CPSV canonical forms]%
-    \label{cor:cpsv_active_core_equal_ft_unitary}
+\begin{theorem}[Unitary refinement for active CPSV canonical forms]%
+    \label{thm:cpsv_active_core_equal_ft_unitary}
     \lean{MPSTensor.CPSVCanonicalFormData.exists_active_fundamentalTheorem_equal_canonicalForm_unitary}
     \leanok
     \uses{thm:cpsv_active_sector_bnt,
@@ -998,7 +1003,12 @@ give $O_{YX}(N)\to 0$, a contradiction.
     refinement of \cite[Corollary~A.6, lines~1197--1199]{Cirac2016MPDO_arXiv}.
     Again, there is no claim that $D_A=D_B$, and no gauge equivalence between
     $A$ and $B$ is asserted.
-\end{corollary}
+
+    \textbf{Scope restriction (active canonical-form tensors).} This is the
+    active-only, source-restricted unitary form: the conclusion compares the
+    extracted nonzero-weight tensors, not the literal ambient canonical forms.
+    See \path{docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex}.
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:cpsv_active_sector_bnt,

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -946,12 +946,8 @@ give $O_{YX}(N)\to 0$, a contradiction.
     The conclusion concerns the extracted active tensors $P$ and $Q$. It does
     not assert equality of the ambient bond dimensions $D_A$ and $D_B$, and it
     does not assert that $A$ and $B$ are gauge equivalent.
-
-    \textbf{Scope restriction (active canonical-form tensors).} This is the
-    active-only, source-restricted form of the cited equal fundamental theorem:
-    the conclusion compares the extracted nonzero-weight tensors, not the
-    literal ambient canonical forms. See
-    \path{docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex}.
+    % Scope restriction (active canonical-form tensors): active-only corrected form;
+    % see docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1003,11 +999,8 @@ give $O_{YX}(N)\to 0$, a contradiction.
     refinement of \cite[Corollary~A.6, lines~1197--1199]{Cirac2016MPDO_arXiv}.
     Again, there is no claim that $D_A=D_B$, and no gauge equivalence between
     $A$ and $B$ is asserted.
-
-    \textbf{Scope restriction (active canonical-form tensors).} This is the
-    active-only, source-restricted unitary form: the conclusion compares the
-    extracted nonzero-weight tensors, not the literal ambient canonical forms.
-    See \path{docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex}.
+    % Scope restriction (active canonical-form tensors): active-only corrected form;
+    % see docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary

- extract active SectorBNT decompositions from two normalized nonzero CPSV canonical-form tensors
- transport positive-length MPV equality to the extracted tensors
- derive equality of the active dimension sums and a single global gauge
- add the unitary refinement from the existing SectorBNT equal-case theorem
- document the exact active-core and ambient-coordinate boundary in Chapter 10

The conclusions concern the extracted active tensors. They do not assert equality of the original ambient bond dimensions or gauge equivalence of the original tensors.

## Verification

- full `lake build` (10069 jobs)
- diagnostics and lint review of the new proof module
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- double `lualatex` with `TEXINPUTS="../../tex/tenkz//:"`; zero undefined cross-references
- reader-facing prose and forbidden-token checks
- `git diff --check`
- independent proof review found no mathematical, API, or scope defects

Closes #6116.
Advances #6091.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization that composes existing SectorBNT lemmas; no changes to auth, runtime, or core proof APIs beyond new theorems and documentation.
> 
> **Overview**
> Adds **active-core equal Fundamental Theorem** results for pairs of normalized, nonzero CPSV canonical-form tensors with the same positive-length MPV family.
> 
> New Lean module `CanonicalFormEqual.lean` proves that such tensors admit BNT canonical-form sector decompositions on the **nonzero-weight blocks**, with matching active dimension sums and a single global gauge relating the extracted tensors. A **unitary** variant is proved first via `exists_active_isBNTCanonicalForm` and `fundamentalTheorem_equal_canonicalForm_unitary`; the invertible case follows by dropping unitarity.
> 
> The aggregator import and **Chapter 10** blueprint (`ch10_bnt_sector_canonical_form.tex`) are updated with linked theorems and explicit scope notes: conclusions apply to extracted active tensors only—not ambient bond equality or gauge equivalence of the original tensors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a118593c717efb31a0a4d17fe29152aad1803a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->