### PR TITLE
feat(MPU): isolate the specified source-index value

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -22,6 +22,7 @@ import TNLean.MPS.MPU.Simple
 import TNLean.MPS.MPU.SimpleBlocking
 import TNLean.MPS.MPU.SourceCuts
 import TNLean.MPS.MPU.SourceFactors
+import TNLean.MPS.MPU.SourceIndexValue
 import TNLean.MPS.MPU.SourceUBoundary
 import TNLean.MPS.MPU.SourceUClosedNetwork
 import TNLean.MPS.MPU.SourceUContraction

--- a/TNLean/MPS/MPU/SourceIndexValue.lean
+++ b/TNLean/MPS/MPU/SourceIndexValue.lean
@@ -62,9 +62,11 @@ theorem sourceIndexValue_eq_of_common_rank_scale
     (hrU : r[U] ≠ 0) (hℓU : ℓ[U] ≠ 0)
     (hr : r[V] = c * r[U]) (hℓ : ℓ[V] = c * ℓ[U]) :
     sourceIndexValue V = sourceIndexValue U := by
-  rw [sourceIndexValue, sourceIndexValue, hr, hℓ]
-  norm_cast at hc hrU hℓU
-  rw [Real.logb_mul hc hrU, Real.logb_mul hc hℓU]
+  rw [sourceIndexValue, sourceIndexValue, hr, hℓ, Nat.cast_mul, Nat.cast_mul]
+  have hcReal : (c : ℝ) ≠ 0 := by exact_mod_cast hc
+  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hrU
+  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓU
+  rw [Real.logb_mul hcReal hrReal, Real.logb_mul hcReal hℓReal]
   ring
 
 /-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is nonzero, then
@@ -77,16 +79,20 @@ theorem sourceIndexValue_eq_logb_rightRank_div (U : MPOTensor d D)
     sourceIndexValue U = Real.logb 2 ((r[U] : ℝ) / d) := by
   have hr : r[U] ≠ 0 := by
     intro h
-    simp [h, hd] at hprod
+    rw [h, zero_mul] at hprod
+    exact hd (Nat.pow_eq_zero.mp hprod.symm).1
   have hℓ : ℓ[U] ≠ 0 := by
     intro h
-    simp [h, hd] at hprod
-  norm_cast at hd hr hℓ
+    rw [h, mul_zero] at hprod
+    exact hd (Nat.pow_eq_zero.mp hprod.symm).1
+  have hdReal : (d : ℝ) ≠ 0 := by exact_mod_cast hd
+  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hr
+  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓ
   have hprodReal : (r[U] : ℝ) * (ℓ[U] : ℝ) = (d : ℝ) * d := by
     exact_mod_cast hprod.trans (pow_two d)
   have hlog := congrArg (Real.logb 2) hprodReal
-  rw [Real.logb_mul hr hℓ, Real.logb_mul hd hd] at hlog
-  rw [sourceIndexValue, Real.logb_div hr hd]
+  rw [Real.logb_mul hrReal hℓReal, Real.logb_mul hdReal hdReal] at hlog
+  rw [sourceIndexValue, Real.logb_div hrReal hdReal]
   linarith
 
 /-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is nonzero, then
@@ -99,16 +105,20 @@ theorem sourceIndexValue_eq_neg_logb_leftRank_div (U : MPOTensor d D)
     sourceIndexValue U = -Real.logb 2 ((ℓ[U] : ℝ) / d) := by
   have hr : r[U] ≠ 0 := by
     intro h
-    simp [h, hd] at hprod
+    rw [h, zero_mul] at hprod
+    exact hd (Nat.pow_eq_zero.mp hprod.symm).1
   have hℓ : ℓ[U] ≠ 0 := by
     intro h
