### PR TITLE
feat(MPS/MPDO): certify CPSV entropy arithmetic

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -86,6 +86,7 @@ import TNLean.MPS.MPDO.CPSVBNTFusionTensorClauseFromRFP
 import TNLean.MPS.MPDO.CPSVBNTTheoremEquivalence
 import TNLean.MPS.MPDO.CPSVBlocking
 import TNLean.MPS.MPDO.CPSVExample412Literal
+import TNLean.MPS.MPDO.CPSVExamples410411Arithmetic
 import TNLean.MPS.MPDO.CPSVFigureEight
 import TNLean.MPS.MPDO.CPSVGroupedFigureEight
 import TNLean.MPS.MPDO.CPSVGroupedGramNormalization

--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -20,10 +20,10 @@ and
 This module certifies these comparisons and the positivity of the logarithms of
 their ratios.
 
-The proofs first evaluate both sides as natural numbers. Casting the resulting
-strict inequalities to the real numbers and dividing by the positive
-denominators shows that each ratio is greater than one. Strict monotonicity of
-the real logarithm at one then gives the logarithmic statements.
+Normalization directly certifies all four closed arithmetic goals. For each
+logarithmic statement, `Real.log_pos` first reduces positivity of the logarithm
+to the assertion that its ratio is greater than one; normalization then closes
+that rational inequality.
 
 These scalar results do not identify reduced-state spectra and do not assert
 saturation or failure of an area law. Such conclusions require separate formal
@@ -35,15 +35,13 @@ links from the printed tensors to the corresponding entropy expressions.
   the four-site calculation for Example 4.10.
 * `example411_integer_inequality`: the exact integer comparison associated with
   the four-site calculation for Example 4.11.
-* `example410_logRatio_pos`: positivity of the first logarithmic ratio.
-* `example411_logRatio_pos`: positivity of the second logarithmic ratio.
+* `example410_log_ratio_pos`: positivity of the first logarithmic ratio.
+* `example411_log_ratio_pos`: positivity of the second logarithmic ratio.
 
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Examples 4.10 and
   4.11, lines 897--924.
-* `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex` for the scope boundary of
-  these scalar statements.
 -/
 
 namespace CPSVExamples410411Arithmetic
@@ -51,8 +49,7 @@ namespace CPSVExamples410411Arithmetic
 /-- The strict integer comparison arising in the exact four-site calculation
 for CPSV16 Example 4.10.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; scope in
-`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`. -/
+Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
 theorem example410_integer_inequality :
     (2 : ℕ) ^ 32 * 7 ^ 7 > 3 ^ 3 * 5 ^ 20 := by
   norm_num
@@ -60,8 +57,7 @@ theorem example410_integer_inequality :
 /-- The strict integer comparison arising in the exact four-site calculation
 for the literal weights printed in CPSV16 Example 4.11.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924; scope in
-`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`. -/
+Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924. -/
 theorem example411_integer_inequality :
     (41 : ℕ) ^ 82 * 5 ^ 50 > 2 ^ 48 * 13 ^ 52 * 7 ^ 112 := by
   norm_num
@@ -72,9 +68,8 @@ strictly positive.
 This is only a scalar arithmetic statement; it does not identify the ratio with
 an entropy difference.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; scope in
-`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`. -/
-theorem example410_logRatio_pos :
+Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+theorem example410_log_ratio_pos :
     0 < Real.log (((2 : ℝ) ^ 32 * 7 ^ 7) / (3 ^ 3 * 5 ^ 20)) := by
   apply Real.log_pos
   norm_num
@@ -85,9 +80,8 @@ CPSV16 Example 4.11 is strictly positive.
 This is only a scalar arithmetic statement; it does not identify the ratio with
 an entropy difference.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924; scope in
-`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`. -/
-theorem example411_logRatio_pos :
+Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924. -/
+theorem example411_log_ratio_pos :
     0 < Real.log
       (((41 : ℝ) ^ 82 * 5 ^ 50) / (2 ^ 48 * 13 ^ 52 * 7 ^ 112)) := by
   apply Real.log_pos

--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Tactic.NormNum
 
 /-!
 # Exact arithmetic for CPSV16 Examples 4.10 and 4.11

