### PR TITLE
feat(MPU): preserve CFII data under positive blocking

### DIFF
--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -24,7 +24,8 @@ letterwise reconstruction, not only equality of closed-chain coefficients.
   tensors.
 * `MPSTensor.CPSVCanonicalFormData.blockTensor`: literal canonical-form data
   block exactly.
-* `MPSTensor.CPSVCanonicalFormIIData.blockTensor`: canonical-form-II data block exactly.
+* `MPSTensor.CPSVCanonicalFormIIData.blockTensor`: blockwise canonical-form-II data block
+  exactly.
 * `MPSTensor.IsCPSVCanonicalForm.blockTensor`: positive blocking preserves
   literal CPSV canonical form.
 
@@ -273,10 +274,11 @@ end CPSVCanonicalFormData
 
 namespace CPSVCanonicalFormIIData
 
-/-- Literal CPSV canonical-form-II data are preserved by positive physical blocking.
+/-- Blockwise CPSV canonical-form-II data are preserved by positive physical blocking.
 
 Each fixed-point matrix remains positive definite and diagonal, and is fixed by the blocked transfer
-map because that map is the corresponding positive power of the original transfer map.
+map because that map is the corresponding positive power of the original transfer map. The same
+matrix is retained, so any separately supplied trace normalization is also unchanged.
 
 Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. -/
 noncomputable def blockTensor {A : MPSTensor d D}

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -24,6 +24,7 @@ letterwise reconstruction, not only equality of closed-chain coefficients.
   tensors.
 * `MPSTensor.CPSVCanonicalFormData.blockTensor`: literal canonical-form data
   block exactly.
+* `MPSTensor.CPSVCanonicalFormIIData.blockTensor`: canonical-form-II data block exactly.
 * `MPSTensor.IsCPSVCanonicalForm.blockTensor`: positive blocking preserves
   literal CPSV canonical form.
 
@@ -269,6 +270,29 @@ noncomputable def blockTensor {A : MPSTensor d D}
             rfl
 
 end CPSVCanonicalFormData
+
+namespace CPSVCanonicalFormIIData
+
+/-- Literal CPSV canonical-form-II data are preserved by positive physical blocking.
+
+Each fixed-point matrix remains positive definite and diagonal, and is fixed by the blocked transfer
+map because that map is the corresponding positive power of the original transfer map.
+
+Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. -/
+noncomputable def blockTensor {A : MPSTensor d D}
+    (data : CPSVCanonicalFormIIData A) (p : ℕ) (hp : 0 < p) :
+    CPSVCanonicalFormIIData (MPSTensor.blockTensor (d := d) (D := D) A p) where
+  toCPSVCanonicalFormData := data.toCPSVCanonicalFormData.blockTensor p hp
+  blocks_left_canonical := fun k ↦
+    leftCanonical_blockTensor (data.blocks k) p (data.blocks_left_canonical k)
+  blocks_fixed_point := by
+    intro k
+    obtain ⟨Λ, hΛpos, hΛdiag, hΛfix⟩ := data.blocks_fixed_point k
+    exact ⟨Λ, hΛpos, hΛdiag, by
+      change transferMap (MPSTensor.blockTensor (data.blocks k) p) Λ = Λ
+      exact transferMap_blockTensor_fixedPoint (data.blocks k) p Λ hΛfix⟩
+
+end CPSVCanonicalFormIIData
 
 namespace IsCPSVCanonicalForm
 

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -18,14 +18,17 @@ normal block is replaced by its physical block tensor and each CPSV weight is
 raised to the blocking length.  The reconstruction is the exact blocked
 letterwise reconstruction, not only equality of closed-chain coefficients.
 
-## Main results
+## Main definitions
 
