### PR TITLE
feat(parent-hamiltonian): add arbitrary-increment mixed Gram

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -175,8 +175,8 @@ theorem inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q
 -- map there is \(U\circ T\), and
 -- \((U\circ T)^\dagger L=T^\dagger(U^\dagger L)\). Hence its reassociated
 -- mixed-Gram theorem is this identity transported by \(U\), with the same
--- right-hand side; it is a wrapper around this theorem, not a second coordinate
--- proof.
+-- right-hand side; it is an equivalent formulation of this theorem, not a
+-- second coordinate proof.
 
 /-- Exact mixed-Gram identity for the overlapping windows in Nachtergaele's C3
 geometry (arXiv:cond-mat/9410110, equation (2.4)).

--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -10,22 +10,23 @@ import TNLean.MPS.ParentHamiltonian.SpectatorBoundaryGram
 # Mixed Gram of overlapping spectator boundary maps
 
 This file computes the mixed Gram between the tail and left spectator boundary
-maps in the common ambient space used by Nachtergaele's martingale condition C3.
-The calculation is exact: after fixing the prefix spectator \(u\) and final-site
-spectator \(j\), the overlap is the length-\(l\) MPS Gram pairing of the two virtual
-matrices obtained at the ends of the overlap.
+maps in the common ambient spaces used by Nachtergaele's martingale conditions
+C3 and C3'. The calculation is exact: after fixing the prefix spectator \(u\)
+and the arbitrary-increment spectator \(j\), the overlap is the length-\(l\) MPS
+Gram pairing of the two virtual matrices obtained at the ends of the overlap.
 
-The identity below is reconstructed directly from the boundary-map definitions,
-word factorization, and trace cyclicity. It is not stated in this form by FNW or
-Nachtergaele. The sourced target is the projector defect in Nachtergaele,
-arXiv:cond-mat/9410110, equation (2.4); the rational numerical estimate is quoted
-after that equation and in Section 6, equation (6.1). No numerical estimate is
-asserted here.
+The identities below are reconstructed directly from the boundary-map definitions,
+word factorization, and trace cyclicity. They are not stated in this form by FNW
+or Nachtergaele. The sourced targets are the projector defects in Nachtergaele,
+arXiv:cond-mat/9410110, equations (2.4)--(2.5); the rational numerical estimate is
+quoted after equation (2.4) and in Section 6, equation (6.1). No numerical estimate
+is asserted here.
 
 ## Main results
 
+* `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q`
 * `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES`
