### PR TITLE
feat(MPS/MPDO): prove Fibonacci open-boundary rank

### DIFF
--- a/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
+++ b/TNLean/MPS/MPDO/FibonacciBoundaryRank.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.Defs
+import Mathlib.LinearAlgebra.Matrix.Rank
 import Mathlib.NumberTheory.Real.GoldenRatio
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.LinearCombination
@@ -17,9 +19,9 @@ The three binary physical labels are written \(i,j,k\), the fusion weights are
 \(A^{ijk}_{αβ} = δ_{i,α} δ_{k,β} N_{ijk}\).  The structural strong fixed-point
 relation is defined separately in `MPOTensor.IsStrongRFP`.
 
-**Scope restriction (transition-count slice):** This file computes the transition
-counts but does not identify them with the open-boundary or periodic operator ranks.
-In particular, its golden-ratio formula is not an operator-rank theorem.
+The open-boundary calculation identifies the transition count with the ordinary
+matrix rank of the source diagonal operator. The periodic operator-rank identity is
+not established here, so the golden-ratio formula remains a transition-count theorem.
 
 ## References
 
@@ -63,6 +65,10 @@ def physicalTriple (p : Fin 8) : Fin 2 × Fin 2 × Fin 2 :=
   (⟨p.val / 4, by omega⟩, ⟨(p.val / 2) % 2, Nat.mod_lt _ (by omega)⟩,
     ⟨p.val % 2, Nat.mod_lt _ (by omega)⟩)
 
+private instance (i j k : Fin 2) : Decidable (ExactlyTwoZero i j k) := by
+  unfold ExactlyTwoZero
+  infer_instance
+
 /-- The source tensor \(A^{ijk}_{αβ} = δ_{i,α}δ_{k,β}N_{ijk}\).
 
 Source: arXiv:1606.00608, Appendix D, lines 2116--2121. -/
@@ -103,6 +109,104 @@ theorem x_succ (n : ℕ) (α : Fin 2) :
       x (n + 1) α 1 = x n α 0 + 2 * x n α 1 := by
   fin_cases α <;>
     simp [x, pow_succ, B, Matrix.mul_apply, Fin.sum_univ_two] <;> omega
