### PR TITLE
feat(Algebra): Kramers degeneracy for an antiunitary symmetry of square -1

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -37,6 +37,7 @@ import TNLean.Algebra.HermitianSpectrumPreserver
 import TNLean.Algebra.HermitianTracePower
 import TNLean.Algebra.HermitianUnitaryConjugacy
 import TNLean.Algebra.IrreducibleTensorAction
+import TNLean.Algebra.KramersDegeneracy
 import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.Algebra.ListProduct
 import TNLean.Algebra.MatrixAlgEquiv

--- a/TNLean/Algebra/KramersDegeneracy.lean
+++ b/TNLean/Algebra/KramersDegeneracy.lean
@@ -13,12 +13,12 @@ import Mathlib.LinearAlgebra.Matrix.DotProduct
 # Kramers degeneracy
 
 Wolf, *Quantum Channels & Operations*, Chapter 3, states Kramers' theorem for a
-Hermitian `H` commuting with an antiunitary `T` of square `-1`: every eigenvalue of
-`H` is at least two-fold degenerate.  Wolf reduces the statement to matrices in the
-same breath: writing `T = Γ V` with `Γ` complex conjugation and `V` unitary, the
-commutation `[H, T] = 0` becomes `H Vᴴ = Vᴴ Hᵀ` and the condition `T² = -1` becomes
-antisymmetry `Vᵀ = -V`.  This file formalizes Wolf's reduced matrix form, which is
-what his printed proof actually manipulates.
+Hermitian $H$ commuting with an antiunitary $T$ of square $-1$: every eigenvalue of
+$H$ is at least two-fold degenerate.  Wolf reduces the statement to matrices in the
+same breath: writing $T = \Gamma V$ with $\Gamma$ complex conjugation and $V$ unitary,
+the commutation $[H, T] = 0$ becomes $H V^\dagger = V^\dagger H^T$ and the condition
+$T^2 = -1$ becomes antisymmetry $V^T = -V$.  This file formalizes Wolf's reduced
+matrix form, which is what his printed proof actually manipulates.
 
 Degeneracy is expressed as `2 ≤ Module.finrank ℂ (Module.End.eigenspace H.toLin' μ)`.
 Wolf's proof exhibits two orthogonal eigenvectors for the same eigenvalue, so the
@@ -26,7 +26,7 @@ dimension of the eigenspace is the invariant his argument bounds; the geometric
 multiplicity of a Hermitian matrix also agrees with the algebraic one, so nothing is
 lost against the phrase "two-fold degenerate".
 
-## Main declarations
+## Main results
 
 * `Matrix.dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg`: the quadratic form of an
   antisymmetric complex matrix vanishes identically.
@@ -62,7 +62,7 @@ theorem dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg {M : Matrix n n ℂ}
   simpa using htwo
 
 /-- Two nonzero orthogonal vectors are linearly independent. -/
