### PR TITLE
feat(MPU): transport reduced CFII through physical adjoint

### DIFF
--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -21,6 +21,7 @@ import TNLean.MPS.CanonicalForm.CPSVBlocking
 import TNLean.MPS.CanonicalForm.CPSVCanonicalFormII
 import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
 import TNLean.MPS.CanonicalForm.CommonPeriodCyclicSectors
+import TNLean.MPS.CanonicalForm.Conjugation
 import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.MPS.CanonicalForm.CyclicSectors.Basic
 import TNLean.MPS.CanonicalForm.CyclicSectors.CommutingProj

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+
+/-!
+# MPS canonical-form conjugation
+
+Entrywise complex conjugation preserves injectivity, normality, left-canonical normalization,
+and the transfer-map fixed-point equations used in canonical forms.
+
+## Main definitions
+
+* `MPSTensor.mapStar`: entrywise complex conjugation of an MPS tensor.
+
+## Main results
+
+* `MPSTensor.IsInjective.mapStar`: conjugation preserves injectivity.
+* `MPSTensor.IsNormal.mapStar`: conjugation preserves normality.
+* `MPSTensor.IsLeftCanonical.mapStar`: conjugation preserves left-canonical normalization.
+* `MPSTensor.IsNormalTensor.mapStar`: conjugation preserves normalized normal tensors.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Entrywise complex conjugation of every letter of an MPS tensor. -/
+def mapStar (A : MPSTensor d D) : MPSTensor d D :=
+  fun i ↦ (A i).map (starRingEnd ℂ)
+
+/-- Entrywise conjugation evaluated at one physical letter. -/
+@[simp] theorem mapStar_apply (A : MPSTensor d D) (i : Fin d) :
+    mapStar A i = (A i).map (starRingEnd ℂ) := rfl
+
+/-- Entrywise conjugation is an involution on MPS tensors. -/
+@[simp] theorem mapStar_mapStar (A : MPSTensor d D) :
+    mapStar (mapStar A) = A := by
+  ext i β α
+  simp [mapStar, Matrix.map_apply]
+
+/-- Entrywise conjugation preserves algebraic injectivity. -/
+theorem IsInjective.mapStar {A : MPSTensor d D} (hA : IsInjective A) :
+    IsInjective (mapStar A) := by
+  classical
+  rw [IsInjective]
+  apply top_unique
+  intro X _
+  have hmem : X.map (starRingEnd ℂ) ∈ Submodule.span ℂ (Set.range A) := by
+    rw [hA]
+    trivial
+  have hconj : ∀ Y ∈ Submodule.span ℂ (Set.range A),
+      Y.map (starRingEnd ℂ) ∈ Submodule.span ℂ (Set.range (MPSTensor.mapStar A)) := by
+    intro Y hY
+    induction hY using Submodule.span_induction with
+    | mem Z hZ =>
+        obtain ⟨i, rfl⟩ := hZ
+        exact Submodule.subset_span ⟨i, rfl⟩
+    | zero => simp
+    | add Y Z _ _ hY hZ =>
+        rw [show (Y + Z).map (starRingEnd ℂ) =
+          Y.map (starRingEnd ℂ) + Z.map (starRingEnd ℂ) by
+            exact Matrix.map_add _ (map_add (starRingEnd ℂ)) Y Z]
+        exact Submodule.add_mem _ hY hZ
+    | smul c Y _ hY =>
+        rw [show (c • Y).map (starRingEnd ℂ) =
+          star c • Y.map (starRingEnd ℂ) by
+            ext i j
+            simp [Matrix.map_apply]]
+        exact Submodule.smul_mem _ (star c) hY
+  have := hconj _ hmem
+  convert this using 1
+  ext i j
+  simp [Matrix.map_apply]
+
+private theorem evalWord_mapStar (A : MPSTensor d D) (w : List (Fin d)) :
+    evalWord (mapStar A) w = (evalWord A w).map (starRingEnd ℂ) := by
+  induction w with
+  | nil => simp [evalWord]
+  | cons i w ih =>
+      simp only [evalWord, mapStar_apply, ih]
+      exact ((starRingEnd ℂ).mapMatrix.map_mul (A i) (evalWord A w)).symm
+
+/-- Entrywise conjugation preserves positive-length block injectivity, hence normality. -/
+theorem IsNormal.mapStar {A : MPSTensor d D} (hA : IsNormal A) :
+    IsNormal (mapStar A) := by
+  obtain ⟨N, hN, hInj⟩ := hA
+  refine ⟨N, hN, ?_⟩
+  rw [isNBlkInjective_iff_blockTensor_isInjective] at hInj ⊢
+  have hConj := hInj.mapStar
+  convert hConj using 1
+  ext σ β α
+  simp [blockTensor, evalWord_mapStar]
+
+/-- Left-canonical normalization is preserved by entrywise complex conjugation. -/
+theorem IsLeftCanonical.mapStar {A : MPSTensor d D} (hA : IsLeftCanonical A) :
+    IsLeftCanonical (mapStar A) := by
+  classical
+  rw [IsLeftCanonical] at hA ⊢
+  calc
+    ∑ i, (MPSTensor.mapStar A i)ᴴ * MPSTensor.mapStar A i =
+        (∑ i, (A i)ᴴ * A i).map (starRingEnd ℂ) := by
+      rw [show (∑ i, (A i)ᴴ * A i).map (starRingEnd ℂ) =
+        ∑ i, ((A i)ᴴ * A i).map (starRingEnd ℂ) by
+      exact map_sum ((starRingEnd ℂ).mapMatrix) _ Finset.univ]
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [Matrix.map_mul, Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
+      rfl
+    _ = 1 := by rw [hA]; simp
+
+/-- A spectrally normalized normal tensor remains normal after entrywise conjugation. -/
+theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A)
+    (hLeft : IsLeftCanonical A) : IsNormalTensor (mapStar A) := by
+  letI : NeZero D := ⟨hA.bondDim_ne_zero⟩
+  exact isNormalTensor_of_isNormal_leftCanonical _ hA.isNormal.mapStar hLeft.mapStar
+
+/-- A diagonal positive-definite complex matrix is fixed by entrywise conjugation. -/
+theorem map_star_eq_self_of_posDef_isDiag
+    {n : ℕ} {Λ : Matrix (Fin n) (Fin n) ℂ} (hΛpos : Λ.PosDef) (hΛdiag : Λ.IsDiag) :
+    Λ.map (starRingEnd ℂ) = Λ := by
+  ext i j
+  by_cases hij : i = j
+  · subst j
+    simpa [Matrix.map_apply] using hΛpos.1.apply i i
+  · simp [Matrix.map_apply, hΛdiag hij]
+
+/-- The transfer map of an entrywise-conjugated tensor is the conjugate of the original
+transfer map on conjugated inputs. -/
+theorem transferMap_mapStar (A : MPSTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    transferMap (mapStar A) (X.map (starRingEnd ℂ)) =
+      (transferMap A X).map (starRingEnd ℂ) := by
+  classical
+  simp only [transferMap_apply]
+  rw [show (∑ i, A i * X * (A i)ᴴ).map (starRingEnd ℂ) =
+      ∑ i, (A i * X * (A i)ᴴ).map (starRingEnd ℂ) by
+    exact map_sum ((starRingEnd ℂ).mapMatrix) _ Finset.univ]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Matrix.map_mul, Matrix.map_mul,
+    Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
+  rfl
+
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -113,7 +113,7 @@ theorem IsLeftCanonical.mapStar {A : MPSTensor d D} (hA : IsLeftCanonical A) :
       rfl
     _ = 1 := by rw [hA]; simp
 
-/-- A spectrally normalized normal tensor remains normal after entrywise conjugation. -/
+/-- If a normal tensor is left-canonical, then its entrywise conjugate is a normal tensor. -/
 theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A)
     (hLeft : IsLeftCanonical A) : IsNormalTensor (mapStar A) := by
   letI : NeZero D := ⟨hA.bondDim_ne_zero⟩