--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -42,7 +42,8 @@ links from the printed tensors to the corresponding entropy expressions.
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Examples 4.10 and
   4.11, lines 897--924.
-* TNLean issue #5984.
+* `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex` for the scope boundary of
+  these scalar statements.
 -/
 
 namespace CPSVExamples410411Arithmetic
@@ -50,7 +51,8 @@ namespace CPSVExamples410411Arithmetic
 /-- The strict integer comparison arising in the exact four-site calculation
 for CPSV16 Example 4.10.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; issue #5984. -/
+Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; scope in
+`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`. -/
 theorem example410_integer_inequality :
     (2 : ℕ) ^ 32 * 7 ^ 7 > 3 ^ 3 * 5 ^ 20 := by
   norm_num
@@ -58,7 +60,8 @@ theorem example410_integer_inequality :
 /-- The strict integer comparison arising in the exact four-site calculation
 for the literal weights printed in CPSV16 Example 4.11.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924; issue #5984. -/
+Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924; scope in
+`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`. -/
 theorem example411_integer_inequality :
     (41 : ℕ) ^ 82 * 5 ^ 50 > 2 ^ 48 * 13 ^ 52 * 7 ^ 112 := by
   norm_num
@@ -69,7 +72,8 @@ strictly positive.
 This is only a scalar arithmetic statement; it does not identify the ratio with
 an entropy difference.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; issue #5984. -/
+Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; scope in
+`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`. -/
 theorem example410_logRatio_pos :
     0 < Real.log (((2 : ℝ) ^ 32 * 7 ^ 7) / (3 ^ 3 * 5 ^ 20)) := by
   apply Real.log_pos
@@ -81,7 +85,8 @@ CPSV16 Example 4.11 is strictly positive.
 This is only a scalar arithmetic statement; it does not identify the ratio with
 an entropy difference.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924; issue #5984. -/
+Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924; scope in
+`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`. -/
 theorem example411_logRatio_pos :
     0 < Real.log
       (((41 : ℝ) ^ 82 * 5 ^ 50) / (2 ^ 48 * 13 ^ 52 * 7 ^ 112)) := by

--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+/-!
+# Exact arithmetic for CPSV16 Examples 4.10 and 4.11
+
+The finite four-site calculations associated with CPSV16 Examples 4.10 and 4.11
+lead to the strict integer comparisons
+\[
+  2^{32}7^7>3^3 5^{20}
+\]
+and
+\[
+  41^{82}5^{50}>2^{48}13^{52}7^{112}.
+\]
+This module certifies these comparisons and the positivity of the logarithms of
+their ratios.
+
+The proofs first evaluate both sides as natural numbers. Casting the resulting
+strict inequalities to the real numbers and dividing by the positive
+denominators shows that each ratio is greater than one. Strict monotonicity of
+the real logarithm at one then gives the logarithmic statements.
+
+These scalar results do not identify reduced-state spectra and do not assert
+saturation or failure of an area law. Such conclusions require separate formal
+links from the printed tensors to the corresponding entropy expressions.
+
+## Main results
+
+* `example410_integer_inequality`: the exact integer comparison associated with
+  the four-site calculation for Example 4.10.
+* `example411_integer_inequality`: the exact integer comparison associated with
+  the four-site calculation for Example 4.11.
+* `example410_logRatio_pos`: positivity of the first logarithmic ratio.
+* `example411_logRatio_pos`: positivity of the second logarithmic ratio.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Examples 4.10 and
+  4.11, lines 897--924.
+* TNLean issue #5984.
+-/
+
+namespace CPSVExamples410411Arithmetic
+
+/-- The strict integer comparison arising in the exact four-site calculation
+for CPSV16 Example 4.10.
+
+Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; issue #5984. -/
+theorem example410_integer_inequality :
+    (2 : ℕ) ^ 32 * 7 ^ 7 > 3 ^ 3 * 5 ^ 20 := by
+  norm_num
+
+/-- The strict integer comparison arising in the exact four-site calculation
+for the literal weights printed in CPSV16 Example 4.11.
+
+Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924; issue #5984. -/
+theorem example411_integer_inequality :
+    (41 : ℕ) ^ 82 * 5 ^ 50 > 2 ^ 48 * 13 ^ 52 * 7 ^ 112 := by
+  norm_num
+
+/-- The logarithm of the exact ratio associated with CPSV16 Example 4.10 is
+strictly positive.
+
+This is only a scalar arithmetic statement; it does not identify the ratio with
+an entropy difference.
+
+Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905; issue #5984. -/
+theorem example410_logRatio_pos :
+    0 < Real.log (((2 : ℝ) ^ 32 * 7 ^ 7) / (3 ^ 3 * 5 ^ 20)) := by
+  apply Real.log_pos
+  norm_num
+
+/-- The logarithm of the exact ratio associated with the literal weights in
+CPSV16 Example 4.11 is strictly positive.
+
+This is only a scalar arithmetic statement; it does not identify the ratio with
+an entropy difference.
+
+Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924; issue #5984. -/
+theorem example411_logRatio_pos :
+    0 < Real.log
+      (((41 : ℝ) ^ 82 * 5 ^ 50) / (2 ^ 48 * 13 ^ 52 * 7 ^ 112)) := by
+  apply Real.log_pos
+  norm_num
+
+end CPSVExamples410411Arithmetic

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -168,6 +168,10 @@ For MPDO renormalization fixed points:
   exact normalization boundary between supported and complementary sectors.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
