### PR TITLE
doc(tenkz): a circle frame takes no basis

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -488,17 +488,17 @@ cell resolves to the authored record rather than creating coincident
 population underneath it. Member indices are strictly one-based.
 
 `basis=` is defined on the `flat` and `plane` frames, and a circle frame takes
-no basis. What a basis decomposes is a repeating cell, and what reads the
-decomposition is the frame's translations: one offset pair is one page
-displacement at every cell, the spacing check compares member families under
-each live cell translation, and a declared adjacency travels from cell to cell
-unchanged. A circle frame repeats nothing. Its stations lie on one ring and
-its axes turn from station to station, so a single declared offset would name
-a different page displacement at each of them; there is no repeated cell to
-decompose and no translation to read a decomposition under. A circle carries
-one record per station, and a figure whose site is composite has a repeating
-cell, which is a flat or a plane frame. A basis on a circle is rejected with
-`[TKZ-FRAME-BASIS-CIRCLE]`.
+no basis. A basis is cell-level: what it decomposes is a repeating cell, and
+what reads the decomposition is the frame's translations. One offset pair is
+one page displacement at every cell, the spacing check compares member families
+under each live cell translation, and a declared adjacency travels from cell to
+cell unchanged. A circle frame repeats nothing. Its stations lie on one ring
+and its axes turn from station to station, so a single declared offset would
+name a different page displacement at each of them; there is no repeating cell
+to decompose and no translation to read a decomposition under. A basis on a
+circle is rejected with `[TKZ-FRAME-BASIS-CIRCLE]`. The restriction is about
+the frame's own cell structure and says nothing about what one station may
+carry.
 
 An explicit `basis=` is picture-scoped in the current kernel stage.
 Group-local and atom-local bases are rejected with `TKZ-FRAME-*` diagnostics

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -487,10 +487,22 @@ An authored atom at `(r,c,k)` replaces that member. An authored atom at
 cell resolves to the authored record rather than creating coincident
 population underneath it. Member indices are strictly one-based.
 
-In the current kernel stage an explicit `basis=` belongs to a picture-level
-`flat` or `plane` frame. Group-local, atom-local, and circular bases are
-rejected with `TKZ-FRAME-*` diagnostics until those carriers have a declared
-composition or tangent-offset contract.
+`basis=` is defined on the `flat` and `plane` frames, and a circle frame takes
+no basis. What a basis decomposes is a repeating cell, and what reads the
+decomposition is the frame's translations: one offset pair is one page
+displacement at every cell, the spacing check compares member families under
+each live cell translation, and a declared adjacency travels from cell to cell
+unchanged. A circle frame repeats nothing. Its stations lie on one ring and
+its axes turn from station to station, so a single declared offset would name
+a different page displacement at each of them; there is no repeated cell to
+decompose and no translation to read a decomposition under. A circle carries
+one record per station, and a figure whose site is composite has a repeating
+cell, which is a flat or a plane frame. The refusal is
+`TKZ-FRAME-BASIS-CIRCLE`.
+
+An explicit `basis=` is picture-scoped in the current kernel stage.
+Group-local and atom-local bases are rejected with `TKZ-FRAME-*` diagnostics
+until those carriers have a declared composition contract.
 
 **One clause travels with the circle frame and only with it:** adjacent
 stations are one pitch apart. That fixes a radius the contract otherwise

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -497,8 +497,8 @@ its axes turn from station to station, so a single declared offset would name
 a different page displacement at each of them; there is no repeated cell to
 decompose and no translation to read a decomposition under. A circle carries
 one record per station, and a figure whose site is composite has a repeating
-cell, which is a flat or a plane frame. The refusal is
-`TKZ-FRAME-BASIS-CIRCLE`.
+cell, which is a flat or a plane frame. A basis on a circle is rejected with
+`[TKZ-FRAME-BASIS-CIRCLE]`.
 
 An explicit `basis=` is picture-scoped in the current kernel stage.
 Group-local and atom-local bases are rejected with `TKZ-FRAME-*` diagnostics

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -3039,3 +3039,53 @@ flight; it is deleted by whoever lands next in that file. The lint's
 hand while reading the rest from the registry — knowledge the registry should
 hold, and the fix is a tombstone ledger the linter reads, not another
 discard. Trigger: the next registry tombstone.
