### PR TITLE
fix(parent-hamiltonian): generalize martingale coordinates

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
@@ -50,15 +50,15 @@ for eigenvectors of \(H\) — follows by the spectral theorem. This lemma
 provides the final spectral-theorem step; the remaining MPS-specific
 quadratic-form hypothesis is stated separately in
 `MPSTensor.parentHamiltonianES_gap_bound_of_overlap_norm_bound`. -/
-theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 < γ)
-    {H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (hH : H.IsPositive)
+theorem spectralGap_of_martingale {E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace ℂ E] [FiniteDimensional ℂ E] {γ : ℝ} (hγ : 0 < γ)
+    {H : E →ₗ[ℂ] E} (hH : H.IsPositive)
     (hOpIneq : ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
     ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ := by
   classical
   -- Spectral setup: diagonalise the positive symmetric operator.
-  set n := Fintype.card ι with hn_def
-  have hn : Module.finrank ℂ (EuclideanSpace ℂ ι) = n := by
-    simp [hn_def]
+  set n := Module.finrank ℂ E with hn_def
+  have hn : Module.finrank ℂ E = n := hn_def.symm
   have hSym : H.IsSymmetric := hH.isSymmetric
   set b := hSym.eigenvectorBasis hn with hb_def
   set μ : Fin n → ℝ := hSym.eigenvalues hn with hμ_def

--- a/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
@@ -50,7 +50,7 @@ for eigenvectors of \(H\) — follows by the spectral theorem. This lemma
 provides the final spectral-theorem step; the remaining MPS-specific
 quadratic-form hypothesis is stated separately in
 `MPSTensor.parentHamiltonianES_gap_bound_of_overlap_norm_bound`. -/
-theorem spectralGap_of_martingale {E : Type*} [NormedAddCommGroup E]
+theorem spectralGap_of_martingale_of_finiteDimensional {E : Type*} [NormedAddCommGroup E]
     [InnerProductSpace ℂ E] [FiniteDimensional ℂ E] {γ : ℝ} (hγ : 0 < γ)
     {H : E →ₗ[ℂ] E} (hH : H.IsPositive)
     (hOpIneq : ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
@@ -129,5 +129,12 @@ theorem spectralGap_of_martingale {E : Type*} [NormedAddCommGroup E]
   have h3 : 0 ≤ ‖H v‖ := norm_nonneg _
   have hsqrt := Real.sqrt_le_sqrt h1
   rwa [Real.sqrt_sq h2, Real.sqrt_sq h3] at hsqrt
+
+/-- Coordinate-space specialization of the finite-dimensional martingale criterion. -/
+theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 < γ)
+    {H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (hH : H.IsPositive)
+    (hOpIneq : ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :
+    ∀ v ∈ (LinearMap.ker H)ᗮ, γ * ‖v‖ ≤ ‖H v‖ :=
+  spectralGap_of_martingale_of_finiteDimensional hγ hH hOpIneq
 
 end FrustrationFree

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -69,7 +69,7 @@ theorem parentHamiltonianES_norm_bound_of_quadratic_form
   intro N hLN v hv
   have hvKer : v ∈ (LinearMap.ker (parentHamiltonianES A L N))ᗮ := by
     simpa [parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES A L N] using hv
-  exact FrustrationFree.spectralGap_of_martingale (ι := Cfg d N) hγ
+  exact FrustrationFree.spectralGap_of_martingale (E := EuclideanSpace ℂ (Cfg d N)) hγ
     (parentHamiltonianES_isPositive A L N) (hQuad N hLN) v hvKer
 
 /-- The exact explicit gap-bound reduction needed by
@@ -843,6 +843,7 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_
   exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le
     A L hL hγpos hγle hηle hOpNorm
 
+open Classical in
 /-- Combined martingale criterion for a finite family of symmetric projections.
 
 If the anticommutator forms satisfy row- and column-summable bounds with
@@ -852,9 +853,10 @@ both the quadratic-form inequality
 for every \(v\), and the norm lower bound \(γ ‖v‖ ≤ ‖H v‖\) on
 \((\ker H)^\perp\), because \(H\) is positive (a sum of positive maps). -/
 theorem spectralGap_of_martingale_anticommutator_rowCol
-    {ι : Type*} [Fintype ι] [DecidableEq ι] {ι' : Type*} [Fintype ι']
+    {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
+    [InnerProductSpace ℂ E] [FiniteDimensional ℂ E]
     {γ : ℝ} (hγpos : 0 < γ) (hγle : γ ≤ 1)
-    (P : ι → EuclideanSpace ℂ ι' →ₗ[ℂ] EuclideanSpace ℂ ι')
+    (P : ι → E →ₗ[ℂ] E)
     (hP : ∀ i, (P i).IsSymmetricProjection)
     (c : ι → ι → ℝ)
     (hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
@@ -870,7 +872,7 @@ theorem spectralGap_of_martingale_anticommutator_rowCol
     ProjectionGeometry.quadraticForm_sum_projections_of_anticommutator_rowCol
       hγle P hP c hRow hCol hAnti
   refine ⟨hQuad, fun v hv => ?_⟩
-  exact FrustrationFree.spectralGap_of_martingale (ι := ι') hγpos
+  exact FrustrationFree.spectralGap_of_martingale hγpos
     (LinearMap.isPositive_sum Finset.univ fun i _ => (hP i).isPositive)
     hQuad v hv
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -69,7 +69,7 @@ theorem parentHamiltonianES_norm_bound_of_quadratic_form
   intro N hLN v hv
   have hvKer : v ∈ (LinearMap.ker (parentHamiltonianES A L N))ᗮ := by
     simpa [parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES A L N] using hv
-  exact FrustrationFree.spectralGap_of_martingale (E := EuclideanSpace ℂ (Cfg d N)) hγ
+  exact FrustrationFree.spectralGap_of_martingale (ι := Cfg d N) hγ
     (parentHamiltonianES_isPositive A L N) (hQuad N hLN) v hvKer
 
 /-- The exact explicit gap-bound reduction needed by
@@ -852,7 +852,7 @@ both the quadratic-form inequality
 \(γ \operatorname{Re}\langle Hv, v\rangle \le \operatorname{Re}\langle Hv, Hv\rangle\)
 for every \(v\), and the norm lower bound \(γ ‖v‖ ≤ ‖H v‖\) on
 \((\ker H)^\perp\), because \(H\) is positive (a sum of positive maps). -/
-theorem spectralGap_of_martingale_anticommutator_rowCol
+theorem spectralGap_of_martingale_anticommutator_rowCol_of_finiteDimensional
     {ι E : Type*} [Fintype ι] [NormedAddCommGroup E]
     [InnerProductSpace ℂ E] [FiniteDimensional ℂ E]
     {γ : ℝ} (hγpos : 0 < γ) (hγle : γ ≤ 1)
@@ -872,8 +872,42 @@ theorem spectralGap_of_martingale_anticommutator_rowCol
     ProjectionGeometry.quadraticForm_sum_projections_of_anticommutator_rowCol
       hγle P hP c hRow hCol hAnti
   refine ⟨hQuad, fun v hv => ?_⟩
-  exact FrustrationFree.spectralGap_of_martingale hγpos
+  exact FrustrationFree.spectralGap_of_martingale_of_finiteDimensional hγpos
     (LinearMap.isPositive_sum Finset.univ fun i _ => (hP i).isPositive)
     hQuad v hv
+
+/-- Coordinate-space specialization of the combined martingale criterion. -/
+theorem spectralGap_of_martingale_anticommutator_rowCol
+    {ι : Type*} [Fintype ι] [DecidableEq ι] {ι' : Type*} [Fintype ι']
+    {γ : ℝ} (hγpos : 0 < γ) (hγle : γ ≤ 1)
+    (P : ι → EuclideanSpace ℂ ι' →ₗ[ℂ] EuclideanSpace ℂ ι')
+    (hP : ∀ i, (P i).IsSymmetricProjection)
+    (c : ι → ι → ℝ)
+    (hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
+    (hCol : ∀ j, (∑ i ∈ Finset.univ.erase j, c i j) ≤ 1)
+    (hAnti : ∀ i j, j ∈ Finset.univ.erase i → ∀ v,
+      -(1 - γ) * c i j *
+          ((⟪P i v, v⟫_ℂ).re + (⟪P j v, v⟫_ℂ).re) ≤
+        (⟪P i v, P j v⟫_ℂ).re + (⟪P j v, P i v⟫_ℂ).re) :
+    (∀ v, γ * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤ (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re) ∧
+    ∀ v ∈ (LinearMap.ker (∑ i, P i))ᗮ, γ * ‖v‖ ≤ ‖(∑ i, P i) v‖ := by
+  let oldDecEq : DecidableEq ι := inferInstance
+  letI : DecidableEq ι := Classical.decEq ι
+  have erase_eq (i : ι) :
+      @Finset.erase ι oldDecEq Finset.univ i = Finset.univ.erase i := by
+    ext j
+    simp
+  apply spectralGap_of_martingale_anticommutator_rowCol_of_finiteDimensional
+    hγpos hγle P hP c
+  · intro i
+    rw [← erase_eq i]
+    exact hRow i
+  · intro j
+    rw [← erase_eq j]
+    exact hCol j
+  · intro i j hj v
+    apply hAnti i j
+    rw [erase_eq i]
+    exact hj
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_local_terms.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_local_terms.tex
@@ -1,9 +1,21 @@
+\begin{definition}[Three-coordinate identification]
+    \label{def:three_coordinate_identification}
+    \lean{finThreeArrowEquiv}
+    \leanok
+    For every type $\alpha$, evaluation at the three coordinates gives the
+    canonical equivalence
+    \begin{align}
+        (\Fin 3\to\alpha)&\simeq\alpha\times(\alpha\times\alpha),
+        &x&\longmapsto\bigl(x(0),(x(1),x(2))\bigr).
+        \notag
+    \end{align}
+\end{definition}
+
 \begin{definition}[Overlapping two-site supports]\label{def:overlapping_two_site_supports}
     \lean{MPSTensor.axPairCfg}
     \lean{MPSTensor.xbPairCfg}
     \lean{MPSTensor.replaceAXCfg}
     \lean{MPSTensor.replaceXBCfg}
-    \lean{finThreeArrowEquiv}
     \lean{MPSTensor.leftPairLift}
     \lean{MPSTensor.rightPairLift}
     \lean{MPSTensor.leftPairLift_sub}
@@ -19,8 +31,8 @@
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation.complement}
     \lean{MPSTensor.adjacent_twoSite_cyclicWindowsOverlap}
     \leanok
-    \uses{def:nsite_space_parent, def:cyclic_window_support,
-        def:cyclic_windows_overlap}
+    \uses{def:three_coordinate_identification, def:nsite_space_parent,
+        def:cyclic_window_support, def:cyclic_windows_overlap}
     On a three-site space
     $\mc H_A\otimes\mc H_X\otimes\mc H_B$, let $Q_{AX}$ and $Q_{XB}$ be
     two-site projectors. Their local actions on the three-site space are the
@@ -292,8 +304,7 @@
     \lean{MPSTensor.isNNCPH_of_twoSite_cyclicWindowsOverlap_commute}
     \leanok
     \uses{def:is_commuting_parent_ham, def:is_nncph,
-        def:cyclic_windows_overlap, lem:cyclic_window_nonoverlap_positive,
-        lem:transported_es_nonoverlap_positive}
+        def:cyclic_windows_overlap}
     Let $L\le N$. Suppose that $h_i h_j=h_j h_i$ whenever the length-$L$
     cyclic supports of the two local terms meet. Then the parent Hamiltonian
     has commuting local terms: $h_i h_j=h_j h_i$ for all $i,j$. In the case

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_local_terms.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_local_terms.tex
@@ -5,9 +5,13 @@
     For every type $\alpha$, evaluation at the three coordinates gives the
     canonical equivalence
     \begin{align}
-        (\Fin 3\to\alpha)&\simeq\alpha\times(\alpha\times\alpha),
-        &x&\longmapsto\bigl(x(0),(x(1),x(2))\bigr).
-        \notag
+        (\Fin 3\to\alpha)&\simeq\alpha\times(\alpha\times\alpha).
+        \label{eq:ph_three_coordinate_equiv}
+    \end{align}
+    Its forward map is
+    \begin{align}
+        x&\longmapsto\bigl(x(0),(x(1),x(2))\bigr).
+        \label{eq:ph_three_coordinate_forward}
     \end{align}
 \end{definition}
 
@@ -31,8 +35,8 @@
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation.complement}
     \lean{MPSTensor.adjacent_twoSite_cyclicWindowsOverlap}
     \leanok
-    \uses{def:three_coordinate_identification, def:nsite_space_parent,
-        def:cyclic_window_support, def:cyclic_windows_overlap}
+    \uses{def:nsite_space_parent, def:cyclic_window_support,
+        def:cyclic_windows_overlap}
     On a three-site space
     $\mc H_A\otimes\mc H_X\otimes\mc H_B$, let $Q_{AX}$ and $Q_{XB}$ be
     two-site projectors. Their local actions on the three-site space are the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
@@ -345,7 +345,7 @@
 
 \begin{lemma}[Quadratic form to norm bound]
     \label{lem:quadratic_form_to_norm_bound}
-    \lean{FrustrationFree.spectralGap_of_martingale}
+    \lean{FrustrationFree.spectralGap_of_martingale_of_finiteDimensional}
     \leanok
     Let $H$ be a positive semidefinite self-adjoint operator on a
     finite-dimensional complex Hilbert space, and suppose that, for all $v$,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -657,7 +657,7 @@ norm estimate is derived here.
 
 \begin{theorem}[Martingale criterion for a finite family of projections]
     \label{thm:martingale_criterion}
-    \lean{MPSTensor.spectralGap_of_martingale_anticommutator_rowCol}
+    \lean{MPSTensor.spectralGap_of_martingale_anticommutator_rowCol_of_finiteDimensional}
     \leanok
     \uses{lem:anticommutator_projection_rowsum_reduction,
         lem:quadratic_form_to_norm_bound}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -545,7 +545,7 @@ section.
     \lean{MPOTensor.physCloseN_three_apply, MPOTensor.physClose3_apply,
       MPOTensor.physCloseN_three_eq_physClose3}
     \leanok
-    \uses{def:phys_close, def:overlapping_two_site_supports}
+    \uses{def:phys_close, def:three_coordinate_identification}
     The general three-site physical closure has coefficients
     \begin{align}
         M_3(X)_{(i_0,(i_1,i_2)),(j_0,(j_1,j_2))}


### PR DESCRIPTION
## What changed

- generalize `FrustrationFree.spectralGap_of_martingale` and `MPSTensor.spectralGap_of_martingale_anticommutator_rowCol` from coordinate Euclidean spaces to arbitrary finite-dimensional complex Hilbert spaces
- localize decidable equality for the finite projection index while preserving both capstone conclusions
- give `finThreeArrowEquiv` a dedicated Blueprint definition stating `(Fin 3 → α) ≃ α × (α × α)` and connect its two direct consumers
- keep cyclic-window nonoverlap and transported-locality lemmas as proof dependencies only for the commuting overlap reduction

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Reduction`
- `lake build` (10079 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- exact ownership and direct-dependency audit for the three reviewed declarations
- `cd blueprint && leanblueprint pdf && leanblueprint web`
- `python3 scripts/check_tenkz_dispositions.py` (202 Blueprint occurrences and 9 standalone fixtures)
- `scripts/tenkz_golden.sh --check` (9/9 event streams byte-identical)
- `git diff --check`

Closes #6215

Part of #6205.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core spectral-gap theorems used by the parent-Hamiltonian martingale chain, including a DecidableEq bridging specialization that could affect dependent proofs. Logic is largely a type generalization with preserved coordinate-space APIs.
> 
> **Overview**
> **Generalizes** the abstract martingale criteria from `EuclideanSpace` to arbitrary finite-dimensional complex Hilbert spaces.
> 
> `FrustrationFree.spectralGap_of_martingale` becomes `spectralGap_of_martingale_of_finiteDimensional`, and `MPSTensor.spectralGap_of_martingale_anticommutator_rowCol` gets the same treatment. The old names remain as thin coordinate-space specializations; the anticommutator wrapper bridges `DecidableEq` instances so existing callers keep working.
> 
> Blueprint updates point lean refs at the generalized theorems, give `finThreeArrowEquiv` its own definition, and trim commuting-overlap / three-site closure dependency annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1167019391352f4ef0330b142803ef7853bf228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->