### PR TITLE
feat(MPS): preserve CPSV normality under conjugation

### DIFF
--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Channel.Irreducible.SpectralRadius
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.CanonicalForm.SectorComparison.PrimitiveBlocks
 
@@ -58,96 +57,10 @@ theorem blockTensor {A B : MPSTensor d D} (h : GaugeEquiv A B) (p : ℕ) :
   simpa [MPSTensor.blockTensor, Matrix.GeneralLinearGroup.coe_inv] using
     evalWord_gauge (A := A) (B := B) X hX (wordOfBlock d p i)
 
-/-- The transfer maps of gauge-equivalent tensors are related by the standard
-congruence similarity of completely positive maps.
-
-Source: arXiv:1606.00608, lines 219--223 define the transfer map and lines
-264--268 give the invertible gauge relation. -/
-theorem transferMap_eq_similarityMap {A B : MPSTensor d D} (h : GaugeEquiv A B) :
-    ∃ C : Matrix (Fin D) (Fin D) ℂ, C.det ≠ 0 ∧
-      transferMap (d := d) (D := D) B =
-        similarityMap (D := D) C (transferMap (d := d) (D := D) A) := by
-  obtain ⟨X, hX⟩ := h
-  refine ⟨((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ), ?_, ?_⟩
-  · exact Matrix.GeneralLinearGroup.det_ne_zero (X⁻¹ : GL (Fin D) ℂ)
-  · apply LinearMap.ext
-    intro Y
-    have hXdet : IsUnit ((X : Matrix (Fin D) (Fin D) ℂ).det) :=
-      Ne.isUnit (Matrix.GeneralLinearGroup.det_ne_zero X)
-    have hX_inv_inv :
-        ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹)⁻¹ =
-          (X : Matrix (Fin D) (Fin D) ℂ) :=
-      Matrix.nonsing_inv_nonsing_inv (X : Matrix (Fin D) (Fin D) ℂ) hXdet
-    have hXstar_det : IsUnit (((X : Matrix (Fin D) (Fin D) ℂ)ᴴ).det) := by
-      simpa [Matrix.det_conjTranspose] using IsUnit.star hXdet
-    have hXstar_inv_inv :
-        (((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹)⁻¹ =
-          (X : Matrix (Fin D) (Fin D) ℂ)ᴴ :=
-      Matrix.nonsing_inv_nonsing_inv
-        ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ) hXstar_det
-    calc
-      transferMap (d := d) (D := D) B Y =
-          ∑ x : Fin d,
-            ((X : Matrix (Fin D) (Fin D) ℂ) * A x *
-              (X : Matrix (Fin D) (Fin D) ℂ)⁻¹) * Y *
-              (((X : Matrix (Fin D) (Fin D) ℂ) * A x *
-                (X : Matrix (Fin D) (Fin D) ℂ)⁻¹)ᴴ) := by
-            simp [transferMap_apply, hX]
-      _ = ∑ x : Fin d,
-            (X : Matrix (Fin D) (Fin D) ℂ) *
-              (A x * ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹ * Y *
-                ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹) * (A x)ᴴ) *
-              (X : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-            refine Finset.sum_congr rfl ?_
-            intro x _
-            simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
-              Matrix.mul_assoc]
-      _ = (X : Matrix (Fin D) (Fin D) ℂ) *
-            (∑ x : Fin d,
-              A x * ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹ * Y *
-                ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹) * (A x)ᴴ) *
-            (X : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-            simp [Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc]
-      _ = similarityMap (D := D)
-            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-            (transferMap (d := d) (D := D) A) Y := by
-            simp [similarityMap, transferMap_apply, Matrix.conjTranspose_nonsing_inv,
-              hX_inv_inv, hXstar_inv_inv, Matrix.mul_assoc]
-
 end GaugeEquiv
 
 namespace IsNormalTensor
 
-/-- Transport normal-tensor status backward along a gauge equivalence.
-
-The transfer maps are similar, hence have the same spectral radius and
-peripheral spectrum; irreducibility is transported through the corresponding
-irreducible-map similarity.
-
-Source: arXiv:1606.00608, lines 233--235 define normal tensors and lines
-264--268 give the invertible gauge relation between normal representatives. -/
-theorem of_gaugeEquiv {A B : MPSTensor d D} (hB : IsNormalTensor B)
-    (hGauge : GaugeEquiv A B) :
-    IsNormalTensor A := by
-  obtain ⟨C, hC, hMap⟩ := hGauge.transferMap_eq_similarityMap
-  refine ⟨?_, ?_, ?_⟩
-  · have hIrrB : IsIrreducibleMap (transferMap (d := d) (D := D) B) :=
-      isIrreducibleCP_transferMap_of_isIrreducibleTensor B hB.no_invariant_proj
-    have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
-      have hIrrSim : IsIrreducibleMap
-          (similarityMap (D := D) C (transferMap (d := d) (D := D) A)) := by
-        simpa [hMap] using hIrrB
-      exact (isIrreducibleMap_similarity_iff (D := D) hC).1 hIrrSim
-    exact isIrreducibleTensor_of_isIrreducibleMap A hIrrA
-  · have hsr := hB.spectral_radius_one
-    rw [hMap] at hsr
-    rw [spectralRadius_similarityMap_eq (D := D) C hC
-      (transferMap (d := d) (D := D) A)] at hsr
-    exact hsr
-  · have hPrim := hB.primitive_transfer
-    rw [hMap] at hPrim
-    exact (IsPrimitive.similarityMap_iff (D := D) C hC
-      (transferMap (d := d) (D := D) A)).1 hPrim
 
 /-- Positive physical blocking preserves CPSV normal tensors.
 

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -61,7 +61,6 @@ end GaugeEquiv
 
 namespace IsNormalTensor
 
-
 /-- Positive physical blocking preserves CPSV normal tensors.
 
 The proof puts the tensor into its trace-preserving Perron gauge.  Positive

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -131,9 +131,10 @@ theorem GaugeEquiv.mapStar {A B : MPSTensor d D} (h : GaugeEquiv A B) :
 /-- Entrywise complex conjugation preserves CPSV normal tensors.
 
 The proof uses the pure trace-preserving Perron gauge associated with the
-normal tensor, conjugates that gauge, and transports normality back. This is
-the normalization of arXiv:1606.00608, lines 224--235, together with the gauge
-relation at lines 264--268. -/
+normal tensor, conjugates that gauge, and transports normality back. Entrywise
+conjugation transports the spectral-radius-one normalization of
+arXiv:1606.00608, lines 224--235, together with the gauge relation at lines
+264--268. -/
 theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A) :
     IsNormalTensor (mapStar A) := by
   letI : NeZero D := ⟨hA.bondDim_ne_zero⟩

