### PR TITLE
refactor(MPDO): reuse cyclic one-step offset identity

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
@@ -88,14 +88,11 @@ private theorem offset_from_finRotate {N : ℕ} (hN : 2 ≤ N) (i k : Fin N) :
       simpa [Nat.mod_eq_of_lt i.isLt] using hk'
     subst k
     rw [if_pos hr]
-    by_cases hi : i.val + 1 < N
-    · rw [hrot, Nat.mod_eq_of_lt hi]
-      have heq : i.val + N - (i.val + 1) = N - 1 := by omega
-      rw [heq, Nat.mod_eq_of_lt (by omega)]
-    · have hiN : i.val + 1 = N := by omega
-      rw [hrot, hiN, Nat.mod_self]
-      simp only [Nat.sub_zero, Nat.add_mod_right, Nat.mod_eq_of_lt i.isLt]
-      omega
+    have hrotate : (finRotate N i).val = (MPSTensor.cyclicForwardSite i 1).val := by
+      rw [hrot]
+      rfl
+    rw [hrotate]
+    exact MPSTensor.cyclicForwardSite_one_offset i
   · rw [if_neg hr]
     change (k.val + N - (finRotate N i).val) % N = r - 1
     have hk : k = ⟨((finRotate N i).val + (r - 1)) % N,

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -588,6 +588,14 @@ abstracted — record why, so it is not re-proposed).
   directly, as does its original `MPSTensor.replaceWindow_extractWindow` caller. The initial
   promotion reduced the Lean sources by 41 lines net (6 insertions and 47 deletions).
 
+### One-step cyclic backward offset
+- **Pattern:** the original site has cyclic offset `N - 1` from its one-step forward neighbour.
+- **Reuse:** `MPSTensor.cyclicForwardSite_one_offset` in
+  `TNLean/MPS/ParentHamiltonian/CyclicWindow.lean` records the arithmetic once.
+- **Result:** three occurrences across `CyclicWindow.lean`, `LocalSupportTransport.lean`, and
+  `PhysicalSectorBondTransport.lean` now use the canonical lemma; the `finRotate` caller bridges
+  by equality of values with `cyclicForwardSite i 1`.
+
 ### Cyclic window index and product decomposition
 - **Pattern:** two physical-product modules privately defined the same cyclic shift,
   window/complement index equivalence, its two evaluation lemmas, and the resulting
@@ -988,6 +996,15 @@ abstracted — record why, so it is not re-proposed).
 
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
+
+### general cyclic backward offset — candidate
+- **Pattern:** for an arbitrary step `r`, the offset of `i` from `cyclicForwardSite i r` is
+  `(N - r % N) % N`.
+- **Seen:** no current call site requires the general identity; the promoted one-step lemma is
+  the only needed specialization.
+- **Abstraction (proposed):** a general `MPSTensor.cyclicForwardSite_offset` theorem if a caller
+  needs a non-unit step.
+- **Notes:** Record only; do not generalize the canonical theorem without a concrete consumer.
 
 ### diagonal normalized-ancilla sum collapse — candidate
 - **Pattern:** collapse the doubled sum for `normalizedDiagonalLift` by using


### PR DESCRIPTION
## Summary
- replace the third duplicated wrap/non-wrap offset proof with `cyclicForwardSite_one_offset`
- bridge the Mathlib `finRotate` coordinate to the project cyclic-forward coordinate without changing the private theorem
- record the now-rule-of-three proof pattern and retain the arbitrary-step version only as a candidate

## Mathematical scope
This preserves the cyclic offset convention $\delta_i(k)=(k+N-i)\bmod N$ already documented in the Blueprint; it is proof deduplication only.

## Validation
- targeted Lean passed before the latest disjoint main rebase; after rebase the seeded cache lacks unrelated `InvariantConditionalBlockForm.olean`, so exact-head CI will perform the final compile
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/test_lean_file_policies.py`
- proof-integrity scan
- `git diff --check`

Closes #6252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Lean proof refactor with no API or mathematical convention changes; only documentation and one proof body are touched.
> 
> **Overview**
> **Proof deduplication only** — no change to the cyclic offset convention or theorem statements.
> 
> In `PhysicalSectorBondTransport.lean`, the `r = 0` branch of `offset_from_finRotate` no longer carries a hand-written wrap/non-wrap case split for offset `N - 1`. It now identifies `(finRotate N i).val` with `(cyclicForwardSite i 1).val` and applies **`MPSTensor.cyclicForwardSite_one_offset`**, matching the other two call sites already on that lemma.
> 
> `docs/tactic_patterns.md` records the **one-step cyclic backward offset** pattern as promoted and keeps a **general arbitrary-step** version as a candidate without implementing it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd6c3d8c9d4a6fe106013ae208c1bb02a480d6b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->