### PR TITLE
refactor(mps/mpdo): share two-site embedding reindex proofs

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -140,6 +140,7 @@ import TNLean.MPS.MPDO.CyclicProjector
 import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.DiagonalCutRank
 import TNLean.MPS.MPDO.DiagonalFiniteChain
+import TNLean.MPS.MPDO.EmbedLocalOperatorTwoSite
 import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.FibonacciBoundaryRank
 import TNLean.MPS.MPDO.FigureEightPairwise

--- a/TNLean/MPS/MPDO/EmbedLocalOperatorTwoSite.lean
+++ b/TNLean/MPS/MPDO/EmbedLocalOperatorTwoSite.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CommutingForm
+
+/-!
+# Two-site cyclic local embeddings in pair coordinates
+
+On a periodic chain of length two, the local embedding beginning at site zero
+preserves the order of the two physical indices, while the embedding beginning
+at site one exchanges them. These identities hold for an arbitrary two-site
+matrix.
+-/
+
+namespace MPOTensor
+
+variable {d : ℕ}
+
+/-- In pair coordinates, embedding an arbitrary two-site matrix at site zero
+preserves its physical-index order. -/
+theorem reindex_embedLocalOperator_two_zero
+    (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
+    Matrix.reindex (_root_.finTwoArrowEquiv (Fin d))
+        (_root_.finTwoArrowEquiv (Fin d))
+        (embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2) B) =
+      Matrix.reindex (_root_.finTwoArrowEquiv (Fin d))
+        (_root_.finTwoArrowEquiv (Fin d)) B := by
+  ext σ τ
+  have hAgree : AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 2)
+      ((_root_.finTwoArrowEquiv (Fin d)).symm σ)
+      ((_root_.finTwoArrowEquiv (Fin d)).symm τ) := by
+    funext i
+    fin_cases i <;>
+      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow,
+        _root_.finTwoArrowEquiv]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    embedLocalOperator_apply]
+  rw [if_pos hAgree]
+  simp only [Fin.isValue, finTwoArrowEquiv_symm_apply]
+  congr 1 <;> funext j <;> fin_cases j <;> rfl
+
+/-- In pair coordinates, embedding an arbitrary two-site matrix at site one
+exchanges its two physical indices. -/
+theorem reindex_embedLocalOperator_two_one
+    (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
+    Matrix.reindex (_root_.finTwoArrowEquiv (Fin d))
+        (_root_.finTwoArrowEquiv (Fin d))
+        (embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2) B) =
+      Matrix.reindex (Equiv.prodComm (Fin d) (Fin d))
+        (Equiv.prodComm (Fin d) (Fin d))
+        (Matrix.reindex (_root_.finTwoArrowEquiv (Fin d))
+          (_root_.finTwoArrowEquiv (Fin d)) B) := by
+  ext σ τ
+  have hAgree : AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 2)
+      ((_root_.finTwoArrowEquiv (Fin d)).symm σ)
+      ((_root_.finTwoArrowEquiv (Fin d)).symm τ) := by
+    funext i
+    fin_cases i <;>
+      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow,
+        _root_.finTwoArrowEquiv]
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    embedLocalOperator_apply]
+  rw [if_pos hAgree]
+  simp only [Fin.isValue, finTwoArrowEquiv_symm_apply]
+  congr 1 <;> funext j <;> fin_cases j <;> rfl
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
+++ b/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.SingleKrausPositivity
+import TNLean.MPS.MPDO.EmbedLocalOperatorTwoSite
 import TNLean.MPS.MPDO.PhysicalSupportBondTransport
 
 /-!
@@ -401,49 +402,6 @@ private theorem reindex_embedLocalOperator_three_one
     change 0 = (if σ.1 = τ.1 then 1 else 0) * B _ _
     rw [if_neg (fun hs ↦ h hs.symm), zero_mul]
 
