### PR TITLE
feat(Channel): Wolf's self-dual channel equivalence

### DIFF
--- a/TNLean/Algebra/MatrixTracePairing.lean
+++ b/TNLean/Algebra/MatrixTracePairing.lean
@@ -38,6 +38,7 @@ linear map between matrix algebras.
 * `Matrix.traceBilinForm_nondegenerate` — nondegeneracy of the bilinear trace pairing
 * `Matrix.exists_identity_traceless_basis` — an identity-plus-traceless basis
 * `Matrix.trace_traceAdjointMap_mul` — the adjoint satisfies `tr(E*(ρ) X) = tr(ρ E(X))`
+* `Matrix.traceAdjointMap_apply_apply` — the entries of the adjoint against matrix units
 * `Matrix.traceAdjointMap_traceAdjointMap` — the trace-pairing adjoint is involutive
 * `Matrix.traceAdjointMap_comp` — the trace-pairing adjoint reverses composition
 -/
@@ -250,6 +251,16 @@ theorem trace_traceAdjointMap_mul {n m : Type*} [Fintype n] [Fintype m]
       simp [Matrix.single, smul_eq_mul]
     rw [hsingle, map_smul, Matrix.mul_smul, Matrix.trace_smul]
     simp [traceAdjointMap, Matrix.trace_mul_single, MulOpposite.op_one, one_smul]
+
+/-- Entries of the trace-pairing adjoint: E*(ρ)ᵢⱼ = tr(ρ E(Eⱼᵢ)) with Eⱼᵢ the
+matrix unit. -/
+theorem traceAdjointMap_apply_apply {n m : Type*} [Fintype n] [Fintype m]
+    [DecidableEq n] (E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ)
+    (ρ : Matrix m m ℂ) (i j : n) :
+    traceAdjointMap E ρ i j = Matrix.trace (ρ * E (Matrix.single j i 1)) := by
+  have hsingle := Matrix.trace_mul_single (traceAdjointMap E ρ) j i (1 : ℂ)
+  rw [trace_traceAdjointMap_mul] at hsingle
+  simpa using hsingle.symm
 
 /-- The trace-pairing adjoint is involutive.
 

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -90,6 +90,7 @@ import TNLean.Channel.SchmidtNumberCompact
 import TNLean.Channel.SchmidtNumberFactors
 import TNLean.Channel.SchmidtRank
 import TNLean.Channel.Schwarz
+import TNLean.Channel.SelfDual
 import TNLean.Channel.Semigroup
 import TNLean.Channel.Separable
 import TNLean.Channel.SingleKraus

--- a/TNLean/Channel/SelfDual.lean
+++ b/TNLean/Channel/SelfDual.lean
@@ -7,46 +7,53 @@ import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.TransferMatrix
 
 /-!
-# Self-dual channels (Wolf Section 2.2)
+# Self-dual channels (Wolf §2.3, Proposition 2.6)
 
-Let T : M_d(ℂ) → M_d(ℂ) be completely positive and let T* be its dual,
-characterized by tr[A T*(B)] = tr[T(A) B]. Wolf §2, line 578 states that
+Let $T : M_d(\mathbb C) \to M_d(\mathbb C)$ be completely positive and let $T^*$ be
+its dual, characterized by
+\(\operatorname{tr}[A\, T^*(B)] = \operatorname{tr}[T(A)\, B]\). Wolf's
+Proposition 2.6 states that
 
-1. T = T*,
-2. the transfer matrix tr[σ_α† T(σ_β)] is Hermitian,
-3. T(X) = ∑_j K_j X K_j† for a family of Hermitian K_j
+1. $T = T^*$,
+2. the transfer matrix \(\operatorname{tr}[\sigma_\alpha^\dagger T(\sigma_\beta)]\)
+   is Hermitian,
+3. \(T(X) = \sum_j K_j X K_j^\dagger\) for a family of Hermitian $K_j$
 
 are equivalent.
 
 ## Basis convention
 
-Wolf's transfer matrix tr[F_α† T(G_β)] (Eq. (2.20)) is built from two orthonormal
-families; condition 2 is the special case F_α = G_α = σ_α. Orthonormality is with
-respect to the Hilbert-Schmidt inner product, tr[σ_α† σ_β] = δ_{αβ} (Eq. (2.18)
-with P = 𝟙), and this is the convention carried by `HilbertSchmidtOrthonormal`.
-Hermiticity of the family plays no role in the equivalence; a Hermitian
-Hilbert-Schmidt orthonormal basis is precisely a `TracePairingSelfDualBasis`, since
-for σ_α† = σ_α the two pairings tr[σ_α† X] and tr[σ_α X] coincide.
+Wolf's transfer matrix \(\operatorname{tr}[F_\alpha^\dagger T(G_\beta)]\)
+(Equation (2.20)) is built from two orthonormal families; condition 2 is the special
+case $F_\alpha = G_\alpha = \sigma_\alpha$. Orthonormality is with respect to the
+Hilbert-Schmidt inner product
+\(\operatorname{tr}[\sigma_\alpha^\dagger \sigma_\beta] = \delta_{\alpha\beta}\)
+(Equation (2.18) with $P = \mathbf 1$), and this is the convention carried by
+`HilbertSchmidtOrthonormal`. Hermiticity of the family plays no role in the
+equivalence; a Hermitian Hilbert-Schmidt orthonormal basis is precisely a
+`TracePairingSelfDualBasis`, since for $\sigma_\alpha^\dagger = \sigma_\alpha$ the
+two pairings \(\operatorname{tr}[\sigma_\alpha^\dagger X]\) and
+\(\operatorname{tr}[\sigma_\alpha X]\) coincide.
 
 ## Main definitions
 
-* `HilbertSchmidtOrthonormal` — tr[σ_α† σ_β] = δ_{αβ} (Wolf Eq. (2.18) with P = 𝟙)
-* `transferMatrixOfBasis` — Wolf Eq. (2.20) for identical families F_α = G_α
+* `HilbertSchmidtOrthonormal` —
+  \(\operatorname{tr}[\sigma_\alpha^\dagger \sigma_\beta] = \delta_{\alpha\beta}\)
+  (Wolf Equation (2.18) with $P = \mathbf 1$)
+* `transferMatrixOfBasis` — Wolf Equation (2.20) for identical families
+  $F_\alpha = G_\alpha$
 
 ## Main results
 
-* `self_dual_tfae` — Wolf §2, line 578: the three-way equivalence
-* `transferMatrixOfBasis_injective` — a map is determined by its transfer matrix in a
-  Hilbert-Schmidt orthonormal basis
+* `self_dual_tfae` — Wolf Proposition 2.6: the three-way equivalence
 * `transferMatrixOfBasis_isHermitian_iff` — condition 1 versus condition 2
 * `transferMatrix_isHermitian_iff_traceAdjointMap_eq_self` — condition 2 for the
   matrix-unit transfer matrix of `TNLean.Channel.TransferMatrix`
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.2, proposition
-  "Self-dual channels" at `Notes/WolfNoteTexSource/ch02_representations.tex`
-  line 578][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3,
+  Proposition 2.6][Wolf2012Quantum]
 -/
 
 open scoped Matrix BigOperators Kronecker
@@ -56,7 +63,8 @@ variable {D : ℕ}
 /-! ### Hilbert-Schmidt orthonormal families -/
 
 /-- A family of matrices is **Hilbert-Schmidt orthonormal** when