+
+/-- Whether a physical word contributes to the open-boundary contraction. -/
+private def isSupportedWord (α β : Fin 2) : List (Fin 8) → Bool
+  | [] => α == β
+  | p :: w =>
+      let ijk := physicalTriple p
+      ijk.1 == α && !(decide (ExactlyTwoZero ijk.1 ijk.2.1 ijk.2.2)) &&
+        isSupportedWord ijk.2.2 β w
+
+/-- The number of supported physical words of length \(n\) with fixed virtual endpoints. -/
+private def supportedCount (n : ℕ) (α β : Fin 2) : ℕ :=
+  ∑ σ : Fin n → Fin 8, if isSupportedWord α β (List.ofFn σ) then 1 else 0
+
+@[simp] private lemma supportedCount_zero (α β : Fin 2) :
+    supportedCount 0 α β = if α = β then 1 else 0 := by
+  simp [supportedCount, isSupportedWord]
+
+private lemma supportedCount_succ (n : ℕ) (α β : Fin 2) :
+    supportedCount (n + 1) α β =
+      (if α = 0 then supportedCount n 0 β + supportedCount n 1 β
+       else supportedCount n 0 β + 2 * supportedCount n 1 β) := by
+  rw [supportedCount]
+  rw [Fintype.sum_equiv (finSuccArrowEquiv (Fin 8) n)
+    (fun σ : Fin (n + 1) → Fin 8 =>
+      if isSupportedWord α β (List.ofFn σ) then 1 else 0)
+    (fun p : Fin 8 × (Fin n → Fin 8) =>
+      if isSupportedWord α β (List.ofFn (Fin.cons p.1 p.2)) then 1 else 0)]
+  · simp only [List.ofFn_succ, Fin.cons_zero]
+    change (∑ p : Fin 8 × (Fin n → Fin 8),
+      if isSupportedWord α β (p.1 :: List.ofFn p.2) then 1 else 0) = _
+    rw [Fintype.sum_prod_type]
+    fin_cases α
+    · simp [isSupportedWord, physicalTriple, ExactlyTwoZero, supportedCount,
+        Fin.sum_univ_eight]
+    · simp [isSupportedWord, physicalTriple, ExactlyTwoZero, supportedCount,
+        Fin.sum_univ_eight]
+      omega
+  · intro σ
+    simp
+
+private lemma tensor_mul_apply_ne_zero_iff (W : FusionWeights) (p : Fin 8)
+    (M : Matrix (Fin 2) (Fin 2) ℂ) (α β : Fin 2) :
+    (tensor W p * M) α β ≠ 0 ↔
+      (physicalTriple p).1 = α ∧
+        ¬ExactlyTwoZero (physicalTriple p).1 (physicalTriple p).2.1
+          (physicalTriple p).2.2 ∧
+        M (physicalTriple p).2.2 β ≠ 0 := by
+  fin_cases p <;> fin_cases α <;> fin_cases β <;>
+    simp [Matrix.mul_apply, tensor, physicalTriple, W.zero_iff, ExactlyTwoZero]
+
+private lemma evalWord_apply_ne_zero_iff (W : FusionWeights) (w : List (Fin 8))
+    (α β : Fin 2) : evalWord (tensor W) w α β ≠ 0 ↔ isSupportedWord α β w := by
+  induction w generalizing α with
+  | nil =>
+      fin_cases α <;> fin_cases β <;> simp [evalWord, isSupportedWord]
+  | cons p w ih =>
+      rw [evalWord_cons, tensor_mul_apply_ne_zero_iff, ih]
+      simp only [isSupportedWord, Bool.and_eq_true, Bool.not_eq_true', decide_eq_false_iff_not,
+        beq_iff_eq]
+      tauto
+
+private lemma supportedCount_eq_x (n : ℕ) (α β : Fin 2) :
+    supportedCount n α β = x n α β := by
+  induction n generalizing α with
+  | zero =>
+      fin_cases α <;> fin_cases β <;> simp [x]
+  | succ n ih =>
+      rw [show n + 1 = n + 1 by rfl, supportedCount_succ]
+      fin_cases α <;> fin_cases β <;>
+        simp only [ih]
+      all_goals simp [x, pow_succ', B, Matrix.mul_apply, Fin.sum_univ_two]
+
+/-- The source diagonal open-boundary operator with fixed virtual endpoints.
+Its diagonal entry at \(σ\) is the word amplitude
+\((\alpha|A^{σ_1}\cdots A^{σ_n}|\beta)\), and every off-diagonal entry is zero.
+
+Source: arXiv:1606.00608, Appendix D, lines 2127--2130. -/
+noncomputable def openBoundaryOperator (W : FusionWeights) (n : ℕ) (α β : Fin 2) :
+    Matrix (Fin n → Fin 8) (Fin n → Fin 8) ℂ :=
+  Matrix.diagonal fun σ => evalWord (tensor W) (List.ofFn σ) α β
+
+@[simp] theorem openBoundaryOperator_apply (W : FusionWeights) (n : ℕ) (α β : Fin 2)
+    (σ τ : Fin n → Fin 8) :
+    openBoundaryOperator W n α β σ τ =
+      if σ = τ then evalWord (tensor W) (List.ofFn σ) α β else 0 := by
+  rw [openBoundaryOperator, Matrix.diagonal_apply]
+
+/-- The ordinary matrix rank of the source diagonal open-boundary operator is
+\(x^n_{αβ}\).
+
+Source: arXiv:1606.00608, Appendix D, lines 2127--2130. -/
+theorem rank_openBoundaryOperator_eq_x (W : FusionWeights) (n : ℕ) (α β : Fin 2) :
+    (openBoundaryOperator W n α β).rank = x n α β := by
+  classical
+  rw [openBoundaryOperator, Matrix.rank_diagonal, Fintype.card_subtype]
+  rw [← supportedCount_eq_x n α β]
+  simp only [supportedCount, evalWord_apply_ne_zero_iff]
+  rw [Finset.card_eq_sum_ones, Finset.sum_filter]
 
 /-- The periodic transition count obtained by closing the two boundary labels,
 \(a_N=x^N_{00}+x^N_{11}\).  This definition asserts only the transition count,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -892,23 +892,50 @@ the remaining sites unchanged.
     in $\N$.
 \end{proof}
 
+\begin{definition}[Open-boundary Fibonacci operator]
+    \label{def:cpsv_fibonacci_open_boundary_operator}
+    \lean{MPSTensor.FibonacciBoundary.openBoundaryOperator,
+      MPSTensor.FibonacciBoundary.openBoundaryOperator_apply}
+    \leanok
+    \uses{def:cpsv_fibonacci_support_tensor}
+    For $n>0$ and $\alpha,\beta\in\{0,1\}$, define the matrix
+    $\rho^{(n)}_{\alpha\beta}(A)$, indexed by physical words $\sigma$ and $\tau$, by
+    \begin{align}
+        \bigl(\rho^{(n)}_{\alpha\beta}(A)\bigr)_{\sigma,\tau}
+        &=\begin{cases}
+            (\alpha|A^{\sigma_1}\cdots A^{\sigma_n}|\beta),&\sigma=\tau,\\
+            0,&\sigma\ne\tau.
+          \end{cases}
+    \end{align}
+\end{definition}
+
 \begin{theorem}[Open-boundary Fibonacci operator ranks]
     \label{thm:cpsv_fibonacci_open_boundary_rank_status}
-    \notready
-    \uses{def:cpsv_fibonacci_support_tensor,
-      def:cpsv_fibonacci_boundary_counts,
-      thm:to_mpo_diagonal_rank}
-    For $n>0$ and $\alpha,\beta\in\{0,1\}$, let
-    $\rho^{(n)}_{\alpha\beta}(A)$ be the diagonal open-boundary operator whose
-    coefficient at a physical word is
-    $(\alpha|A^{i_1j_1k_1}\cdots A^{i_nj_nk_n}|\beta)$.  Then
+    \lean{MPSTensor.FibonacciBoundary.rank_openBoundaryOperator_eq_x}
+    \leanok
+    \uses{def:cpsv_fibonacci_open_boundary_operator,
+      def:cpsv_fibonacci_boundary_counts}
+    For $n>0$ and $\alpha,\beta\in\{0,1\}$,
     \begin{align}
-        x^n_{\alpha\beta}
-        &=\operatorname{rank}\rho^{(n)}_{\alpha\beta}(A).
-        \notag
+        \operatorname{rank}\rho^{(n)}_{\alpha\beta}(A)
+        &=x^n_{\alpha\beta}.
     \end{align}
     This is \cite[Appendix~D, lines~2127--2130]{Cirac2016MPDO_arXiv}.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:cpsv_fibonacci_open_boundary_operator,
+      def:cpsv_fibonacci_transition_matrix,
+      def:cpsv_fibonacci_boundary_counts}
+    A diagonal entry is nonzero exactly when its physical labels form an allowed
+    path from $\alpha$ to $\beta$. Splitting a path at its first physical label
+    shows that the numbers of supported words obey the transition rule determined
+    by $B$, with the same length-zero initial values as $x^n_{\alpha\beta}$.
+    Induction therefore identifies the number of nonzero diagonal entries with
+    $x^n_{\alpha\beta}$. The rank of a diagonal matrix is the number of its nonzero
+    diagonal entries.
+\end{proof}
 
 \begin{theorem}[Fibonacci periodic operator-rank formula]
     \label{thm:cpsv_fibonacci_rank_obstruction_status}


