### PR TITLE
feat(Channel): determinant of a linear map bounded by the Choi purity

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -16,6 +16,7 @@ import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.CfcLogAdditive
 import TNLean.Analysis.CoisometricCompression
 import TNLean.Analysis.ConvexHullCompact
+import TNLean.Analysis.DeterminantTraceBound
 import TNLean.Analysis.Dirichlet
 import TNLean.Analysis.Entropy
 import TNLean.Analysis.EntropyDecomposition

--- a/TNLean/Analysis/DeterminantTraceBound.lean
+++ b/TNLean/Analysis/DeterminantTraceBound.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.MatrixTraceInequalities
+
+/-!
+# A determinant bound from the trace of `Aᴴ A`
+
+For a square complex matrix `A` whose index type has cardinality `D`, with
+singular values `s₁, …, s_D`,
+
+  `D ^ D · |det A| ^ 2 ≤ tr[Aᴴ A] ^ D`,
+
+because `|det A| ^ 2 = ∏ᵢ sᵢ ^ 2` and `tr[Aᴴ A] = ∑ᵢ sᵢ ^ 2`. The inequality is
+the arithmetic–geometric mean estimate for the eigenvalues of the positive
+semidefinite matrix `Aᴴ A`. It is the step behind Wolf's bound of the
+determinant of a linear map on `M_d(ℂ)` by the purity of its
+Choi–Jamiolkowski operator, `Wolf §6, lines 520–545`.
+
+The arithmetic–geometric mean estimates of `TNLean.Analysis.MatrixTraceInequalities`
+are indexed by `Fin D`; here they are transported to an arbitrary finite index
+type, which is what a matrix whose rows are labelled by pairs requires.
+
+## Main statements
+
+* `pow_card_mul_prod_le_sum_pow'` — arithmetic–geometric mean inequality in
+  product/sum form over an arbitrary finite index type.
+* `Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow'` — the
+  trace–determinant form `D ^ D · det M ≤ (tr M) ^ D` for a positive
+  semidefinite `M` over an arbitrary finite index type.
+* `Matrix.trace_conjTranspose_mul_self_re` — `tr[Aᴴ A]` is the sum of the
+  squared moduli of the entries of `A`.
+* `Matrix.pow_card_mul_norm_det_sq_le_trace_conjTranspose_mul_self_pow` — the
+  determinant bound `D ^ D · |det A| ^ 2 ≤ tr[Aᴴ A] ^ D`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 6][Wolf2012QChannels]
+-/
+
+open scoped BigOperators Matrix ComplexOrder
+open Matrix Finset
+
+/-- **Arithmetic–geometric mean inequality in product/sum form** over an
+arbitrary finite index type `n`: for a nonnegative family `f : n → ℝ`,
+`D ^ D · ∏ f ≤ (∑ f) ^ D` with `D` the cardinality of `n`. -/
+lemma pow_card_mul_prod_le_sum_pow' {n : Type*} [Fintype n] (f : n → ℝ)
+    (hf : ∀ i, 0 ≤ f i) :
+    (Fintype.card n : ℝ) ^ Fintype.card n * ∏ i, f i ≤ (∑ i, f i) ^ Fintype.card n := by
+  classical
+  set e : Fin (Fintype.card n) ≃ n := (Fintype.equivFin n).symm with he
+  have hprod : ∏ i, f i = ∏ j : Fin (Fintype.card n), f (e j) := (e.prod_comp f).symm
+  have hsum : ∑ i, f i = ∑ j : Fin (Fintype.card n), f (e j) := (e.sum_comp f).symm
+  rw [hprod, hsum]
+  exact pow_card_mul_prod_le_sum_pow (fun j => f (e j)) fun j => hf (e j)
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Trace–determinant arithmetic–geometric mean inequality** over an arbitrary
+finite index type: for a positive semidefinite complex matrix `M` whose index
+type has cardinality `D`, `D ^ D · det M ≤ (tr M) ^ D`, both determinant and
+trace being real. -/
+theorem PosSemidef.pow_card_mul_det_re_le_trace_re_pow' {M : Matrix n n ℂ}
+    (hM : M.PosSemidef) :
+    (Fintype.card n : ℝ) ^ Fintype.card n * M.det.re ≤ M.trace.re ^ Fintype.card n := by
+  classical
+  have hdet : M.det.re = ∏ i, hM.1.eigenvalues i := by
+    simp only [hM.1.det_eq_prod_eigenvalues, ← RCLike.ofReal_prod]
+    exact RCLike.ofReal_re (K := ℂ) _
+  have htr : M.trace.re = ∑ i, hM.1.eigenvalues i := by
+    simp only [hM.1.trace_eq_sum_eigenvalues, ← RCLike.ofReal_sum]
+    exact RCLike.ofReal_re (K := ℂ) _
+  rw [hdet, htr]
+  exact pow_card_mul_prod_le_sum_pow' hM.1.eigenvalues fun i => hM.eigenvalues_nonneg i
+
+/-- `tr[Aᴴ A] = ∑_{i,j} |A_{ij}| ^ 2`: the trace of `Aᴴ A` collects the squared
+moduli of all entries of `A`. -/
+theorem trace_conjTranspose_mul_self_re {m p : Type*} [Fintype m] [Fintype p]
+    (A : Matrix m p ℂ) :
+    (Aᴴ * A).trace.re = ∑ i, ∑ j, ‖A i j‖ ^ 2 := by
+  have hcomplex : (Aᴴ * A).trace = ((∑ i, ∑ j, ‖A i j‖ ^ 2 : ℝ) : ℂ) := by
+    simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Complex.ofReal_sum, Complex.ofReal_pow]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+    simpa using RCLike.conj_mul (K := ℂ) (A i j)
+  rw [hcomplex, Complex.ofReal_re]
+
+/-- **Determinant bound by the trace of `Aᴴ A`.** For a square complex matrix
+`A` whose index type has cardinality `D`,
+
+  `D ^ D · |det A| ^ 2 ≤ tr[Aᴴ A] ^ D`.
+
+In singular values `s₁, …, s_D` of `A` this reads `D ^ D · ∏ᵢ sᵢ ^ 2 ≤
+(∑ᵢ sᵢ ^ 2) ^ D`, the arithmetic–geometric mean inequality. -/
+theorem pow_card_mul_norm_det_sq_le_trace_conjTranspose_mul_self_pow (A : Matrix n n ℂ) :
+    (Fintype.card n : ℝ) ^ Fintype.card n * ‖A.det‖ ^ 2 ≤
+      (Aᴴ * A).trace.re ^ Fintype.card n := by
+  have hpsd : (Aᴴ * A).PosSemidef := Matrix.posSemidef_conjTranspose_mul_self A
+  have hdet : (Aᴴ * A).det.re = ‖A.det‖ ^ 2 := by
+    rw [Matrix.det_mul, Matrix.det_conjTranspose,
+      show star A.det * A.det = ((‖A.det‖ ^ 2 : ℝ) : ℂ) by
+        simpa using RCLike.conj_mul (K := ℂ) A.det,
+      Complex.ofReal_re]
+  simpa only [hdet] using hpsd.pow_card_mul_det_re_le_trace_re_pow'
+
+end Matrix

--- a/TNLean/Analysis/DeterminantTraceBound.lean
+++ b/TNLean/Analysis/DeterminantTraceBound.lean
@@ -39,7 +39,6 @@ type, which is what a matrix whose rows are labelled by pairs requires.
 -/
 
 open scoped BigOperators Matrix ComplexOrder
