### PR TITLE
feat(martingale): discharge the open-chain C3 threshold

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -57,6 +57,7 @@ import TNLean.MPS.ParentHamiltonian.LocalSupport
 import TNLean.MPS.ParentHamiltonian.LocalSupportTransport
 import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
+import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -36,8 +36,8 @@ The seven components are:
   Hamiltonian transport, positivity, commutation, and kernel identification;
 * `Martingale.OpenChain` — open-chain ground-space projectors, their intersection,
   and the projector-defect reduction to an anticommutator estimate;
-* `Martingale.C3Threshold` — a uniform blocked length satisfying the open-chain
-  C3 defect threshold and its anticommutator consequence;
+* `Martingale.C3Threshold` — a uniform input-site overlap length satisfying the
+  open-chain C3 defect threshold and its anticommutator consequence;
 * `Martingale.OverlapReduction` — reduction from overlapping-window commutation
   to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
+import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
 import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
@@ -27,7 +28,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The six components are:
+The seven components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale` (quadratic form implies norm bound);
@@ -35,6 +36,8 @@ The six components are:
   Hamiltonian transport, positivity, commutation, and kernel identification;
 * `Martingale.OpenChain` — open-chain ground-space projectors, their intersection,
   and the projector-defect reduction to an anticommutator estimate;
+* `Martingale.C3Threshold` — a uniform blocked length satisfying the open-chain
+  C3 defect threshold and its anticommutator consequence;
 * `Martingale.OverlapReduction` — reduction from overlapping-window commutation
   to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered

--- a/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
@@ -10,9 +10,10 @@ import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
 /-!
 # The open-chain C3 threshold
 
-This file chooses a blocked overlap length at which the spectator-uniform geometric
-projector-defect estimate satisfies Nachtergaele's condition C3. One site of the input
-tensor is one blocked-chain filtration step.
+This file chooses an overlap length, measured in sites of the input tensor, at which the
+spectator-uniform geometric projector-defect estimate satisfies Nachtergaele's condition
+C3. If the input tensor is already a blocked representative, one such site is one
+blocked-chain filtration step.
 
 ## Main results
 
@@ -121,9 +122,9 @@ theorem IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold
   exact hDefect K l (by omega) hl_small
 
 /-- The C3 threshold yields the uniform open-chain anticommutator estimate for
-the complementary excitation projections. This is the direct corollary of
-Nachtergaele's projector defect identity following condition C3,
-arXiv:cond-mat/9410110, eq. (2.4). -/
+the complementary excitation projections. Nachtergaele's identity following condition
+C3 identifies the projector defect, arXiv:cond-mat/9410110, eq. (2.4); the
+anticommutator estimate is the two-projection consequence proved in this development. -/
 theorem IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold
     [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.FNWContraction
+import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
+import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
+
+/-!
+# The open-chain C3 threshold
+
+This file chooses a blocked overlap length at which the spectator-uniform geometric
+projector-defect estimate satisfies Nachtergaele's condition C3. One site of the input
+tensor is one blocked-chain filtration step.
+
+## Main results
+
+* `MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold`
+  chooses a block-injective overlap length and one uniform C3 defect coefficient.
+* `MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold`
+  gives the corresponding open-chain excitation-projection anticommutator estimate.
+
+## References
+
+* B. Nachtergaele, arXiv:cond-mat/9410110, eqs. (2.4)--(2.5), Theorem 3,
+  and Section 6.
+-/
+
+open Filter
+open scoped ComplexOrder InnerProductSpace Topology
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+private theorem tendsto_sqrt_succ_mul_pow_of_lt_one {r : ℝ}
+    (hr : 0 ≤ r) (hr_lt_one : r < 1) :
+    Tendsto (fun n : ℕ => Real.sqrt ((n + 1 : ℕ) : ℝ) * r ^ n) atTop (𝓝 0) := by
+  apply squeeze_zero
+  · intro n
+    positivity
+  · intro n
+    have hsqrt : Real.sqrt ((n + 1 : ℕ) : ℝ) ≤ ((n + 1 : ℕ) : ℝ) := by
+      rw [Real.sqrt_le_self_iff]
+      exact Or.inr (by norm_num [Nat.cast_add])
+    exact mul_le_mul_of_nonneg_right hsqrt (pow_nonneg hr n)
+  · simpa only [Nat.cast_add, Nat.cast_one, add_mul, one_mul, zero_add] using
+      (tendsto_self_mul_const_pow_of_lt_one hr hr_lt_one).add
+        (tendsto_pow_atTop_nhds_zero_of_lt_one hr hr_lt_one)
+
+private theorem tendsto_geometric_c3_coefficient_mul_sqrt
+    {C c r : ℝ} (hr : 0 ≤ r) (hr_lt_one : r < 1) :
+    Tendsto
+      (fun n : ℕ =>
+        (1 - c * r ^ n)⁻¹ * (C * r ^ n) * Real.sqrt ((n + 1 : ℕ) : ℝ))
+      atTop (𝓝 0) := by
+  have hr_pow : Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) :=
+    tendsto_pow_atTop_nhds_zero_of_lt_one hr hr_lt_one
+  have hden : Tendsto (fun n : ℕ => 1 - c * r ^ n) atTop (𝓝 1) := by
+    simpa using tendsto_const_nhds.sub (tendsto_const_nhds.mul hr_pow)
+  have hinv : Tendsto (fun n : ℕ => (1 - c * r ^ n)⁻¹) atTop (𝓝 1) := by
+    simpa using hden.inv₀ one_ne_zero
+  have hdecay := tendsto_sqrt_succ_mul_pow_of_lt_one hr hr_lt_one
+  have hscaled : Tendsto
+      (fun n : ℕ => C * (Real.sqrt ((n + 1 : ℕ) : ℝ) * r ^ n))
+      atTop (𝓝 0) := by
+    simpa using tendsto_const_nhds.mul hdecay
+  simpa only [mul_assoc, mul_left_comm, mul_comm, one_mul, zero_mul, mul_zero] using
+    hinv.mul hscaled
+
+/-- A primitive MPS with faithful fixed point has a block-injective overlap length
+at which the uniform open-chain ground-projector defect satisfies Nachtergaele's
+condition C3, arXiv:cond-mat/9410110, eq. (2.4).
+
+The coefficient is the geometric-over-denominator bound reconstructed in
+`openChain_groundProjection_defect_le_geometric`. It is sufficient for C3; this
+statement does not assert the optimized FNW numerator from Nachtergaele, Section 6. -/
+theorem IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ l : ℕ, ∃ ε : ℝ,
+      1 < l ∧ IsNBlkInjective A l ∧ 0 ≤ ε ∧
+      ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
+      ∀ K : ℕ,
+        ‖openChainTailGroundProjectionES A K (l + 1) ∘L
+              openChainLeftGroundProjectionES A (K + l) -
+            (groundSpaceES A (K + l + 1)).starProjection‖ ≤ ε := by
+  obtain ⟨C, c, r, hC, hc, hr, hr_lt_one, hDefect⟩ :=
+    hP.openChain_groundProjection_defect_le_geometric hρ
+  obtain ⟨L, hLpos, hLinj⟩ := isNormal_of_isPrimitiveMPS_with_posDef hP hρ
+  have hr_pow : Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) :=
+    tendsto_pow_atTop_nhds_zero_of_lt_one hr.le hr_lt_one
+  have hsmall_lim : Tendsto (fun n : ℕ => c * r ^ n) atTop (𝓝 0) := by
+    simpa using tendsto_const_nhds.mul hr_pow
+  have hcoefficient_lim :=
+    tendsto_geometric_c3_coefficient_mul_sqrt (C := C) (c := c) hr.le hr_lt_one
+  have hsmall : ∀ᶠ n : ℕ in atTop, c * r ^ n < 1 :=
+    (tendsto_order.1 hsmall_lim).2 1 zero_lt_one
+  have hcoefficient : ∀ᶠ n : ℕ in atTop,
+      (1 - c * r ^ n)⁻¹ * (C * r ^ n) *
+          Real.sqrt ((n + 1 : ℕ) : ℝ) < 1 :=
+    (tendsto_order.1 hcoefficient_lim).2 1 zero_lt_one
+  have hlarge : ∀ᶠ n : ℕ in atTop, max 2 L ≤ n := eventually_ge_atTop _
+  obtain ⟨l, hl_large, hl_small, hl_coefficient⟩ :=
+    (hlarge.and (hsmall.and hcoefficient)).exists
+  let ε := (1 - c * r ^ l)⁻¹ * (C * r ^ l)
+  have hl : 1 < l := lt_of_lt_of_le (by omega) hl_large
+  have hLle : L ≤ l := le_trans (le_max_right 2 L) hl_large
+  have hInj : IsNBlkInjective A l := isNBlkInjective_of_le hLpos hLinj hLle
+  have hden : 0 < 1 - c * r ^ l := sub_pos.mpr hl_small
+  have hε : 0 ≤ ε := by
+    dsimp only [ε]
+    positivity
+  have hsqrt : 0 < Real.sqrt ((l + 1 : ℕ) : ℝ) := Real.sqrt_pos.2 (by positivity)
+  have hε_lt : ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) := by
+    rw [lt_div_iff₀ hsqrt]
+    simpa only [ε, one_mul] using hl_coefficient
+  refine ⟨l, ε, hl, hInj, hε, hε_lt, ?_⟩
+  intro K
+  exact hDefect K l (by omega) hl_small
+
+/-- The C3 threshold yields the uniform open-chain anticommutator estimate for
+the complementary excitation projections. This is the direct corollary of
+Nachtergaele's projector defect identity following condition C3,
+arXiv:cond-mat/9410110, eq. (2.4). -/
+theorem IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ l : ℕ, ∃ ε : ℝ,
+      1 < l ∧ 0 ≤ ε ∧ ε < 1 / Real.sqrt ((l + 1 : ℕ) : ℝ) ∧
+      ∀ (K : ℕ) (v : EuclideanSpace ℂ (Cfg d (K + l + 1))),
+        -ε *
+            (RCLike.re
+                (⟪(openChainTailGroundSpaceES A K (l + 1))ᗮ.starProjection v, v⟫_ℂ) +
+              RCLike.re
+                (⟪(openChainLeftGroundSpaceES A (K + l))ᗮ.starProjection v, v⟫_ℂ)) ≤
+          RCLike.re
+              (⟪(openChainTailGroundSpaceES A K (l + 1))ᗮ.starProjection v,
+                (openChainLeftGroundSpaceES A (K + l))ᗮ.starProjection v⟫_ℂ) +
+            RCLike.re
+              (⟪(openChainLeftGroundSpaceES A (K + l))ᗮ.starProjection v,
+                (openChainTailGroundSpaceES A K (l + 1))ᗮ.starProjection v⟫_ℂ) := by
+  obtain ⟨l, ε, hl, hInj, hε, hε_lt, hDefect⟩ :=
+    hP.exists_openChain_groundProjection_defect_lt_c3_threshold hρ
+  refine ⟨l, ε, hl, hε, hε_lt, ?_⟩
+  intro K v
+  exact re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect
+    hInj hl.le (hDefect K) v
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
@@ -16,8 +16,9 @@ implies the generic Friedrichs-angle anticommutator estimate.
 
 **Scope restriction (Nachtergaele C3):** This file formalizes only the open-chain
 projector geometry and the implication from its defect to the Friedrichs and
-anticommutator bounds. The geometric defect estimate and the choice of a blocked
-length satisfying the C3 threshold are proved separately. Transport from this
+anticommutator bounds. The geometric defect estimate and the choice of an overlap
+length, measured in sites of the input tensor, satisfying the C3 threshold are proved
+separately. Transport from this
 open-chain statement to cyclic parent-Hamiltonian windows remains outside this
 file; see `docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenChain.lean
