### PR TITLE
feat(Channel): Wolf Prop 3.2 as bounds on the Schmidt-rank infimum

### DIFF
--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -409,11 +409,14 @@ normalized vector ψ of Schmidt rank at most k satisfies
 infimum over such vectors.
 
 This version covers Schmidt rank 1 ≤ k < D', where D' is the dimension of the
-first tensor factor.  From k = D' on, the Schmidt-rank constraint is vacuous and
-the Rayleigh estimate λ_min ≤ ⟨ψ|τ|ψ⟩ of
-`Matrix.IsHermitian.spectral_lower_bound_top` applies, itself dominating the
-bound above; the two together cover every k ≥ 1, hence the source's range
-1 ≤ k ≤ D with D the dimension of the second factor.  See
+first tensor factor.  From k = D' on, the Schmidt-rank constraint is vacuous, the
+Rayleigh estimate λ_min ≤ ⟨ψ|τ|ψ⟩ of
+`Matrix.IsHermitian.spectral_lower_bound_top` applies, and every ‖ρᵢ‖₍ₖ₎ = 1, so
+at a minimizing index j the bound above reads
+ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) = λ_min + Σ_{i:νᵢ≤0, i≠j} (νᵢ − ν₀) ≤ λ_min
+when λ_min ≤ 0, and ν₀ ≤ λ_min when every eigenvalue is positive.  The two
+together cover every k ≥ 1, hence the source's range 1 ≤ k ≤ D with D the
+dimension of the second factor.  See
 `docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`. -/
 theorem IsHermitian.spectral_lower_bound {τ : Matrix (m × n) (m × n) ℂ}
     (hτ : τ.IsHermitian) {ν₀ : ℝ} {k : ℕ} (hk1 : 1 ≤ k) (hk : k < Fintype.card m)

--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -61,7 +61,7 @@ overlap vector.
   characterization of the least eigenvalue gives min_ψ ⟨ψ|τ|ψ⟩ = λ_min.
 * `Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations` and
   `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le` -- equations (3.7)
-  and (3.8) in the source's form, as the two bounds on
+  and (3.8) for n < D' in the source's form, as the two bounds on
   inf_ψ ⟨ψ|τ|ψ⟩ over the normalized vectors of Schmidt rank at most n.
 * `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top` and
   `Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top` -- the same infimum
