### PR TITLE
feat(SectorBNT): prove equal-ambient CPSV gauge equivalence

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT.lean
@@ -13,6 +13,7 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Blocking
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormBridge
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormEqual
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormEqualAmbient
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
 import TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
@@ -55,18 +55,23 @@ private lemma gaugeEquiv_cast_dim {n m : ℕ} (h : n = m)
 
 /-- **Equal-ambient CPSV fundamental theorem.**
 
-Two normalized nonzero CPSV canonical-form tensors in the same ambient bond dimension that generate
-the same matrix product vectors at every positive length are gauge equivalent. Inactive
-zero-weight blocks and unused ambient coordinates are allowed: the exact active reconstructions
-retain only the nonzero-weight blocks, while the ambient lifting aligns their possibly different
-coisometric inclusions.
+Two normalized nonzero CPSV canonical-form tensors in the same ambient bond
+dimension that generate the same matrix product vectors at every positive length
+are gauge equivalent. Inactive zero-weight blocks and unused ambient coordinates
+are allowed: the exact active reconstructions retain only the nonzero-weight blocks,
+while the ambient lifting aligns their possibly different coisometric inclusions.
 
-This theorem is explicitly homogeneous in the ambient dimension `D`; it makes no heterogeneous
-ambient-dimension claim. The ambient lifting is a project-derived corollary of the cited active
-fundamental theorem and the coisometry-alignment lemma.
+This theorem is explicitly homogeneous in the ambient dimension \(D\); it makes no
+heterogeneous ambient-dimension claim. The ambient lifting is a project-derived
+corollary of the cited active fundamental theorem and the coisometry-alignment lemma.
 
-Source: arXiv:2011.12127v2, lines 1831--1906; arXiv:1606.00608, lines 237--301 and
-1135--1199. -/
+**Scope restriction (equal ambient dimension and nonzero tensors):** The theorem
+assumes a common ambient bond dimension and excludes zero tensors. It does not prove
+the heterogeneous ambient statement of the cited source corollary. See
+`docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex`.
+
+Source: arXiv:2011.12127v2, lines 1831--1906; arXiv:1606.00608,
+lines 237--301 and 1135--1199. -/
 theorem fundamentalTheorem_equal_ambient_canonicalForm
     (dataA : CPSVCanonicalFormData A)
     (dataB : CPSVCanonicalFormData B)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormEqual
