### PR TITLE
ci(tenkz): gate the benchmark book and keep failure renders

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -255,6 +255,10 @@ jobs:
               - 'docs/tenkz/**/*.tex'
               - 'docs/tenkz/manual2.tex'
               - 'docs/tenkz/tenkzmanual2.sty'
+              # The RMP benchmark book's own style file: a runtime input of
+              # `tenkz_rmp.py book --all` (the book driver rmp-benchmark.tex
+              # already matches 'docs/tenkz/**/*.tex' above).
+              - 'docs/tenkz/tenkzrmpbenchmark.sty'
               - 'scripts/tenkz_manual_doctest.py'
               - 'scripts/test_tenkz_manual_doctest.py'
               - 'scripts/tenkz_audit.py'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -390,19 +390,23 @@ jobs:
       - name: Check string-engine event and pixel probes
         run: scripts/tenkz_string_probes.sh
 
-  # Compiles and audits the 130-target RMP benchmark: tenkz's own reproduction
-  # of the diagrams in the tensor-network review paper it is modeled on. This
-  # is the book the library was actually built against, and it is where every
-  # visual defect in the campaign was found — including one regression that
-  # every other job in this file missed (issue #5824). "check" compiles each
-  # target standalone and audits its render event log; a measured full run
-  # took about four to five minutes on a ten-core development machine at full
-  # harness parallelism, so it runs on every pull request that can move RMP
-  # ink, gated by the same `corpus` path filter already used above. The
-  # slower step -- typesetting the full illustrated book and rendering every
-  # page to an image -- runs weekly and on demand instead, in
-  # tenkz-rmp-book.yml, because that step is about producing the reviewable
-  # book, not about catching a regression quickly.
+  # Compiles, audits, and typesets the 130-target RMP benchmark: tenkz's own
+  # reproduction of the diagrams in the tensor-network review paper it is
+  # modeled on. This is the book the library was actually built against, and
+  # it is where every visual defect in the campaign was found — including one
+  # regression that every other job in this file missed (issue #5824).
+  # "book" does everything "check" does (each target compiled standalone,
+  # its render event log audited) and then typesets the full book, so a break
+  # in the book's own preamble or page layout also fails here instead of
+  # waiting up to a week for tenkz-rmp-book.yml (issue #5828). The typeset
+  # adds under a minute on a ten-core development machine; the 130 target
+  # compiles that dominate either command measured six to eight minutes on
+  # GitHub's runner. Every target always runs — there is no changed-target
+  # subset, because a reachability heuristic that silently missed a target
+  # would be worse than a full corpus that costs single-digit minutes. The
+  # genuinely slower step, rasterizing every page to an image, runs weekly
+  # and on demand instead, in tenkz-rmp-book.yml, because that step is about
+  # producing the reviewable book, not about catching a regression quickly.
   tenkz-rmp:
     name: Check tenkz RMP benchmark corpus
     needs: changes
@@ -426,8 +430,36 @@ jobs:
       # the harness. GitHub's hosted runner has four shared cores, and four
       # parallel compiles left no slack: one run timed out a target under
       # ordinary load. Two parallel compiles leave that headroom back.
