### PR TITLE
fix(MPDO): avoid generated bond-bit name collision

### DIFF
--- a/TNLean/MPS/MPDO/RescalingStableChiAttachment.lean
+++ b/TNLean/MPS/MPDO/RescalingStableChiAttachment.lean
@@ -72,7 +72,7 @@ two-sided inverse `chainEmbed N` of `φ N` on chain-OK strings.  This is the
 Project example; not from CPSV16. -/
 
 /-- A bond label is `bondEquiv` applied to its own pair of bits. -/
-lemma bondEquiv_bit1_bit2 (k : Fin 4) : bondEquiv (bit1 k, bit2 k) = k := by
+lemma bondEquiv_bondBit1_bondBit2 (k : Fin 4) : bondEquiv (bondBit1 k, bondBit2 k) = k := by
   fin_cases k <;> rfl
 
 /-- The boundary embedding reconstructing a physical-index string from a
@@ -103,7 +103,7 @@ lemma chainEmbed_φ_of_chainOK {N : ℕ} {p : Fin N → Fin 4} (hp : ChainOK N p
   funext n
   simp only [chainEmbed, φ]
   rw [← hp n]
-  exact bondEquiv_bit1_bit2 (p n)
+  exact bondEquiv_bondBit1_bondBit2 (p n)
 
 /-- `chainEmbed N` is injective: it has `φ N` as a left inverse. -/
 lemma chainEmbed_injective (N : ℕ) : Function.Injective (chainEmbed N) := by

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFP.lean
@@ -349,24 +349,24 @@ sum to at most one term.  Positivity is `R_isMPDO`. -/
 
 /-- The first bit of a bond label `k : Fin 4` under the Kronecker
 identification `bondEquiv : Fin 2 × Fin 2 ≃ Fin 4`:
-`bit1 k = (bondEquiv.symm k).1` (`bit1_eq_bondEquiv_symm_fst`).
-Together with `bit2` it reads a bond
+`bondBit1 k = (bondEquiv.symm k).1` (`bondBit1_eq_bondEquiv_symm_fst`).
+Together with `bondBit2` it reads a bond
 label as the pair of bits indexing the two tensor factors of the vertical
 (Kronecker) reading `B^{ab} = A^a ⊗ conj(A^b)`.
 
 Project example; not from CPSV16. -/
-def bit1 : Fin 4 → Fin 2
+def bondBit1 : Fin 4 → Fin 2
   | 0 => 0
   | 1 => 0
   | 2 => 1
   | 3 => 1
 
 /-- The second bit of a bond label `k : Fin 4` under `bondEquiv`:
-`bit2 k = (bondEquiv.symm k).2` (`bit2_eq_bondEquiv_symm_snd`).
-See `bit1`.
+`bondBit2 k = (bondEquiv.symm k).2` (`bondBit2_eq_bondEquiv_symm_snd`).
+See `bondBit1`.
 
 Project example; not from CPSV16. -/
-def bit2 : Fin 4 → Fin 2
+def bondBit2 : Fin 4 → Fin 2
   | 0 => 0
   | 1 => 1
   | 2 => 0
@@ -374,14 +374,14 @@ def bit2 : Fin 4 → Fin 2
 
 /-- The first bit of a bond label is the first component of its preimage
 under `bondEquiv`. -/
-@[simp] lemma bit1_eq_bondEquiv_symm_fst (k : Fin 4) :
-    bit1 k = (bondEquiv.symm k).1 := by
+@[simp] lemma bondBit1_eq_bondEquiv_symm_fst (k : Fin 4) :
+    bondBit1 k = (bondEquiv.symm k).1 := by
   fin_cases k <;> rfl
 
 /-- The second bit of a bond label is the second component of its preimage
 under `bondEquiv`. -/
-@[simp] lemma bit2_eq_bondEquiv_symm_snd (k : Fin 4) :
-    bit2 k = (bondEquiv.symm k).2 := by
+@[simp] lemma bondBit2_eq_bondEquiv_symm_snd (k : Fin 4) :
+    bondBit2 k = (bondEquiv.symm k).2 := by
   fin_cases k <;> rfl
 
 /-- The entrywise positive square root of `wMat` (`coeff_sq_eq_wMat`).  The
@@ -408,19 +408,19 @@ lemma A_entry_eq_coeff' {a : Fin 4} {r c : Fin 2} (h : A a r c ≠ 0) :
 
 /-- The cyclic bond-matching condition on a physical-index string
 `p : Fin N → Fin 4`: the second bit of each letter equals the first bit of
-the next letter around the ring (`bit2 (p n) = bit1 (p (n + 1))`, with the
+the next letter around the ring (`bondBit2 (p n) = bondBit1 (p (n + 1))`, with the
 successor given by `finRotate N`).  This closed-chain constraint
 collapses the bond sum in the entrywise formula for `mpo R N` to at most
 one term.
 
 Project example; not from CPSV16. -/
 def ChainOK (N : ℕ) (p : Fin N → Fin 4) : Prop :=
-  ∀ n : Fin N, bit2 (p n) = bit1 (p (finRotate N n))
+  ∀ n : Fin N, bondBit2 (p n) = bondBit1 (p (finRotate N n))
 
 /-- `ChainOK N p` is decidable: it is a `Fin N`-indexed universal
 quantification of equalities between `Fin 2` values. -/
 instance decidableChainOK (N : ℕ) (p : Fin N → Fin 4) : Decidable (ChainOK N p) :=
-  inferInstanceAs (Decidable (∀ n : Fin N, bit2 (p n) = bit1 (p (finRotate N n))))
+  inferInstanceAs (Decidable (∀ n : Fin N, bondBit2 (p n) = bondBit1 (p (finRotate N n))))
 
 /-- The indicator matrix of the cyclic bond-matching condition:
 `(chainIndicator N) p q = 1` if both `p` and `q` satisfy `ChainOK N`, and
@@ -617,12 +617,12 @@ lemma wN_posSemidef (N : ℕ) : (wN N).PosSemidef := by
       exact Matrix.PosSemidef.submatrix (Matrix.PosSemidef.kronecker ih wMat_posSemidef) e
 
 /-- The pullback map extracting the first-bit string of a physical-index
-string: `(φ N p) n = bit1 (p n)`.  In the planned factorization it pulls
+string: `(φ N p) n = bondBit1 (p n)`.  In the planned factorization it pulls
 `wN N` back to the `(Fin N → Fin 4)`-indexed space as
 `Matrix.of fun p q => (wN N) (φ N p) (φ N q)`.
 
 Project example; not from CPSV16. -/
-def φ (N : ℕ) (p : Fin N → Fin 4) : Fin N → Fin 2 := fun n => bit1 (p n)
+def φ (N : ℕ) (p : Fin N → Fin 4) : Fin N → Fin 2 := fun n => bondBit1 (p n)
 
 /-- `wMat` is the entrywise square of `coeff'`: the local factor's entries
 are the squared magnitudes of the letter-matrix entries. -/
@@ -638,18 +638,18 @@ lemma A_star_eq (b : Fin 4) (i j : Fin 2) : star (A b i j) = A b i j := by
   simpa [Matrix.map_apply] using h
 
 /-- The bond matrix `R p q` is the rank-one outer product of the letter-column
-vectors `u_{pq} a = A a (bit1 p) (bit1 q)` and `v_{pq} b = A b (bit2 p) (bit2 q)`,
+vectors `u_{pq} a = A a (bondBit1 p) (bondBit1 q)` and `v_{pq} b = A b (bondBit2 p) (bondBit2 q)`,
 scaled by `25/32`.  This is the rank-one structure underlying the closed-chain
 trace factorization of `mpo R N`.
 
 Project example; not from CPSV16. -/
 lemma R_eq_vecMulVec (p q : Fin 4) :
-    R p q = (25/32 : ℂ) • Matrix.vecMulVec (fun a => A a (bit1 p) (bit1 q))
-      (fun b => A b (bit2 p) (bit2 q)) := by
+    R p q = (25/32 : ℂ) • Matrix.vecMulVec (fun a => A a (bondBit1 p) (bondBit1 q))
+      (fun b => A b (bondBit2 p) (bondBit2 q)) := by
   ext a b
   simp only [Matrix.smul_apply, Matrix.vecMulVec_apply, smul_eq_mul, R_apply,
     Matrix.kroneckerMap_apply, Matrix.map_apply, starRingEnd_apply,
-    ← bit1_eq_bondEquiv_symm_fst, ← bit2_eq_bondEquiv_symm_snd]
+    ← bondBit1_eq_bondEquiv_symm_fst, ← bondBit2_eq_bondEquiv_symm_snd]
   rw [A_star_eq]
 
 /-- The dot product of two `A`-letter column vectors collapses: it equals
@@ -707,10 +707,11 @@ when both steps of the bond chain match, and vanishes otherwise.
 
 Project example; not from CPSV16. -/
 lemma dotProduct_A_col_step {N : ℕ} (p q : Fin N → Fin 4) (n : Fin N) :
-    (fun b : Fin 4 => A b (bit2 (p n)) (bit2 (q n))) ⬝ᵥ
-        (fun b : Fin 4 => A b (bit1 (p (finRotate N n))) (bit1 (q (finRotate N n)))) =
-      if bit2 (p n) = bit1 (p (finRotate N n)) ∧ bit2 (q n) = bit1 (q (finRotate N n))
-        then wMat (bit2 (p n)) (bit2 (q n)) else 0 :=
+    (fun b : Fin 4 => A b (bondBit2 (p n)) (bondBit2 (q n))) ⬝ᵥ
+        (fun b : Fin 4 => A b (bondBit1 (p (finRotate N n))) (bondBit1 (q (finRotate N n)))) =
+      if bondBit2 (p n) = bondBit1 (p (finRotate N n)) ∧
+          bondBit2 (q n) = bondBit1 (q (finRotate N n))
+        then wMat (bondBit2 (p n)) (bondBit2 (q n)) else 0 :=
   dotProduct_A_col _ _ _ _
 
 /-- The one-step rotation `finRotate (N + 1)` sends the embedding `i.castSucc`
@@ -740,67 +741,71 @@ theorem mpo_R_entry_formula {N : ℕ} (hN : 0 < N) (p q : Fin N → Fin 4) :
   obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.ne'
   simp only [mpo_apply, mpoMatrixEntry, evalWord_ofFn]
   have hRstep : ∀ i : Fin (n + 1), R (p i) (q i) =
-      (25/32 : ℂ) • Matrix.vecMulVec (fun a => A a (bit1 (p i)) (bit1 (q i)))
-        (fun b => A b (bit2 (p i)) (bit2 (q i))) := fun i => R_eq_vecMulVec (p i) (q i)
+      (25/32 : ℂ) • Matrix.vecMulVec (fun a => A a (bondBit1 (p i)) (bondBit1 (q i)))
+        (fun b => A b (bondBit2 (p i)) (bondBit2 (q i))) := fun i => R_eq_vecMulVec (p i) (q i)
   simp only [hRstep]
   rw [prod_smul_vecMulVec_ofFn (25/32 : ℂ) n
-    (fun i => fun a => A a (bit1 (p i)) (bit1 (q i)))
-    (fun i => fun b => A b (bit2 (p i)) (bit2 (q i)))]
+    (fun i => fun a => A a (bondBit1 (p i)) (bondBit1 (q i)))
+    (fun i => fun b => A b (bondBit2 (p i)) (bondBit2 (q i)))]
   rw [Matrix.trace_smul, Matrix.trace_smul, Matrix.trace_vecMulVec]
   simp only [smul_eq_mul]
   have hlast :