-    simp [h, hd] at hprod
-  norm_cast at hd hr hℓ
+    rw [h, mul_zero] at hprod
+    exact hd (Nat.pow_eq_zero.mp hprod.symm).1
+  have hdReal : (d : ℝ) ≠ 0 := by exact_mod_cast hd
+  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hr
+  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓ
   have hprodReal : (r[U] : ℝ) * (ℓ[U] : ℝ) = (d : ℝ) * d := by
     exact_mod_cast hprod.trans (pow_two d)
   have hlog := congrArg (Real.logb 2) hprodReal
-  rw [Real.logb_mul hr hℓ, Real.logb_mul hd hd] at hlog
-  rw [sourceIndexValue, Real.logb_div hℓ hd]
+  rw [Real.logb_mul hrReal hℓReal, Real.logb_mul hdReal hdReal] at hlog
+  rw [sourceIndexValue, Real.logb_div hℓReal hdReal]
   linarith
 
 end MPOTensor

--- a/TNLean/MPS/MPU/SourceIndexValue.lean
+++ b/TNLean/MPS/MPU/SourceIndexValue.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceCuts
+import Mathlib.Analysis.SpecialFunctions.Log.Base
+
+/-!
+# Source-index value of a specified MPU tensor
+
+This module defines the numerical source-index expression of a specified tensor
+from its right and left source-cut ranks. It does not choose a simple blocking
+and therefore does not define the choice-independent index of an MPU.
+
+For a tensor with right rank $r$ and left rank $\ell$, the value is
+$$
+\frac{1}{2}(\log_2 r-\log_2 \ell).
+$$
+A common nonzero scaling of both ranks cancels from this expression. If the
+supplied ranks satisfy $r\ell=d^2$, the expression also has the two equivalent
+forms $\log_2(r/d)$ and $-\log_2(\ell/d)$.
+
+These are the algebraic parts of arXiv:1703.09188, Definition IV.1 and the
+following paragraph, lines 681--688. Proposition IV.2, which proves independence
+of the chosen simple blocking, is not asserted here.
+
+## Main definitions and results
+
+* `MPOTensor.sourceIndexValue`: the source-index value of a specified tensor.
+* `MPOTensor.sourceIndexValue_eq_of_common_rank_scale`: cancellation of a
+  supplied common nonzero rank scale.
+* `MPOTensor.sourceIndexValue_eq_logb_rightRank_div`: the right-rank formula
+  under a supplied rank-product equality.
+* `MPOTensor.sourceIndexValue_eq_neg_logb_leftRank_div`: the left-rank formula
+  under a supplied rank-product equality.
+-/
+
+namespace MPOTensor
+
+variable {d D e E : ℕ}
+
+/-- The source-index value of a specified tensor, computed from its right and
+left source-cut ranks:
+$$
+\frac{1}{2}(\log_2 r-\log_2 \ell).
+$$
+
+This is the numerical expression in arXiv:1703.09188, Definition IV.1, lines
+681--686. It makes no choice of a simple blocking. -/
+noncomputable def sourceIndexValue (U : MPOTensor d D) : ℝ :=
+  (1 / 2 : ℝ) * (Real.logb 2 r[U] - Real.logb 2 ℓ[U])
+
+/-- Multiplying both source ranks by the same nonzero natural number does not
+change the source-index value.
+
+This is the logarithmic cancellation used in the proof of arXiv:1703.09188,
+Proposition IV.2, lines 697--704, stated only for two specified tensors and
+supplied rank equalities. -/
+theorem sourceIndexValue_eq_of_common_rank_scale
+    (U : MPOTensor d D) (V : MPOTensor e E) (c : ℕ) (hc : c ≠ 0)
+    (hrU : r[U] ≠ 0) (hℓU : ℓ[U] ≠ 0)
+    (hr : r[V] = c * r[U]) (hℓ : ℓ[V] = c * ℓ[U]) :
+    sourceIndexValue V = sourceIndexValue U := by
+  rw [sourceIndexValue, sourceIndexValue, hr, hℓ]
+  norm_cast at hc hrU hℓU
+  rw [Real.logb_mul hc hrU, Real.logb_mul hc hℓU]
+  ring
+
+/-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is nonzero, then
+its source-index value is $\log_2(r/d)$.
+
+This is the first equivalent formula following arXiv:1703.09188, Definition
+IV.1, lines 686--688. -/
+theorem sourceIndexValue_eq_logb_rightRank_div (U : MPOTensor d D)
+    (hd : d ≠ 0) (hprod : r[U] * ℓ[U] = d ^ 2) :
+    sourceIndexValue U = Real.logb 2 ((r[U] : ℝ) / d) := by
+  have hr : r[U] ≠ 0 := by
+    intro h
+    simp [h, hd] at hprod
+  have hℓ : ℓ[U] ≠ 0 := by
+    intro h
+    simp [h, hd] at hprod
+  norm_cast at hd hr hℓ
+  have hprodReal : (r[U] : ℝ) * (ℓ[U] : ℝ) = (d : ℝ) * d := by
+    exact_mod_cast hprod.trans (pow_two d)
+  have hlog := congrArg (Real.logb 2) hprodReal
+  rw [Real.logb_mul hr hℓ, Real.logb_mul hd hd] at hlog
+  rw [sourceIndexValue, Real.logb_div hr hd]
+  linarith
+
+/-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is nonzero, then
+its source-index value is $-\log_2(\ell/d)$.
+
+This is the second equivalent formula following arXiv:1703.09188, Definition
+IV.1, lines 686--688. -/
+theorem sourceIndexValue_eq_neg_logb_leftRank_div (U : MPOTensor d D)
+    (hd : d ≠ 0) (hprod : r[U] * ℓ[U] = d ^ 2) :
+    sourceIndexValue U = -Real.logb 2 ((ℓ[U] : ℝ) / d) := by
+  have hr : r[U] ≠ 0 := by
+    intro h
+    simp [h, hd] at hprod
+  have hℓ : ℓ[U] ≠ 0 := by
+    intro h
+    simp [h, hd] at hprod
+  norm_cast at hd hr hℓ
+  have hprodReal : (r[U] : ℝ) * (ℓ[U] : ℝ) = (d : ℝ) * d := by
+    exact_mod_cast hprod.trans (pow_two d)
+  have hlog := congrArg (Real.logb 2) hprodReal
+  rw [Real.logb_mul hr hℓ, Real.logb_mul hd hd] at hlog
+  rw [sourceIndexValue, Real.logb_div hℓ hd]
+  linarith
+
+end MPOTensor

