### PR TITLE
fix(tenkz): drop the empty record clause from the strict-mode diagnostic

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -2516,6 +2516,16 @@ do
     echo "FAIL: $strict_negative lacked TKZ-LANG-STRICT" >&2
     exit 1
   }
+  # The strict guard fires before its command mints a record, so the
+  # diagnostic carries no record clause; the sentence ends at "is active."
+  if grep -Fq '(record' "$WORK/$strict_negative.transcript"; then
+    echo "FAIL: $strict_negative strict diagnostic carries a record clause" >&2
+    exit 1
+  fi
+  grep -Fq 'is active.' "$WORK/$strict_negative.transcript" || {
+    echo "FAIL: $strict_negative strict diagnostic lost its tail" >&2
+    exit 1
+  }
 done
 
 for contract_negative in \

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -65,7 +65,7 @@
   { [TKZ-WIND-SHAPE]~wind='#1'~must~be~an~integer~pair~\{p,q\}~
     (record~#2). }
 \msg_new:nnn {tenkz}{kernel-strict-sugar}
-  { [TKZ-LANG-STRICT]~'#1'~is~sugar~and~\tnset{strict}~is~active~(record~#2). }
+  { [TKZ-LANG-STRICT]~'#1'~is~sugar~and~\tnset{strict}~is~active. }
 \msg_new:nnn {tenkz}{kernel-declare-class}
   { [TKZ-LANG-DECLARE]~'#1'~is~not~a~declaration~class;~
     expected~atom|skin|species. }
@@ -1428,13 +1428,12 @@
   }
 
 % Sugar guard: under \tnset{strict} a sugar spelling is a coded error.
+% The guard fires before its command mints a record, so the diagnostic
+% carries no record clause.
 \cs_new_protected:Npn \__tenkz_kernel_sugar:n #1
   {
     \bool_if:NT \l__tenkz_kernel_strict_bool
-      {
-        \msg_error:nnee {tenkz}{kernel-strict-sugar} {#1}
-          { \tl_use:N \l__tenkz_model_last_tl }
-      }
+      { \msg_error:nnn {tenkz}{kernel-strict-sugar} {#1} }
   }
 
 % ---------- picture-scope sugar expansions -------------------------------------------


### PR DESCRIPTION
# Context

`[TKZ-LANG-STRICT]` ended with the kernel's record clause, but the sugar guard `\__tenkz_kernel_sugar:n` fires before its command mints a record, so the clause had nothing true to say. Seven picture-scope desugar paths (`sandwich`, `planes`, `boundary`, `lattice`, `ring`, `surface`, `physical`) and the three command reassemblies (`tnbond`, `tnprose`, `tnfuse`) printed `(record )`; the atom-scope paths (`role`, `cluster`) named the atom record whose keys were still being read, a record the sentence is not about. The manual's catalogue chapter quotes diagnostics verbatim and already printed the clause-free sentence, which the defect made untrue on the page (found in LionSR/TNLean#6182).

Closes LionSR/tenkz#209.

# Change

- `tex/tenkz/tenkz-kernel.code.tex`: the `kernel-strict-sugar` message takes one argument and ends at `is active.`; the guard no longer passes `\l__tenkz_model_last_tl`. Two lines, plus a comment stating the constraint.
- `scripts/tenkz_kernel_probes.sh`: the strict-negative loop now refuses `(record` in each transcript and requires the `is active.` tail, so the message shape is pinned by a compile, not by a source grep. The edit is one hunk inside the strict loop (line 2516), clear of LionSR/TNLean#6296's extraction-awk region.

The catalogue quotation at `docs/tenkz/chapters2/ch-catalogue.tex:695-696` already prints the clause-free sentence and is now verbatim-true; no manual edit was needed. `grep -rn "record " docs/tenkz/chapters2/ | grep -i strict` finds nothing else. The registry row for `strict` (`tenkz-language-registry.tex:246`) is prose and quotes no message text.

# Watched failures

Against the unfixed kernel, all five strict negatives tripped both new assertions:

```
n_strict_sandwich refused strict-ok RECORD-CLAUSE TAIL-MISSING
n_strict_role     refused strict-ok RECORD-CLAUSE TAIL-MISSING
n_strict_tnbond   refused strict-ok RECORD-CLAUSE TAIL-MISSING
n_strict_tnprose  refused strict-ok RECORD-CLAUSE TAIL-MISSING
n_strict_tnfuse   refused strict-ok RECORD-CLAUSE TAIL-MISSING
```

with the defect on the page in two shapes:

```
! Package tenkz Error: [TKZ-LANG-STRICT] 'tnbond' is sugar and \tnset {strict}
(tenkz)                is active (record ).
! Package tenkz Error: [TKZ-LANG-STRICT] 'role' is sugar and \tnset {strict}
(tenkz)                is active (record atom-1).
```

After the kernel fix, all five report `no-record-clause tail-ok` and the transcript reads:

```
! Package tenkz Error: [TKZ-LANG-STRICT] 'sandwich' is sugar and \tnset
(tenkz)                {strict} is active.
```

# Message audit

The desugar family's own refusals all fill their record slot with a literal and cannot print empty:

| Site | Message | Record slot | Why it cannot fire empty |
|---|---|---|---|
| `desugar_boundary` (kernel:1451) | `kernel-choice` | literal `picture` | filled |
| `desugar_lattice` (kernel:1475) | `kernel-sugar-value` | literal `picture` | filled |
| `desugar_ring` (kernel:1489) | `kernel-sugar-value` | literal `picture` | filled |
| `desugar_surface` (kernel:1502) | `kernel-sugar-value` | literal `picture` | filled |
| `desugar_physical` (kernel:1519) | `kernel-choice` | literal `picture` | filled |
| `desugar_cluster` (kernel:1534) | `kernel-sugar-value` | literal `atom` | filled |
| `cluster_expand` (kernel:1576) | `kernel-sugar-value` | carrying atom's name | runs at commit time; `kernel-cluster-name` fires first when no name was staged |
| setup `strict` (kernel:1372) | `kernel-choice` | literal `setup` | filled |

The shared alphabet validators do pass `\l__tenkz_model_last_tl`. At body scope the slot is always truthful, because every command mints its record before parsing its keys (`\__tenkz_kernel_tn:nn` 1978→1980, `\__tenkz_kernel_tnwire:nnnn` 2460→2462, `\__tenkz_kernel_tnmark:nnn` 2502→2504); this covers `weight`/`route`/`crossing` (836/864/892), `kernel-tombstone` (935, mark family only), `kernel-atom-positive` (992), and every atom/wire/mark instance of `kernel-choice` (911) and `kernel-unknown-key` (1024).

Their picture- and setup-scope instances CAN still fire before any record exists and print `(record )` today: the picture choices `bonds`/`size`/`metrics`, the side policies `west`/`east`/`north`/`south` (971), and the `unknown` handlers of the picture, setup, and declare families. Code path: `\__tenkz_kernel_begin:n` runs `\__tenkz_model_reset:` (19351, clears `\l__tenkz_model_last_tl`) before `\__tenkz_kernel_keys:nn {tenkz-kernel-picture}` (19378), and the picture record is minted only afterwards (19420); `\tnset`/`\tndeclare` run at document scope where the token list was never set. Filling those slots needs a scope word the shared helpers do not carry (the frame family's unknown handler at 1137 shows the fill pattern), so it is left out of this message-text fix and tracked in the follow-up issue linked below.

# Gates

- strict-negative loop assertions: watched failing pre-fix, passing post-fix (transcripts above).
- `python3 scripts/tenkz_language.py check`: `PASS: tenkz language registry (113 records)`.
- `python3 scripts/tenkz_manual_doctest.py`: `PASS: 49 displayed manual examples and 12 reference examples` (the catalogue's strict refusal block is among them; it must fail with the quoted `[TKZ-LANG-STRICT]` code, and does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wp4fSnSK2r5KhXHKSY8AQs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to one error message and its call site plus test assertions; no auth, data, or runtime behavior beyond diagnostic text.
> 
> **Overview**
> **[TKZ-LANG-STRICT]** no longer appends a `(record …)` clause when `\tnset{strict}` rejects sugar spellings. The strict guard runs before a record exists, so the old clause was empty or misleading; the message now ends at **is active.** with only the sugar name as an argument.
> 
> `\__tenkz_kernel_sugar:n` calls `msg_error:nnn` instead of passing `\l__tenkz_model_last_tl`. The kernel probe loop for strict negatives now fails if the compile transcript contains `(record` and requires the **`is active.`** tail, locking the diagnostic shape to a real compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db34482e9869bab751d5f0274479ab897969445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->