### PR TITLE
feat(MPDO): separate source and normalized simplicity

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -276,6 +276,7 @@ import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCapstone
 import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPViaTS
 import TNLean.MPS.MPDO.RescalingStableNotSimple
+import TNLean.MPS.MPDO.RescalingStableSourceSimple
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SALArbitraryCut
 import TNLean.MPS.MPDO.SALPhysicalSectorCyclicPositivity

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -293,6 +293,7 @@ import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.SimpleTensor
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPDO.SourceBNTBlocking
+import TNLean.MPS.MPDO.SourceSimpleTensor
 import TNLean.MPS.MPDO.SourceZCLMarginal
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.StrongRFP

--- a/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.Core.BlockingTransfer
-import TNLean.MPS.MPDO.SourceSimpleTensor
+import TNLean.MPS.MPDO.RescalingStableSourceSimple
 import TNLean.MPS.RFP.BNTOrthogonality
 
 /-!

--- a/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableNotSimple.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.Core.BlockingTransfer
-import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
+import TNLean.MPS.MPDO.SourceSimpleTensor
 import TNLean.MPS.RFP.BNTOrthogonality
 
 /-!
@@ -27,7 +27,10 @@ No vertical coefficient comparison is used.
   transfer scalar is $(337/512)^L$.
 * `blockTensor_R_not_isHorizontalCF` — no positive blocking admits a normalized
   BNT horizontal canonical form.
-* `R_not_isSimple` — the dimer tensor is not simple.
+* `R_not_isSimple` — the dimer tensor is not simple for the normalized
+  fixed-representative predicate.
+* `R_isSourceSimple_and_not_isSimple` — the normalization-free Definition 4.7
+  verdict and normalized fixed-representative verdict stated side by side.
 
 The obstruction combines the source normalization at arXiv:1606.00608, line
 246 with the positive blocking in the definition of simplicity at lines
@@ -133,5 +136,18 @@ theorem R_not_isSimple : ¬ MPOTensor.IsSimple R := by
   intro hSimple
   obtain ⟨_hMPDO, L, hL, hCanonical⟩ := hSimple
   exact blockTensor_R_not_isHorizontalCF L hL hCanonical.isHorizontalCF
+
+/-- The dimer tensor receives opposite verdicts from the two simplicity
+interfaces: it satisfies normalization-free Definition 4.7 simplicity, while it
+fails the normalized fixed-representative predicate `MPOTensor.IsSimple`.
+
+The first verdict uses the existential one-site BNT witness and does not assert
+simplicity at every positive blocking. The second is the line-246 normalization
+obstruction proved by `R_not_isSimple`.
+
+Source: arXiv:1606.00608, line 246 and Definition 4.7, lines 815--822. -/
+theorem R_isSourceSimple_and_not_isSimple :
+    MPOTensor.IsSourceSimple R ∧ ¬ MPOTensor.IsSimple R :=
+  ⟨R_isSourceSimple, R_not_isSimple⟩
 
 end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/RescalingStableSourceSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableSourceSimple.lean
@@ -88,11 +88,11 @@ the normalized fixed-representative predicate `MPOTensor.IsSimple`.
 
 Source: arXiv:1606.00608, Definition 4.7, lines 815--822. -/
 theorem R_isSourceSimple : MPOTensor.IsSourceSimple R := by
-  have hRne : R ≠ 0 := by
-    intro hR
-    apply physTraceTransfer_R_not_isNilpotent
-    rw [hR]
-    exact IsNilpotent.zero
+  have hRne : ∀ N : ℕ, 0 < N → MPOTensor.mpo R N ≠ 0 := by
+    intro N hN hzero
+    have hentry := congrFun (congrFun hzero (fun _ => 0)) (fun _ => 0)
+    rw [mpo_R_entry_formula hN] at hentry
+    simp [chainIndicator, ChainOK, φ, wN, wMat, bit1, bit2] at hentry
   refine ⟨R_isMPDO, hRne, 1, by norm_num, ?_⟩
   let data := canonicalFormData.reindexPhysical oneSiteDoubledEquiv
   let ref := data.activeBNTRefinement

--- a/TNLean/MPS/MPDO/RescalingStableSourceSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableSourceSimple.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.ActiveBNTRefinement
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
+import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
+import TNLean.MPS.MPDO.SourceSimpleTensor
+
+/-!
+# Normalization-free Definition 4.7 simplicity of the dimer tensor
+
+The rescaling-stable dimer tensor is simple in the normalization-free,
+source-facing sense of arXiv:1606.00608, Definition 4.7. The witness uses
+blocking length one and the active BNT refinement of the tensor's literal CPSV
+canonical form. Its retained block has nonnilpotent ket-against-bra contraction.
+
+## Main results
+
+* `toMPSTensor_blockTensor_R_one`: one-site blocking is the canonical physical
+  relabeling of the doubled tensor.
+* `R_isSourceSimple`: the dimer satisfies normalization-free Definition 4.7
+  simplicity.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.7, lines 815--822
+-/
+
+open scoped Matrix BigOperators
+
+noncomputable section
+
+namespace MPOTensor.RescalingStableLengthDependentRFP
+
+/-- The canonical relabeling from the doubled physical alphabet after one-site
+blocking to the original doubled physical alphabet. -/
+def oneSiteDoubledEquiv :
+    Fin (MPSTensor.blockPhysDim 4 1 * MPSTensor.blockPhysDim 4 1) ≃ Fin (4 * 4) :=
+  finProdFinEquiv.symm |>.trans
+    (Equiv.prodCongr (MPSTensor.singleBlockEquiv 4) (MPSTensor.singleBlockEquiv 4)) |>.trans
+      finProdFinEquiv
+
+@[simp]
+lemma oneSiteDoubledEquiv_diagonal (i : Fin (MPSTensor.blockPhysDim 4 1)) :
+    oneSiteDoubledEquiv (finProdFinEquiv (i, i)) =
+      finProdFinEquiv
+        (MPSTensor.singleBlockEquiv 4 i, MPSTensor.singleBlockEquiv 4 i) := by
+  simp [oneSiteDoubledEquiv]
+
+/-- One-site physical blocking of the dimer gives the canonical physical
+relabeling of its doubled-index tensor. -/
+theorem toMPSTensor_blockTensor_R_one :
+    (MPOTensor.blockTensor R 1).toMPSTensor =
+      MPSTensor.reindexPhysical oneSiteDoubledEquiv R.toMPSTensor := by
+  funext ij
+  simp [MPSTensor.reindexPhysical, MPOTensor.toMPSTensor,
+    MPOTensor.blockTensor_apply, MPSTensor.wordOfBlock_one,
+    MPOTensor.evalWord, oneSiteDoubledEquiv]
+  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+
+/-- The ket-against-bra contraction of `retainedBlock` is unchanged by the
+one-site doubled physical relabeling. -/
+lemma doubledPhysTraceTransfer_reindexPhysical_oneSiteDoubledEquiv :
+    MPOTensor.doubledPhysTraceTransfer 4
+        (MPSTensor.reindexPhysical oneSiteDoubledEquiv retainedBlock) =
+      MPOTensor.doubledPhysTraceTransfer 4 retainedBlock := by
+  rw [MPOTensor.doubledPhysTraceTransfer, MPOTensor.doubledPhysTraceTransfer]
+  change (∑ i : Fin (MPSTensor.blockPhysDim 4 1),
+      retainedBlock (finProdFinEquiv
+        (MPSTensor.singleBlockEquiv 4 i, MPSTensor.singleBlockEquiv 4 i))) =
+    ∑ i : Fin 4, retainedBlock (finProdFinEquiv (i, i))
+  exact (MPSTensor.singleBlockEquiv 4).sum_comp
+    (fun i : Fin 4 => retainedBlock (finProdFinEquiv (i, i)))
+
+/-- The rescaling-stable dimer tensor is simple in the normalization-free,
+source-facing sense of Definition 4.7.
+
+The positive blocking length is $L=1$. The BNT is the representative family
+supplied by the active refinement of `canonicalFormData`; its only retained
+normal block is `retainedBlock`, whose doubled physical-trace transfer is
+nonnilpotent.
+
+This theorem neither asserts simplicity for every positive blocking nor changes
+the normalized fixed-representative predicate `MPOTensor.IsSimple`.
+
+Source: arXiv:1606.00608, Definition 4.7, lines 815--822. -/
+theorem R_isSourceSimple : MPOTensor.IsSourceSimple R := by
+  have hRne : R ≠ 0 := by
+    intro hR
+    apply physTraceTransfer_R_not_isNilpotent
+    rw [hR]
+    exact IsNilpotent.zero
+  refine ⟨R_isMPDO, hRne, 1, by norm_num, ?_⟩
+  let data := canonicalFormData.reindexPhysical oneSiteDoubledEquiv
+  let ref := data.activeBNTRefinement
+  refine ⟨data.activePhaseClasses.g,
+    fun j => ⟨data.dim (data.activeRepresentativeIndex j),
+      data.blocks (data.activeRepresentativeIndex j)⟩, ?_, ?_⟩
+  · rw [toMPSTensor_blockTensor_R_one]
+    exact ref.representativesBNT
+  · intro j
+    change ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer 4
+      (MPSTensor.reindexPhysical oneSiteDoubledEquiv retainedBlock))
+    rw [doubledPhysTraceTransfer_reindexPhysical_oneSiteDoubledEquiv]
+    exact doubledPhysTraceTransfer_retainedBlock_not_isNilpotent
+
+end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/SourceSimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SourceSimpleTensor.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.MPDO.SimpleTensor
 
 /-!

