### PR TITLE
feat(Channel): complete positivity of the mean-ergodic projection

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -41,6 +41,7 @@ import TNLean.Analysis.MatrixTraceInequalities
 import TNLean.Analysis.MeanErgodic
 import TNLean.Analysis.NeumannInverse
 import TNLean.Analysis.OperatorConvexity
+import TNLean.Analysis.OperatorNormConvergence
 import TNLean.Analysis.PosSemidefCommute
 import TNLean.Analysis.ProbabilityEntropy
 import TNLean.Analysis.ProjectionGeometry

--- a/TNLean/Analysis/OperatorNormConvergence.lean
+++ b/TNLean/Analysis/OperatorNormConvergence.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Complex.Basic
+import Mathlib.Analysis.Normed.Module.FiniteDimension
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+
+/-!
+# Pointwise convergence of endomorphisms in finite dimension
+
+Let $E$ be a finite-dimensional complex normed space and let $S_N$ and $P$ be
+continuous linear endomorphisms of $E$. If $S_N(x)\to P(x)$ for every $x\in E$,
+then $S_N\to P$ in the operator norm.
+
+Evaluation on a finite basis identifies the endomorphisms of $E$ with a finite
+product of copies of $E$, linearly and bijectively. In finite dimension both
+directions of this identification are continuous, so coordinatewise convergence
+of the evaluations transports back to convergence of the maps themselves.
+
+## Main statements
+
+* `ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional`: pointwise
+  convergence of continuous linear endomorphisms of a finite-dimensional space
+  implies convergence in the operator norm.
+-/
+
+open Filter
+open scoped Topology
+
+namespace ContinuousLinearMap
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [FiniteDimensional ℂ E]
+
+/-- In finite dimension, pointwise convergence of continuous linear
+endomorphisms implies convergence in the operator norm: evaluation on a finite
+basis is a linear isomorphism onto a finite product, hence a homeomorphism. -/
+theorem tendsto_of_tendsto_apply_of_finiteDimensional {S : ℕ → E →L[ℂ] E} {P : E →L[ℂ] E}
+    (h : ∀ x : E, Tendsto (fun n : ℕ ↦ S n x) atTop (𝓝 (P x))) :
+    Tendsto S atTop (𝓝 P) := by
+  classical
+  let ι := Fin (Module.finrank ℂ E)
+  let b := Module.finBasis ℂ E
+  -- Evaluation on the basis, as a continuous linear map into a finite product.
+  let Φ : (E →L[ℂ] E) →L[ℂ] (ι → E) :=
+    ContinuousLinearMap.pi fun i ↦ (ContinuousLinearMap.apply ℂ E) (b i)
+  have hΦ : ∀ (f : E →L[ℂ] E) (i : ι), Φ f i = f (b i) := fun f i ↦
+    ContinuousLinearMap.pi_apply _ f i
+  -- `Φ` is bijective: maps are determined by their values on the basis.
+  have hinj : Function.Injective Φ.toLinearMap := by
+    intro f g hfg
+    have hfg' : ∀ i : ι, f (b i) = g (b i) := fun i ↦
+      calc f (b i) = Φ f i := (hΦ f i).symm
+        _ = Φ g i := congrFun hfg i
+        _ = g (b i) := hΦ g i
+    have hlin : f.toLinearMap = g.toLinearMap := b.ext hfg'
+    exact ContinuousLinearMap.ext fun x ↦ LinearMap.congr_fun hlin x
+  have hsurj : Function.Surjective Φ.toLinearMap := by
+    intro w
+    refine ⟨LinearMap.toContinuousLinearMap (b.constr ℂ w), ?_⟩
+    ext i
+    change Φ (LinearMap.toContinuousLinearMap (b.constr ℂ w)) i = w i
+    rw [hΦ]
+    exact b.constr_basis (M' := E) ℂ w i
+  let e := LinearEquiv.ofBijective Φ.toLinearMap ⟨hinj, hsurj⟩
+  -- Both directions are continuous in finite dimension.
+  have hfwd : Continuous e := Φ.toLinearMap.continuous_of_finiteDimensional
+  have hbwd : Continuous e.symm := e.symm.toLinearMap.continuous_of_finiteDimensional
+  -- Convergence of the evaluations, then transport back.
+  have hEval : Tendsto (fun n : ℕ ↦ e (S n)) atTop (𝓝 (e P)) := by
+    rw [tendsto_pi_nhds]
+    intro i
+    have hS : ∀ n : ℕ, e (S n) i = S n (b i) := fun n ↦ hΦ (S n) i
+    have hP : e P i = P (b i) := hΦ P i
+    simp_rw [hS, hP]
+    exact h (b i)
+  have hb := (hbwd.tendsto (e P)).comp hEval
+  have heq : e.symm ∘ (fun n : ℕ ↦ e (S n)) = S := by
+    funext n
+    exact e.symm_apply_apply (S n)
+  rw [heq] at hb
+  simpa only [LinearEquiv.symm_apply_apply] using hb
+
+end ContinuousLinearMap

--- a/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Analysis.MeanErgodic
 import TNLean.Channel.Basic
+import TNLean.Channel.Semigroup.CPClosure
 
 /-!
 # Positive trace-nonincreasing mean-ergodic projections
@@ -13,7 +14,10 @@ A positive trace-nonincreasing endomorphism of a finite-dimensional complex
 matrix algebra has bounded forward orbits.  Its finite-dimensional
 mean-ergodic projection is therefore defined and positive.  For a
 trace-preserving map, the projection is trace-preserving and fixes the identity
-whenever the original map fixes the identity.
+whenever the original map fixes the identity.  A completely positive map has a
+completely positive mean-ergodic projection: each Cesàro average is a
+nonnegative multiple of a finite sum of powers, hence completely positive, and
+the set of completely positive maps is closed in finite dimension.
 
 The bounded-orbit estimate is proved directly.  A positive semidefinite orbit
 remains in a bounded trace section of the positive cone.  Hermitian matrices are
@@ -38,6 +42,10 @@ complex linear combinations of two Hermitian matrices.
   fixed by the mean-ergodic projection.
 * `IsPositiveMap.range_meanErgodicProjection_of_tracePreserving`: the range of
   the resulting projection is exactly the fixed-point space.
+* `IsCPMap.meanErgodicProjection_isCPMap`: the mean-ergodic projection of a
+  completely positive map is completely positive.
+* `IsChannel.meanErgodicProjection`: the mean-ergodic projection of a quantum
+  channel is again a quantum channel.
 
 ## References
 
@@ -331,3 +339,110 @@ theorem IsPositiveMap.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving
       T X = X := by
   exact (hT.hasBoundedOrbits_of_tracePreserving hTP)
     |>.meanErgodicProjection_apply_eq_self_iff X
+
+/-! ### Pointwise convergence implies operator-norm convergence in finite dimension -/
+
+namespace ContinuousLinearMap
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [FiniteDimensional ℂ E]
+
+/-- In finite dimension, pointwise convergence of continuous linear
+endomorphisms implies convergence in the operator norm: evaluation on a finite
+basis is a linear isomorphism onto a finite product, hence a homeomorphism. -/
+theorem tendsto_of_tendsto_apply_of_finiteDimensional {S : ℕ → E →L[ℂ] E} {P : E →L[ℂ] E}
+    (h : ∀ x : E, Tendsto (fun n : ℕ ↦ S n x) atTop (𝓝 (P x))) :
+    Tendsto S atTop (𝓝 P) := by
+  classical
+  let ι := Fin (Module.finrank ℂ E)
+  let b := Module.finBasis ℂ E
+  -- Evaluation on the basis, as a continuous linear map into a finite product.
+  let Φ : (E →L[ℂ] E) →L[ℂ] (ι → E) :=
+    ContinuousLinearMap.pi fun i ↦ (ContinuousLinearMap.apply ℂ E) (b i)
+  have hΦ : ∀ (f : E →L[ℂ] E) (i : ι), Φ f i = f (b i) := fun f i ↦
+    ContinuousLinearMap.pi_apply _ f i
+  -- `Φ` is bijective: maps are determined by their values on the basis.
+  have hinj : Function.Injective Φ.toLinearMap := by
+    intro f g hfg
+    have hfg' : ∀ i : ι, f (b i) = g (b i) := fun i ↦
+      calc f (b i) = Φ f i := (hΦ f i).symm
+        _ = Φ g i := congrFun hfg i
+        _ = g (b i) := hΦ g i
+    have hlin : f.toLinearMap = g.toLinearMap := b.ext hfg'
+    exact ContinuousLinearMap.ext fun x ↦ LinearMap.congr_fun hlin x
+  have hsurj : Function.Surjective Φ.toLinearMap := by
+    intro w
+    refine ⟨LinearMap.toContinuousLinearMap (b.constr ℂ w), ?_⟩
+    ext i
+    change Φ (LinearMap.toContinuousLinearMap (b.constr ℂ w)) i = w i
+    rw [hΦ]
+    exact b.constr_basis (M' := E) ℂ w i
+  let e := LinearEquiv.ofBijective Φ.toLinearMap ⟨hinj, hsurj⟩
+  -- Both directions are continuous in finite dimension.
+  have hfwd : Continuous e := Φ.toLinearMap.continuous_of_finiteDimensional
+  have hbwd : Continuous e.symm := e.symm.toLinearMap.continuous_of_finiteDimensional
+  -- Convergence of the evaluations, then transport back.
+  have hEval : Tendsto (fun n : ℕ ↦ e (S n)) atTop (𝓝 (e P)) := by
+    rw [tendsto_pi_nhds]
+    intro i
+    have hS : ∀ n : ℕ, e (S n) i = S n (b i) := fun n ↦ hΦ (S n) i
+    have hP : e P i = P (b i) := hΦ P i
+    simp_rw [hS, hP]
+    exact h (b i)
+  have hb := (hbwd.tendsto (e P)).comp hEval
+  have heq : e.symm ∘ (fun n : ℕ ↦ e (S n)) = S := by
+    funext n
+    exact e.symm_apply_apply (S n)
+  rw [heq] at hb
+  simpa only [LinearEquiv.symm_apply_apply] using hb
+
+end ContinuousLinearMap
+
+/-! ### Complete positivity of the mean-ergodic projection -/
+
+/-- The finite-dimensional mean-ergodic projection of a completely positive
+matrix endomorphism is completely positive.
+
+The `N`-th Cesàro average is the nonnegative multiple `N⁻¹` of the finite sum
+`∑_{n < N} T ^ n`, so it is completely positive.  These averages converge
+pointwise, hence in the operator norm, to the mean-ergodic projection, and the
+set of completely positive maps is closed in finite dimension.
+
+Source: Wolf, Proposition 6.3(iii) and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--238. -/
+theorem IsCPMap.meanErgodicProjection_isCPMap
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsCPMap T) (hbounded : T.HasBoundedOrbits) :
+    IsCPMap (LinearMap.meanErgodicProjection T hbounded) := by
+  classical
+  rcases Nat.eq_zero_or_pos D with rfl | hD
+  · exact isCPMap_finZero _
+  haveI : NeZero D := ⟨hD.ne'⟩
+  set S : ℕ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+    fun N ↦ (((N : ℝ)⁻¹ : ℝ) : ℂ) • ∑ n ∈ Finset.range N, T ^ n with hSdef
+  have hScp : ∀ N, IsCPMap (S N) := fun N ↦
+    (Finset.isCPMap_sum _ _ fun n _ ↦ hT.pow n).smul_nonneg (by positivity)
+  have hSapply : ∀ (N : ℕ) (X : Matrix (Fin D) (Fin D) ℂ),
+      S N X = birkhoffAverage ℂ T _root_.id N X := by
+    intro N X
+    simp only [hSdef, birkhoffAverage, birkhoffSum, LinearMap.smul_apply,
+      LinearMap.coe_sum, Finset.sum_apply, Module.End.pow_apply, id_eq]
+    push_cast
+    rfl
+  refine IsCPMap.of_tendsto_toCLM hScp
+    (ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional fun X ↦ ?_)
+  exact (hbounded.tendsto_birkhoffAverage_meanErgodicProjection X).congr fun N ↦
+    (hSapply N X).symm
+
+/-- The mean-ergodic projection `T_∞` of a quantum channel is again a quantum
+channel: this is the assertion of Wolf's Cesàro-means proposition for `T_∞`
+in the completely positive case.
+
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--238. -/
+theorem IsChannel.meanErgodicProjection
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsChannel T) :
+    IsChannel (LinearMap.meanErgodicProjection T
+      (hT.cp.isPositiveMap.hasBoundedOrbits_of_tracePreserving hT.tp)) where
+  cp := hT.cp.meanErgodicProjection_isCPMap _
+  tp := hT.tp.meanErgodicProjection_isTracePreservingMap _

