### PR TITLE
feat(Channel): equivalence of ensembles by zero-padded unitary mixing

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -26,6 +26,7 @@ import TNLean.Channel.Determinant.HeisenbergDual
 import TNLean.Channel.Determinant.HilbertSchmidt
 import TNLean.Channel.Determinant.UnitaryCharacterization
 import TNLean.Channel.DirectSumConditionalExpectation
+import TNLean.Channel.EnsembleEquivalence
 import TNLean.Channel.EntanglementWitness
 import TNLean.Channel.FaithfulMarginalWhitenedChoi
 import TNLean.Channel.FixedPoint

--- a/TNLean/Channel/EnsembleEquivalence.lean
+++ b/TNLean/Channel/EnsembleEquivalence.lean
@@ -24,6 +24,11 @@ This file supplies that statement. The existing
 hypothesis and the tallness, because on a common index set an isometry is
 square, hence unitary.
 
+## Main definitions
+
+* `WolfProps.padZero` — padding a family indexed by `Fin m` to one indexed by
+  `Fin n` with zero vectors.
+
 ## Main results
 
 * `WolfProps.pureEnsembleDensity_of_extendZero` — extending a family by zero
@@ -32,9 +37,10 @@ square, hence unitary.
 * `WolfProps.pureEnsembleDensity_sumElim_zero`,
   `WolfProps.pureEnsembleDensity_zero_sumElim` — the two zero paddings onto the
   disjoint union of the index sets.
-* `WolfProps.padZero` — padding a family indexed by `Fin m` to one indexed by
-  `Fin n` with zero vectors, and `WolfProps.pureEnsembleDensity_padZero` for its
-  invariance.
+* `WolfProps.padZero_castLE` — the padded family agrees with the original on
+  the retained indices.
+* `WolfProps.pureEnsembleDensity_padZero` — padding to a longer family leaves
+  the ensemble density unchanged.
 * `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad` — the
   equivalence relative to an arbitrary pair of zero paddings onto a common index
   set.
@@ -53,8 +59,8 @@ square isometry over a finite index set is unitary.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2, Proposition
-  "Equivalence of ensembles" (Eq. (2.10))][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2, Proposition 2.4
+  ("Equivalence of ensembles", Eq. (2.10))][Wolf2012QChannels]
 -/
 
 open scoped Matrix

--- a/TNLean/Channel/EnsembleEquivalence.lean
+++ b/TNLean/Channel/EnsembleEquivalence.lean
@@ -135,11 +135,12 @@ theorem pureEnsembleDensity_padZero {m n : ℕ} (h : m ≤ n) (ψ : Fin m → (F
 /-! ### Wolf's equivalence of ensembles -/
 
 /-- **Equivalence of ensembles** (Wolf §2, line 277 of
-`Notes/WolfNoteTexSource/ch02_representations.tex`), relative to a choice of
-zero paddings `Ψ`, `Φ` of the two ensembles onto a common index set `ι`.
+`Notes/WolfNoteTexSource/ch02_representations.tex`), relative to families `Ψ`,
+`Φ` on a common index set `ι` whose densities agree with those of `ψ` and `φ`.
+The canonical such families are the zero paddings of the two ensembles.
 
 Two ensembles of not necessarily normalized vectors induce the same density
-operator iff their padded families are related by a unitary mixing matrix
+operator iff those families are related by a unitary mixing matrix
 `Ψ i = ∑_ℓ U i ℓ • Φ ℓ`. No relation between the cardinalities of the original
 index sets is assumed. -/
 theorem pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad

--- a/TNLean/Channel/EnsembleEquivalence.lean
+++ b/TNLean/Channel/EnsembleEquivalence.lean
@@ -59,9 +59,8 @@ square isometry over a finite index set is unitary.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2, the proposition
-  "Equivalence of ensembles", Eq. (2.10), at line 277 of
-  `Notes/WolfNoteTexSource/ch02_representations.tex`][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2, Proposition 2.4
+  ("Equivalence of ensembles", Eq. (2.10))][Wolf2012QChannels]
 -/
 
 open scoped Matrix

--- a/TNLean/Channel/EnsembleEquivalence.lean
+++ b/TNLean/Channel/EnsembleEquivalence.lean
@@ -11,10 +11,10 @@ import Mathlib.LinearAlgebra.UnitaryGroup
 
 Wolf's *Quantum Channels & Operations: Guided Tour* states the equivalence of
 ensembles (§2, line 277 of `Notes/WolfNoteTexSource/ch02_representations.tex`) as
-follows. Two ensembles of not necessarily normalized vectors `{ψⱼ}` and `{ψ̃_ℓ}`
+follows. Two ensembles of not necessarily normalized vectors `{ψⱼ}` and `{φ_ℓ}`
 satisfy
-`∑ⱼ |ψⱼ⟩⟨ψⱼ| = ∑_ℓ |ψ̃_ℓ⟩⟨ψ̃_ℓ|`
-iff there is a **unitary** `U` with `|ψⱼ⟩ = ∑_ℓ Uⱼ_ℓ |ψ̃_ℓ⟩`, where the smaller
+`∑ⱼ |ψⱼ⟩⟨ψⱼ| = ∑_ℓ |φ_ℓ⟩⟨φ_ℓ|`
+iff there is a **unitary** `U` with `|ψⱼ⟩ = ∑_ℓ Uⱼ_ℓ |φ_ℓ⟩`, where the smaller
 of the two families is padded with zero vectors so that both are indexed alike.
 No relation between the two cardinalities is assumed.
 

--- a/TNLean/Channel/EnsembleEquivalence.lean
+++ b/TNLean/Channel/EnsembleEquivalence.lean
@@ -59,8 +59,9 @@ square isometry over a finite index set is unitary.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2, Proposition 2.4
-  ("Equivalence of ensembles", Eq. (2.10))][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2, the proposition
+  "Equivalence of ensembles", Eq. (2.10), at line 277 of
+  `Notes/WolfNoteTexSource/ch02_representations.tex`][Wolf2012QChannels]
 -/
 
 open scoped Matrix