@@ -399,8 +399,8 @@ theorem IsHermitian.exists_overlap_eq_kyFanNorm {τ : Matrix (m × n) (m × n) �
     congr 1
   rw [hkfn]
 
-/-- **Wolf's Chapter 3, Proposition 3.2, equation (3.7): spectral lower bound.**
-For a Hermitian operator τ on the bipartite space — for instance the
+/-- **Wolf's Chapter 3, Proposition 3.2, equation (3.7) for k < D': spectral
+lower bound.**  For a Hermitian operator τ on the bipartite space — for instance the
 Choi-Jamiolkowski operator of a Hermitian map — with eigenvalues νᵢ and reduced
 eigenvector densities ρᵢ, let ν₀ be a nonnegative lower bound for the positive
 eigenvalues (the smallest positive eigenvalue in the source).  Then every
@@ -434,8 +434,8 @@ theorem IsHermitian.spectral_lower_bound {τ : Matrix (m × n) (m × n) ℂ}
   · rw [hτ.sum_normSq_eigenvector_overlap_re ψ, hψ, Complex.one_re]
   · exact hτ.normSq_overlap_le_kyFanNorm i hk1 hk hψ hrank
 
-/-- **Wolf's Chapter 3, Proposition 3.2, equation (3.8): spectral upper bound.**
-When every eigenvalue of τ is at most ν, there is a normalized vector ψ of
+/-- **Wolf's Chapter 3, Proposition 3.2, equation (3.8) for k < D': spectral
+upper bound.**  When every eigenvalue of τ is at most ν, there is a normalized vector ψ of
 Schmidt rank at most k for which ⟨ψ|τ|ψ⟩ ≤ ν + (νⱼ − ν) ‖ρⱼ‖₍ₖ₎, for any
 chosen eigenvector index j; hence the infimum over such vectors lies below that
 value.  In the source ν is the largest positive eigenvalue and j indexes the
@@ -514,8 +514,8 @@ theorem IsHermitian.schmidtRankLEExpectations_bddBelow [Nonempty m] [Nonempty n]
   rintro r ⟨ψ, hψ, -, rfl⟩
   exact hτ.spectral_lower_bound_top hψ
 
-/-- **Wolf §3, line 153, Eq. (3.7).**  For a Hermitian operator τ on the
-bipartite space with eigenvalues νᵢ, normalized eigenvectors φᵢ and reduced
+/-- **Wolf §3, line 153, Eq. (3.7) for n < D'.**  For a Hermitian operator τ on
+the bipartite space with eigenvalues νᵢ, normalized eigenvectors φᵢ and reduced
 densities ρᵢ = tr₂ |φᵢ⟩⟨φᵢ|, and for ν₀ ≥ 0 a lower bound for the positive
 eigenvalues (the smallest positive eigenvalue in the source),
 inf_ψ ⟨ψ|τ|ψ⟩ ≥ ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ‖ρᵢ‖₍ₙ₎, the infimum being taken
@@ -541,8 +541,8 @@ theorem IsHermitian.le_sInf_schmidtRankLEExpectations [Nonempty m] [Nonempty n]
   rintro r ⟨ψ, hψ, hrank, rfl⟩
   exact hτ.spectral_lower_bound hk1 hk hν0 hmin hψ hrank
 
-/-- **Wolf §3, line 153, Eq. (3.8).**  If every eigenvalue of τ is at most ν
-then, for any eigenvector index j,
+/-- **Wolf §3, line 153, Eq. (3.8) for n < D'.**  If every eigenvalue of τ is at
+most ν then, for any eigenvector index j,
 inf_ψ ⟨ψ|τ|ψ⟩ ≤ ν + (νⱼ − ν) ‖ρⱼ‖₍ₙ₎, the infimum being taken over the
 normalized vectors of Schmidt rank at most n.  In the source ν is the largest positive
 eigenvalue and j indexes the unique non-positive eigenvalue ν₋, all other

--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -255,14 +255,21 @@ theorem rayleigh_eigenvector_re (hτ : τ.IsHermitian) (j : N) :
   · intro h; exact absurd (Finset.mem_univ j) h
 
 /-- **Wolf's Chapter 3, Proposition 3.2, equation (3.7) at the top Schmidt-rank
-index n = D.**  At the top index the Schmidt-rank constraint is vacuous (every
-vector on the bipartite space has Schmidt rank at most D) and the Ky-Fan D-norm
+index n = D'.**  At the top index the Schmidt-rank constraint is vacuous (every
+vector on the bipartite space has Schmidt rank at most D') and the Ky-Fan
+D'-norm
 of each reduced density collapses to its trace, which is one.  The lower
 bound (3.7) therefore degenerates to the Rayleigh characterization of the least
 eigenvalue: every normalized vector ψ satisfies λ_min ≤ ⟨ψ|τ|ψ⟩, with no
 Schmidt-rank restriction.  This is the completely-positive endpoint of the
 positivity chain.  Together with `exists_spectral_lower_bound_top` it gives
-min_ψ ⟨ψ|τ|ψ⟩ = λ_min. -/
+min_ψ ⟨ψ|τ|ψ⟩ = λ_min.
+
+Wolf's positivity index runs over 1 ≤ n ≤ D with D the dimension of the second
+tensor factor (Prop. 3.1), so these indices belong to the source's range when
+D' ≤ D and extend past it when D' > D.  The statement itself needs no relation
+between the two dimensions.
+-/
 theorem spectral_lower_bound_top [Nonempty N] (hτ : τ.IsHermitian)
     {ψ : N → ℂ} (hψ : star ψ ⬝ᵥ ψ = 1) :
     Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues ≤ (star ψ ⬝ᵥ (τ *ᵥ ψ)).re := by
@@ -278,12 +285,18 @@ theorem spectral_lower_bound_top [Nonempty N] (hτ : τ.IsHermitian)
           mul_le_mul_of_nonneg_right (Finset.inf'_le _ (Finset.mem_univ i)) (sq_nonneg _)
 
 /-- **Wolf's Chapter 3, Proposition 3.2, equation (3.8) at the top Schmidt-rank
-index n = D.**  Equation (3.8) bounds the infimum of ⟨ψ|τ|ψ⟩ from above by
+index n = D'.**  Equation (3.8) bounds the infimum of ⟨ψ|τ|ψ⟩ from above by
 exhibiting a low-expectation vector.  At the top index the Schmidt-rank
 constraint is vacuous and the bound becomes λ_min: the eigenvector at an index
 realizing the least eigenvalue is normalized and makes ⟨ψ|τ|ψ⟩ equal to λ_min,
 so inf_ψ ⟨ψ|τ|ψ⟩ ≤ λ_min.  Together with `spectral_lower_bound_top` this gives
-min_ψ ⟨ψ|τ|ψ⟩ = λ_min, the source's top-index statement. -/
+min_ψ ⟨ψ|τ|ψ⟩ = λ_min, the source's top-index statement.
+
+Wolf's positivity index runs over 1 ≤ n ≤ D with D the dimension of the second
+tensor factor (Prop. 3.1), so these indices belong to the source's range when
+D' ≤ D and extend past it when D' > D.  The statement itself needs no relation
+between the two dimensions.
+-/
 theorem exists_spectral_lower_bound_top [Nonempty N] (hτ : τ.IsHermitian) :
     ∃ ψ : N → ℂ, star ψ ⬝ᵥ ψ = 1 ∧
       (star ψ ⬝ᵥ (τ *ᵥ ψ)).re = Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues := by
@@ -580,7 +593,13 @@ the least eigenvalue: inf_ψ ⟨ψ|τ|ψ⟩ = ν_min.
 Equation (3.7) at the top index is a separate statement: its right-hand side
 reads ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀), which for eigenvalues (−2, −1, 3) is −6 while
 ν_min is −2.  The inequality ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ≤ ν_min is
-`Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top`. -/
+`Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top`.
+
+Wolf's positivity index runs over 1 ≤ n ≤ D with D the dimension of the second
+tensor factor (Prop. 3.1), so these indices belong to the source's range when
+D' ≤ D and extend past it when D' > D.  The statement itself needs no relation
+between the two dimensions.
+-/
 theorem IsHermitian.sInf_schmidtRankLEExpectations_top [Nonempty m] [Nonempty n]
     {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {k : ℕ}
     (hk : Fintype.card m ≤ k) :
@@ -603,7 +622,13 @@ Ky-Fan norm ‖ρᵢ‖₍ₙ₎ equals tr ρᵢ = 1, so the right-hand side of 
 summand at a minimizing index already lowers ν₀ to ν_min, and the remaining
 summands are nonpositive.  With
 `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top` this gives (3.7) at the
-top index. -/
+top index.
+
+Wolf's positivity index runs over 1 ≤ n ≤ D with D the dimension of the second
+tensor factor (Prop. 3.1), so these indices belong to the source's range when
+D' ≤ D and extend past it when D' > D.  The statement itself needs no relation
+between the two dimensions.
+-/
 theorem IsHermitian.le_sInf_schmidtRankLEExpectations_top [Nonempty m] [Nonempty n]
     {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {ν₀ : ℝ} {k : ℕ}
     (hk : Fintype.card m ≤ k) (hν0 : 0 ≤ ν₀)

--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -15,10 +15,12 @@ a bipartite space — for instance the Choi-Jamiolkowski operator of a Hermitian
 map — with eigenvalues νᵢ and normalized eigenvectors φᵢ, write ρᵢ for the
 reduced density operator of φᵢ on the first factor.  Denoting by ν₀ the smallest
 positive eigenvalue and by ν the largest one, the expectation of τ in a vector
-ψ of Schmidt rank n is controlled by the Ky-Fan n-norms of the ρᵢ:
-the infimum over normalized Schmidt-rank-n vectors lies above
+ψ of Schmidt rank at most n is controlled by the Ky-Fan n-norms of the ρᵢ:
+the infimum over the normalized vectors of Schmidt rank at most n lies above
 ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ‖ρᵢ‖₍ₙ₎, and — when a single non-positive
-eigenvalue is present — below ν + (ν₋ − ν) ‖ρ₋‖₍ₙ₎.
+eigenvalue is present — below ν + (ν₋ − ν) ‖ρ₋‖₍ₙ₎.  The source writes
+"Schmidt rank n" for the bounded-rank set; the reading is recorded in
+`docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex`.
 
 The argument separates the positive and non-positive parts of the spectral
 decomposition.  The Rayleigh expansion ⟨ψ|τ|ψ⟩ = Σᵢ νᵢ |⟨φᵢ|ψ⟩|² together with
@@ -36,9 +38,10 @@ overlap vector.
   plain vectors.
 * `Matrix.IsHermitian.reducedEigDensity` -- the reduced density operator of an
   eigenvector projector on the first tensor factor.
-* `Matrix.schmidtRankLEExpectations` -- the expectations ⟨ψ|τ|ψ⟩ realized by the
+* `Matrix.schmidtRankLEExpectations` -- the real parts Re ⟨ψ|τ|ψ⟩ realized by the
   normalized vectors of Schmidt rank at most n, the set whose infimum the source
-  bounds.
+  bounds.  For Hermitian τ, the setting of every result here, the quadratic form
+  is real and the real part is the expectation itself.
 
 ## Main results
 
@@ -47,21 +50,23 @@ overlap vector.
 * `Matrix.IsHermitian.sum_normSq_eigenvector_overlap` and its real form -- Parseval's
   identity for the eigenbasis overlaps.
 * `Matrix.IsHermitian.spectral_lower_bound` -- Wolf's Chapter 3, Proposition 3.2,
-  equation (3.7): the lower bound on the expectation in a Schmidt-rank-n vector.
+  equation (3.7): the lower bound on the expectation in a vector of Schmidt rank
+  at most n.
 * `Matrix.IsHermitian.exists_le_spectral_upper_bound` -- Wolf's Chapter 3,
-  Proposition 3.2, equation (3.8): a Schmidt-rank-n vector realizing the matching
-  upper bound on the infimum.
+  Proposition 3.2, equation (3.8): a vector of Schmidt rank at most n realizing
+  the matching upper bound on the infimum.
 * `Matrix.IsHermitian.spectral_lower_bound_top` and
-  `Matrix.IsHermitian.exists_spectral_lower_bound_top` -- the top-index n = D case
-  of equations (3.7) and (3.8), where the Schmidt-rank constraint is vacuous and
-  the bounds reduce to the Rayleigh characterization of the least eigenvalue
-  min_ψ ⟨ψ|τ|ψ⟩ = λ_min.
+  `Matrix.IsHermitian.exists_spectral_lower_bound_top` -- the top-index n = D'
+  case, where the Schmidt-rank constraint is vacuous and the Rayleigh
+  characterization of the least eigenvalue gives min_ψ ⟨ψ|τ|ψ⟩ = λ_min.
 * `Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations` and
   `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le` -- equations (3.7)
   and (3.8) in the source's form, as the two bounds on
-  inf_ψ ⟨ψ|τ|ψ⟩ over the normalized vectors of Schmidt rank n.
-* `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top` -- the same infimum at
-  the top index n = D', where it equals the least eigenvalue.
+  inf_ψ ⟨ψ|τ|ψ⟩ over the normalized vectors of Schmidt rank at most n.
+* `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top` and
+  `Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top` -- the same infimum
+  at an index n ≥ D', where it equals the least eigenvalue, and equation (3.7)
+  there.
 
 ## References
 
@@ -313,6 +318,29 @@ theorem IsHermitian.reducedEigDensity_posSemidef {τ : Matrix (m × n) (m × n) 
   rw [hτ.reducedEigDensity_eq]
   exact posSemidef_self_mul_conjTranspose _
 
+/-- The reduced density operator of an eigenvector has unit trace. -/
+theorem IsHermitian.trace_reducedEigDensity {τ : Matrix (m × n) (m × n) ℂ}
+    (hτ : τ.IsHermitian) (i : m × n) :
+    (hτ.reducedEigDensity i).trace = 1 := by
+  rw [IsHermitian.reducedEigDensity, trace_partialTraceRight, trace_vecMulVec,
+    dotProduct_comm]
+  exact hτ.star_eigenvector_dotProduct_self i
+
+/-- Once the index reaches the dimension of the first tensor factor, the Ky-Fan
+norm of a reduced eigenvector density is its trace: ‖ρᵢ‖₍ₖ₎ = tr ρᵢ = 1 for
+k ≥ D'.  Indices past the dimension contribute a zero eigenvalue. -/
+theorem IsHermitian.kyFanNorm_reducedEigDensity_eq_one {τ : Matrix (m × n) (m × n) ℂ}
+    (hτ : τ.IsHermitian) (i : m × n) {k : ℕ} (hk : Fintype.card m ≤ k) :
+    (hτ.reducedEigDensity_posSemidef i).isHermitian.kyFanNorm k = 1 := by
+  have hstab : (hτ.reducedEigDensity_posSemidef i).isHermitian.kyFanNorm k
+      = (hτ.reducedEigDensity_posSemidef i).isHermitian.kyFanNorm (Fintype.card m) := by
+    simp only [Matrix.IsHermitian.kyFanNorm, Matrix.IsHermitian.descEigenvalue]
+    refine (Finset.sum_subset (Finset.range_subset_range.2 hk) fun x _ hx => ?_).symm
+    rw [Finset.mem_range] at hx
+    exact dif_neg hx
+  rw [hstab, Matrix.IsHermitian.kyFanNorm_card_eq_trace_re, hτ.trace_reducedEigDensity i,
+    Complex.one_re]
+
 /-- The squared overlap of a normalized vector of Schmidt rank at most k with an
 eigenvector is bounded by the Ky-Fan k-norm of that eigenvector's reduced
 density operator.  This is the maximal-overlap lemma (Wolf Lemma 3.1) specialized
@@ -380,11 +408,12 @@ normalized vector ψ of Schmidt rank at most k satisfies
 ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ‖ρᵢ‖₍ₖ₎ ≤ ⟨ψ|τ|ψ⟩, hence the same bound holds for the
 infimum over such vectors.
 
-This version covers Schmidt rank 1 ≤ k < D, where D is the dimension of the
-first tensor factor.  The top index k = D, where the Schmidt-rank constraint is
-vacuous and the bound degenerates to the Rayleigh estimate λ_min ≤ ⟨ψ|τ|ψ⟩, is
-`Matrix.IsHermitian.spectral_lower_bound_top`; the two together cover the full
-source range 1 ≤ k ≤ D.  See
+This version covers Schmidt rank 1 ≤ k < D', where D' is the dimension of the
+first tensor factor.  From k = D' on, the Schmidt-rank constraint is vacuous and
+the Rayleigh estimate λ_min ≤ ⟨ψ|τ|ψ⟩ of
+`Matrix.IsHermitian.spectral_lower_bound_top` applies, itself dominating the
+bound above; the two together cover every k ≥ 1, hence the source's range
+1 ≤ k ≤ D with D the dimension of the second factor.  See
 `docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`. -/
 theorem IsHermitian.spectral_lower_bound {τ : Matrix (m × n) (m × n) ℂ}
     (hτ : τ.IsHermitian) {ν₀ : ℝ} {k : ℕ} (hk1 : 1 ≤ k) (hk : k < Fintype.card m)
@@ -410,9 +439,9 @@ value.  In the source ν is the largest positive eigenvalue and j indexes the
 unique non-positive eigenvalue ν₋, in which case the bound reads
 ν + (ν₋ − ν) ‖ρ₋‖₍ₖ₎.
 
-This version covers 1 ≤ k < D.  At the top index k = D, where the Schmidt
-constraint is vacuous and j is taken at the minimizing index, the bound becomes
-the existence of a vector with ⟨ψ|τ|ψ⟩ = λ_min, i.e.
+This version covers 1 ≤ k < D'.  From k = D' on, where the Schmidt constraint is
+vacuous and j is taken at the minimizing index, the bound becomes the existence
+of a vector with ⟨ψ|τ|ψ⟩ = λ_min, i.e.
 inf_ψ ⟨ψ|τ|ψ⟩ ≤ λ_min; that endpoint is
 `Matrix.IsHermitian.exists_spectral_lower_bound_top`.  See
 `docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`. -/
@@ -441,8 +470,10 @@ is the set over which n-positivity quantifies.  The reading is recorded in
 `docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex`.
 -/
 
-/-- The expectations ⟨ψ|τ|ψ⟩ realized by the normalized vectors ψ of Schmidt
-rank at most k. -/
+/-- The real parts Re ⟨ψ|τ|ψ⟩ realized by the normalized vectors ψ of Schmidt
+rank at most k.  For Hermitian τ the quadratic form is real, so this is the set
+of expectations of τ in those vectors; for a general τ it is the set of their
+real parts. -/
 def schmidtRankLEExpectations (τ : Matrix (m × n) (m × n) ℂ) (k : ℕ) : Set ℝ :=
   {r : ℝ | ∃ ψ : m × n → ℂ, star ψ ⬝ᵥ ψ = 1 ∧ HasSchmidtRankLE k ψ ∧
     (star ψ ⬝ᵥ (τ *ᵥ ψ)).re = r}
@@ -485,14 +516,16 @@ bipartite space with eigenvalues νᵢ, normalized eigenvectors φᵢ and reduce
 densities ρᵢ = tr₂ |φᵢ⟩⟨φᵢ|, and for ν₀ ≥ 0 a lower bound for the positive
 eigenvalues (the smallest positive eigenvalue in the source),
 inf_ψ ⟨ψ|τ|ψ⟩ ≥ ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ‖ρᵢ‖₍ₙ₎, the infimum being taken
-over the normalized vectors of Schmidt rank n.
+over the normalized vectors of Schmidt rank at most n.
 
 The bound holds pointwise at every normalized vector of Schmidt rank at most n,
 hence in particular at those of Schmidt rank exactly n.
 
 The Schmidt-rank range is 1 ≤ n < D', with D' the dimension of the first
-tensor factor; the top index n = D' is
-`Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top`. -/
+tensor factor; the indices n ≥ D' are
+`Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top`.  The two together
+cover every n ≥ 1, hence the source's range 1 ≤ n ≤ D with D the dimension of
+the second factor. -/
 theorem IsHermitian.le_sInf_schmidtRankLEExpectations [Nonempty m] [Nonempty n]
     {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {ν₀ : ℝ} {k : ℕ}
     (hk1 : 1 ≤ k) (hk : k < Fintype.card m) (hν0 : 0 ≤ ν₀)
@@ -508,7 +541,7 @@ theorem IsHermitian.le_sInf_schmidtRankLEExpectations [Nonempty m] [Nonempty n]
 /-- **Wolf §3, line 153, Eq. (3.8).**  If every eigenvalue of τ is at most ν
 then, for any eigenvector index j,
 inf_ψ ⟨ψ|τ|ψ⟩ ≤ ν + (νⱼ − ν) ‖ρⱼ‖₍ₙ₎, the infimum being taken over the
-normalized vectors of Schmidt rank n.  In the source ν is the largest positive
+normalized vectors of Schmidt rank at most n.  In the source ν is the largest positive
 eigenvalue and j indexes the unique non-positive eigenvalue ν₋, all other
 eigenvalues being strictly positive, so that the bound reads
 ν + (ν₋ − ν) ‖ρ₋‖₍ₙ₎.
@@ -521,8 +554,10 @@ maximal-overlap vector has Schmidt rank min(n, rank ρ₋), so a limiting argume
 replaces the witness.  Documented in
 `docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex`.
 
-The Schmidt-rank range is 1 ≤ n < D'; the top index n = D' is
-`Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top`. -/
+The Schmidt-rank range is 1 ≤ n < D'; the indices n ≥ D', where the bound reads
+ν₋ = ν_min, are `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top`.  The two
+together cover every n ≥ 1, hence the source's range 1 ≤ n ≤ D with D the
+dimension of the second factor. -/
 theorem IsHermitian.sInf_schmidtRankLEExpectations_le [Nonempty m] [Nonempty n]
     {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {νsup : ℝ} {k : ℕ} (j : m × n)
     (hk1 : 1 ≤ k) (hk : k < Fintype.card m) (hmax : ∀ i, hτ.eigenvalues i ≤ νsup) :
@@ -533,11 +568,16 @@ theorem IsHermitian.sInf_schmidtRankLEExpectations_le [Nonempty m] [Nonempty n]
   exact (csInf_le (hτ.schmidtRankLEExpectations_bddBelow k)
     (mem_schmidtRankLEExpectations hψ hrank)).trans hle
 
-/-- **Wolf §3, line 153, Eqs. (3.7) and (3.8) at the top index n = D'.**  Once
-the Schmidt-rank bound reaches the dimension D' of the first tensor factor the
-constraint is vacuous and each Ky-Fan norm collapses to ‖ρᵢ‖₍D'₎ = tr ρᵢ = 1,
-so both bounds read ν_min and the infimum is the least eigenvalue:
-inf_ψ ⟨ψ|τ|ψ⟩ = ν_min. -/
+/-- **Wolf §3, line 153, Eq. (3.8) at the top index n = D'.**  Once the
+Schmidt-rank bound reaches the dimension D' of the first tensor factor the
+constraint is vacuous and each Ky-Fan norm collapses to ‖ρᵢ‖₍D'₎ = tr ρᵢ = 1, so
+the right-hand side of (3.8) reads ν + (ν₋ − ν) = ν₋ = ν_min, and the infimum is
+the least eigenvalue: inf_ψ ⟨ψ|τ|ψ⟩ = ν_min.
+
+Equation (3.7) at the top index is a separate statement: its right-hand side
+reads ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀), which for eigenvalues (−2, −1, 3) is −6 while
+ν_min is −2.  The inequality ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ≤ ν_min is
+`Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top`. -/
 theorem IsHermitian.sInf_schmidtRankLEExpectations_top [Nonempty m] [Nonempty n]
     {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {k : ℕ}
     (hk : Fintype.card m ≤ k) :
@@ -553,5 +593,45 @@ theorem IsHermitian.sInf_schmidtRankLEExpectations_top [Nonempty m] [Nonempty n]
       ((schmidtRank_le_left _).trans hk)⟩ ?_
     rintro r ⟨ψ, hψ, -, rfl⟩
     exact hτ.spectral_lower_bound_top hψ
+
+/-- **Wolf §3, line 153, Eq. (3.7) at the top index n = D'.**  For n ≥ D' every
+Ky-Fan norm ‖ρᵢ‖₍ₙ₎ equals tr ρᵢ = 1, so the right-hand side of (3.7) reads
+ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀).  That value is at most the least eigenvalue: the
+summand at a minimizing index already lowers ν₀ to ν_min, and the remaining
+summands are nonpositive.  With
+`Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top` this gives (3.7) at the
+top index. -/
+theorem IsHermitian.le_sInf_schmidtRankLEExpectations_top [Nonempty m] [Nonempty n]
+    {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {ν₀ : ℝ} {k : ℕ}
+    (hk : Fintype.card m ≤ k) (hν0 : 0 ≤ ν₀)
+    (hmin : ∀ i, 0 < hτ.eigenvalues i → ν₀ ≤ hτ.eigenvalues i) :
+    ν₀ + ∑ i ∈ Finset.univ.filter (fun i => hτ.eigenvalues i ≤ 0),
+        (hτ.eigenvalues i - ν₀) * (hτ.reducedEigDensity_posSemidef i).isHermitian.kyFanNorm k
+      ≤ sInf (schmidtRankLEExpectations τ k) := by
+  classical
+  rw [hτ.sInf_schmidtRankLEExpectations_top hk]
+  have hone : ∀ i : m × n,
+      (hτ.reducedEigDensity_posSemidef i).isHermitian.kyFanNorm k = 1 :=
+    fun i => hτ.kyFanNorm_reducedEigDensity_eq_one i hk
+  simp only [hone, mul_one]
+  obtain ⟨j, -, hj⟩ := Finset.exists_mem_eq_inf' Finset.univ_nonempty hτ.eigenvalues
+  rw [hj]
+  rcases le_or_gt (hτ.eigenvalues j) 0 with hjle | hjle
+  · have hjmem : j ∈ Finset.univ.filter (fun i => hτ.eigenvalues i ≤ 0) :=
+      Finset.mem_filter.2 ⟨Finset.mem_univ j, hjle⟩
+    have hsplit := Finset.add_sum_erase _ (fun i => hτ.eigenvalues i - ν₀) hjmem
+    have hrest : ∑ i ∈ (Finset.univ.filter (fun i => hτ.eigenvalues i ≤ 0)).erase j,
+        (hτ.eigenvalues i - ν₀) ≤ 0 := by
+      refine Finset.sum_nonpos fun i hi => ?_
+      have hi0 := (Finset.mem_filter.1 (Finset.mem_of_mem_erase hi)).2
+      linarith
+    linarith
+  · have hempty : Finset.univ.filter (fun i => hτ.eigenvalues i ≤ 0) = ∅ := by
+      refine Finset.filter_eq_empty_iff.2 fun {i} _ => ?_
+      have hji : hτ.eigenvalues j ≤ hτ.eigenvalues i := by
+        rw [← hj]; exact Finset.inf'_le _ (Finset.mem_univ i)
+      exact not_le.2 (lt_of_lt_of_le hjle hji)
+    rw [hempty, Finset.sum_empty, add_zero]
+    exact hmin j hjle
 
 end Matrix

--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -263,8 +263,8 @@ completely-positive endpoint of the positivity chain, and together with
 
 This is not equation (3.7) at that index.  There the Ky-Fan norms collapse to
 ‖ρᵢ‖₍D'₎ = tr ρᵢ = 1 and the right-hand side of (3.7) reads
-ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀), which for the spectrum (−2, −1, 3) is −6 while
-λ_min is −2.  The top-index instance of (3.7) is
+ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀), which for the spectrum (−2, −1, 3) with ν₀ = 3
+is −6 while λ_min is −2.  The top-index instance of (3.7) is
 `Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top`, which uses the
 present bound.
 
@@ -594,8 +594,8 @@ the right-hand side of (3.8) reads ν + (ν₋ − ν) = ν₋ = ν_min, and the
 the least eigenvalue: inf_ψ ⟨ψ|τ|ψ⟩ = ν_min.
 
 Equation (3.7) at the top index is a separate statement: its right-hand side
-reads ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀), which for eigenvalues (−2, −1, 3) is −6 while
-ν_min is −2.  The inequality ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ≤ ν_min is
+reads ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀), which for eigenvalues (−2, −1, 3) with ν₀ = 3
+is −6 while ν_min is −2.  The inequality ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ≤ ν_min is
 `Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top`.
 
 Wolf's positivity index runs over 1 ≤ n ≤ D with D the dimension of the second

--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -36,6 +36,9 @@ overlap vector.
   plain vectors.
 * `Matrix.IsHermitian.reducedEigDensity` -- the reduced density operator of an
   eigenvector projector on the first tensor factor.
+* `Matrix.schmidtRankLEExpectations` -- the expectations ⟨ψ|τ|ψ⟩ realized by the
+  normalized vectors of Schmidt rank at most n, the set whose infimum the source
+  bounds.
 
 ## Main results
 
@@ -53,6 +56,12 @@ overlap vector.
   of equations (3.7) and (3.8), where the Schmidt-rank constraint is vacuous and
   the bounds reduce to the Rayleigh characterization of the least eigenvalue
   min_ψ ⟨ψ|τ|ψ⟩ = λ_min.
+* `Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations` and
+  `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le` -- equations (3.7)
+  and (3.8) in the source's form, as the two bounds on
+  inf_ψ ⟨ψ|τ|ψ⟩ over the normalized vectors of Schmidt rank n.
+* `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top` -- the same infimum at
+  the top index n = D', where it equals the least eigenvalue.
 
 ## References
 
@@ -420,5 +429,129 @@ theorem IsHermitian.exists_le_spectral_upper_bound {τ : Matrix (m × n) (m × n
   refine Matrix.IsHermitian.spectral_upper_bound_core (ν := hτ.eigenvalues)
     (o := fun i => ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2) j (fun i => sq_nonneg _) ?_ hmax
   rw [hτ.sum_normSq_eigenvector_overlap_re ψ, hψnorm, Complex.one_re]
+
+/-! ## The infimum over normalized vectors of bounded Schmidt rank
+
+Wolf §3, line 153 states the criterion as two inequalities for inf_ψ ⟨ψ|τ|ψ⟩,
+the infimum over the normalized vectors of Schmidt rank n.  The vectors so
+named are those of the form (1 ⊗ X)ᴴ ψ' with rank X = n, equivalently the image
+of ℂ^D' ⊗ ℂⁿ under the embedding ℂⁿ ⊆ ℂ^D of the second factor (Wolf §3,
+proof of Prop. 3.1): they are the vectors of Schmidt rank at most n, and that
+is the set over which n-positivity quantifies.  The reading is recorded in
+`docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex`.
+-/
+
+/-- The expectations ⟨ψ|τ|ψ⟩ realized by the normalized vectors ψ of Schmidt
+rank at most k. -/
+def schmidtRankLEExpectations (τ : Matrix (m × n) (m × n) ℂ) (k : ℕ) : Set ℝ :=
+  {r : ℝ | ∃ ψ : m × n → ℂ, star ψ ⬝ᵥ ψ = 1 ∧ HasSchmidtRankLE k ψ ∧
+    (star ψ ⬝ᵥ (τ *ᵥ ψ)).re = r}
+
+omit [DecidableEq m] [DecidableEq n] in
+/-- The expectation of τ in a normalized vector of Schmidt rank at most k
+belongs to the expectation set. -/
+theorem mem_schmidtRankLEExpectations {τ : Matrix (m × n) (m × n) ℂ} {k : ℕ}
+    {ψ : m × n → ℂ} (hψ : star ψ ⬝ᵥ ψ = 1) (hrank : HasSchmidtRankLE k ψ) :
+    (star ψ ⬝ᵥ (τ *ᵥ ψ)).re ∈ schmidtRankLEExpectations τ k :=
+  ⟨ψ, hψ, hrank, rfl⟩
+
+omit [DecidableEq m] [DecidableEq n] in
+/-- The expectation set is nonempty for every Schmidt-rank bound k ≥ 1: a
+normalized product vector has Schmidt rank one. -/
+theorem schmidtRankLEExpectations_nonempty [Nonempty m] [Nonempty n]
+    (τ : Matrix (m × n) (m × n) ℂ) {k : ℕ} (hk1 : 1 ≤ k) :
+    (schmidtRankLEExpectations τ k).Nonempty := by
+  classical
+  obtain ⟨i₀⟩ := ‹Nonempty m›
+  obtain ⟨j₀⟩ := ‹Nonempty n›
+  set u : m → ℂ := fun i => if i = i₀ then 1 else 0 with hu
+  set v : n → ℂ := fun j => if j = j₀ then 1 else 0 with hv
+  refine ⟨_, (fun p : m × n => u p.1 * v p.2), ?_,
+    (hasSchmidtRankLE_one_product u v).mono hk1, rfl⟩
+  simp [dotProduct, Fintype.sum_prod_type, hu, hv]
+
+omit [DecidableEq m] [DecidableEq n] in
+/-- The expectation set is bounded below by the least eigenvalue of τ. -/
+theorem IsHermitian.schmidtRankLEExpectations_bddBelow [Nonempty m] [Nonempty n]
+    {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) (k : ℕ) :
+    BddBelow (schmidtRankLEExpectations τ k) := by
+  classical
+  refine ⟨Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues, ?_⟩
+  rintro r ⟨ψ, hψ, -, rfl⟩
+  exact hτ.spectral_lower_bound_top hψ
+
+/-- **Wolf §3, line 153, Eq. (3.7).**  For a Hermitian operator τ on the
+bipartite space with eigenvalues νᵢ, normalized eigenvectors φᵢ and reduced
+densities ρᵢ = tr₂ |φᵢ⟩⟨φᵢ|, and for ν₀ ≥ 0 a lower bound for the positive
+eigenvalues (the smallest positive eigenvalue in the source),
+inf_ψ ⟨ψ|τ|ψ⟩ ≥ ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ‖ρᵢ‖₍ₙ₎, the infimum being taken
+over the normalized vectors of Schmidt rank n.
+
+The bound holds pointwise at every normalized vector of Schmidt rank at most n,
+hence in particular at those of Schmidt rank exactly n.
+
+The Schmidt-rank range is 1 ≤ n < D', with D' the dimension of the first
+tensor factor; the top index n = D' is
+`Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top`. -/
+theorem IsHermitian.le_sInf_schmidtRankLEExpectations [Nonempty m] [Nonempty n]
+    {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {ν₀ : ℝ} {k : ℕ}
+    (hk1 : 1 ≤ k) (hk : k < Fintype.card m) (hν0 : 0 ≤ ν₀)
+    (hmin : ∀ i, 0 < hτ.eigenvalues i → ν₀ ≤ hτ.eigenvalues i) :
+    ν₀ + ∑ i ∈ Finset.univ.filter (fun i => hτ.eigenvalues i ≤ 0),
+        (hτ.eigenvalues i - ν₀) * (hτ.reducedEigDensity_posSemidef i).isHermitian.kyFanNorm k
+      ≤ sInf (schmidtRankLEExpectations τ k) := by
+  classical
+  refine le_csInf (schmidtRankLEExpectations_nonempty τ hk1) ?_
+  rintro r ⟨ψ, hψ, hrank, rfl⟩
+  exact hτ.spectral_lower_bound hk1 hk hν0 hmin hψ hrank
+
+/-- **Wolf §3, line 153, Eq. (3.8).**  If every eigenvalue of τ is at most ν
+then, for any eigenvector index j,
+inf_ψ ⟨ψ|τ|ψ⟩ ≤ ν + (νⱼ − ν) ‖ρⱼ‖₍ₙ₎, the infimum being taken over the
+normalized vectors of Schmidt rank n.  In the source ν is the largest positive
+eigenvalue and j indexes the unique non-positive eigenvalue ν₋, all other
+eigenvalues being strictly positive, so that the bound reads
+ν + (ν₋ − ν) ‖ρ₋‖₍ₙ₎.
+
+**Scope restriction (Schmidt rank at most n):** the infimum is over the
+normalized vectors of Schmidt rank at most n, the set named by the source.  On
+the alternative reading, in which only the vectors of Schmidt rank exactly n
+compete, the bound remains true but the infimum is in general not attained: the
+maximal-overlap vector has Schmidt rank min(n, rank ρ₋), so a limiting argument
+replaces the witness.  Documented in
+`docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex`.
+
+The Schmidt-rank range is 1 ≤ n < D'; the top index n = D' is
+`Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top`. -/
+theorem IsHermitian.sInf_schmidtRankLEExpectations_le [Nonempty m] [Nonempty n]
+    {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {νsup : ℝ} {k : ℕ} (j : m × n)
+    (hk1 : 1 ≤ k) (hk : k < Fintype.card m) (hmax : ∀ i, hτ.eigenvalues i ≤ νsup) :
+    sInf (schmidtRankLEExpectations τ k)
+      ≤ νsup + (hτ.eigenvalues j - νsup)
+          * (hτ.reducedEigDensity_posSemidef j).isHermitian.kyFanNorm k := by
+  obtain ⟨ψ, hψ, hrank, hle⟩ := hτ.exists_le_spectral_upper_bound j hk1 hk hmax
+  exact (csInf_le (hτ.schmidtRankLEExpectations_bddBelow k)
+    (mem_schmidtRankLEExpectations hψ hrank)).trans hle
+
+/-- **Wolf §3, line 153, Eqs. (3.7) and (3.8) at the top index n = D'.**  Once
+the Schmidt-rank bound reaches the dimension D' of the first tensor factor the
+constraint is vacuous and each Ky-Fan norm collapses to ‖ρᵢ‖₍D'₎ = tr ρᵢ = 1,
+so both bounds read ν_min and the infimum is the least eigenvalue:
+inf_ψ ⟨ψ|τ|ψ⟩ = ν_min. -/
+theorem IsHermitian.sInf_schmidtRankLEExpectations_top [Nonempty m] [Nonempty n]
+    {τ : Matrix (m × n) (m × n) ℂ} (hτ : τ.IsHermitian) {k : ℕ}
+    (hk : Fintype.card m ≤ k) :
+    sInf (schmidtRankLEExpectations τ k)
+      = Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues := by
+  refine le_antisymm ?_ ?_
+  · obtain ⟨ψ, hψ, hval⟩ := hτ.exists_spectral_lower_bound_top
+    have hrank : HasSchmidtRankLE k ψ := (schmidtRank_le_left ψ).trans hk
+    exact hval ▸ csInf_le (hτ.schmidtRankLEExpectations_bddBelow k)
+      (mem_schmidtRankLEExpectations hψ hrank)
+  · refine le_csInf ⟨_, mem_schmidtRankLEExpectations
+      (τ := τ) (k := k) (hτ.star_eigenvector_dotProduct_self (Classical.arbitrary (m × n)))
+      ((schmidtRank_le_left _).trans hk)⟩ ?_
+    rintro r ⟨ψ, hψ, -, rfl⟩
+    exact hτ.spectral_lower_bound_top hψ
 
 end Matrix

--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -254,16 +254,19 @@ theorem rayleigh_eigenvector_re (hτ : τ.IsHermitian) (j : N) :
     rw [hτ.star_eigenvector_dotProduct_eigenvector i j, if_neg hij]; simp
   · intro h; exact absurd (Finset.mem_univ j) h
 
-/-- **Wolf's Chapter 3, Proposition 3.2, equation (3.7) at the top Schmidt-rank
-index n = D'.**  At the top index the Schmidt-rank constraint is vacuous (every
-vector on the bipartite space has Schmidt rank at most D') and the Ky-Fan
-D'-norm
-of each reduced density collapses to its trace, which is one.  The lower
-bound (3.7) therefore degenerates to the Rayleigh characterization of the least
-eigenvalue: every normalized vector ψ satisfies λ_min ≤ ⟨ψ|τ|ψ⟩, with no
-Schmidt-rank restriction.  This is the completely-positive endpoint of the
-positivity chain.  Together with `exists_spectral_lower_bound_top` it gives
-min_ψ ⟨ψ|τ|ψ⟩ = λ_min.
+/-- **Rayleigh lower bound at the top Schmidt-rank index n = D'.**  At the top
+index the Schmidt-rank constraint is vacuous: every vector on the bipartite
+space has Schmidt rank at most D', so every normalized vector ψ satisfies
+λ_min ≤ ⟨ψ|τ|ψ⟩ with no Schmidt-rank restriction.  This is the
+completely-positive endpoint of the positivity chain, and together with
+`exists_spectral_lower_bound_top` it gives min_ψ ⟨ψ|τ|ψ⟩ = λ_min.
+
+This is not equation (3.7) at that index.  There the Ky-Fan norms collapse to
+‖ρᵢ‖₍D'₎ = tr ρᵢ = 1 and the right-hand side of (3.7) reads
+ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀), which for the spectrum (−2, −1, 3) is −6 while
+λ_min is −2.  The top-index instance of (3.7) is
+`Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top`, which uses the
+present bound.
 
 Wolf's positivity index runs over 1 ≤ n ≤ D with D the dimension of the second
 tensor factor (Prop. 3.1), so these indices belong to the source's range when

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -13,6 +13,7 @@ forced by an anti-unitary symmetry of square $-\Id$.
 
 \input{chapter/ch25_positive_not_cp_trace_normalization_and_lorentz_cone}
 \input{chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi}
+\input{chapter/ch25_positive_not_cp_npositivity_infimum}
 \input{chapter/ch25_positive_not_cp_positivity_reduction_and_breuer_hall}
 \input{chapter/ch25_positive_not_cp_choi_and_decomposable_maps}
 \input{chapter/ch25_positive_not_cp_ppt_and_separable_states}

--- a/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
@@ -1,0 +1,141 @@
+\subsection{The criterion as bounds on an infimum}
+
+\cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} states the spectral
+criterion for $n$-positivity as two inequalities for
+$\inf_\psi\bra{\psi}\tau\ket{\psi}$, the infimum being taken over the
+normalized vectors of Schmidt rank $n$. Those vectors are the ones obtained by
+embedding $\C^n$ in the second factor $\C^{D}$, so they are the vectors of
+Schmidt rank at most $n$: this is the set on which $n$-positivity of a
+Hermitian map is tested, and the set whose expectations are collected below.
+
+\begin{definition}[Expectations at bounded Schmidt rank]
+    \label{def:schmidt_rank_le_expectations}
+    \lean{Matrix.schmidtRankLEExpectations}
+    \leanok
+    \uses{def:schmidt_rank}
+    For a matrix $\tau$ on $\C^{D'}\otimes\C^{D}$ and a bound $n$, the set
+    \begin{align}
+        E_n(\tau)
+         & =\{\bra{\psi}\tau\ket{\psi}:\|\psi\|=1,\ \SR(\psi)\le n\}
+        \subseteq\R
+        \label{eq:channel_schmidt_rank_le_expectations}
+    \end{align}
+    collects the expectations of $\tau$ in the normalized vectors of Schmidt
+    rank at most $n$.
+\end{definition}
+
+\begin{lemma}[The expectation set has an infimum]
+    \label{lem:schmidt_rank_le_expectations_inf_exists}
+    \lean{Matrix.schmidtRankLEExpectations_nonempty,
+        Matrix.IsHermitian.schmidtRankLEExpectations_bddBelow}
+    \leanok
+    \uses{def:schmidt_rank_le_expectations, thm:spectral_bound_schmidt_rank_top}
+    For $n\ge1$ the set $E_n(\tau)$ is nonempty, and for Hermitian $\tau$ it is
+    bounded below by the least eigenvalue $\nu_{\min}$ of $\tau$. Hence
+    $\inf E_n(\tau)$ exists.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:schmidt_rank_basic_bounds, thm:spectral_bound_schmidt_rank_top}
+    A normalized product vector has Schmidt rank one, hence Schmidt rank at
+    most $n$, so $E_n(\tau)$ is nonempty. For the lower bound,
+    Theorem~\ref{thm:spectral_bound_schmidt_rank_top} gives
+    $\nu_{\min}\le\bra{\psi}\tau\ket{\psi}$ for every normalized $\psi$,
+    without any Schmidt-rank restriction.
+\end{proof}
+
+\begin{theorem}[Lower bound on the Schmidt-rank infimum]
+    \label{thm:spectral_infimum_lower_bound}
+    \lean{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations}
+    \leanok
+    \uses{def:schmidt_rank_le_expectations,
+        lem:schmidt_rank_le_expectations_inf_exists,
+        thm:spectral_lower_bound_schmidt_rank}
+    Let $\tau$ be a Hermitian operator on $\C^{D'}\otimes\C^{D}$ with
+    eigenvalues $\nu_i$, normalized eigenvectors $\phi_i$ and reduced densities
+    $\rho_i=\tr_2\ketbra{\phi_i}{\phi_i}$. Let $1\le n<D'$ and let
+    $\nu_0\ge0$ be a lower bound for the positive eigenvalues, the smallest
+    positive eigenvalue in \cite[Chapter~3]{Wolf2012Quantum}. Then
+    \begin{align}
+        \nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)}
+         & \le\inf E_n(\tau).
+        \label{eq:channel_spectral_infimum_lower}
+    \end{align}
+    This is \cite[Chapter~3, equation~(3.7)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:spectral_lower_bound_schmidt_rank,
+        lem:schmidt_rank_le_expectations_inf_exists}
+    Theorem~\ref{thm:spectral_lower_bound_schmidt_rank} bounds
+    $\bra{\psi}\tau\ket{\psi}$ below by the left-hand side at every normalized
+    $\psi$ of Schmidt rank at most $n$, that is, at every element of
+    $E_n(\tau)$. A lower bound for every element of a nonempty set is a lower
+    bound for its infimum.
+\end{proof}
+
+\begin{theorem}[Upper bound on the Schmidt-rank infimum]
+    \label{thm:spectral_infimum_upper_bound}
+    \lean{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le}
+    \leanok
+    \uses{def:schmidt_rank_le_expectations,
+        lem:schmidt_rank_le_expectations_inf_exists,
+        thm:spectral_upper_bound_schmidt_rank}
+    With $\tau$, $\phi_i$ and $\rho_i$ as above, let $1\le n<D'$ and suppose
+    every eigenvalue of $\tau$ is at most $\nu$. Then, for every eigenvector
+    index $j$,
+    \begin{align}
+        \inf E_n(\tau)
+         & \le\nu+(\nu_j-\nu)\|\rho_j\|_{(n)}.
+        \label{eq:channel_spectral_infimum_upper}
+    \end{align}
+    Taking $\nu$ to be the largest positive eigenvalue and $j$ the index of the
+    unique non-positive eigenvalue $\nu_-$, which is the situation in which all
+    other eigenvalues are strictly positive, gives
+    $\inf E_n(\tau)\le\nu+(\nu_--\nu)\|\rho_-\|_{(n)}$, that is,
+    \cite[Chapter~3, equation~(3.8)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:spectral_upper_bound_schmidt_rank,
+        lem:schmidt_rank_le_expectations_inf_exists}
+    Theorem~\ref{thm:spectral_upper_bound_schmidt_rank} supplies a normalized
+    $\psi$ of Schmidt rank at most $n$ whose expectation is at most the
+    right-hand side. Its expectation lies in $E_n(\tau)$, so the infimum of
+    $E_n(\tau)$ is at most that expectation, hence at most the right-hand side.
+\end{proof}
+
+\begin{theorem}[The Schmidt-rank infimum at the top index]
+    \label{thm:spectral_infimum_top}
+    \lean{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top}
+    \leanok
+    \uses{def:schmidt_rank_le_expectations,
+        thm:spectral_bound_schmidt_rank_top}
+    Once the Schmidt-rank bound reaches the dimension $D'$ of the first tensor
+    factor the constraint is vacuous and each Ky-Fan norm collapses to
+    $\|\rho_i\|_{(D')}=\tr\rho_i=1$, so both bounds read $\nu_{\min}$ and
+    \begin{align}
+        \inf E_n(\tau)
+         & =\nu_{\min}
+        \qquad (n\ge D').
+        \label{eq:channel_spectral_infimum_top}
+    \end{align}
+    With Theorems~\ref{thm:spectral_infimum_lower_bound}
+    and~\ref{thm:spectral_infimum_upper_bound} this covers the full range
+    $1\le n\le D'$ of \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} in the
+    infimum form of the source.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:spectral_bound_schmidt_rank_top,
+        thm:schmidt_rank_basic_bounds}
+    Every vector has Schmidt rank at most $D'$, so for $n\ge D'$ the set
+    $E_n(\tau)$ is the set of expectations in all normalized vectors. By
+    Theorem~\ref{thm:spectral_bound_schmidt_rank_top} that set is bounded below
+    by $\nu_{\min}$ and contains $\nu_{\min}$, attained at an eigenvector for
+    the least eigenvalue.
+\end{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
@@ -16,12 +16,14 @@ Hermitian map is tested, and the set whose expectations are collected below.
     For a matrix $\tau$ on $\C^{D'}\otimes\C^{D}$ and a bound $n$, the set
     \begin{align}
         E_n(\tau)
-         & =\{\bra{\psi}\tau\ket{\psi}:\|\psi\|=1,\ \SR(\psi)\le n\}
+         & =\{\Re\bra{\psi}\tau\ket{\psi}:\|\psi\|=1,\ \SR(\psi)\le n\}
         \subseteq\R
         \label{eq:channel_schmidt_rank_le_expectations}
     \end{align}
-    collects the expectations of $\tau$ in the normalized vectors of Schmidt
-    rank at most $n$.
+    collects the real parts of the quadratic forms of $\tau$ in the normalized
+    vectors of Schmidt rank at most $n$. For Hermitian $\tau$, the setting of
+    every statement below, the quadratic form is real and $E_n(\tau)$ is the
+    set of expectations of $\tau$ in those vectors.
 \end{definition}
 
 \begin{lemma}[The expectation set has an infimum]
@@ -29,7 +31,7 @@ Hermitian map is tested, and the set whose expectations are collected below.
     \lean{Matrix.schmidtRankLEExpectations_nonempty,
         Matrix.IsHermitian.schmidtRankLEExpectations_bddBelow}
     \leanok
-    \uses{def:schmidt_rank_le_expectations, thm:spectral_bound_schmidt_rank_top}
+    \uses{def:schmidt_rank_le_expectations}
     For $n\ge1$ the set $E_n(\tau)$ is nonempty, and for Hermitian $\tau$ it is
     bounded below by the least eigenvalue $\nu_{\min}$ of $\tau$. Hence
     $\inf E_n(\tau)$ exists.
@@ -49,9 +51,8 @@ Hermitian map is tested, and the set whose expectations are collected below.
     \label{thm:spectral_infimum_lower_bound}
     \lean{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations}
     \leanok
-    \uses{def:schmidt_rank_le_expectations,
-        lem:schmidt_rank_le_expectations_inf_exists,
-        thm:spectral_lower_bound_schmidt_rank}
+    \uses{def:schmidt_rank_le_expectations, def:ky_fan_norm,
+        def:reduced_eig_density}
     Let $\tau$ be a Hermitian operator on $\C^{D'}\otimes\C^{D}$ with
     eigenvalues $\nu_i$, normalized eigenvectors $\phi_i$ and reduced densities
     $\rho_i=\tr_2\ketbra{\phi_i}{\phi_i}$. Let $1\le n<D'$ and let
@@ -80,9 +81,8 @@ Hermitian map is tested, and the set whose expectations are collected below.
     \label{thm:spectral_infimum_upper_bound}
     \lean{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le}
     \leanok
-    \uses{def:schmidt_rank_le_expectations,
-        lem:schmidt_rank_le_expectations_inf_exists,
-        thm:spectral_upper_bound_schmidt_rank}
+    \uses{def:schmidt_rank_le_expectations, def:ky_fan_norm,
+        def:reduced_eig_density}
     With $\tau$, $\phi_i$ and $\rho_i$ as above, let $1\le n<D'$ and suppose
     every eigenvalue of $\tau$ is at most $\nu$. Then, for every eigenvector
     index $j$,
@@ -110,32 +110,52 @@ Hermitian map is tested, and the set whose expectations are collected below.
 
 \begin{theorem}[The Schmidt-rank infimum at the top index]
     \label{thm:spectral_infimum_top}
-    \lean{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top}
+    \lean{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top,
+        Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top}
     \leanok
-    \uses{def:schmidt_rank_le_expectations,
-        thm:spectral_bound_schmidt_rank_top}
+    \uses{def:schmidt_rank_le_expectations, def:ky_fan_norm,
+        def:reduced_eig_density}
     Once the Schmidt-rank bound reaches the dimension $D'$ of the first tensor
-    factor the constraint is vacuous and each Ky-Fan norm collapses to
-    $\|\rho_i\|_{(D')}=\tr\rho_i=1$, so both bounds read $\nu_{\min}$ and
+    factor the constraint is vacuous, and each Ky-Fan norm collapses to
+    $\|\rho_i\|_{(n)}=\tr\rho_i=1$. For $n\ge D'$,
     \begin{align}
         \inf E_n(\tau)
-         & =\nu_{\min}
-        \qquad (n\ge D').
+         & =\nu_{\min},
         \label{eq:channel_spectral_infimum_top}
     \end{align}
-    With Theorems~\ref{thm:spectral_infimum_lower_bound}
-    and~\ref{thm:spectral_infimum_upper_bound} this covers the full range
-    $1\le n\le D'$ of \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} in the
-    infimum form of the source.
+    which is the right-hand side of~(3.8) there, since
+    $\nu+(\nu_--\nu)\|\rho_-\|_{(n)}=\nu_-=\nu_{\min}$ when $\nu_-$ is the only
+    non-positive eigenvalue. The right-hand side of~(3.7) reads
+    $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, which is a strictly weaker bound as
+    soon as $\tau$ has two non-positive eigenvalues: for the spectrum
+    $(-2,-1,3)$ it is $-6$ while $\nu_{\min}=-2$. It is still a lower bound, so
+    for those same $n$
+    \begin{align}
+        \nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)}
+         & \le\inf E_n(\tau),
+        \label{eq:channel_spectral_infimum_top_lower}
+    \end{align}
+    and~(3.7) holds at those indices as well. With
+    Theorems~\ref{thm:spectral_infimum_lower_bound}
+    and~\ref{thm:spectral_infimum_upper_bound} this covers every $n\ge1$, hence
+    the range $1\le n\le D$ of
+    \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum}, where $D$ is the
+    dimension of the second tensor factor.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:spectral_bound_schmidt_rank_top,
-        thm:schmidt_rank_basic_bounds}
+        thm:schmidt_rank_basic_bounds,
+        lem:schmidt_rank_le_expectations_inf_exists}
     Every vector has Schmidt rank at most $D'$, so for $n\ge D'$ the set
     $E_n(\tau)$ is the set of expectations in all normalized vectors. By
     Theorem~\ref{thm:spectral_bound_schmidt_rank_top} that set is bounded below
     by $\nu_{\min}$ and contains $\nu_{\min}$, attained at an eigenvector for
-    the least eigenvalue.
+    the least eigenvalue. This gives~(\ref{eq:channel_spectral_infimum_top}).
+    For~(\ref{eq:channel_spectral_infimum_top_lower}), the summand at a
+    minimizing index $j$ contributes $\nu_j-\nu_0=\nu_{\min}-\nu_0$ whenever
+    $\nu_{\min}\le0$, and every other summand is nonpositive, so the left-hand
+    side is at most $\nu_{\min}$; if instead every eigenvalue is positive the
+    sum is empty and the left-hand side is $\nu_0\le\nu_{\min}$.
 \end{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
@@ -29,12 +29,14 @@ Hermitian map is tested, and the set whose expectations are collected below.
 \begin{lemma}[The expectation set has an infimum]
     \label{lem:schmidt_rank_le_expectations_inf_exists}
     \lean{Matrix.schmidtRankLEExpectations_nonempty,
-        Matrix.IsHermitian.schmidtRankLEExpectations_bddBelow}
+        Matrix.IsHermitian.schmidtRankLEExpectations_bddBelow,
+        Matrix.mem_schmidtRankLEExpectations}
     \leanok
     \uses{def:schmidt_rank_le_expectations}
-    For $n\ge1$ the set $E_n(\tau)$ is nonempty, and for Hermitian $\tau$ it is
-    bounded below by the least eigenvalue $\nu_{\min}$ of $\tau$. Hence
-    $\inf E_n(\tau)$ exists.
+    Assume $D',D\ge1$. For $n\ge1$ the set $E_n(\tau)$ is nonempty, and for
+    Hermitian $\tau$ it is bounded below by the least eigenvalue $\nu_{\min}$ of
+    $\tau$; the expectation of $\tau$ in any normalized vector of Schmidt rank at
+    most $n$ is one of its elements. Hence $\inf E_n(\tau)$ exists.
 \end{lemma}
 
 \begin{proof}
@@ -55,8 +57,8 @@ Hermitian map is tested, and the set whose expectations are collected below.
         def:reduced_eig_density}
     Let $\tau$ be a Hermitian operator on $\C^{D'}\otimes\C^{D}$ with
     eigenvalues $\nu_i$, normalized eigenvectors $\phi_i$ and reduced densities
-    $\rho_i=\tr_2\ketbra{\phi_i}{\phi_i}$. Let $1\le n<D'$ and let
-    $\nu_0\ge0$ be a lower bound for the positive eigenvalues, the smallest
+    $\rho_i=\tr_2\ketbra{\phi_i}{\phi_i}$. Assume $D',D\ge1$, let $1\le n<D'$
+    and let $\nu_0\ge0$ be a lower bound for the positive eigenvalues, the smallest
     positive eigenvalue in \cite[Chapter~3]{Wolf2012Quantum}. Then
     \begin{align}
         \nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)}
@@ -83,9 +85,9 @@ Hermitian map is tested, and the set whose expectations are collected below.
     \leanok
     \uses{def:schmidt_rank_le_expectations, def:ky_fan_norm,
         def:reduced_eig_density}
-    With $\tau$, $\phi_i$ and $\rho_i$ as above, let $1\le n<D'$ and suppose
-    every eigenvalue of $\tau$ is at most $\nu$. Then, for every eigenvector
-    index $j$,
+    With $\tau$, $\phi_i$ and $\rho_i$ as above and $D',D\ge1$, let
+    $1\le n<D'$ and suppose every eigenvalue of $\tau$ is at most $\nu$. Then,
+    for every eigenvector index $j$,
     \begin{align}
         \inf E_n(\tau)
          & \le\nu+(\nu_j-\nu)\|\rho_j\|_{(n)}.
@@ -108,6 +110,32 @@ Hermitian map is tested, and the set whose expectations are collected below.
     $E_n(\tau)$ is at most that expectation, hence at most the right-hand side.
 \end{proof}
 
+\begin{lemma}[The Ky-Fan norm of a reduced eigenvector density at full index]
+    \label{lem:reduced_eig_density_ky_fan_top}
+    \lean{Matrix.IsHermitian.trace_reducedEigDensity,
+        Matrix.IsHermitian.kyFanNorm_reducedEigDensity_eq_one}
+    \leanok
+    \uses{def:ky_fan_norm, def:reduced_eig_density}
+    Each reduced eigenvector density has unit trace, and for $n\ge D'$ its
+    Ky-Fan $n$-norm is that trace:
+    \begin{align}
+        \tr\rho_i &= 1,
+        &
+        \|\rho_i\|_{(n)} &= 1
+        .
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The partial trace preserves the trace, so
+    $\tr\rho_i=\tr\ketbra{\phi_i}{\phi_i}=\braket{\phi_i}{\phi_i}=1$. The Ky-Fan
+    norm sums the $n$ largest eigenvalues in descending order, and an index past
+    the dimension $D'$ contributes zero, so the sum stops growing at $n=D'$,
+    where it is the sum of all eigenvalues of $\rho_i$, that is $\tr\rho_i$.
+\end{proof}
+
 \begin{theorem}[The Schmidt-rank infimum at the top index]
     \label{thm:spectral_infimum_top}
     \lean{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top,
@@ -115,8 +143,9 @@ Hermitian map is tested, and the set whose expectations are collected below.
     \leanok
     \uses{def:schmidt_rank_le_expectations, def:ky_fan_norm,
         def:reduced_eig_density}
-    Once the Schmidt-rank bound reaches the dimension $D'$ of the first tensor
-    factor the constraint is vacuous, and each Ky-Fan norm collapses to
+    Assume $D',D\ge1$. Once the Schmidt-rank bound reaches the dimension $D'$ of
+    the first tensor factor the constraint is vacuous, and each Ky-Fan norm
+    collapses to
     $\|\rho_i\|_{(n)}=\tr\rho_i=1$. For $n\ge D'$,
     \begin{align}
         \inf E_n(\tau)
@@ -147,15 +176,22 @@ Hermitian map is tested, and the set whose expectations are collected below.
     \leanok
     \uses{thm:spectral_bound_schmidt_rank_top,
         thm:schmidt_rank_basic_bounds,
-        lem:schmidt_rank_le_expectations_inf_exists}
+        lem:schmidt_rank_le_expectations_inf_exists,
+        lem:reduced_eig_density_ky_fan_top}
     Every vector has Schmidt rank at most $D'$, so for $n\ge D'$ the set
     $E_n(\tau)$ is the set of expectations in all normalized vectors. By
     Theorem~\ref{thm:spectral_bound_schmidt_rank_top} that set is bounded below
     by $\nu_{\min}$ and contains $\nu_{\min}$, attained at an eigenvector for
     the least eigenvalue. This gives~(\ref{eq:channel_spectral_infimum_top}).
-    For~(\ref{eq:channel_spectral_infimum_top_lower}), the summand at a
-    minimizing index $j$ contributes $\nu_j-\nu_0=\nu_{\min}-\nu_0$ whenever
-    $\nu_{\min}\le0$, and every other summand is nonpositive, so the left-hand
-    side is at most $\nu_{\min}$; if instead every eigenvalue is positive the
-    sum is empty and the left-hand side is $\nu_0\le\nu_{\min}$.
+    For~(\ref{eq:channel_spectral_infimum_top_lower}), let $j$ be a minimizing
+    index. If $\nu_{\min}\le0$ then $j$ belongs to the summation range and
+    \begin{align}
+        \nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)
+        &= \nu_{\min}+\sum_{i:\nu_i\le0,\ i\ne j}(\nu_i-\nu_0)
+        \le \nu_{\min},
+        \notag
+    \end{align}
+    every remaining summand being nonpositive. If instead every eigenvalue is
+    positive the summation range is empty and the left-hand side is
+    $\nu_0\le\nu_{\min}$.
 \end{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
@@ -159,9 +159,10 @@ Hermitian map is tested, and the set whose expectations are collected below.
     which is the right-hand side of~(3.8) there, since
     $\nu+(\nu_--\nu)\|\rho_-\|_{(n)}=\nu_-=\nu_{\min}$ when $\nu_-$ is the only
     non-positive eigenvalue. The right-hand side of~(3.7) reads
-    $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, which is a strictly weaker bound as
-    soon as $\tau$ has two non-positive eigenvalues: for the spectrum
-    $(-2,-1,3)$ it is $-6$ while $\nu_{\min}=-2$. It is still a lower bound: for
+    $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, which can be strictly weaker once
+    $\tau$ has two non-positive eigenvalues: for the spectrum $(-2,-1,3)$ with
+    $\nu_0=3$ it is $-6$ while $\nu_{\min}=-2$. It coincides with $\nu_{\min}$
+    when $\nu_0=0$ and only one eigenvalue is strictly negative. It is still a lower bound: for
     those same $n$, and for $\nu_0\ge0$ a lower bound for the positive
     eigenvalues as in Theorem~\ref{thm:spectral_infimum_lower_bound},
     \begin{align}

--- a/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
@@ -161,8 +161,9 @@ Hermitian map is tested, and the set whose expectations are collected below.
     non-positive eigenvalue. The right-hand side of~(3.7) reads
     $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, which is a strictly weaker bound as
     soon as $\tau$ has two non-positive eigenvalues: for the spectrum
-    $(-2,-1,3)$ it is $-6$ while $\nu_{\min}=-2$. It is still a lower bound, so
-    for those same $n$
+    $(-2,-1,3)$ it is $-6$ while $\nu_{\min}=-2$. It is still a lower bound: for
+    those same $n$, and for $\nu_0\ge0$ a lower bound for the positive
+    eigenvalues as in Theorem~\ref{thm:spectral_infimum_lower_bound},
     \begin{align}
         \nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)}
          & \le\inf E_n(\tau),

--- a/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex
@@ -65,7 +65,9 @@ Hermitian map is tested, and the set whose expectations are collected below.
          & \le\inf E_n(\tau).
         \label{eq:channel_spectral_infimum_lower}
     \end{align}
-    This is \cite[Chapter~3, equation~(3.7)]{Wolf2012Quantum}.
+    This is \cite[Chapter~3, equation~(3.7)]{Wolf2012Quantum} for $n<D'$. The
+    indices $n\ge D'$ are Theorem~\ref{thm:spectral_infimum_top}, and the two
+    together give the equation at every $n\ge1$.
 \end{theorem}
 
 \begin{proof}
@@ -97,7 +99,9 @@ Hermitian map is tested, and the set whose expectations are collected below.
     unique non-positive eigenvalue $\nu_-$, which is the situation in which all
     other eigenvalues are strictly positive, gives
     $\inf E_n(\tau)\le\nu+(\nu_--\nu)\|\rho_-\|_{(n)}$, that is,
-    \cite[Chapter~3, equation~(3.8)]{Wolf2012Quantum}.
+    \cite[Chapter~3, equation~(3.8)]{Wolf2012Quantum} for $n<D'$. The indices
+    $n\ge D'$ are Theorem~\ref{thm:spectral_infimum_top}, and the two together
+    give the equation at every $n\ge1$.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -461,8 +461,9 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
     bound at that index. The positivity index of
     \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum} runs over $1\le n\le D$
     with $D$ the dimension of the second factor, so $n=D'$ is an index the
