### PR TITLE
feat(analysis): add generic two-projection angle block

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -23,6 +23,7 @@ import TNLean.Analysis.EntropyMarkovForward
 import TNLean.Analysis.EntropyMarkovReverse
 import TNLean.Analysis.EntropyReindex
 import TNLean.Analysis.HayashiMarkovStructure
+import TNLean.Analysis.IdempotentEndomorphism
 import TNLean.Analysis.InjectiveRangeProjector
 import TNLean.Analysis.IsometricCompression
 import TNLean.Analysis.JordanBlockPower

--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -60,5 +60,6 @@ import TNLean.Analysis.TraceCFC
 import TNLean.Analysis.TraceNormAbs
 import TNLean.Analysis.TraceNormContractivity
 import TNLean.Analysis.TraceNormVariational
+import TNLean.Analysis.TwoProjectionAngleBlock
 import TNLean.Analysis.TwoProjectionCompression
 import TNLean.Analysis.UpperTriangularBound

--- a/TNLean/Analysis/IdempotentEndomorphism.lean
+++ b/TNLean/Analysis/IdempotentEndomorphism.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Projection
+
+/-!
+# Idempotent endomorphisms
+
+Elementary pointwise consequences of idempotence for linear endomorphisms.
+-/
+
+namespace LinearMap.IsIdempotentElem
+
+variable {R E : Type*} [Semiring R] [AddCommMonoid E] [Module R E]
+
+/-- An idempotent linear endomorphism fixes every vector in its image. -/
+theorem apply_apply {P : E →ₗ[R] E} (hP : IsIdempotentElem P) (x : E) :
+    P (P x) = P x := by
+  simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[R] E ↦ T x) hP.eq
+
+end LinearMap.IsIdempotentElem

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.IdempotentEndomorphism
 import Mathlib.Analysis.InnerProductSpace.Positive
 
 /-!
@@ -33,9 +34,7 @@ quadratic form. -/
 theorem re_inner_apply_apply_self {P : E →ₗ[𝕜] E} (hP : P.IsSymmetricProjection)
     (v : E) :
     RCLike.re (⟪P v, P v⟫_𝕜) = RCLike.re (⟪P v, v⟫_𝕜) := by
-  have hidem : P (P v) = P v := by
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[𝕜] E => T v)
-      hP.isIdempotentElem.eq
+  have hidem : P (P v) = P v := LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem v
   rw [show ⟪P v, P v⟫_𝕜 = ⟪P (P v), v⟫_𝕜 from (hP.isSymmetric (P v) v).symm, hidem]
 
 /-- A norm bound on the compressed product of two projections gives the ordered
@@ -57,9 +56,7 @@ theorem re_inner_apply_apply_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
     (hP : P.IsSymmetricProjection) {c : ℝ}
     (hNorm : ∀ v : E, ‖P (Q v)‖ ≤ c * ‖P v‖) (v : E) :
     -c * RCLike.re (⟪P v, v⟫_𝕜) ≤ RCLike.re (⟪P v, Q v⟫_𝕜) := by
-  have hPidem : P (P v) = P v := by
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[𝕜] E => T v)
-      hP.isIdempotentElem.eq
+  have hPidem : P (P v) = P v := LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem v
   have hcompress : ⟪P v, Q v⟫_𝕜 = ⟪P v, P (Q v)⟫_𝕜 := by
     calc
       ⟪P v, Q v⟫_𝕜 = ⟪P (P v), Q v⟫_𝕜 := by rw [hPidem]
@@ -115,9 +112,7 @@ theorem re_inner_anticommutator_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
     rw [← hQ.re_inner_apply_apply_self v, inner_self_eq_norm_sq]
   have hconj : RCLike.re (⟪Q v, P v⟫_𝕜) = RCLike.re (⟪P v, Q v⟫_𝕜) := by
     rw [← inner_conj_symm (P v) (Q v), RCLike.conj_re]
-  have hPidem : P (P v) = P v := by
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[𝕜] E => T v)
-      hP.isIdempotentElem.eq
+  have hPidem : P (P v) = P v := LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem v
   have hcompress : ⟪P v, Q v⟫_𝕜 = ⟪P v, P (Q v)⟫_𝕜 := by
     calc
       ⟪P v, Q v⟫_𝕜 = ⟪P (P v), Q v⟫_𝕜 := by rw [hPidem]
@@ -152,9 +147,8 @@ theorem re_inner_apply_apply_nonneg_of_commute {P Q : E →ₗ[𝕜] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
     (hcomm : ∀ v : E, P (Q v) = Q (P v)) (v : E) :
     0 ≤ RCLike.re (⟪P v, Q v⟫_𝕜) := by
-  have hQidem : Q (Q (P v)) = Q (P v) := by
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[𝕜] E => T (P v))
-      hQ.isIdempotentElem.eq
+  have hQidem : Q (Q (P v)) = Q (P v) :=
+    LinearMap.IsIdempotentElem.apply_apply hQ.isIdempotentElem (P v)
   have hsym₁ : ⟪P v, Q v⟫_𝕜 = ⟪Q (P v), v⟫_𝕜 := (hQ.isSymmetric (P v) v).symm
   have hsym₂ : ⟪Q (P v), v⟫_𝕜 = ⟪Q (P v), Q v⟫_𝕜 := by
     calc