--- a/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicProjection.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Analysis.MeanErgodic
+import TNLean.Analysis.OperatorNormConvergence
 import TNLean.Channel.Basic
 import TNLean.Channel.Semigroup.CPClosure
 
@@ -14,10 +15,13 @@ A positive trace-nonincreasing endomorphism of a finite-dimensional complex
 matrix algebra has bounded forward orbits.  Its finite-dimensional
 mean-ergodic projection is therefore defined and positive.  For a
 trace-preserving map, the projection is trace-preserving and fixes the identity
-whenever the original map fixes the identity.  A completely positive map has a
-completely positive mean-ergodic projection: each Cesàro average is a
-nonnegative multiple of a finite sum of powers, hence completely positive, and
-the set of completely positive maps is closed in finite dimension.
+whenever the original map fixes the identity.  A completely positive map with
+bounded forward orbits has a completely positive mean-ergodic projection: each
+Cesàro average is a nonnegative multiple of a finite sum of powers, hence
+completely positive, and the set of completely positive maps is closed in finite
+dimension.  For a completely positive trace-preserving map the bounded-orbit
+hypothesis is automatic, so the mean-ergodic projection of a quantum channel is
+again a quantum channel.
 
 The bounded-orbit estimate is proved directly.  A positive semidefinite orbit
 remains in a bounded trace section of the positive cone.  Hermitian matrices are
