### PR TITLE
feat(parent-hamiltonian): prove quantitative C3-prime bound

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
@@ -38,6 +38,22 @@ private theorem sqrt_mul_sqrt_le_of_le {a b B : ℝ} (hB : 0 ≤ B)
         (Real.sqrt_nonneg _) (Real.sqrt_nonneg _)
     _ = B := Real.mul_self_sqrt hB
 
+/-- The norm of four successively subtracted terms is bounded by four times a
+common bound. -/
+private theorem norm_sub_sub_sub_le_four_mul
+    {E : Type*} [SeminormedAddGroup E] {a b c d : E} {B : ℝ}
+    (ha : ‖a‖ ≤ B) (hb : ‖b‖ ≤ B) (hc : ‖c‖ ≤ B) (hd : ‖d‖ ≤ B) :
+    ‖a - b - c - d‖ ≤ 4 * B := by
+  calc
+    ‖a - b - c - d‖ ≤ ‖a‖ + ‖b‖ + ‖c‖ + ‖d‖ := by
+      calc
+        _ ≤ ‖a - b - c‖ + ‖d‖ := norm_sub_le _ _
+        _ ≤ (‖a - b‖ + ‖c‖) + ‖d‖ := by gcongr; exact norm_sub_le _ _
+        _ ≤ ((‖a‖ + ‖b‖) + ‖c‖) + ‖d‖ := by gcongr; exact norm_sub_le _ _
+        _ = _ := by ring
+    _ ≤ B + B + B + B := by gcongr
+    _ = 4 * B := by ring
+
 /-- A moving geometric denominator is bounded by the denominator at the base
 length. -/
 private theorem inverse_one_sub_geometric_le_base {c r : ℝ} (hc : 0 < c)
@@ -503,46 +519,8 @@ theorem IsPrimitiveMPS.wholeIncrement_groundProjection_defect_le_geometric
     rw [wholeIncrement_injectiveRangeProjector_residual_eq_centered_sub_corrections
       A K L Q ρ hρ hLocalTail hLocalLeft hFull]
     calc
-      _ ≤ ‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
-              hLocalTail hLocalLeft‖ +
-          ‖wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
-            hLocalTail hFull‖ +
-          ‖wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
-            hLocalTail hFull‖ +
-          ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
-            hLocalTail hLocalLeft‖ := by
-        calc
-          _ ≤ ‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
-                hLocalTail hLocalLeft -
-              wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
-                hLocalTail hFull -
-              wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
-                hLocalTail hFull‖ +
-              ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
-                hLocalTail hLocalLeft‖ := norm_sub_le _ _
-          _ ≤ (‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
-                hLocalTail hLocalLeft -
-              wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
-                hLocalTail hFull‖ +
-              ‖wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
-                hLocalTail hFull‖) +
-              ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
-                hLocalTail hLocalLeft‖ := by
-            gcongr
-            exact norm_sub_le _ _
-          _ ≤ ((‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
-                hLocalTail hLocalLeft‖ +
-              ‖wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
-                hLocalTail hFull‖) +
-              ‖wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
-                hLocalTail hFull‖) +
-              ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
-                hLocalTail hLocalLeft‖ := by
-            gcongr
-            exact norm_sub_le _ _
-          _ = _ := by ring
-      _ ≤ q * (base * r ^ L) + q * (base * r ^ L) +
-          q * (base * r ^ L) + q * (base * r ^ L) := by gcongr
+      _ ≤ 4 * (q * (base * r ^ L)) :=
+        norm_sub_sub_sub_le_four_mul hCenter hQTail hQFull hQLeft
       _ = q * (C * r ^ L) := by
         dsimp only [C, base]
         ring

--- a/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
@@ -15,12 +15,13 @@ estimate, and the three finite-Gram corrections into a common-ambient
 open-chain projector bound uniform in the spectator length.
 
 **Scope restriction (Nachtergaele C3 coefficient):** The coefficient proved here is a
