### PR TITLE
docs(MPU): track CFII blocking preservation

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -63,7 +63,7 @@ physical indices, as in
     \uses{def:mpdo_physical_blocking, def:blocked_tensor}
     For every integer $L\geq0$, pairing the ket and bra letters site by site
     gives the canonical identification
-    $\{0,\ldots,d^L-1\}^2\simeq\{0,\ldots,d^2-1\}^L$.
+    $\operatorname{Fin}(d^L)^2\simeq\operatorname{Fin}(d^2)^L$.
     Under this identification, the doubled-index MPS tensor of $M^{[L]}$
     is the physical reindexing of the $L$-blocked doubled-index MPS tensor
     of $M$. In particular, one is injective if and only if the other is.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -30,12 +30,12 @@ The two ket indices and the two bra indices are grouped into the blocked
 physical indices, as in
 \cite[Theorem~4.9, lines~851--856]{Cirac2016MPDO_arXiv}.
 
-\begin{definition}[Positive-length physical blocking of an MPO tensor]
-    \label{def:mpdo_positive_physical_blocking}
+\begin{definition}[Physical blocking of an MPO tensor]
+    \label{def:mpdo_physical_blocking}
     \lean{MPOTensor.blockTensor}
     \lean{MPOTensor.blockTensor_apply}
     \leanok
-    For a positive integer $L$, group $L$ adjacent physical sites and denote
+    For an integer $L\geq0$, group $L$ adjacent physical sites and denote
     the resulting local tensor by $M^{[L]}$. It has a length-$L$ ket word
     $I=(i_1,\ldots,i_L)$ and a length-$L$ bra word
     $J=(j_1,\ldots,j_L)$ as its physical indices, and
@@ -44,23 +44,25 @@ physical indices, as in
         &=M^{i_1j_1}\cdots M^{i_Lj_L}.
         \notag
     \end{align}
-    Thus the ket and bra words are grouped separately. This is the MPO
-    version of the physical blocking used for the basis of normal tensors in
+    Thus the ket and bra words are grouped separately. For $L=0$, both
+    words are empty and the unique local matrix is the identity. For $L>0$,
+    this is the MPO version of the physical blocking used for the basis of
+    normal tensors in
     \cite[lines~317--345]{Cirac2016MPDO_arXiv}. It is a local tensor, not the
     closed-chain operator $O_L(M)$ of
     \cite[lines~962--967]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Doubled-index form of positive MPO blocking]
-    \label{thm:mpdo_positive_blocking_doubled_index}
+\begin{theorem}[Doubled-index form of MPO blocking]
+    \label{thm:mpdo_blocking_doubled_index}
     \lean{MPOTensor.blockedDoubledIndexEquiv}
     \lean{MPOTensor.decodeBlock_blockedDoubledIndexEquiv}
     \lean{MPOTensor.toMPSTensor_blockTensor}
     \lean{MPOTensor.isInjective_toMPSTensor_blockTensor_iff}
     \leanok
-    \uses{def:mpdo_positive_physical_blocking, def:blocked_tensor}
-    Let $L>0$. Pairing the ket and bra letters site by site gives the
-    canonical identification
+    \uses{def:mpdo_physical_blocking, def:blocked_tensor}
+    For every integer $L\geq0$, pairing the ket and bra letters site by site
+    gives the canonical identification
     $\{0,\ldots,d^L-1\}^2\simeq\{0,\ldots,d^2-1\}^L$.
     Under this identification, the doubled-index MPS tensor of $M^{[L]}$
     is the physical reindexing of the $L$-blocked doubled-index MPS tensor
@@ -69,7 +71,8 @@ physical indices, as in
 
 \begin{proof}\leanok
     Decode the blocked ket and bra words, pair their letters at each site,
-    and compare the two ordered matrix products. Physical reindexing by a
+    and compare the two ordered matrix products. For $L=0$, both words are
+    empty and both matrix products are the identity. Physical reindexing by a
     bijection preserves the span of the tensor matrices.
 \end{proof}
 
@@ -77,7 +80,7 @@ physical indices, as in
     \label{thm:mpdo_positive_blocking_product}
     \lean{MPOTensor.blockTensor_mulTensor}
     \leanok
-    \uses{def:mpdo_positive_physical_blocking, def:mpdo_operator_product}
+    \uses{def:mpdo_physical_blocking, def:mpdo_operator_product}
     For $L>0$ and two MPO tensors $M,N$ with the same physical dimension,
     let juxtaposition denote the MPO tensor product obtained by contracting
     the intermediate physical index. Then $(MN)^{[L]}=M^{[L]}N^{[L]}$.
