### PR TITLE
feat(Channel): no information without disturbance for completely positive instruments

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -53,6 +53,7 @@ import TNLean.Channel.MaximallyEntangled
 import TNLean.Channel.MaximallyMixed
 import TNLean.Channel.NPositivityChainStrict
 import TNLean.Channel.NPositivitySpectralCriterion
+import TNLean.Channel.NoInformationWithoutDisturbance
 import TNLean.Channel.NormalForm
 import TNLean.Channel.OpenSystem
 import TNLean.Channel.OperatorSystem

--- a/TNLean/Channel/NoInformationWithoutDisturbance.lean
+++ b/TNLean/Channel/NoInformationWithoutDisturbance.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixAux
+import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.POVM
+
+/-!
+# No information without disturbance
+
+This file formalizes the proposition *No information without disturbance* of
+[M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2][Wolf2012QChannels],
+`Notes/WolfNoteTexSource/ch02_representations.tex`, line 154.
+
+An instrument is a family of completely positive maps `{T α : M_d → M_d}`. If the
+instrument causes no disturbance on average, that is if `∑ α, T α = id`, then every
+component is a nonnegative multiple `T α = c α · id` of the identity, and hence the
+probability `tr[T α ρ]` of the outcome `α` equals `c α` for every state `ρ`: the outcome
+statistics carry no information about the input.
+
+The proof is Wolf's. Under the Choi–Jamiolkowski correspondence the hypothesis reads
+`|Ω⟩⟨Ω| = ∑ α, τ α`, where `τ α` is the Choi matrix of `T α`. Complete positivity makes
+each `τ α` positive semidefinite, so the identity above is a decomposition of the pure
+state `|Ω⟩⟨Ω|` into positive parts; each part is dominated by `|Ω⟩⟨Ω|` and a matrix
+dominated by a rank-one positive matrix is a nonnegative multiple of it. Injectivity of
+the Choi correspondence transports the conclusion back to the maps.
+
+## Main results
+
+* `Channel.exists_nonneg_smul_id_of_isCPMap_of_sum_eq_id` — each component of a
+  no-disturbance instrument is a nonnegative multiple of the identity.
+* `Channel.exists_nonneg_weights_of_isCPMap_of_sum_eq_id` — the multipliers are
+  nonnegative and sum to one.
+* `Channel.exists_nonneg_forall_trace_map_eq_of_isCPMap_of_sum_eq_id` — the outcome
+  probability `tr[T α ρ]` is a constant independent of the state `ρ`.
+* `Instrument.exists_nonneg_forall_probability_eq_of_total_eq_id` — the same conclusion
+  for the instrument structure of `TNLean.Channel.POVM`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2, proposition
+  "No information without disturbance"][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix Finset
+
+namespace Channel
+
+variable {D : ℕ} {ι : Type*} [Fintype ι]
+
+/-! ### Rigidity of the maximally entangled projector -/
+
+/-- A positive semidefinite bipartite matrix dominated by the maximally entangled
+projector `|Ω⟩⟨Ω|` is a nonnegative multiple of that projector.
+
+This is the rank-one rigidity step of Wolf's argument, obtained from
+`Matrix.PosSemidef.eq_nonneg_smul_vecMulVec_of_le_smul_vecMulVec` by relabelling the
+bipartite index set `Fin D × Fin D` as `Fin (D * D)`. -/
+theorem exists_nonneg_smul_omegaProj_of_le_omegaProj
+    {A : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hA : A.PosSemidef)
+    (hle : A ≤ Matrix.omegaProj D) :
+    ∃ a : ℂ, 0 ≤ a ∧ A = a • Matrix.omegaProj D := by
+  classical
+  let e : Fin D × Fin D ≃ Fin (D * D) := finProdFinEquiv
+  let ψ : Fin (D * D) → ℂ := Matrix.omegaVec D ∘ e.symm
+  have hvec : (Matrix.omegaProj D).submatrix e.symm e.symm = Matrix.vecMulVec ψ (star ψ) := by
+    ext i j
+    simp [Matrix.omegaProj, Matrix.vecMulVec_apply, ψ]
+  have hAsub : (A.submatrix e.symm e.symm).PosSemidef := hA.submatrix _
+  have hsub : (Matrix.omegaProj D - A).submatrix e.symm e.symm =
+      (Matrix.omegaProj D).submatrix e.symm e.symm - A.submatrix e.symm e.symm := rfl
+  have hdom : A.submatrix e.symm e.symm ≤ (1 : ℂ) • Matrix.vecMulVec ψ (star ψ) := by
+    rw [Matrix.le_iff, one_smul, ← hvec, ← hsub]
+    exact (Matrix.le_iff.mp hle).submatrix _
+  obtain ⟨a, ha, haeq⟩ :=
+    Matrix.PosSemidef.eq_nonneg_smul_vecMulVec_of_le_smul_vecMulVec hAsub ψ hdom
+  rw [← hvec] at haeq
+  refine ⟨a, ha, ?_⟩
+  ext i j
+  simpa using congrArg (fun M => M (e i) (e j)) haeq
+
+/-! ### No information without disturbance -/
+
+/-- **No information without disturbance** (Wolf, Chapter 2, line 154), component form.
+
+If a family of completely positive maps `T α : M_d → M_d` sums to the identity, then
+every component is a nonnegative multiple of the identity. -/
+theorem exists_nonneg_smul_id_of_isCPMap_of_sum_eq_id [NeZero D]
+    {T : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hCP : ∀ α, IsCPMap (T α)) (hsum : ∑ α, T α = LinearMap.id) (α : ι) :
+    ∃ c : ℝ, 0 ≤ c ∧ T α = (c : ℂ) • LinearMap.id := by
+  classical
+  have hpsd : ∀ β, (ChoiJamiolkowski.choiMatrix (T β)).PosSemidef := fun β =>
+    (ChoiJamiolkowski.cp_iff_choi_posSemidef (T β)).mp (hCP β)
+  have hchoisum : ∑ β, ChoiJamiolkowski.choiMatrix (T β) = Matrix.omegaProj D := by
+    have hmap : ChoiJamiolkowski.choiMatrix (∑ β, T β) =
+        ∑ β, ChoiJamiolkowski.choiMatrix (T β) :=
+      map_sum (ChoiJamiolkowski.choiMatrixLinearMap (D := D)) T Finset.univ
+    rw [← hmap, hsum, ChoiJamiolkowski.choiMatrix_id]
+  have hle : ChoiJamiolkowski.choiMatrix (T α) ≤ Matrix.omegaProj D := by
+    rw [← hchoisum]
+    exact Finset.single_le_sum (fun β _ => (hpsd β).nonneg) (Finset.mem_univ α)
+  obtain ⟨a, ha, haeq⟩ := exists_nonneg_smul_omegaProj_of_le_omegaProj (hpsd α) hle
+  obtain ⟨hre, him⟩ := Complex.le_def.mp ha
+  have hareal : (a.re : ℂ) = a := Complex.ext (by simp) (by simpa using him)
+  refine ⟨a.re, by simpa using hre, ChoiJamiolkowski.choiMatrix_injective ?_⟩
+  rw [ChoiJamiolkowski.choiMatrix_smul, ChoiJamiolkowski.choiMatrix_id, hareal, haeq]
+
+/-- **No information without disturbance** (Wolf, Chapter 2, line 154), with the
+normalization of the multipliers.
+
+The multipliers `c α` of a no-disturbance instrument are nonnegative and sum to one. -/
+theorem exists_nonneg_weights_of_isCPMap_of_sum_eq_id [NeZero D]
+    {T : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hCP : ∀ α, IsCPMap (T α)) (hsum : ∑ α, T α = LinearMap.id) :
+    ∃ c : ι → ℝ, (∀ α, 0 ≤ c α) ∧ (∀ α, T α = (c α : ℂ) • LinearMap.id) ∧ ∑ α, c α = 1 := by
+  classical
+  choose c hc0 hcid using exists_nonneg_smul_id_of_isCPMap_of_sum_eq_id hCP hsum
+  have hDne : ((D : ℂ)) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne D)
+  refine ⟨c, hc0, hcid, ?_⟩
+  have happ : ∑ α, T α (1 : Matrix (Fin D) (Fin D) ℂ) = (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    simpa using congrArg (fun L => L (1 : Matrix (Fin D) (Fin D) ℂ)) hsum
+  have htrace : (∑ α, (c α : ℂ)) * (D : ℂ) = (D : ℂ) := by
+    have := congrArg Matrix.trace happ
+    simpa [hcid, Matrix.trace_sum, Matrix.trace_smul, Finset.sum_mul] using this
+  have hone : (∑ α, (c α : ℂ)) = 1 := by
+    field_simp at htrace
+    exact htrace
+  exact_mod_cast hone
+
+/-- **No information without disturbance** (Wolf, Chapter 2, line 154), probability form.
+
+For a no-disturbance instrument the probability `tr[T α ρ]` of the outcome `α` is a
+nonnegative constant, the same for every normalized state `ρ`: the outcome carries no
+information about the input. -/
+theorem exists_nonneg_forall_trace_map_eq_of_isCPMap_of_sum_eq_id [NeZero D]
+    {T : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hCP : ∀ α, IsCPMap (T α)) (hsum : ∑ α, T α = LinearMap.id) (α : ι) :
+    ∃ c : ℝ, 0 ≤ c ∧
+      ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.trace = 1 → (T α ρ).trace = (c : ℂ) := by
+  obtain ⟨c, hc0, hcid⟩ := exists_nonneg_smul_id_of_isCPMap_of_sum_eq_id hCP hsum α
+  refine ⟨c, hc0, fun ρ hρ => ?_⟩
+  rw [hcid]
+  simp [Matrix.trace_smul, hρ]
+
+end Channel
+
+/-- **No information without disturbance** for an instrument (Wolf, Chapter 2, line 154).
+
+If the average map of an instrument is the identity, then each outcome probability is a
+nonnegative constant, the same for every normalized state: the measurement returns no
+information about the input. -/
+theorem Instrument.exists_nonneg_forall_probability_eq_of_total_eq_id
+    {D n : ℕ} [NeZero D] (I : Instrument D n) (hI : I.total = LinearMap.id) (i : Fin n) :
+    ∃ c : ℝ, 0 ≤ c ∧
+      ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.trace = 1 → I.probability i ρ = (c : ℂ) :=
+  Channel.exists_nonneg_forall_trace_map_eq_of_isCPMap_of_sum_eq_id I.cp hI i

--- a/TNLean/Channel/NoInformationWithoutDisturbance.lean
+++ b/TNLean/Channel/NoInformationWithoutDisturbance.lean
@@ -36,7 +36,7 @@ the Choi correspondence transports the conclusion back to the maps.
 * `Channel.exists_nonneg_weights_of_isCPMap_of_sum_eq_id` — the multipliers are
   nonnegative and sum to one.
 * `Channel.exists_nonneg_forall_trace_map_eq_of_isCPMap_of_sum_eq_id` — the outcome
-  probability `tr[T α ρ]` is a constant independent of the state `ρ`.
+  probability `tr[T α ρ]` is a constant, the same for every `ρ` of unit trace.
 * `Instrument.exists_nonneg_forall_probability_eq_of_total_eq_id` — the same conclusion
   for the instrument structure of `TNLean.Channel.POVM`.
 

--- a/TNLean/Channel/NoInformationWithoutDisturbance.lean
+++ b/TNLean/Channel/NoInformationWithoutDisturbance.lean
@@ -17,8 +17,8 @@ This file formalizes the proposition *No information without disturbance* of
 An instrument is a family of completely positive maps `{T α : M_d → M_d}`. If the
 instrument causes no disturbance on average, that is if `∑ α, T α = id`, then every
 component is a nonnegative multiple `T α = c α · id` of the identity, and hence the
-probability `tr[T α ρ]` of the outcome `α` equals `c α` for every state `ρ`: the outcome
-statistics carry no information about the input.
+probability `tr[T α ρ]` of the outcome `α` equals `c α` for every `ρ` of unit trace: the
+outcome statistics carry no information about the input.
 
 The proof is Wolf's. Under the Choi–Jamiolkowski correspondence the hypothesis reads
 `|Ω⟩⟨Ω| = ∑ α, τ α`, where `τ α` is the Choi matrix of `T α`. Complete positivity makes
@@ -126,15 +126,14 @@ theorem exists_nonneg_weights_of_isCPMap_of_sum_eq_id [NeZero D]
   have htrace : (∑ α, (c α : ℂ)) * (D : ℂ) = (D : ℂ) := by
     have := congrArg Matrix.trace happ
     simpa [hcid, Matrix.trace_sum, Matrix.trace_smul, Finset.sum_mul] using this
-  have hone : (∑ α, (c α : ℂ)) = 1 := by
-    field_simp at htrace
-    exact htrace
+  have hone : (∑ α, (c α : ℂ)) = 1 :=
+    mul_right_cancel₀ hDne (by rw [one_mul]; exact htrace)
   exact_mod_cast hone
 
 /-- **No information without disturbance** (Wolf, Chapter 2, line 154), probability form.
 
 For a no-disturbance instrument the probability `tr[T α ρ]` of the outcome `α` is a
-nonnegative constant, the same for every normalized state `ρ`: the outcome carries no
+nonnegative constant, the same for every `ρ` of unit trace: the outcome carries no
 information about the input. -/
 theorem exists_nonneg_forall_trace_map_eq_of_isCPMap_of_sum_eq_id [NeZero D]
     {T : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
@@ -151,7 +150,7 @@ end Channel
 /-- **No information without disturbance** for an instrument (Wolf, Chapter 2, line 154).
 
 If the average map of an instrument is the identity, then each outcome probability is a
-nonnegative constant, the same for every normalized state: the measurement returns no
+nonnegative constant, the same for every input of unit trace: the measurement returns no
 information about the input. -/
 theorem Instrument.exists_nonneg_forall_probability_eq_of_total_eq_id
     {D n : ℕ} [NeZero D] (I : Instrument D n) (hI : I.total = LinearMap.id) (i : Fin n) :

--- a/TNLean/Channel/NoInformationWithoutDisturbance.lean
+++ b/TNLean/Channel/NoInformationWithoutDisturbance.lean
@@ -14,11 +14,13 @@ This file formalizes the proposition *No information without disturbance* of
 [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2][Wolf2012QChannels],
 `Notes/WolfNoteTexSource/ch02_representations.tex`, line 154.
 
-An instrument is a family of completely positive maps `{T α : M_d → M_d}`. If the
-instrument causes no disturbance on average, that is if `∑ α, T α = id`, then every
-component is a nonnegative multiple `T α = c α · id` of the identity, and hence the
-probability `tr[T α ρ]` of the outcome `α` equals `c α` for every `ρ` of unit trace: the
-outcome statistics carry no information about the input.
+An instrument is a family of completely positive maps `{T α : M_d → M_d}` whose sum is
+trace preserving. If the instrument causes no disturbance on average, that is if
+`∑ α, T α = id`, then every component is a nonnegative multiple `T α = c α · id` of the
+identity, and hence the probability `tr[T α ρ]` of the outcome `α` equals `c α` for every
+`ρ` of unit trace: the outcome statistics carry no information about the input. The
+theorems below assume complete positivity of the components and `∑ α, T α = id`, which is
+Wolf's hypothesis, and nothing more.
 
 The proof is Wolf's. Under the Choi–Jamiolkowski correspondence the hypothesis reads
 `|Ω⟩⟨Ω| = ∑ α, τ α`, where `τ α` is the Choi matrix of `T α`. Complete positivity makes
@@ -45,7 +47,6 @@ the Choi correspondence transports the conclusion back to the maps.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
-open Matrix Finset
 
 namespace Channel
 

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -21,6 +21,7 @@ import TNLean.Channel.POVM.RankOneNaimark
 import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.WolfProps
+import TNLean.Channel.NoInformationWithoutDisturbance
 import TNLean.Channel.NormalForm
 import TNLean.Channel.LorentzNormalForm
 
@@ -183,6 +184,15 @@ project import.
     every `vecMulVec v (star v)` is the identity ✓
   - `WolfProps.channel_eq_id_of_fixes_pureStates` — a channel fixing
     every pure-state projector is the identity channel ✓
+  - `Channel.exists_nonneg_smul_id_of_isCPMap_of_sum_eq_id` — the
+    source-faithful statement: a finite family of CP maps with
+    `∑ α, T α = id` has `T α = c α • id` with `c α ≥ 0` ✓
+  - `Channel.exists_nonneg_weights_of_isCPMap_of_sum_eq_id` — the weights
+    satisfy `∑ α, c α = 1` ✓
+  - `Channel.exists_nonneg_forall_trace_map_eq_of_isCPMap_of_sum_eq_id` —
+    `tr[T α ρ] = c α` for every `ρ` of unit trace ✓
+  - `Instrument.exists_nonneg_forall_probability_eq_of_total_eq_id` — the
+    same conclusion for the `Instrument` structure ✓
 
 * **Proposition 2.4** (equivalence of ensembles, Hughston–Jozsa–Wootters):
   - `WolfProps.pureEnsembleDensity` — density operator of a pure-state

--- a/blueprint/src/chapter/ch04_channels_choi_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_choi_foundations.tex
@@ -127,6 +127,24 @@ matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space:
     Apply the identity map in the definition of the Choi matrix.
 \end{proof}
 
+\begin{lemma}[The Choi correspondence is one-to-one]\label{lem:choi_matrix_injective}
+    \lean{ChoiJamiolkowski.choiMatrix_injective,
+        ChoiJamiolkowski.eq_of_choiMatrix_eq}
+    \leanok
+    \uses{def:choi_matrix}
+    Let $D\geq1$. Two linear maps $T,S:\MN{D}\to\MN{D}$ with the same Choi
+    matrix are equal.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:choi_matrix}
+    The $(i_2,j_2)$ slice of $\ketbra{\Omega}{\Omega}$ is $D^{-1}E_{i_2j_2}$,
+    so equality of the Choi matrices gives
+    $D^{-1}T(E_{ij})=D^{-1}S(E_{ij})$ entrywise for every matrix unit
+    $E_{ij}$. Cancel the nonzero factor $D^{-1}$ and extend from the matrix
+    units to all of $\MN{D}$ by linearity.
+\end{proof}
+
 \begin{theorem}[Choi matrix of transposition]\label{thm:choi_transpose_flip}
     \lean{ChoiJamiolkowski.choiMatrix_transposeLinearMapComplex_eq_swap}
     \leanok

--- a/blueprint/src/chapter/ch12_auxiliary_channel_no_information_without_disturbance.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_channel_no_information_without_disturbance.tex
@@ -15,7 +15,7 @@ $\rho$. This is the proposition ``No information without disturbance'' of
     \label{lem:le_omega_proj_eq_nonneg_smul}
     \lean{Channel.exists_nonneg_smul_omegaProj_of_le_omegaProj}
     \leanok
-    \uses{def:maximally_entangled, lem:posSemidef_rankone_domination}
+    \uses{def:maximally_entangled}
     Let $A$ on $\C^d\otimes\C^d$ be positive semidefinite with
     $A\leq\ketbra{\Omega}{\Omega}$. Then $A=a\ketbra{\Omega}{\Omega}$ for a
     non-negative scalar $a$.
@@ -27,38 +27,30 @@ $\rho$. This is the proposition ``No information without disturbance'' of
     The projector $\ketbra{\Omega}{\Omega}$ is the rank-one matrix built
     from the vector $\ket{\Omega}$, so this is
     Lemma~\ref{lem:posSemidef_rankone_domination} with $c=1$ and
-    $\psi=\Omega$, read after relabelling the index set
-    $\{0,\ldots,d-1\}^2$ of the bipartite space by
-    $\{0,\ldots,d^2-1\}$.
+    $\psi=\Omega$, read after transporting along a bijection between the
+    pair index set of the bipartite space $\C^d\otimes\C^d$ and a single
+    index set of the same cardinality $d^2$.
 \end{proof}
 
 \begin{theorem}[No information without disturbance]
     \label{thm:no_information_without_disturbance}
     \lean{Channel.exists_nonneg_smul_id_of_isCPMap_of_sum_eq_id}
     \leanok
-    \uses{def:cp_map, def:choi_matrix, def:maximally_entangled,
-        thm:cp_iff_choi_posSemidef, thm:choi_matrix_id,
-        lem:le_omega_proj_eq_nonneg_smul}
+    \uses{def:cp_map}
     Let $d\geq1$ and let $\{T_\alpha:\MN{d}\to\MN{d}\}$ be a finite family of
     completely positive maps with $\sum_\alpha T_\alpha=\id$. Then for every
     $\alpha$ there is a constant $c_\alpha\geq0$ with
-    \begin{align}
-        T_\alpha&=c_\alpha\id.
-        \notag
-    \end{align}
+    $T_\alpha=c_\alpha\id$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:cp_iff_choi_posSemidef, thm:choi_matrix_id,
-        lem:le_omega_proj_eq_nonneg_smul}
+    \uses{def:choi_matrix, def:maximally_entangled,
+        thm:cp_iff_choi_posSemidef, thm:choi_matrix_id,
+        lem:choi_matrix_injective, lem:le_omega_proj_eq_nonneg_smul}
     Pass to Choi matrices. The Choi matrix of $\id$ is
     $\ketbra{\Omega}{\Omega}$ and the Choi correspondence is linear, so the
