### PR TITLE
feat(MPDO): embed Example 4.11 ambient support

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -85,6 +85,7 @@ import TNLean.MPS.MPDO.BondTwoSingletonPhysicalGauge
 import TNLean.MPS.MPDO.CPSVBNTFusionTensorClauseFromRFP
 import TNLean.MPS.MPDO.CPSVBNTTheoremEquivalence
 import TNLean.MPS.MPDO.CPSVBlocking
+import TNLean.MPS.MPDO.CPSVExample411Ambient
 import TNLean.MPS.MPDO.CPSVExample411BinarySupport
 import TNLean.MPS.MPDO.CPSVExample412Literal
 import TNLean.MPS.MPDO.CPSVExamples410411Arithmetic

--- a/TNLean/MPS/MPDO/CPSVExample411Ambient.lean
+++ b/TNLean/MPS/MPDO/CPSVExample411Ambient.lean
@@ -35,7 +35,7 @@ SAL, ZCL, or unsupported full-MPO entry theorem is asserted here.
 
 ## Main results
 
-* `ambientM_supported`: the exact one-site supported-slice bridge.
+* `ambientM_supported`: the exact one-site supported-slice equality.
 * `ambientM_left_unsupported` and `ambientM_right_unsupported`: unsupported
   one-site physical legs vanish.
 * `mpo_ambientM_eq_singleKrausMap`: the operator-level sitewise congruence.
@@ -109,7 +109,7 @@ theorem inclusion_isometry : inclusionᴴ * inclusion = 1 := by
 /-- The source-facing ambient tensor, obtained by isometrically including the
 binary support model in the two-qubit one-site space.
 
-**Local fix:** this is a support inclusion, not an equivalence between the
+**Local fix (support embedding):** this is a support inclusion, not an equivalence between the
 physical dimensions $2$ and $4$.
 
 Source for the local $\eta_{k,h}$ family: arXiv:1606.00608, Example 4.11,
@@ -118,7 +118,7 @@ lines 907--924. The embedding is the project derivation documented in
 def ambientM : MPOTensor 4 4 :=
   changePhysicalBasis inclusion CPSVExample411BinarySupport.M
 
-/-- Exact one-site bridge on the supported physical slice. -/
+/-- Exact equality on the supported one-site physical slice. -/
 theorem ambientM_supported (k h : Fin 2) :
     ambientM (siteEmbedding k) (siteEmbedding h) =
       CPSVExample411BinarySupport.M k h := by
@@ -159,14 +159,6 @@ configurations. -/
   rw [Fintype.prod_boole]
   congr 1
   exact propext funext_iff.symm
-
-/-- The same sitewise delta identity with the embedded configuration on the
-column leg. -/
-@[simp] theorem sitewisePhysicalMatrix_inclusion_embedConfig_right {N : ℕ}
-    (σ τ : Fin N → Fin 2) :
-    sitewisePhysicalMatrix inclusion N (embedConfig τ) σ =
-      if τ = σ then 1 else 0 :=
-  sitewisePhysicalMatrix_inclusion_embedConfig τ σ
 
 /-- The ambient periodic MPO is the sitewise single-Kraus congruence of the
 binary periodic MPO. -/

