### PR TITLE
feat(analysis): assemble two-projection commuting complement

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -68,5 +68,6 @@ import TNLean.Analysis.TwoProjectionAngleBlock
 import TNLean.Analysis.TwoProjectionAngleOrthogonality
 import TNLean.Analysis.TwoProjectionCompression
 import TNLean.Analysis.TwoProjectionCompressionSpectrum
+import TNLean.Analysis.TwoProjectionDefectBlockSum
 import TNLean.Analysis.TwoProjectionReducedProjection
 import TNLean.Analysis.UpperTriangularBound

--- a/TNLean/Analysis/TwoProjectionDefectBlockSum.lean
+++ b/TNLean/Analysis/TwoProjectionDefectBlockSum.lean
@@ -57,31 +57,34 @@ theorem angleDefectBlock_isInternal {P Q : E →ₗ[ℂ] E}
   simpa only [angleDefectSum, iSup_true] using
     DirectSum.isInternal_biSup_submodule_of_iSupIndep
       (A := fun i : CompressionIndex (P := P) => angleDefectBlock hP hQ i) Set.univ
-      (angleDefectBlock_orthogonalFamily hP hQ).independent
+      ((angleDefectBlock_orthogonalFamily hP hQ).independent.comp Subtype.coe_injective)
 
 /-- The defect-block sum and its orthogonal complement give the ambient orthogonal
  decomposition. -/
 theorem angleDefectSum_isCompl_angleDefectComplement {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     IsCompl (angleDefectSum hP hQ) (angleDefectComplement hP hQ) := by
-  rw [angleDefectComplement]
-  exact Submodule.isCompl_orthogonal
+  exact Submodule.isCompl_orthogonal (K := angleDefectSum hP hQ)
 
 /-- The range of the first projection lies in the sum of the compression defect blocks. -/
 theorem range_le_angleDefectSum {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     P.range ≤ angleDefectSum hP hQ := by
-  rw [← (rangeCompressionEigenbasis hP hQ).toBasis.span_eq, Submodule.span_le]
-  rintro x ⟨i, rfl⟩
-  exact le_iSup (fun j => angleDefectBlock hP hQ j) i <|
-    Submodule.subset_span (by left; rfl)
+  rintro x ⟨y, rfl⟩
+  rw [← (rangeCompressionEigenbasis hP hQ).toBasis.span_eq] at y
+  refine Submodule.span_induction y ?_ (Submodule.zero_mem _) ?_ ?_
+  · rintro _ ⟨i, rfl⟩
+    exact le_iSup (fun j => angleDefectBlock hP hQ j) i <|
+      Submodule.subset_span (by left; rfl)
+  · exact fun _ _ => Submodule.add_mem _
+  · exact fun c _ => Submodule.smul_mem _ c
 
 /-- The defect-block sum is invariant under the first projection. -/
 theorem map_angleDefectSum_le_first_projection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     Submodule.map P (angleDefectSum hP hQ) ≤ angleDefectSum hP hQ := by
   rw [angleDefectSum, Submodule.map_iSup]
-  exact iSup_mono fun i => (map_angleDefectBlock_le_first_projection hP hQ i).trans
+  exact iSup_le fun i => (map_angleDefectBlock_le_first_projection hP hQ i).trans
     (le_iSup (fun j => angleDefectBlock hP hQ j) i)
 
 /-- The defect-block sum is invariant under the second projection. -/
@@ -89,31 +92,32 @@ theorem map_angleDefectSum_le_second_projection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     Submodule.map Q (angleDefectSum hP hQ) ≤ angleDefectSum hP hQ := by
   rw [angleDefectSum, Submodule.map_iSup]
-  exact iSup_mono fun i => (map_angleDefectBlock_le_second_projection hP hQ i).trans
+  exact iSup_le fun i => (map_angleDefectBlock_le_second_projection hP hQ i).trans
     (le_iSup (fun j => angleDefectBlock hP hQ j) i)
 
 /-- The orthogonal complement of the defect-block sum is invariant under the first projection. -/
 theorem map_angleDefectComplement_le_first_projection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     Submodule.map P (angleDefectComplement hP hQ) ≤ angleDefectComplement hP hQ := by
-  rw [Module.End.mem_invtSubmodule_iff_map_le]
-  exact hP.isSymmetric.orthogonalComplement_mem_invtSubmodule
-    (Module.End.mem_invtSubmodule_iff_map_le.mpr
-      (map_angleDefectSum_le_first_projection hP hQ))
+  exact Module.End.mem_invtSubmodule_iff_map_le.mp <|
+    hP.isSymmetric.orthogonalComplement_mem_invtSubmodule
+      (Module.End.mem_invtSubmodule_iff_map_le.mpr
+        (map_angleDefectSum_le_first_projection hP hQ))
 
 /-- The orthogonal complement of the defect-block sum is invariant under the second projection. -/
 theorem map_angleDefectComplement_le_second_projection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     Submodule.map Q (angleDefectComplement hP hQ) ≤ angleDefectComplement hP hQ := by
-  rw [Module.End.mem_invtSubmodule_iff_map_le]
-  exact hQ.isSymmetric.orthogonalComplement_mem_invtSubmodule
-    (Module.End.mem_invtSubmodule_iff_map_le.mpr
-      (map_angleDefectSum_le_second_projection hP hQ))
+  exact Module.End.mem_invtSubmodule_iff_map_le.mp <|
+    hQ.isSymmetric.orthogonalComplement_mem_invtSubmodule
+      (Module.End.mem_invtSubmodule_iff_map_le.mpr
+        (map_angleDefectSum_le_second_projection hP hQ))
 
 /-- The first projection vanishes on the complement of the defect-block sum. -/
 theorem first_projection_apply_eq_zero_of_mem_angleDefectComplement {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {z : E}
     (hz : z ∈ angleDefectComplement hP hQ) : P z = 0 := by
+  apply LinearMap.mem_ker.mp
   rw [← hP.isSymmetric.orthogonal_range]
   exact Submodule.orthogonal_le (range_le_angleDefectSum hP hQ) hz
 
@@ -143,7 +147,6 @@ theorem firstProjectionOnAngleDefectComplement_eq_zero {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     firstProjectionOnAngleDefectComplement hP hQ = 0 := by
   ext z
-  apply Subtype.ext
   exact first_projection_apply_eq_zero_of_mem_angleDefectComplement hP hQ z.property
 
 /-- The first restricted projection remains a symmetric projection. -/
@@ -151,7 +154,7 @@ theorem firstProjectionOnAngleDefectComplement_isSymmetricProjection {P Q : E �
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     (firstProjectionOnAngleDefectComplement hP hQ).IsSymmetricProjection := by
   rw [firstProjectionOnAngleDefectComplement_eq_zero hP hQ]
-  exact ⟨isIdempotentElem_zero, LinearMap.isSymmetric_zero⟩
+  exact ⟨.zero, LinearMap.IsSymmetric.zero⟩
 
 /-- The second restricted projection remains a symmetric projection. -/
 theorem secondProjectionOnAngleDefectComplement_isSymmetricProjection {P Q : E →ₗ[ℂ] E}
@@ -161,7 +164,7 @@ theorem secondProjectionOnAngleDefectComplement_isSymmetricProjection {P Q : E �
     fun z hz => (map_angleDefectComplement_le_second_projection hP hQ) ⟨z, hz, rfl⟩
   constructor
   · apply DFunLike.ext _ _ fun z => Subtype.ext ?_
-    exact hQ.isIdempotentElem.apply_apply z
+    exact LinearMap.IsIdempotentElem.apply_apply hQ.isIdempotentElem z
   · exact hQ.isSymmetric.restrict_invariant hQinv
 
 /-- The restricted projections commute on the complementary summand. This conclusion does not

--- a/TNLean/Analysis/TwoProjectionDefectBlockSum.lean
+++ b/TNLean/Analysis/TwoProjectionDefectBlockSum.lean
@@ -48,16 +48,18 @@ theorem angleDefectBlock_orthogonalFamily {P Q : E →ₗ[ℂ] E}
       (fun i => (angleDefectBlock hP hQ i).subtypeₗᵢ) :=
   OrthogonalFamily.of_pairwise fun _ _ hij => angleDefectBlock_isOrtho hP hQ hij
 
-/-- After lifting each block to the defect-block sum, the family is an internal direct sum. -/
+/-- After lifting each block to the defect-block sum, the full compression-indexed family is an
+internal direct sum. The subtype index records explicitly that every compression-basis coordinate
+is retained. -/
 theorem angleDefectBlock_isInternal {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
-    DirectSum.IsInternal (fun i : CompressionIndex (P := P) =>
-      (angleDefectBlock hP hQ i).comap (angleDefectSum hP hQ).subtype) := by
+    DirectSum.IsInternal (fun i : (Set.univ : Set (CompressionIndex (P := P))) =>
+      (angleDefectBlock hP hQ i).comap
+        (⨆ i ∈ (Set.univ : Set (CompressionIndex (P := P))),
+          angleDefectBlock hP hQ i).subtype) := by
   classical
-  simpa only [angleDefectSum, iSup_true] using
-    DirectSum.isInternal_biSup_submodule_of_iSupIndep
-      (A := fun i : CompressionIndex (P := P) => angleDefectBlock hP hQ i) Set.univ
-      ((angleDefectBlock_orthogonalFamily hP hQ).independent.comp Subtype.coe_injective)
+  apply DirectSum.isInternal_biSup_submodule_of_iSupIndep
+  exact (angleDefectBlock_orthogonalFamily hP hQ).independent.comp Subtype.coe_injective
 
 /-- The defect-block sum and its orthogonal complement give the ambient orthogonal
  decomposition. -/
@@ -70,14 +72,13 @@ theorem angleDefectSum_isCompl_angleDefectComplement {P Q : E →ₗ[ℂ] E}
 theorem range_le_angleDefectSum {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     P.range ≤ angleDefectSum hP hQ := by
-  rintro x ⟨y, rfl⟩
-  rw [← (rangeCompressionEigenbasis hP hQ).toBasis.span_eq] at y
-  refine Submodule.span_induction y ?_ (Submodule.zero_mem _) ?_ ?_
-  · rintro _ ⟨i, rfl⟩
-    exact le_iSup (fun j => angleDefectBlock hP hQ j) i <|
+  rintro x hx
+  obtain ⟨c, hc⟩ :=
+    (rangeCompressionEigenbasis hP hQ).toBasis.mem_submodule_iff.mp hx
+  rw [hc]
+  exact Submodule.sum_mem _ fun i _ => Submodule.smul_mem _ _ <|
+    le_iSup (fun j => angleDefectBlock hP hQ j) i <|
       Submodule.subset_span (by left; rfl)
-  · exact fun _ _ => Submodule.add_mem _
-  · exact fun c _ => Submodule.smul_mem _ c
 
 /-- The defect-block sum is invariant under the first projection. -/
 theorem map_angleDefectSum_le_first_projection {P Q : E →ₗ[ℂ] E}
@@ -99,22 +100,21 @@ theorem map_angleDefectSum_le_second_projection {P Q : E →ₗ[ℂ] E}
 theorem map_angleDefectComplement_le_first_projection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     Submodule.map P (angleDefectComplement hP hQ) ≤ angleDefectComplement hP hQ := by
-  exact Module.End.mem_invtSubmodule_iff_map_le.mp <|
+  exact (Module.End.mem_invtSubmodule_iff_map_le (f := P)).mp <|
     hP.isSymmetric.orthogonalComplement_mem_invtSubmodule
-      (Module.End.mem_invtSubmodule_iff_map_le.mpr
+      ((Module.End.mem_invtSubmodule_iff_map_le (f := P)).mpr
         (map_angleDefectSum_le_first_projection hP hQ))
 
 /-- The orthogonal complement of the defect-block sum is invariant under the second projection. -/
 theorem map_angleDefectComplement_le_second_projection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     Submodule.map Q (angleDefectComplement hP hQ) ≤ angleDefectComplement hP hQ := by
-  exact Module.End.mem_invtSubmodule_iff_map_le.mp <|
+  exact (Module.End.mem_invtSubmodule_iff_map_le (f := Q)).mp <|
     hQ.isSymmetric.orthogonalComplement_mem_invtSubmodule
-      (Module.End.mem_invtSubmodule_iff_map_le.mpr
+      ((Module.End.mem_invtSubmodule_iff_map_le (f := Q)).mpr
         (map_angleDefectSum_le_second_projection hP hQ))
 
-/-- The first projection vanishes on the complement of the defect-block sum. -/
-theorem first_projection_apply_eq_zero_of_mem_angleDefectComplement {P Q : E →ₗ[ℂ] E}
+private theorem first_projection_apply_eq_zero {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {z : E}
     (hz : z ∈ angleDefectComplement hP hQ) : P z = 0 := by
   apply LinearMap.mem_ker.mp
@@ -126,9 +126,9 @@ theorem projections_comp_apply_eq_zero_of_mem_angleDefectComplement {P Q : E →
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {z : E}
     (hz : z ∈ angleDefectComplement hP hQ) : P (Q z) = 0 ∧ Q (P z) = 0 := by
   constructor
-  · exact first_projection_apply_eq_zero_of_mem_angleDefectComplement hP hQ <|
+  · exact first_projection_apply_eq_zero hP hQ <|
       (map_angleDefectComplement_le_second_projection hP hQ) ⟨z, hz, rfl⟩
-  · rw [first_projection_apply_eq_zero_of_mem_angleDefectComplement hP hQ hz, map_zero]
+  · rw [first_projection_apply_eq_zero hP hQ hz, map_zero]
 
 /-- The restriction of the first projection to the complementary summand. -/
 noncomputable def firstProjectionOnAngleDefectComplement {P Q : E →ₗ[ℂ] E}
@@ -142,19 +142,16 @@ noncomputable def secondProjectionOnAngleDefectComplement {P Q : E →ₗ[ℂ] E
     angleDefectComplement hP hQ →ₗ[ℂ] angleDefectComplement hP hQ :=
   Q.restrict fun _ hz => (map_angleDefectComplement_le_second_projection hP hQ) ⟨_, hz, rfl⟩
 
-/-- The first restricted projection is the zero map. -/
-theorem firstProjectionOnAngleDefectComplement_eq_zero {P Q : E →ₗ[ℂ] E}
-    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
-    firstProjectionOnAngleDefectComplement hP hQ = 0 := by
-  ext z
-  exact first_projection_apply_eq_zero_of_mem_angleDefectComplement hP hQ z.property
-
-/-- The first restricted projection remains a symmetric projection. -/
+/-- The first restricted map is idempotent and symmetric. -/
 theorem firstProjectionOnAngleDefectComplement_isSymmetricProjection {P Q : E →ₗ[ℂ] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     (firstProjectionOnAngleDefectComplement hP hQ).IsSymmetricProjection := by
-  rw [firstProjectionOnAngleDefectComplement_eq_zero hP hQ]
-  exact ⟨.zero, LinearMap.IsSymmetric.zero⟩
+  let hPinv : ∀ z ∈ angleDefectComplement hP hQ, P z ∈ angleDefectComplement hP hQ :=
+    fun z hz => (map_angleDefectComplement_le_first_projection hP hQ) ⟨z, hz, rfl⟩
+  constructor
+  · apply DFunLike.ext _ _ fun z => Subtype.ext ?_
+    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
+  · exact hP.isSymmetric.restrict_invariant hPinv
 
 /-- The second restricted projection remains a symmetric projection. -/
 theorem secondProjectionOnAngleDefectComplement_isSymmetricProjection {P Q : E →ₗ[ℂ] E}
@@ -173,7 +170,8 @@ theorem firstProjectionOnAngleDefectComplement_commute_secondProjection {P Q : E
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
     Commute (firstProjectionOnAngleDefectComplement hP hQ)
       (secondProjectionOnAngleDefectComplement hP hQ) := by
-  rw [firstProjectionOnAngleDefectComplement_eq_zero hP hQ]
-  exact Commute.zero_left _
+  apply DFunLike.ext _ _ fun z => Subtype.ext ?_
+  exact (projections_comp_apply_eq_zero_of_mem_angleDefectComplement hP hQ z.property).1.trans
+    (projections_comp_apply_eq_zero_of_mem_angleDefectComplement hP hQ z.property).2.symm
 
 end LinearMap.IsSymmetricProjection

--- a/TNLean/Analysis/TwoProjectionDefectBlockSum.lean
+++ b/TNLean/Analysis/TwoProjectionDefectBlockSum.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.TwoProjectionAngleOrthogonality
+import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
+import Mathlib.Analysis.InnerProductSpace.Semisimple
+
+/-!
+# Orthogonal sum of two-projection defect blocks
+
+The defect blocks indexed by the compression eigenbasis form an orthogonal internal sum. Their
+sum and its orthogonal complement are invariant under both projections. The first projection
+vanishes on the complement, and therefore the two restricted projections commute there even
+though the original projections need not commute.
+
+This is the orthogonal-sum and commuting-remainder part of Jordan's lemma used in
+arXiv:1703.09188, Proposition IV.5 (`prop:continuity-index`), lines 759–762.
+
+**Local fix (projector label):** Source line 762 repeats `P` for the second projector, where the
+surrounding argument requires `Q`; see `docs/paper-gaps/1703_two_projection_projector_typo.tex`.
+-/
+
+open scoped InnerProductSpace
+
+namespace LinearMap.IsSymmetricProjection
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+private abbrev CompressionIndex {P : E →ₗ[ℂ] E} := Fin (Module.finrank ℂ P.range)
+
+/-- The supremum of the defect blocks indexed by the full compression eigenbasis. -/
+noncomputable def angleDefectSum {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) : Submodule ℂ E :=
+  ⨆ i, angleDefectBlock hP hQ i
+
+/-- The orthogonal complement of the sum of all compression defect blocks. -/
+noncomputable def angleDefectComplement {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) : Submodule ℂ E :=
+  (angleDefectSum hP hQ)ᗮ
+
+/-- The compression-indexed defect blocks form an orthogonal family. -/
+theorem angleDefectBlock_orthogonalFamily {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    OrthogonalFamily ℂ (fun i : CompressionIndex (P := P) => angleDefectBlock hP hQ i)
+      (fun i => (angleDefectBlock hP hQ i).subtypeₗᵢ) :=
+  OrthogonalFamily.of_pairwise fun _ _ hij => angleDefectBlock_isOrtho hP hQ hij
+
+/-- After lifting each block to the defect-block sum, the family is an internal direct sum. -/
+theorem angleDefectBlock_isInternal {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    DirectSum.IsInternal (fun i : CompressionIndex (P := P) =>
+      (angleDefectBlock hP hQ i).comap (angleDefectSum hP hQ).subtype) := by
+  classical
+  simpa only [angleDefectSum, iSup_true] using
+    DirectSum.isInternal_biSup_submodule_of_iSupIndep
+      (A := fun i : CompressionIndex (P := P) => angleDefectBlock hP hQ i) Set.univ
+      (angleDefectBlock_orthogonalFamily hP hQ).independent
+
+/-- The defect-block sum and its orthogonal complement give the ambient orthogonal
+ decomposition. -/
+theorem angleDefectSum_isCompl_angleDefectComplement {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    IsCompl (angleDefectSum hP hQ) (angleDefectComplement hP hQ) := by
+  rw [angleDefectComplement]
+  exact Submodule.isCompl_orthogonal
+
+/-- The range of the first projection lies in the sum of the compression defect blocks. -/
+theorem range_le_angleDefectSum {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    P.range ≤ angleDefectSum hP hQ := by
+  rw [← (rangeCompressionEigenbasis hP hQ).toBasis.span_eq, Submodule.span_le]
+  rintro x ⟨i, rfl⟩
+  exact le_iSup (fun j => angleDefectBlock hP hQ j) i <|
+    Submodule.subset_span (by left; rfl)
+
+/-- The defect-block sum is invariant under the first projection. -/
+theorem map_angleDefectSum_le_first_projection {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    Submodule.map P (angleDefectSum hP hQ) ≤ angleDefectSum hP hQ := by
+  rw [angleDefectSum, Submodule.map_iSup]
+  exact iSup_mono fun i => (map_angleDefectBlock_le_first_projection hP hQ i).trans
+    (le_iSup (fun j => angleDefectBlock hP hQ j) i)
+
+/-- The defect-block sum is invariant under the second projection. -/
+theorem map_angleDefectSum_le_second_projection {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    Submodule.map Q (angleDefectSum hP hQ) ≤ angleDefectSum hP hQ := by
+  rw [angleDefectSum, Submodule.map_iSup]
+  exact iSup_mono fun i => (map_angleDefectBlock_le_second_projection hP hQ i).trans
+    (le_iSup (fun j => angleDefectBlock hP hQ j) i)
+
+/-- The orthogonal complement of the defect-block sum is invariant under the first projection. -/
+theorem map_angleDefectComplement_le_first_projection {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    Submodule.map P (angleDefectComplement hP hQ) ≤ angleDefectComplement hP hQ := by
+  rw [Module.End.mem_invtSubmodule_iff_map_le]
+  exact hP.isSymmetric.orthogonalComplement_mem_invtSubmodule
+    (Module.End.mem_invtSubmodule_iff_map_le.mpr
+      (map_angleDefectSum_le_first_projection hP hQ))
+
+/-- The orthogonal complement of the defect-block sum is invariant under the second projection. -/
+theorem map_angleDefectComplement_le_second_projection {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    Submodule.map Q (angleDefectComplement hP hQ) ≤ angleDefectComplement hP hQ := by
+  rw [Module.End.mem_invtSubmodule_iff_map_le]
+  exact hQ.isSymmetric.orthogonalComplement_mem_invtSubmodule
+    (Module.End.mem_invtSubmodule_iff_map_le.mpr
+      (map_angleDefectSum_le_second_projection hP hQ))
+
+/-- The first projection vanishes on the complement of the defect-block sum. -/
+theorem first_projection_apply_eq_zero_of_mem_angleDefectComplement {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {z : E}
+    (hz : z ∈ angleDefectComplement hP hQ) : P z = 0 := by
+  rw [← hP.isSymmetric.orthogonal_range]
+  exact Submodule.orthogonal_le (range_le_angleDefectSum hP hQ) hz
+
+/-- Both compositions agree, and vanish, on the complement of the defect-block sum. -/
+theorem projections_comp_apply_eq_zero_of_mem_angleDefectComplement {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {z : E}
+    (hz : z ∈ angleDefectComplement hP hQ) : P (Q z) = 0 ∧ Q (P z) = 0 := by
+  constructor
+  · exact first_projection_apply_eq_zero_of_mem_angleDefectComplement hP hQ <|
+      (map_angleDefectComplement_le_second_projection hP hQ) ⟨z, hz, rfl⟩
+  · rw [first_projection_apply_eq_zero_of_mem_angleDefectComplement hP hQ hz, map_zero]
+
+/-- The restriction of the first projection to the complementary summand. -/
+noncomputable def firstProjectionOnAngleDefectComplement {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    angleDefectComplement hP hQ →ₗ[ℂ] angleDefectComplement hP hQ :=
+  P.restrict fun _ hz => (map_angleDefectComplement_le_first_projection hP hQ) ⟨_, hz, rfl⟩
+
+/-- The restriction of the second projection to the complementary summand. -/
+noncomputable def secondProjectionOnAngleDefectComplement {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    angleDefectComplement hP hQ →ₗ[ℂ] angleDefectComplement hP hQ :=
+  Q.restrict fun _ hz => (map_angleDefectComplement_le_second_projection hP hQ) ⟨_, hz, rfl⟩
+
+/-- The first restricted projection is the zero map. -/
+theorem firstProjectionOnAngleDefectComplement_eq_zero {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    firstProjectionOnAngleDefectComplement hP hQ = 0 := by
+  ext z
+  apply Subtype.ext
+  exact first_projection_apply_eq_zero_of_mem_angleDefectComplement hP hQ z.property
+
+/-- The first restricted projection remains a symmetric projection. -/
+theorem firstProjectionOnAngleDefectComplement_isSymmetricProjection {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    (firstProjectionOnAngleDefectComplement hP hQ).IsSymmetricProjection := by
+  rw [firstProjectionOnAngleDefectComplement_eq_zero hP hQ]
+  exact ⟨isIdempotentElem_zero, LinearMap.isSymmetric_zero⟩
+
+/-- The second restricted projection remains a symmetric projection. -/
+theorem secondProjectionOnAngleDefectComplement_isSymmetricProjection {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    (secondProjectionOnAngleDefectComplement hP hQ).IsSymmetricProjection := by
+  let hQinv : ∀ z ∈ angleDefectComplement hP hQ, Q z ∈ angleDefectComplement hP hQ :=
+    fun z hz => (map_angleDefectComplement_le_second_projection hP hQ) ⟨z, hz, rfl⟩
+  constructor
+  · apply DFunLike.ext _ _ fun z => Subtype.ext ?_
+    exact hQ.isIdempotentElem.apply_apply z
+  · exact hQ.isSymmetric.restrict_invariant hQinv
+
+/-- The restricted projections commute on the complementary summand. This conclusion does not
+assume that the original projections commute on the ambient space. -/
+theorem firstProjectionOnAngleDefectComplement_commute_secondProjection {P Q : E →ₗ[ℂ] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) :
+    Commute (firstProjectionOnAngleDefectComplement hP hQ)
+      (secondProjectionOnAngleDefectComplement hP hQ) := by
+  rw [firstProjectionOnAngleDefectComplement_eq_zero hP hQ]
+  exact Commute.zero_left _
+
+end LinearMap.IsSymmetricProjection

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5553,7 +5553,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{prop:continuity-index}
   \notready
   \discussion{6022}
-  \uses{def:mpu_canonical_form,ThmFund1,thm:mpu_two_projection_angle_block,
+  \uses{def:mpu_canonical_form,ThmFund1,
+    thm:mpu_two_projection_angle_defect_sum,
     thm:mpu_two_projection_reduced_projection,
     thm:mpu_two_projection_reduced_projection_right_factor}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5423,7 +5423,6 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     LinearMap.IsSymmetricProjection.map_angleDefectSum_le_second_projection,
     LinearMap.IsSymmetricProjection.map_angleDefectComplement_le_first_projection,
     LinearMap.IsSymmetricProjection.map_angleDefectComplement_le_second_projection,
-    LinearMap.IsSymmetricProjection.first_projection_apply_eq_zero_of_mem_angleDefectComplement,
     LinearMap.IsSymmetricProjection.projections_comp_apply_eq_zero_of_mem_angleDefectComplement,
     LinearMap.IsSymmetricProjection.firstProjectionOnAngleDefectComplement,
     LinearMap.IsSymmetricProjection.secondProjectionOnAngleDefectComplement,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5430,8 +5430,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     LinearMap.IsSymmetricProjection.secondProjectionOnAngleDefectComplement_isSymmetricProjection,
     LinearMap.IsSymmetricProjection.firstProjectionOnAngleDefectComplement_commute_secondProjection}
   \leanok
-  \uses{def:mpu_two_projection_angle_defect_sum,
-    thm:mpu_two_projection_angle_block_orthogonality}
+  \uses{def:mpu_two_projection_angle_defect_sum}
   The blocks $(B_i)_i$ form an orthogonal internal direct sum in $B$, and
   \begin{align}
     E&=B\mathbin{\perp\!\oplus}K.
@@ -5449,6 +5448,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{thm:mpu_two_projection_angle_block_orthogonality}
   Pairwise orthogonality of the blocks implies independence, while their
   supremum is $B$ by definition. Hence they form an internal direct sum in
   $B$. The standard orthogonal-complement decomposition gives

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5398,7 +5398,71 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   $B_i=\operatorname{span}\{x_i,d_i\}$. Its dimension bound follows from
   its two generators.
 \end{proof}
+\begin{definition}[Defect-block sum and complementary summand]
+  \label{def:mpu_two_projection_angle_defect_sum}
+  \lean{LinearMap.IsSymmetricProjection.angleDefectSum,
+    LinearMap.IsSymmetricProjection.angleDefectComplement}
+  \leanok
+  \uses{def:mpu_two_projection_angle_defect_block}
+  For the compression defect blocks $(B_i)_i$, define
+  \begin{align}
+    B&=\bigvee_i B_i,&K&=B^\perp.
+  \end{align}
+  The index $i$ ranges over every vector in the chosen compression eigenbasis,
+  including repeated eigenvalues and the endpoint eigenvalues $0$ and $1$.
+  % Source lines: paper_v2.tex 759--762.
+\end{definition}
 
+\begin{theorem}[Orthogonal defect-block sum and commuting remainder]
+  \label{thm:mpu_two_projection_angle_defect_sum}
+  \lean{LinearMap.IsSymmetricProjection.angleDefectBlock_orthogonalFamily,
+    LinearMap.IsSymmetricProjection.angleDefectBlock_isInternal,
+    LinearMap.IsSymmetricProjection.angleDefectSum_isCompl_angleDefectComplement,
+    LinearMap.IsSymmetricProjection.range_le_angleDefectSum,
+    LinearMap.IsSymmetricProjection.map_angleDefectSum_le_first_projection,
+    LinearMap.IsSymmetricProjection.map_angleDefectSum_le_second_projection,
+    LinearMap.IsSymmetricProjection.map_angleDefectComplement_le_first_projection,
+    LinearMap.IsSymmetricProjection.map_angleDefectComplement_le_second_projection,
+    LinearMap.IsSymmetricProjection.first_projection_apply_eq_zero_of_mem_angleDefectComplement,
+    LinearMap.IsSymmetricProjection.projections_comp_apply_eq_zero_of_mem_angleDefectComplement,
+    LinearMap.IsSymmetricProjection.firstProjectionOnAngleDefectComplement,
+    LinearMap.IsSymmetricProjection.secondProjectionOnAngleDefectComplement,
+    LinearMap.IsSymmetricProjection.firstProjectionOnAngleDefectComplement_isSymmetricProjection,
+    LinearMap.IsSymmetricProjection.secondProjectionOnAngleDefectComplement_isSymmetricProjection,
+    LinearMap.IsSymmetricProjection.firstProjectionOnAngleDefectComplement_commute_secondProjection}
+  \leanok
+  \uses{def:mpu_two_projection_angle_defect_sum,
+    thm:mpu_two_projection_angle_block_orthogonality}
+  The blocks $(B_i)_i$ form an orthogonal internal direct sum in $B$, and
+  \begin{align}
+    E&=B\mathbin{\perp\!\oplus}K.
+  \end{align}
+  Both $B$ and $K$ are invariant under $P$ and $Q$. Moreover,
+  $\operatorname{ran}P\subseteq B$, so for every $z\in K$,
+  \begin{align}
+    Pz&=0,&P(Qz)&=0,&Q(Pz)&=0.
+  \end{align}
+  Consequently the restrictions $P|_K$ and $Q|_K$ are orthogonal projections
+  and commute. No commutation of $P$ and $Q$ on the ambient space is assumed.
+  % Source lines: paper_v2.tex 759--762.
+  % Local correction: line 762 repeats P where Q is intended; see
+  % docs/paper-gaps/1703_two_projection_projector_typo.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+  Pairwise orthogonality of the blocks implies independence, while their
+  supremum is $B$ by definition. Hence they form an internal direct sum in
+  $B$. The standard orthogonal-complement decomposition gives
+  $E=B\mathbin{\perp\!\oplus}B^\perp$.
+
+  The local action formulas show that each $B_i$ is invariant under both
+  projections, hence so is $B$. Symmetry of each projection then makes
+  $K=B^\perp$ invariant. The compression eigenvectors form a basis of
+  $\operatorname{ran}P$, and each lies in its block $B_i$; therefore
+  $\operatorname{ran}P\subseteq B$. Thus $P$ vanishes on $K$. Since $Qz\in K$
+  whenever $z\in K$, both $P(Qz)$ and $Q(Pz)$ vanish. The two restricted
+  projections therefore commute.
+\end{proof}
 \begin{definition}[Reduced projection]
   \label{def:mpu_two_projection_reduced_projection}
   \lean{LinearMap.IsSymmetricProjection.reducedProjection}

--- a/docs/paper-gaps/1703_two_projection_projector_typo.tex
+++ b/docs/paper-gaps/1703_two_projection_projector_typo.tex
@@ -32,9 +32,13 @@ The generic angle-block declarations
 \leanid{LinearMap.IsSymmetricProjection.angleDefect_block} and
 \leanid{LinearMap.IsSymmetricProjection.exists_orthonormal_angle_block}
 therefore use symmetric projections $P$ and $Q$. They prove the exact local
-action of both operators on a generic two-dimensional block. This is a local
-correction of a typographical error and does not add a hypothesis or alter the
-mathematical claim.
+action of both operators on a generic two-dimensional block. The declarations
+\leanid{LinearMap.IsSymmetricProjection.angleDefectSum} and
+\leanid{LinearMap.IsSymmetricProjection.angleDefectComplement} assemble the
+compression-indexed blocks into an orthogonal internal sum and its invariant
+orthogonal complement. On that complement, the restricted projections commute.
+This is a local correction of a typographical error and does not add a
+hypothesis or alter the mathematical claim.
 
 The declaration
 \leanid{LinearMap.IsSymmetricProjection.reducedProjection} defines the reduced
@@ -52,12 +56,15 @@ theorem, which gives the invertible map from line 770.
 
 \section{Verdict}
 
-\textbf{Verdict: resolved local fix (projector label and reduced projector).}
+\textbf{Verdict: resolved local fix.}
 The formalized angle block uses $Q$ as the second projector, which resolves the
 source's repeated $P$ label without changing the mathematical statement. The
+compression-indexed blocks, including endpoint coordinates, are assembled into
+an orthogonal internal sum with a commuting complementary remainder. The
 reduced projector and its identities from lines 764--770 are also formalized.
-The distinct global problem of assembling the generic and endpoint blocks into
-an orthogonal direct sum remains open.
+The coordinate-free reduced projector has not been identified with the source's
+particular blockwise projector; no such identification is needed for its proved
+absorption and range identities.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- form the orthogonal internal sum of compression defect blocks and its complementary summand
- prove both summands invariant under the two symmetric projections
- show the first projection vanishes on the complement, both mixed compositions vanish there, and the restricted projections commute
- package the restricted symmetric projections and source-faithful Chapter 28 coverage

The individual restriction of the second projection need not vanish because common endpoint spaces can survive in the complement. This PR does not identify the coordinate-free reduced projector with a blockwise projector or prove MPU rank continuity.

## Validation

- `lake build TNLean.Analysis.TwoProjectionDefectBlockSum TNLean.Analysis`
- generated import aggregators
- blueprint sync and `leanblueprint checkdecls` at 7629/7629
- proof-integrity scan
- `git diff --check`

Closes #6382
Advances #6294
Advances #6259
