### PR TITLE
feat(parent-hamiltonian): transport blocked aligned sum

### DIFF
--- a/TNLean/MPS/ParentHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.MPS.ParentHamiltonian
 
+import TNLean.MPS.ParentHamiltonian.AlignedBlockedHamiltonian
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChainBoundary

--- a/TNLean/MPS/ParentHamiltonian/AlignedBlockedHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/AlignedBlockedHamiltonian.lean
@@ -1,0 +1,308 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BlockedGroundSpaceTransport
+import TNLean.MPS.ParentHamiltonian.Martingale.Transport
+
+/-!
+# Block-aligned parent Hamiltonians
+
+Physical blocking by `p` sends the range-two interaction of the blocked tensor to the
+range-`2 * p` interaction of the original tensor at starts divisible by `p`.  This file
+records that local conjugacy, identifies the transported blocked Hamiltonian with the sparse
+sum over those starts, and compares that sum with the full original parent Hamiltonian.
+
+## References
+
+* B. Nachtergaele, arXiv:cond-mat/9410110, equation (3.14).
+* arXiv:2011.12127, Section IV.C.
+-/
+
+open scoped BigOperators ComplexOrder InnerProductSpace
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The original-chain site at the beginning of blocked site `i`. -/
+def alignedOriginalSite {N p : ℕ} (hp : 0 < p) (i : Fin N) : Fin (N * p) :=
+  ⟨i.val * p, by
+    have hi := i.isLt
+    exact Nat.mul_lt_mul_of_pos_right hi hp⟩
+
+@[simp] theorem alignedOriginalSite_val {N p : ℕ} (hp : 0 < p) (i : Fin N) :
+    (alignedOriginalSite hp i).val = i.val * p :=
+  rfl
+
+/-- Block-aligned starts are pairwise distinct. -/
+theorem alignedOriginalSite_injective {N p : ℕ} (hp : 0 < p) :
+    Function.Injective (alignedOriginalSite (N := N) hp) := by
+  intro i j hij
+  apply Fin.ext
+  have hval := congrArg Fin.val hij
+  simp only [alignedOriginalSite_val] at hval
+  exact Nat.eq_of_mul_eq_mul_right hp hval
+
+@[simp] private theorem blockedConfigEquiv_apply_finProd (d N p : ℕ)
+    (σ : Cfg (blockPhysDim d p) N) (i : Fin N) (j : Fin p) :
+    blockedConfigEquiv d N p σ (finProdFinEquiv (i, j)) =
+      decodeBlock d p (σ i) j := by
+  simp [blockedConfigEquiv, Equiv.arrowCongr, Equiv.curry, decodeBlockEquiv_apply,
+    Function.comp]
+
+private theorem block_site_add_mod {N p : ℕ} (hNpos : 0 < N) (_hp : 0 < p)
+    (i q : Fin N) (r : Fin p) :
+    (i.val * p + (q.val * p + r.val)) % (N * p) =
+      ((i.val + q.val) % N) * p + r.val := by
+  rw [show i.val * p + (q.val * p + r.val) = (i.val + q.val) * p + r.val by ring]
+  rw [Nat.add_mod, Nat.mul_mod_mul_right]
+  rw [Nat.mod_eq_of_lt (lt_of_lt_of_le r.isLt (by
+    calc p = 1 * p := by simp
+      _ ≤ N * p := Nat.mul_le_mul_right p hNpos))]
+  rw [Nat.mod_eq_of_lt]
+  calc
+    (i.val + q.val) % N * p + r.val <
+        (i.val + q.val) % N * p + p := Nat.add_lt_add_left r.isLt _
+    _ = ((i.val + q.val) % N + 1) * p := by
+      rw [Nat.add_mul, Nat.one_mul]
+    _ ≤ N * p := Nat.mul_le_mul_right p (by
+      exact Nat.succ_le_iff.mpr (Nat.mod_lt _ hNpos))
+
+private theorem block_site_offset_mod {N p : ℕ} (hp : 0 < p)
+    (i q : Fin N) (r : Fin p) :
+    (q.val * p + r.val + N * p - i.val * p) % (N * p) =
+      ((q.val + N - i.val) % N) * p + r.val := by
+  let off : Fin N := ⟨(q.val + N - i.val) % N, Nat.mod_lt _ (Fin.pos i)⟩
+  have hoff_lt : off.val * p + r.val < N * p := by
+    calc
+      off.val * p + r.val < off.val * p + p := Nat.add_lt_add_left r.isLt _
+      _ = (off.val + 1) * p := by rw [Nat.add_mul, Nat.one_mul]
+      _ ≤ N * p := Nat.mul_le_mul_right p (by omega)
+  have hadd : (i.val * p + (off.val * p + r.val)) % (N * p) = q.val * p + r.val := by
+    rw [block_site_add_mod (Fin.pos i) hp i off r]
+    have hiq := add_offset_mod_eq i.isLt q.isLt
+    change (i.val + off.val) % N = q.val at hiq
+    rw [hiq]
+  have hoff := offset_mod_eq
+    (show i.val * p < N * p from Nat.mul_lt_mul_of_pos_right i.isLt hp) hoff_lt
+  rw [hadd] at hoff
+  exact hoff
+
+theorem blockedConfigEquiv_extractWindow_aligned
+    {N p : ℕ} (hp : 0 < p) (hN : 2 ≤ N)
+    (i : Fin N) (σ : Cfg (blockPhysDim d p) N) :
+    extractWindow (2 * p) (alignedOriginalSite hp i) (blockedConfigEquiv d N p σ) =
+      blockedConfigEquiv d 2 p (extractWindow 2 i σ) := by
+  funext k
+  obtain ⟨⟨q, r⟩, rfl⟩ := finProdFinEquiv.surjective k
+  let qN : Fin N := ⟨q.val, Nat.lt_of_lt_of_le q.isLt hN⟩
+  have hsite :
+      (⟨((alignedOriginalSite hp i).val + (finProdFinEquiv (q, r)).val) % (N * p),
+          Nat.mod_lt _ (Nat.mul_pos (Fin.pos i) hp)⟩ : Fin (N * p)) =
+        finProdFinEquiv
+          (⟨(i.val + q.val) % N, Nat.mod_lt _ (Fin.pos i)⟩, r) := by
+    apply Fin.ext
+    simp only [alignedOriginalSite_val]
+    rw [show (finProdFinEquiv (q, r)).val = q.val * p + r.val by
+      simp [finProdFinEquiv, Nat.mul_comm, Nat.add_comm]]
+    rw [show (finProdFinEquiv
+        (⟨(i.val + q.val) % N, Nat.mod_lt _ (Fin.pos i)⟩, r)).val =
+          ((i.val + q.val) % N) * p + r.val by
+      simp [finProdFinEquiv, Nat.mul_comm, Nat.add_comm]]
+    exact block_site_add_mod (Fin.pos i) hp i qN r
+  change (blockedConfigEquiv d N p σ)
+      (⟨((alignedOriginalSite hp i).val + (finProdFinEquiv (q, r)).val) % (N * p),
+        _⟩ : Fin (N * p)) = _
+  rw [hsite]
+  simp only [blockedConfigEquiv_apply_finProd]
+  congr 2
+
+theorem blockedConfigEquiv_replaceWindow_aligned
+    {N p : ℕ} (hp : 0 < p) (hN : 2 ≤ N)
+    (i : Fin N) (σ : Cfg (blockPhysDim d p) N)
+    (τ : Cfg (blockPhysDim d p) 2) :
+    blockedConfigEquiv d N p (replaceWindow 2 hN i σ τ) =
+      replaceWindow (2 * p) (Nat.mul_le_mul_right p hN) (alignedOriginalSite hp i)
+        (blockedConfigEquiv d N p σ) (blockedConfigEquiv d 2 p τ) := by
+  funext k
+  obtain ⟨⟨q, r⟩, rfl⟩ := finProdFinEquiv.surjective k
+  simp only [blockedConfigEquiv_apply_finProd, replaceWindow]
+  have hoff :
+      ((finProdFinEquiv (q, r)).val + N * p - (alignedOriginalSite hp i).val) % (N * p) =
+        ((q.val + N - i.val) % N) * p + r.val := by
+    simp only [alignedOriginalSite_val]
+    rw [show (finProdFinEquiv (q, r)).val = q.val * p + r.val by
+      simp [finProdFinEquiv, Nat.mul_comm, Nat.add_comm]]
+    exact block_site_offset_mod hp i q r
+  rw [hoff]
+  by_cases hq : (q.val + N - i.val) % N < 2
+  · have hoff_lt : ((q.val + N - i.val) % N) * p + r.val < 2 * p := by
+      calc
+        ((q.val + N - i.val) % N) * p + r.val <
+            ((q.val + N - i.val) % N) * p + p := Nat.add_lt_add_left r.isLt _
+        _ = ((q.val + N - i.val) % N + 1) * p := by rw [Nat.add_mul, Nat.one_mul]
+        _ ≤ 2 * p := Nat.mul_le_mul_right p (Nat.succ_le_iff.mpr hq)
+    rw [dif_pos hq, dif_pos hoff_lt]
+    let off : Fin 2 := ⟨(q.val + N - i.val) % N, hq⟩
+    have hidx :
+        (⟨((q.val + N - i.val) % N) * p + r.val, hoff_lt⟩ : Fin (2 * p)) =
+          finProdFinEquiv (off, r) := by
+      apply Fin.ext
+      simp [off, finProdFinEquiv, Nat.mul_comm, Nat.add_comm]
+    rw [hidx, blockedConfigEquiv_apply_finProd]
+  · have hoff_ge : ¬((q.val + N - i.val) % N) * p + r.val < 2 * p := by
+      intro h
+      have hmul : 2 * p ≤ ((q.val + N - i.val) % N) * p :=
+        Nat.mul_le_mul_right p (by omega)
+      omega
+    rw [dif_neg hq, dif_neg hoff_ge]
+
+/-- A blocked range-two term is the original range-`2 * p` term at the aligned start. -/
+theorem localTermES_blockTensor_two_conj (A : MPSTensor d D) {N p : ℕ}
+    (hp : 0 < p) (hN : 2 ≤ N) (i : Fin N) :
+    localTermES A (2 * p) (alignedOriginalSite hp i) =
+      (blockedConfigLinearIsometryEquiv d N p).toLinearEquiv.toLinearMap.comp
+        ((localTermES (blockTensor A p) 2 i).comp
+          (blockedConfigLinearIsometryEquiv d N p).symm.toLinearEquiv.toLinearMap) := by
+  ext v σ
+  simp only [LinearMap.comp_apply]
+  rw [localTermES_apply A (2 * p) (alignedOriginalSite hp i)
+    (Nat.mul_le_mul_right p hN)]
+  change parentInteractionES A (2 * p)
+      ((cyclicRestrictES (d := d) (Fin.pos (alignedOriginalSite hp i))
+        (2 * p) (alignedOriginalSite hp i) σ) v)
+      (extractWindow (2 * p) (alignedOriginalSite hp i) σ) =
+    localTermES (blockTensor A p) 2 i
+      ((blockedConfigLinearIsometryEquiv d N p).symm v)
+      ((blockedConfigEquiv d N p).symm σ)
+  rw [localTermES_apply (blockTensor A p) 2 i hN]
+  have hinteraction := congrArg (fun f => f)
+    (show parentInteractionES A (2 * p) =
+      (blockedConfigLinearIsometryEquiv d 2 p).toLinearEquiv.toLinearMap.comp
+        ((parentInteractionES (blockTensor A p) 2).comp
+          (blockedConfigLinearIsometryEquiv d 2 p).symm.toLinearEquiv.toLinearMap) by
+      simp only [parentInteractionES, Submodule.starProjection_orthogonal']
+      rw [starProjection_groundSpaceES_blockTensor_conj A p 2]
+      ext w
+      simp)
+  have hextract := blockedConfigEquiv_extractWindow_aligned
+    (d := d) hp hN i ((blockedConfigEquiv d N p).symm σ)
+  simp only [Equiv.apply_symm_apply] at hextract
+  have hreplace (τ : Cfg (blockPhysDim d p) 2) :=
+    blockedConfigEquiv_replaceWindow_aligned
+      (d := d) hp hN i ((blockedConfigEquiv d N p).symm σ) τ
+  simp only [Equiv.apply_symm_apply] at hreplace
+  change parentInteractionES A (2 * p)
+      ((cyclicRestrictES (d := d) (Fin.pos (alignedOriginalSite hp i))
+        (2 * p) (alignedOriginalSite hp i) σ) v)
+      (extractWindow (2 * p) (alignedOriginalSite hp i) σ) =
+    parentInteractionES (blockTensor A p) 2
+      ((cyclicRestrictES (d := blockPhysDim d p) (Fin.pos i) 2 i
+        ((blockedConfigEquiv d N p).symm σ))
+          ((blockedConfigLinearIsometryEquiv d N p).symm v))
+      (extractWindow 2 i ((blockedConfigEquiv d N p).symm σ))
+  rw [hinteraction]
+  simp only [LinearMap.comp_apply]
+  change parentInteractionES (blockTensor A p) 2
+      ((blockedConfigLinearIsometryEquiv d 2 p).symm
+        ((cyclicRestrictES (d := d) (Fin.pos (alignedOriginalSite hp i))
+          (2 * p) (alignedOriginalSite hp i) σ) v))
+      ((blockedConfigEquiv d 2 p).symm
+        (extractWindow (2 * p) (alignedOriginalSite hp i) σ)) = _
+  rw [hextract, Equiv.symm_apply_apply]
+  apply congrArg (fun w => parentInteractionES (blockTensor A p) 2 w
+    (extractWindow 2 i ((blockedConfigEquiv d N p).symm σ)))
+  ext τ
+  rw [blockedConfigLinearIsometryEquiv_symm_apply_apply]
+  rw [cyclicRestrictES_apply, cyclicRestrictES_apply]
+  rw [blockedConfigLinearIsometryEquiv_symm_apply_apply]
+  change v (cyclicCfg (Fin.pos (alignedOriginalSite hp i)) (2 * p)
+      (alignedOriginalSite hp i) (blockedConfigEquiv d 2 p τ) σ) =
+    v (blockedConfigEquiv d N p
+      (cyclicCfg (Fin.pos i) 2 i τ ((blockedConfigEquiv d N p).symm σ)))
+  change v (replaceWindow (2 * p) (Nat.mul_le_mul_right p hN)
+      (alignedOriginalSite hp i) σ (blockedConfigEquiv d 2 p τ)) =
+    v (blockedConfigEquiv d N p
+      (replaceWindow 2 hN i ((blockedConfigEquiv d N p).symm σ) τ))
+  rw [← hreplace τ]
+
+
+
+/-- The blocked range-two parent Hamiltonian transported to the original chain. -/
+noncomputable def transportedBlockedParentHamiltonianES (A : MPSTensor d D)
+    (N p : ℕ) :
+    EuclideanSpace ℂ (Cfg d (N * p)) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d (N * p)) :=
+  (blockedConfigLinearIsometryEquiv d N p).toLinearEquiv.toLinearMap.comp
+    ((parentHamiltonianES (blockTensor A p) 2 N).comp
+      (blockedConfigLinearIsometryEquiv d N p).symm.toLinearEquiv.toLinearMap)
+
+/-- The sparse original-site sum over starts divisible by `p`. -/
+noncomputable def alignedParentHamiltonianES (A : MPSTensor d D)
+    (N p : ℕ) (hp : 0 < p) :
+    EuclideanSpace ℂ (Cfg d (N * p)) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d (N * p)) :=
+  ∑ i : Fin N, localTermES A (2 * p) (alignedOriginalSite hp i)
+
+/-- Transporting the blocked range-two Hamiltonian gives the sparse aligned sum. -/
+theorem transportedBlockedParentHamiltonianES_eq_alignedParentHamiltonianES
+    (A : MPSTensor d D) {N p : ℕ} (hp : 0 < p) (hN : 2 ≤ N) :
+    transportedBlockedParentHamiltonianES A N p =
+      alignedParentHamiltonianES A N p hp := by
+  rw [transportedBlockedParentHamiltonianES, parentHamiltonianES_eq_sum_localTermES]
+  rw [alignedParentHamiltonianES]
+  apply LinearMap.ext
+  intro v
+  simp only [LinearMap.comp_apply, LinearMap.sum_apply]
+  rw [map_sum]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  exact LinearMap.congr_fun (localTermES_blockTensor_two_conj A hp hN i).symm v
+
+/-- The sparse aligned parent Hamiltonian is positive. -/
+theorem alignedParentHamiltonianES_isPositive (A : MPSTensor d D)
+    (N p : ℕ) (hp : 0 < p) :
+    (alignedParentHamiltonianES A N p hp).IsPositive := by
+  rw [alignedParentHamiltonianES]
+  exact LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A (2 * p) _
+
+/-- The transported blocked Hamiltonian is positive. -/
+theorem transportedBlockedParentHamiltonianES_isPositive (A : MPSTensor d D)
+    {N p : ℕ} (hp : 0 < p) (hN : 2 ≤ N) :
+    (transportedBlockedParentHamiltonianES A N p).IsPositive := by
+  rw [transportedBlockedParentHamiltonianES_eq_alignedParentHamiltonianES A hp hN]
+  exact alignedParentHamiltonianES_isPositive A N p hp
+
+/-- The aligned starts form a subset of all original-chain starts. -/
+private def alignedOriginalSites {N p : ℕ} (hp : 0 < p) : Finset (Fin (N * p)) :=
+  Finset.univ.image (alignedOriginalSite hp)
+
+/-- The sparse aligned Hamiltonian is bounded above by the full original parent Hamiltonian. -/
+theorem alignedParentHamiltonianES_le_parentHamiltonianES (A : MPSTensor d D)
+    {N p : ℕ} (hp : 0 < p) :
+    alignedParentHamiltonianES A N p hp ≤ parentHamiltonianES A (2 * p) (N * p) := by
+  rw [parentHamiltonianES_eq_sum_localTermES]
+  have hsum :
+      ∑ i : Fin N, localTermES A (2 * p) (alignedOriginalSite hp i) =
+        ∑ j ∈ alignedOriginalSites hp, localTermES A (2 * p) j := by
+    rw [alignedOriginalSites, Finset.sum_image]
+    intro i _ j _ hij
+    exact alignedOriginalSite_injective hp hij
+  rw [alignedParentHamiltonianES, hsum]
+  exact Finset.sum_le_univ_sum_of_nonneg fun j =>
+    (show 0 ≤ localTermES A (2 * p) j from
+      (LinearMap.nonneg_iff_isPositive (localTermES A (2 * p) j)).mpr
+        (localTermES_isPositive A (2 * p) j))
+
+/-- Positivity and the full Loewner comparison for the transported blocked Hamiltonian. -/
+theorem transportedBlockedParentHamiltonianES_nonneg_le_parentHamiltonianES
+    (A : MPSTensor d D) {N p : ℕ} (hp : 0 < p) (hN : 2 ≤ N) :
+    0 ≤ transportedBlockedParentHamiltonianES A N p ∧
+      transportedBlockedParentHamiltonianES A N p ≤
+        parentHamiltonianES A (2 * p) (N * p) := by
+  rw [transportedBlockedParentHamiltonianES_eq_alignedParentHamiltonianES A hp hN]
+  exact ⟨(LinearMap.nonneg_iff_isPositive
+      (alignedParentHamiltonianES A N p hp)).mpr
+        (alignedParentHamiltonianES_isPositive A N p hp),
+    alignedParentHamiltonianES_le_parentHamiltonianES A hp⟩
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/AlignedBlockedHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/AlignedBlockedHamiltonian.lean
@@ -9,8 +9,8 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 /-!
 # Block-aligned parent Hamiltonians
 
