### PR TITLE
chore(MPS/MPDO): import PureRecovery from its actual consumer

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.FusionIsometries
+import TNLean.MPS.MPDO.PureRecovery
 
 /-!
 # Counterexample to the support-algebra converse

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import Mathlib.Algebra.Module.Submodule.LinearMap
 import TNLean.MPS.Core.BlockingTransfer
-import TNLean.MPS.MPDO.PureRecovery
 import TNLean.MPS.MPDO.ZCL
 
 /-!


### PR DESCRIPTION
## Summary

Retargets the `PureRecovery` import to its actual consumer, as specified in #6211 (part of tracker #6205).

- Adds `import TNLean.MPS.MPDO.PureRecovery` directly to `TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean`, the actual consumer of `MPSTensor.toMPOTensor` and `toMPOTensor_transferMap`.
- Removes the unused `PureRecovery` import from `TNLean/MPS/MPDO/FusionIsometries.lean`, which uses nothing from it.

This follows the rejected isolated deletion in #6207: the import is not used by `FusionIsometries`, but it supplied the only non-umbrella path for `AlgebraFusionCounterexample`.

## API preservation

All declarations, proofs, and the `TransferRetractData` API are unchanged. The diff is import-only (one line added, one line removed).

## Aggregator regeneration

`python3 scripts/generate_import_aggregators.py` was run. The MPDO aggregator (`TNLean/MPS/MPDO.lean`) already imported all three modules directly, so no generated files changed. `--check` confirms the import frontier is current.

## Validation

- `lake build TNLean.MPS.MPDO.FusionIsometries` ✔
- `lake build TNLean.MPS.MPDO.AlgebraStructure` ✔
- `lake build TNLean.MPS.MPDO.AlgebraFusionCounterexample` ✔
- `lake build TNLean.MPS.MPDO` (aggregator + representative consumers) ✔
- `lake build` (full, 10079 jobs) ✔
- `python3 scripts/generate_import_aggregators.py --check` ✔
- No `sorry`/`axiom` introduced.

Closes #6211.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no logic, API, or security-sensitive changes.
> 
> **Overview**
> Retargets the `PureRecovery` import so it lives with the module that actually uses it.
> 
> Adds `import TNLean.MPS.MPDO.PureRecovery` to `AlgebraFusionCounterexample`, which needs `MPSTensor.toMPOTensor` and `toMPOTensor_transferMap`. Removes the unused import from `FusionIsometries`. No declarations or proofs change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b33dd1797d79e4598966c9bf8e18f8ddee4fb19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->