@@ -94,7 +97,7 @@ physical indices, as in
     \lean{MPOTensor.mpo_blockTensor_eq_reindex}
     \lean{MPOTensor.IsMPDO.blockTensor}
     \leanok
-    \uses{def:mpdo_positive_physical_blocking, def:mpo_family, def:mpdo}
+    \uses{def:mpdo_physical_blocking, def:mpo_family, def:mpdo}
     Let $L\in\N$, and let
     \begin{align}
         \Phi_{N,L}\colon
@@ -159,7 +162,7 @@ physical indices, as in
     \lean{MPOTensor.mpo_blockTwo_eq_reindex_blockTensor}
     \lean{MPOTensor.IsMPDO.blockTwo}
     \leanok
-    \uses{def:mpdo_positive_physical_blocking,
+    \uses{def:mpdo_physical_blocking,
         def:mpdo_two_site_blocking, def:mpdo}
     Let $\varphi:\{0,\ldots,d^2-1\}\to
     \{0,\ldots,d-1\}^2$ be the canonical bijection. Then
@@ -184,8 +187,8 @@ physical indices, as in
     \lean{MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTensor}
     \lean{MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTwo}
     \leanok
-    \uses{def:mpdo_positive_physical_blocking, def:mpdo_two_site_blocking,
-        thm:mpdo_positive_blocking_doubled_index,
+    \uses{def:mpdo_physical_blocking, def:mpdo_two_site_blocking,
+        thm:mpdo_blocking_doubled_index,
         thm:mpdo_block_two_as_positive_blocking,
         thm:cpsv_physical_reindexing,
         thm:cpsv_literal_canonical_form_positive_blocking}
@@ -197,8 +200,8 @@ physical indices, as in
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpdo_positive_physical_blocking, def:mpdo_two_site_blocking,
-        thm:mpdo_positive_blocking_doubled_index,
+    \uses{def:mpdo_physical_blocking, def:mpdo_two_site_blocking,
+        thm:mpdo_blocking_doubled_index,
         thm:mpdo_block_two_as_positive_blocking,
         thm:cpsv_physical_reindexing,
         thm:cpsv_literal_canonical_form_positive_blocking}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -63,7 +63,11 @@ physical indices, as in
     \uses{def:mpdo_physical_blocking, def:blocked_tensor}
     For every integer $L\geq0$, pairing the ket and bra letters site by site
     gives the canonical identification
-    $\operatorname{Fin}(d^L)^2\simeq\operatorname{Fin}(d^2)^L$.
+    \begin{align}
+        \Fin{d^L}\times\Fin{d^L}
+        &\simeq (\Fin d\times\Fin d)^{\Fin L}
+         \simeq \Fin{(d^2)^L}.
+    \end{align}
     Under this identification, the doubled-index MPS tensor of $M^{[L]}$
     is the physical reindexing of the $L$-blocked doubled-index MPS tensor
     of $M$. In particular, one is injective if and only if the other is.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -508,7 +508,7 @@ $G_{\alpha,\beta}^{ij}=\bigoplus_\gamma
         exists_positive_block_with_injective_fusion}
     \leanok
     \uses{thm:cpsv_bnt_blocked_simultaneous_span,
-        thm:mpdo_positive_blocking_doubled_index,
+        thm:mpdo_blocking_doubled_index,
         thm:mpdo_positive_blocking_product,
         thm:mpdo_bnt_length_independent_zipper}
     Suppose that the labelled doubled-index tensors form the basis of normal

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -68,7 +68,7 @@
     \label{def:mpdo_simple_tensor}
     \lean{MPOTensor.IsSimple}
     \leanok
-    \uses{def:mpdo, def:mpdo_positive_physical_blocking,
+    \uses{def:mpdo, def:mpdo_physical_blocking,
         def:mpdo_simple_cf_tensor}
     First block a positive number of physical sites and write the blocked
     doubled-index tensor in canonical form over a basis of normal tensors, as

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3163,8 +3163,10 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}\leanok
     \uses{def:mpu_full_active_support,
-        def:mpu_active_blocks_blocking_equiv}
-    Reindex the sum of the unchanged active block dimensions by the
+        def:mpu_active_blocks_blocking_equiv,
+        thm:cpsv_literal_canonical_form_positive_blocking}
+    Positive blocking supplies canonical-form data with the same block
+    dimensions. Reindex their active-dimension sum by the
     equivalence in Definition~\ref{def:mpu_active_blocks_blocking_equiv}.
 \end{proof}
 