--- a/TNLean/Channel/EnsembleEquivalence.lean
+++ b/TNLean/Channel/EnsembleEquivalence.lean
@@ -42,8 +42,8 @@ square, hence unitary.
 * `WolfProps.pureEnsembleDensity_padZero` — padding to a longer family leaves
   the ensemble density unchanged.
 * `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad` — the
-  equivalence relative to an arbitrary pair of zero paddings onto a common index
-  set.
+  equivalence relative to families on a common index set whose densities agree
+  with the two ensembles, canonically the zero paddings.
 * `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing` — Wolf's
   statement with the disjoint union `ι₁ ⊕ ι₂` as common index set.
 * `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_fin` — Wolf's

--- a/TNLean/Channel/EnsembleEquivalence.lean
+++ b/TNLean/Channel/EnsembleEquivalence.lean
@@ -64,7 +64,6 @@ square isometry over a finite index set is unitary.
 -/
 
 open scoped Matrix
-open Matrix Finset
 
 variable {D : ℕ}
 

--- a/TNLean/Channel/EnsembleEquivalence.lean
+++ b/TNLean/Channel/EnsembleEquivalence.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.WolfProps
+import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# Equivalence of ensembles by zero-padded unitary mixing
+
+Wolf's *Quantum Channels & Operations: Guided Tour* states the equivalence of
+ensembles (§2, line 277 of `Notes/WolfNoteTexSource/ch02_representations.tex`) as
+follows. Two ensembles of not necessarily normalized vectors `{ψⱼ}` and `{ψ̃_ℓ}`
+satisfy
+`∑ⱼ |ψⱼ⟩⟨ψⱼ| = ∑_ℓ |ψ̃_ℓ⟩⟨ψ̃_ℓ|`
+iff there is a **unitary** `U` with `|ψⱼ⟩ = ∑_ℓ Uⱼ_ℓ |ψ̃_ℓ⟩`, where the smaller
+of the two families is padded with zero vectors so that both are indexed alike.
+No relation between the two cardinalities is assumed.
+
+This file supplies that statement. The existing
+`WolfProps.pureEnsembleDensity_eq_iff_exists_isometric_mixing` assumes
+`card ι₂ ≤ card ι₁` and produces a tall isometry; padding removes both the
+hypothesis and the tallness, because on a common index set an isometry is
+square, hence unitary.
+
+## Main results
+
+* `WolfProps.pureEnsembleDensity_of_extendZero` — extending a family by zero
+  vectors along an injection of index sets leaves the ensemble density
+  unchanged.
+* `WolfProps.pureEnsembleDensity_sumElim_zero`,
+  `WolfProps.pureEnsembleDensity_zero_sumElim` — the two zero paddings onto the
+  disjoint union of the index sets.
+* `WolfProps.padZero` — padding a family indexed by `Fin m` to one indexed by
+  `Fin n` with zero vectors, and `WolfProps.pureEnsembleDensity_padZero` for its
+  invariance.
+* `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad` — the
+  equivalence relative to an arbitrary pair of zero paddings onto a common index
+  set.
+* `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing` — Wolf's
+  statement with the disjoint union `ι₁ ⊕ ι₂` as common index set.
+* `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_fin` — Wolf's
+  statement with `Fin (max m n)` as common index set.
+
+## Design notes
+
+Padding contributes no new mathematics. Zero vectors add zero rank-one terms to
+the density operator, so both densities survive the passage to the common index
+set; the ensembles are then equinumerous, the tall isometry supplied by
+`WolfProps.exists_isometric_mixing_of_pureEnsembleDensity_eq` is square, and a
+square isometry over a finite index set is unitary.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, §2, Proposition
+  "Equivalence of ensembles" (Eq. (2.10))][Wolf2012QChannels]
+-/
+
+open scoped Matrix
+open Matrix Finset
+
+variable {D : ℕ}
+
+namespace WolfProps
+
+/-! ### Zero padding leaves the ensemble density unchanged -/
+
+/-- Extending an ensemble by zero vectors leaves its density operator unchanged.
+
+Here `e` injects the original index set into the larger one, `Ψ` restricts along
+`e` to the original family, and `Ψ` vanishes off the image of `e`. Wolf's
+"padded with zero vectors" is exactly this situation. -/
+theorem pureEnsembleDensity_of_extendZero {ι₁ ι : Type*} [Fintype ι₁] [Fintype ι]
+    (ψ : ι₁ → (Fin D → ℂ)) (Ψ : ι → (Fin D → ℂ)) {e : ι₁ → ι}
+    (he : Function.Injective e) (hres : ∀ i, Ψ (e i) = ψ i)
+    (hpad : ∀ k, (∀ i, e i ≠ k) → Ψ k = 0) :
+    pureEnsembleDensity Ψ = pureEnsembleDensity ψ := by
+  classical
+  unfold pureEnsembleDensity
+  have hzero : ∀ k ∈ (Finset.univ : Finset ι), k ∉ Finset.univ.image e →
+      Matrix.vecMulVec (Ψ k) (star (Ψ k)) = 0 := by
+    intro k _ hk
+    have hne : ∀ i, e i ≠ k := fun i hi =>
+      hk (Finset.mem_image.mpr ⟨i, Finset.mem_univ i, hi⟩)
+    simp [hpad k hne]
+  rw [← Finset.sum_subset (Finset.subset_univ (Finset.univ.image e)) hzero,
+    Finset.sum_image fun i _ j _ hij => he hij]
+  simp only [hres]
+
+/-- Padding a family indexed by `ι₁` with zero vectors on `ι₂` leaves its
+density operator unchanged. -/
+theorem pureEnsembleDensity_sumElim_zero {ι₁ ι₂ : Type*} [Fintype ι₁] [Fintype ι₂]
+    (ψ : ι₁ → (Fin D → ℂ)) :
+    pureEnsembleDensity (Sum.elim ψ (0 : ι₂ → (Fin D → ℂ))) = pureEnsembleDensity ψ :=
+  pureEnsembleDensity_of_extendZero ψ _ Sum.inl_injective (fun _ => rfl)
+    (fun k hk => by cases k with
+      | inl i => exact absurd rfl (hk i)
+      | inr _ => rfl)
+
+/-- Padding a family indexed by `ι₂` with zero vectors on `ι₁` leaves its
+density operator unchanged. -/
+theorem pureEnsembleDensity_zero_sumElim {ι₁ ι₂ : Type*} [Fintype ι₁] [Fintype ι₂]
+    (φ : ι₂ → (Fin D → ℂ)) :
+    pureEnsembleDensity (Sum.elim (0 : ι₁ → (Fin D → ℂ)) φ) = pureEnsembleDensity φ :=
+  pureEnsembleDensity_of_extendZero φ _ Sum.inr_injective (fun _ => rfl)
+    (fun k hk => by cases k with
+      | inl _ => rfl
+      | inr j => exact absurd rfl (hk j))
+
+/-- Pad a family of `m` vectors with zero vectors to a family of `n` vectors.
+Only the first `min m n` entries survive; the intended use is `m ≤ n`. -/
+def padZero {m n : ℕ} (ψ : Fin m → (Fin D → ℂ)) (k : Fin n) : Fin D → ℂ :=
+  if h : (k : ℕ) < m then ψ ⟨k, h⟩ else 0
+
+@[simp]
+theorem padZero_castLE {m n : ℕ} (h : m ≤ n) (ψ : Fin m → (Fin D → ℂ)) (i : Fin m) :
+    padZero (n := n) ψ (Fin.castLE h i) = ψ i := by
+  simp [padZero]
+
+/-- Zero padding from `Fin m` to `Fin n` leaves the ensemble density unchanged. -/
+theorem pureEnsembleDensity_padZero {m n : ℕ} (h : m ≤ n) (ψ : Fin m → (Fin D → ℂ)) :
+    pureEnsembleDensity (padZero (n := n) ψ) = pureEnsembleDensity ψ := by
+  refine pureEnsembleDensity_of_extendZero ψ _ (e := Fin.castLE h)
+    (fun i j hij => Fin.ext (by simpa using congrArg Fin.val hij))
+    (padZero_castLE h ψ) (fun k hk => ?_)
+  have hk' : ¬ (k : ℕ) < m := fun hlt => hk ⟨k, hlt⟩ (Fin.ext rfl)
+  simp [padZero, hk']
+
+/-! ### Wolf's equivalence of ensembles -/
+
+/-- **Equivalence of ensembles** (Wolf §2, line 277 of
+`Notes/WolfNoteTexSource/ch02_representations.tex`), relative to a choice of
+zero paddings `Ψ`, `Φ` of the two ensembles onto a common index set `ι`.
+
+Two ensembles of not necessarily normalized vectors induce the same density
+operator iff their padded families are related by a unitary mixing matrix
+`Ψ i = ∑_ℓ U i ℓ • Φ ℓ`. No relation between the cardinalities of the original
+index sets is assumed. -/
+theorem pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad
+    {ι₁ ι₂ ι : Type*} [Fintype ι₁] [Fintype ι₂] [Fintype ι] [DecidableEq ι]
+    (ψ : ι₁ → (Fin D → ℂ)) (φ : ι₂ → (Fin D → ℂ)) (Ψ Φ : ι → (Fin D → ℂ))
+    (hΨ : pureEnsembleDensity Ψ = pureEnsembleDensity ψ)
+    (hΦ : pureEnsembleDensity Φ = pureEnsembleDensity φ) :
+    pureEnsembleDensity ψ = pureEnsembleDensity φ ↔
+      ∃ U : Matrix ι ι ℂ, U ∈ Matrix.unitaryGroup ι ℂ ∧
+        ∀ i, Ψ i = fun a => ∑ ℓ, U i ℓ * Φ ℓ a := by
+  constructor
+  · intro hρ
+    obtain ⟨U, hU, hmix⟩ :=
+      exists_isometric_mixing_of_pureEnsembleDensity_eq Ψ Φ (hΨ.trans (hρ.trans hΦ.symm)) le_rfl
+    refine ⟨U, ?_, hmix⟩
+    -- On a common index set the isometry is square, so `Uᴴ U = 1` already
+    -- forces `U Uᴴ = 1`.
+    rw [Matrix.mem_unitaryGroup_iff']
+    simpa [Matrix.star_eq_conjTranspose] using hU
+  · rintro ⟨U, hU, hmix⟩
+    have hUiso : Uᴴ * U = 1 := by
+      simpa [Matrix.star_eq_conjTranspose] using Matrix.mem_unitaryGroup_iff'.mp hU
+    have hpad := pureEnsembleDensity_eq_of_isometric_mixing Ψ Φ U hUiso hmix
+    rwa [hΨ, hΦ] at hpad
+
+/-- **Equivalence of ensembles** (Wolf §2, line 277 of
+`Notes/WolfNoteTexSource/ch02_representations.tex`), with the disjoint union
+`ι₁ ⊕ ι₂` as the common index set.
+
+Two ensembles `{ψⱼ}_{j ∈ ι₁}` and `{φ_ℓ}_{ℓ ∈ ι₂}` of not necessarily normalized
+vectors satisfy `∑ⱼ |ψⱼ⟩⟨ψⱼ| = ∑_ℓ |φ_ℓ⟩⟨φ_ℓ|` iff, after padding both families
+with zero vectors on the complementary index set, there is a unitary `U` with
+`ψⱼ = ∑_ℓ Uⱼ_ℓ φ_ℓ`. There is no cardinality hypothesis. -/
+theorem pureEnsembleDensity_eq_iff_exists_unitary_mixing
+    {ι₁ ι₂ : Type*} [Fintype ι₁] [Fintype ι₂] [DecidableEq ι₁] [DecidableEq ι₂]
+    (ψ : ι₁ → (Fin D → ℂ)) (φ : ι₂ → (Fin D → ℂ)) :
+    pureEnsembleDensity ψ = pureEnsembleDensity φ ↔
+      ∃ U : Matrix (ι₁ ⊕ ι₂) (ι₁ ⊕ ι₂) ℂ, U ∈ Matrix.unitaryGroup (ι₁ ⊕ ι₂) ℂ ∧
+        ∀ i, Sum.elim ψ (0 : ι₂ → (Fin D → ℂ)) i =
+          fun a => ∑ ℓ, U i ℓ * Sum.elim (0 : ι₁ → (Fin D → ℂ)) φ ℓ a :=
+  pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad ψ φ _ _
+    (pureEnsembleDensity_sumElim_zero ψ) (pureEnsembleDensity_zero_sumElim φ)
+
+/-- **Equivalence of ensembles** (Wolf §2, line 277 of
+`Notes/WolfNoteTexSource/ch02_representations.tex`), with `Fin (max m n)` as the
+common index set.
+
+An ensemble of `m` vectors and an ensemble of `n` vectors induce the same
+density operator iff, after padding both with zero vectors to length
+`max m n`, there is a unitary `U` with `ψⱼ = ∑_ℓ Uⱼ_ℓ φ_ℓ`. There is no
+relation assumed between `m` and `n`. -/
+theorem pureEnsembleDensity_eq_iff_exists_unitary_mixing_fin {m n : ℕ}
+    (ψ : Fin m → (Fin D → ℂ)) (φ : Fin n → (Fin D → ℂ)) :
+    pureEnsembleDensity ψ = pureEnsembleDensity φ ↔
+      ∃ U : Matrix (Fin (max m n)) (Fin (max m n)) ℂ,
+        U ∈ Matrix.unitaryGroup (Fin (max m n)) ℂ ∧
+        ∀ i, padZero ψ i = fun a => ∑ ℓ, U i ℓ * padZero φ ℓ a :=
+  pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad ψ φ _ _
+    (pureEnsembleDensity_padZero (le_max_left m n) ψ)
+    (pureEnsembleDensity_padZero (le_max_right m n) φ)
+
+end WolfProps

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -215,7 +215,14 @@ project import.
     necessary direction (HJW converse): equal densities force an
     isometric mixing matrix between the two ensembles ✓
   - `WolfProps.pureEnsembleDensity_eq_iff_exists_isometric_mixing` —
-    both directions stated as an iff ✓
+    both directions stated as an iff, under the cardinality hypothesis
+    `card ι₂ ≤ card ι₁` ✓
+  - `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing` — Wolf's
+    own statement, in `TNLean.Channel.EnsembleEquivalence`: after padding
+    both ensembles with zero vectors onto `ι₁ ⊕ ι₂`, equal densities are
+    equivalent to unitary mixing, with no cardinality hypothesis ✓
+  - `WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_fin` —
+    the same statement with `Fin (max m n)` as common index set ✓
 
 ### Section 2.2 Transfer matrix
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -23,6 +23,7 @@ import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.WolfProps
 import TNLean.Channel.NoInformationWithoutDisturbance
+import TNLean.Channel.EnsembleEquivalence
 import TNLean.Channel.NormalForm
 import TNLean.Channel.LorentzNormalForm
 

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -12,5 +12,6 @@ are not prerequisites for the matrix-product-state Fundamental Theorem.
 %% =========================================================
 
 \input{chapter/ch16_channel_representations_choi_and_kraus}
+\input{chapter/ch16_channel_representations_ensemble_equivalence}
 \input{chapter/ch16_channel_representations_dilations_and_ordered_cp}
 \input{chapter/ch16_channel_representations_normal_forms_and_determinant}

--- a/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
@@ -3,7 +3,7 @@
 \label{sec:ensemble_equivalence_unitary}
 %% =========================================================
 
-\cite[Proposition~2.4, Equation~(2.10)]{Wolf2012Quantum} states the equivalence
+\cite[Equivalence of ensembles, Equation~(2.10)]{Wolf2012Quantum} states the equivalence
 of ensembles without any relation between the two cardinalities: two ensembles
 of not necessarily normalized vectors $\{\psi_j\}$ and
 $\{\widetilde\psi_\ell\}$ satisfy $\sum_j \ketbra{\psi_j}{\psi_j} = \sum_\ell

--- a/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
@@ -1,0 +1,139 @@
+%% =========================================================
+\section{Equivalence of ensembles by zero-padded unitary mixing}
+\label{sec:ensemble_equivalence_unitary}
+%% =========================================================
+
+Wolf states the equivalence of ensembles without any relation between the two
+cardinalities: two ensembles of not necessarily normalized vectors
+$\{\psi_j\}$ and $\{\widetilde\psi_\ell\}$ satisfy
+$\sum_j \ketbra{\psi_j}{\psi_j} = \sum_\ell
+\ketbra{\widetilde\psi_\ell}{\widetilde\psi_\ell}$ iff there is a
+\emph{unitary} $U$ with $\psi_j = \sum_\ell U_{j\ell}\widetilde\psi_\ell$,
+where the smaller family is padded with zero vectors so that both are indexed
+by one common set. Theorem~\ref{thm:pureEnsembleDensity_eq_iff_exists_isometric_mixing}
+carries the cardinality hypothesis $|\iota_2| \le |\iota_1|$ and delivers a
+tall isometry; this section removes both restrictions.
+
+\begin{lemma}[Zero padding preserves the ensemble density]
+    \label{lem:pureEnsembleDensity_of_extendZero}
+    \lean{WolfProps.pureEnsembleDensity_of_extendZero}
+    \leanok
+    \uses{def:pureEnsembleDensity}
+    Let $e \colon \iota_1 \to \iota$ be injective and let
+    $\{\Psi_k\}_{k \in \iota}$ satisfy $\Psi_{e(i)} = \psi_i$ for all
+    $i \in \iota_1$ and $\Psi_k = 0$ for every $k$ outside the image of $e$.
+    Then $\sum_{k} \ketbra{\Psi_k}{\Psi_k} = \sum_i \ketbra{\psi_i}{\psi_i}$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:pureEnsembleDensity}
+    The terms indexed outside the image of $e$ vanish, since
+    $\ketbra{0}{0} = 0$. The remaining sum runs over the image of $e$, and
+    injectivity of $e$ reindexes it as a sum over $\iota_1$, where
+    $\Psi_{e(i)} = \psi_i$ identifies each term.
+\end{proof}
+
+Two instances of Lemma~\ref{lem:pureEnsembleDensity_of_extendZero} supply the
+paddings used below: extension by zero along the two inclusions of
+$\iota_1$ and $\iota_2$ into the disjoint union $\iota_1 \sqcup \iota_2$, and
+extension by zero of a family of $m$ vectors to a family of $\max(m,n)$
+vectors.
+
+\begin{definition}[Zero padding to a longer family]
+    \label{def:padZero}
+    \lean{WolfProps.padZero}
+    \leanok
+    For an ensemble $\{\psi_j\}_{j < m}$ and $n \ge m$, the padded ensemble
+    $\{\psi_k^{\mathrm{pad}}\}_{k < n}$ is $\psi_k$ for $k < m$ and the zero
+    vector otherwise.
+\end{definition}
+
+\begin{lemma}[Padding to a longer family preserves the density]
+    \label{lem:pureEnsembleDensity_padZero}
+    \lean{WolfProps.pureEnsembleDensity_padZero}
+    \leanok
+    \uses{def:pureEnsembleDensity, def:padZero,
+        lem:pureEnsembleDensity_of_extendZero}
+    For $m \le n$ the padded ensemble of Definition~\ref{def:padZero} has the
+    same density operator as the original ensemble.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:pureEnsembleDensity_of_extendZero}
+    Apply Lemma~\ref{lem:pureEnsembleDensity_of_extendZero} to the inclusion
+    $\{0,\dots,m-1\} \hookrightarrow \{0,\dots,n-1\}$.
+\end{proof}
+
+\begin{theorem}[Equivalence of ensembles, relative to a padding]
+    \label{thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}
+    \lean{WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}
+    \leanok
+    \uses{def:pureEnsembleDensity,
+        thm:exists_isometric_mixing_of_pureEnsembleDensity_eq,
+        thm:pureEnsembleDensity_eq_of_isometric_mixing}
+    Let $\{\Psi_k\}_{k \in \iota}$ and $\{\Phi_k\}_{k \in \iota}$ be ensembles
+    on one common finite index set whose density operators agree with those of
+    $\{\psi_i\}_{i \in \iota_1}$ and $\{\phi_j\}_{j \in \iota_2}$ respectively.
+    Then
+    \[
+        \sum_i \ketbra{\psi_i}{\psi_i} = \sum_j \ketbra{\phi_j}{\phi_j}
+    \]
+    iff there is a unitary $U \in \C^{\iota \times \iota}$ with
+    $\Psi_k = \sum_\ell U_{k\ell}\Phi_\ell$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:exists_isometric_mixing_of_pureEnsembleDensity_eq,
+        thm:pureEnsembleDensity_eq_of_isometric_mixing}
+    Suppose the two density operators agree. The hypotheses on $\Psi$ and
+    $\Phi$ then give $\sum_k \ketbra{\Psi_k}{\Psi_k} = \sum_k
+    \ketbra{\Phi_k}{\Phi_k}$, and both families are indexed by the same finite
+    set, so the cardinality hypothesis of
+    Theorem~\ref{thm:exists_isometric_mixing_of_pureEnsembleDensity_eq} holds
+    with equality. That theorem supplies $U \in \C^{\iota\times\iota}$ with
+    $U^\dagger U = \Id$ and $\Psi_k = \sum_\ell U_{k\ell}\Phi_\ell$. A square
+    matrix over a finite index set with $U^\dagger U = \Id$ also satisfies
+    $U U^\dagger = \Id$, so $U$ is unitary.
+
+    Conversely, a unitary $U$ is in particular an isometry, so
+    Theorem~\ref{thm:pureEnsembleDensity_eq_of_isometric_mixing} equates the
+    densities of $\Psi$ and $\Phi$; the hypotheses on $\Psi$ and $\Phi$ transfer
+    the equality back to $\psi$ and $\phi$.
+\end{proof}
+
+\begin{theorem}[Equivalence of ensembles]
+    \label{thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing}
+    \lean{WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing,
+        WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_fin}
+    \leanok
+    \uses{def:pureEnsembleDensity, def:padZero,
+        lem:pureEnsembleDensity_of_extendZero,
+        lem:pureEnsembleDensity_padZero,
+        thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}
+    Two ensembles $\{\psi_j\}$ and $\{\widetilde\psi_\ell\}$ of not necessarily
+    normalized vectors satisfy
+    \[
+        \sum_j \ketbra{\psi_j}{\psi_j}
+        = \sum_\ell \ketbra{\widetilde\psi_\ell}{\widetilde\psi_\ell}
+    \]
+    iff there is a unitary $U$ with
+    $\psi_j = \sum_\ell U_{j\ell}\widetilde\psi_\ell$, where both families are
+    first padded with zero vectors onto one common index set. No relation
+    between the two cardinalities is assumed. Two paddings are recorded: onto
+    the disjoint union $\iota_1 \sqcup \iota_2$ of the two index sets, and, for
+    ensembles of $m$ and $n$ vectors, onto $\{0,\dots,\max(m,n)-1\}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:pureEnsembleDensity_of_extendZero,
+        lem:pureEnsembleDensity_padZero,
+        thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}
+    Lemmas~\ref{lem:pureEnsembleDensity_of_extendZero}
+    and~\ref{lem:pureEnsembleDensity_padZero} show that either padding leaves
+    both density operators unchanged, which is exactly the hypothesis of
+    Theorem~\ref{thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}.
+\end{proof}

