### PR TITLE
feat(QCA): expose finite translation isometry

### DIFF
--- a/TNLean/QCA/AlgebraicTranslation.lean
+++ b/TNLean/QCA/AlgebraicTranslation.lean
@@ -306,8 +306,7 @@ lemma norm_algebraicLocalTranslation (d : ℕ) [NeZero d] (a : ℤ)
     ‖algebraicLocalTranslation d a A‖ = ‖A‖ := by
   induction A using DirectLimit.induction with
   | _ Λ A =>
-      change ‖localTranslation d a Λ A‖ = ‖A‖
-      exact StarAlgEquiv.norm_map (localTranslation d a Λ) A
+      exact localTranslation_norm d a Λ A
 
 /-- Algebraic-local translation is an operator-norm isometry.
 

--- a/TNLean/QCA/Translation.lean
+++ b/TNLean/QCA/Translation.lean
@@ -28,6 +28,8 @@ quasi-local observables, finite propagation, or quantum cellular automata.
 
 * `SpinChain.translateRegion_zero` — translation by zero fixes a region.
 * `SpinChain.translateRegion_add` — successive region translations add their displacements.
+* `SpinChain.localTranslation_norm` — finite-region translations preserve the operator norm.
+* `SpinChain.localTranslation_isometry` — finite-region translations are operator-norm isometries.
 * `SpinChain.localTranslation_localInclusion` — finite-region translations commute with canonical
   local inclusions.
 
@@ -210,6 +212,24 @@ lemma localTranslation_apply (d : ℕ) (a : ℤ) (Λ : Finset ℤ)
     (A : LocalAlgebra d Λ) (x y : Config d (translateRegion a Λ)) :
     localTranslation d a Λ A x y =
       A ((Config.translation d a Λ).symm x) ((Config.translation d a Λ).symm y) := rfl
+
+open scoped ComplexOrder in
+/-- Finite-region translation preserves the C⋆ operator norm.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the quasi-local algebra
+and its lattice translation. -/
+lemma localTranslation_norm (d : ℕ) (a : ℤ) (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    ‖localTranslation d a Λ A‖ = ‖A‖ := by
+  exact StarAlgEquiv.norm_map (localTranslation d a Λ) A
+
+open scoped ComplexOrder in
+/-- Finite-region translation is an operator-norm isometry.
+
+Context: arXiv:1703.09188, Appendix, lines 2292--2298, which introduce the quasi-local algebra
+and its lattice translation. -/
+lemma localTranslation_isometry (d : ℕ) (a : ℤ) (Λ : Finset ℤ) :
+    Isometry (localTranslation d a Λ) := by
+  exact StarAlgEquiv.isometry (localTranslation d a Λ)
 
 /-- A translated local observable evaluated on translated configurations has its original matrix
 entry.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7712,6 +7712,27 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   translation $i\mapsto i+a$.
 \end{definition}
 
+\begin{lemma}[Norm preservation of finite-region translation]
+  \label{lem:qca_finite_local_translation_norm}
+  \lean{SpinChain.localTranslation_norm,
+    SpinChain.localTranslation_isometry}
+  \leanok
+  \uses{def:qca_finite_local_translation}
+  Let $d$ be a nonnegative integer, let $\Lambda\subset\mathbb Z$ be finite,
+  and let $a\in\mathbb Z$. For every $A\in\mathcal A_\Lambda$,
+  \begin{align}
+    \lVert\tau_{a,\Lambda}(A)\rVert&=\lVert A\rVert.
+  \end{align}
+  Consequently, $\tau_{a,\Lambda}$ is an isometry from
+  $\mathcal A_\Lambda$ onto $\mathcal A_{\Lambda+a}$.
+\end{lemma}
+
+\begin{proof}\leanok
+  Translation bijectively relabels the configuration basis. The resulting
+  star-algebra equivalence between the two finite matrix algebras preserves
+  the operator norm, and hence preserves distances.
+\end{proof}
+
 \begin{lemma}[Finite-region translation action laws]
   \label{lem:qca_finite_translation_action}
   \lean{SpinChain.siteTranslation_zero,SpinChain.siteTranslation_add,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7728,9 +7728,16 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{lemma}
 
 \begin{proof}\leanok
+  \uses{def:qca_finite_local_translation}
   Translation bijectively relabels the configuration basis. The resulting
   star-algebra equivalence between the two finite matrix algebras preserves
-  the operator norm, and hence preserves distances.
+  the operator norm. Applying this identity to $A-B$ and using linearity gives
+  \begin{align}
+    \lVert\tau_{a,\Lambda}(A)-\tau_{a,\Lambda}(B)\rVert
+      &=\lVert\tau_{a,\Lambda}(A-B)\rVert
+       =\lVert A-B\rVert,
+  \end{align}
+  so distances are preserved.
 \end{proof}
 
 \begin{lemma}[Finite-region translation action laws]
@@ -8179,8 +8186,8 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{proof}\leanok
   \uses{def:qca_algebraic_local_operator_norm,
-    def:qca_finite_local_translation,
     def:qca_algebraic_local_translation,
+    lem:qca_finite_local_translation_norm,
     thm:qca_local_observable_finite_support}
   Choose $A_\Lambda\in\mathcal A_\Lambda$ with
   $A=\iota_\Lambda(A_\Lambda)$. Finite-region translation is a star-algebra


### PR DESCRIPTION
## Summary

- add named finite-region norm preservation and isometry theorems for `localTranslation`
- keep the result valid for every `d : ℕ`; no unnecessary positivity hypothesis
- reuse the named finite theorem in the algebraic-local norm proof
- add the exact finite-region statement and proof to Chapter 28

## Source context

- `Papers/1703.09188/paper_v2.tex`, Appendix lines 2292–2298
- Schumacher–Werner, quant-ph/0405174, Definition 1

The cited passage supplies the local-algebra/translation context; norm preservation itself follows canonically because finite translation is a star-algebra equivalence of matrix algebras.

## Validation

- direct Lean compilation of both changed Lean files
- focused Translation, AlgebraicTranslation, and QCA aggregate checks completed before publication
- blueprint synchronization: Chapter 28 530/530 with reverse coverage for both declarations
- project style lint and declaration lints found no new issue
- integrity/no-bypass, line-length, prose, and `git diff --check` pass

Closes #6475