### PR DESCRIPTION
## What changed

- define the CPSV16 open-boundary diagonal operator with fixed virtual endpoints
- prove that its ordinary matrix rank equals the Fibonacci transition count `x n α β` for arbitrary supported positive fusion weights
- synchronize the Blueprint statement and remove the inapplicable periodic-trace rank dependency

The Lean theorem also covers the empty word. The Blueprint retains the paper's positive-length statement. This PR does not claim the periodic rank identification tracked by #6080.

## Validation

- `lake build TNLean.MPS.MPDO.FibonacciBoundaryRank` (2081/2081)
- `lake build` (10081/10081)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (7324/7324 synchronized)
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint/src && TEXINPUTS="../../tex/tenkz//:" lualatex -interaction=nonstopmode -halt-on-error print.tex` twice (no undefined cross-references)
- `git diff --check`

Closes #6078
Advances #5921

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal mathematics in an isolated MPS/MPDO file plus blueprint sync; no auth, runtime, or API surface changes.
> 
> **Overview**
> This PR **closes the open-boundary slice** of CPSV16 Appendix D: the transition counts `x^n_{αβ}` are no longer only matrix-power definitions—they are identified with **ordinary matrix rank** of the diagonal open-boundary operator.
> 
> Lean adds `openBoundaryOperator` (diagonal matrix indexed by physical words, entries from `evalWord` on the Fibonacci support tensor) and `rank_openBoundaryOperator_eq_x`, proved by counting **supported physical words** (`isSupportedWord` / `supportedCount`) and showing that count satisfies the same recurrence as `B^n`. Positive fusion weights enter only through “nonzero diagonal entry ↔ allowed path,” so the rank does not depend on the specific positive `N_{ijk}`.
> 
> The **module doc** is updated to state this open-boundary rank identification explicitly while **not** claiming periodic operator rank (golden-ratio formula stays transition-count only).
> 
> The **blueprint** gains `def:cpsv_fibonacci_open_boundary_operator`, marks the open-boundary rank theorem `\leanok` with proof sketch, and drops the prior `\notready` / inapplicable periodic-trace rank dependency from that statement’s uses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3054337c1e35e76566cf68eef82d345c56782e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->