### PR TITLE
chore(tenkz): verify the offline vendored flat

### DIFF
--- a/docs/tenkz/ctan/DEPENDENCIES.md
+++ b/docs/tenkz/ctan/DEPENDENCIES.md
@@ -114,10 +114,17 @@ that had to be generated before it could be read.
 Eight cases are compiled, covering the six picture classes an upload is judged
 on: a flat placement, a plane frame, a circle frame, a string with crossings,
 an enclosure, and a diagrammatic equation. Six are the review benchmark's
-preamble-free cases, compiled inside the standalone document an author would
-write around them; two are kernel probes, which carry their own preamble and
-are compiled as they stand, so the self-contained document form is covered as
-well as the fragment form.
+preamble-free cases, compiled inside a document the harness writes around them;
+two are kernel probes, which carry their own preamble and are compiled as they
+stand, so the self-contained document form is covered as well as the fragment
+form.
+
+The document the harness writes asks for `article`, `amsmath`, and `amssymb`
+and nothing else, so a machine meeting the requirements in `README.md` can run
+those six. The two kernel probes declare `standalone`, which is a separate CTAN
+package: it is a requirement of the harness, not of tenkz, and a machine
+without it fails those two cases before the package is loaded. Whoever runs the
+release check needs `standalone` installed; nobody who loads tenkz does.
 
 Each run is read rather than counted. The engine writes an input record, and
 every runtime file it opened must have resolved inside the flat directory. The

--- a/docs/tenkz/ctan/DEPENDENCIES.md
+++ b/docs/tenkz/ctan/DEPENDENCIES.md
@@ -41,26 +41,50 @@ this is the group a host document's own TikZ styles reach into.
 | Library | Read by | For |
 |---|---|---|
 | `arrows.meta` | `tenkz-core.code.tex` (lines 372 to 392) | The barb an oriented index carries. |
+| `backgrounds` | `tenkz-tree.code.tex` (lines 472 and 488, in `\tenkz_tree_geometry:n`) | The layer a fusion tree draws its skin on, so the wires or ribbons sit behind the glyphs rather than over them. The layer is named `background` and the library that declares it is `backgrounds`; no file under `tex/tenkz/` declares a layer of its own. |
 | `decorations.markings` | `tenkz-core.code.tex` (lines 370 to 393), `tenkz-string.code.tex` (line 1511) | Placing a direction mark at a stated position along a wire, and placing the coordinate a string's bead is reported at. |
 | `decorations.pathreplacing` | `tenkz-core.code.tex` (lines 396 and 397) | The brace an annotation draws. |
 | `shapes.geometric` | `tenkz-core.code.tex` (lines 231, 1129 to 1157) | The isosceles triangle a library-owned glyph is built on, together with the three anchors the package adds to it. |
 
 ## 4. Loaded and unread
 
-`backgrounds` and `fit` are loaded by `tenkz.sty` and read by nothing: no file
-under `tex/tenkz/` calls either, and no case in `tests/tenkz/` or picture in
-`docs/tenkz/` does. `backgrounds` is named twice in the source, both times in a
-sentence saying the renderer's class order does the work a background layer
-would do elsewhere, which is a statement that the library is not used. `fit`
-does not appear at all.
+`fit` is loaded by `tenkz.sty` and read by nothing.
 
-They are recorded rather than dropped. Both come from pgf, so an installation
-that has `tikz` has them, and carrying them costs nobody anything; removing the
-loads would change what a host document inherits when it loads tenkz, which is
-a release decision about the package's load-time surface rather than a staging
-one. The entries sit in `MANIFEST.toml` under `unconsumed` so that the decision
-stays visible, and so a later consumer moves the entry rather than appearing
-without one.
+### How that is established
+
+Not by searching for the library's name. A library is reached through the names
+it defines rather than through its own, so a search for `backgrounds` finds two
+sentences in the source and misses `\begin{pgfonlayer}{background}` on the next
+page, which is the call that needs it. The reading that settles the question is
+to remove the load and compile: a library nothing reads changes nothing, and a
+library something reads takes its consumer down with it.
+
+Both loads were removed one at a time and the whole corpus compiled against the
+result, 468 fixtures in all: every case under `tests/tenkz/rmp/`, every kernel
+probe including the nested suites, and every string probe.
+
+- Without `backgrounds`, `tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-fusion-tensor.tex`
+  fails with `Package pgf Error: Sorry, the requested layer 'background' could
+  not be found`. The library is a real dependency and is listed in section 3.
+- Without `fit`, all 334 positive fixtures compile. The 134 that fail are
+  exactly the 134 negative fixtures, each failing with the tenkz coded error it
+  exists to produce, and none of them names pgf, a missing key, or `fit`.
+
+### Why it stays
+
+`fit` is recorded rather than dropped. It comes from pgf, so an installation
+that has `tikz` has it and the upload's requirements are the same either way;
+removing the load would change what a host document inherits when it loads
+tenkz, which is a release decision about the package's load-time surface rather
+than a staging one. The entry sits in `MANIFEST.toml` under `unconsumed` so the
+decision stays visible, and so a later consumer moves the entry rather than
+appearing without one.
+
+The check that reads this file's classification reads it for internal
+consistency only: that every loaded library is filed exactly once, and that no
+class is left out. It cannot tell a library nothing reads from one whose
+consumer nobody found. Only the ablation above can, and it has to be rerun when
+the load list changes.
 
 ## 5. What is gone
 

--- a/docs/tenkz/ctan/DEPENDENCIES.md
+++ b/docs/tenkz/ctan/DEPENDENCIES.md
@@ -11,7 +11,7 @@ without a traced consumer fails `scripts/tenkz_ctan.py check`.
 
 `tikz`, loaded by `tenkz.sty`. Everything else on this page is a TikZ library.
 
-Three of the libraries are not part of pgf and come from packages of their own:
+Two of the libraries are not part of pgf and come from packages of their own.
 `hobby` and `spath3` are separate CTAN packages, and an installation without
 them fails at package load rather than at the first curve. They are the two
 names a distribution build has to be told about.
@@ -26,9 +26,9 @@ rather than how they look.
 
 | Library | Read by | For |
 |---|---|---|
-| `calc` | `tenkz-tree.code.tex` (18 coordinate expressions, from line 40) | The partway modifier that places a fusion tree's vertices and its patch control points along the segment between two known points. |
+| `calc` | `tenkz-tree.code.tex` (18 lines, from line 40) | The partway modifier that places a fusion tree's vertices and its patch control points along the segment between two known points. |
 | `hobby` | `tenkz-string.code.tex` (line 232 asserts the library is present) | The curve through a string's waypoints. A string is given its route as a point sequence, and this is what turns the sequence into one smooth path. |
-| `spath3` | `tenkz-string.code.tex` (76 calls), `tenkz-kernel.code.tex` (lines 14993, 15443, 16648), `tenkz-render.code.tex` (lines 85 and 189) | Saving a string's route as a path and cutting it. Crossing surgery is a split of a saved path at its intersections; the renderer then draws the saved route rather than recomputing it. |
+| `spath3` | `tenkz-string.code.tex` (71 lines), `tenkz-kernel.code.tex` (lines 14993, 15443, 16648), `tenkz-render.code.tex` (lines 85 and 189) | Saving a string's route as a path and cutting it. Crossing surgery is a split of a saved path at its intersections; the renderer then draws the saved route rather than recomputing it. |
 | `intersections` | `tenkz-string.code.tex` (lines 234, 573, 905), `tenkz-kernel.code.tex` (line 9942) | Counting and locating where two routes meet. A declared crossing that produces no intersection is a coded error, and this is the engine that decides. |
 
 ## 3. Host ink

--- a/docs/tenkz/ctan/DEPENDENCIES.md
+++ b/docs/tenkz/ctan/DEPENDENCIES.md
@@ -1,0 +1,133 @@
+# What tenkz needs, and who reads it
+
+The archive carries eleven runtime files and nothing else. Everything below is
+what an installation must already have for those eleven to load and draw. The
+list is not copied from the package's load line: each entry names the code that
+reads the library, so a reader can check the claim, and the classification is
+pinned in `MANIFEST.toml` so a library that enters or leaves the load list
+without a traced consumer fails `scripts/tenkz_ctan.py check`.
+
+## 1. The one package
+
+`tikz`, loaded by `tenkz.sty`. Everything else on this page is a TikZ library.
+
+Three of the libraries are not part of pgf and come from packages of their own:
+`hobby` and `spath3` are separate CTAN packages, and an installation without
+them fails at package load rather than at the first curve. They are the two
+names a distribution build has to be told about.
+
+## 2. Placement and model ownership
+
+These are what the package computes and places with. Take one away and the
+model has no answer for where a tensor, a wire, or a crossing goes. None of
+them is reachable from a host document's styles: an author never writes to
+them, and a host that redefined one would be changing where tenkz puts things
+rather than how they look.
+
+| Library | Read by | For |
+|---|---|---|
+| `calc` | `tenkz-tree.code.tex` (18 coordinate expressions, from line 40) | The partway modifier that places a fusion tree's vertices and its patch control points along the segment between two known points. |
+| `hobby` | `tenkz-string.code.tex` (line 232 asserts the library is present) | The curve through a string's waypoints. A string is given its route as a point sequence, and this is what turns the sequence into one smooth path. |
+| `spath3` | `tenkz-string.code.tex` (76 calls), `tenkz-kernel.code.tex` (lines 14993, 15443, 16648), `tenkz-render.code.tex` (lines 85 and 189) | Saving a string's route as a path and cutting it. Crossing surgery is a split of a saved path at its intersections; the renderer then draws the saved route rather than recomputing it. |
+| `intersections` | `tenkz-string.code.tex` (lines 234, 573, 905), `tenkz-kernel.code.tex` (line 9942) | Counting and locating where two routes meet. A declared crossing that produces no intersection is a coded error, and this is the engine that decides. |
+
+## 3. Host ink
+
+These are what the drawing needs. Take one away and the network is placed and
+undrawable: an arrow tip, a brace, a direction mark, or a station outline is
+missing. The distinction from the previous group matters to an author, because
+this is the group a host document's own TikZ styles reach into.
+
+| Library | Read by | For |
+|---|---|---|
+| `arrows.meta` | `tenkz-core.code.tex` (lines 372 to 392) | The barb an oriented index carries. |
+| `decorations.markings` | `tenkz-core.code.tex` (lines 370 to 393), `tenkz-string.code.tex` (line 1511) | Placing a direction mark at a stated position along a wire, and placing the coordinate a string's bead is reported at. |
+| `decorations.pathreplacing` | `tenkz-core.code.tex` (lines 396 and 397) | The brace an annotation draws. |
+| `shapes.geometric` | `tenkz-core.code.tex` (lines 231, 1129 to 1157) | The isosceles triangle a library-owned glyph is built on, together with the three anchors the package adds to it. |
+
+## 4. Loaded and unread
+
+`backgrounds` and `fit` are loaded by `tenkz.sty` and read by nothing: no file
+under `tex/tenkz/` calls either, and no case in `tests/tenkz/` or picture in
+`docs/tenkz/` does. `backgrounds` is named twice in the source, both times in a
+sentence saying the renderer's class order does the work a background layer
+would do elsewhere, which is a statement that the library is not used. `fit`
+does not appear at all.
+
+They are recorded rather than dropped. Both come from pgf, so an installation
+that has `tikz` has them, and carrying them costs nobody anything; removing the
+loads would change what a host document inherits when it loads tenkz, which is
+a release decision about the package's load-time surface rather than a staging
+one. The entries sit in `MANIFEST.toml` under `unconsumed` so that the decision
+stays visible, and so a later consumer moves the entry rather than appearing
+without one.
+
+## 5. What is gone
+
+The commutative-diagram, free-placement, and lattice front ends were removed
+along with the loads they brought. No file under `tex/tenkz/` loads `tikz-cd`,
+`tikzcd`, or `quantikz`. The one occurrence of the phrase in the package is a
+sentence in `tenkz.sty` saying commutative diagrams belong to tikz-cd and are
+outside this language, and the closure walk blanks comments before it reads a
+load, so that sentence cannot reach the dependency list and a surviving load
+would be the only way the name could. `scripts/tenkz_ctan.py check` reads the
+absence from the walked closure rather than asserting it.
+
+The blueprint keeps its own `tikz-cd` load in
+`blueprint/src/macros/diagrams.tex`. That is the blueprint's dependency, not
+the package's: it is not on the load graph walked from `tenkz.sty`, and nothing
+the archive carries reads it.
+
+## 6. The offline flat
+
+`python3 scripts/tenkz_ctan.py offline` builds the archive, unpacks it into one
+directory with no subdirectory, writes representative corpus cases beside it,
+and compiles each one there. It is the arXiv reading of the same files: a
+source submission is unpacked beside a manuscript rather than installed, so a
+runtime that only resolves through a directory would fail, and so would one
+that had to be generated before it could be read.
+
+Eight cases are compiled, covering the six picture classes an upload is judged
+on: a flat placement, a plane frame, a circle frame, a string with crossings,
+an enclosure, and a diagrammatic equation. Six are the review benchmark's
+preamble-free cases, compiled inside the standalone document an author would
+write around them; two are kernel probes, which carry their own preamble and
+are compiled as they stand, so the self-contained document form is covered as
+well as the fragment form.
+
+Each run is read rather than counted. The engine writes an input record, and
+every runtime file it opened must have resolved inside the flat directory. The
+event stream goes through `scripts/tenkz_audit.py`, which is the audit
+`HACKING.md` prescribes, so an empty picture, a detached closure, a crossing
+that produced no occlusion, or an equation whose two sides expose different
+boundaries is a failed run. On top of the audit, each case has to show its own
+class in the stream: a plane frame writes a frame record naming the plane map,
+a circle frame writes a boundary signature with a numeric compass face because
+it transports each port along its station's outward radius, a crossing writes
+crossing records, an enclosure writes an enclosure mark, an equation writes a
+check record that folded its panels into a relation, and a flat placement
+writes no frame record at all. A case swapped for one of another class fails on
+both the source it declares and the stream it writes.
+
+### What the isolation is
+
+The run gets an environment built rather than inherited. The home directory and
+the three TeX trees an installation lets a user override are pointed at empty
+directories, so no personally installed copy of tenkz can answer. The search
+path is the current directory and then the installation, which is what leaves
+`tikz`, `hobby`, and `spath3` findable and is also why the input record decides
+where the runtime came from. The four variables that let kpathsea build a font
+or a format on demand are set to refuse. Fourteen installers and fetchers,
+`tlmgr` and the `mktex` family among them, are shadowed by scripts that record
+their own call and fail, and the run fails if any of them was reached for. The
+engine is invoked with no shell escape, so it can start no process of its own.
+Proxy variables point at the discard port.
+
+### What it does not prove
+
+It does not prove the machine had no network. It proves that the runs installed
+nothing, fetched nothing, generated no font and no format, and read no file
+from this repository: every tenkz file came from the unpacked archive, and
+everything else came from the pinned installation. A stronger claim would need
+the run confined to a network namespace, which is not portable to the platforms
+this harness runs on.

--- a/docs/tenkz/ctan/MANIFEST.toml
+++ b/docs/tenkz/ctan/MANIFEST.toml
@@ -52,6 +52,32 @@ libraries = [
   "spath3",
 ]
 
+[runtime.requires.ownership]
+# Why each library is loaded, traced to the code that reads it.
+# `docs/tenkz/ctan/DEPENDENCIES.md` is the reading; this is the pin, and the
+# check refuses a library that enters or leaves the load list without one.
+#
+# `placement` is what the package computes and places with: take one away and
+# the model has no answer for where a tensor, a wire, or a crossing goes.
+# `ink` is what the drawing needs: take one away and the network is placed and
+# undrawable, an arrow tip or a brace or a station outline missing. The
+# distinction matters to an author, because the second group is what a host
+# document's own styles reach into and the first is not.
+placement = ["calc", "hobby", "intersections", "spath3"]
+ink = [
+  "arrows.meta",
+  "decorations.markings",
+  "decorations.pathreplacing",
+  "shapes.geometric",
+]
+# Loaded, and read by nothing in the package or the corpus. Both come from pgf
+# rather than from a package of their own, so carrying them costs an
+# installation nothing beyond `tikz`, which is why they are recorded here
+# instead of dropped: removing a load is a change to what a host document
+# inherits at package load, and that is a release decision rather than a
+# staging one.
+unconsumed = ["backgrounds", "fit"]
+
 [material]
 # Staged name = the file it is copied from, unmodified. The version and date
 # these carry are checked against the `\ProvidesPackage` line; none of them