+import TNLean.MPS.SharedInfra.CoisometryGauge
+
+/-!
+# Equal-ambient fundamental theorem for CPSV canonical forms
+
+This module lifts the active-core equal theorem to the original tensors when their ambient bond
+spaces have the same dimension.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+variable {A B : MPSTensor d D}
+
+namespace CPSVCanonicalFormData
+
+/-- **Equal-ambient CPSV fundamental theorem.**
+
+Two normalized nonzero CPSV canonical-form tensors in the same ambient bond dimension that generate
+the same matrix product vectors at every positive length are gauge equivalent. Inactive
+zero-weight blocks and unused ambient coordinates are allowed: the exact active reconstructions
+retain only the nonzero-weight blocks, while the ambient lifting aligns their possibly different
+coisometric inclusions.
+
+This theorem is explicitly homogeneous in the ambient dimension `D`; it makes no heterogeneous
+ambient-dimension claim.
+
+Source: arXiv:2011.12127v2, lines 1831--1906; arXiv:1606.00608, lines 237--301 and
+1135--1199. -/
+theorem fundamentalTheorem_equal_ambient_canonicalForm
+    (dataA : CPSVCanonicalFormData A)
+    (dataB : CPSVCanonicalFormData B)
+    (hNormA : dataA.IsWeightNormalized)
+    (hNormB : dataB.IsWeightNormalized)
+    (hA : A ≠ 0) (hB : B ≠ 0)
+    (hEqual : SameMPV₂Pos A B) :
+    GaugeEquiv A B := by
+  obtain ⟨P, hPBNT, _hPDim, UA, hUA, XA, hRecA⟩ :=
+    dataA.exists_active_isBNTCanonicalForm_exact hNormA hA
+  obtain ⟨Q, hQBNT, _hQDim, UB, hUB, XB, hRecB⟩ :=
+    dataB.exists_active_isBNTCanonicalForm_exact hNormB hB
+  let C : MPSTensor d P.totalDim := fun i =>
+    (XA : Matrix _ _ ℂ) * P.toTensor i * (↑(XA⁻¹) : Matrix _ _ ℂ)
+  let E : MPSTensor d Q.totalDim := fun i =>
+    (XB : Matrix _ _ ℂ) * Q.toTensor i * (↑(XB⁻¹) : Matrix _ _ ℂ)
+  have hAC : SameMPV₂Pos A C :=
+    sameMPV₂Pos_of_coisometry_reconstruction A C UA hUA hRecA
+  have hBE : SameMPV₂Pos B E :=
+    sameMPV₂Pos_of_coisometry_reconstruction B E UB hUB hRecB
+  have hPC : SameMPV₂Pos P.toTensor C :=
+    fun N _hN w => GaugeEquiv.sameMPV ⟨XA, fun _ => rfl⟩ N w
+  have hQE : SameMPV₂Pos Q.toTensor E :=
+    fun N _hN w => GaugeEquiv.sameMPV ⟨XB, fun _ => rfl⟩ N w
+  have hPQ : SameMPV₂Pos P.toTensor Q.toTensor :=
+    hPC.trans (hAC.symm.trans (hEqual.trans (hBE.trans hQE.symm)))
+  obtain ⟨hTotal, Y, hGauge⟩ :=
+    fundamentalTheorem_equal_canonicalForm hPBNT hQBNT hPQ
+  cases hTotal
+  have hCE : GaugeEquiv C E := by
+    exact (⟨XA, fun _ => rfl⟩ : GaugeEquiv P.toTensor C).symm.trans
+      ((⟨Y, hGauge⟩ : GaugeEquiv P.toTensor Q.toTensor).trans
+        (⟨XB, fun _ => rfl⟩ : GaugeEquiv Q.toTensor E))
+  exact GaugeEquiv.of_coisometry_reconstruction UA UB hUA hUB hRecA hRecB hCE
+
+end CPSVCanonicalFormData
+
+end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
@@ -3,7 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormEqual
+import TNLean.MPS.FundamentalTheorem.SectorBNT.CanonicalFormBridge
+import TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord
 import TNLean.MPS.SharedInfra.CoisometryGauge
 
 /-!
@@ -61,7 +62,8 @@ retain only the nonzero-weight blocks, while the ambient lifting aligns their po
 coisometric inclusions.
 
 This theorem is explicitly homogeneous in the ambient dimension `D`; it makes no heterogeneous
-ambient-dimension claim.
+ambient-dimension claim. The ambient lifting is a project-derived corollary of the cited active
+fundamental theorem and the coisometry-alignment lemma.
 
 Source: arXiv:2011.12127v2, lines 1831--1906; arXiv:1606.00608, lines 237--301 and
 1135--1199. -/
@@ -81,14 +83,16 @@ theorem fundamentalTheorem_equal_ambient_canonicalForm
     (XA : Matrix _ _ ℂ) * P.toTensor i * (↑(XA⁻¹) : Matrix _ _ ℂ)
   let E : MPSTensor d Q.totalDim := fun i =>
     (XB : Matrix _ _ ℂ) * Q.toTensor i * (↑(XB⁻¹) : Matrix _ _ ℂ)
+  have hGaugePC : GaugeEquiv P.toTensor C := ⟨XA, fun _ => rfl⟩
+  have hGaugeQE : GaugeEquiv Q.toTensor E := ⟨XB, fun _ => rfl⟩
   have hAC : SameMPV₂Pos A C :=
     sameMPV₂Pos_of_coisometry_reconstruction A C UA hUA hRecA
   have hBE : SameMPV₂Pos B E :=
     sameMPV₂Pos_of_coisometry_reconstruction B E UB hUB hRecB
   have hPC : SameMPV₂Pos P.toTensor C :=
