### PR TITLE
refactor(tenkz): book the up=/down= tombstones inside the doc closeout

### DIFF
--- a/docs/tenkz/ANNOUNCEMENT-1.0-draft.md
+++ b/docs/tenkz/ANNOUNCEMENT-1.0-draft.md
@@ -53,20 +53,21 @@ product states:
 
 ```latex
 \[
-  \begin{tenkz}[physical=up]
-    \tn[up=$i$]{B}
+  \begin{tenkz}[cols=1, boundary=open]
+    \tn[ports={90:physical:$i$}]{B}
   \end{tenkz}
   \;=\;
-  \begin{tenkz}[physical=up]
-    \tnX{X} & \tn[up=$i$]{A} & \tnX{X^{-1}}
+  \begin{tenkz}[boundary=open]
+    \tn[skin=ring]{X} & \tn[ports={90:physical:$i$}]{A} & \tn[skin=ring]{X^{-1}}
   \end{tenkz}
 \]
 ```
 
-No coordinates, no lengths: `physical=up` declares each atom's outward leg,
-`&` chains atoms along the row, and the protruding stubs on both sides are
-the same boundary signature — two open virtual indices and one physical
-index — which the equation check verifies.
+No coordinates, no lengths: the typed port `90:physical` declares each
+tensor's outward leg along its row's own normal, `&` chains atoms along the
+row, and the protruding stubs on both sides are the same boundary signature
+— two open virtual indices and one physical index — which the equation
+check verifies.
 
 ### The compatibility promise
 

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -3216,15 +3216,17 @@ two refusal fixtures `n_atom_up_key.tex` and `n_atom_down_key.tex` pin the
 unknown-key answer as before.
 
 The rows are the ledger's first bare keys whose surviving words live in
-alphabets only the parser states: `up` and `down` remain choice words of
-the `physical=` policy and end words of the `open` wire-end grammar,
-neither spelled by a registry `enum(...)` the way `boundary=` carries the
-word `periodic`. The lint's buried-spelling patterns now read
-those owners from the parser source and step over the live spellings,
-exactly as they step over a live `enum(...)` word, so `physical=up` and
-`open up` stand in case source while a document's `up=$i$` is refused with
-the row's migration. Retiring or admitting a word remains one kernel edit
-and no edit in the lint.
+alphabets only the parsers state: `up` and `down` remain choice words of
+the `physical=` policy, end words of the `open` wire-end grammar, and
+compass faces of the declaration door (`up:physical`), none spelled by a
+registry `enum(...)` the way `boundary=` carries the word `periodic`. The
+lint's buried-spelling patterns now read those owners from the parser
+source and step over the live spellings, exactly as they step over a live
+`enum(...)` word — an owner is a frame, the text standing before or after
+the word — so `physical=up`, `open up`, and `up:physical` stand in case
+source while a document's `up=$i$` is refused with the row's migration.
+Retiring or admitting a word remains one parser edit and no edit in the
+lint.
 
 The announcement draft's gauge figure, the one live spelling of the dead
 keys outside `history/` and the refusal fixtures, is respelled onto typed

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -3199,3 +3199,36 @@ points at `form=bracket`.
 | flag | verdict |
 |---|---|
 | flag:consumers:key:kernel-mark:form | tombstoned in part: the four words that took a record and drew nothing leave the parser today, the alphabet standing at `bracket`, `enclosure`, `label` with the recording `prose` row the sugar ledger keeps; the key itself has consumers and stays kernel, so this executes the session-1 verdict rather than deferring it again; permanent |
