### PR TITLE
feat(MPDO): prove the dimer tensor is not simple

### DIFF
--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -57,33 +57,6 @@ theorem blockTensor {A B : MPSTensor d D} (h : GaugeEquiv A B) (p : ℕ) :
   simpa [MPSTensor.blockTensor, Matrix.GeneralLinearGroup.coe_inv] using
     evalWord_gauge (A := A) (B := B) X hX (wordOfBlock d p i)
 
-
-/-- Gauge equivalence transports quasi-idempotence of the transfer map. -/
-theorem transferMap_comp_self_eq_smul_iff {A B : MPSTensor d D}
-    (h : GaugeEquiv A B) (c : ℂ) :
-    transferMap (d := d) (D := D) B ∘ₗ transferMap (d := d) (D := D) B =
-        c • transferMap (d := d) (D := D) B ↔
-      transferMap (d := d) (D := D) A ∘ₗ transferMap (d := d) (D := D) A =
-        c • transferMap (d := d) (D := D) A := by
-  obtain ⟨C, hC, hMap⟩ := h.transferMap_eq_similarityMap
-  let e := (Matrix.congruenceLinearEquiv C hC).symm.conjAlgEquiv ℂ
-  have hSimilarity (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
-      Matrix (Fin D) (Fin D) ℂ) :
-      similarityMap (D := D) C E = e E := by
-    apply LinearMap.ext
-    intro X
-    ext i j
-    simp [e, similarityMap, LinearEquiv.conjAlgEquiv_apply, Matrix.mul_assoc]
-  rw [hMap, hSimilarity]
-  constructor
-  · intro hPoly
-    apply e.injective
-    rw [← Module.End.mul_eq_comp] at hPoly ⊢
-    simpa using hPoly
-  · intro hPoly
-    rw [← Module.End.mul_eq_comp] at hPoly ⊢
-    simpa using congrArg e hPoly
-
 end GaugeEquiv
 
 namespace IsNormalTensor

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -57,6 +57,33 @@ theorem blockTensor {A B : MPSTensor d D} (h : GaugeEquiv A B) (p : ℕ) :
   simpa [MPSTensor.blockTensor, Matrix.GeneralLinearGroup.coe_inv] using
     evalWord_gauge (A := A) (B := B) X hX (wordOfBlock d p i)
 
+
+/-- Gauge equivalence transports quasi-idempotence of the transfer map. -/
+theorem transferMap_comp_self_eq_smul_iff {A B : MPSTensor d D}
+    (h : GaugeEquiv A B) (c : ℂ) :
+    transferMap (d := d) (D := D) B ∘ₗ transferMap (d := d) (D := D) B =
+        c • transferMap (d := d) (D := D) B ↔
+      transferMap (d := d) (D := D) A ∘ₗ transferMap (d := d) (D := D) A =
+        c • transferMap (d := d) (D := D) A := by
+  obtain ⟨C, hC, hMap⟩ := h.transferMap_eq_similarityMap
+  let e := (Matrix.congruenceLinearEquiv C hC).symm.conjAlgEquiv ℂ
+  have hSimilarity (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin D) (Fin D) ℂ) :
+      similarityMap (D := D) C E = e E := by
+    apply LinearMap.ext
+    intro X
+    ext i j
+    simp [e, similarityMap, LinearEquiv.conjAlgEquiv_apply, Matrix.mul_assoc]
+  rw [hMap, hSimilarity]
+  constructor
+  · intro hPoly
+    apply e.injective
+    rw [← Module.End.mul_eq_comp] at hPoly ⊢
+    simpa using hPoly
+  · intro hPoly
+    rw [← Module.End.mul_eq_comp] at hPoly ⊢
+    simpa using congrArg e hPoly
+
 end GaugeEquiv
 
 namespace IsNormalTensor

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -33,6 +33,8 @@ tensor.
 
 * `GaugeEquiv.transferMap_eq_similarityMap`: gauge-equivalent tensors have
   similar transfer maps.
+* `GaugeEquiv.transferMap_comp_self_eq_smul_iff`: transfer quasi-idempotence is
+  invariant under gauge equivalence.
 * `IsNormalTensor.of_gaugeEquiv`: CPSV normal-tensor status is invariant under
   gauge equivalence.
 * `exists_tpGauge_of_irreducible_spectralRadius_one`: an irreducible
@@ -122,6 +124,32 @@ theorem transferMap_eq_similarityMap {A B : MPSTensor d D} (h : GaugeEquiv A B) 
             (transferMap (d := d) (D := D) A) Y := by
             simp [similarityMap, transferMap_apply, Matrix.conjTranspose_nonsing_inv,
               hX_inv_inv, hXstar_inv_inv, Matrix.mul_assoc]
+
+/-- Gauge equivalence transports quasi-idempotence of the transfer map. -/
+theorem transferMap_comp_self_eq_smul_iff {A B : MPSTensor d D}
+    (h : GaugeEquiv A B) (c : ℂ) :
+    transferMap (d := d) (D := D) B ∘ₗ transferMap (d := d) (D := D) B =
+        c • transferMap (d := d) (D := D) B ↔
+      transferMap (d := d) (D := D) A ∘ₗ transferMap (d := d) (D := D) A =
+        c • transferMap (d := d) (D := D) A := by
+  obtain ⟨C, hC, hMap⟩ := h.transferMap_eq_similarityMap
+  let e := (Matrix.congruenceLinearEquiv C hC).symm.conjAlgEquiv ℂ
+  have hSimilarity (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin D) (Fin D) ℂ) :
+      similarityMap (D := D) C E = e E := by
+    apply LinearMap.ext
+    intro X
+    ext i j
+    simp [e, similarityMap, LinearEquiv.conjAlgEquiv_apply, Matrix.mul_assoc]
+  rw [hMap, hSimilarity]
+  constructor
+  · intro hPoly
+    apply e.injective
+    rw [← Module.End.mul_eq_comp] at hPoly ⊢
+    simpa using hPoly
+  · intro hPoly
+    rw [← Module.End.mul_eq_comp] at hPoly ⊢
+    simpa using congrArg e hPoly
 
 end GaugeEquiv
 

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -77,7 +77,8 @@ theorem transferMap_blockTensor_quasi_idempotent
           (transferMap (d := d) (D := D) A) ^ L =
         ((transferMap (d := d) (D := D) A) ^ L) ^ 2 := by rw [pow_two]
     _ = ((transferMap (d := d) (D := D) A) ^ 2) ^ L := by
-      rw [← pow_mul, ← pow_mul, Nat.mul_comm L 2]
+      simpa only [pow_mul] using congrArg
+        (fun n : ℕ => (transferMap (d := d) (D := D) A) ^ n) (Nat.mul_comm L 2)
     _ = (c • transferMap (d := d) (D := D) A) ^ L := by rw [pow_two, h]
     _ = c ^ L • (transferMap (d := d) (D := D) A) ^ L := by rw [smul_pow]
 

--- a/TNLean/MPS/Core/BlockingTransfer.lean
+++ b/TNLean/MPS/Core/BlockingTransfer.lean
@@ -14,9 +14,10 @@ import Mathlib.LinearAlgebra.Eigenspace.Basic
 
 This file identifies the transfer map of a physically blocked tensor with the
 corresponding iterate of the original transfer map. As consequences,
-`transferMap_blockTensor_hasEigenvalue` and
-`transferMap_blockTensor_fixedPoint` transport eigenvalues and fixed points
-through blocking.
+`transferMap_blockTensor_quasi_idempotent`,
+`transferMap_blockTensor_hasEigenvalue`, and
+`transferMap_blockTensor_fixedPoint` transport quasi-idempotence, eigenvalues,
+and fixed points through blocking.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
@@ -57,6 +58,28 @@ theorem transferMap_blockTensor
       (transferMap (d := d) (D := D) A) ^ L := by
   ext X : 1
   simpa using transferMap_blockTensor_apply (A := A) (L := L) (X := X)
+
+/-- Quasi-idempotence propagates through physical blocking, with the scalar raised to the
+blocking length. -/
+theorem transferMap_blockTensor_quasi_idempotent
+    (A : MPSTensor d D) (L : ℕ) (c : ℂ)
+    (h : transferMap (d := d) (D := D) A * transferMap (d := d) (D := D) A =
+      c • transferMap (d := d) (D := D) A) :
+    transferMap (d := blockPhysDim d L) (D := D)
+        (blockTensor (d := d) (D := D) A L) *
+      transferMap (d := blockPhysDim d L) (D := D)
+        (blockTensor (d := d) (D := D) A L) =
+      c ^ L • transferMap (d := blockPhysDim d L) (D := D)
+        (blockTensor (d := d) (D := D) A L) := by
+  rw [transferMap_blockTensor]
+  calc
+    (transferMap (d := d) (D := D) A) ^ L *
+          (transferMap (d := d) (D := D) A) ^ L =
+        ((transferMap (d := d) (D := D) A) ^ L) ^ 2 := by rw [pow_two]
+    _ = ((transferMap (d := d) (D := D) A) ^ 2) ^ L := by
+      rw [← pow_mul, ← pow_mul, Nat.mul_comm L 2]
+    _ = (c • transferMap (d := d) (D := D) A) ^ L := by rw [pow_two, h]
+    _ = c ^ L • (transferMap (d := d) (D := D) A) ^ L := by rw [smul_pow]
 
 /-- Eigenvalues transport along physical blocking: if `μ` is an eigenvalue of `transferMap A`,
 then `μ ^ L` is an eigenvalue of the transfer map of the blocked tensor. -/

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -274,6 +274,7 @@ import TNLean.MPS.MPDO.RescalingStableLengthDependentRFP
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPBNTClause
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCapstone
+import TNLean.MPS.MPDO.RescalingStableNotSimple
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPViaTS
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SALArbitraryCut

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -274,8 +274,8 @@ import TNLean.MPS.MPDO.RescalingStableLengthDependentRFP
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPBNTClause
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCapstone
-import TNLean.MPS.MPDO.RescalingStableNotSimple
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPViaTS
+import TNLean.MPS.MPDO.RescalingStableNotSimple
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SALArbitraryCut
 import TNLean.MPS.MPDO.SALPhysicalSectorCyclicPositivity