-open Matrix Finset
 
 /-- **Arithmetic–geometric mean inequality in product/sum form** over an
 arbitrary finite index type `n`: for a nonnegative family `f : n → ℝ`,
@@ -48,7 +47,7 @@ lemma pow_card_mul_prod_le_sum_pow' {n : Type*} [Fintype n] (f : n → ℝ)
     (hf : ∀ i, 0 ≤ f i) :
     (Fintype.card n : ℝ) ^ Fintype.card n * ∏ i, f i ≤ (∑ i, f i) ^ Fintype.card n := by
   classical
-  set e : Fin (Fintype.card n) ≃ n := (Fintype.equivFin n).symm with he
+  set e : Fin (Fintype.card n) ≃ n := (Fintype.equivFin n).symm
   have hprod : ∏ i, f i = ∏ j : Fin (Fintype.card n), f (e j) := (e.prod_comp f).symm
   have hsum : ∑ i, f i = ∑ j : Fin (Fintype.card n), f (e j) := (e.sum_comp f).symm
   rw [hprod, hsum]

--- a/TNLean/Analysis/DeterminantTraceBound.lean
+++ b/TNLean/Analysis/DeterminantTraceBound.lean
@@ -30,8 +30,6 @@ type, which is what a matrix whose rows are labelled by pairs requires.
 * `Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow'` — the
   trace–determinant form `D ^ D · det M ≤ (tr M) ^ D` for a positive
   semidefinite `M` over an arbitrary finite index type.
-* `Matrix.trace_conjTranspose_mul_self_re` — `tr[Aᴴ A]` is the sum of the
-  squared moduli of the entries of `A`.
 * `Matrix.pow_card_mul_norm_det_sq_le_trace_conjTranspose_mul_self_pow` — the
   determinant bound `D ^ D · |det A| ^ 2 ≤ tr[Aᴴ A] ^ D`.
 
@@ -76,19 +74,6 @@ theorem PosSemidef.pow_card_mul_det_re_le_trace_re_pow' {M : Matrix n n ℂ}
     exact RCLike.ofReal_re (K := ℂ) _
   rw [hdet, htr]
   exact pow_card_mul_prod_le_sum_pow' hM.1.eigenvalues fun i => hM.eigenvalues_nonneg i
-
-/-- `tr[Aᴴ A] = ∑_{i,j} |A_{ij}| ^ 2`: the trace of `Aᴴ A` collects the squared
-moduli of all entries of `A`. -/
-theorem trace_conjTranspose_mul_self_re {m p : Type*} [Fintype m] [Fintype p]
-    (A : Matrix m p ℂ) :
-    (Aᴴ * A).trace.re = ∑ i, ∑ j, ‖A i j‖ ^ 2 := by
-  have hcomplex : (Aᴴ * A).trace = ((∑ i, ∑ j, ‖A i j‖ ^ 2 : ℝ) : ℂ) := by
-    simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
-      Complex.ofReal_sum, Complex.ofReal_pow]
-    rw [Finset.sum_comm]
-    refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
-    simpa using RCLike.conj_mul (K := ℂ) (A i j)
-  rw [hcomplex, Complex.ofReal_re]
 
 /-- **Determinant bound by the trace of `Aᴴ A`.** For a square complex matrix
 `A` whose index type has cardinality `D`,

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -21,6 +21,7 @@ import TNLean.Channel.DensityRetract
 import TNLean.Channel.Determinant
 import TNLean.Channel.Determinant.Basic
 import TNLean.Channel.Determinant.Bound
+import TNLean.Channel.Determinant.ChoiBound
 import TNLean.Channel.Determinant.HeisenbergDual
 import TNLean.Channel.Determinant.HilbertSchmidt
 import TNLean.Channel.Determinant.UnitaryCharacterization

--- a/TNLean/Channel/Determinant.lean
+++ b/TNLean/Channel/Determinant.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.Determinant.Basic
 import TNLean.Channel.Determinant.Bound
+import TNLean.Channel.Determinant.ChoiBound
 import TNLean.Channel.Determinant.HilbertSchmidt
 import TNLean.Channel.Determinant.HeisenbergDual
 import TNLean.Channel.Determinant.UnitaryCharacterization
@@ -13,7 +14,7 @@ import TNLean.Channel.Determinant.UnitaryCharacterization
 # Determinants of quantum channels
 
 Thin module assembling the determinant development for quantum channels from
-five focused sub-modules.
+six focused sub-modules.
 
 The division follows the same organization as the earlier `Full/` and
 `Growth/` developments:
@@ -22,6 +23,9 @@ The division follows the same organization as the earlier `Full/` and
   channels.
 * `TNLean.Channel.Determinant.Bound` — Wolf Theorem 6.1(1), the determinant
   bound for positive trace-preserving maps.
+* `TNLean.Channel.Determinant.ChoiBound` — Wolf Eq. (6.27), the determinant
+  of an arbitrary linear map bounded by the purity of its Choi--Jamiolkowski
+  operator.
 * `TNLean.Channel.Determinant.HilbertSchmidt` — spectral and Hilbert--Schmidt
   auxiliary lemmas for the rigidity argument.
 * `TNLean.Channel.Determinant.HeisenbergDual` — Heisenberg-dual
@@ -41,6 +45,8 @@ The division follows the same organization as the earlier `Full/` and
 * `channelDet_norm_le_one_of_positive_tracePreserving` — Wolf Theorem 6.1(1).
 * `channelDet_norm_eq_one_iff_exists_unitaryChannel` — Wolf Theorem 6.1(2)
   for CPTP maps.
+* `norm_channelDet_le_choiPurity_rpow` — Wolf Eq. (6.27), the Choi bound
+  `|det T| ≤ tr[τ† τ]^{d²/2}` for an arbitrary linear map.
 
 ## References
 

--- a/TNLean/Channel/Determinant/ChoiBound.lean
+++ b/TNLean/Channel/Determinant/ChoiBound.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.Analysis.DeterminantTraceBound
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.Determinant.Basic
@@ -64,12 +65,12 @@ namespace ChannelDeterminant
 namespace Internal
 
 /-- The matrix-unit basis of `M_d(ℂ)`: `matrixSpaceBasis d (i, j, ()) = E_{ij}`. -/
-theorem matrixSpaceBasis_apply_single (i j : Fin d) :
+private theorem matrixSpaceBasis_apply_single (i j : Fin d) :
     matrixSpaceBasis d (i, j, ()) = Matrix.single i j (1 : ℂ) := by
   simp [matrixSpaceBasis, Module.Basis.matrix_apply, Module.Basis.singleton_apply]
 
 /-- The coordinates of `M` in the matrix-unit basis are the entries of `M`. -/
-theorem matrixSpaceBasis_repr_apply (M : MatrixAlg d) (i j : Fin d) :
+private theorem matrixSpaceBasis_repr_apply (M : MatrixAlg d) (i j : Fin d) :
     (matrixSpaceBasis d).repr M (i, j, ()) = M i j := by
   classical
   have hsum : M = ∑ x : Fin d, ∑ y : Fin d, M x y • matrixSpaceBasis d (x, y, ()) := by
@@ -133,7 +134,7 @@ noncomputable def choiPurity (T : MatrixEnd d) : ℝ :=
   ((ChoiJamiolkowski.choiMatrix T)ᴴ * ChoiJamiolkowski.choiMatrix T).trace.re
 
 theorem choiPurity_nonneg (T : MatrixEnd d) : 0 ≤ choiPurity T := by
