### PR TITLE
feat(MPDO): prove Example 4.11 block probabilities

### DIFF
--- a/TNLean/MPS/MPDO/CPSVExample411BinarySupport.lean
+++ b/TNLean/MPS/MPDO/CPSVExample411BinarySupport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.MatrixCyclicTracePower
+import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.CyclicEdgeWeightTensor
 
 /-!
@@ -37,6 +38,11 @@ SAL, ZCL, or ambient-tensor equivalence is asserted here.
 * `M`: the associated cyclic-edge matrix-product tensor.
 * `cycleWeight`: the unnormalized weight of a binary cycle labeling.
 * `partitionFunction`: the sum of all binary cycle weights.
+* `internalTransitionCount`: the number of transitions internal to a retained word.
+* `internalEdgeProduct`: the product of edge weights internal to a retained word.
+* `firstLabel`: the first label of a nonempty retained word.
+* `lastLabel`: the final label of a nonempty retained word.
+* `complementPathWeight`: the complementary path weight with fixed endpoints.
 
 ## Main results
 
@@ -45,6 +51,12 @@ SAL, ZCL, or ambient-tensor equivalence is asserted here.
 * `partitionFunction_eq_trace_pow`: the cycle sum equals `tr(W^N)`.
 * `trace_weightMatrix_pow`: the closed trace-power formula.
 * `partitionFunction_closed_form`: the closed positive-length normalization.
+* `weightMatrix_pow_apply`: the closed form for every entry of a weight-matrix power.
+* `sum_complementPathWeight_eq_weightMatrix_pow`: the complementary path sum.
+* `sum_cycleWeight_append_eq_internalEdgeProduct_mul_pow`: the retained-word cycle sum.
+* `internalEdgeProduct_eq`: the transition-count formula for internal edges.
+* `reducedBlockState_apply_eq_internal_mul_pow`: the exact normalized path formula.
+* `reducedBlockState_apply`: the closed finite-ring block probability.
 -/
 
 open scoped BigOperators Matrix
@@ -82,6 +94,97 @@ def cycleWeight {N : ℕ} [NeZero N] (σ : Fin N → Fin 2) : ℂ :=
 Source: arXiv:1606.00608, Example 4.11, lines 907--924. -/
 def partitionFunction (N : ℕ) [NeZero N] : ℂ :=
   ∑ σ : Fin N → Fin 2, cycleWeight σ
+
+/-- The number of internal nearest-neighbor transitions in a binary word.
+
+This excludes the closing edge from the final site back to the first site. It is
+used below for a project-derived finite-ring consequence of CPSV16 Example 4.11. -/
+def internalTransitionCount : {L : ℕ} → (Fin L → Fin 2) → ℕ
+  | 0, _ => 0
+  | 1, _ => 0
+  | L + 2, x => (if x 0 = x 1 then 0 else 1) +
+      internalTransitionCount (fun i : Fin (L + 1) ↦ x i.succ)
+
+/-- The product of the internal edge weights of a binary word. -/
+def internalEdgeProduct {L : ℕ} (x : Fin L → Fin 2) : ℂ :=
+  ∏ i : Fin (L - 1), weightMatrix (x (Fin.castLE (Nat.sub_le L 1) i))
+    (x ⟨i.val + 1, by have hi := i.isLt; omega⟩)
+
+/-- The first label of a nonempty binary word. -/
+def firstLabel {L : ℕ} (hL : 1 ≤ L) (x : Fin L → Fin 2) : Fin 2 := x ⟨0, by omega⟩
+
+/-- The final label of a nonempty binary word. -/
+def lastLabel {L : ℕ} (hL : 1 ≤ L) (x : Fin L → Fin 2) : Fin 2 := x ⟨L - 1, by omega⟩
+
+/-- The product along the complementary path from $a$ to $b$ through the
+listed internal labels. -/
+def complementPathWeight (a b : Fin 2) : {K : ℕ} → (Fin K → Fin 2) → ℂ
+  | 0, _ => weightMatrix a b
+  | K + 1, w => weightMatrix a (w 0) *
+      complementPathWeight (w 0) b (fun i : Fin K ↦ w i.succ)
+
+@[simp] private theorem complementPathWeight_zero (a b : Fin 2) (w : Fin 0 → Fin 2) :
+    complementPathWeight a b w = weightMatrix a b := rfl
+
+@[simp] private theorem complementPathWeight_cons {K : ℕ} (a b c : Fin 2)
+    (w : Fin K → Fin 2) :
+    complementPathWeight a b (Fin.cons c w) =
+      weightMatrix a c * complementPathWeight c b w := rfl
+
+/-- The endpoint-augmented vertex list of a complementary path. -/
+private def pathVertices {R : ℕ} (a b : Fin 2) (w : Fin R → Fin 2) :
+    Fin (R + 2) → Fin 2 :=
+  Fin.cons a (Fin.snoc w b)
+
+private theorem pathVertices_tail {R : ℕ} (a b : Fin 2) (w : Fin (R + 1) → Fin 2)
+    (i : Fin (R + 2)) :
+    pathVertices (w 0) b (fun j : Fin R ↦ w j.succ) i = pathVertices a b w i.succ := by
+  change (Fin.cons (w 0) (Fin.snoc (fun j : Fin R ↦ w j.succ) b) :
+      Fin (R + 2) → Fin 2) i =
+    (Fin.cons a (Fin.snoc w b) : Fin (R + 3) → Fin 2) i.succ
+  refine Fin.cases ?_ (fun j ↦ ?_) i
+  · rfl
+  · change (Fin.snoc (fun k : Fin R ↦ w k.succ) b : Fin (R + 1) → Fin 2) j =
+      (Fin.snoc w b : Fin (R + 2) → Fin 2) j.succ
+    by_cases hj : j.val < R
+    · have hcast : j = Fin.castSucc (⟨j.val, hj⟩ : Fin R) := by apply Fin.ext; rfl
+      rw [hcast, Fin.snoc_castSucc]
+      rw [show (Fin.castSucc (⟨j.val, hj⟩ : Fin R)).succ =
+          Fin.castSucc (⟨j.val + 1, by omega⟩ : Fin (R + 1)) by apply Fin.ext; rfl,
+        Fin.snoc_castSucc]
+      congr
+    · have hlast : j = Fin.last R := by apply Fin.ext; simp; omega
+      subst j
+      simp
+
+private theorem complementPathWeight_eq_prod {R : ℕ} (a b : Fin 2)
+    (w : Fin R → Fin 2) :
+    complementPathWeight a b w =
+      ∏ i : Fin (R + 1), weightMatrix (pathVertices a b w i.castSucc)
+        (pathVertices a b w i.succ) := by
+  induction R generalizing a with
+  | zero =>
+      rw [complementPathWeight_zero, Fin.prod_univ_one]
+      rfl
+  | succ R ih =>
+      rw [complementPathWeight, Fin.prod_univ_succ, ih (w 0)]
+      congr 1
+      apply Finset.prod_congr rfl
+      intro i _
+      change weightMatrix
+          ((Fin.cons (w 0) (Fin.snoc (fun j : Fin R ↦ w j.succ) b) :
+            Fin (R + 2) → Fin 2) i.castSucc)
+          ((Fin.cons (w 0) (Fin.snoc (fun j : Fin R ↦ w j.succ) b) :
+            Fin (R + 2) → Fin 2) i.succ) =
+        weightMatrix ((Fin.cons a (Fin.snoc w b) : Fin (R + 3) → Fin 2) i.succ.castSucc)
+          ((Fin.cons a (Fin.snoc w b) : Fin (R + 3) → Fin 2) i.succ.succ)
+      change weightMatrix
+          (pathVertices (w 0) b (fun j : Fin R ↦ w j.succ) i.castSucc)
+          (pathVertices (w 0) b (fun j : Fin R ↦ w j.succ) i.succ) =
+        weightMatrix (pathVertices a b w i.succ.castSucc)
+          (pathVertices a b w i.succ.succ)
+      rw [pathVertices_tail a b w i.castSucc, pathVertices_tail a b w i.succ]
+      congr 2
 
 /-- The effective binary tensor has exactly the expected diagonal cycle entries.
 
