### PR TITLE
docs(blueprint): cover the contiguous-restriction ground-space map

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -318,62 +318,34 @@
     restriction again has the form of a ground-space vector.
 \end{proof}
 
-\begin{theorem}[Ground-space contiguous-window restriction]
-    \label{thm:contiguous_restriction_ground_space_map_intersection}
-    \lean{MPSTensor.contiguousRestrictₗ_groundSpaceMap_mem_groundSpace}
-    \leanok
-    \uses{def:ground_space_map, def:ground_space_parent,
+\begin{remark}[Ground-space contiguous-window restriction]
+    \label{rem:contiguous_restriction_ground_space_map_intersection}
+    \uses{thm:contiguous_restriction_ground_space_map,
+        def:ground_space_map, def:ground_space_parent,
         rem:contiguous_window_operators}
-    Assume $s+L \le N$, and let $\tau$ be a full configuration supplying the
-    complementary values. Write the words to the left and right of the window
-    $[s,s+L-1]$ as
-    \begin{align}
-        w_L&=(\tau_0,\ldots,\tau_{s-1}),
-        \notag\\
-        w_R&=(\tau_{s+L},\ldots,\tau_{N-1}).
-        \notag
-    \end{align}
-    For every boundary matrix $X$, both outside words are absorbed into the
-    boundary matrix, and the restriction is again a ground-space vector:
+    The two-sided window restriction is recorded in the martingale chapter as
+    Theorem~\ref{thm:contiguous_restriction_ground_space_map}: for sites
+    $s,L,N$ with $s+L \le N$, a full configuration $\tau$ supplying the
+    complementary values, and a boundary matrix $X$, the nonwrapping
+    restriction of the open-boundary ground-space vector $\Gamma_N(X)$ to the
+    window $[s,s+L-1]$ is again an open-boundary ground-space vector,
     \begin{align}
         \Res^\tau_{s,L}\Gamma_N(X)&\in G_L(A).
         \notag
     \end{align}
-    This two-sided absorption generalizes
-    Lemma~\ref{lem:ground_space_in_tail_ground}, whose suffix restriction
-    absorbs only the prefix. It is the frustration-free restriction identity
-    for the nonwrapping windows of the compatible open chain of
-    \cite[Equation~(3.12)]{Nachtergaele1996Spectral}, whose zero-energy space
-    is identified in \cite[Equation~(3.13)]{Nachtergaele1996Spectral}.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{lem:ground_space_map_apply, lem:eval_word_append}
-    For a length-$L$ word $\omega$, inserting $\omega$ into the window turns
-    the configuration word into $w_L\omega w_R$, and multiplicativity of word
-    evaluation gives
-    \begin{align}
-        A^{w_L\omega w_R}
-        &= A^{w_L}A^\omega A^{w_R}.
-        \notag
-    \end{align}
-    The restriction therefore evaluates to
-    \begin{align}
-        (\Res^\tau_{s,L}\Gamma_N(X))(\omega)
-        &= \tr(A^{w_L}A^\omega A^{w_R}X),
-        \notag
-    \end{align}
-    and cyclicity of the trace moves both outside words onto the boundary
-    matrix:
+    Both outside words are absorbed into the boundary matrix: writing
+    $w_L=(\tau_0,\ldots,\tau_{s-1})$ and
+    $w_R=(\tau_{s+L},\ldots,\tau_{N-1})$, word multiplicativity and
+    cyclicity of the trace give
     \begin{align}
         \tr(A^{w_L}A^\omega A^{w_R}X)
-        &= \tr(A^\omega A^{w_R}XA^{w_L}).
+        &=\tr(A^\omega A^{w_R}XA^{w_L}),
         \notag
     \end{align}
-    The right-hand side is $\Gamma_L(A^{w_R}XA^{w_L})(\omega)$, so the
-    restricted vector is the ground-space vector $\Gamma_L(A^{w_R}XA^{w_L})$.
-\end{proof}
+    so the restriction is $\Gamma_L(A^{w_R}XA^{w_L})$. This two-sided
+    absorption generalizes Lemma~\ref{lem:ground_space_in_tail_ground},
+    whose suffix restriction absorbs only the prefix.
+\end{remark}
 
 \begin{lemma}[Left-tail compatibility]\label{lem:left_tail_compatibility}
     \lean{MPSTensor.exists_left_tail_compatibility}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -318,6 +318,62 @@
     restriction again has the form of a ground-space vector.
 \end{proof}
 
+\begin{lemma}[Ground-space contiguous-window restriction]
+    \label{lem:contiguous_restriction_ground_space_map}
+    \lean{MPSTensor.contiguousRestrictₗ_groundSpaceMap_mem_groundSpace}
+    \leanok
+    \uses{def:ground_space_map, def:ground_space_parent,
+        rem:contiguous_window_operators}
+    Assume $s+L \le N$, and let $\tau$ be a full configuration supplying the
+    complementary values. Write the words to the left and right of the window
+    $[s,s+L-1]$ as
+    \begin{align}
+        w_L&=(\tau_0,\ldots,\tau_{s-1}),
+        \notag\\
+        w_R&=(\tau_{s+L},\ldots,\tau_{N-1}).
+        \notag
+    \end{align}
+    For every boundary matrix $X$, both outside words are absorbed into the
+    boundary matrix:
+    \begin{align}
+        \Res^\tau_{s,L}\Gamma_N(X)
+        &= \Gamma_L(A^{w_R}XA^{w_L})\in G_L(A).
+        \notag
+    \end{align}
+    This two-sided absorption generalizes
+    Lemma~\ref{lem:ground_space_in_tail_ground}, whose suffix restriction
+    absorbs only the prefix. The identity is the nonwrapping restriction of
+    \cite[Equation~(3.12)]{Nachtergaele1996Spectral}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:ground_space_map_apply, lem:eval_word_append}
+    For a length-$L$ word $\omega$, inserting $\omega$ into the window turns
+    the configuration word into $w_L\omega w_R$, and multiplicativity of word
+    evaluation gives
+    \begin{align}
+        A^{w_L\omega w_R}
+        &= A^{w_L}A^\omega A^{w_R}.
+        \notag
+    \end{align}
+    The restriction therefore evaluates to
+    \begin{align}
+        (\Res^\tau_{s,L}\Gamma_N(X))(\omega)
+        &= \tr(A^{w_L}A^\omega A^{w_R}X),
+        \notag
+    \end{align}
+    and cyclicity of the trace moves both outside words onto the boundary
+    matrix:
+    \begin{align}
+        \tr(A^{w_L}A^\omega A^{w_R}X)
+        &= \tr(A^\omega A^{w_R}XA^{w_L}).
+        \notag
+    \end{align}
+    The right-hand side is $\Gamma_L(A^{w_R}XA^{w_L})(\omega)$, so the
+    restricted vector is the ground-space vector $\Gamma_L(A^{w_R}XA^{w_L})$.
+\end{proof}
+
 \begin{lemma}[Left-tail compatibility]\label{lem:left_tail_compatibility}
     \lean{MPSTensor.exists_left_tail_compatibility}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -318,8 +318,8 @@
     restriction again has the form of a ground-space vector.
 \end{proof}
 
