### PR TITLE
feat(parent-hamiltonian): transfer blocked gap to divisible rings

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -44,6 +44,7 @@ import TNLean.Analysis.NeumannInverse
 import TNLean.Analysis.OperatorConvexity
 import TNLean.Analysis.OperatorNormConvergence
 import TNLean.Analysis.PosSemidefCommute
+import TNLean.Analysis.PositiveGapTransfer
 import TNLean.Analysis.ProbabilityEntropy
 import TNLean.Analysis.ProjectionGeometry
 import TNLean.Analysis.RelativeEntropyResolventIntegral

--- a/TNLean/Analysis/PositiveGapTransfer.lean
+++ b/TNLean/Analysis/PositiveGapTransfer.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.InnerProductSpace.Positive
+import Mathlib.Analysis.InnerProductSpace.Spectrum
+
+/-!
+# Transfer of gaps through positive-operator comparison
+
+This file packages the finite-dimensional spectral argument used to transfer a
+known gap from a positive operator to a larger positive operator with the same
+kernel.
+
+## Main results
+
+* `LinearMap.IsPositive.re_inner_ge_of_norm_gap` converts a norm gap on the
+  orthogonal complement of the kernel into a quadratic-form lower bound.
+* `LinearMap.IsPositive.norm_gap_of_le_of_ker_eq` transfers a norm gap through
+  Loewner domination when the kernels agree.
+-/
+
+open scoped InnerProductSpace
+
+namespace LinearMap.IsPositive
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+/-- For a positive operator, a norm lower bound on the orthogonal complement
+of its kernel implies the same quadratic-form lower bound. -/
+theorem re_inner_ge_of_norm_gap {P : E →ₗ[ℂ] E} (hP : P.IsPositive)
+    {γ : ℝ} (_hγ : 0 ≤ γ)
+    (hGap : ∀ v ∈ (LinearMap.ker P)ᗮ, γ * ‖v‖ ≤ ‖P v‖)
+    (v : E) (hv : v ∈ (LinearMap.ker P)ᗮ) :
+    γ * ‖v‖ ^ 2 ≤ (⟪P v, v⟫_ℂ).re := by
+  classical
+  let n := Module.finrank ℂ E
+  let b := hP.isSymmetric.eigenvectorBasis rfl
+  let μ := hP.isSymmetric.eigenvalues rfl
+  have hμ : ∀ i, 0 ≤ μ i := hP.nonneg_eigenvalues rfl
+  have hμGap : ∀ i, μ i = 0 ∨ γ ≤ μ i := by
+    intro i
+    by_cases hi : μ i = 0
+    · exact Or.inl hi
+    · right
+      have hbi : b i ∈ (LinearMap.ker P)ᗮ := by
+        intro w hw
+        rw [LinearMap.mem_ker] at hw
+        have horth := hP.isSymmetric w (b i)
+        rw [hw, inner_zero_left, hP.isSymmetric.apply_eigenvectorBasis rfl,
+          inner_smul_right] at horth
+        exact (mul_eq_zero.mp horth.symm).resolve_left (Complex.ofReal_ne_zero.mpr hi)
+      have h := hGap (b i) hbi
+      rw [hP.isSymmetric.apply_eigenvectorBasis rfl, norm_smul,
+        OrthonormalBasis.norm_eq_one] at h
+      have h' : γ ≤ |μ i| := by
+        simpa only [RCLike.norm_ofReal, mul_one] using h
+      rwa [abs_of_nonneg (hμ i)] at h'
+  have hv_sq : ‖v‖ ^ 2 = ∑ i, ‖(b.repr v) i‖ ^ 2 := by
+    rw [← b.repr.norm_map v, EuclideanSpace.norm_sq_eq]
+  have hPv : P v = ∑ i, ((μ i : ℂ) * (b.repr v) i) • b i := by
+    nth_rw 1 [← b.sum_repr v]
+    rw [map_sum]
+    apply Finset.sum_congr rfl
+    intro i hi
+    rw [map_smul, hP.isSymmetric.apply_eigenvectorBasis rfl, smul_smul]
+    congr 1
+    exact mul_comm _ _
+  have hquad : (⟪P v, v⟫_ℂ).re =
+      ∑ i, μ i * ‖(b.repr v) i‖ ^ 2 := by
+    rw [hPv, sum_inner, Complex.re_sum]
+    apply Finset.sum_congr rfl
+    intro i hi
+    rw [inner_smul_left, b.repr_apply_apply, map_mul, Complex.conj_ofReal]
+    rw [mul_assoc]
+    rw [← Complex.normSq_eq_conj_mul_self]
+    rw [Complex.sq_norm]
+    simp
+  rw [hv_sq, hquad, Finset.mul_sum]
+  apply Finset.sum_le_sum
+  intro i hi
+  rcases hμGap i with hzero | hbound
+  · have hcoeff : (b.repr v) i = 0 := by
+      rw [b.repr_apply_apply]
+      exact Submodule.inner_right_of_mem_orthogonal
+        (by
+          rw [LinearMap.mem_ker, hP.isSymmetric.apply_eigenvectorBasis rfl]
+          change (μ i : ℂ) • b i = 0
+          simp [hzero]) hv
+    simp [hcoeff]
+  · exact mul_le_mul_of_nonneg_right hbound (sq_nonneg _)
+
+/-- A positive operator `Q` inherits the norm gap of a positive operator `P`
+when `P ≤ Q` in Loewner order and their kernels agree. -/
+theorem norm_gap_of_le_of_ker_eq {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsPositive) (_hQ : Q.IsPositive) {γ : ℝ} (hγ : 0 ≤ γ)
+    (hPQ : P ≤ Q) (hker : LinearMap.ker P = LinearMap.ker Q)
+    (hGap : ∀ v ∈ (LinearMap.ker P)ᗮ, γ * ‖v‖ ≤ ‖P v‖) :
+    ∀ v ∈ (LinearMap.ker Q)ᗮ, γ * ‖v‖ ≤ ‖Q v‖ := by
+  intro v hv
+  have hvP : v ∈ (LinearMap.ker P)ᗮ := by simpa [hker] using hv
+  have henergyP := hP.re_inner_ge_of_norm_gap hγ hGap v hvP
+  have henergyPQ : (⟪P v, v⟫_ℂ).re ≤ (⟪Q v, v⟫_ℂ).re := by
+    have hnonneg := hPQ.re_inner_nonneg_left v
+    simpa [sub_apply, inner_sub_left] using hnonneg
+  have hinnerNorm : (⟪Q v, v⟫_ℂ).re ≤ ‖Q v‖ * ‖v‖ :=
+    @re_inner_le_norm ℂ E _ _ _ (Q v) v
+  by_cases hv0 : v = 0
+  · simp [hv0]
+  · have hvpos : 0 < ‖v‖ := norm_pos_iff.mpr hv0
+    have hmul : γ * ‖v‖ * ‖v‖ ≤ ‖Q v‖ * ‖v‖ := by
+      calc
+        γ * ‖v‖ * ‖v‖ = γ * ‖v‖ ^ 2 := by ring
+        _ ≤ (⟪P v, v⟫_ℂ).re := henergyP
+        _ ≤ (⟪Q v, v⟫_ℂ).re := henergyPQ
+        _ ≤ ‖Q v‖ * ‖v‖ := hinnerNorm
+    exact le_of_mul_le_mul_right hmul hvpos
+
+end LinearMap.IsPositive