-Physical blocking by `p` sends the range-two interaction of the blocked tensor to the
-range-`2 * p` interaction of the original tensor at starts divisible by `p`.  This file
+Physical blocking by \(p\) sends the range-two interaction of the blocked tensor to the
+range-\(2p\) interaction of the original tensor at starts divisible by \(p\). This file
 records that local conjugacy, identifies the transported blocked Hamiltonian with the sparse
 sum over those starts, and compares that sum with the full original parent Hamiltonian.
 
@@ -26,12 +26,13 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- The original-chain site at the beginning of blocked site `i`. -/
+/-- The original-chain site at the beginning of blocked site \(i\). -/
 def alignedOriginalSite {N p : ℕ} (hp : 0 < p) (i : Fin N) : Fin (N * p) :=
   ⟨i.val * p, by
     have hi := i.isLt
     exact Nat.mul_lt_mul_of_pos_right hi hp⟩
 
+/-- The aligned original-site start has natural-number value \(ip\). -/
 @[simp] theorem alignedOriginalSite_val {N p : ℕ} (hp : 0 < p) (i : Fin N) :
     (alignedOriginalSite hp i).val = i.val * p :=
   rfl
@@ -90,6 +91,8 @@ private theorem block_site_offset_mod {N p : ℕ} (hp : 0 < p)
   rw [hadd] at hoff
   exact hoff
 