@@ -3495,6 +3497,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \uses{def:cpsv_cfii,def:mpu_normalized_flattening,
         thm:cpsv_literal_canonical_form_positive_blocking,
         thm:cpsv_physical_reindexing,
+        lem:blocked_irreducibility_direct_support,
         thm:mpu_left_canonical_blocking_reindexing,
         thm:mpu_normalized_flattening_blocking}
     Let $A$ have canonical-form-II data with retained weights $\mu_k$, blocks
@@ -3516,10 +3519,16 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     and then relabeling by $\vartheta_L$ from
     Theorem~\ref{thm:mpu_normalized_flattening_blocking}.
     Theorem~\ref{thm:mpu_left_canonical_blocking_reindexing} preserves the
-    left-canonical identity under both operations. The blocked transfer map
-    of each retained block is the $L$th power of its original transfer map.
-    Hence it fixes the same $\Lambda_k$, while positivity and diagonality are
-    unchanged. A physical bijection leaves the transfer map unchanged. The
+    left-canonical identity under both operations. For each retained block,
+    Lemma~\ref{lem:blocked_irreducibility_direct_support} gives
+    \begin{align}
+        \E_{A_k^{[L]}}&=\E_{A_k}^{L},
+        &\E_{A_k}^{L}(\Lambda_k)&=\Lambda_k.
+    \end{align}
+    The second identity follows by iterating
+    $\E_{A_k}(\Lambda_k)=\Lambda_k$. Thus the same positive definite diagonal
+    matrix is fixed after blocking. A physical bijection leaves the transfer
+    map unchanged. The
     final construction applies these two operations to
     (\ref{eq:mpu_normalized_flattening_blocking}).
 \end{definition}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3131,6 +3131,51 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{definition}
 
+\begin{theorem}[Active blocks and full support under physical blocking]
+    \label{thm:mpu_full_active_support_blocking}
+    \lean{MPSTensor.CPSVCanonicalFormData.activeEquivBlockTensor,
+        MPSTensor.CPSVCanonicalFormData.hasFullActiveSupport_blockTensor}
+    \leanok
+    \uses{def:mpu_full_active_support,
+        thm:cpsv_literal_canonical_form_positive_blocking}
+    Let canonical-form data for $A$ have active block set
+    $K=\{k\mid\mu_k\ne0\}$. For every positive integer $L$, the active
+    blocks of the blocked data are canonically identified with $K$ because
+    \begin{align}
+        \mu_k^L\ne0 &\iff \mu_k\ne0.
+    \end{align}
+    Under this identification their bond dimensions are unchanged. In
+    particular, if
+    \begin{align}
+        \sum_{k\in K}D_k&=D,
+    \end{align}
+    then the positively blocked canonical-form data also have full active
+    support.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_full_active_support,
+        thm:cpsv_literal_canonical_form_positive_blocking}
+    Positive blocking replaces each weight $\mu_k$ by $\mu_k^L$. Since
+    $L>0$, this preserves precisely the nonzero weights. Reindex the sum of
+    the unchanged active block dimensions by the resulting bijection.
+\end{proof}
+
+\begin{theorem}[Full active support under physical relabeling]
+    \label{thm:mpu_full_active_support_reindexing}
+    \lean{MPSTensor.CPSVCanonicalFormData.hasFullActiveSupport_reindexPhysical}
+    \leanok
+    \uses{def:mpu_full_active_support,thm:cpsv_physical_reindexing}
+    A bijective relabeling of the physical alphabet preserves full active
+    support of canonical-form data.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_full_active_support,thm:cpsv_physical_reindexing}
+    Physical relabeling leaves the weights, active blocks, and their bond
+    dimensions unchanged, so the full-support sum is unchanged.
+\end{proof}
+
 \begin{theorem}[An ambient-dimensional active block is irreducible]
     \label{thm:mpu_active_block_ambient_irreducible}
     \lean{MPSTensor.CPSVCanonicalFormData.isIrreducibleTensor_of_active_dim_eq}
@@ -3357,6 +3402,81 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     This is the normalization used in the normal-tensor argument of
     \cite[Section~III, equation~(13)]{Cirac2017MPU}.
 \end{definition}
