### PR TITLE
feat(QCA): normalize propagation to symmetric intervals

### DIFF
--- a/TNLean/QCA/FinitePropagation.lean
+++ b/TNLean/QCA/FinitePropagation.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Data.Finset.Lattice.Fold
+import Mathlib.Data.Int.Interval
 import TNLean.QCA.QuasiLocal
 import TNLean.QCA.RegionSumset
 
@@ -15,7 +17,8 @@ neighborhood when it sends every observable supported in \(\Lambda\) to one supp
 \(\Lambda + \mathcal N\), uniformly over finite regions \(\Lambda\).
 
 This file records equivalent support, range-inclusion, and finite-region witness formulations of
-that condition, together with neighborhood monotonicity and forward-composition closure.
+that condition, together with neighborhood monotonicity, forward-composition closure, and
+normalization to a symmetric interval.
 
 ## Main definitions
 
@@ -31,10 +34,16 @@ that condition, together with neighborhood monotonicity and forward-composition 
 * `SpinChain.propagatesWithin_iff_quasiLocalObservable` — the universal pointwise formulation.
 * `SpinChain.propagatesWithin_iff_range_subset` — the range-inclusion formulation.
 * `SpinChain.propagatesWithin_iff_exists_local` — the finite-region witness formulation.
+* `SpinChain.exists_subset_symmetric_Icc` — every finite integer region lies in some
+  symmetric interval.
 * `SpinChain.PropagatesWithin.mono` — propagation is monotone under neighborhood enlargement.
 * `SpinChain.PropagatesWithin.trans` — forward propagation bounds compose by region sumset.
+* `SpinChain.PropagatesWithin.exists_symmetric_Icc` — a propagation neighborhood can be enlarged
+  to a symmetric interval.
 * `SpinChain.HasFinitePropagation.exists_superset` — valid neighborhoods can contain any finite set.
 * `SpinChain.HasFinitePropagation.trans` — finite forward propagation is closed under composition.
+* `SpinChain.HasFinitePropagation.exists_symmetric_Icc` — finite propagation admits a symmetric
+  interval witness.
 
 ## References
 
@@ -101,6 +110,17 @@ def HasFinitePropagation {d : ℕ} [NeZero d]
     (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) : Prop :=
   ∃ 𝓝 : Finset ℤ, PropagatesWithin ω 𝓝
 
+/-- Every finite set of integers is contained in a symmetric interval
+\([-R,R] \cap \mathbb Z\).
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma exists_subset_symmetric_Icc (𝓝 : Finset ℤ) :
+    ∃ R : ℕ, 𝓝 ⊆ Finset.Icc (-(R : ℤ)) (R : ℤ) := by
+  refine ⟨𝓝.sup Int.natAbs, ?_⟩
+  intro n hn
+  rw [Finset.mem_Icc, ← abs_le, Int.abs_eq_natAbs]
+  exact_mod_cast Finset.le_sup hn
+
 variable {d : ℕ} [NeZero d]
   {ω η : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 𝓜 : Finset ℤ}
 
@@ -124,6 +144,16 @@ lemma trans (hω : PropagatesWithin ω 𝓝) (hη : PropagatesWithin η 𝓜) :
   rw [← regionSumset_assoc]
   exact hη (regionSumset Λ 𝓝) (ω x) (hω Λ x hx)
 
+/-- A finite propagation neighborhood can be enlarged to a symmetric interval
+\([-R,R] \cap \mathbb Z\).
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma exists_symmetric_Icc (hω : PropagatesWithin ω 𝓝) :
+    ∃ R : ℕ, 𝓝 ⊆ Finset.Icc (-(R : ℤ)) (R : ℤ) ∧
+      PropagatesWithin ω (Finset.Icc (-(R : ℤ)) (R : ℤ)) := by
+  obtain ⟨R, h𝓝R⟩ := exists_subset_symmetric_Icc 𝓝
+  exact ⟨R, h𝓝R, hω.mono h𝓝R⟩
+
 end PropagatesWithin
 
 namespace HasFinitePropagation
