### PR TITLE
feat(Channel/Peripheral): prove Wolf's asymptotic-image proposition

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -22,6 +22,7 @@ import TNLean.Algebra.CornerCompression
 import TNLean.Algebra.CornerSkolemNoether
 import TNLean.Algebra.DependentBlockDiagonal
 import TNLean.Algebra.DirectedWalkCoboundary
+import TNLean.Algebra.EigenspaceMap
 import TNLean.Algebra.EigenvectorProjection
 import TNLean.Algebra.EqualRangeRightFactor
 import TNLean.Algebra.EventuallyConstantCycleWeights

--- a/TNLean/Algebra/EigenspaceMap.lean
+++ b/TNLean/Algebra/EigenspaceMap.lean
@@ -12,7 +12,7 @@ An endomorphism acts on its `μ`-eigenspace as multiplication by `μ`.  When
 `μ ≠ 0` that action is invertible, so the eigenspace is mapped *onto* itself
 and not merely into itself.
 
-## Main statements
+## Main results
 
 * `Module.End.map_eigenspace_of_ne_zero`: `f (ker (f - μ)) = ker (f - μ)` for
   `μ ≠ 0`.

--- a/TNLean/Algebra/EigenspaceMap.lean
+++ b/TNLean/Algebra/EigenspaceMap.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Eigenspace.Basic
+
+/-!
+# Images of eigenspaces
+
+An endomorphism acts on its `μ`-eigenspace as multiplication by `μ`.  When
+`μ ≠ 0` that action is invertible, so the eigenspace is mapped *onto* itself
+and not merely into itself.
+
+## Main statements
+
+* `Module.End.map_eigenspace_of_ne_zero`: `f (ker (f - μ)) = ker (f - μ)` for
+  `μ ≠ 0`.
+-/
+
+namespace Module.End
+
+variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V]
+
+/-- An eigenspace for a **nonzero** eigenvalue is mapped *onto* itself: on the
+`μ`-eigenspace the endomorphism acts as multiplication by `μ`, which is
+invertible when `μ ≠ 0`. -/
+theorem map_eigenspace_of_ne_zero (f : Module.End K V) {μ : K} (hμ : μ ≠ 0) :
+    Submodule.map f (f.eigenspace μ) = f.eigenspace μ := by
+  refine le_antisymm ?_ fun y hy ↦ ?_
+  · rintro _ ⟨x, hx, rfl⟩
+    rw [Module.End.mem_eigenspace_iff.mp hx]
+    exact (f.eigenspace μ).smul_mem μ hx
+  · refine ⟨μ⁻¹ • y, (f.eigenspace μ).smul_mem _ hy, ?_⟩
+    rw [map_smul, Module.End.mem_eigenspace_iff.mp hy, smul_smul, inv_mul_cancel₀ hμ,
+      one_smul]
+
+end Module.End

--- a/TNLean/Channel/Peripheral.lean
+++ b/TNLean/Channel/Peripheral.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.Channel.Peripheral
 
+import TNLean.Channel.Peripheral.AsymptoticImage
 import TNLean.Channel.Peripheral.CesaroRecurrence
 import TNLean.Channel.Peripheral.ClosureFixedPoint
 import TNLean.Channel.Peripheral.ClosureFixedPointKraus

--- a/TNLean/Channel/Peripheral/AsymptoticImage.lean
+++ b/TNLean/Channel/Peripheral/AsymptoticImage.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.EigenspaceMap
-import TNLean.Channel.Peripheral.CesaroRecurrence
 import TNLean.Channel.FixedPoint.StationarySpan
+import TNLean.Channel.Peripheral.CesaroRecurrence
 
 /-!
 # The asymptotic image — Wolf's proposition on `X_T`