+
+\begin{theorem}[Normalized flattening under blocking]
+    \label{thm:mpu_normalized_flattening_blocking}
+    \lean{MPOTensor.normalizedFlattening_blockTensor}
+    \leanok
+    \uses{def:mpu_normalized_flattening,
+        thm:mpdo_positive_blocking_doubled_index}
+    Let $\mathcal U$ be an MPO tensor of physical dimension $d$, and let
+    $L\geq0$. Pairing the ket and bra letters at each site gives a canonical
+    bijection
+    \begin{align}
+        \vartheta_L:\{0,\ldots,d^L-1\}^2
+          &\longrightarrow \{0,\ldots,d^2-1\}^L.
+    \end{align}
+    If $\widetilde{\mathcal U}=d^{-1/2}\mathcal U$ denotes normalized
+    flattening, then
+    \begin{align}
+        \widetilde{\mathcal U^{[L]}}
+          &=\vartheta_L^*\bigl(\widetilde{\mathcal U}^{[L]}\bigr).
+        \label{eq:mpu_normalized_flattening_blocking}
+    \end{align}
+    Thus normalized flattening commutes with blocking, up to the canonical
+    doubled-index relabeling. This is the normalized form of the blocking
+    operation in \cite[Definition~II.5 and equation~(9)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_normalized_flattening,
+        thm:mpdo_positive_blocking_doubled_index}
+    A blocked letter is a product of $L$ original letters. The identity
+    \begin{align}
+        \bigl(\sqrt{d^L}\bigr)^{-1}
+          &=\bigl((\sqrt d)^{-1}\bigr)^L
+    \end{align}
+    identifies its normalization with the product of the $L$ one-site
+    normalizations. Theorem~\ref{thm:mpdo_positive_blocking_doubled_index}
+    identifies the two physical indexings.
+\end{proof}
+
+\begin{theorem}[Canonical-form-II data under blocking and relabeling]
+    \label{thm:mpu_cfii_blocking_reindexing}
+    \lean{MPSTensor.CPSVCanonicalFormIIData.blockTensor,
+        MPSTensor.CPSVCanonicalFormIIData.reindexPhysical,
+        MPOTensor.blockTensorCFIIData}
+    \leanok
+    \uses{def:cpsv_cfii,def:mpu_normalized_flattening,
+        thm:cpsv_literal_canonical_form_positive_blocking,
+        thm:cpsv_physical_reindexing,
+        thm:mpu_normalized_flattening_blocking}
+    Let $A$ have canonical-form-II data with retained weights $\mu_k$, blocks
+    $A_k$, and positive definite diagonal fixed matrices $\Lambda_k$. For
+    every positive integer $L$, the blocked tensor $A^{[L]}$ has
+    canonical-form-II data with weights $\mu_k^L$, blocks $A_k^{[L]}$, and
+    the same matrices $\Lambda_k$. A bijective relabeling of the physical
+    alphabet likewise preserves canonical-form-II data and the matrices
+    $\Lambda_k$.
+
+    Consequently, if the normalized flattening $\widetilde{\mathcal U}$ of an
+    MPO tensor has canonical-form-II data, then for every $L>0$ the normalized
+    flattening of $\mathcal U^{[L]}$ has the data obtained by first blocking
+    and then relabeling by $\vartheta_L$ from
+    Theorem~\ref{thm:mpu_normalized_flattening_blocking}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:cpsv_cfii,
+        thm:cpsv_literal_canonical_form_positive_blocking,
+        thm:cpsv_physical_reindexing,
+        thm:mpu_normalized_flattening_blocking}
+    The blocked transfer map of each retained block is the $L$th power of its
+    original transfer map. Hence it fixes the same $\Lambda_k$, while
+    positivity and diagonality are unchanged. A physical bijection leaves the
+    transfer map unchanged. Apply these two constructions to
+    equation~(\ref{eq:mpu_normalized_flattening_blocking}).
+\end{proof}
 
 \begin{theorem}[Self-overlap scaling]
     \label{thm:mpu_self_overlap_scaling}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3415,8 +3415,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     $0^{-1}=0$, the algebraic identity below also holds for $d=0$. Pairing
     the ket and bra letters at each site gives a canonical bijection
     \begin{align}
-        \vartheta_L:\{0,\ldots,d^L-1\}^2
-          &\longrightarrow \{0,\ldots,d^2-1\}^L.
+        \vartheta_L:\operatorname{Fin}(d^L)^2
+          &\longrightarrow \operatorname{Fin}(d^2)^L.
     \end{align}
     If $\widetilde{\mathcal U}=d^{-1/2}\mathcal U$ denotes normalized
     flattening, then
