### PR TITLE
feat(QCA): commute disjointly supported observables

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.QCA
 
 import TNLean.QCA.AlgebraicTranslation
+import TNLean.QCA.DisjointSupport
 import TNLean.QCA.FinitePropagation
 import TNLean.QCA.IsQCA
 import TNLean.QCA.LocalAlgebra

--- a/TNLean/QCA/DisjointSupport.lean
+++ b/TNLean/QCA/DisjointSupport.lean
@@ -16,13 +16,13 @@ named result of the source.
 
 ## Main results
 
-* `SpinChain.localInclusion_mul_comm_of_disjoint` — disjoint finite-region observables commute in
+* `SpinChain.localInclusion_commute_of_disjoint` — disjoint finite-region observables commute in
   the algebra on their union.
-* `SpinChain.localObservable_mul_comm_of_disjoint` — their algebraic-local images commute.
-* `SpinChain.SupportedIn.mul_comm_of_disjoint` — algebraic observables with disjoint supports
+* `SpinChain.localObservable_commute_of_disjoint` — their algebraic-local images commute.
+* `SpinChain.SupportedIn.commute_of_disjoint` — algebraic observables with disjoint supports
   commute.
-* `SpinChain.quasiLocalObservable_mul_comm_of_disjoint` — their quasi-local images commute.
-* `SpinChain.QuasiLocalSupportedIn.mul_comm_of_disjoint` — quasi-local observables with disjoint
+* `SpinChain.quasiLocalObservable_commute_of_disjoint` — their quasi-local images commute.
+* `SpinChain.QuasiLocalSupportedIn.commute_of_disjoint` — quasi-local observables with disjoint
   finite supports commute.
 
 ## References
@@ -112,12 +112,11 @@ algebra on their union.
 
 This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
 lines 2292--2300. -/
-theorem localInclusion_mul_comm_of_disjoint (hΛΓ : Disjoint Λ Γ)
+theorem localInclusion_commute_of_disjoint (hΛΓ : Disjoint Λ Γ)
     (A : LocalAlgebra d Λ) (B : LocalAlgebra d Γ) :
-    localInclusion (d := d) Finset.subset_union_left A *
-        localInclusion Finset.subset_union_right B =
-      localInclusion Finset.subset_union_right B *
-        localInclusion Finset.subset_union_left A := by
+    Commute (localInclusion (d := d) Finset.subset_union_left A)
+      (localInclusion Finset.subset_union_right B) := by
+  rw [commute_iff_eq]
   ext x y
   change (∑ z, localInclusion Finset.subset_union_left A x z *
       localInclusion Finset.subset_union_right B z y) =
@@ -166,50 +165,49 @@ theorem localInclusion_mul_comm_of_disjoint (hΛΓ : Disjoint Λ Γ)
 
 This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
 lines 2292--2300. -/
-theorem localObservable_mul_comm_of_disjoint (hΛΓ : Disjoint Λ Γ)
+theorem localObservable_commute_of_disjoint (hΛΓ : Disjoint Λ Γ)
     (A : LocalAlgebra d Λ) (B : LocalAlgebra d Γ) :
-    localObservable d Λ A * localObservable d Γ B =
-      localObservable d Γ B * localObservable d Λ A := by
-  rw [← localObservable_localInclusion d Finset.subset_union_left A,
+    Commute (localObservable d Λ A) (localObservable d Γ B) := by
+  rw [commute_iff_eq, ← localObservable_localInclusion d Finset.subset_union_left A,
     ← localObservable_localInclusion d Finset.subset_union_right B,
-    ← map_mul, localInclusion_mul_comm_of_disjoint hΛΓ, map_mul]
+    ← map_mul, (localInclusion_commute_of_disjoint hΛΓ A B).eq, map_mul]
 
 /-- Algebraic local observables with disjoint finite supports commute.
 
 This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
 lines 2292--2300. -/
-theorem SupportedIn.mul_comm_of_disjoint {X Y : AlgebraicLocalAlgebra d}
+theorem SupportedIn.commute_of_disjoint {X Y : AlgebraicLocalAlgebra d}
     (hX : SupportedIn X Λ) (hY : SupportedIn Y Γ) (hΛΓ : Disjoint Λ Γ) :