--- a/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
@@ -28,10 +28,15 @@ tall isometry; this section removes both restrictions.
 \begin{proof}
     \leanok
     \uses{def:pureEnsembleDensity}
-    The terms indexed outside the image of $e$ vanish, since
-    $\ketbra{0}{0} = 0$. The remaining sum runs over the image of $e$, and
-    injectivity of $e$ reindexes it as a sum over $\iota_1$, where
-    $\Psi_{e(i)} = \psi_i$ identifies each term.
+    \begin{align}
+        \sum_{k \in \iota} \ketbra{\Psi_k}{\Psi_k}
+        = \sum_{k \in e(\iota_1)} \ketbra{\Psi_k}{\Psi_k}
+        = \sum_{i \in \iota_1} \ketbra{\Psi_{e(i)}}{\Psi_{e(i)}}
+        = \sum_{i \in \iota_1} \ketbra{\psi_i}{\psi_i}.
+    \end{align}
+    The first equality drops the terms outside the image of $e$, which vanish
+    because $\ketbra{0}{0} = 0$; the second reindexes along $e$, which is
+    injective; the third substitutes $\Psi_{e(i)} = \psi_i$.
 \end{proof}
 
 Two instances of Lemma~\ref{lem:pureEnsembleDensity_of_extendZero} supply the