@@ -16,9 +16,10 @@ implies the generic Friedrichs-angle anticommutator estimate.
 
 **Scope restriction (Nachtergaele C3):** This file formalizes only the open-chain
 projector geometry and the implication from its defect to the Friedrichs and
-anticommutator bounds. The FNW numerical transfer bound controlling the defect
-remains unformalized; see
-`docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
+anticommutator bounds. The geometric defect estimate and the choice of a blocked
+length satisfying the C3 threshold are proved separately. Transport from this
+open-chain statement to cyclic parent-Hamiltonian windows remains outside this
+file; see `docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
 
 For the increasing intervals \(\Lambda_n = [1, n]\) in arXiv:cond-mat/9410110,
 eq. (2.4), the two spaces are the ground conditions on \(\Lambda_n\) and on the tail

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1313,11 +1313,13 @@ norm estimate is derived here.
     the displayed reconstruction, not the optimized FNW rational numerator.
 \end{proof}
 
-\begin{lemma}[Uniform open-chain projector-defect threshold]
-    \label{lem:nachtergaele_c3_blocked_length}
+\begin{theorem}[Uniform open-chain projector-defect threshold]
+    \label{thm:nachtergaele_c3_blocked_length}
     \lean{MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold}
     \lean{MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold}
     \leanok