-    fun N _hN w => GaugeEquiv.sameMPV ⟨XA, fun _ => rfl⟩ N w
+    fun N _hN w => GaugeEquiv.sameMPV hGaugePC N w
   have hQE : SameMPV₂Pos Q.toTensor E :=
-    fun N _hN w => GaugeEquiv.sameMPV ⟨XB, fun _ => rfl⟩ N w
+    fun N _hN w => GaugeEquiv.sameMPV hGaugeQE N w
   have hPQ : SameMPV₂Pos P.toTensor Q.toTensor :=
     hPC.trans (hAC.symm.trans (hEqual.trans (hBE.trans hQE.symm)))
   obtain ⟨hTotal, Y, hGauge⟩ :=
@@ -113,12 +117,10 @@ theorem fundamentalTheorem_equal_ambient_canonicalForm
         _ = cast hm (P.toTensor i) := by rw [hp]
     rw [hPi]
     exact hGauge i
-  have hP'C' : GaugeEquiv P' C' := by
-    exact gaugeEquiv_cast_dim hTotal
-      (⟨XA, fun _ => rfl⟩ : GaugeEquiv P.toTensor C)
+  have hP'C' : GaugeEquiv P' C' :=
+    gaugeEquiv_cast_dim hTotal hGaugePC
   have hCE : GaugeEquiv C' E :=
