### PR TITLE
refactor(tenkz): read tombstones from one record

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -94,16 +94,15 @@
         % Semantic boundary signature: (virtual-west=0 | virtual-east=0 |
         % physical-up=L+1 | physical-down=0).  This finite schematic emits
         % (virtual-west=0 | virtual-east=0 | physical-up=3 | physical-down=0).
-        % The traced sides draw the periodic return; the site-count brace does
-        % not draw in the kernel yet (#5482), so its mathematics stays as the
-        % south label under the return.
+        % The traced sides draw the periodic return, and the bracket beneath
+        % it counts the sites the way the source braces them.
         \tenkzkernel
         \begin{tenkz}[rows={wire}, cols=5, boundary=periodic]
             \tn[skin=ring]{X'} &
             \tn[label pos=s, ports={90:physical:$\sigma_1$}]{A} &
             \tn[label pos=s, ports={90:physical}]{A} & \tn[skin=dots]{} &
             \tn[label pos=s, ports={90:physical:$\sigma_{L+1}$}]{A}
-            \tnmark[form=label, label pos=s]{s outside}{$L+1\text{ sites}$}
+            \tnmark[form=bracket]{(1,2) .. (1,5)}{$L+1\text{ sites}$}
         \end{tenkz}
     \end{center}
     \begin{enumerate}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -69,7 +69,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch12_symmetry_virtual_and_cohomology.tex` | L181, 196, 330, 459, 473 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex` | L55 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex` | L276 `tenkz` → `P-grid` | — | — |
-| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
+| `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L100 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1595, 1637 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -177,16 +177,23 @@ spelling the parser refuses by name to carry a row stating the same
 migration, and every row for a word struck from a live alphabet to name a
 spelling the parser refuses and the alphabet no longer holds.
 
-Three shapes of row, by what is left of the spelling.  `key=value` is a word
+Four shapes of row, by what is left of the spelling.  `key=value` is a word
 struck from a live key's alphabet, and the parser refuses it through a branch
-of that key.  A bare `key` is a key that no longer exists and a spelling
-beginning with a backslash is a command that no longer exists, taking the
-scope `command`; neither leaves the parser anything to branch on, so the
-unknown-key error or an undefined control sequence answers it, the check is
-that the registry really has dropped the spelling, and the lint is what reads
-the row.  Write a multi-word key with `~` as the rest of the registry does
-and wrap a long migration; both are read out before any row is compared or
-matched, so the spelling a document writes is the spelling that is caught.
+of that key.  The other three no longer exist at all, so the parser has
+nothing to branch on and the unknown-key error or an undefined spelling
+answers them; the check is that the registry really has dropped the spelling,
+and the lint is what reads the row.  A bare `key` is a retired key.  A
+spelling beginning with a backslash is a retired command, takes the scope
+`command`, and is matched from its own backslash.  A row under the scope
+`environment` is a retired environment, such as the dialects LANGUAGE-1.0
+section 10 lists, and is matched where a document names one, in the argument
+of `\begin` or `\end`.
+
+Write a multi-word key with `~` as the rest of the registry does and wrap a
+long migration; both are read out before any row is compared or matched, so
+the spelling a document writes is the spelling that is caught.  A row that
+states no spelling is a finding, and one spelling is buried once across the
+whole ledger, since the lint reads flat source where no scope is visible.
 
 The gate first compares the pinned meters with the base revision.  M1 total or
 kernel growth requires an `Extension-gate: #NNNN` citation, or a

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -169,6 +169,17 @@ spellings and earn continued use.  The other status words record lifecycle
 debt: `alias(...; sunset=...)` reads old sources until its stated rewrite, and
 `escape` names raw geometry whose uses count in meter M3.
 
+A retired spelling leaves a tombstone row in the same registry, giving its
+scope, the dead spelling, and the migration.  Retiring a word is therefore
+one edit: the source lint builds its rejection from those rows and reports
+the migration with the finding, and `tenkz_language.py check` requires every
+spelling the parser refuses by name to carry a row stating the same
+migration, and every row for a word struck from a live alphabet to name a
+spelling the parser refuses and the alphabet no longer holds.  A row whose
+spelling has no `=` is a key that no longer exists; nothing survives for the
+parser to branch on, so the unknown-key error answers it and only the lint
+reads the row.
+
 The gate first compares the pinned meters with the base revision.  M1 total or
 kernel growth requires an `Extension-gate: #NNNN` citation, or a
 `Census-correction: #NNNN` citation while parser identities are unchanged;

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -175,10 +175,18 @@ one edit: the source lint builds its rejection from those rows and reports
 the migration with the finding, and `tenkz_language.py check` requires every
 spelling the parser refuses by name to carry a row stating the same
 migration, and every row for a word struck from a live alphabet to name a
-spelling the parser refuses and the alphabet no longer holds.  A row whose
-spelling has no `=` is a key that no longer exists; nothing survives for the
-parser to branch on, so the unknown-key error answers it and only the lint
-reads the row.
+spelling the parser refuses and the alphabet no longer holds.
+
+Three shapes of row, by what is left of the spelling.  `key=value` is a word
+struck from a live key's alphabet, and the parser refuses it through a branch
+of that key.  A bare `key` is a key that no longer exists and a spelling
+beginning with a backslash is a command that no longer exists, taking the
+scope `command`; neither leaves the parser anything to branch on, so the
+unknown-key error or an undefined control sequence answers it, the check is
+that the registry really has dropped the spelling, and the lint is what reads
+the row.  Write a multi-word key with `~` as the rest of the registry does
+and wrap a long migration; both are read out before any row is compared or
+matched, so the spelling a document writes is the spelling that is caught.
 
 The gate first compares the pinned meters with the base revision.  M1 total or
 kernel growth requires an `Extension-gate: #NNNN` citation, or a

--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -958,7 +958,7 @@ policy for the shared leg; write the ports for the lone one.
 | `sandwich` | `rows={ket,op,bra}` |
 | `physical=up\|down\|updown\|none` | expander: declares each frame-cell atom's outward face physical, one port per face slot — a `wide=k` atom answers with `k` legs, one per spanned cell, exactly as the authored `90@1..@k` port list; geometric overlay atoms are excluded; in a plane this is the independent page-transverse axis, not a numeric in-plane face |
 | `boundary=open\|none` | `west=<w>, east=<w>` |
-| `boundary=periodic`, `periodic` | `west=trace, east=trace` |
+| `boundary=periodic` | `west=trace, east=trace` |
 | `west={cup=$m$}` (any side) | side `cup` + `\tn[skin=ring, at=on <cup wire> 0.5]{m}` |
 | `west={tail=$m$}` (any side) | side `open` + boundary-skin atom on the stub wire |
 | `west label=$m$` etc., `bond label=` | `\tnmark[form=label]{<generated wire>}{m}` |
@@ -1061,6 +1061,7 @@ is not the fixed two-axis atom contract of §7.
 | `(r,c)-(r,c)` cell ranges | `(r,c) .. (r,c)` — a hyphen cannot be told from a generated name |
 | `\tnpic` as a command | the sugar row `\tnpic` over the picture environment (§9) |
 | aliases `chain axis`, `legs at`, `rows`→span, `boundary legs`, `label at` | kernel spellings above |
+| `periodic` as a picture flag | `boundary=periodic`, the value spelling the alphabet keeps |
 
 ## 11. The shrink gate
 

--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -364,24 +364,73 @@ def _kernel_tombstones() -> dict[tuple[str, str], str]:
     )
 
 
+def tombstone_rows(entries: list[Entry]) -> list[tuple[str, str, str]]:
+    """The ledger's rows as scope, spelling, and migration a reader is shown.
+
+    The registry writes a multi-word key the parser's way, with `~` for the
+    space, and wraps a long migration to keep its line short.  Neither is
+    visible in a document, so both are read out here rather than at each of
+    the three places that consume a row: the check, the lint, and a reader.
+    """
+    return [
+        (entry.fields[0], _sentence(entry.fields[1]), _sentence(entry.fields[2]))
+        for entry in entries
+        if entry.kind == "tombstone"
+    ]
+
+
 def tombstone_errors(
-    rows: list[tuple[str, ...]],
+    rows: list[tuple[str, str, str]],
     key_vocabulary: dict[tuple[str, str], tuple[str, str]],
+    commands: set[str],
     kernel: dict[tuple[str, str], str],
 ) -> list[str]:
     """Hold the tombstone ledger, the live vocabulary, and the parser to one list.
 
-    A `key=value` row is a word struck from a live alphabet: the key must
-    still exist, the word must not, and the parser must refuse the spelling
-    with the migration the ledger states.  A bare row is a key that no longer
-    exists, which the parser cannot branch on, so only the lint reads it and
-    the check is that the key really is gone.
+    A row spelled `key=value` is a word struck from a live alphabet: the key
+    must still exist, the word must not, and the parser must refuse the
+    spelling with the migration the ledger states.  A bare row is a key that
+    no longer exists and a row spelled with a leading backslash is a command
+    that no longer exists; neither leaves anything for the parser to branch
+    on, so the check is that the spelling really is gone and only the lint
+    reads the row.
+
+    Rows arrive from `tombstone_rows`, which has already read `~` and any
+    wrapping out of them, so every comparison here is against the spelling
+    and the sentence a document and a reader actually carry.
     """
     errors: list[str] = []
     recorded: dict[tuple[str, str], str] = {}
+    scopes = {scope for scope, _name in key_vocabulary}
+    seen: set[tuple[str, str]] = set()
     for scope, spelling, migration in rows:
-        if not migration.strip():
+        # Two rows may differ as written and mean one spelling, which the
+        # rest of this function would silently collapse to whichever came
+        # last.
+        if (scope, spelling) in seen:
+            errors.append(f"tombstone {scope}:{spelling} is recorded twice")
+        seen.add((scope, spelling))
+        if not migration:
             errors.append(f"tombstone {scope}:{spelling} names no migration")
+        if spelling.startswith("\\"):
+            # A dead command has no key scope to sit in, so it says so; the
+            # spelling would otherwise be read as a key and never checked.
+            if scope != "command":
+                errors.append(
+                    f"tombstone {scope}:{spelling} is a command and takes "
+                    "the scope 'command'"
+                )
+            elif spelling.removeprefix("\\") in commands:
+                errors.append(
+                    f"tombstone {scope}:{spelling} names a command the "
+                    "registry still carries"
+                )
+            continue
+        if scope not in scopes:
+            errors.append(
+                f"tombstone {scope}:{spelling} names no registered scope"
+            )
+            continue
         key, _separator, value = spelling.partition("=")
         key, value = key.strip(), value.strip()
         if not value:
@@ -597,7 +646,12 @@ def check(entries: list[Entry]) -> list[str]:
                 f"value alias {scope}:{spelling} {value_error}"
             )
     errors.extend(
-        tombstone_errors(by_kind["tombstone"], key_vocabulary, _kernel_tombstones())
+        tombstone_errors(
+            tombstone_rows(entries),
+            key_vocabulary,
+            {row[0] for row in by_kind["command"]},
+            _kernel_tombstones(),
+        )
     )
     if BASELINE.is_file():
         baseline = json.loads(BASELINE.read_text(encoding="utf-8"))