-* `MPSTensor.IsNormalTensor.blockTensor`: positive blocking preserves normal
-  tensors.
 * `MPSTensor.CPSVCanonicalFormData.blockTensor`: literal canonical-form data
   block exactly.
 * `MPSTensor.CPSVCanonicalFormIIData.blockTensor`: blockwise canonical-form-II data block
   exactly.
+
+## Main results
+
+* `MPSTensor.IsNormalTensor.blockTensor`: positive blocking preserves normal
+  tensors.
 * `MPSTensor.IsCPSVCanonicalForm.blockTensor`: positive blocking preserves
   literal CPSV canonical form.
 
@@ -280,7 +283,7 @@ Each fixed-point matrix remains positive definite and diagonal, and is fixed by 
 map because that map is the corresponding positive power of the original transfer map. The same
 matrix is retained, so any separately supplied trace normalization is also unchanged.
 
-Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. -/
+Source: arXiv:1703.09188, Section II, lines 297--305, and Section III, line 356. -/
 noncomputable def blockTensor {A : MPSTensor d D}
     (data : CPSVCanonicalFormIIData A) (p : ℕ) (hp : 0 < p) :
     CPSVCanonicalFormIIData (MPSTensor.blockTensor (d := d) (D := D) A p) where

--- a/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
@@ -16,6 +16,7 @@ preserves normal tensors and the retained-block reconstruction of literal CPSV c
 
 * `MPSTensor.IsNormalTensor.reindexPhysical`: physical relabeling preserves normal tensors.
 * `MPSTensor.CPSVCanonicalFormData.reindexPhysical`: relabel literal canonical-form data.
+* `MPSTensor.CPSVCanonicalFormIIData.reindexPhysical`: relabel canonical-form-II data.
 * `MPSTensor.IsCPSVCanonicalForm.reindexPhysical`: physical relabeling preserves literal
   canonical form.
 
@@ -73,6 +74,30 @@ noncomputable def reindexPhysical {A : MPSTensor d₂ D}
     simpa [MPSTensor.reindexPhysical, toTensorFromBlocks] using data.reconstruct (e i)
 
 end CPSVCanonicalFormData
+
+namespace CPSVCanonicalFormIIData
+
+/-- Relabel the physical alphabet in literal CPSV canonical-form-II data.
+
+The fixed-point matrices are unchanged because a bijective physical relabeling leaves each block's
+transfer map unchanged.
+
+Source: arXiv:1703.09188, definition `blocking` and line 356; CFII is defined at lines 271--281. -/
+noncomputable def reindexPhysical {A : MPSTensor d₂ D}
+    (data : CPSVCanonicalFormIIData A) (e : Fin d₁ ≃ Fin d₂) :
+    CPSVCanonicalFormIIData (MPSTensor.reindexPhysical e A) where
+  toCPSVCanonicalFormData := data.toCPSVCanonicalFormData.reindexPhysical e
+  blocks_left_canonical := fun k ↦
+    (leftCanonical_reindexPhysical_equiv e (data.blocks k)).2 (data.blocks_left_canonical k)
+  blocks_fixed_point := by
+    intro k
+    obtain ⟨Λ, hΛpos, hΛdiag, hΛfix⟩ := data.blocks_fixed_point k
+    exact ⟨Λ, hΛpos, hΛdiag, by
+      change transferMap (MPSTensor.reindexPhysical e (data.blocks k)) Λ = Λ
+      rw [transferMap_reindexPhysical_equiv]
+      exact hΛfix⟩
+
+end CPSVCanonicalFormIIData
 
 namespace IsCPSVCanonicalForm
 

--- a/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
@@ -77,12 +77,12 @@ end CPSVCanonicalFormData
 
 namespace CPSVCanonicalFormIIData
 
-/-- Relabel the physical alphabet in literal CPSV canonical-form-II data.
+/-- Relabel the physical alphabet in blockwise CPSV canonical-form-II data.
 
 The fixed-point matrices are unchanged because a bijective physical relabeling leaves each block's
