### PR TITLE
feat(algebra): prove fixed-product rank constancy

### DIFF
--- a/TNLean/Algebra/MatrixRankClosed.lean
+++ b/TNLean/Algebra/MatrixRankClosed.lean
@@ -165,14 +165,15 @@ theorem lowerSemicontinuous_rank :
   change IsClosed {A : Matrix m n ℂ | A.rank ≤ k}
   exact isClosed_setOf_rank_le (m := m) (n := n) k
 
+end Matrix
+
 /-- The rank along a continuous path of finite complex matrices is lower semicontinuous. -/
-theorem _root_.Continuous.lowerSemicontinuous_matrix_rank
-    {X : Type*} [TopologicalSpace X] {A : X → Matrix m n ℂ} (hA : Continuous A) :
+theorem Continuous.lowerSemicontinuous_matrix_rank
+    {X m n : Type*} [TopologicalSpace X] [Finite m] [Fintype n]
+    {A : X → Matrix m n ℂ} (hA : Continuous A) :
     LowerSemicontinuous fun x => (A x).rank := by
   simpa only [Function.comp_def] using
-    (lowerSemicontinuous_rank (m := m) (n := n)).comp hA
-
-end Matrix
+    (Matrix.lowerSemicontinuous_rank (m := m) (n := n)).comp hA
 
 section FixedPositiveProduct
 

--- a/TNLean/Algebra/MatrixRankClosed.lean
+++ b/TNLean/Algebra/MatrixRankClosed.lean
@@ -9,6 +9,9 @@ import Mathlib.LinearAlgebra.Dimension.Finite
 import Mathlib.LinearAlgebra.Dimension.OrzechProperty
 import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
 import Mathlib.Topology.Instances.Matrix
+import Mathlib.Topology.LocallyConstant.Basic
+import Mathlib.Topology.Semicontinuity.Basic
+import Mathlib.Topology.UnitInterval
 import Mathlib.Analysis.Complex.Basic
 
 /-!
@@ -28,12 +31,17 @@ entrywise convergence over `ℂ`, i.e. matrix rank is lower semicontinuous.
   index selections `f, g` of size `k+1` with `A.submatrix f g` invertible.
 * `Matrix.isClosed_setOf_rank_le`: the set `{A | A.rank ≤ k}` of complex matrices is
   closed.
+* `Matrix.lowerSemicontinuous_rank`: matrix rank over `ℂ` is lower semicontinuous.
+* `isLocallyConstant_pair_of_lowerSemicontinuous_nat_mul_eq`: two lower-semicontinuous
+  natural-valued functions with fixed positive product are locally constant.
 
 The closedness result underlies the compactness of the set of states of Schmidt number
-at most `r` (Wolf, *Quantum Channels & Operations*, Proposition 3.3).
+at most `r` (Wolf, *Quantum Channels & Operations*, Proposition 3.3). The final two
+results isolate the topological argument in arXiv:1703.09188, lines 813–817.
 -/
 
-open Matrix Module Submodule Set
+open Filter Matrix Module Submodule Set
+open scoped Topology
 
 namespace Matrix
 
@@ -147,4 +155,86 @@ theorem isClosed_setOf_rank_le (k : ℕ) :
     (continuous_id.matrix_submatrix f g).matrix_det
   exact isOpen_ne.preimage hcont
 
+/-- Matrix rank over finite complex matrices is lower semicontinuous.
+
+This packages `isClosed_setOf_rank_le` in Mathlib's semicontinuity API. -/
+theorem lowerSemicontinuous_rank :
+    LowerSemicontinuous fun A : Matrix m n ℂ => A.rank := by
+  rw [lowerSemicontinuous_iff_isClosed_preimage]
+  intro k
+  change IsClosed {A : Matrix m n ℂ | A.rank ≤ k}
+  exact isClosed_setOf_rank_le (m := m) (n := n) k
+
+/-- The rank along a continuous path of finite complex matrices is lower semicontinuous. -/
+theorem _root_.Continuous.lowerSemicontinuous_matrix_rank
+    {X : Type*} [TopologicalSpace X] {A : X → Matrix m n ℂ} (hA : Continuous A) :
+    LowerSemicontinuous fun x => (A x).rank := by
+  simpa only [Function.comp_def] using
+    (lowerSemicontinuous_rank (m := m) (n := n)).comp hA
+
 end Matrix
