### PR TITLE
feat(MPS/Chain): formalize varying-bond OBC padding

### DIFF
--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -49,6 +49,51 @@ theorem sum_finSigmaFinEquiv {g : ℕ} {mult : Fin g → ℕ} {β : Type*}
   rw [Equiv.sum_comp finSigmaFinEquiv.symm f, ← Finset.univ_sigma_univ,
     Finset.sum_sigma]
 
+/-- A sum over dependent finite coordinates can be rewritten over coordinatewise
+larger finite types by extending the summand by zero outside the original box. -/
+theorem sum_piFin_castLE_extend_zero {ι β : Type*} [Fintype ι] [DecidableEq ι]
+    [AddCommMonoid β] (r s : ι → ℕ) (f : ((i : ι) → Fin (r i)) → β)
+    (h : ∀ i, r i ≤ s i) :
+    ∑ x, f x = ∑ y : (i : ι) → Fin (s i),
+      if hlt : ∀ i, (y i).val < r i then
+        f (fun i => ⟨(y i).val, hlt i⟩)
+      else 0 := by
+  classical
+  let p : ((i : ι) → Fin (s i)) → Prop := fun y => ∀ i, (y i).val < r i
+  let e : ((i : ι) → Fin (r i)) ≃ {y : (i : ι) → Fin (s i) // p y} := {
+    toFun x := ⟨fun i => Fin.castLE (h i) (x i), fun i => (x i).isLt⟩
+    invFun y := fun i => ⟨(y.1 i).val, y.2 i⟩
+    left_inv x := by
+      funext i
+      apply Fin.ext
+      rfl
+    right_inv y := by
+      apply Subtype.ext
+      funext i
+      apply Fin.ext
+      rfl
+  }
+  calc
+    ∑ x, f x = ∑ z : {y : (i : ι) → Fin (s i) // p y}, f (e.symm z) := by
+      exact Fintype.sum_equiv e f (fun z => f (e.symm z)) fun x => by simp
+    _ = ∑ y ∈ (Finset.univ.filter p),
+          if hlt : p y then f (fun i => ⟨(y i).val, hlt i⟩) else 0 := by
+      rw [← Finset.sum_subtype_eq_sum_filter]
+      refine Finset.sum_congr ?_ ?_
+      · ext z
+        simp [p]
+      intro z _
+      rw [dif_pos z.2]
+      congr
+    _ = ∑ y : (i : ι) → Fin (s i),
+          if hlt : ∀ i, (y i).val < r i then
+            f (fun i => ⟨(y i).val, hlt i⟩)
+          else 0 := by
+      rw [Finset.sum_filter]
+      refine Finset.sum_congr rfl ?_
+      intro y _
+      by_cases hlt : p y <;> simp [p, hlt]
+
 end Fintype
 
 namespace Fin

--- a/TNLean/MPS/Chain.lean
+++ b/TNLean/MPS/Chain.lean
@@ -16,4 +16,5 @@ import TNLean.MPS.Chain.FundamentalTheorem
 import TNLean.MPS.Chain.OneSidedInverse
 import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.TranslationInvariance
+import TNLean.MPS.Chain.VaryingBondOBC
 import TNLean.MPS.Chain.VirtualInsertion

--- a/TNLean/MPS/Chain/VaryingBondOBC.lean
+++ b/TNLean/MPS/Chain/VaryingBondOBC.lean
@@ -30,10 +30,12 @@ bond dimensions are bounded by `D`. Intermediate bond dimensions may be zero.
 
 Source: PGVWC07, arXiv:quant-ph/0608197, lines 419--429. -/
 structure OBCChainTensor (d D N : ℕ) where
+  /-- The dimension of each virtual bond space. -/
   bondDim : Fin (N + 1) → ℕ
   bondDim_le : ∀ k, bondDim k ≤ D
   left_dim : bondDim 0 = 1
   right_dim : bondDim (Fin.last N) = 1
+  /-- The rectangular matrix associated with a site and physical index. -/
   tensor : ∀ k : Fin N, Fin d →
     Matrix (Fin (bondDim k.castSucc)) (Fin (bondDim k.succ)) ℂ
 
@@ -72,13 +74,14 @@ def zeroPad (A : OBCChainTensor d D N) : MPSChainTensor d D N :=
       else 0
     else 0
 
+/-- The coefficient of a length-zero open chain is one. -/
 @[simp] theorem coeff_zero (A : OBCChainTensor d D 0) (σ : Fin 0 → Fin d) :
     coeff A σ = 1 := by
   simp [coeff, A.left_dim]
 
 /-- At length zero, the square-chain coefficient is the trace of the `D × D`
 identity matrix. This records the mismatch with `coeff_zero` explicitly. -/
-@[simp] theorem coeff_zeroPad_zero (A : OBCChainTensor d D 0)
+theorem coeff_zeroPad_zero (A : OBCChainTensor d D 0)
     (σ : Fin 0 → Fin d) :
     (zeroPad A).coeff σ = D := by
   simp [MPSChainTensor.coeff, Matrix.trace_one]

--- a/TNLean/MPS/Chain/VaryingBondOBC.lean
+++ b/TNLean/MPS/Chain/VaryingBondOBC.lean
@@ -1,0 +1,235 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.FinSum
+import TNLean.MPS.Chain.Defs
+import TNLean.MPS.Core.CyclicTrace
+
+/-!
+# Fixed-length open-boundary chains with varying bond dimensions
+
+This file records the rectangular open-boundary MPS data used in the proof of
+PGVWC07, Theorem 3. The virtual cut is fixed: only the physical configuration
+is translated. Rectangular site matrices are also embedded entrywise into a
+square site-dependent chain. This embedding is an algebraic factorization used
+inside TNLean; it is not a separately stated result of PGVWC07.
+
+## References
+
+* arXiv:quant-ph/0608197, lines 419--429 and 620--649 of
+  `Papers/quant-ph_0608197/MPSarchive.tex`.
+-/
+
+open scoped BigOperators Matrix
+
+/-- A fixed-length open-boundary MPS chain whose virtual dimensions may vary
+from bond to bond. The first and last bond spaces are one-dimensional, and all
+bond dimensions are bounded by `D`. Intermediate bond dimensions may be zero.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, lines 419--429. -/
+structure OBCChainTensor (d D N : ℕ) where
+  bondDim : Fin (N + 1) → ℕ
+  bondDim_le : ∀ k, bondDim k ≤ D
+  left_dim : bondDim 0 = 1
+  right_dim : bondDim (Fin.last N) = 1
+  tensor : ∀ k : Fin N, Fin d →
+    Matrix (Fin (bondDim k.castSucc)) (Fin (bondDim k.succ)) ℂ
+
+namespace OBCChainTensor
+
+variable {d D N : ℕ}
+
+/-- The dependent virtual-path contraction of a rectangular open-boundary
+chain. At length zero it is the empty product summed over the singleton
+endpoint path, hence equals one.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, lines 419--429. -/
+def coeff (A : OBCChainTensor d D N) (σ : Fin N → Fin d) : ℂ :=
+  ∑ α : (k : Fin (N + 1)) → Fin (A.bondDim k),
+    ∏ k : Fin N, A.tensor k (σ k) (α k.castSucc) (α k.succ)
+
+/-- Cyclic translation of the physical configuration. The bond-dimension
+vector and the distinguished open cut are unchanged. -/
+def cyclicTranslateConfig (s : Fin N) (σ : Fin N → Fin d) : Fin N → Fin d :=
+  fun k => σ (k + s)
+
+/-- Translation invariance of the state represented by one fixed-length
+open-boundary chain. -/
+def IsTranslationInvariantState (A : OBCChainTensor d D N) : Prop :=
+  ∀ s : Fin N, ∀ σ : Fin N → Fin d,
+    coeff A (cyclicTranslateConfig s σ) = coeff A σ
+
+/-- Entrywise zero-padding of every rectangular site matrix into a `D × D`
+matrix. The result is a closed square site-dependent chain, not itself the
+source open-boundary representation. -/
+def zeroPad (A : OBCChainTensor d D N) : MPSChainTensor d D N :=
+  fun k i a b =>
+    if ha : a.val < A.bondDim k.castSucc then
+      if hb : b.val < A.bondDim k.succ then
+        A.tensor k i ⟨a.val, ha⟩ ⟨b.val, hb⟩
+      else 0
+    else 0
+
+@[simp] theorem coeff_zero (A : OBCChainTensor d D 0) (σ : Fin 0 → Fin d) :
+    coeff A σ = 1 := by
+  simp [coeff, A.left_dim]
+
+/-- At length zero, the square-chain coefficient is the trace of the `D × D`
+identity matrix. This records the mismatch with `coeff_zero` explicitly. -/
+@[simp] theorem coeff_zeroPad_zero (A : OBCChainTensor d D 0)
+    (σ : Fin 0 → Fin d) :
+    (zeroPad A).coeff σ = D := by
+  simp [MPSChainTensor.coeff, Matrix.trace_one]
+
+/-- If one virtual bond has dimension zero, the dependent path space is empty
+and the open-boundary coefficient vanishes. -/
+theorem coeff_eq_zero_of_bondDim_eq_zero (A : OBCChainTensor d D N)
+    (σ : Fin N → Fin d) (k : Fin (N + 1)) (hk : A.bondDim k = 0) :
+    coeff A σ = 0 := by
+  letI : IsEmpty ((j : Fin (N + 1)) → Fin (A.bondDim j)) :=
+    ⟨fun α => Fin.elim0 (hk ▸ α k)⟩
+  simp [coeff]
+
+end OBCChainTensor
+
+namespace MPSChainTensor
+
+variable {d D N : ℕ}
+
+/-- The coefficient of a positive-length square site-dependent chain is the
+sum of its matrix entries over cyclic virtual paths. -/
+theorem coeff_eq_sum_cyclic (A : MPSChainTensor d D N)
+    [NeZero N] (σ : Fin N → Fin d) :
+    A.coeff σ = ∑ g : Fin N → Fin D,
+      ∏ k : Fin N, A k (σ k) (g k) (g (k + 1)) := by
+  let B : MPSTensor (N * d) D := fun q =>
+    A (finProdFinEquiv.symm q).1 (finProdFinEquiv.symm q).2
+  let τ : Fin N → Fin (N * d) := fun k => finProdFinEquiv (k, σ k)
+  have h := MPSTensor.trace_evalWord_eq_sum_cyclic B τ
+  rw [MPSTensor.evalWord_ofFn_eq_prod] at h
+  simp only [B, τ, Equiv.symm_apply_apply] at h
+  simpa [MPSChainTensor.coeff, MPSChainTensor.eval, List.ofFn_eq_map] using h
+
+end MPSChainTensor
+
+namespace OBCChainTensor
+
+variable {d D N : ℕ}
+
+private def rightIndex (A : OBCChainTensor d D N) :
+    Fin (A.bondDim (Fin.last N)) :=
+  ⟨0, by rw [A.right_dim]; omega⟩
+
+private theorem coeff_eq_sum_init (A : OBCChainTensor d D N)
+    (σ : Fin N → Fin d) :
+    coeff A σ =
+      ∑ g : (k : Fin N) → Fin (A.bondDim k.castSucc),
+        ∏ k : Fin N,
+          A.tensor k (σ k)
+            ((Fin.snoc (α := fun j => Fin (A.bondDim j)) g (rightIndex A)) k.castSucc)
+            ((Fin.snoc (α := fun j => Fin (A.bondDim j)) g (rightIndex A)) k.succ) := by
+  classical
+  letI : Unique (Fin (A.bondDim (Fin.last N))) :=
+    Equiv.unique (Fin.castOrderIso A.right_dim).toEquiv
+  rw [coeff, ← Equiv.sum_comp
+    (Fin.snocEquiv fun k : Fin (N + 1) => Fin (A.bondDim k))]
+  rw [Fintype.sum_prod_type, Fintype.sum_unique]
+  apply Finset.sum_congr rfl
+  intro g _
+  congr 2
+
+/-- For positive length, entrywise square padding preserves every state
+coefficient. Zero intermediate bond dimensions are allowed: then the dependent
+path space is empty and the padded cyclic sum also vanishes.
+
+The positive-length hypothesis is necessary. At `N = 0`, `coeff A σ = 1`,
+whereas the coefficient of the empty square chain is `D`.
+
+The rectangular data are from PGVWC07, arXiv:quant-ph/0608197, lines 419--429;
+the zero-padding identity is TNLean's algebraic factorization. -/
+theorem coeff_zeroPad (A : OBCChainTensor d D N) [NeZero N]
+    (σ : Fin N → Fin d) :
+    (zeroPad A).coeff σ = coeff A σ := by
+  obtain ⟨n, rfl⟩ : ∃ n, N = n + 1 :=
+    ⟨N - 1, (Nat.succ_pred_eq_of_pos (NeZero.pos N)).symm⟩
+  rw [MPSChainTensor.coeff_eq_sum_cyclic, coeff_eq_sum_init]
+  rw [Fintype.sum_piFin_castLE_extend_zero
+    (fun k : Fin (n + 1) => A.bondDim k.castSucc) (fun _ : Fin (n + 1) => D)
+    (fun g => ∏ k : Fin (n + 1),
+      A.tensor k (σ k)
+        ((Fin.snoc (α := fun j => Fin (A.bondDim j)) g (rightIndex A)) k.castSucc)
+        ((Fin.snoc (α := fun j => Fin (A.bondDim j)) g (rightIndex A)) k.succ)
+    ) (fun k => A.bondDim_le k.castSucc)]
+  symm
+  apply Finset.sum_congr rfl
+  intro g _
+  by_cases hlt : ∀ k, (g k).val < A.bondDim k.castSucc
+  · rw [dif_pos hlt]
+    apply Finset.prod_congr rfl
+    intro k _
+    simp only [zeroPad]
+    rw [dif_pos (hlt k)]
+    by_cases hk : k = Fin.last n
+    · subst hk
+      have hnext : (Fin.last n + 1 : Fin (n + 1)) = 0 := Fin.last_add_one n
+      have hcol : (g 0).val < A.bondDim (Fin.last n).succ := by
+        rw [Fin.succ_last, A.right_dim]
+        have hzero := hlt (0 : Fin (n + 1))
+        change (g 0).val < A.bondDim (0 : Fin (n + 2)) at hzero
+        rw [A.left_dim] at hzero
+        exact hzero
+      rw [hnext, dif_pos hcol]
+      congr 2
+      · rw [Fin.snoc_castSucc]
+      · apply Fin.ext
+        change (Fin.snoc (α := fun j => Fin (A.bondDim j)) (fun i : Fin (n + 1) =>
+          (⟨(g i).val, hlt i⟩ : Fin (A.bondDim i.castSucc))) (rightIndex A)
+          (Fin.last n).succ).val = (g 0).val
+        rw [Fin.succ_last, Fin.snoc_last]
+        have hzero := hlt (0 : Fin (n + 1))
+        change (g 0).val < A.bondDim (0 : Fin (n + 2)) at hzero
+        rw [A.left_dim] at hzero
+        exact (Nat.lt_one_iff.mp hzero).symm
+    · have hklt : k.val + 1 < n + 1 := by
+        have hkval : k.val ≠ n := by
+          intro h
+          apply hk
+          apply Fin.ext
+          exact h
+        omega
+      let j : Fin (n + 1) := ⟨k.val + 1, hklt⟩
+      have hj : k + 1 = j := by
+        apply Fin.ext
+        simp [j, Fin.val_add, Nat.mod_eq_of_lt hklt]
+      have hsucc : k.succ = j.castSucc := by
+        apply Fin.ext
+        rfl
+      have hcol : (g (k + 1)).val < A.bondDim k.succ := by
+        rw [hj, hsucc]
+        exact hlt j
+      rw [dif_pos hcol]
+      congr 2
+      · rw [Fin.snoc_castSucc]
+      · apply Fin.ext
+        change (Fin.snoc (α := fun j => Fin (A.bondDim j)) (fun i : Fin (n + 1) =>
+          (⟨(g i).val, hlt i⟩ : Fin (A.bondDim i.castSucc))) (rightIndex A) k.succ).val =
+          (g (k + 1)).val
+        rw [hsucc, Fin.snoc_castSucc, hj]
+  · rw [dif_neg hlt]
+    obtain ⟨k, hk⟩ := Classical.not_forall.mp hlt
+    symm
+    apply Finset.prod_eq_zero (Finset.mem_univ k)
+    simp only [zeroPad]
+    rw [dif_neg hk]
+
+/-- A zero-dimensional virtual bond also makes the positive-length padded
+square-chain coefficient vanish. -/
+theorem coeff_zeroPad_eq_zero_of_bondDim_eq_zero
+    (A : OBCChainTensor d D N) [NeZero N] (σ : Fin N → Fin d)
+    (k : Fin (N + 1)) (hk : A.bondDim k = 0) :
+    (zeroPad A).coeff σ = 0 := by
+  rw [coeff_zeroPad, coeff_eq_zero_of_bondDim_eq_zero A σ k hk]
+
+end OBCChainTensor

--- a/TNLean/MPS/Chain/VaryingBondOBC.lean
+++ b/TNLean/MPS/Chain/VaryingBondOBC.lean
@@ -26,7 +26,7 @@ open scoped BigOperators Matrix
 
 /-- A fixed-length open-boundary MPS chain whose virtual dimensions may vary
 from bond to bond. The first and last bond spaces are one-dimensional, and all
-bond dimensions are bounded by `D`. Intermediate bond dimensions may be zero.
+bond dimensions are bounded by \(D\). Intermediate bond dimensions may be zero.
 
 Source: PGVWC07, arXiv:quant-ph/0608197, lines 419--429. -/
 structure OBCChainTensor (d D N : ℕ) where
@@ -63,7 +63,7 @@ def IsTranslationInvariantState (A : OBCChainTensor d D N) : Prop :=
   ∀ s : Fin N, ∀ σ : Fin N → Fin d,
     coeff A (cyclicTranslateConfig s σ) = coeff A σ
 
-/-- Entrywise zero-padding of every rectangular site matrix into a `D × D`
+/-- Entrywise zero-padding of every rectangular site matrix into a \(D \times D\)
 matrix. The result is a closed square site-dependent chain, not itself the
 source open-boundary representation. -/
 def zeroPad (A : OBCChainTensor d D N) : MPSChainTensor d D N :=
@@ -79,7 +79,7 @@ def zeroPad (A : OBCChainTensor d D N) : MPSChainTensor d D N :=
     coeff A σ = 1 := by
   simp [coeff, A.left_dim]
 
-/-- At length zero, the square-chain coefficient is the trace of the `D × D`
+/-- At length zero, the square-chain coefficient is the trace of the \(D \times D\)
 identity matrix. This records the mismatch with `coeff_zero` explicitly. -/
 theorem coeff_zeroPad_zero (A : OBCChainTensor d D 0)
     (σ : Fin 0 → Fin d) :
@@ -147,8 +147,8 @@ private theorem coeff_eq_sum_init (A : OBCChainTensor d D N)
 coefficient. Zero intermediate bond dimensions are allowed: then the dependent
 path space is empty and the padded cyclic sum also vanishes.
 
-The positive-length hypothesis is necessary. At `N = 0`, `coeff A σ = 1`,
-whereas the coefficient of the empty square chain is `D`.
+The positive-length hypothesis is necessary. At \(N = 0\), the open-chain
+coefficient is one, whereas the coefficient of the empty square chain is \(D\).
 
 The rectangular data are from PGVWC07, arXiv:quant-ph/0608197, lines 419--429;
 the zero-padding identity is TNLean's algebraic factorization. -/

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -1,13 +1,13 @@
 %% ---------------------------------------------------------
-\section{Non-translation-invariant periodic chains}
+\section{Site-dependent chains at fixed length}
 \label{sec:non_ti_setup}
 %% ---------------------------------------------------------
 
-The algebraic proof of~\cite{Molnar2018NormalPEPS} keeps a fixed periodic
-chain length and lets the local tensors vary from site to site. The
-necessary objects---the coefficient of a configuration, the same-state
-relation, sitewise injectivity, and cyclic gauge equivalence---are recorded
-first.
+The algebraic proof of~\cite{Molnar2018NormalPEPS} uses periodic square chains
+whose tensors vary from site to site. The proof of
+\cite[Theorem~3]{PerezGarcia2007Matrix} starts instead from a varying-bond
+open chain. We record both fixed-length constructions and distinguish their
+boundary conventions.
 
 \begin{definition}[Periodic non-TI chain data]\label{def:non_ti_chain}
     \lean{MPSChainTensor, MPSChainTensor.coeff, MPSChainTensor.SameState, MPSChainTensor.IsInjective, MPSChainTensor.GaugeEquiv}
@@ -55,82 +55,225 @@ first.
     \end{center}
 \end{definition}
 
-\begin{definition}[Fixed-length varying-bond open chain]
+\begin{definition}[Varying-bond open chain]
     \label{def:varying_bond_obc_chain}
-    \lean{OBCChainTensor, OBCChainTensor.coeff, OBCChainTensor.cyclicTranslateConfig, OBCChainTensor.IsTranslationInvariantState}
+    \lean{OBCChainTensor}
     \leanok
     Fix a chain length $N$ and dimensions $D_0,\ldots,D_N\leq D$ with
     $D_0=D_N=1$. A varying-bond open chain consists of matrices
     $A_k^i\in\mathbb C^{D_k\times D_{k+1}}$ for
-    $k=0,\ldots,N-1$ and $i=0,\ldots,d-1$. Its coefficient at the physical
-    configuration $\sigma$ is the dependent virtual-path contraction
+    $k=0,\ldots,N-1$ and $i=0,\ldots,d-1$. Intermediate dimensions may
+    vanish. The number $D$ is a common upper bound and need not be the least
+    such bound.
+
+    This is the open-boundary representation of
+    \cite[Section~II.B]{PerezGarcia2007Matrix}. The source takes
+    $D=\max_k D_k$; allowing an arbitrary common upper bound does not change
+    the rectangular chain.
+\end{definition}
+
+\begin{definition}[Open-chain coefficient]
+    \label{def:varying_bond_obc_coeff}
+    \lean{OBCChainTensor.coeff}
+    \leanok
+    \uses{def:varying_bond_obc_chain}
+    For a physical configuration
+    $\sigma=(\sigma_0,\ldots,\sigma_{N-1})$, define
     \begin{align}
         c_A(\sigma)
-        &=\sum_{\substack{0\leq\alpha_k<D_k\\0\leq k\leq N}}
+        &:=\sum_{\alpha_0=0}^{D_0-1}\cdots
+          \sum_{\alpha_N=0}^{D_N-1}
           \prod_{k=0}^{N-1}
           (A_k^{\sigma_k})_{\alpha_k,\alpha_{k+1}}.
         \label{eq:varying_bond_obc_coeff}
     \end{align}
-    This is the open-boundary representation of
-    \cite[Section~II.B]{PerezGarcia2007Matrix}. A cyclic translation acts only
-    on $\sigma$; it does not rotate the dimensions or move the open cut.
-    Translation invariance at this fixed length means that $c_A(\sigma)$ is
-    unchanged by every such translation. Zero intermediate dimensions are
-    permitted and give an empty virtual-path space. For $N=0$, the unique
-    empty path has coefficient $1$.
+    Since $D_0=D_N=1$, this is the scalar matrix product in
+    \cite[Section~II.B]{PerezGarcia2007Matrix}. If an intermediate dimension
+    vanishes, the virtual-path set is empty. For $N=0$, there is one empty
+    path and its empty product is $1$.
 \end{definition}
+
+\begin{definition}[Cyclic translation of an open-chain configuration]
+    \label{def:varying_bond_obc_translation}
+    \lean{OBCChainTensor.cyclicTranslateConfig}
+    \leanok
+    Let $N\geq1$. For $s\in\mathbb Z/N\mathbb Z$, the cyclic translation of
+    a physical configuration is
+    \begin{align}
+        (T_s\sigma)_k&=\sigma_{k+s}.
+        \label{eq:varying_bond_obc_translation}
+    \end{align}
+    Only the physical configuration is translated. The dimensions
+    $D_0,\ldots,D_N$, the site matrices, and the distinguished open cut remain
+    fixed. At $N=0$, there is no translation parameter.
+\end{definition}
+
+\begin{definition}[Translation invariance at fixed length]
+    \label{def:varying_bond_obc_ti}
+    \lean{OBCChainTensor.IsTranslationInvariantState}
+    \leanok
+    \uses{def:varying_bond_obc_coeff, def:varying_bond_obc_translation}
+    For $N\geq1$, a varying-bond open chain represents a
+    translation-invariant state at length $N$ if, for every
+    $s\in\mathbb Z/N\mathbb Z$ and every physical configuration $\sigma$,
+    \begin{align}
+        c_A(T_s\sigma)&=c_A(\sigma).
+        \label{eq:varying_bond_obc_ti}
+    \end{align}
+    This condition compares coefficients at one fixed length. It does not
+    rotate the bond dimensions or identify open cuts. At $N=0$, the condition
+    is vacuous.
+\end{definition}
+
+\begin{theorem}[Empty open-chain coefficient]
+    \label{thm:varying_bond_obc_coeff_zero}
+    \lean{OBCChainTensor.coeff_zero}
+    \leanok
+    \uses{def:varying_bond_obc_coeff}
+    At $N=0$, the open-chain coefficient is $1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:varying_bond_obc_coeff}
+    The left endpoint space is one-dimensional, so there is one virtual path.
+    Its product contains no factors and therefore equals $1$.
+\end{proof}
+
+\begin{theorem}[Vanishing from a zero virtual dimension]
+    \label{thm:varying_bond_obc_zero_bond}
+    \lean{OBCChainTensor.coeff_eq_zero_of_bondDim_eq_zero}
+    \leanok
+    \uses{def:varying_bond_obc_coeff}
+    If $D_k=0$ for some $k\in\{0,\ldots,N\}$, then
+    $c_A(\sigma)=0$ for every physical configuration $\sigma$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:varying_bond_obc_coeff}
+    No virtual path can have a coordinate in the empty $k$th bond space, so
+    the sum in~(\ref{eq:varying_bond_obc_coeff}) is empty.
+\end{proof}
 
 \begin{definition}[Square padding of a varying-bond open chain]
     \label{def:varying_bond_obc_zero_pad}
     \lean{OBCChainTensor.zeroPad}
     \leanok
     \uses{def:varying_bond_obc_chain, def:non_ti_chain}