--- a/TNLean/MPS/MPDO/SourceSimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SourceSimpleTensor.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.ActiveBNTRefinement
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
+import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
+
+/-!
+# Normalization-free Definition 4.7 simplicity
+
+This module records the source-facing simplicity condition of arXiv:1606.00608,
+Definition 4.7. After a positive physical blocking, the doubled-index tensor must
+admit a CPSV basis of normal tensors, and the ket-against-bra contraction of every
+basis element must be nonnilpotent. The interface includes the condition that the
+tensor generates MPDOs, but deliberately excludes the separate line-246
+unit-weight normalization.
+
+## Main results
+
+* `MPOTensor.IsSourceSimple`: normalization-free Definition 4.7 simplicity.
+* `MPOTensor.RescalingStableLengthDependentRFP.toMPSTensor_blockTensor_R_one`:
+  one-site blocking is the canonical physical relabeling of the doubled tensor.
+* `MPOTensor.RescalingStableLengthDependentRFP.R_isSourceSimple`: the dimer is
+  simple in the normalization-free Definition 4.7 sense, witnessed at blocking
+  length one by the active BNT refinement of its literal canonical form.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Definition 4.7, lines 815--822
+-/
+
+open scoped Matrix BigOperators
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- **Normalization-free Definition 4.7 simplicity.** A tensor generating MPDOs
+is source-simple when, after some positive physical blocking, its doubled-index
+tensor has a CPSV basis of normal tensors and no basis element has nilpotent
+ket-against-bra contraction.
+
+The witness uses `MPSTensor.IsCPSVBasisOfNormalTensors`, rather than an arbitrary
+family of canonical blocks. It does not impose the line-246 unit-weight
+normalization and makes no claim that every positive blocking has such a witness.
+
+Source: arXiv:1606.00608, Definition 4.7, lines 815--822. -/
+def IsSourceSimple (M : MPOTensor d D) : Prop :=
+  IsMPDO M ∧
+    ∃ L : ℕ, 0 < L ∧
+      ∃ g : ℕ,
+        ∃ blocks : (j : Fin g) →
+            Σ D' : ℕ, MPSTensor
+              (MPSTensor.blockPhysDim d L * MPSTensor.blockPhysDim d L) D',
+          MPSTensor.IsCPSVBasisOfNormalTensors (blockTensor M L).toMPSTensor blocks ∧
+            ∀ j, ¬ IsNilpotent
+              (doubledPhysTraceTransfer (MPSTensor.blockPhysDim d L) (blocks j).2)
+
+end MPOTensor
+
+namespace MPOTensor.RescalingStableLengthDependentRFP
+
+/-- The canonical relabeling from the doubled physical alphabet after one-site
+blocking to the original doubled physical alphabet. -/
+noncomputable def oneSiteDoubledEquiv :
+    Fin (MPSTensor.blockPhysDim 4 1 * MPSTensor.blockPhysDim 4 1) ≃ Fin (4 * 4) :=
+  finProdFinEquiv.symm |>.trans
+    (Equiv.prodCongr (MPSTensor.singleBlockEquiv 4) (MPSTensor.singleBlockEquiv 4)) |>.trans
+      finProdFinEquiv
+
+@[simp]
+lemma oneSiteDoubledEquiv_diagonal (i : Fin (MPSTensor.blockPhysDim 4 1)) :
+    oneSiteDoubledEquiv (finProdFinEquiv (i, i)) =
+      finProdFinEquiv
+        (MPSTensor.singleBlockEquiv 4 i, MPSTensor.singleBlockEquiv 4 i) := by
+  simp [oneSiteDoubledEquiv]
+
+/-- One-site physical blocking of the dimer gives the canonical physical
+relabeling of its doubled-index tensor. -/
+theorem toMPSTensor_blockTensor_R_one :
+    (MPOTensor.blockTensor R 1).toMPSTensor =
+      MPSTensor.reindexPhysical oneSiteDoubledEquiv R.toMPSTensor := by
+  funext ij
+  simp [MPSTensor.reindexPhysical, MPOTensor.toMPSTensor,
+    MPOTensor.blockTensor_apply, MPSTensor.wordOfBlock_one,
+    MPOTensor.evalWord, oneSiteDoubledEquiv]
+  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
+
+/-- The ket-against-bra contraction of `retainedBlock` is unchanged by the
+one-site doubled physical relabeling. -/
+lemma doubledPhysTraceTransfer_reindexPhysical_oneSiteDoubledEquiv :
+    MPOTensor.doubledPhysTraceTransfer 4
+        (MPSTensor.reindexPhysical oneSiteDoubledEquiv retainedBlock) =
+      MPOTensor.doubledPhysTraceTransfer 4 retainedBlock := by
+  rw [MPOTensor.doubledPhysTraceTransfer, MPOTensor.doubledPhysTraceTransfer]
+  change (∑ i : Fin (MPSTensor.blockPhysDim 4 1),
+      retainedBlock (finProdFinEquiv
+        (MPSTensor.singleBlockEquiv 4 i, MPSTensor.singleBlockEquiv 4 i))) =
+    ∑ i : Fin 4, retainedBlock (finProdFinEquiv (i, i))
+  exact (MPSTensor.singleBlockEquiv 4).sum_comp
+    (fun i : Fin 4 => retainedBlock (finProdFinEquiv (i, i)))
+
+/-- The rescaling-stable dimer tensor is simple in the normalization-free,
+source-facing sense of Definition 4.7.
+
+The positive blocking length is $L=1$. The BNT is the representative family
+supplied by the active refinement of `canonicalFormData`; its only retained
+normal block is `retainedBlock`, whose doubled physical-trace transfer is
+nonnilpotent.
+
+This theorem neither asserts simplicity for every positive blocking nor changes
+the normalized fixed-representative predicate `MPOTensor.IsSimple`.
+
+Source: arXiv:1606.00608, Definition 4.7, lines 815--822. -/
+theorem R_isSourceSimple : MPOTensor.IsSourceSimple R := by
+  refine ⟨R_isMPDO, 1, by norm_num, ?_⟩
+  let data := canonicalFormData.reindexPhysical oneSiteDoubledEquiv
+  let ref := data.activeBNTRefinement
+  refine ⟨data.activePhaseClasses.g,
+    fun j => ⟨data.dim (data.activeRepresentativeIndex j),
+      data.blocks (data.activeRepresentativeIndex j)⟩, ?_, ?_⟩
+  · rw [toMPSTensor_blockTensor_R_one]
+    exact ref.representativesBNT
+  · intro j
+    change ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer 4
+      (MPSTensor.reindexPhysical oneSiteDoubledEquiv retainedBlock))
+    rw [doubledPhysTraceTransfer_reindexPhysical_oneSiteDoubledEquiv]
+    exact doubledPhysTraceTransfer_retainedBlock_not_isNilpotent
+
+end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/SourceSimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SourceSimpleTensor.lean
@@ -3,9 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.CanonicalForm.ActiveBNTRefinement
-import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
-import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
+import TNLean.MPS.MPDO.SimpleTensor
 
 /-!
 # Normalization-free Definition 4.7 simplicity