--- a/TNLean/Analysis/TwoProjectionAngleBlock.lean
+++ b/TNLean/Analysis/TwoProjectionAngleBlock.lean
@@ -3,14 +3,14 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Analysis.ProjectionGeometry
+import Mathlib.Analysis.InnerProductSpace.Positive
 
 /-!
 # A generic angle block for two orthogonal projections
 
 This file gives the local two-dimensional block used in the two-projection
-lemma invoked in arXiv:1703.09188, Proposition 1, lines 756–764.  It does not
-assume that the projections commute.
+lemma invoked in arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`),
+lines 756–764. It does not assume that the projections commute.
 -/
 
 open scoped InnerProductSpace
@@ -53,16 +53,16 @@ def angleDefect (Q : E →ₗ[ℂ] E) (μ : ℝ) (x : E) : E :=
   Q x - (μ : ℂ) • x
 
 /-- One generic two-dimensional angle block associated with an eigenvalue
-`0 < μ < 1` of the compression of `Q` to `range P`.
+\(0 < μ < 1\) of the compression of `Q` to `range P`.
 
-The first vector is a unit compression eigenvector `x`.  The second vector is
-`Q x - μ x`; its squared norm is `μ(1-μ)`, so it is nonzero and can be
-normalized in the subsequent corollary.  The displayed identities are the
+The first vector is a unit compression eigenvector `x`. The second vector is
+\(Qx - μx\); its squared norm is \(μ(1-μ)\), so it is nonzero and can be
+normalized in the subsequent corollary. The displayed identities are the
 exact actions of `P` and `Q` on this block.
 -/
 theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
-    {μ : ℝ} (_hμ0 : 0 < μ) (_hμ1 : μ < 1) {x : E}
+    {μ : ℝ} {x : E}
     (hxP : P x = x) (hxnorm : ‖x‖ = 1) (hxEig : P (Q x) = (μ : ℂ) • x) :
     P (angleDefect Q μ x) = 0 ∧
       Q x = (μ : ℂ) • x + angleDefect Q μ x ∧
@@ -121,7 +121,7 @@ theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
 /-- Normalized form of `angleDefect_block`. The vectors `x,w` are orthonormal;
 on their two-dimensional span, `P` acts as the projection onto `x`, while `Q`
 has its standard angle-block action with off-diagonal coefficient
-`sqrt (μ(1-μ))`. -/
+\(\sqrt{μ(1-μ)}\). -/
 theorem exists_orthonormal_angleBlock {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
     {μ : ℝ} (hμ0 : 0 < μ) (hμ1 : μ < 1) {x : E}
@@ -137,7 +137,7 @@ theorem exists_orthonormal_angleBlock {P Q : E →ₗ[ℂ] E}
   have ha0 : a ≠ 0 := ne_of_gt hapos
   have haSq : a ^ 2 = μ * (1 - μ) := Real.sq_sqrt hdpos.le
   obtain ⟨hdP, hxQ, hQd, hxd, hdNormSq⟩ :=
-    angleDefect_block hP hQ hμ0 hμ1 hxP hxnorm hxEig
+    angleDefect_block hP hQ hxP hxnorm hxEig
   have hdNorm : ‖d‖ = a := by
     have hda : ‖d‖ ^ 2 = a ^ 2 := by simpa [d, haSq] using hdNormSq
     nlinarith [norm_nonneg d]
@@ -161,7 +161,8 @@ theorem exists_orthonormal_angleBlock {P Q : E →ₗ[ℂ] E}
       norm_cast
       calc
         a⁻¹ * (μ * (1 - μ)) = a⁻¹ * a ^ 2 := by rw [haSq]
-        _ = a := by field_simp
-    · ring
+        _ = a⁻¹ * (a * a) := by rw [pow_two]
+        _ = a := by rw [inv_mul_cancel_left₀ ha0]
+    · rw [mul_comm]
 
 end LinearMap.IsSymmetricProjection

--- a/TNLean/Analysis/TwoProjectionAngleBlock.lean
+++ b/TNLean/Analysis/TwoProjectionAngleBlock.lean
@@ -32,7 +32,15 @@ def rangeCompression {P Q : E →ₗ[ℂ] E} (hP : P.IsSymmetricProjection) :
     exact ⟨P (Q x), by
       exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem (Q x)⟩
 
-/-- The compression of a symmetric projection is symmetric on `range P`. -/
+/-- The compression of a symmetric projection is symmetric on `range P`.
+
+This is the compression used in the two-projection argument of
+arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`),
+`Papers/1703.09188/paper_v2.tex`, lines 756–764.
+
+**Local fix (projector label):** Source line 762 repeats `P` for the second
+projector, where the surrounding argument requires `Q`; see
+`docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
 theorem rangeCompression_isSymmetric {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     (rangeCompression hP (Q := Q)).IsSymmetric := by

--- a/TNLean/Analysis/TwoProjectionAngleBlock.lean
+++ b/TNLean/Analysis/TwoProjectionAngleBlock.lean
@@ -118,9 +118,10 @@ theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
         rw [angleDefect, inner_sub_left, inner_smul_left]
       _ = μ * (1 - μ) := by rw [hQxDefect, hxDefect]; norm_num
 
-/-- Normalized form of `angleDefect_block`.  The vectors `x,w` are orthonormal,
-`P` is the rank-one projection onto `x`, and `Q` has its standard angle-block
-action with off-diagonal coefficient `sqrt (μ(1-μ))`. -/
+/-- Normalized form of `angleDefect_block`. The vectors `x,w` are orthonormal;
+on their two-dimensional span, `P` acts as the projection onto `x`, while `Q`
+has its standard angle-block action with off-diagonal coefficient
+`sqrt (μ(1-μ))`. -/
 theorem exists_orthonormal_angleBlock {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
     {μ : ℝ} (hμ0 : 0 < μ) (hμ1 : μ < 1) {x : E}

--- a/TNLean/Analysis/TwoProjectionAngleBlock.lean
+++ b/TNLean/Analysis/TwoProjectionAngleBlock.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.IdempotentEndomorphism
 import Mathlib.Analysis.InnerProductSpace.Positive
 
 /-!
@@ -11,6 +12,10 @@ import Mathlib.Analysis.InnerProductSpace.Positive
 This file gives the local two-dimensional block used in the two-projection
 lemma invoked in arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`),
 lines 756–764. It does not assume that the projections commute.
