### PR TITLE
feat(MPS/MPU): add factor-free sandwich continuity

### DIFF
--- a/TNLean/MPS/MPU.lean
+++ b/TNLean/MPS/MPU.lean
@@ -15,6 +15,7 @@ import TNLean.MPS.MPU.CanonicalForm
 import TNLean.MPS.MPU.DoubleLayerContraction
 import TNLean.MPS.MPU.Equivalence
 import TNLean.MPS.MPU.Examples
+import TNLean.MPS.MPU.FactorFreeSandwich
 import TNLean.MPS.MPU.MPUCanonicalForm
 import TNLean.MPS.MPU.MatchingContractions
 import TNLean.MPS.MPU.PhysicalAdjointCanonicalForm

--- a/TNLean/MPS/MPU/FactorFreeSandwich.lean
+++ b/TNLean/MPS/MPU/FactorFreeSandwich.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPU.DoubleLayerContraction
+import TNLean.MPS.MPU.VirtualSandwich
+
+/-!
+# Factor-free virtual sandwiching
+
+This module expresses the final contraction in the proof of
+[Cirac--Perez-Garcia--Schuch--Verstraete 2017, arXiv:1703.09188],
+Proposition IV.5, without choosing factors of the doubled-virtual matrix.
+
+For a doubled-virtual matrix `E`, the contraction is
+$$
+  C(W,E)^{ij}_{ab} = \sum_{c,e} E_{(b,e),(c,a)} W^{ij}_{ce}.
+$$
+The pairs are encoded by `finProdFinEquiv`. When `E` is rank one, Mathlib's
+column-stacking convention for `Matrix.vec` identifies this contraction with
+an ordinary virtual sandwich, with no transpose, adjoint, or scalar factor.
+
+The results do not choose the rank-one factors continuously, deduce positivity
+from arbitrary factors, construct reduced representatives, or assert rank
+constancy.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Contract an MPO tensor with a matrix on its doubled virtual indices:
+$C(W,E)^{ij}_{ab}=\sum_{c,e}E_{(b,e),(c,a)}W^{ij}_{ce}$.
+
+Source: arXiv:1703.09188, Proposition IV.5, Figure `IV_index4.png`, lines
+807--812. -/
+noncomputable def doubledVirtualContraction (W : MPOTensor d D)
+    (E : Matrix (Fin (D * D)) (Fin (D * D)) ℂ) : MPOTensor d D :=
+  fun i j a b ↦ ∑ c : Fin D, ∑ e : Fin D,
+    E (finProdFinEquiv (b, e)) (finProdFinEquiv (c, a)) * W i j c e
+
+/-- Entrywise expansion of the doubled-virtual contraction. -/
+@[simp] theorem doubledVirtualContraction_apply (W : MPOTensor d D)
+    (E : Matrix (Fin (D * D)) (Fin (D * D)) ℂ) (i j : Fin d) (a b : Fin D) :
+    doubledVirtualContraction W E i j a b =
+      ∑ c : Fin D, ∑ e : Fin D,
+        E (finProdFinEquiv (b, e)) (finProdFinEquiv (c, a)) * W i j c e :=
+  rfl
+
+/-- A rank-one doubled-virtual contraction is an ordinary virtual sandwich.
+The left matrix unvectorizes `Phi`, while the right matrix unvectorizes `rho`.
+
+Source: arXiv:1703.09188, Proposition IV.5, Figure `IV_index4.png`, lines
+807--812. -/
+theorem doubledVirtualContraction_vecMulVec (W : MPOTensor d D)
+    (rho Phi : Fin (D * D) → ℂ) :
+    doubledVirtualContraction W (Matrix.vecMulVec rho Phi) =
+      virtualSandwich
+        (fun a c ↦ Phi (finProdFinEquiv (c, a))) W
+        (fun e b ↦ rho (finProdFinEquiv (b, e))) := by
+  classical
+  ext i j a b
+  simp only [doubledVirtualContraction_apply, Matrix.vecMulVec_apply,
+    virtualSandwich_apply, Matrix.mul_apply, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro e _
+  apply Finset.sum_congr rfl
+  intro c _
+  ring
+
+/-- For matrices `L` and `R`, column vectorization of the rank-one doubled
+matrix gives exactly the sandwich $L W^{ij}R$.
+
+Source: arXiv:1703.09188, Proposition IV.5, Figure `IV_index4.png`, lines
+807--812. -/
+theorem doubledVirtualContraction_vecMulVec_vec (W : MPOTensor d D)
+    (L R : Matrix (Fin D) (Fin D) ℂ) :
+    doubledVirtualContraction W
+        (Matrix.vecMulVec
+          (fun k ↦ R.vec (finProdFinEquiv.symm k))
+          (fun k ↦ L.vec (finProdFinEquiv.symm k))) =
+      virtualSandwich L W R := by
+  simpa using doubledVirtualContraction_vecMulVec W
+    (fun k ↦ R.vec (finProdFinEquiv.symm k))
+    (fun k ↦ L.vec (finProdFinEquiv.symm k))
+
+/-- The doubled-virtual contraction is jointly continuous in the MPO tensor and
+contracting matrix.
+
+Source: arXiv:1703.09188, Proposition IV.5, Figure `IV_index4.png`, lines
+807--812. -/
+theorem continuous_doubledVirtualContraction {X : Type*} [TopologicalSpace X]
+    {W : X → MPOTensor d D}
+    {E : X → Matrix (Fin (D * D)) (Fin (D * D)) ℂ}
+    (hW : Continuous W) (hE : Continuous E) :
+    Continuous (fun x ↦ doubledVirtualContraction (W x) (E x)) := by
+  unfold doubledVirtualContraction
+  fun_prop
+
+/-- The physical-adjoint double layer depends continuously on the MPO tensor. -/
+theorem continuous_doubleLayerTensor :
+    Continuous (doubleLayerTensor : MPOTensor d D → MPOTensor d (D * D)) := by
+  refine continuous_pi fun i ↦ continuous_pi fun j ↦
+    continuous_pi fun p ↦ continuous_pi fun q ↦ ?_
+  rcases finProdFinEquiv.surjective p with ⟨⟨p₁, p₂⟩, rfl⟩
+  rcases finProdFinEquiv.surjective q with ⟨⟨q₁, q₂⟩, rfl⟩
+  simp only [doubleLayerTensor_apply, Matrix.submatrix_apply, Matrix.sum_apply,
+    Matrix.kronecker_apply, physicalAdjointTensor_apply, Equiv.symm_apply_apply,
+    RCLike.star_def]
+  fun_prop
+
+/-- The normalized physical diagonal depends continuously on the MPO tensor. -/
+theorem continuous_normalizedDiagonal :
+    Continuous (normalizedDiagonal : MPOTensor d D → Matrix (Fin D) (Fin D) ℂ) := by
+  unfold normalizedDiagonal contractPhysical
+  fun_prop
+
+/-- The normalized diagonal of the physical-adjoint double layer depends
+continuously on the MPO tensor.
+
+Source: arXiv:1703.09188, Proposition IV.5, Figure `IV_index4.png`, lines
+807--812. -/
+theorem continuous_normalizedDiagonal_doubleLayerTensor :
+    Continuous (fun W : MPOTensor d D ↦ normalizedDiagonal (doubleLayerTensor W)) :=
+  continuous_normalizedDiagonal.comp continuous_doubleLayerTensor
+
+/-- Contract the normalized double-layer diagonal directly into the original
+MPO tensor, without choosing rank-one factors.
+
+Source: arXiv:1703.09188, Proposition IV.5, Figure `IV_index4.png`, lines
+807--812. -/
+noncomputable def factorFreeSandwich (W : MPOTensor d D) : MPOTensor d D :=
+  doubledVirtualContraction W (normalizedDiagonal (doubleLayerTensor W))
+
+/-- Entrywise expansion of the factor-free sandwich. -/
+@[simp] theorem factorFreeSandwich_apply (W : MPOTensor d D)
+    (i j : Fin d) (a b : Fin D) :
+    factorFreeSandwich W i j a b =
+      ∑ c : Fin D, ∑ e : Fin D,
+        normalizedDiagonal (doubleLayerTensor W)
+          (finProdFinEquiv (b, e)) (finProdFinEquiv (c, a)) * W i j c e :=
+  rfl
+
+/-- The factor-free sandwich is continuous in the entries of the MPO tensor.
+
+Source: arXiv:1703.09188, Proposition IV.5, Figure `IV_index4.png`, lines
+807--812. -/
+theorem continuous_factorFreeSandwich :
+    Continuous (factorFreeSandwich : MPOTensor d D → MPOTensor d D) := by
+  change Continuous (fun W : MPOTensor d D ↦
+    doubledVirtualContraction W (normalizedDiagonal (doubleLayerTensor W)))
+  exact continuous_doubledVirtualContraction continuous_id
+    continuous_normalizedDiagonal_doubleLayerTensor
+
+end MPOTensor
+
+namespace Continuous
+
+/-- A continuous MPO family remains continuous after the factor-free sandwich.
+
+Source: arXiv:1703.09188, Proposition IV.5, Figure `IV_index4.png`, lines
+807--812. -/
+theorem factorFreeSandwich {X : Type*} [TopologicalSpace X] {d D : ℕ}
+    {W : X → MPOTensor d D} (hW : Continuous W) :
+    Continuous (fun x ↦ MPOTensor.factorFreeSandwich (W x)) :=
+  MPOTensor.continuous_factorFreeSandwich.comp hW
+
+end Continuous

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5706,6 +5706,90 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   $\mathcal U(x)$, and $B(x)$, hence is continuous.
 \end{proof}
 
+\begin{definition}[Doubled-virtual contraction and factor-free sandwich]
+  \label{def:mpu_factor_free_sandwich}
+  \lean{MPOTensor.doubledVirtualContraction,
+    MPOTensor.doubledVirtualContraction_apply,
+    MPOTensor.factorFreeSandwich,
+    MPOTensor.factorFreeSandwich_apply}
+  \leanok
+  \uses{def:mpu_double_layer}
+  Let $q:\Fin D\times\Fin D\to\Fin{D^2}$ be the standard enumeration of a
+  pair. For an MPO tensor $\mathcal W$ and a doubled-virtual matrix
+  $E\in\mathbb C^{D^2\times D^2}$, define
+  \begin{align}
+    C(\mathcal W,E)^{ij}_{ab}
+      &=\sum_{c,e=0}^{D-1}E_{q(b,e),q(c,a)}W^{ij}_{ce}.
+      \label{eq:mpu_factor_free_contraction}
+  \end{align}
+  If $E(\mathcal W)$ denotes the normalized physical diagonal of the
+  physical-adjoint double layer of $\mathcal W$, define
+  \begin{align}
+    \widehat{\mathcal W}_{\mathrm{ff}}
+      &=C\bigl(\mathcal W,E(\mathcal W)\bigr).
+      \label{eq:mpu_factor_free_sandwich}
+  \end{align}
+  This is the contraction shown in Figure~\texttt{IV\_index4.png} of
+  \cite[Proposition~IV.5]{Cirac2017MPU}.
+  % Source lines: paper_v2.tex 807--812.
+\end{definition}
+
+\begin{theorem}[Rank-one identity and continuity of the factor-free sandwich]
+  \label{thm:mpu_factor_free_sandwich_continuous}
+  \lean{MPOTensor.doubledVirtualContraction_vecMulVec,
+    MPOTensor.doubledVirtualContraction_vecMulVec_vec,
+    MPOTensor.continuous_doubledVirtualContraction,
+    MPOTensor.continuous_doubleLayerTensor,
+    MPOTensor.continuous_normalizedDiagonal,
+    MPOTensor.continuous_normalizedDiagonal_doubleLayerTensor,
+    MPOTensor.continuous_factorFreeSandwich,
+    Continuous.factorFreeSandwich}
+  \leanok
+  \uses{def:mpu_factor_free_sandwich,def:mpu_virtual_sandwich}
+  Let $L,R\in\mathbb C^{D\times D}$ and let $\operatorname{vec}$ stack
+  matrix columns, so
+  \begin{align}
+    \operatorname{vec}(L)_{q(c,a)}&=L_{ac},\\
+    \operatorname{vec}(R)_{q(b,e)}&=R_{eb}.
+  \end{align}
+  Then the rank-one doubled-virtual matrix satisfies
+  \begin{align}
+    C\!\left(\mathcal W,
+      \lvert\operatorname{vec}(R))(\operatorname{vec}(L)\rvert\right)^{ij}
+      &=L W^{ij}R.
+      \label{eq:mpu_factor_free_rank_one}
+  \end{align}
+  No transpose, adjoint, or normalization factor occurs. The binary map
+  $(\mathcal W,E)\mapsto C(\mathcal W,E)$, the map
+  $\mathcal W\mapsto E(\mathcal W)$, and consequently the map
+  $\mathcal W\mapsto\widehat{\mathcal W}_{\mathrm{ff}}$ are continuous.
+  These assertions neither choose $L$ and $R$ continuously nor infer their
+  positivity. They make no claim about reduced representatives or constancy
+  of ranks.
+  % Source lines: paper_v2.tex 807--812.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{def:mpu_factor_free_sandwich}
+  Expanding the left-hand side of
+  (\ref{eq:mpu_factor_free_rank_one}) and using column stacking gives
+  \begin{align}
+    C\!\left(\mathcal W,
+      \lvert\operatorname{vec}(R))(\operatorname{vec}(L)\rvert\right)^{ij}_{ab}
+      &=\sum_{c,e}R_{eb}L_{ac}W^{ij}_{ce}\\
+      &=\sum_{c,e}L_{ac}W^{ij}_{ce}R_{eb}
+       =(L W^{ij}R)_{ab}.
+  \end{align}
+  This proves (\ref{eq:mpu_factor_free_rank_one}). Each entry in
+  (\ref{eq:mpu_factor_free_contraction}) is a finite sum of products, so the
+  binary contraction is continuous. The double-layer entries are finite sums
+  of products of entries of $\mathcal W$ and their complex conjugates, and the
+  normalized physical diagonal is another finite sum. Hence
+  $\mathcal W\mapsto E(\mathcal W)$ is continuous. Substitution into
+  (\ref{eq:mpu_factor_free_sandwich}) proves continuity of the factor-free
+  sandwich.
+\end{proof}
+
 \begin{theorem}[Source cuts of a virtual sandwich]
   \label{thm:mpu_virtual_sandwich_source_cuts}
   \lean{MPOTensor.sourceCutM₁_virtualSandwich,
@@ -5858,6 +5942,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     thm:mpu_two_projection_reduced_projection_right_factor,
     thm:mpu_rank_lower_semicontinuous,
     thm:mpu_fixed_product_preconnected,
+    thm:mpu_factor_free_sandwich_continuous,
     thm:mpu_virtual_sandwich_source_ranks,
     thm:mpu_ambient_support_inverse_extension}
   Let $[0,1]\ni x\mapsto\mathcal W(x)$ be a continuous path of tensors


### PR DESCRIPTION
## What changed

- define the doubled-virtual contraction $C(W,E)^{ij}_{ab}=\sum_{c,e}E_{(b,e),(c,a)}W^{ij}_{ce}$
- prove that a rank-one matrix $E=\operatorname{vec}(R)\operatorname{vec}(L)^T$ gives exactly the virtual sandwich $LWR$
- prove continuity of the double layer, normalized diagonal, binary contraction, and factor-free sandwich
- record the exact formulas and scope boundaries in Chapter 28 while leaving `prop:continuity-index` not ready

## Validation

- `lake build TNLean.MPS.MPU.FactorFreeSandwich TNLean.MPS.MPU`
- generated MPU import-aggregator check
- Blueprint-to-Lean synchronization and `leanblueprint checkdecls`
- two LuaLaTeX passes with zero undefined mathematical references
- proof-integrity scan and `git diff --check`
- independent orientation and API review found no substantive issues; both public evaluation lemmas now have docstrings
- rebased onto exact current `origin/main` and revalidated

Closes #6449
