### PR TITLE
fix(tenkz): follow stream-opened files in the offline closure walk

### DIFF
--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -331,8 +331,8 @@ PIPE_FILENAME = re.compile(
 # conditional variants through the signature, so the family is read the way
 # the loaders' conditional variants are.
 STREAM_OPEN_CALL = re.compile(
-    r"\\openin\s*" + STREAM_OPERAND + r"\"([^\"]+)\""
-    r"|\\openin\s*" + STREAM_OPERAND + r"([^\s{}\\%\"]+)"
+    r"\\openin(?![a-zA-Z])\s*" + STREAM_OPERAND + r"\"([^\"]+)\""
+    r"|\\openin(?![a-zA-Z])\s*" + STREAM_OPERAND + r"([^\s{}\\%\"]+)"
     r"|\\ior_open:[a-zA-Z]+\s*(?:\\[A-Za-z@_:]+\s*)?\{\s*\"?([^}\"]*?)\"?\s*\}",
     re.DOTALL,
 )

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -323,6 +323,19 @@ PIPE_FILENAME = re.compile(
     + STREAM_OPERAND
     + r"(?:\{\s*)?\"?\s*\|"
 )
+# A file a stream primitive opens for reading is a load: the engine resolves
+# it like any other input, so a closure walk that skipped it would certify an
+# archive offline while a run reads an unstaged file from the installation.
+# Only the read side is followed; `\openout` and `\iow_open:Nn` create their
+# file, so there is nothing for the archive to carry. expl3 names the
+# conditional variants through the signature, so the family is read the way
+# the loaders' conditional variants are.
+STREAM_OPEN_CALL = re.compile(
+    r"\\openin\s*" + STREAM_OPERAND + r"\"([^\"]+)\""
+    r"|\\openin\s*" + STREAM_OPERAND + r"([^\s{}\\%\"]+)"
+    r"|\\ior_open:[a-zA-Z]+\s*(?:\\[A-Za-z@_:]+\s*)?\{\s*\"?([^}\"]*?)\"?\s*\}",
+    re.DOTALL,
+)
 # The named ways to reach a shell that are not a write at all: the TeX
 # primitive's LaTeX name, and expl3's own shell interface, which a file under
 # `\ExplSyntaxOn` would use in preference to either. The expl3 names are the
@@ -652,6 +665,8 @@ def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
             libraries.extend(part.strip() for part in group.split(",") if part.strip())
         for braced, quoted, bare in INPUT_CALL.findall(text):
             visit((braced or quoted or bare).strip())
+        for quoted, bare, braced in STREAM_OPEN_CALL.findall(text):
+            visit((quoted or bare or braced).strip())
 
     visit(entry)
     closure.packages = sorted(set(packages))

--- a/scripts/tenkz_ctan.py
+++ b/scripts/tenkz_ctan.py
@@ -314,7 +314,13 @@ REDEFINED_NAME = re.compile(
 # The operand a stream primitive takes before its file name: a control
 # sequence or a number, with the equals sign optional, which is TeX's own
 # syntax and not a house spelling.
-STREAM_OPERAND = r"(?:\\[A-Za-z@_:]+|[0-9]+)?\s*=?\s*"
+# The number may be spelled in any of TeX's integer syntaxes: decimal,
+# hexadecimal after a double quote, octal after a single quote, or a
+# character code after a backtick.  A quote left unread here would be
+# taken for the head of a quoted file name and the call would go unread.
+STREAM_OPERAND = (
+    r"(?:\\[A-Za-z@_:]+|\"[0-9A-Fa-f]+|'[0-7]+|`\\?.|[0-9]+)?\s*=?\s*"
+)
 # Only the primitives that open a file are read. `\write` and `\read` take a
 # stream that is already open and a token list that is data, so a token list
 # beginning with a bar is text and refusing it would refuse a valid release.
@@ -331,10 +337,30 @@ PIPE_FILENAME = re.compile(
 # conditional variants through the signature, so the family is read the way
 # the loaders' conditional variants are.
 STREAM_OPEN_CALL = re.compile(
-    r"\\openin(?![a-zA-Z])\s*" + STREAM_OPERAND + r"\"([^\"]+)\""
-    r"|\\openin(?![a-zA-Z])\s*" + STREAM_OPERAND + r"([^\s{}\\%\"]+)"
+    r"\\openin(?![A-Za-z@_:])\s*" + STREAM_OPERAND + r"\"([^\"]+)\""
+    r"|\\openin(?![A-Za-z@_:])\s*" + STREAM_OPERAND + r"([^\s{}\\%\"]+)"
     r"|\\ior_open:[a-zA-Z]+\s*(?:\\[A-Za-z@_:]+\s*)?\{\s*\"?([^}\"]*?)\"?\s*\}",
     re.DOTALL,
+)
+# The write side is read too, not as a dependency but as a provenance: a
+# file the runtime writes and later reopens is the run's own product, and
+# requiring the archive to carry it would refuse every log-and-reread.
+WRITE_OPEN_CALL = re.compile(
+    r"\\openout(?![A-Za-z@_:])\s*" + STREAM_OPERAND + r"\"([^\"]+)\""
+    r"|\\openout(?![A-Za-z@_:])\s*" + STREAM_OPERAND + r"([^\s{}\\%\"]+)"
+    r"|\\iow_open:[a-zA-Z]+\s*(?:\\[A-Za-z@_:]+\s*)?\{\s*\"?([^}\"]*?)\"?\s*\}",
+    re.DOTALL,
+)
+# A file name the source supplies through a macro is opened by TeX after
+# expansion, which a static walk cannot perform.  The walk fails closed on
+# the read side rather than certifying a closure it could not see.  The
+# operand is required here: with it optional, the stream's own register
+# would be read as the macro and every ordinary `\openin\src=name` would
+# be refused.
+MACRO_STREAM_OPEN = re.compile(
+    r"\\openin(?![A-Za-z@_:])\s*"
+    r"(?:\\[A-Za-z@_:]+|\"[0-9A-Fa-f]+|'[0-7]+|`\\?.|[0-9]+)\s*=?\s*"
+    r"\\[A-Za-z@_:]+"
 )
 # The named ways to reach a shell that are not a write at all: the TeX
 # primitive's LaTeX name, and expl3's own shell interface, which a file under
@@ -644,14 +670,25 @@ def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
     closure = Closure()
     packages: list[str] = []
     libraries: list[str] = []
+    # The files the runtime writes before it reads them back: the run's own
+    # products, not archive inputs.  Collected in load order so a product is
+    # known by the time a later open reads it.
+    written: set[str] = set()
+    scanned: set[str] = set()
+
+    def record(name: str) -> None:
+        if name not in closure.files:
+            path = source / name
+            if not path.is_file():
+                raise SystemExit(f"{entry} loads {name}, which is missing")
+            closure.files.append(name)
 
     def visit(name: str) -> None:
-        if name in closure.files:
+        record(name)
+        if name in scanned:
             return
+        scanned.add(name)
         path = source / name
-        if not path.is_file():
-            raise SystemExit(f"{entry} loads {name}, which is missing")
-        closure.files.append(name)
         try:
             # Comments are blanked, and so are the `\\` control symbols: a
             # load spelled inside a macro body as text is not a load, and
@@ -659,14 +696,39 @@ def walk_closure(source: Path = SOURCE, entry: str = ENTRY.name) -> Closure:
             text = uncontrolled(strip_comments(path.read_bytes().decode("utf-8")))
         except UnicodeDecodeError as error:
             raise SystemExit(f"{name} is not UTF-8 and cannot be read: {error}") from None
+        macro_named = MACRO_STREAM_OPEN.search(text)
+        if macro_named is not None:
+            raise SystemExit(
+                f"{name} opens a stream on a macro-supplied file name, which "
+                f"a static walk cannot resolve: {macro_named.group().strip()}"
+            )
         for group in REQUIRE_CALL.findall(text):
             packages.extend(part.strip() for part in group.split(",") if part.strip())
         for group in LIBRARY_CALL.findall(text):
             libraries.extend(part.strip() for part in group.split(",") if part.strip())
-        for braced, quoted, bare in INPUT_CALL.findall(text):
-            visit((braced or quoted or bare).strip())
-        for quoted, bare, braced in STREAM_OPEN_CALL.findall(text):
-            visit((quoted or bare or braced).strip())
+        # Every syntax is read in source order: the closure's contract is the
+        # load order, and a stream opened before an input loads first.  A
+        # stream-opened file is recorded but not scanned — the primitive opens
+        # data, not TeX source, so text inside it that looks like a load is
+        # not one.  A name the runtime wrote first is its own product and is
+        # not recorded at all.
+        loads = [
+            *((match, "input") for match in INPUT_CALL.finditer(text)),
+            *((match, "stream") for match in STREAM_OPEN_CALL.finditer(text)),
+            *((match, "write") for match in WRITE_OPEN_CALL.finditer(text)),
+        ]
+        loads.sort(key=lambda load: load[0].start())
+        for match, kind in loads:
+            found = next(
+                group for group in match.groups() if group is not None
+            ).strip()
+            if kind == "write":
+                written.add(found)
+            elif kind == "stream":
+                if found not in written:
+                    record(found)
+            else:
+                visit(found)
 
     visit(entry)
     closure.packages = sorted(set(packages))

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -130,6 +130,14 @@ def test_closure_reads_the_stream_opened_file() -> None:
                          "\\openin\\src = local.cfg",
                          "\\openin1 local.cfg",
                          '\\openin\\src="local.cfg"',
+                         # The stream number in TeX's other integer
+                         # syntaxes: a quote left unread would be taken
+                         # for the head of a quoted file name and the
+                         # call would go unread.
+                         '\\openin"1=local.cfg',
+                         "\\openin'17=local.cfg",
+                         "\\openin`\\s=local.cfg",
+                         '\\openin"A="local.cfg"',
                          "\\ior_open:Nn \\g_src_ior {local.cfg}",
                          "\\ior_open:NnF \\g_src_ior {local.cfg} {}",
                          '\\ior_open:Nn \\g_src_ior {"local.cfg"}'):
@@ -145,13 +153,58 @@ def test_closure_reads_the_stream_opened_file() -> None:
                          "% \\openin\\src=ghost.cfg",
                          # A control word is read whole: a longer name that
                          # merely opens with the primitive's letters is not
-                         # the primitive plus a file name.
-                         "\\opening{Dear Reader}"):
+                         # the primitive plus a file name, and expl3 words
+                         # continue through underscores and colons.
+                         "\\opening{Dear Reader}",
+                         "\\openinside{note}",
+                         "\\openin_aux:w stop;"):
             (source / "tenkz.sty").write_text(
                 STAGE_CONTRACT + innocent + "\n", encoding="utf-8"
             )
             closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
             assert closure.files == ["tenkz.sty"], innocent