+    \uses{def:primitive_mps, def:l_blk_injective,
+        def:open_chain_ground_subspaces_es, def:ground_space_es}
     Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
     positive-definite fixed point.  There are an overlap length $l>1$, measured
     in sites of $A$, and a number $\varepsilon_l\geq0$ such that $A$ is
@@ -1332,7 +1334,7 @@ norm estimate is derived here.
     estimate, gives the corresponding anticommutator bound for every $K$.  If
     $A$ is already a blocked representative, one site of $A$ is one
     blocked-chain filtration step.
-\end{lemma}
+\end{theorem}
 \begin{proof}
     \leanok
     \uses{thm:fnw_overlapping_window_contraction,
@@ -1358,7 +1360,7 @@ norm estimate is derived here.
     \label{lem:blocked_to_cyclic_ground_projector_comparison}
     \notready
     \discussion{5925}
-    \uses{lem:nachtergaele_c3_blocked_length}
+    \uses{thm:nachtergaele_c3_blocked_length}
     Let $A$ be a normal tensor, let $B$ be the injective tensor obtained from
     $A$ by the chosen blocking, and let $L>1$ be the resulting cyclic interaction
     range.  For every $N\ge2L$ and every overlapping off-diagonal pair of cyclic

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1318,23 +1318,26 @@ norm estimate is derived here.
     \lean{MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold}
     \lean{MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold}
     \leanok
-    \uses{thm:fnw_overlapping_window_contraction,
-        thm:nachtergaele_open_chain_projector_defect}
-    Let $A$ be a primitive MPS tensor with a positive-definite fixed point.
-    There are a blocked overlap length $l>1$ and a number $\varepsilon_l\geq0$
-    such that $A$ is $l$-block injective, the projector defect is bounded
+    Let $A$ be a primitive MPS tensor with nonzero bond dimension and a
+    positive-definite fixed point.  There are an overlap length $l>1$, measured
+    in sites of $A$, and a number $\varepsilon_l\geq0$ such that $A$ is
+    $l$-block injective, the projector defect is bounded
     uniformly in the left length $K$ by $\varepsilon_l$, and
     \begin{align}
         \varepsilon_l&<\frac{1}{\sqrt{l+1}}.
         \notag
     \end{align}
-    Thus Nachtergaele's condition C3
-    \cite[Eq.~(2.4)]{Nachtergaele1996Spectral} gives the corresponding
-    anticommutator bound for every $K$.  One site of $A$ is one blocked-chain
-    filtration step.
+    Nachtergaele's projector-defect identity following condition C3
+    \cite[Eq.~(2.4)]{Nachtergaele1996Spectral}, together with the two-projection
+    estimate, gives the corresponding anticommutator bound for every $K$.  If
+    $A$ is already a blocked representative, one site of $A$ is one
+    blocked-chain filtration step.
 \end{lemma}
 \begin{proof}
     \leanok
+    \uses{thm:fnw_overlapping_window_contraction,
+        thm:normal_from_primitive_posdef, thm:wordspan_blk_inj_succ,
+        thm:nachtergaele_open_chain_projector_defect}
     The geometric projector estimate supplies $C,c,r>0$ with $r<1$.  Since
     \begin{align}
         \sqrt{n+1}\,r^n&\longrightarrow0,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1315,22 +1315,41 @@ norm estimate is derived here.
 
 \begin{lemma}[Uniform open-chain projector-defect threshold]
     \label{lem:nachtergaele_c3_blocked_length}
-    \notready
-    \discussion{5924}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold}
+    \leanok
     \uses{thm:fnw_overlapping_window_contraction,
         thm:nachtergaele_open_chain_projector_defect}