@@ -13,18 +11,13 @@ import TNLean.MPS.MPDO.RescalingStableLengthDependentRFPCanonicalForm
 This module records the source-facing simplicity condition of arXiv:1606.00608,
 Definition 4.7. After a positive physical blocking, the doubled-index tensor must
 admit a CPSV basis of normal tensors, and the ket-against-bra contraction of every
-basis element must be nonnilpotent. The interface includes the condition that the
-tensor generates MPDOs, but deliberately excludes the separate line-246
-unit-weight normalization.
+basis element must be nonnilpotent. The interface requires a nonzero tensor that
+generates MPDOs, but deliberately excludes the separate line-246 unit-weight
+normalization.
 
-## Main results
+## Main result
 
 * `MPOTensor.IsSourceSimple`: normalization-free Definition 4.7 simplicity.
-* `MPOTensor.RescalingStableLengthDependentRFP.toMPSTensor_blockTensor_R_one`:
-  one-site blocking is the canonical physical relabeling of the doubled tensor.
-* `MPOTensor.RescalingStableLengthDependentRFP.R_isSourceSimple`: the dimer is
-  simple in the normalization-free Definition 4.7 sense, witnessed at blocking
-  length one by the active BNT refinement of its literal canonical form.
 
 ## References
 
@@ -32,26 +25,25 @@ unit-weight normalization.
   Definition 4.7, lines 815--822
 -/
 
-open scoped Matrix BigOperators
-
-noncomputable section
-
 namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- **Normalization-free Definition 4.7 simplicity.** A tensor generating MPDOs
-is source-simple when, after some positive physical blocking, its doubled-index
-tensor has a CPSV basis of normal tensors and no basis element has nilpotent
-ket-against-bra contraction.
+/-- **Normalization-free Definition 4.7 simplicity.** A nonzero tensor
+generating MPDOs is source-simple when, after some positive physical blocking,
+its doubled-index tensor has a CPSV basis of normal tensors and no basis element
+has nilpotent ket-against-bra contraction.
 
-The witness uses `MPSTensor.IsCPSVBasisOfNormalTensors`, rather than an arbitrary
-family of canonical blocks. It does not impose the line-246 unit-weight
-normalization and makes no claim that every positive blocking has such a witness.
+The nonzero condition records the source boundary that the tensor generates a
+nontrivial density-operator family; in particular, the zero MPO tensor is not
+simple. The BNT witness uses `MPSTensor.IsCPSVBasisOfNormalTensors`, rather than
+an arbitrary family of canonical blocks. It does not impose the line-246
+unit-weight normalization and makes no claim that every positive blocking has
+such a witness.
 
 Source: arXiv:1606.00608, Definition 4.7, lines 815--822. -/
 def IsSourceSimple (M : MPOTensor d D) : Prop :=
-  IsMPDO M ∧
+  IsMPDO M ∧ M ≠ 0 ∧
     ∃ L : ℕ, 0 < L ∧
       ∃ g : ℕ,
         ∃ blocks : (j : Fin g) →
@@ -62,74 +54,3 @@ def IsSourceSimple (M : MPOTensor d D) : Prop :=
               (doubledPhysTraceTransfer (MPSTensor.blockPhysDim d L) (blocks j).2)
 
 end MPOTensor