-    hP'C'.symm.trans (hP'Q.trans
-      (⟨XB, fun _ => rfl⟩ : GaugeEquiv Q.toTensor E))
+    hP'C'.symm.trans (hP'Q.trans hGaugeQE)
   have hUA' : UA' * UA'ᴴ = 1 :=
     coisometry_cast_rows hTotal UA hUA
   have hRecA' : ∀ i, A i = UA'ᴴ * C' i * UA' :=

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CanonicalFormEqualAmbient.lean
@@ -22,6 +22,36 @@ variable {A B : MPSTensor d D}
 
 namespace CPSVCanonicalFormData
 
+private lemma mpsTensor_cast_apply {n m : ℕ} (h : n = m)
+    (T : MPSTensor d n) (i : Fin d) :
+    (cast (congr_arg (MPSTensor d) h) T) i =
+      cast (congr_arg (fun r => Matrix (Fin r) (Fin r) ℂ) h) (T i) := by
+  subst h
+  rfl
+
+private lemma coisometry_cast_rows {n m : ℕ} (h : n = m)
+    (U : Matrix (Fin n) (Fin D) ℂ) (hU : U * Uᴴ = 1) :
+    let V := cast (congr_arg (fun r => Matrix (Fin r) (Fin D) ℂ) h) U
+    V * Vᴴ = 1 := by
+  subst h
+  exact hU
+
+private lemma reconstruction_cast_rows {n m : ℕ} (h : n = m)
+    (T : MPSTensor d n) (U : Matrix (Fin n) (Fin D) ℂ)
+    (hRec : ∀ i, A i = Uᴴ * T i * U) :
+    let T' := cast (congr_arg (MPSTensor d) h) T
+    let U' := cast (congr_arg (fun r => Matrix (Fin r) (Fin D) ℂ) h) U
+    ∀ i, A i = U'ᴴ * T' i * U' := by
+  subst h
+  exact hRec
+
+private lemma gaugeEquiv_cast_dim {n m : ℕ} (h : n = m)
+    {S T : MPSTensor d n} (hGauge : GaugeEquiv S T) :
+    GaugeEquiv (cast (congr_arg (MPSTensor d) h) S)
+      (cast (congr_arg (MPSTensor d) h) T) := by
+  subst h
+  exact hGauge
+
 /-- **Equal-ambient CPSV fundamental theorem.**
 
 Two normalized nonzero CPSV canonical-form tensors in the same ambient bond dimension that generate
@@ -63,12 +93,38 @@ theorem fundamentalTheorem_equal_ambient_canonicalForm
     hPC.trans (hAC.symm.trans (hEqual.trans (hBE.trans hQE.symm)))
   obtain ⟨hTotal, Y, hGauge⟩ :=
     fundamentalTheorem_equal_canonicalForm hPBNT hQBNT hPQ
-  cases hTotal
-  have hCE : GaugeEquiv C E := by
-    exact (⟨XA, fun _ => rfl⟩ : GaugeEquiv P.toTensor C).symm.trans
-      ((⟨Y, hGauge⟩ : GaugeEquiv P.toTensor Q.toTensor).trans
-        (⟨XB, fun _ => rfl⟩ : GaugeEquiv Q.toTensor E))
-  exact GaugeEquiv.of_coisometry_reconstruction UA UB hUA hUB hRecA hRecB hCE
+  let P' := cast (congr_arg (MPSTensor d) hTotal) P.toTensor
+  let C' := cast (congr_arg (MPSTensor d) hTotal) C
+  let UA' := cast
+    (congr_arg (fun r => Matrix (Fin r) (Fin D) ℂ) hTotal) UA
+  have hP'Q : GaugeEquiv P' Q.toTensor := by
+    refine ⟨Y, fun i => ?_⟩
+    have hPi : P' i =
+        cast (by rw [hTotal] :
+          Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+            Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ) (P.toTensor i) := by
+      let hm : Matrix (Fin P.totalDim) (Fin P.totalDim) ℂ =
+          Matrix (Fin Q.totalDim) (Fin Q.totalDim) ℂ := by rw [hTotal]
+      have hp : congr_arg (fun r => Matrix (Fin r) (Fin r) ℂ) hTotal = hm :=
+        Subsingleton.elim _ _
+      calc
+        P' i = cast (congr_arg (fun r => Matrix (Fin r) (Fin r) ℂ) hTotal)
+            (P.toTensor i) := mpsTensor_cast_apply hTotal P.toTensor i
+        _ = cast hm (P.toTensor i) := by rw [hp]
+    rw [hPi]
+    exact hGauge i
+  have hP'C' : GaugeEquiv P' C' := by
+    exact gaugeEquiv_cast_dim hTotal
+      (⟨XA, fun _ => rfl⟩ : GaugeEquiv P.toTensor C)
+  have hCE : GaugeEquiv C' E :=
+    hP'C'.symm.trans (hP'Q.trans
+      (⟨XB, fun _ => rfl⟩ : GaugeEquiv Q.toTensor E))
+  have hUA' : UA' * UA'ᴴ = 1 :=
+    coisometry_cast_rows hTotal UA hUA
+  have hRecA' : ∀ i, A i = UA'ᴴ * C' i * UA' :=
+    reconstruction_cast_rows hTotal C UA hRecA
+  exact GaugeEquiv.of_coisometry_reconstruction
+    UA' UB hUA' hUB hRecA' hRecB hCE
 
 end CPSVCanonicalFormData
 

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -1313,6 +1313,10 @@ give $O_{YX}(N)\to 0$, a contradiction.
     canonical forms with different ambient bond dimensions.
 \end{theorem}
 
+The cited sources supply the active canonical-form comparison. The passage back
+from the active tensors to the ambient tensors is the coisometric lifting of
+Theorem~\ref{thm:coisometry_reconstruction_gauge_equiv}.
+
 \begin{proof}\leanok
     \uses{thm:cpsv_active_sector_bnt_exact,
         thm:coisometry_reconstruction_same_mpv_pos,
@@ -1328,14 +1332,19 @@ give $O_{YX}(N)\to 0$, a contradiction.
         B^i&=U_B^\dagger X_BQ^iX_B^{-1}U_B.
         \label{eq:cpsv_equal_ambient_reconstructions}
     \end{align}
-    Coisometric reconstruction and gauge invariance show that $P$ and $Q$
-    generate the same positive-length matrix product vectors. Hence
-    Theorem~\ref{thm:cpgsv_equal_case_source} identifies their retained
-    dimensions and gives a gauge between $P$ and $Q$. Composing this gauge with
-    $X_A^{-1}$ and $X_B$ gives a gauge between the two middle tensors in
-    (\ref{eq:cpsv_equal_ambient_reconstructions}).
-    Theorem~\ref{thm:coisometry_reconstruction_gauge_equiv} aligns the two
-    coisometries inside the common ambient space and yields
+    Theorem~\ref{thm:coisometry_reconstruction_same_mpv_pos}, gauge invariance,
+    and the hypothesis give
+    \begin{align}
+        \mc{V}^+(P)
+        &=\mc{V}^+(A)=\mc{V}^+(B)=\mc{V}^+(Q).
+        \label{eq:cpsv_equal_ambient_active_mpv}
+    \end{align}
+    Theorem~\ref{thm:cpgsv_equal_case_source} therefore identifies the retained
+    dimensions and gives $Y$ such that $Q^i=YP^iY^{-1}$. After identifying the
+    retained spaces, the two middle tensors in
+    (\ref{eq:cpsv_equal_ambient_reconstructions}) are conjugate by
+    $X_BYX_A^{-1}$. Theorem~\ref{thm:coisometry_reconstruction_gauge_equiv}
+    aligns the two coisometries inside the common ambient space and yields
     (\ref{eq:cpsv_equal_ambient_gauge}).
 \end{proof}
 

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -1292,6 +1292,53 @@ give $O_{YX}(N)\to 0$, a contradiction.
     (\ref{eq:cpsv_active_core_unitary_dims}).
 \end{proof}
 
+% Source anchors: RMP arXiv:2011.12127v2, lines 1831--1906;
+% CPSV16 arXiv:1606.00608, lines 237--301 and 1135--1199.
+\begin{theorem}[Equal-ambient gauge equivalence for CPSV canonical forms]%
+    \label{thm:cpsv_equal_ambient_gauge}
+    \lean{MPSTensor.CPSVCanonicalFormData.%
+        fundamentalTheorem_equal_ambient_canonicalForm}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:same_mpv2_pos, def:gauge_equiv}
+    Let $A$ and $B$ have the same ambient bond dimension $D$. Suppose they have
+    normalized CPSV canonical-form data, neither tensor is zero, and
+    $\mc{V}^+(A)=\mc{V}^+(B)$. Then $A$ and $B$ are gauge equivalent: there is
+    $G\in\GL_D(\C)$ such that, for every physical index $i$,
+    \begin{align}
+        B^i&=GA^iG^{-1}.
+        \label{eq:cpsv_equal_ambient_gauge}
+    \end{align}
+    Zero-weight listed blocks and unused ambient coordinates are allowed. The
+    conclusion requires the common ambient dimension $D$ and makes no claim for
+    canonical forms with different ambient bond dimensions.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_active_sector_bnt_exact,
+        thm:coisometry_reconstruction_same_mpv_pos,
+        thm:cpgsv_equal_case_source,
+        thm:coisometry_reconstruction_gauge_equiv,
+        thm:gauge_invariance}
+    Apply Theorem~\ref{thm:cpsv_active_sector_bnt_exact} to obtain
+    BNT canonical forms $P,Q$, coisometries $U_A,U_B$, and retained-space
+    gauges $X_A,X_B$ with
+    \begin{align}
+        A^i&=U_A^\dagger X_AP^iX_A^{-1}U_A,
+        \notag\\
+        B^i&=U_B^\dagger X_BQ^iX_B^{-1}U_B.
+        \label{eq:cpsv_equal_ambient_reconstructions}
+    \end{align}
+    Coisometric reconstruction and gauge invariance show that $P$ and $Q$
+    generate the same positive-length matrix product vectors. Hence
+    Theorem~\ref{thm:cpgsv_equal_case_source} identifies their retained
+    dimensions and gives a gauge between $P$ and $Q$. Composing this gauge with
+    $X_A^{-1}$ and $X_B$ gives a gauge between the two middle tensors in
+    (\ref{eq:cpsv_equal_ambient_reconstructions}).
+    Theorem~\ref{thm:coisometry_reconstruction_gauge_equiv} aligns the two
+    coisometries inside the common ambient space and yields
+    (\ref{eq:cpsv_equal_ambient_gauge}).
+\end{proof}
+
 Combining the after-blocking preparation with the normalized-weight construction
 gives the arbitrary-input statement, conditional on the weight normalization.
 

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -1300,9 +1300,11 @@ give $O_{YX}(N)\to 0$, a contradiction.
         fundamentalTheorem_equal_ambient_canonicalForm}
     \leanok
     \uses{def:cpsv_canonical_form, def:same_mpv2_pos, def:gauge_equiv}
