### PR TITLE
docs(blueprint): cover open-Hamiltonian inclusions

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -792,6 +792,7 @@ neither the C1--C3 estimate nor periodic coercivity.
 
 \begin{definition}[Compatible open-chain parent Hamiltonian]
     \label{def:open_parent_hamiltonian_es}
+    \lean{MPSTensor.NonwrappingStart}
     \lean{MPSTensor.openParentHamiltonianES}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients}
@@ -826,14 +827,81 @@ neither the C1--C3 estimate nor periodic coercivity.
     positive. Positivity is preserved by finite sums.
 \end{proof}
 
+\begin{theorem}[Zero energy forces every compatible local constraint]
+    \label{thm:open_parent_hamiltonian_zero_local_terms}
+    \lean{MPSTensor.localTermES_eq_zero_of_openParentHamiltonianES_eq_zero}
+    \leanok
+    \uses{def:open_parent_hamiltonian_es}
+    If $H^{\mathrm{open}}_{N,L}(A)v=0$, then, for every $i\in I_{L,N}$,
+    \begin{align}
+        h_{i,\mathrm{ES}}(A,L)v&=0.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{rem:projection_geometry_rowsum_identities,
+        lem:transported_es_local_projections}
+    Take the inner product of the sum with $v$. Each summand is an orthogonal
+    projection, so every summand has zero quadratic form and therefore
+    annihilates $v$.
+\end{proof}
+
+\begin{theorem}[Open-boundary vectors have zero compatible energy]
+    \label{thm:open_ground_space_le_hamiltonian_kernel}
+    \lean{MPSTensor.groundSpaceES_le_ker_openParentHamiltonianES}
+    \leanok
+    \uses{def:open_parent_hamiltonian_es, def:ground_space_es}
+    For every $A$, $L$, and $N$,
+    \begin{align}
+        G_N^{\mathrm{ES}}(A)
+        &\subseteq \ker H^{\mathrm{open}}_{N,L}(A).
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:mem_ground_space_es, rem:contiguous_window_operators,
+        lem:local_term_es_kernel_restrictions}
+    Every non-wrapping restriction of a vector in $G_N^{\mathrm{ES}}(A)$ lies
+    in $G_L^{\mathrm{ES}}(A)$ after absorbing the matrices outside the interval
+    into its boundary matrix. Hence every compatible local term annihilates the
+    vector.
+\end{proof}
+
+\begin{theorem}[Compatible zero energy has open-boundary form]
+    \label{thm:open_hamiltonian_kernel_le_ground_space}
+    \lean{MPSTensor.ker_openParentHamiltonianES_le_groundSpaceES_of_isNBlkInjective}
+    \leanok
+    \uses{def:open_parent_hamiltonian_es, def:ground_space_es,
+        def:l_blk_injective}
+    Assume $D\geq1$, $L_0>0$, and $N\geq L_0+1$. If $A$ is
+    $L_0$-block-injective, then
+    \begin{align}
+        \ker H^{\mathrm{open}}_{N,L_0+1}(A)
+        &\subseteq G_N^{\mathrm{ES}}(A).
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:open_parent_hamiltonian_zero_local_terms,
+        lem:mem_ground_space_es, rem:contiguous_window_operators,
+        lem:local_term_es_kernel_restrictions,
+        thm:normal_open_chain_range_reduction}
+    The zero-energy condition gives every non-wrapping length-$L_0+1$ local
+    constraint. The local kernel criterion identifies each corresponding
+    restriction with a vector in $G_{L_0+1}^{\mathrm{ES}}(A)$, and the
+    open-chain intersection theorem extends these constraints to the full
+    interval.
+\end{proof}
+
 \begin{theorem}[Ground-state property of the compatible open chain]
     \label{thm:open_parent_hamiltonian_kernel_ground_space}
     \lean{MPSTensor.ker_openParentHamiltonianES_eq_groundSpaceES_of_isNBlkInjective}
     \leanok
     \uses{def:open_parent_hamiltonian_es, def:ground_space_es,
-        def:l_blk_injective, lem:open_parent_hamiltonian_es_positive,
-        lem:local_term_es_kernel_restrictions,
-        thm:normal_open_chain_range_reduction}
+        def:l_blk_injective}
     Assume $D\geq1$, $L_0>0$, and $N\geq L_0+1$. If $A$ is
     $L_0$-block-injective, then
     \begin{align}