--- a/docs/tenkz/ctan/MANIFEST.toml
+++ b/docs/tenkz/ctan/MANIFEST.toml
@@ -66,17 +66,20 @@ libraries = [
 placement = ["calc", "hobby", "intersections", "spath3"]
 ink = [
   "arrows.meta",
+  "backgrounds",
   "decorations.markings",
   "decorations.pathreplacing",
   "shapes.geometric",
 ]
-# Loaded, and read by nothing in the package or the corpus. Both come from pgf
-# rather than from a package of their own, so carrying them costs an
-# installation nothing beyond `tikz`, which is why they are recorded here
-# instead of dropped: removing a load is a change to what a host document
-# inherits at package load, and that is a release decision rather than a
-# staging one.
-unconsumed = ["backgrounds", "fit"]
+# Loaded, and read by nothing. A library is reached through the names it
+# defines rather than through its own, so this class is not settled by looking
+# for the library's name: it is settled by removing the load and compiling the
+# corpus, which is the reading DEPENDENCIES.md records. `fit` comes from pgf
+# rather than from a package of its own, so carrying it costs an installation
+# nothing beyond `tikz`, which is why it is recorded here instead of dropped:
+# removing a load is a change to what a host document inherits at package load,
+# and that is a release decision rather than a staging one.
+unconsumed = ["fit"]
 
 [material]
 # Staged name = the file it is copied from, unmodified. The version and date

--- a/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
+++ b/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
@@ -15,6 +15,13 @@ named by `RELEASE-POLICY.md` §3 may change it.
 - [ ] `python3 scripts/tenkz_ctan.py check` passes at that head, with a TeX
       installation present so the clean-install check runs rather than being
       skipped. Add `--require-smoke` to make its absence a failure.
+- [ ] `python3 scripts/tenkz_ctan.py offline` passes. It is part of `check`
+      above and repeated here because it is the reading an arXiv submission
+      gets rather than an installation: the archive is unpacked flat, a case
+      of each picture class is compiled beside it with no installer or
+      fetcher reachable, and each result is audited.
+      `docs/tenkz/ctan/DEPENDENCIES.md` states what the isolation is and what
+      it does not prove.
 - [ ] `python3 scripts/tenkz_ctan.py sync` shows the version and date the
       release artifacts agree on. Disagreement is the release-preparation
       change's work, not the archive builder's.
@@ -78,7 +85,9 @@ is hard to correct later.
       commit are filled in.
 - [ ] The package appears in TeX Live's next update, and the `hobby` and
       `spath3` dependencies are recorded so a distribution build does not
-      drop them.
+      drop them. They are the two libraries that come from packages of their
+      own rather than from pgf; `docs/tenkz/ctan/DEPENDENCIES.md` traces every
+      load to the code that reads it.
 
 ## What the check proves, and what it does not
 
@@ -94,6 +103,17 @@ its own and compiles a picture against it, asking the engine to record every
 file it opened and requiring that every tenkz file resolved inside the
 unpacked directory — so a runtime file the archive forgot is a failed run
 rather than a silent fall-back to a copy already installed on the machine.
+
+It then reads the same tree as an arXiv source submission and compiles against
+it. The submission reading is stricter than the installation one: the tree has
+to be flat, has to be the runtime rather than the sources a runtime is
+generated from, has to name no path on the machine that built it, and has to
+call no primitive that would need a shell. Against the flattened archive it
+compiles a case of each picture class the release is judged on, with the user
+TeX trees emptied, every installer and fetcher shadowed by a script that
+records its own call and fails, and font and format generation refused. Each
+result goes through the event audit and has to show its own class in the
+stream, so a run that produced a PDF and no tensor network fails.
 
 Every finding is a printed line of the report, and the check prints all of
 them: a staged name an unpacking tool would misread does not cut the report

--- a/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
+++ b/docs/tenkz/ctan/UPLOAD-CHECKLIST.md
@@ -15,13 +15,15 @@ named by `RELEASE-POLICY.md` §3 may change it.
 - [ ] `python3 scripts/tenkz_ctan.py check` passes at that head, with a TeX
       installation present so the clean-install check runs rather than being
       skipped. Add `--require-smoke` to make its absence a failure.
-- [ ] `python3 scripts/tenkz_ctan.py offline` passes. It is part of `check`
-      above and repeated here because it is the reading an arXiv submission
-      gets rather than an installation: the archive is unpacked flat, a case
-      of each picture class is compiled beside it with no installer or
-      fetcher reachable, and each result is audited.
-      `docs/tenkz/ctan/DEPENDENCIES.md` states what the isolation is and what
-      it does not prove.
+- [ ] `python3 scripts/tenkz_ctan.py offline --require-engine` passes. It is
+      part of `check` above and repeated here because it is the reading an
+      arXiv submission gets rather than an installation: the archive is
+      unpacked flat, a case of each picture class is compiled beside it with
+      no installer or fetcher reachable, and each result is audited. Without
+      `--require-engine` the command reports itself skipped and exits 0 on a
+      machine with no TeX installation, which would tick this box while
+      proving nothing. `docs/tenkz/ctan/DEPENDENCIES.md` states what the
+      isolation is and what it does not prove.
 - [ ] `python3 scripts/tenkz_ctan.py sync` shows the version and date the
       release artifacts agree on. Disagreement is the release-preparation
       change's work, not the archive builder's.

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -36,6 +36,7 @@ Commands:
   stage         write the staging tree under --out (default build/ctan)
   archive       write the tree, the archive, and the archive's digest
   sync          report the version and date state of the release artifacts
+  offline       compile the corpus cases against the archive, unpacked flat
   check         run every acceptance check and report one line each
 
 `check` exits 1 on the first failing check's report, 0 when every check
@@ -183,6 +184,136 @@ SMOKE_DOCUMENT = r"""\documentclass{article}
 \end{tenkz}
 \end{document}
 """
+
+# The ways a loaded TikZ library reaches the package, and the report that has
+# to account for every one of them. `docs/tenkz/ctan/DEPENDENCIES.md` reads the
+# same three words: a library the package's own placement and model code calls,
+# a library only the ink it draws needs, and a library loaded with no consumer
+# anywhere in the source. The third class is not a spare bin. It is the finding
+# a rederivation exists to produce, and it is named so that a library entering
+# or leaving it is a reviewed edit rather than a silence.
+DEPENDENCY_CLASSES = ("placement", "ink", "unconsumed")
+
+# Front ends the package once carried, and the load each of them brought with
+# it. They are checked by absence: the closure walk blanks comments before it
+# reads a load, so the sentence in `tenkz.sty` that says commutative diagrams
+# belong to tikz-cd is prose and not a dependency, and a real load would be the
+# only way any of these names could reach the closure.
+RETIRED_DEPENDENCIES = ("tikz-cd", "tikzcd", "quantikz")
+
+# What arXiv will not do for a source submission, expressed as the file kinds
+# whose presence would mean it has to. A `.dtx` or `.ins` pair is the usual
+# LaTeX-package shape and needs a docstrip run before the runtime exists; a
+# `.fmt` or a `.mf` needs the format or the font built. tenkz stages its
+# runtime as the files the engine reads, so none of these may be staged.
+REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
+
+# The primitives a submission may not need, because arXiv compiles without
+# `\write18`. tenkz draws with TikZ and computes with expl3, so it calls none
+# of them; the check is what keeps that true.
+SHELL_ESCAPE_CALLS = (r"\write18", r"\ShellEscape", r"\immediate\write18")
+
+# An absolute path in a staged source names the machine that wrote it. The
+# pattern catches the two spellings a TeX file can carry: a Unix path opening
+# a load argument, and a Windows drive letter.
+ABSOLUTE_LOAD = re.compile(
+    r"\\(?:input|include|usepackage|RequirePackage|includegraphics)"
+    r"\s*(?:\[[^]]*\]\s*)?\{\s*(?:/|[A-Za-z]:[\\/])"
+)
+
+
+@dataclass(frozen=True)
+class OfflineCase:
+    """One picture class, the corpus case that draws it, and its evidence.
+
+    `declares` is read from the case source and `emits` from the event stream
+    the compiled run wrote, so a case swapped for one of another class fails
+    on both sides rather than passing as "a picture compiled". `absent` is the
+    negative half of the same reading: a flat placement is recognized by the
+    frame record it does not write.
+    """
+
+    name: str
+    picture_class: str
+    source: str
+    document: bool
+    declares: str
+    emits: str
+    absent: str = ""
+
+
+# The six picture classes an upload is judged on, each drawn by a case the
+# corpus already owns and audits: the review benchmark for the classes it
+# covers, and the kernel probes for the self-contained document form, whose
+# preamble is the one an author writes rather than one this tool supplies.
+OFFLINE_CASES = (
+    OfflineCase(
+        "flat", "flat",
+        "tests/tenkz/rmp/section-ii/cases/rmp-ii-mps-marginal.tex",
+        False, r"\begin{tenkz}", r"atom\|", absent=r"(?m)^frame\|",
+    ),
+    OfflineCase(
+        "plane", "plane",
+        "tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-marginal.tex",
+        False, "frame=plane", r"(?m)^frame\|.*map=plane",
+    ),
+    OfflineCase(
+        "circle", "circle",
+        "tests/tenkz/rmp/section-ii/cases/rmp-ii-triangle-network.tex",
+        # A circle frame transports each port along its station's outward
+        # radius, so the boundary signature carries a numeric compass face. A
+        # flat or plane placement writes a named one, so the digit is the
+        # reading that tells the two apart.
+        False, "frame=circle", r"kernel-boundary\|signature=phys:[0-9]",
+    ),
+    OfflineCase(
+        "crossing", "string/crossing",
+        "tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-two.tex",
+        False, r"\tnwire", r"(?m)^stringcross\|",
+    ),
+    OfflineCase(
+        "enclosure", "enclosure",
+        "tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-projection.tex",
+        False, "form=enclosure", r"(?m)^mark\|.*form=enclosure",
+    ),
+    OfflineCase(
+        "equation", "equation",
+        "tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-brickwork.tex",
+        False, r"\begin{tenkzeq}", r"(?m)^check\|.*result=equal",
+    ),
+    OfflineCase(
+        "probe-plane", "plane",
+        "tests/tenkz/kernel/k_plane.tex",
+        True, "frame=plane", r"(?m)^frame\|.*map=plane",
+    ),
+    OfflineCase(
+        "probe-crossing", "string/crossing",
+        "tests/tenkz/kernel/k_braid.tex",
+        True, r"\tnwire", r"(?m)^stringcross\|",
+    ),
+)
+
+# The document an author writes around a preamble-free case. It names the case
+# by its flat basename, which is what the submission would look like.
+OFFLINE_WRAPPER = r"""\documentclass[border=8pt,varwidth=270mm]{standalone}
+\usepackage{amsmath,amssymb,mathtools}
+\usepackage{tenkz}
+\begin{document}
+\input{%s}
+\end{document}
+"""
+
+# The tools a run must not reach for. Each is shadowed by a script that records
+# its own call and fails, so "no installation and no fetch happened" is read
+# from whether any of them ran rather than assumed from a run that passed.
+# `tlmgr` would install a missing package; the `mktex` family would build a
+# font or a format on the fly, which is the other way a run can quietly repair
+# an incomplete environment.
+INTERPOSED_TOOLS = (
+    "tlmgr", "curl", "wget", "git", "ftp", "scp", "ssh", "rsync",
+    "mktextfm", "mktexpk", "mktexmf", "mktexlsr", "updmap", "fmtutil",
+)
+TRIPWIRE = "#!/bin/sh\nprintf '%s\\n' \"$0\" >> \"$TENKZ_OFFLINE_TRIPWIRE\"\nexit 127\n"
 
 
 # --------------------------------------------------------------------------
@@ -632,6 +763,82 @@ def check_closure(closure: Closure, manifest: dict) -> Report:
     return report
 
 
+def check_dependencies(closure: Closure, manifest: dict) -> Report:
+    """Every loaded library is accounted for by one consumer class, and the
+    retired front ends' loads are gone.
+
+    The closure says what is loaded. It cannot say why, and a list of ten
+    library names is not a dependency report: an author reading it cannot tell
+    which of them the package needs to place a tensor and which of them only
+    the ink it draws needs. The manifest's classification says which, and this
+    check is what stops the two from drifting: a library that enters or leaves
+    the load list without a class, or that is filed under two, fails here.
+
+    Absence is checked the same way. The retired front ends each brought a load
+    with them, and the walk that reads loads has already blanked the comments,
+    so a name from that list reaching the closure would mean a real load
+    survived the removal rather than a sentence about one.
+    """
+
+    report = Report("dependencies")
+    ownership = manifest["runtime"]["requires"].get("ownership")
+    if not isinstance(ownership, dict):
+        report.failures.append(
+            f"{MANIFEST_LABEL} declares no [runtime.requires.ownership]; the "
+            "loaded libraries are then a list nobody has traced to a consumer"
+        )
+        return report
+    unknown = sorted(set(ownership) - set(DEPENDENCY_CLASSES))
+    report.require(
+        not unknown,
+        f"{MANIFEST_LABEL} files libraries under {unknown}, and a library "
+        f"reaches the package one of {list(DEPENDENCY_CLASSES)} ways",
+    )
+    classified: dict[str, list[str]] = {}
+    for name in DEPENDENCY_CLASSES:
+        members = ownership.get(name, [])
+        if not isinstance(members, list) or any(
+            not isinstance(member, str) for member in members
+        ):
+            report.failures.append(f"[runtime.requires.ownership] {name} is not a list of names")
+            return report
+        classified[name] = members
+    twice = sorted(
+        library
+        for library in closure.libraries
+        if sum(library in members for members in classified.values()) > 1
+    )
+    report.require(
+        not twice,
+        f"{twice} are filed under more than one consumer class; a library is "
+        "read for one reason or the report does not say what that reason is",
+    )
+    filed = sorted({library for members in classified.values() for library in members})
+    report.require(
+        filed == closure.libraries,
+        f"the classification covers {filed}, and {ENTRY.name} loads "
+        f"{closure.libraries}",
+    )
+    loaded = set(closure.packages) | set(closure.libraries)
+    survivors = sorted(name for name in RETIRED_DEPENDENCIES if name in loaded)
+    report.require(
+        not survivors,
+        f"{ENTRY.name} still loads {survivors}, which the retired front ends "
+        "brought and their removal was supposed to take with them",
+    )
+    report.notes.append(
+        "; ".join(
+            f"{name}: {len(classified[name])}" for name in DEPENDENCY_CLASSES
+        )
+        + f"; no load of {', '.join(RETIRED_DEPENDENCIES)}"
+    )
+    if classified["unconsumed"]:
+        report.notes.append(
+            f"loaded with no consumer in the source: {', '.join(classified['unconsumed'])}"
+        )
+    return report
+
+
 def check_source_tree(closure: Closure, manifest: dict, source: Path = SOURCE) -> Report:
     """Nothing in the source directory is unaccounted for, and none of it is debris."""
 
@@ -1029,6 +1236,264 @@ def check_smoke(archive: Path, required: bool) -> Report:
     return report
 
 
+def check_arxiv(tree: Path) -> Report:
+    """The staged tree read as an arXiv source submission.
+
+    An upload to CTAN and a source submission to arXiv are the same files under
+    two sets of rules, and the second set is the stricter one: arXiv unpacks a
+    submission beside the manuscript rather than installing it, runs no
+    docstrip and no font builder, and compiles without shell escape. So the
+    tree has to be flat, has to be the runtime itself rather than the sources a
+    runtime is generated from, has to name no path on the machine that wrote
+    it, and has to call no primitive that would need a shell.
+    """
+
+    report = Report("arxiv")
+    for path in sorted(tree.rglob("*")):
+        report.require(
+            not path.is_dir(),
+            f"{path.name} is a directory, and a submission unpacks beside a "
+            "manuscript rather than into a tree of its own",
+        )
+        if path.is_dir():
+            continue
+        report.require(
+            path.suffix not in REGENERATED_SUFFIXES,
+            f"{path.name} would have to be run before the runtime exists, and "
+            "a submission is compiled rather than built",
+        )
+        if path.suffix not in {".sty", ".tex"}:
+            continue
+        text = path.read_bytes().decode("utf-8", errors="replace")
+        report.require(
+            ABSOLUTE_LOAD.search(strip_comments(text)) is None,
+            f"{path.name} loads a file by absolute path, which names the "
+            "machine it was written on",
+        )
+        for call in SHELL_ESCAPE_CALLS:
+            report.require(
+                call not in strip_comments(text),
+                f"{path.name} calls {call}, and a submission compiles with no shell",
+            )
+    report.notes.append(
+        f"{len(list(tree.iterdir()))} files, one directory deep, no generated "
+        "source and no shell call"
+    )
+    return report
+
+
+def offline_room(archive: Path, room: Path) -> list[str]:
+    """Unpack the archive flat into one directory, as a submission unpacks.
+
+    CTAN receives a `tenkz/` directory and an installation puts it on the
+    search path. A submission has no search path to put it on: the files sit
+    beside the manuscript, so this is where the archive is flattened and where
+    a runtime file that only resolves through a directory would fail.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="tenkz-offline-unpack-") as unpacking:
+        with zipfile.ZipFile(archive) as bundle:
+            bundle.extractall(unpacking)
+        unpacked = Path(unpacking) / PACKAGE
+        staged = sorted(path.name for path in unpacked.iterdir())
+        for path in sorted(unpacked.iterdir()):
+            shutil.copy2(path, room / path.name)
+    return staged
+
+
+def offline_environment(room: Path, shims: Path, tripwire: Path, home: Path) -> dict[str, str]:
+    """The environment a run gets, built rather than inherited.
+
+    Nothing of the caller's environment reaches the engine except the search
+    path it needs to find its own binaries, and the shim directory comes first
+    on it, so an installer or a fetcher the run reached for would be recorded
+    instead of run. `TEXINPUTS` is the current directory and then the
+    installation: the empty last element is what leaves `tikz`, `hobby`, and
+    `spath3` findable, and it is also why the input record, not the exit
+    status, decides where the runtime came from.
+    """
+
+    return {
+        "PATH": os.pathsep.join([str(shims), "/usr/bin", "/bin", os.environ.get("PATH", "")]),
+        "HOME": str(home),
+        "TEXMFHOME": str(home / "texmf"),
+        "TEXMFVAR": str(home / "texmf-var"),
+        "TEXMFCONFIG": str(home / "texmf-config"),
+        "TEXINPUTS": ".:",
+        "TEXMFOUTPUT": str(room),
+        "TENKZ_OFFLINE_TRIPWIRE": str(tripwire),
+        # kpathsea reads these before it runs a generator, so a missing font or
+        # format is a failed run rather than a build nobody asked for.
+        "MKTEXTFM": "0",
+        "MKTEXPK": "0",
+        "MKTEXMF": "0",
+        "MKTEXFMT": "0",
+        # The discard port, for any client that honours a proxy variable: a
+        # fetch that got past the shims still has nowhere to go.
+        "http_proxy": "http://127.0.0.1:9",
+        "https_proxy": "http://127.0.0.1:9",
+        "ftp_proxy": "http://127.0.0.1:9",
+        "all_proxy": "http://127.0.0.1:9",
+    }
+
+
+def write_shims(shims: Path) -> None:
+    """Shadow every tool a run could install or fetch with, and record calls."""
+
+    shims.mkdir(parents=True, exist_ok=True)
+    for tool in INTERPOSED_TOOLS:
+        shim = shims / tool
+        shim.write_text(TRIPWIRE, encoding="utf-8")
+        shim.chmod(0o755)
+
+
+def recorded_inputs(record: Path) -> list[str]:
+    """Every file the engine opened, from its input record."""
+
+    return [
+        line[len("INPUT "):].strip()
+        for line in record.read_text(encoding="utf-8", errors="replace").splitlines()
+        if line.startswith("INPUT ")
+    ]
+
+
+def check_offline(archive: Path, required: bool) -> Report:
+    """Compile one case of every picture class against the unpacked flat.
+
+    The clean-install check proves the archive carries a runtime. This one
+    proves the runtime draws: a case of each class the release is judged on is
+    compiled beside the flattened archive, with no network reachable and no
+    installer on the path, and each result is read as the corpus reads it --
+    the event stream through the audit, and the class's own record through the
+    evidence the case declares. A run that produced a PDF and no tensor network
+    fails here, and so does one whose picture is of another class than the one
+    it was chosen for.
+    """
+
+    report = Report("offline")
+    engine = shutil.which("xelatex")
+    if engine is None:
+        if required:
+            report.failures.append("xelatex is absent and the check was required")
+        else:
+            report.skipped = "xelatex is absent"
+        return report
+    audit = ROOT / "scripts/tenkz_audit.py"
+    if not audit.is_file():
+        report.failures.append(f"{audit.relative_to(ROOT)} is missing; nothing would read the runs")
+        return report
+    with tempfile.TemporaryDirectory(prefix="tenkz-offline-") as directory:
+        base = Path(directory)
+        room = base / "submission"
+        room.mkdir()
+        home = base / "home"
+        (home / "texmf").mkdir(parents=True)
+        tripwire = base / "reached-for.txt"
+        shims = base / "shims"
+        write_shims(shims)
+        staged = offline_room(archive, room)
+        environment = offline_environment(room, shims, tripwire, home)
+        for case in OFFLINE_CASES:
+            _offline_case(case, room, engine, environment, audit, report)
+        if tripwire.exists():
+            report.failures.append(
+                "the runs reached for an installer or a fetcher: "
+                + tripwire.read_text(encoding="utf-8", errors="replace").replace("\n", " ")
+            )
+    if not report.failures:
+        report.notes.append(
+            f"{len(OFFLINE_CASES)} cases over "
+            f"{len({case.picture_class for case in OFFLINE_CASES})} picture classes, "
+            f"compiled and audited against {len(staged)} flat files, with "
+            f"{len(INTERPOSED_TOOLS)} installers and fetchers shadowed and uncalled"
+        )
+    return report
+
+
+def _offline_case(case: OfflineCase, room: Path, engine: str,
+                  environment: dict[str, str], audit: Path, report: Report) -> None:
+    """Compile one case in the flat room and read what it wrote."""
+
+    source = ROOT / case.source
+    if not source.is_file():
+        report.failures.append(f"{case.source} is missing; the {case.picture_class} case has moved")
+        return
+    text = source.read_text(encoding="utf-8")
+    if case.declares not in text:
+        report.failures.append(
+            f"{case.name}: {case.source} no longer spells {case.declares!r}, so it "
+            f"is not the {case.picture_class} case this check reads"
+        )
+        return
+    job = f"tenkz-offline-{case.name}"
+    if case.document:
+        read = f"{job}.tex"
+        (room / read).write_text(text, encoding="utf-8")
+    else:
+        read = f"{job}-case.tex"
+        (room / read).write_text(text, encoding="utf-8")
+        (room / f"{job}.tex").write_text(OFFLINE_WRAPPER % read, encoding="utf-8")
+    try:
+        finished = subprocess.run(
+            [engine, "-no-shell-escape", "-interaction=nonstopmode",
+             "-halt-on-error", "-recorder", f"{job}.tex"],
+            cwd=room, env=environment, capture_output=True, text=True, timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        report.failures.append(f"{case.name} did not finish compiling within 300 seconds")
+        return
+    if finished.returncode != 0:
+        tail = "\n".join((finished.stdout + finished.stderr).splitlines()[-20:])
+        report.failures.append(
+            f"{case.name} ({case.picture_class}) failed to compile from the flat "
+            f"archive, exit {finished.returncode}:\n{tail}"
+        )
+        return
+    pdf, stream, record = (room / f"{job}.pdf", room / f"{job}.tnlog", room / f"{job}.fls")
+    if not pdf.is_file() or pdf.stat().st_size == 0:
+        report.failures.append(f"{case.name} produced no PDF")
+        return
+    if not stream.is_file() or not stream.read_text(encoding="utf-8").strip():
+        report.failures.append(f"{case.name} produced no event stream, so it drew nothing to read")
+        return
+    if not record.is_file():
+        report.failures.append(f"{case.name} wrote no input record to read")
+        return
+    opened = recorded_inputs(record)
+    strangers = [path for path in opened if (room / path).resolve().is_relative_to(ROOT)]
+    report.require(
+        not strangers,
+        f"{case.name} read {sorted(set(strangers))} from the repository, so the "
+        "flat archive did not answer for the run",
+    )
+    runtime = [path for path in opened if Path(path).name.startswith(PACKAGE)]
+    report.require(runtime, f"{case.name} opened no tenkz file, so it proved nothing")
+    report.require(
+        all((room / path).resolve().is_relative_to(room.resolve()) for path in runtime),
+        f"{case.name} resolved a runtime file outside the flat archive, so an "
+        "installed copy answered for it",
+    )
+    events = stream.read_text(encoding="utf-8")
+    report.require(
+        re.search(case.emits, events) is not None,
+        f"{case.name} compiled but its stream records no {case.picture_class} "
+        f"picture: nothing matches {case.emits!r}",
+    )
+    if case.absent:
+        report.require(
+            re.search(case.absent, events) is None,
+            f"{case.name} records {case.absent!r}, which a {case.picture_class} "
+            "picture does not write",
+        )
+    read_back = subprocess.run(
+        [sys.executable, str(audit), str(stream), str(room / read)],
+        cwd=room, capture_output=True, text=True, timeout=300,
+    )
+    if read_back.returncode != 0:
+        tail = "\n".join((read_back.stdout + read_back.stderr).splitlines()[-15:])
+        report.failures.append(f"{case.name} failed the event audit:\n{tail}")
+
+
 def release_sync(release: Release) -> list[tuple[str, str]]:
     """What each release artifact currently says about its version and date.
 
@@ -1093,6 +1558,23 @@ def command_archive(out: Path) -> int:
     return 0
 
 
+def command_offline(require_engine: bool) -> int:
+    """Build the archive and compile the picture classes against its flat."""
+
+    with tempfile.TemporaryDirectory(prefix="tenkz-ctan-offline-") as directory:
+        archive, _, _ = build(Path(directory) / "out")
+        report = check_offline(archive, require_engine)
+    print(f"  {report.status:4s} {report.name}")
+    for note in report.notes:
+        print(f"         {note}")
+    if report.skipped:
+        print(f"         skipped: {report.skipped}")
+    for failure in report.failures:
+        for line in failure.splitlines():
+            print(f"         {line}")
+    return 1 if report.failures else 0
+
+
 def command_sync() -> int:
     for artifact, state in release_sync(read_release()):
         print(f"  {artifact:28s} {state}")
@@ -1106,6 +1588,7 @@ def command_check(require_smoke: bool, keep: Path | None) -> int:
     material = check_material(manifest)
     reports = [
         check_closure(closure, manifest),
+        check_dependencies(closure, manifest),
         check_source_tree(closure, manifest),
         material,
         check_headers(closure),
@@ -1124,7 +1607,7 @@ def command_check(require_smoke: bool, keep: Path | None) -> int:
     blocked = material.failures + encoding.failures + names.failures
     digest = ""
     if blocked:
-        for name in ("permissions", "debris", "determinism", "clean-install"):
+        for name in ("permissions", "debris", "arxiv", "determinism", "clean-install", "offline"):
             skipped = Report(name)
             skipped.skipped = f"the staged material is not complete ({len(blocked)} finding(s))"
             reports.append(skipped)
@@ -1134,8 +1617,10 @@ def command_check(require_smoke: bool, keep: Path | None) -> int:
             archive, _, digest = build(destination)
             reports.append(check_permissions(destination / PACKAGE))
             reports.append(check_debris(destination / PACKAGE))
+            reports.append(check_arxiv(destination / PACKAGE))
             reports.append(check_determinism(release))
             reports.append(check_smoke(archive, require_smoke))
+            reports.append(check_offline(archive, require_smoke))
     for report in reports:
         print(f"  {report.status:4s} {report.name}")
         for note in report.notes:
@@ -1164,6 +1649,14 @@ def main(argv: list[str]) -> int:
     staging.add_argument("--out", type=Path, default=DEFAULT_OUT)
     packing = commands.add_parser("archive", help="write the tree and the archive")
     packing.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    offline = commands.add_parser(
+        "offline", help="compile the picture classes against the unpacked flat"
+    )
+    offline.add_argument(
+        "--require-engine",
+        action="store_true",
+        help="fail rather than skip when no TeX engine is installed",
+    )
     commands.add_parser("sync", help="report the release artifacts' version state")
     checking = commands.add_parser("check", help="run every acceptance check")
     checking.add_argument(
@@ -1184,6 +1677,8 @@ def main(argv: list[str]) -> int:
         return command_stage(arguments.out)
     if arguments.command == "archive":
         return command_archive(arguments.out)
+    if arguments.command == "offline":
+        return command_offline(arguments.require_engine)
     if arguments.command == "sync":
         return command_sync()
     return command_check(arguments.require_smoke, arguments.out)

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -215,6 +215,28 @@ DEPENDENCY_CLASSES = ("placement", "ink", "unconsumed")
 # only way any of these names could reach the closure.
 RETIRED_DEPENDENCIES = ("tikz-cd", "tikzcd", "quantikz")
 
+# A TikZ library vendored as a file goes by its conventional file name, and a
+# stem alone would leave `tikzlibrarytikzcd.code` bearing no resemblance to the
+# library it is. The suffixes are stripped in the order a name carries them,
+# so `tenkz-core.code.tex` reduces to `tenkz-core` and not to `tenkz-core.code`.
+TIKZ_LIBRARY_FILE = re.compile(r"^tikzlibrary(?P<library>.+)$")
+LOAD_SUFFIXES = (".code.tex", ".tex", ".sty", ".def", ".cls", ".cfg")
+
+
+def load_names(name: str) -> set[str]:
+    """Every name one loaded file could be known by."""
+
+    bare = name
+    for suffix in LOAD_SUFFIXES:
+        if bare.endswith(suffix):
+            bare = bare[: -len(suffix)]
+            break
+    names = {name, bare}
+    library = TIKZ_LIBRARY_FILE.match(bare)
+    if library is not None:
+        names.add(library["library"])
+    return names
+
 # What arXiv will not do for a source submission, expressed as the file kinds
 # whose presence would mean it has to. A `.dtx` or `.ins` pair is the usual
 # LaTeX-package shape and needs a docstrip run before the runtime exists; a
@@ -977,14 +999,13 @@ def check_dependencies(closure: Closure, manifest: dict) -> Report:
         f"{closure.libraries}",
     )
     # A retired front end can arrive as a package load, a library load, or a
-    # file the entry point inputs, and a vendored `tikz-cd.sty` reaches the
-    # closure only in the third way. The stem is what the name is compared
-    # against, since a load carries the suffix and a package name does not.
-    loaded = (
-        set(closure.packages)
-        | set(closure.libraries)
-        | {Path(name).stem for name in closure.files}
-    )
+    # file the entry point inputs, and a vendored `tikz-cd.sty` or
+    # `tikzlibrarytikzcd.code.tex` reaches the closure only in the third way.
+    # Each file is compared under every name it could be known by, since a load
+    # carries a suffix and a conventional library file carries a prefix too.
+    loaded = set(closure.packages) | set(closure.libraries)
+    for name in closure.files:
+        loaded |= load_names(name)
     survivors = sorted(name for name in RETIRED_DEPENDENCIES if name in loaded)
     report.require(
         not survivors,
@@ -1452,7 +1473,7 @@ def check_arxiv(tree: Path, closure: Closure) -> Report:
             continue
         text = strip_comments(path.read_bytes().decode("utf-8", errors="replace"))
         report.require(
-            ABSOLUTE_LOAD.search(text) is None,
+            ABSOLUTE_LOAD.search(uncontrolled(text)) is None,
             f"{path.name} loads a file by absolute path, which names the "
             "machine it was written on",
         )
@@ -1493,6 +1514,14 @@ def offline_room(archive: Path, room: Path) -> list[str]:
         if not unpacked.is_dir():
             raise SystemExit(
                 f"{archive.name} does not unpack into a single {PACKAGE}/ directory"
+            )
+        siblings = sorted(
+            path.name for path in Path(unpacking).iterdir() if path.name != PACKAGE
+        )
+        if siblings:
+            raise SystemExit(
+                f"{archive.name} unpacks {PACKAGE}/ beside {siblings}; an upload "
+                "unpacks into one directory and nothing else"
             )
         staged = sorted(path.name for path in unpacked.iterdir())
         for path in sorted(unpacked.iterdir()):

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -96,8 +96,13 @@ PAYLOAD = re.compile(
 # load, and a closure that missed it would let the manifest pin a dependency
 # list the package does not have.
 INPUT_CALL = re.compile(r"\\input\s*\{([^}]*)\}", re.DOTALL)
+# Both spellings of a package load. A `.sty` writes `\RequirePackage`, but
+# nothing stops a staged runtime file from writing `\usepackage`, and the two
+# load the same package: a closure that read only the first would let a load
+# reach an upload without reaching the pin, and would report the retired front
+# ends absent while one of them was being loaded.
 REQUIRE_CALL = re.compile(
-    r"\\RequirePackage\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}", re.DOTALL
+    r"\\(?:RequirePackage|usepackage)\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}", re.DOTALL
 )
 LIBRARY_CALL = re.compile(r"\\usetikzlibrary\s*\{([^}]*)\}", re.DOTALL)
 
@@ -209,47 +214,64 @@ RETIRED_DEPENDENCIES = ("tikz-cd", "tikzcd", "quantikz")
 REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 
 # The primitives a submission may not need, because arXiv compiles without
-# `\write18`. tenkz draws with TikZ and computes with expl3, so it calls none
-# of them; the check is what keeps that true.
+# `\write18`. tenkz writes its event stream to a file stream it allocates, and
+# calls nothing that reaches a shell; the check is what keeps that true.
 #
-# The stream is a number, not a spelling. TeX's integer scanner takes optional
-# space, leading zeros, and a `"` or `'` prefix for hexadecimal and octal, so
-# `\write 18`, `\write018`, `\write"12`, and `\write'22` all open stream 18,
-# and so does a run of signs with an even number of minuses: `\write+18` and
-# `\write--18`. The constant is therefore read and evaluated rather than
-# matched against one way of writing it. What this does not read is a stream held in a register or
-# an expl3 stream variable, which no constant search can: a submission that
-# reached the shell that way would need the run to catch it, and the offline
-# compile runs with shell escape off for exactly that reason.
-WRITE_STREAM = re.compile(
-    r"\\write(?P<signs>[\s+-]*)"
-    r"(?:\"(?P<hex>[0-9A-Fa-f]+)|'(?P<oct>[0-7]+)|(?P<dec>[0-9]+))"
+# The gate fails closed, because TeX's integer scanner accepts more spellings
+# of 18 than a pattern can enumerate: space, leading zeros, a run of signs, `"`
+# for hexadecimal and `'` for octal, a backtick character constant, `\numexpr`,
+# a register. So a `\write` is read three ways and refused if it is none of
+# them: a constant, evaluated in the base its prefix names and compared with
+# 18; a stream the same file allocated with `\newwrite` or `\iow_new:N`, which
+# is a file stream by construction and by intent; or anything else, which
+# cannot be shown not to be 18 and is a finding on that ground alone.
+WRITE_CALL = re.compile(
+    r"\\write(?![A-Za-z])(?P<signs>[\s+-]*)"
+    r"(?:\"(?P<hex>[0-9A-Fa-f]+)|'(?P<oct>[0-7]+)|(?P<dec>[0-9]+)"
+    r"|(?P<name>\\[A-Za-z@_:]+))?"
 )
+ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 SHELL_ESCAPE_NAME = re.compile(r"\\ShellEscape\b")
 SHELL_ESCAPE_STREAM = 18
 
 
 def shell_escape_call(text: str) -> str:
-    r"""The first call to the shell-escape stream in `text`, or nothing.
+    r"""What in `text` could reach a shell, named, or nothing.
 
-    Every `\write` constant is evaluated in the base its prefix names and
-    compared with 18, so the reading does not depend on how the number was
-    written.
+    A `\write` to a constant stream is read in the base its prefix names, so
+    the verdict does not depend on how the number was written, and only 18 is
+    a finding. A `\write` to a stream the same file allocated is a file stream.
+    A `\write` to anything else is a finding, because it cannot be shown not to
+    be 18.
     """
 
     named = SHELL_ESCAPE_NAME.search(text)
     if named is not None:
-        return named.group(0)
-    for found in WRITE_STREAM.finditer(text):
+        return f"{named.group(0)}, the shell-escape primitive"
+    allocated = set(ALLOCATED_STREAM.findall(text))
+    for found in WRITE_CALL.finditer(text):
+        if found["name"] is not None:
+            if found["name"] in allocated:
+                continue
+            return (
+                f"{found.group(0).strip()}, a stream this file does not allocate"
+            )
         digits, base = (
             (found["hex"], 16) if found["hex"]
             else (found["oct"], 8) if found["oct"]
-            else (found["dec"], 10)
+            else (found["dec"], 10) if found["dec"]
+            else (None, 10)
         )
+        if digits is None:
+            return (
+                f"{found.group(0).strip()}, whose stream is not a constant this "
+                "reading can evaluate"
+            )
         sign = -1 if found["signs"].count("-") % 2 else 1
         if sign * int(digits, base) == SHELL_ESCAPE_STREAM:
-            return found.group(0)
+            return f"{found.group(0)}, the shell-escape stream"
     return ""
+
 
 # An absolute path in a staged source names the machine that wrote it. The
 # pattern catches the spellings a TeX file can carry: a Unix path or a Windows

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -301,12 +301,17 @@ REDEFINED_NAME = re.compile(
 # interface. The bar is only a command in a file name, so the reading is
 # scoped to one: a bare `"|` in a macro body or in typeset documentation is
 # two characters, and refusing it would refuse a source that executes nothing.
+# The operand a stream primitive takes before its file name: a control
+# sequence or a number, with the equals sign optional, which is TeX's own
+# syntax and not a house spelling.
+STREAM_OPERAND = r"(?:\\[A-Za-z@_:]+|[0-9]+)?\s*=?\s*"
+# Only the primitives that open a file are read. `\write` and `\read` take a
+# stream that is already open and a token list that is data, so a token list
+# beginning with a bar is text and refusing it would refuse a valid release.
 PIPE_FILENAME = re.compile(
-    r"\\(?:openin|openout|input|include|read|write)\s*"
-    r"(?:\\[A-Za-z@_:]+\s*)?"
-    r"(?:=\s*)?"
-    r"(?:\{\s*)?"
-    r"\"?\s*\|"
+    r"\\(?:openin|openout|input|include)\s*"
+    + STREAM_OPERAND
+    + r"(?:\{\s*)?\"?\s*\|"
 )
 # The named ways to reach a shell that are not a write at all: the TeX
 # primitive's LaTeX name, and expl3's own shell interface, which a file under
@@ -410,7 +415,7 @@ ABSOLUTE_LOAD = re.compile(
     r"|file_if_exist:nTF)(?:\s*\*)?"
     rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
-    rf"|\\open(?:in|out)\s*(?:\\[A-Za-z@_:]+)?\s*=\s*\"?{ABSOLUTE_PATH_HEAD}"
+    rf"|\\open(?:in|out)\s*{STREAM_OPERAND}\"?{ABSOLUTE_PATH_HEAD}"
 )
 
 

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -210,8 +210,11 @@ REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 
 # The primitives a submission may not need, because arXiv compiles without
 # `\write18`. tenkz draws with TikZ and computes with expl3, so it calls none
-# of them; the check is what keeps that true.
-SHELL_ESCAPE_CALLS = (r"\write18", r"\ShellEscape", r"\immediate\write18")
+# of them; the check is what keeps that true. TeX reads a stream number as a
+# number, so `\write 18` and `\immediate \write 18` open the same stream as
+# the compact spelling, and the pattern allows the space rather than pinning
+# one way of writing it.
+SHELL_ESCAPE_CALL = re.compile(r"\\write\s*18\b|\\ShellEscape\b")
 
 # An absolute path in a staged source names the machine that wrote it. The
 # pattern catches the spellings a TeX file can carry: a Unix path or a Windows
@@ -1266,7 +1269,7 @@ def check_smoke(archive: Path, required: bool) -> Report:
     return report
 
 
-def check_arxiv(tree: Path) -> Report:
+def check_arxiv(tree: Path, closure: Closure) -> Report:
     """The staged tree read as an arXiv source submission.
 
     An upload to CTAN and a source submission to arXiv are the same files under
@@ -1276,9 +1279,18 @@ def check_arxiv(tree: Path) -> Report:
     tree has to be flat, has to be the runtime itself rather than the sources a
     runtime is generated from, has to name no path on the machine that wrote
     it, and has to call no primitive that would need a shell.
+
+    The last two are read from the closure rather than from a list of suffixes.
+    Every file the engine opens is on the load graph, whatever it is called, so
+    a runtime file added later as a class, a definition file, or a
+    configuration is scanned because it is loaded and not because somebody
+    remembered to add its suffix here. The reader-facing material is not
+    scanned: arXiv never compiles a change record, and a change record that
+    mentioned a primitive in prose would be a finding about nothing.
     """
 
     report = Report("arxiv")
+    loaded = set(closure.files)
     for path in sorted(tree.rglob("*")):
         report.require(
             not path.is_dir(),
@@ -1292,22 +1304,23 @@ def check_arxiv(tree: Path) -> Report:
             f"{path.name} would have to be run before the runtime exists, and "
             "a submission is compiled rather than built",
         )
-        if path.suffix not in {".sty", ".tex"}:
+        if path.name not in loaded:
             continue
-        text = path.read_bytes().decode("utf-8", errors="replace")
+        text = strip_comments(path.read_bytes().decode("utf-8", errors="replace"))
         report.require(
-            ABSOLUTE_LOAD.search(strip_comments(text)) is None,
+            ABSOLUTE_LOAD.search(text) is None,
             f"{path.name} loads a file by absolute path, which names the "
             "machine it was written on",
         )
-        for call in SHELL_ESCAPE_CALLS:
-            report.require(
-                call not in strip_comments(text),
-                f"{path.name} calls {call}, and a submission compiles with no shell",
-            )
+        called = SHELL_ESCAPE_CALL.search(text)
+        report.require(
+            called is None,
+            f"{path.name} calls {called.group(0) if called else ''}, and a "
+            "submission compiles with no shell",
+        )
     report.notes.append(
-        f"{len(list(tree.iterdir()))} files, one directory deep, no generated "
-        "source and no shell call"
+        f"{len(list(tree.iterdir()))} files, one directory deep; "
+        f"{len(loaded)} loaded sources read, no generated source and no shell call"
     )
     return report
 
@@ -1458,8 +1471,13 @@ def check_offline(archive: Path, required: bool) -> Report:
             report.failures.append(str(refusal))
             return report
         environment = offline_environment(room, shims, tripwire, home)
+        # The runtime the archive carries, by name, taken from the load graph
+        # rather than from a `tenkz` prefix: the documents this check writes
+        # are named from the package too, so a prefix match would count a
+        # driver file this function wrote as proof that the package answered.
+        carried = {name for name in walk_closure().files if name in set(staged)}
         for case in OFFLINE_CASES:
-            _offline_case(case, room, engine, environment, audit, report)
+            _offline_case(case, room, engine, environment, audit, carried, report)
         if tripwire.exists():
             report.failures.append(
                 "the runs reached for an installer or a fetcher: "
@@ -1476,8 +1494,13 @@ def check_offline(archive: Path, required: bool) -> Report:
 
 
 def _offline_case(case: OfflineCase, room: Path, engine: str,
-                  environment: dict[str, str], audit: Path, report: Report) -> None:
-    """Compile one case in the flat room and read what it wrote."""
+                  environment: dict[str, str], audit: Path, carried: set[str],
+                  report: Report) -> None:
+    """Compile one case in the flat room and read what it wrote.
+
+    `carried` is the runtime the archive holds, by name, and it is what a
+    record line is read against.
+    """
 
     source = ROOT / case.source
     if not source.is_file():
@@ -1532,8 +1555,12 @@ def _offline_case(case: OfflineCase, room: Path, engine: str,
         f"{case.name} read {sorted(set(strangers))} from the repository, so the "
         "flat archive did not answer for the run",
     )
-    runtime = [path for path in opened if Path(path).name.startswith(PACKAGE)]
-    report.require(runtime, f"{case.name} opened no tenkz file, so it proved nothing")
+    runtime = [path for path in opened if Path(path).name in carried]
+    report.require(
+        runtime,
+        f"{case.name} opened none of the archive's runtime files, so it proved "
+        "nothing about them",
+    )
     report.require(
         not foreign_runtime_files(runtime, room, flat),
         f"{case.name} resolved a runtime file outside the flat archive, so an "
@@ -1551,10 +1578,16 @@ def _offline_case(case: OfflineCase, room: Path, engine: str,
             f"{case.name} records {case.absent!r}, which a {case.picture_class} "
             "picture does not write",
         )
-    read_back = subprocess.run(
-        [sys.executable, str(audit), str(stream), str(room / read)],
-        cwd=room, capture_output=True, text=True, timeout=300,
-    )
+    try:
+        read_back = subprocess.run(
+            [sys.executable, str(audit), str(stream), str(room / read)],
+            cwd=room, capture_output=True, text=True, timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        report.failures.append(
+            f"{case.name}: the event audit did not finish within 300 seconds"
+        )
+        return
     if read_back.returncode != 0:
         tail = "\n".join((read_back.stdout + read_back.stderr).splitlines()[-15:])
         report.failures.append(f"{case.name} failed the event audit:\n{tail}")
@@ -1683,7 +1716,7 @@ def command_check(require_smoke: bool, keep: Path | None) -> int:
             archive, _, digest = build(destination)
             reports.append(check_permissions(destination / PACKAGE))
             reports.append(check_debris(destination / PACKAGE))
-            reports.append(check_arxiv(destination / PACKAGE))
+            reports.append(check_arxiv(destination / PACKAGE, closure))
             reports.append(check_determinism(release))
             reports.append(check_smoke(archive, require_smoke))
             reports.append(check_offline(archive, require_smoke))

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -95,7 +95,9 @@ PAYLOAD = re.compile(
 # its arguments, so the patterns allow it too: `\RequirePackage {tikz}` is a
 # load, and a closure that missed it would let the manifest pin a dependency
 # list the package does not have.
-# Every spelling of an input, expl3's `\file_input:n` among them. The braced
+# Every spelling of an input, the conditional loaders and expl3's own among
+# them: a file loaded only when it exists is still a file the upload has to
+# carry, and a walk that skipped it would let an installed copy answer. The braced
 # one is tried first, then Web2C's
 # quoted form, which is how a name holding a space is written and which may
 # follow the control word with no space at all, then the bare one, which reads
@@ -104,7 +106,8 @@ PAYLOAD = re.compile(
 # A walk that read one spelling would let a stage module, or a package, reach
 # an upload without reaching the pin.
 INPUT_CALL = re.compile(
-    r"\\(?:input|file_input:n)\s*\{\s*\"?([^}\"]*?)\"?\s*\}"
+    r"\\(?:input|InputIfFileExists|file_input:n|file_if_exist_input:[a-zA-Z]+)"
+    r"\s*\{\s*\"?([^}\"]*?)\"?\s*\}"
     r"|\\input\s*\"([^\"]+)\""
     r"|\\input\s+([^\s{}\\%\"]+)",
     re.DOTALL,
@@ -446,9 +449,10 @@ ABSOLUTE_LOAD = re.compile(
     rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\{{?\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\open(?:in|out)\s*{STREAM_OPERAND}\"?{ABSOLUTE_PATH_HEAD}"
-    r"|\\(?:ior_open:Nn|iow_open:Nn|file_get:nnN|file_get_full_name:nN"
-    r"|file_if_exist_input:n)\s*(?:\\[A-Za-z@_:]+\s*)?"
+    r"|\\(?:ior_open|iow_open|file_get|file_get_full_name"
+    r"|file_if_exist_input):[a-zA-Z]+\s*(?:\\[A-Za-z@_:]+\s*)?"
     rf"\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
+    rf"|\\font\s*{STREAM_OPERAND}\"?{ABSOLUTE_PATH_HEAD}"
 )
 
 

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -246,9 +246,16 @@ WRITE_CALL = re.compile(
 ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 # The named ways to reach a shell that are not a write at all: the TeX
 # primitive's LaTeX name, and expl3's own shell interface, which a file under
-# `\ExplSyntaxOn` would use in preference to either.
+# `\ExplSyntaxOn` would use in preference to either. The expl3 names are the
+# ones its source defines, `\sys_shell_now:n`, `\sys_shell_shipout:n`,
+# `\sys_get_shell:nnN`, `\ior_shell_open:Nn`, `\iow_shell_open:Nn`, and the
+# primitive alias `\tex_shellescape:D`, read from `l3kernel` rather than
+# recalled, because a name invented here would be a gate that looks closed.
 SHELL_ESCAPE_NAME = re.compile(
-    r"\\ShellEscape\b|\\sys_(?:shell_(?:now|shipout|open)|get_shell):[a-zA-Z]*"
+    r"\\ShellEscape\b"
+    r"|\\sys_(?:shell_(?:now|shipout)|get_shell):[a-zA-Z]*"
+    r"|\\(?:ior|iow)_shell_open:[a-zA-Z]*"
+    r"|\\tex_shellescape:D"
 )
 SHELL_ESCAPE_STREAM = 18
 

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -95,13 +95,18 @@ PAYLOAD = re.compile(
 # its arguments, so the patterns allow it too: `\RequirePackage {tikz}` is a
 # load, and a closure that missed it would let the manifest pin a dependency
 # list the package does not have.
-# Both of plain TeX's spellings. The braced one is tried first; the unbraced
-# one reads to the next space, as TeX does, and stops at a brace, a comment, or
-# a control sequence rather than guessing past one. A walk that read only the
-# braced form would let a stage module, or a package, reach an upload without
-# reaching the pin.
+# Every spelling of an input. The braced one is tried first, then Web2C's
+# quoted form, which is how a name holding a space is written and which may
+# follow the control word with no space at all, then the bare one, which reads
+# to the next space as TeX does and stops at a brace, a comment, or a control
+# sequence rather than guessing past one. Quotes are stripped from the name.
+# A walk that read one spelling would let a stage module, or a package, reach
+# an upload without reaching the pin.
 INPUT_CALL = re.compile(
-    r"\\input\s*\{([^}]*)\}|\\input\s+([^\s{}\\%]+)", re.DOTALL
+    r"\\input\s*\{\s*\"?([^}\"]*?)\"?\s*\}"
+    r"|\\input\s*\"([^\"]+)\""
+    r"|\\input\s+([^\s{}\\%\"]+)",
+    re.DOTALL,
 )
 # Every spelling of a package load. A `.sty` writes `\RequirePackage`, but
 # nothing stops a staged runtime file from writing `\usepackage` or
@@ -261,8 +266,9 @@ REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 # a register. So a `\write` is read three ways and refused if it is none of
 # them: a constant, evaluated in the base its prefix names and compared with
 # 18; a stream the same file allocated with `\newwrite` or `\iow_new:N`, which
-# is a file stream by construction and by intent; or anything else, which
-# cannot be shown not to be 18 and is a finding on that ground alone.
+# is a file stream by construction and by intent, unless the same file also
+# redefines the name; or anything else, which cannot be shown not to be 18 and
+# is a finding on that ground alone.
 #
 # The boundary after `write` excludes `@` and, for a file under
 # `\ExplSyntaxOn`, `_` and `:`, because those are letters there: `\write@event`
@@ -281,11 +287,27 @@ WRITE_CALL = re.compile(
     r"|(?P<name>\\[A-Za-z@_:]+))?"
 )
 ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
-# Web2C reads a file name opening with a pipe as a command to run, so
-# `\openin\stream="|uname -a"` reaches a shell without naming a stream or an
-# API. The quote is what marks it as a file name to the engine, and nothing in
-# a tensor-diagram package has a reason to write one.
-PIPE_FILENAME = re.compile(r"\"\s*\|")
+# A control sequence the same file also redefines is no longer the stream it
+# was allocated as: `\newwrite\out \def\out{18} \write\out{...}` reaches the
+# shell through a name the allocation vouched for. Reading order is beyond a
+# text scan, so an allocated name that is redefined anywhere in the file loses
+# the allocation ground and is refused with every other unreadable stream.
+REDEFINED_NAME = re.compile(
+    r"\\(?:def|edef|gdef|xdef|let|cs_set[a-z_]*:Npn|cs_new[a-z_]*:Npn)"
+    r"\s*(\\[A-Za-z@_:]+)"
+)
+# Web2C reads a file name whose first character is a bar as a command to run,
+# so `\openin\stream="|uname -a"` reaches a shell without naming a stream or an
+# interface. The bar is only a command in a file name, so the reading is
+# scoped to one: a bare `"|` in a macro body or in typeset documentation is
+# two characters, and refusing it would refuse a source that executes nothing.
+PIPE_FILENAME = re.compile(
+    r"\\(?:openin|openout|input|include|read|write)\s*"
+    r"(?:\\[A-Za-z@_:]+\s*)?"
+    r"(?:=\s*)?"
+    r"(?:\{\s*)?"
+    r"\"?\s*\|"
+)
 # The named ways to reach a shell that are not a write at all: the TeX
 # primitive's LaTeX name, and expl3's own shell interface, which a file under
 # `\ExplSyntaxOn` would use in preference to either. The expl3 names are the
@@ -344,7 +366,9 @@ def shell_escape_call(text: str) -> str:
             f'{text[piped.start():piped.end()]}, a file name opening a pipe, '
             "which the engine runs as a command"
         )
-    allocated = set(ALLOCATED_STREAM.findall(scanned))
+    allocated = set(ALLOCATED_STREAM.findall(scanned)) - set(
+        REDEFINED_NAME.findall(scanned)
+    )
     for found in WRITE_CALL.finditer(scanned):
         call = text[found.start():found.end()]
         if found["name"] is not None:
@@ -386,6 +410,7 @@ ABSOLUTE_LOAD = re.compile(
     r"|file_if_exist:nTF)(?:\s*\*)?"
     rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
+    rf"|\\open(?:in|out)\s*(?:\\[A-Za-z@_:]+)?\s*=\s*\"?{ABSOLUTE_PATH_HEAD}"
 )
 
 
@@ -464,10 +489,12 @@ OFFLINE_CASES = (
 
 # The document an author writes around a preamble-free case. It names the case
 # by its flat basename, which is what the submission would look like. The
-# preamble is the corpus driver's without `mathtools`, which none of the cases
-# below calls: the check is of tenkz, so it asks the environment for nothing
-# beyond what tenkz and the mathematics around it need.
-OFFLINE_WRAPPER = r"""\documentclass[border=8pt,varwidth=270mm]{standalone}
+# preamble asks the environment for nothing beyond what the README declares an
+# installation must have. It is `article` rather than the corpus driver's
+# `standalone`, and it drops `mathtools`, which none of the cases below calls:
+# a gate that failed on a minimal installation would be reporting on the
+# installation rather than on the archive.
+OFFLINE_WRAPPER = r"""\documentclass{article}
 \usepackage{amsmath,amssymb}
 \usepackage{tenkz}
 \begin{document}
@@ -581,8 +608,8 @@ def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
             packages.extend(part.strip() for part in group.split(",") if part.strip())
         for group in LIBRARY_CALL.findall(text):
             libraries.extend(part.strip() for part in group.split(",") if part.strip())
-        for braced, unbraced in INPUT_CALL.findall(text):
-            visit((braced or unbraced).strip())
+        for braced, quoted, bare in INPUT_CALL.findall(text):
+            visit((braced or quoted or bare).strip())
 
     visit(entry)
     closure.packages = sorted(set(packages))

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -1399,6 +1399,25 @@ def recorded_inputs(record: Path) -> list[str]:
     ]
 
 
+def repository_inputs(opened: list[str], room: Path, flat: Path) -> list[str]:
+    """Those of the opened files that came from the repository, not the flat.
+
+    The room is the base a relative record line resolves against, and it is
+    also the one directory a file may legitimately come from besides the
+    installation. It is subtracted before the repository is read, because a
+    temporary directory is placed wherever `TMPDIR` says, and a runner that
+    put it inside the workspace would otherwise make every file the archive
+    itself answered look like one the repository did.
+    """
+
+    return [
+        path
+        for path in opened
+        if not (room / path).resolve().is_relative_to(flat)
+        and (room / path).resolve().is_relative_to(ROOT)
+    ]
+
+
 def check_offline(archive: Path, required: bool) -> Report:
     """Compile one case of every picture class against the unpacked flat.
 
@@ -1506,17 +1525,8 @@ def _offline_case(case: OfflineCase, room: Path, engine: str,
         report.failures.append(f"{case.name} wrote no input record to read")
         return
     opened = recorded_inputs(record)
-    # The room is the base a relative record line resolves against, and it is
-    # also the one directory a file may legitimately come from besides the
-    # installation. It is excluded before the repository is read, because a
-    # temporary directory is placed wherever `TMPDIR` says, and a runner that
-    # puts it inside the workspace would otherwise make every file the archive
-    # itself answered look like one the repository did.
     flat = room.resolve()
-    elsewhere = [
-        path for path in opened if not (room / path).resolve().is_relative_to(flat)
-    ]
-    strangers = [path for path in elsewhere if (room / path).resolve().is_relative_to(ROOT)]
+    strangers = repository_inputs(opened, room, flat)
     report.require(
         not strangers,
         f"{case.name} read {sorted(set(strangers))} from the repository, so the "

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -212,7 +212,9 @@ RETIRED_DEPENDENCIES = ("tikz-cd", "tikzcd", "quantikz")
 # whose presence would mean it has to. A `.dtx` or `.ins` pair is the usual
 # LaTeX-package shape and needs a docstrip run before the runtime exists; a
 # `.fmt` or a `.mf` needs the format or the font built. tenkz stages its
-# runtime as the files the engine reads, so none of these may be staged.
+# runtime as the files the engine reads, so none of these may be staged. The
+# comparison lowers the suffix first: a file system that preserves case will
+# hand back `tenkz.INS`, and docstrip does not care which way it was typed.
 REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 
 # The primitives a submission may not need, because arXiv compiles without
@@ -248,14 +250,15 @@ ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 # primitive's LaTeX name, and expl3's own shell interface, which a file under
 # `\ExplSyntaxOn` would use in preference to either. The expl3 names are the
 # ones its source defines, `\sys_shell_now:n`, `\sys_shell_shipout:n`,
-# `\sys_get_shell:nnN`, `\ior_shell_open:Nn`, `\iow_shell_open:Nn`, and the
-# primitive alias `\tex_shellescape:D`, read from `l3kernel` rather than
-# recalled, because a name invented here would be a gate that looks closed.
+# `\sys_get_shell:nnN`, `\ior_shell_open:Nn`, and `\iow_shell_open:Nn`, read
+# from `l3kernel` rather than recalled, because a name invented here would be a
+# gate that looks closed. Only executors are named: `\tex_shellescape:D` and
+# `\sys_if_shell:TF` report whether the engine has a shell and run nothing, so
+# reading them as calls would refuse a file for asking a question.
 SHELL_ESCAPE_NAME = re.compile(
     r"\\ShellEscape\b"
     r"|\\sys_(?:shell_(?:now|shipout)|get_shell):[a-zA-Z]*"
     r"|\\(?:ior|iow)_shell_open:[a-zA-Z]*"
-    r"|\\tex_shellescape:D"
 )
 SHELL_ESCAPE_STREAM = 18
 
@@ -303,7 +306,9 @@ def shell_escape_call(text: str) -> str:
 # drive letter opening a braced load argument, with the star a starred form
 # such as `\includegraphics*` puts before its arguments and the space LaTeX's
 # star test skips before it, and the same two opening `\input` unbraced, which
-# is plain TeX's own syntax and reads to the next space. The loader list is
+# is plain TeX's own syntax and reads to the next space. Either spelling may
+# open with a quote, which is how a path holding a space is written. The
+# loader list is
 # every one the LaTeX kernel defines that takes a file name, conditional ones
 # included: a runtime whose behaviour depends on a machine-local file is not
 # submittable even when the file's absence is handled.
@@ -311,7 +316,7 @@ ABSOLUTE_PATH_HEAD = r"(?:/|[A-Za-z]:[\\/])"
 ABSOLUTE_LOAD = re.compile(
     r"\\(?:input|include|usepackage|RequirePackageWithOptions|RequirePackage"
     r"|InputIfFileExists|includegraphics)(?:\s*\*)?"
-    rf"\s*(?:\[[^]]*\]\s*)?\{{\s*{ABSOLUTE_PATH_HEAD}"
+    rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
 )
 
@@ -1251,6 +1256,16 @@ def check_determinism(release: Release) -> Report:
     return report
 
 
+def recorded_inputs(record: Path) -> list[str]:
+    """Every file the engine opened, from its input record."""
+
+    return [
+        line[len("INPUT "):].strip()
+        for line in record.read_text(encoding="utf-8", errors="replace").splitlines()
+        if line.startswith("INPUT ")
+    ]
+
+
 def resolved_runtime_files(record: Path) -> list[str]:
     """The runtime files the engine actually opened, from its input record.
 
@@ -1263,14 +1278,11 @@ def resolved_runtime_files(record: Path) -> list[str]:
     exit status, says where the runtime came from.
     """
 
-    opened: list[str] = []
-    for line in record.read_text(encoding="utf-8", errors="replace").splitlines():
-        if not line.startswith("INPUT "):
-            continue
-        path = line[len("INPUT "):].strip()
-        if Path(path).name.startswith(PACKAGE):
-            opened.append(path)
-    return opened
+    return [
+        path
+        for path in recorded_inputs(record)
+        if Path(path).name.startswith(PACKAGE)
+    ]
 
 
 def foreign_runtime_files(opened: list[str], room: Path, unpacked: Path) -> list[str]:
@@ -1388,7 +1400,7 @@ def check_arxiv(tree: Path, closure: Closure) -> Report:
         if path.is_dir():
             continue
         report.require(
-            path.suffix not in REGENERATED_SUFFIXES,
+            path.suffix.lower() not in REGENERATED_SUFFIXES,
             f"{path.name} would have to be run before the runtime exists, and "
             "a submission is compiled rather than built",
         )
@@ -1492,16 +1504,6 @@ def write_shims(shims: Path) -> None:
         shim = shims / tool
         shim.write_text(TRIPWIRE, encoding="utf-8")
         shim.chmod(0o755)
-
-
-def recorded_inputs(record: Path) -> list[str]:
-    """Every file the engine opened, from its input record."""
-
-    return [
-        line[len("INPUT "):].strip()
-        for line in record.read_text(encoding="utf-8", errors="replace").splitlines()
-        if line.startswith("INPUT ")
-    ]
 
 
 def carried_runtime() -> set[str]:

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -248,7 +248,8 @@ REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 # recognizable is matched and the rest is out of scope, stated here rather
 # than implied by silence.
 WRITE_CALL = re.compile(
-    r"(?:\\write|\\csname\s*write\s*\\endcsname)(?![A-Za-z@_:])(?P<signs>[\s+-]*)"
+    r"(?<!\\)(?:\\write|\\csname\s*write\s*\\endcsname)"
+    r"(?![A-Za-z@_:])(?P<signs>[\s+-]*)"
     r"(?:\"(?P<hex>[0-9A-Fa-f]+)|'(?P<oct>[0-7]+)|(?P<dec>[0-9]+)"
     r"|(?P<name>\\[A-Za-z@_:]+))?"
 )
@@ -263,12 +264,16 @@ ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 # gate that looks closed. Only executors are named: `\tex_shellescape:D` and
 # `\sys_if_shell:TF` report whether the engine has a shell and run nothing, so
 # reading them as calls would refuse a file for asking a question.
-# The boundary is the one `WRITE_CALL` uses, for the same reason: `@` is a
+# The lookbehind is the other half of reading a control sequence: `\\write18`
+# is the control symbol `\\` followed by ordinary characters, not the
+# primitive, and a gate that read it as one would refuse a package for
+# typesetting the spelling. The boundary after the name is the one `WRITE_CALL`
+# uses, for the same reason: `@` is a
 # letter in a package and `_` and `:` are letters under `\ExplSyntaxOn`, so
 # `\ShellEscape@status` and `\sys_shell_now:n_aux` are control words of their
 # own and refusing them would block a shell-free release over a name.
 SHELL_ESCAPE_NAME = re.compile(
-    r"(?:\\(?:Delayed)?ShellEscape"
+    r"(?<!\\)(?:\\(?:Delayed)?ShellEscape"
     r"|\\sys_(?:shell_(?:now|shipout)|get_shell):[a-zA-Z]*"
     r"|\\(?:ior|iow)_shell_open:[a-zA-Z]*)"
     r"(?![A-Za-z@_:])"
@@ -957,7 +962,15 @@ def check_dependencies(closure: Closure, manifest: dict) -> Report:
         f"the classification covers {filed}, and {ENTRY.name} loads "
         f"{closure.libraries}",
     )
-    loaded = set(closure.packages) | set(closure.libraries)
+    # A retired front end can arrive as a package load, a library load, or a
+    # file the entry point inputs, and a vendored `tikz-cd.sty` reaches the
+    # closure only in the third way. The stem is what the name is compared
+    # against, since a load carries the suffix and a package name does not.
+    loaded = (
+        set(closure.packages)
+        | set(closure.libraries)
+        | {Path(name).stem for name in closure.files}
+    )
     survivors = sorted(name for name in RETIRED_DEPENDENCIES if name in loaded)
     report.require(
         not survivors,

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -95,7 +95,14 @@ PAYLOAD = re.compile(
 # its arguments, so the patterns allow it too: `\RequirePackage {tikz}` is a
 # load, and a closure that missed it would let the manifest pin a dependency
 # list the package does not have.
-INPUT_CALL = re.compile(r"\\input\s*\{([^}]*)\}", re.DOTALL)
+# Both of plain TeX's spellings. The braced one is tried first; the unbraced
+# one reads to the next space, as TeX does, and stops at a brace, a comment, or
+# a control sequence rather than guessing past one. A walk that read only the
+# braced form would let a stage module, or a package, reach an upload without
+# reaching the pin.
+INPUT_CALL = re.compile(
+    r"\\input\s*\{([^}]*)\}|\\input\s+([^\s{}\\%]+)", re.DOTALL
+)
 # Every spelling of a package load. A `.sty` writes `\RequirePackage`, but
 # nothing stops a staged runtime file from writing `\usepackage` or
 # `\RequirePackageWithOptions`, and they load the same package. A closure that
@@ -250,15 +257,21 @@ ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 # primitive's LaTeX name, and expl3's own shell interface, which a file under
 # `\ExplSyntaxOn` would use in preference to either. The expl3 names are the
 # ones its source defines, `\sys_shell_now:n`, `\sys_shell_shipout:n`,
-# `\sys_get_shell:nnN`, `\ior_shell_open:Nn`, and `\iow_shell_open:Nn`, read
+# `\sys_get_shell:nnN`, `\ior_shell_open:Nn`, and `\iow_shell_open:Nn`, with
+# shellesc's `\DelayedShellEscape` beside its `\ShellEscape`, read
 # from `l3kernel` rather than recalled, because a name invented here would be a
 # gate that looks closed. Only executors are named: `\tex_shellescape:D` and
 # `\sys_if_shell:TF` report whether the engine has a shell and run nothing, so
 # reading them as calls would refuse a file for asking a question.
+# The boundary is the one `WRITE_CALL` uses, for the same reason: `@` is a
+# letter in a package and `_` and `:` are letters under `\ExplSyntaxOn`, so
+# `\ShellEscape@status` and `\sys_shell_now:n_aux` are control words of their
+# own and refusing them would block a shell-free release over a name.
 SHELL_ESCAPE_NAME = re.compile(
-    r"\\ShellEscape\b"
+    r"(?:\\(?:Delayed)?ShellEscape"
     r"|\\sys_(?:shell_(?:now|shipout)|get_shell):[a-zA-Z]*"
-    r"|\\(?:ior|iow)_shell_open:[a-zA-Z]*"
+    r"|\\(?:ior|iow)_shell_open:[a-zA-Z]*)"
+    r"(?![A-Za-z@_:])"
 )
 SHELL_ESCAPE_STREAM = 18
 
@@ -315,7 +328,7 @@ def shell_escape_call(text: str) -> str:
 ABSOLUTE_PATH_HEAD = r"(?:/|[A-Za-z]:[\\/])"
 ABSOLUTE_LOAD = re.compile(
     r"\\(?:input|include|usepackage|RequirePackageWithOptions|RequirePackage"
-    r"|InputIfFileExists|includegraphics)(?:\s*\*)?"
+    r"|InputIfFileExists|IfFileExists|includegraphics)(?:\s*\*)?"
     rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
 )
@@ -508,8 +521,8 @@ def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
             packages.extend(part.strip() for part in group.split(",") if part.strip())
         for group in LIBRARY_CALL.findall(text):
             libraries.extend(part.strip() for part in group.split(",") if part.strip())
-        for target in INPUT_CALL.findall(text):
-            visit(target.strip())
+        for braced, unbraced in INPUT_CALL.findall(text):
+            visit((braced or unbraced).strip())
 
     visit(entry)
     closure.packages = sorted(set(packages))

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -214,14 +214,16 @@ REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 #
 # The stream is a number, not a spelling. TeX's integer scanner takes optional
 # space, leading zeros, and a `"` or `'` prefix for hexadecimal and octal, so
-# `\write 18`, `\write018`, `\write"12`, and `\write'22` all open stream 18.
-# The constant is therefore read and evaluated rather than matched against one
-# way of writing it. What this does not read is a stream held in a register or
+# `\write 18`, `\write018`, `\write"12`, and `\write'22` all open stream 18,
+# and so does a run of signs with an even number of minuses: `\write+18` and
+# `\write--18`. The constant is therefore read and evaluated rather than
+# matched against one way of writing it. What this does not read is a stream held in a register or
 # an expl3 stream variable, which no constant search can: a submission that
 # reached the shell that way would need the run to catch it, and the offline
 # compile runs with shell escape off for exactly that reason.
 WRITE_STREAM = re.compile(
-    r"\\write\s*(?:\"(?P<hex>[0-9A-Fa-f]+)|'(?P<oct>[0-7]+)|(?P<dec>[0-9]+))"
+    r"\\write(?P<signs>[\s+-]*)"
+    r"(?:\"(?P<hex>[0-9A-Fa-f]+)|'(?P<oct>[0-7]+)|(?P<dec>[0-9]+))"
 )
 SHELL_ESCAPE_NAME = re.compile(r"\\ShellEscape\b")
 SHELL_ESCAPE_STREAM = 18
@@ -244,7 +246,8 @@ def shell_escape_call(text: str) -> str:
             else (found["oct"], 8) if found["oct"]
             else (found["dec"], 10)
         )
-        if int(digits, base) == SHELL_ESCAPE_STREAM:
+        sign = -1 if found["signs"].count("-") % 2 else 1
+        if sign * int(digits, base) == SHELL_ESCAPE_STREAM:
             return found.group(0)
     return ""
 
@@ -1448,6 +1451,23 @@ def recorded_inputs(record: Path) -> list[str]:
     ]
 
 
+def carried_runtime() -> set[str]:
+    """The runtime file names a record line is read against.
+
+    It comes from the load graph rather than from a `tenkz` prefix, because the
+    documents the offline check writes are named from the package too and a
+    prefix match would count one of them as proof that the package answered.
+
+    It is deliberately not narrowed to what the archive staged. A runtime file
+    the archive forgot has to stay in the reading: an installed copy answering
+    for it resolves outside the room, and dropping the name is what would hide
+    that. The archive's own completeness is the closure check's question, and
+    it is asked there.
+    """
+
+    return set(walk_closure().files)
+
+
 def repository_inputs(opened: list[str], room: Path, flat: Path) -> list[str]:
     """Those of the opened files that came from the repository, not the flat.
 
@@ -1507,14 +1527,7 @@ def check_offline(archive: Path, required: bool) -> Report:
             report.failures.append(str(refusal))
             return report
         environment = offline_environment(room, shims, tripwire, home)
-        # The runtime the entry point loads, by name. It comes from the load
-        # graph rather than from a `tenkz` prefix, because the documents this
-        # check writes are named from the package too and a prefix match would
-        # count one of them as proof that the package answered. It is not
-        # narrowed to what the archive staged either: a file the archive forgot
-        # has to stay in the reading, or an installed copy answering for it
-        # would resolve outside the room and never be looked at.
-        carried = set(walk_closure().files)
+        carried = carried_runtime()
         for case in OFFLINE_CASES:
             _offline_case(case, room, engine, environment, audit, carried, report)
         if tripwire.exists():

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -291,12 +291,16 @@ ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 # A control sequence the same file also redefines is no longer the stream it
 # was allocated as: `\newwrite\out \def\out{18} \write\out{...}` reaches the
 # shell through a name the allocation vouched for, and so does `\chardef\out=18`
-# and every other primitive that binds a constant. Reading order is beyond a
+# and every other primitive that binds a constant. Only the forms that bind
+# are read: `\cs_if_exist:NTF` and `\cs_show:N` ask about a name and leave it
+# alone, and taking the allocation ground away for a question asked would
+# refuse a release for looking. Reading order is beyond a
 # text scan, so an allocated name that is redefined anywhere in the file loses
 # the allocation ground and is refused with every other unreadable stream.
 REDEFINED_NAME = re.compile(
     r"\\(?:def|edef|gdef|xdef|let|chardef|mathchardef|countdef|dimendef"
-    r"|toksdef|skipdef|muskipdef|cs_[a-z_]*:N[a-zA-Z]*)"
+    r"|toksdef|skipdef|muskipdef"
+    r"|cs_(?:new|set|gset|gnew|undefine)[a-z_]*:N[a-zA-Z]*)"
     r"\s*(\\[A-Za-z@_:]+)"
 )
 # Web2C reads a file name whose first character is a bar as a command to run,
@@ -442,6 +446,9 @@ ABSOLUTE_LOAD = re.compile(
     rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\{{?\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\open(?:in|out)\s*{STREAM_OPERAND}\"?{ABSOLUTE_PATH_HEAD}"
+    r"|\\(?:ior_open:Nn|iow_open:Nn|file_get:nnN|file_get_full_name:nN"
+    r"|file_if_exist_input:n)\s*(?:\\[A-Za-z@_:]+\s*)?"
+    rf"\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
 )
 
 

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -289,11 +289,13 @@ WRITE_CALL = re.compile(
 ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 # A control sequence the same file also redefines is no longer the stream it
 # was allocated as: `\newwrite\out \def\out{18} \write\out{...}` reaches the
-# shell through a name the allocation vouched for. Reading order is beyond a
+# shell through a name the allocation vouched for, and so does `\chardef\out=18`
+# and every other primitive that binds a constant. Reading order is beyond a
 # text scan, so an allocated name that is redefined anywhere in the file loses
 # the allocation ground and is refused with every other unreadable stream.
 REDEFINED_NAME = re.compile(
-    r"\\(?:def|edef|gdef|xdef|let|cs_set[a-z_]*:Npn|cs_new[a-z_]*:Npn)"
+    r"\\(?:def|edef|gdef|xdef|let|chardef|mathchardef|countdef|dimendef"
+    r"|toksdef|skipdef|muskipdef|cs_set[a-z_]*:Npn|cs_new[a-z_]*:Npn)"
     r"\s*(\\[A-Za-z@_:]+)"
 )
 # Web2C reads a file name whose first character is a bar as a command to run,
@@ -412,8 +414,8 @@ ABSOLUTE_PATH_HEAD = r"(?:/|[A-Za-z]:[\\/])"
 ABSOLUTE_LOAD = re.compile(
     r"\\(?:input|include|usepackage|RequirePackageWithOptions|RequirePackage"
     r"|InputIfFileExists|IfFileExists|includegraphics|file_input:n"
-    r"|file_if_exist:nTF)(?:\s*\*)?"
-    rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
+    r"|file_if_exist:nTF|graphicspath)(?:\s*\*)?"
+    rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\{{?\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\open(?:in|out)\s*{STREAM_OPERAND}\"?{ABSOLUTE_PATH_HEAD}"
 )

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -95,7 +95,8 @@ PAYLOAD = re.compile(
 # its arguments, so the patterns allow it too: `\RequirePackage {tikz}` is a
 # load, and a closure that missed it would let the manifest pin a dependency
 # list the package does not have.
-# Every spelling of an input. The braced one is tried first, then Web2C's
+# Every spelling of an input, expl3's `\file_input:n` among them. The braced
+# one is tried first, then Web2C's
 # quoted form, which is how a name holding a space is written and which may
 # follow the control word with no space at all, then the bare one, which reads
 # to the next space as TeX does and stops at a brace, a comment, or a control
@@ -103,7 +104,7 @@ PAYLOAD = re.compile(
 # A walk that read one spelling would let a stage module, or a package, reach
 # an upload without reaching the pin.
 INPUT_CALL = re.compile(
-    r"\\input\s*\{\s*\"?([^}\"]*?)\"?\s*\}"
+    r"\\(?:input|file_input:n)\s*\{\s*\"?([^}\"]*?)\"?\s*\}"
     r"|\\input\s*\"([^\"]+)\""
     r"|\\input\s+([^\s{}\\%\"]+)",
     re.DOTALL,
@@ -295,7 +296,7 @@ ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 # the allocation ground and is refused with every other unreadable stream.
 REDEFINED_NAME = re.compile(
     r"\\(?:def|edef|gdef|xdef|let|chardef|mathchardef|countdef|dimendef"
-    r"|toksdef|skipdef|muskipdef|cs_set[a-z_]*:Npn|cs_new[a-z_]*:Npn)"
+    r"|toksdef|skipdef|muskipdef|cs_[a-z_]*:N[a-zA-Z]*)"
     r"\s*(\\[A-Za-z@_:]+)"
 )
 # Web2C reads a file name whose first character is a bar as a command to run,
@@ -337,6 +338,24 @@ SHELL_ESCAPE_NAME = re.compile(
     r"(?![A-Za-z@_:])"
 )
 SHELL_ESCAPE_STREAM = 18
+
+
+def absolute_load(text: str) -> str:
+    """The first load in `text` naming an absolute path, or nothing.
+
+    `\\graphicspath` is read separately because its argument is a list: the
+    pattern that reads a single load would see only the first directory, and
+    an absolute second one names the machine just as loudly.
+    """
+
+    found = ABSOLUTE_LOAD.search(text)
+    if found is not None:
+        return found.group(0)
+    for declaration in GRAPHICS_PATH.finditer(text):
+        for directory in GRAPHICS_DIRECTORY.findall(declaration.group(1)):
+            if re.match(ABSOLUTE_PATH_HEAD, directory.strip().strip('"')):
+                return f"\\graphicspath entry {directory.strip()}"
+    return ""
 
 
 def uncontrolled(text: str) -> str:
@@ -411,6 +430,11 @@ def shell_escape_call(text: str) -> str:
 # included: a runtime whose behaviour depends on a machine-local file is not
 # submittable even when the file's absence is handled.
 ABSOLUTE_PATH_HEAD = r"(?:/|[A-Za-z]:[\\/])"
+# `\graphicspath` takes a brace group of brace groups and every one of them is
+# a directory a later image load resolves against, so the declaration is read
+# whole rather than through its first entry.
+GRAPHICS_PATH = re.compile(r"\\graphicspath\s*\{((?:\s*\{[^{}]*\}\s*)+)\}")
+GRAPHICS_DIRECTORY = re.compile(r"\{\s*\"?\s*([^{}]*)\}")
 ABSOLUTE_LOAD = re.compile(
     r"\\(?:input|include|usepackage|RequirePackageWithOptions|RequirePackage"
     r"|InputIfFileExists|IfFileExists|includegraphics|file_input:n"
@@ -1526,7 +1550,7 @@ def check_arxiv(tree: Path, closure: Closure) -> Report:
             continue
         text = strip_comments(path.read_bytes().decode("utf-8", errors="replace"))
         report.require(
-            ABSOLUTE_LOAD.search(uncontrolled(text)) is None,
+            not absolute_load(uncontrolled(text)),
             f"{path.name} loads a file by absolute path, which names the "
             "machine it was written on",
         )

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -210,11 +210,43 @@ REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 
 # The primitives a submission may not need, because arXiv compiles without
 # `\write18`. tenkz draws with TikZ and computes with expl3, so it calls none
-# of them; the check is what keeps that true. TeX reads a stream number as a
-# number, so `\write 18` and `\immediate \write 18` open the same stream as
-# the compact spelling, and the pattern allows the space rather than pinning
-# one way of writing it.
-SHELL_ESCAPE_CALL = re.compile(r"\\write\s*18\b|\\ShellEscape\b")
+# of them; the check is what keeps that true.
+#
+# The stream is a number, not a spelling. TeX's integer scanner takes optional
+# space, leading zeros, and a `"` or `'` prefix for hexadecimal and octal, so
+# `\write 18`, `\write018`, `\write"12`, and `\write'22` all open stream 18.
+# The constant is therefore read and evaluated rather than matched against one
+# way of writing it. What this does not read is a stream held in a register or
+# an expl3 stream variable, which no constant search can: a submission that
+# reached the shell that way would need the run to catch it, and the offline
+# compile runs with shell escape off for exactly that reason.
+WRITE_STREAM = re.compile(
+    r"\\write\s*(?:\"(?P<hex>[0-9A-Fa-f]+)|'(?P<oct>[0-7]+)|(?P<dec>[0-9]+))"
+)
+SHELL_ESCAPE_NAME = re.compile(r"\\ShellEscape\b")
+SHELL_ESCAPE_STREAM = 18
+
+
+def shell_escape_call(text: str) -> str:
+    r"""The first call to the shell-escape stream in `text`, or nothing.
+
+    Every `\write` constant is evaluated in the base its prefix names and
+    compared with 18, so the reading does not depend on how the number was
+    written.
+    """
+
+    named = SHELL_ESCAPE_NAME.search(text)
+    if named is not None:
+        return named.group(0)
+    for found in WRITE_STREAM.finditer(text):
+        digits, base = (
+            (found["hex"], 16) if found["hex"]
+            else (found["oct"], 8) if found["oct"]
+            else (found["dec"], 10)
+        )
+        if int(digits, base) == SHELL_ESCAPE_STREAM:
+            return found.group(0)
+    return ""
 
 # An absolute path in a staged source names the machine that wrote it. The
 # pattern catches the spellings a TeX file can carry: a Unix path or a Windows
@@ -1312,11 +1344,10 @@ def check_arxiv(tree: Path, closure: Closure) -> Report:
             f"{path.name} loads a file by absolute path, which names the "
             "machine it was written on",
         )
-        called = SHELL_ESCAPE_CALL.search(text)
+        called = shell_escape_call(text)
         report.require(
-            called is None,
-            f"{path.name} calls {called.group(0) if called else ''}, and a "
-            "submission compiles with no shell",
+            not called,
+            f"{path.name} calls {called}, and a submission compiles with no shell",
         )
     report.notes.append(
         f"{len(list(tree.iterdir()))} files, one directory deep; "
@@ -1352,6 +1383,11 @@ def offline_room(archive: Path, room: Path) -> list[str]:
             )
         staged = sorted(path.name for path in unpacked.iterdir())
         for path in sorted(unpacked.iterdir()):
+            if not path.is_file():
+                raise SystemExit(
+                    f"{archive.name} holds {PACKAGE}/{path.name}, which is not a "
+                    "file; an upload unpacks one directory deep"
+                )
             shutil.copy2(path, room / path.name)
     return staged
 
@@ -1471,11 +1507,14 @@ def check_offline(archive: Path, required: bool) -> Report:
             report.failures.append(str(refusal))
             return report
         environment = offline_environment(room, shims, tripwire, home)
-        # The runtime the archive carries, by name, taken from the load graph
-        # rather than from a `tenkz` prefix: the documents this check writes
-        # are named from the package too, so a prefix match would count a
-        # driver file this function wrote as proof that the package answered.
-        carried = {name for name in walk_closure().files if name in set(staged)}
+        # The runtime the entry point loads, by name. It comes from the load
+        # graph rather than from a `tenkz` prefix, because the documents this
+        # check writes are named from the package too and a prefix match would
+        # count one of them as proof that the package answered. It is not
+        # narrowed to what the archive staged either: a file the archive forgot
+        # has to stay in the reading, or an installed copy answering for it
+        # would resolve outside the room and never be looked at.
+        carried = set(walk_closure().files)
         for case in OFFLINE_CASES:
             _offline_case(case, room, engine, environment, audit, carried, report)
         if tripwire.exists():

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -1662,14 +1662,14 @@ def _offline_case(case: OfflineCase, room: Path, engine: str,
         f"{case.name} read {sorted(set(strangers))} from the repository, so the "
         "flat archive did not answer for the run",
     )
-    runtime = [path for path in opened if Path(path).name in carried]
+    # That the package answered at all is already established above: the event
+    # stream is written by tenkz and by nothing else, so a run that reached
+    # this line loaded it. What is left to read is where it was loaded from.
+    # There is deliberately no assertion that the list is non-empty; it could
+    # not fail, and an assertion that cannot fail reads as coverage.
+    answered = [path for path in opened if Path(path).name in carried]
     report.require(
-        runtime,
-        f"{case.name} opened none of the archive's runtime files, so it proved "
-        "nothing about them",
-    )
-    report.require(
-        not foreign_runtime_files(runtime, room, flat),
+        not foreign_runtime_files(answered, room, flat),
         f"{case.name} resolved a runtime file outside the flat archive, so an "
         "installed copy answered for it",
     )

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -294,9 +294,12 @@ OFFLINE_CASES = (
 )
 
 # The document an author writes around a preamble-free case. It names the case
-# by its flat basename, which is what the submission would look like.
+# by its flat basename, which is what the submission would look like. The
+# preamble is the corpus driver's without `mathtools`, which none of the cases
+# below calls: the check is of tenkz, so it asks the environment for nothing
+# beyond what tenkz and the mathematics around it need.
 OFFLINE_WRAPPER = r"""\documentclass[border=8pt,varwidth=270mm]{standalone}
-\usepackage{amsmath,amssymb,mathtools}
+\usepackage{amsmath,amssymb}
 \usepackage{tenkz}
 \begin{document}
 \input{%s}

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -96,13 +96,15 @@ PAYLOAD = re.compile(
 # load, and a closure that missed it would let the manifest pin a dependency
 # list the package does not have.
 INPUT_CALL = re.compile(r"\\input\s*\{([^}]*)\}", re.DOTALL)
-# Both spellings of a package load. A `.sty` writes `\RequirePackage`, but
-# nothing stops a staged runtime file from writing `\usepackage`, and the two
-# load the same package: a closure that read only the first would let a load
-# reach an upload without reaching the pin, and would report the retired front
-# ends absent while one of them was being loaded.
+# Every spelling of a package load. A `.sty` writes `\RequirePackage`, but
+# nothing stops a staged runtime file from writing `\usepackage` or
+# `\RequirePackageWithOptions`, and they load the same package. A closure that
+# read one spelling would let a load reach an upload without reaching the pin,
+# and would report the retired front ends absent while one was being loaded.
 REQUIRE_CALL = re.compile(
-    r"\\(?:RequirePackage|usepackage)\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}", re.DOTALL
+    r"\\(?:RequirePackageWithOptions|RequirePackage|usepackage)"
+    r"\s*(?:\[[^]]*\]\s*)?\{([^}]*)\}",
+    re.DOTALL,
 )
 LIBRARY_CALL = re.compile(r"\\usetikzlibrary\s*\{([^}]*)\}", re.DOTALL)
 
@@ -242,7 +244,12 @@ WRITE_CALL = re.compile(
     r"|(?P<name>\\[A-Za-z@_:]+))?"
 )
 ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
-SHELL_ESCAPE_NAME = re.compile(r"\\ShellEscape\b")
+# The named ways to reach a shell that are not a write at all: the TeX
+# primitive's LaTeX name, and expl3's own shell interface, which a file under
+# `\ExplSyntaxOn` would use in preference to either.
+SHELL_ESCAPE_NAME = re.compile(
+    r"\\ShellEscape\b|\\sys_(?:shell_(?:now|shipout|open)|get_shell):[a-zA-Z]*"
+)
 SHELL_ESCAPE_STREAM = 18
 
 
@@ -258,7 +265,7 @@ def shell_escape_call(text: str) -> str:
 
     named = SHELL_ESCAPE_NAME.search(text)
     if named is not None:
-        return f"{named.group(0)}, the shell-escape primitive"
+        return f"{named.group(0)}, which reaches a shell"
     allocated = set(ALLOCATED_STREAM.findall(text))
     for found in WRITE_CALL.finditer(text):
         if found["name"] is not None:
@@ -287,12 +294,16 @@ def shell_escape_call(text: str) -> str:
 # An absolute path in a staged source names the machine that wrote it. The
 # pattern catches the spellings a TeX file can carry: a Unix path or a Windows
 # drive letter opening a braced load argument, with the star a starred form
-# such as `\includegraphics*` puts before its arguments, and the same two
-# opening `\input` unbraced, which is plain TeX's own syntax and reads to the
-# next space.
+# such as `\includegraphics*` puts before its arguments and the space LaTeX's
+# star test skips before it, and the same two opening `\input` unbraced, which
+# is plain TeX's own syntax and reads to the next space. The loader list is
+# every one the LaTeX kernel defines that takes a file name, conditional ones
+# included: a runtime whose behaviour depends on a machine-local file is not
+# submittable even when the file's absence is handled.
 ABSOLUTE_PATH_HEAD = r"(?:/|[A-Za-z]:[\\/])"
 ABSOLUTE_LOAD = re.compile(
-    r"\\(?:input|include|usepackage|RequirePackage|includegraphics)\*?"
+    r"\\(?:input|include|usepackage|RequirePackageWithOptions|RequirePackage"
+    r"|InputIfFileExists|includegraphics)(?:\s*\*)?"
     rf"\s*(?:\[[^]]*\]\s*)?\{{\s*{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
 )

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -248,7 +248,7 @@ REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 # recognizable is matched and the rest is out of scope, stated here rather
 # than implied by silence.
 WRITE_CALL = re.compile(
-    r"(?<!\\)(?:\\write|\\csname\s*write\s*\\endcsname)"
+    r"(?:\\write|\\csname\s*write\s*\\endcsname)"
     r"(?![A-Za-z@_:])(?P<signs>[\s+-]*)"
     r"(?:\"(?P<hex>[0-9A-Fa-f]+)|'(?P<oct>[0-7]+)|(?P<dec>[0-9]+)"
     r"|(?P<name>\\[A-Za-z@_:]+))?"
@@ -264,21 +264,32 @@ ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
 # gate that looks closed. Only executors are named: `\tex_shellescape:D` and
 # `\sys_if_shell:TF` report whether the engine has a shell and run nothing, so
 # reading them as calls would refuse a file for asking a question.
-# The lookbehind is the other half of reading a control sequence: `\\write18`
-# is the control symbol `\\` followed by ordinary characters, not the
-# primitive, and a gate that read it as one would refuse a package for
-# typesetting the spelling. The boundary after the name is the one `WRITE_CALL`
-# uses, for the same reason: `@` is a
+# The boundary after the name is the one `WRITE_CALL` uses, for the same
+# reason: `@` is a
 # letter in a package and `_` and `:` are letters under `\ExplSyntaxOn`, so
 # `\ShellEscape@status` and `\sys_shell_now:n_aux` are control words of their
 # own and refusing them would block a shell-free release over a name.
 SHELL_ESCAPE_NAME = re.compile(
-    r"(?<!\\)(?:\\(?:Delayed)?ShellEscape"
+    r"(?:\\(?:Delayed)?ShellEscape"
     r"|\\sys_(?:shell_(?:now|shipout)|get_shell):[a-zA-Z]*"
     r"|\\(?:ior|iow)_shell_open:[a-zA-Z]*)"
     r"(?![A-Za-z@_:])"
 )
 SHELL_ESCAPE_STREAM = 18
+
+
+def uncontrolled(text: str) -> str:
+    r"""`text` with every `\\` control symbol blanked out.
+
+    A backslash preceded by an odd number of backslashes starts a control
+    sequence and one preceded by an even number does not, so the pairs are
+    removed before anything is read: `\\write18` is the control symbol and then
+    ordinary characters, while `\\\write18` is that symbol and then the
+    primitive. Blanking keeps the length, so a match's span still indexes the
+    text it came from.
+    """
+
+    return text.replace("\\\\", "\x00\x00")
 
 
 def shell_escape_call(text: str) -> str:
@@ -291,17 +302,17 @@ def shell_escape_call(text: str) -> str:
     be 18.
     """
 
-    named = SHELL_ESCAPE_NAME.search(text)
+    scanned = uncontrolled(text)
+    named = SHELL_ESCAPE_NAME.search(scanned)
     if named is not None:
-        return f"{named.group(0)}, which reaches a shell"
-    allocated = set(ALLOCATED_STREAM.findall(text))
-    for found in WRITE_CALL.finditer(text):
+        return f"{text[named.start():named.end()]}, which reaches a shell"
+    allocated = set(ALLOCATED_STREAM.findall(scanned))
+    for found in WRITE_CALL.finditer(scanned):
+        call = text[found.start():found.end()]
         if found["name"] is not None:
             if found["name"] in allocated:
                 continue
-            return (
-                f"{found.group(0).strip()}, a stream this file does not allocate"
-            )
+            return f"{call.strip()}, a stream this file does not allocate"
         digits, base = (
             (found["hex"], 16) if found["hex"]
             else (found["oct"], 8) if found["oct"]
@@ -310,12 +321,12 @@ def shell_escape_call(text: str) -> str:
         )
         if digits is None:
             return (
-                f"{found.group(0).strip()}, whose stream is not a constant this "
-                "reading can evaluate"
+                f"{call.strip()}, whose stream is not a constant this reading "
+                "can evaluate"
             )
         sign = -1 if found["signs"].count("-") % 2 else 1
         if sign * int(digits, base) == SHELL_ESCAPE_STREAM:
-            return f"{found.group(0)}, the shell-escape stream"
+            return f"{call}, the shell-escape stream"
     return ""
 
 
@@ -333,7 +344,8 @@ def shell_escape_call(text: str) -> str:
 ABSOLUTE_PATH_HEAD = r"(?:/|[A-Za-z]:[\\/])"
 ABSOLUTE_LOAD = re.compile(
     r"\\(?:input|include|usepackage|RequirePackageWithOptions|RequirePackage"
-    r"|InputIfFileExists|IfFileExists|includegraphics)(?:\s*\*)?"
+    r"|InputIfFileExists|IfFileExists|includegraphics|file_input:n"
+    r"|file_if_exist:nTF)(?:\s*\*)?"
     rf"\s*(?:\[[^]]*\]\s*)?\{{\s*\"?{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
 )
@@ -386,7 +398,9 @@ OFFLINE_CASES = (
     OfflineCase(
         "crossing", "string/crossing",
         "tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-two.tex",
-        False, r"\tnwire", r"(?m)^stringcross\|",
+        # `\tnwire` alone would not tell this case from the flat one, which
+        # draws wires too. A string-kind wire is what a crossing is made of.
+        False, "kind=string", r"(?m)^stringcross\|",
     ),
     OfflineCase(
         "enclosure", "enclosure",
@@ -406,7 +420,7 @@ OFFLINE_CASES = (
     OfflineCase(
         "probe-crossing", "string/crossing",
         "tests/tenkz/kernel/k_braid.tex",
-        True, r"\tnwire", r"(?m)^stringcross\|",
+        True, "cross=", r"(?m)^stringcross\|",
     ),
 )
 
@@ -977,13 +991,17 @@ def check_dependencies(closure: Closure, manifest: dict) -> Report:
         f"{ENTRY.name} still loads {survivors}, which the retired front ends "
         "brought and their removal was supposed to take with them",
     )
-    report.notes.append(
-        "; ".join(
-            f"{name}: {len(classified[name])}" for name in DEPENDENCY_CLASSES
+    # The note states what the check found, so it is written only when the
+    # check held: a line claiming no retired load, printed above the line
+    # reporting one, is worse than no line at all.
+    if not report.failures:
+        report.notes.append(
+            "; ".join(
+                f"{name}: {len(classified[name])}" for name in DEPENDENCY_CLASSES
+            )
+            + f"; no load of {', '.join(RETIRED_DEPENDENCIES)}"
         )
-        + f"; no load of {', '.join(RETIRED_DEPENDENCIES)}"
-    )
-    if classified["unconsumed"]:
+    if not report.failures and classified["unconsumed"]:
         report.notes.append(
             "loaded and unread, by the ablation recorded in DEPENDENCIES.md: "
             + ", ".join(classified["unconsumed"])
@@ -1443,10 +1461,11 @@ def check_arxiv(tree: Path, closure: Closure) -> Report:
             not called,
             f"{path.name} calls {called}, and a submission compiles with no shell",
         )
-    report.notes.append(
-        f"{len(list(tree.iterdir()))} files, one directory deep; "
-        f"{len(loaded)} loaded sources read, no generated source and no shell call"
-    )
+    if not report.failures:
+        report.notes.append(
+            f"{len(list(tree.iterdir()))} files, one directory deep; "
+            f"{len(loaded)} loaded sources read, no generated source and no shell call"
+        )
     return report
 
 

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -224,14 +224,19 @@ LOAD_SUFFIXES = (".code.tex", ".tex", ".sty", ".def", ".cls", ".cfg")
 
 
 def load_names(name: str) -> set[str]:
-    """Every name one loaded file could be known by."""
+    """Every name one loaded file could be known by.
 
-    bare = name
+    A load may carry a directory, so the basename is what the suffix and the
+    `tikzlibrary` prefix are stripped from; the name as written stays in the
+    set as well, since that is what a manifest would pin.
+    """
+
+    bare = Path(name).name
     for suffix in LOAD_SUFFIXES:
         if bare.endswith(suffix):
             bare = bare[: -len(suffix)]
             break
-    names = {name, bare}
+    names = {name, Path(name).name, bare}
     library = TIKZ_LIBRARY_FILE.match(bare)
     if library is not None:
         names.add(library["library"])
@@ -276,6 +281,11 @@ WRITE_CALL = re.compile(
     r"|(?P<name>\\[A-Za-z@_:]+))?"
 )
 ALLOCATED_STREAM = re.compile(r"\\(?:newwrite|iow_new:N)\s*(\\[A-Za-z@_:]+)")
+# Web2C reads a file name opening with a pipe as a command to run, so
+# `\openin\stream="|uname -a"` reaches a shell without naming a stream or an
+# API. The quote is what marks it as a file name to the engine, and nothing in
+# a tensor-diagram package has a reason to write one.
+PIPE_FILENAME = re.compile(r"\"\s*\|")
 # The named ways to reach a shell that are not a write at all: the TeX
 # primitive's LaTeX name, and expl3's own shell interface, which a file under
 # `\ExplSyntaxOn` would use in preference to either. The expl3 names are the
@@ -328,6 +338,12 @@ def shell_escape_call(text: str) -> str:
     named = SHELL_ESCAPE_NAME.search(scanned)
     if named is not None:
         return f"{text[named.start():named.end()]}, which reaches a shell"
+    piped = PIPE_FILENAME.search(scanned)
+    if piped is not None:
+        return (
+            f'{text[piped.start():piped.end()]}, a file name opening a pipe, '
+            "which the engine runs as a command"
+        )
     allocated = set(ALLOCATED_STREAM.findall(scanned))
     for found in WRITE_CALL.finditer(scanned):
         call = text[found.start():found.end()]
@@ -555,7 +571,10 @@ def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
             raise SystemExit(f"{entry} loads {name}, which is missing")
         closure.files.append(name)
         try:
-            text = strip_comments(path.read_bytes().decode("utf-8"))
+            # Comments are blanked, and so are the `\\` control symbols: a
+            # load spelled inside a macro body as text is not a load, and
+            # recording one would refuse a release over a definition.
+            text = uncontrolled(strip_comments(path.read_bytes().decode("utf-8")))
         except UnicodeDecodeError as error:
             raise SystemExit(f"{name} is not UTF-8 and cannot be read: {error}") from None
         for group in REQUIRE_CALL.findall(text):

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -225,8 +225,19 @@ REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 # 18; a stream the same file allocated with `\newwrite` or `\iow_new:N`, which
 # is a file stream by construction and by intent; or anything else, which
 # cannot be shown not to be 18 and is a finding on that ground alone.
+#
+# The boundary after `write` excludes `@` and, for a file under
+# `\ExplSyntaxOn`, `_` and `:`, because those are letters there: `\write@event`
+# and `\write:nn` are control words of their own, and reading them as the
+# primitive would refuse a release over a name.
+#
+# What the reading is for is a mistake in a staged source, not a source
+# written to hide a shell call from it. A primitive assembled at run time
+# cannot be read from the text at all, so the one spelling that is still
+# recognizable is matched and the rest is out of scope, stated here rather
+# than implied by silence.
 WRITE_CALL = re.compile(
-    r"\\write(?![A-Za-z])(?P<signs>[\s+-]*)"
+    r"(?:\\write|\\csname\s*write\s*\\endcsname)(?![A-Za-z@_:])(?P<signs>[\s+-]*)"
     r"(?:\"(?P<hex>[0-9A-Fa-f]+)|'(?P<oct>[0-7]+)|(?P<dec>[0-9]+)"
     r"|(?P<name>\\[A-Za-z@_:]+))?"
 )
@@ -275,11 +286,13 @@ def shell_escape_call(text: str) -> str:
 
 # An absolute path in a staged source names the machine that wrote it. The
 # pattern catches the spellings a TeX file can carry: a Unix path or a Windows
-# drive letter opening a braced load argument, and the same two opening `\input`
-# unbraced, which is plain TeX's own syntax and reads to the next space.
+# drive letter opening a braced load argument, with the star a starred form
+# such as `\includegraphics*` puts before its arguments, and the same two
+# opening `\input` unbraced, which is plain TeX's own syntax and reads to the
+# next space.
 ABSOLUTE_PATH_HEAD = r"(?:/|[A-Za-z]:[\\/])"
 ABSOLUTE_LOAD = re.compile(
-    r"\\(?:input|include|usepackage|RequirePackage|includegraphics)"
+    r"\\(?:input|include|usepackage|RequirePackage|includegraphics)\*?"
     rf"\s*(?:\[[^]]*\]\s*)?\{{\s*{ABSOLUTE_PATH_HEAD}"
     rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
 )

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -214,11 +214,14 @@ REGENERATED_SUFFIXES = frozenset({".dtx", ".ins", ".fmt", ".mf", ".drv"})
 SHELL_ESCAPE_CALLS = (r"\write18", r"\ShellEscape", r"\immediate\write18")
 
 # An absolute path in a staged source names the machine that wrote it. The
-# pattern catches the two spellings a TeX file can carry: a Unix path opening
-# a load argument, and a Windows drive letter.
+# pattern catches the spellings a TeX file can carry: a Unix path or a Windows
+# drive letter opening a braced load argument, and the same two opening `\input`
+# unbraced, which is plain TeX's own syntax and reads to the next space.
+ABSOLUTE_PATH_HEAD = r"(?:/|[A-Za-z]:[\\/])"
 ABSOLUTE_LOAD = re.compile(
     r"\\(?:input|include|usepackage|RequirePackage|includegraphics)"
-    r"\s*(?:\[[^]]*\]\s*)?\{\s*(?:/|[A-Za-z]:[\\/])"
+    rf"\s*(?:\[[^]]*\]\s*)?\{{\s*{ABSOLUTE_PATH_HEAD}"
+    rf"|\\input\s*\"?{ABSOLUTE_PATH_HEAD}"
 )
 
 
@@ -775,7 +778,17 @@ def check_dependencies(closure: Closure, manifest: dict) -> Report:
     which of them the package needs to place a tensor and which of them only
     the ink it draws needs. The manifest's classification says which, and this
     check is what stops the two from drifting: a library that enters or leaves
-    the load list without a class, or that is filed under two, fails here.
+    the load list without a class, that is filed under two, or that is named
+    twice inside one, fails here, and so does a manifest that leaves a class
+    out rather than declaring it empty.
+
+    What this cannot read is whether a class is the *right* one, and the
+    `unconsumed` class is where that matters: nothing here can tell a library
+    nothing reads from one whose consumer the reader did not find. Searching
+    for the library's name does not settle it either, because a library is
+    reached through the names it defines rather than through its own. The class
+    is established by removing the load and compiling, and
+    `docs/tenkz/ctan/DEPENDENCIES.md` records that reading.
 
     Absence is checked the same way. The retired front ends each brought a load
     with them, and the walk that reads loads has already blanked the comments,
@@ -799,12 +812,25 @@ def check_dependencies(closure: Closure, manifest: dict) -> Report:
     )
     classified: dict[str, list[str]] = {}
     for name in DEPENDENCY_CLASSES:
-        members = ownership.get(name, [])
+        if name not in ownership:
+            report.failures.append(
+                f"{MANIFEST_LABEL} declares no {name!r} class; a class with no "
+                "members is written as an empty list, because leaving it out "
+                "reads as a class nobody considered"
+            )
+            return report
+        members = ownership[name]
         if not isinstance(members, list) or any(
             not isinstance(member, str) for member in members
         ):
             report.failures.append(f"[runtime.requires.ownership] {name} is not a list of names")
             return report
+        repeated = sorted({member for member in members if members.count(member) > 1})
+        report.require(
+            not repeated,
+            f"{repeated} are named more than once under {name!r}, which reads "
+            "as more consumers than the report traced",
+        )
         classified[name] = members
     twice = sorted(
         library
@@ -837,7 +863,8 @@ def check_dependencies(closure: Closure, manifest: dict) -> Report:
     )
     if classified["unconsumed"]:
         report.notes.append(
-            f"loaded with no consumer in the source: {', '.join(classified['unconsumed'])}"
+            "loaded and unread, by the ablation recorded in DEPENDENCIES.md: "
+            + ", ".join(classified["unconsumed"])
         )
     return report
 
@@ -1292,12 +1319,24 @@ def offline_room(archive: Path, room: Path) -> list[str]:
     search path. A submission has no search path to put it on: the files sit
     beside the manuscript, so this is where the archive is flattened and where
     a runtime file that only resolves through a directory would fail.
+
+    An archive that does not open, or that does not hold the one directory the
+    upload is judged on, is answered with a message rather than a traceback:
+    this tool's contract is that every finding is a printed line of the report,
+    and a caller that raised here would break it.
     """
 
     with tempfile.TemporaryDirectory(prefix="tenkz-offline-unpack-") as unpacking:
-        with zipfile.ZipFile(archive) as bundle:
-            bundle.extractall(unpacking)
+        try:
+            with zipfile.ZipFile(archive) as bundle:
+                bundle.extractall(unpacking)
+        except (zipfile.BadZipFile, OSError) as error:
+            raise SystemExit(f"{archive.name} does not open as an archive: {error}") from None
         unpacked = Path(unpacking) / PACKAGE
+        if not unpacked.is_dir():
+            raise SystemExit(
+                f"{archive.name} does not unpack into a single {PACKAGE}/ directory"
+            )
         staged = sorted(path.name for path in unpacked.iterdir())
         for path in sorted(unpacked.iterdir()):
             shutil.copy2(path, room / path.name)
@@ -1394,7 +1433,11 @@ def check_offline(archive: Path, required: bool) -> Report:
         tripwire = base / "reached-for.txt"
         shims = base / "shims"
         write_shims(shims)
-        staged = offline_room(archive, room)
+        try:
+            staged = offline_room(archive, room)
+        except SystemExit as refusal:
+            report.failures.append(str(refusal))
+            return report
         environment = offline_environment(room, shims, tripwire, home)
         for case in OFFLINE_CASES:
             _offline_case(case, room, engine, environment, audit, report)
@@ -1463,7 +1506,17 @@ def _offline_case(case: OfflineCase, room: Path, engine: str,
         report.failures.append(f"{case.name} wrote no input record to read")
         return
     opened = recorded_inputs(record)
-    strangers = [path for path in opened if (room / path).resolve().is_relative_to(ROOT)]
+    # The room is the base a relative record line resolves against, and it is
+    # also the one directory a file may legitimately come from besides the
+    # installation. It is excluded before the repository is read, because a
+    # temporary directory is placed wherever `TMPDIR` says, and a runner that
+    # puts it inside the workspace would otherwise make every file the archive
+    # itself answered look like one the repository did.
+    flat = room.resolve()
+    elsewhere = [
+        path for path in opened if not (room / path).resolve().is_relative_to(flat)
+    ]
+    strangers = [path for path in elsewhere if (room / path).resolve().is_relative_to(ROOT)]
     report.require(
         not strangers,
         f"{case.name} read {sorted(set(strangers))} from the repository, so the "
@@ -1472,7 +1525,7 @@ def _offline_case(case: OfflineCase, room: Path, engine: str,
     runtime = [path for path in opened if Path(path).name.startswith(PACKAGE)]
     report.require(runtime, f"{case.name} opened no tenkz file, so it proved nothing")
     report.require(
-        all((room / path).resolve().is_relative_to(room.resolve()) for path in runtime),
+        not foreign_runtime_files(runtime, room, flat),
         f"{case.name} resolved a runtime file outside the flat archive, so an "
         "installed copy answered for it",
     )

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -790,13 +790,14 @@ def test_a_package_load_is_read_in_both_of_its_spellings() -> None:
     with tempfile.TemporaryDirectory() as directory:
         source = Path(directory) / "tex"
         source.mkdir()
-        (source / "tenkz.sty").write_text(
-            STAGE_CONTRACT + "\\usepackage{tikz-cd}\n", encoding="utf-8"
-        )
-        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
-    assert closure.packages == ["tikz-cd"], closure.packages
-    report = tenkz_ctan.check_dependencies(closure, _ownership([], [], []))
-    assert any("tikz-cd" in reason for reason in report.failures), report.failures
+        for spelling in ("usepackage", "RequirePackage", "RequirePackageWithOptions"):
+            (source / "tenkz.sty").write_text(
+                STAGE_CONTRACT + f"\\{spelling}{{tikz-cd}}\n", encoding="utf-8"
+            )
+            closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+            assert closure.packages == ["tikz-cd"], (spelling, closure.packages)
+            report = tenkz_ctan.check_dependencies(closure, _ownership([], [], []))
+            assert any("tikz-cd" in r for r in report.failures), (spelling, report.failures)
 
 
 def test_a_retired_front_end_load_fails_the_dependency_check() -> None:
@@ -880,6 +881,12 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
         assert not tenkz_ctan.shell_escape_call(name), name
     # The one assembled spelling that is still readable from the text.
     assert tenkz_ctan.shell_escape_call(r"\csname write\endcsname18{x}")
+    # The named ways to reach a shell that are not a write at all. A file
+    # under `\ExplSyntaxOn` would use the expl3 interface in preference to
+    # either primitive.
+    for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
+                  r"\sys_shell_open:Nn \x {ls}", r"\sys_get_shell:nnN {x}{y}\z"):
+        assert tenkz_ctan.shell_escape_call(named), named
     # Numbers that are not 18 in the base their prefix names, an odd run of
     # minus signs, and a control sequence that merely starts with the same
     # letters.
@@ -944,12 +951,16 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
             "\\input /Users/somebody/tenkz-core.code.tex\n", encoding="utf-8"
         )
         unbraced = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
-        # A starred form puts its star between the command and its arguments.
-        (tree / "tenkz.sty").write_text(
-            "\\includegraphics*{/Users/somebody/figure.pdf}\n", encoding="utf-8"
-        )
-        starred = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
-        assert any("absolute path" in reason for reason in starred.failures), starred.failures
+        # A starred form puts its star between the command and its arguments,
+        # and LaTeX's star test skips a space before it. A conditional loader
+        # is a loader: a runtime whose behaviour depends on a machine-local
+        # file is not submittable even when the file's absence is handled.
+        for load in (r"\includegraphics*{/Users/somebody/figure.pdf}",
+                     r"\includegraphics *{/Users/somebody/figure.pdf}",
+                     r"\InputIfFileExists{/Users/somebody/local.cfg}{}{}"):
+            (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")
+            found = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
+            assert any("absolute path" in r for r in found.failures), (load, found.failures)
         (tree / "tenkz.sty").write_text("\\input tenkz-core.code.tex\n", encoding="utf-8")
         relative = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
     assert any("absolute path" in reason for reason in unbraced.failures), unbraced.failures

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -943,8 +943,12 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     # `\\write18` is the control symbol and then ordinary characters, and a
     # gate that read it as the primitive would refuse a package for
     # typesetting the spelling.
-    for typeset in (r"\\write18{x}", r"\\ShellEscape{x}"):
+    # It is the parity of the run that decides, not whether one backslash
+    # precedes: `\\\write18` is that control symbol and then the primitive.
+    for typeset in (r"\\write18{x}", r"\\ShellEscape{x}", r"\\\\write18{x}"):
         assert not tenkz_ctan.shell_escape_call(typeset), typeset
+    for odd in (r"\\\write18{x}", r"\\\ShellEscape{x}"):
+        assert tenkz_ctan.shell_escape_call(odd), odd
     # Numbers that are not 18 in the base their prefix names, an odd run of
     # minus signs, and a control sequence that merely starts with the same
     # letters.
@@ -1017,6 +1021,7 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                      r"\includegraphics *{/Users/somebody/figure.pdf}",
                      r"\InputIfFileExists{/Users/somebody/local.cfg}{}{}",
                      r"\IfFileExists{/Users/somebody/local.cfg}{}{}",
+                     r"\file_input:n { /Users/somebody/local.tex }",
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")
@@ -1163,6 +1168,24 @@ def test_the_offline_check_says_so_when_there_is_no_engine() -> None:
         tenkz_ctan.shutil.which = engine
     assert skipped.status == "SKIP", skipped
     assert refused.failures, refused
+
+
+def test_a_note_never_contradicts_the_finding_printed_beside_it() -> None:
+    """A closing note states what the check found, so it is written only when
+    the check held. A line claiming no retired load, printed above the line
+    reporting one, is worse than no line at all."""
+
+    closure = tenkz_ctan.Closure(packages=["tikz", "tikz-cd"], libraries=[])
+    caught = tenkz_ctan.check_dependencies(closure, _ownership([], [], []))
+    assert caught.failures, caught
+    assert not caught.notes, caught.notes
+    with tempfile.TemporaryDirectory() as directory:
+        tree = Path(directory) / PACKAGE_DIR
+        tree.mkdir(parents=True)
+        (tree / "tenkz.sty").write_text("\\write18{uname -a}\n", encoding="utf-8")
+        loud = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
+    assert loud.failures, loud
+    assert not loud.notes, loud.notes
 
 
 def test_the_offline_check_reports_a_case_that_cannot_be_read() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -832,6 +832,44 @@ def test_a_tree_arxiv_would_have_to_build_or_shell_out_for_fails() -> None:
     assert "absolute path" in findings, report.failures
 
 
+def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
+    """TeX scans the stream as an integer, so leading zeros and the `"` and
+    `'` prefixes for hexadecimal and octal all reach stream 18. The constant is
+    evaluated rather than matched against one way of writing it."""
+
+    for call in (r"\write18{x}", r"\write 18{x}", r"\immediate \write 18{x}",
+                 r"\write018{x}", '\\write"12{x}', r"\write'22{x}",
+                 r"\ShellEscape{x}"):
+        assert tenkz_ctan.shell_escape_call(call), call
+    # Numbers that are not 18 in the base their prefix names, and a stream
+    # named by a control sequence, which no constant search can read.
+    for quiet in (r"\write17{x}", r"\write180{x}", '\\write"18{x}',
+                  r"\write \myout{x}"):
+        assert not tenkz_ctan.shell_escape_call(quiet), quiet
+
+
+def test_a_closure_file_the_archive_forgot_stays_in_the_reading() -> None:
+    """`carried` comes from the load graph and is not narrowed to what the
+    archive staged. A file the archive omitted has to stay in the reading, or
+    an installed copy answering for it would resolve outside the room and never
+    be looked at."""
+
+    (ROOT / "build").mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=ROOT / "build") as directory:
+        room = Path(directory)
+        carried = set(tenkz_ctan.walk_closure().files)
+        forgotten = "tenkz-string.code.tex"
+        assert forgotten in carried, sorted(carried)
+        # The engine answered it from an installation instead of the flat.
+        installed = "/usr/local/texlive/tex/latex/tenkz/" + forgotten
+        runtime = [path for path in [installed] if Path(path).name in carried]
+        assert runtime == [installed], runtime
+        assert tenkz_ctan.foreign_runtime_files(runtime, room, room.resolve())
+        # The check's own driver files are not on the load graph, so they never
+        # stand in for a runtime file the run never opened.
+        assert "tenkz-offline-flat.tex" not in carried
+
+
 def test_a_loaded_source_is_read_whatever_it_is_called() -> None:
     """The scan follows the load graph rather than a list of suffixes, so a
     runtime file added later as a class or a configuration is read because it

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -837,6 +837,20 @@ def test_a_retired_front_end_vendored_as_a_file_is_caught() -> None:
     assert closure.files == ["tenkz.sty", "tikz-cd.sty"], closure.files
     report = tenkz_ctan.check_dependencies(closure, _ownership([], [], []))
     assert any("tikz-cd" in reason for reason in report.failures), report.failures
+    # A TikZ library vendored as a file goes by its conventional file name, so
+    # the reading strips the prefix and the suffix a load carries.
+    assert tenkz_ctan.load_names("tikzlibrarytikzcd.code.tex") >= {"tikzcd"}
+    assert tenkz_ctan.load_names("tenkz-core.code.tex") >= {"tenkz-core"}
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory) / "tex"
+        source.mkdir()
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT + "\\input{tikzlibrarytikzcd.code.tex}\n", encoding="utf-8"
+        )
+        (source / "tikzlibrarytikzcd.code.tex").write_text(STAGE_CONTRACT, encoding="utf-8")
+        vendored = tenkz_ctan.walk_closure(source, "tenkz.sty")
+    library = tenkz_ctan.check_dependencies(vendored, _ownership([], [], []))
+    assert any("tikzcd" in reason for reason in library.failures), library.failures
 
 
 def test_a_retired_front_end_load_fails_the_dependency_check() -> None:
@@ -1087,8 +1101,11 @@ def test_a_commented_shell_call_is_not_a_shell_call() -> None:
     with tempfile.TemporaryDirectory() as directory:
         tree = Path(directory) / PACKAGE_DIR
         tree.mkdir(parents=True)
+        # A comment, and text that typesets the spellings rather than using
+        # them: `\\\\input` is the control symbol and then ordinary characters.
         (tree / "tenkz.sty").write_text(
-            "% tenkz never calls \\write18, and never loads {/absolute}.\n",
+            "% tenkz never calls \\write18, and never loads {/absolute}.\n"
+            "The spelling \\\\input{/absolute/path} is text, not a load.\n",
             encoding="utf-8",
         )
         report = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
@@ -1233,11 +1250,14 @@ def test_the_offline_check_reports_an_archive_it_cannot_read() -> None:
         with zipfile.ZipFile(room / "nested.zip", "w") as bundle:
             bundle.writestr(f"{PACKAGE_DIR}/tenkz.sty", real.read_bytes())
             bundle.writestr(f"{PACKAGE_DIR}/runtime/", b"")
+        with zipfile.ZipFile(room / "extra.zip", "w") as bundle:
+            bundle.writestr(f"{PACKAGE_DIR}/tenkz.sty", real.read_bytes())
+            bundle.writestr("READ-ME-FIRST.txt", b"a stray member\n")
         try:
             tenkz_ctan.shutil.which = lambda _name: "/somewhere/xelatex"
             reports = {
                 name: tenkz_ctan.check_offline(room / f"{name}.zip", required=True)
-                for name in ("torn", "loose", "nested")
+                for name in ("torn", "loose", "nested", "extra")
             }
         finally:
             tenkz_ctan.shutil.which = engine
@@ -1248,6 +1268,9 @@ def test_the_offline_check_reports_an_archive_it_cannot_read() -> None:
     assert any(
         "is not a file" in r for r in reports["nested"].failures
     ), reports["nested"].failures
+    assert any(
+        "beside ['READ-ME-FIRST.txt']" in r for r in reports["extra"].failures
+    ), reports["extra"].failures
 
 
 def test_an_installer_that_fired_is_read_as_a_finding() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -717,6 +717,186 @@ def test_the_release_report_survives_an_absent_artifact() -> None:
     assert dict(rows)["docs/tenkz/CHANGES.md"] == "absent", rows
 
 
+def _ownership(placement: list[str], ink: list[str], unconsumed: list[str]) -> dict:
+    """A manifest holding one library classification and nothing else."""
+
+    return {
+        "runtime": {
+            "requires": {
+                "packages": ["tikz"],
+                "libraries": sorted(placement + ink + unconsumed),
+                "ownership": {
+                    "placement": placement,
+                    "ink": ink,
+                    "unconsumed": unconsumed,
+                },
+            }
+        }
+    }
+
+
+def test_a_loaded_library_without_a_consumer_class_is_caught() -> None:
+    """A list of library names is not a dependency report. A library that
+    entered or left the load list without being traced to the code that reads
+    it fails here, which is what stops the report from going stale."""
+
+    closure = tenkz_ctan.Closure(libraries=["calc", "hobby"], packages=["tikz"])
+    missing = tenkz_ctan.check_dependencies(
+        closure, _ownership(["calc"], [], [])
+    )
+    assert any("loads" in reason for reason in missing.failures), missing.failures
+    invented = tenkz_ctan.check_dependencies(
+        closure, _ownership(["calc", "hobby"], ["spath3"], [])
+    )
+    assert invented.failures, "a class naming a library nothing loads passed"
+    twice = tenkz_ctan.check_dependencies(
+        closure, _ownership(["calc", "hobby"], ["hobby"], [])
+    )
+    assert any(
+        "more than one consumer class" in reason for reason in twice.failures
+    ), twice.failures
+    sound = tenkz_ctan.check_dependencies(closure, _ownership(["calc"], ["hobby"], []))
+    assert not sound.failures, sound.failures
+
+
+def test_a_manifest_with_no_classification_at_all_is_named() -> None:
+    manifest = {"runtime": {"requires": {"packages": ["tikz"], "libraries": []}}}
+    report = tenkz_ctan.check_dependencies(tenkz_ctan.Closure(), manifest)
+    assert any("ownership" in reason for reason in report.failures), report.failures
+
+
+def test_a_retired_front_end_load_fails_the_dependency_check() -> None:
+    """The removed front ends each brought a load. The walk blanks comments
+    before it reads one, so a retired name in the closure is a surviving load
+    rather than the sentence in `tenkz.sty` that mentions tikz-cd."""
+
+    closure = tenkz_ctan.Closure(packages=["tikz", "tikz-cd"], libraries=[])
+    report = tenkz_ctan.check_dependencies(closure, _ownership([], [], []))
+    assert any("tikz-cd" in reason for reason in report.failures), report.failures
+    walked = tenkz_ctan.walk_closure()
+    loaded = set(walked.packages) | set(walked.libraries)
+    assert not loaded & set(tenkz_ctan.RETIRED_DEPENDENCIES), sorted(loaded)
+
+
+def test_the_real_classification_covers_the_real_load_list() -> None:
+    report = tenkz_ctan.check_dependencies(
+        tenkz_ctan.walk_closure(), tenkz_ctan.read_manifest()
+    )
+    assert not report.failures, report.failures
+
+
+def test_a_tree_arxiv_would_have_to_build_or_shell_out_for_fails() -> None:
+    """The submission reading of the same files: flat, already the runtime,
+    naming no path on the machine that wrote it, calling no shell."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        tree = Path(directory) / PACKAGE_DIR
+        (tree / "nested").mkdir(parents=True)
+        (tree / "tenkz.sty").write_text("% a runtime file\n", encoding="utf-8")
+        (tree / "tenkz.ins").write_text("% a docstrip run\n", encoding="utf-8")
+        (tree / "loud.sty").write_text("\\immediate\\write18{rm -rf /}\n", encoding="utf-8")
+        (tree / "elsewhere.sty").write_text(
+            "\\input{/Users/somebody/tenkz-core.code.tex}\n", encoding="utf-8"
+        )
+        report = tenkz_ctan.check_arxiv(tree)
+    findings = " ".join(report.failures)
+    assert "nested" in findings, report.failures
+    assert "tenkz.ins" in findings, report.failures
+    assert "write18" in findings, report.failures
+    assert "absolute path" in findings, report.failures
+
+
+def test_a_commented_shell_call_is_not_a_shell_call() -> None:
+    """Comments are blanked before the reading, as everywhere else here: a
+    sentence about `\\write18` is prose, and refusing it would be refusing the
+    file that documents why the package does not call it."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        tree = Path(directory) / PACKAGE_DIR
+        tree.mkdir(parents=True)
+        (tree / "tenkz.sty").write_text(
+            "% tenkz never calls \\write18, and never loads {/absolute}.\n",
+            encoding="utf-8",
+        )
+        report = tenkz_ctan.check_arxiv(tree)
+    assert not report.failures, report.failures
+
+
+def test_an_interposed_tool_records_its_own_call_and_fails() -> None:
+    """The offline claim is read from whether an installer ran, so the shims
+    have to record. A shim that silently succeeded would let a run repair an
+    incomplete environment and still report that nothing was fetched."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        room = Path(directory)
+        shims = room / "shims"
+        tenkz_ctan.write_shims(shims)
+        tripwire = room / "reached-for.txt"
+        assert sorted(path.name for path in shims.iterdir()) == sorted(
+            tenkz_ctan.INTERPOSED_TOOLS
+        )
+        called = subprocess.run(
+            [str(shims / "tlmgr"), "install", "tenkz"],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "TENKZ_OFFLINE_TRIPWIRE": str(tripwire)},
+        )
+        assert called.returncode != 0, called.stdout
+        assert tripwire.is_file(), "the shim ran and recorded nothing"
+        assert "tlmgr" in tripwire.read_text(encoding="utf-8")
+
+
+def test_the_offline_environment_inherits_nothing_that_could_answer() -> None:
+    """A user tree, a repository on the search path, or an on-demand font
+    builder would each let a run pass while proving less than it claims."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        room = Path(directory)
+        environment = tenkz_ctan.offline_environment(
+            room / "submission", room / "shims", room / "tripwire", room / "home"
+        )
+    assert environment["TEXINPUTS"] == ".:", environment["TEXINPUTS"]
+    assert str(ROOT) not in environment["TEXINPUTS"]
+    assert environment["PATH"].startswith(str(room / "shims"))
+    for tree in ("TEXMFHOME", "TEXMFVAR", "TEXMFCONFIG", "HOME"):
+        assert environment[tree].startswith(str(room / "home")), tree
+    for generator in ("MKTEXTFM", "MKTEXPK", "MKTEXMF", "MKTEXFMT"):
+        assert environment[generator] == "0", generator
+
+
+def test_the_offline_cases_are_the_picture_classes_and_still_say_so() -> None:
+    """The corpus owns the cases, so this reads them rather than copying
+    them: a case that moved, or that stopped drawing the class it was chosen
+    for, is caught without an engine."""
+
+    classes = {case.picture_class for case in tenkz_ctan.OFFLINE_CASES}
+    assert classes == {
+        "flat", "plane", "circle", "string/crossing", "enclosure", "equation"
+    }, sorted(classes)
+    assert any(
+        case.source.startswith("tests/tenkz/kernel/")
+        for case in tenkz_ctan.OFFLINE_CASES
+    ), "no self-contained kernel probe is compiled"
+    names = [case.name for case in tenkz_ctan.OFFLINE_CASES]
+    assert len(set(names)) == len(names), names
+    for case in tenkz_ctan.OFFLINE_CASES:
+        source = ROOT / case.source
+        assert source.is_file(), case.source
+        assert case.declares in source.read_text(encoding="utf-8"), case.name
+
+
+def test_the_offline_check_says_so_when_there_is_no_engine() -> None:
+    engine = tenkz_ctan.shutil.which
+    try:
+        tenkz_ctan.shutil.which = lambda _name: None
+        skipped = tenkz_ctan.check_offline(Path("unread.zip"), required=False)
+        refused = tenkz_ctan.check_offline(Path("unread.zip"), required=True)
+    finally:
+        tenkz_ctan.shutil.which = engine
+    assert skipped.status == "SKIP", skipped
+    assert refused.failures, refused
+
+
 def test_check_passes_now() -> None:
     subprocess.run([sys.executable, str(SCRIPT), "check"], check=True)
 

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -988,9 +988,9 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     assert not tenkz_ctan.shell_escape_call(
         "\\newwrite\\out\n\\immediate\\write\\out{x}\n"
     )
-    assert tenkz_ctan.shell_escape_call(
-        "\\newwrite\\out\n\\def\\out{18}\n\\write\\out{x}\n"
-    )
+    for overwritten in ("\\newwrite\\out\n\\def\\out{18}\n\\write\\out{x}\n",
+                        "\\newwrite\\out\n\\chardef\\out=18\n\\write\\out{x}\n"):
+        assert tenkz_ctan.shell_escape_call(overwritten), overwritten
     for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
                   r"\sys_get_shell:nnN {x}{y}\z", r"\ior_shell_open:Nn \x {ls}",
                   r"\iow_shell_open:Nn \x {ls}", r"\DelayedShellEscape{ls}"):
@@ -1091,6 +1091,7 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                      r"\openin\src=/Users/somebody/data.tex",
                      r"\openin1 /Users/somebody/data.tex",
                      r"\openout\log=/Users/somebody/run.log",
+                     r"\graphicspath{{/Users/somebody/figures/}}",
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -869,9 +869,21 @@ def test_a_temporary_directory_inside_the_repository_is_not_a_leak() -> None:
         room = Path(directory)
         (room / "tenkz.sty").write_text("% the staged runtime\n", encoding="utf-8")
         assert room.resolve().is_relative_to(ROOT), room
+        # The reading the offline check performs, on a room the repository
+        # contains. Both halves have to survive it: the runtime one, which asks
+        # where a tenkz file resolved, and the repository one, which asks
+        # whether anything at all came from the checkout.
         assert not tenkz_ctan.foreign_runtime_files(
             ["./tenkz.sty", "tenkz.sty"], room, room.resolve()
         )
+        assert not tenkz_ctan.repository_inputs(
+            ["./tenkz.sty", "tenkz.sty"], room, room.resolve()
+        )
+        # A file the repository really did answer is still found, so the room
+        # exclusion narrows the reading rather than emptying it.
+        assert tenkz_ctan.repository_inputs(
+            [str(ROOT / "tex/tenkz/tenkz.sty")], room, room.resolve()
+        ) == [str(ROOT / "tex/tenkz/tenkz.sty")]
 
 
 def test_a_commented_shell_call_is_not_a_shell_call() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -781,6 +781,24 @@ def test_a_class_left_out_or_stated_twice_is_caught() -> None:
     ), repeated.failures
 
 
+def test_a_package_load_is_read_in_both_of_its_spellings() -> None:
+    """A `.sty` writes `\\RequirePackage`, but nothing stops a staged runtime
+    file from writing `\\usepackage`, and the two load the same package. A walk
+    that read only the first would report a retired front end absent while it
+    was being loaded."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory) / "tex"
+        source.mkdir()
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT + "\\usepackage{tikz-cd}\n", encoding="utf-8"
+        )
+        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+    assert closure.packages == ["tikz-cd"], closure.packages
+    report = tenkz_ctan.check_dependencies(closure, _ownership([], [], []))
+    assert any("tikz-cd" in reason for reason in report.failures), report.failures
+
+
 def test_a_retired_front_end_load_fails_the_dependency_check() -> None:
     """The removed front ends each brought a load. The walk blanks comments
     before it reads one, so a retired name in the closure is a surviving load
@@ -841,11 +859,25 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
                  r"\write018{x}", '\\write"12{x}', r"\write'22{x}",
                  r"\write+18{x}", r"\write--18{x}", r"\ShellEscape{x}"):
         assert tenkz_ctan.shell_escape_call(call), call
+    # The gate fails closed, so a stream the reading cannot evaluate is a
+    # finding on its own: a character constant, an integer expression, a
+    # stream the file never allocated.
+    for unread in (r"\write`^^R{x}", r"\write\numexpr18\relax{x}",
+                   r"\write \myout{x}"):
+        assert tenkz_ctan.shell_escape_call(unread), unread
+    # A stream the same file allocated is a file stream by construction, which
+    # is how the package writes its event stream.
+    allocated = "\\newwrite\\tenkz@log\n\\immediate\\write\\tenkz@log{#1}\n"
+    assert not tenkz_ctan.shell_escape_call(allocated), allocated
+    assert tenkz_ctan.shell_escape_call(
+        "\\immediate\\write\\tenkz@log{#1}\n"
+    ), "a stream nothing allocated passed"
     # Numbers that are not 18 in the base their prefix names, an odd run of
-    # minus signs, and a stream named by a control sequence, which no constant
-    # search can read.
+    # minus signs, and a control sequence that merely starts with the same
+    # letters.
     for quiet in (r"\write17{x}", r"\write180{x}", '\\write"18{x}',
-                  r"\write-18{x}", r"\write+-18{x}", r"\write \myout{x}"):
+                  r"\write-18{x}", r"\write+-18{x}", r"\writer{x}",
+                  r"\iow_now:Nn \g_out {x}"):
         assert not tenkz_ctan.shell_escape_call(quiet), quiet
 
 

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -821,6 +821,24 @@ def test_a_package_load_is_read_in_both_of_its_spellings() -> None:
             assert any("tikz-cd" in r for r in report.failures), (spelling, report.failures)
 
 
+def test_a_retired_front_end_vendored_as_a_file_is_caught() -> None:
+    """A retired front end can arrive as a package load, a library load, or a
+    file the entry point inputs. The third reaches the closure only as a file
+    name, so the reading compares stems as well."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory) / "tex"
+        source.mkdir()
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT + "\\input{tikz-cd.sty}\n", encoding="utf-8"
+        )
+        (source / "tikz-cd.sty").write_text(STAGE_CONTRACT, encoding="utf-8")
+        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+    assert closure.files == ["tenkz.sty", "tikz-cd.sty"], closure.files
+    report = tenkz_ctan.check_dependencies(closure, _ownership([], [], []))
+    assert any("tikz-cd" in reason for reason in report.failures), report.failures
+
+
 def test_a_retired_front_end_load_fails_the_dependency_check() -> None:
     """The removed front ends each brought a load. The walk blanks comments
     before it reads one, so a retired name in the closure is a surviving load
@@ -921,6 +939,12 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     for longer in (r"\ShellEscape@status", r"\ShellEscaped{x}",
                    r"\sys_shell_now:n_aux {x}"):
         assert not tenkz_ctan.shell_escape_call(longer), longer
+    # A backslash preceded by a backslash does not start a control sequence:
+    # `\\write18` is the control symbol and then ordinary characters, and a
+    # gate that read it as the primitive would refuse a package for
+    # typesetting the spelling.
+    for typeset in (r"\\write18{x}", r"\\ShellEscape{x}"):
+        assert not tenkz_ctan.shell_escape_call(typeset), typeset
     # Numbers that are not 18 in the base their prefix names, an odd run of
     # minus signs, and a control sequence that merely starts with the same
     # letters.

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -971,10 +971,17 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     # no API.
     # The bar is a command only in a file name, so the reading is scoped to
     # one: two characters in a macro body or in prose execute nothing.
-    for piped in ('\\openin\\stream="|uname -a"', r"\input{|cmd}", r'\input "|cmd"'):
+    # The stream operand is a control sequence or a number, and the equals
+    # sign is optional: that is TeX's syntax, not a house spelling.
+    for piped in ('\\openin\\stream="|uname -a"', r"\input{|cmd}", r'\input "|cmd"',
+                  '\\openout1="|cmd"', '\\openin1="|cmd"'):
         assert tenkz_ctan.shell_escape_call(piped), piped
+    # Only the primitives that open a file are read: `\\write` and `\\read` take
+    # a stream already open and a token list that is data, so a token list
+    # beginning with a bar is text.
     for plain in ('\\openin\\stream="plain.tex"', r'\def\separator{"|}',
-                  'the sequence "| in prose'):
+                  'the sequence "| in prose',
+                  "\\newwrite\\out\n\\write\\out{|literal}\n"):
         assert not tenkz_ctan.shell_escape_call(plain), plain
     # A name the same file redefines is no longer the stream it was allocated
     # as, so the allocation ground does not carry it.
@@ -1082,6 +1089,8 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                      r"\IfFileExists{/Users/somebody/local.cfg}{}{}",
                      r"\file_input:n { /Users/somebody/local.tex }",
                      r"\openin\src=/Users/somebody/data.tex",
+                     r"\openin1 /Users/somebody/data.tex",
+                     r"\openout\log=/Users/somebody/run.log",
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -68,6 +68,23 @@ def test_closure_reads_the_load_graph_and_not_the_prose() -> None:
     assert closure.libraries == ["calc", "hobby"], closure.libraries
 
 
+def test_a_load_spelled_as_text_is_not_a_load() -> None:
+    """`\\\\usepackage` in a macro body is the control symbol and then
+    ordinary characters. Recording it would refuse a release over a
+    definition, so the closure blanks the pairs as the arXiv readings do."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory) / "tex"
+        source.mkdir()
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT + "\\def\\showload{\\\\usepackage{tikz-cd}}\n",
+            encoding="utf-8",
+        )
+        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+    assert closure.packages == [], closure.packages
+    assert not tenkz_ctan.check_dependencies(closure, _ownership([], [], [])).failures
+
+
 def test_closure_reads_the_unbraced_input() -> None:
     """Plain TeX's `\\input` takes a file name with no braces, reading to the
     next space. A walk that read only the braced form would let a stage module
@@ -841,6 +858,9 @@ def test_a_retired_front_end_vendored_as_a_file_is_caught() -> None:
     # the reading strips the prefix and the suffix a load carries.
     assert tenkz_ctan.load_names("tikzlibrarytikzcd.code.tex") >= {"tikzcd"}
     assert tenkz_ctan.load_names("tenkz-core.code.tex") >= {"tenkz-core"}
+    # A load may carry a directory, and the basename is what the prefix and
+    # the suffix are stripped from.
+    assert tenkz_ctan.load_names("vendor/tikzlibrarytikzcd.code.tex") >= {"tikzcd"}
     with tempfile.TemporaryDirectory() as directory:
         source = Path(directory) / "tex"
         source.mkdir()
@@ -939,6 +959,10 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     # The named ways to reach a shell that are not a write at all. A file
     # under `\ExplSyntaxOn` would use the expl3 interface in preference to
     # either primitive.
+    # Web2C runs a file name opening with a pipe, which names no stream and
+    # no API.
+    assert tenkz_ctan.shell_escape_call('\\openin\\stream="|uname -a"')
+    assert not tenkz_ctan.shell_escape_call('\\openin\\stream="plain.tex"')
     for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
                   r"\sys_get_shell:nnN {x}{y}\z", r"\ior_shell_open:Nn \x {ls}",
                   r"\iow_shell_open:Nn \x {ls}", r"\DelayedShellEscape{ls}"):

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -103,9 +103,11 @@ def test_closure_reads_the_unbraced_input() -> None:
         closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
         assert closure.files == ["tenkz.sty", "tenkz-stage.code.tex"], closure.files
         assert closure.packages == ["tikz-cd"], closure.packages
-        # Web2C's quoted form, which may follow the control word with no space.
+        # Web2C's quoted form, which may follow the control word with no
+        # space, and expl3's own file input.
         for spelling in ('\\input"tenkz-stage.code.tex"',
-                         '\\input {"tenkz-stage.code.tex"}'):
+                         '\\input {"tenkz-stage.code.tex"}',
+                         '\\file_input:n {tenkz-stage.code.tex}'):
             (source / "tenkz.sty").write_text(
                 STAGE_CONTRACT + spelling + "\n", encoding="utf-8"
             )
@@ -989,7 +991,8 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
         "\\newwrite\\out\n\\immediate\\write\\out{x}\n"
     )
     for overwritten in ("\\newwrite\\out\n\\def\\out{18}\n\\write\\out{x}\n",
-                        "\\newwrite\\out\n\\chardef\\out=18\n\\write\\out{x}\n"):
+                        "\\newwrite\\out\n\\chardef\\out=18\n\\write\\out{x}\n",
+                        "\\newwrite\\out\n\\cs_gset:Npn \\out {18}\n\\write\\out{x}\n"):
         assert tenkz_ctan.shell_escape_call(overwritten), overwritten
     for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
                   r"\sys_get_shell:nnN {x}{y}\z", r"\ior_shell_open:Nn \x {ls}",
@@ -1092,6 +1095,8 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                      r"\openin1 /Users/somebody/data.tex",
                      r"\openout\log=/Users/somebody/run.log",
                      r"\graphicspath{{/Users/somebody/figures/}}",
+                     # Every directory in the list, not only the first.
+                     r"\graphicspath{{figures/}{/Users/somebody/more/}}",
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -68,6 +68,26 @@ def test_closure_reads_the_load_graph_and_not_the_prose() -> None:
     assert closure.libraries == ["calc", "hobby"], closure.libraries
 
 
+def test_closure_reads_the_unbraced_input() -> None:
+    """Plain TeX's `\\input` takes a file name with no braces, reading to the
+    next space. A walk that read only the braced form would let a stage module
+    reach an upload without reaching the pin, and the load it brought with it
+    would go unread."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory) / "tex"
+        source.mkdir()
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT + "\\input tenkz-stage.code.tex\n", encoding="utf-8"
+        )
+        (source / "tenkz-stage.code.tex").write_text(
+            STAGE_CONTRACT + "\\usepackage{tikz-cd}\n", encoding="utf-8"
+        )
+        closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+    assert closure.files == ["tenkz.sty", "tenkz-stage.code.tex"], closure.files
+    assert closure.packages == ["tikz-cd"], closure.packages
+
+
 def test_closure_reads_tex_spacing_before_arguments() -> None:
     with tempfile.TemporaryDirectory() as directory:
         source = Path(directory) / "tex"
@@ -889,13 +909,18 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     # either primitive.
     for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
                   r"\sys_get_shell:nnN {x}{y}\z", r"\ior_shell_open:Nn \x {ls}",
-                  r"\iow_shell_open:Nn \x {ls}"):
+                  r"\iow_shell_open:Nn \x {ls}", r"\DelayedShellEscape{ls}"):
         assert tenkz_ctan.shell_escape_call(named), named
     # Asking whether the engine has a shell runs nothing. Reading these as
     # calls would refuse a file for putting the question.
     for asks in (r"\tex_shellescape:D", r"\sys_if_shell:TF {y}{n}",
                  r"\sys_shell_open:Nn \x {ls}"):
         assert not tenkz_ctan.shell_escape_call(asks), asks
+    # A longer control word that merely starts with an executor's letters is a
+    # different macro, on the same boundary rule the write gate uses.
+    for longer in (r"\ShellEscape@status", r"\ShellEscaped{x}",
+                   r"\sys_shell_now:n_aux {x}"):
+        assert not tenkz_ctan.shell_escape_call(longer), longer
     # Numbers that are not 18 in the base their prefix names, an odd run of
     # minus signs, and a control sequence that merely starts with the same
     # letters.
@@ -967,6 +992,7 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
         for load in (r"\includegraphics*{/Users/somebody/figure.pdf}",
                      r"\includegraphics *{/Users/somebody/figure.pdf}",
                      r"\InputIfFileExists{/Users/somebody/local.cfg}{}{}",
+                     r"\IfFileExists{/Users/somebody/local.cfg}{}{}",
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -834,7 +834,9 @@ def test_a_tree_arxiv_would_have_to_build_or_shell_out_for_fails() -> None:
         tree = Path(directory) / PACKAGE_DIR
         (tree / "nested").mkdir(parents=True)
         (tree / "tenkz.sty").write_text("% a runtime file\n", encoding="utf-8")
-        (tree / "tenkz.ins").write_text("% a docstrip run\n", encoding="utf-8")
+        # Upper case is the same docstrip run: a file system that preserves
+        # case hands the suffix back as it was typed.
+        (tree / "tenkz.INS").write_text("% a docstrip run\n", encoding="utf-8")
         (tree / "loud.sty").write_text("\\immediate \\write 18{rm -rf /}\n", encoding="utf-8")
         (tree / "elsewhere.sty").write_text(
             "\\input{/Users/somebody/tenkz-core.code.tex}\n", encoding="utf-8"
@@ -844,7 +846,7 @@ def test_a_tree_arxiv_would_have_to_build_or_shell_out_for_fails() -> None:
         )
     findings = " ".join(report.failures)
     assert "nested" in findings, report.failures
-    assert "tenkz.ins" in findings, report.failures
+    assert "tenkz.INS" in findings, report.failures
     # The spaced spelling opens the same stream as the compact one, and TeX
     # reads the number either way.
     assert "write 18" in findings, report.failures
@@ -886,8 +888,13 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     # either primitive.
     for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
                   r"\sys_get_shell:nnN {x}{y}\z", r"\ior_shell_open:Nn \x {ls}",
-                  r"\iow_shell_open:Nn \x {ls}", r"\tex_shellescape:D"):
+                  r"\iow_shell_open:Nn \x {ls}"):
         assert tenkz_ctan.shell_escape_call(named), named
+    # Asking whether the engine has a shell runs nothing. Reading these as
+    # calls would refuse a file for putting the question.
+    for asks in (r"\tex_shellescape:D", r"\sys_if_shell:TF {y}{n}",
+                 r"\sys_shell_open:Nn \x {ls}"):
+        assert not tenkz_ctan.shell_escape_call(asks), asks
     # Numbers that are not 18 in the base their prefix names, an odd run of
     # minus signs, and a control sequence that merely starts with the same
     # letters.
@@ -958,7 +965,9 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
         # file is not submittable even when the file's absence is handled.
         for load in (r"\includegraphics*{/Users/somebody/figure.pdf}",
                      r"\includegraphics *{/Users/somebody/figure.pdf}",
-                     r"\InputIfFileExists{/Users/somebody/local.cfg}{}{}"):
+                     r"\InputIfFileExists{/Users/somebody/local.cfg}{}{}",
+                     # A path holding a space is written quoted, braced or not.
+                     '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")
             found = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
             assert any("absolute path" in r for r in found.failures), (load, found.failures)

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -872,6 +872,14 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     assert tenkz_ctan.shell_escape_call(
         "\\immediate\\write\\tenkz@log{#1}\n"
     ), "a stream nothing allocated passed"
+    # A control word that merely begins with the primitive's letters is a name,
+    # not the primitive: `@` is a letter in a package and `_` and `:` are
+    # letters under `\ExplSyntaxOn`, so refusing these would block a release
+    # over a spelling.
+    for name in (r"\write@event{x}", r"\write:nn {x}{y}", r"\write_stuff{x}"):
+        assert not tenkz_ctan.shell_escape_call(name), name
+    # The one assembled spelling that is still readable from the text.
+    assert tenkz_ctan.shell_escape_call(r"\csname write\endcsname18{x}")
     # Numbers that are not 18 in the base their prefix names, an odd run of
     # minus signs, and a control sequence that merely starts with the same
     # letters.
@@ -936,6 +944,12 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
             "\\input /Users/somebody/tenkz-core.code.tex\n", encoding="utf-8"
         )
         unbraced = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
+        # A starred form puts its star between the command and its arguments.
+        (tree / "tenkz.sty").write_text(
+            "\\includegraphics*{/Users/somebody/figure.pdf}\n", encoding="utf-8"
+        )
+        starred = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
+        assert any("absolute path" in reason for reason in starred.failures), starred.failures
         (tree / "tenkz.sty").write_text("\\input tenkz-core.code.tex\n", encoding="utf-8")
         relative = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
     assert any("absolute path" in reason for reason in unbraced.failures), unbraced.failures

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import zipfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -1112,6 +1113,114 @@ def test_the_offline_check_says_so_when_there_is_no_engine() -> None:
         tenkz_ctan.shutil.which = engine
     assert skipped.status == "SKIP", skipped
     assert refused.failures, refused
+
+
+def test_the_offline_check_reports_a_case_that_cannot_be_read() -> None:
+    """The two findings that need no engine: a case source that has moved, and
+    one that no longer spells the construct it was chosen for. Both are seeded
+    here because a guard nobody has watched fail is not a guard."""
+
+    engine = tenkz_ctan.shutil.which
+    saved = tenkz_ctan.OFFLINE_CASES
+    flat = next(case for case in saved if case.name == "flat")
+    moved = tenkz_ctan.OfflineCase(
+        flat.name, flat.picture_class, "tests/tenkz/rmp/gone.tex", False,
+        flat.declares, flat.emits,
+    )
+    renamed = tenkz_ctan.OfflineCase(
+        flat.name, flat.picture_class, flat.source, False,
+        r"\begin{something-else}", flat.emits,
+    )
+    with tempfile.TemporaryDirectory() as directory:
+        archive, _, _ = tenkz_ctan.build(Path(directory) / "out")
+        try:
+            tenkz_ctan.shutil.which = lambda _name: "/somewhere/xelatex"
+            tenkz_ctan.OFFLINE_CASES = (moved,)
+            gone = tenkz_ctan.check_offline(archive, required=True)
+            tenkz_ctan.OFFLINE_CASES = (renamed,)
+            drifted = tenkz_ctan.check_offline(archive, required=True)
+        finally:
+            tenkz_ctan.shutil.which = engine
+            tenkz_ctan.OFFLINE_CASES = saved
+    assert any("gone.tex is missing" in reason for reason in gone.failures), gone.failures
+    assert any("no longer spells" in reason for reason in drifted.failures), drifted.failures
+
+
+def test_the_offline_check_reports_an_archive_it_cannot_read() -> None:
+    """Three shapes an archive can arrive in that are not an upload, each
+    seeded and each required to be a report line rather than a traceback."""
+
+    engine = tenkz_ctan.shutil.which
+    with tempfile.TemporaryDirectory() as directory:
+        room = Path(directory)
+        (room / "torn.zip").write_bytes(b"not a zip file at all")
+        real = ROOT / "docs/tenkz/ctan/MANIFEST.toml"
+        with zipfile.ZipFile(room / "loose.zip", "w") as bundle:
+            bundle.writestr("tenkz.sty", real.read_bytes())
+        with zipfile.ZipFile(room / "nested.zip", "w") as bundle:
+            bundle.writestr(f"{PACKAGE_DIR}/tenkz.sty", real.read_bytes())
+            bundle.writestr(f"{PACKAGE_DIR}/runtime/", b"")
+        try:
+            tenkz_ctan.shutil.which = lambda _name: "/somewhere/xelatex"
+            reports = {
+                name: tenkz_ctan.check_offline(room / f"{name}.zip", required=True)
+                for name in ("torn", "loose", "nested")
+            }
+        finally:
+            tenkz_ctan.shutil.which = engine
+    assert any("does not open" in r for r in reports["torn"].failures), reports["torn"].failures
+    assert any(
+        "does not unpack into a single" in r for r in reports["loose"].failures
+    ), reports["loose"].failures
+    assert any(
+        "is not a file" in r for r in reports["nested"].failures
+    ), reports["nested"].failures
+
+
+def test_an_installer_that_fired_is_read_as_a_finding() -> None:
+    """The shim half is pinned above. This is the reading that turns a shim
+    that fired into a failed check, seeded by leaving the record a shim would
+    have written."""
+
+    engine = tenkz_ctan.shutil.which
+    saved = tenkz_ctan.OFFLINE_CASES
+    original = tenkz_ctan.write_shims
+
+    def firing(shims: Path) -> None:
+        original(shims)
+        (shims.parent / "reached-for.txt").write_text("/shims/tlmgr\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory() as directory:
+        archive, _, _ = tenkz_ctan.build(Path(directory) / "out")
+        try:
+            tenkz_ctan.shutil.which = lambda _name: "/somewhere/xelatex"
+            tenkz_ctan.write_shims = firing
+            # No case is compiled: the engine is a fiction here, and the
+            # reading under test runs after the cases either way.
+            tenkz_ctan.OFFLINE_CASES = ()
+            report = tenkz_ctan.check_offline(archive, required=True)
+        finally:
+            tenkz_ctan.shutil.which = engine
+            tenkz_ctan.write_shims = original
+            tenkz_ctan.OFFLINE_CASES = saved
+    assert any(
+        "reached for an installer" in reason for reason in report.failures
+    ), report.failures
+
+
+def test_an_ownership_class_of_the_wrong_shape_is_named() -> None:
+    """The two remaining shapes a classification can arrive in: a class nobody
+    declared, and a class that is not a list of names."""
+
+    closure = tenkz_ctan.Closure(libraries=["calc"], packages=["tikz"])
+    invented = _ownership(["calc"], [], [])
+    invented["runtime"]["requires"]["ownership"]["legacy"] = ["calc"]
+    unknown = tenkz_ctan.check_dependencies(closure, invented)
+    assert any("legacy" in reason for reason in unknown.failures), unknown.failures
+    misshapen = _ownership(["calc"], [], [])
+    misshapen["runtime"]["requires"]["ownership"]["placement"] = "calc"
+    shape = tenkz_ctan.check_dependencies(closure, misshapen)
+    assert any("not a list" in reason for reason in shape.failures), shape.failures
 
 
 def test_check_passes_now() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -885,7 +885,8 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     # under `\ExplSyntaxOn` would use the expl3 interface in preference to
     # either primitive.
     for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
-                  r"\sys_shell_open:Nn \x {ls}", r"\sys_get_shell:nnN {x}{y}\z"):
+                  r"\sys_get_shell:nnN {x}{y}\z", r"\ior_shell_open:Nn \x {ls}",
+                  r"\iow_shell_open:Nn \x {ls}", r"\tex_shellescape:D"):
         assert tenkz_ctan.shell_escape_call(named), named
     # Numbers that are not 18 in the base their prefix names, an odd run of
     # minus signs, and a control sequence that merely starts with the same

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -801,6 +801,12 @@ def test_the_real_classification_covers_the_real_load_list() -> None:
     assert not report.failures, report.failures
 
 