-tr[σ_α† σ_β] = δ_{αβ} (Wolf §2, Eq. (2.18) with P = 𝟙). -/
+\(\operatorname{tr}[\sigma_\alpha^\dagger \sigma_\beta] = \delta_{\alpha\beta}\)
+(Wolf Equation (2.18) with $P = \mathbf 1$). -/
 def HilbertSchmidtOrthonormal {ι : Type*} [DecidableEq ι]
     (σ : ι → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   ∀ α β, Matrix.trace ((σ α)ᴴ * σ β) = if α = β then 1 else 0
@@ -66,8 +74,8 @@ namespace HilbertSchmidtOrthonormal
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 variable {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
 
-/-- In a Hilbert-Schmidt orthonormal basis the coordinates of X are the pairings
-tr[σ_α† X]. -/
+/-- In a Hilbert-Schmidt orthonormal basis the coordinates of $X$ are the pairings
+\(\operatorname{tr}[\sigma_\alpha^\dagger X]\). -/
 theorem repr_apply (hσ : HilbertSchmidtOrthonormal (σ ·))
     (X : Matrix (Fin D) (Fin D) ℂ) (α : ι) :
     σ.repr X α = Matrix.trace ((σ α)ᴴ * X) := by
@@ -78,7 +86,8 @@ theorem repr_apply (hσ : HilbertSchmidtOrthonormal (σ ·))
   simp
 
 /-- A Hermitian Hilbert-Schmidt orthonormal basis is trace-self-dual: for
-σ_α† = σ_α the coordinate functionals are X ↦ tr[σ_α X]. -/
+$\sigma_\alpha^\dagger = \sigma_\alpha$ the coordinate functionals are
+$X \mapsto \operatorname{tr}[\sigma_\alpha X]$. -/
 theorem tracePairingSelfDualBasis (hσ : HilbertSchmidtOrthonormal (σ ·))
     (hherm : ∀ α, (σ α)ᴴ = σ α) : TracePairingSelfDualBasis σ := by
   intro α X
@@ -97,8 +106,9 @@ end HilbertSchmidtOrthonormal
 
 /-! ### The transfer matrix in a single orthonormal family -/
 
-/-- The **transfer matrix** of T in the family σ used on both sides,
-tr[σ_α† T(σ_β)]. This is Wolf Eq. (2.20) with F_α = G_α = σ_α. -/
+/-- The **transfer matrix** of $T$ in the family $\sigma$ used on both sides,
+\(\operatorname{tr}[\sigma_\alpha^\dagger T(\sigma_\beta)]\). This is Wolf
+Equation (2.20) with $F_\alpha = G_\alpha = \sigma_\alpha$. -/
 noncomputable def transferMatrixOfBasis {ι : Type*}
     (σ : ι → Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
@@ -111,8 +121,8 @@ theorem transferMatrixOfBasis_apply {ι : Type*}
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) (α β : ι) :
     transferMatrixOfBasis σ T α β = Matrix.trace ((σ α)ᴴ * T (σ β)) := rfl
 
-/-- **Wolf §2, line 573**: for a Hermiticity-preserving map the dual map is
-represented by the Hermitian conjugate transfer matrix. -/
+/-- For a Hermiticity-preserving map the dual map is represented by the Hermitian
+conjugate transfer matrix (Wolf §2.3, paragraph following Equation (2.20)). -/
 theorem transferMatrixOfBasis_conjTranspose {ι : Type*}
     (σ : ι → Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -126,12 +136,12 @@ theorem transferMatrixOfBasis_conjTranspose {ι : Type*}
     Matrix.trace_mul_comm, Matrix.trace_mul_comm ((σ α)ᴴ)]
   exact (Matrix.trace_traceAdjointMap_mul T (σ β) ((σ α)ᴴ)).symm
 
-/-- **The transfer matrix in a Hilbert-Schmidt orthonormal basis determines the
-map**: equal transfer matrices force equal maps.  Pairing the difference against
-every basis element gives tr[σ_α† (T − S)(σ_β)] = 0 for all α, and
-nondegeneracy of the Hilbert-Schmidt pairing forces (T − S)(σ_β) = 0 on a
-basis. -/
-theorem transferMatrixOfBasis_injective {ι : Type*} [Fintype ι] [DecidableEq ι]
+/-- The transfer matrix in a Hilbert-Schmidt orthonormal basis determines the map:
+\(\widehat T = \widehat S\) forces $T = S$. Pairing the difference against every
+basis element gives \(\operatorname{tr}[\sigma_\alpha^\dagger (T - S)(\sigma_\beta)]
+= 0\), and nondegeneracy of the Hilbert-Schmidt pairing forces
+\((T - S)(\sigma_\beta) = 0\) on a basis. -/
+private theorem transferMatrixOfBasis_injective {ι : Type*} [Fintype ι] [DecidableEq ι]
     {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
     (hσ : HilbertSchmidtOrthonormal (σ ·)) :
     Function.Injective (transferMatrixOfBasis (D := D) (σ ·)) := by
@@ -140,9 +150,10 @@ theorem transferMatrixOfBasis_injective {ι : Type*} [Fintype ι] [DecidableEq �
   refine sub_eq_zero.mp (hσ.eq_zero_of_trace_conjTranspose_mul fun α => ?_)
   have hαβ := congrFun (congrFun h α) β
   rw [transferMatrixOfBasis_apply, transferMatrixOfBasis_apply] at hαβ
-  rw [Matrix.mul_sub, Matrix.trace_sub, hαβ, sub_self]
+  rw [Matrix.mul_sub, Matrix.trace_sub, hαβ]
+  simp
 
-/-- **Wolf §2, line 578, conditions 1 and 2**: for a Hermiticity-preserving map the
+/-- **Wolf Proposition 2.6, conditions 1 and 2**: for a Hermiticity-preserving map the
 transfer matrix in a Hilbert-Schmidt orthonormal basis used on both sides is
 Hermitian exactly when the map equals its dual. -/
 theorem transferMatrixOfBasis_isHermitian_iff {ι : Type*} [Fintype ι] [DecidableEq ι]
@@ -157,8 +168,9 @@ theorem transferMatrixOfBasis_isHermitian_iff {ι : Type*} [Fintype ι] [Decidab
 
 /-! ### Kraus families and the dual map -/
 
-/-- The dual map of T(X) = ∑ᵢ Kᵢ X Kᵢ† is T*(X) = ∑ᵢ Kᵢ† X Kᵢ: the Kraus
-operators of T and T* differ by Hermitian conjugation (Wolf §2, line 308). -/
+/-- The dual map of \(T(X) = \sum_i K_i X K_i^\dagger\) is
+\(T^*(X) = \sum_i K_i^\dagger X K_i\): the Kraus operators of $T$ and $T^*$ differ
+by Hermitian conjugation (Wolf §2.2, remark following Proposition 2.4). -/
 theorem traceAdjointMap_of_kraus {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ)
@@ -189,11 +201,13 @@ theorem IsCPMap.map_conjTranspose
   obtain ⟨r, K, hK⟩ := hT
   exact map_conjTranspose_of_kraus K T hK X
 
-/-- **Wolf §2, line 578, direction 1 → 3**: a map with the two Kraus
-representations T(X) = ∑ⱼ Kⱼ X Kⱼ† and T(X) = ∑ⱼ Kⱼ† X Kⱼ is written as
-T(X) = ½ ∑ⱼ (Kⱼ X Kⱼ† + Kⱼ† X Kⱼ), and the unitary recombination
-(a, b) ↦ ((a + b)/√2, i(a - b)/√2) turns every pair (Kⱼ, Kⱼ†)/√2 into the
-Hermitian pair (Kⱼ + Kⱼ†)/2, i(Kⱼ - Kⱼ†)/2. -/
+/-- **Wolf Proposition 2.6, direction \(1 \to 3\)**: a map with the two Kraus
+representations \(T(X) = \sum_j K_j X K_j^\dagger\) and
+\(T(X) = \sum_j K_j^\dagger X K_j\) is written as
+\(T(X) = \frac{1}{2} \sum_j (K_j X K_j^\dagger + K_j^\dagger X K_j)\), and the
+unitary recombination \((a, b) \mapsto ((a + b)/\sqrt{2},\ i(a - b)/\sqrt{2})\)
+turns every pair \((K_j, K_j^\dagger)/\sqrt{2}\) into the Hermitian pair
+\((K_j + K_j^\dagger)/2\), \(i(K_j - K_j^\dagger)/2\). -/
 theorem exists_hermitian_kraus_of_self_dual {r : ℕ}
     (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -299,13 +313,15 @@ theorem exists_hermitian_kraus_of_self_dual {r : ℕ}
 
 /-! ### The self-dual channel proposition -/
 
-/-- **Wolf §2, line 578 (self-dual channels)**: for a completely positive map
-T : M_d(ℂ) → M_d(ℂ) the following are equivalent.
+/-- **Wolf Proposition 2.6 (self-dual channels)**: for a completely positive map
+$T : M_d(\mathbb C) \to M_d(\mathbb C)$ the following are equivalent.
 
-1. T equals its dual T*, characterized by tr[A T*(B)] = tr[T(A) B].
-2. The transfer matrix tr[σ_α† T(σ_β)] in one Hilbert-Schmidt orthonormal basis σ
-   used on both sides is Hermitian.
-3. T admits a family of Hermitian Kraus operators. -/
+1. $T$ equals its dual $T^*$, characterized by
+   \(\operatorname{tr}[A\, T^*(B)] = \operatorname{tr}[T(A)\, B]\).
+2. The transfer matrix \(\operatorname{tr}[\sigma_\alpha^\dagger T(\sigma_\beta)]\)
+   in one Hilbert-Schmidt orthonormal basis $\sigma$ used on both sides is
+   Hermitian.
+3. $T$ admits a family of Hermitian Kraus operators. -/
 theorem self_dual_tfae {ι : Type*} [Fintype ι] [DecidableEq ι]
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsCPMap T)
@@ -337,7 +353,8 @@ theorem self_dual_tfae {ι : Type*} [Fintype ι] [DecidableEq ι]
 /-! ### Condition 2 in the basis of matrix units -/
 
 /-- For a Hermiticity-preserving map the matrix-unit transfer matrix of the dual
-map is the Hermitian conjugate transfer matrix (Wolf §2, line 573). -/
+map is the Hermitian conjugate transfer matrix (Wolf §2.3, paragraph following
+Equation (2.20)). -/
 theorem transferMatrix_conjTranspose_eq_traceAdjointMap
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hHP : ∀ X, T Xᴴ = (T X)ᴴ) :
@@ -350,7 +367,7 @@ theorem transferMatrix_conjTranspose_eq_traceAdjointMap
   rw [hswap]
   simp
 
-/-- **Wolf §2, line 578, conditions 1 and 2 in matrix units**: a completely positive
+/-- **Wolf Proposition 2.6, conditions 1 and 2 in matrix units**: a completely positive
 map equals its dual exactly when its matrix-unit transfer matrix is Hermitian. -/
 theorem transferMatrix_isHermitian_iff_traceAdjointMap_eq_self
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/Channel/SelfDual.lean
+++ b/TNLean/Channel/SelfDual.lean
@@ -9,33 +9,35 @@ import TNLean.Channel.TransferMatrix
 /-!
 # Self-dual channels (Wolf Section 2.2)
 
-Let `T : M_d(ℂ) → M_d(ℂ)` be completely positive and let `T*` be its dual,
-characterized by `tr[A T*(B)] = tr[T(A) B]`. Wolf §2, line 578 states that
+Let T : M_d(ℂ) → M_d(ℂ) be completely positive and let T* be its dual,
+characterized by tr[A T*(B)] = tr[T(A) B]. Wolf §2, line 578 states that
 
-1. `T = T*`,
-2. the transfer matrix `tr[σ_α† T(σ_β)]` is Hermitian,
-3. `T(X) = ∑_j K_j X K_j†` for a family of Hermitian `K_j`
+1. T = T*,
+2. the transfer matrix tr[σ_α† T(σ_β)] is Hermitian,
+3. T(X) = ∑_j K_j X K_j† for a family of Hermitian K_j
 
 are equivalent.
 
 ## Basis convention
 
-Wolf's transfer matrix `tr[F_α† T(G_β)]` (Eq. (2.20)) is built from two orthonormal
-families; condition 2 is the special case `F_α = G_α = σ_α`. Orthonormality is with
-respect to the Hilbert-Schmidt inner product, `tr[σ_α† σ_β] = δ_{αβ}` (Eq. (2.18)
-with `P = 𝟙`), and this is the convention carried by `HilbertSchmidtOrthonormal`.
+Wolf's transfer matrix tr[F_α† T(G_β)] (Eq. (2.20)) is built from two orthonormal
+families; condition 2 is the special case F_α = G_α = σ_α. Orthonormality is with
+respect to the Hilbert-Schmidt inner product, tr[σ_α† σ_β] = δ_{αβ} (Eq. (2.18)
+with P = 𝟙), and this is the convention carried by `HilbertSchmidtOrthonormal`.
 Hermiticity of the family plays no role in the equivalence; a Hermitian
 Hilbert-Schmidt orthonormal basis is precisely a `TracePairingSelfDualBasis`, since
-for `σ_α† = σ_α` the two pairings `tr[σ_α† X]` and `tr[σ_α X]` coincide.
+for σ_α† = σ_α the two pairings tr[σ_α† X] and tr[σ_α X] coincide.
 
 ## Main definitions
 
-* `HilbertSchmidtOrthonormal` — `tr[σ_α† σ_β] = δ_{αβ}` (Wolf Eq. (2.18) with `P = 𝟙`)
-* `transferMatrixOfBasis` — Wolf Eq. (2.20) for identical families `F_α = G_α`
+* `HilbertSchmidtOrthonormal` — tr[σ_α† σ_β] = δ_{αβ} (Wolf Eq. (2.18) with P = 𝟙)
+* `transferMatrixOfBasis` — Wolf Eq. (2.20) for identical families F_α = G_α
 
 ## Main results
 
-* `selfDual_tfae` — Wolf §2, line 578: the three-way equivalence
+* `self_dual_tfae` — Wolf §2, line 578: the three-way equivalence
+* `transferMatrixOfBasis_injective` — a map is determined by its transfer matrix in a
+  Hilbert-Schmidt orthonormal basis
 * `transferMatrixOfBasis_isHermitian_iff` — condition 1 versus condition 2
 * `transferMatrix_isHermitian_iff_traceAdjointMap_eq_self` — condition 2 for the
   matrix-unit transfer matrix of `TNLean.Channel.TransferMatrix`
@@ -48,14 +50,13 @@ for `σ_α† = σ_α` the two pairings `tr[σ_α† X]` and `tr[σ_α X]` coinc
 -/
 
 open scoped Matrix BigOperators Kronecker
-open Matrix Finset
 
 variable {D : ℕ}
 
 /-! ### Hilbert-Schmidt orthonormal families -/
 
 /-- A family of matrices is **Hilbert-Schmidt orthonormal** when
-`tr[σ_α† σ_β] = δ_{αβ}` (Wolf §2, Eq. (2.18) with `P = 𝟙`). -/
+tr[σ_α† σ_β] = δ_{αβ} (Wolf §2, Eq. (2.18) with P = 𝟙). -/
 def HilbertSchmidtOrthonormal {ι : Type*} [DecidableEq ι]
     (σ : ι → Matrix (Fin D) (Fin D) ℂ) : Prop :=
   ∀ α β, Matrix.trace ((σ α)ᴴ * σ β) = if α = β then 1 else 0
@@ -65,8 +66,8 @@ namespace HilbertSchmidtOrthonormal
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 variable {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
 
-/-- In a Hilbert-Schmidt orthonormal basis the coordinates of `X` are the pairings
-`tr[σ_α† X]`. -/
+/-- In a Hilbert-Schmidt orthonormal basis the coordinates of X are the pairings
+tr[σ_α† X]. -/
 theorem repr_apply (hσ : HilbertSchmidtOrthonormal (σ ·))
     (X : Matrix (Fin D) (Fin D) ℂ) (α : ι) :
     σ.repr X α = Matrix.trace ((σ α)ᴴ * X) := by
@@ -77,7 +78,7 @@ theorem repr_apply (hσ : HilbertSchmidtOrthonormal (σ ·))
   simp
 
 /-- A Hermitian Hilbert-Schmidt orthonormal basis is trace-self-dual: for
-`σ_α† = σ_α` the coordinate functionals are `X ↦ tr[σ_α X]`. -/
+σ_α† = σ_α the coordinate functionals are X ↦ tr[σ_α X]. -/
 theorem tracePairingSelfDualBasis (hσ : HilbertSchmidtOrthonormal (σ ·))
     (hherm : ∀ α, (σ α)ᴴ = σ α) : TracePairingSelfDualBasis σ := by
   intro α X
@@ -96,8 +97,8 @@ end HilbertSchmidtOrthonormal
 
 /-! ### The transfer matrix in a single orthonormal family -/
 
-/-- The **transfer matrix** of `T` in the family `σ` used on both sides,
-`tr[σ_α† T(σ_β)]`. This is Wolf Eq. (2.20) with `F_α = G_α = σ_α`. -/
+/-- The **transfer matrix** of T in the family σ used on both sides,
+tr[σ_α† T(σ_β)]. This is Wolf Eq. (2.20) with F_α = G_α = σ_α. -/
 noncomputable def transferMatrixOfBasis {ι : Type*}
     (σ : ι → Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
@@ -109,15 +110,6 @@ theorem transferMatrixOfBasis_apply {ι : Type*}
     (σ : ι → Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) (α β : ι) :
     transferMatrixOfBasis σ T α β = Matrix.trace ((σ α)ᴴ * T (σ β)) := rfl
-
-/-- Entries of the trace-pairing adjoint: `T*(ρ)_{ij} = tr[ρ T(E_{ji})]`. -/
-theorem traceAdjointMap_apply_apply
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (i j : Fin D) :
-    Matrix.traceAdjointMap T ρ i j = Matrix.trace (ρ * T (Matrix.single j i 1)) := by
-  have hsingle := Matrix.trace_mul_single (Matrix.traceAdjointMap T ρ) j i (1 : ℂ)
-  rw [Matrix.trace_traceAdjointMap_mul] at hsingle
-  simpa using hsingle.symm
 
 /-- **Wolf §2, line 573**: for a Hermiticity-preserving map the dual map is
 represented by the Hermitian conjugate transfer matrix. -/
@@ -134,7 +126,11 @@ theorem transferMatrixOfBasis_conjTranspose {ι : Type*}
     Matrix.trace_mul_comm, Matrix.trace_mul_comm ((σ α)ᴴ)]
   exact (Matrix.trace_traceAdjointMap_mul T (σ β) ((σ α)ᴴ)).symm
 
-/-- The transfer matrix in a basis determines the map. -/
+/-- **The transfer matrix in a Hilbert-Schmidt orthonormal basis determines the
+map**: equal transfer matrices force equal maps.  Pairing the difference against
+every basis element gives tr[σ_α† (T − S)(σ_β)] = 0 for all α, and
+nondegeneracy of the Hilbert-Schmidt pairing forces (T − S)(σ_β) = 0 on a
+basis. -/
 theorem transferMatrixOfBasis_injective {ι : Type*} [Fintype ι] [DecidableEq ι]
     {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
     (hσ : HilbertSchmidtOrthonormal (σ ·)) :
@@ -161,8 +157,8 @@ theorem transferMatrixOfBasis_isHermitian_iff {ι : Type*} [Fintype ι] [Decidab
 
 /-! ### Kraus families and the dual map -/
 
-/-- The dual map of `T(X) = ∑ᵢ Kᵢ X Kᵢ†` is `T*(X) = ∑ᵢ Kᵢ† X Kᵢ`: the Kraus
-operators of `T` and `T*` differ by Hermitian conjugation (Wolf §2, line 308). -/
+/-- The dual map of T(X) = ∑ᵢ Kᵢ X Kᵢ† is T*(X) = ∑ᵢ Kᵢ† X Kᵢ: the Kraus
+operators of T and T* differ by Hermitian conjugation (Wolf §2, line 308). -/
 theorem traceAdjointMap_of_kraus {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ)
@@ -194,10 +190,10 @@ theorem IsCPMap.map_conjTranspose
   exact map_conjTranspose_of_kraus K T hK X
 
 /-- **Wolf §2, line 578, direction 1 → 3**: a map with the two Kraus
-representations `T(X) = ∑ⱼ Kⱼ X Kⱼ†` and `T(X) = ∑ⱼ Kⱼ† X Kⱼ` is written as
-`T(X) = ½ ∑ⱼ (Kⱼ X Kⱼ† + Kⱼ† X Kⱼ)`, and the unitary recombination
-`(a, b) ↦ ((a + b)/√2, i(a - b)/√2)` turns every pair `(Kⱼ, Kⱼ†)/√2` into the
-Hermitian pair `(Kⱼ + Kⱼ†)/2`, `i(Kⱼ - Kⱼ†)/2`. -/
+representations T(X) = ∑ⱼ Kⱼ X Kⱼ† and T(X) = ∑ⱼ Kⱼ† X Kⱼ is written as
+T(X) = ½ ∑ⱼ (Kⱼ X Kⱼ† + Kⱼ† X Kⱼ), and the unitary recombination
+(a, b) ↦ ((a + b)/√2, i(a - b)/√2) turns every pair (Kⱼ, Kⱼ†)/√2 into the
+Hermitian pair (Kⱼ + Kⱼ†)/2, i(Kⱼ - Kⱼ†)/2. -/
 theorem exists_hermitian_kraus_of_self_dual {r : ℕ}
     (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -304,13 +300,13 @@ theorem exists_hermitian_kraus_of_self_dual {r : ℕ}
 /-! ### The self-dual channel proposition -/
 
 /-- **Wolf §2, line 578 (self-dual channels)**: for a completely positive map
-`T : M_d(ℂ) → M_d(ℂ)` the following are equivalent.
+T : M_d(ℂ) → M_d(ℂ) the following are equivalent.
 
-1. `T` equals its dual `T*`, characterized by `tr[A T*(B)] = tr[T(A) B]`.
-2. The transfer matrix `tr[σ_α† T(σ_β)]` in one Hilbert-Schmidt orthonormal basis
-   `σ` used on both sides is Hermitian.
-3. `T` admits a family of Hermitian Kraus operators. -/
-theorem selfDual_tfae {ι : Type*} [Fintype ι] [DecidableEq ι]
+1. T equals its dual T*, characterized by tr[A T*(B)] = tr[T(A) B].
+2. The transfer matrix tr[σ_α† T(σ_β)] in one Hilbert-Schmidt orthonormal basis σ
+   used on both sides is Hermitian.
+3. T admits a family of Hermitian Kraus operators. -/
+theorem self_dual_tfae {ι : Type*} [Fintype ι] [DecidableEq ι]
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsCPMap T)
     {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
@@ -348,7 +344,7 @@ theorem transferMatrix_conjTranspose_eq_traceAdjointMap
     (transferMatrix T)ᴴ = transferMatrix (Matrix.traceAdjointMap T) := by
   ext ⟨j, i⟩ ⟨l, k⟩
   rw [Matrix.conjTranspose_apply, transferMatrix_apply, transferMatrix_apply,
-    traceAdjointMap_apply_apply, Matrix.trace_single_mul]
+    Matrix.traceAdjointMap_apply_apply, Matrix.trace_single_mul]
   have hswap := hHP (Matrix.single i j (1 : ℂ))
   rw [Matrix.conjTranspose_single, star_one] at hswap
   rw [hswap]

--- a/TNLean/Channel/SelfDual.lean
+++ b/TNLean/Channel/SelfDual.lean
@@ -1,0 +1,365 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KrausRepresentation
+import TNLean.Channel.TransferMatrix
+
+/-!
+# Self-dual channels (Wolf Section 2.2)
+
+Let `T : M_d(ℂ) → M_d(ℂ)` be completely positive and let `T*` be its dual,
+characterized by `tr[A T*(B)] = tr[T(A) B]`. Wolf §2, line 578 states that
+
+1. `T = T*`,
+2. the transfer matrix `tr[σ_α† T(σ_β)]` is Hermitian,
+3. `T(X) = ∑_j K_j X K_j†` for a family of Hermitian `K_j`
+
+are equivalent.
+
+## Basis convention
+
+Wolf's transfer matrix `tr[F_α† T(G_β)]` (Eq. (2.20)) is built from two orthonormal
+families; condition 2 is the special case `F_α = G_α = σ_α`. Orthonormality is with
+respect to the Hilbert-Schmidt inner product, `tr[σ_α† σ_β] = δ_{αβ}` (Eq. (2.18)
+with `P = 𝟙`), and this is the convention carried by `HilbertSchmidtOrthonormal`.
+Hermiticity of the family plays no role in the equivalence; a Hermitian
+Hilbert-Schmidt orthonormal basis is precisely a `TracePairingSelfDualBasis`, since
+for `σ_α† = σ_α` the two pairings `tr[σ_α† X]` and `tr[σ_α X]` coincide.
+
+## Main definitions
+
+* `HilbertSchmidtOrthonormal` — `tr[σ_α† σ_β] = δ_{αβ}` (Wolf Eq. (2.18) with `P = 𝟙`)
+* `transferMatrixOfBasis` — Wolf Eq. (2.20) for identical families `F_α = G_α`
+
+## Main results
+
+* `selfDual_tfae` — Wolf §2, line 578: the three-way equivalence
+* `transferMatrixOfBasis_isHermitian_iff` — condition 1 versus condition 2
+* `transferMatrix_isHermitian_iff_traceAdjointMap_eq_self` — condition 2 for the
+  matrix-unit transfer matrix of `TNLean.Channel.TransferMatrix`
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.2, proposition
+  "Self-dual channels" at `Notes/WolfNoteTexSource/ch02_representations.tex`
+  line 578][Wolf2012QChannels]
+-/
+
+open scoped Matrix BigOperators Kronecker
+open Matrix Finset
+
+variable {D : ℕ}
+
+/-! ### Hilbert-Schmidt orthonormal families -/
+
+/-- A family of matrices is **Hilbert-Schmidt orthonormal** when
+`tr[σ_α† σ_β] = δ_{αβ}` (Wolf §2, Eq. (2.18) with `P = 𝟙`). -/
+def HilbertSchmidtOrthonormal {ι : Type*} [DecidableEq ι]
+    (σ : ι → Matrix (Fin D) (Fin D) ℂ) : Prop :=
+  ∀ α β, Matrix.trace ((σ α)ᴴ * σ β) = if α = β then 1 else 0
+
+namespace HilbertSchmidtOrthonormal
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+variable {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
+
+/-- In a Hilbert-Schmidt orthonormal basis the coordinates of `X` are the pairings
+`tr[σ_α† X]`. -/
+theorem repr_apply (hσ : HilbertSchmidtOrthonormal (σ ·))
+    (X : Matrix (Fin D) (Fin D) ℂ) (α : ι) :
+    σ.repr X α = Matrix.trace ((σ α)ᴴ * X) := by
+  conv_rhs => rw [← σ.sum_repr X]
+  rw [Matrix.mul_sum, Matrix.trace_sum]
+  simp_rw [Matrix.mul_smul, Matrix.trace_smul, hσ α, smul_eq_mul, mul_ite,
+    mul_one, mul_zero]
+  simp
+
+/-- A Hermitian Hilbert-Schmidt orthonormal basis is trace-self-dual: for
+`σ_α† = σ_α` the coordinate functionals are `X ↦ tr[σ_α X]`. -/
+theorem tracePairingSelfDualBasis (hσ : HilbertSchmidtOrthonormal (σ ·))
+    (hherm : ∀ α, (σ α)ᴴ = σ α) : TracePairingSelfDualBasis σ := by
+  intro α X
+  rw [hσ.repr_apply X α, hherm]
+
+/-- A matrix pairing to zero against every member of a Hilbert-Schmidt orthonormal
+basis is zero. -/
+theorem eq_zero_of_trace_conjTranspose_mul (hσ : HilbertSchmidtOrthonormal (σ ·))
+    {X : Matrix (Fin D) (Fin D) ℂ} (h : ∀ α, Matrix.trace ((σ α)ᴴ * X) = 0) :
+    X = 0 := by
+  refine σ.repr.injective ?_
+  ext α
+  simp [hσ.repr_apply X α, h α]
+
+end HilbertSchmidtOrthonormal
+
+/-! ### The transfer matrix in a single orthonormal family -/
+
+/-- The **transfer matrix** of `T` in the family `σ` used on both sides,
+`tr[σ_α† T(σ_β)]`. This is Wolf Eq. (2.20) with `F_α = G_α = σ_α`. -/
+noncomputable def transferMatrixOfBasis {ι : Type*}
+    (σ : ι → Matrix (Fin D) (Fin D) ℂ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    Matrix ι ι ℂ :=
+  Matrix.of fun α β => Matrix.trace ((σ α)ᴴ * T (σ β))
+
+@[simp]
+theorem transferMatrixOfBasis_apply {ι : Type*}
+    (σ : ι → Matrix (Fin D) (Fin D) ℂ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) (α β : ι) :
+    transferMatrixOfBasis σ T α β = Matrix.trace ((σ α)ᴴ * T (σ β)) := rfl
+
+/-- Entries of the trace-pairing adjoint: `T*(ρ)_{ij} = tr[ρ T(E_{ji})]`. -/
+theorem traceAdjointMap_apply_apply
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (i j : Fin D) :
+    Matrix.traceAdjointMap T ρ i j = Matrix.trace (ρ * T (Matrix.single j i 1)) := by
+  have hsingle := Matrix.trace_mul_single (Matrix.traceAdjointMap T ρ) j i (1 : ℂ)
+  rw [Matrix.trace_traceAdjointMap_mul] at hsingle
+  simpa using hsingle.symm
+
+/-- **Wolf §2, line 573**: for a Hermiticity-preserving map the dual map is
+represented by the Hermitian conjugate transfer matrix. -/
+theorem transferMatrixOfBasis_conjTranspose {ι : Type*}
+    (σ : ι → Matrix (Fin D) (Fin D) ℂ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hHP : ∀ X, T Xᴴ = (T X)ᴴ) :
+    (transferMatrixOfBasis σ T)ᴴ =
+      transferMatrixOfBasis σ (Matrix.traceAdjointMap T) := by
+  ext α β
+  rw [Matrix.conjTranspose_apply, transferMatrixOfBasis_apply,
+    transferMatrixOfBasis_apply, ← Matrix.trace_conjTranspose,
+    Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, ← hHP,
+    Matrix.trace_mul_comm, Matrix.trace_mul_comm ((σ α)ᴴ)]
+  exact (Matrix.trace_traceAdjointMap_mul T (σ β) ((σ α)ᴴ)).symm
+
+/-- The transfer matrix in a basis determines the map. -/
+theorem transferMatrixOfBasis_injective {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hσ : HilbertSchmidtOrthonormal (σ ·)) :
+    Function.Injective (transferMatrixOfBasis (D := D) (σ ·)) := by
+  intro S T h
+  refine σ.ext fun β => ?_
+  refine sub_eq_zero.mp (hσ.eq_zero_of_trace_conjTranspose_mul fun α => ?_)
+  have hαβ := congrFun (congrFun h α) β
+  rw [transferMatrixOfBasis_apply, transferMatrixOfBasis_apply] at hαβ
+  rw [Matrix.mul_sub, Matrix.trace_sub, hαβ, sub_self]
+
+/-- **Wolf §2, line 578, conditions 1 and 2**: for a Hermiticity-preserving map the
+transfer matrix in a Hilbert-Schmidt orthonormal basis used on both sides is
+Hermitian exactly when the map equals its dual. -/
+theorem transferMatrixOfBasis_isHermitian_iff {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hσ : HilbertSchmidtOrthonormal (σ ·))
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hHP : ∀ X, T Xᴴ = (T X)ᴴ) :
+    (transferMatrixOfBasis (σ ·) T).IsHermitian ↔ Matrix.traceAdjointMap T = T := by
+  show (transferMatrixOfBasis (σ ·) T)ᴴ = transferMatrixOfBasis (σ ·) T ↔ _
+  rw [transferMatrixOfBasis_conjTranspose (σ ·) T hHP]
+  exact ⟨fun h => transferMatrixOfBasis_injective hσ h, fun h => by rw [h]⟩
+
+/-! ### Kraus families and the dual map -/
+
+/-- The dual map of `T(X) = ∑ᵢ Kᵢ X Kᵢ†` is `T*(X) = ∑ᵢ Kᵢ† X Kᵢ`: the Kraus
+operators of `T` and `T*` differ by Hermitian conjugation (Wolf §2, line 308). -/
+theorem traceAdjointMap_of_kraus {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.traceAdjointMap T X = ∑ i : Fin r, (K i)ᴴ * X * K i := by
+  refine Matrix.ext_iff_trace_mul_right.mpr fun N => ?_
+  rw [Matrix.trace_traceAdjointMap_mul, hK, Finset.sum_mul, Matrix.trace_sum,
+    Matrix.mul_sum, Matrix.trace_sum]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  have hleft : X * (K i * N * (K i)ᴴ) = X * K i * N * (K i)ᴴ := by
+    simp [Matrix.mul_assoc]
+  have hright : (K i)ᴴ * X * K i * N = (K i)ᴴ * (X * K i * N) := by
+    simp [Matrix.mul_assoc]
+  rw [hleft, hright, Matrix.trace_mul_comm]
+
+/-- A map with a Kraus representation preserves Hermiticity. -/
+theorem map_conjTranspose_of_kraus {r : ℕ} (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    T Xᴴ = (T X)ᴴ := by
+  simp [hK, Matrix.conjTranspose_sum, Matrix.conjTranspose_mul, Matrix.mul_assoc]
+
+/-- A completely positive map preserves Hermiticity. -/
+theorem IsCPMap.map_conjTranspose
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsCPMap T) (X : Matrix (Fin D) (Fin D) ℂ) : T Xᴴ = (T X)ᴴ := by
+  obtain ⟨r, K, hK⟩ := hT
+  exact map_conjTranspose_of_kraus K T hK X
+
+/-- **Wolf §2, line 578, direction 1 → 3**: a map with the two Kraus
+representations `T(X) = ∑ⱼ Kⱼ X Kⱼ†` and `T(X) = ∑ⱼ Kⱼ† X Kⱼ` is written as
+`T(X) = ½ ∑ⱼ (Kⱼ X Kⱼ† + Kⱼ† X Kⱼ)`, and the unitary recombination
+`(a, b) ↦ ((a + b)/√2, i(a - b)/√2)` turns every pair `(Kⱼ, Kⱼ†)/√2` into the
+Hermitian pair `(Kⱼ + Kⱼ†)/2`, `i(Kⱼ - Kⱼ†)/2`. -/
+theorem exists_hermitian_kraus_of_self_dual {r : ℕ}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ)
+    (hKdual : ∀ X, T X = ∑ i : Fin r, (K i)ᴴ * X * K i) :
+    ∃ (s : ℕ) (L : Fin s → Matrix (Fin D) (Fin D) ℂ),
+      (∀ j, (L j)ᴴ = L j) ∧ ∀ X, T X = ∑ j : Fin s, L j * X * (L j)ᴴ := by
+  classical
+  set c : ℂ := ((Real.sqrt 2 : ℝ) : ℂ)⁻¹ with hc
+  have hcstar : star c = c := by
+    rw [hc, star_inv₀, Complex.star_def, Complex.conj_ofReal]
+  have hcc : c * c = (2 : ℂ)⁻¹ := by
+    rw [hc, ← mul_inv, ← Complex.ofReal_mul,
+      Real.mul_self_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+    norm_num
+  -- the symmetrized Kraus family `(Kⱼ, Kⱼ†)/√2`
+  set A : Fin r × Bool → Matrix (Fin D) (Fin D) ℂ :=
+    fun p => c • (if p.2 then (K p.1)ᴴ else K p.1) with hA
+  -- the recombination `(a, b) ↦ ((a + b)/√2, i(a - b)/√2)`
+  set W : Matrix Bool Bool ℂ :=
+    fun b b' => if b then (if b' then -Complex.I else Complex.I) else 1 with hW
+  have hWunit : Wᴴ * W = (2 : ℂ) • (1 : Matrix Bool Bool ℂ) := by
+    ext b b'
+    cases b <;> cases b' <;>
+      simp [hW, Matrix.mul_apply, Matrix.conjTranspose_apply, Complex.I_mul_I] <;>
+      norm_num
+  set U : Matrix (Fin r × Bool) (Fin r × Bool) ℂ :=
+    (1 : Matrix (Fin r) (Fin r) ℂ) ⊗ₖ (c • W) with hU
+  have hUunit : Uᴴ * U = 1 := by
+    have hV : (c • W)ᴴ * (c • W) = 1 := by
+      rw [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, hWunit,
+        smul_smul, smul_smul, hcstar, hcc]
+      norm_num
+    rw [hU, Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+      Matrix.conjTranspose_one, Matrix.one_mul, hV, Matrix.one_kronecker_one]
+  set B : Fin r × Bool → Matrix (Fin D) (Fin D) ℂ :=
+    fun p => ∑ q : Fin r × Bool, U p q • A q with hB
+  have hAtrue : ∀ i : Fin r, A (i, true) = c • (K i)ᴴ := by intro i; simp [hA]
+  have hAfalse : ∀ i : Fin r, A (i, false) = c • K i := by intro i; simp [hA]
+  have hexp : ∀ (i : Fin r) (b : Bool),
+      B (i, b) = (c * W b true) • A (i, true) + (c * W b false) • A (i, false) := by
+    intro i b
+    rw [hB]
+    simp only [hU, Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.smul_apply,
+      smul_eq_mul, ite_mul, one_mul, zero_mul, ite_smul, zero_smul,
+      Fintype.sum_prod_type, Fintype.sum_bool, Finset.sum_add_distrib,
+      Finset.sum_ite_eq, Finset.mem_univ, if_true]
+  have hBfalse : ∀ i : Fin r, B (i, false) = ((2 : ℂ)⁻¹) • (K i + (K i)ᴴ) := by
+    intro i
+    have hW1 : W false true = 1 := by simp [hW]
+    have hW2 : W false false = 1 := by simp [hW]
+    rw [hexp i false, hW1, hW2, hAtrue i, hAfalse i]
+    simp only [mul_one, smul_smul, hcc]
+    module
+  have hBtrue : ∀ i : Fin r, B (i, true) = (Complex.I / 2) • (K i - (K i)ᴴ) := by
+    intro i
+    have hW1 : W true true = -Complex.I := by simp [hW]
+    have hW2 : W true false = Complex.I := by simp [hW]
+    rw [hexp i true, hW1, hW2, hAtrue i, hAfalse i]
+    simp only [smul_smul]
+    rw [show c * -Complex.I * c = -(Complex.I * (c * c)) by ring,
+      show c * Complex.I * c = Complex.I * (c * c) by ring, hcc]
+    module
+  have hBherm : ∀ p : Fin r × Bool, (B p)ᴴ = B p := by
+    rintro ⟨i, b⟩
+    cases b with
+    | false =>
+        rw [hBfalse i, Matrix.conjTranspose_smul, Matrix.conjTranspose_add,
+          Matrix.conjTranspose_conjTranspose,
+          show star ((2 : ℂ)⁻¹) = (2 : ℂ)⁻¹ by norm_num, add_comm]
+    | true =>
+        rw [hBtrue i, Matrix.conjTranspose_smul, Matrix.conjTranspose_sub,
+          Matrix.conjTranspose_conjTranspose,
+          show star (Complex.I / 2) = -(Complex.I / 2) by
+            simp [Complex.conj_I, neg_div], neg_smul, ← smul_neg,
+          neg_sub]
+  have hAB : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ p : Fin r × Bool, B p * X * (B p)ᴴ =
+        ∑ q : Fin r × Bool, A q * X * (A q)ᴴ :=
+    kraus_same_map_of_unitary_combination B A U hUunit fun p => rfl
+  have hAT : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ q : Fin r × Bool, A q * X * (A q)ᴴ = T X := by
+    intro X
+    have hterm : ∀ i : Fin r,
+        A (i, true) * X * (A (i, true))ᴴ + A (i, false) * X * (A (i, false))ᴴ =
+          ((2 : ℂ)⁻¹) • ((K i)ᴴ * X * K i) + ((2 : ℂ)⁻¹) • (K i * X * (K i)ᴴ) := by
+      intro i
+      rw [hAtrue i, hAfalse i]
+      simp only [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+        Matrix.conjTranspose_conjTranspose, hcstar, hcc]
+    rw [Fintype.sum_prod_type]
+    simp only [Fintype.sum_bool, hterm]
+    rw [Finset.sum_add_distrib, ← Finset.smul_sum, ← Finset.smul_sum, ← hK X,
+      ← hKdual X, ← add_smul]
+    norm_num
+  refine ⟨r * 2, fun m =>
+    B (((Equiv.prodCongr (Equiv.refl (Fin r)) finTwoEquiv.symm).trans
+      finProdFinEquiv).symm m), fun m => hBherm _, fun X => ?_⟩
+  rw [← hAT X, ← hAB X]
+  exact (Equiv.sum_comp
+    ((Equiv.prodCongr (Equiv.refl (Fin r)) finTwoEquiv.symm).trans finProdFinEquiv).symm
+    fun p => B p * X * (B p)ᴴ).symm
+
+/-! ### The self-dual channel proposition -/
+
+/-- **Wolf §2, line 578 (self-dual channels)**: for a completely positive map
+`T : M_d(ℂ) → M_d(ℂ)` the following are equivalent.
+
+1. `T` equals its dual `T*`, characterized by `tr[A T*(B)] = tr[T(A) B]`.
+2. The transfer matrix `tr[σ_α† T(σ_β)]` in one Hilbert-Schmidt orthonormal basis
+   `σ` used on both sides is Hermitian.
+3. `T` admits a family of Hermitian Kraus operators. -/
+theorem selfDual_tfae {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsCPMap T)
+    {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
+    (hσ : HilbertSchmidtOrthonormal (σ ·)) :
+    List.TFAE [
+      Matrix.traceAdjointMap T = T,
+      (transferMatrixOfBasis (σ ·) T).IsHermitian,
+      ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),
+        (∀ j, (K j)ᴴ = K j) ∧ ∀ X, T X = ∑ j : Fin r, K j * X * (K j)ᴴ
+    ] := by
+  tfae_have h21 : 2 ↔ 1 :=
+    transferMatrixOfBasis_isHermitian_iff hσ hT.map_conjTranspose
+  tfae_have h31 : 3 → 1 := by
+    rintro ⟨r, K, hherm, hK⟩
+    refine LinearMap.ext fun X => ?_
+    rw [traceAdjointMap_of_kraus K T hK X, hK X]
+    exact Finset.sum_congr rfl fun i _ => by rw [hherm i]
+  tfae_have h13 : 1 → 3 := by
+    intro h1
+    obtain ⟨r, K, hK⟩ := hT
+    have hKdual : ∀ X, T X = ∑ i : Fin r, (K i)ᴴ * X * K i := by
+      intro X
+      conv_lhs => rw [← h1]
+      exact traceAdjointMap_of_kraus K T hK X
+    exact exists_hermitian_kraus_of_self_dual K T hK hKdual
+  tfae_finish
+
+/-! ### Condition 2 in the basis of matrix units -/
+
+/-- For a Hermiticity-preserving map the matrix-unit transfer matrix of the dual
+map is the Hermitian conjugate transfer matrix (Wolf §2, line 573). -/
+theorem transferMatrix_conjTranspose_eq_traceAdjointMap
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hHP : ∀ X, T Xᴴ = (T X)ᴴ) :
+    (transferMatrix T)ᴴ = transferMatrix (Matrix.traceAdjointMap T) := by
+  ext ⟨j, i⟩ ⟨l, k⟩
+  rw [Matrix.conjTranspose_apply, transferMatrix_apply, transferMatrix_apply,
+    traceAdjointMap_apply_apply, Matrix.trace_single_mul]
+  have hswap := hHP (Matrix.single i j (1 : ℂ))
+  rw [Matrix.conjTranspose_single, star_one] at hswap
+  rw [hswap]
+  simp
+
+/-- **Wolf §2, line 578, conditions 1 and 2 in matrix units**: a completely positive
+map equals its dual exactly when its matrix-unit transfer matrix is Hermitian. -/
+theorem transferMatrix_isHermitian_iff_traceAdjointMap_eq_self
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsCPMap T) :
+    (transferMatrix T).IsHermitian ↔ Matrix.traceAdjointMap T = T := by
+  show (transferMatrix T)ᴴ = transferMatrix T ↔ _
+  rw [transferMatrix_conjTranspose_eq_traceAdjointMap T hT.map_conjTranspose]
+  exact ⟨fun h => transferMatrix_injective h, fun h => by rw [h]⟩

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -16,3 +16,4 @@ are not prerequisites for the matrix-product-state Fundamental Theorem.
 \input{chapter/ch16_channel_representations_dilations_and_ordered_cp}
 \input{chapter/ch16_channel_representations_normal_forms_and_determinant}
 \input{chapter/ch16_channel_representations_determinant_choi_bound}
+\input{chapter/ch16_channel_representations_self_dual}

--- a/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
@@ -2,11 +2,13 @@
 \label{sec:self_dual_channels}
 %% =========================================================
 
-Wolf's transfer matrix $\widehat T_{\alpha\beta}=\tr(F_\alpha^\dagger T(G_\beta))$
-is built from two orthonormal families. Taking one and the same family on both
-sides turns the Hermiticity of $\widehat T$ into a statement about $T$ alone, and
-that statement is self-duality. Orthonormality is always meant for the
-Hilbert--Schmidt pairing.
+The transfer matrix $\widehat T_{\alpha\beta}=\tr(F_\alpha^\dagger T(G_\beta))$
+of \cite[Section~2.2, equation~(2.20)]{Wolf2012Quantum} is built from two
+orthonormal families. Taking one and the same family on both sides turns the
+Hermiticity of $\widehat T$ into a statement about $T$ alone, and that statement
+is self-duality. Orthonormality is always meant for the Hilbert--Schmidt
+pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
+\cite[Section~2.2]{Wolf2012Quantum}; the families are not assumed Hermitian.
 
 \begin{definition}[Hilbert--Schmidt orthonormal family]
     \label{def:hilbert_schmidt_orthonormal}
@@ -25,7 +27,6 @@ Hilbert--Schmidt pairing.
     \label{def:transfer_matrix_of_basis}
     \lean{transferMatrixOfBasis}
     \leanok
-    \uses{def:hilbert_schmidt_orthonormal}
     For a linear map $T:\MN{d}\to\MN{d}$ and a family $(\sigma_\alpha)$ in
     $\MN{d}$ used on both sides, the \emph{transfer matrix of $T$ in
     $(\sigma_\alpha)$} is
@@ -110,7 +111,6 @@ Hilbert--Schmidt pairing.
     \label{lem:hermitian_kraus_of_self_dual}
     \lean{exists_hermitian_kraus_of_self_dual}
     \leanok
-    \uses{lem:trace_adjoint_of_kraus, thm:kraus_same_map_of_unitary_combination}
     Suppose $T(X)=\sum_j K_j X K_j^\dagger$ and also
     $T(X)=\sum_j K_j^\dagger X K_j$. Then $T$ has a family of Hermitian Kraus
     operators, namely $\tfrac12(K_j+K_j^\dagger)$ and
@@ -131,15 +131,82 @@ Hilbert--Schmidt pairing.
     $\tfrac{i}{2}(K_j-K_j^\dagger)$, both of which are Hermitian.
 \end{proof}
 
+\begin{lemma}[The transfer matrix determines the map]
+    \label{lem:transfer_matrix_of_basis_injective}
+    \lean{transferMatrixOfBasis_injective}
+    \leanok
+    \uses{def:transfer_matrix_of_basis, def:hilbert_schmidt_orthonormal}
+    Let $(\sigma_\alpha)$ be a Hilbert--Schmidt orthonormal basis of $\MN{d}$.
+    For linear maps $S,T:\MN{d}\to\MN{d}$,
+    \begin{align}
+        \widehat T=\widehat S
+        &\implies T=S.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:hilbert_schmidt_orthonormal_coordinates}
+    Equality of the transfer matrices reads
+    $\tr\bigl(\sigma_\alpha^\dagger(T-S)(\sigma_\beta)\bigr)=0$ for all
+    $\alpha,\beta$. For fixed $\beta$ this makes every coordinate of
+    $(T-S)(\sigma_\beta)$ vanish, so $(T-S)(\sigma_\beta)=0$; a linear map
+    vanishing on a basis is zero.
+\end{proof}
+
+\begin{lemma}[Self-duality against Hermiticity of the transfer matrix]
+    \label{lem:transfer_matrix_of_basis_hermitian_iff}
+    \lean{transferMatrixOfBasis_isHermitian_iff}
+    \leanok
+    \uses{def:transfer_matrix_of_basis, def:hilbert_schmidt_orthonormal,
+        def:trace_pairing_adjoint}
+    Let $T:\MN{d}\to\MN{d}$ satisfy $T(X^\dagger)=T(X)^\dagger$ and let
+    $(\sigma_\alpha)$ be a Hilbert--Schmidt orthonormal basis of $\MN{d}$ used on
+    both sides. Then
+    \begin{align}
+        \widehat T=\widehat T^\dagger
+        &\iff T=T^*.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:transfer_matrix_of_basis_dual,
+        lem:transfer_matrix_of_basis_injective}
+    By Lemma~\ref{lem:transfer_matrix_of_basis_dual},
+    $\widehat T^\dagger=\widehat{T^*}$. So
+    $\widehat T=\widehat T^\dagger$ reads $\widehat{T^*}=\widehat T$, which by
+    Lemma~\ref{lem:transfer_matrix_of_basis_injective} is $T^*=T$; the converse
+    substitutes $T^*=T$ into the same identity.
+\end{proof}
+
+\begin{lemma}[The same equivalence in the matrix units]
+    \label{lem:transfer_matrix_units_hermitian_iff}
+    \lean{transferMatrix_isHermitian_iff_traceAdjointMap_eq_self}
+    \leanok
+    \uses{def:cp_map, def:trace_pairing_adjoint, def:mpu_transfer_matrix}
+    Let $T:\MN{d}\to\MN{d}$ be completely positive and let $\widehat T$ be its
+    transfer matrix in the matrix units. Then
+    \begin{align}
+        \widehat T=\widehat T^\dagger
+        &\iff T=T^*.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:transfer_matrix_of_basis_dual, lem:trace_adjoint_of_kraus}
+    Complete positivity gives $T(X^\dagger)=T(X)^\dagger$, so
+    $\widehat T^\dagger=\widehat{T^*}$ for the matrix-unit transfer matrix as
+    well, and that transfer matrix determines the map.
+\end{proof}
+
 \begin{proposition}[Self-dual channels]
     \label{prop:self_dual_channels}
-    \lean{selfDual_tfae, transferMatrix_isHermitian_iff_traceAdjointMap_eq_self,
-        transferMatrixOfBasis_isHermitian_iff}
+    \lean{self_dual_tfae}
     \leanok
     \uses{def:cp_map, def:trace_pairing_adjoint, def:transfer_matrix_of_basis,
-        lem:transfer_matrix_of_basis_dual, lem:trace_adjoint_of_kraus,
-        lem:hermitian_kraus_of_self_dual,
-        lem:hilbert_schmidt_orthonormal_coordinates}
+        def:hilbert_schmidt_orthonormal}
     Let $T:\MN{d}\to\MN{d}$ be completely positive and let $(\sigma_\alpha)$ be a
     Hilbert--Schmidt orthonormal basis of $\MN{d}$. The following are equivalent.
     \begin{enumerate}
@@ -148,18 +215,33 @@ Hilbert--Schmidt pairing.
             the family $(\sigma_\alpha)$ on both sides.
         \item $T$ admits a family of Hermitian Kraus operators.
     \end{enumerate}
+    This is the proposition ``Self-dual channels'' of
+    \cite[Section~2.2]{Wolf2012Quantum}.
 \end{proposition}
 
 \begin{proof}\leanok
-    \uses{lem:transfer_matrix_of_basis_dual, lem:trace_adjoint_of_kraus,
-        lem:hermitian_kraus_of_self_dual,
-        lem:hilbert_schmidt_orthonormal_coordinates}
-    A completely positive map preserves Hermiticity, so
-    $\widehat T^\dagger=\widehat{T^*}$; since a map is determined by its transfer
-    matrix in a basis, conditions~1 and~2 are the same statement. Condition~3
-    implies condition~1 because the Kraus operators of $T$ and $T^*$ differ by
-    Hermitian conjugation, and a family of Hermitian operators is fixed by that
-    exchange. Condition~1 gives $T$ the two Kraus representations
-    $\sum_j K_jXK_j^\dagger$ and $\sum_j K_j^\dagger XK_j$, and the Hermitian
-    recombination of the symmetrized family yields condition~3.
+    \uses{lem:transfer_matrix_of_basis_hermitian_iff, lem:trace_adjoint_of_kraus,
+        lem:hermitian_kraus_of_self_dual}
+    Conditions~1 and~2 are equivalent by
+    Lemma~\ref{lem:transfer_matrix_of_basis_hermitian_iff}, complete positivity
+    supplying the Hermiticity preservation it requires. For $3\Rightarrow1$, a
+    family of Hermitian Kraus operators is fixed by the exchange
+    $K_j\mapsto K_j^\dagger$ that carries $T$ to $T^*$:
+    \begin{align}
+        T^*(X)
+        &= \sum_j K_j^\dagger XK_j
+        = \sum_j K_jXK_j^\dagger
+        = T(X).
+        \notag
+    \end{align}
+    For $1\Rightarrow3$, condition~1 turns any Kraus representation
+    $T(X)=\sum_jK_jXK_j^\dagger$ into a second one,
+    \begin{align}
+        T(X)
+        &= T^*(X)
+        = \sum_j K_j^\dagger XK_j,
+        \notag
+    \end{align}
+    and the Hermitian recombination of the symmetrized family
+    (Lemma~\ref{lem:hermitian_kraus_of_self_dual}) yields condition~3.
 \end{proof}

--- a/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
@@ -65,7 +65,8 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     \lean{transferMatrixOfBasis_conjTranspose,
         transferMatrix_conjTranspose_eq_traceAdjointMap}
     \leanok
-    \uses{def:transfer_matrix_of_basis, def:trace_pairing_adjoint}
+    \uses{def:transfer_matrix_of_basis, def:trace_pairing_adjoint,
+        def:mpu_transfer_matrix}
     Let $T:\MN{d}\to\MN{d}$ satisfy $T(X^\dagger)=T(X)^\dagger$. Then in any
     family $(\sigma_\alpha)$ used on both sides,
     \begin{align}
@@ -77,7 +78,7 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{def:trace_pairing_adjoint}
+    \uses{def:trace_pairing_adjoint, def:mpu_transfer_matrix}
     The $(\alpha,\beta)$ entry of $(\widehat T)^\dagger$ is
     $\overline{\tr(\sigma_\beta^\dagger T(\sigma_\alpha))}
     =\tr\bigl(T(\sigma_\alpha)^\dagger\sigma_\beta\bigr)$. Hermiticity
@@ -85,6 +86,14 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     $T(\sigma_\alpha^\dagger)$, and the defining identity
     $\tr(AT^*(B))=\tr(T(A)B)$ of the dual map turns the result into
     $\tr(\sigma_\alpha^\dagger T^*(\sigma_\beta))$.
+
+    In the matrix units the same two steps appear entrywise. There the
+    $\bigl((j,i),(\ell,k)\bigr)$ entry of $\widehat T$ is
+    $\bigl(T(E_{k\ell})\bigr)_{ij}$, and the entry of
+    $\widehat{T^*}$ is $\tr\bigl(E_{k\ell}\,T(E_{ji})\bigr)$ by the entrywise
+    form of the dual map; conjugating the first and using
+    $E_{k\ell}^\dagger=E_{\ell k}$ together with Hermiticity preservation
+    identifies the two.
 \end{proof}
 
 \begin{lemma}[Dual map of a Kraus family]

--- a/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
@@ -1,0 +1,165 @@
+\section{Self-dual channels}
+\label{sec:self_dual_channels}
+%% =========================================================
+
+Wolf's transfer matrix $\widehat T_{\alpha\beta}=\tr(F_\alpha^\dagger T(G_\beta))$
+is built from two orthonormal families. Taking one and the same family on both
+sides turns the Hermiticity of $\widehat T$ into a statement about $T$ alone, and
+that statement is self-duality. Orthonormality is always meant for the
+Hilbert--Schmidt pairing.
+
+\begin{definition}[Hilbert--Schmidt orthonormal family]
+    \label{def:hilbert_schmidt_orthonormal}
+    \lean{HilbertSchmidtOrthonormal}
+    \leanok
+    A family $(\sigma_\alpha)$ in $\MN{d}$ is \emph{Hilbert--Schmidt orthonormal}
+    when
+    \begin{align}
+        \tr\bigl(\sigma_\alpha^\dagger \sigma_\beta\bigr)
+        &= \delta_{\alpha\beta}.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{definition}[Transfer matrix in one orthonormal family]
+    \label{def:transfer_matrix_of_basis}
+    \lean{transferMatrixOfBasis}
+    \leanok
+    \uses{def:hilbert_schmidt_orthonormal}
+    For a linear map $T:\MN{d}\to\MN{d}$ and a family $(\sigma_\alpha)$ in
+    $\MN{d}$ used on both sides, the \emph{transfer matrix of $T$ in
+    $(\sigma_\alpha)$} is
+    \begin{align}
+        \widehat T_{\alpha\beta}
+        &= \tr\bigl(\sigma_\alpha^\dagger T(\sigma_\beta)\bigr).
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{lemma}[Coordinates in a Hilbert--Schmidt orthonormal basis]
+    \label{lem:hilbert_schmidt_orthonormal_coordinates}
+    \lean{HilbertSchmidtOrthonormal.repr_apply,
+        HilbertSchmidtOrthonormal.eq_zero_of_trace_conjTranspose_mul,
+        HilbertSchmidtOrthonormal.tracePairingSelfDualBasis}
+    \leanok
+    \uses{def:hilbert_schmidt_orthonormal}
+    Let $(\sigma_\alpha)$ be a Hilbert--Schmidt orthonormal basis of $\MN{d}$.
+    The coordinates of $X\in\MN{d}$ in this basis are
+    $\tr(\sigma_\alpha^\dagger X)$; consequently $X=0$ as soon as
+    $\tr(\sigma_\alpha^\dagger X)=0$ for every $\alpha$. If in addition every
+    $\sigma_\alpha$ is Hermitian, the coordinates are $\tr(\sigma_\alpha X)$, so
+    the basis is self-dual for the bilinear trace pairing.
+\end{lemma}
+
+\begin{proof}\leanok
+    Expanding $X=\sum_\beta c_\beta\sigma_\beta$ and pairing with
+    $\sigma_\alpha$ gives $\tr(\sigma_\alpha^\dagger X)=c_\alpha$ by
+    orthonormality. Vanishing of all coordinates forces $X=0$. For Hermitian
+    $\sigma_\alpha$ the two pairings $\tr(\sigma_\alpha^\dagger X)$ and
+    $\tr(\sigma_\alpha X)$ agree.
+\end{proof}
+
+\begin{lemma}[Transfer matrix of the dual map]
+    \label{lem:transfer_matrix_of_basis_dual}
+    \lean{transferMatrixOfBasis_conjTranspose,
+        transferMatrix_conjTranspose_eq_traceAdjointMap}
+    \leanok
+    \uses{def:transfer_matrix_of_basis, def:trace_pairing_adjoint}
+    Let $T:\MN{d}\to\MN{d}$ satisfy $T(X^\dagger)=T(X)^\dagger$. Then in any
+    family $(\sigma_\alpha)$ used on both sides,
+    \begin{align}
+        \bigl(\widehat T\bigr)^\dagger &= \widehat{T^*},
+        \notag
+    \end{align}
+    and the same identity holds for the transfer matrix taken in the matrix
+    units.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:trace_pairing_adjoint}
+    The $(\alpha,\beta)$ entry of $(\widehat T)^\dagger$ is
+    $\overline{\tr(\sigma_\beta^\dagger T(\sigma_\alpha))}
+    =\tr\bigl(T(\sigma_\alpha)^\dagger\sigma_\beta\bigr)$. Hermiticity
+    preservation replaces $T(\sigma_\alpha)^\dagger$ by
+    $T(\sigma_\alpha^\dagger)$, and the defining identity
+    $\tr(AT^*(B))=\tr(T(A)B)$ of the dual map turns the result into
+    $\tr(\sigma_\alpha^\dagger T^*(\sigma_\beta))$.
+\end{proof}
+
+\begin{lemma}[Dual map of a Kraus family]
+    \label{lem:trace_adjoint_of_kraus}
+    \lean{traceAdjointMap_of_kraus, map_conjTranspose_of_kraus,
+        IsCPMap.map_conjTranspose}
+    \leanok
+    \uses{def:trace_pairing_adjoint, def:cp_map}
+    If $T(X)=\sum_j K_j X K_j^\dagger$ then $T^*(X)=\sum_j K_j^\dagger X K_j$: the
+    Kraus operators of $T$ and of $T^*$ differ by Hermitian conjugation. Such a
+    $T$ also satisfies $T(X^\dagger)=T(X)^\dagger$.
+\end{lemma}
+
+\begin{proof}\leanok
+    For every $N$,
+    $\tr\bigl(\sum_j K_j^\dagger XK_j\,N\bigr)
+    =\sum_j\tr\bigl(X\,K_jNK_j^\dagger\bigr)=\tr(X\,T(N))$ by cyclicity of the
+    trace, which is the defining identity of $T^*$. Nondegeneracy of the trace
+    pairing identifies the two maps. Hermiticity preservation is the
+    conjugate transpose of the Kraus sum.
+\end{proof}
+
+\begin{lemma}[Hermitian recombination of a symmetrized Kraus family]
+    \label{lem:hermitian_kraus_of_self_dual}
+    \lean{exists_hermitian_kraus_of_self_dual}
+    \leanok
+    \uses{lem:trace_adjoint_of_kraus, thm:kraus_same_map_of_unitary_combination}
+    Suppose $T(X)=\sum_j K_j X K_j^\dagger$ and also
+    $T(X)=\sum_j K_j^\dagger X K_j$. Then $T$ has a family of Hermitian Kraus
+    operators, namely $\tfrac12(K_j+K_j^\dagger)$ and
+    $\tfrac{i}{2}(K_j-K_j^\dagger)$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:kraus_same_map_of_unitary_combination}
+    Averaging the two representations gives
+    \begin{align}
+        T(X)
+        &= \frac12\sum_j\bigl(K_jXK_j^\dagger+K_j^\dagger XK_j\bigr),
+        \notag
+    \end{align}
+    that is, the Kraus family $(K_j,K_j^\dagger)/\sqrt2$. Mixing each such pair by
+    the unitary $(a,b)\mapsto\bigl((a+b)/\sqrt2,\;i(a-b)/\sqrt2\bigr)$ leaves the
+    map unchanged and produces the pair $\tfrac12(K_j+K_j^\dagger)$,
+    $\tfrac{i}{2}(K_j-K_j^\dagger)$, both of which are Hermitian.
+\end{proof}
+
+\begin{proposition}[Self-dual channels]
+    \label{prop:self_dual_channels}
+    \lean{selfDual_tfae, transferMatrix_isHermitian_iff_traceAdjointMap_eq_self,
+        transferMatrixOfBasis_isHermitian_iff}
+    \leanok
+    \uses{def:cp_map, def:trace_pairing_adjoint, def:transfer_matrix_of_basis,
+        lem:transfer_matrix_of_basis_dual, lem:trace_adjoint_of_kraus,
+        lem:hermitian_kraus_of_self_dual,
+        lem:hilbert_schmidt_orthonormal_coordinates}
+    Let $T:\MN{d}\to\MN{d}$ be completely positive and let $(\sigma_\alpha)$ be a
+    Hilbert--Schmidt orthonormal basis of $\MN{d}$. The following are equivalent.
+    \begin{enumerate}
+        \item $T=T^*$.
+        \item $\widehat T=\widehat T^\dagger$, the transfer matrix being taken in
+            the family $(\sigma_\alpha)$ on both sides.
+        \item $T$ admits a family of Hermitian Kraus operators.
+    \end{enumerate}
+\end{proposition}
+
+\begin{proof}\leanok
+    \uses{lem:transfer_matrix_of_basis_dual, lem:trace_adjoint_of_kraus,
+        lem:hermitian_kraus_of_self_dual,
+        lem:hilbert_schmidt_orthonormal_coordinates}
+    A completely positive map preserves Hermiticity, so
+    $\widehat T^\dagger=\widehat{T^*}$; since a map is determined by its transfer
+    matrix in a basis, conditions~1 and~2 are the same statement. Condition~3
+    implies condition~1 because the Kraus operators of $T$ and $T^*$ differ by
+    Hermitian conjugation, and a family of Hermitian operators is fixed by that
+    exchange. Condition~1 gives $T$ the two Kraus representations
+    $\sum_j K_jXK_j^\dagger$ and $\sum_j K_j^\dagger XK_j$, and the Hermitian
+    recombination of the symmetrized family yields condition~3.
+\end{proof}

