### PR TITLE
fix(parent-hamiltonian): resolve selected review follow-ups

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -60,9 +60,15 @@ theorem contiguousRestrictₗ_apply {N : ℕ} (s M : ℕ) (hsM : s + M ≤ N)
 /-- Restricting an open-boundary MPS vector to a contiguous window gives an
 open-boundary MPS vector on that window.
 
-The matrices outside the window are absorbed into its boundary matrix. This is
-the nonwrapping restriction in Nachtergaele, arXiv:cond-mat/9410110, equation
-(3.12). -/
+Let \(w_L=(τ_0,\ldots,τ_{s-1})\) and
+\(w_R=(τ_{s+L},\ldots,τ_{N-1})\) be the fixed words to the left and right of
+the window. The concrete boundary-matrix identity is
+\[
+  \operatorname{Res}_{s,L}^{τ}\Gamma_N(X)
+    = \Gamma_L\!\left(A^{w_R} X A^{w_L}\right).
+\]
+This is the nonwrapping restriction in Nachtergaele,
+arXiv:cond-mat/9410110, equation (3.12). -/
 theorem contiguousRestrictₗ_groundSpaceMap_mem_groundSpace
     {A : MPSTensor d D} {s L N : ℕ} (hsL : s + L ≤ N)
     (τ : Fin N → Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OpenHamiltonian.lean
@@ -13,10 +13,11 @@ For a chain of length `N`, this file sums the canonical local parent interaction
 only over starts whose length-`L` windows stay inside the linear interval.  Thus
 no local term crosses the cut between the last and first sites.
 
-When the tensor is block-injective at length \(L₀\), with \(0 < L₀\) and
-\(L₀ + 1 \le N\), the kernel of the length-\(L₀ + 1\) open Hamiltonian is the
-open MPS boundary-condition space `groundSpaceES A N`.  This is the finite-volume
-ground-space input for Nachtergaele's C1--C3 martingale theorem.
+When the tensor has virtual dimension \(D \ge 1\) and is block-injective at
+length \(L₀\), with \(0 < L₀\) and \(L₀ + 1 \le N\), the kernel of the
+length-\(L₀ + 1\) open Hamiltonian is the open MPS boundary-condition space
+`groundSpaceES A N`. This is the finite-volume ground-space input for
+Nachtergaele's C1--C3 martingale theorem.
 
 ## References
 
@@ -95,7 +96,11 @@ theorem openParentHamiltonianES_self_norm_eq_of_mem_orthogonal_ker
 full-window volume.
 
 This is \(γ_{l+1} = 1\) in Nachtergaele, arXiv:cond-mat/9410110,
-Theorem 2.1(i), for \(L = l + 1\). -/
+Theorem 2.1(i), for \(L = l + 1\).
+
+**Scope restriction (single-window volume):** This proves only the volume
+\(N=L\). It does not establish the general-volume C1--C3 martingale gap; see
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem openParentHamiltonianES_self_unit_gap (A : MPSTensor d D)
     {L : ℕ} (hL : 0 < L) (v : EuclideanSpace ℂ (Cfg d L))
     (hv : v ∈ (LinearMap.ker (openParentHamiltonianES A L L))ᗮ) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -974,26 +974,19 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) :
     HasUniqueGroundState (chainGroundSpace A (2 * L₀) N) := by