+def _loaded(*names: str) -> "tenkz_ctan.Closure":
+    """A closure that loads exactly the named files, for the arXiv reading."""
+
+    return tenkz_ctan.Closure(files=list(names))
+
+
 def test_a_tree_arxiv_would_have_to_build_or_shell_out_for_fails() -> None:
     """The submission reading of the same files: flat, already the runtime,
     naming no path on the machine that wrote it, calling no shell."""
@@ -810,16 +816,39 @@ def test_a_tree_arxiv_would_have_to_build_or_shell_out_for_fails() -> None:
         (tree / "nested").mkdir(parents=True)
         (tree / "tenkz.sty").write_text("% a runtime file\n", encoding="utf-8")
         (tree / "tenkz.ins").write_text("% a docstrip run\n", encoding="utf-8")
-        (tree / "loud.sty").write_text("\\immediate\\write18{rm -rf /}\n", encoding="utf-8")
+        (tree / "loud.sty").write_text("\\immediate \\write 18{rm -rf /}\n", encoding="utf-8")
         (tree / "elsewhere.sty").write_text(
             "\\input{/Users/somebody/tenkz-core.code.tex}\n", encoding="utf-8"
         )
-        report = tenkz_ctan.check_arxiv(tree)
+        report = tenkz_ctan.check_arxiv(
+            tree, _loaded("tenkz.sty", "loud.sty", "elsewhere.sty")
+        )
     findings = " ".join(report.failures)
     assert "nested" in findings, report.failures
     assert "tenkz.ins" in findings, report.failures
