### PR TITLE
docs(blueprint): record trace-adjoint dependency kernels

### DIFF
--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -65,6 +65,7 @@ family $\{A^i\}$ under the trace.
 \begin{theorem}[The trace pairing map is injective for injective tensors]%
     \label{thm:trace_pairing_injective}
     \lean{MPSTensor.traceMulRightPi_ker_eq_bot}
+    \lean{MPSTensor.eq_zero_of_forall_trace_mul_right_eq_zero}
     \leanok
     \uses{def:trace_pairing_map, def:injective}
     If $A$ is injective, then $\ker \Phi_A = \{0\}$.

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -175,6 +175,26 @@
     $\{A^i\}$.
 \end{proof}
 
+\begin{lemma}[Trace adjointness of transfer maps]
+    \label{lem:trace_mul_transfer_map_adjoint}
+    \lean{trace_mul_transferMap_adjoint}
+    \lean{Kraus.trace_mul_transferMap_adjoint}
+    \leanok
+    \uses{def:transfer_map}
+    For matrices $\rho$ and $X$ and a finite family $(K_i)_i$,
+    \begin{align}
+        \tr\!\left(\rho\sum_i K_iXK_i^\dagger\right)
+        &=\tr\!\left(\left(\sum_iK_i^\dagger\rho K_i\right)X\right).
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Cyclicity of the trace gives
+    $\tr(\rho K_iXK_i^\dagger)=\tr(K_i^\dagger\rho K_iX)$ for every~$i$;
+    summing over~$i$ proves the identity.
+\end{proof}
+
 \begin{theorem}[Transfer map is a channel]\label{thm:transfer_channel}
     \lean{MPSTensor.transferMap_isChannel}
     \leanok

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -185,14 +185,14 @@
     \begin{align}
         \tr\!\left(\rho\sum_i K_iXK_i^\dagger\right)
         &=\tr\!\left(\left(\sum_iK_i^\dagger\rho K_i\right)X\right).
-        \notag
     \end{align}
 \end{lemma}
 
 \begin{proof}\leanok
-    Cyclicity of the trace gives
-    $\tr(\rho K_iXK_i^\dagger)=\tr(K_i^\dagger\rho K_iX)$ for every~$i$;
-    summing over~$i$ proves the identity.
+    \uses{lem:trace_mul_map_eq_trace_adjointMap_mul}
+    Apply Lemma~\ref{lem:trace_mul_map_eq_trace_adjointMap_mul} to the Kraus
+    map determined by $(K_i)_i$. Identifying this Kraus map and its adjoint
+    with the corresponding transfer maps gives the stated identity.
 \end{proof}
 
 \begin{theorem}[Transfer map is a channel]\label{thm:transfer_channel}

--- a/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
+++ b/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
@@ -34,15 +34,11 @@ matching between normal blocks.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:trace_mul_transfer_map_adjoint,
+    \uses{thm:pure_perron_tp_gauge,
         lem:perron_gauge_primitive_iff}
-    The irreducible Perron--Frobenius theorem gives positive definite right and
-    left eigenvectors with positive eigenvalues $r$ and $t$. The spectral
-    normalization gives $r=1$. Adjointness with respect to the trace pairing
-    gives $r\,\Tr(\sigma\rho)=t\,\Tr(\sigma\rho)$. Since $\sigma$ and $\rho$
-    are positive definite, their pairing is nonzero, hence $t=1$. Thus the
-    Perron gauge is a pure similarity. Irreducibility and primitivity are
-    invariant under this similarity.
+    Pure Perron normalization gives a trace-preserving gauge by a pure
+    similarity. Irreducibility and primitivity are invariant under this
+    similarity.
 \end{proof}
 
 \begin{theorem}[Spectral normality gives eventual block injectivity]

--- a/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
+++ b/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
@@ -29,12 +29,10 @@ matching between normal blocks.
     one.  There is a positive definite matrix $\sigma$ satisfying
     \begin{align}
         \sum_i(A^i)^\dagger\sigma A^i&=\sigma.
-        \notag
     \end{align}
     The tensor
     \begin{align}
         B^i&=\sigma^{1/2}A^i\sigma^{-1/2}