-reconstructed substitute sufficient for condition C3, not the optimized rational numerator
-quoted from Fannes--Nachtergaele--Werner in Nachtergaele, equation (6.1). See
+reconstructed substitute for the open-chain projector estimate, not the optimized rational
+numerator quoted in Nachtergaele, equation (6.1). See
 `docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
 
 ## Main results
 
+* `MPSTensor.IsPrimitiveMPS.wholeIncrement_groundProjection_defect_le_geometric`
 * `MPSTensor.IsPrimitiveMPS.openChain_groundProjection_defect_le_geometric`
 -/
 
@@ -160,6 +161,393 @@ theorem c3CenteredProjectorResidualES_norm_le [NeZero D]
         (mul_nonneg (norm_nonneg R) (norm_nonneg Pleft))
         (Real.sqrt_nonneg _)
     _ = _ := by ring
+
+/-- Norm bound for the whole-increment centered physical sandwich. -/
+theorem wholeIncrementCenteredProjectorResidualES_norm_le [NeZero D]
+    (A : MPSTensor d D) (K L Q : ℕ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosDef)
+    (hLocalTail : Function.Injective (groundSpaceMapES A (L + Q)))
+    (hLocalLeft : Function.Injective (groundSpaceMapES A (K + L))) :
+    let Itail := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (L + Q)) hLocalTail
+    let Ileft := ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + L)) hLocalLeft
+    ‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
+        hLocalTail hLocalLeft‖ ≤
+      Real.sqrt ‖Itail‖ *
+        ‖wholeIncrementCenteredResidualES A K L Q ρ
+          (ne_of_gt hρ.trace_pos)‖ * Real.sqrt ‖Ileft‖ := by
+  dsimp only
+  let Ptail := (reassocTailBoundaryMapES A K L Q).comp
+    (ContinuousLinearMap.inverseGram (reassocTailBoundaryMapES A K L Q)
+      ((physicalReassocES (d := d) K L Q).injective.comp
+        (tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+          A K (L + Q) hLocalTail)))
+  let R := wholeIncrementCenteredResidualES A K L Q ρ
+    (ne_of_gt hρ.trace_pos)
+  let Pleft := (ContinuousLinearMap.inverseGram
+    (leftBoundaryMapES A (K + L) Q)
+      (leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+        A (K + L) Q hLocalLeft)).comp
+          (leftBoundaryMapES A (K + L) Q).adjoint
+  simp only [wholeIncrementCenteredProjectorResidualES]
+  rw [← inverseGram_reassocTailBoundaryMapES_eq_fiberwise_inverseGram
+    A K L Q hLocalTail]
+  rw [← inverseGram_leftBoundaryMapES_eq_fiberwise_inverseGram
+    A (K + L) Q hLocalLeft]
+  change ‖Ptail.comp (R.comp Pleft)‖ ≤ _
+  calc
+    ‖Ptail.comp (R.comp Pleft)‖ ≤ ‖Ptail‖ * ‖R.comp Pleft‖ :=
+      ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ ‖Ptail‖ * (‖R‖ * ‖Pleft‖) := by
+      gcongr
+      exact ContinuousLinearMap.opNorm_comp_le _ _
+    _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (L + Q)) hLocalTail‖ * (‖R‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + L)) hLocalLeft‖) := by
+      have hPtail : ‖Ptail‖ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (L + Q)) hLocalTail‖ := by
+        dsimp only [Ptail]
+        exact norm_reassocTailBoundaryMapES_comp_inverseGram_le_sqrt
+          A K L Q hLocalTail
+      have hPleft : ‖Pleft‖ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + L)) hLocalLeft‖ := by
+        dsimp only [Pleft]
+        exact norm_inverseGram_comp_leftBoundaryMapES_adjoint_le_sqrt
+          A (K + L) Q hLocalLeft
+      exact mul_le_mul hPtail
+        (mul_le_mul_of_nonneg_left hPleft (norm_nonneg R))
+        (mul_nonneg (norm_nonneg R) (norm_nonneg Pleft))
+        (Real.sqrt_nonneg _)
+    _ = _ := by ring
+
+set_option maxHeartbeats 800000 in
+-- The four-term operator-norm assembly requires extra elaboration budget.
+/-- A geometric-over-denominator estimate for a whole suffix increment.
+The decay is controlled by the overlap length `L`; the constants are uniform in
+both the prefix length `K` and suffix increment `Q`. -/
+theorem IsPrimitiveMPS.wholeIncrement_groundProjection_defect_le_geometric
+    [NeZero D] {A : MPSTensor d D}
+    {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ C c r : ℝ,
+      0 < C ∧ 0 < c ∧ 0 < r ∧ r < 1 ∧
+      ∀ K L Q : ℕ, 1 ≤ L → c * r ^ L < 1 →
+        ‖(reassocTailBoundaryMapES A K L Q).range.starProjection ∘L
+              (leftBoundaryMapES A (K + L) Q).range.starProjection -
+            (groundSpaceES A (K + L + Q)).starProjection‖ ≤
+          (1 - c * r ^ L)⁻¹ * (C * r ^ L) := by
+  let Kinf := Matrix.gramReshuffle
+    (fixedPointProj ρ (ne_of_gt hρ.trace_pos))
+  let Iinf := Ring.inverse Kinf
+  obtain ⟨g, c, r, hg, hc, hr_pos, hr_lt_one, hc_eq, hGramInv⟩ :=
+    hP.groundSpaceMapES_geometric_inverseGram_bounds hρ
+  obtain ⟨C_T, hC_T, hTail⟩ := hP.tailVirtualMapES_norm_uniform
+  have hKinfUnit : IsUnit Kinf := by
+    simpa only [Kinf] using Matrix.gramReshuffle_fixedPointProj_isUnit hρ
+  have hIinfUnit : IsUnit Iinf := by
+    simpa only [Iinf] using hKinfUnit.ringInverse
+  have hIinf_pos : 0 < ‖Iinf‖ := norm_pos_iff.mpr hIinfUnit.ne_zero
+  let M := ‖Kinf‖ * ‖Iinf‖
+  let C := 4 * (‖Iinf‖ * C_T * g * (M + 1))
+  have hC : 0 < C := by
+    dsimp only [C, M]
+    positivity
+  refine ⟨C, c, r, hC, hc, hr_pos, hr_lt_one, ?_⟩
+  intro K L Q hL hsmall
+  have hsmall_of_le {n : ℕ} (hLn : L ≤ n) : c * r ^ n < 1 := by
+    have hpow : r ^ n ≤ r ^ L :=
+      pow_le_pow_of_le_one hr_pos.le hr_lt_one.le hLn
+    exact (mul_le_mul_of_nonneg_left hpow hc.le).trans_lt hsmall
+  obtain ⟨hGramL, -⟩ := hGramInv L hL
+  obtain ⟨hGramTail, hTailPoint⟩ := hGramInv (L + Q) (by omega)
+  obtain ⟨hLocalTail, -, hInvTailRaw, -⟩ :=
+    hTailPoint (hsmall_of_le (by omega))
+  obtain ⟨hGramLeft, hLeftPoint⟩ := hGramInv (K + L) (by omega)
+  obtain ⟨hLocalLeft, -, hInvLeftRaw, -⟩ :=
+    hLeftPoint (hsmall_of_le (by omega))
+  obtain ⟨hGramFull, hFullPoint⟩ := hGramInv (K + L + Q) (by omega)
+  obtain ⟨hFull, -, hInvFullRaw, -⟩ :=
+    hFullPoint (hsmall_of_le (by omega))
+  let q := (1 - c * r ^ L)⁻¹
+  let B := q * ‖Iinf‖
+  have hq_pos : 0 < q := by
+    dsimp only [q]
+    positivity
+  have hB_nonneg : 0 ≤ B := by
+    dsimp only [B]
+    positivity
+  have hInvTail : ‖ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (L + Q)) hLocalTail‖ ≤ B := by
+    calc
+      _ ≤ (1 - c * r ^ (L + Q))⁻¹ * ‖Iinf‖ := hInvTailRaw
+      _ ≤ q * ‖Iinf‖ := by
+        gcongr
+        exact inverse_one_sub_geometric_le_base hc hr_pos hr_lt_one
+          (by omega) hsmall
+      _ = B := rfl
+  have hInvLeft : ‖ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + L)) hLocalLeft‖ ≤ B := by
+    calc
+      _ ≤ (1 - c * r ^ (K + L))⁻¹ * ‖Iinf‖ := hInvLeftRaw
+      _ ≤ q * ‖Iinf‖ := by
+        gcongr
+        exact inverse_one_sub_geometric_le_base hc hr_pos hr_lt_one
+          (by omega) hsmall
+      _ = B := rfl
+  have hInvFull : ‖ContinuousLinearMap.inverseGram
+      (groundSpaceMapES A (K + L + Q)) hFull‖ ≤ B := by
+    calc
+      _ ≤ (1 - c * r ^ (K + L + Q))⁻¹ * ‖Iinf‖ := hInvFullRaw
+      _ ≤ q * ‖Iinf‖ := by
+        gcongr
+        exact inverse_one_sub_geometric_le_base hc hr_pos hr_lt_one
+          (by omega) hsmall
+      _ = B := rfl
+  have hSqrtTailLeft :
+      Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (L + Q)) hLocalTail‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + L)) hLocalLeft‖ ≤ B :=
+    sqrt_mul_sqrt_le_of_le hB_nonneg hInvTail hInvLeft
+  have hSqrtTailFull :
+      Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (L + Q)) hLocalTail‖ *
+        Real.sqrt ‖ContinuousLinearMap.inverseGram
+          (groundSpaceMapES A (K + L + Q)) hFull‖ ≤ B :=
+    sqrt_mul_sqrt_le_of_le hB_nonneg hInvTail hInvFull
+  have hpow {n : ℕ} (hLn : L ≤ n) : r ^ n ≤ r ^ L :=
+    pow_le_pow_of_le_one hr_pos.le hr_lt_one.le hLn
+  have hGramTailBase : ‖groundSpaceGram A (L + Q) - Kinf‖ ≤ g * r ^ L :=
+    hGramTail.trans (mul_le_mul_of_nonneg_left (hpow (by omega)) hg.le)
+  have hGramLeftBase : ‖groundSpaceGram A (K + L) - Kinf‖ ≤ g * r ^ L :=
+    hGramLeft.trans (mul_le_mul_of_nonneg_left (hpow (by omega)) hg.le)
+  have hGramFullBase : ‖groundSpaceGram A (K + L + Q) - Kinf‖ ≤ g * r ^ L :=
+    hGramFull.trans (mul_le_mul_of_nonneg_left (hpow (by omega)) hg.le)
+  have hCenterVirtual :
+      ‖wholeIncrementCenteredResidualES A K L Q ρ
+        (ne_of_gt hρ.trace_pos)‖ ≤ g * r ^ L * C_T := by
+    calc
+      _ ≤ ‖groundSpaceGram A L - Kinf‖ * ‖tailVirtualMapES A K‖ := by
+        simpa only [Kinf] using
+          hP.wholeIncrementCenteredResidualES_norm_le hρ K L Q
+      _ ≤ (g * r ^ L) * C_T :=
+        mul_le_mul hGramL (hTail K) (norm_nonneg _)
+          (mul_nonneg hg.le (pow_nonneg hr_pos.le _))
+  let base := ‖Iinf‖ * C_T * g * (M + 1)
+  have hbase_nonneg : 0 ≤ base := by
+    dsimp only [base, M]
+    positivity
+  have hM_nonneg : 0 ≤ M := by
+    dsimp only [M]
+    positivity
+  have hFactorBounds : 1 ≤ M + 1 ∧ M ≤ M + 1 := by
+    constructor <;> linarith
+  obtain ⟨hOne_le, hM_le⟩ := hFactorBounds
+  have hTerm (x : ℝ) (hx : x ≤ M + 1) :
+      q * ((‖Iinf‖ * C_T * g * x) * r ^ L) ≤ q * (base * r ^ L) := by
+    apply mul_le_mul_of_nonneg_left _ hq_pos.le
+    apply mul_le_mul_of_nonneg_right _ (pow_nonneg hr_pos.le _)
+    dsimp only [base]
+    simpa only [mul_assoc] using mul_le_mul_of_nonneg_left hx
+      (mul_nonneg (mul_nonneg (norm_nonneg Iinf) hC_T.le) hg.le)
+  have hCenter : ‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
+      hLocalTail hLocalLeft‖ ≤ q * (base * r ^ L) := by
+    calc
+      _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (L + Q)) hLocalTail‖ *
+          ‖wholeIncrementCenteredResidualES A K L Q ρ
+            (ne_of_gt hρ.trace_pos)‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + L)) hLocalLeft‖ :=
+        wholeIncrementCenteredProjectorResidualES_norm_le A K L Q ρ hρ
+          hLocalTail hLocalLeft
+      _ = (Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (L + Q)) hLocalTail‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + L)) hLocalLeft‖) *
+          ‖wholeIncrementCenteredResidualES A K L Q ρ
+            (ne_of_gt hρ.trace_pos)‖ := by ring
+      _ ≤ B * ((g * r ^ L) * C_T) :=
+        mul_le_mul hSqrtTailLeft hCenterVirtual (norm_nonneg _) hB_nonneg
+      _ ≤ q * (base * r ^ L) := by
+        dsimp only [B, base]
+        calc
+          q * ‖Iinf‖ * (g * r ^ L * C_T) =
+              q * ((‖Iinf‖ * C_T * g) * r ^ L) := by ring
+          _ ≤ q * (base * r ^ L) := by
+            simpa only [mul_one] using hTerm 1 hOne_le
+  have hQTail : ‖wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
+      hLocalTail hFull‖ ≤ q * (base * r ^ L) := by
+    calc
+      _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (L + Q)) hLocalTail‖ *
+          ‖groundSpaceGram A (L + Q) - Kinf‖ * ‖tailVirtualMapES A K‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + L + Q)) hFull‖ := by
+        simpa only [Kinf] using wholeIncrementTailFiniteGramCorrectionES_norm_le
+          A K L Q ρ hρ hLocalTail hFull
+      _ = (Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (L + Q)) hLocalTail‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + L + Q)) hFull‖) *
+          (‖groundSpaceGram A (L + Q) - Kinf‖ * ‖tailVirtualMapES A K‖) := by ring
+      _ ≤ B * ((g * r ^ L) * C_T) := by
+        apply mul_le_mul hSqrtTailFull
+        · exact mul_le_mul hGramTailBase (hTail K) (norm_nonneg _)
+            (mul_nonneg hg.le (pow_nonneg hr_pos.le _))
+        · exact mul_nonneg (norm_nonneg _) (norm_nonneg _)
+        · exact hB_nonneg
+      _ ≤ q * (base * r ^ L) := by
+        dsimp only [B, base]
+        calc
+          q * ‖Iinf‖ * (g * r ^ L * C_T) =
+              q * ((‖Iinf‖ * C_T * g) * r ^ L) := by ring
+          _ ≤ q * (base * r ^ L) := by
+            simpa only [mul_one] using hTerm 1 hOne_le
+  have hQFull : ‖wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
+      hLocalTail hFull‖ ≤ q * (base * r ^ L) := by
+    calc
+      _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (L + Q)) hLocalTail‖ * ‖Kinf‖ *
+          ‖tailVirtualMapES A K‖ * ‖Iinf‖ *
+          ‖groundSpaceGram A (K + L + Q) - Kinf‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + L + Q)) hFull‖ := by
+        simpa only [Kinf, Iinf] using wholeIncrementFullInverseGramCorrectionES_norm_le
+          A K L Q ρ hρ hLocalTail hFull
+      _ = (Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (L + Q)) hLocalTail‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + L + Q)) hFull‖) *
+          (M * ‖tailVirtualMapES A K‖ *
+            ‖groundSpaceGram A (K + L + Q) - Kinf‖) := by
+        dsimp only [M]
+        ring
+      _ ≤ B * (M * C_T * (g * r ^ L)) := by
+        have hInner : M * ‖tailVirtualMapES A K‖ *
+            ‖groundSpaceGram A (K + L + Q) - Kinf‖ ≤
+            M * C_T * (g * r ^ L) := by
+          exact mul_le_mul
+            (mul_le_mul_of_nonneg_left (hTail K) hM_nonneg) hGramFullBase
+            (norm_nonneg _) (mul_nonneg hM_nonneg hC_T.le)
+        exact mul_le_mul hSqrtTailFull hInner
+          (mul_nonneg (mul_nonneg hM_nonneg (norm_nonneg _)) (norm_nonneg _))
+          hB_nonneg
+      _ ≤ q * (base * r ^ L) := by
+        dsimp only [B, base]
+        calc
+          q * ‖Iinf‖ * (M * C_T * (g * r ^ L)) =
+              q * ((‖Iinf‖ * C_T * g * M) * r ^ L) := by ring
+          _ ≤ q * (base * r ^ L) := hTerm M hM_le
+  have hLeftVirtual : ‖leftVirtualMapES A Q‖ ≤ 1 :=
+    leftVirtualMapES_norm_le_one_of_leftCanonical A Q hP.norm
+  have hQLeft : ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
+      hLocalTail hLocalLeft‖ ≤ q * (base * r ^ L) := by
+    calc
+      _ ≤ Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (L + Q)) hLocalTail‖ * ‖Kinf‖ *
+          ‖tailVirtualMapES A K‖ * ‖Iinf‖ * ‖leftVirtualMapES A Q‖ *
+          ‖groundSpaceGram A (K + L) - Kinf‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + L)) hLocalLeft‖ := by
+        simpa only [Kinf, Iinf] using wholeIncrementLeftFiniteGramCorrectionES_norm_le
+          A K L Q ρ hρ hLocalTail hLocalLeft
+      _ = (Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (L + Q)) hLocalTail‖ *
+          Real.sqrt ‖ContinuousLinearMap.inverseGram
+            (groundSpaceMapES A (K + L)) hLocalLeft‖) *
+          (M * ‖tailVirtualMapES A K‖ * ‖leftVirtualMapES A Q‖ *
+            ‖groundSpaceGram A (K + L) - Kinf‖) := by
+        dsimp only [M]
+        ring
+      _ ≤ B * (M * C_T * 1 * (g * r ^ L)) := by
+        have hPrefix : M * ‖tailVirtualMapES A K‖ * ‖leftVirtualMapES A Q‖ ≤
+            M * C_T * 1 := by
+          calc
+            M * ‖tailVirtualMapES A K‖ * ‖leftVirtualMapES A Q‖ ≤
+                M * C_T * ‖leftVirtualMapES A Q‖ := by
+              gcongr
+              exact hTail K
+            _ ≤ M * C_T * 1 := by
+              gcongr
+        have hInner : M * ‖tailVirtualMapES A K‖ * ‖leftVirtualMapES A Q‖ *
+            ‖groundSpaceGram A (K + L) - Kinf‖ ≤
+            M * C_T * 1 * (g * r ^ L) :=
+          mul_le_mul hPrefix hGramLeftBase (norm_nonneg _)
+            (mul_nonneg (mul_nonneg hM_nonneg hC_T.le) zero_le_one)
+        exact mul_le_mul hSqrtTailLeft hInner
+          (mul_nonneg
+            (mul_nonneg (mul_nonneg hM_nonneg (norm_nonneg _)) (norm_nonneg _))
+            (norm_nonneg _)) hB_nonneg
+      _ ≤ q * (base * r ^ L) := by
+        dsimp only [B, base]
+        calc
+          q * ‖Iinf‖ * (M * C_T * 1 * (g * r ^ L)) =
+              q * ((‖Iinf‖ * C_T * g * M) * r ^ L) := by ring
+          _ ≤ q * (base * r ^ L) := hTerm M hM_le
+  have hInjectiveDefect :
+      ‖(ContinuousLinearMap.injectiveRangeProjector
+          (reassocTailBoundaryMapES A K L Q)
+            ((physicalReassocES (d := d) K L Q).injective.comp
+              (tailBoundaryMapES_injective_of_groundSpaceMapES_injective
+                A K (L + Q) hLocalTail))).comp
+          (ContinuousLinearMap.injectiveRangeProjector
+            (leftBoundaryMapES A (K + L) Q)
+              (leftBoundaryMapES_injective_of_groundSpaceMapES_injective
+                A (K + L) Q hLocalLeft)) -
+        ContinuousLinearMap.injectiveRangeProjector
+          (groundSpaceMapES A (K + L + Q)) hFull‖ ≤
+        q * (C * r ^ L) := by
+    rw [wholeIncrement_injectiveRangeProjector_residual_eq_centered_sub_corrections
+      A K L Q ρ hρ hLocalTail hLocalLeft hFull]
+    calc
+      _ ≤ ‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
+              hLocalTail hLocalLeft‖ +
+          ‖wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
+            hLocalTail hFull‖ +
+          ‖wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
+            hLocalTail hFull‖ +
+          ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
+            hLocalTail hLocalLeft‖ := by
+        calc
+          _ ≤ ‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
+                hLocalTail hLocalLeft -
+              wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
+                hLocalTail hFull -
+              wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
+                hLocalTail hFull‖ +
+              ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
+                hLocalTail hLocalLeft‖ := norm_sub_le _ _
+          _ ≤ (‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
+                hLocalTail hLocalLeft -
+              wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
+                hLocalTail hFull‖ +
+              ‖wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
+                hLocalTail hFull‖) +
+              ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
+                hLocalTail hLocalLeft‖ := by
+            gcongr
+            exact norm_sub_le _ _
+          _ ≤ ((‖wholeIncrementCenteredProjectorResidualES A K L Q ρ hρ
+                hLocalTail hLocalLeft‖ +
+              ‖wholeIncrementTailFiniteGramCorrectionES A K L Q ρ hρ
+                hLocalTail hFull‖) +
+              ‖wholeIncrementFullInverseGramCorrectionES A K L Q ρ hρ
+                hLocalTail hFull‖) +
+              ‖wholeIncrementLeftFiniteGramCorrectionES A K L Q ρ hρ
+                hLocalTail hLocalLeft‖ := by
+            gcongr
+            exact norm_sub_le _ _
+          _ = _ := by ring
+      _ ≤ q * (base * r ^ L) + q * (base * r ^ L) +
+          q * (base * r ^ L) + q * (base * r ^ L) := by gcongr
+      _ = q * (C * r ^ L) := by
+        dsimp only [C, base]
+        ring
+  simpa only [ContinuousLinearMap.injectiveRangeProjector_eq_starProjection,
+    range_groundSpaceMapES, q] using hInjectiveDefect
 
 /-- A spectator-uniform geometric-over-denominator estimate for the open-chain
 C3 projector defect. The constants are reconstructed from the limiting Gram

--- a/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
+++ b/TNLean/MPS/ParentHamiltonian/FNWContraction.lean
@@ -225,8 +225,8 @@ theorem wholeIncrementCenteredProjectorResidualES_norm_le [NeZero D]
 set_option maxHeartbeats 800000 in
 -- The four-term operator-norm assembly requires extra elaboration budget.
 /-- A geometric-over-denominator estimate for a whole suffix increment.
-The decay is controlled by the overlap length `L`; the constants are uniform in
-both the prefix length `K` and suffix increment `Q`. -/
+The decay is controlled by the overlap length \(L\); the constants are uniform in
+both the prefix length \(K\) and suffix increment \(Q\). -/
 theorem IsPrimitiveMPS.wholeIncrement_groundProjection_defect_le_geometric
     [NeZero D] {A : MPSTensor d D}
     {ρ : Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
@@ -17,6 +17,12 @@ blocked-chain filtration step.
 
 ## Main results
 
+* `MPSTensor.IsPrimitiveMPS.
+    exists_uniform_wholeIncrement_defect_le_seven_sixteenths`
+  chooses one original-site scale uniformly for every prefix length.
+* `MPSTensor.IsPrimitiveMPS.
+    exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths`
+  specializes the uniform estimate to three equal original-site blocks.
 * `MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold`
   chooses a block-injective overlap length and one uniform C3 defect coefficient.
 * `MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold`
@@ -70,13 +76,77 @@ private theorem tendsto_geometric_c3_coefficient_mul_sqrt
   simpa only [mul_assoc, mul_left_comm, mul_comm, one_mul, zero_mul, mul_zero] using
     hinv.mul hscaled
 
+private theorem tendsto_geometric_coefficient
+    {C c r : ℝ} (hr : 0 ≤ r) (hr_lt_one : r < 1) :
+    Tendsto (fun n : ℕ => (1 - c * r ^ n)⁻¹ * (C * r ^ n))
+      atTop (𝓝 0) := by
+  have hr_pow : Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) :=
+    tendsto_pow_atTop_nhds_zero_of_lt_one hr hr_lt_one
+  have hden : Tendsto (fun n : ℕ => 1 - c * r ^ n) atTop (𝓝 1) := by
+    simpa using tendsto_const_nhds.sub (tendsto_const_nhds.mul hr_pow)
+  have hinv : Tendsto (fun n : ℕ => (1 - c * r ^ n)⁻¹) atTop (𝓝 1) := by
+    simpa using hden.inv₀ one_ne_zero
+  have hscaled : Tendsto (fun n : ℕ => C * r ^ n) atTop (𝓝 0) := by
+    simpa using tendsto_const_nhds.mul hr_pow
+  simpa using hinv.mul hscaled
+
+/-- There is a positive block-injective length \(p\), measured in sites of the
+input tensor, such that the whole-increment projector defect with overlap and
+suffix lengths \(L=Q=p\) is at most \(7/16\) for every prefix length \(K\). -/
+theorem IsPrimitiveMPS.exists_uniform_wholeIncrement_defect_le_seven_sixteenths
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ p : ℕ,
+      0 < p ∧ IsNBlkInjective A p ∧
+        ∀ K : ℕ,
+          ‖(reassocTailBoundaryMapES A K p p).range.starProjection ∘L
+                (leftBoundaryMapES A (K + p) p).range.starProjection -
+              (groundSpaceES A (K + p + p)).starProjection‖ ≤ 7 / 16 := by
+  obtain ⟨C, c, r, hC, hc, hr, hr_lt_one, hDefect⟩ :=
+    hP.wholeIncrement_groundProjection_defect_le_geometric hρ
+  obtain ⟨L, hLpos, hLinj⟩ := isNormal_of_isPrimitiveMPS_with_posDef hP hρ
+  have hr_pow : Tendsto (fun n : ℕ => r ^ n) atTop (𝓝 0) :=
+    tendsto_pow_atTop_nhds_zero_of_lt_one hr.le hr_lt_one
+  have hsmall_lim : Tendsto (fun n : ℕ => c * r ^ n) atTop (𝓝 0) := by
+    simpa using tendsto_const_nhds.mul hr_pow
+  have hcoefficient_lim :=
+    tendsto_geometric_coefficient (C := C) (c := c) hr.le hr_lt_one
+  have hsmall : ∀ᶠ n : ℕ in atTop, c * r ^ n < 1 :=
+    (tendsto_order.1 hsmall_lim).2 1 zero_lt_one
+  have hcoefficient : ∀ᶠ n : ℕ in atTop,
+      (1 - c * r ^ n)⁻¹ * (C * r ^ n) < 7 / 16 :=
+    (tendsto_order.1 hcoefficient_lim).2 (7 / 16) (by norm_num)
+  have hlarge : ∀ᶠ n : ℕ in atTop, max 1 L ≤ n := eventually_ge_atTop _
+  obtain ⟨p, hp_large, hp_small, hp_coefficient⟩ :=
+    (hlarge.and (hsmall.and hcoefficient)).exists
+  have hp : 0 < p := lt_of_lt_of_le (by omega) hp_large
+  have hLle : L ≤ p := le_trans (le_max_right 1 L) hp_large
+  have hInj : IsNBlkInjective A p := isNBlkInjective_of_le hLpos hLinj hLle
+  refine ⟨p, hp, hInj, fun K ↦ ?_⟩
+  exact (hDefect K p p (by omega) hp_small).trans hp_coefficient.le
+
+/-- At the length \(p\) chosen uniformly above, taking the prefix length
+\(K=p\) gives three consecutive blocks of \(p\) original sites and projector
+defect at most \(7/16\). -/
+theorem IsPrimitiveMPS.exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths
+    [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :
+    ∃ p : ℕ,
+      0 < p ∧ IsNBlkInjective A p ∧
+        ‖(reassocTailBoundaryMapES A p p p).range.starProjection ∘L
+              (leftBoundaryMapES A (p + p) p).range.starProjection -
+            (groundSpaceES A (p + p + p)).starProjection‖ ≤ 7 / 16 := by
+  obtain ⟨p, hp, hInj, hDefect⟩ :=
+    hP.exists_uniform_wholeIncrement_defect_le_seven_sixteenths hρ
+  exact ⟨p, hp, hInj, hDefect p⟩
+
 /-- A primitive MPS with faithful fixed point has a block-injective overlap length
 at which the uniform open-chain ground-projector defect satisfies Nachtergaele's
 condition C3, arXiv:cond-mat/9410110, eq. (2.4).
 
 The coefficient is the geometric-over-denominator bound reconstructed in
 `openChain_groundProjection_defect_le_geometric`. It is sufficient for C3; this
-statement does not assert the optimized FNW numerator from Nachtergaele, Section 6. -/
+statement does not assert the optimized numerator quoted in Nachtergaele, Section 6. -/
 theorem IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold
     [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ) (hρ : ρ.PosDef) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/C3Threshold.lean
@@ -17,11 +17,9 @@ blocked-chain filtration step.
 
 ## Main results
 
-* `MPSTensor.IsPrimitiveMPS.
-    exists_uniform_wholeIncrement_defect_le_seven_sixteenths`
+* `MPSTensor.IsPrimitiveMPS.exists_uniform_wholeIncrement_defect_le_seven_sixteenths`
   chooses one original-site scale uniformly for every prefix length.
-* `MPSTensor.IsPrimitiveMPS.
-    exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths`
+* `MPSTensor.IsPrimitiveMPS.exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths`
   specializes the uniform estimate to three equal original-site blocks.
 * `MPSTensor.IsPrimitiveMPS.exists_openChain_groundProjection_defect_lt_c3_threshold`
   chooses a block-injective overlap length and one uniform C3 defect coefficient.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1446,8 +1446,8 @@ norm estimate is derived here.
     \lean{MPSTensor.wholeIncrementCenteredProjectorResidualES_norm_le}
     \leanok
     \uses{def:whole_increment_centered_projector_sandwich,
-        thm:reassociated_tail_pseudoinverse_bound,
-        thm:left_spectator_pseudoinverse_bound}
+        def:whole_increment_centered_residual, def:inverse_gram,
+        def:ground_space_map_es}
     Assume $D>0$, let $\rho$ be positive definite, and suppose that
     $\Gamma_{L+Q}^{\mathrm{ES}}$ and $\Gamma_{K+L}^{\mathrm{ES}}$ are
     injective.  Put
@@ -1467,6 +1467,8 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{def:whole_increment_centered_projector_sandwich,
+        thm:reassociated_tail_inverse_gram,
+        thm:spectator_boundary_direct_sum_gram,
         thm:reassociated_tail_pseudoinverse_bound,
         thm:left_spectator_pseudoinverse_bound}
     Apply submultiplicativity to the centered residual between the two
@@ -2082,12 +2084,8 @@ norm estimate is derived here.
     \label{thm:whole_increment_ground_projection_defect_geometric}
     \lean{MPSTensor.IsPrimitiveMPS.wholeIncrement_groundProjection_defect_le_geometric}
     \leanok
-    \uses{thm:whole_increment_centered_projector_sandwich_bound,
-        thm:whole_increment_finite_gram_corrections,
-        thm:whole_increment_correction_bounds,
-        thm:primitive_whole_increment_centered_residual_bound,
-        thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
-        thm:primitive_tail_virtual_map_norm_uniform}
+    \uses{def:primitive_mps, def:reassociated_tail_boundary_map,
+        def:spectator_boundary_maps_es, def:ground_space_es}
     Let $A$ be primitive with positive-definite fixed point $\rho$ and nonzero
     bond dimension.  There are constants $C,c,r>0$, with $r<1$, such that for
     all $K,L,Q\in\mathbb N$ with $L\geq1$ and $cr^L<1$,
@@ -2106,12 +2104,16 @@ norm estimate is derived here.
 
 \begin{proof}
     \leanok
-    \uses{thm:whole_increment_centered_projector_sandwich_bound,
-        thm:whole_increment_finite_gram_corrections,
-        thm:whole_increment_correction_bounds,
+    \uses{thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
+        thm:primitive_tail_virtual_map_norm_uniform,
+        thm:fixed_point_gram_metric_is_unit,
         thm:primitive_whole_increment_centered_residual_bound,
-        thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
-        thm:primitive_tail_virtual_map_norm_uniform}
+        thm:whole_increment_left_virtual_norm,
+        thm:whole_increment_centered_projector_sandwich_bound,
+        thm:whole_increment_correction_bounds,
+        thm:whole_increment_finite_gram_corrections,
+        thm:injective_range_projector_inverse_gram,
+        thm:range_ground_space_map_es}
     Bound the centered sandwich and the three finite-Gram corrections in the
     exact projector telescope.  Geometric convergence of the finite Grams and
     the uniform tail-map bound make each term at most a fixed multiple of

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1441,6 +1441,39 @@ norm estimate is derived here.
     boundary pseudoinverse.
 \end{definition}
 
+\begin{theorem}[Norm bound for the whole-increment centered projector sandwich]
+    \label{thm:whole_increment_centered_projector_sandwich_bound}
+    \lean{MPSTensor.wholeIncrementCenteredProjectorResidualES_norm_le}
+    \leanok
+    \uses{def:whole_increment_centered_projector_sandwich,
+        thm:reassociated_tail_pseudoinverse_bound,
+        thm:left_spectator_pseudoinverse_bound}
+    Assume $D>0$, let $\rho$ be positive definite, and suppose that
+    $\Gamma_{L+Q}^{\mathrm{ES}}$ and $\Gamma_{K+L}^{\mathrm{ES}}$ are
+    injective.  Put
+    \begin{align}
+      I_t&=\mathcal K_{L+Q}^{-1},&
+      I_\ell&=\mathcal K_{K+L}^{-1}.
+    \end{align}
+    Then the centered physical sandwich $\widehat R_{K,L,Q}$ satisfies
+    \begin{align}
+      \lVert\widehat R_{K,L,Q}\rVert
+      &\leq \sqrt{\lVert I_t\rVert}\,
+        \lVert R_{K,L,Q}\rVert\,
+        \sqrt{\lVert I_\ell\rVert}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:whole_increment_centered_projector_sandwich,
+        thm:reassociated_tail_pseudoinverse_bound,
+        thm:left_spectator_pseudoinverse_bound}
+    Apply submultiplicativity to the centered residual between the two
+    pseudoinverse factors.  Bound the exterior factors by the square roots of
+    the corresponding inverse-Gram norms.
+\end{proof}
+
 \begin{theorem}[Whole-increment physical correction telescope]
     \label{thm:whole_increment_finite_gram_corrections}
     \lean{MPSTensor.wholeIncrement_injectiveRangeProjector_residual_eq_centered_sub_corrections}
@@ -2040,6 +2073,101 @@ norm estimate is derived here.
     range identities replace the three inverse-Gram range projectors by the
     tail, left, and full physical ground-space projectors.  The coefficient is
     the displayed reconstruction, not the optimized FNW rational numerator.
+\end{proof}
+
+% The following estimate is reconstructed from the exact inverse-Gram
+% factorization.  It is not attributed to FNW and does not claim the optimized
+% numerator in Nachtergaele's equation (6.1).
+\begin{theorem}[Prefix-uniform geometric whole-increment projector defect]
+    \label{thm:whole_increment_ground_projection_defect_geometric}
+    \lean{MPSTensor.IsPrimitiveMPS.wholeIncrement_groundProjection_defect_le_geometric}
+    \leanok
+    \uses{thm:whole_increment_centered_projector_sandwich_bound,
+        thm:whole_increment_finite_gram_corrections,
+        thm:whole_increment_correction_bounds,
+        thm:primitive_whole_increment_centered_residual_bound,
+        thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
+        thm:primitive_tail_virtual_map_norm_uniform}
+    Let $A$ be primitive with positive-definite fixed point $\rho$ and nonzero
+    bond dimension.  There are constants $C,c,r>0$, with $r<1$, such that for
+    all $K,L,Q\in\mathbb N$ with $L\geq1$ and $cr^L<1$,
+    \begin{align}
+      &\left\lVert
+        P^{\mathrm{tail}}_{K;L,Q}P^{\mathrm{left}}_{K+L,Q}
+        -P_{\mathcal G_{K+L+Q}^{\mathrm{ES}}(A)}
+      \right\rVert
+      \leq \frac{Cr^L}{1-cr^L}.
+    \end{align}
+    Here $P^{\mathrm{tail}}_{K;L,Q}$ is the range projector of the
+    reassociated tail boundary map and $P^{\mathrm{left}}_{K+L,Q}$ is the
+    range projector of the left boundary map.  The constants are independent
+    of both the prefix length $K$ and the suffix length $Q$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:whole_increment_centered_projector_sandwich_bound,
+        thm:whole_increment_finite_gram_corrections,
+        thm:whole_increment_correction_bounds,
+        thm:primitive_whole_increment_centered_residual_bound,
+        thm:primitive_ground_space_map_geometric_inverse_gram_bounds,
+        thm:primitive_tail_virtual_map_norm_uniform}
+    Bound the centered sandwich and the three finite-Gram corrections in the
+    exact projector telescope.  Geometric convergence of the finite Grams and
+    the uniform tail-map bound make each term at most a fixed multiple of
+    $r^L/(1-cr^L)$, uniformly in $K$ and $Q$.  Sum the four estimates and
+    absorb their constants into $C$.
+\end{proof}
+
+\begin{theorem}[Uniform whole-increment defect at the coefficient $7/16$]
+    \label{thm:uniform_whole_increment_defect_seven_sixteenths}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_uniform_wholeIncrement_defect_le_seven_sixteenths}
+    \leanok
+    \uses{thm:whole_increment_ground_projection_defect_geometric,
+        thm:normal_from_primitive_posdef, thm:wordspan_blk_inj_succ}
+    Let $A$ be primitive with positive-definite fixed point $\rho$ and nonzero
+    bond dimension.  There is an integer $p>0$, measured in sites of $A$, such
+    that $A$ is $p$-block injective and, for every $K\in\mathbb N$,
+    \begin{align}
+      \left\lVert
+        P^{\mathrm{tail}}_{K;p,p}P^{\mathrm{left}}_{K+p,p}
+        -P_{\mathcal G_{K+2p}^{\mathrm{ES}}(A)}
+      \right\rVert
+      &\leq \frac{7}{16}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:whole_increment_ground_projection_defect_geometric,
+        thm:normal_from_primitive_posdef, thm:wordspan_blk_inj_succ}
+    Choose $p$ above a positive block-injectivity length and sufficiently large
+    that $cr^p<1$ and $Cr^p/(1-cr^p)<7/16$.  Block injectivity propagates to
+    $p$, and the geometric whole-increment estimate applies with $L=Q=p$ for
+    every prefix length $K$.
+\end{proof}
+
+\begin{theorem}[Three-block whole-increment defect at the coefficient $7/16$]
+    \label{thm:three_block_whole_increment_defect_seven_sixteenths}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths}
+    \leanok
+    \uses{thm:uniform_whole_increment_defect_seven_sixteenths}
+    Under the same hypotheses, there is an integer $p>0$, measured in sites of
+    $A$, such that $A$ is $p$-block injective and
+    \begin{align}
+      \left\lVert
+        P^{\mathrm{tail}}_{p;p,p}P^{\mathrm{left}}_{2p,p}
+        -P_{\mathcal G_{3p}^{\mathrm{ES}}(A)}
+      \right\rVert
+      &\leq \frac{7}{16}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:uniform_whole_increment_defect_seven_sixteenths}
+    Apply the prefix-uniform theorem at $K=p$.  The three consecutive regions
+    then each contain exactly $p$ sites of the input tensor.
 \end{proof}
 
 \begin{theorem}[Uniform open-chain projector-defect threshold]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -859,7 +859,16 @@ and generic prerequisites now include:
     For a primitive tensor with positive-definite fixed point and nonzero bond
     dimension, it gives constants $C,c,r>0$, with $r<1$, such that for every
     prefix length $K$, overlap length $L\geq1$, and suffix length $Q$ satisfying
-    $cr^L<1$,
+    $cr^L<1$.  Write
+    \begin{align}
+      P^{\mathrm{tail}}_{K;L,Q}
+      &:=P_{\operatorname{ran}(\widetilde\Gamma^{\mathrm{tail}}_{K;L,Q})},
+      &
+      P^{\mathrm{left}}_{K+L,Q}
+      &:=P_{\operatorname{ran}(\Gamma^{\mathrm{left}}_{K+L,Q})}.
+    \end{align}
+    These are the orthogonal projectors onto the ranges of the reassociated tail and
+    left boundary maps.  Then
     \begin{align}
       \left\lVert
         P^{\mathrm{tail}}_{K;L,Q}P^{\mathrm{left}}_{K+L,Q}
@@ -1243,8 +1252,7 @@ conversion retains its proved $D^{3/2}$ norm factor inside $g$.
 
 \section{Verdict}
 
-\textbf{Verdict: the open-chain quantitative estimates are resolved, while
-source optimization and cyclic transport remain open.}  The exact
+\textbf{Verdict: scope restriction.}  The exact
 whole-increment algebra, the reconstructed prefix-uniform geometric
 C3$^\prime$-type estimate, and the three-block coefficient $7/16$ are proved.
 All lengths are measured in sites of the input tensor.  These bounds come from

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -493,7 +493,7 @@ explicit than the review paragraph: the exact constants and the cyclic-window
 blocking convention still have to be compared with the FNW, Nachtergaele, and
 Kastoryano--Lucia estimates.
 
-\section{Inverse-Gram reduction and the remaining FNW contraction}
+\section{Inverse-Gram reduction and the remaining optimized FNW comparison}
 
 For $n\ge1$, write $[n]:=\{0,\ldots,n-1\}$.  Fix an MPS tensor
 $A=\{A^s\}_{s\in[d]}$ with $A^s\in\mathbb C^{D\times D}$.  For
@@ -779,8 +779,9 @@ and generic prerequisites now include:
     These are exact unweighted identities, including empty spectator types;
     they assert no direct-sum norm estimate.  The C3 specializations are stated
     next.
-  \item The C3$^\prime$ whole-increment algebra is now separated from its
-    still-missing numerical estimate.  For a suffix increment $Q$, define the
+  \item The C3$^\prime$ whole-increment algebra and a quantitative
+    prefix-uniform estimate are now complete.  For a suffix increment $Q$,
+    define the
     left virtual map by
     \begin{align}
       J_Q^{\mathrm{left}}X
@@ -846,16 +847,41 @@ and generic prerequisites now include:
     \leanid{MPSTensor.wholeIncrementCenteredProjectorResidualES}.  The
     reassociated tail pseudoinverse bound is
     \leanid{MPSTensor.norm_reassocTailBoundaryMapES_comp_inverseGram_le_sqrt}.
+    The centered physical sandwich is controlled by
+    \leanid{MPSTensor.wholeIncrementCenteredProjectorResidualES_norm_le}.
     The three correction bounds are
     \leanid{MPSTensor.wholeIncrementTailFiniteGramCorrectionES_norm_le},
     \leanid{MPSTensor.wholeIncrementFullInverseGramCorrectionES_norm_le}, and
     \leanid{MPSTensor.wholeIncrementLeftFiniteGramCorrectionES_norm_le}.
 
-    This completed slice is exact algebra only.  It removes growth from the
-    length-$Q$ left virtual factor, factors the centered mixed term, and exposes
-    every finite-Gram correction.  It does not yet prove uniform smallness of
-    the assembled whole-increment projector defect, establish Nachtergaele's
-    C3$^\prime$ bound, or imply the three-block coefficient $7/16$.
+    The assembled quantitative estimate is
+    \leanid{MPSTensor.IsPrimitiveMPS.wholeIncrement_groundProjection_defect_le_geometric}.
+    For a primitive tensor with positive-definite fixed point and nonzero bond
+    dimension, it gives constants $C,c,r>0$, with $r<1$, such that for every
+    prefix length $K$, overlap length $L\geq1$, and suffix length $Q$ satisfying
+    $cr^L<1$,
+    \begin{align}
+      \left\lVert
+        P^{\mathrm{tail}}_{K;L,Q}P^{\mathrm{left}}_{K+L,Q}
+        -P_{\mathcal G_{K+L+Q}^{\mathrm{ES}}(A)}
+      \right\rVert
+      &\leq \frac{Cr^L}{1-cr^L}.
+    \end{align}
+    The constants are independent of both $K$ and $Q$.  This estimate is
+    reconstructed from the exact inverse-Gram telescope and is not attributed
+    to FNW.  It supplies the quantitative C3$^\prime$-type estimate needed here,
+    but it does not claim the optimized numerator in Nachtergaele's
+    equation~(6.1).
+
+    The theorem
+    \leanid{MPSTensor.IsPrimitiveMPS.exists_uniform_wholeIncrement_defect_le_seven_sixteenths}
+    then chooses one integer $p>0$, measured in sites of the input tensor, such
+    that $A$ is $p$-block injective and the preceding defect with $L=Q=p$ is at
+    most $7/16$ for every prefix length $K$.  Its specialization
+    \leanid{MPSTensor.IsPrimitiveMPS.exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths}
+    takes $K=p$ and gives the same bound for three consecutive blocks of $p$
+    original sites.  Thus prefix-uniform quantitative smallness and the
+    three-block coefficient $7/16$ are resolved in original-site units.
   \item The mixed Gram of the C3 tail map at
     \((K,l+1)\) and left map at \((K+l,1)\) is computed exactly by
     \leanid{MPSTensor.inner_tailBoundaryMapES_adjoint_leftBoundaryMapES}.
@@ -1217,14 +1243,15 @@ conversion retains its proved $D^{3/2}$ norm factor inside $g$.
 
 \section{Verdict}
 
-\textbf{Verdict: open gap, with a resolved local correction.}  The exact
-whole-increment algebra, including reassociation, the mixed Gram, the centered
-factorization, and the three finite-Gram corrections, is resolved.  The
-quantitative C3$^\prime$ estimate uniform in the filtration prefix and the
-three-block coefficient $7/16$ remain formalization gaps.  Separately, the
-open-chain C3 threshold is proved in unweighted coordinates, while the optimized
-FNW numerator and the blocked-to-cyclic parent-Hamiltonian comparison remain
-open source-comparison problems.
+\textbf{Verdict: the open-chain quantitative estimates are resolved, while
+source optimization and cyclic transport remain open.}  The exact
+whole-increment algebra, the reconstructed prefix-uniform geometric
+C3$^\prime$-type estimate, and the three-block coefficient $7/16$ are proved.
+All lengths are measured in sites of the input tensor.  These bounds come from
+the formal inverse-Gram reconstruction and are not attributed to FNW.  The
+optimized FNW numerator and its source constants remain open, as does the
+blocked-to-cyclic ground-projector comparison needed for the periodic
+parent-Hamiltonian gap theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary
- bound the whole-increment centered projector sandwich
- combine the centered term and three finite-Gram corrections into a geometric-over-denominator estimate uniform in prefix length and suffix increment
- choose one positive block-injective original-site scale $p$ with the C3-prime defect at most $7/16$ for every prefix $K$
- specialize to $K=p$ for the three consecutive $p$-site blocks required by #6152

## Source scope
The uniform theorem is the quantitative C3-prime step associated with Nachtergaele's equation (2.5). It keeps $p$ in sites of the input tensor and proves the prefix-uniform estimate before taking the three-block specialization. The coefficient $7/16$ is selected for the downstream range-two cyclic row-sum argument; it is not identified with the optimized FNW numerator.

## Validation
- `lake build TNLean.MPS.ParentHamiltonian.FNWContraction TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`

Closes #6152.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new Lean proof on the parent-Hamiltonian martingale/C3 path; errors would affect spectral-gap infrastructure, though existing open-chain C3 threshold theorems are unchanged in how they are invoked.
> 
> **Overview**
> Adds the **quantitative C3′-type step** for whole suffix increments: a geometric-over-denominator bound on the tail×left ground-projector defect that is **uniform in prefix length \(K\) and suffix increment \(Q\)**, with decay controlled by overlap length \(L\).
> 
> In `FNWContraction.lean`, the proof assembles the existing four-term inverse-Gram telescope (centered sandwich plus three finite-Gram corrections), adds small norm lemmas (`wholeIncrementCenteredProjectorResidualES_norm_le`, four-term triangle bound), and proves `IsPrimitiveMPS.wholeIncrement_groundProjection_defect_le_geometric`.
> 
> `C3Threshold.lean` then picks a **single original-site scale \(p\)** (block-injective) so that defect with \(L=Q=p\) is **≤ 7/16 for every \(K\)**, and specializes to **three consecutive \(p\)-site blocks** when \(K=p\)—closing the gap called out for downstream range-two cyclic arguments.
> 
> Blueprint ch13 and `cpgsv21_martingale_overlap.tex` are updated to record these results and to narrow scope: bounds are **reconstructed**, not the optimized FNW numerator in Nachtergaele (6.1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f648c6c1115fdb8d21e46ffd01a083fbb26d68ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->