--- a/TNLean/MPS/MPU/SourceIndexValue.lean
+++ b/TNLean/MPS/MPU/SourceIndexValue.lean
@@ -10,14 +10,14 @@ import Mathlib.Analysis.SpecialFunctions.Log.Base
 # Source-index value of a specified MPU tensor
 
 This module defines the numerical source-index expression of a specified tensor
-from its right and left source-cut ranks. It does not choose a simple blocking
-and therefore does not define the choice-independent index of an MPU.
+from its positive right and left source-cut ranks. It does not choose a simple
+blocking and therefore does not define the choice-independent index of an MPU.
 
-For a tensor with right rank $r$ and left rank $\ell$, the value is
+For a tensor with positive right rank $r$ and left rank $\ell$, the value is
 $$
 \frac{1}{2}(\log_2 r-\log_2 \ell).
 $$
-A common nonzero scaling of both ranks cancels from this expression. If the
+A common positive scaling of both ranks cancels from this expression. If the
 supplied ranks satisfy $r\ell=d^2$, the expression also has the two equivalent
 forms $\log_2(r/d)$ and $-\log_2(\ell/d)$.
 
@@ -25,11 +25,15 @@ These are the algebraic parts of arXiv:1703.09188, Definition IV.1 and the
 following paragraph, lines 681--688. Proposition IV.2, which proves independence
 of the chosen simple blocking, is not asserted here.
 
