### PR TITLE
feat(QCA): define translation covariance

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -17,3 +17,4 @@ import TNLean.QCA.QuasiLocal
 import TNLean.QCA.QuasiLocalTranslation
 import TNLean.QCA.RegionSumset
 import TNLean.QCA.Translation
+import TNLean.QCA.TranslationCovariance

--- a/TNLean/QCA/TranslationCovariance.lean
+++ b/TNLean/QCA/TranslationCovariance.lean
@@ -43,8 +43,9 @@ def TranslationCovariant {d : ℕ} [NeZero d]
 The multiplication on star-automorphisms satisfies `(ω * τ) A = ω (τ A)`, so the displayed
 identity has the same orientation as `Commute ω τ`.
 
-Source: arXiv:1703.09188, Appendix, line 2298. -/
-theorem translationCovariant_iff (d : ℕ) [NeZero d]
+Source context: arXiv:1703.09188, Appendix, line 2298; this characterization is not
+stated separately there. -/
+theorem translationCovariant_iff {d : ℕ} [NeZero d]
     (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) :
     TranslationCovariant ω ↔
       ∀ (a : ℤ) (A : QuasiLocalAlgebra d),
@@ -59,8 +60,9 @@ theorem translationCovariant_iff (d : ℕ) [NeZero d]
 
 /-- The identity star-automorphism of the quasi-local algebra is translation covariant.
 
-Source: arXiv:1703.09188, Appendix, line 2298. -/
-theorem translationCovariant_refl (d : ℕ) [NeZero d] :
+Source context: arXiv:1703.09188, Appendix, line 2298; this closure property is not stated
+separately there. -/
+theorem translationCovariant_refl {d : ℕ} [NeZero d] :
     TranslationCovariant (StarAlgEquiv.refl ℂ (QuasiLocalAlgebra d)) := by
   intro a
   rw [← StarAlgEquiv.aut_one]
@@ -71,7 +73,8 @@ theorem translationCovariant_refl (d : ℕ) [NeZero d] :
 Here `ω.trans η` first applies `ω` and then `η`. Under the star-automorphism group
 multiplication, this is `η * ω`; both factors commute with every translation.
 
-Source: arXiv:1703.09188, Appendix, line 2298. -/
+Source context: arXiv:1703.09188, Appendix, line 2298; this closure property is not stated
+separately there. -/
 theorem TranslationCovariant.trans
     {d : ℕ} [NeZero d]
     {ω η : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}

--- a/TNLean/QCA/TranslationCovariance.lean
+++ b/TNLean/QCA/TranslationCovariance.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.QuasiLocalTranslation
+
+/-!
+# Translation covariance of quasi-local automorphisms
+
+A star-algebra automorphism of the quasi-local observable algebra is translation covariant when it
+commutes with every lattice translation. This file records the equivalent pointwise formulation and
+shows that translation covariance is preserved by the identity and forward composition.
+
+## Main definitions
+
+* `SpinChain.TranslationCovariant` — commutation with every quasi-local translation.
+
+## Main results
+
+* `SpinChain.translationCovariant_iff` — the exact pointwise commutation criterion.
+* `SpinChain.translationCovariant_refl` — the identity automorphism is translation covariant.
+* `SpinChain.TranslationCovariant.trans` — forward composition preserves translation covariance.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, line 2298.
+-/
+
+namespace SpinChain
+
+/-- A quasi-local star-automorphism is **translation covariant** when it commutes with every
+quasi-local lattice translation.
+
+Source: arXiv:1703.09188, Appendix, line 2298, where a one-dimensional QCA is required to commute
+with the translation operator. -/
+def TranslationCovariant {d : ℕ} [NeZero d]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) : Prop :=
+  ∀ a : ℤ, Commute ω (quasiLocalTranslation d a)
+
+/-- Translation covariance is equivalent to pointwise commutation with every lattice translation.
+
+The multiplication on star-automorphisms satisfies `(ω * τ) A = ω (τ A)`, so the displayed
+identity has the same orientation as `Commute ω τ`.
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+theorem translationCovariant_iff (d : ℕ) [NeZero d]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) :
+    TranslationCovariant ω ↔
+      ∀ (a : ℤ) (A : QuasiLocalAlgebra d),
+        ω (quasiLocalTranslation d a A) = quasiLocalTranslation d a (ω A) := by
+  constructor
+  · intro h a A
+    simpa only [StarAlgEquiv.mul_apply] using DFunLike.congr_fun (h a).eq A
+  · intro h a
+    change ω * quasiLocalTranslation d a = quasiLocalTranslation d a * ω
+    ext A
+    simpa only [StarAlgEquiv.mul_apply] using h a A
+
+/-- The identity star-automorphism of the quasi-local algebra is translation covariant.
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+theorem translationCovariant_refl (d : ℕ) [NeZero d] :
+    TranslationCovariant (StarAlgEquiv.refl ℂ (QuasiLocalAlgebra d)) := by
+  intro a
+  rw [← StarAlgEquiv.aut_one]
+  exact Commute.one_left _
+
+/-- Forward composition of translation-covariant star-automorphisms is translation covariant.
+
+Here `ω.trans η` first applies `ω` and then `η`. Under the star-automorphism group
+multiplication, this is `η * ω`; both factors commute with every translation.
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+theorem TranslationCovariant.trans
+    {d : ℕ} [NeZero d]
+    {ω η : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d}
+    (hω : TranslationCovariant ω) (hη : TranslationCovariant η) :
+    TranslationCovariant (ω.trans η) := by
+  intro a
+  rw [← StarAlgEquiv.aut_mul]
+  exact (hη a).mul_left (hω a)
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8424,6 +8424,65 @@ as separate results in the appendix.
   $\tau_{-a}$.
 \end{proof}
 