--- a/TNLean/Analysis/PositiveGapTransfer.lean
+++ b/TNLean/Analysis/PositiveGapTransfer.lean
@@ -92,10 +92,10 @@ theorem re_inner_ge_of_norm_gap {P : E →ₗ[ℂ] E} (hP : P.IsPositive)
     simp [hcoeff]
   · exact mul_le_mul_of_nonneg_right hbound (sq_nonneg _)
 
-/-- A positive operator `Q` inherits the norm gap of a positive operator `P`
-when `P ≤ Q` in Loewner order and their kernels agree. -/
+/-- An operator \(Q\) inherits the norm gap of a positive operator \(P\)
+when \(P \leq Q\) in Loewner order and their kernels agree. -/
 theorem norm_gap_of_le_of_ker_eq {P Q : E →ₗ[ℂ] E}
-    (hP : P.IsPositive) (_hQ : Q.IsPositive) {γ : ℝ} (hγ : 0 ≤ γ)
+    (hP : P.IsPositive) {γ : ℝ} (hγ : 0 ≤ γ)
     (hPQ : P ≤ Q) (hker : LinearMap.ker P = LinearMap.ker Q)
     (hGap : ∀ v ∈ (LinearMap.ker P)ᗮ, γ * ‖v‖ ≤ ‖P v‖) :
     ∀ v ∈ (LinearMap.ker Q)ᗮ, γ * ‖v‖ ≤ ‖Q v‖ := by

--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -60,6 +60,8 @@ import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.AdjacentLocalTerms
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
+import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
+import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -32,7 +32,7 @@ all-vector norm-compression estimates for the excitation projections are also
 recorded as conditional sufficient hypotheses; they are not the source
 principal-angle estimate for the local ground spaces.
 
-The nine components are:
+The eleven components are:
 
 * `Martingale.AbstractCriterion` — abstract martingale criterion
   `FrustrationFree.spectralGap_of_martingale` (quadratic form implies norm bound);

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -6,6 +6,8 @@ Authors: TNLean contributors
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.AdjacentLocalTerms
 import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
+import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
+import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalGap
 import TNLean.MPS.ParentHamiltonian.Martingale.C3Threshold
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 import TNLean.MPS.ParentHamiltonian.Martingale.OpenChain
@@ -45,6 +47,10 @@ The nine components are:
   open-chain C3 defect threshold and its anticommutator consequence;
 * `Martingale.BlockedGap` — transport of that threshold to three blocked sites
   and the explicit range-two blocked parent-Hamiltonian gap;
+* `Martingale.BlockedOriginalComparison` — exact aligned local-term conjugacy
+  and quadratic-form domination by the original range-$2p$ Hamiltonian;
+* `Martingale.BlockedOriginalGap` — transfer of the gap constant $1/8$ to
+  original-site periodic chains of length divisible by the block length;
 * `Martingale.OverlapReduction` — reduction from overlapping-window commutation
   to all-pairs commutation using locality for disjoint windows;
 * `Martingale.Reduction` — martingale quadratic-form reductions from ordered

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalComparison.lean
@@ -10,13 +10,13 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 # Blocked and original parent interactions
 
 This file records the exact local conjugacy underlying comparison of a blocked
-range-two parent Hamiltonian with the range-`2 * p` parent Hamiltonian in
+range-two parent Hamiltonian with the range-\(2p\) parent Hamiltonian in
 original-site coordinates.
 
 ## Main results
 
 * `MPSTensor.parentInteractionES_blockTensor_conj` identifies the parent
-  interaction on `N` blocked sites with the original interaction on `N * p`
+  interaction on \(N\) blocked sites with the original interaction on \(Np\)
   sites under the canonical blocked-configuration isometry.
 
 ## References
@@ -186,7 +186,7 @@ private theorem replaceWindow_blockedConfigEquiv_aligned
     rw [hidx]
   · rw [dif_neg hqwin, dif_neg (not_congr hwindow |>.mpr hqwin)]
 
-/-- Restricting an original-site state to a whole aligned `2 * p` window and
+/-- Restricting an original-site state to a whole aligned \(2p\) window and
 then regrouping it into two blocks agrees with first regrouping the full chain
 and then restricting to the corresponding blocked two-site window. -/
 private theorem cyclicRestrictES_blockedConfigLinearIsometryEquiv_aligned
@@ -226,8 +226,8 @@ private theorem cyclicRestrictES_blockedConfigLinearIsometryEquiv_aligned
   simpa using replaceWindow_blockedConfigEquiv_aligned d p hp hN i
     ((blockedConfigEquiv d N p).symm ω) τ
 
-/-- The blocked range-two local term at site `i` is exactly conjugate to the
-original range-`2 * p` local term at the aligned start `p * i`. -/
+/-- The blocked range-two local term at site \(i\) is exactly conjugate to the
+original range-\(2p\) local term at the aligned start \(pi\). -/
 theorem localTermES_blockTensor_conj_aligned
     (A : MPSTensor d D) (p : ℕ) (hp : 0 < p) {N : ℕ} (hN : 2 ≤ N)
     (i : Fin N) :
@@ -273,7 +273,7 @@ theorem localTermES_blockTensor_conj_aligned
   apply (blockedConfigEquiv d 2 p).injective
   simpa using hextract
 