-    assert "write18" in findings, report.failures
+    # The spaced spelling opens the same stream as the compact one, and TeX
+    # reads the number either way.
+    assert "write 18" in findings, report.failures
     assert "absolute path" in findings, report.failures
+
+
+def test_a_loaded_source_is_read_whatever_it_is_called() -> None:
+    """The scan follows the load graph rather than a list of suffixes, so a
+    runtime file added later as a class or a configuration is read because it
+    is loaded, and reader-facing material is not read at all."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        tree = Path(directory) / PACKAGE_DIR
+        tree.mkdir(parents=True)
+        (tree / "tenkz.cfg").write_text("\\write18{uname -a}\n", encoding="utf-8")
+        (tree / "CHANGES.md").write_text(
+            "The package calls no \\write18 and loads no /absolute path.\n",
+            encoding="utf-8",
+        )
+        scanned = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.cfg"))
+        unscanned = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
+    assert any("write18" in reason for reason in scanned.failures), scanned.failures
+    assert not unscanned.failures, unscanned.failures
 
 
 def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
@@ -833,9 +862,9 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
         (tree / "tenkz.sty").write_text(
             "\\input /Users/somebody/tenkz-core.code.tex\n", encoding="utf-8"
         )
-        unbraced = tenkz_ctan.check_arxiv(tree)
+        unbraced = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
         (tree / "tenkz.sty").write_text("\\input tenkz-core.code.tex\n", encoding="utf-8")
-        relative = tenkz_ctan.check_arxiv(tree)
+        relative = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
     assert any("absolute path" in reason for reason in unbraced.failures), unbraced.failures
     assert not relative.failures, relative.failures
 
@@ -898,7 +927,7 @@ def test_a_commented_shell_call_is_not_a_shell_call() -> None:
             "% tenkz never calls \\write18, and never loads {/absolute}.\n",
             encoding="utf-8",
         )
-        report = tenkz_ctan.check_arxiv(tree)
+        report = tenkz_ctan.check_arxiv(tree, _loaded("tenkz.sty"))
     assert not report.failures, report.failures
 
 

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -765,6 +765,22 @@ def test_a_manifest_with_no_classification_at_all_is_named() -> None:
     assert any("ownership" in reason for reason in report.failures), report.failures
 
 
+def test_a_class_left_out_or_stated_twice_is_caught() -> None:
+    """A class omitted reads as one nobody considered, and a library named
+    twice inside one class reads as more consumers than were traced. Neither
+    is caught by the cover comparison, which goes through a set."""
+
+    closure = tenkz_ctan.Closure(libraries=["calc"], packages=["tikz"])
+    dropped = _ownership(["calc"], [], [])
+    del dropped["runtime"]["requires"]["ownership"]["unconsumed"]
+    missing = tenkz_ctan.check_dependencies(closure, dropped)
+    assert any("unconsumed" in reason for reason in missing.failures), missing.failures
+    repeated = tenkz_ctan.check_dependencies(closure, _ownership(["calc", "calc"], [], []))
+    assert any(
+        "more than once" in reason for reason in repeated.failures
+    ), repeated.failures
+
+
 def test_a_retired_front_end_load_fails_the_dependency_check() -> None:
     """The removed front ends each brought a load. The walk blanks comments
     before it reads one, so a retired name in the closure is a surviving load