-    Embed each rectangular matrix entrywise into the upper-left corner of a
-    $D\times D$ matrix and set all remaining entries to zero. This gives a
-    square site-dependent closed chain. It is an auxiliary algebraic
-    factorization: the proof of
-    \cite[Theorem~3]{PerezGarcia2007Matrix} instead places the rectangular
-    matrices directly into compatible off-diagonal blocks of the final
-    $ND\times ND$ cyclic matrix.
+    For each site $k$, embed $A_k^i$ into the upper-left
+    $D_k\times D_{k+1}$ corner of a $D\times D$ matrix
+    $\widetilde A_k^i$ and set every other entry to zero. The matrices
+    $\widetilde A_k^i$ form a square site-dependent closed chain.
+
+    This square padding is an auxiliary algebraic factorization.
+    The proof of \cite[Theorem~3]{PerezGarcia2007Matrix} does not first replace
+    the rectangular open chain by this square chain. It places the original
+    rectangular matrices directly into the compatible off-diagonal blocks of
+    one $ND\times ND$ cyclic matrix.
 \end{definition}
+
+\begin{theorem}[Empty padded-chain coefficient]
+    \label{thm:varying_bond_obc_zero_pad_zero}
+    \lean{OBCChainTensor.coeff_zeroPad_zero}
+    \leanok
+    \uses{def:varying_bond_obc_zero_pad, def:non_ti_chain}
+    At $N=0$, the coefficient of the padded square chain is $D$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:varying_bond_obc_zero_pad, def:non_ti_chain}
+    The empty matrix product is the $D\times D$ identity, whose trace is $D$.
+\end{proof}
+
+\begin{theorem}[Zero-extension of a dependent finite sum]
+    \label{thm:pi_fin_sum_zero_extension}
+    \lean{Fintype.sum_piFin_castLE_extend_zero}
+    \leanok
+    Let $I$ be finite, let $r_i\leq s_i$ be nonnegative integers for
+    $i\in I$, and let $f$ take values in an additive commutative monoid. Then
+    the sum of $f$ over $\prod_{i\in I}\{0,\ldots,r_i-1\}$ equals its sum over
+    $\prod_{i\in I}\{0,\ldots,s_i-1\}$ after extending $f$ by zero outside
+    the smaller Cartesian product.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The coordinatewise inclusions identify the smaller Cartesian product with
+    the subset of the larger product on which every coordinate is below its
+    original bound. Split the larger sum into this subset and its complement.
+\end{proof}
+
+\begin{theorem}[Cyclic path expansion for a square chain]
+    \label{thm:chain_coeff_sum_cyclic}
+    \lean{MPSChainTensor.coeff_eq_sum_cyclic}
+    \leanok
+    \uses{def:non_ti_chain}
+    Let $N\geq1$ and let $B_0,\ldots,B_{N-1}$ be a square site-dependent
+    chain of bond dimension $D$. For every physical configuration $\sigma$,
+    \begin{align}
+        c_{B,\sigma}
+        &=\sum_{g\colon\mathbb Z/N\mathbb Z\to\{0,\ldots,D-1\}}
+          \prod_{k\in\mathbb Z/N\mathbb Z}
+          (B_k^{\sigma_k})_{g(k),g(k+1)}.
+        \label{eq:chain_coeff_sum_cyclic}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:trace_eval_word_eq_sum_cyclic}
+    Encode the site and physical indices as one enlarged physical index and
+    apply the cyclic trace expansion for a closed matrix product.
+\end{proof}
 
 \begin{theorem}[Positive-length coefficient preservation]
     \label{thm:varying_bond_obc_zero_pad_coeff}