-transfer map unchanged.
+transfer map unchanged. In particular, any separately supplied trace normalization is unchanged.
 
-Source: arXiv:1703.09188, definition `blocking` and line 356; CFII is defined at lines 271--281. -/
+Source: arXiv:1703.09188, CFII definition at lines 271--281. -/
 noncomputable def reindexPhysical {A : MPSTensor d₂ D}
     (data : CPSVCanonicalFormIIData A) (e : Fin d₁ ≃ Fin d₂) :
     CPSVCanonicalFormIIData (MPSTensor.reindexPhysical e A) where

--- a/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
@@ -12,11 +12,14 @@ import TNLean.MPS.Core.PhysicalReindexTransport
 A bijective relabeling of the physical alphabet leaves the transfer map unchanged.  It therefore
 preserves normal tensors and the retained-block reconstruction of literal CPSV canonical form.
 
+## Main definitions
+
+* `MPSTensor.CPSVCanonicalFormData.reindexPhysical`: relabel literal canonical-form data.
+* `MPSTensor.CPSVCanonicalFormIIData.reindexPhysical`: relabel canonical-form-II data.
+
 ## Main results
 
 * `MPSTensor.IsNormalTensor.reindexPhysical`: physical relabeling preserves normal tensors.
-* `MPSTensor.CPSVCanonicalFormData.reindexPhysical`: relabel literal canonical-form data.
-* `MPSTensor.CPSVCanonicalFormIIData.reindexPhysical`: relabel canonical-form-II data.
 * `MPSTensor.IsCPSVCanonicalForm.reindexPhysical`: physical relabeling preserves literal
   canonical form.
 

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -49,7 +49,7 @@ def HasFullActiveSupport (data : CPSVCanonicalFormData A) : Prop :=
 /-- Positive blocking identifies the active retained indices exactly with the original active
 indices.
 
-Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. The positivity
+Source: arXiv:1703.09188, Section II, lines 297--305, and Section III, line 356. The positivity
 assumption excludes the zero-site block, whose weights are all raised to the zeroth power. -/
 noncomputable def activeEquivBlockTensor (data : CPSVCanonicalFormData A)
     (p : ℕ) (hp : 0 < p) :
@@ -68,7 +68,7 @@ noncomputable def activeEquivBlockTensor (data : CPSVCanonicalFormData A)
 
 This uses the exact active-index equivalence, so it makes no claim for the zero-site block.
 
-Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. -/
+Source: arXiv:1703.09188, Section II, lines 297--305, and Section III, line 356. -/
 theorem hasFullActiveSupport_blockTensor (data : CPSVCanonicalFormData A)
     (hfull : data.HasFullActiveSupport) (p : ℕ) (hp : 0 < p) :
     (data.blockTensor p hp).HasFullActiveSupport := by
@@ -367,12 +367,12 @@ theorem normalizedFlattening_blockTensor (U : MPOTensor d D) (p : ℕ) :
     exact Complex.ofReal_pow _ _
   rw [hsqrtC, inv_pow]
 
-/-- Package canonical-form-II data for a positively blocked MPO normalized flattening.
+/-- Construct canonical-form-II data for a positively blocked MPO normalized flattening.
 
 The blocked MPS data are relabeled by `blockedDoubledIndexEquiv`, matching the index orientation in
 `normalizedFlattening_blockTensor`.
 
-Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. -/
+Source: arXiv:1703.09188, Section II, lines 297--305, and Section III, line 356. -/
 noncomputable def blockTensorCFIIData (U : MPOTensor d D)
     (data : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
     (p : ℕ) (hp : 0 < p) :

--- a/TNLean/MPS/MPU/CanonicalForm.lean
+++ b/TNLean/MPS/MPU/CanonicalForm.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Peripheral.TransferMatrix
-import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.CanonicalForm.CPSVBlocking
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
 import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPU.ActiveTransferMultiplicity
 import TNLean.MPS.MPU.TransferMatrix
 
@@ -43,6 +45,49 @@ canonical-form definition. See
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`. -/
 def HasFullActiveSupport (data : CPSVCanonicalFormData A) : Prop :=
   ∑ k : data.Active, data.dim k.1 = D
+
+/-- Positive blocking identifies the active retained indices exactly with the original active
+indices.
+
+Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. The positivity
+assumption excludes the zero-site block, whose weights are all raised to the zeroth power. -/
+noncomputable def activeEquivBlockTensor (data : CPSVCanonicalFormData A)
+    (p : ℕ) (hp : 0 < p) :
+    (data.blockTensor p hp).Active ≃ data.Active where
+  toFun k := ⟨k.1, by
+    have hk := k.property
+    change data.weights k.1 ^ p ≠ 0 at hk
+    exact (pow_ne_zero_iff hp.ne').mp hk⟩
+  invFun k := ⟨k.1, by
+    change data.weights k.1 ^ p ≠ 0
+    exact pow_ne_zero p k.property⟩
+  left_inv k := Subtype.ext rfl
+  right_inv k := Subtype.ext rfl
+
+/-- Full active support is preserved by blocking a positive number of sites.
+
+This uses the exact active-index equivalence, so it makes no claim for the zero-site block.
+
+Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. -/
+theorem hasFullActiveSupport_blockTensor (data : CPSVCanonicalFormData A)
+    (hfull : data.HasFullActiveSupport) (p : ℕ) (hp : 0 < p) :
+    (data.blockTensor p hp).HasFullActiveSupport := by
+  classical
+  change (∑ k : (data.blockTensor p hp).Active, (data.blockTensor p hp).dim k.1) = D
+  calc
+    (∑ k : (data.blockTensor p hp).Active, (data.blockTensor p hp).dim k.1) =
+        ∑ k : (data.blockTensor p hp).Active, data.dim ((data.activeEquivBlockTensor p hp) k).1 :=
+      rfl
+    _ = ∑ k : data.Active, data.dim k.1 :=
+      (data.activeEquivBlockTensor p hp).sum_comp (fun k : data.Active ↦ data.dim k.1)
+    _ = D := hfull
+
+/-- Full active support is unchanged by a bijective relabeling of the physical alphabet. -/
+theorem hasFullActiveSupport_reindexPhysical {d' : ℕ} (data : CPSVCanonicalFormData A)
+    (hfull : data.HasFullActiveSupport) (e : Fin d' ≃ Fin d) :
+    (data.reindexPhysical e).HasFullActiveSupport := by
+  change ∑ k : data.Active, data.dim k.1 = D
+  exact hfull
 
 /-- Tensor irreducibility is invariant under simultaneous bond-index reindexing. -/
 private theorem isIrreducibleTensor_reindexBond
@@ -287,6 +332,53 @@ end MPSTensor
 namespace MPOTensor
 
 variable {d D : ℕ}
+
+private theorem sqrt_blockPhysDim (d p : ℕ) :
+    Real.sqrt (MPSTensor.blockPhysDim d p) = Real.sqrt d ^ p := by
+  suffices Real.sqrt ((d ^ p : ℕ) : ℝ) = Real.sqrt d ^ p by
+    simpa [MPSTensor.blockPhysDim] using this
+  induction p with
+  | zero => simp
+  | succ p ih =>
+      rw [pow_succ, Nat.cast_mul, Real.sqrt_mul (by positivity), ih]
+      simp [pow_succ]
+
+/-- Normalized MPO flattening commutes with physical blocking, up to the canonical equivalence
+between a doubled blocked index and a block of doubled indices.
+
+The identity holds for every blocking length; positivity is required only when it is used to
+preserve the active support and normal blocks.
+
+Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, equation
+`eq:transfer-op`, and line 356. -/
+theorem normalizedFlattening_blockTensor (U : MPOTensor d D) (p : ℕ) :
+    (MPOTensor.blockTensor U p).normalizedFlattening =
+      MPSTensor.reindexPhysical (blockedDoubledIndexEquiv d p)
+        (MPSTensor.blockTensor U.normalizedFlattening p) := by
+  funext ij
+  rw [normalizedFlattening, toMPSTensor_blockTensor]
+  simp only [MPSTensor.reindexPhysical, MPSTensor.blockTensor]
+  change _ = MPSTensor.evalWord
+    (fun i => ((Real.sqrt d : ℂ)⁻¹) • U.toMPSTensor i) _
+  rw [MPSTensor.evalWord_smul, MPSTensor.length_wordOfBlock]
+  have hsqrtC : (Real.sqrt (MPSTensor.blockPhysDim d p) : ℂ) =
+      (Real.sqrt d : ℂ) ^ p := by
+    rw [sqrt_blockPhysDim]
+    exact Complex.ofReal_pow _ _
+  rw [hsqrtC, inv_pow]
+
+/-- Package canonical-form-II data for a positively blocked MPO normalized flattening.
+
+The blocked MPS data are relabeled by `blockedDoubledIndexEquiv`, matching the index orientation in
+`normalizedFlattening_blockTensor`.
+
+Source: arXiv:1703.09188, definition `blocking`, equation `MPUblock`, and line 356. -/
+noncomputable def blockTensorCFIIData (U : MPOTensor d D)
+    (data : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
+    (p : ℕ) (hp : 0 < p) :
+    MPSTensor.CPSVCanonicalFormIIData (MPOTensor.blockTensor U p).normalizedFlattening := by
+  rw [normalizedFlattening_blockTensor]
+  exact (data.blockTensor p hp).reindexPhysical (blockedDoubledIndexEquiv d p)
 
 /-- The normalized flattening of an MPU is normal when the chosen CPSV canonical-form
 representative has full active support.


### PR DESCRIPTION
## What changed

- extend paper canonical-form-II data through physical relabeling and positive physical blocking
- identify the active blocks before and after a positive block and preserve full active support
- prove the normalized-flattening blocking formula with the existing doubled-index orientation
- construct canonical-form-II data for the normalized flattening of a positively blocked MPO
- retain the same fixed-point matrices without claiming preservation of source cuts, source ranks, compact-SVD choices, `sourceU`, or `sourceV`

## Validation

- `lake build TNLean.MPS.CanonicalForm.CPSVPhysicalReindex TNLean.MPS.CanonicalForm.CPSVBlocking TNLean.MPS.MPU.CanonicalForm TNLean.MPS.MPU.TransferStabilization` (8,915/8,915)
- focused independent mathematical and style review
- proof-integrity scan of changed files
- `git diff --check origin/main...HEAD`

Advances #6138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to formal Lean proofs in MPS canonical-form and MPU theory; scope is moderate but correctness matters for downstream MPU formalization.
> 
> **Overview**
> Extends **canonical-form-II (CFII)** structure through the same physical operations already proved for literal CPSV data: **`CPSVCanonicalFormIIData.blockTensor`** (positive site blocking) and **`CPSVCanonicalFormIIData.reindexPhysical`**, keeping the same diagonal fixed-point matrices while reusing blocked left-canonical and transfer-map lemmas.
> 
> On the MPU side, **`MPU/CanonicalForm`** wires those lemmas in: an **`activeEquivBlockTensor`** equivalence shows active blocks match before/after positive blocking, **`HasFullActiveSupport`** is shown stable under blocking and physical relabeling, **`normalizedFlattening_blockTensor`** relates blocked MPO flattening to blocked MPS flattening via **`blockedDoubledIndexEquiv`**, and **`blockTensorCFIIData`** builds CFII data for a positively blocked MPO’s normalized flattening from existing flattening CFII data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad50a9beda0640258ef98f834f5190bbca220911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->