@@ -146,6 +176,16 @@ lemma trans (hω : HasFinitePropagation ω) (hη : HasFinitePropagation η) :
   obtain ⟨𝓝, h𝓝⟩ := hω
   obtain ⟨𝓜, h𝓜⟩ := hη
   exact ⟨regionSumset 𝓝 𝓜, h𝓝.trans h𝓜⟩
+
+/-- Finite forward propagation admits a symmetric-interval witness
+\([-R,R] \cap \mathbb Z\).
+
+Source: arXiv:1703.09188, Appendix, line 2298. -/
+lemma exists_symmetric_Icc (hω : HasFinitePropagation ω) :
+    ∃ R : ℕ, PropagatesWithin ω (Finset.Icc (-(R : ℤ)) (R : ℤ)) := by
+  obtain ⟨𝓝, h𝓝⟩ := hω
+  obtain ⟨R, _, hR⟩ := h𝓝.exists_symmetric_Icc
+  exact ⟨R, hR⟩
 
 end HasFinitePropagation
 

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8706,3 +8706,38 @@ $\omega^{-1}$.
   region sumsets.  For the existential assertion, choose one finite propagation
   neighborhood for each automorphism and use their sumset.
 \end{proof}
+
+\begin{lemma}[Symmetric-interval normalization of finite propagation]
+  \label{lem:qca_finite_propagation_symmetric_interval}
+  \lean{SpinChain.exists_subset_symmetric_Icc,
+    SpinChain.PropagatesWithin.exists_symmetric_Icc,
+    SpinChain.HasFinitePropagation.exists_symmetric_Icc}
+  \leanok
+  \uses{def:qca_propagates_within,def:qca_finite_propagation}
+  Every finite set $\mathcal N\subset\mathbb Z$ is contained in
+  $[-R,R]\cap\mathbb Z$ for some $R\in\mathbb N$.  This includes
+  $\mathcal N=\varnothing$, for which one may take $R=0$.  If $\omega$
+  propagates within a fixed set $\mathcal N$, then $R$ may be chosen so that
+  \begin{align}
+    \mathcal N&\subseteq[-R,R]\cap\mathbb Z, \\
+    \omega&\text{ propagates within }[-R,R]\cap\mathbb Z.
+  \end{align}
+  Consequently, finite forward propagation admits a symmetric-interval
+  witness:
+  \begin{align}
+    \exists R\in\mathbb N,\qquad
+    \omega&\text{ propagates within }[-R,R]\cap\mathbb Z.
+  \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_finite_propagation,
+    lem:qca_propagation_neighborhood_mono}
+  Let $R$ be the maximum of $|n|$ over $n\in\mathcal N$, with value $0$
+  when $\mathcal N$ is empty.  Then $-R\leq n\leq R$ for every
+  $n\in\mathcal N$, which gives
+  $\mathcal N\subseteq[-R,R]\cap\mathbb Z$.  Enlargement of propagation
+  neighborhoods gives the fixed-neighborhood assertion.  Finally, choose a
+  finite propagation neighborhood and apply this enlargement to its symmetric
+  interval.
+\end{proof}


### PR DESCRIPTION
Closes #6484

## Summary
- enclose every finite integer neighborhood in a symmetric interval `[-R,R]` using an empty-safe radius
- enlarge fixed forward-propagation bounds to symmetric intervals
- obtain symmetric-interval witnesses for finite forward propagation
- document the exact Appendix line 2298 normalization in Chapter 28

## Scope
This normalizes forward witnesses only. It asserts no minimal radius, inverse locality, blocking, or periodic stabilization.

## Validation
- `lake build TNLean.QCA.FinitePropagation TNLean.QCA`
- generated import aggregators current
- Blueprint/Lean sync and reverse coverage clean
- changed reader-facing prose, proof-integrity, and diff checks clean