### PR TITLE
feat(MPDO): assemble normalization-free dimer RFP capstone

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -271,6 +271,7 @@ import TNLean.MPS.MPDO.RescalingStableExplicitVerticalBNT
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFP
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPBNTClause
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
+import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCapstone
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPViaTS
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SALArbitraryCut

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPViaTS
 # Length-dependent BNT coefficients for a renormalization fixed point
 
 This file assembles the established properties of the dimer tensor `R` into
-an explicit positive answer to the question after Theorem 4.14 of CPSV16.
+a normalization-free variant of the question after Theorem 4.14 of CPSV16.
 
 ## Main result
 
@@ -34,16 +34,17 @@ namespace MPOTensor.RescalingStableLengthDependentRFP
 canonical form, and its explicit one-label tensor-attached BNT presentation has
 coefficients that depend on the positive chain length.
 
-This answers the existential question in arXiv:1606.00608, lines 995--997, for
-the displayed vertical presentation. It does not assert presentation
-independence. The source's standing unit-weight convention is not part of this
-statement. -/
+This proves a normalization-free variant of the question in
+arXiv:1606.00608, lines 995--997, for the displayed vertical presentation. It
+does not assert presentation independence. The source additionally assumes
+that every canonical weight has modulus at most one and at least one has
+modulus one; that normalization is not part of this statement. -/
 theorem exists_isRFPViaTS_not_lengthIndependent_bntCoefficients_R :
     ∃ (M : MPOTensor 4 4) (H : BNTAlgebraTensorClause M),
       MPSTensor.IsCPSVCanonicalForm M.toMPSTensor ∧
         IsMPDO M ∧ IsRFPViaTS M ∧ ¬ H.coeffs.LengthIndependent := by
-  refine ⟨R, R_oneLabelBNTAlgebraTensorClause,
-    R_toMPSTensor_isCPSVCanonicalForm, R_isMPDO, isRFPViaTS_R, ?_⟩
-  simpa using oneLabelCoeffs_not_lengthIndependent
+  exact ⟨R, R_oneLabelBNTAlgebraTensorClause,
+    R_toMPSTensor_isCPSVCanonicalForm, R_isMPDO, isRFPViaTS_R,
+    oneLabelCoeffs_not_lengthIndependent⟩
 
 end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.RescalingStableExplicitVerticalBNT
+import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPViaTS
+
+/-!
+# Length-dependent BNT coefficients for a renormalization fixed point
+
+This file assembles the established properties of the dimer tensor `R` into
+an explicit positive answer to the question after Theorem 4.14 of CPSV16.
+
+## Main result
+
+* `exists_isRFPViaTS_not_lengthIndependent_bntCoefficients_R` exhibits `R` in
+  literal CPSV canonical form as an MPDO renormalization fixed point whose
+  displayed tensor-attached BNT coefficient family depends on chain length.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14 and the question at lines 995--997.
+-/
+
+open scoped ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.RescalingStableLengthDependentRFP
+
+/-- The dimer tensor `R` is an MPDO renormalization fixed point in literal CPSV
+canonical form, and its explicit one-label tensor-attached BNT presentation has
+coefficients that depend on the positive chain length.
+
+This answers the existential question in arXiv:1606.00608, lines 995--997, for
+the displayed vertical presentation. It does not assert presentation
+independence. The source's standing unit-weight convention is not part of this
+statement. -/
+theorem exists_isRFPViaTS_not_lengthIndependent_bntCoefficients_R :
+    ∃ (M : MPOTensor 4 4) (H : BNTAlgebraTensorClause M),
+      MPSTensor.IsCPSVCanonicalForm M.toMPSTensor ∧
+        IsMPDO M ∧ IsRFPViaTS M ∧ ¬ H.coeffs.LengthIndependent := by
+  refine ⟨R, R_oneLabelBNTAlgebraTensorClause,
+    R_toMPSTensor_isCPSVCanonicalForm, R_isMPDO, isRFPViaTS_R, ?_⟩
+  simpa using oneLabelCoeffs_not_lengthIndependent
+
+end MPOTensor.RescalingStableLengthDependentRFP

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1233,3 +1233,39 @@
     Substitute the trace-power form of the coefficients into the
     associativity constraint.
 \end{proof}
