### PR TITLE
feat(Channel): rectangular Stinespring representation for every ancilla dimension

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -97,6 +97,7 @@ import TNLean.Channel.SingleKrausPositivity
 import TNLean.Channel.Spectral
 import TNLean.Channel.StarSubalgebraConditionalExpectation
 import TNLean.Channel.Stinespring
+import TNLean.Channel.StinespringRectangular
 import TNLean.Channel.SupportCompletion
 import TNLean.Channel.SupportedMarginalChannel
 import TNLean.Channel.TensorMap

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -96,20 +96,20 @@ theorem stinespringV_isometry_iff_kraus_normalized {r : ℕ}
 
 /-! ### Stinespring representation of the dual and Schrödinger maps -/
 
-/-- **Stinespring representation, Heisenberg picture** (Wolf Theorem 2.2, Eq. (2.11)):
+/-- **Stinespring representation, Heisenberg picture** (Wolf Theorem 2.2,
+Eq. (2.11)): \(T^*(A) = V^\dagger (A \otimes \mathbb 1_r) V\), where \(V\) is
+the Stinespring isometry. This matches the Kraus form
+\(T^*(A) = \sum_j K_j^\dagger A K_j\). In this file, \(T^*\) is the Heisenberg
+dual acting on observables, while the Schrödinger map uses adjoints in the
+opposite order.
 