--- a/TNLean/MPS/MPDO/CPSVExample411Ambient.lean
+++ b/TNLean/MPS/MPDO/CPSVExample411Ambient.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CPSVExample411BinarySupport
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+
+/-!
+# Ambient two-qubit-site model for CPSV16 Example 4.11
+
+This module embeds the effective binary-support tensor for CPSV16 Example 4.11
+into the source-facing four-dimensional one-site space. The supported binary
+label $k$ is sent to the two-qubit basis vector $|k,k\rangle$, indexed by
+`finProdFinEquiv (k, k)`. The resulting periodic MPO is the sitewise isometric
+congruence of the binary model, so its supported entries and trace are
+transported exactly.
+
+**Local fix (support embedding):** the effective physical dimension $2$ is not
+identified with the ambient physical dimension $4$. It is included as the span
+of $|0,0\rangle$ and $|1,1\rangle$.
+
+**Scope restriction:** CPSV16, Example 4.11, lines 907--924 is cited only for
+the four operators $\eta_{k,h}$ and their two-qubit site interpretation. The
+embedding consequences below are project derivations recorded in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. No spectrum, entropy,
+SAL, ZCL, or unsupported full-MPO entry theorem is asserted here.
+
+## Main definitions
+
+* `siteEmbedding`: the supported-label inclusion $k \mapsto |k,k\rangle$.
+* `inclusion`: the corresponding rectangular one-site isometry.
+* `ambientM`: the physical-dimension-$4$ tensor obtained from the binary model.
+* `embedConfig`: the sitewise inclusion of a binary configuration.
+
+## Main results
+
+* `ambientM_supported`: the exact one-site supported-slice bridge.
+* `ambientM_left_unsupported` and `ambientM_right_unsupported`: unsupported
+  one-site physical legs vanish.
+* `mpo_ambientM_eq_singleKrausMap`: the operator-level sitewise congruence.
+* `mpo_ambientM_supported_apply`: the positive-length supported MPO entries.
+* `trace_mpo_ambientM`: equality of ambient and binary traces.
+* `trace_mpo_ambientM_eq_partitionFunction` and
+  `trace_mpo_ambientM_closed_form`: exact normalization formulas.
+-/
+
+open scoped BigOperators Matrix
+
+noncomputable section
+
+namespace MPOTensor.CPSVExample411Ambient
+
+open PhysicalSectorFactorization
+
+/-- The supported binary label $k$ occupies the ambient two-qubit basis vector
+$|k,k\rangle$.
+
+Source for the two-qubit site interpretation: arXiv:1606.00608, Example 4.11,
+lines 907--924. -/
+def siteEmbedding (k : Fin 2) : Fin 4 := finProdFinEquiv (k, k)
+
+/-- The supported-label map into the ambient two-qubit basis is injective. -/
+theorem siteEmbedding_injective : Function.Injective siteEmbedding := by
+  intro k h hkh
+  exact congrArg Prod.fst (finProdFinEquiv.injective hkh)
+
+/-- The rectangular inclusion of the supported one-site space into the
+ambient two-qubit one-site space. -/
+def inclusion : Matrix (Fin 4) (Fin 2) ℂ :=
+  fun i k ↦ if i = siteEmbedding k then 1 else 0
+
+@[simp] theorem inclusion_apply (i : Fin 4) (k : Fin 2) :
+    inclusion i k = if i = siteEmbedding k then 1 else 0 := rfl
+
+@[simp] theorem siteEmbedding_inj {k h : Fin 2} :
+    siteEmbedding k = siteEmbedding h ↔ k = h :=
+  siteEmbedding_injective.eq_iff
+
+@[simp] theorem inclusion_siteEmbedding (k h : Fin 2) :
+    inclusion (siteEmbedding k) h = if k = h then 1 else 0 := by
+  rw [inclusion_apply]
+  exact if_congr siteEmbedding_inj rfl rfl
+
+/-- The one-site support inclusion is an isometry. -/
+theorem inclusion_isometry : inclusionᴴ * inclusion = 1 := by
+  ext k h
+  rw [Matrix.mul_apply]
+  by_cases hkh : k = h
+  · subst h
+    rw [Fintype.sum_eq_single (siteEmbedding k)]
+    · simp
+    · intro i hik
+      simp only [Matrix.conjTranspose_apply, inclusion_apply]
+      rw [if_neg hik]
+      simp
+  · simp only [Matrix.one_apply, if_neg hkh]
+    have hemb : siteEmbedding k ≠ siteEmbedding h := fun h' ↦
+      hkh (siteEmbedding_injective h')
+    apply Finset.sum_eq_zero
+    intro i _
+    simp only [Matrix.conjTranspose_apply, inclusion_apply]
+    by_cases hik : i = siteEmbedding k
+    · rw [if_pos hik, if_neg (hik ▸ hemb)]
+      simp
+    · rw [if_neg hik]
+      simp
+
+/-- The source-facing ambient tensor, obtained by isometrically including the
+binary support model in the two-qubit one-site space.
+
+**Local fix:** this is a support inclusion, not an equivalence between the
+physical dimensions $2$ and $4$.
+
+Source for the local $\eta_{k,h}$ family: arXiv:1606.00608, Example 4.11,
+lines 907--924. The embedding is the project derivation documented in
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. -/
+def ambientM : MPOTensor 4 4 :=
+  changePhysicalBasis inclusion CPSVExample411BinarySupport.M
+
+/-- Exact one-site bridge on the supported physical slice. -/
+theorem ambientM_supported (k h : Fin 2) :
+    ambientM (siteEmbedding k) (siteEmbedding h) =
+      CPSVExample411BinarySupport.M k h := by
+  ext beta alpha
+  simp [ambientM, changePhysicalBasis, physicalSlice, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, inclusion_apply]
+
+/-- A physical ket leg outside the supported two-qubit basis slice vanishes. -/
+theorem ambientM_left_unsupported (i : Fin 4)
+    (hi : ∀ k : Fin 2, i ≠ siteEmbedding k) (j : Fin 4) :
+    ambientM i j = 0 := by
+  rw [ambientM, changePhysicalBasis_apply_eq_sum]
+  apply Finset.sum_eq_zero
+  intro p _
+  simp [inclusion_apply, hi p.1]
+
+/-- A physical bra leg outside the supported two-qubit basis slice vanishes. -/
+theorem ambientM_right_unsupported (j : Fin 4)
+    (hj : ∀ k : Fin 2, j ≠ siteEmbedding k) (i : Fin 4) :
+    ambientM i j = 0 := by
+  rw [ambientM, changePhysicalBasis_apply_eq_sum]
+  apply Finset.sum_eq_zero
+  intro p _
+  simp [inclusion_apply, hj p.2]
+
+/-- Sitewise embedding of a binary physical configuration into the ambient
+four-dimensional site space. -/
+def embedConfig {N : ℕ} (σ : Fin N → Fin 2) : Fin N → Fin 4 :=
+  fun n ↦ siteEmbedding (σ n)
+
+/-- The sitewise inclusion is the rectangular delta matrix on embedded
+configurations. -/
+@[simp] theorem sitewisePhysicalMatrix_inclusion_embedConfig {N : ℕ}
+    (σ τ : Fin N → Fin 2) :
+    sitewisePhysicalMatrix inclusion N (embedConfig σ) τ =
+      if σ = τ then 1 else 0 := by
+  simp only [sitewisePhysicalMatrix, embedConfig, inclusion_siteEmbedding]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact propext funext_iff.symm
+
+/-- The same sitewise delta identity with the embedded configuration on the
+column leg. -/
+@[simp] theorem sitewisePhysicalMatrix_inclusion_embedConfig_right {N : ℕ}
+    (σ τ : Fin N → Fin 2) :
+    sitewisePhysicalMatrix inclusion N (embedConfig τ) σ =
+      if τ = σ then 1 else 0 :=
+  sitewisePhysicalMatrix_inclusion_embedConfig τ σ
+
+/-- The ambient periodic MPO is the sitewise single-Kraus congruence of the
+binary periodic MPO. -/
+theorem mpo_ambientM_eq_singleKrausMap (N : ℕ) :
+    mpo ambientM N = singleKrausMap (sitewisePhysicalMatrix inclusion N)
+      (mpo CPSVExample411BinarySupport.M N) := by
+  exact (singleKrausMap_sitewisePhysicalMatrix_mpo inclusion CPSVExample411BinarySupport.M N).symm
+
+/-- Supported positive-length entries of the ambient MPO are exactly the
+binary cycle weights. -/
+theorem mpo_ambientM_supported_apply {N : ℕ} [NeZero N]
+    (σ τ : Fin N → Fin 2) :
+    mpo ambientM N (embedConfig σ) (embedConfig τ) =
+      if σ = τ then CPSVExample411BinarySupport.cycleWeight σ else 0 := by
+  rw [mpo_ambientM_eq_singleKrausMap, singleKrausMap_apply]
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    sitewisePhysicalMatrix_inclusion_embedConfig, ite_mul, one_mul, zero_mul,
+    Fintype.sum_ite_eq]
+  have hstar (q : Fin N → Fin 2) :
+      star (if τ = q then (1 : ℂ) else 0) = if τ = q then 1 else 0 := by
+    split <;> simp
+  simp_rw [hstar]
+  simp only [mul_ite, mul_one, mul_zero, Fintype.sum_ite_eq]
+  change mpo CPSVExample411BinarySupport.M N σ τ = _
+  exact CPSVExample411BinarySupport.mpo_M_apply σ τ
+
+/-- The ambient and binary periodic MPOs have equal traces at every length. -/
+theorem trace_mpo_ambientM (N : ℕ) :
+    Matrix.trace (mpo ambientM N) = Matrix.trace (mpo CPSVExample411BinarySupport.M N) := by
+  exact trace_mpo_changePhysicalBasis_of_isometry
+    inclusion inclusion_isometry CPSVExample411BinarySupport.M N
+
+/-- For positive length, the ambient MPO trace is the binary cycle partition
+function. -/
+theorem trace_mpo_ambientM_eq_partitionFunction {N : ℕ} [NeZero N] :
+    Matrix.trace (mpo ambientM N) = CPSVExample411BinarySupport.partitionFunction N := by
+  rw [trace_mpo_ambientM, CPSVExample411BinarySupport.mpo_M_eq_diagonal,
+    Matrix.trace_diagonal, CPSVExample411BinarySupport.partitionFunction]
+
+/-- The exact positive-length normalization of the ambient two-qubit-site MPO. -/
+theorem trace_mpo_ambientM_closed_form {N : ℕ} [NeZero N] :
+    Matrix.trace (mpo ambientM N) = ((3 : ℂ) ^ N + 1) / (2 : ℂ) ^ N := by
+  rw [trace_mpo_ambientM_eq_partitionFunction,
+    CPSVExample411BinarySupport.partitionFunction_closed_form]
+
+end MPOTensor.CPSVExample411Ambient

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1153,7 +1153,7 @@ This is the calculation in
     $\sigma$, write $\iota\sigma$ for its sitewise image in the ambient basis.
 \end{definition}
 
