### PR TITLE
refactor(MPS/MPDO): share residual coordinate helpers

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -93,10 +93,6 @@ private theorem physicalCoordinateMatrixN_coisometry
   congr 1
   exact propext funext_iff.symm
 
-private def braKetFunctionsEquiv {i a b : Type*} :
-    ((i → b) × (i → a)) ≃ (i → a × b) :=
-  (Equiv.prodComm _ _).trans (Equiv.arrowProdEquivProdArrow i (fun _ ↦ a) (fun _ ↦ b)).symm
-
 /-- The length-`N` MPO transforms by the sitewise physical coordinate
 matrix.
 
@@ -130,7 +126,7 @@ private theorem physicalCoordinateMatrixN_mpo
       (∏ i : Fin N, star (F.physicalCoordinateMatrix (t i) (q i)))
   rw [hexpand]
   have h := Fintype.sum_equiv
-    (braKetFunctionsEquiv (i := Fin N) (a := Fin d) (b := Fin d))
+    (MPOTensor.braKetFunctionsEquiv (i := Fin N) (a := Fin d) (b := Fin d))
     (fun p : (Fin N → Fin d) × (Fin N → Fin d) ↦
       (∏ i : Fin N, F.physicalCoordinateMatrix (s i) (p.2 i)) *
         Matrix.trace (MPOTensor.evalWord K (List.ofFn p.2) (List.ofFn p.1)) *

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -135,7 +135,8 @@ theorem reindex_sitewisePhysicalMatrix_two
   congr 1
   exact propext funext_iff.symm
 
-private def braKetFunctionsEquiv {i a b : Type*} :
+/-- Reindex a pair of bra and ket configurations as a configuration of pairs. -/
+def braKetFunctionsEquiv {i a b : Type*} :
     ((i → b) × (i → a)) ≃ (i → a × b) :=
   (Equiv.prodComm _ _).trans
     (Equiv.arrowProdEquivProdArrow i (fun _ ↦ a) (fun _ ↦ b)).symm

--- a/TNLean/MPS/MPDO/VerticalCopyBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalCopyBlocks.lean
@@ -23,6 +23,8 @@ noncomputable section
 
 namespace MPOTensor
 
+namespace VerticalCopyBlocks
+
 private theorem verticalAssembledTensor_apply_copy_ne
     {g d : ℕ} (dim mult : Fin g → ℕ)
     (weight : (α : Fin g) → Fin (mult α) → ℂ)
@@ -33,12 +35,11 @@ private theorem verticalAssembledTensor_apply_copy_ne
     verticalAssembledTensor dim mult weight B v
         (verticalSectorFinEquiv dim mult ⟨α, (q, i)⟩)
         (verticalSectorFinEquiv dim mult ⟨β, (r, j)⟩) = 0 := by
-  have hflat : finSigmaFinEquiv ⟨α, q⟩ ≠ finSigmaFinEquiv ⟨β, r⟩ :=
-    fun hEq => h (finSigmaFinEquiv.injective hEq)
-  simp [verticalAssembledTensor, MPSTensor.toTensorFromBlocks,
-    Matrix.reindex_apply, Matrix.submatrix_apply,
-    verticalSectorFinEquiv_outer_symm, Matrix.blockDiagonal'_apply_ne,
-    hflat]
+  exact MPOTensor.verticalAssembledTensor_apply_copy_ne dim mult weight B h v i j
+
+end VerticalCopyBlocks
+
+open VerticalCopyBlocks
 
 /-- In retained-copy coordinates, the assembled vertical tensor is the
 block diagonal of its weighted simple blocks.

--- a/TNLean/MPS/MPDO/VerticalProductRetainedBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalProductRetainedBlocks.lean
@@ -24,6 +24,8 @@ noncomputable section
 
 namespace MPOTensor
 
+namespace VerticalProductRetainedBlocks
+
 private theorem verticalAssembledTensor_apply_copy_ne
     {g d : ℕ} (dim mult : Fin g → ℕ)
     (weight : (α : Fin g) → Fin (mult α) → ℂ)
@@ -34,12 +36,11 @@ private theorem verticalAssembledTensor_apply_copy_ne
     verticalAssembledTensor dim mult weight B v
         (verticalSectorFinEquiv dim mult ⟨α, (q, i)⟩)
         (verticalSectorFinEquiv dim mult ⟨β, (r, j)⟩) = 0 := by
-  have hflat : finSigmaFinEquiv ⟨α, q⟩ ≠ finSigmaFinEquiv ⟨β, r⟩ :=
-    fun hEq => h (finSigmaFinEquiv.injective hEq)
-  simp [verticalAssembledTensor, MPSTensor.toTensorFromBlocks,
-    Matrix.reindex_apply, Matrix.submatrix_apply,
-    verticalSectorFinEquiv_outer_symm, Matrix.blockDiagonal'_apply_ne,
-    hflat]
+  exact MPOTensor.verticalAssembledTensor_apply_copy_ne dim mult weight B h v i j
+
+end VerticalProductRetainedBlocks
+
+open VerticalProductRetainedBlocks
 
 private def verticalProductSectorEquiv {g : ℕ} (dim mult : Fin g → ℕ) :
     ((α : Fin g) × (Fin (mult α) × Fin (dim α))) ×

--- a/TNLean/MPS/MPDO/VerticalSectorCoordinates.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorCoordinates.lean
@@ -114,6 +114,27 @@ theorem verticalAssembledTensor_apply_copy_same
   rw [hweight]
   exact congrArg (weight α q * ·) hentry.symm
 
+/-- Evaluating an assembled vertical tensor between distinct retained copies
+vanishes.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+theorem verticalAssembledTensor_apply_copy_ne
+    {g d : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (B : (α : Fin g) → MPSTensor d (dim α))
+    {α β : Fin g} {q : Fin (mult α)} {r : Fin (mult β)}
+    (h : (⟨α, q⟩ : (α : Fin g) × Fin (mult α)) ≠ ⟨β, r⟩)
+    (v : Fin d) (i : Fin (dim α)) (j : Fin (dim β)) :
+    verticalAssembledTensor dim mult weight B v
+        (verticalSectorFinEquiv dim mult ⟨α, (q, i)⟩)
+        (verticalSectorFinEquiv dim mult ⟨β, (r, j)⟩) = 0 := by
+  have hflat : finSigmaFinEquiv ⟨α, q⟩ ≠ finSigmaFinEquiv ⟨β, r⟩ :=
+    fun hEq => h (finSigmaFinEquiv.injective hEq)
+  simp [verticalAssembledTensor, MPSTensor.toTensorFromBlocks,
+    Matrix.reindex_apply, Matrix.submatrix_apply,
+    verticalSectorFinEquiv_outer_symm, Matrix.blockDiagonal'_apply_ne,
+    hflat]
+
 /-- Matrices on the flattened retained physical space of a vertical canonical
 form. -/
 abbrev RetainedVerticalSectorMatrix {g : ℕ} (dim mult : Fin g → ℕ) :=

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -419,6 +419,20 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Unequal retained vertical-copy evaluation
+- **Pattern:** unfold an assembled vertical tensor at two retained coordinates whose copy
+  indices differ, then reduce the cross-copy matrix entry to zero through the block-diagonal
+  assembly.
+- **Reuse:** `MPOTensor.verticalAssembledTensor_apply_copy_ne` in
+  `TNLean/MPS/MPDO/VerticalSectorCoordinates.lean` owns the shared unequal-copy argument.
+- **Result:** the former private implementations
+  `VerticalCopyBlocks.verticalAssembledTensor_apply_copy_ne` in
+  `TNLean/MPS/MPDO/VerticalCopyBlocks.lean` and
+  `VerticalProductRetainedBlocks.verticalAssembledTensor_apply_copy_ne` in
+  `TNLean/MPS/MPDO/VerticalProductRetainedBlocks.lean` now delegate to the shared owner.
+  Unlike `MPOTensor.verticalAssembledTensor_apply_copy_same`, this theorem handles distinct
+  retained copy indices and proves that the assembled tensor entry vanishes.
+
 ### Block-diagonal boundary assembly
 - **Pattern:** decompose membership in a finite supremum of open-boundary block spaces into
   finitely supported components, choose one boundary matrix per component, rescale by the


### PR DESCRIPTION
## What changed

- added the shared different-copy coordinate theorem beside the existing same-copy theorem in `VerticalSectorCoordinates`;
- retained both existing private consumer declarations as thin wrappers;
- exposed the common bra/ket function equivalence from `SitewisePhysicalMatrix` and removed its downstream duplicate;
- preserved every existing public theorem header and the copy-block versus retained-product-sector split.

## Validation

- exact-head specialist review: approved at `9f9c0ed62f0e4207023e03d112e271ebb3cad913`;
- targeted MPDO modules and aggregator: passed, 9,475 jobs before rebase and 9,196 jobs in review after rebase;
- full `lake build`: passed, 10,074 jobs;
- generated import aggregators: current, 52 files covering 1,363 production modules;
- Blueprint declaration sync and `leanblueprint checkdecls`: passed;
- no new `sorry`, `admit`, `axiom`, or `unsafe`; worktree clean.

Closes #6146.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9f9c0ed62f0e4207023e03d112e271ebb3cad913. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->