### PR TITLE
fix(tenkz): report manifest and name failures in check

### DIFF
--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -263,6 +263,33 @@ def test_the_whole_check_reports_a_missing_file_rather_than_raising() -> None:
     assert "SKIP clean-install" in finished.stdout, finished.stdout
 
 
+def test_the_whole_check_reports_an_unwritable_name_rather_than_raising() -> None:
+    """The command itself, not one check in isolation: a manifest staging a
+    name an unpacking tool would misread must print its report and exit 1,
+    keeping the other checks' lines rather than replacing them."""
+
+    original = (ROOT / "docs/tenkz/ctan/MANIFEST.toml").read_text(encoding="utf-8")
+    broken = original.replace(
+        '"LICENSE" = "LICENSE"',
+        '"LICENSE" = "LICENSE"\n"license" = "LICENSE"',
+    )
+    assert broken != original
+    with tempfile.TemporaryDirectory() as directory:
+        manifest = Path(directory) / "MANIFEST.toml"
+        manifest.write_text(broken, encoding="utf-8")
+        finished = subprocess.run(
+            [sys.executable, str(SCRIPT), "check"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "TENKZ_CTAN_MANIFEST": str(manifest)},
+        )
+    assert finished.returncode == 1, finished.stdout + finished.stderr
+    assert "Traceback" not in finished.stderr, finished.stderr
+    assert "FAIL names" in finished.stdout, finished.stdout
+    assert "differ only in case" in finished.stdout, finished.stdout
+    assert "SKIP clean-install" in finished.stdout, finished.stdout
+
+
 def test_the_archive_is_a_function_of_the_files_it_carries() -> None:
     with tempfile.TemporaryDirectory() as directory:
         room = Path(directory)


### PR DESCRIPTION
## Summary

Review follow-ups from LionSR/TNLean#5880 on `scripts/tenkz_ctan.py`: a manifest missing one of its three top-level tables must be refused with a message naming the table (#5945), and a staged name an unpacking tool would misread must appear as a `FAIL names` line in the `check` report rather than aborting the command and discarding the other reports (#5944).

Both behaviors are on main since c0fcd8ccd:

- `read_manifest()` validates that `[material]`, `[runtime]`, and `[source_tree]` are each present and a table, refusing with a message naming the missing one, before any consumer indexes into them. `test_a_manifest_without_its_tables_is_named_rather_than_raised` runs `check` against the manifest with each table removed and asserts the refusal.
- `staged_content` no longer runs the name check and raises; `command_check` computes `check_names` on the built mapping and prints its report, skipping the built-tree checks when the staged material is blocked. The write path keeps its refuse-before-write behavior through the separate `require_writable_names`, so `stage` and `archive` still stop on the same findings.

What was still missing is the end-to-end pin for the second contract: no test ran the whole `check` command against a names-violating manifest. This PR adds `test_the_whole_check_reports_an_unwritable_name_rather_than_raising`, mirroring `test_the_whole_check_reports_a_missing_file_rather_than_raising`: a case-colliding material entry goes through `check` as a subprocess, and the test asserts the `FAIL names` line, the `differ only in case` finding, the skipped built-tree checks, and exit status 1 with no traceback.

Closes LionSR/tenkz#187.
Closes LionSR/tenkz#186.

## Testing

- `scripts/test_tenkz_ctan.py`: 30 passed.
- All `scripts/test_tenkz_*.py` except `test_tenkz_equation_web.py`: 79 passed. `test_tenkz_equation_web.py` fails collection in this environment for lack of the `playwright` module, on main as well; it is unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f054dbcd468b6ca8836ab48e8c49a8f54885dde2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->