-  `T*(A) = V† (A ⊗ 𝟙_r) V`
-
-where `V` is the Stinespring isometry. This matches the Kraus form
-`T*(A) = ∑ⱼ Kⱼ† A Kⱼ`.
-In this file, `T*` is the Heisenberg dual acting on observables, while the
-Schrödinger map uses adjoints in the opposite order.
-
-The two index types are unrelated: for Kraus operators `Kⱼ : Matrix β α ℂ` the
-observable `A` lives on the output space `ℂ^β` and the displayed identity lives
-on the input space `ℂ^α`. This is Wolf's rectangular shape `T : M_d → M_{d'}`,
-with input space `ℂ^α = ℂ^d` and output space `ℂ^β = ℂ^{d'}`; the square case
-is `α = β`. -/
+The two index types are unrelated: for Kraus operators \(K_j\) of matrix type
+`Matrix β α ℂ`, the observable \(A\) lives on the output space
+\(\mathbb C^{\beta}\) and the displayed identity lives on the input space
+\(\mathbb C^{\alpha}\). The symbols \(\alpha\) and \(\beta\) are index types:
+in Wolf's rectangular shape \(T : M_d \to M_{d'}\) one takes
+\(\alpha = \mathrm{Fin}\ d\) and \(\beta = \mathrm{Fin}\ d'\), and the square
+case is \(\alpha = \beta\). -/
 theorem stinespring_dual_representation {r : ℕ} {α β : Type*} [Fintype β]
     (K : Fin r → Matrix β α ℂ) (A : Matrix β β ℂ) :
     (stinespringV K)ᴴ *
@@ -214,12 +214,12 @@ theorem stinespring_schrodinger_representation {r : ℕ}
 
 /-! ### `π` as a concrete `*`-representation and existential Stinespring statements -/
 
-/-- The concrete representation `π(A) = A ⊗ 𝟙_r` used in the finite-dimensional
-Stinespring construction.
+/-- The concrete representation \(\pi(A) = A \otimes \mathbb 1_r\) used in the
+finite-dimensional Stinespring construction.
 
-The observable index type is arbitrary, so that `π` also covers Wolf's
-rectangular setting, where `A` ranges over the output algebra `M_{d'}` while the
-Stinespring matrix has input space `ℂ^d`. -/
+The observable index type is arbitrary, so that \(\pi\) also covers Wolf's
+rectangular setting, where \(A\) ranges over the output algebra \(M_{d'}\)
+while the Stinespring matrix has input space \(\mathbb C^d\). -/
 noncomputable def stinespringPi {r : ℕ} {β : Type*}
     (A : Matrix β β ℂ) :
     Matrix (β × Fin r) (β × Fin r) ℂ :=

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -103,9 +103,14 @@ theorem stinespringV_isometry_iff_kraus_normalized {r : ℕ}
 where `V` is the Stinespring isometry. This matches the Kraus form
 `T*(A) = ∑ⱼ Kⱼ† A Kⱼ`.
 In this file, `T*` is the Heisenberg dual acting on observables, while the
-Schrödinger map uses adjoints in the opposite order. -/
-theorem stinespring_dual_representation {r : ℕ}
-    (K : Fin r → Matrix (Fin D) (Fin D) ℂ) (A : Matrix (Fin D) (Fin D) ℂ) :
+Schrödinger map uses adjoints in the opposite order.
+
+The two index types are unrelated: for Kraus operators `Kⱼ : Matrix β α ℂ` the
+observable `A` lives on the output space `β` and the displayed identity lives on
+the input space `α`. This is Wolf's rectangular shape `T : M_d → M_{d'}`, with
+`α = ℂ^d` and `β = ℂ^{d'}`; the square case is `α = β`. -/
+theorem stinespring_dual_representation {r : ℕ} {α β : Type*} [Fintype β]
+    (K : Fin r → Matrix β α ℂ) (A : Matrix β β ℂ) :
     (stinespringV K)ᴴ *
       -- This is `stinespringPi A` (defined below); kept inline to avoid forward reference.
       (kroneckerMap (· * ·) A (1 : Matrix (Fin r) (Fin r) ℂ)) *
@@ -209,26 +214,30 @@ theorem stinespring_schrodinger_representation {r : ℕ}
 /-! ### `π` as a concrete `*`-representation and existential Stinespring statements -/
 
 /-- The concrete representation `π(A) = A ⊗ 𝟙_r` used in the finite-dimensional
-Stinespring construction. -/
-noncomputable def stinespringPi {r : ℕ}
-    (A : Matrix (Fin D) (Fin D) ℂ) :
-    Matrix (Fin D × Fin r) (Fin D × Fin r) ℂ :=
+Stinespring construction.
+
+The observable index type is arbitrary, so that `π` also covers Wolf's
+rectangular setting, where `A` ranges over the output algebra `M_{d'}` while the
+Stinespring matrix has input space `ℂ^d`. -/
+noncomputable def stinespringPi {r : ℕ} {β : Type*}
+    (A : Matrix β β ℂ) :
+    Matrix (β × Fin r) (β × Fin r) ℂ :=
   kroneckerMap (· * ·) A (1 : Matrix (Fin r) (Fin r) ℂ)
 
 @[simp]
-theorem stinespringPi_apply {r : ℕ}
-    (A : Matrix (Fin D) (Fin D) ℂ) (i j : Fin D) (a b : Fin r) :
+theorem stinespringPi_apply {r : ℕ} {β : Type*}
+    (A : Matrix β β ℂ) (i j : β) (a b : Fin r) :
     stinespringPi (r := r) A (i, a) (j, b) = A i j * (1 : Matrix (Fin r) (Fin r) ℂ) a b := rfl
 
 @[simp]
-theorem stinespringPi_one {r : ℕ} :
-    stinespringPi (D := D) (r := r) (1 : Matrix (Fin D) (Fin D) ℂ) = 1 := by
+theorem stinespringPi_one {r : ℕ} {β : Type*} [DecidableEq β] :
+    stinespringPi (r := r) (1 : Matrix β β ℂ) = 1 := by
   unfold stinespringPi
-  exact Matrix.one_kronecker_one (m := Fin D) (n := Fin r) (α := ℂ)
+  exact Matrix.one_kronecker_one (m := β) (n := Fin r) (α := ℂ)
 
 @[simp]
-theorem stinespringPi_mul {r : ℕ}
-    (A B : Matrix (Fin D) (Fin D) ℂ) :
+theorem stinespringPi_mul {r : ℕ} {β : Type*} [Fintype β]
+    (A B : Matrix β β ℂ) :
     stinespringPi (r := r) (A * B) = stinespringPi (r := r) A * stinespringPi (r := r) B := by
   unfold stinespringPi
   convert Matrix.mul_kronecker_mul (A := A) (B := B)
@@ -236,8 +245,8 @@ theorem stinespringPi_mul {r : ℕ}
   simp
 
 @[simp]
-theorem stinespringPi_conjTranspose {r : ℕ}
-    (A : Matrix (Fin D) (Fin D) ℂ) :
+theorem stinespringPi_conjTranspose {r : ℕ} {β : Type*}
+    (A : Matrix β β ℂ) :
     (stinespringPi (r := r) A)ᴴ = stinespringPi (r := r) Aᴴ := by
   unfold stinespringPi
   convert Matrix.conjTranspose_kronecker (x := A) (y := (1 : Matrix (Fin r) (Fin r) ℂ)) using 1

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -106,9 +106,10 @@ In this file, `T*` is the Heisenberg dual acting on observables, while the
 Schrödinger map uses adjoints in the opposite order.
 
 The two index types are unrelated: for Kraus operators `Kⱼ : Matrix β α ℂ` the
-observable `A` lives on the output space `β` and the displayed identity lives on
-the input space `α`. This is Wolf's rectangular shape `T : M_d → M_{d'}`, with
-`α = ℂ^d` and `β = ℂ^{d'}`; the square case is `α = β`. -/
+observable `A` lives on the output space `ℂ^β` and the displayed identity lives
+on the input space `ℂ^α`. This is Wolf's rectangular shape `T : M_d → M_{d'}`,
+with input space `ℂ^α = ℂ^d` and output space `ℂ^β = ℂ^{d'}`; the square case
+is `α = β`. -/
 theorem stinespring_dual_representation {r : ℕ} {α β : Type*} [Fintype β]
     (K : Fin r → Matrix β α ℂ) (A : Matrix β β ℂ) :
     (stinespringV K)ᴴ *

--- a/TNLean/Channel/StinespringRectangular.lean
+++ b/TNLean/Channel/StinespringRectangular.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KrausRectangular
+import TNLean.Channel.Stinespring
+
+/-!
+# Stinespring representation for rectangular completely positive maps
+
+This file proves the Stinespring representation theorem in the shape stated in
+Wolf, *Quantum Channels & Operations*, Chapter 2,
+`Notes/WolfNoteTexSource/ch02_representations.tex`, line 322:
+
+> Let `T : M_d → M_{d'}` be a completely positive linear map. Then for every
+> `r ≥ rank(τ)` there is a `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` such that
+> `T*(A) = V†(A ⊗ 𝟙_r)V` for all `A ∈ M_{d'}`.
+> `V` is an isometry (that is, `V†V = 𝟙_d`) if and only if `T` is trace
+> preserving.
+
+Here `τ` is the Choi matrix of `T` and `T*` is the dual map, characterized by
+the trace pairing `tr[T*(A)X] = tr[A T(X)]` (Wolf, Equation (2.3)).
+
+## Main results
+
+* `ChoiRectangular.exists_stinespringV_of_isKrausCP` — Wolf's theorem: for every
+  ancilla dimension `r` at least the Choi rank there is a single `V` realizing
+  the Heisenberg identity `T*(A) = V†(A ⊗ 𝟙_r)V`, and this `V` is an isometry
+  exactly when `T` is trace preserving.
+* `ChoiRectangular.exists_stinespringV_traceAdjointMap_of_isKrausCP` — the same
+  statement with `T*` the trace-pairing adjoint `Matrix.traceAdjointMap T`, so
+  that nothing at all is assumed about `T*`.
+* `ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP` — the minimal
+  dilation `r = rank(τ)`.
+
+## Design notes
+
+The dual map `T*` enters the statement as a linear map satisfying the trace
+pairing that defines it; the pairing determines `T*` uniquely, so this is
+Wolf's `T*` and not an additional assumption on `T`.
+
+The dilation matrix is `V = Σⱼ Kⱼ ⊗ |j⟩` built by `stinespringV` from a Kraus
+family of `T` with exactly `r` operators, obtained by zero-padding a minimal
+family of `rank(τ)` operators. The square existential statements
+`exists_stinespring_dilation` and `exists_stinespring_isometry_of_cptp` in
+`TNLean/Channel/Stinespring.lean` remain as separate, weaker packagings: they
+expose the Kraus family and leave the ancilla dimension existentially
+quantified.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2,
+  Theorem 2.2][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix Finset BigOperators
+
+namespace ChoiRectangular
+
+variable {d d' : ℕ}
+
+/-- **Stinespring representation** (Wolf, Chapter 2, Theorem 2.2,
+Equation (2.11); `Notes/WolfNoteTexSource/ch02_representations.tex`, line 322).
+
+Let `T : M_d → M_{d'}` be completely positive with dual `T*`, characterized by
+the trace pairing `tr[T*(A)X] = tr[A T(X)]`. Then for **every** ancilla
+dimension `r ≥ rank(τ)`, where `τ` is the Choi matrix of `T`, there is a
+`V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` with
+
+  `T*(A) = V†(A ⊗ 𝟙_r)V` for all `A ∈ M_{d'}`,
+
+and `V` is an isometry, `V†V = 𝟙_d`, if and only if `T` is trace preserving.
+
+The dilation matrix is `V = Σⱼ Kⱼ ⊗ |j⟩` for a Kraus family `{Kⱼ}` of `T` with
+exactly `r` operators, and `π(A) = A ⊗ 𝟙_r` is `stinespringPi`. -/
+theorem exists_stinespringV_of_isKrausCP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    {Tstar : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    (hT : IsKrausCP T)
+    (hTstar : ∀ (A : Matrix (Fin d') (Fin d') ℂ) (X : Matrix (Fin d) (Fin d) ℂ),
+      (Tstar A * X).trace = (A * T X).trace)
+    {r : ℕ} (hr : Channel.choiRank T ≤ r) :
+    ∃ V : Matrix (Fin d' × Fin r) (Fin d) ℂ,
+      (∀ A : Matrix (Fin d') (Fin d') ℂ, Tstar A = Vᴴ * stinespringPi (r := r) A * V) ∧
+      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) := by
+  -- A minimal Kraus family has `rank(τ)` operators; zero-pad it to `r` operators.
+  obtain ⟨K, hK⟩ := Channel.hasKrausCard_mono (Channel.hasKrausCard_choiRank_of_cp hT) hr
+  refine ⟨stinespringV K, fun A => ?_, ?_⟩
+  · -- The trace pairing identifies `T*(A)` with the Kraus form `Σⱼ Kⱼ†AKⱼ`.
+    have hdual : Tstar A = ∑ j : Fin r, (K j)ᴴ * A * K j := by
+      refine Matrix.ext_iff_trace_mul_right.2 fun X => ?_
+      rw [hTstar A X, hK X, Finset.mul_sum, Finset.sum_mul, Matrix.trace_sum,
+        Matrix.trace_sum]
+      refine Finset.sum_congr rfl fun j _ => ?_
+      calc (A * (K j * X * (K j)ᴴ)).trace
+          = (A * K j * X * (K j)ᴴ).trace := by simp [Matrix.mul_assoc]
+        _ = ((K j)ᴴ * (A * K j * X)).trace := Matrix.trace_mul_comm _ _
+        _ = ((K j)ᴴ * A * K j * X).trace := by simp [Matrix.mul_assoc]
+    rw [hdual, ← stinespring_dual_representation K A]
+    rfl
+  · -- `V†V = Σⱼ Kⱼ†Kⱼ`, which is `𝟙` exactly for trace-preserving `T`.
+    rw [stinespringV_conjTranspose_mul]
+    exact (kraus_tp_iff_sum_conjTranspose_mul K T hK).symm
+
+/-- **Stinespring representation for the trace-pairing adjoint** (Wolf,
+Chapter 2, Theorem 2.2; `Notes/WolfNoteTexSource/ch02_representations.tex`,
+line 322).
+
+The dual map is `Matrix.traceAdjointMap T`, the unique map satisfying the
+trace pairing `tr[T*(A)X] = tr[A T(X)]`, so this form of the theorem carries
+no hypothesis beyond complete positivity of `T` and `r ≥ rank(τ)`. -/
+theorem exists_stinespringV_traceAdjointMap_of_isKrausCP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCP T) {r : ℕ} (hr : Channel.choiRank T ≤ r) :
+    ∃ V : Matrix (Fin d' × Fin r) (Fin d) ℂ,
+      (∀ A : Matrix (Fin d') (Fin d') ℂ,
+        Matrix.traceAdjointMap T A = Vᴴ * stinespringPi (r := r) A * V) ∧
+      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
+  exists_stinespringV_of_isKrausCP hT (Matrix.trace_traceAdjointMap_mul T) hr
+
+/-- **Minimal Stinespring dilation** (Wolf, Chapter 2, Theorem 2.2): the
+smallest admissible ancilla dimension is the Choi rank `r = rank(τ)`, and the
+dilation there is called minimal. -/
+theorem exists_stinespringV_choiRank_of_isKrausCP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    {Tstar : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
+    (hT : IsKrausCP T)
+    (hTstar : ∀ (A : Matrix (Fin d') (Fin d') ℂ) (X : Matrix (Fin d) (Fin d) ℂ),
+      (Tstar A * X).trace = (A * T X).trace) :
+    ∃ V : Matrix (Fin d' × Fin (Channel.choiRank T)) (Fin d) ℂ,
+      (∀ A : Matrix (Fin d') (Fin d') ℂ,
+        Tstar A = Vᴴ * stinespringPi (r := Channel.choiRank T) A * V) ∧
+      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
+  exists_stinespringV_of_isKrausCP hT hTstar le_rfl
+
+end ChoiRectangular

--- a/TNLean/Channel/StinespringRectangular.lean
+++ b/TNLean/Channel/StinespringRectangular.lean
@@ -31,8 +31,9 @@ the trace pairing `tr[T*(A)X] = tr[A T(X)]` (Wolf, Equation (2.3)).
 * `ChoiRectangular.exists_stinespringV_traceAdjointMap_of_isKrausCP` — the same
   statement with `T*` the trace-pairing adjoint `Matrix.traceAdjointMap T`, so
   that nothing at all is assumed about `T*`.
-* `ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP` — the minimal
-  dilation `r = rank(τ)`.
+* `ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP` and
+  `ChoiRectangular.exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP` —
+  the dilation at the Choi-rank ancilla dimension `r = rank(τ)`.
 
 ## Design notes
 
@@ -42,11 +43,11 @@ Wolf's `T*` and not an additional assumption on `T`.
 
 The dilation matrix is `V = Σⱼ Kⱼ ⊗ |j⟩` built by `stinespringV` from a Kraus
 family of `T` with exactly `r` operators, obtained by zero-padding a minimal
-family of `rank(τ)` operators. The square existential statements
+family of `rank(τ)` operators. The square statements
 `exists_stinespring_dilation` and `exists_stinespring_isometry_of_cptp` in
-`TNLean/Channel/Stinespring.lean` remain as separate, weaker packagings: they
-expose the Kraus family and leave the ancilla dimension existentially
-quantified.
+`TNLean/Channel/Stinespring.lean` remain separate and are weaker: their ancilla
+dimension is existentially quantified, whereas the theorems here hold for an
+arbitrary `r` at least the Choi rank.
 
 ## References
 
@@ -120,9 +121,14 @@ theorem exists_stinespringV_traceAdjointMap_of_isKrausCP
       (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
   exists_stinespringV_of_isKrausCP hT (Matrix.trace_traceAdjointMap_mul T) hr
 
-/-- **Minimal Stinespring dilation** (Wolf, Chapter 2, Theorem 2.2): the
-smallest admissible ancilla dimension is the Choi rank `r = rank(τ)`, and the
-dilation there is called minimal. -/
+/-- **Stinespring dilation at the Choi-rank ancilla dimension** (Wolf,
+Chapter 2, Theorem 2.2): the case `r = rank(τ)` of
+`exists_stinespringV_of_isKrausCP`. A dilation with this ancilla dimension is
+called minimal.
+
+That no ancilla dimension below `rank(τ)` admits a dilation is not asserted
+here: it would need a Kraus family of `r` operators extracted from an arbitrary
+`V`, and Wolf's Theorem 2.2 states only the existence for `r ≥ rank(τ)`. -/
 theorem exists_stinespringV_choiRank_of_isKrausCP
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
     {Tstar : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
@@ -134,5 +140,18 @@ theorem exists_stinespringV_choiRank_of_isKrausCP
         Tstar A = Vᴴ * stinespringPi (r := Channel.choiRank T) A * V) ∧
       (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
   exists_stinespringV_of_isKrausCP hT hTstar le_rfl
+
+/-- **Stinespring dilation at the Choi-rank ancilla dimension, trace-pairing
+adjoint form** (Wolf, Chapter 2, Theorem 2.2): the case `r = rank(τ)` of
+`exists_stinespringV_traceAdjointMap_of_isKrausCP`, so that complete positivity
+of `T` is the only hypothesis. -/
+theorem exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCP T) :
+    ∃ V : Matrix (Fin d' × Fin (Channel.choiRank T)) (Fin d) ℂ,
+      (∀ A : Matrix (Fin d') (Fin d') ℂ,
+        Matrix.traceAdjointMap T A = Vᴴ * stinespringPi (r := Channel.choiRank T) A * V) ∧
+      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
+  exists_stinespringV_traceAdjointMap_of_isKrausCP hT le_rfl
 
 end ChoiRectangular

--- a/TNLean/Channel/StinespringRectangular.lean
+++ b/TNLean/Channel/StinespringRectangular.lean
@@ -13,41 +13,55 @@ This file proves the Stinespring representation theorem in the shape stated in
 Wolf, *Quantum Channels & Operations*, Chapter 2,
 `Notes/WolfNoteTexSource/ch02_representations.tex`, line 322:
 
-> Let `T : M_d → M_{d'}` be a completely positive linear map. Then for every
-> `r ≥ rank(τ)` there is a `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` such that
-> `T*(A) = V†(A ⊗ 𝟙_r)V` for all `A ∈ M_{d'}`.
-> `V` is an isometry (that is, `V†V = 𝟙_d`) if and only if `T` is trace
-> preserving.
+> Let \(T : M_d \to M_{d'}\) be a completely positive linear map. Then for every
+> \(r \ge \operatorname{rank}(\tau)\) there is a
+> \(V : \mathbb C^d \to \mathbb C^{d'} \otimes \mathbb C^r\) such that
+> \(T^*(A) = V^\dagger (A \otimes \mathbb 1_r) V\) for all \(A \in M_{d'}\).
+> \(V\) is an isometry (that is, \(V^\dagger V = \mathbb 1_d\)) if and only if
+> \(T\) is trace preserving.
 
-Here `τ` is the Choi matrix of `T` and `T*` is the dual map, characterized by
-the trace pairing `tr[T*(A)X] = tr[A T(X)]` (Wolf, Equation (2.3)).
+Here \(\tau\) is the Choi matrix of \(T\), and the dual \(T^*\) is the
+trace-pairing adjoint `Matrix.traceAdjointMap T`, characterized by the identity
+\(\operatorname{tr}[T^*(A)X] = \operatorname{tr}[A\,T(X)]\) (Wolf, Equation
+(2.3)); that identity is `Matrix.trace_traceAdjointMap_mul`, so the theorems
+below carry no hypothesis on the dual beyond complete positivity of \(T\) and
+the lower bound on the ancilla dimension.
 
 ## Main results
 
 * `ChoiRectangular.exists_stinespringV_of_isKrausCP` — Wolf's theorem: for every
-  ancilla dimension `r` at least the Choi rank there is a single `V` realizing
-  the Heisenberg identity `T*(A) = V†(A ⊗ 𝟙_r)V`, and this `V` is an isometry
-  exactly when `T` is trace preserving.
-* `ChoiRectangular.exists_stinespringV_traceAdjointMap_of_isKrausCP` — the same
-  statement with `T*` the trace-pairing adjoint `Matrix.traceAdjointMap T`, so
-  that nothing at all is assumed about `T*`.
-* `ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP` and
-  `ChoiRectangular.exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP` —
-  the dilation at the Choi-rank ancilla dimension `r = rank(τ)`.
+  ancilla dimension \(r\) at least the Choi rank there is a single \(V\)
+  realizing the Heisenberg identity \(T^*(A) = V^\dagger(A \otimes \mathbb 1_r)V\)
+  for every observable \(A\), and this \(V\) is an isometry exactly when \(T\)
+  is trace preserving.
+* `ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP` — the case
+  \(r = \operatorname{rank}(\tau)\) of the same statement.
+* `ChoiRectangular.exists_stinespringV_pairing_of_isKrausCP` and
+  `ChoiRectangular.exists_stinespringV_pairing_choiRank_of_isKrausCP` — the
+  same two statements for a dual map supplied through the trace pairing that
+  characterizes it.
+* `ChoiRectangular.choiRank_le_of_stinespring_dual_representation` — the
+  converse bound: an ancilla dimension \(r\) that admits a dilation of \(T\)
+  satisfies \(\operatorname{rank}(\tau) \le r\). Together with the case
+  \(r = \operatorname{rank}(\tau)\) above, the Choi rank is the least
+  admissible ancilla dimension; dilations with \(r = \operatorname{rank}(\tau)\)
+  are minimal in the sense of the discussion following Wolf's Theorem 2.2
+  (`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 346–351).
 
 ## Design notes
 
-The dual map `T*` enters the statement as a linear map satisfying the trace
-pairing that defines it; the pairing determines `T*` uniquely, so this is
-Wolf's `T*` and not an additional assumption on `T`.
+The dual map is the canonical trace-pairing adjoint `Matrix.traceAdjointMap T`;
+the theorems named `_pairing_` transport the same conclusion to any linear map
+satisfying the trace pairing, which determines the dual uniquely.
 
-The dilation matrix is `V = Σⱼ Kⱼ ⊗ |j⟩` built by `stinespringV` from a Kraus
-family of `T` with exactly `r` operators, obtained by zero-padding a minimal
-family of `rank(τ)` operators. The square statements
-`exists_stinespring_dilation` and `exists_stinespring_isometry_of_cptp` in
-`TNLean/Channel/Stinespring.lean` remain separate and are weaker: their ancilla
-dimension is existentially quantified, whereas the theorems here hold for an
-arbitrary `r` at least the Choi rank.
+The dilation matrix is \(V = \sum_j K_j \otimes |j\rangle\), built by
+`stinespringV` from a Kraus family of \(T\) with exactly \(r\) operators,
+obtained by zero-padding a minimal family of \(\operatorname{rank}(\tau)\)
+operators. The square statements `exists_stinespring_dilation` and
+`exists_stinespring_isometry_of_cptp` in `TNLean/Channel/Stinespring.lean`
+remain separate and are weaker: their ancilla dimension is existentially
+quantified, whereas the theorems here hold for an arbitrary \(r\) at least the
+Choi rank.
 
 ## References
 
@@ -55,8 +69,8 @@ arbitrary `r` at least the Choi rank.
   Theorem 2.2][Wolf2012QChannels]
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder
-open Matrix Finset BigOperators
+open scoped Matrix
+open BigOperators
 
 namespace ChoiRectangular
 
@@ -65,18 +79,114 @@ variable {d d' : ℕ}
 /-- **Stinespring representation** (Wolf, Chapter 2, Theorem 2.2,
 Equation (2.11); `Notes/WolfNoteTexSource/ch02_representations.tex`, line 322).
 
-Let `T : M_d → M_{d'}` be completely positive with dual `T*`, characterized by
-the trace pairing `tr[T*(A)X] = tr[A T(X)]`. Then for **every** ancilla
-dimension `r ≥ rank(τ)`, where `τ` is the Choi matrix of `T`, there is a
-`V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` with
+Let \(T : M_d \to M_{d'}\) be completely positive, with dual \(T^*\) the
+trace-pairing adjoint of \(T\). Then for **every** ancilla dimension
+\(r \ge \operatorname{rank}(\tau)\), where \(\tau\) is the Choi matrix of
+\(T\), there is a \(V : \mathbb C^d \to \mathbb C^{d'} \otimes \mathbb C^r\)
+with \(T^*(A) = V^\dagger(A \otimes \mathbb 1_r)V\) for every
+\(A \in M_{d'}\), and \(V\) is an isometry, \(V^\dagger V = \mathbb 1_d\), if
+and only if \(T\) is trace preserving.
 
-  `T*(A) = V†(A ⊗ 𝟙_r)V` for all `A ∈ M_{d'}`,
-
-and `V` is an isometry, `V†V = 𝟙_d`, if and only if `T` is trace preserving.
-
-The dilation matrix is `V = Σⱼ Kⱼ ⊗ |j⟩` for a Kraus family `{Kⱼ}` of `T` with
-exactly `r` operators, and `π(A) = A ⊗ 𝟙_r` is `stinespringPi`. -/
+The dilation matrix is \(V = \sum_j K_j \otimes |j\rangle\) for a Kraus family
+\(\{K_j\}_{j=0}^{r-1}\) of \(T\) with exactly \(r\) operators, and
+\(\pi(A) = A \otimes \mathbb 1_r\) is `stinespringPi`. -/
 theorem exists_stinespringV_of_isKrausCP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCP T) {r : ℕ} (hr : Channel.choiRank T ≤ r) :
+    ∃ V : Matrix (Fin d' × Fin r) (Fin d) ℂ,
+      (∀ A : Matrix (Fin d') (Fin d') ℂ,
+        Matrix.traceAdjointMap T A = Vᴴ * stinespringPi (r := r) A * V) ∧
+      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) := by
+  -- A minimal Kraus family has `rank(τ)` operators; zero-pad it to `r` operators.
+  obtain ⟨K, hK⟩ := Channel.hasKrausCard_mono (Channel.hasKrausCard_choiRank_of_cp hT) hr
+  refine ⟨stinespringV K, fun A => ?_, ?_⟩
+  · -- The trace pairing identifies the adjoint `T*(A)` with the Kraus form
+    -- `∑ⱼ Kⱼ†AKⱼ`.
+    have hdual : Matrix.traceAdjointMap T A = ∑ j : Fin r, (K j)ᴴ * A * K j := by
+      refine Matrix.ext_iff_trace_mul_right.2 fun X => ?_
+      rw [Matrix.trace_traceAdjointMap_mul T A X, hK X, Finset.mul_sum, Finset.sum_mul,
+        Matrix.trace_sum, Matrix.trace_sum]
+      refine Finset.sum_congr rfl fun j _ => ?_
+      calc (A * (K j * X * (K j)ᴴ)).trace
+          = (A * K j * X * (K j)ᴴ).trace := by simp [Matrix.mul_assoc]
+        _ = ((K j)ᴴ * (A * K j * X)).trace := Matrix.trace_mul_comm _ _
+        _ = ((K j)ᴴ * A * K j * X).trace := by simp [Matrix.mul_assoc]
+    rw [hdual, ← stinespring_dual_representation K A]
+    rfl
+  · -- `V†V = ∑ⱼ Kⱼ†Kⱼ`, which is `𝟙` exactly for trace-preserving `T`.
+    rw [stinespringV_conjTranspose_mul]
+    exact (kraus_tp_iff_sum_conjTranspose_mul K T hK).symm
+
+/-- **Stinespring dilation at the Choi-rank ancilla dimension** (Wolf,
+Chapter 2, Theorem 2.2): the case \(r = \operatorname{rank}(\tau)\) of
+`exists_stinespringV_of_isKrausCP`, so that complete positivity of \(T\) is the
+only hypothesis.
+
+A dilation with this ancilla dimension is called minimal, and by
+`choiRank_le_of_stinespring_dual_representation` the Choi rank is the least
+admissible ancilla dimension. -/
+theorem exists_stinespringV_choiRank_of_isKrausCP
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
+    (hT : IsKrausCP T) :
+    ∃ V : Matrix (Fin d' × Fin (Channel.choiRank T)) (Fin d) ℂ,
+      (∀ A : Matrix (Fin d') (Fin d') ℂ,
+        Matrix.traceAdjointMap T A =
+          Vᴴ * stinespringPi (r := Channel.choiRank T) A * V) ∧
+      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
+  exists_stinespringV_of_isKrausCP hT le_rfl
+
+/-- **Least dilation dimension** (Wolf, Chapter 2, discussion after Theorem 2.2,
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 346–351): in the same
+way in which \(V\) is assembled from Kraus operators, the operators
+\(K_j = (\mathbb 1_{d'} \otimes \langle j|)V\) are recovered from the blocks of
+\(V\). Any dilation with ancilla dimension \(r\) therefore exhibits an
+\(r\)-operator Kraus family of \(T\), forcing
+\(\operatorname{rank}(\tau) \le r\).
+
+No complete positivity or trace-preservation hypothesis is needed: the
+dilation identity itself produces the Kraus family, for the trace-pairing
+adjoint of \(T\). -/
+theorem choiRank_le_of_stinespring_dual_representation
+    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ} {r : ℕ}
+    (V : Matrix (Fin d' × Fin r) (Fin d) ℂ)
+    (hV : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+      Matrix.traceAdjointMap T A = Vᴴ * stinespringPi (r := r) A * V) :
+    Channel.choiRank T ≤ r := by
+  classical
+  -- The blocks `K j = (𝟙 ⊗ ⟨j|) V` of the dilation form a Kraus family of `T`.
+  obtain ⟨K, hstV⟩ : ∃ K : Fin r → Matrix (Fin d') (Fin d) ℂ, stinespringV K = V :=
+    ⟨fun j i k => V (i, j) k, by ext p k; rcases p with ⟨i, j⟩; rfl⟩
+  have hdual : ∀ A : Matrix (Fin d') (Fin d') ℂ,
+      Matrix.traceAdjointMap T A = ∑ j : Fin r, (K j)ᴴ * A * K j := by
+    intro A
+    rw [hV A, ← hstV, ← stinespring_dual_representation K A]
+    rfl
+  refine Channel.choiRank_le_of_hasKrausCard ⟨K, fun X => ?_⟩
+  -- Nondegeneracy of the trace pairing turns the dilation identity into the
+  -- Schrödinger-form Kraus identity `T X = ∑ⱼ Kⱼ X Kⱼ†`.
+  refine Matrix.ext_iff_trace_mul_right.2 fun A => ?_
+  calc (T X * A).trace
+      = (A * T X).trace := Matrix.trace_mul_comm _ _
+    _ = (Matrix.traceAdjointMap T A * X).trace :=
+        (Matrix.trace_traceAdjointMap_mul T A X).symm
+    _ = ((∑ j : Fin r, (K j)ᴴ * A * K j) * X).trace := by rw [hdual A]
+    _ = (A * ∑ j : Fin r, K j * X * (K j)ᴴ).trace := by
+        rw [Finset.mul_sum, Finset.sum_mul, Matrix.trace_sum, Matrix.trace_sum]
+        refine Finset.sum_congr rfl fun j _ => ?_
+        calc ((K j)ᴴ * A * K j * X).trace
+            = ((K j)ᴴ * (A * K j * X)).trace := by simp [Matrix.mul_assoc]
+          _ = (A * K j * X * (K j)ᴴ).trace := Matrix.trace_mul_comm _ _
+          _ = (A * (K j * X * (K j)ᴴ)).trace := by simp [Matrix.mul_assoc]
+    _ = ((∑ j : Fin r, K j * X * (K j)ᴴ) * A).trace := Matrix.trace_mul_comm _ _
+
+/-- **Stinespring representation for a dual supplied by the trace pairing**
+(Wolf, Chapter 2, Theorem 2.2; `Notes/WolfNoteTexSource/ch02_representations.tex`,
+line 322): the variant of `exists_stinespringV_of_isKrausCP` in which the dual
+map is an arbitrary linear map satisfying the trace pairing
+\(\operatorname{tr}[T^*(A)X] = \operatorname{tr}[A\,T(X)]\) that characterizes
+the dual (Wolf, Equation (2.3)). The pairing determines the dual uniquely, so
+this is the same theorem, made usable when a dual map is already in hand. -/
+theorem exists_stinespringV_pairing_of_isKrausCP
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
     {Tstar : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
     (hT : IsKrausCP T)
@@ -86,50 +196,19 @@ theorem exists_stinespringV_of_isKrausCP
     ∃ V : Matrix (Fin d' × Fin r) (Fin d) ℂ,
       (∀ A : Matrix (Fin d') (Fin d') ℂ, Tstar A = Vᴴ * stinespringPi (r := r) A * V) ∧
       (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) := by
-  -- A minimal Kraus family has `rank(τ)` operators; zero-pad it to `r` operators.
-  obtain ⟨K, hK⟩ := Channel.hasKrausCard_mono (Channel.hasKrausCard_choiRank_of_cp hT) hr
-  refine ⟨stinespringV K, fun A => ?_, ?_⟩
-  · -- The trace pairing identifies `T*(A)` with the Kraus form `Σⱼ Kⱼ†AKⱼ`.
-    have hdual : Tstar A = ∑ j : Fin r, (K j)ᴴ * A * K j := by
-      refine Matrix.ext_iff_trace_mul_right.2 fun X => ?_
-      rw [hTstar A X, hK X, Finset.mul_sum, Finset.sum_mul, Matrix.trace_sum,
-        Matrix.trace_sum]
-      refine Finset.sum_congr rfl fun j _ => ?_
-      calc (A * (K j * X * (K j)ᴴ)).trace
-          = (A * K j * X * (K j)ᴴ).trace := by simp [Matrix.mul_assoc]
-        _ = ((K j)ᴴ * (A * K j * X)).trace := Matrix.trace_mul_comm _ _
-        _ = ((K j)ᴴ * A * K j * X).trace := by simp [Matrix.mul_assoc]
-    rw [hdual, ← stinespring_dual_representation K A]
-    rfl
-  · -- `V†V = Σⱼ Kⱼ†Kⱼ`, which is `𝟙` exactly for trace-preserving `T`.
-    rw [stinespringV_conjTranspose_mul]
-    exact (kraus_tp_iff_sum_conjTranspose_mul K T hK).symm
+  obtain ⟨V, hV, hViso⟩ := exists_stinespringV_of_isKrausCP hT hr
+  refine ⟨V, fun A => ?_, hViso⟩
+  -- The trace pairing determines the dual map uniquely.
+  have hdual : Tstar A = Matrix.traceAdjointMap T A :=
+    Matrix.ext_iff_trace_mul_right.2 fun X => by
+      rw [hTstar A X, Matrix.trace_traceAdjointMap_mul]
+  rw [hdual]
+  exact hV A
 
-/-- **Stinespring representation for the trace-pairing adjoint** (Wolf,
-Chapter 2, Theorem 2.2; `Notes/WolfNoteTexSource/ch02_representations.tex`,
-line 322).
-
-The dual map is `Matrix.traceAdjointMap T`, the unique map satisfying the
-trace pairing `tr[T*(A)X] = tr[A T(X)]`, so this form of the theorem carries
-no hypothesis beyond complete positivity of `T` and `r ≥ rank(τ)`. -/
-theorem exists_stinespringV_traceAdjointMap_of_isKrausCP
-    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
-    (hT : IsKrausCP T) {r : ℕ} (hr : Channel.choiRank T ≤ r) :
-    ∃ V : Matrix (Fin d' × Fin r) (Fin d) ℂ,
-      (∀ A : Matrix (Fin d') (Fin d') ℂ,
-        Matrix.traceAdjointMap T A = Vᴴ * stinespringPi (r := r) A * V) ∧
-      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
-  exists_stinespringV_of_isKrausCP hT (Matrix.trace_traceAdjointMap_mul T) hr
-
-/-- **Stinespring dilation at the Choi-rank ancilla dimension** (Wolf,
-Chapter 2, Theorem 2.2): the case `r = rank(τ)` of
-`exists_stinespringV_of_isKrausCP`. A dilation with this ancilla dimension is
-called minimal.
-
-That no ancilla dimension below `rank(τ)` admits a dilation is not asserted
-here: it would need a Kraus family of `r` operators extracted from an arbitrary
-`V`, and Wolf's Theorem 2.2 states only the existence for `r ≥ rank(τ)`. -/
-theorem exists_stinespringV_choiRank_of_isKrausCP
+/-- **Stinespring dilation at the Choi-rank ancilla dimension for a dual
+supplied by the trace pairing** (Wolf, Chapter 2, Theorem 2.2): the case
+\(r = \operatorname{rank}(\tau)\) of `exists_stinespringV_pairing_of_isKrausCP`. -/
+theorem exists_stinespringV_pairing_choiRank_of_isKrausCP
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
     {Tstar : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
     (hT : IsKrausCP T)
@@ -139,19 +218,6 @@ theorem exists_stinespringV_choiRank_of_isKrausCP
       (∀ A : Matrix (Fin d') (Fin d') ℂ,
         Tstar A = Vᴴ * stinespringPi (r := Channel.choiRank T) A * V) ∧
       (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
-  exists_stinespringV_of_isKrausCP hT hTstar le_rfl
-
-/-- **Stinespring dilation at the Choi-rank ancilla dimension, trace-pairing
-adjoint form** (Wolf, Chapter 2, Theorem 2.2): the case `r = rank(τ)` of
-`exists_stinespringV_traceAdjointMap_of_isKrausCP`, so that complete positivity
-of `T` is the only hypothesis. -/
-theorem exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP
-    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
-    (hT : IsKrausCP T) :
-    ∃ V : Matrix (Fin d' × Fin (Channel.choiRank T)) (Fin d) ℂ,
-      (∀ A : Matrix (Fin d') (Fin d') ℂ,
-        Matrix.traceAdjointMap T A = Vᴴ * stinespringPi (r := Channel.choiRank T) A * V) ∧
-      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace) :=
-  exists_stinespringV_traceAdjointMap_of_isKrausCP hT le_rfl
+  exists_stinespringV_pairing_of_isKrausCP hT hTstar le_rfl
 
 end ChoiRectangular

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -126,8 +126,10 @@ project import.
     — for a completely positive `T : M_d → M_{d'}` and every `r ≥ rank(τ)`
     there is a `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` with `T*(A) = V†(A ⊗ 𝟙_r)V`, an
     isometry exactly when `T` is trace preserving ✓
-    `exists_stinespringV_choiRank_of_isKrausCP`
-    — the minimal dilation `r = rank(τ)` ✓
+    `exists_stinespringV_choiRank_of_isKrausCP` /
+    `exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP`
+    — the dilation at the Choi-rank ancilla dimension `r = rank(τ)`, called a
+    minimal dilation ✓
 
 * **Theorem 2.3** (ordered CP-maps):
   - `CPDominates` — CP partial order: `S - T` is completely positive ✓

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -122,14 +122,17 @@ project import.
   - **Full statement** in `TNLean/Channel/StinespringRectangular.lean`
     (namespace `ChoiRectangular`):
     `exists_stinespringV_of_isKrausCP` /
-    `exists_stinespringV_traceAdjointMap_of_isKrausCP`
+    `exists_stinespringV_pairing_of_isKrausCP`
     — for a completely positive `T : M_d → M_{d'}` and every `r ≥ rank(τ)`
     there is a `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` with `T*(A) = V†(A ⊗ 𝟙_r)V`, an
     isometry exactly when `T` is trace preserving ✓
     `exists_stinespringV_choiRank_of_isKrausCP` /
-    `exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP`
-    — the dilation at the Choi-rank ancilla dimension `r = rank(τ)`, called a
-    minimal dilation ✓
+    `exists_stinespringV_pairing_choiRank_of_isKrausCP`
+    — the dilation at the Choi-rank ancilla dimension `r = rank(τ)` ✓
+    `choiRank_le_of_stinespring_dual_representation`
+    — the converse bound: a dilation with ancilla dimension `r` forces
+    `rank(τ) ≤ r`, so `r = rank(τ)` is the least admissible ancilla dimension
+    and dilations with it are minimal (discussion after Thm. 2.2) ✓
 
 * **Theorem 2.3** (ordered CP-maps):
   - `CPDominates` — CP partial order: `S - T` is completely positive ✓

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -14,6 +14,7 @@ import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring
+import TNLean.Channel.StinespringRectangular
 import TNLean.Channel.OrderedCP
 import TNLean.Channel.RadonNikodym
 import TNLean.Channel.OpenSystem
@@ -118,6 +119,15 @@ project import.
   - `stinespring_dual_representation` — `T*(A) = V†(A ⊗ 𝟙)V` ✓
   - `stinespringV_isometry_iff_kraus_normalized` — `V†V = 𝟙` ↔ TP ✓
   - `stinespring_schrodinger_representation` — `T(ρ) = tr_r(VρV†)` ✓
+  - **Full statement** in `TNLean/Channel/StinespringRectangular.lean`
+    (namespace `ChoiRectangular`):
+    `exists_stinespringV_of_isKrausCP` /
+    `exists_stinespringV_traceAdjointMap_of_isKrausCP`
+    — for a completely positive `T : M_d → M_{d'}` and every `r ≥ rank(τ)`
+    there is a `V : ℂ^d → ℂ^{d'} ⊗ ℂ^r` with `T*(A) = V†(A ⊗ 𝟙_r)V`, an
+    isometry exactly when `T` is trace preserving ✓
+    `exists_stinespringV_choiRank_of_isKrausCP`
+    — the minimal dilation `r = rank(τ)` ✓
 
 * **Theorem 2.3** (ordered CP-maps):
   - `CPDominates` — CP partial order: `S - T` is completely positive ✓

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -213,9 +213,7 @@ channel:
         ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP,
         ChoiRectangular.exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP}
     \leanok
-    \uses{def:is_kraus_cp, def:trace_pairing_adjoint, def:kraus_rank_rect,
-        thm:kraus_rect_rank_minimal, thm:kraus_rect_normalization,
-        def:stinespring_v}
+    \uses{def:is_kraus_cp, def:trace_pairing_adjoint, def:kraus_rank_rect}
     Let $T:\MN{d}\to\MN{d'}$ be completely positive with Choi matrix $\tau$ and
     dual $T^*$. Then for every $r\geq\rank(\tau)$ there is a
     $V:\C^{d}\to\C^{d'}\otimes\C^{r}$ such that, for all $A\in\MN{d'}$,
@@ -231,7 +229,7 @@ channel:
 
 \begin{proof}
     \leanok
-    \uses{def:kraus_rank_rect, thm:kraus_rect_rank_minimal,
+    \uses{def:kraus_rank_rect, def:stinespring_v, thm:kraus_rect_rank_minimal,
         thm:kraus_rect_normalization, thm:stinespring_dual_representation,
         thm:stinespring_v_conjTranspose_mul,
         thm:trace_pairing_adjoint_identity, thm:trace_nondeg}

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -109,17 +109,18 @@ channel:
     \lean{stinespring_dual_representation}
     \leanok
     \uses{def:stinespring_v, def:cp_map, thm:stinespring_v_conjTranspose_mul}
-    Let $K_j:\C^{d}\to\C^{d'}$ be Kraus operators of $T:\MN{d}\to\MN{d'}$ and
-    let $V=\sum_j K_j\otimes\ket{j}$. Then, for every observable $A\in\MN{d'}$
-    on the output space,
+    Let $K_j:\C^{d}\to\C^{d'}$, $j=0,\dots,r-1$, be an arbitrary family of
+    matrices and let $V=\sum_j K_j\otimes\ket{j}$. Then, for every observable
+    $A\in\MN{d'}$ on the output space,
     \begin{align}
         V^\dagger(A\otimes\Id_r)V
-        &=\sum_j K_j^\dagger A K_j
-          =T^*(A).
+        &=\sum_j K_j^\dagger A K_j,
         \label{eq:representations_stinespring_dual}
     \end{align}
-    Both sides lie in $\MN{d}$, on the input space. This is the Stinespring
-    representation of the \emph{dual} (Heisenberg picture) map $T^*$; the
+    an identity in $\MN{d}$ on the input space, valid for arbitrary $K$
+    independently of any channel. When the $K_j$ are Kraus operators of a map
+    $T:\MN{d}\to\MN{d'}$, the right-hand side is the dual
+    (Heisenberg-picture) map $T^*(A)$ of \ref{def:trace_pairing_adjoint}; the
     square case is $d=d'$.
 \end{theorem}
 
@@ -129,7 +130,9 @@ channel:
     Compute $(V^\dagger(A\otimes\Id_r)V)_{ab}$
     by summing over the product index $(i,j)$;
     the $\delta_{jl}$ from $\Id_r$ collapses the sum over $l$, giving
-    $\sum_j K_j^\dagger A K_j$.
+    $\sum_j K_j^\dagger A K_j$. For Kraus operators of $T$, the trace
+    pairing identifies this sum with $T^*(A)$, as displayed in the proof of
+    Theorem~\ref{thm:stinespring_rectangular}.
 \end{proof}
 
 \begin{theorem}[The Stinespring isometry condition iff trace preservation]\label{thm:stinespringV_isometry_iff_kraus_normalized}

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -203,6 +203,45 @@ channel:
     the Stinespring isometry condition $V^\dagger V=\Id$.
 \end{proof}
 
+\begin{theorem}[Stinespring representation, rectangular form]
+    \label{thm:stinespring_rectangular}
+    \lean{ChoiRectangular.exists_stinespringV_of_isKrausCP,
+        ChoiRectangular.exists_stinespringV_traceAdjointMap_of_isKrausCP,
+        ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP}
+    \leanok
+    \uses{def:is_kraus_cp, def:trace_pairing_adjoint, def:kraus_rank_rect,
+        thm:kraus_rect_rank_minimal, thm:kraus_rect_normalization,
+        def:stinespring_v}
+    Let $T:\MN{d}\to\MN{d'}$ be completely positive with Choi matrix $\tau$ and
+    dual $T^*$. Then for every $r\geq\rank(\tau)$ there is a
+    $V:\C^{d}\to\C^{d'}\otimes\C^{r}$ such that
+    \begin{align}
+        T^*(A)&=V^\dagger(A\otimes\Id_r)V
+        \qquad\text{for all }A\in\MN{d'},
+        \label{eq:stinespring_rectangular}
+    \end{align}
+    and $V$ is an isometry, $V^\dagger V=\Id_d$, if and only if $T$ is trace
+    preserving. The smallest admissible dilation dimension is
+    $r=\rank(\tau)$, where the dilation is called minimal. This is
+    \cite[Theorem~2.2]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kraus_rect_rank_minimal, thm:kraus_rect_normalization,
+        thm:stinespring_dual_representation}
+    By minimality of the Kraus rank, $T$ has a Kraus family of exactly
+    $\rank(\tau)$ operators; padding it with zeros gives a family
+    $\{K_j\}_{j=1}^{r}$ for every $r\geq\rank(\tau)$. Set
+    $V:=\sum_j K_j\otimes\ket{j}$ for an orthonormal basis $\{\ket{j}\}$ of
+    $\C^{r}$. Then $V^\dagger(A\otimes\Id_r)V=\sum_j K_j^\dagger AK_j$, whose
+    trace pairing against every $X$ agrees with that of $T^*(A)$; since the
+    trace pairing is nondegenerate, this gives
+    (\ref{eq:stinespring_rectangular}). Finally
+    $V^\dagger V=\sum_j K_j^\dagger K_j$, and the latter equals $\Id_d$
+    exactly when $T$ is trace preserving.
+\end{proof}
+
 %% =========================================================
 \section{Ordered CP maps, Radon--Nikodym, and open-system representation}
 \label{sec:ordered_cp}

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -241,11 +241,13 @@ channel:
     $V:=\sum_j K_j\otimes\ket{j}$ for an orthonormal basis $\{\ket{j}\}$ of
     $\C^{r}$, so that $V^\dagger(A\otimes\Id_r)V=\sum_j K_j^\dagger AK_j$. The
     trace pairing gives
-    \[
-        \tr\bigl[T^*(A)X\bigr]=\tr\bigl[A\,T(X)\bigr]
-        =\tr\Bigl[A\sum_j K_jXK_j^\dagger\Bigr]
-        =\tr\Bigl[\sum_j K_j^\dagger AK_j\,X\Bigr]
-    \]
+    \begin{align}
+        \tr\bigl[T^*(A)X\bigr]
+        &=\tr\bigl[A\,T(X)\bigr]
+          =\tr\Bigl[A\sum_j K_jXK_j^\dagger\Bigr]
+          =\tr\Bigl[\sum_j K_j^\dagger AK_j\,X\Bigr]
+        \label{eq:stinespring_rectangular_pairing}
+    \end{align}
     for every $X\in\MN{d}$, and nondegeneracy of the trace pairing yields
     (\ref{eq:stinespring_rectangular}). Finally
     $V^\dagger V=\sum_j K_j^\dagger K_j$, and the latter equals $\Id_d$

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -109,15 +109,18 @@ channel:
     \lean{stinespring_dual_representation}
     \leanok
     \uses{def:stinespring_v, def:cp_map, thm:stinespring_v_conjTranspose_mul}
-    For Kraus operators $\{K_j\}$ and $A\in\MN{D}$,
+    Let $K_j:\C^{d}\to\C^{d'}$ be Kraus operators of $T:\MN{d}\to\MN{d'}$ and
+    let $V=\sum_j K_j\otimes\ket{j}$. Then, for every observable $A\in\MN{d'}$
+    on the output space,
     \begin{align}
         V^\dagger(A\otimes\Id_r)V
         &=\sum_j K_j^\dagger A K_j
           =T^*(A).
         \label{eq:representations_stinespring_dual}
     \end{align}
-    This is the Stinespring representation of the \emph{dual} (Heisenberg
-    picture) map $T^*$.
+    Both sides lie in $\MN{d}$, on the input space. This is the Stinespring
+    representation of the \emph{dual} (Heisenberg picture) map $T^*$; the
+    square case is $d=d'$.
 \end{theorem}
 
 \begin{proof}
@@ -207,36 +210,43 @@ channel:
     \label{thm:stinespring_rectangular}
     \lean{ChoiRectangular.exists_stinespringV_of_isKrausCP,
         ChoiRectangular.exists_stinespringV_traceAdjointMap_of_isKrausCP,
-        ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP}
+        ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP,
+        ChoiRectangular.exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP}
     \leanok
     \uses{def:is_kraus_cp, def:trace_pairing_adjoint, def:kraus_rank_rect,
         thm:kraus_rect_rank_minimal, thm:kraus_rect_normalization,
         def:stinespring_v}
     Let $T:\MN{d}\to\MN{d'}$ be completely positive with Choi matrix $\tau$ and
     dual $T^*$. Then for every $r\geq\rank(\tau)$ there is a
-    $V:\C^{d}\to\C^{d'}\otimes\C^{r}$ such that
+    $V:\C^{d}\to\C^{d'}\otimes\C^{r}$ such that, for all $A\in\MN{d'}$,
     \begin{align}
-        T^*(A)&=V^\dagger(A\otimes\Id_r)V
-        \qquad\text{for all }A\in\MN{d'},
+        T^*(A)&=V^\dagger(A\otimes\Id_r)V,
         \label{eq:stinespring_rectangular}
     \end{align}
     and $V$ is an isometry, $V^\dagger V=\Id_d$, if and only if $T$ is trace
-    preserving. The smallest admissible dilation dimension is
-    $r=\rank(\tau)$, where the dilation is called minimal. This is
-    \cite[Theorem~2.2]{Wolf2012Quantum}.
+    preserving. In particular $r=\rank(\tau)$ is an admissible ancilla
+    dimension, and a dilation with that ancilla dimension is called minimal.
+    This is \cite[Theorem~2.2]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:kraus_rect_rank_minimal, thm:kraus_rect_normalization,
-        thm:stinespring_dual_representation}
+    \uses{def:kraus_rank_rect, thm:kraus_rect_rank_minimal,
+        thm:kraus_rect_normalization, thm:stinespring_dual_representation,
+        thm:stinespring_v_conjTranspose_mul,
+        thm:trace_pairing_adjoint_identity, thm:trace_nondeg}
     By minimality of the Kraus rank, $T$ has a Kraus family of exactly
     $\rank(\tau)$ operators; padding it with zeros gives a family
-    $\{K_j\}_{j=1}^{r}$ for every $r\geq\rank(\tau)$. Set
+    $\{K_j\}_{j=0}^{r-1}$ for every $r\geq\rank(\tau)$. Set
     $V:=\sum_j K_j\otimes\ket{j}$ for an orthonormal basis $\{\ket{j}\}$ of
-    $\C^{r}$. Then $V^\dagger(A\otimes\Id_r)V=\sum_j K_j^\dagger AK_j$, whose
-    trace pairing against every $X$ agrees with that of $T^*(A)$; since the
-    trace pairing is nondegenerate, this gives
+    $\C^{r}$, so that $V^\dagger(A\otimes\Id_r)V=\sum_j K_j^\dagger AK_j$. The
+    trace pairing gives
+    \[
+        \tr\bigl[T^*(A)X\bigr]=\tr\bigl[A\,T(X)\bigr]
+        =\tr\Bigl[A\sum_j K_jXK_j^\dagger\Bigr]
+        =\tr\Bigl[\sum_j K_j^\dagger AK_j\,X\Bigr]
+    \]
+    for every $X\in\MN{d}$, and nondegeneracy of the trace pairing yields
     (\ref{eq:stinespring_rectangular}). Finally
     $V^\dagger V=\sum_j K_j^\dagger K_j$, and the latter equals $\Id_d$
     exactly when $T$ is trace preserving.

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -209,9 +209,9 @@ channel:
 \begin{theorem}[Stinespring representation, rectangular form]
     \label{thm:stinespring_rectangular}
     \lean{ChoiRectangular.exists_stinespringV_of_isKrausCP,
-        ChoiRectangular.exists_stinespringV_traceAdjointMap_of_isKrausCP,
         ChoiRectangular.exists_stinespringV_choiRank_of_isKrausCP,
-        ChoiRectangular.exists_stinespringV_traceAdjointMap_choiRank_of_isKrausCP}
+        ChoiRectangular.exists_stinespringV_pairing_of_isKrausCP,
+        ChoiRectangular.exists_stinespringV_pairing_choiRank_of_isKrausCP}
     \leanok
     \uses{def:is_kraus_cp, def:trace_pairing_adjoint, def:kraus_rank_rect}
     Let $T:\MN{d}\to\MN{d'}$ be completely positive with Choi matrix $\tau$ and
@@ -223,8 +223,9 @@ channel:
     \end{align}
     and $V$ is an isometry, $V^\dagger V=\Id_d$, if and only if $T$ is trace
     preserving. In particular $r=\rank(\tau)$ is an admissible ancilla
-    dimension, and a dilation with that ancilla dimension is called minimal.
-    This is \cite[Theorem~2.2]{Wolf2012Quantum}.
+    dimension; by Lemma~\ref{lem:stinespring_rectangular_least_dim} no smaller
+    ancilla dimension is admissible, and a dilation with $r=\rank(\tau)$ is
+    called minimal. This is \cite[Theorem~2.2]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
@@ -250,6 +251,44 @@ channel:
     (\ref{eq:stinespring_rectangular}). Finally
     $V^\dagger V=\sum_j K_j^\dagger K_j$, and the latter equals $\Id_d$
     exactly when $T$ is trace preserving.
+\end{proof}
+
+\begin{lemma}[Least dilation dimension]\label{lem:stinespring_rectangular_least_dim}
+    \lean{ChoiRectangular.choiRank_le_of_stinespring_dual_representation}
+    \leanok
+    \uses{def:trace_pairing_adjoint, def:kraus_rank_rect}
+    Let $T:\MN{d}\to\MN{d'}$ be a linear map with Choi matrix $\tau$ and dual
+    $T^*$. If for some ancilla dimension $r$ there is a
+    $V:\C^{d}\to\C^{d'}\otimes\C^{r}$ such that
+    (\ref{eq:stinespring_rectangular}) holds for all $A\in\MN{d'}$, then
+    $\rank(\tau)\le r$. Together with
+    Theorem~\ref{thm:stinespring_rectangular}, the least admissible ancilla
+    dimension is $\rank(\tau)$, and dilations with $r=\rank(\tau)$ are
+    minimal. This is the discussion following
+    \cite[Theorem~2.2]{Wolf2012Quantum}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:stinespring_v, thm:kraus_rect_rank_minimal,
+        thm:stinespring_dual_representation,
+        thm:trace_pairing_adjoint_identity, thm:trace_nondeg}
+    The Kraus operators are recovered from $V$ as the blocks
+    $K_j=(\Id_{d'}\otimes\bra{j})V$, which satisfy
+    $V=\sum_jK_j\otimes\ket{j}$, so that
+    $T^*(A)=\sum_jK_j^\dagger AK_j$ for every $A\in\MN{d'}$. For every
+    $X\in\MN{d}$, the trace pairing gives
+    \begin{align}
+        \tr\bigl[A\,T(X)\bigr]
+        &=\tr\bigl[T^*(A)X\bigr]
+          =\tr\Bigl[\sum_jK_j^\dagger AK_j\,X\Bigr]
+          =\tr\Bigl[A\sum_jK_jXK_j^\dagger\Bigr],
+        \label{eq:stinespring_rectangular_least_pairing}
+    \end{align}
+    and nondegeneracy of the trace pairing yields
+    $T(X)=\sum_jK_jXK_j^\dagger$: an $r$-operator Kraus family of $T$. Any
+    $r$-operator Kraus family forces $\rank(\tau)\le r$, the bound in the
+    minimality of the Kraus rank.
 \end{proof}
 
 %% =========================================================


### PR DESCRIPTION
## Source

Wolf, *Quantum Channels & Operations*, Chapter 2, Theorem 2.2 (Stinespring representation),
`Notes/WolfNoteTexSource/ch02_representations.tex`, line 322:

> Let $T:\mathcal M_d \to \mathcal M_{d'}$ be a completely positive linear map. Then for every
> $r \ge \operatorname{rank}(\tau)$ (recall that $\operatorname{rank}(\tau)\le dd'$) there is a
> $V:\mathbb C^d \to \mathbb C^{d'} \otimes \mathbb C^r$ such that
> $T^*(A) = V^\dagger (A \otimes \mathbb 1_r)V$ for all $A \in \mathcal M_{d'}$.
> $V$ is an isometry (i.e., $V^\dagger V = \mathbb 1_d$) iff $T$ is trace preserving.

## Landed signature

New file `TNLean/Channel/StinespringRectangular.lean`, namespace `ChoiRectangular`:

```lean
theorem exists_stinespringV_of_isKrausCP
    {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ}
    {Tstar : Matrix (Fin d') (Fin d') ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
    (hT : IsKrausCP T)
    (hTstar : ∀ (A : Matrix (Fin d') (Fin d') ℂ) (X : Matrix (Fin d) (Fin d) ℂ),
      (Tstar A * X).trace = (A * T X).trace)
    {r : ℕ} (hr : Channel.choiRank T ≤ r) :
    ∃ V : Matrix (Fin d' × Fin r) (Fin d) ℂ,
      (∀ A : Matrix (Fin d') (Fin d') ℂ, Tstar A = Vᴴ * stinespringPi (r := r) A * V) ∧
      (Vᴴ * V = 1 ↔ ∀ X : Matrix (Fin d) (Fin d) ℂ, (T X).trace = X.trace)
```

Two corollaries:

* `exists_stinespringV_traceAdjointMap_of_isKrausCP` — the same statement with `T*` taken to be
  `Matrix.traceAdjointMap T`, so the only hypotheses are `IsKrausCP T` and `choiRank T ≤ r`.
* `exists_stinespringV_choiRank_of_isKrausCP` — the minimal dilation `r = rank(τ)`.

## Hypothesis-by-hypothesis match

| Wolf | Lean |
|---|---|
| $T:\mathcal M_d\to\mathcal M_{d'}$ | `T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ` — rectangular, `d` and `d'` independent |
| $T$ completely positive | `IsKrausCP T`, equivalent to complete positivity by `isKrausCP_iff_choiMatrix_posSemidef` (Choi) |
| $T^*$, the dual | `Tstar` with the trace pairing `tr[T*(A)X] = tr[A T(X)]` that defines it; the pairing is nondegenerate, so this names Wolf's `T*` and adds nothing. The `traceAdjointMap` corollary discharges it outright. |
| **for every** $r \ge \operatorname{rank}(\tau)$ | `{r : ℕ} (hr : Channel.choiRank T ≤ r)` — universally quantified, in hypothesis position; `Channel.choiRank T` is `(choiMatrix T).rank` |
| $V:\mathbb C^d\to\mathbb C^{d'}\otimes\mathbb C^r$ | `V : Matrix (Fin d' × Fin r) (Fin d) ℂ` |
| $T^*(A)=V^\dagger(A\otimes\mathbb 1_r)V$ for all $A$ | `∀ A, Tstar A = Vᴴ * stinespringPi (r := r) A * V`, where `stinespringPi A = A ⊗ₖ 𝟙_r` |
| $V^\dagger V=\mathbb 1_d$ iff $T$ trace preserving | `Vᴴ * V = 1 ↔ ∀ X, (T X).trace = X.trace`, on the *same* `V` |

No hypothesis is present that Wolf's statement does not have. In particular the ancilla dimension
is not existentially quantified, and the isometry clause is an `iff` on the same witness rather
than a separate trace-preserving-only theorem.

## Proof

Wolf's proof, unchanged: `Channel.hasKrausCard_choiRank_of_cp` gives a Kraus family of exactly
`rank(τ)` operators, `Channel.hasKrausCard_mono` zero-pads it to `r` operators, and
`stinespringV` assembles `V = Σⱼ Kⱼ ⊗ |j⟩`. The Heisenberg identity comes from
`stinespring_dual_representation` after identifying `T*(A)` with `Σⱼ Kⱼ†AKⱼ` through
nondegeneracy of the trace pairing (`Matrix.ext_iff_trace_mul_right`). The isometry clause is
`stinespringV_conjTranspose_mul` composed with `kraus_tp_iff_sum_conjTranspose_mul`.

## Supporting change: index-type generalization

`stinespringPi`, `stinespringPi_apply`, `stinespringPi_one`, `stinespringPi_mul`,
`stinespringPi_conjTranspose`, and `stinespring_dual_representation` in
`TNLean/Channel/Stinespring.lean` were stated for one square index type `Fin D`. They are now
stated for an arbitrary observable index type, which is what the rectangular shape needs: the
observable `A` lives on the output space while the identity `V†V = 𝟙` lives on the input space.
The square case is the specialization. No statement was weakened, and every existing caller
compiles unchanged.

## What became of the old square theorems

`exists_stinespring_dilation` and `exists_stinespring_isometry_of_cptp` are **kept, not derived**.
They are not corollaries of the new theorem, for two reasons:

1. Their conclusion exposes the Kraus family `K` and asserts `V = stinespringV K`. The new
   theorem's conclusion is an existential in `V` alone and does not expose the Kraus data.
2. `exists_stinespring_dilation` puts the *Heisenberg* map itself in the hypothesis (`E` is CP and
   `E(A) = V†π(A)V`), whereas the new theorem puts the Schrödinger map `T` in the hypothesis and
   the dual `T*` in the conclusion. Recovering the former from the latter would require
   constructing `T` as the trace-pairing adjoint of `E` and transporting complete positivity
   across it — more machinery than the existing six-line direct proof.

They remain accurate statements of the weaker packagings, and their blueprint entries are
untouched.

## Paper-gap note

None added, and none required. The issue's acceptance criteria asked for a note recording the
square/existential restriction; with the source-faithful theorem landed, the stricter-hypothesis
version is no longer the only available formalization of Wolf's Theorem 2.2, which is the
condition under CLAUDE.md that triggers the note requirement.

## Blueprint

One new entry, `thm:stinespring_rectangular`, in
`blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex`, stating Wolf's
hypotheses verbatim in mathematical prose with `\lean{}` on all three declarations and `\leanok`
on statement and proof. The existing square entries `thm:exists_stinespring_dilation` and
`thm:exists_stinespring_isometry_of_cptp` are unchanged. Nothing was touched in
`ch04_channels_rectangular_kraus_maps.tex` or `ch16_channel_representations_choi_and_kraus.tex`;
the new entry only cites labels already defined there.

`TNLean/Channel/WolfChapter2Index.lean` records the new declarations under Theorem 2.2.

## Verification

| Command | Outcome |
|---|---|
| `lake env lean TNLean/Channel/StinespringRectangular.lean` | clean |
| `lake build TNLean.Channel.StinespringRectangular` | `Build completed successfully (3037 jobs)` |
| `lake build` on every consumer found by `rg -l 'Channel.Stinespring'` / `rg -l 'exists_stinespring'` (`KoashiImoto.MarkovDilation.AmbientBlockAction`, `KoashiImoto.MarkovDilation.Basic`, `KoashiImoto.MarkovDilationBlockForm`, `KrausFreedom`, `OpenSystem`, `OrderedCP`, `POVM`, `POVM.Uniqueness`, `RadonNikodym`, `WolfChapter2Index`, `Entropy.MutualInformationDataProcessing`) | `Build completed successfully (3315 jobs)` |
| `lake build TNLean.Channel` | `Build completed successfully (9104 jobs)` |
| `rg -n "sorry\|axiom\|native_decide\|maxHeartbeats" ` on all changed Lean files | no hits |
| `python3 scripts/blueprint_lean_sync.py` | exit 0, no Stinespring findings |
| line length ≤ 100 on changed Lean files | clean |

No caller needed fixing: the index-type generalization is strictly a weakening of the hypotheses
on `stinespringPi` and `stinespring_dual_representation`.

Closes LionSR/QICLean#121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176U7wiKWaxFAKBHv3Jgjz3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of known quantum-channel theory with localized API generalizations; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **Wolf Theorem 2.2 in rectangular form**: for CP `T : M_d → M_{d'}` and every ancilla dimension `r ≥ rank(τ)`, there is a dilation `V` with `T*(A) = V†(A ⊗ 𝟙_r)V`, and `V†V = 𝟙_d` iff `T` is trace preserving. New file `TNLean/Channel/StinespringRectangular.lean` (`ChoiRectangular`) proves this via Kraus padding to length `r`, `stinespringV`, and trace-pairing identification; corollaries use `Matrix.traceAdjointMap` and the minimal case `r = rank(τ)`.
> 
> **Supporting change:** `stinespringPi` and `stinespring_dual_representation` in `Stinespring.lean` are generalized from square `Fin D` to separate input/output index types so observables sit on the output algebra in the rectangular setting.
> 
> Blueprint gains `thm:stinespring_rectangular`; the dual-representation theorem prose is updated for rectangular Kraus maps. `WolfChapter2Index` and channel imports wire in the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea6538ac08c5a7d9d8f71095625b6b471f2d45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->