+
+**Local fix:** Source line 762 repeats `P` for the second projector, where the
+surrounding argument requires `Q`. This typographical correction is documented
+in `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
 -/
 
 open scoped InnerProductSpace
@@ -25,8 +30,7 @@ def rangeCompression {P Q : E →ₗ[ℂ] E} (hP : P.IsSymmetricProjection) :
   (P.comp Q).restrict fun x hx ↦ by
     rw [LinearMap.mem_range]
     exact ⟨P (Q x), by
-      simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T (Q x))
-        hP.isIdempotentElem.eq⟩
+      exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem (Q x)⟩
 
 /-- The compression of a symmetric projection is symmetric on `range P`. -/
 theorem rangeCompression_isSymmetric {P Q : E →ₗ[ℂ] E}
@@ -37,28 +41,33 @@ theorem rangeCompression_isSymmetric {P Q : E →ₗ[ℂ] E}
   have hx : P (x : E) = x := by
     obtain ⟨z, hz⟩ := x.property
     rw [← hz]
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T z)
-      hP.isIdempotentElem.eq
+    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
   have hy : P (y : E) = y := by
     obtain ⟨z, hz⟩ := y.property
     rw [← hz]
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T z)
-      hP.isIdempotentElem.eq
+    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
   rw [hP.isSymmetric, hQ.isSymmetric, hy]
   exact ((hP.isSymmetric x (Q y)).symm.trans (by rw [hx])).symm
 
-/-- The unnormalized vector perpendicular to `range P` paired with an eigenvector
-of the compression `P Q P`. -/
+/-- The defect vector \(Qx-μx\).
+
+When `x` satisfies the compression-eigenvector hypotheses of
+`angleDefect_block`, this vector is orthogonal to `x` and lies in the kernel of
+`P`. -/
 def angleDefect (Q : E →ₗ[ℂ] E) (μ : ℝ) (x : E) : E :=
   Q x - (μ : ℂ) • x
 
-/-- One generic two-dimensional angle block associated with an eigenvalue
-\(0 < μ < 1\) of the compression of `Q` to `range P`.
+/-- Exact formulas for the possibly degenerate angle block determined by a unit
+compression eigenvector.
 
-The first vector is a unit compression eigenvector `x`. The second vector is
-\(Qx - μx\); its squared norm is \(μ(1-μ)\), so it is nonzero and can be
-normalized in the subsequent corollary. The displayed identities are the
-exact actions of `P` and `Q` on this block.
+**Local fix:** Source line 762 repeats `P` for the second projector; the
+surrounding argument requires `Q`. See
+`docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+
+The defect vector \(Qx-μx\) lies in the kernel of `P`, is orthogonal to `x`,
+and has squared norm \(μ(1-μ)\). No strict endpoint bound or nonzero claim is
+made here; `exists_orthonormal_angle_block` adds \(0<μ<1\) before normalizing
+the defect.
 -/
 theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
