### PR TITLE
feat(QCA): add finite region sumsets

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -13,4 +13,5 @@ import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit
 import TNLean.QCA.LocalNorm
 import TNLean.QCA.QuasiLocal
+import TNLean.QCA.RegionSumset
 import TNLean.QCA.Translation

--- a/TNLean/QCA/RegionSumset.lean
+++ b/TNLean/QCA/RegionSumset.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.Translation
+
+/-!
+# Sumsets of finite spin-chain regions
+
+For finite regions \(\Lambda, \mathcal N \subset \mathbb Z\), this file records the finite
+sumset \(\Lambda + \mathcal N\) used to state the propagation condition for a quantum cellular
+automaton. The construction is Mathlib's pointwise addition on finite sets.
+
+This file concerns only finite regions. It does not define propagation predicates, maps on local
+observable algebras, or quantum cellular automata.
+
+## Main definitions
+
+* `SpinChain.regionSumset` — the pointwise sum \(\Lambda + \mathcal N\) of finite regions.
+
+## Main results
+
+* `SpinChain.mem_regionSumset` — membership in a finite-region sumset.
+* `SpinChain.regionSumset_singleton_right` — addition by a singleton is `translateRegion`.
+* `SpinChain.regionSumset_mono` — the sumset is monotone in both regions.
+* `SpinChain.regionSumset_assoc` — finite-region sumsets are associative.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2292--2298.
+* Schumacher--Werner, quant-ph/0405174, Definition 1.
+-/
+
+open scoped Pointwise
+
+namespace SpinChain
+
+/-- The finite-region sumset \(\Lambda + \mathcal N\), formed using pointwise addition on
+`Finset ℤ`.
+
+This is the region appearing in the finite-propagation condition
+\(\omega(\mathcal A_\Lambda) \subseteq \mathcal A_{\Lambda + \mathcal N}\).
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+abbrev regionSumset (Λ 𝓝 : Finset ℤ) : Finset ℤ :=
+  Λ + 𝓝
+
+/-- A site belongs to \(\Lambda + \mathcal N\) exactly when it is the sum of a site in
+\(\Lambda\) and a displacement in \(\mathcal N\).
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma mem_regionSumset (i : ℤ) (Λ 𝓝 : Finset ℤ) :
+    i ∈ regionSumset Λ 𝓝 ↔ ∃ j ∈ Λ, ∃ a ∈ 𝓝, j + a = i := by
+  exact Finset.mem_add
+
+/-- Adding the singleton displacement region \(\{a\}\) agrees with translation by \(a\).
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+@[simp]
+lemma regionSumset_singleton_right (Λ : Finset ℤ) (a : ℤ) :
+    regionSumset Λ {a} = translateRegion a Λ := by
+  ext i
+  constructor
+  · rw [mem_regionSumset]
+    rintro ⟨j, hj, b, hb, rfl⟩
+    rw [Finset.mem_singleton] at hb
+    subst b
+    simpa using hj
+  · rw [mem_translateRegion]
+    intro hi
+    rw [mem_regionSumset]
+    exact ⟨i - a, hi, a, Finset.mem_singleton_self a, by simp⟩
+
+/-- The finite-region sumset is monotone in both arguments.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma regionSumset_mono {Λ Γ 𝓝 𝓜 : Finset ℤ} (hΛ : Λ ⊆ Γ) (h𝓝 : 𝓝 ⊆ 𝓜) :
+    regionSumset Λ 𝓝 ⊆ regionSumset Γ 𝓜 := by
+  exact Finset.add_subset_add hΛ h𝓝
+
+/-- Enlarging the first region enlarges its sumset with a fixed displacement region.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma regionSumset_mono_left {Λ Γ : Finset ℤ} (𝓝 : Finset ℤ) (h : Λ ⊆ Γ) :
+    regionSumset Λ 𝓝 ⊆ regionSumset Γ 𝓝 :=
+  Finset.add_subset_add_right h
+
+/-- Enlarging the displacement region enlarges the sumset with a fixed first region.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma regionSumset_mono_right (Λ : Finset ℤ) {𝓝 𝓜 : Finset ℤ} (h : 𝓝 ⊆ 𝓜) :
+    regionSumset Λ 𝓝 ⊆ regionSumset Λ 𝓜 :=
+  Finset.add_subset_add_left h
+
+/-- The sumset with an empty first region is empty.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma regionSumset_empty_left (𝓝 : Finset ℤ) : regionSumset ∅ 𝓝 = ∅ := by
+  exact Finset.empty_add 𝓝
+
+/-- The sumset with an empty displacement region is empty.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma regionSumset_empty_right (Λ : Finset ℤ) : regionSumset Λ ∅ = ∅ := by
+  exact Finset.add_empty Λ
+
+/-- The singleton zero region is a left identity for finite-region sumsets.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+@[simp]
+lemma regionSumset_zero_left (𝓝 : Finset ℤ) : regionSumset {0} 𝓝 = 𝓝 := by
+  change (0 : Finset ℤ) + 𝓝 = 𝓝
+  exact zero_add 𝓝
+
+/-- The singleton zero region is a right identity for finite-region sumsets.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma regionSumset_zero_right (Λ : Finset ℤ) : regionSumset Λ {0} = Λ := by
+  change Λ + (0 : Finset ℤ) = Λ
+  exact add_zero Λ
+
+/-- Translating the first region translates its sumset by the same displacement.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma regionSumset_translateRegion_left (a : ℤ) (Λ 𝓝 : Finset ℤ) :
+    regionSumset (translateRegion a Λ) 𝓝 = translateRegion a (regionSumset Λ 𝓝) := by
+  rw [← regionSumset_singleton_right, ← regionSumset_singleton_right]
+  change (Λ + {a}) + 𝓝 = (Λ + 𝓝) + {a}
+  ac_rfl
+
+/-- Translating the displacement region translates the sumset by the same displacement.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma regionSumset_translateRegion_right (a : ℤ) (Λ 𝓝 : Finset ℤ) :
+    regionSumset Λ (translateRegion a 𝓝) = translateRegion a (regionSumset Λ 𝓝) := by
+  rw [← regionSumset_singleton_right, ← regionSumset_singleton_right]
+  change Λ + (𝓝 + {a}) = (Λ + 𝓝) + {a}
+  ac_rfl
+
+/-- Finite-region sumsets are associative.
+
+This law supports composition of finite-propagation bounds.
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma regionSumset_assoc (Λ 𝓝 𝓜 : Finset ℤ) :
+    regionSumset (regionSumset Λ 𝓝) 𝓜 = regionSumset Λ (regionSumset 𝓝 𝓜) :=
+  add_assoc Λ 𝓝 𝓜
+
+end SpinChain