-
-namespace MPOTensor.RescalingStableLengthDependentRFP
-
-/-- The canonical relabeling from the doubled physical alphabet after one-site
-blocking to the original doubled physical alphabet. -/
-noncomputable def oneSiteDoubledEquiv :
-    Fin (MPSTensor.blockPhysDim 4 1 * MPSTensor.blockPhysDim 4 1) ≃ Fin (4 * 4) :=
-  finProdFinEquiv.symm |>.trans
-    (Equiv.prodCongr (MPSTensor.singleBlockEquiv 4) (MPSTensor.singleBlockEquiv 4)) |>.trans
-      finProdFinEquiv
-
-@[simp]
-lemma oneSiteDoubledEquiv_diagonal (i : Fin (MPSTensor.blockPhysDim 4 1)) :
-    oneSiteDoubledEquiv (finProdFinEquiv (i, i)) =
-      finProdFinEquiv
-        (MPSTensor.singleBlockEquiv 4 i, MPSTensor.singleBlockEquiv 4 i) := by
-  simp [oneSiteDoubledEquiv]
-
-/-- One-site physical blocking of the dimer gives the canonical physical
-relabeling of its doubled-index tensor. -/
-theorem toMPSTensor_blockTensor_R_one :
-    (MPOTensor.blockTensor R 1).toMPSTensor =
-      MPSTensor.reindexPhysical oneSiteDoubledEquiv R.toMPSTensor := by
-  funext ij
-  simp [MPSTensor.reindexPhysical, MPOTensor.toMPSTensor,
-    MPOTensor.blockTensor_apply, MPSTensor.wordOfBlock_one,
-    MPOTensor.evalWord, oneSiteDoubledEquiv]
-  rw [MPSTensor.finProdFinEquiv_divNat, MPSTensor.finProdFinEquiv_modNat]
-
-/-- The ket-against-bra contraction of `retainedBlock` is unchanged by the
-one-site doubled physical relabeling. -/
-lemma doubledPhysTraceTransfer_reindexPhysical_oneSiteDoubledEquiv :
-    MPOTensor.doubledPhysTraceTransfer 4
-        (MPSTensor.reindexPhysical oneSiteDoubledEquiv retainedBlock) =
-      MPOTensor.doubledPhysTraceTransfer 4 retainedBlock := by
-  rw [MPOTensor.doubledPhysTraceTransfer, MPOTensor.doubledPhysTraceTransfer]
-  change (∑ i : Fin (MPSTensor.blockPhysDim 4 1),
-      retainedBlock (finProdFinEquiv
-        (MPSTensor.singleBlockEquiv 4 i, MPSTensor.singleBlockEquiv 4 i))) =
-    ∑ i : Fin 4, retainedBlock (finProdFinEquiv (i, i))
-  exact (MPSTensor.singleBlockEquiv 4).sum_comp
-    (fun i : Fin 4 => retainedBlock (finProdFinEquiv (i, i)))
-
-/-- The rescaling-stable dimer tensor is simple in the normalization-free,
-source-facing sense of Definition 4.7.
-
-The positive blocking length is $L=1$. The BNT is the representative family
-supplied by the active refinement of `canonicalFormData`; its only retained
-normal block is `retainedBlock`, whose doubled physical-trace transfer is
-nonnilpotent.
-
-This theorem neither asserts simplicity for every positive blocking nor changes
-the normalized fixed-representative predicate `MPOTensor.IsSimple`.
-
-Source: arXiv:1606.00608, Definition 4.7, lines 815--822. -/
-theorem R_isSourceSimple : MPOTensor.IsSourceSimple R := by
-  refine ⟨R_isMPDO, 1, by norm_num, ?_⟩
-  let data := canonicalFormData.reindexPhysical oneSiteDoubledEquiv
-  let ref := data.activeBNTRefinement
-  refine ⟨data.activePhaseClasses.g,
-    fun j => ⟨data.dim (data.activeRepresentativeIndex j),
-      data.blocks (data.activeRepresentativeIndex j)⟩, ?_, ?_⟩
-  · rw [toMPSTensor_blockTensor_R_one]
-    exact ref.representativesBNT
-  · intro j
-    change ¬ IsNilpotent (MPOTensor.doubledPhysTraceTransfer 4
-      (MPSTensor.reindexPhysical oneSiteDoubledEquiv retainedBlock))
-    rw [doubledPhysTraceTransfer_reindexPhysical_oneSiteDoubledEquiv]
-    exact doubledPhysTraceTransfer_retainedBlock_not_isNilpotent
-
-end MPOTensor.RescalingStableLengthDependentRFP

--- a/TNLean/MPS/MPDO/SourceSimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SourceSimpleTensor.lean
@@ -11,9 +11,9 @@ import TNLean.MPS.MPDO.SimpleTensor
 This module records the source-facing simplicity condition of arXiv:1606.00608,
 Definition 4.7. After a positive physical blocking, the doubled-index tensor must
 admit a CPSV basis of normal tensors, and the ket-against-bra contraction of every
-basis element must be nonnilpotent. The interface requires a nonzero tensor that
-generates MPDOs, but deliberately excludes the separate line-246 unit-weight
-normalization.
+basis element must be nonnilpotent. The interface requires every positive-length
+generated MPO to be nonzero, but deliberately excludes the separate line-246
+unit-weight normalization.
 
 ## Main result
 

--- a/TNLean/MPS/MPDO/SourceSimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SourceSimpleTensor.lean
@@ -29,21 +29,21 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- **Normalization-free Definition 4.7 simplicity.** A nonzero tensor
-generating MPDOs is source-simple when, after some positive physical blocking,
-its doubled-index tensor has a CPSV basis of normal tensors and no basis element
-has nilpotent ket-against-bra contraction.
+/-- **Normalization-free Definition 4.7 simplicity.** A tensor generating a
+nonzero MPDO at every positive chain length is source-simple when, after some
+positive physical blocking, its doubled-index tensor has a CPSV basis of normal
+tensors and no basis element has nilpotent ket-against-bra contraction.
 
-The nonzero condition records the source boundary that the tensor generates a
-nontrivial density-operator family; in particular, the zero MPO tensor is not
-simple. The BNT witness uses `MPSTensor.IsCPSVBasisOfNormalTensors`, rather than
-an arbitrary family of canonical blocks. It does not impose the line-246
-unit-weight normalization and makes no claim that every positive blocking has
-such a witness.
+The positive-length nonzero condition records the source boundary that the
+tensor generates a genuine density-operator family; in particular, null
+periodic representations are not simple. The BNT witness uses
+`MPSTensor.IsCPSVBasisOfNormalTensors`, rather than an arbitrary family of
+canonical blocks. It does not impose the line-246 unit-weight normalization and
+makes no claim that every positive blocking has such a witness.
 
 Source: arXiv:1606.00608, Definition 4.7, lines 815--822. -/
 def IsSourceSimple (M : MPOTensor d D) : Prop :=
-  IsMPDO M ∧ M ≠ 0 ∧
+  IsMPDO M ∧ (∀ N : ℕ, 0 < N → mpo M N ≠ 0) ∧
     ∃ L : ℕ, 0 < L ∧
       ∃ g : ℕ,
         ∃ blocks : (j : Fin g) →

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1115,8 +1115,9 @@
         thm:mpdo_bnt_label_rescaling_stable_cf,
         thm:mpdo_bnt_label_rescaling_stable_non_nilpotent}
     Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_ismpdo} gives the MPDO
-    condition. The nonnilpotent physical-trace transfer below also shows that
-    $R$ is nonzero. Choose the one-site blocking. Its doubled-index tensor is the
+    condition. The entry formula gives a nonzero diagonal entry of
+    $\rho^{(N)}(R)$ at every positive length $N$. Choose the one-site blocking.
+    Its doubled-index tensor is the
     canonical physical relabeling of $R^{\bullet\bullet}$. Refine the canonical
     form from Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_cf} to its active
     basis of normal tensors. The only retained member is $\widehat R$, whose

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -822,7 +822,7 @@
     \end{align}
 \end{proof}
 
-\begin{theorem}[The rescaling-stable dimer tensor is not simple]
+\begin{theorem}[The rescaling-stable dimer fails normalized simplicity]
     \label{thm:mpdo_bnt_label_rescaling_stable_not_simple}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
         transferMap_blockTensor_R_toMPSTensor_quasi_idempotent}
@@ -841,8 +841,8 @@
         \notag
     \end{align}
     For every positive integer $L$, the blocking $R^{[L]}$ admits no normalized
-    horizontal canonical form. Consequently $R$ is not simple in the
-    fixed-representative sense of
+    horizontal canonical form. Consequently $R$ fails normalized
+    fixed-representative simplicity in the sense of
     Definition~\ref{def:mpdo_simple_tensor}.
 
     % Maintainer scope: the conclusion quantifies over every normalized BNT