@@ -145,6 +145,5 @@ theorem transferMap_mapStar (A : MPSTensor d D)
   rw [Matrix.map_mul, Matrix.map_mul,
     Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
   rfl
-
 
 end MPSTensor

--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -17,6 +17,7 @@ import TNLean.MPS.MPU.Equivalence
 import TNLean.MPS.MPU.Examples
 import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.MatchingContractions
+import TNLean.MPS.MPU.PhysicalAdjointCanonicalForm
 import TNLean.MPS.MPU.PhysicalAncilla
 import TNLean.MPS.MPU.ResidualAlgebra
 import TNLean.MPS.MPU.Simple

--- a/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
+++ b/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
@@ -1,0 +1,313 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.MPU.CanonicalForm
+import TNLean.MPS.MPDO.PhysicalAdjoint
+
+/-!
+# Reduced canonical-form-II data under physical adjunction
+
+Physical adjunction of an MPO exchanges its two physical coordinates and conjugates every
+coefficient. This file transports literal CPSV canonical-form-II data through that operation.
+The construction preserves the reduced full-active-support condition and does not compare any
+selected compact singular-value decompositions or source factors.
+
+## Main definitions
+
+* `MPSTensor.mapStar`: entrywise complex conjugation of an MPS tensor.
+* `MPOTensor.physicalPairSwapEquiv`: exchange of the two flattened physical coordinates.
+* `MPSTensor.CPSVCanonicalFormIIData.physicalAdjointNormalizedFlattening`: transformed CFII data.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1703.09188, equations
+  `eq:transfer-op` and `II_CF`, lines 271--281 and 336--340.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Entrywise complex conjugation of every letter of an MPS tensor. -/
+def mapStar (A : MPSTensor d D) : MPSTensor d D :=
+  fun i ↦ (A i).map (starRingEnd ℂ)
+
+@[simp] theorem mapStar_apply (A : MPSTensor d D) (i : Fin d) :
+    mapStar A i = (A i).map (starRingEnd ℂ) := rfl
+
+@[simp] theorem mapStar_mapStar (A : MPSTensor d D) :
+    mapStar (mapStar A) = A := by
+  ext i β α
+  simp [mapStar, Matrix.map_apply]
+
+/-- Entrywise conjugation preserves algebraic injectivity. -/
+theorem IsInjective.mapStar {A : MPSTensor d D} (hA : IsInjective A) :
+    IsInjective (mapStar A) := by
+  classical
+  rw [IsInjective]
+  apply top_unique
+  intro X _
+  have hmem : X.map (starRingEnd ℂ) ∈ Submodule.span ℂ (Set.range A) := by
+    rw [hA]
+    trivial
+  have hconj : ∀ Y ∈ Submodule.span ℂ (Set.range A),
+      Y.map (starRingEnd ℂ) ∈ Submodule.span ℂ (Set.range (MPSTensor.mapStar A)) := by
+    intro Y hY
+    induction hY using Submodule.span_induction with
+    | mem Z hZ =>
+        obtain ⟨i, rfl⟩ := hZ
+        exact Submodule.subset_span ⟨i, rfl⟩
+    | zero => simp
+    | add Y Z _ _ hY hZ =>
+        rw [show (Y + Z).map (starRingEnd ℂ) =
+          Y.map (starRingEnd ℂ) + Z.map (starRingEnd ℂ) by
+            exact Matrix.map_add _ (map_add (starRingEnd ℂ)) Y Z]
+        exact Submodule.add_mem _ hY hZ
+    | smul c Y _ hY =>
+        rw [show (c • Y).map (starRingEnd ℂ) =
+          star c • Y.map (starRingEnd ℂ) by
+            ext i j
+            simp [Matrix.map_apply]]
+        exact Submodule.smul_mem _ (star c) hY
+  have := hconj _ hmem
+  convert this using 1
+  ext i j
+  simp [Matrix.map_apply]
+
+private theorem evalWord_mapStar (A : MPSTensor d D) (w : List (Fin d)) :
+    evalWord (mapStar A) w = (evalWord A w).map (starRingEnd ℂ) := by
+  induction w with
+  | nil => simp [evalWord]
+  | cons i w ih =>
+      simp only [evalWord, mapStar_apply, ih]
+      exact ((starRingEnd ℂ).mapMatrix.map_mul (A i) (evalWord A w)).symm
+
+/-- Entrywise conjugation preserves positive-length block injectivity, hence normality. -/
+theorem IsNormal.mapStar {A : MPSTensor d D} (hA : IsNormal A) :
+    IsNormal (mapStar A) := by
+  obtain ⟨N, hN, hInj⟩ := hA
+  refine ⟨N, hN, ?_⟩
+  rw [isNBlkInjective_iff_blockTensor_isInjective] at hInj ⊢
+  have hConj := hInj.mapStar
+  convert hConj using 1
+  ext σ β α
+  simp [blockTensor, evalWord_mapStar]
+
+/-- Left-canonical normalization is preserved by entrywise complex conjugation. -/
+theorem IsLeftCanonical.mapStar {A : MPSTensor d D} (hA : IsLeftCanonical A) :
+    IsLeftCanonical (mapStar A) := by
+  classical
+  rw [IsLeftCanonical] at hA ⊢
+  calc
+    ∑ i, (MPSTensor.mapStar A i)ᴴ * MPSTensor.mapStar A i =
+        (∑ i, (A i)ᴴ * A i).map (starRingEnd ℂ) := by
+      rw [show (∑ i, (A i)ᴴ * A i).map (starRingEnd ℂ) =
+        ∑ i, ((A i)ᴴ * A i).map (starRingEnd ℂ) by
+      exact map_sum ((starRingEnd ℂ).mapMatrix) _ Finset.univ]
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [Matrix.map_mul, Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
+      rfl
+    _ = 1 := by rw [hA]; simp
+
+/-- A spectrally normalized normal tensor remains normal after entrywise conjugation. -/
+theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A)
+    (hLeft : IsLeftCanonical A) : IsNormalTensor (mapStar A) := by
+  letI : NeZero D := ⟨hA.bondDim_ne_zero⟩
+  exact isNormalTensor_of_isNormal_leftCanonical _ hA.isNormal.mapStar hLeft.mapStar
+
+private theorem map_star_eq_self_of_posDef_isDiag
+    {n : ℕ} {Λ : Matrix (Fin n) (Fin n) ℂ} (hΛpos : Λ.PosDef) (hΛdiag : Λ.IsDiag) :
+    Λ.map (starRingEnd ℂ) = Λ := by
+  ext i j
+  by_cases hij : i = j
+  · subst j
+    simpa [Matrix.map_apply] using hΛpos.1.apply i i
+  · simp [Matrix.map_apply, hΛdiag hij]
+
+private theorem transferMap_mapStar (A : MPSTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    transferMap (mapStar A) (X.map (starRingEnd ℂ)) =
+      (transferMap A X).map (starRingEnd ℂ) := by
+  classical
+  simp only [transferMap_apply]
+  rw [show (∑ i, A i * X * (A i)ᴴ).map (starRingEnd ℂ) =
+      ∑ i, (A i * X * (A i)ᴴ).map (starRingEnd ℂ) by
+    exact map_sum ((starRingEnd ℂ).mapMatrix) _ Finset.univ]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Matrix.map_mul, Matrix.map_mul,
+    Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
+  rfl
+
+
+end MPSTensor
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Exchange the two coordinates of a flattened physical pair. -/
+def physicalPairSwapEquiv (d : ℕ) : Fin (d * d) ≃ Fin (d * d) where
+  toFun ij := finProdFinEquiv (ij.modNat, ij.divNat)
+  invFun ij := finProdFinEquiv (ij.modNat, ij.divNat)
+  left_inv ij := by
+    rw [show ij = finProdFinEquiv (ij.divNat, ij.modNat) by
+      exact (finProdFinEquiv.apply_symm_apply ij).symm]
+    simp
+  right_inv ij := by
+    rw [show ij = finProdFinEquiv (ij.divNat, ij.modNat) by
+      exact (finProdFinEquiv.apply_symm_apply ij).symm]
+    simp
+
+@[simp] theorem physicalPairSwapEquiv_finProdFinEquiv (i j : Fin d) :
+    physicalPairSwapEquiv d (finProdFinEquiv (i, j)) = finProdFinEquiv (j, i) := by
+  simp [physicalPairSwapEquiv]
+
+@[simp] theorem physicalPairSwapEquiv_symm :
+    (physicalPairSwapEquiv d).symm = physicalPairSwapEquiv d := rfl
+
+/-- The normalized flattening of the physical adjoint is obtained by applying entrywise complex
+conjugation to every virtual matrix entry and exchanging the two flattened physical coordinates. -/
+theorem normalizedFlattening_physicalAdjointTensor (U : MPOTensor d D) :
+    (physicalAdjointTensor U).normalizedFlattening =
+      MPSTensor.reindexPhysical (physicalPairSwapEquiv d)
+        (MPSTensor.mapStar U.normalizedFlattening) := by
+  ext ij β α
+  rw [show ij = finProdFinEquiv (ij.divNat, ij.modNat) by
+    exact (finProdFinEquiv.apply_symm_apply ij).symm]
+  simp [normalizedFlattening, MPSTensor.reindexPhysical, MPSTensor.mapStar,
+    MPOTensor.toMPSTensor, Matrix.smul_apply, Matrix.map_apply, RCLike.star_def]
+
+end MPOTensor
+
+namespace MPSTensor.CPSVCanonicalFormIIData
+
+variable {d D : ℕ} {U : MPOTensor d D}
+
+/-- Transport literal CPSV canonical-form-II data through physical adjunction.
+
+The block count and dimensions are unchanged. We conjugate the weights, blocks, and ambient
+coisometry entrywise, then exchange the two physical coordinates. A diagonal positive-definite
+fixed point is real, so the same matrix remains fixed by the transformed transfer map.
+
+This is the reduced-CFII operation used with arXiv:1703.09188, equations `II_CF` and
+`eq:transfer-op`, lines 271--281 and 336--340. It makes no assertion about selected compact-SVD
+witnesses or source factors. -/
+noncomputable def physicalAdjointNormalizedFlattening
+    (data : CPSVCanonicalFormIIData U.normalizedFlattening) :
+    CPSVCanonicalFormIIData (MPOTensor.physicalAdjointTensor U).normalizedFlattening where
+  r := data.r
+  dim := data.dim
+  dim_pos := data.dim_pos
+  weights := fun k ↦ star (data.weights k)
+  blocks := fun k ↦ MPSTensor.reindexPhysical (MPOTensor.physicalPairSwapEquiv d)
+    (MPSTensor.mapStar (data.blocks k))
+  blocks_normal := fun k ↦
+    (MPSTensor.IsNormalTensor.mapStar (data.blocks_normal k)
+      (data.blocks_left_canonical k)).reindexPhysical (MPOTensor.physicalPairSwapEquiv d)
+  total_dim_le := data.total_dim_le
+  ambient_coisometry := data.ambient_coisometry.map (starRingEnd ℂ)
+  coisometric := by
+    have hmap := congrArg (fun M ↦ M.map (starRingEnd ℂ)) data.coisometric
+    simpa [Matrix.map_mul,
+      Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])] using hmap
+  reconstruct := by
+    intro i
+    rw [MPOTensor.normalizedFlattening_physicalAdjointTensor]
+    have hmap := congrArg (fun M ↦ M.map (starRingEnd ℂ))
+      (data.reconstruct (MPOTensor.physicalPairSwapEquiv d i))
+    have hmiddle :
+        (MPSTensor.toTensorFromBlocks data.weights data.blocks
+          (MPOTensor.physicalPairSwapEquiv d i)).map (starRingEnd ℂ) =
+          MPSTensor.toTensorFromBlocks (fun k ↦ star (data.weights k))
+            (fun k ↦ MPSTensor.reindexPhysical (MPOTensor.physicalPairSwapEquiv d)
+              (MPSTensor.mapStar (data.blocks k))) i := by
+      simp only [MPSTensor.toTensorFromBlocks, MPSTensor.reindexPhysical]
+      rw [show ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+          (Matrix.blockDiagonal' fun k => data.weights k •
+            data.blocks k (MPOTensor.physicalPairSwapEquiv d i))).map (starRingEnd ℂ) =
+          (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
+            ((Matrix.blockDiagonal' fun k => data.weights k •
+              data.blocks k (MPOTensor.physicalPairSwapEquiv d i)).map (starRingEnd ℂ)) by
+        ext β α
+        rfl]
+      rw [Matrix.blockDiagonal'_map _ _ (by simp)]
+      congr 2
+      funext k
+      ext β α
+      simp [MPSTensor.mapStar, Matrix.map_apply]
+    rw [Matrix.map_mul, Matrix.map_mul,
+      Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj]),
+      hmiddle] at hmap
+    exact hmap
+  blocks_left_canonical := fun k ↦
+    (MPSTensor.leftCanonical_reindexPhysical_equiv
+      (MPOTensor.physicalPairSwapEquiv d) _).2
+      (MPSTensor.IsLeftCanonical.mapStar (data.blocks_left_canonical k))
+  blocks_fixed_point := by
+    intro k
+    obtain ⟨Λ, hΛpos, hΛdiag, hΛfix⟩ := data.blocks_fixed_point k
+    refine ⟨Λ, hΛpos, hΛdiag, ?_⟩
+    rw [MPSTensor.transferMap_reindexPhysical_equiv]
+    rw [← MPSTensor.map_star_eq_self_of_posDef_isDiag hΛpos hΛdiag,
+      MPSTensor.transferMap_mapStar, hΛfix,
+      MPSTensor.map_star_eq_self_of_posDef_isDiag hΛpos hΛdiag]
+
+@[simp] theorem physicalAdjointNormalizedFlattening_r
+    (data : CPSVCanonicalFormIIData U.normalizedFlattening) :
+    data.physicalAdjointNormalizedFlattening.r = data.r := rfl
+
+@[simp] theorem physicalAdjointNormalizedFlattening_dim
+    (data : CPSVCanonicalFormIIData U.normalizedFlattening) :
+    data.physicalAdjointNormalizedFlattening.dim = data.dim := rfl
+
+@[simp] theorem physicalAdjointNormalizedFlattening_weights
+    (data : CPSVCanonicalFormIIData U.normalizedFlattening) (k : Fin data.r) :
+    data.physicalAdjointNormalizedFlattening.weights k = star (data.weights k) := rfl
+
+@[simp] theorem physicalAdjointNormalizedFlattening_blocks
+    (data : CPSVCanonicalFormIIData U.normalizedFlattening) (k : Fin data.r) :
+    data.physicalAdjointNormalizedFlattening.blocks k =
+      MPSTensor.reindexPhysical (MPOTensor.physicalPairSwapEquiv d)
+        (MPSTensor.mapStar (data.blocks k)) := rfl
+
+@[simp] theorem physicalAdjointNormalizedFlattening_ambientCoisometry
+    (data : CPSVCanonicalFormIIData U.normalizedFlattening) :
+    data.physicalAdjointNormalizedFlattening.ambient_coisometry =
+      data.ambient_coisometry.map (starRingEnd ℂ) := rfl
+
+/-- Physical adjunction preserves full active support of reduced CFII data. -/
+theorem hasFullActiveSupport_physicalAdjointNormalizedFlattening
+    (data : CPSVCanonicalFormIIData U.normalizedFlattening)
+    (hfull : data.toCPSVCanonicalFormData.HasFullActiveSupport) :
+    data.physicalAdjointNormalizedFlattening.toCPSVCanonicalFormData.HasFullActiveSupport := by
+  classical
+  simp only [MPSTensor.CPSVCanonicalFormData.HasFullActiveSupport]
+  change (∑ k : {k : Fin data.r // star (data.weights k) ≠ 0}, data.dim k.1) = D
+  let e : {k : Fin data.r // star (data.weights k) ≠ 0} ≃
+      data.toCPSVCanonicalFormData.Active :=
+    Equiv.subtypeEquiv (Equiv.refl _) (fun k ↦ star_ne_zero)
+  apply (e.sum_comp (fun k ↦ data.dim k.1)).trans
+  exact hfull
+
+end MPSTensor.CPSVCanonicalFormIIData
+
+namespace MPSTensor.IsCPSVCanonicalFormII
+
+variable {d D : ℕ} {U : MPOTensor d D}
+
+/-- Physical adjunction preserves literal CPSV canonical form II of the normalized flattening. -/
+theorem physicalAdjointNormalizedFlattening
+    (h : MPSTensor.IsCPSVCanonicalFormII U.normalizedFlattening) :
+    MPSTensor.IsCPSVCanonicalFormII
+      (MPOTensor.physicalAdjointTensor U).normalizedFlattening := by
+  obtain ⟨data⟩ := h
+  exact ⟨data.physicalAdjointNormalizedFlattening⟩
+
+end MPSTensor.IsCPSVCanonicalFormII

--- a/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
+++ b/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.CanonicalForm.Conjugation
 import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPDO.PhysicalAdjoint
 
@@ -12,141 +12,23 @@ import TNLean.MPS.MPDO.PhysicalAdjoint
 
 Physical adjunction of an MPO exchanges its two physical coordinates and conjugates every
 coefficient. This file transports literal CPSV canonical-form-II data through that operation.
-The construction preserves the reduced full-active-support condition and does not compare any
-selected compact singular-value decompositions or source factors.
+The construction preserves canonical form II unconditionally and preserves the reduced
+full-active-support condition when it holds for the original data.
 
 ## Main definitions
 
-* `MPSTensor.mapStar`: entrywise complex conjugation of an MPS tensor.
 * `MPOTensor.physicalPairSwapEquiv`: exchange of the two flattened physical coordinates.
 * `MPSTensor.CPSVCanonicalFormIIData.physicalAdjointNormalizedFlattening`: transformed CFII data.
 
 ## References
 
-* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1703.09188, equations
-  `eq:transfer-op` and `II_CF`, lines 271--281 and 336--340.
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608, Appendix A,
+  lines 1054--1077, for the literal canonical-form-II structure.
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1703.09188, equation `Erightleft`,
+  lines 271--281, and equation `eq:transfer-op`, lines 336--340, for the MPU normalization context.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
-
-namespace MPSTensor
-
-variable {d D : ℕ}
-
-/-- Entrywise complex conjugation of every letter of an MPS tensor. -/
-def mapStar (A : MPSTensor d D) : MPSTensor d D :=
-  fun i ↦ (A i).map (starRingEnd ℂ)
-
-@[simp] theorem mapStar_apply (A : MPSTensor d D) (i : Fin d) :
-    mapStar A i = (A i).map (starRingEnd ℂ) := rfl
-
-@[simp] theorem mapStar_mapStar (A : MPSTensor d D) :
-    mapStar (mapStar A) = A := by
-  ext i β α
-  simp [mapStar, Matrix.map_apply]
-
-/-- Entrywise conjugation preserves algebraic injectivity. -/
-theorem IsInjective.mapStar {A : MPSTensor d D} (hA : IsInjective A) :
-    IsInjective (mapStar A) := by
-  classical
-  rw [IsInjective]
-  apply top_unique
-  intro X _
-  have hmem : X.map (starRingEnd ℂ) ∈ Submodule.span ℂ (Set.range A) := by
-    rw [hA]
-    trivial
-  have hconj : ∀ Y ∈ Submodule.span ℂ (Set.range A),
-      Y.map (starRingEnd ℂ) ∈ Submodule.span ℂ (Set.range (MPSTensor.mapStar A)) := by
-    intro Y hY
-    induction hY using Submodule.span_induction with
-    | mem Z hZ =>
-        obtain ⟨i, rfl⟩ := hZ
-        exact Submodule.subset_span ⟨i, rfl⟩
-    | zero => simp
-    | add Y Z _ _ hY hZ =>
-        rw [show (Y + Z).map (starRingEnd ℂ) =
-          Y.map (starRingEnd ℂ) + Z.map (starRingEnd ℂ) by
-            exact Matrix.map_add _ (map_add (starRingEnd ℂ)) Y Z]
-        exact Submodule.add_mem _ hY hZ
-    | smul c Y _ hY =>
-        rw [show (c • Y).map (starRingEnd ℂ) =
-          star c • Y.map (starRingEnd ℂ) by
-            ext i j
-            simp [Matrix.map_apply]]
-        exact Submodule.smul_mem _ (star c) hY
-  have := hconj _ hmem
-  convert this using 1
-  ext i j
-  simp [Matrix.map_apply]
-
-private theorem evalWord_mapStar (A : MPSTensor d D) (w : List (Fin d)) :
-    evalWord (mapStar A) w = (evalWord A w).map (starRingEnd ℂ) := by
-  induction w with
-  | nil => simp [evalWord]
-  | cons i w ih =>
-      simp only [evalWord, mapStar_apply, ih]
-      exact ((starRingEnd ℂ).mapMatrix.map_mul (A i) (evalWord A w)).symm
-
-/-- Entrywise conjugation preserves positive-length block injectivity, hence normality. -/
-theorem IsNormal.mapStar {A : MPSTensor d D} (hA : IsNormal A) :
-    IsNormal (mapStar A) := by
-  obtain ⟨N, hN, hInj⟩ := hA
-  refine ⟨N, hN, ?_⟩
-  rw [isNBlkInjective_iff_blockTensor_isInjective] at hInj ⊢
-  have hConj := hInj.mapStar
-  convert hConj using 1
-  ext σ β α
-  simp [blockTensor, evalWord_mapStar]
-
-/-- Left-canonical normalization is preserved by entrywise complex conjugation. -/
-theorem IsLeftCanonical.mapStar {A : MPSTensor d D} (hA : IsLeftCanonical A) :
-    IsLeftCanonical (mapStar A) := by
-  classical
-  rw [IsLeftCanonical] at hA ⊢
-  calc
-    ∑ i, (MPSTensor.mapStar A i)ᴴ * MPSTensor.mapStar A i =
-        (∑ i, (A i)ᴴ * A i).map (starRingEnd ℂ) := by
-      rw [show (∑ i, (A i)ᴴ * A i).map (starRingEnd ℂ) =
-        ∑ i, ((A i)ᴴ * A i).map (starRingEnd ℂ) by
-      exact map_sum ((starRingEnd ℂ).mapMatrix) _ Finset.univ]
-      apply Finset.sum_congr rfl
-      intro i _
-      rw [Matrix.map_mul, Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
-      rfl
-    _ = 1 := by rw [hA]; simp
-
-/-- A spectrally normalized normal tensor remains normal after entrywise conjugation. -/
-theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A)
-    (hLeft : IsLeftCanonical A) : IsNormalTensor (mapStar A) := by
-  letI : NeZero D := ⟨hA.bondDim_ne_zero⟩
-  exact isNormalTensor_of_isNormal_leftCanonical _ hA.isNormal.mapStar hLeft.mapStar
-
-private theorem map_star_eq_self_of_posDef_isDiag
-    {n : ℕ} {Λ : Matrix (Fin n) (Fin n) ℂ} (hΛpos : Λ.PosDef) (hΛdiag : Λ.IsDiag) :
-    Λ.map (starRingEnd ℂ) = Λ := by
-  ext i j
-  by_cases hij : i = j
-  · subst j
-    simpa [Matrix.map_apply] using hΛpos.1.apply i i
-  · simp [Matrix.map_apply, hΛdiag hij]
-
-private theorem transferMap_mapStar (A : MPSTensor d D)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    transferMap (mapStar A) (X.map (starRingEnd ℂ)) =
-      (transferMap A X).map (starRingEnd ℂ) := by
-  classical
-  simp only [transferMap_apply]
-  rw [show (∑ i, A i * X * (A i)ᴴ).map (starRingEnd ℂ) =
-      ∑ i, (A i * X * (A i)ᴴ).map (starRingEnd ℂ) by
-    exact map_sum ((starRingEnd ℂ).mapMatrix) _ Finset.univ]
-  apply Finset.sum_congr rfl
-  intro i _
-  rw [Matrix.map_mul, Matrix.map_mul,
-    Matrix.conjTranspose_map (starRingEnd ℂ) (by simp [Function.Semiconj])]
-  rfl
-
-
-end MPSTensor
 
 namespace MPOTensor
 
@@ -165,10 +47,12 @@ def physicalPairSwapEquiv (d : ℕ) : Fin (d * d) ≃ Fin (d * d) where
       exact (finProdFinEquiv.apply_symm_apply ij).symm]
     simp
 
+/-- The physical-pair swap exchanges the two coordinates under `finProdFinEquiv`. -/
 @[simp] theorem physicalPairSwapEquiv_finProdFinEquiv (i j : Fin d) :
     physicalPairSwapEquiv d (finProdFinEquiv (i, j)) = finProdFinEquiv (j, i) := by
   simp [physicalPairSwapEquiv]
 
+/-- The physical-pair swap is its own inverse. -/
 @[simp] theorem physicalPairSwapEquiv_symm :
     (physicalPairSwapEquiv d).symm = physicalPairSwapEquiv d := rfl
 
@@ -196,9 +80,10 @@ The block count and dimensions are unchanged. We conjugate the weights, blocks, 
 coisometry entrywise, then exchange the two physical coordinates. A diagonal positive-definite
 fixed point is real, so the same matrix remains fixed by the transformed transfer map.
 
-This is the reduced-CFII operation used with arXiv:1703.09188, equations `II_CF` and
-`eq:transfer-op`, lines 271--281 and 336--340. It makes no assertion about selected compact-SVD
-witnesses or source factors. -/
+The literal canonical-form-II structure is from arXiv:1606.00608, Appendix A,
+lines 1054--1077. The normalization equations used here are the MPU context in
+arXiv:1703.09188, equation `Erightleft`, lines 271--281, and equation `eq:transfer-op`,
+lines 336--340. -/
 noncomputable def physicalAdjointNormalizedFlattening
     (data : CPSVCanonicalFormIIData U.normalizedFlattening) :
     CPSVCanonicalFormIIData (MPOTensor.physicalAdjointTensor U).normalizedFlattening where
@@ -259,25 +144,30 @@ noncomputable def physicalAdjointNormalizedFlattening
       MPSTensor.transferMap_mapStar, hΛfix,
       MPSTensor.map_star_eq_self_of_posDef_isDiag hΛpos hΛdiag]
 
+/-- The transported data have the same block count. -/
 @[simp] theorem physicalAdjointNormalizedFlattening_r
     (data : CPSVCanonicalFormIIData U.normalizedFlattening) :
     data.physicalAdjointNormalizedFlattening.r = data.r := rfl
 
+/-- The transported data have the same block dimensions. -/
 @[simp] theorem physicalAdjointNormalizedFlattening_dim
     (data : CPSVCanonicalFormIIData U.normalizedFlattening) :
     data.physicalAdjointNormalizedFlattening.dim = data.dim := rfl
 
+/-- The transported weights are the conjugates of the original weights. -/
 @[simp] theorem physicalAdjointNormalizedFlattening_weights
     (data : CPSVCanonicalFormIIData U.normalizedFlattening) (k : Fin data.r) :
     data.physicalAdjointNormalizedFlattening.weights k = star (data.weights k) := rfl
 
+/-- The transported blocks are conjugated and then physically swapped. -/
 @[simp] theorem physicalAdjointNormalizedFlattening_blocks
     (data : CPSVCanonicalFormIIData U.normalizedFlattening) (k : Fin data.r) :
     data.physicalAdjointNormalizedFlattening.blocks k =
       MPSTensor.reindexPhysical (MPOTensor.physicalPairSwapEquiv d)
         (MPSTensor.mapStar (data.blocks k)) := rfl
 
-@[simp] theorem physicalAdjointNormalizedFlattening_ambientCoisometry
+/-- The transported ambient coisometry is the entrywise conjugate of the original one. -/
+@[simp] theorem physicalAdjointNormalizedFlattening_ambient_coisometry
     (data : CPSVCanonicalFormIIData U.normalizedFlattening) :
     data.physicalAdjointNormalizedFlattening.ambient_coisometry =
       data.ambient_coisometry.map (starRingEnd ℂ) := rfl
@@ -302,7 +192,11 @@ namespace MPSTensor.IsCPSVCanonicalFormII
 
 variable {d D : ℕ} {U : MPOTensor d D}
 
-/-- Physical adjunction preserves literal CPSV canonical form II of the normalized flattening. -/
+/-- Physical adjunction preserves literal CPSV canonical form II of the normalized flattening.
+
+The literal canonical-form-II structure is from arXiv:1606.00608, Appendix A,
+lines 1054--1077. The normalization context is arXiv:1703.09188, equation `Erightleft`,
+lines 271--281, and equation `eq:transfer-op`, lines 336--340. -/
 theorem physicalAdjointNormalizedFlattening
     (h : MPSTensor.IsCPSVCanonicalFormII U.normalizedFlattening) :
     MPSTensor.IsCPSVCanonicalFormII

--- a/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
+++ b/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
@@ -34,27 +34,22 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- Exchange the two coordinates of a flattened physical pair. -/
-def physicalPairSwapEquiv (d : ℕ) : Fin (d * d) ≃ Fin (d * d) where
-  toFun ij := finProdFinEquiv (ij.modNat, ij.divNat)
-  invFun ij := finProdFinEquiv (ij.modNat, ij.divNat)
-  left_inv ij := by
-    rw [show ij = finProdFinEquiv (ij.divNat, ij.modNat) by
-      exact (finProdFinEquiv.apply_symm_apply ij).symm]
-    simp
-  right_inv ij := by
-    rw [show ij = finProdFinEquiv (ij.divNat, ij.modNat) by
-      exact (finProdFinEquiv.apply_symm_apply ij).symm]
-    simp
+/-- Exchange the two coordinates of a flattened physical pair.
+
+This is the existing pair-swap equivalence, named here for its role on the physical alphabet rather
+than its role on a doubled virtual bond. -/
+def physicalPairSwapEquiv (d : ℕ) : Fin (d * d) ≃ Fin (d * d) :=
+  bondPairSwapEquiv d
 
 /-- The physical-pair swap exchanges the two coordinates under `finProdFinEquiv`. -/
 @[simp] theorem physicalPairSwapEquiv_finProdFinEquiv (i j : Fin d) :
     physicalPairSwapEquiv d (finProdFinEquiv (i, j)) = finProdFinEquiv (j, i) := by
-  simp [physicalPairSwapEquiv]
+  rw [physicalPairSwapEquiv, bondPairSwapEquiv_apply, bondPairSwap_finProdFinEquiv]
 
 /-- The physical-pair swap is its own inverse. -/
 @[simp] theorem physicalPairSwapEquiv_symm :
-    (physicalPairSwapEquiv d).symm = physicalPairSwapEquiv d := rfl
+    (physicalPairSwapEquiv d).symm = physicalPairSwapEquiv d := by
+  rw [physicalPairSwapEquiv, bondPairSwapEquiv_symm]
 
 /-- The normalized flattening of the physical adjoint is obtained by applying entrywise complex
 conjugation to every virtual matrix entry and exchanging the two flattened physical coordinates. -/

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -343,6 +343,33 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     Definition~\ref{def:nt_cpsv} hold for $A$ itself.
 \end{proof}
 
+\begin{theorem}[Canonical normalization under entrywise conjugation]
+    \label{thm:cpsv_map_star_preservation}
+    \lean{MPSTensor.IsLeftCanonical.mapStar}
+    \lean{MPSTensor.IsNormalTensor.mapStar}
+    \leanok
+    \uses{def:left_canonical_tensor,def:nt_cpsv,
+        thm:is_normal_tensor_of_is_normal_left_canonical}
+    Let $\overline A$ denote entrywise conjugation of every matrix $A^i$. If
+    $A$ is left-canonical, then $\overline A$ is left-canonical. If, in
+    addition, $A$ is a CPSV normal tensor, then $\overline A$ is a CPSV normal
+    tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:left_canonical_tensor,
+        thm:is_normal_tensor_of_is_normal_left_canonical}
+    Conjugating the left-canonical identity gives
+    \begin{align}
+        \sum_i(\overline{A^i})^\dagger\overline{A^i}
+        &=\overline{\sum_i(A^i)^\dagger A^i}
+         =\overline{\Id}=\Id.
+    \end{align}
+    Entrywise conjugation also preserves positive-length block injectivity.
+    Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical} applied to
+    $\overline A$ now gives the CPSV normal-tensor conclusion.
+\end{proof}
+
 \begin{definition}[CPSV canonical form]
     \label{def:cpsv_canonical_form}
     \lean{MPSTensor.CPSVCanonicalFormData}