+/-- Flattening a blocked configuration commutes with extracting the two-block window at an
+aligned start. -/
 theorem blockedConfigEquiv_extractWindow_aligned
     {N p : ℕ} (hp : 0 < p) (hN : 2 ≤ N)
     (i : Fin N) (σ : Cfg (blockPhysDim d p) N) :
@@ -119,6 +122,8 @@ theorem blockedConfigEquiv_extractWindow_aligned
   simp only [blockedConfigEquiv_apply_finProd]
   congr 2
 
+/-- Flattening a blocked configuration commutes with replacing the two-block window at an
+aligned start. -/
 theorem blockedConfigEquiv_replaceWindow_aligned
     {N p : ℕ} (hp : 0 < p) (hN : 2 ≤ N)
     (i : Fin N) (σ : Cfg (blockPhysDim d p) N)
@@ -159,7 +164,7 @@ theorem blockedConfigEquiv_replaceWindow_aligned
       omega
     rw [dif_neg hq, dif_neg hoff_ge]
 
-/-- A blocked range-two term is the original range-`2 * p` term at the aligned start. -/
+/-- A blocked range-two term is the original range-\(2p\) term at the aligned start. -/
 theorem localTermES_blockTensor_two_conj (A : MPSTensor d D) {N p : ℕ}
     (hp : 0 < p) (hN : 2 ≤ N) (i : Fin N) :
     localTermES A (2 * p) (alignedOriginalSite hp i) =
