### PR TITLE
docs(MPDO): register fixed-representative scope markers

### DIFF
--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCapstone.lean
@@ -36,9 +36,13 @@ coefficients that depend on the positive chain length.
 
 This proves a normalization-free variant of the question in
 arXiv:1606.00608, lines 995--997, for the displayed vertical presentation. It
-does not assert presentation independence. The source additionally assumes
+does not assert presentation independence.
+
+**Scope restriction (unit-weight convention):** The source additionally assumes
 that every canonical weight has modulus at most one and at least one has
-modulus one; that normalization is not part of this statement. -/
+modulus one; that normalization is not part of this statement. The resulting
+fixed-representative scale tension is recorded in
+`docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`. -/
 theorem exists_isRFPViaTS_not_lengthIndependent_bntCoefficients_R :
     ∃ (M : MPOTensor 4 4) (H : BNTAlgebraTensorClause M),
       MPSTensor.IsCPSVCanonicalForm M.toMPSTensor ∧

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1477,9 +1477,8 @@
     not assert that length dependence is invariant under a change of
     presentation.  It also does not supply the source's additional canonical
     normalization: every weight has modulus at most one and at least one has
-    modulus one.  The resulting fixed-representative scale tension is recorded
-    in
-    \path{docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex}.
+    modulus one.
+    % Scope note: docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1477,7 +1477,9 @@
     not assert that length dependence is invariant under a change of
     presentation.  It also does not supply the source's additional canonical
     normalization: every weight has modulus at most one and at least one has
-    modulus one.
+    modulus one.  The resulting fixed-representative scale tension is recorded
+    in
+    \path{docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -275,6 +275,7 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
 \end{theorem}
 
 \begin{proof}\leanok
+    \lean{Matrix.partialTraceRight_singleKraus_kronecker_isometry}
     Let $X$ denote the operator before conjugation.  Reindex the chain into its
     first $L$ and final $K$ sites.  The sitewise matrix becomes
     $V^{\otimes L}\otimes V^{\otimes K}$.  Since

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -489,6 +489,12 @@ model different levels of data and different sources.
   horizontal canonical form plus the MPDO and nonnilpotent-sector conditions of
   arXiv:1606.00608, lines 815--822. The sanctioned one-way bridge is
   `MPOTensor.IsSimpleCanonicalForm.isHorizontalCF`.
+- `MPOTensor.IsSimpleCanonicalForm` and `MPOTensor.IsSimple` are normalized
+  fixed-representative predicates. The latter permits positive physical
+  blocking, but still requires the blocked tensor itself to admit the source's
+  line-246 unit-weight witness. Neither predicate is a quotient by nonzero
+  scalar rescaling; see
+  `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
 
 The `CF` spelling in these established MPDO names is retained for compatibility
 and paper-local vocabulary. New public predicates should spell out

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -83,6 +83,11 @@ For MPDO renormalization fixed points:
   simple-tensor predicate. The source copy-weight lemma is formalized on the
   chosen blocked canonical form; independence of the choices is not presently
   needed.
+- `cpsv16_unit_weight_rfp_scale_tension.tex` records the tension between the
+  source's line-246 unit-weight convention and the scale fixed by Definition
+  4.1. In particular, `MPOTensor.IsSimpleCanonicalForm` and
+  `MPOTensor.IsSimple` are normalized fixed-representative predicates, not
+  quotients by nonzero scalar rescaling.
 - `cpsv16_gsnnch_sector_decomposition.tex` records that
   `MPOTensor.GSNNCHData` retains the source orthogonal sectors and natural
   multiplicities. Positive commuting products on supplied orthogonal sectors


### PR DESCRIPTION
## Summary
- mark the dimer RFP capstone with the unit-weight scope restriction and dedicated paper-gap reference
- register the fixed-representative simplicity caveat in the glossary and paper-gap index
- tag the load-bearing partial-trace isometry lemma in the prefix-marginal Blueprint proof

## Scope
Documentation and Blueprint metadata only. No theorem statement or proof changes.

## Checks
- Blueprint synchronization and reverse coverage: 7761/7761
- reader-facing prose check
- chktex on both edited Blueprint chapters
- git diff --check

A direct targeted Lean invocation encountered the pre-existing generated-name collision `MPOTensor.RescalingStableLengthDependentRFP.bit1.eq_2` while loading imports, before the edited docstring; CI remains the authoritative compilation gate.

Closes #6397
Closes #6408
Closes #6467