### PR TITLE
feat(MPS/MPU): expose source-v stabilized input-tail support

### DIFF
--- a/TNLean/MPS/MPU/DoubleLayerContraction.lean
+++ b/TNLean/MPS/MPU/DoubleLayerContraction.lean
@@ -118,6 +118,28 @@ theorem normalizedDiagonal_blockTensor [NeZero d] (L : ℕ)
   congr 1
   simp [List.ofFn_const]
 
+/-- A normalized physical-diagonal power is the normalized sum of diagonal
+open words.
+
+This is the algebraic expansion of the diagonal tail used in the complete
+source-factor networks.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--600). -/
+theorem normalizedDiagonal_pow_eq_sum_evalWord [NeZero d]
+    (W : MPOTensor d D) (K : ℕ) :
+    normalizedDiagonal W ^ K =
+      ((d : ℂ)⁻¹) ^ K •
+        ∑ τ : Fin K → Fin d, evalWord W (List.ofFn τ) (List.ofFn τ) := by
+  classical
+  simp only [normalizedDiagonal, contractPhysical, Matrix.one_apply, ite_smul,
+    one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true,
+    evalWord_ofFn]
+  rw [smul_pow]
+  congr 1
+  simpa [List.ofFn_const] using
+    (List.prod_ofFn_sum (fun _ : Fin K ↦ fun i : Fin d ↦ W i i))
+
 /-- The normalized diagonal of the physical-adjoint double layer is the
 normalized transfer matrix, with the row and column pair indices explicitly
 encoded by `finProdFinEquiv`.

--- a/TNLean/MPS/MPU/DoubleLayerContraction.lean
+++ b/TNLean/MPS/MPU/DoubleLayerContraction.lean
@@ -126,7 +126,7 @@ source-factor networks.
 
 Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
 (lines 563--600). -/
-theorem normalizedDiagonal_pow_eq_sum_evalWord [NeZero d]
+theorem normalizedDiagonal_pow_eq_sum_evalWord
     (W : MPOTensor d D) (K : ℕ) :
     normalizedDiagonal W ^ K =
       ((d : ℂ)⁻¹) ^ K •

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -67,6 +67,51 @@ theorem IsMPU.normalized_mpo_tail_coisometry [NeZero d]
   · rw [if_neg hpq, if_neg (Ne.symm hpq)]
     simp
 
+/-- Input-first MPU isometry, with a common input tail of length \(K\)
+traced out and normalized by \(d^{-K}\), leaves the identity on the first two
+input sites.
+
+This is the input-first counterpart of `IsMPU.normalized_mpo_tail_coisometry`.
+It follows directly from the global equation `Uᴴ U = 1`, without an ambient
+source-factor coisometry.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--600). -/
+theorem IsMPU.normalized_mpo_tail_isometry [NeZero d]
+    {U : MPOTensor d D} (hU : IsMPU U) (K : ℕ)
+    (p q : Fin d × Fin d) :
+    ((d : ℂ)⁻¹) ^ K *
+        ∑ τ : Fin K → Fin d, ∑ η : Fin (K + 2) → Fin d,
+          star (mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))) *
+          mpo U (K + 2) η
+            ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ)) =
+      if p = q then 1 else 0 := by
+  classical
+  have hiso := hU.conjTranspose_mpo_mul_mpo (N := K + 2) (by omega)
+  have hentry (τ : Fin K → Fin d) :
+      (∑ η : Fin (K + 2) → Fin d,
+        star (mpo U (K + 2) η
+          ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))) *
+        mpo U (K + 2) η
+          ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ))) =
+        if p = q then 1 else 0 := by
+    have := congrArg (fun M ↦ M
+      ((finAddTwoArrowEquiv (Fin d) K).symm (p, τ))
+      ((finAddTwoArrowEquiv (Fin d) K).symm (q, τ))) hiso
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply,
+      (finAddTwoArrowEquiv (Fin d) K).symm.injective.eq_iff, Prod.mk.injEq,
+      and_true] using this
+  simp_rw [hentry]
+  by_cases hpq : p = q
+  · subst q
+    simp only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul,
+      Fintype.card_pi_const, Fintype.card_fin, Nat.cast_pow, if_pos]
+    have hd : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne d)
+    rw [inv_pow, ← mul_assoc, inv_mul_cancel₀ (pow_ne_zero K hd), one_mul]
+  · rw [if_neg hpq]
+    simp
+
 /-- The stabilized first block followed by the corrected \(D^2\) block has the
 exact simple contractions obtained from the supplied fixed matrix and the
 identity left vector.

