### PR TITLE
feat(parent-hamiltonian): prove geometric C3 projector defect

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -44,6 +44,7 @@ import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.ParentHamiltonian.ExtendRight
+import TNLean.MPS.ParentHamiltonian.FNWContraction
 import TNLean.MPS.ParentHamiltonian.GramConvergence
 import TNLean.MPS.ParentHamiltonian.GramInverseConvergence
 import TNLean.MPS.ParentHamiltonian.GroundSpace

--- a/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
@@ -27,6 +27,29 @@ inverse norm visible in the assembled constant.
 
 open scoped ComplexOrder Matrix Matrix.Norms.Frobenius
 
+/-- If two real numbers are bounded by the same nonnegative number, the product of
+their square roots is bounded by that number. -/
+private theorem sqrt_mul_sqrt_le_of_le {a b B : ℝ} (hB : 0 ≤ B)
+    (haB : a ≤ B) (hbB : b ≤ B) :
+    Real.sqrt a * Real.sqrt b ≤ B := by
+  calc
+    Real.sqrt a * Real.sqrt b ≤ Real.sqrt B * Real.sqrt B := by
+      exact mul_le_mul (Real.sqrt_le_sqrt haB) (Real.sqrt_le_sqrt hbB)
+        (Real.sqrt_nonneg _) (Real.sqrt_nonneg _)
+    _ = B := Real.mul_self_sqrt hB
+
+/-- A moving geometric denominator is bounded by the denominator at the base
+length. -/
+private theorem inverse_one_sub_geometric_le_base {c r : ℝ} (hc : 0 < c)
+    (hr_pos : 0 < r) (hr_lt_one : r < 1) {l n : ℕ} (hln : l ≤ n)
+    (hsmall : c * r ^ l < 1) :
+    (1 - c * r ^ n)⁻¹ ≤ (1 - c * r ^ l)⁻¹ := by
+  have hpow : r ^ n ≤ r ^ l :=
+    pow_le_pow_of_le_one hr_pos.le hr_lt_one.le hln
+  have hden : 1 - c * r ^ l ≤ 1 - c * r ^ n := by
+    linarith [mul_le_mul_of_nonneg_left hpow hc.le]
+  exact inv_anti₀ (sub_pos.mpr hsmall) hden
+
 namespace MPSTensor
 
 variable {d D : ℕ}
@@ -82,29 +105,6 @@ theorem c3_injectiveRangeProjector_residual_eq_centered_sub_corrections [NeZero 
     c3LeftFiniteGramCorrectionES, ContinuousLinearMap.comp_sub,
     ContinuousLinearMap.sub_comp, ContinuousLinearMap.comp_apply,
     sub_apply]
-
-/-- If two real numbers are bounded by the same nonnegative number, the product of
-their square roots is bounded by that number. -/
-private theorem sqrt_mul_sqrt_le_of_le {a b B : ℝ} (hB : 0 ≤ B)
-    (haB : a ≤ B) (hbB : b ≤ B) :
-    Real.sqrt a * Real.sqrt b ≤ B := by
-  calc
-    Real.sqrt a * Real.sqrt b ≤ Real.sqrt B * Real.sqrt B := by
-      exact mul_le_mul (Real.sqrt_le_sqrt haB) (Real.sqrt_le_sqrt hbB)
-        (Real.sqrt_nonneg _) (Real.sqrt_nonneg _)
-    _ = B := Real.mul_self_sqrt hB
-
-/-- A moving geometric denominator is bounded by the denominator at the base
-length. -/
-private theorem inverse_one_sub_geometric_le_base {c r : ℝ} (hc : 0 < c)
-    (hr_pos : 0 < r) (hr_lt_one : r < 1) {l n : ℕ} (hln : l ≤ n)
-    (hsmall : c * r ^ l < 1) :
-    (1 - c * r ^ n)⁻¹ ≤ (1 - c * r ^ l)⁻¹ := by
-  have hpow : r ^ n ≤ r ^ l :=
-    pow_le_pow_of_le_one hr_pos.le hr_lt_one.le hln
-  have hden : 1 - c * r ^ l ≤ 1 - c * r ^ n := by
-    linarith [mul_le_mul_of_nonneg_left hpow hc.le]
-  exact inv_anti₀ (sub_pos.mpr hsmall) hden
 
 /-- Norm bound for the centered physical sandwich. -/
 theorem c3CenteredProjectorResidualES_norm_le [NeZero D]
@@ -269,8 +269,12 @@ theorem IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric
         simpa only [Kinf] using c3_centeredVirtualResidualES_norm_le A K l ρ hρ
       _ ≤ J * (g * r ^ l) * C_T := by
         dsimp only [J]
-        gcongr
-        exact hTail K
+        apply mul_le_mul
+        · exact mul_le_mul_of_nonneg_left hGramL (norm_nonneg _)
+        · exact hTail K
+        · exact norm_nonneg _
+        · exact mul_nonneg (norm_nonneg _)
+            (mul_nonneg hg.le (pow_nonneg hr_pos.le _))
   let base := ‖Iinf‖ * C_T * g * (J + 1) * (M + 1)
   have hbase_nonneg : 0 ≤ base := by
     dsimp only [base, J, M]

--- a/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
@@ -14,11 +14,10 @@ This file assembles the exact limiting-metric telescope, the centered overlap
 estimate, and the three finite-Gram corrections into a common-ambient
 open-chain projector bound uniform in the spectator length.
 
-The coefficient proved here is a reconstructed TNLean substitute sufficient
-for Nachtergaele's condition C3. It is not the optimized rational numerator
-quoted from Fannes--Nachtergaele--Werner in Nachtergaele, equation (6.1). The
-proof works around the nonidentity limiting Gram metric and keeps its norm and
-inverse norm visible in the assembled constant.
+**Scope restriction (Nachtergaele C3 coefficient):** The coefficient proved here is a
+reconstructed substitute sufficient for condition C3, not the optimized rational numerator
+quoted from Fannes--Nachtergaele--Werner in Nachtergaele, equation (6.1). See
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
 
 ## Main results
 
@@ -164,9 +163,7 @@ theorem c3CenteredProjectorResidualES_norm_le [NeZero D]
 
 /-- A spectator-uniform geometric-over-denominator estimate for the open-chain
 C3 projector defect. The constants are reconstructed from the limiting Gram
-metric, geometric Gram convergence, and uniform virtual-word bounds. This is a
-TNLean substitute sufficient for Nachtergaele C3, not the optimized FNW
-rational numerator quoted in Nachtergaele, equation (6.1). -/
+metric, geometric Gram convergence, and uniform virtual-word bounds. -/
 theorem IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric
     [NeZero D] {A : MPSTensor d D}
     {ρ : Matrix (Fin D) (Fin D) ℂ}
