### PR TITLE
refactor(parent-hamiltonian): single-source cyclic one-step offset

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -419,11 +419,11 @@ theorem cyclicForwardSite_forwardSite {N : ℕ} (i : Fin N) (a b : ℕ) :
   omega
 
 /-- The cyclic offset of the site \(i\), measured from its forward neighbour
-\(\mathrm{cyclicForwardSite}\,i\,1\), is \(N - 1\).
+`cyclicForwardSite i 1`, is \(N - 1\).
 
 When a cyclic window of length \(L \le N\) is shifted one site forward, the
 former starting site \(i\) wraps to cyclic offset \(N - 1\) relative to the new
-start \(\mathrm{cyclicForwardSite}\,i\,1\); equivalently, \(i\) lies exactly one
+start `cyclicForwardSite i 1`; equivalently, \(i\) lies exactly one
 step behind the new start on the cycle. -/
 theorem cyclicForwardSite_one_offset {N : ℕ} (i : Fin N) :
     (i.val + N - (cyclicForwardSite i 1).val) % N = N - 1 := by

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -418,6 +418,30 @@ theorem cyclicForwardSite_forwardSite {N : ℕ} (i : Fin N) (a b : ℕ) :
   congr 1
   omega
 
+/-- The cyclic offset of the site \(i\), measured from its forward neighbour
+\(\mathrm{cyclicForwardSite}\,i\,1\), is \(N - 1\).
+
+When a cyclic window of length \(L \le N\) is shifted one site forward, the
+former starting site \(i\) wraps to cyclic offset \(N - 1\) relative to the new
+start \(\mathrm{cyclicForwardSite}\,i\,1\); equivalently, \(i\) lies exactly one
+step behind the new start on the cycle. -/
+theorem cyclicForwardSite_one_offset {N : ℕ} (i : Fin N) :
+    (i.val + N - (cyclicForwardSite i 1).val) % N = N - 1 := by
+  by_cases hi : i.val + 1 < N
+  · have hval : (cyclicForwardSite i 1).val = i.val + 1 := by
+      simp [cyclicForwardSite, Nat.mod_eq_of_lt hi]
+    rw [hval]
+    have hsub : i.val + N - (i.val + 1) = N - 1 := by omega
+    rw [hsub]
+    exact Nat.mod_eq_of_lt (by omega)
+  · have hiN : i.val + 1 = N := by omega
+    have hval : (cyclicForwardSite i 1).val = 0 := by
+      simp [cyclicForwardSite, hiN]
+    rw [hval]
+    have hsub : i.val + N - 0 = (N - 1) + N := by omega
+    rw [hsub, Nat.add_mod_right]
+    exact Nat.mod_eq_of_lt (by omega)
+
 private theorem cyclicForwardSite_eq_mod_eq {N : ℕ} (i : Fin N) {a b : ℕ}
     (h : cyclicForwardSite i a = cyclicForwardSite i b) : a % N = b % N := by
   have hval := congrArg Fin.val h
@@ -632,21 +656,8 @@ theorem cyclicRestrictₗ_restrictFirst {N L : ℕ} (hN : 0 < N) (hLN : L + 1 �
       have hk' := eq_cyclic_site_of_offset_eq (N := N) hN (i := i) (k := k) hzero
       simpa [Nat.mod_eq_of_lt i.isLt] using hk'
     subst k
-    have hshift_eq : (i.val + N - (cyclicForwardSite i 1).val) % N = N - 1 := by
-      by_cases hi : i.val + 1 < N
-      · have hval : (cyclicForwardSite i 1).val = i.val + 1 := by
-          simp [cyclicForwardSite, Nat.mod_eq_of_lt hi]
-        rw [hval]
-        have hsub : i.val + N - (i.val + 1) = N - 1 := by omega
-        rw [hsub]
-        exact Nat.mod_eq_of_lt (by omega)
-      · have hiN : i.val + 1 = N := by omega
-        have hval : (cyclicForwardSite i 1).val = 0 := by
-          simp [cyclicForwardSite, hiN]
-        rw [hval]
-        have hsub : i.val + N - 0 = (N - 1) + N := by omega
-        rw [hsub, Nat.add_mod_right]
-        exact Nat.mod_eq_of_lt (by omega)
+    have hshift_eq : (i.val + N - (cyclicForwardSite i 1).val) % N = N - 1 :=
+      cyclicForwardSite_one_offset i
     have hshift : ¬((i.val + N - (cyclicForwardSite i 1).val) % N < L) := by
       rw [hshift_eq]
       omega

--- a/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
@@ -154,21 +154,8 @@ private theorem replaceWindow_three_replaceWindow_two_right
       simpa [Nat.mod_eq_of_lt i.isLt] using hk'
     subst k
     have hshift_eq :
-        (i.val + N - (cyclicForwardSite i 1).val) % N = N - 1 := by
-      by_cases hi : i.val + 1 < N
-      · have hval : (cyclicForwardSite i 1).val = i.val + 1 := by
-          simp [cyclicForwardSite, Nat.mod_eq_of_lt hi]
-        rw [hval]
-        have hsub : i.val + N - (i.val + 1) = N - 1 := by omega
-        rw [hsub]
-        exact Nat.mod_eq_of_lt (by omega)
-      · have hiN : i.val + 1 = N := by omega
-        have hval : (cyclicForwardSite i 1).val = 0 := by
-          simp [cyclicForwardSite, hiN]
-        rw [hval]
-        have hsub : i.val + N - 0 = (N - 1) + N := by omega
-        rw [hsub, Nat.add_mod_right]
-        exact Nat.mod_eq_of_lt (by omega)
+        (i.val + N - (cyclicForwardSite i 1).val) % N = N - 1 :=
+      cyclicForwardSite_one_offset i
     have hshift : ¬((i.val + N - (cyclicForwardSite i 1).val) % N < 2) := by
       rw [hshift_eq]
       omega

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -176,6 +176,7 @@
     \lean{MPSTensor.cyclicRestrictₗ_cyclicCfg_outside}
     \lean{MPSTensor.cyclicCfg_cyclicForwardSite}
     \lean{MPSTensor.eq_cyclic_site_of_offset_eq}
+    \lean{MPSTensor.cyclicForwardSite_one_offset}
     \lean{MPSTensor.cyclicRestrictₗ_restrictLast}
     \lean{MPSTensor.cyclicRestrictₗ_restrictFirst}
     \lean{MPSTensor.cyclicCfg_eq_contiguousCfg}


### PR DESCRIPTION
## What changed

- add the canonical cyclic-forward one-step offset identity in `CyclicWindow`
- reuse it in cyclic restriction and three-site local-support transport
- preserve all enclosing theorem statements, coordinate APIs, and private visibility

## Validation

- targeted ParentHamiltonian modules and direct consumers
- full `lake build`: 10,081 jobs
- `git diff --check`
- proof-integrity scan

Closes #6228
Advances #6227

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only DRY refactor with no runtime or API changes; behavior is unchanged aside from citing one canonical lemma.
> 
> **Overview**
> Factors a repeated cyclic-window arithmetic step into one shared lemma **`cyclicForwardSite_one_offset`**, which proves that site `i` has cyclic offset `N - 1` relative to `cyclicForwardSite i 1`.
> 
> **`cyclicRestrictₗ_restrictFirst`** and **`replaceWindow_three_replaceWindow_two_right`** now invoke that lemma instead of duplicating the same `by_cases` proof inline. The blueprint remark on cyclic interval restrictions links the new theorem for documentation parity.
> 
> No API or theorem-statement changes beyond this extraction and reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 886797667aaf5e772e565cb309bad499b5e28009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->