### PR TITLE
docs(MPU): correct Theorem III.4 dependency details

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3840,8 +3840,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{thm:mpu_source_u_complete_network}
   \notready
   \discussion{5982}
-  \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_source_uv,
-    def:mpo_family}
+  \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_transfer_matrix,
+    def:mpu_source_uv,def:mpo_family}
   Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
   dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
   $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
@@ -3860,8 +3860,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
   Here $\tau$ ranges over input words of length $K$, and $\eta$ ranges over
   output words of length $K+2$. This is the supplied-fixed-pair form of the
-  range-insertion equality in
-  \cite[Lemma~III.7, lines~545--557]{Cirac2017MPU}.
+  range-insertion equality in \cite[Lemma~III.7]{Cirac2017MPU}.
+  % Source locator: paper_v2.tex, lines 545--557.
 \end{theorem}
 
 \begin{proof}
@@ -3909,10 +3909,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
   Compute both source cuts, their ranks $r$ and $\ell$, the source operator
   $v$, and the right source factors $Y_1,Y_2$ from this same tensor
-  $\mathcal U$ using $\rho$. Then the supplied contraction
+  $\mathcal U$ using $\rho$. Let $W$ be the double layer of $\mathcal U$.
+  Then the supplied contraction
   \begin{align}
-    U^{ij}U^{k\ell}
-      &=U^{ij}\lvert\rho)(\Phi\rvert U^{k\ell}
+    W^{ij}W^{k\ell}
+      &=W^{ij}\lvert\rho)(\Phi\rvert W^{k\ell}
   \end{align}
   holds if and only if
   \begin{align}
@@ -3922,8 +3923,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   When $\mathcal U$ is simple,
   Theorem~\ref{thm:mpu_supplied_projector_simple2} supplies the displayed
   contraction with this same fixed pair. This is the complete equivalence in
-  \cite[equation~\texttt{vUnitary}, proof of Theorem~III.8,
-  lines~577--600]{Cirac2017MPU}.
+  \cite[equality labelled~\texttt{vUnitary} in the proof of
+  Theorem~III.8]{Cirac2017MPU}.
+  % Source locator: paper_v2.tex, lines 577--600.
 \end{theorem}
 
 \begin{proof}
@@ -3940,7 +3942,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{lemuisometry}
   \notready
   \discussion{5708}
-  \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_source_uv}
+  % **Scope restriction (supplied stabilized fixed pair):** this lemma assumes
+  % the exact rank-one transfer identity explicitly, whereas source Lemma III.7
+  % uses the preceding MPU and canonical-form-II convention. Documented in
+  % docs/paper-gaps/mpu_canonical_form_full_support.tex.
+  \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_transfer_matrix,
+    def:mpu_source_uv}
   Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
   dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
   $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
@@ -3975,6 +3982,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{ThmFund1}
   \notready
   \discussion{5708}
+  % **Scope restriction (reduced full-support representative and $D>1$):**
+  % source Theorem III.8 is stated under the preceding reduced-representative
+  % convention without these displayed hypotheses. Documented in
+  % docs/paper-gaps/mpu_canonical_form_full_support.tex.
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
     def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
     thm:mpu_reduced_cfii_transfer_stabilization}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3895,32 +3895,40 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
     def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
     def:mpu_source_v_dressing,thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_matching_direct_block_contractions,
     thm:mpu_supplied_projector_simple2}
   Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
   canonical-form-II data for its normalized flattening whose active blocks
   fill the ambient bond space. Let $\rho$ and $(\Phi\rvert$ be the normalized
   fixed pair supplied by
   Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, set
-  $J=D^2-1$ and $K=JD^2$, and put $W=\mathcal U^{[K]}$. Recompute the source
-  factors and $v$ from $W$ using $\rho$. Then the supplied contraction
+  $J=D^2-1$ and $K=JD^2$, and put $W=\mathcal U^{[K]}$. Recompute both
+  source cuts from $W$. Let $r_W$ and $\ell_W$ be their ranks, and let $u_W$
+  and $v_W$ be the source operators constructed from $W$ using $\rho$. Write
+  $Y_{1,W}$ and $Y_{2,W}$ for the corresponding right source factors. Then
+  the supplied contraction
   \begin{align}
     W^{ij}W^{k\ell}
       &=W^{ij}\lvert\rho)(\Phi\rvert W^{k\ell}
   \end{align}
   holds if and only if
   \begin{align}
-    (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
-      &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
+    (Y_{1,W}\otimes Y_{2,W})^\dagger v_W^\dagger v_W
+      (Y_{1,W}\otimes Y_{2,W})
+      &=(Y_{1,W}\otimes Y_{2,W})^\dagger(Y_{1,W}\otimes Y_{2,W}).
   \end{align}
-  When $W$ is simple, Theorem~\ref{thm:mpu_supplied_projector_simple2}
-  supplies the displayed contraction with this same stabilized pair. This is
-  the complete equality labelled \texttt{vUnitary} in
-  \cite[proof of Theorem~III.8, lines~577--588]{Cirac2017MPU}, with the
-  stabilized transfer power retained in the internal contraction.
+  Theorem~\ref{thm:mpu_matching_direct_block_contractions} supplies the
+  displayed contraction with this same stabilized pair. When $W$ is simple,
+  Theorem~\ref{thm:mpu_supplied_projector_simple2} gives the same fixed-pair
+  form directly. This is the complete equality in
+  \cite[equation~\texttt{vUnitary}, proof of Theorem~III.8,
+  lines~577--588]{Cirac2017MPU}, with the stabilized transfer power retained
+  in the internal contraction.
 \end{theorem}
 
 \begin{proof}
   \uses{thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_matching_direct_block_contractions,
     thm:mpu_supplied_projector_simple2,
     thm:mpu_supplied_witness_overlapping_reblocking,
     thm:mpu_source_v_four_u_expansions,
@@ -3976,50 +3984,58 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \discussion{5708}
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
     def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
-    thm:mpu_reduced_cfii_transfer_stabilization}
+    thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_matching_direct_block_contractions}
   Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
   canonical-form-II data for its normalized flattening whose active blocks
-  fill the ambient bond space, and construct the source factors from the
-  normalized positive right fixed point $\rho$ supplied by
-  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Let $r$, $\ell$,
-  $u$, and $v$ be the resulting source-cut ranks and source operators. Then
-  the following conditions are equivalent:
+  fill the ambient bond space. Let $\rho$ and $(\Phi\rvert$ be the normalized
+  fixed pair supplied by
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, set
+  $J=D^2-1$ and $K=JD^2$, and put $W=\mathcal U^{[K]}$. Recompute both source
+  cuts from $W$. Let $r_W$ and $\ell_W$ be their ranks, and let $u_W$ and
+  $v_W$ be the source operators constructed from $W$ using $\rho$. Then the
+  following conditions are equivalent:
   \begin{enumerate}
-    \item $\mathcal U$ is simple;
-    \item $r\ell=d^2$;
-    \item $u$ is unitary;
-    \item $v$ is unitary.
+    \item $W$ is simple;
+    \item $r_W\ell_W=(d^K)^2$;
+    \item $u_W$ is unitary;
+    \item $v_W$ is unitary.
   \end{enumerate}
 \end{theorem}
 
 \begin{proof}
-  \uses{lemuisometry,thm:mpu_supplied_projector_simple2,thm:mpu_simple1,
+  \uses{lemuisometry,thm:mpu_matching_direct_block_contractions,
+    thm:mpu_supplied_projector_simple2,
     thm:mpu_source_v_complete_reduced_contraction,
     thm:mpu_source_uv_two_site_factorization,
     thm:mpu_source_v_dressed_gram_cancel}
-  Lemma~\ref{lemuisometry} gives $u^\dagger u=\Id$ before any of the four
-  conditions is assumed. Thus $u$ is a standing isometry and
-  $r\ell\geq d^2$ throughout the proof.
+  Apply Lemma~\ref{lemuisometry} to the blocked tensor $W$ and its source
+  factors. This gives $u_W^\dagger u_W=\Id$ before any of the four conditions
+  is assumed. Thus $u_W$ is a standing isometry and
+  $r_W\ell_W\geq(d^K)^2$ throughout the proof.
 
-  Suppose first that $\mathcal U$ is simple. The stabilized transfer power and
-  Theorem~\ref{thm:mpu_supplied_projector_simple2} give the second contraction
-  with the supplied pair $\lvert\rho)(\Phi\rvert$. By
+  Suppose first that $W$ is simple. The direct-block matching contractions
+  obtained from $E^J=\lvert\rho)(\Phi\rvert$, together with
+  Theorem~\ref{thm:mpu_supplied_projector_simple2}, give the second contraction
+  for $W$ with this same fixed pair. By
   Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction},
   \begin{align}
-    (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
-      &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
+    (Y_{1,W}\otimes Y_{2,W})^\dagger v_W^\dagger v_W
+      (Y_{1,W}\otimes Y_{2,W})
+      &=(Y_{1,W}\otimes Y_{2,W})^\dagger(Y_{1,W}\otimes Y_{2,W}).
   \end{align}
-  Cancelling the dressing by the right inverses of $Y_1$ and $Y_2$ gives
-  $v^\dagger v=\Id$, hence $r\ell\leq d^2$. Together with the standing
-  source-$u$ isometry, this gives $r\ell=d^2$.
+  Cancelling the dressing by the right inverses of $Y_{1,W}$ and $Y_{2,W}$
+  gives $v_W^\dagger v_W=\Id$, hence $r_W\ell_W\leq(d^K)^2$. Together with
+  the standing source-$u_W$ isometry, this gives $r_W\ell_W=(d^K)^2$.
 
-  If $r\ell=d^2$, the standing isometry $u$ is square and therefore unitary.
-  If $u$ is unitary, the exact two-site factorization of $U^{(2)}$ and
-  unitarity of $U^{(2)}$ imply that $v$ is unitary. Finally, suppose that $v$
-  is unitary. The fixed-point identity gives the first simple-tensor
-  contraction. Unitarity of $v$ gives the dressed Gram identity, and
+  If $r_W\ell_W=(d^K)^2$, the standing isometry $u_W$ is square and therefore
+  unitary. If $u_W$ is unitary, the exact two-site factorization of $W^{(2)}$
+  and unitarity of $W^{(2)}$ imply that $v_W$ is unitary. Finally, suppose that
+  $v_W$ is unitary. Unitarity gives the dressed Gram identity, and
   Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction} gives the
-  supplied second contraction.
+  supplied second contraction for $W$.
+  Theorem~\ref{thm:mpu_matching_direct_block_contractions} supplies the first
+  contraction with the same pair, so $W$ is simple.
 \end{proof}
 
 \begin{definition}[Standard form]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3840,52 +3840,56 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{thm:mpu_source_u_complete_network}
   \notready
   \discussion{5982}
-  \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
-    def:mpu_full_active_support,def:mpu_source_uv,def:mpo_family,
-    thm:mpu_reduced_cfii_transfer_stabilization}
-  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
-  canonical-form-II data for its normalized flattening whose active blocks
-  fill the ambient bond space, and let $\rho$ be the normalized positive right
-  fixed point supplied by
-  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Set
+  \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_source_uv,
+    def:mpo_family,thm:mpu_reflected_transfer_power,
+    thm:mpu_matching_direct_block_contractions,
+    thm:mpu_supplied_witness_overlapping_reblocking,
+    thm:mpu_reflected_supplied_contractions}
+  Let $W$ be an MPU tensor with physical dimension $q>0$ and bond dimension
+  $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
+  $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that the
+  normalized transfer matrix of $W$ satisfies
   \begin{align}