+
+### 2026-08-13 — the dead face keys get their tombstone rows
+
+The typed-port landing (2026-08-03, #5191) removed the atom keys `up=` and
+`down=` from the parser and moved the census, but wrote no tombstone rows.
+A reader of an old document met a bare unknown-key error with no migration,
+and the ledger's own rule — a retired spelling is recorded once, in the
+registry, and everything that must refuse it reads the row — held for every
+retirement except this one. The registry now carries the two bare rows,
+saying what the contract's section 10 has said since the landing: the
+outward physical face is the row's own normal, spelled `ports=` with
+`90:physical` for `up=` and `270:physical` for `down=`, the label riding
+the port; the `physical=` policy grows the unlabelled port per cell. The
+two refusal fixtures `n_atom_up_key.tex` and `n_atom_down_key.tex` pin the
+unknown-key answer as before.
+
+The rows are the ledger's first bare keys whose surviving words live in
+alphabets only the parser states: `up` and `down` remain choice words of
+the `physical=` policy and end words of the `open` wire-end grammar,
+neither spelled by a registry `enum(...)` the way `boundary=` carries the
+word `periodic`. The lint's buried-spelling patterns now read
+those owners from the parser source and step over the live spellings,
+exactly as they step over a live `enum(...)` word, so `physical=up` and
+`open up` stand in case source while a document's `up=$i$` is refused with
+the row's migration. Retiring or admitting a word remains one kernel edit
+and no edit in the lint.
+
+The announcement draft's gauge figure, the one live spelling of the dead
+keys outside `history/` and the refusal fixtures, is respelled onto typed
+ports in the blueprint's own form; the respelled panels compile and both
+expose the boundary signature the surrounding prose asserts.
+
+Meters unchanged: the census counts key rows, and these are tombstones.

--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -395,6 +395,49 @@ def _kernel_tombstones() -> dict[tuple[str, str], str]:
     )
 
 
+# A bare tombstone row bans its word from case source, and the word may
+# outlive the key that died inside alphabets the registry types opaquely.
+# The kernel parser states those alphabets -- the choice tables, and the
+# wire-end grammar whose open words follow the word `open' -- so the live
+# owners are read from the parser source, exactly as the refused spellings
+# above are: adding or retiring a word is one kernel edit and no edit here.
+_KERNEL_CHOICE = re.compile(r"\\__tenkz_kernel_choice:nnnn\s*(?=\{)")
+_KERNEL_OPEN_WORDS = re.compile(r"\\A\s+open\s+\\s\+\s+\(([a-z|]+)\)\s+\\Z")
+
+
+def _live_word_owners_from_texts(texts: Iterable[str]) -> dict[str, set[str]]:
+    """Collect each parser-held word with the live spellings that carry it.
+
+    The value is a set of source prefixes: a choice word is carried as
+    `<key>=<word>`, an open end word as `open <word>`.  A pattern built for
+    a dead bare key steps over these, so a live spelling of the surviving
+    word is never reported as the dead key.
+    """
+    owners: dict[str, set[str]] = {}
+    for text in texts:
+        text = strip_comments(text)
+        for match in _KERNEL_CHOICE.finditer(text):
+            position = match.end()
+            fields: list[str] = []
+            for _ in range(3):
+                field, position = _group(text, position)
+                fields.append(field)
+            _family, key, words = (_sentence(field) for field in fields)
+            for word in words.split(","):
+                owners.setdefault(word.strip(), set()).add(f"{key}=")
+        for match in _KERNEL_OPEN_WORDS.finditer(text):
+            for word in match.group(1).split("|"):
+                owners.setdefault(word.strip(), set()).add("open ")
+    return owners
+
+
+def live_word_owners() -> dict[str, set[str]]:
+    return _live_word_owners_from_texts(
+        path.read_text(encoding="utf-8")
+        for path in (ROOT / "tex/tenkz").glob("*.code.tex")
+    )
+
+
 def tombstone_rows(entries: list[Entry]) -> list[tuple[str, str, str]]:
     """The ledger's rows as scope, spelling, and migration a reader is shown.
 

--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -449,6 +449,7 @@ def _live_word_owners_from_texts(
 
 
 def live_word_owners() -> dict[str, set[tuple[str, str]]]:
+    """Parser-held words and the live frames that carry them, read from the kernel source."""
     return _live_word_owners_from_texts(
         path.read_text(encoding="utf-8")
         for path in (ROOT / "tex/tenkz").glob("*.code.tex")

--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -397,23 +397,34 @@ def _kernel_tombstones() -> dict[tuple[str, str], str]:
 
 # A bare tombstone row bans its word from case source, and the word may
 # outlive the key that died inside alphabets the registry types opaquely.
-# The kernel parser states those alphabets -- the choice tables, and the
-# wire-end grammar whose open words follow the word `open' -- so the live
+# The parsers state those alphabets -- the kernel's choice tables, the
+# wire-end grammar whose open words follow the word `open', and the
+# declaration door's compass faces spelled `<word>:<type>' -- so the live
 # owners are read from the parser source, exactly as the refused spellings
-# above are: adding or retiring a word is one kernel edit and no edit here.
+# above are: adding or retiring a word is one parser edit and no edit here.
 _KERNEL_CHOICE = re.compile(r"\\__tenkz_kernel_choice:nnnn\s*(?=\{)")
 _KERNEL_OPEN_WORDS = re.compile(r"\\A\s+open\s+\\s\+\s+\(([a-z|]+)\)\s+\\Z")
+_DECLAREATOM_FACES = re.compile(
+    r"\\A\s+\\s\*\s+\(([a-z|]+)\)\s+:\s+\(([a-z|]+)\)\s+\\s\*\s+\\Z"
+)
 
 
-def _live_word_owners_from_texts(texts: Iterable[str]) -> dict[str, set[str]]:
+def _live_word_owners_from_texts(
+    texts: Iterable[str],
+) -> dict[str, set[tuple[str, str]]]:
     """Collect each parser-held word with the live spellings that carry it.
 
