### PR TITLE
feat(QCA): add algebraic-local translations

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.QCA
 
+import TNLean.QCA.AlgebraicTranslation
 import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit
 import TNLean.QCA.LocalNorm

--- a/TNLean/QCA/AlgebraicTranslation.lean
+++ b/TNLean/QCA/AlgebraicTranslation.lean
@@ -1,0 +1,324 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.LocalNorm
+import TNLean.QCA.Translation
+
+/-!
+# Translations of algebraic-local observables
+
+Finite-region translations are compatible with the canonical local inclusions, so they induce an
+additive action of the lattice on the algebraic local algebra by star-algebra equivalences. This
+action translates finite supports exactly and preserves the operator norm.
+
+This file concerns the algebraic local algebra only. It does not extend translations to the
+quasi-local completion or define finite propagation, inverse locality, or quantum cellular
+automata.
+
+## Main definitions
+
+* `SpinChain.algebraicLocalTranslationHom` — translation as a star-algebra homomorphism.
+* `SpinChain.algebraicLocalTranslation` — translation as a star-algebra equivalence.
+
+## Main results
+
+* `SpinChain.algebraicLocalTranslation_localObservable` — evaluation on a finite-region
+  representative.
+* `SpinChain.algebraicLocalTranslation_zero` and `SpinChain.algebraicLocalTranslation_add` — the
+  additive action laws.
+* `SpinChain.algebraicLocalTranslation_supportedIn_iff` — exact transport of finite support.
+* `SpinChain.norm_algebraicLocalTranslation` — translation preserves the operator norm.
+* `SpinChain.algebraicLocalTranslation_isometry` — translation is an isometry.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2292--2306,
+  for the algebraic local algebra, its norm completion, and the translation requirement for QCA.
+* Schumacher--Werner, quant-ph/0405174, Definition 1.
+-/
+
+open scoped ComplexOrder
+
+namespace SpinChain
+
+attribute [local instance] CStarMatrix.instNorm CStarMatrix.instNormedAddCommGroup
+  CStarMatrix.instNormedRing CStarMatrix.instCStarRing
+
+/-- Translation of finite-region representatives induces a star-algebra homomorphism on the
+algebraic local algebra.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+noncomputable def algebraicLocalTranslationHom (d : ℕ) (a : ℤ) :
+    AlgebraicLocalAlgebra d →⋆ₐ[ℂ] AlgebraicLocalAlgebra d :=
+  algebraicLocalAlgebraLift
+    (fun Λ ↦ (localObservable d (translateRegion a Λ)).comp
+      (localTranslation d a Λ).toStarAlgHom)
+    (by
+      intro Λ Γ h A
+      change localObservable d (translateRegion a Γ)
+          (localTranslation d a Γ (localInclusion h A)) =
+        localObservable d (translateRegion a Λ) (localTranslation d a Λ A)
+      calc
+        _ = localObservable d (translateRegion a Γ)
+            (localInclusion (translateRegion_mono a h) (localTranslation d a Λ A)) := by
+              rw [localTranslation_localInclusion]
+        _ = _ := localObservable_localInclusion d (translateRegion_mono a h) _)
+
+/-- Algebraic-local translation sends a finite-region representative to its translated
+representative.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+@[simp]
+lemma algebraicLocalTranslationHom_localObservable (d : ℕ) (a : ℤ)
+    (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    algebraicLocalTranslationHom d a (localObservable d Λ A) =
+      localObservable d (translateRegion a Λ) (localTranslation d a Λ A) :=
+  rfl
+
+/-- Translation by zero gives the same element of the algebraic direct limit on every
+finite-region representative. -/
+private lemma algebraicLocalTranslation_zero_rep (d : ℕ) (Λ : Finset ℤ)
+    (A : LocalAlgebra d Λ) :
+    localObservable d (translateRegion 0 Λ) (localTranslation d 0 Λ A) =
+      localObservable d Λ A := by
+  let h : translateRegion 0 Λ ⊆ Λ := by simp
+  rw [← localObservable_localInclusion d h]
+  congr 1
+  ext x y
+  rw [localInclusion_apply]
+  have hcomp : (Config.splitEquiv h x).2 = (Config.splitEquiv h y).2 := by
+    funext i
+    exact False.elim ((Finset.mem_sdiff.mp i.2).2 (by simpa using i.2))
+  rw [if_pos hcomp, mul_one]
+  let x₀ := (Config.translation d 0 Λ).symm (Config.restrict h x)
+  let y₀ := (Config.translation d 0 Λ).symm (Config.restrict h y)
+  change localTranslation d 0 Λ A (Config.restrict h x) (Config.restrict h y) = A x y
+  rw [show Config.restrict h x = Config.translation d 0 Λ x₀ from
+    (Equiv.apply_symm_apply _ _).symm]
+  rw [show Config.restrict h y = Config.translation d 0 Λ y₀ from
+    (Equiv.apply_symm_apply _ _).symm]
+  rw [localTranslation_zero]
+  congr 2 <;> funext i
+  · change x _ = x i
+    congr 1
+    apply Subtype.ext
+    simp
+  · change y _ = y i
+    congr 1
+    apply Subtype.ext
+    simp
+
+/-- Successive finite-region translations give the same element of the algebraic direct limit as
+translation by the sum. -/
+private lemma algebraicLocalTranslation_add_rep (d : ℕ) (a b : ℤ) (Λ : Finset ℤ)
+    (A : LocalAlgebra d Λ) :
+    localObservable d (translateRegion b (translateRegion a Λ))
+        (localTranslation d b (translateRegion a Λ) (localTranslation d a Λ A)) =
+      localObservable d (translateRegion (a + b) Λ) (localTranslation d (a + b) Λ A) := by
+  let h : translateRegion b (translateRegion a Λ) ⊆ translateRegion (a + b) Λ := by
+    intro i hi
+    simp only [mem_translateRegion] at hi ⊢
+    ring_nf at hi ⊢
+    exact hi
+  rw [← localObservable_localInclusion d h]
+  congr 1
+  ext x y
+  rw [localInclusion_apply]
+  have hcomp : (Config.splitEquiv h x).2 = (Config.splitEquiv h y).2 := by
+    funext i
+    exact False.elim ((Finset.mem_sdiff.mp i.2).2 (by
+      have hi := (Finset.mem_sdiff.mp i.2).1
+      simp only [mem_translateRegion] at hi ⊢
+      ring_nf at hi ⊢
+      exact hi))
+  rw [if_pos hcomp, mul_one]
+  let x₀ := (Config.translation d (a + b) Λ).symm x
+  let y₀ := (Config.translation d (a + b) Λ).symm y
+  have hx : Config.restrict h x =
+      Config.translation d b (translateRegion a Λ) (Config.translation d a Λ x₀) := by
+    funext i
+    change x _ = x _
+    congr 1
+    apply Subtype.ext
+    simp only [siteTranslation_apply_val, siteTranslation_symm_apply_val]
+    ring
+  have hy : Config.restrict h y =
+      Config.translation d b (translateRegion a Λ) (Config.translation d a Λ y₀) := by
+    funext i
+    change y _ = y _
+    congr 1
+    apply Subtype.ext
+    simp only [siteTranslation_apply_val, siteTranslation_symm_apply_val]
+    ring
+  rw [hx, hy]
+  have hx₀ : Config.translation d (a + b) Λ x₀ = x := Equiv.apply_symm_apply _ _
+  have hy₀ : Config.translation d (a + b) Λ y₀ = y := Equiv.apply_symm_apply _ _
+  simpa only [hx₀, hy₀] using localTranslation_add d a b Λ A x₀ y₀
+
+/-- Translation by zero is the identity star-algebra homomorphism on algebraic-local
+observables.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+@[simp]
+lemma algebraicLocalTranslationHom_zero (d : ℕ) :
+    algebraicLocalTranslationHom d 0 = StarAlgHom.id ℂ (AlgebraicLocalAlgebra d) := by
+  apply algebraicLocalAlgebra_starAlgHom_ext
+  intro Λ
+  ext A
+  exact algebraicLocalTranslation_zero_rep d Λ A
+
+/-- Successive algebraic-local translation homomorphisms compose by adding their displacements.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+lemma algebraicLocalTranslationHom_add (d : ℕ) (a b : ℤ) :
+    (algebraicLocalTranslationHom d b).comp (algebraicLocalTranslationHom d a) =
+      algebraicLocalTranslationHom d (a + b) := by
+  apply algebraicLocalAlgebra_starAlgHom_ext
+  intro Λ
+  ext A
+  exact algebraicLocalTranslation_add_rep d a b Λ A
+
+/-- Translation by a lattice displacement is a star-algebra equivalence of the algebraic local
+algebra, with inverse given by the opposite displacement.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+noncomputable def algebraicLocalTranslation (d : ℕ) (a : ℤ) :
+    AlgebraicLocalAlgebra d ≃⋆ₐ[ℂ] AlgebraicLocalAlgebra d :=
+  StarAlgEquiv.ofBijective (algebraicLocalTranslationHom d a) ⟨
+    fun A B hAB ↦ by
+      have h := congrArg (algebraicLocalTranslationHom d (-a)) hAB
+      have hA : algebraicLocalTranslationHom d (-a)
+          (algebraicLocalTranslationHom d a A) = A := by
+        rw [← StarAlgHom.comp_apply, algebraicLocalTranslationHom_add,
+          add_neg_cancel, algebraicLocalTranslationHom_zero]
+        rfl
+      have hB : algebraicLocalTranslationHom d (-a)
+          (algebraicLocalTranslationHom d a B) = B := by
+        rw [← StarAlgHom.comp_apply, algebraicLocalTranslationHom_add,
+          add_neg_cancel, algebraicLocalTranslationHom_zero]
+        rfl
+      rwa [hA, hB] at h,
+    fun A ↦ ⟨algebraicLocalTranslationHom d (-a) A, by
+      rw [← StarAlgHom.comp_apply, algebraicLocalTranslationHom_add,
+        neg_add_cancel, algebraicLocalTranslationHom_zero]
+      rfl⟩⟩
+
+/-- Algebraic-local translation as an equivalence has the same underlying map as the lifted
+translation homomorphism. -/
+@[simp]
+lemma algebraicLocalTranslation_apply (d : ℕ) (a : ℤ) (A : AlgebraicLocalAlgebra d) :
+    algebraicLocalTranslation d a A = algebraicLocalTranslationHom d a A :=
+  StarAlgEquiv.ofBijective_apply _ _
+
+/-- Algebraic-local translation sends a finite-region representative to its translated
+representative.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+lemma algebraicLocalTranslation_localObservable (d : ℕ) (a : ℤ)
+    (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    algebraicLocalTranslation d a (localObservable d Λ A) =
+      localObservable d (translateRegion a Λ) (localTranslation d a Λ A) := by
+  simpa only [algebraicLocalTranslation_apply] using
+    algebraicLocalTranslationHom_localObservable d a Λ A
+
+/-- Translation by zero is the identity star-algebra equivalence.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+@[simp]
+lemma algebraicLocalTranslation_zero (d : ℕ) :
+    algebraicLocalTranslation d 0 = StarAlgEquiv.refl ℂ (AlgebraicLocalAlgebra d) := by
+  ext A
+  simp
+
+/-- Successive algebraic-local translation equivalences compose by adding their displacements.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+lemma algebraicLocalTranslation_add (d : ℕ) (a b : ℤ) :
+    (algebraicLocalTranslation d a).trans (algebraicLocalTranslation d b) =
+      algebraicLocalTranslation d (a + b) := by
+  ext A
+  change algebraicLocalTranslationHom d b (algebraicLocalTranslationHom d a A) =
+    algebraicLocalTranslationHom d (a + b) A
+  exact DFunLike.congr_fun (algebraicLocalTranslationHom_add d a b) A
+
+/-- The inverse of translation by `a` is translation by `-a`.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+@[simp]
+lemma algebraicLocalTranslation_symm (d : ℕ) (a : ℤ) :
+    (algebraicLocalTranslation d a).symm = algebraicLocalTranslation d (-a) := by
+  apply StarAlgEquiv.ext
+  intro A
+  apply (algebraicLocalTranslation d a).symm_apply_eq.mpr
+  change A = algebraicLocalTranslationHom d a (algebraicLocalTranslationHom d (-a) A)
+  rw [← StarAlgHom.comp_apply, algebraicLocalTranslationHom_add,
+    neg_add_cancel, algebraicLocalTranslationHom_zero]
+  rfl
+
+/-- Algebraic-local translation carries support in `Λ` to support in `Λ + a`.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+lemma algebraicLocalTranslation_supportedIn (d : ℕ) (a : ℤ)
+    {A : AlgebraicLocalAlgebra d} {Λ : Finset ℤ} (hA : SupportedIn A Λ) :
+    SupportedIn (algebraicLocalTranslation d a A) (translateRegion a Λ) := by
+  obtain ⟨B, rfl⟩ := hA
+  exact ⟨localTranslation d a Λ B,
+    (algebraicLocalTranslation_localObservable d a Λ B).symm⟩
+
+/-- Algebraic-local translation carries support in `Λ` exactly to support in `Λ + a`.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
+algebra and its lattice translation operator. -/
+lemma algebraicLocalTranslation_supportedIn_iff (d : ℕ) (a : ℤ)
+    (A : AlgebraicLocalAlgebra d) (Λ : Finset ℤ) :
+    SupportedIn A Λ ↔
+      SupportedIn (algebraicLocalTranslation d a A) (translateRegion a Λ) := by
+  constructor
+  · exact algebraicLocalTranslation_supportedIn d a
+  · intro hA
+    have h := algebraicLocalTranslation_supportedIn d (-a) hA
+    change SupportedIn
+      (algebraicLocalTranslationHom d (-a) (algebraicLocalTranslationHom d a A))
+      (translateRegion (-a) (translateRegion a Λ)) at h
+    rw [← StarAlgHom.comp_apply, algebraicLocalTranslationHom_add,
+      add_neg_cancel, algebraicLocalTranslationHom_zero] at h
+    rw [translateRegion_add a (-a), add_neg_cancel, translateRegion_zero] at h
+    exact h
+
+/-- Algebraic-local translation preserves the operator norm.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2306, which use the norm topology and lattice
+translations in the definition and construction of one-dimensional QCA. -/
+lemma norm_algebraicLocalTranslation (d : ℕ) [NeZero d] (a : ℤ)
+    (A : AlgebraicLocalAlgebra d) :
+    ‖algebraicLocalTranslation d a A‖ = ‖A‖ := by
+  induction A using DirectLimit.induction with
+  | _ Λ A =>
+      change ‖localTranslation d a Λ A‖ = ‖A‖
+      exact StarAlgEquiv.norm_map (localTranslation d a Λ) A
+
+/-- Algebraic-local translation is an operator-norm isometry.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2306, which use the norm topology and lattice
+translations in the definition and construction of one-dimensional QCA. -/
+lemma algebraicLocalTranslation_isometry (d : ℕ) [NeZero d] (a : ℤ) :
+    Isometry (algebraicLocalTranslation d a) := by
+  rw [isometry_iff_dist_eq]
+  intro A B
+  rw [dist_eq_norm, dist_eq_norm]
+  rw [← map_sub]
+  exact norm_algebraicLocalTranslation d a (A - B)
+
+end SpinChain

--- a/TNLean/QCA/AlgebraicTranslation.lean
+++ b/TNLean/QCA/AlgebraicTranslation.lean
@@ -50,7 +50,7 @@ attribute [local instance] CStarMatrix.instNorm CStarMatrix.instNormedAddCommGro
 algebraic local algebra.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 noncomputable def algebraicLocalTranslationHom (d : ℕ) (a : ℤ) :
     AlgebraicLocalAlgebra d →⋆ₐ[ℂ] AlgebraicLocalAlgebra d :=
   algebraicLocalAlgebraLift
@@ -71,7 +71,7 @@ noncomputable def algebraicLocalTranslationHom (d : ℕ) (a : ℤ) :
 representative.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 @[simp]
 lemma algebraicLocalTranslationHom_localObservable (d : ℕ) (a : ℤ)
     (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
@@ -163,7 +163,7 @@ private lemma algebraicLocalTranslation_add_rep (d : ℕ) (a b : ℤ) (Λ : Fins
 observables.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 @[simp]
 lemma algebraicLocalTranslationHom_zero (d : ℕ) :
     algebraicLocalTranslationHom d 0 = StarAlgHom.id ℂ (AlgebraicLocalAlgebra d) := by
@@ -175,7 +175,7 @@ lemma algebraicLocalTranslationHom_zero (d : ℕ) :
 /-- Successive algebraic-local translation homomorphisms compose by adding their displacements.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 lemma algebraicLocalTranslationHom_add (d : ℕ) (a b : ℤ) :
     (algebraicLocalTranslationHom d b).comp (algebraicLocalTranslationHom d a) =
       algebraicLocalTranslationHom d (a + b) := by
@@ -188,7 +188,7 @@ lemma algebraicLocalTranslationHom_add (d : ℕ) (a b : ℤ) :
 algebra, with inverse given by the opposite displacement.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 noncomputable def algebraicLocalTranslation (d : ℕ) (a : ℤ) :
     AlgebraicLocalAlgebra d ≃⋆ₐ[ℂ] AlgebraicLocalAlgebra d :=
   StarAlgEquiv.ofBijective (algebraicLocalTranslationHom d a) ⟨
@@ -221,7 +221,7 @@ lemma algebraicLocalTranslation_apply (d : ℕ) (a : ℤ) (A : AlgebraicLocalAlg
 representative.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 lemma algebraicLocalTranslation_localObservable (d : ℕ) (a : ℤ)
     (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
     algebraicLocalTranslation d a (localObservable d Λ A) =
@@ -232,7 +232,7 @@ lemma algebraicLocalTranslation_localObservable (d : ℕ) (a : ℤ)
 /-- Translation by zero is the identity star-algebra equivalence.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 @[simp]
 lemma algebraicLocalTranslation_zero (d : ℕ) :
     algebraicLocalTranslation d 0 = StarAlgEquiv.refl ℂ (AlgebraicLocalAlgebra d) := by
@@ -242,7 +242,7 @@ lemma algebraicLocalTranslation_zero (d : ℕ) :
 /-- Successive algebraic-local translation equivalences compose by adding their displacements.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 lemma algebraicLocalTranslation_add (d : ℕ) (a b : ℤ) :
     (algebraicLocalTranslation d a).trans (algebraicLocalTranslation d b) =
       algebraicLocalTranslation d (a + b) := by
@@ -254,7 +254,7 @@ lemma algebraicLocalTranslation_add (d : ℕ) (a b : ℤ) :
 /-- The inverse of translation by `a` is translation by `-a`.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 @[simp]
 lemma algebraicLocalTranslation_symm (d : ℕ) (a : ℤ) :
     (algebraicLocalTranslation d a).symm = algebraicLocalTranslation d (-a) := by
@@ -269,7 +269,7 @@ lemma algebraicLocalTranslation_symm (d : ℕ) (a : ℤ) :
 /-- Algebraic-local translation carries support in `Λ` to support in `Λ + a`.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 lemma algebraicLocalTranslation_supportedIn (d : ℕ) (a : ℤ)
     {A : AlgebraicLocalAlgebra d} {Λ : Finset ℤ} (hA : SupportedIn A Λ) :
     SupportedIn (algebraicLocalTranslation d a A) (translateRegion a Λ) := by
@@ -280,7 +280,7 @@ lemma algebraicLocalTranslation_supportedIn (d : ℕ) (a : ℤ)
 /-- Algebraic-local translation carries support in `Λ` exactly to support in `Λ + a`.
 
 Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the algebraic local
-algebra and its lattice translation operator. -/
+algebra and use the lattice translation operator. -/
 lemma algebraicLocalTranslation_supportedIn_iff (d : ℕ) (a : ℤ)
     (A : AlgebraicLocalAlgebra d) (Λ : Finset ℤ) :
     SupportedIn A Λ ↔

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7981,7 +7981,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{definition}
 
 \begin{proof}\leanok
-  \uses{lem:qca_finite_local_translation_naturality,
+  \uses{def:qca_translate_region,def:qca_algebraic_local_algebra,
+    lem:qca_finite_local_translation_naturality,
     thm:qca_algebraic_local_algebra_universal}
   Naturality gives, for $\Lambda\subseteq\Gamma$,
   \begin{align}
@@ -8032,8 +8033,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \leanok
   \uses{def:qca_algebraic_local_translation_hom}
   For every $a\in\mathbb Z$, the homomorphism $\tau_a$ is a star-algebra
-  automorphism of $\mathcal A_{\mathrm{loc}}$. Its inverse is $\tau_{-a}$,
-  and on finite-region representatives
+  automorphism of $\mathcal A_{\mathrm{loc}}$, and on finite-region
+  representatives
   \begin{align}
     \tau_a(\iota_\Lambda(A))
       &=\iota_{\Lambda+a}(\tau_{a,\Lambda}(A)).
@@ -8072,7 +8073,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
     lem:qca_algebraic_local_translation_hom_action}
   The first two identities are the homomorphism action laws expressed as
   identities of star-algebra automorphisms. Taking $b=-a$ in the composition
-  law gives the inverse identity.
+  law gives
+  \begin{align}
+    \tau_{-a}\circ\tau_a&=\tau_0=\operatorname{id}, \\
+    \tau_a\circ\tau_{-a}&=\tau_0=\operatorname{id},
+  \end{align}
+  which is the inverse identity.
 \end{proof}
 
 \begin{lemma}[Exact translation of algebraic-local supports]
@@ -8117,7 +8123,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \begin{proof}\leanok
   \uses{def:qca_algebraic_local_operator_norm,
     def:qca_finite_local_translation,
-    def:qca_algebraic_local_translation}
+    def:qca_algebraic_local_translation,
+    thm:qca_local_observable_finite_support}
   Choose $A_\Lambda\in\mathcal A_\Lambda$ with
   $A=\iota_\Lambda(A_\Lambda)$. Finite-region translation is a star-algebra
   equivalence of matrix algebras, hence preserves the operator norm. Therefore

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7960,6 +7960,176 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   system.
 \end{proof}
 
+\begin{definition}[Algebraic-local translation homomorphism]
+  \label{def:qca_algebraic_local_translation_hom}
+  \lean{SpinChain.algebraicLocalTranslationHom,
+    SpinChain.algebraicLocalTranslationHom_localObservable}
+  \leanok
+  \uses{def:qca_finite_local_translation,
+    def:qca_algebraic_local_algebra}
+  For $a\in\mathbb Z$, finite-region translations induce a star-algebra
+  homomorphism
+  \begin{align}
+    \tau_a\colon\mathcal A_{\mathrm{loc}}&\longrightarrow
+      \mathcal A_{\mathrm{loc}}
+  \end{align}
+  determined on every finite-region representative by
+  \begin{align}
+    \tau_a(\iota_\Lambda(A))
+      &=\iota_{\Lambda+a}(\tau_{a,\Lambda}(A)).
+  \end{align}
+\end{definition}
+
+\begin{proof}\leanok
+  \uses{lem:qca_finite_local_translation_naturality,
+    thm:qca_algebraic_local_algebra_universal}
+  Naturality gives, for $\Lambda\subseteq\Gamma$,
+  \begin{align}
+    \iota_{\Gamma+a}\!\left(\tau_{a,\Gamma}(\iota_{\Lambda,\Gamma}(A))\right)
+      &=\iota_{\Gamma+a}\!\left(\iota_{\Lambda+a,\Gamma+a}(\tau_{a,\Lambda}(A))\right) \\
+      &=\iota_{\Lambda+a}(\tau_{a,\Lambda}(A)).
+  \end{align}
+  Hence the finite-region maps form a compatible family and induce the stated
+  homomorphism on the algebraic direct limit.
+\end{proof}
+
+\begin{lemma}[Action laws for algebraic-local translation homomorphisms]
+  \label{lem:qca_algebraic_local_translation_hom_action}
+  \lean{SpinChain.algebraicLocalTranslationHom_zero,
+    SpinChain.algebraicLocalTranslationHom_add}
+  \leanok
+  \uses{def:qca_algebraic_local_translation_hom}
+  The homomorphisms satisfy
+  \begin{align}
+    \tau_0&=\operatorname{id}, \\
+    \tau_b\circ\tau_a&=\tau_{a+b}.
+  \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_translate_region,def:qca_algebraic_local_algebra,
+    lem:qca_finite_translation_action,
+    thm:qca_algebraic_local_algebra_universal}
+  On a representative $A\in\mathcal A_\Lambda$, the two sides of the
+  composition law are represented on the equal finite regions
+  $(\Lambda+a)+b$ and $\Lambda+(a+b)$. The finite-region action identity
+  therefore gives
+  \begin{align}
+    \tau_b(\tau_a(\iota_\Lambda(A)))
+      &=\iota_{\Lambda+(a+b)}
+        (\tau_{a+b,\Lambda}(A))
+       =\tau_{a+b}(\iota_\Lambda(A)).
+  \end{align}
+  The zero law is proved in the same way. Equality on all finite-region
+  representatives determines equality on the algebraic direct limit.
+\end{proof}
+
+\begin{definition}[Translation of algebraic-local observables]
+  \label{def:qca_algebraic_local_translation}
+  \lean{SpinChain.algebraicLocalTranslation,
+    SpinChain.algebraicLocalTranslation_apply,
+    SpinChain.algebraicLocalTranslation_localObservable}
+  \leanok
+  \uses{def:qca_algebraic_local_translation_hom}
+  For every $a\in\mathbb Z$, the homomorphism $\tau_a$ is a star-algebra
+  automorphism of $\mathcal A_{\mathrm{loc}}$. Its inverse is $\tau_{-a}$,
+  and on finite-region representatives
+  \begin{align}
+    \tau_a(\iota_\Lambda(A))
+      &=\iota_{\Lambda+a}(\tau_{a,\Lambda}(A)).
+  \end{align}
+\end{definition}
+
+\begin{proof}\leanok
+  \uses{def:qca_algebraic_local_translation_hom,
+    lem:qca_algebraic_local_translation_hom_action}
+  The homomorphism action laws give
+  \begin{align}
+    \tau_{-a}\circ\tau_a&=\tau_0=\operatorname{id}, \\
+    \tau_a\circ\tau_{-a}&=\tau_0=\operatorname{id}.
+  \end{align}
+  Thus $\tau_a$ is bijective with inverse $\tau_{-a}$. The formula on
+  finite-region representatives is the defining formula for the homomorphism.
+\end{proof}
+
+\begin{lemma}[Algebraic-local translation action laws]
+  \label{lem:qca_algebraic_local_translation_action}
+  \lean{SpinChain.algebraicLocalTranslation_zero,
+    SpinChain.algebraicLocalTranslation_add,
+    SpinChain.algebraicLocalTranslation_symm}
+  \leanok
+  \uses{def:qca_algebraic_local_translation}
+  The automorphisms form an additive action of $\mathbb Z$:
+  \begin{align}
+    \tau_0&=\operatorname{id}, \\
+    \tau_b\circ\tau_a&=\tau_{a+b}, \\
+    \tau_a^{-1}&=\tau_{-a}.
+  \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_algebraic_local_translation,
+    lem:qca_algebraic_local_translation_hom_action}
+  The first two identities are the homomorphism action laws expressed as
+  identities of star-algebra automorphisms. Taking $b=-a$ in the composition
+  law gives the inverse identity.
+\end{proof}
+
+\begin{lemma}[Exact translation of algebraic-local supports]
+  \label{lem:qca_algebraic_local_translation_support}
+  \lean{SpinChain.algebraicLocalTranslation_supportedIn,
+    SpinChain.algebraicLocalTranslation_supportedIn_iff}
+  \leanok
+  \uses{def:qca_supported_in,def:qca_algebraic_local_translation}
+  A local observable $A$ is supported in a finite region $\Lambda$ if and only
+  if $\tau_a(A)$ is supported in $\Lambda+a$.
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_translate_region,
+    def:qca_algebraic_local_translation,
+    lem:qca_algebraic_local_translation_hom_action}
+  If $A=\iota_\Lambda(A_\Lambda)$, then
+  \begin{align}
+    \tau_a(A)
+      &=\iota_{\Lambda+a}(\tau_{a,\Lambda}(A_\Lambda)),
+  \end{align}
+  which proves the forward implication. Apply the same argument to
+  $\tau_a(A)$ with displacement $-a$, and use
+  $\tau_{-a}\tau_a=\operatorname{id}$ and
+  $(\Lambda+a)-a=\Lambda$, for the reverse implication.
+\end{proof}
+
+\begin{lemma}[Norm isometry of algebraic-local translation]
+  \label{lem:qca_algebraic_local_translation_isometry}
+  \lean{SpinChain.norm_algebraicLocalTranslation,
+    SpinChain.algebraicLocalTranslation_isometry}
+  \leanok
+  \uses{def:qca_algebraic_local_operator_norm,
+    def:qca_algebraic_local_translation}
+  If $d>0$, then every translation preserves the operator norm and distance:
+  \begin{align}
+    \lVert\tau_a(A)\rVert&=\lVert A\rVert, \\
+    \lVert\tau_a(A)-\tau_a(B)\rVert&=\lVert A-B\rVert.
+  \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_algebraic_local_operator_norm,
+    def:qca_finite_local_translation,
+    def:qca_algebraic_local_translation}
+  Choose $A_\Lambda\in\mathcal A_\Lambda$ with
+  $A=\iota_\Lambda(A_\Lambda)$. Finite-region translation is a star-algebra
+  equivalence of matrix algebras, hence preserves the operator norm. Therefore
+  \begin{align}
+    \lVert\tau_a(A)\rVert
+      &=\lVert\tau_{a,\Lambda}(A_\Lambda)\rVert
+       =\lVert A_\Lambda\rVert
+       =\lVert A\rVert.
+  \end{align}
+  Applying this equality to $A-B$ gives distance preservation.
+\end{proof}
+
 \begin{definition}[Quasi-local observable algebra]
   \label{def:qca_quasi_local_algebra}
   \lean{SpinChain.QuasiLocalAlgebra,SpinChain.algebraicToQuasiLocal,


### PR DESCRIPTION
## Summary

- lift finite-region translations through the existing algebraic direct-limit universal property
- prove zero/additive action laws while hiding dependent region-index transport in focused private representative lemmas
- package inverse displacement as a star-algebra equivalence
- prove exact finite-support transport and operator-norm isometry
- add acyclic, formula-driven Chapter 28 nodes with direct proof dependencies

This is the algebraic-local implementation leaf under #6468. It deliberately stops before quasi-local completion, finite propagation, inverse locality, blocking, or an `IsQCA` predicate.

## Source context

- `Papers/1703.09188/paper_v2.tex`, Appendix, lines 2292–2306
- Schumacher–Werner, quant-ph/0405174, Definition 1

The cited passage introduces `𝒜_loc`, norm completion, and the lattice-translation requirement; this PR supplies the requested algebraic-local infrastructure rather than attributing these helper lemmas directly to the paper.

## Validation

- direct Lean compilation of `TNLean/QCA/AlgebraicTranslation.lean`
- `lake build TNLean.QCA.AlgebraicTranslation TNLean.QCA` (2977 jobs)
- diagnostics and full default lints: zero findings across 14 public declarations
- generated imports current
- blueprint sync: 7744/7744 globally, 528/528 in Chapter 28
- reverse declaration coverage and new dependency-subgraph acyclicity
- blueprint web build, reader-facing prose, integrity, line-length, no-bypass, and `git diff --check`
- independent Mathlib/API feasibility scout, Lean style review, and dedicated blueprint dependency audit

Closes #6473