-  rw [choiPurity, Matrix.trace_conjTranspose_mul_self_re]
+  rw [choiPurity, Matrix.trace_conjTranspose_mul_self_re_eq_sum_norm_sq]
   positivity
 
 /-- The purity is the sum of the squared moduli of the entries of `τ`. -/
@@ -141,14 +142,14 @@ theorem choiPurity_eq_sum (T : MatrixEnd d) :
     choiPurity T =
       ∑ i₁ : Fin d, ∑ j₁ : Fin d, ∑ i₂ : Fin d, ∑ j₂ : Fin d,
         ‖ChoiJamiolkowski.choiMatrix T (i₁, j₁) (i₂, j₂)‖ ^ 2 := by
-  rw [choiPurity, Matrix.trace_conjTranspose_mul_self_re]
+  rw [choiPurity, Matrix.trace_conjTranspose_mul_self_re_eq_sum_norm_sq, Finset.sum_comm]
   simp [Fintype.sum_prod_type]
 
 /-- **Wolf Eq. (6.28).** The matrix representation and the Choi–Jamiolkowski
 operator have proportional Hilbert–Schmidt norms: `tr[A† A] = d² tr[τ† τ]`. -/
 theorem trace_conjTranspose_mul_self_channelMatrix (T : MatrixEnd d) :
     ((channelMatrix T)ᴴ * channelMatrix T).trace.re = (d : ℝ) ^ 2 * choiPurity T := by
-  rw [Matrix.trace_conjTranspose_mul_self_re, choiPurity_eq_sum]
+  rw [Matrix.trace_conjTranspose_mul_self_re_eq_sum_norm_sq, Finset.sum_comm, choiPurity_eq_sum]
   simp only [Fintype.sum_prod_type, Finset.univ_unique, Finset.sum_singleton,
     channelMatrix_apply_eq_choiMatrix, norm_mul, mul_pow, Complex.norm_natCast,
     ← Finset.mul_sum]