-    hypothesis reads
-    \begin{align}
-        \ketbra{\Omega}{\Omega}&=\sum_\alpha\tau_\alpha,
-        \notag
-    \end{align}
+    hypothesis reads $\ketbra{\Omega}{\Omega}=\sum_\alpha\tau_\alpha$,
     where $\tau_\alpha$ is the Choi matrix of $T_\alpha$. Each $\tau_\alpha$
     is positive semidefinite because $T_\alpha$ is completely positive, so
     every summand is dominated by the whole sum:
@@ -66,8 +58,8 @@ $\rho$. This is the proposition ``No information without disturbance'' of
     is pure, hence admits no non-trivial decomposition, and
     Lemma~\ref{lem:le_omega_proj_eq_nonneg_smul} gives
     $\tau_\alpha=c_\alpha\ketbra{\Omega}{\Omega}$ with $c_\alpha\geq0$. The
-    right-hand side is the Choi matrix of $c_\alpha\id$, and the Choi
-    correspondence is one-to-one, so $T_\alpha=c_\alpha\id$.
+    right-hand side is the Choi matrix of $c_\alpha\id$, so
+    Lemma~\ref{lem:choi_matrix_injective} gives $T_\alpha=c_\alpha\id$.
 \end{proof}
 
 \begin{theorem}[Normalization of the outcome weights]