--- a/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
@@ -125,10 +125,16 @@ vectors.
     matrix over a finite index set with $U^\dagger U = \Id$ also satisfies
     $U U^\dagger = \Id$, so $U$ is unitary.
 
-    Conversely, a unitary $U$ is in particular an isometry, so
-    Theorem~\ref{thm:pureEnsembleDensity_eq_of_isometric_mixing} equates the
-    densities of $\Psi$ and $\Phi$; the hypotheses on $\Psi$ and $\Phi$ transfer
-    the equality back to $\psi$ and $\phi$.
+    Conversely, a unitary $U$ satisfies $U^\dagger U = \Id$, so
+    Theorem~\ref{thm:pureEnsembleDensity_eq_of_isometric_mixing} gives
+    $\sum_k \ketbra{\Psi_k}{\Psi_k} = \sum_k \ketbra{\Phi_k}{\Phi_k}$. Together
+    with the two density agreements this reads
+    \begin{align}
+        \sum_i \ketbra{\psi_i}{\psi_i}
+        = \sum_k \ketbra{\Psi_k}{\Psi_k}
+        = \sum_k \ketbra{\Phi_k}{\Phi_k}
+        = \sum_j \ketbra{\phi_j}{\phi_j}.
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Equivalence of ensembles]

--- a/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
@@ -3,7 +3,7 @@
 \label{sec:ensemble_equivalence_unitary}
 %% =========================================================
 