--- a/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_self_dual.tex
@@ -3,12 +3,13 @@
 %% =========================================================
 
 The transfer matrix $\widehat T_{\alpha\beta}=\tr(F_\alpha^\dagger T(G_\beta))$
-of \cite[Section~2.2, equation~(2.20)]{Wolf2012Quantum} is built from two
+of \cite[Section~2.3, Equation~(2.20)]{Wolf2012Quantum} is built from two
 orthonormal families. Taking one and the same family on both sides turns the
 Hermiticity of $\widehat T$ into a statement about $T$ alone, and that statement
 is self-duality. Orthonormality is always meant for the Hilbert--Schmidt
-pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
-\cite[Section~2.2]{Wolf2012Quantum}; the families are not assumed Hermitian.
+pairing of \cite[Section~2.3, Equation~(2.18)]{Wolf2012Quantum}, that is,
+$\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$; the families are not
+assumed Hermitian.
 
 \begin{definition}[Hilbert--Schmidt orthonormal family]
     \label{def:hilbert_schmidt_orthonormal}
@@ -19,11 +20,12 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     \begin{align}
         \tr\bigl(\sigma_\alpha^\dagger \sigma_\beta\bigr)
         &= \delta_{\alpha\beta}.
-        \notag
     \end{align}
+    This is the pairing $\tr(PA^\dagger B)$ of
+    \cite[Equation~(2.18)]{Wolf2012Quantum} in the case $P=\Id$.
 \end{definition}
 