-theorem linearIndependent_pair_of_dotProduct_star_eq_zero {u v : n → ℂ} (hu : u ≠ 0)
+private theorem linearIndependent_pair_of_dotProduct_star_eq_zero {u v : n → ℂ} (hu : u ≠ 0)
     (hv : v ≠ 0) (huv : star u ⬝ᵥ v = 0) : LinearIndependent ℂ ![u, v] := by
   rw [LinearIndependent.pair_iff' hu]
   intro a hav
@@ -109,20 +109,23 @@ private theorem conj_eq_self_of_hasEigenvalue {H : Matrix n n ℂ} (hH : H.IsHer
 /-- **Kramers' theorem** (Wolf, *Quantum Channels & Operations*, §3, line 503), in Wolf's own
 matrix reduction of the antiunitary statement.
 
-Wolf states the theorem for a Hermitian `H` and an antiunitary `T` with `[H, T] = 0` and
-`T² = -1`, and immediately rewrites both hypotheses in matrix terms: with `T = Γ V` for `Γ`
-complex conjugation and `V` unitary, commutation is `H Vᴴ = Vᴴ Hᵀ` and `T² = -1` is
-antisymmetry `Vᵀ = -V`.  Those two matrix identities, together with `Vᴴ V = 1`, are the
-hypotheses below, so the statement is Wolf's with the antiunitary rewritten exactly as he
-rewrites it; no further hypothesis is imposed.
+Wolf states the theorem for a Hermitian $H$ and an antiunitary $T$ with $[H, T] = 0$ and
+$T^2 = -1$, and immediately rewrites both hypotheses in matrix terms: with $T = \Gamma V$
+for $\Gamma$ complex conjugation and $V$ unitary, commutation is
+$H V^\dagger = V^\dagger H^T$ and $T^2 = -1$ is antisymmetry $V^T = -V$.  Those two matrix
+identities, together with $V^\dagger V = 1$, are the hypotheses below, so the statement is
+Wolf's with the antiunitary rewritten exactly as he rewrites it; no further hypothesis is
+imposed.
 
 "At least two-fold degenerate" is `2 ≤ Module.finrank ℂ (Module.End.eigenspace H.toLin' μ)`:
 Wolf's proof produces a second eigenvector orthogonal to the first, so the eigenspace
 dimension is what the argument bounds.
 
-The proof is Wolf's.  From `H ψ = μ ψ` the vector `φ = Vᴴ star ψ` satisfies
-`H φ = Vᴴ Hᵀ star ψ = μ φ`; it is nonzero because `V` is unitary; and `⟨ψ, φ⟩ = 0` because
-the quadratic form of the antisymmetric matrix `Vᴴ` vanishes. -/
+The proof is Wolf's.  From $H \psi = \mu \psi$ the vector
+$\varphi = V^\dagger \overline{\psi}$ satisfies
+$H \varphi = V^\dagger H^T \overline{\psi} = \mu \varphi$; it is nonzero because $V$ is
+unitary; and $\langle \psi, \varphi \rangle = 0$ because the quadratic form of the
+antisymmetric matrix $V^\dagger$ vanishes. -/
 theorem two_le_finrank_eigenspace_of_antisymmetric_unitary {H V : Matrix n n ℂ}
     (hH : H.IsHermitian) (hVunit : Vᴴ * V = 1) (hHV : H * Vᴴ = Vᴴ * Hᵀ) (hVanti : Vᵀ = -V)
     {μ : ℂ} (hμ : Module.End.HasEigenvalue (Matrix.toLin' H) μ) :

--- a/TNLean/Algebra/KramersDegeneracy.lean
+++ b/TNLean/Algebra/KramersDegeneracy.lean
@@ -120,8 +120,8 @@ rewrites it; no further hypothesis is imposed.
 Wolf's proof produces a second eigenvector orthogonal to the first, so the eigenspace
 dimension is what the argument bounds.
 
-The proof is Wolf's.  From `H ψ = μ ψ` the vector `φ = Vᴴ ψ̄` satisfies
-`H φ = Vᴴ Hᵀ ψ̄ = μ φ`; it is nonzero because `V` is unitary; and `⟨ψ, φ⟩ = 0` because
+The proof is Wolf's.  From `H ψ = μ ψ` the vector `φ = Vᴴ star ψ` satisfies
+`H φ = Vᴴ Hᵀ star ψ = μ φ`; it is nonzero because `V` is unitary; and `⟨ψ, φ⟩ = 0` because
 the quadratic form of the antisymmetric matrix `Vᴴ` vanishes. -/
 theorem two_le_finrank_eigenspace_of_antisymmetric_unitary {H V : Matrix n n ℂ}
     (hH : H.IsHermitian) (hVunit : Vᴴ * V = 1) (hHV : H * Vᴴ = Vᴴ * Hᵀ) (hVanti : Vᵀ = -V)

--- a/TNLean/Algebra/KramersDegeneracy.lean
+++ b/TNLean/Algebra/KramersDegeneracy.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Matrix.Spectrum
+import Mathlib.LinearAlgebra.Dimension.Finite
+import Mathlib.LinearAlgebra.Eigenspace.Matrix
+import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
+import Mathlib.LinearAlgebra.Matrix.DotProduct
+
+/-!
+# Kramers degeneracy
+
+Wolf, *Quantum Channels & Operations*, Chapter 3, states Kramers' theorem for a
+Hermitian `H` commuting with an antiunitary `T` of square `-1`: every eigenvalue of
+`H` is at least two-fold degenerate.  Wolf reduces the statement to matrices in the
+same breath: writing `T = Γ V` with `Γ` complex conjugation and `V` unitary, the
+commutation `[H, T] = 0` becomes `H Vᴴ = Vᴴ Hᵀ` and the condition `T² = -1` becomes
+antisymmetry `Vᵀ = -V`.  This file formalizes Wolf's reduced matrix form, which is
+what his printed proof actually manipulates.
+
+Degeneracy is expressed as `2 ≤ Module.finrank ℂ (Module.End.eigenspace H.toLin' μ)`.
+Wolf's proof exhibits two orthogonal eigenvectors for the same eigenvalue, so the
+dimension of the eigenspace is the invariant his argument bounds; the geometric
+multiplicity of a Hermitian matrix also agrees with the algebraic one, so nothing is
+lost against the phrase "two-fold degenerate".
+
+## Main declarations
+
+* `Matrix.dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg`: the quadratic form of an
+  antisymmetric complex matrix vanishes identically.
+* `Matrix.two_le_finrank_eigenspace_of_linearIndependent_pair`: two independent
+  eigenvectors for one eigenvalue bound the eigenspace dimension below by two.
+* `Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary`: Kramers'
+  theorem in Wolf's matrix form.
+
+## References
+
+* Wolf, *Quantum Channels & Operations*, Chapter 3, Kramers' theorem (§3, line 503 of
+  `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`).
+-/
+
+open scoped ComplexOrder Matrix
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n]
+
+/-- The quadratic form of an antisymmetric complex matrix vanishes: if `Mᵀ = -M`, then
+`x ⬝ᵥ M *ᵥ x = 0` for every vector `x`.  This is the mechanism behind the orthogonality
+step of Kramers' theorem. -/
+theorem dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg {M : Matrix n n ℂ}
+    (hM : Mᵀ = -M) (x : n → ℂ) : x ⬝ᵥ M *ᵥ x = 0 := by
+  have hself : x ⬝ᵥ M *ᵥ x = -(x ⬝ᵥ M *ᵥ x) := by
+    calc x ⬝ᵥ M *ᵥ x = x ᵥ* M ⬝ᵥ x := Matrix.dotProduct_mulVec x M x
+      _ = Mᵀ *ᵥ x ⬝ᵥ x := by rw [Matrix.mulVec_transpose]
+      _ = (-M) *ᵥ x ⬝ᵥ x := by rw [hM]
+      _ = -(M *ᵥ x ⬝ᵥ x) := by rw [Matrix.neg_mulVec, neg_dotProduct]
+      _ = -(x ⬝ᵥ M *ᵥ x) := by rw [dotProduct_comm]
+  have htwo : (2 : ℂ) * (x ⬝ᵥ M *ᵥ x) = 0 := by linear_combination hself
+  simpa using htwo
+
+/-- Two nonzero orthogonal vectors are linearly independent. -/
+theorem linearIndependent_pair_of_dotProduct_star_eq_zero {u v : n → ℂ} (hu : u ≠ 0)
+    (hv : v ≠ 0) (huv : star u ⬝ᵥ v = 0) : LinearIndependent ℂ ![u, v] := by
+  rw [LinearIndependent.pair_iff' hu]
+  intro a hav
+  refine hv ?_
+  have hself : star u ⬝ᵥ u ≠ 0 := fun h => hu (dotProduct_star_self_eq_zero.mp h)
+  have ha : a * (star u ⬝ᵥ u) = 0 := by
+    have h : star u ⬝ᵥ (a • u) = 0 := by rw [hav]; exact huv
+    rwa [dotProduct_smul, smul_eq_mul] at h
+  rw [← hav, (mul_eq_zero.mp ha).resolve_right hself, zero_smul]
+
+variable [DecidableEq n]
+
+/-- Two linearly independent eigenvectors of `A` for the same eigenvalue `μ` force the
+eigenspace of `μ` to have dimension at least two. -/
+theorem two_le_finrank_eigenspace_of_linearIndependent_pair {A : Matrix n n ℂ} {μ : ℂ}
+    {u v : n → ℂ} (hu : A *ᵥ u = μ • u) (hv : A *ᵥ v = μ • v)
+    (hLI : LinearIndependent ℂ ![u, v]) :
+    2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' A) μ) := by
+  have hmem : ∀ i : Fin 2, ![u, v] i ∈ Module.End.eigenspace (Matrix.toLin' A) μ := by
+    intro i
+    fin_cases i <;> rw [Module.End.mem_eigenspace_iff, Matrix.toLin'_apply] <;>
+      simpa using ‹_›
+  have hLIsub : LinearIndependent ℂ fun i : Fin 2 => (⟨![u, v] i, hmem i⟩ :
+      Module.End.eigenspace (Matrix.toLin' A) μ) :=
+    LinearIndependent.of_comp (Module.End.eigenspace (Matrix.toLin' A) μ).subtype hLI
+  simpa using hLIsub.fintype_card_le_finrank
+
+end Matrix
+
+namespace Matrix.IsHermitian
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Every eigenvalue of a Hermitian matrix is fixed by complex conjugation. -/
+private theorem conj_eq_self_of_hasEigenvalue {H : Matrix n n ℂ} (hH : H.IsHermitian) {μ : ℂ}
+    (hμ : Module.End.HasEigenvalue (Matrix.toLin' H) μ) : (starRingEnd ℂ) μ = μ := by
+  have hspec : μ ∈ spectrum ℂ H := by
+    rw [← Matrix.spectrum_toLin']
+    exact Module.End.hasEigenvalue_iff_mem_spectrum.mp hμ
+  rw [hH.spectrum_eq_image_range] at hspec
+  obtain ⟨r, -, rfl⟩ := hspec
+  simp
+
+/-- **Kramers' theorem** (Wolf, *Quantum Channels & Operations*, §3, line 503), in Wolf's own
+matrix reduction of the antiunitary statement.
+
+Wolf states the theorem for a Hermitian `H` and an antiunitary `T` with `[H, T] = 0` and
+`T² = -1`, and immediately rewrites both hypotheses in matrix terms: with `T = Γ V` for `Γ`
+complex conjugation and `V` unitary, commutation is `H Vᴴ = Vᴴ Hᵀ` and `T² = -1` is
+antisymmetry `Vᵀ = -V`.  Those two matrix identities, together with `Vᴴ V = 1`, are the
+hypotheses below, so the statement is Wolf's with the antiunitary rewritten exactly as he
+rewrites it; no further hypothesis is imposed.
+
+"At least two-fold degenerate" is `2 ≤ Module.finrank ℂ (Module.End.eigenspace H.toLin' μ)`:
+Wolf's proof produces a second eigenvector orthogonal to the first, so the eigenspace
+dimension is what the argument bounds.
+
+The proof is Wolf's.  From `H ψ = μ ψ` the vector `φ = Vᴴ ψ̄` satisfies
+`H φ = Vᴴ Hᵀ ψ̄ = μ φ`; it is nonzero because `V` is unitary; and `⟨ψ, φ⟩ = 0` because
+the quadratic form of the antisymmetric matrix `Vᴴ` vanishes. -/
+theorem two_le_finrank_eigenspace_of_antisymmetric_unitary {H V : Matrix n n ℂ}
+    (hH : H.IsHermitian) (hVunit : Vᴴ * V = 1) (hHV : H * Vᴴ = Vᴴ * Hᵀ) (hVanti : Vᵀ = -V)
+    {μ : ℂ} (hμ : Module.End.HasEigenvalue (Matrix.toLin' H) μ) :
+    2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' H) μ) := by
+  obtain ⟨ψ, hψmem, hψne⟩ := hμ.exists_hasEigenvector
+  have hψ : H *ᵥ ψ = μ • ψ := by
+    have := Module.End.mem_eigenspace_iff.mp hψmem
+    rwa [Matrix.toLin'_apply] at this
+  -- Wolf's second eigenvector.
+  set φ : n → ℂ := Vᴴ *ᵥ star ψ with hφdef
+  have hconj : (starRingEnd ℂ) μ = μ := conj_eq_self_of_hasEigenvalue hH hμ
+  have hHtrans : Hᵀ *ᵥ star ψ = μ • star ψ := by
+    rw [Matrix.mulVec_transpose, ← hH.eq, ← Matrix.star_mulVec, hψ]
+    ext i
+    simp [Pi.star_apply, hconj]
+  have hφ : H *ᵥ φ = μ • φ := by
+    rw [hφdef, Matrix.mulVec_mulVec, hHV, ← Matrix.mulVec_mulVec, hHtrans,
+      Matrix.mulVec_smul]
+  have hφne : φ ≠ 0 := by
+    intro hzero
+    have hVVH : V * Vᴴ = 1 := mul_eq_one_comm.mp hVunit
+    have : star ψ = 0 := by
+      have := congrArg (fun w => V *ᵥ w) hzero
+      rwa [hφdef, Matrix.mulVec_mulVec, hVVH, Matrix.one_mulVec, Matrix.mulVec_zero] at this
+    exact hψne (by simpa using congrArg star this)
+  -- Wolf's orthogonality: `Vᴴ` is antisymmetric, so its quadratic form vanishes.
+  have hVHanti : (Vᴴ)ᵀ = -Vᴴ := by
+    ext i j
+    have h : V j i = -V i j := by
+      have hij : Vᵀ i j = (-V) i j := by rw [hVanti]
+      simpa using hij
+    simp [Matrix.transpose_apply, Matrix.conjTranspose_apply, Matrix.neg_apply, h]
+  have horth : star ψ ⬝ᵥ φ = 0 :=
+    Matrix.dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg hVHanti (star ψ)
+  exact Matrix.two_le_finrank_eigenspace_of_linearIndependent_pair hψ hφ
+    (Matrix.linearIndependent_pair_of_dotProduct_star_eq_zero hψne hφne horth)
+
+end Matrix.IsHermitian

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -8,7 +8,8 @@ Ky Fan's maximum principle gives the extremal Schmidt-rank overlap, while the
 Choi criteria lead to the strict positivity thresholds of the reduction
 family. The chapter concludes with positive maps outside complete positivity,
 the partial transpose and PPT property, separable states, Schmidt number, and
-the full reduction criterion.
+the full reduction criterion. A closing section treats the eigenvalue degeneracy
+forced by an anti-unitary symmetry of square $-\Id$.
 
 \input{chapter/ch25_positive_not_cp_trace_normalization_and_lorentz_cone}
 \input{chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi}
@@ -16,3 +17,4 @@ the full reduction criterion.
 \input{chapter/ch25_positive_not_cp_choi_and_decomposable_maps}
 \input{chapter/ch25_positive_not_cp_ppt_and_separable_states}
 \input{chapter/ch25_positive_not_cp_schmidt_number_and_entanglement}
+\input{chapter/ch25_positive_not_cp_kramers_degeneracy}

--- a/blueprint/src/chapter/ch25_positive_not_cp_kramers_degeneracy.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_kramers_degeneracy.tex
@@ -1,0 +1,40 @@
+\section{Kramers degeneracy}
+
+\begin{theorem}[Kramers' theorem]
+    \label{thm:kramers_degeneracy}
+    \lean{Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary}
+    \leanok
+    Let $H\in\MN{D}$ be Hermitian and let $T$ be an anti-unitary operator with
+    $[H,T]=0$ and $T^2=-\Id$. Then every eigenvalue of $H$ is at least two-fold
+    degenerate. Writing $T=\Gamma V$ with $\Gamma$ complex conjugation and $V$
+    unitary, the two hypotheses become $HV^\dagger=V^\dagger H^T$ and $V^T=-V$,
+    and the theorem is proved in that matrix form
+    \cite[Chapter~3, Kramer's theorem]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Let $H\ket{\psi}=\lambda\ket{\psi}$ with $\ket{\psi}\neq 0$, and set
+    $\ket{\varphi}=V^\dagger\ket{\overline{\psi}}$. Hermiticity gives
+    $H^T=\overline{H}$ and $\lambda\in\R$, so
+    \begin{align}
+        H\ket{\varphi}
+         & =HV^\dagger\ket{\overline{\psi}}
+        =V^\dagger H^T\ket{\overline{\psi}}
+        =V^\dagger\overline{H}\ket{\overline{\psi}}
+        =\lambda V^\dagger\ket{\overline{\psi}}
+        =\lambda\ket{\varphi},
+        \notag
+    \end{align}
+    and $\ket{\varphi}\neq 0$ because $V$ is unitary. Antisymmetry of $V$ passes
+    to $V^\dagger$, since $(V^\dagger)^T=\overline{V}=-V^\dagger$, and the
+    quadratic form of an antisymmetric matrix is its own negative, whence
+    \begin{align}
+        \braket{\psi}{\varphi}
+         & =\bra{\psi}V^\dagger\ket{\overline{\psi}}
+        =-\bra{\psi}V^\dagger\ket{\overline{\psi}}
+        =0.
+        \notag
+    \end{align}
+    Thus $\ket{\psi}$ and $\ket{\varphi}$ are orthogonal non-zero vectors in the
+    eigenspace of $\lambda$, which therefore has dimension at least two.
+\end{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_kramers_degeneracy.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_kramers_degeneracy.tex
@@ -23,7 +23,6 @@
         =V^\dagger\overline{H}\ket{\overline{\psi}}
         =\lambda V^\dagger\ket{\overline{\psi}}
         =\lambda\ket{\varphi},
-        \notag
     \end{align}
     and $\ket{\varphi}\neq 0$ because $V$ is unitary. Antisymmetry of $V$ passes
     to $V^\dagger$, since $(V^\dagger)^T=\overline{V}=-V^\dagger$, and the
@@ -33,7 +32,6 @@
          & =\bra{\psi}V^\dagger\ket{\overline{\psi}}
         =-\bra{\psi}V^\dagger\ket{\overline{\psi}}
         =0.
-        \notag
     \end{align}
     Thus $\ket{\psi}$ and $\ket{\varphi}$ are orthogonal non-zero vectors in the
     eigenspace of $\lambda$, which therefore has dimension at least two.


### PR DESCRIPTION
## Wolf's statement

Wolf, *Quantum Channels & Operations*, Chapter 3 (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, line 503):

> **Kramer's theorem.** If $[H,T]=0$ and $T^2=-1$ for a Hermitian $H$ and anti-unitary $T$, then each eigenvalue of $H$ is at least two-fold degenerate.

## The matrix reduction is Wolf's own

The paragraph immediately preceding the theorem (line 500) performs the reduction itself:

> Suppose $[H,T]=0$ for some anti-unitary $T$ and Hermitian $H$. Writing $T=\Gamma V$ with $V$ unitary this becomes equivalent to $HV^\dagger = V^\dagger H^T$. Moreover, $T^2=-1$ is equivalent to $V^T=-V$ being anti-symmetric.

So the hypotheses `Vᴴ * V = 1`, `H * Vᴴ = Vᴴ * Hᵀ`, `Vᵀ = -V` are exactly Wolf's two conditions plus unitarity of `V`, transcribed with no addition. Wolf's printed proof manipulates only these matrix identities — it never uses `T` again. The formalization is therefore faithful to the source statement, not a strengthening of it: no hypothesis appears that is absent from Wolf's own reduced form.

"At least two-fold degenerate" is rendered as `2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' H) μ)`, the eigenspace dimension, which is the quantity Wolf's argument bounds (he exhibits two orthogonal eigenvectors); for Hermitian `H` geometric and algebraic multiplicity agree.

## Landed signature

```lean
theorem Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary
    {n : Type*} [Fintype n] [DecidableEq n] {H V : Matrix n n ℂ}
    (hH : H.IsHermitian) (hVunit : Vᴴ * V = 1) (hHV : H * Vᴴ = Vᴴ * Hᵀ) (hVanti : Vᵀ = -V)
    {μ : ℂ} (hμ : Module.End.HasEigenvalue (Matrix.toLin' H) μ) :
    2 ≤ Module.finrank ℂ (Module.End.eigenspace (Matrix.toLin' H) μ)
```

The proof is Wolf's, step for step: from `H ψ = μ ψ` set `φ = Vᴴ ψ̄`; then `H φ = Vᴴ Hᵀ ψ̄ = μ φ` using that `μ` is real for Hermitian `H`; `φ ≠ 0` because `V` is unitary; and `⟨ψ, φ⟩ = ψ̄ᵀ Vᴴ ψ̄ = 0` because `Vᵀ = -V` forces `(Vᴴ)ᵀ = -Vᴴ`, so the quadratic form of `Vᴴ` is its own negative.

Two supporting lemmas land alongside:

- `Matrix.dotProduct_mulVec_self_eq_zero_of_transpose_eq_neg` — the quadratic form of an antisymmetric complex matrix vanishes.
- `Matrix.two_le_finrank_eigenspace_of_linearIndependent_pair` — two independent eigenvectors for one eigenvalue bound the eigenspace dimension below by two.

## Why Kramer's theorem II is not in this PR

Wolf's second theorem (line 527) relaxes the hypothesis: `H` Hermitian and `HA = AHᵀ` for some antisymmetric `A ≠ 0`. Wolf remarks that "the same proof shows" it, but the same proof does **not** go through as written. With `V` unitary the vector `Vᴴ ψ̄` is automatically nonzero; for a general antisymmetric `A ≠ 0` the vector `A ψ̄` can vanish, since `A` need not be invertible and `ψ̄` may lie in its kernel. The nondegeneracy step therefore needs a genuinely different argument (the second eigenvector has to be produced on the range of `A`, or the eigenvalue restricted to eigenvectors outside `ker A`). Shipping it here would have required either an invertibility hypothesis Wolf does not state — which the faithfulness rule forbids — or a proof that is not the one in the source. Theorem II stays open on LionSR/QICLean#17.

## Verification

- `lake env lean TNLean/Algebra/KramersDegeneracy.lean` — exit 0, no errors, no warnings.
- `lake build TNLean.Algebra` — succeeds (aggregator regenerated).
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` — current.
- `rg -n "sorry|axiom|native_decide|maxHeartbeats" TNLean/Algebra/KramersDegeneracy.lean` — no matches.
- Line length: all lines ≤ 100 characters.

## Blueprint

New section `Kramers degeneracy` in the Wolf Chapter 3 blueprint chapter, with `\lean{...}`, `\leanok` on statement and proof.

Refs LionSR/QICLean#17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained Mathlib linear algebra with no auth, I/O, or runtime behavior; only library and documentation surface changes.
> 
> **Overview**
> Formalizes **Kramers' theorem** in Wolf's matrix form: for Hermitian `H`, unitary `V` with `Vᵀ = -V`, and `H * Vᴴ = Vᴴ * Hᵀ`, every eigenvalue has eigenspace dimension at least 2 (`Matrix.IsHermitian.two_le_finrank_eigenspace_of_antisymmetric_unitary`).
> 
> New file `TNLean/Algebra/KramersDegeneracy.lean` proves this via Wolf's second eigenvector `Vᴴ ψ̄`, with helpers for vanishing quadratic forms of antisymmetric matrices and for turning two independent eigenvectors into a dimension bound. The module is imported from the generated `TNLean.Algebra` aggregator.
> 
> The Wolf Chapter 3 blueprint gains a **Kramers degeneracy** section (`ch25_positive_not_cp_kramers_degeneracy.tex`) linked to the Lean theorem, and the chapter intro mentions anti-unitary symmetry with square `-Id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e656d7ab6e327fc58b397eecfae13e3d5069729c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->