### PR TITLE
docs: record diagonal ancilla sum collapse pattern

### DIFF
--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -989,6 +989,25 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### diagonal normalized-ancilla sum collapse — candidate
+- **Pattern:** collapse the doubled sum for `normalizedDiagonalLift` by using
+  `Finset.sum_eq_single` to retain the diagonal ancilla letter `(a, a)`, then
+  cancel the resulting normalization with
+  `(x : ℂ) * (Real.sqrt x : ℂ)⁻¹ * (Real.sqrt x : ℂ)⁻¹ = 1` for `0 < x`.
+- **Seen:** 2 occurrences in `TNLean/MPS/MPU/PhysicalAncilla.lean`:
+  `MPOTensor.transferMap_normalizedDiagonalLift` (lines 198--220), for
+  `A ij * X * (A ij)ᴴ`, and
+  `MPOTensor.leftCanonical_normalizedDiagonalLift` (lines 262--283), for
+  `(A ij)ᴴ * A ij`.
+- **Abstraction (proposed):** if a third occurrence appears, extract the
+  lowest-sufficient helper lemma shared by both matrix-product orientations;
+  do not introduce a tactic solely for this pattern.
+- **Notes:** Use when a sum over the normalized diagonal ancilla alphabet has
+  off-diagonal terms that simplify to zero, every surviving diagonal term has
+  the same matrix factor, and `0 < x` permits cancellation of the two
+  inverse-square-root scalars against the ancilla cardinality. This is below
+  the rule-of-three promotion threshold.
+
 ### positive-part support-projection trace estimate — candidate
 - **Pattern:** for a positive linear map `T` and Hermitian `H`, decompose
   `T H = T H⁺ - T H⁻`, obtain the support projection `P` of `(T H)⁺`, and


### PR DESCRIPTION
## Summary
- record the repeated normalized diagonal-ancilla sum collapse as a candidate pattern
- identify the transfer-map and left-canonical occurrence sites
- state the precise conditions for future reuse while retaining the rule-of-three threshold

## Checks
- `git diff --check`
- verified the candidate appears exactly once and names both current declarations
- verified every added ledger line is at most 100 characters

No Lean code changed; no build was run under the hot-main protocol.

Closes #6242

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `docs/tactic_patterns.md` with no build or proof impact.
> 
> **Overview**
> Adds a **candidate** entry to the tactic pattern ledger for collapsing sums over `normalizedDiagonalLift`, documenting the repeated proof block without promoting it yet.
> 
> The entry describes using `Finset.sum_eq_single` to keep only diagonal ancilla pairs `(a, a)`, then canceling the `1/√x` normalization when `0 < x`. It points to the two current sites in `PhysicalAncilla.lean`—`transferMap_normalizedDiagonalLift` and `leftCanonical_normalizedDiagonalLift`—and states that a shared helper should wait until a third occurrence (rule of three); no new tactic is proposed.
> 
> **No Lean code changes**; documentation only (closes #6242).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbb968771ee601b56ddcc72faf09d6453c0a46a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->