### PR TITLE
feat(parent-hamiltonian): prove fixed-window C2 leaf

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
@@ -46,6 +46,63 @@ noncomputable def openParentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
   ∑ i : NonwrappingStart L N, localTermES A L i.1
 
+/-- At volume \(N = L > 0\), the compatible open parent Hamiltonian is the
+canonical local projector on the full chain.
+
+This is the fixed-window operator underlying \(γ_{l+1} = 1\) in Nachtergaele,
+arXiv:cond-mat/9410110, Theorem 2.1(i). -/
+theorem openParentHamiltonianES_self_eq_parentInteractionES (A : MPSTensor d D)
+    {L : ℕ} (hL : 0 < L) :
+    openParentHamiltonianES A L L = parentInteractionES A L := by
+  let i : NonwrappingStart L L := ⟨⟨0, hL⟩, by simp⟩
+  letI : Subsingleton (NonwrappingStart L L) :=
+    ⟨fun j k => by
+      apply Subtype.ext
+      apply Fin.ext
+      have hj := j.2
+      have hk := k.2
+      omega⟩
+  rw [openParentHamiltonianES, Fintype.sum_subsingleton _ i]
+  ext v σ
+  rw [localTermES_apply A L i.1 (le_refl L) v σ]
+  have hrestrict : cyclicRestrictES (d := d) hL L i.1 σ v = v := by
+    ext ω
+    change v (cyclicCfg hL L (⟨0, hL⟩ : Fin L) ω σ) = v ω
+    rw [show cyclicCfg hL L (⟨0, hL⟩ : Fin L) ω σ = ω by
+      funext k
+      simp [cyclicCfg, Nat.mod_eq_of_lt k.isLt]]
+  rw [hrestrict]
+  rw [show extractWindow L i.1 σ = σ by
+    funext k
+    simp [i, extractWindow, Nat.mod_eq_of_lt k.isLt]]
+
+/-- The full-window compatible open parent Hamiltonian preserves the norm on
+the orthogonal complement of its kernel. -/
+theorem openParentHamiltonianES_self_norm_eq_of_mem_orthogonal_ker
+    (A : MPSTensor d D) {L : ℕ} (hL : 0 < L)
+    (v : EuclideanSpace ℂ (Cfg d L))
+    (hv : v ∈ (LinearMap.ker (openParentHamiltonianES A L L))ᗮ) :
+    ‖openParentHamiltonianES A L L v‖ = ‖v‖ := by
+  rw [openParentHamiltonianES_self_eq_parentInteractionES A hL] at hv ⊢
+  change ‖(groundSpaceES A L)ᗮ.starProjection v‖ = ‖v‖
+  apply Submodule.norm_starProjection_apply
+  have hker : LinearMap.ker (parentInteractionES A L) = groundSpaceES A L := by
+    ext w
+    rw [LinearMap.mem_ker, parentInteractionES_apply_eq_zero_iff]
+  rwa [hker] at hv
+
+/-- The compatible open parent Hamiltonian has unit norm gap at the first
+full-window volume.
+
+This is \(γ_{l+1} = 1\) in Nachtergaele, arXiv:cond-mat/9410110,
+Theorem 2.1(i), for \(L = l + 1\). -/
+theorem openParentHamiltonianES_self_unit_gap (A : MPSTensor d D)
+    {L : ℕ} (hL : 0 < L) (v : EuclideanSpace ℂ (Cfg d L))
+    (hv : v ∈ (LinearMap.ker (openParentHamiltonianES A L L))ᗮ) :
+    (1 : ℝ) * ‖v‖ ≤ ‖openParentHamiltonianES A L L v‖ := by
+  simpa only [one_mul] using
+    (openParentHamiltonianES_self_norm_eq_of_mem_orthogonal_ker A hL v hv).symm.le
+
 /-- The open-chain parent Hamiltonian is positive because every summand is an
 orthogonal projection. -/
 theorem openParentHamiltonianES_isPositive (A : MPSTensor d D) (L N : ℕ) :

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -786,9 +786,10 @@ Nachtergaele~\cite[Equation~(3.12)]{Nachtergaele1996Spectral}, whose
 zero-energy space is identified in Equation~(3.13). Equations~(3.14)--(3.16)
 continue with comparison of compatible interactions, approximate commutation
 of ground-state projectors, and a uniform gap. Theorem~2.1(i) of the same