@@ -448,6 +475,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 \begin{theorem}[Physical relabeling preserves CPSV normal and canonical form]
     \label{thm:cpsv_physical_reindexing}
     \lean{MPSTensor.IsNormalTensor.reindexPhysical}
+    \lean{MPSTensor.leftCanonical_reindexPhysical_equiv}
+    \lean{MPSTensor.transferMap_reindexPhysical_equiv}
     \lean{MPSTensor.CPSVCanonicalFormData.reindexPhysical}
     \lean{MPSTensor.IsCPSVCanonicalForm.reindexPhysical}
     \leanok
@@ -458,7 +487,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
         &= A^{e(j)}.
         \label{eq:cpsv_physical_reindexing_tensor}
     \end{align}
-    If $A$ is a CPSV normal tensor, then $e^*A$ is a CPSV normal tensor. If
+    The transfer maps of $A$ and $e^*A$ agree. In particular, physical
+    relabeling preserves left-canonical normalization and CPSV normality. If
     $A$ has canonical-form data
     \begin{align}
         A^i

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1629,13 +1629,17 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \leanok
     \uses{def:cpsv_cfii,def:mpu_physical_pair_swap,
         thm:mpu_physical_adjoint_normalized_flattening,
-        thm:is_normal_tensor_of_is_normal_left_canonical,
-        thm:cpsv_physical_reindexing}
-    Given canonical-form-II data for $\widetilde{\mathcal U}$, keep the block
-    count and dimensions, replace $\mu_k$ by $\overline{\mu_k}$, replace
-    $A_k$ by $s^*\overline{A_k}$, and replace the ambient coisometry $V$ by
-    $\overline V$.  The resulting data reconstruct
-    $\widetilde{\mathcal U^\sharp}$.
+        thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing}
+    Given canonical-form-II data for $\widetilde{\mathcal U}$, define the
+    transformed tuple by
+    \begin{align}
+        r'&=r,\\
+        D'_k&=D_k,\\
+        \mu'_k&=\overline{\mu_k},\\
+        (A'_k)^{(i,j)}&=\overline{A_k^{(j,i)}},\\
+        V'&=\overline V.
+    \end{align}
+    These data reconstruct $\widetilde{\mathcal U^\sharp}$.
 \end{definition}
 
 \begin{theorem}[Canonical form II under physical adjunction]
@@ -1648,14 +1652,31 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:mpu_physical_adjoint_cfii_data}
-    Entrywise conjugation preserves positive-length block injectivity and
-    left-canonical normalization, hence normality.  Physical relabeling also
-    preserves normality and left-canonical normalization.  Conjugating
-    $VV^*=\Id$ gives $\overline V(\overline V)^*=\Id$, and conjugating the
-    direct-sum reconstruction gives the required reconstruction.  A diagonal
-    positive fixed matrix $\Lambda_k$ is real, so conjugating
-    $\E_{A_k}(\Lambda_k)=\Lambda_k$ gives the transformed fixed-point equation.
+    \uses{def:mpu_physical_adjoint_cfii_data,
+        thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing}
+    Theorem~\ref{thm:cpsv_map_star_preservation} gives normality and
+    left-canonical normalization after entrywise conjugation, and
+    Theorem~\ref{thm:cpsv_physical_reindexing} preserves these properties under
+    the physical-pair swap.  Conjugating the coisometry equation gives
+    \begin{align}
+        V'V'^\dagger
+        &=\overline{VV^\dagger}=\Id.
+    \end{align}
+    Conjugating the reconstruction at the swapped physical index gives
+    \begin{align}
+        \widetilde{\mathcal U^\sharp}^{\,(i,j)}
+        &=(V')^\dagger
+          \left(\bigoplus_k\mu'_k(A'_k)^{(i,j)}\right)V'.
+    \end{align}
+    Finally, each diagonal positive matrix $\Lambda_k$ is real, and therefore
+    \begin{align}
+        \E_{\overline{A_k}}(\Lambda_k)
+        &=\overline{\E_{A_k}(\Lambda_k)}
+         =\overline{\Lambda_k}
+         =\Lambda_k.
+    \end{align}
+    Physical relabeling leaves this transfer map unchanged, which proves the
+    transformed fixed-point equation.
 \end{proof}
 
 \begin{theorem}[Full active support under physical adjunction]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1594,9 +1594,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \lean{MPOTensor.physicalPairSwapEquiv,
         MPOTensor.physicalPairSwapEquiv_finProdFinEquiv}
     \leanok