@@ -880,9 +880,9 @@
         0<\left(\frac{337}{512}\right)^L<1,
         \notag
     \end{align}
-    a contradiction. Simplicity would provide such a normalized horizontal
-    canonical form after some positive blocking by
-    \cite[lines~815--822]{Cirac2016MPDO_arXiv}; hence $R$ is not simple.
+    a contradiction. Normalized fixed-representative simplicity would provide
+    such a horizontal canonical form after some positive blocking. Hence
+    $R$ fails Definition~\ref{def:mpdo_simple_tensor}.
 \end{proof}
 
 \begin{theorem}[Positivity of the rescaling-stable coefficient family]%
@@ -1031,7 +1031,8 @@
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
         doubledPhysTraceTransfer_retainedBlock_not_isNilpotent}
     \leanok
-    \uses{def:mpdo_doubled_phys_trace_transfer, def:mpdo_simple_tensor,
+    \uses{def:mpdo_doubled_phys_trace_transfer,
+        def:mpdo_source_simple_tensor,
         thm:mpdo_bnt_label_rescaling_stable_length_dependence,
         thm:mpdo_bnt_label_rescaling_stable_cf}
     Let $\widehat R=\mu^{-1}R^{\bullet\bullet}$ be the single retained normal
@@ -1045,7 +1046,7 @@
     \end{align}
     Consequently neither $\mathcal T_R$ nor
     $\mathcal T_{\widehat R}$ is nilpotent. Thus the retained basis element
-    satisfies the non-nilpotency clause in the definition of a simple tensor.
+    satisfies the non-nilpotency clause in source simplicity.
 
     This conclusion concerns only that clause for the displayed one-block
     presentation. The retained decomposition has the non-unit weight
@@ -1068,7 +1069,7 @@
     Replacing $R$ by the normalized block uses the nontrivial scale
     $c=\mu^{-1}$ and therefore changes the representative on which the
     renormalization fixed-point condition is evaluated. Consequently this
-    result neither proves nor refutes simplicity of $R$, and it makes no
+    result by itself does not establish source simplicity, and it makes no
     claim about other presentations or blockings.
 \end{theorem}
 \begin{proof}\leanok
@@ -1088,6 +1089,56 @@
     $\mathcal T_{\widehat R}=\mu^{-1}\mathcal T_R$. Since $\mu>0$, a
     nilpotent $\mathcal T_{\widehat R}$ would remain nilpotent after
     multiplication by $\mu$, forcing $\mathcal T_R$ to be nilpotent.
+\end{proof}
+
+\begin{theorem}[Source simplicity of the rescaling-stable dimer]
+    \label{thm:mpdo_bnt_label_rescaling_stable_source_simple}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.oneSiteDoubledEquiv}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        toMPSTensor_blockTensor_R_one}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        doubledPhysTraceTransfer_reindexPhysical_oneSiteDoubledEquiv}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.R_isSourceSimple}
+    \leanok
+    \uses{def:mpdo_source_simple_tensor,
+        thm:mpdo_bnt_label_rescaling_stable_ismpdo,
+        thm:mpdo_bnt_label_rescaling_stable_cf,
+        thm:mpdo_bnt_label_rescaling_stable_non_nilpotent}
+    The dimer tensor $R$ is source-simple. The positive blocking length is
+    $L=1$. After the canonical relabeling of the doubled physical alphabet,
+    the active basis of normal tensors has one member, namely the retained
+    block $\widehat R$, and its physical-trace transfer is non-nilpotent.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_ismpdo,
+        thm:mpdo_bnt_label_rescaling_stable_cf,
+        thm:mpdo_bnt_label_rescaling_stable_non_nilpotent}
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_ismpdo} gives the MPDO
+    condition. The nonnilpotent physical-trace transfer below also shows that
+    $R$ is nonzero. Choose the one-site blocking. Its doubled-index tensor is the
+    canonical physical relabeling of $R^{\bullet\bullet}$. Refine the canonical
+    form from Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_cf} to its active
+    basis of normal tensors. The only retained member is $\widehat R$, whose
+    physical-trace transfer is non-nilpotent by
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_non_nilpotent}.
+\end{proof}
+
+\begin{corollary}[The two simplicity interfaces give opposite verdicts]
+    \label{cor:mpdo_bnt_label_rescaling_stable_simplicity_verdicts}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        R_isSourceSimple_and_not_isSimple}
+    \leanok
+    \uses{thm:mpdo_bnt_label_rescaling_stable_source_simple,
+        thm:mpdo_bnt_label_rescaling_stable_not_simple}
+    The dimer tensor $R$ is source-simple, witnessed by the one-site blocking,
+    but it does not satisfy normalized fixed-representative simplicity.
+\end{corollary}
+
+\begin{proof}\leanok
+    Combine
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_source_simple} with
+    Theorem~\ref{thm:mpdo_bnt_label_rescaling_stable_not_simple}.
 \end{proof}
 
 \begin{theorem}[The rescaling-stable tensor is a renormalization fixed

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -1095,6 +1095,8 @@
     \label{thm:mpdo_bnt_label_rescaling_stable_source_simple}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.oneSiteDoubledEquiv}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
+        oneSiteDoubledEquiv_diagonal}
+    \lean{MPOTensor.RescalingStableLengthDependentRFP.%
         toMPSTensor_blockTensor_R_one}
     \lean{MPOTensor.RescalingStableLengthDependentRFP.%
         doubledPhysTraceTransfer_reindexPhysical_oneSiteDoubledEquiv}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -64,58 +64,78 @@
     \end{align}
 \end{proof}
 
-\begin{definition}[Simple tensor]
+\begin{definition}[Source-simple tensor]
+    \label{def:mpdo_source_simple_tensor}
+    \lean{MPOTensor.IsSourceSimple}
+    \leanok
+    \uses{def:mpdo, def:mpdo_physical_blocking, def:bnt_cpsv,
+        def:mpdo_doubled_phys_trace_transfer}
+    A nonzero tensor generating MPDOs is \emph{source-simple} if there is a
+    positive physical blocking length $L$ such that the doubled-index tensor
+    of the $L$-site blocking has a finite basis of normal tensors
+    $B_1,\ldots,B_g$ and every physical-trace transfer $\mathcal T_{B_j}$ is
+    non-nilpotent. This is the simplicity condition
+    of~\cite[lines~815--822]{Cirac2016MPDO_arXiv}.
+
+    The quantifier over the blocking length is existential. The definition
+    imposes neither the global unit-weight normalization
+    of~\cite[line~246]{Cirac2016MPDO_arXiv} nor a normalized horizontal
+    canonical-form witness.
+\end{definition}
+
+\begin{definition}[Normalized fixed-representative simplicity]
     \label{def:mpdo_simple_tensor}
     \lean{MPOTensor.IsSimple}
     \leanok
     \uses{def:mpdo, def:mpdo_physical_blocking,
         def:mpdo_simple_cf_tensor}
