### PR TITLE
refactor(analysis): reuse idempotent range membership

### DIFF
--- a/TNLean/Analysis/TwoProjectionAngleBlock.lean
+++ b/TNLean/Analysis/TwoProjectionAngleBlock.lean
@@ -46,14 +46,10 @@ theorem rangeCompression_isSymmetric {P Q : E →ₗ[ℂ] E}
     (rangeCompression hP (Q := Q)).IsSymmetric := by
   intro x y
   change ⟪(P (Q x) : E), (y : E)⟫_ℂ = ⟪(x : E), (P (Q y) : E)⟫_ℂ
-  have hx : P (x : E) = x := by
-    obtain ⟨z, hz⟩ := x.property
-    rw [← hz]
-    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
-  have hy : P (y : E) = y := by
-    obtain ⟨z, hz⟩ := y.property
-    rw [← hz]
-    exact LinearMap.IsIdempotentElem.apply_apply hP.isIdempotentElem z
+  have hx : P (x : E) = x :=
+    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp x.property
+  have hy : P (y : E) = y :=
+    (LinearMap.IsIdempotentElem.mem_range_iff hP.isIdempotentElem).mp y.property
   rw [hP.isSymmetric, hQ.isSymmetric, hy]
   exact ((hP.isSymmetric x (Q y)).symm.trans (by rw [hx])).symm
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -39,6 +39,17 @@ abstracted — record why, so it is not re-proposed).
   later two-projection block assembly can use the same facts without repeating
   subtype coercion arguments.
 
+### fixed point from idempotent range membership — promoted
+- **Pattern:** derive `P x = x` from `x ∈ LinearMap.range P` when `P` is
+  idempotent.
+- **Seen:** the two range-subtype arguments in
+  `TNLean/Analysis/TwoProjectionAngleBlock.lean` and the compression-eigenbasis
+  argument in `TNLean/Analysis/TwoProjectionCompressionSpectrum.lean` before
+  cleanup (2026-08-14).
+- **Abstraction:** `LinearMap.IsIdempotentElem.mem_range_iff` in Mathlib.
+- **Notes:** use the forward implication directly rather than unpacking a range
+  witness and applying idempotency by hand.
+
 ### pointwise idempotent endomorphism application — promoted
 - **Pattern:** apply an equality `P * P = P` to a vector with `congrArg`, then
   simplify `Module.End.mul_apply` to obtain `P (P x) = P x`.


### PR DESCRIPTION
## What changed

- replace the remaining manual fixed-point derivations for vectors in a projection range with `LinearMap.IsIdempotentElem.mem_range_iff`
- record the repeated proof pattern in the tactic ledger

No theorem statement or mathematical scope changes.

## Validation

- `lake build TNLean.Analysis.TwoProjectionAngleBlock`
- Lean diagnostics: clean
- generated import aggregators
- proof-integrity check
- `git diff --check`

Closes #6365