--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -211,6 +211,12 @@ def _group(text: str, start: int) -> tuple[str, int]:
     raise ValueError(f"unclosed registry group at offset {start}")
 
 
+def _commented_out(text: str, position: int) -> bool:
+    """Whether a comment mark earlier on the line already ended it for TeX."""
+    line_start = text.rfind("\n", 0, position) + 1
+    return re.search(r"(?<!\\)%", text[line_start:position]) is not None
+
+
 def load_registry() -> list[Entry]:
     text = REGISTRY.read_text(encoding="utf-8")
     pattern = re.compile(
@@ -219,6 +225,11 @@ def load_registry() -> list[Entry]:
     )
     entries: list[Entry] = []
     for match in pattern.finditer(text):
+        # A record the file comments out does not run, so the tools may not
+        # read it either; otherwise the registry means one thing to TeX and
+        # another to everything that checks it.
+        if _commented_out(text, match.start()):
+            continue
         kind = match.group(1)
         pos = match.end()
         fields: list[str] = []
@@ -341,6 +352,28 @@ def _sentence(text: str) -> str:
     return " ".join(text.replace("~", " ").split())
 
 
+def tombstone_shape(scope: str, spelling: str) -> str:
+    """Which kind of dead spelling a row states.
+
+    `command` and `environment` are named by the scope they take, since a
+    retired environment's spelling is an ordinary word.  `value` is a word
+    struck from a live key's alphabet and `key` a key that no longer exists.
+    `malformed` is a row that states no spelling at all: an empty one, or a
+    key with an equals sign and nothing after it, which would otherwise pass
+    as a bare key and ban a live word.
+    """
+    if not spelling:
+        return "malformed"
+    if spelling.startswith("\\"):
+        return "command"
+    if scope == "environment":
+        return "environment"
+    key, separator, value = spelling.partition("=")
+    if not key.strip() or (separator and not value.strip()):
+        return "malformed"
+    return "value" if separator else "key"
+
+
 def _kernel_tombstones_from_texts(texts: Iterable[str]) -> dict[tuple[str, str], str]:
     """Collect the spellings the kernel parser refuses by name and their migrations."""
     tombstones: dict[tuple[str, str], str] = {}
@@ -382,7 +415,7 @@ def tombstone_rows(entries: list[Entry]) -> list[tuple[str, str, str]]:
 def tombstone_errors(
     rows: list[tuple[str, str, str]],
     key_vocabulary: dict[tuple[str, str], tuple[str, str]],
-    commands: set[str],
+    surface: dict[str, set[str]],
     kernel: dict[tuple[str, str], str],
 ) -> list[str]:
     """Hold the tombstone ledger, the live vocabulary, and the parser to one list.
@@ -390,10 +423,10 @@ def tombstone_errors(
     A row spelled `key=value` is a word struck from a live alphabet: the key
     must still exist, the word must not, and the parser must refuse the
     spelling with the migration the ledger states.  A bare row is a key that
-    no longer exists and a row spelled with a leading backslash is a command
-    that no longer exists; neither leaves anything for the parser to branch
-    on, so the check is that the spelling really is gone and only the lint
-    reads the row.
+    no longer exists, and a command or an environment row is one of those,
+    checked against `surface`; none of the three leaves anything for the
+    parser to branch on, so the check is that the spelling really is gone and
+    only the lint reads the row.
 
     Rows arrive from `tombstone_rows`, which has already read `~` and any
     wrapping out of them, so every comparison here is against the spelling
@@ -402,27 +435,35 @@ def tombstone_errors(
     errors: list[str] = []
     recorded: dict[tuple[str, str], str] = {}
     scopes = {scope for scope, _name in key_vocabulary}
-    seen: set[tuple[str, str]] = set()
+    # The lint matches a spelling in flat source, where no scope is visible,
+    # so one spelling buried twice would be reported with whichever migration
+    # sorted first.  A ledger the lint can read is one spelling per row.
+    seen: set[str] = set()
     for scope, spelling, migration in rows:
-        # Two rows may differ as written and mean one spelling, which the
-        # rest of this function would silently collapse to whichever came
-        # last.
-        if (scope, spelling) in seen:
+        if spelling in seen:
             errors.append(f"tombstone {scope}:{spelling} is recorded twice")
-        seen.add((scope, spelling))
+        seen.add(spelling)
         if not migration:
             errors.append(f"tombstone {scope}:{spelling} names no migration")
-        if spelling.startswith("\\"):
-            # A dead command has no key scope to sit in, so it says so; the
-            # spelling would otherwise be read as a key and never checked.
-            if scope != "command":
+        shape = tombstone_shape(scope, spelling)
+        if shape == "malformed":
+            errors.append(
+                f"tombstone {scope}:{spelling!r} states no spelling; a row is "
+                "a command, an environment, a key, or key=value"
+            )
+            continue
+        if shape in {"command", "environment"}:
+            # A dead command or environment has no key scope to sit in, so it
+            # says so; the spelling would otherwise be read as a key and the
+            # lint would look for it as a bare word.
+            if scope != shape:
                 errors.append(
-                    f"tombstone {scope}:{spelling} is a command and takes "
-                    "the scope 'command'"
+                    f"tombstone {scope}:{spelling} is a {shape} and takes "
+                    f"the scope '{shape}'"
                 )
-            elif spelling.removeprefix("\\") in commands:
+            elif spelling.removeprefix("\\") in surface.get(shape, set()):
                 errors.append(
-                    f"tombstone {scope}:{spelling} names a command the "
+                    f"tombstone {scope}:{spelling} names a {shape} the "
                     "registry still carries"
                 )
             continue
@@ -433,7 +474,7 @@ def tombstone_errors(
             continue
         key, _separator, value = spelling.partition("=")
         key, value = key.strip(), value.strip()
-        if not value:
+        if shape == "key":
             if (scope, key) in key_vocabulary:
                 errors.append(
                     f"tombstone {scope}:{spelling} names a key the registry "
@@ -649,7 +690,10 @@ def check(entries: list[Entry]) -> list[str]:
         tombstone_errors(
             tombstone_rows(entries),
             key_vocabulary,
-            {row[0] for row in by_kind["command"]},
+            {
+                "command": {row[0] for row in by_kind["command"]},
+                "environment": {row[0] for row in by_kind["environment"]},
+            },
             _kernel_tombstones(),
         )
     )

--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from tenkzlib.texcase import strip_comments
 
 ROOT = Path(__file__).resolve().parents[1]
 REGISTRY = ROOT / "tex/tenkz/tenkz-language-registry.tex"
@@ -211,25 +212,18 @@ def _group(text: str, start: int) -> tuple[str, int]:
     raise ValueError(f"unclosed registry group at offset {start}")
 
 
-def _commented_out(text: str, position: int) -> bool:
-    """Whether a comment mark earlier on the line already ended it for TeX."""
-    line_start = text.rfind("\n", 0, position) + 1
-    return re.search(r"(?<!\\)%", text[line_start:position]) is not None
-
-
 def load_registry() -> list[Entry]:
-    text = REGISTRY.read_text(encoding="utf-8")
+    # A record the file comments out does not run, so the tools may not read
+    # it either; otherwise the registry means one thing to TeX and another to
+    # everything that checks it.  The shared reader blanks a comment in place,
+    # so every offset below is the offset in the file.
+    text = strip_comments(REGISTRY.read_text(encoding="utf-8"))
     pattern = re.compile(
         r"\\__tenkz_language_registry_"
         r"(environment|command|key|alias|example|prelude|tombstone):[n]+"
     )
     entries: list[Entry] = []
     for match in pattern.finditer(text):
-        # A record the file comments out does not run, so the tools may not
-        # read it either; otherwise the registry means one thing to TeX and
-        # another to everything that checks it.
-        if _commented_out(text, match.start()):
-            continue
         kind = match.group(1)
         pos = match.end()
         fields: list[str] = []
@@ -434,6 +428,8 @@ def tombstone_errors(
     """
     errors: list[str] = []
     recorded: dict[tuple[str, str], str] = {}
+    # Rows already reported for a word the alphabet still holds.
+    stale: set[tuple[str, str]] = set()
     scopes = {scope for scope, _name in key_vocabulary}
     # The lint matches a spelling in flat source, where no scope is visible,
     # so one spelling buried twice would be reported with whichever migration