@@ -3449,7 +3449,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPSTensor.leftCanonical_blockTensor,
         MPSTensor.leftCanonical_reindexPhysical_equiv}
     \leanok
-    \uses{def:blocked_tensor,thm:cpsv_physical_reindexing}
+    \uses{def:blocked_tensor,def:left_canonical_tensor}
     Suppose that an MPS tensor $A$ is left-canonical:
     \begin{align}
         \sum_i (A^i)^\dagger A^i&=\Id.
@@ -3470,16 +3470,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:blocked_tensor,thm:cpsv_physical_reindexing}
-    Expand equation~(\ref{eq:mpu_left_canonical_blocking}) as a sum over
+    \uses{def:blocked_tensor,def:left_canonical_tensor}
+    Expand~(\ref{eq:mpu_left_canonical_blocking}) as a sum over
     length-$L$ words and sum one letter at a time, repeatedly applying the
     one-site left-canonical identity. For $L=0$, the unique empty word
-    evaluates to the identity. Equation~(\ref{eq:mpu_left_canonical_reindexing})
-    follows by reindexing the finite sum along $e$.
+    evaluates to the identity. The equivalence
+    (\ref{eq:mpu_left_canonical_reindexing}) follows by reindexing the finite
+    sum along $e$.
 \end{proof}
 
-\begin{theorem}[Canonical-form-II data under blocking and relabeling]
-    \label{thm:mpu_cfii_blocking_reindexing}
+\begin{definition}[Canonical-form-II data under blocking and relabeling]
+    \label{def:mpu_cfii_blocking_reindexing}
     \lean{MPSTensor.CPSVCanonicalFormIIData.blockTensor,
         MPSTensor.CPSVCanonicalFormIIData.reindexPhysical,
         MPOTensor.blockTensorCFIIData}
@@ -3507,22 +3508,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     flattening of $\mathcal U^{[L]}$ has the data obtained by first blocking
     and then relabeling by $\vartheta_L$ from
     Theorem~\ref{thm:mpu_normalized_flattening_blocking}.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:cpsv_cfii,
-        thm:cpsv_literal_canonical_form_positive_blocking,
-        thm:cpsv_physical_reindexing,
-        thm:mpu_left_canonical_blocking_reindexing,
-        thm:mpu_normalized_flattening_blocking}
     Theorem~\ref{thm:mpu_left_canonical_blocking_reindexing} preserves the
     left-canonical identity under both operations. The blocked transfer map
-    of each retained block is the $L$th power of its
-    original transfer map. Hence it fixes the same $\Lambda_k$, while
-    positivity and diagonality are unchanged. A physical bijection leaves the
-    transfer map unchanged. Apply these two constructions to
-    equation~(\ref{eq:mpu_normalized_flattening_blocking}).
-\end{proof}
+    of each retained block is the $L$th power of its original transfer map.
+    Hence it fixes the same $\Lambda_k$, while positivity and diagonality are
+    unchanged. A physical bijection leaves the transfer map unchanged. The
+    final construction applies these two operations to
+    (\ref{eq:mpu_normalized_flattening_blocking}).
+\end{definition}
 
 \begin{theorem}[Self-overlap scaling]
     \label{thm:mpu_self_overlap_scaling}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3151,7 +3151,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPSTensor.CPSVCanonicalFormData.hasFullActiveSupport_blockTensor}
     \leanok
     \uses{def:mpu_full_active_support,
-        def:mpu_active_blocks_blocking_equiv}
+        def:mpu_active_blocks_blocking_equiv,
+        thm:cpsv_literal_canonical_form_positive_blocking}
     Suppose that canonical-form data have active block set $K$ and full active
     support:
     \begin{align}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1610,7 +1610,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{def:mpu_tensor_product_block_equiv}
     \lean{MPOTensor.tensorProductBlockEquiv}
     \leanok
-    \uses{def:mpdo_positive_physical_blocking}
+    \uses{def:mpdo_physical_blocking}
     A blocked word of $L$ product letters separates canonically into two
     blocked words:
     \begin{align}
@@ -1694,7 +1694,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_block_tensor_product}
     \lean{MPOTensor.blockTensor_tensorProduct}
     \leanok