-\begin{definition}[Transfer matrix in one orthonormal family]
+\begin{definition}[Transfer matrix in one family]
     \label{def:transfer_matrix_of_basis}
     \lean{transferMatrixOfBasis}
     \leanok
@@ -32,9 +34,9 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     $(\sigma_\alpha)$} is
     \begin{align}
         \widehat T_{\alpha\beta}
-        &= \tr\bigl(\sigma_\alpha^\dagger T(\sigma_\beta)\bigr).
-        \notag
+        &= \tr\bigl(\sigma_\alpha^\dagger T(\sigma_\beta)\bigr),
     \end{align}
+    which is \cite[Equation~(2.20)]{Wolf2012Quantum} with $F_\alpha=G_\alpha$.
 \end{definition}
 
 \begin{lemma}[Coordinates in a Hilbert--Schmidt orthonormal basis]
@@ -54,10 +56,15 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
 
 \begin{proof}\leanok
     Expanding $X=\sum_\beta c_\beta\sigma_\beta$ and pairing with
-    $\sigma_\alpha$ gives $\tr(\sigma_\alpha^\dagger X)=c_\alpha$ by
-    orthonormality. Vanishing of all coordinates forces $X=0$. For Hermitian
-    $\sigma_\alpha$ the two pairings $\tr(\sigma_\alpha^\dagger X)$ and
-    $\tr(\sigma_\alpha X)$ agree.
+    $\sigma_\alpha$ gives, by orthonormality,
+    \begin{align}
+        \tr\bigl(\sigma_\alpha^\dagger X\bigr)
+        &= \sum_\beta c_\beta\,\tr\bigl(\sigma_\alpha^\dagger\sigma_\beta\bigr)
+         = c_\alpha.
+    \end{align}
+    Vanishing of all coordinates forces $X=0$. For Hermitian $\sigma_\alpha$ the
+    two pairings $\tr(\sigma_\alpha^\dagger X)$ and $\tr(\sigma_\alpha X)$
+    agree.
 \end{proof}
 
 \begin{lemma}[Transfer matrix of the dual map]