@@ -178,15 +183,14 @@ theorem localTermES_blockTensor_two_conj (A : MPSTensor d D) {N p : ℕ}
       ((blockedConfigLinearIsometryEquiv d N p).symm v)
       ((blockedConfigEquiv d N p).symm σ)
   rw [localTermES_apply (blockTensor A p) 2 i hN]
-  have hinteraction := congrArg (fun f => f)
-    (show parentInteractionES A (2 * p) =
+  have hinteraction : parentInteractionES A (2 * p) =
       (blockedConfigLinearIsometryEquiv d 2 p).toLinearEquiv.toLinearMap.comp
         ((parentInteractionES (blockTensor A p) 2).comp
-          (blockedConfigLinearIsometryEquiv d 2 p).symm.toLinearEquiv.toLinearMap) by
-      simp only [parentInteractionES, Submodule.starProjection_orthogonal']
-      rw [starProjection_groundSpaceES_blockTensor_conj A p 2]
-      ext w
-      simp)
+          (blockedConfigLinearIsometryEquiv d 2 p).symm.toLinearEquiv.toLinearMap) := by
+    simp only [parentInteractionES, Submodule.starProjection_orthogonal']
+    rw [starProjection_groundSpaceES_blockTensor_conj A p 2]
+    ext w
+    simp
   have hextract := blockedConfigEquiv_extractWindow_aligned
     (d := d) hp hN i ((blockedConfigEquiv d N p).symm σ)
   simp only [Equiv.apply_symm_apply] at hextract
@@ -228,8 +232,6 @@ theorem localTermES_blockTensor_two_conj (A : MPSTensor d D) {N p : ℕ}
       (replaceWindow 2 hN i ((blockedConfigEquiv d N p).symm σ) τ))
   rw [← hreplace τ]
 