@@ -112,8 +104,7 @@ $\rho$. This is the proposition ``No information without disturbance'' of
     \label{cor:no_information_instrument}
     \lean{Instrument.exists_nonneg_forall_probability_eq_of_total_eq_id}
     \leanok
-    \uses{def:instrument, def:instrument_operations,
-        thm:no_information_probability}
+    \uses{def:instrument, def:instrument_operations}
     Let $\{\Phi_i\}$ be a quantum instrument on $\MN{d}$ with $d\geq1$ whose
     total channel is the identity. Then for every outcome $i$ the probability
     $p_i(\rho)$ is a non-negative constant, the same for every $\rho$ of unit

--- a/blueprint/src/chapter/ch12_auxiliary_channel_no_information_without_disturbance.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_channel_no_information_without_disturbance.tex
@@ -2,10 +2,11 @@
 \label{sec:no_information_without_disturbance}
 %% =========================================================
 
-An \emph{instrument} on $\MN{d}$ is a finite family
-$\{T_\alpha:\MN{d}\to\MN{d}\}$ of completely positive maps, the outcome
-$\alpha$ occurring with probability $\tr[T_\alpha(\rho)]$ on the input
-$\rho$. The instrument leaves the input undisturbed on average when
+An \emph{instrument} on $\MN{d}$ (Definition~\ref{def:instrument}) is a finite
+family $\{T_\alpha:\MN{d}\to\MN{d}\}$ of completely positive maps whose sum is
+trace-preserving; the outcome $\alpha$ occurs with probability
+$\tr[T_\alpha(\rho)]$ on the input $\rho$. The instrument leaves the input
+undisturbed on average when
 $\sum_\alpha T_\alpha=\id$. In that case the outcome distribution is the
 same for every input, so the measurement returns no information about
 $\rho$. This is the proposition ``No information without disturbance'' of