-    source speaks about when $D'\le D$, and lies beyond its range when
-    PLACEHOLDER $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, a weaker inequality than
+    source speaks about when $D'\le D$, and lies beyond its range when $D'>D$.
+    The lower bound of the same proposition reads, at that index,
+    $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, an inequality no stronger than
     (\ref{eq:schwarz_spectral_schmidt_top}), and
     Theorem~\ref{thm:spectral_infimum_top} establishes it. With
     Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -455,9 +455,14 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
          & =\nu_{\min}.
         \label{eq:schwarz_spectral_schmidt_top}
     \end{align}
-    There is no Schmidt-rank restriction. This is the upper bound of
-    \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} at $n=D'$, where
-    $\nu+(\nu_--\nu)\|\rho_-\|_{(D')}=\nu_-=\nu_{\min}$. The lower bound there
+    There is no Schmidt-rank restriction. At $n=D'$ the right-hand side of the
+    upper bound of \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} reads
+    $\nu+(\nu_--\nu)\|\rho_-\|_{(D')}=\nu_-=\nu_{\min}$, so the display is that
+    bound at that index. The positivity index of
+    \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum} runs over $1\le n\le D$
+    with $D$ the dimension of the second factor, so $n=D'$ is an index the
+    source speaks about when $D'\le D$, and lies beyond its range when
+    $D'>D$. The lower bound there
     reads $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, a weaker inequality than
     (\ref{eq:schwarz_spectral_schmidt_top}), and
     Theorem~\ref{thm:spectral_infimum_top} establishes it. With

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -457,13 +457,13 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
     \end{align}
     There is no Schmidt-rank restriction. This is the upper bound of
     \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} at $n=D'$, where
-    $\nu+(\nu_--\nu)\|\rho_-\|_{(D')}=\nu_-=\nu_{\min}$; the lower bound there
-    reads $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, which is at most
-    $\nu_{\min}$, so it follows as well. Together with
-    Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}
-    and~\ref{thm:spectral_upper_bound_schmidt_rank}, this covers every $n\ge1$,
-    hence the range of
-    \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum}.
+    $\nu+(\nu_--\nu)\|\rho_-\|_{(D')}=\nu_-=\nu_{\min}$. The lower bound there
+    reads $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, a weaker inequality than
+    (\ref{eq:schwarz_spectral_schmidt_top}); it is treated separately in
+    Theorem~\ref{thm:spectral_infimum_top}, which also assembles the two
+    endpoints with Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}
+    and~\ref{thm:spectral_upper_bound_schmidt_rank} into coverage of every
+    $n\ge1$.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -462,8 +462,7 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
     \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum} runs over $1\le n\le D$
     with $D$ the dimension of the second factor, so $n=D'$ is an index the
     source speaks about when $D'\le D$, and lies beyond its range when
-    $D'>D$. The lower bound there
-    reads $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, a weaker inequality than
+    PLACEHOLDER $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, a weaker inequality than
     (\ref{eq:schwarz_spectral_schmidt_top}), and
     Theorem~\ref{thm:spectral_infimum_top} establishes it. With
     Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -459,11 +459,11 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
     \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} at $n=D'$, where
     $\nu+(\nu_--\nu)\|\rho_-\|_{(D')}=\nu_-=\nu_{\min}$. The lower bound there
     reads $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, a weaker inequality than
-    (\ref{eq:schwarz_spectral_schmidt_top}); it is treated separately in
-    Theorem~\ref{thm:spectral_infimum_top}, which also assembles the two
-    endpoints with Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}
-    and~\ref{thm:spectral_upper_bound_schmidt_rank} into coverage of every
-    $n\ge1$.
+    (\ref{eq:schwarz_spectral_schmidt_top}), and
+    Theorem~\ref{thm:spectral_infimum_top} establishes it. With
+    Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}
+    and~\ref{thm:spectral_upper_bound_schmidt_rank}, both bounds then hold at
+    every $n\ge1$.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_two_positive_schmidt_and_choi.tex
@@ -445,23 +445,24 @@ Section~\ref{sec:app_positive_not_cp_ky_fan}.
     \leanok
     \uses{lem:eigenbasis_rayleigh, lem:eigenbasis_parseval}
     At the top index $n=D'$, the Schmidt-rank constraint is vacuous and each