-source obtains a gap from conditions C1--C3. The statements below give only the
-compatible Hamiltonian, its positivity, and its zero-energy space; they assert
-neither the C1--C3 estimate nor periodic coercivity.
+source obtains a gap from its three stated hypotheses. In addition to the
+compatible Hamiltonian and its zero-energy space, the statements below verify
+only the unit norm lower bound at the full-window volume $N=L$. They give no
+gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{definition}[Compatible open-chain parent Hamiltonian]
     \label{def:open_parent_hamiltonian_es}
@@ -810,6 +811,57 @@ neither the C1--C3 estimate nor periodic coercivity.
     $L=l+1$, the starting sites are $0,\ldots,N-l-1$, in agreement with
     \cite[Equation~(3.12)]{Nachtergaele1996Spectral}.
 \end{definition}
+
+\begin{theorem}[Full-window compatible interaction]
+    \label{thm:open_parent_hamiltonian_full_window}
+    \lean{MPSTensor.openParentHamiltonianES_self_eq_parentInteractionES}
+    \leanok
+    \uses{def:open_parent_hamiltonian_es,
+        rem:euclidean_local_projector_ingredients}
+    If $L>0$, then $I_{L,L}=\{0\}$ and
+    \begin{align}
+        H^{\mathrm{open}}_{L,L}(A)
+        &=h_{0,\mathrm{ES}}(A,L)=P_L^{\mathrm{ES}}(A).
+        \label{eq:open_parent_hamiltonian_full_window}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The inequality $i+L\leq L$ forces $i=0$. For this sole window, restriction
+    to the full chain and extraction of the window are both the identity, so
+    the local term is $P_L^{\mathrm{ES}}(A)$.
+\end{proof}
+
+\begin{theorem}[Unit gap at the full-window volume]
+    \label{thm:open_parent_hamiltonian_full_window_unit_gap}
+    \lean{MPSTensor.openParentHamiltonianES_self_norm_eq_of_mem_orthogonal_ker,
+        MPSTensor.openParentHamiltonianES_self_unit_gap}
+    \leanok
+    \uses{thm:open_parent_hamiltonian_full_window}
+    If $L>0$ and
+    $v\in(\ker H^{\mathrm{open}}_{L,L}(A))^\perp$, then
+    \begin{align}
+        \lVert H^{\mathrm{open}}_{L,L}(A)v\rVert
+        &=\lVert v\rVert,
+        \label{eq:open_parent_hamiltonian_full_window_norm}
+        \\
+        \lVert v\rVert
+        &\leq\lVert H^{\mathrm{open}}_{L,L}(A)v\rVert.
+    \end{align}
+    Thus $\gamma_{l+1}=1$ at the full-window volume $N=L=l+1$ in
+    \cite[Theorem~2.1(i)]{Nachtergaele1996Spectral}. This neither asserts that
+    the excited subspace is nonzero nor supplies a gap for any $N>L$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:open_parent_hamiltonian_full_window}
+    By~(\ref{eq:open_parent_hamiltonian_full_window}), the Hamiltonian is the
+    orthogonal projector onto $(G_L^{\mathrm{ES}}(A))^\perp$. Its kernel is
+    $G_L^{\mathrm{ES}}(A)$, and an orthogonal projector preserves the norm of
+    every vector in its range. The inequality is the resulting equality.
+\end{proof}
 
 \begin{lemma}[Positivity of the compatible open-chain Hamiltonian]
     \label{lem:open_parent_hamiltonian_es_positive}


### PR DESCRIPTION
## What changed

- identify the one-window Hamiltonian `Hᵒᵖᵉⁿ_{L,L}` with the complementary ground-space projection
- prove exact norm preservation on the orthogonal complement of its kernel
- expose the corresponding unit-gap inequality
- add Chapter 13 coverage limited explicitly to the fixed-window C2 leaf

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.OpenHamiltonian` (3,155 jobs)
- Blueprint source sync and declaration checks (7,658/7,658 entries)
- import aggregators: 53 generated files covering 1,406 production modules
- tenkz golden compatibility: 9/9 event streams byte-identical
- exact-head specialist review: approved
- `git diff --check`

Closes #6428