-private theorem reindex_embedLocalOperator_two_zero
-    (B : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
-    Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
-        (_root_.finTwoArrowEquiv (Fin e))
-        (embedLocalOperator (d := e) 2 2 (by decide) (0 : Fin 2) B) =
-      Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
-        (_root_.finTwoArrowEquiv (Fin e)) B := by
-  ext σ τ
-  have hAgree : AgreesOutsideWindow (d := e) 2 (by decide) (0 : Fin 2)
-      ((_root_.finTwoArrowEquiv (Fin e)).symm σ)
-      ((_root_.finTwoArrowEquiv (Fin e)).symm τ) := by
-    funext i
-    fin_cases i <;>
-      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow,
-        _root_.finTwoArrowEquiv]
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    embedLocalOperator_apply]
-  rw [if_pos hAgree]
-  simp only [Fin.isValue, finTwoArrowEquiv_symm_apply]
-  congr 1 <;> funext j <;> fin_cases j <;> rfl
-
-private theorem reindex_embedLocalOperator_two_one
-    (B : Matrix (Fin 2 → Fin e) (Fin 2 → Fin e) ℂ) :
-    Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
-        (_root_.finTwoArrowEquiv (Fin e))
-        (embedLocalOperator (d := e) 2 2 (by decide) (1 : Fin 2) B) =
-      swapPairMatrix
-        (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
-          (_root_.finTwoArrowEquiv (Fin e)) B) := by
-  ext σ τ
-  have hAgree : AgreesOutsideWindow (d := e) 2 (by decide) (1 : Fin 2)
-      ((_root_.finTwoArrowEquiv (Fin e)).symm σ)
-      ((_root_.finTwoArrowEquiv (Fin e)).symm τ) := by
-    funext i
-    fin_cases i <;>
-      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow,
-        _root_.finTwoArrowEquiv]
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    embedLocalOperator_apply]
-  rw [if_pos hAgree]
-  simp only [Fin.isValue, finTwoArrowEquiv_symm_apply]
-  congr 1 <;> funext j <;> fin_cases j <;> rfl
-
 /-- On a two-site periodic chain, isometric conjugation carries the product
 of the two oppositely oriented restricted bonds to the product of their
 ambient lifts.
@@ -499,13 +457,16 @@ theorem singleKrausMap_crossedTwoSiteBondProduct
       (_root_.finTwoArrowEquiv (Fin e)) C)
   have hswap' :
       singleKrausMap (V ⊗ₖ V)
-          (swapPairMatrix (Matrix.reindex
-            (_root_.finTwoArrowEquiv (Fin e))
-            (_root_.finTwoArrowEquiv (Fin e)) C)) =
-        swapPairMatrix (singleKrausMap (V ⊗ₖ V)
-          (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
-            (_root_.finTwoArrowEquiv (Fin e)) C)) := by
-    simpa only [Matrix.conjTranspose_kronecker,
+          (Matrix.reindex (Equiv.prodComm (Fin e) (Fin e))
+            (Equiv.prodComm (Fin e) (Fin e))
+            (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+              (_root_.finTwoArrowEquiv (Fin e)) C)) =
+        Matrix.reindex (Equiv.prodComm (Fin d) (Fin d))
+          (Equiv.prodComm (Fin d) (Fin d))
+          (singleKrausMap (V ⊗ₖ V)
+            (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
+              (_root_.finTwoArrowEquiv (Fin e)) C)) := by
+    simpa only [swapPairMatrix, Matrix.conjTranspose_kronecker,
       Matrix.conjTranspose_conjTranspose] using hswap.symm
   rw [hswap']
 

--- a/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.MPDO.EmbedLocalOperatorTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorBondTransport
 
 /-!
@@ -233,17 +234,8 @@ theorem reindex_embedLocalOperator_two_zero
     Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
         (embedLocalOperator (d := d) 2 2 (by decide) (0 : Fin 2) F.physicalBond) =
       F.physicalPairBond := by
-  ext σ τ
-  have hAgree : AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 2)
-      ((finTwoArrowEquiv (Fin d)).symm σ)
-      ((finTwoArrowEquiv (Fin d)).symm τ) := by
-    funext i
-    fin_cases i <;>
-      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, finTwoArrowEquiv]
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    embedLocalOperator_apply]
-  rw [if_pos hAgree]
-  simp [physicalBond, MPSTensor.extractWindow, finTwoArrowEquiv]
+  rw [MPOTensor.reindex_embedLocalOperator_two_zero]
+  rfl
 
 /-- On the two-site periodic chain, the translate beginning at site one is
 the pair matrix with its two tensor factors exchanged.
