### PR TITLE
feat(analysis): classify two-projection compression spectrum

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -63,4 +63,5 @@ import TNLean.Analysis.TraceNormContractivity
 import TNLean.Analysis.TraceNormVariational
 import TNLean.Analysis.TwoProjectionAngleBlock
 import TNLean.Analysis.TwoProjectionCompression
+import TNLean.Analysis.TwoProjectionCompressionSpectrum
 import TNLean.Analysis.UpperTriangularBound

--- a/TNLean/Analysis/TwoProjectionCompressionSpectrum.lean
+++ b/TNLean/Analysis/TwoProjectionCompressionSpectrum.lean
@@ -9,10 +9,10 @@ import Mathlib.Analysis.InnerProductSpace.Spectrum
 /-!
 # Compression spectrum for the two-projection decomposition
 
-This file starts the global assembly in Jordan's lemma for two orthogonal
-projections.  It diagonalizes the compression of the second projection to the
-range of the first and classifies every compression eigenvector as an endpoint
-block or a genuine two-dimensional angle block.
+This file begins Jordan's lemma for two orthogonal projections: it diagonalizes
+the compression of the second projection to the range of the first and
+classifies every compression eigenvector as a common one-dimensional block
+(compression eigenvalue `0` or `1`) or a genuine two-dimensional angle block.
 
 The construction is the first global step used in arXiv:1703.09188,
 Proposition IV.5 (`prop:continuity-index`), lines 759–762.
@@ -40,8 +40,8 @@ noncomputable def rangeCompressionEigenvalues {P Q : E →ₗ[ℂ] E}
 
 /-- An orthonormal eigenbasis for the compression of `Q` to `range P`.
 