@@ -804,6 +820,58 @@ def test_a_tree_arxiv_would_have_to_build_or_shell_out_for_fails() -> None:
     assert "tenkz.ins" in findings, report.failures
     assert "write18" in findings, report.failures
     assert "absolute path" in findings, report.failures
+
+
+def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
+    """Plain TeX's `\\input` takes a filename with no braces, reading to the
+    next space. A gate that only read the braced spelling would pass a staged
+    file that loads from the machine it was written on."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        tree = Path(directory) / PACKAGE_DIR
+        tree.mkdir(parents=True)
+        (tree / "tenkz.sty").write_text(
+            "\\input /Users/somebody/tenkz-core.code.tex\n", encoding="utf-8"
+        )
+        unbraced = tenkz_ctan.check_arxiv(tree)
+        (tree / "tenkz.sty").write_text("\\input tenkz-core.code.tex\n", encoding="utf-8")
+        relative = tenkz_ctan.check_arxiv(tree)
+    assert any("absolute path" in reason for reason in unbraced.failures), unbraced.failures
+    assert not relative.failures, relative.failures
+
+
+def test_an_archive_that_does_not_open_is_a_report_line() -> None:
+    """The tool's contract is that every finding is a printed line. An archive
+    that is not one, or that does not hold the directory an upload is judged
+    on, has to arrive as a failed check rather than as a traceback."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        room = Path(directory)
+        torn = room / "torn.zip"
+        torn.write_bytes(b"not a zip file at all")
+        engine = tenkz_ctan.shutil.which
+        try:
+            tenkz_ctan.shutil.which = lambda _name: "/somewhere/xelatex"
+            report = tenkz_ctan.check_offline(torn, required=True)
+        finally:
+            tenkz_ctan.shutil.which = engine
+    assert report.status == "FAIL", report
+    assert any("does not open" in reason for reason in report.failures), report.failures
+
+
+def test_a_temporary_directory_inside_the_repository_is_not_a_leak() -> None:
+    """`tempfile` puts the room wherever `TMPDIR` says, and a runner that puts
+    it inside the workspace would otherwise make every file the flat archive
+    itself answered look like one the repository answered."""
+
+    (ROOT / "build").mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=ROOT / "build") as directory:
+        room = Path(directory)
+        (room / "tenkz.sty").write_text("% the staged runtime\n", encoding="utf-8")
+        assert room.resolve().is_relative_to(ROOT), room
+        assert not tenkz_ctan.foreign_runtime_files(
+            ["./tenkz.sty", "tenkz.sty"], room, room.resolve()
+        )
 
 
 def test_a_commented_shell_call_is_not_a_shell_call() -> None:

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -107,7 +107,9 @@ def test_closure_reads_the_unbraced_input() -> None:
         # space, and expl3's own file input.
         for spelling in ('\\input"tenkz-stage.code.tex"',
                          '\\input {"tenkz-stage.code.tex"}',
-                         '\\file_input:n {tenkz-stage.code.tex}'):
+                         '\\file_input:n {tenkz-stage.code.tex}',
+                         '\\InputIfFileExists{tenkz-stage.code.tex}{}{}',
+                         '\\file_if_exist_input:n {tenkz-stage.code.tex}'):
             (source / "tenkz.sty").write_text(
                 STAGE_CONTRACT + spelling + "\n", encoding="utf-8"
             )
