### PR TITLE
feat(Channel): decompose rectangular linear maps into completely positive maps

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -11,13 +11,14 @@ import TNLean.Algebra.MatrixAux
 # Hermitian matrix extremal eigenvalues
 
 This file provides lemmas for Hermitian complex matrices over an arbitrary finite
-index type: decomposition into Hermitian components, rank-one positive
+index type: decomposition into Hermitian components, the Jordan decomposition of
+a Hermitian matrix into positive and negative parts, rank-one positive
 semidefinite criteria, extremal eigenvalues, scalar-shift spectral formulae, and
 commutation transport from a power of a positive semidefinite matrix to the
 matrix itself.
 -/
 
-open scoped Matrix ComplexOrder InnerProductSpace
+open scoped Matrix ComplexOrder InnerProductSpace MatrixOrder
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
@@ -51,6 +52,38 @@ theorem exists_isHermitian_decomposition (X : Matrix n n ℂ) :
       rw [mul_assoc, Complex.I_mul_I]
       ring]
   module
+
+omit [Fintype n] [DecidableEq n] in
+/-- **Hermitian and anti-Hermitian parts**: every square complex matrix is
+`H₁ + i H₂` with `H₁` and `H₂` Hermitian. This is `exists_isHermitian_decomposition`
+rescaled so that the witnesses are Wolf's, `H₁ = (τ + τ†)/2` and
+`H₂ = (i τ† - i τ)/2`; `Notes/WolfNoteTexSource/ch02_representations.tex`,
+line 144. -/
+theorem exists_isHermitian_eq_add_smul_I (τ : Matrix n n ℂ) :
+    ∃ H₁ H₂ : Matrix n n ℂ, H₁.IsHermitian ∧ H₂.IsHermitian ∧
+      τ = H₁ + Complex.I • H₂ := by
+  obtain ⟨H₁, H₂, -, -, hH₁, hH₂, hτ⟩ := exists_isHermitian_decomposition τ
+  have hhalf : IsSelfAdjoint ((2⁻¹ : ℂ)) := by
+    rw [isSelfAdjoint_iff]
+    norm_num
+  refine ⟨(2⁻¹ : ℂ) • H₁, (-2⁻¹ : ℂ) • H₂, hH₁.smul hhalf, hH₂.smul hhalf.neg, ?_⟩
+  rw [hτ]
+  module
+
+omit [Fintype n] [DecidableEq n] in
+/-- **Jordan decomposition**: a Hermitian matrix is the difference of two
+positive semidefinite matrices, namely its positive and negative parts. This is
+the spectral decomposition step of Wolf Chapter 2, Proposition 2.2 (decomposition
+into completely positive maps);
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 146–148. -/
+theorem IsHermitian.exists_eq_sub_posSemidef [Finite n] {H : Matrix n n ℂ}
+    (hH : H.IsHermitian) :
+    ∃ P N : Matrix n n ℂ, P.PosSemidef ∧ N.PosSemidef ∧ H = P - N := by
+  classical
+  cases nonempty_fintype n
+  exact ⟨H⁺, H⁻, Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg H),
+    Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg H),
+    (CFC.posPart_sub_negPart H (isSelfAdjoint_iff.mpr hH)).symm⟩
 
 /-! ## Rank-one diagonal positivity criteria -/
 

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.Channel.Basic
 import TNLean.Channel.BreuerHallIndecomposable
 import TNLean.Channel.BreuerHallMap
+import TNLean.Channel.CPDecomposition
 import TNLean.Channel.ChoiDoeblin
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.ChoiRectangular

