### PR TITLE
MPU: saturate blocking rank bounds from endpoint products

### DIFF
--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -25,6 +25,9 @@ No simplicity or MPU hypothesis is needed for these rank inequalities.
 * `leftRank_blockTensor_succ_le`: one-site left-rank bound.
 * `rightRank_blockTensor_le_pow_mul`: iterated right-rank bound.
 * `leftRank_blockTensor_le_pow_mul`: iterated left-rank bound.
+* `blockingRanks_eq_pow_mul_of_products`: simultaneous exact rank growth.
+* `rightRank_blockTensor_eq_pow_mul_of_products`: exact right-rank growth.
+* `leftRank_blockTensor_eq_pow_mul_of_products`: exact left-rank growth.
 -/
 
 open scoped BigOperators
@@ -236,5 +239,54 @@ theorem leftRank_blockTensor_le_pow_mul (U : MPOTensor d D) {k₀ k : ℕ}
         _ = d ^ (k + 1 - k₀) * ℓ[blockTensor U k₀] := by
           rw [Nat.succ_sub (by omega), pow_succ]
           simp [Nat.mul_assoc, Nat.mul_comm]
+
+/-- If the endpoint right--left rank products have their physical-dimension
+values, then both blocking rank bounds are saturated.
+
+This is the arithmetic saturation step in the proof of arXiv:1703.09188,
+Proposition IV.2 (`index-well-defined`), line 703. The endpoint product
+identities are supplied explicitly; a later application of the paper's
+fundamental theorem will establish them for simple MPU blocks. -/
+theorem blockingRanks_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
+    (h : k₀ ≤ k) (hd : 0 < d)
+    (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))
+    (hprod : r[blockTensor U k] * ℓ[blockTensor U k] = d ^ (2 * k)) :
+    r[blockTensor U k] = d ^ (k - k₀) * r[blockTensor U k₀] ∧
+      ℓ[blockTensor U k] = d ^ (k - k₀) * ℓ[blockTensor U k₀] := by
+  apply eq_and_eq_of_pos_of_le_of_mul_le_mul
+  · exact Nat.pos_of_mul_pos_right (hprod.symm ▸ Nat.pow_pos hd)
+  · exact Nat.pos_of_mul_pos_left (hprod.symm ▸ Nat.pow_pos hd)
+  · exact rightRank_blockTensor_le_pow_mul U h
+  · exact leftRank_blockTensor_le_pow_mul U h
+  · rw [hprod]
+    calc
+      d ^ (k - k₀) * r[blockTensor U k₀] *
+          (d ^ (k - k₀) * ℓ[blockTensor U k₀]) =
+          d ^ (2 * (k - k₀)) *
+            (r[blockTensor U k₀] * ℓ[blockTensor U k₀]) := by ring
+      _ = d ^ (2 * (k - k₀)) * d ^ (2 * k₀) := by rw [hprod₀]
+      _ = d ^ (2 * k) := by
+        rw [← pow_add]
+        congr 1
+        omega
+    exact le_rfl
+
+/-- The right source-cut rank attains its blocking upper bound when the endpoint
+rank products have their physical-dimension values. -/
+theorem rightRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
+    (h : k₀ ≤ k) (hd : 0 < d)
+    (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))
+    (hprod : r[blockTensor U k] * ℓ[blockTensor U k] = d ^ (2 * k)) :
+    r[blockTensor U k] = d ^ (k - k₀) * r[blockTensor U k₀] :=
+  (blockingRanks_eq_pow_mul_of_products U h hd hprod₀ hprod).1
+
+/-- The left source-cut rank attains its blocking upper bound when the endpoint
+rank products have their physical-dimension values. -/
+theorem leftRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
+    (h : k₀ ≤ k) (hd : 0 < d)
+    (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))
+    (hprod : r[blockTensor U k] * ℓ[blockTensor U k] = d ^ (2 * k)) :
+    ℓ[blockTensor U k] = d ^ (k - k₀) * ℓ[blockTensor U k₀] :=
+  (blockingRanks_eq_pow_mul_of_products U h hd hprod₀ hprod).2
 
 end MPOTensor

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -277,10 +277,14 @@ theorem blockingRanks_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     exact le_rfl
 
 /-- The right source-cut rank attains its blocking upper bound when the endpoint
