### PR TITLE
feat(QCA): define finite propagation predicates

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.QCA
 
 import TNLean.QCA.AlgebraicTranslation
+import TNLean.QCA.FinitePropagation
 import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit
 import TNLean.QCA.LocalNorm

--- a/TNLean/QCA/FinitePropagation.lean
+++ b/TNLean/QCA/FinitePropagation.lean
@@ -86,7 +86,7 @@ it sends observables supported in every finite region \(\Lambda\) to observables
 Source: arXiv:1703.09188, Appendix, line 2298. -/
 def PropagatesWithin {d : ℕ} [NeZero d]
     (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) (𝓝 : Finset ℤ) : Prop :=
-  ∀ Λ x, QuasiLocalSupportedIn x Λ →
+  ∀ (Λ : Finset ℤ) (x : QuasiLocalAlgebra d), QuasiLocalSupportedIn x Λ →
     QuasiLocalSupportedIn (ω x) (regionSumset Λ 𝓝)
 
 /-- A quasi-local star-automorphism has finite propagation when it propagates within some finite

--- a/TNLean/QCA/FinitePropagation.lean
+++ b/TNLean/QCA/FinitePropagation.lean
@@ -89,8 +89,8 @@ def PropagatesWithin {d : ℕ} [NeZero d]
   ∀ (Λ : Finset ℤ) (x : QuasiLocalAlgebra d), QuasiLocalSupportedIn x Λ →
     QuasiLocalSupportedIn (ω x) (regionSumset Λ 𝓝)
 
-/-- A quasi-local star-automorphism has finite propagation when it propagates within some finite
-neighborhood.
+/-- A quasi-local star-automorphism has finite forward propagation when it propagates within some
+finite neighborhood.
 
 Source: arXiv:1703.09188, Appendix, line 2298. -/
 def HasFinitePropagation {d : ℕ} [NeZero d]

