### PR TITLE
docs(MPDO): record unit-weight RFP scale tension

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Basic.lean
@@ -154,7 +154,9 @@ structure IsBNTCanonicalForm (P : SectorDecomposition d) where
   `c_N^{(j)} = ∑_q μ_{j,q}^N` is not eventually zero in `N`, not that some
   specific copy `q` of sector `j` has `‖μ_{j,q}‖ = 1`.  See
   `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex` for the closed
-  global-versus-per-sector audit. -/
+  global-versus-per-sector audit. For the separate interaction between this
+  source convention and the scale fixed by MPDO renormalization, see
+  `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
   weight_unit_exists : ∃ (j : Fin P.basisCount) (q : Fin (P.copies j)),
     ‖P.weight j q‖ = 1
 

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -90,7 +90,9 @@ def IsRFPViaTS (M : MPOTensor d D) : Prop :=
 This is the zero-correlation-length part of arXiv:1606.00608, lines 1333--1340:
 trace preservation of the map from one site to
 two sites identifies the traces of the one-site and two-site physical closures
-for every virtual boundary matrix. -/
+for every virtual boundary matrix. For its interaction with the line-246
+unit-weight convention on a fixed tensor representative, see
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 theorem physTraceTransfer_sq_of_isRFPViaTS (M : MPOTensor d D) (h : IsRFPViaTS M) :
     physTraceTransfer M * physTraceTransfer M = physTraceTransfer M := by
   obtain ⟨_, T, _, hT, _, hT_close⟩ := h

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
@@ -304,7 +304,8 @@ so multiplying a hypothetical nilpotent by `weight` would make
 `physTraceTransfer R` nilpotent.
 
 This is the basis-element non-nilpotency condition of arXiv:1606.00608,
-lines 815--822, for the single retained block of this project example.
+Definition 4.7, lines 815--822, for the single retained block of this project
+example.
 
 **Scope restriction (fixed representative):** This is only the nilpotency
 clause for the displayed one-block presentation. The weight `√(337/512)` is

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
@@ -304,12 +304,14 @@ so multiplying a hypothetical nilpotent by `weight` would make
 `physTraceTransfer R` nilpotent.
 
 This is the basis-element non-nilpotency condition of arXiv:1606.00608,
-lines 815--822, for the single retained block of this project example. It is
-only the nilpotency clause for this displayed one-block presentation. The
-weight `√(337/512)` is not a unit weight, and replacing `R` by `retainedBlock`
-changes the fixed representative on which Definition 4.1 is evaluated. Thus
-this theorem neither proves nor refutes `MPOTensor.IsSimple R`, and it makes no
-claim about other presentations or blockings. See
+lines 815--822, for the single retained block of this project example.
+
+**Scope restriction (fixed representative):** This is only the nilpotency
+clause for the displayed one-block presentation. The weight `√(337/512)` is
+not a unit weight, and replacing `R` by `retainedBlock` changes the fixed
+representative on which Definition 4.1 is evaluated. Thus this theorem neither
+proves nor refutes `MPOTensor.IsSimple R`, and it makes no claim about other
+presentations or blockings. See
 `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 theorem doubledPhysTraceTransfer_retainedBlock_not_isNilpotent :
     ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer 4 retainedBlock) := by

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
@@ -304,9 +304,13 @@ so multiplying a hypothetical nilpotent by `weight` would make
 `physTraceTransfer R` nilpotent.
 
 This is the basis-element non-nilpotency condition of arXiv:1606.00608,
-Definition 4.7, lines 815--822, for the single retained block of this project
-example.  It does not assert `MPOTensor.IsSimple R`, whose definition also
-includes canonical-form normalization requirements. -/
+lines 815--822, for the single retained block of this project example. It is
+only the nilpotency clause for this displayed one-block presentation. The
+weight `√(337/512)` is not a unit weight, and replacing `R` by `retainedBlock`
+changes the fixed representative on which Definition 4.1 is evaluated. Thus
+this theorem neither proves nor refutes `MPOTensor.IsSimple R`, and it makes no
+claim about other presentations or blockings. See
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 theorem doubledPhysTraceTransfer_retainedBlock_not_isNilpotent :
     ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer 4 retainedBlock) := by
   rw [doubledPhysTraceTransfer_retainedBlock]