--- a/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.CPSVBlocking
+import TNLean.MPS.Core.BlockingTransfer
+import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
+import TNLean.MPS.RFP.BNTOrthogonality
+
+/-!
+# Presentation-independent nonsimplicity of the rescaling-stable dimer tensor
+
+The transfer map of the rescaling-stable dimer tensor `R` is quasi-idempotent
+with scalar $337/512$. After blocking $L>0$ sites, the scalar is
+$(337/512)^L$, which is strictly smaller than one. A normalized BNT horizontal
+canonical form would force this scalar to equal one by its global unit-weight
+copy and the trace-preserving normalization of that copy. Hence no positive
+blocking of `R` has horizontal canonical form, independently of the chosen BNT
+presentation, and `R` is not simple.
+
+No vertical coefficient comparison is used.
+
+## Main results
+
+* `transferMap_blockTensor_R_toMPSTensor_quasi_idempotent` — the blocked
+  transfer scalar is $(337/512)^L$.
+* `blockTensor_R_not_isHorizontalCF` — no positive blocking admits a normalized
+  BNT horizontal canonical form.
+* `R_not_isSimple` — the dimer tensor is not simple.
+
+The obstruction combines the source normalization at arXiv:1606.00608, line
+246 with the positive blocking in the definition of simplicity at lines
+815--822.
+-/
+
+open scoped Matrix BigOperators
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A normalized BNT-refined horizontal form forces the scalar in a transfer
+quasi-idempotence equation to equal one.
+
+The horizontal gauge transports the equation to the normalized sector
+decomposition, where
+`MPSTensor.IsBNTCanonicalForm.eq_one_of_transferMap_comp_self_eq_smul`
+applies. -/
+theorem IsHorizontalCF.eq_one_of_transferMap_comp_self_eq_smul
+    {M : MPOTensor d D} (hHorizontal : IsHorizontalCF M) (c : ℂ)
+    (h : MPSTensor.transferMap M.toMPSTensor ∘ₗ
+        MPSTensor.transferMap M.toMPSTensor =
+      c • MPSTensor.transferMap M.toMPSTensor) :
+    c = 1 := by
+  obtain ⟨S, hCF, hTotal, X, hEq⟩ := hHorizontal
+  subst D
+  have hGauge : MPSTensor.GaugeEquiv S.toTensor M.toMPSTensor := by
+    refine ⟨MPSTensor.globalGaugeOfBlocks X, ?_⟩
+    intro i
+    simpa using hEq i
+  have hSector := (hGauge.transferMap_comp_self_eq_smul_iff c).mp h
+  exact hCF.eq_one_of_transferMap_comp_self_eq_smul S c hSector
+
+end MPOTensor
+
+namespace MPOTensor.RescalingStableLengthDependentRFP
+
+/-- The transfer map of the $L$-site blocked dimer tensor is quasi-idempotent
+with scalar $(337/512)^L$.
+
+Project example; the blocking convention is arXiv:1606.00608, lines 815--822. -/
+theorem transferMap_blockTensor_R_toMPSTensor_quasi_idempotent (L : ℕ) :
+    MPSTensor.transferMap (MPOTensor.blockTensor R L).toMPSTensor *
+        MPSTensor.transferMap (MPOTensor.blockTensor R L).toMPSTensor =
+      (337/512 : ℂ) ^ L •
+        MPSTensor.transferMap (MPOTensor.blockTensor R L).toMPSTensor := by
+  rw [MPOTensor.toMPSTensor_blockTensor,
+    MPSTensor.transferMap_reindexPhysical_equiv]
+  apply MPSTensor.transferMap_blockTensor_quasi_idempotent
+  apply LinearMap.ext
+  intro X
+  simpa only [Module.End.mul_apply, LinearMap.smul_apply] using
+    transferMap_R_toMPSTensor_idem X
+
+/-- No positive physical blocking of `R` admits a normalized BNT-refined
+horizontal canonical form.
+
+This conclusion is independent of the chosen BNT presentation: the proof uses
+only the existence of a unit-weight copy in any normalized BNT witness, then
+restricts transfer quasi-idempotence to that copy.
+
+Source: arXiv:1606.00608, line 246 and lines 815--822. -/
+theorem blockTensor_R_not_isHorizontalCF (L : ℕ) (hL : 0 < L) :
+    ¬ MPOTensor.IsHorizontalCF (MPOTensor.blockTensor R L) := by
+  intro hHorizontal
+  have hBlocked := transferMap_blockTensor_R_toMPSTensor_quasi_idempotent L
+  have hBlockedComp :
+      MPSTensor.transferMap (MPOTensor.blockTensor R L).toMPSTensor ∘ₗ
+          MPSTensor.transferMap (MPOTensor.blockTensor R L).toMPSTensor =
+        (337/512 : ℂ) ^ L •
+          MPSTensor.transferMap (MPOTensor.blockTensor R L).toMPSTensor := by
+    simpa only [Module.End.mul_eq_comp] using hBlocked
+  have hone := hHorizontal.eq_one_of_transferMap_comp_self_eq_smul
+    ((337/512 : ℂ) ^ L) hBlockedComp
+  have hlt : (337/512 : ℝ) ^ L < 1 :=
+    pow_lt_one₀ (by norm_num) (by norm_num) (Nat.ne_of_gt hL)
+  have hne : (337/512 : ℂ) ^ L ≠ 1 := by
+    intro heq
+    have hcast : (337/512 : ℂ) = ((337/512 : ℝ) : ℂ) := by norm_num
+    rw [hcast] at heq
+    have heqReal : (337/512 : ℝ) ^ L = 1 := by
+      exact_mod_cast heq
+    exact (ne_of_lt hlt) heqReal
+  exact hne hone
+
+/-- The rescaling-stable dimer tensor `R` is not simple, for every canonical-form
+presentation and every positive blocking length.
+
+Source: arXiv:1606.00608, definition of simplicity at lines 815--822. -/
+theorem R_not_isSimple : ¬ MPOTensor.IsSimple R := by
+  intro hSimple
+  obtain ⟨_hMPDO, L, hL, hCanonical⟩ := hSimple
+  exact blockTensor_R_not_isHorizontalCF L hL hCanonical.isHorizontalCF
+
+end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
@@ -71,7 +71,8 @@ namespace MPOTensor.RescalingStableLengthDependentRFP
 /-- The transfer map of the $L$-site blocked dimer tensor is quasi-idempotent
 with scalar $(337/512)^L$.
 
-Project example; the blocking convention is arXiv:1606.00608, lines 815--822. -/
+Project example; the physical blocking convention is arXiv:1606.00608,
+lines 227--231. -/
 theorem transferMap_blockTensor_R_toMPSTensor_quasi_idempotent (L : ℕ) :
     MPSTensor.transferMap (MPOTensor.blockTensor R L).toMPSTensor *
         MPSTensor.transferMap (MPOTensor.blockTensor R L).toMPSTensor =

--- a/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.CanonicalForm.CPSVBlocking
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.Core.BlockingTransfer
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
 import TNLean.MPS.RFP.BNTOrthogonality

--- a/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
@@ -120,6 +120,10 @@ theorem blockTensor_R_not_isHorizontalCF (L : ℕ) (hL : 0 < L) :
 /-- The rescaling-stable dimer tensor `R` is not simple, for every canonical-form
 presentation and every positive blocking length.
 
+**Scope restriction (fixed representative):** This theorem concerns the current
+normalized-witness predicate `MPOTensor.IsSimple`, not a scale-invariant notion
+of simplicity. See `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
+
 Source: arXiv:1606.00608, definition of simplicity at lines 815--822. -/
 theorem R_not_isSimple : ¬ MPOTensor.IsSimple R := by
   intro hSimple

--- a/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
@@ -93,6 +93,10 @@ This conclusion is independent of the chosen BNT presentation: the proof uses
 only the existence of a unit-weight copy in any normalized BNT witness, then
 restricts transfer quasi-idempotence to that copy.
 
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is the
+project's BNT-refined exact-gauge predicate, which is stronger than literal CPSV
+canonical form. See `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 Source: arXiv:1606.00608, line 246 and lines 815--822. -/
 theorem blockTensor_R_not_isHorizontalCF (L : ℕ) (hL : 0 < L) :
     ¬ MPOTensor.IsHorizontalCF (MPOTensor.blockTensor R L) := by

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -432,12 +432,12 @@ namespace IsBNTCanonicalForm
 /-- The unit-weight convention in a normalized BNT presentation forces any
 transfer quasi-idempotence scalar to equal one.
 
-Choose the unit-modulus copy supplied by the BNT normalization. Restrict the
-whole direct-sum transfer equation to that diagonal corner. Unit modulus removes
-the copy weight, so the representative transfer map satisfies
-$\mathcal E^2=c\mathcal E$. Left canonicity makes $\mathcal E$ trace preserving;
-taking the trace at the identity therefore gives $D=cD$, and the positive bond
-dimension gives $c=1$.
+Choose the unit-modulus copy supplied by the BNT normalization, with weight
+$w$. Then $w\,\overline w=1$, so $\mathcal E_{wA}=\mathcal E_A$. Restricting the
+whole direct-sum transfer equation to that diagonal corner therefore gives
+$\mathcal E_A^2=c\mathcal E_A$. Left canonicity makes $\mathcal E_A$ trace
+preserving; taking the trace at the identity gives $D=cD$, and the positive
+bond dimension gives $c=1$.
 
 Source convention: arXiv:1606.00608, line 246 (unit-weight normalization).
 The conclusion is a formal consequence of that convention and trace preservation. -/

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -439,8 +439,8 @@ $\mathcal E^2=c\mathcal E$. Left canonicity makes $\mathcal E$ trace preserving;
 taking the trace at the identity therefore gives $D=cD$, and the positive bond
 dimension gives $c=1$.
 