@@ -181,7 +178,7 @@ theorem IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric
   let Kinf := Matrix.gramReshuffle
     (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
   let Iinf := Ring.inverse Kinf
-  obtain ⟨g, c, r, hg, hc, hr_pos, hr_lt_one, -, hGramInv⟩ :=
+  obtain ⟨g, c, r, hg, hc, hr_pos, hr_lt_one, hc_eq, hGramInv⟩ :=
     hP.groundSpaceMapES_geometric_inverseGram_bounds hρ
   obtain ⟨C_T, hC_T, hTail⟩ := hP.tailVirtualMapES_norm_uniform
   have hKinfUnit : IsUnit Kinf := by
@@ -285,14 +282,14 @@ theorem IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric
   have hM_nonneg : 0 ≤ M := by
     dsimp only [M]
     positivity
-  have hJ_le : J ≤ (J + 1) * (M + 1) := by
-    nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
-  have hOne_le : 1 ≤ (J + 1) * (M + 1) := by
-    nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
-  have hM_le : M ≤ (J + 1) * (M + 1) := by
-    nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
-  have hJM_le : J * M ≤ (J + 1) * (M + 1) := by
-    nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
+  have hFactorBounds :
+      J ≤ (J + 1) * (M + 1) ∧
+      1 ≤ (J + 1) * (M + 1) ∧
+      M ≤ (J + 1) * (M + 1) ∧
+      J * M ≤ (J + 1) * (M + 1) := by
+    refine ⟨?_, ?_, ?_, ?_⟩ <;>
+      nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
+  obtain ⟨hJ_le, hOne_le, hM_le, hJM_le⟩ := hFactorBounds
   have hTerm (x : ℝ) (hx : x ≤ (J + 1) * (M + 1)) :
       q * ((‖Iinf‖ * C_T * g * x) * r ^ l) ≤ q * (base * r ^ l) := by
     apply mul_le_mul_of_nonneg_left _ hq_pos.le

--- a/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
@@ -1,0 +1,483 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.C3CorrectionBounds
+import TNLean.MPS.ParentHamiltonian.CenteredOverlapFactor
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
+
+/-!
+# A geometric C3 projector-defect bound
+
+This file assembles the exact limiting-metric telescope, the centered overlap
+estimate, and the three finite-Gram corrections into a common-ambient
+open-chain projector bound uniform in the spectator length.
+
+The coefficient proved here is a reconstructed TNLean substitute sufficient
+for Nachtergaele's condition C3. It is not the optimized rational numerator
+quoted from Fannes--Nachtergaele--Werner in Nachtergaele, equation (6.1). The
+proof works around the nonidentity limiting Gram metric and keeps its norm and
+inverse norm visible in the assembled constant.
+
+## Main result
+
+* `MPSTensor.IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric`
+-/
+
+open scoped ComplexOrder Matrix Matrix.Norms.Frobenius
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The physical sandwich containing the centered virtual C3 residual. -/
+noncomputable def c3CenteredProjectorResidualES [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l))) :
+    EuclideanSpace ℂ (Cfg d (K + l + 1)) →L[ℂ]
+      EuclideanSpace ℂ (Cfg d (K + l + 1)) :=
+  let Itail := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (l + 1)) hLocalTail
+  let Ileft := ContinuousLinearMap.inverseGram
+    (groundSpaceMapES A (K + l)) hLocalLeft
+  (tailBoundaryMapES A K (l + 1)).comp
+    ((boundaryFiberwiseMap (D := D) (Cfg d K) Itail).comp
+      ((c3CenteredVirtualResidualES A K l ρ hρ).comp
+        ((boundaryFiberwiseMap (D := D) (Cfg d 1) Ileft).comp
+          (leftBoundaryMapES A (K + l) 1).adjoint)))
+
+/-- Exact assembly of the projector defect into the centered physical sandwich
+and the three finite-Gram correction sandwiches. -/
+theorem c3_injectiveRangeProjector_residual_eq_centered_sub_corrections [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l)))
+    (hFull : Function.Injective (groundSpaceMapES A (K + l + 1))) :
+    let hTail := tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+      A K (l + 1) hLocalTail
+    let hLeft := leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+      A (K + l) 1 hLocalLeft
+    (ContinuousLinearMap.injectiveRangeProjector
+        (tailBoundaryMapES A K (l + 1)) hTail).comp
+        (ContinuousLinearMap.injectiveRangeProjector
+          (leftBoundaryMapES A (K + l) 1) hLeft) -
+      ContinuousLinearMap.injectiveRangeProjector
+        (groundSpaceMapES A (K + l + 1)) hFull =
+      c3CenteredProjectorResidualES A K l ρ hρ hLocalTail hLocalLeft -
+        c3TailFiniteGramCorrectionES A K l ρ hρ
+          hLocalTail hLocalLeft hFull -
+        c3FullInverseGramCorrectionES A K l ρ hρ
+          hLocalTail hLocalLeft hFull -
+        c3LeftFiniteGramCorrectionES A K l ρ hρ hLocalTail hLocalLeft := by
+  dsimp only
+  rw [c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors
+    A K l ρ hρ hLocalTail hLocalLeft hFull]
+  ext x
+  simp only [c3CenteredProjectorResidualES, c3CenteredVirtualResidualES,
+    c3TailFiniteGramCorrectionES, c3FullInverseGramCorrectionES,
+    c3LeftFiniteGramCorrectionES, ContinuousLinearMap.comp_sub,
+    ContinuousLinearMap.sub_comp, ContinuousLinearMap.comp_apply,
+    sub_apply]
+
+/-- If two nonnegative numbers are bounded by the same nonnegative number,
+the product of their square roots is bounded by that number. -/
+theorem sqrt_mul_sqrt_le_of_le {a b B : ℝ} (hB : 0 ≤ B)
+    (haB : a ≤ B) (hbB : b ≤ B) :
+    Real.sqrt a * Real.sqrt b ≤ B := by
+  calc
+    Real.sqrt a * Real.sqrt b ≤ Real.sqrt B * Real.sqrt B := by
+      exact mul_le_mul (Real.sqrt_le_sqrt haB) (Real.sqrt_le_sqrt hbB)
+        (Real.sqrt_nonneg _) (Real.sqrt_nonneg _)
+    _ = B := Real.mul_self_sqrt hB
+
+/-- A moving geometric denominator is bounded by the denominator at the base
+length. -/
+theorem inverse_one_sub_geometric_le_base {c r : ℝ} (hc : 0 < c)
+    (hr_pos : 0 < r) (hr_lt_one : r < 1) {l n : ℕ} (hln : l ≤ n)
+    (hsmall : c * r ^ l < 1) :
+    (1 - c * r ^ n)⁻¹ ≤ (1 - c * r ^ l)⁻¹ := by
+  have hpow : r ^ n ≤ r ^ l :=
+    pow_le_pow_of_le_one hr_pos.le hr_lt_one.le hln
+  have hden : 1 - c * r ^ l ≤ 1 - c * r ^ n := by
+    linarith [mul_le_mul_of_nonneg_left hpow hc.le]
+  exact inv_anti₀ (sub_pos.mpr hsmall) hden
+
+/-- Norm bound for the centered physical sandwich. -/
+theorem c3CenteredProjectorResidualES_norm_le [NeZero D]
+    (A : MPSTensor d D) (K l : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (l + 1)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + l))) :
+    let Itail := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (l + 1)) hLocalTail
+    let Ileft := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l)) hLocalLeft
+    ‖c3CenteredProjectorResidualES A K l ρ hρ hLocalTail hLocalLeft‖ ≤
+      Real.sqrt ‖Itail‖ * ‖c3CenteredVirtualResidualES A K l ρ hρ‖ *
+        Real.sqrt ‖Ileft‖ := by
+  dsimp only
+  simp only [c3CenteredProjectorResidualES]
+  let Ptail := (tailBoundaryMapES A K (l + 1)).comp
+    (ContinuousLinearMap.inverseGram (tailBoundaryMapES A K (l + 1))
+      (tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+        A K (l + 1) hLocalTail))
+  let R := c3CenteredVirtualResidualES A K l ρ hρ
+  let Pleft := (ContinuousLinearMap.inverseGram
+    (leftBoundaryMapES A (K + l) 1)
+      (leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+        A (K + l) 1 hLocalLeft)).comp
+          (leftBoundaryMapES A (K + l) 1).adjoint
+  rw [← inverseGram_tailBoundaryMapES_eq_fiberwise_inverseGram
+    A K (l + 1) hLocalTail]
+  rw [← inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram
+    A (K + l) 1 hLocalLeft]
+  change ‖Ptail.comp (R.comp Pleft)‖ ≤ _
+  calc
+    ‖Ptail.comp (R.comp Pleft)‖ ≤ ‖Ptail‖ * ‖R.comp Pleft‖ :=
+      ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖R‖ * ‖Pleft‖) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (l + 1)) hLocalTail‖ * (‖R‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + l)) hLocalLeft‖) := by
+      have hPtail : ‖Ptail‖ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (l + 1)) hLocalTail‖ := by
+        dsimp only [Ptail]
+        exact norm_tailBoundaryMapES_comp_inverseGram_le_sqrt
+          A K (l + 1) hLocalTail
+      have hPleft : ‖Pleft‖ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + l)) hLocalLeft‖ := by
+        dsimp only [Pleft]
+        exact norm_inverseGram_comp_leftBoundaryMapES_adjoint_le_sqrt
+          A (K + l) 1 hLocalLeft
+      exact mul_le_mul hPtail
+        (mul_le_mul_of_nonneg_left hPleft (norm_nonneg R))
+        (mul_nonneg (norm_nonneg R) (norm_nonneg Pleft))
+        (Real.sqrt_nonneg _)
+    _ = _ := by ring
+
+/-- A spectator-uniform geometric-over-denominator estimate for the open-chain
+C3 projector defect. The constants are reconstructed from the limiting Gram
+metric, geometric Gram convergence, and uniform virtual-word bounds. This is a
+TNLean substitute sufficient for Nachtergaele C3, not the optimized FNW
+rational numerator quoted in Nachtergaele, equation (6.1). -/
+theorem IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric
+    [NeZero D] {A : MPSTensor d D}
+    {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ C c r : ℝ,
+      0 < C ∧ 0 < c ∧ 0 < r ∧ r < 1 ∧
+      ∀ K l : ℕ, 1 ≤ l → c * r ^ l < 1 →
+        ‖openChainTailGroundProjectionES A K (l + 1) ∘L
+              openChainLeftGroundProjectionES A (K + l) -
+            (groundSpaceES A (K + l + 1)).starProjection‖ ≤
+          (1 - c * r ^ l)⁻¹ * (C * r ^ l) := by
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Iinf := Ring.inverse Kinf
+  obtain ⟨g, c, r, hg, hc, hr_pos, hr_lt_one, hc_def, hGramInv⟩ :=
+    hP.groundSpaceMapES_geometric_inverseGram_bounds hρ
+  obtain ⟨C_T, hC_T, hTail⟩ := hP.tailVirtualMapES_norm_uniform
+  have hKinfUnit : IsUnit Kinf := by
+    simpa only [Kinf] using Matrix.gramReshuffle_fixedPointProj_isUnit hρ
+  have hIinfUnit : IsUnit Iinf := by
+    simpa only [Iinf] using hKinfUnit.ringInverse
+  have hIinf_pos : 0 < ‖Iinf‖ := norm_pos_iff.mpr hIinfUnit.ne_zero
+  let J := ‖leftVirtualMapES A 1‖
+  let M := ‖Kinf‖ * ‖Iinf‖
+  let C := 4 * (‖Iinf‖ * C_T * g * (J + 1) * (M + 1))
+  have hC : 0 < C := by
+    dsimp only [C, J, M]
+    positivity
+  refine ⟨C, c, r, hC, hc, hr_pos, hr_lt_one, ?_⟩
+  intro K l hl hsmall
+  obtain ⟨hsmallTail, hsmallLeft, hsmallFull⟩ :=
+    geometric_smallness_at_c3_lengths hc hr_pos hr_lt_one hsmall K
+  obtain ⟨hGramL, -⟩ := hGramInv l hl
+  obtain ⟨hGramTail, hTailPoint⟩ := hGramInv (l + 1) (by omega)
+  obtain ⟨hLocalTail, -, hInvTailRaw, -⟩ := hTailPoint hsmallTail
+  obtain ⟨hGramLeft, hLeftPoint⟩ := hGramInv (K + l) (by omega)
+  obtain ⟨hLocalLeft, -, hInvLeftRaw, -⟩ := hLeftPoint hsmallLeft
+  obtain ⟨hGramFull, hFullPoint⟩ := hGramInv (K + l + 1) (by omega)
+  obtain ⟨hFull, -, hInvFullRaw, -⟩ := hFullPoint hsmallFull
+  let q := (1 - c * r ^ l)⁻¹
+  let B := q * ‖Iinf‖
+  have hq_pos : 0 < q := by
+    dsimp only [q]
+    positivity
+  have hB_nonneg : 0 ≤ B := by
+    dsimp only [B]
+    positivity
+  have hInvTail : ‖ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (l + 1)) hLocalTail‖ ≤ B := by
+    calc
+      _ ≤ (1 - c * r ^ (l + 1))⁻¹ * ‖Iinf‖ := hInvTailRaw
+      _ ≤ q * ‖Iinf‖ := by
+        gcongr
+        exact inverse_one_sub_geometric_le_base hc hr_pos hr_lt_one
+          (by omega) hsmall
+      _ = B := rfl
+  have hInvLeft : ‖ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l)) hLocalLeft‖ ≤ B := by
+    calc
+      _ ≤ (1 - c * r ^ (K + l))⁻¹ * ‖Iinf‖ := hInvLeftRaw
+      _ ≤ q * ‖Iinf‖ := by
+        gcongr
+        exact inverse_one_sub_geometric_le_base hc hr_pos hr_lt_one
+          (by omega) hsmall
+      _ = B := rfl
+  have hInvFull : ‖ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + l + 1)) hFull‖ ≤ B := by
+    calc
+      _ ≤ (1 - c * r ^ (K + l + 1))⁻¹ * ‖Iinf‖ := hInvFullRaw
+      _ ≤ q * ‖Iinf‖ := by
+        gcongr
+        exact inverse_one_sub_geometric_le_base hc hr_pos hr_lt_one
+          (by omega) hsmall
+      _ = B := rfl
+  have hSqrtTailLeft :
+      Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + l)) hLocalLeft‖ ≤ B :=
+    sqrt_mul_sqrt_le_of_le hB_nonneg hInvTail hInvLeft
+  have hSqrtTailFull :
+      Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + l + 1)) hFull‖ ≤ B :=
+    sqrt_mul_sqrt_le_of_le hB_nonneg hInvTail hInvFull
+  have hpow {n : ℕ} (hln : l ≤ n) : r ^ n ≤ r ^ l :=
+    pow_le_pow_of_le_one hr_pos.le hr_lt_one.le hln
+  have hGramTailBase : ‖groundSpaceGram A (l + 1) - Kinf‖ ≤ g * r ^ l :=
+    hGramTail.trans (mul_le_mul_of_nonneg_left (hpow (by omega)) hg.le)
+  have hGramLeftBase : ‖groundSpaceGram A (K + l) - Kinf‖ ≤ g * r ^ l :=
+    hGramLeft.trans (mul_le_mul_of_nonneg_left (hpow (by omega)) hg.le)
+  have hGramFullBase : ‖groundSpaceGram A (K + l + 1) - Kinf‖ ≤ g * r ^ l :=
+    hGramFull.trans (mul_le_mul_of_nonneg_left (hpow (by omega)) hg.le)
+  have hCenterVirtual : ‖c3CenteredVirtualResidualES A K l ρ hρ‖ ≤
+      J * (g * r ^ l) * C_T := by
+    calc
+      _ ≤ ‖leftVirtualMapES A 1‖ *
+          ‖groundSpaceGram A l - Kinf‖ * ‖tailVirtualMapES A K‖ := by
+        simpa only [Kinf] using c3_centeredVirtualResidualES_norm_le A K l ρ hρ
+      _ ≤ J * (g * r ^ l) * C_T := by
+        dsimp only [J]
+        gcongr
+        exact hTail K
+  let base := ‖Iinf‖ * C_T * g * (J + 1) * (M + 1)
+  have hbase_nonneg : 0 ≤ base := by
+    dsimp only [base, J, M]
+    positivity
+  have hJ_nonneg : 0 ≤ J := by
+    dsimp only [J]
+    positivity
+  have hM_nonneg : 0 ≤ M := by
+    dsimp only [M]
+    positivity
+  have hJ_le : J ≤ (J + 1) * (M + 1) := by
+    nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
+  have hOne_le : 1 ≤ (J + 1) * (M + 1) := by
+    nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
+  have hM_le : M ≤ (J + 1) * (M + 1) := by
+    nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
+  have hJM_le : J * M ≤ (J + 1) * (M + 1) := by
+    nlinarith only [hJ_nonneg, hM_nonneg, mul_nonneg hJ_nonneg hM_nonneg]
+  have hTerm (x : ℝ) (hx : x ≤ (J + 1) * (M + 1)) :
+      q * ((‖Iinf‖ * C_T * g * x) * r ^ l) ≤ q * (base * r ^ l) := by
+    apply mul_le_mul_of_nonneg_left _ hq_pos.le
+    apply mul_le_mul_of_nonneg_right _ (pow_nonneg hr_pos.le _)
+    dsimp only [base]
+    simpa only [mul_assoc] using mul_le_mul_of_nonneg_left hx
+      (mul_nonneg (mul_nonneg (norm_nonneg Iinf) hC_T.le) hg.le)
+  have hCenter : ‖c3CenteredProjectorResidualES A K l ρ hρ
+      hLocalTail hLocalLeft‖ ≤ q * (base * r ^ l) := by
+    calc
+      _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+          ‖c3CenteredVirtualResidualES A K l ρ hρ‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + l)) hLocalLeft‖ :=
+        c3CenteredProjectorResidualES_norm_le A K l ρ hρ
+          hLocalTail hLocalLeft
+      _ = (Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + l)) hLocalLeft‖) *
+          ‖c3CenteredVirtualResidualES A K l ρ hρ‖ := by ring
+      _ ≤ B * (J * (g * r ^ l) * C_T) :=
+        mul_le_mul hSqrtTailLeft hCenterVirtual (norm_nonneg _) hB_nonneg
+      _ ≤ q * (base * r ^ l) := by
+        dsimp only [B, base]
+        calc
+          q * ‖Iinf‖ * (J * (g * r ^ l) * C_T) =
+              q * ((‖Iinf‖ * C_T * g * J) * r ^ l) := by ring
+          _ ≤ q * (base * r ^ l) := hTerm J hJ_le
+  have hQTail : ‖c3TailFiniteGramCorrectionES A K l ρ hρ
+      hLocalTail hLocalLeft hFull‖ ≤ q * (base * r ^ l) := by
+    calc
+      _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+          ‖groundSpaceGram A (l + 1) - Kinf‖ * ‖tailVirtualMapES A K‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + l + 1)) hFull‖ := by
+        simpa only [Kinf] using c3TailFiniteGramCorrectionES_norm_le
+          A K l ρ hρ hLocalTail hLocalLeft hFull
+      _ = (Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + l + 1)) hFull‖) *
+          (‖groundSpaceGram A (l + 1) - Kinf‖ * ‖tailVirtualMapES A K‖) := by ring
+      _ ≤ B * ((g * r ^ l) * C_T) := by
+        apply mul_le_mul hSqrtTailFull
+        · exact mul_le_mul hGramTailBase (hTail K) (norm_nonneg _)
+            (mul_nonneg hg.le (pow_nonneg hr_pos.le _))
+        · exact mul_nonneg (norm_nonneg _) (norm_nonneg _)
+        · exact hB_nonneg
+      _ ≤ q * (base * r ^ l) := by
+        dsimp only [B, base]
+        calc
+          q * ‖Iinf‖ * (g * r ^ l * C_T) =
+              q * ((‖Iinf‖ * C_T * g) * r ^ l) := by ring
+          _ ≤ q * (base * r ^ l) := by
+            simpa only [mul_one] using hTerm 1 hOne_le
+  have hQFull : ‖c3FullInverseGramCorrectionES A K l ρ hρ
+      hLocalTail hLocalLeft hFull‖ ≤ q * (base * r ^ l) := by
+    calc
+      _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (l + 1)) hLocalTail‖ * ‖Kinf‖ *
+          ‖tailVirtualMapES A K‖ * ‖Iinf‖ *
+          ‖groundSpaceGram A (K + l + 1) - Kinf‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + l + 1)) hFull‖ := by
+        simpa only [Kinf, Iinf] using c3FullInverseGramCorrectionES_norm_le
+          A K l ρ hρ hLocalTail hLocalLeft hFull
+      _ = (Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + l + 1)) hFull‖) *
+          (‖Kinf‖ * ‖Iinf‖ * ‖tailVirtualMapES A K‖ *
+            ‖groundSpaceGram A (K + l + 1) - Kinf‖) := by ring
+      _ ≤ B * (M * C_T * (g * r ^ l)) := by
+        have hInner : M * ‖tailVirtualMapES A K‖ *
+            ‖groundSpaceGram A (K + l + 1) - Kinf‖ ≤
+            M * C_T * (g * r ^ l) := by
+          exact mul_le_mul
+            (mul_le_mul_of_nonneg_left (hTail K) hM_nonneg) hGramFullBase
+            (norm_nonneg _) (mul_nonneg hM_nonneg hC_T.le)
+        exact mul_le_mul hSqrtTailFull hInner
+          (mul_nonneg (mul_nonneg hM_nonneg (norm_nonneg _)) (norm_nonneg _))
+          hB_nonneg
+      _ ≤ q * (base * r ^ l) := by
+        dsimp only [B, base]
+        calc
+          q * ‖Iinf‖ * (M * C_T * (g * r ^ l)) =
+              q * ((‖Iinf‖ * C_T * g * M) * r ^ l) := by ring
+          _ ≤ q * (base * r ^ l) := hTerm M hM_le
+  have hQLeft : ‖c3LeftFiniteGramCorrectionES A K l ρ hρ
+      hLocalTail hLocalLeft‖ ≤ q * (base * r ^ l) := by
+    calc
+      _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (l + 1)) hLocalTail‖ * ‖Kinf‖ *
+          ‖tailVirtualMapES A K‖ * ‖Iinf‖ * ‖leftVirtualMapES A 1‖ *
+          ‖groundSpaceGram A (K + l) - Kinf‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + l)) hLocalLeft‖ := by
+        simpa only [Kinf, Iinf] using c3LeftFiniteGramCorrectionES_norm_le
+          A K l ρ hρ hLocalTail hLocalLeft
+      _ = (Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (l + 1)) hLocalTail‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + l)) hLocalLeft‖) *
+          (M * ‖tailVirtualMapES A K‖ * J *
+            ‖groundSpaceGram A (K + l) - Kinf‖) := by
+        dsimp only [M, J]
+        ring
+      _ ≤ B * (M * C_T * J * (g * r ^ l)) := by
+        have hInner : M * ‖tailVirtualMapES A K‖ * J *
+            ‖groundSpaceGram A (K + l) - Kinf‖ ≤
+            M * C_T * J * (g * r ^ l) := by
+          exact mul_le_mul
+            (mul_le_mul_of_nonneg_right
+              (mul_le_mul_of_nonneg_left (hTail K) hM_nonneg) hJ_nonneg)
+            hGramLeftBase (norm_nonneg _)
+            (mul_nonneg (mul_nonneg hM_nonneg hC_T.le) hJ_nonneg)
+        exact mul_le_mul hSqrtTailLeft hInner
+          (mul_nonneg
+            (mul_nonneg (mul_nonneg hM_nonneg (norm_nonneg _)) hJ_nonneg)
+            (norm_nonneg _)) hB_nonneg
+      _ ≤ q * (base * r ^ l) := by
+        dsimp only [B, base]
+        calc
+          q * ‖Iinf‖ * (M * C_T * J * (g * r ^ l)) =
+              q * ((‖Iinf‖ * C_T * g * J * M) * r ^ l) := by ring
+          _ ≤ q * (base * r ^ l) := by
+            simpa only [mul_assoc] using hTerm (J * M) hJM_le
+  have hInjectiveDefect :
+      ‖(ContinuousLinearMap.injectiveRangeProjector
+          (tailBoundaryMapES A K (l + 1))
+            (tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+              A K (l + 1) hLocalTail)).comp
+          (ContinuousLinearMap.injectiveRangeProjector
+            (leftBoundaryMapES A (K + l) 1)
+              (leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+                A (K + l) 1 hLocalLeft)) -
+        ContinuousLinearMap.injectiveRangeProjector
+          (groundSpaceMapES A (K + l + 1)) hFull‖ ≤
+        q * (C * r ^ l) := by
+    rw [c3_injectiveRangeProjector_residual_eq_centered_sub_corrections
+      A K l ρ hρ hLocalTail hLocalLeft hFull]
+    calc
+      _ ≤ ‖c3CenteredProjectorResidualES A K l ρ hρ hLocalTail hLocalLeft‖ +
+          ‖c3TailFiniteGramCorrectionES A K l ρ hρ
+            hLocalTail hLocalLeft hFull‖ +
+          ‖c3FullInverseGramCorrectionES A K l ρ hρ
+            hLocalTail hLocalLeft hFull‖ +
+          ‖c3LeftFiniteGramCorrectionES A K l ρ hρ hLocalTail hLocalLeft‖ := by
+        calc
+          _ ≤ ‖c3CenteredProjectorResidualES A K l ρ hρ
+                hLocalTail hLocalLeft -
+              c3TailFiniteGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft hFull -
+              c3FullInverseGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft hFull‖ +
+              ‖c3LeftFiniteGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft‖ := norm_sub_le _ _
+          _ ≤ (‖c3CenteredProjectorResidualES A K l ρ hρ
+                hLocalTail hLocalLeft -
+              c3TailFiniteGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft hFull‖ +
+              ‖c3FullInverseGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft hFull‖) +
+              ‖c3LeftFiniteGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft‖ := by
+            gcongr
+            exact norm_sub_le _ _
+          _ ≤ ((‖c3CenteredProjectorResidualES A K l ρ hρ
+                hLocalTail hLocalLeft‖ +
+              ‖c3TailFiniteGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft hFull‖) +
+              ‖c3FullInverseGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft hFull‖) +
+              ‖c3LeftFiniteGramCorrectionES A K l ρ hρ
+                hLocalTail hLocalLeft‖ := by
+            gcongr
+            exact norm_sub_le _ _
+          _ = _ := by ring
+      _ ≤ q * (base * r ^ l) + q * (base * r ^ l) +
+          q * (base * r ^ l) + q * (base * r ^ l) := by gcongr
+      _ = q * (C * r ^ l) := by
+        dsimp only [C, base]
+        ring
+  simpa only [openChainTailGroundProjectionES, openChainLeftGroundProjectionES,
+    ContinuousLinearMap.injectiveRangeProjector_eq_starProjection,
+    range_tailBoundaryMapES, range_leftBoundaryMapES_one,
+    range_groundSpaceMapES, q] using hInjectiveDefect
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
@@ -181,7 +181,7 @@ theorem IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric
   let Kinf := Matrix.gramReshuffle
     (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
   let Iinf := Ring.inverse Kinf
-  obtain ⟨g, c, r, hg, hc, hr_pos, hr_lt_one, hc_def, hGramInv⟩ :=
+  obtain ⟨g, c, r, hg, hc, hr_pos, hr_lt_one, -, hGramInv⟩ :=
     hP.groundSpaceMapES_geometric_inverseGram_bounds hρ
   obtain ⟨C_T, hC_T, hTail⟩ := hP.tailVirtualMapES_norm_uniform
   have hKinfUnit : IsUnit Kinf := by

--- a/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
@@ -20,7 +20,7 @@ quoted from Fannes--Nachtergaele--Werner in Nachtergaele, equation (6.1). The
 proof works around the nonidentity limiting Gram metric and keeps its norm and
 inverse norm visible in the assembled constant.
 
-## Main result
+## Main results
 
 * `MPSTensor.IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric`
 -/
@@ -83,9 +83,9 @@ theorem c3_injectiveRangeProjector_residual_eq_centered_sub_corrections [NeZero 
     ContinuousLinearMap.sub_comp, ContinuousLinearMap.comp_apply,
     sub_apply]
 
-/-- If two nonnegative numbers are bounded by the same nonnegative number,
-the product of their square roots is bounded by that number. -/
-theorem sqrt_mul_sqrt_le_of_le {a b B : ℝ} (hB : 0 ≤ B)
+/-- If two real numbers are bounded by the same nonnegative number, the product of
+their square roots is bounded by that number. -/
+private theorem sqrt_mul_sqrt_le_of_le {a b B : ℝ} (hB : 0 ≤ B)
     (haB : a ≤ B) (hbB : b ≤ B) :
     Real.sqrt a * Real.sqrt b ≤ B := by
   calc
@@ -96,7 +96,7 @@ theorem sqrt_mul_sqrt_le_of_le {a b B : ℝ} (hB : 0 ≤ B)
 
 /-- A moving geometric denominator is bounded by the denominator at the base
 length. -/
-theorem inverse_one_sub_geometric_le_base {c r : ℝ} (hc : 0 < c)
+private theorem inverse_one_sub_geometric_le_base {c r : ℝ} (hc : 0 < c)
     (hr_pos : 0 < r) (hr_lt_one : r < 1) {l n : ℕ} (hln : l ≤ n)
     (hsmall : c * r ^ l < 1) :
     (1 - c * r ^ n)⁻¹ ≤ (1 - c * r ^ l)⁻¹ := by

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1266,8 +1266,7 @@ norm estimate is derived here.
         thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
         thm:geometric_smallness_at_c3_lengths,
         thm:tail_boundary_map_range_es_transport,
-        thm:left_boundary_map_range_es_transport,
-        thm:ground_space_es_projection_inverse_gram}
+        thm:left_boundary_map_range_es_transport}
     Let $A$ be primitive with positive-definite fixed point $\rho$ and nonzero
     bond dimension.  There are constants $C,c,r>0$, with $r<1$, such that for
     every spectator length $K$ and every $l\geq1$ satisfying $cr^l<1$,
