### PR TITLE
feat(analysis): construct the reduced two-projection projector

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -66,4 +66,5 @@ import TNLean.Analysis.TraceNormVariational
 import TNLean.Analysis.TwoProjectionAngleBlock
 import TNLean.Analysis.TwoProjectionCompression
 import TNLean.Analysis.TwoProjectionCompressionSpectrum
+import TNLean.Analysis.TwoProjectionReducedProjection
 import TNLean.Analysis.UpperTriangularBound

--- a/TNLean/Analysis/TwoProjectionReducedProjection.lean
+++ b/TNLean/Analysis/TwoProjectionReducedProjection.lean
@@ -26,10 +26,9 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 
 /-- The reduced projection associated to two symmetric projections `P` and `Q`.
 
-It is the orthogonal projection onto `range (P.comp Q)`. By
-`reducedProjection_range_triple`, this is also the orthogonal projection onto
-`range (P.comp (Q.comp P))`, the coordinate-free form of the blockwise projector
-from arXiv:1703.09188, Proposition IV.5, lines 764–770. -/
+It is the orthogonal projection onto `range (P.comp Q)`. The source instead defines
+its projector blockwise in arXiv:1703.09188, Proposition IV.5, line 764. Identifying
+that blockwise projector with this canonical construction belongs to issue #6294. -/
 noncomputable def reducedProjection (P Q : E →ₗ[ℂ] E) : E →ₗ[ℂ] E :=
   (LinearMap.range (P.comp Q)).starProjection
 
@@ -45,8 +44,9 @@ theorem range_reducedProjection (P Q : E →ₗ[ℂ] E) :
 
 /-- For symmetric projections, `range (P.comp Q)` equals `range (P.comp Q.comp P)`.
 
-Thus `reducedProjection P Q` is exactly the projector onto the triple-product range
-specified in arXiv:1703.09188, Proposition IV.5, lines 764–770. -/
+This range identity is a coordinate-free consequence of the projection hypotheses. The
+source defines its reduced projector blockwise; issue #6294 owns the identification of
+that blockwise projector with `reducedProjection P Q`. -/
 theorem reducedProjection_range_triple {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     LinearMap.range (P.comp (Q.comp P)) = LinearMap.range (P.comp Q) := by
@@ -99,7 +99,10 @@ theorem comp_reducedProjection_left {P Q : E →ₗ[ℂ] E}
   simpa [LinearMap.adjoint_comp, hP.isSymmetric.adjoint_eq, hQ.isSymmetric.adjoint_eq,
     (reducedProjection_isSymmetric P Q).isSymmetric.adjoint_eq] using h.symm
 
-/-- The reduced product and the reduced projection have the same range. -/
+/-- The reduced product and the reduced projection have the same range.
+
+This derived range equality is the input to the equal-range right-factor theorem; it is
+not a separately stated item of arXiv:1703.09188, Proposition IV.5. -/
 theorem range_reducedProjection_comp {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) :
     LinearMap.range ((reducedProjection P Q).comp Q) =
@@ -113,15 +116,5 @@ theorem exists_reducedProjection_rightFactor {P Q : E →ₗ[ℂ] E}
       ((reducedProjection P Q).comp Q).comp Y.toLinearMap = reducedProjection P Q := by
   exact LinearMap.exists_linearEquiv_comp_eq_of_range_eq _ _
     (range_reducedProjection_comp hP)
-
-/-- The paper's right factor, expressed as a unit in the endomorphism ring. -/
-theorem exists_isUnit_reducedProjection_rightFactor {P Q : E →ₗ[ℂ] E}
-    (hP : P.IsSymmetricProjection) :
-    ∃ Y : Module.End ℂ E, IsUnit Y ∧
-      ((reducedProjection P Q).comp Q).comp Y = reducedProjection P Q := by
-  obtain ⟨Y, hY⟩ := exists_reducedProjection_rightFactor (P := P) (Q := Q) hP
-  refine ⟨Y.toLinearMap, ?_, hY⟩
-  rw [Module.End.isUnit_iff]
-  exact Y.bijective
 
 end LinearMap.IsSymmetricProjection

--- a/TNLean/Analysis/TwoProjectionReducedProjection.lean
+++ b/TNLean/Analysis/TwoProjectionReducedProjection.lean
@@ -64,7 +64,8 @@ theorem reducedProjection_range_triple {P Q : E →ₗ[ℂ] E}
   rw [hcomp, hAadj] at h
   exact h
 
-/-- The first source identity: `P.comp (reducedProjection P Q) = reducedProjection P Q`. -/
+/-- Property (i) of arXiv:1703.09188, Proposition IV.5, line 767:
+`P.comp (reducedProjection P Q) = reducedProjection P Q`. -/
 theorem comp_reducedProjection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) :
     P.comp (reducedProjection P Q) = reducedProjection P Q := by
