### PR TITLE
fix(MPS/Periodic): add boundary-aware empty-chain decomposition

### DIFF
--- a/TNLean/MPS/Periodic/StateVectorDecomposition.lean
+++ b/TNLean/MPS/Periodic/StateVectorDecomposition.lean
@@ -173,13 +173,12 @@ state-vector decomposition at every length. For
   \operatorname{tr}(A^{i_0}\cdots A^{i_{N-1}})
     = \sum_u \operatorname{tr}(F_u(\sigma)).
 \]
-Here `cornerProd Q A u w` is the repeated corner-transition product starting
-with the boundary projector `Q u`. At length zero,
-\(\operatorname{evalWord}(A, []) = 1\) and
-\(\operatorname{cornerProd}(Q, A, u, []) = Q_u\), so the formula reads
-\(\operatorname{tr}(1) = \sum_u \operatorname{tr}(Q_u)\). It does not identify
-the empty `projectorComponentChain` coefficient, whose chain evaluation is
-\(1\) and hence forgets the boundary projector.
+Here `cornerProd` is the repeated corner-transition product starting with the
+boundary projector `Q u`. At length zero, `evalWord` gives
+\(A^{[]} = 1\), while `cornerProd` gives \(F_u([]) = Q_u\), so the formula
+reads \(\operatorname{tr}(1) = \sum_u \operatorname{tr}(Q_u)\). It does not
+identify the empty `projectorComponentChain` coefficient, whose chain evaluation
+is \(1\) and hence forgets the boundary projector.
 
 Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 5, lines 860--880. The
 empty-word convention is the formal extension of the source's inserted-projector
@@ -287,6 +286,22 @@ theorem exists_paper_cyclic_projectors_of_isPeriodic
   · intro k i
     exact negReindex_paper_shift A hA.leftCanonical hPproj hCyclic' k i
 