--- a/TNLean/MPS/MPDO/SimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SimpleTensor.lean
@@ -109,7 +109,15 @@ the separate biCF hypothesis imposed there, since the copy-independence
 argument at lines 1646--1658 does not use the inverse tensor. It retains the
 assumption that `M` generates MPDOs; its canonical-form witness has the shape
 of `MPOTensor.IsHorizontalCF`, with the additional requirement that no basis
-element have nilpotent physical-trace transfer. -/
+element have nilpotent physical-trace transfer.
+
+**Fixed-representative scope:** The BNT witness includes the line-246 global
+unit-weight convention through `MPSTensor.IsBNTCanonicalForm.weight_unit_exists`.
+Thus this predicate is evaluated on the displayed tensor `M`, not modulo a
+nonzero scalar rescaling. The mathematical nilpotency clause is scale invariant,
+but the packaged canonical-form normalization need not be compatible with the
+scale fixed by Definition 4.1. See
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 def IsSimpleCanonicalForm (M : MPOTensor d D) : Prop :=
   IsMPDO M ∧
     ∃ S : MPSTensor.SectorDecomposition (d * d),
@@ -132,7 +140,13 @@ def IsSimpleCanonicalForm (M : MPOTensor d D) : Prop :=
 /-- **Simple MPO tensor** (arXiv:1606.00608, lines 815--822). Before choosing
 the BNT, the source blocks a positive number of physical sites (line 815).
 A tensor is simple when one such blocked tensor is a simple canonical-form
-tensor in the sense above. -/
+tensor in the sense above.
+
+**Fixed-representative scope:** This permits a positive physical blocking but
+does not quotient the blocked tensor by nonzero scalar rescaling or assert
+presentation independence. Its canonical-form witness therefore retains the
+line-246 unit-weight convention at the scale of `blockTensor M L`. See
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 def IsSimple (M : MPOTensor d D) : Prop :=
   IsMPDO M ∧ ∃ L : ℕ, 0 < L ∧ IsSimpleCanonicalForm (blockTensor M L)
 

--- a/TNLean/MPS/MPDO/SimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SimpleTensor.lean
@@ -116,8 +116,8 @@ line-246 global unit-weight convention through
 `MPSTensor.IsBNTCanonicalForm.weight_unit_exists`.
 Thus this predicate is evaluated on the displayed tensor `M`, not modulo a
 nonzero scalar rescaling. The mathematical nilpotency clause is scale invariant,
-but the packaged canonical-form normalization need not be compatible with the
-scale fixed by Definition 4.1. See
+but the unit-weight normalization included in the canonical-form witness need
+not be compatible with the scale fixed by Definition 4.1. See
 `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 def IsSimpleCanonicalForm (M : MPOTensor d D) : Prop :=
   IsMPDO M ∧

--- a/TNLean/MPS/MPDO/SimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SimpleTensor.lean
@@ -111,8 +111,9 @@ assumption that `M` generates MPDOs; its canonical-form witness has the shape
 of `MPOTensor.IsHorizontalCF`, with the additional requirement that no basis
 element have nilpotent physical-trace transfer.
 
-**Fixed-representative scope:** The BNT witness includes the line-246 global
-unit-weight convention through `MPSTensor.IsBNTCanonicalForm.weight_unit_exists`.
+**Scope restriction (fixed representative):** The BNT witness includes the
+line-246 global unit-weight convention through
+`MPSTensor.IsBNTCanonicalForm.weight_unit_exists`.
 Thus this predicate is evaluated on the displayed tensor `M`, not modulo a
 nonzero scalar rescaling. The mathematical nilpotency clause is scale invariant,
 but the packaged canonical-form normalization need not be compatible with the
@@ -142,10 +143,10 @@ the BNT, the source blocks a positive number of physical sites (line 815).
 A tensor is simple when one such blocked tensor is a simple canonical-form
 tensor in the sense above.
 
-**Fixed-representative scope:** This permits a positive physical blocking but
-does not quotient the blocked tensor by nonzero scalar rescaling or assert
-presentation independence. Its canonical-form witness therefore retains the
-line-246 unit-weight convention at the scale of `blockTensor M L`. See
+**Scope restriction (fixed representative):** This permits a positive physical
+blocking but does not quotient the blocked tensor by nonzero scalar rescaling or
+assert presentation independence. Its canonical-form witness therefore retains
+the line-246 unit-weight convention at the scale of `blockTensor M L`. See
 `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 def IsSimple (M : MPOTensor d D) : Prop :=
   IsMPDO M ∧ ∃ L : ℕ, 0 < L ∧ IsSimpleCanonicalForm (blockTensor M L)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -900,11 +900,24 @@
     $\mu=\sqrt{337/512}$, whereas
     Definition~\ref{def:mpdo_simple_tensor} also retains the global
     unit-weight convention of \cite[line~246]{Cirac2016MPDO_arXiv}.