-    \uses{def:mpdo_physical_adjoint,def:mpu_normalized_flattening}
-    On the flattened physical alphabet, physical adjunction uses the
-    involution
+    On the flattened physical alphabet, define the involution
     \begin{align}
         s(i,j)&=(j,i).
     \end{align}
@@ -1610,8 +1608,7 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \leanok
     \uses{def:mpdo_physical_adjoint,def:mpu_normalized_flattening,
         def:mpu_physical_pair_swap}
-    The normalized flattening of the physical adjoint is obtained by
-    entrywise conjugation followed by the physical-pair swap:
+    The normalized flattening of the physical adjoint satisfies
     \begin{align}
       \widetilde{\mathcal U^\sharp}^{\,(i,j)}
         &=\overline{\widetilde{\mathcal U}^{\,(j,i)}}.
@@ -1619,41 +1616,70 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:mpdo_physical_adjoint,def:mpu_normalized_flattening,
+        def:mpu_physical_pair_swap}
     Expand the normalized flattening. Its factor $d^{-1/2}$ is real, while
     physical adjunction exchanges the ket and bra coordinates and conjugates
     every virtual matrix entry.
 \end{proof}
 
-\begin{theorem}[Reduced canonical-form-II data under physical adjunction]
-    \label{thm:mpu_physical_adjoint_reduced_cfii}
-    \lean{MPSTensor.CPSVCanonicalFormIIData.physicalAdjointNormalizedFlattening,
-        MPSTensor.CPSVCanonicalFormIIData.hasFullActiveSupport_physicalAdjointNormalizedFlattening,
-        MPSTensor.IsCPSVCanonicalFormII.physicalAdjointNormalizedFlattening}
+\begin{definition}[Canonical-form-II data under physical adjunction]
+    \label{def:mpu_physical_adjoint_cfii_data}
+    \lean{MPSTensor.CPSVCanonicalFormIIData.physicalAdjointNormalizedFlattening}
     \leanok