+/-- Adding a number of unit shifts divisible by `p` fixes every index in `Fin p`. -/
+private theorem add_nsmul_one_fin_eq_self_of_dvd [NeZero p]
+    {N : ℕ} (hdiv : p ∣ N) (u : Fin p) :
+    u + N • (1 : Fin p) = u := by
+  obtain ⟨k, rfl⟩ := hdiv
+  have hpzero : p • (1 : Fin p) = 0 := by
+    simpa only [Fintype.card_fin] using
+      (card_nsmul_eq_zero (x := (1 : Fin p)))
+  have hcycle : (p * k) • (1 : Fin p) = 0 := by
+    calc
+      (p * k) • (1 : Fin p) = k • (p • (1 : Fin p)) := by
+        rw [mul_comm, mul_nsmul']
+      _ = k • 0 := by rw [hpzero]
+      _ = 0 := nsmul_zero k
+  rw [hcycle, add_zero]
+
 /-- **PGVWC07 Theorem 5, boundary-aware periodic branch.**
 
 If \(p\mid N\), a period-\(p\) tensor supplies cyclic projectors and a
@@ -303,8 +318,10 @@ period, and peripheral spectrum equal to the \(p\)-th roots of unity.
 
 **Scope restriction (normalized orientation):** this theorem uses
 `IsPeriodic p A` rather than deriving these conditions from the one-block
-unital canonical hypotheses of the printed theorem. This boundary is recorded
-in `docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex`.
+unital canonical hypotheses of the printed theorem. At \(N=0\), its
+boundary-trace identity is a formal empty-word extension of the printed
+positive-chain calculation. Both boundaries are recorded in
+`docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex`.
 
 Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 5, lines 849--880. -/
 theorem pgvwc07_periodic_stateVector_boundary_decomposition_of_dvd
@@ -327,18 +344,7 @@ theorem pgvwc07_periodic_stateVector_boundary_decomposition_of_dvd
   refine ⟨Q, hQproj, hQsum, hshift, ?_, ?_, ?_⟩
   · intro u j i
     rfl
-  · obtain ⟨k, rfl⟩ := hdiv
-    intro u
-    have hpzero : p • (1 : Fin p) = 0 := by
-      simpa only [Fintype.card_fin] using
-        (card_nsmul_eq_zero (x := (1 : Fin p)))
-    have hcycle : (p * k) • (1 : Fin p) = 0 := by
-      calc
-        (p * k) • (1 : Fin p) = k • (p • (1 : Fin p)) := by
-          rw [mul_comm, mul_nsmul']
-        _ = k • 0 := by rw [hpzero]
-        _ = 0 := nsmul_zero k
-    rw [hcycle, add_zero]
+  · exact add_nsmul_one_fin_eq_self_of_dvd hdiv
   · exact mpv_eq_sum_trace_cornerProd Q A hQproj hQsum hshift
 
 /-- **PGVWC07 Theorem 5, periodic branch.**
@@ -381,18 +387,7 @@ theorem pgvwc07_periodic_stateVector_decomposition_of_dvd
   refine ⟨Q, hQproj, hQsum, hshift, ?_, ?_, ?_⟩
   · intro u j i
     rfl
-  · obtain ⟨k, rfl⟩ := hdiv
-    intro u
-    have hpzero : p • (1 : Fin p) = 0 := by
-      simpa only [Fintype.card_fin] using
-        (card_nsmul_eq_zero (x := (1 : Fin p)))
-    have hcycle : (p * k) • (1 : Fin p) = 0 := by
-      calc
-        (p * k) • (1 : Fin p) = k • (p • (1 : Fin p)) := by
-          rw [mul_comm, mul_nsmul']
-        _ = k • 0 := by rw [hpzero]
-        _ = 0 := nsmul_zero k
-    rw [hcycle, add_zero]
+  · exact add_nsmul_one_fin_eq_self_of_dvd hdiv
   · obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hN)
     exact mpv_eq_sum_projectorComponentChain_coeff Q A hQproj hQsum hshift
 

--- a/TNLean/MPS/Periodic/StateVectorDecomposition.lean
+++ b/TNLean/MPS/Periodic/StateVectorDecomposition.lean
@@ -154,6 +154,42 @@ private theorem cornerProd_eq_projector_mul_evalWord
       rw [Matrix.mul_assoc, (hQproj _).2]
     _ = Q u * evalWord A w := htransport.symm
 
+/-- At positive length, the trace of the boundary-aware corner product equals the
+coefficient of the corresponding explicit projector-component chain. -/
+theorem projectorComponentChain_coeff_eq_trace_cornerProd
+    (Q : Fin p → MatrixAlg D) (A : MPSTensor d D)
+    (hQproj : ∀ k, IsOrthogonalProjection (Q k))
+    (u : Fin p) (σ : Fin (N + 1) → Fin d) :
+    MPSChainTensor.coeff (projectorComponentChain Q A u (N + 1)) σ =
+      Matrix.trace (cornerProd Q A u (List.ofFn σ)) := by
+  rw [MPSChainTensor.coeff, projectorComponentChain_eval Q A hQproj]
+
+/-- Inserting the cyclic resolution of the identity gives a boundary-aware
+state-vector decomposition at every length:
+\[
+  \operatorname{tr}(A^{\sigma_1}\cdots A^{\sigma_N})
+    = \sum_u \operatorname{tr}(F_u^{\boldsymbol\sigma}).
+\]
+Here `cornerProd Q A u w` is the repeated corner-transition product starting
+with the boundary projector `Q u`. In particular, at length zero the convention
+is `evalWord A [] = 1` and `cornerProd Q A u [] = Q u`, so the formula reads
+`trace 1 = ∑ u, trace (Q u)`. It does not identify the empty
+`projectorComponentChain` coefficient, whose chain evaluation is `1` and hence
+forgets the boundary projector. -/
+theorem mpv_eq_sum_trace_cornerProd
+    (Q : Fin p → MatrixAlg D) (A : MPSTensor d D)
+    (hQproj : ∀ k, IsOrthogonalProjection (Q k))
+    (hQsum : ∑ k, Q k = 1)
+    (hshift : ∀ k i, Q k * A i = A i * Q (k + 1))
+    (σ : Fin N → Fin d) :
+    mpv A σ = ∑ u : Fin p, Matrix.trace (cornerProd Q A u (List.ofFn σ)) := by
+  simp only [mpv, coeff, cornerProd_eq_projector_mul_evalWord Q A hQproj hshift]
+  calc
+    (evalWord A (List.ofFn σ)).trace =
+        ((∑ u : Fin p, Q u) * evalWord A (List.ofFn σ)).trace := by rw [hQsum, one_mul]
+    _ = ∑ u : Fin p, (Q u * evalWord A (List.ofFn σ)).trace := by
+      rw [Finset.sum_mul, Matrix.trace_sum]
+
 /-- At every positive length, inserting the cyclic resolution of the identity
 splits an MPS coefficient into the sum of the explicit projector-component
 chain coefficients. -/
@@ -242,6 +278,60 @@ theorem exists_paper_cyclic_projectors_of_isPeriodic
     (convert (Equiv.sum_comp (Equiv.neg (Fin p)) P).trans hPsum using 1; rfl)
   · intro k i
     exact negReindex_paper_shift A hA.leftCanonical hPproj hCyclic' k i
+
+/-- **PGVWC07 Theorem 5, boundary-aware periodic branch.**
+
+If \(p\mid N\), a period-\(p\) tensor supplies cyclic projectors and a
+fixed-length decomposition into the traces of its repeated corner-transition
+products. This formulation is valid at every length. At \(N=0\), divisibility
+and sector closure are automatic, and the decomposition uses the boundary
+values `cornerProd Q A u [] = Q u`; it does not claim that the coefficients of
+empty `projectorComponentChain`s retain those projectors.
+
+The source phrases the hypothesis as a one-block canonical transfer operator
+with \(p\) peripheral eigenvalues. Here `IsPeriodic p A` is the maintained
+normalized surface: it states irreducibility, left-canonical form, positive
+period, and peripheral spectrum equal to the \(p\)-th roots of unity.
+
+**Scope restriction (normalized orientation):** this theorem uses
+`IsPeriodic p A` rather than deriving these conditions from the one-block
+unital canonical hypotheses of the printed theorem. This boundary is recorded
+in `docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex`.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 5, lines 849--880. -/
+theorem pgvwc07_periodic_stateVector_boundary_decomposition_of_dvd
+    (A : MPSTensor d D) (hA : IsPeriodic p A)
+    {N : ℕ} (hdiv : p ∣ N) :
+    let _ : NeZero p := ⟨Nat.ne_of_gt hA.period_pos⟩
+    ∃ Q : Fin p → MatrixAlg D,
+      (∀ k, IsOrthogonalProjection (Q k)) ∧
+      (∑ k, Q k = 1) ∧
+      (∀ k i, Q k * A i = A i * Q (k + 1)) ∧
+      (∀ (u : Fin p) (j : Fin N) (i : Fin d),
+        projectorComponentChain Q A u N j i =
+          Q (u + j.val • (1 : Fin p)) * A i *
+            Q (u + j.val • (1 : Fin p) + 1)) ∧
+      (∀ u : Fin p, u + N • (1 : Fin p) = u) ∧
+      (∀ σ : Fin N → Fin d,
+        mpv A σ = ∑ u : Fin p, Matrix.trace (cornerProd Q A u (List.ofFn σ))) := by
+  letI : NeZero p := ⟨Nat.ne_of_gt hA.period_pos⟩
+  obtain ⟨Q, hQproj, hQsum, hshift⟩ := exists_paper_cyclic_projectors_of_isPeriodic A hA
+  refine ⟨Q, hQproj, hQsum, hshift, ?_, ?_, ?_⟩
+  · intro u j i
+    rfl
+  · obtain ⟨k, rfl⟩ := hdiv
+    intro u
+    have hpzero : p • (1 : Fin p) = 0 := by
+      simpa only [Fintype.card_fin] using
+        (card_nsmul_eq_zero (x := (1 : Fin p)))
+    have hcycle : (p * k) • (1 : Fin p) = 0 := by
+      calc
+        (p * k) • (1 : Fin p) = k • (p • (1 : Fin p)) := by
+          rw [mul_comm, mul_nsmul']
+        _ = k • 0 := by rw [hpzero]
+        _ = 0 := nsmul_zero k
+    rw [hcycle, add_zero]
+  · exact mpv_eq_sum_trace_cornerProd Q A hQproj hQsum hshift
 
 /-- **PGVWC07 Theorem 5, periodic branch.**
 

--- a/TNLean/MPS/Periodic/StateVectorDecomposition.lean
+++ b/TNLean/MPS/Periodic/StateVectorDecomposition.lean
@@ -155,7 +155,9 @@ private theorem cornerProd_eq_projector_mul_evalWord
     _ = Q u * evalWord A w := htransport.symm
 
 /-- At positive length, the trace of the boundary-aware corner product equals the
-coefficient of the corresponding explicit projector-component chain. -/
+coefficient of the corresponding explicit projector-component chain.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 5, lines 860--880. -/
 theorem projectorComponentChain_coeff_eq_trace_cornerProd
     (Q : Fin p → MatrixAlg D) (A : MPSTensor d D)
     (hQproj : ∀ k, IsOrthogonalProjection (Q k))
@@ -165,17 +167,23 @@ theorem projectorComponentChain_coeff_eq_trace_cornerProd
   rw [MPSChainTensor.coeff, projectorComponentChain_eval Q A hQproj]
 
 /-- Inserting the cyclic resolution of the identity gives a boundary-aware
-state-vector decomposition at every length:
+state-vector decomposition at every length. For
+\(\sigma = (i_0, \ldots, i_{N-1})\),
 \[
-  \operatorname{tr}(A^{\sigma_1}\cdots A^{\sigma_N})
-    = \sum_u \operatorname{tr}(F_u^{\boldsymbol\sigma}).
+  \operatorname{tr}(A^{i_0}\cdots A^{i_{N-1}})
+    = \sum_u \operatorname{tr}(F_u(\sigma)).
 \]
 Here `cornerProd Q A u w` is the repeated corner-transition product starting
-with the boundary projector `Q u`. In particular, at length zero the convention
-is `evalWord A [] = 1` and `cornerProd Q A u [] = Q u`, so the formula reads
-`trace 1 = ∑ u, trace (Q u)`. It does not identify the empty
-`projectorComponentChain` coefficient, whose chain evaluation is `1` and hence
-forgets the boundary projector. -/
+with the boundary projector `Q u`. At length zero,
+\(\operatorname{evalWord}(A, []) = 1\) and
+\(\operatorname{cornerProd}(Q, A, u, []) = Q_u\), so the formula reads
+\(\operatorname{tr}(1) = \sum_u \operatorname{tr}(Q_u)\). It does not identify
+the empty `projectorComponentChain` coefficient, whose chain evaluation is
+\(1\) and hence forgets the boundary projector.
+
+Source: PGVWC07, arXiv:quant-ph/0608197, Theorem 5, lines 860--880. The
+empty-word convention is the formal extension of the source's inserted-projector
+calculation. -/
 theorem mpv_eq_sum_trace_cornerProd
     (Q : Fin p → MatrixAlg D) (A : MPSTensor d D)
     (hQproj : ∀ k, IsOrthogonalProjection (Q k))

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -133,10 +133,12 @@ counterpart in Theorem~\ref{thm:cyclic_sector_decomp_after_blocking}.
     Choose the cyclic projections supplied by periodicity. If $p\mid N$, then
     $Q_{u+N}=Q_u$, and Theorem~\ref{thm:pgvwc07_boundary_trace_coefficients}
     gives (\ref{eq:pgvwc07_periodic_boundary_decomposition}) at every length.
-    For $N>0$, the same theorem identifies each summand with the coefficient of
-    the component chain $B_u$, proving
-    (\ref{eq:pgvwc07_periodic_state_vector_decomposition}). If $p\nmid N$,
-    then $Q_{u+N}\ne Q_u$; cyclicity of the trace and orthogonality give
+    For $N>0$, the explicit component-chain decomposition follows by inserting
+    $\sum_uQ_u=\Id$ and multiplying the local corner matrices; this proves
+    (\ref{eq:pgvwc07_periodic_state_vector_decomposition}). The separate
+    coefficient identity in Theorem~\ref{thm:pgvwc07_boundary_trace_coefficients}
+    identifies its summands with the boundary traces. If $p\nmid N$, then
+    $Q_{u+N}\ne Q_u$; cyclicity of the trace and orthogonality give
     $\tr F_u(\sigma)=0$ for every $u$ and $\sigma$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -37,42 +37,108 @@ counterpart in Theorem~\ref{thm:cyclic_sector_decomp_after_blocking}.
     $D$ as $A$ and repeats with period $p$.
 \end{definition}
 
-% Scope restriction (normalized orientation): this is the IsPeriodic surface,
-% not yet a wrapper from PGVWC07's one-block unital hypotheses.
-\begin{theorem}[Normalized periodic state-vector decomposition]
-    \label{thm:pgvwc07_periodic_state_vector_decomposition}
-    \lean{MPSTensor.pgvwc07_periodic_stateVector_decomposition_of_dvd,
-        MPSTensor.pgvwc07_stateVector_eq_zero_of_not_dvd}
+\begin{theorem}[Boundary traces and component-chain coefficients]
+    \label{thm:pgvwc07_boundary_trace_coefficients}
+    \lean{MPSTensor.projectorComponentChain_coeff_eq_trace_cornerProd,
+        MPSTensor.mpv_eq_sum_trace_cornerProd}
     \leanok
-    \uses{def:pgvwc07_projector_component_chain, def:periodic_tensor}
-    This is a normalized form of the state-vector conclusion in
-    \cite[Theorem~5]{PerezGarcia2007Matrix}. Let $A$ be an irreducible
-    left-canonical tensor whose peripheral transfer
-    spectrum is the set of $p$-th roots of unity. For a positive ring length
-    $N$, if $p\mid N$, then its state vector is the sum of the $p$ component
-    chains in~(\ref{eq:pgvwc07_projector_component_chain}):
+    \uses{def:pgvwc07_projector_component_chain}
+    Suppose that the orthogonal projections satisfy
+    $\sum_uQ_u=\Id$ and $Q_uA^i=A^iQ_{u+1}$. For a word
+    $\sigma=(i_0,\ldots,i_{N-1})$, define the boundary product
     \begin{align}
-        V_N(A)
-        &=\sum_{u\in\mathbb Z/p\mathbb Z}c_{B_u}.
-        \label{eq:pgvwc07_periodic_state_vector_decomposition}
+        F_u(\sigma)
+        &=Q_uA^{i_0}Q_{u+1}A^{i_1}\cdots
+          Q_{u+N-1}A^{i_{N-1}}Q_{u+N}.
+        \label{eq:pgvwc07_boundary_product}
     \end{align}
-    Each summand is represented by a $p$-periodic MPS of bond dimension $D$.
-    If $p\nmid N$, then $V_N(A)=0$.
+    At every length $N\geq 0$,
+    \begin{align}
+        V^{(N)}(A)_\sigma
+        &=\sum_{u\in\mathbb Z/p\mathbb Z}\tr F_u(\sigma).
+        \label{eq:pgvwc07_boundary_coefficient_decomposition}
+    \end{align}
+    If $N>0$, then $\tr F_u(\sigma)$ is the coefficient of the explicit
+    component chain from Definition~\ref{def:pgvwc07_projector_component_chain}.
+    At $N=0$, the boundary product is $F_u(\varnothing)=Q_u$, so
+    \begin{align}
+        \tr(\Id)
+        &=\sum_{u\in\mathbb Z/p\mathbb Z}\tr(Q_u).
+        \label{eq:pgvwc07_empty_boundary_decomposition}
+    \end{align}
+    This is not the sum of the ordinary empty component-chain coefficients:
+    an empty chain evaluates to $\Id$ and does not retain its starting
+    projection.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{def:pgvwc07_projector_component_chain}
-    Choose orthogonal cyclic projections with
-    $\sum_uQ_u=\Id$ and $Q_uA^i=A^iQ_{u+1}$. The component product telescopes to
+    The cyclic relation and orthogonality give
+    $F_u(\sigma)=Q_uA^{i_0}\cdots A^{i_{N-1}}$. Hence
     \begin{align}
-        B_{u,0}^{i_0}\cdots B_{u,N-1}^{i_{N-1}}
-        &=Q_uA^{i_0}\cdots A^{i_{N-1}}Q_{u+N}.
+        \tr(A^{i_0}\cdots A^{i_{N-1}})
+        &=\tr\!\left(\left(\sum_uQ_u\right)
+          A^{i_0}\cdots A^{i_{N-1}}\right)
+          =\sum_u\tr F_u(\sigma).
     \end{align}
-    Summing its trace over $u$ gives the original coefficient. If $p\mid N$,
-    then $Q_{u+N}=Q_u$ and every chain closes with period $p$. If $p\nmid N$,
-    then $Q_{u+N}\ne Q_u$; cyclicity of the trace and orthogonality make every
-    component coefficient zero.
+    For $N>0$, multiplying the local matrices in
+    (\ref{eq:pgvwc07_projector_component_chain}) gives
+    $F_u(\sigma)$, proving the coefficient identity. For $N=0$, the same trace
+    calculation reduces to (\ref{eq:pgvwc07_empty_boundary_decomposition}).
+\end{proof}
+
+% Scope restriction (normalized orientation): this is the IsPeriodic surface,
+% not yet a theorem from PGVWC07's one-block unital hypotheses. Issue #6232.
+\begin{theorem}[Normalized periodic state-vector decomposition]
+    \label{thm:pgvwc07_periodic_state_vector_decomposition}
+    \lean{MPSTensor.pgvwc07_periodic_stateVector_boundary_decomposition_of_dvd,
+        MPSTensor.pgvwc07_periodic_stateVector_decomposition_of_dvd,
+        MPSTensor.pgvwc07_stateVector_eq_zero_of_not_dvd}
+    \leanok
+    \uses{def:pgvwc07_projector_component_chain, def:periodic_tensor,
+        thm:pgvwc07_boundary_trace_coefficients}
+    This is a normalized form of the state-vector conclusion in
+    \cite[Theorem~5]{PerezGarcia2007Matrix}. Let $A$ be an irreducible
+    left-canonical tensor whose peripheral transfer spectrum is the set of
+    $p$-th roots of unity. If $p\mid N$, there are orthogonal cyclic
+    projections $(Q_u)_{u\in\mathbb Z/p\mathbb Z}$ such that
+    $\sum_uQ_u=\Id$, $Q_uA^i=A^iQ_{u+1}$, and $Q_{u+N}=Q_u$. For every
+    ring length $N\geq0$, its coefficients satisfy the boundary-aware
+    decomposition
+    \begin{align}
+        V^{(N)}(A)_\sigma
+        &=\sum_{u\in\mathbb Z/p\mathbb Z}\tr F_u(\sigma).
+        \label{eq:pgvwc07_periodic_boundary_decomposition}
+    \end{align}
+    For $N>0$, this becomes the source's decomposition into the $p$ explicit
+    component chains:
+    \begin{align}
+        \ket{V^{(N)}(A)}
+        &=\sum_{u\in\mathbb Z/p\mathbb Z}\ket{V^{(N)}(B_u)}.
+        \label{eq:pgvwc07_periodic_state_vector_decomposition}
+    \end{align}
+    Each $B_u$ is a $p$-periodic MPS of bond dimension $D$ with local matrices
+    given by (\ref{eq:pgvwc07_projector_component_chain}). At $N=0$,
+    (\ref{eq:pgvwc07_periodic_boundary_decomposition}) instead uses the boundary
+    traces $\tr(Q_u)$ from
+    (\ref{eq:pgvwc07_empty_boundary_decomposition}); it does not identify them
+    with ordinary empty-chain coefficients. If $p\nmid N$, then
+    $\ket{V^{(N)}(A)}=0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:pgvwc07_projector_component_chain,
+        thm:pgvwc07_boundary_trace_coefficients}
+    Choose the cyclic projections supplied by periodicity. If $p\mid N$, then
+    $Q_{u+N}=Q_u$, and Theorem~\ref{thm:pgvwc07_boundary_trace_coefficients}
+    gives (\ref{eq:pgvwc07_periodic_boundary_decomposition}) at every length.
+    For $N>0$, the same theorem identifies each summand with the coefficient of
+    the component chain $B_u$, proving
+    (\ref{eq:pgvwc07_periodic_state_vector_decomposition}). If $p\nmid N$,
+    then $Q_{u+N}\ne Q_u$; cyclicity of the trace and orthogonality give
+    $\tr F_u(\sigma)=0$ for every $u$ and $\sigma$.
 \end{proof}
 
 Two normalizations appear. The unital orientation

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -96,8 +96,7 @@ counterpart in Theorem~\ref{thm:cyclic_sector_decomp_after_blocking}.
         MPSTensor.pgvwc07_periodic_stateVector_decomposition_of_dvd,
         MPSTensor.pgvwc07_stateVector_eq_zero_of_not_dvd}
     \leanok
-    \uses{def:pgvwc07_projector_component_chain, def:periodic_tensor,
-        thm:pgvwc07_boundary_trace_coefficients}
+    \uses{def:pgvwc07_projector_component_chain, def:periodic_tensor}
     This is a normalized form of the state-vector conclusion in
     \cite[Theorem~5]{PerezGarcia2007Matrix}. Let $A$ be an irreducible
     left-canonical tensor whose peripheral transfer spectrum is the set of

--- a/docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex
+++ b/docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex
@@ -52,8 +52,9 @@ unital canonical representation and counts the peripheral eigenvalues of the
 associated transfer map. This normalized-orientation restriction remains
 tracked by issue~\#6232.
 
-Let $(Q_u)_{u\in\mathbb Z/p\mathbb Z}$ be the cyclic projections and, for a
-word $\sigma=(i_0,\ldots,i_{N-1})$, let
+Let $A=(A^i)_{i=0}^{d-1}$ be the MPS matrix family. Let
+$(Q_u)_{u\in\mathbb Z/p\mathbb Z}$ be its cyclic projections and, for a word
+$\sigma=(i_0,\ldots,i_{N-1})$, let
 \[
   F_u(\sigma)
   =Q_uA^{i_0}Q_{u+1}A^{i_1}\cdots
@@ -61,19 +62,19 @@ word $\sigma=(i_0,\ldots,i_{N-1})$, let
 \]
 At every length, including $N=0$, the formal decomposition is
 \[
-  \operatorname{tr}(A^{i_0}\cdots A^{i_{N-1}})
-  =\sum_{u\in\mathbb Z/p\mathbb Z}\operatorname{tr}F_u(\sigma).
+  \tr(A^{i_0}\cdots A^{i_{N-1}})
+  =\sum_{u\in\mathbb Z/p\mathbb Z}\tr F_u(\sigma).
 \]
 For positive $N$, \leanid{MPSTensor.projectorComponentChain_coeff_eq_trace_cornerProd}
 identifies each boundary trace with the coefficient of the explicit periodic
 component chain. At $N=0$, the boundary product is $F_u(\varnothing)=Q_u$, so
 the formula reads
 \[
-  \operatorname{tr}(\mathbf 1)=
-  \sum_{u\in\mathbb Z/p\mathbb Z}\operatorname{tr}(Q_u).
+  \tr(\Id)=
+  \sum_{u\in\mathbb Z/p\mathbb Z}\tr(Q_u).
 \]
 This must be distinguished from ordinary empty component-chain coefficients.
-An empty chain evaluates to $\mathbf 1$ independently of $u$ and therefore
+An empty chain evaluates to $\Id$ independently of $u$ and therefore
 does not retain the boundary projector. The boundary-aware theorem closes the
 length-zero part of issue~\#6233 without changing the positive-length explicit
 component-chain statement.

--- a/docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex
+++ b/docs/paper-gaps/pgvwc07_periodic_decomposition_scope.tex
@@ -9,7 +9,7 @@
 
 \title{Scope of the Formal Periodic Decomposition Relative to PGVWC07}
 \author{}
-\date{2026-06-04}
+\date{2026-08-12}
 
 \begin{document}
 \maketitle
@@ -39,40 +39,65 @@ splits $\psi$ into the claimed $p$-periodic summands
 
 \section{Formal boundary}
 
-TNLean proves the explicit fixed-length decomposition in
-\leanid{MPSTensor.pgvwc07_periodic_stateVector_decomposition_of_dvd} and the
+TNLean proves the boundary-aware divisible-length decomposition in
+\leanid{MPSTensor.pgvwc07_periodic_stateVector_boundary_decomposition_of_dvd},
+the positive-length explicit component-chain form in
+\leanid{MPSTensor.pgvwc07_periodic_stateVector_decomposition_of_dvd}, and the
 vanishing branch in
-\leanid{MPSTensor.pgvwc07_stateVector_eq_zero_of_not_dvd}. Both declarations
-use \leanid{MPSTensor.IsPeriodic}, which assumes left-canonical orientation,
-irreducibility, positive period, and an exact $p$-th-root peripheral spectrum.
-The printed theorem instead starts from its one-block unital canonical
-representation and counts the peripheral eigenvalues of the associated
-transfer map.
+\leanid{MPSTensor.pgvwc07_stateVector_eq_zero_of_not_dvd}. All three
+declarations use \leanid{MPSTensor.IsPeriodic}, which assumes left-canonical
+orientation, irreducibility, positive period, and an exact $p$-th-root
+peripheral spectrum. The printed theorem instead starts from its one-block
+unital canonical representation and counts the peripheral eigenvalues of the
+associated transfer map. This normalized-orientation restriction remains
+tracked by issue~\#6232.
 
-The periodic branch is stated for positive ring lengths because the current
-coefficient decomposition is proved for a nonempty chain. The formal results
-therefore give a normalized theorem surface and the complete fixed-positive-
-length calculation, but not yet a literal theorem from the printed
-hypotheses.
+Let $(Q_u)_{u\in\mathbb Z/p\mathbb Z}$ be the cyclic projections and, for a
+word $\sigma=(i_0,\ldots,i_{N-1})$, let
+\[
+  F_u(\sigma)
+  =Q_uA^{i_0}Q_{u+1}A^{i_1}\cdots
+    Q_{u+N-1}A^{i_{N-1}}Q_{u+N}.
+\]
+At every length, including $N=0$, the formal decomposition is
+\[
+  \operatorname{tr}(A^{i_0}\cdots A^{i_{N-1}})
+  =\sum_{u\in\mathbb Z/p\mathbb Z}\operatorname{tr}F_u(\sigma).
+\]
+For positive $N$, \leanid{MPSTensor.projectorComponentChain_coeff_eq_trace_cornerProd}
+identifies each boundary trace with the coefficient of the explicit periodic
+component chain. At $N=0$, the boundary product is $F_u(\varnothing)=Q_u$, so
+the formula reads
+\[
+  \operatorname{tr}(\mathbf 1)=
+  \sum_{u\in\mathbb Z/p\mathbb Z}\operatorname{tr}(Q_u).
+\]
+This must be distinguished from ordinary empty component-chain coefficients.
+An empty chain evaluates to $\mathbf 1$ independently of $u$ and therefore
+does not retain the boundary projector. The boundary-aware theorem closes the
+length-zero part of issue~\#6233 without changing the positive-length explicit
+component-chain statement.
 
-\section{Elimination plan}
+\section{Remaining scope restriction}
 
-Prove a source-facing equivalence from the paper's one-block unital canonical
-hypotheses and peripheral-eigenvalue count to
-\leanid{MPSTensor.IsPeriodic}, accounting for the adjoint normalization
-orientation. Then compose this equivalence with the two fixed-length
-statements above. If length zero is included in the formal source interface,
-add its direct empty-chain calculation separately. No new cyclic-projector or
-positive-length state-vector calculation is required.
+To obtain a theorem with the printed hypotheses, prove that the paper's
+one-block unital canonical assumptions and peripheral-eigenvalue count imply
+the maintained periodicity hypotheses, after accounting for the adjoint change
+between unital and left-canonical orientations. Composing that result with the
+three declarations above would give the printed periodic decomposition and
+vanishing dichotomy. No further fixed-length coefficient calculation is
+required.
 
 \section{Verdict}
 
-\textbf{Verdict: scope restriction.} The formal declarations prove the
-periodic decomposition and vanishing dichotomy under the maintained
-\leanid{MPSTensor.IsPeriodic} hypotheses, with positive length required in the
-decomposition branch. The wrapper from the printed one-block unital
-hypotheses and peripheral-eigenvalue count remains open, so the current
-statements are normalized specializations of PGVWC07 Theorem~5.
+\textbf{Verdict: scope restriction.} The positive-length restriction from
+issue~\#6233 is closed: the divisible-period branch now has a boundary-aware
+coefficient decomposition for every $N\geq0$, while the explicit periodic
+component-chain theorem remains stated for $N>0$, where its coefficients equal
+the boundary traces. The separate normalized-orientation restriction remains
+open under issue~\#6232, so the formal declarations are still normalized
+specializations of PGVWC07 Theorem~5 rather than a theorem from its literal
+one-block unital hypotheses.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- prove an all-length cyclic-projector decomposition using the boundary-aware corner products;
- identify those boundary traces with explicit component-chain coefficients at positive length;
- add an `IsPeriodic` divisible-length capstone valid at `N = 0`;
- document why ordinary empty component-chain coefficients cannot retain their starting projector;
- synchronize Chapter 9 and the PGVWC07 periodic-decomposition scope note.

The existing positive-length component-chain theorem remains unchanged. At zero length the new theorem uses `cornerProd Q A u [] = Q u`, so the identity is `tr(1) = ∑ᵤ tr(Qᵤ)` rather than the false sum of `p` ordinary empty-chain coefficients.

## Validation

- `lake build TNLean.MPS.Periodic.StateVectorDecomposition`
- full `lake build` (10081 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- Blueprint double `lualatex` compile
- proof-integrity scan and `git diff --check`

Closes #6233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and documentation only; no runtime or security-sensitive paths. Risk is mainly proof-correctness and maintaining alignment between Lean, blueprint, and scope notes.
> 
> **Overview**
> Closes the length-zero gap in PGVWC07 Theorem 5 by decomposing MPS coefficients as **sums of traces of boundary-aware corner products** \(F_u(\sigma)\), valid for **every** \(N \geq 0\) when \(p \mid N\).
> 
> New Lean lemmas tie positive-length component-chain coefficients to those boundary traces, extract `u + N • 1 = u` under divisibility into a shared helper, and add **`pgvwc07_periodic_stateVector_boundary_decomposition_of_dvd`** as the all-length `IsPeriodic` capstone. The existing positive-length sum-over-component-chains theorem is unchanged and now reuses that helper.
> 
> Chapter 9 and the PGVWC07 scope note document that at \(N=0\) one gets \(\mathrm{tr}(\mathrm{Id}) = \sum_u \mathrm{tr}(Q_u)\), not a sum of ordinary empty-chain coefficients (which evaluate to \(\mathrm{Id}\) and drop the starting projector).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72ca0dcff23ae5b3adffe44c1b3e6d11650e4acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->