-rank products have their physical-dimension values.
+products satisfy $r_{k_0}\ell_{k_0}=d^{2k_0}$ and $r_k\ell_k=d^{2k}$.
 
 This is the right-rank conclusion of the saturation step in the proof of
-arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), line 703. -/
+arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), line 703.
+
+**Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
+consistent blocked identity is $d^{2k}$. See
+`docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex`. -/
 theorem rightRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) (hd : 0 < d)
     (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))
@@ -289,10 +293,14 @@ theorem rightRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k
   (blockingRanks_eq_pow_mul_of_products U h hd hprod₀ hprod).1
 
 /-- The left source-cut rank attains its blocking upper bound when the endpoint
-rank products have their physical-dimension values.
+products satisfy $r_{k_0}\ell_{k_0}=d^{2k_0}$ and $r_k\ell_k=d^{2k}$.
 
 This is the left-rank conclusion of the saturation step in the proof of
-arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), line 703. -/
+arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), line 703.
+
+**Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
+consistent blocked identity is $d^{2k}$. See
+`docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex`. -/
 theorem leftRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) (hd : 0 < d)
     (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -249,7 +249,7 @@ identities are supplied explicitly; a later application of the paper's
 fundamental theorem will establish them for simple MPU blocks.
 
 **Local fix (rank-product exponent):** Source line 703 prints $d^k$; consistently
-with Theorem IV.1 and the blocked physical dimension $d^k$, the endpoint
+with Theorem III.8 and the blocked physical dimension $d^k$, the endpoint
 product is $d^{2k}$. See
 `docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex`. -/
 theorem blockingRanks_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
@@ -277,7 +277,10 @@ theorem blockingRanks_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     exact le_rfl
 
 /-- The right source-cut rank attains its blocking upper bound when the endpoint
-rank products have their physical-dimension values. -/
+rank products have their physical-dimension values.
+
+This is the right-rank conclusion of the saturation step in the proof of
+arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), line 703. -/
 theorem rightRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) (hd : 0 < d)
     (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))
@@ -286,7 +289,10 @@ theorem rightRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k
   (blockingRanks_eq_pow_mul_of_products U h hd hprod₀ hprod).1
 
 /-- The left source-cut rank attains its blocking upper bound when the endpoint
-rank products have their physical-dimension values. -/
+rank products have their physical-dimension values.
+
+This is the left-rank conclusion of the saturation step in the proof of
+arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), line 703. -/
 theorem leftRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) (hd : 0 < d)
     (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -246,7 +246,12 @@ values, then both blocking rank bounds are saturated.
 This is the arithmetic saturation step in the proof of arXiv:1703.09188,
 Proposition IV.2 (`index-well-defined`), line 703. The endpoint product
 identities are supplied explicitly; a later application of the paper's
-fundamental theorem will establish them for simple MPU blocks. -/
+fundamental theorem will establish them for simple MPU blocks.
+
+**Local fix (rank-product exponent):** Source line 703 prints $d^k$; consistently
+with Theorem IV.1 and the blocked physical dimension $d^k$, the endpoint
+product is $d^{2k}$. See
+`docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex`. -/
 theorem blockingRanks_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) (hd : 0 < d)
     (hprod₀ : r[blockTensor U k₀] * ℓ[blockTensor U k₀] = d ^ (2 * k₀))

--- a/TNLean/MPS/MPU/BlockingRanks.lean
+++ b/TNLean/MPS/MPU/BlockingRanks.lean
@@ -276,14 +276,15 @@ theorem blockingRanks_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
         omega
     exact le_rfl
 
-/-- The right source-cut rank attains its blocking upper bound when the endpoint
-products satisfy $r_{k_0}\ell_{k_0}=d^{2k_0}$ and $r_k\ell_k=d^{2k}$.
+/-- The right source-cut rank attains its blocking upper bound when
+$r_{k₀}\ell_{k₀}=d^{2k₀}$ and $r_k\ell_k=d^{2k}$.
 
 This is the right-rank conclusion of the saturation step in the proof of
 arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), line 703.
 