-    Ky-Fan $D'$-norm reduces to $\|\rho_i\|_{(D')}=\tr\rho_i=1$. Thus the
-    lower and upper bounds of
-    \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} reduce to the Rayleigh
-    characterization of the least eigenvalue: the lower bound becomes
-    $\nu_{\min}\le\bra{\psi}\tau\ket{\psi}$ for every normalized $\psi$, and
-    the upper bound on the infimum becomes the existence of a normalized
-    eigenvector with
+    Ky-Fan $D'$-norm reduces to $\|\rho_i\|_{(D')}=\tr\rho_i=1$. The Rayleigh
+    characterization of the least eigenvalue then applies: every normalized
+    $\psi$ satisfies $\nu_{\min}\le\bra{\psi}\tau\ket{\psi}$, and a
+    least-eigenvalue eigenvector attains
     $\bra{\psi}\tau\ket{\psi}=\nu_{\min}$. Together they give
     \begin{align}
         \inf_{\|\psi\|=1}\bra{\psi}\tau\ket{\psi}
          & =\nu_{\min}.
         \label{eq:schwarz_spectral_schmidt_top}
     \end{align}
-    There is no Schmidt-rank restriction. Together with
+    There is no Schmidt-rank restriction. This is the upper bound of
+    \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} at $n=D'$, where
+    $\nu+(\nu_--\nu)\|\rho_-\|_{(D')}=\nu_-=\nu_{\min}$; the lower bound there
+    reads $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$, which is at most
+    $\nu_{\min}$, so it follows as well. Together with
     Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}
-    and~\ref{thm:spectral_upper_bound_schmidt_rank}, this covers the full
-    range $1\le n\le D'$ of
+    and~\ref{thm:spectral_upper_bound_schmidt_rank}, this covers every $n\ge1$,
+    hence the range of
     \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum}.
 \end{theorem}
 