-  have hNormal : IsNormal A := ⟨L₀, hL₀, hA⟩
-  have hN' : L₀ + 1 ≤ N := by omega
-  rw [HasUniqueGroundState,
-    chainGroundSpace_eq_mpvSubmodule_normal hNormal hA hL₀ (by omega) (by omega) hN
-      hN']
-  have hmpv := mpv_ne_zero_of_isNBlkInjective hA hL₀ hN'
-  change Module.finrank ℂ (ℂ ∙ (mpv A : NSiteSpace d N)) = 1
-  exact finrank_span_singleton (K := ℂ) hmpv
+  exact parentHamiltonian_unique_gs hA hL₀ (by omega) hN
 
+set_option linter.unusedVariables false in
 /-- Unique ground state for normal tensors at range \(L₀+1\) on every ring
 with \(L₀+1\le N\): \(\dim \mathcal G_{N,L₀+1}(A)=1\). This is
-arXiv:2011.12127, Section IV.C, lines 2086--2094. -/
+arXiv:2011.12127, Section IV.C, lines 2086--2094.
+
+The normality hypothesis is redundant because positive-length block injectivity already
+implies normality; it is retained in this specialization. -/
+@[nolint unusedArguments]
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :
     HasUniqueGroundState (chainGroundSpace A (L₀ + 1) N) := by
-  rw [HasUniqueGroundState,
-    chainGroundSpace_eq_mpvSubmodule_normal hA hInj hL₀ (by omega) (by omega)
-      hN hN]
-  have hmpv := mpv_ne_zero_of_isNBlkInjective hInj hL₀ hN
-  change Module.finrank ℂ (ℂ ∙ (mpv A : NSiteSpace d N)) = 1
-  exact finrank_span_singleton (K := ℂ) hmpv
+  exact parentHamiltonian_unique_gs hInj hL₀ (by omega) hN
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing_comparisons.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing_comparisons.tex
@@ -82,7 +82,8 @@
 
 \begin{proof}
     \leanok
-    \uses{def:ground_space_parent, rem:cyclic_window_operators}
+    \uses{def:ground_space_parent, rem:cyclic_window_operators,
+        thm:contiguous_restriction_ground_space_map}
     When the window stays inside the chosen linear interval, the boundary matrix
     remains outside the window. Write
     $A_{\mathrm{left}}=A^j_{\tau_0}\cdots A^j_{\tau_{i-1}}$ and

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_reverse.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_reverse.tex
@@ -658,9 +658,20 @@ change-of-cut theorem replaces the complementary-word comparison.
     \uses{def:normal, thm:chain_ground_space_eq_mpv_normal,
         thm:mpv_ne_zero_blk_injective}
     Block injectivity at the positive length $L_0$ makes $A$ normal. Hence
-    Theorem~\ref{thm:chain_ground_space_eq_mpv_normal} identifies the ground
-    space with $\spn\{V^{(N)}(A)\}$. The MPV is nonzero by
-    Theorem~\ref{thm:mpv_ne_zero_blk_injective}, so this span has dimension one.
+    Theorem~\ref{thm:chain_ground_space_eq_mpv_normal} gives
+    \begin{align}
+        \mathcal G_{N,L}(A)
+        &=\spn\bigl\{V^{(N)}(A)\bigr\}.
+    \end{align}
+    The block-injectivity nonvanishing theorem gives
+    \begin{align}
+        V^{(N)}(A)&\neq0.
+    \end{align}
+    Therefore
+    \begin{align}
+        \dim\mathcal G_{N,L}(A)
+        &=\dim\spn\bigl\{V^{(N)}(A)\bigr\}=1.
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Unique ground state on the periodic chain]%
@@ -690,19 +701,35 @@ change-of-cut theorem replaces the complementary-word comparison.
     \label{thm:unique_gs_injective}
     \lean{MPSTensor.parentHamiltonian_unique_gs_injective}
     \leanok
-    \uses{thm:chain_ground_space_eq_mpv_normal}
+    \uses{def:chain_ground_space, def:l_blk_injective,
+        def:has_unique_ground_state}
     If $A$ becomes injective after blocking $L_0 > 0$ sites and $D \ge 1$,
     the parent Hamiltonian with interaction range $2L_0$ has a unique ground
     state on every periodic chain with $N \ge 2L_0$. In particular, this
     includes $L_0=1$ and $N=2$.
 \end{theorem}
 