@@ -1284,15 +1283,14 @@ norm estimate is derived here.
 
 \begin{proof}
     \leanok
-    \uses{thm:c3_projector_gram_error_telescope,
+    \uses{thm:c3_centered_physical_assembly,
         thm:primitive_tail_virtual_map_norm_uniform,
         thm:c3_centered_overlap_factorization_geometric,
         thm:c3_correction_bounds,
         thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
         thm:geometric_smallness_at_c3_lengths,
         thm:tail_boundary_map_range_es_transport,
-        thm:left_boundary_map_range_es_transport,
-        thm:ground_space_es_projection_inverse_gram}
+        thm:left_boundary_map_range_es_transport}
     Put $K_\infty=\mathscr R(P_\rho)$ and
     $I_\infty=K_\infty^{-1}$.  Choose $g,c,r>0$ from the geometric Gram and
     inverse-Gram estimate, so that $c=\lVert I_\infty\rVert g$, and choose

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1220,14 +1220,12 @@ norm estimate is derived here.
     \lean{MPSTensor.c3CenteredProjectorResidualES_norm_le}
     \leanok
     \uses{def:c3_centered_physical_sandwich,
-        thm:c3_projector_gram_error_telescope,
-        thm:c3_centered_overlap_factorization_geometric,
-        thm:c3_correction_factorizations,
-        thm:tail_spectator_pseudoinverse_bound,
-        thm:left_spectator_pseudoinverse_bound}
+        def:c3_correction_sandwiches,
+        def:open_chain_ground_subspaces_es}
     Whenever the three finite Grams are invertible, the common-ambient defect is
     \begin{align}
