### PR TITLE
fix(docs): escape Wielandt blueprint labels

### DIFF
--- a/docs/paper-gaps/quantum_wielandt_deviation_v1.tex
+++ b/docs/paper-gaps/quantum_wielandt_deviation_v1.tex
@@ -142,8 +142,8 @@ $i(A)$, where $i(A)$ is defined using the spaces $S_n(A)$ themselves.
     \leanid{MPSTensor.cumulativeSpan_eq_top} in
     \path{TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean}; the theorem for
     the spaces $S_n(A)$ is the general theorem cited above. The blueprint makes
-    this distinction at \texttt{thm:cumulative_eq_top} and states the general
-    bound at \texttt{thm:wielandt_general} in the Chapter~8 sources under
+    this distinction at \texttt{thm:cumulative\_eq\_top} and states the general
+    bound at \texttt{thm:wielandt\_general} in the Chapter~8 sources under
     \path{blueprint/src/chapter/}.}
 
 Finally, the lower-level use of normality is not itself a mismatch. In these


### PR DESCRIPTION
## What changed

- escape underscores in the two Chapter 8 blueprint labels printed by `quantum_wielandt_deviation_v1.tex`
- fix the `Missing $ inserted` failure exposed by the fresh full-documentation run after #6518

## Validation

- `cd docs/paper-gaps && latexmk -C quantum_wielandt_deviation_v1.tex && latexmk -pdf -interaction=nonstopmode -halt-on-error quantum_wielandt_deviation_v1.tex && latexmk -c quantum_wielandt_deviation_v1.tex`
- output: 5-page PDF; only pre-existing box warnings remain

Advances #6415