### PR TITLE
feat(ParentHamiltonian): transport cyclic anticommutator forms

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
@@ -5,15 +5,17 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.LocalSupport
+import TNLean.MPS.ParentHamiltonian.CyclicWindowIndex
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 
 /-!
-# Three-site local support and transport of the nearest-neighbor commutator
+# Three-site local support and cyclic transport
 
 This file first identifies the three-site MPS ground space with the
 intersection of the kernels of its two adjacent length-two parent interactions.
-It then transports the local commutation relation between these interactions
-to every translated three-site window of a longer periodic chain.
+It then transports local relations between these interactions to every
+translated three-site window of a longer periodic chain, including a generic
+anticommutator quadratic-form inequality and the commuting specialization.
 
 The chain-length hypothesis is (3 \leq N), matching the (N>2) condition in
 arXiv:1606.00608, Theorem 3.10 and the local relation
@@ -25,6 +27,9 @@ arXiv:1606.00608, Theorem 3.10 and the local relation
   \((L+1)\)-site ground space by the two adjacent length-\(L\) kernels.
 * `groundSpace_three_eq_adjacent_twoSite_parent_kernels` gives the three-site
   specialization for the canonical two-site parent interaction.
+* `re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite` and
+  `re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite` transport a
+  three-site anticommutator quadratic-form estimate to every cyclic adjacent pair.
 * `localTerm_adjacent_twoSite_commute_of_threeSite_zero_one_commute` transports
   the three-site commutator to every translated three-site window.
 
@@ -33,6 +38,8 @@ arXiv:1606.00608, Theorem 3.10 and the local relation
 * arXiv:2011.12127, Section IV.C.
 * arXiv:1606.00608, Definition 3.9 and Appendix D, Definition D.2.
 -/
+
+open scoped BigOperators ComplexOrder InnerProductSpace
 
 namespace MPSTensor
 
@@ -278,6 +285,210 @@ private theorem cyclicRestrictₗ_three_extractWindow
     cyclicRestrictₗ (by omega) 3 i σ ψ (extractWindow 3 i σ) = ψ σ := by
   change ψ (replaceWindow 3 hN i σ (extractWindow 3 i σ)) = ψ σ
   rw [replaceWindow_extractWindow]