-* `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered`
+* `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered
 -/
 
 open scoped Matrix
@@ -47,6 +48,125 @@ private def cfgAppendThreeEquiv (d K l R : ℕ) :
 private theorem cfgAppendThreeEquiv_apply (d K l R : ℕ)
     (u : Cfg d K) (τ : Cfg d l) (j : Cfg d R) :
     cfgAppendThreeEquiv d K l R (u, (τ, j)) = Fin.append u (Fin.append τ j) := rfl
+
+/-- Exact arbitrary-increment mixed-Gram identity for the overlapping windows in
+Nachtergaele's C3' geometry (arXiv:cond-mat/9410110, equation (2.5)).
+
+For a prefix spectator \(u\) and a \(q\)-site increment spectator \(j\), the tail
+boundary matrix entering the \(l\)-site overlap is \(A^j X_u\), while the left
+boundary matrix is \(Z_j A^u\). Thus the mixed Gram is a sum of length-\(l\)
+ground-space Gram pairings with exactly this multiplication order. The canonical
+reindexing only identifies \(K+(l+q)\) with \((K+l)+q\).
+
+This is an algebraic identity reconstructed from the definitions. It is not the
+analytic C3' norm estimate in equation (2.5), and it asserts no contraction or
+uniformity in the increment. -/
+theorem inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q
+    (A : MPSTensor d D) (K l q : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg d K))
+    (y : BoundaryFamilySpace (D := D) (Cfg d q)) :
+    inner ℂ x ((tailBoundaryMapES A K (l + q)).adjoint
+      ((LinearIsometryEquiv.piLpCongrLeft 2 ℂ ℂ
+        (Equiv.arrowCongr (finCongr (Nat.add_assoc K l q)) (Equiv.refl (Fin d))))
+        (leftBoundaryMapES A (K + l) q y))) =
+      ∑ u : Cfg d K, ∑ j : Cfg d q,
+        inner ℂ
+          (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+            (evalWord A (List.ofFn j) *
+              boundaryFamilyEquiv (D := D) (Cfg d K) x u))
+          (groundSpaceGram A l
+            (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
+              (boundaryFamilyEquiv (D := D) (Cfg d q) y j *
+                evalWord A (List.ofFn u)))) := by
+  rw [ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
+  trans ∑ p : Cfg d K × (Cfg d l × Cfg d q),
+      inner ℂ
+        ((tailBoundaryMapES A K (l + q) x) (cfgAppendThreeEquiv d K l q p))
+        ((leftBoundaryMapES A (K + l) q y)
+          ((Equiv.arrowCongr (finCongr (Nat.add_assoc K l q))
+            (Equiv.refl (Fin d))).symm (cfgAppendThreeEquiv d K l q p)))
+  · symm
+    apply Fintype.sum_equiv (cfgAppendThreeEquiv d K l q)
+    intro p
+    rfl
+  · simp only [Fintype.sum_prod_type]
+    apply Finset.sum_congr rfl
+    intro u _
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [groundSpaceGram, ContinuousLinearMap.comp_apply,
+      ContinuousLinearMap.adjoint_inner_right,
+      groundSpaceMapES_frobeniusEquivEuclidean_apply,
+      groundSpaceMapES_frobeniusEquivEuclidean_apply, PiLp.inner_apply]
+    apply Finset.sum_congr rfl
+    intro τ _
+    have hTailPrefix :
+        Fin.append u (Fin.append τ j) ∘ Fin.castAdd (l + q) = u := by
+      ext i
+      simp [Fin.append_left]
+    have hTailSuffix :
+        Fin.append u (Fin.append τ j) ∘ Fin.natAdd K = Fin.append τ j := by
+      ext i
+      simp [Fin.append_right]
+    have hAssoc :
+        (Equiv.arrowCongr (finCongr (Nat.add_assoc K l q))
+          (Equiv.refl (Fin d))).symm (Fin.append u (Fin.append τ j)) =
+            Fin.append (Fin.append u τ) j := by
+      rw [Equiv.arrowCongr_symm]
+      ext i
+      rw [Equiv.arrowCongr_apply]
+      simp only [Function.comp_apply, Equiv.refl_symm, Equiv.refl_apply,
+        finCongr_symm, finCongr_apply]
+      apply congrArg Fin.val
+      exact congrFun (Fin.append_assoc u τ j).symm i
+    have hLeftPrefix :
+        (Equiv.arrowCongr (finCongr (Nat.add_assoc K l q))
+            (Equiv.refl (Fin d))).symm (Fin.append u (Fin.append τ j)) ∘
+              Fin.castAdd q = Fin.append u τ := by
+      rw [hAssoc]
+      ext i
+      simp [Fin.append_left]
+    have hLeftSuffix :
+        (Equiv.arrowCongr (finCongr (Nat.add_assoc K l q))
+            (Equiv.refl (Fin d))).symm (Fin.append u (Fin.append τ j)) ∘
+              Fin.natAdd (K + l) = j := by
+      rw [hAssoc]
+      ext i
+      simp [Fin.append_right]
+    have hTailTrace :
+        Matrix.trace
+            (evalWord A (List.ofFn (Fin.append τ j)) *
+              boundaryFamilyEquiv (D := D) (Cfg d K) x u) =
+          Matrix.trace
+            (evalWord A (List.ofFn τ) *
+              (evalWord A (List.ofFn j) *
+                boundaryFamilyEquiv (D := D) (Cfg d K) x u)) := by
+      rw [List.ofFn_fin_append, evalWord_append]
+      simp only [Matrix.mul_assoc]
+    have hLeftTrace :
+        Matrix.trace
+            (evalWord A (List.ofFn (Fin.append u τ)) *
+              boundaryFamilyEquiv (D := D) (Cfg d q) y j) =
+          Matrix.trace
+            (evalWord A (List.ofFn τ) *
+              (boundaryFamilyEquiv (D := D) (Cfg d q) y j *
+                evalWord A (List.ofFn u))) := by
+      rw [List.ofFn_fin_append, evalWord_append]
+      symm
+      simpa only [Matrix.mul_assoc] using Matrix.trace_mul_cycle
+        (evalWord A (List.ofFn τ))
+        (boundaryFamilyEquiv (D := D) (Cfg d q) y j)
+        (evalWord A (List.ofFn u))
+    simp only [tailBoundaryMapES_apply, WithLp.linearEquiv_symm_apply,
+      AddEquiv.toEquiv_eq_coe, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
+      WithLp.addEquiv_symm_apply, cfgAppendThreeEquiv_apply,
+      tailBoundaryMap_apply, boundaryFamilyEquiv_apply_apply,
+      leftBoundaryMapES_apply, leftBoundaryMap_apply, RCLike.inner_apply,
+      groundSpaceMap_apply, hTailPrefix, hTailSuffix, hLeftPrefix, hLeftSuffix]
+    simp only [boundaryFamilyEquiv_apply_apply] at hTailTrace hLeftTrace
+    rw [hLeftTrace]
+    rw [hTailTrace]
 
 /-- Exact mixed-Gram identity for the overlapping windows in Nachtergaele's C3
 geometry (arXiv:cond-mat/9410110, equation (2.4)).
@@ -74,89 +194,11 @@ theorem inner_tailBoundaryMapES_adjoint_leftBoundaryMapES
             (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)
               (boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
                 evalWord A (List.ofFn u)))) := by
-  rw [ContinuousLinearMap.adjoint_inner_right, PiLp.inner_apply]
-  trans ∑ p : Cfg d K × (Cfg d l × Cfg d 1),
-      inner ℂ
-        ((tailBoundaryMapES A K (l + 1) x) (cfgAppendThreeEquiv d K l 1 p))
-        ((leftBoundaryMapES A (K + l) 1 y) (cfgAppendThreeEquiv d K l 1 p))
-  · symm
-    apply Fintype.sum_equiv (cfgAppendThreeEquiv d K l 1)
-    intro p
-    rfl
-  · simp only [Fintype.sum_prod_type]
-    apply Finset.sum_congr rfl
-    intro u _
-    rw [Finset.sum_comm]
-    apply Finset.sum_congr rfl
-    intro j _
-    rw [groundSpaceGram, ContinuousLinearMap.comp_apply,
-      ContinuousLinearMap.adjoint_inner_right,
-      groundSpaceMapES_frobeniusEquivEuclidean_apply,
-      groundSpaceMapES_frobeniusEquivEuclidean_apply, PiLp.inner_apply]
-    apply Finset.sum_congr rfl
-    intro τ _
-    have hTailPrefix :
-        Fin.append u (Fin.append τ j) ∘ Fin.castAdd (l + 1) = u := by
-      ext i
-      simp [Fin.append_left]
-    have hTailSuffix :
-        Fin.append u (Fin.append τ j) ∘ Fin.natAdd K = Fin.append τ j := by
-      ext i
-      simp [Fin.append_right]
-    have hLeftPrefix :
-        Fin.append u (Fin.append τ j) ∘ Fin.castAdd 1 = Fin.append u τ := by
-      ext i
-      have hi := congrFun (Fin.append_assoc u τ j) (Fin.castAdd 1 i)
-      apply congrArg Fin.val
-      simpa using hi.symm
-    have hLeftSuffix :
-        Fin.append u (Fin.append τ j) ∘ Fin.natAdd (K + l) = j := by
-      ext i
-      have hi := congrFun (Fin.append_assoc u τ j) (Fin.natAdd (K + l) i)
-      apply congrArg Fin.val
-      simpa using hi.symm
-    have hTailTrace :
-        Matrix.trace
-            (evalWord A (List.ofFn (Fin.append τ j)) *
-              boundaryFamilyEquiv (D := D) (Cfg d K) x u) =
-          Matrix.trace
-            (evalWord A (List.ofFn τ) *
-              (evalWord A (List.ofFn j) *
-                boundaryFamilyEquiv (D := D) (Cfg d K) x u)) := by
-      rw [List.ofFn_fin_append, evalWord_append]
-      simp only [Matrix.mul_assoc]
-    have hLeftTrace :
-        Matrix.trace
-            (evalWord A (List.ofFn (Fin.append u τ)) *
-              boundaryFamilyEquiv (D := D) (Cfg d 1) y j) =
-          Matrix.trace
-            (evalWord A (List.ofFn τ) *
-              (boundaryFamilyEquiv (D := D) (Cfg d 1) y j *
-                evalWord A (List.ofFn u))) := by
-      rw [List.ofFn_fin_append, evalWord_append]
-      symm
-      simpa only [Matrix.mul_assoc] using Matrix.trace_mul_cycle
-        (evalWord A (List.ofFn τ))
-        (boundaryFamilyEquiv (D := D) (Cfg d 1) y j)
-        (evalWord A (List.ofFn u))
-    simp only [tailBoundaryMapES_apply, WithLp.linearEquiv_symm_apply,
-      AddEquiv.toEquiv_eq_coe, Equiv.invFun_as_coe, AddEquiv.coe_toEquiv_symm,
-      WithLp.addEquiv_symm_apply, cfgAppendThreeEquiv_apply,
-      tailBoundaryMap_apply, List.ofFn_succ, evalWord_cons,
-      boundaryFamilyEquiv_apply_apply,
-      leftBoundaryMapES_apply, leftBoundaryMap_apply, RCLike.inner_apply,
-      Fin.isValue, List.ofFn_zero, evalWord_nil, Matrix.mul_one,
-      groundSpaceMap_apply, hTailPrefix, hTailSuffix, hLeftPrefix, hLeftSuffix]
-    simp only [boundaryFamilyEquiv_apply_apply] at hTailTrace hLeftTrace
-    rw [hLeftTrace]
-    have hEvalAppend :
-        A (Fin.append τ j 0) *
-            evalWord A (List.ofFn fun i => Fin.append τ j i.succ) =
-          evalWord A (List.ofFn (Fin.append τ j)) := by
-      rw [List.ofFn_succ, evalWord_cons]
-    rw [hEvalAppend, hTailTrace]
-    simp only [List.ofFn_succ, List.ofFn_zero, evalWord_cons, evalWord_nil,
-      Matrix.mul_one]
+  convert inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q A K l 1 x y using 1
+  apply congrArg (fun z => inner ℂ x ((tailBoundaryMapES A K (l + 1)).adjoint z))
+  apply PiLp.ext
+  intro σ
+  rfl
 
 /-- Exact centering of the overlapping mixed Gram at the nonidentity limiting
 Gram metric.

--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -26,7 +26,7 @@ is asserted here.
 
 * `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q`
 * `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES`
-* `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered
+* `inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered`
 -/
 
 open scoped Matrix
