### PR TITLE
feat(Analysis): prove Wolf Eq. (8.104) Jordan-block power bounds

### DIFF
--- a/TNLean/Analysis/JordanBlockPower.lean
+++ b/TNLean/Analysis/JordanBlockPower.lean
@@ -48,7 +48,9 @@ Source: Wolf (2012), Chapter 8, Eq. (8.104), lines 1197--1215.
 * `jordanBlock` -- the Jordan block $J_D(\lambda) = \lambda I + N$.
 * `jordanBlock_pow` -- truncated binomial expansion of $J_D(\lambda)^n$.
 * `norm_apply_le_l2_opNorm` -- the largest singular value dominates every entry.
+* `conjTranspose_nilpotentShift_mul_self` -- $N^{\dagger}N=\operatorname{diag}(0,1,\dots,1)$.
 * `l2_opNorm_nilpotentShift_le_one` -- $\|N\|_\infty \le 1$.
+* `l2_opNorm_nilpotentShift_pow_le_one` -- $\|N^k\|_\infty \le 1$.
 * `le_l2_opNorm_jordanBlock_pow` -- left inequality of Wolf Eq. (8.104).
 * `l2_opNorm_jordanBlock_pow_le` -- right inequality of Wolf Eq. (8.104).
 * `l2_opNorm_jordanBlock_pow_bounds` -- Wolf Eq. (8.104).
@@ -349,6 +351,8 @@ lemma conjTranspose_nilpotentShift_mul_self (D : ℕ) :
       omega
     · rw [if_pos rfl, if_neg hi]
       have hlt : (i : ℕ) - 1 < D := lt_of_le_of_lt (Nat.sub_le _ _) i.is_lt
+      -- `hval` is never named below, but it puts the value of the witness coordinate in
+      -- context, which is what lets the `omega` calls in this branch see it.
       have hval : ((⟨(i : ℕ) - 1, hlt⟩ : Fin D) : ℕ) = (i : ℕ) - 1 := rfl
       rw [Finset.sum_eq_single (⟨(i : ℕ) - 1, hlt⟩ : Fin D)]
       · have hi' : (i : ℕ) = ((⟨(i : ℕ) - 1, hlt⟩ : Fin D) : ℕ) + 1 := by omega
@@ -366,7 +370,13 @@ lemma conjTranspose_nilpotentShift_mul_self (D : ℕ) :
     exact hij (Fin.ext (by omega))
 
 /-- Wolf's $\|N\|_\infty = 1$, stated as an inequality because the shift on a