-        \notag
     \end{align}
     is left-canonical and irreducible, and $A$ and $B$ are related by a pure
     invertible similarity.

--- a/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
+++ b/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
@@ -34,7 +34,8 @@ matching between normal blocks.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:perron_gauge_primitive_iff}
+    \uses{lem:trace_mul_transfer_map_adjoint,
+        lem:perron_gauge_primitive_iff}
     The irreducible Perron--Frobenius theorem gives positive definite right and
     left eigenvectors with positive eigenvalues $r$ and $t$. The spectral
     normalization gives $r=1$. Adjointness with respect to the trace pairing

--- a/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
+++ b/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
@@ -21,6 +21,41 @@ matching between normal blocks.
     the definition of a normal tensor.
 \end{proof}
 
+\begin{theorem}[Pure Perron normalization at spectral radius one]
+    \label{thm:pure_perron_tp_gauge}
+    \lean{MPSTensor.exists_tpGauge_of_irreducible_spectralRadius_one}
+    \leanok
+    Let $A$ be irreducible and suppose that the spectral radius of $\E_A$ is
+    one.  There is a positive definite matrix $\sigma$ satisfying
+    \begin{align}
+        \sum_i(A^i)^\dagger\sigma A^i&=\sigma.
+        \notag
+    \end{align}
+    The tensor
+    \begin{align}
+        B^i&=\sigma^{1/2}A^i\sigma^{-1/2}
+        \notag
+    \end{align}
+    is left-canonical and irreducible, and $A$ and $B$ are related by a pure
+    invertible similarity.
+\end{theorem}
+\begin{proof}
+    \uses{lem:trace_mul_transfer_map_adjoint,
+        lem:irreducible_transfer_perron_pair,
+        lem:spectral_radius_one_matrix_dim_pos,
+        thm:posDef_adjoint_eigenvector,
+        thm:spectral_radius_real_pf_irred,
+        thm:tp_gauge_from_adjoint_fixed,
+        lem:tp_gauge_equiv,
+        lem:similarity_irred_iff}
+    \leanok
+    Positive-definite right and left Perron eigenvectors have the same positive
+    eigenvalue by the trace pairing.  The spectral-radius identity makes this
+    eigenvalue equal to one.  Thus the left Perron eigenvector is an adjoint
+    fixed point, so its square-root gauge is trace-preserving.  Similarity
+    preserves irreducibility.
+\end{proof}
+
 \begin{theorem}[Spectral normality gives a pure trace-preserving gauge]
     \label{thm:cpsv_normal_tp_gauge}
     \lean{MPSTensor.IsNormalTensor.exists_tpGauge}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
@@ -645,7 +645,6 @@
       selectedFixedProduct_cyclicActive_reflTransGen_neighboringOperator_ne_zero}
     \leanok
     \uses{def:injective, def:mpdo_eta_local_structure_data,
-      thm:trace_pairing_injective,
       thm:mpdo_eta_fixed_bond_product_tensor,
       thm:mpdo_fixed_bond_positive_physical_sector_representative,
       def:mpdo_physical_sector_factorization,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
@@ -645,6 +645,7 @@
       selectedFixedProduct_cyclicActive_reflTransGen_neighboringOperator_ne_zero}
     \leanok
     \uses{def:injective, def:mpdo_eta_local_structure_data,
+      thm:trace_pairing_injective,
       thm:mpdo_eta_fixed_bond_product_tensor,
       thm:mpdo_fixed_bond_positive_physical_sector_representative,
       def:mpdo_physical_sector_factorization,
@@ -657,6 +658,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:trace_pairing_injective}
     At lengths two and three, express the closed operators of $K$ in the
     physical coordinates of $F$. They are nonzero scalar multiples of the
     corresponding closed operators of $C$. The length-two identity and

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -46,41 +46,6 @@
     every eigenvalue and hence the unit-circle eigenvalue set.
 \end{proof}
 