--- a/TNLean/Channel/Determinant/ChoiBound.lean
+++ b/TNLean/Channel/Determinant/ChoiBound.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.DeterminantTraceBound
+import TNLean.Channel.ChoiJamiolkowski
+import TNLean.Channel.Determinant.Basic
+
+/-!
+# Determinant of a linear map and the purity of its Choi operator
+
+Let `T : M_d(ℂ) → M_d(ℂ)` be a linear map and `τ = (T ⊗ id)(|Ω⟩⟨Ω|)` its
+Choi–Jamiolkowski operator. Wolf's bound is
+
+  `|det T| ≤ tr[τ† τ] ^ (d² / 2)`.
+
+No positivity, trace preservation or unitality is assumed: the estimate holds
+for every linear map on `M_d(ℂ)`.
+
+The proof follows Wolf. Write `A` for the matrix representing `T` in the
+matrix-unit basis (Wolf's `\widehat{T}`). The Choi operator and `A` are related
+by the reshuffling `A = d τ^Γ`, `⟨m,n| τ^Γ |k,ℓ⟩ = ⟨m,k| τ |n,ℓ⟩`, so that the
+two operators carry the same multiset of squared entry moduli up to the factor
+`d²`:
+
+  `tr[τ† τ] = (1/d²) tr[A† A] = (1/d²) ∑ᵢ sᵢ²`,
+
+with `sᵢ` the singular values of `A`. Since `|det T| = ∏ᵢ sᵢ`, the
+arithmetic–geometric mean inequality applied to the `d²` numbers `sᵢ²` gives the
+bound, the factors `(d²)^{d²}` on the two sides cancelling exactly.
+
+## Main definitions
+
+* `choiPurity T` — the purity `tr[τ† τ]` of the Choi–Jamiolkowski operator of
+  `T`.
+
+## Main statements
+
+* `channelMatrix_apply_eq_choiMatrix` — the reshuffling `A = d τ^Γ`
+  (Wolf Eq. (2.22)).
+* `trace_conjTranspose_mul_self_channelMatrix` — `tr[A† A] = d² tr[τ† τ]`
+  (Wolf Eq. (6.28)).
+* `norm_channelDet_sq_le_choiPurity_pow` — `|det T|² ≤ tr[τ† τ]^{d²}`.
+* `norm_channelDet_le_choiPurity_rpow` — `|det T| ≤ tr[τ† τ]^{d²/2}`
+  (Wolf Eq. (6.27)).
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 6][Wolf2012QChannels],
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 520–545.
+
+## Tags
+
+quantum channel, determinant, Choi-Jamiolkowski operator, purity
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix
+
+variable {d : ℕ}
+
+namespace ChannelDeterminant
+namespace Internal
+
+/-- The matrix-unit basis of `M_d(ℂ)`: `matrixSpaceBasis d (i, j, ()) = E_{ij}`. -/
+theorem matrixSpaceBasis_apply_single (i j : Fin d) :
+    matrixSpaceBasis d (i, j, ()) = Matrix.single i j (1 : ℂ) := by
+  simp [matrixSpaceBasis, Module.Basis.matrix_apply, Module.Basis.singleton_apply]
+
+/-- The coordinates of `M` in the matrix-unit basis are the entries of `M`. -/
+theorem matrixSpaceBasis_repr_apply (M : MatrixAlg d) (i j : Fin d) :
+    (matrixSpaceBasis d).repr M (i, j, ()) = M i j := by
+  classical
+  have hsum : M = ∑ x : Fin d, ∑ y : Fin d, M x y • matrixSpaceBasis d (x, y, ()) := by
+    ext a b
+    simp only [Matrix.sum_apply, Matrix.smul_apply, matrixSpaceBasis_apply_single,
+      Matrix.single_apply, smul_eq_mul, mul_ite, mul_one, mul_zero]
+    rw [Finset.sum_eq_single a, Finset.sum_eq_single b] <;> simp +contextual
+  conv_lhs => rw [hsum]
+  simp only [map_sum, map_smul, Module.Basis.repr_self, Finsupp.coe_finsetSum,
+    Finset.sum_apply, Finsupp.smul_apply, Finsupp.single_apply, Prod.mk.injEq, smul_eq_mul,
+    mul_ite, mul_one, mul_zero, ite_and]
+  simp [Finset.sum_ite_eq']
+
+end Internal
+end ChannelDeterminant
+
+open ChannelDeterminant.Internal
+
+section Reshuffling
+
+/-- The entries of the matrix `A` representing `T` in the matrix-unit basis:
+`A_{(i₁,i₂),(j₁,j₂)} = T(E_{j₁ j₂})_{i₁ i₂}`. -/
+theorem channelMatrix_apply (T : MatrixEnd d) (i₁ i₂ j₁ j₂ : Fin d) (u v : Unit) :
+    channelMatrix T (i₁, i₂, u) (j₁, j₂, v) = T (Matrix.single j₁ j₂ (1 : ℂ)) i₁ i₂ := by
+  cases u
+  cases v
+  rw [channelMatrix, LinearMap.toMatrix_apply, matrixSpaceBasis_apply_single,
+    matrixSpaceBasis_repr_apply]
+
+/-- The entries of the Choi–Jamiolkowski operator on matrix units:
+`τ_{(i₁,i₂),(j₁,j₂)} = (1/d) T(E_{i₂ j₂})_{i₁ j₁}`. -/
+theorem choiMatrix_apply_single (T : MatrixEnd d) (i₁ i₂ j₁ j₂ : Fin d) :
+    ChoiJamiolkowski.choiMatrix T (i₁, i₂) (j₁, j₂) =
+      (1 / (d : ℂ)) * T (Matrix.single i₂ j₂ (1 : ℂ)) i₁ j₁ := by
+  have hd : 0 < d := Fin.pos i₁
+  have hsingle : Matrix.single i₂ j₂ ((1 : ℂ) / (d : ℂ)) =
+      ((1 : ℂ) / (d : ℂ)) • Matrix.single i₂ j₂ (1 : ℂ) := by
+    ext a b
+    simp [Matrix.single_apply]
+  rw [ChoiJamiolkowski.choiMatrix_apply, ChoiJamiolkowski.omegaSlice_eq_single,
+    ChoiJamiolkowski.omegaCoeff_eq_inv hd, hsingle, map_smul]
+  simp
+
+/-- **Wolf Eq. (2.22).** The matrix representation of `T` in the matrix-unit
+basis is `d` times the reshuffling of the Choi–Jamiolkowski operator:
+`A_{(i₁,i₂),(j₁,j₂)} = d · τ_{(i₁,j₁),(i₂,j₂)}`. -/
+theorem channelMatrix_apply_eq_choiMatrix (T : MatrixEnd d) (i₁ i₂ j₁ j₂ : Fin d) (u v : Unit) :
+    channelMatrix T (i₁, i₂, u) (j₁, j₂, v) =
+      (d : ℂ) * ChoiJamiolkowski.choiMatrix T (i₁, j₁) (i₂, j₂) := by
+  have hd : (d : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (Fin.pos i₁).ne'
+  rw [channelMatrix_apply, choiMatrix_apply_single, ← mul_assoc,
+    mul_one_div, div_self hd, one_mul]
+
+end Reshuffling
+
+section Purity
+
+/-- The **purity** `tr[τ† τ]` of the Choi–Jamiolkowski operator `τ` of a linear
+map `T : M_d(ℂ) → M_d(ℂ)`. Wolf §6, line 531. -/
+noncomputable def choiPurity (T : MatrixEnd d) : ℝ :=
+  ((ChoiJamiolkowski.choiMatrix T)ᴴ * ChoiJamiolkowski.choiMatrix T).trace.re
+
+theorem choiPurity_nonneg (T : MatrixEnd d) : 0 ≤ choiPurity T := by
+  rw [choiPurity, Matrix.trace_conjTranspose_mul_self_re]
+  positivity
+
+/-- The purity is the sum of the squared moduli of the entries of `τ`. -/
+theorem choiPurity_eq_sum (T : MatrixEnd d) :
+    choiPurity T =
+      ∑ i₁ : Fin d, ∑ j₁ : Fin d, ∑ i₂ : Fin d, ∑ j₂ : Fin d,
+        ‖ChoiJamiolkowski.choiMatrix T (i₁, j₁) (i₂, j₂)‖ ^ 2 := by
+  rw [choiPurity, Matrix.trace_conjTranspose_mul_self_re]
+  simp [Fintype.sum_prod_type]
+
+/-- **Wolf Eq. (6.28).** The matrix representation and the Choi–Jamiolkowski
+operator have proportional Hilbert–Schmidt norms: `tr[A† A] = d² tr[τ† τ]`. -/
+theorem trace_conjTranspose_mul_self_channelMatrix (T : MatrixEnd d) :
+    ((channelMatrix T)ᴴ * channelMatrix T).trace.re = (d : ℝ) ^ 2 * choiPurity T := by
+  rw [Matrix.trace_conjTranspose_mul_self_re, choiPurity_eq_sum]
+  simp only [Fintype.sum_prod_type, Finset.univ_unique, Finset.sum_singleton,
+    channelMatrix_apply_eq_choiMatrix, norm_mul, mul_pow, Complex.norm_natCast,
+    ← Finset.mul_sum]
+  refine congrArg (fun s : ℝ => (d : ℝ) ^ 2 * s) ?_
+  exact Finset.sum_congr rfl fun _ _ => Finset.sum_comm
+
+end Purity
+
+section ChoiBound
+
+/-- **Wolf Eq. (6.27), squared form.** For every linear map
+`T : M_d(ℂ) → M_d(ℂ)` with Choi–Jamiolkowski operator `τ`,
+
+  `|det T|² ≤ tr[τ† τ]^{d²}`.
+
+No positivity, trace preservation or unitality is assumed. -/
+theorem norm_channelDet_sq_le_choiPurity_pow (T : MatrixEnd d) :
+    ‖channelDet T‖ ^ 2 ≤ choiPurity T ^ (d ^ 2) := by
+  have hcard : Fintype.card (MatrixBasisIndex d) = d ^ 2 := by
+    simp [MatrixBasisIndex, pow_two]
+  have hbound :=
+    Matrix.pow_card_mul_norm_det_sq_le_trace_conjTranspose_mul_self_pow (channelMatrix T)
+  rw [hcard, trace_conjTranspose_mul_self_channelMatrix, mul_pow] at hbound
+  have hcast : ((d ^ 2 : ℕ) : ℝ) = (d : ℝ) ^ 2 := by push_cast; ring
+  rw [hcast] at hbound
+  have hpos : (0 : ℝ) < ((d : ℝ) ^ 2) ^ (d ^ 2) := by
+    rcases Nat.eq_zero_or_pos d with rfl | hd
+    · norm_num
+    · have : (0 : ℝ) < (d : ℝ) := by exact_mod_cast hd
+      positivity
+  exact le_of_mul_le_mul_left hbound hpos
+
+/-- **Wolf Eq. (6.27).** For every linear map `T : M_d(ℂ) → M_d(ℂ)` with
+Choi–Jamiolkowski operator `τ`,
+
+  `|det T| ≤ tr[τ† τ]^{d²/2}`.
+
+No positivity, trace preservation or unitality is assumed. -/
+theorem norm_channelDet_le_choiPurity_rpow (T : MatrixEnd d) :
+    ‖channelDet T‖ ≤ choiPurity T ^ ((d : ℝ) ^ 2 / 2) := by
+  have hp : 0 ≤ choiPurity T := choiPurity_nonneg T
+  have hsq : (choiPurity T ^ ((d : ℝ) ^ 2 / 2)) ^ 2 = choiPurity T ^ (d ^ 2) := by
+    rw [← Real.rpow_natCast (choiPurity T ^ ((d : ℝ) ^ 2 / 2)) 2, ← Real.rpow_mul hp,
+      show (d : ℝ) ^ 2 / 2 * ((2 : ℕ) : ℝ) = ((d ^ 2 : ℕ) : ℝ) by push_cast; ring]
+    exact Real.rpow_natCast _ _
+  have hbound := norm_channelDet_sq_le_choiPurity_pow T
+  rw [← hsq] at hbound
+  exact le_of_pow_le_pow_left₀ two_ne_zero (Real.rpow_nonneg hp _) hbound
+
+end ChoiBound

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -14,3 +14,4 @@ are not prerequisites for the matrix-product-state Fundamental Theorem.
 \input{chapter/ch16_channel_representations_choi_and_kraus}
 \input{chapter/ch16_channel_representations_dilations_and_ordered_cp}
 \input{chapter/ch16_channel_representations_normal_forms_and_determinant}
+\input{chapter/ch16_channel_representations_determinant_choi_bound}

--- a/blueprint/src/chapter/ch16_channel_representations_determinant_choi_bound.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_determinant_choi_bound.tex
@@ -89,11 +89,12 @@
     Lemma~\ref{lem:choi_purity_eq_hilbert_schmidt},
     $\sum_i s_i^2=D^2\tr[\tau^\dagger\tau]$. The geometric--arithmetic mean
     inequality for the $D^2$ nonnegative numbers $s_i^2$ reads
-    \begin{align*}
+    \begin{align}
         (D^2)^{D^2}\prod_{i} s_i^2
         &\le \Bigl(\sum_i s_i^2\Bigr)^{D^2}
         = (D^2)^{D^2}\,\tr[\tau^\dagger\tau]^{D^2}.
-    \end{align*}
+        \notag
+    \end{align}
     Cancelling $(D^2)^{D^2}$ gives $|\det T|^2\le\tr[\tau^\dagger\tau]^{D^2}$,
     and taking square roots gives the stated bound.
 \end{proof}

--- a/blueprint/src/chapter/ch16_channel_representations_determinant_choi_bound.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_determinant_choi_bound.tex
@@ -8,15 +8,24 @@
 
 \begin{definition}[Purity of the Choi--Jamio\l{}kowski operator]
     \label{def:choi_purity}
-    \lean{choiPurity}\leanok
+    \lean{choiPurity, choiPurity_nonneg, choiPurity_eq_sum}\leanok
     \uses{def:choi_matrix}
     For a linear map $T : \MN{D} \to \MN{D}$ with Choi--Jamio\l{}kowski
-    operator $\tau$, the \emph{purity} of $\tau$ is
-    $\tr[\tau^\dagger\tau]$.
+    operator $\tau$, the \emph{purity} of $\tau$ is $\tr[\tau^\dagger\tau]$,
+    the sum
+    \begin{align}
+        \tr[\tau^\dagger\tau]
+        &= \sum_{i_1,j_1,i_2,j_2}
+            \bigl|\tau_{(i_1,j_1),(i_2,j_2)}\bigr|^2
+        \label{eq:representations_purity_entries}
+    \end{align}
+    of the squared moduli of the entries of $\tau$; in particular it is
+    non-negative.
 \end{definition}
 
 \begin{lemma}[Reshuffling]\label{lem:channel_matrix_eq_reshuffled_choi}
-    \lean{channelMatrix_apply_eq_choiMatrix}\leanok
+    \lean{channelMatrix_apply_eq_choiMatrix, channelMatrix_apply,
+        choiMatrix_apply_single}\leanok
     \uses{def:channel_det, def:choi_matrix}
     Let $T : \MN{D} \to \MN{D}$ be a linear map, $\widehat{T}$ its matrix with
     respect to the matrix-unit basis and $\tau$ its Choi--Jamio\l{}kowski
@@ -33,38 +42,73 @@
 \end{lemma}
 
 \begin{proof}\leanok
-    Both sides are computed on matrix units. The matrix of $T$ has entries
-    $\widehat{T}_{(i_1,i_2),(j_1,j_2)}=(T(E_{j_1j_2}))_{i_1i_2}$, while the
-    Choi--Jamio\l{}kowski operator has entries
-    $\tau_{(i_1,i_2),(j_1,j_2)}=\frac1D(T(E_{i_2j_2}))_{i_1j_1}$. Substituting
-    $(i_1,j_1)$ for the row pair and $(i_2,j_2)$ for the column pair in the
-    second formula gives $\frac1D(T(E_{j_1j_2}))_{i_1i_2}$.
+    Both sides are computed on the matrix units $E_{ij}$:
+    \begin{align}
+        \widehat{T}_{(i_1,i_2),(j_1,j_2)}
+        &= \bigl(T(E_{j_1j_2})\bigr)_{i_1i_2},
+        \label{eq:representations_channel_matrix_entries}\\
+        \tau_{(i_1,i_2),(j_1,j_2)}
+        &= \frac1D\bigl(T(E_{i_2j_2})\bigr)_{i_1j_1}.
+        \label{eq:representations_choi_entries}
+    \end{align}
+    Substituting $(i_1,j_1)$ for the row pair and $(i_2,j_2)$ for the column
+    pair in (\ref{eq:representations_choi_entries}) gives
+    $\frac1D\bigl(T(E_{j_1j_2})\bigr)_{i_1i_2}$, which by
+    (\ref{eq:representations_channel_matrix_entries}) is
+    $\frac1D\widehat{T}_{(i_1,i_2),(j_1,j_2)}$.
 \end{proof}
 
 \begin{lemma}[Purity and the matrix representation]
     \label{lem:choi_purity_eq_hilbert_schmidt}
     \lean{trace_conjTranspose_mul_self_channelMatrix}\leanok
-    \uses{def:choi_purity, lem:channel_matrix_eq_reshuffled_choi}
+    \uses{def:channel_det, def:choi_purity}
     With the notation of Lemma~\ref{lem:channel_matrix_eq_reshuffled_choi},
     \begin{align}
-        \tr[\tau^\dagger\tau]
-        &= \frac{1}{D^2}\,\tr[\widehat{T}^\dagger\widehat{T}]
-        = \frac{1}{D^2}\sum_{i=1}^{D^2}s_i^2,
-        \label{eq:representations_purity_singular_values}
+        \tr[\widehat{T}^\dagger\widehat{T}]
+        &= D^2\,\tr[\tau^\dagger\tau].
+        \label{eq:representations_purity_factor}
     \end{align}
-    where the $s_i$ are the singular values of $\widehat{T}$. This is
-    \cite[Eq.~(6.28)]{Wolf2012Quantum}.
+    For $D\geq1$ this is \cite[Eq.~(6.28)]{Wolf2012Quantum}, which states it in
+    the divided form $\tr[\tau^\dagger\tau]=D^{-2}\tr[\widehat{T}^\dagger
+    \widehat{T}]$.
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{lem:channel_matrix_eq_reshuffled_choi}
     The trace $\tr[A^\dagger A]$ is the sum of the squared moduli of the
-    entries of $A$. Reshuffling permutes the index quadruples
-    $(i_1,i_2,j_1,j_2)$ without repetition, so it leaves that sum unchanged;
-    by Lemma~\ref{lem:channel_matrix_eq_reshuffled_choi} the entries of
-    $\widehat{T}$ exceed the corresponding entries of $\tau$ by the factor $D$,
-    whence the factor $D^2$. The second equality is the description of
-    $\tr[\widehat{T}^\dagger\widehat{T}]$ through the eigenvalues of
-    $\widehat{T}^\dagger\widehat{T}$, which are the squared singular values.
+    entries of $A$, so (\ref{eq:representations_reshuffling}) gives
+    \begin{align}
+        \tr[\widehat{T}^\dagger\widehat{T}]
+        &= \sum_{i_1,i_2,j_1,j_2}
+            \bigl|\widehat{T}_{(i_1,i_2),(j_1,j_2)}\bigr|^2
+         = D^2\sum_{i_1,i_2,j_1,j_2}
+            \bigl|\tau_{(i_1,j_1),(i_2,j_2)}\bigr|^2.
+        \label{eq:representations_purity_entry_sum}
+    \end{align}
+    Reshuffling permutes the index quadruples $(i_1,i_2,j_1,j_2)$ without
+    repetition, so the remaining sum is $\tr[\tau^\dagger\tau]$ by
+    (\ref{eq:representations_purity_entries}).
+\end{proof}
+
+\begin{lemma}[Determinant bound by the Hilbert--Schmidt norm]
+    \label{lem:det_sq_le_hilbert_schmidt_pow}
+    \lean{Matrix.pow_card_mul_norm_det_sq_le_trace_conjTranspose_mul_self_pow}
+    \leanok
+    \uses{lem:trace_det_amgm}
+    For a square complex matrix $A$ whose index set has $n$ elements,
+    \begin{align}
+        n^{n}\,|\det A|^2 &\leq \tr[A^\dagger A]^{n}.
+        \label{eq:representations_det_sq_hs_bound}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:trace_det_amgm}
+    The matrix $A^\dagger A$ is positive semidefinite and
+    $\det(A^\dagger A)=|\det A|^2$, so
+    (\ref{eq:representations_trace_det_amgm}) applied to $M=A^\dagger A$ is the
+    asserted bound. In the singular values $s_1,\dots,s_n$ of $A$ it reads
+    $n^n\prod_i s_i^2\leq\bigl(\sum_i s_i^2\bigr)^n$.
 \end{proof}
 
 \begin{theorem}[Determinant and Choi--Jamio\l{}kowski operator]
@@ -83,18 +127,17 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:choi_purity_eq_hilbert_schmidt}
-    Write $s_1,\dots,s_{D^2}$ for the singular values of $\widehat{T}$, so that
-    $|\det T|=\prod_i s_i$ and, by
-    Lemma~\ref{lem:choi_purity_eq_hilbert_schmidt},
-    $\sum_i s_i^2=D^2\tr[\tau^\dagger\tau]$. The geometric--arithmetic mean
-    inequality for the $D^2$ nonnegative numbers $s_i^2$ reads
+    \uses{lem:choi_purity_eq_hilbert_schmidt, lem:det_sq_le_hilbert_schmidt_pow}
+    The matrix $\widehat{T}$ is indexed by the $D^2$ matrix units and
+    $\det T=\det\widehat{T}$, so (\ref{eq:representations_det_sq_hs_bound}) with
+    $n=D^2$, followed by (\ref{eq:representations_purity_factor}), gives
     \begin{align}