-**Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
-consistent blocked identity is $d^{2k}$. See
+**Local fix (rank-product exponent):** Source line 703 prints $d^k$; consistently
+with Theorem III.8 and the blocked physical dimension $d^k$, the endpoint
+product is $d^{2k}$. See
 `docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex`. -/
 theorem rightRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) (hd : 0 < d)
@@ -292,14 +293,15 @@ theorem rightRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k
     r[blockTensor U k] = d ^ (k - k₀) * r[blockTensor U k₀] :=
   (blockingRanks_eq_pow_mul_of_products U h hd hprod₀ hprod).1
 
-/-- The left source-cut rank attains its blocking upper bound when the endpoint
-products satisfy $r_{k_0}\ell_{k_0}=d^{2k_0}$ and $r_k\ell_k=d^{2k}$.
+/-- The left source-cut rank attains its blocking upper bound when
+$r_{k₀}\ell_{k₀}=d^{2k₀}$ and $r_k\ell_k=d^{2k}$.
 
 This is the left-rank conclusion of the saturation step in the proof of
 arXiv:1703.09188, Proposition IV.2 (`index-well-defined`), line 703.
 
-**Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
-consistent blocked identity is $d^{2k}$. See
+**Local fix (rank-product exponent):** Source line 703 prints $d^k$; consistently
+with Theorem III.8 and the blocked physical dimension $d^k$, the endpoint
+product is $d^{2k}$. See
 `docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex`. -/
 theorem leftRank_blockTensor_eq_pow_mul_of_products (U : MPOTensor d D) {k₀ k : ℕ}
     (h : k₀ ≤ k) (hd : 0 < d)

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1866,6 +1866,46 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{proof}
 
+\begin{theorem}[Exact blocking growth from endpoint rank products]
+    \label{thm:mpu_source_cut_rank_blocking_saturation}
+    \lean{MPOTensor.rightRank_blockTensor_eq_pow_mul_of_products,
+        MPOTensor.leftRank_blockTensor_eq_pow_mul_of_products}
+    \leanok
+    \uses{thm:mpu_source_cut_rank_blocking}
+    Let $d>0$ and $L_0\leq L$. Suppose the endpoint source-cut ranks satisfy
+    the supplied product identities
+    \begin{align}
+        r_{L_0}\ell_{L_0}&=d^{2L_0},&
+        r_L\ell_L&=d^{2L}.
+    \end{align}
+    Then the blocking bounds are exact:
+    \begin{align}
+        r_L&=d^{L-L_0}r_{L_0},&
+        \ell_L&=d^{L-L_0}\ell_{L_0}.
+    \end{align}
+    This is the saturation step in the proof of
+    \cite[Proposition~IV.2, line~703]{Cirac2017MPU}. The endpoint product
+    identities are hypotheses here; they are not consequences of the blocking
+    bounds.
+\end{theorem}
+
+\begin{proof}\leanok
+    The blocking bounds give
+    \begin{align}
+        r_L&\leq d^{L-L_0}r_{L_0},&
+        \ell_L&\leq d^{L-L_0}\ell_{L_0}.
+    \end{align}
+    Their upper bounds have product
+    \begin{align}
+      \bigl(d^{L-L_0}r_{L_0}\bigr)
+      \bigl(d^{L-L_0}\ell_{L_0}\bigr)
+      &=d^{2(L-L_0)}d^{2L_0}=d^{2L}=r_L\ell_L.
+    \end{align}
+    Since $d>0$, the latter product is positive, so both $r_L$ and $\ell_L$
+    are positive. Hence neither upper bound can be strict, and both equalities
+    follow.
+\end{proof}
+
 \begin{definition}[Product-index source weight]
     \label{def:mpu_source_weight}
     \lean{MPOTensor.sourceWeight}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1868,7 +1868,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{theorem}[Exact blocking growth from endpoint rank products]
     \label{thm:mpu_source_cut_rank_blocking_saturation}