@@ -71,29 +78,33 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     family $(\sigma_\alpha)$ used on both sides,
     \begin{align}
         \bigl(\widehat T\bigr)^\dagger &= \widehat{T^*},
-        \notag
     \end{align}
     and the same identity holds for the transfer matrix taken in the matrix
-    units.
+    units. This is the Hermitian-map case of the sentence following
+    \cite[Equation~(2.20)]{Wolf2012Quantum}.
 \end{lemma}
 
 \begin{proof}\leanok
     \uses{def:trace_pairing_adjoint, def:mpu_transfer_matrix}
-    The $(\alpha,\beta)$ entry of $(\widehat T)^\dagger$ is
-    $\overline{\tr(\sigma_\beta^\dagger T(\sigma_\alpha))}
-    =\tr\bigl(T(\sigma_\alpha)^\dagger\sigma_\beta\bigr)$. Hermiticity
-    preservation replaces $T(\sigma_\alpha)^\dagger$ by
-    $T(\sigma_\alpha^\dagger)$, and the defining identity
-    $\tr(AT^*(B))=\tr(T(A)B)$ of the dual map turns the result into
-    $\tr(\sigma_\alpha^\dagger T^*(\sigma_\beta))$.
+    Conjugating the trace and then using Hermiticity preservation and the
+    defining identity $\tr(AT^*(B))=\tr(T(A)B)$ of the dual map computes the
+    $(\alpha,\beta)$ entry of $(\widehat T)^\dagger$:
+    \begin{align}
+        \overline{\tr\bigl(\sigma_\beta^\dagger T(\sigma_\alpha)\bigr)}
+        &= \tr\bigl(T(\sigma_\alpha)^\dagger\sigma_\beta\bigr)
+         = \tr\bigl(T(\sigma_\alpha^\dagger)\sigma_\beta\bigr)
+         = \tr\bigl(\sigma_\alpha^\dagger T^*(\sigma_\beta)\bigr).
+    \end{align}
 