-\cite[Equivalence of ensembles, Equation~(2.10)]{Wolf2012Quantum} states the equivalence
+\cite[Proposition~2.4, Equation~(2.10)]{Wolf2012Quantum} states the equivalence
 of ensembles without any relation between the two cardinalities: two ensembles
 of not necessarily normalized vectors $\{\psi_j\}$ and
 $\{\widetilde\psi_\ell\}$ satisfy $\sum_j \ketbra{\psi_j}{\psi_j} = \sum_\ell

--- a/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex
@@ -3,10 +3,10 @@
 \label{sec:ensemble_equivalence_unitary}
 %% =========================================================
 
-Wolf states the equivalence of ensembles without any relation between the two
-cardinalities: two ensembles of not necessarily normalized vectors
-$\{\psi_j\}$ and $\{\widetilde\psi_\ell\}$ satisfy
-$\sum_j \ketbra{\psi_j}{\psi_j} = \sum_\ell
+\cite[Proposition~2.4, Equation~(2.10)]{Wolf2012Quantum} states the equivalence
+of ensembles without any relation between the two cardinalities: two ensembles
+of not necessarily normalized vectors $\{\psi_j\}$ and
+$\{\widetilde\psi_\ell\}$ satisfy $\sum_j \ketbra{\psi_j}{\psi_j} = \sum_\ell
 \ketbra{\widetilde\psi_\ell}{\widetilde\psi_\ell}$ iff there is a
 \emph{unitary} $U$ with $\psi_j = \sum_\ell U_{j\ell}\widetilde\psi_\ell$,
 where the smaller family is padded with zero vectors so that both are indexed