@@ -848,19 +916,10 @@ neither the C1--C3 estimate nor periodic coercivity.
 
 \begin{proof}
     \leanok
-    \uses{lem:open_parent_hamiltonian_es_positive,
-        lem:local_term_es_kernel_restrictions,
-        thm:normal_open_chain_range_reduction}
-    Every non-wrapping restriction of a vector in $G_N^{\mathrm{ES}}(A)$ lies
-    in $G_{L_0+1}^{\mathrm{ES}}(A)$: the matrices outside the interval are
-    absorbed into the boundary matrix. Hence every summand in
-    (\ref{eq:open_parent_hamiltonian_es}) annihilates the vector.
-
-    Conversely, if the sum annihilates a vector, positivity of its projection
-    summands forces every non-wrapping local term to annihilate that vector.
-    The local kernel criterion places each fixed-complement restriction in
-    $G_{L_0+1}^{\mathrm{ES}}(A)$. The open-chain iteration of the intersection
-    property then places the original vector in $G_N^{\mathrm{ES}}(A)$.
+    \uses{thm:open_ground_space_le_hamiltonian_kernel,
+        thm:open_hamiltonian_kernel_le_ground_space}
+    The two preceding inclusions identify each space as a subspace of the
+    other, so antisymmetry gives the equality.
 \end{proof}
 
 \begin{theorem}[Nachtergaele open-chain projector defect]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -844,9 +844,9 @@ neither the C1--C3 estimate nor periodic coercivity.
         lem:transported_es_local_projections}
     Taking the inner product of the sum with $v$ gives
     \begin{align}
-        \sum_{i\in I_{L,N}}\operatorname{re}
+        \sum_{i\in I_{L,N}}\re
         \langle h_{i,\mathrm{ES}}(A,L)v,v\rangle
-        &=\langle H^{\mathrm{open}}_{N,L}(A)v,v\rangle=0.
+        &=\re\langle H^{\mathrm{open}}_{N,L}(A)v,v\rangle=0.
     \end{align}
     Each summand is the squared norm of the image of $v$ under an orthogonal
     projection. Hence every local term annihilates $v$.
@@ -902,13 +902,16 @@ neither the C1--C3 estimate nor periodic coercivity.
         lem:mem_ground_space_es, rem:contiguous_window_operators,
         rem:cyclic_window_operators, lem:local_term_es_kernel_restrictions,
         thm:normal_open_chain_range_reduction}
-    For every start $s$ with $s+L_0+1\leq N$ and every complementary
-    configuration $\tau$, the three ingredients give
+    In the following display, $s$ ranges over all starts satisfying
+    $s+L_0+1\leq N$, and $\tau$ ranges over all complementary configurations.
+    The three ingredients give
     \begin{align}
         H^{\mathrm{open}}_{N,L_0+1}(A)v=0
-        &\Longrightarrow h_{s,\mathrm{ES}}(A,L_0+1)v=0
-        \Longrightarrow \Res^\tau_{s,L_0+1}v
-            \in G_{L_0+1}^{\mathrm{ES}}(A)
+        &\Longrightarrow
+          \bigl(\forall s,\ h_{s,\mathrm{ES}}(A,L_0+1)v=0\bigr)
+        \Longrightarrow
+          \bigl(\forall s,\tau,\
+            \Res^\tau_{s,L_0+1}v\in G_{L_0+1}^{\mathrm{ES}}(A)\bigr)
         \Longrightarrow v\in G_N^{\mathrm{ES}}(A).
     \end{align}
     The middle implication is the local kernel criterion, and the last is the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -842,9 +842,14 @@ neither the C1--C3 estimate nor periodic coercivity.
     \leanok
     \uses{rem:projection_geometry_rowsum_identities,
         lem:transported_es_local_projections}
