### PR TITLE
feat(QCA): extend translations to quasi-local algebra

### DIFF
--- a/TNLean/Analysis/CStarCompletion.lean
+++ b/TNLean/Analysis/CStarCompletion.lean
@@ -22,6 +22,8 @@ both are imported together.
 * `UniformSpace.Completion.toComplAlgHom` — the canonical algebra homomorphism into the
   completion.
 * `UniformSpace.Completion.toComplStarAlgHom` — its star-preserving version.
+* `UniformSpace.Completion.mapStarAlgEquiv` — the extension of a continuous star-algebra
+  equivalence whose inverse is continuous.
 
 ## Main results
 
@@ -128,6 +130,71 @@ theorem denseRange_toComplStarAlgHom :
   Completion.denseRange_coe
 
 end Complex
+
+section MapStarAlgEquiv
+
+variable [NormedStarGroup A] [NormedAlgebra ℂ A]
+  {B : Type*} [NormedRing B] [StarRing B] [NormedStarGroup B] [NormedAlgebra ℂ B]
+
+/-- A continuous complex star-algebra equivalence with continuous inverse extends to the norm
+completions. -/
+noncomputable def mapStarAlgEquiv (f : A ≃⋆ₐ[ℂ] B)
+    (hf : Continuous f) (hf' : Continuous f.symm) : Completion A ≃⋆ₐ[ℂ] Completion B where
+  toFun := Completion.map f
+  invFun := Completion.map f.symm
+  left_inv x := by
+    induction x using Completion.induction_on with
+    | hp => exact isClosed_eq (by fun_prop) continuous_id
+    | ih a => simp only [Completion.map_coe
+        (uniformContinuous_addMonoidHom_of_continuous hf), Completion.map_coe
+        (uniformContinuous_addMonoidHom_of_continuous hf'), f.symm_apply_apply]
+  right_inv x := by
+    induction x using Completion.induction_on with
+    | hp => exact isClosed_eq (by fun_prop) continuous_id
+    | ih b => simp only [Completion.map_coe
+        (uniformContinuous_addMonoidHom_of_continuous hf'), Completion.map_coe
+        (uniformContinuous_addMonoidHom_of_continuous hf), f.apply_symm_apply]
+  map_mul' x y := by
+    induction x, y using Completion.induction_on₂ with
+    | hp => exact isClosed_eq (by fun_prop) (by fun_prop)
+    | ih a b => simp only [← coe_mul, Completion.map_coe
+        (uniformContinuous_addMonoidHom_of_continuous hf), map_mul]
+  map_add' x y := by
+    induction x, y using Completion.induction_on₂ with
+    | hp => exact isClosed_eq (by fun_prop) (by fun_prop)
+    | ih a b => simp only [← coe_add, Completion.map_coe
+        (uniformContinuous_addMonoidHom_of_continuous hf), map_add]
+  map_star' x := by
+    induction x using Completion.induction_on with
+    | hp => exact isClosed_eq (by fun_prop) (by fun_prop)
+    | ih a => simp only [← coe_star, Completion.map_coe
+        (uniformContinuous_addMonoidHom_of_continuous hf), map_star]
+  map_smul' c x := by
+    induction x using Completion.induction_on with
+    | hp =>
+        exact isClosed_eq
+          (Completion.continuous_map.comp
+            (ContinuousConstSMul.continuous_const_smul c))
+          ((ContinuousConstSMul.continuous_const_smul c).comp
+            Completion.continuous_map)
+    | ih a => simp only [← coe_smul, Completion.map_coe
+        (uniformContinuous_addMonoidHom_of_continuous hf), map_smul]
+
+/-- The extension of a star-algebra equivalence acts by the completion map. -/
+theorem mapStarAlgEquiv_apply (f : A ≃⋆ₐ[ℂ] B)
+    (hf : Continuous f) (hf' : Continuous f.symm) (x : Completion A) :
+    mapStarAlgEquiv f hf hf' x = Completion.map f x :=
+  rfl
+
+/-- The extension of a star-algebra equivalence agrees with it on the original algebra. -/
+@[simp]
+theorem mapStarAlgEquiv_coe (f : A ≃⋆ₐ[ℂ] B)
+    (hf : Continuous f) (hf' : Continuous f.symm) (a : A) :
+    mapStarAlgEquiv f hf hf' (a : Completion A) = (f a : B) := by
+  rw [mapStarAlgEquiv_apply, Completion.map_coe
+    (uniformContinuous_addMonoidHom_of_continuous hf)]
+
+end MapStarAlgEquiv
 
 section ComplexCStar
 

--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -13,5 +13,6 @@ import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit
 import TNLean.QCA.LocalNorm
 import TNLean.QCA.QuasiLocal
+import TNLean.QCA.QuasiLocalTranslation
 import TNLean.QCA.RegionSumset
 import TNLean.QCA.Translation

--- a/TNLean/QCA/QuasiLocalTranslation.lean
+++ b/TNLean/QCA/QuasiLocalTranslation.lean
@@ -156,7 +156,8 @@ lemma quasiLocalTranslation_symm (d : ℕ) [NeZero d] (a : ℤ) :
 /-- Quasi-local translation preserves the operator norm.
 
 Source context: the appendix invokes translation as an automorphism of the quasi-local algebra at
-line 2298; norm preservation is a standard C-star algebra consequence, not a separate claim there. -/
+line 2298; norm preservation is a standard C-star algebra consequence, not a separate claim
+there. -/
 @[simp]
 lemma norm_quasiLocalTranslation (d : ℕ) [NeZero d] (a : ℤ)
     (A : QuasiLocalAlgebra d) :

--- a/TNLean/QCA/QuasiLocalTranslation.lean
+++ b/TNLean/QCA/QuasiLocalTranslation.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.AlgebraicTranslation
+import TNLean.QCA.QuasiLocal
+
+/-!
+# Translations of quasi-local observables
+
+Operator-norm isometries of the algebraic local algebra extend continuously to its completion.
+Thus lattice translations induce an additive action on the quasi-local observable algebra by
+star-algebra equivalences. The extension agrees with algebraic-local and finite-region translation
+on the dense local subalgebra and preserves the operator norm.
+
+This file concerns translations of quasi-local observables only. It does not define finite support
+in the completion, finite propagation, translation covariance, or quantum cellular automata.
+
+## Main definitions
+
+* `SpinChain.quasiLocalTranslation` — quasi-local translation as a star-algebra equivalence.
+
+## Main results
+
+* `SpinChain.quasiLocalTranslation_algebraicToQuasiLocal` — evaluation on the dense algebraic
+  subalgebra.
+* `SpinChain.quasiLocalTranslation_quasiLocalObservable` — evaluation on a finite-region
+  representative.
+* `SpinChain.quasiLocalTranslation_zero`, `SpinChain.quasiLocalTranslation_add`, and
+  `SpinChain.quasiLocalTranslation_symm` — the additive action and inverse laws.
+* `SpinChain.norm_quasiLocalTranslation` and `SpinChain.quasiLocalTranslation_isometry` — norm
+  and distance preservation.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2292--2306.
+* Schumacher--Werner, quant-ph/0405174, Definition 1.
+-/
+
+open scoped ComplexOrder
+
+namespace SpinChain
+
+attribute [local instance] CStarMatrix.instNorm CStarMatrix.instNormedAddCommGroup
+  CStarMatrix.instNormedRing CStarMatrix.instCStarRing
+
+/-- Translation by a lattice displacement extends from algebraic-local observables to a
+star-algebra equivalence of the quasi-local algebra.
+
+Source context: arXiv:1703.09188, Appendix, lines 2292--2296 construct the quasi-local
+completion, while line 2298 invokes its translation operator in the definition of a QCA and line
+2306 invokes translation covariance. The extension below supplies that background operator; it is
+not stated separately in the appendix. -/
+noncomputable def quasiLocalTranslation (d : ℕ) [NeZero d] (a : ℤ) :
+    QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d :=
+  UniformSpace.Completion.mapStarAlgEquiv
+    (algebraicLocalTranslation d a)
+    (algebraicLocalTranslation_isometry d a).continuous
+    (by
+      rw [algebraicLocalTranslation_symm]
+      exact (algebraicLocalTranslation_isometry d (-a)).continuous)
+
+/-- Quasi-local translation acts by the completion map of algebraic-local translation. -/
+lemma quasiLocalTranslation_apply (d : ℕ) [NeZero d] (a : ℤ)
+    (A : QuasiLocalAlgebra d) :
+    quasiLocalTranslation d a A =
+      UniformSpace.Completion.map (algebraicLocalTranslation d a) A :=
+  rfl
+
+/-- Quasi-local translation agrees with algebraic-local translation on the dense algebraic
+subalgebra.
+
+Source context: this is the dense-subalgebra formula underlying the translation operator invoked in
+arXiv:1703.09188, Appendix, line 2298; the formula is not displayed separately there. -/
+@[simp]
+lemma quasiLocalTranslation_algebraicToQuasiLocal (d : ℕ) [NeZero d] (a : ℤ)
+    (A : AlgebraicLocalAlgebra d) :
+    quasiLocalTranslation d a (algebraicToQuasiLocal d A) =
+      algebraicToQuasiLocal d (algebraicLocalTranslation d a A) :=
+  UniformSpace.Completion.mapStarAlgEquiv_coe _ _ _ A
+
+/-- Quasi-local translation sends a finite-region representative to its translated
+representative.
+
+Source context: this is the finite-region formula underlying the translation operator invoked in
+arXiv:1703.09188, Appendix, line 2298; the formula is not displayed separately there. -/
+lemma quasiLocalTranslation_quasiLocalObservable (d : ℕ) [NeZero d] (a : ℤ)
+    (Λ : Finset ℤ) (A : LocalAlgebra d Λ) :
+    quasiLocalTranslation d a (quasiLocalObservable d Λ A) =
+      quasiLocalObservable d (translateRegion a Λ) (localTranslation d a Λ A) := by
+  rw [quasiLocalObservable, quasiLocalObservable, StarAlgHom.comp_apply,
+    StarAlgHom.comp_apply, quasiLocalTranslation_algebraicToQuasiLocal,
+    algebraicLocalTranslation_localObservable]
+
+/-- Translation by zero is the identity on the quasi-local algebra.
+
+Source context: the group-action laws are implicit in the translation operator invoked in
+arXiv:1703.09188, Appendix, line 2298; they are not stated separately there. -/
+@[simp]
+lemma quasiLocalTranslation_zero (d : ℕ) [NeZero d] :
+    quasiLocalTranslation d 0 = StarAlgEquiv.refl ℂ (QuasiLocalAlgebra d) := by
+  apply StarAlgEquiv.ext
+  intro A
+  induction A using UniformSpace.Completion.induction_on with
+  | hp =>
+      change IsClosed {A : QuasiLocalAlgebra d |
+        UniformSpace.Completion.map (algebraicLocalTranslation d 0) A = A}
+      exact isClosed_eq UniformSpace.Completion.continuous_map continuous_id
+  | ih A =>
+      change quasiLocalTranslation d 0 (algebraicToQuasiLocal d A) =
+        algebraicToQuasiLocal d A
+      simp
+
+/-- Successive quasi-local translations compose by adding their displacements.
+
+Source context: the group-action laws are implicit in the translation operator invoked in
+arXiv:1703.09188, Appendix, line 2298; they are not stated separately there. -/
+lemma quasiLocalTranslation_add (d : ℕ) [NeZero d] (a b : ℤ) :
+    (quasiLocalTranslation d a).trans (quasiLocalTranslation d b) =
+      quasiLocalTranslation d (a + b) := by
+  apply StarAlgEquiv.ext
+  intro A
+  induction A using UniformSpace.Completion.induction_on with
+  | hp =>
+      change IsClosed {A : QuasiLocalAlgebra d |
+        UniformSpace.Completion.map (algebraicLocalTranslation d b)
+            (UniformSpace.Completion.map (algebraicLocalTranslation d a) A) =
+          UniformSpace.Completion.map (algebraicLocalTranslation d (a + b)) A}
+      exact isClosed_eq
+        (UniformSpace.Completion.continuous_map.comp
+          UniformSpace.Completion.continuous_map)
+        UniformSpace.Completion.continuous_map
+  | ih A =>
+      change quasiLocalTranslation d b
+          (quasiLocalTranslation d a (algebraicToQuasiLocal d A)) =
+        quasiLocalTranslation d (a + b) (algebraicToQuasiLocal d A)
+      simp only [quasiLocalTranslation_algebraicToQuasiLocal]
+      rw [← StarAlgEquiv.trans_apply, algebraicLocalTranslation_add]
+
+/-- The inverse of quasi-local translation by `a` is translation by `-a`.
+
+Source context: the group-action laws are implicit in the translation operator invoked in
+arXiv:1703.09188, Appendix, line 2298; they are not stated separately there. -/
+@[simp]
+lemma quasiLocalTranslation_symm (d : ℕ) [NeZero d] (a : ℤ) :
+    (quasiLocalTranslation d a).symm = quasiLocalTranslation d (-a) := by
+  apply StarAlgEquiv.ext
+  intro A
+  apply (quasiLocalTranslation d a).symm_apply_eq.mpr
+  change A = quasiLocalTranslation d a (quasiLocalTranslation d (-a) A)
+  rw [← StarAlgEquiv.trans_apply, quasiLocalTranslation_add, neg_add_cancel,
+    quasiLocalTranslation_zero]
+  rfl
+
+/-- Quasi-local translation preserves the operator norm.
+
+Source context: the appendix invokes translation as an automorphism of the quasi-local algebra at
+line 2298; norm preservation is a standard C-star algebra consequence, not a separate claim there. -/
+@[simp]
+lemma norm_quasiLocalTranslation (d : ℕ) [NeZero d] (a : ℤ)
+    (A : QuasiLocalAlgebra d) :
+    ‖quasiLocalTranslation d a A‖ = ‖A‖ :=
+  StarAlgEquiv.norm_map (quasiLocalTranslation d a) A
+
+/-- Quasi-local translation is an operator-norm isometry.
+
+Source context: the appendix invokes translation as an automorphism of the quasi-local algebra at
+line 2298; isometry is a standard C-star algebra consequence, not a separate claim there. -/
+lemma quasiLocalTranslation_isometry (d : ℕ) [NeZero d] (a : ℤ) :
+    Isometry (quasiLocalTranslation d a) :=
+  StarAlgEquiv.isometry (quasiLocalTranslation d a)
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8324,7 +8324,6 @@ as separate results in the appendix.
     UniformSpace.Completion.mapStarAlgEquiv_apply,
     UniformSpace.Completion.mapStarAlgEquiv_coe}
   \leanok
-  \uses{def:qca_quasi_local_algebra}
   Let $A$ and $B$ be complex normed star algebras, and let
   $f\colon A\to B$ be a star-algebra equivalence.  If $f$ and $f^{-1}$ are
   continuous, then $f$ extends to a star-algebra equivalence
@@ -8340,7 +8339,6 @@ as separate results in the appendix.
 \end{definition}
 
 \begin{proof}\leanok
-  \uses{def:qca_quasi_local_algebra}
   Apply the completion functor to $f$ and $f^{-1}$.  On the dense canonical
   images their composites satisfy
   \begin{align}
@@ -8383,6 +8381,7 @@ as separate results in the appendix.
     def:qca_algebraic_local_translation,
     def:qca_quasi_local_algebra,
     def:qca_quasi_local_observable,
+    lem:qca_algebraic_local_translation_action,
     lem:qca_algebraic_local_translation_isometry}
   Algebraic-local translation and its inverse translation by $-a$ are
   operator-norm isometries, hence continuous.  Extend this equivalence to the

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8311,3 +8311,141 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   Taking closures proves the second equality.  This theorem concerns the union
   over all finite regions and makes no claim about the image of a fixed region.
 \end{proof}
+
+The appendix introduces the quasi-local algebra and then invokes lattice
+translation in the definition of a QCA and in its covariance condition
+\cite[lines~2292--2306]{Cirac2017MPU}.  The following completion result and
+translation laws make this background structure explicit; they are not stated
+as separate results in the appendix.
+
+\begin{definition}[Extension of star-algebra equivalences to completions]
+  \label{def:completion_star_alg_equiv}
+  \lean{UniformSpace.Completion.mapStarAlgEquiv,
+    UniformSpace.Completion.mapStarAlgEquiv_apply,
+    UniformSpace.Completion.mapStarAlgEquiv_coe}
+  \leanok
+  \uses{def:qca_quasi_local_algebra}
+  Let $A$ and $B$ be complex normed star algebras, and let
+  $f\colon A\to B$ be a star-algebra equivalence.  If $f$ and $f^{-1}$ are
+  continuous, then $f$ extends to a star-algebra equivalence
+  \begin{align}
+    \widehat f\colon\widehat A&\longrightarrow\widehat B
+  \end{align}
+  between their norm completions.  Its underlying map is the continuous
+  extension of $f$.  Writing $j_A$ and $j_B$ for the canonical maps into the
+  completions, the extension satisfies
+  \begin{align}
+    \widehat f(j_A(x))&=j_B(f(x)).
+  \end{align}
+\end{definition}
+
+\begin{proof}\leanok
+  \uses{def:qca_quasi_local_algebra}
+  Apply the completion functor to $f$ and $f^{-1}$.  On the dense canonical
+  images their composites satisfy
+  \begin{align}
+    \widehat{f^{-1}}\bigl(\widehat f(j_A(x))\bigr)&=j_A(x), &
+    \widehat f\bigl(\widehat{f^{-1}}(j_B(y))\bigr)&=j_B(y).
+  \end{align}
+  Continuity gives the two inverse identities on the completions.
+  Multiplication, addition, scalar multiplication, and the star operation
+  commute with the extension because the corresponding identities hold on
+  the canonical images and both sides are continuous.
+\end{proof}
+
+\begin{definition}[Translation of quasi-local observables]
+  \label{def:qca_quasi_local_translation}
+  \lean{SpinChain.quasiLocalTranslation,
+    SpinChain.quasiLocalTranslation_apply,
+    SpinChain.quasiLocalTranslation_algebraicToQuasiLocal,
+    SpinChain.quasiLocalTranslation_quasiLocalObservable}
+  \leanok
+  \uses{def:completion_star_alg_equiv,
+    def:qca_algebraic_local_translation,def:qca_quasi_local_algebra,
+    def:qca_quasi_local_observable,
+    lem:qca_algebraic_local_translation_isometry}
+  For $d>0$ and every $a\in\mathbb Z$, algebraic-local translation extends to
+  a star-algebra automorphism
+  \begin{align}
+    \tau_a\colon\mathcal A&\longrightarrow\mathcal A
+  \end{align}
+  of the quasi-local algebra.  On the dense algebraic-local subalgebra and on
+  finite-region observables it satisfies
+  \begin{align}
+    \tau_a(j(A))&=j(\tau_a(A)), \\
+    \tau_a(j_\Lambda(A_\Lambda))
+      &=j_{\Lambda+a}(\tau_{a,\Lambda}(A_\Lambda)).
+  \end{align}
+\end{definition}
+
+\begin{proof}\leanok
+  \uses{def:completion_star_alg_equiv,
+    def:qca_algebraic_local_translation,
+    def:qca_quasi_local_algebra,
+    def:qca_quasi_local_observable,
+    lem:qca_algebraic_local_translation_isometry}
+  Algebraic-local translation and its inverse translation by $-a$ are
+  operator-norm isometries, hence continuous.  Extend this equivalence to the
+  norm completion.  The extension identity gives
+  \begin{align}
+    \tau_a(j(A))&=j(\tau_a(A)).
+  \end{align}
+  Substituting $A=\iota_\Lambda(A_\Lambda)$ and using the finite-region
+  translation formula gives the second identity.
+\end{proof}
+
+\begin{lemma}[Quasi-local translation action laws]
+  \label{lem:qca_quasi_local_translation_action}
+  \lean{SpinChain.quasiLocalTranslation_zero,
+    SpinChain.quasiLocalTranslation_add,
+    SpinChain.quasiLocalTranslation_symm}
+  \leanok
+  \uses{def:qca_quasi_local_translation}
+  For $d>0$, the quasi-local automorphisms form an additive action of
+  $\mathbb Z$:
+  \begin{align}
+    \tau_0&=\operatorname{id}, \\
+    \tau_b\circ\tau_a&=\tau_{a+b}, \\
+    \tau_a^{-1}&=\tau_{-a}.
+  \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_quasi_local_translation,
+    lem:qca_algebraic_local_translation_action}
+  On the canonical image of the algebraic-local algebra,
+  \begin{align}
+    \tau_b\bigl(\tau_a(j(A))\bigr)
+      &=j\bigl(\tau_b(\tau_a(A))\bigr)
+       =j(\tau_{a+b}(A)), \\
+    \tau_0(j(A))&=j(A).
+  \end{align}
+  Continuity extends these identities to the completion.  Taking
+  $(a,b)=(a,-a)$ and $(-a,a)$ identifies the inverse of $\tau_a$ with
+  $\tau_{-a}$.
+\end{proof}
+
+\begin{lemma}[Norm isometry of quasi-local translation]
+  \label{lem:qca_quasi_local_translation_isometry}
+  \lean{SpinChain.norm_quasiLocalTranslation,
+    SpinChain.quasiLocalTranslation_isometry}
+  \leanok
+  \uses{def:qca_quasi_local_translation,def:qca_quasi_local_algebra}
+  For $d>0$, every quasi-local translation preserves the operator norm and
+  distance:
+  \begin{align}
+    \lVert\tau_a(A)\rVert&=\lVert A\rVert, \\
+    \lVert\tau_a(A)-\tau_a(B)\rVert&=\lVert A-B\rVert.
+  \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_quasi_local_translation,def:qca_quasi_local_algebra}
+  A star-algebra equivalence between complex C-star algebras preserves the
+  C-star norm.  Since $\tau_a$ is linear,
+  \begin{align}
+    \lVert\tau_a(A)-\tau_a(B)\rVert
+      &=\lVert\tau_a(A-B)\rVert
+       =\lVert A-B\rVert.
+  \end{align}
+\end{proof}


### PR DESCRIPTION
## Summary

- add a generic completion constructor for continuous complex star-algebra equivalences
- extend algebraic-local lattice translations uniquely to quasi-local star-algebra automorphisms
- prove evaluation on the dense algebraic-local image and finite-region observables
- prove zero, additive-composition, inverse, norm-preservation, and isometry laws
- document the generic analytic prerequisite and quasi-local formulas in Chapter 28

This is the quasi-local translation implementation leaf under #6468. It deliberately stops before quasi-local support predicates, finite propagation, translation covariance of arbitrary automorphisms, or `IsQCA`.

## Source context

- `Papers/1703.09188/paper_v2.tex`, Appendix, lines 2292–2306
- Schumacher–Werner, quant-ph/0405174, Definition 1

The paper constructs the quasi-local completion and invokes lattice translation in the QCA definition; this PR formalizes the required completion extension and its standard consequences without attributing the helper lemmas directly to the paper.

## Validation

- direct Lean checks for `CStarCompletion.lean` and `QuasiLocalTranslation.lean`
- targeted builds of `TNLean.Analysis.CStarCompletion`, `TNLean.QCA.QuasiLocalTranslation`, and `TNLean.QCA`
- diagnostics and full default lints: zero findings
- generated imports current: 53 aggregators / 1415 production modules
- Blueprint sync: 7795/7795 globally and 555/555 in Chapter 28
- reverse coverage: all 12 new declarations covered
- dependency-subgraph, prose, proof-integrity, line-length, and `git diff --check`
- independent completion/API scout, Lean style review, and dedicated Blueprint audit

Closes #6477