+\begin{definition}[Translation covariance]
+  \label{def:qca_translation_covariant}
+  \lean{SpinChain.TranslationCovariant}
+  \leanok
+  \uses{def:qca_quasi_local_translation,def:qca_quasi_local_algebra}
+  For $d>0$, a star-algebra automorphism $\omega$ of the quasi-local algebra
+  $\mathcal A$ is translation covariant if
+  \begin{align}
+    \omega\circ\tau_a=\tau_a\circ\omega
+  \end{align}
+  for every $a\in\mathbb Z$.  This is the covariance condition in the
+  definition of a one-dimensional QCA \cite[line~2298]{Cirac2017MPU}.
+\end{definition}
+
+\begin{lemma}[Pointwise characterization of translation covariance]
+  \label{lem:qca_translation_covariant_iff}
+  \lean{SpinChain.translationCovariant_iff}
+  \leanok
+  \uses{def:qca_translation_covariant}
+  For $d>0$, a star-algebra automorphism $\omega$ of $\mathcal A$ is
+  translation covariant if and only if
+  \begin{align}
+    \omega\bigl(\tau_a(A)\bigr)=\tau_a\bigl(\omega(A)\bigr)
+  \end{align}
+  for every $a\in\mathbb Z$ and every $A\in\mathcal A$.
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_translation_covariant}
+  Two automorphisms are equal if and only if they agree on every observable.
+  Apply this observation to the two composites in the definition.
+\end{proof}
+
+\begin{lemma}[Identity and composition of translation-covariant automorphisms]
+  \label{lem:qca_translation_covariant_identity_composition}
+  \lean{SpinChain.translationCovariant_refl,
+    SpinChain.TranslationCovariant.trans}
+  \leanok
+  \uses{def:qca_translation_covariant}
+  For $d>0$, the identity automorphism of $\mathcal A$ is translation
+  covariant.  If $\omega$ and $\eta$ are translation covariant, then so is
+  the composite
+  \begin{align}
+    A\longmapsto\eta\bigl(\omega(A)\bigr),
+  \end{align}
+  which first applies $\omega$ and then $\eta$.
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_translation_covariant}
+  The identity commutes pointwise with every translation.  For the composite,
+  translation covariance gives
+  \begin{align}
+    \eta\bigl(\omega(\tau_a(A))\bigr)
+      &=\eta\bigl(\tau_a(\omega(A))\bigr)
+       =\tau_a\bigl(\eta(\omega(A))\bigr).
+  \end{align}
+\end{proof}
+
 \begin{lemma}[Norm isometry of quasi-local translation]
   \label{lem:qca_quasi_local_translation_isometry}
   \lean{SpinChain.norm_quasiLocalTranslation,

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8438,8 +8438,8 @@ as separate results in the appendix.
   definition of a one-dimensional QCA \cite[line~2298]{Cirac2017MPU}.
 \end{definition}
 
-\begin{lemma}[Pointwise characterization of translation covariance]
-  \label{lem:qca_translation_covariant_iff}
+\begin{theorem}[Pointwise characterization of translation covariance]
+  \label{thm:qca_translation_covariant_iff}
   \lean{SpinChain.translationCovariant_iff}
   \leanok
   \uses{def:qca_translation_covariant}
@@ -8449,7 +8449,7 @@ as separate results in the appendix.
     \omega\bigl(\tau_a(A)\bigr)=\tau_a\bigl(\omega(A)\bigr)
   \end{align}
   for every $a\in\mathbb Z$ and every $A\in\mathcal A$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
   \uses{def:qca_translation_covariant}
@@ -8457,8 +8457,8 @@ as separate results in the appendix.
   Apply this observation to the two composites in the definition.
 \end{proof}
 
-\begin{lemma}[Identity and composition of translation-covariant automorphisms]
-  \label{lem:qca_translation_covariant_identity_composition}
+\begin{theorem}[Identity and composition of translation-covariant automorphisms]
+  \label{thm:qca_translation_covariant_identity_composition}
   \lean{SpinChain.translationCovariant_refl,
     SpinChain.TranslationCovariant.trans}
   \leanok
@@ -8470,7 +8470,7 @@ as separate results in the appendix.
     A\longmapsto\eta\bigl(\omega(A)\bigr),
   \end{align}
   which first applies $\omega$ and then $\eta$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
   \uses{def:qca_translation_covariant}


### PR DESCRIPTION
## Summary

- define translation covariance for quasi-local star-automorphisms as commutation with every lattice translation
- prove the exact pointwise characterization
- prove identity and forward-composition closure with the correct `StarAlgEquiv.trans` order
- document the source clause and closure formulas in Chapter 28

This is implementation leaf #6482 under #6468. Finite propagation and `IsQCA` remain separate.

## Source

- `Papers/1703.09188/paper_v2.tex`, Appendix line 2298

## Validation

- direct Lean check for `TNLean/QCA/TranslationCovariance.lean`
- targeted builds of `TNLean.QCA.TranslationCovariance` and `TNLean.QCA`
- generated imports: 53 aggregators / 1417 production modules
- Blueprint sync and reverse coverage: 4/4 declarations
- focused lint, proof-integrity, line-length, prose, and diff checks
- independent API scouting, Lean style review, and exact-patch review

Closes #6482
