### PR TITLE
docs(blueprint): complete physical-adjoint CFII dependencies

### DIFF
--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -348,8 +348,7 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \lean{MPSTensor.IsLeftCanonical.mapStar}
     \lean{MPSTensor.IsNormalTensor.mapStar}
     \leanok
-    \uses{def:left_canonical_tensor,def:nt_cpsv,
-        thm:is_normal_tensor_of_is_normal_left_canonical}
+    \uses{def:left_canonical_tensor,def:nt_cpsv}
     Let $\overline A$ denote entrywise conjugation of every matrix $A^i$. If
     $A$ is left-canonical, then $\overline A$ is left-canonical. If, in
     addition, $A$ is a CPSV normal tensor, then $\overline A$ is a CPSV normal
@@ -365,9 +364,38 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
         &=\overline{\sum_i(A^i)^\dagger A^i}
          =\overline{\Id}=\Id.
     \end{align}
+    \lean{MPSTensor.IsNormal.mapStar}
     Entrywise conjugation also preserves positive-length block injectivity.
     Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical} applied to
     $\overline A$ now gives the CPSV normal-tensor conclusion.
+\end{proof}
+
+\begin{theorem}[Transfer maps and positive diagonal matrices under
+    entrywise conjugation]
+    \label{thm:cpsv_map_star_transfer_fixed_point}
+    \lean{MPSTensor.transferMap_mapStar}
+    \lean{MPSTensor.map_star_eq_self_of_posDef_isDiag}
+    \leanok
+    \uses{def:transfer_map}
+    For every tensor $A$ and matrix $X$,
+    \begin{align}
+        \E_{\overline A}(\overline X)
+        &=\overline{\E_A(X)}.
+        \label{eq:cpsv_map_star_transfer}
+    \end{align}
+    If $\Lambda$ is positive definite and diagonal, then
+    \begin{align}
+        \overline\Lambda&=\Lambda.
+        \label{eq:cpsv_map_star_posdef_diag}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:transfer_map}
+    Entrywise conjugation commutes with finite sums and matrix products, which
+    gives~(\ref{eq:cpsv_map_star_transfer}). The diagonal entries of a
+    positive-definite complex matrix are real, while all off-diagonal entries
+    of a diagonal matrix vanish. This proves~(\ref{eq:cpsv_map_star_posdef_diag}).
 \end{proof}
 
 \begin{definition}[CPSV canonical form]

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1635,7 +1635,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \leanok
     \uses{def:cpsv_cfii,def:mpu_physical_pair_swap,
         thm:mpu_physical_adjoint_normalized_flattening,
-        thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing}
+        thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing,
+        thm:cpsv_map_star_transfer_fixed_point}
     Given canonical-form-II data for $\widetilde{\mathcal U}$, define the
     transformed tuple by
     \begin{align}
@@ -1652,15 +1653,15 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_physical_adjoint_cfii}
     \lean{MPSTensor.IsCPSVCanonicalFormII.physicalAdjointNormalizedFlattening}
     \leanok
-    \uses{def:cpsv_cfii}
+    \uses{def:cpsv_cfii,def:mpdo_physical_adjoint,
+        def:mpu_normalized_flattening}
     If $\widetilde{\mathcal U}$ is in canonical form II, then
     $\widetilde{\mathcal U^\sharp}$ is in canonical form II.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpu_physical_adjoint_cfii_data,
-        thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing,
-        thm:cpsv_map_star_transfer_fixed_point}
+        thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing}
     Theorem~\ref{thm:cpsv_map_star_preservation} gives normality and
     left-canonical normalization after entrywise conjugation, and
     Theorem~\ref{thm:cpsv_physical_reindexing} preserves these properties under

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1618,9 +1618,15 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}\leanok
     \uses{def:mpdo_physical_adjoint,def:mpu_normalized_flattening,
         def:mpu_physical_pair_swap}
-    Expand the normalized flattening. Its factor $d^{-1/2}$ is real, while
-    physical adjunction exchanges the ket and bra coordinates and conjugates
-    every virtual matrix entry.
+    For every pair of physical indices $(i,j)$,
+    \begin{align}
+        \widetilde{\mathcal U^\sharp}^{\,(i,j)}
+        &=\frac{1}{\sqrt d}\,(\mathcal U^\sharp)^{(i,j)}
+         =\frac{1}{\sqrt d}\,\overline{\mathcal U^{(j,i)}}
+         =\overline{\widetilde{\mathcal U}^{\,(j,i)}}.
+    \end{align}
+    The first equality is the normalized flattening, the second is physical
+    adjunction, and the third uses the reality of $d^{-1/2}$.
 \end{proof}
 
 \begin{definition}[Canonical-form-II data under physical adjunction]
@@ -1646,14 +1652,15 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
     \label{thm:mpu_physical_adjoint_cfii}
     \lean{MPSTensor.IsCPSVCanonicalFormII.physicalAdjointNormalizedFlattening}
     \leanok
-    \uses{def:cpsv_cfii,def:mpu_physical_adjoint_cfii_data}
+    \uses{def:cpsv_cfii}
     If $\widetilde{\mathcal U}$ is in canonical form II, then
     $\widetilde{\mathcal U^\sharp}$ is in canonical form II.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpu_physical_adjoint_cfii_data,
-        thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing}
+        thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing,
+        thm:cpsv_map_star_transfer_fixed_point}
     Theorem~\ref{thm:cpsv_map_star_preservation} gives normality and
     left-canonical normalization after entrywise conjugation, and
     Theorem~\ref{thm:cpsv_physical_reindexing} preserves these properties under
@@ -1692,9 +1699,15 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 
 \begin{proof}\leanok
     \uses{def:mpu_full_active_support,def:mpu_physical_adjoint_cfii_data}
-    Complex conjugation preserves nonzero weights.  Hence the active indices
-    and their block dimensions are unchanged, so their dimension sum remains
-    equal to the ambient bond dimension.
+    Complex conjugation gives $\overline{\mu_k}\ne0$ if and only if
+    $\mu_k\ne0$. Thus $k\mapsto k$ is a bijection between the two active
+    index sets, and
+    \begin{align}
+        \sum_{k:\,\overline{\mu_k}\ne0}D_k
+        &=\sum_{k:\,\mu_k\ne0}D_k
+         =D.
+    \end{align}
+    The last equality is the assumed full active support.
 \end{proof}
 
 % Scope: the preceding three entries concern literal CFII data only. They do not


### PR DESCRIPTION
## What changed

- tag the conjugation lemmas used by the physical-adjoint CFII construction
- add a formula-driven blueprint node for transfer-map conjugation and reality of diagonal positive matrices
- move proof-only dependencies to proof-level `uses`
- display the normalized-flattening and full-active-support computations explicitly

No Lean declaration or mathematical scope changes.

## Validation

- blueprint sync and `leanblueprint checkdecls`
- reader-facing prose check
- `git diff --check`

Closes #6401