-    In the matrix units the same two steps appear entrywise. There the
-    $\bigl((j,i),(\ell,k)\bigr)$ entry of $\widehat T$ is
-    $\bigl(T(E_{k\ell})\bigr)_{ij}$, and the entry of
-    $\widehat{T^*}$ is $\tr\bigl(E_{k\ell}\,T(E_{ji})\bigr)$ by the entrywise
-    form of the dual map; conjugating the first and using
-    $E_{k\ell}^\dagger=E_{\ell k}$ together with Hermiticity preservation
-    identifies the two.
+    In the matrix units the same two steps appear entrywise. For the entrywise
+    form of the dual map and $E_{ij}^\dagger=E_{ji}$,
+    \begin{align}
+        \overline{\bigl(T(E_{ij})\bigr)_{k\ell}}
+        &= \bigl(T(E_{ji})\bigr)_{\ell k}
+         = \bigl(T^*(E_{k\ell})\bigr)_{ij},
+    \end{align}
+    and these are the $\bigl((j,i),(\ell,k)\bigr)$ entries of
+    $(\widehat T)^\dagger$ and of $\widehat{T^*}$.
 \end{proof}
 
 \begin{lemma}[Dual map of a Kraus family]
@@ -103,17 +114,24 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     \leanok
     \uses{def:trace_pairing_adjoint, def:cp_map}
     If $T(X)=\sum_j K_j X K_j^\dagger$ then $T^*(X)=\sum_j K_j^\dagger X K_j$: the
