### PR TITLE
feat(parent-hamiltonian): prove blocked range-two gap

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -59,6 +59,7 @@ import TNLean.MPS.ParentHamiltonian.LocalSupportTransport
 import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.AdjacentLocalTerms
+import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.AdjacentLocalTerms
+import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
@@ -29,7 +30,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The eight components are:
+The nine components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale` (quadratic form implies norm bound);
@@ -42,6 +43,8 @@ The eight components are:
   and the projector-defect reduction to an anticommutator estimate;
 * `Martingale.C3Threshold` — a uniform input-site overlap length satisfying the
   open-chain C3 defect threshold and its anticommutator consequence;
+* `Martingale.BlockedGap` — transport of that threshold to three blocked sites
+  and the explicit range-two blocked parent-Hamiltonian gap;
 * `Martingale.OverlapReduction` — reduction from overlapping-window commutation
   to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
@@ -19,7 +19,7 @@ tensor. No comparison with an interaction on the original unblocked chain is mad
 ## Main results
 
 * `MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth` chooses a
-  physical block length and proves the explicit gap constant `1 / 8` for the blocked tensor.
+  physical block length and proves the explicit gap constant \(1/8\) for the blocked tensor.
 
 ## References
 
@@ -238,7 +238,7 @@ theorem openChainLeftGroundSpaceES_blockTensor_map
 three-site open-chain projector defect of the blocked tensor.
 
 Both sides act on the explicit blocked Hilbert space. The right side is conjugated
-from the `3 * p`-site original Hilbert space by `blockedConfigLinearIsometryEquiv`.
+from the \(3p\)-site original Hilbert space by `blockedConfigLinearIsometryEquiv`.
 This statement transports only the two whole-block spectator spaces and the full
 three-block ground space. -/
 theorem blockTensor_threeSite_openChain_defect_norm_eq
@@ -403,9 +403,9 @@ private theorem IsPrimitiveMPS.exists_blockTensor_anticommutator
   exact ⟨p, hp, hInj, hAnti⟩
 
 /-- A primitive MPS tensor with a positive-definite fixed point admits
-physical blocking whose range-two blocked parent Hamiltonian has gap constant `1 / 8`.
+physical blocking whose range-two blocked parent Hamiltonian has gap constant \(1/8\).
 
-The coefficient `7 / 16` is first obtained for the whole-increment C3-prime
+The coefficient \(7/16\) is first obtained for the whole-increment C3-prime
 projector defect on three original blocks. Explicit blocked Hilbert-space transport
 turns it into the adjacent three-site anticommutator estimate. The forward and
 backward cyclic transports then cover every overlapping off-diagonal pair, and the

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
@@ -20,8 +20,8 @@ tensor. No comparison with an interaction on the original unblocked chain is mad
 
 * `MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth` chooses a
   physical block length and proves the explicit gap constant \(1/8\) for the blocked tensor.
-* `MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped` packages the
-  corresponding uniform positive gap through the public anticommutator consumer.
+* `MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped` proves a
+  uniform positive gap for the same blocked range-two parent Hamiltonians.
 
 ## References
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
@@ -20,6 +20,8 @@ tensor. No comparison with an interaction on the original unblocked chain is mad
 
 * `MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth` chooses a
   physical block length and proves the explicit gap constant \(1/8\) for the blocked tensor.
+* `MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped` packages the
+  corresponding uniform positive gap through the public anticommutator consumer.
 
 ## References
 
@@ -35,7 +37,7 @@ variable {d D : ℕ}
 
 /-- The common physical-coordinate isometry from three blocked sites to three
 consecutive original blocks. -/
-noncomputable def blockedThreeConfigLinearIsometryEquiv (d p : ℕ) :
+private noncomputable def blockedThreeConfigLinearIsometryEquiv (d p : ℕ) :
     EuclideanSpace ℂ (Cfg (blockPhysDim d p) 3) ≃ₗᵢ[ℂ]
       EuclideanSpace ℂ (Cfg d (p + p + p)) :=
   (blockedConfigLinearIsometryEquiv d 3 p).trans
@@ -45,7 +47,7 @@ noncomputable def blockedThreeConfigLinearIsometryEquiv (d p : ℕ) :
 
 /-- Reindex a one-block spectator configuration as a length-`p` original-site
 spectator configuration, retaining the virtual matrix coordinates. -/
-noncomputable def blockSpectatorLinearIsometryEquiv (d D p : ℕ) :
+private noncomputable def blockSpectatorLinearIsometryEquiv (d D p : ℕ) :
     BoundaryFamilySpace (D := D) (Cfg (blockPhysDim d p) 1) ≃ₗᵢ[ℂ]
       BoundaryFamilySpace (D := D) (Cfg d p) :=
   LinearIsometryEquiv.piLpCongrLeft 2 ℂ ℂ
@@ -55,7 +57,7 @@ noncomputable def blockSpectatorLinearIsometryEquiv (d D p : ℕ) :
 
 /-- The blocked tail spectator map intertwines with the original whole-block
 tail spectator map in the common three-block coordinates. -/
-theorem blockedThreeConfigLinearIsometryEquiv_tailBoundaryMapES
+private theorem blockedThreeConfigLinearIsometryEquiv_tailBoundaryMapES
     (A : MPSTensor d D) (p : ℕ)
     (x : BoundaryFamilySpace (D := D) (Cfg (blockPhysDim d p) 1)) :
     blockedThreeConfigLinearIsometryEquiv d p
@@ -95,7 +97,7 @@ theorem blockedThreeConfigLinearIsometryEquiv_tailBoundaryMapES
 
 /-- The blocked left spectator map intertwines with the original whole-block
 left spectator map in the common three-block coordinates. -/
-theorem blockedThreeConfigLinearIsometryEquiv_leftBoundaryMapES
+private theorem blockedThreeConfigLinearIsometryEquiv_leftBoundaryMapES
     (A : MPSTensor d D) (p : ℕ)
     (x : BoundaryFamilySpace (D := D) (Cfg (blockPhysDim d p) 1)) :
     blockedThreeConfigLinearIsometryEquiv d p
@@ -149,7 +151,7 @@ theorem blockedThreeConfigLinearIsometryEquiv_leftBoundaryMapES
 
 /-- The three-block Euclidean boundary map intertwines with the common
 reassociated physical-coordinate isometry. -/
-theorem blockedThreeConfigLinearIsometryEquiv_groundSpaceMapES
+private theorem blockedThreeConfigLinearIsometryEquiv_groundSpaceMapES
     (A : MPSTensor d D) (p : ℕ)
     (x : EuclideanSpace ℂ (Fin D × Fin D)) :
     blockedThreeConfigLinearIsometryEquiv d p
@@ -178,7 +180,7 @@ theorem blockedThreeConfigLinearIsometryEquiv_groundSpaceMapES
 
 /-- The full three-block ground space maps exactly to the original-site ground
 space in the common coordinates. -/
-theorem groundSpaceES_three_blockTensor_map
+private theorem groundSpaceES_three_blockTensor_map
     (A : MPSTensor d D) (p : ℕ) :
     (groundSpaceES (blockTensor A p) 3).map
         (blockedThreeConfigLinearIsometryEquiv d p).toLinearEquiv.toLinearMap =
@@ -194,7 +196,7 @@ theorem groundSpaceES_three_blockTensor_map
 
 /-- The blocked one-site-prefix tail space maps exactly to the original whole-block
 tail spectator range. -/
-theorem openChainTailGroundSpaceES_blockTensor_map
+private theorem openChainTailGroundSpaceES_blockTensor_map
     (A : MPSTensor d D) (p : ℕ) :
     (openChainTailGroundSpaceES (blockTensor A p) 1 2).map
         (blockedThreeConfigLinearIsometryEquiv d p).toLinearEquiv.toLinearMap =
@@ -215,7 +217,7 @@ theorem openChainTailGroundSpaceES_blockTensor_map
 
 /-- The blocked one-site-suffix left space maps exactly to the original
 whole-block left spectator range. -/
-theorem openChainLeftGroundSpaceES_blockTensor_map
+private theorem openChainLeftGroundSpaceES_blockTensor_map
     (A : MPSTensor d D) (p : ℕ) :
     (openChainLeftGroundSpaceES (blockTensor A p) 2).map
         (blockedThreeConfigLinearIsometryEquiv d p).toLinearEquiv.toLinearMap =

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
@@ -1,0 +1,408 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BlockedGroundSpaceTransport
+import TNLean.MPS.ParentHamiltonian.LocalSupportTransport
+import TNLean.MPS.ParentHamiltonian.Martingale.AdjacentLocalTerms
+import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
+import TNLean.MPS.ParentHamiltonian.Martingale.Gap
+
+/-!
+# Spectral gap after physical blocking
+
+This file combines the whole-increment C3-prime estimate with physical blocking.
+The resulting parent Hamiltonian is the range-two parent Hamiltonian of the blocked
+tensor. No comparison with an interaction on the original unblocked chain is made.
+
+## Main results
+
+* `MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth` chooses a
+  physical block length and proves the explicit gap constant `1 / 8` for the blocked tensor.
+
+## References
+
+* B. Nachtergaele, arXiv:cond-mat/9410110, eqs. (2.4)--(2.5), Theorem 3.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:2011.12127, Section IV.C.
+-/
+
+open scoped ComplexOrder InnerProductSpace Matrix.Norms.Frobenius
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The common physical-coordinate isometry from three blocked sites to three
+consecutive original blocks. -/
+noncomputable def blockedThreeConfigLinearIsometryEquiv (d p : ℕ) :
+    EuclideanSpace ℂ (Cfg (blockPhysDim d p) 3) ≃ₗᵢ[ℂ]
+      EuclideanSpace ℂ (Cfg d (p + p + p)) :=
+  (blockedConfigLinearIsometryEquiv d 3 p).trans
+    (LinearIsometryEquiv.piLpCongrLeft 2 ℂ ℂ
+      (Equiv.arrowCongr (finCongr (by omega : 3 * p = p + p + p))
+        (Equiv.refl (Fin d))))
+
+/-- Reindex a one-block spectator configuration as a length-`p` original-site
+spectator configuration, retaining the virtual matrix coordinates. -/
+noncomputable def blockSpectatorLinearIsometryEquiv (d D p : ℕ) :
+    BoundaryFamilySpace (D := D) (Cfg (blockPhysDim d p) 1) ≃ₗᵢ[ℂ]
+      BoundaryFamilySpace (D := D) (Cfg d p) :=
+  LinearIsometryEquiv.piLpCongrLeft 2 ℂ ℂ
+    (((blockedConfigEquiv d 1 p).trans
+      (Equiv.arrowCongr (finCongr (by omega : 1 * p = p))
+        (Equiv.refl (Fin d)))).prodCongr (Equiv.refl (Fin D × Fin D)))
+
+/-- The blocked tail spectator map intertwines with the original whole-block
+tail spectator map in the common three-block coordinates. -/
+theorem blockedThreeConfigLinearIsometryEquiv_tailBoundaryMapES
+    (A : MPSTensor d D) (p : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg (blockPhysDim d p) 1)) :
+    blockedThreeConfigLinearIsometryEquiv d p
+        (tailBoundaryMapES (blockTensor A p) 1 2 x) =
+      reassocTailBoundaryMapES A p p p
+        (blockSpectatorLinearIsometryEquiv d D p x) := by
+  ext σ
+  simp only [blockedThreeConfigLinearIsometryEquiv, LinearIsometryEquiv.trans_apply,
+    tailBoundaryMapES_apply, reassocTailBoundaryMapES, ContinuousLinearMap.comp_apply]
+  change Matrix.trace (MPSTensor.evalWord (blockTensor A p) (List.ofFn _) * _) =
+    Matrix.trace (MPSTensor.evalWord A (List.ofFn _) * _)
+  congr 2
+  rw [evalWord_blockTensor, ← ofFn_blockedConfigEquiv d 2 p]
+  congr 1
+  congr 1
+  · omega
+  simp [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry,
+    decodeBlockEquiv_apply, Function.comp_def, finProdFinEquiv]
+  apply (Fin.heq_fun_iff (by omega)).2
+  intro k
+  congr 1
+  apply Fin.ext
+  simp
+  rw [Nat.mul_add]
+  have hk := Nat.mod_add_div k.val p
+  omega
+
+/-- The blocked left spectator map intertwines with the original whole-block
+left spectator map in the common three-block coordinates. -/
+theorem blockedThreeConfigLinearIsometryEquiv_leftBoundaryMapES
+    (A : MPSTensor d D) (p : ℕ)
+    (x : BoundaryFamilySpace (D := D) (Cfg (blockPhysDim d p) 1)) :
+    blockedThreeConfigLinearIsometryEquiv d p
+        (leftBoundaryMapES (blockTensor A p) 2 1 x) =
+      leftBoundaryMapES A (p + p) p
+        (blockSpectatorLinearIsometryEquiv d D p x) := by
+  ext σ
+  simp only [blockedThreeConfigLinearIsometryEquiv, LinearIsometryEquiv.trans_apply,
+    leftBoundaryMapES_apply]
+  change Matrix.trace (MPSTensor.evalWord (blockTensor A p) (List.ofFn _) * _) =
+    Matrix.trace (MPSTensor.evalWord A (List.ofFn _) * _)
+  congr 2
+  rw [evalWord_blockTensor, ← ofFn_blockedConfigEquiv d 2 p]
+  congr 1
+  congr 1
+  · omega
+  simp [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry,
+    decodeBlockEquiv_apply, Function.comp_def, finProdFinEquiv]
+  apply (Fin.heq_fun_iff (by omega)).2
+  intro k
+  congr 1
+  apply Fin.ext
+  simp
+  have hk := Nat.mod_add_div k.val p
+  omega
+  ext a b
+  simp [blockSpectatorLinearIsometryEquiv, boundaryFamilyEquiv_apply_apply,
+    blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry, Function.comp_def,
+    finProdFinEquiv]
+  apply congrArg x.1
+  congr 1
+  funext k
+  congr 1
+  unfold Function.curry
+  funext j
+  apply congrArg σ
+  apply Fin.ext
+  simp
+  omega
+
+/-- The three-block Euclidean boundary map intertwines with the common
+reassociated physical-coordinate isometry. -/
+theorem blockedThreeConfigLinearIsometryEquiv_groundSpaceMapES
+    (A : MPSTensor d D) (p : ℕ)
+    (x : EuclideanSpace ℂ (Fin D × Fin D)) :
+    blockedThreeConfigLinearIsometryEquiv d p
+        (groundSpaceMapES (blockTensor A p) 3 x) =
+      groundSpaceMapES A (p + p + p) x := by
+  rw [blockedThreeConfigLinearIsometryEquiv]
+  change (LinearIsometryEquiv.piLpCongrLeft 2 ℂ ℂ _)
+    (blockedConfigLinearIsometryEquiv d 3 p
+      (groundSpaceMapES (blockTensor A p) 3 x)) = _
+  rw [blockedConfigLinearIsometryEquiv_groundSpaceMapES]
+  apply PiLp.ext
+  intro σ
+  have hword :
+      List.ofFn ((((finCongr (by omega : 3 * p = p + p + p)).arrowCongr
+        (Equiv.refl (Fin d))).symm) σ) = List.ofFn σ := by
+    convert (List.ofFn_congr (m := p + p + p) (n := 3 * p)
+      (by omega) σ).symm using 1
+    ext i
+    rfl
+  simp only [LinearIsometryEquiv.piLpCongrLeft_apply, Equiv.piCongrLeft',
+    Equiv.coe_fn_mk, groundSpaceMapES]
+  let X := (Matrix.frobeniusEquivEuclidean (Fin D) (Fin D)).symm x
+  change Matrix.trace (MPSTensor.evalWord A _ * X) =
+    Matrix.trace (MPSTensor.evalWord A _ * X)
+  rw [hword]
+
+/-- The full three-block ground space maps exactly to the original-site ground
+space in the common coordinates. -/
+theorem groundSpaceES_three_blockTensor_map
+    (A : MPSTensor d D) (p : ℕ) :
+    (groundSpaceES (blockTensor A p) 3).map
+        (blockedThreeConfigLinearIsometryEquiv d p).toLinearEquiv.toLinearMap =
+      groundSpaceES A (p + p + p) := by
+  rw [← range_groundSpaceMapES, ← range_groundSpaceMapES]
+  ext v
+  constructor
+  · rintro ⟨w, ⟨x, rfl⟩, rfl⟩
+    exact ⟨x, (blockedThreeConfigLinearIsometryEquiv_groundSpaceMapES A p x).symm⟩
+  · rintro ⟨x, rfl⟩
+    exact ⟨groundSpaceMapES (blockTensor A p) 3 x, ⟨x, rfl⟩,
+      blockedThreeConfigLinearIsometryEquiv_groundSpaceMapES A p x⟩
+
+/-- The blocked one-site-prefix tail space maps exactly to the original whole-block
+tail spectator range. -/
+theorem openChainTailGroundSpaceES_blockTensor_map
+    (A : MPSTensor d D) (p : ℕ) :
+    (openChainTailGroundSpaceES (blockTensor A p) 1 2).map
+        (blockedThreeConfigLinearIsometryEquiv d p).toLinearEquiv.toLinearMap =
+      (reassocTailBoundaryMapES A p p p).range := by
+  rw [← range_tailBoundaryMapES]
+  ext v
+  constructor
+  · rintro ⟨w, ⟨x, rfl⟩, rfl⟩
+    exact ⟨blockSpectatorLinearIsometryEquiv d D p x,
+      (blockedThreeConfigLinearIsometryEquiv_tailBoundaryMapES A p x).symm⟩
+  · rintro ⟨x, hx⟩
+    let y := (blockSpectatorLinearIsometryEquiv d D p).symm x
+    refine ⟨tailBoundaryMapES (blockTensor A p) 1 2 y, ⟨y, rfl⟩, ?_⟩
+    change blockedThreeConfigLinearIsometryEquiv d p
+      (tailBoundaryMapES (blockTensor A p) 1 2 y) = v
+    rw [blockedThreeConfigLinearIsometryEquiv_tailBoundaryMapES]
+    simpa [y] using hx
+
+/-- The blocked one-site-suffix left space maps exactly to the original
+whole-block left spectator range. -/
+theorem openChainLeftGroundSpaceES_blockTensor_map
+    (A : MPSTensor d D) (p : ℕ) :
+    (openChainLeftGroundSpaceES (blockTensor A p) 2).map
+        (blockedThreeConfigLinearIsometryEquiv d p).toLinearEquiv.toLinearMap =
+      (leftBoundaryMapES A (p + p) p).range := by
+  rw [← range_leftBoundaryMapES_one]
+  ext v
+  constructor
+  · rintro ⟨w, ⟨x, rfl⟩, rfl⟩
+    exact ⟨blockSpectatorLinearIsometryEquiv d D p x,
+      (blockedThreeConfigLinearIsometryEquiv_leftBoundaryMapES A p x).symm⟩
+  · rintro ⟨x, hx⟩
+    let y := (blockSpectatorLinearIsometryEquiv d D p).symm x
+    refine ⟨leftBoundaryMapES (blockTensor A p) 2 1 y, ⟨y, rfl⟩, ?_⟩
+    change blockedThreeConfigLinearIsometryEquiv d p
+      (leftBoundaryMapES (blockTensor A p) 2 1 y) = v
+    rw [blockedThreeConfigLinearIsometryEquiv_leftBoundaryMapES]
+    simpa [y] using hx
+
+/-- The whole-block C3-prime projector defect on three consecutive blocks is the
+three-site open-chain projector defect of the blocked tensor.
+
+Both sides act on the explicit blocked Hilbert space. The right side is conjugated
+from the `3 * p`-site original Hilbert space by `blockedConfigLinearIsometryEquiv`.
+This statement transports only the two whole-block spectator spaces and the full
+three-block ground space. -/
+theorem blockTensor_threeSite_openChain_defect_norm_eq
+    [NeZero d] (A : MPSTensor d D) (p : ℕ) :
+    ‖openChainTailGroundProjectionES (blockTensor A p) 1 2 ∘L
+          openChainLeftGroundProjectionES (blockTensor A p) 2 -
+        (groundSpaceES (blockTensor A p) 3).starProjection‖ =
+      ‖(reassocTailBoundaryMapES A p p p).range.starProjection ∘L
+            (leftBoundaryMapES A (p + p) p).range.starProjection -
+          (groundSpaceES A (p + p + p)).starProjection‖ := by
+  letI : NeZero (blockPhysDim d p) := ⟨by
+    rw [blockPhysDim_eq_pow]
+    exact pow_ne_zero p (NeZero.ne d)⟩
+  let U := blockedThreeConfigLinearIsometryEquiv d p
+  let T := openChainTailGroundSpaceES (blockTensor A p) 1 2
+  let L := openChainLeftGroundSpaceES (blockTensor A p) 2
+  let G := groundSpaceES (blockTensor A p) 3
+  let X := T.starProjection ∘L L.starProjection - G.starProjection
+  have hT : T.map U.toLinearEquiv.toLinearMap =
+      (reassocTailBoundaryMapES A p p p).range :=
+    openChainTailGroundSpaceES_blockTensor_map A p
+  have hL : L.map U.toLinearEquiv.toLinearMap =
+      (leftBoundaryMapES A (p + p) p).range :=
+    openChainLeftGroundSpaceES_blockTensor_map A p
+  have hG : G.map U.toLinearEquiv.toLinearMap = groundSpaceES A (p + p + p) :=
+    groundSpaceES_three_blockTensor_map A p
+  have hconj :
+      U.toContinuousLinearEquiv.toContinuousLinearMap.comp
+        (X.comp U.symm.toContinuousLinearEquiv.toContinuousLinearMap) =
+      (reassocTailBoundaryMapES A p p p).range.starProjection ∘L
+          (leftBoundaryMapES A (p + p) p).range.starProjection -
+        (groundSpaceES A (p + p + p)).starProjection := by
+    apply ContinuousLinearMap.ext
+    intro v
+    simp only [ContinuousLinearMap.comp_apply, X, sub_apply]
+    have hTp := Submodule.starProjection_map_apply U T v
+    have hLp := Submodule.starProjection_map_apply U L v
+    have hGp := Submodule.starProjection_map_apply U G v
+    have hTp' : (reassocTailBoundaryMapES A p p p).range.starProjection v =
+        U (T.starProjection (U.symm v)) := by
+      simpa only [hT] using hTp
+    have hLp' : (leftBoundaryMapES A (p + p) p).range.starProjection v =
+        U (L.starProjection (U.symm v)) := by
+      simpa only [hL] using hLp
+    have hGp' : (groundSpaceES A (p + p + p)).starProjection v =
+        U (G.starProjection (U.symm v)) := by
+      simpa only [hG] using hGp
+    rw [hLp', hGp', map_sub]
+    have hTpL := Submodule.starProjection_map_apply U T
+      (U (L.starProjection (U.symm v)))
+    have hTpL' : (reassocTailBoundaryMapES A p p p).range.starProjection
+        (U (L.starProjection (U.symm v))) =
+      U (T.starProjection (U.symm (U (L.starProjection (U.symm v))))) := by
+      simpa only [hT] using hTpL
+    rw [hTpL', U.symm_apply_apply]
+    simp
+  rw [← hconj]
+  change ‖X‖ = ‖U.toContinuousLinearEquiv.toContinuousLinearMap.comp
+    (X.comp U.symm.toContinuousLinearEquiv.toContinuousLinearMap)‖
+  have hpost := U.toLinearIsometry.norm_toContinuousLinearMap_comp
+    (g := X.comp U.symm.toContinuousLinearEquiv.toContinuousLinearMap)
+  rw [show U.toLinearIsometry.toContinuousLinearMap =
+    U.toContinuousLinearEquiv.toContinuousLinearMap by rfl] at hpost
+  rw [hpost]
+  apply le_antisymm
+  · have h := ContinuousLinearMap.opNorm_comp_le
+      (X.comp U.symm.toContinuousLinearEquiv.toContinuousLinearMap)
+      U.toContinuousLinearEquiv.toContinuousLinearMap
+    rw [U.norm_toContinuousLinearMap] at h
+    simpa [ContinuousLinearMap.comp_assoc] using h
+  · have h := ContinuousLinearMap.opNorm_comp_le X
+      U.symm.toContinuousLinearEquiv.toContinuousLinearMap
+    rw [U.symm.norm_toContinuousLinearMap] at h
+    simpa using h
+
+private theorem cyclicBackwardSite_forwardSite_one {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
+    cyclicBackwardSite (cyclicForwardSite i 1) 1 = i := by
+  apply Fin.ext
+  simp only [cyclicForwardSite, cyclicBackwardSite, Fin.val_mk]
+  rw [Nat.mod_eq_of_lt (by omega : 1 < N)]
+  by_cases hi : i.val + 1 < N
+  · rw [Nat.mod_eq_of_lt hi]
+    have hsum : i.val + 1 + N - 1 = i.val + N := by omega
+    rw [hsum, Nat.add_mod_right, Nat.mod_eq_of_lt i.isLt]
+  · have hi_last : i.val + 1 = N := by omega
+    have hi_val : N - 1 = i.val := by omega
+    rw [hi_last, Nat.mod_self, Nat.zero_add, Nat.mod_eq_of_lt (by omega), hi_val]
+
+/-- A primitive MPS tensor with a positive-definite fixed point admits a physical
+blocking whose range-two blocked parent Hamiltonian has gap constant `1 / 8`.
+
+The coefficient `7 / 16` is first obtained for the whole-increment C3-prime
+projector defect on three original blocks. Explicit blocked Hilbert-space transport
+turns it into the adjacent three-site anticommutator estimate. The forward and
+backward cyclic transports then cover every overlapping off-diagonal pair, and the
+finite-overlap martingale reduction gives the displayed bound.
+
+The conclusion concerns only `blockTensor A p`; it makes no comparison with an
+original-site parent interaction. -/
+theorem IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth
+    [NeZero d] [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : Matrix.PosDef ρ) :
+    ∃ p : ℕ,
+      0 < p ∧ IsNBlkInjective A p ∧
+        ∀ (N : ℕ) (_hN : 4 ≤ N)
+          (v : EuclideanSpace ℂ (Cfg (blockPhysDim d p) N)),
+          v ∈ (parentHamiltonianGroundSpaceES (blockTensor A p) 2 N)ᗮ →
+            (1 / 8 : ℝ) * ‖v‖ ≤
+              ‖parentHamiltonianES (blockTensor A p) 2 N v‖ := by
+  obtain ⟨p, hp, hInj, hDefect⟩ :=
+    hP.exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths hρ
+  let B := blockTensor A p
+  letI : NeZero (blockPhysDim d p) := ⟨by
+    rw [blockPhysDim_eq_pow]
+    exact pow_ne_zero p (NeZero.ne d)⟩
+  have hBInj : IsInjective B :=
+    (isNBlkInjective_iff_blockTensor_isInjective A p).mp hInj
+  have hBlockedDefect :
+      ‖openChainTailGroundProjectionES B 1 2 ∘L
+            openChainLeftGroundProjectionES B 2 -
+          (groundSpaceES B 3).starProjection‖ ≤ 7 / 16 := by
+    rw [blockTensor_threeSite_openChain_defect_norm_eq A p]
+    simpa only [B, Nat.add_assoc] using hDefect
+  have hThree : ∀ w : EuclideanSpace ℂ (Cfg (blockPhysDim d p) 3),
+      -(7 / 16 : ℝ) *
+          ((⟪localTermES B 2 (0 : Fin 3) w, w⟫_ℂ).re +
+            (⟪localTermES B 2 (1 : Fin 3) w, w⟫_ℂ).re) ≤
+        (⟪localTermES B 2 (0 : Fin 3) w,
+            localTermES B 2 (1 : Fin 3) w⟫_ℂ).re +
+          (⟪localTermES B 2 (1 : Fin 3) w,
+            localTermES B 2 (0 : Fin 3) w⟫_ℂ).re := by
+    intro w
+    have hAnti := re_inner_openChain_anticommutator_ge_neg_of_groundProjection_defect
+      (A := B) (K := 1) (L₀ := 1) (isNBlkInjective_one_of_isInjective hBInj)
+        (by omega) hBlockedDefect w
+    norm_num only at hAnti
+    change -(7 / 16 : ℝ) *
+        ((⟪(openChainTailGroundSpaceES B 1 2)ᗮ.starProjection.toLinearMap w, w⟫_ℂ).re +
+          (⟪(openChainLeftGroundSpaceES B 2)ᗮ.starProjection.toLinearMap w, w⟫_ℂ).re) ≤
+      (⟪(openChainTailGroundSpaceES B 1 2)ᗮ.starProjection.toLinearMap w,
+          (openChainLeftGroundSpaceES B 2)ᗮ.starProjection.toLinearMap w⟫_ℂ).re +
+        (⟪(openChainLeftGroundSpaceES B 2)ᗮ.starProjection.toLinearMap w,
+          (openChainTailGroundSpaceES B 1 2)ᗮ.starProjection.toLinearMap w⟫_ℂ).re at hAnti
+    rw [openChainTailGroundSpaceES_orthogonal_starProjection_eq_localTermES,
+      openChainLeftGroundSpaceES_orthogonal_starProjection_eq_localTermES] at hAnti
+    have hsum :
+        (⟪localTermES B 2 (1 : Fin 3) w, w⟫_ℂ).re +
+            (⟪localTermES B 2 (0 : Fin 3) w, w⟫_ℂ).re =
+          (⟪localTermES B 2 (0 : Fin 3) w, w⟫_ℂ).re +
+            (⟪localTermES B 2 (1 : Fin 3) w, w⟫_ℂ).re := add_comm _ _
+    have hcross :
+        (⟪localTermES B 2 (1 : Fin 3) w, localTermES B 2 (0 : Fin 3) w⟫_ℂ).re +
+            (⟪localTermES B 2 (0 : Fin 3) w, localTermES B 2 (1 : Fin 3) w⟫_ℂ).re =
+          (⟪localTermES B 2 (0 : Fin 3) w, localTermES B 2 (1 : Fin 3) w⟫_ℂ).re +
+            (⟪localTermES B 2 (1 : Fin 3) w, localTermES B 2 (0 : Fin 3) w⟫_ℂ).re :=
+      add_comm _ _
+    rw [hsum, hcross] at hAnti
+    exact hAnti
+  have hAnti : ∀ (N : ℕ) (_hN : 2 * 2 ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N 2 i j →
+        ∀ v : EuclideanSpace ℂ (Cfg (blockPhysDim d p) N),
+          - (1 - ((1 : ℝ) / (4 * (2 : ℝ)))) *
+              (((2 * (2 - 1) : ℕ) : ℝ)⁻¹) *
+              ((⟪localTermES B 2 i v, v⟫_ℂ).re +
+                (⟪localTermES B 2 j v, v⟫_ℂ).re) ≤
+            (⟪localTermES B 2 i v, localTermES B 2 j v⟫_ℂ).re +
+              (⟪localTermES B 2 j v, localTermES B 2 i v⟫_ℂ).re := by
+    intro N hN i j hji hOverlap v
+    have hne : j ≠ i := (Finset.mem_erase.mp hji).1
+    norm_num only [Nat.reduceSub, Nat.reduceMul, Nat.cast_ofNat, invOf_eq_inv]
+    rcases cyclicWindowsOverlap_twoSite_cases hOverlap with rfl | hForward | hBackward
+    · exact False.elim (hne rfl)
+    · subst j
+      exact re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite
+        hThree (by omega) i v
+    · subst i
+      have hBack := re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite
+        hThree (by omega) (cyclicForwardSite j 1) v
+      rw [cyclicBackwardSite_forwardSite_one (by omega) j] at hBack
+      simpa only [add_comm] using hBack
+  obtain ⟨_, hGap⟩ :=
+    parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator
+      B 2 (by omega) hAnti
+  refine ⟨p, hp, hInj, ?_⟩
+  intro N hN v hv
+  convert hGap N hN v hv using 1 <;> norm_num
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
@@ -72,13 +72,23 @@ theorem blockedThreeConfigLinearIsometryEquiv_tailBoundaryMapES
   congr 1
   congr 1
   · omega
-  simp [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry,
-    decodeBlockEquiv_apply, Function.comp_def, finProdFinEquiv]
+  have hindex (k : Fin (2 * p)) :
+      k.val % p + p * (1 + k.val / p) = p + k.val := by
+    rw [Nat.mul_add, Nat.mul_one]
+    calc
+      k.val % p + (p + p * (k.val / p)) = p + (k.val % p + p * (k.val / p)) := by
+        ac_rfl
+      _ = p + k.val := congrArg (p + ·) (Nat.mod_add_div k.val p)
+  suffices (fun k : Fin (2 * p) => σ ⟨k.val % p + p * (1 + k.val / p), by
+      rw [hindex]
+      omega⟩) ≍ fun k : Fin (p + p) => σ (k.addNat p) by
+    simpa [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry,
+      decodeBlockEquiv_apply, Function.comp_def, finProdFinEquiv]
   apply (Fin.heq_fun_iff (by omega)).2
   intro k
   congr 1
   apply Fin.ext
-  simp
+  simp only [Fin.addNat_mk]
   rw [Nat.mul_add]
   have hk := Nat.mod_add_div k.val p
   omega
@@ -98,23 +108,34 @@ theorem blockedThreeConfigLinearIsometryEquiv_leftBoundaryMapES
   change Matrix.trace (MPSTensor.evalWord (blockTensor A p) (List.ofFn _) * _) =
     Matrix.trace (MPSTensor.evalWord A (List.ofFn _) * _)
   congr 2
-  rw [evalWord_blockTensor, ← ofFn_blockedConfigEquiv d 2 p]
-  congr 1
-  congr 1
-  · omega
-  simp [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry,
-    decodeBlockEquiv_apply, Function.comp_def, finProdFinEquiv]
-  apply (Fin.heq_fun_iff (by omega)).2
-  intro k
-  congr 1
-  apply Fin.ext
-  simp
-  have hk := Nat.mod_add_div k.val p
-  omega
+  · rw [evalWord_blockTensor, ← ofFn_blockedConfigEquiv d 2 p]
+    congr 1
+    congr 1
+    · omega
+    suffices (fun k : Fin (2 * p) => σ ⟨k.val % p + p * (k.val / p), by
+        rw [Nat.mod_add_div]
+        omega⟩) ≍ fun k : Fin (p + p) => σ (Fin.castAdd p k) by
+      simpa [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry,
+        decodeBlockEquiv_apply, Function.comp_def, finProdFinEquiv]
+    apply (Fin.heq_fun_iff (by omega)).2
+    intro k
+    congr 1
+    apply Fin.ext
+    simp
+    have hk := Nat.mod_add_div k.val p
+    omega
   ext a b
-  simp [blockSpectatorLinearIsometryEquiv, boundaryFamilyEquiv_apply_apply,
-    blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry, Function.comp_def,
-    finProdFinEquiv]
+  suffices x.ofLp
+        (fun k => (decodeBlockEquiv d p).symm
+          (Function.curry (fun ij : Fin 3 × Fin p =>
+            σ ((finCongr (by omega : 3 * p = p + p + p)) (finProdFinEquiv ij)))
+            (Fin.natAdd 2 k)), b, a) =
+      x.ofLp
+        (fun k => (decodeBlockEquiv d p).symm
+          (Function.curry (fun ij => σ (Fin.natAdd (p + p) ij.2)) k), b, a) by
+    simpa [blockSpectatorLinearIsometryEquiv, boundaryFamilyEquiv_apply_apply,
+      blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry, Function.comp_def,
+      finProdFinEquiv]
   apply congrArg x.1
   congr 1
   funext k
@@ -293,40 +314,22 @@ theorem blockTensor_threeSite_openChain_defect_norm_eq
     rw [U.symm.norm_toContinuousLinearMap] at h
     simpa using h
 
-private theorem cyclicBackwardSite_forwardSite_one {N : ℕ} (hN : 2 ≤ N) (i : Fin N) :
-    cyclicBackwardSite (cyclicForwardSite i 1) 1 = i := by
-  apply Fin.ext
-  simp only [cyclicForwardSite, cyclicBackwardSite, Fin.val_mk]
-  rw [Nat.mod_eq_of_lt (by omega : 1 < N)]
-  by_cases hi : i.val + 1 < N
-  · rw [Nat.mod_eq_of_lt hi]
-    have hsum : i.val + 1 + N - 1 = i.val + N := by omega
-    rw [hsum, Nat.add_mod_right, Nat.mod_eq_of_lt i.isLt]
-  · have hi_last : i.val + 1 = N := by omega
-    have hi_val : N - 1 = i.val := by omega
-    rw [hi_last, Nat.mod_self, Nat.zero_add, Nat.mod_eq_of_lt (by omega), hi_val]
-
-/-- A primitive MPS tensor with a positive-definite fixed point admits a physical
-blocking whose range-two blocked parent Hamiltonian has gap constant `1 / 8`.
-
-The coefficient `7 / 16` is first obtained for the whole-increment C3-prime
-projector defect on three original blocks. Explicit blocked Hilbert-space transport
-turns it into the adjacent three-site anticommutator estimate. The forward and
-backward cyclic transports then cover every overlapping off-diagonal pair, and the
-finite-overlap martingale reduction gives the displayed bound.
-
-The conclusion concerns only `blockTensor A p`; it makes no comparison with an
-original-site parent interaction. -/
-theorem IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth
+private theorem IsPrimitiveMPS.exists_blockTensor_anticommutator
     [NeZero d] [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsPrimitiveMPS A ρ) (hρ : Matrix.PosDef ρ) :
     ∃ p : ℕ,
       0 < p ∧ IsNBlkInjective A p ∧
-        ∀ (N : ℕ) (_hN : 4 ≤ N)
-          (v : EuclideanSpace ℂ (Cfg (blockPhysDim d p) N)),
-          v ∈ (parentHamiltonianGroundSpaceES (blockTensor A p) 2 N)ᗮ →
-            (1 / 8 : ℝ) * ‖v‖ ≤
-              ‖parentHamiltonianES (blockTensor A p) 2 N v‖ := by
+        ∀ (N : ℕ) (_hN : 2 * 2 ≤ N) (i j : Fin N),
+          j ∈ Finset.univ.erase i → cyclicWindowsOverlap N 2 i j →
+            ∀ v : EuclideanSpace ℂ (Cfg (blockPhysDim d p) N),
+              - (1 - ((1 : ℝ) / (4 * (2 : ℝ)))) *
+                  (((2 * (2 - 1) : ℕ) : ℝ)⁻¹) *
+                  ((⟪localTermES (blockTensor A p) 2 i v, v⟫_ℂ).re +
+                    (⟪localTermES (blockTensor A p) 2 j v, v⟫_ℂ).re) ≤
+                (⟪localTermES (blockTensor A p) 2 i v,
+                    localTermES (blockTensor A p) 2 j v⟫_ℂ).re +
+                  (⟪localTermES (blockTensor A p) 2 j v,
+                    localTermES (blockTensor A p) 2 i v⟫_ℂ).re := by
   obtain ⟨p, hp, hInj, hDefect⟩ :=
     hP.exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths hρ
   let B := blockTensor A p
@@ -394,15 +397,65 @@ theorem IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth
       exact re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite
         hThree (by omega) i v
     · subst i
-      have hBack := re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite
-        hThree (by omega) (cyclicForwardSite j 1) v
-      rw [cyclicBackwardSite_forwardSite_one (by omega) j] at hBack
-      simpa only [add_comm] using hBack
+      simpa only [add_comm] using
+        re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite
+          hThree (by omega) j v
+  exact ⟨p, hp, hInj, hAnti⟩
+
+/-- A primitive MPS tensor with a positive-definite fixed point admits
+physical blocking whose range-two blocked parent Hamiltonian has gap constant `1 / 8`.
+
+The coefficient `7 / 16` is first obtained for the whole-increment C3-prime
+projector defect on three original blocks. Explicit blocked Hilbert-space transport
+turns it into the adjacent three-site anticommutator estimate. The forward and
+backward cyclic transports then cover every overlapping off-diagonal pair, and the
+finite-overlap martingale reduction gives the displayed bound.
+
+The conclusion concerns only `blockTensor A p`; it makes no comparison with an
+original-site parent interaction. -/
+theorem IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth
+    [NeZero d] [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : Matrix.PosDef ρ) :
+    ∃ p : ℕ,
+      0 < p ∧ IsNBlkInjective A p ∧
+        ∀ (N : ℕ) (_hN : 4 ≤ N)
+          (v : EuclideanSpace ℂ (Cfg (blockPhysDim d p) N)),
+          v ∈ (parentHamiltonianGroundSpaceES (blockTensor A p) 2 N)ᗮ →
+            (1 / 8 : ℝ) * ‖v‖ ≤
+              ‖parentHamiltonianES (blockTensor A p) 2 N v‖ := by
+  obtain ⟨p, hp, hInj, hAnti⟩ := hP.exists_blockTensor_anticommutator hρ
+  let B := blockTensor A p
+  letI : NeZero (blockPhysDim d p) := ⟨by
+    rw [blockPhysDim_eq_pow]
+    exact pow_ne_zero p (NeZero.ne d)⟩
   obtain ⟨_, hGap⟩ :=
     parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator
       B 2 (by omega) hAnti
   refine ⟨p, hp, hInj, ?_⟩
   intro N hN v hv
-  convert hGap N hN v hv using 1 <;> norm_num
+  have hγ : (1 / 8 : ℝ) = 1 / (4 * (2 : ℝ)) := by norm_num
+  rw [hγ]
+  exact hGap N hN v hv
+
+/-- A primitive MPS tensor with a positive-definite fixed point admits
+physical blocking whose range-two blocked parent Hamiltonian has a uniform positive gap.
+
+The conclusion concerns only `blockTensor A p`; it makes no comparison with an
+original-site parent interaction. -/
+theorem IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped
+    [NeZero d] [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : Matrix.PosDef ρ) :
+    ∃ p : ℕ,
+      0 < p ∧ IsNBlkInjective A p ∧
+        ∃ γ > 0, ∀ (N : ℕ) (_hN : 4 ≤ N)
+          (v : EuclideanSpace ℂ (Cfg (blockPhysDim d p) N)),
+          v ∈ (parentHamiltonianGroundSpaceES (blockTensor A p) 2 N)ᗮ →
+            γ * ‖v‖ ≤ ‖parentHamiltonianES (blockTensor A p) 2 N v‖ := by
+  obtain ⟨p, hp, hInj, hAnti⟩ := hP.exists_blockTensor_anticommutator hρ
+  letI : NeZero (blockPhysDim d p) := ⟨by
+    rw [blockPhysDim_eq_pow]
+    exact pow_ne_zero p (NeZero.ne d)⟩
+  exact ⟨p, hp, hInj,
+    parentHamiltonian_gapped_of_anticommutator (blockTensor A p) 2 (by omega) hAnti⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2246,11 +2246,12 @@ norm estimate is derived here.
 
 \begin{theorem}[Uniform gap for a blocked primitive MPS parent Hamiltonian]
     \label{lem:martingale_mps}
-    \lean{MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth,
+        MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped}
     \leanok
     \uses{lem:blocked_to_cyclic_ground_projector_comparison,
         lem:cyclic_window_overlap_cardinality,
-        thm:anticommutator_gap_bound}
+        thm:anticommutator_gap_bound, thm:parent_hamiltonian_gapped}
     Let $A$ be a primitive MPS tensor with nonzero physical and bond dimensions,
     and suppose that its fixed point is positive definite.  There is a blocking
     length $p>0$ such that $A$ is $p$-block injective and, with
@@ -2266,7 +2267,7 @@ norm estimate is derived here.
     \leanok
     \uses{lem:blocked_to_cyclic_ground_projector_comparison,
         lem:cyclic_window_overlap_cardinality,
-        thm:anticommutator_gap_bound}
+        thm:anticommutator_gap_bound, thm:parent_hamiltonian_gapped}
     Choose $p$ so that the three-block projector defect is at most $7/16$.
     Lemma~\ref{lem:blocked_to_cyclic_ground_projector_comparison} gives the same
     coefficient for every overlapping cyclic pair.  For range two each row has

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2245,7 +2245,7 @@ norm estimate is derived here.
 \end{lemma}
 
 \begin{theorem}[Uniform gap for a blocked primitive MPS parent Hamiltonian]
-    \label{lem:martingale_mps}
+    \label{thm:martingale_mps}
     \lean{MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth,
         MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped}
     \leanok
@@ -2279,7 +2279,7 @@ norm estimate is derived here.
     \label{thm:normal_mps_parent_hamiltonian_gap}
     \notready
     \discussion{5926}
-    \uses{lem:martingale_mps, thm:anticommutator_gap_bound,
+    \uses{thm:martingale_mps, thm:anticommutator_gap_bound,
         thm:parent_hamiltonian_gapped}
     Let $A$ be a normal tensor.  There exist an interaction range $L>1$ and
     a constant $\gamma>0$ such that, for every $N\ge2L$ and every
@@ -2289,7 +2289,7 @@ norm estimate is derived here.
         &\le \lVert H_{N,L}(A)v\rVert.
         \notag
     \end{align}
-    Theorem~\ref{lem:martingale_mps} proves this estimate only for the
+    Theorem~\ref{thm:martingale_mps} proves this estimate only for the
     range-two Hamiltonian of $B=\operatorname{block}_p(A)$ on $N$ blocked sites.
     It does not identify that operator, its kernel, or its energy scale with
     the range-$L$ Hamiltonian of $A$ on the original-site chain.  The remaining
@@ -2299,9 +2299,9 @@ norm estimate is derived here.
 \begin{proof}
     \notready
     \discussion{5926}
-    \uses{lem:martingale_mps, thm:anticommutator_gap_bound,
+    \uses{thm:martingale_mps, thm:anticommutator_gap_bound,
         thm:parent_hamiltonian_gapped}
-    Apply Theorem~\ref{lem:martingale_mps} to the blocked tensor.  Then compare
+    Apply Theorem~\ref{thm:martingale_mps} to the blocked tensor.  Then compare
     its range-two local projections and ground-space complement with a fixed-range
     parent interaction for $A$ in original-site units, retaining a uniform positive
     lower bound under that comparison.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2215,47 +2215,64 @@ norm estimate is derived here.
     gives the anticommutator statement.
 \end{proof}
 
-\begin{lemma}[Blocked-to-cyclic ground-projector comparison]
+\begin{lemma}[Blocked three-site projector and adjacent-pair transport]
     \label{lem:blocked_to_cyclic_ground_projector_comparison}
-    \notready
-    \discussion{5925}
-    \uses{thm:nachtergaele_c3_blocked_length}
-    Let $A$ be a normal tensor, let $B$ be the injective tensor obtained from
-    $A$ by the chosen blocking, and let $L>1$ be the resulting cyclic interaction
-    range.  For every $N\ge2L$ and every overlapping off-diagonal pair of cyclic
-    windows, including pairs crossing the periodic cut, let $q_i,q_j$ be the
-    corresponding ground-space projectors and let $P_{ij}$ project onto their
-    common ground space.  Then
+    \lean{MPSTensor.blockTensor_threeSite_openChain_defect_norm_eq,
+        MPSTensor.re_inner_localTermES_adjacent_twoSite_forward_ge_of_threeSite,
+        MPSTensor.re_inner_localTermES_adjacent_twoSite_backward_ge_of_threeSite}
+    \leanok
+    \uses{thm:three_block_whole_increment_defect_seven_sixteenths,
+        thm:friedrichs_ground_space_excitation_anticommutator}
+    Let $A$ be a primitive MPS tensor and let $p>0$ be a blocking length.
+    For $B=\operatorname{block}_p(A)$, the defect of the two open-chain
+    ground-space projectors on three sites of $B$ is exactly the defect of the
+    corresponding three consecutive $p$-site regions of $A$.  In particular,
+    the bound
     \begin{align}
-        \lVert q_iq_j-P_{ij}\rVert
-        &\le
-        \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}.
-        \notag
+        \left\lVert
+          P^{\mathrm{tail}}_{1,2}(B)P^{\mathrm{left}}_2(B)
+          -P_{\mathcal G_3^{\mathrm{ES}}(B)}
+        \right\rVert
+        &\leq \frac{7}{16}
     \end{align}
-    This blocked-to-cyclic comparison is a separate transport obligation after
-    condition C3.  It is not a pairwise consequence of the open-chain estimate.
+    gives the adjacent three-site anticommutator inequality
+    \begin{align}
+        h_0h_1+h_1h_0&\geq-\frac{7}{16}(h_0+h_1).
+    \end{align}
+    The same quadratic-form inequality holds for every forward or backward
+    adjacent pair of cyclic range-two terms on every chain of length at least
+    three, including pairs crossing the periodic cut.
 \end{lemma}
 
-\begin{lemma}[Blocked open-chain input for the cyclic martingale condition]
+\begin{theorem}[Uniform gap for a blocked primitive MPS parent Hamiltonian]
     \label{lem:martingale_mps}
-    \notready
-    \discussion{5925}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth}
+    \leanok
     \uses{lem:blocked_to_cyclic_ground_projector_comparison,
-        thm:friedrichs_ground_space_excitation_anticommutator,
-        lem:cyclic_window_overlap_cardinality}
-    Under the hypotheses and notation of
-    Lemma~\ref{lem:blocked_to_cyclic_ground_projector_comparison}, the cyclic
-    excitation projections $h_i=\Id-q_i$ satisfy
+        lem:cyclic_window_overlap_cardinality,
+        thm:anticommutator_gap_bound}
+    Let $A$ be a primitive MPS tensor with nonzero physical and bond dimensions,
+    and suppose that its fixed point is positive definite.  There is a blocking
+    length $p>0$ such that $A$ is $p$-block injective and, with
+    $B=\operatorname{block}_p(A)$, for every $N\geq4$ and every
+    $v\in(\ker H_{N,2}(B))^\perp$,
     \begin{align}
-        h_i h_j+h_jh_i
-        &\ge
-        -\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}(h_i+h_j)
-        \notag
+        \frac{1}{8}\lVert v\rVert
+        &\leq \lVert H_{N,2}(B)v\rVert.
     \end{align}
-    in quadratic form for every overlapping off-diagonal pair.  The cyclic
-    overlap-cardinality bound makes these coefficients row summable.  No
-    all-vector excitation-compression estimate is used.
-\end{lemma}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:blocked_to_cyclic_ground_projector_comparison,
+        lem:cyclic_window_overlap_cardinality,
+        thm:anticommutator_gap_bound}
+    Choose $p$ so that the three-block projector defect is at most $7/16$.
+    Lemma~\ref{lem:blocked_to_cyclic_ground_projector_comparison} gives the same
+    coefficient for every overlapping cyclic pair.  For range two each row has
+    at most two such pairs, so the martingale estimate gives
+    $1-2(7/16)=1/8$.
+\end{proof}
 
 \begin{theorem}[Uniform gap for normal MPS parent Hamiltonians]
     \label{thm:normal_mps_parent_hamiltonian_gap}
@@ -2271,9 +2288,11 @@ norm estimate is derived here.
         &\le \lVert H_{N,L}(A)v\rVert.
         \notag
     \end{align}
-    The construction passes through an injective blocking; the proof must
-    compare the blocked interaction with this stated parent Hamiltonian rather
-    than suppressing the change of blocking unit.
+    Theorem~\ref{lem:martingale_mps} proves this estimate only for the
+    range-two Hamiltonian of $B=\operatorname{block}_p(A)$ on $N$ blocked sites.
+    It does not identify that operator, its kernel, or its energy scale with
+    the range-$L$ Hamiltonian of $A$ on the original-site chain.  The remaining
+    step is precisely this blocked-to-original interaction comparison.
 \end{theorem}
 
 \begin{proof}
@@ -2281,9 +2300,10 @@ norm estimate is derived here.
     \discussion{5926}
     \uses{lem:martingale_mps, thm:anticommutator_gap_bound,
         thm:parent_hamiltonian_gapped}
-    Apply the completed cyclic anticommutator reduction to the constants supplied
-    by Lemma~\ref{lem:martingale_mps}, then perform the stated blocked-to-original
-    interaction comparison.
+    Apply Theorem~\ref{lem:martingale_mps} to the blocked tensor.  Then compare
+    its range-two local projections and ground-space complement with a fixed-range
+    parent interaction for $A$ in original-site units, retaining a uniform positive
+    lower bound under that comparison.
 \end{proof}
 
 \begin{theorem}[Gap bound from cyclic overlap compression]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -426,7 +426,7 @@ nonzero vector.
 
 \section{Relation to the blueprint}
 
-The blueprint item labelled \path{lem:martingale_mps} in
+The blueprint item labelled \path{thm:martingale_mps} in
 \path{blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex}
 records the completed blocked range-two theorem.  For a primitive tensor with a
 positive-definite fixed point it chooses $p>0$, sets

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -111,9 +111,9 @@ $\eta_l<1/\sqrt{2}$, and Theorem~3 gives the corresponding gap lower bounds
 \cite[Equations~(2.4)--(2.5) and Theorem~3]{Nachtergaele1996Spectral}. In
 Section~6, Nachtergaele proves the GVBS/MPS gap by verifying C3$'$ using the
 projection estimates inherited from Fannes--Nachtergaele--Werner
-\cite[Section~6]{Nachtergaele1996Spectral}. The remaining formal task is to
-convert one of these source estimates to the cyclic-window inequality used
-below, with constants in the same blocking convention.
+\cite[Section~6]{Nachtergaele1996Spectral}. The formal development instead
+obtains a sufficient range-two estimate after physical blocking.  The optimized
+FNW numerator and the identification of its source constants remain open.
 
 \subsection{Open-chain projector geometry}
 
@@ -160,9 +160,9 @@ The companion theorem
 \leanid{MPSTensor.IsPrimitiveMPS.exists_re_inner_openChain_anticommutator_ge_c3_threshold}
 combines Nachtergaele's projector-defect identity with the two-projection
 estimate proved here to give the corresponding anticommutator inequality for
-every left length.  The remaining task is the separate blocked-to-cyclic
-comparison, including windows
-crossing the periodic cut.  No excitation-compression estimate is used.
+every left length.  For the final range-two argument, exact blocked three-site
+identities now connect the three-block defect to the local terms of the blocked
+tensor.  No excitation-compression estimate is used.
 
 \subsection{Three-site to cyclic transport}
 
@@ -183,16 +183,21 @@ restriction, and sums over the complement.  Since the window may begin at any
 site, the result includes positions crossing the periodic cut; the backward
 statement begins the forward window at the cyclic predecessor.
 
-This theorem is only transport infrastructure.  It does not supply the
-three-site numerical estimate, does not claim the optimized FNW coefficient,
-and does not use an excitation-compression surrogate.  In particular, the
-open-chain C3 estimate still has to be identified with the two concrete
-three-site range-two local terms before it can feed this transport theorem.
+The exact identification is
+\leanid{MPSTensor.blockTensor_threeSite_openChain_defect_norm_eq}.  It equates
+the three-site open-chain projector defect of $B=\operatorname{block}_p(A)$
+with the whole-block defect on three consecutive $p$-site regions of $A$.
+Together with
+\leanid{MPSTensor.IsPrimitiveMPS.exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths},
+it supplies the coefficient $7/16$ for the adjacent three-site terms of $B$.
+The two transport theorems above then cover every overlapping off-diagonal
+cyclic pair, including the periodic cut.  This argument does not claim the
+optimized FNW coefficient and does not use an excitation-compression surrogate.
 
 \section{Finite-row martingale reduction}
 
-The current development separates the finite-row martingale algebra from the
-remaining MPS-specific principal-angle estimate. Fix an interaction range
+The current development separates the general finite-row martingale algebra from
+the completed range-two blocked MPS specialization. Fix an interaction range
 $L>1$ and an $N$-site periodic chain with $N\ge 2L$. Let $p_i$ denote the
 Hilbert-space representative of the length-$L$ local parent-Hamiltonian
 projection at the cyclic window starting at $i$. Write $i\sim_L j$ when the two
@@ -331,19 +336,19 @@ existential MPS gap theorem, but it would not immediately be the displayed
 all-$L$ estimate with constant $1/(4L)$ unless the constants are converted to
 the same blocking convention.
 
-Consequently the remaining comparison is neither the row-sum algebra nor the
-generic two-projection geometry; both parts have been isolated and formalized.
-In particular,
+The general source comparison remains open at the level of the optimized FNW
+coefficient and its source constants.  It is no longer needed for the proved
+range-two blocked theorem: the exact three-site identification gives coefficient
+$7/16$, and cyclic transport gives every overlapping pair.  In particular,
 \leanid{re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
 shows that a Friedrichs bound $\eta$ for the two ground-space ranges, after
 removing their common intersection, gives
 \[
   h_i h_j+h_jh_i\ge -\eta(h_i+h_j)
 \]
-for the complementary excitation projections. The remaining comparison is
-whether the cited FNW--Nachtergaele--Kastoryano estimates supply the required
-uniform ground-space Friedrichs bound, with constants independent of the chain
-length, after the same blocking convention has been fixed.
+for the complementary excitation projections. What remains open is whether the
+cited FNW--Nachtergaele--Kastoryano estimates recover their optimized numerator
+and source constants in the present Gram and blocking conventions.
 The qualitative fact that two finite-dimensional subspaces have a well-defined
 principal-angle decomposition is not enough: the martingale reduction needs a
 uniform numerical bound after the same blocking convention has been fixed.
@@ -407,9 +412,10 @@ and
 \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt},
 with public reformulations
 \leanid{parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant} and
-\leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. The correct
-remaining route is the blocked-to-cyclic ground-projector comparison tracked
-in issue~\#5925. The generic theorem
+\leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. For the
+blocked range-two theorem, the exact three-site projector identity and the
+forward and backward adjacent-pair transports replace this conditional route.
+The generic theorem
 \leanid{re_inner_anticommutator_starProjection_orthogonal_ge_neg_of_friedrichs_bound}
 then supplies the excitation-projection anticommutator estimate. This route uses
 the intersection identity $\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
@@ -422,13 +428,12 @@ nonzero vector.
 
 The blueprint item labelled \path{lem:martingale_mps} in
 \path{blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex}
-separates the finite-row martingale reduction from the still-open cyclic
-comparison.
-It does not assert that the displayed all-$L>1$ cyclic-window bound has already
-been obtained from the cited principal-angle estimates. Instead, it records the
-source anticommutator estimate as the hypothesis of
-Theorem \path{thm:anticommutator_gap_bound}, and records norm-compression
-estimates as sufficient stronger hypotheses.
+records the completed blocked range-two theorem.  For a primitive tensor with a
+positive-definite fixed point it chooses $p>0$, sets
+$B=\operatorname{block}_p(A)$, and proves a gap lower bound $1/8$ for
+$H_{N,2}(B)$ for every $N\ge4$.  Its preceding item records the exact
+three-site projector identification and the transport of the $7/16$ adjacent
+anticommutator estimate to every cyclic overlap.
 
 The source-matching theorem entry
 \path{thm:anticommutator_gap_bound} points to
@@ -453,27 +458,21 @@ The two norm-compression theorem entries are therefore conditional on the same
 stronger input, specialized either to this displayed coefficient or to an
 arbitrary coefficient satisfying (E). Thus all finite-row, cyclic-window,
 non-overlap, anticommutator, norm-compression, and spectral-theorem reductions
-are proved, while the MPS-specific anticommutator estimate remains to be proved
-or matched precisely to the cited martingale estimates.
-
-The open-chain threshold is now settled.  Once the blocked-to-cyclic comparison
-is proved, the blueprint should say that the cyclic-window anticommutator
-estimate follows under the convention used here. The blueprint should
-identify the reduced ground-space
-Friedrichs-to-anticommutator reduction as the source-facing route. The all-vector
-compression bound (N$_\eta$), if separately assumed, is only a stronger
-conditional estimate implying a gap.
+are proved, and the blocked
+range-two MPS specialization is complete.  The all-vector compression bound
+(N$_\eta$), if separately assumed, remains only a stronger conditional estimate.
+The separate open problem is to compare the blocked Hamiltonian with a parent
+interaction for the original tensor in original-site units, as recorded under
+issue~\#5926.
 
 \section{Conclusion}
 
-The conclusion is a difference between the review paragraph and the formal
-quantitative statement, with one mathematical comparison still to be made. The
-source states the martingale condition in terms of general row-sum coefficients
-and invokes principal-angle estimates to obtain a positive MPS parent-Hamiltonian
-gap. The formal proof contains the direct finite-overlap anticommutator
-reduction for cyclic windows, specializes the row coefficients to
-$c_{ij}=1/(2(L-1))$ on overlapping pairs, and leaves the remaining MPS-specific
-work as the source anticommutator estimate. It also records the stronger
+The source states the martingale condition in terms of general row-sum
+coefficients and invokes principal-angle estimates to obtain a positive MPS
+parent-Hamiltonian gap. The formal proof contains the direct finite-overlap
+anticommutator reduction for cyclic windows and specializes it to the blocked
+range-two tensor with adjacent-pair coefficient $7/16$, giving gap $1/8$. It
+also records the stronger
 norm-compression route
 \[
     \|p_i p_j v\|\le \eta\|p_i v\|,
@@ -488,10 +487,9 @@ is a sufficient special case for this stronger route, not the only possible way
 to use the formal martingale reduction.
 
 The Cirac--Perez-Garcia--Schuch--Verstraete 2021 statement is not being
-challenged. The comparison records that the available formal argument is more
-explicit than the review paragraph: the exact constants and the cyclic-window
-blocking convention still have to be compared with the FNW, Nachtergaele, and
-Kastoryano--Lucia estimates.
+challenged.  The formal result gives a sufficient explicit constant for the
+range-two parent Hamiltonian after blocking.  Recovering the optimized FNW
+numerator and its source constants remains a separate comparison.
 
 \section{Inverse-Gram reduction and the remaining optimized FNW comparison}
 
@@ -1252,14 +1250,16 @@ conversion retains its proved $D^{3/2}$ norm factor inside $g$.
 
 \section{Verdict}
 
-\textbf{Verdict: scope restriction.}  The exact
-whole-increment algebra, the reconstructed prefix-uniform geometric
-C3$^\prime$-type estimate, and the three-block coefficient $7/16$ are proved.
-All lengths are measured in sites of the input tensor.  These bounds come from
-the formal inverse-Gram reconstruction and are not attributed to FNW.  The
-optimized FNW numerator and its source constants remain open, as does the
-blocked-to-cyclic ground-projector comparison needed for the periodic
-parent-Hamiltonian gap theorem.
+\textbf{Verdict: scope restriction.}  The exact whole-increment algebra, the
+reconstructed prefix-uniform geometric C3$^\prime$-type estimate, the
+three-block coefficient $7/16$, and the resulting cyclic range-two gap $1/8$
+for a suitable blocked tensor are proved.  All lengths before blocking are
+measured in sites of the input tensor, while the final chain length counts
+blocked sites.  These bounds come from the formal inverse-Gram reconstruction
+and are not attributed to FNW.  The optimized FNW numerator and its source
+constants remain open.  Issue~\#5926 concerns the separate comparison between
+this blocked range-two Hamiltonian and an interaction for the original tensor;
+no additional public existential theorem is asserted here.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- transport the three-block whole-increment projector defect through the explicit blocked Hilbert-space isometry, including both spectator spaces;
- identify the resulting three-site excitation projections with the adjacent range-two local terms;
- transport the coefficient $7/16$ to every forward and backward cyclic overlap and discharge the range-two row-sum reduction;
- prove the explicit blocked gap constant $1/8$ and instantiate the public positive-gap consumer;
- synchronize Chapter 13 and the martingale paper-gap note, retaining #5926 as the blocked-to-original interaction comparison.

The conclusion concerns only `blockTensor A p` with interaction range two. It makes no comparison with the original-site parent interaction.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap TNLean.MPS.ParentHamiltonian.Martingale` (8881 jobs)
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- double LuaLaTeX pass for `blueprint/src/print.tex` with `TEXINPUTS="../../tex/tenkz//:"`
- `git diff --check`