-    \lean{MPOTensor.rightRank_blockTensor_eq_pow_mul_of_products,
+    \lean{MPOTensor.blockingRanks_eq_pow_mul_of_products,
+        MPOTensor.rightRank_blockTensor_eq_pow_mul_of_products,
         MPOTensor.leftRank_blockTensor_eq_pow_mul_of_products}
     \leanok
     Let $d>0$ and $L_0\leq L$. Suppose the endpoint source-cut ranks satisfy
@@ -1883,7 +1884,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         \ell_L&=d^{L-L_0}\ell_{L_0}.
     \end{align}
     This is the saturation step in the proof of
-    \cite[Proposition~IV.2, line~703]{Cirac2017MPU}. The endpoint product
+    \cite[Proposition~IV.2]{Cirac2017MPU}. The endpoint product
     identities are hypotheses here; they are not consequences of the blocking
     bounds.
 % **Local fix (rank-product exponent):** Source line 703 prints $d^k$; the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1871,7 +1871,6 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.rightRank_blockTensor_eq_pow_mul_of_products,
         MPOTensor.leftRank_blockTensor_eq_pow_mul_of_products}
     \leanok
-    \uses{thm:mpu_source_cut_rank_blocking}
     Let $d>0$ and $L_0\leq L$. Suppose the endpoint source-cut ranks satisfy
     the supplied product identities
     \begin{align}
@@ -1887,9 +1886,13 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \cite[Proposition~IV.2, line~703]{Cirac2017MPU}. The endpoint product
     identities are hypotheses here; they are not consequences of the blocking
     bounds.
+% **Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
+% consistent blocked identity is $d^{2k}$. See
+% docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_source_cut_rank_blocking}
     The blocking bounds give
     \begin{align}
         r_L&\leq d^{L-L_0}r_{L_0},&

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1884,9 +1884,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         \ell_L&=d^{L-L_0}\ell_{L_0}.
     \end{align}
     This is the saturation step in the proof of
-    \cite[Proposition~IV.2]{Cirac2017MPU}. The endpoint product
-    identities are hypotheses here; they are not consequences of the blocking
-    bounds.
+    \cite[Proposition~IV.2]{Cirac2017MPU}. The endpoint product identities are
+    hypotheses here; they are not consequences of the blocking bounds.
 % **Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
 % consistent blocked identity is $d^{2k}$. See
 % docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1884,8 +1884,9 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
         \ell_L&=d^{L-L_0}\ell_{L_0}.
     \end{align}
     This is the saturation step in the proof of
-    \cite[Proposition~IV.2]{Cirac2017MPU}. The endpoint product identities are
-    hypotheses here; they are not consequences of the blocking bounds.
+    \cite[Proposition~IV.2]{Cirac2017MPU}.
+% The endpoint product identities are supplied hypotheses here, not consequences
+% of the blocking bounds.
 % **Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
 % consistent blocked identity is $d^{2k}$. See
 % docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex.
@@ -4545,6 +4546,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \notready
   \discussion{6014}
   \uses{def:index,ThmFund1,thm:mpu_source_cut_rank_blocking,
+    thm:mpu_source_cut_rank_blocking_saturation,
     thm:mpu_all_later_simple_blockings}
   The source index is independent of the chosen simple blocking. More
   precisely, if $k\geq k_0$ and both $\mathcal U_{k_0}$ and $\mathcal U_k$

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1885,7 +1885,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
     This is the saturation step in the proof of
     \cite[Proposition~IV.2]{Cirac2017MPU}.
-% The endpoint product identities are supplied hypotheses here, not consequences
+% The endpoint product identities are hypotheses here; they are not consequences
 % of the blocking bounds.
 % **Local fix (rank-product exponent):** Source line 703 prints $d^k$; the
 % consistent blocked identity is $d^{2k}$. See

--- a/docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex
+++ b/docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex
@@ -25,7 +25,7 @@ Here the blocking length is $k$, so the blocked physical dimension is $d^k$.
 
 \section{Consistent rank-product identity}
 
-Theorem~IV.1, lines~561--568, states that for a simple tensor of physical
+Theorem~III.8, lines~561--568, states that for a simple tensor of physical
 dimension $q$, the corresponding ranks obey
 \[
   r\ell=q^2.
@@ -51,9 +51,16 @@ It takes the two endpoint identities
 \]
 as explicit hypotheses and combines them with the independently proved
 blocking upper bounds. A later application may obtain the hypotheses from the
-formal counterpart of Theorem~IV.1 under its own assumptions.
+formal counterpart of Theorem~III.8 under its own assumptions. The simultaneous
+saturation result is
+\leanid{MPOTensor.blockingRanks_eq_pow_mul_of_products}; its focused right- and
+left-rank accessors are
+\leanid{MPOTensor.rightRank_blockTensor_eq_pow_mul_of_products} and
+\leanid{MPOTensor.leftRank_blockTensor_eq_pow_mul_of_products}.
 
 \section{Verdict}
