### PR TITLE
feat(QCA): add two-sided finite-propagation predicates

### DIFF
--- a/TNLean/QCA/FinitePropagation.lean
+++ b/TNLean/QCA/FinitePropagation.lean
@@ -18,13 +18,18 @@ neighborhood when it sends every observable supported in \(\Lambda\) to one supp
 
 This file records equivalent support, range-inclusion, and finite-region witness formulations of
 that condition, together with neighborhood monotonicity, forward-composition closure, and
-normalization to a symmetric interval.
+normalization to a symmetric interval. It also provides two-sided convenience predicates that
+require propagation bounds separately for an automorphism and its inverse.
 
 ## Main definitions
 
 * `SpinChain.QuasiLocalSupportedIn` — membership in a finite-region observable algebra.
 * `SpinChain.PropagatesWithin` — propagation bounded by a fixed finite neighborhood.
 * `SpinChain.HasFinitePropagation` — existence of a finite propagation neighborhood.
+* `SpinChain.PropagatesWithinTwoSided` — a common neighborhood bound for an automorphism and
+  its inverse.
+* `SpinChain.HasTwoSidedFinitePropagation` — separate finite propagation bounds for an
+  automorphism and its inverse.
 
 ## Main results
 
@@ -50,6 +55,8 @@ normalization to a symmetric interval.
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, line 2298.
 * Schumacher--Werner, quant-ph/0405174, Definition 1.
 -/
+
+open scoped Pointwise
 
 namespace SpinChain
 
@@ -109,6 +116,39 @@ Source: arXiv:1703.09188, Appendix, line 2298. -/
 def HasFinitePropagation {d : ℕ} [NeZero d]
     (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) : Prop :=
   ∃ 𝓝 : Finset ℤ, PropagatesWithin ω 𝓝
+
+/-- A finite neighborhood is a two-sided propagation bound when it bounds both an automorphism
+and its inverse.
+
+This is a derived convenience predicate, not the forward-only QCA definition in either cited
+source. Context: arXiv:1703.09188, Appendix, line 2298; Schumacher--Werner, Definition 1. -/
+def PropagatesWithinTwoSided {d : ℕ} [NeZero d]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) (𝓝 : Finset ℤ) : Prop :=
+  PropagatesWithin ω 𝓝 ∧ PropagatesWithin ω.symm 𝓝
+
+/-- A quasi-local star-automorphism has two-sided finite propagation when it and its inverse each
+have finite forward propagation, possibly with different finite neighborhoods.
+
+This is a derived convenience predicate, not the forward-only QCA definition in either cited
+source. Context: arXiv:1703.09188, Appendix, line 2298; Schumacher--Werner, Definition 1. -/
+def HasTwoSidedFinitePropagation {d : ℕ} [NeZero d]
+    (ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d) : Prop :=
+  HasFinitePropagation ω ∧ HasFinitePropagation ω.symm
+
+/-- Reflection fixes every symmetric integer interval.
+
+This is an elementary fact about finite neighborhoods. Context: arXiv:1703.09188, Appendix,
+line 2298. -/
+@[simp]
+lemma neg_symmetric_Icc (R : ℕ) :
+    -(Finset.Icc (-(R : ℤ)) (R : ℤ)) = Finset.Icc (-(R : ℤ)) (R : ℤ) := by
+  ext n
+  simp only [Finset.mem_neg, Finset.mem_Icc]
+  constructor
+  · rintro ⟨n, ⟨hnlo, hnhi⟩, rfl⟩
+    exact ⟨neg_le_neg hnhi, by simpa using neg_le_neg hnlo⟩
+  · rintro ⟨hnlo, hnhi⟩
+    exact ⟨-n, ⟨neg_le_neg hnhi, by simpa using neg_le_neg hnlo⟩, neg_neg n⟩
 
 /-- Every finite set of integers is contained in a symmetric interval
 \([-R,R] \cap \mathbb Z\).
@@ -188,6 +228,62 @@ lemma exists_symmetric_Icc (hω : HasFinitePropagation ω) :
   exact ⟨R, hR⟩
 
 end HasFinitePropagation