-    Nachtergaele's condition C3
-    \cite[Eq.~(2.4)]{Nachtergaele1996Spectral} holds at some positive blocked
-    overlap length $l$: the uniform projector defect $\varepsilon_l$ satisfies
+    Let $A$ be a primitive MPS tensor with a positive-definite fixed point.
+    There are a blocked overlap length $l>1$ and a number $\varepsilon_l\geq0$
+    such that $A$ is $l$-block injective, the projector defect is bounded
+    uniformly in the left length $K$ by $\varepsilon_l$, and
     \begin{align}
         \varepsilon_l&<\frac{1}{\sqrt{l+1}}.
         \notag
     \end{align}
-    Here one blocked site is one step of the martingale filtration.  The choice
-    of $l$ includes the positivity of the FNW denominator and all geometric
-    decay side conditions.  The open-chain projector-defect theorem then gives
-    the required Friedrichs and anticommutator bounds for every left length.
+    Thus Nachtergaele's condition C3
+    \cite[Eq.~(2.4)]{Nachtergaele1996Spectral} gives the corresponding
+    anticommutator bound for every $K$.  One site of $A$ is one blocked-chain
+    filtration step.
 \end{lemma}
+\begin{proof}
+    \leanok
+    The geometric projector estimate supplies $C,c,r>0$ with $r<1$.  Since
+    \begin{align}
+        \sqrt{n+1}\,r^n&\longrightarrow0,
+    \end{align}
+    continuity of inversion at $1$ gives
+    \begin{align}
+        \frac{Cr^n}{1-cr^n}\sqrt{n+1}&\longrightarrow0.
+    \end{align}
+    Normality supplies a positive block-injectivity length.  Choose $l$ above
+    that length and above $1$ so that $cr^l<1$ and the last display is less
+    than $1$.  Block injectivity propagates to $l$, and the geometric estimate
+    gives the uniform defect bound with
+    $\varepsilon_l=(1-cr^l)^{-1}Cr^l$.  The open-chain projector-defect theorem
+    gives the anticommutator statement.
+\end{proof}
 
 \begin{lemma}[Blocked-to-cyclic ground-projector comparison]
     \label{lem:blocked_to_cyclic_ground_projector_comparison}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -151,14 +151,17 @@ separate batched condition C3$'$ involving $E_n^{(p)}$.
 The open-chain numerical step is also complete.  The geometric estimate below
 is uniform in the left length, and
 \leanid{MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold}
