### PR TITLE
docs(MPU): scope Theorem III.4 to reduced CFII data

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3840,25 +3840,53 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{lemuisometry}
   \notready
   \discussion{5708}
-  \uses{def:mpu_source_uv,thm:mpu_source_u_expanded_metric,
-    thm:mpu_source_u_terminal_boundary,thm:mpu_bounded_simple_blocking}
-  For every MPU tensor $\mathcal U$, the operator $u$ associated with the two
-  source cuts satisfies
+  \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
+    def:mpu_full_active_support,def:mpu_source_uv,
+    thm:mpu_reduced_cfii_transfer_stabilization}
+  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$.  Choose
+  canonical-form-II data for its normalized flattening whose active blocks
+  fill the ambient bond space.  Let $\rho$ be the normalized positive right
+  fixed point supplied by
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, and use $\rho$ in
+  the source factors associated with the two source cuts.  Then
   \begin{align}
     u^\dagger u&=\Id.
   \end{align}
   Consequently $u$ is an isometry and $r\ell\geq d^2$.
 \end{lemma}
 
+\begin{proof}
+  \uses{thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_source_u_expanded_metric,
+    thm:mpu_source_u_terminal_boundary,thm:mpu_bounded_simple_blocking}
+  The chosen reduced canonical-form-II data give
+  \begin{align}
+    \rho&>0,
+    &\tr(\rho)&=1,
+    &E(\rho)&=\rho,
+    &E^{D^2-1}&=\lvert\rho)(\Phi\rvert,
+  \end{align}
+  with $(\Phi\rvert$ the vectorized identity.  Choose a blocking length at
+  which the tensor is simple.  Expanding the source-$u$ metric through that
+  blocked periodic contraction and applying the terminal boundary identity
+  reduces it to the normalized contraction of
+  $U^{(K+2)\dagger}U^{(K+2)}$, which is the identity.
+\end{proof}
+
 \begin{theorem}[Simple-tensor equivalence theorem]
   \label{ThmFund1}
   \notready
   \discussion{5708}
-  \uses{lemuisometry,def:mpu_simple,thm:mpu_simple1,
-    thm:mpu_source_uv_two_site_factorization,
-    thm:mpu_source_factor_right_inverses}
-  Let $\mathcal U$ be an MPU tensor, and let $r$, $\ell$, $u$, and $v$ be
-  obtained from its two source cuts. The following conditions are equivalent:
+  \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
+    def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
+    thm:mpu_reduced_cfii_transfer_stabilization}
+  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$.  Choose
+  canonical-form-II data for its normalized flattening whose active blocks
+  fill the ambient bond space, and construct the source factors from the
+  normalized positive right fixed point $\rho$ supplied by
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}.  Let $r$, $\ell$,
+  $u$, and $v$ be the resulting source-cut ranks and source operators.  Then
+  the following conditions are equivalent:
   \begin{enumerate}
     \item $\mathcal U$ is simple;
     \item $r\ell=d^2$;
@@ -3866,6 +3894,35 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \item $v$ is unitary.
   \end{enumerate}
 \end{theorem}