-\begin{theorem}[Exact ambient support and periodic-operator bridge]
+\begin{theorem}[Exact ambient support and periodic-operator congruence]
     \label{thm:cpsv_example411_ambient_support_bridge}
     \lean{MPOTensor.CPSVExample411Ambient.ambientM_supported,
         MPOTensor.CPSVExample411Ambient.ambientM_left_unsupported,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1054,9 +1054,9 @@ This is the calculation in
 \end{theorem}
 
 % CPSV16 Example 4.11, lines 907--924.
-% Scope restriction: this is the supported binary encoding, not yet the ambient
-% two-qubit-per-site tensor. See
-% docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex and issue #6302.
+% Scope restriction: this is the effective supported model; the ambient
+% two-qubit-per-site realization is the isometric support inclusion below.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
 \begin{definition}[Effective binary-support model for Example 4.11]
     \label{def:cpsv_example411_binary_support_model}
     \lean{MPOTensor.CPSVExample411BinarySupport.weightMatrix,
@@ -1083,9 +1083,10 @@ This is the calculation in
         &Z_N&=\sum_{\sigma}c_N(\sigma).
         \notag
     \end{align}
-    This is a physical-dimension-$2$ support model.  The source's ambient site
-    has physical dimension $4$, and identifying the model with its literal
-    tensor requires a later support embedding.
+    This is a physical-dimension-$2$ support model.  The ambient
+    physical-dimension-$4$ realization is obtained by the support inclusion
+    defined below; the two physical spaces are not identified by an
+    equivalence.
 \end{definition}
 
 \begin{theorem}[Diagonal formula and normalization of the binary-support model]
@@ -1104,9 +1105,10 @@ This is the calculation in
         &Z_N&=\operatorname{tr}(W^N)=\frac{3^N+1}{2^N}.
         \notag
     \end{align}
-    These identities concern only the effective binary support model.  They do
-    not assert spectra, entropy, saturation of the area law, zero correlation
-    length, or equivalence with the ambient physical-dimension-$4$ tensor.
+    These identities first concern the effective binary support model.  The
+    ambient definition below transports the operator and trace identities, but
+    no spectrum, entropy, saturation of the area law, or zero correlation
+    length assertion is made here.
 \end{theorem}
 
 \begin{proof}
@@ -1121,6 +1123,90 @@ This is the calculation in
     Hadamard basis diagonalizes $W$ with eigenvalues $3/2$ and $1/2$, so
     cyclicity of the trace gives
     $\operatorname{tr}(W^N)=(3/2)^N+(1/2)^N=(3^N+1)/2^N$.
+\end{proof}
+
+% CPSV16 Example 4.11, lines 907--924.
+% Local fix (support embedding): Fin 2 is included in Fin 4 by k |-> (k,k),
+% rather than identified with it by an equivalence.
+% Scope restriction: the source is cited for eta and the site interpretation;
+% the embedding consequences are project derivations documented in
+% docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{definition}[Ambient two-qubit-site support inclusion]
+    \label{def:cpsv_example411_ambient_support_inclusion}
+    \lean{MPOTensor.CPSVExample411Ambient.siteEmbedding,
+        MPOTensor.CPSVExample411Ambient.siteEmbedding_injective,
+        MPOTensor.CPSVExample411Ambient.inclusion,
+        MPOTensor.CPSVExample411Ambient.inclusion_isometry,
+        MPOTensor.CPSVExample411Ambient.ambientM,
+        MPOTensor.CPSVExample411Ambient.embedConfig}
+    \leanok
+    \uses{def:cpsv_example411_binary_support_model}
+    Identify the ambient one-site basis with
+    $\{|a,b\rangle:a,b\in\{0,1\}\}$.  Define
+    \begin{align}
+        \iota(k)&=|k,k\rangle,
+        &V_{i,k}&=\delta_{i,\iota(k)},
+        &\widetilde M&=V M V^*.
+        \notag
+    \end{align}
+    Then $\iota$ is injective and $V^*V=I_2$.  For a binary configuration
+    $\sigma$, write $\iota\sigma$ for its sitewise image in the ambient basis.
+\end{definition}
+
+\begin{theorem}[Exact ambient support and periodic-operator bridge]
+    \label{thm:cpsv_example411_ambient_support_bridge}
+    \lean{MPOTensor.CPSVExample411Ambient.ambientM_supported,
+        MPOTensor.CPSVExample411Ambient.ambientM_left_unsupported,
+        MPOTensor.CPSVExample411Ambient.ambientM_right_unsupported,
+        MPOTensor.CPSVExample411Ambient.mpo_ambientM_eq_singleKrausMap,
+        MPOTensor.CPSVExample411Ambient.mpo_ambientM_supported_apply}
+    \leanok
+    \uses{def:cpsv_example411_ambient_support_inclusion,
+        thm:cpsv_example411_binary_support_normalization}
+    The supported one-site slices satisfy
+    $\widetilde M^{\iota(k),\iota(h)}=M^{k,h}$, while a one-site slice vanishes
+    if either physical leg lies outside the image of $\iota$.  For every
+    positive $N$,
+    \begin{align}
+        \operatorname{mpo}(\widetilde M,N)
+        &=V^{\otimes N}\operatorname{mpo}(M,N)(V^{\otimes N})^*,
+        &\operatorname{mpo}(\widetilde M,N)_{\iota\sigma,\iota\tau}
+        &=\delta_{\sigma,\tau}c_N(\sigma).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The rectangular delta matrix collapses each local coordinate sum to the
+    unique supported binary label.  Applying the same inclusion independently
+    at every site gives the displayed congruence, and the supported entry
+    formula follows from the binary diagonal formula.
+\end{proof}
+
+\begin{theorem}[Ambient trace and closed normalization]
+    \label{thm:cpsv_example411_ambient_normalization}
+    \lean{MPOTensor.CPSVExample411Ambient.trace_mpo_ambientM,
+        MPOTensor.CPSVExample411Ambient.trace_mpo_ambientM_eq_partitionFunction,
+        MPOTensor.CPSVExample411Ambient.trace_mpo_ambientM_closed_form}
+    \leanok
+    \uses{def:cpsv_example411_ambient_support_inclusion,
+        thm:cpsv_example411_binary_support_normalization}
+    For every positive $N$, the ambient trace equals the binary partition
+    function:
+    \begin{align}
+        \operatorname{tr}(\operatorname{mpo}(\widetilde M,N))
+        &=\operatorname{tr}(\operatorname{mpo}(M,N))
+         =Z_N=\frac{3^N+1}{2^N}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Cyclicity of the trace and $V^*V=I_2$ preserve the trace under the
+    sitewise congruence.  The binary partition-function identity and its closed
+    form then give the result.
 \end{proof}
 
 % CPSV16 Example 4.12, lines 932--939.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1178,6 +1178,8 @@ This is the calculation in
 
 \begin{proof}
     \leanok
+    \uses{lem:mpdo_sitewise_physical_coordinate_congruence,
+        thm:cpsv_example411_binary_support_normalization}
     The rectangular delta matrix collapses each local coordinate sum to the
     unique supported binary label.  Applying the same inclusion independently
     at every site gives the displayed congruence, and the supported entry
@@ -1204,6 +1206,8 @@ This is the calculation in
 
 \begin{proof}
     \leanok
+    \uses{thm:mpdo_sal_physical_isometry_transport,
+        thm:cpsv_example411_binary_support_normalization}
     Cyclicity of the trace and $V^*V=I_2$ preserve the trace under the
     sitewise congruence.  The binary partition-function identity and its closed
     form then give the result.

--- a/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
+++ b/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
@@ -203,12 +203,24 @@ two exact natural-number comparisons.  The declarations
 of the corresponding logarithmic ratios.  These results entered the project in
 commit \texttt{a79bfc93314f3f721abecdbc184065497672d7e5}.
 
-This arithmetic certification does not identify the reduced-state spectra, prove
-the entropy identities, or connect either ratio to the tensor defined by the
-source.  Those spectral, entropy, tensor, and final area-law links remain open in
-\ghissue{6301} for Example~4.10 and \ghissue{6302} for Example~4.11.  The
-Blueprint status node therefore remains not ready and is not marked as
-formalized.
+\paragraph{Local fix (ambient support inclusion).}
+For Example~4.11, the effective binary one-site space is included in the
+source-facing two-qubit site by $k\mapsto |k,k\rangle$; it is not identified
+with the four-dimensional site by an equivalence.  The module
+\doclink{TNLean/MPS/MPDO/CPSVExample411Ambient} proves the exact supported
+one-site slice, vanishing whenever either local physical leg is unsupported,
+the sitewise periodic-operator congruence, the supported positive-length
+entries, and equality of the ambient trace with
+$Z_N=(3^N+1)/2^N$.
+
+\paragraph{Scope restriction (spectral and entropy consequences).}
+The ambient operator and trace bridge for Example~4.11 is complete.  This does
+not yet identify the reduced-state spectra, prove the entropy identities, or
+connect the certified logarithmic ratio to saturation of the area law or zero
+correlation length.  Those spectral, entropy, SAL, and ZCL links remain open in
+\ghissue{6302}.  Example~4.10's tensor and final entropy links remain open in
+\ghissue{6301}.  The corresponding source-level status therefore remains not
+ready.
 
 Example~4.12 is outside the entropy correction in this note. Its statement,
 dependencies, and separate normalization question are unchanged.

--- a/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
+++ b/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
@@ -218,8 +218,9 @@ The declaration
 the ambient trace $Z_N=(3^N+1)/2^N$.
 
 \paragraph{Scope restriction (spectral and entropy consequences).}
-The ambient operator and trace bridge for Example~4.11 is complete.  This does
-not yet identify the reduced-state spectra, prove the entropy identities, or
+The ambient operator congruence and trace equality for Example~4.11 are
+complete.  This does not yet identify the reduced-state spectra, prove the
+entropy identities, or
 connect the certified logarithmic ratio to saturation of the area law or zero
 correlation length.  Those spectral, entropy, SAL, and ZCL links remain open in
 \ghissue{6302}.  Example~4.10's tensor and final entropy links remain open in

--- a/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
+++ b/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
@@ -208,10 +208,14 @@ For Example~4.11, the effective binary one-site space is included in the
 source-facing two-qubit site by $k\mapsto |k,k\rangle$; it is not identified
 with the four-dimensional site by an equivalence.  The module
 \doclink{TNLean/MPS/MPDO/CPSVExample411Ambient} proves the exact supported
-one-site slice, vanishing whenever either local physical leg is unsupported,
-the sitewise periodic-operator congruence, the supported positive-length
-entries, and equality of the ambient trace with
-$Z_N=(3^N+1)/2^N$.
+one-site slice and vanishing whenever either local physical leg is unsupported.
+The declarations
+\leanid{MPOTensor.CPSVExample411Ambient.mpo_ambientM_eq_singleKrausMap} and
+\leanid{MPOTensor.CPSVExample411Ambient.mpo_ambientM_supported_apply} give the
+sitewise periodic-operator congruence and supported positive-length entries.
+The declaration
+\leanid{MPOTensor.CPSVExample411Ambient.trace_mpo_ambientM_closed_form} gives
+the ambient trace $Z_N=(3^N+1)/2^N$.
 
 \paragraph{Scope restriction (spectral and entropy consequences).}
 The ambient operator and trace bridge for Example~4.11 is complete.  This does


### PR DESCRIPTION
## Summary

- embed the effective binary support by $k \mapsto |k,k\rangle$ in the ambient two-qubit site
- prove the rectangular inclusion is isometric, identify supported local slices, and show unsupported local legs vanish
- transport the periodic MPO by the existing sitewise single-Kraus congruence, including supported entries and trace/normalization
- synchronize the Blueprint and advance the Example 4.11 paper-gap boundary while keeping spectra, entropy, SAL, and ZCL out of scope

## Source and scope

CPSV16 Example 4.11, lines 907--924, is cited only for the $\eta_{k,h}$ family and its two-qubit site interpretation. The ambient embedding consequences are project derivations. This PR does not assert spectra, entropy, SAL, or ZCL. It does not add the optional arbitrary unsupported full-MPO entry theorem; the local unsupported-leg results and operator congruence are the clean support statement in this slice.

## Validation

- `lake env lean TNLean/MPS/MPDO/CPSVExample411Ambient.lean`
- Blueprint sync and changed-declaration coverage
- Blueprint PDF (1049 pages)
- focused paper-gap note compile
- focused chktex and reader-facing prose checks
- import aggregator generation/test, module policies, forbidden-token integrity, and diff checks

Closes #6345.
Advances #6302 without closing it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formalized lemmas on an example-specific embedding with no auth, security, or runtime impact; scope is bounded and does not claim open spectral/entropy results.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/CPSVExample411Ambient`**, which embeds the effective dim-2 binary model into the source-facing dim-4 site by **$k \mapsto |k,k\rangle$** via a rectangular isometry `inclusion` (not a dim equivalence). **`ambientM`** is `changePhysicalBasis inclusion` of the existing binary tensor; the module proves supported slice equality, vanishing on unsupported legs, sitewise **single-Kraus** periodic-operator congruence, supported MPO entries as cycle weights, and trace equality with closed form **$Z_N=(3^N+1)/2^N$**.
> 
> Wires the module through **`MPDO.lean`** and extends the Blueprint capstone with definitions/theorems for the ambient support inclusion, operator bridge, and ambient normalization. Updates **`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`** to record this as the local fix for Example 4.11 while **spectra, entropy, SAL, and ZCL** stay explicitly out of scope (#6302).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e5cb6d87a94ee8914fc9f4959afd9cde03dffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->