+
+/-! ### Transport of three-site quadratic forms -/
+
+private def cyclicWindowCfgEquiv {N : ℕ} (hN : 3 ≤ N) (i : Fin N) :
+    Cfg d 3 × Cfg d (N - 3) ≃ Cfg d N :=
+  (Equiv.sumArrowEquivProdArrow (Fin 3) (Fin (N - 3)) (Fin d)).symm.trans
+    (Equiv.piCongrLeft (fun _ : Fin N ↦ Fin d) (cyclicWindowIndexEquiv 3 N hN i))
+
+@[simp] private theorem cyclicWindowCfgEquiv_apply_window {N : ℕ} (hN : 3 ≤ N)
+    (i : Fin N) (σ : Cfg d 3) (τ : Cfg d (N - 3)) (r : Fin 3) :
+    cyclicWindowCfgEquiv hN i (σ, τ) (cyclicForwardSite i r.val) = σ r := by
+  change Equiv.piCongrLeft (fun _ : Fin N ↦ Fin d) (cyclicWindowIndexEquiv 3 N hN i)
+    ((Equiv.sumArrowEquivProdArrow (Fin 3) (Fin (N - 3)) (Fin d)).symm (σ, τ))
+    (cyclicWindowIndexEquiv 3 N hN i (Sum.inl r)) = σ r
+  rw [Equiv.piCongrLeft_apply_apply]
+  rfl
+
+private theorem cyclicCfg_cyclicWindowCfgEquiv {N : ℕ} (hN : 3 ≤ N) [NeZero d]
+    (i : Fin N) (σ : Cfg d 3) (τ : Cfg d (N - 3)) :
+    cyclicCfg (by omega) 3 i σ (cyclicWindowCfgEquiv hN i ((fun _ ↦ 0), τ)) =
+      cyclicWindowCfgEquiv hN i (σ, τ) := by
+  funext k
+  simp only [cyclicCfg]
+  by_cases hk : (k.val + N - i.val) % N < 3
+  · rw [dif_pos hk]
+    let r : Fin 3 := ⟨(k.val + N - i.val) % N, hk⟩
+    have hki : k = cyclicForwardSite i r.val := by
+      simpa [cyclicForwardSite, r] using
+        eq_cyclic_site_of_offset_eq (Fin.pos i) (i := i) (k := k) (r := r.val) rfl
+    have hleft : σ ⟨(k.val + N - i.val) % N, hk⟩ = σ r := rfl
+    rw [hleft]
+    rw [hki]
+    exact cyclicWindowCfgEquiv_apply_window hN i σ τ r |>.symm
+  · rw [dif_neg hk]
+    let x := (cyclicWindowIndexEquiv 3 N hN i).symm k
+    have hkx : cyclicWindowIndexEquiv 3 N hN i x = k := by simp [x]
+    rcases x with r | r
+    · exfalso
+      apply hk
+      rw [← hkx]
+      change ((cyclicForwardSite i r.val).val + N - i.val) % N < 3
+      rw [show ((cyclicForwardSite i r.val).val + N - i.val) % N = r.val by
+        simpa [cyclicForwardSite] using
+          offset_mod_eq i.isLt (Nat.lt_of_lt_of_le r.isLt hN)]
+      exact r.isLt
+    · change Equiv.piCongrLeft (fun _ : Fin N ↦ Fin d)
+          (cyclicWindowIndexEquiv 3 N hN i)
+          ((Equiv.sumArrowEquivProdArrow (Fin 3) (Fin (N - 3)) (Fin d)).symm
+            (fun _ ↦ 0, τ)) k =
+        Equiv.piCongrLeft (fun _ : Fin N ↦ Fin d)
+          (cyclicWindowIndexEquiv 3 N hN i)
+          ((Equiv.sumArrowEquivProdArrow (Fin 3) (Fin (N - 3)) (Fin d)).symm
+            (σ, τ)) k
+      rw [← hkx, Equiv.piCongrLeft_apply_apply, Equiv.piCongrLeft_apply_apply]
+      rfl
+
+private theorem re_inner_eq_sum_cyclicRestrict_three {N : ℕ} (hN : 3 ≤ N)
+    [NeZero d] (i : Fin N) (u v : EuclideanSpace ℂ (Cfg d N)) :
+    (⟪u, v⟫_ℂ).re =
+      ∑ τ : Cfg d (N - 3),
+        (⟪LinearMap.withLpMap 2 (cyclicRestrictₗ (d := d) (by omega) 3 i
+              (cyclicWindowCfgEquiv hN i ((fun _ ↦ 0), τ))) u,
+            LinearMap.withLpMap 2 (cyclicRestrictₗ (d := d) (by omega) 3 i
+              (cyclicWindowCfgEquiv hN i ((fun _ ↦ 0), τ))) v⟫_ℂ).re := by
+  rw [PiLp.inner_apply]
+  trans (∑ p : Cfg d 3 × Cfg d (N - 3),
+    inner ℂ (u.ofLp (cyclicWindowCfgEquiv hN i p))
+      (v.ofLp (cyclicWindowCfgEquiv hN i p))).re
+  · congr 1
+    symm
+    apply Fintype.sum_equiv (cyclicWindowCfgEquiv hN i)
+    intro p
+    rfl
+  · simp only [Fintype.sum_prod_type]
+    rw [Finset.sum_comm]
+    change Complex.reCLM (∑ y, ∑ x,
+      inner ℂ (u.ofLp (cyclicWindowCfgEquiv hN i (x, y)))
+        (v.ofLp (cyclicWindowCfgEquiv hN i (x, y)))) = _
+    rw [map_sum Complex.reCLM]
+    apply Finset.sum_congr rfl
+    intro τ _
+    rw [PiLp.inner_apply]
+    change Complex.reCLM (∑ x, _) = Complex.reCLM (∑ x, _)
+    congr 1
+    apply Finset.sum_congr rfl
+    intro σ _
+    apply congrArg₂ (inner ℂ)
+    · change u.ofLp (cyclicWindowCfgEquiv hN i (σ, τ)) =
+        u.ofLp (cyclicCfg (by omega) 3 i σ
+          (cyclicWindowCfgEquiv hN i ((fun _ ↦ 0), τ)))
+      rw [cyclicCfg_cyclicWindowCfgEquiv]
+    · change v.ofLp (cyclicWindowCfgEquiv hN i (σ, τ)) =
+        v.ofLp (cyclicCfg (by omega) 3 i σ
+          (cyclicWindowCfgEquiv hN i ((fun _ ↦ 0), τ)))
+      rw [cyclicCfg_cyclicWindowCfgEquiv]
+
+private theorem cyclicRestrictES_three_localTerm_left
+    {A : MPSTensor d D} {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N)
+    (v : EuclideanSpace ℂ (Cfg d N)) :
+    LinearMap.withLpMap 2 (cyclicRestrictₗ (d := d) (by omega) 3 i τ)
+        (localTermES A 2 i v) =
+      localTermES A 2 (0 : Fin 3)
+        (LinearMap.withLpMap 2 (cyclicRestrictₗ (d := d) (by omega) 3 i τ) v) := by
+  let eN := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  let e3 := WithLp.linearEquiv 2 ℂ (NSiteSpace d 3)
+  apply e3.injective
+  simpa [localTermES, eN, e3, LinearMap.withLpMap] using
+    cyclicRestrictₗ_three_localTerm_left (A := A) hN i τ (eN v)
+
+private theorem cyclicRestrictES_three_localTerm_right
+    {A : MPSTensor d D} {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (τ : Cfg d N)
+    (v : EuclideanSpace ℂ (Cfg d N)) :
+    LinearMap.withLpMap 2 (cyclicRestrictₗ (d := d) (by omega) 3 i τ)
+        (localTermES A 2 (cyclicForwardSite i 1) v) =
+      localTermES A 2 (1 : Fin 3)
+        (LinearMap.withLpMap 2 (cyclicRestrictₗ (d := d) (by omega) 3 i τ) v) := by
+  let eN := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  let e3 := WithLp.linearEquiv 2 ℂ (NSiteSpace d 3)
+  apply e3.injective
+  simpa [localTermES, eN, e3, LinearMap.withLpMap] using
+    cyclicRestrictₗ_three_localTerm_right (A := A) hN i τ (eN v)
+
+/-- A three-site anticommutator quadratic-form estimate for the adjacent
+range-two terms transports to every forward adjacent pair on a periodic chain
+with \(3 \leq N\), with the same coefficient.
+
+The restriction begins at the arbitrary site `i`, so it also covers the two
+forward pairs whose three-site window crosses the periodic cut.  This is the
+source form \(h_i h_j + h_j h_i \geq -c(h_i+h_j)\) from
+arXiv:2011.12127, Section IV.C, lines 2170--2180. -/
+theorem re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite
+    [NeZero d] {A : MPSTensor d D} {c : ℝ}
+    (h₃ : ∀ w : EuclideanSpace ℂ (Cfg d 3),
+      -c * ((⟪localTermES A 2 (0 : Fin 3) w, w⟫_ℂ).re +
+          (⟪localTermES A 2 (1 : Fin 3) w, w⟫_ℂ).re) ≤
+        (⟪localTermES A 2 (0 : Fin 3) w,
+            localTermES A 2 (1 : Fin 3) w⟫_ℂ).re +
+          (⟪localTermES A 2 (1 : Fin 3) w,
+            localTermES A 2 (0 : Fin 3) w⟫_ℂ).re)
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (v : EuclideanSpace ℂ (Cfg d N)) :
+    -c * ((⟪localTermES A 2 i v, v⟫_ℂ).re +
+        (⟪localTermES A 2 (cyclicForwardSite i 1) v, v⟫_ℂ).re) ≤
+      (⟪localTermES A 2 i v,
+          localTermES A 2 (cyclicForwardSite i 1) v⟫_ℂ).re +
+        (⟪localTermES A 2 (cyclicForwardSite i 1) v,
+          localTermES A 2 i v⟫_ℂ).re := by
+  simp_rw [re_inner_eq_sum_cyclicRestrict_three hN i]
+  rw [← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+  change -c * (∑ τ, _) ≤ ∑ τ, _
+  rw [Finset.mul_sum]
+  apply Finset.sum_le_sum
+  intro τ _
+  let outside := cyclicWindowCfgEquiv hN i ((fun _ ↦ 0), τ)
+  let w := LinearMap.withLpMap 2 (cyclicRestrictₗ (d := d) (by omega) 3 i outside) v
+  have hleft := cyclicRestrictES_three_localTerm_left (A := A) hN i outside v
+  have hright := cyclicRestrictES_three_localTerm_right (A := A) hN i outside v
+  rw [hleft, hright]
+  exact h₃ w
+
+private theorem cyclicForwardSite_backwardSite_one {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
+    cyclicForwardSite (cyclicBackwardSite i 1) 1 = i := by
+  apply Fin.ext
+  simp only [cyclicForwardSite, cyclicBackwardSite, Fin.val_mk]
+  rw [Nat.mod_eq_of_lt (by omega : 1 < N)]
+  by_cases hi : 0 < i.val
+  · have hback : (i.val + N - 1) % N = i.val - 1 := by
+      rw [show i.val + N - 1 = (i.val - 1) + N by omega, Nat.add_mod_right]
+      exact Nat.mod_eq_of_lt (by omega)
+    rw [hback, show i.val - 1 + 1 = i.val by omega, Nat.mod_eq_of_lt i.isLt]
+  · have hi0 : i.val = 0 := by omega
+    rw [hi0]
+    simp only [Nat.zero_add]
+    rw [Nat.mod_eq_of_lt (by omega : N - 1 < N)]
+    rw [show N - 1 + 1 = N by omega, Nat.mod_self]
+
+/-- The same three-site anticommutator estimate transports to every backward
+adjacent pair on a periodic chain with \(3 \leq N\), with unchanged coefficient.
+
+The proof starts the forward three-site window at the cyclic predecessor of
+\(i\); when \(i = 0\), this is explicitly the wrapping pair between sites
+\(0\) and \(N-1\). -/
+theorem re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite
+    [NeZero d] {A : MPSTensor d D} {c : ℝ}
+    (h₃ : ∀ w : EuclideanSpace ℂ (Cfg d 3),
+      -c * ((⟪localTermES A 2 (0 : Fin 3) w, w⟫_ℂ).re +
+          (⟪localTermES A 2 (1 : Fin 3) w, w⟫_ℂ).re) ≤
+        (⟪localTermES A 2 (0 : Fin 3) w,
+            localTermES A 2 (1 : Fin 3) w⟫_ℂ).re +
+          (⟪localTermES A 2 (1 : Fin 3) w,
+            localTermES A 2 (0 : Fin 3) w⟫_ℂ).re)
+    {N : ℕ} (hN : 3 ≤ N) (i : Fin N) (v : EuclideanSpace ℂ (Cfg d N)) :
+    -c * ((⟪localTermES A 2 i v, v⟫_ℂ).re +
+        (⟪localTermES A 2 (cyclicBackwardSite i 1) v, v⟫_ℂ).re) ≤
+      (⟪localTermES A 2 i v,
+          localTermES A 2 (cyclicBackwardSite i 1) v⟫_ℂ).re +
+        (⟪localTermES A 2 (cyclicBackwardSite i 1) v,
+          localTermES A 2 i v⟫_ℂ).re := by
+  let j := cyclicBackwardSite i 1
+  have hj : cyclicForwardSite j 1 = i := cyclicForwardSite_backwardSite_one (by omega) i
+  have h := re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite
+    h₃ hN j v
+  rw [hj] at h
+  simpa [j, add_comm] using h
+
 
 /-! ### Transport of the commutator -/
 

--- a/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
@@ -411,7 +411,7 @@ private theorem cyclicRestrictES_three_localTerm_right
 range-two terms transports to every forward adjacent pair on a periodic chain
 with \(3 \leq N\), with the same coefficient.
 
-The restriction begins at the arbitrary site `i`, so it also covers the two
+The restriction begins at the arbitrary site \(i\), so it also covers the two
 forward pairs whose three-site window crosses the periodic cut.  This is the
 source form \(h_i h_j + h_j h_i \geq -c(h_i+h_j)\) from
 arXiv:2011.12127, Section IV.C, lines 2170--2180. -/

--- a/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean
@@ -288,6 +288,10 @@ private theorem cyclicRestrictₗ_three_extractWindow
 
 /-! ### Transport of three-site quadratic forms -/
 
+/-- Split an \(N\)-site configuration into the cyclic three-site window
+starting at \(i\) and its ordered complement.  The first coordinates occur at
+cyclic offsets \(0,1,2\) from \(i\); the complementary coordinates then occur
+at offsets \(3,4,\ldots,N-1\), in that order. -/
 private def cyclicWindowCfgEquiv {N : ℕ} (hN : 3 ≤ N) (i : Fin N) :
     Cfg d 3 × Cfg d (N - 3) ≃ Cfg d N :=
   (Equiv.sumArrowEquivProdArrow (Fin 3) (Fin (N - 3)) (Fin d)).symm.trans

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
@@ -1,3 +1,37 @@
+
+\begin{lemma}[Three-site anticommutator transport to cyclic adjacent pairs]
+    \label{lem:three_site_anticommutator_cyclic_transport}
+    \lean{MPSTensor.re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite}
+    \lean{MPSTensor.re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite}
+    \leanok
+    \uses{rem:euclidean_local_projector_ingredients}
+    Let $h_0,h_1$ be the two adjacent range-two local terms on three sites.
+    Suppose that, for every three-site vector $w$,
+    \begin{align}
+      -c\bigl(\re\langle h_0w,w\rangle+\re\langle h_1w,w\rangle\bigr)
+      \leq
+      \re\langle h_0w,h_1w\rangle+\re\langle h_1w,h_0w\rangle.
+      \notag
+    \end{align}
+    Then for every $N\geq3$, every site $i\in\Fin{N}$, and every $N$-site
+    vector $v$, the same inequality with the same coefficient $c$ holds for
+    both adjacent cyclic pairs $(h_i,h_{i+1})$ and $(h_i,h_{i-1})$.  All site
+    indices are taken modulo $N$, so this includes pairs and three-site windows
+    crossing the periodic cut.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Split the configuration basis into the cyclic three-site window beginning
+    at $i$ and its ordered complement.  The global quadratic form is the sum,
+    over complementary configurations, of the corresponding three-site
+    quadratic forms.  Cyclic restriction intertwines the two global local terms
+    with the terms at sites $0$ and $1$ on the three-site chain, so the assumed
+    estimate applies in each summand and summation leaves $c$ unchanged.  For
+    the backward pair, begin the forward window at $i-1$; moving one step
+    forward from that site returns $i$, including when $i=0$.
+\end{proof}
+
 \begin{lemma}[Quadratic-form estimate from the martingale condition]
     \label{lem:parent_hamiltonian_ordered_rowsum_quadratic}
     \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
@@ -4,7 +4,7 @@
     \lean{MPSTensor.re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients,
-        rem:cyclic_window_operators, thm:three_site_commutator_chain_transport}
+        rem:cyclic_window_operators}
     Assume that the physical dimension satisfies $d>0$, and fix a coefficient
     $c\in\mathbb R$. Let $h_0,h_1$ be the two adjacent range-two local terms on
     three sites. Suppose that, for every three-site vector $w$,
@@ -75,9 +75,11 @@
           +\re\langle h_1w_\tau,h_0w_\tau\rangle\bigr),
       \label{eq:three_site_anticommutator_fiber_sum}
     \end{align}
-    which becomes
-    (\ref{eq:three_site_anticommutator_transport_forward}) by the preceding two
-    identities; in particular, summation leaves $c$ unchanged. For the backward
+    By the fiber decomposition
+    (\ref{eq:three_site_anticommutator_fiber_decomposition}) and restriction
+    intertwining (\ref{eq:three_site_anticommutator_restriction_intertwining}),
+    this is (\ref{eq:three_site_anticommutator_transport_forward}); in
+    particular, summation leaves $c$ unchanged. For the backward
     pair, begin the forward window at $i-1$. Moving one step forward from that
     site returns $i$, including when $i=0$, and yields
     (\ref{eq:three_site_anticommutator_transport_backward}).

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
@@ -63,7 +63,7 @@
       \label{eq:three_site_anticommutator_restriction_intertwining}
     \end{align}
     Applying
-    \eqref{eq:three_site_anticommutator_transport_hypothesis} to
+    (\ref{eq:three_site_anticommutator_transport_hypothesis}) to
     $w_\tau=R_{i,\tau}^{(3)}v$ and summing over the complement gives
     \begin{align}
       \sum_{\tau\in\mathcal C_{N-3}}
@@ -76,11 +76,11 @@
       \label{eq:three_site_anticommutator_fiber_sum}
     \end{align}
     which becomes
-    \eqref{eq:three_site_anticommutator_transport_forward} by the preceding two
+    (\ref{eq:three_site_anticommutator_transport_forward}) by the preceding two
     identities; in particular, summation leaves $c$ unchanged. For the backward
     pair, begin the forward window at $i-1$. Moving one step forward from that
     site returns $i$, including when $i=0$, and yields
-    \eqref{eq:three_site_anticommutator_transport_backward}.
+    (\ref{eq:three_site_anticommutator_transport_backward}).
 \end{proof}
 
 \begin{lemma}[Quadratic-form estimate from the martingale condition]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
@@ -1,35 +1,86 @@
-
-\begin{lemma}[Three-site anticommutator transport to cyclic adjacent pairs]
-    \label{lem:three_site_anticommutator_cyclic_transport}
+\begin{theorem}[Three-site anticommutator transport to cyclic adjacent pairs]
+    \label{thm:three_site_anticommutator_cyclic_transport}
     \lean{MPSTensor.re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite}
     \lean{MPSTensor.re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite}
     \leanok
-    \uses{rem:euclidean_local_projector_ingredients}
-    Let $h_0,h_1$ be the two adjacent range-two local terms on three sites.
-    Suppose that, for every three-site vector $w$,
+    \uses{rem:euclidean_local_projector_ingredients,
+        rem:cyclic_window_operators, thm:three_site_commutator_chain_transport}
+    Assume that the physical dimension satisfies $d>0$, and fix a coefficient
+    $c\in\mathbb R$. Let $h_0,h_1$ be the two adjacent range-two local terms on
+    three sites. Suppose that, for every three-site vector $w$,
     \begin{align}
-      -c\bigl(\re\langle h_0w,w\rangle+\re\langle h_1w,w\rangle\bigr)
-      \leq
+      -c(\re\langle h_0w,w\rangle+\re\langle h_1w,w\rangle)
+      &\leq
       \re\langle h_0w,h_1w\rangle+\re\langle h_1w,h_0w\rangle.
-      \notag
+      \label{eq:three_site_anticommutator_transport_hypothesis}
     \end{align}
-    Then for every $N\geq3$, every site $i\in\Fin{N}$, and every $N$-site
-    vector $v$, the same inequality with the same coefficient $c$ holds for
-    both adjacent cyclic pairs $(h_i,h_{i+1})$ and $(h_i,h_{i-1})$.  All site
-    indices are taken modulo $N$, so this includes pairs and three-site windows
-    crossing the periodic cut.
-\end{lemma}
+    Then, for every $N\geq3$, every site $i\in\Fin{N}$, and every $N$-site
+    vector $v$, the forward pair satisfies
+    \begin{align}
+      -c\bigl(\re\langle h_iv,v\rangle
+          +\re\langle h_{i+1}v,v\rangle\bigr)
+      &\leq \re\langle h_iv,h_{i+1}v\rangle
+          +\re\langle h_{i+1}v,h_iv\rangle,
+      \label{eq:three_site_anticommutator_transport_forward}
+    \end{align}
+    and the backward pair satisfies
+    \begin{align}
+      -c\bigl(\re\langle h_iv,v\rangle
+          +\re\langle h_{i-1}v,v\rangle\bigr)
+      &\leq \re\langle h_iv,h_{i-1}v\rangle
+          +\re\langle h_{i-1}v,h_iv\rangle.
+      \label{eq:three_site_anticommutator_transport_backward}
+    \end{align}
+    All site indices are taken modulo $N$, so these conclusions include pairs
+    and three-site windows crossing the periodic cut.
+\end{theorem}
 
 \begin{proof}
     \leanok
-    Split the configuration basis into the cyclic three-site window beginning
-    at $i$ and its ordered complement.  The global quadratic form is the sum,
-    over complementary configurations, of the corresponding three-site
-    quadratic forms.  Cyclic restriction intertwines the two global local terms
-    with the terms at sites $0$ and $1$ on the three-site chain, so the assumed
-    estimate applies in each summand and summation leaves $c$ unchanged.  For
-    the backward pair, begin the forward window at $i-1$; moving one step
-    forward from that site returns $i$, including when $i=0$.
+    \uses{rem:cyclic_window_operators,
+        thm:three_site_commutator_chain_transport}
+    For a cyclic three-site window beginning at $i$, write
+    $\mathcal C_{N-3}$ for its ordered complementary configurations and
+    $R_{i,\tau}^{(3)}$ for restriction with complement $\tau$ fixed. The cyclic
+    window operators of Remark~\ref{rem:cyclic_window_operators} give the fiber
+    decomposition
+    \begin{align}
+      \re\langle u,v\rangle
+      &=\sum_{\tau\in\mathcal C_{N-3}}
+        \re\left\langle R_{i,\tau}^{(3)}u,
+          R_{i,\tau}^{(3)}v\right\rangle.
+      \label{eq:three_site_anticommutator_fiber_decomposition}
+    \end{align}
+    The restriction identities in
+    Theorem~\ref{thm:three_site_commutator_chain_transport} intertwine the two
+    adjacent terms:
+    \begin{align}
+      R_{i,\tau}^{(3)}h_i
+      &=h_0R_{i,\tau}^{(3)},
+      &
+      R_{i,\tau}^{(3)}h_{i+1}
+      &=h_1R_{i,\tau}^{(3)}.
+      \label{eq:three_site_anticommutator_restriction_intertwining}
+    \end{align}
+    Applying
+    \eqref{eq:three_site_anticommutator_transport_hypothesis} to
+    $w_\tau=R_{i,\tau}^{(3)}v$ and summing over the complement gives
+    \begin{align}
+      \sum_{\tau\in\mathcal C_{N-3}}
+        -c\bigl(\re\langle h_0w_\tau,w_\tau\rangle
+          +\re\langle h_1w_\tau,w_\tau\rangle\bigr)
+      &\leq
+      \sum_{\tau\in\mathcal C_{N-3}}
+        \bigl(\re\langle h_0w_\tau,h_1w_\tau\rangle
+          +\re\langle h_1w_\tau,h_0w_\tau\rangle\bigr),
+      \label{eq:three_site_anticommutator_fiber_sum}
+    \end{align}
+    which becomes
+    \eqref{eq:three_site_anticommutator_transport_forward} by the preceding two
+    identities; in particular, summation leaves $c$ unchanged. For the backward
+    pair, begin the forward window at $i-1$. Moving one step forward from that
+    site returns $i$, including when $i=0$, and yields
+    \eqref{eq:three_site_anticommutator_transport_backward}.
 \end{proof}
 
 \begin{lemma}[Quadratic-form estimate from the martingale condition]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
@@ -1,34 +1,60 @@
+\begin{lemma}[Cyclic window and complement factorization]
+    \label{lem:cyclic_window_complement_factorization}
+    \lean{MPSTensor.cyclicWindowIndexEquiv}
+    \lean{MPSTensor.cyclicWindowIndexEquiv_inl}
+    \lean{MPSTensor.cyclicWindowIndexEquiv_inr}
+    \lean{MPSTensor.prod_cyclicWindow_complement}
+    \leanok
+    If $L\leq N$ and $i\in\Fin{N}$, the sites of the periodic chain are in
+    bijection with the disjoint union of the cyclic window
+    $i,i+1,\ldots,i+L-1$ and its ordered complement
+    $i+L,i+L+1,\ldots,i+N-1$, with all indices taken modulo $N$.
+    Consequently, every product over the chain factors as the product over the
+    cyclic window times the product over its ordered complement.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Rotate the chain so that $i$ is the initial site, then split the resulting
+    ordered set after its first $L$ elements. Reindexing a finite product by
+    this bijection gives the factorization.
+\end{proof}
+
 \begin{theorem}[Three-site anticommutator transport to cyclic adjacent pairs]
     \label{thm:three_site_anticommutator_cyclic_transport}
     \lean{MPSTensor.re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite}
     \lean{MPSTensor.re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients,
-        rem:cyclic_window_operators}
-    Assume that the physical dimension satisfies $d>0$, and fix a coefficient
-    $c\in\mathbb R$. Let $h_0,h_1$ be the two adjacent range-two local terms on
-    three sites. Suppose that, for every three-site vector $w$,
+        rem:cyclic_window_operators,
+        lem:cyclic_window_complement_factorization}
+    Fix a tensor $A$ with physical dimension $d>0$ and a coefficient
+    $c\in\mathbb R$. For every chain length $N$ and site $i\in\Fin{N}$, set
+    $h_i^{(N)}:=h_{i,\mathrm{ES}}^{(N,2)}(A)$, the Euclidean range-two parent
+    term of this same tensor $A$ at $i$. Suppose that, for
+    every three-site vector $w$,
     \begin{align}