+
+\begin{proof}
+  \uses{lemuisometry,thm:mpu_simple1,
+    thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_source_uv_two_site_factorization,
+    thm:mpu_source_factor_right_inverses,
+    thm:mpu_source_v_dressed_entries,
+    thm:mpu_source_v_dressed_gram_cancel}
+  If $\mathcal U$ is simple, the two simple-tensor contractions give the
+  dressed Gram identity
+  \begin{align}
+    (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
+      &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
+  \end{align}
+  The right inverses of $Y_1$ and $Y_2$ cancel the dressing, so
+  $v^\dagger v=\Id$.  Hence $r\ell\leq d^2$, while
+  Lemma~\ref{lemuisometry} gives $r\ell\geq d^2$.
+  This proves the first implication.
+
+  If $r\ell=d^2$, the isometry $u$ is square and therefore unitary.  If $u$
+  is unitary, the exact two-site factorization of $U^{(2)}$ and unitarity of
+  $U^{(2)}$ imply that $v$ is unitary.  Finally, if $v$ is unitary, the fixed
+  point identity gives the first simple-tensor contraction, while the same
+  complete source-cut contraction used above gives the second one.
+
+  % The complete four-way Lean capstone remains downstream of issue #6071.
+  % Its missing step is the combined source-v network contraction; no
+  % representative-transport theorem is asserted here.
+\end{proof}
 
 \begin{definition}[Standard form]
   \label{SF}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3836,6 +3836,83 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \section{Standard form, index, and symmetry classification}
 
+\begin{theorem}[Complete source-$u$ network contraction]
+  \label{thm:mpu_source_u_complete_network}
+  \notready
+  \discussion{5982}
+  \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
+    def:mpu_full_active_support,def:mpu_source_uv,def:mpo_family,
+    thm:mpu_reduced_cfii_transfer_stabilization}
+  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
+  canonical-form-II data for its normalized flattening whose active blocks
+  fill the ambient bond space, and let $\rho$ be the normalized positive right
+  fixed point supplied by
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Set
+  \begin{align}
+    J&=D^2-1,\\
+    K&=JD^2.
+  \end{align}
+  For retained physical pairs $p,q\in\{0,\ldots,d-1\}^2$, the complete
+  source-$u$ contraction satisfies
+  \begin{align}
+    \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+      &=d^{-K}\sum_{\tau,\eta}
+        U^{(K+2)}_{(q,\tau),\eta}
+        \overline{U^{(K+2)}_{(p,\tau),\eta}}.
+  \end{align}
+  Here $\tau$ ranges over input words of length $K$, and $\eta$ ranges over
+  output words of length $K+2$. This is the range-insertion equality in the
+  proof of \cite[Lemma~III.3]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}
+  \uses{thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_source_u_gram_second_cut_metric,
+    thm:mpu_supplied_witness_overlapping_reblocking,
+    thm:mpu_source_u_terminal_boundary,
+    thm:mpu_normalized_output_tail_closed_trace}
+  The stabilized transfer power is
+  $E^J=\lvert\rho)(\Phi\rvert$. Blocking a further $D^2$ sites gives the two
+  simple contractions at length $K$. Expand the ordinary Gram entry through
+  the two source cuts, insert their range projections, and apply these
+  contractions to the intervening blocked network. The terminal source-factor
+  contraction removes the remaining boundary indices. The resulting closed
+  network is the normalized $(K+2)$-site contraction displayed above.
+\end{proof}
+
+\begin{theorem}[Complete reduced source-$v$ contraction]
+  \label{thm:mpu_source_v_complete_reduced_contraction}
+  \notready
+  \discussion{6071}
+  \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
+    def:mpu_full_active_support,def:mpu_simple,
+    def:mpu_source_v_dressing,thm:mpu_reduced_cfii_transfer_stabilization}
+  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
+  canonical-form-II data for its normalized flattening whose active blocks
+  fill the ambient bond space, and construct the source factors from the
+  normalized positive right fixed point $\rho$ supplied by
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Then the second
+  simple-tensor contraction~(\ref{eq:mpu_simple2}) holds if and only if
+  \begin{align}
+    (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
+      &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
+  \end{align}
+  This is the complete blocked-network identification in equation~(31) of
+  \cite[Theorem~III.4]{Cirac2017MPU}, with the stabilized transfer power
+  inserted in the internal contraction.
+\end{theorem}
+
+\begin{proof}
+  \uses{thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_supplied_witness_overlapping_reblocking,
+    thm:mpu_source_v_four_u_expansions,
+    thm:mpu_source_v_dressed_entries}
+  Insert $E^{D^2-1}=\lvert\rho)(\Phi\rvert$ into the complete blocked network.
+  Expand both source cuts and rotate the second cut. The resulting four-letter
+  expression identifies the second simple-tensor contraction with the dressed
+  Gram equation in both directions.
+\end{proof}
+
 \begin{lemma}[The source operator $u$ is an isometry]
   \label{lemuisometry}
   \notready
@@ -3843,12 +3920,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
     def:mpu_full_active_support,def:mpu_source_uv,
     thm:mpu_reduced_cfii_transfer_stabilization}