-    \lean{OBCChainTensor.coeff_zeroPad,
-      OBCChainTensor.coeff_eq_zero_of_bondDim_eq_zero,
-      OBCChainTensor.coeff_zeroPad_eq_zero_of_bondDim_eq_zero,
-      OBCChainTensor.coeff_zero, OBCChainTensor.coeff_zeroPad_zero,
-      Fintype.sum_piFin_castLE_extend_zero,
-      MPSChainTensor.coeff_eq_sum_cyclic}
+    \lean{OBCChainTensor.coeff_zeroPad}
     \leanok
-    \uses{def:varying_bond_obc_chain, def:varying_bond_obc_zero_pad}
-    For every fixed $N\geq1$ and every physical configuration $\sigma$,
-    the trace coefficient of the padded square chain equals the rectangular
-    open-chain contraction:
+    \uses{def:varying_bond_obc_coeff, def:varying_bond_obc_zero_pad}
+    Let $N\geq1$. For every physical configuration $\sigma$,
     \begin{align}
         \tr\!\left(\widetilde A_0^{\sigma_0}\cdots
           \widetilde A_{N-1}^{\sigma_{N-1}}\right)
         &=c_A(\sigma).
         \label{eq:varying_bond_obc_zero_pad_coeff}
     \end{align}
