### PR TITLE
feat(Channel/Peripheral): weighted Cesàro formula for the peripheral projection

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -37,7 +37,6 @@ import TNLean.Analysis.LiebScalarIntegral
 import TNLean.Analysis.MarginalSupport
 import TNLean.Analysis.MatrixFamilySupport
 import TNLean.Analysis.MatrixOrderTopology
-import TNLean.Analysis.MatrixReducedProjection
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.MatrixTraceInequalities
 import TNLean.Analysis.MeanErgodic
@@ -72,4 +71,4 @@ import TNLean.Analysis.TwoProjectionCompressionSpectrum
 import TNLean.Analysis.TwoProjectionDefectBlockSum
 import TNLean.Analysis.TwoProjectionReducedProjection
 import TNLean.Analysis.UpperTriangularBound
-import TNLean.Analysis.WeightedPositiveKernel
+import TNLean.Analysis.WeightedCesaroMean

--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -37,6 +37,7 @@ import TNLean.Analysis.LiebScalarIntegral
 import TNLean.Analysis.MarginalSupport
 import TNLean.Analysis.MatrixFamilySupport
 import TNLean.Analysis.MatrixOrderTopology
+import TNLean.Analysis.MatrixReducedProjection
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.MatrixTraceInequalities
 import TNLean.Analysis.MeanErgodic
@@ -72,3 +73,4 @@ import TNLean.Analysis.TwoProjectionDefectBlockSum
 import TNLean.Analysis.TwoProjectionReducedProjection
 import TNLean.Analysis.UpperTriangularBound
 import TNLean.Analysis.WeightedCesaroMean
+import TNLean.Analysis.WeightedPositiveKernel