-/-- The range-`2 * p` original parent Hamiltonian dominates, as a quadratic
+/-- The range-\(2p\) original parent Hamiltonian dominates, as a quadratic
 form, the conjugated blocked range-two Hamiltonian obtained by retaining only
 block-aligned starts. This finite cyclic sparse-sum comparison is a TNLean
 reconstruction; Nachtergaele's rescaling argument is stated for compatible open

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalComparison.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BlockedGroundSpaceTransport
+import TNLean.MPS.ParentHamiltonian.Martingale.Transport
+
+/-!
+# Blocked and original parent interactions
+
+This file records the exact local conjugacy underlying comparison of a blocked
+range-two parent Hamiltonian with the range-`2 * p` parent Hamiltonian in
+original-site coordinates.
+
+## Main results
+
+* `MPSTensor.parentInteractionES_blockTensor_conj` identifies the parent
+  interaction on `N` blocked sites with the original interaction on `N * p`
+  sites under the canonical blocked-configuration isometry.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:2011.12127, lines 1985--1992.
+* B. Nachtergaele, arXiv:cond-mat/9410110, condition C3-prime and the rescaled
+  finite-volume sequence in the proof of Theorem 2.1(ii).
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The blocked local parent interaction is exactly the original parent
+interaction on the corresponding whole block, after computational-basis
+reindexing. No injectivity hypothesis is needed. -/
+theorem parentInteractionES_blockTensor_conj
+    (A : MPSTensor d D) (p N : ℕ) :
+    parentInteractionES A (N * p) =
+      (blockedConfigLinearIsometryEquiv d N p).toLinearEquiv.toLinearMap.comp
+        ((parentInteractionES (blockTensor A p) N).comp
+          (blockedConfigLinearIsometryEquiv d N p).symm.toLinearEquiv.toLinearMap) := by
+  let U := blockedConfigLinearIsometryEquiv d N p
+  apply LinearMap.ext
+  intro v
+  rw [parentInteractionES, parentInteractionES]
+  rw [Submodule.starProjection_orthogonal', Submodule.starProjection_orthogonal']
+  change v - (groundSpaceES A (N * p)).starProjection v =
+    U (U.symm v - (groundSpaceES (blockTensor A p) N).starProjection (U.symm v))
+  rw [starProjection_groundSpaceES_blockTensor_map_apply A p N v, map_sub,
+    U.apply_symm_apply]
+
+/-- The original-site start corresponding to a blocked site. -/
+private def alignedOriginalStart {N p : ℕ} (hp : 0 < p) (i : Fin N) : Fin (N * p) :=
+  ⟨i.val * p, by
+    have hi := i.isLt
+    nlinarith⟩
+
+private theorem extractWindow_blockedConfigEquiv_aligned
+    (d p : ℕ) (hp : 0 < p) {N : ℕ} (i : Fin N)
+    (σ : Cfg (blockPhysDim d p) N) :
+    extractWindow (2 * p) (alignedOriginalStart hp i) (blockedConfigEquiv d N p σ) =
+      blockedConfigEquiv d 2 p (extractWindow 2 i σ) := by
+  funext r
+  let k : Fin (N * p) :=
+    ⟨(i.val * p + r.val) % (N * p), Nat.mod_lt _ (Nat.mul_pos (Fin.pos i) hp)⟩
+  let q : Fin N :=
+    ⟨(i.val + (finProdFinEquiv.symm r).1.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  change decodeBlock d p (σ (finProdFinEquiv.symm k).1)
+      (finProdFinEquiv.symm k).2 =
+    decodeBlock d p (σ q) (finProdFinEquiv.symm r).2
+  have hfst : (finProdFinEquiv.symm k).1 = q := by
+    apply Fin.ext
+    simp only [finProdFinEquiv_symm_apply]
+    change ((i.val * p + r.val) % (N * p)) / p =
+      (i.val + r.val / p) % N
+    rw [Nat.mod_mul_left_div_self]
+    rw [show i.val * p + r.val = r.val + p * i.val by ac_rfl]
+    rw [Nat.add_mul_div_left r.val i.val hp]
+    congr 1
+    omega
+  have hsnd : (finProdFinEquiv.symm k).2 = (finProdFinEquiv.symm r).2 := by
+    apply Fin.ext
+    simp only [finProdFinEquiv_symm_apply]
+    change ((i.val * p + r.val) % (N * p)) % p = r.val % p
+    rw [Nat.mod_mul_left_mod, Nat.mul_add_mod_self_right]
+  rw [hfst, hsnd]
+
+private theorem replaceWindow_blockedConfigEquiv_aligned
+    (d p : ℕ) (hp : 0 < p) {N : ℕ} (hN : 2 ≤ N) (i : Fin N)
+    (σ : Cfg (blockPhysDim d p) N) (τ : Cfg (blockPhysDim d p) 2) :
+    replaceWindow (2 * p) (by nlinarith : 2 * p ≤ N * p) (alignedOriginalStart hp i)
+        (blockedConfigEquiv d N p σ) (blockedConfigEquiv d 2 p τ) =
+      blockedConfigEquiv d N p (replaceWindow 2 hN i σ τ) := by
+  funext k
+  change (if h : (k.val + N * p - i.val * p) % (N * p) < 2 * p then
+      decodeBlock d p
+        (τ (finProdFinEquiv.symm
+          (⟨(k.val + N * p - i.val * p) % (N * p), h⟩ : Fin (2 * p))).1)
+        (finProdFinEquiv.symm
+          (⟨(k.val + N * p - i.val * p) % (N * p), h⟩ : Fin (2 * p))).2
+    else decodeBlock d p (σ (finProdFinEquiv.symm k).1) (finProdFinEquiv.symm k).2) =
+    decodeBlock d p
+      ((if h : (((finProdFinEquiv.symm k).1.val + N - i.val) % N) < 2 then
+          τ ⟨((finProdFinEquiv.symm k).1.val + N - i.val) % N, h⟩
+        else σ (finProdFinEquiv.symm k).1))
+      (finProdFinEquiv.symm k).2
+  let q := (finProdFinEquiv.symm k).1
+  let r := (finProdFinEquiv.symm k).2
+  have hk : k.val = q.val * p + r.val := by
+    dsimp [q, r]
+    simp only [finProdFinEquiv_symm_apply]
+    exact (Nat.mod_add_div k.val p).symm.trans (by ac_rfl)
+  have hoff :
+      (k.val + N * p - i.val * p) % (N * p) =
+        ((q.val + N - i.val) % N) * p + r.val := by
+    rw [hk]
+    have hi : i.val ≤ q.val + N := by omega
+    have heq : q.val * p + r.val + N * p - i.val * p =
+        (q.val + N - i.val) * p + r.val := by
+      rw [show q.val * p + r.val + N * p = r.val + (q.val + N) * p by ring]
+      rw [Nat.add_sub_assoc (Nat.mul_le_mul_right p hi), Nat.sub_mul]
+      ac_rfl
+    rw [heq]
+    have hmod : ((q.val + N - i.val) * p + r.val) % (N * p) =
+        (((q.val + N - i.val) % N) * p + r.val) := by
+      rw [Nat.add_mod, Nat.mul_mod_mul_right]
+      have hr : r.val % (N * p) = r.val := Nat.mod_eq_of_lt (by nlinarith [r.isLt])
+      rw [hr]
+      have hlt : (q.val + N - i.val) % N * p + r.val < N * p := by
+        have hqmod := Nat.mod_lt (q.val + N - i.val) (Fin.pos i)
+        calc
+          (q.val + N - i.val) % N * p + r.val
+              < (q.val + N - i.val) % N * p + p :=
+            Nat.add_lt_add_left r.isLt _
+          _ ≤ N * p := by
+            rw [← Nat.succ_mul]
+            exact Nat.mul_le_mul_right p (Nat.succ_le_of_lt hqmod)
+      rw [Nat.mod_eq_of_lt hlt]
+    exact hmod
+  have hwindow :
+      (k.val + N * p - i.val * p) % (N * p) < 2 * p ↔
+        (q.val + N - i.val) % N < 2 := by
+    rw [hoff]
+    have hr := r.isLt
+    constructor <;> intro h
+    · by_contra hnot
+      have htwo : 2 ≤ (q.val + N - i.val) % N := by omega
+      have hmul := Nat.mul_le_mul_right p htwo
+      omega
+    · calc
+        (q.val + N - i.val) % N * p + r.val
+            < (q.val + N - i.val) % N * p + p := Nat.add_lt_add_left r.isLt _
+        _ ≤ 2 * p := by
+          rw [← Nat.succ_mul]
+          exact Nat.mul_le_mul_right p h
+  by_cases hqwin : (q.val + N - i.val) % N < 2
+  · rw [dif_pos hqwin, dif_pos (hwindow.mpr hqwin)]
+    change decodeBlock d p
+        (τ (finProdFinEquiv.symm
+          (⟨(k.val + N * p - i.val * p) % (N * p), hwindow.mpr hqwin⟩ :
+            Fin (2 * p))).1)
+        (finProdFinEquiv.symm
+          (⟨(k.val + N * p - i.val * p) % (N * p), hwindow.mpr hqwin⟩ :
+            Fin (2 * p))).2 =
+      decodeBlock d p (τ ⟨(q.val + N - i.val) % N, hqwin⟩) r
+    have hidx :
+        finProdFinEquiv.symm
+          (⟨(k.val + N * p - i.val * p) % (N * p), hwindow.mpr hqwin⟩ :
+            Fin (2 * p)) =
+          (⟨(q.val + N - i.val) % N, hqwin⟩, r) := by
+      apply Prod.ext
+      · apply Fin.ext
+        simp only [finProdFinEquiv_symm_apply]
+        change ((k.val + N * p - i.val * p) % (N * p)) / p =
+          (q.val + N - i.val) % N
+        rw [hoff]
+        rw [show ((q.val + N - i.val) % N * p + r.val) / p =
+            (q.val + N - i.val) % N by
+          rw [show (q.val + N - i.val) % N * p + r.val =
+            r.val + p * ((q.val + N - i.val) % N) by ac_rfl]
+          rw [Nat.add_mul_div_left r.val _ hp, Nat.div_eq_of_lt r.isLt, zero_add]]
+      · apply Fin.ext
+        simp only [finProdFinEquiv_symm_apply]
+        change ((k.val + N * p - i.val * p) % (N * p)) % p = r.val
+        rw [hoff, Nat.mul_add_mod_self_right, Nat.mod_eq_of_lt r.isLt]
+    rw [hidx]
+  · rw [dif_neg hqwin, dif_neg (not_congr hwindow |>.mpr hqwin)]
+
+/-- Restricting an original-site state to a whole aligned `2 * p` window and
+then regrouping it into two blocks agrees with first regrouping the full chain
+and then restricting to the corresponding blocked two-site window. -/
+private theorem cyclicRestrictES_blockedConfigLinearIsometryEquiv_aligned
+    (d p : ℕ) (hp : 0 < p) {N : ℕ} (hN : 2 ≤ N) (i : Fin N)
+    (ω : Cfg d (N * p)) (v : EuclideanSpace ℂ (Cfg d (N * p))) :
+    cyclicRestrictES (d := blockPhysDim d p) (Fin.pos i) 2 i
+        ((blockedConfigEquiv d N p).symm ω)
+        ((blockedConfigLinearIsometryEquiv d N p).symm v) =
+      (blockedConfigLinearIsometryEquiv d 2 p).symm
+        (cyclicRestrictES (d := d) (Nat.mul_pos (Fin.pos i) hp) (2 * p)
+          (alignedOriginalStart hp i) ω v) := by
+  ext τ
+  change ((WithLp.linearEquiv 2 ℂ _).symm
+      (cyclicRestrictₗ (Fin.pos i) 2 i ((blockedConfigEquiv d N p).symm ω)
+        ((WithLp.linearEquiv 2 ℂ _)
+          ((blockedConfigLinearIsometryEquiv d N p).symm v)))) τ = _
+  simp only [WithLp.linearEquiv_symm_apply, WithLp.coe_linearEquiv]
+  simp only [blockedConfigLinearIsometryEquiv_symm_apply_apply]
+  change (WithLp.toLp 2
+      (cyclicRestrictₗ (Fin.pos i) 2 i ((blockedConfigEquiv d N p).symm ω)
+        ((blockedConfigLinearIsometryEquiv d N p).symm v).ofLp)).ofLp τ = _
+  rw [WithLp.ofLp_toLp]
+  rw [cyclicRestrictₗ_apply]
+  rw [blockedConfigLinearIsometryEquiv_symm_apply_apply]
+  rw [cyclicRestrictES]
+  simp only [LinearMap.withLpMap, LinearMap.comp_apply]
+  change v (blockedConfigEquiv d N p
+      (cyclicCfg (Fin.pos i) 2 i τ ((blockedConfigEquiv d N p).symm ω))) =
+    v (cyclicCfg (Nat.mul_pos (Fin.pos i) hp) (2 * p) (alignedOriginalStart hp i)
+      (blockedConfigEquiv d 2 p τ) ω)
+  apply congrArg v
+  change blockedConfigEquiv d N p
+      (replaceWindow 2 hN i ((blockedConfigEquiv d N p).symm ω) τ) =
+    replaceWindow (2 * p) (by nlinarith) (alignedOriginalStart hp i) ω
+      (blockedConfigEquiv d 2 p τ)
+  symm
+  simpa using replaceWindow_blockedConfigEquiv_aligned d p hp hN i
+    ((blockedConfigEquiv d N p).symm ω) τ
+
+/-- The blocked range-two local term at site `i` is exactly conjugate to the
+original range-`2 * p` local term at the aligned start `p * i`. -/
+theorem localTermES_blockTensor_conj_aligned
+    (A : MPSTensor d D) (p : ℕ) (hp : 0 < p) {N : ℕ} (hN : 2 ≤ N)
+    (i : Fin N) :
+    localTermES A (2 * p) (alignedOriginalStart hp i) =
+      (blockedConfigLinearIsometryEquiv d N p).toLinearEquiv.toLinearMap.comp
+        ((localTermES (blockTensor A p) 2 i).comp
+          (blockedConfigLinearIsometryEquiv d N p).symm.toLinearEquiv.toLinearMap) := by
+  apply LinearMap.ext
+  intro v
+  ext ω
+  rw [localTermES_apply A (2 * p) (alignedOriginalStart hp i)
+    (by nlinarith : 2 * p ≤ N * p) v ω]
+  change parentInteractionES A (2 * p)
+      (cyclicRestrictES (d := d) (Nat.mul_pos (Fin.pos i) hp) (2 * p)
+        (alignedOriginalStart hp i) ω v)
+      (extractWindow (2 * p) (alignedOriginalStart hp i) ω) = _
+  simp only [LinearMap.comp_apply]
+  change _ = localTermES (blockTensor A p) 2 i
+    ((blockedConfigLinearIsometryEquiv d N p).symm v)
+      ((blockedConfigEquiv d N p).symm ω)
+  rw [localTermES_apply (blockTensor A p) 2 i hN
+    ((blockedConfigLinearIsometryEquiv d N p).symm v)
+    ((blockedConfigEquiv d N p).symm ω)]
+  have hrestrict := cyclicRestrictES_blockedConfigLinearIsometryEquiv_aligned
+    d p hp hN i ω v
+  have hinteraction := LinearMap.congr_fun
+    (parentInteractionES_blockTensor_conj A p 2)
+    (cyclicRestrictES (d := d) (Nat.mul_pos (Fin.pos i) hp) (2 * p)
+      (alignedOriginalStart hp i) ω v)
+  rw [hrestrict]
+  rw [hinteraction]
+  simp only [LinearMap.comp_apply]
+  let y := parentInteractionES (blockTensor A p) 2
+    ((blockedConfigLinearIsometryEquiv d 2 p).symm
+      (cyclicRestrictES (d := d) (Nat.mul_pos (Fin.pos i) hp) (2 * p)
+        (alignedOriginalStart hp i) ω v))
+  change y ((blockedConfigEquiv d 2 p).symm
+      (extractWindow (2 * p) (alignedOriginalStart hp i) ω)) =
+    y (extractWindow 2 i ((blockedConfigEquiv d N p).symm ω))
+  apply congrArg y
+  have hextract := extractWindow_blockedConfigEquiv_aligned d p hp i
+    ((blockedConfigEquiv d N p).symm ω)
+  apply (blockedConfigEquiv d 2 p).injective
+  simpa using hextract
+
+/-- The range-`2 * p` original parent Hamiltonian dominates, as a quadratic
+form, the conjugated blocked range-two Hamiltonian obtained by retaining only
+block-aligned starts. This finite cyclic sparse-sum comparison is a TNLean
+reconstruction; Nachtergaele's rescaling argument is stated for compatible open
+intervals. -/
+theorem blockTensor_parentHamiltonianES_conj_le
+    (A : MPSTensor d D) (p : ℕ) (hp : 0 < p) {N : ℕ} (hN : 2 ≤ N) :
+    (blockedConfigLinearIsometryEquiv d N p).toLinearEquiv.toLinearMap.comp
+        ((parentHamiltonianES (blockTensor A p) 2 N).comp
+          (blockedConfigLinearIsometryEquiv d N p).symm.toLinearEquiv.toLinearMap) ≤
+      parentHamiltonianES A (2 * p) (N * p) := by
+  rw [LinearMap.le_def]
+  have hFull : parentHamiltonianES A (2 * p) (N * p) =
+      ∑ j : Fin (N * p), localTermES A (2 * p) j :=
+    parentHamiltonianES_eq_sum_localTermES A (2 * p) (N * p)
+  have hSparse :
+      (blockedConfigLinearIsometryEquiv d N p).toLinearEquiv.toLinearMap.comp
+          ((parentHamiltonianES (blockTensor A p) 2 N).comp
+            (blockedConfigLinearIsometryEquiv d N p).symm.toLinearEquiv.toLinearMap) =
+        ∑ i : Fin N, localTermES A (2 * p) (alignedOriginalStart hp i) := by
+    rw [parentHamiltonianES_eq_sum_localTermES]
+    apply LinearMap.ext
+    intro v
+    simp only [LinearMap.comp_apply, LinearMap.sum_apply, map_sum]
+    apply Finset.sum_congr rfl
+    intro i hi
+    exact LinearMap.congr_fun (localTermES_blockTensor_conj_aligned A p hp hN i) v |>.symm
+  rw [hFull, hSparse]
+  let aligned : Finset (Fin (N * p)) := Finset.univ.map
+    ⟨alignedOriginalStart hp, fun i j hij => by
+      apply Fin.ext
+      have hij' := congrArg Fin.val hij
+      simp only [alignedOriginalStart] at hij'
+      exact Nat.eq_of_mul_eq_mul_right hp hij'⟩
+  have hAlignedSum :
+      ∑ i : Fin N, localTermES A (2 * p) (alignedOriginalStart hp i) =
+        ∑ j ∈ aligned, localTermES A (2 * p) j := by
+    dsimp [aligned]
+    rw [Finset.sum_map]
+    rfl
+  rw [hAlignedSum]
+  have hsplit := Finset.sum_sdiff (f := fun j : Fin (N * p) => localTermES A (2 * p) j)
+    (Finset.subset_univ aligned)
+  rw [← hsplit]
+  abel_nf
+  exact LinearMap.isPositive_sum _ fun j _ => localTermES_isPositive A (2 * p) j
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalGap.lean
@@ -13,8 +13,8 @@ import TNLean.MPS.ParentHamiltonian.UniqueGroundState
 # Spectral gap in original-site units after blocking
 
 This file transfers the proved range-two gap of a blocked primitive MPS tensor
-to the canonical range-`2 * p` parent Hamiltonian of the original tensor on
-periodic chains whose lengths are multiples of `p`.
+to the canonical range-\(2p\) parent Hamiltonian of the original tensor on
+periodic chains whose lengths are multiples of \(p\).
 
 The finite cyclic sparse-sum comparison is a TNLean reconstruction. The cited
 Nachtergaele source uses a rescaled sequence of compatible open intervals; it
@@ -23,8 +23,8 @@ does not state the finite periodic comparison below.
 ## Main result
 
 * `MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul`
-  gives the original-site interaction range `2 * p` and gap `1 / 8` on lengths
-  `N * p`, for `N ≥ 4`.
+  gives the original-site interaction range \(2p\) and gap \(1/8\) on lengths
+  \(Np\), for \(N \geq 4\).
 
 ## References
 
@@ -109,8 +109,8 @@ private theorem parentHamiltonianES_blockTensor_conj_ker_eq
       simp only [map_smul]
       rw [hmpv]
 
-/-- A primitive tensor has an original-site range-`2 * p` parent Hamiltonian
-with gap `1 / 8` on every periodic chain of length `N * p`, `N ≥ 4`.
+/-- A primitive tensor has an original-site range-\(2p\) parent Hamiltonian
+with gap \(1/8\) on every periodic chain of length \(Np\), \(N \geq 4\).
 
 **Scope restriction (divisible periodic lengths):** the conclusion is only for
 chain lengths divisible by the selected block length. The remainder-length
@@ -150,7 +150,6 @@ theorem IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul
       change 0 ≤ (⟪U (parentHamiltonianES (blockTensor A p) 2 N (U.symm x)), x⟫_ℂ).re
       rw [hinner]
       exact (parentHamiltonianES_isPositive (blockTensor A p) 2 N).re_inner_nonneg_left _
-  have hQpos : Q.IsPositive := parentHamiltonianES_isPositive A (2 * p) (N * p)
   have hPQ : P ≤ Q := blockTensor_parentHamiltonianES_conj_le A p hp (by omega)
   have hker : LinearMap.ker P = LinearMap.ker Q :=
     parentHamiltonianES_blockTensor_conj_ker_eq A p hp hInj hN
@@ -173,6 +172,6 @@ theorem IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul
     simpa [P, z] using hGap N hN z hz
   have hvker : v ∈ (LinearMap.ker Q)ᗮ := by
     simpa [Q, parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES] using hv
-  exact hPpos.norm_gap_of_le_of_ker_eq hQpos (by norm_num) hPQ hker hGapP v hvker
+  exact hPpos.norm_gap_of_le_of_ker_eq (by norm_num) hPQ hker hGapP v hvker
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalGap.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.PositiveGapTransfer
+import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.Martingale.BlockedGap
+import TNLean.MPS.ParentHamiltonian.Martingale.BlockedOriginalComparison
+import TNLean.MPS.ParentHamiltonian.UniqueGroundState
+
+/-!
+# Spectral gap in original-site units after blocking
+
+This file transfers the proved range-two gap of a blocked primitive MPS tensor
+to the canonical range-`2 * p` parent Hamiltonian of the original tensor on
+periodic chains whose lengths are multiples of `p`.
+
+The finite cyclic sparse-sum comparison is a TNLean reconstruction. The cited
+Nachtergaele source uses a rescaled sequence of compatible open intervals; it
+does not state the finite periodic comparison below.
+
+## Main result
+
+* `MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul`
+  gives the original-site interaction range `2 * p` and gap `1 / 8` on lengths
+  `N * p`, for `N ≥ 4`.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:2011.12127, Section IV.C.
+* B. Nachtergaele, arXiv:cond-mat/9410110, equations (3.12)--(3.16) and the
+  rescaled-volume argument in Theorem 2.1(ii).
+-/
+
+open scoped ComplexOrder InnerProductSpace
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+private theorem parentHamiltonianES_blockTensor_conj_ker_eq
+    [NeZero D] (A : MPSTensor d D) (p : ℕ) (hp : 0 < p)
+    (hInj : IsNBlkInjective A p) {N : ℕ} (hN : 4 ≤ N) :
+    LinearMap.ker
+        ((blockedConfigLinearIsometryEquiv d N p).toLinearEquiv.toLinearMap.comp
+          ((parentHamiltonianES (blockTensor A p) 2 N).comp
+            (blockedConfigLinearIsometryEquiv d N p).symm.toLinearEquiv.toLinearMap)) =
+      LinearMap.ker (parentHamiltonianES A (2 * p) (N * p)) := by
+  let U := blockedConfigLinearIsometryEquiv d N p
+  have hB : IsInjective (blockTensor A p) :=
+    (isNBlkInjective_iff_blockTensor_isInjective A p).mp hInj
+  have hNpos : 0 < N := by omega
+  have hNp : 0 < N * p := Nat.mul_pos hNpos hp
+  have hBchain := chainGroundSpace_eq_mpvSubmodule hB (by omega) (by omega)
+    (by omega : 2 ≤ N)
+  have hAchain := chainGroundSpace_eq_mpvSubmodule_normal
+    (⟨p, hp, hInj⟩ : IsNormal A) hInj hp (by nlinarith) (by nlinarith)
+      (by nlinarith : 2 * p ≤ N * p) (by nlinarith)
+  let eB := WithLp.linearEquiv 2 ℂ (NSiteSpace (blockPhysDim d p) N)
+  let eA := WithLp.linearEquiv 2 ℂ (NSiteSpace d (N * p))
+  have hmpv : U (eB.symm (mpv (blockTensor A p))) = eA.symm (mpv A) := by
+    ext σ
+    change mpv (blockTensor A p) ((blockedConfigEquiv d N p).symm σ) = mpv A σ
+    rw [mpv_eq_groundSpaceMap_one, mpv_eq_groundSpaceMap_one]
+    exact groundSpaceMap_blockTensor_blockedConfigEquiv A p N 1 σ
+  ext v
+  rw [LinearMap.mem_ker, LinearMap.comp_apply, LinearMap.comp_apply]
+  have hUzero : U ((parentHamiltonianES (blockTensor A p) 2 N) (U.symm v)) = 0 ↔
+      parentHamiltonianES (blockTensor A p) 2 N (U.symm v) = 0 := by
+    exact U.injective.eq_iff' (map_zero U)
+  change U (parentHamiltonianES (blockTensor A p) 2 N (U.symm v)) = 0 ↔ _
+  rw [hUzero]
+  rw [← mem_parentHamiltonianGroundSpaceES_iff]
+  change U.symm v ∈ parentHamiltonianGroundSpaceES (blockTensor A p) 2 N ↔
+    v ∈ LinearMap.ker (parentHamiltonianES A (2 * p) (N * p))
+  rw [← parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES]
+  rw [parentHamiltonianGroundSpaceES_eq_chainGroundSpaceES _ hNpos (by omega : 2 ≤ N)]
+  rw [parentHamiltonianGroundSpaceES_eq_chainGroundSpaceES _ hNp
+    (by nlinarith : 2 * p ≤ N * p)]
+  simp only [chainGroundSpaceES, hBchain, hAchain, Submodule.mem_map]
+  constructor
+  · rintro ⟨w, hw, hwv⟩
+    rw [mpvSubmodule, Submodule.mem_span_singleton] at hw
+    obtain ⟨c, rfl⟩ := hw
+    refine ⟨c • (mpv A : NSiteSpace d (N * p)), ?_, ?_⟩
+    · rw [mpvSubmodule, Submodule.mem_span_singleton]
+      exact ⟨c, rfl⟩
+    · calc
+        eA.symm (c • (mpv A : NSiteSpace d (N * p))) =
+            c • eA.symm (mpv A) := by simp
+        _ = c • U (eB.symm (mpv (blockTensor A p))) := by rw [hmpv]
+        _ = U (eB.symm (c • (mpv (blockTensor A p) :
+            NSiteSpace (blockPhysDim d p) N))) := by simp
+        _ = v := by
+          change U ((WithLp.linearEquiv 2 ℂ (NSiteSpace (blockPhysDim d p) N)).symm
+            (c • (mpv (blockTensor A p) : NSiteSpace (blockPhysDim d p) N))) = v
+          exact congrArg U hwv |>.trans (U.apply_symm_apply v)
+  · rintro ⟨w, hw, hwv⟩
+    rw [mpvSubmodule, Submodule.mem_span_singleton] at hw
+    obtain ⟨c, rfl⟩ := hw
+    refine ⟨c • (mpv (blockTensor A p) : NSiteSpace (blockPhysDim d p) N), ?_, ?_⟩
+    · rw [mpvSubmodule, Submodule.mem_span_singleton]
+      exact ⟨c, rfl⟩
+    · apply U.injective
+      rw [U.apply_symm_apply, ← hwv]
+      change U (eB.symm (c • (mpv (blockTensor A p) :
+        NSiteSpace (blockPhysDim d p) N))) = eA.symm (c • (mpv A : NSiteSpace d (N * p)))
+      simp only [map_smul]
+      rw [hmpv]
+
+/-- A primitive tensor has an original-site range-`2 * p` parent Hamiltonian
+with gap `1 / 8` on every periodic chain of length `N * p`, `N ≥ 4`.
+
+**Scope restriction (divisible periodic lengths):** the conclusion is only for
+chain lengths divisible by the selected block length. The remainder-length
+extension is not proved here. See
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul
+    [NeZero d] [NeZero D] {A : MPSTensor d D} {ρ : Matrix (Fin D) (Fin D) ℂ}
+    (hP : IsPrimitiveMPS A ρ) (hρ : Matrix.PosDef ρ) :
+    ∃ p : ℕ, 0 < p ∧ IsNBlkInjective A p ∧
+      ∀ (N : ℕ) (_hN : 4 ≤ N) (v : EuclideanSpace ℂ (Cfg d (N * p))),
+        v ∈ (parentHamiltonianGroundSpaceES A (2 * p) (N * p))ᗮ →
+          (1 / 8 : ℝ) * ‖v‖ ≤ ‖parentHamiltonianES A (2 * p) (N * p) v‖ := by
+  obtain ⟨p, hp, hInj, hGap⟩ := hP.exists_blockTensor_parentHamiltonianES_gap_eighth hρ
+  refine ⟨p, hp, hInj, ?_⟩
+  intro N hN v hv
+  let U := blockedConfigLinearIsometryEquiv d N p
+  let P := U.toLinearEquiv.toLinearMap.comp
+    ((parentHamiltonianES (blockTensor A p) 2 N).comp U.symm.toLinearEquiv.toLinearMap)
+  let Q := parentHamiltonianES A (2 * p) (N * p)
+  have hPpos : P.IsPositive := by
+    constructor
+    · intro x y
+      simp only [P, LinearMap.comp_apply]
+      calc
+        ⟪U (parentHamiltonianES (blockTensor A p) 2 N (U.symm x)), y⟫_ℂ =
+            ⟪parentHamiltonianES (blockTensor A p) 2 N (U.symm x), U.symm y⟫_ℂ := by
+          rw [← U.inner_map_map, U.apply_symm_apply]
+        _ = ⟪U.symm x, parentHamiltonianES (blockTensor A p) 2 N (U.symm y)⟫_ℂ :=
+          (parentHamiltonianES_isPositive (blockTensor A p) 2 N).isSymmetric _ _
+        _ = ⟪x, U (parentHamiltonianES (blockTensor A p) 2 N (U.symm y))⟫_ℂ := by
+          rw [← U.inner_map_map, U.apply_symm_apply]
+    · intro x
+      simp only [P, LinearMap.comp_apply]
+      have hinner := U.inner_map_map
+        (parentHamiltonianES (blockTensor A p) 2 N (U.symm x)) (U.symm x)
+      rw [U.apply_symm_apply] at hinner
+      change 0 ≤ (⟪U (parentHamiltonianES (blockTensor A p) 2 N (U.symm x)), x⟫_ℂ).re
+      rw [hinner]
+      exact (parentHamiltonianES_isPositive (blockTensor A p) 2 N).re_inner_nonneg_left _
+  have hQpos : Q.IsPositive := parentHamiltonianES_isPositive A (2 * p) (N * p)
+  have hPQ : P ≤ Q := blockTensor_parentHamiltonianES_conj_le A p hp (by omega)
+  have hker : LinearMap.ker P = LinearMap.ker Q :=
+    parentHamiltonianES_blockTensor_conj_ker_eq A p hp hInj hN
+  have hGapP : ∀ w ∈ (LinearMap.ker P)ᗮ, (1 / 8 : ℝ) * ‖w‖ ≤ ‖P w‖ := by
+    intro w hw
+    let z := U.symm w
+    have hz : z ∈
+        (parentHamiltonianGroundSpaceES (blockTensor A p) 2 N)ᗮ := by
+      rw [parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES]
+      intro x hx
+      have hUx : U x ∈ LinearMap.ker P := by
+        rw [LinearMap.mem_ker]
+        change U (parentHamiltonianES (blockTensor A p) 2 N (U.symm (U x))) = 0
+        rw [U.symm_apply_apply, hx, map_zero]
+      have horth := hw (U x) hUx
+      change ⟪x, U.symm w⟫_ℂ = 0
+      have hinner := U.inner_map_map x (U.symm w)
+      rw [U.apply_symm_apply] at hinner
+      exact hinner.symm.trans horth
+    simpa [P, z] using hGap N hN z hz
+  have hvker : v ∈ (LinearMap.ker Q)ᗮ := by
+    simpa [Q, parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES] using hv
+  exact hPpos.norm_gap_of_le_of_ker_eq hQpos (by norm_num) hPQ hker hGapP v hvker
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -378,7 +378,8 @@ private theorem cyclicRestrictES_adjoint_apply {N : ℕ} (hN : 0 < N) {L : ℕ}
       _ = if SameOutsideWindow (L := L) i σ τ then v (extractWindow L i σ) else 0 := by
             simp [hστ]
 
-@[simp] private theorem localTermES_apply {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N)
+/-- Evaluate a transported local term through the cyclic restriction to its window. -/
+@[simp] theorem localTermES_apply {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N)
     (hLN : L ≤ N) (v : EuclideanSpace ℂ (Cfg d N)) (σ : Cfg d N) :
     localTermES A L i v σ =
       parentInteractionES A L ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2275,11 +2275,37 @@ norm estimate is derived here.
     $1-2(7/16)=1/8$.
 \end{proof}
 
+\begin{lemma}[Positive gap transfer under Loewner domination]
+    \label{lem:positive_gap_transfer_loewner}
+    \lean{LinearMap.IsPositive.re_inner_ge_of_norm_gap,
+        LinearMap.IsPositive.norm_gap_of_le_of_ker_eq}
+    \leanok
+    Let $P$ and $Q$ be finite-dimensional complex endomorphisms.  If $P$ is
+    positive, $P\leq Q$, and $\ker P=\ker Q$, then every norm-gap lower bound
+    for $P$ on $(\ker P)^\perp$ is also a norm-gap lower bound for $Q$ on
+    $(\ker Q)^\perp$.
+\end{lemma}
+
+\begin{lemma}[Blocked local terms and the aligned sparse sum]
+    \label{lem:blocked_original_aligned_sparse_sum}
+    \lean{MPSTensor.localTermES_apply,
+        MPSTensor.parentInteractionES_blockTensor_conj,
+        MPSTensor.localTermES_blockTensor_conj_aligned,
+        MPSTensor.blockTensor_parentHamiltonianES_conj_le}
+    \leanok
+    Under the canonical configuration isometry, the range-two local term of
+    $\operatorname{block}_p(A)$ at blocked site $i$ is the range-$2p$ local
+    term of $A$ at original start $pi$.  Consequently the conjugated blocked
+    Hamiltonian is the aligned sparse sum and is bounded above, in Loewner
+    order, by the full range-$2p$ parent Hamiltonian of $A$.
+\end{lemma}
+
 \begin{theorem}[Original-site gap on block-divisible periodic chains]
     \label{thm:martingale_mps_original_site_multiples}
     \lean{MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul}
     \leanok
-    \uses{thm:martingale_mps}
+    \uses{thm:martingale_mps, lem:positive_gap_transfer_loewner,
+        lem:blocked_original_aligned_sparse_sum}
     Under the hypotheses of Theorem~\ref{thm:martingale_mps}, one can choose
     the same $p>0$ so that the original tensor has interaction range $2p$ and,
     for every $N\ge4$ and every
@@ -2293,7 +2319,8 @@ norm estimate is derived here.
 
 \begin{proof}
     \leanok
-    \uses{thm:martingale_mps}
+    \uses{thm:martingale_mps, lem:positive_gap_transfer_loewner,
+        lem:blocked_original_aligned_sparse_sum}
     The canonical configuration isometry identifies each blocked range-two
     term with the original range-$2p$ term beginning at the corresponding
     block boundary.  Thus the conjugated blocked Hamiltonian is the sum over

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2275,12 +2275,41 @@ norm estimate is derived here.
     $1-2(7/16)=1/8$.
 \end{proof}
 
+\begin{theorem}[Original-site gap on block-divisible periodic chains]
+    \label{thm:martingale_mps_original_site_multiples}
+    \lean{MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul}
+    \leanok
+    \uses{thm:martingale_mps}
+    Under the hypotheses of Theorem~\ref{thm:martingale_mps}, one can choose
+    the same $p>0$ so that the original tensor has interaction range $2p$ and,
+    for every $N\ge4$ and every
+    $v\in(\ker H_{Np,2p}(A))^\perp$,
+    \begin{align}
+        \frac18\lVert v\rVert
+        &\leq \lVert H_{Np,2p}(A)v\rVert.
+    \end{align}
+    This statement concerns only periodic chain lengths divisible by $p$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:martingale_mps}
+    The canonical configuration isometry identifies each blocked range-two
+    term with the original range-$2p$ term beginning at the corresponding
+    block boundary.  Thus the conjugated blocked Hamiltonian is the sum over
+    block-aligned starts.  The remaining original local terms are positive, so
+    the full Hamiltonian dominates this sparse sum as a quadratic form.  Block
+    injectivity identifies both kernels with the same periodic MPS line under
+    the isometry.  The positive-operator comparison therefore transfers the
+    constant $1/8$ without loss.
+\end{proof}
+
 \begin{theorem}[Uniform gap for normal MPS parent Hamiltonians]
     \label{thm:normal_mps_parent_hamiltonian_gap}
     \notready
     \discussion{5926}
