### PR TITLE
feat(mpu): add common simple blocking continuity

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -23,6 +23,8 @@ arXiv:1606.00608.
 
 * `MPOTensor.blockTensor`: the tensor obtained by blocking an arbitrary number
   of adjacent sites.
+* `MPOTensor.continuous_blockTensor` and `Continuous.blockTensor`: fixed-length
+  blocking is continuous, including along continuous tensor families.
 * `MPOTensor.mpo_blockTensor_eq_reindex`: closing a blocked chain gives the
   corresponding longer unblocked chain.
 * `MPOTensor.IsMPDO.blockTensor`: physical blocking preserves the MPDO property.

--- a/TNLean/MPS/MPDO/PhysicalBlocking.lean
+++ b/TNLean/MPS/MPDO/PhysicalBlocking.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Topology.Instances.Matrix
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Channel.KrausCPTP
 import TNLean.MPS.Core.CyclicTrace
@@ -66,6 +67,45 @@ lemma blockTensor_apply (M : MPOTensor d D) (L : ℕ)
     blockTensor M L i j =
       evalWord M (MPSTensor.wordOfBlock d L i) (MPSTensor.wordOfBlock d L j) :=
   rfl
+
+/-- Word evaluation at fixed ket and bra words depends continuously on the MPO tensor.
+
+The recursive proof follows the ordered product in `evalWord`: the head matrix
+multiplies the continuously evaluated tail on the left. -/
+theorem continuous_evalWord (is js : List (Fin d)) :
+    Continuous (fun M : MPOTensor d D ↦ evalWord M is js) := by
+  induction is generalizing js with
+  | nil =>
+      cases js <;> exact continuous_const
+  | cons i is ih =>
+      cases js with
+      | nil => exact continuous_const
+      | cons j js =>
+          have hhead : Continuous (fun M : MPOTensor d D ↦ M i j) :=
+            (continuous_apply j).comp (continuous_apply i)
+          exact hhead.matrix_mul (ih js)
+
+/-- Physical blocking by a fixed length is continuous in the entries of the MPO tensor.
+
+Source: arXiv:1703.09188, proof of Proposition `prop:continuity-index`,
+lines 747--752. -/
+theorem continuous_blockTensor (L : ℕ) :
+    Continuous (fun M : MPOTensor d D ↦ blockTensor M L) := by
+  refine continuous_pi fun i ↦ continuous_pi fun j ↦ ?_
+  exact continuous_evalWord (MPSTensor.wordOfBlock d L i) (MPSTensor.wordOfBlock d L j)
+
+end MPOTensor
+
+/-- A continuous family of MPO tensors remains continuous after any fixed physical blocking.
+
+Source: arXiv:1703.09188, proof of Proposition `prop:continuity-index`,
+lines 747--752. -/
+theorem Continuous.blockTensor {X : Type*} [TopologicalSpace X] {d D : ℕ}
+    {M : X → MPOTensor d D} (hM : Continuous M) (L : ℕ) :
+    Continuous (fun x ↦ MPOTensor.blockTensor (M x) L) :=
+  (MPOTensor.continuous_blockTensor L).comp hM
+
+namespace MPOTensor
 
 /-- Canonical identification between the doubled physical index of an
 `L`-site MPO block and the `L`-site block of the doubled MPS index.

--- a/TNLean/MPS/MPU/SimpleBlocking.lean
+++ b/TNLean/MPS/MPU/SimpleBlocking.lean
@@ -891,6 +891,17 @@ theorem IsMPU.exists_blockTensor_isMPUSimple
     obtain ⟨k, hk, hklt, hsimple⟩ := hU.exists_blockTensor_isMPUSimple_of_one_lt hDgt
     exact ⟨k, hk, hklt.le, hsimple⟩
 
+/-- Every MPU of positive physical and bond dimensions is MPU-simple after
+blocking exactly \(D^4\) sites.
+
+Source: arXiv:1703.09188, proof of Proposition `prop:continuity-index`,
+lines 747--752. -/
+theorem IsMPU.blockTensor_pow_four_isMPUSimple
+    [NeZero d] [NeZero D] {U : MPOTensor d D} (hU : IsMPU U) :
+    IsMPUSimple (MPOTensor.blockTensor U (D ^ 4)) := by
+  obtain ⟨k, hk, hkD, hsimple⟩ := hU.exists_blockTensor_isMPUSimple
+  exact hU.blockTensor_isMPUSimple_of_le hk hkD hsimple
+
 end BlockingConstruction
 
 end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1020,8 +1020,7 @@ closing a chain of $N$ copies of $\mathcal U$.
         MPOTensor.continuous_blockTensor,
         Continuous.blockTensor}
     \leanok
