### PR TITLE
docs(MPDO): display prefix marginal contraction

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -276,9 +276,15 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 
 \begin{proof}\leanok
     Reindex the chain into its first $L$ and final $K$ sites.  The sitewise
-    matrix becomes $V^{\otimes L}\otimes V^{\otimes K}$, and
-    $(V^{\otimes K})^*V^{\otimes K}=I$ removes the second factor under the
-    partial trace.
+    matrix becomes $V^{\otimes L}\otimes V^{\otimes K}$.  Since
+    $(V^{\otimes K})^*V^{\otimes K}=I$, the partial trace satisfies
+    \begin{align}
+      &\tr_K\!\left[
+        \bigl(V^{\otimes L}\otimes V^{\otimes K}\bigr)X
+        \bigl(V^{\otimes L}\otimes V^{\otimes K}\bigr)^*\right]\\
+      &\qquad=V^{\otimes L}\tr_K[X](V^{\otimes L})^*.
+      \notag
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Reduced states under an isometric physical inclusion]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -275,13 +275,15 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 \end{theorem}
 
 \begin{proof}\leanok
-    Reindex the chain into its first $L$ and final $K$ sites.  The sitewise
-    matrix becomes $V^{\otimes L}\otimes V^{\otimes K}$.  Since
+    Let $X$ denote the operator before conjugation.  Reindex the chain into its
+    first $L$ and final $K$ sites.  The sitewise matrix becomes
+    $V^{\otimes L}\otimes V^{\otimes K}$.  Since
     $(V^{\otimes K})^*V^{\otimes K}=I$, the partial trace satisfies
     \begin{align}
       &\tr_K\!\left[
         \bigl(V^{\otimes L}\otimes V^{\otimes K}\bigr)X
-        \bigl(V^{\otimes L}\otimes V^{\otimes K}\bigr)^*\right]\\
+        \bigl(V^{\otimes L}\otimes V^{\otimes K}\bigr)^*\right]
+        \notag\\
       &\qquad=V^{\otimes L}\tr_K[X](V^{\otimes L})^*.
       \notag
     \end{align}


### PR DESCRIPTION
## Summary

- follow up the late post-merge review on #6354
- display the sitewise-isometry partial-trace identity in the prefix-marginal Blueprint proof
- record explicitly that `(V^{⊗K})* V^{⊗K} = I` removes the traced-site factors

## Verification

- `python3 scripts/blueprint_lean_sync.py --ci`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `git diff --check`

Follow-up to #6354.