-## Main definitions and results
+## Main definitions
 
-* `MPOTensor.sourceIndexValue`: the source-index value of a specified tensor.
+* `MPOTensor.sourceIndexValue`: the source-index value of a specified tensor
+  whose two source ranks are positive.
+
+## Main results
+
 * `MPOTensor.sourceIndexValue_eq_of_common_rank_scale`: cancellation of a
-  supplied common nonzero rank scale.
+  supplied common positive rank scale.
 * `MPOTensor.sourceIndexValue_eq_logb_rightRank_div`: the right-rank formula
   under a supplied rank-product equality.
 * `MPOTensor.sourceIndexValue_eq_neg_logb_leftRank_div`: the left-rank formula
@@ -40,54 +44,49 @@ namespace MPOTensor
 
 variable {d D e E : ℕ}
 
-/-- The source-index value of a specified tensor, computed from its right and
-left source-cut ranks:
+/-- The source-index value of a specified tensor with positive right and left
+source-cut ranks:
 $$
 \frac{1}{2}(\log_2 r-\log_2 \ell).
 $$
 
 This is the numerical expression in arXiv:1703.09188, Definition IV.1, lines
 681--686. It makes no choice of a simple blocking. -/
-noncomputable def sourceIndexValue (U : MPOTensor d D) : ℝ :=
+noncomputable def sourceIndexValue (U : MPOTensor d D)
+    (_hr : 0 < r[U]) (_hℓ : 0 < ℓ[U]) : ℝ :=
   (1 / 2 : ℝ) * (Real.logb 2 r[U] - Real.logb 2 ℓ[U])
 
-/-- Multiplying both source ranks by the same nonzero natural number does not
-change the source-index value.
+/-- Multiplying both positive source ranks by the same positive natural number
+does not change the source-index value.
 
 This is the logarithmic cancellation used in the proof of arXiv:1703.09188,
 Proposition IV.2, lines 697--704, stated only for two specified tensors and
 supplied rank equalities. -/
 theorem sourceIndexValue_eq_of_common_rank_scale
-    (U : MPOTensor d D) (V : MPOTensor e E) (c : ℕ) (hc : c ≠ 0)
-    (hrU : r[U] ≠ 0) (hℓU : ℓ[U] ≠ 0)
+    (U : MPOTensor d D) (V : MPOTensor e E) (c : ℕ) (hc : 0 < c)
+    (hrU : 0 < r[U]) (hℓU : 0 < ℓ[U])
     (hr : r[V] = c * r[U]) (hℓ : ℓ[V] = c * ℓ[U]) :
-    sourceIndexValue V = sourceIndexValue U := by
+    sourceIndexValue V (hr.symm ▸ Nat.mul_pos hc hrU) (hℓ.symm ▸ Nat.mul_pos hc hℓU) =
+      sourceIndexValue U hrU hℓU := by
   rw [sourceIndexValue, sourceIndexValue, hr, hℓ, Nat.cast_mul, Nat.cast_mul]
-  have hcReal : (c : ℝ) ≠ 0 := by exact_mod_cast hc
-  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hrU
-  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓU
+  have hcReal : (c : ℝ) ≠ 0 := by exact_mod_cast hc.ne'
+  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hrU.ne'
+  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓU.ne'
   rw [Real.logb_mul hcReal hrReal, Real.logb_mul hcReal hℓReal]
   ring
 
-/-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is nonzero, then
+/-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is positive, then
 its source-index value is $\log_2(r/d)$.
 
 This is the first equivalent formula following arXiv:1703.09188, Definition
 IV.1, lines 686--688. -/
 theorem sourceIndexValue_eq_logb_rightRank_div (U : MPOTensor d D)