--- a/TNLean/MPS/MPU/SourceUClosedNetwork.lean
+++ b/TNLean/MPS/MPU/SourceUClosedNetwork.lean
@@ -142,21 +142,6 @@ theorem sourceU_gram_apply_eq_closed_output_letter
   intro j _
   ring
 
-/-- A normalized diagonal power is the normalized sum of diagonal open words. -/
-private lemma normalizedDiagonal_pow_eq_sum_evalWord
-    [NeZero d] (W : MPOTensor d D) (K : ℕ) :
-    normalizedDiagonal W ^ K =
-      ((d : ℂ)⁻¹) ^ K •
-        ∑ τ : Fin K → Fin d, evalWord W (List.ofFn τ) (List.ofFn τ) := by
-  classical
-  simp only [normalizedDiagonal, contractPhysical, Matrix.one_apply, ite_smul,
-    one_smul, zero_smul, Finset.sum_ite_eq', Finset.mem_univ, if_true,
-    evalWord_ofFn]
-  rw [smul_pow]
-  congr 1
-  simpa [List.ofFn_const] using
-    (List.prod_ofFn_sum (fun _ : Fin K ↦ fun i : Fin d ↦ W i i))
-
 /-- The normalized output-tail contraction is a fully closed output-first
 double-layer trace, with retained letters in $(q,p)$ order.
 

--- a/TNLean/MPS/MPU/SourceVIsometry.lean
+++ b/TNLean/MPS/MPU/SourceVIsometry.lean
@@ -251,6 +251,52 @@ theorem sourceYTensor_gram_eq_four_u_weighted
       simp_rw [Finset.sum_mul, Finset.mul_sum]
       conv_lhs => arg 2; ext α; arg 2; ext α'; rw [Finset.sum_comm]
 
+/-- Entry expansion of the product \(v(Y_1\otimes Y_2)\) after
+regrouping the two source-cut output indices. The first source cut contracts to
+one local tensor entry, while the two second-cut factors remain coupled.
+
+The source-bond order is `Fin r[U] × Fin ℓ[U]`; no partial second-cut Gram is
+formed.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--600). -/
+theorem sourceV_mul_sourceYTensor_apply
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (z p : Fin d × Fin d) (a : Fin D × Fin D) :
+    (sourceV U ρ hρ * sourceYTensor U ρ hρ) z
+        (((p.1, a.1), (p.2, a.2))) =
+      ∑ γ : Fin D, ∑ l : Fin ℓ[U],
+        U p.1 z.1 γ a.1 *
+          (sourceY₂ U l (z.2, γ) * sourceY₂ U l (p.2, a.2)) := by
+  classical
+  simp only [Matrix.mul_apply, sourceV, sourceYTensor_apply,
+    Fintype.sum_prod_type, Finset.sum_mul]
+  let f := fun (r : Fin r[U]) (l : Fin ℓ[U]) (γ : Fin D) ↦
+    sourceX₁ U ρ hρ (γ, z.1) r * sourceY₂ U l (z.2, γ) *
+      (sourceY₁ U ρ hρ r (p.1, a.1) * sourceY₂ U l (p.2, a.2))
+  change (∑ r, ∑ l, ∑ γ, f r l γ) = _
+  calc
+    _ = ∑ l, ∑ r, ∑ γ, f r l γ := Finset.sum_comm
+    _ = ∑ l, ∑ γ, ∑ r, f r l γ := by
+      exact Finset.sum_congr rfl fun l _ ↦ Finset.sum_comm
+    _ = ∑ γ, ∑ l, ∑ r, f r l γ := Finset.sum_comm
+    _ = ∑ γ, ∑ l,
+        (∑ r, sourceX₁ U ρ hρ (γ, z.1) r *
+          sourceY₁ U ρ hρ r (p.1, a.1)) *
+            (sourceY₂ U l (z.2, γ) * sourceY₂ U l (p.2, a.2)) := by
+      refine Finset.sum_congr rfl fun γ _ ↦ ?_
+      refine Finset.sum_congr rfl fun l _ ↦ ?_
+      simp_rw [Finset.sum_mul]
+      refine Finset.sum_congr rfl fun r _ ↦ ?_
+      simp only [f]
+      ring
+    _ = _ := by
+      refine Finset.sum_congr rfl fun γ _ ↦ ?_
+      refine Finset.sum_congr rfl fun l _ ↦ ?_
+      change ((sourceX₁ U ρ hρ * sourceY₁ U ρ hρ)
+        (γ, z.1) (p.1, a.1)) * _ = _
+      rw [sourceX₁_mul_sourceY₁_apply]
+
 /-- Entry formula for $Z_1\otimes Z_2$ in dotted/solid source-bond order.
 
 Source: arXiv:1703.09188, equations `YZ=1` and `vUnitary`, lines 495--506 and

