### PR TITLE
feat(MPU): exchange source ranks under physical adjoint

### DIFF
--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.MPDO.PhysicalAdjoint
 import Mathlib.LinearAlgebra.Matrix.Rank
 import Mathlib.Logic.Equiv.Fin.Basic
 
@@ -55,6 +55,10 @@ definition `defnrl` and lines 697–704 of the paper.
   $r \le \min(Dd, dD) = Dd$ and similarly $\ell \le Dd$.
 * `sourceCutM₁_reindexPhysical`, `sourceCutM₂_reindexPhysical`: physical reindexing
   formulas for the two cuts.
+* `sourceCutM₁_physicalAdjointTensor`, `sourceCutM₂_physicalAdjointTensor`:
+  physical adjunction exchanges the two cuts and conjugates their entries.
+* `rightRank_physicalAdjointTensor`, `leftRank_physicalAdjointTensor`:
+  physical adjunction exchanges the two source ranks.
 * `rightRank_reindexPhysical`, `leftRank_reindexPhysical`: invariance of both ranks
   under bijective physical reindexing.
 * `sourceCutM₁_apply`, `sourceCutM₂_apply`, `sourceCutM₁Fin_apply`,
@@ -65,6 +69,8 @@ definition `defnrl` and lines 697–704 of the paper.
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1703.09188,
   Section III, definition `defnrl`, lines 450–477 and 697–704.
 -/
+
+open scoped ComplexOrder
 
 namespace MPOTensor
 
@@ -96,6 +102,35 @@ def sourceCutM₂ : Matrix (Fin D × Fin d) (Fin d × Fin D) ℂ :=
 
 @[simp] lemma sourceCutM₂_apply (α : Fin D) (i : Fin d) (j : Fin d) (β : Fin D) :
     sourceCutM₂ U (α, i) (j, β) = U i j α β := rfl
+
+/-- Physical adjunction exchanges the first source cut with the entrywise conjugate of the
+second source cut:
+$$M_1(U^\sharp)=\overline{M_2(U)}.$$
+
+The row and column indices remain `(left virtual, physical)` and `(physical, right virtual)`;
+only the roles of the upper and lower physical indices are exchanged.
+
+Source: arXiv:1703.09188, source cuts at lines 450–506 and physical adjunction at
+lines 1196–1252. -/
+theorem sourceCutM₁_physicalAdjointTensor :
+    sourceCutM₁ (physicalAdjointTensor U) = (sourceCutM₂ U).map (starRingEnd ℂ) := by
+  ext row col
+  rcases row with ⟨α, j⟩
+  rcases col with ⟨i, β⟩
+  rfl
+
+/-- Physical adjunction exchanges the second source cut with the entrywise conjugate of the
+first source cut:
+$$M_2(U^\sharp)=\overline{M_1(U)}.$$
+
+Source: arXiv:1703.09188, source cuts at lines 450–506 and physical adjunction at
+lines 1196–1252. -/
+theorem sourceCutM₂_physicalAdjointTensor :
+    sourceCutM₂ (physicalAdjointTensor U) = (sourceCutM₁ U).map (starRingEnd ℂ) := by
+  ext row col
+  rcases row with ⟨α, i⟩
+  rcases col with ⟨j, β⟩
+  rfl
 
 /-- Physical reindexing acts on the down leg of each row and the up leg of
 each column of the first source cut.
@@ -191,6 +226,29 @@ noncomputable def leftRank : ℕ := (sourceCutM₂ U).rank
 lemma rightRank_eq : r[U] = (sourceCutM₁ U).rank := rfl
 
 lemma leftRank_eq : ℓ[U] = (sourceCutM₂ U).rank := rfl
+
+/-- Physical adjunction exchanges the right source rank with the left source rank:
+$$r[U^\sharp]=\ell[U].$$
+
+This is the raw source-rank identity underlying the sign reversal of the MPU index under
+adjunction; it does not choose or compare standard-form factors.
+
+Source: arXiv:1703.09188, definition `defnrl` and lines 1196–1207. -/
+theorem rightRank_physicalAdjointTensor : r[physicalAdjointTensor U] = ℓ[U] := by
+  rw [rightRank, sourceCutM₁_physicalAdjointTensor]
+  change (Matrix.conjTranspose (Matrix.transpose (sourceCutM₂ U))).rank = _
+  rw [Matrix.rank_conjTranspose, Matrix.rank_transpose]
+  rfl
+
+/-- Physical adjunction exchanges the left source rank with the right source rank:
+$$\ell[U^\sharp]=r[U].$$
+
+Source: arXiv:1703.09188, definition `defnrl` and lines 1196–1207. -/
+theorem leftRank_physicalAdjointTensor : ℓ[physicalAdjointTensor U] = r[U] := by
+  rw [leftRank, sourceCutM₂_physicalAdjointTensor]
+  change (Matrix.conjTranspose (Matrix.transpose (sourceCutM₁ U))).rank = _
+  rw [Matrix.rank_conjTranspose, Matrix.rank_transpose]
+  rfl
 
 /-- Bijective physical reindexing preserves the right source rank.
 

