### PR TITLE
refactor(parent-hamiltonian): simplify blocked-gap wrappers

### DIFF
--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -54,6 +54,11 @@ lemma blockPhysDim_eq_pow (d L : ℕ) : blockPhysDim d L = d ^ L := by
   -- `Fintype.card_fun` gives `card (α → β) = card β ^ card α`.
   simp [Fintype.card_fin]
 
+/-- Blocking a nonempty physical alphabet preserves nonemptiness of its physical dimension. -/
+instance instNeZeroBlockPhysDim [NeZero d] : NeZero (blockPhysDim d L) := ⟨by
+  rw [blockPhysDim_eq_pow]
+  exact pow_ne_zero L (NeZero.ne d)⟩
+
 /-- The physical alphabet after blocking one site is equivalent to the original alphabet. -/
 noncomputable def singleBlockEquiv (d : ℕ) : Fin (blockPhysDim d 1) ≃ Fin d :=
   ((finCongr (blockPhysDim_eq_pow d 1)).trans finFunctionFinEquiv.symm).trans

--- a/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean
@@ -251,9 +251,6 @@ theorem blockTensor_threeSite_openChain_defect_norm_eq
       ‖(reassocTailBoundaryMapES A p p p).range.starProjection ∘L
             (leftBoundaryMapES A (p + p) p).range.starProjection -
           (groundSpaceES A (p + p + p)).starProjection‖ := by
-  letI : NeZero (blockPhysDim d p) := ⟨by
-    rw [blockPhysDim_eq_pow]
-    exact pow_ne_zero p (NeZero.ne d)⟩
   let U := blockedThreeConfigLinearIsometryEquiv d p
   let T := openChainTailGroundSpaceES (blockTensor A p) 1 2
   let L := openChainLeftGroundSpaceES (blockTensor A p) 2
@@ -335,9 +332,6 @@ private theorem IsPrimitiveMPS.exists_blockTensor_anticommutator
   obtain ⟨p, hp, hInj, hDefect⟩ :=
     hP.exists_threeBlock_wholeIncrement_defect_le_seven_sixteenths hρ
   let B := blockTensor A p
-  letI : NeZero (blockPhysDim d p) := ⟨by
-    rw [blockPhysDim_eq_pow]
-    exact pow_ne_zero p (NeZero.ne d)⟩
   have hBInj : IsInjective B :=
     (isNBlkInjective_iff_blockTensor_isInjective A p).mp hInj
   have hBlockedDefect :
@@ -427,9 +421,6 @@ theorem IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth
               ‖parentHamiltonianES (blockTensor A p) 2 N v‖ := by
   obtain ⟨p, hp, hInj, hAnti⟩ := hP.exists_blockTensor_anticommutator hρ
   let B := blockTensor A p
-  letI : NeZero (blockPhysDim d p) := ⟨by
-    rw [blockPhysDim_eq_pow]
-    exact pow_ne_zero p (NeZero.ne d)⟩
   obtain ⟨_, hGap⟩ :=
     parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator
       B 2 (by omega) hAnti
@@ -453,11 +444,8 @@ theorem IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped
           (v : EuclideanSpace ℂ (Cfg (blockPhysDim d p) N)),
           v ∈ (parentHamiltonianGroundSpaceES (blockTensor A p) 2 N)ᗮ →
             γ * ‖v‖ ≤ ‖parentHamiltonianES (blockTensor A p) 2 N v‖ := by
-  obtain ⟨p, hp, hInj, hAnti⟩ := hP.exists_blockTensor_anticommutator hρ
-  letI : NeZero (blockPhysDim d p) := ⟨by
-    rw [blockPhysDim_eq_pow]
-    exact pow_ne_zero p (NeZero.ne d)⟩
-  exact ⟨p, hp, hInj,
-    parentHamiltonian_gapped_of_anticommutator (blockTensor A p) 2 (by omega) hAnti⟩
+  obtain ⟨p, hp, hInj, hGap⟩ :=
+    hP.exists_blockTensor_parentHamiltonianES_gap_eighth hρ
+  exact ⟨p, hp, hInj, 1 / 8, by norm_num, hGap⟩
 
 end MPSTensor

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -859,6 +859,18 @@ abstracted — record why, so it is not re-proposed).
 - **Result:** both theorem statements are unchanged, and their previously profiled
   multi-second declarations fall below the one-second profiler threshold.
 
+### Blocked physical-dimension nonzeroness and explicit-gap specialization
+- **Pattern:** `Martingale/BlockedGap.lean` repeated the same three-line construction
+  of `NeZero (blockPhysDim d p)` four times, and the qualitative blocked-gap theorem
+  repeated the anticommutator route already used by the preceding explicit-gap theorem.
+- **Reuse:** `TNLean/MPS/Core/Blocking.lean` now provides the canonical instance
+  `MPSTensor.instNeZeroBlockPhysDim`. The four local calculations are removed.
+  `IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped` is now a thin
+  corollary of `IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth`,
+  using `1 / 8` as the positive gap witness.
+- **Result:** The public theorem signatures and order in
+  `TNLean/MPS/ParentHamiltonian/Martingale/BlockedGap.lean` are unchanged.
+
 ### Non-decaying-overlap dimension and gauge-phase dichotomy
 - **Pattern:** The `hDim`/`hGPE` tails of
   `exists_state_scalar_of_nondecaying_overlap` (`MatchAux.lean`) and


### PR DESCRIPTION
## Summary
- implement issue #6377 while preserving all public and Blueprint theorem leaves
- use canonical owners and keep compatibility declarations intact

## Validation
- targeted module and consumer builds
- full local build where Lean sources changed
- import, Blueprint, formatting, and diff gates appropriate to the changed files
- exact-head specialist review approved

Closes #6377