--- a/TNLean/MPS/CanonicalForm/Conjugation.lean
+++ b/TNLean/MPS/CanonicalForm/Conjugation.lean
@@ -20,6 +20,7 @@ and the transfer-map fixed-point equations used in canonical forms.
 * `MPSTensor.IsInjective.mapStar`: conjugation preserves injectivity.
 * `MPSTensor.IsNormal.mapStar`: conjugation preserves normality.
 * `MPSTensor.IsLeftCanonical.mapStar`: conjugation preserves left-canonical normalization.
+* `MPSTensor.GaugeEquiv.mapStar`: conjugation preserves gauge equivalence.
 * `MPSTensor.IsNormalTensor.mapStar`: conjugation preserves normalized normal tensors.
 -/
 
@@ -113,11 +114,36 @@ theorem IsLeftCanonical.mapStar {A : MPSTensor d D} (hA : IsLeftCanonical A) :
       rfl
     _ = 1 := by rw [hA]; simp
 
-/-- If a normal tensor is left-canonical, then its entrywise conjugate is a normal tensor. -/
-theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A)
-    (hLeft : IsLeftCanonical A) : IsNormalTensor (mapStar A) := by
+/-- Gauge equivalence is preserved by entrywise complex conjugation.
+
+This conjugates the invertible gauge in the relation of arXiv:1606.00608,
+lines 264--268. -/
+theorem GaugeEquiv.mapStar {A B : MPSTensor d D} (h : GaugeEquiv A B) :
+    GaugeEquiv (mapStar A) (mapStar B) := by
+  obtain ⟨X, hX⟩ := h
+  let f : Matrix (Fin D) (Fin D) ℂ →+* Matrix (Fin D) (Fin D) ℂ :=
+    (starRingEnd ℂ).mapMatrix
+  let Xbar : GL (Fin D) ℂ := (Units.map f.toMonoidHom) X
+  refine ⟨Xbar, fun i ↦ ?_⟩
+  rw [mapStar_apply, mapStar_apply, hX i, Matrix.map_mul, Matrix.map_mul]
+  rfl
+
+/-- Entrywise complex conjugation preserves CPSV normal tensors.
+
+The proof uses the pure trace-preserving Perron gauge associated with the
+normal tensor, conjugates that gauge, and transports normality back. This is
+the normalization of arXiv:1606.00608, lines 224--235, together with the gauge
+relation at lines 264--268. -/
+theorem IsNormalTensor.mapStar {A : MPSTensor d D} (hA : IsNormalTensor A) :
+    IsNormalTensor (mapStar A) := by
   letI : NeZero D := ⟨hA.bondDim_ne_zero⟩
