### PR TITLE
docs(MPDO): correct Example 4.11 arithmetic provenance

### DIFF
--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -9,9 +9,8 @@ import Mathlib.Tactic.NormNum
 /-!
 # Exact arithmetic for CPSV16 Examples 4.10 and 4.11
 
-The printed four-site calculation in CPSV16 Example 4.10 and the independently
-derived four-site specialization of the family in Example 4.11 lead to the
-strict integer comparisons
+Independent exact four-site derivations associated with CPSV16 Examples 4.10
+and 4.11 lead to the strict integer comparisons
 \[
   2^{32}7^7>3^3 5^{20}
 \]
@@ -31,15 +30,14 @@ These scalar results do not identify reduced-state spectra and do not assert
 saturation or failure of an area law. Such conclusions require separate formal
 links from the printed tensors to the corresponding entropy expressions.
 
-**Scope restriction:** See `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`;
-this module certifies only scalar arithmetic endpoints, not entropy
-statements, and records the boundary between the printed Example 4.10
-calculation and the derived four-site specialization of Example 4.11.
+**Scope restriction (scalar, not entropy):** See docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex.
+
+**Local fix (channel):** Left-right flip. See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
 
 ## Main results
 
-* `example410_integer_inequality`: the exact integer comparison associated with
-  the four-site calculation for Example 4.10.
+* `example410_integer_inequality`: the exact integer comparison derived from the
+  corrected four-site calculation for Example 4.10 at flip probability one quarter.
 * `example411_integer_inequality`: the exact integer comparison associated with
   the derived four-site specialization of Example 4.11.
 * `example410_log_ratio_pos`: positivity of the first logarithmic ratio.
@@ -48,17 +46,22 @@ calculation and the derived four-site specialization of Example 4.11.
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Example 4.10,
-  lines 897--905, and the arbitrary-length family of Example 4.11, lines 907--924.
-* `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`, for the independent
-  four-site specialization and entropy calculation for Example 4.11.
+  lines 897--905, for the repeated-label channel, decimal entropies, and printed
+  claim; and Example 4.11, lines 907--924, for its arbitrary-length family.
+* `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`, for both independent
+  exact four-site derivations.
 -/
 
 namespace CPSVExamples410411Arithmetic
 
-/-- The strict integer comparison arising in the exact four-site calculation
-for CPSV16 Example 4.10.
+/-- The strict integer comparison arising from the exact four-site calculation
+for the corrected left-right channel in CPSV16 Example 4.10 at flip probability
+one quarter.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+Source: the independent derivation recorded in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. The source paper,
+arXiv:1606.00608, Example 4.10, lines 897--905, prints only the repeated-label
+channel, decimal entropies, and its qualitative claim. -/
 theorem example410_integer_inequality :
     (2 : ℕ) ^ 32 * 7 ^ 7 > 3 ^ 3 * 5 ^ 20 := by
   norm_num
@@ -74,13 +77,17 @@ theorem example411_integer_inequality :
     (41 : ℕ) ^ 82 * 5 ^ 50 > 2 ^ 48 * 13 ^ 52 * 7 ^ 112 := by
   norm_num
 
-/-- The logarithm of the exact ratio associated with CPSV16 Example 4.10 is
-strictly positive.
+/-- The logarithm of the exact ratio derived from the corrected left-right
+channel in CPSV16 Example 4.10 at flip probability one quarter is strictly
+positive.
 
 This is only a scalar arithmetic statement; it does not identify the ratio with
 an entropy difference.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.10, lines 897--905. -/
+Source: the independent derivation recorded in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. The source paper,
+arXiv:1606.00608, Example 4.10, lines 897--905, prints only the repeated-label
+channel, decimal entropies, and its qualitative claim. -/
 theorem example410_log_ratio_pos :
     0 < Real.log (((2 : ℝ) ^ 32 * 7 ^ 7) / (3 ^ 3 * 5 ^ 20)) := by
   apply Real.log_pos

--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -31,7 +31,10 @@ These scalar results do not identify reduced-state spectra and do not assert
 saturation or failure of an area law. Such conclusions require separate formal
 links from the printed tensors to the corresponding entropy expressions.
 
-**Scope restriction (scalar):** No entropy. See docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex.
+**Scope restriction:** See `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`;
+this module certifies only scalar arithmetic endpoints, not entropy
+statements, and records the boundary between the printed Example 4.10
+calculation and the derived four-site specialization of Example 4.11.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -31,10 +31,11 @@ These scalar results do not identify reduced-state spectra and do not assert
 saturation or failure of an area law. Such conclusions require separate formal
 links from the printed tensors to the corresponding entropy expressions.
 