+
+### 2026-08-12 — the circle frame takes no basis, and stops promising one
+
+`basis=` has been refused on a circle frame since the basis landed, and both
+the refusal and the contract clause behind it were written as a deferral: the
+message read *currently requires flat or plane* and named a tangent-offset
+contract, and §4 deferred circular bases *until those carriers have a declared
+composition or tangent-offset contract*. Nobody asked for that contract. The
+capability was read against the demand corpus the way the gate reads any
+other.
+
+What the corpus holds. Thirty-eight circle-frame picture sites: one benchmark
+case, four blueprint figures, thirty-three kernel fixtures. Every one of them
+carries exactly one record per station; not one places a second site at a
+station, which is the only thing a basis would be for. Sixty-seven `basis=`
+sites, every one of them on a `flat` or a `plane`, except the single site that
+names a circle, which is the negative fixture pinning the refusal. The one
+benchmark circle target, `rmp-ii-triangle-network`, is faithful with an empty
+defect list. No verdict row, wave-2 target, or demand table names a circle
+basis, a tangent offset, or a radial offset. The amendment that introduced the
+basis argues it from Bravais decomposition on flat and plane lattices and names
+five consumers, none of them circular. Two regressions,
+`r_basis_frame_replace` and `r_basis_equation_replace`, depend on a later
+circle frame discarding an earlier basis.
+
+Why the absence is structural and not a backlog. A basis decomposes a
+repeating cell, and the frame's translations are what read the decomposition:
+one offset pair is one page displacement at every cell, the spacing check
+compares member families under each live cell translation, and a declared
+adjacency travels from cell to cell unchanged. A circle repeats nothing. Its
+stations lie on one ring and its axes turn from station to station, so a single
+declared offset would name a different page displacement at each of them.
+There is no repeated cell to decompose and no translation to read a
+decomposition under. A tangent-offset contract would have to invent all three,
+for no figure.
+
+So the refusal stays and the promise goes. §4 now states the restriction as the
+contract rather than as a stage, and the message reads *basis= is defined on
+flat and plane frames; a circle frame repeats no cell and carries one record
+per station*. The error code is unchanged, so the negative fixture and the
+probe pin what they always pinned. The group-local and atom-local refusals keep
+their stage wording, because those carriers are tracked work and this one is
+not.
+
+Trigger for revisiting: a demand-corpus figure that puts two or more records at
+one circle station. Such a figure must first say what a declared offset means
+where the axes turn, and the contract reopens then and not before.
+
+No registry row, parser leaf, key, alias, or overload moves; M1, M2, M3, M5,
+and M6 are unchanged.

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -3051,9 +3051,10 @@ capability was read against the demand corpus the way the gate reads any
 other.
 
 What the corpus holds. Thirty-eight circle-frame picture sites: one benchmark
-case, four blueprint figures, thirty-three kernel fixtures. Every one of them
-carries exactly one record per station; not one places a second site at a
-station, which is the only thing a basis would be for. Sixty-seven `basis=`
+case, four blueprint figures, thirty-three kernel fixtures. Not one of them
+repeats a site structure across its stations, which is what a cell-level basis
+would state; every station carries a single record, and no circle picture in
+the package clusters one. Sixty-seven `basis=`
 sites, every one of them on a `flat` or a `plane`, except the single site that
 names a circle, which is the negative fixture pinning the refusal. The one
 benchmark circle target, `rmp-ii-triangle-network`, is faithful with an empty
@@ -3064,28 +3065,37 @@ five consumers, none of them circular. Two regressions,
 `r_basis_frame_replace` and `r_basis_equation_replace`, depend on a later
 circle frame discarding an earlier basis.
 