-    \uses{def:mpdo_positive_physical_blocking,
+    \uses{def:mpdo_physical_blocking,
         def:mpu_physical_reindexing,def:mpu_independent_tensor_product,
         def:mpu_tensor_product_block_equiv}
     For every blocking length $L$, separating each blocked product letter by
@@ -1708,7 +1708,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpdo_positive_physical_blocking,
+    \uses{def:mpdo_physical_blocking,
         def:mpu_physical_reindexing,def:mpu_independent_tensor_product,
         thm:mpu_tensor_product_block_decoding}
     Evaluate both sides on blocked ket and bra letters. Word multiplication of
@@ -1792,7 +1792,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.rightRank_blockTensor_succ_le,
         MPOTensor.leftRank_blockTensor_succ_le}
     \leanok
-    \uses{def:mpdo_positive_physical_blocking,def:mpu_source_matrix_one,
+    \uses{def:mpdo_physical_blocking,def:mpu_source_matrix_one,
         def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank}
     Let $\mathcal U^{[L]}$ denote the direct blocking of $L$ sites of a tensor
     $\mathcal U$ with physical dimension $d$, and let $r_L$ and $\ell_L$ be
@@ -2703,7 +2703,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.outputLayer_normalizedDiagonal_pow_eq_vecMulVec}
     \leanok
     \uses{def:mpu_double_layer,def:mpdo_physical_adjoint,
-        def:mpdo_positive_physical_blocking,def:mpu_normalized_flattening,
+        def:mpdo_physical_blocking,def:mpu_normalized_flattening,
         def:mpu_transfer_matrix}
     Let $\mathcal U$ be an MPO tensor.  Write $E$ for the transfer matrix of
     its normalized flattening, $E^\sharp$ for that of $\mathcal U^\sharp$,
@@ -2761,7 +2761,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         MPOTensor.IsMPU.reflected_blockTensor_mul_sq_add_two_simple_contractions}
     \leanok
     \uses{def:mpu,def:mpu_double_layer,def:mpdo_physical_adjoint,
-        def:mpdo_positive_physical_blocking,def:mpu_normalized_flattening,
+        def:mpdo_physical_blocking,def:mpu_normalized_flattening,
         def:mpu_transfer_matrix}
     Let $\mathcal U$ be an MPU with $d,D>0$.  Let $E$ be the transfer matrix
     of its normalized flattening, and suppose
@@ -3408,10 +3408,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.normalizedFlattening_blockTensor}
     \leanok
     \uses{def:mpu_normalized_flattening,
-        thm:mpdo_positive_blocking_doubled_index}
+        thm:mpdo_blocking_doubled_index}
     Let $\mathcal U$ be an MPO tensor of physical dimension $d$, and let
-    $L\geq0$. Pairing the ket and bra letters at each site gives a canonical
-    bijection
+    $L\geq0$. For the normalized-tensor interpretation assume $d>0$, as in
+    Definition~\ref{def:mpu_normalized_flattening}; with the convention
+    $0^{-1}=0$, the algebraic identity below also holds for $d=0$. Pairing
+    the ket and bra letters at each site gives a canonical bijection
     \begin{align}
         \vartheta_L:\{0,\ldots,d^L-1\}^2
           &\longrightarrow \{0,\ldots,d^2-1\}^L.
@@ -3430,15 +3432,50 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{proof}\leanok
     \uses{def:mpu_normalized_flattening,
-        thm:mpdo_positive_blocking_doubled_index}
+        thm:mpdo_blocking_doubled_index}
     A blocked letter is a product of $L$ original letters. The identity
     \begin{align}
         \bigl(\sqrt{d^L}\bigr)^{-1}
           &=\bigl((\sqrt d)^{-1}\bigr)^L
     \end{align}
     identifies its normalization with the product of the $L$ one-site
