### PR TITLE
doc(tenkz): align tnmultiples captions on a shared baseline

### DIFF
--- a/docs/tenkz/tenkzmanual2.sty
+++ b/docs/tenkz/tenkzmanual2.sty
@@ -190,6 +190,8 @@
 \box_new:N \l_mtwo_panel_box
 \box_new:N \l_mtwo_panellab_box
 \dim_new:N \l_mtwo_panel_dim
+\dim_new:N \l_mtwo_paneldepth_dim
+\int_new:N \l_mtwo_panel_int
 \tl_new:N  \l_mtwo_sigbreak_tl
 \tl_new:N  \l_mtwo_formula_tl
 \tl_new:N  \l_mtwo_caption_tl
@@ -368,14 +370,13 @@
     \par \addvspace{\mtwo@unitsep}
   }
 
-% One small-multiples panel: define the `variant' key at picture and atom
-% scope in the kernel's own key families, render the shared body, set the
-% variant keys beneath it.  The panel's reference point is the render's
-% own baseline (the wire axis), so the wires of all panels in a row are
-% collinear.
-\cs_new_protected:Npn \mtwo_variant_panel:nn #1 #2
+% Measure one small-multiples panel: define the `variant' key at picture
+% and atom scope in the kernel's own key families, compile the shared
+% body under this panel's variant keys into a stored box, and fold the
+% content depth into the call-wide maximum.  Each panel compiles here
+% exactly once; the emitting pass reuses the stored box.
+\cs_new_protected:Npn \mtwo_variant_measure:nn #1 #2
   {
-    \mode_leave_vertical:
     \keys_define:nn { tenkz-kernel-picture }
       {
         variant .code:n    = { \keys_set:nn { tenkz-kernel-picture } {#2} },
@@ -386,7 +387,31 @@
         variant .code:n    = { \keys_set:nn { tenkz-kernel-atom } {#2} },
         variant .default:n = { },
       }
-    \hbox_set:Nn \l_mtwo_panel_box { \input{\jobname.exm} \unskip }
+    \int_incr:N \l_mtwo_panel_int
+    \box_if_exist:cF { l_mtwo_panel_ \int_use:N \l_mtwo_panel_int _box }
+      { \box_new:c { l_mtwo_panel_ \int_use:N \l_mtwo_panel_int _box } }
+    \hbox_set:cn { l_mtwo_panel_ \int_use:N \l_mtwo_panel_int _box }
+      { \input{\jobname.exm} \unskip }
+    \dim_set:Nn \l_mtwo_paneldepth_dim
+      {
+        \dim_max:nn { \l_mtwo_paneldepth_dim }
+          { \box_dp:c { l_mtwo_panel_ \int_use:N \l_mtwo_panel_int _box } }
+      }
+  }
+
+% Emit one small-multiples panel from its stored box.  The panel's
+% reference point is the render's own baseline (the wire axis), so the
+% wires of all panels in a row are collinear.  The content box's depth
+% is normalised to the deepest panel of the call, so every variant label
+% hangs from one shared baseline no matter how deep its own panel's ink
+% reaches.
+\cs_new_protected:Npn \mtwo_variant_panel:nn #1 #2
+  {
+    \mode_leave_vertical:
+    \int_incr:N \l_mtwo_panel_int
+    \box_set_eq:Nc \l_mtwo_panel_box
+      { l_mtwo_panel_ \int_use:N \l_mtwo_panel_int _box }
+    \box_set_dp:Nn \l_mtwo_panel_box { \l_mtwo_paneldepth_dim }
     \hbox_set:Nn \l_mtwo_panellab_box { \scriptsize \ttfamily #1 }
     \dim_set:Nn \l_mtwo_panel_dim
       {
@@ -411,6 +436,14 @@
     \clist_set:NV \l_mtwo_variants_clist \l_mtwo_variants_tl
     \mtwo_unit_output:n
       {
+        % first pass: compile every panel and record the deepest content
+        % box, the shared reference below which each caption is set
+        \dim_zero:N \l_mtwo_paneldepth_dim
+        \int_zero:N \l_mtwo_panel_int
+        \clist_map_inline:Nn \l_mtwo_variants_clist
+          { \mtwo_variant_measure:nn ##1 }
+        % second pass: emit the stored panels
+        \int_zero:N \l_mtwo_panel_int
         \bool_set_true:N \l_mtwo_first_bool
         \clist_map_inline:Nn \l_mtwo_variants_clist
           {


### PR DESCRIPTION
## Summary

In a `tnmultiples` row every panel is a `\vtop` whose reference point is the render's own baseline, so the wires of all panels are collinear; but each variant label then sat at its own panel's content depth, so deeper panels (Example 3.7's legs-down pair) pushed their captions a line and a half below the shallow pair's.

The fix splits panel packing into two passes inside one call. A measuring pass compiles every panel into a stored box and records the deepest content box of the call; the emitting pass reuses the stored boxes with each content box's depth normalised to that maximum, so every variant label hangs from one shared baseline. Each panel still compiles exactly once, the wire-axis alignment is untouched, and the per-call maximum is the right reference because a call's panels are variants of one picture. The caption-band clearance below the label (`\mtwo@panelrowsep`, v2.3) is unchanged.

## Verification

- `python3 scripts/tenkz_manual_doctest.py`: PASS (28 displayed manual examples and 12 reference examples).
- `manual2.tex` builds clean with xelatex (two passes, 25 pages, unchanged page count).
- Both `tnmultiples` uses in `chapters2/` (the only two) rendered from `docs/tenkz/manual2.pdf` with `pdftoppm -r 400` and inspected:
  - page 9, Example 3.7 (`physical=none|up|down|updown`): before, the two legs-down captions sat visibly lower; after, all four captions share one baseline and the wires remain collinear.
  - page 6, Example 3.3 (`boundary=none|open|periodic`): the pre-existing wrap is unchanged, the first row's two captions share one baseline, and the wrapped periodic panel starts on a clear row with no overlap and no clipped ink.

Closes LionSR/tenkz#190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation typography fix in the manual style package only; no runtime, auth, or data-handling impact.
> 
> **Overview**
> Fixes uneven caption placement in `tnmultiples` rows: deeper panels no longer push their variant labels below shallower ones.
> 
> Panel packing is now a **two-pass** process. A measuring pass compiles each variant once into a stored box and records the call-wide maximum depth; the emitting pass reuses those boxes with depths normalized to that maximum so every caption hangs from one shared baseline. Wire-axis alignment and per-panel compile-once behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4388d1cb58082af2ff8562bd08365b06a26a97bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->