-        (D^2)^{D^2}\prod_{i} s_i^2
-        &\le \Bigl(\sum_i s_i^2\Bigr)^{D^2}
+        (D^2)^{D^2}\,|\det T|^2
+        &\le \tr[\widehat{T}^\dagger\widehat{T}]^{D^2}
         = (D^2)^{D^2}\,\tr[\tau^\dagger\tau]^{D^2}.
         \notag
     \end{align}
-    Cancelling $(D^2)^{D^2}$ gives $|\det T|^2\le\tr[\tau^\dagger\tau]^{D^2}$,
-    and taking square roots gives the stated bound.
+    Cancelling the positive factor $(D^2)^{D^2}$ gives
+    $|\det T|^2\le\tr[\tau^\dagger\tau]^{D^2}$, and taking square roots gives
+    the stated bound.
 \end{proof}

--- a/blueprint/src/chapter/ch16_channel_representations_determinant_choi_bound.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_determinant_choi_bound.tex
@@ -1,0 +1,99 @@
+%% =========================================================
+\section{Determinant and Choi--Jamio\l{}kowski operator}
+\label{sec:channel_determinant_choi_bound}
+%% =========================================================
+
+%% Source: \cite[Section~6.1, Eq.~(6.27)]{Wolf2012Quantum};
+%% Notes/WolfNoteTexSource/ch06_spectral_properties.tex, lines 520--545.
+
+\begin{definition}[Purity of the Choi--Jamio\l{}kowski operator]
+    \label{def:choi_purity}
+    \lean{choiPurity}\leanok
+    \uses{def:choi_matrix}
+    For a linear map $T : \MN{D} \to \MN{D}$ with Choi--Jamio\l{}kowski
+    operator $\tau$, the \emph{purity} of $\tau$ is
+    $\tr[\tau^\dagger\tau]$.
+\end{definition}
+
+\begin{lemma}[Reshuffling]\label{lem:channel_matrix_eq_reshuffled_choi}
+    \lean{channelMatrix_apply_eq_choiMatrix}\leanok
+    \uses{def:channel_det, def:choi_matrix}
+    Let $T : \MN{D} \to \MN{D}$ be a linear map, $\widehat{T}$ its matrix with
+    respect to the matrix-unit basis and $\tau$ its Choi--Jamio\l{}kowski
+    operator. Then
+    \begin{align}
+        \widehat{T}_{(i_1,i_2),(j_1,j_2)}
+        &= D\,\tau_{(i_1,j_1),(i_2,j_2)}.
+        \label{eq:representations_reshuffling}
+    \end{align}
+    Equivalently $\widehat{T}=D\,\tau^{\Gamma}$, where the involution
+    $\tau\mapsto\tau^{\Gamma}$ is defined by
+    $\bra{m,n}\tau^{\Gamma}\ket{k,\ell}=\bra{m,k}\tau\ket{n,\ell}$.
+    This is \cite[Eq.~(2.22)]{Wolf2012Quantum}.
+\end{lemma}
+
+\begin{proof}\leanok
+    Both sides are computed on matrix units. The matrix of $T$ has entries
+    $\widehat{T}_{(i_1,i_2),(j_1,j_2)}=(T(E_{j_1j_2}))_{i_1i_2}$, while the
+    Choi--Jamio\l{}kowski operator has entries
+    $\tau_{(i_1,i_2),(j_1,j_2)}=\frac1D(T(E_{i_2j_2}))_{i_1j_1}$. Substituting
+    $(i_1,j_1)$ for the row pair and $(i_2,j_2)$ for the column pair in the
+    second formula gives $\frac1D(T(E_{j_1j_2}))_{i_1i_2}$.
+\end{proof}
+
+\begin{lemma}[Purity and the matrix representation]
+    \label{lem:choi_purity_eq_hilbert_schmidt}
+    \lean{trace_conjTranspose_mul_self_channelMatrix}\leanok
+    \uses{def:choi_purity, lem:channel_matrix_eq_reshuffled_choi}
+    With the notation of Lemma~\ref{lem:channel_matrix_eq_reshuffled_choi},
+    \begin{align}
+        \tr[\tau^\dagger\tau]
+        &= \frac{1}{D^2}\,\tr[\widehat{T}^\dagger\widehat{T}]
+        = \frac{1}{D^2}\sum_{i=1}^{D^2}s_i^2,
+        \label{eq:representations_purity_singular_values}
+    \end{align}
+    where the $s_i$ are the singular values of $\widehat{T}$. This is
+    \cite[Eq.~(6.28)]{Wolf2012Quantum}.
+\end{lemma}
+
+\begin{proof}\leanok
+    The trace $\tr[A^\dagger A]$ is the sum of the squared moduli of the
+    entries of $A$. Reshuffling permutes the index quadruples
+    $(i_1,i_2,j_1,j_2)$ without repetition, so it leaves that sum unchanged;
+    by Lemma~\ref{lem:channel_matrix_eq_reshuffled_choi} the entries of
+    $\widehat{T}$ exceed the corresponding entries of $\tau$ by the factor $D$,
+    whence the factor $D^2$. The second equality is the description of
+    $\tr[\widehat{T}^\dagger\widehat{T}]$ through the eigenvalues of
+    $\widehat{T}^\dagger\widehat{T}$, which are the squared singular values.
+\end{proof}
+
+\begin{theorem}[Determinant and Choi--Jamio\l{}kowski operator]
+    \label{thm:channelDet_le_choi_purity}
+    \lean{norm_channelDet_le_choiPurity_rpow,
+        norm_channelDet_sq_le_choiPurity_pow}\leanok
+    \uses{def:channel_det, def:choi_purity}
+    Let $T:\MN{D}\to\MN{D}$ be a linear map and $\tau$ the corresponding
+    Choi--Jamio\l{}kowski operator. Then
+    \begin{align}
+        |\det T| &\le \tr[\tau^\dagger\tau]^{D^2/2}.
+        \label{eq:representations_det_choi_bound}
+    \end{align}
+    No positivity, trace preservation or unitality is assumed. This is
+    \cite[Eq.~(6.27)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:choi_purity_eq_hilbert_schmidt}
+    Write $s_1,\dots,s_{D^2}$ for the singular values of $\widehat{T}$, so that
+    $|\det T|=\prod_i s_i$ and, by
+    Lemma~\ref{lem:choi_purity_eq_hilbert_schmidt},
+    $\sum_i s_i^2=D^2\tr[\tau^\dagger\tau]$. The geometric--arithmetic mean
+    inequality for the $D^2$ nonnegative numbers $s_i^2$ reads
+    \begin{align*}
+        (D^2)^{D^2}\prod_{i} s_i^2
+        &\le \Bigl(\sum_i s_i^2\Bigr)^{D^2}
+        = (D^2)^{D^2}\,\tr[\tau^\dagger\tau]^{D^2}.
+    \end{align*}
+    Cancelling $(D^2)^{D^2}$ gives $|\det T|^2\le\tr[\tau^\dagger\tau]^{D^2}$,
+    and taking square roots gives the stated bound.
+\end{proof}