-    (hd : d ≠ 0) (hprod : r[U] * ℓ[U] = d ^ 2) :
-    sourceIndexValue U = Real.logb 2 ((r[U] : ℝ) / d) := by
-  have hr : r[U] ≠ 0 := by
-    intro h
-    rw [h, zero_mul] at hprod
-    exact hd (Nat.pow_eq_zero.mp hprod.symm).1
-  have hℓ : ℓ[U] ≠ 0 := by
-    intro h
-    rw [h, mul_zero] at hprod
-    exact hd (Nat.pow_eq_zero.mp hprod.symm).1
-  have hdReal : (d : ℝ) ≠ 0 := by exact_mod_cast hd
-  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hr
-  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓ
+    (hr : 0 < r[U]) (hℓ : 0 < ℓ[U]) (hd : 0 < d)
+    (hprod : r[U] * ℓ[U] = d ^ 2) :
+    sourceIndexValue U hr hℓ = Real.logb 2 ((r[U] : ℝ) / d) := by
+  have hdReal : (d : ℝ) ≠ 0 := by exact_mod_cast hd.ne'
+  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hr.ne'
+  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓ.ne'
   have hprodReal : (r[U] : ℝ) * (ℓ[U] : ℝ) = (d : ℝ) * d := by
     exact_mod_cast hprod.trans (pow_two d)
   have hlog := congrArg (Real.logb 2) hprodReal
@@ -95,25 +94,18 @@ theorem sourceIndexValue_eq_logb_rightRank_div (U : MPOTensor d D)
   rw [sourceIndexValue, Real.logb_div hrReal hdReal]
   linarith
 
-/-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is nonzero, then
+/-- If the supplied source ranks satisfy $r\ell=d^2$ and $d$ is positive, then
 its source-index value is $-\log_2(\ell/d)$.
 
 This is the second equivalent formula following arXiv:1703.09188, Definition
 IV.1, lines 686--688. -/
 theorem sourceIndexValue_eq_neg_logb_leftRank_div (U : MPOTensor d D)
-    (hd : d ≠ 0) (hprod : r[U] * ℓ[U] = d ^ 2) :
-    sourceIndexValue U = -Real.logb 2 ((ℓ[U] : ℝ) / d) := by
-  have hr : r[U] ≠ 0 := by
-    intro h
-    rw [h, zero_mul] at hprod
-    exact hd (Nat.pow_eq_zero.mp hprod.symm).1
-  have hℓ : ℓ[U] ≠ 0 := by
-    intro h
-    rw [h, mul_zero] at hprod
-    exact hd (Nat.pow_eq_zero.mp hprod.symm).1
-  have hdReal : (d : ℝ) ≠ 0 := by exact_mod_cast hd
-  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hr
-  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓ
+    (hr : 0 < r[U]) (hℓ : 0 < ℓ[U]) (hd : 0 < d)
+    (hprod : r[U] * ℓ[U] = d ^ 2) :
+    sourceIndexValue U hr hℓ = -Real.logb 2 ((ℓ[U] : ℝ) / d) := by
+  have hdReal : (d : ℝ) ≠ 0 := by exact_mod_cast hd.ne'
+  have hrReal : (r[U] : ℝ) ≠ 0 := by exact_mod_cast hr.ne'
+  have hℓReal : (ℓ[U] : ℝ) ≠ 0 := by exact_mod_cast hℓ.ne'
   have hprodReal : (r[U] : ℝ) * (ℓ[U] : ℝ) = (d : ℝ) * d := by
     exact_mod_cast hprod.trans (pow_two d)
   have hlog := congrArg (Real.logb 2) hprodReal

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4460,8 +4460,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \lean{MPOTensor.sourceIndexValue}
   \leanok
   \uses{def:mpu_right_rank,def:mpu_left_rank}
-  For a specified tensor $\mathcal U$ with right and left source-cut ranks
-  $r$ and $\ell$, define
+  For a specified tensor $\mathcal U$ whose right and left source-cut ranks
+  $r$ and $\ell$ are positive, define
   \begin{align}
     \operatorname{ind}_{\mathrm{src}}(\mathcal U)
       &=\frac12(\log_2 r-\log_2\ell).
