### PR TITLE
feat(MPS/MPU): add virtual sandwich rank formulas

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -41,3 +41,4 @@ import TNLean.MPS.MPU.TensorProduct
 import TNLean.MPS.MPU.ThreeFormSpan
 import TNLean.MPS.MPU.TransferMatrix
 import TNLean.MPS.MPU.TransferStabilization
+import TNLean.MPS.MPU.VirtualSandwich

--- a/TNLean/MPS/MPU/VirtualSandwich.lean
+++ b/TNLean/MPS/MPU/VirtualSandwich.lean
@@ -19,7 +19,7 @@ $A$ and $B$ preserve both source-cut ranks.
 
 This is the rank-preservation step in
 [Cirac--Perez-Garcia--Schuch--Verstraete 2017, arXiv:1703.09188],
-Proposition IV.5, lines 786--804.
+Proposition IV.5, lines 786--812.
 -/
 
 open scoped Matrix Kronecker
@@ -44,7 +44,7 @@ def virtualSandwich (A : Matrix (Fin D) (Fin D) ℂ) (U : MPOTensor d D)
 /-- Continuous families of virtual matrices and MPO tensors give a continuous
 family after virtual sandwiching.
 
-Source: arXiv:1703.09188, Proposition IV.5, lines 786--804. -/
+Source: arXiv:1703.09188, Proposition IV.5, lines 807--812. -/
 theorem continuous_virtualSandwich {X : Type*} [TopologicalSpace X]
     {A : X → Matrix (Fin D) (Fin D) ℂ} {U : X → MPOTensor d D}
     {B : X → Matrix (Fin D) (Fin D) ℂ} (hA : Continuous A)

