### PR TITLE
feat(analysis): prove two-projection block orthogonality

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -65,6 +65,7 @@ import TNLean.Analysis.TraceNormAbs
 import TNLean.Analysis.TraceNormContractivity
 import TNLean.Analysis.TraceNormVariational
 import TNLean.Analysis.TwoProjectionAngleBlock
+import TNLean.Analysis.TwoProjectionAngleOrthogonality
 import TNLean.Analysis.TwoProjectionCompression
 import TNLean.Analysis.TwoProjectionCompressionSpectrum
 import TNLean.Analysis.TwoProjectionReducedProjection

--- a/TNLean/Analysis/TwoProjectionAngleOrthogonality.lean
+++ b/TNLean/Analysis/TwoProjectionAngleOrthogonality.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.TwoProjectionCompressionSpectrum
+import Mathlib.Analysis.InnerProductSpace.Orthogonal
+
+/-!
+# Orthogonality of two-projection angle blocks
+
+Distinct vectors in the chosen orthonormal eigenbasis of the compression of one orthogonal
+projection to the range of another determine orthogonal defect blocks. The argument never
+compares eigenvalues, so it applies without change inside repeated eigenspaces.
+
+These are the cross-block orthogonality identities in the Jordan-lemma decomposition used in
+arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`), lines 759–762.
+
+**Local fix (projector label):** Source line 762 repeats `P` for the second projector, where the
+surrounding argument requires `Q`; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+-/
+
+open scoped InnerProductSpace
+
+namespace LinearMap.IsSymmetricProjection
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+private abbrev CompressionIndex {P : E →ₗ[ℂ] E} := Fin (Module.finrank ℂ P.range)
+
+/-- Every compression eigenvector is orthogonal to every angle defect. -/
+theorem rangeCompressionEigenbasis_inner_angleDefect_eq_zero {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i j : CompressionIndex (P := P)) :
+    ⟪(rangeCompressionEigenbasis hP hQ i : E),
+      angleDefect Q (rangeCompressionEigenvalues hP hQ j)
+        (rangeCompressionEigenbasis hP hQ j : E)⟫_ℂ = 0 := by
+  let x := fun k => (rangeCompressionEigenbasis hP hQ k : E)
+  let μ := rangeCompressionEigenvalues hP hQ
+  have hxiP : P (x i) = x i :=
+    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
+      (rangeCompressionEigenbasis hP hQ i).property
+  have hxjEig : P (Q (x j)) = (μ j : ℂ) • x j :=
+    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ j)
+  rw [angleDefect, inner_sub_right, inner_smul_right]
+  calc
+    ⟪x i, Q (x j)⟫_ℂ - (μ j : ℂ) * ⟪x i, x j⟫_ℂ =
+        ⟪P (x i), Q (x j)⟫_ℂ - (μ j : ℂ) * ⟪x i, x j⟫_ℂ := by rw [hxiP]
+    _ = ⟪x i, P (Q (x j))⟫_ℂ - (μ j : ℂ) * ⟪x i, x j⟫_ℂ := by
+      rw [hP.isSymmetric]
+    _ = 0 := by rw [hxjEig, inner_smul_right]; exact sub_self _
+
+/-- Every angle defect is orthogonal to every compression eigenvector. -/
+theorem angleDefect_inner_rangeCompressionEigenbasis_eq_zero {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i j : CompressionIndex (P := P)) :
+    ⟪angleDefect Q (rangeCompressionEigenvalues hP hQ i)
+        (rangeCompressionEigenbasis hP hQ i : E),
+      (rangeCompressionEigenbasis hP hQ j : E)⟫_ℂ = 0 := by
+  rw [inner_eq_zero_symm]
+  exact rangeCompressionEigenbasis_inner_angleDefect_eq_zero hP hQ j i
+
+/-- Exact pairing of two angle defects, before imposing distinctness of their basis indices. -/
+theorem angleDefect_inner_angleDefect {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i j : CompressionIndex (P := P)) :
+    ⟪angleDefect Q (rangeCompressionEigenvalues hP hQ i)
+        (rangeCompressionEigenbasis hP hQ i : E),
+      angleDefect Q (rangeCompressionEigenvalues hP hQ j)
+        (rangeCompressionEigenbasis hP hQ j : E)⟫_ℂ =
+      (rangeCompressionEigenvalues hP hQ j *
+        (1 - rangeCompressionEigenvalues hP hQ j) : ℂ) *
+        ⟪(rangeCompressionEigenbasis hP hQ i : E),
+          (rangeCompressionEigenbasis hP hQ j : E)⟫_ℂ := by
+  let x := fun k => (rangeCompressionEigenbasis hP hQ k : E)
+  let μ := rangeCompressionEigenvalues hP hQ
+  have hxd : ⟪x i, angleDefect Q (μ j) (x j)⟫_ℂ = 0 :=
+    rangeCompressionEigenbasis_inner_angleDefect_eq_zero hP hQ i j
+  have hxjP : P (x j) = x j :=
+    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
+      (rangeCompressionEigenbasis hP hQ j).property
+  have hxjnorm : ‖x j‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one j
+  have hxjEig : P (Q (x j)) = (μ j : ℂ) • x j :=
+    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ j)
+  have hQdj := (angleDefect_block hP hQ hxjP hxjnorm hxjEig).2.2.1
+  change ⟪Q (x i) - (μ i : ℂ) • x i, angleDefect Q (μ j) (x j)⟫_ℂ = _
+  rw [inner_sub_left, inner_smul_left, hxd, mul_zero, sub_zero]
+  rw [hQ.isSymmetric, hQdj, inner_add_right, inner_smul_right, inner_smul_right, hxd,
+    mul_zero, add_zero]
+  norm_cast
+
+/-- Angle defects belonging to distinct compression-basis coordinates are orthogonal. This
+includes distinct basis vectors with the same compression eigenvalue. -/
+theorem angleDefect_inner_angleDefect_eq_zero {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    {i j : CompressionIndex (P := P)} (hij : i ≠ j) :
+    ⟪angleDefect Q (rangeCompressionEigenvalues hP hQ i)
+        (rangeCompressionEigenbasis hP hQ i : E),
+      angleDefect Q (rangeCompressionEigenvalues hP hQ j)
+        (rangeCompressionEigenbasis hP hQ j : E)⟫_ℂ = 0 := by
+  rw [angleDefect_inner_angleDefect hP hQ i j]
+  have hinner : ⟪(rangeCompressionEigenbasis hP hQ i : E),
+      (rangeCompressionEigenbasis hP hQ j : E)⟫_ℂ = 0 :=
+    (rangeCompressionEigenbasis hP hQ).inner_eq_zero hij
+  rw [hinner, mul_zero]
+
+/-- The span of a compression eigenvector and its unnormalized angle defect. -/
+noncomputable def angleDefectBlock {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : CompressionIndex (P := P)) : Submodule ℂ E :=
+  Submodule.span ℂ {(rangeCompressionEigenbasis hP hQ i : E),
+    angleDefect Q (rangeCompressionEigenvalues hP hQ i)
+      (rangeCompressionEigenbasis hP hQ i : E)}
+
+/-- The defect block has dimension at most two, including at the degenerate endpoints. -/
+theorem finrank_angleDefectBlock_le_two {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : CompressionIndex (P := P)) :
+    Module.finrank ℂ (angleDefectBlock hP hQ i) ≤ 2 := by
+  classical
+  rw [angleDefectBlock]
+  let s : Finset E := {(rangeCompressionEigenbasis hP hQ i : E),
+    angleDefect Q (rangeCompressionEigenvalues hP hQ i)
+      (rangeCompressionEigenbasis hP hQ i : E)}
+  rw [show ({(rangeCompressionEigenbasis hP hQ i : E),
+      angleDefect Q (rangeCompressionEigenvalues hP hQ i)
+        (rangeCompressionEigenbasis hP hQ i : E)} : Set E) = (s : Set E) by simp [s]]
+  exact (finrank_span_finset_le_card s).trans (Finset.card_insert_le _ _ |>.trans (by simp))
+
+/-- Each defect block is invariant under the first projection. -/
+theorem map_angleDefectBlock_le_P {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : CompressionIndex (P := P)) :
+    Submodule.map P (angleDefectBlock hP hQ i) ≤ angleDefectBlock hP hQ i := by
+  let x := (rangeCompressionEigenbasis hP hQ i : E)
+  let μ := rangeCompressionEigenvalues hP hQ i
+  have hxP : P x = x :=
+    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
+      (rangeCompressionEigenbasis hP hQ i).property
+  have hxnorm : ‖x‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
+  have hxEig : P (Q x) = (μ : ℂ) • x :=
+    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+  have hdP := (angleDefect_block hP hQ hxP hxnorm hxEig).1
+  rw [angleDefectBlock, LinearMap.map_span_le]
+  rintro y (rfl | rfl)
+  · rw [hxP]
+    exact Submodule.subset_span (by left; rfl)
+  · rw [hdP]
+    exact Submodule.zero_mem _
+
+/-- Each defect block is invariant under the second projection. -/
+theorem map_angleDefectBlock_le_Q {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : CompressionIndex (P := P)) :
+    Submodule.map Q (angleDefectBlock hP hQ i) ≤ angleDefectBlock hP hQ i := by
+  let x := (rangeCompressionEigenbasis hP hQ i : E)
+  let μ := rangeCompressionEigenvalues hP hQ i
+  let d := angleDefect Q μ x
+  have hxP : P x = x :=
+    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
+      (rangeCompressionEigenbasis hP hQ i).property
+  have hxnorm : ‖x‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
+  have hxEig : P (Q x) = (μ : ℂ) • x :=
+    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+  obtain ⟨_, hxQ, hQd, _, _⟩ := angleDefect_block hP hQ hxP hxnorm hxEig
+  rw [angleDefectBlock, LinearMap.map_span_le]
+  rintro y (rfl | rfl)
+  · rw [hxQ]
+    exact Submodule.add_mem _
+      (Submodule.smul_mem _ _ (Submodule.subset_span (by left; rfl)))
+      (Submodule.subset_span (by right; rfl))
+  · rw [hQd]
+    exact Submodule.add_mem _
+      (Submodule.smul_mem _ _ (Submodule.subset_span (by left; rfl)))
+      (Submodule.smul_mem _ _ (Submodule.subset_span (by right; rfl)))
+
+/-- Distinct compression-basis coordinates determine orthogonal defect blocks. In particular,
+this remains true for repeated compression eigenvalues. -/
+theorem angleDefectBlock_isOrtho {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    {i j : CompressionIndex (P := P)} (hij : i ≠ j) :
+    angleDefectBlock hP hQ i ⟂ angleDefectBlock hP hQ j := by
+  rw [angleDefectBlock, angleDefectBlock, Submodule.isOrtho_span]
+  rintro u (rfl | rfl) v (rfl | rfl)
+  · exact (rangeCompressionEigenbasis hP hQ).inner_eq_zero hij
+  · exact rangeCompressionEigenbasis_inner_angleDefect_eq_zero hP hQ i j
+  · exact angleDefect_inner_rangeCompressionEigenbasis_eq_zero hP hQ i j
+  · exact angleDefect_inner_angleDefect_eq_zero hP hQ hij
+
+end LinearMap.IsSymmetricProjection

--- a/TNLean/Analysis/TwoProjectionAngleOrthogonality.lean
+++ b/TNLean/Analysis/TwoProjectionAngleOrthogonality.lean
@@ -38,11 +38,9 @@ theorem rangeCompressionEigenbasis_inner_angleDefect_eq_zero {P Q : E →ₗ[ℂ
         (rangeCompressionEigenbasis hP hQ j : E)⟫_ℂ = 0 := by
   let x := fun k => (rangeCompressionEigenbasis hP hQ k : E)
   let μ := rangeCompressionEigenvalues hP hQ
-  have hxiP : P (x i) = x i :=
-    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
-      (rangeCompressionEigenbasis hP hQ i).property
+  have hxiP : P (x i) = x i := rangeCompressionEigenbasis_apply_self hP hQ i
   have hxjEig : P (Q (x j)) = (μ j : ℂ) • x j :=
-    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ j)
+    rangeCompressionEigenbasis_apply_compression hP hQ j
   rw [angleDefect, inner_sub_right, inner_smul_right]
   calc
     ⟪x i, Q (x j)⟫_ℂ - (μ j : ℂ) * ⟪x i, x j⟫_ℂ =
@@ -77,12 +75,10 @@ theorem angleDefect_inner_angleDefect {P Q : E →ₗ[ℂ] E}
   let μ := rangeCompressionEigenvalues hP hQ
   have hxd : ⟪x i, angleDefect Q (μ j) (x j)⟫_ℂ = 0 :=
     rangeCompressionEigenbasis_inner_angleDefect_eq_zero hP hQ i j
-  have hxjP : P (x j) = x j :=
-    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
-      (rangeCompressionEigenbasis hP hQ j).property
+  have hxjP : P (x j) = x j := rangeCompressionEigenbasis_apply_self hP hQ j
   have hxjnorm : ‖x j‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one j
   have hxjEig : P (Q (x j)) = (μ j : ℂ) • x j :=
-    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ j)
+    rangeCompressionEigenbasis_apply_compression hP hQ j
   have hQdj := (angleDefect_block hP hQ hxjP hxjnorm hxjEig).2.2.1
   change ⟪Q (x i) - (μ i : ℂ) • x i, angleDefect Q (μ j) (x j)⟫_ℂ = _
   rw [inner_sub_left, inner_smul_left, hxd, mul_zero, sub_zero]
@@ -135,12 +131,10 @@ theorem map_angleDefectBlock_le_first_projection {P Q : E →ₗ[ℂ] E}
     Submodule.map P (angleDefectBlock hP hQ i) ≤ angleDefectBlock hP hQ i := by
   let x := (rangeCompressionEigenbasis hP hQ i : E)
   let μ := rangeCompressionEigenvalues hP hQ i
-  have hxP : P x = x :=
-    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
-      (rangeCompressionEigenbasis hP hQ i).property
+  have hxP : P x = x := rangeCompressionEigenbasis_apply_self hP hQ i
   have hxnorm : ‖x‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
   have hxEig : P (Q x) = (μ : ℂ) • x :=
-    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+    rangeCompressionEigenbasis_apply_compression hP hQ i
   have hdP := (angleDefect_block hP hQ hxP hxnorm hxEig).1
   rw [angleDefectBlock, LinearMap.map_span_le]
   rintro y (rfl | rfl)
@@ -157,12 +151,10 @@ theorem map_angleDefectBlock_le_second_projection {P Q : E →ₗ[ℂ] E}
   let x := (rangeCompressionEigenbasis hP hQ i : E)
   let μ := rangeCompressionEigenvalues hP hQ i
   let d := angleDefect Q μ x
-  have hxP : P x = x :=
-    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
-      (rangeCompressionEigenbasis hP hQ i).property
+  have hxP : P x = x := rangeCompressionEigenbasis_apply_self hP hQ i
   have hxnorm : ‖x‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
   have hxEig : P (Q x) = (μ : ℂ) • x :=
-    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+    rangeCompressionEigenbasis_apply_compression hP hQ i
   obtain ⟨_, hxQ, hQd, _, _⟩ := angleDefect_block hP hQ hxP hxnorm hxEig
   rw [angleDefectBlock, LinearMap.map_span_le]
   rintro y (rfl | rfl)

--- a/TNLean/Analysis/TwoProjectionAngleOrthogonality.lean
+++ b/TNLean/Analysis/TwoProjectionAngleOrthogonality.lean
@@ -129,7 +129,7 @@ theorem finrank_angleDefectBlock_le_two {P Q : E →ₗ[ℂ] E}
   exact (finrank_span_finset_le_card s).trans (Finset.card_insert_le _ _ |>.trans (by simp))
 
 /-- Each defect block is invariant under the first projection. -/
-theorem map_angleDefectBlock_le_P {P Q : E →ₗ[ℂ] E}
+theorem map_angleDefectBlock_le_first_projection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
     (i : CompressionIndex (P := P)) :
     Submodule.map P (angleDefectBlock hP hQ i) ≤ angleDefectBlock hP hQ i := by
@@ -150,7 +150,7 @@ theorem map_angleDefectBlock_le_P {P Q : E →ₗ[ℂ] E}
     exact Submodule.zero_mem _
 
 /-- Each defect block is invariant under the second projection. -/
-theorem map_angleDefectBlock_le_Q {P Q : E →ₗ[ℂ] E}
+theorem map_angleDefectBlock_le_second_projection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
     (i : CompressionIndex (P := P)) :
     Submodule.map Q (angleDefectBlock hP hQ i) ≤ angleDefectBlock hP hQ i := by

--- a/TNLean/Analysis/TwoProjectionCompressionSpectrum.lean
+++ b/TNLean/Analysis/TwoProjectionCompressionSpectrum.lean
@@ -56,6 +56,24 @@ theorem rangeCompression_apply_eigenbasis {P Q : E →ₗ[ℂ] E}
         rangeCompressionEigenbasis hP hQ i := by
   exact (rangeCompression_isSymmetric hP hQ).apply_eigenvectorBasis rfl i
 
+/-- The ambient first projection fixes every vector in the compression eigenbasis. -/
+theorem rangeCompressionEigenbasis_apply_self {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : Fin (Module.finrank ℂ P.range)) :
+    P (rangeCompressionEigenbasis hP hQ i : E) =
+      (rangeCompressionEigenbasis hP hQ i : E) := by
+  exact (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
+    (rangeCompressionEigenbasis hP hQ i).property
+
+/-- The ambient compression equation for a vector in `rangeCompressionEigenbasis`. -/
+theorem rangeCompressionEigenbasis_apply_compression {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection)
+    (i : Fin (Module.finrank ℂ P.range)) :
+    P (Q (rangeCompressionEigenbasis hP hQ i : E)) =
+      (rangeCompressionEigenvalues hP hQ i : ℂ) •
+        (rangeCompressionEigenbasis hP hQ i : E) := by
+  exact congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+
 /-- Every eigenvalue of the compressed projection belongs to `[0,1]`.
 
 These endpoint bounds separate the commuting one-dimensional summands from the
@@ -67,10 +85,9 @@ theorem rangeCompressionEigenvalues_mem_unitInterval {P Q : E →ₗ[ℂ] E}
   let x := rangeCompressionEigenbasis hP hQ i
   let μ := rangeCompressionEigenvalues hP hQ i
   have hxnorm : ‖(x : E)‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
-  have hxP : P (x : E) = x :=
-    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp x.property
+  have hxP : P (x : E) = x := rangeCompressionEigenbasis_apply_self hP hQ i
   have hxEig : P (Q (x : E)) = (μ : ℂ) • (x : E) :=
-    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+    rangeCompressionEigenbasis_apply_compression hP hQ i
   obtain ⟨_, _, _, _, hnorm⟩ := angleDefect_block hP hQ hxP hxnorm hxEig
   change 0 ≤ μ ∧ μ ≤ 1
   constructor <;> nlinarith [sq_nonneg ‖angleDefect Q μ (x : E)‖]
@@ -98,11 +115,9 @@ theorem rangeCompressionEigenvalues_eq_zero_or_eq_one_or_exists_angle_block
   let x : E := rangeCompressionEigenbasis hP hQ i
   let μ := rangeCompressionEigenvalues hP hQ i
   have hxnorm : ‖x‖ = 1 := (rangeCompressionEigenbasis hP hQ).norm_eq_one i
-  have hxP : P x = x :=
-    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp
-      (rangeCompressionEigenbasis hP hQ i).property
+  have hxP : P x = x := rangeCompressionEigenbasis_apply_self hP hQ i
   have hxEig : P (Q x) = (μ : ℂ) • x :=
-    congr_arg Subtype.val (rangeCompression_apply_eigenbasis hP hQ i)
+    rangeCompressionEigenbasis_apply_compression hP hQ i
   have hμ := rangeCompressionEigenvalues_mem_unitInterval hP hQ i
   rcases hμ with ⟨hμ0, hμ1⟩
   rcases eq_or_lt_of_le hμ0 with hμeq | hμpos

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5285,6 +5285,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{theorem}[Compression-spectrum endpoint and angle-block trichotomy]
   \label{thm:mpu_two_projection_compression_spectrum}
   \lean{LinearMap.IsSymmetricProjection.rangeCompression_apply_eigenbasis,
+    LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis_apply_self,
+    LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis_apply_compression,
     LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues_mem_unitInterval,
     LinearMap.IsSymmetricProjection.rangeCompressionEigenvalues_eq_zero_or_eq_one_or_exists_angle_block}
   \leanok
@@ -5322,7 +5324,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{definition}[Compression defect block]
   \label{def:mpu_two_projection_angle_defect_block}
-  \lean{LinearMap.IsSymmetricProjection.angleDefectBlock}
+  \lean{LinearMap.IsSymmetricProjection.angleDefect,
+    LinearMap.IsSymmetricProjection.angleDefectBlock}
   \leanok
   \uses{def:mpu_two_projection_compression_spectral_data,
     thm:mpu_two_projection_angle_block}
@@ -5377,11 +5380,32 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
        =\langle x_i,PQx_j\rangle
        =\mu_j\langle x_i,x_j\rangle=0.
   \end{align}
-  This proves both eigenvector--defect identities. Symmetry of $Q$ and the
-  local formula $Qd_j=\mu_j(1-\mu_j)x_j+(1-\mu_j)d_j$ give the exact
-  defect pairing. Orthogonality of the generated spans follows by linearity.
-  The local action formulas also show that both projections preserve each
-  two-generator span, while its dimension bound follows from its generators.
+  This proves both eigenvector--defect identities. For the exact defect
+  pairing, symmetry of $Q$ and the local action formula give
+  \begin{align}
+    Qd_j&=\mu_j(1-\mu_j)x_j+(1-\mu_j)d_j,\\
+    \langle d_i,d_j\rangle
+      &=\langle Qx_i,d_j\rangle-\mu_i\langle x_i,d_j\rangle,\\
+    \langle Qx_i,d_j\rangle-\mu_i\langle x_i,d_j\rangle
+      &=\langle x_i,Qd_j\rangle,\\
+    \langle x_i,Qd_j\rangle
+      &=\mu_j(1-\mu_j)\langle x_i,x_j\rangle
+        +(1-\mu_j)\langle x_i,d_j\rangle,\\
+    \langle d_i,d_j\rangle
+      &=\mu_j(1-\mu_j)\langle x_i,x_j\rangle.
+  \end{align}
+  Orthogonality of the generated spans follows by linearity. The action formulas
+  \begin{align}
+    Px_i&=x_i,\\
+    Pd_i&=0,\\
+    Qx_i&=\mu_i x_i+d_i,\\
+    Qd_i&=\mu_i(1-\mu_i)x_i+(1-\mu_i)d_i
+  \end{align}
+  show that both projections preserve
+  $B_i=\operatorname{span}\{x_i,d_i\}$. Its dimension bound follows from
+  its two generators.
+\end{proof}
+
 \begin{definition}[Reduced projection]
   \label{def:mpu_two_projection_reduced_projection}
   \lean{LinearMap.IsSymmetricProjection.reducedProjection}
@@ -5466,6 +5490,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
   and the equal-ranges right-factor theorem give an invertible $Y$ satisfying
   $\widetilde P QY=\widetilde P$.
+\end{proof}
 \end{proof}
 
 \begin{proposition}[Constancy of the source ranks]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5327,8 +5327,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \lean{LinearMap.IsSymmetricProjection.angleDefect,
     LinearMap.IsSymmetricProjection.angleDefectBlock}
   \leanok
-  \uses{def:mpu_two_projection_compression_spectral_data,
-    thm:mpu_two_projection_angle_block}
+  \uses{def:mpu_two_projection_compression_spectral_data}
   For compression spectral data $(x_i,\mu_i)$, define
   \begin{align}
     d_i&=Qx_i-\mu_i x_i,\\
@@ -5347,23 +5346,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     LinearMap.IsSymmetricProjection.map_angleDefectBlock_le_second_projection,
     LinearMap.IsSymmetricProjection.angleDefectBlock_isOrtho}
   \leanok
-  \uses{def:mpu_two_projection_angle_defect_block,
-    thm:mpu_two_projection_compression_spectrum,
-    thm:mpu_two_projection_angle_block}
-  For distinct indices $i\ne j$,
+  \uses{def:mpu_two_projection_angle_defect_block}
+  For all indices $i,j$,
   \begin{align}
     \langle x_i,d_j\rangle&=0,\\
     \langle d_i,x_j\rangle&=0,\\
-    \langle d_i,d_j\rangle&=0.
-  \end{align}
-  More generally,
-  \begin{align}
     \langle d_i,d_j\rangle
       &=\mu_j(1-\mu_j)\langle x_i,x_j\rangle.
   \end{align}
-  Hence these identities also hold when $\mu_i=\mu_j$ but $i\ne j$. The
-  block $B_i$ has dimension at most two, is invariant under both $P$ and $Q$,
-  and satisfies $B_i\perp B_j$ for distinct indices.
+  In particular, $\langle d_i,d_j\rangle=0$ when $i\ne j$, including when
+  $\mu_i=\mu_j$. The block $B_i$ has dimension at most two, is invariant under
+  both $P$ and $Q$, and satisfies $B_i\perp B_j$ for distinct indices.
   % This does not assert an ambient direct sum or any property of the remaining
   % orthogonal complement.
   % Source lines: paper_v2.tex 759--762.
@@ -5375,12 +5368,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     thm:mpu_two_projection_angle_block}
   Since $Px_i=x_i$, symmetry of $P$ and the compression eigenvalue equation give
   \begin{align}
-    \langle x_i,Qx_j\rangle
-      &=\langle Px_i,Qx_j\rangle
-       =\langle x_i,PQx_j\rangle
-       =\mu_j\langle x_i,x_j\rangle=0.
+    \langle x_i,d_j\rangle
+      &=\langle x_i,Qx_j\rangle-\mu_j\langle x_i,x_j\rangle\\
+      &=\langle Px_i,Qx_j\rangle-\mu_j\langle x_i,x_j\rangle\\
+      &=\langle x_i,PQx_j\rangle-\mu_j\langle x_i,x_j\rangle=0.
   \end{align}
-  This proves both eigenvector--defect identities. For the exact defect
+  Conjugate symmetry gives $\langle d_i,x_j\rangle=0$. For the exact defect
   pairing, symmetry of $Q$ and the local action formula give
   \begin{align}
     Qd_j&=\mu_j(1-\mu_j)x_j+(1-\mu_j)d_j,\\

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5320,28 +5320,37 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   Theorem~\ref{thm:mpu_two_projection_angle_block}.
 \end{proof}
 
+\begin{definition}[Compression defect block]
+  \label{def:mpu_two_projection_angle_defect_block}
+  \lean{LinearMap.IsSymmetricProjection.angleDefectBlock}
+  \leanok
+  \uses{def:mpu_two_projection_compression_spectral_data,
+    thm:mpu_two_projection_angle_block}
+  For compression spectral data $(x_i,\mu_i)$, define
+  \begin{align}
+    d_i&=Qx_i-\mu_i x_i,\\
+    B_i&=\operatorname{span}\{x_i,d_i\}.
+  \end{align}
+\end{definition}
+
 \begin{theorem}[Orthogonality of compression angle blocks]
   \label{thm:mpu_two_projection_angle_block_orthogonality}
   \lean{LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis_inner_angleDefect_eq_zero,
     LinearMap.IsSymmetricProjection.angleDefect_inner_rangeCompressionEigenbasis_eq_zero,
     LinearMap.IsSymmetricProjection.angleDefect_inner_angleDefect,
     LinearMap.IsSymmetricProjection.angleDefect_inner_angleDefect_eq_zero,
-    LinearMap.IsSymmetricProjection.angleDefectBlock,
     LinearMap.IsSymmetricProjection.finrank_angleDefectBlock_le_two,
-    LinearMap.IsSymmetricProjection.map_angleDefectBlock_le_P,
-    LinearMap.IsSymmetricProjection.map_angleDefectBlock_le_Q,
+    LinearMap.IsSymmetricProjection.map_angleDefectBlock_le_first_projection,
+    LinearMap.IsSymmetricProjection.map_angleDefectBlock_le_second_projection,
     LinearMap.IsSymmetricProjection.angleDefectBlock_isOrtho}
   \leanok
-  \uses{def:mpu_two_projection_compression_spectral_data,
-    thm:mpu_two_projection_compression_spectrum}
-  For distinct indices $i\ne j$, put
+  \uses{def:mpu_two_projection_angle_defect_block,
+    thm:mpu_two_projection_compression_spectrum,
+    thm:mpu_two_projection_angle_block}
+  For distinct indices $i\ne j$,
   \begin{align}
-    d_i&=Qx_i-\mu_i x_i.
-  \end{align}
-  Then
-  \begin{align}
-    \langle x_i,d_j\rangle&=0,&
-    \langle d_i,x_j\rangle&=0,&
+    \langle x_i,d_j\rangle&=0,\\
+    \langle d_i,x_j\rangle&=0,\\
     \langle d_i,d_j\rangle&=0.
   \end{align}
   More generally,
@@ -5350,15 +5359,17 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
       &=\mu_j(1-\mu_j)\langle x_i,x_j\rangle.
   \end{align}
   Hence these identities also hold when $\mu_i=\mu_j$ but $i\ne j$. The
-  defect block $B_i=\operatorname{span}\{x_i,d_i\}$ has dimension at most two,
-  is invariant under both $P$ and $Q$, and satisfies $B_i\perp B_j$ for
-  distinct indices. This does not assert an ambient direct sum or any property
-  of the remaining orthogonal complement.
+  block $B_i$ has dimension at most two, is invariant under both $P$ and $Q$,
+  and satisfies $B_i\perp B_j$ for distinct indices.
+  % This does not assert an ambient direct sum or any property of the remaining
+  % orthogonal complement.
   % Source lines: paper_v2.tex 759--762.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{def:mpu_two_projection_compression_spectral_data}
+  \uses{def:mpu_two_projection_angle_defect_block,
+    thm:mpu_two_projection_compression_spectrum,
+    thm:mpu_two_projection_angle_block}
   Since $Px_i=x_i$, symmetry of $P$ and the compression eigenvalue equation give
   \begin{align}
     \langle x_i,Qx_j\rangle

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5320,6 +5320,57 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   Theorem~\ref{thm:mpu_two_projection_angle_block}.
 \end{proof}
 
+\begin{theorem}[Orthogonality of compression angle blocks]
+  \label{thm:mpu_two_projection_angle_block_orthogonality}
+  \lean{LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis_inner_angleDefect_eq_zero,
+    LinearMap.IsSymmetricProjection.angleDefect_inner_rangeCompressionEigenbasis_eq_zero,
+    LinearMap.IsSymmetricProjection.angleDefect_inner_angleDefect,
+    LinearMap.IsSymmetricProjection.angleDefect_inner_angleDefect_eq_zero,
+    LinearMap.IsSymmetricProjection.angleDefectBlock,
+    LinearMap.IsSymmetricProjection.finrank_angleDefectBlock_le_two,
+    LinearMap.IsSymmetricProjection.map_angleDefectBlock_le_P,
+    LinearMap.IsSymmetricProjection.map_angleDefectBlock_le_Q,
+    LinearMap.IsSymmetricProjection.angleDefectBlock_isOrtho}
+  \leanok
+  \uses{def:mpu_two_projection_compression_spectral_data,
+    thm:mpu_two_projection_compression_spectrum}
+  For distinct indices $i\ne j$, put
+  \begin{align}
+    d_i&=Qx_i-\mu_i x_i.
+  \end{align}
+  Then
+  \begin{align}
+    \langle x_i,d_j\rangle&=0,&
+    \langle d_i,x_j\rangle&=0,&
+    \langle d_i,d_j\rangle&=0.
+  \end{align}
+  More generally,
+  \begin{align}
+    \langle d_i,d_j\rangle
+      &=\mu_j(1-\mu_j)\langle x_i,x_j\rangle.
+  \end{align}
+  Hence these identities also hold when $\mu_i=\mu_j$ but $i\ne j$. The
+  defect block $B_i=\operatorname{span}\{x_i,d_i\}$ has dimension at most two,
+  is invariant under both $P$ and $Q$, and satisfies $B_i\perp B_j$ for
+  distinct indices. This does not assert an ambient direct sum or any property
+  of the remaining orthogonal complement.
+  % Source lines: paper_v2.tex 759--762.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{def:mpu_two_projection_compression_spectral_data}
+  Since $Px_i=x_i$, symmetry of $P$ and the compression eigenvalue equation give
+  \begin{align}
+    \langle x_i,Qx_j\rangle
+      &=\langle Px_i,Qx_j\rangle
+       =\langle x_i,PQx_j\rangle
+       =\mu_j\langle x_i,x_j\rangle=0.
+  \end{align}
+  This proves both eigenvector--defect identities. Symmetry of $Q$ and the
+  local formula $Qd_j=\mu_j(1-\mu_j)x_j+(1-\mu_j)d_j$ give the exact
+  defect pairing. Orthogonality of the generated spans follows by linearity.
+  The local action formulas also show that both projections preserve each
+  two-generator span, while its dimension bound follows from its generators.
 \begin{definition}[Reduced projection]
   \label{def:mpu_two_projection_reduced_projection}
   \lean{LinearMap.IsSymmetricProjection.reducedProjection}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,21 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### ambient compression eigenbasis equations — promoted
+- **Pattern:** derive that a compression eigenbasis vector is fixed by the first
+  projection from subtype range membership, and recover its ambient compression
+  eigenvalue equation by applying `Subtype.val` to the compressed equation.
+- **Seen:** six paired occurrences across
+  `TNLean/Analysis/TwoProjectionCompressionSpectrum.lean` and
+  `TNLean/Analysis/TwoProjectionAngleOrthogonality.lean` before promotion
+  (2026-08-13).
+- **Abstraction:** `LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis_apply_self`
+  and `LinearMap.IsSymmetricProjection.rangeCompressionEigenbasis_apply_compression`
+  in `TNLean/Analysis/TwoProjectionCompressionSpectrum.lean`.
+- **Notes:** all six motivating call sites now use the public ambient equations;
+  later two-projection block assembly can use the same facts without repeating
+  subtype coercion arguments.
+
 ### pointwise idempotent endomorphism application — promoted
 - **Pattern:** apply an equality `P * P = P` to a vector with `congrArg`, then
   simplify `Module.End.mul_apply` to obtain `P (P x) = P x`.


### PR DESCRIPTION
## What changed

- prove exact compression angle-defect pairings and cross-index orthogonality
- handle repeated compression eigenvalues by indexing the chosen orthonormal eigenbasis, not spectral values
- define the two-generator defect blocks, prove dimension at most two, invariance under both projections, and pairwise orthogonality
- document only this cross-block slice in Chapter 28

This does not construct the ambient direct sum, commuting remainder, reduced projector, or rank-continuity theorem.

## Validation

- `lake build TNLean.Analysis.TwoProjectionAngleOrthogonality TNLean.Analysis`
- proof-integrity scan
- `git diff --check`
- blueprint sync and `leanblueprint checkdecls`

Closes #6364
Advances #6294