@@ -1106,6 +1108,10 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                      r"\graphicspath{{figures/}{/Users/somebody/more/}}",
                      r"\file_get:nnN {/Users/somebody/data} {} \l_tmpa_tl",
                      r"\ior_open:Nn \stream {/Users/somebody/data}",
+                     # The argument signature is part of an expl3 name, so the
+                     # conditional variants have to be reached too.
+                     r"\file_if_exist_input:nF {/Users/somebody/data}{}",
+                     '\\font\\tenkzfont="/Users/somebody/foo.otf"',
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -994,6 +994,13 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
                         "\\newwrite\\out\n\\chardef\\out=18\n\\write\\out{x}\n",
                         "\\newwrite\\out\n\\cs_gset:Npn \\out {18}\n\\write\\out{x}\n"):
         assert tenkz_ctan.shell_escape_call(overwritten), overwritten
+    # Asking about a name is not rebinding it: taking the allocation ground
+    # away for a question would refuse a release for looking.
+    for asked in (r"\cs_if_exist:NTF \out {y}{n}", r"\cs_show:N \out",
+                  r"\cs_use:N \out"):
+        assert not tenkz_ctan.shell_escape_call(
+            "\\newwrite\\out\n" + asked + "\n\\immediate\\write\\out{x}\n"
+        ), asked
     for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
                   r"\sys_get_shell:nnN {x}{y}\z", r"\ior_shell_open:Nn \x {ls}",
                   r"\iow_shell_open:Nn \x {ls}", r"\DelayedShellEscape{ls}"):