+
+section FixedPositiveProduct
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- Two lower-semicontinuous natural-valued functions with a fixed positive product are
+locally constant.
+
+Indeed, lower semicontinuity makes both factors weakly increase near any point. Since
+both factors are positive and their product is fixed, neither factor can increase.
+This is the numerical topological step in arXiv:1703.09188, lines 813–817. -/
+theorem isLocallyConstant_pair_of_lowerSemicontinuous_nat_mul_eq
+    {r l : X → ℕ} {c : ℕ} (hr : LowerSemicontinuous r) (hl : LowerSemicontinuous l)
+    (hc : 0 < c) (hmul : ∀ x, r x * l x = c) :
+    IsLocallyConstant r ∧ IsLocallyConstant l := by
+  have hpair : IsLocallyConstant fun x => (r x, l x) :=
+    (IsLocallyConstant.iff_eventually_eq _).2 fun x => by
+      have hr_pos : 0 < r x := Nat.pos_of_mul_pos_right (hmul x ▸ hc)
+      have hl_pos : 0 < l x := Nat.pos_of_mul_pos_left (hmul x ▸ hc)
+      have hr_ge : ∀ᶠ y in 𝓝 x, r x ≤ r y :=
+        (hr x (r x - 1) (by omega)).mono fun y hy => by omega
+      have hl_ge : ∀ᶠ y in 𝓝 x, l x ≤ l y :=
+        (hl x (l x - 1) (by omega)).mono fun y hy => by omega
+      filter_upwards [hr_ge, hl_ge] with y hry hly
+      have hprod : r x * l x = r y * l y := (hmul x).trans (hmul y).symm
+      have hle : r y * l x ≤ r x * l x := by
+        calc
+          r y * l x ≤ r y * l y := Nat.mul_le_mul_left _ hly
+          _ = r x * l x := hprod.symm
+      have hr_eq : r x = r y := Nat.eq_of_mul_eq_mul_right hl_pos <|
+        le_antisymm (Nat.mul_le_mul_right _ hry) hle
+      have hl_eq : l x = l y := Nat.eq_of_mul_eq_mul_left hr_pos <| by
+        simpa only [hr_eq] using hprod
+      exact Prod.ext hr_eq.symm hl_eq.symm
+  exact ⟨hpair.comp Prod.fst, hpair.comp Prod.snd⟩
+
+/-- On a preconnected set, lower-semicontinuous natural-valued functions with a fixed
+positive product take the same pair of values at every two points of the set. -/
+theorem eq_of_lowerSemicontinuous_nat_mul_eq_of_isPreconnected
+    {r l : X → ℕ} {c : ℕ} (hr : LowerSemicontinuous r) (hl : LowerSemicontinuous l)
+    (hc : 0 < c) (hmul : ∀ x, r x * l x = c) {s : Set X} (hs : IsPreconnected s)
+    {x y : X} (hx : x ∈ s) (hy : y ∈ s) : r x = r y ∧ l x = l y := by
+  obtain ⟨hr_local, hl_local⟩ :=
+    isLocallyConstant_pair_of_lowerSemicontinuous_nat_mul_eq hr hl hc hmul
+  exact ⟨hr_local.apply_eq_of_isPreconnected hs hx hy,
+    hl_local.apply_eq_of_isPreconnected hs hx hy⟩
+
+/-- On a preconnected space, lower-semicontinuous natural-valued functions with a fixed
+positive product are constant. -/
+theorem eq_of_lowerSemicontinuous_nat_mul_eq
+    [PreconnectedSpace X] {r l : X → ℕ} {c : ℕ} (hr : LowerSemicontinuous r)
+    (hl : LowerSemicontinuous l) (hc : 0 < c) (hmul : ∀ x, r x * l x = c)
+    (x y : X) : r x = r y ∧ l x = l y :=
+  eq_of_lowerSemicontinuous_nat_mul_eq_of_isPreconnected hr hl hc hmul
+    isPreconnected_univ trivial trivial
+
+/-- Lower-semicontinuous natural-valued functions with fixed positive product are
+constant on the unit interval. -/
+theorem unitInterval_eq_of_lowerSemicontinuous_nat_mul_eq
+    {r l : unitInterval → ℕ} {c : ℕ} (hr : LowerSemicontinuous r)
+    (hl : LowerSemicontinuous l) (hc : 0 < c) (hmul : ∀ x, r x * l x = c)
+    (x y : unitInterval) : r x = r y ∧ l x = l y :=
+  eq_of_lowerSemicontinuous_nat_mul_eq hr hl hc hmul x y
+
+end FixedPositiveProduct

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5562,6 +5562,84 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   $\widetilde P QY=\widetilde P$.
 \end{proof}
 
