### PR TITLE
refactor(mps/mpdo): share three-site AgreesOutsideWindow characterizations

### DIFF
--- a/TNLean/MPS/MPDO/EmbedLocalOperatorTwoSite.lean
+++ b/TNLean/MPS/MPDO/EmbedLocalOperatorTwoSite.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.CommutingForm
 
 /-!
@@ -17,6 +18,50 @@ matrix.
 namespace MPOTensor
 
 variable {d : ℕ}
+
+/-! ### Agreement outside a length-two window on a three-site chain
+
+In right-associated triple coordinates, two configurations agree outside a
+length-two window exactly when their coordinate outside the window coincides.
+These characterizations are reused by the three-site local-embedding
+identifications for both the physical-sector and isometric transports. -/
+
+/-- In right-associated triple coordinates, agreement outside a length-two
+window starting at the first site holds exactly when the third coordinates
+coincide. -/
+theorem agreesOutsideWindow_finThreeArrowEquiv_three_zero
+    (σ τ : Fin d × (Fin d × Fin d)) :
+    AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
+        ((_root_.finThreeArrowEquiv (Fin d)).symm σ)
+        ((_root_.finThreeArrowEquiv (Fin d)).symm τ) ↔
+      τ.2.2 = σ.2.2 := by
+  constructor
+  · intro ha
+    have h := congrFun ha (2 : Fin 3)
+    simpa [AgreesOutsideWindow, MPSTensor.replaceWindow,
+      MPSTensor.extractWindow] using h
+  · intro ha
+    funext i
+    fin_cases i <;>
+      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+
+/-- In right-associated triple coordinates, agreement outside a length-two
+window starting at the second site holds exactly when the first coordinates
+coincide. -/
+theorem agreesOutsideWindow_finThreeArrowEquiv_three_one
+    (σ τ : Fin d × (Fin d × Fin d)) :
+    AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3)
+        ((_root_.finThreeArrowEquiv (Fin d)).symm σ)
+        ((_root_.finThreeArrowEquiv (Fin d)).symm τ) ↔
+      τ.1 = σ.1 := by
+  constructor
+  · intro ha
+    have h := congrFun ha (0 : Fin 3)
+    simpa [MPSTensor.replaceWindow, MPSTensor.extractWindow] using h
+  · intro ha
+    funext i
+    fin_cases i <;>
+      simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
 
 /-- In pair coordinates, embedding an arbitrary two-site matrix at site zero
 preserves its physical-index order. -/

--- a/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
+++ b/TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean
@@ -297,20 +297,7 @@ private theorem reindex_embedLocalOperator_three_zero
         (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
           (_root_.finTwoArrowEquiv (Fin e)) B) := by
   ext σ τ
-  have hAgree :
-      AgreesOutsideWindow (d := e) 2 (by decide) (0 : Fin 3)
-          ((_root_.finThreeArrowEquiv (Fin e)).symm σ)
-          ((_root_.finThreeArrowEquiv (Fin e)).symm τ) ↔
-        τ.2.2 = σ.2.2 := by
-    constructor
-    · intro ha
-      have h := congrFun ha (2 : Fin 3)
-      simpa [AgreesOutsideWindow, MPSTensor.replaceWindow,
-        MPSTensor.extractWindow] using h
-    · intro ha
-      funext i
-      fin_cases i <;>
-        simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+  have hAgree := agreesOutsideWindow_finThreeArrowEquiv_three_zero σ τ
   have hσ :
       MPSTensor.extractWindow 2 (0 : Fin 3)
           ((_root_.finThreeArrowEquiv (Fin e)).symm σ) =
@@ -357,19 +344,7 @@ private theorem reindex_embedLocalOperator_three_one
         (Matrix.reindex (_root_.finTwoArrowEquiv (Fin e))
           (_root_.finTwoArrowEquiv (Fin e)) B) := by
   ext σ τ
-  have hAgree :
-      AgreesOutsideWindow (d := e) 2 (by decide) (1 : Fin 3)
-          ((_root_.finThreeArrowEquiv (Fin e)).symm σ)
-          ((_root_.finThreeArrowEquiv (Fin e)).symm τ) ↔
-        τ.1 = σ.1 := by
-    constructor
-    · intro ha
-      have h := congrFun ha (0 : Fin 3)
-      simpa [MPSTensor.replaceWindow, MPSTensor.extractWindow] using h
-    · intro ha
-      funext i
-      fin_cases i <;>
-        simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+  have hAgree := agreesOutsideWindow_finThreeArrowEquiv_three_one σ τ
   have hσ :
       MPSTensor.extractWindow 2 (1 : Fin 3)
           ((_root_.finThreeArrowEquiv (Fin e)).symm σ) =

--- a/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
+import TNLean.MPS.MPDO.EmbedLocalOperatorTwoSite
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.CommutingForm
 
@@ -62,20 +63,7 @@ theorem reindex_embedLocalOperator_zero (F : PhysicalSectorFactorization K) :
         (embedLocalOperator (d := d) 2 3 (by decide) (0 : Fin 3) F.physicalBond) =
       leftPairMatrix F.physicalPairBond := by
   ext σ τ