-    \uses{thm:martingale_mps, thm:anticommutator_gap_bound,
-        thm:parent_hamiltonian_gapped}
+    \uses{thm:martingale_mps_original_site_multiples,
+        thm:anticommutator_gap_bound, thm:parent_hamiltonian_gapped}
     Let $A$ be a normal tensor.  There exist an interaction range $L>1$ and
     a constant $\gamma>0$ such that, for every $N\ge2L$ and every
     $v\in(\ker H_{N,L}(A))^\perp$,
@@ -2289,22 +2318,21 @@ norm estimate is derived here.
         &\le \lVert H_{N,L}(A)v\rVert.
         \notag
     \end{align}
-    Theorem~\ref{thm:martingale_mps} proves this estimate only for the
-    range-two Hamiltonian of $B=\operatorname{block}_p(A)$ on $N$ blocked sites.
-    It does not identify that operator, its kernel, or its energy scale with
-    the range-$L$ Hamiltonian of $A$ on the original-site chain.  The remaining
-    step is precisely this blocked-to-original interaction comparison.
+    Theorem~\ref{thm:martingale_mps_original_site_multiples} proves the estimate
+    with $L=2p$ when the periodic chain length is divisible by $p$.  The
+    unrestricted statement still requires a remainder-length comparison for
+    the finitely many congruence classes modulo $p$.
 \end{theorem}
 
 \begin{proof}
     \notready
     \discussion{5926}
