### PR TITLE
feat(MPDO): prove Example 4.11 entropy obstruction

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -87,6 +87,7 @@ import TNLean.MPS.MPDO.CPSVBNTTheoremEquivalence
 import TNLean.MPS.MPDO.CPSVBlocking
 import TNLean.MPS.MPDO.CPSVExample411Ambient
 import TNLean.MPS.MPDO.CPSVExample411BinarySupport
+import TNLean.MPS.MPDO.CPSVExample411Entropy
 import TNLean.MPS.MPDO.CPSVExample411Spectrum
 import TNLean.MPS.MPDO.CPSVExample412Literal
 import TNLean.MPS.MPDO.CPSVExamples410411Arithmetic

--- a/TNLean/MPS/MPDO/CPSVExample411Entropy.lean
+++ b/TNLean/MPS/MPDO/CPSVExample411Entropy.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CPSVExample411Spectrum
+import TNLean.MPS.MPDO.CPSVExamples410411Arithmetic
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+
+/-!
+# Finite-ring entropy obstruction for CPSV16 Example 4.11
+
+This module derives the natural-logarithm block entropies of the effective binary model on a
+four-site ring from its previously established characteristic-polynomial roots. Their mutual
+information difference is the logarithm of the exact positive ratio certified separately in the
+arithmetic module. Hence the effective tensor does not satisfy saturation of the area law, and the
+same conclusion holds after its isometric inclusion into the two-qubit one-site space.
+
+These are project-derived finite-periodic consequences of the neighboring operators printed in
+CPSV16 Example 4.11. They do not assert zero correlation length or a thermodynamic-limit claim.
+See `docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex`.
+
+## Main results
+
+* `M_isMPDO`: the effective binary tensor generates positive semidefinite operators.
+* `blockEntropy_one` through `blockEntropy_four`: the four exact natural-logarithm entropies.
+* `mutualInfo_two_sub_one`: the exact logarithmic mutual-information difference.
+* `mutualInfo_two_sub_one_pos`: strict positivity from the certified integer comparison.
+* `M_not_isSAL`: the effective binary tensor does not satisfy saturation of the area law.
+* `ambientM_not_isSAL`: neither does its isometric inclusion into the two-qubit site space.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.CPSVExample411Entropy
+
+open CPSVExample411BinarySupport CPSVExample411Spectrum
+
+private theorem weightMatrix_nonneg (i j : Fin 2) :
+    (0 : ℂ) ≤ weightMatrix i j := by
+  fin_cases i <;> fin_cases j
+  · norm_num [weightMatrix]
+  · simp [weightMatrix]
+  · simp [weightMatrix]
+  · norm_num [weightMatrix]
+
+private theorem cycleWeight_nonneg {N : ℕ} [NeZero N] (σ : Fin N → Fin 2) :
+    (0 : ℂ) ≤ cycleWeight σ := by
+  exact Finset.prod_nonneg fun n _ ↦ weightMatrix_nonneg (σ n) (σ (n + 1))
+
+/-- The effective binary tensor generates positive semidefinite periodic operators at every
+positive length. -/
+theorem M_isMPDO : IsMPDO M := by
+  intro N hN
+  letI : NeZero N := ⟨by omega⟩
+  rw [mpo_M_eq_diagonal]
+  exact Matrix.PosSemidef.diagonal cycleWeight_nonneg
+
+private lemma blockEntropy_of_roots {L : ℕ} (hL : L ≤ 4) (s : Multiset ℝ)
+    (hroots : (reducedBlockState M 4 L hL).charpoly.roots =
+      s.map (fun r : ℝ ↦ (r : ℂ))) :
+    blockEntropy M 4 L hL (M_isMPDO 4 (by omega)) = (s.map Real.negMulLog).sum := by
+  exact Matrix.vonNeumannEntropy_of_charpoly_roots_eq
+    (reducedBlockState_isHermitian M 4 L hL (M_isMPDO 4 (by omega))) s hroots
+
+/-- The one-site block entropy on the four-site ring is $\log 2$. -/
+theorem blockEntropy_one :
+    blockEntropy M 4 1 (by omega) (M_isMPDO 4 (by omega)) = Real.log 2 := by
+  rw [blockEntropy_of_roots (by omega) (2 • {(1 / 2 : ℝ)})]
+  · simp only [Multiset.map_nsmul, Multiset.map_singleton, Multiset.sum_nsmul,
+      Multiset.sum_singleton, Real.negMulLog]
+    rw [Real.log_div (by norm_num) (by norm_num)]
+    simp only [Real.log_one]
+    ring
+  · rw [effective_charpoly_roots_one]
+    simp only [Multiset.map_nsmul, Multiset.map_singleton]
+    norm_num
+
+/-- The two-site block entropy on the four-site ring is the entropy sum of its two root values. -/
+theorem blockEntropy_two :
+    blockEntropy M 4 2 (by omega) (M_isMPDO 4 (by omega)) =
+      2 * Real.negMulLog (14 / 41) + 2 * Real.negMulLog (13 / 82) := by
+  rw [blockEntropy_of_roots (by omega)
+    (2 • {(14 / 41 : ℝ)} + 2 • {(13 / 82 : ℝ)})]
+  · simp only [Multiset.map_add, Multiset.sum_add, Multiset.map_nsmul,
+      Multiset.sum_nsmul, Multiset.map_singleton, Multiset.sum_singleton]
+    norm_num
+  · rw [effective_charpoly_roots_two]
+    simp only [Multiset.map_add, Multiset.map_nsmul, Multiset.map_singleton]
+    norm_num
+
+/-- The three-site block entropy on the four-site ring is the entropy sum of its three root
+values. -/
+theorem blockEntropy_three :
+    blockEntropy M 4 3 (by omega) (M_isMPDO 4 (by omega)) =
+      2 * Real.negMulLog (10 / 41) + 4 * Real.negMulLog (4 / 41) +
+        2 * Real.negMulLog (5 / 82) := by
+  rw [blockEntropy_of_roots (by omega)
+    (2 • {(10 / 41 : ℝ)} + 4 • {(4 / 41 : ℝ)} + 2 • {(5 / 82 : ℝ)})]
+  · simp only [Multiset.map_add, Multiset.sum_add, Multiset.map_nsmul,
+      Multiset.sum_nsmul, Multiset.map_singleton, Multiset.sum_singleton]
+    norm_num
+  · rw [effective_charpoly_roots_three]
+    simp only [Multiset.map_add, Multiset.map_nsmul, Multiset.map_singleton]
+    norm_num
+
+/-- The four-site entropy is the entropy sum of the three root values of the full state. -/
+theorem blockEntropy_four :
+    blockEntropy M 4 4 (by omega) (M_isMPDO 4 (by omega)) =
+      2 * Real.negMulLog (8 / 41) + 12 * Real.negMulLog (2 / 41) +
+        2 * Real.negMulLog (1 / 82) := by
+  rw [blockEntropy_of_roots (by omega)
+    (2 • {(8 / 41 : ℝ)} + 12 • {(2 / 41 : ℝ)} + 2 • {(1 / 82 : ℝ)})]
+  · simp only [Multiset.map_add, Multiset.sum_add, Multiset.map_nsmul,
+      Multiset.sum_nsmul, Multiset.map_singleton, Multiset.sum_singleton]
+    norm_num
+  · rw [effective_charpoly_roots_four]
+    simp only [Multiset.map_add, Multiset.map_nsmul, Multiset.map_singleton]
+    norm_num
+
+/-- On the four-site ring, the difference $I_2-I_1$ is the natural logarithm of the exact
+positive rational ratio arising from the root multisets. -/
+theorem mutualInfo_two_sub_one :
+    mutualInfoChain M 4 2 (by omega) (M_isMPDO 4 (by omega)) -
+        mutualInfoChain M 4 1 (by omega) (M_isMPDO 4 (by omega)) =
+      (1 / 82 : ℝ) * Real.log
+        (((41 : ℝ) ^ 82 * 5 ^ 50) / (2 ^ 48 * 13 ^ 52 * 7 ^ 112)) := by
+  have hlog : Real.log
+      (((41 : ℝ) ^ 82 * 5 ^ 50) / (2 ^ 48 * 13 ^ 52 * 7 ^ 112)) =
+      82 * Real.log 41 + 50 * Real.log 5 -
+        (48 * Real.log 2 + 52 * Real.log 13 + 112 * Real.log 7) := by
+    rw [Real.log_div (by norm_num : ((41 : ℝ) ^ 82 * 5 ^ 50) ≠ 0)
+      (by norm_num : ((2 : ℝ) ^ 48 * 13 ^ 52 * 7 ^ 112) ≠ 0),
+      Real.log_mul (by norm_num : (41 : ℝ) ^ 82 ≠ 0)
+        (by norm_num : (5 : ℝ) ^ 50 ≠ 0),
+      Real.log_mul (by norm_num : (2 : ℝ) ^ 48 * 13 ^ 52 ≠ 0)
+        (by norm_num : (7 : ℝ) ^ 112 ≠ 0),
+      Real.log_mul (by norm_num : (2 : ℝ) ^ 48 ≠ 0)
+        (by norm_num : (13 : ℝ) ^ 52 ≠ 0)]
+    simp only [Real.log_pow]
+    ring
+  rw [mutualInfoChain, mutualInfoChain, blockEntropy_one, blockEntropy_two,
+    blockEntropy_three, blockEntropy_four, hlog]
+  simp only [Real.negMulLog]
+  rw [Real.log_div (by norm_num : (14 : ℝ) ≠ 0) (by norm_num : (41 : ℝ) ≠ 0),
+    Real.log_div (by norm_num : (13 : ℝ) ≠ 0) (by norm_num : (82 : ℝ) ≠ 0),
+    Real.log_div (by norm_num : (10 : ℝ) ≠ 0) (by norm_num : (41 : ℝ) ≠ 0),
+    Real.log_div (by norm_num : (4 : ℝ) ≠ 0) (by norm_num : (41 : ℝ) ≠ 0),
+    Real.log_div (by norm_num : (5 : ℝ) ≠ 0) (by norm_num : (82 : ℝ) ≠ 0)]
+  have h14 : Real.log (14 : ℝ) = Real.log 2 + Real.log 7 := by
+    rw [show (14 : ℝ) = 2 * 7 by norm_num,
+      Real.log_mul (by norm_num : (2 : ℝ) ≠ 0) (by norm_num : (7 : ℝ) ≠ 0)]
+  have h82 : Real.log (82 : ℝ) = Real.log 2 + Real.log 41 := by
+    rw [show (82 : ℝ) = 2 * 41 by norm_num,
+      Real.log_mul (by norm_num : (2 : ℝ) ≠ 0) (by norm_num : (41 : ℝ) ≠ 0)]
+  have h10 : Real.log (10 : ℝ) = Real.log 2 + Real.log 5 := by
+    rw [show (10 : ℝ) = 2 * 5 by norm_num,
+      Real.log_mul (by norm_num : (2 : ℝ) ≠ 0) (by norm_num : (5 : ℝ) ≠ 0)]
+  have h4 : Real.log (4 : ℝ) = Real.log 2 + Real.log 2 := by
+    rw [show (4 : ℝ) = 2 * 2 by norm_num,
+      Real.log_mul (by norm_num : (2 : ℝ) ≠ 0) (by norm_num : (2 : ℝ) ≠ 0)]
+  rw [h14, h82, h10, h4]
+  ring
+
+/-- The exact mutual-information difference on the four-site ring is strictly positive. -/
+theorem mutualInfo_two_sub_one_pos :
+    0 < mutualInfoChain M 4 2 (by omega) (M_isMPDO 4 (by omega)) -
+      mutualInfoChain M 4 1 (by omega) (M_isMPDO 4 (by omega)) := by
+  rw [mutualInfo_two_sub_one]
+  positivity [CPSVExamples410411Arithmetic.example411_log_ratio_pos]
+
+/-- The effective binary finite-ring tensor does not satisfy saturation of the area law. -/
+theorem M_not_isSAL : ¬ IsSAL M := by
+  intro hSAL
+  have hEq := mutualInfoChain_eq_of_isSAL M hSAL (N := 4) (L := 1) (L' := 2)
+    (by omega) (by omega) (by omega) (by omega)
+  have hPos := mutualInfo_two_sub_one_pos
+  rw [hEq] at hPos
+  linarith
+
+/-- The isometrically included two-qubit-site tensor also does not satisfy saturation of the area
+law. -/
+theorem ambientM_not_isSAL : ¬ IsSAL CPSVExample411Ambient.ambientM := by
+  intro hSAL
+  apply M_not_isSAL
+  exact isSAL_of_changePhysicalBasis_isSAL_of_isometry
+    CPSVExample411Ambient.inclusion CPSVExample411Ambient.inclusion_isometry M hSAL
+
+end MPOTensor.CPSVExample411Entropy

--- a/TNLean/MPS/MPDO/CPSVExample411Entropy.lean
+++ b/TNLean/MPS/MPDO/CPSVExample411Entropy.lean
@@ -54,7 +54,7 @@ private theorem cycleWeight_nonneg {N : ℕ} [NeZero N] (σ : Fin N → Fin 2) :
 positive length. -/
 theorem M_isMPDO : IsMPDO M := by
   intro N hN
-  letI : NeZero N := ⟨by omega⟩
+  letI : NeZero N := ⟨hN.ne'⟩
   rw [mpo_M_eq_diagonal]
   exact Matrix.PosSemidef.diagonal cycleWeight_nonneg
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1390,7 +1390,9 @@ This is the calculation in
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_example411_length_four_effective_spectra}
+    \uses{thm:cpsv_example411_binary_support_normalization,
+        thm:cpsv_example411_length_four_effective_spectra,
+        lem:entropy_charpoly_roots}
     Every positive-length periodic operator is diagonal, and each diagonal
     entry is a product of entries of
     $W=\left(\begin{smallmatrix}1&1/2\\1/2&1\end{smallmatrix}\right)$, hence is
