### PR TITLE
refactor(mpdo): import canonical cyclic-active owner

### DIFF
--- a/TNLean/MPS/MPDO/CyclicActiveCutCoordinates.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveCutCoordinates.lean
@@ -3,8 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Analysis.HayashiMarkovStructure
-import TNLean.MPS.MPDO.CyclicActiveMarkovNormalization
+import TNLean.MPS.MPDO.CyclicActiveFourthRegion
 
 /-!
 # Coordinates for cyclic-active one-site cuts


### PR DESCRIPTION
## What changed

- replaced two redundant imports in `CyclicActiveCutCoordinates.lean` with the single canonical owner `CyclicActiveFourthRegion`;
- retained the compatibility module and MPDO aggregator unchanged;
- preserved every declaration, theorem statement, and proof byte-for-byte.

## Validation

- exact-head import review: approved at `4827fcb68808466a0c8627d42e8e32e442095fac`;
- full warm `lake build`: passed, 10,078 jobs;
- cyclic-active downstream chain built;
- import graph acyclic and compatibility wrapper absent from the changed file's cone;
- proof-integrity and diff checks passed; worktree clean.

Closes #6177.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with no logic or proof changes; build and import-graph checks already passed.
> 
> **Overview**
> **Simplifies imports** in `CyclicActiveCutCoordinates.lean` by replacing `HayashiMarkovStructure` and `CyclicActiveMarkovNormalization` with the single canonical owner `CyclicActiveFourthRegion`.
> 
> No declarations, theorems, or proofs change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4827fcb68808466a0c8627d42e8e32e442095fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->