-Why the absence is structural and not a backlog. A basis decomposes a
-repeating cell, and the frame's translations are what read the decomposition:
-one offset pair is one page displacement at every cell, the spacing check
-compares member families under each live cell translation, and a declared
-adjacency travels from cell to cell unchanged. A circle repeats nothing. Its
-stations lie on one ring and its axes turn from station to station, so a single
-declared offset would name a different page displacement at each of them.
-There is no repeated cell to decompose and no translation to read a
-decomposition under. A tangent-offset contract would have to invent all three,
-for no figure.
+Why the absence is structural and not a backlog. A basis is cell-level: what it
+decomposes is a repeating cell, and the frame's translations are what read the
+decomposition. One offset pair is one page displacement at every cell, the
+spacing check compares member families under each live cell translation, and a
+declared adjacency travels from cell to cell unchanged. A circle repeats
+nothing. Its stations lie on one ring and its axes turn from station to
+station, so a single declared offset would name a different page displacement
+at each of them. There is no repeating cell to decompose and no translation to
+read a decomposition under. A tangent-offset contract would have to invent all
+three, for no figure.
+
+The restriction reaches the frame and stops there. A station is free to carry a
+composite site by other means: the atom-scoped `cluster=` expands on a circle
+station exactly as it does on a flat one, into addressable children on a
+quarter-scale subframe carried by the station. What the circle lacks is not
+composition at a site but a cell to repeat one across, so the refusal must not
+be written as a claim about how many records a station holds.
 
 So the refusal stays and the promise goes. §4 now states the restriction as the
-contract rather than as a stage, and the message reads *basis= is defined on
-flat and plane frames; a circle frame repeats no cell and carries one record
-per station*. The error code is unchanged, so the negative fixture and the
+contract rather than as a stage, and the message reads *basis= is cell-level
+and is defined on flat and plane frames; a circle frame has no repeating cell
+to decompose*. The error code is unchanged, so the negative fixture and the
 probe pin what they always pinned. The group-local and atom-local refusals keep
 their stage wording, because those carriers are tracked work and this one is
 not.
 
-Trigger for revisiting: a demand-corpus figure that puts two or more records at
-one circle station. Such a figure must first say what a declared offset means
-where the axes turn, and the contract reopens then and not before.
+Trigger for revisiting: a demand-corpus figure that repeats one composite site
+across the stations of a circle, which is what a cell-level basis would state
+and what `cluster=` at each station would only restate by hand. Such a figure
+must first say what a declared offset means where the axes turn, and the
+contract reopens then and not before.
 
 No registry row, parser leaf, key, alias, or overload moves; M1, M2, M3, M5,
 and M6 are unchanged.