-one-dimensional space is zero.  Source: Wolf (2012), Chapter 8, line 1215. -/
+one-dimensional space is zero.  Source: Wolf (2012), Chapter 8, line 1215.
+
+**Local fix (Wolf (2012), Chapter 8, line 1215, $D = 1$):** the source's equality
+$\|N\|_\infty = 1$ fails at $D = 1$, where $N = 0$, so the bound is stated as
+$\|N\|_\infty \le 1$, which holds for every $D$ and is the direction the upper
+bound of Eq. (8.104) consumes.  The correction is documented in
+`docs/paper-gaps/wolf_eq8104_shift_norm_one_dimensional.tex`. -/
 lemma l2_opNorm_nilpotentShift_le_one (D : ℕ) : ‖nilpotentShift D‖ ≤ 1 := by
   have hsq : ‖nilpotentShift D‖ * ‖nilpotentShift D‖ ≤ 1 := by
     rw [← l2_opNorm_conjTranspose_mul_self, conjTranspose_nilpotentShift_mul_self,

--- a/TNLean/Analysis/JordanBlockPower.lean
+++ b/TNLean/Analysis/JordanBlockPower.lean
@@ -3,13 +3,14 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Nat.Choose.Sum
 import Lean.Elab.Tactic.Omega
 
 /-!
-# Jordan block: definition, nilpotent shift, and binomial expansion
+# Jordan block: powers, nilpotent shift, and the two-sided norm estimate
 
 Let $D \ge 1$ be a positive integer.  Define the $D \times D$ **nilpotent upper
 shift** $N$ by $N_{i,j}=1$ when $j=i+1$, $0$ otherwise, and the **Jordan
@@ -26,9 +27,18 @@ $$
 where terms with $k \ge D$ vanish because $N^D=0$.  Each $N^k$ is the $k$-th
 superdiagonal matrix: $(N^k)_{i,j}=1$ iff $j=i+k$.
 
-These are purely algebraic calculations; they do not involve any norm bounds.
-The two-sided operator-norm estimate of Wolf Eq. (8.104) requires additional
-$\ell^2$ operator-norm infrastructure and is not yet formalized.
+Measuring $J_D(\lambda)^n$ in the largest singular value $\|\cdot\|_\infty$,
+that is in the $\ell^2$ operator norm, the expansion yields Wolf's two-sided
+estimate: for every $k_0 \le \min\{n,\,D-1\}$,
+$$
+|\lambda|^{\,n-k_0}\binom{n}{k_0}
+  \le \bigl\|J_D(\lambda)^n\bigr\|_\infty
+  \le \sum_{k=0}^{\min\{n,\,D-1\}} |\lambda|^{\,n-k}\binom{n}{k}.
+$$
+The left inequality reads off the $(0,k_0)$ entry of the expansion and uses
+that the largest singular value dominates every entry.  The right inequality
+is the triangle inequality together with $\|N\|_\infty \le 1$.
+Source: Wolf (2012), Chapter 8, Eq. (8.104), lines 1197--1215.
 
 ## Main declarations
 
@@ -37,6 +47,11 @@ $\ell^2$ operator-norm infrastructure and is not yet formalized.
 * `nilpotentShift_pow_D_eq_zero` -- $N^D=0$.
 * `jordanBlock` -- the Jordan block $J_D(\lambda) = \lambda I + N$.
 * `jordanBlock_pow` -- truncated binomial expansion of $J_D(\lambda)^n$.
+* `norm_apply_le_l2_opNorm` -- the largest singular value dominates every entry.
+* `l2_opNorm_nilpotentShift_le_one` -- $\|N\|_\infty \le 1$.
+* `le_l2_opNorm_jordanBlock_pow` -- left inequality of Wolf Eq. (8.104).
+* `l2_opNorm_jordanBlock_pow_le` -- right inequality of Wolf Eq. (8.104).
+* `l2_opNorm_jordanBlock_pow_bounds` -- Wolf Eq. (8.104).
 -/
 
 namespace Matrix
@@ -293,5 +308,145 @@ lemma jordanBlock_pow (a : ℂ) (n : ℕ) [NeZero D] :
   rw [h_trunc]
 
 end JordanBlock
+
+section OperatorNorm
+
+open scoped Matrix.Norms.L2Operator
+
+/-- The largest singular value dominates every entry: $|A_{i,j}| \le \|A\|_\infty$.
+Evaluating the associated Euclidean operator on the $j$-th standard basis vector
+returns the $j$-th column of $A$, whose $i$-th coordinate is $A_{i,j}$.
+Source: Wolf (2012), Chapter 8, lines 1213--1214. -/
+lemma norm_apply_le_l2_opNorm {n : Type*} [Fintype n] [DecidableEq n]
+    (A : Matrix n n ℂ) (i j : n) : ‖A i j‖ ≤ ‖A‖ := by
+  set x : EuclideanSpace ℂ n := PiLp.single 2 j (1 : ℂ) with hxdef
+  have hx : ‖x‖ = 1 := by simp [hxdef]
+  have hcol : ‖toEuclideanCLM (n := n) (𝕜 := ℂ) A x‖ ≤ ‖A‖ := by
+    have h := (toEuclideanCLM (n := n) (𝕜 := ℂ) A).le_opNorm x
+    rwa [hx, mul_one, l2_opNorm_toEuclideanCLM] at h
+  refine le_trans (le_of_eq ?_) ((PiLp.norm_apply_le _ i).trans hcol)
+  simp [hxdef, PiLp.ofLp_single]
+
+/-- The Gram matrix of the nilpotent shift is the diagonal projection that kills
+the first coordinate: $N^{\dagger}N = \operatorname{diag}(0,1,\dots,1)$. -/
+lemma conjTranspose_nilpotentShift_mul_self (D : ℕ) :
+    (nilpotentShift D)ᴴ * nilpotentShift D =
+      diagonal (fun i : Fin D => if (i : ℕ) = 0 then (0 : ℂ) else 1) := by
+  ext i j
+  rw [Matrix.mul_apply, Matrix.diagonal_apply]
+  have hterm : ∀ k : Fin D, (nilpotentShift D)ᴴ i k * nilpotentShift D k j =
+      if (i : ℕ) = (k : ℕ) + 1 ∧ (j : ℕ) = (k : ℕ) + 1 then (1 : ℂ) else 0 := by
+    intro k
+    simp only [conjTranspose_apply, nilpotentShift_apply]
+    split_ifs with h₁ h₂ h₃ <;> simp_all
+  simp only [hterm]
+  by_cases hij : i = j
+  · subst hij
+    by_cases hi : (i : ℕ) = 0
+    · rw [if_pos rfl, if_pos hi]
+      refine Finset.sum_eq_zero fun k _ => ?_
+      rw [if_neg]
+      omega
+    · rw [if_pos rfl, if_neg hi]
+      have hlt : (i : ℕ) - 1 < D := lt_of_le_of_lt (Nat.sub_le _ _) i.is_lt
+      have hval : ((⟨(i : ℕ) - 1, hlt⟩ : Fin D) : ℕ) = (i : ℕ) - 1 := rfl
+      rw [Finset.sum_eq_single (⟨(i : ℕ) - 1, hlt⟩ : Fin D)]
+      · have hi' : (i : ℕ) = ((⟨(i : ℕ) - 1, hlt⟩ : Fin D) : ℕ) + 1 := by omega
+        rw [if_pos ⟨hi', hi'⟩]
+      · intro k _ hk
+        rw [if_neg]
+        rintro ⟨h₁, h₂⟩
+        exact hk (Fin.ext (by omega))
+      · intro hmem
+        exact absurd (Finset.mem_univ _) hmem
+  · rw [if_neg hij]
+    refine Finset.sum_eq_zero fun k _ => ?_
+    rw [if_neg]
+    rintro ⟨h₁, h₂⟩
+    exact hij (Fin.ext (by omega))
+
+/-- Wolf's $\|N\|_\infty = 1$, stated as an inequality because the shift on a
+one-dimensional space is zero.  Source: Wolf (2012), Chapter 8, line 1215. -/
+lemma l2_opNorm_nilpotentShift_le_one (D : ℕ) : ‖nilpotentShift D‖ ≤ 1 := by
+  have hsq : ‖nilpotentShift D‖ * ‖nilpotentShift D‖ ≤ 1 := by
+    rw [← l2_opNorm_conjTranspose_mul_self, conjTranspose_nilpotentShift_mul_self,
+      l2_opNorm_diagonal]
+    refine (pi_norm_le_iff_of_nonneg zero_le_one).mpr fun i => ?_
+    by_cases hi : (i : ℕ) = 0 <;> simp [hi]
+  nlinarith [norm_nonneg (nilpotentShift D)]
+
+/-- Every power of the nilpotent shift is a contraction. -/
+lemma l2_opNorm_nilpotentShift_pow_le_one (D : ℕ) (k : ℕ) :
+    ‖nilpotentShift D ^ k‖ ≤ 1 := by
+  induction k with
+  | zero =>
+    rw [pow_zero, ← Matrix.diagonal_one, l2_opNorm_diagonal]
+    exact (pi_norm_le_iff_of_nonneg zero_le_one).mpr fun i => by simp
+  | succ k ih =>
+    refine (pow_succ (nilpotentShift D) k ▸ l2_opNorm_mul _ _).trans ?_
+    nlinarith [norm_nonneg (nilpotentShift D ^ k), norm_nonneg (nilpotentShift D),
+      l2_opNorm_nilpotentShift_le_one D]
+
+/-- Right inequality of Wolf Eq. (8.104):
+$\|J_D(\lambda)^n\|_\infty \le \sum_{k=0}^{\min\{n,D-1\}}|\lambda|^{n-k}\binom{n}{k}$.
+Source: Wolf (2012), Chapter 8, Eq. (8.104), lines 1197--1215. -/
+theorem l2_opNorm_jordanBlock_pow_le (D : ℕ) [NeZero D] (a : ℂ) (n : ℕ) :
+    ‖jordanBlock D a ^ n‖ ≤
+      ∑ k ∈ Finset.range (min n (D - 1) + 1), ‖a‖ ^ (n - k) * (n.choose k : ℝ) := by
+  rw [jordanBlock_pow]
+  refine (norm_sum_le _ _).trans (Finset.sum_le_sum fun k _ => ?_)
+  have hnorm : ‖((n.choose k : ℂ) * a ^ (n - k)) • (nilpotentShift D ^ k)‖ =
+      ‖a‖ ^ (n - k) * (n.choose k : ℝ) * ‖nilpotentShift D ^ k‖ := by
+    rw [norm_smul, norm_mul, norm_pow, Complex.norm_natCast]
+    ring
+  calc ‖((n.choose k : ℂ) * a ^ (n - k)) • (nilpotentShift D ^ k)‖
+      = ‖a‖ ^ (n - k) * (n.choose k : ℝ) * ‖nilpotentShift D ^ k‖ := hnorm
+    _ ≤ ‖a‖ ^ (n - k) * (n.choose k : ℝ) * 1 :=
+        mul_le_mul_of_nonneg_left (l2_opNorm_nilpotentShift_pow_le_one D k) (by positivity)
+    _ = ‖a‖ ^ (n - k) * (n.choose k : ℝ) := mul_one _
+
+/-- Left inequality of Wolf Eq. (8.104):
+$|\lambda|^{n-k_0}\binom{n}{k_0} \le \|J_D(\lambda)^n\|_\infty$ for every
+$k_0 \le \min\{n,D-1\}$.  The bound reads off the entry of $J_D(\lambda)^n$ in
+row $0$ and column $k_0$, which is $\lambda^{n-k_0}\binom{n}{k_0}$.
+Source: Wolf (2012), Chapter 8, Eq. (8.104), lines 1197--1215. -/
+theorem le_l2_opNorm_jordanBlock_pow (D : ℕ) [NeZero D] (a : ℂ) (n k₀ : ℕ)
+    (hk₀ : k₀ ≤ min n (D - 1)) :
+    ‖a‖ ^ (n - k₀) * (n.choose k₀ : ℝ) ≤ ‖jordanBlock D a ^ n‖ := by
+  have hD : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
+  have hk₀D : k₀ < D := lt_of_le_of_lt (le_trans hk₀ (min_le_right _ _)) (by omega)
+  have hmem : k₀ ∈ Finset.range (min n (D - 1) + 1) := Finset.mem_range.mpr (by omega)
+  have hentry : (jordanBlock D a ^ n) ⟨0, hD⟩ ⟨k₀, hk₀D⟩ =
+      (n.choose k₀ : ℂ) * a ^ (n - k₀) := by
+    rw [jordanBlock_pow]
+    simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, nilpotentShift_pow_apply]
+    rw [Finset.sum_eq_single k₀]
+    · simp
+    · intro k _ hk
+      rw [if_neg (by simpa using fun h => hk (by omega)), mul_zero]
+    · intro hcon
+      exact absurd hmem hcon
+  calc ‖a‖ ^ (n - k₀) * (n.choose k₀ : ℝ)
+      = ‖(jordanBlock D a ^ n) ⟨0, hD⟩ ⟨k₀, hk₀D⟩‖ := by
+        rw [hentry, norm_mul, norm_pow, Complex.norm_natCast]
+        ring
+    _ ≤ ‖jordanBlock D a ^ n‖ := norm_apply_le_l2_opNorm _ _ _
+
+/-- Wolf Eq. (8.104): the two-sided estimate on the largest singular value of a
+Jordan-block power.  For every $k_0 \le \min\{n, D-1\}$,
+$$
+|\lambda|^{\,n-k_0}\binom{n}{k_0}
+  \le \bigl\|J_D(\lambda)^n\bigr\|_\infty
+  \le \sum_{k=0}^{\min\{n,\,D-1\}} |\lambda|^{\,n-k}\binom{n}{k}.
+$$
+Source: Wolf (2012), Chapter 8, Eq. (8.104), lines 1197--1215. -/
+theorem l2_opNorm_jordanBlock_pow_bounds (D : ℕ) [NeZero D] (a : ℂ) (n k₀ : ℕ)
+    (hk₀ : k₀ ≤ min n (D - 1)) :
+    ‖a‖ ^ (n - k₀) * (n.choose k₀ : ℝ) ≤ ‖jordanBlock D a ^ n‖ ∧
+      ‖jordanBlock D a ^ n‖ ≤
+        ∑ k ∈ Finset.range (min n (D - 1) + 1), ‖a‖ ^ (n - k) * (n.choose k : ℝ) :=
+  ⟨le_l2_opNorm_jordanBlock_pow D a n k₀ hk₀, l2_opNorm_jordanBlock_pow_le D a n⟩
+
+end OperatorNorm
 
 end Matrix

