### PR TITLE
feat(MPS/MPU): preserve unitarity under composition

### DIFF
--- a/TNLean/MPS/MPU/Basic.lean
+++ b/TNLean/MPS/MPU/Basic.lean
@@ -89,7 +89,7 @@ lemma conjTranspose_mpo_mul_mpo {U : MPOTensor d D} (hU : IsMPU U) {N : ℕ} (hN
 /-- Concatenating two matrix product unitary tensors in the order `U * V`
 again gives a matrix product unitary tensor.
 
-The local tensor is `mulTensor U V`, whose periodic operator is
+The local tensor is `MPOTensor.mulTensor U V`, whose periodic operator is
 `mpo U N * mpo V N`; thus the order agrees with the concatenation tensor
 constructed in the source.
 

--- a/TNLean/MPS/MPU/Basic.lean
+++ b/TNLean/MPS/MPU/Basic.lean
@@ -86,6 +86,21 @@ lemma conjTranspose_mpo_mul_mpo {U : MPOTensor d D} (hU : IsMPU U) {N : ℕ} (hN
   rw [Matrix.mem_unitaryGroup_iff'] at hmem
   simpa [Matrix.star_eq_conjTranspose] using hmem
 
+/-- Concatenating two matrix product unitary tensors in the order `U * V`
+again gives a matrix product unitary tensor.
+
+The local tensor is `mulTensor U V`, whose periodic operator is
+`mpo U N * mpo V N`; thus the order agrees with the concatenation tensor
+constructed in the source.
+
+Source: arXiv:1703.09188, proof of Theorem `IndexTh` (ii), lines 837--841. -/
+theorem mulTensor {D₁ D₂ : ℕ} {U : MPOTensor d D₁} {V : MPOTensor d D₂}
+    (hU : IsMPU U) (hV : IsMPU V) : IsMPU (MPOTensor.mulTensor U V) := by
+  intro N hN
+  rw [mpo_mulTensor]
+  exact (Matrix.unitaryGroup (Fin N → Fin d) ℂ).mul_mem
+    (hU.mpo_mem_unitaryGroup hN) (hV.mpo_mem_unitaryGroup hN)
+
 end IsMPU
 
 /-! ### Blocking preservation -/

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -144,6 +144,28 @@ closing a chain of $N$ copies of $\mathcal U$.
     Use the equivalent left-multiplied characterization of a unitary matrix.
 \end{proof}
 
+\begin{theorem}[Composition preserves matrix product unitarity]
+    \label{thm:mpu_composition}
+    \lean{MPOTensor.IsMPU.mulTensor}
+    \leanok
+    \uses{def:mpu,def:mpdo_operator_product,
+        thm:mpdo_operator_product_mpo}
+    Let $\mathcal U$ and $\mathcal V$ be matrix product unitary tensors with the
+    same physical dimension.  Contracting the output index of $\mathcal U$
+    with the input index of $\mathcal V$ gives a matrix product unitary tensor
+    whose periodic operator is $U^{(N)}V^{(N)}$, in that order.  This is the
+    concatenation tensor $\mathcal W$ in the proof of
+    \cite[Theorem~IV.3(ii)]{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu,thm:mpdo_operator_product_mpo}
+    For every $N>1$, both $U^{(N)}$ and $V^{(N)}$ are unitary.  The defining
+    contraction of the product tensor gives the periodic operator
+    $U^{(N)}V^{(N)}$, which is unitary because the unitary matrices form a
+    group under multiplication.
+\end{proof}
+
 \begin{lemma}[Physical blocking preserves matrix product unitarity]
     \label{lem:mpu_blocking}
     \lean{MPOTensor.IsMPU.blockTensor}


### PR DESCRIPTION
## Summary

- prove that `MPOTensor.mulTensor U V` preserves `MPOTensor.IsMPU`
- rewrite its periodic operator as `mpo U N * mpo V N` and use unitary-group closure under multiplication
- preserve the source's composition order exactly and synchronize Chapter 28 with the concatenation tensor in Theorem `IndexTh` (ii)

This PR is intentionally limited to periodic unitarity under composition. It does not address source-cut rank bounds, standard form, or index additivity.

## Checks

- `lake env lean TNLean/MPS/MPU/Basic.lean`
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint --changed-files TNLean/MPS/MPU/Basic.lean --diff-base origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- proof-integrity scan of `TNLean/MPS/MPU/Basic.lean`
- `git diff --check`

Closes #6256

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive formalization in MPU theory; proof reuses existing `mpo_mulTensor` and standard group lemmas with no behavioral or infrastructure changes.
> 
> **Overview**
> **Composition of MPU tensors stays MPU.** The PR adds `MPOTensor.IsMPU.mulTensor`: if `U` and `V` are matrix product unitary, then `MPOTensor.mulTensor U V` is too. For each `N > 1`, the periodic operator is `mpo U N * mpo V N` via `mpo_mulTensor`, and unitarity follows from closure of the unitary group under multiplication.
> 
> Chapter 28 (`ch28_mpu.tex`) gains **Theorem `thm:mpu_composition`**, linked to the Lean proof and aligned with Cirac et al. Theorem IV.3(ii) concatenation order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd54e594ebe0c6c0e1eee53f896574ca347740e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->