@@ -54,8 +55,7 @@ $\rho$. This is the proposition ``No information without disturbance'' of
     where $\tau_\alpha$ is the Choi matrix of $T_\alpha$. Each $\tau_\alpha$
     is positive semidefinite because $T_\alpha$ is completely positive, so
     every summand is dominated by the whole sum:
-    $\tau_\alpha\leq\ketbra{\Omega}{\Omega}$. The maximally entangled state
-    is pure, hence admits no non-trivial decomposition, and
+    $\tau_\alpha\leq\ketbra{\Omega}{\Omega}$. Then
     Lemma~\ref{lem:le_omega_proj_eq_nonneg_smul} gives
     $\tau_\alpha=c_\alpha\ketbra{\Omega}{\Omega}$ with $c_\alpha\geq0$. The
     right-hand side is the Choi matrix of $c_\alpha\id$, so

--- a/blueprint/src/chapter/ch12_auxiliary_channel_no_information_without_disturbance.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_channel_no_information_without_disturbance.tex
@@ -1,0 +1,129 @@
+\section{No information without disturbance}
+\label{sec:no_information_without_disturbance}
+%% =========================================================
+
+An \emph{instrument} on $\MN{d}$ is a finite family
+$\{T_\alpha:\MN{d}\to\MN{d}\}$ of completely positive maps, the outcome
+$\alpha$ occurring with probability $\tr[T_\alpha(\rho)]$ on the input
+$\rho$. The instrument leaves the input undisturbed on average when
+$\sum_\alpha T_\alpha=\id$. In that case the outcome distribution is the
+same for every input, so the measurement returns no information about
+$\rho$. This is the proposition ``No information without disturbance'' of
+\cite[Chapter~2]{Wolf2012Quantum}.
+
+\begin{lemma}[Domination by the maximally entangled projector]
+    \label{lem:le_omega_proj_eq_nonneg_smul}
+    \lean{Channel.exists_nonneg_smul_omegaProj_of_le_omegaProj}
+    \leanok
+    \uses{def:maximally_entangled, lem:posSemidef_rankone_domination}
+    Let $A$ on $\C^d\otimes\C^d$ be positive semidefinite with
+    $A\leq\ketbra{\Omega}{\Omega}$. Then $A=a\ketbra{\Omega}{\Omega}$ for a
+    non-negative scalar $a$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:posSemidef_rankone_domination}
+    The projector $\ketbra{\Omega}{\Omega}$ is the rank-one matrix built
+    from the vector $\ket{\Omega}$, so this is
+    Lemma~\ref{lem:posSemidef_rankone_domination} with $c=1$ and
+    $\psi=\Omega$, read after relabelling the index set
+    $\{0,\ldots,d-1\}^2$ of the bipartite space by
+    $\{0,\ldots,d^2-1\}$.
+\end{proof}
+
+\begin{theorem}[No information without disturbance]
+    \label{thm:no_information_without_disturbance}
+    \lean{Channel.exists_nonneg_smul_id_of_isCPMap_of_sum_eq_id}
+    \leanok
+    \uses{def:cp_map, def:choi_matrix, def:maximally_entangled,
+        thm:cp_iff_choi_posSemidef, thm:choi_matrix_id,
+        lem:le_omega_proj_eq_nonneg_smul}
+    Let $d\geq1$ and let $\{T_\alpha:\MN{d}\to\MN{d}\}$ be a finite family of
+    completely positive maps with $\sum_\alpha T_\alpha=\id$. Then for every
+    $\alpha$ there is a constant $c_\alpha\geq0$ with
+    \begin{align}
+        T_\alpha&=c_\alpha\id.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cp_iff_choi_posSemidef, thm:choi_matrix_id,
+        lem:le_omega_proj_eq_nonneg_smul}
+    Pass to Choi matrices. The Choi matrix of $\id$ is
+    $\ketbra{\Omega}{\Omega}$ and the Choi correspondence is linear, so the
+    hypothesis reads
+    \begin{align}
+        \ketbra{\Omega}{\Omega}&=\sum_\alpha\tau_\alpha,
+        \notag
+    \end{align}
+    where $\tau_\alpha$ is the Choi matrix of $T_\alpha$. Each $\tau_\alpha$
+    is positive semidefinite because $T_\alpha$ is completely positive, so
+    every summand is dominated by the whole sum:
+    $\tau_\alpha\leq\ketbra{\Omega}{\Omega}$. The maximally entangled state
+    is pure, hence admits no non-trivial decomposition, and
+    Lemma~\ref{lem:le_omega_proj_eq_nonneg_smul} gives
+    $\tau_\alpha=c_\alpha\ketbra{\Omega}{\Omega}$ with $c_\alpha\geq0$. The
+    right-hand side is the Choi matrix of $c_\alpha\id$, and the Choi
+    correspondence is one-to-one, so $T_\alpha=c_\alpha\id$.
+\end{proof}
+
+\begin{theorem}[Normalization of the outcome weights]
+    \label{thm:no_information_weights_sum_one}
+    \lean{Channel.exists_nonneg_weights_of_isCPMap_of_sum_eq_id}
+    \leanok
+    \uses{thm:no_information_without_disturbance}
+    Under the hypotheses of
+    Theorem~\ref{thm:no_information_without_disturbance} the constants
+    satisfy $c_\alpha\geq0$ and $\sum_\alpha c_\alpha=1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:no_information_without_disturbance}
+    Evaluate $\sum_\alpha T_\alpha=\id$ at the identity matrix and take the
+    trace: the left-hand side gives $d\sum_\alpha c_\alpha$ and the
+    right-hand side gives $d$. Divide by $d\geq1$.
+\end{proof}
+
+\begin{theorem}[The outcome probability is independent of the input]
+    \label{thm:no_information_probability}
+    \lean{Channel.exists_nonneg_forall_trace_map_eq_of_isCPMap_of_sum_eq_id}
+    \leanok
+    \uses{thm:no_information_without_disturbance}
+    Under the hypotheses of
+    Theorem~\ref{thm:no_information_without_disturbance} there is, for every
+    $\alpha$, a constant $c_\alpha\geq0$ with
+    $\tr[T_\alpha(\rho)]=c_\alpha$ for every $\rho$ of unit trace. The
+    probability of the outcome $\alpha$ therefore does not depend on the
+    input, so no information is gained.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:no_information_without_disturbance}
+    By Theorem~\ref{thm:no_information_without_disturbance},
+    $T_\alpha(\rho)=c_\alpha\rho$, whose trace is $c_\alpha\tr(\rho)=c_\alpha$.
+\end{proof}
+
+\begin{corollary}[No information without disturbance for an instrument]
+    \label{cor:no_information_instrument}
+    \lean{Instrument.exists_nonneg_forall_probability_eq_of_total_eq_id}
+    \leanok
+    \uses{def:instrument, def:instrument_operations,
+        thm:no_information_probability}
+    Let $\{\Phi_i\}$ be a quantum instrument on $\MN{d}$ with $d\geq1$ whose
+    total channel is the identity. Then for every outcome $i$ the probability
+    $p_i(\rho)$ is a non-negative constant, the same for every $\rho$ of unit
+    trace.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:no_information_probability}
+    The component maps of an instrument are completely positive and their sum
+    is the identity by hypothesis, so
+    Theorem~\ref{thm:no_information_probability} applies.
+\end{proof}

