### PR TITLE
scratch: #6217 corpus path-filter demonstration (do not merge)

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -1171,7 +1171,7 @@ twenty-six there rather than here, so the one arrival is counted once.
 
 ```tex
 \[\begin{tenkz}[rows={wire,wire}, cols=4, bonds=none]
-  \tnwire[kind=string, species=left,  name=a]{(1,1)}{(2,3)}
+  \tnwire[kind=string, species=left,  name=z]{(1,1)}{(2,3)}
   \tnwire[kind=string, species=right, name=b,
           cross={under at crossing of a and b}]{(1,4)}{(2,2)}
   \tnmark[form=label, label pos=45]{crossing of a and b}{$R$}


### PR DESCRIPTION
Seeded demonstration for LionSR/tenkz#199, per the issue's verification note: this branch edits ONLY docs/tenkz/LANGUAGE-1.0.md (one drifted character in the §9 sketch). Expected: the tenkz-corpus job now RUNS (before LionSR/TNLean#6273 it was skipped for contract-only edits) and its kernel-probe step FAILS on the drift. Closed unmerged once the run links are recorded on LionSR/tenkz#199.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only, non-merge demo; no runtime or package code changes, only a deliberate inconsistency in an example sketch.
> 
> **Overview**
> **Demonstration-only change** for LionSR/tenkz#199 (do not merge): the §12.1 braid TeX block in `LANGUAGE-1.0.md` renames the left string wire from `name=a` to `name=z` while the right wire and the mark still reference `crossing of a and b`.
> 
> That single identifier mismatch is meant to exercise the **tenkz-corpus** job after path-filter fixes—contract-only edits used to skip the job; this doc-only edit should run it and the **kernel-probe** step should fail on the drifted name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379bf6670cf99713c12c2626e302e2ef54dd74f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->