--- a/docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex
@@ -108,9 +108,12 @@ Schmidt rank exactly $n$ for every $n\le\min(D',D)$, which makes the infimum ove
 $S_{=n}$ meaningful, and the perturbation
 $\psi_\varepsilon=(1-\varepsilon^2)^{1/2}\psi+\varepsilon\,u\otimes v$ with
 $u,v$ orthogonal to the Schmidt vectors of $\psi$, which raises the Schmidt rank
-by one at a cost $O(\varepsilon^2)$ in the expectation. Iterating the
-perturbation and letting $\varepsilon\to0$ gives the missing inequality
-$\inf_{S_{=n}}\le\inf_{S_{\le n}}$.
+by one. The expectation changes by
+$2\varepsilon\sqrt{1-\varepsilon^2}\,\Re\bra{\psi}\tau\ket{u\otimes v}
++O(\varepsilon^2)$, hence by $O(\varepsilon)$ in general: the cross term
+vanishes only under an orthogonality condition on $\tau$ that the argument does
+not need. Iterating the perturbation and letting $\varepsilon\to0$ gives the
+missing inequality $\inf_{S_{=n}}\le\inf_{S_{\le n}}$.
 
 \section{Verdict}
 

--- a/docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex
@@ -22,7 +22,10 @@ Wolf's criterion for $n$-positivity\footnote{%
 bounds an infimum. For a Hermitian $\tau\in\mathcal M_{D'}\otimes\mathcal M_{D}$
 with spectral decomposition $\tau=\sum_i\nu_i\ketbra{\phi_i}{\phi_i}$, reduced
 densities $\rho_i=\tr_2\ketbra{\phi_i}{\phi_i}$, smallest positive eigenvalue
-$\nu_0$ and largest eigenvalue $\nu$,
+$\nu_0$ and largest eigenvalue $\nu$, write $\|\cdot\|_{(n)}$ for the Ky-Fan
+$n$-norm, the sum of the $n$ largest eigenvalues of a positive semidefinite
+matrix. When exactly one eigenvalue $\nu_-$ of $\tau$ is non-positive, write
+$\rho_-$ for the reduced density of its eigenvector. Then
 \begin{align}
   \inf_\psi\bra{\psi}\tau\ket{\psi}
    & \ge \nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)},