-  exact isNormalTensor_of_isNormal_leftCanonical _ hA.isNormal.mapStar hLeft.mapStar
+  obtain ⟨σ, _hσ, _hσfix, hLeft, hGauge, _hPrim, _hIrr⟩ := hA.exists_tpGauge
+  have hGaugeNormal : IsNormalTensor (tpGauge (d := d) (D := D) A σ) :=
+    hA.of_gaugeEquiv hGauge.symm
+  have hGaugeStarNormal :
+      IsNormalTensor (MPSTensor.mapStar (tpGauge (d := d) (D := D) A σ)) :=
+    isNormalTensor_of_isNormal_leftCanonical _ hGaugeNormal.isNormal.mapStar hLeft.mapStar
+  exact hGaugeStarNormal.of_gaugeEquiv hGauge.mapStar
 
 /-- A diagonal positive-definite complex matrix is fixed by entrywise conjugation. -/
 theorem map_star_eq_self_of_posDef_isDiag

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexPhasePositivity
+import TNLean.Channel.Irreducible.SpectralRadius
 import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.Core.TransferChannel
 import TNLean.MPS.CanonicalForm.PhaseCover
@@ -30,6 +31,10 @@ tensor.
 
 ## Main statements
 
+* `GaugeEquiv.transferMap_eq_similarityMap`: gauge-equivalent tensors have
+  similar transfer maps.
+* `IsNormalTensor.of_gaugeEquiv`: CPSV normal-tensor status is invariant under
+  gauge equivalence.
 * `exists_tpGauge_of_irreducible_spectralRadius_one`: an irreducible
   spectral-radius-one tensor admits a pure trace-preserving Perron gauge.
 * `IsNormalTensor.exists_tpGauge`: a normal tensor admits a pure
@@ -59,6 +64,101 @@ open Filter
 namespace MPSTensor
 
 variable {d D : ℕ}