-chooses one block-injective $l>1$ and one coefficient $\varepsilon_l\geq0$ with
+chooses one block-injective $l>1$, measured in sites of the input tensor, and
+one coefficient $\varepsilon_l\geq0$ with
 \[
   \varepsilon_l<\frac{1}{\sqrt{l+1}}.
 \]
 The companion theorem
 \leanid{MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold}
-gives the corresponding anticommutator inequality for every left length.  The
-remaining task is the separate blocked-to-cyclic comparison, including windows
+combines Nachtergaele's projector-defect identity with the two-projection
+estimate proved here to give the corresponding anticommutator inequality for
+every left length.  The remaining task is the separate blocked-to-cyclic
+comparison, including windows
 crossing the periodic cut.  No excitation-compression estimate is used.
 
 \section{Finite-row martingale reduction}
@@ -1093,8 +1096,10 @@ and
 \end{align}
 The same $l$ works for every spectator length $K$, and
 \leanid{MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold}
-then gives the open-chain anticommutator inequality.  One site of the input
-tensor is one blocked-chain filtration step.
+then gives the open-chain anticommutator inequality by the two-projection
+argument.  The length $l$ is measured in sites of the input tensor.  If that
+tensor is already a blocked representative, one such site is one blocked-chain
+filtration step.
 
 The coefficient is not the optimized FNW expression
 \begin{align}
@@ -1111,7 +1116,7 @@ conversion retains its proved $D^{3/2}$ norm factor inside $g$.
 \section{Verdict}
 
 \textbf{Verdict: the open-chain C3 threshold is resolved.}  The