--- a/TNLean/MPS/MPU/SourceCuts.lean
+++ b/TNLean/MPS/MPU/SourceCuts.lean
@@ -110,8 +110,9 @@ $$M_1(U^\sharp)=\overline{M_2(U)}.$$
 The row and column indices remain `(left virtual, physical)` and `(physical, right virtual)`;
 only the roles of the upper and lower physical indices are exchanged.
 
-Source: arXiv:1703.09188, source cuts at lines 450–506 and physical adjunction at
-lines 1196–1252. -/
+The source cuts follow arXiv:1703.09188, lines 450–506. The local physical-adjoint
+operation follows arXiv:1606.00608, Appendix C.2, lines 1634–1689; arXiv:1703.09188,
+lines 1201–1207 use the resulting adjoint family to reverse the index. -/
 theorem sourceCutM₁_physicalAdjointTensor :
     sourceCutM₁ (physicalAdjointTensor U) = (sourceCutM₂ U).map (starRingEnd ℂ) := by
   ext row col
@@ -123,8 +124,9 @@ theorem sourceCutM₁_physicalAdjointTensor :
 first source cut:
 $$M_2(U^\sharp)=\overline{M_1(U)}.$$
 
-Source: arXiv:1703.09188, source cuts at lines 450–506 and physical adjunction at
-lines 1196–1252. -/
+The source cuts follow arXiv:1703.09188, lines 450–506. The local physical-adjoint
+operation follows arXiv:1606.00608, Appendix C.2, lines 1634–1689; arXiv:1703.09188,
+lines 1201–1207 use the resulting adjoint family to reverse the index. -/
 theorem sourceCutM₂_physicalAdjointTensor :
     sourceCutM₂ (physicalAdjointTensor U) = (sourceCutM₁ U).map (starRingEnd ℂ) := by
   ext row col

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1542,6 +1542,43 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{definition}
 
+% Auxiliary transformation identity from source cuts (paper lines 450--506)
+% and physical adjunction (paper lines 1196--1252), not the time-reversal classification.
+\begin{theorem}[Source cuts and ranks under physical adjunction]
+    \label{thm:mpu_physical_adjoint_source_ranks}
+    \lean{MPOTensor.sourceCutM₁_physicalAdjointTensor,
+        MPOTensor.sourceCutM₂_physicalAdjointTensor,
+        MPOTensor.rightRank_physicalAdjointTensor,
+        MPOTensor.leftRank_physicalAdjointTensor}
+    \leanok
+    \uses{def:mpdo_physical_adjoint,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank}
+    Physical adjunction exchanges the two source cuts and conjugates every
+    entry:
+    \begin{align}
+        M_1(\mathcal U^\sharp)&=\overline{M_2(\mathcal U)}.
+    \end{align}
+    \begin{align}
+        M_2(\mathcal U^\sharp)&=\overline{M_1(\mathcal U)}.
+    \end{align}
+    Consequently, it exchanges the two source ranks:
+    \begin{align}
+        r(\mathcal U^\sharp)&=\ell(\mathcal U).
+    \end{align}
+    \begin{align}
+        \ell(\mathcal U^\sharp)&=r(\mathcal U).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_physical_adjoint,def:mpu_source_matrix_one,
+        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank}
+    The physical adjoint exchanges the upper and lower physical indices while
+    leaving both auxiliary indices fixed. Thus the first regrouping becomes
+    the entrywise conjugate of the second, and conversely. Entrywise
+    conjugation preserves matrix rank, so the two rank identities follow.
+\end{proof}
+
 \begin{theorem}[Source cuts under physical reindexing]
     \label{thm:mpu_source_cuts_physical_reindexing}
     \lean{MPOTensor.sourceCutM₁_reindexPhysical,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1542,41 +1542,48 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \end{align}
 \end{definition}
 
-% Auxiliary transformation identity from source cuts (paper lines 450--506)
-% and physical adjunction (paper lines 1196--1252), not the time-reversal classification.
-\begin{theorem}[Source cuts and ranks under physical adjunction]
-    \label{thm:mpu_physical_adjoint_source_ranks}
+% Auxiliary transformation identities from source cuts (paper lines 450--506)
+% and the existing physical-adjoint tensor, not the time-reversal classification.
+\begin{theorem}[Source cuts under physical adjunction]
+    \label{thm:mpu_physical_adjoint_source_cuts}
     \lean{MPOTensor.sourceCutM₁_physicalAdjointTensor,
-        MPOTensor.sourceCutM₂_physicalAdjointTensor,
-        MPOTensor.rightRank_physicalAdjointTensor,
-        MPOTensor.leftRank_physicalAdjointTensor}
+        MPOTensor.sourceCutM₂_physicalAdjointTensor}
     \leanok
     \uses{def:mpdo_physical_adjoint,def:mpu_source_matrix_one,
-        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank}
+        def:mpu_source_matrix_two}
     Physical adjunction exchanges the two source cuts and conjugates every
     entry:
     \begin{align}