@@ -43,7 +47,7 @@ complex linear combinations of two Hermitian matrices.
 * `IsPositiveMap.range_meanErgodicProjection_of_tracePreserving`: the range of
   the resulting projection is exactly the fixed-point space.
 * `IsCPMap.meanErgodicProjection_isCPMap`: the mean-ergodic projection of a
-  completely positive map is completely positive.
+  completely positive map with bounded forward orbits is completely positive.
 * `IsChannel.meanErgodicProjection`: the mean-ergodic projection of a quantum
   channel is again a quantum channel.
 
@@ -340,74 +344,21 @@ theorem IsPositiveMap.meanErgodicProjection_apply_eq_self_iff_of_tracePreserving
   exact (hT.hasBoundedOrbits_of_tracePreserving hTP)
     |>.meanErgodicProjection_apply_eq_self_iff X
 
-/-! ### Pointwise convergence implies operator-norm convergence in finite dimension -/
-
-namespace ContinuousLinearMap
-
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [FiniteDimensional ℂ E]
-
-/-- In finite dimension, pointwise convergence of continuous linear
-endomorphisms implies convergence in the operator norm: evaluation on a finite
-basis is a linear isomorphism onto a finite product, hence a homeomorphism. -/
-theorem tendsto_of_tendsto_apply_of_finiteDimensional {S : ℕ → E →L[ℂ] E} {P : E →L[ℂ] E}
-    (h : ∀ x : E, Tendsto (fun n : ℕ ↦ S n x) atTop (𝓝 (P x))) :
-    Tendsto S atTop (𝓝 P) := by
-  classical
-  let ι := Fin (Module.finrank ℂ E)
-  let b := Module.finBasis ℂ E
-  -- Evaluation on the basis, as a continuous linear map into a finite product.
-  let Φ : (E →L[ℂ] E) →L[ℂ] (ι → E) :=
-    ContinuousLinearMap.pi fun i ↦ (ContinuousLinearMap.apply ℂ E) (b i)
-  have hΦ : ∀ (f : E →L[ℂ] E) (i : ι), Φ f i = f (b i) := fun f i ↦
-    ContinuousLinearMap.pi_apply _ f i
-  -- `Φ` is bijective: maps are determined by their values on the basis.
-  have hinj : Function.Injective Φ.toLinearMap := by
-    intro f g hfg
-    have hfg' : ∀ i : ι, f (b i) = g (b i) := fun i ↦
-      calc f (b i) = Φ f i := (hΦ f i).symm
-        _ = Φ g i := congrFun hfg i
-        _ = g (b i) := hΦ g i
-    have hlin : f.toLinearMap = g.toLinearMap := b.ext hfg'
-    exact ContinuousLinearMap.ext fun x ↦ LinearMap.congr_fun hlin x
-  have hsurj : Function.Surjective Φ.toLinearMap := by
-    intro w
-    refine ⟨LinearMap.toContinuousLinearMap (b.constr ℂ w), ?_⟩
-    ext i
-    change Φ (LinearMap.toContinuousLinearMap (b.constr ℂ w)) i = w i
-    rw [hΦ]
-    exact b.constr_basis (M' := E) ℂ w i
-  let e := LinearEquiv.ofBijective Φ.toLinearMap ⟨hinj, hsurj⟩
-  -- Both directions are continuous in finite dimension.
-  have hfwd : Continuous e := Φ.toLinearMap.continuous_of_finiteDimensional
-  have hbwd : Continuous e.symm := e.symm.toLinearMap.continuous_of_finiteDimensional
-  -- Convergence of the evaluations, then transport back.
-  have hEval : Tendsto (fun n : ℕ ↦ e (S n)) atTop (𝓝 (e P)) := by
-    rw [tendsto_pi_nhds]
-    intro i
-    have hS : ∀ n : ℕ, e (S n) i = S n (b i) := fun n ↦ hΦ (S n) i
-    have hP : e P i = P (b i) := hΦ P i
-    simp_rw [hS, hP]
-    exact h (b i)
-  have hb := (hbwd.tendsto (e P)).comp hEval
-  have heq : e.symm ∘ (fun n : ℕ ↦ e (S n)) = S := by
-    funext n
-    exact e.symm_apply_apply (S n)
-  rw [heq] at hb
-  simpa only [LinearEquiv.symm_apply_apply] using hb
-
-end ContinuousLinearMap
-
 /-! ### Complete positivity of the mean-ergodic projection -/
 
 /-- The finite-dimensional mean-ergodic projection of a completely positive
-matrix endomorphism is completely positive.
+matrix endomorphism with bounded forward orbits is completely positive.
 
-The `N`-th Cesàro average is the nonnegative multiple `N⁻¹` of the finite sum
-`∑_{n < N} T ^ n`, so it is completely positive.  These averages converge
-pointwise, hence in the operator norm, to the mean-ergodic projection, and the
-set of completely positive maps is closed in finite dimension.
+The $N$-th Cesàro average is
+$$
+  S_N = \frac{1}{N}\sum_{n=0}^{N-1} T^n,
+$$
+a nonnegative multiple of a finite sum of completely positive powers, hence
+completely positive.  These averages converge pointwise, hence in the operator
+norm, to $T_\infty$, and the set of completely positive maps is closed in finite
+dimension.
 
-Source: Wolf, Proposition 6.3(iii) and Equation (6.14), local source
+Source: Wolf, Proposition 6.3 and Equation (6.14), local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--238. -/
 theorem IsCPMap.meanErgodicProjection_isCPMap
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
@@ -433,9 +384,9 @@ theorem IsCPMap.meanErgodicProjection_isCPMap
   exact (hbounded.tendsto_birkhoffAverage_meanErgodicProjection X).congr fun N ↦
     (hSapply N X).symm
 
-/-- The mean-ergodic projection `T_∞` of a quantum channel is again a quantum
-channel: this is the assertion of Wolf's Cesàro-means proposition for `T_∞`
-in the completely positive case.
+/-- The mean-ergodic projection $T_\infty$ of a quantum channel is again a
+quantum channel: this is the assertion of Wolf's Cesàro-means proposition for
+$T_\infty$ in the completely positive case.
 
 Source: Wolf, Proposition 6.3 and Equation (6.14), local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226--238. -/

--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -7,6 +7,7 @@ import TNLean.Channel.Peripheral.SpectralProjection
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.Semigroup.CPClosure
 import TNLean.Analysis.Dirichlet
+import TNLean.Analysis.OperatorNormConvergence
 import Mathlib.Data.Nat.Choose.Bounds
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Analysis.SpecificLimits.Normed

--- a/TNLean/Channel/Peripheral/CesaroRecurrence.lean
+++ b/TNLean/Channel/Peripheral/CesaroRecurrence.lean
@@ -305,63 +305,6 @@ theorem norm_le_one_of_hasEigenvalue (hf : f.HasBoundedOrbits) {μ : ℂ}
 
 end LinearMap.HasBoundedOrbits
 
-/-! ### Pointwise convergence implies operator-norm convergence in finite dimension -/
-
-namespace ContinuousLinearMap
-
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [FiniteDimensional ℂ E]
-
-/-- In finite dimension, pointwise convergence of continuous linear
-endomorphisms implies convergence in the operator norm: evaluation on a finite
-basis is a linear isomorphism onto a finite product, hence a homeomorphism. -/
-theorem tendsto_of_tendsto_apply_of_finiteDimensional {S : ℕ → E →L[ℂ] E} {P : E →L[ℂ] E}
-    (h : ∀ x : E, Tendsto (fun n : ℕ ↦ S n x) atTop (𝓝 (P x))) :
-    Tendsto S atTop (𝓝 P) := by
-  classical
-  let ι := Fin (Module.finrank ℂ E)
-  let b := Module.finBasis ℂ E
-  -- Evaluation on the basis, as a continuous linear map into a finite product.
-  let Φ : (E →L[ℂ] E) →L[ℂ] (ι → E) :=
-    ContinuousLinearMap.pi fun i ↦ (ContinuousLinearMap.apply ℂ E) (b i)
-  have hΦ : ∀ (f : E →L[ℂ] E) (i : ι), Φ f i = f (b i) := fun f i ↦
-    ContinuousLinearMap.pi_apply _ f i
-  -- `Φ` is bijective: maps are determined by their values on the basis.
-  have hinj : Function.Injective Φ.toLinearMap := by
-    intro f g hfg
-    have hfg' : ∀ i : ι, f (b i) = g (b i) := fun i ↦
-      calc f (b i) = Φ f i := (hΦ f i).symm
-        _ = Φ g i := congrFun hfg i
-        _ = g (b i) := hΦ g i
-    have hlin : f.toLinearMap = g.toLinearMap := b.ext hfg'
-    exact ContinuousLinearMap.ext fun x ↦ LinearMap.congr_fun hlin x
-  have hsurj : Function.Surjective Φ.toLinearMap := by
-    intro w
-    refine ⟨LinearMap.toContinuousLinearMap (b.constr ℂ w), ?_⟩
-    ext i
-    change Φ (LinearMap.toContinuousLinearMap (b.constr ℂ w)) i = w i
-    rw [hΦ]
-    exact b.constr_basis (M' := E) ℂ w i
-  let e := LinearEquiv.ofBijective Φ.toLinearMap ⟨hinj, hsurj⟩
-  -- Both directions are continuous in finite dimension.
-  have hfwd : Continuous e := Φ.toLinearMap.continuous_of_finiteDimensional
-  have hbwd : Continuous e.symm := e.symm.toLinearMap.continuous_of_finiteDimensional
-  -- Convergence of the evaluations, then transport back.
-  have hEval : Tendsto (fun n : ℕ ↦ e (S n)) atTop (𝓝 (e P)) := by
-    rw [tendsto_pi_nhds]
-    intro i
-    have hS : ∀ n : ℕ, e (S n) i = S n (b i) := fun n ↦ hΦ (S n) i
-    have hP : e P i = P (b i) := hΦ P i
-    simp_rw [hS, hP]
-    exact h (b i)
-  have hb := (hbwd.tendsto (e P)).comp hEval
-  have heq : e.symm ∘ (fun n : ℕ ↦ e (S n)) = S := by
-    funext n
-    exact e.symm_apply_apply (S n)
-  rw [heq] at hb
-  simpa only [LinearEquiv.symm_apply_apply] using hb
-
-end ContinuousLinearMap
-
 /-! ### Wolf Proposition 6.3(i): the recurrent subsequence for positive TP maps -/
 
 namespace IsPositiveMap

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -189,6 +189,47 @@
     assertion for $T_\varphi'$.
 \end{proof}
 
+\begin{lemma}[Pointwise limits of endomorphisms in finite dimension]
+    \label{lem:tendsto_clm_of_tendsto_apply}
+    \lean{ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional}
+    \leanok
+    Let $E$ be a finite-dimensional complex normed space and let $S_N$ and $P$
+    be continuous linear endomorphisms of $E$. If $S_N(x)\to P(x)$ for every
+    $x\in E$, then $S_N\to P$ in the operator norm.
+\end{lemma}
+
+\begin{proof}\leanok
+    Fix a basis $e_1,\dots,e_m$ of $E$. Evaluation on the basis,
+    \begin{align}
+        \Phi(S)=(S(e_1),\dots,S(e_m)),
+    \end{align}
+    is a linear bijection from the endomorphisms of $E$ onto $E^m$, since an
+    endomorphism is determined by, and may be prescribed arbitrarily on, a
+    basis. In finite dimension every linear map is continuous, so both $\Phi$
+    and $\Phi^{-1}$ are continuous. The hypothesis says $\Phi(S_N)\to\Phi(P)$
+    coordinatewise, hence $S_N=\Phi^{-1}(\Phi(S_N))\to\Phi^{-1}(\Phi(P))=P$.
+\end{proof}
+
+\begin{lemma}[Closedness of the completely positive maps]
+    \label{lem:cp_maps_closed}
+    \lean{isClosed_setOf_isCPMap, IsCPMap.of_tendsto_toCLM}
+    \leanok
+    \uses{def:cp_map}
+    Let $D>0$. The completely positive maps form a closed subset of the
+    endomorphisms of $\MN{D}$ in the operator norm. In particular, if every
+    $S_N:\MN{D}\to\MN{D}$ is completely positive and $S_N\to P$ in the
+    operator norm, then $P$ is completely positive.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:cp_map}
+    A map is completely positive precisely when its Choi matrix is positive
+    semidefinite. The Choi matrix depends linearly, hence continuously, on the
+    map, and the positive semidefinite matrices are closed. The set of
+    completely positive maps is therefore the preimage of a closed set under a
+    continuous map.
+\end{proof}
+
 \begin{corollary}[Channel structure of the mean-ergodic projection]
     \label{cor:mean_ergodic_projection_channel}
     \lean{IsCPMap.meanErgodicProjection_isCPMap,
@@ -199,8 +240,8 @@
         thm:positive_trace_preserving_mean_ergodic_projection}
     Let $T:\MN{D}\to\MN{D}$ be completely positive and trace-preserving. Then
     the mean-ergodic projection $T_\infty$ of
-    \cite[Equation~(6.14)]{Wolf2012Quantum} is completely positive, hence a
-    quantum channel. Together with
+    \cite[Equation~(6.14)]{Wolf2012Quantum} is completely positive and
+    trace-preserving, hence a quantum channel. Together with
     Corollary~\ref{cor:peripheral_projection_channel} this completes the
     preservation assertion of \cite[Proposition~6.3]{Wolf2012Quantum} for all
     three maps $T_\infty$, $T_\varphi$, and $T_\varphi'$.
@@ -209,12 +250,29 @@
 \begin{proof}\leanok
     \uses{def:mean_ergodic_projection,
         thm:mean_ergodic_bounded_orbits,
-        thm:positive_trace_preserving_mean_ergodic_projection}
-    The $N$-th Ces\`aro average is the nonnegative multiple $1/N$ of a finite
-    sum of powers of $T$, and powers and sums of completely positive maps are
-    completely positive. These averages converge pointwise to $T_\infty$,
-    hence in operator norm, and in finite dimension the completely positive
-    maps form a closed set. Trace preservation of $T_\infty$ is
+        thm:positive_trace_preserving_mean_ergodic_projection,
+        thm:trace_preserving_mean_ergodic_projection,
+        lem:tendsto_clm_of_tendsto_apply,
+        lem:cp_maps_closed}
+    Write
+    \begin{align}
+        S_N=\frac{1}{N}\sum_{n=0}^{N-1}T^n
+    \end{align}
+    for the $N$-th Ces\`aro average. Powers of a completely positive map are
+    completely positive, and so are finite sums and nonnegative multiples of
+    completely positive maps, so every $S_N$ is completely positive. By
+    (\ref{eq:channel_mean_ergodic_limit}),
+    \begin{align}
+        S_N(X)\longrightarrow T_\infty(X)\quad\text{for every }X\in\MN{D},
+    \end{align}
+    and Lemma~\ref{lem:tendsto_clm_of_tendsto_apply} upgrades this to
+    \begin{align}
+        S_N\longrightarrow T_\infty
+    \end{align}
+    in the operator norm. Lemma~\ref{lem:cp_maps_closed} then makes $T_\infty$
+    completely positive. Trace preservation of $T_\infty$ is
+    Theorem~\ref{thm:trace_preserving_mean_ergodic_projection}, and the
+    bounded orbits it requires come from
     Theorem~\ref{thm:positive_trace_preserving_mean_ergodic_projection}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -214,7 +214,7 @@
     \label{lem:cp_maps_closed}
     \lean{isClosed_setOf_isCPMap, IsCPMap.of_tendsto_toCLM}
     \leanok
-    \uses{def:cp_map}
+    \uses{def:cp_map, thm:cp_iff_choi_posSemidef}
     Let $D>0$. The completely positive maps form a closed subset of the
     endomorphisms of $\MN{D}$ in the operator norm. In particular, if every
     $S_N:\MN{D}\to\MN{D}$ is completely positive and $S_N\to P$ in the
@@ -222,12 +222,12 @@
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{def:cp_map}
-    A map is completely positive precisely when its Choi matrix is positive
-    semidefinite. The Choi matrix depends linearly, hence continuously, on the
-    map, and the positive semidefinite matrices are closed. The set of
-    completely positive maps is therefore the preimage of a closed set under a
-    continuous map.
+    \uses{def:cp_map, def:choi_matrix, thm:cp_iff_choi_posSemidef}
+    By Theorem~\ref{thm:cp_iff_choi_posSemidef} a map is completely positive
+    precisely when its Choi matrix is positive semidefinite. The Choi matrix
+    depends linearly, hence continuously, on the map, and the positive
+    semidefinite matrices are closed. The set of completely positive maps is
+    therefore the preimage of a closed set under a continuous map.
 \end{proof}
 
 \begin{corollary}[Channel structure of the mean-ergodic projection]
@@ -235,13 +235,17 @@
     \lean{IsCPMap.meanErgodicProjection_isCPMap,
         IsChannel.meanErgodicProjection}
     \leanok
-    \uses{def:mean_ergodic_projection,
+    \uses{def:cp_map,
+        def:has_bounded_orbits,
+        def:mean_ergodic_projection,
         thm:mean_ergodic_bounded_orbits,
         thm:positive_trace_preserving_mean_ergodic_projection}
-    Let $T:\MN{D}\to\MN{D}$ be completely positive and trace-preserving. Then
+    Let $T:\MN{D}\to\MN{D}$ be completely positive with bounded orbits. Then
     the mean-ergodic projection $T_\infty$ of
-    \cite[Equation~(6.14)]{Wolf2012Quantum} is completely positive and
-    trace-preserving, hence a quantum channel. Together with
+    \cite[Equation~(6.14)]{Wolf2012Quantum} is completely positive. If $T$ is
+    completely positive and trace-preserving, the bounded orbits are automatic
+    and $T_\infty$ is completely positive and trace-preserving, hence a
+    quantum channel. Together with
     Corollary~\ref{cor:peripheral_projection_channel} this completes the
     preservation assertion of \cite[Proposition~6.3]{Wolf2012Quantum} for all
     three maps $T_\infty$, $T_\varphi$, and $T_\varphi'$.
@@ -254,16 +258,17 @@
         thm:trace_preserving_mean_ergodic_projection,
         lem:tendsto_clm_of_tendsto_apply,
         lem:cp_maps_closed}
-    Write
+    For $D=0$ the algebra is trivial and every linear map is completely
+    positive, so assume $D>0$. Write
     \begin{align}
         S_N=\frac{1}{N}\sum_{n=0}^{N-1}T^n
     \end{align}
     for the $N$-th Ces\`aro average. Powers of a completely positive map are
     completely positive, and so are finite sums and nonnegative multiples of
-    completely positive maps, so every $S_N$ is completely positive. By
-    (\ref{eq:channel_mean_ergodic_limit}),
+    completely positive maps, so every $S_N$ is completely positive. For every
+    $X\in\MN{D}$, (\ref{eq:channel_mean_ergodic_limit}) gives
     \begin{align}
-        S_N(X)\longrightarrow T_\infty(X)\quad\text{for every }X\in\MN{D},
+        S_N(X)\longrightarrow T_\infty(X),
     \end{align}
     and Lemma~\ref{lem:tendsto_clm_of_tendsto_apply} upgrades this to
     \begin{align}

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -189,6 +189,35 @@
     assertion for $T_\varphi'$.
 \end{proof}
 
+\begin{corollary}[Channel structure of the mean-ergodic projection]
+    \label{cor:mean_ergodic_projection_channel}
+    \lean{IsCPMap.meanErgodicProjection_isCPMap,
+        IsChannel.meanErgodicProjection}
+    \leanok
+    \uses{def:mean_ergodic_projection,
+        thm:mean_ergodic_bounded_orbits,
+        thm:positive_trace_preserving_mean_ergodic_projection}
+    Let $T:\MN{D}\to\MN{D}$ be completely positive and trace-preserving. Then
+    the mean-ergodic projection $T_\infty$ of
+    \cite[Equation~(6.14)]{Wolf2012Quantum} is completely positive, hence a
+    quantum channel. Together with
+    Corollary~\ref{cor:peripheral_projection_channel} this completes the
+    preservation assertion of \cite[Proposition~6.3]{Wolf2012Quantum} for all
+    three maps $T_\infty$, $T_\varphi$, and $T_\varphi'$.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{def:mean_ergodic_projection,
+        thm:mean_ergodic_bounded_orbits,
+        thm:positive_trace_preserving_mean_ergodic_projection}
+    The $N$-th Ces\`aro average is the nonnegative multiple $1/N$ of a finite
+    sum of powers of $T$, and powers and sums of completely positive maps are
+    completely positive. These averages converge pointwise to $T_\infty$,
+    hence in operator norm, and in finite dimension the completely positive
+    maps form a closed set. Trace preservation of $T_\infty$ is
+    Theorem~\ref{thm:positive_trace_preserving_mean_ergodic_projection}.
+\end{proof}
+
 \begin{theorem}[Peripheral absorption of the mean-ergodic projection]
     \label{thm:peripheral_mean_ergodic_absorption}
     \lean{IsPositiveMap.peripheralProjection_comp_meanErgodicProjection}


### PR DESCRIPTION
### Motivation

- Closes the last missing clause of Wolf's Cesàro-means proposition. Source:
  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 226–238
  (Wolf §6, Proposition "Cesaro means", Equation (6.14)):

  > Let $T:\mathcal M_d(\mathbb C)\to\mathcal M_d(\mathbb C)$ be a linear map which is
  > trace-preserving and (completely) positive. Then $T_\infty, T_\phi, T_\varphi$ are
  > trace-preserving and (completely) positive as well.

- Positivity and trace preservation of $T_\infty$ were already formalized
  (`IsPositiveMap.meanErgodicProjection_isPositiveMap`,
  `IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap`), and the
  $T_\varphi$ / $T_\varphi'$ clauses were closed in LionSR/TNLean#5630. Complete positivity of
  $T_\infty$ was the remaining gap.

### Description

`TNLean/Channel/FixedPoint/MeanErgodicProjection.lean`:

- New `IsCPMap.meanErgodicProjection_isCPMap`:

  ```lean
  theorem IsCPMap.meanErgodicProjection_isCPMap
      {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
      (hT : IsCPMap T) (hbounded : T.HasBoundedOrbits) :
      IsCPMap (LinearMap.meanErgodicProjection T hbounded)
  ```

  matching the shape of the positivity companion
  `IsPositiveMap.meanErgodicProjection_isPositiveMap`. No unitality,
  irreducibility, or primitivity hypothesis is used; bounded orbits come for free
  from positivity plus trace preservation via
  `IsPositiveMap.hasBoundedOrbits_of_tracePreserving`.

- New `IsChannel.meanErgodicProjection`, packaging the source's hypothesis set
  exactly: a completely positive trace-preserving $T$ has a completely positive
  trace-preserving $T_\infty$.

- Argument (Wolf's own compactness route): the $N$-th Cesàro average is
  $N^{-1}\sum_{n<N}T^n$, completely positive by `Finset.isCPMap_sum`,
  `IsCPMap.pow`, `IsCPMap.smul_nonneg`; these averages converge pointwise to
  $T_\infty$ by
  `LinearMap.HasBoundedOrbits.tendsto_birkhoffAverage_meanErgodicProjection`,
  hence in the operator norm in finite dimension; and the completely positive
  maps form a closed set, `IsCPMap.of_tendsto_toCLM`. The dimension-zero case is
  `isCPMap_finZero`.

- The generic helper
  `ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional` (pointwise
  convergence of continuous linear endomorphisms implies operator-norm
  convergence in finite dimension) moves here from
  `TNLean/Channel/Peripheral/CesaroRecurrence.lean`, unchanged. There is no
  import cycle: `CesaroRecurrence.lean` already imports
  `MeanErgodicProjection.lean`, so its single use site in
  `IsPositiveMap.tendsto_endEquiv_pow_peripheralProjection` still resolves and
  `IsPositiveMap.peripheralProjection_isCPMap` is unaffected. Nothing is
  duplicated.

`blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex`:

- New corollary "Channel structure of the mean-ergodic projection"
  (`cor:mean_ergodic_projection_channel`) with `\lean{IsCPMap.meanErgodicProjection_isCPMap,
  IsChannel.meanErgodicProjection}`, `\leanok`, and `\leanok` on its proof.

### Testing

- `lake env lean TNLean/Channel/FixedPoint/MeanErgodicProjection.lean` — no errors,
  no warnings.
- `lake build TNLean.Channel` — `Build completed successfully (9103 jobs).` This
  covers `CesaroRecurrence.lean`, `Channel/Peripheral.lean`,
  `Channel/FixedPoint.lean`, and `Channel/WolfChapter6Index.lean`; every direct
  and transitive importer of the two changed Lean files lives under
  `TNLean/Channel`.
- `rg -n "sorry|axiom|native_decide|maxHeartbeats"` on both changed Lean files —
  no matches.
- `leanblueprint checkdecls` could not run in this worktree: it needs the
  generated `blueprint/lean_decls`, which only a `leanblueprint web`/`pdf` run
  produces. Both cited declaration names were verified against the compiled file
  instead; neither sits inside a namespace, so the full names are exactly as
  written.

### Coverage of the source proposition

The Cesàro-means proposition is now fully covered for all three maps:

- $T_\infty$: trace-preserving (`IsTracePreservingMap.meanErgodicProjection_isTracePreservingMap`),
  positive (`IsPositiveMap.meanErgodicProjection_isPositiveMap`), completely
  positive (this PR).
- $T_\phi$ and $T_\varphi$: positive, trace-preserving, and completely positive
  from LionSR/TNLean#5630 (`IsPositiveMap.peripheralProjection_isCPMap`,
  `IsChannel.peripheralProjection`, `IsChannel.peripheralWeightedProjection`).

Items (i)–(iii) of the proposition were already formalized. Nothing from
lines 226–238 remains open.

---
Closes LionSR/QICLean#285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176U7wiKWaxFAKBHv3Jgjz3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and blueprint sync; no runtime, auth, or data paths—only reorganized analysis lemmas and new channel theorems built on existing closedness/limit infrastructure.
> 
> **Overview**
> Closes the last Wolf Proposition 6.3 preservation clause: the mean-ergodic projection **T_∞** of a completely positive map (with bounded orbits) stays completely positive, and **`IsChannel.meanErgodicProjection`** packages the quantum-channel case.
> 
> The proof identifies Cesàro averages **S_N** with completely positive maps, uses existing pointwise convergence to **T_∞**, and passes the limit through **`IsCPMap.of_tendsto_toCLM`** after upgrading to operator-norm convergence via **`ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional`**, which is **moved** from `CesaroRecurrence.lean` into new **`TNLean/Analysis/OperatorNormConvergence.lean`** and wired through `Analysis.lean`.
> 
> The blueprint chapter adds the finite-dimensional pointwise→operator-norm lemma, closedness of CP maps, and corollary **`cor:mean_ergodic_projection_channel`** aligned with the new Lean theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46da24aa6cd66642a3ff7c5af75937dd9c0c076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->