### PR TITLE
refactor(Analysis): share the Wolf Eq. (8.103) summation bound

### DIFF
--- a/TNLean/Analysis/UpperTriangularBound.lean
+++ b/TNLean/Analysis/UpperTriangularBound.lean
@@ -665,6 +665,89 @@ theorem wolf_eq_105_seminorm (ν : RingSeminorm (Matrix (Fin D) (Fin D) R))
 end RingSeminormCorollary
 
 
+section WolfEq103Sum
+
+variable {D : ℕ} {R : Type*} [Ring R] {Λ N : Matrix (Fin D) (Fin D) R} {n : ℕ}
+
+open RingSeminorm
+
+/-- **Wolf Eq. (8.103)** from a uniform bound on the binomial coefficients.
+
+If \(\binom{n}{k}\le C\) for every \(1\le k\le D-1\), then the word expansion of Eq. (8.105)
+collapses to the constant \((D-1)C\). The coarse constant \(n^{D-1}\) and the refined constant
+\(\binom{n}{D-1}\) are the two instances used below.
+
+**Scope restriction (natural exponent):** the exponent \(n-D+1\) is negative when \(n<D-1\),
+so \(D-1\le n\) is assumed. See docs/paper-gaps/wolf_ch8_eq_8_103_negative_exponent.tex. -/
+private lemma wolf_eq_103_of_choose_le (ν : RingSeminorm (Matrix (Fin D) (Fin D) R))
+    (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
+    (hDpos : D ≠ 0) (hn_ge : D - 1 ≤ n) (hνΛ : ν Λ ≤ 1) (C : ℕ)
+    (hC : ∀ k ∈ Finset.Icc 1 (D - 1), Nat.choose n k ≤ C) :
+    ν ((Λ + N) ^ n) ≤ ν (Λ ^ n) +
+      (((D-1 : ℕ) * C : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1)) *
+      max (ν N) ((ν N) ^ (D-1)) := by
+  have h_nonneg_νΛ : 0 ≤ ν Λ := apply_nonneg ν _
+  have h_nonneg_νN : 0 ≤ ν N := apply_nonneg ν _
+  have h_base := wolf_eq_105_seminorm ν hΛ_diag hN_sut hDpos n
+  have h_min_eq : min n (D - 1) = D - 1 := Nat.min_eq_right hn_ge
+  rw [h_min_eq] at h_base
+  by_cases hIcc_empty : Finset.Icc (1 : ℕ) (D - 1) = ∅
+  · rw [hIcc_empty, Finset.sum_empty] at h_base
+    have h_nonneg_extra : 0 ≤ (((D-1 : ℕ) * C : ℕ) : ℝ)
+        * (ν Λ) ^ (n - (D-1)) *
+      max (ν N) ((ν N) ^ (D-1)) := by positivity
+    nlinarith
+  · have h_Dm1_pos : 1 ≤ D - 1 := by
+      contrapose! hIcc_empty
+      exact Finset.Icc_eq_empty_of_lt (by omega)
+    have h_card : (Finset.Icc 1 (D - 1)).card = D - 1 := by
+      simp
+    have h_cardℝ : ((Finset.Icc 1 (D - 1)).card : ℝ) = (D - 1 : ℝ) := by
+      have hD1' : 1 ≤ D := by omega
+      rw [h_card, Nat.cast_sub hD1', Nat.cast_one]
+    have h_term_bound (k : ℕ) (hk : k ∈ Finset.Icc 1 (D - 1)) :
+        ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k)) ≤
+        (C : ℝ) * max (ν N) ((ν N) ^ (D-1)) * (ν Λ) ^ (n - (D-1)) := by
+      rcases Finset.mem_Icc.mp hk with ⟨hk1, hk2⟩
+      have h_choose : (Nat.choose n k : ℝ) ≤ (C : ℝ) := mod_cast hC k hk
+      have h_nuN_pow : (ν N) ^ k ≤ max (ν N) ((ν N) ^ (D-1)) :=
+        pow_le_max_of_one_le h_nonneg_νN hk1 hk2
+      have h_nuΛ_pow : (ν Λ) ^ (n - k) ≤ (ν Λ) ^ (n - (D - 1)) := by
+        have h_exp_le : n - (D - 1) ≤ n - k := by omega
+        exact pow_le_pow_of_le_one h_nonneg_νΛ hνΛ h_exp_le
+      have h_nonneg_choose : 0 ≤ (Nat.choose n k : ℝ) := by exact mod_cast Nat.zero_le _
+      have h_nonneg_C : 0 ≤ (C : ℝ) := by exact mod_cast Nat.zero_le _
+      calc
+        ((Nat.choose n k : ℝ) * (ν N) ^ k) * (ν Λ) ^ (n - k) ≤
+            ((C : ℝ) * max (ν N) ((ν N) ^ (D-1))) * (ν Λ) ^ (n - k) := by
+          gcongr
+        _ ≤ ((C : ℝ) * max (ν N) ((ν N) ^ (D-1))) * (ν Λ) ^ (n - (D-1)) := by
+          gcongr
+    have h_sum_bound : (∑ k ∈ Finset.Icc 1 (D - 1),
+        ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k))) ≤
+        (((D-1 : ℕ) * C : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1)) *
+        max (ν N) ((ν N) ^ (D-1)) := by
+      have hD1 : 1 ≤ D := by omega
+      calc
+        (∑ k ∈ Finset.Icc 1 (D - 1),
+            ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k))) ≤
+            (∑ _k ∈ Finset.Icc 1 (D - 1),
+              ((C : ℝ) * max (ν N) ((ν N) ^ (D-1)) * (ν Λ) ^ (n - (D-1)))) :=
+          Finset.sum_le_sum (fun k hk => h_term_bound k hk)
+        _ = ((Finset.Icc 1 (D - 1)).card : ℝ) *
+            ((C : ℝ) * max (ν N) ((ν N) ^ (D-1)) * (ν Λ) ^ (n - (D-1))) := by
+          simp
+        _ = (D - 1 : ℝ) * ((C : ℝ) * max (ν N) ((ν N) ^ (D-1))
+              * (ν Λ) ^ (n - (D-1))) := by
+          rw [h_cardℝ]
+        _ = (((D-1 : ℕ) * C : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1))
+              * max (ν N) ((ν N) ^ (D-1)) := by
+          rw [Nat.cast_mul, Nat.cast_sub hD1, Nat.cast_one]
+          ring
+    nlinarith
+
+end WolfEq103Sum
+
 section WolfEq103
 
 variable {D : ℕ} {R : Type*} [Ring R] {Λ N : Matrix (Fin D) (Fin D) R} {n : ℕ}