@@ -255,18 +247,7 @@ theorem reindex_embedLocalOperator_two_one
     Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
         (embedLocalOperator (d := d) 2 2 (by decide) (1 : Fin 2) F.physicalBond) =
       swapPairMatrix F.physicalPairBond := by
-  ext σ τ
-  have hAgree : AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 2)
-      ((finTwoArrowEquiv (Fin d)).symm σ)
-      ((finTwoArrowEquiv (Fin d)).symm τ) := by
-    funext i
-    fin_cases i <;>
-      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, finTwoArrowEquiv]
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    embedLocalOperator_apply]
-  rw [if_pos hAgree]
-  simp [swapPairMatrix, physicalBond, MPSTensor.extractWindow,
-    finTwoArrowEquiv]
+  rw [MPOTensor.reindex_embedLocalOperator_two_one]
   rfl
 
 /-- The two oppositely ordered translates of the physical bond commute on the

--- a/blueprint/src/chapter/ch21_mpdo_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp.tex
@@ -14,7 +14,8 @@ renormalization condition and then records its comparison with the pure-state
 formalism.  It next passes to zero correlation length, purification fixed
 points, mutual information, and saturation of the area law. The source
 definitions of simple tensors and Gibbs states of nearest-neighbor commuting
-Hamiltonians precede the simple local and commuting structures. The
+Hamiltonians, together with the cyclic coordinates used for local embeddings,
+precede the simple local and commuting structures. The
 boundary-theory interlude of the source is outside the present MPO development.
 The general case and its algebraic characterization continue in
 Chapter~\ref{ch:mpdo_rfp_algebraic}.
@@ -24,6 +25,7 @@ Chapter~\ref{ch:mpdo_rfp_algebraic}.
 \input{chapter/ch21_mpdo_rfp_foundations}
 \input{chapter/ch21_mpdo_rfp_area_law}
 \input{chapter/ch21_mpdo_rfp_simple_definition}
+\input{chapter/ch21_mpdo_rfp_local_embedding_coordinates}
 \input{chapter/ch21_mpdo_rfp_gsnnch_definitions}
 \input{chapter/ch21_mpdo_rfp_blocked_rfp}
 \input{chapter/ch21_mpdo_rfp_simple_local_structure}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -1172,6 +1172,7 @@ firstSiteMatrix_mul_reducedBlockState}
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{thm:mpdo_cyclic_local_embedding_reindex}
     In the coordinates given by the window-plus-complement splitting of the
     chain, the embedded operator decomposes as
     \begin{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_local_embedding_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_local_embedding_coordinates.tex
@@ -1,0 +1,47 @@
+\section{Cyclic local-embedding coordinates}
+
+\begin{definition}[Cyclic window-complement coordinates]
+    \label{def:mpdo_cyclic_window_complement_coordinates}
+    \lean{MPOTensor.windowComplementEquiv}
+    \leanok
+    A periodic configuration is identified with the ordered pair consisting of
+    its restriction to the cyclic window $W_i^L$ and its restriction to the
+    complementary cyclic interval.
+\end{definition}
+
+\begin{theorem}[Local embeddings in window-complement coordinates]
+    \label{thm:mpdo_cyclic_local_embedding_reindex}
+    \lean{MPOTensor.reindex_embedLocalOperator_windowComplement}
+    \leanok
+    \uses{def:mpdo_cyclic_window_complement_coordinates}
+    In cyclic window-complement coordinates, every local embedding has the form
+    $E_i^L(B)=B\otimes\Id_{\mathrm{comp}}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_cyclic_window_complement_coordinates}
+    The matrix entry between $(x,u)$ and $(y,v)$ vanishes unless the
+    complementary configurations agree, $u=v$. In that case it equals
+    $B_{x,y}$, which is the corresponding entry of
+    $B\otimes\Id_{\mathrm{comp}}$.
+\end{proof}
+
+\begin{theorem}[Two-site local embeddings in pair coordinates]
+    \label{thm:mpdo_generic_two_site_translation_identities}
+    \lean{MPOTensor.reindex_embedLocalOperator_two_zero,
+        MPOTensor.reindex_embedLocalOperator_two_one}
+    \leanok
+    Under the canonical identification of two-site configurations with ordered
+    pairs, embedding an arbitrary two-site operator $B$ beginning at site zero
+    gives $B$, while embedding it beginning at site one gives
+    $SBS^{-1}$, where $S(x\otimes y)=y\otimes x$ exchanges the two factors.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The cyclic windows beginning at sites zero and one read the physical sites
+    in the orders $(0,1)$ and $(1,0)$, respectively. Reindexing by ordered pairs
+    therefore preserves $B$ in the first case and conjugates it by $S$ in the
+    second.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_commuting_physical_bonds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_commuting_physical_bonds.tex
@@ -120,6 +120,29 @@
     {Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Two-site translation identities]