-    Let $A$ and $B$ have the same ambient bond dimension $D$. Suppose they have
-    normalized CPSV canonical-form data, neither tensor is zero, and
-    $\mc{V}^+(A)=\mc{V}^+(B)$. Then $A$ and $B$ are gauge equivalent: there is
+    Let $A$ and $B$ have the same ambient bond dimension $D$. Suppose each
+    tensor has CPSV canonical-form data, both data satisfy the separate weight
+    normalization condition~(\ref{eq:cpsv_weight_normalization}), neither tensor
+    is zero, and $\mc{V}^+(A)=\mc{V}^+(B)$. Then $A$ and $B$ are gauge equivalent:
+    there is
     $G\in\GL_D(\C)$ such that, for every physical index $i$,
     \begin{align}
         B^i&=GA^iG^{-1}.

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -248,6 +248,15 @@ source correction rather than another matching argument.  In CPSV16, the
 equal-MPV ambient conjugacy corollary has the additional zero-weight-coordinate
 and ambient-dimension obstruction recorded separately.
 
+The formal declaration
+\path{MPSTensor.CPSVCanonicalFormData.fundamentalTheorem_equal_ambient_canonicalForm}
+now covers the nonzero equal-ambient sub-case.  It assumes that both tensors
+have the same ambient bond dimension and that their canonical-form data satisfy
+the separate weight normalization.  Exact active reconstructions and a
+coisometry-alignment argument then give ambient gauge equivalence.  This does
+not remove the heterogeneous ambient-dimension obstruction or the zero-family
+boundary of the printed corollary.
+
 CPSV21 uses the same weak BNT definition, so the extra zero-coefficient
 representative still refutes the chosen-BNT cardinality conclusion of
 Theorem~4.4.  It does not refute Corollary~4.5.  The latter concerns the ambient


