### PR TITLE
refactor(Channel): use canonical support compression imports

### DIFF
--- a/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
+++ b/TNLean/Channel/FixedPoint/CornerFixedPoints.lean
@@ -8,7 +8,7 @@ import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.StationaryProjection
 import TNLean.Channel.FixedPoint.SupportInvariance
 import TNLean.Channel.KrausCornerCompression
-import TNLean.Channel.Spectral.Support
+import TNLean.Analysis.SupportCompression
 
 /-!
 # Corner-restricted fixed points for finite Kraus maps

--- a/TNLean/Channel/FixedPoint/StationarySupportRestriction.lean
+++ b/TNLean/Channel/FixedPoint/StationarySupportRestriction.lean
@@ -7,7 +7,7 @@ import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.OrthogonalProjection
 import TNLean.Channel.FixedPoint.MaximalSupportBasic
 import TNLean.Channel.FixedPoint.StationaryProjection
-import TNLean.Channel.Spectral.Support
+import TNLean.Analysis.SupportCompression
 
 /-!
 # Restriction to the support of a stationary positive matrix

--- a/TNLean/Channel/KoashiImoto/JointSupport.lean
+++ b/TNLean/Channel/KoashiImoto/JointSupport.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.FixedPoint.SupportInvariance
 import TNLean.Channel.KoashiImoto.PreservingBlockAction
-import TNLean.Channel.Spectral.Support
+import TNLean.Analysis.SupportCompression
 
 /-!
 # Joint-support compression for invariant state families

--- a/TNLean/Channel/WeightedHilbertSchmidt.lean
+++ b/TNLean/Channel/WeightedHilbertSchmidt.lean
@@ -11,7 +11,7 @@ import TNLean.Analysis.CoisometricCompression
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Channel.Peripheral.UnitalKraus
 import TNLean.Channel.SingleKraus
-import TNLean.Channel.Spectral.Support
+import TNLean.Analysis.SupportCompression
 
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.Rayleigh


### PR DESCRIPTION
## What changed

- retargeted four internal Channel modules from the compatibility import `TNLean.Channel.Spectral.Support` to canonical owner `TNLean.Analysis.SupportCompression`;
- retained the compatibility module and all generated aggregators unchanged;
- changed no declarations or proofs.

## Validation

- exact-head post-rebase specialist review: approved at `e38e9d7fa8d9258878ee6728b6ee0ec4923622df`;
- all four consumers and the Channel aggregator: passed;
- full `lake build`: passed, 10,074 jobs;
- generated import aggregators: current, 52 files covering 1,363 production modules;
- Blueprint declaration sync and `leanblueprint checkdecls`: passed;
- diff is exactly four import substitutions; worktree clean.

Closes #6149.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e38e9d7fa8d9258878ee6728b6ee0ec4923622df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->