-    If an intermediate dimension is zero, both sides vanish. The restriction
-    $N\geq1$ is necessary: at $N=0$ the open-chain empty-path coefficient is
-    $1$, whereas the square-chain trace of the empty product is $D$. The
-    equality concerns this one fixed length and makes no assertion relating
-    states at different lengths.
+    No positivity assumption is imposed on the intermediate dimensions. The
+    endpoint conditions already imply $D\geq1$ whenever such a chain exists.
+    The equality concerns only this fixed length.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{def:varying_bond_obc_chain, def:varying_bond_obc_zero_pad}
-    Expand the square-chain trace as a sum over cyclic virtual paths. Every
-    path with an index outside the corresponding rectangular bond range has a
-    zero factor. The remaining paths are exactly the dependent open-chain
-    paths: the first and last virtual indices both equal the unique element of
-    their one-dimensional endpoint spaces. Their products agree entry by
-    entry, which proves~\eqref{eq:varying_bond_obc_zero_pad_coeff}.
+    \uses{thm:chain_coeff_sum_cyclic, thm:pi_fin_sum_zero_extension,
+        def:varying_bond_obc_coeff, def:varying_bond_obc_zero_pad}
+    Expand the left-hand side by~(\ref{eq:chain_coeff_sum_cyclic}). Extend the
+    dependent sum in~(\ref{eq:varying_bond_obc_coeff}) to the common dimension
+    $D$ by Theorem~\ref{thm:pi_fin_sum_zero_extension}. Every extended path
+    outside the rectangular bond ranges has a zero matrix entry. For the
+    remaining paths, the one-dimensional endpoint spaces identify the last
+    virtual coordinate with the first, and the products agree term by term.
 \end{proof}
 