--- a/TNLean/MPS/MPU/SuppliedFixedWitnesses.lean
+++ b/TNLean/MPS/MPU/SuppliedFixedWitnesses.lean
@@ -160,7 +160,7 @@ two retained double-layer letters.
 Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
 (lines 563--600). -/
 theorem doubleLayerTensor_rankOne_mul_eq_normalizedDiagonal_tail
-    [NeZero d] (W : MPOTensor d D) (ρ Φ : Fin (D * D) → ℂ) (J : ℕ)
+    (W : MPOTensor d D) (ρ Φ : Fin (D * D) → ℂ) (J : ℕ)
     (hpower : normalizedDiagonal (doubleLayerTensor W) ^ J =
       Matrix.vecMulVec ρ Φ)
     (i j k l : Fin d) :
@@ -182,7 +182,7 @@ introduces the rank-one matrix, and the power equation expands it as the tail.
 Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
 (lines 563--600). -/
 theorem doubleLayerTensor_mul_eq_normalizedDiagonal_tail_of_simple2
-    [NeZero d] (W : MPOTensor d D) (ρ Φ : Fin (D * D) → ℂ) (J : ℕ)
+    (W : MPOTensor d D) (ρ Φ : Fin (D * D) → ℂ) (J : ℕ)
     (hpower : normalizedDiagonal (doubleLayerTensor W) ^ J =
       Matrix.vecMulVec ρ Φ)
     (hsimple2 : ∀ i j k l : Fin d,

--- a/TNLean/MPS/MPU/SuppliedFixedWitnesses.lean
+++ b/TNLean/MPS/MPU/SuppliedFixedWitnesses.lean
@@ -134,4 +134,70 @@ theorem IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec
     _ = doubleLayerTensor W i j * Matrix.vecMulVec ρ Φ *
         doubleLayerTensor W k l := by rw [hpower]
 
+/-- A normalized rank-one power with normalized fixed pair fixes its
+right vector and its left covector. These are the two boundaries of the
+stabilized diagonal tail.
+
+Source: arXiv:1703.09188, equation `Erightleft` and Theorem III.8,
+equations (31)--(32), lines 274--280 and 563--600. -/
+theorem normalizedDiagonal_pow_fixed_pair_of_eq_vecMulVec
+    (W : MPOTensor d D) (ρ Φ : Fin (D * D) → ℂ) (J : ℕ)
+    (hpair : Φ ⬝ᵥ ρ = 1)
+    (hpower : normalizedDiagonal (doubleLayerTensor W) ^ J =
+      Matrix.vecMulVec ρ Φ) :
+    normalizedDiagonal (doubleLayerTensor W) ^ J *ᵥ ρ = ρ ∧
+      Matrix.vecMul Φ (normalizedDiagonal (doubleLayerTensor W) ^ J) = Φ := by
+  constructor
+  · rw [hpower, Matrix.vecMulVec_mulVec, hpair]
+    simp
+  · rw [hpower, Matrix.vecMul_vecMulVec, hpair]
+    simp
+
+/-- Replacing an aligned rank-one insertion by its supplied
+normalized-diagonal power gives the exact normalized diagonal-word tail between
+two retained double-layer letters.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--600). -/
+theorem doubleLayerTensor_rankOne_mul_eq_normalizedDiagonal_tail
+    [NeZero d] (W : MPOTensor d D) (ρ Φ : Fin (D * D) → ℂ) (J : ℕ)
+    (hpower : normalizedDiagonal (doubleLayerTensor W) ^ J =
+      Matrix.vecMulVec ρ Φ)
+    (i j k l : Fin d) :
+    doubleLayerTensor W i j * Matrix.vecMulVec ρ Φ *
+        doubleLayerTensor W k l =
+      ((d : ℂ)⁻¹) ^ J •
+        ∑ τ : Fin J → Fin d,
+          doubleLayerTensor W i j *
+            evalWord (doubleLayerTensor W) (List.ofFn τ) (List.ofFn τ) *
+              doubleLayerTensor W k l := by
+  rw [← hpower, normalizedDiagonal_pow_eq_sum_evalWord]
+  simp only [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_sum, Finset.sum_mul]
+
+/-- Aligned supplied `simple2` and the supplied normalized-diagonal power
+identify the ordinary two-letter double-layer product with the exact normalized
+diagonal-word tail. Both hypotheses are used in the same network: `simple2`
+introduces the rank-one matrix, and the power equation expands it as the tail.
+
+Source: arXiv:1703.09188, Theorem III.8, equations (31)--(32), Section III.B
+(lines 563--600). -/
+theorem doubleLayerTensor_mul_eq_normalizedDiagonal_tail_of_simple2
+    [NeZero d] (W : MPOTensor d D) (ρ Φ : Fin (D * D) → ℂ) (J : ℕ)
+    (hpower : normalizedDiagonal (doubleLayerTensor W) ^ J =
+      Matrix.vecMulVec ρ Φ)
+    (hsimple2 : ∀ i j k l : Fin d,
+      doubleLayerTensor W i j * doubleLayerTensor W k l =
+        doubleLayerTensor W i j * Matrix.vecMulVec ρ Φ *
+          doubleLayerTensor W k l)
+    (i j k l : Fin d) :
+    doubleLayerTensor W i j * doubleLayerTensor W k l =
+      ((d : ℂ)⁻¹) ^ J •
+        ∑ τ : Fin J → Fin d,
+          doubleLayerTensor W i j *
+            evalWord (doubleLayerTensor W) (List.ofFn τ) (List.ofFn τ) *
+              doubleLayerTensor W k l := by
+  rw [hsimple2]
+  exact doubleLayerTensor_rankOne_mul_eq_normalizedDiagonal_tail
+    W ρ Φ J hpower i j k l
+
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -385,7 +385,7 @@ closing a chain of $N$ copies of $\mathcal U$.
     \lean{MPOTensor.normalizedDiagonal_pow_eq_sum_evalWord}
     \leanok
     \uses{def:mpo_eval_word}