@@ -1398,6 +1400,27 @@ This is the calculation in
     multiplicities in
     Theorem~\ref{thm:cpsv_example411_length_four_effective_spectra} gives the
     displayed entropy.
+\end{proof}
+
+% Project-derived scalar certificate for CPSV16 Example 4.11.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{theorem}[Positivity of the Example 4.11 logarithmic ratio]
+    \label{thm:cpsv_example411_log_ratio_pos}
+    \lean{CPSVExamples410411Arithmetic.example411_log_ratio_pos}
+    \leanok
+    The exact scalar ratio from the four-site calculation satisfies
+    \[
+      \log\!\left(
+        \frac{41^{82}5^{50}}{2^{48}13^{52}7^{112}}
+      \right)>0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The numerator is strictly larger than the denominator, as follows by an
+    exact integer calculation, so the ratio is greater than one and its
+    logarithm is strictly positive.
 \end{proof}
 
 \begin{theorem}[Exact length-four mutual-information obstruction]
@@ -1421,7 +1444,8 @@ This is the calculation in
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_example411_length_four_effective_entropies}
+    \uses{thm:cpsv_example411_length_four_effective_entropies,
+        thm:cpsv_example411_log_ratio_pos}
     Since $I_2-I_1=2S_2-S_1-S_3$, expanding
     $h(x)=-x\log x$ and using the logarithm rules gives the displayed identity.
     The certified comparison
