### PR TITLE
refactor(MPS/MPDO): share Hayashi sector coordinate evaluation

### DIFF
--- a/TNLean/Analysis/HayashiMarkovStructure.lean
+++ b/TNLean/Analysis/HayashiMarkovStructure.lean
@@ -173,3 +173,100 @@ structure HayashiMarkovDecomposition {dA dB dC : ℕ}
           (HayashiMarkov.liftB (dA := dA) (dB := dB) (dC := dC)
             (U_B : Matrix (Fin dB) (Fin dB) ℂ))ᴴ)
       = HayashiMarkov.blockState (dA := dA) (dC := dC) dL dR p ρ_left ρ_right
+
+/-- Evaluate the Hayashi state identity at coordinates adapted to the middle-sector
+decomposition. The dependent conditional records the transport of the primed
+coordinates when the two sector labels agree.
+
+Source: Hayashi, *Quantum Information: An Introduction*, Springer 2006,
+Theorem 5.24. -/
+theorem HayashiMarkovDecomposition.h_state_apply_middle_sector
+    {dA dB dC : ℕ}
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    (hη : HayashiMarkovDecomposition ρ_ABC) (a a' : Fin dA) (c c' : Fin dC)
+    (k k' : Fin hη.m) (l : Fin (hη.dL k)) (r : Fin (hη.dR k))
+    (l' : Fin (hη.dL k')) (r' : Fin (hη.dR k')) :
+    (∑ b : Fin dB, ∑ b' : Fin dB,
+      (hη.U_B : Matrix (Fin dB) (Fin dB) ℂ) (hη.decompB.symm ⟨k, (l, r)⟩) b *
+        ρ_ABC (a, b, c) (a', b', c') *
+          star ((hη.U_B : Matrix (Fin dB) (Fin dB) ℂ)
+            (hη.decompB.symm ⟨k', (l', r')⟩) b')) =
+      if h : k = k' then
+        (hη.p k : ℂ) * hη.ρ_left k (a, l) (a', h ▸ l') *
+          hη.ρ_right k (r, c) (h ▸ r', c')
+      else 0 := by
+  classical
+  let b : Fin dB := hη.decompB.symm ⟨k, (l, r)⟩
+  let b' : Fin dB := hη.decompB.symm ⟨k', (l', r')⟩
+  have hs := congrFun (congrFun hη.h_state
+    (a, (⟨k, (l, r)⟩, c))) (a', (⟨k', (l', r')⟩, c'))
+  rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
+  have hleft : (HayashiMarkov.abcEquiv hη.decompB).symm
+      (a, (⟨k, (l, r)⟩, c)) = (a, b, c) := by
+    simp [HayashiMarkov.abcEquiv, b]
+  have hright : (HayashiMarkov.abcEquiv hη.decompB).symm
+      (a', (⟨k', (l', r')⟩, c')) = (a', b', c') := by
+    simp [HayashiMarkov.abcEquiv, b']
+  have hliftApply (x x' : Fin dA) (y y' : Fin dB) (z z' : Fin dC) :
+      HayashiMarkov.liftB (dA := dA) (dB := dB) (dC := dC)
+        (hη.U_B : Matrix (Fin dB) (Fin dB) ℂ)
+          (x, y, z) (x', y', z') =
+        (if x = x' then 1 else 0) * (hη.U_B : Matrix (Fin dB) (Fin dB) ℂ) y y' *
+          (if z = z' then 1 else 0) := by
+    unfold HayashiMarkov.liftB
+    simp only [Matrix.kroneckerMap_apply, Matrix.one_apply]
+    ring
+  have hliftMul (x : Fin dA) (y : Fin dB) (z : Fin dC)
+      (w : Fin dA × Fin dB × Fin dC) :
+      (HayashiMarkov.liftB (dA := dA) (dB := dB) (dC := dC)
+        (hη.U_B : Matrix (Fin dB) (Fin dB) ℂ) * ρ_ABC)
+          (x, y, z) w =
+        ∑ β : Fin dB, (hη.U_B : Matrix (Fin dB) (Fin dB) ℂ) y β *
+          ρ_ABC (x, β, z) w := by
+    rw [Matrix.mul_apply, Fintype.sum_prod_type]
+    rw [Finset.sum_eq_single x]
+    · rw [Fintype.sum_prod_type]
+      refine Finset.sum_congr rfl fun β _ ↦ ?_
+      rw [Finset.sum_eq_single z]
+      · rw [hliftApply, if_pos rfl, if_pos rfl, one_mul, mul_one]
+      · intro z'' _ hz''
+        rw [hliftApply, if_neg (Ne.symm hz''), mul_zero, zero_mul]
+      · intro h
+        exact absurd (Finset.mem_univ z) h
+    · intro x'' _ hx''
+      refine Finset.sum_eq_zero fun yz _ ↦ ?_
+      obtain ⟨β, γ⟩ := yz
+      rw [hliftApply, if_neg (Ne.symm hx''), zero_mul, zero_mul, zero_mul]
+    · intro h
+      exact absurd (Finset.mem_univ x) h
+  have hmulLiftConj (X : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) (w : Fin dA × Fin dB × Fin dC)
+      (x : Fin dA) (y : Fin dB) (z : Fin dC) :
+      (X * (HayashiMarkov.liftB (dA := dA) (dB := dB) (dC := dC)
+          (hη.U_B : Matrix (Fin dB) (Fin dB) ℂ))ᴴ) w (x, y, z) =
+        ∑ β : Fin dB, X w (x, β, z) *
+          star ((hη.U_B : Matrix (Fin dB) (Fin dB) ℂ) y β) := by
+    rw [Matrix.mul_apply, Fintype.sum_prod_type]
+    rw [Finset.sum_eq_single x]
+    · rw [Fintype.sum_prod_type]
+      refine Finset.sum_congr rfl fun β _ ↦ ?_
+      rw [Finset.sum_eq_single z]
+      · rw [Matrix.conjTranspose_apply, hliftApply, if_pos rfl, if_pos rfl,
+          one_mul, mul_one, Complex.star_def]
+      · intro z'' _ hz''
+        rw [Matrix.conjTranspose_apply, hliftApply, if_neg (Ne.symm hz''), mul_zero]
+        simp
+      · intro h
+        exact absurd (Finset.mem_univ z) h
+    · intro x'' _ hx''
+      refine Finset.sum_eq_zero fun yz _ ↦ ?_
+      obtain ⟨β, γ⟩ := yz
+      rw [Matrix.conjTranspose_apply, hliftApply, if_neg (Ne.symm hx''), zero_mul]
+      simp
+    · intro h
+      exact absurd (Finset.mem_univ x) h
+  rw [hleft, hright, hmulLiftConj, HayashiMarkov.blockState_apply] at hs
+  simp_rw [hliftMul, Finset.sum_mul] at hs
+  rw [Finset.sum_comm] at hs
+  simpa [b, b'] using hs

--- a/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
@@ -82,19 +82,8 @@ theorem outerInverseContraction_markov_block
           (hη.p k : ℂ) * hη.ρ_left k (i₁, l) (j₁, h ▸ l') *
             hη.ρ_right k (r, i₃) (h ▸ r', j₃)
         else 0 := by
-    have hs := congrFun (congrFun hη.h_state
-      (i₁, (⟨k, (l, r)⟩, i₃))) (j₁, (⟨k', (l', r')⟩, j₃))
-    rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
-    have hleft : (HayashiMarkov.abcEquiv hη.decompB).symm
-        (i₁, (⟨k, (l, r)⟩, i₃)) = (i₁, b, i₃) := by
-      simp [HayashiMarkov.abcEquiv, b]
-    have hright : (HayashiMarkov.abcEquiv hη.decompB).symm
-        (j₁, (⟨k', (l', r')⟩, j₃)) = (j₁, b', j₃) := by
-      simp [HayashiMarkov.abcEquiv, b']
-    rw [hleft, hright] at hs
-    rw [HayashiMarkov.liftB_conj_apply] at hs
-    rw [HayashiMarkov.blockState_apply] at hs
-    simpa [b, b', U] using hs
+    simpa [b, b', U] using
+      hη.h_state_apply_middle_sector i₁ j₁ i₃ j₃ k k' l r l' r'
   rw [Matrix.reindex_apply, Matrix.submatrix_apply]
   change (U * outerInverseContraction C ρ x y * Uᴴ) b b' = _
   have hExpand :

--- a/TNLean/MPS/MPDO/BNTMarkovSectorProjectors.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovSectorProjectors.lean
@@ -162,14 +162,6 @@ theorem exists_bntMarkovBlockNonzero_of_probability_ne_zero
     Matrix.exists_diagonal_ne_zero_of_trace_eq_one
       (hη.ρ_right k) (hη.hρ_right_dm k).2
   let b : Fin d := hη.decompB.symm ⟨k, (l, r)⟩
-  have hs := congrFun (congrFun hη.h_state
-    (i₁, (⟨k, (l, r)⟩, i₃))) (i₁, (⟨k, (l, r)⟩, i₃))
-  rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
-  have hindex : (HayashiMarkov.abcEquiv hη.decompB).symm
-      (i₁, (⟨k, (l, r)⟩, i₃)) = (i₁, b, i₃) := by
-    simp [HayashiMarkov.abcEquiv, b]
-  rw [hindex, HayashiMarkov.liftB_conj_apply,
-    HayashiMarkov.blockState_apply] at hs
   have hs' :
       (∑ i₂ : Fin d, ∑ j₂ : Fin d,
         (hη.U_B : Matrix (Fin d) (Fin d) ℂ) b i₂ *
@@ -177,7 +169,8 @@ theorem exists_bntMarkovBlockNonzero_of_probability_ne_zero
             star ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) b j₂)) =
         (hη.p k : ℂ) * hη.ρ_left k (i₁, l) (i₁, l) *
           hη.ρ_right k (r, i₃) (r, i₃) := by
-    simpa using hs
+    simpa [b] using
+      hη.h_state_apply_middle_sector i₁ i₁ i₃ i₃ k k l r l r
   have hsum_ne :
       (∑ s : Fin g, Matrix.trace
         (K s i₁ i₁ * conjugatePhysical (K s) hη.U_B b b *

--- a/TNLean/MPS/MPDO/HayashiSectorComparison.lean
+++ b/TNLean/MPS/MPDO/HayashiSectorComparison.lean
@@ -312,19 +312,8 @@ theorem inverseMap_hayashi_sector_comparison {d D : ℕ}
           (starRingEnd ℂ) (U b' j₂) =
         (hη.p k : ℂ) * hη.ρ_left k (i₁, l) (j₁, l') *
           hη.ρ_right k (r, i₃) (r', j₃) := by
-    have hs := congrFun (congrFun hη.h_state
-      (i₁, (⟨k, (l, r)⟩, i₃))) (j₁, (⟨k, (l', r')⟩, j₃))
-    rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
-    have hleft : (HayashiMarkov.abcEquiv hη.decompB).symm
-        (i₁, (⟨k, (l, r)⟩, i₃)) = (i₁, b, i₃) := by
-      simp [HayashiMarkov.abcEquiv, b]
-    have hright : (HayashiMarkov.abcEquiv hη.decompB).symm
-        (j₁, (⟨k, (l', r')⟩, j₃)) = (j₁, b', j₃) := by
-      simp [HayashiMarkov.abcEquiv, b']
-    rw [hleft, hright] at hs
-    rw [HayashiMarkov.liftB_conj_apply] at hs
-    rw [HayashiMarkov.blockState_apply] at hs
-    simpa [b, b', U] using hs
+    simpa [b, b', U] using
+      hη.h_state_apply_middle_sector i₁ j₁ i₃ j₃ k k l r l' r'
   rw [Matrix.reindex_apply, Matrix.submatrix_apply]
   change R β₃ α₁ * (U * physicalSlice K β₁ α₃ * Uᴴ) b b' = _
   rw [inverseMap_conj_physicalSlice_expansion K hK R ρ hρ α₁ β₁ α₃ β₃ U b b']

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorRecurrence.lean
@@ -154,14 +154,6 @@ theorem exists_active_sectorVirtualMatrix_ne_zero
         (hη.U_B : Matrix (Fin d) (Fin d) ℂ)ᴴ) b b) = _ at hslice
     change conjugatePhysical K hη.U_B b b gamma delta = 0
     exact hslice.trans hzero
-  have hs := congrFun (congrFun hη.h_state
-    (i₁, (⟨k, (l, r)⟩, i₃))) (i₁, (⟨k, (l, r)⟩, i₃))
-  rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
-  have hindex : (HayashiMarkov.abcEquiv hη.decompB).symm
-      (i₁, (⟨k, (l, r)⟩, i₃)) = (i₁, b, i₃) := by
-    simp [HayashiMarkov.abcEquiv, b]
-  rw [hindex, HayashiMarkov.liftB_conj_apply,
-    HayashiMarkov.blockState_apply] at hs
   have hs' :
       (∑ i₂ : Fin d, ∑ j₂ : Fin d,
         (hη.U_B : Matrix (Fin d) (Fin d) ℂ) b i₂ *
@@ -169,7 +161,8 @@ theorem exists_active_sectorVirtualMatrix_ne_zero
             star ((hη.U_B : Matrix (Fin d) (Fin d) ℂ) b j₂)) =
         (hη.p k : ℂ) * hη.ρ_left k (i₁, l) (i₁, l) *
           hη.ρ_right k (r, i₃) (r, i₃) := by
-    simpa using hs
+    simpa [b] using
+      hη.h_state_apply_middle_sector i₁ i₁ i₃ i₃ k k l r l r
   have hclosure := conjugated_middle_threeSiteClosure
     K R hρ hη.U_B i₁ i₁ i₃ i₃ b b
   rw [hclosure, hmid] at hs'

--- a/TNLean/MPS/MPDO/SectorFactorization.lean
+++ b/TNLean/MPS/MPDO/SectorFactorization.lean
@@ -116,19 +116,8 @@ theorem inverseMap_hayashi_sector_offdiagonal
       ∑ i₂ : Fin d, ∑ j₂ : Fin d,
         U b i₂ * ρ (i₁, i₂, i₃) (j₁, j₂, j₃) *
           (starRingEnd ℂ) (U b' j₂) = 0 := by
-    have hs := congrFun (congrFun hη.h_state
-      (i₁, (⟨k, (l, r)⟩, i₃))) (j₁, (⟨k', (l', r')⟩, j₃))
-    rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
-    have hleft : (HayashiMarkov.abcEquiv hη.decompB).symm
-        (i₁, (⟨k, (l, r)⟩, i₃)) = (i₁, b, i₃) := by
-      simp [HayashiMarkov.abcEquiv, b]
-    have hright : (HayashiMarkov.abcEquiv hη.decompB).symm
-        (j₁, (⟨k', (l', r')⟩, j₃)) = (j₁, b', j₃) := by
-      simp [HayashiMarkov.abcEquiv, b']
-    rw [hleft, hright] at hs
-    rw [HayashiMarkov.liftB_conj_apply] at hs
-    rw [HayashiMarkov.blockState_apply, dif_neg hkk'] at hs
-    simpa [U] using hs
+    simpa [b, b', U, hkk'] using
+      hη.h_state_apply_middle_sector i₁ j₁ i₃ j₃ k k' l r l' r'
   rw [Matrix.reindex_apply, Matrix.submatrix_apply]
   change R β₃ α₁ * (U * physicalSlice K β₁ α₃ * Uᴴ) b b' = 0
   rw [inverseMap_conj_physicalSlice_expansion K hK R ρ hρ α₁ β₁ α₃ β₃ U b b']

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -499,43 +499,6 @@ abbrev EtaStructure
       (Fin dA × Fin dB × Fin dC) ℂ) : Type :=
   Entropy.QuantumMarkovDecomposition ρ_ABC
 
-/-- Evaluate the Hayashi state identity at coordinates adapted to the middle-sector
-decomposition. The dependent conditional records the transport of the right
-coordinates when the two sector labels agree.
-
-Source: Hayashi, *Quantum Information: An Introduction*, Springer 2006,
-Theorem 5.24. -/
-theorem _root_.HayashiMarkovDecomposition.h_state_apply_middle_sector
-    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
-      (Fin dA × Fin dB × Fin dC) ℂ}
-    (hη : EtaStructure ρ_ABC) (a a' : Fin dA) (c c' : Fin dC)
-    (k k' : Fin hη.m) (l : Fin (hη.dL k)) (r : Fin (hη.dR k))
-    (l' : Fin (hη.dL k')) (r' : Fin (hη.dR k')) :
-    (∑ b : Fin dB, ∑ b' : Fin dB,
-      (hη.U_B : Matrix (Fin dB) (Fin dB) ℂ) (hη.decompB.symm ⟨k, (l, r)⟩) b *
-        ρ_ABC (a, b, c) (a', b', c') *
-          star ((hη.U_B : Matrix (Fin dB) (Fin dB) ℂ)
-            (hη.decompB.symm ⟨k', (l', r')⟩) b')) =
-      if h : k = k' then
-        (hη.p k : ℂ) * hη.ρ_left k (a, l) (a', h ▸ l') *
-          hη.ρ_right k (r, c) (h ▸ r', c')
-      else 0 := by
-  classical
-  let b : Fin dB := hη.decompB.symm ⟨k, (l, r)⟩
-  let b' : Fin dB := hη.decompB.symm ⟨k', (l', r')⟩
-  have hs := congrFun (congrFun hη.h_state
-    (a, (⟨k, (l, r)⟩, c))) (a', (⟨k', (l', r')⟩, c'))
-  rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
-  have hleft : (HayashiMarkov.abcEquiv hη.decompB).symm
-      (a, (⟨k, (l, r)⟩, c)) = (a, b, c) := by
-    simp [HayashiMarkov.abcEquiv, b]
-  have hright : (HayashiMarkov.abcEquiv hη.decompB).symm
-      (a', (⟨k', (l', r')⟩, c')) = (a', b', c') := by
-    simp [HayashiMarkov.abcEquiv, b']
-  rw [hleft, hright, HayashiMarkov.liftB_conj_apply,
-    HayashiMarkov.blockState_apply] at hs
-  simpa [b, b'] using hs
-
 /-- **Lemma C.2, local entropy form**: strong area law implies the local
 `η`-structure.
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -499,6 +499,43 @@ abbrev EtaStructure
       (Fin dA × Fin dB × Fin dC) ℂ) : Type :=
   Entropy.QuantumMarkovDecomposition ρ_ABC
 
+/-- Evaluate the Hayashi state identity at coordinates adapted to the middle-sector
+decomposition. The dependent conditional records the transport of the right
+coordinates when the two sector labels agree.
+
+Source: Hayashi, *Quantum Information: An Introduction*, Springer 2006,
+Theorem 5.24. -/
+theorem _root_.HayashiMarkovDecomposition.h_state_apply_middle_sector
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    (hη : EtaStructure ρ_ABC) (a a' : Fin dA) (c c' : Fin dC)
+    (k k' : Fin hη.m) (l : Fin (hη.dL k)) (r : Fin (hη.dR k))
+    (l' : Fin (hη.dL k')) (r' : Fin (hη.dR k')) :
+    (∑ b : Fin dB, ∑ b' : Fin dB,
+      (hη.U_B : Matrix (Fin dB) (Fin dB) ℂ) (hη.decompB.symm ⟨k, (l, r)⟩) b *
+        ρ_ABC (a, b, c) (a', b', c') *
+          star ((hη.U_B : Matrix (Fin dB) (Fin dB) ℂ)
+            (hη.decompB.symm ⟨k', (l', r')⟩) b')) =
+      if h : k = k' then
+        (hη.p k : ℂ) * hη.ρ_left k (a, l) (a', h ▸ l') *
+          hη.ρ_right k (r, c) (h ▸ r', c')
+      else 0 := by
+  classical
+  let b : Fin dB := hη.decompB.symm ⟨k, (l, r)⟩
+  let b' : Fin dB := hη.decompB.symm ⟨k', (l', r')⟩
+  have hs := congrFun (congrFun hη.h_state
+    (a, (⟨k, (l, r)⟩, c))) (a', (⟨k', (l', r')⟩, c'))
+  rw [Matrix.reindex_apply, Matrix.submatrix_apply] at hs
+  have hleft : (HayashiMarkov.abcEquiv hη.decompB).symm
+      (a, (⟨k, (l, r)⟩, c)) = (a, b, c) := by
+    simp [HayashiMarkov.abcEquiv, b]
+  have hright : (HayashiMarkov.abcEquiv hη.decompB).symm
+      (a', (⟨k', (l', r')⟩, c')) = (a', b', c') := by
+    simp [HayashiMarkov.abcEquiv, b']
+  rw [hleft, hright, HayashiMarkov.liftB_conj_apply,
+    HayashiMarkov.blockState_apply] at hs
+  simpa [b, b'] using hs
+
 /-- **Lemma C.2, local entropy form**: strong area law implies the local
 `η`-structure.
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -33,7 +33,7 @@ abstracted — record why, so it is not re-proposed).
   `BNTMarkovSectorProjectors.lean`, and `InverseMapActiveSectorRecurrence.lean`
   before promotion (2026-08-11).
 - **Abstraction:** `HayashiMarkovDecomposition.h_state_apply_middle_sector` in
-  `TNLean/MPS/MPDO/SimpleLocalStructure.lean`.
+  `TNLean/Analysis/HayashiMarkovStructure.lean`.
 - **Notes:** the theorem retains the dependent conditional for equal versus unequal
   sectors. Diagonal and off-diagonal consumers perform their respective
   specializations locally, while the mixed-sector consumer uses the full formula.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,20 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### Hayashi state evaluation in middle-sector coordinates — promoted
+- **Pattern:** evaluate `EtaStructure.h_state` at decomposed middle-site coordinates,
+  identify both inverse reindexings, expand the lifted unitary conjugation, and
+  simplify the dependent block-state conditional.
+- **Seen:** five occurrences in `HayashiSectorComparison.lean`,
+  `BNTMarkovKeyFormula.lean`, `SectorFactorization.lean`,
+  `BNTMarkovSectorProjectors.lean`, and `InverseMapActiveSectorRecurrence.lean`
+  before promotion (2026-08-11).
+- **Abstraction:** `HayashiMarkovDecomposition.h_state_apply_middle_sector` in
+  `TNLean/MPS/MPDO/SimpleLocalStructure.lean`.
+- **Notes:** the theorem retains the dependent conditional for equal versus unequal
+  sectors. Diagonal and off-diagonal consumers perform their respective
+  specializations locally, while the mixed-sector consumer uses the full formula.
+
 ### retained vertical-copy dependent-cast evaluation — promoted
 - **Pattern:** unfold the multiplicity-expanded assembled tensor at two coordinates
   in the same retained copy, identify the round-tripped dependent copy index, and


### PR DESCRIPTION
## What changed

- added `HayashiMarkovDecomposition.h_state_apply_middle_sector` in the common quantum-Markov decomposition owner;
- routed five repeated coordinate evaluations through the shared theorem;
- preserved the full dependent conditional and the separate diagonal and off-diagonal specializations;
- kept all existing declaration headers and Blueprint-tagged leaves unchanged;
- recorded the promoted proof pattern in the tactic ledger.

## Validation

- exact-head specialist review: approved at `035783f429d073ab7134d9494ee1fca5ef91b5cc`;
- owner and five consumers: passed, 3,449 jobs in review;
- MPDO aggregator: passed, 9,475 jobs;
- full `lake build`: passed, 10,074 jobs;
- generated import aggregators: current, 52 files covering 1,363 production modules;
- Blueprint declaration sync and `leanblueprint checkdecls`: passed with 7,274 of 7,274 theorem-like entries synchronized;
- no new forbidden declarations or unsafe casts; worktree clean.

Closes #6147.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 035783f429d073ab7134d9494ee1fca5ef91b5cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->