-    Let $\mathcal W$ be an MPO tensor of positive physical dimension $d$, and
+    Let $\mathcal W$ be an MPO tensor of physical dimension $d$, and
     let
     \begin{align}
         R&=\frac1d\sum_{i=0}^{d-1}W^{ii}
@@ -1058,8 +1058,8 @@ closing a chain of $N$ copies of $\mathcal U$.
     \leanok
     \uses{def:mpu_double_layer,
         thm:mpu_normalized_diagonal_word_expansion}
-    Let $W$ be the double layer of an MPO tensor of positive physical
-    dimension, and let $R$ be its normalized physical diagonal.  If
+    Let $W$ be the double layer of an MPO tensor, and let $R$ be its
+    normalized physical diagonal.  If
     \begin{align}
         R^J&=\lvert\rho)(\Phi\rvert,
     \end{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -2956,10 +2956,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
     The first source cut has contracted to one local tensor entry, while the
     two factors from the second cut remain in the same summand.  No partial
-    second-cut Gram matrix has been formed.  This is a one-sided support
-    identity for the simultaneous source-cut calculation in
-    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU};
-    it does not perform that complete contraction.
+    second-cut Gram matrix has been formed.  This coupling is the source-cut
+    ordering in the calculation of
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -380,6 +380,34 @@ closing a chain of $N$ copies of $\mathcal U$.
     Transfer stabilization gives the final rank-one specialization.
 \end{proof}
 
+\begin{theorem}[Normalized diagonal as a diagonal-word sum]
+    \label{thm:mpu_normalized_diagonal_word_expansion}
+    \lean{MPOTensor.normalizedDiagonal_pow_eq_sum_evalWord}
+    \leanok
+    \uses{def:mpo_eval_word}
+    Let $\mathcal W$ be an MPO tensor of positive physical dimension $d$, and
+    let
+    \begin{align}
+        R&=\frac1d\sum_{i=0}^{d-1}W^{ii}
+    \end{align}
+    be its normalized physical diagonal.  For every $K\geq0$,
+    \begin{align}
+        R^K
+        &=d^{-K}\sum_{\tau\in\{0,\ldots,d-1\}^K}
+          W^{\tau_0\tau_0}\cdots W^{\tau_{K-1}\tau_{K-1}}.
+    \end{align}
+    At $K=0$, the word product is the identity matrix.  This is the algebraic
+    diagonal-tail expansion used in the source-factor networks of
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpo_eval_word}
+    Expand the $K$th power of the finite sum defining $R$.  Distributivity
+    indexes the resulting terms by physical words $\tau$, and each term is
+    the ordered diagonal word displayed above.
+\end{proof}
+
 \begin{theorem}[Identity plus traceless physical decomposition]
     \label{thm:mpu_WIsom}
     \lean{Matrix.exists_identity_traceless_basis,
@@ -885,6 +913,33 @@ closing a chain of $N$ copies of $\mathcal U$.
     tails, and $d^{-K}d^K=1$ because $d>0$.
 \end{proof}
 
+\begin{theorem}[Normalized input-tail isometry]
+    \label{thm:mpu_normalized_input_tail_isometry}
+    \lean{MPOTensor.IsMPU.normalized_mpo_tail_isometry}
+    \leanok
+    \uses{def:mpu,def:mpo_family}
+    Let $d>0$, let $\mathcal U$ be an MPU, and let $K\geq0$.  For
+    $p,q\in\Fin d\times\Fin d$, separate the first two input sites from a
+    common input tail $\tau\in\Fin K\to\Fin d$.  Then
+    \begin{align}
+        d^{-K}\sum_{\tau}\sum_{\eta}
+        \overline{U^{(K+2)}_{\eta,(p,\tau)}}
+        U^{(K+2)}_{\eta,(q,\tau)}
+        &=\delta_{p,q}.
+    \end{align}
+    The global contraction is the input-first equation
+    $(U^{(K+2)})^\dagger U^{(K+2)}=\Id$.  This is the input-oriented tail
+    contraction supporting the network calculation in
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpu_adjoint_mul}
+    Apply input-first unitarity for each fixed tail.  The inner output sum is
+    $\delta_{p,q}$.  Summing over the $d^K$ tails and multiplying by $d^{-K}$
+    leaves the same Kronecker delta.
+\end{proof}
+
 % Formalization scope: identifying this normalized scalar with
 % $(\texttt{sourceU})^\dagger\texttt{sourceU}$ is treated separately.
 