-  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$.  Choose
+  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
   canonical-form-II data for its normalized flattening whose active blocks
-  fill the ambient bond space.  Let $\rho$ be the normalized positive right
+  fill the ambient bond space. Let $\rho$ be the normalized positive right
   fixed point supplied by
   Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, and use $\rho$ in
-  the source factors associated with the two source cuts.  Then
+  the source factors associated with the two source cuts. Then
   \begin{align}
     u^\dagger u&=\Id.
   \end{align}
@@ -3857,20 +3934,20 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{proof}
   \uses{thm:mpu_reduced_cfii_transfer_stabilization,
-    thm:mpu_source_u_expanded_metric,
-    thm:mpu_source_u_terminal_boundary,thm:mpu_bounded_simple_blocking}
-  The chosen reduced canonical-form-II data give
+    thm:mpu_source_u_complete_network,
+    thm:mpu_normalized_output_tail_coisometry}
+  Set $J=D^2-1$ and $K=JD^2$. The chosen reduced canonical-form-II data give
   \begin{align}
-    \rho&>0,
-    &\tr(\rho)&=1,
-    &E(\rho)&=\rho,
-    &E^{D^2-1}&=\lvert\rho)(\Phi\rvert,
+    \rho&>0,\\
+    \tr(\rho)&=1,\\
+    E\lvert\rho)&=\lvert\rho),\\
+    (\Phi\rvert E&=(\Phi\rvert,\\
+    E^J&=\lvert\rho)(\Phi\rvert.
   \end{align}
-  with $(\Phi\rvert$ the vectorized identity.  Choose a blocking length at
-  which the tensor is simple.  Expanding the source-$u$ metric through that
-  blocked periodic contraction and applying the terminal boundary identity
-  reduces it to the normalized contraction of
-  $U^{(K+2)\dagger}U^{(K+2)}$, which is the identity.
+  By Theorem~\ref{thm:mpu_source_u_complete_network}, the $(p,q)$ entry of
+  $u^\dagger u$ is the normalized contraction of
+  $U^{(K+2)\dagger}U^{(K+2)}$ with a common length-$K$ input tail. MPU
+  unitarity evaluates this contraction as $\delta_{p,q}$.
 \end{proof}
 
 \begin{theorem}[Simple-tensor equivalence theorem]
@@ -3880,12 +3957,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
     def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
     thm:mpu_reduced_cfii_transfer_stabilization}
-  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$.  Choose
+  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
   canonical-form-II data for its normalized flattening whose active blocks
   fill the ambient bond space, and construct the source factors from the
   normalized positive right fixed point $\rho$ supplied by
-  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}.  Let $r$, $\ell$,
-  $u$, and $v$ be the resulting source-cut ranks and source operators.  Then
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Let $r$, $\ell$,
+  $u$, and $v$ be the resulting source-cut ranks and source operators. Then
   the following conditions are equivalent:
   \begin{enumerate}
     \item $\mathcal U$ is simple;
@@ -3896,32 +3973,29 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}
-  \uses{lemuisometry,thm:mpu_simple1,
-    thm:mpu_reduced_cfii_transfer_stabilization,
+  \uses{thm:mpu_source_u_complete_network,
+    thm:mpu_normalized_output_tail_coisometry,thm:mpu_simple1,
+    thm:mpu_source_v_complete_reduced_contraction,
     thm:mpu_source_uv_two_site_factorization,
-    thm:mpu_source_factor_right_inverses,
-    thm:mpu_source_v_dressed_entries,
     thm:mpu_source_v_dressed_gram_cancel}
-  If $\mathcal U$ is simple, the two simple-tensor contractions give the
-  dressed Gram identity
+  Suppose first that $\mathcal U$ is simple. By
+  Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction},
   \begin{align}
     (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
       &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
   \end{align}
-  The right inverses of $Y_1$ and $Y_2$ cancel the dressing, so
-  $v^\dagger v=\Id$.  Hence $r\ell\leq d^2$, while
-  Lemma~\ref{lemuisometry} gives $r\ell\geq d^2$.
-  This proves the first implication.
+  Cancelling the dressing by the right inverses of $Y_1$ and $Y_2$ gives
+  $v^\dagger v=\Id$. Hence $r\ell\leq d^2$. The complete source-$u$
+  contraction and MPU unitarity give $u^\dagger u=\Id$, hence
+  $r\ell\geq d^2$.
 
-  If $r\ell=d^2$, the isometry $u$ is square and therefore unitary.  If $u$
+  If $r\ell=d^2$, the isometry $u$ is square and therefore unitary. If $u$
   is unitary, the exact two-site factorization of $U^{(2)}$ and unitarity of
-  $U^{(2)}$ imply that $v$ is unitary.  Finally, if $v$ is unitary, the fixed
-  point identity gives the first simple-tensor contraction, while the same
-  complete source-cut contraction used above gives the second one.
-
-  % The complete four-way Lean capstone remains downstream of issue #6071.
-  % Its missing step is the combined source-v network contraction; no
-  % representative-transport theorem is asserted here.
+  $U^{(2)}$ imply that $v$ is unitary. Finally, suppose that $v$ is unitary.
+  The fixed-point identity gives the first simple-tensor contraction.
+  Unitarity of $v$ gives the dressed Gram identity, and
+  Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction} gives the second
+  contraction.
 \end{proof}
 
 \begin{definition}[Standard form]

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -3,9 +3,9 @@
 \usepackage{xurl}
 \usepackage[hidelinks]{hyperref}
 \input{command}