-    normalizations. Theorem~\ref{thm:mpdo_positive_blocking_doubled_index}
-    identifies the two physical indexings.
+    normalizations. Theorem~\ref{thm:mpdo_blocking_doubled_index}
+    identifies the two physical indexings for every $L\geq0$; at $L=0$ both
+    blocked words are empty and both local matrix products are the identity.
+\end{proof}
+
+\begin{theorem}[Left-canonical normalization under blocking and relabeling]
+    \label{thm:mpu_left_canonical_blocking_reindexing}
+    \lean{MPSTensor.leftCanonical_blockTensor,
+        MPSTensor.leftCanonical_reindexPhysical_equiv}
+    \leanok
+    \uses{def:blocked_tensor,thm:cpsv_physical_reindexing}
+    Suppose that an MPS tensor $A$ is left-canonical:
+    \begin{align}
+        \sum_i (A^i)^\dagger A^i&=\Id.
+    \end{align}
+    Then for every $L\geq0$ its blocked tensor is left-canonical:
+    \begin{align}
+        \sum_I \bigl((A^{[L]})^I\bigr)^\dagger(A^{[L]})^I&=\Id.
+        \label{eq:mpu_left_canonical_blocking}
+    \end{align}
+    If $e$ is a bijection of physical alphabets, then $e^*A$ is
+    left-canonical if and only if $A$ is:
+    \begin{align}
+        \sum_j \bigl((e^*A)^j\bigr)^\dagger(e^*A)^j=\Id
+        \quad\Longleftrightarrow\quad
+        \sum_i(A^i)^\dagger A^i=\Id.
+        \label{eq:mpu_left_canonical_reindexing}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:blocked_tensor,thm:cpsv_physical_reindexing}
+    Expand equation~(\ref{eq:mpu_left_canonical_blocking}) as a sum over
+    length-$L$ words and sum one letter at a time, repeatedly applying the
+    one-site left-canonical identity. For $L=0$, the unique empty word
+    evaluates to the identity. Equation~(\ref{eq:mpu_left_canonical_reindexing})
+    follows by reindexing the finite sum along $e$.
 \end{proof}
 
 \begin{theorem}[Canonical-form-II data under blocking and relabeling]
@@ -3450,14 +3487,20 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \uses{def:cpsv_cfii,def:mpu_normalized_flattening,
         thm:cpsv_literal_canonical_form_positive_blocking,
         thm:cpsv_physical_reindexing,
+        thm:mpu_left_canonical_blocking_reindexing,
         thm:mpu_normalized_flattening_blocking}
     Let $A$ have canonical-form-II data with retained weights $\mu_k$, blocks
     $A_k$, and positive definite diagonal fixed matrices $\Lambda_k$. For
     every positive integer $L$, the blocked tensor $A^{[L]}$ has
     canonical-form-II data with weights $\mu_k^L$, blocks $A_k^{[L]}$, and
-    the same matrices $\Lambda_k$. A bijective relabeling of the physical
-    alphabet likewise preserves canonical-form-II data and the matrices
-    $\Lambda_k$.
+    the same matrices $\Lambda_k$. The retained blocks remain
+    left-canonical:
+    \begin{align}
+        \sum_I \bigl((A_k^{[L]})^I\bigr)^\dagger(A_k^{[L]})^I&=\Id.
+    \end{align}
+    A bijective relabeling of the physical alphabet likewise preserves
+    canonical-form-II data, including both the matrices $\Lambda_k$ and the
+    left-canonical identities.
 
     Consequently, if the normalized flattening $\widetilde{\mathcal U}$ of an
     MPO tensor has canonical-form-II data, then for every $L>0$ the normalized
@@ -3470,8 +3513,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \uses{def:cpsv_cfii,
         thm:cpsv_literal_canonical_form_positive_blocking,
         thm:cpsv_physical_reindexing,
+        thm:mpu_left_canonical_blocking_reindexing,
         thm:mpu_normalized_flattening_blocking}
-    The blocked transfer map of each retained block is the $L$th power of its
+    Theorem~\ref{thm:mpu_left_canonical_blocking_reindexing} preserves the
+    left-canonical identity under both operations. The blocked transfer map
+    of each retained block is the $L$th power of its
     original transfer map. Hence it fixes the same $\Lambda_k$, while
     positivity and diagonality are unchanged. A physical bijection leaves the
     transfer map unchanged. Apply these two constructions to
@@ -4010,7 +4056,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \lean{MPOTensor.IsMPU.exists_reduced_cfii_forced_block_simple_contractions}
     \leanok
     \uses{def:mpu,def:mpu_normalized_flattening,def:cpsv_cfii,
-        def:mpu_full_active_support,def:mpdo_positive_physical_blocking,
+        def:mpu_full_active_support,def:mpdo_physical_blocking,
         def:mpu_double_layer}
     Let $d>0$, $D>1$, and let $\mathcal U$ be an MPU whose normalized
     flattening has chosen canonical-form-II data with full active support. Put

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -3131,34 +3131,41 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{definition}
 