-spectator-uniform projector estimate and a blocked length satisfying
+spectator-uniform projector estimate and an input-site overlap length satisfying
 $\varepsilon_l<1/\sqrt{l+1}$ are proved in the unweighted coordinates.  The
 optimized FNW numerator remains an open source-comparison problem, and the
 blocked-to-cyclic parent-Hamiltonian comparison remains separate.

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1115,11 +1115,12 @@ conversion retains its proved $D^{3/2}$ norm factor inside $g$.
 
 \section{Verdict}
 
-\textbf{Verdict: the open-chain C3 threshold is resolved.}  The
-spectator-uniform projector estimate and an input-site overlap length satisfying
-$\varepsilon_l<1/\sqrt{l+1}$ are proved in the unweighted coordinates.  The
-optimized FNW numerator remains an open source-comparison problem, and the
-blocked-to-cyclic parent-Hamiltonian comparison remains separate.
+\textbf{Verdict: local correction (resolved), with an open optimized-coefficient
+scope.}  The spectator-uniform projector estimate and an input-site overlap
+length satisfying $\varepsilon_l<1/\sqrt{l+1}$ are proved in the unweighted
+coordinates, so the open-chain C3 threshold is resolved.  The optimized FNW
+numerator remains an open source-comparison problem, and the blocked-to-cyclic
+parent-Hamiltonian comparison remains separate.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -148,12 +148,18 @@ using the identity following condition C3 in
 \cite[Equation~(2.4)]{Nachtergaele1996Spectral}. Equation~(2.5) is the
 separate batched condition C3$'$ involving $E_n^{(p)}$.
 