-    \uses{def:cpsv_cfii,def:mpu_full_active_support,
-        thm:mpu_physical_adjoint_normalized_flattening}
-    Suppose the normalized flattening has canonical-form-II data with full
-    active support. Physical adjunction preserves the block count and block
-    dimensions, conjugates every weight, conjugates every block before the
-    physical-pair swap, and conjugates the ambient coisometry. The resulting
-    data again have full active support and canonical form II.
+    \uses{def:cpsv_cfii,def:mpu_physical_pair_swap,
+        thm:mpu_physical_adjoint_normalized_flattening,
+        thm:is_normal_tensor_of_is_normal_left_canonical,
+        thm:cpsv_physical_reindexing}
+    Given canonical-form-II data for $\widetilde{\mathcal U}$, keep the block
+    count and dimensions, replace $\mu_k$ by $\overline{\mu_k}$, replace
+    $A_k$ by $s^*\overline{A_k}$, and replace the ambient coisometry $V$ by
+    $\overline V$.  The resulting data reconstruct
+    $\widetilde{\mathcal U^\sharp}$.
+\end{definition}
 
-    Each diagonal positive fixed matrix $\Lambda_k$ is unchanged. Indeed,
-    positivity and diagonality imply that its entries are real, and
-    conjugating its fixed-point equation gives the transformed equation.
-    This statement concerns canonical-form data only and does not identify
-    any selected singular-value decomposition or source factor.
+\begin{theorem}[Canonical form II under physical adjunction]
+    \label{thm:mpu_physical_adjoint_cfii}
+    \lean{MPSTensor.IsCPSVCanonicalFormII.physicalAdjointNormalizedFlattening}
+    \leanok
+    \uses{def:cpsv_cfii,def:mpu_physical_adjoint_cfii_data}
+    If $\widetilde{\mathcal U}$ is in canonical form II, then
+    $\widetilde{\mathcal U^\sharp}$ is in canonical form II.
 \end{theorem}
 
 \begin{proof}\leanok