-    J&=D^2-1,\\
-    K&=JD^2.
+    E_W&=\lvert\rho)(\Phi\rvert.
   \end{align}
-  For retained physical pairs $p,q\in\{0,\ldots,d-1\}^2$, the complete
-  source-$u$ contraction satisfies
+  Construct the source factors and $u_W$ from $W$ using $\rho$, and set
+  $L=D^2$. For retained physical pairs
+  $p,q'\in\{0,\ldots,q-1\}^2$, the complete source-$u$ contraction satisfies
   \begin{align}
-    \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
-      &=d^{-K}\sum_{\tau,\eta}
-        U^{(K+2)}_{(q,\tau),\eta}
-        \overline{U^{(K+2)}_{(p,\tau),\eta}}.
+    \sum_{l,r}(u_W)_{(l,r),q'}\overline{(u_W)_{(l,r),p}}
+      &=q^{-L}\sum_{\tau,\eta}
+        W^{(L+2)}_{(q',\tau),\eta}
+        \overline{W^{(L+2)}_{(p,\tau),\eta}}.
   \end{align}
-  Here $\tau$ ranges over input words of length $K$, and $\eta$ ranges over
-  output words of length $K+2$. This is the range-insertion equality in the
-  proof of \cite[Lemma~III.7, lines~545--557]{Cirac2017MPU}.
+  Here $\tau$ ranges over input words of length $L$, and $\eta$ ranges over
+  output words of length $L+2$. This is the supplied-fixed-pair form of the
+  range-insertion equality in
+  \cite[Lemma~III.7, lines~545--557]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:mpu_reduced_cfii_transfer_stabilization,
-    thm:mpu_reflected_transfer_power,
+  \uses{thm:mpu_reflected_transfer_power,
+    thm:mpu_matching_direct_block_contractions,
+    thm:mpu_supplied_witness_overlapping_reblocking,
     thm:mpu_reflected_supplied_contractions,
     thm:mpu_source_x1_range_projection,
     thm:mpu_source_x2_range_projection,
     thm:mpu_source_u_gram_second_cut_metric,
     thm:mpu_source_u_terminal_boundary,
     thm:mpu_normalized_output_tail_closed_trace}
-  The stabilized transfer power is
-  $E^J=\lvert\rho)(\Phi\rvert$. Its reflected form supplies the aligned
-  one- and two-letter contractions at lengths $K$ and $K+2$. Expand the
-  ordinary Gram entry while retaining both external source-$u$ tensors and
-  the full $\rho$-weighted boundary. Insert the first- and second-cut range
-  projections, but contract them only inside this closed $(K+2)$-site
-  network. The remaining step is a simultaneous use of the reflected
-  one- and two-letter contractions to move the second-cut metric through the
-  overlapping windows. Only after every virtual and source index is closed
-  does the terminal boundary contraction reduce the network to the normalized
-  output-first trace displayed above. No separate identity for the second-cut
-  metric or either ambient range projection is asserted.
+  Apply the direct and reflected supplied-contraction theorems to $W$ with
+  exponent one. The identity
+  $E_W=\lvert\rho)(\Phi\rvert$ supplies the aligned one- and two-letter
+  contractions at lengths $L$ and $L+2$, with the same fixed pair at both
+  lengths. Expand the ordinary Gram entry while retaining both external
+  source-$u_W$ tensors and the full $\rho$-weighted boundary. Insert the
+  first- and second-cut range projections, but contract them only inside this
+  closed $(L+2)$-site network. The remaining step is a simultaneous use of
+  the reflected one- and two-letter contractions to move the second-cut
+  metric through the overlapping windows. Only after every virtual and source
+  index is closed does the terminal boundary contraction reduce the network
+  to the normalized output-first trace displayed above. No separate identity
+  for the second-cut metric or either ambient range projection is asserted.
 \end{proof}
 
 \begin{theorem}[Complete reduced source-$v$ contraction]
@@ -3945,37 +3949,36 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{lemuisometry}
   \notready
   \discussion{5708}
-  \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
-    def:mpu_full_active_support,def:mpu_source_uv,
-    thm:mpu_reduced_cfii_transfer_stabilization}
-  Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
-  canonical-form-II data for its normalized flattening whose active blocks
-  fill the ambient bond space. Let $\rho$ be the normalized positive right
-  fixed point supplied by
-  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, and use $\rho$ in
-  the source factors associated with the two source cuts. Then
+  \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_source_uv,
+    thm:mpu_reflected_transfer_power,
+    thm:mpu_matching_direct_block_contractions,
+    thm:mpu_supplied_witness_overlapping_reblocking,
+    thm:mpu_reflected_supplied_contractions,
+    thm:mpu_source_u_complete_network}
+  Let $W$ be an MPU tensor with physical dimension $q>0$ and bond dimension
+  $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
+  $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that the
+  normalized transfer matrix of $W$ satisfies
   \begin{align}
-    u^\dagger u&=\Id.
+    E_W&=\lvert\rho)(\Phi\rvert.
   \end{align}
-  Consequently $u$ is an isometry and $r\ell\geq d^2$.
+  Let $r_W$ and $\ell_W$ be the two source-cut ranks, and construct the source
+  factors and $u_W$ from $W$ using $\rho$. The direct and reflected
+  supplied-contraction theorems then provide the common fixed-pair package at
+  lengths $D^2$ and $D^2+2$. One has
+  \begin{align}
+    u_W^\dagger u_W&=\Id.
+  \end{align}
+  Consequently $u_W$ is an isometry and $r_W\ell_W\geq q^2$.
 \end{lemma}
 
 \begin{proof}
-  \uses{thm:mpu_reduced_cfii_transfer_stabilization,
-    thm:mpu_source_u_complete_network,
+  \uses{thm:mpu_source_u_complete_network,
     thm:mpu_normalized_output_tail_coisometry}
-  Set $J=D^2-1$ and $K=JD^2$. The chosen reduced canonical-form-II data give
-  \begin{align}
-    \rho&>0,\\
-    \tr(\rho)&=1,\\
-    E\lvert\rho)&=\lvert\rho),\\
-    (\Phi\rvert E&=(\Phi\rvert,\\
-    E^J&=\lvert\rho)(\Phi\rvert.
-  \end{align}
-  By Theorem~\ref{thm:mpu_source_u_complete_network}, the $(p,q)$ entry of
-  $u^\dagger u$ is the normalized contraction of
-  $U^{(K+2)}U^{(K+2)\dagger}$ with a common length-$K$ input tail. MPU
-  unitarity evaluates this output-first contraction as $\delta_{p,q}$.
+  Set $L=D^2$. By Theorem~\ref{thm:mpu_source_u_complete_network}, the
+  $(p,q')$ entry of $u_W^\dagger u_W$ is the normalized contraction of
+  $W^{(L+2)}W^{(L+2)\dagger}$ with a common length-$L$ input tail. MPU
+  unitarity evaluates this output-first contraction as $\delta_{p,q'}$.
 \end{proof}
 
 \begin{theorem}[Simple-tensor equivalence theorem]
@@ -3985,16 +3988,21 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
     def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
     thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_reflected_transfer_power,
     thm:mpu_matching_direct_block_contractions}
   Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
   canonical-form-II data for its normalized flattening whose active blocks
   fill the ambient bond space. Let $\rho$ and $(\Phi\rvert$ be the normalized
   fixed pair supplied by
   Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, set
-  $J=D^2-1$ and $K=JD^2$, and put $W=\mathcal U^{[K]}$. Recompute both source
-  cuts from $W$. Let $r_W$ and $\ell_W$ be their ranks, and let $u_W$ and
-  $v_W$ be the source operators constructed from $W$ using $\rho$. Then the
-  following conditions are equivalent:
+  $J=D^2-1$ and $K=JD^2$, and put $W=\mathcal U^{[K]}$. The blocked transfer
+  identity is
+  \begin{align}
+    E_W&=\lvert\rho)(\Phi\rvert.
+  \end{align}
+  Recompute both source cuts from $W$. Let $r_W$ and $\ell_W$ be their ranks,
+  and let $u_W$ and $v_W$ be the source operators constructed from $W$ using
+  $\rho$. Then the following conditions are equivalent:
   \begin{enumerate}
     \item $W$ is simple;
     \item $r_W\ell_W=(d^K)^2$;
@@ -4004,14 +4012,18 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}
-  \uses{lemuisometry,thm:mpu_matching_direct_block_contractions,
+  \uses{lemuisometry,thm:mpu_reflected_transfer_power,
+    thm:mpu_matching_direct_block_contractions,
     thm:mpu_supplied_projector_simple2,
     thm:mpu_source_v_complete_reduced_contraction,
     thm:mpu_source_uv_two_site_factorization,
     thm:mpu_source_v_dressed_gram_cancel}
-  Apply Lemma~\ref{lemuisometry} to the blocked tensor $W$ and its source
-  factors. This gives $u_W^\dagger u_W=\Id$ before any of the four conditions
-  is assumed. Thus $u_W$ is a standing isometry and
+  The reduced full-support data give
+  $E^J=\lvert\rho)(\Phi\rvert$. The blocked transfer-power identity gives
+  $E_W=\lvert\rho)(\Phi\rvert$ with the same positive trace-one matrix.
+  Lemma~\ref{lemuisometry} therefore applies directly to $W$ and its source
+  factors. It gives $u_W^\dagger u_W=\Id$ before any of the four conditions is
+  assumed. Thus $u_W$ is a standing isometry and
   $r_W\ell_W\geq(d^K)^2$ throughout the proof.
 
   Suppose first that $W$ is simple. The direct-block matching contractions

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3862,22 +3862,30 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
   Here $\tau$ ranges over input words of length $K$, and $\eta$ ranges over
   output words of length $K+2$. This is the range-insertion equality in the
-  proof of \cite[Lemma~III.3]{Cirac2017MPU}.
+  proof of \cite[Lemma~III.7, lines~545--557]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}
   \uses{thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_reflected_transfer_power,
+    thm:mpu_reflected_supplied_contractions,
+    thm:mpu_source_x1_range_projection,
+    thm:mpu_source_x2_range_projection,
     thm:mpu_source_u_gram_second_cut_metric,
-    thm:mpu_supplied_witness_overlapping_reblocking,
     thm:mpu_source_u_terminal_boundary,
     thm:mpu_normalized_output_tail_closed_trace}
   The stabilized transfer power is
-  $E^J=\lvert\rho)(\Phi\rvert$. Blocking a further $D^2$ sites gives the two
-  simple contractions at length $K$. Expand the ordinary Gram entry through
-  the two source cuts, insert their range projections, and apply these
-  contractions to the intervening blocked network. The terminal source-factor
-  contraction removes the remaining boundary indices. The resulting closed
-  network is the normalized $(K+2)$-site contraction displayed above.
+  $E^J=\lvert\rho)(\Phi\rvert$. Its reflected form supplies the aligned
+  one- and two-letter contractions at lengths $K$ and $K+2$. Expand the
+  ordinary Gram entry while retaining both external source-$u$ tensors and
+  the full $\rho$-weighted boundary. Insert the first- and second-cut range
+  projections, but contract them only inside this closed $(K+2)$-site
+  network. The remaining step is a simultaneous use of the reflected
+  one- and two-letter contractions to move the second-cut metric through the
+  overlapping windows. Only after every virtual and source index is closed
+  does the terminal boundary contraction reduce the network to the normalized
+  output-first trace displayed above. No separate identity for the second-cut
+  metric or either ambient range projection is asserted.
 \end{proof}
 
 \begin{theorem}[Complete reduced source-$v$ contraction]
@@ -3885,32 +3893,44 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \notready
   \discussion{6071}
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
-    def:mpu_full_active_support,def:mpu_simple,
-    def:mpu_source_v_dressing,thm:mpu_reduced_cfii_transfer_stabilization}
+    def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
+    def:mpu_source_v_dressing,thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_supplied_projector_simple2}
   Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
   canonical-form-II data for its normalized flattening whose active blocks
-  fill the ambient bond space, and construct the source factors from the
-  normalized positive right fixed point $\rho$ supplied by
-  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Then the second
-  simple-tensor contraction~(\ref{eq:mpu_simple2}) holds if and only if
+  fill the ambient bond space. Let $\rho$ and $(\Phi\rvert$ be the normalized
+  fixed pair supplied by
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, set
+  $J=D^2-1$ and $K=JD^2$, and put $W=\mathcal U^{[K]}$. Recompute the source
+  factors and $v$ from $W$ using $\rho$. Then the supplied contraction
+  \begin{align}
+    W^{ij}W^{k\ell}
+      &=W^{ij}\lvert\rho)(\Phi\rvert W^{k\ell}
+  \end{align}
+  holds if and only if
   \begin{align}
     (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
       &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
   \end{align}
-  This is the complete blocked-network identification in equation~(31) of
-  \cite[Theorem~III.4]{Cirac2017MPU}, with the stabilized transfer power
-  inserted in the internal contraction.
+  When $W$ is simple, Theorem~\ref{thm:mpu_supplied_projector_simple2}
+  supplies the displayed contraction with this same stabilized pair. This is
+  the complete equality labelled \texttt{vUnitary} in
+  \cite[proof of Theorem~III.8, lines~577--588]{Cirac2017MPU}, with the
+  stabilized transfer power retained in the internal contraction.
 \end{theorem}
 
 \begin{proof}
   \uses{thm:mpu_reduced_cfii_transfer_stabilization,
+    thm:mpu_supplied_projector_simple2,
     thm:mpu_supplied_witness_overlapping_reblocking,
     thm:mpu_source_v_four_u_expansions,
     thm:mpu_source_v_dressed_entries}
   Insert $E^{D^2-1}=\lvert\rho)(\Phi\rvert$ into the complete blocked network.
-  Expand both source cuts and rotate the second cut. The resulting four-letter
-  expression identifies the second simple-tensor contraction with the dressed
-  Gram equation in both directions.
+  The supplied-projector theorem fixes the insertion witnesses as
+  $\lvert\rho)(\Phi\rvert$, rather than an arbitrary pair from simplicity.
+  Expand both source cuts and rotate the second cut. Contract the resulting
+  four-letter expression as one closed network to obtain the dressed Gram
+  equation, and reverse the same calculation for the converse.
 \end{proof}
 
 \begin{lemma}[The source operator $u$ is an isometry]
@@ -3946,8 +3966,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
   By Theorem~\ref{thm:mpu_source_u_complete_network}, the $(p,q)$ entry of
   $u^\dagger u$ is the normalized contraction of
-  $U^{(K+2)\dagger}U^{(K+2)}$ with a common length-$K$ input tail. MPU
-  unitarity evaluates this contraction as $\delta_{p,q}$.
+  $U^{(K+2)}U^{(K+2)\dagger}$ with a common length-$K$ input tail. MPU
+  unitarity evaluates this output-first contraction as $\delta_{p,q}$.
 \end{proof}
 
 \begin{theorem}[Simple-tensor equivalence theorem]
@@ -3973,29 +3993,33 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:mpu_source_u_complete_network,
-    thm:mpu_normalized_output_tail_coisometry,thm:mpu_simple1,
+  \uses{lemuisometry,thm:mpu_supplied_projector_simple2,thm:mpu_simple1,
     thm:mpu_source_v_complete_reduced_contraction,
     thm:mpu_source_uv_two_site_factorization,
     thm:mpu_source_v_dressed_gram_cancel}
-  Suppose first that $\mathcal U$ is simple. By
+  Lemma~\ref{lemuisometry} gives $u^\dagger u=\Id$ before any of the four
+  conditions is assumed. Thus $u$ is a standing isometry and
+  $r\ell\geq d^2$ throughout the proof.
+
+  Suppose first that $\mathcal U$ is simple. The stabilized transfer power and
+  Theorem~\ref{thm:mpu_supplied_projector_simple2} give the second contraction
+  with the supplied pair $\lvert\rho)(\Phi\rvert$. By
   Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction},
   \begin{align}
     (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
       &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
   \end{align}
   Cancelling the dressing by the right inverses of $Y_1$ and $Y_2$ gives
-  $v^\dagger v=\Id$. Hence $r\ell\leq d^2$. The complete source-$u$
-  contraction and MPU unitarity give $u^\dagger u=\Id$, hence
-  $r\ell\geq d^2$.
+  $v^\dagger v=\Id$, hence $r\ell\leq d^2$. Together with the standing
+  source-$u$ isometry, this gives $r\ell=d^2$.
 
-  If $r\ell=d^2$, the isometry $u$ is square and therefore unitary. If $u$
-  is unitary, the exact two-site factorization of $U^{(2)}$ and unitarity of
-  $U^{(2)}$ imply that $v$ is unitary. Finally, suppose that $v$ is unitary.
-  The fixed-point identity gives the first simple-tensor contraction.
-  Unitarity of $v$ gives the dressed Gram identity, and
-  Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction} gives the second
-  contraction.
+  If $r\ell=d^2$, the standing isometry $u$ is square and therefore unitary.
+  If $u$ is unitary, the exact two-site factorization of $U^{(2)}$ and
+  unitarity of $U^{(2)}$ imply that $v$ is unitary. Finally, suppose that $v$
+  is unitary. The fixed-point identity gives the first simple-tensor
+  contraction. Unitarity of $v$ gives the dressed Gram identity, and
+  Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction} gives the
+  supplied second contraction.
 \end{proof}
 
 \begin{definition}[Standard form]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3841,28 +3841,25 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \notready
   \discussion{5982}
   \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_source_uv,
-    def:mpo_family,thm:mpu_reflected_transfer_power,
-    thm:mpu_matching_direct_block_contractions,
-    thm:mpu_supplied_witness_overlapping_reblocking,
-    thm:mpu_reflected_supplied_contractions}
-  Let $W$ be an MPU tensor with physical dimension $q>0$ and bond dimension
-  $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
-  $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that the
-  normalized transfer matrix of $W$ satisfies
+    def:mpo_family}
+  Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
+  dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
+  $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
+  some $J>0$ the normalized transfer matrix satisfies
   \begin{align}