-  have hAgree :
-      AgreesOutsideWindow (d := d) 2 (by decide) (0 : Fin 3)
-          ((_root_.finThreeArrowEquiv (Fin d)).symm σ)
-          ((_root_.finThreeArrowEquiv (Fin d)).symm τ) ↔
-        τ.2.2 = σ.2.2 := by
-    constructor
-    · intro ha
-      have h := congrFun ha (2 : Fin 3)
-      simpa [AgreesOutsideWindow, MPSTensor.replaceWindow,
-        MPSTensor.extractWindow] using h
-    · intro ha
-      funext i
-      fin_cases i <;>
-        simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+  have hAgree := agreesOutsideWindow_finThreeArrowEquiv_three_zero σ τ
   by_cases h : τ.2.2 = σ.2.2
   · have ha := hAgree.mpr h
     simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,
@@ -110,19 +98,7 @@ theorem reindex_embedLocalOperator_one (F : PhysicalSectorFactorization K) :
         (embedLocalOperator (d := d) 2 3 (by decide) (1 : Fin 3) F.physicalBond) =
       rightPairMatrix F.physicalPairBond := by
   ext σ τ
-  have hAgree :
-      AgreesOutsideWindow (d := d) 2 (by decide) (1 : Fin 3)
-          ((_root_.finThreeArrowEquiv (Fin d)).symm σ)
-          ((_root_.finThreeArrowEquiv (Fin d)).symm τ) ↔
-        τ.1 = σ.1 := by
-    constructor
-    · intro ha
-      have h := congrFun ha (0 : Fin 3)
-      simpa [MPSTensor.replaceWindow, MPSTensor.extractWindow] using h
-    · intro ha
-      funext i
-      fin_cases i <;>
-        simp [MPSTensor.replaceWindow, MPSTensor.extractWindow, ha]
+  have hAgree := agreesOutsideWindow_finThreeArrowEquiv_three_one σ τ
   by_cases h : τ.1 = σ.1
   · have ha := hAgree.mpr h
     simp only [Fin.isValue, Matrix.reindex_apply, Matrix.submatrix_apply,


### PR DESCRIPTION
Closes #6206. Part of #6205.

## Summary

Extracts the duplicated `finThreeArrowEquiv`-wrapped three-site `AgreesOutsideWindow` `Iff` proofs into exactly two generic shared lemmas in `EmbedLocalOperatorTwoSite.lean`:

- `agreesOutsideWindow_finThreeArrowEquiv_three_zero` — agreement outside a length-two window at the first site holds iff the third coordinates coincide.
- `agreesOutsideWindow_finThreeArrowEquiv_three_one` — agreement outside a length-two window at the second site holds iff the first coordinates coincide.

These were duplicated across two files with identical proof bodies (a `constructor` of two cases each):

| Source file | Consumer theorem | Visibility |
|---|---|---|
| `PhysicalSectorBondCommutativity.lean` | `reindex_embedLocalOperator_zero` | public |
| `PhysicalSectorBondCommutativity.lean` | `reindex_embedLocalOperator_one` | public |
| `IsometricAdjacentBondTransport.lean` | `reindex_embedLocalOperator_three_zero` | `private` |
| `IsometricAdjacentBondTransport.lean` | `reindex_embedLocalOperator_three_one` | `private` |

Each consumer now reads its `hAgree` as a single-line application of the shared lemma. The enclosing statements and visibility are preserved: the public theorems remain public and the private wrappers remain private, with their distinct `hσ`/`hτ` extraction lemmas intact (these remain raw and distinct, as required).

## What changed

- `TNLean/MPS/MPDO/EmbedLocalOperatorTwoSite.lean`: added the two shared lemmas (+ `FinTupleEquiv` import for `finThreeArrowEquiv`).
- `TNLean/MPS/MPDO/PhysicalSectorBondCommutativity.lean`: replaced two duplicated `hAgree` blocks with lemma applications (+ `EmbedLocalOperatorTwoSite` import).
- `TNLean/MPS/MPDO/IsometricAdjacentBondTransport.lean`: replaced two duplicated `hAgree` blocks with lemma applications.

Net: +50 / −54 lines.

## Verification

- `lake build` (full, 10079 jobs): success.
- Style linter (`lake exe lint_style`) on the three changed files: clean.
- `leanblueprint checkdecls`: clean — all blueprint-referenced declarations exist; no Blueprint coverage/dependency update is required (the shared lemmas are internal helpers, not referenced by any `\\lean{}` tag).
- `sorry`/`axiom` scan in changed files: none.

No Blueprint changes were required: the shared lemmas are internal proof helpers and no `\\lean{}` tag references them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactoring with no statement or visibility changes; only shared helper lemmas replace duplicated inline proofs.
> 
> **Overview**
> Extracts duplicated three-site `AgreesOutsideWindow` characterizations into two shared lemmas in `EmbedLocalOperatorTwoSite.lean`, then reuses them from the physical-sector and isometric bond-transport proofs.
> 
> **`agreesOutsideWindow_finThreeArrowEquiv_three_zero`** and **`agreesOutsideWindow_finThreeArrowEquiv_three_one`** replace identical inline `hAgree` blocks in `reindex_embedLocalOperator_zero`/`one` and the private three-site wrappers. Enclosing theorem statements and visibility are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103bd1df0b8d42a49410ddd7b9b37ea976ed646f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->