-
-
 /-- The blocked range-two parent Hamiltonian transported to the original chain. -/
 noncomputable def transportedBlockedParentHamiltonianES (A : MPSTensor d D)
     (N p : ℕ) :
@@ -238,7 +240,7 @@ noncomputable def transportedBlockedParentHamiltonianES (A : MPSTensor d D)
     ((parentHamiltonianES (blockTensor A p) 2 N).comp
       (blockedConfigLinearIsometryEquiv d N p).symm.toLinearEquiv.toLinearMap)
 
-/-- The sparse original-site sum over starts divisible by `p`. -/
+/-- The sparse original-site sum over starts divisible by \(p\). -/
 noncomputable def alignedParentHamiltonianES (A : MPSTensor d D)
     (N p : ℕ) (hp : 0 < p) :
     EuclideanSpace ℂ (Cfg d (N * p)) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d (N * p)) :=

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -183,6 +183,8 @@ private theorem cyclicCfg_eq_replaceWindow {N : ℕ} (hN : 0 < N) (L : ℕ)
     cyclicCfg hN L i σ τ = replaceWindow L hLN i τ σ := by
   rfl
 
+/-- Evaluating a Euclidean cyclic restriction reads the input vector on the configuration
+obtained by inserting the window values into the fixed outside configuration. -/
 @[simp] theorem cyclicRestrictES_apply {N : ℕ} (hN : 0 < N) (L : ℕ)
     (i : Fin N) (τ : Cfg d N) (v : EuclideanSpace ℂ (Cfg d N)) (ω : Cfg d L) :
     cyclicRestrictES (d := d) hN L i τ v ω = v (cyclicCfg hN L i ω τ) := rfl