-    Conjugation preserves positive-length block injectivity and
-    left-canonical normalization, hence normality. It also preserves the
-    coisometry equation and the direct-sum reconstruction. Nonzero weights
-    remain nonzero under conjugation, so the active indices and their block
-    dimensions are unchanged. The later reflected transfer calculation has
-    the separately fixed orientation $\rho^{\mathsf T}$ in
-    Theorem~\ref{thm:mpu_reflected_transfer_power}.
+    \uses{def:mpu_physical_adjoint_cfii_data}
+    Entrywise conjugation preserves positive-length block injectivity and
+    left-canonical normalization, hence normality.  Physical relabeling also
+    preserves normality and left-canonical normalization.  Conjugating
+    $VV^*=\Id$ gives $\overline V(\overline V)^*=\Id$, and conjugating the
+    direct-sum reconstruction gives the required reconstruction.  A diagonal
+    positive fixed matrix $\Lambda_k$ is real, so conjugating
+    $\E_{A_k}(\Lambda_k)=\Lambda_k$ gives the transformed fixed-point equation.
 \end{proof}
+
+\begin{theorem}[Full active support under physical adjunction]
+    \label{thm:mpu_physical_adjoint_full_active_support}
+    \lean{MPSTensor.CPSVCanonicalFormIIData.hasFullActiveSupport_physicalAdjointNormalizedFlattening}
+    \leanok
+    \uses{def:mpu_full_active_support,def:mpu_physical_adjoint_cfii_data}
+    If canonical-form-II data for $\widetilde{\mathcal U}$ have full active
+    support, then the data from
+    Definition~\ref{def:mpu_physical_adjoint_cfii_data} also have full active
+    support.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpu_full_active_support,def:mpu_physical_adjoint_cfii_data}
+    Complex conjugation preserves nonzero weights.  Hence the active indices
+    and their block dimensions are unchanged, so their dimension sum remains
+    equal to the ambient bond dimension.
+\end{proof}
+
+% Scope: the preceding three entries concern literal CFII data only. They do not
+% identify a selected compact SVD, source factor, sourceU, or sourceV witness.
+% Downstream orientation: the reflected transfer theorem separately fixes the
+% right-hand density as rho.transpose; no such orientation is asserted here.
 
 \begin{theorem}[Source ranks under physical adjunction]
     \label{thm:mpu_physical_adjoint_source_ranks}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1589,6 +1589,72 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     the entrywise conjugate of the second, and conversely.
 \end{proof}
 