+
+\textbf{Verdict: local correction (resolved).}
 
 This is a local correction of the exponent in one sentence of the proof of
 Proposition~IV.2. It does not add an assumption beyond the rank-product

--- a/docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex
+++ b/docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex
@@ -1,0 +1,66 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{command}
+
+\title{The Endpoint Rank-Product Exponent in MPU Index Well-Definedness}
+\author{}
+\date{2026-08-12}
+
+\begin{document}
+\maketitle
+
+\section{The printed exponent}
+
+In the proof of Proposition~IV.2 of \cite{Cirac2017MPU}, line~703 of
+\path{Papers/1703.09188/paper_v2.tex} states that the right and left
+source-cut ranks of the blocked tensor satisfy
+\[
+  r_k\ell_k=d^k.
+\]
+Here the blocking length is $k$, so the blocked physical dimension is $d^k$.
+
+\section{Consistent rank-product identity}
+
+Theorem~IV.1, lines~561--568, states that for a simple tensor of physical
+dimension $q$, the corresponding ranks obey
+\[
+  r\ell=q^2.
+\]
+Applying this statement to the $k$-site block, whose physical dimension is
+$q=d^k$, gives
+\[
+  r_k\ell_k=(d^k)^2=d^{2k}.
+\]
+The same square appears in the one-site discussion at line~688, where
+$r\ell=d^2$, and in the later blocking argument at line~845. Thus the
+occurrence of $d^k$ at line~703 is a typographical exponent error; the
+consistent endpoint identity is $d^{2k}$.
+
+\section{Formal treatment}
+
+The blocking-rank saturation theorem does not prove this rank-product identity.
+It takes the two endpoint identities
+\[
+  r_{k_0}\ell_{k_0}=d^{2k_0},
+  \qquad
+  r_k\ell_k=d^{2k}
+\]
+as explicit hypotheses and combines them with the independently proved
+blocking upper bounds. A later application may obtain the hypotheses from the
+formal counterpart of Theorem~IV.1 under its own assumptions.
+
+\section{Verdict}
+
+This is a local correction of the exponent in one sentence of the proof of
+Proposition~IV.2. It does not add an assumption beyond the rank-product
+identity used by that proof, but the formal saturation result keeps that
+identity explicit rather than claiming it from blocking alone.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex
+++ b/docs/paper-gaps/cpgsv17_mpu_blocking_rank_product_exponent.tex
@@ -15,57 +15,52 @@
 
 \section{The printed exponent}
 
-In the proof of Proposition~IV.2 of \cite{Cirac2017MPU}, line~703 of
-\path{Papers/1703.09188/paper_v2.tex} states that the right and left
-source-cut ranks of the blocked tensor satisfy
+In the proof of Proposition~IV.2 of \cite{Cirac2017MPU}, the right and left
+source-cut ranks of the $k$-site blocked tensor are printed as
 \[
   r_k\ell_k=d^k.
 \]
-Here the blocking length is $k$, so the blocked physical dimension is $d^k$.
+The blocked physical dimension is $d^k$.
 
 \section{Consistent rank-product identity}
 
-Theorem~III.8, lines~561--568, states that for a simple tensor of physical
-dimension $q$, the corresponding ranks obey
+Theorem~III.8 states that for a simple tensor of physical dimension $q$, the
+corresponding ranks obey
 \[
   r\ell=q^2.
 \]
-Applying this statement to the $k$-site block, whose physical dimension is
-$q=d^k$, gives
+Applying this statement to the $k$-site block, with $q=d^k$, gives
 \[
   r_k\ell_k=(d^k)^2=d^{2k}.
 \]
-The same square appears in the one-site discussion at line~688, where
-$r\ell=d^2$, and in the later blocking argument at line~845. Thus the
-occurrence of $d^k$ at line~703 is a typographical exponent error; the
-consistent endpoint identity is $d^{2k}$.
+The same square occurs in the index discussion and in the later blocking
+argument. Thus the occurrence of $d^k$ in the proof of Proposition~IV.2 is a
+typographical exponent error; the consistent endpoint identity is $d^{2k}$.
 
 \section{Formal treatment}
 