--- a/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
@@ -334,14 +334,16 @@ This section states the existence theorems from
     Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow'}
     \leanok
     \uses{lem:amgm_prod_sum}
-    For a positive-semidefinite matrix $M$ whose rows and columns are indexed
-    by a finite set with $D$ elements,
+    For a positive-semidefinite $D \times D$ matrix $M$,
     \begin{align}
         D^{D}\det M
         &\leq(\tr M)^{D},
         \label{eq:representations_trace_det_amgm}
     \end{align}
-    and equality holds if and only if $M=(\tr M/D)\Id$.
+    and equality holds if and only if $M=(\tr M/D)\Id$. The inequality holds
+    for a positive-semidefinite matrix whose rows and columns are indexed by
+    any finite set with $D$ elements; the equality characterization is stated
+    only for $D \times D$ matrices.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -349,8 +351,10 @@ This section states the existence theorems from
     $\tr M=\sum_{i}\lambda_{i}$ are expressed through the non-negative
     eigenvalues $\lambda_i$ of $M$. The bound is the
     arithmetic--geometric-mean inequality with uniform weights $1/D$, raised
-    to the $D$-th power; equality holds exactly when all eigenvalues coincide,
-    that is, when $M$ is a scalar matrix.
+    to the $D$-th power; for a $D \times D$ matrix, equality holds exactly
+    when all eigenvalues coincide, that is, when $M$ is a scalar matrix.
+    Relabelling the index set along a bijection to $\{0,\ldots,D-1\}$ carries
+    the inequality to an arbitrary finite index set.
 \end{proof}
 
 % Lean: Wolf.exists_normal_form_generic