--- a/TNLean/Channel/CPDecomposition.lean
+++ b/TNLean/Channel/CPDecomposition.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.ChoiRectangular
+
+/-!
+# Decomposition of linear maps into completely positive maps
+
+Every linear map `T : M_d(ℂ) → M_{d'}(ℂ)` is a complex linear combination of
+four completely positive maps, and a Hermitian map — one satisfying
+`T(B†) = T(B)†` for every `B` — is a real linear combination of two of them.
+This is the proposition "Decomposition into completely positive maps" of
+Wolf Chapter 2, `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 130–149.
+
+The proof is Wolf's. Because the correspondence `T ↔ τ` of Proposition 2.1 is
+one-to-one and linear, it suffices to decompose the Choi matrix. Wolf's display
+
+  `τ = (τ + τ†)/2 + i (i τ† - i τ)/2`
+
+writes `τ` as a complex linear combination of two Hermitian matrices, and the
+spectral decomposition writes each Hermitian matrix as a real linear
+combination of two positive semidefinite ones. Every positive semidefinite
+operator on `ℂ^{d'} ⊗ ℂ^d` is the Choi matrix of a completely positive map, so
+transporting the four positive semidefinite pieces back through the
+correspondence produces the four completely positive maps.
+
+## Main results
+
+* `Matrix.IsHermitian.exists_eq_sub_posSemidef` — the Jordan decomposition of a
+  Hermitian matrix into a difference of two positive semidefinite matrices.
+* `Matrix.exists_isHermitian_eq_add_smul_I` — Wolf's display: every square
+  matrix is `H₁ + i H₂` with `H₁` and `H₂` Hermitian.
+* `ChoiRectangular.exists_four_isKrausCP_complexCombination` — every linear map
+  `M_d(ℂ) → M_{d'}(ℂ)` is a complex linear combination of four completely
+  positive maps.
+* `ChoiRectangular.exists_two_isKrausCP_realCombination_of_hermiticityPreserving`
+  — a Hermitian map is a real linear combination of two completely positive
+  maps.
+
+## Implementation notes
+
+Complete positivity is the rectangular Kraus predicate `IsKrausCP`, the notion
+used in the complete-positivity clause of Wolf Proposition 2.1 and in
+Wolf Theorem 2.1. No hypothesis is placed on the dimensions: for `d = 0` the
+input algebra has a single element, every linear map out of it vanishes, and
+the empty combination already witnesses the statement.
+
+The square sandwich polarization `WolfProps.cp_decomposition_of_sandwich_sum`
+proves a different statement: it decomposes a map already presented in the
+form `X ↦ ∑ᵢ Aᵢ X Bᵢ†` on a single matrix algebra.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2,
+  Proposition "Decomposition into completely positive maps"][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix Finset
+
+namespace Matrix
+
+variable {n : Type*}
+
+/-- **Jordan decomposition**: a Hermitian matrix is the difference of two
+positive semidefinite matrices, namely its positive and negative parts. This is
+the spectral decomposition step of Wolf Chapter 2, proposition "Decomposition
+into completely positive maps"; `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 146–148. -/
+theorem IsHermitian.exists_eq_sub_posSemidef [Finite n] {H : Matrix n n ℂ}
+    (hH : H.IsHermitian) :
+    ∃ P N : Matrix n n ℂ, P.PosSemidef ∧ N.PosSemidef ∧ H = P - N := by
+  classical
+  cases nonempty_fintype n
+  exact ⟨H⁺, H⁻, Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg H),
+    Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg H),
+    (CFC.posPart_sub_negPart H (isSelfAdjoint_iff.mpr hH)).symm⟩
+
+/-- **Hermitian and anti-Hermitian parts**: every square complex matrix is
+`H₁ + i H₂` with `H₁` and `H₂` Hermitian. The witnesses are Wolf's,
+`H₁ = (τ + τ†)/2` and `H₂ = (i τ† - i τ)/2`;
+`Notes/WolfNoteTexSource/ch02_representations.tex`, line 144. -/
+theorem exists_isHermitian_eq_add_smul_I (τ : Matrix n n ℂ) :
+    ∃ H₁ H₂ : Matrix n n ℂ, H₁.IsHermitian ∧ H₂.IsHermitian ∧
+      τ = H₁ + Complex.I • H₂ := by
+  refine ⟨(2 : ℂ)⁻¹ • (τ + τᴴ), (2 : ℂ)⁻¹ • (Complex.I • τᴴ - Complex.I • τ),
+    ?_, ?_, ?_⟩
+  · change ((2 : ℂ)⁻¹ • (τ + τᴴ))ᴴ = _
+    rw [← star_eq_conjTranspose, ← star_eq_conjTranspose]
+    simp [star_smul, add_comm]
+  · change ((2 : ℂ)⁻¹ • (Complex.I • τᴴ - Complex.I • τ))ᴴ = _
+    simp only [← star_eq_conjTranspose, star_smul, star_sub, star_star, RCLike.star_def,
+      Complex.conj_I, map_inv₀, map_ofNat]
+    module
+  · have hI : Complex.I * Complex.I = -1 := Complex.I_mul_I
+    match_scalars
+    · linear_combination ((1 : ℂ) / 2) * hI
+    · linear_combination (-(1 : ℂ) / 2) * hI
+
+end Matrix
+
+namespace ChoiRectangular
+
+variable {d d' : ℕ}
+
+/-- The Choi assignment commutes with finite sums of maps. -/
+theorem choiMatrix_sum {ι : Type*} (s : Finset ι)
+    (T : ι → (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)) :
+    choiMatrix (∑ i ∈ s, T i) = ∑ i ∈ s, choiMatrix (T i) :=
+  map_sum (choiMatrixLinearMap (d := d) (d' := d')) T s
+
+/-- The zero map is completely positive: the empty Kraus family represents it. -/
+private theorem isKrausCP_zero :
+    IsKrausCP (0 : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :=
+  ⟨0, Fin.elim0, by simp⟩
+
+/-- Over the zero-dimensional input algebra there is only the zero map. -/
+private theorem eq_zero_of_isEmpty
+    (T : Matrix (Fin 0) (Fin 0) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) : T = 0 := by
+  refine LinearMap.ext fun B => ?_
+  have hB : B = 0 := by ext i; exact i.elim0
+  rw [hB, map_zero, LinearMap.zero_apply]
+
+/-- **Decomposition into completely positive maps** (Wolf, Chapter 2). Every
+linear map `T : M_d(ℂ) → M_{d'}(ℂ)` is a complex linear combination of four
+completely positive maps.
+
+Wolf, Chapter 2, proposition "Decomposition into completely positive maps",
+first sentence; `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 130–135. -/
+theorem exists_four_isKrausCP_complexCombination
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
+    ∃ (c : Fin 4 → ℂ)
+      (S : Fin 4 → (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)),
+      (∀ k, IsKrausCP (S k)) ∧ T = ∑ k, c k • S k := by
+  rcases Nat.eq_zero_or_pos d with rfl | hd
+  · exact ⟨0, 0, fun _ => isKrausCP_zero, by simp [eq_zero_of_isEmpty T]⟩
+  haveI : NeZero d := ⟨hd.ne'⟩
+  obtain ⟨H₁, H₂, hH₁, hH₂, hsplit⟩ :=
+    Matrix.exists_isHermitian_eq_add_smul_I (choiMatrix T)
+  obtain ⟨P₁, N₁, hP₁, hN₁, hH₁eq⟩ := hH₁.exists_eq_sub_posSemidef
+  obtain ⟨P₂, N₂, hP₂, hN₂, hH₂eq⟩ := hH₂.exists_eq_sub_posSemidef
+  obtain ⟨S₁, hS₁cp, hS₁⟩ := exists_isKrausCP_of_posSemidef hP₁
+  obtain ⟨S₂, hS₂cp, hS₂⟩ := exists_isKrausCP_of_posSemidef hN₁
+  obtain ⟨S₃, hS₃cp, hS₃⟩ := exists_isKrausCP_of_posSemidef hP₂
+  obtain ⟨S₄, hS₄cp, hS₄⟩ := exists_isKrausCP_of_posSemidef hN₂
+  refine ⟨![1, -1, Complex.I, -Complex.I], ![S₁, S₂, S₃, S₄], ?_,
+    choiMatrix_injective ?_⟩
+  · intro k
+    fin_cases k
+    exacts [hS₁cp, hS₂cp, hS₃cp, hS₄cp]
+  · rw [choiMatrix_sum]
+    simp only [Fin.sum_univ_four, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.head_cons, choiMatrix_smul, hS₁, hS₂, hS₃, hS₄, Matrix.cons_val_two,
+      Matrix.cons_val_three, Matrix.tail_cons]
+    rw [hsplit, hH₁eq, hH₂eq]
+    module
+
+/-- **Decomposition into completely positive maps**, Hermitian case (Wolf,
+Chapter 2). A linear map `T : M_d(ℂ) → M_{d'}(ℂ)` that is Hermitian, that is,
+`T(B†) = T(B)†` for every `B ∈ M_d(ℂ)`, is a real linear combination of two
+completely positive maps.
+
+Wolf, Chapter 2, proposition "Decomposition into completely positive maps",
+second sentence; `Notes/WolfNoteTexSource/ch02_representations.tex`,
+lines 132–134. -/
+theorem exists_two_isKrausCP_realCombination_of_hermiticityPreserving
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
+    (hT : ∀ B : Matrix (Fin d) (Fin d) ℂ, T (Bᴴ) = (T B)ᴴ) :
+    ∃ (c : Fin 2 → ℝ)
+      (S : Fin 2 → (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)),
+      (∀ k, IsKrausCP (S k)) ∧ T = ∑ k, (c k : ℂ) • S k := by
+  rcases Nat.eq_zero_or_pos d with rfl | hd
+  · exact ⟨0, 0, fun _ => isKrausCP_zero, by simp [eq_zero_of_isEmpty T]⟩
+  haveI : NeZero d := ⟨hd.ne'⟩
+  have hherm : (choiMatrix T).IsHermitian :=
+    (choiMatrix_isHermitian_iff_hermiticityPreserving T).mpr hT
+  obtain ⟨P, N, hP, hN, hsplit⟩ := hherm.exists_eq_sub_posSemidef
+  obtain ⟨S₁, hS₁cp, hS₁⟩ := exists_isKrausCP_of_posSemidef hP
+  obtain ⟨S₂, hS₂cp, hS₂⟩ := exists_isKrausCP_of_posSemidef hN
+  refine ⟨![1, -1], ![S₁, S₂], ?_, choiMatrix_injective ?_⟩
+  · intro k
+    fin_cases k
+    exacts [hS₁cp, hS₂cp]
+  · rw [choiMatrix_sum]
+    simp only [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one,
+      Matrix.cons_val_fin_one, choiMatrix_smul, hS₁, hS₂]
+    rw [hsplit]
+    push_cast
+    module
+
+end ChoiRectangular

--- a/TNLean/Channel/CPDecomposition.lean
+++ b/TNLean/Channel/CPDecomposition.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.ChoiRectangular
 
 /-!
@@ -11,9 +12,8 @@ import TNLean.Channel.ChoiRectangular
 Every linear map `T : M_d(ℂ) → M_{d'}(ℂ)` is a complex linear combination of
 four completely positive maps, and a Hermitian map — one satisfying
 `T(B†) = T(B)†` for every `B` — is a real linear combination of two of them.
-This is the proposition "Decomposition into completely positive maps" of
-Wolf Chapter 2, `Notes/WolfNoteTexSource/ch02_representations.tex`,
-lines 130–149.
+This is Wolf Chapter 2, Proposition 2.2 (decomposition into completely positive
+maps), `Notes/WolfNoteTexSource/ch02_representations.tex`, lines 130–149.
 
 The proof is Wolf's. Because the correspondence `T ↔ τ` of Proposition 2.1 is
 one-to-one and linear, it suffices to decompose the Choi matrix. Wolf's display
@@ -29,10 +29,6 @@ correspondence produces the four completely positive maps.
 
 ## Main results
 
-* `Matrix.IsHermitian.exists_eq_sub_posSemidef` — the Jordan decomposition of a
-  Hermitian matrix into a difference of two positive semidefinite matrices.
-* `Matrix.exists_isHermitian_eq_add_smul_I` — Wolf's display: every square
-  matrix is `H₁ + i H₂` with `H₁` and `H₂` Hermitian.
 * `ChoiRectangular.exists_four_isKrausCP_complexCombination` — every linear map
   `M_d(ℂ) → M_{d'}(ℂ)` is a complex linear combination of four completely
   positive maps.
@@ -48,69 +44,27 @@ Wolf Theorem 2.1. No hypothesis is placed on the dimensions: for `d = 0` the
 input algebra has a single element, every linear map out of it vanishes, and
 the empty combination already witnesses the statement.
 
-The square sandwich polarization `WolfProps.cp_decomposition_of_sandwich_sum`
-proves a different statement: it decomposes a map already presented in the
-form `X ↦ ∑ᵢ Aᵢ X Bᵢ†` on a single matrix algebra.
+The two matrix ingredients carry no channel hypotheses and live in
+`TNLean/Algebra/HermitianHelpers.lean`: `Matrix.exists_isHermitian_eq_add_smul_I`
+for Wolf's display and `Matrix.IsHermitian.exists_eq_sub_posSemidef` for the
+spectral step.
+
+`WolfProps.cp_decomposition_of_sandwich_sum` proves a different statement: it
+decomposes a map already presented in the form `X ↦ ∑ᵢ Aᵢ X Bᵢ†` on a single
+matrix algebra.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2,
-  Proposition "Decomposition into completely positive maps"][Wolf2012QChannels]
+  Proposition 2.2 "Decomposition into completely positive maps"][Wolf2012QChannels]
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
 open Matrix Finset
 
-namespace Matrix
-
-variable {n : Type*}
-
-/-- **Jordan decomposition**: a Hermitian matrix is the difference of two
-positive semidefinite matrices, namely its positive and negative parts. This is
-the spectral decomposition step of Wolf Chapter 2, proposition "Decomposition
-into completely positive maps"; `Notes/WolfNoteTexSource/ch02_representations.tex`,
-lines 146–148. -/
-theorem IsHermitian.exists_eq_sub_posSemidef [Finite n] {H : Matrix n n ℂ}
-    (hH : H.IsHermitian) :
-    ∃ P N : Matrix n n ℂ, P.PosSemidef ∧ N.PosSemidef ∧ H = P - N := by
-  classical
-  cases nonempty_fintype n
-  exact ⟨H⁺, H⁻, Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg H),
-    Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg H),
-    (CFC.posPart_sub_negPart H (isSelfAdjoint_iff.mpr hH)).symm⟩
-
-/-- **Hermitian and anti-Hermitian parts**: every square complex matrix is
-`H₁ + i H₂` with `H₁` and `H₂` Hermitian. The witnesses are Wolf's,
-`H₁ = (τ + τ†)/2` and `H₂ = (i τ† - i τ)/2`;
-`Notes/WolfNoteTexSource/ch02_representations.tex`, line 144. -/
-theorem exists_isHermitian_eq_add_smul_I (τ : Matrix n n ℂ) :
-    ∃ H₁ H₂ : Matrix n n ℂ, H₁.IsHermitian ∧ H₂.IsHermitian ∧
-      τ = H₁ + Complex.I • H₂ := by
-  refine ⟨(2 : ℂ)⁻¹ • (τ + τᴴ), (2 : ℂ)⁻¹ • (Complex.I • τᴴ - Complex.I • τ),
-    ?_, ?_, ?_⟩
-  · change ((2 : ℂ)⁻¹ • (τ + τᴴ))ᴴ = _
-    rw [← star_eq_conjTranspose, ← star_eq_conjTranspose]
-    simp [star_smul, add_comm]
-  · change ((2 : ℂ)⁻¹ • (Complex.I • τᴴ - Complex.I • τ))ᴴ = _
-    simp only [← star_eq_conjTranspose, star_smul, star_sub, star_star, RCLike.star_def,
-      Complex.conj_I, map_inv₀, map_ofNat]
-    module
-  · have hI : Complex.I * Complex.I = -1 := Complex.I_mul_I
-    match_scalars
-    · linear_combination ((1 : ℂ) / 2) * hI
-    · linear_combination (-(1 : ℂ) / 2) * hI
-
-end Matrix
-
 namespace ChoiRectangular
 
 variable {d d' : ℕ}
-
-/-- The Choi assignment commutes with finite sums of maps. -/
-theorem choiMatrix_sum {ι : Type*} (s : Finset ι)
-    (T : ι → (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)) :
-    choiMatrix (∑ i ∈ s, T i) = ∑ i ∈ s, choiMatrix (T i) :=
-  map_sum (choiMatrixLinearMap (d := d) (d' := d')) T s
 
 /-- The zero map is completely positive: the empty Kraus family represents it. -/
 private theorem isKrausCP_zero :
@@ -124,13 +78,12 @@ private theorem eq_zero_of_isEmpty
   have hB : B = 0 := by ext i; exact i.elim0
   rw [hB, map_zero, LinearMap.zero_apply]
 
-/-- **Decomposition into completely positive maps** (Wolf, Chapter 2). Every
-linear map `T : M_d(ℂ) → M_{d'}(ℂ)` is a complex linear combination of four
-completely positive maps.
+/-- **Decomposition into completely positive maps** (Wolf, Proposition 2.2).
+Every linear map `T : M_d(ℂ) → M_{d'}(ℂ)` is a complex linear combination of
+four completely positive maps.
 
-Wolf, Chapter 2, proposition "Decomposition into completely positive maps",
-first sentence; `Notes/WolfNoteTexSource/ch02_representations.tex`,
-lines 130–135. -/
+Wolf, Chapter 2, Proposition 2.2, first sentence;
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 130–135. -/
 theorem exists_four_isKrausCP_complexCombination
     (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
     ∃ (c : Fin 4 → ℂ)
@@ -160,13 +113,12 @@ theorem exists_four_isKrausCP_complexCombination
     module
 
 /-- **Decomposition into completely positive maps**, Hermitian case (Wolf,
-Chapter 2). A linear map `T : M_d(ℂ) → M_{d'}(ℂ)` that is Hermitian, that is,
-`T(B†) = T(B)†` for every `B ∈ M_d(ℂ)`, is a real linear combination of two
+Proposition 2.2). A linear map `T : M_d(ℂ) → M_{d'}(ℂ)` that is Hermitian, that
+is, `T(B†) = T(B)†` for every `B ∈ M_d(ℂ)`, is a real linear combination of two
 completely positive maps.
 
-Wolf, Chapter 2, proposition "Decomposition into completely positive maps",
-second sentence; `Notes/WolfNoteTexSource/ch02_representations.tex`,
-lines 132–134. -/
+Wolf, Chapter 2, Proposition 2.2, second sentence;
+`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 132–134. -/
 theorem exists_two_isKrausCP_realCombination_of_hermiticityPreserving
     (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
     (hT : ∀ B : Matrix (Fin d) (Fin d) ℂ, T (Bᴴ) = (T B)ᴴ) :

--- a/TNLean/Channel/CPDecomposition.lean
+++ b/TNLean/Channel/CPDecomposition.lean
@@ -41,8 +41,9 @@ correspondence produces the four completely positive maps.
 Complete positivity is the rectangular Kraus predicate `IsKrausCP`, the notion
 used in the complete-positivity clause of Wolf Proposition 2.1 and in
 Wolf Theorem 2.1. No hypothesis is placed on the dimensions: for `d = 0` the
-input algebra has a single element, every linear map out of it vanishes, and
-the empty combination already witnesses the statement.
+input algebra has a single element and every linear map out of it vanishes, so
+the four (respectively two) zero maps with zero coefficients already witness
+the statement.
 
 The two matrix ingredients carry no channel hypotheses and live in
 `TNLean/Algebra/HermitianHelpers.lean`: `Matrix.exists_isHermitian_eq_add_smul_I`

--- a/TNLean/Channel/ChoiRectangular.lean
+++ b/TNLean/Channel/ChoiRectangular.lean
@@ -126,6 +126,12 @@ noncomputable def choiMatrixLinearMap :
     choiMatrix (c • T) = c • choiMatrix T :=
   (choiMatrixLinearMap (d := d) (d' := d')).map_smul c T
 
+/-- The Choi assignment commutes with finite sums of maps. -/
+theorem choiMatrix_sum {ι : Type*} (s : Finset ι)
+    (T : ι → (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)) :
+    choiMatrix (∑ i ∈ s, T i) = ∑ i ∈ s, choiMatrix (T i) :=
+  map_sum (choiMatrixLinearMap (d := d) (d' := d')) T s
+
 /-- The **inverse Choi assignment**: for an operator `τ` on `ℂ^{d'} ⊗ ℂ^d`,
 the linear map `T : M_d(ℂ) → M_{d'}(ℂ)` with entries
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -171,14 +171,16 @@ project import.
 
 ### Section 2.1 Representation corollaries (Propositions 2.2–2.4)
 
-* **Decomposition into completely positive maps** (the unnumbered proposition
-  following Proposition 2.1), in `TNLean/Channel/CPDecomposition.lean`:
+* **Proposition 2.2** (decomposition into completely positive maps), in
+  `TNLean/Channel/CPDecomposition.lean`:
   - `ChoiRectangular.exists_four_isKrausCP_complexCombination` — every linear
     map `M_d(ℂ) → M_{d'}(ℂ)` is a ℂ-linear combination of four CP maps ✓
   - `ChoiRectangular.exists_two_isKrausCP_realCombination_of_hermiticityPreserving`
     — a Hermitian map is an ℝ-linear combination of two CP maps ✓
 
-* **Proposition 2.2** (CP decomposition of sandwich sums, square algebra):
+* **Proposition 2.2, sandwich-sum specialization** (square algebra, with the
+  four CP maps written out through the polarization identity of Chapter 1,
+  `Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 586–591):
   - `WolfProps.polarization_sandwich` — `4 • (A X Bᴴ) = (A+B) X (A+B)ᴴ
     − (A−B) X (A−B)ᴴ + I•(A+I·B) X (A+I·B)ᴴ − I•(A−I·B) X (A−I·B)ᴴ` ✓
   - `WolfProps.cp_decomposition_of_sandwich_sum` — every map of `M_D(ℂ)` given

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -8,6 +8,7 @@ import TNLean.Channel.MaximallyEntangled
 import TNLean.Channel.TensorMap
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.ChoiRectangular
+import TNLean.Channel.CPDecomposition
 import TNLean.Channel.KrausRectangular
 import TNLean.Channel.KrausRank
 import TNLean.Channel.KrausRepresentation
@@ -170,11 +171,19 @@ project import.
 
 ### Section 2.1 Representation corollaries (Propositions 2.2–2.4)
 
-* **Proposition 2.2** (CP decomposition):
+* **Decomposition into completely positive maps** (the unnumbered proposition
+  following Proposition 2.1), in `TNLean/Channel/CPDecomposition.lean`:
+  - `ChoiRectangular.exists_four_isKrausCP_complexCombination` — every linear
+    map `M_d(ℂ) → M_{d'}(ℂ)` is a ℂ-linear combination of four CP maps ✓
+  - `ChoiRectangular.exists_two_isKrausCP_realCombination_of_hermiticityPreserving`
+    — a Hermitian map is an ℝ-linear combination of two CP maps ✓
+
+* **Proposition 2.2** (CP decomposition of sandwich sums, square algebra):
   - `WolfProps.polarization_sandwich` — `4 • (A X Bᴴ) = (A+B) X (A+B)ᴴ
     − (A−B) X (A−B)ᴴ + I•(A+I·B) X (A+I·B)ᴴ − I•(A−I·B) X (A−I·B)ᴴ` ✓
-  - `WolfProps.cp_decomposition_of_sandwich_sum` — every
-    `∑ᵢ Aᵢ X Bᵢᴴ` is a signed ℂ-linear combination of four CP maps ✓
+  - `WolfProps.cp_decomposition_of_sandwich_sum` — every map of `M_D(ℂ)` given
+    in the sandwich-sum form `X ↦ ∑ᵢ Aᵢ X Bᵢᴴ` is a signed ℂ-linear
+    combination of four CP maps ✓
 
 * **Proposition 2.3** (no information without disturbance):
   - `WolfProps.vecMulVec_star_eq_polarization` — rank-one outer products

--- a/TNLean/Channel/WolfProps.lean
+++ b/TNLean/Channel/WolfProps.lean
@@ -15,10 +15,14 @@ import Mathlib.Algebra.BigOperators.Ring.Finset
 This file formalises the remaining Chapter 2 representation corollaries from
 Wolf's *Quantum Channels & Operations: Guided Tour*:
 
-* **Proposition 2.2** — every sesquilinear sandwich `A * X * Bᴴ` decomposes as a
-  signed complex combination of four single-Kraus terms (polarization
-  identity). Any linear map expressible as `∑ᵢ Aᵢ * X * Bᵢᴴ` is therefore
-  a complex linear combination of CP maps.
+* **Proposition 2.2, sandwich-sum specialization** — every sesquilinear sandwich
+  `A * X * Bᴴ` decomposes as a signed complex combination of four single-Kraus
+  terms, by the polarization identity of Wolf Chapter 1
+  (`Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 586–591).
+  Any linear map expressible as `∑ᵢ Aᵢ * X * Bᵢᴴ` is therefore a complex linear
+  combination of CP maps. Proposition 2.2 for an arbitrary linear map between
+  matrix algebras of possibly different dimensions is proved in
+  `TNLean/Channel/CPDecomposition.lean`.
 * **Proposition 2.3** — no information without disturbance: any linear map fixing
   every rank-one self-outer-product is the identity. In particular, a
   quantum channel that leaves every pure state invariant is the identity.
@@ -28,9 +32,10 @@ Wolf's *Quantum Channels & Operations: Guided Tour*:
 
 ## Main results
 
-* `WolfProps.polarization_sandwich` — Proposition 2.2 as a polarization identity.
-* `WolfProps.cp_decomposition_of_sandwich_sum` — Proposition 2.2 corollary: every
-  `∑ᵢ Aᵢ * X * Bᵢᴴ` is a signed ℂ-linear combination of CP maps.
+* `WolfProps.polarization_sandwich` — the Chapter 1 polarization identity in
+  sandwich form.
+* `WolfProps.cp_decomposition_of_sandwich_sum` — Proposition 2.2 for sandwich
+  sums: every `∑ᵢ Aᵢ * X * Bᵢᴴ` is a signed ℂ-linear combination of CP maps.
 * `WolfProps.vecMulVec_star_eq_polarization` — polarization of rank-one
   outer products into rank-one self-outer-products.
 * `WolfProps.exists_eq_smul_id_of_maps_rankOne_to_span` — a linear map preserving
@@ -51,7 +56,7 @@ Wolf's *Quantum Channels & Operations: Guided Tour*:
 
 ## Design notes
 
-The Proposition 2.2 polarization is proved at the entry level by reducing to a
+The sandwich polarization is proved at the entry level by reducing to a
 scalar polarization identity in `ℂ` (which is closed by
 `linear_combination`). The Proposition 2.3 reduction chain exploits the fact that
 rank-one outer products span `M_D(ℂ)` over `ℂ`, obtained by specializing
@@ -80,7 +85,7 @@ namespace WolfProps
 /-! ### Scalar polarization -/
 
 /-- Scalar polarization identity used entry-wise to prove the sandwich
-polarization (Proposition 2.2). For any four complex numbers `α β γ δ`,
+polarization. For any four complex numbers `α β γ δ`,
 
   `4 · α · (star δ) = (α+β)(star γ + star δ) - (α-β)(star γ - star δ)
      + I · (α + I·β)(star γ - I·star δ) - I · (α - I·β)(star γ + I·star δ).`
@@ -97,11 +102,12 @@ private theorem scalar_polarization (α β γ δ : ℂ) :
   have hI : Complex.I * Complex.I = -1 := Complex.I_mul_I
   linear_combination (2 * α * star δ - 2 * β * star γ) * hI
 
-/-! ### Sandwich polarization (Proposition 2.2 core identity) -/
+/-! ### Sandwich polarization -/
 
-/-- **Proposition 2.2 (Wolf), polarization form**. The sesquilinear sandwich
-`A * X * Bᴴ` decomposes as a signed ℂ-linear combination of four
-single-Kraus terms `K X Kᴴ`:
+/-- **Polarization identity in sandwich form** (Wolf, Chapter 1,
+`Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 586–591). The
+sesquilinear sandwich `A * X * Bᴴ` decomposes as a signed ℂ-linear combination
+of four single-Kraus terms `K X Kᴴ`:
 
   `4 • (A X Bᴴ) = (A+B) X (A+B)ᴴ - (A-B) X (A-B)ᴴ
       + I • (A + I•B) X (A + I•B)ᴴ - I • (A - I•B) X (A - I•B)ᴴ`.
@@ -143,7 +149,7 @@ theorem polarization_sandwich (A B X : Matrix (Fin D) (Fin D) ℂ) :
           Finset.sum_congr rfl fun _ _ => pw _ _
     _ = _ := by simp only [Finset.sum_sub_distrib, Finset.sum_add_distrib]
 
-/-- **Proposition 2.2 (Wolf), CP-decomposition form**. Every map expressible as
+/-- **Proposition 2.2 (Wolf), sandwich-sum specialization**. Every map expressible as
 `T(X) = ∑ᵢ Aᵢ * X * Bᵢᴴ` has the explicit ℂ-linear CP-decomposition
 
   `4 • T(X) = ∑ᵢ (Aᵢ+Bᵢ) X (Aᵢ+Bᵢ)ᴴ - ∑ᵢ (Aᵢ-Bᵢ) X (Aᵢ-Bᵢ)ᴴ

--- a/blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex
+++ b/blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex
@@ -338,6 +338,47 @@ the input factor is written $\tr_B$.
     Theorems~\ref{thm:choi_rect_unital} and~\ref{thm:choi_rect_tp}.
 \end{proof}
 
+\begin{theorem}[Decomposition into completely positive maps]
+    \label{thm:choi_rect_cp_decomposition}
+    \lean{ChoiRectangular.exists_four_isKrausCP_complexCombination,
+        ChoiRectangular.exists_two_isKrausCP_realCombination_of_hermiticityPreserving,
+        Matrix.exists_isHermitian_eq_add_smul_I,
+        Matrix.IsHermitian.exists_eq_sub_posSemidef}
+    \leanok
+    \uses{def:is_kraus_cp}
+    Every linear map $T:\MN{d}\to\MN{d'}$ is a complex linear combination of
+    four completely positive maps. If $T$ is Hermitian, that is
+    $T(B^\dagger)=T(B)^\dagger$ for every $B\in\MN{d}$, then $T$ is a real
+    linear combination of two of them. This is the proposition on
+    decomposition into completely positive maps of
+    \cite[Chapter~2]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:choi_matrix_rect, thm:choi_rect_mutual_inverse, thm:choi_rect_cp,
+        thm:choi_rect_hermiticity}
+    The assignment $T\leftrightarrow\tau$ is linear and one-to-one, so it
+    suffices to decompose $\tau$. The identity
+    \begin{align}
+        \tau
+          &= \frac{\tau+\tau^\dagger}{2}
+             + i\,\frac{i\tau^\dagger-i\tau}{2}
+        \notag
+    \end{align}
+    presents $\tau$ as a complex linear combination of two Hermitian
+    operators, and the spectral decomposition writes each of them as the
+    difference of its positive and negative parts, both positive
+    semidefinite. Every positive semidefinite operator on
+    $\C^{d'}\otimes\C^{d}$ is the Choi matrix of a completely positive map, so
+    carrying the four positive semidefinite pieces back through the
+    correspondence produces the four completely positive maps, with
+    coefficients $1,-1,i,-i$. If $T$ is Hermitian then $\tau$ is Hermitian by
+    Theorem~\ref{thm:choi_rect_hermiticity}, so the second summand vanishes
+    and the positive and negative parts of $\tau$ alone give two completely
+    positive maps, with coefficients $1$ and $-1$.
+\end{proof}
+
 \section{The Kraus representation theorem for rectangular matrix algebras}
 
 \begin{theorem}[Kraus normalization conditions]

--- a/blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex
+++ b/blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex
@@ -156,7 +156,8 @@ the input factor is written $\tr_B$.
 
 \begin{definition}[Choi matrix of a map between matrix algebras]
     \label{def:choi_matrix_rect}
-    \lean{ChoiRectangular.choiMatrix, ChoiRectangular.mapOfChoiMatrix}
+    \lean{ChoiRectangular.choiMatrix, ChoiRectangular.choiMatrixLinearMap,
+        ChoiRectangular.mapOfChoiMatrix}
     \leanok
     \uses{def:maximally_entangled, def:tensor_map_id}
     The \emph{Choi matrix} of a linear map $T:\MN{d}\to\MN{d'}$ is
@@ -171,22 +172,30 @@ the input factor is written $\tr_B$.
 
 \begin{lemma}[Linearity of the Choi assignment]
     \label{lem:choi_rect_linear}
-    \lean{ChoiRectangular.choiMatrixLinearMap, ChoiRectangular.choiMatrix_add,
-        ChoiRectangular.choiMatrix_smul, ChoiRectangular.choiMatrix_sum}
+    \lean{ChoiRectangular.choiMatrix_add, ChoiRectangular.choiMatrix_smul,
+        ChoiRectangular.choiMatrix_sum}
     \leanok
     \uses{def:choi_matrix_rect}
-    The assignment $T\mapsto\tau$ is complex linear: it carries sums to sums,
-    scalar multiples to scalar multiples, and hence finite sums
-    $\sum_{i\in s}T_i$ to $\sum_{i\in s}\tau_i$.
+    Write $\tau_T$ for the Choi matrix of $T$. For all linear maps
+    $T,S:\MN{d}\to\MN{d'}$, all $c\in\C$, all finite index sets $s$ and all
+    families $(T_i)_{i\in s}$,
+    \begin{align}
+        \tau_{T+S} &= \tau_T + \tau_S,
+        \label{eq:choi_rect_linear_add}\\
+        \tau_{cT} &= c\,\tau_T,
+        \label{eq:choi_rect_linear_smul}\\
+        \tau_{\sum_{i\in s}T_i} &= \sum_{i\in s}\tau_{T_i}.
+        \label{eq:choi_rect_linear_sum}
+    \end{align}
 \end{lemma}
 
 \begin{proof}
     \leanok
-    The Choi matrix is the image of $T$ under $T\mapsto(T\otimes
-    \operatorname{id}_d)$ evaluated at the fixed operator
-    $\ketbra{\Omega_d}{\Omega_d}$, and each entry of $\tau$ is a value of $T$
-    at a fixed matrix. Linearity in $T$ is therefore entrywise, and the
-    finite-sum form follows by induction on the index set.
+    Each entry $\tau_{(i_1,i_2),(j_1,j_2)}$ is the value of $T$ at a fixed
+    matrix, read off at a fixed pair of indices, so
+    (\ref{eq:choi_rect_linear_add}) and (\ref{eq:choi_rect_linear_smul}) hold
+    entrywise. They make $T\mapsto\tau_T$ a complex linear map, and
+    (\ref{eq:choi_rect_linear_sum}) is the image of a finite sum under it.
 \end{proof}
 
 \begin{theorem}[Mutual inverses of the Choi correspondence]

--- a/blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex
+++ b/blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex
@@ -169,6 +169,26 @@ the input factor is written $\tr_B$.
     \cite[Proposition~2.1]{Wolf2012Quantum}.
 \end{definition}
 
+\begin{lemma}[Linearity of the Choi assignment]
+    \label{lem:choi_rect_linear}
+    \lean{ChoiRectangular.choiMatrixLinearMap, ChoiRectangular.choiMatrix_add,
+        ChoiRectangular.choiMatrix_smul, ChoiRectangular.choiMatrix_sum}
+    \leanok
+    \uses{def:choi_matrix_rect}
+    The assignment $T\mapsto\tau$ is complex linear: it carries sums to sums,
+    scalar multiples to scalar multiples, and hence finite sums
+    $\sum_{i\in s}T_i$ to $\sum_{i\in s}\tau_i$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The Choi matrix is the image of $T$ under $T\mapsto(T\otimes
+    \operatorname{id}_d)$ evaluated at the fixed operator
+    $\ketbra{\Omega_d}{\Omega_d}$, and each entry of $\tau$ is a value of $T$
+    at a fixed matrix. Linearity in $T$ is therefore entrywise, and the
+    finite-sum form follows by induction on the index set.
+\end{proof}
+
 \begin{theorem}[Mutual inverses of the Choi correspondence]
     \label{thm:choi_rect_mutual_inverse}
     \lean{ChoiRectangular.mapOfChoiMatrix_choiMatrix,
@@ -349,22 +369,24 @@ the input factor is written $\tr_B$.
     Every linear map $T:\MN{d}\to\MN{d'}$ is a complex linear combination of
     four completely positive maps. If $T$ is Hermitian, that is
     $T(B^\dagger)=T(B)^\dagger$ for every $B\in\MN{d}$, then $T$ is a real
-    linear combination of two of them. This is the proposition on
-    decomposition into completely positive maps of
-    \cite[Chapter~2]{Wolf2012Quantum}.
+    linear combination of two of them. This is
+    \cite[Proposition~2.2]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{def:choi_matrix_rect, thm:choi_rect_mutual_inverse, thm:choi_rect_cp,
+    \uses{def:choi_matrix_rect, lem:choi_rect_linear,
+        thm:choi_rect_mutual_inverse, thm:choi_rect_cp,
         thm:choi_rect_hermiticity}
-    The assignment $T\leftrightarrow\tau$ is linear and one-to-one, so it
-    suffices to decompose $\tau$. The identity
+    The assignment $T\leftrightarrow\tau$ is linear by
+    Lemma~\ref{lem:choi_rect_linear} and one-to-one by
+    Theorem~\ref{thm:choi_rect_mutual_inverse}, so it suffices to decompose
+    $\tau$. The identity
     \begin{align}
         \tau
           &= \frac{\tau+\tau^\dagger}{2}
              + i\,\frac{i\tau^\dagger-i\tau}{2}
-        \notag
+        \label{eq:choi_rect_hermitian_split}
     \end{align}
     presents $\tau$ as a complex linear combination of two Hermitian
     operators, and the spectral decomposition writes each of them as the
@@ -374,9 +396,10 @@ the input factor is written $\tr_B$.
     carrying the four positive semidefinite pieces back through the
     correspondence produces the four completely positive maps, with
     coefficients $1,-1,i,-i$. If $T$ is Hermitian then $\tau$ is Hermitian by
-    Theorem~\ref{thm:choi_rect_hermiticity}, so the second summand vanishes
-    and the positive and negative parts of $\tau$ alone give two completely
-    positive maps, with coefficients $1$ and $-1$.
+    Theorem~\ref{thm:choi_rect_hermiticity}, so the second summand
+    of~(\ref{eq:choi_rect_hermitian_split}) vanishes and the positive and
+    negative parts of $\tau$ alone give two completely positive maps, with
+    coefficients $1$ and $-1$.
 \end{proof}
 
 \section{The Kraus representation theorem for rectangular matrix algebras}

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -525,9 +525,8 @@ The next three corollaries support channel decompositions and correspond to
     $4\,T = T_1 - T_2 + i\,T_3 - i\,T_4$ with each $T_k$ a CP map given
     explicitly by a single-side Kraus sum of the combined families. The
     hypothesis is that $T$ is presented in sandwich-sum form on a single
-    matrix algebra $\MN{D}$; the decomposition of an arbitrary linear map
-    $\MN{d}\to\MN{d'}$ is
-    Theorem~\ref{thm:choi_rect_cp_decomposition}.
+    matrix algebra $\MN{D}$; Theorem~\ref{thm:choi_rect_cp_decomposition}
+    decomposes an arbitrary linear map $\MN{d}\to\MN{d'}$.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -523,7 +523,11 @@ The next three corollaries support channel decompositions and correspond to
     For any finite Kraus-like families $\{A_i\}, \{B_i\}$, the map
     $T(X) = \sum_i A_i X B_i^\dagger$ satisfies
     $4\,T = T_1 - T_2 + i\,T_3 - i\,T_4$ with each $T_k$ a CP map given
-    explicitly by a single-side Kraus sum of the combined families.
+    explicitly by a single-side Kraus sum of the combined families. The
+    hypothesis is that $T$ is presented in sandwich-sum form on a single
+    matrix algebra $\MN{D}$; the decomposition of an arbitrary linear map
+    $\MN{d}\to\MN{d'}$ is
+    Theorem~\ref{thm:choi_rect_cp_decomposition}.
 \end{theorem}
 
 \begin{proof}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -72,7 +72,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1595, 1637 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
-| `ch16_channel_representations_choi_and_kraus.tex` | L695 `tenkz` → `P-grid` | — | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | L694 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -72,7 +72,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | L101 `tenkz` → `P-grid` | — | — |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | L36, 1595, 1637 `tenkz` → `P-grid` | — | — |
 | `ch14_correlations.tex` | L68 `tenkz` → `P-grid` | — | — |
-| `ch16_channel_representations_choi_and_kraus.tex` | L691 `tenkz` → `P-grid` | — | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | L695 `tenkz` → `P-grid` | — | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | L23 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | L154, 161, 181, 186, 234, 240, 339, 433 `tenkz` → `P-grid` | — | — |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | L105, 109, 221, 229, 368, 381, 432 `tenkz` → `P-grid` | — | — |


### PR DESCRIPTION
## Source

Wolf, *Quantum Channels & Operations*, Chapter 2, proposition "Decomposition into
completely positive maps"; `Notes/WolfNoteTexSource/ch02_representations.tex`,
lines 130–149.

> Every linear map $T \in \mathcal B(\mathcal M_d, \mathcal M_{d'})$ can be written as a
> complex linear combination of four completely positive maps. If $T$ is Hermitian
> (i.e. $T(B^\dagger) = T(B)^\dagger$ for all $B$), it can be written as a real linear
> combination of two of them.

## Landed signatures

`TNLean/Channel/CPDecomposition.lean`:

```lean
theorem ChoiRectangular.exists_four_isKrausCP_complexCombination
    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ) :
    ∃ (c : Fin 4 → ℂ)
      (S : Fin 4 → (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)),
      (∀ k, IsKrausCP (S k)) ∧ T = ∑ k, c k • S k

theorem ChoiRectangular.exists_two_isKrausCP_realCombination_of_hermiticityPreserving
    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)
    (hT : ∀ B : Matrix (Fin d) (Fin d) ℂ, T (Bᴴ) = (T B)ᴴ) :
    ∃ (c : Fin 2 → ℝ)
      (S : Fin 2 → (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)),
      (∀ k, IsKrausCP (S k)) ∧ T = ∑ k, (c k : ℂ) • S k
```

Supporting lemmas in the same file:

```lean
theorem Matrix.exists_isHermitian_eq_add_smul_I (τ : Matrix n n ℂ) :
    ∃ H₁ H₂ : Matrix n n ℂ, H₁.IsHermitian ∧ H₂.IsHermitian ∧ τ = H₁ + Complex.I • H₂

theorem Matrix.IsHermitian.exists_eq_sub_posSemidef [Finite n] {H : Matrix n n ℂ}
    (hH : H.IsHermitian) :
    ∃ P N : Matrix n n ℂ, P.PosSemidef ∧ N.PosSemidef ∧ H = P - N

theorem ChoiRectangular.choiMatrix_sum {ι : Type*} (s : Finset ι)
    (T : ι → (Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ)) :
    choiMatrix (∑ i ∈ s, T i) = ∑ i ∈ s, choiMatrix (T i)
```

## Hypothesis match with the source

| Wolf | Lean |
|---|---|
| $T \in \mathcal B(\mathcal M_d, \mathcal M_{d'})$, arbitrary linear map | `T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d') (Fin d') ℂ`, no further hypothesis |
| input and output dimensions may differ | `d` and `d'` independent naturals; no `d = d'`, no positivity assumption (the `d = 0` case is discharged internally) |
| completely positive | `IsKrausCP`, the rectangular Kraus predicate used for the complete-positivity clause of Wolf Proposition 2.1 |
| complex linear combination of four | `c : Fin 4 → ℂ`, `T = ∑ k, c k • S k` with all four `S k` completely positive |
| $T$ Hermitian: $T(B^\dagger) = T(B)^\dagger$ for all $B$ | `hT : ∀ B, T Bᴴ = (T B)ᴴ` — the source's hypothesis verbatim, nothing added |
| real linear combination of two | `c : Fin 2 → ℝ`, `T = ∑ k, (c k : ℂ) • S k` |

Nothing is assumed beyond the source. In particular the four-map clause quantifies over
*every* linear map, not only maps presented in sandwich-sum form.

Wolf's proof is followed step for step: the Choi matrix `τ` is split as
`τ = (τ + τ†)/2 + i (iτ† − iτ)/2` into two Hermitian parts, each Hermitian part is
Jordan-split into positive and negative parts, each positive semidefinite piece becomes a
completely positive map by `ChoiRectangular.exists_isKrausCP_of_posSemidef`, and the
combination is transported back with `ChoiRectangular.choiMatrix_injective`. In the
Hermitian case `ChoiRectangular.choiMatrix_isHermitian_iff_hermiticityPreserving` makes
`τ` Hermitian, so only its positive and negative parts appear, with coefficients `1, -1`.

The pre-existing `Channel.WolfProps.cp_decomposition_of_sandwich_sum` is untouched; it
decomposes a map on a single matrix algebra already presented as `X ↦ ∑ᵢ Aᵢ X Bᵢ†` and is
not the source theorem. Its blueprint entry and the Wolf Chapter 2 index entry now say so
and point to the new theorem.

## Blueprint

`blueprint/src/chapter/ch04_channels_rectangular_kraus_maps.tex`: new
`thm:choi_rect_cp_decomposition` with `\lean{...}` and `\leanok` on the statement and
`\leanok` on the proof, in the rectangular Choi section next to the Proposition 2.1
clauses it uses. `ch16_channel_representations_choi_and_kraus.tex`: one sentence added to
the sandwich-sum entry recording its hypothesis and cross-referencing the new theorem.

## Verification

- `lake build TNLean.Channel.CPDecomposition` — success, no warnings.
- `lake build TNLean.Channel TNLean.Channel.WolfChapter2Index` — success (9104 jobs).
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` — "Import
  aggregators are current".
- `python3 scripts/blueprint_lean_sync.py --warn-missing-blueprint ...` — no changed
  declaration missing a blueprint entry.
- `lake exe lint_style TNLean/Channel/CPDecomposition.lean` — clean; no line exceeds 100
  characters.
- `rg -n "sorry|admit|axiom|native_decide|maxHeartbeats"` on the changed Lean files — no
  hits.
- `latexmk -pdf print.tex` in `blueprint/src` — the new entry compiles with no LaTeX
  errors; all labels it cites resolve. Build artefacts were removed, `print.pdf` restored.

Closes LionSR/QICLean#317.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formalization and documentation on top of existing Choi/CP infrastructure; no changes to runtime auth, security, or data paths.
> 
> **Overview**
> Formalizes **Wolf Proposition 2.2** for arbitrary rectangular maps `M_d(ℂ) → M_{d'}(ℂ)`: every linear map is a ℂ-linear combination of four `IsKrausCP` maps, and Hermitian maps are an ℝ-linear combination of two.
> 
> Adds **`TNLean/Channel/CPDecomposition.lean`** with proofs via the Choi matrix (Hermitian split, Jordan positive/negative parts, `choiMatrix_injective`), plus **`d = 0`** edge cases. **`HermitianHelpers`** gains `exists_isHermitian_eq_add_smul_I` and `IsHermitian.exists_eq_sub_posSemidef`; **`ChoiRectangular.choiMatrix_sum`** supports finite sums.
> 
> **`WolfProps`** sandwich-sum CP decomposition is reframed as a **specialization** (polarization on one algebra), not the general theorem. Blueprint adds Choi linearity lemma, **`thm:choi_rect_cp_decomposition`**, and cross-links from ch16; import aggregators and Wolf Chapter 2 index updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c09c831948031e42678d006f3e2a15c8aee542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->