+
+namespace GaugeEquiv
+
+/-- The transfer maps of gauge-equivalent tensors are related by the standard
+congruence similarity of completely positive maps.
+
+Source: arXiv:1606.00608, lines 219--223 define the transfer map and lines
+264--268 give the invertible gauge relation. -/
+theorem transferMap_eq_similarityMap {A B : MPSTensor d D} (h : GaugeEquiv A B) :
+    ∃ C : Matrix (Fin D) (Fin D) ℂ, C.det ≠ 0 ∧
+      transferMap (d := d) (D := D) B =
+        similarityMap (D := D) C (transferMap (d := d) (D := D) A) := by
+  obtain ⟨X, hX⟩ := h
+  refine ⟨((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ), ?_, ?_⟩
+  · exact Matrix.GeneralLinearGroup.det_ne_zero (X⁻¹ : GL (Fin D) ℂ)
+  · apply LinearMap.ext
+    intro Y
+    have hXdet : IsUnit ((X : Matrix (Fin D) (Fin D) ℂ).det) :=
+      Ne.isUnit (Matrix.GeneralLinearGroup.det_ne_zero X)
+    have hX_inv_inv :
+        ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹)⁻¹ =
+          (X : Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.nonsing_inv_nonsing_inv (X : Matrix (Fin D) (Fin D) ℂ) hXdet
+    have hXstar_det : IsUnit (((X : Matrix (Fin D) (Fin D) ℂ)ᴴ).det) := by
+      simpa [Matrix.det_conjTranspose] using IsUnit.star hXdet
+    have hXstar_inv_inv :
+        (((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹)⁻¹ =
+          (X : Matrix (Fin D) (Fin D) ℂ)ᴴ :=
+      Matrix.nonsing_inv_nonsing_inv
+        ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ) hXstar_det
+    calc
+      transferMap (d := d) (D := D) B Y =
+          ∑ x : Fin d,
+            ((X : Matrix (Fin D) (Fin D) ℂ) * A x *
+              (X : Matrix (Fin D) (Fin D) ℂ)⁻¹) * Y *
+              (((X : Matrix (Fin D) (Fin D) ℂ) * A x *
+                (X : Matrix (Fin D) (Fin D) ℂ)⁻¹)ᴴ) := by
+            simp [transferMap_apply, hX]
+      _ = ∑ x : Fin d,
+            (X : Matrix (Fin D) (Fin D) ℂ) *
+              (A x * ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹ * Y *
+                ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹) * (A x)ᴴ) *
+              (X : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
+            refine Finset.sum_congr rfl ?_
+            intro x _
+            simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
+              Matrix.mul_assoc]
+      _ = (X : Matrix (Fin D) (Fin D) ℂ) *
+            (∑ x : Fin d,
+              A x * ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹ * Y *
+                ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹) * (A x)ᴴ) *
+            (X : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
+            simp [Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc]
+      _ = similarityMap (D := D)
+            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+            (transferMap (d := d) (D := D) A) Y := by
+            simp [similarityMap, transferMap_apply, Matrix.conjTranspose_nonsing_inv,
+              hX_inv_inv, hXstar_inv_inv, Matrix.mul_assoc]
+
+end GaugeEquiv
+
+namespace IsNormalTensor
+
+/-- Transport normal-tensor status backward along a gauge equivalence.
+
+The transfer maps are similar, hence have the same spectral radius and
+peripheral spectrum; irreducibility is transported through the corresponding
+irreducible-map similarity.
+
+Source: arXiv:1606.00608, lines 233--235 define normal tensors and lines
+264--268 give the invertible gauge relation between normal representatives. -/
+theorem of_gaugeEquiv {A B : MPSTensor d D} (hB : IsNormalTensor B)
+    (hGauge : GaugeEquiv A B) :
+    IsNormalTensor A := by
+  obtain ⟨C, hC, hMap⟩ := hGauge.transferMap_eq_similarityMap
+  refine ⟨?_, ?_, ?_⟩
+  · have hIrrB : IsIrreducibleMap (transferMap (d := d) (D := D) B) :=
+      isIrreducibleCP_transferMap_of_isIrreducibleTensor B hB.no_invariant_proj
+    have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
+      have hIrrSim : IsIrreducibleMap
+          (similarityMap (D := D) C (transferMap (d := d) (D := D) A)) := by
+        simpa [hMap] using hIrrB
+      exact (isIrreducibleMap_similarity_iff (D := D) hC).1 hIrrSim
+    exact isIrreducibleTensor_of_isIrreducibleMap A hIrrA
+  · have hsr := hB.spectral_radius_one
+    rw [hMap] at hsr
+    rw [spectralRadius_similarityMap_eq (D := D) C hC
+      (transferMap (d := d) (D := D) A)] at hsr
+    exact hsr
+  · have hPrim := hB.primitive_transfer
+    rw [hMap] at hPrim
+    exact (IsPrimitive.similarityMap_iff (D := D) C hC
+      (transferMap (d := d) (D := D) A)).1 hPrim
+
+end IsNormalTensor
 
 /-- An irreducible tensor of spectral radius one admits a trace-preserving Perron gauge with no
 scalar rescaling.

--- a/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
+++ b/TNLean/MPS/MPU/PhysicalAdjointCanonicalForm.lean
@@ -89,8 +89,8 @@ noncomputable def physicalAdjointNormalizedFlattening
   blocks := fun k ↦ MPSTensor.reindexPhysical (MPOTensor.physicalPairSwapEquiv d)
     (MPSTensor.mapStar (data.blocks k))
   blocks_normal := fun k ↦
-    (MPSTensor.IsNormalTensor.mapStar (data.blocks_normal k)
-      (data.blocks_left_canonical k)).reindexPhysical (MPOTensor.physicalPairSwapEquiv d)
+    (MPSTensor.IsNormalTensor.mapStar (data.blocks_normal k)).reindexPhysical
+      (MPOTensor.physicalPairSwapEquiv d)
   total_dim_le := data.total_dim_le
   ambient_coisometry := data.ambient_coisometry.map (starRingEnd ℂ)
   coisometric := by

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -350,8 +350,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \lean{MPSTensor.IsNormalTensor.mapStar}
     \leanok
     \uses{def:left_canonical_tensor,def:nt_cpsv,def:gauge_equiv}
-    Let $\overline A$ denote entrywise conjugation of every matrix $A^i$. If
-    $A$ and $B$ are gauge equivalent through $X$, then $\overline A$ and
+    For a tensor or matrix, an overline denotes entrywise conjugation. If $A$
+    and $B$ are gauge equivalent through $X$, then $\overline A$ and
     $\overline B$ are gauge equivalent through $\overline X$. If $A$ is
     left-canonical, then $\overline A$ is left-canonical. Independently, if $A$
     is a CPSV normal tensor, then $\overline A$ is a CPSV normal tensor.
@@ -359,11 +359,11 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 
 \begin{proof}\leanok
     \uses{def:left_canonical_tensor,def:gauge_equiv,
-        thm:cpsv_normal_tp_gauge,
+        thm:cpsv_normal_tp_gauge,thm:pure_perron_tp_gauge,
         thm:cpsv_normal_tensor_gauge_transport,
         thm:is_normal_tensor_of_is_normal_left_canonical}
     Entrywise conjugating $B^i=X A^i X^{-1}$ gives
-    $\overline{B^i}=\overline X\,\overline{A^i}\,\overline X^{-1}$.
+    $\overline{B^i}=\overline X\,\overline{A^i}\,(\overline X)^{-1}$.
     Conjugating the left-canonical identity gives
     \begin{align}
         \sum_i(\overline{A^i})^\dagger\overline{A^i}

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -343,31 +343,42 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     Definition~\ref{def:nt_cpsv} hold for $A$ itself.
 \end{proof}
 
-\begin{theorem}[Canonical normalization under entrywise conjugation]
+\begin{theorem}[Normality and left-canonical normalization under entrywise conjugation]
     \label{thm:cpsv_map_star_preservation}
     \lean{MPSTensor.IsLeftCanonical.mapStar}
+    \lean{MPSTensor.GaugeEquiv.mapStar}
     \lean{MPSTensor.IsNormalTensor.mapStar}
     \leanok
-    \uses{def:left_canonical_tensor,def:nt_cpsv}
+    \uses{def:left_canonical_tensor,def:nt_cpsv,def:gauge_equiv}
     Let $\overline A$ denote entrywise conjugation of every matrix $A^i$. If
-    $A$ is left-canonical, then $\overline A$ is left-canonical. If, in
-    addition, $A$ is a CPSV normal tensor, then $\overline A$ is a CPSV normal
-    tensor.
+    $A$ and $B$ are gauge equivalent through $X$, then $\overline A$ and
+    $\overline B$ are gauge equivalent through $\overline X$. If $A$ is
+    left-canonical, then $\overline A$ is left-canonical. Independently, if $A$
+    is a CPSV normal tensor, then $\overline A$ is a CPSV normal tensor.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:left_canonical_tensor,
+    \uses{def:left_canonical_tensor,def:gauge_equiv,
+        thm:cpsv_normal_tp_gauge,
+        thm:cpsv_normal_tensor_gauge_transport,
         thm:is_normal_tensor_of_is_normal_left_canonical}
+    Entrywise conjugating $B^i=X A^i X^{-1}$ gives
+    $\overline{B^i}=\overline X\,\overline{A^i}\,\overline X^{-1}$.
     Conjugating the left-canonical identity gives
     \begin{align}
         \sum_i(\overline{A^i})^\dagger\overline{A^i}
         &=\overline{\sum_i(A^i)^\dagger A^i}
          =\overline{\Id}=\Id.
     \end{align}
+    For the normal-tensor assertion, put $A$ into the trace-preserving Perron
+    gauge supplied by Theorem~\ref{thm:cpsv_normal_tp_gauge}. Gauge transport
+    preserves normal-tensor status, and entrywise conjugation preserves the
+    gauge relation. The conjugated representative is left-canonical; moreover,
     \lean{MPSTensor.IsNormal.mapStar}
-    Entrywise conjugation also preserves positive-length block injectivity.
-    Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical} applied to
-    $\overline A$ now gives the CPSV normal-tensor conclusion.
+    entrywise conjugation preserves its positive-length block injectivity.
+    Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical} therefore
+    makes the conjugated representative a CPSV normal tensor. Transporting
+    back through the conjugated gauge gives the result for $\overline A$.
 \end{proof}
 
 \begin{theorem}[Transfer maps and positive diagonal matrices under

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -359,7 +359,7 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 
 \begin{proof}\leanok
     \uses{def:left_canonical_tensor,def:gauge_equiv,
-        thm:cpsv_normal_tp_gauge,thm:pure_perron_tp_gauge,
+        thm:cpsv_normal_tp_gauge,
         thm:cpsv_normal_tensor_gauge_transport,
         thm:is_normal_tensor_of_is_normal_left_canonical}
     Entrywise conjugating $B^i=X A^i X^{-1}$ gives
@@ -373,7 +373,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     For the normal-tensor assertion, put $A$ into the trace-preserving Perron
     gauge supplied by Theorem~\ref{thm:cpsv_normal_tp_gauge}. Gauge transport
     preserves normal-tensor status, and entrywise conjugation preserves the
-    gauge relation. The conjugated representative is left-canonical; moreover,
+    gauge relation. The Perron representative is trace-preserving, hence
+    left-canonical, and conjugation preserves this identity. Moreover,
     \lean{MPSTensor.IsNormal.mapStar}
     entrywise conjugation preserves its positive-length block injectivity.
     Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical} therefore

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -359,7 +359,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 
 \begin{proof}\leanok
     \uses{def:left_canonical_tensor,def:gauge_equiv,
-        thm:cpsv_normal_tp_gauge,
+        thm:cpsv_normal_bond_dim_pos,thm:cpsv_normal_tp_gauge,
+        thm:cpsv_normal_eventually_injective,
         thm:cpsv_normal_tensor_gauge_transport,
         thm:is_normal_tensor_of_is_normal_left_canonical}
     Entrywise conjugating $B^i=X A^i X^{-1}$ gives

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -1696,8 +1696,8 @@ physical indices and $\alpha,\beta$ are auxiliary indices.
 \begin{proof}\leanok
     \uses{def:mpu_physical_adjoint_cfii_data,
         thm:cpsv_map_star_preservation,thm:cpsv_physical_reindexing}