+\begin{theorem}[Padded coefficient with a zero virtual dimension]
+    \label{thm:varying_bond_obc_zero_pad_zero_bond}
+    \lean{OBCChainTensor.coeff_zeroPad_eq_zero_of_bondDim_eq_zero}
+    \leanok
+    \uses{def:varying_bond_obc_zero_pad}
+    Let $N\geq1$. If $D_k=0$ for some
+    $k\in\{0,\ldots,N\}$, then the padded square-chain coefficient vanishes
+    for every physical configuration.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:varying_bond_obc_zero_pad_coeff,
+        thm:varying_bond_obc_zero_bond}
+    Apply positive-length coefficient preservation and then the vanishing of
+    the open-chain contraction.
+\end{proof}
 \begin{definition}[Cyclic block tensor at fixed length]
     \label{def:chain_cyclic_block_tensor}
     \lean{MPSChainTensor.cyclicRotation, MPSChainTensor.cyclicBlockTensor}

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -55,6 +55,82 @@ first.
     \end{center}
 \end{definition}
 
+\begin{definition}[Fixed-length varying-bond open chain]
+    \label{def:varying_bond_obc_chain}
+    \lean{OBCChainTensor, OBCChainTensor.coeff, OBCChainTensor.cyclicTranslateConfig, OBCChainTensor.IsTranslationInvariantState}
+    \leanok
+    Fix a chain length $N$ and dimensions $D_0,\ldots,D_N\leq D$ with
+    $D_0=D_N=1$. A varying-bond open chain consists of matrices
+    $A_k^i\in\mathbb C^{D_k\times D_{k+1}}$ for
+    $k=0,\ldots,N-1$ and $i=0,\ldots,d-1$. Its coefficient at the physical
+    configuration $\sigma$ is the dependent virtual-path contraction
+    \begin{align}
+        c_A(\sigma)
+        &=\sum_{\substack{0\leq\alpha_k<D_k\\0\leq k\leq N}}
+          \prod_{k=0}^{N-1}
+          (A_k^{\sigma_k})_{\alpha_k,\alpha_{k+1}}.
+        \label{eq:varying_bond_obc_coeff}
+    \end{align}
+    This is the open-boundary representation of
+    \cite[Section~II.B]{PerezGarcia2007Matrix}. A cyclic translation acts only
+    on $\sigma$; it does not rotate the dimensions or move the open cut.
+    Translation invariance at this fixed length means that $c_A(\sigma)$ is
+    unchanged by every such translation. Zero intermediate dimensions are
+    permitted and give an empty virtual-path space. For $N=0$, the unique
+    empty path has coefficient $1$.
+\end{definition}
+
+\begin{definition}[Square padding of a varying-bond open chain]
+    \label{def:varying_bond_obc_zero_pad}
+    \lean{OBCChainTensor.zeroPad}
+    \leanok
+    \uses{def:varying_bond_obc_chain, def:non_ti_chain}
+    Embed each rectangular matrix entrywise into the upper-left corner of a
+    $D\times D$ matrix and set all remaining entries to zero. This gives a
+    square site-dependent closed chain. It is an auxiliary algebraic
+    factorization: the proof of
+    \cite[Theorem~3]{PerezGarcia2007Matrix} instead places the rectangular
+    matrices directly into compatible off-diagonal blocks of the final
+    $ND\times ND$ cyclic matrix.
+\end{definition}
+
+\begin{theorem}[Positive-length coefficient preservation]
+    \label{thm:varying_bond_obc_zero_pad_coeff}
+    \lean{OBCChainTensor.coeff_zeroPad,
+      OBCChainTensor.coeff_eq_zero_of_bondDim_eq_zero,
+      OBCChainTensor.coeff_zeroPad_eq_zero_of_bondDim_eq_zero,
+      OBCChainTensor.coeff_zero, OBCChainTensor.coeff_zeroPad_zero,
+      Fintype.sum_piFin_castLE_extend_zero,
+      MPSChainTensor.coeff_eq_sum_cyclic}
+    \leanok
+    \uses{def:varying_bond_obc_chain, def:varying_bond_obc_zero_pad}
+    For every fixed $N\geq1$ and every physical configuration $\sigma$,
+    the trace coefficient of the padded square chain equals the rectangular
+    open-chain contraction:
+    \begin{align}
+        \tr\!\left(\widetilde A_0^{\sigma_0}\cdots
+          \widetilde A_{N-1}^{\sigma_{N-1}}\right)
+        &=c_A(\sigma).
+        \label{eq:varying_bond_obc_zero_pad_coeff}
+    \end{align}
+    If an intermediate dimension is zero, both sides vanish. The restriction
+    $N\geq1$ is necessary: at $N=0$ the open-chain empty-path coefficient is
+    $1$, whereas the square-chain trace of the empty product is $D$. The
+    equality concerns this one fixed length and makes no assertion relating
+    states at different lengths.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:varying_bond_obc_chain, def:varying_bond_obc_zero_pad}
+    Expand the square-chain trace as a sum over cyclic virtual paths. Every
+    path with an index outside the corresponding rectangular bond range has a
+    zero factor. The remaining paths are exactly the dependent open-chain
+    paths: the first and last virtual indices both equal the unique element of
+    their one-dimensional endpoint spaces. Their products agree entry by
+    entry, which proves~\eqref{eq:varying_bond_obc_zero_pad_coeff}.
+\end{proof}
+
 \begin{definition}[Cyclic block tensor at fixed length]
     \label{def:chain_cyclic_block_tensor}
     \lean{MPSChainTensor.cyclicRotation, MPSChainTensor.cyclicBlockTensor}

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -223,7 +223,7 @@ boundary conventions.
 
 \begin{proof}
     \leanok