@@ -4484,13 +4484,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     r_{\mathcal V}&=c r_{\mathcal U},&
     \ell_{\mathcal V}&=c\ell_{\mathcal U},
   \end{align}
-  where $c$, $r_{\mathcal U}$, and $\ell_{\mathcal U}$ are nonzero. Then
+  where $c$, $r_{\mathcal U}$, and $\ell_{\mathcal U}$ are positive. Then
   \begin{align}
     \operatorname{ind}_{\mathrm{src}}(\mathcal V)
       &=\operatorname{ind}_{\mathrm{src}}(\mathcal U).
   \end{align}
-  If $d$ is nonzero and a specified tensor has
-  $r_{\mathcal U}\ell_{\mathcal U}=d^2$, then
+  If $d$, $r_{\mathcal U}$, and $\ell_{\mathcal U}$ are positive and a
+  specified tensor has $r_{\mathcal U}\ell_{\mathcal U}=d^2$, then
   \begin{align}
     \operatorname{ind}_{\mathrm{src}}(\mathcal U)
       &=\log_2\frac{r_{\mathcal U}}d

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4470,22 +4470,6 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   % Auxiliary to paper_v2.tex lines 681--688; issue 6255.
 \end{definition}
 
-\begin{theorem}[Product and quotient laws for real logarithms]
-  \label{thm:mpu_real_logb_mul_div}
-  \lean{Real.logb_mul,Real.logb_div}
-  \leanok
-  For nonzero real numbers $x$ and $y$ and any base $b$,
-  \begin{align}
-    \log_b(xy)&=\log_bx+\log_by,&
-    \log_b(x/y)&=\log_bx-\log_by.
-  \end{align}
-\end{theorem}
-
-\begin{proof}\leanok
-  Divide the corresponding product and quotient laws for the natural
-  logarithm by $\log b$.
-\end{proof}
-
 \begin{theorem}[Auxiliary source-index identities]
   \label{thm:mpu_specified_source_index_identities}
   \lean{MPOTensor.sourceIndexValue_eq_of_common_rank_scale,
@@ -4516,7 +4500,6 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{thm:mpu_real_logb_mul_div}
   Expand the definition. For common scaling, apply
   $\log_2(cx)=\log_2c+\log_2x$ to both ranks and cancel the two copies of
   $\log_2c$. For the equivalent formulas, apply the same product identity to

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4455,6 +4455,75 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   two images and multiply their dimensions.
 \end{proof}
 
+\begin{definition}[Specified-tensor source-index value]
+  \label{def:mpu_specified_source_index_value}
+  \lean{MPOTensor.sourceIndexValue}
+  \leanok
+  \uses{def:mpu_right_rank,def:mpu_left_rank}
+  For a specified tensor $\mathcal U$ with right and left source-cut ranks
+  $r$ and $\ell$, define
+  \begin{align}
+    \operatorname{ind}_{\mathrm{src}}(\mathcal U)
+      &=\frac12(\log_2 r-\log_2\ell).
+  \end{align}
+  This definition makes no choice of a simple blocking.
+  % Auxiliary to paper_v2.tex lines 681--688; issue 6255.
+\end{definition}
+
+\begin{theorem}[Product and quotient laws for real logarithms]
+  \label{thm:mpu_real_logb_mul_div}
+  \lean{Real.logb_mul,Real.logb_div}
+  \leanok
+  For nonzero real numbers $x$ and $y$ and any base $b$,
+  \begin{align}
+    \log_b(xy)&=\log_bx+\log_by,&
+    \log_b(x/y)&=\log_bx-\log_by.
+  \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+  Divide the corresponding product and quotient laws for the natural
+  logarithm by $\log b$.
+\end{proof}
+
+\begin{theorem}[Auxiliary source-index identities]
+  \label{thm:mpu_specified_source_index_identities}
+  \lean{MPOTensor.sourceIndexValue_eq_of_common_rank_scale,
+    MPOTensor.sourceIndexValue_eq_logb_rightRank_div,
+    MPOTensor.sourceIndexValue_eq_neg_logb_leftRank_div}
+  \leanok
+  \uses{def:mpu_specified_source_index_value,
+    def:mpu_right_rank,def:mpu_left_rank}
+  Let $\mathcal U$ and $\mathcal V$ be specified tensors. Suppose that their
+  source ranks obey
+  \begin{align}
+    r_{\mathcal V}&=c r_{\mathcal U},&
+    \ell_{\mathcal V}&=c\ell_{\mathcal U},
+  \end{align}
+  where $c$, $r_{\mathcal U}$, and $\ell_{\mathcal U}$ are nonzero. Then
+  \begin{align}
+    \operatorname{ind}_{\mathrm{src}}(\mathcal V)
+      &=\operatorname{ind}_{\mathrm{src}}(\mathcal U).
+  \end{align}
+  If $d$ is nonzero and a specified tensor has
+  $r_{\mathcal U}\ell_{\mathcal U}=d^2$, then
+  \begin{align}
+    \operatorname{ind}_{\mathrm{src}}(\mathcal U)
+      &=\log_2\frac{r_{\mathcal U}}d
+       =-\log_2\frac{\ell_{\mathcal U}}d.
+  \end{align}
+  % Auxiliary to paper_v2.tex lines 681--704; issue 6255.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:mpu_real_logb_mul_div}
+  Expand the definition. For common scaling, apply
+  $\log_2(cx)=\log_2c+\log_2x$ to both ranks and cancel the two copies of
+  $\log_2c$. For the equivalent formulas, apply the same product identity to
+  $r_{\mathcal U}\ell_{\mathcal U}=d^2$ and use
+  $\log_2(x/y)=\log_2x-\log_2y$.
+\end{proof}
+
 \begin{definition}[Index]
   \label{def:index}
   \notready

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4500,6 +4500,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{def:mpu_specified_source_index_value}
   Expand the definition. For common scaling, apply
   $\log_2(cx)=\log_2c+\log_2x$ to both ranks and cancel the two copies of
   $\log_2c$. For the equivalent formulas, apply the same product identity to


