### PR TITLE
docs(blueprint): sharpen compression-spectrum scope

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5179,18 +5179,18 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     thm:mpu_two_projection_angle_block}
   Let $P$ and $Q$ be orthogonal projections on a finite-dimensional complex
   inner-product space, with compression spectral data $(x_i,\mu_i)$. Then
-  $\mu_i\in[0,1]$ for every $i$, and exactly the following source-relevant
-  alternatives hold:
+  $\mu_i\in[0,1]$ for every $i$, and exactly one of the following alternatives
+  holds:
   \begin{enumerate}
     \item $\mu_i=0$ and $Qx_i=0$;
     \item $\mu_i=1$ and $Qx_i=x_i$;
     \item $0<\mu_i<1$, and $x_i$ belongs to the two-dimensional angle block
       described in Theorem~\ref{thm:mpu_two_projection_angle_block}.
   \end{enumerate}
-  This theorem classifies the compression eigenvectors. The pairwise
-  orthogonality of the resulting angle blocks, the ambient orthogonal direct
-  sum, and commutation on its remaining summand are separate.
+  This theorem classifies the compression eigenvectors.
   % Source lines: paper_v2.tex 759--762.
+  % Scope: no pairwise orthogonality of angle blocks, no ambient orthogonal
+  % direct sum, and no commutation on the remaining summand.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## What changed

- state the Chapter 28 compression-spectrum trichotomy as exactly one exhaustive alternative
- retain the mathematical classification sentence while moving the negative scope disclaimer into a LaTeX comment

This is the focused documentation follow-up to #6316 and addresses the two remaining exact-head blueprint review threads for #6294. It does not close #6294.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`
- `git diff --check`