--- a/tests/tenkz/kernel/negative/n_frame_basis_circle.tex
+++ b/tests/tenkz/kernel/negative/n_frame_basis_circle.tex
@@ -1,4 +1,4 @@
-%% Negative regression: circle members need a tangent-offset contract.
+%% Negative regression: a circle frame repeats no cell and takes no basis.
 \documentclass{standalone}
 \usepackage{tenkz}
 \begin{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -156,8 +156,8 @@
   { [TKZ-SIZE-SCOPE]~size=~is~picture~and~equation~policy:~a~group~shares~
     its~picture's~size~class,~and~an~atom~states~its~own. }
 \msg_new:nnn {tenkz}{kernel-frame-basis-circle}
-  { [TKZ-FRAME-BASIS-CIRCLE]~basis=~is~defined~on~flat~and~plane~frames;~
-    a~circle~frame~repeats~no~cell~and~carries~one~record~per~station. }
+  { [TKZ-FRAME-BASIS-CIRCLE]~basis=~is~cell-level~and~is~defined~on~flat~
+    and~plane~frames;~a~circle~frame~has~no~repeating~cell~to~decompose. }
 \msg_new:nnn {tenkz}{kernel-frame-basis-policy}
   { [TKZ-FRAME-BASIS-POLICY]~displaced~or~multi-member~bases~require~
     explicit~wires;~picture~policy~'#1'~has~no~member-level~meaning. }

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -156,8 +156,8 @@
   { [TKZ-SIZE-SCOPE]~size=~is~picture~and~equation~policy:~a~group~shares~
     its~picture's~size~class,~and~an~atom~states~its~own. }
 \msg_new:nnn {tenkz}{kernel-frame-basis-circle}
-  { [TKZ-FRAME-BASIS-CIRCLE]~basis=~currently~requires~flat~or~plane;~
-    a~circle~basis~needs~a~declared~tangent-offset~contract. }
+  { [TKZ-FRAME-BASIS-CIRCLE]~basis=~is~defined~on~flat~and~plane~frames;~
+    a~circle~frame~repeats~no~cell~and~carries~one~record~per~station. }
 \msg_new:nnn {tenkz}{kernel-frame-basis-policy}
   { [TKZ-FRAME-BASIS-POLICY]~displaced~or~multi-member~bases~require~
     explicit~wires;~picture~policy~'#1'~has~no~member-level~meaning. }


### PR DESCRIPTION
Part of LionSR/tenkz#13, Remaining-to-1.0 item 3.

`basis=` on a circle frame was a hard refusal wearing the clothes of a
deferral. The message read *currently requires flat or plane* and named a
tangent-offset contract; `LANGUAGE-1.0` §4 deferred circular bases *until those
carriers have a declared composition or tangent-offset contract*. Item 3 of the
tracker therefore cannot be ticked as written, and the wording promises
machinery that no figure has ever asked for. This states the restriction as the
contract instead.

## The demand evidence

The capability was read against the demand corpus the way the shrink gate reads
any other.

- **Thirty-eight circle-frame picture sites** across the package: one benchmark
  case (`rmp-ii-triangle-network`), four blueprint figures (the ch24 PEPS
  five-vertex cycles), thirty-three kernel fixtures. Every one carries exactly
  one record per station. Not one places a second site at a station, which is
  the only thing a basis is for.
- **Sixty-seven `basis=` sites**, every one on a `flat` or a `plane`. The single
  site naming a circle is `tests/tenkz/kernel/negative/n_frame_basis_circle.tex`,
  the fixture that pins the refusal.
- **Zero `basis=` in `blueprint/src/`**, and none in `docs/tenkz/chapters2/`
  outside the generated reference row.
- **The verdict ledger records no demand.** `rmp-ii-triangle-network` is
  `faithful` with an empty defect list; no row's note or next action names a
  circle basis, a tangent offset, or a radial offset. `wave2-targets.md` has no
  circle or basis row.
- **The amendment that introduced the basis** (`AMENDMENT-remaining-demand.md`
  §"Amendment six: the cell basis") argues it entirely from Bravais
  decomposition on flat and plane lattices, and names five consumers: the
  cluster-state workbench, the CZX state, the GHZ state, the condensation
  lattice, the PEPS renormalization. None circular.
- **Two regressions depend on the opposite behaviour.**
  `r_basis_frame_replace.tex` and `r_basis_equation_replace.tex` both assert
  that a later circle frame discards an earlier basis.
- **The only prose about a circle basis is the refusal quoting itself.** The
  three occurrences of "tangent-offset contract" in the tree were the message,
  the contract clause, and the fixture comment.
- **The author sources** are out of tree (`tests/tenkz/rmp/author-source.sha256`
  checks them by hash against a directory not present on this machine), so the
  corpus manifest is the record of what they draw: exactly one target carries
  the `circle-frame` capability, its ink line reads *canonical public kernel
  circle frame; no raw TikZ*, and its boundary is three open physical spokes on
  three stations.

## The branch taken, and why

No consumer, so the gap closes as a contract amendment rather than as
speculative machinery. The demand-driven rule in `GOAL.md` is the governing
one, and the absence here is structural rather than a backlog. A basis is
cell-level: what it decomposes is a repeating cell, and what reads the
decomposition is the frame's translations. One offset pair is one page
displacement at every cell, the spacing check compares member families under
each live cell translation, and a declared adjacency travels from cell to cell
unchanged. A circle repeats nothing. Its stations lie on one ring and its axes
turn from station to station, so a single declared offset would name a
different page displacement at each of them. There is no repeating cell to
decompose and no translation to read a decomposition under, and a
tangent-offset contract would have to invent all three for no figure.

The restriction reaches the frame and stops there, and the contract says so
explicitly. A station is free to carry a composite site by other means: the
atom-scoped `cluster=` expands on a circle station exactly as on a flat one,
which was verified by compiling `\tn[at=(1,2), name=g, cluster=2x2]{}` inside a
four-station circle picture. It yields four addressable children on a
quarter-scale subframe carried by the station, with zero diagnostics. What the
circle lacks is not composition at a site but a cell to repeat one across.
(Raised by both reviewers against an earlier revision that overreached on this
point; corrected in b571119ec.)

## What changed

- `docs/tenkz/LANGUAGE-1.0.md` §4: the deferral becomes the contract. `basis=`
  is defined on `flat` and `plane`; a circle frame repeats no cell, carries one
  record per station, and a basis on it is rejected with
  `[TKZ-FRAME-BASIS-CIRCLE]`. The group-local and atom-local refusals keep
  their stage wording in a separate paragraph: those carriers are tracked work
  and this one is not.
- `tex/tenkz/tenkz-kernel.code.tex`: the message drops *currently* and the
  promised contract, and reads *basis= is cell-level and is defined on flat and
  plane frames; a circle frame has no repeating cell to decompose*. The error
  code is unchanged, so the negative fixture and the probe assertion at
  `scripts/tenkz_kernel_probes.sh:2094` pin exactly what they pinned before.
- `tests/tenkz/kernel/negative/n_frame_basis_circle.tex`: header comment
  restated. The body is unchanged.
- `docs/tenkz/SHRINK.md`: a dated entry recording the decision, the counts
  above, the structural reason, and the trigger for revisiting.

The registry row for `basis` is deliberately untouched. Registry descriptions
carry a key's meaning, not its guards; §4 and the message own the restriction,
and a third copy would be a twin.

## Proposed replacement for item 3 of the LionSR/tenkz#13 checklist

Not edited here. Suggested text:

> - [x] 3. LionSR/tenkz#117 circle frame completion: the circle frame's open-end alphabet
>   is closed to `n|e|s|w`, with diagonals rejected by
>   `[TKZ-CIRCLE-OPEN-DIRECTION]` and pinned by four negative fixtures; a circle
>   frame takes no cell-level basis, which `LANGUAGE-1.0` §4 now states as the
>   contract rather than as a deferral, with the demand evidence and the
>   reopening trigger recorded in `SHRINK.md`.

## Gates

All run on this branch's head (b571119ec, after the reviewer correction).

| gate | result |
|---|---|
| `python3 scripts/tenkz_language.py check` | PASS: tenkz language registry (100 records) |
| `bash scripts/tenkz_kernel_probes.sh --check` | PASS: 155 review regressions hold; 11 sugar spellings byte-identical in events and pixels; 12 kernel record streams byte-identical; kernel pixels byte-identical |
| `bash scripts/tenkz_golden.sh --check` | PASS: 9 event streams byte-identical to the golden baseline |
| `python3 scripts/tenkz_rmp.py check --all` | PASS: validated, compiled, linted, and audited 130 targets. Verdicts unchanged: faithful 90, cosmetic-gap 40, structural-gap 0, unfaithful 0, blocked 0. Pairing verified 120, context-only 10 |
| `python3 scripts/tenkz_shrink.py meters` | byte-identical to the pinned `tests/tenkz/census-baseline.json`, which is the evidence for the entry's closing census line |
| `python3 scripts/test_tenkz_label_overlap.py` | PASS |
| `python3 scripts/test_tenkz_index_routing.py` | PASS |
| `python3 scripts/test_tenkz_cubic.py` | PASS |
| `python3 scripts/tenkz_lint.py` on the touched fixture | 1 file scanned, 0 findings |
| demolition and disposition checkers, `test_check_tenkz_policy.py` | PASS |

Focused negative compile of `tests/tenkz/kernel/negative/n_frame_basis_circle.tex`
stops the run with the new text under the old code:

```
! Package tenkz Error: [TKZ-FRAME-BASIS-CIRCLE] basis= is cell-level and is
(tenkz)                defined on flat and plane frames; a circle frame has
(tenkz)                no repeating cell to decompose.
```

No document contradicts the amended clause: the only remaining circle-and-basis
statements in `docs/tenkz/` are the §2 key table, which already scoped `basis=`
to a picture-level flat or plane, and the amended §4 paragraph. The three
"tangent-offset contract" occurrences are gone from the tree, and no remaining
sentence claims anything about how many records a circle station holds.

Pixel evidence is parity rather than replacement: the change is one message
string and two comments, and the kernel pixel ledger is byte-identical.