-      (fun a : Fin 4 => A a (bit1 (p 0)) (bit1 (q 0))) ⬝ᵥ
-          (fun b : Fin 4 => A b (bit2 (p (Fin.last n))) (bit2 (q (Fin.last n)))) =
-        (fun b : Fin 4 => A b (bit2 (p (Fin.last n))) (bit2 (q (Fin.last n)))) ⬝ᵥ
-          (fun a : Fin 4 => A a (bit1 (p 0)) (bit1 (q 0))) :=
+      (fun a : Fin 4 => A a (bondBit1 (p 0)) (bondBit1 (q 0))) ⬝ᵥ
+          (fun b : Fin 4 => A b (bondBit2 (p (Fin.last n))) (bondBit2 (q (Fin.last n)))) =
+        (fun b : Fin 4 => A b (bondBit2 (p (Fin.last n))) (bondBit2 (q (Fin.last n)))) ⬝ᵥ
+          (fun a : Fin 4 => A a (bondBit1 (p 0)) (bondBit1 (q 0))) :=
     dotProduct_comm _ _
   rw [hlast]
   -- combine the open-chain pairing product with the wraparound term into a
   -- single cyclic product indexed by `Fin (n + 1)`, driven by `finRotate`.
   set g : Fin (n + 1) → ℂ := fun i =>
-      (fun b : Fin 4 => A b (bit2 (p i)) (bit2 (q i))) ⬝ᵥ
-        (fun a : Fin 4 => A a (bit1 (p (finRotate (n + 1) i))) (bit1 (q (finRotate (n + 1) i))))
+      (fun b : Fin 4 => A b (bondBit2 (p i)) (bondBit2 (q i))) ⬝ᵥ
+        (fun a : Fin 4 =>
+          A a (bondBit1 (p (finRotate (n + 1) i)))
+            (bondBit1 (q (finRotate (n + 1) i))))
     with hg
   have hgterm : ∀ i : Fin (n + 1), g i =
-      if bit2 (p i) = bit1 (p (finRotate (n + 1) i)) ∧ bit2 (q i) = bit1 (q (finRotate (n + 1) i))
-        then wMat (bit2 (p i)) (bit2 (q i)) else 0 :=
+      if bondBit2 (p i) = bondBit1 (p (finRotate (n + 1) i)) ∧
+          bondBit2 (q i) = bondBit1 (q (finRotate (n + 1) i))
+        then wMat (bondBit2 (p i)) (bondBit2 (q i)) else 0 :=
     fun i => dotProduct_A_col_step p q i
   have hstep : ∀ i : Fin n,
-      (fun b : Fin 4 => A b (bit2 (p i.castSucc)) (bit2 (q i.castSucc))) ⬝ᵥ
-          (fun a : Fin 4 => A a (bit1 (p i.succ)) (bit1 (q i.succ))) = g i.castSucc := by
+      (fun b : Fin 4 => A b (bondBit2 (p i.castSucc)) (bondBit2 (q i.castSucc))) ⬝ᵥ
+          (fun a : Fin 4 => A a (bondBit1 (p i.succ)) (bondBit1 (q i.succ))) = g i.castSucc := by
     intro i
     simp only [hg, finRotate_succ_castSucc]
   have hlaststep :
-      (fun b : Fin 4 => A b (bit2 (p (Fin.last n))) (bit2 (q (Fin.last n)))) ⬝ᵥ
-          (fun a : Fin 4 => A a (bit1 (p 0)) (bit1 (q 0))) = g (Fin.last n) := by
+      (fun b : Fin 4 => A b (bondBit2 (p (Fin.last n))) (bondBit2 (q (Fin.last n)))) ⬝ᵥ
+          (fun a : Fin 4 => A a (bondBit1 (p 0)) (bondBit1 (q 0))) = g (Fin.last n) := by
     simp only [hg, finRotate_last]
   have hcombine :
-      (∏ i : Fin n, (fun b : Fin 4 => A b (bit2 (p i.castSucc)) (bit2 (q i.castSucc))) ⬝ᵥ
-          (fun a : Fin 4 => A a (bit1 (p i.succ)) (bit1 (q i.succ)))) *
-        ((fun b : Fin 4 => A b (bit2 (p (Fin.last n))) (bit2 (q (Fin.last n)))) ⬝ᵥ
-          (fun a : Fin 4 => A a (bit1 (p 0)) (bit1 (q 0)))) = ∏ i : Fin (n + 1), g i := by
+      (∏ i : Fin n,
+        (fun b : Fin 4 => A b (bondBit2 (p i.castSucc)) (bondBit2 (q i.castSucc))) ⬝ᵥ
+          (fun a : Fin 4 => A a (bondBit1 (p i.succ)) (bondBit1 (q i.succ)))) *
+        ((fun b : Fin 4 => A b (bondBit2 (p (Fin.last n))) (bondBit2 (q (Fin.last n)))) ⬝ᵥ
+          (fun a : Fin 4 => A a (bondBit1 (p 0)) (bondBit1 (q 0)))) = ∏ i : Fin (n + 1), g i := by
     rw [Fin.prod_univ_castSucc]
     exact congrArg₂ (· * ·) (Finset.prod_congr rfl fun i _ => hstep i) hlaststep
   rw [hcombine]
   have hmain : (∏ i : Fin (n + 1), g i) =
       chainIndicator (n + 1) p q * wN (n + 1) (φ (n + 1) p) (φ (n + 1) q) := by
     by_cases hChain : ChainOK (n + 1) p ∧ ChainOK (n + 1) q
