### PR TITLE
feat(MPS/MPDO): prove R transfer non-nilpotency

### DIFF
--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.LengthIndependentCoefficients
 import Mathlib.Analysis.Matrix.Order
+import Mathlib.RingTheory.Nilpotent.Basic
 
 /-!
 # A rescaling-stable length-dependent coefficient family
@@ -15,6 +16,7 @@ of the project example motivated by arXiv:1606.00608, Theorem 4.14 and lines
 
 * `physTraceTransfer_R_idempotent` — the physical-trace transfer of `R` is
   idempotent (rank‑1 projector $(25/32)\,|t\rangle\langle t|$ with $t_a = \operatorname{tr}(A^a)$);
+* `physTraceTransfer_R_not_isNilpotent` — this nonzero idempotent is not nilpotent;
 * `oneLabelCoeffs_not_lengthIndependent` — the one-label BNT coefficient
   family `c^{(L)} = 1 + (7/25)^L` (on `χ = diag(1, 7/25)`) is not
   length-independent;
@@ -194,6 +196,22 @@ theorem physTraceTransfer_R_idempotent :
       simp [Finset.mul_sum]
     _ = ((25/32 : ℂ) ^ 2) * Matrix.trace (A a) * Matrix.trace (A b) * (32/25 : ℂ) := by rw [hsum]
     _ = (25/32 : ℂ) * Matrix.trace (A a) * Matrix.trace (A b) := by ring
+
+/-- The physical-trace transfer of `R` is not nilpotent.  It is a nonzero
+idempotent: its `(0, 0)` entry is `1/2`, so nilpotency would contradict
+`physTraceTransfer_R_idempotent`.
+
+This is the non-nilpotency condition of arXiv:1606.00608, Definition 4.7,
+lines 815--822, for the unnormalized horizontal tensor of this project example.
+It does not assert `MPOTensor.IsSimple R`, whose canonical-form normalization
+has additional requirements. -/
+theorem physTraceTransfer_R_not_isNilpotent :
+    ¬ IsNilpotent (physTraceTransfer R) := by
+  intro hnil
+  have hidem : IsIdempotentElem (physTraceTransfer R) := physTraceTransfer_R_idempotent
+  have hzero := hidem.eq_zero_of_isNilpotent hnil
+  have hentry := congrFun (congrFun hzero (0 : Fin 4)) (0 : Fin 4)
+  simp [physTraceTransfer_R_entry, A_trace] at hentry
 
 /-! ### The tensor and its transfer -/
 

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFP
+import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.RFP.BeigiLoopBNTIdentification
 
 /-!
@@ -59,6 +60,8 @@ full ambient bond dimension `4` and a trivial (identity) coisometry
   matrix algebra.
 * `retainedBlock_isNormalTensor` : the weight-normalized retained tensor is a CPSV
   normal tensor.
+* `doubledPhysTraceTransfer_retainedBlock_not_isNilpotent` : the retained block's
+  ket-against-bra contraction is not nilpotent.
 * `R_toMPSTensor_isCPSVCanonicalForm` : `R.toMPSTensor` is in literal CPSV canonical
   form.
 
@@ -284,6 +287,35 @@ lemma weight_sq_C : (weight : ℂ) ^ 2 = 337/512 := by
 single retained block of the literal CPSV canonical form
 (`R_toMPSTensor_isCPSVCanonicalForm`). -/
 def retainedBlock : MPSTensor 16 4 := fun i => (weight⁻¹ : ℂ) • R.toMPSTensor i
+
+/-- The retained block's doubled physical-trace transfer is the inverse-weight
+rescaling of the physical-trace transfer of `R`. -/
+lemma doubledPhysTraceTransfer_retainedBlock :
+    MPOTensor.doubledPhysTraceTransfer 4 retainedBlock =
+      (weight⁻¹ : ℂ) • MPOTensor.physTraceTransfer R := by
+  rw [MPOTensor.doubledPhysTraceTransfer]
+  change (∑ i : Fin 4, (weight⁻¹ : ℂ) • R.toMPSTensor (finProdFinEquiv (i, i))) = _
+  rw [← Finset.smul_sum]
+  congr 1
+
+/-- The ket-against-bra contraction of the retained horizontal block is not
+nilpotent.  It is the nonzero scalar multiple `weight⁻¹ • physTraceTransfer R`,
+so multiplying a hypothetical nilpotent by `weight` would make
+`physTraceTransfer R` nilpotent.
+
+This is the basis-element non-nilpotency condition of arXiv:1606.00608,
+Definition 4.7, lines 815--822, for the single retained block of this project
+example.  It does not assert `MPOTensor.IsSimple R`, whose definition also
+includes canonical-form normalization requirements. -/
+theorem doubledPhysTraceTransfer_retainedBlock_not_isNilpotent :
+    ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer 4 retainedBlock) := by
+  rw [doubledPhysTraceTransfer_retainedBlock]
+  intro hnil
+  have hscaled := hnil.smul (weight : ℂ)
+  rw [smul_smul] at hscaled
+  have hw : (weight : ℂ) ≠ 0 := by exact_mod_cast weight_ne
+  rw [mul_inv_cancel₀ hw, one_smul] at hscaled
+  exact physTraceTransfer_R_not_isNilpotent hscaled
 
 /-- `transferMap retainedBlock` is `(weight : ℂ)⁻¹ ^ 2` times `transferMap R.toMPSTensor`,
 since the transfer map is quadratic in the tensor and `weight⁻¹` is real. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -870,6 +870,56 @@
     trivial (identity) coisometry.
 \end{proof}
 