-    \uses{thm:martingale_mps, thm:anticommutator_gap_bound,
-        thm:parent_hamiltonian_gapped}
-    Apply Theorem~\ref{thm:martingale_mps} to the blocked tensor.  Then compare
-    its range-two local projections and ground-space complement with a fixed-range
-    parent interaction for $A$ in original-site units, retaining a uniform positive
-    lower bound under that comparison.
+    \uses{thm:martingale_mps_original_site_multiples,
+        thm:anticommutator_gap_bound, thm:parent_hamiltonian_gapped}
+    The divisible-length case is
+    Theorem~\ref{thm:martingale_mps_original_site_multiples}.  It remains to
+    control chains of length $Np+r$, $0<r<p$, by a boundary/remainder argument
+    that preserves the ground-space complement and a uniform positive constant.
 \end{proof}
 
 \begin{theorem}[Gap bound from cyclic overlap compression]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -1257,9 +1257,27 @@ for a suitable blocked tensor are proved.  All lengths before blocking are
 measured in sites of the input tensor, while the final chain length counts
 blocked sites.  These bounds come from the formal inverse-Gram reconstruction
 and are not attributed to FNW.  The optimized FNW numerator and its source
-constants remain open.  Issue~\#5926 concerns the separate comparison between
-this blocked range-two Hamiltonian and an interaction for the original tensor;
-no additional public existential theorem is asserted here.
+constants remain open.
+
+The blocked-to-original comparison is now proved on periodic lengths divisible
+by the chosen block length.  Under the canonical configuration isometry, every
+blocked range-two term is exactly the original range-$2p$ term beginning at a
+block boundary.  The conjugated blocked Hamiltonian is therefore the sparse sum
+over aligned starts, and the omitted original local projections give a positive
+quadratic-form remainder.  Block injectivity identifies the blocked and
+original kernels with the same periodic MPS line under this isometry.  Hence
+\leanid{MPSTensor.IsPrimitiveMPS.exists_parentHamiltonianES_gap_eighth_mul}
+retains the gap constant $1/8$ for $H_{Np,2p}(A)$, $N\ge4$.
+
+This finite cyclic sparse-sum argument is a TNLean reconstruction.  Nachtergaele,
+\cite[equations~(3.12)--(3.16)]{Nachtergaele1996Spectral}, formulates compatible
+open intervals and the proof of Theorem~2.1(ii) uses the rescaled sequence
+$\widetilde\Lambda_n=\Lambda_{ln}$; the source does not state the finite periodic
+operator comparison above.  The precise remaining leaf for the unrestricted
+normal-MPS theorem is the remainder-length case: chains $Np+r$ with
+$0<r<p$.  It requires a boundary/remainder comparison preserving the common
+ground-space complement and a uniform positive constant.  No all-length claim
+is made here.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary
- identify each blocked range-two local term with the aligned original range-`2p` term
- prove the conjugated blocked Hamiltonian is Loewner-dominated by the full original parent Hamiltonian
- transfer the blocked `1/8` gap through equal kernels to original periodic chains of length `N*p`
- synchronize Chapter 13 and the martingale paper-gap inventory

## Source scope
The finite cyclic sparse-sum comparison is a TNLean reconstruction. Nachtergaele, `References/cond-mat_9410110/main.tex`, equations (3.12)--(3.16), treats compatible open intervals and a rescaled sequence; this PR does not attribute the periodic comparison to the source.

The result is intentionally restricted to block-divisible chain lengths. The nonzero remainder classes are tracked separately in #6374, so this PR does not close #5926.

## Validation
- `lake env lean TNLean/Analysis/PositiveGapTransfer.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalComparison.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/BlockedOriginalGap.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `git diff --check`
- proof-integrity grep over changed Lean files

Refs #5926
Refs #6374