### PR TITLE
chore(imports): remove stale RFP and MPDO imports

### DIFF
--- a/TNLean/MPS/MPDO/LemmaC5CaseI.lean
+++ b/TNLean/MPS/MPDO/LemmaC5CaseI.lean
@@ -16,7 +16,6 @@ import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.Analysis.MatrixTraceInequalities
 import TNLean.Algebra.PerronFrobenius.Idempotent
 import TNLean.Algebra.PerronFrobenius.PerronVector
-import TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic
 import TNLean.Algebra.PerronFrobenius.RankOne
 import TNLean.Algebra.PerronFrobenius.Substochastic
 import TNLean.Algebra.TraceReindex

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -11,7 +11,6 @@ import TNLean.MPS.RFP.BeigiSectorGraphConstruction
 import TNLean.MPS.RFP.BNTDirectSumBasis
 import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.StructuralForm
-import TNLean.Wielandt.Primitivity.Equivalence
 
 /-!
 # Identification of Beigi loop sectors with normal tensors


### PR DESCRIPTION
## What changed

- remove the unused `TNLean.Wielandt.Primitivity.Equivalence` import from `BeigiLoopBNTIdentification`
- remove the unused `TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic` import from `LemmaC5CaseI`
- retain `TNLean.MPS.MPDO.PureRecovery` in `FusionIsometries`: the direct module still builds without it, but the direct consumer `AlgebraFusionCounterexample` loses declarations supplied transitively and fails
- leave declarations, proofs, compatibility modules, aggregators, and public interfaces unchanged

## Validation

- `lake build TNLean.MPS.RFP.BeigiLoopBNTIdentification TNLean.MPS.RFP.MainMPSConditional TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm`
- attempted `lake build TNLean.MPS.MPDO.FusionIsometries TNLean.MPS.MPDO.AlgebraFusionCounterexample TNLean.MPS.MPDO.AlgebraStructure` without `PureRecovery` (rejected because `AlgebraFusionCounterexample` failed); restored import and reran successfully
- `lake build TNLean.MPS.MPDO.LemmaC5CaseI TNLean.MPS.MPDO.InverseMapLemmaC5CaseI`
- `python3 scripts/generate_import_aggregators.py --check` (52 generated files, 1368 production modules)
- `lake build TNLean.MPS.RFP TNLean.MPS.MPDO`
- `lake build` (10079 jobs)
- `git diff --check`

Closes #6207.
Tracker: #6205.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no logic, interface, or proof changes.
> 
> **Overview**
> Removes two unused imports with no declaration or proof changes.
> 
> Drops `TNLean.Algebra.PerronFrobenius.PrimitiveAperiodic` from `LemmaC5CaseI` and `TNLean.Wielandt.Primitivity.Equivalence` from `BeigiLoopBNTIdentification`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad096595a48c6b088e15aa8e7c7581e5b80b2d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->