### PR TITLE
refactor(PEPS): lower per-bond gauge uniqueness to n ≥ 2L+1

### DIFF
--- a/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
+++ b/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
@@ -33,10 +33,12 @@ overlapping-window corollary `fundamentalTheorem_normalMPS_of_overlap`.
 
 The uniqueness clause `fundamentalTheorem_normalMPS_gauge_unique` carries the
 same system size, as the source's uniqueness carries none of its own: the two
-gauge families are compared directly, without the blocking geometry of the
-Section-`normal` route.  Iterating both relations along the spanning
-length-`L` word products of `A` shows that the transports from a bond `v` to
-the bond `v + L` agree on the full matrix algebra, so the two gauges at every
+gauge families are compared directly, without cutting the chain into the
+three injective arcs that the Section-`normal` route blocks it into.
+Iterating both relations along a word `x` of length `L` gives
+`B^x = Z_v⁻¹ A^x Z_{v+L}` and the same with `Z'`; since the products `A^x`
+span the full matrix algebra, the comparison extends to every matrix `W`,
+`Z_v⁻¹ W Z_{v+L} = Z'⁻¹_v W Z'_{v+L}`, so the two gauges at every
 bond differ by a nonzero scalar (`gaugeFamily_bond_proportional`), and the
 relation `B = Z_v⁻¹ A Z_{v+1}` pins the ratio of consecutive scalars against
 the nonzero tensor `B`, merging them into one constant.
@@ -442,9 +444,10 @@ consecutive constants against the nonzero tensor `B`, merging them into one.
 The source's uniqueness clause carries no system-size constraint, and the
 argument here needs none beyond the `n ≥ 2L + 1` of the existence clause
 `fundamentalTheorem_normalMPS`: comparing the two gauge families along the
-spanning length-`L` words leaves the pair of gauges at one bond differing by
-a scalar, with no blocking geometry involved.  The single-gauge form of the
-same clause is
+spanning length-`L` words gives `Z_v⁻¹ W Z_{v+L} = Z'⁻¹_v W Z'_{v+L}` for
+every matrix `W`, hence `Z'_v = c_v Z_v` at one bond.  The chain is never cut
+into the injective arcs that the existence clause blocks it into.  The
+single-gauge form of the same clause is
 `fundamentalTheorem_normalMPS_translationInvariant_gauge_unique`.
 
 Source: arXiv:1804.04964, Section 3, first corollary after the theorem

--- a/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
+++ b/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
@@ -31,24 +31,25 @@ source's alternative proof (line 1623 and Section `normal_alt`, the corollary
 after Lemma 5): `fundamentalTheorem_normalMPS` delegates to the
 overlapping-window corollary `fundamentalTheorem_normalMPS_of_overlap`.
 
-The uniqueness clause `fundamentalTheorem_normalMPS_gauge_unique` still uses
-the `n ≥ 3L` route through the cycle-graph corollary
-(`fundamentalTheorem_normalMPS_cycle`).  There the cycle tensors of `A` and
-`B` generate the same state since their coefficients are the matrix-product
-traces, every arc of `L` consecutive sites is blocked-injective by `L`-block
-injectivity of the matrix tensors, and the graph-level gauge equivalence
-hands back one invertible matrix per edge.  The per-edge matrices convert to
-per-bond gauges through the stored-edge orientation: away from the seam the
+The uniqueness clause `fundamentalTheorem_normalMPS_gauge_unique` carries the
+same system size, as the source's uniqueness carries none of its own: the two
+gauge families are compared directly, without the blocking geometry of the
+Section-`normal` route.  Iterating both relations along the spanning
+length-`L` word products of `A` shows that the transports from a bond `v` to
+the bond `v + L` agree on the full matrix algebra, so the two gauges at every
+bond differ by a nonzero scalar (`gaugeFamily_bond_proportional`), and the
+relation `B = Z_v⁻¹ A Z_{v+1}` pins the ratio of consecutive scalars against
+the nonzero tensor `B`, merging them into one constant.
+
+The graph-level presentation of the same corollary is still reachable from
+here: the per-edge matrices of the cycle-graph gauge equivalence convert to
+per-bond gauges through the stored-edge orientation — away from the seam the
 gauge of the bond entering site `v` is the transpose of the edge matrix,
-while on the seam edge — stored with its endpoints in the opposite order — it
-is the inverse (`cycleGaugeOfEdgeGauge`).  The per-vertex component identity
-of the graph-level gauge equivalence is equivalent to the matrix identity
-`B = Z_v⁻¹ A Z_{v+1}` (`cycleGauge_component_iff_matrix`).  The uniqueness
-clause converts a per-bond family back into a per-edge family
-(`edgeGaugeOfCycleGauge`), invokes the graph-level uniqueness for a constant
-per edge, and merges the constants into one because the relation
-`B = Z_v⁻¹ A Z_{v+1}` pins the ratio of consecutive constants against the
-nonzero tensor `B`.
+while on the seam edge, stored with its endpoints in the opposite order, it
+is the inverse (`cycleGaugeOfEdgeGauge`, inverted by
+`edgeGaugeOfCycleGauge`) — and the per-vertex component identity of the
+graph-level gauge equivalence is equivalent to the matrix identity
+`B = Z_v⁻¹ A Z_{v+1}` (`cycleGauge_component_iff_matrix`).
 
 The matrix-level hypotheses match the source corollary: `0 < L` (implicit in
 blocking `L` consecutive sites), positive bond dimension, `L`-block
@@ -433,24 +434,24 @@ after the theorem labelled `normal`: the gauges `Z_i` are unique up to a
 multiplicative constant).
 
 Two families of per-bond gauges realizing the relation `B = Z_v⁻¹ A Z_{v+1}`
-at every site of the closed chain of `n ≥ 3L` sites are proportional by a
-single constant.  The per-edge constants come from the graph-level uniqueness
-clause; the relation itself pins the ratio of consecutive constants against
-the nonzero tensor `B`, merging them into one.
+at every site of the closed chain of `n ≥ 2L + 1` sites are proportional by
+a single constant.  At each bond the two gauges are proportional
+(`gaugeFamily_bond_proportional`), and the relation itself pins the ratio of
+consecutive constants against the nonzero tensor `B`, merging them into one.
 