+\begin{definition}[Physical-pair swap]
+    \label{def:mpu_physical_pair_swap}
+    \lean{MPOTensor.physicalPairSwapEquiv,
+        MPOTensor.physicalPairSwapEquiv_finProdFinEquiv}
+    \leanok
+    \uses{def:mpdo_physical_adjoint,def:mpu_normalized_flattening}
+    On the flattened physical alphabet, physical adjunction uses the
+    involution
+    \begin{align}
+        s(i,j)&=(j,i).
+    \end{align}
+    This acts on physical coordinates and is distinct from the doubled-bond
+    exchange used in reflected transfer calculations.
+\end{definition}
+
+\begin{theorem}[Normalized flattening under physical adjunction]
+    \label{thm:mpu_physical_adjoint_normalized_flattening}
+    \lean{MPOTensor.normalizedFlattening_physicalAdjointTensor}
+    \leanok
+    \uses{def:mpdo_physical_adjoint,def:mpu_normalized_flattening,
+        def:mpu_physical_pair_swap}
+    The normalized flattening of the physical adjoint is obtained by
+    entrywise conjugation followed by the physical-pair swap:
+    \begin{align}
+      \widetilde{\mathcal U^\sharp}^{\,(i,j)}
+        &=\overline{\widetilde{\mathcal U}^{\,(j,i)}}.
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the normalized flattening. Its factor $d^{-1/2}$ is real, while
+    physical adjunction exchanges the ket and bra coordinates and conjugates
+    every virtual matrix entry.
+\end{proof}
+
+\begin{theorem}[Reduced canonical-form-II data under physical adjunction]
+    \label{thm:mpu_physical_adjoint_reduced_cfii}
+    \lean{MPSTensor.CPSVCanonicalFormIIData.physicalAdjointNormalizedFlattening,
+        MPSTensor.CPSVCanonicalFormIIData.hasFullActiveSupport_physicalAdjointNormalizedFlattening,
+        MPSTensor.IsCPSVCanonicalFormII.physicalAdjointNormalizedFlattening}
+    \leanok
+    \uses{def:cpsv_cfii,def:mpu_full_active_support,
+        thm:mpu_physical_adjoint_normalized_flattening}
+    Suppose the normalized flattening has canonical-form-II data with full
+    active support. Physical adjunction preserves the block count and block
+    dimensions, conjugates every weight, conjugates every block before the
+    physical-pair swap, and conjugates the ambient coisometry. The resulting
+    data again have full active support and canonical form II.
+
+    Each diagonal positive fixed matrix $\Lambda_k$ is unchanged. Indeed,
+    positivity and diagonality imply that its entries are real, and
+    conjugating its fixed-point equation gives the transformed equation.
+    This statement concerns canonical-form data only and does not identify
+    any selected singular-value decomposition or source factor.
+\end{theorem}
+
+\begin{proof}\leanok
+    Conjugation preserves positive-length block injectivity and
+    left-canonical normalization, hence normality. It also preserves the
+    coisometry equation and the direct-sum reconstruction. Nonzero weights
+    remain nonzero under conjugation, so the active indices and their block
+    dimensions are unchanged. The later reflected transfer calculation has
+    the separately fixed orientation $\rho^{\mathsf T}$ in
+    Theorem~\ref{thm:mpu_reflected_transfer_power}.
+\end{proof}
+
 \begin{theorem}[Source ranks under physical adjunction]
     \label{thm:mpu_physical_adjoint_source_ranks}
     \lean{MPOTensor.rightRank_physicalAdjointTensor,

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -1010,6 +1010,21 @@ abstracted — record why, so it is not re-proposed).
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
 
