### PR TITLE
refactor(parent-hamiltonian): canonicalize ground-space injectivity

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -6,7 +6,6 @@ Authors: TNLean contributors
 import TNLean.MPS.Core.WordFactor
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.FundamentalTheorem.FiniteLength
-import TNLean.Algebra.TracePairing
 import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.List.OfFn
 
@@ -18,8 +17,6 @@ periodic parent-Hamiltonian closure argument for block-injective tensors.
 
 ## Main results
 
-- `MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top`
-- `MPSTensor.groundSpaceMap_injective_of_isNBlkInjective`
 - `MPSTensor.exists_right_factor_of_block_word_compatibility`
 - `MPSTensor.commutes_block_words_of_commutes_long_words_of_isNBlkInjective`
 
@@ -47,38 +44,6 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-- If words of length \(L\) span the full matrix algebra, then `groundSpaceMap A L`
-has trivial kernel. -/
-theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D}
-    {L : ℕ} (hWord : wordSpan A L = ⊤) :
-    Function.Injective (groundSpaceMap A L) := by
-  have hker : (groundSpaceMap A L).ker = ⊥ := by
-    apply (LinearMap.ker_eq_bot').2
-    intro X hX
-    have hφ :
-        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
-      apply LinearMap.ext_on_range
-        (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
-      · simpa [wordSpan] using hWord
-      · intro σ
-        simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
-          congrArg (fun ψ => ψ σ) hX
-    exact (Matrix.ext_iff_trace_mul_right (A := X) (B := 0)).2 fun N => by
-      have hNX : Matrix.trace (N * X) = 0 := by
-        simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
-      calc
-        Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
-        _ = 0 := hNX
-        _ = Matrix.trace (0 * N) := by simp
-  exact LinearMap.ker_eq_bot.mp hker
-
-/-- Block injectivity at length \(L₀\) makes the map \(Γ_{L₀}\) injective. -/
-theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D}
-    {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) :
-    Function.Injective (groundSpaceMap A L₀) := by
-  apply groundSpaceMap_injective_of_wordSpan_eq_top
-  exact (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
 
 /-- If a family indexed by length-\(L₀\) words is compatible with multiplication by
 single physical letters, then block injectivity strips the letter and produces a

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -261,6 +261,38 @@ theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
         _ = Matrix.trace (0 * N) := by simp
   exact LinearMap.ker_eq_bot.mp hker
 
+/-- If words of length \(L\) span the full matrix algebra, then `groundSpaceMap A L`
+has trivial kernel. -/
+theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D}
+    {L : ℕ} (hWord : wordSpan A L = ⊤) :
+    Function.Injective (groundSpaceMap A L) := by
+  have hker : (groundSpaceMap A L).ker = ⊥ := by
+    apply (LinearMap.ker_eq_bot').2
+    intro X hX
+    have hφ :
+        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulRight ℂ X) = 0 := by
+      apply LinearMap.ext_on_range
+        (v := fun σ : Fin L → Fin d => evalWord A (List.ofFn σ))
+      · simpa [wordSpan] using hWord
+      · intro σ
+        simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
+          congrArg (fun ψ => ψ σ) hX
+    exact (Matrix.ext_iff_trace_mul_right (A := X) (B := 0)).2 fun N => by
+      have hNX : Matrix.trace (N * X) = 0 := by
+        simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
+      calc
+        Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
+        _ = 0 := hNX
+        _ = Matrix.trace (0 * N) := by simp
+  exact LinearMap.ker_eq_bot.mp hker
+
+/-- Block injectivity at length \(L₀\) makes the map \(Γ_{L₀}\) injective. -/
+theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D}
+    {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) :
+    Function.Injective (groundSpaceMap A L₀) := by
+  apply groundSpaceMap_injective_of_wordSpan_eq_top
+  exact (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+
 /-- For an injective tensor, the ground space has dimension exactly \(D^2\) for
 \(L \geq 1\).
 

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -33,6 +33,10 @@ state of the parent Hamiltonian.
 * `MPSTensor.groundSpace_inLeftGround` — forward direction, left window
 * `MPSTensor.groundSpace_inRightGround` — forward direction, right window
 * `MPSTensor.groundSpaceMap_injective` — injectivity for injective tensors
+* `MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top` — injectivity from exact
+  word-span fullness
+* `MPSTensor.groundSpaceMap_injective_of_isNBlkInjective` — injectivity at a
+  block-injective length
 * `MPSTensor.groundSpace_finrank_eq` — dimension equals \(D^2\)
 * `MPSTensor.groundSpace_intersection` — the intersection property
 

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
-import TNLean.MPS.Chain.BlockedChainFT
 import Mathlib.Data.Fin.Tuple.Basic
 
 /-!
@@ -89,27 +88,6 @@ produces the expected boundary matrix \(X A_i\). -/
           rw [Matrix.mul_assoc]
     _ = Matrix.trace (evalWord A (List.ofFn σ) * (X * A i)) := by
           rw [Matrix.trace_mul_comm]
-
-/-- If the length-\(L\) word span is all of \(M_D\), then `groundSpaceMap A L` is
-injective. -/
-theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}
-    (hwordL : wordSpan A L = ⊤) :
-    Function.Injective (groundSpaceMap A L) := by
-  have hBlkInj : IsInjective (blockTensor A L) := by
-    exact (isNBlkInjective_iff_blockTensor_isInjective A L).mp
-      ((wordSpan_eq_top_iff_isNBlkInjective A L).mp hwordL)
-  intro X Y hXY
-  apply groundSpaceMap_injective hBlkInj (show 0 < 1 by omega)
-  ext σ
-  have hXY' := congrArg (fun ψ => ψ (decodeBlock d L (σ 0))) hXY
-  simpa [groundSpaceMap_apply, blockTensor, wordOfBlock, decodeBlock] using hXY'
-
-/-- Block injectivity at length \(L\) implies injectivity of `groundSpaceMap A L`. -/
-theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}
-    (hInj : IsNBlkInjective A L) :
-    Function.Injective (groundSpaceMap A L) :=
-  groundSpaceMap_injective_of_wordSpan_eq_top
-    ((wordSpan_eq_top_iff_isNBlkInjective A L).mpr hInj)
 
 /-- Restricting a ground-space vector to a suffix slice preserves the ground-space
 form, with the prefix word moved to the right boundary matrix by trace cyclicity. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -18,13 +18,14 @@
     \label{thm:ground_space_map_injective_word_span}
     \lean{MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top}
     \leanok