--- a/blueprint/src/chapter/ch27_channel_asymptotics_jordan_block_power.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_jordan_block_power.tex
@@ -1,10 +1,9 @@
 % Preparatory lemma: nilpotent-shift and binomial expansion
 % Source: Wolf (2012), Chapter 8, lines 1211--1212
 %
-% This is a purely algebraic calculation that provides the algebraic
-% formula for powers of a Jordan block.  It does NOT deliver the
-% two-sided operator-norm bound of Wolf Eq. (8.104); that will require
-% additional $\ell^2$ norm infrastructure and is separate.
+% This is the purely algebraic half: the closed formula for powers of a
+% Jordan block.  The two-sided estimate on the largest singular value,
+% Wolf Eq. (8.104), follows it below.
 \begin{lemma}[Nilpotent shift and Jordan-block binomial expansion]
     \label{lem:jordan_block_power}
     \lean{Matrix.nilpotentShift_pow_apply, Matrix.nilpotentShift_pow_D_eq_zero, Matrix.jordanBlock_pow}
@@ -31,4 +30,38 @@
   observing that $N^{k}=0$ whenever $k\ge D$ truncates the sum at
   $k\le\min\{n,D-1\}$.  The superdiagonal formula $N^{k}_{i,j}=1$ iff $j=i+k$
   is a straightforward induction on $k$ using the definition of $N$.