-    The value is a set of source prefixes: a choice word is carried as
-    `<key>=<word>`, an open end word as `open <word>`.  A pattern built for
-    a dead bare key steps over these, so a live spelling of the surviving
-    word is never reported as the dead key.
+    The value is a set of frames, the text standing before and after the
+    word in source: a choice word is carried as `<key>=<word>`, an open end
+    word as `open <word>`, a declaration face word as `<word>:<type>`.  A
+    pattern built for a dead bare key steps over these, so a live spelling
+    of the surviving word is never reported as the dead key.  The face
+    frames take every word-type pair the extraction admits, including the
+    pairs validation then refuses; a refused pair never stands in a
+    compiling document, so stepping over it passes nothing a compile would
+    not already answer.
     """
-    owners: dict[str, set[str]] = {}
+    owners: dict[str, set[tuple[str, str]]] = {}
     for text in texts:
         text = strip_comments(text)
         for match in _KERNEL_CHOICE.finditer(text):
@@ -424,14 +435,20 @@ def _live_word_owners_from_texts(texts: Iterable[str]) -> dict[str, set[str]]:
                 fields.append(field)
             _family, key, words = (_sentence(field) for field in fields)
             for word in words.split(","):
-                owners.setdefault(word.strip(), set()).add(f"{key}=")
+                owners.setdefault(word.strip(), set()).add((f"{key}=", ""))
         for match in _KERNEL_OPEN_WORDS.finditer(text):
             for word in match.group(1).split("|"):
-                owners.setdefault(word.strip(), set()).add("open ")
+                owners.setdefault(word.strip(), set()).add(("open ", ""))
+        for match in _DECLAREATOM_FACES.finditer(text):
+            for word in match.group(1).split("|"):
+                for port_type in match.group(2).split("|"):
+                    owners.setdefault(word.strip(), set()).add(
+                        ("", f":{port_type.strip()}")
+                    )
     return owners
 
 
-def live_word_owners() -> dict[str, set[str]]:
+def live_word_owners() -> dict[str, set[tuple[str, str]]]:
     return _live_word_owners_from_texts(
         path.read_text(encoding="utf-8")
         for path in (ROOT / "tex/tenkz").glob("*.code.tex")

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from tenkz_audit import ENVIRONMENT_LANGS
 from tenkz_language import (
     Entry,
+    live_word_owners,
     load_registry,
     parse_status,
     tombstone_rows,
@@ -105,7 +106,10 @@ def registry_alias_patterns() -> list[re.Pattern[str]]:
     return patterns
 
 
-def tombstone_patterns(entries: list[Entry]) -> list[tuple[re.Pattern[str], str]]:
+def tombstone_patterns(
+    entries: list[Entry],
+    word_owners: dict[str, set[str]] | None = None,
+) -> list[tuple[re.Pattern[str], str]]:
     """Source patterns and migrations for the spellings a ledger buries.
 
     A `key=value` row is a word struck from a live alphabet, so the pattern is