-      -c(\re\langle h_0w,w\rangle+\re\langle h_1w,w\rangle)
+      -c(\re\langle h_0^{(3)}w,w\rangle+\re\langle h_1^{(3)}w,w\rangle)
       &\leq
-      \re\langle h_0w,h_1w\rangle+\re\langle h_1w,h_0w\rangle.
+      \re\langle h_0^{(3)}w,h_1^{(3)}w\rangle
+      +\re\langle h_1^{(3)}w,h_0^{(3)}w\rangle.
       \label{eq:three_site_anticommutator_transport_hypothesis}
     \end{align}
     Then, for every $N\geq3$, every site $i\in\Fin{N}$, and every $N$-site
     vector $v$, the forward pair satisfies
     \begin{align}
-      -c\bigl(\re\langle h_iv,v\rangle
-          +\re\langle h_{i+1}v,v\rangle\bigr)
-      &\leq \re\langle h_iv,h_{i+1}v\rangle
-          +\re\langle h_{i+1}v,h_iv\rangle,
+      -c\bigl(\re\langle h_i^{(N)}v,v\rangle
+          +\re\langle h_{i+1}^{(N)}v,v\rangle\bigr)
+      &\leq \re\langle h_i^{(N)}v,h_{i+1}^{(N)}v\rangle
+          +\re\langle h_{i+1}^{(N)}v,h_i^{(N)}v\rangle,
       \label{eq:three_site_anticommutator_transport_forward}
     \end{align}
     and the backward pair satisfies
     \begin{align}