-    E_W&=\lvert\rho)(\Phi\rvert.
+    E^J&=\lvert\rho)(\Phi\rvert.
   \end{align}
-  Construct the source factors and $u_W$ from $W$ using $\rho$, and set
-  $L=D^2$. For retained physical pairs
-  $p,q'\in\{0,\ldots,q-1\}^2$, the complete source-$u$ contraction satisfies
+  Construct the source factors and $u$ from $\mathcal U$ using $\rho$, and set
+  $K=JD^2$. For retained physical pairs
+  $p,q\in\{0,\ldots,d-1\}^2$, the complete source-$u$ contraction satisfies
   \begin{align}
-    \sum_{l,r}(u_W)_{(l,r),q'}\overline{(u_W)_{(l,r),p}}
-      &=q^{-L}\sum_{\tau,\eta}
-        W^{(L+2)}_{(q',\tau),\eta}
-        \overline{W^{(L+2)}_{(p,\tau),\eta}}.
+    \sum_{l,r}u_{(l,r),q}\overline{u_{(l,r),p}}
+      &=d^{-K}\sum_{\tau,\eta}
+        U^{(K+2)}_{(q,\tau),\eta}
+        \overline{U^{(K+2)}_{(p,\tau),\eta}}.
   \end{align}
-  Here $\tau$ ranges over input words of length $L$, and $\eta$ ranges over
-  output words of length $L+2$. This is the supplied-fixed-pair form of the
+  Here $\tau$ ranges over input words of length $K$, and $\eta$ ranges over
+  output words of length $K+2$. This is the supplied-fixed-pair form of the
   range-insertion equality in
   \cite[Lemma~III.7, lines~545--557]{Cirac2017MPU}.
 \end{theorem}
@@ -3877,19 +3874,21 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     thm:mpu_source_u_gram_second_cut_metric,
     thm:mpu_source_u_terminal_boundary,
     thm:mpu_normalized_output_tail_closed_trace}
-  Apply the direct and reflected supplied-contraction theorems to $W$ with
-  exponent one. The identity
-  $E_W=\lvert\rho)(\Phi\rvert$ supplies the aligned one- and two-letter
-  contractions at lengths $L$ and $L+2$, with the same fixed pair at both
-  lengths. Expand the ordinary Gram entry while retaining both external
-  source-$u_W$ tensors and the full $\rho$-weighted boundary. Insert the
-  first- and second-cut range projections, but contract them only inside this
-  closed $(L+2)$-site network. The remaining step is a simultaneous use of
-  the reflected one- and two-letter contractions to move the second-cut
-  metric through the overlapping windows. Only after every virtual and source
-  index is closed does the terminal boundary contraction reduce the network
-  to the normalized output-first trace displayed above. No separate identity
-  for the second-cut metric or either ambient range projection is asserted.
+  Put $W=\mathcal U^{[K]}$. The reflected transfer-power identity, the direct
+  matching contractions, and supplied-witness reblocking give the aligned
+  direct and reflected contractions at lengths $K$ and $K+2$, with the same
+  fixed pair at both lengths. The block $W$ is used
+  only inside this contraction argument; the external source tensors are the
+  source-$u$ factors of $\mathcal U$.
+
+  Expand the ordinary Gram entry while retaining both external source-$u$
+  tensors and the full $\rho$-weighted boundary. Insert the first- and
+  second-cut range projections, but contract them only inside the closed
+  $(K+2)$-site network. The reflected contractions move the second-cut metric
+  through the overlapping windows. After every virtual and source index is
+  closed, the terminal boundary contraction gives the normalized output-first
+  trace displayed above. No separate identity for the second-cut metric or
+  either ambient range projection is asserted.
 \end{proof}
 
 \begin{theorem}[Complete reduced source-$v$ contraction]
@@ -3899,86 +3898,77 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
     def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
     def:mpu_source_v_dressing,thm:mpu_reduced_cfii_transfer_stabilization,
-    thm:mpu_matching_direct_block_contractions,
     thm:mpu_supplied_projector_simple2}
   Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
   canonical-form-II data for its normalized flattening whose active blocks
   fill the ambient bond space. Let $\rho$ and $(\Phi\rvert$ be the normalized
   fixed pair supplied by
-  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, set
-  $J=D^2-1$ and $K=JD^2$, and put $W=\mathcal U^{[K]}$. Recompute both
-  source cuts from $W$. Let $r_W$ and $\ell_W$ be their ranks, and let $u_W$
-  and $v_W$ be the source operators constructed from $W$ using $\rho$. Write
-  $Y_{1,W}$ and $Y_{2,W}$ for the corresponding right source factors. Then
-  the supplied contraction
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, so that
   \begin{align}
-    W^{ij}W^{k\ell}
-      &=W^{ij}\lvert\rho)(\Phi\rvert W^{k\ell}
+    E^{D^2-1}&=\lvert\rho)(\Phi\rvert.
+  \end{align}
+  Compute both source cuts, their ranks $r$ and $\ell$, the source operator
+  $v$, and the right source factors $Y_1,Y_2$ from this same tensor
+  $\mathcal U$ using $\rho$. Then the supplied contraction
+  \begin{align}
+    U^{ij}U^{k\ell}
+      &=U^{ij}\lvert\rho)(\Phi\rvert U^{k\ell}
   \end{align}
   holds if and only if
   \begin{align}
-    (Y_{1,W}\otimes Y_{2,W})^\dagger v_W^\dagger v_W
-      (Y_{1,W}\otimes Y_{2,W})
-      &=(Y_{1,W}\otimes Y_{2,W})^\dagger(Y_{1,W}\otimes Y_{2,W}).
+    (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
+      &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
   \end{align}
-  Theorem~\ref{thm:mpu_matching_direct_block_contractions} supplies the
-  displayed contraction with this same stabilized pair. When $W$ is simple,
-  Theorem~\ref{thm:mpu_supplied_projector_simple2} gives the same fixed-pair
-  form directly. This is the complete equality in
+  When $\mathcal U$ is simple,
+  Theorem~\ref{thm:mpu_supplied_projector_simple2} supplies the displayed
+  contraction with this same fixed pair. This is the complete equivalence in
   \cite[equation~\texttt{vUnitary}, proof of Theorem~III.8,
-  lines~577--588]{Cirac2017MPU}, with the stabilized transfer power retained
-  in the internal contraction.
+  lines~577--600]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:mpu_reduced_cfii_transfer_stabilization,
-    thm:mpu_matching_direct_block_contractions,
-    thm:mpu_supplied_projector_simple2,
-    thm:mpu_supplied_witness_overlapping_reblocking,
-    thm:mpu_source_v_four_u_expansions,
+  \uses{thm:mpu_source_v_four_u_expansions,
     thm:mpu_source_v_dressed_entries}
-  Insert $E^{D^2-1}=\lvert\rho)(\Phi\rvert$ into the complete blocked network.
-  The supplied-projector theorem fixes the insertion witnesses as
-  $\lvert\rho)(\Phi\rvert$, rather than an arbitrary pair from simplicity.
-  Expand both source cuts and rotate the second cut. Contract the resulting
-  four-letter expression as one closed network to obtain the dressed Gram
-  equation, and reverse the same calculation for the converse.
+  Insert $E^{D^2-1}=\lvert\rho)(\Phi\rvert$ into the complete network while
+  retaining the source factors of $\mathcal U$. Expand both source cuts and
+  rotate the second cut. Contract the resulting four-letter expression as one
+  closed network to obtain the dressed Gram equation, and reverse the same
+  calculation for the converse.
 \end{proof}
 
 \begin{lemma}[The source operator $u$ is an isometry]
   \label{lemuisometry}
   \notready
   \discussion{5708}
-  \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_source_uv,
-    thm:mpu_reflected_transfer_power,
-    thm:mpu_matching_direct_block_contractions,
-    thm:mpu_supplied_witness_overlapping_reblocking,
-    thm:mpu_reflected_supplied_contractions,
-    thm:mpu_source_u_complete_network}
-  Let $W$ be an MPU tensor with physical dimension $q>0$ and bond dimension
-  $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
-  $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that the
-  normalized transfer matrix of $W$ satisfies
+  \uses{def:mpu,def:mpu_normalized_flattening,def:mpu_source_uv}
+  Let $\mathcal U$ be an MPU tensor with physical dimension $d>0$ and bond
+  dimension $D>0$. Let $\rho>0$ satisfy $\tr(\rho)=1$, put
+  $(\Phi\rvert=\operatorname{vec}(\Id_D)^{\mathsf T}$, and suppose that for
+  some $J>0$ the normalized transfer matrix satisfies
   \begin{align}
-    E_W&=\lvert\rho)(\Phi\rvert.
+    E^J&=\lvert\rho)(\Phi\rvert.
   \end{align}
-  Let $r_W$ and $\ell_W$ be the two source-cut ranks, and construct the source
-  factors and $u_W$ from $W$ using $\rho$. The direct and reflected
-  supplied-contraction theorems then provide the common fixed-pair package at
-  lengths $D^2$ and $D^2+2$. One has
+  Let $r$ and $\ell$ be the two source-cut ranks, and construct the source
+  factors and $u$ from $\mathcal U$ using $\rho$. Then
   \begin{align}
-    u_W^\dagger u_W&=\Id.
+    u^\dagger u&=\Id.
   \end{align}
-  Consequently $u_W$ is an isometry and $r_W\ell_W\geq q^2$.
+  Consequently $u$ is an isometry and $r\ell\geq d^2$.
 \end{lemma}
 
 \begin{proof}
   \uses{thm:mpu_source_u_complete_network,
     thm:mpu_normalized_output_tail_coisometry}
-  Set $L=D^2$. By Theorem~\ref{thm:mpu_source_u_complete_network}, the
-  $(p,q')$ entry of $u_W^\dagger u_W$ is the normalized contraction of
-  $W^{(L+2)}W^{(L+2)\dagger}$ with a common length-$L$ input tail. MPU
-  unitarity evaluates this output-first contraction as $\delta_{p,q'}$.
+  Set $K=JD^2$. The complete-network identity and output-first MPU unitarity
+  give, for all retained physical pairs $p,q$,
+  \begin{align}
+    (u^\dagger u)_{p,q}
+      &=d^{-K}\sum_{\tau,\eta}
+        U^{(K+2)}_{(q,\tau),\eta}
+        \overline{U^{(K+2)}_{(p,\tau),\eta}}\\
+      &=\delta_{p,q}.
+  \end{align}
+  Hence $u^\dagger u=\Id$.
 \end{proof}
 
 \begin{theorem}[Simple-tensor equivalence theorem]
@@ -3987,67 +3977,54 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \discussion{5708}
   \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
     def:mpu_full_active_support,def:mpu_simple,def:mpu_source_uv,
-    thm:mpu_reduced_cfii_transfer_stabilization,
-    thm:mpu_reflected_transfer_power,
-    thm:mpu_matching_direct_block_contractions}
+    thm:mpu_reduced_cfii_transfer_stabilization}
   Let $\mathcal U$ be an MPU tensor with $d>0$ and $D>1$. Choose
   canonical-form-II data for its normalized flattening whose active blocks
   fill the ambient bond space. Let $\rho$ and $(\Phi\rvert$ be the normalized
   fixed pair supplied by
-  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}, set
-  $J=D^2-1$ and $K=JD^2$, and put $W=\mathcal U^{[K]}$. The blocked transfer
-  identity is
-  \begin{align}
-    E_W&=\lvert\rho)(\Phi\rvert.
-  \end{align}
-  Recompute both source cuts from $W$. Let $r_W$ and $\ell_W$ be their ranks,
-  and let $u_W$ and $v_W$ be the source operators constructed from $W$ using
-  $\rho$. Then the following conditions are equivalent:
+  Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization}. Compute the
+  source-cut ranks $r$ and $\ell$ and the source operators $u$ and $v$ from
+  this same tensor $\mathcal U$ using $\rho$. Then the following conditions
+  are equivalent:
   \begin{enumerate}
-    \item $W$ is simple;
-    \item $r_W\ell_W=(d^K)^2$;
-    \item $u_W$ is unitary;
-    \item $v_W$ is unitary.
+    \item $\mathcal U$ is simple;
+    \item $r\ell=d^2$;
+    \item $u$ is unitary;
+    \item $v$ is unitary.
   \end{enumerate}
 \end{theorem}
 
 \begin{proof}
-  \uses{lemuisometry,thm:mpu_reflected_transfer_power,
-    thm:mpu_matching_direct_block_contractions,
-    thm:mpu_supplied_projector_simple2,
+  \uses{lemuisometry,thm:mpu_supplied_projector_simple2,
+    thm:mpu_supplied_witness_overlapping_reblocking,
     thm:mpu_source_v_complete_reduced_contraction,
     thm:mpu_source_uv_two_site_factorization,
     thm:mpu_source_v_dressed_gram_cancel}
-  The reduced full-support data give
-  $E^J=\lvert\rho)(\Phi\rvert$. The blocked transfer-power identity gives
-  $E_W=\lvert\rho)(\Phi\rvert$ with the same positive trace-one matrix.
-  Lemma~\ref{lemuisometry} therefore applies directly to $W$ and its source
-  factors. It gives $u_W^\dagger u_W=\Id$ before any of the four conditions is
-  assumed. Thus $u_W$ is a standing isometry and
-  $r_W\ell_W\geq(d^K)^2$ throughout the proof.
+  Lemma~\ref{lemuisometry} gives $u^\dagger u=\Id$ before any of the four
+  conditions is assumed. Thus $u$ is a standing isometry and
+  $r\ell\geq d^2$ throughout the proof.
 
-  Suppose first that $W$ is simple. The direct-block matching contractions
-  obtained from $E^J=\lvert\rho)(\Phi\rvert$, together with
-  Theorem~\ref{thm:mpu_supplied_projector_simple2}, give the second contraction
-  for $W$ with this same fixed pair. By
+  Suppose first that $\mathcal U$ is simple.
+  Theorem~\ref{thm:mpu_supplied_projector_simple2}, applied to the stabilized
+  transfer power, gives the second contraction with the supplied pair
+  $\lvert\rho)(\Phi\rvert$. By
   Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction},
   \begin{align}
-    (Y_{1,W}\otimes Y_{2,W})^\dagger v_W^\dagger v_W
-      (Y_{1,W}\otimes Y_{2,W})
-      &=(Y_{1,W}\otimes Y_{2,W})^\dagger(Y_{1,W}\otimes Y_{2,W}).
+    (Y_1\otimes Y_2)^\dagger v^\dagger v(Y_1\otimes Y_2)
+      &=(Y_1\otimes Y_2)^\dagger(Y_1\otimes Y_2).
   \end{align}
-  Cancelling the dressing by the right inverses of $Y_{1,W}$ and $Y_{2,W}$
-  gives $v_W^\dagger v_W=\Id$, hence $r_W\ell_W\leq(d^K)^2$. Together with
-  the standing source-$u_W$ isometry, this gives $r_W\ell_W=(d^K)^2$.
+  Cancelling the dressing by the right inverses of $Y_1$ and $Y_2$ gives
+  $v^\dagger v=\Id$, hence $r\ell\leq d^2$. Together with the standing
+  source-$u$ isometry, this gives $r\ell=d^2$.
 
-  If $r_W\ell_W=(d^K)^2$, the standing isometry $u_W$ is square and therefore
-  unitary. If $u_W$ is unitary, the exact two-site factorization of $W^{(2)}$
-  and unitarity of $W^{(2)}$ imply that $v_W$ is unitary. Finally, suppose that
-  $v_W$ is unitary. Unitarity gives the dressed Gram identity, and
+  If $r\ell=d^2$, the standing isometry $u$ is square and therefore unitary.
+  If $u$ is unitary, the exact two-site factorization of $U^{(2)}$ and
+  unitarity of $U^{(2)}$ imply that $v$ is unitary. Finally, suppose that $v$
+  is unitary. Unitarity gives the dressed Gram identity, and
   Theorem~\ref{thm:mpu_source_v_complete_reduced_contraction} gives the
-  supplied second contraction for $W$.
-  Theorem~\ref{thm:mpu_matching_direct_block_contractions} supplies the first
-  contraction with the same pair, so $W$ is simple.
+  supplied second contraction for $\mathcal U$. The same-witness implication
+  in Theorem~\ref{thm:mpu_supplied_witness_overlapping_reblocking} supplies
+  the first contraction, so $\mathcal U$ is simple.
 \end{proof}
 
 \begin{definition}[Standard form]

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -136,7 +136,8 @@ used to replace the source cuts, ranks, or operators of $\mathcal U$, and no
 transport of source data across blocking is asserted.
 
 \section{Verdict}
-\textbf{Verdict: scope restriction.} The paper's normal-tensor proposition,
+\textbf{Verdict: scope restriction with two open gaps.} The paper's
+normal-tensor proposition,
 the source-isometry lemma, and Theorem~III.8 concern the intended reduced
 canonical-form-II representative, with zero-weight blocks and the ambient zero
 complement omitted. This reduction is not an explicit hypothesis of the
@@ -146,6 +147,8 @@ Consequently, a source-faithful formalization must construct this reduced
 representative and transport the source constructions, or explicitly assume
 chosen canonical-form-II data with full active support.  The formalization uses
 the latter option.  It does not yet construct the representative reduction.
+The two open gaps are the complete source-$u$ contraction tracked by
+issue~\#5982 and the complete source-$v$ equivalence tracked by issue~\#6071.
 The full-support irreducibility implication is formalized by
 \leanid{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_card_active_eq_one_of_fullActiveSupport}.
 The spectral-radius and primitivity conclusions are derived from the shifted

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -109,9 +109,15 @@ The explicit reduced-CFII and full-active-support hypotheses resolve the scope
 question tracked by issue~\#5855. They do not prove the two complete network
 identities needed for Theorem~III.8. The source-$u$ range-insertion equality in
 Lemma~III.7, labelled \texttt{lemuisometry} in the source, remains tracked by
-issue~\#5982. The complete blocked source-$v$ contraction corresponding to the
-equality labelled \texttt{vUnitary} in the proof of Theorem~III.8 remains
-tracked by issue~\#6071 \cite[lines~545--600]{Cirac2017MPU}. The formalization
+issue~\#5982. The complete blocked source-$v$ contraction remains tracked by
+issue~\#6071 \cite[equation~\texttt{vUnitary}, proof of Theorem~III.8,
+lines~577--600]{Cirac2017MPU}.
+
+Accordingly, the planned simple-tensor equivalence theorem is stated only for
+the direct block $W=\mathcal U^{[(D^2-1)D^2]}$. Its ranks and source operators
+are all recomputed from $W$. The theorem compares simplicity of $W$ with the
+unitarity and dimension conditions for those same blocked source operators. It
+does not identify them with the source data of $\mathcal U$. The formalization
 also does not construct a reduced representative or transport the source cuts,
 the ranks, simplicity, or the operators $u$ and $v$ from such a representative
 back to the original bond space.

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -113,14 +113,22 @@ issue~\#5982. The complete blocked source-$v$ contraction remains tracked by
 issue~\#6071 \cite[equation~\texttt{vUnitary}, proof of Theorem~III.8,
 lines~577--600]{Cirac2017MPU}.
 