--- a/blueprint/src/chapter/ch12_auxiliary_channel_theory.tex
+++ b/blueprint/src/chapter/ch12_auxiliary_channel_theory.tex
@@ -19,5 +19,6 @@ complete the Perron--Frobenius programme of
 
 \input{chapter/ch12_auxiliary_wolf_ch01}
 \input{chapter/ch04_channels_choi_foundations}
+\input{chapter/ch12_auxiliary_channel_no_information_without_disturbance}
 \input{chapter/ch05_schwarz_abstract_domains_and_order_auxiliary}
 \input{chapter/ch06_qpf_auxiliary_extensions}


### PR DESCRIPTION
## Wolf's statement

Wolf, *Quantum Channels & Operations*, Chapter 2 (`Notes/WolfNoteTexSource/ch02_representations.tex`, line 154):

> **No information without disturbance.** Consider an instrument represented by a set of completely positive maps $\{T_\alpha:\mathcal M_d \to \mathcal M_d\}$. If there is no disturbance on average, i.e., $T=\sum_\alpha T_\alpha$ satisfies $T=\mathrm{id}$, then $T_\alpha \propto \mathrm{id}$ for every $\alpha$ and the probability for obtaining an outcome $\alpha$ (given by $\mathrm{tr}[T_\alpha(\rho)]$) is independent of the input $\rho$ (hence, no information gain).