-      -c\bigl(\re\langle h_iv,v\rangle
-          +\re\langle h_{i-1}v,v\rangle\bigr)
-      &\leq \re\langle h_iv,h_{i-1}v\rangle
-          +\re\langle h_{i-1}v,h_iv\rangle.
+      -c\bigl(\re\langle h_i^{(N)}v,v\rangle
+          +\re\langle h_{i-1}^{(N)}v,v\rangle\bigr)
+      &\leq \re\langle h_i^{(N)}v,h_{i-1}^{(N)}v\rangle
+          +\re\langle h_{i-1}^{(N)}v,h_i^{(N)}v\rangle.
       \label{eq:three_site_anticommutator_transport_backward}
     \end{align}
     All site indices are taken modulo $N$, so these conclusions include pairs
@@ -38,12 +64,15 @@
 \begin{proof}
     \leanok
     \uses{rem:cyclic_window_operators,
+        lem:cyclic_window_complement_factorization,
         thm:three_site_commutator_chain_transport}
     For a cyclic three-site window beginning at $i$, write
     $\mathcal C_{N-3}$ for its ordered complementary configurations and
-    $R_{i,\tau}^{(3)}$ for restriction with complement $\tau$ fixed. The cyclic
-    window operators of Remark~\ref{rem:cyclic_window_operators} give the fiber
-    decomposition
+    $R_{i,\tau}^{(3)}$ for restriction with complement $\tau$ fixed.
+    Lemma~\ref{lem:cyclic_window_complement_factorization} identifies every
+    chain configuration uniquely with its window and complement, while the
+    cyclic restriction operators of Remark~\ref{rem:cyclic_window_operators}
+    give the fiber decomposition
     \begin{align}
       \re\langle u,v\rangle
       &=\sum_{\tau\in\mathcal C_{N-3}}