@@ -682,85 +765,10 @@ theorem wolf_eq_103 (ν : RingSeminorm (Matrix (Fin D) (Fin D) R))
     ν ((Λ + N) ^ n) ≤ ν (Λ ^ n) +
       (((D-1 : ℕ) * n ^ (D-1 : ℕ) : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1)) *
       max (ν N) ((ν N) ^ (D-1)) := by
-  have h_nonneg_νΛ : 0 ≤ ν Λ := apply_nonneg ν _
-  have h_nonneg_νN : 0 ≤ ν N := apply_nonneg ν _
-  have h_base := wolf_eq_105_seminorm ν hΛ_diag hN_sut hDpos n
-  have h_min_eq : min n (D - 1) = D - 1 := Nat.min_eq_right hn_ge
-  rw [h_min_eq] at h_base
-  by_cases hIcc_empty : Finset.Icc (1 : ℕ) (D - 1) = ∅
-  · rw [hIcc_empty, Finset.sum_empty] at h_base
-    have h_nonneg_extra : 0 ≤ (((D-1 : ℕ) * n ^ (D-1 : ℕ) : ℕ) : ℝ)
-        * (ν Λ) ^ (n - (D-1)) *
-      max (ν N) ((ν N) ^ (D-1)) := by positivity
-    nlinarith
-  · have h_Dm1_pos : 1 ≤ D - 1 := by
-      contrapose! hIcc_empty
-      exact Finset.Icc_eq_empty_of_lt (by omega)
-    have h_card : (Finset.Icc 1 (D - 1)).card = D - 1 := by
-      simp
-    have h_cardℝ : ((Finset.Icc 1 (D - 1)).card : ℝ) = (D - 1 : ℝ) := by
-      have hD1' : 1 ≤ D := by omega
-      rw [h_card, Nat.cast_sub hD1', Nat.cast_one]
-    have h_term_bound (k : ℕ) (hk : k ∈ Finset.Icc 1 (D - 1)) :
-        ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k)) ≤
-        ((n ^ (D-1 : ℕ) : ℕ) : ℝ) * max (ν N) ((ν N) ^ (D-1)) * (ν Λ) ^ (n - (D-1)) := by
-      rcases Finset.mem_Icc.mp hk with ⟨hk1, hk2⟩
-      have h_choose : (Nat.choose n k : ℝ) ≤ ((n ^ (D-1 : ℕ) : ℕ) : ℝ) := by
-        have h_choose_nat : Nat.choose n k ≤ n ^ k := Nat.choose_le_pow n k
-        have h_pow_mono : n ^ k ≤ n ^ (D-1) := by
-          by_cases hn0 : n = 0
-          · subst hn0
-            have : D = 1 := by omega
-            subst this
-            have : Finset.Icc (1 : ℕ) 0 = ∅ := by decide
-            rw [this] at hk
-            simp at hk
-          · have hnpos : 0 < n := Nat.pos_of_ne_zero hn0
-            exact Nat.pow_le_pow_right hnpos hk2
-        exact mod_cast h_choose_nat.trans h_pow_mono
-      have h_nuN_pow : (ν N) ^ k ≤ max (ν N) ((ν N) ^ (D-1)) :=
-        pow_le_max_of_one_le h_nonneg_νN hk1 hk2
-      have h_nuΛ_pow : (ν Λ) ^ (n - k) ≤ (ν Λ) ^ (n - (D - 1)) := by
-        have h_exp_le : n - (D - 1) ≤ n - k := by omega
-        exact pow_le_pow_of_le_one h_nonneg_νΛ hνΛ h_exp_le
-      have h_nonneg_choose : 0 ≤ (Nat.choose n k : ℝ) := by exact mod_cast Nat.zero_le _
-      have h_nonneg_npow : 0 ≤ ((n ^ (D-1 : ℕ) : ℕ) : ℝ) := by exact mod_cast Nat.zero_le _
-      have h_prod : ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k)) ≤
-          (((n ^ (D-1 : ℕ) : ℕ) : ℝ) * max (ν N) ((ν N) ^ (D-1))
-            * (ν Λ) ^ (n - (D-1))) := by
-        calc
-          ((Nat.choose n k : ℝ) * (ν N) ^ k) * (ν Λ) ^ (n - k) ≤
-              (((n ^ (D-1 : ℕ) : ℕ) : ℝ) * max (ν N) ((ν N) ^ (D-1)))
-                * (ν Λ) ^ (n - k) := by
-            gcongr
-          _ ≤ (((n ^ (D-1 : ℕ) : ℕ) : ℝ) * max (ν N) ((ν N) ^ (D-1)))
-              * (ν Λ) ^ (n - (D-1)) := by
-            gcongr
-      exact h_prod
-    have h_sum_bound : (∑ k ∈ Finset.Icc 1 (D - 1),
-        ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k))) ≤
-        (((D-1 : ℕ) * n ^ (D-1 : ℕ) : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1)) *
-        max (ν N) ((ν N) ^ (D-1)) := by
-      have hD1 : 1 ≤ D := by omega
-      calc
-        (∑ k ∈ Finset.Icc 1 (D - 1),
-            ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k))) ≤
-            (∑ k ∈ Finset.Icc 1 (D - 1),
-              (((n ^ (D-1 : ℕ) : ℕ) : ℝ) * max (ν N) ((ν N) ^ (D-1))
-                * (ν Λ) ^ (n - (D-1)))) :=
-          Finset.sum_le_sum (fun k hk => h_term_bound k hk)
-        _ = ((Finset.Icc 1 (D - 1)).card : ℝ) *
-            (((n ^ (D-1 : ℕ) : ℕ) : ℝ) * max (ν N) ((ν N) ^ (D-1))
-              * (ν Λ) ^ (n - (D-1))) := by
-          simp
-        _ = (D - 1 : ℝ) * (((n ^ (D-1 : ℕ) : ℕ) : ℝ) * max (ν N) ((ν N) ^ (D-1))
-              * (ν Λ) ^ (n - (D-1))) := by
-          rw [h_cardℝ]
-        _ = (((D-1 : ℕ) * n ^ (D-1 : ℕ) : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1))
-              * max (ν N) ((ν N) ^ (D-1)) := by
-          rw [Nat.cast_mul, Nat.cast_sub hD1, Nat.cast_one, Nat.cast_pow]
-          ring
-    nlinarith
+  refine wolf_eq_103_of_choose_le ν hΛ_diag hN_sut hDpos hn_ge hνΛ (n ^ (D-1 : ℕ)) ?_
+  intro k hk
+  rcases Finset.mem_Icc.mp hk with ⟨hk1, hk2⟩
+  exact (Nat.choose_le_pow n k).trans (Nat.pow_le_pow_right (by omega) hk2)
 
 end WolfEq103
 
