### PR TITLE
test(tenkz): make the manual doctest catch a refusal block losing its diagnostic

### DIFF
--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -358,8 +358,9 @@ def _find_environment_end(text: str, environment: str, offset: int) -> re.Match[
     return pattern.search(text, offset)
 
 
-def _mask_display_environments(text: str) -> str:
-    masked = list(text)
+def _display_environment_spans(text: str) -> list[tuple[str, int, int]]:
+    """Displayed-environment spans in the order the example walk visits them."""
+    spans: list[tuple[str, int, int]] = []
     pattern = re.compile(
         r"^[ \t]*\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}",
         re.MULTILINE,
@@ -369,10 +370,15 @@ def _mask_display_environments(text: str) -> str:
         end = _find_environment_end(text, match.group(1), match.end())
         if end is None:
             break
-        for index in range(match.start(), end.end()):
-            if masked[index] != "\n":
-                masked[index] = " "
+        spans.append((match.group(1), match.start(), end.end()))
         offset = end.end()
+    return spans
+
+
+def _mask_display_environments(text: str) -> str:
+    masked = list(text)
+    for _, start, end in _display_environment_spans(text):
+        _blank_range(masked, start, end)
     return "".join(masked)
 
 

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import tempfile
+from collections import Counter
 from types import SimpleNamespace
 from pathlib import Path
 
@@ -47,6 +49,36 @@ def main() -> int:
         raise AssertionError(
             "no refusal block in the manual was pinned to [TKZ-EQ-SIGNATURE]: "
             f"found {sorted(codes)}"
+        )
+    # A refusal block that loses its classification silently becomes an
+    # ordinary example, and the assertions above stay green as long as one
+    # classified refusal survives.  Cross-check structurally: in every source
+    # file, each uncommented \begin{tnrefusal} must surface as exactly one
+    # extracted example carrying expected_failure.  Count-matching per file
+    # names the chapter that lost a refusal without pinning diagnostic codes
+    # or a numeric floor: renaming a diagnostic or retiring a refusal block
+    # removes both sides of the equation.
+    classified = Counter(
+        example.source.resolve() for example in manual if example.expected_failure
+    )
+    begin_refusal = re.compile(r"\\begin\{tnrefusal\}")
+    for source in DOCTEST._manual_sources():
+        declared = len(
+            begin_refusal.findall(
+                DOCTEST._strip_tex_comments(source.read_text(encoding="utf-8"))
+            )
+        )
+        extracted_refusals = classified.pop(source.resolve(), 0)
+        if declared != extracted_refusals:
+            raise AssertionError(
+                f"{source}: {declared} uncommented tnrefusal block(s) in the "
+                f"source, but {extracted_refusals} extracted example(s) carry "
+                "expected_failure"
+            )
+    if classified:
+        raise AssertionError(
+            "expected-failure examples came from files outside the manual "
+            f"source graph: {sorted(str(path) for path in classified)}"
         )
     if len(reference) < REFERENCE_FLOOR:
         raise AssertionError(

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -4,12 +4,13 @@
 from __future__ import annotations
 
 import importlib.util
-import re
 import sys
 import tempfile
 from collections import Counter
 from types import SimpleNamespace
 from pathlib import Path
+
+from tenkzlib.texcase import scan_environments
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -33,6 +34,33 @@ DISPLAYED_FLOOR = 49
 REFERENCE_FLOOR = 12
 
 
+def _declared_refusals(
+    text: str, source_dir: Path, inherited_conditionals: tuple[str, ...] = ()
+) -> int:
+    """Count the tnrefusal blocks TeX would execute in a chapter.
+
+    The count reads the chapter through the extractor's own preprocessing:
+    inert TeX is masked first, and displayed-environment bodies are excluded
+    by the same span walk the extractor uses, so a refusal quoted inside a
+    Verbatim block or parked in a dead conditional never enters the count.
+    A second pass with the shared environment scanner then charges refusal
+    begins the extractor cannot see — a spaced \\begin {tnrefusal} is
+    executable TeX — so an extractor blind spot fails the gate instead of
+    hiding inside it.
+    """
+    scan_text = DOCTEST._mask_inert_tex(text, source_dir, inherited_conditionals)
+    spans = DOCTEST._display_environment_spans(scan_text)
+    visible = sum(1 for name, _, _ in spans if name == "tnrefusal")
+    blind = len(
+        scan_environments(
+            DOCTEST._mask_nonexecuted_tokens(scan_text),
+            ("tnrefusal",),
+            ignored_control_spans=[(start, end) for _, start, end in spans],
+        )
+    )
+    return visible + blind
+
+
 def main() -> int:
     manual = DOCTEST.displayed_examples()
     reference = DOCTEST.reference_examples()
@@ -53,25 +81,24 @@ def main() -> int:
     # A refusal block that loses its classification silently becomes an
     # ordinary example, and the assertions above stay green as long as one
     # classified refusal survives.  Cross-check structurally: in every source
-    # file, each uncommented \begin{tnrefusal} must surface as exactly one
+    # file, each executable tnrefusal block must surface as exactly one
     # extracted example carrying expected_failure.  Count-matching per file
     # names the chapter that lost a refusal without pinning diagnostic codes
     # or a numeric floor: renaming a diagnostic or retiring a refusal block
-    # removes both sides of the equation.
+    # removes both sides of the equation.  The equality also holds in the
+    # reverse direction: a classification conjured from inert text leaves
+    # the declared side behind and fails the same check.
     classified = Counter(
         example.source.resolve() for example in manual if example.expected_failure
     )
-    begin_refusal = re.compile(r"\\begin\{tnrefusal\}")
-    for source in DOCTEST._manual_sources():
-        declared = len(
-            begin_refusal.findall(
-                DOCTEST._strip_tex_comments(source.read_text(encoding="utf-8"))
-            )
+    for source, inherited_conditionals in DOCTEST._manual_source_contexts():
+        declared = _declared_refusals(
+            source.read_text(encoding="utf-8"), source.parent, inherited_conditionals
         )
         extracted_refusals = classified.pop(source.resolve(), 0)
         if declared != extracted_refusals:
             raise AssertionError(
-                f"{source}: {declared} uncommented tnrefusal block(s) in the "
+                f"{source}: {declared} executable tnrefusal block(s) in the "
                 f"source, but {extracted_refusals} extracted example(s) carry "
                 "expected_failure"
             )
@@ -79,6 +106,31 @@ def main() -> int:
         raise AssertionError(
             "expected-failure examples came from files outside the manual "
             f"source graph: {sorted(str(path) for path in classified)}"
+        )
+    # The declared count answers to TeX, not to the extractor: a spaced
+    # begin is executable and counts, while a refusal quoted in a Verbatim
+    # body or parked in a dead conditional does not.
+    refusal_shapes = r"""
+\begin {tnrefusal}[diagnostic={[TKZ-SPACED] a spaced begin is executable}]
+spaced
+\end{tnrefusal}
+\begin{Verbatim}
+\begin{tnrefusal}[diagnostic={[TKZ-QUOTED] displayed, never executed}]
+\end{tnrefusal}
+\end{Verbatim}
+\iffalse
+\begin{tnrefusal}[diagnostic={[TKZ-DEAD] unreachable branch}]
+\end{tnrefusal}
+\fi
+\newcommand{\storedrefusal}{\begin{tnrefusal}}
+\begin{tnrefusal}[diagnostic={[TKZ-LIVE] the block the extractor sees}]
+live
+\end{tnrefusal}
+"""
+    if _declared_refusals(refusal_shapes, Path.cwd()) != 2:
+        raise AssertionError(
+            "the declared refusal count does not follow TeX execution: "
+            "expected the spaced and live blocks only"
         )
     if len(reference) < REFERENCE_FLOOR:
         raise AssertionError(


### PR DESCRIPTION
## Context

`scripts/test_tenkz_manual_doctest.py` asserted only that at least one extracted manual example carries `expected_failure` and that `[TKZ-EQ-SIGNATURE]` is among the codes. If the extraction path in `scripts/tenkz_manual_doctest.py` stops classifying some `tnrefusal` environments, those refusal blocks silently become ordinary examples — the doctest then compiles them expecting success — while the gate stays green as long as one classified refusal survives.

Per the design constraint recorded on the LionSR/TNLean#6182 thread, the mechanism must not fail when a diagnostic is renamed or a chapter legitimately retires a refusal; a pinned code set and a numeric floor were both explicitly rejected there.

## Change

Add a structural cross-check to `scripts/test_tenkz_manual_doctest.py`: independently count uncommented `\begin{tnrefusal}` occurrences per source file across `_manual_sources()` (comments stripped with the module's own `_strip_tex_comments`) and assert per-source-file equality with the number of extracted examples carrying `expected_failure`. A trailing check rejects expected-failure examples whose source lies outside the manual's input graph, so the two counters cover each other. Count-matching satisfies the LionSR/TNLean#6182 constraint: renaming a diagnostic changes neither side, and retiring a refusal block removes both sides of the equation.

## Watched failure

The task-suggested seed — dropping `"tnrefusal"` from `DISPLAY_ENVIRONMENTS` — does not reproduce the silent defect: the blocks vanish from extraction entirely, and the existing gate fails loudly first with `expected at least 49 displayed TeX examples, found 46` (the refusal assertions would also fail, since no refusal is extracted at all). The silent direction needs the block extracted but declassified.

Seeding the classification instead (`expected_failure` assigned only when the options contain `EQ-SIGNATURE`, at the `_refusal_diagnostic` call site) turns the two ch-catalogue refusals (`[TKZ-LANG-TOMBSTONE]`, `[TKZ-LANG-STRICT]`) into ordinary examples while the tutorial's `[TKZ-EQ-SIGNATURE]` block keeps its classification — and the unfixed test passes:

```
PASS: tenkz manual doctest extraction and reference coverage
```

With the new cross-check applied on top of that seed:

```
AssertionError: docs/tenkz/chapters2/ch-catalogue.tex: 2 uncommented tnrefusal
block(s) in the source, but 0 extracted example(s) carry expected_failure
```

Seed reverted; on clean code both `python3 scripts/test_tenkz_manual_doctest.py` and the full `python3 scripts/tenkz_manual_doctest.py` pass.

Closes LionSR/tenkz#210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wp4fSnSK2r5KhXHKSY8AQs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to manual doctest scripts and regression tests; no runtime or production TeX paths are modified.
> 
> **Overview**
> **Strengthens the tenkz manual doctest** so a `tnrefusal` block cannot lose `expected_failure` classification while the gate still passes because one classified refusal remains.
> 
> `scripts/tenkz_manual_doctest.py` factors **`_display_environment_spans`** out of **`_mask_display_environments`**, exposing the same span walk the extractor uses so tests can reason about displayed-environment regions without duplicating logic.
> 
> `scripts/test_tenkz_manual_doctest.py` adds **`_declared_refusals`**, which counts **executable** `\begin{tnrefusal}` blocks per chapter using the extractor’s inert-Tex masking and display-environment spans (quoted in `Verbatim`, dead `\iffalse` branches, etc. excluded). A second pass with **`scan_environments`** also counts refusal begins the display walk might miss (e.g. spaced `\begin {tnrefusal}`). For every file in **`_manual_source_contexts`**, the test asserts equality with the number of extracted examples carrying **`expected_failure`**, and rejects classifications from files outside the manual input graph. A small synthetic **`refusal_shapes`** fixture locks that counting behavior to TeX execution (expects 2: spaced + live only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3cfb65e783086914c1edb820990f00a9388cb4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->