--- a/TNLean/QCA/RegionSumset.lean
+++ b/TNLean/QCA/RegionSumset.lean
@@ -50,8 +50,8 @@ abbrev regionSumset (Λ 𝓝 : Finset ℤ) : Finset ℤ :=
 
 Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
 lemma mem_regionSumset (i : ℤ) (Λ 𝓝 : Finset ℤ) :
-    i ∈ regionSumset Λ 𝓝 ↔ ∃ j ∈ Λ, ∃ a ∈ 𝓝, j + a = i := by
-  exact Finset.mem_add
+    i ∈ regionSumset Λ 𝓝 ↔ ∃ j ∈ Λ, ∃ a ∈ 𝓝, j + a = i :=
+  Finset.mem_add
 
 /-- Adding the singleton displacement region \(\{a\}\) agrees with translation by \(a\).
 
@@ -75,8 +75,8 @@ lemma regionSumset_singleton_right (Λ : Finset ℤ) (a : ℤ) :
 
 Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
 lemma regionSumset_mono {Λ Γ 𝓝 𝓜 : Finset ℤ} (hΛ : Λ ⊆ Γ) (h𝓝 : 𝓝 ⊆ 𝓜) :
-    regionSumset Λ 𝓝 ⊆ regionSumset Γ 𝓜 := by
-  exact Finset.add_subset_add hΛ h𝓝
+    regionSumset Λ 𝓝 ⊆ regionSumset Γ 𝓜 :=
+  Finset.add_subset_add hΛ h𝓝
 
 /-- Enlarging the first region enlarges its sumset with a fixed displacement region.
 