@@ -40,46 +40,68 @@ $\iota_1$ and $\iota_2$ into the disjoint union $\iota_1 \sqcup \iota_2$, and
 extension by zero of a family of $m$ vectors to a family of $\max(m,n)$
 vectors.
 
-\begin{definition}[Zero padding to a longer family]
-    \label{def:padZero}
-    \lean{WolfProps.padZero}
+\begin{lemma}[Padding onto a disjoint union preserves the density]
+    \label{lem:pureEnsembleDensity_sumElim_zero}
+    \lean{WolfProps.pureEnsembleDensity_sumElim_zero,
+        WolfProps.pureEnsembleDensity_zero_sumElim}
     \leanok
-    For an ensemble $\{\psi_j\}_{j < m}$ and $n \ge m$, the padded ensemble
-    $\{\psi_k^{\mathrm{pad}}\}_{k < n}$ is $\psi_k$ for $k < m$ and the zero
-    vector otherwise.
+    \uses{def:pureEnsembleDensity}
+    Let $\{\psi_i\}_{i \in \iota_1}$ and $\{\phi_j\}_{j \in \iota_2}$ be
+    ensembles. Extend $\psi$ by the zero vector on the second summand of
+    $\iota_1 \sqcup \iota_2$, and extend $\phi$ by the zero vector on the first
+    summand. Both extended families have the same density operator as the
+    family they extend.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:pureEnsembleDensity_of_extendZero}
+    Apply Lemma~\ref{lem:pureEnsembleDensity_of_extendZero} to the two
+    inclusions $\iota_1 \hookrightarrow \iota_1 \sqcup \iota_2$ and
+    $\iota_2 \hookrightarrow \iota_1 \sqcup \iota_2$, which are injective and
+    have complementary images.
+\end{proof}
+
+\begin{definition}[Zero padding along an enumerated index set]
+    \label{def:padZero}
+    \lean{WolfProps.padZero, WolfProps.padZero_castLE}
+    \leanok
+    Let $\{\psi_k\}_{k < m}$ be an ensemble and let $n$ be a natural number.
+    The padded ensemble $\{\psi_k^{\mathrm{pad}}\}_{k < n}$ is $\psi_k$ for
+    $k < m$ and the zero vector for $m \le k < n$. For $m \le n$ the padded
+    family agrees with $\psi$ on every index $k < m$ and retains the whole
+    ensemble; for $n < m$ only the first $n$ vectors survive. The intended use
+    is $m \le n$.
 \end{definition}
 
 \begin{lemma}[Padding to a longer family preserves the density]
     \label{lem:pureEnsembleDensity_padZero}
     \lean{WolfProps.pureEnsembleDensity_padZero}
     \leanok