+    \label{thm:mpdo_physical_two_site_translation_identities}
+    \lean{MPOTensor.PhysicalSectorFactorization.reindex_embedLocalOperator_two_zero,
+        MPOTensor.PhysicalSectorFactorization.reindex_embedLocalOperator_two_one}
+    \leanok
+    \uses{def:mpdo_global_sector_closure_coordinates,
+        def:mpdo_physical_two_site_bond}
+    Under the canonical identification of two-site configurations with ordered
+    pairs, the translates beginning at sites zero and one are respectively
+    $B_{01}=B_{\mathrm{physical}}$ and
+    $B_{10}=S B_{\mathrm{physical}}S^{-1}$, where
+    $S(x\otimes y)=y\otimes x$ exchanges the two physical factors.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_global_sector_closure_coordinates,
+        def:mpdo_physical_two_site_bond}
+    For the translate beginning at zero, extracting the cyclic window preserves
+    the order $(0,1)$. For the translate beginning at one, extraction gives the
+    order $(1,0)$, which conjugates the pair matrix by $S$.
+\end{proof}
+
 \begin{theorem}[Positivity of the physical two-site bond]
     \label{thm:mpdo_physical_two_site_bond_pos}
     \lean{MPOTensor.PhysicalSectorFactorization.physicalPairBond_pos,
@@ -265,6 +288,35 @@ $\eta_{k,l}^{(12)}\eta_{l,h}^{(23)}
     second configuration.
 \end{proof}
 
+\begin{definition}[Cyclic window-complement coordinates]
+    \label{def:mpdo_cyclic_window_complement_coordinates}
+    \lean{MPOTensor.windowComplementEquiv}
+    \leanok
+    A periodic configuration is identified with the ordered pair consisting of
+    its restriction to the cyclic window $W_i^L$ and its restriction to the
+    complementary cyclic interval.
+\end{definition}
+
+\begin{theorem}[Local embeddings in window-complement coordinates]
+    \label{thm:mpdo_cyclic_local_embedding_reindex}
+    \lean{MPOTensor.reindex_embedLocalOperator_windowComplement}
+    \leanok
+    \uses{def:mpdo_cyclic_window_complement_coordinates,
+        thm:mpdo_agreement_outside_cyclic_window}
+    In cyclic window-complement coordinates, every local embedding has the form
+    $E_i^L(B)=B\otimes\Id_{\mathrm{comp}}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:mpdo_cyclic_window_complement_coordinates,
+        thm:mpdo_agreement_outside_cyclic_window}
+    The matrix entry between $(x,u)$ and $(y,v)$ vanishes unless the
+    complementary configurations agree, $u=v$. In that case it equals
+    $B_{x,y}$, which is the corresponding entry of
+    $B\otimes\Id_{\mathrm{comp}}$.
+\end{proof}
+
 \begin{theorem}[Multiplicativity of cyclic local embeddings]
     \label{thm:mpdo_cyclic_local_embedding_mul}
     \lean{MPOTensor.embedLocalOperator_mul}