@@ -74,7 +75,8 @@ theorem comp_reducedProjection {P Q : E →ₗ[ℂ] E}
   rw [range_reducedProjection] at hx
   exact LinearMap.range_comp_le_range Q P hx
 
-/-- The second source identity: `(reducedProjection P Q).comp Q = P.comp Q`. -/
+/-- Property (ii) of arXiv:1703.09188, Proposition IV.5, line 768:
+`(reducedProjection P Q).comp Q = P.comp Q`. -/
 theorem reducedProjection_comp {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) :
     (reducedProjection P Q).comp Q = P.comp Q := by
@@ -91,7 +93,8 @@ theorem reducedProjection_comp {P Q : E →ₗ[ℂ] E}
     rw [show P (P (Q x)) = P (Q x) by simpa [Module.End.mul_apply] using hPx,
       sub_self, inner_zero_left]
 
-/-- The third source identity: `Q.comp P = Q.comp (reducedProjection P Q)`. -/
+/-- Property (iii) of arXiv:1703.09188, Proposition IV.5, line 769:
+`Q.comp P = Q.comp (reducedProjection P Q)`. -/
 theorem comp_reducedProjection_left {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     Q.comp P = Q.comp (reducedProjection P Q) := by

--- a/TNLean/Analysis/TwoProjectionReducedProjection.lean
+++ b/TNLean/Analysis/TwoProjectionReducedProjection.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.EqualRangeRightFactor
+import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+
+/-!
+# The reduced projection of two orthogonal projections
+
+For symmetric projections `P` and `Q` on a finite-dimensional complex inner-product
+space, this file defines the reduced projection canonically as the orthogonal projection
+onto `range (P.comp Q)`. It proves the absorption and range identities used in
+arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`), lines 764–770, and obtains
+the invertible right factor from equality of ranges.
+-/
+
+open scoped InnerProductSpace
+
+namespace LinearMap.IsSymmetricProjection
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+/-- The reduced projection associated to two symmetric projections `P` and `Q`.
+
+It is the orthogonal projection onto `range (P.comp Q)`. By
+`reducedProjection_range_triple`, this is also the orthogonal projection onto
+`range (P.comp (Q.comp P))`, the coordinate-free form of the blockwise projector
+from arXiv:1703.09188, Proposition IV.5, lines 764–770. -/
+noncomputable def reducedProjection (P Q : E →ₗ[ℂ] E) : E →ₗ[ℂ] E :=
+  (LinearMap.range (P.comp Q)).starProjection
+
+/-- The reduced projection is a symmetric projection. -/
+theorem reducedProjection_isSymmetric (P Q : E →ₗ[ℂ] E) :
+    (reducedProjection P Q).IsSymmetricProjection := by
+  exact Submodule.isSymmetricProjection_starProjection _
+
+/-- The reduced projection has range `range (P.comp Q)`. -/
+theorem range_reducedProjection (P Q : E →ₗ[ℂ] E) :
+    LinearMap.range (reducedProjection P Q) = LinearMap.range (P.comp Q) := by
+  exact Submodule.range_starProjection _
+
+/-- For symmetric projections, `range (P.comp Q)` equals `range (P.comp Q.comp P)`.
+
+Thus `reducedProjection P Q` is exactly the projector onto the triple-product range
+specified in arXiv:1703.09188, Proposition IV.5, lines 764–770. -/
+theorem reducedProjection_range_triple {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    LinearMap.range (P.comp (Q.comp P)) = LinearMap.range (P.comp Q) := by
+  let A := Q.comp P
+  have hAadj : LinearMap.adjoint A = P.comp Q := by
+    simp [A, LinearMap.adjoint_comp, hP.isSymmetric.adjoint_eq,
+      hQ.isSymmetric.adjoint_eq]
+  have h := LinearMap.range_adjoint_comp_self A
+  have hcomp : (LinearMap.adjoint A).comp A = P.comp (Q.comp P) := by
+    rw [hAadj]
+    ext x
+    change P (Q (Q (P x))) = P (Q (P x))
+    have hQx := congrArg (fun T : Module.End ℂ E ↦ T (P x)) hQ.isIdempotentElem.eq
+    simpa [Module.End.mul_apply] using congrArg P hQx
+  rw [hcomp, hAadj] at h
+  exact h
+
+/-- The first source identity: `P.comp (reducedProjection P Q) = reducedProjection P Q`. -/
+theorem comp_reducedProjection {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) :
+    P.comp (reducedProjection P Q) = reducedProjection P Q := by
+  ext x
+  apply (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
+  have hx : reducedProjection P Q x ∈ LinearMap.range (reducedProjection P Q) := ⟨x, rfl⟩
+  rw [range_reducedProjection] at hx
+  exact LinearMap.range_comp_le_range Q P hx
+
+/-- The second source identity: `(reducedProjection P Q).comp Q = P.comp Q`. -/
+theorem reducedProjection_comp {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) :
+    (reducedProjection P Q).comp Q = P.comp Q := by
+  ext x
+  apply Submodule.eq_starProjection_of_mem_orthogonal
+  · exact ⟨x, rfl⟩
+  · rw [Submodule.mem_orthogonal']
+    intro y hy
+    obtain ⟨z, rfl⟩ := hy
+    change ⟪Q x - P (Q x), P (Q z)⟫_ℂ = 0
+    rw [← hP.isSymmetric (Q x - P (Q x)) (Q z)]
+    have hPx := congrArg (fun T : Module.End ℂ E ↦ T (Q x)) hP.isIdempotentElem.eq
+    simp only [map_sub]
+    rw [show P (P (Q x)) = P (Q x) by simpa [Module.End.mul_apply] using hPx,
+      sub_self, inner_zero_left]
+
+/-- The third source identity: `Q.comp P = Q.comp (reducedProjection P Q)`. -/
+theorem comp_reducedProjection_left {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    Q.comp P = Q.comp (reducedProjection P Q) := by
+  have h := congrArg LinearMap.adjoint (reducedProjection_comp (P := P) (Q := Q) hP)
+  simpa [LinearMap.adjoint_comp, hP.isSymmetric.adjoint_eq, hQ.isSymmetric.adjoint_eq,
+    (reducedProjection_isSymmetric P Q).isSymmetric.adjoint_eq] using h.symm
+
+/-- The reduced product and the reduced projection have the same range. -/
+theorem range_reducedProjection_comp {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) :
+    LinearMap.range ((reducedProjection P Q).comp Q) =
+      LinearMap.range (reducedProjection P Q) := by
+  rw [reducedProjection_comp hP, range_reducedProjection]
+
+/-- The invertible right factor in arXiv:1703.09188, Proposition IV.5, line 770. -/
+theorem exists_reducedProjection_rightFactor {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) :
+    ∃ Y : E ≃ₗ[ℂ] E,
+      ((reducedProjection P Q).comp Q).comp Y.toLinearMap = reducedProjection P Q := by
+  exact LinearMap.exists_linearEquiv_comp_eq_of_range_eq _ _
+    (range_reducedProjection_comp hP)
+
+/-- The paper's right factor, expressed as a unit in the endomorphism ring. -/
+theorem exists_isUnit_reducedProjection_rightFactor {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) :
+    ∃ Y : Module.End ℂ E, IsUnit Y ∧
+      ((reducedProjection P Q).comp Q).comp Y = reducedProjection P Q := by
+  obtain ⟨Y, hY⟩ := exists_reducedProjection_rightFactor (P := P) (Q := Q) hP
+  refine ⟨Y.toLinearMap, ?_, hY⟩
+  rw [Module.End.isUnit_iff]
+  exact Y.bijective
+
+end LinearMap.IsSymmetricProjection

--- a/TNLean/Analysis/TwoProjectionReducedProjection.lean
+++ b/TNLean/Analysis/TwoProjectionReducedProjection.lean
@@ -12,9 +12,9 @@ import Mathlib.Analysis.InnerProductSpace.Projection.Basic
 
 For symmetric projections `P` and `Q` on a finite-dimensional complex inner-product
 space, this file defines the reduced projection canonically as the orthogonal projection
-onto `range (P.comp Q)`. It proves the absorption and range identities used in
-arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`), lines 764–770, and obtains
-the invertible right factor from equality of ranges.
+onto `range (P.comp Q)`. It proves properties (i)–(iii) of arXiv:1703.09188,
+Proposition IV.5, lines 764–769, together with the required range equality, and obtains
+the invertible right factor in property (iv) from equality of ranges.
 -/
 
 open scoped InnerProductSpace

