### PR TITLE
feat(Channel): generalize isometric charpoly padding

### DIFF
--- a/TNLean/Channel/SingleKrausPositivity.lean
+++ b/TNLean/Channel/SingleKrausPositivity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixUnitaryBetween
 import TNLean.Channel.KrausCPTP
 import Mathlib.LinearAlgebra.Matrix.Rank
 
@@ -20,6 +21,10 @@ isometry.
   Kronecker products.
 * `Matrix.singleKrausMap_mul_of_isometry`: isometric single-Kraus conjugation
   preserves multiplication.
+* `Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry`: isometric conjugation pads the
+  characteristic polynomial by zero roots.
+* `Matrix.singleKrausMap_charpoly_roots_eq_zero_add_of_isometry`: the corresponding root-multiset
+  identity.
 * `Matrix.posSemidef_of_singleKraus_isometry`: positivity can be read back
   through an isometric single-Kraus conjugation.
 -/
@@ -62,6 +67,28 @@ theorem Matrix.singleKrausMap_mul_of_isometry
   simp only [singleKrausMap_apply, Matrix.mul_assoc]
   rw [← Matrix.mul_assoc Vᴴ V, hV]
   simp
+
+/-- Isometric single-Kraus conjugation pads the characteristic polynomial by zero roots whose
+multiplicity is the codimension of the isometric inclusion. -/
+theorem Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) (A : Matrix α α ℂ) :
+    (singleKrausMap V A).charpoly =
+      Polynomial.X ^ (Fintype.card β - Fintype.card α) * A.charpoly := by
+  rw [singleKrausMap_apply, Matrix.mul_assoc,
+    Matrix.charpoly_mul_comm_of_le V (A * Vᴴ) (Matrix.IsIsometry.card_le V hV),
+    Matrix.mul_assoc, hV, Matrix.mul_one]
+
+/-- The roots after isometric single-Kraus conjugation are the original roots together with one
+zero for every dimension added by the isometric inclusion. -/
+theorem Matrix.singleKrausMap_charpoly_roots_eq_zero_add_of_isometry
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) (A : Matrix α α ℂ) :
+    (singleKrausMap V A).charpoly.roots =
+      (Fintype.card β - Fintype.card α) • {(0 : ℂ)} + A.charpoly.roots := by
+  rw [Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry V hV A,
+    Polynomial.roots_mul, Polynomial.roots_X_pow]
+  exact mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero) (Matrix.charpoly_monic A).ne_zero
 
 /-- Positivity can be read back through an isometric single-Kraus
 conjugation. -/

--- a/TNLean/MPS/MPDO/CPSVExample411Spectrum.lean
+++ b/TNLean/MPS/MPDO/CPSVExample411Spectrum.lean
@@ -165,28 +165,25 @@ theorem ambient_charpoly_eq_X_pow_mul_effective {L : ℕ} (hL4 : L ≤ 4) :
   rw [CPSVExample411Ambient.ambientM,
     reducedBlockState_changePhysicalBasis_of_isometry CPSVExample411Ambient.inclusion
       CPSVExample411Ambient.inclusion_isometry,
-    singleKrausMap_apply, Matrix.mul_assoc]
-  rw [Matrix.charpoly_mul_comm_of_le
-    (sitewisePhysicalMatrix CPSVExample411Ambient.inclusion L)
-    (reducedBlockState CPSVExample411BinarySupport.M 4 L hL4 *
-      (sitewisePhysicalMatrix CPSVExample411Ambient.inclusion L)ᴴ)]
-  · simp only [Fintype.card_fun, Fintype.card_fin]
-    rw [Matrix.mul_assoc,
-      sitewisePhysicalMatrix_isometry CPSVExample411Ambient.inclusion
-        CPSVExample411Ambient.inclusion_isometry,
-      Matrix.mul_one]
-  · simp only [Fintype.card_fun, Fintype.card_fin]
-    exact Nat.pow_le_pow_left (by omega) L
+    Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry
+      (sitewisePhysicalMatrix CPSVExample411Ambient.inclusion L)
+      (sitewisePhysicalMatrix_isometry CPSVExample411Ambient.inclusion
+        CPSVExample411Ambient.inclusion_isometry L)]
+  simp only [Fintype.card_fun, Fintype.card_fin]
 
 /-- The full ambient root multiset consists of $4^L-2^L$ zeros followed by the effective roots. -/
 theorem ambient_charpoly_roots_eq_zero_add_effective {L : ℕ} (hL4 : L ≤ 4) :
     (reducedBlockState CPSVExample411Ambient.ambientM 4 L hL4).charpoly.roots =
       (4 ^ L - 2 ^ L) • {(0 : ℂ)} +
         (reducedBlockState CPSVExample411BinarySupport.M 4 L hL4).charpoly.roots := by