--- a/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
@@ -353,8 +353,8 @@ This section states the existence theorems from
     arithmetic--geometric-mean inequality with uniform weights $1/D$, raised
     to the $D$-th power; for a $D \times D$ matrix, equality holds exactly
     when all eigenvalues coincide, that is, when $M$ is a scalar matrix.
-    Relabelling the index set along a bijection to $\{0,\ldots,D-1\}$ carries
-    the inequality to an arbitrary finite index set.
+    Relabelling along a bijection with the index set of a $D \times D$ matrix
+    carries the inequality to an arbitrary finite index set of $D$ elements.
 \end{proof}
 
 % Lean: Wolf.exists_normal_form_generic

--- a/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
@@ -297,12 +297,14 @@ This section states the existence theorems from
     so the minimiser on the compact set is a global minimiser.
 \end{proof}
 
-% Lean: pow_card_mul_prod_le_sum_pow
+% Lean: pow_card_mul_prod_le_sum_pow, pow_card_mul_prod_le_sum_pow'
 \begin{lemma}[Arithmetic--geometric-mean inequality, product/sum form]
 \label{lem:amgm_prod_sum}
-    \lean{pow_card_mul_prod_le_sum_pow}
+    \lean{pow_card_mul_prod_le_sum_pow, pow_card_mul_prod_le_sum_pow'}
     \leanok
-    For a non-negative family $f_{0},\ldots,f_{D-1}$ of real numbers,
+    For a non-negative family $f_{0},\ldots,f_{D-1}$ of real numbers, or more
+    generally for a non-negative family indexed by a finite set with $D$
+    elements,
     \begin{align}
         D^{D}\prod_{i}f_{i}
         &\leq\left(\sum_{i}f_{i}\right)^{D}.
@@ -323,14 +325,17 @@ This section states the existence theorems from
 \end{proof}
 
 % Lean: Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow,
-% Matrix.PosSemidef.pow_card_mul_det_re_eq_trace_re_pow_iff
+% Matrix.PosSemidef.pow_card_mul_det_re_eq_trace_re_pow_iff,
+% Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow'
 \begin{lemma}[Trace--determinant AM--GM for positive-semidefinite matrices]
 \label{lem:trace_det_amgm}
     \lean{Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow,
-    Matrix.PosSemidef.pow_card_mul_det_re_eq_trace_re_pow_iff}
+    Matrix.PosSemidef.pow_card_mul_det_re_eq_trace_re_pow_iff,
+    Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow'}
     \leanok
     \uses{lem:amgm_prod_sum}
-    For a positive-semidefinite $D \times D$ matrix $M$,
+    For a positive-semidefinite matrix $M$ whose rows and columns are indexed
+    by a finite set with $D$ elements,
     \begin{align}
         D^{D}\det M
         &\leq(\tr M)^{D},


### PR DESCRIPTION
## Source

Wolf, *Quantum Channels & Operations*, Chapter 6,
`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 520–545
(Proposition "Determinant and Choi–Jamiolkowski operator", Eq. (6.27)).

As printed:

> Let $T:\mathcal{M}_d\to\mathcal{M}_d$ be a **linear map** and $\tau$ the corresponding
> Choi–Jamiolkowski operator. Then
> $$|\det T| \le \tr[\tau^\dagger \tau]^{d^2/2}.$$

with the proof through Eq. (6.28), $\tr[\tau^\dagger\tau]=\frac{1}{d^2}\tr[\widehat{T}^\dagger\widehat{T}]=\frac{1}{d^2}\sum_i s_i^2$,
Eq. (2.22) $\widehat{T}=d\,\tau^\Gamma$, and the geometric–arithmetic mean inequality
together with $|\det T|=\prod_i s_i$.

This is **item 4 of the five acceptance criteria of LionSR/QICLean#38**. Items 1, 2, 3 and 5 are
untouched here.

## Landed signature

```lean
theorem norm_channelDet_le_choiPurity_rpow {d : ℕ} (T : ChannelDeterminant.Internal.MatrixEnd d) :
    ‖channelDet T‖ ≤ choiPurity T ^ ((d : ℝ) ^ 2 / 2)
```

with the squared workhorse form

```lean
theorem norm_channelDet_sq_le_choiPurity_pow {d : ℕ} (T : ChannelDeterminant.Internal.MatrixEnd d) :
    ‖channelDet T‖ ^ 2 ≤ choiPurity T ^ (d ^ 2)
```

where

```lean
noncomputable def choiPurity {d : ℕ} (T : ChannelDeterminant.Internal.MatrixEnd d) : ℝ :=
  ((ChoiJamiolkowski.choiMatrix T)ᴴ * ChoiJamiolkowski.choiMatrix T).trace.re
```

## Hypothesis-by-hypothesis match

| Wolf | Lean |
|---|---|
| $T:\mathcal{M}_d\to\mathcal{M}_d$ linear | `T : MatrixAlg d →ₗ[ℂ] MatrixAlg d` (`MatrixEnd d`) |
| $\tau$ the Choi–Jamiolkowski operator of $T$ | `ChoiJamiolkowski.choiMatrix T` |
| $\det T$ | `channelDet T`, the determinant of the matrix of `T` in the matrix-unit basis (`= LinearMap.det T`) |
| $\tr[\tau^\dagger\tau]$ | `choiPurity T` |
| conclusion $|\det T|\le\tr[\tau^\dagger\tau]^{d^2/2}$ | `‖channelDet T‖ ≤ choiPurity T ^ ((d : ℝ) ^ 2 / 2)` |

**No hypothesis is added.** In particular the statement assumes neither positivity,
nor complete positivity, nor trace preservation, nor unitality, nor `d > 0`; it
quantifies over every `ℂ`-linear endomorphism of `M_d(ℂ)`. The `d = 0` case is
covered: both sides equal `1`.

## Normalization convention, as verified against the definitions

TNLean's Choi operator is normalized and ordered output × input:
`ChoiJamiolkowski.choiMatrix T (i₁,i₂) (j₁,j₂) = (1/d)·(T E_{i₂j₂})_{i₁j₁}`
(`ChoiJamiolkowski.omegaSlice_eq_single` plus `omegaCoeff_eq_inv`; the convention is
already recorded in `def:choi_matrix`), while the matrix representation in the
matrix-unit basis has
`channelMatrix T (i₁,i₂,·) (j₁,j₂,·) = (T E_{j₁j₂})_{i₁i₂}`.

Hence the reshuffling is exactly Wolf's Eq. (2.22),

```lean
channelMatrix T (i₁, i₂, u) (j₁, j₂, v) = (d : ℂ) * ChoiJamiolkowski.choiMatrix T (i₁, j₁) (i₂, j₂)
```

`channelMatrix_apply_eq_choiMatrix`, matching
$\bra{m,n}\tau^\Gamma\ket{k,\ell}=\bra{m,k}\tau\ket{n,\ell}$ with row pair $(m,n)=(i_1,i_2)$
and column pair $(k,\ell)=(j_1,j_2)$.

Since the reshuffling permutes index quadruples without repetition, the sums of squared
entry moduli agree up to the factor $d^2$, giving Wolf Eq. (6.28) in the form

```lean
trace_conjTranspose_mul_self_channelMatrix :
    ((channelMatrix T)ᴴ * channelMatrix T).trace.re = (d : ℝ) ^ 2 * choiPurity T
```

so **the normalization factor is exactly `d²`**, i.e. `tr[τ†τ] = (1/d²)·tr[T̂ᴴT̂]` as printed.
This is what makes the two `(d²)^{d²}` factors cancel in the final estimate, leaving the
`d`-free bound.

## New Layer-0 material

`TNLean/Analysis/DeterminantTraceBound.lean` (generic matrix facts, per
`docs/import_structure.md`):

* `pow_card_mul_prod_le_sum_pow'` — arithmetic–geometric mean in product/sum form over an
  arbitrary finite index type (the existing lemma in `MatrixTraceInequalities` is indexed by
  `Fin D`; a matrix whose rows are labelled by index pairs needs the general form).
* `Matrix.PosSemidef.pow_card_mul_det_re_le_trace_re_pow'` — its trace–determinant form.
* `Matrix.trace_conjTranspose_mul_self_re` — `tr[Aᴴ A] = ∑_{i,j} |A_{ij}|²`.
* `Matrix.pow_card_mul_norm_det_sq_le_trace_conjTranspose_mul_self_pow` —
  `D^D · |det A|² ≤ tr[Aᴴ A]^D`, Wolf's geometric–arithmetic mean step.

No existing file's statements were changed; the `Fin D` lemmas and their call sites are
untouched.

## Blueprint

New `\input` sub-file `blueprint/src/chapter/ch16_channel_representations_determinant_choi_bound.tex`
(section "Determinant and Choi–Jamiolkowski operator"), wired into
`ch16_channel_representations.tex`. It carries `def:choi_purity`,
`lem:channel_matrix_eq_reshuffled_choi`, `lem:choi_purity_eq_hilbert_schmidt` and
`thm:channelDet_le_choi_purity`, all with `\lean{...}`/`\leanok` and `\leanok` on the proofs.
No line shifts in any file with a `docs/tenkz/DISPOSITIONS.md` anchor.

## Verification

| Command | Outcome |
|---|---|
| `lake env lean TNLean/Analysis/DeterminantTraceBound.lean` | clean |
| `lake env lean TNLean/Channel/Determinant/ChoiBound.lean` | clean |
| `lake env lean TNLean/Channel/Determinant.lean` | clean |
| `lake build TNLean.Channel` | `Build completed successfully (9105 jobs)` |
| `lake exe lint_style` | exit 0 |
| `rg -n "sorry\|axiom"` on changed files | no matches |
| `#print axioms norm_channelDet_le_choiPurity_rpow` | `[propext, Classical.choice, Quot.sound]` |
| `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` | aggregators current |
| `python3 scripts/blueprint_lean_sync.py --ci` | `✓ Blueprint and Lean code are in sync.` |
| `python3 scripts/check_tenkz_dispositions.py` | `PASS: 202 blueprint occurrences and 9 standalone fixtures reconcile exactly` |

`leanblueprint checkdecls` is CI-only (`blueprint/lean_decls` is generated there).

Refs LionSR/QICLean#38

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style analysis and channel theory with no runtime, auth, or data-path changes; existing `Fin D` lemmas are unchanged.
> 
> **Overview**
> Adds **Wolf Eq. (6.27)**: for any linear map `T : M_d(ℂ) → M_d(ℂ)`, `‖channelDet T‖` is bounded by the **Choi purity** `choiPurity T = tr[τ†τ]` raised to `(d²/2)`, with no CP/TP/unitality assumptions.
> 
> New **`TNLean/Analysis/DeterminantTraceBound.lean`** lifts existing `Fin D` AM–GM inequalities to arbitrary finite index types and proves `D^D · |det A|² ≤ tr[Aᴴ A]^D`. **`TNLean/Channel/Determinant/ChoiBound.lean`** defines `choiPurity`, proves the matrix-unit vs Choi **reshuffling** (`A = d τ^Γ`) and `tr[T̂†T̂] = d² · choiPurity`, then applies the determinant–trace bound to `channelMatrix T` and cancels the `(d²)^{d²}` factors.
> 
> Aggregator imports and channel determinant module docs are updated; blueprint gains **`ch16_channel_representations_determinant_choi_bound.tex`** and extends the existing trace–determinant AM–GM lemma tags for the generalized index-type variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe8e52cddd0f87ec6fc25068221e61d35b995f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->