### PR TITLE
fix(docs): define argmin in Brouwer gap note

### DIFF
--- a/docs/paper-gaps/brouwer_general_compact_convex.tex
+++ b/docs/paper-gaps/brouwer_general_compact_convex.tex
@@ -53,7 +53,7 @@ this gap:
 \begin{enumerate}
   \item \textbf{Metric projection.}  For a nonempty closed convex set~\(K\) in a
     finite-dimensional Euclidean space, the nearest-point map
-    \(\operatorname{proj}_K(x) = \argmin_{p \in K} \lVert x-p\rVert\) is unique,
+    \(\operatorname{proj}_K(x) = \operatorname*{argmin}_{p \in K} \lVert x-p\rVert\) is unique,
     1-Lipschitz, and restricts to the identity on~\(K\).  This provides the
     retraction required by the existing retract-based fixed-point theorem.  The
     existence, uniqueness, and continuity of the metric projection for convex


### PR DESCRIPTION
## What changed

- replace the undefined `\argmin` control sequence in the Wolf Theorem 6.10 gap note with `\operatorname*{argmin}`
- restore the paper-gap PDF stage that stopped at `brouwer_general_compact_convex.tex` in hosted full-documentation run 31930592778

## Validation

- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error brouwer_general_compact_convex.tex && latexmk -c brouwer_general_compact_convex.tex`
- repaired note compiles to a 2-page PDF; only the pre-existing overfull-box warning remains
- complete `scripts/build-paper-gaps.sh` progressed past this note and was interrupted only by the local 10-minute command limit

Advances #6415