### PR TITLE
fix(tenkz): read kernel tombstone branches through the comment stripper

### DIFF
--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -372,6 +372,10 @@ def _kernel_tombstones_from_texts(texts: Iterable[str]) -> dict[tuple[str, str],
     """Collect the spellings the kernel parser refuses by name and their migrations."""
     tombstones: dict[tuple[str, str], str] = {}
     for text in texts:
+        # A branch the file comments out does not run, so TeX accepts the
+        # spelling again; reading the raw text would keep counting it as a
+        # refusal and report a pairing the parser no longer holds.
+        text = strip_comments(text)
         for match in _KERNEL_TOMBSTONE.finditer(text):
             position = match.end()
             fields: list[str] = []

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -637,6 +637,37 @@ def test_kernel_tombstones_are_read_with_their_migrations() -> None:
     }
 
 
+def test_a_commented_out_kernel_branch_is_not_a_refusal() -> None:
+    # A kernel file means one thing to TeX and must mean the same to the
+    # tools: a tombstone branch behind a comment mark does not run, so the
+    # parser accepts the spelling again and the reader may not count it.
+    live = r"""
+\__tenkz_kernel_tombstone:nnnn { tenkz-kernel-mark } { form } { band }
+  { use~form=enclosure~with~tint }
+"""
+    hidden_on_one_line = (
+        "% \\__tenkz_kernel_tombstone:nnnn { tenkz-kernel-mark }"
+        " { form } { ghost } { use~form=enclosure }\n"
+    )
+    # The wrapped shape the kernel actually writes: the comment mark leaves
+    # the head readable but breaks the reader off mid-row when read raw.
+    hidden_wrapped = (
+        "% \\__tenkz_kernel_tombstone:nnnn { tenkz-kernel-mark }"
+        " { form } { wraith }\n"
+        "%   { use~form=enclosure }\n"
+    )
+    # An escaped backslash is a complete control symbol, so the comment mark
+    # after it starts a real comment and the branch does not run.
+    hidden_after_control_symbol = (
+        "\\\\% \\__tenkz_kernel_tombstone:nnnn { tenkz-kernel-mark }"
+        " { form } { shade } { use~form=enclosure }\n"
+    )
+    text = live + hidden_on_one_line + hidden_wrapped + hidden_after_control_symbol
+    assert _kernel_tombstones_from_texts([text]) == {
+        ("kernel-mark", "form=band"): "use form=enclosure with tint"
+    }
+
+
 VOCABULARY = {
     ("kernel-mark", "form"): ("kernel", "enum(bracket|enclosure|label|prose)"),
     ("kernel-mark", "label pos"): ("kernel", "angle"),


### PR DESCRIPTION
## Context

Closes LionSR/tenkz#200 (follow-up from the LionSR/tenkz#6 checking-surface sweep). The blocker noted on the issue is discharged: LionSR/TNLean#6186 merged, so `tex/tenkz/tenkz-kernel.code.tex` carries four real kernel tombstone rows (`form=brace-above/brace-below/cut/band`, lines 1337–1348) and the false-pass direction is reachable on main.

## Defect

`_kernel_tombstones_from_texts` read the raw text of `tex/tenkz/*.code.tex`, while `load_registry` reads the registry through `tenkzlib.texcase.strip_comments`. A kernel tombstone branch behind a comment mark does not run — TeX accepts the spelling again — but the raw reader kept counting it as a refusal, so the ledger/parser pairing check (`tombstone_errors`, run by `python3 scripts/tenkz_language.py check` in the pr-ci `Check tenkz language ledger` step) reported agreement it no longer holds.

## Watched failures (working agreement 2)

Seeded on main before the fix:

- **False pass:** commenting out the `form=band` row folded to one line → `check` exits 0, `PASS: tenkz language registry (113 records)`, while the kernel accepts `form=band` again.
- **Crash shape:** commenting the row in the kernel's own wrapped spelling (`%` on each continuation line) → the raw reader breaks off mid-row: `ValueError: expected '{' at registry offset 59782` from `_group`.

With the fix, the same single-line seed makes `check` exit 1 with `the tombstone ledger records spellings the parser does not refuse: kernel-mark:form=band`; the seed reverted, `check` passes clean.

## Change

- `scripts/tenkz_language.py`: `_kernel_tombstones_from_texts` reads each text through `strip_comments`, mirroring `load_registry`; the fix sits on the tested seam so every consumer gets it.
- `scripts/test_tenkz_shrink.py`: `test_a_commented_out_kernel_branch_is_not_a_refusal` keeps the three seed shapes (single-line hidden row, kernel-wrapped hidden row, row behind a comment mark after an escaped backslash) beside a live row that must still be read. Watched failing with the fix reverted (the wrapped shape crashes), passes with it.

`pytest scripts/test_tenkz_shrink.py scripts/test_tenkz_language.py`: 47 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UP8U2EDj6USwT4n8xnoYq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Python-only language-check tooling; no runtime TeX or registry content changes.
> 
> **Overview**
> **Kernel tombstone discovery** now runs each `tex/tenkz/*.code.tex` snippet through `strip_comments` before matching `\__tenkz_kernel_tombstone:nnnn`, matching how `load_registry` reads the language registry.
> 
> That closes a ledger/parser mismatch: commented-out tombstone branches are inactive in TeX, but the old raw-text scan could still treat them as refusals (false `check` pass) or mis-parse wrapped `%` continuations and crash in `_group`.
> 
> A new shrink test locks in single-line, kernel-wrapped, and post–control-symbol comment shapes so only live tombstone rows are counted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950aa93e7e15e7c1277f6a1b565c8f95a8b5d72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->