+
+namespace PropagatesWithinTwoSided
+
+/-- A common two-sided propagation neighborhood remains valid after enlargement.
+
+This is an elementary consequence of forward-neighborhood monotonicity and is not a separate
+claim of the cited sources. -/
+lemma mono (hω : PropagatesWithinTwoSided ω 𝓝) (h𝓝𝓜 : 𝓝 ⊆ 𝓜) :
+    PropagatesWithinTwoSided ω 𝓜 :=
+  ⟨hω.1.mono h𝓝𝓜, hω.2.mono h𝓝𝓜⟩
+
+/-- A forward bound by \(\mathcal N\) and an inverse bound by \(-\mathcal N\) have the common
+neighborhood \(\mathcal N\cup(-\mathcal N)\).
+
+This only enlarges two supplied bounds. It does not derive inverse propagation from forward
+propagation. -/
+lemma of_reflected (hω : PropagatesWithin ω 𝓝) (hωinv : PropagatesWithin ω.symm (-𝓝)) :
+    PropagatesWithinTwoSided ω (𝓝 ∪ (-𝓝)) :=
+  ⟨hω.mono Finset.subset_union_left, hωinv.mono Finset.subset_union_right⟩
+
+/-- A common two-sided propagation neighborhood can be enlarged to a symmetric interval.
+
+This is an elementary consequence of finite-neighborhood enlargement and is not a separate claim
+of the cited sources. -/
+lemma exists_symmetric_Icc (hω : PropagatesWithinTwoSided ω 𝓝) :
+    ∃ R : ℕ, 𝓝 ⊆ Finset.Icc (-(R : ℤ)) (R : ℤ) ∧
+      PropagatesWithinTwoSided ω (Finset.Icc (-(R : ℤ)) (R : ℤ)) := by
+  obtain ⟨R, h𝓝R⟩ := exists_subset_symmetric_Icc 𝓝
+  exact ⟨R, h𝓝R, hω.mono h𝓝R⟩
+
+end PropagatesWithinTwoSided
+
+namespace HasTwoSidedFinitePropagation
+
+/-- Separate finite propagation bounds for an automorphism and its inverse have one common
+finite neighborhood.
+
+This only combines supplied forward and inverse bounds. It does not prove that the inverse has
+finite propagation. -/
+lemma exists_common_neighborhood (hω : HasTwoSidedFinitePropagation ω) :
+    ∃ 𝓝 : Finset ℤ, PropagatesWithinTwoSided ω 𝓝 := by
+  obtain ⟨⟨𝓝, h𝓝⟩, ⟨𝓜, h𝓜⟩⟩ := hω
+  exact ⟨𝓝 ∪ 𝓜, h𝓝.mono Finset.subset_union_left, h𝓜.mono Finset.subset_union_right⟩
+
+/-- Two-sided finite propagation admits one symmetric-interval neighborhood for the automorphism
+and its inverse.
+
+This only combines and enlarges supplied forward and inverse bounds. It does not prove inverse
+locality from forward locality. -/
+lemma exists_symmetric_Icc (hω : HasTwoSidedFinitePropagation ω) :
+    ∃ R : ℕ, PropagatesWithinTwoSided ω (Finset.Icc (-(R : ℤ)) (R : ℤ)) := by
+  obtain ⟨𝓝, h𝓝⟩ := hω.exists_common_neighborhood
+  obtain ⟨R, _, hR⟩ := h𝓝.exists_symmetric_Icc
+  exact ⟨R, hR⟩
+
+end HasTwoSidedFinitePropagation
 
 /-- Propagation within \(\mathcal N\) can be checked pointwise on the canonical image of each
 finite-region observable algebra.

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -8780,6 +8780,87 @@ $\omega^{-1}$.
   interval.
 \end{proof}
 