--- a/TNLean/MPS/MPU/VirtualSandwich.lean
+++ b/TNLean/MPS/MPU/VirtualSandwich.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.SourceCuts
+import Mathlib.Topology.Instances.Matrix
+
+/-!
+# Virtual sandwiching of an MPO tensor
+
+This module studies the pointwise transformation
+$$
+  U^{ij} \longmapsto A U^{ij} B
+$$
+of an MPO tensor. Both raw source cuts are multiplied on the left by
+$A \otimes I_d$ and on the right by $I_d \otimes B$. Consequently, invertible
+$A$ and $B$ preserve both source-cut ranks.
+
+This is the rank-preservation step in
+[Cirac--Perez-Garcia--Schuch--Verstraete 2017, arXiv:1703.09188],
+Proposition IV.5, lines 786--804.
+-/
+
+open scoped Matrix Kronecker
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Sandwich every virtual matrix of an MPO tensor between two fixed matrices:
+$\widehat U^{ij}=A U^{ij}B$.
+
+Source: arXiv:1703.09188, Proposition IV.5, lines 786--804. -/
+def virtualSandwich (A : Matrix (Fin D) (Fin D) ℂ) (U : MPOTensor d D)
+    (B : Matrix (Fin D) (Fin D) ℂ) : MPOTensor d D :=
+  fun i j ↦ A * U i j * B
+
+@[simp] theorem virtualSandwich_apply (A : Matrix (Fin D) (Fin D) ℂ)
+    (U : MPOTensor d D) (B : Matrix (Fin D) (Fin D) ℂ) (i j : Fin d) :
+    virtualSandwich A U B i j = A * U i j * B :=
+  rfl
+
+/-- Continuous families of virtual matrices and MPO tensors give a continuous
+family after virtual sandwiching.
+
+Source: arXiv:1703.09188, Proposition IV.5, lines 786--804. -/
+theorem continuous_virtualSandwich {X : Type*} [TopologicalSpace X]
+    {A : X → Matrix (Fin D) (Fin D) ℂ} {U : X → MPOTensor d D}
+    {B : X → Matrix (Fin D) (Fin D) ℂ} (hA : Continuous A)
+    (hU : Continuous U) (hB : Continuous B) :
+    Continuous fun x ↦ virtualSandwich (A x) (U x) (B x) := by
+  refine continuous_pi fun i ↦ continuous_pi fun j ↦ ?_
+  have hUij : Continuous fun x ↦ U x i j :=
+    (continuous_apply j).comp ((continuous_apply i).comp hU)
+  simpa [virtualSandwich] using (hA.matrix_mul hUij).matrix_mul hB
+
+/-- The first raw source cut of a virtual sandwich is
+$(A\otimes I_d)M_1(U)(I_d\otimes B)$, with no transpose or conjugation.
+
+Source: arXiv:1703.09188, Proposition IV.5, lines 786--804. -/
+theorem sourceCutM₁_virtualSandwich (A : Matrix (Fin D) (Fin D) ℂ)
+    (U : MPOTensor d D) (B : Matrix (Fin D) (Fin D) ℂ) :
+    sourceCutM₁ (virtualSandwich A U B) =
+      (A ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) * sourceCutM₁ U *
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ B) := by
+  ext ⟨α, j⟩ ⟨i, β⟩
+  simp [virtualSandwich, sourceCutM₁, Matrix.mul_apply, Matrix.one_apply,
+    Fintype.sum_prod_type]
+
+/-- The second raw source cut of a virtual sandwich is
+$(A\otimes I_d)M_2(U)(I_d\otimes B)$, with no transpose or conjugation.
+
+Source: arXiv:1703.09188, Proposition IV.5, lines 786--804. -/
+theorem sourceCutM₂_virtualSandwich (A : Matrix (Fin D) (Fin D) ℂ)
+    (U : MPOTensor d D) (B : Matrix (Fin D) (Fin D) ℂ) :
+    sourceCutM₂ (virtualSandwich A U B) =
+      (A ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) * sourceCutM₂ U *
+        ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ B) := by
+  ext ⟨α, i⟩ ⟨j, β⟩
+  simp [virtualSandwich, sourceCutM₂, Matrix.mul_apply, Matrix.one_apply,
+    Fintype.sum_prod_type]
+
+private lemma isUnit_det_kronecker_one (A : Matrix (Fin D) (Fin D) ℂ)
+    (hA : IsUnit A) :
+    IsUnit (A ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)).det := by
+  rw [Matrix.det_kronecker]
+  simpa using ((Matrix.isUnit_iff_isUnit_det A).mp hA).pow d
+
+private lemma isUnit_det_one_kronecker (B : Matrix (Fin D) (Fin D) ℂ)
+    (hB : IsUnit B) :
+    IsUnit ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ B).det := by
+  rw [Matrix.det_kronecker]
+  simpa using ((Matrix.isUnit_iff_isUnit_det B).mp hB).pow d
+
+/-- Invertible virtual matrices preserve the right source rank.
+
+Source: arXiv:1703.09188, Proposition IV.5, lines 786--804. -/
+theorem rightRank_virtualSandwich (A : Matrix (Fin D) (Fin D) ℂ)
+    (U : MPOTensor d D) (B : Matrix (Fin D) (Fin D) ℂ)
+    (hA : IsUnit A) (hB : IsUnit B) :
+    r[virtualSandwich A U B] = r[U] := by
+  rw [rightRank, sourceCutM₁_virtualSandwich]
+  rw [Matrix.rank_mul_eq_left_of_isUnit_det _ _ (isUnit_det_one_kronecker B hB)]
+  exact Matrix.rank_mul_eq_right_of_isUnit_det _ _ (isUnit_det_kronecker_one A hA)
+
+/-- Invertible virtual matrices preserve the left source rank.
+
+Source: arXiv:1703.09188, Proposition IV.5, lines 786--804. -/
+theorem leftRank_virtualSandwich (A : Matrix (Fin D) (Fin D) ℂ)
+    (U : MPOTensor d D) (B : Matrix (Fin D) (Fin D) ℂ)
+    (hA : IsUnit A) (hB : IsUnit B) :
+    ℓ[virtualSandwich A U B] = ℓ[U] := by
+  rw [leftRank, sourceCutM₂_virtualSandwich]
+  rw [Matrix.rank_mul_eq_left_of_isUnit_det _ _ (isUnit_det_one_kronecker B hB)]
+  exact Matrix.rank_mul_eq_right_of_isUnit_det _ _ (isUnit_det_kronecker_one A hA)
+
+end MPOTensor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5678,8 +5678,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \label{def:mpu_virtual_sandwich}
   \lean{MPOTensor.virtualSandwich,MPOTensor.virtualSandwich_apply}
   \leanok
-  \uses{}
-  For an MPO tensor $\mathcal U=(U^{ij})_{i,j=1}^d$ of bond dimension $D$
+  For an MPO tensor $\mathcal U=(U^{ij})_{0\leq i,j<d}$ of bond dimension $D$
   and matrices $A,B\in\mathbb C^{D\times D}$, define
   \begin{align}
     \widehat{\mathcal U}^{ij}&=A U^{ij}B.
@@ -5698,7 +5697,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     x\longmapsto A(x)\mathcal U(x)B(x)
   \end{align}
   is continuous.
-  % Source lines: paper_v2.tex 786--804.
+  % Source lines: paper_v2.tex 807--812.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -5772,7 +5771,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     thm:mpu_two_projection_reduced_projection,
     thm:mpu_two_projection_reduced_projection_right_factor,
     thm:mpu_rank_lower_semicontinuous,
-    thm:mpu_fixed_product_preconnected}
+    thm:mpu_fixed_product_preconnected,
+    thm:mpu_virtual_sandwich_source_ranks}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors
   generating MPUs, without requiring the path to be in canonical form. For
   each $x$, take the canonical form and the two source-cut ranks $r(x)$ and

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5674,6 +5674,94 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   on $S$. The unit interval is connected, hence preconnected.
 \end{proof}
 