@@ -70,12 +79,7 @@ theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
         ((μ * (1 - μ) : ℝ) : ℂ) • x + ((1 - μ : ℝ) : ℂ) • angleDefect Q μ x ∧
       ⟪x, angleDefect Q μ x⟫_ℂ = 0 ∧
       ‖angleDefect Q μ x‖ ^ 2 = μ * (1 - μ) := by
-  have hPidem : P (P (Q x)) = P (Q x) := by
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T (Q x))
-      hP.isIdempotentElem.eq
-  have hQidem : Q (Q x) = Q x := by
-    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T x)
-      hQ.isIdempotentElem.eq
+  have hQidem : Q (Q x) = Q x := LinearMap.IsIdempotentElem.apply_apply hQ.isIdempotentElem x
   have hxx : ⟪x, x⟫_ℂ = 1 := by
     rw [inner_self_eq_norm_sq_to_K, hxnorm]
     norm_num
@@ -118,11 +122,16 @@ theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
         rw [angleDefect, inner_sub_left, inner_smul_left]
       _ = μ * (1 - μ) := by rw [hQxDefect, hxDefect]; norm_num
 
-/-- Normalized form of `angleDefect_block`. The vectors `x,w` are orthonormal;
-on their two-dimensional span, `P` acts as the projection onto `x`, while `Q`
+/-- Normalized form of `angleDefect_block`.
+
+**Local fix:** The second projector in arXiv:1703.09188, line 762 is `Q`, not
+the repeated `P`; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+
+The vectors `x,w` are orthonormal; on their two-dimensional span, `P` acts as
+the projection onto `x`, while `Q`
 has its standard angle-block action with off-diagonal coefficient
 \(\sqrt{μ(1-μ)}\). -/