@@ -117,16 +121,19 @@ def tombstone_patterns(entries: list[Entry]) -> list[tuple[re.Pattern[str], str]
     boundary before it would match nothing, since neither the backslash nor
     the space before it is a word character.  An environment is named where a
     document names one, in the argument of `\\begin` or `\\end`.  A bare row
-    is a key that no longer exists; where its word survives as the value of a
-    live enum, the pattern steps over that live spelling, which is where a
-    reader of the dead one should be.
+    is a key that no longer exists; where its word survives -- as the value
+    of a live enum, or in an alphabet only the parser states, such as a
+    policy's choice words or the wire-end grammar's open words -- the pattern
+    steps over that live spelling, which is where a reader of the dead one
+    should be.  The parser-held owners arrive from `live_word_owners` unless
+    the caller supplies its own map.
 
     Every spelling arrives from `tombstone_rows` with the registry's `~`
     already read as the space a document writes, so a multi-word key is
     matched the way source spells it rather than the way the registry does.
     A row stating no spelling gets no pattern; the language check reports it.
     """
-    enum_owners: dict[str, set[str]] = {}
+    owners: dict[str, set[str]] = {}
     for entry in entries:
         if entry.kind != "key":
             continue
@@ -134,7 +141,13 @@ def tombstone_patterns(entries: list[Entry]) -> list[tuple[re.Pattern[str], str]
         if enum is None:
             continue
         for word in enum.group(1).split("|"):
-            enum_owners.setdefault(word, set()).add(entry.fields[1].replace("~", " "))
+            owners.setdefault(word, set()).add(
+                entry.fields[1].replace("~", " ") + "="
+            )
+    if word_owners is None:
+        word_owners = live_word_owners()
+    for word, prefixes in word_owners.items():
+        owners.setdefault(word, set()).update(prefixes)
     patterns: list[tuple[re.Pattern[str], str]] = []
     for scope, spelling, migration in sorted(tombstone_rows(entries)):
         key, _separator, value = spelling.partition("=")
@@ -160,16 +173,17 @@ def tombstone_patterns(entries: list[Entry]) -> list[tuple[re.Pattern[str], str]
             )
         else:
             # A lookbehind takes no variable width, so a live owner is stepped
-            # over as the source spells it with no space around the equals.
-            # A spaced `owner = word` is therefore reported, which over-reports
-            # a live spelling rather than passing a dead one, and is what the
-            # hardcoded expression this replaced did.  Matching only where a
-            # key may appear would trade that for a possible under-report,
-            # which is the failure this ledger exists to prevent.
+            # over as the source spells it: no space around a choice's equals,
+            # one space after the open word.  A spaced `owner = word` is
+            # therefore reported, which over-reports a live spelling rather
+            # than passing a dead one, and is what the hardcoded expression
+            # this replaced did.  Matching only where a key may appear would
+            # trade that for a possible under-report, which is the failure
+            # this ledger exists to prevent.
             expression = (
                 "".join(
-                    f"(?<!{re.escape(owner)}=)"
-                    for owner in sorted(enum_owners.get(key, set()))
+                    f"(?<!{re.escape(owner)})"
+                    for owner in sorted(owners.get(key, set()))
                 )
                 + r"\b"
                 + re.escape(key).replace(r"\ ", r"\s+")

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -108,7 +108,7 @@ def registry_alias_patterns() -> list[re.Pattern[str]]:
 
 def tombstone_patterns(
     entries: list[Entry],
-    word_owners: dict[str, set[str]] | None = None,
+    word_owners: dict[str, set[tuple[str, str]]] | None = None,
 ) -> list[tuple[re.Pattern[str], str]]:
     """Source patterns and migrations for the spellings a ledger buries.
 
@@ -123,17 +123,21 @@ def tombstone_patterns(
     document names one, in the argument of `\\begin` or `\\end`.  A bare row
     is a key that no longer exists; where its word survives -- as the value
     of a live enum, or in an alphabet only the parser states, such as a
-    policy's choice words or the wire-end grammar's open words -- the pattern
-    steps over that live spelling, which is where a reader of the dead one
-    should be.  The parser-held owners arrive from `live_word_owners` unless
-    the caller supplies its own map.
+    policy's choice words, the wire-end grammar's open words, or the
+    declaration door's face words -- the pattern steps over that live
+    spelling, which is where a reader of the dead one should be.  An owner
+    is a frame, the text standing before and after the word, so a word
+    carried by what follows it (a face word before its `:type`) is stepped
+    over exactly as one carried by what precedes it (a choice word after
+    its `key=`).  The parser-held owners arrive from `live_word_owners`
+    unless the caller supplies its own map.
 
     Every spelling arrives from `tombstone_rows` with the registry's `~`
     already read as the space a document writes, so a multi-word key is
     matched the way source spells it rather than the way the registry does.
     A row stating no spelling gets no pattern; the language check reports it.
     """
-    owners: dict[str, set[str]] = {}
+    owners: dict[str, set[tuple[str, str]]] = {}
     for entry in entries:
         if entry.kind != "key":
             continue
@@ -142,12 +146,12 @@ def tombstone_patterns(
             continue
         for word in enum.group(1).split("|"):
             owners.setdefault(word, set()).add(
-                entry.fields[1].replace("~", " ") + "="
+                (entry.fields[1].replace("~", " ") + "=", "")
             )
     if word_owners is None:
         word_owners = live_word_owners()
-    for word, prefixes in word_owners.items():
-        owners.setdefault(word, set()).update(prefixes)
+    for word, frames in word_owners.items():
+        owners.setdefault(word, set()).update(frames)
     patterns: list[tuple[re.Pattern[str], str]] = []
     for scope, spelling, migration in sorted(tombstone_rows(entries)):
         key, _separator, value = spelling.partition("=")
@@ -174,20 +178,27 @@ def tombstone_patterns(
         else:
             # A lookbehind takes no variable width, so a live owner is stepped
             # over as the source spells it: no space around a choice's equals,
-            # one space after the open word.  A spaced `owner = word` is
-            # therefore reported, which over-reports a live spelling rather
-            # than passing a dead one, and is what the hardcoded expression
-            # this replaced did.  Matching only where a key may appear would
-            # trade that for a possible under-report, which is the failure
-            # this ledger exists to prevent.
+            # one space after the open word, none around a face's colon.  A
+            # spaced `owner = word` is therefore reported, which over-reports
+            # a live spelling rather than passing a dead one, and is what the
+            # hardcoded expression this replaced did.  Matching only where a
+            # key may appear would trade that for a possible under-report,
+            # which is the failure this ledger exists to prevent.
+            frames = sorted(owners.get(key, set()))
             expression = (
                 "".join(
-                    f"(?<!{re.escape(owner)})"
-                    for owner in sorted(owners.get(key, set()))
+                    f"(?<!{re.escape(before)})"
+                    for before, _after in frames
+                    if before
                 )
                 + r"\b"
                 + re.escape(key).replace(r"\ ", r"\s+")
                 + r"\b"
+                + "".join(
+                    f"(?!{re.escape(after)})"
+                    for _before, after in frames
+                    if after
+                )
             )
         patterns.append((re.compile(expression), migration))
     return patterns

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -515,36 +515,41 @@ def test_rmp_buried_patterns_come_from_the_tombstone_ledger() -> None:
 
 def test_a_buried_key_steps_over_the_live_words_the_parser_holds() -> None:
     # The dead atom face keys are the case in point: each word outlives its
-    # key as a choice of the live physical= policy and as the transverse
-    # word of an open wire end.  The pattern steps over both live spellings
-    # and catches the dead key wherever a document still writes it.
+    # key as a choice of the live physical= policy, as the transverse word
+    # of an open wire end, and as a compass face of the declaration door.
+    # The pattern steps over all three live spellings and catches the dead
+    # key wherever a document still writes it.
     entries = [
         Entry("tombstone", ("kernel-atom", "up", "use ports=")),
         Entry("tombstone", ("kernel-atom", "down", "use ports=")),
     ]
+    frames = {("physical=", ""), ("open ", ""), ("", ":physical")}
     patterns = tombstone_patterns(
-        entries,
-        word_owners={"up": {"physical=", "open "}, "down": {"physical=", "open "}},
+        entries, word_owners={"up": frames, "down": frames}
     )
     for live in (
         r"\begin{tenkz}[rows={wire}, cols=1, physical=up]",
         r"\tn[conjugate, physical=down]{}",
         r"\tnwire{(1,1,1)}{open up}",
         r"\tnwire{(1,1,2)}{open down}",
+        r"\tndeclareatom{\tnseed}{skin=box, ports={west:virtual, up:physical}}",
+        r"\tndeclareatom{\tnseed}{skin=box, ports={down:physical}}",
         "physical=updown",
     ):
         assert not any(pattern.search(live) for pattern, _ in patterns), live
-    for dead in (r"\tn[up=$i$]{B}", r"\tn[down=$j$]{}"):
+    for dead in (r"\tn[up=$i$]{B}", r"\tn[down=$j$]{}", r"\tn[at=(1,1), up]{}"):
         assert any(pattern.search(dead) for pattern, _ in patterns), dead
 
 
 def test_the_live_word_owners_are_read_from_the_parser() -> None:
-    # The owners come from the kernel source, not from a list kept here:
-    # the atom physical= choice table and the wire-end open grammar both
-    # carry the words the dead face keys left behind.
+    # The owners come from the parser source, not from a list kept here:
+    # the atom physical= choice table, the wire-end open grammar, and the
+    # declaration door's face extraction all carry the words the dead face
+    # keys left behind.
     owners = tenkz_language.live_word_owners()
-    assert {"physical=", "open "} <= owners["up"]
-    assert {"physical=", "open "} <= owners["down"]
+    expected = {("physical=", ""), ("open ", ""), ("", ":physical")}
+    assert expected <= owners["up"]
+    assert expected <= owners["down"]
 
 
 def test_a_buried_value_is_bounded_on_both_sides_of_its_key() -> None:

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -513,6 +513,40 @@ def test_rmp_buried_patterns_come_from_the_tombstone_ledger() -> None:
     assert caught == ["use boundary=periodic"], caught
 
 
+def test_a_buried_key_steps_over_the_live_words_the_parser_holds() -> None:
+    # The dead atom face keys are the case in point: each word outlives its
+    # key as a choice of the live physical= policy and as the transverse
+    # word of an open wire end.  The pattern steps over both live spellings
+    # and catches the dead key wherever a document still writes it.
+    entries = [
+        Entry("tombstone", ("kernel-atom", "up", "use ports=")),
+        Entry("tombstone", ("kernel-atom", "down", "use ports=")),
+    ]
+    patterns = tombstone_patterns(
+        entries,
+        word_owners={"up": {"physical=", "open "}, "down": {"physical=", "open "}},
+    )
+    for live in (
+        r"\begin{tenkz}[rows={wire}, cols=1, physical=up]",
+        r"\tn[conjugate, physical=down]{}",
+        r"\tnwire{(1,1,1)}{open up}",
+        r"\tnwire{(1,1,2)}{open down}",
+        "physical=updown",
+    ):
+        assert not any(pattern.search(live) for pattern, _ in patterns), live
+    for dead in (r"\tn[up=$i$]{B}", r"\tn[down=$j$]{}"):
+        assert any(pattern.search(dead) for pattern, _ in patterns), dead
+
+
+def test_the_live_word_owners_are_read_from_the_parser() -> None:
+    # The owners come from the kernel source, not from a list kept here:
+    # the atom physical= choice table and the wire-end open grammar both
+    # carry the words the dead face keys left behind.
+    owners = tenkz_language.live_word_owners()
+    assert {"physical=", "open "} <= owners["up"]
+    assert {"physical=", "open "} <= owners["down"]
+
+
 def test_a_buried_value_is_bounded_on_both_sides_of_its_key() -> None:
     # Without a left boundary `form=band` reads `transform=band` too, and an
     # RMP case that never used the retired key is rejected.
@@ -553,12 +587,15 @@ def test_a_buried_environment_is_matched_where_a_document_names_one() -> None:
 
 def test_the_lint_spells_no_buried_word_of_its_own() -> None:
     # The debt this replaces: a retired spelling written into the script and
-    # hand-discarded from the registry read beside it.
+    # hand-discarded from the registry read beside it.  A spelling is a word,
+    # not a run of letters: a short row like the dead atom face key sits
+    # inside ordinary English (`groups`, `suppresses`) without being spelled.
     source = (ROOT / "scripts/tenkz_lint.py").read_text(encoding="utf-8")
     buried = tenkz_language.tombstone_rows(tenkz_shrink.load_registry())
     assert buried
     for _scope, spelling, _migration in buried:
-        assert spelling not in source, spelling
+        pattern = rf"(?<![\w\\]){re.escape(spelling)}(?![\w])"
+        assert not re.search(pattern, source), spelling
 
 
 def test_buried_patterns_match_the_spelling_a_document_writes() -> None:

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -271,6 +271,16 @@
 \__tenkz_language_registry_tombstone:nnn {kernel-picture}{periodic}
   {use boundary=periodic}
 %
+% The two atom face-label keys retired with the typed-port landing
+% (2026-08-03): each hung a physical label on a page direction.  The face
+% belongs to ports= now and the label rides the port; the physical= policy
+% grows the unlabelled port per cell.
+\__tenkz_language_registry_tombstone:nnn {kernel-atom}{up}
+  {use ports={90:physical:<label>}; the outward physical face is the row's
+    own normal}
+\__tenkz_language_registry_tombstone:nnn {kernel-atom}{down}
+  {use ports={270:physical:<label>}, exactly as up above}
+%
 % The four mark forms below took a record and drew nothing.  What the sources
 % brace, the benchmark already brackets (rmp-ii-spectrum-transfer); what they
 % cut, it encloses; what they shade, a tinted enclosure carries.  Each row is


### PR DESCRIPTION
## Context

PR-3 of the item-1 series under LionSR/tenkz#13 (the four sentenced keys): the `up=`/`down=` closeout. The retirement itself already executed — the typed-port landing (#5191, SHRINK 2026-08-03) deleted the parser rows, and `tests/tenkz/kernel/negative/n_atom_up_key.tex` / `n_atom_down_key.tex` pin the generic unknown-key refusal — but the registry tombstone ledger was never given its rows, and two documents still spelled the dead keys as if live.

## Change

- **Registry** (`tex/tenkz/tenkz-language-registry.tex`): two bare tombstone rows, `kernel-atom:up` and `kernel-atom:down`, migrating onto `ports=` per LANGUAGE-1.0 §10 (`90:physical:<label>` / `270:physical:<label>`; the outward physical face is the row's own normal).
- **Lint** (`scripts/tenkz_lint.py`, `scripts/tenkz_language.py`): these are the ledger's first bare keys whose surviving words live in alphabets only the parser states — `up`/`down` remain choice words of the `physical=` policy and end words of the `open` wire-end grammar, neither spelled by a registry `enum(...)`. Left alone, the bare-key patterns reported 64 live spellings (`physical=up`, `open down`, …) across the 130 RMP cases. Per the lint's own doctrine the pattern steps over a live spelling of a surviving word, so `tombstone_patterns` now also takes owners read from the kernel parser source (`live_word_owners`): the choice tables and the open-word grammar. Retiring or admitting a word stays one kernel edit and no edit in the lint. New tests pin the step-over and the parser-sourced owners; the `no-buried-word-of-its-own` test now matches a spelling as a word rather than a run of letters (`up` sits inside `groups` without being spelled).
- **Docs**: `ANNOUNCEMENT-1.0-draft.md`'s gauge figure — the one live spelling of the dead keys outside `history/` and the refusal fixtures — is respelled onto typed ports in the blueprint's own form (`ch12_symmetry_algebra.tex`), prose adjusted; compile-verified standalone, both panels exposing the identical boundary signature `open:e, open:w, phys:n` the prose asserts. SHRINK.md gains a dated session entry booking the correction.
- **Census**: untouched by design — `tests/tenkz/census-baseline.json` counts key rows per ledger and tombstones are a different record kind; `tenkz_shrink.py meters` verified byte-identical to the baseline.

The plan named `docs/tenkz/manual2.exm:5–6` as a second stale-spelling site; no such file exists in the tree or in git history — a repo-wide sweep found no other live `up=`/`down=` spellings outside `docs/tenkz/history/` and the two negative fixtures.

## Checks

- `python3 scripts/tenkz_language.py check` — PASS (115 records)
- `python3 -m pytest scripts/test_tenkz_shrink.py scripts/test_tenkz_language.py -q` — 49 passed
- `python3 scripts/tenkz_lint.py` on the CI target set (289 files) and on `tests/tenkz/rmp/*/cases/*.tex` (130 files) — 0 findings
- `python3 scripts/tenkz_shrink.py gate` — PASS (census stable at 86, all 60 flags carry verdicts); `meters` identical to `tests/tenkz/census-baseline.json`
- `python3 scripts/check_tenkz_dispositions.py` — PASS (its `DEAD_KEYS` already lists `up`/`down`)
- `n_atom_up_key.tex` compile — still refused with `TKZ-LANG-UNKNOWN-KEY`; respelled announcement figure compiles clean

## Flag: amendment seven's landing status (not fixed here)

AMENDMENT-remaining-demand.md:657–659 binds "amendments five and seven should land together". Five's mechanism is verifiably in the kernel (`physical=` sugar, `ports=` face transport). Seven ("extent from counts, labels from ink") has landed **in mechanism but not in its retirements**: the extent-from-counts rule is contract doctrine (LANGUAGE-1.0 §7.4, lines 825–832, with the equation-scope name measure kept above the class-reference floor) and the label-station rule lives as the registry's `label pos` auto ordering (first free face s, n, e, w); but the two displacement keys seven sentences — `nudge=` on atoms and on marks — still hold live parser rows (`tenkz-kernel.code.tex:1284`, `:1353`) and kernel registry rows (172/232-area), booked in the registry header as awaiting "the change that implements its amendment". So the five-and-seven binding is honored at mechanism level; seven's `nudge=` burn-down remains open under item 1's sibling work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry, lint, and documentation only; parser behavior and census baselines are unchanged by design.
> 
> **Overview**
> Completes the **typed-port landing closeout** for retired atom keys **`up=`** and **`down=`** by recording them in the language registry with migrations onto **`ports=`** (`90:physical` / `270:physical`), so readers get a documented path instead of a bare unknown-key error.
> 
> **Lint** bare-key tombstone matching now **steps over live uses of the same word** not only in registry `enum(...)` values but in **alphabets only the kernel parser defines**—`physical=` choices, `open` wire-end words, and declaration **`face:type`** ports—via new **`live_word_owners()`** scraped from kernel `.code.tex`. That avoids false positives on spellings like `physical=up` while still flagging dead `\tn[up=…]`.
> 
> **Docs**: SHRINK session entry for the tombstones; the 1.0 announcement gauge figure is respelled from `physical=up` / `up=$i$` to **`boundary=open`**, **`ports={90:physical:…}`**, and ring skins. **Tests** cover step-over behavior, parser-sourced owners, and word-boundary checks in the lint self-test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74ad227015036116c6e62a58e94814c22d39f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->