@@ -55,11 +84,11 @@
     Theorem~\ref{thm:three_site_commutator_chain_transport} intertwine the two
     adjacent terms:
     \begin{align}
-      R_{i,\tau}^{(3)}h_i
-      &=h_0R_{i,\tau}^{(3)},
+      R_{i,\tau}^{(3)}h_i^{(N)}
+      &=h_0^{(3)}R_{i,\tau}^{(3)},
       &
-      R_{i,\tau}^{(3)}h_{i+1}
-      &=h_1R_{i,\tau}^{(3)}.
+      R_{i,\tau}^{(3)}h_{i+1}^{(N)}
+      &=h_1^{(3)}R_{i,\tau}^{(3)}.
       \label{eq:three_site_anticommutator_restriction_intertwining}
     \end{align}
     Applying
@@ -67,12 +96,12 @@
     $w_\tau=R_{i,\tau}^{(3)}v$ and summing over the complement gives
     \begin{align}
       \sum_{\tau\in\mathcal C_{N-3}}
-        -c\bigl(\re\langle h_0w_\tau,w_\tau\rangle
-          +\re\langle h_1w_\tau,w_\tau\rangle\bigr)
+        -c\bigl(\re\langle h_0^{(3)}w_\tau,w_\tau\rangle
+          +\re\langle h_1^{(3)}w_\tau,w_\tau\rangle\bigr)
       &\leq
       \sum_{\tau\in\mathcal C_{N-3}}
