### PR TITLE
docs(blueprint): fix CPSV16 RFP dependencies and rank reference

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -956,7 +956,9 @@ the remaining sites unchanged.
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_fibonacci_periodic_count_golden_ratio,
+    \uses{def:cpsv_fibonacci_open_boundary_operator,
+      def:cpsv_fibonacci_periodic_count,
+      thm:cpsv_fibonacci_periodic_count_golden_ratio,
       thm:cpsv_fibonacci_open_boundary_rank_status,
       thm:to_mpo_diagonal_rank}
     The diagonal MPO rank counts physical words with nonzero periodic amplitude.
@@ -1010,9 +1012,9 @@ the remaining sites unchanged.
         \operatorname{rank}\rho^{(N)}(A)
         &=\operatorname{rank}\rho^{(1)}(A)
           \bigl(\operatorname{rank}P\bigr)^{N-1}.
-        \label{eq:cpsv-fibonacci-strong-rfp-rank}
+        \label{eq:cpsv_fib_strong_rfp_rank}
     \end{align}
-    Equation~\eqref{eq:cpsv-fibonacci-strong-rfp-rank} contradicts the
+    (\ref{eq:cpsv_fib_strong_rfp_rank}) contradicts the
     non-geometricity of the Fibonacci periodic ranks.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_strong.tex
@@ -190,7 +190,8 @@ change of basis. The matrix is not assumed to have trace one.
     \leanok
     \uses{thm:mpdo_strong_rfp_phys_close,
       thm:mpdo_strong_rfp_global_operator_identity,
-      lem:mpdo_localized_first_site_preparation}
+      lem:mpdo_localized_first_site_preparation,
+      thm:mpu_kronecker_rank}
     Unitary conjugation and relabelling of matrix coordinates preserve rank,
     while rank is multiplicative under Kronecker products. Applying these
     facts to (\ref{eq:mpdo_strong_rfp_global_closure}) gives the recurrence.


### PR DESCRIPTION
## Summary

- record the direct Kronecker-rank dependency in the Strong-RFP periodic rank proof
- record the open-boundary operator and periodic-count dependencies in the Fibonacci periodic rank proof
- conform the Fibonacci Strong-RFP rank display label and reference to Blueprint conventions

Closes #6278.
Closes #6285.
Closes #6293.

## Verification

- Blueprint-Lean synchronization: 7,382/7,382
- changed-file `chktex`
- literal reference/control-character scan
- `git diff --check`

No Lean declarations or mathematical statements changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only `\uses` and label/reference edits with no code or formal statement changes.
> 
> **Overview**
> This PR **only updates Blueprint–Lean synchronization metadata** in two CPSV16 strong-RFP chapters; no Lean declarations or mathematical statements change.
> 
> In **`ch21_mpdo_rfp_renormalization.tex`**, the Fibonacci periodic operator-rank proof now lists **`def:cpsv_fibonacci_open_boundary_operator`** and **`def:cpsv_fibonacci_periodic_count`** in `\uses`, alongside the existing golden-ratio and open-boundary rank theorems. The Fibonacci-not-strong-RFP contradiction proof renames display label **`eq:cpsv-fibonacci-strong-rfp-rank`** → **`eq:cpsv_fib_strong_rfp_rank`** and cites it with **`(\ref{...})`** instead of **`Equation~\eqref{...}`**, matching Blueprint naming conventions.
> 
> In **`ch21_mpdo_rfp_strong.tex`**, the geometric periodic rank-growth proof adds **`thm:mpu_kronecker_rank`** to `\uses`, explicitly tying the prose about multiplicative Kronecker rank to the existing MPU theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9cf5f5b2d7767a25cf4ad1c2534c2d6b75b8e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->