-    \uses{thm:trace_eval_word_eq_sum_cyclic}
+    \uses{lem:eval_word_of_fn_prod, thm:trace_eval_word_eq_sum_cyclic}
     Encode the site and physical indices as one enlarged physical index and
     apply the cyclic trace expansion for a closed matrix product.
 \end{proof}
@@ -261,7 +261,7 @@ boundary conventions.
     \label{thm:varying_bond_obc_zero_pad_zero_bond}
     \lean{OBCChainTensor.coeff_zeroPad_eq_zero_of_bondDim_eq_zero}
     \leanok
-    \uses{def:varying_bond_obc_zero_pad}
+    \uses{def:non_ti_chain, def:varying_bond_obc_zero_pad}
     Let $N\geq1$. If $D_k=0$ for some
     $k\in\{0,\ldots,N\}$, then the padded square-chain coefficient vanishes
     for every physical configuration.

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -92,7 +92,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L326, 332, 338, 352, 363, 369 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L363, 882, 886, 892, 897 `tenkz` → `P-grid` | — | — |
-| `ch23_algebraic_ft_foundations.tex` | L48, 52, 236, 240, 441, 445, 458, 462, 505, 509, 513, 522, 526 `tenkz` → `P-grid` | — | — |
+| `ch23_algebraic_ft_foundations.tex` | L48, 52, 455, 459, 660, 664, 677, 681, 724, 728, 732, 741, 745 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | L84, 104, 294, 300, 312, 324, 577, 596 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- add `OBCChainTensor`, a fixed-length varying-bond rectangular open-boundary MPS surface with endpoint dimensions one and a common ambient bond bound
- define its literal dependent virtual-path coefficient and physical cyclic translation/TI predicate without rotating the bond data or open cut
- add entrywise zero-padding into `MPSChainTensor d D N`
- prove `OBCChainTensor.coeff_zeroPad` for positive lengths
- formalize the exact length-zero boundary: the OBC empty-path coefficient is `1`, while the padded closed-chain coefficient is `D`
- allow zero intermediate bond dimensions and prove both coefficients then vanish
- add the dependent finite-product zero-extension lemma and square-chain cyclic path expansion used by the padding proof
- synchronize Chapter 23 with declaration-level nodes, direct dependencies, edge cases, and the PGVWC07 source boundary