+\begin{theorem}[Lower semicontinuity of finite matrix rank]
+  \label{thm:mpu_rank_lower_semicontinuous}
+  \lean{Matrix.lowerSemicontinuous_rank,
+    Continuous.lowerSemicontinuous_matrix_rank}
+  \leanok
+  For finite index sets $M,N$, matrix rank defines a lower-semicontinuous map
+  \begin{align}
+    \operatorname{rank}\colon
+      \operatorname{Mat}_{M\times N}(\mathbb C)&\longrightarrow\mathbb N.
+  \end{align}
+  Consequently, if $A\colon X\to\operatorname{Mat}_{M\times N}(\mathbb C)$
+  is continuous, then $x\mapsto\operatorname{rank}A(x)$ is lower
+  semicontinuous.
+  % Source lines: paper_v2.tex 813--814.
+\end{theorem}
+
+\begin{proof}\leanok
+  For every $k\in\mathbb N$, the sublevel set is the closed determinantal set
+  \begin{align}
+    \{A:\operatorname{rank}A\leq k\}.
+  \end{align}
+  These closed sublevel sets characterize lower semicontinuity. Composition
+  with a continuous map preserves lower semicontinuity.
+\end{proof}
+
+\begin{theorem}[Fixed positive product gives local constancy]
+  \label{thm:mpu_fixed_product_locally_constant}
+  \lean{isLocallyConstant_pair_of_lowerSemicontinuous_nat_mul_eq}
+  \leanok
+  Let $r,\ell\colon X\to\mathbb N$ be lower semicontinuous. Suppose that
+  $c>0$ and
+  \begin{align}
+    r(x)\ell(x)&=c
+  \end{align}
+  for every $x\in X$. Then both $r$ and $\ell$ are locally constant.
+\end{theorem}
+
+\begin{proof}\leanok
+  Fix $x\in X$. Since $c>0$, both $r(x)$ and $\ell(x)$ are positive. Lower
+  semicontinuity gives a neighborhood $U$ of $x$ on which
+  \begin{align}
+    r(y)&\geq r(x),& \ell(y)&\geq\ell(x).
+  \end{align}
+  For $y\in U$, monotonicity of multiplication and the fixed-product identity
+  give
+  \begin{align}
+    r(x)\ell(x)
+      &\leq r(y)\ell(x)
+      \leq r(y)\ell(y)
+      =r(x)\ell(x).
+  \end{align}
+  Positivity permits cancellation, first of $\ell(x)$ and then of $r(x)$, so
+  $r(y)=r(x)$ and $\ell(y)=\ell(x)$.
+\end{proof}
+
+\begin{theorem}[Fixed positive product on a preconnected set]
+  \label{thm:mpu_fixed_product_preconnected}
+  \lean{eq_of_lowerSemicontinuous_nat_mul_eq_of_isPreconnected,
+    eq_of_lowerSemicontinuous_nat_mul_eq,
+    unitInterval_eq_of_lowerSemicontinuous_nat_mul_eq}
+  \leanok
+  Under the hypotheses of
+  Theorem~\ref{thm:mpu_fixed_product_locally_constant}, if $S\subseteq X$ is
+  preconnected, then for all $x,y\in S$,
+  \begin{align}
+    r(x)&=r(y),& \ell(x)&=\ell(y).
+  \end{align}
+  In particular, both functions are constant when $X$ is preconnected and
+  when $X=[0,1]$.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:mpu_fixed_product_locally_constant}
+  A locally constant function has open fibers. A preconnected set cannot meet
+  two disjoint nonempty open fibers, so each of $r$ and $\ell$ has one value
+  on $S$. The unit interval is connected, hence preconnected.
+\end{proof}
+
 \begin{proposition}[Constancy of the source ranks]
   \label{prop:continuity-index}
   \notready
@@ -5569,7 +5647,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \uses{def:mpu_canonical_form,ThmFund1,
     thm:mpu_two_projection_angle_defect_sum,
     thm:mpu_two_projection_reduced_projection,
-    thm:mpu_two_projection_reduced_projection_right_factor}
+    thm:mpu_two_projection_reduced_projection_right_factor,
+    thm:mpu_rank_lower_semicontinuous,
+    thm:mpu_fixed_product_preconnected}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors
   generating MPUs, without requiring the path to be in canonical form. For
   each $x$, take the canonical form and the two source-cut ranks $r(x)$ and


### PR DESCRIPTION
## What changed

- package finite complex matrix rank as a lower-semicontinuous natural-valued map, including composition with continuous matrix families
- prove that two lower-semicontinuous natural-valued functions with a fixed positive product are locally constant
- derive constancy on preconnected sets, preconnected spaces, and the unit interval
- add formula-driven Chapter 28 prerequisites while leaving `prop:continuity-index` not ready

## Validation

- `lake build TNLean.Algebra.MatrixRankClosed`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main...HEAD`

Closes #6436
Advances #6022