-      P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}-P_{G_{K+l+1}(A)}
+      P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}
+        -P_{\mathcal G_{K+l+1}^{\mathrm{ES}}(A)}
       &=\widehat R_{K,l}-Q_1-Q_2-Q_3,
     \end{align}
     and
@@ -1241,8 +1239,7 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{thm:c3_projector_gram_error_telescope,
-        thm:c3_centered_overlap_factorization_geometric,
-        thm:c3_correction_factorizations,
+        thm:spectator_boundary_direct_sum_gram,
         thm:tail_spectator_pseudoinverse_bound,
         thm:left_spectator_pseudoinverse_bound}
     Distribute the two exterior pseudoinverse factors across the exact four-term
@@ -1254,26 +1251,18 @@ norm estimate is derived here.
 % This theorem is a TNLean reconstruction sufficient for condition C3.  It
 % does not assert the optimized FNW numerator quoted in Nachtergaele, Eq. (6.1).
 \begin{theorem}[Spectator-uniform geometric C3 projector defect]
-    \label{lem:fnw_overlapping_window_contraction}
+    \label{thm:fnw_overlapping_window_contraction}
     \lean{MPSTensor.IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric}
     \leanok
     \discussion{6134}
-    \uses{def:primitive_mps, def:open_chain_ground_subspaces_es,
-        thm:c3_centered_physical_assembly,
-        thm:primitive_tail_virtual_map_norm_uniform,
-        thm:c3_centered_overlap_factorization_geometric,
-        thm:c3_correction_bounds,
-        thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
-        thm:geometric_smallness_at_c3_lengths,
-        thm:tail_boundary_map_range_es_transport,
-        thm:left_boundary_map_range_es_transport}
+    \uses{def:primitive_mps, def:open_chain_ground_subspaces_es}
     Let $A$ be primitive with positive-definite fixed point $\rho$ and nonzero
     bond dimension.  There are constants $C,c,r>0$, with $r<1$, such that for
     every spectator length $K$ and every $l\geq1$ satisfying $cr^l<1$,
     \begin{align}
         \left\|
         P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}