--- a/TNLean/QCA/FinitePropagation.lean
+++ b/TNLean/QCA/FinitePropagation.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.QuasiLocal
+import TNLean.QCA.RegionSumset
+
+/-!
+# Finite propagation on the quasi-local algebra
+
+A quasi-local observable is supported in a finite region when it lies in the range of that
+region's canonical embedding. A quasi-local star-automorphism propagates within a finite
+neighborhood when it sends every observable supported in \(\Lambda\) to one supported in
+\(\Lambda + \mathcal N\), uniformly over finite regions \(\Lambda\).
+
+This file records equivalent support, range-inclusion, and finite-region witness formulations of
+that condition. Neighborhood monotonicity and composition are treated separately.
+
+## Main definitions
+
+* `SpinChain.QuasiLocalSupportedIn` — membership in a finite-region observable algebra.
+* `SpinChain.PropagatesWithin` — propagation bounded by a fixed finite neighborhood.
+* `SpinChain.HasFinitePropagation` — existence of a finite propagation neighborhood.
+
+## Main results
+
+* `SpinChain.QuasiLocalSupportedIn.quasiLocalObservable` — every embedded finite-region
+  observable is supported in its region.
+* `SpinChain.QuasiLocalSupportedIn.mono` — support is monotone under region enlargement.
+* `SpinChain.propagatesWithin_iff_quasiLocalObservable` — the universal pointwise formulation.
+* `SpinChain.propagatesWithin_iff_range_subset` — the range-inclusion formulation.
+* `SpinChain.propagatesWithin_iff_exists_local` — the finite-region witness formulation.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, line 2298.
+* Schumacher--Werner, quant-ph/0405174, Definition 1.
+-/
+
+namespace SpinChain
+
+/-- A quasi-local observable is supported in the finite region \(\Lambda\) when it belongs to the
+range of the canonical map from \(\mathcal A_\Lambda\).
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+def QuasiLocalSupportedIn {d : ℕ} [NeZero d] (x : QuasiLocalAlgebra d)
+    (Λ : Finset ℤ) : Prop :=
+  x ∈ Set.range (quasiLocalObservable d Λ)
+
+namespace QuasiLocalSupportedIn
+
+variable {d : ℕ} [NeZero d] {x : QuasiLocalAlgebra d} {Λ Γ : Finset ℤ}
+
+/-- Every finite-region observable, embedded in the quasi-local algebra, is supported in its
+region.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma quasiLocalObservable (A : LocalAlgebra d Λ) :
+    QuasiLocalSupportedIn (SpinChain.quasiLocalObservable d Λ A) Λ :=
+  ⟨A, rfl⟩
+
+/-- A quasi-local observable is supported in a region exactly when it has a representative in
+that region's finite observable algebra.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma iff_exists :
+    QuasiLocalSupportedIn x Λ ↔
+      ∃ A : LocalAlgebra d Λ, SpinChain.quasiLocalObservable d Λ A = x :=
+  Iff.rfl
+
+/-- Quasi-local support is monotone under enlargement of the finite region.
+
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
+lemma mono (hx : QuasiLocalSupportedIn x Λ) (hΛΓ : Λ ⊆ Γ) :
+    QuasiLocalSupportedIn x Γ := by
+  obtain ⟨A, rfl⟩ := hx
+  exact ⟨localInclusion hΛΓ A, quasiLocalObservable_localInclusion d hΛΓ A⟩
+
+end QuasiLocalSupportedIn
+
+/-- A quasi-local star-automorphism propagates within the finite neighborhood \(\mathcal N\) when
+it sends observables supported in every finite region \(\Lambda\) to observables supported in
+\(\Lambda + \mathcal N\).
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+def PropagatesWithin {d : ℕ} [NeZero d]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) (𝓝 : Finset ℤ) : Prop :=
+  ∀ Λ x, QuasiLocalSupportedIn x Λ →
+    QuasiLocalSupportedIn (ω x) (regionSumset Λ 𝓝)
+
+/-- A quasi-local star-automorphism has finite propagation when it propagates within some finite
+neighborhood.
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+def HasFinitePropagation {d : ℕ} [NeZero d]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) : Prop :=
+  ∃ 𝓝 : Finset ℤ, PropagatesWithin ω 𝓝
+
+variable {d : ℕ} [NeZero d]
+  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
+
+/-- Propagation within \(\mathcal N\) can be checked pointwise on the canonical image of each
+finite-region observable algebra.
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma propagatesWithin_iff_quasiLocalObservable :
+    PropagatesWithin ω 𝓝 ↔
+      ∀ (Λ : Finset ℤ) (A : LocalAlgebra d Λ),
+        QuasiLocalSupportedIn (ω (quasiLocalObservable d Λ A)) (regionSumset Λ 𝓝) := by
+  constructor
+  · intro h Λ A
+    exact h Λ _ (QuasiLocalSupportedIn.quasiLocalObservable A)
+  · intro h Λ x hx
+    obtain ⟨A, rfl⟩ := hx
+    exact h Λ A
+
+/-- Propagation within \(\mathcal N\) is equivalent to inclusion of the image range of every
+finite-region observable algebra in the range for \(\Lambda + \mathcal N\).
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma propagatesWithin_iff_range_subset :
+    PropagatesWithin ω 𝓝 ↔
+      ∀ Λ : Finset ℤ,
+        Set.range (ω ∘ quasiLocalObservable d Λ) ⊆
+          Set.range (quasiLocalObservable d (regionSumset Λ 𝓝)) := by
+  rw [propagatesWithin_iff_quasiLocalObservable]
+  apply forall_congr'
+  intro Λ
+  rw [Set.range_subset_iff]
+  rfl
+
+/-- Propagation within \(\mathcal N\) is equivalent to the existence, for every finite-region
+observable, of a representative on \(\Lambda + \mathcal N\) for its image.
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma propagatesWithin_iff_exists_local :
+    PropagatesWithin ω 𝓝 ↔
+      ∀ (Λ : Finset ℤ) (A : LocalAlgebra d Λ),
+        ∃ B : LocalAlgebra d (regionSumset Λ 𝓝),
+          ω (quasiLocalObservable d Λ A) =
+            quasiLocalObservable d (regionSumset Λ 𝓝) B := by
+  rw [propagatesWithin_iff_quasiLocalObservable]
+  constructor
+  · intro h Λ A
+    obtain ⟨B, hB⟩ := h Λ A
+    exact ⟨B, hB.symm⟩
+  · intro h Λ A
+    obtain ⟨B, hB⟩ := h Λ A
+    exact ⟨B, hB.symm⟩
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8448,3 +8448,130 @@ as separate results in the appendix.
        =\lVert A-B\rVert.
   \end{align}
 \end{proof}
