### PR TITLE
fix(MPDO): add direct key-formula import owners

### DIFF
--- a/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
+++ b/TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTThreeSiteCollapse
+import TNLean.MPS.MPDO.BiCFDerivation.Core
+import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.SimpleLocalStructure
 
 /-!


### PR DESCRIPTION
## Summary
- import `MPDO.Defs` directly for `physicalSlice`
- import `BiCFDerivation.Core` directly for `MPSTensor.IsMPOBlockLeftInverse`
- preserve every declaration, proof, docstring, and Blueprint entry

## Source scope
Import hygiene only. The existing comparison remains the entrywise Appendix C.2 `keyformula` relating BNT sectors and the quantum-Markov decomposition in arXiv:1606.00608, lines 1719--1732.

## Validation
- `lake env lean TNLean/MPS/MPDO/BNTMarkovKeyFormula.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/test_lean_file_policies.py`
- `git diff --check`

Closes #6241

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two new import lines only; no logic or API changes.
> 
> **Overview**
> **Import hygiene only** for `BNTMarkovKeyFormula.lean`: the module now imports `TNLean.MPS.MPDO.Defs` and `TNLean.MPS.MPDO.BiCFDerivation.Core` directly so symbols used in the Appendix C.2 key formula (`physicalSlice`, `MPSTensor.IsMPOBlockLeftInverse`) are owned by explicit imports rather than transitive ones.
> 
> No theorems, proofs, docstrings, or Blueprint entries change; behavior of the BNT vs quantum-Markov comparison module is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b8856c536b5c11446734ae228a6e5a97d3efd07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->