### PR TITLE
ci(workflows): add LANGUAGE-1.0.md to the tenkz corpus path filter

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -255,6 +255,10 @@ jobs:
               - 'docs/tenkz/**/*.tex'
               - 'docs/tenkz/manual2.tex'
               - 'docs/tenkz/tenkzmanual2.sty'
+              # The kernel probes diff the contract's printed sketches
+              # against their fixtures, so contract-side drift must run
+              # the corpus job too ('docs/tenkz/**/*.tex' misses a .md).
+              - 'docs/tenkz/LANGUAGE-1.0.md'
               # The RMP benchmark book's own style file: a runtime input of
               # `tenkz_rmp.py book --all` (the book driver rmp-benchmark.tex
               # already matches 'docs/tenkz/**/*.tex' above).


### PR DESCRIPTION
## Context

Closes LionSR/tenkz#199 (follow-up from the LionSR/tenkz#6 checking-surface sweep). The `tenkz-corpus` job's `Check tenkz kernel record contracts` step runs `scripts/tenkz_kernel_probes.sh`, which diffs the printed sketches in `docs/tenkz/LANGUAGE-1.0.md` against their fixture files. The `corpus` filter of the `changes` job did not list the contract: `docs/tenkz/**/*.tex` misses a `.md`, and `docs/tenkz/**` appears only in the `blueprint` and `shrink` filters. So a PR editing only the contract triggered the workflow but skipped the corpus job — contract-side sketch drift (the exact direction LionSR/TNLean#6180 fixed) failed no gate.

## Change

One filter row: `- 'docs/tenkz/LANGUAGE-1.0.md'` in the `corpus` block, beside the other manual/doc inputs, with a comment stating why a `.md` sits in a `.tex` list.

## Verification

`dorny/paths-filter` only evaluates in CI, so the guarded direction cannot be watched locally. Evidence plan, as the issue's own verification note prescribes: after this merges, a scratch branch editing **only** `docs/tenkz/LANGUAGE-1.0.md` (one sketch character drifted) must show the `tenkz-corpus` job running and the kernel-probe step failing; before this change, the same branch shape shows the job skipped. I will run that scratch-branch demonstration right after merge and record the run links on LionSR/tenkz#199 before it is considered discharged. (This PR itself touches the workflow file, which matches the top-level `workflow` filter, so it is not the clean demonstration.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UP8U2EDj6USwT4n8xnoYq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow path-filter only; no runtime or application logic changes.
> 
> **Overview**
> **Fixes a CI gap** where PRs that only change `docs/tenkz/LANGUAGE-1.0.md` could trigger the workflow but **skip** the `tenkz-corpus` job, because the `corpus` filter listed `docs/tenkz/**/*.tex` and did not include that `.md` contract file.
> 
> Adds `docs/tenkz/LANGUAGE-1.0.md` to the `changes` job’s `corpus` filter (with a short comment) so edits to the language contract **run** `Check tenkz kernel record contracts` via `tenkz_kernel_probes.sh`, which diffs printed sketches in that file against fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b7592c81407330fd8290677767c0b228512e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->