### PR TITLE
feat(MPU): package the reduced-CFII forced-block supplier

### DIFF
--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPU.SimpleBlocking
+import TNLean.MPS.MPU.TransferStabilization
 
 /-!
 # Matching blocked contractions and output-tail coisometry
@@ -173,5 +174,56 @@ theorem IsMPU.blockTensor_mul_sq_simple_contractions_of_transfer_power
   · intro i j k l
     have hijkl := hs.2 (e i) (e j) (e k) (e l)
     simpa only [e, ← htensor, doubleLayerTensor_reindexPhysical] using hijkl
+
+/-- A reduced full-support canonical-form-II representative supplies the
+normalized positive fixed pair and the exact aligned simple contractions on
+the forced block of length \(J D^2\), where \(J = D^2 - 1\).
+
+All fixed-point data and both contractions refer to the same original tensor
+and its direct block; no source-cut factorization or source-v isometry is
+asserted.
+
+Source: arXiv:1703.09188, equations `Erightleft`, `simple1`, and `simple2`,
+lines 397--427; the resulting simple tensor is the input used in Theorem
+`ThmFund1`, lines 563--601.
+
+**Scope restriction (full active support):** This packages the chosen reduced
+representative supplied by
+`IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii`. See
+`docs/paper-gaps/mpu_canonical_form_full_support.tex`.
+
+**Local fix (nil-matrix length):** the second blocking uses \(D^2\); see
+`docs/paper-gaps/mpu_nil_matrix_bound.tex`. -/
+theorem IsMPU.exists_reduced_cfii_forced_block_simple_contractions
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) (hD : 1 < D)
+    (cfii : MPSTensor.CPSVCanonicalFormIIData U.normalizedFlattening)
+    (hfull : cfii.toCPSVCanonicalFormData.HasFullActiveSupport) :
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ,
+      ρ.PosDef ∧ Matrix.trace ρ = 1 ∧
+      MPSTensor.transferMap U.normalizedFlattening ρ = ρ ∧
+      Matrix.vecMul (1 : Matrix (Fin D) (Fin D) ℂ).vec
+          (transferMatrix (MPSTensor.transferMap U.normalizedFlattening)) =
+        (1 : Matrix (Fin D) (Fin D) ℂ).vec ∧
+      transferMatrix (MPSTensor.transferMap U.normalizedFlattening) ^ (D * D - 1) =
+        Matrix.vecMulVec ρ.vec (1 : Matrix (Fin D) (Fin D) ℂ).vec ∧
+      let J := D * D - 1
+      let ρ' : Fin (D * D) → ℂ := fun i ↦ ρ.vec (finProdFinEquiv.symm i)
+      let Φ' : Fin (D * D) → ℂ := fun i ↦
+        (1 : Matrix (Fin D) (Fin D) ℂ).vec (finProdFinEquiv.symm i)
+      (∀ i j : Fin (MPSTensor.blockPhysDim d (J * (D * D))),
+        Φ' ⬝ᵥ (doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *ᵥ ρ') =
+          if i = j then 1 else 0) ∧
+      (∀ i j k l : Fin (MPSTensor.blockPhysDim d (J * (D * D))),
+        doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *
+            doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l =
+          doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) i j *
+            Matrix.vecMulVec ρ' Φ' *
+              doubleLayerTensor (MPOTensor.blockTensor U (J * (D * D))) k l) := by
+  obtain ⟨_, _, ρ, _, _, _, _, _, _, hρpd, hρtrace, hρfix, hΦfix, hpower⟩ :=
+    hU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii hD cfii hfull
+  have hJ : 0 < D * D - 1 := Nat.sub_pos_of_lt (by nlinarith)
+  have hs := hU.blockTensor_mul_sq_simple_contractions_of_transfer_power
+    ρ hρtrace (D * D - 1) hJ hpower
+  exact ⟨ρ, hρpd, hρtrace, hρfix, hΦfix, hpower, hs⟩
 
 end MPOTensor

--- a/TNLean/MPS/MPU/MatchingContractions.lean
+++ b/TNLean/MPS/MPU/MatchingContractions.lean
@@ -183,11 +183,11 @@ All fixed-point data and both contractions refer to the same original tensor
 and its direct block; no source-cut factorization or source-v isometry is
 asserted.
 
-Source: arXiv:1703.09188, equations `Erightleft`, `simple1`, and `simple2`,
-lines 397--427; the resulting simple tensor is the input used in Theorem
-`ThmFund1`, lines 563--601.
+Source: arXiv:1703.09188, Section III.A, lines 397--427. The forced simple
+block is subsequently used in Lemma III.7, lines 550--556; Theorem III.8 uses
+that lemma at lines 589 and 592.
 
-**Scope restriction (full active support):** This packages the chosen reduced
+**Scope restriction (full active support):** This uses the chosen reduced
 representative supplied by
 `IsMPU.normalized_transfer_power_eq_vecMulVec_of_reduced_cfii`. See
 `docs/paper-gaps/mpu_canonical_form_full_support.tex`.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3889,8 +3889,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \label{thm:mpu_reduced_cfii_forced_block_simple_contractions}
     \lean{MPOTensor.IsMPU.exists_reduced_cfii_forced_block_simple_contractions}
     \leanok