--- a/TNLean/Channel/Peripheral/AsymptoticImage.lean
+++ b/TNLean/Channel/Peripheral/AsymptoticImage.lean
@@ -1,0 +1,179 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Peripheral.CesaroRecurrence
+import TNLean.Channel.FixedPoint.StationarySpan
+
+/-!
+# The asymptotic image — Wolf's proposition on `X_T`
+
+Let `T : M_d(ℂ) → M_d(ℂ)` be a positive trace-preserving linear map and let
+
+`X_T := span {X | ∃ φ : ℝ, T X = exp (i φ) • X}`
+
+be the span of the peripheral eigenvectors of Wolf Equation (6.65).  Wolf's
+proposition on the *asymptotic image* describes `X_T` through the peripheral
+spectral projection `T_φ` of Wolf Equation (6.12):
+
+1. `T_φ (M_d(ℂ)) = X_T`,
+2. there are positive semidefinite `ρ_i` with `X_T = span {ρ_i}`,
+3. `T (X_T) = X_T`.
+
+The proof follows Wolf.  Clause 1 records that `X_T` is exactly the set of
+fixed points of `T_φ`, which for a projection is its image.  Clause 2 applies
+Wolf Corollary 6.8 (`IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities`)
+to `T_φ`, which is itself positive and trace-preserving.  Clause 3 expands an
+element of `X_T` in peripheral eigenvectors: on the `μ`-eigenspace `T` acts as
+multiplication by the unit phase `μ`, and a nonzero scalar maps an eigenspace
+onto itself.
+
+## Main statements
+
+* `Module.End.map_eigenspace_of_ne_zero`: an eigenspace for a nonzero
+  eigenvalue is mapped onto itself.
+* `IsPositiveMap.fixedPointsSubmodule_peripheralProjection`: `X_T` is the
+  fixed-point space of `T_φ`.
+* `IsPositiveMap.range_peripheralProjection_eq_iSup_eigenspace`: clause 1.
+* `IsPositiveMap.span_stationaryDensity_peripheralProjection_eq_peripheralSubspace`
+  and `IsPositiveMap.exists_posSemidef_span_eq_iSup_eigenspace`: clause 2.
+* `IsPositiveMap.map_peripheralSubspace`: clause 3.
+* `IsPositiveMap.asymptotic_image`: the three clauses together.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition
+  (Asymptotic image) and Equation (6.65); local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1568--1590.
+-/
+
+open scoped ComplexOrder
+open Matrix
+
+namespace Module.End
+
+variable {V : Type*} [AddCommGroup V] [Module ℂ V]
+
+/-- An eigenspace for a **nonzero** eigenvalue is mapped *onto* itself: on the
+`μ`-eigenspace the endomorphism acts as multiplication by `μ`, which is
+invertible when `μ ≠ 0`.
+
+This is the one-eigenvalue case of the third clause of Wolf's proposition on
+the asymptotic image; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1568--1590. -/
+theorem map_eigenspace_of_ne_zero (f : Module.End ℂ V) {μ : ℂ} (hμ : μ ≠ 0) :
+    Submodule.map f (f.eigenspace μ) = f.eigenspace μ := by
+  refine le_antisymm ?_ fun y hy ↦ ?_
+  · rintro _ ⟨x, hx, rfl⟩
+    rw [Module.End.mem_eigenspace_iff.mp hx]
+    exact (f.eigenspace μ).smul_mem μ hx
+  · refine ⟨μ⁻¹ • y, (f.eigenspace μ).smul_mem _ hy, ?_⟩
+    rw [map_smul, Module.End.mem_eigenspace_iff.mp hy, smul_smul, inv_mul_cancel₀ hμ,
+      one_smul]
+
+end Module.End
+
+namespace IsPositiveMap
+
+variable {D : ℕ} [NeZero D] {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+
+omit [NeZero D] in
+/-- The peripheral subspace `X_T` is exactly the fixed-point space of the
+peripheral spectral projection `T_φ`.  This is Wolf's observation that "`X_T`
+coincides with the space of fixed points of `T_φ`"; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1568--1590. -/
+theorem fixedPointsSubmodule_peripheralProjection
+    (f : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) :
+    fixedPointsSubmodule f.peripheralProjection = f.peripheralSubspace := by
+  ext X
+  rw [mem_fixedPointsSubmodule, Module.End.peripheralProjection_apply_eq_self_iff]
+
+/-- **Wolf, asymptotic image, clause 1**: `T_φ (M_d(ℂ)) = X_T`, where `X_T` is
+the span of the peripheral eigenvectors of Wolf Equation (6.65).
+
+The image of the projection `T_φ` is its fixed-point space, which is the
+peripheral spectral subspace; for a positive trace-preserving map the
+peripheral Jordan blocks are trivial (Wolf Proposition 6.2), so that subspace
+is the span of the peripheral eigenspaces.
+
+Source: Wolf §6, lines 1568--1590; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
+theorem range_peripheralProjection_eq_iSup_eigenspace
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    LinearMap.range T.peripheralProjection =
+      ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ := by
+  rw [Module.End.range_peripheralProjection, hPos.peripheralSubspace_eq_iSup_eigenspace hTP]
+
+/-- **Wolf, asymptotic image, clause 2**, spanning form: `X_T` is spanned by
+the stationary density matrices of `T_φ`.
+
+Wolf derives this from clause 1 together with Corollary 6.8: the peripheral
+projection of a positive trace-preserving map is again positive and
+trace-preserving, and Corollary 6.8 spans the fixed-point space of such a map
+by stationary density matrices.
+
+Source: Wolf §6, lines 1568--1590; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
+theorem span_stationaryDensity_peripheralProjection_eq_peripheralSubspace
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    Submodule.span ℂ {ρ | IsStationaryDensity T.peripheralProjection ρ} =
+      T.peripheralSubspace := by
+  rw [fixedPointsSubmodule_spanned_by_stationaryDensities _
+      (hPos.peripheralProjection_isPositiveMap hTP)
+      (hPos.peripheralProjection_isTracePreservingMap hTP),
+    fixedPointsSubmodule_peripheralProjection]
+
+/-- **Wolf, asymptotic image, clause 2**: there exist positive semidefinite
+matrices whose span is `X_T`.
+
+Source: Wolf §6, lines 1568--1590; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
+theorem exists_posSemidef_span_eq_iSup_eigenspace
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    ∃ S : Set (Matrix (Fin D) (Fin D) ℂ), (∀ ρ ∈ S, ρ.PosSemidef) ∧
+      Submodule.span ℂ S = ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ :=
+  ⟨{ρ | IsStationaryDensity T.peripheralProjection ρ},
+    fun _ hρ ↦ IsStationaryDensity.posSemidef hρ, by
+      rw [hPos.span_stationaryDensity_peripheralProjection_eq_peripheralSubspace hTP,
+        hPos.peripheralSubspace_eq_iSup_eigenspace hTP]⟩
+
+/-- **Wolf, asymptotic image, clause 3**: `T (X_T) = X_T`.
+
+Expanding an element of `X_T` in peripheral eigenvectors reduces the claim to
+one eigenspace at a time, and there `T` acts as multiplication by a unit
+phase, which is invertible.
+
+Source: Wolf §6, lines 1568--1590; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
+theorem map_peripheralSubspace
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    Submodule.map T T.peripheralSubspace = T.peripheralSubspace := by
+  rw [hPos.peripheralSubspace_eq_iSup_eigenspace hTP, Submodule.map_iSup]
+  refine iSup_congr fun μ ↦ ?_
+  rw [Submodule.map_iSup]
+  exact iSup_congr fun hμ ↦
+    T.map_eigenspace_of_ne_zero (norm_ne_zero_iff.mp (by rw [hμ.2]; exact one_ne_zero))
+
+/-- **Wolf, Proposition (Asymptotic image).**  For a positive trace-preserving
+linear map `T` on `M_d(ℂ)`, write `X_T` for the span of the peripheral
+eigenvectors of Wolf Equation (6.65).  Then
+
+1. `T_φ (M_d(ℂ)) = X_T`,
+2. there are positive semidefinite matrices whose span is `X_T`,
+3. `T (X_T) = X_T`.
+
+Source: Wolf §6, lines 1568--1590; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
+theorem asymptotic_image (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    (LinearMap.range T.peripheralProjection =
+        ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ) ∧
+      (∃ S : Set (Matrix (Fin D) (Fin D) ℂ), (∀ ρ ∈ S, ρ.PosSemidef) ∧
+        Submodule.span ℂ S = ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ) ∧
+      Submodule.map T (⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ) =
+        ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ :=
+  ⟨hPos.range_peripheralProjection_eq_iSup_eigenspace hTP,
+    hPos.exists_posSemidef_span_eq_iSup_eigenspace hTP, by
+      rw [← hPos.peripheralSubspace_eq_iSup_eigenspace hTP, hPos.map_peripheralSubspace hTP]⟩
+
+end IsPositiveMap

--- a/TNLean/Channel/Peripheral/AsymptoticImage.lean
+++ b/TNLean/Channel/Peripheral/AsymptoticImage.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.EigenspaceMap
 import TNLean.Channel.Peripheral.CesaroRecurrence
 import TNLean.Channel.FixedPoint.StationarySpan
 
@@ -23,16 +24,16 @@ spectral projection `T_φ` of Wolf Equation (6.12):
 
 The proof follows Wolf.  Clause 1 records that `X_T` is exactly the set of
 fixed points of `T_φ`, which for a projection is its image.  Clause 2 applies
-Wolf Corollary 6.8 (`IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities`)
-to `T_φ`, which is itself positive and trace-preserving.  Clause 3 expands an
+Wolf Corollary 6.5, Linearly independent stationary states
+(`IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities`), to
+`T_φ`, which is itself positive and trace-preserving; this is the corollary
+Wolf's own proof of the proposition invokes at this step.  Clause 3 expands an
 element of `X_T` in peripheral eigenvectors: on the `μ`-eigenspace `T` acts as
 multiplication by the unit phase `μ`, and a nonzero scalar maps an eigenspace
-onto itself.
+onto itself (`Module.End.map_eigenspace_of_ne_zero`).
 
 ## Main statements
 
-* `Module.End.map_eigenspace_of_ne_zero`: an eigenspace for a nonzero
-  eigenvalue is mapped onto itself.
 * `IsPositiveMap.fixedPointsSubmodule_peripheralProjection`: `X_T` is the
   fixed-point space of `T_φ`.
 * `IsPositiveMap.range_peripheralProjection_eq_iSup_eigenspace`: clause 1.
@@ -43,36 +44,15 @@ onto itself.
 
 ## References
 
-* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 6.12
   (Asymptotic image) and Equation (6.65); local source
   `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1568--1590.
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.5
+  (Linearly independent stationary states); local source, lines 1204--1212.
 -/
 
 open scoped ComplexOrder
 open Matrix
-
-namespace Module.End
-
-variable {V : Type*} [AddCommGroup V] [Module ℂ V]
-
-/-- An eigenspace for a **nonzero** eigenvalue is mapped *onto* itself: on the
-`μ`-eigenspace the endomorphism acts as multiplication by `μ`, which is
-invertible when `μ ≠ 0`.
-
-This is the one-eigenvalue case of the third clause of Wolf's proposition on
-the asymptotic image; local source
-`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1568--1590. -/
-theorem map_eigenspace_of_ne_zero (f : Module.End ℂ V) {μ : ℂ} (hμ : μ ≠ 0) :
-    Submodule.map f (f.eigenspace μ) = f.eigenspace μ := by
-  refine le_antisymm ?_ fun y hy ↦ ?_
-  · rintro _ ⟨x, hx, rfl⟩
-    rw [Module.End.mem_eigenspace_iff.mp hx]
-    exact (f.eigenspace μ).smul_mem μ hx
-  · refine ⟨μ⁻¹ • y, (f.eigenspace μ).smul_mem _ hy, ?_⟩
-    rw [map_smul, Module.End.mem_eigenspace_iff.mp hy, smul_smul, inv_mul_cancel₀ hμ,
-      one_smul]
-
-end Module.End
 
 namespace IsPositiveMap
 
@@ -97,7 +77,7 @@ peripheral spectral subspace; for a positive trace-preserving map the
 peripheral Jordan blocks are trivial (Wolf Proposition 6.2), so that subspace
 is the span of the peripheral eigenspaces.
 
-Source: Wolf §6, lines 1568--1590; local source
+Source: Wolf Proposition 6.12, lines 1568--1590; local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
 theorem range_peripheralProjection_eq_iSup_eigenspace
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
@@ -108,12 +88,13 @@ theorem range_peripheralProjection_eq_iSup_eigenspace
 /-- **Wolf, asymptotic image, clause 2**, spanning form: `X_T` is spanned by
 the stationary density matrices of `T_φ`.
 
-Wolf derives this from clause 1 together with Corollary 6.8: the peripheral
+Wolf derives this from clause 1 together with Corollary 6.5: the peripheral
 projection of a positive trace-preserving map is again positive and
-trace-preserving, and Corollary 6.8 spans the fixed-point space of such a map
+trace-preserving, and Corollary 6.5 spans the fixed-point space of such a map
 by stationary density matrices.
 
-Source: Wolf §6, lines 1568--1590; local source
+Source: Wolf Proposition 6.12, lines 1568--1590, and Corollary 6.5, lines
+1204--1212; local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
 theorem span_stationaryDensity_peripheralProjection_eq_peripheralSubspace
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
@@ -127,7 +108,7 @@ theorem span_stationaryDensity_peripheralProjection_eq_peripheralSubspace
 /-- **Wolf, asymptotic image, clause 2**: there exist positive semidefinite
 matrices whose span is `X_T`.
 
-Source: Wolf §6, lines 1568--1590; local source
+Source: Wolf Proposition 6.12, lines 1568--1590; local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
 theorem exists_posSemidef_span_eq_iSup_eigenspace
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
@@ -144,7 +125,7 @@ Expanding an element of `X_T` in peripheral eigenvectors reduces the claim to
 one eigenspace at a time, and there `T` acts as multiplication by a unit
 phase, which is invertible.
 
-Source: Wolf §6, lines 1568--1590; local source
+Source: Wolf Proposition 6.12, lines 1568--1590; local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
 theorem map_peripheralSubspace
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
@@ -155,7 +136,7 @@ theorem map_peripheralSubspace
   exact iSup_congr fun hμ ↦
     T.map_eigenspace_of_ne_zero (norm_ne_zero_iff.mp (by rw [hμ.2]; exact one_ne_zero))
 
-/-- **Wolf, Proposition (Asymptotic image).**  For a positive trace-preserving
+/-- **Wolf Proposition 6.12 (Asymptotic image).**  For a positive trace-preserving
 linear map `T` on `M_d(ℂ)`, write `X_T` for the span of the peripheral
 eigenvectors of Wolf Equation (6.65).  Then
 
@@ -163,7 +144,7 @@ eigenvectors of Wolf Equation (6.65).  Then
 2. there are positive semidefinite matrices whose span is `X_T`,
 3. `T (X_T) = X_T`.
 
-Source: Wolf §6, lines 1568--1590; local source
+Source: Wolf Proposition 6.12, lines 1568--1590; local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`. -/
 theorem asymptotic_image (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
     (LinearMap.range T.peripheralProjection =

--- a/TNLean/Channel/Peripheral/AsymptoticImage.lean
+++ b/TNLean/Channel/Peripheral/AsymptoticImage.lean
@@ -32,7 +32,7 @@ element of `X_T` in peripheral eigenvectors: on the `μ`-eigenspace `T` acts as
 multiplication by the unit phase `μ`, and a nonzero scalar maps an eigenspace
 onto itself (`Module.End.map_eigenspace_of_ne_zero`).
 
-## Main statements
+## Main results
 
 * `IsPositiveMap.fixedPointsSubmodule_peripheralProjection`: `X_T` is the
   fixed-point space of `T_φ`.

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -664,7 +664,7 @@ machinery (Proposition 3).
 
 ## Section 6.5 Cycles and recurrences
 
-### Wolf Proposition (Asymptotic image) — FORMALIZED
+### Wolf Proposition 6.12 (Asymptotic image) — FORMALIZED
 
 For a positive trace-preserving `T` on `M_D(ℂ)`, write `X_T` for the span of
 the peripheral eigenvectors and `T_φ` for the peripheral spectral projection.

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -381,7 +381,7 @@ Additionally:
 * Numbered theorem: `IsPositiveMap.wolf_prop_6_8` —
   `TNLean.Channel.WolfChapter6Wrappers`.
 
-### Wolf Corollary 6.8 (Linearly independent stationary states) — FORMALIZED
+### Wolf Corollary 6.5 (Linearly independent stationary states) — FORMALIZED
 
 In `TNLean.Channel.FixedPoint.StationarySpan`:
 
@@ -396,7 +396,7 @@ In `TNLean.Channel.FixedPoint.StationarySpan`:
   the fixed-point subspace is spanned (over ℂ) by stationary density matrices
   (PSD, trace 1, fixed by `E`).
 * `IsPositiveMap.exists_stationaryDensity_basis_of_fixedPointsSubmodule` —
-  Wolf Corollary 6.8: when the fixed-point subspace has dimension `r`, there
+  Wolf Corollary 6.5: when the fixed-point subspace has dimension `r`, there
   exist `r` linearly independent stationary density matrices spanning it.
 
 ### Wolf Corollary 6.6 (projected support corner) — FORMALIZED (Kraus case)

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -7,6 +7,7 @@ import TNLean.Analysis.MeanErgodic
 import TNLean.Analysis.Dirichlet
 import TNLean.Channel.Determinant.Bound
 import TNLean.Channel.FixedPoint.Algebra
+import TNLean.Channel.Peripheral.AsymptoticImage
 import TNLean.Channel.Peripheral.CyclicGroupKraus
 import TNLean.Channel.Peripheral.JordanBlocks
 import TNLean.Channel.Peripheral.SpectralRadius
@@ -662,6 +663,26 @@ machinery (Proposition 3).
 ---
 
 ## Section 6.5 Cycles and recurrences
+
+### Wolf Proposition (Asymptotic image) — FORMALIZED
+
+For a positive trace-preserving `T` on `M_D(ℂ)`, write `X_T` for the span of
+the peripheral eigenvectors and `T_φ` for the peripheral spectral projection.
+All three clauses live in `TNLean.Channel.Peripheral.AsymptoticImage`:
+
+* `IsPositiveMap.range_peripheralProjection_eq_iSup_eigenspace` —
+  clause 1, `T_φ (M_D(ℂ)) = X_T`.
+* `IsPositiveMap.exists_posSemidef_span_eq_iSup_eigenspace` —
+  clause 2, `X_T` is the span of a set of positive semidefinite matrices; the
+  spanning form `IsPositiveMap.span_stationaryDensity_peripheralProjection_eq_peripheralSubspace`
+  identifies that set with the stationary densities of `T_φ`.
+* `IsPositiveMap.map_peripheralSubspace` — clause 3, `T (X_T) = X_T`.
+* `IsPositiveMap.asymptotic_image` — the three clauses together.
+
+The auxiliary `IsPositiveMap.fixedPointsSubmodule_peripheralProjection`
+records that `X_T` is the fixed-point space of `T_φ`, and
+`Module.End.map_eigenspace_of_ne_zero` supplies the one-eigenvalue case of
+clause 3.
 
 ### Wolf Theorem 6.16 (Structure of cycles) — PARTIALLY FORMALIZED
 

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -324,14 +324,14 @@
     let
     \begin{align}
         \mathcal X_T
-        =\operatorname{span}\{X\in\MN{D}\mid
+        =\spn\{X\in\MN{D}\mid
         \exists\varphi\in\R:\ T(X)=e^{i\varphi}X\}
     \end{align}
     be the span of its peripheral eigenvectors. Then
     \begin{enumerate}
         \item $T_\varphi(\MN{D})=\mathcal X_T$,
         \item there are positive semidefinite matrices $\rho_i$ with
-              $\mathcal X_T=\operatorname{span}\{\rho_i\}$,
+              $\mathcal X_T=\spn\{\rho_i\}$,
         \item $T(\mathcal X_T)=\mathcal X_T$.
     \end{enumerate}
     This is \cite[Proposition~6.12 (Asymptotic image)]{Wolf2012Quantum}.
@@ -343,24 +343,36 @@
         thm:peripheral_jordan_trivial,
         cor:peripheral_projection_channel,
         cor:stationary_density_span}
-    A matrix is fixed by the projection $T_\varphi$ exactly when it lies in the
-    peripheral subspace, and the image of a projection is its set of fixed
-    points; since the peripheral Jordan blocks of a positive trace-preserving
-    map are trivial, the peripheral subspace is the span of the peripheral
-    eigenspaces. This gives the first claim.
+    Write $V_\mu=\ker(T-\mu)$ for the eigenspace of a peripheral eigenvalue
+    $\mu$, so that $\mathcal X_T=\sum_{|\mu|=1}V_\mu$ once the peripheral
+    Jordan blocks are known to be trivial.
+
+    The image of the projection $T_\varphi$ is its set of fixed points, and a
+    matrix is fixed by $T_\varphi$ exactly when it lies in the peripheral
+    subspace:
+    \begin{align}
+        T_\varphi(\MN{D})=\{X\in\MN{D}\mid T_\varphi(X)=X\}
+        =\sum_{|\mu|=1}V_\mu=\mathcal X_T,
+    \end{align}
+    the third equality by triviality of the peripheral Jordan blocks. This is
+    the first claim.
 
     The projection $T_\varphi$ is itself positive and trace-preserving, so its
-    fixed-point space is spanned by its stationary density matrices; with the
-    first claim this gives the second.
-
-    For the third claim, expand an element of $\mathcal X_T$ in peripheral
-    eigenvectors. On the eigenspace for a peripheral eigenvalue $\mu$ the map
-    $T$ acts as multiplication by $\mu$, and $|\mu|=1$ forces $\mu\neq0$, so
+    fixed-point space is spanned by its stationary density matrices:
     \begin{align}
-        T\bigl(\ker(T-\mu)\bigr)=\ker(T-\mu).
+        \mathcal X_T=\{X\in\MN{D}\mid T_\varphi(X)=X\}
+        =\spn\{\rho\mid \rho\ \text{a stationary density matrix of }T_\varphi\}.
     \end{align}
-    Summing over the peripheral eigenvalues gives
-    $T(\mathcal X_T)=\mathcal X_T$.
+    Every such $\rho$ is positive semidefinite, which is the second claim.
+
+    On $V_\mu$ the map $T$ acts as multiplication by $\mu$, and $|\mu|=1$
+    forces $\mu\neq0$, so multiplication by $\mu$ carries $V_\mu$ onto itself
+    and $T(V_\mu)=\mu V_\mu=V_\mu$. Summing over the peripheral eigenvalues,
+    \begin{align}
+        T(\mathcal X_T)=T\Bigl(\sum_{|\mu|=1}V_\mu\Bigr)
+        =\sum_{|\mu|=1}T(V_\mu)=\sum_{|\mu|=1}V_\mu=\mathcal X_T,
+    \end{align}
+    which is the third claim.
 \end{proof}
 
 \begin{theorem}[Ces\`aro fixed-point theorem]\label{thm:cesaro_fixedpoint}

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -319,10 +319,7 @@
         IsPositiveMap.map_peripheralSubspace,
         IsPositiveMap.asymptotic_image}
     \leanok
-    \uses{def:peripheral_spectral_projections,
-        thm:peripheral_jordan_trivial,
-        cor:peripheral_projection_channel,
-        cor:stationary_density_span}
+    \uses{def:peripheral_spectral_projections}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving, with $D>0$, and
     let
     \begin{align}
@@ -337,12 +334,12 @@
               $\mathcal X_T=\operatorname{span}\{\rho_i\}$,
         \item $T(\mathcal X_T)=\mathcal X_T$.
     \end{enumerate}
-    This is the proposition on the asymptotic image in
-    \cite[Chapter~6]{Wolf2012Quantum}.
+    This is \cite[Proposition~6.12 (Asymptotic image)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:peripheral_spectral_projections,
+        thm:peripheral_spectral_projection_properties,
         thm:peripheral_jordan_trivial,
         cor:peripheral_projection_channel,
         cor:stationary_density_span}
@@ -359,8 +356,11 @@
     For the third claim, expand an element of $\mathcal X_T$ in peripheral
     eigenvectors. On the eigenspace for a peripheral eigenvalue $\mu$ the map
     $T$ acts as multiplication by $\mu$, and $|\mu|=1$ forces $\mu\neq0$, so
-    that eigenspace is carried onto itself. Summing over the peripheral
-    eigenvalues gives $T(\mathcal X_T)=\mathcal X_T$.
+    \begin{align}
+        T\bigl(\ker(T-\mu)\bigr)=\ker(T-\mu).
+    \end{align}
+    Summing over the peripheral eigenvalues gives
+    $T(\mathcal X_T)=\mathcal X_T$.
 \end{proof}
 
 \begin{theorem}[Ces\`aro fixed-point theorem]\label{thm:cesaro_fixedpoint}

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -344,18 +344,26 @@
         cor:peripheral_projection_channel,
         cor:stationary_density_span}
     Write $V_\mu=\ker(T-\mu)$ for the eigenspace of a peripheral eigenvalue
-    $\mu$, so that $\mathcal X_T=\sum_{|\mu|=1}V_\mu$ once the peripheral
-    Jordan blocks are known to be trivial.
-
-    The image of the projection $T_\varphi$ is its set of fixed points, and a
-    matrix is fixed by $T_\varphi$ exactly when it lies in the peripheral
-    subspace:
+    $\mu$, so that $\mathcal X_T=\sum_{|\mu|=1}V_\mu$ by the definition of
+    $\mathcal X_T$. The image of the projection $T_\varphi$ is its set of
+    fixed points, and the fixed points of $T_\varphi$ are the linear
+    combinations of peripheral eigenvectors:
     \begin{align}
-        T_\varphi(\MN{D})=\{X\in\MN{D}\mid T_\varphi(X)=X\}
-        =\sum_{|\mu|=1}V_\mu=\mathcal X_T,
+        T_\varphi(\MN{D})
+         & =\{X\in\MN{D}\mid T_\varphi(X)=X\}
+        \label{eq:channel_asymptotic_fixed_points}\\
+         & =\sum_{|\mu|=1}V_\mu
+        \label{eq:channel_asymptotic_eigenspace_sum}\\
+         & =\mathcal X_T.
+        \label{eq:channel_asymptotic_definition}
     \end{align}
-    the third equality by triviality of the peripheral Jordan blocks. This is
-    the first claim.
+    The equality (\ref{eq:channel_asymptotic_fixed_points}) holds because
+    $T_\varphi$ is a projection; a matrix fixed by $T_\varphi$ lies in the
+    peripheral subspace, whose Jordan blocks are trivial for a positive
+    trace-preserving map (Theorem~\ref{thm:peripheral_jordan_trivial}),
+    which gives (\ref{eq:channel_asymptotic_eigenspace_sum}); and
+    (\ref{eq:channel_asymptotic_definition}) is the definition of
+    $\mathcal X_T$. This is the first claim.
 
     The projection $T_\varphi$ is itself positive and trace-preserving, so its
     fixed-point space is spanned by its stationary density matrices:

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -309,6 +309,60 @@
     that $T_\varphi$ also fixes it pointwise.
 \end{proof}
 
+\begin{theorem}[Asymptotic image]
+    \label{thm:peripheral_asymptotic_image}
+    \lean{Module.End.map_eigenspace_of_ne_zero,
+        IsPositiveMap.fixedPointsSubmodule_peripheralProjection,
+        IsPositiveMap.range_peripheralProjection_eq_iSup_eigenspace,
+        IsPositiveMap.span_stationaryDensity_peripheralProjection_eq_peripheralSubspace,
+        IsPositiveMap.exists_posSemidef_span_eq_iSup_eigenspace,
+        IsPositiveMap.map_peripheralSubspace,
+        IsPositiveMap.asymptotic_image}
+    \leanok
+    \uses{def:peripheral_spectral_projections,
+        thm:peripheral_jordan_trivial,
+        cor:peripheral_projection_channel,
+        cor:stationary_density_span}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving, with $D>0$, and
+    let
+    \begin{align}
+        \mathcal X_T
+        =\operatorname{span}\{X\in\MN{D}\mid
+        \exists\varphi\in\R:\ T(X)=e^{i\varphi}X\}
+    \end{align}
+    be the span of its peripheral eigenvectors. Then
+    \begin{enumerate}
+        \item $T_\varphi(\MN{D})=\mathcal X_T$,
+        \item there are positive semidefinite matrices $\rho_i$ with
+              $\mathcal X_T=\operatorname{span}\{\rho_i\}$,
+        \item $T(\mathcal X_T)=\mathcal X_T$.
+    \end{enumerate}
+    This is the proposition on the asymptotic image in
+    \cite[Chapter~6]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:peripheral_spectral_projections,
+        thm:peripheral_jordan_trivial,
+        cor:peripheral_projection_channel,
+        cor:stationary_density_span}
+    A matrix is fixed by the projection $T_\varphi$ exactly when it lies in the
+    peripheral subspace, and the image of a projection is its set of fixed
+    points; since the peripheral Jordan blocks of a positive trace-preserving
+    map are trivial, the peripheral subspace is the span of the peripheral
+    eigenspaces. This gives the first claim.
+
+    The projection $T_\varphi$ is itself positive and trace-preserving, so its
+    fixed-point space is spanned by its stationary density matrices; with the
+    first claim this gives the second.
+
+    For the third claim, expand an element of $\mathcal X_T$ in peripheral
+    eigenvectors. On the eigenspace for a peripheral eigenvalue $\mu$ the map
+    $T$ acts as multiplication by $\mu$, and $|\mu|=1$ forces $\mu\neq0$, so
+    that eigenspace is carried onto itself. Summing over the peripheral
+    eigenvalues gives $T(\mathcal X_T)=\mathcal X_T$.
+\end{proof}
+
 \begin{theorem}[Ces\`aro fixed-point theorem]\label{thm:cesaro_fixedpoint}
     \lean{IsChannel.exists_posSemidef_fixedPoint}
     \leanok


### PR DESCRIPTION
## Wolf's proposition on the asymptotic image

Source: `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1568--1590,
proposition "Asymptotic image". For a **positive and trace-preserving** linear map
`T : M_d(ℂ) → M_d(ℂ)`, writing `X_T` for the span of the peripheral eigenvectors and
`T_φ` for the peripheral spectral projection:

1. `T_φ(M_d(ℂ)) = X_T`;
2. there exist positive semidefinite `ρ_i` with `X_T = span{ρ_i}`;
3. `T(X_T) = X_T`.

All three clauses are proved, in the new module
`TNLean/Channel/Peripheral/AsymptoticImage.lean`.

## Landed signatures

```lean
theorem Module.End.map_eigenspace_of_ne_zero (f : Module.End ℂ V) {μ : ℂ} (hμ : μ ≠ 0) :
    Submodule.map f (f.eigenspace μ) = f.eigenspace μ

theorem IsPositiveMap.fixedPointsSubmodule_peripheralProjection
    (f : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)) :
    fixedPointsSubmodule f.peripheralProjection = f.peripheralSubspace

theorem IsPositiveMap.range_peripheralProjection_eq_iSup_eigenspace
    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
    LinearMap.range T.peripheralProjection =
      ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ

theorem IsPositiveMap.span_stationaryDensity_peripheralProjection_eq_peripheralSubspace
    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
    Submodule.span ℂ {ρ | IsStationaryDensity T.peripheralProjection ρ} =
      T.peripheralSubspace

theorem IsPositiveMap.exists_posSemidef_span_eq_iSup_eigenspace
    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
    ∃ S : Set (Matrix (Fin D) (Fin D) ℂ), (∀ ρ ∈ S, ρ.PosSemidef) ∧
      Submodule.span ℂ S = ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ

theorem IsPositiveMap.map_peripheralSubspace
    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
    Submodule.map T T.peripheralSubspace = T.peripheralSubspace

theorem IsPositiveMap.asymptotic_image
    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
    (LinearMap.range T.peripheralProjection =
        ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ) ∧
      (∃ S : Set (Matrix (Fin D) (Fin D) ℂ), (∀ ρ ∈ S, ρ.PosSemidef) ∧
        Submodule.span ℂ S = ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ) ∧
      Submodule.map T (⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ) =
        ⨆ μ ∈ peripheralEigenvalues T, T.eigenspace μ
```

`{D : ℕ} [NeZero D]`, `T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)` throughout;
`fixedPointsSubmodule_peripheralProjection` omits `[NeZero D]`.

## Clause-by-clause hypothesis match

| Source clause | Lean statement | Hypotheses in source | Hypotheses in Lean |
|---|---|---|---|
| 1. `T_φ(M_d(ℂ)) = X_T` | `range_peripheralProjection_eq_iSup_eigenspace` | `T` positive, trace-preserving | `IsPositiveMap T`, `IsTracePreservingMap T` |
| 2. `∃{ρ_i ≥ 0}, X_T = span{ρ_i}` | `exists_posSemidef_span_eq_iSup_eigenspace` | `T` positive, trace-preserving | `IsPositiveMap T`, `IsTracePreservingMap T` |
| 3. `T(X_T) = X_T` | `map_peripheralSubspace` | `T` positive, trace-preserving | `IsPositiveMap T`, `IsTracePreservingMap T` |

No complete positivity, unitality, irreducibility, primitivity, or Schwarz
hypothesis is used anywhere: every auxiliary result invoked
(`IsPositiveMap.peripheralSubspace_eq_iSup_eigenspace`,
`IsPositiveMap.peripheralProjection_isPositiveMap`,
`IsPositiveMap.peripheralProjection_isTracePreservingMap`,
`IsPositiveMap.fixedPointsSubmodule_spanned_by_stationaryDensities`) carries
exactly the positive plus trace-preserving hypothesis pair. `[NeZero D]` records
`d ≥ 1`, which is implicit in the source's `M_d(ℂ)`.

## Proof route (Wolf's own)

* Clause 1: a matrix is fixed by `T_φ` exactly when it lies in the peripheral
  subspace, and the image of a projection is its fixed-point set; triviality of
  the peripheral Jordan blocks for a positive trace-preserving map identifies
  the peripheral subspace with the span of the peripheral eigenspaces.
* Clause 2: `T_φ` is itself positive and trace-preserving, so Wolf's corollary
  on linearly independent stationary states spans its fixed-point space by
  stationary densities; combined with clause 1 this is the assertion.
* Clause 3: expand an element of `X_T` in peripheral eigenvectors; on the
  `μ`-eigenspace `T` acts as multiplication by `μ`, and `|μ| = 1` gives `μ ≠ 0`,
  so each peripheral eigenspace is carried onto itself.

## Blueprint

`blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex` gains
`\begin{theorem}[Asymptotic image]` with label `thm:peripheral_asymptotic_image`,
`\lean{...}` for all seven declarations, `\leanok` on the statement and on the
proof, and `\uses` of the peripheral spectral projection definition, the
peripheral Jordan-triviality theorem, the channel structure of the peripheral
projections, and the stationary-density span corollary.

`TNLean/Channel/WolfChapter6Index.lean` gains the matching Chapter 6 index entry
under Section 6.5.

## Verification

| Command | Outcome |
|---|---|
| `lake env lean TNLean/Channel/Peripheral/AsymptoticImage.lean` | clean, no output |
| `lake env lean TNLean/Channel/WolfChapter6Index.lean` | clean, no output |
| `lake build TNLean.Channel.Peripheral` | `Build completed successfully (8813 jobs)` |
| `lake build` | `Build completed successfully (10090 jobs)` |
| `rg -n "sorry\|axiom\|native_decide\|maxHeartbeats"` on the changed Lean files | no matches |
| `python3 scripts/generate_import_aggregators.py --check` | `Import aggregators are current` |
| `python3 scripts/blueprint_lean_sync.py --ci` | `Blueprint and Lean code are in sync`; `ch06_qpf_cesaro_fixed_points.tex` goes from 30/30 to 37/37 formalized references, `missing_lean: 0` |
| `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` | no violations |
| `python3 scripts/check_forbidden_lean_tokens.py`, `check_oversized_lean_files.py` | clean |

`leanblueprint checkdecls` needs the `blueprint/lean_decls` list that `leanblueprint web`
generates; that file is not in the tree, so the equivalent declaration-existence check was
run through `scripts/blueprint_lean_sync.py`, which greps the Lean source for every
`\lean{}` reference. CI will run `checkdecls` after its blueprint build.

## Issue status

`Refs LionSR/QICLean#32`. Issue LionSR/QICLean#32 has two halves; this PR covers the second, the
asymptotic-image proposition. The first half — the recurrent-vector
characterization of the range of `T_φ` (`X ∈ range(T_φ)` iff for every `ε > 0`
there is `n` with `‖T^n(X) − X‖ ≤ ε`, source lines 266--271) — is **not**
included and remains open.

This clears task 1 of LionSR/QICLean#40 ("Prove the three clauses of the asymptotic-image
proposition for a positive trace-preserving map"), the line-1568 item of that
issue. Tasks 2--5 of LionSR/QICLean#40 (Theorem 6.16, the block permutation, the blockwise
unitaries) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176U7wiKWaxFAKBHv3Jgjz3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive Mathlib formalization with no runtime or auth paths; correctness risk is limited to proof logic, mitigated by reuse of existing peripheral fixed-point machinery.
> 
> **Overview**
> Adds a formal proof of **Wolf Proposition 6.12 (Asymptotic image)** for positive trace-preserving maps on matrix algebras: the peripheral spectral projection’s range equals the span of peripheral eigenvectors, that span is generated by positive semidefinite stationary densities of `T_φ`, and `T` stabilizes the peripheral subspace.
> 
> New Lean pieces are `TNLean.Algebra.EigenspaceMap` (`Module.End.map_eigenspace_of_ne_zero`, used for clause 3) and `TNLean.Channel.Peripheral.AsymptoticImage` (`IsPositiveMap.asymptotic_image` and clause lemmas), wired through existing peripheral Jordan triviality, projection range, and stationary-density span results. The blueprint chapter gains `\begin{theorem}[Asymptotic image]` with `\leanok` proof, and `WolfChapter6Index` documents the formalized entry under Section 6.5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af7ff16a62462ecd9b3df2ac24a70d3adac6425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->