-        M_1(\mathcal U^\sharp)&=\overline{M_2(\mathcal U)}.
-    \end{align}
-    \begin{align}
+        M_1(\mathcal U^\sharp)&=\overline{M_2(\mathcal U)},\\
         M_2(\mathcal U^\sharp)&=\overline{M_1(\mathcal U)}.
-    \end{align}
-    Consequently, it exchanges the two source ranks:
-    \begin{align}
-        r(\mathcal U^\sharp)&=\ell(\mathcal U).
-    \end{align}
-    \begin{align}
-        \ell(\mathcal U^\sharp)&=r(\mathcal U).
     \end{align}
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpdo_physical_adjoint,def:mpu_source_matrix_one,
-        def:mpu_source_matrix_two,def:mpu_right_rank,def:mpu_left_rank}
+        def:mpu_source_matrix_two}
     The physical adjoint exchanges the upper and lower physical indices while
     leaving both auxiliary indices fixed. Thus the first regrouping becomes
-    the entrywise conjugate of the second, and conversely. Entrywise
-    conjugation preserves matrix rank, so the two rank identities follow.
+    the entrywise conjugate of the second, and conversely.
+\end{proof}
+
+\begin{theorem}[Source ranks under physical adjunction]
+    \label{thm:mpu_physical_adjoint_source_ranks}
+    \lean{MPOTensor.rightRank_physicalAdjointTensor,
+        MPOTensor.leftRank_physicalAdjointTensor}
+    \leanok
+    \uses{def:mpdo_physical_adjoint,def:mpu_right_rank,def:mpu_left_rank}
+    Physical adjunction exchanges the two source ranks:
+    \begin{align}
+        r(\mathcal U^\sharp)&=\ell(\mathcal U),\\
+        \ell(\mathcal U^\sharp)&=r(\mathcal U).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpu_physical_adjoint_source_cuts}
+    Apply Theorem~\ref{thm:mpu_physical_adjoint_source_cuts} and use invariance
+    of matrix rank under entrywise conjugation.
 \end{proof}
 
 \begin{theorem}[Source cuts under physical reindexing]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1581,7 +1581,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpu_physical_adjoint_source_cuts}
+    \uses{thm:mpu_physical_adjoint_source_cuts,def:mpu_right_rank,
+        def:mpu_left_rank}
     Apply Theorem~\ref{thm:mpu_physical_adjoint_source_cuts} and use invariance
     of matrix rank under entrywise conjugation.
 \end{proof}


### PR DESCRIPTION
## What changed

- prove that physical adjunction exchanges the two source cuts by entrywise conjugation
- derive `r[U♯] = ℓ[U]` and `ℓ[U♯] = r[U]` from existing matrix-rank invariance
- record separate source-cut and source-rank blueprint nodes
- make no claim about CFII data or chosen compact-SVD factors

## Validation

- `lake build TNLean.MPS.MPU.SourceCuts`
- targeted downstream source-factor/source-u build
- blueprint sync and checkdecls
- two LuaLaTeX passes

Closes #6260. Advances #6139.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean and LaTeX documentation with no runtime, auth, or data-path changes; proofs are small and rely on existing rank lemmas.
> 
> **Overview**
> Formalizes how **physical adjoint** acts on MPU **source cuts** \(M_1, M_2\) and their ranks \(r, \ell\): adjunction swaps the two regroupings and conjugates entries, so **right and left source ranks exchange** under \(U^\sharp\).
> 
> In `SourceCuts.lean`, the module now imports `PhysicalAdjoint` and adds `sourceCutM₁_physicalAdjointTensor` / `sourceCutM₂_physicalAdjointTensor` (proved by index extensionality) plus `rightRank_physicalAdjointTensor` and `leftRank_physicalAdjointTensor`, using matrix rank invariance under conjugate-transpose. Module docs list these results; `open scoped ComplexOrder` is added for the star/conjugation layer.
> 
> The blueprint chapter **ch28_mpu** gets matching theorem nodes and short proofs, wired to the new Lean declarations, without extending claims to CFII or chosen SVD factors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88dc27524aa9061d9fff53a2bd85f00fb9368ddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->