-    \uses{def:ground_space_map, def:word_span, thm:trace_nondeg}
+    \uses{def:ground_space_map, def:word_span}
     If the length-$L$ products $\{A^\sigma : |\sigma| = L\}$ span $\MN{D}$, then
     $\Gamma_L$ is injective.
 \end{theorem}
 
 \begin{proof}
     \leanok
+    \uses{thm:trace_nondeg}
     If $\Gamma_L(X) = 0$, then $\tr(A^\sigma X) = 0$ for every word $\sigma$ of
     length $L$. The spanning hypothesis turns this into $\tr(MX) = 0$ for every
     $M \in \MN{D}$, and the trace pairing gives $X = 0$.
@@ -34,14 +35,13 @@
     \label{thm:ground_space_map_injective_blk}
     \lean{MPSTensor.groundSpaceMap_injective_of_isNBlkInjective}
     \leanok
-    \uses{thm:ground_space_map_injective_word_span, def:l_blk_injective,
-        lem:wordspan_blk_inj}
-    If $\operatorname{IsNBlkInjective}(A,L_0)$ holds, then $\Gamma_{L_0}$ is
-    injective.
+    \uses{def:ground_space_map, def:l_blk_injective}
+    If $A$ is $L_0$-block injective, then $\Gamma_{L_0}$ is injective.
 \end{theorem}
 
 \begin{proof}
     \leanok
+    \uses{thm:ground_space_map_injective_word_span, lem:wordspan_blk_inj}
     Lemma~\ref{lem:wordspan_blk_inj} identifies $L_0$-block injectivity with
     the word-span hypothesis of
     Theorem~\ref{thm:ground_space_map_injective_word_span}.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -18,7 +18,7 @@
     \label{thm:ground_space_map_injective_word_span}
     \lean{MPSTensor.groundSpaceMap_injective_of_wordSpan_eq_top}
     \leanok
-    \uses{def:ground_space_map}
+    \uses{def:ground_space_map, def:word_span, thm:trace_nondeg}
     If the length-$L$ products $\{A^\sigma : |\sigma| = L\}$ span $\MN{D}$, then
     $\Gamma_L$ is injective.
 \end{theorem}
@@ -34,15 +34,16 @@
     \label{thm:ground_space_map_injective_blk}
     \lean{MPSTensor.groundSpaceMap_injective_of_isNBlkInjective}
     \leanok
-    \uses{thm:ground_space_map_injective_word_span, def:l_blk_injective}
-    If the length-$L_0$ products span the full matrix algebra,
-    $\spn\{A^\omega : |\omega| = L_0\} = \MN{D}$, then $\Gamma_{L_0}$ is
+    \uses{thm:ground_space_map_injective_word_span, def:l_blk_injective,
+        lem:wordspan_blk_inj}
+    If $\operatorname{IsNBlkInjective}(A,L_0)$ holds, then $\Gamma_{L_0}$ is
     injective.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The hypothesis is precisely the fixed-length spanning condition needed by
+    Lemma~\ref{lem:wordspan_blk_inj} identifies $L_0$-block injectivity with
+    the word-span hypothesis of
     Theorem~\ref{thm:ground_space_map_injective_word_span}.
 \end{proof}
 

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -69,7 +69,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch12_symmetry_virtual_and_cohomology.tex` | L181, 196, 330, 459, 473 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L102 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1595, 1637 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- moved both ground-space injectivity theorems to `IntersectionProperty.lean`, their lowest common owner;
- removed duplicate declarations from `BlockStrip.lean` and `SuffixWindow.lean` and dropped their now-unused direct imports;
- preserved both fully qualified theorem names and public types;
- corrected the Blueprint hypotheses and direct proof dependencies for word-span fullness versus block injectivity.

## Validation

- exact-head Lean review: approved at `4eb0e8f2e764f3f56d791c47dd28c2d0dcdc890b`;
- full warm `lake build`: passed, 10,078 jobs;
- owner, former owners, six direct consumers, and ParentHamiltonian aggregator built;
- theorem types preserved modulo binder names; each declaration now has one source owner;
- import graph acyclic and generated aggregators current;
- Blueprint sync and declaration checks passed;
- proof-integrity and diff checks passed; worktree clean.

Closes #6175.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor that consolidates duplicate theorem declarations without changing public names or types. Downstream consumers keep the same API.
> 
> **Overview**
> **Canonicalizes** the two ground-space injectivity lemmas by giving them a single owner in `IntersectionProperty.lean`.
> 
> Removes duplicate `groundSpaceMap_injective_of_wordSpan_eq_top` / `groundSpaceMap_injective_of_isNBlkInjective` declarations from `BlockStrip.lean` and `SuffixWindow.lean`, and drops the now-unused imports those copies required. Public theorem names and types are preserved.
> 
> Also corrects Blueprint hypotheses and `\uses` edges so word-span fullness and block injectivity are stated and depended on accurately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1624a91453d95dc61e3c30f4ea51c352d9919a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->