@@ -378,6 +380,8 @@ private theorem cyclicRestrictES_adjoint_apply {N : ℕ} (hN : 0 < N) {L : ℕ}
       _ = if SameOutsideWindow (L := L) i σ τ then v (extractWindow L i σ) else 0 := by
             simp [hστ]
 
+/-- Pointwise evaluation of a Euclidean local term: restrict to the cyclic window, apply the
+local parent interaction, and read the result at the extracted window configuration. -/
 @[simp] theorem localTermES_apply {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N)
     (hLN : L ≤ N) (v : EuclideanSpace ℂ (Cfg d N)) (σ : Cfg d N) :
     localTermES A L i v σ =

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -183,7 +183,7 @@ private theorem cyclicCfg_eq_replaceWindow {N : ℕ} (hN : 0 < N) (L : ℕ)
     cyclicCfg hN L i σ τ = replaceWindow L hLN i τ σ := by
   rfl
 
-@[simp] private theorem cyclicRestrictES_apply {N : ℕ} (hN : 0 < N) (L : ℕ)
+@[simp] theorem cyclicRestrictES_apply {N : ℕ} (hN : 0 < N) (L : ℕ)
     (i : Fin N) (τ : Cfg d N) (v : EuclideanSpace ℂ (Cfg d N)) (ω : Cfg d L) :
     cyclicRestrictES (d := d) hN L i τ v ω = v (cyclicCfg hN L i ω τ) := rfl
 