+\begin{proof}
+    \leanok
+    \uses{thm:parent_hamiltonian_unique_gs}
+    Since $L_0>0$, one has $L_0<2L_0$. The result is therefore the case
+    $L=2L_0$ of Theorem~\ref{thm:parent_hamiltonian_unique_gs}.
+\end{proof}
+
 \begin{theorem}[Unique ground state for normal tensors at range $L_0+1$]%
     \label{thm:unique_gs_normal}
     \lean{MPSTensor.parentHamiltonian_unique_gs_normal}
     \leanok
-    \uses{thm:unique_gs_injective}
+    \uses{def:chain_ground_space, def:normal, def:l_blk_injective,
+        def:has_unique_ground_state}
     If $A$ is normal, becomes injective after blocking $L_0 > 0$ sites, and
     $D \ge 1$, then the parent Hamiltonian with interaction range $L_0 + 1$
     has a unique ground state on every periodic chain with $L_0+1\le N$.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:parent_hamiltonian_unique_gs}
+    The inequalities $L_0<L_0+1\leq N$ put this statement in the range of
+    Theorem~\ref{thm:parent_hamiltonian_unique_gs}.
+\end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -786,10 +786,11 @@ Nachtergaele~\cite[Equation~(3.12)]{Nachtergaele1996Spectral}, whose
 zero-energy space is identified in Equation~(3.13). Equations~(3.14)--(3.16)
 continue with comparison of compatible interactions, approximate commutation
 of ground-state projectors, and a uniform gap. Theorem~2.1(i) of the same
-source obtains a gap from its three stated hypotheses. In addition to the
-compatible Hamiltonian and its zero-energy space, the statements below verify
-only the unit norm lower bound at the full-window volume $N=L$. They give no
-gap estimate for $N>L$ and no periodic coercivity.
+source obtains a gap from its three stated hypotheses. Every compatible
+Hamiltonian below is positive because it is a sum of orthogonal projections.
+In addition to the compatible Hamiltonian and its zero-energy space, the
+statements below verify only the unit norm lower bound at the full-window volume
+$N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{definition}[Compatible open-chain parent Hamiltonian]
     \label{def:open_parent_hamiltonian_es}
@@ -819,19 +820,37 @@ gap estimate for $N>L$ and no periodic coercivity.
     \leanok
     \uses{def:open_parent_hamiltonian_es,
         rem:euclidean_local_projector_ingredients}
-    If $L>0$, then $I_{L,L}=\{0\}$ and
+    If $L>0$, then
     \begin{align}
         H^{\mathrm{open}}_{L,L}(A)
-        &=h_{0,\mathrm{ES}}(A,L)=P_L^{\mathrm{ES}}(A).
+        &=P_L^{\mathrm{ES}}(A).
         \label{eq:open_parent_hamiltonian_full_window}
     \end{align}
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The inequality $i+L\leq L$ forces $i=0$. For this sole window, restriction
-    to the full chain and extraction of the window are both the identity, so
-    the local term is $P_L^{\mathrm{ES}}(A)$.
+    \uses{def:open_parent_hamiltonian_es, rem:cyclic_window_operators,
+        def:extract_window, lem:blocked_original_aligned_sparse_sum}
+    The interaction has one window:
+    \begin{align}
+        I_{L,L}&=\{0\}.
+    \end{align}
+    On that window, restriction and extraction are identities:
+    \begin{align}
+        \Res^\tau_{0,L}v&=v.
+    \end{align}
+    Likewise,
+    \begin{align}
+        \sigma_{[0,L-1]}&=\sigma.
+    \end{align}
+    Therefore
+    \begin{align}
+        H^{\mathrm{open}}_{L,L}(A)
+        &=\sum_{i\in I_{L,L}}h_{i,\mathrm{ES}}(A,L)
+          =h_{0,\mathrm{ES}}(A,L)
+          =P_L^{\mathrm{ES}}(A).
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Unit gap at the full-window volume]
@@ -844,9 +863,11 @@ gap estimate for $N>L$ and no periodic coercivity.
     $v\in(\ker H^{\mathrm{open}}_{L,L}(A))^\perp$, then
     \begin{align}
         \lVert H^{\mathrm{open}}_{L,L}(A)v\rVert
