### PR TITLE
feat(QCA): add propagation neighborhood monotonicity

### DIFF
--- a/TNLean/QCA/FinitePropagation.lean
+++ b/TNLean/QCA/FinitePropagation.lean
@@ -15,7 +15,7 @@ neighborhood when it sends every observable supported in \(\Lambda\) to one supp
 \(\Lambda + \mathcal N\), uniformly over finite regions \(\Lambda\).
 
 This file records equivalent support, range-inclusion, and finite-region witness formulations of
-that condition. Neighborhood monotonicity and composition are treated separately.
+that condition, together with neighborhood monotonicity. Composition is treated separately.
 
 ## Main definitions
 
@@ -31,6 +31,8 @@ that condition. Neighborhood monotonicity and composition are treated separately
 * `SpinChain.propagatesWithin_iff_quasiLocalObservable` — the universal pointwise formulation.
 * `SpinChain.propagatesWithin_iff_range_subset` — the range-inclusion formulation.
 * `SpinChain.propagatesWithin_iff_exists_local` — the finite-region witness formulation.
+* `SpinChain.PropagatesWithin.mono` — propagation is monotone under neighborhood enlargement.
+* `SpinChain.HasFinitePropagation.exists_superset` — valid neighborhoods can contain any finite set.
 
 ## References
 
@@ -98,7 +100,32 @@ def HasFinitePropagation {d : ℕ} [NeZero d]
   ∃ 𝓝 : Finset ℤ, PropagatesWithin ω 𝓝
 
 variable {d : ℕ} [NeZero d]
-  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
+  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 𝓜 : Finset ℤ}
+
+namespace PropagatesWithin
+
+/-- Propagation is preserved when the finite neighborhood is enlarged.
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma mono (hω : PropagatesWithin ω 𝓝) (h𝓝𝓜 : 𝓝 ⊆ 𝓜) :
+    PropagatesWithin ω 𝓜 := by
+  intro Λ x hx
+  exact (hω Λ x hx).mono (regionSumset_mono_right Λ h𝓝𝓜)
+
+end PropagatesWithin
+
+namespace HasFinitePropagation
+
+/-- Any finite region is contained in some propagation neighborhood of an automorphism with
+finite forward propagation.
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma exists_superset (hω : HasFinitePropagation ω) (𝓝 : Finset ℤ) :
+    ∃ 𝓜 : Finset ℤ, 𝓝 ⊆ 𝓜 ∧ PropagatesWithin ω 𝓜 := by
+  obtain ⟨𝓜, h𝓜⟩ := hω
+  exact ⟨𝓜 ∪ 𝓝, Finset.subset_union_right, h𝓜.mono Finset.subset_union_left⟩
+
+end HasFinitePropagation
 
 /-- Propagation within \(\mathcal N\) can be checked pointwise on the canonical image of each
 finite-region observable algebra.

--- a/TNLean/QCA/FinitePropagation.lean
+++ b/TNLean/QCA/FinitePropagation.lean
@@ -116,14 +116,14 @@ end PropagatesWithin
 
 namespace HasFinitePropagation
 
-/-- Any finite region is contained in some propagation neighborhood of an automorphism with
-finite forward propagation.
+/-- Any prescribed finite set is contained in some propagation neighborhood of an automorphism
+with finite forward propagation.
 
 Source: arXiv:1703.09188, Appendix, line 2298. -/
-lemma exists_superset (hω : HasFinitePropagation ω) (𝓝 : Finset ℤ) :
-    ∃ 𝓜 : Finset ℤ, 𝓝 ⊆ 𝓜 ∧ PropagatesWithin ω 𝓜 := by
-  obtain ⟨𝓜, h𝓜⟩ := hω
-  exact ⟨𝓜 ∪ 𝓝, Finset.subset_union_right, h𝓜.mono Finset.subset_union_left⟩
+lemma exists_superset (hω : HasFinitePropagation ω) (𝓢 : Finset ℤ) :
+    ∃ 𝓜 : Finset ℤ, 𝓢 ⊆ 𝓜 ∧ PropagatesWithin ω 𝓜 := by
+  obtain ⟨𝓚, h𝓚⟩ := hω
+  exact ⟨𝓚 ∪ 𝓢, Finset.subset_union_right, h𝓚.mono Finset.subset_union_left⟩
 
 end HasFinitePropagation
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8631,3 +8631,43 @@ $\omega^{-1}$.
   the existence of a representative $B$ in that finite-region algebra, which
   gives \textup{(d)}.
 \end{proof}
+
+\begin{lemma}[Enlargement of propagation neighborhoods]
+  \label{lem:qca_propagation_neighborhood_mono}
+  \lean{SpinChain.PropagatesWithin.mono,
+    SpinChain.HasFinitePropagation.exists_superset}
+  \leanok
+  \uses{def:qca_propagates_within,def:qca_finite_propagation}
+  Let $d>0$ and let $\omega\colon\mathcal A\to\mathcal A$ be a star-algebra
+  automorphism.  If $\mathcal N\subseteq\mathcal M$ and $\omega$ propagates
+  within $\mathcal N$, then $\omega$ propagates within $\mathcal M$.  More
+  explicitly, for every finite region $\Lambda$,
+  \begin{align}
+    \Lambda+\mathcal N&\subseteq\Lambda+\mathcal M, \\
+    x\text{ supported in }\Lambda
+      &\implies \omega(x)\text{ supported in }\Lambda+\mathcal N
+      \implies \omega(x)\text{ supported in }\Lambda+\mathcal M.
+  \end{align}
+  Consequently, if $\omega$ has finite forward propagation, then for every
+  prescribed finite set $\mathcal N\subset\mathbb Z$ there is a finite set
+  $\mathcal M\subset\mathbb Z$ such that
+  \begin{align}
+    \mathcal N&\subseteq\mathcal M, \\
+    &\forall\Lambda\Subset\mathbb Z,\quad
+      \omega(\mathcal A_\Lambda)\subseteq
+      \mathcal A_{\Lambda+\mathcal M}.
+  \end{align}
+  This is the neighborhood-enlargement consequence of the propagation
+  condition in Appendix line~2298 of \cite{Cirac2017MPU}.
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_region_sumset,lem:qca_quasi_local_support_mono,
+    def:qca_propagates_within,def:qca_finite_propagation}
+  Monotonicity of the sumset in its second argument gives
+  $\Lambda+\mathcal N\subseteq\Lambda+\mathcal M$.  Monotonicity of
+  quasi-local support then enlarges the support of $\omega(x)$ from
+  $\Lambda+\mathcal N$ to $\Lambda+\mathcal M$.  For the final assertion,
+  choose a finite propagation neighborhood $\mathcal K$ and take
+  $\mathcal M=\mathcal K\cup\mathcal N$.
+\end{proof}


### PR DESCRIPTION
## Summary

- prove fixed-neighborhood forward propagation is monotone under neighborhood enlargement
- prove any prescribed finite set is contained in some valid propagation neighborhood for a finite-forward-propagation automorphism
- document both consequences in Chapter 28

This is implementation leaf #6480 under #6468. Composition and symmetric-interval normalization remain in #6481 and #6484.

## Source

- `Papers/1703.09188/paper_v2.tex`, Appendix line 2298

## Validation

- direct Lean check for `TNLean/QCA/FinitePropagation.lean`
- targeted QCA build
- Blueprint sync/reverse coverage and diff checks
- independent Lean/API and Blueprint review

Closes #6480