-    Kraus operators of $T$ and of $T^*$ differ by Hermitian conjugation. Such a
-    $T$ also satisfies $T(X^\dagger)=T(X)^\dagger$.
+    Kraus operators of $T$ and of $T^*$ differ by Hermitian conjugation, as in
+    \cite[Section~2.2, after Proposition~2.4]{Wolf2012Quantum}. Such a $T$
+    satisfies $T(X^\dagger)=T(X)^\dagger$, and so does every completely positive
+    map.
 \end{lemma}
 
 \begin{proof}\leanok
-    For every $N$,
-    $\tr\bigl(\sum_j K_j^\dagger XK_j\,N\bigr)
-    =\sum_j\tr\bigl(X\,K_jNK_j^\dagger\bigr)=\tr(X\,T(N))$ by cyclicity of the
-    trace, which is the defining identity of $T^*$. Nondegeneracy of the trace
-    pairing identifies the two maps. Hermiticity preservation is the
-    conjugate transpose of the Kraus sum.
+    The candidate $X\mapsto\sum_jK_j^\dagger XK_j$ satisfies the defining
+    property of $T^*$: for every $N$, cyclicity of the trace gives
+    \begin{align}
+        \tr\bigl(T^*(X)\,N\bigr)
+        &= \sum_j\tr\bigl(K_j^\dagger XK_j\,N\bigr)
+         = \sum_j\tr\bigl(X\,K_jNK_j^\dagger\bigr)
+         = \tr\bigl(X\,T(N)\bigr),
+    \end{align}
+    and nondegeneracy of the trace pairing identifies the two maps. Hermiticity
+    preservation is the conjugate transpose of the Kraus sum, and it descends to
+    completely positive maps by taking any Kraus representation.
 \end{proof}
 
 \begin{lemma}[Hermitian recombination of a symmetrized Kraus family]
@@ -132,35 +150,11 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     \begin{align}
         T(X)
         &= \frac12\sum_j\bigl(K_jXK_j^\dagger+K_j^\dagger XK_j\bigr),
-        \notag
     \end{align}
-    that is, the Kraus family $(K_j,K_j^\dagger)/\sqrt2$. Mixing each such pair by
-    the unitary $(a,b)\mapsto\bigl((a+b)/\sqrt2,\;i(a-b)/\sqrt2\bigr)$ leaves the
-    map unchanged and produces the pair $\tfrac12(K_j+K_j^\dagger)$,
+    that is, the Kraus family $(K_j,K_j^\dagger)/\sqrt2$. Mixing each such pair
+    by the unitary $(a,b)\mapsto\bigl((a+b)/\sqrt2,\;i(a-b)/\sqrt2\bigr)$ leaves
+    the map unchanged and produces the pair $\tfrac12(K_j+K_j^\dagger)$,
     $\tfrac{i}{2}(K_j-K_j^\dagger)$, both of which are Hermitian.
-\end{proof}
-
-\begin{lemma}[The transfer matrix determines the map]
-    \label{lem:transfer_matrix_of_basis_injective}
-    \lean{transferMatrixOfBasis_injective}
-    \leanok
-    \uses{def:transfer_matrix_of_basis, def:hilbert_schmidt_orthonormal}
-    Let $(\sigma_\alpha)$ be a Hilbert--Schmidt orthonormal basis of $\MN{d}$.
-    For linear maps $S,T:\MN{d}\to\MN{d}$,
-    \begin{align}
-        \widehat T=\widehat S
-        &\implies T=S.
-        \notag
-    \end{align}
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{lem:hilbert_schmidt_orthonormal_coordinates}
-    Equality of the transfer matrices reads
-    $\tr\bigl(\sigma_\alpha^\dagger(T-S)(\sigma_\beta)\bigr)=0$ for all
-    $\alpha,\beta$. For fixed $\beta$ this makes every coordinate of
-    $(T-S)(\sigma_\beta)$ vanish, so $(T-S)(\sigma_\beta)=0$; a linear map
-    vanishing on a basis is zero.
 \end{proof}
 
 \begin{lemma}[Self-duality against Hermiticity of the transfer matrix]