-\begin{lemma}[Ground-space contiguous-window restriction]
-    \label{lem:contiguous_restriction_ground_space_map}
+\begin{theorem}[Ground-space contiguous-window restriction]
+    \label{thm:contiguous_restriction_ground_space_map_intersection}
     \lean{MPSTensor.contiguousRestrictₗ_groundSpaceMap_mem_groundSpace}
     \leanok
     \uses{def:ground_space_map, def:ground_space_parent,
@@ -334,17 +334,18 @@
         \notag
     \end{align}
     For every boundary matrix $X$, both outside words are absorbed into the
-    boundary matrix:
+    boundary matrix, and the restriction is again a ground-space vector:
     \begin{align}
-        \Res^\tau_{s,L}\Gamma_N(X)
-        &= \Gamma_L(A^{w_R}XA^{w_L})\in G_L(A).
+        \Res^\tau_{s,L}\Gamma_N(X)&\in G_L(A).
         \notag
     \end{align}
     This two-sided absorption generalizes
     Lemma~\ref{lem:ground_space_in_tail_ground}, whose suffix restriction
-    absorbs only the prefix. The identity is the nonwrapping restriction of
-    \cite[Equation~(3.12)]{Nachtergaele1996Spectral}.
-\end{lemma}
+    absorbs only the prefix. It is the frustration-free restriction identity
+    for the nonwrapping windows of the compatible open chain of
+    \cite[Equation~(3.12)]{Nachtergaele1996Spectral}, whose zero-energy space
+    is identified in \cite[Equation~(3.13)]{Nachtergaele1996Spectral}.
+\end{theorem}
 
 \begin{proof}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex
@@ -336,7 +336,7 @@
     Both outside words are absorbed into the boundary matrix: writing
     $w_L=(\tau_0,\ldots,\tau_{s-1})$ and
     $w_R=(\tau_{s+L},\ldots,\tau_{N-1})$, word multiplicativity and
-    cyclicity of the trace give
+    cyclicity of the trace give, for any window word $\omega$,
     \begin{align}
         \tr(A^{w_L}A^\omega A^{w_R}X)
         &=\tr(A^\omega A^{w_R}XA^{w_L}),


### PR DESCRIPTION
## What changed

Adds a remark `rem:contiguous_restriction_ground_space_map_intersection` beside `lem:ground_space_in_tail_ground` in ch13 (intersection-property chapter) that cites the martingale-chapter theorem `thm:contiguous_restriction_ground_space_map` (#6450) across chapters and sketches the two-sided window absorption (both outside words absorbed into the boundary matrix, generalizing the prefix-only `lem:ground_space_in_tail_ground`), citing Nachtergaele cond-mat/9410110 Eq. (3.12)/(3.13) in the project's established reading.

Issue #6458 required no edit here: its footnote label and caligraphic-$G$ fixes landed via #6459 (verified on main).

## Validation

- `blueprint_lean_sync.py --update-lean-decls` + `leanblueprint checkdecls`: in sync, 0 missing.
- Double `lualatex print.tex`: 0 undefined References; artifacts cleaned.

Closes #6444