+
+\begin{definition}[Finite-region support in the quasi-local algebra]
+  \label{def:qca_quasi_local_supported_in}
+  \lean{SpinChain.QuasiLocalSupportedIn,
+    SpinChain.QuasiLocalSupportedIn.quasiLocalObservable,
+    SpinChain.QuasiLocalSupportedIn.iff_exists}
+  \leanok
+  \uses{def:qca_quasi_local_observable}
+  For $d>0$, a quasi-local observable $x\in\mathcal A$ is supported in a
+  finite region $\Lambda\subset\mathbb Z$ if it belongs to the image of the
+  canonical embedding $j_\Lambda\colon\mathcal A_\Lambda\to\mathcal A$.
+  Equivalently,
+  \begin{align}
+    x\text{ is supported in }\Lambda
+      &\iff x\in j_\Lambda(\mathcal A_\Lambda) \\
+      &\iff \text{there exists }A\in\mathcal A_\Lambda
+        \text{ such that }j_\Lambda(A)=x.
+  \end{align}
+  In particular, $j_\Lambda(A)$ is supported in $\Lambda$ for every
+  $A\in\mathcal A_\Lambda$.
+\end{definition}
+
+\begin{proof}\leanok
+  \uses{def:qca_quasi_local_observable}
+  These assertions follow directly from membership in the range of
+  $j_\Lambda$.
+\end{proof}
+
+\begin{lemma}[Monotonicity of quasi-local support]
+  \label{lem:qca_quasi_local_support_mono}
+  \lean{SpinChain.QuasiLocalSupportedIn.mono}
+  \leanok
+  \uses{def:qca_quasi_local_supported_in,def:qca_local_inclusion}
+  Let $d>0$.  If $x\in\mathcal A$ is supported in $\Lambda$ and
+  $\Lambda\subseteq\Gamma$, then $x$ is supported in $\Gamma$.
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_quasi_local_supported_in,def:qca_local_inclusion,
+    lem:qca_quasi_local_observable}
+  Write $x=j_\Lambda(A)$.  Enlarge $A$ to $\mathcal A_\Gamma$ by tensoring
+  with the identity on $\Gamma\setminus\Lambda$.  Compatibility of the
+  canonical embeddings identifies the image of this enlargement with $x$.
+\end{proof}
+
+The appendix requires that ``there exists a finite subset
+$\mathcal N\subset\mathbb Z$'' such that, for every finite
+$\Lambda\subset\mathbb Z$,
+\begin{align}
+  \omega(\mathcal A_\Lambda)&\subset
+    \mathcal A_{\Lambda+\mathcal N}.
+\end{align}
+This is the propagation condition stated at line~2298 of
+\cite{Cirac2017MPU}.  The definitions below isolate this forward inclusion.
+They do not impose translation covariance or a propagation bound for
+$\omega^{-1}$.
+
+\begin{definition}[Propagation within a fixed neighborhood]
+  \label{def:qca_propagates_within}
+  \lean{SpinChain.PropagatesWithin}
+  \leanok
+  \uses{def:qca_quasi_local_supported_in,def:qca_region_sumset}
+  Let $d>0$, let $\omega\colon\mathcal A\to\mathcal A$ be a star-algebra
+  automorphism, and let $\mathcal N\subset\mathbb Z$ be finite.  The
+  automorphism $\omega$ propagates within $\mathcal N$ if, for every finite
+  region $\Lambda$ and every $x\in\mathcal A$,
+  \begin{align}
+    x\text{ supported in }\Lambda
+      &\implies
+    \omega(x)\text{ supported in }\Lambda+\mathcal N.
+  \end{align}
+\end{definition}
+
+\begin{definition}[Finite forward propagation]
+  \label{def:qca_finite_propagation}
+  \lean{SpinChain.HasFinitePropagation}
+  \leanok
+  \uses{def:qca_propagates_within}
+  Let $d>0$ and let $\omega\colon\mathcal A\to\mathcal A$ be a star-algebra
+  automorphism.  The automorphism $\omega$ has finite forward propagation if
+  there exists a finite set $\mathcal N\subset\mathbb Z$ such that $\omega$
+  propagates within $\mathcal N$.
+\end{definition}
+
+\begin{theorem}[Equivalent formulations of forward propagation]
+  \label{thm:qca_propagates_within_iff}
+  \lean{SpinChain.propagatesWithin_iff_quasiLocalObservable,
+    SpinChain.propagatesWithin_iff_range_subset,
+    SpinChain.propagatesWithin_iff_exists_local}
+  \leanok
+  \uses{def:qca_quasi_local_supported_in,def:qca_propagates_within,
+    def:qca_quasi_local_observable,def:qca_region_sumset}
+  Let $d>0$, let $\omega\colon\mathcal A\to\mathcal A$ be a star-algebra
+  automorphism, and let $\mathcal N\subset\mathbb Z$ be finite.  The following
+  conditions are equivalent:
+  \begin{align}
+    &\omega\text{ propagates within }\mathcal N; \tag{a}\\
+    &\omega(j_\Lambda(A))\text{ is supported in }
+      \Lambda+\mathcal N
+      \quad\text{for all finite }\Lambda
+      \text{ and }A\in\mathcal A_\Lambda; \tag{b}\\
+    &\omega\bigl(j_\Lambda(\mathcal A_\Lambda)\bigr)
+      \subseteq j_{\Lambda+\mathcal N}
+        (\mathcal A_{\Lambda+\mathcal N})
+      \quad\text{for every finite }\Lambda; \tag{c}\\
+    &\text{for every finite }\Lambda\text{ and }A\in\mathcal A_\Lambda,
+      \text{ there exists }B\in\mathcal A_{\Lambda+\mathcal N}
+      \text{ such that} \notag\\
+    &\hspace{8em}
+      \omega(j_\Lambda(A))=j_{\Lambda+\mathcal N}(B). \tag{d}
+  \end{align}
+  Thus condition~\textup{(c)} is precisely the range-inclusion formula from
+  line~2298 of \cite{Cirac2017MPU}, expressed inside the quasi-local algebra,
+  and condition~\textup{(d)} is its finite-region witness form.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{def:qca_quasi_local_supported_in,def:qca_propagates_within,
+    def:qca_quasi_local_observable}
+  Every observable supported in $\Lambda$ has the form $j_\Lambda(A)$, so
+  \textup{(a)} and \textup{(b)} are equivalent.  Replacing support by
+  membership in the range of the canonical embedding gives \textup{(c)}.
+  Finally, membership in
+  $j_{\Lambda+\mathcal N}(\mathcal A_{\Lambda+\mathcal N})$ is equivalent to
+  the existence of a representative $B$ in that finite-region algebra, which
+  gives \textup{(d)}.
+\end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8480,7 +8480,7 @@ as separate results in the appendix.
   \label{lem:qca_quasi_local_support_mono}
   \lean{SpinChain.QuasiLocalSupportedIn.mono}
   \leanok