-        \bigl(\re\langle h_0w_\tau,h_1w_\tau\rangle
-          +\re\langle h_1w_\tau,h_0w_\tau\rangle\bigr),
+        \bigl(\re\langle h_0^{(3)}w_\tau,h_1^{(3)}w_\tau\rangle
+          +\re\langle h_1^{(3)}w_\tau,h_0^{(3)}w_\tau\rangle\bigr),
       \label{eq:three_site_anticommutator_fiber_sum}
     \end{align}
     By the fiber decomposition

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex
@@ -1,23 +1,32 @@
-\begin{lemma}[Cyclic window and complement factorization]
-    \label{lem:cyclic_window_complement_factorization}
+\begin{definition}[Cyclic window and complement indexing]
+    \label{def:cyclic_window_complement_indexing}
     \lean{MPSTensor.cyclicWindowIndexEquiv}
     \lean{MPSTensor.cyclicWindowIndexEquiv_inl}
     \lean{MPSTensor.cyclicWindowIndexEquiv_inr}
-    \lean{MPSTensor.prod_cyclicWindow_complement}
     \leanok
-    If $L\leq N$ and $i\in\Fin{N}$, the sites of the periodic chain are in
-    bijection with the disjoint union of the cyclic window
+    If $L\leq N$ and $i\in\Fin{N}$, identify the sites of the periodic chain
+    with the disjoint union of the cyclic window
     $i,i+1,\ldots,i+L-1$ and its ordered complement
     $i+L,i+L+1,\ldots,i+N-1$, with all indices taken modulo $N$.