-    X * Y = Y * X := by
+    Commute X Y := by
   obtain ⟨A, rfl⟩ := hX
   obtain ⟨B, rfl⟩ := hY
-  exact localObservable_mul_comm_of_disjoint hΛΓ A B
+  exact localObservable_commute_of_disjoint hΛΓ A B
 
 /-- Canonical quasi-local observables from disjoint regions commute.
 
 This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
 lines 2292--2300. -/
-theorem quasiLocalObservable_mul_comm_of_disjoint [NeZero d] (hΛΓ : Disjoint Λ Γ)
+theorem quasiLocalObservable_commute_of_disjoint [NeZero d] (hΛΓ : Disjoint Λ Γ)
     (A : LocalAlgebra d Λ) (B : LocalAlgebra d Γ) :
-    quasiLocalObservable d Λ A * quasiLocalObservable d Γ B =
-      quasiLocalObservable d Γ B * quasiLocalObservable d Λ A := by
+    Commute (quasiLocalObservable d Λ A) (quasiLocalObservable d Γ B) := by
+  rw [commute_iff_eq]
   change algebraicToQuasiLocal d (localObservable d Λ A) *
       algebraicToQuasiLocal d (localObservable d Γ B) =
     algebraicToQuasiLocal d (localObservable d Γ B) *
       algebraicToQuasiLocal d (localObservable d Λ A)
-  rw [← map_mul, localObservable_mul_comm_of_disjoint hΛΓ, map_mul]
+  rw [← map_mul, (localObservable_commute_of_disjoint hΛΓ A B).eq, map_mul]
 
 /-- Quasi-local observables with disjoint finite supports commute.
 
 This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
 lines 2292--2300. -/
-theorem QuasiLocalSupportedIn.mul_comm_of_disjoint [NeZero d]
+theorem QuasiLocalSupportedIn.commute_of_disjoint [NeZero d]
     {X Y : QuasiLocalAlgebra d} (hX : QuasiLocalSupportedIn X Λ)
     (hY : QuasiLocalSupportedIn Y Γ) (hΛΓ : Disjoint Λ Γ) :
-    X * Y = Y * X := by
+    Commute X Y := by
   obtain ⟨A, rfl⟩ := hX
   obtain ⟨B, rfl⟩ := hY
-  exact quasiLocalObservable_mul_comm_of_disjoint hΛΓ A B
+  exact quasiLocalObservable_commute_of_disjoint hΛΓ A B
 
 end Local
 