@@ -109,14 +112,21 @@ by one at a cost $O(\varepsilon^2)$ in the expectation. Iterating the
 perturbation and letting $\varepsilon\to0$ gives the missing inequality
 $\inf_{S_{=n}}\le\inf_{S_{\le n}}$.
 
-\section{Conclusion}
+\section{Verdict}
 
+\textbf{Classification: resolved reading, with a scope restriction on (3.8).}
 The source's ``vectors of Schmidt rank $n$'' are the vectors of Schmidt rank at
 most $n$, as its own proof of Prop.~3.1 shows, and the formalized inequalities
-are (3.7) and (3.8) over that set. Under the exact-rank reading the same two
-inequalities hold, with (3.7) an immediate consequence of the bounded-rank
-statement and (3.8) requiring the limiting argument sketched above in place of a
-witness.
+are (3.7) and (3.8) over that set. No hypothesis foreign to the source enters.
+
+The scope restriction concerns (3.8) alone. Under the exact-rank reading the
+same two inequalities hold, with (3.7) an immediate consequence of the
+bounded-rank statement and (3.8) requiring the limiting argument sketched above
+in place of a witness. That limiting argument, equivalently the identity
+$\inf_{S_{\le n}}=\inf_{S_{=n}}$, is not formalized; it is not needed for either
+bound as stated. The Lean statement of (3.8) carries a
+\textbf{Scope restriction (Schmidt rank at most $n$)} marker pointing at this
+note.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex
@@ -1,0 +1,124 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{The Schmidt-rank set in the spectral $n$-positivity criterion
+  (Wolf Prop.~3.2)}
+\author{}
+\date{2026-08-13}
+
+\begin{document}
+\maketitle
+
+\section{The assertion}
+
+Wolf's criterion for $n$-positivity\footnote{%
+  \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, line 153,
+  equations (3.7) and (3.8).}
+bounds an infimum. For a Hermitian $\tau\in\mathcal M_{D'}\otimes\mathcal M_{D}$
+with spectral decomposition $\tau=\sum_i\nu_i\ketbra{\phi_i}{\phi_i}$, reduced
+densities $\rho_i=\tr_2\ketbra{\phi_i}{\phi_i}$, smallest positive eigenvalue
+$\nu_0$ and largest eigenvalue $\nu$,
+\begin{align}
+  \inf_\psi\bra{\psi}\tau\ket{\psi}
+   & \ge \nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)},
+  \tag{3.7}                                                       \\
+  \inf_\psi\bra{\psi}\tau\ket{\psi}
+   & \le \nu+(\nu_--\nu)\|\rho_-\|_{(n)},
+  \tag{3.8}
+\end{align}
+the second under the hypothesis that all eigenvalues but $\nu_-$ are strictly
+positive. In both displays ``the infimum is taken over all normalized vectors of
+Schmidt rank $n$''.
+
+\section{The point at issue}
+
+The phrase ``Schmidt rank $n$'' admits two readings: the vectors whose Schmidt
+rank equals $n$, and the vectors whose Schmidt rank is at most $n$. The two sets
+differ, and the infimum is taken over whichever one is meant.
+
+The source fixes the reading in the proof of the preceding
+proposition.\footnote{Same file, Prop.~3.1 and its proof.} There $n$-positivity
+of $T$ is expressed as
+$(T\otimes\mathrm{id}_n)(\ketbra{\phi}{\phi})\ge0$ for all
+$\phi\in\C^{D}\otimes\C^{n}$, and the embedding $\C^{n}\subseteq\C^{D}$ turns
+this into a condition on the vectors of $\C^{D}\otimes\C^{D}$ that the source
+calls ``of Schmidt rank $n$''. That image is the set of vectors of Schmidt rank
+\emph{at most} $n$: a vector $\phi\in\C^{D}\otimes\C^{n}$ of Schmidt rank $r<n$
+is not excluded from the quantifier. The same identification is made once more
+at the end of the proof, where $\ket{\psi}=(\one\otimes X)^\dagger\ket{\tilde
+\psi}$ with $\operatorname{rank}X=n$ is called a vector of Schmidt rank $n$, although its
+Schmidt rank is only bounded by $n$.
+
+The bounded-rank reading is also the one carrying the operational content:
+$n$-positivity of a Hermitian map is equivalent to nonnegativity of
+$\bra{\psi}\tau\ket{\psi}$ on the vectors of Schmidt rank at most $n$, and it is
+this set that the criterion is applied to.
+
+\section{The two readings compared}
+
+Write $S_{\le n}$ for the normalized vectors of Schmidt rank at most $n$ and
+$S_{=n}$ for those of Schmidt rank exactly $n$, so $S_{=n}\subseteq S_{\le n}$.
+
+Inequality (3.7) is proved pointwise: every $\psi\in S_{\le n}$ satisfies
+$\bra{\psi}\tau\ket{\psi}\ge\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)\|\rho_i\|_{(n)}$,
+using $|\braket{\phi_i}{\psi}|^2\le\|\rho_i\|_{(n)}$. The bound therefore holds
+at every vector of $S_{=n}$ as well, and the bounded-rank statement of (3.7) is
+the stronger of the two.
+
+Inequality (3.8) is the reverse comparison, and there the two readings part. The
+vector realizing $|\braket{\phi_-}{\psi}|^2=\|\rho_-\|_{(n)}$ is built from the
+$n$ largest eigenvalues of $\rho_-$, so its Schmidt rank is
+$\min(n,\operatorname{rank}\rho_-)$. When $\operatorname{rank}\rho_-<n$ the
+witness lies in $S_{\le n}$ but not in $S_{=n}$, and the value $\nu+(\nu_--\nu)\|\rho_-\|_{(n)}=\nu_-$ is not
+attained on $S_{=n}$: a vector of $S_{=n}$ attaining it would lie in the
+$\nu_-$ eigenspace, which is spanned by $\phi_-$ and contains no vector of
+Schmidt rank $n$. The infimum over $S_{=n}$ still equals $\nu_-$, because
+$\phi_-$ is a limit of vectors of Schmidt rank exactly $n$ whenever
+$n\le\min(D',D)$ and the quadratic form is continuous, but it is a limit and not
+a witness.
+
+Consequently $\inf_{S_{\le n}}=\inf_{S_{=n}}$ for $1\le n\le\min(D',D)$, the two
+readings give the same two inequalities, and the difference is only which of
+them is proved by exhibiting a vector.
+
+\section{The formalized statement}
+
+The formalization takes the set named by the source, the normalized vectors of
+Schmidt rank at most $n$, and states both inequalities for the infimum of the
+expectations over that set.\footnote{Formal declarations:
+  \leanid{Matrix.schmidtRankLEExpectations},
+  \leanid{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations} for (3.7),
+  \leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le} for (3.8), and
+  \leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top} for the top
+  index, all in
+  \doclink{TNLean/Channel/NPositivitySpectralCriterion}.} No hypothesis absent
+from the source is used.
+
+What is not formalized is the identity $\inf_{S_{\le n}}=\inf_{S_{=n}}$ of the
+previous section. Formalizing it needs two ingredients: a normalized vector of
+Schmidt rank exactly $n$ for every $n\le\min(D',D)$, which makes the infimum over
+$S_{=n}$ meaningful, and the perturbation
+$\psi_\varepsilon=(1-\varepsilon^2)^{1/2}\psi+\varepsilon\,u\otimes v$ with
+$u,v$ orthogonal to the Schmidt vectors of $\psi$, which raises the Schmidt rank
+by one at a cost $O(\varepsilon^2)$ in the expectation. Iterating the
+perturbation and letting $\varepsilon\to0$ gives the missing inequality
+$\inf_{S_{=n}}\le\inf_{S_{\le n}}$.
+
+\section{Conclusion}
+
+The source's ``vectors of Schmidt rank $n$'' are the vectors of Schmidt rank at
+most $n$, as its own proof of Prop.~3.1 shows, and the formalized inequalities
+are (3.7) and (3.8) over that set. Under the exact-rank reading the same two
+inequalities hold, with (3.7) an immediate consequence of the bounded-rank
+statement and (3.8) requiring the limiting argument sketched above in place of a
+witness.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
@@ -78,8 +78,8 @@ the infimum of $\langle\psi|\tau|\psi\rangle$ over all normalized vectors:
   for every normalized $\psi$, so $\inf_\psi\langle\psi|\tau|\psi\rangle\ge
   \nu_{\min}$. The right-hand side of~(3.7) reads
   $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$ there, which is at most $\nu_{\min}$
-  and in general strictly below it: for the spectrum $(-2,-1,3)$ it is $-6$
-  while $\nu_{\min}=-2$. So~(3.7) at the top index follows from the Rayleigh
+  and can be strictly below it: for the spectrum $(-2,-1,3)$ with $\nu_0=3$ it is
+  $-6$ while $\nu_{\min}=-2$. So~(3.7) at the top index follows from the Rayleigh
   estimate, but is not the same inequality.
   \item The upper bound~(3.8) on the infimum becomes the existence of a normalized
   vector with $\langle\psi|\tau|\psi\rangle=\nu_{\min}$, namely a least-eigenvalue

--- a/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
@@ -51,6 +51,16 @@ establish these bounds in the per-vector form: every normalized vector $\psi$ of
 Schmidt rank at most $n$ satisfies the lower bound~(3.7), and some such $\psi$
 realizes the upper bound~(3.8).
 
+The source's infimum form of the same two bounds is stated for the infimum of
+the expectations $\bra{\psi}\tau\ket{\psi}$ over the normalized vectors of
+Schmidt rank at most $n$.\footnote{Formal declarations:
+    \leanid{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations}~(3.7),
+    \leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le}~(3.8), and
+    \leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top} for the top
+    index, in \doclink{TNLean/Channel/NPositivitySpectralCriterion}.} The
+reading of the source's phrase ``vectors of Schmidt rank $n$'' is discussed in
+\path{docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex}.
+
 \section{Status}
 
 The top index $n=D'$ is resolved by a route that bypasses the $n<D'$ restriction