-    Consequently, every product over the chain factors as the product over the
-    cyclic window times the product over its ordered complement.
-\end{lemma}
+\end{definition}
+
+\begin{theorem}[Cyclic product factorization]
+    \label{thm:cyclic_window_complement_product_factorization}
+    \lean{MPSTensor.prod_cyclicWindow_complement}
+    \leanok
+    \uses{def:cyclic_window_complement_indexing}
+    Let $M$ be a commutative monoid. If $L\leq N$, $i\in\Fin{N}$, and
+    $f\colon\Fin{N}\to M$, then the product of $f$ over the chain equals the
+    product over the cyclic window beginning at $i$ times the product over its
+    ordered complement.
+\end{theorem}
 
 \begin{proof}
     \leanok
-    Rotate the chain so that $i$ is the initial site, then split the resulting
-    ordered set after its first $L$ elements. Reindexing a finite product by
-    this bijection gives the factorization.
+    \uses{def:cyclic_window_complement_indexing}
+    Reindex the product by the cyclic window and complement identification of
+    Definition~\ref{def:cyclic_window_complement_indexing}, then split the
+    product over the resulting disjoint union.
 \end{proof}
 
 \begin{theorem}[Three-site anticommutator transport to cyclic adjacent pairs]
@@ -26,8 +35,7 @@
     \lean{MPSTensor.re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients,
-        rem:cyclic_window_operators,
-        lem:cyclic_window_complement_factorization}
+        rem:cyclic_window_operators}
     Fix a tensor $A$ with physical dimension $d>0$ and a coefficient
     $c\in\mathbb R$. For every chain length $N$ and site $i\in\Fin{N}$, set
     $h_i^{(N)}:=h_{i,\mathrm{ES}}^{(N,2)}(A)$, the Euclidean range-two parent