+        # Both syntaxes are visited in source order: the closure's contract
+        # is the load order, and a stream opened before an input loads first.
+        (source / "second.tex").write_text("data\n", encoding="utf-8")
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT + "\\openin\\src=local.cfg\n\\input second.tex\n",
+            encoding="utf-8",
+        )
+        ordered = tenkz_ctan.walk_closure(source, "tenkz.sty")
+        assert ordered.files == ["tenkz.sty", "local.cfg", "second.tex"], ordered.files
+        # The stream primitive opens data, not TeX source: text inside the
+        # file that looks like a load is not one.
+        (source / "local.cfg").write_text(
+            "\\input{ghost.tex}\n\\usepackage{ghostpkg}\n", encoding="utf-8"
+        )
+        data = tenkz_ctan.walk_closure(source, "tenkz.sty")
+        assert data.files == ["tenkz.sty", "local.cfg", "second.tex"], data.files
+        assert "ghostpkg" not in data.packages, data.packages
+        (source / "local.cfg").write_text("data\n", encoding="utf-8")
+        # A file the runtime writes and later reopens is the run's own
+        # product, not an archive input.
+        for product in ("\\openout\\log=run.log\n\\openin\\src=run.log\n",
+                        "\\iow_open:Nn \\g_out_iow {scratch.dat}\n"
+                        "\\ior_open:Nn \\g_in_ior {scratch.dat}\n"):
+            (source / "tenkz.sty").write_text(
+                STAGE_CONTRACT + product, encoding="utf-8"
+            )
+            closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+            assert closure.files == ["tenkz.sty"], product
+        # A macro-supplied file name is opened after expansion, which a
+        # static walk cannot perform: the walk fails closed rather than
+        # certifying a closure it could not see.
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT
+            + "\\def\\filename{local.cfg}\n\\openin\\src\\filename\n",
+            encoding="utf-8",
+        )
+        try:
+            tenkz_ctan.walk_closure(source, "tenkz.sty")
+        except SystemExit as refusal:
+            assert "macro-supplied" in str(refusal), refusal
+        else:
+            raise AssertionError("a macro-supplied stream name passed the walk")
         # A stream-opened file the tree does not hold is a missing load,
         # not a pass: behaviour depending on a machine-local file is not
         # submittable even when the file's absence is handled.

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -117,6 +117,51 @@ def test_closure_reads_the_unbraced_input() -> None:
             assert quoted.files == ["tenkz.sty", "tenkz-stage.code.tex"], spelling
 
 