@@ -275,6 +327,7 @@ $\eta_{k,l}^{(12)}\eta_{l,h}^{(23)}
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpdo_cyclic_local_embedding_reindex}
     Identify a periodic configuration with its restriction to $W_i^L$ and
     its restriction to the cyclic complement. In these coordinates,
     $E_i^L(B)=B\otimes\Id$, so the assertion is the mixed-product identity.
@@ -349,6 +402,7 @@ $\eta_{k,l}^{(12)}\eta_{l,h}^{(23)}
 
 \begin{proof}
     \leanok
+    \uses{thm:mpdo_physical_two_site_translation_identities}
     Fix sectors $(k,h)$ and regroup the two physical sites as
     $(L_k\otimes R_h)\otimes(R_k\otimes L_h)$.
     The translate in the order $(0,1)$ is

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_commuting_physical_bonds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_commuting_physical_bonds.tex
@@ -125,8 +125,7 @@
     \lean{MPOTensor.PhysicalSectorFactorization.reindex_embedLocalOperator_two_zero,
         MPOTensor.PhysicalSectorFactorization.reindex_embedLocalOperator_two_one}
     \leanok
-    \uses{def:mpdo_global_sector_closure_coordinates,
-        def:mpdo_physical_two_site_bond}
+    \uses{def:mpdo_physical_two_site_bond}
     Under the canonical identification of two-site configurations with ordered
     pairs, the translates beginning at sites zero and one are respectively
     $B_{01}=B_{\mathrm{physical}}$ and
@@ -136,11 +135,12 @@
 
 \begin{proof}
     \leanok
-    \uses{def:mpdo_global_sector_closure_coordinates,
-        def:mpdo_physical_two_site_bond}
-    For the translate beginning at zero, extracting the cyclic window preserves
-    the order $(0,1)$. For the translate beginning at one, extraction gives the
-    order $(1,0)$, which conjugates the pair matrix by $S$.
+    \uses{def:mpdo_physical_two_site_bond,
+        thm:mpdo_generic_two_site_translation_identities}
+    Apply Theorem~\ref{thm:mpdo_generic_two_site_translation_identities} to
+    $B_{\mathrm{physical}}$. Its pair-coordinate matrix is the operator in
+    Definition~\ref{def:mpdo_physical_two_site_bond}, so the two generic
+    identities give the stated formulas.
 \end{proof}
 
 \begin{theorem}[Positivity of the physical two-site bond]
@@ -286,35 +286,6 @@ $\eta_{k,l}^{(12)}\eta_{l,h}^{(23)}
     Conversely, if the two configurations agree on the complement, replacing
     the window of the first by the window of the second reconstructs the
     second configuration.