-    \uses{def:pureEnsembleDensity, def:padZero,
-        lem:pureEnsembleDensity_of_extendZero}
+    \uses{def:pureEnsembleDensity, def:padZero}
     For $m \le n$ the padded ensemble of Definition~\ref{def:padZero} has the
     same density operator as the original ensemble.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    \uses{lem:pureEnsembleDensity_of_extendZero}
+    \uses{lem:pureEnsembleDensity_of_extendZero, def:padZero}
     Apply Lemma~\ref{lem:pureEnsembleDensity_of_extendZero} to the inclusion
-    $\{0,\dots,m-1\} \hookrightarrow \{0,\dots,n-1\}$.
+    $\{k : k < m\} \hookrightarrow \{k : k < n\}$.
 \end{proof}
 
 \begin{theorem}[Equivalence of ensembles, relative to a padding]
     \label{thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}
     \lean{WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}
     \leanok
-    \uses{def:pureEnsembleDensity,
-        thm:exists_isometric_mixing_of_pureEnsembleDensity_eq,
-        thm:pureEnsembleDensity_eq_of_isometric_mixing}
+    \uses{def:pureEnsembleDensity}
     Let $\{\Psi_k\}_{k \in \iota}$ and $\{\Phi_k\}_{k \in \iota}$ be ensembles
     on one common finite index set whose density operators agree with those of
     $\{\psi_i\}_{i \in \iota_1}$ and $\{\phi_j\}_{j \in \iota_2}$ respectively.
     Then
-    \[
+    \begin{align}
         \sum_i \ketbra{\psi_i}{\psi_i} = \sum_j \ketbra{\phi_j}{\phi_j}
-    \]
+    \end{align}
     iff there is a unitary $U \in \C^{\iota \times \iota}$ with
     $\Psi_k = \sum_\ell U_{k\ell}\Phi_\ell$.
 \end{theorem}
@@ -109,30 +131,27 @@ vectors.
     \lean{WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing,
         WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_fin}
     \leanok
-    \uses{def:pureEnsembleDensity, def:padZero,
-        lem:pureEnsembleDensity_of_extendZero,
-        lem:pureEnsembleDensity_padZero,
-        thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}
+    \uses{def:pureEnsembleDensity, def:padZero}
     Two ensembles $\{\psi_j\}$ and $\{\widetilde\psi_\ell\}$ of not necessarily
     normalized vectors satisfy
-    \[
+    \begin{align}
         \sum_j \ketbra{\psi_j}{\psi_j}
         = \sum_\ell \ketbra{\widetilde\psi_\ell}{\widetilde\psi_\ell}
-    \]
+    \end{align}
     iff there is a unitary $U$ with
     $\psi_j = \sum_\ell U_{j\ell}\widetilde\psi_\ell$, where both families are
     first padded with zero vectors onto one common index set. No relation
     between the two cardinalities is assumed. Two paddings are recorded: onto
     the disjoint union $\iota_1 \sqcup \iota_2$ of the two index sets, and, for