-The source's uniqueness clause carries no system-size constraint, while this
-proof keeps the `n ≥ 3L` of the graph-level uniqueness route it invokes; the
-existence clause `fundamentalTheorem_normalMPS` already holds at the optimal
-`n ≥ 2L + 1`.  The size-free single-gauge uniqueness is
-`fundamentalTheorem_normalMPS_translationInvariant_gauge_unique`; lowering
-this per-bond clause to `n ≥ 2L + 1` is tracked as a follow-up to
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+The source's uniqueness clause carries no system-size constraint, and the
+argument here needs none beyond the `n ≥ 2L + 1` of the existence clause
+`fundamentalTheorem_normalMPS`: comparing the two gauge families along the
+spanning length-`L` words leaves the pair of gauges at one bond differing by
+a scalar, with no blocking geometry involved.  The single-gauge form of the
+same clause is
+`fundamentalTheorem_normalMPS_translationInvariant_gauge_unique`.
 
 Source: arXiv:1804.04964, Section 3, first corollary after the theorem
 labelled `normal`, lines 1585--1631 of
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL : 0 < L)
-    (hn : 3 * L ≤ n) (hD : 0 < D) (A B : MPSTensor d D)
+    (hn : 2 * L + 1 ≤ n) (hD : 0 < D) (A B : MPSTensor d D)
     (hA : MPSTensor.IsNBlkInjective A L)
     (hB : MPSTensor.IsNBlkInjective B L) (Z Z' : Fin n → GL (Fin D) ℂ)
     (hZ : ∀ (v : Fin n) (i : Fin d),
@@ -459,100 +460,9 @@ theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL
       B i = ((Z' v)⁻¹ : GL (Fin D) ℂ) * A i * (Z' (v + 1) : GL (Fin D) ℂ)) :
     ∃ c : ℂˣ, ∀ v : Fin n, (Z' v : Matrix (Fin D) (Fin D) ℂ) =
       (c : ℂ) • (Z v : Matrix (Fin D) (Fin D) ℂ) := by
-  have hn3 : 3 ≤ n := by omega
-  have hLn : L < n := by omega
-  -- Convert each per-bond family back into a per-edge family.
-  have hXrel : ∀ v : Fin n,
-      ∀ (η : (ie : IncidentEdge (SimpleGraph.cycleGraph n) v) → Fin D) (σ : Fin d),
-      (cycleTensorOfMPS hn3 B).component v η σ =
-        gaugeVertex (cycleTensorOfMPS hn3 A) (edgeGaugeOfCycleGauge Z) v η σ := by
-    intro v
-    refine (cycleGauge_component_iff_matrix hn3 A B (edgeGaugeOfCycleGauge Z) v).mpr ?_
-    intro i
-    rw [cycleGaugeOfEdgeGauge_edgeGaugeOfCycleGauge hn3 Z v,
-      cycleGaugeOfEdgeGauge_edgeGaugeOfCycleGauge hn3 Z (v + 1)]
-    exact hZ v i
-  have hXrel' : ∀ v : Fin n,
-      ∀ (η : (ie : IncidentEdge (SimpleGraph.cycleGraph n) v) → Fin D) (σ : Fin d),
-      (cycleTensorOfMPS hn3 B).component v η σ =
-        gaugeVertex (cycleTensorOfMPS hn3 A) (edgeGaugeOfCycleGauge Z') v η σ := by
-    intro v
-    refine (cycleGauge_component_iff_matrix hn3 A B (edgeGaugeOfCycleGauge Z') v).mpr ?_
-    intro i
-    rw [cycleGaugeOfEdgeGauge_edgeGaugeOfCycleGauge hn3 Z' v,
-      cycleGaugeOfEdgeGauge_edgeGaugeOfCycleGauge hn3 Z' (v + 1)]
-    exact hZ' v i
-  -- The graph-level uniqueness gives a constant on every edge.
-  have hedge : ∀ e : Edge (SimpleGraph.cycleGraph n), ∃ ce : ℂˣ,
-      (edgeGaugeOfCycleGauge Z' e : Matrix (Fin D) (Fin D) ℂ) =
-        (ce : ℂ) • (edgeGaugeOfCycleGauge Z e : Matrix (Fin D) (Fin D) ℂ) :=
-    fun e => fundamentalTheorem_normalMPS_cycle_gauge_unique hL hn
-      (cycleTensorOfMPS hn3 A) (cycleTensorOfMPS hn3 B)
-      (fun s => regionBlockedTensorInjective_cycleTensorOfMPS hn3 hL hLn hD hA s)
-      (fun s => regionBlockedTensorInjective_cycleTensorOfMPS hn3 hL hLn hD hB s)
-      rfl (fun _ => hD) (fun _ => hD)
-      (edgeGaugeOfCycleGauge Z) (edgeGaugeOfCycleGauge Z')
-      (fun v η σ => hXrel v η σ) (fun v η σ => hXrel' v η σ) e
-  -- Per-bond constants: transpose away from the seam, invert at the seam.
-  have hprop : ∀ v : Fin n, ∃ μ : ℂˣ,
-      (Z' v : Matrix (Fin D) (Fin D) ℂ) = (μ : ℂ) • (Z v : Matrix (Fin D) (Fin D) ℂ) := by
-    intro v
-    by_cases hv0 : v = 0
-    · -- The bond entering site `0` is the seam edge, carrying the inverses.
-      obtain ⟨ce, hce⟩ := hedge (cycleSuccEdge hn3 (v - 1))
-      have hcond : ¬ ((cycleSuccEdge hn3 (v - 1)).1.1 + 1 = (cycleSuccEdge hn3 (v - 1)).1.2) := by
-        have hpair := cycleSuccEdge_val_of_eq hn3 (pred_zero_wrap hn3 hv0)
-        rw [hpair]
-        change ¬ (v - 1 + 1) + 1 = v - 1
-        rw [sub_add_cancel]
-        intro h
-        have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
-        have hval := congrArg Fin.val h
-        rw [Fin.val_add_eq_ite, h1, val_sub_eq_ite, h1] at hval
-        have := v.isLt
-        split_ifs at hval <;> omega
-      have hZ1 : (cycleSuccEdge hn3 (v - 1)).1.1 = v := by
-        rw [cycleSuccEdge_val_of_eq hn3 (pred_zero_wrap hn3 hv0)]
-        change v - 1 + 1 = v
-        rw [sub_add_cancel]
-      rw [edgeGaugeOfCycleGauge, edgeGaugeOfCycleGauge, if_neg hcond, if_neg hcond, hZ1]
-        at hce
-      -- `hce`: the inverses are proportional; invert the proportionality.
-      refine ⟨ce⁻¹, ?_⟩
-      have hZval : ((Z v : Matrix (Fin D) (Fin D) ℂ)) =
-          (ce : ℂ) • (Z' v : Matrix (Fin D) (Fin D) ℂ) := by
-        calc (Z v : Matrix (Fin D) (Fin D) ℂ)
-            = (Z' v : Matrix (Fin D) (Fin D) ℂ) *
-                (((Z' v)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
-                (Z v : Matrix (Fin D) (Fin D) ℂ) := by
-              rw [← Units.val_mul, mul_inv_cancel, Units.val_one, Matrix.one_mul]
-          _ = (Z' v : Matrix (Fin D) (Fin D) ℂ) *
-                ((ce : ℂ) • (((Z v)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) *
-                (Z v : Matrix (Fin D) (Fin D) ℂ) := by rw [← hce]
-          _ = (ce : ℂ) • ((Z' v : Matrix (Fin D) (Fin D) ℂ) *
-                ((((Z v)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
-                  (Z v : Matrix (Fin D) (Fin D) ℂ))) := by
-              rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_assoc]
-          _ = (ce : ℂ) • (Z' v : Matrix (Fin D) (Fin D) ℂ) := by
-              rw [← Units.val_mul, inv_mul_cancel, Units.val_one, Matrix.mul_one]
-      rw [hZval, smul_smul, Units.val_inv_eq_inv_val, inv_mul_cancel₀ (Units.ne_zero ce),
-        one_smul]
-    · -- Away from the seam the bond carries the transposes.
-      obtain ⟨ce, hce⟩ := hedge (cycleSuccEdge hn3 (v - 1))
-      have hpair := cycleSuccEdge_val_of_lt hn3 (pred_val_lt hn3 hv0)
-      have hcond : (cycleSuccEdge hn3 (v - 1)).1.1 + 1 = (cycleSuccEdge hn3 (v - 1)).1.2 := by
-        rw [hpair]
-      rw [edgeGaugeOfCycleGauge, edgeGaugeOfCycleGauge, if_pos hcond, if_pos hcond, hpair]
-        at hce
-      refine ⟨ce, ?_⟩
-      have hce' : (glTranspose (Z' (v - 1 + 1)) : Matrix (Fin D) (Fin D) ℂ) =
-          (ce : ℂ) • (glTranspose (Z (v - 1 + 1)) : Matrix (Fin D) (Fin D) ℂ) := hce
-      rw [glTranspose_coe, glTranspose_coe, sub_add_cancel] at hce'
-      have := congrArg Matrix.transpose hce'
-      rwa [Matrix.transpose_transpose, Matrix.transpose_smul, Matrix.transpose_transpose]
-        at this
   classical
-  choose μ hμ using hprop
+  -- At every bond the two gauges are proportional.
+  choose μ hμ using gaugeFamily_bond_proportional hA hZ hZ'
   -- The relation pins the ratio of consecutive constants against `B ≠ 0`.
   obtain ⟨i₀, hi₀⟩ := MPSTensor.exists_ne_zero_of_isNBlkInjective hL hD hB
   -- The inverse of a proportional gauge is inversely proportional.

--- a/TNLean/PEPS/CycleMPSOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSOverlapCapstone.lean
@@ -26,9 +26,12 @@ translation-invariant MPS on `n ≥ 2L + 1` sites — two matrix tensors, each
   closed-chain corollary; the named matrix-level corollary
   `fundamentalTheorem_normalMPS` delegates to it for its `n ≥ 2L + 1` bound.
 
-The uniqueness clause of the source corollary — the gauge `Z` is unique up
-to a multiplicative constant — needs no system size and is proved here
-as `fundamentalTheorem_normalMPS_translationInvariant_gauge_unique`.
+The uniqueness clause of the source corollary — the gauges are unique up to
+a multiplicative constant — needs no system size and is proved here in both
+forms: `fundamentalTheorem_normalMPS_translationInvariant_gauge_unique` for
+the single gauge, and `gaugeFamily_bond_proportional` for the per-bond
+family, whose bondwise constants the named corollary
+`fundamentalTheorem_normalMPS_gauge_unique` merges into one.
 
 The route specializes the site-dependent closed-chain capstone
 (`TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`) to a constant (translation-
@@ -548,6 +551,41 @@ theorem gl_proportional_of_conj_eq {D : ℕ} (Z Z' : GL (Fin D) ℂ)
   rw [inv_inv, inv_inv] at hflip
   exact ⟨c⁻¹, hflip⟩
 
+/-- **Proportionality from conjugations sharing a bond transport.**  If
+`X⁻¹ W Y = X'⁻¹ W Y'` for every matrix `W`, then `X` and `X'` differ by a
+nonzero scalar: the identity pins the two transports `X⁻¹ Y` and `X'⁻¹ Y'`
+to the same matrix, and cancelling that common transport on the right
+leaves equal conjugations by `X` and by `X'`. -/
+theorem gl_proportional_of_transport_eq {D : ℕ} (X Y X' Y' : GL (Fin D) ℂ)
+    (h : ∀ W : Matrix (Fin D) (Fin D) ℂ,
+      ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * W *
+          (Y : Matrix (Fin D) (Fin D) ℂ) =
+        ((X'⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * W *
+          (Y' : Matrix (Fin D) (Fin D) ℂ)) :
+    ∃ c : ℂˣ, (X' : Matrix (Fin D) (Fin D) ℂ) =
+      (c : ℂ) • (X : Matrix (Fin D) (Fin D) ℂ) := by
+  -- The identity pins the two transports to the same matrix.
+  have hG : ((X⁻¹ * Y : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) =
+      ((X'⁻¹ * Y' : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    have h1 := h 1
+    rw [Matrix.mul_one, Matrix.mul_one] at h1
+    rw [Units.val_mul, Units.val_mul]
+    exact h1
+  have hGu : (X⁻¹ * Y : GL (Fin D) ℂ) = X'⁻¹ * Y' := Units.ext hG
+  refine gl_proportional_of_conj_eq X X' fun W => ?_
+  have hW := h W
+  have hsplit : (Y : Matrix (Fin D) (Fin D) ℂ) =
+      (X : Matrix (Fin D) (Fin D) ℂ) *
+        ((X⁻¹ * Y : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [← Units.val_mul, mul_inv_cancel_left]
+  have hsplit' : (Y' : Matrix (Fin D) (Fin D) ℂ) =
+      (X' : Matrix (Fin D) (Fin D) ℂ) *
+        ((X⁻¹ * Y : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [hGu, ← Units.val_mul, mul_inv_cancel_left]
+  rw [hsplit, hsplit'] at hW
+  simp only [← Matrix.mul_assoc] at hW
+  exact (Units.isUnit (X⁻¹ * Y)).mul_right_cancel hW
+
 /-! ### The single-gauge relation iterated along a word -/
 
 /-- **The single-gauge relation iterated along a word.**  If
@@ -574,6 +612,72 @@ theorem evalWord_eq_smul_conj_of_gauge {d D : ℕ} {A B : MPSTensor d D} {Z : GL
       rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul]
       congr 1
       simp only [Matrix.mul_assoc, Units.mul_inv_cancel_left]
+
+/-! ### The per-bond gauge relation iterated along a word -/
+
+/-- **The per-bond gauge relation iterated along a word.**  If
+`B^i = Z_v⁻¹ A^i Z_{v+1}` at every site of the closed chain, then every word
+product of `B` is the word product of `A` conjugated by the gauges at the
+two ends of the word: `B^{w} = Z_v⁻¹ A^{w} Z_{v+|w|}`, indices on the chain.
+
+Source: arXiv:1804.04964, Section 3 — the step from the per-bond conclusion
+of the first corollary after the theorem labelled `normal` (lines
+1585--1622 of `Papers/1804.04964/paper_normal.tex`) towards its
+translation-invariant form (lines 1624--1661). -/
+theorem evalWord_eq_conj_of_gaugeFamily {n d D : ℕ} [NeZero n] {A B : MPSTensor d D}
+    {Z : Fin n → GL (Fin D) ℂ}
+    (hZ : ∀ (v : Fin n) (i : Fin d),
+      B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ))
+    (w : List (Fin d)) (v : Fin n) :
+    MPSTensor.evalWord B w =
+      ((Z v)⁻¹ : GL (Fin D) ℂ) * MPSTensor.evalWord A w *
+        (Z (v + (w.length : Fin n)) : GL (Fin D) ℂ) := by
+  induction w generalizing v with
+  | nil =>
+      simp only [MPSTensor.evalWord_nil, List.length_nil, Nat.cast_zero, add_zero,
+        Matrix.mul_one, Units.inv_mul]
+  | cons i w ih =>
+      have hidx : v + ((i :: w).length : Fin n) = v + 1 + (w.length : Fin n) := by
+        rw [List.length_cons, Nat.cast_add, Nat.cast_one, ← add_assoc, add_right_comm]
+      rw [MPSTensor.evalWord_cons, MPSTensor.evalWord_cons, hZ v i, ih (v + 1), hidx]
+      simp only [Matrix.mul_assoc, Units.mul_inv_cancel_left]
+
+/-- **Two per-bond gauge families are proportional at every bond.**  If both
+`Z` and `Z'` realize `B^i = Z_v⁻¹ A^i Z_{v+1}` at every site of the closed
+chain, then at every bond `v` the two gauges differ by a nonzero scalar.
+Iterating the two relations along the spanning length-`L` words from the
+common starting site `v` shows that the two transports from `v` to `v + L`
+agree on the full matrix algebra; the empty word pins the two bond
+transports `Z_v⁻¹ Z_{v+L} = Z'^{-1}_v Z'_{v+L}`, and the centralizer of the
+full matrix algebra is the scalars.  No system size is needed.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, line 1621 of `Papers/1804.04964/paper_normal.tex`: "the
+gauges `Z_i` are unique up to a multiplicative constant". -/
+theorem gaugeFamily_bond_proportional {n L d D : ℕ} [NeZero n] {A B : MPSTensor d D}
+    (hA : MPSTensor.IsNBlkInjective A L) {Z Z' : Fin n → GL (Fin D) ℂ}
+    (hZ : ∀ (v : Fin n) (i : Fin d),
+      B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ))
+    (hZ' : ∀ (v : Fin n) (i : Fin d),
+      B i = ((Z' v)⁻¹ : GL (Fin D) ℂ) * A i * (Z' (v + 1) : GL (Fin D) ℂ))
+    (v : Fin n) :
+    ∃ c : ℂˣ, (Z' v : Matrix (Fin D) (Fin D) ℂ) =
+      (c : ℂ) • (Z v : Matrix (Fin D) (Fin D) ℂ) := by
+  have hAspan : Submodule.span ℂ (Set.range fun σ : Fin L → Fin d =>
+      MPSTensor.evalWord A (List.ofFn σ)) = ⊤ := hA
+  -- The two iterated relations agree on the spanning word products, hence
+  -- on every matrix.
+  have hE : ∀ M : Matrix (Fin D) (Fin D) ℂ,
+      ((Z v)⁻¹ : GL (Fin D) ℂ) * M * (Z (v + (L : Fin n)) : GL (Fin D) ℂ) =
+        ((Z' v)⁻¹ : GL (Fin D) ℂ) * M * (Z' (v + (L : Fin n)) : GL (Fin D) ℂ) := by
+    refine conj_eq_conj_of_span hAspan ?_
+    rintro M ⟨σ, rfl⟩
+    have h1 := evalWord_eq_conj_of_gaugeFamily hZ (List.ofFn σ) v
+    have h2 := evalWord_eq_conj_of_gaugeFamily hZ' (List.ofFn σ) v
+    rw [List.length_ofFn] at h1 h2
+    exact h1.symm.trans h2
+  exact gl_proportional_of_transport_eq (Z v) (Z (v + (L : Fin n))) (Z' v)
+    (Z' (v + (L : Fin n))) hE
 
 /-! ### The strengthened closed-chain corollaries -/
 

--- a/TNLean/PEPS/CycleMPSOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSOverlapCapstone.lean
@@ -647,8 +647,8 @@ theorem evalWord_eq_conj_of_gaugeFamily {n d D : ℕ} [NeZero n] {A B : MPSTenso
 chain, then at every bond `v` the two gauges differ by a nonzero scalar.
 Iterating the two relations along the spanning length-`L` words from the
 common starting site `v` shows that the two transports from `v` to `v + L`
-agree on the full matrix algebra; the empty word pins the two bond
-transports `Z_v⁻¹ Z_{v+L} = Z'^{-1}_v Z'_{v+L}`, and the centralizer of the
+agree on the full matrix algebra; taking the identity there pins the two
+bond transports `Z_v⁻¹ Z_{v+L} = Z'^{-1}_v Z'_{v+L}`, and the centralizer of the
 full matrix algebra is the scalars.  No system size is needed.
 
 Source: arXiv:1804.04964, Section 3, first corollary after the theorem
@@ -816,8 +816,9 @@ Two single-gauge realizations `B^i = λ · Z⁻¹ A^i Z` and
 `B^i = λ' · Z'⁻¹ A^i Z'` of the same pair of `L`-block injective tensors
 have proportional gauges: there is a nonzero scalar `c` with `Z' = c · Z`.
 Iterating each relation along the spanning length-`L` words shows that the
-two conjugations of the full matrix algebra agree — the empty word pins
-`λ^L = λ'^L`, and `λ ≠ 0` because `B` is nonzero — so the centralizer step
+two conjugations of the full matrix algebra agree — taking the identity
+there pins `λ^L = λ'^L`, and `λ ≠ 0` because `B` is nonzero — so the
+centralizer step
 applies.  No system size and no root-of-unity condition on `λ`, `λ'` are
 needed.
 
@@ -854,7 +855,7 @@ theorem fundamentalTheorem_normalMPS_translationInvariant_gauge_unique {L d D : 
     rw [List.length_ofFn] at h1 h2
     simp only [Matrix.smul_mul]
     exact h1.symm.trans h2
-  -- The empty word pins the two scaling factors to the same value.
+  -- Taking the identity pins the two scaling factors to the same value.
   have hLL : lam ^ L = lam' ^ L := by
     have h1 := hE 1
     simp only [Matrix.mul_one, Matrix.smul_mul] at h1

--- a/TNLean/PEPS/CycleMPSTranslationInvariant.lean
+++ b/TNLean/PEPS/CycleMPSTranslationInvariant.lean
@@ -49,35 +49,6 @@ open scoped Fin.NatCast
 namespace TNLean
 namespace PEPS
 
-/-! ### Iterating the per-bond relation along a word -/
-
-/-- **The per-bond gauge relation iterated along a word.**  If
-`B^i = Z_v⁻¹ A^i Z_{v+1}` at every site of the closed chain, then every word
-product of `B` is the word product of `A` conjugated by the gauges at the
-two ends of the word: `B^{w} = Z_v⁻¹ A^{w} Z_{v+|w|}`, indices on the chain.
-
-Source: arXiv:1804.04964, Section 3 — the step from the per-bond conclusion
-of the first corollary after the theorem labelled `normal` (lines
-1585--1622 of `Papers/1804.04964/paper_normal.tex`) towards its
-translation-invariant form (lines 1624--1661). -/
-theorem evalWord_eq_conj_of_gaugeFamily {n d D : ℕ} [NeZero n] {A B : MPSTensor d D}
-    {Z : Fin n → GL (Fin D) ℂ}
-    (hZ : ∀ (v : Fin n) (i : Fin d),
-      B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ))
-    (w : List (Fin d)) (v : Fin n) :
-    MPSTensor.evalWord B w =
-      ((Z v)⁻¹ : GL (Fin D) ℂ) * MPSTensor.evalWord A w *
-        (Z (v + (w.length : Fin n)) : GL (Fin D) ℂ) := by
-  induction w generalizing v with
-  | nil =>
-      simp only [MPSTensor.evalWord_nil, List.length_nil, Nat.cast_zero, add_zero,
-        Matrix.mul_one, Units.inv_mul]
-  | cons i w ih =>
-      have hidx : v + ((i :: w).length : Fin n) = v + 1 + (w.length : Fin n) := by
-        rw [List.length_cons, Nat.cast_add, Nat.cast_one, ← add_assoc, add_right_comm]
-      rw [MPSTensor.evalWord_cons, MPSTensor.evalWord_cons, hZ v i, ih (v + 1), hidx]
-      simp only [Matrix.mul_assoc, Units.mul_inv_cancel_left]
-
 /-! ### Collapsing the per-bond family -/
 
 /-- **Consecutive per-bond gauges are proportional.**  For an `L`-block
@@ -112,34 +83,8 @@ theorem gaugeFamily_succ_proportional {n L d D : ℕ} [NeZero n] {A B : MPSTenso
     have h2 := evalWord_eq_conj_of_gaugeFamily hZ (List.ofFn σ) (v + 1)
     rw [List.length_ofFn] at h1 h2
     exact h1.symm.trans h2
-  -- The empty word pins the two bond transports to the same matrix.
-  have hG : (((Z v)⁻¹ * Z (v + (L : Fin n)) : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) =
-      (((Z (v + 1))⁻¹ * Z (v + 1 + (L : Fin n)) : GL (Fin D) ℂ) :
-        Matrix (Fin D) (Fin D) ℂ) := by
-    have h1 := hE 1
-    rw [Matrix.mul_one, Matrix.mul_one] at h1
-    rw [Units.val_mul, Units.val_mul]
-    exact h1
-  have hGu : ((Z v)⁻¹ * Z (v + (L : Fin n)) : GL (Fin D) ℂ) =
-      (Z (v + 1))⁻¹ * Z (v + 1 + (L : Fin n)) := Units.ext hG
-  -- Cancelling the common bond transport leaves equal conjugations.
-  have hconj : ∀ W : Matrix (Fin D) (Fin D) ℂ,
-      ((Z v)⁻¹ : GL (Fin D) ℂ) * W * (Z v : Matrix (Fin D) (Fin D) ℂ) =
-        ((Z (v + 1))⁻¹ : GL (Fin D) ℂ) * W * (Z (v + 1) : Matrix (Fin D) (Fin D) ℂ) := by
-    intro W
-    have h := hE W
-    have hsplit : (Z (v + (L : Fin n)) : Matrix (Fin D) (Fin D) ℂ) =
-        (Z v : Matrix (Fin D) (Fin D) ℂ) *
-          (((Z v)⁻¹ * Z (v + (L : Fin n)) : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
-      rw [← Units.val_mul, mul_inv_cancel_left]
-    have hsplit' : (Z (v + 1 + (L : Fin n)) : Matrix (Fin D) (Fin D) ℂ) =
-        (Z (v + 1) : Matrix (Fin D) (Fin D) ℂ) *
-          (((Z v)⁻¹ * Z (v + (L : Fin n)) : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
-      rw [hGu, ← Units.val_mul, mul_inv_cancel_left]
-    rw [hsplit, hsplit'] at h
-    simp only [← Matrix.mul_assoc] at h
-    exact (Units.isUnit ((Z v)⁻¹ * Z (v + (L : Fin n)))).mul_right_cancel h
-  exact gl_proportional_of_conj_eq (Z v) (Z (v + 1)) hconj
+  exact gl_proportional_of_transport_eq (Z v) (Z (v + (L : Fin n))) (Z (v + 1))
+    (Z (v + 1 + (L : Fin n))) hE
 
 /-! ### The translation-invariant corollary -/
 

--- a/TNLean/PEPS/CycleMPSTranslationInvariant.lean
+++ b/TNLean/PEPS/CycleMPSTranslationInvariant.lean
@@ -28,7 +28,7 @@ product of `B` by the gauges at the two ends of the word
 starting sites `v` and `v + 1` over the spanning length-`L` word products of
 `A` shows that the two conjugations agree on the full matrix algebra, so
 consecutive gauges differ by a nonzero scalar
-(`gaugeFamily_succ_proportional`): the empty word pins the two bond
+(`gaugeFamily_succ_proportional`): taking the identity pins the two bond
 transports `Z_v⁻¹ Z_{v+L} = Z_{v+1}⁻¹ Z_{v+1+L}` to the same matrix, and the
 centralizer of the full matrix algebra is the scalars.  The same-state
 relation pins consecutive scalars against the nonzero tensor `B`, so a
@@ -56,8 +56,8 @@ injective tensor `A`, the per-bond relation `B^i = Z_v⁻¹ A^i Z_{v+1}` at
 every site forces consecutive gauges to differ by a nonzero scalar:
 iterating the relation along the spanning length-`L` words from the
 starting sites `v` and `v + 1` shows that conjugation by `Z_v` and by
-`Z_{v+1}` agree on the full matrix algebra — the empty word pins the two
-bond transports `Z_v⁻¹ Z_{v+L} = Z_{v+1}⁻¹ Z_{v+1+L}` to the same matrix —
+`Z_{v+1}` agree on the full matrix algebra — taking the identity pins the
+two bond transports `Z_v⁻¹ Z_{v+L} = Z_{v+1}⁻¹ Z_{v+1+L}` to the same matrix —
 and the centralizer of the full matrix algebra is the scalars.
 
 Source: arXiv:1804.04964, Section 3, the corollary for TI MPS, lines

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_mps.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_mps.tex
@@ -258,14 +258,43 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     gauge family directly.
 \end{proof}
 
+\begin{lemma}[Two per-bond gauge families are proportional at every bond]%
+    \label{lem:gaugeFamily_bond_proportional}
+    \lean{TNLean.PEPS.gaugeFamily_bond_proportional}
+    \leanok
+    \uses{def:l_blk_injective, def:eval_word}
+    Let $n$ be positive, let $A$ and $B$ be tensors of $D \times D$ matrices
+    over physical dimension $d$ with $A$ being $L$-block injective, and let
+    $Z_v$ and $Z'_v$ ($v = 1, \ldots, n$, $n + 1 \equiv 1$) be two families of
+    invertible matrices with $B^i = Z_v^{-1} A^i Z_{v+1}$ and
+    $B^i = Z'^{-1}_v A^i Z'_{v+1}$ at every site $v$ and every $i$. Then for
+    every bond $v$ there is a nonzero scalar $c$ with $Z'_v = c\,Z_v$. No
+    condition on the system size is needed.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:eval_word}
+    Iterating each relation along a word $x$ of length $L$ from the starting
+    site $v$ gives
+    $B^{x_1} \cdots B^{x_L} = Z_v^{-1} A^{x_1} \cdots A^{x_L} Z_{v+L}$ and
+    the same with $Z'$. Since the word products
+    $A^{x_1} \cdots A^{x_L}$ span the full matrix algebra by $L$-block
+    injectivity, the comparison extends linearly to every matrix $W$:
+    $Z_v^{-1} W Z_{v+L} = Z'^{-1}_v W Z'_{v+L}$. The empty word ($W$ the
+    identity) pins the two bond transports
+    $Z_v^{-1} Z_{v+L} = Z'^{-1}_v Z'_{v+L}$ to the same invertible matrix;
+    cancelling it leaves $Z_v^{-1} W Z_v = Z'^{-1}_v W Z'_v$ for every $W$,
+    so $Z'_v Z_v^{-1}$ commutes with the full matrix algebra, hence is a
+    scalar, nonzero by invertibility.
+\end{proof}
+
 \begin{corollary}[Uniqueness of the per-bond gauges up to one constant,
         matrix form]%
     \label{cor:fundamentalTheorem_normalMPS_gauge_unique}
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_gauge_unique}
     \leanok
     \uses{def:l_blk_injective}
-    Let $n$ be positive, let $0 < L$ with $3L \le n$, and let $A$ and $B$ be
-    tensors of $D \times D$ matrices with $D>0$, each $L$-block injective.
+    Let $n$ be positive, let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$
+    be tensors of $D \times D$ matrices with $D>0$, each $L$-block injective.
     If two
     families $Z$ and $Z'$ of invertible matrices on the bonds of the closed
     chain both satisfy $B^i = Z_v^{-1} A^i Z_{v+1}$ at every site, then they
@@ -276,19 +305,12 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     tensor. Equality of the two states is not needed.
 \end{corollary}
 \begin{proof}\leanok
-    \uses{cor:fundamentalTheorem_normalMPS_cycle_gauge_unique,
-        lem:regionBlockedTensorInjective_cycleTensorOfMPS,
-        def:cycleTensorOfMPS, def:gaugeVertex}
-    Each per-bond family converts back into a per-edge family - the
-    transpose of the bond gauge away from the seam, the inverse on the seam
-    edge - realizing the per-site gauge identity between the cycle tensors,
-    so the closed-chain uniqueness clause
-    (Corollary~\ref{cor:fundamentalTheorem_normalMPS_cycle_gauge_unique})
-    gives a constant on every edge; undoing the conversion gives a constant
-    per bond. The relation $B^i = Z_v^{-1} A^i Z_{v+1}$ for both families
-    forces the scalar $\mu_v^{-1}\mu_{v+1}$ to fix the nonzero tensor $B$,
-    so consecutive constants agree, and going around the cycle merges them
-    into one.
+    \uses{lem:gaugeFamily_bond_proportional}
+    At every bond the two gauges differ by a nonzero scalar $\mu_v$
+    (Lemma~\ref{lem:gaugeFamily_bond_proportional}). The relation
+    $B^i = Z_v^{-1} A^i Z_{v+1}$ for both families forces the scalar
+    $\mu_v^{-1}\mu_{v+1}$ to fix the nonzero tensor $B$, so consecutive
+    constants agree, and going around the cycle merges them into one.
 \end{proof}
 
 \begin{lemma}[Consecutive per-bond gauges are proportional]%

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_mps.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone_normal_mps.tex
@@ -279,8 +279,8 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     the same with $Z'$. Since the word products
     $A^{x_1} \cdots A^{x_L}$ span the full matrix algebra by $L$-block
     injectivity, the comparison extends linearly to every matrix $W$:
-    $Z_v^{-1} W Z_{v+L} = Z'^{-1}_v W Z'_{v+L}$. The empty word ($W$ the
-    identity) pins the two bond transports
+    $Z_v^{-1} W Z_{v+L} = Z'^{-1}_v W Z'_{v+L}$. Taking $W$ to be the identity
+    in this extended relation pins the two bond transports
     $Z_v^{-1} Z_{v+L} = Z'^{-1}_v Z'_{v+L}$ to the same invertible matrix;
     cancelling it leaves $Z_v^{-1} W Z_v = Z'^{-1}_v W Z'_v$ for every $W$,
     so $Z'_v Z_v^{-1}$ commutes with the full matrix algebra, hence is a
@@ -332,8 +332,8 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     Comparing the iterations from $v$ and from $v + 1$ over the word
     products $A^{x_1} \cdots A^{x_L}$, which span the full matrix algebra by
     $L$-block injectivity, the comparison extends linearly to every matrix
-    $W$: $Z_v^{-1} W Z_{v+L} = Z_{v+1}^{-1} W Z_{v+1+L}$. The empty word
-    ($W$ the identity) pins the two bond transports
+    $W$: $Z_v^{-1} W Z_{v+L} = Z_{v+1}^{-1} W Z_{v+1+L}$. Taking $W$ to be the
+    identity in this extended relation pins the two bond transports
     $Z_v^{-1} Z_{v+L} = Z_{v+1}^{-1} Z_{v+1+L}$ to the same invertible
     matrix; cancelling it leaves $Z_v^{-1} W Z_v = Z_{v+1}^{-1} W Z_{v+1}$
     for every $W$, so $Z_{v+1} Z_v^{-1}$ commutes with the full matrix

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2526,10 +2526,10 @@ clause now carries the optimal $n \ge 2L + 1$ of the source's alternative
 proof: \path{fundamentalTheorem_normalMPS} delegates to the
 overlapping-window corollary \path{fundamentalTheorem_normalMPS_of_overlap}
 (documented in the section ``The strengthening to $n \ge 2L+1$ via
-overlapping windows'' below).  The uniqueness clause keeps the $n \ge 3L$
-of the graph-level per-edge route it invokes; lowering it to $n \ge 2L + 1$
-is the remaining follow-up for the closed-chain corollary, the source's
-uniqueness needing no system size.  The unpacking
+overlapping windows'' below).  The uniqueness clause carries the same
+$n \ge 2L + 1$: the source's uniqueness needs no system size of its own, and
+the argument that delivers it needs nothing beyond the size that produced
+the two gauge families.  The unpacking
 meets the same seam convention as on the torus: the ordered-edge normal
 form stores the wraparound edge with its endpoints swapped, so the per-bond
 gauge is the transpose of the per-edge matrix away from the seam and its
@@ -2538,8 +2538,13 @@ component identity is equivalent to the conjugation relation through the
 two-bond factorization of the gauge action
 (\path{gaugeVertex_cycleTensorOfMPS},
 \path{cycleGauge_component_iff_matrix}).  The single-constant uniqueness
-goes through the graph-level per-edge clause and a merge: the conjugation
-relation for both families fixes the nonzero tensor $B$ by the scalar
+compares the two families directly and then merges: iterating both
+conjugation relations along the spanning length-$L$ word products of $A$
+makes the transports from a bond to its $L$-th successor agree on the whole
+matrix algebra, so the two gauges at every bond differ by a scalar
+(\path{gaugeFamily_bond_proportional}, blueprint
+\path{lem:gaugeFamily_bond_proportional}), and the conjugation relation for
+both families fixes the nonzero tensor $B$ by the scalar
 $\mu_v^{-1}\mu_{v+1}$, so consecutive per-bond constants agree around the
 cycle.  The matrix and site-dependent closed-chain statements now assume
 positive bond dimension, matching the source's tensor-network setting and
@@ -2805,10 +2810,13 @@ blocking route.  The graph-level closed-chain corollary
 of its three-disjoint-arc cover, which the overlapping-window apparatus
 replaces rather than reuses; the matrix-level existence clauses no longer
 route through it.  The per-bond uniqueness clause
-\leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_gauge_unique} still invokes
-the graph-level per-edge uniqueness and so keeps $n \ge 3L$; lowering it to
-$n \ge 2L + 1$ is the remaining follow-up, the source's uniqueness needing
-no system size.  The translation-invariant single-gauge uniqueness clause of
+\leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_gauge_unique} no longer
+invokes the graph-level per-edge uniqueness: comparing the two gauge
+families along the spanning length-$L$ words proves them proportional at
+every bond (\leanid{TNLean.PEPS.gaugeFamily_bond_proportional}) with no
+condition on the system size, so the clause carries the same $n \ge 2L + 1$
+as the existence clause that produces the families.  The
+translation-invariant single-gauge uniqueness clause of
 the source corollary needs no system size and was already delivered by
 \leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}.
 With this, every numbered claim of the source's Section \path{normal_alt}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2820,15 +2820,14 @@ translation-invariant single-gauge uniqueness clause of
 the source corollary needs no system size and was already delivered by
 \leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}.
 With this, every numbered claim of the source's Section \path{normal_alt}
-for matrix-product states is formalized for one site-independent tensor;
-the site-dependent form of Lemma~5 and the $2L+1$ strengthening for
-two-dimensional tensor networks (the corollary at lines 2297--2318) remain
-open.
+for matrix-product states is formalized for one site-independent tensor.
+The $2L+1$ strengthening for two-dimensional tensor networks (the corollary
+at lines 2297--2318) remains open.
 
 \section*{The site-dependent form of Lemma 5}
 
-The site-dependent form of Lemma~5, recorded as open at the end of the
-previous section, is now formalized, and the site-independent statements
+The site-dependent form of Lemma~5 is formalized, and the site-independent
+statements
 landed there are its constant specializations.  The development works with
 the existing site-dependent chains (\leanid{MPSChainTensor}, one tensor per
 site of the closed chain, \path{TNLean/MPS/Chain/Defs.lean}) and adds the


### PR DESCRIPTION
Closes #3478.

## The source

`Papers/1804.04964/paper_normal.tex`, the first corollary after the theorem
labelled `normal` (non-translation-invariant form). Line 1621:

> Moreover, the gauges $Z_i$ are unique up to a multiplicative constant.

Line 1623 strengthens the whole corollary — uniqueness included — to
$n \ge 2L+1$ via the argument of Section `normal_alt`. The uniqueness clause
carries no size condition of its own, so the previous `3 * L ≤ n` appears
nowhere in the source: under the CLAUDE.md faithfulness rule the Lean theorem
was a strictly weaker, non-source statement. This restores it.

## Signature

Before:

```lean
theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL : 0 < L)
    (hn : 3 * L ≤ n) (hD : 0 < D) (A B : MPSTensor d D)
    (hA : MPSTensor.IsNBlkInjective A L) (hB : MPSTensor.IsNBlkInjective B L)
    (Z Z' : Fin n → GL (Fin D) ℂ)
    (hZ : ∀ (v : Fin n) (i : Fin d),
      B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ))
    (hZ' : ∀ (v : Fin n) (i : Fin d),
      B i = ((Z' v)⁻¹ : GL (Fin D) ℂ) * A i * (Z' (v + 1) : GL (Fin D) ℂ)) :
    ∃ c : ℂˣ, ∀ v : Fin n, (Z' v : Matrix (Fin D) (Fin D) ℂ) =
      (c : ℂ) • (Z v : Matrix (Fin D) (Fin D) ℂ)
```

After — only `hn` changes; the conclusion and every other hypothesis are
untouched:

```lean
theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL : 0 < L)
    (hn : 2 * L + 1 ≤ n) (hD : 0 < D) (A B : MPSTensor d D)
    ...
```

The bound now matches the existence clause `fundamentalTheorem_normalMPS`,
which already carries `2 * L + 1 ≤ n`.

## The argument

The paper's own "compare the two ends" argument, with no blocking geometry.
From the two families, `Z_v⁻¹ A^i Z_{v+1} = Z'^{-1}_v A^i Z'_{v+1}`. Iterating
both relations along a word of length `L` from the same starting bond `v`
(`evalWord_eq_conj_of_gaugeFamily`) and spanning with `L`-block injectivity
(`conj_eq_conj_of_span`) gives `Z_v⁻¹ W Z_{v+L} = Z'^{-1}_v W Z'_{v+L}` for
every matrix `W`. The empty word pins the two bond transports
`Z_v⁻¹ Z_{v+L} = Z'^{-1}_v Z'_{v+L}` to the same invertible matrix; cancelling
it leaves equal conjugations by `Z_v` and by `Z'_v`, so `Z'_v Z_v⁻¹` commutes
with the full matrix algebra and is a scalar (`gl_proportional_of_conj_eq`).
This is the new lemma `gaugeFamily_bond_proportional`, which needs no
condition on the system size at all. The old tail of the proof then merges the
bondwise scalars: `μ_v⁻¹ μ_{v+1}` fixes the nonzero tensor `B`
(`MPSTensor.exists_ne_zero_of_isNBlkInjective`), so consecutive constants agree
around the cycle.

The transport-cancellation step is shared with `gaugeFamily_succ_proportional`,
which proved it inline; it is factored out as
`gl_proportional_of_transport_eq` and both callers use it. The word iteration
`evalWord_eq_conj_of_gaugeFamily` moves from
`TNLean/PEPS/CycleMPSTranslationInvariant.lean` to
`TNLean/PEPS/CycleMPSOverlapCapstone.lean` so both users can reach it; the
statement is unchanged.

The graph-level detour is only dropped, not deleted:
`fundamentalTheorem_normalMPS_cycle_gauge_unique` and the per-edge/per-bond
conversion lemmas (`edgeGaugeOfCycleGauge`, `cycleGauge_component_iff_matrix`)
keep their statements and blueprint entries.

## Blueprint and paper-gap note

* `cor:fundamentalTheorem_normalMPS_gauge_unique` now reads `2L + 1 \le n`,
  keeping `\lean{}`/`\leanok`; its proof cites the new
  `lem:gaugeFamily_bond_proportional` instead of the graph-level clause.
* `docs/paper-gaps/peps_normal_ft_section3_route.tex` is amended, not deleted:
  it documents the whole Section 3 route, of which the `3L` uniqueness bound
  was one open item. Both passages recording that follow-up are rewritten to
  state the clause now carries `n ≥ 2L + 1`. No open item about this bound
  remains in the note.

## Verification

* `lake env lean` on each changed file — clean, no warnings:
  `TNLean/PEPS/CycleMPSOverlapCapstone.lean`,
  `TNLean/PEPS/CycleMPSFundamentalTheorem.lean`,
  `TNLean/PEPS/CycleMPSTranslationInvariant.lean`.
* `lake build TNLean.PEPS` — 3372 jobs, completed successfully (the only
  importer of the changed modules is `TNLean/PEPS.lean`).
* `rg -n "sorry|axiom|native_decide|maxHeartbeats"` on the changed files —
  no hits.
* `python3 scripts/blueprint_lean_sync.py --root . --ci` — blueprint and Lean
  in sync, 7383/7383.
* Lines within 100 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176U7wiKWaxFAKBHv3Jgjz3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal mathematics and documentation only; no runtime or security-sensitive code. Proof structure is simplified and the stated bound is strengthened toward the paper.
> 
> **Overview**
> **`fundamentalTheorem_normalMPS_gauge_unique`** now assumes **`2 * L + 1 ≤ n`** (aligned with the existence clause) instead of **`3 * L ≤ n`**. The proof no longer converts per-bond gauges to cycle-graph edge gauges and calls **`fundamentalTheorem_normalMPS_cycle_gauge_unique`**; it calls **`gaugeFamily_bond_proportional`** and keeps the existing merge of bondwise scalars around the cycle.
> 
> **`CycleMPSOverlapCapstone.lean`** adds **`gl_proportional_of_transport_eq`**, moves **`evalWord_eq_conj_of_gaugeFamily`** here from **`CycleMPSTranslationInvariant.lean`**, and proves **`gaugeFamily_bond_proportional`** by iterating both gauge relations along length-`L` words and spanning with **`L`**-block injectivity. **`gaugeFamily_succ_proportional`** is refactored to use the shared transport lemma.
> 
> Blueprint (**`ch24_peps_ft_normal_capstone_normal_mps.tex`**) and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** are updated to document the new bound and direct uniqueness route; graph-level cycle lemmas remain but are not used for this corollary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54fb3db92e6035f7d7a27062a4228f1ad8eca2b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->