### PR TITLE
fix(blueprint): record direct proof dependencies

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -613,6 +613,7 @@ $\bigvee_jG_{n+2}(A^j)$ used for the degenerate parent-Hamiltonian ground space.
 
 \begin{proof}
     \leanok
+    \uses{lem:product_word_span_from_bnt_block_separation}
     For the base of induction over the target blocks, the empty word gives the
     identity tuple on the empty target set. This does not represent a physical
     chain of length zero. The span of word tuples is closed under pointwise

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -593,6 +593,7 @@
         exists_isRFPViaTS_not_lengthIndependent_bntCoefficients}
     \leanok
     \uses{def:mpdo_bnt_label_length_independent,
+        thm:mpdo_bond_two_singleton_normalized_algebra,
         thm:mpdo_bnt_algebra_tensor_to_rfp}
     There is an MPDO $M$ in literal CPSV canonical form that is a
     renormalization fixed point and has a tensor-attached BNT presentation
@@ -609,6 +610,7 @@
 \begin{proof}\leanok
     \uses{thm:mpdo_bond_two_singleton_ambient_ghz,
         thm:mpdo_bond_two_singleton_cpsv_form,
+        thm:mpdo_bond_two_singleton_normalized_algebra,
         thm:mpdo_bond_two_singleton_tensor_clause,
         thm:mpdo_bnt_algebra_tensor_to_rfp}
     The bond-two singleton tensor is positive on every nonempty chain, is in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
@@ -789,7 +789,8 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpdo_four_site_sal_bnt_sector_projectors}
+    \uses{thm:mpdo_bnt_projector_local_selection,
+      thm:mpdo_four_site_sal_bnt_sector_projectors}
     Sitewise multiplication by $P_s$ is the periodic MPO obtained by changing
     every local physical matrix by $P_s$. The preceding theorem replaces
     each normal representative by itself when its label is $s$ and by the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex
@@ -789,6 +789,7 @@ strong subadditivity for a normalized three-site reduced state.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpdo_four_site_sal_bnt_sector_projectors}
     Sitewise multiplication by $P_s$ is the periodic MPO obtained by changing
     every local physical matrix by $P_s$. The preceding theorem replaces
     each normal representative by itself when its label is $s$ and by the


### PR DESCRIPTION
## What changed

- record the normalized singleton coefficient owner as the statement and proof dependency of the length-dependent RFP example
- record the block-selector span theorem as the direct proof dependency of the pair-separating span theorem
- record the four-site sector-projector theorem as the direct proof dependency of packaged positive-length compression
- preserve unique `\lean` ownership for every affected declaration

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`: 7308/7308 entries formalized
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- exact owner audit: all five affected declarations have one Blueprint owner
- `TEXINPUTS="../../tex/tenkz//:" lualatex -interaction=nonstopmode -halt-on-error print.tex` twice: 0 undefined references on pass 2
- `python3 scripts/check_tenkz_dispositions.py`: 202 Blueprint occurrences and 9 fixtures reconcile
- `TENKZ_CORPUS_JOBS=4 scripts/tenkz_golden.sh --check`: 9/9 event streams byte-identical
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`: 52 generated files cover 1368 modules
- `lake build` twice: 10079 jobs, both green
- `git diff --check`

Closes #6199.
Follow-up to #6192.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint metadata-only change: adds `\uses` annotations with no mathematical or Lean proof content modified.
> 
> **Overview**
> Adds missing **direct `\uses` dependencies** in three blueprint proofs so Lean ownership and dependency graphs stay accurate.
> 
> Records `lem:product_word_span_from_bnt_block_separation` on the pair-separating span proof, `thm:mpdo_bond_two_singleton_normalized_algebra` on the length-dependent RFP example (statement and proof), and the local-selection / four-site sector-projector theorems on positive-length BNT compression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06cc14908f56f211c75dd5eb8b44b9b5438234ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->