The proof is Wolf's own, step for step: on the level of Jamiolkowski states the hypothesis reads $|\Omega\rangle\langle\Omega| = \sum_\alpha \tau_\alpha$ with $\tau_\alpha \ge 0$; the maximally entangled state is pure, so the decomposition is trivial and $\tau_\alpha = c_\alpha |\Omega\rangle\langle\Omega|$ with $c_\alpha \ge 0$; Choi injectivity returns $T_\alpha = c_\alpha\,\mathrm{id}$.

## Landed signatures

`TNLean/Channel/NoInformationWithoutDisturbance.lean` (new module).

The $T_\alpha = c_\alpha\,\mathrm{id}$ clause:

```lean
theorem Channel.exists_nonneg_smul_id_of_isCPMap_of_sum_eq_id [NeZero D]
    {T : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
    (hCP : ∀ α, IsCPMap (T α)) (hsum : ∑ α, T α = LinearMap.id) (α : ι) :
    ∃ c : ℝ, 0 ≤ c ∧ T α = (c : ℂ) • LinearMap.id
```

with the normalization $\sum_\alpha c_\alpha = 1$ recorded separately:

```lean
theorem Channel.exists_nonneg_weights_of_isCPMap_of_sum_eq_id [NeZero D]
    {T : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
    (hCP : ∀ α, IsCPMap (T α)) (hsum : ∑ α, T α = LinearMap.id) :
    ∃ c : ι → ℝ, (∀ α, 0 ≤ c α) ∧ (∀ α, T α = (c α : ℂ) • LinearMap.id) ∧ ∑ α, c α = 1
```

