### PR TITLE
feat(MPS/Chain): prove fixed-length cyclic block averaging

### DIFF
--- a/TNLean/MPS/Chain.lean
+++ b/TNLean/MPS/Chain.lean
@@ -10,6 +10,7 @@ Authors: TNLean contributors
 
 import TNLean.MPS.Chain.AlgebraIsomorphism
 import TNLean.MPS.Chain.BlockedChainFT
+import TNLean.MPS.Chain.CyclicBlockAverage
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Chain.FundamentalTheorem
 import TNLean.MPS.Chain.OneSidedInverse

--- a/TNLean/MPS/Chain/CyclicBlockAverage.lean
+++ b/TNLean/MPS/Chain/CyclicBlockAverage.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Chain.Defs
+import TNLean.MPS.Core.CyclicTrace
+
+import Mathlib.Analysis.SpecialFunctions.Pow.Complex
+import Mathlib.Data.Matrix.Block
+import Mathlib.LinearAlgebra.Matrix.Permutation
+import Mathlib.LinearAlgebra.Matrix.Reindex
+
+/-!
+# Cyclic block averaging for a fixed MPS chain
+
+This file formalizes the cyclic off-diagonal block construction in the proof of
+PGVWC07, Theorem 3 (arXiv:quant-ph/0608197, lines 620--649). For a fixed
+positive chain length `N`, it turns a square site-dependent chain into one
+site-independent tensor of bond dimension `N * D`. At length `N`, the new
+coefficient is the normalized average of the coefficients of all cyclic
+rotations of the chain.
+
+The tensor constructed here depends on `N`; the result concerns only its
+length-`N` coefficient.
+-/
+
+open scoped Matrix
+
+namespace MPSChainTensor
+
+variable {d D N : ℕ}
+
+/-- The rotation of a chain by `k` sites. -/
+def cyclicRotation (A : MPSChainTensor d D N) (k : Fin N) : MPSChainTensor d D N :=
+  fun j => A (finCycle k j)
+
+@[simp] theorem cyclicRotation_apply (A : MPSChainTensor d D N) (k j : Fin N) :
+    cyclicRotation A k j = A (j + k) := rfl
+
+/-- Rotating by `k` sites is the `k`-fold iterate of the one-site cyclic shift. -/
+theorem cyclicRotation_eq_iterate_cyclicShift (A : MPSChainTensor d D N) (k : Fin N) :
+    cyclicRotation A k = (cyclicShift^[k.val]) A := by
+  have hiterate : ∀ (m : ℕ) (B : MPSChainTensor d D N) (j : Fin N),
+      (cyclicShift^[m]) B j = B ((finRotate N)^[m] j) := by
+    intro m
+    induction m with
+    | zero => simp
+    | succ m ih =>
+        intro B j
+        rw [Function.iterate_succ_apply, ih, cyclicShift, cyclicSucc,
+          Function.iterate_succ_apply']
+  ext j i a b
+  rw [hiterate, ← finCycle_eq_finRotate_iterate]
+  rfl
+
+/-- The permutation of block coordinates induced by cyclic successor. -/
+def cyclicBlockPerm : Equiv.Perm (Fin D × Fin N) :=
+  Equiv.prodCongr (Equiv.refl (Fin D)) (finRotate N)
+
+/-- The cyclic permutation matrix on the `N` blocks of size `D`. -/
+def cyclicBlockPermMatrix : Matrix (Fin D × Fin N) (Fin D × Fin N) ℂ :=
+  (cyclicBlockPerm (D := D) (N := N)).permMatrix ℂ
+
+/-- Flatten block coordinates in the order `Fin N × Fin D` to `Fin (N * D)`. -/
+def cyclicBlockFinEquiv : Fin D × Fin N ≃ Fin (N * D) :=
+  (Equiv.prodComm (Fin D) (Fin N)).trans finProdFinEquiv
+
+/-- The unnormalized cyclic off-diagonal block matrix for one physical index. -/
+def cyclicBlockMatrix (A : MPSChainTensor d D N) (i : Fin d) :
+    Matrix (Fin D × Fin N) (Fin D × Fin N) ℂ :=
+  Matrix.blockDiagonal (fun k => A k i) * cyclicBlockPermMatrix
+
+/-- The scalar `N⁻¹/N` whose `N`th power is `N⁻¹`. -/
+noncomputable def cyclicBlockNormalization (N : ℕ) : ℂ :=
+  ((N : ℂ)⁻¹) ^ ((N : ℂ)⁻¹)
+
+/-- The fixed-length site-independent tensor obtained from cyclic off-diagonal blocks.
+
+This is the block matrix in PGVWC07, Theorem 3 (arXiv:quant-ph/0608197,
+lines 635--647), reindexed to bond coordinates `Fin (N * D)` and multiplied by
+`N⁻¹/N`. -/
+noncomputable def cyclicBlockTensor (A : MPSChainTensor d D N) : MPSTensor d (N * D) :=
+  fun i => cyclicBlockNormalization N •
+    Matrix.reindex (cyclicBlockFinEquiv (D := D) (N := N))
+      (cyclicBlockFinEquiv (D := D) (N := N)) (cyclicBlockMatrix A i)
+
+private def pathEval (A : MPSChainTensor d D N) (k : Fin N) :
+    List (Fin d) → Matrix (Fin D) (Fin D) ℂ
+  | [] => 1
+  | i :: w => A k i * pathEval A (finRotate N k) w
+
+private theorem cyclicBlockPermMatrix_mul_blockDiagonal
+    (M : Fin N → Matrix (Fin D) (Fin D) ℂ) :
+    cyclicBlockPermMatrix (D := D) (N := N) * Matrix.blockDiagonal M =
+      Matrix.blockDiagonal (M ∘ finRotate N) * cyclicBlockPermMatrix := by
+  rw [cyclicBlockPermMatrix, PEquiv.toMatrix_toPEquiv_mul,
+    PEquiv.mul_toMatrix_toPEquiv]
+  ext ⟨a, k⟩ ⟨b, l⟩
+  change Matrix.blockDiagonal M (a, finRotate N k) (b, l) =
+    Matrix.blockDiagonal (M ∘ finRotate N) (a, k) (b, (finRotate N).symm l)
+  simp only [Matrix.blockDiagonal_apply, Function.comp_apply]
+  rw [if_congr ((finRotate N).eq_symm_apply) rfl rfl]
+
+private def blockEvalWord
+    (A : Fin d → Matrix (Fin D × Fin N) (Fin D × Fin N) ℂ) :
+    List (Fin d) → Matrix (Fin D × Fin N) (Fin D × Fin N) ℂ
+  | [] => 1
+  | i :: w => A i * blockEvalWord A w
+
+private theorem blockEvalWord_cyclicBlockMatrix
+    (A : MPSChainTensor d D N) (w : List (Fin d)) :
+    blockEvalWord (cyclicBlockMatrix A) w =
+      Matrix.blockDiagonal (fun k => pathEval A k w) *
+        cyclicBlockPermMatrix (D := D) (N := N) ^ w.length := by
+  induction w with
+  | nil =>
+      simp only [blockEvalWord, pathEval, List.length_nil, pow_zero, Matrix.mul_one]
+      exact Matrix.blockDiagonal_one.symm
+  | cons i w ih =>
+      simp only [blockEvalWord, List.length_cons, pathEval]
+      rw [ih, cyclicBlockMatrix, Matrix.mul_assoc,
+        ← Matrix.mul_assoc (cyclicBlockPermMatrix (D := D) (N := N)),
+        cyclicBlockPermMatrix_mul_blockDiagonal]
+      calc
+        (Matrix.blockDiagonal fun k => A k i) *
+              ((Matrix.blockDiagonal ((fun k => pathEval A k w) ∘ finRotate N) *
+                cyclicBlockPermMatrix) * cyclicBlockPermMatrix ^ w.length) =
+            ((Matrix.blockDiagonal fun k => A k i) *
+              Matrix.blockDiagonal ((fun k => pathEval A k w) ∘ finRotate N)) *
+                (cyclicBlockPermMatrix * cyclicBlockPermMatrix ^ w.length) := by
+          noncomm_ring
+        _ = (Matrix.blockDiagonal fun k => A k i * pathEval A (finRotate N k) w) *
+              (cyclicBlockPermMatrix * cyclicBlockPermMatrix ^ w.length) := by
+          rw [← Matrix.blockDiagonal_mul]
+          rfl
+        _ = (Matrix.blockDiagonal fun k => A k i * pathEval A (finRotate N k) w) *
+              cyclicBlockPermMatrix ^ (w.length + 1) := by rw [← pow_succ']
+
+private theorem pathEval_ofFn (A : MPSChainTensor d D N) (σ : Fin N → Fin d)
+    (k : Fin N) :
+    pathEval A k (List.ofFn σ) = eval (cyclicRotation A k) σ := by
+  have haux : ∀ (m : ℕ) (τ : Fin m → Fin d) (l : Fin N),
+      pathEval A l (List.ofFn τ) =
+        Fin.prod fun j => A ((finRotate N)^[j.val] l) (τ j) := by
+    intro m
+    induction m with
+    | zero => simp [pathEval]
+    | succ m ih =>
+        intro τ l
+        rw [List.ofFn_succ, pathEval, Fin.prod_succ, ih]
+        congr 1
+  rw [haux]
+  unfold eval
+  congr 1
+  funext j
+  rw [← finCycle_eq_finRotate_iterate]
+  simp [cyclicRotation, finCycle_apply, add_comm]
+
+private theorem cyclicBlockPermMatrix_pow_length [NeZero N] :
+    cyclicBlockPermMatrix (D := D) (N := N) ^ N = 1 := by
+  have hrotate (k : Fin N) : (finRotate N)^[N] k = k := by
+    cases N with
+    | zero => exact k.elim0
+    | succ n =>
+        apply Fin.ext
+        have h : ∀ m : ℕ, (((finRotate (n + 1))^[m]) k).val =
+            (k.val + m) % (n + 1) := by
+          intro m
+          induction m with
+          | zero => simp [Nat.mod_eq_of_lt k.isLt]
+          | succ m ih =>
+              rw [Function.iterate_succ_apply', finRotate_apply, Fin.val_add, ih,
+                Nat.mod_add_mod, Fin.val_one', Nat.add_mod_mod]
+              apply congrArg (fun x : ℕ => x % (n + 1))
+              omega
+        rw [h]
+        simp [Nat.mod_eq_of_lt k.isLt]
+  have hmatrix (p : Equiv.Perm (Fin D × Fin N)) : ∀ m : ℕ,
+      p.permMatrix ℂ ^ m = (p ^ m).permMatrix ℂ := by
+    intro m
+    induction m with
+    | zero => simp
+    | succ m ih => rw [pow_succ', ih, ← Matrix.permMatrix_mul, ← pow_succ]
+  have hperm : cyclicBlockPerm (D := D) (N := N) ^ N = 1 := by
+    apply Equiv.ext
+    rintro ⟨a, k⟩
+    rw [Equiv.Perm.coe_pow]
+    have hblock : ∀ m : ℕ,
+        ((cyclicBlockPerm (D := D) (N := N) : Fin D × Fin N → Fin D × Fin N)^[m])
+            (a, k) = (a, (finRotate N)^[m] k) := by
+      intro m
+      induction m with
+      | zero => rfl
+      | succ m ih =>
+          rw [Function.iterate_succ_apply', Function.iterate_succ_apply', ih]
+          rfl
+    rw [hblock, hrotate]
+    rfl
+  rw [cyclicBlockPermMatrix, hmatrix, hperm, Matrix.permMatrix_one]
+
+private theorem trace_reindex_cyclicBlockFinEquiv
+    (M : Matrix (Fin D × Fin N) (Fin D × Fin N) ℂ) :
+    Matrix.trace
+      (Matrix.reindex (cyclicBlockFinEquiv (D := D) (N := N))
+        (cyclicBlockFinEquiv (D := D) (N := N)) M) = Matrix.trace M := by
+  simpa [Matrix.trace, Matrix.diag, Matrix.reindex_apply] using
+    Equiv.sum_comp (cyclicBlockFinEquiv (D := D) (N := N)).symm (fun i => M i i)
+
+private theorem evalWord_reindex_cyclicBlockFinEquiv
+    (A : Fin d → Matrix (Fin D × Fin N) (Fin D × Fin N) ℂ) (w : List (Fin d)) :
+    MPSTensor.evalWord
+        (fun i => Matrix.reindex (cyclicBlockFinEquiv (D := D) (N := N))
+          (cyclicBlockFinEquiv (D := D) (N := N)) (A i)) w =
+      Matrix.reindex (cyclicBlockFinEquiv (D := D) (N := N))
+        (cyclicBlockFinEquiv (D := D) (N := N)) (blockEvalWord A w) := by
+  induction w with
+  | nil =>
+      simp only [MPSTensor.evalWord_nil, blockEvalWord]
+      exact (Matrix.reindexLinearEquiv_one ℂ ℂ
+        (cyclicBlockFinEquiv (D := D) (N := N))).symm
+  | cons i w ih =>
+      simp only [MPSTensor.evalWord_cons, blockEvalWord]
+      rw [ih]
+      exact Matrix.reindexLinearEquiv_mul ℂ ℂ
+        (cyclicBlockFinEquiv (D := D) (N := N))
+        (cyclicBlockFinEquiv (D := D) (N := N))
+        (cyclicBlockFinEquiv (D := D) (N := N)) (A i) (blockEvalWord A w)
+
+/-- At the fixed positive length `N`, the cyclic block tensor coefficient is
+exactly the normalized average of the coefficients of all cyclic rotations of
+`A`.
+
+This is the general algebraic averaging identity underlying PGVWC07,
+Theorem 3 (arXiv:quant-ph/0608197, lines 643--648). It makes no translation
+invariance, injectivity, purity, or canonical-form assumption, and asserts no
+equality at lengths other than `N`. -/
+theorem mpv_cyclicBlockTensor_eq_average [NeZero N]
+    (A : MPSChainTensor d D N) (σ : Fin N → Fin d) :
+    MPSTensor.mpv (cyclicBlockTensor A) σ =
+      (N : ℂ)⁻¹ * ∑ k : Fin N, coeff (cyclicRotation A k) σ := by
+  change Matrix.trace
+      (MPSTensor.evalWord
+        (fun i => cyclicBlockNormalization N •
+          Matrix.reindex (cyclicBlockFinEquiv (D := D) (N := N))
+            (cyclicBlockFinEquiv (D := D) (N := N)) (cyclicBlockMatrix A i))
+        (List.ofFn σ)) = _
+  rw [MPSTensor.evalWord_smul, List.length_ofFn, Matrix.trace_smul]
+  simp only [smul_eq_mul]
+  rw [evalWord_reindex_cyclicBlockFinEquiv, blockEvalWord_cyclicBlockMatrix,
+    List.length_ofFn, cyclicBlockPermMatrix_pow_length, Matrix.mul_one,
+    trace_reindex_cyclicBlockFinEquiv, Matrix.trace_blockDiagonal]
+  simp_rw [pathEval_ofFn, coeff]
+  rw [show cyclicBlockNormalization N ^ N = (N : ℂ)⁻¹ by
+    exact Complex.cpow_nat_inv_pow ((N : ℂ)⁻¹) (NeZero.ne N)]
+
+end MPSChainTensor

--- a/TNLean/MPS/Chain/CyclicBlockAverage.lean
+++ b/TNLean/MPS/Chain/CyclicBlockAverage.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.Chain.Defs
-import TNLean.MPS.Core.CyclicTrace
 
 import Mathlib.Analysis.SpecialFunctions.Pow.Complex
 import Mathlib.Data.Matrix.Block
@@ -25,8 +24,6 @@ The tensor constructed here depends on `N`; the result concerns only its
 length-`N` coefficient.
 -/
 
-open scoped Matrix
-
 namespace MPSChainTensor
 
 variable {d D N : ℕ}
@@ -35,6 +32,7 @@ variable {d D N : ℕ}
 def cyclicRotation (A : MPSChainTensor d D N) (k : Fin N) : MPSChainTensor d D N :=
   fun j => A (finCycle k j)
 
+/-- A cyclic rotation evaluates the chain at the shifted site. -/
 @[simp] theorem cyclicRotation_apply (A : MPSChainTensor d D N) (k j : Fin N) :
     cyclicRotation A k j = A (j + k) := rfl
 
@@ -71,7 +69,7 @@ def cyclicBlockMatrix (A : MPSChainTensor d D N) (i : Fin d) :
     Matrix (Fin D × Fin N) (Fin D × Fin N) ℂ :=
   Matrix.blockDiagonal (fun k => A k i) * cyclicBlockPermMatrix
 
-/-- The scalar `N⁻¹/N` whose `N`th power is `N⁻¹`. -/
+/-- The scalar `N ^ (-1 / N)` whose `N`th power is `N⁻¹`. -/
 noncomputable def cyclicBlockNormalization (N : ℕ) : ℂ :=
   ((N : ℂ)⁻¹) ^ ((N : ℂ)⁻¹)
 
@@ -79,7 +77,7 @@ noncomputable def cyclicBlockNormalization (N : ℕ) : ℂ :=
 
 This is the block matrix in PGVWC07, Theorem 3 (arXiv:quant-ph/0608197,
 lines 635--647), reindexed to bond coordinates `Fin (N * D)` and multiplied by
-`N⁻¹/N`. -/
+`N ^ (-1 / N)`. -/
 noncomputable def cyclicBlockTensor (A : MPSChainTensor d D N) : MPSTensor d (N * D) :=
   fun i => cyclicBlockNormalization N •
     Matrix.reindex (cyclicBlockFinEquiv (D := D) (N := N))

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -81,7 +81,7 @@ first.
     \label{thm:chain_cyclic_block_average}
     \lean{MPSChainTensor.mpv_cyclicBlockTensor_eq_average}
     \leanok
-    \uses{def:chain_cyclic_block_tensor, def:non_ti_chain}
+    \uses{def:chain_cyclic_block_tensor, def:non_ti_chain, lem:eval_word_smul}
     For every basis configuration $\sigma\in\{0,\ldots,d-1\}^N$, the
     length-$N$ coefficient of the tensor in
     Definition~\ref{def:chain_cyclic_block_tensor} is
@@ -90,13 +90,15 @@ first.
         &=\frac{1}{N}\sum_{k=0}^{N-1}c_{A^{(k)},\sigma}.
         \label{eq:chain_cyclic_block_average}
     \end{align}
-    This is the cyclic block-matrix calculation in the proof of
-    \cite[Theorem~3]{PerezGarcia2007Matrix}; it asserts only the coefficient
-    identity at the fixed length $N$.
+    Reindexing the finite sum and cyclically permuting factors under the trace
+    identifies this with the physical-configuration rotation in
+    \cite[Theorem~3]{PerezGarcia2007Matrix}. This identity concerns only the
+    fixed length $N$.
 \end{theorem}
 
 \begin{proof}
     \leanok
+    \uses{def:chain_cyclic_block_tensor, def:non_ti_chain, lem:eval_word_smul}
     Write $D_i=\operatorname{diag}(A_0^i,\ldots,A_{N-1}^i)$ and omit the
     scalar normalization temporarily. Commuting the cyclic permutation through
     a block diagonal gives

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -55,6 +55,71 @@ first.
     \end{center}
 \end{definition}
 
+\begin{definition}[Cyclic block tensor at fixed length]
+    \label{def:chain_cyclic_block_tensor}
+    \lean{MPSChainTensor.cyclicRotation, MPSChainTensor.cyclicBlockTensor}
+    \leanok
+    \uses{def:non_ti_chain}
+    Let $N\geq 1$ and let $A_0,\ldots,A_{N-1}$ be a periodic chain of
+    $D\times D$ matrices. For $k\in\mathbb Z/N\mathbb Z$, write
+    $(A^{(k)})_j=A_{j+k}$ for the cyclic rotation by $k$ sites. Let $P$ be
+    the permutation matrix on the block coordinate satisfying
+    $P(e_a\otimes e_k)=e_a\otimes e_{k-1}$. For each physical index $i$, set
+    \begin{align}
+        B^i
+        &=N^{-1/N}\operatorname{diag}
+            \left(A_0^i,\ldots,A_{N-1}^i\right)P
+        \in\MN{ND}.
+        \label{eq:chain_cyclic_block_tensor}
+    \end{align}
+    Thus the $(k,k+1)$ block of $B^i$ is $N^{-1/N}A_k^i$, with block
+    indices taken modulo $N$, and every other block vanishes. The tensor $B$
+    depends on the fixed length $N$.
+\end{definition}
+
+\begin{theorem}[Fixed-length cyclic block average]
+    \label{thm:chain_cyclic_block_average}
+    \lean{MPSChainTensor.mpv_cyclicBlockTensor_eq_average}
+    \leanok
+    \uses{def:chain_cyclic_block_tensor, def:non_ti_chain}
+    For every basis configuration $\sigma\in\{0,\ldots,d-1\}^N$, the
+    length-$N$ coefficient of the tensor in
+    Definition~\ref{def:chain_cyclic_block_tensor} is
+    \begin{align}
+        V^{(N)}(B)_\sigma
+        &=\frac{1}{N}\sum_{k=0}^{N-1}c_{A^{(k)},\sigma}.
+        \label{eq:chain_cyclic_block_average}
+    \end{align}
+    This is the cyclic block-matrix calculation in the proof of
+    \cite[Theorem~3]{PerezGarcia2007Matrix}; it asserts only the coefficient
+    identity at the fixed length $N$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write $D_i=\operatorname{diag}(A_0^i,\ldots,A_{N-1}^i)$ and omit the
+    scalar normalization temporarily. Commuting the cyclic permutation through
+    a block diagonal gives
+    \begin{align}
+        P\operatorname{diag}(M_0,\ldots,M_{N-1})
+        &=\operatorname{diag}(M_1,\ldots,M_0)P.
+        \label{eq:chain_cyclic_block_commute}
+    \end{align}
+    Repeated use of~(\ref{eq:chain_cyclic_block_commute}), followed by
+    $P^N=I$, yields
+    \begin{align}
+        D_{\sigma_0}P\cdots D_{\sigma_{N-1}}P
+        &=\operatorname{diag}\left(
+            \prod_{j=0}^{N-1}A_{j+k}^{\sigma_j}
+          \right)_{k=0}^{N-1}.
+        \label{eq:chain_cyclic_block_product}
+    \end{align}
+    Taking the trace of~(\ref{eq:chain_cyclic_block_product}) sums the traces
+    of its diagonal blocks. Finally,
+    $(N^{-1/N})^N=N^{-1}$ gives
+    (\ref{eq:chain_cyclic_block_average}).
+\end{proof}
+
 \begin{lemma}[Cyclic gauge equivalence is an equivalence relation]
     \label{lem:chain_gauge_equiv_equivalence}
     \lean{MPSChainTensor.GaugeEquiv.refl}

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -81,7 +81,7 @@ first.
     \label{thm:chain_cyclic_block_average}
     \lean{MPSChainTensor.mpv_cyclicBlockTensor_eq_average}
     \leanok
-    \uses{def:chain_cyclic_block_tensor, def:non_ti_chain, lem:eval_word_smul}
+    \uses{def:chain_cyclic_block_tensor, def:non_ti_chain}
     For every basis configuration $\sigma\in\{0,\ldots,d-1\}^N$, the
     length-$N$ coefficient of the tensor in
     Definition~\ref{def:chain_cyclic_block_tensor} is

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -92,7 +92,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L326, 332, 338, 352, 363, 369 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L363, 882, 886, 892, 897 `tenkz` → `P-grid` | — | — |
-| `ch23_algebraic_ft_foundations.tex` | L48, 52, 169, 173, 374, 378, 391, 395, 438, 442, 446, 455, 459 `tenkz` → `P-grid` | — | — |
+| `ch23_algebraic_ft_foundations.tex` | L48, 52, 236, 240, 441, 445, 458, 462, 505, 509, 513, 522, 526 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | L84, 104, 294, 300, 312, 324, 577, 596 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- add `MPSChainTensor.cyclicBlockTensor`, the PGVWC07 cyclic off-diagonal block construction for one fixed ring length
- prove
  ```lean
  MPSChainTensor.mpv_cyclicBlockTensor_eq_average
  ```
  identifying its length-$N$ coefficient with the normalized average of the square site-dependent chain coefficients over all cyclic rotations
- keep the tensor and theorem explicitly dependent on $N$
- import the result through `TNLean.MPS.Chain`
- add a Chapter 23 Blueprint entry with the fixed-length source boundary

This is the algebraic averaging leaf from PGVWC07 Theorem 3. It does not call the square `MPSChainTensor` input an OBC representation, and it does not claim `SameMPV`, `SameMPV₂`, or equality at any other length. The varying-bond rectangular OBC input and padding step remain in #6142.

## Validation

- `lake build TNLean.MPS.Chain.CyclicBlockAverage TNLean.MPS.Chain`
- full `lake build` after rebasing onto current `origin/main` (10074 jobs)
- blueprint synchronization and declaration checks (7274/7274 entries)
- double Blueprint LuaLaTeX compilation with no undefined references
- proof-integrity scan
- `git diff --check`

Closes #6143
Advances #6087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal mathematics and documentation; no runtime, security, or data-path changes.
> 
> **Overview**
> Adds the **PGVWC07 cyclic off-diagonal block** construction at a fixed ring length `N`: a site-independent `MPSTensor` with bond dimension `N * D`, built from block-diagonal site matrices and a cyclic block permutation, scaled by `N^{-1/N}`.
> 
> The main result **`mpv_cyclicBlockTensor_eq_average`** shows that at length `N` only, the MPV coefficient equals **(1/N) times the sum** of `coeff` over all **cyclic rotations** of the original square site-dependent chain—without assuming translation invariance, injectivity, or equality at other lengths.
> 
> The new module is wired through **`TNLean.MPS.Chain`**, and Chapter 23 Blueprint gains matching **definition, theorem, and proof** (`def:chain_cyclic_block_tensor`, `thm:chain_cyclic_block_average`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e1ea3f1e50a4a3519e699842abf4364b4d7568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->