### PR DESCRIPTION
## What changed

- add `MPSTensor.CPSVCanonicalFormData.fundamentalTheorem_equal_ambient_canonicalForm`
- start from exact active coisometric reconstructions of two normalized nonzero CPSV canonical tensors in the same ambient bond dimension
- apply the active SectorBNT equal-case theorem on the retained spaces
- transport the retained gauge across the proved active-dimension equality
- lift the retained gauge through the two coisometric reconstructions to obtain `GaugeEquiv A B`
- synchronize Chapter 10 with the equal-ambient statement, proof dependencies, and source boundary

The theorem allows zero-weight listed blocks and unused ambient coordinates. Equal ambient dimension is explicit in the common type `A B : MPSTensor d D`; no ambient dimension equality is inferred from heterogeneous positive-length MPV equality. The coisometric ambient lift is a project-derived corollary of the source active comparison.

## Validation

- targeted equal-ambient module and SectorBNT aggregator builds
- full `lake build` (10077 jobs before the final direct-import and documentation-only review refinements)
- post-rebase targeted builds against exact current main
- proof-integrity, diagnostics, module-policy, and import-aggregator checks
- blueprint synchronization and declaration checks
- reader-facing prose check
- double LuaLaTeX with no undefined cross-references
- independent Lean/API and Blueprint/source-boundary reviews
- `git diff --check`

Closes #6161
Advances #6122

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a core Fundamental Theorem surface and its blueprint/source-boundary claims, but builds on already-proved active comparison and coisometry-lift lemmas rather than new auth or data paths.
> 
> **Overview**
> Adds **`fundamentalTheorem_equal_ambient_canonicalForm`**: when two normalized nonzero CPSV canonical forms share ambient bond dimension `D` and the same positive-length MPVs, they are gauge equivalent.
> 
> The proof extracts exact active coisometric reconstructions, applies the existing active equal SectorBNT theorem on the retained spaces, then lifts the retained gauge back through coisometry alignment. Zero-weight blocks and unused ambient coordinates are allowed; heterogeneous ambient dimensions remain out of scope.
> 
> Also syncs Chapter 10 and the theorem-surface gap note with this equal-ambient sub-case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27f321ac956fa412703a98a8e34a99b8669671b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->