@@ -492,6 +488,12 @@ def tombstone_errors(
             errors.append(
                 f"tombstone {scope}:{spelling} is still a word of {record[1]}"
             )
+            # A row landing ahead of its parser branch has one cause, and it
+            # is this one.  The row stays recorded so the parser's own list is
+            # still compared against it, but it is not reported a second time
+            # as a spelling the parser does not refuse, which is true and
+            # points at the wrong thing.
+            stale.add((scope, f"{key}={value}"))
         recorded[(scope, f"{key}={value}")] = migration
     unrecorded = sorted(
         f"{scope}:{spelling}" for scope, spelling in kernel.keys() - recorded.keys()
@@ -502,7 +504,8 @@ def tombstone_errors(
             + ", ".join(unrecorded)
         )
     unrefused = sorted(
-        f"{scope}:{spelling}" for scope, spelling in recorded.keys() - kernel.keys()
+        f"{scope}:{spelling}"
+        for scope, spelling in recorded.keys() - kernel.keys() - stale
     )
     if unrefused:
         errors.append(

--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -35,6 +35,7 @@ ARITIES = {
     "alias": 4,
     "example": 3,
     "prelude": 3,
+    "tombstone": 3,
 }
 
 BASELINE = ROOT / "tests/tenkz/census-baseline.json"
@@ -214,7 +215,7 @@ def load_registry() -> list[Entry]:
     text = REGISTRY.read_text(encoding="utf-8")
     pattern = re.compile(
         r"\\__tenkz_language_registry_"
-        r"(environment|command|key|alias|example|prelude):[n]+"
+        r"(environment|command|key|alias|example|prelude|tombstone):[n]+"
     )
     entries: list[Entry] = []
     for match in pattern.finditer(text):
@@ -327,6 +328,107 @@ def _kernel_leaf_keys_from_texts(texts) -> set[tuple[str, str]]:
     return leaves
 
 
+# A word struck from a live key's alphabet stays installed as a branch that
+# refuses the spelling and states the migration.  Reading those branches is
+# what lets the language check hold the registry's tombstone ledger and the
+# parser to one list; the lookahead skips the helper's own definition, whose
+# next token is a parameter rather than an argument group.
+_KERNEL_TOMBSTONE = re.compile(r"\\__tenkz_kernel_tombstone:nnnn\s*(?=\{)")
+
+
+def _sentence(text: str) -> str:
+    """Read an expl3 argument as the sentence a reader is shown."""
+    return " ".join(text.replace("~", " ").split())
+
+
+def _kernel_tombstones_from_texts(texts: Iterable[str]) -> dict[tuple[str, str], str]:
+    """Collect the spellings the kernel parser refuses by name and their migrations."""
+    tombstones: dict[tuple[str, str], str] = {}
+    for text in texts:
+        for match in _KERNEL_TOMBSTONE.finditer(text):
+            position = match.end()
+            fields: list[str] = []
+            for _ in range(4):
+                field, position = _group(text, position)
+                fields.append(field)
+            family, key, value, migration = (_sentence(field) for field in fields)
+            scope = family.removeprefix("tenkz-")
+            tombstones[(scope, f"{key}={value}")] = migration
+    return tombstones
+
+
+def _kernel_tombstones() -> dict[tuple[str, str], str]:
+    return _kernel_tombstones_from_texts(
+        path.read_text(encoding="utf-8")
+        for path in (ROOT / "tex/tenkz").glob("*.code.tex")
+    )
+
+
+def tombstone_errors(
+    rows: list[tuple[str, ...]],
+    key_vocabulary: dict[tuple[str, str], tuple[str, str]],
+    kernel: dict[tuple[str, str], str],
+) -> list[str]:
+    """Hold the tombstone ledger, the live vocabulary, and the parser to one list.
+
+    A `key=value` row is a word struck from a live alphabet: the key must
+    still exist, the word must not, and the parser must refuse the spelling
+    with the migration the ledger states.  A bare row is a key that no longer
+    exists, which the parser cannot branch on, so only the lint reads it and
+    the check is that the key really is gone.
+    """
+    errors: list[str] = []
+    recorded: dict[tuple[str, str], str] = {}
+    for scope, spelling, migration in rows:
+        if not migration.strip():
+            errors.append(f"tombstone {scope}:{spelling} names no migration")
+        key, _separator, value = spelling.partition("=")
+        key, value = key.strip(), value.strip()
+        if not value:
+            if (scope, key) in key_vocabulary:
+                errors.append(
+                    f"tombstone {scope}:{spelling} names a key the registry "
+                    "still carries"
+                )
+            continue
+        record = key_vocabulary.get((scope, key))
+        if record is None:
+            errors.append(
+                f"tombstone {scope}:{spelling} names no registered key"
+            )
+            continue
+        enum = re.fullmatch(r"enum\(([^)]*)\)", record[1])
+        if enum is not None and value in enum.group(1).split("|"):
+            errors.append(
+                f"tombstone {scope}:{spelling} is still a word of {record[1]}"
+            )
+        recorded[(scope, f"{key}={value}")] = migration
+    unrecorded = sorted(
+        f"{scope}:{spelling}" for scope, spelling in kernel.keys() - recorded.keys()
+    )
+    if unrecorded:
+        errors.append(
+            "the parser refuses spellings the tombstone ledger does not record: "
+            + ", ".join(unrecorded)
+        )
+    unrefused = sorted(
+        f"{scope}:{spelling}" for scope, spelling in recorded.keys() - kernel.keys()
+    )
+    if unrefused:
+        errors.append(
+            "the tombstone ledger records spellings the parser does not refuse: "
+            + ", ".join(unrefused)
+        )
+    for scope, spelling in sorted(recorded.keys() & kernel.keys()):
+        if recorded[(scope, spelling)] != kernel[(scope, spelling)]:
+            errors.append(
+                f"tombstone {scope}:{spelling} migrates to "
+                f"{recorded[(scope, spelling)]!r} in the ledger and "
+                f"{kernel[(scope, spelling)]!r} in the parser"
+            )
+    return errors
+
+
 def _parser_leaf_keys() -> set[tuple[str, str]]:
     """Collect public leaf-key spellings installed by the TeX parsers.
 
@@ -364,7 +466,9 @@ def check(entries: list[Entry]) -> list[str]:
     }
     for kind, rows in by_kind.items():
         names = [
-            f"{row[0]}:{row[1]}" if kind in {"key", "prelude"} else row[0]
+            f"{row[0]}:{row[1]}"
+            if kind in {"key", "prelude", "tombstone"}
+            else row[0]
             for row in rows
         ]
         duplicates = sorted(name for name in set(names) if names.count(name) > 1)
@@ -492,6 +596,9 @@ def check(entries: list[Entry]) -> list[str]:
             errors.append(
                 f"value alias {scope}:{spelling} {value_error}"
             )
+    errors.extend(
+        tombstone_errors(by_kind["tombstone"], key_vocabulary, _kernel_tombstones())
+    )
     if BASELINE.is_file():
         baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
         recorded = baseline["m1_census"]["value"]

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -24,8 +24,9 @@ Rules (findings exit 1 unless escaped):
            headers, preamble-free source, canonical spellings, public names,
            at most 88 characters per line, and at most 100 lines per case.
            The buried spellings come from the registry's tombstone rows and
-           are reported with the migration each row states, so a spelling is
-           retired in one place and refused everywhere.
+           are reported with the migration each row states, so retiring a
+           spelling needs no edit here.  These rules read case files alone:
+           a chapter's prose may write a dead word as an English word.
 
 Escape: a comment `% tenkz-lint: allow <rule> <reason>` on the finding's
 line or the line directly above suppresses that rule there (`allow all`
@@ -46,7 +47,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tenkz_audit import ENVIRONMENT_LANGS
-from tenkz_language import load_registry, parse_status
+from tenkz_language import Entry, load_registry, parse_status, tombstone_rows
 from tenkzlib.texcase import (
     TeXEnvironmentNestingError,
     match_group,
@@ -98,15 +99,21 @@ def registry_alias_patterns() -> list[re.Pattern[str]]:
     return patterns
 
 
-def registry_tombstone_patterns() -> list[tuple[re.Pattern[str], str]]:
-    """Source patterns and migrations for the spellings the registry buries.
+def tombstone_patterns(entries: list[Entry]) -> list[tuple[re.Pattern[str], str]]:
+    """Source patterns and migrations for the spellings a ledger buries.
 
     A `key=value` row is a word struck from a live alphabet, so the pattern is
-    that spelling.  A bare row is a key that no longer exists; where its word
+    that spelling.  A row spelled with a leading backslash is a command, whose
+    own backslash is where it starts: a word boundary before it would match
+    nothing, since neither the backslash nor the space before it is a word
+    character.  A bare row is a key that no longer exists; where its word
     survives as the value of a live enum, the pattern steps over that live
     spelling, which is where a reader of the dead one should be.
+
+    Every spelling arrives from `tombstone_rows` with the registry's `~`
+    already read as the space a document writes, so a multi-word key is
+    matched the way source spells it rather than the way the registry does.
     """
-    entries = load_registry()
     enum_owners: dict[str, set[str]] = {}
     for entry in entries:
         if entry.kind != "key":
@@ -115,22 +122,23 @@ def registry_tombstone_patterns() -> list[tuple[re.Pattern[str], str]]:
         if enum is None:
             continue
         for word in enum.group(1).split("|"):
-            enum_owners.setdefault(word, set()).add(entry.fields[1])
+            enum_owners.setdefault(word, set()).add(entry.fields[1].replace("~", " "))
     patterns: list[tuple[re.Pattern[str], str]] = []
-    for entry in sorted(
-        (entry for entry in entries if entry.kind == "tombstone"),
-        key=lambda entry: entry.fields[:2],
-    ):
-        _scope, spelling, migration = entry.fields
+    for _scope, spelling, migration in sorted(tombstone_rows(entries)):
         key, _separator, value = spelling.partition("=")
         key, value = key.strip(), value.strip()
-        if value:
+        if spelling.startswith("\\"):
+            expression = re.escape(spelling) + r"(?![A-Za-z])"
+        elif value:
             expression = (
                 re.escape(key).replace(r"\ ", r"\s+")
                 + r"\s*=\s*"
                 + re.escape(value).replace(r"\ ", r"\s*")
+                + r"(?![\w-])"
             )
         else:
+            # A lookbehind takes no variable width, so a live owner is stepped
+            # over as the source spells it with no space around the equals.
             expression = (
                 "".join(
                     f"(?<!{re.escape(owner)}=)"
@@ -142,6 +150,11 @@ def registry_tombstone_patterns() -> list[tuple[re.Pattern[str], str]]:
             )
         patterns.append((re.compile(expression), migration))
     return patterns
+
+
+def registry_tombstone_patterns() -> list[tuple[re.Pattern[str], str]]:
+    """The buried spellings the registry itself records."""
+    return tombstone_patterns(load_registry())
 
 
 RMP_REGISTRY_ALIAS_PATTERNS = registry_alias_patterns()

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -23,6 +23,9 @@ Rules (findings exit 1 unless escaped):
   rmp-*    Canonical RMP case files additionally require the six provenance
            headers, preamble-free source, canonical spellings, public names,
            at most 88 characters per line, and at most 100 lines per case.
+           The buried spellings come from the registry's tombstone rows and
+           are reported with the migration each row states, so a spelling is
+           retired in one place and refused everywhere.
 
 Escape: a comment `% tenkz-lint: allow <rule> <reason>` on the finding's
 line or the line directly above suppresses that rule there (`allow all`
@@ -84,10 +87,6 @@ def registry_alias_patterns() -> list[re.Pattern[str]]:
         for entry in load_registry()
         if entry.kind == "alias"
     }
-    # `rows` is canonical at picture scope and needs command-aware parsing;
-    # periodic has a dedicated boundary-sensitive expression below.
-    aliases.discard("rows")
-    aliases.discard("periodic")
     patterns = [
         re.compile(r"\b" + re.escape(name).replace(r"\ ", r"\s+") + r"(?:\s*=|\b)")
         for name in sorted(aliases)
@@ -99,7 +98,54 @@ def registry_alias_patterns() -> list[re.Pattern[str]]:
     return patterns
 
 
+def registry_tombstone_patterns() -> list[tuple[re.Pattern[str], str]]:
+    """Source patterns and migrations for the spellings the registry buries.
+
+    A `key=value` row is a word struck from a live alphabet, so the pattern is
+    that spelling.  A bare row is a key that no longer exists; where its word
+    survives as the value of a live enum, the pattern steps over that live
+    spelling, which is where a reader of the dead one should be.
+    """
+    entries = load_registry()
+    enum_owners: dict[str, set[str]] = {}
+    for entry in entries:
+        if entry.kind != "key":
+            continue
+        enum = re.fullmatch(r"enum\(([^)]*)\)", entry.fields[2])
+        if enum is None:
+            continue
+        for word in enum.group(1).split("|"):
+            enum_owners.setdefault(word, set()).add(entry.fields[1])
+    patterns: list[tuple[re.Pattern[str], str]] = []
+    for entry in sorted(
+        (entry for entry in entries if entry.kind == "tombstone"),
+        key=lambda entry: entry.fields[:2],
+    ):
+        _scope, spelling, migration = entry.fields
+        key, _separator, value = spelling.partition("=")
+        key, value = key.strip(), value.strip()
+        if value:
+            expression = (
+                re.escape(key).replace(r"\ ", r"\s+")
+                + r"\s*=\s*"
+                + re.escape(value).replace(r"\ ", r"\s*")
+            )
+        else:
+            expression = (
+                "".join(
+                    f"(?<!{re.escape(owner)}=)"
+                    for owner in sorted(enum_owners.get(key, set()))
+                )
+                + r"\b"
+                + re.escape(key).replace(r"\ ", r"\s+")
+                + r"\b"
+            )
+        patterns.append((re.compile(expression), migration))
+    return patterns
+
+
 RMP_REGISTRY_ALIAS_PATTERNS = registry_alias_patterns()
+RMP_REGISTRY_TOMBSTONE_PATTERNS = registry_tombstone_patterns()
 
 
 @dataclass
@@ -109,7 +155,8 @@ class Finding:
     rule: str
     snippet: str
     allowed: bool
-    reason: str = ""
+    # Where a buried spelling's meaning went, reported with the finding.
+    migration: str = ""
 
 
 @dataclass
@@ -181,8 +228,8 @@ def lint_file(path: Path) -> list[Finding]:
     findings: list[Finding] = []
     seen: set[tuple[int, str]] = set()  # one report per (line, rule)
 
-    def scan(text: str, base: int, rules: list[tuple[str, re.Pattern[str]]]) -> None:
-        for rule, pat in rules:
+    def scan(text: str, base: int, rules: list[tuple]) -> None:
+        for rule, pat, *migration in rules:
             for m in pat.finditer(text):
                 offset = base + m.start()
                 lineno = line_of(offset)
@@ -192,7 +239,8 @@ def lint_file(path: Path) -> list[Finding]:
                 seen.add(key)
                 snippet = raw_lines[lineno - 1].strip() if lineno <= len(raw_lines) else ""
                 findings.append(Finding(path, lineno, rule, snippet,
-                                        escaped(lineno, rule)))
+                                        escaped(lineno, rule),
+                                        migration[0] if migration else ""))
 
     try:
         bodies = scan_bodies(src)
@@ -217,10 +265,13 @@ def lint_file(path: Path) -> list[Finding]:
             ("rmp-private", re.compile(r"\\(?:__tenkz|tenkz@|tenkz_[A-Za-z])")),
             ("rmp-macro", re.compile(r"\\(?:newcommand|def|NewDocumentCommand)\b")),
             ("rmp-raw-ink", re.compile(r"\\(?:draw|fill|filldraw|shade|node|path|tikzset)\b")),
-            ("rmp-alias", re.compile(r"(?<!boundary=)\bperiodic\b")),
             ("rmp-metadata", re.compile(r"^%\s*Fixture\s*:", re.MULTILINE)),
         ]
         source_rules.extend(("rmp-alias", pattern) for pattern in RMP_REGISTRY_ALIAS_PATTERNS)
+        source_rules.extend(
+            ("rmp-alias", pattern, migration)
+            for pattern, migration in RMP_REGISTRY_TOMBSTONE_PATTERNS
+        )
         scan(src, 0, source_rules)
         if len(raw_lines) > 100:
             findings.append(Finding(
@@ -395,7 +446,8 @@ def main(argv: list[str]) -> int:
         for f in lint_file(path):
             total += 1
             status = "allowed" if f.allowed else "FINDING"
-            print(f"{f.path}:{f.line}: [{f.rule}] {status}: {f.snippet}")
+            migration = f" ({f.migration})" if f.migration else ""
+            print(f"{f.path}:{f.line}: [{f.rule}] {status}: {f.snippet}{migration}")
             if not f.allowed:
                 failed += 1
     print(f"tenkz-lint: {scanned} file(s) scanned, {total} finding(s), "

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -228,6 +228,8 @@ def lint_file(path: Path) -> list[Finding]:
     findings: list[Finding] = []
     seen: set[tuple[int, str]] = set()  # one report per (line, rule)
 
+    # A rule is (name, pattern), and a buried spelling adds the migration it
+    # names as a third element.
     def scan(text: str, base: int, rules: list[tuple]) -> None:
         for rule, pat, *migration in rules:
             for m in pat.finditer(text):

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -47,7 +47,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tenkz_audit import ENVIRONMENT_LANGS
-from tenkz_language import Entry, load_registry, parse_status, tombstone_rows
+from tenkz_language import (
+    Entry,
+    load_registry,
+    parse_status,
+    tombstone_rows,
+    tombstone_shape,
+)
 from tenkzlib.texcase import (
     TeXEnvironmentNestingError,
     match_group,
@@ -103,16 +109,22 @@ def tombstone_patterns(entries: list[Entry]) -> list[tuple[re.Pattern[str], str]
     """Source patterns and migrations for the spellings a ledger buries.
 
     A `key=value` row is a word struck from a live alphabet, so the pattern is
-    that spelling.  A row spelled with a leading backslash is a command, whose
-    own backslash is where it starts: a word boundary before it would match
+    that spelling, bounded on both sides: without a left boundary `form=band`
+    would also read `transform=band`.  The value may arrive in a brace group,
+    which is ordinary key-value spelling and reaches the parser as the bare
+    word.  A row spelled with a leading backslash is a command, whose own
+    backslash is where it starts: a word boundary before it would match
     nothing, since neither the backslash nor the space before it is a word
-    character.  A bare row is a key that no longer exists; where its word
-    survives as the value of a live enum, the pattern steps over that live
-    spelling, which is where a reader of the dead one should be.
+    character.  An environment is named where a document names one, in the
+    argument of `\\begin` or `\\end`.  A bare row is a key that no longer
+    exists; where its word survives as the value of a live enum, the pattern
+    steps over that live spelling, which is where a reader of the dead one
+    should be.
 
     Every spelling arrives from `tombstone_rows` with the registry's `~`
     already read as the space a document writes, so a multi-word key is
     matched the way source spells it rather than the way the registry does.
+    A row stating no spelling gets no pattern; the language check reports it.
     """
     enum_owners: dict[str, set[str]] = {}
     for entry in entries:
@@ -124,15 +136,25 @@ def tombstone_patterns(entries: list[Entry]) -> list[tuple[re.Pattern[str], str]
         for word in enum.group(1).split("|"):
             enum_owners.setdefault(word, set()).add(entry.fields[1].replace("~", " "))
     patterns: list[tuple[re.Pattern[str], str]] = []
-    for _scope, spelling, migration in sorted(tombstone_rows(entries)):
+    for scope, spelling, migration in sorted(tombstone_rows(entries)):
         key, _separator, value = spelling.partition("=")
         key, value = key.strip(), value.strip()
-        if spelling.startswith("\\"):
+        shape = tombstone_shape(scope, spelling)
+        if shape == "malformed":
+            continue
+        if shape == "command":
             expression = re.escape(spelling) + r"(?![A-Za-z])"
-        elif value:
+        elif shape == "environment":
             expression = (
-                re.escape(key).replace(r"\ ", r"\s+")
-                + r"\s*=\s*"
+                r"\\(?:begin|end)\s*\{\s*"
+                + re.escape(spelling)
+                + r"\s*\}"
+            )
+        elif shape == "value":
+            expression = (
+                r"(?<![\w-])"
+                + re.escape(key).replace(r"\ ", r"\s+")
+                + r"\s*=\s*\{?\s*"
                 + re.escape(value).replace(r"\ ", r"\s*")
                 + r"(?![\w-])"
             )

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -161,6 +161,11 @@ def tombstone_patterns(entries: list[Entry]) -> list[tuple[re.Pattern[str], str]
         else:
             # A lookbehind takes no variable width, so a live owner is stepped
             # over as the source spells it with no space around the equals.
+            # A spaced `owner = word` is therefore reported, which over-reports
+            # a live spelling rather than passing a dead one, and is what the
+            # hardcoded expression this replaced did.  Matching only where a
+            # key may appear would trade that for a possible under-report,
+            # which is the failure this ledger exists to prevent.
             expression = (
                 "".join(
                     f"(?<!{re.escape(owner)}=)"

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -27,6 +27,7 @@ from tenkz_lint import (  # noqa: E402
     ink_token_count,
     registry_alias_patterns,
     registry_tombstone_patterns,
+    tombstone_patterns,
 )
 import tenkz_shrink  # noqa: E402
 
@@ -516,14 +517,45 @@ def test_the_lint_spells_no_buried_word_of_its_own() -> None:
     # The debt this replaces: a retired spelling written into the script and
     # hand-discarded from the registry read beside it.
     source = (ROOT / "scripts/tenkz_lint.py").read_text(encoding="utf-8")
-    buried = {
-        entry.fields[1]
-        for entry in tenkz_shrink.load_registry()
-        if entry.kind == "tombstone"
-    }
+    buried = tenkz_language.tombstone_rows(tenkz_shrink.load_registry())
     assert buried
-    for spelling in buried:
+    for _scope, spelling, _migration in buried:
         assert spelling not in source, spelling
+
+
+def test_buried_patterns_match_the_spelling_a_document_writes() -> None:
+    # The registry writes a multi-word key with `~` and wraps a long
+    # migration; a document writes an ordinary space and one line.  A pattern
+    # built from the registry's own spelling would ask source for a `~` and
+    # so could never fire.
+    entries = [
+        Entry(
+            "key",
+            ("kernel-mark", "label~pos", "angle", "auto", "kernel", "Quadrant."),
+        ),
+        Entry(
+            "tombstone",
+            ("kernel-mark", "label~pos=outside", "use label pos=270,\n    the south"),
+        ),
+        Entry("tombstone", ("kernel-picture", "chain~axis", "use frame=")),
+        Entry("tombstone", ("picture", r"\tnput", r"use \tn[at=<address>]")),
+    ]
+    assert tenkz_language.tombstone_rows(entries) == [
+        ("kernel-mark", "label pos=outside", "use label pos=270, the south"),
+        ("kernel-picture", "chain axis", "use frame="),
+        ("picture", r"\tnput", r"use \tn[at=<address>]"),
+    ]
+    patterns = {
+        migration: pattern
+        for pattern, migration in tombstone_patterns(entries)
+    }
+    outside = patterns["use label pos=270, the south"]
+    assert outside.search(r"\tnmark[label pos = outside]{(1,1)}{$m$}")
+    assert not outside.search(r"\tnmark[label~pos=outside]{(1,1)}{$m$}")
+    assert patterns["use frame="].search(r"\begin{tenkz}[chain axis=east]")
+    command = patterns[r"use \tn[at=<address>]"]
+    assert command.search(r"  \tnput{(1,1)}{A}")
+    assert not command.search(r"  \tnputmore{(1,1)}{A}")
 
 
 def test_kernel_tombstones_are_read_with_their_migrations() -> None:
@@ -542,41 +574,54 @@ def test_kernel_tombstones_are_read_with_their_migrations() -> None:
     }
 
 
+VOCABULARY = {
+    ("kernel-mark", "form"): ("kernel", "enum(bracket|enclosure|label|prose)"),
+    ("kernel-mark", "label pos"): ("kernel", "angle"),
+    ("kernel-picture", "boundary"): ("sugar", "enum(open|none|periodic)"),
+}
+COMMANDS = {"tn", "tnmark"}
+
+
+def buried_errors(rows, vocabulary=None, commands=None, parser=None):
+    return tenkz_language.tombstone_errors(
+        rows,
+        VOCABULARY if vocabulary is None else vocabulary,
+        COMMANDS if commands is None else commands,
+        {} if parser is None else parser,
+    )
+
+
 def test_a_buried_spelling_stands_in_both_records_or_neither() -> None:
-    vocabulary = {
-        ("kernel-mark", "form"): ("kernel", "enum(bracket|enclosure|label|prose)"),
-        ("kernel-picture", "boundary"): ("sugar", "enum(open|none|periodic)"),
-    }
     ledger = [("kernel-mark", "form=band", "use form=enclosure with tint")]
     parser = {("kernel-mark", "form=band"): "use form=enclosure with tint"}
-    assert tenkz_language.tombstone_errors(ledger, vocabulary, parser) == []
-    only_parser = tenkz_language.tombstone_errors([], vocabulary, parser)
+    assert buried_errors(ledger, parser=parser) == []
+    only_parser = buried_errors([], parser=parser)
     assert only_parser == [
         "the parser refuses spellings the tombstone ledger does not record: "
         "kernel-mark:form=band"
     ], only_parser
-    only_ledger = tenkz_language.tombstone_errors(ledger, vocabulary, {})
+    only_ledger = buried_errors(ledger)
     assert only_ledger == [
         "the tombstone ledger records spellings the parser does not refuse: "
         "kernel-mark:form=band"
     ], only_ledger
-    reworded = tenkz_language.tombstone_errors(
-        ledger,
-        vocabulary,
-        {("kernel-mark", "form=band"): "use form=enclosure"},
+    reworded = buried_errors(
+        ledger, parser={("kernel-mark", "form=band"): "use form=enclosure"}
     )
     assert len(reworded) == 1 and "migrates to" in reworded[0], reworded
+    twice = buried_errors(ledger + ledger, parser=parser)
+    assert twice == ["tombstone kernel-mark:form=band is recorded twice"], twice
 
 
 def test_a_buried_word_may_not_stand_in_its_own_alphabet() -> None:
     vocabulary = {
+        **VOCABULARY,
         ("kernel-mark", "form"): ("kernel", "enum(bracket|band|label)"),
-        ("kernel-picture", "boundary"): ("sugar", "enum(open|none|periodic)"),
     }
-    errors = tenkz_language.tombstone_errors(
+    errors = buried_errors(
         [("kernel-mark", "form=band", "use form=enclosure with tint")],
-        vocabulary,
-        {("kernel-mark", "form=band"): "use form=enclosure with tint"},
+        vocabulary=vocabulary,
+        parser={("kernel-mark", "form=band"): "use form=enclosure with tint"},
     )
     assert errors == [
         "tombstone kernel-mark:form=band is still a word of "
@@ -584,15 +629,42 @@ def test_a_buried_word_may_not_stand_in_its_own_alphabet() -> None:
     ], errors
     # A bare row is a key that no longer exists, so a live key refutes it and
     # a migration is mandatory either way.
-    assert tenkz_language.tombstone_errors(
-        [("kernel-picture", "boundary", "")], vocabulary, {}
-    ) == [
+    assert buried_errors([("kernel-picture", "boundary", "")]) == [
         "tombstone kernel-picture:boundary names no migration",
         "tombstone kernel-picture:boundary names a key the registry still carries",
     ]
-    assert tenkz_language.tombstone_errors(
-        [("kernel-mark", "shape=round", "use form=enclosure")], vocabulary, {}
+    assert buried_errors(
+        [("kernel-mark", "shape=round", "use form=enclosure")]
     ) == ["tombstone kernel-mark:shape=round names no registered key"]
+    assert buried_errors(
+        [("kernel-marks", "form=band", "use form=enclosure")]
+    ) == ["tombstone kernel-marks:form=band names no registered scope"]
+
+
+def test_a_buried_command_is_checked_against_the_live_commands() -> None:
+    # A command tombstone leaves the parser nothing to branch on: the control
+    # sequence is undefined, so the check is that the registry no longer
+    # carries the command and the lint is what reads the row.
+    assert buried_errors([("command", r"\tnput", r"use \tn[at=<address>]")]) == []
+    assert buried_errors([("command", r"\tnmark", "use nothing")]) == [
+        "tombstone command:\\tnmark names a command the registry still carries"
+    ]
+    assert buried_errors([("kernel-mark", r"\tnput", "use nothing")]) == [
+        "tombstone kernel-mark:\\tnput is a command and takes the scope 'command'"
+    ]
+
+
+def test_a_multi_word_buried_key_is_read_as_a_document_writes_it() -> None:
+    # The registry spells `label~pos`; the check reads its vocabulary with
+    # ordinary spaces, so a row spelled the registry's own way must not be
+    # reported as naming no registered key.
+    rows = tenkz_language.tombstone_rows(
+        [Entry("tombstone", ("kernel-mark", "label~pos=outside", "use label pos=270"))]
+    )
+    assert rows == [("kernel-mark", "label pos=outside", "use label pos=270")]
+    assert buried_errors(
+        rows, parser={("kernel-mark", "label pos=outside"): "use label pos=270"}
+    ) == []
 
 
 def test_baseline_matches_actuals() -> None:

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -513,6 +513,44 @@ def test_rmp_buried_patterns_come_from_the_tombstone_ledger() -> None:
     assert caught == ["use boundary=periodic"], caught
 
 
+def test_a_buried_value_is_bounded_on_both_sides_of_its_key() -> None:
+    # Without a left boundary `form=band` reads `transform=band` too, and an
+    # RMP case that never used the retired key is rejected.
+    entries = [
+        Entry(
+            "key",
+            ("kernel-mark", "form", "enum(bracket|label)", "label", "kernel", "Form."),
+        ),
+        Entry(
+            "tombstone",
+            ("kernel-mark", "form=band", "use form=enclosure with tint"),
+        ),
+    ]
+    (pattern, _migration), = tombstone_patterns(entries)
+    assert pattern.search(r"\tnmark[form=band]{(1,1)}{$m$}")
+    assert pattern.search(r"\tnmark[form = band]{(1,1)}{$m$}")
+    # A brace group is ordinary key-value spelling and reaches the parser as
+    # the bare word, so the lint reads it as the parser does.
+    assert pattern.search(r"\tnmark[form={band}]{(1,1)}{$m$}")
+    for innocent in (
+        r"\tnmark[transform=band]{(1,1)}{$m$}",
+        r"\tnmark[platform=band]{(1,1)}{$m$}",
+        r"\tnmark[some-form=band]{(1,1)}{$m$}",
+        r"\tnmark[form=bandwidth]{(1,1)}{$m$}",
+        r"\tnmark[form=band-two]{(1,1)}{$m$}",
+    ):
+        assert not pattern.search(innocent), innocent
+
+
+def test_a_buried_environment_is_matched_where_a_document_names_one() -> None:
+    (pattern, _migration), = tombstone_patterns(
+        [Entry("tombstone", ("environment", "tenkzfree", "use tenkz with lattice="))]
+    )
+    assert pattern.search(r"\begin{tenkzfree}")
+    assert pattern.search(r"\end{ tenkzfree }")
+    assert not pattern.search("the tenkzfree dialect is gone")
+
+
 def test_the_lint_spells_no_buried_word_of_its_own() -> None:
     # The debt this replaces: a retired spelling written into the script and
     # hand-discarded from the registry read beside it.
@@ -558,6 +596,27 @@ def test_buried_patterns_match_the_spelling_a_document_writes() -> None:
     assert not command.search(r"  \tnputmore{(1,1)}{A}")
 
 
+def test_a_commented_out_record_is_not_a_record() -> None:
+    # The registry means one thing to TeX and must mean the same to the tools:
+    # a row behind a comment mark does not run, so it is not read.
+    registry = tenkz_language.REGISTRY.read_text(encoding="utf-8")
+    live = len(tenkz_shrink.load_registry())
+    assert live == len(tenkz_language.load_registry())
+    disabled = registry + (
+        "% \\__tenkz_language_registry_tombstone:nnn {kernel-mark}{form=ghost}\n"
+        "%   {use form=enclosure}\n"
+    )
+    original = tenkz_language.REGISTRY
+    scratch = original.with_name("registry-comment-probe.tex")
+    scratch.write_text(disabled, encoding="utf-8")
+    try:
+        tenkz_language.REGISTRY = scratch
+        assert len(tenkz_language.load_registry()) == live
+    finally:
+        tenkz_language.REGISTRY = original
+        scratch.unlink()
+
+
 def test_kernel_tombstones_are_read_with_their_migrations() -> None:
     source = r"""
 \cs_new_protected:Npn \__tenkz_kernel_tombstone:nnnn #1#2#3#4
@@ -579,14 +638,16 @@ VOCABULARY = {
     ("kernel-mark", "label pos"): ("kernel", "angle"),
     ("kernel-picture", "boundary"): ("sugar", "enum(open|none|periodic)"),
 }
-COMMANDS = {"tn", "tnmark"}
 
 
-def buried_errors(rows, vocabulary=None, commands=None, parser=None):
+SURFACE = {"command": {"tn", "tnmark"}, "environment": {"tenkz", "tenkzeq"}}
+
+
+def buried_errors(rows, vocabulary=None, surface=None, parser=None):
     return tenkz_language.tombstone_errors(
         rows,
         VOCABULARY if vocabulary is None else vocabulary,
-        COMMANDS if commands is None else commands,
+        SURFACE if surface is None else surface,
         {} if parser is None else parser,
     )
 
@@ -641,10 +702,10 @@ def test_a_buried_word_may_not_stand_in_its_own_alphabet() -> None:
     ) == ["tombstone kernel-marks:form=band names no registered scope"]
 
 
-def test_a_buried_command_is_checked_against_the_live_commands() -> None:
-    # A command tombstone leaves the parser nothing to branch on: the control
-    # sequence is undefined, so the check is that the registry no longer
-    # carries the command and the lint is what reads the row.
+def test_a_buried_command_or_environment_is_checked_against_the_live_surface() -> None:
+    # Neither leaves the parser anything to branch on: the control sequence is
+    # undefined and the environment is gone, so the check is that the registry
+    # no longer carries the spelling and the lint is what reads the row.
     assert buried_errors([("command", r"\tnput", r"use \tn[at=<address>]")]) == []
     assert buried_errors([("command", r"\tnmark", "use nothing")]) == [
         "tombstone command:\\tnmark names a command the registry still carries"
@@ -652,6 +713,43 @@ def test_a_buried_command_is_checked_against_the_live_commands() -> None:
     assert buried_errors([("kernel-mark", r"\tnput", "use nothing")]) == [
         "tombstone kernel-mark:\\tnput is a command and takes the scope 'command'"
     ]
+    assert buried_errors(
+        [("environment", "tenkzfree", "use tenkz with lattice=")]
+    ) == []
+    assert buried_errors([("environment", "tenkzeq", "use nothing")]) == [
+        "tombstone environment:tenkzeq names a environment the registry still carries"
+    ]
+
+
+def test_a_row_stating_no_spelling_is_not_read_as_a_bare_key() -> None:
+    # An empty spelling or a trailing equals would otherwise pass as a bare
+    # key: the first compiles to a pattern matching every line, the second
+    # bans a live key's own name.
+    for spelling in ("", "retired=", "=value", "  "):
+        errors = buried_errors([("kernel-mark", spelling, "use something")])
+        assert errors == [
+            f"tombstone kernel-mark:{spelling!r} states no spelling; a row is "
+            "a command, an environment, a key, or key=value"
+        ], (spelling, errors)
+    assert not tombstone_patterns(
+        [Entry("tombstone", ("kernel-mark", "retired=", "use something"))]
+    )
+
+
+def test_one_spelling_is_buried_once_across_the_whole_ledger() -> None:
+    # The lint matches flat source where no scope is visible, so two scopes
+    # burying one spelling would report whichever migration sorted first.
+    rows = [
+        ("kernel-mark", "species=old", "use species=new"),
+        ("kernel-wire", "species=old", "use species=other"),
+    ]
+    vocabulary = {
+        **VOCABULARY,
+        ("kernel-mark", "species"): ("kernel", "declared-name"),
+        ("kernel-wire", "species"): ("kernel", "declared-name"),
+    }
+    errors = buried_errors(rows, vocabulary=vocabulary)
+    assert "tombstone kernel-wire:species=old is recorded twice" in errors, errors
 
 
 def test_a_multi_word_buried_key_is_read_as_a_document_writes_it() -> None:

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -14,14 +14,20 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/tenkz_shrink.py"
 
 sys.path.insert(0, str(ROOT / "scripts"))
+import tenkz_language  # noqa: E402
 from tenkz_language import (  # noqa: E402
     Entry,
     _kernel_leaf_keys_from_texts,
+    _kernel_tombstones_from_texts,
     check,
     parse_alias_payload,
     parse_status,
 )
-from tenkz_lint import ink_token_count, registry_alias_patterns  # noqa: E402
+from tenkz_lint import (  # noqa: E402
+    ink_token_count,
+    registry_alias_patterns,
+    registry_tombstone_patterns,
+)
 import tenkz_shrink  # noqa: E402
 
 
@@ -490,6 +496,103 @@ def test_rmp_alias_patterns_use_only_alias_ledgers() -> None:
     canonical = "dot, route=arc, label=x"
     assert not any(pattern.search(canonical) for pattern in patterns)
     assert not patterns
+
+
+def test_rmp_buried_patterns_come_from_the_tombstone_ledger() -> None:
+    patterns = registry_tombstone_patterns()
+    assert patterns
+    # The live word stands where the alphabet still holds it, and the dead
+    # bare key is caught wherever a document still writes it.
+    assert not any(pattern.search("boundary=periodic") for pattern, _ in patterns)
+    caught = [
+        migration
+        for pattern, migration in patterns
+        if pattern.search(r"\begin{tenkz}[cols=3, periodic]")
+    ]
+    assert caught == ["use boundary=periodic"], caught
+
+
+def test_the_lint_spells_no_buried_word_of_its_own() -> None:
+    # The debt this replaces: a retired spelling written into the script and
+    # hand-discarded from the registry read beside it.
+    source = (ROOT / "scripts/tenkz_lint.py").read_text(encoding="utf-8")
+    buried = {
+        entry.fields[1]
+        for entry in tenkz_shrink.load_registry()
+        if entry.kind == "tombstone"
+    }
+    assert buried
+    for spelling in buried:
+        assert spelling not in source, spelling
+
+
+def test_kernel_tombstones_are_read_with_their_migrations() -> None:
+    source = r"""
+\cs_new_protected:Npn \__tenkz_kernel_tombstone:nnnn #1#2#3#4
+  { \keys_define:nn {#1} { #2 / #3 .code:n = { } } }
+\__tenkz_kernel_tombstone:nnnn { tenkz-kernel-mark } { form } { band }
+  { use~form=enclosure~with~tint,~which~lays~ink~over~the~paper~its~
+    contour~encloses }
+"""
+    assert _kernel_tombstones_from_texts([source]) == {
+        ("kernel-mark", "form=band"): (
+            "use form=enclosure with tint, which lays ink over the paper its "
+            "contour encloses"
+        )
+    }
+
+
+def test_a_buried_spelling_stands_in_both_records_or_neither() -> None:
+    vocabulary = {
+        ("kernel-mark", "form"): ("kernel", "enum(bracket|enclosure|label|prose)"),
+        ("kernel-picture", "boundary"): ("sugar", "enum(open|none|periodic)"),
+    }
+    ledger = [("kernel-mark", "form=band", "use form=enclosure with tint")]
+    parser = {("kernel-mark", "form=band"): "use form=enclosure with tint"}
+    assert tenkz_language.tombstone_errors(ledger, vocabulary, parser) == []
+    only_parser = tenkz_language.tombstone_errors([], vocabulary, parser)
+    assert only_parser == [
+        "the parser refuses spellings the tombstone ledger does not record: "
+        "kernel-mark:form=band"
+    ], only_parser
+    only_ledger = tenkz_language.tombstone_errors(ledger, vocabulary, {})
+    assert only_ledger == [
+        "the tombstone ledger records spellings the parser does not refuse: "
+        "kernel-mark:form=band"
+    ], only_ledger
+    reworded = tenkz_language.tombstone_errors(
+        ledger,
+        vocabulary,
+        {("kernel-mark", "form=band"): "use form=enclosure"},
+    )
+    assert len(reworded) == 1 and "migrates to" in reworded[0], reworded
+
+
+def test_a_buried_word_may_not_stand_in_its_own_alphabet() -> None:
+    vocabulary = {
+        ("kernel-mark", "form"): ("kernel", "enum(bracket|band|label)"),
+        ("kernel-picture", "boundary"): ("sugar", "enum(open|none|periodic)"),
+    }
+    errors = tenkz_language.tombstone_errors(
+        [("kernel-mark", "form=band", "use form=enclosure with tint")],
+        vocabulary,
+        {("kernel-mark", "form=band"): "use form=enclosure with tint"},
+    )
+    assert errors == [
+        "tombstone kernel-mark:form=band is still a word of "
+        "enum(bracket|band|label)"
+    ], errors
+    # A bare row is a key that no longer exists, so a live key refutes it and
+    # a migration is mandatory either way.
+    assert tenkz_language.tombstone_errors(
+        [("kernel-picture", "boundary", "")], vocabulary, {}
+    ) == [
+        "tombstone kernel-picture:boundary names no migration",
+        "tombstone kernel-picture:boundary names a key the registry still carries",
+    ]
+    assert tenkz_language.tombstone_errors(
+        [("kernel-mark", "shape=round", "use form=enclosure")], vocabulary, {}
+    ) == ["tombstone kernel-mark:shape=round names no registered key"]
 
 
 def test_baseline_matches_actuals() -> None:

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -605,6 +605,10 @@ def test_a_commented_out_record_is_not_a_record() -> None:
     disabled = registry + (
         "% \\__tenkz_language_registry_tombstone:nnn {kernel-mark}{form=ghost}\n"
         "%   {use form=enclosure}\n"
+        # An escaped backslash is a complete control symbol, so the comment
+        # mark after it starts a real comment and the row does not run.
+        "\\\\% \\__tenkz_language_registry_tombstone:nnn {kernel-mark}{form=wraith}\n"
+        "%   {use form=enclosure}\n"
     )
     original = tenkz_language.REGISTRY
     scratch = original.with_name("registry-comment-probe.tex")
@@ -672,6 +676,28 @@ def test_a_buried_spelling_stands_in_both_records_or_neither() -> None:
     assert len(reworded) == 1 and "migrates to" in reworded[0], reworded
     twice = buried_errors(ledger + ledger, parser=parser)
     assert twice == ["tombstone kernel-mark:form=band is recorded twice"], twice
+
+
+def test_a_row_ahead_of_its_parser_branch_reports_one_cause() -> None:
+    # The word is still in the alphabet, which is the whole of what is wrong.
+    # A reader of CI output should not also be told that the parser does not
+    # refuse it, nor that the ledger does not record it: both are true, and
+    # both point at the wrong thing.
+    vocabulary = {
+        **VOCABULARY,
+        ("kernel-mark", "form"): ("kernel", "enum(bracket|band|label)"),
+    }
+    row = [("kernel-mark", "form=band", "use form=enclosure with tint")]
+    only_cause = [
+        "tombstone kernel-mark:form=band is still a word of "
+        "enum(bracket|band|label)"
+    ]
+    assert buried_errors(row, vocabulary=vocabulary) == only_cause
+    assert buried_errors(
+        row,
+        vocabulary=vocabulary,
+        parser={("kernel-mark", "form=band"): "use form=enclosure with tint"},
+    ) == only_cause
 
 
 def test_a_buried_word_may_not_stand_in_its_own_alphabet() -> None:

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -242,5 +242,12 @@
 % and names the migration there.  A bare spelling is a key that no longer
 % exists: nothing survives to branch on, the unknown-key error answers it, and
 % the row is what tells a reader of an old document where the meaning went.
+% A spelling beginning with a backslash is a command that no longer exists,
+% and takes the scope `command'.
+%
+% Write a multi-word key the way the rest of the registry does, with ~ for the
+% space, and wrap a long migration to keep the line short.  Both are read out
+% before anything compares or matches a row, so what a document writes is what
+% is matched.
 \__tenkz_language_registry_tombstone:nnn {kernel-picture}{periodic}
   {use boundary=periodic}

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -229,3 +229,18 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-declare}{hue}{hue-source}{house cycle}{kernel}{Species ink; source:* reproduces a cited palette.}
 \__tenkz_language_registry_key:nnnnnn {kernel-declare}{base}{identifier}{empty}{kernel}{Skin the declaration extends.}
 \__tenkz_language_registry_key:nnnnnn {kernel-declare}{pairings}{port-pair-list}{empty}{kernel}{Skin-internal wires between own ports.}
+
+% ---- tombstones (LANGUAGE-1.0 section 10) ----
+%
+% scope, dead spelling, migration.  A retired spelling is recorded once, here,
+% and everything that must refuse it reads these rows: the source lint builds
+% its rejection from them, and the language check requires every spelling the
+% parser refuses by name to carry one, with the same migration in both places.
+%
+% A spelling written `key=value' is a word struck from a live key's alphabet.
+% The key survives, so the parser refuses the word through a branch of its own
+% and names the migration there.  A bare spelling is a key that no longer
+% exists: nothing survives to branch on, the unknown-key error answers it, and
+% the row is what tells a reader of an old document where the meaning went.
+\__tenkz_language_registry_tombstone:nnn {kernel-picture}{periodic}
+  {use boundary=periodic}

--- a/tex/tenkz/tenkz-language.code.tex
+++ b/tex/tenkz/tenkz-language.code.tex
@@ -27,6 +27,13 @@
   { \seq_gput_right:Nn \g__tenkz_language_examples_seq {{#1}{#2}{#3}} }
 \cs_new_protected:Npn \__tenkz_language_registry_prelude:nnn #1#2#3
   { \seq_gput_right:Nn \g__tenkz_language_preludes_seq {{#1}{#2}{#3}} }
+% A tombstone row is a record of a spelling that no longer runs, so the
+% language stage keeps none of it: the parser installs its own refusals
+% (tenkz-kernel.code.tex) and the tools read the rows from the registry
+% source.  The rows live in the registry because a dead spelling belongs
+% beside the live vocabulary it was struck from, and because one record is
+% the only way the parser's refusals and the lint's cannot disagree.
+\cs_new_protected:Npn \__tenkz_language_registry_tombstone:nnn #1#2#3 { }
 \input{tenkz-language-registry.tex}
 
 \msg_new:nnn {tenkz} {language-value}


### PR DESCRIPTION
## What this changes

`scripts/tenkz_lint.py` spelled the retired `periodic` by hand in its
`rmp-alias` rule and discarded two names from the set it read out of the
registry. The spelling now lives in one place and the script holds none of it.

**The record.** The registry gains a tombstone row: scope, dead spelling,
migration.

```tex
\__tenkz_language_registry_tombstone:nnn {kernel-picture}{periodic}
  {use boundary=periodic}
```

The registry is the home because `LANGUAGE-1.0.md` §10 already says it is
("deleted spellings stay in the registry as tombstones; the linter rejects
them forever with the migration hint"), because it sits beside the live
vocabulary a dead spelling was struck from, and because `tenkz_language.py`
already parses that file, so the Python side reads the rows through the path
it uses for every other record rather than a second reader. The language
stage keeps nothing: a tombstone is a record, not state, and the parser
installs its own refusals.

Four shapes of row, by what is left of the spelling. `key=value` is a word
struck from a live key's alphabet; the key survives, so the parser refuses
the word through a branch of its own. A bare `key` is a key that no longer
exists, a leading backslash is a command, and a row under the scope
`environment` is an environment; none of the three leaves the parser anything
to branch on, so the unknown-key error or an undefined spelling answers it
and only the lint reads the row. `periodic` is the second kind. A row that
states no spelling at all is a finding rather than a silently reclassified
bare key, and one spelling is buried once across the whole ledger, since the
lint matches flat source where no scope is visible.

One function, `tombstone_rows`, reads a row before anything consumes it: the
registry writes a multi-word key with `~` and wraps a long migration, and
neither reaches a document, so both are resolved once rather than at each of
the three places that read a row.

**The lint.** `registry_tombstone_patterns()` builds the rejection from the
rows. For a bare spelling whose word survives as the value of a live enum,
the pattern steps over that live spelling, derived from the enum rows rather
than written down: for `periodic` this reproduces the deleted expression
`(?<!boundary=)\bperiodic\b` character for character. Findings now carry the
migration the row states, which is the hint §10 asks for. Both hand-discards
are gone; the set they guarded has been empty since the surface swap, and
`rows` was discarded as an alias row that died with the grid front end.

**The check.** `tenkz_language.py check` now holds the ledger and the parser
to one list, in both directions: a spelling the parser refuses by name and
the ledger does not record fails, a `key=value` row the parser does not
refuse fails, a row whose word is still in its key's alphabet fails, and a
row whose migration differs from the parser's message fails. Two lists that
disagree cannot survive CI.

## Evidence that the check fails when it should

Four divergences were seeded in the working tree and removed again:

| seed | result |
|---|---|
| kernel tombstone for `form=band`, no registry row | `the parser refuses spellings the tombstone ledger does not record: kernel-mark:form=band` |
| registry row for `form=band`, no parser refusal | `the tombstone ledger records spellings the parser does not refuse: kernel-mark:form=band`, plus `is still a word of enum(...)` |
| both records present and agreeing, word out of the alphabet | `PASS` |
| both present, migrations reworded apart | `tombstone kernel-mark:form=band migrates to '...' in the ledger and '...' in the parser` |

The third seed is the shape the tree takes once LionSR/TNLean#6186 lands, so the check is
satisfiable exactly when the two records agree.

Three more seeds cover the spellings the registry writes its own way, added
after review. The rows were written with `~` for the space and the migration
wrapped, as the registry writes everything else, and a matching kernel
tombstone was seeded for the `key=value` one:

```tex
\__tenkz_language_registry_tombstone:nnn {kernel-picture}{chain~axis}
  {use frame=, which is where a chain's axis went}
\__tenkz_language_registry_tombstone:nnn {kernel-mark}{label~pos=outside}
  {use label pos=270, the station a mark speaking from the south
    takes by default}
\__tenkz_language_registry_tombstone:nnn {command}{\tnput}
  {use \tn[at=<address>]}
```

`tenkz_language.py check` accepts all three, including the wrapped `~`
migration against the parser's own wrapped `~` message. The lint fires on
source spelled the ordinary way:

```
probe.tex:7:  [rmp-alias] FINDING: \begin{tenkz}[cols=3, chain axis=east]
              (use frame=, which is where a chain's axis went)
probe.tex:9:  [rmp-alias] FINDING: \tnmark[label pos = outside]{(1,1)}{$m$}
              (use label pos=270, the station a mark speaking from the south takes by default)
probe.tex:10: [rmp-alias] FINDING: \tnput{(1,2)}{B}
              (use \tn[at=<address>])
```

None of the three fired before the fix, which is what the review caught:

```
label\~pos\s*=\s*outside   on `label pos = outside`: False
label\s+pos\s*=\s*outside  on `label pos = outside`: True
\b\\tnput                  on `  \tnput{(1,1)}{A}`:   False
\\tnput(?![A-Za-z])         on `  \tnput{(1,1)}{A}`:   True
```

Every seed was removed again; the ledger on this branch carries `periodic`
alone. All seven cases are unit tests in `scripts/test_tenkz_shrink.py`,
together with a test that the lint source contains no buried spelling of its
own, which itself fails when a spelling is put back into the script.

## Landing order

This assumes LionSR/TNLean#6186 lands first. LionSR/TNLean#6186 installs four `form=` tombstones in the
parser; under this check they need four ledger rows, which is the check doing
its work rather than a defect. Whichever of the two lands second carries
these rows:

```tex
\__tenkz_language_registry_tombstone:nnn {kernel-mark}{form=brace-above}
  {use form=bracket with label pos=90; a bracket speaks from the side its label sits on}
\__tenkz_language_registry_tombstone:nnn {kernel-mark}{form=brace-below}
  {use form=bracket, which speaks from the south when it names no side}
\__tenkz_language_registry_tombstone:nnn {kernel-mark}{form=cut}
  {no successor: the sources' cut is the contour of what it separates, so use form=enclosure over that selection}
\__tenkz_language_registry_tombstone:nnn {kernel-mark}{form=band}
  {use form=enclosure with tint, which lays ink over the paper its contour encloses}
```

## The ch13 picture

The comment saying the site-count brace does not draw was stale: LionSR/tenkz#144 landed
the bracket form, and the sibling chapters draw exactly this figure with
`form=bracket`. The picture now draws the bracket its neighbours draw and the
comment states what is there. `DISPOSITIONS.md` follows the picture up one
line.

## On LionSR/tenkz#7

Left open, and not closed here. The tombstone ledger does not make the
proposed §2.8 diff cheap, for three reasons found while looking:

- Two of the four alphabet rows have no registry enum to diff against.
  Side policy words are typed `side-policy` and the skins are
  `silhouette-name`; only routes and mark forms are `enum(...)` rows. The
  check needs a mapping from each contract alphabet to what carries its words,
  which is the substance of that issue, not a by-product of this one.
- The contract's alphabet tables are the 1.0 target, not the current
  implementation. §2.8 lists three mark forms and the registry carries four,
  because `prose` is sentenced in §10 and its parser row has not moved. A
  strict diff therefore has to read §10 alongside §2.8, and §10 is where the
  discrepancies live.
- Run against `main` today, the §2.8 diff fails by one word: §10 lists
  `form=cut`, `form=band`, `form=brace-below` and `form=prose` but not
  `form=brace-above`, which LionSR/TNLean#6186 corrects. So the check cannot be written
  before that lands either, and it should be written against the corrected
  table.

No seventh meter, for the reason the ledger already gives: the alphabets are
surface on the same terms as the metric registry, which §11 names as a ledger
the meters do not count.

## What else could not fire

Every pattern and lookup added here, against the question of what input makes
it fire and whether that input occurs in what it scans. Three were wrong and
are fixed above; the rest are stated with their bounds.

| Reads | Fires on | Can that occur |
|---|---|---|
| `_KERNEL_TOMBSTONE` | a `\__tenkz_kernel_tombstone:nnnn` call in `tex/tenkz/*.code.tex` | yes, once LionSR/TNLean#6186 lands; the lookahead steps over the helper's own definition, whose next token is a parameter. A tombstone installed from a `.sty` would be missed, and none is: the `.sty` is a loader |
| ledger key lookup | a `key=value` row naming a live key | fixed: was asking the space-normalized vocabulary for a `~` spelling |
| ledger enum test | a tombstoned word still in its key's `enum(...)` | yes, and it is what stops a row landing before its parser row moves |
| ledger scope test | a row naming no key scope | yes; before, a typo'd scope silently disabled the live-key test |
| duplicate test | two rows meaning one spelling | yes; the raw-field duplicate check upstream cannot see `label~pos` and `label pos` as one |
| lint `key=value` pattern | that spelling in a case file | fixed: was requiring a `~` no source writes. Ends `(?![\w-])` so a longer value is not a match |
| lint command pattern | the control sequence in a case file | fixed: a leading `\b` matched nothing, since neither the backslash nor the space before it is a word character |
| lint bare-key pattern | the word, except where a live enum owner precedes it | yes. The lookbehind takes no variable width, so it steps over `boundary=periodic` but not `boundary = periodic`; that over-reports rather than under-reports, is what the deleted hardcode did, and no source in the corpus writes the spaced form |
| lint migration report | a finding whose rule carried a migration | yes, shown above |

Two bounds worth stating rather than fixing. The lint reports one finding per
line per rule, so a line carrying two buried spellings names the first; the
line is still reported and the file still fails. And case sources are read
with comments stripped, so a dead word in a provenance header is not a
finding, which is what lets `% Boundary: periodic wrapping` sit above a case
that spells `boundary=periodic`.

## Second review round

Two blocking findings and four more, all fixed in `bc74cc9` with seeded
evidence:

- The `key=value` pattern had no left boundary, so `form=band` would have read
  `transform=band` once LionSR/TNLean#6186's rows arrive. Seeded: `transform=band` on line
  9 is not reported, `form=band` on line 10 and `form={band}` on line 11 are.
- `periodic` was not in the contract's own §10 tombstone table. It is now, and
  §9's sugar row narrows to `boundary=periodic`: §10 says no deleted spelling
  is ever reused, so a spelling cannot be buried there and proposed for reuse
  in §9. The narrowed row now states exactly what the registry spells.
- A row stating no spelling (empty, or `retired=`) was read as a bare key and
  compiled to a pattern matching every line. It is a finding now and gets no
  pattern.
- Two rows burying one spelling under different scopes would have reported
  whichever migration sorted first. One spelling is buried once, ledger-wide.
- Environments take their own scope beside commands, matched in the argument
  of `\begin` or `\end`. Seeded with `tenkzfree`: both delimiters reported,
  the same word in prose left alone.
- A record the registry comments out is no longer read, so the file means one
  thing to TeX and the same to the tools. No record changes today.

One finding was refuted rather than fixed: `re.escape` does escape a literal
space (`_special_chars_map` is built over a string containing it), so the
`.replace(r"\ ", r"\s+")` idiom fires and the compiled pattern carries
`\s+`. Checked on the interpreter, not argued.

## Third review round

- The hacking guide counted three shapes of row; the code implements four, and
  it now says so and how each is matched.
- A row whose word the alphabet still holds reported twice: once for the real
  cause and once, through the parser comparison, for something else. It
  reports once. Not by skipping the record, which mirrors the pair rather than
  removing it (a live word the parser *does* refuse would then report "the
  ledger does not record it"), but by subtracting those identities from the
  `unrefused` difference alone. Seeded with a `form=band` row while the enum
  still carries `band`, the mid-landing state of the LionSR/TNLean#6186 sequence: one line,
  naming the cause.
- `_commented_out` was a second TeX-comment parser next to
  `tenkzlib.texcase.strip_comments`, which the project's own rule forbids, and
  its single-character lookbehind read `\\%` as escaping a genuine comment.
  `load_registry` now reads through the shared stripper, which blanks comments
  in place so every offset is still the file's. Seeded: the ledger reads one
  row where the old rule would have read two, the second being a phantom
  behind a real comment.

One thread is answered rather than changed, with the reason now recorded
beside the code: the lookbehind stepping over a live enum owner is
fixed-width, so `boundary = periodic` spaced is reported. That over-reports a
live spelling rather than passing a dead one, is what the hardcoded expression
this replaced did, and the alternatives trade it for a possible under-report,
which is the failure this ledger exists to prevent.

**On the seeds themselves.** All three rounds of findings landed in a shape my
original four seeds did not exercise: those were all a single-word bare key,
and the findings lived in multi-word keys, commands, wrapped migrations,
`key=value` rows, braced values, malformed rows, partially-landed rows, and
escaped comment marks. The seed set now covers all four shapes, both
directions of the parser comparison, malformed rows, and both comment forms.
Same lesson as LionSR/tenkz#6 from the other side: a gate is known to work only on the
inputs someone has watched it handle.

## The blueprint figure, rendered

No gate in the table below renders a blueprint chapter: `tenkz_golden.sh
--check` covers the fixture corpus, and the corpus and probe gates do not
read `blueprint/src`. So the figure was built and read rather than argued
from sibling usage.

`blueprint/src/print.tex`, built from this branch with xelatex, **page 197**,
read at 400 DPI. The bracket spans the `A` sites under the traced return,
carries `L+1 sites` as its label, and clears both the return above it and the
per-site `A` labels between them. No clipped ink, no collision, and the
surrounding proof text is unmoved. The page is the one containing
"inverting and growing back" and the `Y_i = Z_j A^i` step.

## Overlap with LionSR/TNLean#6186

Since this PR opened, LionSR/TNLean#6186 has added its own copy of the tombstone record,
the registrar, and a `tombstone_errors` of the same name, so the two now
conflict in `tenkz_language.py`, `tenkz-language-registry.tex`, and
`tenkz-language.code.tex`. The halves are complementary: LionSR/TNLean#6186 has the four
`form=` rows and the kernel branches, this PR has the lint that reads them,
the `periodic` row, the tests, and the review fixes above. Whichever lands
second should keep `tombstone_rows`/`tombstone_errors` from here, since the
copy there compares a raw registry migration against a normalized parser
message and looks a key up without reading its `~`. Noted on LionSR/TNLean#6186.

## Gates

```
python3 scripts/tenkz_lint.py 'blueprint/src/chapter/*.tex' 'docs/tenkz/manual2.tex' \
  'docs/tenkz/chapters2/*.tex' 'docs/slides/*.tex' 'tex/tenkz/examples/*.tex' \
  'tests/tenkz/rmp/*/cases/*.tex'
  -> 416 file(s) scanned, 0 finding(s), 0 unescaped, byte-identical to the same
     run on current main (the corpus grew by one chapter while this was open)
python3 scripts/tenkz_lint.py --census        -> unchanged, exit 0
python3 scripts/tenkz_language.py check       -> PASS (101 records)
python3 scripts/test_tenkz_language.py        -> PASS
python3 scripts/test_tenkz_shrink.py          -> PASS (all, including the four new tests)
python3 scripts/tenkz_shrink.py gate --base-ref origin/main
                                              -> PASS: census stable at 86, 60 flags carry verdicts
scripts/tenkz_golden.sh --check               -> PASS: 9 event streams byte-identical
                                                 (re-run after the review fixes)
scripts/tenkz_kernel_probes.sh --check        -> PASS: 155 regressions, 11 sugar spellings,
                                                 12 record streams, kernel pixels byte-identical
python3 scripts/check_tenkz_dispositions.py   -> PASS: 202 blueprint occurrences reconcile
python3 scripts/check_tenkz_policy.py, check_tenkz_demolition.py -> PASS
python3 scripts/test_tenkz_pic.py, test_tenkz_equation_audit.py,
        test_tenkz_manual_doctest.py, test_tenkz_blueprint_sweep.py,
        test_tenkz_corpus_provenance.py, test_tenkz_kernel_audit.py,
        test_texcase.py, test_tnlog.py, test_tenkz_ctan.py -> PASS
python3 scripts/tenkz_blueprint_sweep.py      -> 202 pictures, 0 hard findings
                                                 (3 pre-existing ch20/ch21 advisories)
```

A positive control confirms the rule still fires: a case file spelling bare
`periodic` is reported at the same line by the old and new lint, and
`boundary=periodic` beside it is left alone by both.

```
old: .../probe.tex:7: [rmp-alias] FINDING: \begin{tenkz}[cols=3, periodic]
new: .../probe.tex:7: [rmp-alias] FINDING: \begin{tenkz}[cols=3, periodic] (use boundary=periodic)
```

No meter moves: tombstone rows are not keys, so M1 through M6 stand where
they were.

Closes LionSR/tenkz#195.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI-critical language registry, lint, and consistency checks that gate retired spellings; a bug could miss or falsely reject buried forms. No runtime auth or data-path changes.
> 
> **Overview**
> **Centralizes retired spellings** in registry tombstone rows so lint and `tenkz_language.py check` no longer hardcode them.
> 
> Adds a `tombstone` registry record (scope, dead spelling, migration), starting with bare `periodic` → `boundary=periodic`. The lint builds `rmp-alias` patterns from those rows and reports the migration with each finding. The language check keeps the ledger, live vocabulary, and parser refusals in sync in both directions.
> 
> Also updates the ch13 intersection-property figure to use `form=bracket` for the site-count mark (matching sibling chapters) and documents the tombstone shapes in `HACKING.md` / `LANGUAGE-1.0.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6855b265e47a0cb01ed107db81e663d5362a91ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



