### PR TITLE
docs(parent-hamiltonian): finish delayed review follow-ups

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
@@ -49,6 +49,7 @@
     \lean{MPSTensor.parentInteractionES}
     \lean{MPSTensor.cyclicRestrictES}
     \lean{MPSTensor.localTermES}
+    \lean{MPSTensor.localTermES_apply}
     \lean{MPSTensor.localTermESSummand}
     \leanok
     \uses{def:ground_space_es, rem:cyclic_window_operators}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -831,18 +831,19 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 \begin{proof}
     \leanok
     \uses{def:open_parent_hamiltonian_es, rem:cyclic_window_operators,
-        def:extract_window, lem:blocked_original_aligned_sparse_sum}
+        def:extract_window, rem:euclidean_local_projector_ingredients}
     The interaction has one window:
     \begin{align}
         I_{L,L}&=\{0\}.
     \end{align}
-    On that window, restriction and extraction are identities:
+    The outside region is empty, so it has a unique configuration $\tau$.
+    Cyclic restriction to the sole window is the identity:
     \begin{align}
-        \Res^\tau_{0,L}v&=v.
+        R_{0,\tau}v&=v.
     \end{align}
     Likewise,
     \begin{align}
-        \sigma_{[0,L-1]}&=\sigma.
+        \sigma|_{[0,L-1]}&=\sigma.
     \end{align}
     Therefore
     \begin{align}
@@ -996,18 +997,24 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     \uses{lem:mem_ground_space_es,
         thm:contiguous_restriction_ground_space_map,
         rem:cyclic_window_operators, lem:local_term_es_kernel_restrictions}
-    Let $v=\Gamma_N(X)\in G_N^{\mathrm{ES}}(A)$. For every non-wrapping
-    window $[s,s+L-1]$ and complementary configuration $\tau$,
+    Let $v=\iota_N(\Gamma_N^A(X))\in G_N^{\mathrm{ES}}(A)$. For every
+    non-wrapping window $[s,s+L-1]$ and complementary configuration $\tau$,
     Theorem~\ref{thm:contiguous_restriction_ground_space_map} gives
     \begin{align}
-        \Res^\tau_{s,L}\Gamma_N(X)&\in G_L(A).
+        \Res^\tau_{s,L}\Gamma_N^A(X)&\in G_L(A).
     \end{align}
-    Lemma~\ref{lem:mem_ground_space_es} identifies this condition with
+    The non-wrapping identification and
+    Lemma~\ref{lem:mem_ground_space_es} then give
     \begin{align}
-        \Res^\tau_{s,L}\Gamma_N(X)&\in G_L^{\mathrm{ES}}(A).
+        R_{s,\tau}v
+        &=\iota_L\!\left(\Res^\tau_{s,L}\Gamma_N^A(X)\right)
+          \in G_L^{\mathrm{ES}}(A).
     \end{align}
-    The local kernel criterion therefore shows that every compatible local term
-    annihilates $v$.
+    The local kernel criterion therefore gives
+    \begin{align}
+        h_{s,\mathrm{ES}}(A,L)v&=0.
+    \end{align}
+    Thus every compatible local term annihilates $v$.
 \end{proof}
 
 \begin{theorem}[Compatible zero energy has open-boundary form]
@@ -2609,8 +2616,7 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{lemma}[Blocked local terms and the aligned sparse sum]
     \label{lem:blocked_original_aligned_sparse_sum}
-    \lean{MPSTensor.localTermES_apply,
-        MPSTensor.parentInteractionES_blockTensor_conj,
+    \lean{MPSTensor.parentInteractionES_blockTensor_conj,
         MPSTensor.localTermES_blockTensor_conj_aligned,
         MPSTensor.blockTensor_parentHamiltonianES_conj_le}
     \leanok

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -117,8 +117,28 @@ FNW numerator and the identification of its source constants remain open.
 
 \subsection{Unit bound at the full-window volume}
 
-At the full-window volume $N=L$ with $L>0$, the compatible open Hamiltonian
-consists of one orthogonal projection:
+Fix an MPS tensor $A$ and an interaction length $L>0$. If
+$P_{G_L^{\mathrm{ES}}(A)}$ denotes the orthogonal projector onto the
+length-$L$ MPS ground space, define the excitation projector by
+\[
+  P_L^{\mathrm{ES}}(A):=\Id-P_{G_L^{\mathrm{ES}}(A)}.
+\]
+For a chain of length $N$ and a start $i$ with $i+L\leq N$, let
+$h_{i,\mathrm{ES}}(A,L)$ be the copy of this excitation projector on the
+window $[i,i+L-1]$, acting as the identity outside the window. Set
+\[
+  I_{L,N}=\{i\in\{0,\ldots,N-1\}:i+L\leq N\}
+\]
+and define the compatible open Hamiltonian by
+\[
+  H^{\mathrm{open}}_{N,L}(A)
+  :=\sum_{i\in I_{L,N}}h_{i,\mathrm{ES}}(A,L).
+\]
+At the full-window volume $N=L$, the compatible open Hamiltonian consists of
+one orthogonal projection.\footnote{This is the Blueprint theorem
+  ``Full-window compatible interaction''; the formal declaration is
+  \leanid{MPSTensor.openParentHamiltonianES_self_eq_parentInteractionES}.}
+Thus
 \[
   H^{\mathrm{open}}_{L,L}(A)=P_L^{\mathrm{ES}}(A).
 \]


### PR DESCRIPTION
## What changed

- give `localTermES_apply` a mathematically accurate Blueprint owner
- use the established cyclic-restriction and extraction notation in the full-window proof
- display the coefficient-to-Euclidean nonwrapping bridge before the local kernel conclusion
- define every symbol in the full-window paper-gap subsection and retain theorem-title/Lean traceability

This resolves the delayed review threads posted on #6450 after it merged.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- two Blueprint `lualatex` passes with the required `TEXINPUTS`
- standalone paper-gap note compilation with bibliography
- `git diff --check`

Exact-head Blueprint review approved `efaf4fda3079226ac8fd658758abf31614b257d9`.