### PR TITLE
feat(algebra): add invertible equal-range right factor

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -23,6 +23,7 @@ import TNLean.Algebra.CornerSkolemNoether
 import TNLean.Algebra.DependentBlockDiagonal
 import TNLean.Algebra.DirectedWalkCoboundary
 import TNLean.Algebra.EigenvectorProjection
+import TNLean.Algebra.EqualRangeRightFactor
 import TNLean.Algebra.EventuallyConstantCycleWeights
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.FinTupleEquiv

--- a/TNLean/Algebra/EqualRangeRightFactor.lean
+++ b/TNLean/Algebra/EqualRangeRightFactor.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import Mathlib.LinearAlgebra.Matrix.ToLin
+import Mathlib.LinearAlgebra.Projection
+
+/-!
+# Equal-range endomorphisms
+
+This file proves that two finite-dimensional endomorphisms with equal ranges differ by
+precomposition with a linear automorphism. It also gives the corresponding square-matrix
+statement with an invertible right factor.
+
+## Main results
+
+* `LinearMap.exists_linearEquiv_comp_eq_of_range_eq`: equal-range endomorphisms differ by
+  precomposition with a linear equivalence.
+* `Matrix.exists_isUnit_mul_eq_of_range_mulVecLin_eq`: square matrices with the same column
+  space differ by an invertible right factor.
+-/
+
+open Module
+
+namespace LinearMap
+
+variable {K E : Type*} [Field K] [AddCommGroup E] [Module K E] [FiniteDimensional K E]
+
+/-- Two endomorphisms with the same range differ by precomposition with a linear equivalence. -/
+theorem exists_linearEquiv_comp_eq_of_range_eq (A B : Module.End K E)
+    (h : A.range = B.range) :
+    ∃ Y : E ≃ₗ[K] E, A.comp Y.toLinearMap = B := by
+  obtain ⟨CA, hCA⟩ := A.ker.exists_isCompl
+  obtain ⟨CB, hCB⟩ := B.ker.exists_isCompl
+  have hker : finrank K A.ker = finrank K B.ker := by
+    have hA := A.finrank_range_add_finrank_ker
+    have hB := B.finrank_range_add_finrank_ker
+    rw [h] at hA
+    omega
+  let eker : B.ker ≃ₗ[K] A.ker :=
+    Classical.choice (FiniteDimensional.nonempty_linearEquiv_of_finrank_eq hker.symm)
+  let ecomp : CB ≃ₗ[K] CA :=
+    (B.kerComplementEquivRange hCB.symm).trans
+      ((LinearEquiv.ofEq B.range A.range h.symm).trans
+        (A.kerComplementEquivRange hCA.symm).symm)
+  let Y : E ≃ₗ[K] E :=
+    (CB.prodEquivOfIsCompl B.ker hCB.symm).symm |>.trans <|
+      (ecomp.prodCongr eker).trans (CA.prodEquivOfIsCompl A.ker hCA.symm)
+  refine ⟨Y, LinearMap.ext fun x ↦ ?_⟩
+  let z := (CB.prodEquivOfIsCompl B.ker hCB.symm).symm x
+  have hx : x = (z.1 : E) + z.2 := by
+    exact (CB.prodEquivOfIsCompl B.ker hCB.symm).apply_symm_apply x |>.symm
+  change A (Y x) = B x
+  have hecomp : A (ecomp z.1) = B z.1 := by
+    have hecomp' :
+        (A.kerComplementEquivRange hCA.symm) (ecomp z.1) =
+          LinearEquiv.ofEq B.range A.range h.symm
+            ((B.kerComplementEquivRange hCB.symm) z.1) := by
+      exact (A.kerComplementEquivRange hCA.symm).apply_symm_apply _
+    exact congr_arg Subtype.val hecomp'
+  change A (ecomp z.1 + eker z.2) = B x
+  rw [map_add, A.mem_ker.mp (eker z.2).property, add_zero, hecomp, hx, map_add,
+    B.mem_ker.mp z.2.property, add_zero]
+
+end LinearMap
+
+namespace Matrix
+
+variable {K n : Type*} [Field K] [Fintype n] [DecidableEq n]
+
+/-- Square matrices with the same column space differ by an invertible right factor. -/
+theorem exists_isUnit_mul_eq_of_range_mulVecLin_eq (A B : Matrix n n K)
+    (h : LinearMap.range A.mulVecLin = LinearMap.range B.mulVecLin) :
+    ∃ Y : Matrix n n K, IsUnit Y ∧ A * Y = B := by
+  obtain ⟨e, he⟩ := LinearMap.exists_linearEquiv_comp_eq_of_range_eq A.toLin' B.toLin' h
+  let Y := e.toLinearMap.toMatrix'
+  refine ⟨Y, ?_, ?_⟩
+  · rw [LinearMap.isUnit_toMatrix'_iff, Module.End.isUnit_iff]
+    exact e.bijective
+  · apply Matrix.toLin'.injective
+    simpa [Y] using he
+
+end Matrix


### PR DESCRIPTION
Closes #6264.

## Summary

- prove that finite-dimensional endomorphisms with equal ranges differ by precomposition with a linear equivalence
- expose the square-matrix corollary with `IsUnit Y` and the exact orientation `A * Y = B`
- add the narrow algebra module to the generated `TNLean.Algebra` aggregator

## Proof route

Choose complements of `ker A` and `ker B`. Rank-nullity and equality of ranges give equal kernel dimensions, hence a linear equivalence between the kernels. `LinearMap.kerComplementEquivRange` identifies each chosen complement with the common range. Taking the product of these two equivalences and transporting through `Submodule.prodEquivOfIsCompl` produces an automorphism of the ambient space. This treats zero and full-rank maps without separate cases.

The matrix result transports the generic theorem through `Matrix.toLin'`; `LinearMap.isUnit_toMatrix'_iff` proves invertibility, and `Matrix.toLin'_mul` preserves the required right-factor orientation.

## Checks

- `lake build TNLean.Algebra.EqualRangeRightFactor`
- `lake env lean TNLean/Algebra.lean`
- public-signature check importing `TNLean.Algebra.EqualRangeRightFactor`
- proof-integrity scan for forbidden declarations/tactics
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained Mathlib linear algebra proofs with no runtime, auth, or data-path changes; only a new module and aggregator import.
> 
> **Overview**
> Adds **`TNLean.Algebra.EqualRangeRightFactor`**, proving that finite-dimensional endomorphisms with the same range differ by precomposition with a linear equivalence (`LinearMap.exists_linearEquiv_comp_eq_of_range_eq`), and the matrix form: equal column spaces imply **`A * Y = B`** for some **`IsUnit Y`** (`Matrix.exists_isUnit_mul_eq_of_range_mulVecLin_eq`).
> 
> The linear proof builds an ambient automorphism from kernel complements, rank-nullity (equal kernels when ranges match), and `kerComplementEquivRange`, without splitting zero/full-rank cases. The matrix result is obtained via `toLin'` and `isUnit_toMatrix'_iff`. The generated **`TNLean.Algebra`** aggregator imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aadc5f3d7e89f51ebd36666cddde52ef19580072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->