+def test_closure_reads_the_stream_opened_file() -> None:
+    """A file a stream primitive opens for reading is a load. A walk that
+    skipped it would certify an archive offline while a run reads an
+    unstaged file from the installation."""
+
+    with tempfile.TemporaryDirectory() as directory:
+        source = Path(directory) / "tex"
+        source.mkdir()
+        (source / "local.cfg").write_text("data\n", encoding="utf-8")
+        for spelling in ("\\openin\\src=local.cfg",
+                         "\\openin\\src = local.cfg",
+                         "\\openin1 local.cfg",
+                         '\\openin\\src="local.cfg"',
+                         "\\ior_open:Nn \\g_src_ior {local.cfg}",
+                         "\\ior_open:NnF \\g_src_ior {local.cfg} {}",
+                         '\\ior_open:Nn \\g_src_ior {"local.cfg"}'):
+            (source / "tenkz.sty").write_text(
+                STAGE_CONTRACT + spelling + "\n", encoding="utf-8"
+            )
+            closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+            assert closure.files == ["tenkz.sty", "local.cfg"], spelling
+        # The write side creates its file, so there is nothing for the
+        # archive to carry, and a comment is not a load.
+        for innocent in ("\\openout\\log=run.log",
+                         "\\iow_open:Nn \\g_log_iow {run.log}",
+                         "% \\openin\\src=ghost.cfg"):
+            (source / "tenkz.sty").write_text(
+                STAGE_CONTRACT + innocent + "\n", encoding="utf-8"
+            )
+            closure = tenkz_ctan.walk_closure(source, "tenkz.sty")
+            assert closure.files == ["tenkz.sty"], innocent
+        # A stream-opened file the tree does not hold is a missing load,
+        # not a pass: behaviour depending on a machine-local file is not
+        # submittable even when the file's absence is handled.
+        (source / "tenkz.sty").write_text(
+            STAGE_CONTRACT + "\\openin\\src=absent.cfg\n", encoding="utf-8"
+        )
+        try:
+            tenkz_ctan.walk_closure(source, "tenkz.sty")
+        except SystemExit as refusal:
+            assert "absent.cfg" in str(refusal)
+        else:
+            raise AssertionError("a missing stream-opened file passed the walk")
+
+
 def test_closure_reads_tex_spacing_before_arguments() -> None:
     with tempfile.TemporaryDirectory() as directory:
         source = Path(directory) / "tex"