-    · have hall : ∀ i : Fin (n + 1), g i = wMat (bit2 (p i)) (bit2 (q i)) := fun i => by
+    · have hall : ∀ i : Fin (n + 1), g i = wMat (bondBit2 (p i)) (bondBit2 (q i)) := fun i => by
         rw [hgterm, if_pos ⟨hChain.1 i, hChain.2 i⟩]
       have hprodeq : (∏ i : Fin (n + 1), g i) =
-          ∏ i : Fin (n + 1), wMat (bit2 (p i)) (bit2 (q i)) :=
+          ∏ i : Fin (n + 1), wMat (bondBit2 (p i)) (bondBit2 (q i)) :=
         Finset.prod_congr rfl fun i _ => hall i
-      have hrotate : (∏ i : Fin (n + 1), wMat (bit2 (p i)) (bit2 (q i))) =
+      have hrotate : (∏ i : Fin (n + 1), wMat (bondBit2 (p i)) (bondBit2 (q i))) =
           ∏ i : Fin (n + 1),
-            wMat (bit1 (p (finRotate (n + 1) i))) (bit1 (q (finRotate (n + 1) i))) :=
+            wMat (bondBit1 (p (finRotate (n + 1) i))) (bondBit1 (q (finRotate (n + 1) i))) :=
         Finset.prod_congr rfl fun i _ => by rw [hChain.1 i, hChain.2 i]
       have hreindex :
           (∏ i : Fin (n + 1),
-              wMat (bit1 (p (finRotate (n + 1) i))) (bit1 (q (finRotate (n + 1) i)))) =
-            ∏ j : Fin (n + 1), wMat (bit1 (p j)) (bit1 (q j)) :=
-        Equiv.prod_comp (finRotate (n + 1)) (fun j => wMat (bit1 (p j)) (bit1 (q j)))
+              wMat (bondBit1 (p (finRotate (n + 1) i))) (bondBit1 (q (finRotate (n + 1) i)))) =
+            ∏ j : Fin (n + 1), wMat (bondBit1 (p j)) (bondBit1 (q j)) :=
+        Equiv.prod_comp (finRotate (n + 1)) (fun j => wMat (bondBit1 (p j)) (bondBit1 (q j)))
       have hwNeq : wN (n + 1) (φ (n + 1) p) (φ (n + 1) q) =
-          ∏ j : Fin (n + 1), wMat (bit1 (p j)) (bit1 (q j)) := by
+          ∏ j : Fin (n + 1), wMat (bondBit1 (p j)) (bondBit1 (q j)) := by
         simp [wN, φ, Matrix.of_apply]
       have hchainInd : chainIndicator (n + 1) p q = 1 := by
         simp [chainIndicator, hChain.1, hChain.2]

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPCanonicalForm.lean
@@ -213,19 +213,23 @@ lemma transferMap_R_toMPSTensor_eq (X : Matrix (Fin 4) (Fin 4) ℂ) :
   have hterm : ∀ p q : Fin 4,
       R.toMPSTensor (finProdFinEquiv (p, q)) * X * (R.toMPSTensor (finProdFinEquiv (p, q)))ᴴ =
       (25/32 : ℂ) ^ 2 •
-        ((fun b => A b (bit2 p) (bit2 q)) ⬝ᵥ
-          (X.mulVec (fun b => A b (bit2 p) (bit2 q)))) •
-        Matrix.vecMulVec (fun a => A a (bit1 p) (bit1 q)) (fun a => A a (bit1 p) (bit1 q)) := by
+        ((fun b => A b (bondBit2 p) (bondBit2 q)) ⬝ᵥ
+          (X.mulVec (fun b => A b (bondBit2 p) (bondBit2 q)))) •
+        Matrix.vecMulVec (fun a => A a (bondBit1 p) (bondBit1 q))
+          (fun a => A a (bondBit1 p) (bondBit1 q)) := by
     intro p q
     rw [toMPSTensor_R_apply, R_eq_vecMulVec p q, Matrix.conjTranspose_smul]
     simp only [smul_mul_assoc, mul_smul_comm, smul_smul]
-    rw [vecMulVec_conj (Fin 4) (fun a => A a (bit1 p) (bit1 q)) (fun b => A b (bit2 p) (bit2 q)) X]
-    have hstarv : star (fun b => A b (bit2 p) (bit2 q)) = fun b => A b (bit2 p) (bit2 q) := by
+    rw [vecMulVec_conj (Fin 4) (fun a => A a (bondBit1 p) (bondBit1 q))
+      (fun b => A b (bondBit2 p) (bondBit2 q)) X]
+    have hstarv : star (fun b => A b (bondBit2 p) (bondBit2 q)) =
+        fun b => A b (bondBit2 p) (bondBit2 q) := by
       funext b
-      exact A_star_eq b (bit2 p) (bit2 q)
-    have hstaru : star (fun a => A a (bit1 p) (bit1 q)) = fun a => A a (bit1 p) (bit1 q) := by
+      exact A_star_eq b (bondBit2 p) (bondBit2 q)
+    have hstaru : star (fun a => A a (bondBit1 p) (bondBit1 q)) =
+        fun a => A a (bondBit1 p) (bondBit1 q) := by
       funext a
-      exact A_star_eq a (bit1 p) (bit1 q)
+      exact A_star_eq a (bondBit1 p) (bondBit1 q)
     rw [hstarv, hstaru, smul_smul]
     congr 1
     have hstar25 : star (25/32 : ℂ) = 25/32 := by
@@ -236,7 +240,7 @@ lemma transferMap_R_toMPSTensor_eq (X : Matrix (Fin 4) (Fin 4) ℂ) :
   simp_rw [hterm]
   ext a a'
   simp only [Fin.sum_univ_four, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul,
-    dotProduct, Matrix.mulVec, bit1, bit2, fixedDiag, Matrix.diagonal_apply,
+    dotProduct, Matrix.mulVec, bondBit1, bondBit2, fixedDiag, Matrix.diagonal_apply,
     A, sVal, Matrix.single_apply, Matrix.vecMulVec]
   fin_cases a <;> fin_cases a' <;> norm_num <;> ring
 

--- a/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RescalingStableLengthDependentRFPViaTS.lean
@@ -25,8 +25,8 @@ M X` for all virtual operators `X`.
 * `physClose1_R_entry`, `physClose2_R_entry` — closed-form entrywise
   formulas for `R`'s one- and two-site physical operators, showing
   `physClose2 R X` is a gate-restricted, rescaled pullback of `physClose1 R
-  X` along `combine p q := bondEquiv (bit1 p, bit2 q)`, with the
-  bond-matching condition `gate p q := bit2 p = bit1 q`.
+  X` along `combine p q := bondEquiv (bondBit1 p, bondBit2 q)`, with the
+  bond-matching condition `gate p q := bondBit2 p = bondBit1 q`.
 * `refineMap` (`T`) — two Kraus operators built from `wMat`'s
   Walsh–Hadamard eigendecomposition (`eigVecs`, `eigVals`).
 * `refineMap_isKrausCPTP` — `T` is trace-preserving completely positive.
@@ -57,57 +57,57 @@ namespace MPOTensor.RescalingStableLengthDependentRFP
 /-! ### IsRFPViaTS — the tp-CP renormalization maps
 
 The physical index `Fin 4` of `R` factors through the same bit reading used
-above: a physical index `p` carries the pair `(bit1 p, bit2 p)`.  `combine p q`
+above: a physical index `p` carries the pair `(bondBit1 p, bondBit2 p)`.  `combine p q`
 glues the first bit of `p` to the second bit of `q`, and `gate p q` is the
 bond-matching condition between two consecutive letters.  The two-site
 physical operator `physClose2 R X` is a rescaled, gate-restricted pullback of
 the one-site physical operator `physClose1 R X` along `combine`. -/
 
 /-- The physical index gluing the first bit of `p` to the second bit of `q`. -/