+- `cpsv16_exact_arithmetic_scope.tex` records the scope boundary of the
+  certified four-site arithmetic for Examples~4.10 and~4.11: the exact integer
+  comparisons and logarithmic ratios are machine-checked, while the reduced
+  spectra, entropy comparisons, and SAL conclusions remain open.
 
 For the non-periodic MPS Fundamental Theorem background:
 

--- a/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
+++ b/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
@@ -39,8 +39,8 @@ machine-checks the two integer inequalities,
 \leanid{CPSVExamples410411Arithmetic.example410_integer_inequality} and
 \leanid{CPSVExamples410411Arithmetic.example411_integer_inequality},
 and the positivity of the corresponding logarithmic ratios,
-\leanid{CPSVExamples410411Arithmetic.example410_logRatio_pos} and
-\leanid{CPSVExamples410411Arithmetic.example411_logRatio_pos}.
+\leanid{CPSVExamples410411Arithmetic.example410_log_ratio_pos} and
+\leanid{CPSVExamples410411Arithmetic.example411_log_ratio_pos}.
 
 \section{Scope boundary}
 
@@ -51,7 +51,8 @@ assert saturation or failure of an area law.  Deriving the entropy
 comparisons requires separate formal links from the printed tensors to the
 corresponding entropy expressions.  Those links, and the resulting
 corrections to or confirmations of the printed zero-correlation-length and
-SAL claims, remain open in \ghissue{5984}.
+SAL claims, remain under the Example~4.10 and Example~4.11 implementation tasks
+\ghissue{6301} and \ghissue{6302}, respectively.
 
 \section{Verdict}
 

--- a/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
+++ b/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
@@ -44,10 +44,12 @@ and the positivity of the corresponding logarithmic ratios,
 
 \section{Scope boundary}
 
-These are scalar arithmetic statements.  They do not identify the
-reduced-state spectra of the printed tensors, do not assert the entropy
-comparisons $I_2>I_1$ discussed in Examples~4.10 and~4.11, and do not
-assert saturation or failure of an area law.  Deriving the entropy
+For the four-site states, let $S_L$ denote the entropy of $L$ neighboring
+sites and define the chain mutual information by
+$I_L=S_L+S_{4-L}-S_4$.  These are scalar arithmetic statements.  They do
+not identify the reduced-state spectra of the printed tensors, do not assert
+the entropy comparisons $I_2>I_1$ discussed in Examples~4.10 and~4.11, and
+do not assert saturation or failure of an area law.  Deriving the entropy
 comparisons requires separate formal links from the printed tensors to the
 corresponding entropy expressions.  Those links, and the resulting
 corrections to or confirmations of the printed zero-correlation-length and
@@ -56,9 +58,9 @@ SAL claims, remain under the Example~4.10 and Example~4.11 implementation tasks
 
 \section{Verdict}
 