+\end{proof}
+
+% Source: Wolf (2012), Chapter 8, Equation (8.104), lines 1197--1215
+\begin{lemma}[Two-sided estimate for a Jordan-block power]
+    \label{lem:jordan_block_power_norm}
+    \lean{Matrix.l2_opNorm_jordanBlock_pow_bounds}
+    \leanok
+    \uses{lem:jordan_block_power}
+    This is \cite[Chapter~8, Equation~(8.104)]{Wolf2012Quantum}.
+    Let $D\ge 1$, let $J_{D}(\lambda)=\lambda I+N$ be the Jordan block of
+    Lemma~\ref{lem:jordan_block_power}, and write $\|\cdot\|_{\infty}$ for the
+    largest singular value.  Then, for every $n\in\mathbb N$ and every
+    $k_{0}\le\min\{n,D-1\}$,
+    \begin{align}
+      |\lambda|^{\,n-k_{0}}\binom{n}{k_{0}}
+      \le\bigl\|J_{D}(\lambda)^{n}\bigr\|_{\infty}
+      \le\sum_{k=0}^{\min\{n,D-1\}}|\lambda|^{\,n-k}\binom{n}{k}.
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:jordan_block_power}
+    By Lemma~\ref{lem:jordan_block_power} the power $J_{D}(\lambda)^{n}$ is the
+    Toeplitz matrix $\sum_{k}\binom{n}{k}\lambda^{n-k}N^{k}$, whose first row
+    carries the entries $\lambda^{n-k}\binom{n}{k}$.  Since the largest
+    singular value dominates the modulus of every entry, reading the entry in
+    row $0$ and column $k_{0}$ gives the left inequality; the hypothesis
+    $k_{0}\le\min\{n,D-1\}$ is exactly what places that entry inside the
+    matrix and inside the range of summation.  For the right inequality, the
+    triangle inequality distributes the norm over the same expansion, and
+    $\|N^{k}\|_{\infty}\le 1$ for every $k$, because $N^{\dagger}N$ is the
+    diagonal projection $\operatorname{diag}(0,1,\dots,1)$ and the largest
+    singular value is multiplicative under the adjoint pairing.
 \end{proof}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_jordan_block_power.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_jordan_block_power.tex