-        -P_{G_{K+l+1}(A)}
+        -P_{\mathcal G_{K+l+1}^{\mathrm{ES}}(A)}
         \right\|
         &\leq \frac{Cr^l}{1-cr^l}.
         \notag
@@ -1283,29 +1272,33 @@ norm estimate is derived here.
 
 \begin{proof}
     \leanok
-    \uses{thm:c3_centered_physical_assembly,
-        thm:primitive_tail_virtual_map_norm_uniform,
-        thm:c3_centered_overlap_factorization_geometric,
-        thm:c3_correction_bounds,
+    \uses{thm:fixed_point_gram_metric_is_unit,
         thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
+        thm:primitive_tail_virtual_map_norm_uniform,
         thm:geometric_smallness_at_c3_lengths,
-        thm:tail_boundary_map_range_es_transport,
-        thm:left_boundary_map_range_es_transport}
-    Put $K_\infty=\mathscr R(P_\rho)$ and
-    $I_\infty=K_\infty^{-1}$.  Choose $g,c,r>0$ from the geometric Gram and
-    inverse-Gram estimate, so that $c=\lVert I_\infty\rVert g$, and choose
+        thm:c3_centered_overlap_factorization_geometric,
+        thm:c3_centered_physical_assembly,
+        thm:c3_correction_bounds,
+        thm:spectator_boundary_hilbert_factorization,
+        thm:range_ground_space_map_es}
+    Put $\mathcal K_\infty=\mathscr R(P_\rho)$ and
+    $\mathcal I_\infty=\mathcal K_\infty^{-1}$.  Choose $g,c,r>0$ from
+    the geometric Gram and inverse-Gram estimate, so that
+    $c=\lVert\mathcal I_\infty\rVert g$, and choose
     $T>0$ with $\lVert J_K^{\mathrm{tail}}\rVert\leq T$ for every $K$.  With
     \begin{align}
       J&=\lVert J_1^{\mathrm{left}}\rVert,&
