### PR TITLE
docs(parent-hamiltonian): display blocked projector equality

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2230,12 +2230,19 @@ norm estimate is derived here.
     \uses{thm:three_block_whole_increment_defect_seven_sixteenths,
         thm:friedrichs_ground_space_excitation_anticommutator,
         thm:three_site_anticommutator_cyclic_transport}
-    Let $A$ be an MPS tensor with nonzero physical dimension, and let $p$ be
-    any blocking length.  For $B=\operatorname{block}_p(A)$, the defect of the
-    two open-chain
-    ground-space projectors on three sites of $B$ is exactly the defect of the
-    corresponding three consecutive $p$-site regions of $A$.  If $B$ is
-    injective, then the bound
+    Let $A$ be an MPS tensor with nonzero physical dimension, let $p$ be any
+    blocking length, and set $B=\operatorname{block}_p(A)$.  Then
+    \begin{align}
+        \left\lVert
+          P^{\mathrm{tail}}_{1,2}(B)P^{\mathrm{left}}_2(B)
+          -P_{\mathcal G_3^{\mathrm{ES}}(B)}
+        \right\rVert
+        &=\left\lVert
+          P^{\mathrm{tail}}_{p;p,p}P^{\mathrm{left}}_{2p,p}
+          -P_{\mathcal G_{3p}^{\mathrm{ES}}(A)}
+        \right\rVert.
+    \end{align}
+    If $B$ is injective, then the bound on either side
     \begin{align}
         \left\lVert
           P^{\mathrm{tail}}_{1,2}(B)P^{\mathrm{left}}_2(B)


### PR DESCRIPTION
## What changed

- display the blocked three-site projector-defect equality tagged by `MPSTensor.blockTensor_threeSite_openChain_defect_norm_eq`
- preserve arbitrary blocking length for the equality
- retain blocked-tensor injectivity only for the downstream anticommutator consequence

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/generate_import_aggregators.py --check` (53 generated files, 1405 production modules)
- `bash scripts/tenkz_golden.sh --check` (9/9 event streams byte-identical)
- `git diff --check`

Closes #6419