@@ -33,9 +33,18 @@
 \end{proof}
 
 % Source: Wolf (2012), Chapter 8, Equation (8.104), lines 1197--1215
-\begin{lemma}[Two-sided estimate for a Jordan-block power]
-    \label{lem:jordan_block_power_norm}
-    \lean{Matrix.l2_opNorm_jordanBlock_pow_bounds}
+%
+% The source asserts \|N\|_\infty = 1 at line 1215.  That equality fails at
+% D = 1, where the shift is the zero matrix; the proof below uses only
+% \|N\|_\infty \le 1, and only that is formalized.  See
+% docs/paper-gaps/wolf_eq8104_shift_norm_one_dimensional.tex.
+\begin{theorem}[Two-sided estimate for a Jordan-block power]
+    \label{thm:jordan_block_power_norm}
+    \lean{Matrix.l2_opNorm_jordanBlock_pow_bounds,
+      Matrix.le_l2_opNorm_jordanBlock_pow, Matrix.l2_opNorm_jordanBlock_pow_le,
+      Matrix.norm_apply_le_l2_opNorm, Matrix.conjTranspose_nilpotentShift_mul_self,
+      Matrix.l2_opNorm_nilpotentShift_le_one,
+      Matrix.l2_opNorm_nilpotentShift_pow_le_one}
     \leanok
     \uses{lem:jordan_block_power}
     This is \cite[Chapter~8, Equation~(8.104)]{Wolf2012Quantum}.
@@ -48,20 +57,24 @@
       \le\bigl\|J_{D}(\lambda)^{n}\bigr\|_{\infty}
       \le\sum_{k=0}^{\min\{n,D-1\}}|\lambda|^{\,n-k}\binom{n}{k}.
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
     \uses{lem:jordan_block_power}
     By Lemma~\ref{lem:jordan_block_power} the power $J_{D}(\lambda)^{n}$ is the
     Toeplitz matrix $\sum_{k}\binom{n}{k}\lambda^{n-k}N^{k}$, whose first row
-    carries the entries $\lambda^{n-k}\binom{n}{k}$.  Since the largest
-    singular value dominates the modulus of every entry, reading the entry in
-    row $0$ and column $k_{0}$ gives the left inequality; the hypothesis
-    $k_{0}\le\min\{n,D-1\}$ is exactly what places that entry inside the
-    matrix and inside the range of summation.  For the right inequality, the
-    triangle inequality distributes the norm over the same expansion, and
-    $\|N^{k}\|_{\infty}\le 1$ for every $k$, because $N^{\dagger}N$ is the
-    diagonal projection $\operatorname{diag}(0,1,\dots,1)$ and the largest
-    singular value is multiplicative under the adjoint pairing.
+    carries the entries $\lambda^{n-k}\binom{n}{k}$.  Since
+    $|A_{i,j}|\le\|A\|_{\infty}$ for every matrix $A$ and every pair of
+    indices, reading the entry in row $0$ and column $k_{0}$, whose value is
+    $\lambda^{\,n-k_{0}}\binom{n}{k_{0}}$, gives the left inequality; the
+    hypothesis $k_{0}\le\min\{n,D-1\}$ is exactly what places that entry
+    inside the matrix and inside the range of summation.  For the right
+    inequality, the triangle inequality distributes the norm over the same
+    expansion, and $\|N^{k}\|_{\infty}\le 1$ for every $k$: the Gram matrix
+    $N^{\dagger}N$ is the diagonal projection
+    $\operatorname{diag}(0,1,\dots,1)$, so the C*-identity gives
+    $\|N\|_{\infty}^{2}=\|N^{\dagger}N\|_{\infty}\le 1$, and induction on $k$
+    with $\|N^{k+1}\|_{\infty}\le\|N^{k}\|_{\infty}\|N\|_{\infty}$ carries the
+    bound to every power.
 \end{proof}

