### PR TITLE
refactor(MPDO): narrow normalization divergence cleanup

### DIFF
--- a/TNLean/MPS/MPDO/BondTwoSingletonPhysicalGauge.lean
+++ b/TNLean/MPS/MPDO/BondTwoSingletonPhysicalGauge.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.CPSVBlocking
 import TNLean.MPS.MPDO.BondTwoSingletonBaseModel
-import TNLean.MPS.MPDO.InvariantProjection
 
 /-!
 # Physical similarities of the bond-two singleton base model
@@ -470,6 +469,9 @@ full-contract counterexample and does not construct an
 `IdentityMarkedRealization`; it isolates all-length MPDO positivity as the
 failed standing hypothesis in this family.  Source: CPSV16, Appendix C.4,
 lines 2048--2057, and Theorem 4.14(ii). -/
+@[deprecated "Use `gaugeDeformedBaseMPOBNTAlgebraTensorClause`,
+  `gaugeDeformedBaseMPO_toMPSTensor_isCPSVCanonicalForm`, and
+  `gaugeDeformedBaseMPO_gauge_not_isMPDO` directly." (since := "2026-08-16")]
 theorem gaugeDeformedBaseMPO_algebraClause_canonicalForm_not_isMPDO :
     Nonempty (BNTAlgebraTensorClause (gaugeDeformedBaseMPO gauge)) ∧
       MPSTensor.IsCPSVCanonicalForm

--- a/TNLean/MPS/MPDO/BondTwoSingletonPhysicalGauge.lean
+++ b/TNLean/MPS/MPDO/BondTwoSingletonPhysicalGauge.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.CPSVBlocking
 import TNLean.MPS.MPDO.BondTwoSingletonBaseModel
+import TNLean.MPS.MPDO.InvariantProjection
 
 /-!
 # Physical similarities of the bond-two singleton base model

--- a/TNLean/MPS/MPDO/SourceSimpleTensor.lean
+++ b/TNLean/MPS/MPDO/SourceSimpleTensor.lean
@@ -60,14 +60,14 @@ def IsSourceSimple (M : MPOTensor d D) : Prop :=
 /-- Normalized simplicity implies source simplicity when the generated MPO is
 nonzero at every positive length.
 
-The extra nonvanishing hypothesis is necessary because `IsSimple` only asks
-for a canonical form after one positive blocking. Its raw sector weights may
-have phase cancellations at individual lengths, whereas `IsSourceSimple`
-explicitly excludes every positive-length null generated operator.
+The current proof uses the extra nonvanishing hypothesis because `IsSimple`
+only asks for a canonical form after one positive blocking, while raw sector
+weights can algebraically cancel at individual lengths. Whether the full
+`IsSimple` predicate rules out complete cancellation of the closed MPO is not
+yet formalized.
 
-**Scope restriction (positive-length nonvanishing):** the normalized project
-predicate does not itself exclude phase cancellation of the closed MPO at
-individual lengths, so this implication assumes nonvanishing explicitly. See
+**Scope restriction (positive-length nonvanishing):** this implication therefore
+assumes nonvanishing explicitly. See
 `docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex`.
 
 The CPSV basis is the family of distinct normal representatives in the

--- a/docs/audits/2026-08-15_mpdo_dead_proof_cleanup.md
+++ b/docs/audits/2026-08-15_mpdo_dead_proof_cleanup.md
@@ -46,7 +46,10 @@ was relocated to `BNTTheoremWitness` with its paper-facing source citation.
 
 The dead conjunction wrapper
 `MPOTensor.BondTwoSingletonBaseModel.gaugeDeformedBaseMPO_algebraClause_canonicalForm_not_isMPDO`
-is intentionally retained without modification because touching its
+was initially retained without modification because touching its
 `BondTwoSingletonPhysicalGauge` module triggered the repository's 50-second
 changed-module timing limit (62 seconds, then 52 seconds) despite successful full
-Lean builds. Its component theorems are preferred at use sites.
+Lean builds. The follow-up cleanup removes the unused direct
+`InvariantProjection` import from that module and places the wrapper on a dated
+deprecation transition. Its three component theorems are preferred at use sites;
+issue #6503 tracks deletion after the compatibility transition.

--- a/docs/audits/2026-08-15_mpdo_dead_proof_cleanup.md
+++ b/docs/audits/2026-08-15_mpdo_dead_proof_cleanup.md
@@ -49,7 +49,6 @@ The dead conjunction wrapper
 was initially retained without modification because touching its
 `BondTwoSingletonPhysicalGauge` module triggered the repository's 50-second
 changed-module timing limit (62 seconds, then 52 seconds) despite successful full
-Lean builds. The follow-up cleanup removes the unused direct
-`InvariantProjection` import from that module and places the wrapper on a dated
-deprecation transition. Its three component theorems are preferred at use sites;
-issue #6503 tracks deletion after the compatibility transition.
+Lean builds. The follow-up cleanup places the wrapper on a dated deprecation
+transition. Its three component theorems are preferred at use sites; issue #6503
+tracks deletion after the compatibility transition.

--- a/docs/audits/2026-08-15_mpdo_dead_proof_cleanup.md
+++ b/docs/audits/2026-08-15_mpdo_dead_proof_cleanup.md
@@ -50,5 +50,5 @@ was initially retained without modification because touching its
 `BondTwoSingletonPhysicalGauge` module triggered the repository's 50-second
 changed-module timing limit (62 seconds, then 52 seconds) despite successful full
 Lean builds. The follow-up cleanup places the wrapper on a dated deprecation
-transition. Its three component theorems are preferred at use sites; issue #6503
-tracks deletion after the compatibility transition.
+transition. Its three component declarations are preferred at use sites; issue
+#6503 tracks deletion after the compatibility transition.

--- a/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
+++ b/docs/paper-gaps/cpsv16_unit_weight_rfp_scale_tension.tex
@@ -127,8 +127,10 @@ simplicity from normalized simplicity under the explicit hypothesis
     \rho_N(M)&\ne0 &&\text{for every }N>0.
     \label{eq:positive-length-nonzero}
 \end{align}
-The extra hypothesis cannot be omitted from the formal statement because the
-normalized sector weights may cancel at particular lengths. For a fixed tensor,
+The current proof uses this extra hypothesis because normalized sector weights
+can cancel at particular lengths. Whether normalized simplicity itself rules
+out complete cancellation of the generated MPO, or whether a separating tensor
+exists, is not yet formalized and is tracked by issue~\#6501. For a fixed tensor,
 a theorem may also quantify over every normalized BNT witness rather than rely
 on one chosen presentation; the dimer obstruction below has precisely this
 form.


### PR DESCRIPTION
## Summary
- place the remaining dead conjunction wrapper on a dated compatibility transition rather than violating the public-deprecation policy
- correct the source-simplicity note: positive-length nonvanishing is required by the current proof, while its logical necessity remains open under #6501
- update the permanent cleanup audit and continue tracking final wrapper deletion in #6503

## Scope
The normalized `IsSimple` and normalization-free `IsSourceSimple` paths remain mathematically distinct. This PR does not merge their predicates, claim an `IsSimple` scaling equivalence, or settle the separating-witness question.

## Validation
- `git diff --check`
- reader-facing prose check on the diff
- generated import aggregators current
- no local Lake/Lean build, per maintainer instruction

Refs #6501
Refs #6503
