### PR TITLE
test(tenkz): stop printed-example extraction at the next heading and bind each fence once

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -80,9 +80,12 @@ ${#sketch_rows[@]}" >&2
 # count guard above cannot see it because the count is unchanged.  Each row
 # also marks the line of the fence it consumed, and the marks are compared
 # after the loop: the count guard and pairwise-distinct marks together force
-# a bijection between the contract's fences and this table's rows.  A line
-# opening a fence toggles the fence state so a heading-shaped line inside an
-# example neither arms nor stops a scan.
+# a bijection between the contract's fences and this table's rows.  A
+# heading is a hash run followed by a space, so a reference such as #6235
+# at the head of a prose line stops nothing; fences are tracked by their
+# own delimiter — character and length, closing on a run at least as long,
+# as Markdown reads them — so a heading-shaped or backtick line inside any
+# fenced block neither arms nor stops a scan.
 sketch_marks=""
 for sketch_row in "${sketch_rows[@]}"; do
   IFS=: read -r job heading fixture <<SKETCHROW
@@ -90,17 +93,43 @@ $sketch_row
 SKETCHROW
   awk -v heading="$heading" -v mark="$WORK/$job.fenceline" '
     BEGIN { while (substr(heading, level + 1, 1) == "#") level++ }
+    # The run of fence characters opening or closing a fence on this line:
+    # its length, with the character in fc and the trailing text in frest.
+    function fencerun(line,    copy, i) {
+      copy = line
+      sub(/^ {0,3}/, "", copy)
+      fc = substr(copy, 1, 1)
+      if (fc != "`" && fc != "~") return 0
+      i = 0
+      while (substr(copy, i + 1, 1) == fc) i++
+      frest = substr(copy, i + 1)
+      return i
+    }
     {
-      if (!infence && !s && index($0, heading) == 1) { s = 1; next }
-      if (!infence && s && !f && substr($0, 1, 1) == "#") {
+      if (infence) {
+        n = fencerun($0)
+        closed = (n >= flen && fc == fchar)
+        if (closed) { gsub(/[ \t]/, "", frest); closed = (frest == "") }
+        if (f) {
+          if (closed) exit
+          print
+          next
+        }
+        if (closed) infence = 0
+        next
+      }
+      if (!s && index($0, heading) == 1) { s = 1; next }
+      if (s && !f && substr($0, 1, 1) == "#") {
         h = 0
         while (substr($0, h + 1, 1) == "#") h++
-        if (h <= level) exit
+        if (h <= level && substr($0, h + 1, 1) == " ") exit
       }
-      if (s && !f && $0 == "```tex") { f = 1; infence = 1; print NR > mark; next }
-      if (f && $0 == "```") exit
-      if (f) { print; next }
-      if (substr($0, 1, 3) == "```") infence = !infence
+      n = fencerun($0)
+      if (n >= 3) {
+        infence = 1; fchar = fc; flen = n
+        if (s && !f && $0 == "```tex") { f = 1; print NR > mark }
+        next
+      }
     }' "$CONTRACT" | sed -e 's/^\\\[//' -e 's/\\\]$//' >"$WORK/$job.body"
   [ -s "$WORK/$job.body" ] && [ -s "$WORK/$job.fenceline" ] || {
     echo "FAIL: the contract's '$heading' example could not be extracted" >&2
@@ -136,8 +165,8 @@ SKETCHROW
 done
 
 shared_fences="$(printf '%s' "$sketch_marks" | sort -n | awk '
-  $1 == last { print }
-  { last = $1 }')"
+  $1 == last { if (prev != "") { print prev; prev = "" }; print; next }
+  { last = $1; prev = $0 }')"
 [ -z "$shared_fences" ] || {
   echo "FAIL: one printed example answered two rows of the table:" >&2
   echo "$shared_fences" >&2

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -74,19 +74,40 @@ ${#sketch_rows[@]}" >&2
   exit 1
 }
 
+# A row's example is the first fence after its heading and before the next
+# heading of the same or a higher level: without that stop, a row whose own
+# fence left the document silently takes the next section's example, and the
+# count guard above cannot see it because the count is unchanged.  Each row
+# also marks the line of the fence it consumed, and the marks are compared
+# after the loop: the count guard and pairwise-distinct marks together force
+# a bijection between the contract's fences and this table's rows.  A line
+# opening a fence toggles the fence state so a heading-shaped line inside an
+# example neither arms nor stops a scan.
+sketch_marks=""
 for sketch_row in "${sketch_rows[@]}"; do
   IFS=: read -r job heading fixture <<SKETCHROW
 $sketch_row
 SKETCHROW
-  awk -v heading="$heading" '
-    index($0, heading) == 1 { s = 1 }
-    s && $0 == "```tex" { f = 1; next }
-    f && $0 == "```" { exit }
-    f' "$CONTRACT" | sed -e 's/^\\\[//' -e 's/\\\]$//' >"$WORK/$job.body"
-  [ -s "$WORK/$job.body" ] || {
+  awk -v heading="$heading" -v mark="$WORK/$job.fenceline" '
+    BEGIN { while (substr(heading, level + 1, 1) == "#") level++ }
+    {
+      if (!infence && !s && index($0, heading) == 1) { s = 1; next }
+      if (!infence && s && !f && substr($0, 1, 1) == "#") {
+        h = 0
+        while (substr($0, h + 1, 1) == "#") h++
+        if (h <= level) exit
+      }
+      if (s && !f && $0 == "```tex") { f = 1; infence = 1; print NR > mark; next }
+      if (f && $0 == "```") exit
+      if (f) { print; next }
+      if (substr($0, 1, 3) == "```") infence = !infence
+    }' "$CONTRACT" | sed -e 's/^\\\[//' -e 's/\\\]$//' >"$WORK/$job.body"
+  [ -s "$WORK/$job.body" ] && [ -s "$WORK/$job.fenceline" ] || {
     echo "FAIL: the contract's '$heading' example could not be extracted" >&2
     exit 1
   }
+  sketch_marks="$sketch_marks$(cat "$WORK/$job.fenceline") $job
+"
   { printf '%s\n' \
       '\documentclass{standalone}' \
       '\usepackage{tenkz}' \
@@ -113,6 +134,15 @@ SKETCHROW
     exit 1
   fi
 done
+
+shared_fences="$(printf '%s' "$sketch_marks" | sort -n | awk '
+  $1 == last { print }
+  { last = $1 }')"
+[ -z "$shared_fences" ] || {
+  echo "FAIL: one printed example answered two rows of the table:" >&2
+  echo "$shared_fences" >&2
+  exit 1
+}
 
 for tex in "$WORK"/*.tex; do
   compile "$(basename "$tex")"


### PR DESCRIPTION
## Context

Closes LionSR/tenkz#207 (follow-up from LionSR/TNLean#6202's review; the scenario is quoted in the issue). The extraction step of `scripts/tenkz_kernel_probes.sh` armed on a `SKETCHES` row's heading and took the next ```tex fence regardless of intervening headings.

## Defect, watched on main (working agreement 2)

Seeded the review's exact shape against the extraction logic: remove §9's fence from `docs/tenkz/LANGUAGE-1.0.md`, add a ```tex fence after §13. The fence count stays 8 so the count guard passes; the old awk binds the `## 9.` row to **§12.1's example** (verified — it extracts the `\begin{tenkz}[rows={wire,wire},...]` body); the duplicate compiles and audits clean because that row has no fixture comparison; the new fence is never compiled. PASS with a printed example bound to nothing.

## Change

- A row's example is the first fence after its heading and **before the next heading of the same or a higher level** (level read from the row's own `#` prefix; `index(...) == 1` semantics unchanged).
- Lines inside fences neither arm nor stop a scan, so a `#` inside an example is not a heading.
- Each row writes the line number of the fence it consumed; after the loop, pairwise-distinct marks are enforced. With the existing count guard this forces a **bijection** between the contract's fences and the table's rows — the issue's stated target.
- Extraction failure keeps the existing `could not be extracted` message.

## Watched failures (hardened gate)

- Remove-§9-fence + add-after-§13 seed → `FAIL: the contract's '## 9.' example could not be extracted` (count unchanged, so only the new stop catches it).
- Duplicate-consumption seed (a second row bound to `### 12.1`, count balanced with an extra fence) → `FAIL: one printed example answered two rows of the table` naming fence line 1172.
- Clean contract: all 8 rows extract at 8 distinct fence lines, and the full gate (`bash scripts/tenkz_kernel_probes.sh`) passes end to end, golden streams untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UP8U2EDj6USwT4n8xnoYq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the kernel probe gate script’s Markdown parsing; no runtime kernel, auth, or data paths.
> 
> **Overview**
> Hardens **`scripts/tenkz_kernel_probes.sh`** so each `SKETCHES` row pulls the correct ` ```tex ` block from `LANGUAGE-1.0.md`, not merely the next fence in the file.
> 
> **Scoped extraction:** After a row’s heading matches, scanning stops at the next Markdown heading at the **same or higher** level (derived from the row’s `#` prefix). That blocks a missing §9 fence from silently binding §12.1’s example while the fence **count** still matches.
> 
> **Fence-aware awk:** A `fencerun` helper tracks fenced regions (backtick/tilde, length, close rules) so `#` or fence-like lines **inside** a block do not arm or end the search; headings require `#` + space so prose like `#6235` does not act as a stop.
> 
> **Bijection check:** Each row writes the consumed fence’s line number; after the loop, duplicate line numbers fail with `one printed example answered two rows`. Together with the existing count guard, contract fences and table rows are **one-to-one**. Extraction still fails with `could not be extracted` when body or fenceline is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef5c227807f0889aa06061837d23f1c729ba9d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->