### PR TITLE
docs(MPDO): fix zero-length blocking statements

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -64,9 +64,11 @@ physical indices, as in
     For every integer $L\geq0$, pairing the ket and bra letters site by site
     gives the canonical identification
     \begin{align}
-        \Fin{d^L}\times\Fin{d^L}
-        &\simeq (\Fin d\times\Fin d)^{\Fin L}
-         \simeq \Fin{(d^2)^L}.
+        \operatorname{Fin}(d^L)\times\operatorname{Fin}(d^L)
+        &\simeq
+        \bigl(\operatorname{Fin}(d)\times\operatorname{Fin}(d)\bigr)
+          ^{\operatorname{Fin}(L)}
+         \simeq \operatorname{Fin}((d^2)^L).
     \end{align}
     Under this identification, the doubled-index MPS tensor of $M^{[L]}$
     is the physical reindexing of the $L$-blocked doubled-index MPS tensor
@@ -80,20 +82,24 @@ physical indices, as in
     bijection preserves the span of the tensor matrices.
 \end{proof}
 
-\begin{theorem}[Positive blocking commutes with the MPO product]
-    \label{thm:mpdo_positive_blocking_product}
+\begin{theorem}[Blocking commutes with the MPO product]
+    \label{thm:mpdo_blocking_product}
     \lean{MPOTensor.blockTensor_mulTensor}
     \leanok
     \uses{def:mpdo_physical_blocking, def:mpdo_operator_product}
-    For $L>0$ and two MPO tensors $M,N$ with the same physical dimension,
-    let juxtaposition denote the MPO tensor product obtained by contracting
-    the intermediate physical index. Then $(MN)^{[L]}=M^{[L]}N^{[L]}$.
+    For every integer $L\geq0$ and two MPO tensors $M,N$ with the same
+    physical dimension, let juxtaposition denote the MPO tensor product
+    obtained by contracting the intermediate physical index. Then
+    $(MN)^{[L]}=M^{[L]}N^{[L]}$. For $L=0$, each blocked tensor is the unique
+    empty-word local matrix, namely the identity, so the equality reduces to
+    the product of two identity local tensors.
 \end{theorem}
 
 \begin{proof}\leanok
     Expand the product tensor and sum over its length-$L$ intermediate
     physical word. Reindexing this word by one blocked physical index gives
-    the product of the two blocked tensors.
+    the product of the two blocked tensors. When $L=0$, the intermediate word
+    is empty and all three blocked tensors are identities.
 \end{proof}
 
 \begin{theorem}[Closed MPO chains under physical blocking]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -509,7 +509,7 @@ $G_{\alpha,\beta}^{ij}=\bigoplus_\gamma
     \leanok
     \uses{thm:cpsv_bnt_blocked_simultaneous_span,
         thm:mpdo_blocking_doubled_index,
-        thm:mpdo_positive_blocking_product,
+        thm:mpdo_blocking_product,
         thm:mpdo_bnt_length_independent_zipper}
     Suppose that the labelled doubled-index tensors form the basis of normal
     tensors, and that their fusion-isometry family has positive trace-power


### PR DESCRIPTION
## What changed

- replace the Chapter 21 doubled-index blocking display with finite-ordinal notation that remains meaningful for $d=0$ and $L=0$
- state that MPO blocking commutes with the MPO product for every $L\geq0$, including the empty-word identity case at $L=0$
- rename the dependency label to `thm:mpdo_blocking_product` and update its downstream Chapter 21 reference
- preserve the existing Lean declaration links and theorem scope

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `leanblueprint web`
- `bibtex print`, followed by two `lualatex -interaction=nonstopmode -halt-on-error print.tex` passes with `TEXINPUTS="../../tex/tenkz//:"`
- zero undefined references or citations after the second LuaLaTeX pass
- `git diff --check`
- committed scope contains exactly the two relevant Chapter 21 blueprint files

Closes #6286
Closes #6287

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to two blueprint TeX files; no Lean or runtime code changes.
> 
> **Overview**
> Chapter 21 blueprint text is updated so **MPO physical blocking** statements remain valid at **$L=0$** and when **$d=0$**, without changing Lean links or theorem scope.
> 
> The **doubled-index blocking** display now uses **$\operatorname{Fin}(\cdot)$** notation instead of **$\Fin{\cdot}$**, so the identification is stated in finite-ordinal form that still reads correctly for empty words and degenerate dimensions.
> 
> The theorem **“Blocking commutes with the MPO product”** is renamed from the old “positive blocking” wording: label **`thm:mpdo_blocking_product`**, hypothesis **$L\geq0$** (not only **$L>0$**), and an explicit **$L=0$** case where blocked tensors are identity local matrices. The proof adds the empty intermediate word case. A downstream **fusion isometries** chapter reference is updated to the new label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0536946f168136be6275b3bf711659982ae568db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->