-**Scope restriction (scalar arithmetic only):**
-`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex` records this boundary and
-distinguishes the printed Example 4.10 calculation from the independently
-derived four-site specialization of Example 4.11.
+**Scope restriction (scalar arithmetic only):** this module certifies only the
+arithmetic endpoints. See `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`
+for the boundary and the distinction between the printed Example 4.10
+calculation and the independently derived four-site specialization of
+Example 4.11.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -31,11 +31,7 @@ These scalar results do not identify reduced-state spectra and do not assert
 saturation or failure of an area law. Such conclusions require separate formal
 links from the printed tensors to the corresponding entropy expressions.
 
-**Scope restriction (scalar arithmetic only):** this module certifies only the
-arithmetic endpoints. See `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`
-for the boundary and the distinction between the printed Example 4.10
-calculation and the independently derived four-site specialization of
-Example 4.11.
+**Scope restriction (scalar):** No entropy. See docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
+++ b/TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean
@@ -9,8 +9,9 @@ import Mathlib.Tactic.NormNum
 /-!
 # Exact arithmetic for CPSV16 Examples 4.10 and 4.11
 
-The finite four-site calculations associated with CPSV16 Examples 4.10 and 4.11
-lead to the strict integer comparisons
+The printed four-site calculation in CPSV16 Example 4.10 and the independently
+derived four-site specialization of the family in Example 4.11 lead to the
+strict integer comparisons
 \[
   2^{32}7^7>3^3 5^{20}
 \]
@@ -30,19 +31,26 @@ These scalar results do not identify reduced-state spectra and do not assert
 saturation or failure of an area law. Such conclusions require separate formal
 links from the printed tensors to the corresponding entropy expressions.
 
+**Scope restriction (scalar arithmetic only):**
+`docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex` records this boundary and
+distinguishes the printed Example 4.10 calculation from the independently
+derived four-site specialization of Example 4.11.
+
 ## Main results
 
 * `example410_integer_inequality`: the exact integer comparison associated with
   the four-site calculation for Example 4.10.
 * `example411_integer_inequality`: the exact integer comparison associated with
-  the four-site calculation for Example 4.11.
+  the derived four-site specialization of Example 4.11.
 * `example410_log_ratio_pos`: positivity of the first logarithmic ratio.
 * `example411_log_ratio_pos`: positivity of the second logarithmic ratio.
 
 ## References
 
-* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Examples 4.10 and
-  4.11, lines 897--924.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Example 4.10,
+  lines 897--905, and the arbitrary-length family of Example 4.11, lines 907--924.
+* `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`, for the independent
+  four-site specialization and entropy calculation for Example 4.11.
 -/
 
 namespace CPSVExamples410411Arithmetic
@@ -55,10 +63,13 @@ theorem example410_integer_inequality :
     (2 : ℕ) ^ 32 * 7 ^ 7 > 3 ^ 3 * 5 ^ 20 := by
   norm_num
 
-/-- The strict integer comparison arising in the exact four-site calculation
-for the literal weights printed in CPSV16 Example 4.11.
+/-- The strict integer comparison arising from the four-site specialization of
+the arbitrary-length family and literal weights printed in CPSV16 Example 4.11.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924. -/
+Source: the independent derivation recorded in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. The source paper,
+arXiv:1606.00608, Example 4.11, lines 907--924, prints only the arbitrary-length
+family, its weights, and its SAL claim. -/
 theorem example411_integer_inequality :
     (41 : ℕ) ^ 82 * 5 ^ 50 > 2 ^ 48 * 13 ^ 52 * 7 ^ 112 := by
   norm_num
@@ -75,13 +86,16 @@ theorem example410_log_ratio_pos :
   apply Real.log_pos
   norm_num
 
-/-- The logarithm of the exact ratio associated with the literal weights in
-CPSV16 Example 4.11 is strictly positive.
+/-- The logarithm of the exact ratio associated with the four-site specialization
+of the literal weights in CPSV16 Example 4.11 is strictly positive.
 
 This is only a scalar arithmetic statement; it does not identify the ratio with
 an entropy difference.
 
-Source: CPSV16, arXiv:1606.00608, Example 4.11, lines 907--924. -/
+Source: the independent derivation recorded in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. The source paper,
+arXiv:1606.00608, Example 4.11, lines 907--924, prints only the arbitrary-length
+family, its weights, and its SAL claim. -/
 theorem example411_log_ratio_pos :
     0 < Real.log
       (((41 : ℝ) ^ 82 * 5 ^ 50) / (2 ^ 48 * 13 ^ 52 * 7 ^ 112)) := by