@@ -970,6 +1025,90 @@ closing a chain of $N$ copies of $\mathcal U$.
     \end{align}
     Substituting the supplied equality $E^J=|\rho)(\Phi|$ proves the claim.
     No uniqueness of rank-one factorizations is used.
+\end{proof}
+
+\begin{theorem}[Fixed boundaries of a normalized rank-one power]
+    \label{thm:mpu_normalized_diagonal_power_fixed_pair}
+    \lean{MPOTensor.normalizedDiagonal_pow_fixed_pair_of_eq_vecMulVec}
+    \leanok
+    Let $R$ be the normalized physical diagonal of the double layer of an MPO
+    tensor.  Suppose
+    \begin{align}
+        (\Phi\rvert\rho)&=1,
+        &R^J&=\lvert\rho)(\Phi\rvert.
+    \end{align}
+    Then the two boundaries of the stabilized diagonal tail are fixed:
+    \begin{align}
+        R^J\lvert\rho)&=\lvert\rho),
+        &(\Phi\rvert R^J&=(\Phi\rvert.
+    \end{align}
+    This is the fixed-pair normalization underlying equation
+    \texttt{Erightleft} and the tail contractions in
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Substitute $R^J=\lvert\rho)(\Phi\rvert$ in each expression and use
+    $(\Phi\rvert\rho)=1$.
+\end{proof}
+
+\begin{theorem}[Rank-one insertion as a normalized diagonal tail]
+    \label{thm:mpu_rank_one_insertion_diagonal_tail}
+    \lean{MPOTensor.doubleLayerTensor_rankOne_mul_eq_normalizedDiagonal_tail}
+    \leanok
+    \uses{def:mpu_double_layer,
+        thm:mpu_normalized_diagonal_word_expansion}
+    Let $W$ be the double layer of an MPO tensor of positive physical
+    dimension, and let $R$ be its normalized physical diagonal.  If
+    \begin{align}
+        R^J&=\lvert\rho)(\Phi\rvert,
+    \end{align}
+    then, for all physical indices $i,j,k,\ell$,
+    \begin{align}
+        W^{ij}\lvert\rho)(\Phi\rvert W^{k\ell}
+        =d^{-J}\sum_{\tau\in\{0,\ldots,d-1\}^J}
+          W^{ij}W^{\tau_0\tau_0}\cdots
+          W^{\tau_{J-1}\tau_{J-1}}W^{k\ell}.
+    \end{align}
+    This is the exact diagonal-word tail between the two retained letters in
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_normalized_diagonal_word_expansion}
+    Replace the rank-one insertion by $R^J$, apply the diagonal-word
+    expansion, and distribute the two retained letters across the normalized
+    finite sum.
+\end{proof}
+
+\begin{theorem}[Simple two-letter product as a normalized diagonal tail]
+    \label{thm:mpu_simple_two_letter_diagonal_tail}
+    \lean{MPOTensor.doubleLayerTensor_mul_eq_normalizedDiagonal_tail_of_simple2}
+    \leanok
+    \uses{def:mpu_double_layer,
+        thm:mpu_rank_one_insertion_diagonal_tail}
+    In the setting of the preceding theorem, suppose in addition that the
+    same fixed pair satisfies the supplied two-letter contraction
+    \begin{align}
+        W^{ij}W^{k\ell}
+          &=W^{ij}\lvert\rho)(\Phi\rvert W^{k\ell}
+    \end{align}
+    for all physical indices.  Then
+    \begin{align}
+        W^{ij}W^{k\ell}
+        =d^{-J}\sum_{\tau\in\{0,\ldots,d-1\}^J}
+          W^{ij}W^{\tau_0\tau_0}\cdots
+          W^{\tau_{J-1}\tau_{J-1}}W^{k\ell}.
+    \end{align}
+    Thus the supplied insertion and its stabilized transfer power occur in
+    one aligned network, as required in the calculation of
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_rank_one_insertion_diagonal_tail}
+    Apply the supplied two-letter contraction and then replace its rank-one
+    insertion by the normalized diagonal-word tail.
 \end{proof}
 
 \begin{theorem}[The fixed-point simple1 contraction]