@@ -95,14 +95,14 @@ lemma regionSumset_mono_right (Λ : Finset ℤ) {𝓝 𝓜 : Finset ℤ} (h : �
 /-- The sumset with an empty first region is empty.
 
 Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
-lemma regionSumset_empty_left (𝓝 : Finset ℤ) : regionSumset ∅ 𝓝 = ∅ := by
-  exact Finset.empty_add 𝓝
+lemma regionSumset_empty_left (𝓝 : Finset ℤ) : regionSumset ∅ 𝓝 = ∅ :=
+  Finset.empty_add 𝓝
 
 /-- The sumset with an empty displacement region is empty.
 
 Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
-lemma regionSumset_empty_right (Λ : Finset ℤ) : regionSumset Λ ∅ = ∅ := by
-  exact Finset.add_empty Λ
+lemma regionSumset_empty_right (Λ : Finset ℤ) : regionSumset Λ ∅ = ∅ :=
+  Finset.add_empty Λ
 
 /-- The singleton zero region is a left identity for finite-region sumsets.
 
@@ -115,6 +115,7 @@ lemma regionSumset_zero_left (𝓝 : Finset ℤ) : regionSumset {0} 𝓝 = 𝓝 
 /-- The singleton zero region is a right identity for finite-region sumsets.
 
 Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+@[simp]
 lemma regionSumset_zero_right (Λ : Finset ℤ) : regionSumset Λ {0} = Λ := by
   change Λ + (0 : Finset ℤ) = Λ
   exact add_zero Λ

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7667,9 +7667,14 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \begin{align}
     \Lambda+\{a\}&=\Lambda+a.
   \end{align}
-  Translating either argument by $a$ translates the resulting sumset by $a$.
-  Sumsets are associative, as needed to compose propagation bounds. This is
-  the finite region $\Lambda+\mathcal N$ in the propagation condition
+  Translation commutes with either argument, and sumsets are associative:
+  \begin{align}
+    (\Lambda+a)+\mathcal N&=(\Lambda+\mathcal N)+a, \\
+    \Lambda+(\mathcal N+a)&=(\Lambda+\mathcal N)+a, \\
+    (\Lambda+\mathcal N)+\mathcal M&=\Lambda+(\mathcal N+\mathcal M).
+  \end{align}
+  These identities support composition of propagation bounds. This is the
+  finite region $\Lambda+\mathcal N$ in the propagation condition
   of the QCA appendix of \cite{Cirac2017MPU}.
 \end{definition}
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7642,6 +7642,37 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   $\Lambda\subseteq\Gamma$, then $\Lambda+a\subseteq\Gamma+a$.
 \end{definition}
 
+\begin{definition}[Sumset of finite regions]
+  \label{def:qca_region_sumset}
+  \lean{SpinChain.regionSumset,SpinChain.mem_regionSumset,
+    SpinChain.regionSumset_singleton_right,SpinChain.regionSumset_mono,
+    SpinChain.regionSumset_mono_left,SpinChain.regionSumset_mono_right,
+    SpinChain.regionSumset_empty_left,SpinChain.regionSumset_empty_right,
+    SpinChain.regionSumset_zero_left,SpinChain.regionSumset_zero_right,
+    SpinChain.regionSumset_translateRegion_left,
+    SpinChain.regionSumset_translateRegion_right,
+    SpinChain.regionSumset_assoc}
+  \leanok
+  \uses{def:qca_translate_region}
+  For finite regions $\Lambda,\mathcal N\subset\mathbb Z$, define their
+  sumset by
+  \begin{align}
+    \Lambda+\mathcal N
+      &=\{i+a\mid i\in\Lambda,\ a\in\mathcal N\}.
+  \end{align}
+  Hence $j\in\Lambda+\mathcal N$ exactly when $j=i+a$ for some
+  $i\in\Lambda$ and $a\in\mathcal N$. The sumset is monotone in both
+  arguments, either empty argument gives the empty region, and the singleton
+  $\{0\}$ is an identity. A singleton displacement recovers translation,
+  \begin{align}
+    \Lambda+\{a\}&=\Lambda+a.
+  \end{align}
+  Translating either argument by $a$ translates the resulting sumset by $a$.
+  Sumsets are associative, as needed to compose propagation bounds. This is
+  the finite region $\Lambda+\mathcal N$ in the propagation condition
+  of the QCA appendix of \cite{Cirac2017MPU}.
+\end{definition}
+
 \begin{definition}[Translation of sites and configurations]
   \label{def:qca_finite_configuration_translation}
   \lean{SpinChain.siteTranslation,SpinChain.siteTranslation_apply_val,


### PR DESCRIPTION
## Summary

- expose the paper's finite region sumset `Λ + 𝓝` as a source-facing abbreviation of Mathlib pointwise `Finset` addition
- add membership, singleton-translation, monotonicity, empty/zero, translation-interaction, and associativity laws
- document the region algebra required by finite propagation in Chapter 28

This is region-level infrastructure only; it adds no propagation predicate, quasi-local map, inverse-locality theorem, blocking, or periodic-chain claim.

## Source

- `Papers/1703.09188/paper_v2.tex`, Appendix line 2298
- Schumacher–Werner, quant-ph/0405174, Definition 1

## Validation

- direct Lean compilation of `TNLean/QCA/RegionSumset.lean`
- focused QCA module and aggregate checks completed before publication
- generated imports current
- blueprint synchronization and reverse declaration coverage pass
- reader-facing prose, integrity/no-bypass, and `git diff --check` pass
- independent Mathlib-style review removed duplicate wrappers and added the associativity law needed for downstream composition

Closes #6474