-theorem exists_orthonormal_angleBlock {P Q : E →ₗ[ℂ] E}
+theorem exists_orthonormal_angle_block {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
     {μ : ℝ} (hμ0 : 0 < μ) (hμ1 : μ < 1) {x : E}
     (hxP : P x = x) (hxnorm : ‖x‖ = 1) (hxEig : P (Q x) = (μ : ℂ) • x) :

--- a/TNLean/Analysis/TwoProjectionAngleBlock.lean
+++ b/TNLean/Analysis/TwoProjectionAngleBlock.lean
@@ -13,7 +13,7 @@ This file gives the local two-dimensional block used in the two-projection
 lemma invoked in arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`),
 lines 756–764. It does not assume that the projections commute.
 
-**Local fix:** Source line 762 repeats `P` for the second projector, where the
+**Local fix (projector label):** Source line 762 repeats `P` for the second projector, where the
 surrounding argument requires `Q`. This typographical correction is documented
 in `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
 -/
@@ -60,14 +60,15 @@ def angleDefect (Q : E →ₗ[ℂ] E) (μ : ℝ) (x : E) : E :=
 /-- Exact formulas for the possibly degenerate angle block determined by a unit
 compression eigenvector.
 
-**Local fix:** Source line 762 repeats `P` for the second projector; the
+**Local fix (projector label):** Source line 762 repeats `P` for the second projector; the
 surrounding argument requires `Q`. See
 `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
 
-The defect vector \(Qx-μx\) lies in the kernel of `P`, is orthogonal to `x`,
-and has squared norm \(μ(1-μ)\). No strict endpoint bound or nonzero claim is
-made here; `exists_orthonormal_angle_block` adds \(0<μ<1\) before normalizing
-the defect.
+Writing \(d=Qx-μx\), the conclusions include
+\(Pd=0\), \(Qx=μx+d\),
+\(Qd=μ(1-μ)x+(1-μ)d\), \(\langle x,d\rangle=0\), and
+\(\lVert d\rVert^2=μ(1-μ)\). No strict endpoint bound or nonzero claim is made
+here; `exists_orthonormal_angle_block` adds \(0<μ<1\) before normalizing \(d\).
 -/
 theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
@@ -124,7 +125,7 @@ theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
 
 /-- Normalized form of `angleDefect_block`.
 
-**Local fix:** The second projector in arXiv:1703.09188, line 762 is `Q`, not
+**Local fix (projector label):** The second projector in arXiv:1703.09188, line 762 is `Q`, not
 the repeated `P`; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
 
 The vectors `x,w` are orthonormal; on their two-dimensional span, `P` acts as

--- a/TNLean/Analysis/TwoProjectionAngleBlock.lean
+++ b/TNLean/Analysis/TwoProjectionAngleBlock.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.ProjectionGeometry
+
+/-!
+# A generic angle block for two orthogonal projections
+
+This file gives the local two-dimensional block used in the two-projection
+lemma invoked in arXiv:1703.09188, Proposition 1, lines 756–764.  It does not
+assume that the projections commute.
+-/
+
+open scoped InnerProductSpace
+
+namespace LinearMap.IsSymmetricProjection
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+/-- The compression of `Q` to the range of the symmetric projection `P`. -/
+def rangeCompression {P Q : E →ₗ[ℂ] E} (hP : P.IsSymmetricProjection) :
+    P.range →ₗ[ℂ] P.range :=
+  (P.comp Q).restrict fun x hx ↦ by
+    rw [LinearMap.mem_range]
+    exact ⟨P (Q x), by
+      simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T (Q x))
+        hP.isIdempotentElem.eq⟩
+
+/-- The compression of a symmetric projection is symmetric on `range P`. -/
+theorem rangeCompression_isSymmetric {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    (rangeCompression hP (Q := Q)).IsSymmetric := by
+  intro x y
+  change ⟪(P (Q x) : E), (y : E)⟫_ℂ = ⟪(x : E), (P (Q y) : E)⟫_ℂ
+  have hx : P (x : E) = x := by
+    obtain ⟨z, hz⟩ := x.property
+    rw [← hz]
+    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T z)
+      hP.isIdempotentElem.eq
+  have hy : P (y : E) = y := by
+    obtain ⟨z, hz⟩ := y.property
+    rw [← hz]
+    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T z)
+      hP.isIdempotentElem.eq
+  rw [hP.isSymmetric, hQ.isSymmetric, hy]
+  exact ((hP.isSymmetric x (Q y)).symm.trans (by rw [hx])).symm
+
+/-- The unnormalized vector perpendicular to `range P` paired with an eigenvector
+of the compression `P Q P`. -/
+def angleDefect (Q : E →ₗ[ℂ] E) (μ : ℝ) (x : E) : E :=
+  Q x - (μ : ℂ) • x
+
+/-- One generic two-dimensional angle block associated with an eigenvalue
+`0 < μ < 1` of the compression of `Q` to `range P`.
+
+The first vector is a unit compression eigenvector `x`.  The second vector is
+`Q x - μ x`; its squared norm is `μ(1-μ)`, so it is nonzero and can be
+normalized in the subsequent corollary.  The displayed identities are the
+exact actions of `P` and `Q` on this block.
+-/
+theorem angleDefect_block {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    {μ : ℝ} (_hμ0 : 0 < μ) (_hμ1 : μ < 1) {x : E}
+    (hxP : P x = x) (hxnorm : ‖x‖ = 1) (hxEig : P (Q x) = (μ : ℂ) • x) :
+    P (angleDefect Q μ x) = 0 ∧
+      Q x = (μ : ℂ) • x + angleDefect Q μ x ∧
+      Q (angleDefect Q μ x) =
+        ((μ * (1 - μ) : ℝ) : ℂ) • x + ((1 - μ : ℝ) : ℂ) • angleDefect Q μ x ∧
+      ⟪x, angleDefect Q μ x⟫_ℂ = 0 ∧
+      ‖angleDefect Q μ x‖ ^ 2 = μ * (1 - μ) := by
+  have hPidem : P (P (Q x)) = P (Q x) := by
+    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T (Q x))
+      hP.isIdempotentElem.eq
+  have hQidem : Q (Q x) = Q x := by
+    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[ℂ] E ↦ T x)
+      hQ.isIdempotentElem.eq
+  have hxx : ⟪x, x⟫_ℂ = 1 := by
+    rw [inner_self_eq_norm_sq_to_K, hxnorm]
+    norm_num
+  have hxQx : ⟪x, Q x⟫_ℂ = μ := by
+    calc
+      ⟪x, Q x⟫_ℂ = ⟪P x, Q x⟫_ℂ := by rw [hxP]
+      _ = ⟪x, P (Q x)⟫_ℂ := hP.isSymmetric x (Q x)
+      _ = μ := by rw [hxEig, inner_smul_right, hxx, mul_one]
+  have hQxQx : ⟪Q x, Q x⟫_ℂ = μ := by
+    calc
+      ⟪Q x, Q x⟫_ℂ = ⟪x, Q (Q x)⟫_ℂ := hQ.isSymmetric x (Q x)
+      _ = μ := by rw [hQidem, hxQx]
+  constructor
+  · simp only [angleDefect, map_sub, map_smul, hxEig, hxP]
+    norm_num
+  constructor
+  · simp [angleDefect]
+  constructor
+  · simp only [angleDefect, map_sub, map_smul, hQidem]
+    rw [show Q x = (μ : ℂ) • x + angleDefect Q μ x by simp [angleDefect]]
+    module
+  constructor
+  · rw [angleDefect, inner_sub_right, inner_smul_right, hxQx, hxx]
+    norm_num
+  · have hQxx : ⟪Q x, x⟫_ℂ = μ := by
+      rw [← inner_conj_symm, hxQx]
+      exact RCLike.conj_ofReal μ
+    have hxDefect : ⟪x, angleDefect Q μ x⟫_ℂ = 0 := by
+      rw [angleDefect, inner_sub_right, inner_smul_right, hxQx, hxx]
+      norm_num
+    have hQxDefect : ⟪Q x, angleDefect Q μ x⟫_ℂ = μ * (1 - μ) := by
+      rw [angleDefect, inner_sub_right, inner_smul_right, hQxQx, hQxx]
+      ring
+    calc
+      ‖angleDefect Q μ x‖ ^ 2 =
+          RCLike.re (⟪angleDefect Q μ x, angleDefect Q μ x⟫_ℂ) :=
+        @norm_sq_eq_re_inner ℂ E _ _ _ (angleDefect Q μ x)
+      _ = RCLike.re (⟪Q x, angleDefect Q μ x⟫_ℂ -
+          (starRingEnd ℂ) (μ : ℂ) * ⟪x, angleDefect Q μ x⟫_ℂ) := by
+        rw [angleDefect, inner_sub_left, inner_smul_left]
+      _ = μ * (1 - μ) := by rw [hQxDefect, hxDefect]; norm_num
+
+/-- Normalized form of `angleDefect_block`.  The vectors `x,w` are orthonormal,
+`P` is the rank-one projection onto `x`, and `Q` has its standard angle-block
+action with off-diagonal coefficient `sqrt (μ(1-μ))`. -/
+theorem exists_orthonormal_angleBlock {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    {μ : ℝ} (hμ0 : 0 < μ) (hμ1 : μ < 1) {x : E}
+    (hxP : P x = x) (hxnorm : ‖x‖ = 1) (hxEig : P (Q x) = (μ : ℂ) • x) :
+    ∃ w : E,
+      P w = 0 ∧ ‖w‖ = 1 ∧ ⟪x, w⟫_ℂ = 0 ∧
+      Q x = (μ : ℂ) • x + (Real.sqrt (μ * (1 - μ)) : ℂ) • w ∧
+      Q w = (Real.sqrt (μ * (1 - μ)) : ℂ) • x + ((1 - μ : ℝ) : ℂ) • w := by
+  let d := angleDefect Q μ x
+  let a := Real.sqrt (μ * (1 - μ))
+  have hdpos : 0 < μ * (1 - μ) := mul_pos hμ0 (sub_pos.mpr hμ1)
+  have hapos : 0 < a := Real.sqrt_pos.2 hdpos
+  have ha0 : a ≠ 0 := ne_of_gt hapos
+  have haSq : a ^ 2 = μ * (1 - μ) := Real.sq_sqrt hdpos.le
+  obtain ⟨hdP, hxQ, hQd, hxd, hdNormSq⟩ :=
+    angleDefect_block hP hQ hμ0 hμ1 hxP hxnorm hxEig
+  have hdNorm : ‖d‖ = a := by
+    have hda : ‖d‖ ^ 2 = a ^ 2 := by simpa [d, haSq] using hdNormSq
+    nlinarith [norm_nonneg d]
+  refine ⟨((a⁻¹ : ℝ) : ℂ) • d, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [map_smul, hdP, smul_zero]
+  · rw [norm_smul, Complex.norm_real, Real.norm_eq_abs, abs_inv, abs_of_pos hapos,
+      hdNorm]
+    exact inv_mul_cancel₀ ha0
+  · rw [inner_smul_right, hxd, mul_zero]
+  · rw [hxQ]
+    change (μ : ℂ) • x + d = (μ : ℂ) • x + (a : ℂ) • ((a⁻¹ : ℝ) : ℂ) • d
+    rw [smul_smul]
+    simp [ha0]
+  · rw [map_smul, hQd]
+    change ((a⁻¹ : ℝ) : ℂ) •
+        (((μ * (1 - μ) : ℝ) : ℂ) • x + ((1 - μ : ℝ) : ℂ) • d) =
+      (a : ℂ) • x + ((1 - μ : ℝ) : ℂ) • ((a⁻¹ : ℝ) : ℂ) • d
+    rw [smul_add, smul_smul, smul_smul, smul_smul]
+    congr 1
+    · congr 1
+      norm_cast
+      calc
+        a⁻¹ * (μ * (1 - μ)) = a⁻¹ * a ^ 2 := by rw [haSq]
+        _ = a := by field_simp
+    · ring
+
+end LinearMap.IsSymmetricProjection

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4893,9 +4893,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     Qw&=\sqrt{\mu(1-\mu)}\,x+(1-\mu)w.
   \end{align}
   Thus $\operatorname{span}\{x,w\}$ is the generic two-dimensional angle
-  block. The orthogonal direct-sum assembly with the endpoint eigenspaces
-  $\mu=0,1$, and hence the global two-projection lemma used below, remains not
-  ready.
+  block. This lemma concerns one eigenvalue in $(0,1)$; it does not include the
+  endpoint eigenspaces or an orthogonal direct-sum decomposition of the ambient
+  space.
+  % Formalization status: endpoint spaces and global Jordan assembly remain not ready.
   % Source: paper_v2.tex, Proposition IV.5 (prop:continuity-index), lines 756--764.
   % Local correction: line 762 repeats P where Q is intended; see
   % docs/paper-gaps/1703_two_projection_projector_typo.tex.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4873,11 +4873,50 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   % Source lines: paper_v2.tex 733--910 and 1366--1380.
 \end{definition}
 
+\begin{lemma}[Generic two-projection angle block]
+  \label{lem:mpu_two_projection_angle_block}
+  \lean{LinearMap.IsSymmetricProjection.rangeCompression_isSymmetric,
+    LinearMap.IsSymmetricProjection.angleDefect_block,
+    LinearMap.IsSymmetricProjection.exists_orthonormal_angle_block}
+  \leanok
+  \uses{}
+  Let $P$ and $Q$ be orthogonal projections on a complex inner-product space.
+  The compression of $Q$ to $\operatorname{ran}P$ is self-adjoint. If a unit
+  vector $x\in\operatorname{ran}P$ satisfies
+  \begin{align}
+    PQx&=\mu x,&0&<\mu<1,
+  \end{align}
+  then there is a unit vector $w\perp x$ such that
+  \begin{align}
+    Px&=x,&Pw&=0,\\
+    Qx&=\mu x+\sqrt{\mu(1-\mu)}\,w,&
+    Qw&=\sqrt{\mu(1-\mu)}\,x+(1-\mu)w.
+  \end{align}
+  Thus $\operatorname{span}\{x,w\}$ is the generic two-dimensional angle
+  block. The orthogonal direct-sum assembly with the endpoint eigenspaces
+  $\mu=0,1$, and hence the global two-projection lemma used below, remains not
+  ready.
+  % Source: paper_v2.tex, Proposition IV.5 (prop:continuity-index), lines 756--764.
+  % Local correction: line 762 repeats P where Q is intended; see
+  % docs/paper-gaps/1703_two_projection_projector_typo.tex.
+\end{lemma}
+
+\begin{proof}\leanok
+  Set $d=Qx-\mu x$. Symmetry and idempotence give
+  \begin{align}
+    Pd&=0,&\langle x,d\rangle&=0,&
+    \lVert d\rVert^2&=\mu(1-\mu),\\
+    Qd&=\mu(1-\mu)x+(1-\mu)d.
+  \end{align}
+  Since $0<\mu<1$, the vector
+  $w=d/\sqrt{\mu(1-\mu)}$ is well defined and has the stated properties.
+\end{proof}
+
 \begin{proposition}[Constancy of the source ranks]
   \label{prop:continuity-index}
   \notready
   \discussion{6022}
-  \uses{def:mpu_canonical_form,ThmFund1}
+  \uses{def:mpu_canonical_form,ThmFund1,lem:mpu_two_projection_angle_block}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors
   generating MPUs, without requiring the path to be in canonical form. For
   each $x$, take the canonical form and the two source-cut ranks $r(x)$ and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -4873,8 +4873,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   % Source lines: paper_v2.tex 733--910 and 1366--1380.
 \end{definition}
 
-\begin{lemma}[Generic two-projection angle block]
-  \label{lem:mpu_two_projection_angle_block}
+\begin{theorem}[Generic two-projection angle block]
+  \label{thm:mpu_two_projection_angle_block}
   \lean{LinearMap.IsSymmetricProjection.rangeCompression_isSymmetric,
     LinearMap.IsSymmetricProjection.angleDefect_block,
     LinearMap.IsSymmetricProjection.exists_orthonormal_angle_block}
@@ -4900,7 +4900,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   % Source: paper_v2.tex, Proposition IV.5 (prop:continuity-index), lines 756--764.
   % Local correction: line 762 repeats P where Q is intended; see
   % docs/paper-gaps/1703_two_projection_projector_typo.tex.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
   Set $d=Qx-\mu x$. Symmetry and idempotence give
@@ -4917,7 +4917,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{prop:continuity-index}
   \notready
   \discussion{6022}
-  \uses{def:mpu_canonical_form,ThmFund1,lem:mpu_two_projection_angle_block}
+  \uses{def:mpu_canonical_form,ThmFund1,thm:mpu_two_projection_angle_block}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors
   generating MPUs, without requiring the path to be in canonical form. For
   each $x$, take the canonical form and the two source-cut ranks $r(x)$ and

--- a/docs/paper-gaps/1703_two_projection_projector_typo.tex
+++ b/docs/paper-gaps/1703_two_projection_projector_typo.tex
@@ -1,0 +1,46 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Two-Projection Decomposition: Repeated-Projector Typo}
+\author{}
+\date{2026-08-12}
+
+\begin{document}
+\maketitle
+
+\section{Source passage}
+
+In the proof of Proposition~IV.5 of \cite{Cirac2017MPU}, the two-projection
+lemma is used to decompose two projectors on $\mathbb C^D$. The source writes
+\begin{align}
+  P&=\bigoplus_i |0\rangle\langle 0|_i\oplus R,
+  &P&=\bigoplus_i |v_i\rangle\langle v_i|_i\oplus S
+\end{align}
+at lines 760--763 of the local source file. The second projector must be $Q$,
+not $P$. This follows from the preceding sentence, which introduces projectors
+$P$ and $Q$, and from the subsequent identities involving $PQ$ and $QP$.
+
+\section{Formalized interpretation}
+
+The generic angle-block declarations
+\leanid{LinearMap.IsSymmetricProjection.angleDefect_block} and
+\leanid{LinearMap.IsSymmetricProjection.exists_orthonormal_angle_block}
+therefore use symmetric projections $P$ and $Q$. They prove the exact local
+action of both operators on a generic two-dimensional block. This is a local
+correction of a typographical error and does not add a hypothesis or alter the
+mathematical claim.
+
+The global orthogonal direct-sum assembly of all generic and endpoint blocks,
+and the reduced projector used later in Proposition~IV.5, remain to be
+formalized.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/1703_two_projection_projector_typo.tex
+++ b/docs/paper-gaps/1703_two_projection_projector_typo.tex
@@ -36,9 +36,14 @@ action of both operators on a generic two-dimensional block. This is a local
 correction of a typographical error and does not add a hypothesis or alter the
 mathematical claim.
 
-The global orthogonal direct-sum assembly of all generic and endpoint blocks,
-and the reduced projector used later in Proposition~IV.5, remain to be
-formalized.
+\section{Verdict}
+
+\textbf{Verdict: resolved local fix (projector label).} The formalized angle
+block uses $Q$ as the second projector, which resolves the source's repeated
+$P$ label without changing the mathematical statement. The distinct global
+problem of assembling the generic and endpoint blocks into an orthogonal
+direct sum, and constructing the reduced projector used later in
+Proposition~IV.5, remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,18 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### pointwise idempotent endomorphism application — promoted
+- **Pattern:** apply an equality `P * P = P` to a vector with `congrArg`, then
+  simplify `Module.End.mul_apply` to obtain `P (P x) = P x`.
+- **Seen:** nine occurrences across
+  `TNLean/Analysis/ProjectionGeometry.lean` and
+  `TNLean/Analysis/TwoProjectionAngleBlock.lean` before promotion (2026-08-12).
+- **Abstraction:** `LinearMap.IsIdempotentElem.apply_apply` in
+  `TNLean/Analysis/IdempotentEndomorphism.lean`.
+- **Notes:** all motivating call sites now use the generic pointwise lemma. The
+  abstraction assumes only a semiring, an additive commutative monoid, and a
+  module; it does not depend on inner-product or projection symmetry.
+
 ### two-site cyclic local-embedding reindexing — promoted
 - **Pattern:** reindex a cyclic two-site embedding by the equivalence between
   two-site configurations and ordered pairs, prove agreement outside the full


### PR DESCRIPTION
## What changed

- define the compression of `Q` to `range P` for two symmetric projections and prove it symmetric
- construct the generic normalized angle block from a unit compression eigenvector with `0 < μ < 1`
- prove exact `P` and `Q` actions, orthogonality, and normalization formulas
- keep the development generic and noncommuting, with no global block assembly or MPU continuity argument

This is the first focused slice of #6259 and follows `Papers/1703.09188/paper_v2.tex`, lines 756–764.

## Validation

- `lake build TNLean.Analysis.TwoProjectionAngleBlock`
- `lake build TNLean.Analysis`
- `python3 scripts/generate_import_aggregators.py --root . --check`
- proof-integrity scan of the new file: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
- `git diff --check`

Closes #6282
Advances #6259

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Lean analysis lemmas and documentation only; no auth, data, or runtime paths. Remaining MPU continuity assembly is explicitly still open.
> 
> **Overview**
> Adds a **local two-projection angle block** for noncommuting symmetric projections: compression of `Q` to `ran P`, defect-vector identities, and an orthonormal 2D block when `0 < μ < 1` and `PQx = μx` on a unit vector in `ran P` (arXiv:1703.09188, Prop IV.5).
> 
> Introduces **`LinearMap.IsIdempotentElem.apply_apply`** and refactors **`ProjectionGeometry`** (and the new file) to use it instead of repeated inline idempotence proofs.
> 
> **Blueprint** gains theorem `thm:mpu_two_projection_angle_block` (`\leanok`) and **`prop:continuity-index`** now `\uses` it. A **paper-gap note** records the source typo (second projector labeled `P` instead of `Q`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39967b8242dcf2ac57f935f98efb45f6dbd8941c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->