Closes #6156
Closes #5925

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof (~460 lines) in core MPS parent-Hamiltonian theory with many Hilbert-space transport lemmas; conclusions are scoped to blocked tensors only, limiting blast radius.
> 
> **Overview**
> Adds **`Martingale/BlockedGap.lean`** and wires it into the parent-Hamiltonian martingale stack. The new file proves that a primitive MPS with a positive-definite fixed point admits a block length `p` such that the **range-two** parent Hamiltonian of `blockTensor A p` has an explicit spectral gap **1/8** (and a packaged uniform positive gap).
> 
> The proof chain is: equate the blocked three-site open-chain projector defect with the whole-increment defect on three original `p`-site blocks (`blockTensor_threeSite_openChain_defect_norm_eq`), pull in the existing **7/16** bound, turn that into cyclic overlapping-pair anticommutator estimates, then apply the existing martingale gap consumer. **No** identification with the original-site parent Hamiltonian is claimed.
> 
> **Blueprint** Ch.13 and **`docs/paper-gaps/cpgsv21_martingale_overlap.tex`** are updated: the blocked range-two theorem is marked complete; the normal-MPS gap on the unblocked chain remains an open blocked-to-original comparison (#5926).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef1c5aa04a8b5fd130b564c3962bed94b9f8d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->