+\begin{definition}[Virtual sandwich]
+  \label{def:mpu_virtual_sandwich}
+  \lean{MPOTensor.virtualSandwich,MPOTensor.virtualSandwich_apply}
+  \leanok
+  \uses{}
+  For an MPO tensor $\mathcal U=(U^{ij})_{i,j=1}^d$ of bond dimension $D$
+  and matrices $A,B\in\mathbb C^{D\times D}$, define
+  \begin{align}
+    \widehat{\mathcal U}^{ij}&=A U^{ij}B.
+  \end{align}
+  % Source lines: paper_v2.tex 786--804.
+\end{definition}
+
+\begin{theorem}[Continuity of the virtual sandwich]
+  \label{thm:mpu_virtual_sandwich_continuous}
+  \lean{MPOTensor.continuous_virtualSandwich}
+  \leanok
+  \uses{def:mpu_virtual_sandwich}
+  If $x\mapsto A(x)$, $x\mapsto\mathcal U(x)$, and $x\mapsto B(x)$ are
+  continuous families, then
+  \begin{align}
+    x\longmapsto A(x)\mathcal U(x)B(x)
+  \end{align}
+  is continuous.
+  % Source lines: paper_v2.tex 786--804.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{def:mpu_virtual_sandwich}
+  Every matrix entry is a finite sum of products of entries of $A(x)$,
+  $\mathcal U(x)$, and $B(x)$, hence is continuous.
+\end{proof}
+
+\begin{theorem}[Source cuts of a virtual sandwich]
+  \label{thm:mpu_virtual_sandwich_source_cuts}
+  \lean{MPOTensor.sourceCutM₁_virtualSandwich,
+    MPOTensor.sourceCutM₂_virtualSandwich}
+  \leanok
+  \uses{def:mpu_virtual_sandwich,def:mpu_source_matrix_one,
+    def:mpu_source_matrix_two}
+  The two raw source cuts satisfy the literal formulas
+  \begin{align}
+    M_1(\widehat{\mathcal U})
+      &=(A\otimes I_d)M_1(\mathcal U)(I_d\otimes B),\\
+    M_2(\widehat{\mathcal U})
+      &=(A\otimes I_d)M_2(\mathcal U)(I_d\otimes B).
+  \end{align}
+  No transpose or conjugation occurs in either identity.
+  % Source lines: paper_v2.tex 786--804.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{def:mpu_virtual_sandwich,def:mpu_source_matrix_one,
+    def:mpu_source_matrix_two}
+  For $a=1,2$, expand an entry of the right-hand side. The identity factors
+  collapse the two physical sums, leaving
+  \begin{align}
+    \sum_{\gamma,\delta}
+      A_{\alpha\gamma}U^{ij}_{\gamma\delta}B_{\delta\beta}
+      &=(A U^{ij}B)_{\alpha\beta},
+  \end{align}
+  which is the corresponding entry of $M_a(\widehat{\mathcal U})$.
+\end{proof}
+
+\begin{theorem}[Source ranks of a virtual sandwich]
+  \label{thm:mpu_virtual_sandwich_source_ranks}
+  \lean{MPOTensor.rightRank_virtualSandwich,
+    MPOTensor.leftRank_virtualSandwich}
+  \leanok
+  \uses{def:mpu_virtual_sandwich,def:mpu_right_rank,def:mpu_left_rank}
+  If $A$ and $B$ are invertible, then
+  \begin{align}
+    r[\widehat{\mathcal U}]&=r[\mathcal U],&
+    \ell[\widehat{\mathcal U}]&=\ell[\mathcal U].
+  \end{align}
+  This assertion concerns the raw source ranks only.
+  % Source lines: paper_v2.tex 786--804.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:mpu_virtual_sandwich_source_cuts}
+  The determinant identities for Kronecker products show that
+  $A\otimes I_d$ and $I_d\otimes B$ are invertible. Left and right
+  multiplication by these matrices preserves rank. Apply this observation to
+  each source-cut formula in
+  Theorem~\ref{thm:mpu_virtual_sandwich_source_cuts}.
+\end{proof}
+
 \begin{proposition}[Constancy of the source ranks]
   \label{prop:continuity-index}
   \notready


### PR DESCRIPTION
## What changed

- define two-sided virtual multiplication `U^{ij} ↦ A U^{ij} B` and prove continuity for continuous matrix and tensor families
- prove the literal source-cut formulas `(A ⊗ I_d) M₁(U) (I_d ⊗ B)` and `(A ⊗ I_d) M₂(U) (I_d ⊗ B)`
- prove invariance of both source ranks under invertible virtual factors
- register the focused module in the MPU aggregator and add source-faithful Chapter 28 coverage without claiming continuity of the paper's chosen factors

## Validation

- `lake build TNLean.MPS.MPU.VirtualSandwich TNLean.MPS.MPU`
- proof-integrity diff scan
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- generated aggregator check
- `git diff --check origin/main...HEAD`

Closes #6445
Advances #6022