-      M&=\lVert K_\infty\rVert\lVert I_\infty\rVert,
+      M&=\lVert\mathcal K_\infty\rVert
+        \lVert\mathcal I_\infty\rVert,
     \end{align}
     take
     \begin{align}
-      C=4\lVert I_\infty\rVert T g(J+1)(M+1).
+      C=4\lVert\mathcal I_\infty\rVert T g(J+1)(M+1).
     \end{align}
     The condition $cr^l<1$ implies the same condition at $l+1$, $K+l$, and
     $K+l+1$.  Hence every inverse Gram in the exact telescope is bounded by
-    $(1-cr^l)^{-1}\lVert I_\infty\rVert$.  Pairing the two square-root
+    $(1-cr^l)^{-1}\lVert\mathcal I_\infty\rVert$.  Pairing the two
+    square-root
     pseudoinverse factors gives this denominator only once.  The centered term
     and each of the three correction terms are then at most
     \begin{align}
@@ -1321,7 +1314,7 @@ norm estimate is derived here.
     \label{lem:nachtergaele_c3_blocked_length}
     \notready
     \discussion{5924}
-    \uses{lem:fnw_overlapping_window_contraction,
+    \uses{thm:fnw_overlapping_window_contraction,
         thm:nachtergaele_open_chain_projector_defect}
     Nachtergaele's condition C3
     \cite[Eq.~(2.4)]{Nachtergaele1996Spectral} holds at some positive blocked

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1221,7 +1221,8 @@ norm estimate is derived here.
     \leanok
     \uses{def:c3_centered_physical_sandwich,
         def:c3_correction_sandwiches,
-        def:open_chain_ground_subspaces_es}
+        def:open_chain_ground_subspaces_es,
+        def:ground_space_es}
     Whenever the three finite Grams are invertible, the common-ambient defect is
     \begin{align}
       P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}
@@ -1255,7 +1256,8 @@ norm estimate is derived here.
     \lean{MPSTensor.IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric}
     \leanok
     \discussion{6134}
-    \uses{def:primitive_mps, def:open_chain_ground_subspaces_es}
+    \uses{def:primitive_mps, def:open_chain_ground_subspaces_es,
+        def:ground_space_es}
     Let $A$ be primitive with positive-definite fixed point $\rho$ and nonzero
     bond dimension.  There are constants $C,c,r>0$, with $r<1$, such that for
     every spectator length $K$ and every $l\geq1$ satisfying $cr^l<1$,
@@ -1280,7 +1282,8 @@ norm estimate is derived here.
         thm:c3_centered_physical_assembly,
         thm:c3_correction_bounds,
         thm:spectator_boundary_hilbert_factorization,
-        thm:range_ground_space_map_es}
+        thm:range_ground_space_map_es,
+        thm:injective_range_projector_inverse_gram}
     Put $\mathcal K_\infty=\mathscr R(P_\rho)$ and
     $\mathcal I_\infty=\mathcal K_\infty^{-1}$.  Choose $g,c,r>0$ from
     the geometric Gram and inverse-Gram estimate, so that

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1197,55 +1197,126 @@ norm estimate is derived here.
     pseudoinverse identity controls $S_{K+l+1}C^\dagger$.
 \end{proof}
 
-% The exact centered and correction estimates are formalized separately.  Their
-% uniform combination and comparison with the coefficient below remain open.
-\begin{lemma}[Uniform FNW overlapping-window contraction]
+\begin{definition}[Centered physical C3 sandwich]
+    \label{def:c3_centered_physical_sandwich}
+    \lean{MPSTensor.c3CenteredProjectorResidualES}
+    \leanok
+    \uses{def:c3_centered_overlap_factors_residual,
+        thm:tail_boundary_map_factorization,
+        thm:left_boundary_map_factorization}
+    Let $R_{K,l}$ be the centered virtual residual and let $S_n$ be the inverse
+    Gram at length $n$.  The centered physical sandwich is
+    \begin{align}
+      \widehat R_{K,l}
+      =\Gamma^{\mathrm{tail}}_{K,l+1}S_{l+1}^{\oplus\Omega_K}
+        R_{K,l}S_{K+l}^{\oplus\Omega_1}
+        (\Gamma^{\mathrm{left}}_{K+l,1})^\dagger.
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Physical C3 assembly and centered bound]
+    \label{thm:c3_centered_physical_assembly}
+    \lean{MPSTensor.c3_injectiveRangeProjector_residual_eq_centered_sub_corrections}
+    \lean{MPSTensor.c3CenteredProjectorResidualES_norm_le}
+    \leanok
+    \uses{def:c3_centered_physical_sandwich,
+        thm:c3_projector_gram_error_telescope,
+        thm:c3_centered_overlap_factorization_geometric,
+        thm:c3_correction_factorizations,
+        thm:tail_spectator_pseudoinverse_bound,
+        thm:left_spectator_pseudoinverse_bound}
+    Whenever the three finite Grams are invertible, the common-ambient defect is
+    \begin{align}
+      P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}-P_{G_{K+l+1}(A)}
+      &=\widehat R_{K,l}-Q_1-Q_2-Q_3,
+    \end{align}
+    and
+    \begin{align}
+      \lVert\widehat R_{K,l}\rVert
+      &\leq \sqrt{\lVert S_{l+1}\rVert}\,
+        \lVert R_{K,l}\rVert\sqrt{\lVert S_{K+l}\rVert}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:c3_projector_gram_error_telescope,
+        thm:c3_centered_overlap_factorization_geometric,
+        thm:c3_correction_factorizations,
+        thm:tail_spectator_pseudoinverse_bound,
+        thm:left_spectator_pseudoinverse_bound}
+    Distribute the two exterior pseudoinverse factors across the exact four-term
+    telescope.  The three non-centred terms are precisely $Q_1,Q_2,Q_3$.
+    Submultiplicativity and the two square-root pseudoinverse estimates give the
+    displayed norm bound for the remaining centered sandwich.
+\end{proof}
+
+% This theorem is a TNLean reconstruction sufficient for condition C3.  It
+% does not assert the optimized FNW numerator quoted in Nachtergaele, Eq. (6.1).
+\begin{theorem}[Spectator-uniform geometric C3 projector defect]
     \label{lem:fnw_overlapping_window_contraction}
