### PR TITLE
docs(parent-hamiltonian): apply seventh review follow-up

### DIFF
--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -54,7 +54,7 @@ lemma blockPhysDim_eq_pow (d L : ℕ) : blockPhysDim d L = d ^ L := by
   -- `Fintype.card_fun` gives `card (α → β) = card β ^ card α`.
   simp [Fintype.card_fin]
 
-/-- Blocking a nonempty physical alphabet preserves nonemptiness of its physical dimension. -/
+/-- Blocking preserves nonzero physical dimensions. -/
 instance instNeZeroBlockPhysDim [NeZero d] : NeZero (blockPhysDim d L) := ⟨by
   rw [blockPhysDim_eq_pow]
   exact pow_ne_zero L (NeZero.ne d)⟩

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -1591,6 +1591,8 @@ norm estimate is derived here.
     \lean{MPSTensor.c3CenteredVirtualResidualES}
     \leanok
     \uses{def:fixed_point_proj, def:gram_reshuffle,
+        def:whole_increment_left_overlap_factor,
+        def:whole_increment_right_overlap_factor,
         thm:spectator_boundary_hilbert_factorization}
     Let $A$ be an MPS tensor, let $\Omega_K$ be the set of length-$K$ words
     in the physical alphabet, and let
@@ -1633,7 +1635,10 @@ norm estimate is derived here.
     \lean{MPSTensor.IsPrimitiveMPS.c3_centeredVirtualResidualES_norm_sq_le_geometric}
     \leanok
     \uses{def:c3_centered_overlap_factors_residual, def:ground_space_gram,
-        def:primitive_mps}
+        def:primitive_mps,
+        thm:whole_increment_left_overlap_factor_apply,
+        thm:whole_increment_right_overlap_factor_apply,
+        thm:whole_increment_overlap_factor_norms}
     For every $K\in\N$, the common overlap factors have fiber formulas
     \begin{align}
         (F_KX)_{u,j}&=A^jX_u,&
@@ -1678,6 +1683,9 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{thm:c3_projector_gram_error_telescope,
+        thm:whole_increment_left_overlap_factor_apply,
+        thm:whole_increment_right_overlap_factor_apply,
+        thm:whole_increment_overlap_factor_norms,
         thm:boundary_fiberwise_map_norm,
         thm:primitive_ground_space_gram_geometric_fixed_point,
         thm:primitive_tail_virtual_map_norm_uniform}
@@ -2222,11 +2230,12 @@ norm estimate is derived here.
     \uses{thm:three_block_whole_increment_defect_seven_sixteenths,
         thm:friedrichs_ground_space_excitation_anticommutator,
         thm:three_site_anticommutator_cyclic_transport}
-    Let $A$ be a primitive MPS tensor and let $p>0$ be a blocking length.
-    For $B=\operatorname{block}_p(A)$, the defect of the two open-chain
+    Let $A$ be an MPS tensor with nonzero physical dimension, and let $p$ be
+    any blocking length.  For $B=\operatorname{block}_p(A)$, the defect of the
+    two open-chain
     ground-space projectors on three sites of $B$ is exactly the defect of the
-    corresponding three consecutive $p$-site regions of $A$.  In particular,
-    the bound
+    corresponding three consecutive $p$-site regions of $A$.  If $B$ is
+    injective, then the bound
     \begin{align}
         \left\lVert
           P^{\mathrm{tail}}_{1,2}(B)P^{\mathrm{left}}_2(B)
@@ -2248,6 +2257,8 @@ norm estimate is derived here.
     \lean{MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth,
         MPSTensor.IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped}
     \leanok
+    \uses{def:primitive_mps, def:l_blk_injective, def:blocked_tensor,
+        def:parent_ground_space_es, def:parent_hamiltonian_es}
     Let $A$ be a primitive MPS tensor with nonzero physical and bond dimensions,
     and suppose that its fixed point is positive definite.  There is a blocking
     length $p>0$ such that $A$ is $p$-block injective and, with
@@ -2262,8 +2273,7 @@ norm estimate is derived here.
 \begin{proof}
     \leanok
     \uses{lem:blocked_to_cyclic_ground_projector_comparison,
-        lem:parent_hamiltonian_cyclic_overlap_anticommutator_gap,
-        thm:parent_hamiltonian_gapped}
+        lem:parent_hamiltonian_cyclic_overlap_anticommutator_gap}
     Choose $p$ so that the three-block projector defect is at most $7/16$.
     Lemma~\ref{lem:blocked_to_cyclic_ground_projector_comparison} gives the same
     coefficient for every overlapping cyclic pair.  For range two each row has

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -875,11 +875,12 @@ abstracted — record why, so it is not re-proposed).
   multi-second declarations fall below the one-second profiler threshold.
 
 ### Blocked physical-dimension nonzeroness and explicit-gap specialization
-- **Pattern:** `Martingale/BlockedGap.lean` repeated the same three-line construction
-  of `NeZero (blockPhysDim d p)` four times, and the qualitative blocked-gap theorem
-  repeated the anticommutator route already used by the preceding explicit-gap theorem.
-- **Reuse:** `TNLean/MPS/Core/Blocking.lean` now provides the canonical instance
-  `MPSTensor.instNeZeroBlockPhysDim`. The four local calculations are removed.
+- **Pattern:** four local calculations in `Martingale/BlockedGap.lean` repeated the same
+  three-line construction of `NeZero (blockPhysDim d p)`, and the qualitative blocked-gap
+  theorem repeated the anticommutator route already used by the preceding explicit-gap theorem.
+- **Reuse:** `TNLean/MPS/Core/Blocking.lean` now provides the instance
+  `MPSTensor.instNeZeroBlockPhysDim`, replacing exactly those four local calculations in
+  `Martingale/BlockedGap.lean`.
   `IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gapped` is now a thin
   corollary of `IsPrimitiveMPS.exists_blockTensor_parentHamiltonianES_gap_eighth`,
   using `1 / 8` as the positive gap witness.


### PR DESCRIPTION
## What changed

- restore the C3 projector Gram-error dependency while retaining the new canonical whole-increment dependencies
- align the blocked-comparison Blueprint statement with its Lean declaration
- clarify the global blocked physical-dimension instance and its four-call-site refactor ledger entry

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/generate_import_aggregators.py --check` (53 generated files, 1403 production modules)
- `bash scripts/tenkz_golden.sh --check` (9/9 event streams byte-identical)
- exact-head targeted Lean build reviewed green at 8845 jobs
- `git diff --check`

Closes #6403
