### PR TITLE
fix(blueprint): restore canonical dependency ownership

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex
@@ -104,6 +104,7 @@
     \lean{MPSTensor.AppendixBStructuralData.appendixBQAX_factor_action}
     \leanok
     \uses{def:appendixB_qax, thm:pair_lift_kronecker_matrices}
+    \uses{def:three_coordinate_identification}
     On the homogeneous three-single-site coefficient space
     $(\C^d)^{\otimes3}$, the hatted Appendix~B (AX) representative acts as
     $[\widehat Q_{AX}]_{AX} =[\widehat Q_{AX}]\otimes I_d$.
@@ -124,6 +125,7 @@
     \lean{MPSTensor.AppendixBStructuralData.appendixBQXB_factor_action}
     \leanok
     \uses{def:appendixB_qxb, thm:pair_lift_kronecker_matrices}
+    \uses{def:three_coordinate_identification}
     On the homogeneous three-single-site coefficient space
     $(\C^d)^{\otimes3}$, the hatted Appendix~B (XB) representative acts as
     $[\widehat Q_{XB}]_{XB} =I_d\otimes[\widehat Q_{XB}]$.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex
@@ -103,8 +103,8 @@
     \label{thm:appendixB_qax_factor_action}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQAX_factor_action}
     \leanok
-    \uses{def:appendixB_qax, thm:pair_lift_kronecker_matrices}
-    \uses{def:three_coordinate_identification}
+    \uses{def:appendixB_qax, thm:pair_lift_kronecker_matrices,
+        def:three_coordinate_identification}
     On the homogeneous three-single-site coefficient space
     $(\C^d)^{\otimes3}$, the hatted Appendix~B (AX) representative acts as
     $[\widehat Q_{AX}]_{AX} =[\widehat Q_{AX}]\otimes I_d$.
@@ -124,8 +124,8 @@
     \label{thm:appendixB_qxb_factor_action}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQXB_factor_action}
     \leanok
-    \uses{def:appendixB_qxb, thm:pair_lift_kronecker_matrices}
-    \uses{def:three_coordinate_identification}
+    \uses{def:appendixB_qxb, thm:pair_lift_kronecker_matrices,
+        def:three_coordinate_identification}
     On the homogeneous three-single-site coefficient space
     $(\C^d)^{\otimes3}$, the hatted Appendix~B (XB) representative acts as
     $[\widehat Q_{XB}]_{XB} =I_d\otimes[\widehat Q_{XB}]$.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_local_terms.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_local_terms.tex
@@ -97,8 +97,8 @@
     \lean{MPSTensor.leftPairLift_toMatrix_reindex}
     \lean{MPSTensor.rightPairLift_toMatrix_reindex}
     \leanok
-    \uses{def:overlapping_two_site_supports}
-    \uses{def:three_coordinate_identification}
+    \uses{def:overlapping_two_site_supports,
+        def:three_coordinate_identification}
     Let $\mc H=\C^d$, and let $Q$ be an endomorphism of
     $\mc H\otimes\mc H$. Under the canonical identifications of two- and
     three-site configurations with pairs and right-associated triples, the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_local_terms.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_local_terms.tex
@@ -98,6 +98,7 @@
     \lean{MPSTensor.rightPairLift_toMatrix_reindex}
     \leanok
     \uses{def:overlapping_two_site_supports}
+    \uses{def:three_coordinate_identification}
     Let $\mc H=\C^d$, and let $Q$ be an endomorphism of
     $\mc H\otimes\mc H$. Under the canonical identifications of two- and
     three-site configurations with pairs and right-associated triples, the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -111,7 +111,6 @@
     \leanok
     \uses{thm:mpdo_transported_vertical_sector_coefficient_comparison,
       def:vertical_cf_mpdo, def:mpdo_two_site_blocking}
-    \uses{thm:coisometry_reconstruction_same_mpv_pos}
     Under the hypotheses and with the sector correspondence of Theorem~
     \ref{thm:mpdo_transported_vertical_sector_coefficient_comparison}, let
     $B$ be the vertical reading of the two-site blocking, and write
@@ -145,8 +144,8 @@
 
 \begin{proof}\leanok
     \uses{thm:mpdo_operator_product_mpo, lem:mpv_vertical_assembled,
-      thm:mpdo_transported_vertical_sector_coefficient_comparison}
-    \uses{thm:coisometry_reconstruction_same_mpv_pos}
+      thm:mpdo_transported_vertical_sector_coefficient_comparison,
+      thm:coisometry_reconstruction_same_mpv_pos}
     The two-site vertical canonical form first gives
     $O_L(B)=\sum_\delta\tr(\nu_\delta^L)
     O_L(A^{(2)}_\delta)$.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -104,7 +104,6 @@
     \label{thm:mpdo_blocked_vertical_operator_representations}
     \lean{MPOTensor.transportedVerticalSector_exists_blockedOperatorRepresentations}
     \lean{MPOTensor.verticalBNTMPO_verticalTensor_blockTwo}
-    \lean{MPSTensor.sameMPV₂Pos_of_coisometry_reconstruction}
     \lean{MPOTensor.mpo_verticalBNTMPO_verticalAssembledTensor_eq_sum}
     \lean{MPOTensor.mpo_verticalBNTMPO_eq_sum_of_coisometry_reconstruction}
     \lean{MPOTensor.mpo_verticalBNTMPO_eq_pow_smul_of_unitary_reindex}
