### PR TITLE
feat(MPS/Chain): prove PGVWC07 site-independent representation

### DIFF
--- a/TNLean/MPS/Chain.lean
+++ b/TNLean/MPS/Chain.lean
@@ -14,6 +14,7 @@ import TNLean.MPS.Chain.CyclicBlockAverage
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Chain.FundamentalTheorem
 import TNLean.MPS.Chain.OneSidedInverse
+import TNLean.MPS.Chain.SiteIndependent
 import TNLean.MPS.Chain.TensorEquality
 import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.MPS.Chain.VaryingBondOBC

--- a/TNLean/MPS/Chain/SiteIndependent.lean
+++ b/TNLean/MPS/Chain/SiteIndependent.lean
@@ -86,7 +86,9 @@ theorem pgvwc07_site_independent_matrices
     hTI (-k) σ
   simp_rw [hTI']
   rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
-  simp [NeZero.ne N]
+  have hN : (N : ℂ) ≠ 0 := by
+    exact_mod_cast NeZero.ne N
+  simp [hN]
 
 /-- Existence form of `pgvwc07_site_independent_matrices`. -/
 theorem exists_pgvwc07_site_independent_tensor

--- a/TNLean/MPS/Chain/SiteIndependent.lean
+++ b/TNLean/MPS/Chain/SiteIndependent.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Chain.CyclicBlockAverage
+import TNLean.MPS.Chain.VaryingBondOBC
+
+/-!
+# Site-independent matrices for a fixed translation-invariant state
+
+This file completes the construction in PGVWC07, Theorem 3. A varying-bond
+open-boundary representation of a translation-invariant state on one positive
+ring is first padded to a square site-dependent chain. Cyclic block averaging
+then gives one site-independent tensor of bond dimension \(ND\) with the same
+coefficient at that ring length.
+
+The constructed tensor depends on \(N\). No equality at other lengths is
+asserted.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, lines 620--649.
+-/
+
+open scoped BigOperators Matrix
+
+namespace OBCChainTensor
+
+variable {d D N : ℕ}
+
+/-- Rotating the padded square chain by \(k\) sites is the same as translating
+the physical configuration by \(-k\) in the original open-boundary
+coefficient. The inverse is forced by restoring the rotated matrix product to
+the distinguished open cut. -/
+theorem coeff_cyclicRotation_zeroPad_eq_coeff_cyclicTranslateConfig_neg
+    (A : OBCChainTensor d D N) [NeZero N]
+    (k : Fin N) (σ : Fin N → Fin d) :
+    MPSChainTensor.coeff
+        (MPSChainTensor.cyclicRotation A.zeroPad k) σ =
+      A.coeff (cyclicTranslateConfig (-k) σ) := by
+  classical
+  rw [← A.coeff_zeroPad (cyclicTranslateConfig (-k) σ)]
+  rw [MPSChainTensor.coeff_eq_sum_cyclic,
+    MPSChainTensor.coeff_eq_sum_cyclic]
+  let e : (Fin N → Fin D) ≃ (Fin N → Fin D) :=
+    (finCycle k).arrowCongr (Equiv.refl (Fin D))
+  refine Fintype.sum_equiv e _ _ fun g => ?_
+  let F : Fin N → ℂ := fun m =>
+    A.zeroPad m ((cyclicTranslateConfig (-k) σ) m)
+      ((e g) m) ((e g) (m + 1))
+  calc
+    (∏ j : Fin N,
+        (MPSChainTensor.cyclicRotation A.zeroPad k) j
+          (σ j) (g j) (g (j + 1))) =
+      ∏ j : Fin N, F (finCycle k j) := by
+        apply Finset.prod_congr rfl
+        intro j _
+        simp [F, e, MPSChainTensor.cyclicRotation_apply,
+          cyclicTranslateConfig, finCycle, add_assoc]
+        congr 4
+        abel
+    _ = ∏ m : Fin N, F m := Equiv.prod_comp (finCycle k) F
+
+/-- **PGVWC07 Theorem 3.** A varying-bond open-boundary representation of a
+translation-invariant state on one positive ring of length \(N\) yields a
+site-independent trace-MPS representation of bond dimension \(ND\) at that
+same length.
+
+The tensor is `MPSChainTensor.cyclicBlockTensor A.zeroPad` and depends on
+\(N\). Purity is used upstream in PGVWC07 to supply open-boundary data; the
+finite cyclic-block calculation itself needs only the data and the stated
+translation invariance. -/
+theorem pgvwc07_siteIndependentMatrices
+    (A : OBCChainTensor d D N) [NeZero N]
+    (hTI : A.IsTranslationInvariantState) :
+    ∀ σ : Fin N → Fin d,
+      MPSTensor.mpv (MPSChainTensor.cyclicBlockTensor A.zeroPad) σ =
+        A.coeff σ := by
+  intro σ
+  rw [MPSChainTensor.mpv_cyclicBlockTensor_eq_average]
+  simp_rw [coeff_cyclicRotation_zeroPad_eq_coeff_cyclicTranslateConfig_neg A]
+  have hTI' (k : Fin N) :
+      A.coeff (cyclicTranslateConfig (-k) σ) = A.coeff σ :=
+    hTI (-k) σ
+  simp_rw [hTI']
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+  simp [NeZero.ne N]
+
+/-- Existence form of `pgvwc07_siteIndependentMatrices`. -/
+theorem exists_pgvwc07_siteIndependentTensor
+    (A : OBCChainTensor d D N) [NeZero N]
+    (hTI : A.IsTranslationInvariantState) :
+    ∃ B : MPSTensor d (N * D),
+      ∀ σ : Fin N → Fin d, MPSTensor.mpv B σ = A.coeff σ :=
+  ⟨MPSChainTensor.cyclicBlockTensor A.zeroPad,
+    pgvwc07_siteIndependentMatrices A hTI⟩
+
+end OBCChainTensor

--- a/TNLean/MPS/Chain/SiteIndependent.lean
+++ b/TNLean/MPS/Chain/SiteIndependent.lean
@@ -72,8 +72,8 @@ representation; the finite cyclic-block calculation itself needs only the OBC
 chain tensor and the stated translation invariance.
 
 **Scope restriction (supplied OBC representation):** the arbitrary-state OBC
-existence input of PGVWC07 Theorem 3 remains issue #6086. This boundary is
-recorded in `docs/paper-gaps/pgvwc07_site_independent_scope.tex`. -/
+existence input of PGVWC07 Theorem 3 is not included. This boundary is recorded
+in `docs/paper-gaps/pgvwc07_site_independent_scope.tex`. -/
 theorem pgvwc07_site_independent_matrices
     (A : OBCChainTensor d D N) [NeZero N]
     (hTI : A.IsTranslationInvariantState) (σ : Fin N → Fin d) :

--- a/TNLean/MPS/Chain/SiteIndependent.lean
+++ b/TNLean/MPS/Chain/SiteIndependent.lean
@@ -67,16 +67,18 @@ site-independent trace-MPS representation of bond dimension \(ND\) at that
 same length.
 
 The tensor is `MPSChainTensor.cyclicBlockTensor A.zeroPad` and depends on
-\(N\). Purity is used upstream in PGVWC07 to supply open-boundary data; the
-finite cyclic-block calculation itself needs only the data and the stated
-translation invariance. -/
+\(N\). Purity is used upstream in PGVWC07 to supply the rectangular open-boundary
+representation; the finite cyclic-block calculation itself needs only the OBC
+chain tensor and the stated translation invariance.
+
+**Scope restriction (supplied OBC representation):** the arbitrary-state OBC
+existence input of PGVWC07 Theorem 3 remains issue #6086. This boundary is
+recorded in `docs/paper-gaps/pgvwc07_site_independent_scope.tex`. -/
 theorem pgvwc07_site_independent_matrices
     (A : OBCChainTensor d D N) [NeZero N]
-    (hTI : A.IsTranslationInvariantState) :
-    ∀ σ : Fin N → Fin d,
-      MPSTensor.mpv (MPSChainTensor.cyclicBlockTensor A.zeroPad) σ =
-        A.coeff σ := by
-  intro σ
+    (hTI : A.IsTranslationInvariantState) (σ : Fin N → Fin d) :
+    MPSTensor.mpv (MPSChainTensor.cyclicBlockTensor A.zeroPad) σ =
+      A.coeff σ := by
   rw [MPSChainTensor.mpv_cyclicBlockTensor_eq_average]
   simp_rw [coeff_cyclicRotation_zeroPad_eq_coeff_cyclicTranslateConfig_neg A]
   have hTI' (k : Fin N) :

--- a/TNLean/MPS/Chain/SiteIndependent.lean
+++ b/TNLean/MPS/Chain/SiteIndependent.lean
@@ -31,7 +31,7 @@ variable {d D N : ℕ}
 the physical configuration by \(-k\) in the original open-boundary
 coefficient. The inverse is forced by restoring the rotated matrix product to
 the distinguished open cut. -/
-theorem coeff_cyclicRotation_zeroPad_eq_coeff_cyclicTranslateConfig_neg
+private theorem coeff_cyclicRotation_zeroPad_eq_coeff_cyclicTranslateConfig_neg
     (A : OBCChainTensor d D N) [NeZero N]
     (k : Fin N) (σ : Fin N → Fin d) :
     MPSChainTensor.coeff
@@ -60,8 +60,9 @@ theorem coeff_cyclicRotation_zeroPad_eq_coeff_cyclicTranslateConfig_neg
         abel
     _ = ∏ m : Fin N, F m := Equiv.prod_comp (finCycle k) F
 
-/-- **PGVWC07 Theorem 3.** A varying-bond open-boundary representation of a
-translation-invariant state on one positive ring of length \(N\) yields a
+/-- **Conditional PGVWC07 Theorem 3 construction.** A supplied varying-bond
+open-boundary representation of a translation-invariant state on one positive
+ring of length \(N\) yields a
 site-independent trace-MPS representation of bond dimension \(ND\) at that
 same length.
 
@@ -69,7 +70,7 @@ The tensor is `MPSChainTensor.cyclicBlockTensor A.zeroPad` and depends on
 \(N\). Purity is used upstream in PGVWC07 to supply open-boundary data; the
 finite cyclic-block calculation itself needs only the data and the stated
 translation invariance. -/
-theorem pgvwc07_siteIndependentMatrices
+theorem pgvwc07_site_independent_matrices
     (A : OBCChainTensor d D N) [NeZero N]
     (hTI : A.IsTranslationInvariantState) :
     ∀ σ : Fin N → Fin d,
@@ -85,13 +86,13 @@ theorem pgvwc07_siteIndependentMatrices
   rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
   simp [NeZero.ne N]
 
-/-- Existence form of `pgvwc07_siteIndependentMatrices`. -/
-theorem exists_pgvwc07_siteIndependentTensor
+/-- Existence form of `pgvwc07_site_independent_matrices`. -/
+theorem exists_pgvwc07_site_independent_tensor
     (A : OBCChainTensor d D N) [NeZero N]
     (hTI : A.IsTranslationInvariantState) :
     ∃ B : MPSTensor d (N * D),
       ∀ σ : Fin N → Fin d, MPSTensor.mpv B σ = A.coeff σ :=
   ⟨MPSChainTensor.cyclicBlockTensor A.zeroPad,
-    pgvwc07_siteIndependentMatrices A hTI⟩
+    pgvwc07_site_independent_matrices A hTI⟩
 
 end OBCChainTensor

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -341,15 +341,19 @@ boundary conventions.
     (\ref{eq:chain_cyclic_block_average}).
 \end{proof}
 
-\begin{theorem}[Site-independent matrices at fixed length]
+% Scope restriction (supplied OBC representation): PGVWC07 Theorem 3 also
+% obtains this input from purity via its OBC representation theorem.
+\begin{theorem}[Conditional site-independent matrices at fixed length]
     \label{thm:pgvwc07_site_independent_matrices}
-    \lean{OBCChainTensor.pgvwc07_siteIndependentMatrices,
-        OBCChainTensor.exists_pgvwc07_siteIndependentTensor}
+    \lean{OBCChainTensor.pgvwc07_site_independent_matrices,
+        OBCChainTensor.exists_pgvwc07_site_independent_tensor}
     \leanok
-    \uses{def:varying_bond_obc_ti, thm:varying_bond_obc_zero_pad_coeff,
-        thm:chain_cyclic_block_average}
-    Let $N\geq1$. Suppose a translation-invariant state on the $N$-site ring
-    has a varying-bond open-chain representation whose virtual dimensions are
+    \uses{def:varying_bond_obc_ti, def:varying_bond_obc_zero_pad,
+        def:chain_cyclic_block_tensor}
+    This is the cyclic-block construction in
+    \cite[Theorem~3]{PerezGarcia2007Matrix}, conditional on its open-chain
+    input. Let $N\geq1$. Suppose a translation-invariant state on the $N$-site
+    ring has a varying-bond open-chain representation whose virtual dimensions are
     at most $D$. Then it has a site-independent trace-MPS representation of
     bond dimension $ND$ with the same length-$N$ coefficients.
     The constructed tensor depends on $N$, and the equality is asserted only

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -342,7 +342,8 @@ boundary conventions.
 \end{proof}
 
 % Scope restriction (supplied OBC representation): PGVWC07 Theorem 3 also
-% obtains this input from purity via its OBC representation theorem.
+% obtains this input from purity via its OBC representation theorem. See
+% docs/paper-gaps/pgvwc07_site_independent_scope.tex.
 \begin{theorem}[Conditional site-independent matrices at fixed length]
     \label{thm:pgvwc07_site_independent_matrices}
     \lean{OBCChainTensor.pgvwc07_site_independent_matrices,

--- a/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_foundations.tex
@@ -341,6 +341,40 @@ boundary conventions.
     (\ref{eq:chain_cyclic_block_average}).
 \end{proof}
 
+\begin{theorem}[Site-independent matrices at fixed length]
+    \label{thm:pgvwc07_site_independent_matrices}
+    \lean{OBCChainTensor.pgvwc07_siteIndependentMatrices,
+        OBCChainTensor.exists_pgvwc07_siteIndependentTensor}
+    \leanok
+    \uses{def:varying_bond_obc_ti, thm:varying_bond_obc_zero_pad_coeff,
+        thm:chain_cyclic_block_average}
+    Let $N\geq1$. Suppose a translation-invariant state on the $N$-site ring
+    has a varying-bond open-chain representation whose virtual dimensions are
+    at most $D$. Then it has a site-independent trace-MPS representation of
+    bond dimension $ND$ with the same length-$N$ coefficients.
+    The constructed tensor depends on $N$, and the equality is asserted only
+    at this ring length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:chain_coeff_sum_cyclic, thm:varying_bond_obc_zero_pad_coeff,
+        thm:chain_cyclic_block_average}
+    The cyclic rotation of the padded square chain satisfies
+    \begin{align}
+        c_{(\widetilde A)^{(k)},\sigma}
+        &=c_A(\tau_{-k}\sigma),
+        \label{eq:pgvwc07_zero_pad_rotation}
+    \end{align}
+    where $(\tau_s\sigma)_j=\sigma_{j+s}$. To prove
+    (\ref{eq:pgvwc07_zero_pad_rotation}), expand both square-chain traces as
+    cyclic virtual-path sums and reindex the virtual path by the same rotation.
+    The inverse shift appears when the rotated matrix product is restored to
+    the distinguished open cut. Translation invariance makes every term in
+    the cyclic average equal to $c_A(\sigma)$, so the factor $1/N$ cancels the
+    sum of $N$ identical terms.
+\end{proof}
+
 \begin{lemma}[Cyclic gauge equivalence is an equivalence relation]
     \label{lem:chain_gauge_equiv_equivalence}
     \lean{MPSChainTensor.GaugeEquiv.refl}

--- a/docs/paper-gaps/pgvwc07_site_independent_scope.tex
+++ b/docs/paper-gaps/pgvwc07_site_independent_scope.tex
@@ -1,0 +1,7 @@
+% Scope restriction (supplied OBC representation): PGVWC07 Theorem 3 first
+% obtains a varying-bond open-boundary representation of an arbitrary finite
+% pure state from Theorems 1--2. TNLean currently formalizes the subsequent
+% cyclic-block construction conditional on an OBCChainTensor and fixed-length
+% translation invariance. Issue #6086 tracks the missing Schmidt/SVD existence
+% and representation-freedom theorems. Composing that result with
+% OBCChainTensor.pgvwc07_site_independent_matrices will remove this restriction.

--- a/docs/paper-gaps/pgvwc07_site_independent_scope.tex
+++ b/docs/paper-gaps/pgvwc07_site_independent_scope.tex
@@ -1,7 +1,69 @@
-% Scope restriction (supplied OBC representation): PGVWC07 Theorem 3 first
-% obtains a varying-bond open-boundary representation of an arbitrary finite
-% pure state from Theorems 1--2. TNLean currently formalizes the subsequent
-% cyclic-block construction conditional on an OBCChainTensor and fixed-length
-% translation invariance. Issue #6086 tracks the missing Schmidt/SVD existence
-% and representation-freedom theorems. Composing that result with
-% OBCChainTensor.pgvwc07_site_independent_matrices will remove this restriction.
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Scope of the Formal Site-Independent Construction Relative to PGVWC07}
+\author{}
+\date{2026-08-12}
+
+\begin{document}
+\maketitle
+
+\section{Source theorem}
+
+P\'erez-Garc\'ia, Verstraete, Wolf, and Cirac prove that every
+translation-invariant pure state on a finite periodic chain has an MPS
+representation with site-independent matrices
+\cite[Theorem~3]{PerezGarcia2007MPSReps}. Their proof first obtains a
+varying-bond open-boundary representation by successive Schmidt or singular
+value decompositions. It then pads the rectangular virtual spaces to one
+square space and averages the resulting chain over cyclic translations. If
+$N$ is the ring length and $D$ bounds the intermediate bond dimensions, the
+site-independent tensor has bond dimension $ND$.
+
+\section{Formal boundary}
+
+The structure \leanid{OBCChainTensor} records a supplied varying-bond
+open-boundary representation. The theorem
+\leanid{OBCChainTensor.pgvwc07_site_independent_matrices} proves that, for a
+positive fixed length $N$, cyclic averaging of its zero-padding has the same
+coefficients whenever those coefficients are translation invariant. Its
+existence form is
+\leanid{OBCChainTensor.exists_pgvwc07_site_independent_tensor}.
+
+Thus the formal theorem proves the square-padding and cyclic-averaging part of
+PGVWC07 Theorem~3. It does not construct an \leanid{OBCChainTensor} from an
+arbitrary pure state. In particular, purity is not a hypothesis of the formal
+theorem because the representation whose existence purity supplies in the
+source is already an input.
+
+\section{Elimination plan}
+
+Formalize the finite-chain Schmidt decomposition that expresses an arbitrary
+pure state as a varying-bond open-boundary MPS with endpoint bond dimensions
+one. Bound every intermediate bond dimension by a common $D$, instantiate
+\leanid{OBCChainTensor}, and prove that translation invariance of the state
+gives \leanid{OBCChainTensor.IsTranslationInvariantState}. Composing that
+existence theorem with
+\leanid{OBCChainTensor.exists_pgvwc07_site_independent_tensor} will yield the
+source-facing statement for arbitrary translation-invariant pure states.
+Issue \href{https://github.com/LionSR/TNLean/issues/6086}{\#6086} tracks this
+missing existence theorem.
+
+\section{Verdict}
+
+\textbf{Verdict: scope restriction.} The formal declarations prove the
+fixed-length zero-padding and cyclic-averaging construction conditional on a
+supplied varying-bond open-boundary representation. The Schmidt-decomposition
+argument producing that representation from an arbitrary pure state remains
+open, so the current result is not the full source theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -92,7 +92,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L326, 332, 338, 352, 363, 369 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L363, 882, 886, 892, 897 `tenkz` → `P-grid` | — | — |
-| `ch23_algebraic_ft_foundations.tex` | L48, 52, 455, 459, 660, 664, 677, 681, 724, 728, 732, 741, 745 `tenkz` → `P-grid` | — | — |
+| `ch23_algebraic_ft_foundations.tex` | L48, 52, 489, 493, 694, 698, 711, 715, 758, 762, 766, 775, 779 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | L84, 104, 294, 300, 312, 324, 577, 596 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -92,7 +92,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | L189 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | L326, 332, 338, 352, 363, 369 `tenkz` → `P-grid` | — | — |
 | `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | L363, 882, 886, 892, 897 `tenkz` → `P-grid` | — | — |
-| `ch23_algebraic_ft_foundations.tex` | L48, 52, 489, 493, 694, 698, 711, 715, 758, 762, 766, 775, 779 `tenkz` → `P-grid` | — | — |
+| `ch23_algebraic_ft_foundations.tex` | L48, 52, 494, 498, 699, 703, 716, 720, 763, 767, 771, 780, 784 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft.tex` | L27, 57, 93 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | L21 `tenkz` → `P-grid` | — | — |
 | `ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex` | L84, 104, 294, 300, 312, 324, 577, 596 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## What changed

- prove that rotating the zero-padded square chain corresponds to the inverse physical translation of the original OBC coefficient;
- compose varying-bond zero-padding, cyclic block averaging, and fixed-length translation invariance;
- construct the PGVWC07 Theorem 3 site-independent tensor of bond dimension `N * D`;
- expose the module through the generated Chain aggregator and synchronize Chapter 23.

The tensor depends on `N`, and the theorem asserts coefficient equality only at that fixed positive ring length.

## Validation

- `lake build TNLean.MPS.Chain.SiteIndependent`
- `lake build TNLean.MPS.Chain`
- full `lake build` (10080 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- proof-integrity scan and `git diff --check`

Closes #6087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation on top of existing cyclic-block machinery; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Adds **`TNLean.MPS.Chain.SiteIndependent`**, proving that a **supplied** varying-bond open-boundary chain with translation-invariant coefficients yields a **site-independent** trace-MPS of bond dimension **`N * D`** via **`cyclicBlockTensor` on `zeroPad`**, with equality only at that fixed positive ring length.
> 
> The proof links **cyclic rotation of the padded square chain** to **physical translation by \(-k\)** on OBC coefficients, then uses the existing cyclic-block average and translation invariance to collapse the \(1/N\) sum.
> 
> Chapter 23 gains a matching **conditional theorem** and proof sketch; **`docs/paper-gaps/pgvwc07_site_independent_scope.tex`** records that **Schmidt/OBC existence from an arbitrary pure state** (full PGVWC07 Theorem 3) is still out of scope (**#6086**). The generated **`TNLean.MPS.Chain`** import list is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8268f4f8b33e892e7279850706bc7da74bdee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->