-    Theorem~\ref{thm:cpsv_map_star_preservation} gives normality and
-    left-canonical normalization after entrywise conjugation, and
+    Theorem~\ref{thm:cpsv_map_star_preservation} independently preserves
+    normality and left-canonical normalization under entrywise conjugation, and
     Theorem~\ref{thm:cpsv_physical_reindexing} preserves these properties under
     the physical-pair swap.  Conjugating the coisometry equation gives
     \begin{align}


### PR DESCRIPTION
## Summary

- move the generic transfer-map similarity and CPSV normal-tensor gauge transport next to the Perron-gauge API
- prove entrywise conjugation preserves gauge equivalence
- remove the unnecessary `IsLeftCanonical` hypothesis from `IsNormalTensor.mapStar`
- simplify the physical-adjoint CFII transport and align Chapters 9 and 28 with the independent normality/left-canonical conclusions

## Mathematical route

This follows the existing CPSV normalization route rather than adding a new anti-linear spectral theory. A normal tensor is put into its pure trace-preserving Perron gauge, normality is transported to that representative, the already-proved conjugation results are applied there, and normality is transported back through the conjugated gauge. The cited terminology and normalization are from arXiv:1606.00608, lines 224--235 and 264--268; the downstream physical-adjoint use matches arXiv:1703.09188.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/Conjugation.lean`
- `lake build TNLean.MPS.MPU.PhysicalAdjointCanonicalForm`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (7705/7705)
- `python3 scripts/test_generate_import_aggregators.py`
- `git diff --check`
- independent Mathlib/API, Lean feasibility, blueprint, and Lean-style reviews

Exact-head targeted builds pass for , , , and  (8913 jobs). CI remains authoritative for the full repository gate.

Closes #6400.