-    ensembles of $m$ and $n$ vectors, onto $\{0,\dots,\max(m,n)-1\}$.
+    ensembles of $m$ and $n$ vectors, onto $\{k : k < \max(m,n)\}$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{lem:pureEnsembleDensity_of_extendZero,
+    \uses{lem:pureEnsembleDensity_sumElim_zero,
         lem:pureEnsembleDensity_padZero,
         thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}
-    Lemmas~\ref{lem:pureEnsembleDensity_of_extendZero}
+    Lemmas~\ref{lem:pureEnsembleDensity_sumElim_zero}
     and~\ref{lem:pureEnsembleDensity_padZero} show that either padding leaves
     both density operators unchanged, which is exactly the hypothesis of
     Theorem~\ref{thm:pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad}.


### PR DESCRIPTION
## Wolf's statement

Wolf, *Quantum Channels & Operations*, §2 (`Notes/WolfNoteTexSource/ch02_representations.tex`, line 277), Proposition "Equivalence of ensembles":

> Two ensembles of (not necessarily normalized) vectors $\{\psi_j\}$ and $\{\widetilde\psi_\ell\}$ satisfy $\sum_j \ketbra{\psi_j}{\psi_j} = \sum_\ell \ketbra{\widetilde\psi_\ell}{\widetilde\psi_\ell}$ iff there is a **unitary** $U$ such that $\ket{\psi_j} = \sum_\ell U_{j\ell}\ket{\widetilde\psi_\ell}$ (where the smaller set is padded with zero vectors).

There is no cardinality hypothesis, and the mixing map is unitary, not merely isometric.

## What was missing

`WolfProps.pureEnsembleDensity_eq_iff_exists_isometric_mixing` (`TNLean/Channel/WolfProps.lean:575`) assumes `Fintype.card ι₂ ≤ Fintype.card ι₁` and concludes with a tall isometry `V : Matrix ι₁ ι₂ ℂ`, `Vᴴ * V = 1`. Under the faithfulness rule in `CLAUDE.md` that is a different, weaker theorem on both counts. This PR supplies Wolf's own statement.

## Landed signatures

```lean
theorem WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing
    {ι₁ ι₂ : Type*} [Fintype ι₁] [Fintype ι₂] [DecidableEq ι₁] [DecidableEq ι₂]
    (ψ : ι₁ → (Fin D → ℂ)) (φ : ι₂ → (Fin D → ℂ)) :
    pureEnsembleDensity ψ = pureEnsembleDensity φ ↔
      ∃ U : Matrix (ι₁ ⊕ ι₂) (ι₁ ⊕ ι₂) ℂ, U ∈ Matrix.unitaryGroup (ι₁ ⊕ ι₂) ℂ ∧
        ∀ i, Sum.elim ψ (0 : ι₂ → (Fin D → ℂ)) i =
          fun a => ∑ ℓ, U i ℓ * Sum.elim (0 : ι₁ → (Fin D → ℂ)) φ ℓ a
```

```lean
theorem WolfProps.pureEnsembleDensity_eq_iff_exists_unitary_mixing_fin {m n : ℕ}
    (ψ : Fin m → (Fin D → ℂ)) (φ : Fin n → (Fin D → ℂ)) :
    pureEnsembleDensity ψ = pureEnsembleDensity φ ↔
      ∃ U : Matrix (Fin (max m n)) (Fin (max m n)) ℂ,
        U ∈ Matrix.unitaryGroup (Fin (max m n)) ℂ ∧
        ∀ i, padZero ψ i = fun a => ∑ ℓ, U i ℓ * padZero φ ℓ a
```

**No cardinality hypothesis appears in either statement**, and the mixing matrix is a member of `Matrix.unitaryGroup`, i.e. genuinely unitary rather than a tall isometry. Both are `iff`s, matching Wolf. The issue's acceptance criterion naming `Fin (max m n)` is met by the second form; the first is the type-general version over the disjoint union of the two index sets.

Supporting declarations, all in the new `TNLean/Channel/EnsembleEquivalence.lean`:

- `pureEnsembleDensity_of_extendZero` — extending an ensemble by zero vectors along an injection of index sets leaves the density operator unchanged. This is the one padding fact; it is stated once and used for both paddings.
- `pureEnsembleDensity_sumElim_zero`, `pureEnsembleDensity_zero_sumElim` — the two paddings onto `ι₁ ⊕ ι₂`.
- `padZero`, `padZero_castLE`, `pureEnsembleDensity_padZero` — padding a family of `m` vectors to `n ≥ m` vectors and its density invariance.
- `pureEnsembleDensity_eq_iff_exists_unitary_mixing_of_pad` — the equivalence relative to an arbitrary pair of zero paddings onto a common index set; both public forms are one-line instantiations of it.

## Route

Wolf's own: pad both families with zero vectors onto one common index set. Zero vectors contribute zero rank-one terms, so both density operators survive the padding. On a common index set the cardinality hypothesis of `exists_isometric_mixing_of_pureEnsembleDensity_eq` holds with equality, so the isometry it returns is square, and a square matrix with `Uᴴ U = 1` over a finite index set also satisfies `U Uᴴ = 1` (`mul_eq_one_comm` through Mathlib's `IsDedekindFiniteMonoid` instance for square matrices). The converse direction is the existing sufficient direction plus unpadding. No new mathematics beyond the padding bookkeeping.

## What became of the isometric-mixing theorem

`WolfProps.pureEnsembleDensity_eq_iff_exists_isometric_mixing` is left untouched in `TNLean/Channel/WolfProps.lean`, and it is **not** derived as a corollary of the new theorem. Restricting the unitary `U : Matrix (ι₁ ⊕ ι₂) (ι₁ ⊕ ι₂) ℂ` to the `ι₁ × ι₂` block does recover the mixing relation `ψᵢ = ∑ⱼ Vᵢⱼ φⱼ`, but the isometry condition `Vᴴ V = 1` would require a partial column sum of `Uᴴ U` to equal the identity, which unitarity of `U` does not give. So under the cardinality hypothesis the tall-isometry statement carries information the padded unitary statement does not, and the two coexist. The new theorem is the one that formalizes Wolf's proposition; the old one remains as the tall-isometry specialization, and its blueprint entry already states its cardinality hypothesis explicitly.

`TNLean/Channel/WolfChapter2Index.lean` is updated so the Chapter 2 index records both.

## Verification

- `lake env lean TNLean/Channel/EnsembleEquivalence.lean` — exit 0, no errors, no warnings.
- `lake env lean TNLean/Channel/WolfChapter2Index.lean` — exit 0.
- `lake build TNLean.Channel` — `Build completed successfully (9104 jobs)`.
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` — `Import aggregators are current`.
- `python3 scripts/blueprint_lean_sync.py --ci` — `✓ Blueprint and Lean code are in sync.`
- `rg -n "sorry|axiom|native_decide|maxHeartbeats|admit" TNLean/Channel/EnsembleEquivalence.lean` — no matches.
- All lines ≤ 100 characters in both the Lean module and the new blueprint file.

## Blueprint

New sub-file `blueprint/src/chapter/ch16_channel_representations_ensemble_equivalence.tex`, `\input` from `ch16_channel_representations.tex` (the pattern used by LionSR/TNLean#6306, to avoid a contended shared chapter file). It carries `\lean{...}` and `\leanok` on every statement and on every proof, and `\uses` edges to the pure-ensemble density definition and to the two existing isometric-mixing theorems.

Closes LionSR/QICLean#319

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization of known quantum-information bookkeeping on top of existing `WolfProps` theorems; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Adds **`TNLean/Channel/EnsembleEquivalence.lean`** to formalize Wolf’s Proposition 2.4 (equivalence of ensembles) with **unitary** mixing and **no cardinality hypothesis**, by zero-padding both families onto a common index set (`ι₁ ⊕ ι₂` or `Fin (max m n)` via `padZero`).
> 
> Padding lemmas show zero extensions leave `pureEnsembleDensity` unchanged; the main `iff` reuses existing isometric-mixing (HJW) results on the padded families, then upgrades a square isometry to **unitary**. The prior tall-isometry `iff` in `WolfProps` is unchanged; **`WolfChapter2Index`** now documents both statements.
> 
> Blueprint: new **`ch16_channel_representations_ensemble_equivalence.tex`**, included from chapter 16 representations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3216b161ce7bc4e66846e526b47c41ca734023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->