-    \uses{def:mpdo_physical_blocking,thm:mpu_bounded_simple_blocking,
-        thm:mpu_all_later_simple_blockings}
+    \uses{def:mpu,def:mpu_simple,def:mpdo_physical_blocking}
     Let $d,D>0$.  Every bond-$D$ MPU tensor becomes simple after blocking
     exactly $D^4$ sites.  For each fixed $L$, the map
     \begin{align}
@@ -1037,6 +1036,8 @@ closing a chain of $N$ copies of $\mathcal U$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpu_bounded_simple_blocking,
+        thm:mpu_all_later_simple_blockings}
     Choose for each tensor a positive simple blocking length $k\leq D^4$.
     Simplicity persists at every later direct blocking, hence at $D^4$.
     For fixed blocked ket and bra words, every matrix entry of the blocked

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1013,6 +1013,39 @@ closing a chain of $N$ copies of $\mathcal U$.
     on $k'-k$ proves the claim.
 \end{proof}
 
+\begin{theorem}[Common simple blocking along a continuous MPU path]
+    \label{thm:mpu_common_pow_four_simple_blocking}
+    \lean{MPOTensor.IsMPU.blockTensor_pow_four_isMPUSimple,
+        MPOTensor.continuous_evalWord,
+        MPOTensor.continuous_blockTensor,
+        Continuous.blockTensor}
+    \leanok
+    \uses{def:mpdo_physical_blocking,thm:mpu_bounded_simple_blocking,
+        thm:mpu_all_later_simple_blockings}
+    Let $d,D>0$.  Every bond-$D$ MPU tensor becomes simple after blocking
+    exactly $D^4$ sites.  For each fixed $L$, the map
+    \begin{align}
+        \mathcal U&\longmapsto \mathcal U_L
+    \end{align}
+    is continuous.  Consequently, if $x\mapsto\mathcal W(x)$ is a continuous
+    family of bond-$D$ MPU tensors, then
+    $x\mapsto\mathcal W(x)_{D^4}$ is a continuous family of simple tensors.
+    This is only the common-blocking step in the proof of
+    Proposition~\ref{prop:continuity-index}; it does not choose reduced
+    representatives or assert constancy of their source ranks.
+    % Source lines: paper_v2.tex 747--752.
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose for each tensor a positive simple blocking length $k\leq D^4$.
+    Simplicity persists at every later direct blocking, hence at $D^4$.
+    For fixed blocked ket and bra words, every matrix entry of the blocked
+    tensor is a finite sum of products of entries of the original tensor.
+    These entries are continuous, and the finite product and sum operations
+    preserve continuity.  Applying this fixed blocking map to the original
+    path proves the path statement.
+\end{proof}
+
 \begin{theorem}[Supplied-projector simple2 contraction]
     \label{thm:mpu_supplied_projector_simple2}
     \lean{MPOTensor.IsMPUSimple.simple2_of_normalizedDiagonal_pow_eq_vecMulVec}
@@ -5567,6 +5600,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \notready
   \discussion{6022}
   \uses{def:mpu_canonical_form,ThmFund1,
+    thm:mpu_common_pow_four_simple_blocking,
     thm:mpu_two_projection_angle_defect_sum,
     thm:mpu_two_projection_reduced_projection,
     thm:mpu_two_projection_reduced_projection_right_factor}


### PR DESCRIPTION
## What changed

- prove every MPU has a simple blocking at the common length `D ^ 4`
- prove continuity of fixed-word evaluation and physical blocking in the tensor entries
- derive continuity of blocked continuous tensor families
- add Chapter 28 coverage with statement and proof dependencies separated, while leaving `prop:continuity-index` not ready

## Validation

- `lake build TNLean.MPS.MPDO.PhysicalBlocking TNLean.MPS.MPU.SimpleBlocking`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main...HEAD`

Closes #6438
Advances #6022