The rectangular structure is the PGVWC07 OBC representation. Zero-padding through a homogeneous square chain is TNLean's coefficient-preserving factorization for reuse of the cyclic block-average theorem, not a separately printed source theorem. All results are fixed-length and use no `SameMPV` variants.

## Validation

- targeted varying-bond OBC and Chain aggregator builds
- full `lake build` (10077 jobs)
- Mathlib lint suite on the new declarations
- proof-integrity, diagnostics, module-policy, and generated-import checks
- blueprint synchronization and declaration checks
- reader-facing prose check
- double LuaLaTeX with no undefined cross-references
- independent Lean/source and Blueprint/dependency reviews
- `git diff --check`

Closes #6142
Advances #6087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds foundational algebraic infrastructure for PGVWC07 Theorem 3, including a nontrivial coefficient-preservation proof with edge cases (N=0 mismatch, zero bond dims). Incorrect formalization here would propagate into later FT arguments.
> 
> **Overview**
> Adds **`OBCChainTensor`**, the fixed-length rectangular open-boundary MPS surface from PGVWC07 (endpoint bonds dimension 1, intermediate bonds ≤ `D`, zeros allowed), together with its dependent-path `coeff`, physical cyclic translation, and fixed-length TI predicate.
> 
> Introduces entrywise **`zeroPad`** into a square `MPSChainTensor`, and proves **`coeff_zeroPad`**: for `N ≥ 1`, padding preserves every configuration coefficient (including when some intermediate bonds vanish). Explicitly records the `N = 0` mismatch (`1` vs `D`).
> 
> Supporting lemmas: dependent finite-product zero-extension (`sum_piFin_castLE_extend_zero`) and cyclic path expansion for square chains (`coeff_eq_sum_cyclic`). Chapter 23 blueprint is synchronized with the new declarations and source-boundary notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a519820e93d34d4ccc3794bdc1515733d5dcee79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->