-\textbf{Verdict: the arithmetic endpoints are certified; the entropy
-conclusions are not.}  The exact comparisons on which the four-site
-calculations rest are machine-checked, but nothing here is a formalization
-of the printed entropy or area-law claims themselves.
+\textbf{Verdict: scope restriction.}  The arithmetic endpoints are certified,
+but the entropy conclusions are not.  The exact comparisons on which the
+four-site calculations rest are machine-checked, but nothing here is a
+formalization of the printed entropy or area-law claims themselves.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
+++ b/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
@@ -1,0 +1,63 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Exact arithmetic scope for CPSV16 Examples 4.10 and 4.11}
+\author{}
+\date{2026-08-12}
+
+\begin{document}
+\maketitle
+
+\section{Printed comparisons}
+
+Examples~4.10 and~4.11 of Cirac--Perez-Garcia--Schuch--Verstraete
+(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:897--924}) print four-site
+calculations whose entropy comparisons reduce to two strict inequalities of
+natural numbers:
+\[
+  2^{32}7^7>3^3 5^{20}
+\]
+for Example~4.10, and
+\[
+  41^{82}5^{50}>2^{48}13^{52}7^{112}
+\]
+for the bond weights printed in Example~4.11.  Both sides of each comparison
+are positive integers, so each strict inequality is equivalent to positivity
+of the real logarithm of the corresponding ratio.
+
+\section{Certified statements}
+
+The module
+\doclink{TNLean/MPS/MPDO/CPSVExamples410411Arithmetic}
+machine-checks the two integer inequalities,
+\leanid{CPSVExamples410411Arithmetic.example410_integer_inequality} and
+\leanid{CPSVExamples410411Arithmetic.example411_integer_inequality},
+and the positivity of the corresponding logarithmic ratios,
+\leanid{CPSVExamples410411Arithmetic.example410_logRatio_pos} and
+\leanid{CPSVExamples410411Arithmetic.example411_logRatio_pos}.
+
+\section{Scope boundary}
+
+These are scalar arithmetic statements.  They do not identify the
+reduced-state spectra of the printed tensors, do not assert the entropy
+comparisons $I_2>I_1$ discussed in Examples~4.10 and~4.11, and do not
+assert saturation or failure of an area law.  Deriving the entropy
+comparisons requires separate formal links from the printed tensors to the
+corresponding entropy expressions.  Those links, and the resulting
+corrections to or confirmations of the printed zero-correlation-length and
+SAL claims, remain open in \ghissue{5984}.
+
+\section{Verdict}
+
+\textbf{Verdict: the arithmetic endpoints are certified; the entropy
+conclusions are not.}  The exact comparisons on which the four-site
+calculations rest are machine-checked, but nothing here is a formalization
+of the printed entropy or area-law claims themselves.
+
+\end{document}


### PR DESCRIPTION
## Summary

- certify the exact integer inequalities underlying the corrected four-site entropy comparisons for CPSV16 Examples 4.10 and 4.11
- prove positivity of the corresponding real logarithm ratios
- keep these scalar endpoints explicitly separate from the still-pending spectral, entropy-identity, and SAL links

## Source and tracking

- CPSV16 Examples 4.10–4.11, lines 897–924
- advances #5984
- arithmetic prerequisites for #6301 and #6302

## Verification

- `lake env lean TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean`
- generated import aggregator check
- Lean file-policy checks
- proof-integrity scan
- reader-facing prose check
- `git diff --check`

No broad Lake build was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained arithmetic proofs and paper-gap documentation; no changes to auth, data paths, or core MPS logic beyond a new import.
> 
> **Overview**
> Adds **`CPSVExamples410411Arithmetic`**, which machine-checks the two strict integer inequalities from CPSV16 four-site Examples 4.10 and 4.11 (`norm_num`) and proves the corresponding **`Real.log`** ratios are positive via **`Real.log_pos`** plus normalization. The module is wired into the MPS/MPDO import aggregator.
> 
> Documentation records an explicit **scope boundary**: these results certify scalar comparisons only—not reduced spectra, entropy identities \(I_2>I_1\), or area-law claims (tracked separately in issues 6301/6302).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6505487a1d87117b5c081eb64e59401f3d16a589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->