+
+\begin{theorem}[The dimer RFP has length-dependent displayed BNT coefficients]%
+    \label{thm:mpdo_bnt_label_rescaling_stable_rfp_capstone}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        exists_isRFPViaTS_not_lengthIndependent_bntCoefficients_R}
+    \leanok
+    \uses{def:mpdo_bnt_algebra_tensor_clause,
+        def:mpdo_bnt_label_length_independent,
+        thm:mpdo_bnt_label_rescaling_stable_cf,
+        thm:mpdo_bnt_label_rescaling_stable_is_rfp_via_ts,
+        thm:mpdo_bnt_label_rescaling_stable_bnt_algebra_clause}
+    There is an MPDO $M$ in literal CPSV canonical form that is a
+    renormalization fixed point and has a tensor-attached BNT presentation
+    whose structure coefficients depend on the positive chain length.  One
+    may take $M=R$ and the one-label presentation above, for which
+    \begin{align}
+        c^{(L)}_{0,0,0}&=1+\left(\frac{7}{25}\right)^L.
+        \notag
+    \end{align}
+    Thus the question after Theorem~4.14 has an affirmative answer for this
+    displayed vertical presentation.  The statement neither asserts that
+    length dependence is invariant under a change of presentation nor
+    includes the source's standing unit-weight convention.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence,
+        thm:mpdo_bnt_label_rescaling_stable_cf,
+        thm:mpdo_bnt_label_rescaling_stable_is_rfp_via_ts,
+        thm:mpdo_bnt_label_rescaling_stable_bnt_algebra_clause}
+    The preceding results show that $R$ is an MPDO in literal CPSV canonical
+    form, construct its fixed-point maps and its tensor-attached one-label
+    BNT clause, and identify the clause's coefficients with the displayed
+    trace-power family.  Its values at lengths one and two differ, so that
+    family is not length independent.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1239,11 +1239,11 @@
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
         exists_isRFPViaTS_not_lengthIndependent_bntCoefficients_R}
     \leanok
-    \uses{def:mpdo_bnt_algebra_tensor_clause,
-        def:mpdo_bnt_label_length_independent,
-        thm:mpdo_bnt_label_rescaling_stable_cf,
-        thm:mpdo_bnt_label_rescaling_stable_is_rfp_via_ts,
-        thm:mpdo_bnt_label_rescaling_stable_bnt_algebra_clause}
+    \uses{def:cpsv_canonical_form,
+        def:mpdo,
+        def:is_rfp_via_ts,
+        def:mpdo_bnt_algebra_tensor_clause,
+        def:mpdo_bnt_label_length_independent}
     There is an MPDO $M$ in literal CPSV canonical form that is a
     renormalization fixed point and has a tensor-attached BNT presentation
     whose structure coefficients depend on the positive chain length.  One
@@ -1252,15 +1252,18 @@
         c^{(L)}_{0,0,0}&=1+\left(\frac{7}{25}\right)^L.
         \notag
     \end{align}
-    Thus the question after Theorem~4.14 has an affirmative answer for this
-    displayed vertical presentation.  The statement neither asserts that
-    length dependence is invariant under a change of presentation nor
-    includes the source's standing unit-weight convention.
+    This gives a normalization-free variant of the question after
+    Theorem~4.14 for the displayed vertical presentation.  The statement does
+    not assert that length dependence is invariant under a change of
+    presentation.  It also does not supply the source's additional canonical
+    normalization: every weight has modulus at most one and at least one has
+    modulus one.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence,
         thm:mpdo_bnt_label_rescaling_stable_cf,
+        thm:mpdo_bnt_label_rescaling_stable_ismpdo,
         thm:mpdo_bnt_label_rescaling_stable_is_rfp_via_ts,
         thm:mpdo_bnt_label_rescaling_stable_bnt_algebra_clause}
     The preceding results show that $R$ is an MPDO in literal CPSV canonical


### PR DESCRIPTION
Closes #6393.

## Summary
- assemble the existing dimer tensor `R` canonical-form, MPDO, RFP, explicit BNT-clause, and coefficient non-independence results into one theorem;
- state precisely that this proves a normalization-free variant for the displayed presentation, without presentation-invariance or the source canonical-weight normalization;
- add the MPDO aggregate import and Blueprint theorem/dependencies.

## Verification
- `lake env lean TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --ci` (7592/7592)
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `git diff --check`