@@ -140,6 +243,193 @@ private lemma hadamard_mul_eigenvalueMatrix_eq_weightMatrix_mul_hadamard :
     simp [hadamard, eigenvalueMatrix, weightMatrix, Matrix.mul_apply,
       Fin.sum_univ_two] <;> norm_num
 
+/-- Every entry of a power of the binary weight matrix has its exact Hadamard-basis
+closed form. -/
+theorem weightMatrix_pow_apply (N : ℕ) (a b : Fin 2) :
+    (weightMatrix ^ N) a b =
+      (((3 : ℂ) / 2) ^ N + (if a = b then 1 else -1) * ((1 : ℂ) / 2) ^ N) / 2 := by
+  have hmatrix : weightMatrix ^ N =
+      hadamard * eigenvalueMatrix ^ N * ((1 / 2 : ℂ) • hadamard) := by
+    calc
+      weightMatrix ^ N = weightMatrix ^ N * 1 := by rw [Matrix.mul_one]
+      _ = weightMatrix ^ N * (hadamard * ((1 / 2 : ℂ) • hadamard)) := by
+        rw [hadamard_mul_half_hadamard]
+      _ = (weightMatrix ^ N * hadamard) * ((1 / 2 : ℂ) • hadamard) := by
+        rw [Matrix.mul_assoc]
+      _ = hadamard * eigenvalueMatrix ^ N * ((1 / 2 : ℂ) • hadamard) := by
+        rw [(show SemiconjBy hadamard eigenvalueMatrix weightMatrix from
+          hadamard_mul_eigenvalueMatrix_eq_weightMatrix_mul_hadamard).pow_right N]
+  rw [hmatrix]
+  fin_cases a <;> fin_cases b <;>
+    simp [hadamard, eigenvalueMatrix, Matrix.diagonal_pow, Matrix.mul_apply,
+      Fin.sum_univ_two, Matrix.vecMul, dotProduct] <;> ring
+
+
+/-- A cycle with a nonempty retained prefix factors into its internal edges and
+its complementary endpoint path. -/
+private theorem cycleWeight_append_eq_internal_mul_complement {L R : ℕ}
+    (hL : 1 ≤ L) (x : Fin L → Fin 2) (w : Fin R → Fin 2) :
+    letI : NeZero (L + R) := ⟨by omega⟩
+    cycleWeight (Fin.append x w) =
+      internalEdgeProduct x * complementPathWeight (lastLabel hL x) (firstLabel hL x) w := by
+  letI : NeZero (L + R) := ⟨by omega⟩
+  unfold cycleWeight internalEdgeProduct
+  let q : Fin (L + R) → Fin 2 := Fin.append x w
+  have hsplit : L + R = (L - 1) + (R + 1) := by omega
+  rw [Fintype.prod_equiv (finCongr hsplit)
+    (fun n : Fin (L + R) ↦ weightMatrix (q n) (q (n + 1)))
+    (fun n : Fin ((L - 1) + (R + 1)) ↦
+      weightMatrix (q (Fin.cast hsplit.symm n)) (q (Fin.cast hsplit.symm n + 1)))]
+  · rw [Fin.prod_univ_add, complementPathWeight_eq_prod]
+    congr 1
+    · apply Finset.prod_congr rfl
+      intro i _
+      congr 2
+      · change Fin.append x w _ = x _
+        rw [show Fin.cast hsplit.symm (Fin.castAdd (R + 1) i) =
+            Fin.castAdd R (Fin.castLE (Nat.sub_le L 1) i) by apply Fin.ext; rfl,
+          Fin.append_left]
+      · have hi : i.val + 1 < L := by have := i.isLt; omega
+        have hbase : Fin.cast hsplit.symm (Fin.castAdd (R + 1) i) =
+            Fin.castAdd R (Fin.castLE (Nat.sub_le L 1) i) := by
+          apply Fin.ext
+          rfl
+        have hvalbase : (Fin.castAdd R (Fin.castLE (Nat.sub_le L 1) i)).val = i.val := rfl
+        have hadd_lt : (Fin.castAdd R (Fin.castLE (Nat.sub_le L 1) i)).val +
+            (1 : Fin (L + R)).val < L + R := by
+          rw [hvalbase]
+          have hsize : 2 ≤ L + R := by omega
+          have hone : (1 : Fin (L + R)).val = 1 := by
+            exact Nat.mod_eq_of_lt hsize
+          rw [hone]
+          omega
+        have hstep : Fin.castAdd R (Fin.castLE (Nat.sub_le L 1) i) + 1 =
+            Fin.castAdd R (⟨i.val + 1, hi⟩ : Fin L) := by
+          apply Fin.ext
+          rw [Fin.val_add_eq_of_add_lt hadd_lt, hvalbase]
+          have hsize : 2 ≤ L + R := by omega
+          have hone : (1 : Fin (L + R)).val = 1 := by
+            exact Nat.mod_eq_of_lt hsize
+          rw [hone]
+          rfl
+        have hindex : Fin.cast hsplit.symm (Fin.castAdd (R + 1) i) + 1 =
+            Fin.castAdd R (⟨i.val + 1, hi⟩ : Fin L) := by
+          rw [hbase]
+          exact hstep
+        change Fin.append x w _ = x _
+        rw [hindex, Fin.append_left]
+    · apply Finset.prod_congr rfl
+      intro i _
+      congr 2
+      · refine Fin.cases ?_ (fun j ↦ ?_) i
+        · change Fin.append x w _ = lastLabel hL x
+          rw [show Fin.cast hsplit.symm (Fin.natAdd (L - 1) (0 : Fin (R + 1))) =
+              Fin.castAdd R (⟨L - 1, by omega⟩ : Fin L) by apply Fin.ext; simp,
+            Fin.append_left]
+          rfl
+        · change Fin.append x w _ =
+            pathVertices (lastLabel hL x) (firstLabel hL x) w j.succ.castSucc
+          rw [show pathVertices (lastLabel hL x) (firstLabel hL x) w j.succ.castSucc = w j by
+            simp [pathVertices]]
+          rw [show Fin.cast hsplit.symm (Fin.natAdd (L - 1) j.succ) =
+              Fin.natAdd L j by apply Fin.ext; simp; omega,
+            Fin.append_right]
+      · by_cases hi : i.val < R
+        · let j : Fin R := ⟨i.val, hi⟩
+          have hicast : i = Fin.castSucc j := by apply Fin.ext; rfl
+          rw [hicast]
+          change Fin.append x w _ =
+            pathVertices (lastLabel hL x) (firstLabel hL x) w (Fin.castSucc j).succ
+          rw [show pathVertices (lastLabel hL x) (firstLabel hL x) w
+            (Fin.castSucc j).succ = w j by simp [pathVertices]]
+          have hraw : Fin.cast hsplit.symm (Fin.natAdd (L - 1) (Fin.castSucc j)) =
+              ⟨L - 1 + j.val, by omega⟩ := by
+            apply Fin.ext
+            rfl
+          have hsize : 2 ≤ L + R := by omega
+          have hone : (1 : Fin (L + R)).val = 1 := Nat.mod_eq_of_lt hsize
+          have hlt : L - 1 + j.val + (1 : Fin (L + R)).val < L + R := by
+            rw [hone]
+            omega
+          have hindex : Fin.cast hsplit.symm (Fin.natAdd (L - 1) (Fin.castSucc j)) + 1 =
+              Fin.natAdd L j := by
+            rw [hraw]
+            apply Fin.ext
+            rw [Fin.val_add_eq_of_add_lt hlt]
+            rw [hone]
+            simp only [Fin.val_natAdd]
+            omega
+          rw [hindex, Fin.append_right]
+        · have hilast : i = Fin.last R := by apply Fin.ext; simp; omega
+          subst i
+          change Fin.append x w _ =
+            pathVertices (lastLabel hL x) (firstLabel hL x) w (Fin.last R).succ
+          rw [show pathVertices (lastLabel hL x) (firstLabel hL x) w (Fin.last R).succ =
+            firstLabel hL x by simp [pathVertices]]
+          have hbefore : Fin.cast hsplit.symm (Fin.natAdd (L - 1) (Fin.last R)) =
+              ⟨L + R - 1, by omega⟩ := by
+            apply Fin.ext
+            simp
+            omega
+          have hindex : Fin.cast hsplit.symm (Fin.natAdd (L - 1) (Fin.last R)) + 1 =
+              (0 : Fin (L + R)) := by
+            rw [hbefore]
+            apply Fin.ext
+            simp only [Fin.add_def]
+            simp only [Fin.val_zero]
+            by_cases hsize : L + R = 1
+            · have hfin : (1 : Fin (L + R)).val = 0 := by
+                change 1 % (L + R) = 0
+                rw [hsize]
+              rw [hfin, hsize]
+            · have htwo : 2 ≤ L + R := by omega
+              have hone : (1 : Fin (L + R)).val = 1 := Nat.mod_eq_of_lt htwo
+              rw [hone]
+              have hadd : L + R - 1 + 1 = L + R := Nat.sub_add_cancel (by omega)
+              rw [hadd]
+              exact Nat.mod_self (L + R)
+          rw [hindex]
+          change Fin.append x w 0 = x ⟨0, by omega⟩
+          rw [show (0 : Fin (L + R)) = Fin.castAdd R (⟨0, by omega⟩ : Fin L) by rfl,
+            Fin.append_left]
+  · intro i
+    rfl
+
+/-- The sum of endpoint-fixed complementary path weights is the corresponding
+matrix-power entry. -/
+theorem sum_complementPathWeight_eq_weightMatrix_pow (K : ℕ) (a b : Fin 2) :
+    ∑ w : Fin K → Fin 2, complementPathWeight a b w = (weightMatrix ^ (K + 1)) a b := by
+  induction K generalizing a with
+  | zero =>
+      rw [Fintype.sum_unique]
+      rw [complementPathWeight_zero, pow_one]
+  | succ K ih =>
+      rw [← Equiv.sum_comp (Fin.consEquiv (fun _ : Fin (K + 1) ↦ Fin 2))]
+      rw [Fintype.sum_prod_type]
+      change ∑ c : Fin 2, ∑ w : Fin K → Fin 2,
+          weightMatrix a c * complementPathWeight c b w = _
+      calc
+        (∑ c : Fin 2, ∑ w : Fin K → Fin 2,
+            weightMatrix a c * complementPathWeight c b w) =
+            ∑ c : Fin 2, weightMatrix a c * (weightMatrix ^ (K + 1)) c b := by
+          apply Finset.sum_congr rfl
+          intro c _
+          rw [← Finset.mul_sum, ih c]
+        _ = (weightMatrix ^ (K + 1 + 1)) a b := by
+          change (weightMatrix * weightMatrix ^ (K + 1)) a b = _
+          rw [← pow_succ', show K + 1 + 1 = (K + 1) + 1 by omega]
+
+/-- Summing the actual cycle weights over all complementary configurations gives
+the internal edge product times the endpoint matrix-power entry. -/
+theorem sum_cycleWeight_append_eq_internalEdgeProduct_mul_pow {L K : ℕ}
+    (hL : 1 ≤ L) (x : Fin L → Fin 2) :
+    letI : NeZero (L + K) := ⟨by omega⟩
+    ∑ w : Fin K → Fin 2, cycleWeight (Fin.append x w) =
+      internalEdgeProduct x * (weightMatrix ^ (K + 1))
+        (lastLabel hL x) (firstLabel hL x) := by
+  simp_rw [cycleWeight_append_eq_internal_mul_complement hL]
+  rw [← Finset.mul_sum, sum_complementPathWeight_eq_weightMatrix_pow]
+
 /-- The trace of every power of the coefficient matrix extracted from the four
 printed diagonal neighboring operators has the closed form
 `(3^N + 1) / 2^N`.
@@ -168,5 +458,153 @@ Example 4.11, lines 907--924; see
 theorem partitionFunction_closed_form {N : ℕ} [NeZero N] :
     partitionFunction N = ((3 : ℂ) ^ N + 1) / (2 : ℂ) ^ N := by
   rw [partitionFunction_eq_trace_pow, trace_weightMatrix_pow]
+
+private theorem internalEdgeProduct_more {L : ℕ} (x : Fin (L + 2) → Fin 2) :
+    internalEdgeProduct x = weightMatrix (x 0) (x 1) *
+      internalEdgeProduct (fun i : Fin (L + 1) ↦ x i.succ) := by
+  unfold internalEdgeProduct
+  change (∏ i : Fin (L + 1), weightMatrix (x i.castSucc)
+      (x ⟨i.val + 1, by omega⟩)) = _
+  rw [Fin.prod_univ_succ]
+  congr 1
+
+/-- The internal edge product is determined exactly by the number of transitions. -/
+theorem internalEdgeProduct_eq {L : ℕ} (x : Fin L → Fin 2) :
+    internalEdgeProduct x = 1 / (2 : ℂ) ^ internalTransitionCount x := by
+  induction L using Nat.twoStepInduction with
+  | zero => simp [internalEdgeProduct, internalTransitionCount]
+  | one => simp [internalEdgeProduct, internalTransitionCount]
+  | more L ih0 ih1 =>
+      rw [internalEdgeProduct_more, internalTransitionCount, ih1]
+      by_cases h : x 0 = x 1
+      · rw [if_pos h, h]
+        have hx : x 1 = 0 ∨ x 1 = 1 := by omega
+        rcases hx with hx | hx <;> simp [hx, weightMatrix]
+      · rw [if_neg h]
+        have hx0 : x 0 = 0 ∨ x 0 = 1 := by omega
+        have hx1 : x 1 = 0 ∨ x 1 = 1 := by omega
+        rcases hx0 with hx0 | hx0 <;> rcases hx1 with hx1 | hx1 <;>
+          simp_all [weightMatrix]
+        all_goals ring
+
+/-- The existing reduced block state of the effective binary MPO is diagonal, with
+its diagonal entry given by the internal edge product and complementary matrix power. -/
+theorem reducedBlockState_apply_eq_internal_mul_pow {N L : ℕ} [NeZero N] (hL : 1 ≤ L)
+    (hLN : L ≤ N) (x y : Fin L → Fin 2) :
+    reducedBlockState M N L hLN x y = if x = y then
+      internalEdgeProduct x * (weightMatrix ^ (N - L + 1))
+        (lastLabel hL x) (firstLabel hL x) / partitionFunction N else 0 := by
+  generalize hK : N - L = K
+  have hN : N = L + K := by omega
+  subst N
+  have hsub : L + K - L = K := Nat.add_sub_cancel_left L K
+  rw [reducedBlockState_eq_sum, normalizedMPO]
+  simp only [Matrix.smul_apply, smul_eq_mul, mpo_M_apply]
+  by_cases hxy : x = y
+  · subst y
+    simp only [↓reduceIte]
+    rw [← Finset.mul_sum]
+    letI : NeZero (L + (L + K - L)) := ⟨by omega⟩
+    have htotal : L + K = L + (L + K - L) := by omega
+    have hcastsum :
+        (∑ i : Fin (L + K - L) → Fin 2,
+          cycleWeight (Fin.append x i ∘ Fin.cast htotal)) =
+        ∑ i : Fin (L + K - L) → Fin 2, cycleWeight (Fin.append x i) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      unfold cycleWeight
+      symm
+      apply Finset.prod_bij (fun n _ ↦ Fin.cast htotal.symm n)
+      · intro n _
+        exact Finset.mem_univ _
+      · intro n _ m _ h
+        apply Fin.ext
+        simpa using congrArg Fin.val h
+      · intro n _
+        exact ⟨Fin.cast htotal n, Finset.mem_univ _, by simp⟩
+      · intro n _
+        congr 2
+        apply Fin.ext
+        simp [Fin.add_def]
+    rw [hcastsum]
+    have hsum' := sum_cycleWeight_append_eq_internalEdgeProduct_mul_pow
+      (K := L + K - L) hL x
+    rw [hsum', hsub]
+    have htrace : (mpo M (L + K)).trace = partitionFunction (L + K) := by
+      rw [mpo_M_eq_diagonal, Matrix.trace_diagonal]
+      rfl
+    rw [htrace]
+    simp only [div_eq_mul_inv]
+    ring
+  · rw [if_neg hxy]
+    apply Finset.sum_eq_zero
+    intro w _
+    rw [if_neg]
+    · ring
+    intro h
+    apply hxy
+    funext i
+    have htotal : L + K = L + (L + K - L) := by omega
+    have := congrFun h (Fin.cast htotal.symm (Fin.castAdd (L + K - L) i))
+    simpa using this
+
+/-- The parity of the internal transition count records whether the endpoints agree. -/
+private theorem neg_one_pow_internalTransitionCount {L : ℕ} (hL : 1 ≤ L)
+    (x : Fin L → Fin 2) :
+    (-1 : ℂ) ^ internalTransitionCount x =
+      if lastLabel hL x = firstLabel hL x then 1 else -1 := by
+  induction L using Nat.twoStepInduction with
+  | zero => omega
+  | one =>
+      simp only [internalTransitionCount, pow_zero]
+      rw [if_pos]
+      congr
+  | more L ih0 ih1 =>
+      rw [internalTransitionCount]
+      have htail : (1 : ℕ) ≤ L + 1 := by omega
+      rw [pow_add, ih1 htail]
+      change ((-1 : ℂ) ^ (if x 0 = x 1 then 0 else 1)) *
+          (if x ⟨L + 1, by omega⟩ = x 1 then 1 else -1) =
+        if x ⟨L + 1, by omega⟩ = x 0 then 1 else -1
+      by_cases h01 : x 0 = x 1
+      · rw [if_pos h01, pow_zero, one_mul, h01]
+      · rw [if_neg h01, pow_one]
+        have hx0 : x 0 = 0 ∨ x 0 = 1 := by omega
+        have hx1 : x 1 = 0 ∨ x 1 = 1 := by omega
+        have hxlast : x ⟨L + 1, by omega⟩ = 0 ∨ x ⟨L + 1, by omega⟩ = 1 := by omega
+        rcases hx0 with hx0 | hx0 <;> rcases hx1 with hx1 | hx1 <;>
+          rcases hxlast with hxlast | hxlast <;> simp_all
+
+/-- The project-derived exact finite-ring block probability in a form involving
+only nonnegative natural-number exponents. This includes the endpoint cases
+$L = 1$ and $L = N$; no zero-length block formula is asserted.
+
+Project derivation from the neighboring operators printed in arXiv:1606.00608,
+Example 4.11, lines 907--924; see
+`docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`. -/
+theorem reducedBlockState_apply {N L : ℕ} [NeZero N] (hL : 1 ≤ L) (hLN : L ≤ N)
+    (x y : Fin L → Fin 2) :
+    reducedBlockState M N L hLN x y = if x = y then
+      (2 : ℂ) ^ L * ((3 : ℂ) ^ (N - L + 1) +
+        (-1 : ℂ) ^ internalTransitionCount x) /
+          ((2 : ℂ) ^ (internalTransitionCount x + 2) * ((3 : ℂ) ^ N + 1))
+      else 0 := by
+  rw [reducedBlockState_apply_eq_internal_mul_pow hL hLN]
+  split_ifs with hxy
+  · subst y
+    rw [internalEdgeProduct_eq, weightMatrix_pow_apply,
+      neg_one_pow_internalTransitionCount hL, partitionFunction_closed_form]
+    have htwo : (2 : ℂ) ≠ 0 := by norm_num
+    have hthree : (3 : ℂ) ^ N + 1 ≠ 0 := by
+      intro h
+      have hcast : ((3 : ℕ) ^ N + 1 : ℂ) = 0 := by exact_mod_cast h
+      have hz : (3 : ℕ) ^ N + 1 = 0 := by exact_mod_cast hcast
+      exact (Nat.ne_of_gt (Nat.zero_lt_succ ((3 : ℕ) ^ N))) hz
+    rw [div_pow, div_pow]
+    field_simp
+    rw [show N = L + (N - L) by omega]
+    simp only [Nat.add_sub_cancel_left, pow_add]
+    ring
+  · rfl
 
 end MPOTensor.CPSVExample411BinarySupport

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1125,6 +1125,56 @@ This is the calculation in
     $\operatorname{tr}(W^N)=(3/2)^N+(1/2)^N=(3^N+1)/2^N$.
 \end{proof}
 
+% Project-derived finite-ring consequence of CPSV16 Example 4.11.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{definition}[Internal transition count]
+    \label{def:cpsv_example411_binary_internal_transition_count}
+    \lean{MPOTensor.CPSVExample411BinarySupport.internalTransitionCount}
+    \leanok
+    For a binary word $x=(x_1,\ldots,x_L)$, let $t(x)$ be the number of
+    indices $n\in\{1,\ldots,L-1\}$ for which $x_n\ne x_{n+1}$.
+\end{definition}
+
+\begin{theorem}[Exact effective-binary finite-ring block probabilities]
+    \label{thm:cpsv_example411_binary_block_probability}
+    \lean{MPOTensor.CPSVExample411BinarySupport.internalEdgeProduct_eq,
+        MPOTensor.CPSVExample411BinarySupport.weightMatrix_pow_apply,
+        MPOTensor.CPSVExample411BinarySupport.sum_complementPathWeight_eq_weightMatrix_pow,
+        MPOTensor.CPSVExample411BinarySupport.sum_cycleWeight_append_eq_internalEdgeProduct_mul_pow,
+        MPOTensor.CPSVExample411BinarySupport.reducedBlockState_apply_eq_internal_mul_pow,
+        MPOTensor.CPSVExample411BinarySupport.reducedBlockState_apply}
+    \leanok
+    \uses{def:block_entropy,
+        def:cpsv_example411_binary_internal_transition_count,
+        def:cpsv_example411_binary_support_model}
+    Let $1\leq L\leq N$ and let $x\in\{0,1\}^L$.  The effective-binary block
+    state is diagonal, and its entry at $x$ is
+    \begin{align}
+      \mu_{N,L}(x)
+      &=\frac{2^L\bigl(3^{N-L+1}+(-1)^{t(x)}\bigr)}
+        {2^{t(x)+2}(3^N+1)}.
+      \notag
+    \end{align}
+    This includes $L=1$ and $L=N$.  It is a project-derived consequence of the
+    finite periodic model, not a formula stated in CPSV16.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:block_entropy,
+        def:cpsv_example411_binary_internal_transition_count,
+        def:cpsv_example411_binary_support_model,
+        thm:cpsv_example411_binary_support_normalization}
+    Expanding the canonical reduced state as a sum over the complementary
+    labels leaves only equal retained words.  The cycle product then factors
+    into the internal edges and an endpoint-fixed complementary path.  Each
+    internal transition contributes $1/2$, and induction on the path length
+    identifies the complementary path sum with the corresponding entry of
+    $W^{N-L+1}$.  Diagonalizing $W$ gives that entry in terms of its endpoint
+    labels, while the parity of $t(x)$ records whether those endpoints agree.
+    Division by $Z_N$ yields the displayed formula.
+\end{proof}
+
 % CPSV16 Example 4.11, lines 907--924.
 % Local fix (support embedding): Fin 2 is included in Fin 4 by k |-> (k,k),
 % rather than identified with it by an equivalence.

--- a/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
+++ b/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
@@ -124,15 +124,23 @@ where
 \[
   Z_N=\operatorname{tr}(W^N)=\frac{3^N+1}{2^N}.
 \]
-For any $L<N$, summing the complementary path gives the exact reduced
+For $1\leq L\leq N$, summing the complementary path gives the exact reduced
 probability
 \[
-  \mathbb P_{N,L}(k_1,\ldots,k_L)
+  \mu_{N,L}(k_1,\ldots,k_L)
   =\frac{\left(\prod_{n=1}^{L-1}W_{k_n,k_{n+1}}\right)
       (W^{N-L+1})_{k_L,k_1}}{\operatorname{tr}(W^N)}.
 \]
-This formula includes the periodic closing correction; it is not the marginal
-of an open stationary Markov chain.
+This formula includes the endpoint cases $L=1$ and $L=N$ and the periodic
+closing correction; it is not the marginal of an open stationary Markov chain.
+If $t(k)$ counts the transitions among the $L-1$ internal edges, then this
+project-derived finite-ring consequence is
+\[
+  \mu_{N,L}(k)
+  =\frac{2^{L-t(k)-2}\bigl(3^{N-L+1}+(-1)^{t(k)}\bigr)}{3^N+1}.
+\]
+The formal statement uses an equivalent quotient with only nonnegative
+exponents.  Neither block formula is printed in CPSV16.
 
 At $N=4$, the nonzero spectra are
 \begin{align*}
@@ -202,6 +210,22 @@ two exact natural-number comparisons.  The declarations
 \leanid{CPSVExamples410411Arithmetic.example411_log_ratio_pos} prove positivity
 of the corresponding logarithmic ratios.  These results entered the project in
 commit \texttt{a79bfc93314f3f721abecdbc184065497672d7e5}.
+
+\paragraph{Project derivation (effective-binary finite-ring blocks).}
+The module \doclink{TNLean/MPS/MPDO/CPSVExample411BinarySupport} now proves the
+exact internal edge product in
+\leanid{MPOTensor.CPSVExample411BinarySupport.internalEdgeProduct_eq}, every
+entry of $W^m$ in
+\leanid{MPOTensor.CPSVExample411BinarySupport.weightMatrix_pow_apply}, and the
+complementary path-sum identity in
+\leanid{MPOTensor.CPSVExample411BinarySupport.sum_complementPathWeight_eq_weightMatrix_pow}.
+The declaration
+\leanid{MPOTensor.CPSVExample411BinarySupport.reducedBlockState_apply_eq_internal_mul_pow}
+identifies the canonical reduced state with the normalized path formula, and
+\leanid{MPOTensor.CPSVExample411BinarySupport.reducedBlockState_apply} gives the
+closed diagonal block formula for $1\leq L\leq N$.  These are finite-ring
+consequences of the printed neighboring operators, not claims attributed to
+CPSV16.  The result remains entirely in the effective binary model.
 
 \paragraph{Local fix (ambient support inclusion).}
 For Example~4.11, the effective binary one-site space is included in the


### PR DESCRIPTION
## Summary
- prove the actual finite-ring complement-cycle factorization, including the dependent  indexing under 
- derive the exact formula for the existing  from , , , prefix injectivity, and partition normalization
- prove the equivalent closed formula with only nonnegative natural-number exponents for all \(1 \le L \le N\)
- synchronize the Blueprint and paper-gap note to the exact declarations, with no surrogate reduced-state definition or spectrum/entropy/SAL/ZCL claim

## Scope
This remains entirely in the effective binary model. It adds no ambient transport, spectra, entropy, SAL, or ZCL claim.

## Verification
- 
- Scanning Lean source tree …
  Found 16938 declarations in Lean source
Scanning blueprint .tex files …
  Found 7482 unique \lean{} references in blueprint
  Found 7509 theorem-like blueprint entries

======================================================================
  BLUEPRINT ↔ LEAN SYNC REPORT
======================================================================

Per-chapter formalization progress:
  Chapter                                             Done / Total       %
  --------------------------------------------------------------------
  src/appendix/ft_mps/ch05_schwarz.tex                  12 /    12  100.0%
  src/appendix/ft_mps/ch06_qpf.tex                      17 /    17  100.0%
  src/appendix/ft_mps/ch07_spectral.tex                 38 /    38  100.0%
  src/appendix/ft_mps/ch08_wielandt.tex                 45 /    45  100.0%
  src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex    32 /    32  100.0%
  src/appendix/ft_mps/ch09_canonical_splitting_and_gauges.tex    29 /    29  100.0%
  src/appendix/ft_mps/ch10_bnt_block_separation_and_suppliers.tex    11 /    11  100.0%
  src/appendix/ft_mps/ch10_bnt_normal_and_gram_support.tex    12 /    12  100.0%
  src/appendix/ft_mps/ch10_bnt_power_sums_and_sector_bookkeeping.tex    19 /    19  100.0%
  src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex    11 /    11  100.0%
  src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex    13 /    13  100.0%
  src/appendix/ft_mps/ch12_symmetry_algebra.tex         12 /    12  100.0%
  src/appendix/ft_mps/ch12_symmetry_transfer_and_limits.tex    11 /    11  100.0%
  src/appendix/full_only/ch25_positive_not_cp.tex       43 /    43  100.0%
  src/appendix/full_only/ch25_schmidt_number_and_witnesses.tex    11 /    11  100.0%
  src/appendix/full_only/ch27_channel_asymptotics.tex    12 /    12  100.0%
  ch02_mps.tex                                          61 /    61  100.0%
  ch03_single.tex                                       13 /    13  100.0%
  ch04_channels_choi_foundations.tex                    12 /    12  100.0%
  ch04_channels_peripheral_spectrum_and_primitivity.tex    17 /    17  100.0%
  ch04_channels_positive_map_and_channel_foundations.tex    13 /    13  100.0%
  ch04_channels_rectangular_kraus_maps.tex              57 /    57  100.0%
  ch04_channels_transfer_map_foundations.tex            14 /    14  100.0%
  ch05_schwarz_abstract_domains_and_order_auxiliary.tex    36 /    36  100.0%
  ch05_schwarz_douglas.tex                               6 /     6  100.0%
  ch05_schwarz_ft_core.tex                              17 /    17  100.0%
  ch05_schwarz_retractions_and_peripheral_equality.tex     5 /     5  100.0%
  ch05_schwarz_schur_complement.tex                      3 /     3  100.0%
  ch06_qpf.tex                                          47 /    47  100.0%
  ch06_qpf_auxiliary_extensions.tex                      8 /     8  100.0%
  ch06_qpf_cesaro_fixed_points.tex                      35 /    35  100.0%
  ch07_spectral_ft_peripheral_cyclic.tex                 1 /     1  100.0%
  ch07_spectral_mixed_transfer_and_overlap.tex          25 /    25  100.0%
  ch07_spectral_peripheral_refinements_and_primitive_overlap.tex    14 /    14  100.0%
  ch08_wielandt_cumulative_bound.tex                    37 /    37  100.0%
  ch08_wielandt_fixed_length_and_normality.tex          18 /    18  100.0%
  ch08_wielandt_word_span_and_block_injectivity.tex      5 /     5  100.0%
  ch09_canonical.tex                                     8 /     8  100.0%
  ch09_canonical_forms_and_projectors_auxiliary.tex     47 /    47  100.0%
  ch09_canonical_ft_reduction.tex                       14 /    14  100.0%
  ch09_canonical_normal_forms_and_support_auxiliary.tex    23 /    23  100.0%
  ch10_bnt_block_injective_form.tex                     15 /    15  100.0%
  ch10_bnt_definitions_and_characterization.tex          6 /     6  100.0%
  ch10_bnt_matching.tex                                  5 /     5  100.0%
  ch10_bnt_normal_blocks_and_overlap.tex                16 /    16  100.0%
  ch10_bnt_permutation_and_power_sums.tex                9 /     9  100.0%
  ch10_bnt_sector_canonical_form.tex                    80 /    80  100.0%
  ch11_fundamental_theorem_cases.tex                     6 /     6  100.0%
  ch11_fundamental_theorem_core.tex                     11 /    11  100.0%
  ch12_auxiliary_channel_no_information_without_disturbance.tex     5 /     5  100.0%
  ch12_auxiliary_wolf_ch01_positive_maps.tex            48 /    48  100.0%
  ch12_auxiliary_wolf_ch01_spectrum_and_wigner.tex      39 /    39  100.0%
  ch12_auxiliary_wolf_ch01_states.tex                   12 /    12  100.0%
  ch12_symmetry_spt.tex                                  2 /     2  100.0%
  ch12_symmetry_string_order.tex                        23 /    23  100.0%
  ch12_symmetry_virtual_and_cohomology.tex              28 /    28  100.0%
  ch13_parent_hamiltonian_block_diagonal.tex            16 /    16  100.0%
  ch13_parent_hamiltonian_block_diagonal_boundary_crossing_comparisons.tex    15 /    15  100.0%
  ch13_parent_hamiltonian_block_diagonal_chain_equality.tex    14 /    14  100.0%
  ch13_parent_hamiltonian_block_diagonal_periodic_components.tex    16 /    16  100.0%
  ch13_parent_hamiltonian_block_diagonal_single_block_constraints.tex    13 /    13  100.0%
  ch13_parent_hamiltonian_block_intersections.tex      127 /   127  100.0%
  ch13_parent_hamiltonian_block_intersections_intersection_consequences.tex    23 /    23  100.0%
  ch13_parent_hamiltonian_block_intersections_trace_identities.tex    19 /    19  100.0%
  ch13_parent_hamiltonian_blocking_transport.tex         9 /     9  100.0%
  ch13_parent_hamiltonian_bnt_consequences.tex           2 /     2  100.0%
  ch13_parent_hamiltonian_commuting_gap_all_chain_sector_graph.tex    65 /    65  100.0%
  ch13_parent_hamiltonian_commuting_gap_appendix_b_commutation.tex    30 /    30  100.0%
  ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex    34 /    34  100.0%
  ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex    63 /    63  100.0%
  ch13_parent_hamiltonian_commuting_gap_local_terms.tex    56 /    56  100.0%
  ch13_parent_hamiltonian_commuting_gap_rfp_ground_spaces.tex    23 /    23  100.0%
  ch13_parent_hamiltonian_decorrelation_commuting_structure.tex    27 /    27  100.0%
  ch13_parent_hamiltonian_decorrelation_marginal_supports.tex    40 /    40  100.0%
  ch13_parent_hamiltonian_injective_boundary.tex        35 /    35  100.0%
  ch13_parent_hamiltonian_injective_ground_spaces.tex     1 /     1  100.0%
  ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex    56 /    56  100.0%
  ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex    93 /    93  100.0%
  ch13_parent_hamiltonian_normal_boundary.tex           15 /    15  100.0%
  ch13_parent_hamiltonian_normal_closing_boundary_equations.tex    16 /    16  100.0%
  ch13_parent_hamiltonian_normal_closing_boundary_products.tex     9 /     9  100.0%
  ch13_parent_hamiltonian_normal_closing_reverse.tex    15 /    15  100.0%
  ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex    67 /    67  100.0%
  ch13_parent_hamiltonian_spectral_gap_martingale.tex   121 /   121  100.0%
  ch13_parent_hamiltonian_spectral_gap_martingale_cyclic_overlap.tex    31 /    31  100.0%
  ch14_correlations.tex                                 13 /    13  100.0%
  ch15_examples_aklt.tex                                27 /    27  100.0%
  ch15_examples_cluster_state.tex                       13 /    13  100.0%
  ch15_examples_cpsv16_example_34.tex                    8 /     8  100.0%
  ch15_examples_ghz.tex                                 11 /    11  100.0%
  ch15_examples_majumdar_ghosh.tex                       5 /     5  100.0%
  ch15_examples_parent_hamiltonians.tex                  3 /     3  100.0%
  ch15_examples_w_state.tex                             10 /    10  100.0%
  ch16_channel_representations_choi_and_kraus.tex       68 /    68  100.0%
  ch16_channel_representations_determinant_choi_bound.tex    10 /    10  100.0%
  ch16_channel_representations_dilations_and_ordered_cp.tex    55 /    55  100.0%
  ch16_channel_representations_normal_forms_and_determinant.tex    34 /    34  100.0%
  ch17_semigroup_adjoint_kernel_and_reducibility.tex    40 /    40  100.0%
  ch17_semigroup_dissipation_and_primitivity.tex        66 /    66  100.0%
  ch17_semigroup_dynamics_and_gksl.tex                  59 /    59  100.0%
  ch18_operator_convexity_lieb_and_resolvent.tex        18 /    18  100.0%
  ch18_operator_convexity_schwarz_and_jensen.tex        33 /    33  100.0%
  ch19_entropy_corollaries.tex                           4 /     4  100.0%
  ch19_entropy_majorization.tex                          2 /     2  100.0%
  ch19_entropy_mutual_information.tex                   11 /    11  100.0%
  ch19_entropy_trace_norm.tex                           45 /    45  100.0%
  ch19_entropy_tripartite_and_ssa_i.tex                 58 /    58  100.0%
  ch19_entropy_tripartite_and_ssa_ii.tex               116 /   116  100.0%
  ch19_entropy_von_neumann_and_relative_i.tex           38 /    38  100.0%
  ch19_entropy_von_neumann_and_relative_ii.tex          75 /    75  100.0%
  ch20_mpdo_canonical_forms_first_site_contractions.tex    38 /    38  100.0%
  ch20_mpdo_canonical_forms_intro_finite_separation.tex    28 /    28  100.0%
  ch20_mpdo_canonical_forms_periodic_sectors.tex        27 /    27  100.0%
  ch20_mpdo_canonical_forms_positivity_gram_normalization.tex    72 /    72  100.0%
  ch20_mpdo_canonical_forms_representative_marked.tex    44 /    44  100.0%
  ch20_mpdo_canonical_forms_vertical_direct_sums.tex    34 /    34  100.0%
  ch20_mpdo_foundations.tex                             21 /    21  100.0%
  ch21_mpdo_rfp_algebra_tower.tex                       21 /    21  100.0%
  ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex   124 /   124  100.0%
  ch21_mpdo_rfp_area_law_mixed_state_bounds.tex         84 /    84  100.0%
  ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex    90 /    90  100.0%
  ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex    48 /    48  100.0%
  ch21_mpdo_rfp_blocked_rfp_retained_vertical_coordinates.tex    66 /    66  100.0%
  ch21_mpdo_rfp_blocked_rfp_transported_vertical_maps.tex    27 /    27  100.0%
  ch21_mpdo_rfp_bnt_ambient_sector_maps.tex             49 /    49  100.0%
  ch21_mpdo_rfp_bnt_coefficients.tex                    93 /    93  100.0%
  ch21_mpdo_rfp_bnt_conditional_physical_channels.tex    40 /    40  100.0%
  ch21_mpdo_rfp_bnt_direct_sum_unitary_conjugations.tex    15 /    15  100.0%
  ch21_mpdo_rfp_bnt_theorem_data.tex                   173 /   173  100.0%
  ch21_mpdo_rfp_bnt_witnesses.tex                       55 /    55  100.0%
  ch21_mpdo_rfp_commuting_form_bond_products.tex        66 /    66  100.0%
  ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex    92 /    92  100.0%
  ch21_mpdo_rfp_foundations.tex                         58 /    58  100.0%
  ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex    39 /    39  100.0%
  ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex    29 /    29  100.0%
  ch21_mpdo_rfp_fusion_isometries_foundations.tex       39 /    39  100.0%
  ch21_mpdo_rfp_fusion_isometries_product_laws.tex      29 /    29  100.0%
  ch21_mpdo_rfp_fusion_isometries_recursive_density.tex    80 /    80  100.0%
  ch21_mpdo_rfp_gsnnch_definitions.tex                  70 /    70  100.0%
  ch21_mpdo_rfp_local_embedding_coordinates.tex          4 /     4  100.0%
  ch21_mpdo_rfp_renormalization.tex                     88 /    88  100.0%
  ch21_mpdo_rfp_simple_case_two.tex                     21 /    21  100.0%
  ch21_mpdo_rfp_simple_definition.tex                    6 /     6  100.0%
  ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex    25 /    25  100.0%
  ch21_mpdo_rfp_simple_local_coherent_positive_rephasing.tex    62 /    62  100.0%
  ch21_mpdo_rfp_simple_local_commuting_physical_bonds.tex    34 /    34  100.0%
  ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex    29 /    29  100.0%
  ch21_mpdo_rfp_simple_local_markov_bnt_compression.tex    80 /    80  100.0%
  ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex    83 /    83  100.0%
  ch21_mpdo_rfp_simple_local_normalized_preparations_completed_channels.tex    53 /    53  100.0%
  ch21_mpdo_rfp_simple_local_normalized_preparations_controlled_partial_traces.tex    50 /    50  100.0%
  ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex    62 /    62  100.0%
  ch21_mpdo_rfp_simple_local_primitivity_rank_one_trace_matrix.tex    38 /    38  100.0%
  ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex    20 /    20  100.0%
  ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex    64 /    64  100.0%
  ch21_mpdo_rfp_simple_local_structure_capstone.tex    130 /   130  100.0%
  ch21_mpdo_rfp_strong.tex                              13 /    13  100.0%
  ch22_periodic_ft_common_period_blocking.tex            3 /     3  100.0%
  ch22_periodic_ft_equal_case_statement.tex              4 /     4  100.0%
  ch22_periodic_ft_irreducible_rotation.tex             22 /    22  100.0%
  ch22_periodic_ft_overlap_cyclic_sectors.tex           18 /    18  100.0%
  ch22_periodic_ft_overlap_foundations.tex              22 /    22  100.0%
  ch22_periodic_ft_overlap_sector_match_and_consequences.tex    13 /    13  100.0%
  ch22_periodic_ft_physical_symmetries.tex               6 /     6  100.0%
  ch22_periodic_ft_refinement_divisibility.tex          15 /    15  100.0%
  ch22_periodic_ft_z_gauge.tex                          10 /    10  100.0%
  ch23_algebraic_ft_direct_sums_and_symmetry.tex        15 /    15  100.0%
  ch23_algebraic_ft_foundations.tex                     34 /    34  100.0%
  ch23_algebraic_ft_injective_chains_and_product_algebra.tex    37 /    37  100.0%
  ch24_peps_ft_balanced_edge_scalars.tex                18 /    18  100.0%
  ch24_peps_ft_edge_kernel_gauges_absorption_scalar_comparison.tex    22 /    22  100.0%
  ch24_peps_ft_edge_kernel_gauges_insertion_algebra_local_gauges.tex    12 /    12  100.0%
  ch24_peps_ft_edge_kernel_gauges_kernel_descent_recovery.tex    18 /    18  100.0%
  ch24_peps_ft_edge_middle.tex                          49 /    49  100.0%
  ch24_peps_ft_foundations.tex                          81 /    81  100.0%
  ch24_peps_ft_normal_capstone_normal_mps.tex           34 /    34  100.0%
  ch24_peps_ft_normal_capstone_normal_peps.tex          18 /    18  100.0%
  ch24_peps_ft_normal_capstone_site_dependent_and_vertex_injective.tex    24 /    24  100.0%
  ch24_peps_ft_normal_square_blocking_and_fundamental.tex     5 /     5  100.0%
  ch24_peps_ft_normal_square_coordinate_regions.tex     83 /    83  100.0%
  ch24_peps_ft_normal_square_rectangular_injectivity.tex    93 /    93  100.0%
  ch24_peps_ft_normal_square_translated_windows_and_comparison.tex    82 /    82  100.0%
  ch24_peps_ft_normal_union.tex                         72 /    72  100.0%
  ch24_peps_ft_region_transfer_absorption.tex           11 /    11  100.0%
  ch24_peps_ft_region_transfer_covariance.tex           21 /    21  100.0%
  ch24_peps_ft_region_transfer_insertions.tex           54 /    54  100.0%
  ch24_peps_ft_region_transfer_maps.tex                 47 /    47  100.0%
  ch24_peps_ft_torus_bond_local.tex                      3 /     3  100.0%
  ch24_peps_ft_torus_bond_uniform.tex                    6 /     6  100.0%
  ch24_peps_ft_torus_corner_cancellation.tex            20 /    20  100.0%
  ch24_peps_ft_torus_row_cut_obstruction.tex             3 /     3  100.0%
  ch24_peps_ft_torus_single_bond_peeling.tex            22 /    22  100.0%
  ch24_peps_ft_torus_staircase_geometry_and_ft.tex      30 /    30  100.0%
  ch24_peps_ft_torus_translation_and_reference_windows.tex    37 /    37  100.0%
  ch24_peps_ft_torus_window_independence.tex             3 /     3  100.0%
  ch24_peps_ft_torus_window_realizes.tex                 3 /     3  100.0%
  ch25_positive_not_cp_choi_and_decomposable_maps.tex    24 /    24  100.0%
  ch25_positive_not_cp_kramers_degeneracy.tex            1 /     1  100.0%
  ch25_positive_not_cp_positivity_reduction_and_breuer_hall.tex    26 /    26  100.0%
  ch25_positive_not_cp_ppt_and_separable_states.tex     21 /    21  100.0%
  ch25_positive_not_cp_schmidt_number_and_entanglement.tex    11 /    11  100.0%
  ch25_positive_not_cp_trace_normalization_and_lorentz_cone.tex     3 /     3  100.0%
  ch25_positive_not_cp_two_positive_schmidt_and_choi.tex    50 /    50  100.0%
  ch26_mps_rfp_direct_sums_residual_isometries.tex      24 /    24  100.0%
  ch26_mps_rfp_normal_isometry_canonical_forms.tex      18 /    18  100.0%
  ch26_mps_rfp_physical_blocking.tex                    11 /    11  100.0%
  ch26_mps_rfp_renormalization_flow_correlations.tex    29 /    29  100.0%
  ch26_mps_rfp_zero_correlation_length.tex              50 /    50  100.0%
  ch27_channel_asymptotics_direct_sum_corners_and_maximal_support.tex    10 /    10  100.0%
  ch27_channel_asymptotics_direct_sum_schwarz_maps.tex    37 /    37  100.0%
  ch27_channel_asymptotics_fixed_point_algebras.tex     14 /    14  100.0%
  ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex    21 /    21  100.0%
  ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex    53 /    53  100.0%
  ch27_channel_asymptotics_jordan_block_power.tex        3 /     3  100.0%
  ch27_channel_asymptotics_mean_ergodic.tex             19 /    19  100.0%
  ch27_channel_asymptotics_upper_triangular_power.tex     3 /     3  100.0%
  ch27_channel_asymptotics_wedderburn_ii.tex            53 /    53  100.0%
  ch28_mpu.tex                                         403 /   403  100.0%
  --------------------------------------------------------------------
  TOTAL                                               7509 /  7509  100.0%

✓ Blueprint and Lean code are in sync.
- ✓ No newly added reader-facing prose violations found.
- Import aggregators are current: 53 generated files cover 1390 production modules.
- # Repeated tactic patterns (>= 3 occurrences)
# Ranked by lines x occurrences; showing top 20

## 16 occurrences x 4 lines (weight 64)
    apply Finset.sum_congr rfl
    intro i _
    apply Finset.sum_congr rfl
    intro j _
  at: TNLean/Analysis/RelativeEntropyResolventIntegral.lean:328, TNLean/Analysis/RelativeEntropyResolventIntegral.lean:816, TNLean/Analysis/RelativeEntropyResolventIntegral.lean:922 (+13 more)

## 18 occurrences x 3 lines (weight 54)
    apply Finset.sum_congr rfl
    intro i _
    apply Finset.sum_congr rfl
  at: TNLean/Analysis/RelativeEntropyResolventIntegral.lean:328, TNLean/Analysis/RelativeEntropyResolventIntegral.lean:816, TNLean/Analysis/RelativeEntropyResolventIntegral.lean:922 (+15 more)

## 12 occurrences x 3 lines (weight 36)
    rw [Finset.sum_comm]
    apply Finset.sum_congr rfl
    intro j _
  at: TNLean/Analysis/RelativeEntropyResolventIntegral.lean:477, TNLean/Analysis/RelativeEntropySupportLeftRightQuadratic.lean:404, TNLean/Analysis/RelativeEntropySupportLeftRightQuadratic.lean:499 (+9 more)

## 5 occurrences x 7 lines (weight 35)
    · intro i
    simp
    · intro i u v
    simp [mul_assoc, mul_add]
    · intro i
    simp
    · intro i u v
  at: TNLean/Channel/Schwarz/TwoPositive.lean:386, TNLean/Channel/Schwarz/TwoPositive.lean:390, TNLean/Channel/Schwarz/TwoPositive.lean:417 (+2 more)

## 4 occurrences x 8 lines (weight 32)
    · intro i
    simp
    · intro i u v
    simp [mul_assoc, mul_add]
    · intro i
    simp
    · intro i u v
    simp [mul_assoc, mul_add]
  at: TNLean/Channel/Schwarz/TwoPositive.lean:386, TNLean/Channel/Schwarz/TwoPositive.lean:390, TNLean/Channel/Schwarz/TwoPositive.lean:417 (+1 more)

## 5 occurrences x 6 lines (weight 30)
    letI : NormedAddCommGroup (V →L[ℂ] V) := ContinuousLinearMap.toNormedAddCommGroup
    letI : SeminormedRing (V →L[ℂ] V) := ContinuousLinearMap.toSeminormedRing
    letI : NormedRing (V →L[ℂ] V) := ContinuousLinearMap.toNormedRing
    letI : NormedSpace ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedSpace
    letI : NormedAlgebra ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedAlgebra
    haveI : FiniteDimensional ℂ (V →L[ℂ] V) := Φ.toLinearEquiv.finiteDimensional
  at: TNLean/MPS/RFP/BNTOrthogonality.lean:417, TNLean/Spectral/MPVOverlapDecayRect.lean:66, TNLean/Spectral/PrimitiveOverlap.lean:101 (+2 more)

## 10 occurrences x 3 lines (weight 30)
    ext i j
    by_cases hij : i = j
    · subst hij
  at: TNLean/Algebra/HermitianHelpers.lean:178, TNLean/Algebra/HermitianHelpers.lean:207, TNLean/Channel/ChoiJamiolkowski.lean:403 (+7 more)

## 4 occurrences x 7 lines (weight 28)
    apply Subtype.ext
    refine Prod.ext (torusVertex_eq_of_val_eq ?_ ?_) (torusVertex_eq_of_val_eq ?_ ?_)
    · rw [hc1, hr11]
    · rw [hc2, hr12]
    · rw [hc3, hr21]
    · rw [hc4, hr22]
    · rintro rfl
  at: TNLean/PEPS/TorusEdgeBlockingCrossing.lean:240, TNLean/PEPS/TorusEdgeBlockingCrossing.lean:359, TNLean/PEPS/TorusWindowRegion.lean:212 (+1 more)

## 9 occurrences x 3 lines (weight 27)
    · intro i
    simp
    · intro i u v
  at: TNLean/Channel/Schwarz/TwoPositive.lean:386, TNLean/Channel/Schwarz/TwoPositive.lean:390, TNLean/Channel/Schwarz/TwoPositive.lean:394 (+6 more)

## 9 occurrences x 3 lines (weight 27)
    rcases Finset.mem_union.mp hcover with hrb | hc
    · rcases Finset.mem_union.mp hrb with hr | hbl
    · exact absurd hr hwnotred
  at: TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean:89, TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean:244, TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean:97 (+6 more)

## 3 occurrences x 8 lines (weight 24)
    apply continuousOn_finsetSum Finset.univ
    intro i _
    apply continuousOn_finsetSum Finset.univ
    intro j _ t ht
    have ht0 : 0 < t := ht
    have hα : 0 < α i := hA.eigenvalues_pos i
    have hβ : 0 < β j := hB.eigenvalues_pos j
    have hden : α i + t * β j ≠ 0 := by positivity
  at: TNLean/Analysis/RelativeEntropyResolventIntegral.lean:612, TNLean/Analysis/RelativeEntropyResolventIntegral.lean:641, TNLean/Analysis/RelativeEntropyResolventIntegral.lean:870

## 3 occurrences x 8 lines (weight 24)
    simpa [hσdef, Matrix.conjTranspose_conjTranspose] using this
    have hσfix : map C σ = σ := by
    have hmapA : map A ρ = ρ := by
    have heq : map A ρ = Q * map K ρ * Q := by
    rw [hAdef]
    exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
    rw [heq, hρ_fix, hQρQ]
    rw [hσdef]
  at: TNLean/Channel/FixedPoint/CornerBlockForm.lean:115, TNLean/Channel/FixedPoint/CornerFixedPoints.lean:224, TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:172

## 3 occurrences x 8 lines (weight 24)
    have hσfix : map C σ = σ := by
    have hmapA : map A ρ = ρ := by
    have heq : map A ρ = Q * map K ρ * Q := by
    rw [hAdef]
    exact map_cornerCompressionKraus_eq K hQproj (Z := ρ) hQρQ
    rw [heq, hρ_fix, hQρQ]
    rw [hσdef]
    exact map_compressed_fixedPoint A C V Q ρ hCi hVVt hQρQ hmapA
  at: TNLean/Channel/FixedPoint/CornerBlockForm.lean:116, TNLean/Channel/FixedPoint/CornerFixedPoints.lean:225, TNLean/Channel/FixedPoint/WeightedCornerFixedPoints.lean:173

## 3 occurrences x 8 lines (weight 24)
    simp
    · intro i u v
    simp [mul_assoc, mul_add]
    · intro i
    simp
    · intro i u v
    simp [mul_assoc, mul_add]
    · intro i
  at: TNLean/Channel/Schwarz/TwoPositive.lean:387, TNLean/Channel/Schwarz/TwoPositive.lean:418, TNLean/Channel/Schwarz/TwoPositive.lean:422

## 3 occurrences x 8 lines (weight 24)
    · intro i u v
    simp [mul_assoc, mul_add]
    · intro i
    simp
    · intro i u v
    simp [mul_assoc, mul_add]
    · intro i
    simp
  at: TNLean/Channel/Schwarz/TwoPositive.lean:388, TNLean/Channel/Schwarz/TwoPositive.lean:419, TNLean/Channel/Schwarz/TwoPositive.lean:423

## 3 occurrences x 8 lines (weight 24)
    simp [mul_assoc, mul_add]
    · intro i
    simp
    · intro i u v
    simp [mul_assoc, mul_add]
    · intro i
    simp
    · intro i u v
  at: TNLean/Channel/Schwarz/TwoPositive.lean:389, TNLean/Channel/Schwarz/TwoPositive.lean:420, TNLean/Channel/Schwarz/TwoPositive.lean:424

## 4 occurrences x 6 lines (weight 24)
    · refine Finset.sum_congr rfl (fun η hη => ?_)
    rw [Finset.mem_filter] at hη
    rw [if_pos hη.2]
    · refine Finset.sum_eq_zero (fun η hη => ?_)
    rw [Finset.mem_filter] at hη
    rw [if_neg hη.2, smul_zero]
  at: TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean:670, TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean:440, TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean:493 (+1 more)

## 6 occurrences x 4 lines (weight 24)
    · intro i
    simp
    · intro i u v
    simp [mul_assoc, mul_add]
  at: TNLean/Channel/Schwarz/TwoPositive.lean:386, TNLean/Channel/Schwarz/TwoPositive.lean:390, TNLean/Channel/Schwarz/TwoPositive.lean:394 (+3 more)

## 6 occurrences x 4 lines (weight 24)
    intro j
    apply hAtLeastP j
    dsimp [L₀]
    omega
  at: TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean:143, TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean:148, TNLean/MPS/MPDO/PostBlockedRepresentativeSpan.lean:154 (+3 more)

## 6 occurrences x 4 lines (weight 24)
    rcases Finset.mem_union.mp hcover with hrb | hc
    · rcases Finset.mem_union.mp hrb with hr | hbl
    · exact absurd hr hwnotred
    · exact absurd hbl hb
  at: TNLean/PEPS/RegionBlock/ThreeBlockReconcile.lean:244, TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean:97, TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean:207 (+3 more)
- changed Lean proof-debt scan: no , , , , , or 
- 

Closes #6349

Exact head: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization and documentation in a specialized MPDO example module; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Adds **project-derived finite-ring block probability formulas** for CPSV16 Example 4.11’s effective binary support model (`CPSVExample411BinarySupport`), staying in that model only (no ambient spectra/entropy/SAL claims).
> 
> The Lean module gains definitions for internal transitions, complementary path weights, and factorization lemmas showing a retained binary word’s cycle weight splits into internal edges plus an endpoint-fixed complement. New theorems give closed `W^N` entries, path sums as matrix powers, and **`reducedBlockState`** as a diagonal state with explicit entries in terms of transition count `t(x)` and normalization `Z_N`.
> 
> The blueprint capstone chapter and `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex` are updated to cite the new declarations and record the closed formula for `1 ≤ L ≤ N`, including `L = 1` and `L = N`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11983928a9c8e8acd41ec6a42bbe18e16585da38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->