-  rw [ambient_charpoly_eq_X_pow_mul_effective hL4, Polynomial.roots_mul,
-    Polynomial.roots_X_pow]
-  exact mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero)
-    (Matrix.charpoly_monic _).ne_zero
+  rw [CPSVExample411Ambient.ambientM,
+    reducedBlockState_changePhysicalBasis_of_isometry CPSVExample411Ambient.inclusion
+      CPSVExample411Ambient.inclusion_isometry,
+    Matrix.singleKrausMap_charpoly_roots_eq_zero_add_of_isometry
+      (sitewisePhysicalMatrix CPSVExample411Ambient.inclusion L)
+      (sitewisePhysicalMatrix_isometry CPSVExample411Ambient.inclusion
+        CPSVExample411Ambient.inclusion_isometry L)]
+  simp only [Fintype.card_fun, Fintype.card_fin]
 
 /-- The ambient one-site state has two zero roots and two roots equal to $1/2$. -/
 theorem ambient_charpoly_roots_one :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -289,6 +289,35 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     \end{align}
 \end{proof}
 
+\begin{theorem}[Characteristic polynomial under an isometric inclusion]
+    \label{thm:matrix_single_kraus_isometry_charpoly}
+    \lean{Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry,
+        Matrix.singleKrausMap_charpoly_roots_eq_zero_add_of_isometry}
+    \leanok
+    \uses{def:mpdo_single_kraus_map}
+    Let $V:\C^d\to\C^e$ satisfy $V^*V=I_d$, and let $A$ be a $d\times d$
+    matrix. Then $d\leq e$ and
+    \begin{align}
+      \chi_{VAV^*}(X)&=X^{e-d}\chi_A(X).
+      \notag
+    \end{align}
+    Equivalently, the roots of $\chi_{VAV^*}$ are the roots of $\chi_A$
+    together with zero of multiplicity $e-d$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write $VAV^*=V(AV^*)$. Characteristic-polynomial cyclicity for rectangular
+    factors gives
+    \begin{align}
+      \chi_{V(AV^*)}(X)
+      &=X^{e-d}\chi_{(AV^*)V}(X)
+       =X^{e-d}\chi_A(X),
+      \notag
+    \end{align}
+    where the last equality uses $V^*V=I_d$. The root statement follows by
+    taking the roots of the product.
+\end{proof}
+
 \begin{theorem}[Reduced states under an isometric physical inclusion]
     \label{thm:mpdo_reduced_state_physical_isometry_transport}
     \lean{MPOTensor.reducedBlockState_changePhysicalBasis_of_isometry}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -291,7 +291,8 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 
 \begin{theorem}[Characteristic polynomial under an isometric inclusion]
     \label{thm:matrix_single_kraus_isometry_charpoly}