--- a/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
+++ b/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
@@ -14,15 +14,24 @@
 \begin{document}
 \maketitle
 
-\section{Printed comparisons}
+\section{Source statements and derived comparisons}
 
 Example~4.10 of Cirac--Perez-Garcia--Schuch--Verstraete
-(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:897--905}) prints a four-site
-calculation whose entropy comparison reduces to the strict inequality
+(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:897--905}) prints a channel with
+a repeated left-qubit label, four decimal entropy values, and the claim that
+the mutual information does not saturate except at the stated exceptional
+probabilities.  It prints no exact ratio or integer comparison.  Replacing the
+repeated label by the network-consistent left-right correlated flip and setting
+$p=1/4$ reproduces the decimal entropies and gives the independently derived
+comparison
 \[
   2^{32}7^7>3^3 5^{20}.
 \]
-Lines~907--924 print instead an arbitrary-length family for Example~4.11, its
+The corrected channel, reduced spectra, and logarithmic reduction are recorded
+in \path{docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex}, not in the
+source paper.
+
+Lines~907--924 print an arbitrary-length family for Example~4.11, its
 diagonal bond weights, and the claim that it satisfies saturation of the area
 law but not zero correlation length.  They contain no four-site specialization,
 reduced spectra, entropy values, or exact integer comparison.

--- a/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
+++ b/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
@@ -16,20 +16,27 @@
 
 \section{Printed comparisons}
 
-Examples~4.10 and~4.11 of Cirac--Perez-Garcia--Schuch--Verstraete
-(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:897--924}) print four-site
-calculations whose entropy comparisons reduce to two strict inequalities of
-natural numbers:
+Example~4.10 of Cirac--Perez-Garcia--Schuch--Verstraete
+(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:897--905}) prints a four-site
+calculation whose entropy comparison reduces to the strict inequality
 \[
-  2^{32}7^7>3^3 5^{20}
+  2^{32}7^7>3^3 5^{20}.
 \]
-for Example~4.10, and
+Lines~907--924 print instead an arbitrary-length family for Example~4.11, its
+diagonal bond weights, and the claim that it satisfies saturation of the area
+law but not zero correlation length.  They contain no four-site specialization,
+reduced spectra, entropy values, or exact integer comparison.
+
+Independently specializing the printed Example~4.11 family to four sites gives
 \[
-  41^{82}5^{50}>2^{48}13^{52}7^{112}
+  41^{82}5^{50}>2^{48}13^{52}7^{112}.
 \]
-for the bond weights printed in Example~4.11.  Both sides of each comparison
-are positive integers, so each strict inequality is equivalent to positivity
-of the real logarithm of the corresponding ratio.
+The finite-ring distribution, reduced spectra, and logarithmic reduction that
+yield this comparison are recorded in
+\path{docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex}; they are not
+statements printed in the source paper.  Both sides of each comparison are
+positive integers, so each strict inequality is equivalent to positivity of
+the real logarithm of the corresponding ratio.
 
 \section{Certified statements}
 


### PR DESCRIPTION
## Summary

- restrict the CPSV16 lines 907--924 citation to the printed arbitrary-length Example 4.11 family, diagonal weights, and SAL claim
- attribute the four-site specialization, reduced spectra, and exact integer/log comparison to the independent derivation in `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`
- add the required in-source `Scope restriction` marker pointing to `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`
- preserve all four theorem names, types, and proofs

Closes #6321.

## Verification

- `lake env lean TNLean/MPS/MPDO/CPSVExamples410411Arithmetic.lean`
- focused `latexmk` compilation of `docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`
- changed-note `chktex`
- reader-facing prose check
- generated import-aggregator check
- Lean module-policy checks
- Blueprint-Lean synchronization and changed-declaration coverage
- CPSV16 every-label audit
- comment-stripped Lean comparison against `origin/main`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX prose only; no changes to formal statements or proof scripts.
> 
> **Overview**
> **Documentation-only** update to how CPSV16 Examples 4.10 and 4.11 relate to the machine-checked integer inequalities in `CPSVExamples410411Arithmetic`. Theorems, types, and `norm_num` proofs are unchanged.
> 
> The Lean module and `cpsv16_exact_arithmetic_scope.tex` now distinguish what arXiv:1606.00608 **prints** (channels/families, decimal entropies, qualitative claims) from what is **independently derived** in `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex` (corrected 4.10 left–right channel at \(p=1/4\); four-site specialization for 4.11; reduced spectra and exact comparisons). In-source markers point to the scope note and entropy derivation doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7c5c7d97668137c06ebdbaaed86b5b1193ca34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->