-    First block a positive number of physical sites and write the blocked
-    doubled-index tensor in canonical form over a basis of normal tensors, as
-    prescribed at line~815 of \cite{Cirac2016MPDO_arXiv}. A tensor generating
-    MPDOs is \emph{simple} if one such canonical form has no nilpotent basis
-    element \cite[line~822]{Cirac2016MPDO_arXiv}. A basis element is
-    nilpotent when tracing $R\le D$ sites annihilates its density operators
-    for all large chain lengths \cite[line~819]{Cirac2016MPDO_arXiv}; this is
-    nilpotency of its physical-trace transfer matrix.
+    A tensor generating MPDOs satisfies \emph{normalized
+    fixed-representative simplicity} if there is a positive physical blocking
+    length for which the blocked tensor admits the normalized canonical-form
+    witness of Definition~\ref{def:mpdo_simple_cf_tensor}.
 
-    Here simplicity is tested on the blocked tensor itself. The chosen BNT
-    retains the global unit-weight convention of
-    \cite[line~246]{Cirac2016MPDO_arXiv}; it does not identify nonzero scalar
-    multiples or assert independence of the chosen canonical presentation.
+    This project interface includes the global unit-weight convention
+    of~\cite[line~246]{Cirac2016MPDO_arXiv} at the scale of the blocked
+    tensor.
+    It is therefore distinct from source simplicity in
+    Definition~\ref{def:mpdo_source_simple_tensor}: it does not identify
+    nonzero scalar multiples, and no equivalence between the two predicates is
+    asserted.
 \end{definition}
 
-\begin{definition}[Simple tensor in blocked canonical form]
+\begin{definition}[Normalized simplicity in blocked canonical form]
     \label{def:mpdo_simple_cf_tensor}
     \lean{MPOTensor.IsSimpleCanonicalForm}
     \leanok
     \uses{def:mpdo, def:horizontal_cf_mpdo,
         def:mpdo_doubled_phys_trace_transfer}
-    A tensor generating MPDOs is in \emph{simple canonical form} if it has a
-    basis-of-normal-tensors decomposition whose basis elements all have
-    non-nilpotent physical-trace transfer. This records the simple
-    horizontal-canonical-form data of the already-blocked tensor $K$ fixed in
-    \cite[Appendix~C.2, line~1628]{Cirac2016MPDO_arXiv}.
+    A tensor generating MPDOs satisfies this predicate if it has a normalized
+    horizontal basis-of-normal-tensors decomposition whose basis elements all
+    have non-nilpotent physical-trace transfer. This records the
+    horizontal-canonical-form data of the already-blocked tensor $K$ fixed
+    in~\cite[Appendix~C.2, line~1628]{Cirac2016MPDO_arXiv}.
 
-    The definition concerns this fixed representative. Its canonical-form
-    witness includes the global unit-weight convention of
-    \cite[line~246]{Cirac2016MPDO_arXiv}, whereas
-    the non-nilpotency condition itself is unchanged by nonzero scalar
-    rescaling. No invariance under rescaling or replacement of the canonical
-    presentation is asserted.
+    The definition concerns this fixed representative. Its witness includes
+    the global unit-weight convention
+    of~\cite[line~246]{Cirac2016MPDO_arXiv}, whereas the non-nilpotency
+    condition
+    itself is unchanged by nonzero scalar rescaling. It is an ingredient of
+    Definition~\ref{def:mpdo_simple_tensor}, not the normalization-free source
+    predicate of Definition~\ref{def:mpdo_source_simple_tensor}. No invariance
+    under rescaling or replacement of the canonical presentation is asserted.
 \end{definition}
 % Note for maintainers: this predicate does not include the biCF
 % (bidirectional canonical form) hypothesis imposed on K at line 1628.  That
 % condition is not used by the copy-independence argument and is introduced
 % separately when the inverse tensor is needed.
 
-\begin{lemma}[Simple canonical-form tensors are horizontal canonical]
+\begin{lemma}[Normalized simple canonical forms are horizontal canonical]
     \label{lem:mpdo_simple_tensor_horizontal_cf}
     \lean{MPOTensor.IsSimpleCanonicalForm.isHorizontalCF}
     \leanok
     \uses{def:mpdo_simple_cf_tensor, def:horizontal_cf_mpdo}
-    A simple tensor already in the chosen blocked canonical-form setting is
-    in horizontal canonical form.
+    A tensor satisfying normalized simplicity in the chosen blocked
+    canonical-form setting is in horizontal canonical form.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_definition.tex
@@ -70,9 +70,10 @@
     \leanok
     \uses{def:mpdo, def:mpdo_physical_blocking, def:bnt_cpsv,
         def:mpdo_doubled_phys_trace_transfer}
-    A nonzero tensor generating MPDOs is \emph{source-simple} if there is a
-    positive physical blocking length $L$ such that the doubled-index tensor
-    of the $L$-site blocking has a finite basis of normal tensors
+    A tensor generating a nonzero MPDO at every positive chain length is
+    \emph{source-simple} if there is a positive physical blocking length $L$
+    such that the doubled-index tensor of the $L$-site blocking has a finite
+    basis of normal tensors
     $B_1,\ldots,B_g$ and every physical-trace transfer $\mathcal T_{B_j}$ is
     non-nilpotent. This is the simplicity condition
     of~\cite[lines~815--822]{Cirac2016MPDO_arXiv}.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -485,16 +485,22 @@ model different levels of data and different sources.
   Reconstruction still permits an omitted all-zero complement because `Uᴴ * U`
   is the retained-support projection; see
   `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
-- `MPOTensor.IsSimpleCanonicalForm` in `TNLean/MPS/MPDO/SimpleTensor.lean` is
-  horizontal canonical form plus the MPDO and nonnilpotent-sector conditions of
-  arXiv:1606.00608, lines 815--822. The sanctioned one-way bridge is
-  `MPOTensor.IsSimpleCanonicalForm.isHorizontalCF`.
-- `MPOTensor.IsSimpleCanonicalForm` and `MPOTensor.IsSimple` are normalized
-  fixed-representative predicates. The latter permits positive physical
-  blocking, but still requires the blocked tensor itself to admit the source's
+- `MPOTensor.IsSimpleCanonicalForm` and `MPOTensor.IsSimple` in
+  `TNLean/MPS/MPDO/SimpleTensor.lean` are normalized fixed-representative
+  predicates. The former adds the MPDO and nonnilpotent-sector conditions to
+  horizontal canonical form; its sanctioned one-way bridge is
+  `MPOTensor.IsSimpleCanonicalForm.isHorizontalCF`. The latter permits positive
+  physical blocking, but still requires the blocked tensor itself to admit the
   line-246 unit-weight witness. Neither predicate is a quotient by nonzero
   scalar rescaling; see
   `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