-    Replacing $R$ by the normalized
-    block changes the fixed representative on which the renormalization
-    fixed-point condition is evaluated. Consequently this result neither
-    proves nor refutes simplicity of $R$, and it makes no claim about other
-    presentations or blockings.
+    For every scalar $c$, the physical-trace transfer scales as
+    \begin{align}
+        \mathcal T_{cM}&=c\mathcal T_M.
+        \notag
+    \end{align}
+    Hence literal idempotence at two nonzero representatives pins the scale:
+    \begin{align}
+        \mathcal T_M^2=\mathcal T_M\ne0,
+        \quad
+        \mathcal T_{cM}^2=\mathcal T_{cM}\ne0
+        \quad&\Longrightarrow\quad c=1.
+        \notag
+    \end{align}
+    Replacing $R$ by the normalized block uses the nontrivial scale
+    $c=\mu^{-1}$ and therefore changes the representative on which the
+    renormalization fixed-point condition is evaluated. Consequently this
+    result neither proves nor refutes simplicity of $R$, and it makes no
+    claim about other presentations or blockings.
 \end{theorem}
 \begin{proof}\leanok
     \uses{def:mpdo_doubled_phys_trace_transfer,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -896,10 +896,15 @@
     satisfies the non-nilpotency clause in the definition of a simple tensor.
 
     This conclusion concerns only that clause for the displayed one-block
-    presentation; it does not assert that $R$ satisfies the project's full
-    simple-tensor predicate. In particular, that predicate requires a
-    unit-weight BNT canonical-form witness, whereas the displayed retained
-    decomposition has the non-unit weight $\mu=\sqrt{337/512}$.
+    presentation. The retained decomposition has the non-unit weight
+    $\mu=\sqrt{337/512}$, whereas
+    Definition~\ref{def:mpdo_simple_tensor} also retains the global
+    unit-weight convention of \cite[line~246]{Cirac2016MPDO_arXiv}.
+    Replacing $R$ by the normalized
+    block changes the fixed representative on which the renormalization
+    fixed-point condition is evaluated. Consequently this result neither
+    proves nor refutes simplicity of $R$, and it makes no claim about other
+    presentations or blockings.
 \end{theorem}
 \begin{proof}\leanok
     \uses{def:mpdo_doubled_phys_trace_transfer,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -98,7 +98,8 @@
     \cite[Appendix~C.2, line~1628]{Cirac2016MPDO_arXiv}.
 
     The definition concerns this fixed representative. Its canonical-form
-    witness includes the global unit-weight convention at line~246, whereas
+    witness includes the global unit-weight convention of
+    \cite[line~246]{Cirac2016MPDO_arXiv}, whereas
     the non-nilpotency condition itself is unchanged by nonzero scalar
     rescaling. No invariance under rescaling or replacement of the canonical
     presentation is asserted.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -78,6 +78,11 @@
     nilpotent when tracing $R\le D$ sites annihilates its density operators
     for all large chain lengths \cite[line~819]{Cirac2016MPDO_arXiv}; this is
     nilpotency of its physical-trace transfer matrix.
+
+    Here simplicity is tested on the blocked tensor itself. The chosen BNT
+    retains the global unit-weight convention of
+    \cite[line~246]{Cirac2016MPDO_arXiv}; it does not identify nonzero scalar
+    multiples or assert independence of the chosen canonical presentation.
 \end{definition}
 
 \begin{definition}[Simple tensor in blocked canonical form]
@@ -91,6 +96,12 @@
     non-nilpotent physical-trace transfer. This records the simple
     horizontal-canonical-form data of the already-blocked tensor $K$ fixed in
     \cite[Appendix~C.2, line~1628]{Cirac2016MPDO_arXiv}.
+
+    The definition concerns this fixed representative. Its canonical-form
+    witness includes the global unit-weight convention at line~246, whereas
+    the non-nilpotency condition itself is unchanged by nonzero scalar
+    rescaling. No invariance under rescaling or replacement of the canonical
+    presentation is asserted.
 \end{definition}
 % Note for maintainers: this predicate does not include the biCF
 % (bidirectional canonical form) hypothesis imposed on K at line 1628.  That

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -3,6 +3,7 @@
 \usepackage{amsmath,amssymb}
 \usepackage{xurl}
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+\setlength{\emergencystretch}{3em}
 
 \input{./command}
 
@@ -48,15 +49,35 @@ where $\mathcal T_M=\sum_i M^{ii}$ is the physical-trace transfer; this is the
 calculation at lines~1333--1340. The formal statement is
 \leanid{MPOTensor.physTraceTransfer_sq_of_isRFPViaTS}.
 
-These requirements concern different uses of scale. Equation
-\eqref{eq:unit-weight} chooses normalized BNT representatives and places the
-overall scale in their coefficients. Equation \eqref{eq:physical-idempotent}
-constrains the scale of the displayed tensor itself.
+These requirements concern two transfer objects with different scaling laws.
+For the doubled-index MPS transfer map
+\begin{align}
+    \mathcal E_M(X)
+    &=\sum_i M^iX(M^i)^\dagger,
+\end{align}
+one has
+\begin{align}
+    \mathcal E_{cM}
+    &=|c|^2\mathcal E_M.
+    \label{eq:mps-transfer-scaling}
+\end{align}
+For the physical-trace transfer, linearity gives
+\begin{align}
+    \mathcal T_{cM}
+    &=c\mathcal T_M.
+    \label{eq:physical-transfer-scaling}
+\end{align}
+Equation \eqref{eq:unit-weight} normalizes the first object by choosing normal
+BNT representatives and placing the overall scale in their coefficients.
+Equation \eqref{eq:physical-idempotent} constrains the second object at the
+scale of the displayed tensor. The related up-to-scalar treatment of source
+zero correlation length is recorded in
+\path{docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex}.
 
 \section{Fixed-representative scale pinning}
 
-The physical-trace transfer is linear in the tensor. Replacing $M$ by $cM$
-replaces $\mathcal T_M$ by $c\mathcal T_M$. If
+By \eqref{eq:physical-transfer-scaling}, replacing $M$ by $cM$ replaces
+$\mathcal T_M$ by $c\mathcal T_M$. If
 $\mathcal T_M^2=\mathcal T_M\ne0$ and the nonzero rescaling $cM$ also satisfies
 the same literal idempotence equation, then
 \begin{align}
@@ -69,10 +90,10 @@ rescaling of a fixed representative.
 
 By contrast, the simplicity definition at lines~815--823 is phrased through
 the normalized elements of a BNT: the tensor is simple when none of those
-elements has nilpotent ket-against-bra contraction. Multiplying a BNT element by a nonzero scalar does not change
-nilpotency. The mathematical simplicity
-content is therefore insensitive to that rescaling, even though a formal
-predicate that includes the line-246 canonical-form normalization is evaluated
+elements has nilpotent ket-against-bra contraction. Multiplying a BNT
+element by a nonzero scalar does not change nilpotency. The mathematical
+simplicity content is therefore insensitive to that rescaling, even though a
+formal predicate that includes the line-246 canonical-form normalization is evaluated
 on a particular representative.
 
 The declarations \leanid{MPOTensor.IsSimpleCanonicalForm} and
@@ -113,12 +134,12 @@ equation as $R$.
 
 This establishes only a mismatch between the displayed one-block canonical
 normalization and the RFP-pinned representative. It does not prove that
-\leanid{MPOTensor.IsSimple R} is false, does not rule out every alternative
-canonical presentation or blocking, and does not make the displayed BNT
-coefficients presentation-independent. The theorem
-\leanid{MPOTensor.RescalingStableLengthDependentRFP.%
- doubledPhysTraceTransfer_retainedBlock_not_isNilpotent}
-records exactly the non-nilpotency of the retained block and no stronger
+\leanid{MPOTensor.IsSimple} applied to $R$ is false, does not rule out every
+alternative canonical presentation or blocking, and does not make the displayed
+BNT coefficients presentation-independent. In the namespace
+\leanid{MPOTensor.RescalingStableLengthDependentRFP}, the theorem
+\leanid{doubledPhysTraceTransfer_retainedBlock_not_isNilpotent} records
+exactly the non-nilpotency of the retained block and no stronger
 simplicity conclusion.
 
 \section{The vertical one-label identity}
@@ -154,7 +175,7 @@ This note adds no such predicate and proves no generic scale-pinning lemma. It
 only records why the existing simplicity predicates must be read as
 fixed-representative statements, and why non-nilpotency of the displayed dimer
 block does not by itself establish or refute the full predicate
-\leanid{MPOTensor.IsSimple R}.
+\leanid{MPOTensor.IsSimple} applied to $R$.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -164,7 +164,8 @@ not an invariance theorem for coefficients under changes of presentation.
 
 \section{Formalization boundary}
 
-The current declarations are mathematically correct at their stated scope.
+\textbf{Verdict: scope restriction (fixed representative).} The current
+declarations are mathematically correct at their stated scope.
 The line-246 field should not be deleted: it is the source's standing
 canonical-form convention. The appropriate future interface is instead a
 scale-invariant simplicity surface, formulated either on a normalized

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -1,0 +1,162 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{./command}
+
+\title{The CPSV16 Unit-Weight Convention and Renormalization-Fixed-Point Scale}
+\author{}
+\date{2026-08-14}
+
+\begin{document}
+\maketitle
+
+\section{Two scale conventions in the source}
+
+The canonical-form construction of
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete first writes a tensor as
+\begin{align}
+    A^i
+    &=\bigoplus_k \mu_k A_k^i,
+\end{align}
+where every $A_k$ is normal and its transfer map has spectral radius one
+\cite[lines~214--246]{Cirac2016MPDO_arXiv}. Since the states are not normalized
+there, line~246 adopts the standing convention
+\begin{align}
+    |\mu_k|&\leq 1 &&\text{for every $k$},
+    & |\mu_{k_0}|&=1 &&\text{for some $k_0$}.
+    \label{eq:unit-weight}
+\end{align}
+The formal BNT predicate records the second clause through
+\leanid{MPSTensor.IsBNTCanonicalForm.weight_unit_exists}. This is one global
+unit-weight witness, not one witness in every sector; the latter distinction is
+discussed separately in
+\path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}.
+
+Definition~4.1 fixes the scale of the tensor in a different way. For a tensor
+$M$ already in canonical form and generating MPDOs, it requires
+trace-preserving completely positive maps relating the one-site and two-site
+physical closures \cite[lines~645--660]{Cirac2016MPDO_arXiv}. Trace preservation
+gives
+\begin{align}
+    \mathcal T_M^2&=\mathcal T_M,
+    \label{eq:physical-idempotent}
+\end{align}
+where $\mathcal T_M=\sum_i M^{ii}$ is the physical-trace transfer; this is the
+calculation at lines~1333--1340. The formal statement is
+\leanid{MPOTensor.physTraceTransfer_sq_of_isRFPViaTS}.
+
+These requirements concern different uses of scale. Equation
+\eqref{eq:unit-weight} chooses normalized BNT representatives and places the
+overall scale in their coefficients. Equation \eqref{eq:physical-idempotent}
+constrains the scale of the displayed tensor itself.
+
+\section{Fixed-representative scale pinning}
+
+The physical-trace transfer is linear in the tensor. Replacing $M$ by $cM$
+replaces $\mathcal T_M$ by $c\mathcal T_M$. If
+$\mathcal T_M^2=\mathcal T_M\ne0$ and the nonzero rescaling $cM$ also satisfies
+the same literal idempotence equation, then
+\begin{align}
+    c^2\mathcal T_M
+    &=(c\mathcal T_M)^2
+      =c\mathcal T_M,
+\end{align}
+so $c=1$. Thus Definition~4.1 is not invariant under an arbitrary nonzero
+rescaling of a fixed representative.
+
+By contrast, the simplicity definition at lines~815--823 is phrased through
+the normalized elements of a BNT: the tensor is simple when none of those
+elements has nilpotent ket-against-bra contraction. Multiplying a BNT element by a nonzero scalar does not change
+nilpotency. The mathematical simplicity
+content is therefore insensitive to that rescaling, even though a formal
+predicate that includes the line-246 canonical-form normalization is evaluated
+on a particular representative.
+
+The declarations \leanid{MPOTensor.IsSimpleCanonicalForm} and
+\leanid{MPOTensor.IsSimple} retain the source's BNT normalization. The first is
+a predicate on one displayed canonical-form representative. The second permits
+positive physical blocking, but still asks the resulting blocked tensor itself
+to admit such a normalized witness. Neither declaration is a quotient by
+nonzero scalar rescaling, and neither asserts invariance under changing the
+canonical presentation.
+
+\section{The displayed dimer representative}
+
+The project tensor $R$ gives a concrete instance of this tension. Its
+doubled-index MPS transfer map satisfies
+\begin{align}
+    \mathcal E_R^2
+    &=\frac{337}{512}\mathcal E_R.
+\end{align}
+Consequently the displayed one-block CPSV canonical form is
+\begin{align}
+    R^{\bullet\bullet}
+    &=\mu\widehat R,
+    & \mu&=\sqrt{\frac{337}{512}},
+\end{align}
+where the transfer map of the retained block $\widehat R$ is idempotent and
+hence has spectral radius one. This presentation has $0<\mu<1$, so it does not
+itself supply the global unit-weight witness in \eqref{eq:unit-weight}.
+
+On the other hand, the physical-trace transfer of the displayed tensor $R$ is
+a nonzero idempotent: its $(0,0)$ entry is $1/2$. The retained block has
+\begin{align}
+    \mathcal T_{\widehat R}
+    &=\mu^{-1}\mathcal T_R.
+\end{align}
+Since $\mu\ne1$, the scale-pinning calculation above shows that this normalized
+representative does not satisfy the same literal physical-trace idempotence
+equation as $R$.
+
+This establishes only a mismatch between the displayed one-block canonical
+normalization and the RFP-pinned representative. It does not prove that
+\leanid{MPOTensor.IsSimple R} is false, does not rule out every alternative
+canonical presentation or blocking, and does not make the displayed BNT
+coefficients presentation-independent. The theorem
+\leanid{MPOTensor.RescalingStableLengthDependentRFP.%
+ doubledPhysTraceTransfer_retainedBlock_not_isNilpotent}
+records exactly the non-nilpotency of the retained block and no stronger
+simplicity conclusion.
+
+\section{The vertical one-label identity}
+
+The same scale bookkeeping is visible in the algebraic form of
+Theorem~4.14. Its length-one condition is
+\begin{align}
+    m_\gamma
+    &=\sum_{\alpha,\beta}
+      c^{(1)}_{\alpha,\beta,\gamma}m_\alpha m_\beta,
+\end{align}
+where $m_\alpha=\tr(\mu_\alpha)$
+\cite[lines~972--993]{Cirac2016MPDO_arXiv}. In the displayed one-label dimer
+presentation,
+\begin{align}
+    c^{(1)}_{0,0,0}&=\frac{32}{25},
+    &m_0&=\frac{25}{32},
+\end{align}
+so the nonzero solution is fixed by $(c^{(1)}_{0,0,0})^{-1}$ rather than by a
+unit-weight convention. This is a statement about that explicit presentation,
+not an invariance theorem for coefficients under changes of presentation.
+
+\section{Formalization boundary}
+
+The current declarations are mathematically correct at their stated scope.
+The line-246 field should not be deleted: it is the source's standing
+canonical-form convention. The appropriate future interface is instead a
+scale-invariant simplicity surface, formulated either on a normalized
+representative or without packaging the unit-weight convention into the
+simplicity predicate.
+
+This note adds no such predicate and proves no generic scale-pinning lemma. It
+only records why the existing simplicity predicates must be read as
+fixed-representative statements, and why non-nilpotency of the displayed dimer
+block does not by itself establish or refute the full predicate
+\leanid{MPOTensor.IsSimple R}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -169,7 +169,7 @@ declarations are mathematically correct at their stated scope.
 The line-246 field should not be deleted: it is the source's standing
 canonical-form convention. The appropriate future interface is instead a
 scale-invariant simplicity surface, formulated either on a normalized
-representative or without packaging the unit-weight convention into the
+representative or without including the unit-weight convention in the
 simplicity predicate.
 
 This note adds no such predicate and proves no generic scale-pinning lemma. It


### PR DESCRIPTION
## Summary

- document the fixed-representative tension between CPSV16 line 246 and Definition 4.1
- mark the current `IsSimpleCanonicalForm` / `IsSimple` surface as retaining unit-weight normalization
- synchronize the Chapter 21 simplicity and dimer nonnilpotency Blueprint entries
- distinguish physical-trace linear scaling from doubled-index quadratic scaling

## Scope

This PR deliberately records only the proved displayed-presentation boundary. It does not claim
`¬ MPOTensor.IsSimple R`, universality over all presentations or positive blockings, or vertical
coefficient invariance. Those questions remain #6464 and #6395 respectively. The dimer capstone
marker remains reserved for dependent #6408.

## Verification

- targeted Lean checks for all changed Lean files
- targeted dimer module build
- Blueprint sync: 7704/7704 entries synchronized
- diff-scoped prose check and `git diff --check`
- standalone paper-gap compilation with bibliography; no overfull boxes
- independent source-faithfulness and cleanup reviews

Closes #6396