-The blocking-rank saturation theorem does not prove this rank-product identity.
-It takes the two endpoint identities
+The simultaneous saturation theorem
+\leanid{MPOTensor.blockingRanks_eq_pow_mul_of_products} does not prove this
+rank-product identity. It takes the two endpoint identities
 \[
   r_{k_0}\ell_{k_0}=d^{2k_0},
   \qquad
   r_k\ell_k=d^{2k}
 \]
 as explicit hypotheses and combines them with the independently proved
-blocking upper bounds. A later application may obtain the hypotheses from the
-formal counterpart of Theorem~III.8 under its own assumptions. The simultaneous
-saturation result is
-\leanid{MPOTensor.blockingRanks_eq_pow_mul_of_products}; its focused right- and
-left-rank accessors are
+blocking upper bounds. Its focused accessors are
 \leanid{MPOTensor.rightRank_blockTensor_eq_pow_mul_of_products} and
-\leanid{MPOTensor.leftRank_blockTensor_eq_pow_mul_of_products}.
+\leanid{MPOTensor.leftRank_blockTensor_eq_pow_mul_of_products}. A later
+application may obtain the endpoint identities from the formal counterpart of
+Theorem~III.8 under its own assumptions.
 
 \section{Verdict}
 
-\textbf{Verdict: local correction (resolved).}
-
-This is a local correction of the exponent in one sentence of the proof of
-Proposition~IV.2. It does not add an assumption beyond the rank-product
-identity used by that proof, but the formal saturation result keeps that
-identity explicit rather than claiming it from blocking alone.
+\textbf{Verdict: local correction (resolved).}  The exponent in the proof of
+Proposition~IV.2 is corrected from $d^k$ to $d^{2k}$. This does not add an
+assumption beyond the rank-product identity used by that proof, but the formal
+saturation result keeps that identity explicit rather than claiming it from
+blocking alone.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Closes #6254.

## Summary
- prove simultaneous exact right/left source-cut rank growth from the existing blocking upper bounds and supplied endpoint product identities
- expose focused public right-rank and left-rank exact-growth theorems
- add the Chapter 28 blueprint theorem citing Proposition IV.2 (`index-well-defined`), line 703, while keeping the endpoint identities explicit hypotheses

## Proof
Apply Mathlib's `eq_and_eq_of_pos_of_le_of_mul_le_mul` to the two existing `BlockingRanks` upper bounds. Positivity of the endpoint ranks follows from `0 < d` and the supplied product identity at `k`; the product of the two upper bounds is rewritten to the supplied product at `k` using the identity at `k₀` and `k₀ ≤ k`.

## Checks
- `lake env lean TNLean/MPS/MPU/BlockingRanks.lean`
- refreshed only the changed module artifact, then `lake env lean /tmp/RankSatCheck.lean` for all three exported signatures
- `python3 scripts/blueprint_lean_sync.py --root . --report /tmp/tnlean-6254-blueprint.json` (Chapter 28: 362/362; sync clean)
- `git diff --check`

A full project build was intentionally not run under the hot-main protocol. The broad declaration checker was also not used because this seeded worktree lacks an unrelated existing object file (`TNLean.Channel.KoashiImoto.InvariantConditionalBlockForm.olean`); source-level blueprint sync and targeted exported-signature checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal math and documentation; no runtime, auth, or data paths. Assumptions stay explicit rather than deriving endpoint products from blocking alone.
> 
> **Overview**
> Adds **exact** right/left source-cut rank growth under physical blocking when endpoint rank products are given as hypotheses \(r_{k_0}\ell_{k_0}=d^{2k_0}\) and \(r_k\ell_k=d^{2k}\), by combining existing blocking upper bounds with Mathlib’s `eq_and_eq_of_pos_of_le_of_mul_le_mul`.
> 
> Lean exports a joint theorem plus right-only and left-only accessors in `BlockingRanks.lean`. Chapter 28 gains a matching blueprint theorem wired into Proposition IV.2 (`index-well-defined`), and a short paper-gap note documents correcting the printed \(d^k\) endpoint product to \(d^{2k}\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9359362fdc4e7ce5e8913574540a87695bc8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->