-    \lean{Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry,
+    \lean{Matrix.IsIsometry.card_le,
+        Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry,
         Matrix.singleKrausMap_charpoly_roots_eq_zero_add_of_isometry}
     \leanok
     \uses{def:mpdo_single_kraus_map}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -289,13 +289,25 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     \end{align}
 \end{proof}
 
+\begin{lemma}[Rectangular characteristic-polynomial cyclicity]
+    \label{lem:matrix_rectangular_charpoly_cyclicity}
+    \mathlibok % Mathlib: Matrix.charpoly_mul_comm_of_le.
+    Let $A$ be an $e\times d$ matrix and $B$ a $d\times e$ matrix, with
+    $d\leq e$. Then
+    \begin{align}
+      \chi_{AB}(X)&=X^{e-d}\chi_{BA}(X).
+      \notag
+    \end{align}
+\end{lemma}
+
 \begin{theorem}[Characteristic polynomial under an isometric inclusion]
     \label{thm:matrix_single_kraus_isometry_charpoly}
     \lean{Matrix.IsIsometry.card_le,
         Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry,
         Matrix.singleKrausMap_charpoly_roots_eq_zero_add_of_isometry}
     \leanok
-    \uses{def:mpdo_single_kraus_map}
+    \uses{def:mpdo_single_kraus_map,
+        lem:matrix_rectangular_charpoly_cyclicity}
     Let $V:\C^d\to\C^e$ satisfy $V^*V=I_d$, and let $A$ be a $d\times d$
     matrix. Then $d\leq e$ and
     \begin{align}
@@ -315,8 +327,16 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
        =X^{e-d}\chi_A(X),
       \notag
     \end{align}
-    where the last equality uses $V^*V=I_d$. The root statement follows by
-    taking the roots of the product.
+    where the last equality uses $V^*V=I_d$. Taking roots of the product gives
+    \begin{align}
+      \operatorname{roots}(\chi_{VAV^*})
+      &=\operatorname{roots}(X^{e-d}\chi_A)\\
+      &=\operatorname{roots}(X^{e-d})+\operatorname{roots}(\chi_A)\\
+      &=(e-d)\cdot\{0\}+\operatorname{roots}(\chi_A).
+      \notag
+    \end{align}
+    The middle equality applies because $X^{e-d}$ is nonzero and the monic
+    polynomial $\chi_A$ is nonzero.
 \end{proof}
 
 \begin{theorem}[Reduced states under an isometric physical inclusion]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -1399,7 +1399,8 @@ This is the calculation in
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_reduced_state_physical_isometry_transport,
+    \uses{thm:matrix_single_kraus_isometry_charpoly,
+        thm:mpdo_reduced_state_physical_isometry_transport,
         thm:cpsv_example411_length_four_effective_spectra}
     The reduced ambient state is
     $\widetilde\rho_L=V^{\otimes L}\rho_L(V^{\otimes L})^*$.  Applying

--- a/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
+++ b/docs/paper-gaps/cpsv16_examples_4_10_4_11_entropy.tex
@@ -279,8 +279,8 @@ multisets
 \]
 for block lengths one through four.  Here $a^{[m]}$ denotes multiplicity $m$.
 The generic isometric characteristic-polynomial identity
-\leanid{MPOTensor.CPSVExample411Spectrum.ambient_charpoly_eq_X_pow_mul_effective}
-is
+\leanid{Matrix.singleKrausMap_charpoly_eq_X_pow_mul_of_isometry}, specialized by
+\leanid{MPOTensor.CPSVExample411Spectrum.ambient_charpoly_eq_X_pow_mul_effective}, is
 \[
   \chi_{\widetilde\rho_L}(X)
   =X^{4^L-2^L}\chi_{\rho_L}(X).


### PR DESCRIPTION
Closes #6381.

## Summary

- add dimension-generic characteristic-polynomial zero-padding for isometric single-Kraus conjugation
- add the corresponding root-multiset identity
- refactor the Example 4.11 ambient characteristic-polynomial and root results into consumers while preserving their statements and structural `hL4` hypothesis
- add the generic Blueprint node and route the Example 4.11 proof/note through it

## Proof route

For `V : Matrix β α ℂ` and `A : Matrix α α ℂ`, apply rectangular characteristic-polynomial cyclicity to `V` and `A * Vᴴ`. The cardinal side condition follows from `Matrix.IsIsometry.card_le`; then `Vᴴ * V = 1` collapses the smaller factor. The root identity follows from `Polynomial.roots_mul` and `Polynomial.roots_X_pow`.

## Checks

- `lake env lean TNLean/Channel/SingleKrausPositivity.lean`
- `lake env lean TNLean/MPS/MPDO/CPSVExample411Spectrum.lean`
- targeted `lake build TNLean.MPS.MPDO.CPSVExample411Spectrum`
- `python3 scripts/blueprint_lean_sync.py --update`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `python3 scripts/check_reader_facing_prose.py --diff-base 527c9e0e7 --ci`
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`
- changed Lean files contain no `sorry`, `admit`, `native_decide`, or `unsafeCast`