The state-independent-probability corollary:

```lean
theorem Channel.exists_nonneg_forall_trace_map_eq_of_isCPMap_of_sum_eq_id [NeZero D]
    {T : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
    (hCP : ∀ α, IsCPMap (T α)) (hsum : ∑ α, T α = LinearMap.id) (α : ι) :
    ∃ c : ℝ, 0 ≤ c ∧
      ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.trace = 1 → (T α ρ).trace = (c : ℂ)
```

restated for the repository's own instrument structure (`TNLean/Channel/POVM.lean`):

```lean
theorem Instrument.exists_nonneg_forall_probability_eq_of_total_eq_id
    {D n : ℕ} [NeZero D] (I : Instrument D n) (hI : I.total = LinearMap.id) (i : Fin n) :
    ∃ c : ℝ, 0 ≤ c ∧
      ∀ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.trace = 1 → I.probability i ρ = (c : ℂ)
```

One supporting lemma lands alongside, the rank-one rigidity step specialized to the maximally entangled projector:

```lean
theorem Channel.exists_nonneg_smul_omegaProj_of_le_omegaProj
    {A : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hA : A.PosSemidef)
    (hle : A ≤ Matrix.omegaProj D) :
    ∃ a : ℂ, 0 ≤ a ∧ A = a • Matrix.omegaProj D
```

