### PR TITLE
refactor(MPDO): reuse canonical cyclic offset

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorBondTransport.lean
@@ -88,14 +88,11 @@ private theorem offset_from_finRotate {N : ℕ} (hN : 2 ≤ N) (i k : Fin N) :
       simpa [Nat.mod_eq_of_lt i.isLt] using hk'
     subst k
     rw [if_pos hr]
-    by_cases hi : i.val + 1 < N
-    · rw [hrot, Nat.mod_eq_of_lt hi]
-      have heq : i.val + N - (i.val + 1) = N - 1 := by omega
-      rw [heq, Nat.mod_eq_of_lt (by omega)]
-    · have hiN : i.val + 1 = N := by omega
-      rw [hrot, hiN, Nat.mod_self]
-      simp only [Nat.sub_zero, Nat.add_mod_right, Nat.mod_eq_of_lt i.isLt]
-      omega
+    have hforward : finRotate N i = MPSTensor.cyclicForwardSite i 1 := by
+      ext
+      simp [finRotate_apply, Fin.add_def, MPSTensor.cyclicForwardSite]
+    rw [hforward]
+    exact MPSTensor.cyclicForwardSite_one_offset i
   · rw [if_neg hr]
     change (k.val + N - (finRotate N i).val) % N = r - 1
     have hk : k = ⟨((finRotate N i).val + (r - 1)) % N,

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -453,6 +453,15 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### One-step cyclic-forward offset
+- **Identity:** `MPSTensor.cyclicForwardSite_one_offset` states that the old starting site has
+  offset `N - 1` from its one-step cyclic successor.
+- **Call sites:** `MPSTensor.replaceWindow_three_replaceWindow_two_right` in
+  `ParentHamiltonian/LocalSupportTransport.lean`, `MPSTensor.cyclicRestrictₗ_restrictFirst` in
+  `ParentHamiltonian/CyclicWindow.lean`, and `offset_from_finRotate` in
+  `MPDO/PhysicalSectorBondTransport.lean` after identifying
+  `finRotate N i` with `MPSTensor.cyclicForwardSite i 1`.
+
 ### Unequal retained vertical-copy evaluation
 - **Pattern:** unfold an assembled vertical tensor at two retained coordinates whose copy
   indices differ, then reduce the cross-copy matrix entry to zero through the block-diagonal

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -456,10 +456,10 @@ abstracted — record why, so it is not re-proposed).
 ### One-step cyclic-forward offset
 - **Identity:** `MPSTensor.cyclicForwardSite_one_offset` states that the old starting site has
   offset `N - 1` from its one-step cyclic successor.
-- **Call sites:** `MPSTensor.replaceWindow_three_replaceWindow_two_right` in
-  `ParentHamiltonian/LocalSupportTransport.lean`, `MPSTensor.cyclicRestrictₗ_restrictFirst` in
-  `ParentHamiltonian/CyclicWindow.lean`, and `offset_from_finRotate` in
-  `MPDO/PhysicalSectorBondTransport.lean` after identifying
+- **Call sites:** `MPSTensor.cyclicRestrictₗ_restrictFirst` in `ParentHamiltonian/CyclicWindow.lean`,
+  `MPSTensor.replaceWindow_three_replaceWindow_two_right` in
+  `ParentHamiltonian/LocalSupportTransport.lean`, and
+  `offset_from_finRotate` in `MPDO/PhysicalSectorBondTransport.lean` after identifying
   `finRotate N i` with `MPSTensor.cyclicForwardSite i 1`.
 
 ### Unequal retained vertical-copy evaluation


### PR DESCRIPTION
## Summary
- reuse `MPSTensor.cyclicForwardSite_one_offset` in the private `offset_from_finRotate` zero-offset branch
- identify `finRotate N i` with `cyclicForwardSite i 1` instead of repeating the wraparound arithmetic
- record the completed cyclic-offset reuse pattern in the tactic ledger
- preserve the private theorem statement and every public, paper-facing, and Blueprint leaf

## Validation
- `lake build TNLean.MPS.MPDO.PhysicalSectorBondTransport TNLean.MPS.MPDO.PhysicalSectorBondTwoSite TNLean.MPS.MPDO`
- `lake build` (10,081 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check origin/main...HEAD`
- exact-head specialist review approved

Closes #6252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a private helper; no public API or behavioral changes.
> 
> **Overview**
> In **`offset_from_finRotate`**, the zero-offset branch no longer re-proves cyclic wraparound arithmetic. It identifies **`finRotate N i`** with **`MPSTensor.cyclicForwardSite i 1`** and applies the existing lemma **`MPSTensor.cyclicForwardSite_one_offset`**.
> 
> The private theorem’s statement and downstream MPDO callers are unchanged. **`docs/tactic_patterns.md`** records this as a completed one-step cyclic-forward offset reuse pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f636eb90562c07410131f171e92126e74977039b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->