+\begin{theorem}[Non-nilpotency of the retained horizontal block]%
+    \label{thm:mpdo_bnt_label_rescaling_stable_non_nilpotent}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        physTraceTransfer_R_not_isNilpotent}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        doubledPhysTraceTransfer_retainedBlock}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        doubledPhysTraceTransfer_retainedBlock_not_isNilpotent}
+    \leanok
+    \uses{def:mpdo_doubled_phys_trace_transfer, def:mpdo_simple_tensor,
+        thm:mpdo_bnt_label_rescaling_stable_length_dependence,
+        thm:mpdo_bnt_label_rescaling_stable_cf}
+    Let $\widehat R=\mu^{-1}R^{\bullet\bullet}$ be the single retained normal
+    block in the displayed canonical form, where
+    $\mu=\sqrt{337/512}$. Then
+    \begin{align}
+        \mathcal T_{\widehat R}&=\mu^{-1}\mathcal T_R, &
+        \mathcal T_R^2&=\mathcal T_R, &
+        (\mathcal T_R)_{00}&=\frac12.
+        \notag
+    \end{align}
+    Consequently neither $\mathcal T_R$ nor
+    $\mathcal T_{\widehat R}$ is nilpotent. Thus the retained basis element
+    satisfies the non-nilpotency clause in the definition of a simple tensor.
+
+    This conclusion concerns only that clause for the displayed one-block
+    presentation; it does not assert that $R$ satisfies the project's full
+    simple-tensor predicate. In particular, that predicate requires a
+    unit-weight BNT canonical-form witness, whereas the displayed retained
+    decomposition has the non-unit weight $\mu=\sqrt{337/512}$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpdo_doubled_phys_trace_transfer,
+        thm:mpdo_bnt_label_rescaling_stable_length_dependence,
+        thm:mpdo_bnt_label_rescaling_stable_cf}
+    A nilpotent idempotent is zero, but the $(0,0)$ entry of
+    $\mathcal T_R$ is
+    \begin{align}
+        \frac{25}{32}\tr(A^0)^2
+            =\frac{25}{32}\left(\frac45\right)^2
+            =\frac12,
+        \notag
+    \end{align}
+    so $\mathcal T_R$ is not nilpotent. The diagonal physical contraction is
+    linear in the tensor, which gives
+    $\mathcal T_{\widehat R}=\mu^{-1}\mathcal T_R$. Since $\mu>0$, a
+    nilpotent $\mathcal T_{\widehat R}$ would remain nilpotent after
+    multiplication by $\mu$, forcing $\mathcal T_R$ to be nilpotent.
+\end{proof}
+
 \begin{theorem}[The rescaling-stable tensor is a renormalization fixed
     point]%
     \label{thm:mpdo_bnt_label_rescaling_stable_is_rfp_via_ts}


### PR DESCRIPTION
## Summary

- prove that the physical-trace transfer of the project example `R` is not nilpotent, using its nonzero idempotence
- identify the retained canonical block's doubled physical-trace transfer as `weight⁻¹` times that transfer
- prove the retained block contraction is not nilpotent by scalar transport
- state the CPSV16 Definition 4.7 scope explicitly without claiming `MPOTensor.IsSimple R`

Closes #6394.

## Source and scope

The two statements formalize the non-nilpotency clause in arXiv:1606.00608, Definition 4.7, lines 815--822, for the unnormalized horizontal tensor and its single weight-normalized retained block. They do not assert `MPOTensor.IsSimple R`; that predicate carries additional canonical-form normalization requirements tracked separately.

## Checks

- `lake env lean TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean`
- `lake env lean TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean`
- proof-integrity scan on both changed files
- changed-line 100-character check
- `git diff --check`
