### PR TITLE
fix(blueprint): remove duplicate proof terminator

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5547,7 +5547,6 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   and the equal-ranges right-factor theorem give an invertible $Y$ satisfying
   $\widetilde P QY=\widetilde P$.
 \end{proof}
-\end{proof}
 
 \begin{proposition}[Constancy of the source ranks]
   \label{prop:continuity-index}


### PR DESCRIPTION
## What changed

- remove the unmatched duplicate `\end{proof}` in Chapter 28
- restore exact Blueprint compilation on current `main`

## Validation

- `TEXINPUTS="../../tex/tenkz//:" lualatex -interaction=nonstopmode -halt-on-error print.tex` twice
- zero undefined-reference warnings

The duplicate terminator was introduced in `1f076655b` after the preceding proof already closed.