@@ -112,6 +111,7 @@
     \leanok
     \uses{thm:mpdo_transported_vertical_sector_coefficient_comparison,
       def:vertical_cf_mpdo, def:mpdo_two_site_blocking}
+    \uses{thm:coisometry_reconstruction_same_mpv_pos}
     Under the hypotheses and with the sector correspondence of Theorem~
     \ref{thm:mpdo_transported_vertical_sector_coefficient_comparison}, let
     $B$ be the vertical reading of the two-site blocking, and write
@@ -146,6 +146,7 @@
 \begin{proof}\leanok
     \uses{thm:mpdo_operator_product_mpo, lem:mpv_vertical_assembled,
       thm:mpdo_transported_vertical_sector_coefficient_comparison}
+    \uses{thm:coisometry_reconstruction_same_mpv_pos}
     The two-site vertical canonical form first gives
     $O_L(B)=\sum_\delta\tr(\nu_\delta^L)
     O_L(A^{(2)}_\delta)$.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
@@ -20,8 +20,8 @@
         def:mpdo_state_preparation_map,
         def:mpdo_equiv_reindex_map,
         def:mpdo_right_partial_trace_map,
-        def:mpdo_single_kraus_map}
-    \uses{def:trace_prepare_map}
+        def:mpdo_single_kraus_map,
+        def:trace_prepare_map}
     Let $P\in\MN{m}$ be an orthogonal projection, let
     $\rho\in\MN{n}$ be positive semidefinite with $\tr(\rho)=1$, and let
     $\mathcal E\colon\MN{m}\to\MN{n}$ be completely positive.  Define the
@@ -66,8 +66,8 @@
         lem:is_kraus_cp_comp,
         lem:is_kraus_cptp_comp,
         lem:is_kraus_cp_add,
-        thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving}
-    \uses{def:trace_prepare_map}
+        thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving,
+        def:trace_prepare_map}
     The map $\mathcal D_\rho$ factors as state preparation, interchange of
     the two tensor factors, and partial trace.  The map
     $X\mapsto(I-P)X(I-P)^\dagger$ has a single Kraus operator.  Thus the two

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
@@ -3,8 +3,6 @@
 \begin{theorem}[Trace-preserving completion outside a projection]
     \label{thm:matrix_support_completion_cptp}
     \lean{Matrix.supportCompletion_isKrausCPTP}
-    \lean{Matrix.tracePrepareMap}
-    \lean{Matrix.tracePrepareMap_apply}
     \lean{Matrix.tracePrepareMap_trace}
     \lean{Matrix.tracePrepareMap_isKrausCP}
     \lean{Matrix.tracePrepareMap_isKrausCPTP}
@@ -23,6 +21,7 @@
         def:mpdo_equiv_reindex_map,
         def:mpdo_right_partial_trace_map,
         def:mpdo_single_kraus_map}
+    \uses{def:trace_prepare_map}
     Let $P\in\MN{m}$ be an orthogonal projection, let
     $\rho\in\MN{n}$ be positive semidefinite with $\tr(\rho)=1$, and let
     $\mathcal E\colon\MN{m}\to\MN{n}$ be completely positive.  Define the
@@ -68,6 +67,7 @@
         lem:is_kraus_cptp_comp,
         lem:is_kraus_cp_add,
         thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving}
+    \uses{def:trace_prepare_map}
     The map $\mathcal D_\rho$ factors as state preparation, interchange of
     the two tensor factors, and partial trace.  The map
     $X\mapsto(I-P)X(I-P)^\dagger$ has a single Kraus operator.  Thus the two


### PR DESCRIPTION
## What changed

- retain generic ownership of coisometric reconstruction and trace-prepare declarations
- keep Chapter 21 contextual theorem leaves as consumers through direct statement/proof dependencies
- add three missing statement dependencies on the canonical three-coordinate identification
- leave cross-scope and ambiguous ownership clusters unchanged

## Validation

- unique declaration-tag counts
- Blueprint declaration sync and `leanblueprint checkdecls`
- Blueprint web and PDF builds
- tenkz lint on changed files
- full `lake build`: 10,081 jobs
- `git diff --check`

Closes #6230
Advances #6227

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Blueprint metadata (`\lean`, `\uses`) and declaration sync; no mathematical statements or Lean proof bodies are altered.
> 
> **Overview**
> This PR **realigns Blueprint `\lean` / `\uses` edges** so shared lemmas stay owned by their canonical declarations, while Chapter 13/21 theorems only **consume** them through explicit dependencies.
> 
> **Three-coordinate identification:** `thm:pair_lift_kronecker_matrices` and the Appendix B **(AX)/(XB) factor-action** theorems now list `def:three_coordinate_identification` in `\uses`, matching the matrix reindexing those Kronecker identities rely on.
> 
> **Coisometric reconstruction:** `thm:mpdo_blocked_vertical_operator_representations` drops the duplicate `\lean{MPSTensor.sameMPV₂Pos_of_coisometry_reconstruction}` tag from its header and instead cites `thm:coisometry_reconstruction_same_mpv_pos` in the proof `\uses` block.
> 
> **Trace-prepare map:** the CPTP completion theorem removes redundant `\lean` tags for `Matrix.tracePrepareMap` / `tracePrepareMap_apply` from the statement header and wires `def:trace_prepare_map` through `\uses` (statement and proof), keeping the generic definition in `ch19` as the single owner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f610c2db5428f99a759de224d3f24557be6ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->