--- a/TNLean/Analysis/TwoProjectionReducedProjection.lean
+++ b/TNLean/Analysis/TwoProjectionReducedProjection.lean
@@ -28,7 +28,8 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 
 It is the orthogonal projection onto `range (P.comp Q)`. The source instead defines
 its projector blockwise in arXiv:1703.09188, Proposition IV.5, line 764. Identifying
-that blockwise projector with this canonical construction belongs to issue #6294. -/
+that blockwise projector with this canonical construction is recorded in
+`docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
 noncomputable def reducedProjection (P Q : E →ₗ[ℂ] E) : E →ₗ[ℂ] E :=
   (LinearMap.range (P.comp Q)).starProjection
 
@@ -45,8 +46,9 @@ theorem range_reducedProjection (P Q : E →ₗ[ℂ] E) :
 /-- For symmetric projections, `range (P.comp Q)` equals `range (P.comp Q.comp P)`.
 
 This range identity is a coordinate-free consequence of the projection hypotheses. The
-source defines its reduced projector blockwise; issue #6294 owns the identification of
-that blockwise projector with `reducedProjection P Q`. -/
+source defines its reduced projector blockwise; the identification of that blockwise
+projector with `reducedProjection P Q` is recorded in
+`docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
 theorem reducedProjection_range_triple {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     LinearMap.range (P.comp (Q.comp P)) = LinearMap.range (P.comp Q) := by

--- a/TNLean/Analysis/TwoProjectionReducedProjection.lean
+++ b/TNLean/Analysis/TwoProjectionReducedProjection.lean
@@ -27,9 +27,9 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
 /-- The reduced projection associated to two symmetric projections `P` and `Q`.
 
 It is the orthogonal projection onto `range (P.comp Q)`. The source instead defines
-its projector blockwise in arXiv:1703.09188, Proposition IV.5, line 764. Identifying
-that blockwise projector with this canonical construction is recorded in
-`docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
+its projector blockwise in arXiv:1703.09188, Proposition IV.5, line 764. The
+identification with that blockwise projector remains part of the global Jordan
+decomposition; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
 noncomputable def reducedProjection (P Q : E →ₗ[ℂ] E) : E →ₗ[ℂ] E :=
   (LinearMap.range (P.comp Q)).starProjection
 
@@ -46,8 +46,8 @@ theorem range_reducedProjection (P Q : E →ₗ[ℂ] E) :
 /-- For symmetric projections, `range (P.comp Q)` equals `range (P.comp Q.comp P)`.
 
 This range identity is a coordinate-free consequence of the projection hypotheses. The
-source defines its reduced projector blockwise; the identification of that blockwise
-projector with `reducedProjection P Q` is recorded in
+source defines its reduced projector blockwise, and identifying that projector with
+`reducedProjection P Q` remains part of the global Jordan decomposition; see
 `docs/paper-gaps/1703_two_projection_projector_typo.tex`. -/
 theorem reducedProjection_range_triple {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5214,9 +5214,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{}
   Let $P$ and $Q$ be orthogonal projections on a finite-dimensional complex
   inner-product space. Define $\widetilde P$ as the orthogonal projection onto
-  $\operatorname{ran}(PQ)$. Since
-  $\operatorname{ran}(PQP)=\operatorname{ran}(PQ)$, this is also the
-  orthogonal projection onto the triple-product range used in the source.
+  $\operatorname{ran}(PQ)$. The source defines $\widetilde P$ blockwise;
+  identifying its projector with this canonical construction belongs to
+  issue~\#6294.
   % Source lines: paper_v2.tex 764--770.
 \end{definition}
 
@@ -5233,18 +5233,24 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpu_two_projection_reduced_projection}
   The reduced projection satisfies
   \begin{align}
-    P\widetilde P&=\widetilde P,&
-    \widetilde P Q&=PQ,&
-    Q\widetilde P&=QP,&
-    \operatorname{ran}(\widetilde P Q)&=\operatorname{ran}\widetilde P.
+    \operatorname{ran}(\widetilde P)&=\operatorname{ran}(PQ),\\
+    \operatorname{ran}(PQP)&=\operatorname{ran}(PQ),\\
+    P\widetilde P&=\widetilde P,\\
+    \widetilde P Q&=PQ,\\
+    Q\widetilde P&=QP,\\
+    \operatorname{ran}(\widetilde P Q)&=\operatorname{ran}(\widetilde P).
   \end{align}
+  The first two identities describe the canonical construction, while the next
+  three establish the properties in source lines 767--769. Identifying this
+  construction with the source's blockwise projector remains in issue~\#6294.
+  The final range equality is a derived input to the right-factor theorem, not
+  item~(iv) of the source.
   % Source lines: paper_v2.tex 764--769.
 \end{theorem}
 
 \begin{theorem}[Invertible right factor for the reduced projection]
   \label{thm:mpu_two_projection_reduced_projection_right_factor}
-  \lean{LinearMap.IsSymmetricProjection.exists_reducedProjection_rightFactor,
-    LinearMap.IsSymmetricProjection.exists_isUnit_reducedProjection_rightFactor}
+  \lean{LinearMap.IsSymmetricProjection.exists_reducedProjection_rightFactor}
   \leanok
   \uses{thm:mpu_two_projection_reduced_projection}
   There is an invertible linear map $Y$ such that
@@ -5259,6 +5265,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \notready
   \discussion{6022}
   \uses{def:mpu_canonical_form,ThmFund1,thm:mpu_two_projection_angle_block,
+    thm:mpu_two_projection_reduced_projection,
     thm:mpu_two_projection_reduced_projection_right_factor}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors
   generating MPUs, without requiring the path to be in canonical form. For

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5214,9 +5214,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{}
   Let $P$ and $Q$ be orthogonal projections on a finite-dimensional complex
   inner-product space. Define $\widetilde P$ as the orthogonal projection onto
-  $\operatorname{ran}(PQ)$. The source defines $\widetilde P$ blockwise;
-  identifying its projector with this canonical construction belongs to
-  issue~\#6294.
+  $\operatorname{ran}(PQ)$.
+  % The source defines Ptilde blockwise; issue #6294 owns the identification
+  % of that projector with this canonical construction.
   % Source lines: paper_v2.tex 764--770.
 \end{definition}
 
@@ -5241,10 +5241,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     \operatorname{ran}(\widetilde P Q)&=\operatorname{ran}(\widetilde P).
   \end{align}
   The first two identities describe the canonical construction, while the next
-  three establish the properties in source lines 767--769. Identifying this
-  construction with the source's blockwise projector remains in issue~\#6294.
-  The final range equality is a derived input to the right-factor theorem, not
-  item~(iv) of the source.
+  three establish the properties in source lines 767--769. The final range
+  equality is the derived input to the right-factor theorem, not item~(iv) of
+  the source.
+  % Identifying the canonical construction with the source's blockwise
+  % projector remains in issue #6294.
   % Source lines: paper_v2.tex 764--769.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5207,11 +5207,59 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   Theorem~\ref{thm:mpu_two_projection_angle_block}.
 \end{proof}
 
+\begin{definition}[Reduced projection]
+  \label{def:mpu_two_projection_reduced_projection}
+  \lean{LinearMap.IsSymmetricProjection.reducedProjection}
+  \leanok
+  \uses{}
+  Let $P$ and $Q$ be orthogonal projections on a finite-dimensional complex
+  inner-product space. Define $\widetilde P$ as the orthogonal projection onto
+  $\operatorname{ran}(PQ)$. Since
+  $\operatorname{ran}(PQP)=\operatorname{ran}(PQ)$, this is also the
+  orthogonal projection onto the triple-product range used in the source.
+  % Source lines: paper_v2.tex 764--770.
+\end{definition}
+
+\begin{theorem}[Reduced-projection identities]
+  \label{thm:mpu_two_projection_reduced_projection}
+  \lean{LinearMap.IsSymmetricProjection.reducedProjection_isSymmetric,
+    LinearMap.IsSymmetricProjection.range_reducedProjection,
+    LinearMap.IsSymmetricProjection.reducedProjection_range_triple,
+    LinearMap.IsSymmetricProjection.comp_reducedProjection,
+    LinearMap.IsSymmetricProjection.reducedProjection_comp,
+    LinearMap.IsSymmetricProjection.comp_reducedProjection_left,
+    LinearMap.IsSymmetricProjection.range_reducedProjection_comp}
+  \leanok
+  \uses{def:mpu_two_projection_reduced_projection}
+  The reduced projection satisfies
+  \begin{align}
+    P\widetilde P&=\widetilde P,&
+    \widetilde P Q&=PQ,&
+    Q\widetilde P&=QP,&
+    \operatorname{ran}(\widetilde P Q)&=\operatorname{ran}\widetilde P.
+  \end{align}
+  % Source lines: paper_v2.tex 764--769.
+\end{theorem}
+
+\begin{theorem}[Invertible right factor for the reduced projection]
+  \label{thm:mpu_two_projection_reduced_projection_right_factor}
+  \lean{LinearMap.IsSymmetricProjection.exists_reducedProjection_rightFactor,
+    LinearMap.IsSymmetricProjection.exists_isUnit_reducedProjection_rightFactor}
+  \leanok
+  \uses{thm:mpu_two_projection_reduced_projection}
+  There is an invertible linear map $Y$ such that
+  \begin{align}
+    \widetilde P QY=\widetilde P.
+  \end{align}
+  % Source line: paper_v2.tex 770.
+\end{theorem}
+
 \begin{proposition}[Constancy of the source ranks]
   \label{prop:continuity-index}
   \notready
   \discussion{6022}
-  \uses{def:mpu_canonical_form,ThmFund1,thm:mpu_two_projection_angle_block}
+  \uses{def:mpu_canonical_form,ThmFund1,thm:mpu_two_projection_angle_block,
+    thm:mpu_two_projection_reduced_projection_right_factor}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors
   generating MPUs, without requiring the path to be in canonical form. For
   each $x$, take the canonical form and the two source-cut ranks $r(x)$ and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5248,6 +5248,29 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   % Source lines: paper_v2.tex 764--769.
 \end{theorem}
 
+\begin{proof}\leanok
+  Set $A=QP$. The standard range identity for $A^\dagger A$ gives
+  \begin{align}
+    \operatorname{ran}(PQP)
+      &=\operatorname{ran}(A^\dagger A)
+       =\operatorname{ran}(A^\dagger)
+       =\operatorname{ran}(PQ).
+  \end{align}
+  By definition, $\operatorname{ran}(\widetilde P)=\operatorname{ran}(PQ)$,
+  which also gives $P\widetilde P=\widetilde P$. For all $x$ and $z$,
+  \begin{align}
+    \left\langle Qx-PQx,\,PQz\right\rangle&=0.
+  \end{align}
+  Hence $Qx-PQx\in\operatorname{ran}(PQ)^\perp$, so orthogonal projection
+  onto this range yields $\widetilde P Q=PQ$. Taking adjoints gives
+  $Q\widetilde P=QP$. Finally,
+  \begin{align}
+    \operatorname{ran}(\widetilde P Q)
+      &=\operatorname{ran}(PQ)
+       =\operatorname{ran}(\widetilde P).
+  \end{align}
+\end{proof}
+
 \begin{theorem}[Invertible right factor for the reduced projection]
   \label{thm:mpu_two_projection_reduced_projection_right_factor}
   \lean{LinearMap.IsSymmetricProjection.exists_reducedProjection_rightFactor}
@@ -5259,6 +5282,15 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
   % Source line: paper_v2.tex 770.
 \end{theorem}
+
+\begin{proof}\leanok
+  The equality
+  \begin{align}
+    \operatorname{ran}(\widetilde P Q)&=\operatorname{ran}(\widetilde P)
+  \end{align}
+  and the equal-ranges right-factor theorem give an invertible $Y$ satisfying
+  $\widetilde P QY=\widetilde P$.
+\end{proof}
 
 \begin{proposition}[Constancy of the source ranks]
   \label{prop:continuity-index}

--- a/docs/paper-gaps/1703_two_projection_projector_typo.tex
+++ b/docs/paper-gaps/1703_two_projection_projector_typo.tex
@@ -36,14 +36,28 @@ action of both operators on a generic two-dimensional block. This is a local
 correction of a typographical error and does not add a hypothesis or alter the
 mathematical claim.
 
+The declaration
+\leanid{LinearMap.IsSymmetricProjection.reducedProjection} defines the reduced
+projector as the orthogonal projector onto $\operatorname{ran}(PQ)$. The source
+defines its projector blockwise; identifying that projector with the canonical
+construction remains part of issue~\#6294. The associated theorems prove the
+three absorption identities in lines 767--769, the range identities
+\begin{align}
+  \operatorname{ran}(\widetilde P)&=\operatorname{ran}(PQ),\\
+  \operatorname{ran}(PQP)&=\operatorname{ran}(PQ),\\
+  \operatorname{ran}(\widetilde P Q)&=\operatorname{ran}(\widetilde P).
+\end{align}
+The final range identity is the derived input to the equal-range right-factor
+theorem, which gives the invertible map from line 770.
+
 \section{Verdict}
 
-\textbf{Verdict: resolved local fix (projector label).} The formalized angle
-block uses $Q$ as the second projector, which resolves the source's repeated
-$P$ label without changing the mathematical statement. The distinct global
-problem of assembling the generic and endpoint blocks into an orthogonal
-direct sum, and constructing the reduced projector used later in
-Proposition~IV.5, remains open.
+\textbf{Verdict: resolved local fix (projector label and reduced projector).}
+The formalized angle block uses $Q$ as the second projector, which resolves the
+source's repeated $P$ label without changing the mathematical statement. The
+reduced projector and its identities from lines 764--770 are also formalized.
+The distinct global problem of assembling the generic and endpoint blocks into
+an orthogonal direct sum remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- define the reduced projector canonically as the orthogonal projector onto `range(PQ)=range(PQP)`
- prove the three absorption identities and the exact reduced-product range equality from Proposition IV.5
- derive the paper's invertible right factor from the existing equal-range theorem
- document the completed reduced-projector step in Chapter 28 while leaving rank continuity `\notready`

No commutativity assumption or simultaneous diagonalization is used. This closes #6295 independently of the still-open explicit Jordan decomposition #6294.

## Validation

- `lake build TNLean.Analysis.TwoProjectionReducedProjection`
- `lake build TNLean.Analysis`
- generated import aggregator check
- blueprint sync and `leanblueprint checkdecls`
- two LuaLaTeX passes with zero undefined references
- `git diff --check`
- no `sorry` or new axiom

Closes #6295