+- `MPOTensor.IsSourceSimple` in `TNLean/MPS/MPDO/SourceSimpleTensor.lean`
+  is the separate normalization-free source-facing predicate from
+  arXiv:1606.00608, lines 815--822. It requires a nonzero tensor satisfying the
+  MPDO condition and existentially chooses a positive physical blocking whose
+  doubled-index tensor has a coefficient-form basis of normal tensors with
+  nonnilpotent physical-trace transfers. No equivalence with the normalized
+  predicates is asserted.
 
 The `CF` spelling in these established MPDO names is retained for compatibility
 and paper-local vocabulary. New public predicates should spell out

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -496,10 +496,10 @@ model different levels of data and different sources.
   `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
 - `MPOTensor.IsSourceSimple` in `TNLean/MPS/MPDO/SourceSimpleTensor.lean`
   is the separate normalization-free source-facing predicate from
-  arXiv:1606.00608, lines 815--822. It requires a nonzero tensor satisfying the
-  MPDO condition and existentially chooses a positive physical blocking whose
-  doubled-index tensor has a coefficient-form basis of normal tensors with
-  nonnilpotent physical-trace transfers. No equivalence with the normalized
+  arXiv:1606.00608, lines 815--822. It requires a nonzero generated MPO at
+  every positive chain length and existentially chooses a positive physical
+  blocking whose doubled-index tensor has a coefficient-form basis of normal
+  tensors with nonnilpotent physical-trace transfers. No equivalence with the normalized
   predicates is asserted.
 
 The `CF` spelling in these established MPDO names is retained for compatibility

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -79,8 +79,9 @@ For MPDO renormalization fixed points:
   statement (iii), including inactive product sectors, is not claimed.
 - `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT
   elements with nilpotent physical-trace transfer matrices. The exact
-  source-facing predicate is `MPOTensor.IsSourceSimple`: it requires a nonzero
-  MPDO tensor and existentially chooses a positive physical blocking and a
+  source-facing predicate is `MPOTensor.IsSourceSimple`: it requires every
+  positive-length generated MPO to be nonzero and existentially chooses a
+  positive physical blocking and a
   coefficient-form basis of normal tensors whose physical-trace transfers are
   all nonnilpotent.
 - `cpsv16_unit_weight_rfp_scale_tension.tex` records the tension between the

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -78,16 +78,16 @@ For MPDO renormalization fixed points:
   `TNLean/MPS/MPDO/CPSVBNTTheoremEquivalence.lean`. The unrestricted printed
   statement (iii), including inactive product sectors, is not claimed.
 - `cpsv16_simple_tensor_nilpotency.tex` identifies the source's nilpotent BNT
-  elements with nilpotent physical-trace transfer matrices and records the
-  positive physical blocking and chosen-BNT interpretation of the
-  simple-tensor predicate. The source copy-weight lemma is formalized on the
-  chosen blocked canonical form; independence of the choices is not presently
-  needed.
+  elements with nilpotent physical-trace transfer matrices. The exact
+  source-facing predicate is `MPOTensor.IsSourceSimple`: it requires a nonzero
+  MPDO tensor and existentially chooses a positive physical blocking and a
+  coefficient-form basis of normal tensors whose physical-trace transfers are
+  all nonnilpotent.
 - `cpsv16_unit_weight_rfp_scale_tension.tex` records the tension between the
   source's line-246 unit-weight convention and the scale fixed by Definition
-  4.1. In particular, `MPOTensor.IsSimpleCanonicalForm` and
-  `MPOTensor.IsSimple` are normalized fixed-representative predicates, not
-  quotients by nonzero scalar rescaling.
+  4.1. The dimer tensor satisfies `MPOTensor.IsSourceSimple`, witnessed by
+  blocking length one, but fails the normalized fixed-representative predicate
+  `MPOTensor.IsSimple`. No equivalence between these interfaces is asserted.
 - `cpsv16_gsnnch_sector_decomposition.tex` records that
   `MPOTensor.GSNNCHData` retains the source orthogonal sectors and natural
   multiplicities. Positive commuting products on supplied orthogonal sectors

--- a/docs/paper-gaps/cpsv16_simple_tensor_nilpotency.tex
+++ b/docs/paper-gaps/cpsv16_simple_tensor_nilpotency.tex
@@ -47,12 +47,18 @@ on that algebra is nondegenerate. Consequently,
   \mathcal T_A^R=0.                                      \label{eq:nilpotent-equivalence}
 \end{align}
 Since the nilpotency index of a nilpotent $D\times D$ matrix is at most $D$,
-the line-819 condition is precisely nilpotency of $\mathcal T_A$. The formal
-predicate for a chosen blocked canonical form is
-\leanid{MPOTensor.IsSimpleCanonicalForm}; it records this condition for every
-basis element. The source predicate is \leanid{MPOTensor.IsSimple}; it
-existentially quantifies over the positive physical blocking required at
-line~815.
+the line-819 condition is precisely nilpotency of $\mathcal T_A$. The
+source-facing predicate is \leanid{MPOTensor.IsSourceSimple}: it requires a
+nonzero tensor generating MPDOs, existentially quantifies over the positive
+physical blocking required at line~815, chooses a basis of normal tensors for
+the blocked doubled-index tensor, and records this non-nilpotency condition for
+every basis element.
+
+The predicates \leanid{MPOTensor.IsSimpleCanonicalForm} and
+\leanid{MPOTensor.IsSimple} are separate normalized fixed-representative
+interfaces. They include a horizontal canonical-form witness with the source's
+line-246 unit-weight convention. No equivalence with
+\leanid{MPOTensor.IsSourceSimple} is asserted.
 
 The toric-code boundary tensor discussed after Theorem~4.9 of the source
 confirms the reading: its second basis element carries the one-by-one
@@ -60,12 +66,11 @@ transfer $\mathcal T = 0$, so the tensor is not simple, matching the
 source's use of that example outside the simple case.
 
 The source states the predicate for ``a BNT'' of the blocked tensor. The basis of
-normal tensors is unique up to gauge, phase, and permutation, so the choice
-of witness is immaterial mathematically; the formal predicate quantifies
-existentially over a positive blocking and horizontal canonical-form witness,
-and records non-nilpotency for that witness. No theorem currently transports
-non-nilpotency between witnesses; a proof of witness independence can be
-added when an argument needs it.
+normal tensors is unique up to gauge, phase, and permutation, so the choice of
+witness is immaterial mathematically. The formal source-facing predicate
+quantifies existentially over a positive blocking and a coefficient-form basis
+of normal tensors, and records non-nilpotency for that witness. It does not
+require a normalized horizontal canonical-form presentation.
 
 \section{Classification}
 

--- a/docs/paper-gaps/cpsv16_simple_tensor_nilpotency.tex
+++ b/docs/paper-gaps/cpsv16_simple_tensor_nilpotency.tex
@@ -48,11 +48,11 @@ on that algebra is nondegenerate. Consequently,
 \end{align}
 Since the nilpotency index of a nilpotent $D\times D$ matrix is at most $D$,
 the line-819 condition is precisely nilpotency of $\mathcal T_A$. The
-source-facing predicate is \leanid{MPOTensor.IsSourceSimple}: it requires a
-nonzero tensor generating MPDOs, existentially quantifies over the positive
-physical blocking required at line~815, chooses a basis of normal tensors for
-the blocked doubled-index tensor, and records this non-nilpotency condition for
-every basis element.
+source-facing predicate is \leanid{MPOTensor.IsSourceSimple}: it requires the
+generated MPO to be nonzero at every positive chain length, existentially
+quantifies over the positive physical blocking required at line~815, chooses a
+basis of normal tensors for the blocked doubled-index tensor, and records this
+non-nilpotency condition for every basis element.
 
 The predicates \leanid{MPOTensor.IsSimpleCanonicalForm} and
 \leanid{MPOTensor.IsSimple} are separate normalized fixed-representative