It is `Matrix.PosSemidef.eq_nonneg_smul_vecMulVec_of_le_smul_vecMulVec` (`TNLean/Algebra/MatrixAux.lean:812`) read after relabelling the bipartite index set `Fin D × Fin D` as `Fin (D * D)`; the general lemma is stated for a `Fin`-indexed matrix, and relabelling here avoids touching a layer-0 file that the whole development depends on.

The step $\tau_\alpha \le \sum_\beta \tau_\beta$ needed no new lemma: with `MatrixOrder` open, `Finset.single_le_sum` applies to the Loewner order directly.

## Hypothesis match

Wolf assumes exactly two things, and the Lean statements assume exactly those:

| Wolf | Lean |
|---|---|
| $\{T_\alpha : \mathcal M_d \to \mathcal M_d\}$ completely positive | `hCP : ∀ α, IsCPMap (T α)` |
| $\sum_\alpha T_\alpha = \mathrm{id}$ | `hsum : ∑ α, T α = LinearMap.id` |

Nothing further is assumed. In particular the individual $T_\alpha$ are **not** assumed trace-preserving, and no positivity or normalization of the input is required for the scalar-form clause.

Two typing conditions accompany the statement and are worth naming explicitly:

- **`[Fintype ι]`.** Wolf writes $\sum_\alpha$ without qualification; the sum has to be finite for the expression to typecheck. Issue LionSR/QICLean#318 itself asks for the finite-family form.
- **`[NeZero D]`.** Wolf's $\mathcal M_d$ is a nonzero matrix algebra, so $d \ge 1$. It is used through the Choi correspondence (Choi injectivity holds only for `D ≠ 0`) and in the normalization $\sum_\alpha c_\alpha = 1$, which is false for the zero-dimensional algebra.

The probability corollary asks for $\mathrm{tr}(\rho) = 1$ only, not positive semidefiniteness — weaker than "state", so the conclusion covers every normalized $\rho$ Wolf has in mind.

The existing `Channel.WolfProps.channel_eq_id_of_fixes_pureStates` is a different statement (a single map fixing every pure projector is the identity) and is untouched.

## Verification

- `lake env lean TNLean/Channel/NoInformationWithoutDisturbance.lean` — exit 0, no errors, no warnings.
- `lake build TNLean.Channel` — `Build completed successfully (9104 jobs)`.
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` — `Import aggregators are current`.
- `python3 scripts/blueprint_lean_sync.py --ci` — `✓ Blueprint and Lean code are in sync`; the new blueprint file reports 5/5 declarations resolved.
- `rg -n "sorry|admit|axiom|native_decide|maxHeartbeats|unsafeCast" TNLean/Channel/NoInformationWithoutDisturbance.lean` — no matches.
- Line length: all lines ≤ 100 characters in the Lean and LaTeX files.

## Blueprint

New sub-file `blueprint/src/chapter/ch12_auxiliary_channel_no_information_without_disturbance.tex`, `\input` from the auxiliary channel-theory chapter next to the Choi foundations it depends on, so no contended shared chapter file is edited. Five nodes, each with `\lean{...}`, `\leanok`, and `\leanok` on the proof.

Closes LionSR/QICLean#318

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization and documentation; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a Lean formalization of Wolf Chapter 2’s **no information without disturbance** result: if a finite family of CP maps sums to the identity, each map is a nonnegative scalar multiple of `id`, weights sum to 1, and outcome traces (or instrument probabilities) do not depend on the input state.
> 
> The proof follows Wolf via Choi–Jamiolkowski: the sum hypothesis becomes a decomposition of `|Ω⟩⟨Ω|` into PSD summands; a new lemma shows PSD matrices dominated by that projector are scalar multiples of it (via index relabelling to an existing rank-one rigidity result). Choi injectivity pulls the conclusion back to the maps.
> 
> Also adds blueprint nodes for this section and a documented Choi-matrix injectivity lemma, and wires the new module into the channel aggregator and Wolf Chapter 2 index (Proposition 2.3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c2a71fca4509c68c8a97881d145cac74602ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->