--- a/TNLean/Analysis/WeightedCesaroMean.lean
+++ b/TNLean/Analysis/WeightedCesaroMean.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.UnitModulusPowerSum
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Analysis.Asymptotics.SpecificAsymptotics
+
+/-!
+# Cesàro means over `1 ≤ n ≤ N` and orthogonality of unit-modulus phases
+
+Let $s$ be a finite set of complex numbers of modulus one and let
+$\lambda \in s$. The averages
+$$
+  \frac{1}{N}\sum_{n=1}^{N}\sum_{\mu \in s} (\bar\mu\lambda)^n
+$$
+converge to $1$. Each ratio $\bar\mu\lambda$ again has modulus one, and it
+equals $1$ exactly when $\mu = \lambda$; the diagonal term contributes $1$ at
+every $N$, while for $\mu \neq \lambda$ the geometric sum
+$\sum_{n=1}^{N}\zeta^n = (\zeta - \zeta^{N+1})/(1-\zeta)$ stays bounded and its
+average vanishes.
+
+Alongside this scalar identity the file records the vector Cesàro statement in
+the same range of summation: averages over $1 \le n \le N$ of a sequence
+tending to zero tend to zero.
+
+## Main statements
+
+* `WeightedCesaro.tendsto_cesaro_zero`: Cesàro means over $1 \le n \le N$ of a
+  null sequence in a complex normed space vanish.
+* `WeightedCesaro.tendsto_cesaro_geom_zero`: the Cesàro mean of the powers of a
+  unit-modulus number other than $1$ vanishes.
+* `WeightedCesaro.tendsto_cesaro_phase_sum`: the orthogonality relation
+  $\frac{1}{N}\sum_{n=1}^{N}\sum_{\mu \in s}(\bar\mu\lambda)^n \to 1$.
+
+## Tags
+
+Cesàro mean, geometric series, unit modulus, phase
+-/
+
+open Filter
+open scoped Topology
+
+namespace WeightedCesaro
+
+/-- Reindexing a sum over `1 ≤ n ≤ N` as a sum over `0 ≤ i < N`. -/
+theorem sum_Icc_one_eq_sum_range {M : Type*} [AddCommMonoid M] (u : ℕ → M) (N : ℕ) :
+    ∑ n ∈ Finset.Icc 1 N, u n = ∑ i ∈ Finset.range N, u (i + 1) := by
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      rw [Finset.sum_Icc_succ_top (Nat.one_le_iff_ne_zero.mpr (Nat.succ_ne_zero N)),
+        Finset.sum_range_succ, ih]
+
+/-- Cesàro means over `1 ≤ n ≤ N` of a sequence tending to zero tend to zero. -/
+theorem tendsto_cesaro_zero {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    {u : ℕ → E} (h : Tendsto u atTop (𝓝 0)) :
+    Tendsto (fun N : ℕ ↦ (N : ℂ)⁻¹ • ∑ n ∈ Finset.Icc 1 N, u n) atTop (𝓝 0) := by
+  have hshift : Tendsto (fun i : ℕ ↦ u (i + 1)) atTop (𝓝 0) := by
+    simpa [Function.comp_def] using h.comp (tendsto_add_atTop_nat 1)
+  refine hshift.cesaro_smul.congr fun N ↦ ?_
+  rw [sum_Icc_one_eq_sum_range, RCLike.real_smul_eq_coe_smul (K := ℂ)]
+  norm_num
+
+/-- The Cesàro mean over `1 ≤ n ≤ N` of the powers of a unit-modulus number
+other than `1` vanishes. -/
+theorem tendsto_cesaro_geom_zero {ζ : ℂ} (hζ : ‖ζ‖ = 1) (hne : ζ ≠ 1) :
+    Tendsto (fun N : ℕ ↦ (N : ℂ)⁻¹ * ∑ n ∈ Finset.Icc 1 N, ζ ^ n) atTop (𝓝 0) := by
+  have h := (UnitModulusPowerSum.cesaro_geom_sum_tendsto_zero hζ hne).const_mul ζ
+  rw [mul_zero] at h
+  refine h.congr fun N ↦ ?_
+  rw [sum_Icc_one_eq_sum_range]
+  simp only [pow_succ']
+  rw [← Finset.mul_sum]
+  ring
+
+/-- The Cesàro mean over `1 ≤ n ≤ N` of the powers of `1` equals `1`. -/
+theorem tendsto_cesaro_geom_one :
+    Tendsto (fun N : ℕ ↦ (N : ℂ)⁻¹ * ∑ n ∈ Finset.Icc 1 N, (1 : ℂ) ^ n) atTop (𝓝 1) := by
+  refine tendsto_const_nhds.congr' ((eventually_ge_atTop 1).mono fun N hN ↦ ?_)
+  have hNne : (N : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.one_le_iff_ne_zero.mp hN)
+  simp only [one_pow, Finset.sum_const, Nat.card_Icc, Nat.add_sub_cancel, nsmul_eq_mul,
+    mul_one]
+  exact (inv_mul_cancel₀ hNne).symm
+
+/-- **Orthogonality of unit-modulus phases.**  For a finite set `s` of complex
+numbers of modulus one and `lam ∈ s`, the averages
+`(1/N) ∑_{n=1}^{N} ∑_{μ ∈ s} (conj μ * lam) ^ n` converge to `1`: the term
+`μ = lam` contributes `1` at every `N`, and every other term is a bounded
+geometric sum divided by `N`. -/
+theorem tendsto_cesaro_phase_sum {s : Finset ℂ} (hs : ∀ μ ∈ s, ‖μ‖ = 1) {lam : ℂ}
+    (hlam : lam ∈ s) :
+    Tendsto (fun N : ℕ ↦ (N : ℂ)⁻¹ *
+        ∑ n ∈ Finset.Icc 1 N, ∑ μ ∈ s, ((starRingEnd ℂ) μ * lam) ^ n) atTop (𝓝 1) := by
+  classical
+  have hlam1 : ‖lam‖ = 1 := hs lam hlam
+  have hterm : ∀ μ ∈ s, Tendsto (fun N : ℕ ↦ (N : ℂ)⁻¹ *
+      ∑ n ∈ Finset.Icc 1 N, ((starRingEnd ℂ) μ * lam) ^ n) atTop
+      (𝓝 (if μ = lam then 1 else 0)) := by
+    intro μ hμ
+    by_cases hμlam : μ = lam
+    · subst hμlam
+      rw [if_pos rfl]
+      have hone : (starRingEnd ℂ) μ * μ = 1 := by
+        rw [Complex.conj_mul', hs μ hμ]
+        norm_num
+      simp only [hone]
+      exact tendsto_cesaro_geom_one
+    · rw [if_neg hμlam]
+      refine tendsto_cesaro_geom_zero ?_ ?_
+      · rw [norm_mul, RCLike.norm_conj, hs μ hμ, hlam1, one_mul]
+      · intro hζ
+        apply hμlam
+        have hmul : μ * ((starRingEnd ℂ) μ * lam) = μ * 1 := by rw [hζ]
+        rw [← mul_assoc, Complex.mul_conj', hs μ hμ] at hmul
+        simpa using hmul.symm
+  have hsum := tendsto_finsetSum s hterm
+  rw [Finset.sum_ite_eq' s lam (fun _ : ℂ ↦ (1 : ℂ)), if_pos hlam] at hsum
+  refine hsum.congr fun N ↦ ?_
+  rw [← Finset.mul_sum, Finset.sum_comm]
+
+end WeightedCesaro

--- a/TNLean/Channel/Peripheral.lean
+++ b/TNLean/Channel/Peripheral.lean
@@ -34,3 +34,4 @@ import TNLean.Channel.Peripheral.SpectralRadius
 import TNLean.Channel.Peripheral.Spectrum
 import TNLean.Channel.Peripheral.TransferMatrix
 import TNLean.Channel.Peripheral.UnitalKraus
+import TNLean.Channel.Peripheral.WeightedCesaro

--- a/TNLean/Channel/Peripheral/WeightedCesaro.lean
+++ b/TNLean/Channel/Peripheral/WeightedCesaro.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Peripheral.CesaroRecurrence
+import TNLean.Analysis.WeightedCesaroMean
+
+/-!
+# The phase-weighted Cesàro formula for `T_φ` — Wolf Equation (6.15)
+
+For a positive trace-preserving linear map `T` on `M_d(ℂ)` the peripheral
+spectral projection `T_φ` of Wolf Equation (6.12) is the limit of the averages
+$$
+  \frac{1}{N}\sum_{n=1}^{N}\ \sum_{k\,:\,|\lambda_k| = 1} (\bar\lambda_k T)^n ,
+$$
+the inner sum running over the peripheral spectrum of `T`.
+
+The argument splits the space along the complementary pair of spectral
+subspaces of Wolf Equation (6.5).  On the peripheral part, Wolf
+Proposition 6.2 makes the peripheral generalized eigenspaces ordinary
+eigenspaces, so on the `λ_j`-eigenspace the summand `(\bar\lambda_k T)^n` acts
+as the scalar `(\bar\lambda_k\lambda_j)^n`; the ratio has modulus one and
+equals `1` exactly when `λ_k = λ_j`, so the averages converge to `1` by the
+finite geometric sum.  On the non-peripheral part every eigenvalue has modulus
+strictly below one, the powers `T^n` already tend to zero, and multiplying by
+unit phases leaves the norms unchanged, so the averages tend to zero as well.
+
+## Main definitions
+
+* `Module.End.weightedCesaroMean`: the average
+  `(1/N) ∑_{n=1}^{N} ∑_{μ ∈ s} (conj μ • f)^n`.
+
+## Main statements
+
+* `Module.End.tendsto_weightedCesaroMean_apply_self_of_mem_iSup_eigenspace`:
+  the averages fix the span of the eigenspaces indexed by the averaging set.
+* `Module.End.tendsto_weightedCesaroMean_apply_zero_of_tendsto_pow_zero`: the
+  averages vanish wherever the powers already vanish.
+* `IsPositiveMap.tendsto_weightedCesaroMean_peripheralProjection`: **Wolf
+  Equation (6.15)** — the averages over the peripheral spectrum converge
+  pointwise to `T_φ`.
+* `IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_peripheralProjection`:
+  the same convergence in the operator norm.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Equation (6.15);
+  local source `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
+  lines 258--264.
+-/
+
+open scoped Matrix ComplexOrder Matrix.Norms.Frobenius Topology
+open Matrix Filter
+
+namespace Module.End
+
+section Definition
+
+variable {V : Type*} [AddCommGroup V] [Module ℂ V]
+
+/-- The **phase-weighted Cesàro mean** of an endomorphism `f` over a finite set
+`s` of phases:
+`(1/N) ∑_{n=1}^{N} ∑_{μ ∈ s} (conj μ • f)^n`.
+
+Taking `s` to be the peripheral spectrum of `f` gives the averages of Wolf
+Equation (6.15); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 258--264. -/
+noncomputable def weightedCesaroMean (f : Module.End ℂ V) (s : Finset ℂ) (N : ℕ) :
+    Module.End ℂ V :=
+  (N : ℂ)⁻¹ • ∑ n ∈ Finset.Icc 1 N, ∑ μ ∈ s, ((starRingEnd ℂ) μ • f) ^ n
+
+@[simp]
+theorem weightedCesaroMean_apply (f : Module.End ℂ V) (s : Finset ℂ) (N : ℕ) (x : V) :
+    f.weightedCesaroMean s N x =
+      (N : ℂ)⁻¹ • ∑ n ∈ Finset.Icc 1 N, ∑ μ ∈ s, (((starRingEnd ℂ) μ • f) ^ n) x := by
+  simp [weightedCesaroMean]
+
+/-- Peeling one factor off a power of an endomorphism. -/
+private theorem pow_succ_apply (f : Module.End ℂ V) (n : ℕ) (x : V) :
+    (f ^ (n + 1)) x = f ((f ^ n) x) := by
+  rw [pow_succ']; rfl
+
+/-- Powers of a phase-shifted endomorphism carry the phase out as a scalar. -/
+private theorem smul_pow_apply (c : ℂ) (f : Module.End ℂ V) (n : ℕ) (x : V) :
+    ((c • f) ^ n) x = c ^ n • ((f ^ n) x) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ_apply, ih, LinearMap.smul_apply, map_smul, smul_smul, pow_succ_apply,
+        pow_succ', mul_comm]
+
+/-- On the `μ`-eigenspace the `n`-th power acts as the scalar `μ ^ n`. -/
+private theorem pow_apply_of_mem_eigenspace {f : Module.End ℂ V} {μ : ℂ} {x : V}
+    (hx : x ∈ f.eigenspace μ) (n : ℕ) : (f ^ n) x = μ ^ n • x := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ_apply, ih, map_smul, Module.End.mem_eigenspace_iff.mp hx, smul_smul,
+        pow_succ', mul_comm]
+
+end Definition
+
+section Convergence
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℂ V]
+
+/-- **The phase-weighted averages fix the peripheral eigenvectors.**  If every
+element of `s` has modulus one, then on the span of the eigenspaces indexed by
+`s` the averages `(1/N) ∑_{n=1}^{N} ∑_{μ ∈ s} (conj μ • f)^n` converge to the
+identity: on the `λ`-eigenspace the summand indexed by `μ` is the scalar
+`(conj μ * λ)^n`, and only `μ = λ` contributes in the limit. -/
+theorem tendsto_weightedCesaroMean_apply_self_of_mem_iSup_eigenspace
+    {f : Module.End ℂ V} {s : Finset ℂ} (hs : ∀ μ ∈ s, ‖μ‖ = 1) {x : V}
+    (hx : x ∈ ⨆ μ ∈ s, f.eigenspace μ) :
+    Tendsto (fun N : ℕ ↦ f.weightedCesaroMean s N x) atTop (𝓝 x) := by
+  classical
+  obtain ⟨v, hv⟩ := (Submodule.mem_iSup_finset_iff_exists_sum _ x).mp hx
+  rw [← hv]
+  have hterm : ∀ lam ∈ s,
+      Tendsto (fun N : ℕ ↦ f.weightedCesaroMean s N (v lam : V)) atTop (𝓝 (v lam : V)) := by
+    intro lam hlam
+    have hkey : ∀ N : ℕ, f.weightedCesaroMean s N (v lam : V) =
+        ((N : ℂ)⁻¹ * ∑ n ∈ Finset.Icc 1 N,
+          ∑ μ ∈ s, ((starRingEnd ℂ) μ * lam) ^ n) • (v lam : V) := by
+      intro N
+      rw [weightedCesaroMean_apply, mul_smul]
+      congr 1
+      rw [Finset.sum_smul]
+      refine Finset.sum_congr rfl fun n _ ↦ ?_
+      rw [Finset.sum_smul]
+      refine Finset.sum_congr rfl fun μ _ ↦ ?_
+      rw [smul_pow_apply, pow_apply_of_mem_eigenspace (v lam).2, smul_smul, ← mul_pow]
+    have hlim := (WeightedCesaro.tendsto_cesaro_phase_sum hs hlam).smul
+      (tendsto_const_nhds (x := (v lam : V)) (f := atTop (α := ℕ)))
+    rw [one_smul] at hlim
+    exact hlim.congr fun N ↦ (hkey N).symm
+  simpa only [map_sum] using tendsto_finsetSum _ hterm
+
+/-- **The phase-weighted averages vanish where the powers vanish.**  Unit
+phases do not change norms, so if `f ^ n x → 0` then every summand of the
+average tends to zero, and so does the average. -/
+theorem tendsto_weightedCesaroMean_apply_zero_of_tendsto_pow_zero
+    {f : Module.End ℂ V} {s : Finset ℂ} (hs : ∀ μ ∈ s, ‖μ‖ = 1) {x : V}
+    (hx : Tendsto (fun n : ℕ ↦ (f ^ n) x) atTop (𝓝 0)) :
+    Tendsto (fun N : ℕ ↦ f.weightedCesaroMean s N x) atTop (𝓝 0) := by
+  classical
+  have hterm : ∀ μ ∈ s,
+      Tendsto (fun n : ℕ ↦ (((starRingEnd ℂ) μ • f) ^ n) x) atTop (𝓝 0) := by
+    intro μ hμ
+    have hnorm : ∀ n : ℕ, ‖(((starRingEnd ℂ) μ • f) ^ n) x‖ = ‖(f ^ n) x‖ := by
+      intro n
+      rw [smul_pow_apply, norm_smul, norm_pow, RCLike.norm_conj, hs μ hμ, one_pow, one_mul]
+    refine tendsto_zero_iff_norm_tendsto_zero.mpr ?_
+    simpa only [hnorm] using tendsto_zero_iff_norm_tendsto_zero.mp hx
+  have hsum : Tendsto (fun n : ℕ ↦ ∑ μ ∈ s, (((starRingEnd ℂ) μ • f) ^ n) x) atTop (𝓝 0) := by
+    simpa only [Finset.sum_const_zero] using tendsto_finsetSum _ hterm
+  simpa only [weightedCesaroMean_apply] using WeightedCesaro.tendsto_cesaro_zero hsum
+
+end Convergence
+
+end Module.End
+
+namespace IsPositiveMap
+
+variable {D : ℕ} [NeZero D] {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
+
+/-- **Wolf Equation (6.15).**  For a positive trace-preserving map `T` on
+`M_d(ℂ)` the peripheral spectral projection `T_φ` is the limit of the
+phase-weighted averages over the peripheral spectrum,
+`T_φ = lim_N (1/N) ∑_{n=1}^{N} ∑_{k : |λ_k| = 1} (conj λ_k • T)^n`.
+
+Source: Wolf, Equation (6.15); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 258--264. -/
+theorem tendsto_weightedCesaroMean_peripheralProjection
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) {s : Finset ℂ}
+    (hs : (s : Set ℂ) = peripheralEigenvalues T) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Tendsto (fun N : ℕ ↦ T.weightedCesaroMean s N X) atTop
+      (𝓝 (T.peripheralProjection X)) := by
+  have hnorm : ∀ μ ∈ s, ‖μ‖ = 1 := fun μ hμ ↦
+    (hs ▸ (Finset.mem_coe.mpr hμ) : μ ∈ peripheralEigenvalues T).2
+  -- The peripheral part: `T_φ X` lies in the span of the peripheral eigenspaces
+  -- (Wolf Proposition 6.2), where the averages act as the identity.
+  have hPmem : T.peripheralProjection X ∈ ⨆ μ ∈ s, T.eigenspace μ := by
+    have h1 := T.peripheralProjection_apply_mem X
+    rw [hPos.peripheralSubspace_eq_iSup_eigenspace hTP, ← hs] at h1
+    simpa only [Finset.mem_coe] using h1
+  have hper := T.tendsto_weightedCesaroMean_apply_self_of_mem_iSup_eigenspace hnorm hPmem
+  -- The non-peripheral part: the powers already vanish there.
+  have hb : ∀ μ : ℂ, T.HasEigenvalue μ → ‖μ‖ ≤ 1 := fun μ hμ ↦
+    (hPos.hasBoundedOrbits_of_tracePreserving hTP).norm_le_one_of_hasEigenvalue hμ
+  have hnonp := T.tendsto_weightedCesaroMean_apply_zero_of_tendsto_pow_zero hnorm
+    (T.tendsto_pow_apply_zero_of_mem_nonPeripheralSubspace hb
+      (T.sub_peripheralProjection_mem X))
+  -- Combine along `X = T_φ X + (X - T_φ X)`.
+  have hsum := hper.add hnonp
+  rw [add_zero] at hsum
+  exact hsum.congr fun N ↦ by rw [← map_add, add_sub_cancel]
+
+/-- **Wolf Equation (6.15), operator-norm form.**  The phase-weighted averages
+over the peripheral spectrum converge to `T_φ` in the operator norm. -/
+theorem tendsto_endEquiv_weightedCesaroMean_peripheralProjection
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) {s : Finset ℂ}
+    (hs : (s : Set ℂ) = peripheralEigenvalues T) :
+    Tendsto (fun N : ℕ ↦ endEquiv (T.weightedCesaroMean s N)) atTop
+      (𝓝 (endEquiv T.peripheralProjection)) :=
+  ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional fun X ↦
+    hPos.tendsto_weightedCesaroMean_peripheralProjection hTP hs X
+
+/-- **Wolf Equation (6.15)** with the peripheral spectrum enumerated by its own
+finiteness proof. -/
+theorem tendsto_weightedCesaroMean_toFinset_peripheralProjection
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    Tendsto (fun N : ℕ ↦
+        T.weightedCesaroMean (peripheralEigenvalues_finite T).toFinset N X) atTop
+      (𝓝 (T.peripheralProjection X)) :=
+  hPos.tendsto_weightedCesaroMean_peripheralProjection hTP
+    (Set.Finite.coe_toFinset _) X
+
+end IsPositiveMap

--- a/TNLean/Channel/Peripheral/WeightedCesaro.lean
+++ b/TNLean/Channel/Peripheral/WeightedCesaro.lean
@@ -42,6 +42,12 @@ unit phases leaves the norms unchanged, so the averages tend to zero as well.
   pointwise to `T_φ`.
 * `IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_peripheralProjection`:
   the same convergence in the operator norm.
+* `IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection`:
+  **Wolf Equation (6.15)** with the peripheral spectrum enumerated by its own
+  finiteness proof, pointwise.
+* `IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_toFinset_peripheralProjection`:
+  the same convergence in the operator norm, with the peripheral spectrum
+  enumerated by its own finiteness proof.
 
 ## References
 
@@ -208,7 +214,17 @@ theorem tendsto_endEquiv_weightedCesaroMean_peripheralProjection
     hPos.tendsto_weightedCesaroMean_peripheralProjection hTP hs X
 
 /-- **Wolf Equation (6.15)** with the peripheral spectrum enumerated by its own
-finiteness proof. -/
+finiteness proof.
+
+**Local fix (deduplicated phases):** the inner sum of Wolf Equation (6.15) is
+printed over `k : |λ_k| = 1` with `k` indexing the Jordan blocks of
+Equations (6.4)--(6.5) of the source, where several blocks may share an
+eigenvalue.  The summand `(conj λ_k • T)^n` depends only on the eigenvalue
+`λ_k`, so a literal block-indexed reading counts each peripheral phase with
+its geometric multiplicity, and the identity channel on `M_D(ℂ)` with `D > 1`
+would converge to `D ^ 2 • id` instead of `T_φ`.  This theorem reads `k` as
+indexing the distinct peripheral eigenvalues, each phase counted once.  See
+`docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex`. -/
 theorem tendsto_weightedCesaroMean_toFinset_peripheralProjection
     (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
     (X : Matrix (Fin D) (Fin D) ℂ) :
@@ -217,5 +233,24 @@ theorem tendsto_weightedCesaroMean_toFinset_peripheralProjection
       (𝓝 (T.peripheralProjection X)) :=
   hPos.tendsto_weightedCesaroMean_peripheralProjection hTP
     (Set.Finite.coe_toFinset _) X
+
+/-- **Wolf Equation (6.15), operator-norm form.**  The phase-weighted averages
+over the distinct peripheral eigenvalues, each phase counted once, converge to
+`T_φ` in the operator norm.
+
+Source: Wolf, Equation (6.15); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 258--264.
+
+**Local fix (deduplicated phases):** as in
+`IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection`, the
+averages count each distinct peripheral eigenvalue once; see
+`docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex`. -/
+theorem tendsto_endEquiv_weightedCesaroMean_toFinset_peripheralProjection
+    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) :
+    Tendsto (fun N : ℕ ↦
+        endEquiv (T.weightedCesaroMean (peripheralEigenvalues_finite T).toFinset N)) atTop
+      (𝓝 (endEquiv T.peripheralProjection)) :=
+  hPos.tendsto_endEquiv_weightedCesaroMean_peripheralProjection hTP
+    (Set.Finite.coe_toFinset _)
 
 end IsPositiveMap

--- a/TNLean/Channel/Peripheral/WeightedCesaro.lean
+++ b/TNLean/Channel/Peripheral/WeightedCesaro.lean
@@ -56,8 +56,7 @@ unit phases leaves the norms unchanged, so the averages tend to zero as well.
   lines 258--264.
 -/
 
-open scoped Matrix ComplexOrder Matrix.Norms.Frobenius Topology
-open Matrix Filter
+open Filter Topology
 
 namespace Module.End
 
@@ -82,28 +81,15 @@ theorem weightedCesaroMean_apply (f : Module.End ℂ V) (s : Finset ℂ) (N : �
       (N : ℂ)⁻¹ • ∑ n ∈ Finset.Icc 1 N, ∑ μ ∈ s, (((starRingEnd ℂ) μ • f) ^ n) x := by
   simp [weightedCesaroMean]
 
-/-- Peeling one factor off a power of an endomorphism. -/
-private theorem pow_succ_apply (f : Module.End ℂ V) (n : ℕ) (x : V) :
-    (f ^ (n + 1)) x = f ((f ^ n) x) := by
-  rw [pow_succ']; rfl
-
-/-- Powers of a phase-shifted endomorphism carry the phase out as a scalar. -/
-private theorem smul_pow_apply (c : ℂ) (f : Module.End ℂ V) (n : ℕ) (x : V) :
-    ((c • f) ^ n) x = c ^ n • ((f ^ n) x) := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-      rw [pow_succ_apply, ih, LinearMap.smul_apply, map_smul, smul_smul, pow_succ_apply,
-        pow_succ', mul_comm]
-
 /-- On the `μ`-eigenspace the `n`-th power acts as the scalar `μ ^ n`. -/
 private theorem pow_apply_of_mem_eigenspace {f : Module.End ℂ V} {μ : ℂ} {x : V}
     (hx : x ∈ f.eigenspace μ) (n : ℕ) : (f ^ n) x = μ ^ n • x := by
   induction n with
   | zero => simp
   | succ n ih =>
-      rw [pow_succ_apply, ih, map_smul, Module.End.mem_eigenspace_iff.mp hx, smul_smul,
-        pow_succ', mul_comm]
+      rw [pow_succ']
+      change f ((f ^ n) x) = _
+      rw [ih, map_smul, Module.End.mem_eigenspace_iff.mp hx, smul_smul, pow_succ', mul_comm]
 
 end Definition
 
@@ -136,7 +122,8 @@ theorem tendsto_weightedCesaroMean_apply_self_of_mem_iSup_eigenspace
       refine Finset.sum_congr rfl fun n _ ↦ ?_
       rw [Finset.sum_smul]
       refine Finset.sum_congr rfl fun μ _ ↦ ?_
-      rw [smul_pow_apply, pow_apply_of_mem_eigenspace (v lam).2, smul_smul, ← mul_pow]
+      rw [smul_pow, LinearMap.smul_apply, pow_apply_of_mem_eigenspace (v lam).2,
+        smul_smul, ← mul_pow]
     have hlim := (WeightedCesaro.tendsto_cesaro_phase_sum hs hlam).smul
       (tendsto_const_nhds (x := (v lam : V)) (f := atTop (α := ℕ)))
     rw [one_smul] at hlim
@@ -156,7 +143,8 @@ theorem tendsto_weightedCesaroMean_apply_zero_of_tendsto_pow_zero
     intro μ hμ
     have hnorm : ∀ n : ℕ, ‖(((starRingEnd ℂ) μ • f) ^ n) x‖ = ‖(f ^ n) x‖ := by
       intro n
-      rw [smul_pow_apply, norm_smul, norm_pow, RCLike.norm_conj, hs μ hμ, one_pow, one_mul]
+      rw [smul_pow, LinearMap.smul_apply, norm_smul, norm_pow, RCLike.norm_conj, hs μ hμ,
+        one_pow, one_mul]
     refine tendsto_zero_iff_norm_tendsto_zero.mpr ?_
     simpa only [hnorm] using tendsto_zero_iff_norm_tendsto_zero.mp hx
   have hsum : Tendsto (fun n : ℕ ↦ ∑ μ ∈ s, (((starRingEnd ℂ) μ • f) ^ n) x) atTop (𝓝 0) := by
@@ -168,6 +156,8 @@ end Convergence
 end Module.End
 
 namespace IsPositiveMap
+
+open scoped Matrix.Norms.Frobenius
 
 variable {D : ℕ} [NeZero D] {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
 

--- a/TNLean/Channel/Peripheral/WeightedCesaro.lean
+++ b/TNLean/Channel/Peripheral/WeightedCesaro.lean
@@ -216,7 +216,7 @@ theorem tendsto_endEquiv_weightedCesaroMean_peripheralProjection
 /-- **Wolf Equation (6.15)** with the peripheral spectrum enumerated by its own
 finiteness proof.
 
-**Local fix (deduplicated phases):** the inner sum of Wolf Equation (6.15) is
+**Local fix (distinct phases):** the inner sum of Wolf Equation (6.15) is
 printed over `k : |λ_k| = 1` with `k` indexing the Jordan blocks of
 Equations (6.4)--(6.5) of the source, where several blocks may share an
 eigenvalue.  The summand `(conj λ_k • T)^n` depends only on the eigenvalue
@@ -241,7 +241,7 @@ over the distinct peripheral eigenvalues, each phase counted once, converge to
 Source: Wolf, Equation (6.15); local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 258--264.
 
-**Local fix (deduplicated phases):** as in
+**Local fix (distinct phases):** as in
 `IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection`, the
 averages count each distinct peripheral eigenvalue once; see
 `docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex`. -/

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -15,6 +15,8 @@ and~\cite{Evans1978Spectral}.
 
 \input{chapter/ch06_qpf_cesaro_fixed_points}
 
+\input{chapter/ch06_qpf_weighted_cesaro}
+
 \section{Positive definiteness}
 
 \begin{theorem}[Positive-definite growth for irreducible CP maps]

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -89,6 +89,26 @@
     The peripheral and non-peripheral spectral subspaces are complementary.
 \end{theorem}
 
+\begin{lemma}[Powers vanish on the non-peripheral subspace]
+    \label{lem:non_peripheral_pow_vanishing}
+    \lean{Module.End.tendsto_pow_apply_zero_of_mem_nonPeripheralSubspace}
+    \leanok
+    \uses{def:peripheral_spectral_splitting}
+    Let $T$ be an endomorphism of a finite-dimensional complex vector space
+    whose every eigenvalue has modulus at most one. Then $T^{n}(Y)\to0$ for
+    every $Y$ in the non-peripheral subspace:
+    \begin{align}
+        T^{n}(Y)&\longrightarrow0
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Every non-peripheral eigenvalue then has modulus strictly below one, so
+    its maximal generalized eigenspace is annihilated by the powers, and the
+    non-peripheral subspace is the sum of those eigenspaces.
+\end{proof}
+
 \begin{definition}[Peripheral spectral projections]
     \label{def:peripheral_spectral_projections}
     \lean{Module.End.peripheralProjection,

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -98,15 +98,24 @@
     whose every eigenvalue has modulus at most one. Then $T^{n}(Y)\to0$ for
     every $Y$ in the non-peripheral subspace:
     \begin{align}
-        T^{n}(Y)&\longrightarrow0
-        \notag
+        T^{n}(Y)&\longrightarrow0.
+        \label{eq:non_peripheral_pow_vanishing}
     \end{align}
 \end{lemma}
 
 \begin{proof}\leanok
-    Every non-peripheral eigenvalue then has modulus strictly below one, so
-    its maximal generalized eigenspace is annihilated by the powers, and the
-    non-peripheral subspace is the sum of those eigenspaces.
+    Every non-peripheral eigenvalue $\mu$ has modulus strictly below one.
+    On the corresponding maximal generalized eigenspace write
+    $T=\mu\Id+N$ with $N^{\ell}=0$; the binomial expansion gives
+    \begin{align}
+        (\mu\Id+N)^{n}
+        &=\sum_{m=0}^{\ell-1}\binom{n}{m}\mu^{n-m}N^{m}
+        \longrightarrow0,
+        \label{eq:non_peripheral_jordan_decay}
+    \end{align}
+    since each summand carries the factor $\mu^{n}\to0$ against a polynomial
+    in $n$. The non-peripheral subspace is the sum of these eigenspaces, and
+    convergence to zero is preserved by finite sums.
 \end{proof}
 
 \begin{definition}[Peripheral spectral projections]

--- a/blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex
+++ b/blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex
@@ -126,6 +126,7 @@
 
 \begin{proof}\leanok
     \uses{def:peripheral_spectral_splitting,
+        lem:non_peripheral_pow_vanishing,
         thm:peripheral_spectral_complementarity,
         thm:peripheral_jordan_trivial,
         thm:positive_trace_preserving_mean_ergodic_projection,

--- a/blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex
+++ b/blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex
@@ -1,0 +1,138 @@
+\section{The phase-weighted Ces\`aro formula for the peripheral projection}
+
+\begin{lemma}[Orthogonality of unit-modulus phases]
+    \label{lem:unit_modulus_phase_cesaro}
+    \lean{WeightedCesaro.tendsto_cesaro_phase_sum,
+        WeightedCesaro.tendsto_cesaro_geom_zero,
+        WeightedCesaro.tendsto_cesaro_geom_one,
+        WeightedCesaro.sum_Icc_one_eq_sum_range}
+    \leanok
+    Let $s$ be a finite set of complex numbers of modulus one and let
+    $\lambda\in s$. Then
+    \begin{align}
+        \lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^{N}\sum_{\mu\in s}
+        (\bar\mu\lambda)^{n}
+         & =1.
+        \label{eq:unit_modulus_phase_cesaro}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Every ratio $\bar\mu\lambda$ again has modulus one, and
+    $\bar\mu\lambda=1$ forces $\lambda=\mu$, since $\mu\bar\mu=1$. The term
+    $\mu=\lambda$ therefore equals $1$ for every $n$ and contributes $1$ to
+    the mean. For $\mu\neq\lambda$ set $\zeta=\bar\mu\lambda\neq1$; the
+    geometric sum
+    \begin{align}
+        \sum_{n=1}^{N}\zeta^{n}
+         & =\frac{\zeta-\zeta^{N+1}}{1-\zeta}
+        \notag
+    \end{align}
+    is bounded by $2/\lvert1-\zeta\rvert$ uniformly in $N$, so dividing by
+    $N$ sends it to zero.
+\end{proof}
+
+\begin{lemma}[Ces\`aro means of a vanishing sequence]
+    \label{lem:cesaro_mean_of_null_sequence}
+    \lean{WeightedCesaro.tendsto_cesaro_zero}
+    \leanok
+    Let $u_{1},u_{2},\dots$ be a sequence in a complex normed space with
+    $u_{n}\to0$. Then
+    \begin{align}
+        \frac{1}{N}\sum_{n=1}^{N}u_{n}
+         & \longrightarrow0.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    The Ces\`aro mean of a convergent sequence converges to the same limit.
+\end{proof}
+
+\begin{definition}[Phase-weighted Ces\`aro mean]
+    \label{def:weighted_cesaro_mean}
+    \lean{Module.End.weightedCesaroMean,
+        Module.End.weightedCesaroMean_apply}
+    \leanok
+    Let $T$ be an endomorphism of a complex vector space and let $s$ be a
+    finite set of complex numbers. The \emph{phase-weighted Ces\`aro mean} of
+    $T$ over $s$ is
+    \begin{align}
+        C_{N}(T,s)
+         & :=\frac{1}{N}\sum_{n=1}^{N}\sum_{\mu\in s}(\bar\mu T)^{n}.
+        \label{eq:weighted_cesaro_mean}
+    \end{align}
+    Taking for $s$ the eigenvalues of $T$ of modulus one gives the averages of
+    \cite[Equation~(6.15)]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{lemma}[Action of the phase-weighted means on the spectral splitting]
+    \label{lem:weighted_cesaro_mean_on_splitting}
+    \lean{Module.End.tendsto_weightedCesaroMean_apply_self_of_mem_iSup_eigenspace,
+        Module.End.tendsto_weightedCesaroMean_apply_zero_of_tendsto_pow_zero}
+    \leanok
+    \uses{def:weighted_cesaro_mean}
+    Let $T$ be an endomorphism of a complex normed space and let $s$ be a
+    finite set of complex numbers of modulus one.
+    \begin{enumerate}
+        \item[(i)] On the span of the eigenspaces of $T$ belonging to the
+              elements of $s$, the means $C_{N}(T,s)$ converge to the
+              identity.
+        \item[(ii)] At a vector $X$ with $T^{n}(X)\to0$, the means
+              $C_{N}(T,s)(X)$ converge to zero.
+    \end{enumerate}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:unit_modulus_phase_cesaro, lem:cesaro_mean_of_null_sequence}
+    For (i) it suffices to treat a $\lambda$-eigenvector $X$ with
+    $\lambda\in s$, because the span is the sum of the eigenspaces. There
+    $(\bar\mu T)^{n}(X)=(\bar\mu\lambda)^{n}X$, so
+    $C_{N}(T,s)(X)$ is the scalar
+    $\frac{1}{N}\sum_{n=1}^{N}\sum_{\mu\in s}(\bar\mu\lambda)^{n}$ times $X$,
+    which tends to $X$ by (\ref{eq:unit_modulus_phase_cesaro}).
+    For (ii), multiplication by a unit-modulus scalar does not change norms,
+    so $\lVert(\bar\mu T)^{n}(X)\rVert=\lVert T^{n}(X)\rVert\to0$ for every
+    $\mu\in s$; the inner sum is finite, hence also tends to zero, and its
+    Ces\`aro means tend to zero.
+\end{proof}
+
+\begin{theorem}[Phase-weighted Ces\`aro formula for $T_\varphi$]
+    \label{thm:peripheral_projection_weighted_cesaro}
+    \lean{IsPositiveMap.tendsto_weightedCesaroMean_peripheralProjection,
+        IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_peripheralProjection,
+        IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection}
+    \leanok
+    \uses{def:peripheral_spectral_projections, def:weighted_cesaro_mean}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving, with $D>0$, and
+    let $\lambda_{1},\lambda_{2},\dots$ denote its eigenvalues. Then
+    \begin{align}
+        T_\varphi
+         & =\lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^{N}
+        \sum_{k:\lvert\lambda_{k}\rvert=1}(\bar\lambda_{k}T)^{n},
+        \label{eq:peripheral_projection_weighted_cesaro}
+    \end{align}
+    both pointwise and in operator norm. This is
+    \cite[Equation~(6.15)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:peripheral_spectral_splitting,
+        thm:peripheral_spectral_complementarity,
+        thm:peripheral_jordan_trivial,
+        thm:positive_trace_preserving_mean_ergodic_projection,
+        lem:weighted_cesaro_mean_on_splitting,
+        lem:tendsto_clm_of_tendsto_apply}
+    Split $X=T_\varphi(X)+(X-T_\varphi(X))$ along the complementary spectral
+    subspaces. Bounded forward orbits force every eigenvalue to have modulus
+    at most one, so every eigenvalue outside the peripheral spectrum has
+    modulus strictly below one and $T^{n}$ vanishes on the non-peripheral
+    subspace; part (ii) of
+    Lemma~\ref{lem:weighted_cesaro_mean_on_splitting} sends the second
+    summand to zero. Triviality of the peripheral Jordan blocks identifies
+    the peripheral subspace with the span of the peripheral eigenspaces, on
+    which part (i) of the same lemma acts as the identity, so the first
+    summand converges to $T_\varphi(X)$. Pointwise convergence of
+    endomorphisms of a finite-dimensional space is convergence in operator
+    norm.
+\end{proof}

--- a/blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex
+++ b/blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex
@@ -104,25 +104,24 @@
     \leanok
     \uses{def:peripheral_spectral_projections, def:weighted_cesaro_mean}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving, with $D>0$, and
-    let $\lambda_{1},\lambda_{2},\dots$ denote its eigenvalues. Then
+    let $\lambda_{1},\dots,\lambda_{m}$ denote the distinct eigenvalues of
+    $T$ of modulus one. Then
     \begin{align}
         T_\varphi
          & =\lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^{N}
-        \sum_{k:\lvert\lambda_{k}\rvert=1}(\bar\lambda_{k}T)^{n},
+        \sum_{k=1}^{m}(\bar\lambda_{k}T)^{n},
         \label{eq:peripheral_projection_weighted_cesaro}
     \end{align}
     both pointwise and in operator norm. This is
     \cite[Equation~(6.15)]{Wolf2012Quantum}.
-
-    \textbf{Local fix (deduplicated phases):} the inner sum runs over the
-    distinct peripheral eigenvalues, each phase counted once. Indexed by the
-    Jordan blocks of \cite[Equations~(6.4)--(6.5)]{Wolf2012Quantum}, where
-    several blocks may share an eigenvalue, the summand
-    $(\bar\lambda_{k}T)^{n}$ would repeat each phase according to its
-    geometric multiplicity, and for the identity channel the right-hand side
-    would converge to $D^{2}$ times the identity rather than $T_\varphi$. The
-    comparison is recorded in
-    \path{docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex}.
+    % Local fix (distinct phases): Wolf's Equation (6.15) indexes the inner
+    % sum by the Jordan blocks of Equations (6.4)-(6.5), where several blocks
+    % may share an eigenvalue; on that reading the summand (bar lambda_k T)^n
+    % repeats each phase according to its geometric multiplicity, and for the
+    % identity channel the right-hand side would converge to D^2 times the
+    % identity rather than T_phi. The formalization averages over the distinct
+    % peripheral eigenvalues, as stated. The comparison is recorded in
+    % docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -135,7 +134,8 @@
     Split $X=T_\varphi(X)+(X-T_\varphi(X))$ along the complementary spectral
     subspaces. Bounded forward orbits force every eigenvalue to have modulus
     at most one, so every eigenvalue outside the peripheral spectrum has
-    modulus strictly below one and $T^{n}$ vanishes on the non-peripheral
+    modulus strictly below one and $T^{n}(Y)\to0$ for every $Y$ in the
+    non-peripheral
     subspace; part (ii) of
     Lemma~\ref{lem:weighted_cesaro_mean_on_splitting} sends the second
     summand to zero. Triviality of the peripheral Jordan blocks identifies

--- a/blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex
+++ b/blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex
@@ -26,7 +26,6 @@
     \begin{align}
         \sum_{n=1}^{N}\zeta^{n}
          & =\frac{\zeta-\zeta^{N+1}}{1-\zeta}
-        \notag
     \end{align}
     is bounded by $2/\lvert1-\zeta\rvert$ uniformly in $N$, so dividing by
     $N$ sends it to zero.
@@ -41,7 +40,6 @@
     \begin{align}
         \frac{1}{N}\sum_{n=1}^{N}u_{n}
          & \longrightarrow0.
-        \notag
     \end{align}
 \end{lemma}
 
@@ -101,7 +99,8 @@
     \label{thm:peripheral_projection_weighted_cesaro}
     \lean{IsPositiveMap.tendsto_weightedCesaroMean_peripheralProjection,
         IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_peripheralProjection,
-        IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection}
+        IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection,
+        IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_toFinset_peripheralProjection}
     \leanok
     \uses{def:peripheral_spectral_projections, def:weighted_cesaro_mean}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving, with $D>0$, and
@@ -114,6 +113,16 @@
     \end{align}
     both pointwise and in operator norm. This is
     \cite[Equation~(6.15)]{Wolf2012Quantum}.
+
+    \textbf{Local fix (deduplicated phases):} the inner sum runs over the
+    distinct peripheral eigenvalues, each phase counted once. Indexed by the
+    Jordan blocks of \cite[Equations~(6.4)--(6.5)]{Wolf2012Quantum}, where
+    several blocks may share an eigenvalue, the summand
+    $(\bar\lambda_{k}T)^{n}$ would repeat each phase according to its
+    geometric multiplicity, and for the identity channel the right-hand side
+    would converge to $D^{2}$ times the identity rather than $T_\varphi$. The
+    comparison is recorded in
+    \path{docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex
+++ b/docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex
@@ -75,11 +75,11 @@ The formal development averages over the set of eigenvalues of modulus one, so
 each distinct phase appears once.\footnote{Formal declarations:
   \leanid{Module.End.weightedCesaroMean} for the average, and the convergence
   statements
-  \leanid{IsPositiveMap.tendsto\_weightedCesaroMean\_peripheralProjection},
-  \leanid{IsPositiveMap.tendsto\_endEquiv\_weightedCesaroMean\_peripheralProjection},
-  \leanid{IsPositiveMap.tendsto\_weightedCesaroMean\_toFinset\_peripheralProjection},
+  \leanid{IsPositiveMap.tendsto_weightedCesaroMean_peripheralProjection},
+  \leanid{IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_peripheralProjection},
+  \leanid{IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection},
   and
-  \leanid{IsPositiveMap.tendsto\_endEquiv\_weightedCesaroMean\_toFinset\_peripheralProjection}
+  \leanid{IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_toFinset_peripheralProjection}
   in \doclink{TNLean/Channel/Peripheral/WeightedCesaro}.}
 This correction changes no hypothesis of Equation~(6.15); it adjusts the
 multiplicity convention of the inner summation index.

--- a/docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex
+++ b/docs/paper-gaps/wolf_ch6_eq615_deduplicated_phases.tex
@@ -1,0 +1,98 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Phase Index in the Weighted Ces\`aro Formula, Wolf Equation~(6.15)}
+\author{}
+\date{2026-08-16}
+
+\begin{document}
+\maketitle
+
+\section{The source sentence}
+
+After expressing $T_\infty$ as a Ces\`aro mean in his Equation~(6.14), Wolf
+writes, for a trace-preserving positive linear map $T:\MN{D}\to\MN{D}$,
+\begin{align}
+  T_\phi
+  & = \lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^N
+  \sum_{k:|\lambda_k|=1} (\overline{\lambda_k}T)^n.
+  \tag{Wolf eq.~6.15}
+\end{align}
+The local source is
+\path{Notes/WolfNoteTexSource/ch06_spectral_properties.tex},
+lines~258--264 \cite{Wolf2012Quantum}. Throughout the chapter the index $k$
+runs over the Jordan blocks of the superoperator $\widehat T$: by
+Equations~(6.4)--(6.5) of the same source (lines~111--139),
+$\widehat T=X(\bigoplus_{k=1}^K J_k(\lambda_k))X^{-1}$, and ``the number of
+Jordan blocks with eigenvalue $\lambda$ is the geometric multiplicity of
+$\lambda$'' (lines~140--142); several blocks may carry the same eigenvalue.
+
+\section{Correction forced by the multiplicities}
+
+The summand $(\overline{\lambda_k}T)^n$ depends on the eigenvalue $\lambda_k$
+only, not on the block carrying it, so the literal block-indexed inner sum
+counts each peripheral eigenvalue with its geometric multiplicity. Take the
+identity channel $T=\one$ on $\MN{D}$ with $D>1$: every matrix is an eigenvector
+for the eigenvalue $1$, the Jordan decomposition of $\widehat T$ consists of
+$D^2$ one-dimensional blocks all carrying $\lambda_k=1$, and the literal
+right-hand side of Equation~(6.15) is
+\[
+  \lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^N D^2\,\one
+  = D^2\,\one
+  \neq T_\phi=\one.
+\]
+So read literally, with $k$ a block index, the equation is false. The reading
+under which it is true --- plainly the intended one, since the same chapter
+characterizes $T_\phi$ as the projection onto the span of the peripheral
+eigenvectors - is that $k$ runs over the \emph{distinct} peripheral
+eigenvalues,
+\[
+  T_\phi
+  = \lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^N
+  \sum_{\substack{\lambda\ \text{eigenvalue of }T\\ |\lambda|=1}}
+  (\bar\lambda T)^n ,
+\]
+each phase counted once. This is consistent with the rest of the chapter:
+peripheral Jordan blocks of a trace-preserving positive map are
+one-dimensional (source, proposition on lines~181--186), so the peripheral
+subspace is the direct sum of the eigenspaces of the distinct peripheral
+eigenvalues, and on the eigenspace of $\lambda$ the summand indexed by $\mu$
+acts as the scalar $(\bar\mu\lambda)^n$, whose Ces\`aro mean is
+$\delta_{\mu\lambda}$; a single summand per distinct eigenvalue therefore
+suffices to recover the projection. The neighbouring sums
+$\widehat T_\infty$, $\widehat T_\phi$, $\widehat T_\varphi$ of
+Equations~(6.11)--(6.13) are indexed by blocks as well, but they involve the
+block projections $P_k$ and are correct as printed; only Equation~(6.15),
+whose summand lost the block dependence, requires the deduplicated index.
+
+The formal development averages over the set of eigenvalues of modulus one, so
+each distinct phase appears once.\footnote{Formal declarations:
+  \leanid{Module.End.weightedCesaroMean} for the average, and the convergence
+  statements
+  \leanid{IsPositiveMap.tendsto\_weightedCesaroMean\_peripheralProjection},
+  \leanid{IsPositiveMap.tendsto\_endEquiv\_weightedCesaroMean\_peripheralProjection},
+  \leanid{IsPositiveMap.tendsto\_weightedCesaroMean\_toFinset\_peripheralProjection},
+  and
+  \leanid{IsPositiveMap.tendsto\_endEquiv\_weightedCesaroMean\_toFinset\_peripheralProjection}
+  in \doclink{TNLean/Channel/Peripheral/WeightedCesaro}.}
+This correction changes no hypothesis of Equation~(6.15); it adjusts the
+multiplicity convention of the inner summation index.
+
+\section{Verdict}
+
+This is a local correction of the summation index in the source equation: $k$
+is reinterpreted from a Jordan-block index to an index of the distinct
+peripheral eigenvalues. It does not alter the hypotheses or the conclusion of
+Equation~(6.15), which is false under the literal block-indexed reading, as
+the identity channel shows.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Wolf Equation (6.15), as printed

`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 258–264:

> In a similar vein as $T_\infty$ is expressed as a Cesaro mean in Eq. (6.14) we can write
> $$T_\phi = \lim_{N\to\infty}\frac{1}{N}\sum_{n=1}^N \sum_{k:|\lambda_k|=1} (\overline{\lambda_k}T)^n.$$

Wolf calls this "an immediate consequence of the geometric series"; the proof here follows that route.

## Landed signatures

New definition (`TNLean/Channel/Peripheral/WeightedCesaro.lean`):

```lean
noncomputable def Module.End.weightedCesaroMean (f : Module.End ℂ V) (s : Finset ℂ) (N : ℕ) :
    Module.End ℂ V :=
  (N : ℂ)⁻¹ • ∑ n ∈ Finset.Icc 1 N, ∑ μ ∈ s, ((starRingEnd ℂ) μ • f) ^ n
```

Equation (6.15) itself:

```lean
theorem IsPositiveMap.tendsto_weightedCesaroMean_peripheralProjection
    {D : ℕ} [NeZero D] {T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)}
    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) {s : Finset ℂ}
    (hs : (s : Set ℂ) = peripheralEigenvalues T) (X : Matrix (Fin D) (Fin D) ℂ) :
    Tendsto (fun N : ℕ ↦ T.weightedCesaroMean s N X) atTop
      (𝓝 (T.peripheralProjection X))

theorem IsPositiveMap.tendsto_endEquiv_weightedCesaroMean_peripheralProjection
    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) {s : Finset ℂ}
    (hs : (s : Set ℂ) = peripheralEigenvalues T) :
    Tendsto (fun N : ℕ ↦ endEquiv (T.weightedCesaroMean s N)) atTop
      (𝓝 (endEquiv T.peripheralProjection))

theorem IsPositiveMap.tendsto_weightedCesaroMean_toFinset_peripheralProjection
    (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T) (X : Matrix (Fin D) (Fin D) ℂ) :
    Tendsto (fun N : ℕ ↦
        T.weightedCesaroMean (peripheralEigenvalues_finite T).toFinset N X) atTop
      (𝓝 (T.peripheralProjection X))
```

Supporting statements, both new:

* `Module.End.tendsto_weightedCesaroMean_apply_self_of_mem_iSup_eigenspace` — the averages act as the identity on the span of the eigenspaces indexed by the averaging set.
* `Module.End.tendsto_weightedCesaroMean_apply_zero_of_tendsto_pow_zero` — the averages vanish wherever the powers already vanish.

Layer 0, `TNLean/Analysis/WeightedCesaroMean.lean` (generic analysis, per `docs/import_structure.md`):

```lean
theorem WeightedCesaro.tendsto_cesaro_phase_sum {s : Finset ℂ} (hs : ∀ μ ∈ s, ‖μ‖ = 1)
    {lam : ℂ} (hlam : lam ∈ s) :
    Tendsto (fun N : ℕ ↦ (N : ℂ)⁻¹ *
        ∑ n ∈ Finset.Icc 1 N, ∑ μ ∈ s, ((starRingEnd ℂ) μ * lam) ^ n) atTop (𝓝 1)
```

plus `tendsto_cesaro_zero`, `tendsto_cesaro_geom_zero`, `tendsto_cesaro_geom_one`, `sum_Icc_one_eq_sum_range`. The bounded-geometric-sum input is reused from the existing `UnitModulusPowerSum` module rather than reproved.

## Hypothesis match

| Wolf | Lean |
|---|---|
| $T$ positive | `hPos : IsPositiveMap T` |
| $T$ trace-preserving | `hTP : IsTracePreservingMap T` |
| $T$ acts on $\mathcal{M}_d(\mathbb{C})$, $d \ge 1$ | `{D : ℕ} [NeZero D]`, `T : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ)` |
| inner sum over $\{k : |\lambda_k| = 1\}$ | `hs : (s : Set ℂ) = peripheralEigenvalues T` |
| $\sum_{n=1}^{N}$, factor $1/N$ | `Finset.Icc 1 N`, `(N : ℂ)⁻¹ •` |

No complete positivity, unitality, irreducibility, or primitivity is used. `[NeZero D]` is the ambient nondegeneracy of the matrix algebra already carried by the whole `T_φ` package (`IsPositiveMap.peripheralProjection_isPositiveMap` and siblings); it is not a strengthening of Wolf's hypotheses on the map. The last-listed corollary drops `s` by enumerating the peripheral spectrum through its own finiteness proof.

## Proof route (Wolf's)

Split by `Module.End.isCompl_peripheralSubspace_nonPeripheralSubspace`. On the peripheral part, `IsPositiveMap.maxGenEigenspace_eq_eigenspace_of_norm_eq_one` (Wolf Proposition 6.2, already proved) turns the generalized eigenspaces into eigenspaces, so on the $\lambda_j$-eigenspace the summand $(\bar\lambda_k T)^n$ is the scalar $(\bar\lambda_k\lambda_j)^n$; the ratio equals $1$ exactly when $\lambda_k = \lambda_j$, and every other ratio has geometric sums bounded by $2/|1-\zeta|$, so the mean is $\delta_{jk}$. On the non-peripheral part `Module.End.tendsto_pow_apply_zero_of_mem_nonPeripheralSubspace` gives $T^n \to 0$, unit phases leave norms unchanged, and the Cesàro mean of a null sequence is null. Operator-norm convergence comes from `ContinuousLinearMap.tendsto_of_tendsto_apply_of_finiteDimensional` (PR LionSR/TNLean#6323).

## Blueprint

New `\input` sub-file `blueprint/src/chapter/ch06_qpf_weighted_cesaro.tex`, hooked into `ch06_qpf.tex` after the existing Cesàro section. Entries: `lem:unit_modulus_phase_cesaro`, `lem:cesaro_mean_of_null_sequence`, `def:weighted_cesaro_mean`, `lem:weighted_cesaro_mean_on_splitting`, and `thm:peripheral_projection_weighted_cesaro` (Equation (6.15)), all with `\lean{...}`, `\leanok`, and `\leanok` on each proof. Statement `\uses` list only what states the result; proof `\uses` list the peripheral Jordan triviality, the spectral complementarity, the eigenvalue-modulus bound, and the finite-dimensional operator-norm lemma.

## Verification

| Command | Outcome |
|---|---|
| `lake build TNLean.Channel TNLean.Analysis` | Build completed successfully (9126 jobs) |
| `lake build TNLean.Channel.Peripheral.WeightedCesaro` (forced rebuild) | clean, no linter warnings |
| `lake exe lint_style` | no output |
| `rg -n "sorry\|axiom"` on both new modules | no matches |
| `#print axioms` on the three Equation (6.15) theorems | `propext, Classical.choice, Quot.sound` only |
| longest line in new files | ≤ 100 characters; no combining marks |
| `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` | aggregators current (53 files, 1384 modules) |
| `python3 scripts/blueprint_lean_sync.py --ci` | Blueprint and Lean code are in sync |
| `python3 scripts/check_tenkz_dispositions.py` | PASS (202 occurrences, 9 fixtures) |
| `leanblueprint pdf` | builds; new section typeset, no undefined references |

`leanblueprint checkdecls` needs `blueprint/lean_decls`, which is generated by the web build in CI and is not present locally; `blueprint_lean_sync.py --ci` covers the same declaration-existence check.

Closes LionSR/QICLean#284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176U7wiKWaxFAKBHv3Jgjz3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and blueprint text only; they build on existing peripheral spectral infrastructure without changing auth, data paths, or runtime behavior.
> 
> **Overview**
> Adds **Wolf Equation (6.15)**—the peripheral projection `T_φ` is the limit of phase-weighted Cesàro means `(1/N) ∑_{n=1}^N ∑_{|λ|=1} (conj λ • T)^n` for positive trace-preserving maps on matrix algebras.
> 
> **Analysis layer** (`WeightedCesaroMean.lean`): Cesàro means over `1 ≤ n ≤ N`, orthogonality of unit-modulus phase sums, and null-sequence Cesàro convergence (reusing `UnitModulusPowerSum` for bounded geometric sums).
> 
> **Channel layer** (`Peripheral/WeightedCesaro.lean`): defines `Module.End.weightedCesaroMean`, proves the averages act as identity on the span of peripheral eigenspaces and vanish where `T^n → 0`, then splits `X = T_φ(X) + (X - T_φ(X))` along existing peripheral/non-peripheral theory to get pointwise convergence to `T.peripheralProjection` and operator-norm convergence via finite dimensionality.
> 
> **Blueprint**: new `ch06_qpf_weighted_cesaro.tex` section wired into `ch06_qpf.tex` with `\leanok` links to the new declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e027d2756a10a5eb6f1c3e97ee458cb5295da4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->