@@ -74,9 +74,10 @@ require a normalized horizontal canonical-form presentation.
 
 \section{Classification}
 
-Verdict: notational clarification. The formal definition is faithful to
-lines~819--822 under the identification of the line-819 partial-trace
-criterion with matrix nilpotency of the physical-trace transfer; no
-hypothesis is added or dropped.
+Verdict: notational clarification with an explicit nontriviality boundary. The
+formal definition records the source's density-operator setting by requiring
+all positive-length generated MPOs to be nonzero. Subject to that boundary, it
+matches lines~819--822 under the identification of the line-819 partial-trace
+criterion with matrix nilpotency of the physical-trace transfer.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -96,14 +96,21 @@ insensitive to rescaling, even though a formal predicate that includes the
 line-246 canonical-form normalization is evaluated on a particular
 representative.
 
-The declarations \leanid{MPOTensor.IsSimpleCanonicalForm} and
-\leanid{MPOTensor.IsSimple} retain the source's BNT normalization. The first is
-a predicate on one displayed canonical-form representative. The second permits
-positive physical blocking, but still asks the resulting blocked tensor itself
-to admit such a normalized witness. Neither declaration is a quotient by
-nonzero scalar rescaling. For a fixed tensor, however, a theorem may quantify
-over every normalized BNT witness rather than rely on one chosen presentation;
-the dimer obstruction below has precisely this form.
+The declaration \leanid{MPOTensor.IsSourceSimple} records the
+normalization-free source condition: it requires a nonzero tensor generating
+MPDOs and asks for some positive blocking and a basis of normal tensors whose
+physical-trace transfers are all non-nilpotent. It does not impose the line-246
+unit-weight convention.
+
+By contrast, \leanid{MPOTensor.IsSimpleCanonicalForm} and
+\leanid{MPOTensor.IsSimple} are normalized fixed-representative interfaces. The
+first is a predicate on one displayed canonical-form representative. The second
+permits positive physical blocking, but still asks the resulting blocked tensor
+itself to admit such a normalized witness. Neither declaration is a quotient by
+nonzero scalar rescaling, and no equivalence with
+\leanid{MPOTensor.IsSourceSimple} is asserted. For a fixed tensor, however, a
+theorem may quantify over every normalized BNT witness rather than rely on one
+chosen presentation; the dimer obstruction below has precisely this form.
 
 \section{The displayed dimer representative}
 
@@ -163,12 +170,18 @@ The argument quantifies over the arbitrary normalized BNT witness allowed by
 the formal predicate; it does not depend on the displayed one-block
 presentation.
 
-This failure is not a nilpotency result. The retained-block theorem still
-proves that the displayed canonical presentation has non-nilpotent
-physical-trace transfer. The contradiction instead combines quasi-idempotence
-of the doubled-index transfer, the line-246 unit-weight copy, and trace
-preservation of its normal representative. It also uses none of the vertical
-coefficient identities discussed below.
+This failure is not a nilpotency result. The retained-block theorem proves
+that the displayed canonical presentation has non-nilpotent physical-trace
+transfer. Together with positivity and the active one-site BNT refinement, it
+witnesses
+\begin{align}
+    \leanid{MPOTensor.IsSourceSimple}\,R.
+\end{align}
+The source quantifier is existential and is witnessed by $L=1$; no assertion is
+made about every positive blocking. The normalized obstruction instead combines
+quasi-idempotence of the doubled-index transfer, the line-246 unit-weight copy,
+and trace preservation of its normal representative. It uses none of the
+vertical coefficient identities discussed below.
 
 \section{The vertical one-label identity}
 
@@ -192,19 +205,21 @@ not an invariance theorem for coefficients under changes of presentation.
 
 \section{Formalization boundary}
 
-\textbf{Verdict: scope restriction (fixed representative).} The current
-formal predicate is false for the displayed tensor $R$: every positive
-blocking has quasi-idempotence scalar $(337/512)^L<1$, while every normalized
-horizontal BNT witness would force that scalar to be one. This conclusion is
-independent of the choice of normalized BNT witness.
+\textbf{Verdict: two distinct formal interfaces.} The source-facing
+predicate \leanid{MPOTensor.IsSourceSimple} is true for $R$, with positive
+blocking length $L=1$. The normalized fixed-representative predicate
+\leanid{MPOTensor.IsSimple} is false for $R$: every positive blocking has
+quasi-idempotence scalar $\bigl(337/512\bigr)^L<1$, while every normalized horizontal BNT
+witness would force that scalar to be one. The latter conclusion is independent
+of the choice of normalized BNT witness.
 
-The verdict remains representative-dependent. The line-246 field should not
-be deleted: it is the source's standing canonical-form convention. The result
-does not produce a nilpotent BNT block, does not use the vertical coefficient
-family, and does not show that any scale-invariant physical notion of
-simplicity fails for $R$. A future scale-invariant interface would have to be
-formulated either on a normalized representative or without including the
-unit-weight convention in the simplicity predicate.
+The normalized verdict remains representative-dependent. The line-246 field
+should not be deleted: it is the source's standing canonical-form convention.
+The obstruction does not produce a nilpotent BNT block, does not use the
+vertical coefficient family, and does not refute source simplicity. Conversely,
+the one-site source-simplicity witness does not assert that every positive
+blocking is source-simple, that arbitrary rescaling preserves the MPDO
+condition, or that the two simplicity interfaces are equivalent.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -97,10 +97,10 @@ line-246 canonical-form normalization is evaluated on a particular
 representative.
 
 The declaration \leanid{MPOTensor.IsSourceSimple} records the
-normalization-free source condition: it requires a nonzero tensor generating
-MPDOs and asks for some positive blocking and a basis of normal tensors whose
-physical-trace transfers are all non-nilpotent. It does not impose the line-246
-unit-weight convention.
+normalization-free source condition: it requires every positive-length
+generated MPO to be nonzero and asks for some positive blocking and a basis of
+normal tensors whose physical-trace transfers are all non-nilpotent. It does
+not impose the line-246 unit-weight convention.
 
 By contrast, \leanid{MPOTensor.IsSimpleCanonicalForm} and
 \leanid{MPOTensor.IsSimple} are normalized fixed-representative interfaces. The


### PR DESCRIPTION
## Summary
- add `MPOTensor.IsSourceSimple`, the normalization-free Definition 4.7 interface with an explicit nonzero MPDO boundary, existential positive blocking, a genuine CPSV basis of normal tensors, and nonnilpotent physical-trace transfers
- prove the dimer `R` is source-simple with the one-site BNT witness while retaining the existing theorem `¬ MPOTensor.IsSimple R` for the normalized fixed-representative predicate
- state both verdicts side by side and synchronize Chapter 21, glossary, and paper-gap notes

## Scope
Definition 4.7 is existential after blocking; this PR does not claim every positive blocking is source-simple, arbitrary rescaling preserves `IsMPDO`, or the two simplicity interfaces are equivalent.

## Validation
- editor diagnostics clean on the three changed Lean modules
- Blueprint/Lean sync and reverse coverage: 7768/7768
- reader-facing prose check
- git diff --check

Per the current workflow request, no additional local Lake build/rebuild was run; CI is the aggregate compilation gate.

Closes #6479