-      - name: Compile and audit the tenkz RMP benchmark
-        run: TENKZ_RMP_JOBS=2 python3 scripts/tenkz_rmp.py check --all
+      # The work tree is kept outside the checkout (the harness puts the
+      # whole repository on TEXINPUTS recursively) and preserved past the
+      # run, so a failing target's transcript, event log, and render can be
+      # uploaded below.
+      - name: Compile, audit, and typeset the tenkz RMP benchmark
+        env:
+          TENKZ_RMP_JOBS: "2"
+          TENKZ_RMP_WORK_ROOT: ${{ runner.temp }}/rmp-work
+        run: python3 scripts/tenkz_rmp.py book --all
+
+      # On a red run the job log carries only the tail of the failing
+      # compile; the offending render and its event log never reach the
+      # console at all. Upload the preserved work tree so the failure is
+      # diagnosable from the Actions page. Green runs upload nothing, so
+      # the common path stores no artifacts.
+      - name: Upload failure transcripts, event logs, and renders
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tenkz-rmp-failure
+          path: |
+            ${{ runner.temp }}/rmp-work/targets/**/*.txt
+            ${{ runner.temp }}/rmp-work/targets/**/*.log
+            ${{ runner.temp }}/rmp-work/targets/**/*.tnlog
+            ${{ runner.temp }}/rmp-work/targets/**/*.pdf
+            ${{ runner.temp }}/rmp-work/*.txt
+            ${{ runner.temp }}/rmp-work/*.log
+            ${{ runner.temp }}/rmp-work/*.pdf
+          retention-days: 7
+          if-no-files-found: warn
 
   build:
     needs: changes

--- a/.github/workflows/tenkz-rmp-book.yml
+++ b/.github/workflows/tenkz-rmp-book.yml
@@ -3,16 +3,15 @@ name: Tenkz RMP benchmark book
 # The 130-target RMP benchmark is tenkz's own picture book: every case
 # reproduces a diagram from the tensor-network review paper the library is
 # modeled on, and every visual defect found during the campaign was found by
-# reading this book. `pr-ci.yml` compiles and audits all 130 targets on every
-# pull request that can move RMP ink (the `tenkz-rmp` job, gated by the
-# `corpus` path filter). What that job does not do is typeset the book itself
-# or render its pages to images, because that additional step costs about as
-# much time again as the per-target compile, and it exists to produce a book
-# a person reads, not to catch a regression fast. This workflow does that
-# slower step -- once a week, and any time someone asks for it by hand --
-# typesetting the book and rendering every page to an image, so the picture
-# pipeline that ships in the blueprint gets exercised too, and it uploads
-# the compiled PDF so a reviewer can open it without a local checkout.
+# reading this book. `pr-ci.yml` compiles and audits all 130 targets and
+# typesets the book itself on every pull request that can move RMP ink (the
+# `tenkz-rmp` job, gated by the `corpus` path filter). What that job does
+# not do is render the book's pages to images, a step that exists to produce
+# a book a person reads, not to catch a regression fast. This workflow does
+# that slower step -- once a week, and any time someone asks for it by hand
+# -- rendering every page to an image, so the picture pipeline that ships in
+# the blueprint gets exercised too, and it uploads the compiled PDF so a
+# reviewer can open it without a local checkout.
 
 on:
   schedule:

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -44,6 +44,11 @@ python3 scripts/tenkz_rmp.py compare --all \
   --source-root References/RMP_TIKZ_SOURCE_CODE
 ```
 
+Every command works inside a scratch tree that is removed on exit.  Set
+`TENKZ_RMP_WORK_ROOT` to a new or empty directory to keep the tree instead,
+with each target's compile transcript, event log, and PDF; continuous
+integration does this so a failing run's evidence survives for upload.
+
 Every command first runs the corpus-wide physical-dimension ownership check,
 even when `check --id` selects one target.  Case dimensions are classified as
 metric, projection/frame, route/string, or composition/layout and ratcheted in

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import contextlib
 import dataclasses
 import hashlib
 import os
@@ -22,7 +23,7 @@ import tempfile
 import tomllib
 from collections import Counter
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Iterator, Sequence
 
 from tenkzlib.dimension_inventory import (
     DimensionInventoryError,
@@ -1833,6 +1834,32 @@ def compile_comparison(
     return pdf
 
 
+@contextlib.contextmanager
+def working_directory() -> Iterator[Path]:
+    """Yield the scratch tree every compile writes into.
+
+    By default this is a temporary directory removed on exit.  When
+    TENKZ_RMP_WORK_ROOT names a directory, the tree is created there and
+    preserved instead, so a failing run's compile transcripts, event logs,
+    and PDFs survive the process for post-mortem reading; continuous
+    integration points this at a directory outside the checkout (which is
+    on TEXINPUTS recursively) and uploads it as a failure artifact.  The
+    directory must be new or empty: per-target
+    directories are created without overwriting, and artifacts left by a
+    previous run would mix into the audit.
+    """
+    raw = os.environ.get("TENKZ_RMP_WORK_ROOT")
+    if raw is None:
+        with tempfile.TemporaryDirectory(prefix="tenkz-rmp-") as temporary:
+            yield Path(temporary)
+        return
+    work = Path(raw).resolve()
+    if work.exists() and any(work.iterdir()):
+        fail(f"TENKZ_RMP_WORK_ROOT must name a new or empty directory: {work}")
+    work.mkdir(parents=True, exist_ok=True)
+    yield work
+
+
 def positive_jobs() -> int:
     raw = os.environ.get("TENKZ_RMP_JOBS", "4")
     if re.fullmatch(r"[1-9][0-9]*", raw) is None:
@@ -1882,8 +1909,7 @@ def main() -> int:
         validate_verdict_consistency(targets, verdicts)
         if args.command == "compare":
             source_root = args.source_root.resolve()
-        with tempfile.TemporaryDirectory(prefix="tenkz-rmp-") as temporary:
-            work = Path(temporary)
+        with working_directory() as work:
             if args.command == "compare":
                 source_snapshot = work / "author-source"
                 verified = verify_author_source_tree(

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -1854,8 +1854,11 @@ def working_directory() -> Iterator[Path]:
             yield Path(temporary)
         return
     work = Path(raw).resolve()
-    if work.exists() and any(work.iterdir()):
-        fail(f"TENKZ_RMP_WORK_ROOT must name a new or empty directory: {work}")
+    if work.exists():
+        if not work.is_dir():
+            fail(f"TENKZ_RMP_WORK_ROOT must name a directory, not a file: {work}")
+        if any(work.iterdir()):
+            fail(f"TENKZ_RMP_WORK_ROOT must name a new or empty directory: {work}")
     work.mkdir(parents=True, exist_ok=True)
     yield work
 


### PR DESCRIPTION
## Summary

Issue LionSR/tenkz#185 asked for the RMP rendering benchmark in CI. Most of it landed in LionSR/TNLean#5831 and in the older corpus gates; this PR closes only what remains.

Already covered before this PR:

- Rendering regressions (crossing-police refusals, audit failures) fail pull-request CI: the `tenkz-rmp` job added by LionSR/TNLean#5831 runs `tenkz_rmp.py check --all`, the full 130-target benchmark, gated by the `corpus` path filter over `tex/tenkz/**`, `tests/tenkz/**`, `docs/tenkz/**`, and the tenkz scripts. LionSR/TNLean#5831 reproduced the LionSR/TNLean#5816 regression under it.
- Moved golden hashes fail pull-request CI: the `tenkz-corpus` job runs `tenkz_golden.sh --check` and `scripts/tenkz_kernel_probes.sh` under the same filter.

What this PR adds:

- **The benchmark book compilation is now a pull-request gate.** The `tenkz-rmp` job runs `tenkz_rmp.py book --all` instead of `check --all`. `book` does everything `check` does (lint, 130 standalone compiles, per-target event audits) and then typesets the full book with its overfull-box and PDF-existence checks, so a break in `docs/tenkz/rmp-benchmark.tex` or `tenkzrmpbenchmark.sty` fails before merge instead of waiting up to a week for the scheduled `tenkz-rmp-book.yml` run. That workflow keeps its remaining unique work: page rasterization and the reviewable PDF artifact.
- **Failure artifacts.** `tenkz_rmp.py` previously worked in a temporary directory removed on exit, so a red run left only the last 120 console lines of the failing compile; the offending render and its `.tnlog` event log were unrecoverable. A new opt-in `TENKZ_RMP_WORK_ROOT` environment knob keeps the work tree (default behavior unchanged), the CI job points it at `$RUNNER_TEMP/rmp-work` (outside the checkout, which sits on `TEXINPUTS` recursively), and a `failure()`-only step uploads the transcripts, logs, event logs, renders, and book passes with 7-day retention. Green runs upload nothing.

No target subsetting: every one of the 130 targets runs on every triggered job, as before. A changed-target reachability heuristic was considered and rejected in LionSR/TNLean#5831 because most eligible changes touch kernel files that every target depends on. No cache is added; the TeX install continues to use `texra-ai/lean-env-action/blueprint-system-deps`, so the Lean build caches are untouched.

## Measured cost

- `TENKZ_RMP_JOBS=8 TENKZ_RMP_WORK_ROOT=<dir> python3 scripts/tenkz_rmp.py book --all` on this branch: **5m52s** wall clock on a 10-core development machine, measured while a concurrent full `check --all` from another working copy competed for the same cores. LionSR/TNLean#5831 measured 4m31s for `book --all` and 3m57s for `check --all` uncontended at the same parallelism, so the book typeset itself (three serial XeLaTeX passes, unaffected by the jobs setting) adds well under a minute over what the job already paid.
- The per-PR job measured 6m23s to 8m4s at `TENKZ_RMP_JOBS=2` for `check --all` across five CI runs (#5831); the existing 30-minute timeout leaves ample headroom for the book passes.
- The full preserved work tree is about 13 MB (130 target PDFs, transcripts, logs, event logs, book passes, book PDF); it is uploaded only on failure, at 7-day retention.

## Test plan

- [x] `actionlint .github/workflows/pr-ci.yml .github/workflows/tenkz-rmp-book.yml` clean; YAML parses
- [x] `TENKZ_RMP_WORK_ROOT=<dir> python3 scripts/tenkz_rmp.py book --all` passes on this branch (130/130 targets plus the book), work tree preserved with exactly the file classes the upload step globs (130 `.tnlog`, 130 target PDFs, 260 `.txt`, 130 `.log`, root `lint.txt`, `book-pass-{1,2,3}.txt`, book `.log` and `.pdf`)
- [x] Rerunning into the same nonempty work root fails with the new-or-empty-directory message (exit 1)
- [x] Default invocation without `TENKZ_RMP_WORK_ROOT` still works in a removed temporary directory (`check --id rmp-ii-peps-projection` green)
- [x] `tenkz-rmp` job ran (not skipped, via the `workflow` path filter) and passed on this PR: 9m42s wall clock at `TENKZ_RMP_JOBS=2`, inside the historical 6m23s to 8m4s `check --all` range plus the book passes

Closes LionSR/tenkz#185.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a PR-blocking CI gate and the RMP harness work-directory lifecycle, so misconfiguration could hide regressions or leave noisy failure artifacts. Scope is CI/tooling only, not runtime auth or data handling.
> 
> **Overview**
> **Gates full RMP book typesetting on PRs.** The `tenkz-rmp` job now runs `tenkz_rmp.py book --all` instead of `check --all`, so preamble/layout breaks in the benchmark book fail before merge rather than waiting for the weekly workflow. Page rasterization stays in `tenkz-rmp-book.yml`.
> 
> **Keeps failure evidence diagnosable.** Adds opt-in `TENKZ_RMP_WORK_ROOT` so the harness can preserve its scratch tree; CI points it at runner temp and uploads transcripts, `.tnlog`s, and PDFs only on failure. Also adds `tenkzrmpbenchmark.sty` to the corpus path filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb04d67ffaf3ca0f4ca9240efcb48d91f6afe51a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->