-This is the basis on the `P`-range from which the one- and two-dimensional
-blocks in arXiv:1703.09188, Proposition IV.5, lines 759–762 are assembled. -/
+This is the basis from which the one- and two-dimensional blocks in the
+`P`-range are obtained in arXiv:1703.09188, Proposition IV.5, lines 759–762. -/
 noncomputable def rangeCompressionEigenbasis {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     OrthonormalBasis (Fin (Module.finrank ℂ P.range)) ℂ P.range :=
@@ -82,10 +82,10 @@ theorem rangeCompressionEigenvalues_mem_unitInterval {P Q : E →ₗ[ℂ] E}
 blocks; every other eigenvector gives the normalized two-dimensional angle
 block from `exists_orthonormal_angle_block`.
 
-This is the spectral classification step in the global Jordan decomposition
-invoked in arXiv:1703.09188, Proposition IV.5, lines 759–762. It does not yet
-assemble the orthogonal complement of `range P`, nor define the reduced
-projector used later in that proof. -/
+This is the spectral classification used in the global Jordan decomposition
+of arXiv:1703.09188, Proposition IV.5, lines 759–762. It does not yet include
+the orthogonal complement of `range P` in the ambient orthogonal direct sum or
+define the reduced projector used later in that proof. -/
 theorem rangeCompressionEigenvalues_eq_zero_or_eq_one_or_exists_angle_block
     {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)

--- a/TNLean/Analysis/TwoProjectionCompressionSpectrum.lean
+++ b/TNLean/Analysis/TwoProjectionCompressionSpectrum.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.TwoProjectionAngleBlock
+import Mathlib.Analysis.InnerProductSpace.Spectrum
+
+/-!
+# Compression spectrum for the two-projection decomposition
+
+This file starts the global assembly in Jordan's lemma for two orthogonal
+projections.  It diagonalizes the compression of the second projection to the
+range of the first and classifies every compression eigenvector as an endpoint
+block or a genuine two-dimensional angle block.
+
+The construction is the first global step used in arXiv:1703.09188,
+Proposition IV.5 (`prop:continuity-index`), lines 759–762.
+
+**Local fix (projector label):** Source line 762 repeats `P` for the second
+projector, where the surrounding argument requires `Q`; see
+`docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+-/
+
+open scoped InnerProductSpace
+
+namespace LinearMap.IsSymmetricProjection
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+/-- The ordered real eigenvalues of the compression of `Q` to `range P`.
+
+This is the spectral parameter family used in the Jordan decomposition from
+arXiv:1703.09188, Proposition IV.5, lines 759–762. -/
+noncomputable def rangeCompressionEigenvalues {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    Fin (Module.finrank ℂ P.range) → ℝ :=
+  (rangeCompression_isSymmetric hP hQ).eigenvalues rfl
+
+/-- An orthonormal eigenbasis for the compression of `Q` to `range P`.
+
+This is the basis on the `P`-range from which the one- and two-dimensional
+blocks in arXiv:1703.09188, Proposition IV.5, lines 759–762 are assembled. -/
+noncomputable def rangeCompressionEigenbasis {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    OrthonormalBasis (Fin (Module.finrank ℂ P.range)) ℂ P.range :=
+  (rangeCompression_isSymmetric hP hQ).eigenvectorBasis rfl
+
+/-- The compression acts diagonally on `rangeCompressionEigenbasis`. -/
+theorem rangeCompression_apply_eigenbasis {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : Fin (Module.finrank ℂ P.range)) :
+    rangeCompression hP (Q := Q) (rangeCompressionEigenbasis hP hQ i) =
+      (rangeCompressionEigenvalues hP hQ i : ℂ) •
+        rangeCompressionEigenbasis hP hQ i := by
+  exact (rangeCompression_isSymmetric hP hQ).apply_eigenvectorBasis rfl i
+
+/-- Every eigenvalue of the compressed projection belongs to `[0,1]`.
+
+These endpoint bounds separate the commuting one-dimensional summands from the
+genuine angle blocks in arXiv:1703.09188, Proposition IV.5, lines 759–762. -/
+theorem rangeCompressionEigenvalues_mem_unitInterval {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : Fin (Module.finrank ℂ P.range)) :
+    rangeCompressionEigenvalues hP hQ i ∈ Set.Icc (0 : ℝ) 1 := by
+  let x := rangeCompressionEigenbasis hP hQ i
+  let μ := rangeCompressionEigenvalues hP hQ i
+  have hxnorm : ‖(x : E)‖ = 1 := by
+    exact (rangeCompressionEigenbasis hP hQ).norm_eq_one i
+  have hxP : P (x : E) = x := by
+    obtain ⟨z, hz⟩ := x.property
+    rw [← hz]
+    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
+  have hxEig : P (Q (x : E)) = (μ : ℂ) • (x : E) := by
+    exact congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+  obtain ⟨_, _, _, _, hnorm⟩ := angleDefect_block hP hQ hxP hxnorm hxEig
+  change 0 ≤ μ ∧ μ ≤ 1
+  constructor <;> nlinarith [sq_nonneg ‖angleDefect Q μ (x : E)‖]
+
+/-- Compression eigenvectors at `0` and `1` give common one-dimensional
+blocks; every other eigenvector gives the normalized two-dimensional angle
+block from `exists_orthonormal_angle_block`.
+
+This is the spectral classification step in the global Jordan decomposition
+invoked in arXiv:1703.09188, Proposition IV.5, lines 759–762. It does not yet
+assemble the orthogonal complement of `range P`, nor define the reduced
+projector used later in that proof. -/
+theorem rangeCompressionEigenvalues_eq_zero_or_eq_one_or_exists_angle_block
+    {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : Fin (Module.finrank ℂ P.range)) :
+    let x : E := rangeCompressionEigenbasis hP hQ i
+    let μ := rangeCompressionEigenvalues hP hQ i
+    (μ = 0 ∧ Q x = 0) ∨ (μ = 1 ∧ Q x = x) ∨
+      (0 < μ ∧ μ < 1 ∧ ∃ w : E,
+        P w = 0 ∧ ‖w‖ = 1 ∧ ⟪x, w⟫_ℂ = 0 ∧
+        Q x = (μ : ℂ) • x + (Real.sqrt (μ * (1 - μ)) : ℂ) • w ∧
+        Q w = (Real.sqrt (μ * (1 - μ)) : ℂ) • x +
+          ((1 - μ : ℝ) : ℂ) • w) := by
+  let x : E := rangeCompressionEigenbasis hP hQ i
+  let μ := rangeCompressionEigenvalues hP hQ i
+  have hxnorm : ‖x‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
+  have hxP : P x = x := by
+    let xr : P.range := rangeCompressionEigenbasis hP hQ i
+    obtain ⟨z, hz⟩ := xr.property
+    change P (xr : E) = xr
+    rw [← hz]
+    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
+  have hxEig : P (Q x) = (μ : ℂ) • x := by
+    exact congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+  have hμ := rangeCompressionEigenvalues_mem_unitInterval hP hQ i
+  rcases hμ with ⟨hμ0, hμ1⟩
+  rcases eq_or_lt_of_le hμ0 with hμeq | hμpos
+  · left
+    refine ⟨hμeq.symm, ?_⟩
+    obtain ⟨_, _, _, _, hnorm⟩ := angleDefect_block hP hQ hxP hxnorm hxEig
+    have hdefect : angleDefect Q μ x = 0 := by
+      apply norm_eq_zero.mp
+      nlinarith [norm_nonneg (angleDefect Q μ x)]
+    have hμzero : μ = 0 := hμeq.symm
+    have hdefect0 : angleDefect Q 0 x = 0 := by simpa [hμzero] using hdefect
+    calc
+      Q x = (μ : ℂ) • x + angleDefect Q μ x := by simp [angleDefect]
+      _ = 0 := by simp [hμzero, hdefect0]
+  · rcases eq_or_lt_of_le hμ1 with hμeq | hμlt
+    · right; left
+      refine ⟨hμeq, ?_⟩
+      obtain ⟨_, hxQ, _, _, hnorm⟩ := angleDefect_block hP hQ hxP hxnorm hxEig
+      have hdefect : angleDefect Q μ x = 0 := by
+        apply norm_eq_zero.mp
+        nlinarith [norm_nonneg (angleDefect Q μ x)]
+      have hμone : μ = 1 := hμeq
+      have hdefect1 : angleDefect Q 1 x = 0 := by simpa [hμone] using hdefect
+      calc
+        Q x = (μ : ℂ) • x + angleDefect Q μ x := hxQ
+        _ = x := by simp [hμone, hdefect1]
+    · right; right
+      exact ⟨hμpos, hμlt, exists_orthonormal_angle_block hP hQ hμpos hμlt hxP hxnorm hxEig⟩
+
+end LinearMap.IsSymmetricProjection

--- a/TNLean/Analysis/TwoProjectionCompressionSpectrum.lean
+++ b/TNLean/Analysis/TwoProjectionCompressionSpectrum.lean
@@ -66,14 +66,11 @@ theorem rangeCompressionEigenvalues_mem_unitInterval {P Q : E →ₗ[ℂ] E}
     rangeCompressionEigenvalues hP hQ i ∈ Set.Icc (0 : ℝ) 1 := by
   let x := rangeCompressionEigenbasis hP hQ i
   let μ := rangeCompressionEigenvalues hP hQ i
-  have hxnorm : ‖(x : E)‖ = 1 := by
-    exact (rangeCompressionEigenbasis hP hQ).norm_eq_one i
-  have hxP : P (x : E) = x := by
-    obtain ⟨z, hz⟩ := x.property
-    rw [← hz]
-    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
-  have hxEig : P (Q (x : E)) = (μ : ℂ) • (x : E) := by
-    exact congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+  have hxnorm : ‖(x : E)‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
+  have hxP : P (x : E) = x :=
+    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp x.property
+  have hxEig : P (Q (x : E)) = (μ : ℂ) • (x : E) :=
+    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
   obtain ⟨_, _, _, _, hnorm⟩ := angleDefect_block hP hQ hxP hxnorm hxEig
   change 0 ≤ μ ∧ μ ≤ 1
   constructor <;> nlinarith [sq_nonneg ‖angleDefect Q μ (x : E)‖]
@@ -101,14 +98,11 @@ theorem rangeCompressionEigenvalues_eq_zero_or_eq_one_or_exists_angle_block
   let x : E := rangeCompressionEigenbasis hP hQ i
   let μ := rangeCompressionEigenvalues hP hQ i
   have hxnorm : ‖x‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
-  have hxP : P x = x := by
-    let xr : P.range := rangeCompressionEigenbasis hP hQ i
-    obtain ⟨z, hz⟩ := xr.property
-    change P (xr : E) = xr
-    rw [← hz]
-    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
-  have hxEig : P (Q x) = (μ : ℂ) • x := by
-    exact congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+  have hxP : P x = x :=
+    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
+      (rangeCompressionEigenbasis hP hQ i).property
+  have hxEig : P (Q x) = (μ : ℂ) • x :=
+    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
   have hμ := rangeCompressionEigenvalues_mem_unitInterval hP hQ i
   rcases hμ with ⟨hμ0, hμ1⟩
   rcases eq_or_lt_of_le hμ0 with hμeq | hμpos

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5156,19 +5156,31 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   $w=d/\sqrt{\mu(1-\mu)}$ is well defined and has the stated properties.
 \end{proof}
 
+\begin{definition}[Compression spectral data]
+  \label{def:mpu_two_projection_compression_spectral_data}
+  \lean{LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues,
+    LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis}
+  \leanok
+  \uses{thm:mpu_two_projection_angle_block}
+  For orthogonal projections $P$ and $Q$ on a finite-dimensional complex
+  inner-product space, let $(x_i)_i$ be an orthonormal eigenbasis of the
+  compression of $Q$ to $\operatorname{ran}P$, with ordered real eigenvalues
+  $(\mu_i)_i$.
+  % Source lines: paper_v2.tex 759--762.
+\end{definition}
+
 \begin{theorem}[Compression-spectrum endpoint and angle-block trichotomy]
   \label{thm:mpu_two_projection_compression_spectrum}
-  \lean{LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues,
-    LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis,
-    LinearMap.IsSymmetricProjection.rangeCompression_apply_eigenbasis,
+  \lean{LinearMap.IsSymmetricProjection.rangeCompression_apply_eigenbasis,
     LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues_mem_unitInterval,
     LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues_eq_zero_or_eq_one_or_exists_angle_block}
   \leanok
-  \uses{thm:mpu_two_projection_angle_block}
+  \uses{def:mpu_two_projection_compression_spectral_data,
+    thm:mpu_two_projection_angle_block}
   Let $P$ and $Q$ be orthogonal projections on a finite-dimensional complex
-  inner-product space. The compression of $Q$ to $\operatorname{ran}P$ has an
-  orthonormal eigenbasis $(x_i)_i$ with real eigenvalues $\mu_i\in[0,1]$. For
-  every $i$, exactly the following source-relevant alternatives hold:
+  inner-product space, with compression spectral data $(x_i,\mu_i)$. Then
+  $\mu_i\in[0,1]$ for every $i$, and exactly the following source-relevant
+  alternatives hold:
   \begin{enumerate}
     \item $\mu_i=0$ and $Qx_i=0$;
     \item $\mu_i=1$ and $Qx_i=x_i$;
@@ -5182,12 +5194,13 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{thm:mpu_two_projection_angle_block}
   Apply the finite-dimensional spectral theorem to the self-adjoint compression
   of $Q$ to $\operatorname{ran}P$. For a unit compression eigenvector $x$ with
   eigenvalue $\mu$, the angle-defect identity gives
-  \[
-    \lVert Qx-\mu x\rVert^2=\mu(1-\mu),
-  \]
+  \begin{align}
+    \lVert Qx-\mu x\rVert^2&=\mu(1-\mu),
+  \end{align}
   hence $0\leq\mu\leq1$. At $\mu=0$ or $1$ the defect vanishes, giving the two
   common one-dimensional blocks. For $0<\mu<1$, apply
   Theorem~\ref{thm:mpu_two_projection_angle_block}.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5156,6 +5156,43 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   $w=d/\sqrt{\mu(1-\mu)}$ is well defined and has the stated properties.
 \end{proof}
 
+\begin{theorem}[Compression-spectrum endpoint and angle-block trichotomy]
+  \label{thm:mpu_two_projection_compression_spectrum}
+  \lean{LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues,
+    LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis,
+    LinearMap.IsSymmetricProjection.rangeCompression_apply_eigenbasis,
+    LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues_mem_unitInterval,
+    LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues_eq_zero_or_eq_one_or_exists_angle_block}
+  \leanok
+  \uses{thm:mpu_two_projection_angle_block}
+  Let $P$ and $Q$ be orthogonal projections on a finite-dimensional complex
+  inner-product space. The compression of $Q$ to $\operatorname{ran}P$ has an
+  orthonormal eigenbasis $(x_i)_i$ with real eigenvalues $\mu_i\in[0,1]$. For
+  every $i$, exactly the following source-relevant alternatives hold:
+  \begin{enumerate}
+    \item $\mu_i=0$ and $Qx_i=0$;
+    \item $\mu_i=1$ and $Qx_i=x_i$;
+    \item $0<\mu_i<1$, and $x_i$ belongs to the two-dimensional angle block
+      described in Theorem~\ref{thm:mpu_two_projection_angle_block}.
+  \end{enumerate}
+  This theorem classifies the compression eigenvectors. The pairwise
+  orthogonality of the resulting angle blocks, the ambient orthogonal direct
+  sum, and commutation on its remaining summand are separate.
+  % Source lines: paper_v2.tex 759--762.
+\end{theorem}
+
+\begin{proof}\leanok
+  Apply the finite-dimensional spectral theorem to the self-adjoint compression
+  of $Q$ to $\operatorname{ran}P$. For a unit compression eigenvector $x$ with
+  eigenvalue $\mu$, the angle-defect identity gives
+  \[
+    \lVert Qx-\mu x\rVert^2=\mu(1-\mu),
+  \]
+  hence $0\leq\mu\leq1$. At $\mu=0$ or $1$ the defect vanishes, giving the two
+  common one-dimensional blocks. For $0<\mu<1$, apply
+  Theorem~\ref{thm:mpu_two_projection_angle_block}.
+\end{proof}
+
 \begin{proposition}[Constancy of the source ranks]
   \label{prop:continuity-index}
   \notready

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5194,7 +5194,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{thm:mpu_two_projection_angle_block}
+  \uses{def:mpu_two_projection_compression_spectral_data,
+    thm:mpu_two_projection_angle_block}
   Apply the finite-dimensional spectral theorem to the self-adjoint compression
   of $Q$ to $\operatorname{ran}P$. For a unit compression eigenvector $x$ with
   eigenvalue $\mu$, the angle-defect identity gives


### PR DESCRIPTION
## Summary

- define the ordered eigenvalues and orthonormal eigenbasis of the compression of `Q` to `range P`;
- prove every compression eigenvalue lies in `[0,1]`;
- classify each basis vector as a `μ=0` or `μ=1` common one-dimensional block, or a genuine normalized `0<μ<1` angle block.

This is the source-ordered spectral-classification child #6308 of #6294. It deliberately does not claim the global ambient orthogonal direct sum, the commuting remainder, or #6295's reduced projector.

## Source

`Papers/1703.09188/paper_v2.tex`, Proposition `prop:continuity-index`, lines 759–762. The repeated-projector typo on line 762 was already recorded with the local angle-block prerequisite.

## Verification

Using the hot-main-seeded worktree only:

- `lake env lean TNLean/Analysis/TwoProjectionCompressionSpectrum.lean`
- targeted artifact generation for that new module, followed by `lake env lean TNLean/Analysis.lean`
- `git diff --check origin/main...HEAD`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`

Closes #6308. Progress on #6294.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal analysis on finite-dimensional inner-product spaces; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Adds **spectral classification** for compressing orthogonal projection `Q` to `range P`: ordered eigenvalues, an orthonormal eigenbasis, diagonal action of the compression on that basis, eigenvalues in `[0,1]`, and a **trichotomy** on each basis vector—`μ=0` with `Qx=0`, `μ=1` with `Qx=x`, or a genuine `0<μ<1` normalized angle block via existing `exists_orthonormal_angle_block`.
> 
> The new module `TwoProjectionCompressionSpectrum.lean` is wired through `TNLean/Analysis.lean`. The blueprint chapter documents **compression spectral data** and the endpoint/angle-block theorem with `\leanok` links to the new definitions and lemmas, aligned with arXiv:1703.09188 Prop. IV.5 (lines 759–762). The work **does not** yet cover the global orthogonal direct sum or reduced projector steps noted in the docstrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797683d8a93310134cce0384e7f9c00567e8eb21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->