-    Take the inner product of the sum with $v$. Each summand is an orthogonal
-    projection, so every summand has zero quadratic form and therefore
-    annihilates $v$.
+    Taking the inner product of the sum with $v$ gives
+    \begin{align}
+        \sum_{i\in I_{L,N}}\operatorname{re}
+        \langle h_{i,\mathrm{ES}}(A,L)v,v\rangle
+        &=\langle H^{\mathrm{open}}_{N,L}(A)v,v\rangle=0.
+    \end{align}
+    Each summand is the squared norm of the image of $v$ under an orthogonal
+    projection. Hence every local term annihilates $v$.
 \end{proof}
 
 \begin{theorem}[Open-boundary vectors have zero compatible energy]
@@ -862,11 +867,19 @@ neither the C1--C3 estimate nor periodic coercivity.
 \begin{proof}
     \leanok
     \uses{lem:mem_ground_space_es, rem:contiguous_window_operators,
-        lem:local_term_es_kernel_restrictions}
-    Every non-wrapping restriction of a vector in $G_N^{\mathrm{ES}}(A)$ lies
-    in $G_L^{\mathrm{ES}}(A)$ after absorbing the matrices outside the interval
-    into its boundary matrix. Hence every compatible local term annihilates the
-    vector.
+        rem:cyclic_window_operators, lem:local_term_es_kernel_restrictions}
+    Let $v=\Gamma_N(X)\in G_N^{\mathrm{ES}}(A)$. For a non-wrapping window
+    $[s,s+L-1]$ and a complementary configuration $\tau$, the restriction is
+    \begin{align}
+        \Res^\tau_{s,L}\Gamma_N(X)
+        &=\Gamma_L\!\left(
+            A^{\tau_{s+L}\cdots\tau_{N-1}}X
+            A^{\tau_0\cdots\tau_{s-1}}
+          \right)
+        \in G_L^{\mathrm{ES}}(A).
+    \end{align}
+    The local kernel criterion therefore shows that every compatible local term
+    annihilates $v$.
 \end{proof}
 
 \begin{theorem}[Compatible zero energy has open-boundary form]
@@ -887,13 +900,19 @@ neither the C1--C3 estimate nor periodic coercivity.
     \leanok
     \uses{thm:open_parent_hamiltonian_zero_local_terms,
         lem:mem_ground_space_es, rem:contiguous_window_operators,
-        lem:local_term_es_kernel_restrictions,
+        rem:cyclic_window_operators, lem:local_term_es_kernel_restrictions,
         thm:normal_open_chain_range_reduction}
-    The zero-energy condition gives every non-wrapping length-$L_0+1$ local
-    constraint. The local kernel criterion identifies each corresponding
-    restriction with a vector in $G_{L_0+1}^{\mathrm{ES}}(A)$, and the
-    open-chain intersection theorem extends these constraints to the full
-    interval.
+    For every start $s$ with $s+L_0+1\leq N$ and every complementary
+    configuration $\tau$, the three ingredients give
+    \begin{align}
+        H^{\mathrm{open}}_{N,L_0+1}(A)v=0
+        &\Longrightarrow h_{s,\mathrm{ES}}(A,L_0+1)v=0
+        \Longrightarrow \Res^\tau_{s,L_0+1}v
+            \in G_{L_0+1}^{\mathrm{ES}}(A)
+        \Longrightarrow v\in G_N^{\mathrm{ES}}(A).
+    \end{align}
+    The middle implication is the local kernel criterion, and the last is the
+    open-chain intersection theorem.
 \end{proof}
 
 \begin{theorem}[Ground-state property of the compatible open chain]


### PR DESCRIPTION
## What changed

- attach `MPSTensor.NonwrappingStart` to the compatible open-Hamiltonian definition
- add Blueprint nodes for local zero-energy extraction and both kernel inclusions
- route the final kernel equality through those two inclusions

## Validation

- Blueprint source sync and `leanblueprint checkdecls`
- import aggregators: 53 generated files covering 1,406 production modules
- tenkz golden compatibility: 9/9 event streams byte-identical
- `git diff --check`

Closes #6425