@@ -64,12 +72,12 @@
 \begin{proof}
     \leanok
     \uses{rem:cyclic_window_operators,
-        lem:cyclic_window_complement_factorization,
+        def:cyclic_window_complement_indexing,
         thm:three_site_commutator_chain_transport}
     For a cyclic three-site window beginning at $i$, write
     $\mathcal C_{N-3}$ for its ordered complementary configurations and
     $R_{i,\tau}^{(3)}$ for restriction with complement $\tau$ fixed.
-    Lemma~\ref{lem:cyclic_window_complement_factorization} identifies every
+    Definition~\ref{def:cyclic_window_complement_indexing} identifies every
     chain configuration uniquely with its window and complement, while the
     cyclic restriction operators of Remark~\ref{rem:cyclic_window_operators}
     give the fiber decomposition

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -164,6 +164,31 @@ every left length.  The remaining task is the separate blocked-to-cyclic
 comparison, including windows
 crossing the periodic cut.  No excitation-compression estimate is used.
 
+\subsection{Three-site to cyclic transport}
+
+The independent locality step is now complete for range-two terms.  If the two
+adjacent terms $h_0,h_1$ on the three-site Hilbert space satisfy
+\[
+  h_0h_1+h_1h_0\geq-c(h_0+h_1)
+\]
+in quadratic form, then
+\leanid{MPSTensor.re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite}
+and
+\leanid{MPSTensor.re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite}
+transport the same inequality, with the same coefficient $c$, to every forward
+and backward adjacent cyclic pair on every chain of length $N\geq3$.  The proof
+splits the configuration basis into a cyclic three-site window and its ordered
+complement, applies the three-site estimate fiberwise through cyclic
+restriction, and sums over the complement.  Since the window may begin at any
+site, the result includes positions crossing the periodic cut; the backward
+statement begins the forward window at the cyclic predecessor.
+
+This theorem is only transport infrastructure.  It does not supply the
+three-site numerical estimate, does not claim the optimized FNW coefficient,
+and does not use an excitation-compression surrogate.  In particular, the
+open-chain C3 estimate still has to be identified with the two concrete
+three-site range-two local terms before it can feed this transport theorem.
+
 \section{Finite-row martingale reduction}
 
 The current development separates the finite-row martingale algebra from the


### PR DESCRIPTION
## Summary

- transport the source anticommutator quadratic-form inequality from the two adjacent range-two terms on three sites to every forward cyclic adjacent pair
- derive the backward-pair statement, including the periodic-cut pair, by starting at the cyclic predecessor
- preserve the coefficient exactly by decomposing the configuration basis into the cyclic three-site window and its ordered complement
- add exact blueprint and paper-gap coverage while leaving the numerical three-site estimate as a separate input

## Scope

This PR proves transport infrastructure only. It does **not** assume or prove the still-separate numerical estimate, does not identify an optimized FNW coefficient, and does not introduce an excitation-compression surrogate.

## Checks

- `lake env lean TNLean/MPS/ParentHamiltonian/LocalSupportTransport.lean`
- `python3 scripts/check_reader_facing_prose.py --base origin/main`
- `python3 scripts/blueprint_lean_sync.py --ci --diff-base origin/main --diff-head HEAD`
- `git diff --check origin/main...HEAD`

Closes #6155.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation; existing commutator transport is unchanged and no numerical spectral-gap inputs are asserted.
> 
> **Overview**
> Extends **cyclic transport** in `LocalSupportTransport.lean` beyond the existing commutator machinery: a three-site hypothesis on the two adjacent range-two Euclidean local terms is carried to **every forward and backward adjacent pair** on a periodic chain of length \(N\ge 3\), including pairs across the periodic cut.
> 
> The new argument introduces **`cyclicWindowCfgEquiv`** and related lemmas to split the configuration basis into a cyclic three-site window plus ordered complement, decompose real inner products via cyclic restriction, and intertwine `localTermES` on fibers before summing. The **backward** statement is derived from the forward one by starting the window at the cyclic predecessor (`cyclicForwardSite_backwardSite_one`).
> 
> **Blueprint** (`ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex`) gains cyclic window/complement indexing, product factorization, and the anticommutator transport theorem wired to the new Lean names. **`docs/paper-gaps/cpgsv21_martingale_overlap.tex`** documents that this is transport-only infrastructure and does not supply the numerical three-site estimate or FNW coefficient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d9df93ce6efaae836c507da52c0b6032b1ee9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->