-\begin{theorem}[Active blocks and full support under physical blocking]
+\begin{definition}[Active-block equivalence under physical blocking]
+    \label{def:mpu_active_blocks_blocking_equiv}
+    \lean{MPSTensor.CPSVCanonicalFormData.activeEquivBlockTensor}
+    \leanok
+    \uses{thm:cpsv_literal_canonical_form_positive_blocking}
+    Let canonical-form data for $A$ have active block set
+    $K=\{k\mid\mu_k\ne0\}$. For every positive integer $L$, positive
+    blocking gives the canonical identification
+    \begin{align}
+        \{k\mid\mu_k^L\ne0\}&\simeq K,
+    \end{align}
+    induced by $\mu_k^L\ne0\iff\mu_k\ne0$. Under this identification, every
+    active block retains its bond dimension.
+\end{definition}
+
+\begin{theorem}[Full active support under physical blocking]
     \label{thm:mpu_full_active_support_blocking}
-    \lean{MPSTensor.CPSVCanonicalFormData.activeEquivBlockTensor,
-        MPSTensor.CPSVCanonicalFormData.hasFullActiveSupport_blockTensor}
+    \lean{MPSTensor.CPSVCanonicalFormData.hasFullActiveSupport_blockTensor}
     \leanok
     \uses{def:mpu_full_active_support,
-        thm:cpsv_literal_canonical_form_positive_blocking}
-    Let canonical-form data for $A$ have active block set
-    $K=\{k\mid\mu_k\ne0\}$. For every positive integer $L$, the active
-    blocks of the blocked data are canonically identified with $K$ because
+        def:mpu_active_blocks_blocking_equiv}
+    Suppose that canonical-form data have active block set $K$ and full active
+    support:
     \begin{align}
-        \mu_k^L\ne0 &\iff \mu_k\ne0.
+        \sum_{k\in K}D_k&=D.
     \end{align}
-    Under this identification their bond dimensions are unchanged. In
-    particular, if
-    \begin{align}
-        \sum_{k\in K}D_k&=D,
-    \end{align}
-    then the positively blocked canonical-form data also have full active
+    Then every positive physical blocking of these data also has full active
     support.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpu_full_active_support,
-        thm:cpsv_literal_canonical_form_positive_blocking}
-    Positive blocking replaces each weight $\mu_k$ by $\mu_k^L$. Since
-    $L>0$, this preserves precisely the nonzero weights. Reindex the sum of
-    the unchanged active block dimensions by the resulting bijection.
+        def:mpu_active_blocks_blocking_equiv}
+    Reindex the sum of the unchanged active block dimensions by the
+    equivalence in Definition~\ref{def:mpu_active_blocks_blocking_equiv}.
 \end{proof}
 
 \begin{theorem}[Full active support under physical relabeling]


### PR DESCRIPTION
## Summary
- document normalized flattening commuting with physical blocking under the canonical doubled-index relabeling
- document preservation of canonical-form-II data under positive blocking and physical relabeling
- document preservation of active indices and full active support under positive blocking and relabeling

## Checks
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7332/7332 entries in sync)
- `cd blueprint && leanblueprint web` with no `ERROR:` or unknown-renderer warnings
- `git diff --check`

No Lean source was changed and no broad Lake/Mathlib build was run.

Closes #6224

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint/LaTeX changes with synchronized lean decl tags; no Lean source or runtime behavior is modified.
> 
> **Overview**
> **Generalizes MPO physical blocking** in the blueprint from positive lengths only to **all integers \(L\geq0\)**, including the \(L=0\) identity local tensor, and renames `def:mpdo_physical_blocking` / `thm:mpdo_blocking_doubled_index` (formerly “positive” variants). The doubled-index blocking theorem is restated for every \(L\geq0\) with explicit \(\Fin{}\) identifications and an updated proof sketch for the empty-word case.
> 
> **Cross-chapter reference updates** wire the new labels through MPDO RFP/simple definitions, fusion isometries, and the MPU chapter (product blocking, source-cut ranks, reflected transfer powers, reduced CFII).
> 
> **New MPU documentation** in `ch28_mpu.tex` records preservation under positive blocking and physical relabeling: active-block equivalence and **full active support**; **normalized flattening commuting with blocking** (up to \(\vartheta_L\)); **left-canonical** identities for blocked tensors and reindexing; and a definition tying **canonical-form-II data** (weights \(\mu_k^L\), blocks \(A_k^{[L]}\), fixed \(\Lambda_k\), transfer powers) to blocking plus doubled-index relabeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb4bcc7001401db9de35442024594b111ee6986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->