--- a/TNLean/QCA/DisjointSupport.lean
+++ b/TNLean/QCA/DisjointSupport.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.FinitePropagation
+
+/-!
+# Commutation of observables with disjoint finite supports
+
+Observables on disjoint finite regions commute after embedding into a common local algebra. The
+same conclusion holds in the algebraic local algebra and in its quasi-local completion.
+
+This is local tensor-factor infrastructure used by the QCA appendix, rather than a separately
+named result of the source.
+
+## Main results
+
+* `SpinChain.localInclusion_mul_comm_of_disjoint` — disjoint finite-region observables commute in
+  the algebra on their union.
+* `SpinChain.localObservable_mul_comm_of_disjoint` — their algebraic-local images commute.
+* `SpinChain.SupportedIn.mul_comm_of_disjoint` — algebraic observables with disjoint supports
+  commute.
+* `SpinChain.quasiLocalObservable_mul_comm_of_disjoint` — their quasi-local images commute.
+* `SpinChain.QuasiLocalSupportedIn.mul_comm_of_disjoint` — quasi-local observables with disjoint
+  finite supports commute.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, lines 2292--2300.
+-/
+
+namespace SpinChain
+
+namespace Config
+
+/-- A configuration on a disjoint union is determined by its restrictions to both regions.
+
+This is elementary finite tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
+lines 2292--2300. -/
+private lemma eq_of_restrict_eq_restrict {d : ℕ} {Λ Γ : Finset ℤ}
+    {x y : Config d (Λ ∪ Γ)}
+    (hΛ : restrict Finset.subset_union_left x = restrict Finset.subset_union_left y)
+    (hΓ : restrict Finset.subset_union_right x = restrict Finset.subset_union_right y) :
+    x = y := by
+  funext i
+  rcases Finset.mem_union.mp i.2 with hiΛ | hiΓ
+  · exact congrFun hΛ ⟨i, hiΛ⟩
+  · exact congrFun hΓ ⟨i, hiΓ⟩
+
+/-- Splitting configurations on a union of disjoint regions into the two restrictions. -/
+private def disjointUnionEquiv {d : ℕ} {Λ Γ : Finset ℤ} (hΛΓ : Disjoint Λ Γ) :
+    Config d (Λ ∪ Γ) ≃ Config d Λ × Config d Γ where
+  toFun x := (restrict Finset.subset_union_left x, restrict Finset.subset_union_right x)
+  invFun x i := if hiΛ : (i : ℤ) ∈ Λ then x.1 ⟨i, hiΛ⟩ else
+    x.2 ⟨i, (Finset.mem_union.mp i.2).resolve_left hiΛ⟩
+  left_inv x := by
+    apply eq_of_restrict_eq_restrict
+    · funext i
+      simp [restrict]
+    · funext i
+      simp [restrict, hΛΓ.notMem_of_mem_right_finset i.2]
+  right_inv x := by
+    apply Prod.ext
+    · funext i
+      simp [restrict]
+    · funext i
+      simp [restrict, hΛΓ.notMem_of_mem_right_finset i.2]
+
+private lemma splitEquiv_snd_eq_iff_restrict_right {d : ℕ} {Λ Γ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (x y : Config d (Λ ∪ Γ)) :
+    (splitEquiv Finset.subset_union_left x).2 =
+        (splitEquiv Finset.subset_union_left y).2 ↔
+      restrict Finset.subset_union_right x = restrict Finset.subset_union_right y := by
+  constructor
+  · intro h
+    funext i
+    exact congrFun h ⟨i, Finset.mem_sdiff.mpr
+      ⟨Finset.mem_union_right Λ i.2, hΛΓ.notMem_of_mem_right_finset i.2⟩⟩
+  · intro h
+    funext i
+    have hiΓ : (i : ℤ) ∈ Γ :=
+      (Finset.mem_union.mp (Finset.mem_sdiff.mp i.2).1).resolve_left
+        (Finset.mem_sdiff.mp i.2).2
+    exact congrFun h ⟨i, hiΓ⟩
+
+private lemma splitEquiv_snd_eq_iff_restrict_left {d : ℕ} {Λ Γ : Finset ℤ}
+    (hΛΓ : Disjoint Λ Γ) (x y : Config d (Λ ∪ Γ)) :
+    (splitEquiv Finset.subset_union_right x).2 =
+        (splitEquiv Finset.subset_union_right y).2 ↔
+      restrict Finset.subset_union_left x = restrict Finset.subset_union_left y := by
+  constructor
+  · intro h
+    funext i
+    exact congrFun h ⟨i, Finset.mem_sdiff.mpr
+      ⟨Finset.mem_union_left Γ i.2, hΛΓ.notMem_of_mem_left_finset i.2⟩⟩
+  · intro h
+    funext i
+    have hiΛ : (i : ℤ) ∈ Λ :=
+      (Finset.mem_union.mp (Finset.mem_sdiff.mp i.2).1).resolve_right
+        (Finset.mem_sdiff.mp i.2).2
+    exact congrFun h ⟨i, hiΛ⟩
+
+end Config
+
+section Local
+
+variable {d : ℕ} {Λ Γ : Finset ℤ}
+
+/-- Finite-region observables supported on disjoint regions commute after inclusion into the
+algebra on their union.
+
+This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
+lines 2292--2300. -/
+theorem localInclusion_mul_comm_of_disjoint (hΛΓ : Disjoint Λ Γ)
+    (A : LocalAlgebra d Λ) (B : LocalAlgebra d Γ) :
+    localInclusion (d := d) Finset.subset_union_left A *
+        localInclusion Finset.subset_union_right B =
+      localInclusion Finset.subset_union_right B *
+        localInclusion Finset.subset_union_left A := by
+  ext x y
+  change (∑ z, localInclusion Finset.subset_union_left A x z *
+      localInclusion Finset.subset_union_right B z y) =
+    ∑ z, localInclusion Finset.subset_union_right B x z *
+      localInclusion Finset.subset_union_left A z y
+  simp only [localInclusion_apply]
+  simp_rw [Config.splitEquiv_snd_eq_iff_restrict_right hΛΓ,
+    Config.splitEquiv_snd_eq_iff_restrict_left hΛΓ]
+  let e := Config.disjointUnionEquiv (d := d) hΛΓ
+  change (∑ z, (A (e x).1 (e z).1 * if (e x).2 = (e z).2 then 1 else 0) *
+      (B (e z).2 (e y).2 * if (e z).1 = (e y).1 then 1 else 0)) =
+    ∑ z, (B (e x).2 (e z).2 * if (e x).1 = (e z).1 then 1 else 0) *
+      (A (e z).1 (e y).1 * if (e z).2 = (e y).2 then 1 else 0)
+  have hleft :
+      (∑ z : Config d (Λ ∪ Γ),
+        (A (e x).1 (e z).1 * if (e x).2 = (e z).2 then 1 else 0) *
+          (B (e z).2 (e y).2 * if (e z).1 = (e y).1 then 1 else 0)) =
+        ∑ p : Config d Λ × Config d Γ,
+          (A (e x).1 p.1 * if (e x).2 = p.2 then 1 else 0) *
+            (B p.2 (e y).2 * if p.1 = (e y).1 then 1 else 0) := by
+    exact Fintype.sum_equiv e _ _ fun _ ↦ rfl
+  have hright :
+      (∑ z : Config d (Λ ∪ Γ),
+        (B (e x).2 (e z).2 * if (e x).1 = (e z).1 then 1 else 0) *
+          (A (e z).1 (e y).1 * if (e z).2 = (e y).2 then 1 else 0)) =
+        ∑ p : Config d Λ × Config d Γ,
+          (B (e x).2 p.2 * if (e x).1 = p.1 then 1 else 0) *
+            (A p.1 (e y).1 * if p.2 = (e y).2 then 1 else 0) := by
+    exact Fintype.sum_equiv e _ _ fun _ ↦ rfl
+  calc
+    _ = ∑ p : Config d Λ × Config d Γ,
+        (A (e x).1 p.1 * if (e x).2 = p.2 then 1 else 0) *
+          (B p.2 (e y).2 * if p.1 = (e y).1 then 1 else 0) := hleft
+    _ = A (e x).1 (e y).1 * B (e x).2 (e y).2 := by
+      rw [Fintype.sum_prod_type]
+      simp
+    _ = B (e x).2 (e y).2 * A (e x).1 (e y).1 := mul_comm _ _
+    _ = ∑ p : Config d Λ × Config d Γ,
+        (B (e x).2 p.2 * if (e x).1 = p.1 then 1 else 0) *
+          (A p.1 (e y).1 * if p.2 = (e y).2 then 1 else 0) := by
+      rw [Fintype.sum_prod_type]
+      simp
+    _ = _ := hright.symm
+
+/-- Canonical algebraic-local observables from disjoint regions commute.
+
+This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
+lines 2292--2300. -/
+theorem localObservable_mul_comm_of_disjoint (hΛΓ : Disjoint Λ Γ)
+    (A : LocalAlgebra d Λ) (B : LocalAlgebra d Γ) :
+    localObservable d Λ A * localObservable d Γ B =
+      localObservable d Γ B * localObservable d Λ A := by
+  rw [← localObservable_localInclusion d Finset.subset_union_left A,
+    ← localObservable_localInclusion d Finset.subset_union_right B,
+    ← map_mul, localInclusion_mul_comm_of_disjoint hΛΓ, map_mul]
+
+/-- Algebraic local observables with disjoint finite supports commute.
+
+This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
+lines 2292--2300. -/
+theorem SupportedIn.mul_comm_of_disjoint {X Y : AlgebraicLocalAlgebra d}
+    (hX : SupportedIn X Λ) (hY : SupportedIn Y Γ) (hΛΓ : Disjoint Λ Γ) :
+    X * Y = Y * X := by
+  obtain ⟨A, rfl⟩ := hX
+  obtain ⟨B, rfl⟩ := hY
+  exact localObservable_mul_comm_of_disjoint hΛΓ A B
+
+/-- Canonical quasi-local observables from disjoint regions commute.
+
+This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
+lines 2292--2300. -/
+theorem quasiLocalObservable_mul_comm_of_disjoint [NeZero d] (hΛΓ : Disjoint Λ Γ)
+    (A : LocalAlgebra d Λ) (B : LocalAlgebra d Γ) :
+    quasiLocalObservable d Λ A * quasiLocalObservable d Γ B =
+      quasiLocalObservable d Γ B * quasiLocalObservable d Λ A := by
+  change algebraicToQuasiLocal d (localObservable d Λ A) *
+      algebraicToQuasiLocal d (localObservable d Γ B) =
+    algebraicToQuasiLocal d (localObservable d Γ B) *
+      algebraicToQuasiLocal d (localObservable d Λ A)
+  rw [← map_mul, localObservable_mul_comm_of_disjoint hΛΓ, map_mul]
+
+/-- Quasi-local observables with disjoint finite supports commute.
+
+This is elementary tensor-factor infrastructure underlying arXiv:1703.09188, Appendix,
+lines 2292--2300. -/
+theorem QuasiLocalSupportedIn.mul_comm_of_disjoint [NeZero d]
+    {X Y : QuasiLocalAlgebra d} (hX : QuasiLocalSupportedIn X Λ)
+    (hY : QuasiLocalSupportedIn Y Γ) (hΛΓ : Disjoint Λ Γ) :
+    X * Y = Y * X := by
+  obtain ⟨A, rfl⟩ := hX
+  obtain ⟨B, rfl⟩ := hY
+  exact quasiLocalObservable_mul_comm_of_disjoint hΛΓ A B
+
+end Local
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7814,6 +7814,42 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
 \end{proof}
 
+\begin{lemma}[Disjoint finite-region observables commute]
+  \label{lem:qca_disjoint_local_inclusion_commute}
+  \lean{SpinChain.localInclusion_mul_comm_of_disjoint}
+  \leanok
+  \uses{def:qca_local_inclusion}
+  If $\Lambda\cap\Gamma=\varnothing$, $A\in\mathcal A_\Lambda$, and
+  $B\in\mathcal A_\Gamma$, then their images in the algebra of the union
+  satisfy
+  \begin{align}
+    \iota_{\Lambda,\Lambda\cup\Gamma}(A)
+      \iota_{\Gamma,\Lambda\cup\Gamma}(B)
+      &=\iota_{\Gamma,\Lambda\cup\Gamma}(B)
+        \iota_{\Lambda,\Lambda\cup\Gamma}(A).
+  \end{align}
+  This tensor-factor identity is local algebra infrastructure for the
+  quasi-local algebra used in \cite[lines~2292--2300]{Cirac2017MPU}; the
+  appendix does not state it as a separate theorem.
+  % Source context: paper_v2.tex 2292--2300.
+\end{lemma}
+
+\begin{proof}\leanok
+  For configurations $x,y$ on $\Lambda\cup\Gamma$, split each intermediate
+  configuration $z$ into $(z|_\Lambda,z|_\Gamma)$.  The matrix entry of the
+  left-hand side is
+  \begin{align}
+    \sum_{z_\Lambda,z_\Gamma}
+      A(x|_\Lambda,z_\Lambda)
+      \delta_{x|_\Gamma,z_\Gamma}
+      B(z_\Gamma,y|_\Gamma)
+      \delta_{z_\Lambda,y|_\Lambda}
+      &=A(x|_\Lambda,y|_\Lambda)
+        B(x|_\Gamma,y|_\Gamma).
+  \end{align}
+  Reversing the two factors gives the same scalar product.
+\end{proof}
+
 \begin{definition}[Translation of a finite region]
   \label{def:qca_translate_region}
   \lean{SpinChain.translateRegion,SpinChain.mem_translateRegion,
@@ -8215,6 +8251,46 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   its direct limit is therefore injective.  Finally, every element of an
   algebraic direct limit has a representative in one member of the directed
   system.
+\end{proof}
+
+\begin{theorem}[Disjointly supported local observables commute]
+  \label{thm:qca_disjoint_supported_local_commute}
+  \lean{SpinChain.localObservable_mul_comm_of_disjoint,
+    SpinChain.SupportedIn.mul_comm_of_disjoint}
+  \leanok
+  \uses{lem:qca_disjoint_local_inclusion_commute,def:qca_supported_in}
+  If $X,Y\in\mathcal A_{\mathrm{loc}}$ are supported in finite regions
+  $\Lambda$ and $\Gamma$ with $\Lambda\cap\Gamma=\varnothing$, then
+  \begin{align}
+    XY&=YX.
+  \end{align}
+  In particular, for $A\in\mathcal A_\Lambda$ and
+  $B\in\mathcal A_\Gamma$,
+  \begin{align}
+    \iota_\Lambda(A)\iota_\Gamma(B)
+      &=\iota_\Gamma(B)\iota_\Lambda(A).
+  \end{align}
+  This is the algebraic-local form of the tensor-factor identity underlying
+  the construction in \cite[lines~2292--2300]{Cirac2017MPU}, not a named
+  theorem of the appendix.
+  % Source context: paper_v2.tex 2292--2300.
+\end{theorem}
+
+\begin{proof}\leanok
+  Choose representatives $X=\iota_\Lambda(A)$ and
+  $Y=\iota_\Gamma(B)$.  Embed both into
+  $\mathcal A_{\Lambda\cup\Gamma}$.  The preceding finite-region identity
+  gives
+  \begin{align}
+    XY
+      &=\iota_{\Lambda\cup\Gamma}
+        \bigl(\iota_{\Lambda,\Lambda\cup\Gamma}(A)
+        \iota_{\Gamma,\Lambda\cup\Gamma}(B)\bigr) \\
+      &=\iota_{\Lambda\cup\Gamma}
+        \bigl(\iota_{\Gamma,\Lambda\cup\Gamma}(B)
+        \iota_{\Lambda,\Lambda\cup\Gamma}(A)\bigr)
+       =YX.
+  \end{align}
 \end{proof}
 
 \begin{definition}[Algebraic-local translation homomorphism]
@@ -8780,6 +8856,39 @@ as separate results in the appendix.
   Write $x=j_\Lambda(A)$.  Enlarge $A$ to $\mathcal A_\Gamma$ by tensoring
   with the identity on $\Gamma\setminus\Lambda$.  Compatibility of the
   canonical embeddings identifies the image of this enlargement with $x$.
+\end{proof}
+
+\begin{theorem}[Disjointly supported quasi-local observables commute]
+  \label{thm:qca_disjoint_quasi_local_commute}
+  \lean{SpinChain.quasiLocalObservable_mul_comm_of_disjoint,
+    SpinChain.QuasiLocalSupportedIn.mul_comm_of_disjoint}
+  \leanok
+  \uses{thm:qca_disjoint_supported_local_commute,
+    def:qca_quasi_local_supported_in}
+  Let $d>0$.  If $x,y\in\mathcal A$ are supported in finite regions
+  $\Lambda$ and $\Gamma$ with $\Lambda\cap\Gamma=\varnothing$, then
+  \begin{align}
+    xy&=yx.
+  \end{align}
+  Equivalently, for $A\in\mathcal A_\Lambda$ and
+  $B\in\mathcal A_\Gamma$,
+  \begin{align}
+    j_\Lambda(A)j_\Gamma(B)&=j_\Gamma(B)j_\Lambda(A).
+  \end{align}
+  This is finite-support infrastructure for the quasi-local algebra in
+  \cite[lines~2292--2300]{Cirac2017MPU}; it is not stated there as a separate
+  theorem.
+  % Source context: paper_v2.tex 2292--2300.
+\end{theorem}
+
+\begin{proof}\leanok
+  The completion map is a star-algebra homomorphism.  Applying it to the
+  algebraic-local identity gives
+  \begin{align}
+    j(XY)=j(YX),
+  \end{align}
+  and finite-region support provides representatives
+  $x=j_\Lambda(A)$ and $y=j_\Gamma(B)$.
 \end{proof}
 
 The appendix requires that ``there exists a finite subset

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7814,9 +7814,9 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   \end{align}
 \end{proof}
 
-\begin{lemma}[Disjoint finite-region observables commute]
-  \label{lem:qca_disjoint_local_inclusion_commute}
-  \lean{SpinChain.localInclusion_mul_comm_of_disjoint}
+\begin{theorem}[Disjoint finite-region observables commute]
+  \label{thm:qca_disjoint_local_inclusion_commute}
+  \lean{SpinChain.localInclusion_commute_of_disjoint}
   \leanok
   \uses{def:qca_local_inclusion}
   If $\Lambda\cap\Gamma=\varnothing$, $A\in\mathcal A_\Lambda$, and
@@ -7832,7 +7832,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   quasi-local algebra used in \cite[lines~2292--2300]{Cirac2017MPU}; the
   appendix does not state it as a separate theorem.
   % Source context: paper_v2.tex 2292--2300.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
   For configurations $x,y$ on $\Lambda\cup\Gamma$, split each intermediate
@@ -8255,10 +8255,10 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 
 \begin{theorem}[Disjointly supported local observables commute]
   \label{thm:qca_disjoint_supported_local_commute}
-  \lean{SpinChain.localObservable_mul_comm_of_disjoint,
-    SpinChain.SupportedIn.mul_comm_of_disjoint}
+  \lean{SpinChain.localObservable_commute_of_disjoint,
+    SpinChain.SupportedIn.commute_of_disjoint}
   \leanok
-  \uses{lem:qca_disjoint_local_inclusion_commute,def:qca_supported_in}
+  \uses{def:qca_supported_in}
   If $X,Y\in\mathcal A_{\mathrm{loc}}$ are supported in finite regions
   $\Lambda$ and $\Gamma$ with $\Lambda\cap\Gamma=\varnothing$, then
   \begin{align}
@@ -8277,6 +8277,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{thm:qca_disjoint_local_inclusion_commute}
   Choose representatives $X=\iota_\Lambda(A)$ and
   $Y=\iota_\Gamma(B)$.  Embed both into
   $\mathcal A_{\Lambda\cup\Gamma}$.  The preceding finite-region identity
@@ -8860,11 +8861,10 @@ as separate results in the appendix.
 
 \begin{theorem}[Disjointly supported quasi-local observables commute]
   \label{thm:qca_disjoint_quasi_local_commute}
-  \lean{SpinChain.quasiLocalObservable_mul_comm_of_disjoint,
-    SpinChain.QuasiLocalSupportedIn.mul_comm_of_disjoint}
+  \lean{SpinChain.quasiLocalObservable_commute_of_disjoint,
+    SpinChain.QuasiLocalSupportedIn.commute_of_disjoint}
   \leanok
-  \uses{thm:qca_disjoint_supported_local_commute,
-    def:qca_quasi_local_supported_in}
+  \uses{def:qca_quasi_local_supported_in}
   Let $d>0$.  If $x,y\in\mathcal A$ are supported in finite regions
   $\Lambda$ and $\Gamma$ with $\Lambda\cap\Gamma=\varnothing$, then
   \begin{align}
@@ -8882,6 +8882,7 @@ as separate results in the appendix.
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{thm:qca_disjoint_supported_local_commute}
   The completion map is a star-algebra homomorphism.  Applying it to the
   algebraic-local identity gives
   \begin{align}


### PR DESCRIPTION
## What changed
- prove that local inclusions from disjoint finite regions commute
- propagate the `Commute` API to algebraic-local and quasi-local supported observables
- add source-honest Chapter 28 statements and import the new QCA module

## Validation
- `lake build TNLean.QCA.DisjointSupport TNLean.QCA`
- blueprint sync and `leanblueprint checkdecls`
- two LuaLaTeX passes with zero undefined cross-references
- style, proof-integrity, aggregator, and `git diff --check` gates

Closes #6526
Advances #6515