### PR TITLE
docs(parent-hamiltonian): state open-kernel size hypotheses

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
@@ -13,8 +13,9 @@ For a chain of length `N`, this file sums the canonical local parent interaction
 only over starts whose length-`L` windows stay inside the linear interval.  Thus
 no local term crosses the cut between the last and first sites.
 
-The kernel is the open MPS boundary-condition space `groundSpaceES A N` once the
-tensor is block-injective at length \(L - 1\).  This is the finite-volume
+If the tensor is block-injective at a length \(L₀>0\) and \(L₀+1\leq N\),
+then the kernel at interaction length \(L₀+1\) is the open MPS
+boundary-condition space `groundSpaceES A N`.  This is the finite-volume
 ground-space input for Nachtergaele's C1--C3 martingale theorem.
 
 ## References


### PR DESCRIPTION
## What changed

- state the positive block-injectivity length required by the open-kernel theorem
- state the required chain-size inequality and interaction length
- leave the theorem and all mathematical APIs unchanged

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian` (3,155 jobs)
- exact-head specialist review: approved
- `git diff --check`

Closes #6427
