### PR TITLE
docs(tactics): record cyclic step offset candidate

### DIFF
--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1378,17 +1378,19 @@ spectral split → block extraction → MPV calculation → strict bounds
 - **Pattern:** for `i : Fin N` and a step `r`, identify the offset of `i` from
   its `r`-step cyclic forward successor:
   ```lean
-  (i.val + N - (cyclicForwardSite i r).val) % N = (N - r % N) % N
+  (i.val + N - (MPSTensor.cyclicForwardSite i r).val) % N = (N - (r % N)) % N
   ```
-- **Seen:** the `r = 1` case occurs in `cyclicRestrictₗ_restrictFirst`,
-  `replaceWindow_three_replaceWindow_two_right`, and `offset_from_finRotate`.
+- **Seen:** zero current call sites require `r > 1`; this candidate records a
+  source- and blueprint-motivated generalization, not repeated unabstracted code.
 - **Abstraction (proposed):** a `cyclicForwardSite_step_offset` lemma generalizing
-  `MPSTensor.cyclicForwardSite_one_offset`. This remains below the promotion
-  threshold because no current call site requires `r > 1`.
-- **Notes:** under the offset convention in blueprint remark
-  `rem:cyclic_window_operators`, this is the offset of the old starting site
-  from the new start of an `r`-step-shifted cyclic window:
-  $\delta_{\operatorname{cyclicForwardSite}(i,r)}(i)
+  `MPSTensor.cyclicForwardSite_one_offset`, explicitly below the promotion threshold.
+- **Notes:** the completed one-step lemma is the precedent already reused by
+  `cyclicRestrictₗ_restrictFirst`, `replaceWindow_three_replaceWindow_two_right`,
+  and `offset_from_finRotate`; these sites do not count toward this candidate's
+  promotion. Under the offset convention in blueprint remark
+  `rem:cyclic_window_operators`, the proposed identity is the offset of the old
+  starting site from the new start of an `r`-step-shifted cyclic window:
+  $\delta_{\mathrm{cyclicForwardSite}\,i\,r}(i)
   = (N - (r \bmod N)) \bmod N$.
 
 ---

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1374,6 +1374,23 @@ spectral split → block extraction → MPV calculation → strict bounds
   threshold; the surrounding conclusions and final generalized-inverse
   calculation differ.
 
+### general cyclic-forward step offset — candidate
+- **Pattern:** for `i : Fin N` and a step `r`, identify the offset of `i` from
+  its `r`-step cyclic forward successor:
+  ```lean
+  (i.val + N - (cyclicForwardSite i r).val) % N = (N - r % N) % N
+  ```
+- **Seen:** the `r = 1` case occurs in `cyclicRestrictₗ_restrictFirst`,
+  `replaceWindow_three_replaceWindow_two_right`, and `offset_from_finRotate`.
+- **Abstraction (proposed):** a `cyclicForwardSite_step_offset` lemma generalizing
+  `MPSTensor.cyclicForwardSite_one_offset`. This remains below the promotion
+  threshold because no current call site requires `r > 1`.
+- **Notes:** under the offset convention in blueprint remark
+  `rem:cyclic_window_operators`, this is the offset of the old starting site
+  from the new start of an `r`-step-shifted cyclic window:
+  $\delta_{\operatorname{cyclicForwardSite}(i,r)}(i)
+  = (N - (r \bmod N)) \bmod N$.
+
 ---
 
 ## Rejected


### PR DESCRIPTION
## Summary

- record the general step-`r` `cyclicForwardSite` offset identity as a tactic-ledger candidate
- list the three existing one-step occurrences and the proposed general lemma
- preserve the cyclic-window offset convention from blueprint remark `rem:cyclic_window_operators`

## Validation

- `git diff --check`
- changed-line Markdown length check (all added lines at most 100 characters)
- documentation-only scope check (only `docs/tactic_patterns.md` changed)

No Lean declarations or proofs are changed.

Closes #6275

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the tactic ledger markdown is updated; no runtime or proof behavior changes.
> 
> **Overview**
> **Documentation-only:** extends `docs/tactic_patterns.md` with a new **Candidates** entry for the general cyclic-forward step offset pattern.
> 
> The entry records the proposed identity `(i.val + N - (MPSTensor.cyclicForwardSite i r).val) % N = (N - (r % N)) % N`, names a future `cyclicForwardSite_step_offset` lemma as a generalization of `cyclicForwardSite_one_offset`, and states explicitly that there are **no** current call sites needing `r > 1` and that the three existing one-step uses do **not** count toward promotion. It ties the formula to blueprint remark `rem:cyclic_window_operators` for cyclic-window offset convention.
> 
> No Lean declarations or proofs are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e7e49d33a821ed2341796aceacb6ec97709b0df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->