@@ -378,7 +378,7 @@ private theorem cyclicRestrictES_adjoint_apply {N : ℕ} (hN : 0 < N) {L : ℕ}
       _ = if SameOutsideWindow (L := L) i σ τ then v (extractWindow L i σ) else 0 := by
             simp [hστ]
 
-@[simp] private theorem localTermES_apply {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N)
+@[simp] theorem localTermES_apply {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N)
     (hLN : L ≤ N) (v : EuclideanSpace ℂ (Cfg d N)) (σ : Cfg d N) :
     localTermES A L i v σ =
       parentInteractionES A L ((cyclicRestrictES (d := d) (Fin.pos i) L i σ) v)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -110,3 +110,46 @@ construction; they are not attributed to a source theorem.
     Taking $K=G_N^{\mathrm{ES}}(A^{[p]})$ gives
     (\ref{eq:blocked_ground_projector_conjugacy}).
 \end{proof}
+
+\begin{theorem}[Blocked parent Hamiltonian as an aligned subsum]
+    \label{thm:blocked_parent_hamiltonian_aligned_subsum}
+    \lean{MPSTensor.localTermES_blockTensor_two_conj}
+    \lean{MPSTensor.transportedBlockedParentHamiltonianES_eq_alignedParentHamiltonianES}
+    \lean{MPSTensor.transportedBlockedParentHamiltonianES_nonneg_le_parentHamiltonianES}
+    \leanok
+    \uses{def:blocked_configuration_isometry,
+        thm:blocked_local_ground_space_transport}
+    Let $p>0$ and $N\ge2$. For $i\in\Fin{N}$, write $pi$ for the corresponding
+    block-aligned site in the original chain. The blocked range-two interaction
+    satisfies
+    \begin{align}
+        W_{N,p}\,h_i^{A^{[p]},2}\,W_{N,p}^{*}
+        &=h_{pi}^{A,2p}.
+        \label{eq:blocked_local_term_aligned_transport}
+    \end{align}
+    Consequently, the transported blocked parent Hamiltonian is the sparse sum
+    \begin{align}
+        K_{N,p}
+        :=W_{N,p}H_N^{A^{[p]},2}W_{N,p}^{*}
+        &=\sum_{i=0}^{N-1}h_{pi}^{A,2p}.
+        \label{eq:blocked_parent_hamiltonian_aligned_sum}
+    \end{align}
+    This sum contains only block-aligned starts. It is positive and is bounded by
+    the full original-site parent Hamiltonian:
+    \begin{align}
+        0\le K_{N,p}\le H_{Np}^{A,2p}.
+        \label{eq:blocked_parent_hamiltonian_aligned_order}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The blocking isometry sends the two-block cyclic window beginning at $i$ to
+    the $2p$-site cyclic window beginning at $pi$. The local ground-space
+    projector identity therefore gives
+    (\ref{eq:blocked_local_term_aligned_transport}). Summing over blocked starts
+    gives (\ref{eq:blocked_parent_hamiltonian_aligned_sum}). Every local term is
+    positive, so the aligned subsum is positive. Adding the remaining,
+    non-aligned positive local terms gives the upper bound in
+    (\ref{eq:blocked_parent_hamiltonian_aligned_order}).
+\end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -117,7 +117,8 @@ construction; they are not attributed to a source theorem.
     \lean{MPSTensor.transportedBlockedParentHamiltonianES_eq_alignedParentHamiltonianES}
     \lean{MPSTensor.transportedBlockedParentHamiltonianES_nonneg_le_parentHamiltonianES}
     \leanok