@@ -1429,8 +1453,8 @@ This is the calculation in
     Saturation would instead require $I_1=I_2$ on the four-site ring.
 \end{proof}
 
-\begin{corollary}[Ambient length-four saturation obstruction]
-    \label{cor:cpsv_example411_ambient_not_sal}
+\begin{theorem}[Ambient length-four saturation obstruction]
+    \label{thm:cpsv_example411_ambient_not_sal}
     \lean{MPOTensor.CPSVExample411Entropy.ambientM_not_isSAL}
     \leanok
     \uses{def:cpsv_example411_ambient_support_inclusion,
@@ -1438,7 +1462,7 @@ This is the calculation in
         thm:mpdo_sal_physical_isometry_transport}
     The isometric inclusion of the effective binary tensor into the
     two-qubit one-site space does not satisfy saturation of the area law.
-\end{corollary}
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1444,7 +1444,8 @@ This is the calculation in
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_example411_length_four_effective_entropies,
+    \uses{lem:sal_const,
+        thm:cpsv_example411_length_four_effective_entropies,
         thm:cpsv_example411_log_ratio_pos}
     Since $I_2-I_1=2S_2-S_1-S_3$, expanding
     $h(x)=-x\log x$ and using the logarithm rules gives the displayed identity.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1364,6 +1364,91 @@ This is the calculation in
     multiplicity.
 \end{proof}
 
