### PR TITLE
refactor(MPS): tighten MPDO and RFP import owners

### DIFF
--- a/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTThreeSiteCollapse
-import TNLean.MPS.MPDO.HayashiSectorComparison
+import TNLean.MPS.MPDO.SimpleLocalStructure
 
 /-!
 # Comparison of BNT and quantum-Markov sectors

--- a/TNLean/MPS/RFP/Defs.lean
+++ b/TNLean/MPS/RFP/Defs.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.Defs
 import TNLean.MPS.Core.Transfer
-import TNLean.Channel.Stinespring
 import TNLean.Channel.KrausFreedom
 
 /-!


### PR DESCRIPTION
## What changed

- import `SimpleLocalStructure` directly for `EtaStructure` in `BNTMarkovKeyFormula`
- remove redundant direct `Stinespring` import from `RFP.Defs`, retaining `KrausFreedom` as the actual owner
- leave declarations and public interfaces unchanged

## Validation

- targeted MPDO, RFP, and ParentHamiltonian consumers
- import-aggregator policy check
- full `lake build`: 10,081 jobs
- `git diff --check`

Closes #6229
Advances #6227

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with full build validation; no logic or interface changes.
> 
> **Overview**
> This PR only adjusts **import edges** in two MPS modules so each file pulls definitions from their declared owners; **no declarations or public APIs change**.
> 
> In **`BNTMarkovKeyFormula`**, the import of `HayashiSectorComparison` is replaced with a direct import of **`SimpleLocalStructure`**, which is where **`EtaStructure`** (used throughout the BNT/Markov key formulas) actually lives—avoiding a transitive dependency through Hayashi-specific comparison code.
> 
> In **`RFP/Defs`**, the redundant direct import of **`Stinespring`** is dropped; **`KrausFreedom`** remains as the module that supplies rectangular Kraus freedom used in the RFP ↔ Kraus isometry equivalence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee1a307a608064a2399c6f5b2e04296cf6419dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->