### PR TITLE
docs(blueprint): quantify compression trichotomy per index

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5293,8 +5293,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpu_two_projection_compression_spectral_data,
     thm:mpu_two_projection_angle_block}
   Let $P$ and $Q$ be orthogonal projections on a finite-dimensional complex
-  inner-product space, with compression spectral data $(x_i,\mu_i)$. Then
-  $\mu_i\in[0,1]$ for every $i$, and exactly one of the following alternatives
+  inner-product space, with compression spectral data $(x_i,\mu_i)$. Then, for
+  every $i$, $\mu_i\in[0,1]$ and exactly one of the following alternatives
   holds:
   \begin{enumerate}
     \item $\mu_i=0$ and $Qx_i=0$;


### PR DESCRIPTION
## What changed

- make the compression-spectrum trichotomy explicitly quantify over each basis index
- remove the possible false reading that one alternative holds uniformly across the whole spectrum

No Lean declaration changes.

## Validation

- blueprint sync and `leanblueprint checkdecls`
- reader-facing prose check
- blueprint web build
- `git diff --check`

Closes #6383