--- a/docs/paper-gaps/wolf_eq8104_shift_norm_one_dimensional.tex
+++ b/docs/paper-gaps/wolf_eq8104_shift_norm_one_dimensional.tex
@@ -1,0 +1,73 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Jordan-Block Norm Estimate: the Shift Norm in One Dimension}
+\author{}
+\date{2026-08-13}
+
+\begin{document}
+\maketitle
+
+\section{Source passage}
+
+Chapter~8 of \cite{Wolf2012Quantum} derives the two-sided estimate
+\begin{align}
+  |\lambda|^{\,n-k_{0}}\binom{n}{k_{0}}
+    \le \bigl\|J_{D}(\lambda)^{n}\bigr\|_{\infty}
+    \le \sum_{k=0}^{\min\{n,D-1\}}|\lambda|^{\,n-k}\binom{n}{k},
+  \qquad k_{0}\le\min\{n,D-1\},
+\end{align}
+of Equation~(8.104), at lines 1197--1215 of the local source file. The upper
+bound is obtained from the binomial expansion
+$J_{D}(\lambda)^{n}=\sum_{k}\binom{n}{k}\lambda^{n-k}N^{k}$ by the triangle
+inequality, using the assertion $\|N\|_{\infty}=1$ for the strict upper shift
+$N$ at line~1215.
+
+\section{The deviation}
+
+The equality $\|N\|_{\infty}=1$ holds for $D\ge 2$ but fails at $D=1$: the
+strict upper shift on a one-dimensional space is the zero matrix, so
+$\|N\|_{\infty}=0$. Wolf states the equality without a dimension restriction.
+The Jordan block itself is defined for every $D\ge 1$, and Equation~(8.104) is
+asserted for every such $D$, so the intermediate assertion is one degenerate
+case wider than its proof supports.
+
+\section{Formalized interpretation}
+
+Only the direction $\|N\|_{\infty}\le 1$ enters the derivation: the triangle
+inequality is followed by
+$\|N^{k}\|_{\infty}\le\|N\|_{\infty}^{k}\le 1$, which is what discards the
+shift factors from the expansion. The formalization therefore states
+\leanid{Matrix.l2_opNorm_nilpotentShift_le_one} as the inequality
+$\|N\|_{\infty}\le 1$, valid for every $D$, and derives
+\leanid{Matrix.l2_opNorm_nilpotentShift_pow_le_one} from it. The proof is the
+one Wolf indicates: $N^{\dagger}N=\operatorname{diag}(0,1,\dots,1)$, whose
+largest singular value is at most $1$, and the C*-identity
+$\|N\|_{\infty}^{2}=\|N^{\dagger}N\|_{\infty}$ transfers the bound.
+
+At $D=1$ the two sides of Equation~(8.104) coincide: the hypothesis
+$k_{0}\le\min\{n,D-1\}$ forces $k_{0}=0$, and both bounds read
+$|\lambda|^{n}\le\|\lambda^{n}\|_{\infty}\le|\lambda|^{n}$. The theorems
+\leanid{Matrix.le_l2_opNorm_jordanBlock_pow},
+\leanid{Matrix.l2_opNorm_jordanBlock_pow_le} and
+\leanid{Matrix.l2_opNorm_jordanBlock_pow_bounds} therefore carry Wolf's
+hypothesis set unchanged, with no dimension restriction beyond $D\ge 1$, which
+the Jordan block presupposes.
+
+\section{Verdict}
+
+\textbf{Verdict: resolved local fix (shift norm at $D=1$).} Replacing the
+source's intermediate equality $\|N\|_{\infty}=1$ by the inequality
+$\|N\|_{\infty}\le 1$ removes a false degenerate case without weakening
+Equation~(8.104), which is formalized with the source's own hypotheses.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_eq8104_shift_norm_one_dimensional.tex
+++ b/docs/paper-gaps/wolf_eq8104_shift_norm_one_dimensional.tex
@@ -16,12 +16,16 @@
 
 \section{Source passage}
 
-Chapter~8 of \cite{Wolf2012Quantum} derives the two-sided estimate
+Fix an integer $D\ge 1$, let $N\in\MN{D}$ be the strict upper shift
+$N_{i,j}=1$ if $j=i+1$ and $N_{i,j}=0$ otherwise, let
+$J_{D}(\lambda)=\lambda\Id+N$ be the Jordan block with eigenvalue
+$\lambda\in\C$, and write $\|\cdot\|_{\infty}$ for the largest singular value.
+Chapter~8 of \cite{Wolf2012Quantum} derives, for every $n\in\mathbb N$ and
+every natural number $k_{0}\le\min\{n,D-1\}$, the two-sided estimate
 \begin{align}
   |\lambda|^{\,n-k_{0}}\binom{n}{k_{0}}
     \le \bigl\|J_{D}(\lambda)^{n}\bigr\|_{\infty}
-    \le \sum_{k=0}^{\min\{n,D-1\}}|\lambda|^{\,n-k}\binom{n}{k},
-  \qquad k_{0}\le\min\{n,D-1\},
+    \le \sum_{k=0}^{\min\{n,D-1\}}|\lambda|^{\,n-k}\binom{n}{k}
 \end{align}
 of Equation~(8.104), at lines 1197--1215 of the local source file. The upper
 bound is obtained from the binomial expansion
@@ -47,7 +51,9 @@ shift factors from the expansion. The formalization therefore states
 \leanid{Matrix.l2_opNorm_nilpotentShift_le_one} as the inequality
 $\|N\|_{\infty}\le 1$, valid for every $D$, and derives
 \leanid{Matrix.l2_opNorm_nilpotentShift_pow_le_one} from it. The proof is the