-        &=\lVert v\rVert,
+        &=\lVert v\rVert.
         \label{eq:open_parent_hamiltonian_full_window_norm}
-        \\
+    \end{align}
+    In particular,
+    \begin{align}
         \lVert v\rVert
         &\leq\lVert H^{\mathrm{open}}_{L,L}(A)v\rVert.
     \end{align}
@@ -857,11 +878,25 @@ gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{proof}
     \leanok
-    \uses{thm:open_parent_hamiltonian_full_window}
-    By~(\ref{eq:open_parent_hamiltonian_full_window}), the Hamiltonian is the
-    orthogonal projector onto $(G_L^{\mathrm{ES}}(A))^\perp$. Its kernel is
-    $G_L^{\mathrm{ES}}(A)$, and an orthogonal projector preserves the norm of
-    every vector in its range. The inequality is the resulting equality.
+    \uses{thm:open_parent_hamiltonian_full_window,
+        lem:parent_interaction_es_kernel}
+    The full-window identity and the local kernel formula give
+    \begin{align}
+        \ker H^{\mathrm{open}}_{L,L}(A)
+        &=\ker P_L^{\mathrm{ES}}(A)=G_L^{\mathrm{ES}}(A).
+    \end{align}
+    Hence $v$ belongs to $(G_L^{\mathrm{ES}}(A))^\perp$, where the orthogonal
+    projector $P_L^{\mathrm{ES}}(A)$ acts as the identity. Thus
+    \begin{align}
+        \left\lVert H^{\mathrm{open}}_{L,L}(A)v\right\rVert
+        &=\left\lVert P_L^{\mathrm{ES}}(A)v\right\rVert
+          =\lVert v\rVert.
+    \end{align}
+    Consequently,
+    \begin{align}
+        \lVert v\rVert
+        &\leq\left\lVert H^{\mathrm{open}}_{L,L}(A)v\right\rVert.
+    \end{align}
 \end{proof}
 
 \begin{lemma}[Positivity of the compatible open-chain Hamiltonian]
@@ -904,6 +939,46 @@ gap estimate for $N>L$ and no periodic coercivity.
     projection. Hence every local term annihilates $v$.
 \end{proof}
 
+\begin{theorem}[Restriction of an open-boundary MPS vector]
+    \label{thm:contiguous_restriction_ground_space_map}
+    \lean{MPSTensor.contiguousRestrictₗ_groundSpaceMap_mem_groundSpace}
+    \leanok
+    \uses{def:ground_space_parent, rem:contiguous_window_operators}
+    Assume $s+L\leq N$. For every boundary matrix $X$ and complementary
+    configuration $\tau$,
+    \begin{align}
+        \Res^\tau_{s,L}\Gamma_N^A(X)&\in G_L(A).
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:ground_space_map_apply, lem:eval_word_append}
+    For the fixed words
+    \begin{align}
+        w_L&=(\tau_0,\ldots,\tau_{s-1}),
+    \end{align}
+    and
+    \begin{align}
+        w_R&=(\tau_{s+L},\ldots,\tau_{N-1}),
+    \end{align}
+    the word of a configuration obtained by inserting the window word $\omega$
+    is
+    \begin{align}
+        A^{w_L\omega w_R}&=A^{w_L}A^\omega A^{w_R}.
+    \end{align}
+    Cyclicity of the trace gives
+    \begin{align}
+        \operatorname{tr}\!\left(A^{w_L}A^\omega A^{w_R}X\right)
+        &=\operatorname{tr}\!\left(A^\omega A^{w_R}XA^{w_L}\right),
+    \end{align}
+    and hence
+    \begin{align}
+        \Res^\tau_{s,L}\Gamma_N^A(X)
+        &=\Gamma_L^A\!\left(A^{w_R}XA^{w_L}\right)\in G_L(A).
+    \end{align}
+\end{proof}
+
 \begin{theorem}[Open-boundary vectors have zero compatible energy]
     \label{thm:open_ground_space_le_hamiltonian_kernel}
     \lean{MPSTensor.groundSpaceES_le_ker_openParentHamiltonianES}