-    \uses{def:blocked_configuration_isometry}
+    \uses{def:blocked_configuration_isometry, def:blocked_tensor,
+        rem:euclidean_local_projector_ingredients, def:parent_hamiltonian_es}
     Let $p>0$ and $N\ge2$. For $i\in\Fin{N}$, write $pi$ for the corresponding
     block-aligned site in the original chain. The blocked range-two interaction
     satisfies

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_blocking_transport.tex
@@ -117,8 +117,7 @@ construction; they are not attributed to a source theorem.
     \lean{MPSTensor.transportedBlockedParentHamiltonianES_eq_alignedParentHamiltonianES}
     \lean{MPSTensor.transportedBlockedParentHamiltonianES_nonneg_le_parentHamiltonianES}
     \leanok
-    \uses{def:blocked_configuration_isometry,
-        thm:blocked_local_ground_space_transport}
+    \uses{def:blocked_configuration_isometry}
     Let $p>0$ and $N\ge2$. For $i\in\Fin{N}$, write $pi$ for the corresponding
     block-aligned site in the original chain. The blocked range-two interaction
     satisfies
@@ -144,6 +143,7 @@ construction; they are not attributed to a source theorem.
 
 \begin{proof}
     \leanok
+    \uses{thm:blocked_local_ground_space_transport}
     The blocking isometry sends the two-block cyclic window beginning at $i$ to
     the $2p$-site cyclic window beginning at $pi$. The local ground-space
     projector identity therefore gives


### PR DESCRIPTION
## What changed

- identify each blocked start with the aligned original-chain site and prove exact range-two local-term conjugacy under `blockedConfigLinearIsometryEquiv`
- define the transported blocked Hamiltonian and the distinct sparse aligned original-site sum, then prove they agree
- prove positivity and the Loewner comparison with the full range-`2p` original parent Hamiltonian
- record the aligned-subsum statement in the parent-Hamiltonian blueprint

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.AlignedBlockedHamiltonian TNLean.MPS.ParentHamiltonian`
- `lake build` (10106 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- double `lualatex` with `TEXINPUTS="../../tex/tenkz//:"`; no undefined cross-references (pre-existing citation warnings remain)
- `python3 scripts/generate_import_aggregators.py --check`

Closes #6368