-one Wolf indicates: $N^{\dagger}N=\operatorname{diag}(0,1,\dots,1)$, whose
+one Wolf indicates: the Gram identity
+$N^{\dagger}N=\operatorname{diag}(0,1,\dots,1)$, which is
+\leanid{Matrix.conjTranspose_nilpotentShift_mul_self}, gives a matrix whose
 largest singular value is at most $1$, and the C*-identity
 $\|N\|_{\infty}^{2}=\|N^{\dagger}N\|_{\infty}$ transfers the bound.
 


### PR DESCRIPTION
## Source

Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8,
`Notes/WolfNoteTexSource/ch08_distance_measures.tex`, lines 1197–1215,
Equation (8.104), as printed:

> Similarly, if $X$ is a Jordan block with diagonal part $\Lambda=\lambda\mathbb{1}$,
> then for all $n\in\mathbb{N}$ and natural numbers $k_0\le\min\{n,D-1\}$
>
> $$|\lambda|^{n-k_0}\binom{n}{k_0} \le \|X^n\|_\infty \le \sum_{k=0}^{\min\{n,D-1\}} |\lambda|^{n-k}\binom{n}{k}.$$

Here $\|\cdot\|_\infty$ is Wolf's largest singular value, i.e. the $\ell^2$
operator norm; the Lean statements use Mathlib's `Matrix.Norms.L2Operator`
scoped norm instance, following the convention of the other
`TNLean/Analysis/` files. An $\ell^\infty$ row-sum norm would not be a
source-faithful substitute.

Wolf's own route is followed: the lower bound comes from the observation
that the operator norm dominates the modulus of every entry, applied to the
$(0,k_0)$ entry of the binomial expansion; the upper bound is the triangle
inequality together with $\|N\|_\infty=1$ and submultiplicativity.

## Landed signatures

All in `TNLean/Analysis/JordanBlockPower.lean`, namespace `Matrix`, under
`open scoped Matrix.Norms.L2Operator`.

```lean
theorem l2_opNorm_jordanBlock_pow_bounds (D : ℕ) [NeZero D] (a : ℂ) (n k₀ : ℕ)
    (hk₀ : k₀ ≤ min n (D - 1)) :
    ‖a‖ ^ (n - k₀) * (n.choose k₀ : ℝ) ≤ ‖jordanBlock D a ^ n‖ ∧
      ‖jordanBlock D a ^ n‖ ≤
        ∑ k ∈ Finset.range (min n (D - 1) + 1), ‖a‖ ^ (n - k) * (n.choose k : ℝ)

theorem le_l2_opNorm_jordanBlock_pow (D : ℕ) [NeZero D] (a : ℂ) (n k₀ : ℕ)
    (hk₀ : k₀ ≤ min n (D - 1)) :
    ‖a‖ ^ (n - k₀) * (n.choose k₀ : ℝ) ≤ ‖jordanBlock D a ^ n‖

theorem l2_opNorm_jordanBlock_pow_le (D : ℕ) [NeZero D] (a : ℂ) (n : ℕ) :
    ‖jordanBlock D a ^ n‖ ≤
      ∑ k ∈ Finset.range (min n (D - 1) + 1), ‖a‖ ^ (n - k) * (n.choose k : ℝ)
```

Supporting lemmas, both new (Mathlib has neither; see below):

```lean
lemma norm_apply_le_l2_opNorm {n : Type*} [Fintype n] [DecidableEq n]
    (A : Matrix n n ℂ) (i j : n) : ‖A i j‖ ≤ ‖A‖

lemma conjTranspose_nilpotentShift_mul_self (D : ℕ) :
    (nilpotentShift D)ᴴ * nilpotentShift D =
      diagonal (fun i : Fin D => if (i : ℕ) = 0 then (0 : ℂ) else 1)

lemma l2_opNorm_nilpotentShift_le_one (D : ℕ) : ‖nilpotentShift D‖ ≤ 1

lemma l2_opNorm_nilpotentShift_pow_le_one (D : ℕ) (k : ℕ) :
    ‖nilpotentShift D ^ k‖ ≤ 1
```

### Mathlib scouting

Mathlib has no entry-versus-operator-norm bound for the `Matrix.Norms.L2Operator`
norm. `Matrix.norm_entry_le_entrywise_sup_norm` is stated for the entrywise sup
norm, and `CStarMatrix.norm_entry_le_norm` is stated for the `CStarMatrix` type
synonym with its own norm; neither transports without extra work.
`norm_apply_le_l2_opNorm` is therefore proved directly from
`ContinuousLinearMap.le_opNorm` on `Matrix.toEuclideanCLM`, evaluated at
`PiLp.single 2 j 1`, using `Matrix.l2_opNorm_toEuclideanCLM`, `PiLp.norm_single`
and `PiLp.norm_apply_le`. The shift bound reuses Mathlib's
`Matrix.l2_opNorm_conjTranspose_mul_self` and `Matrix.l2_opNorm_diagonal`; the
upper bound reuses `Matrix.l2_opNorm_mul` and `norm_sum_le`.

## Hypothesis match

The source hypothesis is exactly $k_0\le\min\{n,D-1\}$, and that is exactly
`hk₀ : k₀ ≤ min n (D - 1)`. Nothing further is assumed about $\lambda$, $n$,
or $k_0$.