-    \uses{thm:mpu_matching_direct_block_contractions,
-        thm:mpu_reduced_cfii_transfer_stabilization}
+    \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
+        def:mpu_full_active_support,def:mpdo_positive_physical_blocking,
+        def:mpu_double_layer}
     Let $d>0$, $D>1$, and let $\mathcal U$ be an MPU whose normalized
     flattening has chosen canonical-form-II data with full active support. Put
     $J=D^2-1$ and $W=\mathcal U_{JD^2}$. There is a matrix $\rho>0$ with
@@ -3914,6 +3915,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_matching_direct_block_contractions,
+        thm:mpu_reduced_cfii_transfer_stabilization}
     Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization} gives the
     positive trace-one fixed matrix and the identity
     $E^J=\lvert\rho)(\Phi\rvert$. Applying

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3885,6 +3885,42 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     factorization for the stabilized power.
 \end{proof}
 
+\begin{theorem}[Reduced-CFII data for the forced simple block]
+    \label{thm:mpu_reduced_cfii_forced_block_simple_contractions}
+    \lean{MPOTensor.IsMPU.exists_reduced_cfii_forced_block_simple_contractions}
+    \leanok
+    \uses{thm:mpu_matching_direct_block_contractions,
+        thm:mpu_reduced_cfii_transfer_stabilization}
+    Let $d>0$, $D>1$, and let $\mathcal U$ be an MPU whose normalized
+    flattening has chosen canonical-form-II data with full active support. Put
+    $J=D^2-1$ and $W=\mathcal U_{JD^2}$. There is a matrix $\rho>0$ with
+    $\tr(\rho)=1$ such that
+    \begin{align}
+        E\lvert\rho)&=\lvert\rho),
+        &(\Phi\rvert E&=(\Phi\rvert,
+        &E^J&=\lvert\rho)(\Phi\rvert.
+    \end{align}
+    With the corresponding vectorized pair $\rho',\Phi'$, the same blocked
+    tensor $W$ satisfies the two aligned simple contractions
+    \begin{align}
+        \Phi'\mathbin{\boldsymbol\cdot}W^{ij}\rho'
+          &=\delta_{ij},\\
+        W^{ij}W^{k\ell}
+          &=W^{ij}\lvert\rho')(\Phi'\rvert W^{k\ell}.
+    \end{align}
+    This theorem supplies only the fixed pair and the two simple contractions.
+    It does not assert a source-cut factorization or source-$v$ isometry.
+    % Source lines: paper_v2.tex 397--427, 550--556, 589, and 592.
+\end{theorem}
+
+\begin{proof}\leanok
+    Theorem~\ref{thm:mpu_reduced_cfii_transfer_stabilization} gives the
+    positive trace-one fixed matrix and the identity
+    $E^J=\lvert\rho)(\Phi\rvert$. Applying
+    Theorem~\ref{thm:mpu_matching_direct_block_contractions} with this pair
+    gives both contractions on the direct block $W=\mathcal U_{JD^2}$.
+\end{proof}
+
 \begin{definition}[Source-$v$ Gram counterexample data]
     \label{def:mpu_source_v_gram_counterexample_data}
     \lean{MPOTensor.SourceVCounterexample.bondMatrix,


### PR DESCRIPTION
## What changed

- package the positive normalized fixed pair supplied by reduced CFII and full active support
- expose the stabilized rank-one transfer power together with aligned `simple1` and `simple2` contractions on the same forced block of length `(D² - 1)D²`
- keep the unresolved source-v dressed-Gram contraction outside this theorem

## Validation

- `lake build TNLean.MPS.MPU.MatchingContractions`
- `lake build TNLean.MPS.MPU`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff origin/main...HEAD --check`

Closes #6225. Advances #6067.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; proof is a thin composition of existing MPU lemmas with no runtime or security impact.
> 
> **Overview**
> Adds a single **supplier theorem** for the MPU Gram pipeline: from an MPU with chosen reduced canonical-form-II data and **full active support**, it proves existence of a positive trace-one \(\rho\), the normalized transfer fixed pair, the stabilized power \(E^{D^2-1} = |\rho)(\Phi|\), and the aligned **`simple1` / `simple2`** contractions on the forced direct block \(W = \mathcal U_{(D^2-1)D^2}\).
> 
> The Lean proof only wires `normalized_transfer_power_eq_vecMulVec_of_reduced_cfii` to the existing `blockTensor_mul_sq_simple_contractions_of_transfer_power`; it explicitly does **not** claim source-cut factorization or source-\(v\) isometry. The blueprint chapter gains the matching theorem and a short proof citing transfer stabilization plus matching direct-block contractions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb59c1f0f4796e4e7c707b194384f79934ebc0ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->