-  \uses{def:qca_quasi_local_supported_in,def:qca_local_inclusion}
+  \uses{def:qca_quasi_local_supported_in}
   Let $d>0$.  If $x\in\mathcal A$ is supported in $\Lambda$ and
   $\Lambda\subseteq\Gamma$, then $x$ is supported in $\Gamma$.
 \end{lemma}
@@ -8532,8 +8532,8 @@ $\omega^{-1}$.
   propagates within $\mathcal N$.
 \end{definition}
 
-\begin{theorem}[Equivalent formulations of forward propagation]
-  \label{thm:qca_propagates_within_iff}
+\begin{lemma}[Equivalent formulations of forward propagation]
+  \label{lem:qca_propagates_within_iff}
   \lean{SpinChain.propagatesWithin_iff_quasiLocalObservable,
     SpinChain.propagatesWithin_iff_range_subset,
     SpinChain.propagatesWithin_iff_exists_local}
@@ -8545,24 +8545,21 @@ $\omega^{-1}$.
   conditions are equivalent:
   \begin{align}
     &\omega\text{ propagates within }\mathcal N; \tag{a}\\
-    &\omega(j_\Lambda(A))\text{ is supported in }
-      \Lambda+\mathcal N
-      \quad\text{for all finite }\Lambda
-      \text{ and }A\in\mathcal A_\Lambda; \tag{b}\\
-    &\omega\bigl(j_\Lambda(\mathcal A_\Lambda)\bigr)
+    &\forall\Lambda\Subset\mathbb Z,\ \forall A\in\mathcal A_\Lambda,
+      \quad \omega(j_\Lambda(A))\text{ is supported in }
+      \Lambda+\mathcal N; \tag{b}\\
+    &\forall\Lambda\Subset\mathbb Z,\quad
+      \omega\bigl(j_\Lambda(\mathcal A_\Lambda)\bigr)
       \subseteq j_{\Lambda+\mathcal N}