@@ -167,6 +167,10 @@ theorem inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q
     simp only [boundaryFamilyEquiv_apply_apply] at hTailTrace hLeftTrace
     rw [hLeftTrace]
     rw [hTailTrace]
+
+-- A formulation that first reassociates the tail map into the left-associated
+-- ambient space should derive from this theorem by adjoint composition with the
+-- same unitary coordinate reassociation, rather than repeat the coordinate proof.
 
 /-- Exact mixed-Gram identity for the overlapping windows in Nachtergaele's C3
 geometry (arXiv:cond-mat/9410110, equation (2.4)).

--- a/TNLean/MPS/ParentHamiltonian/MixedGram.lean
+++ b/TNLean/MPS/ParentHamiltonian/MixedGram.lean
@@ -168,9 +168,15 @@ theorem inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q
     rw [hLeftTrace]
     rw [hTailTrace]
 
--- A formulation that first reassociates the tail map into the left-associated
--- ambient space should derive from this theorem by adjoint composition with the
--- same unitary coordinate reassociation, rather than repeat the coordinate proof.
+-- Reuse relation for GitHub pull request 6299: the `piLpCongrLeft` map in this
+-- theorem transports the left-window codomain from \(Cfg\ d\ ((K+l)+q)\) to
+-- \(Cfg\ d\ (K+(l+q))\). If \(U\) denotes its inverse unitary and
+-- \(T=\mathtt{tailBoundaryMapES}\ A\ K\ (l+q)\), then the left-associated tail
+-- map there is \(U\circ T\), and
+-- \((U\circ T)^\dagger L=T^\dagger(U^\dagger L)\). Hence its reassociated
+-- mixed-Gram theorem is this identity transported by \(U\), with the same
+-- right-hand side; it is a wrapper around this theorem, not a second coordinate
+-- proof.
 
 /-- Exact mixed-Gram identity for the overlapping windows in Nachtergaele's C3
 geometry (arXiv:cond-mat/9410110, equation (2.4)).

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -428,20 +428,22 @@ norm estimate is derived here.
     The preceding range equalities identify the three physical ranges.
 \end{proof}
 