@@ -2793,6 +2932,49 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     sums. No ambient identity $X_2X_2^\dagger=\Id$ is used.
 \end{proof}
 
+% This theorem is support for issue #6071.  The complete simultaneous mixed
+% source-cut contraction remains open there.
+\begin{theorem}[One-sided contraction of the dressed source operator]
+    \label{thm:mpu_source_v_mul_source_y_tensor_entry}
+    \lean{MPOTensor.sourceV_mul_sourceYTensor_apply}
+    \leanok
+    \discussion{6071}
+    \uses{def:mpu_source_v_dressing,def:mpu_source_uv,
+        thm:mpu_source_factorization_entries}
+    Let $\rho>0$.  For output pair $z=(z_1,z_2)$, physical pair
+    $p=(p_1,p_2)$, and virtual pair $a=(a_1,a_2)$, the entry of
+    $v(Y_1\otimes Y_2)$ is
+    \begin{align}
+      \bigl(v(Y_1\otimes Y_2)\bigr)_{z,((p_1,a_1),(p_2,a_2))}
+      =\sum_{\gamma,l}
+        U^{p_1z_1}_{\gamma a_1}
+        (Y_2)_{l,(z_2,\gamma)}(Y_2)_{l,(p_2,a_2)}.
+    \end{align}
+    The first source cut has contracted to one local tensor entry, while the
+    two factors from the second cut remain in the same summand.  No partial
+    second-cut Gram matrix has been formed.  This is a one-sided support
+    identity for the simultaneous source-cut calculation in
+    \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU};
+    it does not perform that complete contraction.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_source_v_dressing,def:mpu_source_uv,
+        thm:mpu_source_factorization_entries}
+    Expand the matrix product and the tensor product, reorder the three finite
+    sums, and contract $X_1Y_1$ by the first source-cut entry factorization.
+    Keep both $Y_2$ factors together throughout.
+\end{proof}
+
+\begin{remark}[Scope of the stabilized source-$v$ support]
+    The normalized input-tail isometry, the diagonal-word tail identities,
+    and the one-sided formula above are separate support calculations.  They
+    do not yet contract both source cuts simultaneously through the same
+    mixed network.  In particular, they do not establish any dressed Gram
+    identity for $v$.  The complete mixed source-cut contraction used in
+    equations~(31)--(32) remains open.
+\end{remark}
+
 \begin{theorem}[Tensorized source right inverse]
     \label{thm:mpu_source_yz_tensor}
     \lean{MPOTensor.sourceYTensor_mul_sourceZTensor}
