### PR TITLE
fix(blueprint): correct the MPU rank-one outer product

### DIFF
--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -5755,11 +5755,12 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   Then the rank-one doubled-virtual matrix satisfies
   \begin{align}
     C\!\left(\mathcal W,
-      \lvert\operatorname{vec}(R))(\operatorname{vec}(L)\rvert\right)^{ij}
+      \operatorname{vec}(R)\operatorname{vec}(L)^T\right)^{ij}
       &=L W^{ij}R.
       \label{eq:mpu_factor_free_rank_one}
   \end{align}
-  No transpose, adjoint, or normalization factor occurs. The binary map
+  No adjoint or normalization factor occurs in the contraction result. The
+  binary map
   $(\mathcal W,E)\mapsto C(\mathcal W,E)$, the map
   $\mathcal W\mapsto E(\mathcal W)$, and consequently the map
   $\mathcal W\mapsto\widehat{\mathcal W}_{\mathrm{ff}}$ are continuous.
@@ -5775,7 +5776,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   (\ref{eq:mpu_factor_free_rank_one}) and using column stacking gives
   \begin{align}
     C\!\left(\mathcal W,
-      \lvert\operatorname{vec}(R))(\operatorname{vec}(L)\rvert\right)^{ij}_{ab}
+      \operatorname{vec}(R)\operatorname{vec}(L)^T\right)^{ij}_{ab}
       &=\sum_{c,e}R_{eb}L_{ac}W^{ij}_{ce}\\
       &=\sum_{c,e}L_{ac}W^{ij}_{ce}R_{eb}
        =(L W^{ij}R)_{ab}.


### PR DESCRIPTION
## What changed
- replace the misleading bra-ket rank-one factor by the bilinear outer product `vec(R) vec(L)^T` in both equations
- align the surrounding sentence with the Lean contraction theorem while preserving all blueprint metadata

## Validation
- two LuaLaTeX passes with `TEXINPUTS="../../tex/tenkz//:"`
- zero undefined cross-references
- `leanblueprint checkdecls`: 7851/7851 synchronized, all 7824 referenced declarations found
- `git diff --check`

Closes #6463