-        (\mathcal A_{\Lambda+\mathcal N})
-      \quad\text{for every finite }\Lambda; \tag{c}\\
-    &\text{for every finite }\Lambda\text{ and }A\in\mathcal A_\Lambda,
-      \text{ there exists }B\in\mathcal A_{\Lambda+\mathcal N}
-      \text{ such that} \notag\\
-    &\hspace{8em}
+        (\mathcal A_{\Lambda+\mathcal N}); \tag{c}\\
+    &\forall\Lambda\Subset\mathbb Z,\ \forall A\in\mathcal A_\Lambda,
+      \ \exists B\in\mathcal A_{\Lambda+\mathcal N},\quad
       \omega(j_\Lambda(A))=j_{\Lambda+\mathcal N}(B). \tag{d}
   \end{align}
   Thus condition~\textup{(c)} is precisely the range-inclusion formula from
   line~2298 of \cite{Cirac2017MPU}, expressed inside the quasi-local algebra,
   and condition~\textup{(d)} is its finite-region witness form.
-\end{theorem}
+\end{lemma}
 
 \begin{proof}\leanok
   \uses{def:qca_quasi_local_supported_in,def:qca_propagates_within,


### PR DESCRIPTION
## Summary

- define finite-region support for quasi-local observables as membership in the canonical finite-region image
- define fixed-neighborhood forward propagation and existence of a finite propagation neighborhood
- prove equivalent pointwise, range-inclusion, and finite-region witness formulations
- document the source condition and its forward-only scope in Chapter 28

This is the implementation leaf #6478 under #6468. Neighborhood monotonicity and forward composition remain in #6480 and #6481.

## Source

- `Papers/1703.09188/paper_v2.tex`, Appendix line 2298
- Schumacher--Werner, quant-ph/0405174, Definition 1

## Validation

- direct Lean check for `TNLean/QCA/FinitePropagation.lean`
- targeted builds of `TNLean.QCA.FinitePropagation` and `TNLean.QCA`
- generated import aggregate check: 53 aggregators / 1416 production modules
- Blueprint sync: 7804/7804 globally, 564/564 in Chapter 28
- reverse coverage: 9/9 declarations
- focused lint, prose, proof-integrity, line-length, and `git diff --check`
- independent API scout, Lean style review, and Blueprint dependency review

Closes #6478