-Source: arXiv:1606.00608, line 246 (unit-weight normalization) and lines
-543--555 (restriction of the transfer equation to a canonical-form block). -/
+Source convention: arXiv:1606.00608, line 246 (unit-weight normalization).
+The conclusion is a formal consequence of that convention and trace preservation. -/
 theorem eq_one_of_transferMap_comp_self_eq_smul
     (P : SectorDecomposition d) (hCF : IsBNTCanonicalForm P) (c : ℂ)
     (h : transferMap P.toTensor ∘ₗ transferMap P.toTensor =

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -5,9 +5,9 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Algebra.FinSum
-import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.MPS.SharedInfra.Scaling
 import TNLean.Spectral.TransferOperatorGapNT
 
@@ -190,8 +190,8 @@ theorem transferMap_directSumTensor_reindex
 the same relation for the block-diagonal transfer sum. -/
 theorem blockTransferSum_blockTransferSum_eq_smul
     (B : (k : Fin r) → MPSTensor d (dim k)) (c : ℂ)
-    (h : ∀ X, transferMap (directSumTensor B)
-      (transferMap (directSumTensor B) X) = c • transferMap (directSumTensor B) X)
+    (h : transferMap (directSumTensor B) ∘ₗ transferMap (directSumTensor B) =
+      c • transferMap (directSumTensor B))
     (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
     blockTransferSum B (blockTransferSum B Y) = c • blockTransferSum B Y := by
   classical
@@ -204,7 +204,9 @@ theorem blockTransferSum_blockTransferSum_eq_smul
     _ = transferMap (directSumTensor B)
           (transferMap (directSumTensor B) (Matrix.reindex e e Y)) := by
             rw [transferMap_directSumTensor_reindex B Y]
-    _ = c • transferMap (directSumTensor B) (Matrix.reindex e e Y) := h _
+    _ = c • transferMap (directSumTensor B) (Matrix.reindex e e Y) := by
+          have hY := LinearMap.congr_fun h (Matrix.reindex e e Y)
+          simpa only [LinearMap.comp_apply, LinearMap.smul_apply] using hY
     _ = Matrix.reindex e e (c • blockTransferSum B Y) := by
           rw [transferMap_directSumTensor_reindex B Y]
           rfl
@@ -216,21 +218,10 @@ theorem blockTransferSum_blockTransferSum
     (hRFP : IsTransferIdempotent (directSumTensor B))
     (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
     blockTransferSum B (blockTransferSum B Y) = blockTransferSum B Y := by
-  classical
-  set e := finSigmaFinEquiv (m := r) (n := dim) with he
-  apply (Matrix.reindex e e).injective
-  calc
-    Matrix.reindex e e (blockTransferSum B (blockTransferSum B Y))
-        = transferMap (directSumTensor B) (Matrix.reindex e e (blockTransferSum B Y)) :=
-          (transferMap_directSumTensor_reindex B (blockTransferSum B Y)).symm
-    _ = transferMap (directSumTensor B)
-          (transferMap (directSumTensor B) (Matrix.reindex e e Y)) := by
-            rw [transferMap_directSumTensor_reindex B Y]
-    _ = transferMap (directSumTensor B) (Matrix.reindex e e Y) := by
-          have h := LinearMap.congr_fun hRFP (Matrix.reindex e e Y)
-          simpa only [LinearMap.comp_apply] using h
-    _ = Matrix.reindex e e (blockTransferSum B Y) :=
-          transferMap_directSumTensor_reindex B Y
+  change transferMap (directSumTensor B) ∘ₗ transferMap (directSumTensor B) =
+    transferMap (directSumTensor B) at hRFP
+  simpa only [one_smul] using
+    blockTransferSum_blockTransferSum_eq_smul B 1 (by simpa only [one_smul] using hRFP) Y
 
 /-- The `(j, j')` bond-block restriction is surjective: every block matrix is the
 restriction of a direct-sum bond matrix. -/
@@ -255,8 +246,8 @@ private lemma exists_toBlock_eq (j j' : Fin r) [NeZero (dim j)] [NeZero (dim j')
 block pair. In particular, the diagonal corner is the transfer map of that block. -/
 theorem mixedTransferMap₂_comp_self_eq_smul_of_transferMap_comp_self_eq_smul
     (B : (k : Fin r) → MPSTensor d (dim k)) (c : ℂ)
-    (h : ∀ X, transferMap (directSumTensor B)
-      (transferMap (directSumTensor B) X) = c • transferMap (directSumTensor B) X)
+    (h : transferMap (directSumTensor B) ∘ₗ transferMap (directSumTensor B) =
+      c • transferMap (directSumTensor B))
     (j j' : Fin r) [NeZero (dim j)] [NeZero (dim j')] :
     mixedTransferMap₂ (B j) (B j') * mixedTransferMap₂ (B j) (B j') =
       c • mixedTransferMap₂ (B j) (B j') := by
@@ -290,28 +281,13 @@ theorem mixedTransferMap₂_isIdempotentElem_of_isTransferIdempotent_directSum
     (hRFP : IsTransferIdempotent (directSumTensor B)) (j j' : Fin r)
     [NeZero (dim j)] [NeZero (dim j')] :
     IsIdempotentElem (mixedTransferMap₂ (B j) (B j')) := by
-  classical
-  have hStage1 : ∀ Y, (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) =
-      mixedTransferMap₂ (B j) (B j') (Y.submatrix (blockIncl j dim) (blockIncl j' dim)) := by
-    intro Y
-    simpa only [blockTransferSum] using blockDiagonal'_transferSum_toBlock B Y j j'
+  change transferMap (directSumTensor B) ∘ₗ transferMap (directSumTensor B) =
+    transferMap (directSumTensor B) at hRFP
   change mixedTransferMap₂ (B j) (B j') * mixedTransferMap₂ (B j) (B j') =
     mixedTransferMap₂ (B j) (B j')
-  refine LinearMap.ext fun Z => ?_
-  rw [Module.End.mul_apply]
-  obtain ⟨Y, hY⟩ := exists_toBlock_eq j j' Z
-  have e1 : mixedTransferMap₂ (B j) (B j') Z =
-      (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
-    rw [hStage1, hY]
-  calc
-    mixedTransferMap₂ (B j) (B j') (mixedTransferMap₂ (B j) (B j') Z)
-        = mixedTransferMap₂ (B j) (B j')
-            ((blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim)) := by rw [e1]
-    _ = (blockTransferSum B (blockTransferSum B Y)).submatrix
-          (blockIncl j dim) (blockIncl j' dim) := (hStage1 (blockTransferSum B Y)).symm
-    _ = (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
-          rw [blockTransferSum_blockTransferSum B hRFP]
-    _ = mixedTransferMap₂ (B j) (B j') Z := e1.symm
+  simpa only [one_smul] using
+    mixedTransferMap₂_comp_self_eq_smul_of_transferMap_comp_self_eq_smul B 1
+      (by simpa only [one_smul] using hRFP) j j'
 
 /-- If every mixed transfer operator of a block family is idempotent, then the
 block-diagonal transfer sum is idempotent.
@@ -477,10 +453,6 @@ theorem eq_one_of_transferMap_comp_self_eq_smul
     ext i a b
     simp [SectorDecomposition.toTensor, toTensorFromBlocks, directSumTensor, B]
   rw [hTensor] at h
-  have hB : ∀ X,
-      transferMap (directSumTensor B) (transferMap (directSumTensor B) X) =
-        c • transferMap (directSumTensor B) X :=
-    fun X ↦ LinearMap.congr_fun h X
   obtain ⟨j, q, hq⟩ := hCF.weight_unit_exists
   let s : Fin P.totalCopies := P.flatIndexEquiv ⟨j, q⟩
   haveI : NeZero (P.flatDim s) := by
@@ -488,7 +460,7 @@ theorem eq_one_of_transferMap_comp_self_eq_smul
     simpa [s] using (hCF.basis_dim_pos j).ne'
   have hcorner :=
     mixedTransferMap₂_comp_self_eq_smul_of_transferMap_comp_self_eq_smul
-      B c hB s s
+      B c h s s
   rw [mixedTransferMap₂_self] at hcorner
   have hs : P.flatIndexEquiv.symm s = ⟨j, q⟩ :=
     P.flatIndexEquiv.symm_apply_apply ⟨j, q⟩

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -7,6 +7,8 @@ import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Algebra.FinSum
 import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.MPS.Core.MultiBlock
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+import TNLean.MPS.SharedInfra.Scaling
 import TNLean.Spectral.TransferOperatorGapNT
 
 /-!
@@ -32,6 +34,8 @@ The diagonal `j = j'` case is `IsIsometryCanonicalForm`
 * `isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem`
   — exact reduction of whole-tensor transfer idempotence to every mixed block
   pair.
+* `IsBNTCanonicalForm.eq_one_of_transferMap_comp_self_eq_smul` — the BNT
+  unit-weight convention forces the scalar in transfer quasi-idempotence to be one.
 
 ## Route
 
@@ -444,6 +448,83 @@ theorem phases_eq_of_isTransferIdempotent_directSum_scaled_self
     _ = μ q' := one_mul (μ q')
 
 end BlockDecomposition
+
+/-! ## Unit-weight obstruction to nontrivial transfer scaling -/
+
+namespace IsBNTCanonicalForm
+
+/-- The unit-weight convention in a normalized BNT presentation forces any
+transfer quasi-idempotence scalar to equal one.
+
+Choose the unit-modulus copy supplied by the BNT normalization. Restrict the
+whole direct-sum transfer equation to that diagonal corner. Unit modulus removes
+the copy weight, so the representative transfer map satisfies
+$\mathcal E^2=c\mathcal E$. Left canonicity makes $\mathcal E$ trace preserving;
+taking the trace at the identity therefore gives $D=cD$, and the positive bond
+dimension gives $c=1$.
+
+Source: arXiv:1606.00608, line 246 (unit-weight normalization) and lines
+543--555 (restriction of the transfer equation to a canonical-form block). -/
+theorem eq_one_of_transferMap_comp_self_eq_smul
+    (P : SectorDecomposition d) (hCF : IsBNTCanonicalForm P) (c : ℂ)
+    (h : transferMap P.toTensor ∘ₗ transferMap P.toTensor =
+      c • transferMap P.toTensor) :
+    c = 1 := by
+  classical
+  let B : (s : Fin P.totalCopies) → MPSTensor d (P.flatDim s) :=
+    fun s i ↦ P.flatWeight s • P.flatBasis s i
+  have hTensor : P.toTensor = directSumTensor B := by
+    ext i a b
+    simp [SectorDecomposition.toTensor, toTensorFromBlocks, directSumTensor, B]
+  rw [hTensor] at h
+  have hB : ∀ X,
+      transferMap (directSumTensor B) (transferMap (directSumTensor B) X) =
+        c • transferMap (directSumTensor B) X :=
+    fun X ↦ LinearMap.congr_fun h X
+  obtain ⟨j, q, hq⟩ := hCF.weight_unit_exists
+  let s : Fin P.totalCopies := P.flatIndexEquiv ⟨j, q⟩
+  haveI : NeZero (P.flatDim s) := by
+    refine ⟨?_⟩
+    simpa [s] using (hCF.basis_dim_pos j).ne'
+  have hcorner :=
+    mixedTransferMap₂_comp_self_eq_smul_of_transferMap_comp_self_eq_smul
+      B c hB s s
+  rw [mixedTransferMap₂_self] at hcorner
+  have hs : P.flatIndexEquiv.symm s = ⟨j, q⟩ :=
+    P.flatIndexEquiv.symm_apply_apply ⟨j, q⟩
+  have hnorm : ‖P.flatWeight s‖ = 1 := by
+    change ‖P.weight (P.flatIndexEquiv.symm s).1
+      (P.flatIndexEquiv.symm s).2‖ = 1
+    rw [hs]
+    exact hq
+  have hscaled : transferMap (B s) = transferMap (P.flatBasis s) := by
+    apply LinearMap.ext
+    intro X
+    rw [show B s = (fun i ↦ P.flatWeight s • P.flatBasis s i) from rfl,
+      transferMap_smul]
+    have hphase : P.flatWeight s * starRingEnd ℂ (P.flatWeight s) = 1 := by
+      simpa [Complex.normSq_eq_norm_sq, hnorm] using
+        Complex.mul_conj (P.flatWeight s)
+    rw [hphase, one_smul]
+  rw [hscaled] at hcorner
+  have happ := LinearMap.congr_fun hcorner
+    (1 : Matrix (Fin (P.flatDim s)) (Fin (P.flatDim s)) ℂ)
+  have htr := congrArg Matrix.trace happ
+  have hleft : IsLeftCanonical (P.flatBasis s) := by
+    change IsLeftCanonical (P.basis (P.flatIndexEquiv.symm s).1)
+    rw [hs]
+    exact hCF.basis_left_canonical j
+  rw [Module.End.mul_apply, LinearMap.smul_apply,
+    trace_transferMap (P.flatBasis s) _ hleft, Matrix.trace_smul,
+    trace_transferMap (P.flatBasis s) _ hleft] at htr
+  have ht : Matrix.trace
+      (1 : Matrix (Fin (P.flatDim s)) (Fin (P.flatDim s)) ℂ) ≠ 0 := by
+    simpa [Matrix.trace_one] using
+      (Nat.cast_ne_zero.mpr (NeZero.ne (P.flatDim s)) : ((P.flatDim s : ℂ) ≠ 0))
+  apply mul_right_cancel₀ ht
+  simpa using htr.symm
+
+end IsBNTCanonicalForm
 
 /-! ## Spectral gap forces the off-diagonal operator to vanish -/
 

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -182,6 +182,29 @@ theorem transferMap_directSumTensor_reindex
   rw [Matrix.conjTranspose_submatrix, Matrix.submatrix_mul_equiv _ _ _ e.symm _,
     Matrix.submatrix_mul_equiv _ _ _ e.symm _]
 
+/-- A scalar quasi-idempotence relation for the full direct-sum transfer map restricts to
+the same relation for the block-diagonal transfer sum. -/
+theorem blockTransferSum_blockTransferSum_eq_smul
+    (B : (k : Fin r) → MPSTensor d (dim k)) (c : ℂ)
+    (h : ∀ X, transferMap (directSumTensor B)
+      (transferMap (directSumTensor B) X) = c • transferMap (directSumTensor B) X)
+    (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
+    blockTransferSum B (blockTransferSum B Y) = c • blockTransferSum B Y := by
+  classical
+  set e := finSigmaFinEquiv (m := r) (n := dim) with he
+  apply (Matrix.reindex e e).injective
+  calc
+    Matrix.reindex e e (blockTransferSum B (blockTransferSum B Y))
+        = transferMap (directSumTensor B) (Matrix.reindex e e (blockTransferSum B Y)) :=
+          (transferMap_directSumTensor_reindex B (blockTransferSum B Y)).symm
+    _ = transferMap (directSumTensor B)
+          (transferMap (directSumTensor B) (Matrix.reindex e e Y)) := by
+            rw [transferMap_directSumTensor_reindex B Y]
+    _ = c • transferMap (directSumTensor B) (Matrix.reindex e e Y) := h _
+    _ = Matrix.reindex e e (c • blockTransferSum B Y) := by
+          rw [transferMap_directSumTensor_reindex B Y]
+          rfl
+
 /-- Whole-tensor RFP of the direct sum makes
 the block-diagonal transfer sum idempotent. -/
 theorem blockTransferSum_blockTransferSum
@@ -223,6 +246,38 @@ private lemma exists_toBlock_eq (j j' : Fin r) [NeZero (dim j)] [NeZero (dim j')
   have hj' : Function.invFun (blockIncl j' dim) ∘ blockIncl j' dim = id :=
     funext (Function.leftInverse_invFun hinj_j')
   rw [Matrix.submatrix_submatrix, hj, hj', Matrix.submatrix_id_id]
+
+/-- Scalar quasi-idempotence of the full direct-sum transfer map restricts to every ordered
+block pair. In particular, the diagonal corner is the transfer map of that block. -/
+theorem mixedTransferMap₂_comp_self_eq_smul_of_transferMap_comp_self_eq_smul
+    (B : (k : Fin r) → MPSTensor d (dim k)) (c : ℂ)
+    (h : ∀ X, transferMap (directSumTensor B)
+      (transferMap (directSumTensor B) X) = c • transferMap (directSumTensor B) X)
+    (j j' : Fin r) [NeZero (dim j)] [NeZero (dim j')] :
+    mixedTransferMap₂ (B j) (B j') * mixedTransferMap₂ (B j) (B j') =
+      c • mixedTransferMap₂ (B j) (B j') := by
+  classical
+  have hStage1 : ∀ Y, (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) =
+      mixedTransferMap₂ (B j) (B j') (Y.submatrix (blockIncl j dim) (blockIncl j' dim)) := by
+    intro Y
+    simpa only [blockTransferSum] using blockDiagonal'_transferSum_toBlock B Y j j'
+  apply LinearMap.ext
+  intro Z
+  rw [Module.End.mul_apply, LinearMap.smul_apply]
+  obtain ⟨Y, hY⟩ := exists_toBlock_eq j j' Z
+  have e1 : mixedTransferMap₂ (B j) (B j') Z =
+      (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
+    rw [hStage1, hY]
+  calc
+    mixedTransferMap₂ (B j) (B j') (mixedTransferMap₂ (B j) (B j') Z)
+        = mixedTransferMap₂ (B j) (B j')
+            ((blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim)) := by rw [e1]
+    _ = (blockTransferSum B (blockTransferSum B Y)).submatrix
+          (blockIncl j dim) (blockIncl j' dim) := (hStage1 (blockTransferSum B Y)).symm
+    _ = (c • blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
+          rw [blockTransferSum_blockTransferSum_eq_smul B c h]
+    _ = c • (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := rfl
+    _ = c • mixedTransferMap₂ (B j) (B j') Z := congrArg (c • ·) e1.symm
 
 /-- Whole-tensor RFP of the direct sum
 makes every (in particular off-diagonal) mixed transfer operator idempotent. -/

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
@@ -51,6 +51,28 @@ through its own period agrees with the directly $p$-blocked block.
     blocked transfer map primitive.
 \end{proof}
 
+\begin{theorem}[Quasi-idempotence under physical blocking]%
+    \label{thm:transfer_map_block_tensor_quasi_idempotent}
+    \lean{MPSTensor.transferMap_blockTensor_quasi_idempotent}
+    \leanok
+    \uses{def:blocked_tensor, def:transfer_map}
+    Let $A$ be an MPS tensor and let $c\in\C$. If
+    \begin{align}
+        \E_A^2&=c\E_A,
+        \notag
+    \end{align}
+    then, for every integer $L\geq0$,
+    \begin{align}
+        \E_{A^{[L]}}^2&=c^L\E_{A^{[L]}}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    The transfer map of $A^{[L]}$ is $\E_A^L$. Induction on $L$ using
+    $\E_A^2=c\E_A$ gives the stated identity.
+\end{proof}
+
 \begin{lemma}[Adjoint primitivity equivalence]%
     \label{thm:primitive_adjoint_equiv}
     \lean{MPSTensor.IsPrimitive.adjoint_iff}\leanok

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
@@ -69,8 +69,16 @@ through its own period agrees with the directly $p$-blocked block.
 \end{theorem}
 
 \begin{proof}\leanok
-    The transfer map of $A^{[L]}$ is $\E_A^L$. Induction on $L$ using
-    $\E_A^2=c\E_A$ gives the stated identity.
+    \uses{lem:blocked_irreducibility_direct_support}
+    The transfer map of $A^{[L]}$ is $\E_A^L$. Therefore
+    \begin{align}
+        (\E_A^L)^2
+        &=(\E_A^2)^L
+         =(c\E_A)^L
+         =c^L\E_A^L,
+        \notag
+    \end{align}
+    which is the required identity.
 \end{proof}
 
 \begin{lemma}[Adjoint primitivity equivalence]%

--- a/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
+++ b/blueprint/src/chapter/ch04_channels_transfer_map_foundations.tex
@@ -195,6 +195,47 @@
     with the corresponding transfer maps gives the stated identity.
 \end{proof}
 
+\begin{lemma}[Transfer map under scalar multiplication]
+    \label{lem:transfer_map_smul}
+    \lean{MPSTensor.transferMap_smul}
+    \leanok
+    \uses{def:transfer_map}
+    Let $A$ be an MPS tensor and let $w\in\C$. Then, for every bond matrix $X$,
+    \begin{align}
+        \E_{wA}(X)&=w\overline w\,\E_A(X).
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand the transfer map and pull the scalar $w$ and its conjugate out of
+    each summand.
+\end{proof}
+
+\begin{lemma}[Left-canonical transfer maps preserve trace]
+    \label{lem:trace_transfer_map_left_canonical}
+    \lean{MPSTensor.trace_transferMap}
+    \leanok
+    \uses{def:transfer_map, def:left_canonical_tensor}
+    If $A$ is left canonical, then, for every bond matrix $X$,
+    \begin{align}
+        \tr(\E_A(X))&=\tr(X).
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:trace_mul_transfer_map_adjoint}
+    Cyclicity of trace gives
+    \begin{align}
+        \tr(\E_A(X))
+        &=\tr\!\left(\left(\sum_i(A^i)^\dagger A^i\right)X\right)
+         =\tr(X),
+        \notag
+    \end{align}
+    since left canonicity makes the sum in parentheses equal to the identity.
+\end{proof}
+
 \begin{theorem}[Transfer map is a channel]\label{thm:transfer_channel}
     \lean{MPSTensor.transferMap_isChannel}
     \leanok

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -573,6 +573,27 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     Expand both transfer maps and take $C=X^{-1}$.
 \end{proof}
 
+\begin{theorem}[Gauge invariance of transfer quasi-idempotence]
+    \label{thm:cpsv_gauge_transfer_quasi_idempotence}
+    \lean{MPSTensor.GaugeEquiv.transferMap_comp_self_eq_smul_iff}
+    \leanok
+    \uses{def:gauge_equiv, def:transfer_map}
+    Let $A$ and $B$ be gauge-equivalent MPS tensors and let $c\in\C$. Then
+    \begin{align}
+        \E_B^2=c\E_B
+        \quad\Longleftrightarrow\quad
+        \E_A^2=c\E_A.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_gauge_transfer_similarity}
+    Theorem~\ref{thm:cpsv_gauge_transfer_similarity} identifies the two transfer
+    maps by an algebra automorphism. Such an automorphism preserves composition
+    and scalar multiplication, and therefore preserves the displayed equation.
+\end{proof}
+
 \begin{theorem}[Spectral radius under congruence similarity]
     \label{thm:cpsv_spectral_radius_similarity}
     \lean{spectralRadius_similarityMap_eq}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -733,6 +733,36 @@
     $\lambda(1-\lambda)^2=0$. This fails at $\lambda=\frac{7}{25}$.
 \end{proof}
 
+\begin{lemma}[Doubled-index letters and their rank-one factorization]
+    \label{lem:mpdo_bnt_label_rescaling_stable_doubled_letter_factorization}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.toMPSTensor_R_apply}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.R_eq_vecMulVec}
+    \leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    Identify each physical index $p\in\{0,1,2,3\}$ with a pair
+    $(p_1,p_2)\in\{0,1\}^2$, and similarly write $q=(q_1,q_2)$. The
+    doubled-index letter at the paired index $(p,q)$ is the MPO letter $R^{pq}$.
+    Moreover, this bond matrix is the rank-one outer product
+    \begin{align}
+        R^{pq}_{ab}
+        &=\frac{25}{32}A^a_{p_1q_1}A^b_{p_2q_2},
+        \notag
+    \end{align}
+    or equivalently
+    \begin{align}
+        R^{pq}&=\frac{25}{32}u_{pq}v_{pq}^{\mathsf T}, &
+        u_{pq}(a)&=A^a_{p_1q_1}, &
+        v_{pq}(b)&=A^b_{p_2q_2}.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    The first identity is the definition of the doubled-index reading. Expanding
+    the Kronecker-product definition of $R$ and using that the entries of the
+    four letters $A^a$ are real gives the displayed outer product.
+\end{proof}
+
 \begin{lemma}[Rank-one form of the dimer transfer map]
     \label{lem:mpdo_bnt_label_rescaling_stable_transfer_rank_one}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
@@ -758,9 +788,14 @@
 \end{lemma}
 
 \begin{proof}\leanok
-    Expand the sixteen matrix-unit letters of $R$. Every term is proportional
-    to $F$, and collecting their diagonal coefficients gives $\lambda(X)$.
-    Substituting $X=F$ and evaluating the four entries gives $337/512$.
+    \uses{lem:mpdo_bnt_label_rescaling_stable_doubled_letter_factorization}
+    By
+    Lemma~\ref{lem:mpdo_bnt_label_rescaling_stable_doubled_letter_factorization},
+    the doubled-index letters are the matrices $R^{pq}$, each with the displayed
+    outer-product factorization. Substituting these rank-one factors into the
+    transfer-map sum makes every term proportional to $F$, and collecting the
+    diagonal coefficients gives $\lambda(X)$. Substituting $X=F$ and evaluating
+    the four entries gives $337/512$.
 \end{proof}
 
 \begin{lemma}[One-site transfer quasi-idempotence of the dimer tensor]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -765,15 +765,15 @@
         thm:mpdo_bnt_label_rescaling_stable_length_dependence}
     Let $R$ be the dimer tensor of
     Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_length_dependence}. For
-    every positive integer $L$, the transfer map of its $L$-site blocking
-    satisfies
+    every integer $L\geq0$, the transfer map of its $L$-site blocking satisfies
     \begin{align}
         \mathcal E_{R^{[L]}}^2
         &=\left(\frac{337}{512}\right)^L\mathcal E_{R^{[L]}}.
         \notag
     \end{align}
-    No positive blocking of $R$ admits a normalized horizontal canonical form.
-    Consequently $R$ is not simple in the fixed-representative sense of
+    For every positive integer $L$, the blocking $R^{[L]}$ admits no normalized
+    horizontal canonical form. Consequently $R$ is not simple in the
+    fixed-representative sense of
     Definition~\ref{def:mpdo_simple_tensor}.
 
     % Maintainer scope: the conclusion quantifies over every normalized BNT
@@ -791,14 +791,15 @@
     Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent},
     the one-site transfer map satisfies
     $\E_R^2=\frac{337}{512}\E_R$. Applying
-    Theorem~\ref{thm:transfer_map_block_tensor_quasi_idempotent} gives
+    Theorem~\ref{thm:transfer_map_block_tensor_quasi_idempotent} gives, for every
+    integer $L\geq0$,
     \begin{align}
         \E_{R^{[L]}}^2
         &=\left(\frac{337}{512}\right)^L\E_{R^{[L]}}.
         \notag
     \end{align}
-    Suppose that the $L$-site blocking has a normalized horizontal canonical
-    form, where $L>0$. By
+    Now fix $L>0$ and suppose that the $L$-site blocking has a normalized
+    horizontal canonical form. By
     Theorem~\ref{thm:mpdo_horizontal_cf_quasi_idempotent_scalar}, its
     quasi-idempotence scalar must be one. On the other hand,
     \begin{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -733,8 +733,8 @@
     $\lambda(1-\lambda)^2=0$. This fails at $\lambda=\frac{7}{25}$.
 \end{proof}
 
-\begin{theorem}[One-site transfer quasi-idempotence of the dimer tensor]
-    \label{thm:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent}
+\begin{lemma}[One-site transfer quasi-idempotence of the dimer tensor]
+    \label{lem:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
         transferMap_R_toMPSTensor_idem}
     \leanok
@@ -744,7 +744,7 @@
         \E_R^2&=\frac{337}{512}\E_R.
         \notag
     \end{align}
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
     The image of $\E_R$ is spanned by a fixed diagonal matrix. Applying the
@@ -783,12 +783,12 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent,
+    \uses{lem:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent,
         thm:transfer_map_block_tensor_quasi_idempotent,
         thm:mpdo_horizontal_cf_quasi_idempotent_scalar,
         lem:mpdo_simple_tensor_horizontal_cf}
     By
-    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent},
+    Lemma~\ref{lem:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent},
     the one-site transfer map satisfies
     $\E_R^2=\frac{337}{512}\E_R$. Applying
     Theorem~\ref{thm:transfer_map_block_tensor_quasi_idempotent} gives, for every

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -733,6 +733,36 @@
     $\lambda(1-\lambda)^2=0$. This fails at $\lambda=\frac{7}{25}$.
 \end{proof}
 
+\begin{lemma}[Rank-one form of the dimer transfer map]
+    \label{lem:mpdo_bnt_label_rescaling_stable_transfer_rank_one}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        transferMap_R_toMPSTensor_eq}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.cFun_fixedDiag}
+    \leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    Set
+    \begin{align}
+        s&=\left(\frac45,\frac45,\frac35,\frac35\right), &
+        F&=\diag(s_0^2,s_1^2,s_2^2,s_3^2),
+        \notag\\
+        \lambda(X)&=\left(\frac{25}{32}\right)^2
+            \sum_{b=0}^3s_b^2X_{bb}.
+        \notag
+    \end{align}
+    Then the transfer map of $R$ has rank-one form
+    \begin{align}
+        \E_R(X)&=\lambda(X)F,
+        &\lambda(F)&=\frac{337}{512}.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand the sixteen matrix-unit letters of $R$. Every term is proportional
+    to $F$, and collecting their diagonal coefficients gives $\lambda(X)$.
+    Substituting $X=F$ and evaluating the four entries gives $337/512$.
+\end{proof}
+
 \begin{lemma}[One-site transfer quasi-idempotence of the dimer tensor]
     \label{lem:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
@@ -747,10 +777,14 @@
 \end{lemma}
 
 \begin{proof}\leanok
-    The image of $\E_R$ is spanned by a fixed diagonal matrix. Applying the
-    scalar functional defining this rank-one map to that matrix gives
-    $337/512$, so a second application of $\E_R$ multiplies the first by this
-    scalar.
+    \uses{lem:mpdo_bnt_label_rescaling_stable_transfer_rank_one}
+    By Lemma~\ref{lem:mpdo_bnt_label_rescaling_stable_transfer_rank_one},
+    \begin{align}
+        \E_R(\E_R(X))
+        &=\lambda(X)\lambda(F)F
+         =\frac{337}{512}\E_R(X).
+        \notag
+    \end{align}
 \end{proof}
 
 \begin{theorem}[The rescaling-stable dimer tensor is not simple]
@@ -784,13 +818,18 @@
 
 \begin{proof}\leanok
     \uses{lem:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent,
+        thm:mpdo_blocking_doubled_index, thm:cpsv_physical_reindexing,
         thm:transfer_map_block_tensor_quasi_idempotent,
         thm:mpdo_horizontal_cf_quasi_idempotent_scalar,
         lem:mpdo_simple_tensor_horizontal_cf}
     By
     Lemma~\ref{lem:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent},
     the one-site transfer map satisfies
-    $\E_R^2=\frac{337}{512}\E_R$. Applying
+    $\E_R^2=\frac{337}{512}\E_R$.
+    Theorems~\ref{thm:mpdo_blocking_doubled_index} and
+    \ref{thm:cpsv_physical_reindexing} identify the doubled-index MPS tensor of
+    the MPO blocking $R^{[L]}$ with the physical relabeling of the $L$-site MPS
+    blocking, without changing its transfer map. After this transport,
     Theorem~\ref{thm:transfer_map_block_tensor_quasi_idempotent} gives, for every
     integer $L\geq0$,
     \begin{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -764,7 +764,7 @@
 
 \begin{proof}\leanok
     \uses{thm:transfer_map_block_tensor_quasi_idempotent,
-        lem:mpdo_horizontal_cf_quasi_idempotent_scalar,
+        thm:mpdo_horizontal_cf_quasi_idempotent_scalar,
         lem:mpdo_simple_tensor_horizontal_cf}
     The one-site transfer map satisfies
     $\E_R^2=\frac{337}{512}\E_R$. Applying
@@ -776,7 +776,7 @@
     \end{align}
     Suppose that the $L$-site blocking has a normalized horizontal canonical
     form, where $L>0$. By
-    Lemma~\ref{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}, its
+    Theorem~\ref{thm:mpdo_horizontal_cf_quasi_idempotent_scalar}, its
     quasi-idempotence scalar must be one. On the other hand,
     \begin{align}
         0<\left(\frac{337}{512}\right)^L<1,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -763,8 +763,17 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:mpdo_horizontal_cf_quasi_idempotent_scalar,
+    \uses{thm:transfer_map_block_tensor_quasi_idempotent,
+        lem:mpdo_horizontal_cf_quasi_idempotent_scalar,
         lem:mpdo_simple_tensor_horizontal_cf}
+    The one-site transfer map satisfies
+    $\E_R^2=\frac{337}{512}\E_R$. Applying
+    Theorem~\ref{thm:transfer_map_block_tensor_quasi_idempotent} gives
+    \begin{align}
+        \E_{R^{[L]}}^2
+        &=\left(\frac{337}{512}\right)^L\E_{R^{[L]}}.
+        \notag
+    \end{align}
     Suppose that the $L$-site blocking has a normalized horizontal canonical
     form, where $L>0$. By
     Lemma~\ref{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}, its

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -733,6 +733,26 @@
     $\lambda(1-\lambda)^2=0$. This fails at $\lambda=\frac{7}{25}$.
 \end{proof}
 
+\begin{theorem}[One-site transfer quasi-idempotence of the dimer tensor]
+    \label{thm:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        transferMap_R_toMPSTensor_idem}
+    \leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    The transfer map of the dimer tensor $R$ satisfies
+    \begin{align}
+        \E_R^2&=\frac{337}{512}\E_R.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    The image of $\E_R$ is spanned by a fixed diagonal matrix. Applying the
+    scalar functional defining this rank-one map to that matrix gives
+    $337/512$, so a second application of $\E_R$ multiplies the first by this
+    scalar.
+\end{proof}
+
 \begin{theorem}[The rescaling-stable dimer tensor is not simple]
     \label{thm:mpdo_bnt_label_rescaling_stable_not_simple}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
@@ -763,10 +783,13 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:transfer_map_block_tensor_quasi_idempotent,
+    \uses{thm:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent,
+        thm:transfer_map_block_tensor_quasi_idempotent,
         thm:mpdo_horizontal_cf_quasi_idempotent_scalar,
         lem:mpdo_simple_tensor_horizontal_cf}
-    The one-site transfer map satisfies
+    By
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_transfer_quasi_idempotent},
+    the one-site transfer map satisfies
     $\E_R^2=\frac{337}{512}\E_R$. Applying
     Theorem~\ref{thm:transfer_map_block_tensor_quasi_idempotent} gives
     \begin{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -733,6 +733,51 @@
     $\lambda(1-\lambda)^2=0$. This fails at $\lambda=\frac{7}{25}$.
 \end{proof}
 
+\begin{theorem}[The rescaling-stable dimer tensor is not simple]
+    \label{thm:mpdo_bnt_label_rescaling_stable_not_simple}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        transferMap_blockTensor_R_toMPSTensor_quasi_idempotent}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        blockTensor_R_not_isHorizontalCF}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.R_not_isSimple}
+    \leanok
+    \uses{def:mpdo_simple_tensor, def:horizontal_cf_mpdo,
+        thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    Let $R$ be the dimer tensor of
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_length_dependence}. For
+    every positive integer $L$, the transfer map of its $L$-site blocking
+    satisfies
+    \begin{align}
+        \mathcal E_{R^{[L]}}^2
+        &=\left(\frac{337}{512}\right)^L\mathcal E_{R^{[L]}}.
+        \notag
+    \end{align}
+    No positive blocking of $R$ admits a normalized horizontal canonical form.
+    Consequently $R$ is not simple in the fixed-representative sense of
+    Definition~\ref{def:mpdo_simple_tensor}.
+
+    % Maintainer scope: the conclusion quantifies over every normalized BNT
+    % witness admitted by the fixed-representative simplicity definition. It
+    % does not assert that a BNT element is nilpotent, use the vertical
+    % coefficient family, or concern a scale-invariant notion of simplicity.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_horizontal_cf_quasi_idempotent_scalar,
+        lem:mpdo_simple_tensor_horizontal_cf}
+    Suppose that the $L$-site blocking has a normalized horizontal canonical
+    form, where $L>0$. By
+    Lemma~\ref{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}, its
+    quasi-idempotence scalar must be one. On the other hand,
+    \begin{align}
+        0<\left(\frac{337}{512}\right)^L<1,
+        \notag
+    \end{align}
+    a contradiction. Simplicity would provide such a normalized horizontal
+    canonical form after some positive blocking by
+    \cite[lines~815--822]{Cirac2016MPDO_arXiv}; hence $R$ is not simple.
+\end{proof}
+
 \begin{theorem}[Positivity of the rescaling-stable coefficient family]%
     \label{thm:mpdo_bnt_label_rescaling_stable_ismpdo}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.mpo_R_entry_formula}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -141,20 +141,29 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:mixed_transfer_quasi_idempotent_of_direct_sum}
+    \uses{thm:mixed_transfer_quasi_idempotent_of_direct_sum,
+        lem:transfer_map_smul, lem:trace_transfer_map_left_canonical}
     By the normalization at \cite[line~246]{Cirac2016MPDO_arXiv}, some copy has
     weight $\mu$ with $|\mu|=1$.
     Theorem~\ref{thm:mixed_transfer_quasi_idempotent_of_direct_sum} restricts the
     transfer equation of the assembled tensor to this copy's diagonal corner.
-    There
+    By Lemma~\ref{lem:transfer_map_smul},
     \begin{align}
         \E_{\mu A}&=\mu\overline\mu\,\E_A=\E_A.
         \notag
     \end{align}
     Hence the restricted equation is $\E_A^2=c\E_A$. The normal representative
-    is left canonical, so its transfer map is trace preserving. Apply the
-    equation to the identity and take the trace. This gives $D=cD$. Since the
-    bond dimension $D$ is positive, $c=1$.
+    is left canonical, so Lemma~\ref{lem:trace_transfer_map_left_canonical}
+    gives trace preservation. Applying the equation to the identity and taking
+    the trace gives
+    \begin{align}
+        D
+        &=\tr(\E_A(\E_A(\Id)))
+         =c\tr(\E_A(\Id))
+         =cD.
+        \notag
+    \end{align}
+    Since $D>0$, it follows that $c=1$.
 \end{proof}
 
 \begin{theorem}[Unit-weight obstruction in horizontal canonical form]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -158,7 +158,7 @@
 \end{proof}
 
 \begin{theorem}[Unit-weight obstruction in horizontal canonical form]
-    \label{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}
+    \label{thm:mpdo_horizontal_cf_quasi_idempotent_scalar}
     \lean{MPOTensor.IsHorizontalCF.%
         eq_one_of_transferMap_comp_self_eq_smul}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -125,10 +125,37 @@
     non-nilpotency are not needed for this conclusion.
 \end{proof}
 
-\begin{lemma}[Unit-weight obstruction to nontrivial quasi-idempotence]
-    \label{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}
+\begin{theorem}[Unit-weight obstruction for a BNT sector decomposition]
+    \label{thm:bnt_unit_weight_quasi_idempotent_scalar}
     \lean{MPSTensor.IsBNTCanonicalForm.%
         eq_one_of_transferMap_comp_self_eq_smul}
+    \leanok
+    \uses{def:sector_bnt_cf}
+    Let $P$ be a sector decomposition in normalized BNT canonical form, and let
+    $T_P$ be its assembled block-diagonal tensor. If
+    \begin{align}
+        \mathcal E_{T_P}^2&=c\mathcal E_{T_P},
+        \notag
+    \end{align}
+    then $c=1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    By the normalization at \cite[line~246]{Cirac2016MPDO_arXiv}, some copy has
+    weight $\mu$ with $|\mu|=1$. Restrict the transfer equation of the assembled
+    tensor to this copy's diagonal corner. There
+    \begin{align}
+        \E_{\mu A}&=\mu\overline\mu\,\E_A=\E_A.
+        \notag
+    \end{align}
+    Hence the restricted equation is $\E_A^2=c\E_A$. The normal representative
+    is left canonical, so its transfer map is trace preserving. Apply the
+    equation to the identity and take the trace. This gives $D=cD$. Since the
+    bond dimension $D$ is positive, $c=1$.
+\end{proof}
+
+\begin{theorem}[Unit-weight obstruction in horizontal canonical form]
+    \label{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}
     \lean{MPOTensor.IsHorizontalCF.%
         eq_one_of_transferMap_comp_self_eq_smul}
     \leanok
@@ -140,19 +167,14 @@
         \notag
     \end{align}
     then $c=1$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
-    Transport the transfer equation through the block-diagonal gauge to the
-    normalized BNT witness. By the normalization at
-    \cite[line~246]{Cirac2016MPDO_arXiv}, some copy has weight $\mu$ with
-    $|\mu|=1$. On its diagonal corner,
-    \begin{align}
-        \E_{\mu A}&=\mu\overline\mu\,\E_A=\E_A.
-        \notag
-    \end{align}
-    Hence the restricted equation is $\E_A^2=c\E_A$. The normal representative
-    is left canonical, so its transfer map is trace preserving. Apply the
-    equation to the identity and take the trace. This gives $D=cD$. Since the
-    bond dimension $D$ is positive, $c=1$.
+    \uses{thm:bnt_unit_weight_quasi_idempotent_scalar,
+        thm:cpsv_gauge_transfer_quasi_idempotence}
+    The horizontal canonical-form witness gives a normalized BNT sector
+    decomposition whose assembled tensor is gauge equivalent to $M$. Transport
+    the transfer equation across this gauge by
+    Theorem~\ref{thm:cpsv_gauge_transfer_quasi_idempotence}, then apply
+    Theorem~\ref{thm:bnt_unit_weight_quasi_idempotent_scalar}.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -141,9 +141,12 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mixed_transfer_quasi_idempotent_of_direct_sum}
     By the normalization at \cite[line~246]{Cirac2016MPDO_arXiv}, some copy has
-    weight $\mu$ with $|\mu|=1$. Restrict the transfer equation of the assembled
-    tensor to this copy's diagonal corner. There
+    weight $\mu$ with $|\mu|=1$.
+    Theorem~\ref{thm:mixed_transfer_quasi_idempotent_of_direct_sum} restricts the
+    transfer equation of the assembled tensor to this copy's diagonal corner.
+    There
     \begin{align}
         \E_{\mu A}&=\mu\overline\mu\,\E_A=\E_A.
         \notag

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -143,57 +143,16 @@
 \end{lemma}
 
 \begin{proof}\leanok
-    By the normalization at \cite[line~246]{Cirac2016MPDO_arXiv}, some copy
-    has unit-modulus weight. Restrict the transfer equation to its diagonal
-    corner. The weight then disappears. The normal representative is left
-    canonical, so its transfer map is trace preserving. Apply the restricted
+    Transport the transfer equation through the block-diagonal gauge to the
+    normalized BNT witness. By the normalization at
+    \cite[line~246]{Cirac2016MPDO_arXiv}, some copy has weight $\mu$ with
+    $|\mu|=1$. On its diagonal corner,
+    \begin{align}
+        \E_{\mu A}&=\mu\overline\mu\,\E_A=\E_A.
+        \notag
+    \end{align}
+    Hence the restricted equation is $\E_A^2=c\E_A$. The normal representative
+    is left canonical, so its transfer map is trace preserving. Apply the
     equation to the identity and take the trace. This gives $D=cD$. Since the
     bond dimension $D$ is positive, $c=1$.
-\end{proof}
-
-\begin{theorem}[The rescaling-stable dimer tensor is not simple]
-    \label{thm:mpdo_bnt_label_rescaling_stable_not_simple}
-    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
-        transferMap_blockTensor_R_toMPSTensor_quasi_idempotent}
-    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
-        blockTensor_R_not_isHorizontalCF}
-    \lean{MPOTensor.RescalingStableLengthDependentRFP.R_not_isSimple}
-    \leanok
-    \uses{def:mpdo_simple_tensor,
-        lem:mpdo_simple_tensor_horizontal_cf,
-        lem:mpdo_horizontal_cf_quasi_idempotent_scalar,
-        thm:mpdo_bnt_label_rescaling_stable_length_dependence}
-    Let $R$ be the dimer tensor of
-    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_length_dependence}. For
-    every positive integer $L$, the transfer map of its $L$-site blocking
-    satisfies
-    \begin{align}
-        \mathcal E_{R^{[L]}}^2
-        &=\left(\frac{337}{512}\right)^L\mathcal E_{R^{[L]}}.
-        \notag
-    \end{align}
-    No positive blocking of $R$ admits a normalized horizontal canonical form.
-    Consequently $R$ is not simple in the fixed-representative sense of
-    Definition~\ref{def:mpdo_simple_tensor}.
-
-    This conclusion quantifies over every normalized BNT witness permitted by
-    the formal predicate. It does not assert that a BNT element is nilpotent,
-    does not use the vertical coefficient family, and does not concern a
-    scale-invariant notion of simplicity.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{lem:mpdo_horizontal_cf_quasi_idempotent_scalar,
-        lem:mpdo_simple_tensor_horizontal_cf}
-    Suppose that the $L$-site blocking has a normalized horizontal canonical
-    form, where $L>0$. By
-    Lemma~\ref{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}, its
-    quasi-idempotence scalar must be one. On the other hand,
-    \begin{align}
-        0<\left(\frac{337}{512}\right)^L<1,
-        \notag
-    \end{align}
-    a contradiction. Simplicity would provide such a normalized horizontal
-    canonical form after some positive blocking by
-    \cite[lines~815--822]{Cirac2016MPDO_arXiv}; hence $R$ is not simple.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -124,3 +124,76 @@
     block-diagonal gauge---give a horizontal canonical form. Positivity and
     non-nilpotency are not needed for this conclusion.
 \end{proof}
+
+\begin{lemma}[Unit-weight obstruction to nontrivial quasi-idempotence]
+    \label{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}
+    \lean{MPSTensor.IsBNTCanonicalForm.%
+        eq_one_of_transferMap_comp_self_eq_smul}
+    \lean{MPOTensor.IsHorizontalCF.%
+        eq_one_of_transferMap_comp_self_eq_smul}
+    \leanok
+    \uses{def:horizontal_cf_mpdo}
+    Let $M$ be a doubled-index tensor in normalized horizontal canonical form.
+    If its transfer map satisfies
+    \begin{align}
+        \mathcal E_M^2&=c\mathcal E_M,
+        \notag
+    \end{align}
+    then $c=1$.
+\end{lemma}
+
+\begin{proof}\leanok
+    By the normalization at \cite[line~246]{Cirac2016MPDO_arXiv}, some copy
+    has unit-modulus weight. Restrict the transfer equation to its diagonal
+    corner. The weight then disappears. The normal representative is left
+    canonical, so its transfer map is trace preserving. Apply the restricted
+    equation to the identity and take the trace. This gives $D=cD$. Since the
+    bond dimension $D$ is positive, $c=1$.
+\end{proof}
+
+\begin{theorem}[The rescaling-stable dimer tensor is not simple]
+    \label{thm:mpdo_bnt_label_rescaling_stable_not_simple}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        transferMap_blockTensor_R_toMPSTensor_quasi_idempotent}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        blockTensor_R_not_isHorizontalCF}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.R_not_isSimple}
+    \leanok
+    \uses{def:mpdo_simple_tensor,
+        lem:mpdo_simple_tensor_horizontal_cf,
+        lem:mpdo_horizontal_cf_quasi_idempotent_scalar,
+        thm:mpdo_bnt_label_rescaling_stable_length_dependence}
+    Let $R$ be the dimer tensor of
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_length_dependence}. For
+    every positive integer $L$, the transfer map of its $L$-site blocking
+    satisfies
+    \begin{align}
+        \mathcal E_{R^{[L]}}^2
+        &=\left(\frac{337}{512}\right)^L\mathcal E_{R^{[L]}}.
+        \notag
+    \end{align}
+    No positive blocking of $R$ admits a normalized horizontal canonical form.
+    Consequently $R$ is not simple in the fixed-representative sense of
+    Definition~\ref{def:mpdo_simple_tensor}.
+
+    This conclusion quantifies over every normalized BNT witness permitted by
+    the formal predicate. It does not assert that a BNT element is nilpotent,
+    does not use the vertical coefficient family, and does not concern a
+    scale-invariant notion of simplicity.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_horizontal_cf_quasi_idempotent_scalar,
+        lem:mpdo_simple_tensor_horizontal_cf}
+    Suppose that the $L$-site blocking has a normalized horizontal canonical
+    form, where $L>0$. By
+    Lemma~\ref{lem:mpdo_horizontal_cf_quasi_idempotent_scalar}, its
+    quasi-idempotence scalar must be one. On the other hand,
+    \begin{align}
+        0<\left(\frac{337}{512}\right)^L<1,
+        \notag
+    \end{align}
+    a contradiction. Simplicity would provide such a normalized horizontal
+    canonical form after some positive blocking by
+    \cite[lines~815--822]{Cirac2016MPDO_arXiv}; hence $R$ is not simple.
+\end{proof}