The one instance argument is `[NeZero D]`. This is not an addition to Wolf's
hypothesis set: a Jordan block of size $D$ presupposes $D\ge 1$, and the
existing algebraic lemma `Matrix.jordanBlock_pow` (PR LionSR/TNLean#5729) already carries
it. It does **not** follow from `k₀ ≤ min n (D - 1)`: Lean's truncated
subtraction gives `0 - 1 = 0`, so at `D = 0` the hypothesis reduces to
`k₀ = 0` and says nothing about `D`. The lower bound is genuinely false
without it — at `D = 0` the matrix is the empty matrix of norm `0`, while the
left-hand side is `|λ|^n ≥ 0` and equals `1` at `λ = 0, n = 0`. So the
assumption is load-bearing for the lower bound and is stated once, on all
three theorems, rather than being weakened per direction.

`n ≥ 1` is not assumed anywhere.

## Degenerate cases

All are covered by the statements above; none is excluded by a side condition.

- **`D = 1`.** Then `min n (D - 1) = 0`, forcing `k₀ = 0`, and $J_1(\lambda)=\lambda$.
  Both bounds read $|\lambda|^n\le\||\lambda|^n\|\le|\lambda|^n$. Note that
  $\|N\|_\infty=1$ *fails* here ($N=0$), which is why
  `l2_opNorm_nilpotentShift_le_one` is stated as `≤ 1`, never as an equality.
- **`n = 0`.** Then `k₀ = 0` and both sides are `1 = ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖`.
  The identity is handled through `Matrix.diagonal_one` and
  `Matrix.l2_opNorm_diagonal` inside `l2_opNorm_nilpotentShift_pow_le_one` at
  exponent `0`.
- **`λ = 0`.** The convention `‖a‖ ^ 0 = 1` in `ℝ` makes the lower bound at
  `k₀ = n ≤ D - 1` read `1 ≤ ‖N^n‖`, which is correct: `N^n` still carries a
  unit entry because `n < D`. No `λ ≠ 0` hypothesis is needed.
- **`k₀ = 0`.** The lower bound becomes `|λ|^n ≤ ‖J_D(λ)^n‖`, read off the
  diagonal entry. Covered by the general argument with no case split.

## Verification

```
lake env lean TNLean/Analysis/JordanBlockPower.lean      # exit 0, no errors or warnings
lake build TNLean.Analysis                               # Build completed successfully (3439 jobs)
rg -n "sorry|axiom|native_decide|maxHeartbeats|admit|unsafeCast" \
  TNLean/Analysis/JordanBlockPower.lean                  # no matches
python3 scripts/blueprint_lean_sync.py --ci              # only the expected new-declaration entry
```

`#print axioms` on all five new declarations reports
`[propext, Classical.choice, Quot.sound]` only.

`rg -l 'JordanBlockPower'` finds `TNLean/Analysis.lean` as the sole consumer;
that aggregate module is what `lake build TNLean.Analysis` covers.

`leanblueprint checkdecls` cannot run locally because `blueprint/lean_decls`
is generated in CI; `scripts/blueprint_lean_sync.py --ci` reports
`Matrix.l2_opNorm_jordanBlock_pow_bounds` as the one new blueprint reference
awaiting the CI-regenerated `lean_decls`, plus one pre-existing stale PEPS
entry untouched by this branch.

## Blueprint

`blueprint/src/chapter/ch27_channel_asymptotics_jordan_block_power.tex` gains
`\label{lem:jordan_block_power_norm}` with `\lean{Matrix.l2_opNorm_jordanBlock_pow_bounds}`,
`\leanok` on statement and proof, and `\uses{lem:jordan_block_power}`. The
file's leading comment, which recorded the norm estimate as absent, is updated.

## Tracker

This is a leaf of LionSR/QICLean#44. Its only other open leaf, LionSR/QICLean#324, is in PR LionSR/TNLean#6279, so
LionSR/QICLean#44 has no remaining open leaf once both land.

Closes LionSR/QICLean#306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176U7wiKWaxFAKBHv3Jgjz3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib analysis proofs in a dedicated file with no runtime or security surface; the only semantic nuance is the documented Wolf source fix at D=1.
> 
> **Overview**
> Formalizes **Wolf Eq. (8.104)**: two-sided ℓ² operator-norm bounds on `jordanBlock D a ^ n`, building on the existing binomial expansion in `JordanBlockPower.lean`.
> 
> Adds an `OperatorNorm` section with entry-vs-norm control (`norm_apply_le_l2_opNorm`), Gram-matrix computation for the nilpotent shift, and `‖N^k‖ ≤ 1` (using **`‖N‖ ≤ 1`** instead of Wolf’s equality at `D = 1`). Main results: `le_l2_opNorm_jordanBlock_pow`, `l2_opNorm_jordanBlock_pow_le`, and `l2_opNorm_jordanBlock_pow_bounds`. Imports `Mathlib.Analysis.CStarAlgebra.Matrix` and opens `Matrix.Norms.L2Operator`.
> 
> The blueprint chapter gains a `\leanok` theorem for the norm estimate; a **paper-gaps** note documents the `D = 1` shift-norm correction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51407451867d90957f0ef0387a22312b0e53659e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->