### PR TITLE
docs(CPSV16): define the Example 4.10 flip probability

### DIFF
--- a/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
+++ b/docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex
@@ -22,8 +22,8 @@ a repeated left-qubit label, four decimal entropy values, and the claim that
 the mutual information does not saturate except at the stated exceptional
 probabilities.  It prints no exact ratio or integer comparison.  Replacing the
 repeated label by the network-consistent left-right correlated flip and setting
-$p=1/4$ reproduces the decimal entropies and gives the independently derived
-comparison
+the flip probability to $p=1/4$ reproduces the decimal entropies and gives the
+independently derived comparison
 \[
   2^{32}7^7>3^3 5^{20}.
 \]


### PR DESCRIPTION
## Summary

- identify $p$ as the flip probability at its first Example 4.10 occurrence
- leave the corrected-channel arithmetic scope and all other files unchanged

## Checks

- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_exact_arithmetic_scope.tex`
- `chktex -q -l blueprint/.chktexrc docs/paper-gaps/cpsv16_exact_arithmetic_scope.tex`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

Closes #6333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-sentence prose edit in documentation with no code, build, or behavioral impact.
> 
> **Overview**
> Clarifies the Example 4.10 setup in `cpsv16_exact_arithmetic_scope.tex` by naming **the flip probability** when introducing $p=1/4$, instead of only stating `$p=1/4$` after describing the corrected channel. Wording is split across two lines for readability; the arithmetic scope and all other content are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a0d3e3d93ad5e36ca9dd722bd79832d4fdb388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->