+% Project-derived finite-ring consequence of CPSV16 Example 4.11.
+% See docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex.
+\begin{theorem}[Exact length-four effective entropies]
+    \label{thm:cpsv_example411_length_four_effective_entropies}
+    \lean{MPOTensor.CPSVExample411Entropy.M_isMPDO,
+        MPOTensor.CPSVExample411Entropy.blockEntropy_one,
+        MPOTensor.CPSVExample411Entropy.blockEntropy_two,
+        MPOTensor.CPSVExample411Entropy.blockEntropy_three,
+        MPOTensor.CPSVExample411Entropy.blockEntropy_four}
+    \leanok
+    \uses{def:block_entropy,
+        thm:cpsv_example411_length_four_effective_spectra}
+    The effective binary tensor generates positive semidefinite periodic
+    operators.  On the ring of length four, write $S_L=S(\rho_L)$.  With
+    $h(x)=-x\log x$, where $\log$ is the natural logarithm,
+    \begin{align}
+      S_1&=\log 2,\notag\\
+      S_2&=2h(14/41)+2h(13/82),\notag\\
+      S_3&=2h(10/41)+4h(4/41)+2h(5/82),\notag\\
+      S_4&=2h(8/41)+12h(2/41)+2h(1/82).
+      \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_example411_length_four_effective_spectra}
+    Every positive-length periodic operator is diagonal, and each diagonal
+    entry is a product of entries of
+    $W=\left(\begin{smallmatrix}1&1/2\\1/2&1\end{smallmatrix}\right)$, hence is
+    non-negative.  For each $L$, summing $h(\lambda)$ over the roots and their
+    multiplicities in
+    Theorem~\ref{thm:cpsv_example411_length_four_effective_spectra} gives the
+    displayed entropy.
+\end{proof}
+
+\begin{theorem}[Exact length-four mutual-information obstruction]
+    \label{thm:cpsv_example411_length_four_mutual_information_obstruction}
+    \lean{MPOTensor.CPSVExample411Entropy.mutualInfo_two_sub_one,
+        MPOTensor.CPSVExample411Entropy.mutualInfo_two_sub_one_pos,
+        MPOTensor.CPSVExample411Entropy.M_not_isSAL}
+    \leanok
+    \uses{def:is_sal,
+        thm:cpsv_example411_length_four_effective_entropies}
+    For $I_L=S_L+S_{4-L}-S_4$,
+    \begin{align}
+      I_2-I_1
+      &=\frac1{82}\log\!\left(
+        \frac{41^{82}5^{50}}{2^{48}13^{52}7^{112}}\right)>0.
+      \notag
+    \end{align}
+    Consequently, the effective binary tensor does not satisfy saturation of
+    the area law.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_example411_length_four_effective_entropies}
+    Since $I_2-I_1=2S_2-S_1-S_3$, expanding
+    $h(x)=-x\log x$ and using the logarithm rules gives the displayed identity.
+    The certified comparison
+    $41^{82}5^{50}>2^{48}13^{52}7^{112}$ makes its logarithm strictly positive.
+    Saturation would instead require $I_1=I_2$ on the four-site ring.
+\end{proof}
+
+\begin{corollary}[Ambient length-four saturation obstruction]
+    \label{cor:cpsv_example411_ambient_not_sal}
+    \lean{MPOTensor.CPSVExample411Entropy.ambientM_not_isSAL}
+    \leanok
+    \uses{def:cpsv_example411_ambient_support_inclusion,
+        thm:cpsv_example411_length_four_mutual_information_obstruction,
+        thm:mpdo_sal_physical_isometry_transport}
+    The isometric inclusion of the effective binary tensor into the
+    two-qubit one-site space does not satisfy saturation of the area law.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_sal_physical_isometry_transport,
+        thm:cpsv_example411_length_four_mutual_information_obstruction}
+    If the ambient tensor satisfied saturation, descent through the physical
+    isometry would imply saturation for the effective binary tensor, contrary
+    to the preceding theorem.
+\end{proof}
+
 % CPSV16 Example 4.12, lines 932--939.
 % Normalization gap: docs/paper-gaps/cpsv16_example_4_12_normalization.tex.
 \begin{definition}[Literal tensor in Example 4.12]