@@ -175,18 +169,24 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     \begin{align}
         \widehat T=\widehat T^\dagger
         &\iff T=T^*.
-        \notag
     \end{align}
 \end{lemma}
 
 \begin{proof}\leanok
     \uses{lem:transfer_matrix_of_basis_dual,
-        lem:transfer_matrix_of_basis_injective}
+        lem:hilbert_schmidt_orthonormal_coordinates}
     By Lemma~\ref{lem:transfer_matrix_of_basis_dual},
-    $\widehat T^\dagger=\widehat{T^*}$. So
-    $\widehat T=\widehat T^\dagger$ reads $\widehat{T^*}=\widehat T$, which by
-    Lemma~\ref{lem:transfer_matrix_of_basis_injective} is $T^*=T$; the converse
-    substitutes $T^*=T$ into the same identity.
+    $\widehat T^\dagger=\widehat{T^*}$. So $\widehat T=\widehat T^\dagger$ reads
+    $\widehat{T^*}=\widehat T$, that is, for every $\alpha$ and $\beta$,
+    \begin{align}
+        \tr\bigl(\sigma_\alpha^\dagger(T^*-T)(\sigma_\beta)\bigr)=0
+        &\Rightarrow (T^*-T)(\sigma_\beta)=0 \Rightarrow T^*=T,
+    \end{align}
+    where the first implication applies
+    Lemma~\ref{lem:hilbert_schmidt_orthonormal_coordinates} to
+    $(T^*-T)(\sigma_\beta)$ and the second holds because a linear map vanishing
+    on a basis is zero. The converse substitutes $T^*=T$ into
+    Lemma~\ref{lem:transfer_matrix_of_basis_dual}.
 \end{proof}
 
 \begin{lemma}[The same equivalence in the matrix units]
@@ -199,19 +199,28 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     \begin{align}
         \widehat T=\widehat T^\dagger
         &\iff T=T^*.
-        \notag
     \end{align}
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{lem:transfer_matrix_of_basis_dual, lem:trace_adjoint_of_kraus}
-    Complete positivity gives $T(X^\dagger)=T(X)^\dagger$, so
+    \uses{lem:transfer_matrix_of_basis_dual, lem:trace_adjoint_of_kraus,
+        thm:mpu_transfer_matrix_vectorization}
+    Complete positivity gives $T(X^\dagger)=T(X)^\dagger$
+    (Lemma~\ref{lem:trace_adjoint_of_kraus}), so
     $\widehat T^\dagger=\widehat{T^*}$ for the matrix-unit transfer matrix as
-    well, and that transfer matrix determines the map.
+    well (Lemma~\ref{lem:transfer_matrix_of_basis_dual}). By
+    Theorem~\ref{thm:mpu_transfer_matrix_vectorization},
+    $\widehat S\operatorname{vec}(\rho)=\operatorname{vec}(S(\rho))$ for every
+    linear map $S$ and every $\rho\in\MN{d}$; applied with $S=T^*$ and $S=T$
+    this turns equality of the transfer matrices into equality of the maps,
+    \begin{align}
+        \widehat{T^*}=\widehat T
+        &\Rightarrow T^*=T.
+    \end{align}
 \end{proof}
 
-\begin{proposition}[Self-dual channels]
-    \label{prop:self_dual_channels}
+\begin{theorem}[Self-dual channels]
+    \label{thm:self_dual_channels}
     \lean{self_dual_tfae}
     \leanok
     \uses{def:cp_map, def:trace_pairing_adjoint, def:transfer_matrix_of_basis,
@@ -224,9 +233,8 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
             the family $(\sigma_\alpha)$ on both sides.
         \item $T$ admits a family of Hermitian Kraus operators.
     \end{enumerate}
-    This is the proposition ``Self-dual channels'' of
-    \cite[Section~2.2]{Wolf2012Quantum}.
-\end{proposition}
+    This is \cite[Proposition~2.6]{Wolf2012Quantum}.
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{lem:transfer_matrix_of_basis_hermitian_iff, lem:trace_adjoint_of_kraus,
@@ -235,21 +243,20 @@ pairing, $\tr(G_\beta^\dagger G_{\beta'})=\delta_{\beta\beta'}$
     Lemma~\ref{lem:transfer_matrix_of_basis_hermitian_iff}, complete positivity
     supplying the Hermiticity preservation it requires. For $3\Rightarrow1$, a
     family of Hermitian Kraus operators is fixed by the exchange
-    $K_j\mapsto K_j^\dagger$ that carries $T$ to $T^*$:
+    $K_j\mapsto K_j^\dagger$ that carries $T$ to $T^*$
+    (Lemma~\ref{lem:trace_adjoint_of_kraus}):
     \begin{align}
         T^*(X)
         &= \sum_j K_j^\dagger XK_j
-        = \sum_j K_jXK_j^\dagger
-        = T(X).
-        \notag
+         = \sum_j K_jXK_j^\dagger
+         = T(X).
     \end{align}
     For $1\Rightarrow3$, condition~1 turns any Kraus representation
     $T(X)=\sum_jK_jXK_j^\dagger$ into a second one,
     \begin{align}
         T(X)
         &= T^*(X)
-        = \sum_j K_j^\dagger XK_j,
-        \notag
+         = \sum_j K_j^\dagger XK_j,
     \end{align}
     and the Hermitian recombination of the symmetrized family
     (Lemma~\ref{lem:hermitian_kraus_of_self_dual}) yields condition~3.


### PR DESCRIPTION
## Source

Wolf, *Quantum Channels & Operations*, Section 2.2, proposition "Self-dual
channels": `Notes/WolfNoteTexSource/ch02_representations.tex` line 578. For a
completely positive `T : M_d -> M_d` the following are equivalent:

1. `T = T*`;
2. `T̂ = T̂†` when identical bases `F_α = G_α` are chosen;
3. `T` admits a family of Hermitian Kraus operators.

## Landed signature

New module `TNLean/Channel/SelfDual.lean`:

```lean
theorem selfDual_tfae {ι : Type*} [Fintype ι] [DecidableEq ι]
    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
    (hT : IsCPMap T)
    {σ : Module.Basis ι ℂ (Matrix (Fin D) (Fin D) ℂ)}
    (hσ : HilbertSchmidtOrthonormal (σ ·)) :
    List.TFAE [
      Matrix.traceAdjointMap T = T,
      (transferMatrixOfBasis (σ ·) T).IsHermitian,
      ∃ (r : ℕ) (K : Fin r → Matrix (Fin D) (Fin D) ℂ),
        (∀ j, (K j)ᴴ = K j) ∧ ∀ X, T X = ∑ j : Fin r, K j * X * (K j)ᴴ
    ]
```

All three implications are proved; the statement is a genuine three-way
equivalence, not a subset.

Supporting declarations in the same file:

* `HilbertSchmidtOrthonormal`, `HilbertSchmidtOrthonormal.repr_apply`,
  `HilbertSchmidtOrthonormal.eq_zero_of_trace_conjTranspose_mul`,
  `HilbertSchmidtOrthonormal.tracePairingSelfDualBasis`;
* `transferMatrixOfBasis`, `transferMatrixOfBasis_conjTranspose`,
  `transferMatrixOfBasis_injective`, `transferMatrixOfBasis_isHermitian_iff`;
* `traceAdjointMap_apply_apply`, `traceAdjointMap_of_kraus`,
  `map_conjTranspose_of_kraus`, `IsCPMap.map_conjTranspose`,
  `exists_hermitian_kraus_of_self_dual`;
* `transferMatrix_conjTranspose_eq_traceAdjointMap`,
  `transferMatrix_isHermitian_iff_traceAdjointMap_eq_self`, which state
  condition 2 for the matrix-unit `transferMatrix` of
  `TNLean/Channel/TransferMatrix.lean`.

## Basis convention

The dual map is `Matrix.traceAdjointMap`, the adjoint for the bilinear trace
pairing `tr[A T*(B)] = tr[T(A) B]`. That is exactly Wolf's own definition of the
dual map (`ch01_deconstructing_quantum.tex` line 584), so no Hilbert-Schmidt
variant had to be introduced.

Condition 2 is Wolf Eq. (2.20), `T̂_{αβ} = tr[F_α† T(G_β)]`, specialized to
`F_α = G_α = σ_α`. Orthonormality is for the Hilbert-Schmidt inner product,
`tr[σ_α† σ_β] = δ_{αβ}` (Eq. (2.18) with `P = 1`); this is the content of the new
predicate `HilbertSchmidtOrthonormal`. Hermiticity of the family is *not*
required by the equivalence, so it is not assumed. Its relation to the existing
`TracePairingSelfDualBasis` of `TNLean/Channel/TransferMatrix.lean` is recorded
as a lemma: a Hermitian Hilbert-Schmidt orthonormal basis is trace-self-dual,
because for `σ_α† = σ_α` the pairings `tr[σ_α† X]` and `tr[σ_α X]` agree. The
convention is stated in the module docstring under "Basis convention".

## Proof route

Wolf's own: conditions 1 and 2 by inspecting the transfer matrix (Hermiticity
preservation gives `T̂† = T̂*`, and the transfer matrix in a basis determines the
map); 3 implies 1 because the Kraus operators of `T` and `T*` differ by Hermitian
conjugation; 1 implies 3 by writing
`T(X) = ½ ∑_j (K_j X K_j† + K_j† X K_j)` and applying to each pair
`(K_j, K_j†)/√2` the unitary `(a, b) ↦ ((a+b)/√2, i(a−b)/√2)` through
`kraus_same_map_of_unitary_combination`, giving the Hermitian operators
`(K_j + K_j†)/2` and `i(K_j − K_j†)/2`.

## Hypothesis match

Wolf assumes only that `T : M_d -> M_d` is completely positive. The Lean
statement assumes only `IsCPMap T`. No trace preservation, no unitality, no
Hermiticity of the basis.

## Blueprint

New sub-file `blueprint/src/chapter/ch16_channel_representations_self_dual.tex`,
input from `ch16_channel_representations.tex`; all entries carry `\lean{...}`,
`\leanok`, and `\leanok` on the proofs. No line shifts in any file recorded in
`docs/tenkz/DISPOSITIONS.md`.

## Verification

| Command | Outcome |
| --- | --- |
| `lake env lean TNLean/Channel/SelfDual.lean` | clean, no warnings |
| `lake build TNLean.Channel` | 9104 jobs, success |
| `lake exe lint_style` | clean |
| `rg -n "sorry\|axiom" TNLean/Channel/SelfDual.lean` | no matches |
| `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` | current |
| `python3 scripts/blueprint_lean_sync.py --ci` | in sync, 7396/7396 |
| `python3 scripts/check_tenkz_dispositions.py` | PASS |

Closes LionSR/QICLean#203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176U7wiKWaxFAKBHv3Jgjz3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formalization and documentation only; no changes to existing channel runtime behavior or security-sensitive paths.
> 
> **Overview**
> Formalizes Wolf §2.2 **self-dual channels**: for CP `T`, `T = T*` (via `Matrix.traceAdjointMap`), Hermiticity of the Hilbert–Schmidt transfer matrix `transferMatrixOfBasis`, and existence of Hermitian Kraus operators are equivalent (`self_dual_tfae`).
> 
> Adds **`TNLean/Channel/SelfDual.lean`** with `HilbertSchmidtOrthonormal`, basis transfer matrices, Kraus/dual identities, Hermitian Kraus recombination, and the matrix-unit variant; wires it through **`TNLean.Channel`**. Adds **`traceAdjointMap_apply_apply`** in `MatrixTracePairing.lean` for entrywise dual formulas used in the matrix-unit proof.
> 
> Adds blueprint **`ch16_channel_representations_self_dual.tex`** and includes it from the channel representations chapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebf411c7758ab73382b89a00924e9ab05f752592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->