-\begin{theorem}[Mixed Gram of the overlapping spectator boundary maps]%
+\begin{theorem}[Arbitrary-increment mixed Gram of the overlapping spectator boundary maps]%
     \label{thm:spectator_boundary_mixed_gram}
+    \lean{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q}
     \lean{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}
     \leanok
     \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram}
-    Let $X=(X_u)_{u\in\Fin d^K}$ and
-    $Z=(Z_j)_{j\in\Fin d^1}$ be virtual boundary-matrix families.  For the
-    tail window of length $l+1$ and the left window of length $K+l$, their
-    mixed Gram in the common $(K+l+1)$-site Hilbert space is
+    Let $q\in\mathbb N$, let $X=(X_u)_{u\in\Fin d^K}$, and let
+    $Z=(Z_j)_{j\in\Fin d^q}$ be virtual boundary-matrix families.  After the
+    canonical identification of $K+(l+q)$ with $(K+l)+q$, the mixed Gram for
+    the tail window of length $l+q$ and the left window with a $q$-site
+    increment is
     \begin{align}
       \left\langle X,
-        (\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
-        \Gamma^{\mathrm{left}}_{K+l,1}Z\right\rangle
-      &=\sum_{u\in\Fin d^K}\sum_{j\in\Fin d^1}
+        (\Gamma^{\mathrm{tail}}_{K,l+q})^\dagger
+        \Gamma^{\mathrm{left}}_{K+l,q}Z\right\rangle
+      &=\sum_{u\in\Fin d^K}\sum_{j\in\Fin d^q}
         \left\langle
           U(A^jX_u),\,
           \mathcal K_l\,U(Z_jA^u)
@@ -452,19 +454,21 @@ norm estimate is derived here.
     fixed by
     $\tr(A^{\tau,j}X_u)=\tr(A^\tau(A^jX_u))$ and
     $\tr(A^{u,\tau}Z_j)=\tr(A^\tau(Z_jA^u))$.
-    This exact identity is obtained from the definitions and trace cyclicity;
-    it is not the numerical FNW contraction quoted in
-    \cite[after Equation~(2.4) and Equation~(6.1)]{Nachtergaele1996Spectral}.
+    The one-site identity is the specialization $q=1$.  This is the exact
+    algebraic whole-increment identity relevant to condition C3$'$ in
+    \cite[Equation~(2.5)]{Nachtergaele1996Spectral}; it does not prove the
+    norm estimate, uniformity in $q$, or any numerical contraction required
+    there.
 \end{theorem}
 \begin{proof}
     \leanok
     \uses{def:tail_boundary_map,def:left_boundary_map,def:ground_space_gram,
         lem:eval_word_append,thm:ground_space_map_es_frobenius}
     Split a physical configuration into a prefix $u$, an overlap word $\tau$
-    of length $l$, and a final-site configuration $j$.  The adjoint relation
-    turns the mixed Gram into the physical inner product of the two boundary
-    vectors.  For each $(u,\tau,j)$, word multiplicativity and trace cyclicity
-    give
+    of length $l$, and an increment configuration $j$ of length $q$.  The
+    adjoint relation turns the mixed Gram into the physical inner product of
+    the two boundary vectors.  For each $(u,\tau,j)$, word multiplicativity
+    and trace cyclicity give
     \begin{align}
       \tr(A^{\tau,j}X_u)&=\tr(A^\tau(A^jX_u)),&
       \tr(A^{u,\tau}Z_j)&=\tr(A^\tau(Z_jA^u)).
@@ -472,7 +476,8 @@ norm estimate is derived here.
     For fixed $(u,j)$, summing the resulting inner products over $\tau$ is
     exactly the boundary-map Gram pairing
     $\langle U(A^jX_u),\mathcal K_l U(Z_jA^u)\rangle$.  Summing over $u$ and
-    $j$ proves the identity.
+    $j$ proves the arbitrary-increment identity; setting $q=1$ gives the
+    original formula.
 \end{proof}
 
 \begin{theorem}[Centered mixed Gram at the limiting metric]%

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -485,9 +485,11 @@ norm estimate is derived here.
     \lean{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_centered}
     \leanok
     \uses{thm:spectator_boundary_mixed_gram,thm:fixed_point_gram_metric_exact}
-    Let $\rho\in\MN{D}$ have nonzero trace, let
-    $\mathcal K_\infty=\mathscr R(P_\rho)$, and retain the boundary families
-    $X=(X_u)_u$ and $Z=(Z_j)_j$ from the preceding theorem.  Then
+    Specialize the preceding theorem to $q=1$.  Let
+    $X=(X_u)_{u\in\Fin d^K}$ and
+    $Z=(Z_j)_{j\in\Fin d^1}$ be the resulting boundary families.  If
+    $\rho\in\MN{D}$ has nonzero trace and
+    $\mathcal K_\infty=\mathscr R(P_\rho)$, then
     \begin{align}
       &\left\langle X,
         (\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -754,8 +754,9 @@ and generic prerequisites now include:
     These are exact unweighted identities, including empty spectator types;
     they assert no direct-sum norm estimate.  The C3 specializations are stated
     next.
-  \item The arbitrary-increment mixed Gram of the tail map at
-    \((K,l+q)\) and left map at \((K+l,q)\), after the canonical reassociation
+  \item Fix an increment length \(q\in\mathbb N\).  The arbitrary-increment
+    mixed Gram of the tail map at \((K,l+q)\) and left map at \((K+l,q)\),
+    after the canonical reassociation
     of their common configuration space, is computed exactly by
     \leanid{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q}.
     Write \(\Gamma^{\mathrm{tail}}_{K,l+q}\) and

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -754,29 +754,32 @@ and generic prerequisites now include:
     These are exact unweighted identities, including empty spectator types;
     they assert no direct-sum norm estimate.  The C3 specializations are stated
     next.
-  \item The mixed Gram of the C3 tail map at
-    \((K,l+1)\) and left map at \((K+l,1)\) is computed exactly by
-    \leanid{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}.
-    Write \(\Gamma^{\mathrm{tail}}_{K,l+1}\) and
-    \(\Gamma^{\mathrm{left}}_{K+l,1}\) for these two Hilbert-space maps.
+  \item The arbitrary-increment mixed Gram of the tail map at
+    \((K,l+q)\) and left map at \((K+l,q)\), after the canonical reassociation
+    of their common configuration space, is computed exactly by
+    \leanid{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q}.
+    Write \(\Gamma^{\mathrm{tail}}_{K,l+q}\) and
+    \(\Gamma^{\mathrm{left}}_{K+l,q}\) for these two Hilbert-space maps.
     For boundary-family vectors \(x\) and \(y\), write \(X_u\) and \(Z_j\)
     for their matrix fibers.  Then
     \begin{align}
       \left\langle x,
-        (\Gamma^{\mathrm{tail}}_{K,l+1})^\dagger
-        \Gamma^{\mathrm{left}}_{K+l,1}y\right\rangle
-      &=\sum_{u\in\Fin d^K}\sum_{j\in\Fin d^1}
+        (\Gamma^{\mathrm{tail}}_{K,l+q})^\dagger
+        \Gamma^{\mathrm{left}}_{K+l,q}y\right\rangle
+      &=\sum_{u\in\Fin d^K}\sum_{j\in\Fin d^q}
         \left\langle U(A^jX_u),
           \mathcal K_l U(Z_jA^u)\right\rangle.
     \end{align}
-    This formula is an exact algebraic identity reconstructed from the
-    boundary-map definitions, word factorization, and trace cyclicity.  It is
-    not stated in
-    this form by FNW or Nachtergaele and is not attributed to them.  The
-    sourced target remains the projector defect in Nachtergaele's equation
-    (2.4), while the rational estimate is quoted after that equation and in
-    equation (6.1).  No mixed-Gram norm estimate follows from this identity
-    alone.
+    The theorem
+    \leanid{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}
+    is its specialization to \(q=1\).  These formulas are exact algebraic
+    identities reconstructed from the boundary-map definitions, word
+    factorization, and trace cyclicity.  They are not stated in this form by
+    FNW or Nachtergaele and are not attributed to them.  The whole-increment
+    identity matches the index geometry of C3$'$ in Nachtergaele's equation
+    (2.5), but it does not prove the analytic norm estimate, its uniformity in
+    the increment, or a numerical contraction coefficient.  Those remain the
+    open step in issue~\#6152.
   \item For injective maps with common factorizations
     \(T J_1=C=L J_2\),
     \leanid{ContinuousLinearMap.injectiveRangeProjector_comp_sub_of_factorizations}


### PR DESCRIPTION
## Summary

- prove the exact arbitrary-increment mixed-Gram identity with suffix family `Cfg d q`
- canonically reassociate the common physical space from `(K + l) + q` to `K + (l + q)` while preserving the prefix/overlap/increment ordering
- derive the existing one-site theorem from the new result at `q = 1`
- update Chapter 13 and the martingale paper-gap note to separate this algebraic whole-increment leaf from the open C3-prime analytic estimate

## Source scope

The indexing follows Nachtergaele's C3-prime geometry in equation (2.5), but the displayed mixed-Gram formula is reconstructed from the existing boundary-map definitions, word factorization, and trace cyclicity. This PR asserts no norm bound, uniformity, numerical contraction, or attribution of the reconstructed identity to FNW or Nachtergaele.

## Checks

- `lake env lean TNLean/MPS/ParentHamiltonian/MixedGram.lean`
- import/declaration check for both mixed-Gram theorems
- proof-integrity scan of the changed Lean file
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls` (all references in sync)
- `git diff --check`

`leanblueprint checkdecls` reaches the known broad-import collision: `MPSTensor.coisometryExtendGL` is already present from `TNLean.MPS.SharedInfra.CoisometryGauge` when importing `TNLean.MPS.CanonicalForm.CPSVCanonicalFormII`. The new declaration itself was checked through a direct import of `MixedGram`.

Closes #6297

Parent: #6152

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style algebraic extensions and doc/blueprint sync in parent-Hamiltonian spectator Gram machinery; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds an **exact arbitrary-increment mixed-Gram identity** (`inner_tailBoundaryMapES_adjoint_leftBoundaryMapES_q`) for tail length \(l+q\) and left windows with a \(q\)-site suffix family, including canonical reindexing \((K+l)+q \cong K+(l+q)\) via `piLpCongrLeft` / `finCongr (Nat.add_assoc ...)`.
> 
> The former one-site theorem is now a **`q = 1` specialization** proved by `convert` from the general result instead of a separate coordinate proof; the centered mixed-Gram theorem is unchanged.
> 
> **Blueprint Chapter 13** and the **martingale paper-gap note** are updated to state the whole-increment formula (C3′ / eq. 2.5 indexing) and to stress that this is **algebraic only**—no norm bound, uniformity in \(q\), or FNW contraction is claimed (still tracked as open work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 698ffec0ca464d255ad416c8c04ea7bc3b863d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->