-\title{Full Support in the MPU Normal-Tensor Proposition}
+\title{Full Support in MPU Normality and Theorem III.4}
 \author{}
-\date{2026-08-08}
+\date{2026-08-11}
 \begin{document}
 \maketitle
 
@@ -52,23 +52,72 @@ other retained block exists.  The ambient coisometry is square and hence
 unitary; block assembly and unitary conjugation transport irreducibility from
 the normal block to the ambient tensor.
 
+\section{The source factors and Theorem III.4}
+After Proposition~\texttt{prop:normal-tensor}, the source assumes without loss
+of generality that the normalized tensor is in canonical form II
+\cite[lines~350--356]{Cirac2017MPU}.  The source factors are then defined using
+the normalized positive right fixed point $\rho$.  In particular, the first
+factor contains
+\begin{align}
+  \left[V_1(\Id\otimes\rho)V_1^\dagger\right]^{-1/2},
+\end{align}
+whose inverse requires $\rho>0$ on the ambient bond space
+\cite[lines~480--505]{Cirac2017MPU}.  The same factors define $u$ and $v$ in
+the source lemma \texttt{lemuisometry} and Theorem~III.4,
+\texttt{ThmFund1} \cite[lines~532--601]{Cirac2017MPU}.  Thus the positive
+fixed point is part of the preceding canonical-form-II convention, not a
+consequence of the bare MPU predicate for an arbitrary ambient representative.
+
+The supported formal route chooses
+\begin{align}
+  \mathcal C&\in\operatorname{CFII}(d^{-1/2}\mathcal U),
+  &\sum_{k:\,\mu_k\ne0}D_k&=D.
+\end{align}
+Here $\mathcal C$ is chosen canonical-form-II data for the normalized tensor,
+and the second identity is full active support.  The theorem
+\leanid{MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii}
+then supplies the unique active block, its normalized diagonal fixed point
+$\Lambda$, and the ambient matrix
+\begin{align}
+  \rho&=V\Lambda V^\dagger,
+  &\rho&>0,
+  &\tr(\rho)&=1,\\
+  \mathcal E(\rho)&=\rho,
+  &(\Phi\rvert\mathcal E&=(\Phi\rvert,
+  &\mathcal E^{D^2-1}&=\lvert\rho)(\Phi\rvert,
+\end{align}
+where $(\Phi\rvert$ is the vectorized identity.  This $\rho$, rather than an
+arbitrary positive matrix, is the source weight used to define the factors and
+the operators $u$ and $v$.
+
+The present formalization therefore follows the explicit-hypothesis option for
+\texttt{lemuisometry} and Theorem~III.4: both statements carry chosen
+canonical-form-II data and full active support.  It does not prove that every
+ambient MPU representative has a positive definite fixed point, and it does not
+construct a reduced representative or transport the source cuts, the ranks,
+simplicity, or the operators $u$ and $v$ from such a representative back to the
+original bond space.  The complete four-way Lean theorem remains downstream of
+issue~\#6071, whose missing step is the combined source-$v$ network contraction
+for the blocked tensor built from this fixed-point data.
+
 \section{Verdict}
-\textbf{Verdict: the paper's proposition is correct for the intended reduced
-canonical representative, with zero-weight blocks and the ambient zero
-complement omitted; this reduction is not an explicit hypothesis of
+\textbf{Verdict: the paper's normal-tensor proposition, the source-isometry
+lemma, and Theorem~III.4 are correct for the intended reduced canonical-form-II
+representative, with zero-weight blocks and the ambient zero complement omitted;
+this reduction is not an explicit hypothesis of
 Proposition~\texttt{prop:normal-tensor}, and it does not follow from literal
 canonical-form membership alone.}
 Consequently, a source-faithful formalization must construct this reduced
-representative before applying the proposition or explicitly assume full active
-support for the chosen ambient representative.  The formalization does not yet
-construct the representative reduction.  The latter
-implication is formalized by
+representative and transport the source constructions, or explicitly assume
+chosen canonical-form-II data with full active support.  The formalization uses
+the latter option.  It does not yet construct the representative reduction.
+The full-support irreducibility implication is formalized by
 \leanid{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_card_active_eq_one_of_fullActiveSupport}.
 The spectral-radius and primitivity conclusions are derived from the shifted
 normalized transfer traces and combined with full active support in
 \leanid{MPOTensor.IsMPU.isNormalTensor_normalizedFlattening_of_cpsv}.
 Bare \leanid{MPOTensor.IsMPU} is deliberately not used to infer ambient
-normality.
+normality or an ambient positive definite fixed point.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -53,60 +53,70 @@ unitary; block assembly and unitary conjugation transport irreducibility from
 the normal block to the ambient tensor.
 
 \section{The source factors and Theorem III.4}
-After Proposition~\texttt{prop:normal-tensor}, the source assumes without loss
-of generality that the normalized tensor is in canonical form II
-\cite[lines~350--356]{Cirac2017MPU}.  The source factors are then defined using
-the normalized positive right fixed point $\rho$.  In particular, the first
-factor contains
+Let $\mathcal U$ be an MPU tensor with physical dimension $d$ and bond
+dimension $D$, and let $E$ be the transfer matrix of the normalized tensor
+$d^{-1/2}\mathcal U$. After Proposition~\texttt{prop:normal-tensor}, the source
+assumes without loss of generality that this normalized tensor is in canonical
+form II \cite[lines~350--356]{Cirac2017MPU}. Choose such data with full active
+support. Let $\mathcal A_1$ be its unique active block, let $V$ be the inclusion
+of that block into the ambient bond space, and let $\Lambda$ be the block's
+diagonal positive right fixed point normalized to have trace one. Set
 \begin{align}
-  \left[V_1(\Id\otimes\rho)V_1^\dagger\right]^{-1/2},
+  \rho&=V\Lambda V^\dagger.
+\end{align}
+
+The source factors are defined using this matrix $\rho$. In the first singular
+value decomposition, let $V_1$ denote the coisometry appearing in
+$\mathcal M_1=V_1^\dagger D_1U_1$. The corresponding first source factor
+contains
+\begin{align}
+  \left[V_1(I\otimes\rho)V_1^\dagger\right]^{-1/2},
 \end{align}
 whose inverse requires $\rho>0$ on the ambient bond space
-\cite[lines~480--505]{Cirac2017MPU}.  The same factors define $u$ and $v$ in
+\cite[lines~480--505]{Cirac2017MPU}. The same factors define $u$ and $v$ in
 the source lemma \texttt{lemuisometry} and Theorem~III.4,
-\texttt{ThmFund1} \cite[lines~532--601]{Cirac2017MPU}.  Thus the positive
+\texttt{ThmFund1} \cite[lines~532--601]{Cirac2017MPU}. Thus the positive
 fixed point is part of the preceding canonical-form-II convention, not a
 consequence of the bare MPU predicate for an arbitrary ambient representative.
 
-The supported formal route chooses
+The supported formal route assumes
 \begin{align}
-  \mathcal C&\in\operatorname{CFII}(d^{-1/2}\mathcal U),
-  &\sum_{k:\,\mu_k\ne0}D_k&=D.
+  \mathcal C&\in\operatorname{CFII}(d^{-1/2}\mathcal U),\\
+  \sum_{k:\,\mu_k\ne0}D_k&=D.
 \end{align}
-Here $\mathcal C$ is chosen canonical-form-II data for the normalized tensor,
-and the second identity is full active support.  The theorem
+Here $\mathcal C$ denotes the chosen canonical-form-II data, and the second
+identity is full active support. The theorem
 \leanid{MPOTensor.IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii}
-then supplies the unique active block, its normalized diagonal fixed point
-$\Lambda$, and the ambient matrix
+then supplies the unique active block $\mathcal A_1$, the matrices $\Lambda$
+and $\rho$, and the identities
 \begin{align}
-  \rho&=V\Lambda V^\dagger,
-  &\rho&>0,
-  &\tr(\rho)&=1,\\
-  \mathcal E(\rho)&=\rho,
-  &(\Phi\rvert\mathcal E&=(\Phi\rvert,
-  &\mathcal E^{D^2-1}&=\lvert\rho)(\Phi\rvert,
+  \rho&=V\Lambda V^\dagger,\\
+  \rho&>0,\\
+  \tr(\rho)&=1,\\
+  E\lvert\rho)&=\lvert\rho),\\
+  (\Phi\rvert E&=(\Phi\rvert,\\
+  E^{D^2-1}&=\lvert\rho)(\Phi\rvert,
 \end{align}
-where $(\Phi\rvert$ is the vectorized identity.  This $\rho$, rather than an
-arbitrary positive matrix, is the source weight used to define the factors and
-the operators $u$ and $v$.
+where $(\Phi\rvert$ is the vectorized identity bra. This $\rho$, rather than
+an arbitrary positive matrix, is the source weight used to define the factors
+and the operators $u$ and $v$.
 
-The present formalization therefore follows the explicit-hypothesis option for
-\texttt{lemuisometry} and Theorem~III.4: both statements carry chosen
-canonical-form-II data and full active support.  It does not prove that every
-ambient MPU representative has a positive definite fixed point, and it does not
-construct a reduced representative or transport the source cuts, the ranks,
-simplicity, or the operators $u$ and $v$ from such a representative back to the
-original bond space.  The complete four-way Lean theorem remains downstream of
-issue~\#6071, whose missing step is the combined source-$v$ network contraction
-for the blocked tensor built from this fixed-point data.
+The explicit reduced-CFII and full-active-support hypotheses resolve the scope
+question tracked by issue~\#5855. They do not prove the two complete network
+identities needed for Theorem~III.4. The source-$u$ range-insertion equality in
+\texttt{lemuisometry} remains tracked by issue~\#5982. The complete blocked
+source-$v$ contraction corresponding to equation~(31) remains tracked by
+issue~\#6071. The formalization also does not construct a reduced representative
+or transport the source cuts, the ranks, simplicity, or the operators $u$ and
+$v$ from such a representative back to the original bond space.
 
 \section{Verdict}
-\textbf{Verdict: the paper's normal-tensor proposition, the source-isometry
-lemma, and Theorem~III.4 are correct for the intended reduced canonical-form-II
-representative, with zero-weight blocks and the ambient zero complement omitted;
-this reduction is not an explicit hypothesis of
+\textbf{Verdict: scope restriction.} The paper's normal-tensor proposition,
+the source-isometry lemma, and Theorem~III.4 concern the intended reduced
+canonical-form-II representative, with zero-weight blocks and the ambient zero
+complement omitted. This reduction is not an explicit hypothesis of
 Proposition~\texttt{prop:normal-tensor}, and it does not follow from literal
-canonical-form membership alone.}
+canonical-form membership alone.
 Consequently, a source-faithful formalization must construct this reduced
 representative and transport the source constructions, or explicitly assume
 chosen canonical-form-II data with full active support.  The formalization uses


### PR DESCRIPTION
## What changed

- extend the full-active-support paper-gap note from conditional normality through `lemuisometry` and Theorem III.4
- scope the planned Chapter 28 `lemuisometry` and `ThmFund1` statements to chosen reduced CFII data with full active support
- identify the normalized positive fixed point with the existing reduced-CFII transfer-stabilization supplier
- keep the four-way capstone not ready and record its remaining dependency on the complete source-$v$ contraction

This chooses issue #5855 option 2. It does not claim an ambient positive fixed point from bare `IsMPU`, construct a reduced representative, or transport source cuts and ranks.

## Validation

- blueprint source synchronization, 7,193 references resolved
- CI synchronization check
- two LuaLaTeX passes with zero undefined cross-references
- `git diff --check origin/main...HEAD`

Closes #5855
Advances #5708

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint scoping only; no application runtime, security, or data-handling code changes.
> 
> **Overview**
> This PR **narrows the documented scope** of Cirac et al.'s source-isometry lemma (`lemuisometry`) and Theorem III.4 (`ThmFund1`) to **chosen reduced canonical-form-II (CFII) data with full active support**, instead of treating them as consequences of bare `IsMPU` on an arbitrary ambient tensor.
> 
> **Blueprint (Chapter 28)** adds planned theorem statements for the **complete source-$u$ network contraction** and **complete reduced source-$v$ contraction**, both still marked not ready and tied to issues **#5982** and **#6071**. **`lemuisometry`** and **`ThmFund1`** are rewritten so hypotheses explicitly require CFII data whose active blocks fill the bond space, source factors built from the normalized positive fixed point $\rho$ supplied by **`thm:mpu_reduced_cfii_transfer_stabilization`**, and proofs that route through those network identifications plus existing MPU unitarity machinery.
> 
> The **paper-gap note** (`mpu_canonical_form_full_support.tex`) is extended from normality through **`lemuisometry`** and Theorem III.4: it explains how $\rho = V\Lambda V^\dagger$ enters the source factors, records the formal route (reduced CFII + full support), and states that **#5855** is resolved by **option 2** (explicit hypotheses) while **not** claiming construction of a reduced representative or transport of source cuts back to the original bond space.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed897c4309392fc5a9818578301291351978bf60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->