-def combine (p q : Fin 4) : Fin 4 := bondEquiv (bit1 p, bit2 q)
+def combine (p q : Fin 4) : Fin 4 := bondEquiv (bondBit1 p, bondBit2 q)
 
-@[simp] lemma bit1_combine (p q : Fin 4) : bit1 (combine p q) = bit1 p := by
-  simp [combine, bit1_eq_bondEquiv_symm_fst]
+@[simp] lemma bondBit1_combine (p q : Fin 4) : bondBit1 (combine p q) = bondBit1 p := by
+  simp [combine, bondBit1_eq_bondEquiv_symm_fst]
 
-@[simp] lemma bit2_combine (p q : Fin 4) : bit2 (combine p q) = bit2 q := by
-  simp [combine, bit2_eq_bondEquiv_symm_snd]
+@[simp] lemma bondBit2_combine (p q : Fin 4) : bondBit2 (combine p q) = bondBit2 q := by
+  simp [combine, bondBit2_eq_bondEquiv_symm_snd]
 
 /-- The bond-matching condition between two consecutive physical letters:
 the second bit of `p` equals the first bit of `q`. -/
-def gate (p q : Fin 4) : Prop := bit2 p = bit1 q
+def gate (p q : Fin 4) : Prop := bondBit2 p = bondBit1 q
 
 instance decidableGate (p q : Fin 4) : Decidable (gate p q) :=
-  inferInstanceAs (Decidable (bit2 p = bit1 q))
+  inferInstanceAs (Decidable (bondBit2 p = bondBit1 q))
 
 /-- The one-site physical operator of `R`, as a bilinear pairing of the
 letter-column vectors through `X`: `physClose1 R X i j = (25/32) *
 (u_{ij} ⬝ᵥ (v_{ij} ᵥ* X))`. -/
 lemma physClose1_R_entry (X : Matrix (Fin 4) (Fin 4) ℂ) (i j : Fin 4) :
     physClose1 R X i j = (25/32 : ℂ) *
-      ((fun a => A a (bit1 i) (bit1 j)) ⬝ᵥ
-        ((fun b => A b (bit2 i) (bit2 j)) ᵥ* X)) := by
+      ((fun a => A a (bondBit1 i) (bondBit1 j)) ⬝ᵥ
+        ((fun b => A b (bondBit2 i) (bondBit2 j)) ᵥ* X)) := by
   rw [physClose1_apply, R_eq_vecMulVec, Matrix.smul_mul, Matrix.trace_smul,
     Matrix.vecMulVec_mul, Matrix.trace_vecMulVec, smul_eq_mul]
 
 /-- **The two-site physical operator of `R` is a gate-restricted, rescaled
 pullback of the one-site physical operator along `combine`.** When both
 `(i1, i2)` and `(j1, j2)` satisfy the bond-matching condition `gate`, the
-`(i1,i2),(j1,j2)` entry of `physClose2 R X` is `(25/32) · wMat (bit2 i1)
-(bit2 j1)` times the `combine i1 i2, combine j1 j2` entry of `physClose1 R X`;
+`(i1,i2),(j1,j2)` entry of `physClose2 R X` is `(25/32) · wMat (bondBit2 i1)
+(bondBit2 j1)` times the `combine i1 i2, combine j1 j2` entry of `physClose1 R X`;
 otherwise it vanishes. -/
 lemma physClose2_R_entry (X : Matrix (Fin 4) (Fin 4) ℂ) (i1 i2 j1 j2 : Fin 4) :
     physClose2 R X (i1, i2) (j1, j2) =
-      (25/32 : ℂ) * (if gate i1 i2 ∧ gate j1 j2 then wMat (bit2 i1) (bit2 j1) else 0) *
+      (25/32 : ℂ) * (if gate i1 i2 ∧ gate j1 j2 then wMat (bondBit2 i1) (bondBit2 j1) else 0) *
         physClose1 R X (combine i1 i2) (combine j1 j2) := by
   rw [physClose2_apply, R_eq_vecMulVec, R_eq_vecMulVec]
   simp only [smul_mul_assoc, Matrix.mul_smul, smul_smul, Matrix.vecMulVec_mul_vecMulVec,
     Matrix.vecMulVec_smul]
   rw [Matrix.trace_smul, Matrix.vecMulVec_mul, Matrix.trace_vecMulVec, smul_eq_mul]
   rw [physClose1_R_entry]
-  simp only [bit1_combine, bit2_combine]
-  have hdot : (fun b : Fin 4 => A b (bit2 i1) (bit2 j1)) ⬝ᵥ
-      (fun a : Fin 4 => A a (bit1 i2) (bit1 j2)) =
-      if gate i1 i2 ∧ gate j1 j2 then wMat (bit2 i1) (bit2 j1) else 0 :=
+  simp only [bondBit1_combine, bondBit2_combine]
+  have hdot : (fun b : Fin 4 => A b (bondBit2 i1) (bondBit2 j1)) ⬝ᵥ
+      (fun a : Fin 4 => A a (bondBit1 i2) (bondBit1 j2)) =
+      if gate i1 i2 ∧ gate j1 j2 then wMat (bondBit2 i1) (bondBit2 j1) else 0 :=
     dotProduct_A_col _ _ _ _
   rw [hdot]
   by_cases h : gate i1 i2 ∧ gate j1 j2
@@ -138,14 +138,14 @@ lemma eigVecs_sq_sum (s : Fin 2) : (eigVecs s 0) ^ 2 + (eigVecs s 1) ^ 2 = 2 := 
 /-- **The gated fiber of `combine` over a physical index `k` has exactly two
 elements, indexed by the shared bond bit `b`.** For any function `f` of the
 first-site's second bit, the sum over gated pairs `(p, q)` with `combine p q
-= k` of `f (bit2 p)` collapses to `f 0 + f 1`. -/
+= k` of `f (bondBit2 p)` collapses to `f 0 + f 1`. -/
 lemma gated_combine_fiber_sum (k : Fin 4) (f : Fin 2 → ℂ) :
     (∑ pq : Fin 4 × Fin 4,
-        if gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k then f (bit2 pq.1) else 0) =
+        if gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k then f (bondBit2 pq.1) else 0) =
       f 0 + f 1 := by
   rw [Fintype.sum_prod_type]
   fin_cases k <;>
-    simp [gate, combine, bit1, bit2, bondEquiv_val, Fin.sum_univ_four]
+    simp [gate, combine, bondBit1, bondBit2, bondEquiv_val, Fin.sum_univ_four]
 
 /-! ### The refinement map `T`: one-site to two-site physical operators -/
 
@@ -160,12 +160,12 @@ lemma refineAmp_sq (s : Fin 2) : (refineAmp s) ^ 2 = 25 * eigVals s / 64 := by
 
 /-- The `s`-th Kraus operator of the refinement map `T` sending the one-site
 physical operator to the two-site physical operator: it places the
-amplitude `refineAmp s * eigVecs s (bit2 p)` at the gated pair `(p, q)`
+amplitude `refineAmp s * eigVecs s (bondBit2 p)` at the gated pair `(p, q)`
 whose `combine` equals `k`, and vanishes elsewhere. -/
 noncomputable def refineKraus (s : Fin 2) : Matrix (Fin 4 × Fin 4) (Fin 4) ℂ :=
   Matrix.of fun pq k =>
     if gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k then
-      (refineAmp s : ℂ) * eigVecs s (bit2 pq.1)
+      (refineAmp s : ℂ) * eigVecs s (bondBit2 pq.1)
     else 0
 
 /-- The refinement map `T` from one-site to two-site physical operators. -/
@@ -182,7 +182,7 @@ lemma eigVecs_star (s b : Fin 2) : star (eigVecs s b) = eigVecs s b := by
 lemma refineKraus_apply_conj_mul (s : Fin 2) (pq : Fin 4 × Fin 4) (k : Fin 4) :
     star (refineKraus s pq k) * refineKraus s pq k =
       if gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k then