-    \notready
-    \discussion{5923}
-    \uses{def:primitive_mps, def:open_chain_ground_subspaces_es}
-    Let $A$ be a primitive blocked tensor with a positive-definite fixed point,
-    and let $P^{\mathrm{tail}}_{K,l+1}$ and
-    $P^{\mathrm{left}}_{K+l}$ be the tail and left ground-space projectors in
-    their common $(K+l+1)$-site Hilbert space.  There are constants
-    $c>0$ and $0<\lambda<1$, independent of $K$, such that, whenever
-    $c\lambda^l<1$,
+    \lean{MPSTensor.IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric}
+    \leanok
+    \discussion{6134}
+    \uses{def:primitive_mps, def:open_chain_ground_subspaces_es,
+        thm:c3_centered_physical_assembly,
+        thm:primitive_tail_virtual_map_norm_uniform,
+        thm:c3_centered_overlap_factorization_geometric,
+        thm:c3_correction_bounds,
+        thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
+        thm:geometric_smallness_at_c3_lengths,
+        thm:tail_boundary_map_range_es_transport,
+        thm:left_boundary_map_range_es_transport,
+        thm:ground_space_es_projection_inverse_gram}
+    Let $A$ be primitive with positive-definite fixed point $\rho$ and nonzero
+    bond dimension.  There are constants $C,c,r>0$, with $r<1$, such that for
+    every spectator length $K$ and every $l\geq1$ satisfying $cr^l<1$,
     \begin{align}
         \left\|
         P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}
         -P_{G_{K+l+1}(A)}
         \right\|
-        &\le
-        c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l}.
+        &\leq \frac{Cr^l}{1-cr^l}.
         \notag
     \end{align}
-    This is the commutation bound of
-    \cite[Eq.~(6.1)]{Nachtergaele1996Spectral}, obtained there from the
-    Fannes--Nachtergaele--Werner estimates.
-\end{lemma}
+    The constants are independent of $K$.
+\end{theorem}
 
 \begin{proof}
+    \leanok
     \uses{thm:c3_projector_gram_error_telescope,
         thm:primitive_tail_virtual_map_norm_uniform,
         thm:c3_centered_overlap_factorization_geometric,
         thm:c3_correction_bounds,
-        thm:fixed_point_gram_metric_exact,
-        thm:fixed_point_gram_metric_is_unit,
         thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
         thm:geometric_smallness_at_c3_lengths,
-        thm:ground_space_es_projection_inverse_gram,
-        thm:tail_boundary_map_factorization, thm:left_boundary_map_factorization,
         thm:tail_boundary_map_range_es_transport,
-        thm:left_boundary_map_range_es_transport}
-    Insert the limiting-metric telescope into the exact inverse-Gram formulas
-    for the three physical projectors.  Bound the centered summand by
-    Theorem~\ref{thm:c3_centered_overlap_factorization_geometric} and the three
-    finite-Gram summands by Theorem~\ref{thm:c3_correction_bounds}.  The
-    geometric inverse-Gram estimates and the common smallness condition control
-    every inverse at the lengths $l+1$, $K+l$, and $K+l+1$.  The boundary-map
-    factorizations and range identities identify the resulting operator with
-    the overlapping ground-space projector defect.  The FNW finite-volume
-    comparison then gives the stated rational expression.
+        thm:left_boundary_map_range_es_transport,
+        thm:ground_space_es_projection_inverse_gram}
+    Put $K_\infty=\mathscr R(P_\rho)$ and
+    $I_\infty=K_\infty^{-1}$.  Choose $g,c,r>0$ from the geometric Gram and
+    inverse-Gram estimate, so that $c=\lVert I_\infty\rVert g$, and choose
+    $T>0$ with $\lVert J_K^{\mathrm{tail}}\rVert\leq T$ for every $K$.  With
+    \begin{align}
+      J&=\lVert J_1^{\mathrm{left}}\rVert,&
+      M&=\lVert K_\infty\rVert\lVert I_\infty\rVert,
+    \end{align}
+    take
+    \begin{align}
+      C=4\lVert I_\infty\rVert T g(J+1)(M+1).
+    \end{align}
+    The condition $cr^l<1$ implies the same condition at $l+1$, $K+l$, and
+    $K+l+1$.  Hence every inverse Gram in the exact telescope is bounded by
+    $(1-cr^l)^{-1}\lVert I_\infty\rVert$.  Pairing the two square-root
+    pseudoinverse factors gives this denominator only once.  The centered term
+    and each of the three correction terms are then at most
+    \begin{align}
+      (1-cr^l)^{-1}\frac{C}{4}r^l.
+    \end{align}
+    The triangle inequality gives the displayed estimate.  Finally, the exact
+    range identities replace the three inverse-Gram range projectors by the
+    tail, left, and full physical ground-space projectors.  The coefficient is
+    the displayed reconstruction, not the optimized FNW rational numerator.
 \end{proof}
 
 \begin{lemma}[Uniform open-chain projector-defect threshold]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1085,8 +1085,12 @@ source constants still requires the weighted Gram estimates of FNW, Lemmas
 source dimension-dependent value is made; the available unweighted Gram
 conversion retains its proved $D^{3/2}$ norm factor inside $g$.
 
-\textbf{Verdict:} the spectator-uniform C3-sufficient projector estimate is
-proved; the optimized FNW coefficient remains an open source-comparison gap.
+\section{Verdict}
+
+\textbf{Verdict: local correction (resolved), with an open optimized-coefficient
+scope.}  The spectator-uniform projector estimate needed for condition C3 is
+proved in the unweighted coordinates.  The optimized FNW numerator and its
+source constants remain an open source-comparison problem.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1032,26 +1032,60 @@ Furthermore,
 \begin{align}
   \mathcal K_n^{-1}&\longrightarrow\mathscr R(P_\rho)^{-1}.
 \end{align}
-Together with the three raw correction bounds above, these inverse estimates
-control the centered term and all three finite-Gram corrections without
-spectator-cardinality loss.  Their uniform combination and the comparison with
-Nachtergaele's equation~(6.1) remain open.
+The uniform combination is now complete.  Put
+\begin{align}
+  \mathcal K_\infty&=\mathscr R(P_\rho),&
+  \mathcal I_\infty&=\mathcal K_\infty^{-1}.
+\end{align}
+Choose $g,c,r>0$ from
+\leanid{MPSTensor.IsPrimitiveMPS.groundSpaceMapES_geometric_inverseGram_bounds},
+so that $c=\lVert\mathcal I_\infty\rVert g$ and $0<r<1$, and choose $T>0$
+from \leanid{MPSTensor.IsPrimitiveMPS.tailVirtualMapES_norm_uniform}.  Set
+\begin{align}
+  J&=\lVert J_1^{\mathrm{left}}\rVert,&
+  M&=\lVert\mathcal K_\infty\rVert
+       \lVert\mathcal I_\infty\rVert,\\
+  C_*&=4\lVert\mathcal I_\infty\rVert T g(J+1)(M+1).
+\end{align}
+Then
+\leanid{MPSTensor.IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric}
+proves, for every $K$ and every $l\geq1$ with $cr^l<1$,
+\begin{align}
+  \left\|
+    P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}
+      -P_{\mathcal G_{K+l+1}^{\mathrm{ES}}(A)}
+  \right\|
+  &\leq \frac{C_*r^l}{1-cr^l}.
+\end{align}
+The proof depends directly on the exact residual telescope
+\leanid{MPSTensor.c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors},
+the centered factorization and norm estimate
+\leanid{MPSTensor.c3_centeredVirtualResidualES_eq_overlapFactors} and
+\leanid{MPSTensor.c3_centeredVirtualResidualES_norm_le}, the uniform tail bound,
+the pointwise inverse-Gram bounds and their three-length smallness theorem, and
+the three correction estimates
+\leanid{MPSTensor.c3TailFiniteGramCorrectionES_norm_le},
+\leanid{MPSTensor.c3FullInverseGramCorrectionES_norm_le}, and
+\leanid{MPSTensor.c3LeftFiniteGramCorrectionES_norm_le}.  The exact range
+identities for the tail, left, and full boundary maps give the displayed
+physical projectors.  No physical projector is identified with a transfer
+fixed-point projector.
 