-The remaining source step is numerical, not geometric: one must formalize the
-FNW transfer-mixing estimate that bounds this open-chain defect uniformly in
-$n$ by an exponentially decaying function of $l$ (or formalize the Section~6
-C3$'$ route with its batched difference). No cyclic rotation, interval
-evaluator, excitation compression, or numerical transfer estimate is included
-in these results.
+The open-chain numerical step is also complete.  The geometric estimate below
+is uniform in the left length, and
+\leanid{MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold}
+chooses one block-injective $l>1$ and one coefficient $\varepsilon_l\geq0$ with
+\[
+  \varepsilon_l<\frac{1}{\sqrt{l+1}}.
+\]
+The companion theorem
+\leanid{MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold}
+gives the corresponding anticommutator inequality for every left length.  The
+remaining task is the separate blocked-to-cyclic comparison, including windows
+crossing the periodic cut.  No excitation-compression estimate is used.
 
 \section{Finite-row martingale reduction}
 
@@ -374,8 +380,8 @@ and
 with public reformulations
 \leanid{parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant} and
 \leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. The correct
-remaining route is to prove the blocked MPS reduced ground-space Friedrichs
-estimate tracked in issue~\#5455. The generic theorem
+remaining route is the blocked-to-cyclic ground-projector comparison tracked
+in issue~\#5925. The generic theorem
 \leanid{re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
 then supplies the excitation-projection anticommutator estimate. This route uses
 the intersection identity $\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
@@ -387,9 +393,9 @@ nonzero vector.
 \section{Relation to the blueprint}
 
 The blueprint item labelled \path{lem:martingale_mps} in
-\path{blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex}
-separates the finite-row martingale reduction from the still-open quantitative
-estimate.
+\path{blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex}
+separates the finite-row martingale reduction from the still-open cyclic
+comparison.
 It does not assert that the displayed all-$L>1$ cyclic-window bound has already
 been obtained from the cited principal-angle estimates. Instead, it records the
 source anticommutator estimate as the hypothesis of
@@ -422,9 +428,9 @@ non-overlap, anticommutator, norm-compression, and spectral-theorem reductions
 are proved, while the MPS-specific anticommutator estimate remains to be proved
 or matched precisely to the cited martingale estimates.
 
-Once the quantitative comparison with the cited martingale estimates is settled,
-the blueprint should say that the cyclic-window anticommutator estimate follows
-from those estimates under the convention used here. The blueprint should
+The open-chain threshold is now settled.  Once the blocked-to-cyclic comparison
+is proved, the blueprint should say that the cyclic-window anticommutator
+estimate follows under the convention used here. The blueprint should
 identify the reduced ground-space
 Friedrichs-to-anticommutator reduction as the source-facing route. The all-vector
 compression bound (N$_\eta$), if separately assumed, is only a stronger
@@ -967,7 +973,8 @@ and generic prerequisites now include:
     while Cirac--Perez-Garcia--Schuch--Verstraete state the martingale
     anticommutator criterion and its principal-angle interpretation.  None of
     those sources gives the three displayed correction formulas.  Their uniform
-    combination and comparison with Nachtergaele's equation~(6.1) remain open.
+    combination is given below; comparison with the optimized coefficient in
+    Nachtergaele's equation~(6.1) remains open.
 \end{itemize}
 Fix \(K,L_0\in\mathbb N\) and let
 \(\mathcal H_{K+L_0+1}\) be the \((K+L_0+1)\)-site Euclidean space
@@ -978,7 +985,7 @@ Fix \(K,L_0\in\mathbb N\) and let
 Nachtergaele C3 left-window convention) identifies its range with the
 open-chain left subspace \(\mathcal U_{K+L_0}(A)\), both in the common ambient
 \(\mathcal H_{K+L_0+1}\).
-The remaining task is to bound the projector defect
+The relevant projector defect is
 \begin{align}
     \bigl\|
         P^{\mathrm{tail}}_{K,L_0+1}(A)\,
@@ -1073,7 +1080,23 @@ physical projectors.  No physical projector is identified with a transfer
 fixed-point projector.
 
 This coefficient is a reconstructed TNLean substitute sufficient for
-Nachtergaele's condition C3.  It is not the optimized FNW expression
+Nachtergaele's condition C3.  Indeed,
+\leanid{MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold}
+uses
+\begin{align}
+  \sqrt{n+1}\,r^n&\longrightarrow0
+\end{align}
+to choose $l>1$ above a positive block-injectivity length such that $cr^l<1$
+and
+\begin{align}
+  \frac{C_*r^l}{1-cr^l}&<\frac{1}{\sqrt{l+1}}.
+\end{align}
+The same $l$ works for every spectator length $K$, and
+\leanid{MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold}
+then gives the open-chain anticommutator inequality.  One site of the input
+tensor is one blocked-chain filtration step.
+
+The coefficient is not the optimized FNW expression
 \begin{align}
   c\lambda^l\frac{1+c\lambda^l}{1-c\lambda^l},
   \qquad c\lambda^l<1,
@@ -1087,10 +1110,11 @@ conversion retains its proved $D^{3/2}$ norm factor inside $g$.
 
 \section{Verdict}
 
-\textbf{Verdict: local correction (resolved), with an open optimized-coefficient
-scope.}  The spectator-uniform projector estimate needed for condition C3 is
-proved in the unweighted coordinates.  The optimized FNW numerator and its
-source constants remain an open source-comparison problem.
+\textbf{Verdict: the open-chain C3 threshold is resolved.}  The
+spectator-uniform projector estimate and a blocked length satisfying
+$\varepsilon_l<1/\sqrt{l+1}$ are proved in the unweighted coordinates.  The
+optimized FNW numerator remains an open source-comparison problem, and the
+blocked-to-cyclic parent-Hamiltonian comparison remains separate.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- add `MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold`
- choose an overlap length `l > 1`, measured in sites of the input tensor, at which the spectator-uniform geometric defect coefficient satisfies
  \[
  \varepsilon_l<\frac{1}{\sqrt{l+1}}
  \]
- prove block injectivity at the chosen length and discharge positivity and denominator side conditions explicitly
- keep the defect bound uniform in every spectator length `K`
- derive the corresponding open-chain excitation-projection anticommutator estimate through the established two-projection theorem
- synchronize the martingale aggregator, Chapter 13, and the source-audited paper-gap note

If the input tensor is already a blocked representative, one input site is one blocked-chain filtration step. This PR does not perform the later blocked-to-cyclic parent-Hamiltonian transport, which remains #5925. It also does not claim the optimized FNW numerator.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- full `lake build` (10074 jobs)
- proof-integrity and tactic-pattern scans
- blueprint synchronization and changed-declaration checks
- reader-facing prose check
- double LuaLaTeX validation with no undefined cross-references
- standalone paper-gap compilation
- independent mathematical, source-scope, style, and Blueprint reviews
- `git diff --check`

Closes #5924
Advances #5752

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 86c77884fa419cc1f63c97364cce8ed5a287d814. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->