-\end{proof}
-
-\begin{definition}[Cyclic window-complement coordinates]
-    \label{def:mpdo_cyclic_window_complement_coordinates}
-    \lean{MPOTensor.windowComplementEquiv}
-    \leanok
-    A periodic configuration is identified with the ordered pair consisting of
-    its restriction to the cyclic window $W_i^L$ and its restriction to the
-    complementary cyclic interval.
-\end{definition}
-
-\begin{theorem}[Local embeddings in window-complement coordinates]
-    \label{thm:mpdo_cyclic_local_embedding_reindex}
-    \lean{MPOTensor.reindex_embedLocalOperator_windowComplement}
-    \leanok
-    \uses{def:mpdo_cyclic_window_complement_coordinates,
-        thm:mpdo_agreement_outside_cyclic_window}
-    In cyclic window-complement coordinates, every local embedding has the form
-    $E_i^L(B)=B\otimes\Id_{\mathrm{comp}}$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{def:mpdo_cyclic_window_complement_coordinates,
-        thm:mpdo_agreement_outside_cyclic_window}
-    The matrix entry between $(x,u)$ and $(y,v)$ vanishes unless the
-    complementary configurations agree, $u=v$. In that case it equals
-    $B_{x,y}$, which is the corresponding entry of
-    $B\otimes\Id_{\mathrm{comp}}$.
 \end{proof}
 
 \begin{theorem}[Multiplicativity of cyclic local embeddings]

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,24 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### two-site cyclic local-embedding reindexing — promoted
+- **Pattern:** reindex a cyclic two-site embedding by the equivalence between
+  two-site configurations and ordered pairs, prove agreement outside the full
+  window by finite index cases, and identify the extracted coordinates.
+- **Seen:** the sector-specific public proof in
+  `TNLean/MPS/MPDO/PhysicalSectorBondTwoSite.lean` and the private generic proof
+  in `TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean` before promotion
+  (2026-08-12).
+- **Abstraction:** `MPOTensor.reindex_embedLocalOperator_two_zero` and
+  `MPOTensor.reindex_embedLocalOperator_two_one` in
+  `TNLean/MPS/MPDO/EmbedLocalOperatorTwoSite.lean`.
+- **Notes:** the promoted theorems apply to arbitrary two-site matrices. The
+  site-one conclusion states the factor exchange directly with
+  `Matrix.reindex (Equiv.prodComm ...)`. The two
+  `PhysicalSectorFactorization.reindex_embedLocalOperator_two_*` declarations
+  remain public sector-specific specializations, while the isometric
+  calculation uses the generic identities directly.
+
 ### Hayashi state evaluation in middle-sector coordinates — promoted
 - **Pattern:** evaluate `EtaStructure.h_state` at decomposed middle-site coordinates,
   identify both inverse reindexings, apply the lifted-conjugation entry formula, and


### PR DESCRIPTION
## What changed

- added focused generic owner `EmbedLocalOperatorTwoSite.lean` for arbitrary two-site local-operator reindex formulas;
- retained both public physical-sector translation theorems as byte-stable specializations;
- removed private duplicate proofs from isometric adjacent-bond transport and added direct imports from both consumers;
- updated the generated MPDO aggregator and tactic-pattern ledger;
- added Blueprint nodes for cyclic window-complement reindexing and specialized two-site physical translations, with direct dependency edges.

## Validation

- exact-head simplification review: approved at `b06a313f040eb5367994796c52fd21abe0667bdb`;
- full warm `lake build`: passed, 10,079 jobs;
- protected theorem headers byte-identical;
- import graph acyclic; generated aggregators current, 52 files covering 1,368 modules;
- Blueprint sync and declaration checks passed;
- bibliography-aware LuaLaTeX passed with zero undefined citations or references;
- proof-integrity and diff checks passed; worktree clean.

Closes #6176.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor that shares existing lemmas without changing public theorem statements or runtime behavior.
> 
> **Overview**
> **Deduplicates** the two-site cyclic embedding reindex proofs into a shared owner `EmbedLocalOperatorTwoSite.lean`.
> 
> The new generic theorems `reindex_embedLocalOperator_two_zero` / `reindex_embedLocalOperator_two_one` apply to arbitrary two-site matrices: site-zero preserves pair order, site-one exchanges factors via `Equiv.prodComm`.
> 
> `PhysicalSectorBondTwoSite` keeps its public sector-specific theorems as thin specializations. `IsometricAdjacentBondTransport` drops its private copies and uses the shared identities directly.
> 
> Blueprint adds a cyclic local-embedding coordinates section and wires dependency edges for the generic and physical-sector translation identities; the tactic-pattern ledger marks the pattern as promoted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0beb91c162c3053f8090afd6f8b0c7b1fb1a5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->