-In particular, the development does not prove the overlapping-window FNW
-contraction
+This coefficient is a reconstructed TNLean substitute sufficient for
+Nachtergaele's condition C3.  It is not the optimized FNW expression
 \begin{align}
   c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},
   \qquad c\lambda^l<1,
 \end{align}
-which appears as equation \path{boundAm} in
-\cite[Section~6]{Nachtergaele1996Spectral}, and it does not reconstruct the
-source constants.  It does not identify a physical range projector with the
-transfer fixed-point projector, nor does it establish the final numerical
-overlap or spectral-gap bound.  That overlapping-window estimate remains open;
-both boundary maps are unweighted (Frobenius), so the contraction estimate may
-require a fixed-point metric or weighted boundary coordinates.
+quoted as equation \path{boundAm} in
+\cite[Section~6]{Nachtergaele1996Spectral}.  Recovering that numerator and its
+source constants still requires the weighted Gram estimates of FNW, Lemmas
+5.2, 5.3, and 6.2.  In particular, the reconstructed constant is not set equal
+to $D^2$; the available unweighted Gram conversion retains its proved
+$D^{3/2}$ norm factor inside $g$.
 
-\textbf{Verdict:} open gap.
+\textbf{Verdict:} the spectator-uniform C3-sufficient projector estimate is
+proved; the optimized FNW coefficient remains an open source-comparison gap.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -547,7 +547,7 @@ normalization \leanid{Matrix.l2_opNorm_single_one} give
 \end{align}
 Thus for $I=\Fin D$ the corresponding norm factor is $D^{3/2}$.  This is a
 safe generic dimension conversion.  It is not claimed sharp, and it is not
-identified with the FNW source prefactor $c=D^2$.
+identified with the coefficient in the FNW weighted-Gram estimate.
 
 Reshuffling is still not operator-norm invariant and need not preserve singular
 values.  The identity map gives the basic boundary: its operator norm on
@@ -723,7 +723,7 @@ and generic prerequisites now include:
     The last theorem gives squared factor $|I|^3$ against the squared operator
     norm of the map when the matrix space carries its $L^2$ operator norm.
     For $I=\Fin D$ this is norm factor $D^{3/2}$; it is not claimed sharp and
-    is not the FNW prefactor $c=D^2$.
+    is not identified with the coefficient in the FNW weighted-Gram estimate.
   \item The spectator-indexed boundary maps for the tail and left windows are
     defined algebraically in
     \path{TNLean/MPS/ParentHamiltonian/SpectatorBoundary.lean}.  Their
@@ -1057,11 +1057,12 @@ proves, for every $K$ and every $l\geq1$ with $cr^l<1$,
   \right\|
   &\leq \frac{C_*r^l}{1-cr^l}.
 \end{align}
-The proof depends directly on the exact residual telescope
-\leanid{MPSTensor.c3_injectiveRangeProjector_residual_eq_centered_sub_gramErrors},
-the centered factorization and norm estimate
-\leanid{MPSTensor.c3_centeredVirtualResidualES_eq_overlapFactors} and
-\leanid{MPSTensor.c3_centeredVirtualResidualES_norm_le}, the uniform tail bound,
+The proof uses the exact physical four-term assembly
+\leanid{MPSTensor.c3_injectiveRangeProjector_residual_eq_centered_sub_corrections}
+and the centered-sandwich estimate
+\leanid{MPSTensor.c3CenteredProjectorResidualES_norm_le}.  Its virtual input is
+bounded by \leanid{MPSTensor.c3_centeredVirtualResidualES_norm_le}; the other
+inputs are the uniform tail bound,
 the pointwise inverse-Gram bounds and their three-length smallness theorem, and
 the three correction estimates
 \leanid{MPSTensor.c3TailFiniteGramCorrectionES_norm_le},
@@ -1080,9 +1081,9 @@ Nachtergaele's condition C3.  It is not the optimized FNW expression
 quoted as equation \path{boundAm} in
 \cite[Section~6]{Nachtergaele1996Spectral}.  Recovering that numerator and its
 source constants still requires the weighted Gram estimates of FNW, Lemmas
-5.2, 5.3, and 6.2.  In particular, the reconstructed constant is not set equal
-to $D^2$; the available unweighted Gram conversion retains its proved
-$D^{3/2}$ norm factor inside $g$.
+5.2, 5.3, and 6.2.  No identification of the reconstructed constant with a
+source dimension-dependent value is made; the available unweighted Gram
+conversion retains its proved $D^{3/2}$ norm factor inside $g$.
 
 \textbf{Verdict:} the spectator-uniform C3-sufficient projector estimate is
 proved; the optimized FNW coefficient remains an open source-comparison gap.


### PR DESCRIPTION
## What changed

- add `MPSTensor.IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric`
- assemble the exact C3 projector residual, centered geometric term, uniform tail bound, pointwise inverse-Gram estimates, and all three finite-Gram corrections
- obtain a bound uniform in the spectator length `K`:
  \[
  \left\|P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}-P_{\mathcal G_{K+l+1}}\right\|
  \le \frac{Cr^l}{1-cr^l}
  \]
  for `l ≥ 1` and `c r^l < 1`
- import the theorem through the parent-Hamiltonian aggregator
- synchronize Chapter 13 and the martingale paper-gap note

The coefficient is explicitly classified as TNLean's reconstructed geometric-over-denominator substitute sufficient for Nachtergaele C3. It is not the optimized FNW numerator, and this PR does not assert `c = D^2`.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.FNWContraction`
- `lake build TNLean.MPS.ParentHamiltonian`
- full `lake build` (10072 jobs)
- proof-integrity and tactic-pattern scans
- blueprint synchronization and declaration checks (7263/7263)
- reader-facing prose check
- full web and canonical PDF builds
- double LuaLaTeX with no undefined cross-references
- independent Lean/style and blueprint/source-boundary reviews

Closes #6134
Advances #5923

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change is a large new formal proof chain in core parent-Hamiltonian martingale/C3 infrastructure; errors would undermine Nachtergaele C3 inputs, though scope is explicitly limited to a reconstructed coefficient rather than the optimized FNW bound.
> 
> **Overview**
> Adds **`FNWContraction.lean`** and wires it through the parent-Hamiltonian aggregator. The new file defines the centered physical C3 sandwich (`c3CenteredProjectorResidualES`), proves exact decomposition of the tail×left minus full ground projector into that term minus three finite-Gram corrections, and bounds the centered piece via inverse-Gram square-root estimates.
> 
> The main result **`IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric`** gives constants \(C,c,r\) with \(r<1\) such that for every spectator length \(K\), \(l\ge1\), and \(cr^l<1\),
> \[
> \left\|P^{\mathrm{tail}}_{K,l+1}P^{\mathrm{left}}_{K+l}-P_{\mathcal G_{K+l+1}^{\mathrm{ES}}}\right\| \le \frac{Cr^l}{1-cr^l},
> \]
> using geometric inverse-Gram bounds, uniform tail virtual-map norms, and the existing correction estimates—without \(K\)-dependent loss.
> 
> Chapter 13 replaces the **notready** FNW overlapping-window lemma with proved definitions/theorems (`c3_centered_physical_sandwich`, physical assembly, spectator-uniform geometric defect) and points the C3 threshold lemma at the new theorem. The martingale overlap paper-gap note updates its verdict: the spectator-uniform C3 estimate is proved in unweighted coordinates; the optimized FNW rational numerator from Nachtergaele (6.1) remains an open source-comparison problem (prose no longer claims \(c=D^2\) as the FNW prefactor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 162e481a91527f4ff03ddc19acd88c1122f70468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->