--- a/scripts/test_tenkz_ctan.py
+++ b/scripts/test_tenkz_ctan.py
@@ -142,7 +142,11 @@ def test_closure_reads_the_stream_opened_file() -> None:
         # archive to carry, and a comment is not a load.
         for innocent in ("\\openout\\log=run.log",
                          "\\iow_open:Nn \\g_log_iow {run.log}",
-                         "% \\openin\\src=ghost.cfg"):
+                         "% \\openin\\src=ghost.cfg",
+                         # A control word is read whole: a longer name that
+                         # merely opens with the primitive's letters is not
+                         # the primitive plus a file name.
+                         "\\opening{Dear Reader}"):
             (source / "tenkz.sty").write_text(
                 STAGE_CONTRACT + innocent + "\n", encoding="utf-8"
             )


### PR DESCRIPTION
## Context

Closes LionSR/tenkz#205 — the largest of the three `tenkz_ctan.py` follow-ups from the LionSR/TNLean#6171 review.

## Defect, watched on main (working agreement 2)

`walk_closure.visit` followed only `INPUT_CALL`, `REQUIRE_CALL`, and `LIBRARY_CALL`, so a file opened by `\openin` or `\ior_open:Nn` never entered `closure.files`. Everything downstream keys on that closure: `carried_runtime()` is exactly `walk_closure().files`, the archive-completeness check reads it, and the offline check's answered-file reading filters the `.fls` record by carried names. A stream-opened dependency resolving from the system TeX tree was therefore invisible to all of them — the archive certified offline while a run read an unstaged file. Watched: a tree whose entry spells `\openin\src=local.cfg` walks to `['tenkz.sty']`.