-        (refineAmp s : ℂ) ^ 2 * (eigVecs s (bit2 pq.1)) ^ 2
+        (refineAmp s : ℂ) ^ 2 * (eigVecs s (bondBit2 pq.1)) ^ 2
       else 0 := by
   simp only [refineKraus, Matrix.of_apply]
   by_cases h : gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k
@@ -254,11 +254,11 @@ theorem refineMap_physClose1 (X : Matrix (Fin 4) (Fin 4) ℂ) :
   · have hstep : ∀ s : Fin 2,
         (∑ k : Fin 4, (∑ l : Fin 4, refineKraus s (i1, i2) l * physClose1 R X l k) *
             star (refineKraus s (j1, j2) k)) =
-          (refineAmp s : ℂ) ^ 2 * eigVecs s (bit2 i1) * eigVecs s (bit2 j1) *
+          (refineAmp s : ℂ) ^ 2 * eigVecs s (bondBit2 i1) * eigVecs s (bondBit2 j1) *
             physClose1 R X (combine i1 i2) (combine j1 j2) := by
       intro s
       have hl : ∀ k : Fin 4, (∑ l : Fin 4, refineKraus s (i1, i2) l * physClose1 R X l k) =
-          (refineAmp s : ℂ) * eigVecs s (bit2 i1) * physClose1 R X (combine i1 i2) k := by
+          (refineAmp s : ℂ) * eigVecs s (bondBit2 i1) * physClose1 R X (combine i1 i2) k := by
         intro k
         rw [Finset.sum_eq_single (combine i1 i2)]
         · simp [refineKraus, h.1]
@@ -278,11 +278,15 @@ theorem refineMap_physClose1 (X : Matrix (Fin 4) (Fin 4) ℂ) :
       · simp
     rw [Finset.sum_congr rfl fun s _ => hstep s, ← Finset.sum_mul]
     have hcomb :
-        (∑ s : Fin 2, (refineAmp s : ℂ) ^ 2 * eigVecs s (bit2 i1) * eigVecs s (bit2 j1)) =
-        (25/32 : ℂ) * wMat (bit2 i1) (bit2 j1) := by
+        (∑ s : Fin 2,
+          (refineAmp s : ℂ) ^ 2 * eigVecs s (bondBit2 i1) *
+            eigVecs s (bondBit2 j1)) =
+        (25/32 : ℂ) * wMat (bondBit2 i1) (bondBit2 j1) := by
       have hrw : ∀ s : Fin 2,
-          (refineAmp s : ℂ) ^ 2 * eigVecs s (bit2 i1) * eigVecs s (bit2 j1) =
-          (25/64 : ℂ) * ((eigVals s : ℂ) * eigVecs s (bit2 i1) * eigVecs s (bit2 j1)) := by
+          (refineAmp s : ℂ) ^ 2 * eigVecs s (bondBit2 i1) * eigVecs s (bondBit2 j1) =
+          (25/64 : ℂ) *
+            ((eigVals s : ℂ) * eigVecs s (bondBit2 i1) *
+              eigVecs s (bondBit2 j1)) := by
         intro s
         have hsq := refineAmp_sq s
         have : ((refineAmp s : ℝ) : ℂ) ^ 2 = ((refineAmp s) ^ 2 : ℝ) := by push_cast; ring
@@ -321,7 +325,7 @@ lemma coarseAmp_sq : coarseAmp ^ 2 = 1 / 2 := by
 noncomputable def coarseKrausGated (s : Fin 2) : Matrix (Fin 4) (Fin 4 × Fin 4) ℂ :=
   Matrix.of fun k pq =>
     if gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k then
-      (coarseAmp : ℂ) * eigVecs s (bit2 pq.1)
+      (coarseAmp : ℂ) * eigVecs s (bondBit2 pq.1)
     else 0
 
 /-- The `t`-th ungated Kraus operator of the coarse-graining map `S`: a
@@ -329,7 +333,7 @@ deterministic assignment of the (exactly one) ungated pair with `combine`
 value `k` and first-site second bit `t`. -/
 noncomputable def coarseKrausUngated (t : Fin 2) : Matrix (Fin 4) (Fin 4 × Fin 4) ℂ :=
   Matrix.of fun k pq =>
-    if ¬ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k ∧ bit2 pq.1 = t then 1 else 0
+    if ¬ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k ∧ bondBit2 pq.1 = t then 1 else 0
 
 /-- The coarse-graining map `S`, with four Kraus operators: two gated
 (sharing the Walsh–Hadamard structure with `T`) and two ungated (a
@@ -342,11 +346,12 @@ noncomputable def coarseMap :
       Fin 2 ⊕ Fin 2 → Matrix (Fin 4) (Fin 4 × Fin 4) ℂ)
 
 /-- A physical index is determined by its two bits. -/
-lemma eq_of_bit1_bit2 (p q : Fin 4) (h1 : bit1 p = bit1 q) (h2 : bit2 p = bit2 q) : p = q := by
+lemma eq_of_bondBit1_bondBit2 (p q : Fin 4) (h1 : bondBit1 p = bondBit1 q)
+    (h2 : bondBit2 p = bondBit2 q) : p = q := by
   have h : bondEquiv.symm p = bondEquiv.symm q := by
     apply Prod.ext
-    · rw [← bit1_eq_bondEquiv_symm_fst, ← bit1_eq_bondEquiv_symm_fst, h1]
-    · rw [← bit2_eq_bondEquiv_symm_snd, ← bit2_eq_bondEquiv_symm_snd, h2]
+    · rw [← bondBit1_eq_bondEquiv_symm_fst, ← bondBit1_eq_bondEquiv_symm_fst, h1]
+    · rw [← bondBit2_eq_bondEquiv_symm_snd, ← bondBit2_eq_bondEquiv_symm_snd, h2]
   exact bondEquiv.symm.injective h
 
 /-- `Σ_s eigVecs s b ^ 2 = 2` for a fixed bit `b`, summing over the eigenbasis label. -/
@@ -359,44 +364,44 @@ lemma fin2_eq_of_ne_ne {a b c : Fin 2} (hac : a ≠ c) (hbc : b ≠ c) : a = b :
 
 /-- An ungated pair is determined by its `combine` value and the first
 site's second bit. -/