@@ -3929,7 +4111,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}
-  \uses{thm:mpu_source_v_four_u_expansions,
+  \uses{thm:mpu_normalized_input_tail_isometry,
+    thm:mpu_normalized_diagonal_power_fixed_pair,
+    thm:mpu_simple_two_letter_diagonal_tail,
+    thm:mpu_source_v_four_u_expansions,
+    thm:mpu_source_v_mul_source_y_tensor_entry,
     thm:mpu_source_v_dressed_entries}
   Insert $E^{D^2-1}=\lvert\rho)(\Phi\rvert$ into the complete network while
   retaining the source factors of $\mathcal U$. Expand both source cuts and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -390,7 +390,9 @@ closing a chain of $N$ copies of $\mathcal U$.
     \begin{align}
         R&=\frac1d\sum_{i=0}^{d-1}W^{ii}
     \end{align}
-    be its normalized physical diagonal.  For every $K\geq0$,
+    be its normalized physical diagonal.  Here and in the two diagonal-tail
+    identities below, scalar inverses are the totalized complex-field inverses,
+    so $0^{-1}=0$.  For every $K\geq0$,
     \begin{align}
         R^K
         &=d^{-K}\sum_{\tau\in\{0,\ldots,d-1\}^K}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1044,8 +1044,10 @@ closing a chain of $N$ copies of $\mathcal U$.
         R^J\lvert\rho)&=\lvert\rho),
         &(\Phi\rvert R^J&=(\Phi\rvert.
     \end{align}
-    This is the fixed-pair normalization underlying equation
-    \texttt{Erightleft} and the tail contractions in
+    This is the fixed-pair normalization from the canonical-form-II
+    fixed-point equations in
+    \cite[equations~(6a)--(6b)]{Cirac2017MPU} and underlies the tail
+    contractions in
     \cite[Theorem~III.8, Section~III.B, equations~(31)--(32)]{Cirac2017MPU}.
 \end{theorem}
 
@@ -2968,14 +2970,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     Keep both $Y_2$ factors together throughout.
 \end{proof}
 
-\begin{remark}[Scope of the stabilized source-$v$ support]
-    The normalized input-tail isometry, the diagonal-word tail identities,
-    and the one-sided formula above are separate support calculations.  They
-    do not yet contract both source cuts simultaneously through the same
-    mixed network.  In particular, they do not establish any dressed Gram
-    identity for $v$.  The complete mixed source-cut contraction used in
-    equations~(31)--(32) remains open.
-\end{remark}
+% Formalization scope: the input-tail, diagonal-tail, and one-sided source-$v$
+% identities above do not prove a dressed Gram identity.  The simultaneous
+% mixed source-cut contraction is tracked by the not-ready node under #6071.
 
 \begin{theorem}[Tensorized source right inverse]
     \label{thm:mpu_source_yz_tensor}


### PR DESCRIPTION
## Summary

- centralize the generic normalized-diagonal word expansion used by the source-factor networks
- add the input-first normalized MPU tail identity from $U^\dagger U=1$
- expose the exact `sourceV * sourceYTensor` entry contraction in source order $r[W]\times\ell[W]$
- package fixed-pair boundaries and the rank-one / supplied-`simple2` conversion to a normalized diagonal tail
- document all six declarations formula-by-formula in Chapter 28

## Mathematical scope

This is focused support for the same-tensor source-$v$ network in Theorem III.8, Section III.B, equations (31)--(32). It deliberately does **not** prove `SourceVDressedGram` or the remaining simultaneous mixed source-cut contraction in #6071. It introduces no standalone first-cut or partial-$Y_2$ rotation.

All cuts, ranks, source factors, and stabilized data remain attached to the same tensor. The input-tail theorem uses `IsMPU.conjTranspose_mpo_mul_mpo`; `hpower` and aligned `simple2` are both used genuinely in the tail conversion.

## Verification

- direct Lean checks for all five changed MPU modules
- targeted `lake build TNLean.MPS.MPU`
- generated declaration / Chapter 28 synchronization and reverse-coverage checks for the six declarations
- blueprint PDF/web checks and reader-facing prose checks
- proof-integrity and `git diff --check`
- independent exact-head Lean/style and LeanBlueprint reviews approved `c621ff7784a88c07f48f5a0efbf1f877e60894d5`

Closes #6179.
Supports #6071 and #6067.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean lemmas and blueprint documentation only; no existing proofs or core definitions are rewritten beyond promoting one private expansion.
> 
> **Overview**
> Exposes the algebraic ingredients needed for the same-tensor source-$v$ network in Theorem III.8 (eqs. (31)--(32)), without proving `SourceVDressedGram` or the remaining mixed source-cut contraction.
> 
> **Promotes** the private diagonal-word expansion to public `normalizedDiagonal_pow_eq_sum_evalWord`, and adds the input-first counterpart `IsMPU.normalized_mpo_tail_isometry` of the existing output-tail coisometry.
> 
> **Adds** the one-sided entry identity `sourceV_mul_sourceYTensor_apply` (first cut contracted, both `Y₂` factors kept coupled), plus fixed-pair boundary and rank-one / supplied-`simple2` conversions that turn a stabilized insertion into an exact normalized diagonal-word tail.
> 
> Blueprint Chapter 28 documents all six declarations and wires them into the `vUnitary` proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8caba470cdef1bd48856fcd9b330d0a1549b0076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->