## Change

`STREAM_OPEN_CALL` joins the walk, reading `\openin` in its bare and Web2C-quoted spellings (operand-then-filename, the way `ABSOLUTE_LOAD`'s stream branch already reads it) and the `\ior_open:` family through the signature, so the conditional variants (`:NnF`, `:NnTF`) are reached the way the loaders' conditionals are. The new names thread through `carried_runtime`, the completeness reading, and the offline answered-file reading with no further change — all three key on the closure.

Design points the issue left open, settled as:
- **Write side excluded.** `\openout`/`\iow_open:Nn` create their file; there is nothing for the archive to carry, and requiring existence would refuse every log-writing release.
- **A missing stream-opened file refuses the walk** like any other missing load, matching the loader doctrine already in the file: behaviour depending on a machine-local file is not submittable even when the file's absence is handled (`\ior_open:NnF` included).

## Verification

New `test_closure_reads_the_stream_opened_file`: seven read-side spellings each walk to a two-file closure (watched failing on unfixed code); write-side and comment shapes stay out; a missing stream-opened file raises the walk's refusal. Comments are already blanked before the graph is read, so the commented shape rides the existing sanitization. `python3 -m pytest scripts/test_tenkz_ctan.py`: 57 passed. tenkz's own sources contain no stream opens (prose matches only), and the real tree's closure is unchanged at 11 files, so the release gates stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UP8U2EDj6USwT4n8xnoYq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the staged runtime closure is computed, which gates archive staging and offline verification; behavior is narrow and heavily tested but a false positive/negative would affect release certification.
> 
> **Overview**
> **`walk_closure`** no longer ignores files opened for reading via `\openin` and `\ior_open:` (including expl3 conditional spellings). Those names are added to the runtime closure like `\input` dependencies, so archive completeness and offline checks cannot pass while a run still reads unstaged files from the installation.
> 
> The walk now merges **inputs**, **stream opens**, and **write opens** in **source order** for load-order fidelity. Stream operands accept TeX’s full integer syntax (hex, octal, backtick). Stream-opened files are **recorded but not recursively scanned** (data files, not TeX). **Write-then-read** paths track runtime-written files so reopening a log/scratch file is not treated as a missing archive input. **Macro-supplied** `\openin` names fail the walk; missing stream targets fail like other missing loads.
> 
> Contract coverage is added in **`test_closure_reads_the_stream_opened_file`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9810bb979831bd620dc15beb06046ad29cdaa4d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->