### PR TITLE
feat(analysis): add ambient support inverse extension

### DIFF
--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -43,6 +43,8 @@ theory development.
 * `Matrix.PosSemidef.supportInvSqrt`: the inverse square root on the support.
 * `Matrix.PosSemidef.supportInvFourthRoot`: the negative quarter power on the support.
 * `Matrix.PosSemidef.supportInv`: the generalized inverse on the support.
+* `Matrix.PosSemidef.supportInvExtension`: the ambient invertible extension of
+  the generalized inverse by the identity on the orthogonal complement.
 * `Matrix.PosDef.supportInvSqrt_eq_inv_sqrt`: agreement with the ordinary
   inverse square root for positive-definite matrices.
 * `Matrix.PosSemidef.supportInvSqrt_smul`: compatibility with positive scaling.
@@ -675,6 +677,108 @@ theorem PosSemidef.supportProj_mul_supportInv {ρ : Matrix n n ℂ} (hρ : ρ.Po
 theorem PosSemidef.supportInv_mul_supportProj {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
     hρ.supportInv * hρ.supportProj = hρ.supportInv := by
   rw [PosSemidef.supportInv, Matrix.mul_assoc, hρ.supportInvSqrt_mul_supportProj]
+
+/-- The generalized inverse extended by the identity on the orthogonal complement
+of the support. For a positive-semidefinite matrix `ρ` with support projection
+`P`, this is `ρ⁺ + (1 - P)`.
+
+This is the ambient invertible matrix used in arXiv:1703.09188v2,
+Proposition IV.5, lines 786--797. -/
+noncomputable def PosSemidef.supportInvExtension
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
+  hρ.supportInv + (1 - hρ.supportProj)
+
+/-- The explicit inverse of `supportInvExtension`: the original matrix extended
+by the identity on the orthogonal complement of its support. -/
+noncomputable def PosSemidef.supportInvExtensionInverse
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
+  ρ + (1 - hρ.supportProj)
+
+/-- The ambient support-inverse extension left-multiplied by the original
+matrix gives the support projection: `X ρ = P`. -/
+theorem PosSemidef.supportInvExtension_mul_self
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInvExtension * ρ = hρ.supportProj := by
+  have hcomp : (1 - hρ.supportProj) * ρ = 0 := by
+    rw [Matrix.sub_mul, Matrix.one_mul, hρ.supportProj_mul_self, sub_self]
+  rw [PosSemidef.supportInvExtension, Matrix.add_mul, hcomp, add_zero]
+  simpa only [PosSemidef.supportProj] using hρ.supportInv_mul_self
+
+/-- The original matrix right-multiplied by its ambient support-inverse
+extension gives the support projection: `ρ X = P`. -/
+theorem PosSemidef.self_mul_supportInvExtension
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    ρ * hρ.supportInvExtension = hρ.supportProj := by
+  rw [PosSemidef.supportInvExtension, Matrix.mul_add]
+  have hleft : ρ * hρ.supportInv = hρ.supportProj := by
+    simpa only [PosSemidef.supportProj] using hρ.self_mul_supportInv
+  rw [hleft, Matrix.mul_sub, Matrix.mul_one, hρ.mul_supportProj_self, sub_self, add_zero]
+
+/-- The ambient support-inverse extension multiplied by its explicit inverse is
+the identity. -/
+theorem PosSemidef.supportInvExtension_mul_inverse
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInvExtension * hρ.supportInvExtensionInverse = 1 := by
+  have hinvρ : hρ.supportInv * ρ = hρ.supportProj := by
+    simpa only [PosSemidef.supportProj] using hρ.supportInv_mul_self
+  have hcompρ : (1 - hρ.supportProj) * ρ = 0 := by
+    rw [Matrix.sub_mul, Matrix.one_mul, hρ.supportProj_mul_self, sub_self]
+  have hcompidem : (1 - hρ.supportProj) * (1 - hρ.supportProj) =
+      1 - hρ.supportProj := by
+    calc
+      (1 - hρ.supportProj) * (1 - hρ.supportProj) =
+          1 - hρ.supportProj - hρ.supportProj + hρ.supportProj * hρ.supportProj := by
+        noncomm_ring
+      _ = 1 - hρ.supportProj := by rw [hρ.supportProj_idem]; abel
+  rw [PosSemidef.supportInvExtension, PosSemidef.supportInvExtensionInverse]
+  calc
+    (hρ.supportInv + (1 - hρ.supportProj)) * (ρ + (1 - hρ.supportProj)) =
+        hρ.supportProj + (1 - hρ.supportProj) := by
+      rw [Matrix.add_mul, Matrix.mul_add, Matrix.mul_add, hinvρ,
+        Matrix.mul_sub, Matrix.mul_one, hρ.supportInv_mul_supportProj, sub_self,
+        hcompρ, hcompidem]
+      simp
+    _ = 1 := by abel
+
+/-- The explicit inverse multiplied by the ambient support-inverse extension is
+the identity. -/
+theorem PosSemidef.supportInvExtension_inverse_mul
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInvExtensionInverse * hρ.supportInvExtension = 1 := by
+  have hρinv : ρ * hρ.supportInv = hρ.supportProj := by
+    simpa only [PosSemidef.supportProj] using hρ.self_mul_supportInv
+  have hcompidem : (1 - hρ.supportProj) * (1 - hρ.supportProj) =
+      1 - hρ.supportProj := by
+    calc
+      (1 - hρ.supportProj) * (1 - hρ.supportProj) =
+          1 - hρ.supportProj - hρ.supportProj + hρ.supportProj * hρ.supportProj := by
+        noncomm_ring
+      _ = 1 - hρ.supportProj := by rw [hρ.supportProj_idem]; abel
+  rw [PosSemidef.supportInvExtension, PosSemidef.supportInvExtensionInverse]
+  calc
+    (ρ + (1 - hρ.supportProj)) * (hρ.supportInv + (1 - hρ.supportProj)) =
+        hρ.supportProj + (1 - hρ.supportProj) := by
+      rw [Matrix.add_mul, Matrix.mul_add, Matrix.mul_add, hρinv,
+        Matrix.mul_sub, Matrix.mul_one, hρ.mul_supportProj_self, sub_self,
+        Matrix.sub_mul, Matrix.one_mul, hρ.supportProj_mul_supportInv, sub_self,
+        hcompidem]
+      simp
+    _ = 1 := by abel
+
+/-- The ambient support-inverse extension packaged as a unit, with inverse
+`ρ + (1 - P)`. -/
+noncomputable def PosSemidef.supportInvExtensionUnit
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) : (Matrix n n ℂ)ˣ :=
+  Units.mk hρ.supportInvExtension hρ.supportInvExtensionInverse
+    hρ.supportInvExtension_mul_inverse hρ.supportInvExtension_inverse_mul
+
+/-- The determinant of the ambient support-inverse extension is a unit. This
+form feeds directly into the matrix rank invariance lemmas. -/
+theorem PosSemidef.isUnit_det_supportInvExtension
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    IsUnit hρ.supportInvExtension.det :=
+  Matrix.isUnit_iff_isUnit_det hρ.supportInvExtension |>.mp
+    hρ.supportInvExtensionUnit.isUnit
 
 /-- On a positive-definite matrix, the generalized inverse on the support is
 the ordinary inverse. -/

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -682,8 +682,9 @@ theorem PosSemidef.supportInv_mul_supportProj {ρ : Matrix n n ℂ} (hρ : ρ.Po
 of the support. For a positive-semidefinite matrix `ρ` with support projection
 `P`, this is `ρ⁺ + (1 - P)`.
 
-This is the ambient invertible matrix used in arXiv:1703.09188v2,
-Proposition IV.5, lines 786--797. -/
+This construction gives an explicit witness for the ambient invertible matrix
+required in arXiv:1703.09188v2, Proposition IV.5, lines 786--797. The paper
+requires such a matrix but does not state this formula. -/
 noncomputable def PosSemidef.supportInvExtension
     {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
   hρ.supportInv + (1 - hρ.supportProj)
@@ -772,13 +773,19 @@ noncomputable def PosSemidef.supportInvExtensionUnit
   Units.mk hρ.supportInvExtension hρ.supportInvExtensionInverse
     hρ.supportInvExtension_mul_inverse hρ.supportInvExtension_inverse_mul
 
+/-- The ambient support-inverse extension is a unit. -/
+theorem PosSemidef.isUnit_supportInvExtension
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    IsUnit hρ.supportInvExtension :=
+  hρ.supportInvExtensionUnit.isUnit
+
 /-- The determinant of the ambient support-inverse extension is a unit. This
 form feeds directly into the matrix rank invariance lemmas. -/
 theorem PosSemidef.isUnit_det_supportInvExtension
     {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
     IsUnit hρ.supportInvExtension.det :=
   Matrix.isUnit_iff_isUnit_det hρ.supportInvExtension |>.mp
-    hρ.supportInvExtensionUnit.isUnit
+    hρ.isUnit_supportInvExtension
 
 /-- On a positive-definite matrix, the generalized inverse on the support is
 the ordinary inverse. -/

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -726,11 +726,7 @@ theorem PosSemidef.supportInvExtension_mul_inverse
     rw [Matrix.sub_mul, Matrix.one_mul, hρ.supportProj_mul_self, sub_self]
   have hcompidem : (1 - hρ.supportProj) * (1 - hρ.supportProj) =
       1 - hρ.supportProj := by
-    calc
-      (1 - hρ.supportProj) * (1 - hρ.supportProj) =
-          1 - hρ.supportProj - hρ.supportProj + hρ.supportProj * hρ.supportProj := by
-        noncomm_ring
-      _ = 1 - hρ.supportProj := by rw [hρ.supportProj_idem]; abel
+    simpa only [PosSemidef.supportProj] using hρ.isHermitian.one_sub_supportProj_idem
   rw [PosSemidef.supportInvExtension, PosSemidef.supportInvExtensionInverse]
   calc
     (hρ.supportInv + (1 - hρ.supportProj)) * (ρ + (1 - hρ.supportProj)) =
@@ -750,11 +746,7 @@ theorem PosSemidef.supportInvExtension_inverse_mul
     simpa only [PosSemidef.supportProj] using hρ.self_mul_supportInv
   have hcompidem : (1 - hρ.supportProj) * (1 - hρ.supportProj) =
       1 - hρ.supportProj := by
-    calc
-      (1 - hρ.supportProj) * (1 - hρ.supportProj) =
-          1 - hρ.supportProj - hρ.supportProj + hρ.supportProj * hρ.supportProj := by
-        noncomm_ring
-      _ = 1 - hρ.supportProj := by rw [hρ.supportProj_idem]; abel
+    simpa only [PosSemidef.supportProj] using hρ.isHermitian.one_sub_supportProj_idem
   rw [PosSemidef.supportInvExtension, PosSemidef.supportInvExtensionInverse]
   calc
     (ρ + (1 - hρ.supportProj)) * (hρ.supportInv + (1 - hρ.supportProj)) =

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5761,6 +5761,72 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   Theorem~\ref{thm:mpu_virtual_sandwich_source_cuts}.
 \end{proof}
 
+\begin{theorem}[Ambient support-inverse extension]
+  \label{thm:mpu_ambient_support_inverse_extension}
+  \lean{Matrix.PosSemidef.supportInvExtension,
+    Matrix.PosSemidef.supportInvExtensionInverse,
+    Matrix.PosSemidef.supportInvExtension_mul_self,
+    Matrix.PosSemidef.self_mul_supportInvExtension,
+    Matrix.PosSemidef.supportInvExtension_mul_inverse,
+    Matrix.PosSemidef.supportInvExtension_inverse_mul,
+    Matrix.PosSemidef.supportInvExtensionUnit,
+    Matrix.PosSemidef.isUnit_det_supportInvExtension}
+  \leanok
+  \uses{def:support_proj,def:support_inverse_square_root}
+  Let $A\succeq0$ have support projection $P$, and let $A^+$ denote its
+  inverse on the support. Set
+  \begin{align}
+    X_A&=A^++(\Id-P).
+  \end{align}
+  Its inverse is
+  \begin{align}
+    X_A^{-1}&=A+(\Id-P),
+  \end{align}
+  and multiplication by $A$ gives
+  \begin{align}
+    X_AA=AX_A&=P.
+  \end{align}
+  In particular, for positive semidefinite outer factors $L$ and $R$ with
+  support projections $P$ and $Q$, respectively, the invertible choices
+  $X=X_L$ and $Z=X_R$ satisfy
+  \begin{align}
+    XL&=P.
+  \end{align}
+  Similarly,
+  \begin{align}
+    RZ&=Q.
+  \end{align}
+  % Source: paper_v2.tex, Proposition IV.5, lines 786--797.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{lem:support_inverse_square_root_generalized_inverse}
+  The support identities give
+  \begin{align}
+    A^+A=AA^+&=P.
+  \end{align}
+  Their complementary forms are
+  \begin{align}
+    A^+(\Id-P)=(\Id-P)A^+&=0,
+  \end{align}
+  \begin{align}
+    A(\Id-P)=(\Id-P)A&=0,
+  \end{align}
+  and idempotence of $P$ gives
+  \begin{align}
+    (\Id-P)^2&=\Id-P.
+  \end{align}
+  Therefore
+  \begin{align}
+    X_AX_A^{-1}&=P+(\Id-P)=\Id.
+  \end{align}
+  Likewise,
+  \begin{align}
+    X_A^{-1}X_A&=P+(\Id-P)=\Id,
+  \end{align}
+  while multiplication by $A$ gives $X_AA=AX_A=P$.
+\end{proof}
+
 \begin{proposition}[Constancy of the source ranks]
   \label{prop:continuity-index}
   \notready
@@ -5772,7 +5838,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     thm:mpu_two_projection_reduced_projection_right_factor,
     thm:mpu_rank_lower_semicontinuous,
     thm:mpu_fixed_product_preconnected,
-    thm:mpu_virtual_sandwich_source_ranks}
+    thm:mpu_virtual_sandwich_source_ranks,
+    thm:mpu_ambient_support_inverse_extension}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors
   generating MPUs, without requiring the path to be in canonical form. For
   each $x$, take the canonical form and the two source-cut ranks $r(x)$ and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5761,28 +5761,40 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   Theorem~\ref{thm:mpu_virtual_sandwich_source_cuts}.
 \end{proof}
 
-\begin{theorem}[Ambient support-inverse extension]
-  \label{thm:mpu_ambient_support_inverse_extension}
+\begin{definition}[Ambient support-inverse extension]
+  \label{def:mpu_ambient_support_inverse_extension}
   \lean{Matrix.PosSemidef.supportInvExtension,
-    Matrix.PosSemidef.supportInvExtensionInverse,
-    Matrix.PosSemidef.supportInvExtension_mul_self,
+    Matrix.PosSemidef.supportInvExtensionInverse}
+  \leanok
+  \uses{def:support_proj,def:support_inverse_square_root}
+  Let $A\succeq0$ have support projection $P$, and let $A^+$ denote its
+  inverse on the support. Define
+  \begin{align}
+    X_A&=A^++(\Id-P).
+  \end{align}
+  Define also
+  \begin{align}
+    Z_A&=A+(\Id-P).
+  \end{align}
+  This construction gives explicit witnesses for the invertible matrices
+  required in Proposition~IV.5 of \cite{Cirac2017MPU}; the paper requires
+  those matrices but does not state these formulas.
+  % Source requirement: paper_v2.tex, Proposition IV.5, lines 786--797.
+  % The displayed construction is a formal witness, not a formula from the paper.
+\end{definition}
+
+\begin{theorem}[Invertibility and support identities]
+  \label{thm:mpu_ambient_support_inverse_extension}
+  \lean{Matrix.PosSemidef.supportInvExtension_mul_self,
     Matrix.PosSemidef.self_mul_supportInvExtension,
     Matrix.PosSemidef.supportInvExtension_mul_inverse,
     Matrix.PosSemidef.supportInvExtension_inverse_mul,
     Matrix.PosSemidef.supportInvExtensionUnit,
+    Matrix.PosSemidef.isUnit_supportInvExtension,
     Matrix.PosSemidef.isUnit_det_supportInvExtension}
   \leanok
-  \uses{def:support_proj,def:support_inverse_square_root}
-  Let $A\succeq0$ have support projection $P$, and let $A^+$ denote its
-  inverse on the support. Set
-  \begin{align}
-    X_A&=A^++(\Id-P).
-  \end{align}
-  Its inverse is
-  \begin{align}
-    X_A^{-1}&=A+(\Id-P),
-  \end{align}
-  and multiplication by $A$ gives
+  \uses{def:mpu_ambient_support_inverse_extension}
+  The matrices $X_A$ and $Z_A$ are mutually inverse, and
   \begin{align}
     X_AA=AX_A&=P.
   \end{align}
@@ -5796,7 +5808,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \begin{align}
     RZ&=Q.
   \end{align}
-  % Source: paper_v2.tex, Proposition IV.5, lines 786--797.
+  % This proves the existence step used in paper_v2.tex, lines 786--797.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -5818,11 +5830,11 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
   Therefore
   \begin{align}
-    X_AX_A^{-1}&=P+(\Id-P)=\Id.
+    X_AZ_A&=P+(\Id-P)=\Id.
   \end{align}
   Likewise,
   \begin{align}
-    X_A^{-1}X_A&=P+(\Id-P)=\Id,
+    Z_AX_A&=P+(\Id-P)=\Id,
   \end{align}
   while multiplication by $A$ gives $X_AA=AX_A=P$.
 \end{proof}


### PR DESCRIPTION
## What changed

- define the ambient support-inverse extension `A⁺ + (1 - P)` for a positive-semidefinite matrix
- prove both support identities `X * A = P` and `A * X = P`
- construct the explicit inverse `A + (1 - P)` and package matrix and determinant invertibility
- add formula-driven Chapter 28 coverage as the `XL = P`, `RZ = Q` prerequisite for source-rank comparison

## Validation

- `lake build TNLean.Analysis.MatrixSqrt TNLean.MPS.MPU.SourceFactors`
- proof-integrity diff scan
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main...HEAD`

Closes #6446
Advances #6022