--- a/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
+++ b/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
@@ -19,8 +19,10 @@
 Examples~4.10 and~4.11 of Cirac--Perez-Garcia--Schuch--Verstraete
 \cite{Cirac2016MPDO_arXiv} are printed at lines~897--924 of
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex}. This note separates the literal
-source statements from two finite-ring corrections. All entropies below use
-base-two logarithms, as do the numerical values printed in Example~4.10.
+source statements from two finite-ring corrections. The explanatory
+calculations below use base-two logarithms, as do the numerical values printed
+in Example~4.10. The formal entropy definition uses natural logarithms; conversion
+to bits divides every entropy and mutual information by $\ln 2$.
 
 For a normalized four-spin state, let $S_L$ be the entropy of $L$ consecutive
 spins and set
@@ -266,14 +268,33 @@ multiplicities $2$, $12$, $56$, and $240$, respectively.
 These spectral formulas are finite-periodic project derivations, not statements
 attributed to CPSV16.
 
-\paragraph{Scope restriction (entropy consequences).}
-The ambient operator congruence, trace equality, and exact $N=4$ reduced-state
-spectra for Example~4.11 are complete.  This does not yet prove the entropy
-identities or connect the certified logarithmic ratio to saturation of the area
-law or zero correlation length.  Those entropy, SAL, and ZCL links remain open
-in \ghissue{6302}.  Example~4.10's tensor and final entropy links remain open in
-\ghissue{6301}.  The corresponding source-level status therefore remains not
-ready.
+\paragraph{Project derivation (entropy and saturation obstruction).}
+The module \doclink{TNLean/MPS/MPDO/CPSVExample411Entropy} first proves that the
+effective binary tensor is an MPDO: every positive-length periodic operator is
+diagonal with non-negative cycle weights.  It then evaluates the four block
+entropies directly from the established root multisets.  These formal entropies
+use natural logarithms.  In particular,
+\[
+  I_2-I_1
+  =\frac{1}{82}
+    \ln\!\left(\frac{41^{82}5^{50}}{2^{48}13^{52}7^{112}}\right)>0.
+\]
+The bit-valued formula earlier in this note is obtained by dividing by $\ln 2$.
+The strict inequality reuses
+\leanid{CPSVExamples410411Arithmetic.example411_log_ratio_pos}; neither the
+spectra nor the integer inequality is recomputed.  Therefore the effective
+binary tensor does not satisfy SAL.  Contraposition of SAL descent through the
+physical isometry gives the same conclusion for the ambient tensor
+\leanid{MPOTensor.CPSVExample411Ambient.ambientM}.
+
+\paragraph{Scope restriction (remaining consequences).}
+The ambient operator congruence, trace equality, exact $N=4$ reduced-state
+spectra, entropy identities, and finite-ring SAL obstruction for Example~4.11
+are complete.  No zero-correlation-length or thermodynamic-limit conclusion is
+made.  Those remaining links stay open in \ghissue{6302}.  Example~4.10's tensor
+and final entropy links remain open in \ghissue{6301}.  The printed Example~4.11
+SAL claim remains false for the literal finite periodic family; the certified
+result is a project-derived counterexample, not a theorem attributed to CPSV16.
 
 Example~4.12 is outside the entropy correction in this note. Its statement,
 dependencies, and separate normalization question are unchanged.


### PR DESCRIPTION
## Summary

- prove the effective binary Example 4.11 tensor is an MPDO from its nonnegative diagonal cycle weights
- derive the exact $N=4$ block entropies from the certified characteristic-polynomial root multisets
- prove the natural-log identity
  $$I_2-I_1=\frac1{82}\log\!\left(\frac{41^{82}5^{50}}{2^{48}13^{52}7^{112}}\right)>0$$
  by reusing the existing exact arithmetic endpoint
- conclude effective and ambient finite-ring non-SAL, transporting the latter through the established isometric support embedding
- synchronize the Blueprint and paper-gap note, keeping the bit conversion and source boundary explicit

These are project-derived finite-periodic consequences of the printed Example 4.11 weights. This PR makes no ZCL or thermodynamic-limit claim.

## Verification

- `lake env lean TNLean/MPS/MPDO/CPSVExample411Entropy.lean`
- `lake env lean TNLean/MPS/MPDO.lean`
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/CPSVExample411Entropy.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- generated import aggregate check
- proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`
- `git diff --check`

Closes #6355