+\begin{definition}[Two-sided finite-propagation predicates]
+  \label{def:qca_two_sided_finite_propagation}
+  \lean{SpinChain.PropagatesWithinTwoSided,
+    SpinChain.HasTwoSidedFinitePropagation}
+  \leanok
+  \uses{def:qca_propagates_within,def:qca_finite_propagation}
+  Let $d>0$, and let $\omega$ be a star-algebra automorphism of $\mathcal A$.
+  A finite set $\mathcal N\subset\mathbb Z$ is a two-sided propagation
+  neighborhood when
+  \begin{align}
+    \omega(\mathcal A_\Lambda)&\subseteq
+      \mathcal A_{\Lambda+\mathcal N}
+  \end{align}
+  and
+  \begin{align}
+    \omega^{-1}(\mathcal A_\Lambda)&\subseteq
+      \mathcal A_{\Lambda+\mathcal N}
+  \end{align}
+  for every finite $\Lambda\subset\mathbb Z$.  The automorphism has two-sided
+  finite propagation when $\omega$ and $\omega^{-1}$ each have a finite forward
+  propagation neighborhood; the two neighborhoods need not initially agree.
+
+  These are derived convenience predicates.  The definition in
+  \cite[line~2298]{Cirac2017MPU} and Schumacher--Werner,
+  quant-ph/0405174, Definition~1, both define locality by the forward inclusion
+  for $\omega$ alone.  In particular, these predicates do not assert that
+  forward locality implies locality of the inverse.
+\end{definition}
+
+\begin{lemma}[Common neighborhoods for two-sided propagation]
+  \label{lem:qca_two_sided_common_neighborhood}
+  \lean{SpinChain.neg_symmetric_Icc,
+    SpinChain.PropagatesWithinTwoSided.mono,
+    SpinChain.PropagatesWithinTwoSided.of_reflected,
+    SpinChain.PropagatesWithinTwoSided.exists_symmetric_Icc,
+    SpinChain.HasTwoSidedFinitePropagation.exists_common_neighborhood,
+    SpinChain.HasTwoSidedFinitePropagation.exists_symmetric_Icc}
+  \leanok
+  \uses{def:qca_two_sided_finite_propagation}
+  For a finite set $\mathcal N\subset\mathbb Z$, write
+  \begin{align}
+    -\mathcal N&=\{-a\mid a\in\mathcal N\}.
+  \end{align}
+  Reflection fixes every symmetric interval:
+  \begin{align}
+    -\bigl([-R,R]\cap\mathbb Z\bigr)&=[-R,R]\cap\mathbb Z.
+  \end{align}
+  If $\mathcal N\subseteq\mathcal M$, then every common two-sided bound by
+  $\mathcal N$ is also a common bound by $\mathcal M$.  More generally, if
+  $\omega$ propagates within $\mathcal N$ and $\omega^{-1}$ propagates within
+  $-\mathcal N$, then both propagate within
+  \begin{align}
+    \mathcal N\cup(-\mathcal N).
+  \end{align}
+  Finally, any two-sided finite-propagation pair admits a common finite
+  neighborhood and therefore a common symmetric-interval neighborhood.  Thus
+  there is an $R\in\mathbb N$ such that
+  \begin{align}
+    \omega(\mathcal A_\Lambda)&\subseteq
+      \mathcal A_{\Lambda+([-R,R]\cap\mathbb Z)}
+  \end{align}
+  and
+  \begin{align}
+    \omega^{-1}(\mathcal A_\Lambda)&\subseteq
+      \mathcal A_{\Lambda+([-R,R]\cap\mathbb Z)}
+  \end{align}
+  for every finite $\Lambda\subset\mathbb Z$.
+\end{lemma}
+
+\begin{proof}\leanok
+  \uses{def:qca_two_sided_finite_propagation,
+    lem:qca_propagation_neighborhood_mono,
+    lem:qca_finite_propagation_symmetric_interval}
+  Negation reverses the two endpoint inequalities, so it preserves
+  $[-R,R]\cap\mathbb Z$.  Enlarge each supplied neighborhood using monotonicity.
+  For reflected bounds, both inclusions into $\mathcal N\cup(-\mathcal N)$ are
+  immediate.  For arbitrary finite forward and inverse neighborhoods, first
+  take their union and then enlarge that common neighborhood to a symmetric
+  interval.
+\end{proof}
+
 \begin{definition}[One-dimensional quantum cellular automaton]
   \label{def:qca}
   \lean{SpinChain.IsQCA}


### PR DESCRIPTION
## What changed
- define common-neighborhood and existential two-sided finite propagation for a quasi-local automorphism and its inverse
- add reflected-neighborhood, union, monotonicity, and symmetric-interval convenience lemmas without deriving inverse locality
- document the forward-only source definition and the derived two-sided API in Chapter 28

## Validation
- `lake build TNLean.QCA.FinitePropagation`
- `lake build TNLean.QCA.IsQCA`
- blueprint sync and `leanblueprint checkdecls`
- two LuaLaTeX passes with zero undefined cross-references
- style, proof-integrity, reader-facing prose, and `git diff --check`

Closes #6514
Advances #6498