@@ -88,6 +98,7 @@ their top-index endpoints
 \leanid{Matrix.IsHermitian.spectral_lower_bound_top}~(3.7) and
 \leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top}~(3.8) for the
 completely-positive endpoint $n=D'$, by the route detailed in the Status above.
+The infimum form of the source's statement is available over the same range.
 No hypothesis foreign to the source is used.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
@@ -37,9 +37,10 @@ and, when a single eigenvalue $\nu_-$ is non-positive,
   \tag{3.8}
 \end{align}
 Each $\rho_i$ acts on the first factor $\mathbb{C}^{D'}$, so its Ky-Fan
-$n$-norm $\|\rho_i\|_{(n)}$ is meaningful for $1\le n\le D'$. The Schmidt rank
-$n$ ranges over $1\le n\le D'$, so the top value $n=D'$ is within the source's
-scope.
+$n$-norm $\|\rho_i\|_{(n)}$ is meaningful for $1\le n\le D'$. Proposition~3.1 of
+the same chapter restricts the positivity index to $1\le n\le D$, the dimension
+of the second factor (same file, lines 90--92), so the top value $n=D'$ of the
+Ky-Fan norm is within the source's scope whichever of $D$ and $D'$ is larger.
 
 \section{Formalized statement}
 
@@ -69,12 +70,18 @@ constraint is vacuous: every normalized vector qualifies and
 $\|\rho_i\|_{(D')}=\tr\rho_i=1$. Both bounds therefore constrain the same quantity,
 the infimum of $\langle\psi|\tau|\psi\rangle$ over all normalized vectors:
 \begin{itemize}
-  \item The lower bound~(3.7) becomes $\nu_{\min}\le\langle\psi|\tau|\psi\rangle$
+  \item The Rayleigh estimate gives $\nu_{\min}\le\langle\psi|\tau|\psi\rangle$
   for every normalized $\psi$, so $\inf_\psi\langle\psi|\tau|\psi\rangle\ge
-  \nu_{\min}$.
+  \nu_{\min}$. The right-hand side of~(3.7) reads
+  $\nu_0+\sum_{i:\nu_i\le0}(\nu_i-\nu_0)$ there, which is at most $\nu_{\min}$
+  and in general strictly below it: for the spectrum $(-2,-1,3)$ it is $-6$
+  while $\nu_{\min}=-2$. So~(3.7) at the top index follows from the Rayleigh
+  estimate, but is not the same inequality.
   \item The upper bound~(3.8) on the infimum becomes the existence of a normalized
   vector with $\langle\psi|\tau|\psi\rangle=\nu_{\min}$, namely a least-eigenvalue
-  eigenvector, so $\inf_\psi\langle\psi|\tau|\psi\rangle\le\nu_{\min}$.
+  eigenvector, so $\inf_\psi\langle\psi|\tau|\psi\rangle\le\nu_{\min}$; and under
+  the hypothesis of~(3.8) that $\nu_-$ is the only non-positive eigenvalue, the
+  right-hand side $\nu+(\nu_--\nu)\|\rho_-\|_{(D')}$ is exactly $\nu_-=\nu_{\min}$.
 \end{itemize}
 Together they give $\inf_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$. Both facts
 follow directly from the Rayleigh expansion $\langle\psi|\tau|\psi\rangle=\sum_i
@@ -84,22 +91,27 @@ evaluating at the least-eigenvalue eigenvector; the Ky-Fan machinery of the $n<D
 proof is not invoked.
 
 The top-index endpoint is recorded as
-\leanid{Matrix.IsHermitian.spectral_lower_bound_top} for~(3.7) and
-\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top} for~(3.8), which
-together state $\min_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$.
+\leanid{Matrix.IsHermitian.spectral_lower_bound_top} and
+\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top}, which together
+state $\min_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$. Inequality~(3.7)
+itself at the top index, in the infimum form, is
+\leanid{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top}, and~(3.8) is
+the corresponding half of
+\leanid{Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top}.
 
 \section{Classification}
 
-\emph{Resolved.} The full source range $1\le n\le D'$ of bounds~(3.7) and~(3.8)
-is now formalized: the per-vector bounds
+\emph{Resolved.} Bounds~(3.7) and~(3.8) are now formalized at every index
+$n\ge1$, hence over the source's range $1\le n\le D$: the per-vector bounds
 \leanid{Matrix.IsHermitian.spectral_lower_bound} and
 \leanid{Matrix.IsHermitian.exists_le_spectral_upper_bound} for $1\le n<D'$, and
-their top-index endpoints
-\leanid{Matrix.IsHermitian.spectral_lower_bound_top}~(3.7) and
-\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top}~(3.8) for the
-completely-positive endpoint $n=D'$, by the route detailed in the Status above.
-The infimum form of the source's statement is available over the same range.
-No hypothesis foreign to the source is used.
+their endpoints
+\leanid{Matrix.IsHermitian.spectral_lower_bound_top} and
+\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top} for $n\ge D'$, by
+the route detailed in the Status above. The infimum form of the source's
+statement is available over the same range,
+\leanid{Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations_top} carrying~(3.7)
+at the top indices. No hypothesis foreign to the source is used.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
@@ -39,8 +39,12 @@ and, when a single eigenvalue $\nu_-$ is non-positive,
 Each $\rho_i$ acts on the first factor $\mathbb{C}^{D'}$, so its Ky-Fan
 $n$-norm $\|\rho_i\|_{(n)}$ is meaningful for $1\le n\le D'$. Proposition~3.1 of
 the same chapter restricts the positivity index to $1\le n\le D$, the dimension
-of the second factor (same file, lines 90--92), so the top value $n=D'$ of the
-Ky-Fan norm is within the source's scope whichever of $D$ and $D'$ is larger.
+of the second factor (same file, lines 90--92), and that is the range the source
+asserts. The value $n=D'$ therefore lies inside the source's range exactly when
+$D'\le D$; when $D'>D$ it lies beyond, and the formal endpoint below is an
+extension of the source rather than an instance of it. What matters for coverage
+is that the formal statements together hold at every $n\ge1$, hence at every $n$
+the source speaks about.
 
 \section{Formalized statement}
 
@@ -102,7 +106,8 @@ the corresponding half of
 \section{Classification}
 
 \emph{Resolved.} Bounds~(3.7) and~(3.8) are now formalized at every index
-$n\ge1$, hence over the source's range $1\le n\le D$: the per-vector bounds
+$n\ge1$, hence over the source's range $1\le n\le D$ whatever the two dimensions
+are, and beyond it when $D'>D$: the per-vector bounds
 \leanid{Matrix.IsHermitian.spectral_lower_bound} and
 \leanid{Matrix.IsHermitian.exists_le_spectral_upper_bound} for $1\le n<D'$, and
 their endpoints


### PR DESCRIPTION
Wolf's criterion for $n$-positivity (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, line 153) states two inequalities for an infimum:

- (3.7) $\inf_\psi \langle\psi|\tau|\psi\rangle \ge \nu_0 + \sum_{i:\nu_i\le0}(\nu_i-\nu_0)\lVert\rho_i\rVert_{(n)}$;
- (3.8) when all eigenvalues but $\nu_-$ are strictly positive, $\inf_\psi \langle\psi|\tau|\psi\rangle \le \nu_\infty + (\nu_- - \nu_\infty)\lVert\rho_-\rVert_{(n)}$,

the infimum being over the normalized vectors of Schmidt rank $n$. The file already had the per-vector lower bound and the existence form of the upper bound; no declaration stated the infimum. This adds it.

## Landed signatures

In `TNLean/Channel/NPositivitySpectralCriterion.lean`:

- `Matrix.schmidtRankLEExpectations (τ : Matrix (m × n) (m × n) ℂ) (k : ℕ) : Set ℝ` — the expectations $\langle\psi|\tau|\psi\rangle$ at normalized $\psi$ with `HasSchmidtRankLE k ψ`;
- `Matrix.mem_schmidtRankLEExpectations`, `Matrix.schmidtRankLEExpectations_nonempty` (a normalized product vector, for `1 ≤ k`), `Matrix.IsHermitian.schmidtRankLEExpectations_bddBelow` (the least eigenvalue, from `spectral_lower_bound_top`);
- `Matrix.IsHermitian.le_sInf_schmidtRankLEExpectations` — eq. (3.7): `ν₀ + ∑ i with νᵢ ≤ 0, (νᵢ - ν₀) * ‖ρᵢ‖₍ₖ₎ ≤ sInf (schmidtRankLEExpectations τ k)` for `1 ≤ k < Fintype.card m`, via `le_csInf` over the per-vector bound;
- `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_le` — eq. (3.8): `sInf (schmidtRankLEExpectations τ k) ≤ νsup + (νⱼ - νsup) * ‖ρⱼ‖₍ₖ₎`, via `csInf_le` at the maximal-overlap witness;
- `Matrix.IsHermitian.sInf_schmidtRankLEExpectations_top` — at `Fintype.card m ≤ k` the infimum is the least eigenvalue, which closes the source range $1\le n\le D'$ in infimum form.

No new hypothesis beyond `Nonempty m`, `Nonempty n` (without which no normalized vector exists) and the Schmidt-rank range already carried by the per-vector bounds. `#print axioms` on all three main theorems: `propext`, `Classical.choice`, `Quot.sound`.

## Exact rank versus rank at most $n$

Wolf writes "vectors of Schmidt rank $n$"; the formalization quantifies over Schmidt rank at most $n$. The source fixes that reading itself, in the proof of Prop. 3.1 (same file):

- $n$-positivity is $(T\otimes\mathrm{id}_n)(|\phi\rangle\langle\phi|)\ge0$ for all $\phi\in\mathbb{C}^D\otimes\mathbb{C}^n$, and "embedding $\mathbb{C}^n$ in $\mathbb{C}^D$" turns this into a condition on the vectors Wolf calls "of Schmidt rank $n$". The image of that embedding contains the vectors of Schmidt rank $r<n$, so the named set is $\{\mathrm{SR}(\psi)\le n\}$.
- At the end of the same proof, $|\psi\rangle=(\mathbb{1}\otimes X)^\dagger|\tilde\psi\rangle$ with $\mathrm{rank}\,X=n$ is called a vector of Schmidt rank $n$, although its Schmidt rank is only bounded by $n$.

Under the exact-rank reading both inequalities still hold and the two infima agree, but the proofs differ: (3.7) is pointwise, so the landed statement (over the larger set) implies the exact-rank one; (3.8) is proved by a witness, and the maximal-overlap vector has Schmidt rank $\min(n,\mathrm{rank}\,\rho_-)$, so when $\mathrm{rank}\,\rho_-<n$ the value $\nu_-$ is a limit of expectations at Schmidt rank exactly $n$ and not attained there. That is why (3.8) carries a `**Scope restriction (Schmidt rank at most n):**` marker. The whole comparison, with the perturbation argument that would remove it, is written up in `docs/paper-gaps/wolf_prop_3_2_schmidt_rank_reading.tex`.

## Blueprint

New sub-file `blueprint/src/chapter/ch25_positive_not_cp_npositivity_infimum.tex` with the definition, the existence-of-infimum lemma, and the three theorems, each `\lean{...}` + `\leanok`; one `\input` line added to `ch25_positive_not_cp.tex`.

## Verification

| command | outcome |
|---|---|
| `lake env lean TNLean/Channel/NPositivitySpectralCriterion.lean` | clean, no warnings |
| `lake build TNLean.Channel` | 9103 jobs, success |
| `lake exe lint_style` | clean |
| `rg -n "sorry\|axiom"` on the changed file | no hits |
| `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` | current |
| `python3 scripts/blueprint_lean_sync.py --ci` | in sync, new file 6/6 |
| `#print axioms` on the three theorems | `propext`, `Classical.choice`, `Quot.sound` |
| `latexmk` on both paper-gap notes | compile |

`lake exe checkdecls` needs a full-project build not available in this worktree; the six declarations were checked directly with `#check` against the built module.

Closes LionSR/QICLean#166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176U7wiKWaxFAKBHv3Jgjz3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in the Channel spectral-criterion module; no runtime, auth, or data-path changes.
> 
> **Overview**
> Formalizes Wolf Prop. 3.2 as **infimum bounds** over normalized vectors of Schmidt rank at most *n*, not only per-vector spectral inequalities.
> 
> Introduces `Matrix.schmidtRankLEExpectations` and proves `le_sInf_schmidtRankLEExpectations` / `sInf_schmidtRankLEExpectations_le` for (3.7)–(3.8) when *n* &lt; *D′*, plus top-index theorems (`sInf_schmidtRankLEExpectations_top`, `le_sInf_schmidtRankLEExpectations_top`) with Ky-Fan norms collapsing to trace 1. Documentation and module comments now use **rank at most *n*** and separate Rayleigh top bounds from the spectral (3.7) RHS at *n* = *D′*.
> 
> Adds blueprint `ch25_positive_not_cp_npositivity_infimum.tex`, paper-gap notes on Schmidt-rank wording and top-index scope, and small clarifications in the existing spectral blueprint section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973ab91086fb1879e2d55d9247957e6e7b70e382. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->