@@ -1097,6 +1104,8 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                      r"\graphicspath{{/Users/somebody/figures/}}",
                      # Every directory in the list, not only the first.
                      r"\graphicspath{{figures/}{/Users/somebody/more/}}",
+                     r"\file_get:nnN {/Users/somebody/data} {} \l_tmpa_tl",
+                     r"\ior_open:Nn \stream {/Users/somebody/data}",
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -101,8 +101,16 @@ def test_closure_reads_the_unbraced_input() -> None:
             STAGE_CONTRACT + "\\usepackage{tikz-cd}\n", encoding="utf-8"
         )
         closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
-    assert closure.files == ["tenkz.sty", "tenkz-stage.code.tex"], closure.files
-    assert closure.packages == ["tikz-cd"], closure.packages
+        assert closure.files == ["tenkz.sty", "tenkz-stage.code.tex"], closure.files
+        assert closure.packages == ["tikz-cd"], closure.packages
+        # Web2C's quoted form, which may follow the control word with no space.
+        for spelling in ('\\input"tenkz-stage.code.tex"',
+                         '\\input {"tenkz-stage.code.tex"}'):
+            (source / "tenkz.sty").write_text(
+                STAGE_CONTRACT + spelling + "\n", encoding="utf-8"
+            )
+            quoted = tenkz_ctan.walk_closure(source, "tenkz.sty")
+            assert quoted.files == ["tenkz.sty", "tenkz-stage.code.tex"], spelling
 
 
 def test_closure_reads_tex_spacing_before_arguments() -> None:
@@ -961,8 +969,21 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
     # either primitive.
     # Web2C runs a file name opening with a pipe, which names no stream and
     # no API.
-    assert tenkz_ctan.shell_escape_call('\\openin\\stream="|uname -a"')
-    assert not tenkz_ctan.shell_escape_call('\\openin\\stream="plain.tex"')
+    # The bar is a command only in a file name, so the reading is scoped to
+    # one: two characters in a macro body or in prose execute nothing.
+    for piped in ('\\openin\\stream="|uname -a"', r"\input{|cmd}", r'\input "|cmd"'):
+        assert tenkz_ctan.shell_escape_call(piped), piped
+    for plain in ('\\openin\\stream="plain.tex"', r'\def\separator{"|}',
+                  'the sequence "| in prose'):
+        assert not tenkz_ctan.shell_escape_call(plain), plain
+    # A name the same file redefines is no longer the stream it was allocated
+    # as, so the allocation ground does not carry it.
+    assert not tenkz_ctan.shell_escape_call(
+        "\\newwrite\\out\n\\immediate\\write\\out{x}\n"
+    )
+    assert tenkz_ctan.shell_escape_call(
+        "\\newwrite\\out\n\\def\\out{18}\n\\write\\out{x}\n"
+    )
     for named in (r"\sys_shell_now:n {ls}", r"\sys_shell_shipout:x {ls}",
                   r"\sys_get_shell:nnN {x}{y}\z", r"\ior_shell_open:Nn \x {ls}",
                   r"\iow_shell_open:Nn \x {ls}", r"\DelayedShellEscape{ls}"):
@@ -1060,6 +1081,7 @@ def test_an_unbraced_absolute_input_is_an_absolute_path() -> None:
                      r"\InputIfFileExists{/Users/somebody/local.cfg}{}{}",
                      r"\IfFileExists{/Users/somebody/local.cfg}{}{}",
                      r"\file_input:n { /Users/somebody/local.tex }",
+                     r"\openin\src=/Users/somebody/data.tex",
                      # A path holding a space is written quoted, braced or not.
                      '\\input{"/Users/somebody/My Documents/f.tex"}'):
             (tree / "tenkz.sty").write_text(load + "\n", encoding="utf-8")

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -839,12 +839,13 @@ def test_every_spelling_of_stream_eighteen_is_the_shell_escape_stream() -> None:
 
     for call in (r"\write18{x}", r"\write 18{x}", r"\immediate \write 18{x}",
                  r"\write018{x}", '\\write"12{x}', r"\write'22{x}",
-                 r"\ShellEscape{x}"):
+                 r"\write+18{x}", r"\write--18{x}", r"\ShellEscape{x}"):
         assert tenkz_ctan.shell_escape_call(call), call
-    # Numbers that are not 18 in the base their prefix names, and a stream
-    # named by a control sequence, which no constant search can read.
+    # Numbers that are not 18 in the base their prefix names, an odd run of
+    # minus signs, and a stream named by a control sequence, which no constant
+    # search can read.
     for quiet in (r"\write17{x}", r"\write180{x}", '\\write"18{x}',
-                  r"\write \myout{x}"):
+                  r"\write-18{x}", r"\write+-18{x}", r"\write \myout{x}"):
         assert not tenkz_ctan.shell_escape_call(quiet), quiet
 
 
@@ -857,7 +858,9 @@ def test_a_closure_file_the_archive_forgot_stays_in_the_reading() -> None:
     (ROOT / "build").mkdir(exist_ok=True)
     with tempfile.TemporaryDirectory(dir=ROOT / "build") as directory:
         room = Path(directory)
-        carried = set(tenkz_ctan.walk_closure().files)
+        # The production reading, not a local rebuild of it: narrowing this
+        # again is what the test exists to catch.
+        carried = tenkz_ctan.carried_runtime()
         forgotten = "tenkz-string.code.tex"
         assert forgotten in carried, sorted(carried)
         # The engine answered it from an installation instead of the flat.


### PR DESCRIPTION
Closes LionSR/tenkz#130.

Rederives the runtime dependency list from actual consumers now that the
cd, free, and lattice front ends are gone, and compiles the vendored flat
offline against a case of every picture class the release is judged on.

## The dependency report

`docs/tenkz/ctan/DEPENDENCIES.md` traces every load to the code that reads
it, with file and line, and separates the two ownerships the issue asks
for. The classification is pinned in `MANIFEST.toml` under
`[runtime.requires.ownership]` and checked, so a library that enters or
leaves the load list without a traced consumer fails
`scripts/tenkz_ctan.py check` rather than sitting in a document that
quietly goes stale.

| Class | Libraries |
|---|---|
| Placement and model ownership | `calc`, `hobby`, `intersections`, `spath3` |
| Host ink | `arrows.meta`, `backgrounds`, `decorations.markings`, `decorations.pathreplacing`, `shapes.geometric` |
| Loaded and unread | `fit` |

The manifest and the walked closure did not disagree, and could not: the
closure is walked from `tenkz.sty` and the pin is compared against it. The
disagreement is between the load list and the source, and finding it took
two methods rather than one.

The first pass searched for each library's own name and put both
`backgrounds` and `fit` in `unconsumed`. That was wrong for `backgrounds`,
and review caught it: a library is reached through the names it defines,
not through its own, so the search for `backgrounds` found two sentences
and missed `\begin{pgfonlayer}{background}` in `\tenkz_tree_geometry:n`
(`tenkz-tree.code.tex:472-488`), the layer a fusion tree draws its skin on.
No file under `tex/tenkz/` declares a layer of its own, so the load is the
only thing that declares it. `backgrounds` is now in `ink`.

`fit` was then re-verified by the method that would have caught the first
error rather than the one that missed it. Each load was removed in turn and
the whole corpus compiled against the result, 468 fixtures: every case
under `tests/tenkz/rmp/`, every kernel probe including the nested suites,
every string probe.

- Without `backgrounds`, `rmp-iii-a-fusion-tensor` fails with `Package pgf
  Error: Sorry, the requested layer 'background' could not be found`, and
  compiles with the load restored.
- Without `fit`, all 334 positive fixtures compile. The 134 failures are
  exactly the 134 negative fixtures, each failing with the tenkz coded
  error it exists to produce; none names pgf, a missing key, or `fit`.

`fit` is recorded rather than dropped. It comes from pgf, so an
installation that has `tikz` has it and the upload's external requirements
are unchanged either way; removing the load would change what a host
document inherits when it loads tenkz, which is a release decision about
the load-time surface rather than a staging one. The `unconsumed` class
keeps the decision visible, and a later consumer moves the entry rather
than appearing without one.

`check_dependencies` verifies the classification is internally consistent:
every loaded library filed exactly once, no class left out, no library
named twice within a class. It cannot tell an unread library from one whose
consumer nobody found, and its docstring and `DEPENDENCIES.md` both say so
and name the ablation as the reading that settles it.

## tikz-cd

Provably absent. No file under `tex/tenkz/` loads `tikz-cd`, `tikzcd`, or
`quantikz`. The single occurrence of the name is a sentence in `tenkz.sty`
saying commutative diagrams belong to tikz-cd and are outside this
language. The closure walk blanks comments before it reads a load, so that
sentence cannot reach the dependency list, and the check reads the absence
from the walked closure. A test asserts the same thing directly and a
second test seeds a fabricated `tikz-cd` load to confirm the check catches
one. The blueprint keeps its own `tikz-cd` load in
`blueprint/src/macros/diagrams.tex`; that is not on the graph walked from
`tenkz.sty` and nothing the archive carries reads it.

## The offline compile

`python3 scripts/tenkz_ctan.py offline` builds the archive, unpacks it into
one directory with no subdirectory, writes the cases beside it, and
compiles each there. It also runs inside `check`, which is the gate
`UPLOAD-CHECKLIST.md` names, and skips without an engine as the
clean-install check does. It adds about 40 seconds to `check`.

Eight cases over the six required classes, all passing:

| Class | Case | Evidence read from the run |
|---|---|---|
| flat | `rmp-ii-mps-marginal` | atoms and wires, and no frame record |
| plane | `rmp-ii-peps-marginal` | a frame record naming the plane map |
| circle | `rmp-ii-triangle-network` | a boundary signature with a numeric compass face, which is what transporting a port along a station's outward radius produces |
| string/crossing | `rmp-iii-b-braid-two` | crossing records |
| enclosure | `rmp-ii-peps-projection` | an enclosure mark |
| equation | `rmp-ii-mpu-brickwork` | a check record that folded its panels into a relation |
| plane, self-contained | `tests/tenkz/kernel/k_plane.tex` | the same frame record |
| string/crossing, self-contained | `tests/tenkz/kernel/k_braid.tex` | the same crossing records |

Six are the review benchmark's preamble-free fragments, compiled inside the
standalone document an author writes around them; two are kernel probes
carrying their own preamble, so the self-contained document form is covered
as well as the fragment form. Every run is read, not counted: the event
stream goes through `scripts/tenkz_audit.py`, the audit `HACKING.md`
prescribes, so an empty picture, a detached closure, a crossing that
produced no occlusion, or an equation whose sides expose different
boundaries is a failure; the engine's input record has to show every
runtime file resolving inside the flat directory; and the class marker
above has to appear. Both negative paths were exercised: an archive with
one runtime file removed fails at compile, and a case pointed at a picture
of another class fails on the marker.

No missing dependency and no staging bug turned up. The flat compiled on
the first attempt.

## How the isolation was enforced, and its limits

The run gets an environment built rather than inherited. `HOME`,
`TEXMFHOME`, `TEXMFVAR`, and `TEXMFCONFIG` point at empty directories, so
no personally installed copy of tenkz can answer. `TEXINPUTS` is `.:`, the
current directory and then the installation: the repository is not on it,
and the empty last element is what leaves `tikz`, `hobby`, and `spath3`
findable. `MKTEXTFM`, `MKTEXPK`, `MKTEXMF`, and `MKTEXFMT` are set to
refuse, so no font or format is built on demand. Fourteen installers and
fetchers, `tlmgr` and the `mktex` family among them, are shadowed by
scripts first on `PATH` that record their own call and exit non-zero, and
the check fails if any of them was reached for. The engine runs with
`-no-shell-escape`, so it can start no process of its own. Proxy variables
point at the discard port.

The limit, stated in the report and not overclaimed: this does not prove
the machine had no network. It proves the runs installed nothing, fetched
nothing, generated no font and no format, and read no file from this
repository. Every tenkz file came from the unpacked archive and everything
else came from the pinned installation. A stronger claim would need the run
confined to a network namespace, which is not portable to the platforms
this harness runs on.

## arXiv suitability

Confirmed by a check rather than by inspection. The staged tree is flat,
one directory deep; it carries no `.dtx`, `.ins`, `.fmt`, `.mf`, or `.drv`,
so nothing has to be run before the runtime exists; no staged source loads
a file by absolute path; and no staged source calls `\write18` or
`\ShellEscape`. The compile above is the same tree read the way a
submission is read, unpacked beside the manuscript rather than installed.

## Every assertion was seeded and watched to fail

A gate that cannot fail reads as coverage. One of the offline assertions
could not: it required that a run had opened one of the archive's runtime
files, and the event stream is written by tenkz and by nothing else, so a
run that reached the assertion had already loaded the package. It is
deleted, with a comment saying why, leaving the reading that can fail,
which is where those files resolved from.

Every remaining offline assertion was then seeded with a violation and
watched to produce its finding. All ten fired:

| seeded violation | the finding it produced |
|---|---|
| a case source that has moved | `gone.tex is missing; the flat case has moved` |
| a case that no longer spells its construct | `no longer spells '\begin{something-else}'` |
| a flat case that writes a frame record | `records '(?m)^frame\|', which a flat picture does not write` |
| a circle case drawing no circle | `records no circle picture` |
| the archive missing a runtime file | `failed to compile from the flat archive, exit 1` |
| a file read from the repository | `read [...] from the repository` |
| a runtime file answered from outside the flat | `resolved a runtime file outside the flat archive` |
| an event audit that refuses the stream | `failed the event audit` |
| an installer reached for during the runs | `the runs reached for an installer or a fetcher` |
| an archive without its package directory | `does not unpack into a single tenkz/ directory` |

The two hardest to reach are worth naming. For the seventh, a second
complete runtime was unpacked beside the room and put earlier on
`TEXINPUTS`: the run compiled, and the check reported that an installed
copy had answered. For the sixth, the wrapper read a repository file by
absolute path: the run compiled, and the check reported the read. Both
seeds are reverted.

Seven of the ten need no engine and are pinned as tests rather than left
as a run-once claim. The four that need one are reproducible from the case
table by the same substitutions.

Two limits, stated rather than implied. The tripwire is proven in two
halves, the shim recording its own call and the check reading a shim that
fired; no seed proves a real run would invoke one, because with
`-no-shell-escape` the engine can start no process at all, which is the
point of the flag. And the arXiv shell reading is a reading of source: it
evaluates a `\write` constant in any base, accepts a stream the same file
allocated, and refuses anything else, but a primitive assembled at run
time cannot be read from text.

## The source readings, after review

The arXiv gate's two readings, for a shell call and for an absolute path,
went through eleven rounds of review. Every finding was real and every one
is fixed. What they read now, in both directions:

- a write stream in decimal, octal, or hexadecimal, with leading zeros, a
  sign run of either parity, spaces, or assembled through `\csname`;
- a stream the same file allocated, which passes, unless the file also
  rebinds the name through any of thirteen primitives or an expl3 setter;
- the named executors, from `l3kernel`'s own source rather than from
  memory, and shellesc's delayed form;
- a file name opening a pipe, scoped to the primitives that open a file;
- loaders braced, unbraced, quoted, starred, conditional, expl3, stream
  opening, font, and `\graphicspath` read as the list it is.

And, as importantly, what they do not refuse: a control word that merely
begins with an executor's letters, a spelling typeset as text after an
even-length backslash run, a `\write` to an allocated stream, a token list
beginning with a bar, and a question asked about a name rather than a
rebinding of it. Four of the eleven rounds were false positives that would
have refused a shell-free release, including one in the package's own
source.

Two boundaries are written into the source rather than left to be
inferred. The readings read source and not execution, so a primitive
assembled at run time or a stream whose value depends on reading order is
outside them. And they fail closed on what they cannot read, which is what
keeps that residue small: a `\write` whose stream is neither a constant nor
an unrebound allocation is a finding on that ground alone.

## Nothing else

No version number, no soak state, and no file under `tex/tenkz/` is
touched. `scripts/test_tenkz_ctan.py` gains twenty-seven tests at the end of the
file, appended without restructuring, so LionSR/TNLean#6163 does not conflict.

## Blocking the upload

Nothing new. The one blocking item stays the one `UPLOAD-CHECKLIST.md`
already names: the archive stages no manual, because the manual's
reproducible build is unfinished, and CTAN expects documentation in the
package. The licence question the checklist raises, whether to offer LPPL
1.3c beside Apache 2.0, is still a maintainer decision to be made before
the upload rather than after.

## Verification

- `python3 scripts/tenkz_ctan.py check --require-smoke` passes, every
  report `ok`, in about 34 seconds.
- `python3 scripts/tenkz_ctan.py offline --require-engine` passes.
- `python3 scripts/test_tenkz_ctan.py` passes, 55 tests.
- `check_tenkz_demolition.py`, `check_tenkz_dispositions.py`, and
  `check_tenkz_policy.py` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CTAN release gates and shell-escape/isolation checks that decide whether an upload is accepted, but leaves the package runtime under `tex/tenkz/` untouched.
> 
> **Overview**
> **Rederives and pins TikZ dependency ownership**, then hardens the CTAN checker so a flattened archive must compile every picture class offline the way arXiv would read it.
> 
> Adds `DEPENDENCIES.md` and a `[runtime.requires.ownership]` pin in `MANIFEST.toml` classifying loads as **placement**, **ink**, or **unconsumed** (`fit`). `check_dependencies` refuses drift from the walked closure and asserts retired front ends (`tikz-cd` / `tikzcd` / `quantikz`) stay absent.
> 
> Extends `tenkz_ctan.py` with an **`offline`** command (also run from `check`): unpacks the archive flat, compiles eight corpus cases across six picture classes under an isolated env (no installers/fetchers, no shell escape, empty user TeX trees), and audits each event stream. Adds an **`arxiv`** check for flat layout, no regenerated sources, no absolute loads, and no shell-reaching primitives. Closure parsing now covers more `\input` / package-load spellings.
> 
> Updates the upload checklist and adds matching unit tests for the new gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4fa348163ba6505fa0d301deff7079c7d421a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