+### flattened-pair reconstruction from quotient and remainder — candidate
+- **Pattern:** rewrite `ij : Fin (d * d)` as
+  `finProdFinEquiv (ij.divNat, ij.modNat)` using
+  `(finProdFinEquiv.apply_symm_apply ij).symm` before simplifying a flattened
+  pair operation.
+- **Seen:** 3 occurrences across `TNLean/MPS/MPDO/PhysicalAdjoint.lean` and
+  `TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean` after the physical-pair
+  equivalence deduplication (2026-08-13); the latter contributes one occurrence.
+- **Abstraction (proposed):** add a low-level simp lemma such as
+  `finProdFinEquiv_divNat_modNat` near the shared flattened-index definitions,
+  then replace all occurrences together.
+- **Notes:** Promotion would require editing established MPDO code outside the
+  narrow CFII review-fix scope. Record the repeated goal now and refactor the
+  complete set in one low-level follow-up rather than adding a leaf-local helper.
+
 ### diagonal normalized-ancilla sum collapse — candidate
 - **Pattern:** collapse the doubled sum for `normalizedDiagonalLift` by using
   `Finset.sum_eq_single` to retain the diagonal ancilla letter `(a, a)`, then


### PR DESCRIPTION
## What changed

- add entrywise-conjugation preservation for the MPS properties needed by CFII data
- identify the normalized flattening of the physical adjoint as conjugation followed by physical-pair swap
- construct explicit transformed CPSV canonical-form-II data and preserve full active support
- retain diagonal positive block fixed points and record the later general fixed-matrix orientation as `rho.transpose`

This PR does not compare selected compact SVDs, selected source factors, `sourceU`, or `sourceV`.

## Validation

- `lake build TNLean.MPS.MPU.PhysicalAdjointCanonicalForm`
- `lake build TNLean.MPS.MPU`
- editor diagnostics and proof-integrity scan
- import aggregators
- blueprint sync and declaration check
- two LuaLaTeX passes with zero undefined references
- `git diff --check`

Closes #6277
Advances #6139