### PR TITLE
docs(parent-hamiltonian): unify full-window gap notation

### DIFF
--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -118,10 +118,10 @@ FNW numerator and the identification of its source constants remain open.
 \subsection{Unit bound at the full-window volume}
 
 Fix an MPS tensor $A$ and an interaction length $L>0$. If
-$P_{G_L^{\mathrm{ES}}(A)}$ denotes the orthogonal projector onto the
+$P_{\mathcal G_L^{\mathrm{ES}}(A)}$ denotes the orthogonal projector onto the
 length-$L$ MPS ground space, define the excitation projector by
 \[
-  P_L^{\mathrm{ES}}(A):=\Id-P_{G_L^{\mathrm{ES}}(A)}.
+  P_L^{\mathrm{ES}}(A):=\Id-P_{\mathcal G_L^{\mathrm{ES}}(A)}.
 \]
 For a chain of length $N$ and a start $i$ with $i+L\leq N$, let
 $h_{i,\mathrm{ES}}(A,L)$ be the copy of this excitation projector on the
@@ -136,7 +136,8 @@ and define the compatible open Hamiltonian by
 \]
 At the full-window volume $N=L$, the compatible open Hamiltonian consists of
 one orthogonal projection.\footnote{This is the Blueprint theorem
-  ``Full-window compatible interaction''; the formal declaration is
+  ``Full-window compatible interaction,'' labelled
+  \path{thm:open_parent_hamiltonian_full_window}; the formal declaration is
   \leanid{MPSTensor.openParentHamiltonianES_self_eq_parentInteractionES}.}
 Thus
 \[


### PR DESCRIPTION
## What changed

- use the established calligraphic ground-space notation in the full-window paper-gap subsection
- complete the traceability footnote with the theorem title, Blueprint identifier, and Lean declaration

This resolves the two delayed review threads posted on #6453 after merge.

## Validation

- standalone LaTeX compilation
- `git diff --check`

Exact-head Blueprint review approved `61709a9608480a5b9021418a3d1e00489da1230e`.