-\begin{theorem}[Pure Perron normalization at spectral radius one]
-    \label{thm:pure_perron_tp_gauge}
-    \lean{MPSTensor.exists_tpGauge_of_irreducible_spectralRadius_one}
-    \leanok
-    Let $A$ be irreducible and suppose that the spectral radius of $\E_A$ is
-    one.  There is a positive definite matrix $\sigma$ satisfying
-    \begin{align}
-        \sum_i(A^i)^\dagger\sigma A^i&=\sigma.
-        \notag
-    \end{align}
-    The tensor
-    \begin{align}
-        B^i&=\sigma^{1/2}A^i\sigma^{-1/2}
-        \notag
-    \end{align}
-    is left-canonical and irreducible, and $A$ and $B$ are related by a pure
-    invertible similarity.
-\end{theorem}
-\begin{proof}
-    \uses{lem:trace_mul_transfer_map_adjoint,
-        lem:irreducible_transfer_perron_pair,
-        lem:spectral_radius_one_matrix_dim_pos,
-        thm:posDef_adjoint_eigenvector,
-        thm:spectral_radius_real_pf_irred,
-        thm:tp_gauge_from_adjoint_fixed,
-        lem:tp_gauge_equiv,
-        lem:similarity_irred_iff}
-    \leanok
-    Positive-definite right and left Perron eigenvectors have the same positive
-    eigenvalue by the trace pairing.  The spectral-radius identity makes this
-    eigenvalue equal to one.  Thus the left Perron eigenvector is an adjoint
-    fixed point, so its square-root gauge is trace-preserving.  Similarity
-    preserves irreducibility.
-\end{proof}
-
 \begin{definition}[Left-canonical periodic tensor]
     \label{def:periodic_tensor}
     \lean{MPSTensor.IsPeriodic}

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -65,7 +65,8 @@
     invertible similarity.
 \end{theorem}
 \begin{proof}
-    \uses{lem:irreducible_transfer_perron_pair,
+    \uses{lem:trace_mul_transfer_map_adjoint,
+        lem:irreducible_transfer_perron_pair,
         lem:spectral_radius_one_matrix_dim_pos,
         thm:posDef_adjoint_eigenvector,
         thm:spectral_radius_real_pf_irred,

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -62,7 +62,7 @@ separate public-surface occurrence and therefore appears separately.
 | Source | Preserve | Codemod | Redraw |
 |---|---|---|---|
 | `ch02_mps.tex` | L25, 56, 176, 208, 281, 865, 995 `tenkz` → `P-grid` | — | — |
-| `ch03_single.tex` | L251 `tenkz` → `P-grid` | — | — |
+| `ch03_single.tex` | L252 `tenkz` → `P-grid` | — | — |
 | `ch04_channels_choi_foundations.tex` | L87 `tenkz` → `P-grid` | — | — |
 | `ch11_fundamental_theorem_core.tex` | L42, 46 `tenkz` → `P-grid` | — | — |
 | `ch12_symmetry_string_order.tex` | L41, 80, 362, 367, 398, 404, 449, 455, 488, 493, 531, 537, 842, 847 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- linked the selected fixed-product cyclic recurrence to the shared injective trace-pairing kernel;
- tagged `MPSTensor.eq_zero_of_forall_trace_mul_right_eq_zero` in that kernel node;
- added a formula-driven transfer-map trace-adjoint lemma tagged with the core theorem and its Kraus wrapper;
- added the adjoint dependency to the normal-tensor and pure Perron TP-gauge proofs;
- moved the pure Perron node to its canonical Chapter 10 owner and updated the tracked tenkz line inventory after the Chapter 3 tag addition.

## Validation

- exact-head Blueprint review: approved at `e8c6d1aebef0fe9141fd2db8da7271c26f76a1f4`;
- `blueprint_lean_sync.py --ci`: passed;
- `lake exe checkdecls` and `leanblueprint checkdecls`: passed;
- double `lualatex` with repository `TEXINPUTS`: passed, 979 pages, zero undefined cross-references;
- standalone citation warnings remain because `print.bbl` is absent, matching the repository baseline;
- full `lake build`: passed, 10,075 jobs;
- generated import aggregators: current, 52 files covering 1,364 production modules;
- tenkz disposition and demolition guards: passed;
- worktree clean with generated artifacts removed.

Closes #6148.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0782905b45f02070d838478b094781f0add04506. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