-lemma eq_of_ungated_combine_bit2 {pq pq' : Fin 4 × Fin 4} (h1 : ¬ gate pq.1 pq.2)
+lemma eq_of_ungated_combine_bondBit2 {pq pq' : Fin 4 × Fin 4} (h1 : ¬ gate pq.1 pq.2)
     (h1' : ¬ gate pq'.1 pq'.2) (hc : combine pq.1 pq.2 = combine pq'.1 pq'.2)
-    (hb : bit2 pq.1 = bit2 pq'.1) : pq = pq' := by
-  have e1 : bit1 pq.1 = bit1 pq'.1 := by
-    have h := congrArg bit1 hc
-    rwa [bit1_combine, bit1_combine] at h
-  have e2 : bit2 pq.2 = bit2 pq'.2 := by
-    have h := congrArg bit2 hc
-    rwa [bit2_combine, bit2_combine] at h
-  have e3 : bit1 pq.2 = bit1 pq'.2 := by
-    have h1b : bit1 pq.2 ≠ bit2 pq.1 := fun h => h1 h.symm
-    have h1'b : bit1 pq'.2 ≠ bit2 pq.1 := by
+    (hb : bondBit2 pq.1 = bondBit2 pq'.1) : pq = pq' := by
+  have e1 : bondBit1 pq.1 = bondBit1 pq'.1 := by
+    have h := congrArg bondBit1 hc
+    rwa [bondBit1_combine, bondBit1_combine] at h
+  have e2 : bondBit2 pq.2 = bondBit2 pq'.2 := by
+    have h := congrArg bondBit2 hc
+    rwa [bondBit2_combine, bondBit2_combine] at h
+  have e3 : bondBit1 pq.2 = bondBit1 pq'.2 := by
+    have h1b : bondBit1 pq.2 ≠ bondBit2 pq.1 := fun h => h1 h.symm
+    have h1'b : bondBit1 pq'.2 ≠ bondBit2 pq.1 := by
       rw [hb]; exact fun h => h1' h.symm
     exact fin2_eq_of_ne_ne h1b h1'b
   apply Prod.ext
-  · exact eq_of_bit1_bit2 _ _ e1 hb
-  · exact eq_of_bit1_bit2 _ _ e3 e2
+  · exact eq_of_bondBit1_bondBit2 _ _ e1 hb
+  · exact eq_of_bondBit1_bondBit2 _ _ e3 e2
 
 lemma coarseAmp_star : star ((coarseAmp : ℝ) : ℂ) = (coarseAmp : ℂ) :=
   Complex.conj_ofReal _
 
 /-- Two `gate`-satisfying pairs sharing a `combine` value and distinct from
 each other cannot share their first site's second bit: if they did,
-`eq_of_bit1_bit2` would force the pairs to coincide. -/
-lemma bit2_ne_of_gate_combine_eq {pq pq' : Fin 4 × Fin 4} (hg : gate pq.1 pq.2)
+`eq_of_bondBit1_bondBit2` would force the pairs to coincide. -/
+lemma bondBit2_ne_of_gate_combine_eq {pq pq' : Fin 4 × Fin 4} (hg : gate pq.1 pq.2)
     (hg' : gate pq'.1 pq'.2) (hc : combine pq.1 pq.2 = combine pq'.1 pq'.2) (hne : pq ≠ pq') :
-    bit2 pq.1 ≠ bit2 pq'.1 := by
+    bondBit2 pq.1 ≠ bondBit2 pq'.1 := by
   intro hb
   apply hne
-  have h1 : bit1 pq.1 = bit1 pq'.1 := by
-    have := congrArg bit1 hc
-    rwa [bit1_combine, bit1_combine] at this
-  have hp1 : pq.1 = pq'.1 := eq_of_bit1_bit2 _ _ h1 hb
-  have h2 : bit1 pq.2 = bit1 pq'.2 := hg.symm.trans (hb.trans hg')
-  have h3 : bit2 pq.2 = bit2 pq'.2 := by
-    have := congrArg bit2 hc
-    rwa [bit2_combine, bit2_combine] at this
-  exact Prod.ext hp1 (eq_of_bit1_bit2 _ _ h2 h3)
+  have h1 : bondBit1 pq.1 = bondBit1 pq'.1 := by
+    have := congrArg bondBit1 hc
+    rwa [bondBit1_combine, bondBit1_combine] at this
+  have hp1 : pq.1 = pq'.1 := eq_of_bondBit1_bondBit2 _ _ h1 hb
+  have h2 : bondBit1 pq.2 = bondBit1 pq'.2 := hg.symm.trans (hb.trans hg')
+  have h3 : bondBit2 pq.2 = bondBit2 pq'.2 := by
+    have := congrArg bondBit2 hc
+    rwa [bondBit2_combine, bondBit2_combine] at this
+  exact Prod.ext hp1 (eq_of_bondBit1_bondBit2 _ _ h2 h3)
 
 /-- The off-diagonal cancellation between the eigenbasis rows for distinct
 bits: the two gated Kraus operators of `S` are orthogonal on any pair of
@@ -419,16 +424,16 @@ lemma coarseKraus_resolution :
   have hgated_term : ∀ s : Fin 2,
       (∑ k : Fin 4, star (coarseKrausGated s k pq) * coarseKrausGated s k pq') =
         if gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2 then
-          (coarseAmp : ℂ) ^ 2 * eigVecs s (bit2 pq.1) * eigVecs s (bit2 pq'.1)
+          (coarseAmp : ℂ) ^ 2 * eigVecs s (bondBit2 pq.1) * eigVecs s (bondBit2 pq'.1)
         else 0 := by
     intro s
     by_cases h : gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2
     · rw [if_pos h]
       have e1 : coarseKrausGated s (combine pq.1 pq.2) pq =
-          (coarseAmp : ℂ) * eigVecs s (bit2 pq.1) := by
+          (coarseAmp : ℂ) * eigVecs s (bondBit2 pq.1) := by
         simp [coarseKrausGated, Matrix.of_apply, h.1]
       have e2 : coarseKrausGated s (combine pq.1 pq.2) pq' =
-          (coarseAmp : ℂ) * eigVecs s (bit2 pq'.1) := by
+          (coarseAmp : ℂ) * eigVecs s (bondBit2 pq'.1) := by
         simp only [coarseKrausGated, Matrix.of_apply]
         exact if_pos ⟨h.2.1, h.2.2.symm⟩
       rw [Finset.sum_eq_single (combine pq.1 pq.2)]
@@ -466,10 +471,12 @@ lemma coarseKraus_resolution :
   -- The ungated contribution at a fixed label `t`, as a sum over the domain `Fin 4`.
   have hungated_term : ∀ t : Fin 2,
       (∑ k : Fin 4, star (coarseKrausUngated t k pq) * coarseKrausUngated t k pq') =
-        if ¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = t ∧ bit2 pq'.1 = t ∧
+        if ¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bondBit2 pq.1 = t ∧
+            bondBit2 pq'.1 = t ∧
             combine pq.1 pq.2 = combine pq'.1 pq'.2 then 1 else 0 := by
     intro t
-    by_cases h : ¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = t ∧ bit2 pq'.1 = t ∧
+    by_cases h : ¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bondBit2 pq.1 = t ∧
+        bondBit2 pq'.1 = t ∧
         combine pq.1 pq.2 = combine pq'.1 pq'.2
     · rw [if_pos h]
       obtain ⟨hg1, hg2, hb1, hb2, hc⟩ := h
@@ -490,8 +497,10 @@ lemma coarseKraus_resolution :
     · rw [if_neg h]
       apply Finset.sum_eq_zero
       intro k _
-      by_cases hpk : ¬ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k ∧ bit2 pq.1 = t
-      · have hpk' : ¬ (¬ gate pq'.1 pq'.2 ∧ combine pq'.1 pq'.2 = k ∧ bit2 pq'.1 = t) := by
+      by_cases hpk : ¬ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = k ∧ bondBit2 pq.1 = t
+      · have hpk' :
+            ¬ (¬ gate pq'.1 pq'.2 ∧ combine pq'.1 pq'.2 = k ∧
+              bondBit2 pq'.1 = t) := by
           rintro ⟨hg', hc', hb'⟩
           exact h ⟨hpk.1, hg', hpk.2.2, hb', hpk.2.1.trans hc'.symm⟩
         have e : coarseKrausUngated t k pq' = 0 := by
@@ -509,39 +518,47 @@ lemma coarseKraus_resolution :
     by_cases hg : gate pq.1 pq.2
     · have hCg : gate pq.1 pq.2 ∧ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = combine pq.1 pq.2 :=
         ⟨hg, hg, rfl⟩
-      have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
-          bit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := fun hc => hc.1 hg
-      have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
-          bit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := fun hc => hc.1 hg
+      have hCu0 :
+          ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bondBit2 pq.1 = (0 : Fin 2) ∧
+            bondBit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) :=
+        fun hc => hc.1 hg
+      have hCu1 :
+          ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bondBit2 pq.1 = (1 : Fin 2) ∧
+            bondBit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) :=
+        fun hc => hc.1 hg
       rw [if_pos hCg, if_pos hCg, if_neg hCu0, if_neg hCu1]
-      have hsum : (eigVecs 0 (bit2 pq.1)) ^ 2 + (eigVecs 1 (bit2 pq.1)) ^ 2 = (2 : ℂ) := by
-        exact_mod_cast eigVecs_sq_sum' (bit2 pq.1)
+      have hsum :
+          (eigVecs 0 (bondBit2 pq.1)) ^ 2 + (eigVecs 1 (bondBit2 pq.1)) ^ 2 =
+            (2 : ℂ) := by
+        exact_mod_cast eigVecs_sq_sum' (bondBit2 pq.1)
       have hamp : (coarseAmp : ℂ) ^ 2 = (1 / 2 : ℂ) := by
         have hcast : ((coarseAmp : ℝ) : ℂ) ^ 2 = ((coarseAmp ^ 2 : ℝ) : ℂ) := by push_cast; ring
         rw [hcast, coarseAmp_sq]; norm_num
-      have step : (coarseAmp : ℂ) ^ 2 * eigVecs 0 (bit2 pq.1) * eigVecs 0 (bit2 pq.1) +
-          (coarseAmp : ℂ) ^ 2 * eigVecs 1 (bit2 pq.1) * eigVecs 1 (bit2 pq.1) + (0 + 0) =
-          (coarseAmp : ℂ) ^ 2 * ((eigVecs 0 (bit2 pq.1)) ^ 2 + (eigVecs 1 (bit2 pq.1)) ^ 2) := by
+      have step :
+          (coarseAmp : ℂ) ^ 2 * eigVecs 0 (bondBit2 pq.1) * eigVecs 0 (bondBit2 pq.1) +
+          (coarseAmp : ℂ) ^ 2 * eigVecs 1 (bondBit2 pq.1) * eigVecs 1 (bondBit2 pq.1) + (0 + 0) =
+          (coarseAmp : ℂ) ^ 2 *
+            ((eigVecs 0 (bondBit2 pq.1)) ^ 2 + (eigVecs 1 (bondBit2 pq.1)) ^ 2) := by
         ring
       rw [step, hsum, hamp]; norm_num
     · have hCg : ¬ (gate pq.1 pq.2 ∧ gate pq.1 pq.2 ∧ combine pq.1 pq.2 = combine pq.1 pq.2) :=
         fun hc => hg hc.1
       rw [if_neg hCg, if_neg hCg]
-      by_cases hb : bit2 pq.1 = (0 : Fin 2)
-      · have hCu0 : ¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
-            bit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2 :=
+      by_cases hb : bondBit2 pq.1 = (0 : Fin 2)
+      · have hCu0 : ¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bondBit2 pq.1 = (0 : Fin 2) ∧
+            bondBit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2 :=
           ⟨hg, hg, hb, hb, rfl⟩
-        have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
-            bit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := by
+        have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bondBit2 pq.1 = (1 : Fin 2) ∧
+            bondBit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := by
           rintro ⟨_, _, hb1, _, _⟩
           rw [hb] at hb1; exact absurd hb1 (by decide)
         rw [if_pos hCu0, if_neg hCu1]; norm_num
-      · have hb1 : bit2 pq.1 = (1 : Fin 2) := by omega
-        have hCu1 : ¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
-            bit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2 :=
+      · have hb1 : bondBit2 pq.1 = (1 : Fin 2) := by omega
+        have hCu1 : ¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bondBit2 pq.1 = (1 : Fin 2) ∧
+            bondBit2 pq.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2 :=
           ⟨hg, hg, hb1, hb1, rfl⟩
-        have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
-            bit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := by
+        have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq.1 pq.2 ∧ bondBit2 pq.1 = (0 : Fin 2) ∧
+            bondBit2 pq.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq.1 pq.2) := by
           rintro ⟨_, _, hb0, _, _⟩
           exact hb hb0
         rw [if_neg hCu0, if_pos hCu1]; norm_num
@@ -549,51 +566,73 @@ lemma coarseKraus_resolution :
     by_cases hg : gate pq.1 pq.2
     · by_cases hg' : gate pq'.1 pq'.2
       · by_cases hc : combine pq.1 pq.2 = combine pq'.1 pq'.2
-        · have hCg : gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2 :=
+        · have hCg :
+              gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧
+                combine pq.1 pq.2 = combine pq'.1 pq'.2 :=
             ⟨hg, hg', hc⟩
-          have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
-              bit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+          have hCu0 :
+              ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧
+                bondBit2 pq.1 = (0 : Fin 2) ∧
+              bondBit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
             fun hcon => hcon.1 hg
-          have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
-              bit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+          have hCu1 :
+              ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧
+                bondBit2 pq.1 = (1 : Fin 2) ∧
+              bondBit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
             fun hcon => hcon.1 hg
           rw [if_pos hCg, if_pos hCg, if_neg hCu0, if_neg hCu1]
-          have hbne : bit2 pq.1 ≠ bit2 pq'.1 := bit2_ne_of_gate_combine_eq hg hg' hc heq
-          have step : (coarseAmp : ℂ) ^ 2 * eigVecs 0 (bit2 pq.1) * eigVecs 0 (bit2 pq'.1) +
-              (coarseAmp : ℂ) ^ 2 * eigVecs 1 (bit2 pq.1) * eigVecs 1 (bit2 pq'.1) + (0 + 0) =
+          have hbne : bondBit2 pq.1 ≠ bondBit2 pq'.1 :=
+            bondBit2_ne_of_gate_combine_eq hg hg' hc heq
+          have step :
+              (coarseAmp : ℂ) ^ 2 * eigVecs 0 (bondBit2 pq.1) *
+                eigVecs 0 (bondBit2 pq'.1) +
+              (coarseAmp : ℂ) ^ 2 * eigVecs 1 (bondBit2 pq.1) *
+                eigVecs 1 (bondBit2 pq'.1) + (0 + 0) =
               (coarseAmp : ℂ) ^ 2 *
-                (eigVecs 0 (bit2 pq.1) * eigVecs 0 (bit2 pq'.1) +
-                  eigVecs 1 (bit2 pq.1) * eigVecs 1 (bit2 pq'.1)) := by
+                (eigVecs 0 (bondBit2 pq.1) * eigVecs 0 (bondBit2 pq'.1) +
+                  eigVecs 1 (bondBit2 pq.1) * eigVecs 1 (bondBit2 pq'.1)) := by
             ring
           rw [step, eigVecs_orthogonal' hbne, mul_zero]
         · have hCg : ¬ (gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧
               combine pq.1 pq.2 = combine pq'.1 pq'.2) := fun hcon => hc hcon.2.2
-          have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
-              bit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+          have hCu0 :
+              ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧
+                bondBit2 pq.1 = (0 : Fin 2) ∧
+              bondBit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
             fun hcon => hcon.1 hg
-          have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
-              bit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+          have hCu1 :
+              ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧
+                bondBit2 pq.1 = (1 : Fin 2) ∧
+              bondBit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
             fun hcon => hcon.1 hg
           rw [if_neg hCg, if_neg hCg, if_neg hCu0, if_neg hCu1]; norm_num
       · have hCg : ¬ (gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧
             combine pq.1 pq.2 = combine pq'.1 pq'.2) := fun hcon => hg' hcon.2.1
-        have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
-            bit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+        have hCu0 :
+            ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧
+              bondBit2 pq.1 = (0 : Fin 2) ∧
+            bondBit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
           fun hcon => hcon.1 hg
-        have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
-            bit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
+        have hCu1 :
+            ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧
+              bondBit2 pq.1 = (1 : Fin 2) ∧
+            bondBit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) :=
           fun hcon => hcon.1 hg
         rw [if_neg hCg, if_neg hCg, if_neg hCu0, if_neg hCu1]; norm_num
     · have hCg : ¬ (gate pq.1 pq.2 ∧ gate pq'.1 pq'.2 ∧
           combine pq.1 pq.2 = combine pq'.1 pq'.2) := fun hcon => hg hcon.1
-      have hCu0 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (0 : Fin 2) ∧
-          bit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) := by
+      have hCu0 :
+          ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧
+            bondBit2 pq.1 = (0 : Fin 2) ∧
+          bondBit2 pq'.1 = (0 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) := by
         rintro ⟨hg1, hg1', hb1, hb1', hceq⟩
-        exact heq (eq_of_ungated_combine_bit2 hg1 hg1' hceq (hb1.trans hb1'.symm))
-      have hCu1 : ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧ bit2 pq.1 = (1 : Fin 2) ∧
-          bit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) := by
+        exact heq (eq_of_ungated_combine_bondBit2 hg1 hg1' hceq (hb1.trans hb1'.symm))
+      have hCu1 :
+          ¬ (¬ gate pq.1 pq.2 ∧ ¬ gate pq'.1 pq'.2 ∧
+            bondBit2 pq.1 = (1 : Fin 2) ∧
+          bondBit2 pq'.1 = (1 : Fin 2) ∧ combine pq.1 pq.2 = combine pq'.1 pq'.2) := by
         rintro ⟨hg1, hg1', hb1, hb1', hceq⟩
-        exact heq (eq_of_ungated_combine_bit2 hg1 hg1' hceq (hb1.trans hb1'.symm))
+        exact heq (eq_of_ungated_combine_bondBit2 hg1 hg1' hceq (hb1.trans hb1'.symm))
       rw [if_neg hCg, if_neg hCg, if_neg hCu0, if_neg hCu1]; norm_num
 
 /-- **`coarseMap` is trace-preserving completely positive.** -/
@@ -623,7 +662,7 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
     have hinner : (∑ p : Fin 4 × Fin 4, coarseKrausUngated t i p * physClose2 R X p q) = 0 := by
       apply Finset.sum_eq_zero
       intro p _
-      by_cases hp : ¬ gate p.1 p.2 ∧ combine p.1 p.2 = i ∧ bit2 p.1 = t
+      by_cases hp : ¬ gate p.1 p.2 ∧ combine p.1 p.2 = i ∧ bondBit2 p.1 = t
       · have hz : physClose2 R X p q = 0 := by
           rw [physClose2_R_entry, if_neg (fun hcon : gate p.1 p.2 ∧ gate q.1 q.2 => hp.1 hcon.1)]
           ring
@@ -647,7 +686,7 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
       (∑ p : Fin 4 × Fin 4, coarseKrausGated s i p * physClose2 R X p q) =
         (if gate q.1 q.2 then
             (coarseAmp : ℂ) * (25 / 32 : ℂ) * physClose1 R X i (combine q.1 q.2) *
-              (eigVecs s 0 * wMat 0 (bit2 q.1) + eigVecs s 1 * wMat 1 (bit2 q.1))
+              (eigVecs s 0 * wMat 0 (bondBit2 q.1) + eigVecs s 1 * wMat 1 (bondBit2 q.1))
           else 0) := by
     intro s q
     by_cases hq : gate q.1 q.2
@@ -655,17 +694,19 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
       have hcongr : (∑ p : Fin 4 × Fin 4, coarseKrausGated s i p * physClose2 R X p q) =
           ∑ p : Fin 4 × Fin 4, if gate p.1 p.2 ∧ combine p.1 p.2 = i then
               (coarseAmp : ℂ) * (25 / 32 : ℂ) * physClose1 R X i (combine q.1 q.2) *
-                (eigVecs s (bit2 p.1) * wMat (bit2 p.1) (bit2 q.1))
+                (eigVecs s (bondBit2 p.1) * wMat (bondBit2 p.1) (bondBit2 q.1))
             else 0 := by
         apply Finset.sum_congr rfl
         intro p _
         by_cases hp : gate p.1 p.2 ∧ combine p.1 p.2 = i
         · rw [if_pos hp]
-          have e : coarseKrausGated s i p = (coarseAmp : ℂ) * eigVecs s (bit2 p.1) := by
+          have e : coarseKrausGated s i p = (coarseAmp : ℂ) * eigVecs s (bondBit2 p.1) := by
             simp only [coarseKrausGated, Matrix.of_apply]
             exact if_pos hp
-          have c1 : (if gate p.1 p.2 ∧ gate q.1 q.2 then wMat (bit2 p.1) (bit2 q.1) else 0) =
-              wMat (bit2 p.1) (bit2 q.1) := if_pos ⟨hp.1, hq⟩
+          have c1 :
+              (if gate p.1 p.2 ∧ gate q.1 q.2 then
+                wMat (bondBit2 p.1) (bondBit2 q.1) else 0) =
+              wMat (bondBit2 p.1) (bondBit2 q.1) := if_pos ⟨hp.1, hq⟩
           rw [e, physClose2_R_entry, hp.2, c1]; ring
         · rw [if_neg hp]
           have e : coarseKrausGated s i p = 0 := by
@@ -673,16 +714,18 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
             exact if_neg hp
           rw [e, zero_mul]
       rw [hcongr, gated_combine_fiber_sum i (fun b => (coarseAmp : ℂ) * (25 / 32 : ℂ) *
-          physClose1 R X i (combine q.1 q.2) * (eigVecs s b * wMat b (bit2 q.1)))]
+          physClose1 R X i (combine q.1 q.2) * (eigVecs s b * wMat b (bondBit2 q.1)))]
       ring
     · rw [if_neg hq]
       apply Finset.sum_eq_zero
       intro p _
       by_cases hp : gate p.1 p.2 ∧ combine p.1 p.2 = i
-      · have e : coarseKrausGated s i p = (coarseAmp : ℂ) * eigVecs s (bit2 p.1) := by
+      · have e : coarseKrausGated s i p = (coarseAmp : ℂ) * eigVecs s (bondBit2 p.1) := by
           simp only [coarseKrausGated, Matrix.of_apply]
           exact if_pos hp
-        have c1 : (if gate p.1 p.2 ∧ gate q.1 q.2 then wMat (bit2 p.1) (bit2 q.1) else 0) = 0 :=
+        have c1 :
+            (if gate p.1 p.2 ∧ gate q.1 q.2 then
+              wMat (bondBit2 p.1) (bondBit2 q.1) else 0) = 0 :=
           if_neg (fun hcon => hq hcon.2)
         rw [e, physClose2_R_entry, c1]; ring
       · have e : coarseKrausGated s i p = 0 := by
@@ -700,15 +743,15 @@ theorem coarseMap_physClose2 (X : Matrix (Fin 4) (Fin 4) ℂ) :
         coarseKrausGated s i p * physClose2 R X p q) * star (coarseKrausGated s j q)) =
         ∑ q : Fin 4 × Fin 4, if gate q.1 q.2 ∧ combine q.1 q.2 = j then
             (coarseAmp : ℂ) ^ 2 * (25 / 32 : ℂ) * physClose1 R X i j *
-              (eigVecs s 0 * wMat 0 (bit2 q.1) + eigVecs s 1 * wMat 1 (bit2 q.1)) *
-              eigVecs s (bit2 q.1)
+              (eigVecs s 0 * wMat 0 (bondBit2 q.1) + eigVecs s 1 * wMat 1 (bondBit2 q.1)) *
+              eigVecs s (bondBit2 q.1)
           else 0 := by
       apply Finset.sum_congr rfl
       intro q _
       rw [hinner]
       by_cases hqj : gate q.1 q.2 ∧ combine q.1 q.2 = j
       · rw [if_pos hqj.1, if_pos hqj, hqj.2]
-        have e : coarseKrausGated s j q = (coarseAmp : ℂ) * eigVecs s (bit2 q.1) := by
+        have e : coarseKrausGated s j q = (coarseAmp : ℂ) * eigVecs s (bondBit2 q.1) := by
           simp only [coarseKrausGated, Matrix.of_apply]
           exact if_pos hqj
         rw [e, star_mul', eigVecs_star, coarseAmp_star]

--- a/TNLean/MPS/MPDO/RescalingStableSourceSimple.lean
+++ b/TNLean/MPS/MPDO/RescalingStableSourceSimple.lean
@@ -92,7 +92,7 @@ theorem R_isSourceSimple : MPOTensor.IsSourceSimple R := by
     intro N hN hzero
     have hentry := congrFun (congrFun hzero (fun _ => 0)) (fun _ => 0)
     rw [mpo_R_entry_formula hN] at hentry
-    simp [chainIndicator, ChainOK, φ, wN, wMat, bit1, bit2] at hentry
+    simp [chainIndicator, ChainOK, φ, wN, wMat, bondBit1, bondBit2] at hentry
   refine ⟨R_isMPDO, hRne, 1, by norm_num, ?_⟩
   let data := canonicalFormData.reindexPhysical oneSiteDoubledEquiv
   let ref := data.activeBNTRefinement


### PR DESCRIPTION
## Summary

- rename the dimer bond-label projections from namespace-shadowing `bit1`/`bit2` to
  `bondBit1`/`bondBit2`
- rename the dependent local lemmas and update every call site, including the newly merged
  source-facing simplicity witness
- preserve all mathematical terms and theorem content; a whitespace-insensitive audit after mapping
  the identifiers back is identical to `origin/main`

## Scope

This is elaboration hygiene only. It does not change the dimer tensor, RFP maps, simplicity
predicates, Blueprint claims, or the CPSV16 normalization/presentation conclusions.

## Checks

- targeted Lean: `RescalingStableLengthDependentRFP.lean`
- targeted Lean: `RescalingStableChiAttachment.lean`
- targeted Lean: `RescalingStableLengthDependentRFPCanonicalForm.lean`
- targeted Lean: `RescalingStableLengthDependentRFPViaTS.lean`
- targeted Lean: `RescalingStableLengthDependentRFPCapstone.lean`
- targeted Lean: `RescalingStableSourceSimple.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- no stale lowercase `bit1`/`bit2` in `RescalingStable*.lean`
- no `sorry`/`axiom` in changed files
- `git diff --check`

Closes #6486.