@@ -918,17 +993,18 @@ gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{proof}
     \leanok
-    \uses{lem:mem_ground_space_es, rem:contiguous_window_operators,
+    \uses{lem:mem_ground_space_es,
+        thm:contiguous_restriction_ground_space_map,
         rem:cyclic_window_operators, lem:local_term_es_kernel_restrictions}
-    Let $v=\Gamma_N(X)\in G_N^{\mathrm{ES}}(A)$. For a non-wrapping window
-    $[s,s+L-1]$ and a complementary configuration $\tau$, the restriction is
+    Let $v=\Gamma_N(X)\in G_N^{\mathrm{ES}}(A)$. For every non-wrapping
+    window $[s,s+L-1]$ and complementary configuration $\tau$,
+    Theorem~\ref{thm:contiguous_restriction_ground_space_map} gives
     \begin{align}
-        \Res^\tau_{s,L}\Gamma_N(X)
-        &=\Gamma_L\!\left(
-            A^{\tau_{s+L}\cdots\tau_{N-1}}X
-            A^{\tau_0\cdots\tau_{s-1}}
-          \right)
-        \in G_L^{\mathrm{ES}}(A).
+        \Res^\tau_{s,L}\Gamma_N(X)&\in G_L(A).
+    \end{align}
+    Lemma~\ref{lem:mem_ground_space_es} identifies this condition with
+    \begin{align}
+        \Res^\tau_{s,L}\Gamma_N(X)&\in G_L^{\mathrm{ES}}(A).
     \end{align}
     The local kernel criterion therefore shows that every compatible local term
     annihilates $v$.

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -115,6 +115,19 @@ projection estimates inherited from Fannes--Nachtergaele--Werner
 obtains a sufficient range-two estimate after physical blocking.  The optimized
 FNW numerator and the identification of its source constants remain open.
 
+\subsection{Unit bound at the full-window volume}
+
+At the full-window volume $N=L$ with $L>0$, the compatible open Hamiltonian
+consists of one orthogonal projection:
+\[
+  H^{\mathrm{open}}_{L,L}(A)=P_L^{\mathrm{ES}}(A).
+\]
+Consequently it preserves the norm on the orthogonal complement of its kernel.
+This identity verifies only the single-window case.  It gives no gap estimate
+for $N>L$.  The general-volume result instead requires the C1--C3 ingredients
+described below: the open-chain ground-space intersection, the quantitative
+projector-defect estimate, and the finite-row martingale reduction.
+
 \subsection{Open-chain projector geometry}
 
 The source-faithful open-chain geometry is now isolated before any cyclic


### PR DESCRIPTION
## What changed

- route the legacy unique-ground-state wrappers through the general interaction-range theorem without changing their APIs
- add exact Blueprint coverage for contiguous open-boundary restrictions and synchronize direct proof dependencies
- state the virtual-dimension hypothesis in the open-Hamiltonian header
- make the full-window unit-bound statements and proof sketches match the checked Lean declarations
- record explicitly that the unit bound at `N = L` is not the general-volume C1-C3 gap

This resolves the outstanding review threads on PRs #6429, #6431, #6440, and #6441.

## Validation

- `lake build` (10119 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- two `lualatex` passes with `TEXINPUTS="../../tex/tenkz//:"`
- `git diff --check`

Exact-head Lean and Blueprint specialist reviews approved `cb47f51c84d6064dfd91ba4c94e85e1211b33f46`.