### PR DESCRIPTION
## What changed

- define the source-index value of a specified MPU tensor from its existing source ranks
- prove cancellation under a supplied common rank scaling
- prove the two source formulas under a supplied rank product `rℓ = d²`
- add distinctly labelled auxiliary Chapter 28 coverage while leaving the source index and well-definedness nodes not ready

## Validation

- `lake build TNLean.MPS.MPU.SourceIndexValue`
- `lake build TNLean.MPS.MPU`
- aggregator generation check
- blueprint sync and `leanblueprint checkdecls`
- two LuaLaTeX passes with no undefined references

Closes #6255. Advances #6014.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained Mathlib log algebra on existing rank notation; no auth, data, or behavioral runtime changes.
> 
> **Overview**
> Introduces **`MPOTensor.sourceIndexValue`**, the \(\frac12(\log_2 r - \log_2 \ell)\) expression for a **specified** MPU tensor from positive source-cut ranks, without fixing a simple blocking or proving blocking-independence.
> 
> Adds three Lean lemmas: **common positive scaling** of both ranks leaves the value unchanged, and under **\(r\ell = d^2\)** the two equivalent forms \(\log_2(r/d)\) and \(-\log_2(\ell/d)\). The new module is wired into the MPU aggregator.
> 
> Chapter 28 gains **auxiliary** blueprint nodes (`def:mpu_specified_source_index_value`, `thm:mpu_specified_source_index_identities`) linked to those declarations; the main **Index** definition and well-definedness material stay **not ready**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8eba3c7bfef7d29623c82820de1e19868de451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->