--- a/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
@@ -43,9 +43,20 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    Expand the direct-sum transfer map. Reindexing converts each block-diagonal
-    matrix product into the corresponding block-labelled product, and summing
-    over the physical index gives $\mathcal S_B$.
+    Since $\Phi$ preserves products and adjoints, expanding the transfer map
+    gives
+    \begin{align}
+        \E_{\oplus_k B_k}(\Phi(Y))
+        &=\sum_i\Phi\!\left(\bigoplus_k B_k^i\right)\Phi(Y)
+            \Phi\!\left(\bigoplus_k B_k^i\right)^\dagger
+        \notag\\
+        &=\Phi\!\left(\sum_i
+            \left(\bigoplus_k B_k^i\right)Y
+            \left(\bigoplus_k B_k^i\right)^\dagger\right)
+        \notag\\
+        &=\Phi(\mathcal S_B(Y)).
+        \notag
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Direct-sum quasi-idempotence on the block transfer sum]%

--- a/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
@@ -96,11 +96,19 @@
 \begin{proof}\leanok
     \uses{thm:block_transfer_sum_quasi_idempotent_of_direct_sum,
         lem:block_diagonal_transfer_sum_to_block}
-    Realize an arbitrary rectangular matrix as the $(j,j')$ block of a matrix
-    on the total bond space. Theorem~\ref{thm:block_transfer_sum_quasi_idempotent_of_direct_sum}
-    gives $\mathcal S_B^2=c\mathcal S_B$. Restricting this identity to the
-    $(j,j')$ block twice and applying
-    Lemma~\ref{lem:block_diagonal_transfer_sum_to_block} gives the result.
+    Let $Z$ be an arbitrary rectangular matrix and realize it as the $(j,j')$
+    block of a matrix $Y$ on the total bond space. By
+    Lemma~\ref{lem:block_diagonal_transfer_sum_to_block},
+    $[\mathcal S_B(Y)]_{j,j'}=\E_{j,j'}(Z)$.
+    Theorem~\ref{thm:block_transfer_sum_quasi_idempotent_of_direct_sum} gives
+    $\mathcal S_B^2=c\mathcal S_B$, and hence
+    \begin{align}
+        \E_{j,j'}(\E_{j,j'}(Z))
+        &=[\mathcal S_B(\mathcal S_B(Y))]_{j,j'}
+         =[c\mathcal S_B(Y)]_{j,j'}
+         =c\E_{j,j'}(Z).
+        \notag
+    \end{align}
 \end{proof}
 
 \begin{lemma}[Pairwise idempotence of the block transfer sum]%

--- a/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
@@ -27,6 +27,27 @@
     \end{align}
 \end{proof}
 
+\begin{theorem}[Reindexing the direct-sum transfer map]%
+    \label{thm:direct_sum_transfer_reindex}
+    \lean{MPSTensor.transferMap_directSumTensor_reindex}
+    \leanok
+    \uses{def:transfer_map}
+    Let $(B_k)_k$ be a family of tensors, let $\Phi$ be the canonical
+    identification of the block-labelled bond space with the total bond space,
+    and let $\mathcal S_B$ be the block transfer sum. Then, for every block
+    matrix $Y$,
+    \begin{align}
+        \E_{\oplus_k B_k}(\Phi(Y))&=\Phi(\mathcal S_B(Y)).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the direct-sum transfer map. Reindexing converts each block-diagonal
+    matrix product into the corresponding block-labelled product, and summing
+    over the physical index gives $\mathcal S_B$.
+\end{proof}
+
 \begin{theorem}[Direct-sum quasi-idempotence on the block transfer sum]%
     \label{thm:block_transfer_sum_quasi_idempotent_of_direct_sum}
     \lean{MPSTensor.blockTransferSum_blockTransferSum_eq_smul}
@@ -46,10 +67,11 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:block_diagonal_transfer_sum_to_block}
-    Reindex the total bond space by its block labels. Under this identification,
-    the direct-sum transfer map is $\mathcal S_B$. Transporting the assumed
-    equation through the reindexing gives the displayed identity.
+    \uses{thm:direct_sum_transfer_reindex}
+    Reindex the total bond space by its block labels. By
+    Theorem~\ref{thm:direct_sum_transfer_reindex}, the direct-sum transfer map
+    becomes $\mathcal S_B$. Transporting the assumed equation through this
+    identification gives the displayed identity.
 \end{proof}
 
 \begin{theorem}[Direct-sum quasi-idempotence on every mixed corner]%

--- a/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
@@ -80,13 +80,13 @@
         mixedTransferMap₂_comp_self_eq_smul_of_transferMap_comp_self_eq_smul}
     \leanok
     \uses{def:mixed_transfer_rect, def:transfer_map}
-    Let $(B_k)_k$ be a family of tensors with positive bond dimensions, and let
-    $c\in\C$. If
+    Let $(B_k)_k$ be a family of tensors and let $c\in\C$. If
     \begin{align}
         \E_{\oplus_k B_k}^2&=c\E_{\oplus_k B_k},
         \notag
     \end{align}
-    then, for every ordered pair of blocks $(j,j')$,
+    then, for every ordered pair of blocks $(j,j')$ whose two bond dimensions
+    are positive,
     \begin{align}
         \E_{j,j'}^2&=c\E_{j,j'}.
         \notag

--- a/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
@@ -27,6 +27,60 @@
     \end{align}
 \end{proof}
 
+\begin{theorem}[Direct-sum quasi-idempotence on the block transfer sum]%
+    \label{thm:block_transfer_sum_quasi_idempotent_of_direct_sum}
+    \lean{MPSTensor.blockTransferSum_blockTransferSum_eq_smul}
+    \leanok
+    \uses{def:transfer_map}
+    Let $(B_k)_k$ be a family of tensors and let $c\in\C$. If
+    \begin{align}
+        \E_{\oplus_k B_k}^2&=c\E_{\oplus_k B_k},
+        \notag
+    \end{align}
+    then the corresponding block transfer sum $\mathcal S_B$ satisfies, for
+    every bond matrix $Y$,
+    \begin{align}
+        \mathcal S_B(\mathcal S_B(Y))&=c\mathcal S_B(Y).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:block_diagonal_transfer_sum_to_block}
+    Reindex the total bond space by its block labels. Under this identification,
+    the direct-sum transfer map is $\mathcal S_B$. Transporting the assumed
+    equation through the reindexing gives the displayed identity.
+\end{proof}
+
+\begin{theorem}[Direct-sum quasi-idempotence on every mixed corner]%
+    \label{thm:mixed_transfer_quasi_idempotent_of_direct_sum}
+    \lean{MPSTensor.%
+        mixedTransferMap₂_comp_self_eq_smul_of_transferMap_comp_self_eq_smul}
+    \leanok
+    \uses{def:mixed_transfer_rect, def:transfer_map}
+    Let $(B_k)_k$ be a family of tensors with positive bond dimensions, and let
+    $c\in\C$. If
+    \begin{align}
+        \E_{\oplus_k B_k}^2&=c\E_{\oplus_k B_k},
+        \notag
+    \end{align}
+    then, for every ordered pair of blocks $(j,j')$,
+    \begin{align}
+        \E_{j,j'}^2&=c\E_{j,j'}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:block_transfer_sum_quasi_idempotent_of_direct_sum,
+        lem:block_diagonal_transfer_sum_to_block}
+    Realize an arbitrary rectangular matrix as the $(j,j')$ block of a matrix
+    on the total bond space. Theorem~\ref{thm:block_transfer_sum_quasi_idempotent_of_direct_sum}
+    gives $\mathcal S_B^2=c\mathcal S_B$. Restricting this identity to the
+    $(j,j')$ block twice and applying
+    Lemma~\ref{lem:block_diagonal_transfer_sum_to_block} gives the result.
+\end{proof}
+
 \begin{lemma}[Pairwise idempotence of the block transfer sum]%
     \label{lem:block_transfer_sum_idempotent_of_pairwise_mixed}
     \lean{MPSTensor.blockTransferSum_idempotent_of_pairwise_mixedTransferMap₂}

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -9,7 +9,7 @@
 
 \title{The CPSV16 Unit-Weight Convention and Renormalization-Fixed-Point Scale}
 \author{}
-\date{2026-08-14}
+\date{2026-08-15}
 
 \begin{document}
 \maketitle
@@ -88,21 +88,22 @@ the same literal idempotence equation, then
 so $c=1$. Thus Definition~4.1 is not invariant under an arbitrary nonzero
 rescaling of a fixed representative.
 
-By contrast, the simplicity definition at lines~815--823 is phrased through
-the normalized elements of a BNT: the tensor is simple when none of those
-elements has nilpotent ket-against-bra contraction. Multiplying a BNT
-element by a nonzero scalar does not change nilpotency. The mathematical
-simplicity content is therefore insensitive to that rescaling, even though a
-formal predicate that includes the line-246 canonical-form normalization is evaluated
-on a particular representative.
+By contrast, the simplicity definition at lines~815--822 is phrased through
+the elements of a BNT: the tensor is simple when none of those elements has
+nilpotent ket-against-bra contraction. Multiplying a BNT element by a nonzero
+scalar does not change nilpotency. That nilpotency clause is therefore
+insensitive to rescaling, even though a formal predicate that includes the
+line-246 canonical-form normalization is evaluated on a particular
+representative.
 
 The declarations \leanid{MPOTensor.IsSimpleCanonicalForm} and
 \leanid{MPOTensor.IsSimple} retain the source's BNT normalization. The first is
 a predicate on one displayed canonical-form representative. The second permits
 positive physical blocking, but still asks the resulting blocked tensor itself
 to admit such a normalized witness. Neither declaration is a quotient by
-nonzero scalar rescaling, and neither asserts invariance under changing the
-canonical presentation.
+nonzero scalar rescaling. For a fixed tensor, however, a theorem may quantify
+over every normalized BNT witness rather than rely on one chosen presentation;
+the dimer obstruction below has precisely this form.
 
 \section{The displayed dimer representative}
 
@@ -132,15 +133,42 @@ Since $\mu\ne1$, the scale-pinning calculation above shows that this normalized
 representative does not satisfy the same literal physical-trace idempotence
 equation as $R$.
 
-This establishes only a mismatch between the displayed one-block canonical
-normalization and the RFP-pinned representative. It does not prove that
-\leanid{MPOTensor.IsSimple} applied to $R$ is false, does not rule out every
-alternative canonical presentation or blocking, and does not make the displayed
-BNT coefficients presentation-independent. In the namespace
-\leanid{MPOTensor.RescalingStableLengthDependentRFP}, the theorem
-\leanid{doubledPhysTraceTransfer_retainedBlock_not_isNilpotent} records
-exactly the non-nilpotency of the retained block and no stronger
-simplicity conclusion.
+The obstruction is stronger than this displayed-presentation mismatch. For
+every positive blocking length $L$, the doubled-index transfer map of the
+blocked tensor satisfies
+\begin{align}
+    \mathcal E_{R^{[L]}}^2
+    &=\left(\frac{337}{512}\right)^L\mathcal E_{R^{[L]}}.
+    \label{eq:blocked-quasi-idempotence}
+\end{align}
+Suppose that $R^{[L]}$ admitted any normalized horizontal BNT witness. The
+gauge to that witness transports \eqref{eq:blocked-quasi-idempotence}. The
+global unit-weight condition from line~246 supplies a copy whose weight has
+modulus one. Restricting the transported equation to that copy removes the
+weight. Its normal representative is left canonical, so its transfer map is
+trace preserving. Taking the trace of the quasi-idempotence equation at the
+identity forces
+\begin{align}
+    \left(\frac{337}{512}\right)^L&=1.
+\end{align}
+This contradicts $0<(337/512)^L<1$. Hence no positive blocking of $R$ admits a
+normalized horizontal canonical form. Since the formal simple-canonical-form
+predicate includes such a horizontal witness, the theorem
+\leanid{R_not_isSimple} in the namespace
+\leanid{MPOTensor.RescalingStableLengthDependentRFP} proves
+\begin{align}
+    \lnot\,\leanid{MPOTensor.IsSimple}\,R.
+\end{align}
+The argument quantifies over the arbitrary normalized BNT witness allowed by
+the formal predicate; it does not depend on the displayed one-block
+presentation.
+
+This failure is not a nilpotency result. The retained-block theorem still
+proves that the displayed canonical presentation has non-nilpotent
+physical-trace transfer. The contradiction instead combines quasi-idempotence
+of the doubled-index transfer, the line-246 unit-weight copy, and trace
+preservation of its normal representative. It also uses none of the vertical
+coefficient identities discussed below.
 
 \section{The vertical one-label identity}
 
@@ -165,18 +193,18 @@ not an invariance theorem for coefficients under changes of presentation.
 \section{Formalization boundary}
 
 \textbf{Verdict: scope restriction (fixed representative).} The current
-declarations are mathematically correct at their stated scope.
-The line-246 field should not be deleted: it is the source's standing
-canonical-form convention. The appropriate future interface is instead a
-scale-invariant simplicity surface, formulated either on a normalized
-representative or without including the unit-weight convention in the
-simplicity predicate.
+formal predicate is false for the displayed tensor $R$: every positive
+blocking has quasi-idempotence scalar $(337/512)^L<1$, while every normalized
+horizontal BNT witness would force that scalar to be one. This conclusion is
+independent of the choice of normalized BNT witness.
 
-This note adds no such predicate and proves no generic scale-pinning lemma. It
-only records why the existing simplicity predicates must be read as
-fixed-representative statements, and why non-nilpotency of the displayed dimer
-block does not by itself establish or refute the full predicate
-\leanid{MPOTensor.IsSimple} applied to $R$.
+The verdict remains representative-dependent. The line-246 field should not
+be deleted: it is the source's standing canonical-form convention. The result
+does not produce a nilpotent BNT block, does not use the vertical coefficient
+family, and does not show that any scale-invariant physical notion of
+simplicity fails for $R$. A future scale-invariant interface would have to be
+formulated either on a normalized representative or without including the
+unit-weight convention in the simplicity predicate.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Closes #6464.

## Summary
- propagate transfer-map quasi-idempotence through positive physical blocking and gauge equivalence
- restrict direct-sum quasi-idempotence to arbitrary mixed-transfer corners
- prove the line-246 global unit-weight convention forces a normalized BNT quasi-idempotence scalar to equal one
- show every positive blocking of the dimer `R` fails `IsHorizontalCF`, hence prove `R_not_isSimple`
- synchronize the Blueprint and fixed-representative paper-gap note

## Scope
The proof quantifies over the arbitrary normalized BNT witness supplied by the formal predicate. It does not assume uniqueness of the displayed retained block, does not use vertical coefficient rigidity, and does not assert a nilpotent BNT element or failure of a future scale-invariant simplicity notion.

## Verification
- targeted Lean compilation of `BlockingTransfer`, `NormalTensorGauge`, `BNTOrthogonality`, and `RescalingStableNotSimple`
- `lake build TNLean.MPS.MPDO.RescalingStableNotSimple`
- Blueprint synchronization: 7722/7722
- Blueprint PDF and web builds
- standalone paper-gap LaTeX build
- `git diff --check` and forbidden-placeholder scan