@@ -781,90 +789,27 @@ theorem wolf_eq_103_refined (ν : RingSeminorm (Matrix (Fin D) (Fin D) R))
     ν ((Λ + N) ^ n) ≤ ν (Λ ^ n) +
       (((D-1 : ℕ) * Nat.choose n (D-1) : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1)) *
       max (ν N) ((ν N) ^ (D-1)) := by
-  have h_nonneg_νΛ : 0 ≤ ν Λ := apply_nonneg ν _
-  have h_nonneg_νN : 0 ≤ ν N := apply_nonneg ν _
-  have h_Dm1_le_n : D - 1 ≤ n := by omega
-  have h_base := wolf_eq_105_seminorm ν hΛ_diag hN_sut hDpos n
-  have h_min_eq : min n (D - 1) = D - 1 := Nat.min_eq_right h_Dm1_le_n
-  rw [h_min_eq] at h_base
-  by_cases hIcc_empty : Finset.Icc (1 : ℕ) (D - 1) = ∅
-  · rw [hIcc_empty, Finset.sum_empty] at h_base
-    have h_nonneg_extra : 0 ≤ (((D-1 : ℕ) * Nat.choose n (D-1) : ℕ) : ℝ)
-        * (ν Λ) ^ (n - (D-1)) *
-      max (ν N) ((ν N) ^ (D-1)) := by positivity
-    nlinarith
-  · have h_Dm1_pos : 1 ≤ D - 1 := by
-      contrapose! hIcc_empty
-      exact Finset.Icc_eq_empty_of_lt (by omega)
-    have h_card : (Finset.Icc 1 (D - 1)).card = D - 1 := by
-      simp
-    have h_cardℝ : ((Finset.Icc 1 (D - 1)).card : ℝ) = (D - 1 : ℝ) := by
-      have hD1' : 1 ≤ D := by omega
-      rw [h_card, Nat.cast_sub hD1', Nat.cast_one]
-    -- Refined bound: Nat.choose n k ≤ Nat.choose n (D-1) for k ≤ D-1
-    -- The binomial coefficients increase up to the middle index.
-    have h_choose_refined (k : ℕ) (hk : k ∈ Finset.Icc 1 (D - 1)) :
-        Nat.choose n k ≤ Nat.choose n (D - 1) := by
-      rcases Finset.mem_Icc.mp hk with ⟨hk1, hk2⟩
-      obtain ⟨d, hd⟩ := Nat.exists_eq_add_of_le hk2
-      have h_helper : ∀ d', 2 * (k + d') ≤ n → Nat.choose n k ≤ Nat.choose n (k + d') := by
-        intro d'
-        induction' d' with d' ih
-        · intro; rfl
-        · intro hbound
-          have hbound' : 2 * (k + d') ≤ n := by omega
-          have hk_d'_lt_half : k + d' < n / 2 := by omega
-          have hstep : Nat.choose n (k + d') ≤ Nat.choose n (k + d' + 1) :=
-            Nat.choose_le_succ_of_lt_half_left hk_d'_lt_half
-          have h_eq : k + d' + 1 = k + (d' + 1) := by omega
-          rw [← h_eq]
-          exact (ih hbound').trans hstep
-      have h_total_bound : 2 * (k + d) ≤ n := by
-        omega
-      simpa [hd] using h_helper d h_total_bound
-    have h_term_bound (k : ℕ) (hk : k ∈ Finset.Icc 1 (D - 1)) :
-        ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k)) ≤
-        ((Nat.choose n (D-1) : ℝ) * max (ν N) ((ν N) ^ (D-1)) * (ν Λ) ^ (n - (D-1))) := by
-      rcases Finset.mem_Icc.mp hk with ⟨hk1, hk2⟩
-      have h_choose : (Nat.choose n k : ℝ) ≤ (Nat.choose n (D-1) : ℝ) :=
-        mod_cast h_choose_refined k hk
-      have h_nuN_pow : (ν N) ^ k ≤ max (ν N) ((ν N) ^ (D-1)) :=
-        pow_le_max_of_one_le h_nonneg_νN hk1 hk2
-      have h_nuΛ_pow : (ν Λ) ^ (n - k) ≤ (ν Λ) ^ (n - (D - 1)) := by
-        have h_exp_le : n - (D - 1) ≤ n - k := by omega
-        exact pow_le_pow_of_le_one h_nonneg_νΛ hνΛ h_exp_le
-      have h_prod : ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k)) ≤
-          ((Nat.choose n (D-1) : ℝ) * max (ν N) ((ν N) ^ (D-1)) * (ν Λ) ^ (n - (D-1))) := by
-        calc
-          ((Nat.choose n k : ℝ) * (ν N) ^ k) * (ν Λ) ^ (n - k) ≤
-              ((Nat.choose n (D-1) : ℝ) * max (ν N) ((ν N) ^ (D-1))) * (ν Λ) ^ (n - k) := by
-            gcongr
-          _ ≤ ((Nat.choose n (D-1) : ℝ) * max (ν N) ((ν N) ^ (D-1)))
-              * (ν Λ) ^ (n - (D-1)) := by
-            gcongr
-      exact h_prod
-    have h_sum_bound : (∑ k ∈ Finset.Icc 1 (D - 1),
-        ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k))) ≤
-        (((D-1 : ℕ) * Nat.choose n (D-1) : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1)) *
-        max (ν N) ((ν N) ^ (D-1)) := by
-      have hD1 : 1 ≤ D := by omega
-      calc
-        (∑ k ∈ Finset.Icc 1 (D - 1),
-            ((Nat.choose n k : ℝ) * (ν N) ^ k * (ν Λ) ^ (n - k))) ≤
-            (∑ k ∈ Finset.Icc 1 (D - 1),
-              ((Nat.choose n (D-1) : ℝ) * max (ν N) ((ν N) ^ (D-1)) * (ν Λ) ^ (n - (D-1)))) :=
-          Finset.sum_le_sum (fun k hk => h_term_bound k hk)
-        _ = ((Finset.Icc 1 (D - 1)).card : ℝ) *
-            ((Nat.choose n (D-1) : ℝ) * max (ν N) ((ν N) ^ (D-1)) * (ν Λ) ^ (n - (D-1))) := by
-          simp
-        _ = (D - 1 : ℝ) * ((Nat.choose n (D-1) : ℝ) * max (ν N) ((ν N) ^ (D-1))
-              * (ν Λ) ^ (n - (D-1))) := by
-          rw [h_cardℝ]
-        _ = (((D-1 : ℕ) * Nat.choose n (D-1) : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1))
-              * max (ν N) ((ν N) ^ (D-1)) := by
-          rw [Nat.cast_mul, Nat.cast_sub hD1, Nat.cast_one]
-          ring
-    nlinarith
+  refine wolf_eq_103_of_choose_le ν hΛ_diag hN_sut hDpos (by omega) hνΛ
+    (Nat.choose n (D-1)) ?_
+  -- The binomial coefficients increase up to the middle index, so the largest one on
+  -- `Finset.Icc 1 (D-1)` sits at `D-1`.
+  intro k hk
+  rcases Finset.mem_Icc.mp hk with ⟨hk1, hk2⟩
+  obtain ⟨d, hd⟩ := Nat.exists_eq_add_of_le hk2
+  have h_helper : ∀ d', 2 * (k + d') ≤ n → Nat.choose n k ≤ Nat.choose n (k + d') := by
+    intro d'
+    induction' d' with d' ih
+    · intro; rfl
+    · intro hbound
+      have hbound' : 2 * (k + d') ≤ n := by omega
+      have hk_d'_lt_half : k + d' < n / 2 := by omega
+      have hstep : Nat.choose n (k + d') ≤ Nat.choose n (k + d' + 1) :=
+        Nat.choose_le_succ_of_lt_half_left hk_d'_lt_half
+      have h_eq : k + d' + 1 = k + (d' + 1) := by omega
+      rw [← h_eq]
+      exact (ih hbound').trans hstep
+  have h_total_bound : 2 * (k + d) ≤ n := by omega
+  simpa [hd] using h_helper d h_total_bound
 
 end WolfEq103Refined
 

--- a/TNLean/Analysis/UpperTriangularBound.lean
+++ b/TNLean/Analysis/UpperTriangularBound.lean
@@ -31,8 +31,9 @@ together with the coarse and refined power bounds (Wolf Eq. 8.103).
 * `Matrix.wolf_eq_105_seminorm` — the word-expansion bound for all `n`
 * `Matrix.wolf_eq_103` — the coarse constant `(D-1)n^{D-1}` under `D-1 ≤ n`
 * `Matrix.wolf_eq_103_refined` — the binomial-coefficient constant under `2(D-1) ≤ n`
-* `Matrix.wolf_eq_103_of_choose_le` (private) — the shared summation bound behind both
-  (8.103) constants, parametrized by a uniform bound on the binomial coefficients
+
+Both (8.103) constants descend from a single summation bound, parametrized by a uniform
+bound on the binomial coefficients, which stays private to this file.
 
 ## References
 

--- a/TNLean/Analysis/UpperTriangularBound.lean
+++ b/TNLean/Analysis/UpperTriangularBound.lean
@@ -797,7 +797,7 @@ theorem wolf_eq_103_refined (ν : RingSeminorm (Matrix (Fin D) (Fin D) R))
   -- The binomial coefficients increase up to the middle index, so the largest one on
   -- `Finset.Icc 1 (D-1)` sits at `D-1`.
   intro k hk
-  rcases Finset.mem_Icc.mp hk with ⟨hk1, hk2⟩
+  rcases Finset.mem_Icc.mp hk with ⟨_, hk2⟩
   obtain ⟨d, hd⟩ := Nat.exists_eq_add_of_le hk2
   have h_helper : ∀ d', 2 * (k + d') ≤ n → Nat.choose n k ≤ Nat.choose n (k + d') := by
     intro d'

--- a/TNLean/Analysis/UpperTriangularBound.lean
+++ b/TNLean/Analysis/UpperTriangularBound.lean
@@ -31,6 +31,8 @@ together with the coarse and refined power bounds (Wolf Eq. 8.103).
 * `Matrix.wolf_eq_105_seminorm` — the word-expansion bound for all `n`
 * `Matrix.wolf_eq_103` — the coarse constant `(D-1)n^{D-1}` under `D-1 ≤ n`
 * `Matrix.wolf_eq_103_refined` — the binomial-coefficient constant under `2(D-1) ≤ n`
+* `Matrix.wolf_eq_103_of_choose_le` (private) — the shared summation bound behind both
+  (8.103) constants, parametrized by a uniform bound on the binomial coefficients
 
 ## References
 


### PR DESCRIPTION
## What was deduplicated

`Matrix.wolf_eq_103` and `Matrix.wolf_eq_103_refined` in
`TNLean/Analysis/UpperTriangularBound.lean` ran the same argument twice: apply
`wolf_eq_105_seminorm`, split on whether `Finset.Icc 1 (D-1)` is empty, compute
`(Finset.Icc 1 (D-1)).card = D - 1` and its cast to `ℝ`, bound each summand by
`pow_le_max_of_one_le` and `pow_le_pow_of_le_one`, and collapse the finite sum.
The two copies differed only in the constant bounding the binomial coefficients.

That argument is now the private lemma `Matrix.wolf_eq_103_of_choose_le`,
parametrized by a bound `C : ℕ` together with

```lean
(hC : ∀ k ∈ Finset.Icc 1 (D - 1), Nat.choose n k ≤ C)
```

The coarse theorem instantiates it with `C := n ^ (D-1)` (justified by
`Nat.choose_le_pow` and `Nat.pow_le_pow_right`), the refined one with
`C := Nat.choose n (D-1)` (justified by the `Nat.choose_le_succ_of_lt_half_left`
monotonicity induction, which is all that remains of that proof). Each public
proof is now four to twelve lines.

Net: 74 insertions, 129 deletions.

## Both public statements are unchanged

```lean
theorem wolf_eq_103 (ν : RingSeminorm (Matrix (Fin D) (Fin D) R))
    (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
    (hDpos : D ≠ 0) (hn_ge : D - 1 ≤ n) (hνΛ : ν Λ ≤ 1) :
    ν ((Λ + N) ^ n) ≤ ν (Λ ^ n) +
      (((D-1 : ℕ) * n ^ (D-1 : ℕ) : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1)) *
      max (ν N) ((ν N) ^ (D-1))

theorem wolf_eq_103_refined (ν : RingSeminorm (Matrix (Fin D) (Fin D) R))
    (hΛ_diag : IsDiag Λ) (hN_sut : IsStrictlyUpperTriangular N)
    (hDpos : D ≠ 0) (hn_ge : 2 * (D - 1) ≤ n) (hνΛ : ν Λ ≤ 1) :
    ν ((Λ + N) ^ n) ≤ ν (Λ ^ n) +
      (((D-1 : ℕ) * Nat.choose n (D-1) : ℕ) : ℝ) * (ν Λ) ^ (n - (D-1)) *
      max (ν N) ((ν N) ^ (D-1))
```

Both are byte-identical to `main`, docstrings included. The documented
natural-exponent scope restriction is untouched, no negative-exponent claim is
made, and public `Matrix.countN` was not moved.

## Verification

| Command | Outcome |
|---|---|
| `lake env lean TNLean/Analysis/UpperTriangularBound.lean` | clean, no errors or new warnings |
| `lake build TNLean.Analysis` (the only module importing the file) | `Build completed successfully (3437 jobs)` |
| `rg -n "sorry\|axiom" TNLean/Analysis/UpperTriangularBound.lean` | no matches |
| line length ≤ 100 over the changed file | no violations |

The two linter warnings the build prints (`simp` flexibility at line 489, the
`induction'` at the binomial monotonicity step) are both present on `main`; the
`induction'` block was moved verbatim.

## Blueprint

`blueprint/src/chapter/ch27_channel_asymptotics_upper_triangular_power.tex`
carries `\lean{Matrix.wolf_eq_103, Matrix.wolf_eq_103_refined}` with `\leanok`.
Both names, statements, and hypotheses are unchanged, so no blueprint edit is
needed. The new lemma is `private` and takes no blueprint entry.

Closes LionSR/QICLean#324.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactor with identical public API; no behavior or downstream contract changes beyond internal structure.
> 
> **Overview**
> Factors the duplicated Wolf Eq. (8.103) proof in `UpperTriangularBound.lean` into a **private** lemma `wolf_eq_103_of_choose_le`, which assumes a uniform bound `C` on `Nat.choose n k` for `k ∈ Finset.Icc 1 (D - 1)` and yields the `(D-1)C` constant form.
> 
> **`wolf_eq_103`** and **`wolf_eq_103_refined`** now only supply `C` and prove `hC`: coarse uses `C := n^(D-1)` via `Nat.choose_le_pow` / `Nat.pow_le_pow_right`; refined uses `C := Nat.choose n (D-1)` via the existing binomial monotonicity induction. The module doc notes that both (8.103) constants come from this single summation bound.
> 
> Public theorem **statements, names, and docstrings are unchanged**; net ~55 lines removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7055365d2ddcb0aa8514c712bfedd17b924376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->