-Accordingly, the planned simple-tensor equivalence theorem is stated only for
-the direct block $W=\mathcal U^{[(D^2-1)D^2]}$. Its ranks and source operators
-are all recomputed from $W$. The theorem compares simplicity of $W$ with the
-unitarity and dimension conditions for those same blocked source operators. It
-does not identify them with the source data of $\mathcal U$. The formalization
-also does not construct a reduced representative or transport the source cuts,
-the ranks, simplicity, or the operators $u$ and $v$ from such a representative
-back to the original bond space.
+Accordingly, reduced canonical-form-II data with full active support are
+assumed only for $\mathcal U$. They supply the positive trace-one fixed matrix
+$\rho$ and the rank-one transfer power. For the direct block
+$W=\mathcal U^{[(D^2-1)D^2]}$, this becomes the supplied identity
+$E_W=\lvert\rho)(\Phi\rvert$. The planned source-isometry lemma consumes this
+identity and the associated direct and reflected contraction package on $W$;
+it does not assume or construct canonical-form-II data for $W$.
+
+The planned simple-tensor equivalence theorem is stated only for this block
+$W$. Its ranks and source operators are all recomputed from $W$. The theorem
+compares simplicity of $W$ with the unitarity and dimension conditions for
+those same blocked source operators. It does not identify them with the source
+data of $\mathcal U$. The formalization also does not construct a reduced
+representative or transport the source cuts, the ranks, simplicity, or the
+operators $u$ and $v$ from such a representative back to the original bond
+space.
 
 \section{Verdict}
 \textbf{Verdict: scope restriction.} The paper's normal-tensor proposition,

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -10,10 +10,12 @@
 \maketitle
 
 \section{Source statement and surrounding convention}
-Proposition~\texttt{prop:normal-tensor} of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
-states that the normalized MPU transfer matrix has one nonzero eigenvalue, equal
-to one, and that the normalized local tensor is normal
-\cite[lines~344--354]{Cirac2017MPU}.  The proposition itself displays no
+The normal-tensor proposition of
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete states that the normalized MPU
+transfer matrix has one nonzero eigenvalue, equal to one, and that the
+normalized local tensor is normal
+\cite[proposition labelled~\texttt{prop:normal-tensor},
+lines~344--354]{Cirac2017MPU}.  The proposition itself displays no
 canonical-form or minimality hypothesis.  Its section has already imposed the
 standing convention that, without further notice, the local tensor has first
 been replaced by a tensor in canonical form
@@ -55,9 +57,9 @@ the normal block to the ambient tensor.
 \section{The source factors and Theorem III.8}
 Let $\mathcal U$ be an MPU tensor with physical dimension $d$ and bond
 dimension $D$, and let $E$ be the transfer matrix of the normalized tensor
-$d^{-1/2}\mathcal U$. After Proposition~\texttt{prop:normal-tensor}, the source
-assumes without loss of generality that this normalized tensor is in canonical
-form II \cite[lines~350--356]{Cirac2017MPU}. Choose such data with full active
+$d^{-1/2}\mathcal U$. After the normal-tensor proposition, the source assumes
+without loss of generality that this normalized tensor is in canonical form II
+\cite[lines~350--356]{Cirac2017MPU}. Choose such data with full active
 support. Let $\mathcal A_1$ be its unique active block, let $V$ be the inclusion
 of that block into the ambient bond space, and let $\Lambda$ be the block's
 diagonal positive right fixed point normalized to have trace one. Set
@@ -77,9 +79,10 @@ itself force $\rho$ to be positive definite on the ambient bond space. The
 current TNLean source-factor construction assumes ambient positive
 definiteness, and full active support supplies that stronger hypothesis
 \cite[lines~480--505]{Cirac2017MPU}. The same factors define $u$ and $v$ in
-the source lemma \texttt{lemuisometry} and Theorem~III.8,
-\texttt{ThmFund1} \cite[lines~532--601]{Cirac2017MPU}. Thus ambient positive
-definiteness is a restriction of the current formal construction, not a
+the source-isometry lemma and Theorem~III.8
+\cite[labels~\texttt{lemuisometry} and~\texttt{ThmFund1},
+lines~532--601]{Cirac2017MPU}. Thus ambient positive definiteness is a
+restriction of the current formal construction, not a
 logical consequence of invertibility of the compressed source metric or of
 the bare MPU predicate.
 
@@ -105,38 +108,40 @@ where $(\Phi\rvert$ is the vectorized identity bra. This $\rho$, rather than
 an arbitrary positive matrix, is the source weight used to define the factors
 and the operators $u$ and $v$.
 
-The explicit reduced-CFII and full-active-support hypotheses resolve the scope
-question tracked by issue~\#5855. They do not prove the two complete network
-identities needed for Theorem~III.8. The source-$u$ range-insertion equality in
-Lemma~III.7, labelled \texttt{lemuisometry} in the source, remains tracked by
-issue~\#5982. The complete blocked source-$v$ contraction remains tracked by
-issue~\#6071 \cite[equation~\texttt{vUnitary}, proof of Theorem~III.8,
+The explicit reduced-CFII and full-active-support hypotheses resolve the
+ambient-positivity question tracked by issue~\#5855. They do not prove the two
+complete network identities needed for Theorem~III.8. The source-$u$
+range-insertion equality remains tracked by issue~\#5982
+\cite[Lemma~III.7, label~\texttt{lemuisometry},
+lines~545--557]{Cirac2017MPU}. The complete source-$v$ equivalence remains
+tracked by issue~\#6071
+\cite[equation~\texttt{vUnitary}, proof of Theorem~III.8,
 lines~577--600]{Cirac2017MPU}.
 
-Accordingly, reduced canonical-form-II data with full active support are
-assumed only for $\mathcal U$. They supply the positive trace-one fixed matrix
-$\rho$ and the rank-one transfer power. For the direct block
-$W=\mathcal U^{[(D^2-1)D^2]}$, this becomes the supplied identity
-$E_W=\lvert\rho)(\Phi\rvert$. The planned source-isometry lemma consumes this
-identity and the associated direct and reflected contraction package on $W$;
-it does not assume or construct canonical-form-II data for $W$.
+Reduced canonical-form-II data with full active support are assumed for the
+same tensor $\mathcal U$ whose source cuts, ranks, and source operators occur
+in the two planned results. These data supply the positive trace-one matrix
+$\rho$ and the rank-one transfer power
+\begin{align}
+  E^{D^2-1}&=\lvert\rho)(\Phi\rvert.
+\end{align}
+The source-isometry lemma and Theorem~III.8 both retain the source factors of
+$\mathcal U$.
 
-The planned simple-tensor equivalence theorem is stated only for this block
-$W$. Its ranks and source operators are all recomputed from $W$. The theorem
-compares simplicity of $W$ with the unitarity and dimension conditions for
-those same blocked source operators. It does not identify them with the source
-data of $\mathcal U$. The formalization also does not construct a reduced
-representative or transport the source cuts, the ranks, simplicity, or the
-operators $u$ and $v$ from such a representative back to the original bond
-space.
+Blocking appears only inside the proof of the source-isometry lemma. Put
+$J=D^2-1$, $K=JD^2$, and let $\mathcal U^{[K]}$ denote the direct $K$-site
+block of $\mathcal U$. This internal block supplies the direct and reflected
+contractions used to evaluate the closed network for $u^\dagger u$. It is not
+used to replace the source cuts, ranks, or operators of $\mathcal U$, and no
+transport of source data across blocking is asserted.
 
 \section{Verdict}
 \textbf{Verdict: scope restriction.} The paper's normal-tensor proposition,
 the source-isometry lemma, and Theorem~III.8 concern the intended reduced
 canonical-form-II representative, with zero-weight blocks and the ambient zero
-complement omitted. This reduction is not an explicit hypothesis of
-Proposition~\texttt{prop:normal-tensor}, and it does not follow from literal
-canonical-form membership alone.
+complement omitted. This reduction is not an explicit hypothesis of the
+normal-tensor proposition, and it does not follow from literal canonical-form
+membership alone.
 Consequently, a source-faithful formalization must construct this reduced
 representative and transport the source constructions, or explicitly assume
 chosen canonical-form-II data with full active support.  The formalization uses

--- a/docs/paper-gaps/mpu_canonical_form_full_support.tex
+++ b/docs/paper-gaps/mpu_canonical_form_full_support.tex
@@ -3,7 +3,7 @@
 \usepackage{xurl}
 \usepackage[hidelinks]{hyperref}
 \input{command}
-\title{Full Support in MPU Normality and Theorem III.4}
+\title{Full Support in MPU Normality and Theorem III.8}
 \author{}
 \date{2026-08-11}
 \begin{document}
@@ -52,7 +52,7 @@ other retained block exists.  The ambient coisometry is square and hence
 unitary; block assembly and unitary conjugation transport irreducibility from
 the normal block to the ambient tensor.
 
-\section{The source factors and Theorem III.4}
+\section{The source factors and Theorem III.8}
 Let $\mathcal U$ be an MPU tensor with physical dimension $d$ and bond
 dimension $D$, and let $E$ be the transfer matrix of the normalized tensor
 $d^{-1/2}\mathcal U$. After Proposition~\texttt{prop:normal-tensor}, the source
@@ -67,17 +67,21 @@ diagonal positive right fixed point normalized to have trace one. Set
 
 The source factors are defined using this matrix $\rho$. In the first singular
 value decomposition, let $V_1$ denote the coisometry appearing in
-$\mathcal M_1=V_1^\dagger D_1U_1$. The corresponding first source factor
-contains
+$M_1=V_1^\dagger D_1U_1$. The corresponding first source factor contains
 \begin{align}
-  \left[V_1(I\otimes\rho)V_1^\dagger\right]^{-1/2},
+  \left[V_1(\rho\otimes\Id_d)V_1^\dagger\right]^{-1/2}.
 \end{align}
-whose inverse requires $\rho>0$ on the ambient bond space
+The inverse only requires the compressed matrix
+$V_1(\rho\otimes\Id_d)V_1^\dagger$ to be positive definite; it does not by
+itself force $\rho$ to be positive definite on the ambient bond space. The
+current TNLean source-factor construction assumes ambient positive
+definiteness, and full active support supplies that stronger hypothesis
 \cite[lines~480--505]{Cirac2017MPU}. The same factors define $u$ and $v$ in
-the source lemma \texttt{lemuisometry} and Theorem~III.4,
-\texttt{ThmFund1} \cite[lines~532--601]{Cirac2017MPU}. Thus the positive
-fixed point is part of the preceding canonical-form-II convention, not a
-consequence of the bare MPU predicate for an arbitrary ambient representative.
+the source lemma \texttt{lemuisometry} and Theorem~III.8,
+\texttt{ThmFund1} \cite[lines~532--601]{Cirac2017MPU}. Thus ambient positive
+definiteness is a restriction of the current formal construction, not a
+logical consequence of invertibility of the compressed source metric or of
+the bare MPU predicate.
 
 The supported formal route assumes
 \begin{align}
@@ -103,16 +107,18 @@ and the operators $u$ and $v$.
 
 The explicit reduced-CFII and full-active-support hypotheses resolve the scope
 question tracked by issue~\#5855. They do not prove the two complete network
-identities needed for Theorem~III.4. The source-$u$ range-insertion equality in
-\texttt{lemuisometry} remains tracked by issue~\#5982. The complete blocked
-source-$v$ contraction corresponding to equation~(31) remains tracked by
-issue~\#6071. The formalization also does not construct a reduced representative
-or transport the source cuts, the ranks, simplicity, or the operators $u$ and
-$v$ from such a representative back to the original bond space.
+identities needed for Theorem~III.8. The source-$u$ range-insertion equality in
+Lemma~III.7, labelled \texttt{lemuisometry} in the source, remains tracked by
+issue~\#5982. The complete blocked source-$v$ contraction corresponding to the
+equality labelled \texttt{vUnitary} in the proof of Theorem~III.8 remains
+tracked by issue~\#6071 \cite[lines~545--600]{Cirac2017MPU}. The formalization
+also does not construct a reduced representative or transport the source cuts,
+the ranks, simplicity, or the operators $u$ and $v$ from such a representative
+back to the original bond space.
 
 \section{Verdict}
 \textbf{Verdict: scope restriction.} The paper's normal-tensor proposition,
-the source-isometry lemma, and Theorem~III.4 concern the intended reduced
+the source-isometry lemma, and Theorem~III.8 concern the intended reduced
 canonical-form-II representative, with zero-weight blocks and the ambient zero
 complement omitted. This reduction is not an explicit hypothesis of
 Proposition~\texttt{prop:normal-tensor}, and it does not follow from literal


### PR DESCRIPTION
## What changed

- correct the source-$u$ planned contraction dependencies, supplied fixed-pair binding, output-first orientation, and Lemma III.7 citation
- make source-$u$ isometry a standing ingredient in the four-way proof
- correct the source-$v$ statement dependency and replace the wrong equation-(31) locator by the source `vUnitary` equality
- align paper-gap notation and state ambient positive definiteness as a restriction of the current source-factor construction

## Validation

- blueprint source synchronization and CI-style sync check
- `leanblueprint checkdecls`
- two LuaLaTeX passes with zero undefined cross-references
- `git diff --check origin/main...HEAD`

Closes #6130
Follow-up to #6129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint dependency/citation fixes only; no Lean proof or runtime code changes.
> 
> **Overview**
> This PR **realigns blueprint MPU documentation** with Cirac et al. (Theorem **III.8**, Lemma **III.7**) and clarifies how reduced canonical-form-II data and the stabilized transfer fixed pair bind to the **same** tensor \(\mathcal U\)’s source cuts and operators.
> 
> **Source-\(u\) network** (`thm:mpu_source_u_complete_network`): hypotheses now assume an explicit supplied \(\rho>0\) and \(E^J=\lvert\rho)(\Phi\rvert\) (not only reduced-CFII stabilization), cite **Lemma III.7**, and the proof sketch routes through reflected transfer power, matching block contractions, and range projections **inside** the closed \((K+2)\)-site network while **external** source-\(u\) factors stay those of \(\mathcal U\).
> 
> **Source-\(v\)** (`thm:mpu_source_v_complete_reduced_contraction`): adds the supplied rank-one simple2 contraction as an equivalence ingredient, replaces the wrong equation-(31) locator with the source **`vUnitary`** equality, and tightens the proof to a bidirectional four-letter network contraction.
> 
> **Isometry lemma** (`lemuisometry`) and **simple-tensor equivalence** (`ThmFund1`): the isometry of \(u\) is a **standing** ingredient (from the complete-network identity plus MPU unitarity); the four-way proof no longer re-derives \(u^\dagger u=\Id\) from simplicity. Comments document **scope restrictions** vs. the paper’s unstated reduced-representative convention.
> 
> **Paper-gap note** (`docs/paper-gaps/mpu_canonical_form_full_support.tex`): retitled to Theorem III.8; corrects source-factor metric notation to \(V_1(\rho\otimes\Id_d)V_1^\dagger\); states ambient positive definiteness as a restriction of the current construction; and records that blocking \(\mathcal U^{[K]}\) is **internal** to the source-\(u\) proof only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64350c07a42a703c5a1acc91abc8c67b4e7f2f5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->