### PR TITLE
feat(analysis): finite-range cyclic Knabe inequality

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -99,3 +99,4 @@ import TNLean.Algebra.TracePairing
 import TNLean.Algebra.TracePowerCharPoly
 import TNLean.Algebra.TraceReindex
 import TNLean.Algebra.UnitModulusPowerSum
+import TNLean.Algebra.ZModCyclicSums

--- a/TNLean/Algebra/ZModCyclicSums.lean
+++ b/TNLean/Algebra/ZModCyclicSums.lean
@@ -1,0 +1,362 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Order.Interval.Finset.Nat
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Module
+
+/-!
+# Cyclic sums over `ZMod`
+
+This file collects translation-invariance, triangular-counting, window-counting,
+and offset-partition identities for sums over a finite cyclic group.
+-/
+
+namespace ProjectionGeometry
+
+section CyclicSums
+
+variable {M : Type*} [AddCommMonoid M] {N : ℕ} [NeZero N]
+
+/-- Cyclic translation invariance: summing over the cyclic group `ZMod N`
+commutes with right translation of the index. -/
+theorem sum_comp_addRight (F : ZMod N → M) (d : ZMod N) :
+    ∑ i, F (i + d) = ∑ i, F i := by
+  simpa using Equiv.sum_comp (Equiv.addRight d) F
+
+/-- Cyclic translation invariance: summing over the cyclic group `ZMod N`
+commutes with left translation of the index. -/
+theorem sum_comp_addLeft (F : ZMod N → M) (d : ZMod N) :
+    ∑ i, F (d + i) = ∑ i, F i := by
+  simpa using Equiv.sum_comp (Equiv.addLeft d) F
+
+/-- Weighted triangular count, upper form.  Summing the offsets `e` with
+`1 ≤ e < m - q` over all `q < m` counts each `e` with `1 ≤ e < m` exactly
+`m - e` times. -/
+theorem sum_range_Ico_triangular (F : ℕ → M) (m : ℕ) :
+    (∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q), F e) =
+      ∑ e ∈ Finset.Ico 1 m, (m - e) • F e := by
+  classical
+  have hExtend : ∀ q ∈ Finset.range m,
+      (∑ e ∈ Finset.Ico 1 (m - q), F e) =
+        ∑ e ∈ Finset.Ico 1 m, (if e ∈ Finset.Ico 1 (m - q) then F e else 0) := by
+    intro q _
+    have hfil : (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (m - q)) =
+        Finset.Ico 1 (m - q) := by
+      refine Finset.ext fun x => ?_
+      simp only [Finset.mem_filter, Finset.mem_Ico]
+      omega
+    have h1 : (∑ e ∈ Finset.Ico 1 (m - q), F e) =
+        ∑ e ∈ (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (m - q)), F e := by
+      rw [hfil]
+    rw [h1, Finset.sum_filter]
+  rw [Finset.sum_congr rfl (fun q hq => hExtend q hq), Finset.sum_comm]
+  refine Finset.sum_congr rfl fun e he => ?_
+  have hem : 1 ≤ e ∧ e < m := Finset.mem_Ico.mp he
+  have hCard : ∑ q ∈ Finset.range m, (if q ∈ Finset.range (m - e) then F e else 0) =
+      (m - e) • F e := by
+    have hfil : (Finset.range m).filter (fun q => q ∈ Finset.range (m - e)) =
+        Finset.range (m - e) := by
+      refine Finset.ext fun x => ?_
+      simp only [Finset.mem_filter, Finset.mem_range]
+      omega
+    rw [← Finset.sum_filter (s := Finset.range m), hfil, Finset.sum_const]
+    congr 1
+    simp
+  rw [← hCard]
+  refine Finset.sum_congr rfl fun q hq => ?_
+  have hqm : q < m := Finset.mem_range.mp hq
+  by_cases h1 : e ∈ Finset.Ico 1 (m - q)
+  · by_cases h2 : q ∈ Finset.range (m - e)
+    · simp [h1, h2]
+    · exfalso
+      simp only [Finset.mem_Ico, Finset.mem_range] at h1 h2
+      omega
+  · by_cases h2 : q ∈ Finset.range (m - e)
+    · exfalso
+      simp only [Finset.mem_Ico, Finset.mem_range] at h1 h2
+      omega
+    · simp [h1, h2]
+
+/-- Weighted triangular count, lower form.  Summing the offsets `e` with
+`1 ≤ e ≤ q` over all `q < m` counts each `e` with `1 ≤ e < m` exactly
+`m - e` times. -/
+theorem sum_range_Ico_triangular_lower (F : ℕ → M) (m : ℕ) :
+    (∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1), F e) =
+      ∑ e ∈ Finset.Ico 1 m, (m - e) • F e := by
+  classical
+  have hExtend : ∀ q ∈ Finset.range m,
+      (∑ e ∈ Finset.Ico 1 (q + 1), F e) =
+        ∑ e ∈ Finset.Ico 1 m, (if e ∈ Finset.Ico 1 (q + 1) then F e else 0) := by
+    intro q hq
+    have hqm : q < m := Finset.mem_range.mp hq
+    have hfil : (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (q + 1)) =
+        Finset.Ico 1 (q + 1) := by
+      refine Finset.ext fun x => ?_
+      simp only [Finset.mem_filter, Finset.mem_Ico]
+      omega
+    have h1 : (∑ e ∈ Finset.Ico 1 (q + 1), F e) =
+        ∑ e ∈ (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (q + 1)), F e := by
+      rw [hfil]
+    rw [h1, Finset.sum_filter]
+  rw [Finset.sum_congr rfl (fun q hq => hExtend q hq), Finset.sum_comm]
+  refine Finset.sum_congr rfl fun e he => ?_
+  have hem : 1 ≤ e ∧ e < m := Finset.mem_Ico.mp he
+  have hCard : ∑ q ∈ Finset.range m, (if q ∈ Finset.Ico e m then F e else 0) =
+      (m - e) • F e := by
+    have hfil : (Finset.range m).filter (fun q => q ∈ Finset.Ico e m) =
+        Finset.Ico e m := by
+      refine Finset.ext fun x => ?_
+      simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]
+      omega
+    rw [← Finset.sum_filter (s := Finset.range m), hfil, Finset.sum_const]
+    congr 1
+    simp
+  rw [← hCard]
+  refine Finset.sum_congr rfl fun q hq => ?_
+  have hqm : q < m := Finset.mem_range.mp hq
+  by_cases h1 : e ∈ Finset.Ico 1 (q + 1)
+  · by_cases h2 : q ∈ Finset.Ico e m
+    · simp [h1, h2]
+    · exfalso
+      simp only [Finset.mem_Ico] at h1 h2
+      omega
+  · by_cases h2 : q ∈ Finset.Ico e m
+    · exfalso
+      simp only [Finset.mem_Ico] at h1 h2
+      omega
+    · simp [h1, h2]
+
+/-- Cyclic double counting for a square window of offsets.  For any function
+`T` on pairs of cyclic sites, summing `T (s + q) (s + q')` over all starting
+points `s` and all pairs of offsets `q, q' < m` produces the diagonal `T i i`
+with multiplicity `m`, and each ordered pair `(i, i + e)` and `(i, i - e)` with
+`1 ≤ e < m` with multiplicity `m - e`. -/
+theorem sum_cyclic_window_eq (T : ZMod N → ZMod N → M) (m : ℕ) :
+    (∑ s : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+        T (s + q) (s + q')) =
+      m • ∑ i : ZMod N, T i i +
+        ∑ e ∈ Finset.Ico 1 m, (m - e) •
+          ∑ i : ZMod N, (T i (i + e) + T i (i - e)) := by
+  classical
+  -- Translate the sum over starting points for each fixed pair of offsets.
+  have hStep1 : ∀ q ∈ Finset.range m, ∀ q' ∈ Finset.range m,
+      (∑ s : ZMod N, T (s + q) (s + q')) = ∑ i : ZMod N, T i (i + (q' - q)) := by
+    intro q _ q' _
+    have harg : ∀ s : ZMod N, (s + q) + (q' - q) = s + q' := by
+      intro s
+      abel
+    calc (∑ s : ZMod N, T (s + q) (s + q'))
+        = ∑ s : ZMod N, T (s + q) ((s + q) + (q' - q)) :=
+          Finset.sum_congr rfl fun s _ => by rw [harg s]
+      _ = ∑ i : ZMod N, T i (i + (q' - q)) :=
+          sum_comp_addRight (fun u => T u (u + (q' - q))) q
+  -- Flatten the sum over starting points to the inside.
+  have hFlat : (∑ s : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+      T (s + q) (s + q')) =
+      ∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+        T i (i + (q' - q)) := by
+    conv_rhs => rw [Finset.sum_comm]
+    conv_lhs => rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun q hq => ?_
+    conv_rhs => rw [Finset.sum_comm]
+    conv_lhs => rw [Finset.sum_comm]
+    exact Finset.sum_congr rfl fun q' hq' => hStep1 q hq q' hq'
+  -- Split each offset square into the diagonal and the two triangles.
+  have hSplit : ∀ i : ZMod N,
+      (∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m, T i (i + (q' - q))) =
+        (∑ q ∈ Finset.range m, T i i) +
+          ((∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q), T i (i + e)) +
+            ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e)) := by
+    intro i
+    have hPer : ∀ q ∈ Finset.range m,
+        (∑ q' ∈ Finset.range m, T i (i + (q' - q))) =
+          T i i + ((∑ e ∈ Finset.Ico 1 (m - q), T i (i + e)) +
+            ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e)) := by
+      intro q hq
+      have hqm : q < m := Finset.mem_range.mp hq
+      have hRange : Finset.range m =
+          Finset.Ico 0 q ∪ insert q (Finset.Ico (q + 1) m) := by
+        have h1 : Finset.range m = Finset.Ico 0 m := Finset.range_eq_Ico m
+        have h2 : Finset.Ico 0 m = Finset.Ico 0 q ∪ Finset.Ico q m :=
+          (Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)).symm
+        have h3 : Finset.Ico q m = insert q (Finset.Ico (q + 1) m) := by
+          rw [← Finset.insert_erase (Finset.mem_Ico.mpr ⟨le_refl q, by omega⟩),
+            ← Nat.Ico_succ_left_eq_erase_Ico]
+        rw [h1, h2, h3]
+      rw [hRange, Finset.sum_union (Finset.disjoint_iff_inter_eq_empty.mpr
+        (Finset.eq_empty_iff_forall_notMem.mpr fun x hx => by
+          simp only [Finset.mem_inter, Finset.mem_Ico, Finset.mem_insert] at hx
+          omega)), Finset.sum_insert (by
+        intro hxs
+        simp only [Finset.mem_Ico] at hxs
+        omega)]
+      -- The strict lower triangle reindexes by the positive offset difference.
+      have hFirst : (∑ q' ∈ Finset.Ico 0 q, T i (i + (q' - q))) =
+          ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e) := by
+        refine Finset.sum_nbij' (fun q' => q - q') (fun e => q - e) ?_ ?_ ?_ ?_ ?_
+        · intro q' hq'
+          simp only [Finset.mem_Ico] at hq' ⊢
+          omega
+        · intro e he
+          simp only [Finset.mem_Ico] at he ⊢
+          omega
+        · intro q' hq'
+          simp only [Finset.mem_Ico] at hq'
+          omega
+        · intro e he
+          simp only [Finset.mem_Ico] at he
+          omega
+        · intro q' hq'
+          have hq'q : q' ≤ q := by
+            simp only [Finset.mem_Ico] at hq'
+            omega
+          have hcast : ((q' : ZMod N) - q) = -((q - q' : ℕ) : ZMod N) := by
+            have hsub : (((q - q' : ℕ) : ZMod N)) + (q' : ZMod N) = (q : ZMod N) := by
+              rw [← Nat.cast_add, Nat.sub_add_cancel hq'q]
+            linear_combination (norm := module) hsub
+          change T i (i + (↑q' - ↑q)) = T i (i - ↑(q - q'))
+          congr 1
+          rw [hcast]
+          abel
+      -- The strict upper triangle reindexes by the positive offset difference.
+      have hThird : (∑ q' ∈ Finset.Ico (q + 1) m, T i (i + (q' - q))) =
+          ∑ e ∈ Finset.Ico 1 (m - q), T i (i + e) := by
+        refine Finset.sum_nbij' (fun q' => q' - q) (fun e => q + e) ?_ ?_ ?_ ?_ ?_
+        · intro q' hq'
+          simp only [Finset.mem_Ico] at hq' ⊢
+          omega
+        · intro e he
+          simp only [Finset.mem_Ico] at he ⊢
+          omega
+        · intro q' hq'
+          simp only [Finset.mem_Ico] at hq'
+          omega
+        · intro e he
+          simp only [Finset.mem_Ico] at he
+          omega
+        · intro q' hq'
+          have hq'q : q < q' := by
+            simp only [Finset.mem_Ico] at hq'
+            omega
+          change T i (i + (↑q' - ↑q)) = T i (i + ↑(q' - q))
+          rw [Nat.cast_sub hq'q.le]
+      rw [hFirst, hThird, sub_self, add_zero]
+      ac_rfl
+    rw [Finset.sum_congr rfl hPer, Finset.sum_add_distrib, Finset.sum_add_distrib]
+  -- Assemble: diagonal, then the two weighted triangles.
+  rw [hFlat, Finset.sum_congr rfl fun i _ => hSplit i, Finset.sum_add_distrib,
+    Finset.sum_add_distrib]
+  have hDiag : (∑ i : ZMod N, ∑ q ∈ Finset.range m, T i i) = m • ∑ i : ZMod N, T i i := by
+    rw [Finset.sum_comm]
+    simp
+  rw [hDiag]
+  have hUpper : (∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q),
+      T i (i + e)) = ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i + e) := by
+    rw [Finset.sum_congr rfl fun i _ => sum_range_Ico_triangular (fun e => T i (i + e)) m,
+      Finset.sum_comm]
+    exact Finset.sum_congr rfl fun e _ => (Finset.smul_sum).symm
+  have hLower : (∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1),
+      T i (i - e)) = ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i - e) := by
+    rw [Finset.sum_congr rfl fun i _ =>
+      sum_range_Ico_triangular_lower (fun e => T i (i - e)) m, Finset.sum_comm]
+    exact Finset.sum_congr rfl fun e _ => (Finset.smul_sum).symm
+  have hComb : (∑ e ∈ Finset.Ico 1 m, (m - e) •
+        ∑ i : ZMod N, (T i (i + e) + T i (i - e))) =
+      (∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i + e)) +
+        (∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i - e)) := by
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun e _ => by rw [Finset.sum_add_distrib, smul_add]
+  rw [hUpper, hLower, ← hComb]
+
+/-- Partition of the nonzero cyclic offsets into short offsets `1 ≤ e < m`,
+the reflection `N - e` of each short offset, and middle offsets
+`m ≤ k ≤ N - m`.  The partition requires `1 ≤ m ≤ N / 2`, so that the middle
+interval is well placed and short offsets and their reflections are distinct. -/
+theorem sum_offset_partition (F : ZMod N → M) {m : ℕ} (hm1 : 1 ≤ m) (hm : 2 * m ≤ N) :
+    (∑ u ∈ (Finset.univ.erase 0 : Finset (ZMod N)), F u) =
+      (∑ e ∈ Finset.Ico 1 m, (F e + F ((N - e : ℕ) : ZMod N))) +
+        ∑ k ∈ Finset.Ico m (N - m + 1), F k := by
+  classical
+  -- Index the nonzero cyclic offsets by the integer interval `1 ≤ k < N`.
+  have hBij : (∑ u ∈ Finset.univ.erase (0 : ZMod N), F u) =
+      ∑ k ∈ Finset.Ico 1 N, F k := by
+    refine Finset.sum_nbij' (fun u => u.val) (fun k => (k : ZMod N)) ?_ ?_ ?_ ?_ ?_
+    · intro u hu
+      have hu0 : u ≠ 0 := by simpa using hu
+      have hlt : u.val < N := ZMod.val_lt u
+      have hne : u.val ≠ 0 := fun h0 => hu0 (by
+        rw [← ZMod.natCast_zmod_val u, h0]
+        simp)
+      simp only [Finset.mem_Ico]
+      omega
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk
+      have hkne : (k : ZMod N) ≠ 0 := by
+        intro h0
+        have hkmod : k % N = 0 := by
+          rw [← ZMod.val_natCast N k, h0]
+          simp
+        rw [Nat.mod_eq_of_lt (by omega)] at hkmod
+        omega
+      exact Finset.mem_erase.2 ⟨hkne, Finset.mem_univ _⟩
+    · intro u _
+      exact ZMod.natCast_zmod_val u
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk
+      have hkN : ((k : ZMod N)).val = k % N := ZMod.val_natCast N k
+      rw [hkN, Nat.mod_eq_of_lt (by omega)]
+    · intro u _
+      rw [ZMod.natCast_zmod_val]
+  rw [hBij]
+  -- Split the interval `1 ≤ k < N` into short, middle, and long offsets.
+  have hUnion : (Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1)) ∪ Finset.Ico (N - m + 1) N =
+      Finset.Ico 1 N := by
+    have hU1 : Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1) = Finset.Ico 1 (N - m + 1) :=
+      Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)
+    have hU2 : Finset.Ico 1 (N - m + 1) ∪ Finset.Ico (N - m + 1) N = Finset.Ico 1 N :=
+      Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)
+    rw [hU1, hU2]
+  have hDisj1 : Disjoint (Finset.Ico 1 m) (Finset.Ico m (N - m + 1)) := by
+    rw [Finset.disjoint_iff_inter_eq_empty]
+    refine Finset.eq_empty_iff_forall_notMem.mpr fun x hx => ?_
+    simp only [Finset.mem_inter, Finset.mem_Ico] at hx
+    omega
+  have hDisj2 : Disjoint (Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1))
+      (Finset.Ico (N - m + 1) N) := by
+    rw [Finset.disjoint_iff_inter_eq_empty]
+    refine Finset.eq_empty_iff_forall_notMem.mpr fun x hx => ?_
+    simp only [Finset.mem_inter, Finset.mem_union, Finset.mem_Ico] at hx
+    omega
+  -- Reflect the long offsets `N - m + 1 ≤ k < N` back to short offsets.
+  have hLong : (∑ k ∈ Finset.Ico (N - m + 1) N, F k) =
+      ∑ e ∈ Finset.Ico 1 m, F ((N - e : ℕ) : ZMod N) := by
+    refine Finset.sum_nbij' (fun k => N - k) (fun e => N - e) ?_ ?_ ?_ ?_ ?_
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk ⊢
+      omega
+    · intro e he
+      simp only [Finset.mem_Ico] at he ⊢
+      omega
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk
+      omega
+    · intro e he
+      simp only [Finset.mem_Ico] at he
+      omega
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk
+      have hkN : N - (N - k) = k := by omega
+      simp only [hkN]
+  rw [← hUnion, Finset.sum_union hDisj2, Finset.sum_union hDisj1, hLong,
+    Finset.sum_add_distrib]
+  ac_rfl
+
+end CyclicSums
+
+end ProjectionGeometry

--- a/TNLean/Algebra/ZModCyclicSums.lean
+++ b/TNLean/Algebra/ZModCyclicSums.lean
@@ -17,7 +17,7 @@ This file collects translation-invariance, triangular-counting, window-counting,
 and offset-partition identities for sums over a finite cyclic group.
 -/
 
-namespace ProjectionGeometry
+namespace ZModCyclicSums
 
 section CyclicSums
 
@@ -359,4 +359,4 @@ theorem sum_offset_partition (F : ZMod N → M) {m : ℕ} (hm1 : 1 ≤ m) (hm : 
 
 end CyclicSums
 
-end ProjectionGeometry
+end ZModCyclicSums

--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -23,6 +23,7 @@ import TNLean.Analysis.EntropyDecomposition
 import TNLean.Analysis.EntropyMarkovForward
 import TNLean.Analysis.EntropyMarkovReverse
 import TNLean.Analysis.EntropyReindex
+import TNLean.Analysis.FiniteRangeKnabe
 import TNLean.Analysis.HayashiMarkovStructure
 import TNLean.Analysis.IdempotentEndomorphism
 import TNLean.Analysis.InjectiveRangeProjector

--- a/TNLean/Analysis/FiniteRangeKnabe.lean
+++ b/TNLean/Analysis/FiniteRangeKnabe.lean
@@ -26,8 +26,10 @@ then
 \(\delta=(m\gamma-(R-1)^2)/(m-R+1)\), whenever
 \((R-1)^2<m\gamma\).
 
-For \(R=2\), this recovers Knabe's nearest-neighbor coefficient
-\((m\gamma-1)/(m-1)\).
+For \(R=2\), the coefficient becomes the nearest-neighbor value
+\((m\gamma-1)/(m-1)\); the threshold \(\gamma>1/m\) that it demands is
+Knabe's, while the closed form itself is obtained by the present
+derivation, as recorded under Sources.
 
 ## Sources
 
@@ -44,7 +46,8 @@ the cited sources, and is not attributed to any of them.
 ## Main results
 
 * `ProjectionGeometry.cyclicWindowSum_sq_sum_eq`: the cyclic double-counting
-  identity `∑ s A s ^ 2 = m • H + ∑ e (m - e) • Q e`.
+  identity \(\sum_s A_s^2=mH+\sum_{e}(m-e)Q_e\), where
+  \(Q_e=\sum_i(h_ih_{i+e}+h_ih_{i-e})\).
 * `ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe`: the
   finite-range Knabe inequality.
 * `ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe_nearest_neighbor`:

--- a/TNLean/Analysis/FiniteRangeKnabe.lean
+++ b/TNLean/Analysis/FiniteRangeKnabe.lean
@@ -3,9 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Algebra.BigOperators.Intervals
-import Mathlib.Data.ZMod.Basic
-import Mathlib.Order.Interval.Finset.Nat
+import TNLean.Algebra.ZModCyclicSums
 import TNLean.Analysis.ProjectionGeometry
 
 /-!
@@ -75,353 +73,16 @@ theorem re_inner_anticommutator_le {P Q : E →ₗ[𝕜] E} (hP : P.IsSymmetricP
   have h0 : (0 : ℝ) ≤ RCLike.re ⟪P v - Q v, P v - Q v⟫_𝕜 :=
     inner_self_nonneg (x := P v - Q v)
   rw [inner_sub_sub_self] at h0
-  simp only [map_add, map_sub] at h0
-  rw [hP.re_inner_apply_apply_self, hQ.re_inner_apply_apply_self] at h0
+  have h0' : (0 : ℝ) ≤ RCLike.re ⟪P v, P v⟫_𝕜 - RCLike.re ⟪P v, Q v⟫_𝕜 -
+      RCLike.re ⟪Q v, P v⟫_𝕜 + RCLike.re ⟪Q v, Q v⟫_𝕜 := by
+    simpa only [map_add, map_sub] using h0
+  rw [hP.re_inner_apply_apply_self, hQ.re_inner_apply_apply_self] at h0'
   linarith
 
 end LinearMap.IsSymmetricProjection
 
 namespace ProjectionGeometry
 
-section CyclicSums
-
-variable {M : Type*} [AddCommMonoid M] {N : ℕ} [NeZero N]
-
-/-- Cyclic translation invariance: summing over the cyclic group `ZMod N`
-commutes with right translation of the index. -/
-theorem sum_comp_addRight (F : ZMod N → M) (d : ZMod N) :
-    ∑ i, F (i + d) = ∑ i, F i := by
-  simpa using Equiv.sum_comp (Equiv.addRight d) F
-
-/-- Cyclic translation invariance: summing over the cyclic group `ZMod N`
-commutes with left translation of the index. -/
-theorem sum_comp_addLeft (F : ZMod N → M) (d : ZMod N) :
-    ∑ i, F (d + i) = ∑ i, F i := by
-  simpa using Equiv.sum_comp (Equiv.addLeft d) F
-
-/-- Weighted triangular count, upper form.  Summing the offsets `e` with
-`1 ≤ e < m - q` over all `q < m` counts each `e` with `1 ≤ e < m` exactly
-`m - e` times. -/
-theorem sum_range_Ico_triangular (F : ℕ → M) (m : ℕ) :
-    (∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q), F e) =
-      ∑ e ∈ Finset.Ico 1 m, (m - e) • F e := by
-  classical
-  have hExtend : ∀ q ∈ Finset.range m,
-      (∑ e ∈ Finset.Ico 1 (m - q), F e) =
-        ∑ e ∈ Finset.Ico 1 m, (if e ∈ Finset.Ico 1 (m - q) then F e else 0) := by
-    intro q _
-    have hfil : (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (m - q)) =
-        Finset.Ico 1 (m - q) := by
-      refine Finset.ext fun x => ?_
-      simp only [Finset.mem_filter, Finset.mem_Ico]
-      omega
-    have h1 : (∑ e ∈ Finset.Ico 1 (m - q), F e) =
-        ∑ e ∈ (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (m - q)), F e := by
-      rw [hfil]
-    rw [h1, Finset.sum_filter]
-  rw [Finset.sum_congr rfl (fun q hq => hExtend q hq), Finset.sum_comm]
-  refine Finset.sum_congr rfl fun e he => ?_
-  have hem : 1 ≤ e ∧ e < m := Finset.mem_Ico.mp he
-  have hCard : ∑ q ∈ Finset.range m, (if q ∈ Finset.range (m - e) then F e else 0) =
-      (m - e) • F e := by
-    have hfil : (Finset.range m).filter (fun q => q ∈ Finset.range (m - e)) =
-        Finset.range (m - e) := by
-      refine Finset.ext fun x => ?_
-      simp only [Finset.mem_filter, Finset.mem_range]
-      omega
-    rw [← Finset.sum_filter (s := Finset.range m), hfil, Finset.sum_const]
-    congr 1
-    simp
-  rw [← hCard]
-  refine Finset.sum_congr rfl fun q hq => ?_
-  have hqm : q < m := Finset.mem_range.mp hq
-  by_cases h1 : e ∈ Finset.Ico 1 (m - q)
-  · by_cases h2 : q ∈ Finset.range (m - e)
-    · simp [h1, h2]
-    · exfalso
-      simp only [Finset.mem_Ico, Finset.mem_range] at h1 h2
-      omega
-  · by_cases h2 : q ∈ Finset.range (m - e)
-    · exfalso
-      simp only [Finset.mem_Ico, Finset.mem_range] at h1 h2
-      omega
-    · simp [h1, h2]
-
-/-- Weighted triangular count, lower form.  Summing the offsets `e` with
-`1 ≤ e ≤ q` over all `q < m` counts each `e` with `1 ≤ e < m` exactly
-`m - e` times. -/
-theorem sum_range_Ico_triangular_lower (F : ℕ → M) (m : ℕ) :
-    (∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1), F e) =
-      ∑ e ∈ Finset.Ico 1 m, (m - e) • F e := by
-  classical
-  have hExtend : ∀ q ∈ Finset.range m,
-      (∑ e ∈ Finset.Ico 1 (q + 1), F e) =
-        ∑ e ∈ Finset.Ico 1 m, (if e ∈ Finset.Ico 1 (q + 1) then F e else 0) := by
-    intro q hq
-    have hqm : q < m := Finset.mem_range.mp hq
-    have hfil : (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (q + 1)) =
-        Finset.Ico 1 (q + 1) := by
-      refine Finset.ext fun x => ?_
-      simp only [Finset.mem_filter, Finset.mem_Ico]
-      omega
-    have h1 : (∑ e ∈ Finset.Ico 1 (q + 1), F e) =
-        ∑ e ∈ (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (q + 1)), F e := by
-      rw [hfil]
-    rw [h1, Finset.sum_filter]
-  rw [Finset.sum_congr rfl (fun q hq => hExtend q hq), Finset.sum_comm]
-  refine Finset.sum_congr rfl fun e he => ?_
-  have hem : 1 ≤ e ∧ e < m := Finset.mem_Ico.mp he
-  have hCard : ∑ q ∈ Finset.range m, (if q ∈ Finset.Ico e m then F e else 0) =
-      (m - e) • F e := by
-    have hfil : (Finset.range m).filter (fun q => q ∈ Finset.Ico e m) =
-        Finset.Ico e m := by
-      refine Finset.ext fun x => ?_
-      simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]
-      omega
-    rw [← Finset.sum_filter (s := Finset.range m), hfil, Finset.sum_const]
-    congr 1
-    simp
-  rw [← hCard]
-  refine Finset.sum_congr rfl fun q hq => ?_
-  have hqm : q < m := Finset.mem_range.mp hq
-  by_cases h1 : e ∈ Finset.Ico 1 (q + 1)
-  · by_cases h2 : q ∈ Finset.Ico e m
-    · simp [h1, h2]
-    · exfalso
-      simp only [Finset.mem_Ico] at h1 h2
-      omega
-  · by_cases h2 : q ∈ Finset.Ico e m
-    · exfalso
-      simp only [Finset.mem_Ico] at h1 h2
-      omega
-    · simp [h1, h2]
-
-/-- Cyclic double counting for a square window of offsets.  For any function
-`T` on pairs of cyclic sites, summing `T (s + q) (s + q')` over all starting
-points `s` and all pairs of offsets `q, q' < m` produces the diagonal `T i i`
-with multiplicity `m`, and each ordered pair `(i, i + e)` and `(i, i - e)` with
-`1 ≤ e < m` with multiplicity `m - e`. -/
-theorem sum_cyclic_window_eq (T : ZMod N → ZMod N → M) (m : ℕ) :
-    (∑ s : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
-        T (s + q) (s + q')) =
-      m • ∑ i : ZMod N, T i i +
-        ∑ e ∈ Finset.Ico 1 m, (m - e) •
-          ∑ i : ZMod N, (T i (i + e) + T i (i - e)) := by
-  classical
-  -- Translate the sum over starting points for each fixed pair of offsets.
-  have hStep1 : ∀ q ∈ Finset.range m, ∀ q' ∈ Finset.range m,
-      (∑ s : ZMod N, T (s + q) (s + q')) = ∑ i : ZMod N, T i (i + (q' - q)) := by
-    intro q _ q' _
-    have harg : ∀ s : ZMod N, (s + q) + (q' - q) = s + q' := by
-      intro s
-      abel
-    calc (∑ s : ZMod N, T (s + q) (s + q'))
-        = ∑ s : ZMod N, T (s + q) ((s + q) + (q' - q)) :=
-          Finset.sum_congr rfl fun s _ => by rw [harg s]
-      _ = ∑ i : ZMod N, T i (i + (q' - q)) :=
-          sum_comp_addRight (fun u => T u (u + (q' - q))) q
-  -- Flatten the sum over starting points to the inside.
-  have hFlat : (∑ s : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
-      T (s + q) (s + q')) =
-      ∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
-        T i (i + (q' - q)) := by
-    conv_rhs => rw [Finset.sum_comm]
-    conv_lhs => rw [Finset.sum_comm]
-    refine Finset.sum_congr rfl fun q hq => ?_
-    conv_rhs => rw [Finset.sum_comm]
-    conv_lhs => rw [Finset.sum_comm]
-    exact Finset.sum_congr rfl fun q' hq' => hStep1 q hq q' hq'
-  -- Split each offset square into the diagonal and the two triangles.
-  have hSplit : ∀ i : ZMod N,
-      (∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m, T i (i + (q' - q))) =
-        (∑ q ∈ Finset.range m, T i i) +
-          ((∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q), T i (i + e)) +
-            ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e)) := by
-    intro i
-    have hPer : ∀ q ∈ Finset.range m,
-        (∑ q' ∈ Finset.range m, T i (i + (q' - q))) =
-          T i i + ((∑ e ∈ Finset.Ico 1 (m - q), T i (i + e)) +
-            ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e)) := by
-      intro q hq
-      have hqm : q < m := Finset.mem_range.mp hq
-      have hRange : Finset.range m =
-          Finset.Ico 0 q ∪ insert q (Finset.Ico (q + 1) m) := by
-        have h1 : Finset.range m = Finset.Ico 0 m := Finset.range_eq_Ico m
-        have h2 : Finset.Ico 0 m = Finset.Ico 0 q ∪ Finset.Ico q m :=
-          (Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)).symm
-        have h3 : Finset.Ico q m = insert q (Finset.Ico (q + 1) m) := by
-          rw [← Finset.insert_erase (Finset.mem_Ico.mpr ⟨le_refl q, by omega⟩),
-            ← Nat.Ico_succ_left_eq_erase_Ico]
-        rw [h1, h2, h3]
-      rw [hRange, Finset.sum_union (Finset.disjoint_iff_inter_eq_empty.mpr
-        (Finset.eq_empty_iff_forall_notMem.mpr fun x hx => by
-          simp only [Finset.mem_inter, Finset.mem_Ico, Finset.mem_insert] at hx
-          omega)), Finset.sum_insert (by
-        intro hxs
-        simp only [Finset.mem_Ico] at hxs
-        omega)]
-      -- The strict lower triangle reindexes by the positive offset difference.
-      have hFirst : (∑ q' ∈ Finset.Ico 0 q, T i (i + (q' - q))) =
-          ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e) := by
-        refine Finset.sum_nbij' (fun q' => q - q') (fun e => q - e) ?_ ?_ ?_ ?_ ?_
-        · intro q' hq'
-          simp only [Finset.mem_Ico] at hq' ⊢
-          omega
-        · intro e he
-          simp only [Finset.mem_Ico] at he ⊢
-          omega
-        · intro q' hq'
-          simp only [Finset.mem_Ico] at hq'
-          omega
-        · intro e he
-          simp only [Finset.mem_Ico] at he
-          omega
-        · intro q' hq'
-          have hq'q : q' ≤ q := by
-            simp only [Finset.mem_Ico] at hq'
-            omega
-          have hcast : ((q' : ZMod N) - q) = -((q - q' : ℕ) : ZMod N) := by
-            have hsub : (((q - q' : ℕ) : ZMod N)) + (q' : ZMod N) = (q : ZMod N) := by
-              rw [← Nat.cast_add, Nat.sub_add_cancel hq'q]
-            linear_combination (norm := module) hsub
-          change T i (i + (↑q' - ↑q)) = T i (i - ↑(q - q'))
-          congr 1
-          rw [hcast]
-          abel
-      -- The strict upper triangle reindexes by the positive offset difference.
-      have hThird : (∑ q' ∈ Finset.Ico (q + 1) m, T i (i + (q' - q))) =
-          ∑ e ∈ Finset.Ico 1 (m - q), T i (i + e) := by
-        refine Finset.sum_nbij' (fun q' => q' - q) (fun e => q + e) ?_ ?_ ?_ ?_ ?_
-        · intro q' hq'
-          simp only [Finset.mem_Ico] at hq' ⊢
-          omega
-        · intro e he
-          simp only [Finset.mem_Ico] at he ⊢
-          omega
-        · intro q' hq'
-          simp only [Finset.mem_Ico] at hq'
-          omega
-        · intro e he
-          simp only [Finset.mem_Ico] at he
-          omega
-        · intro q' hq'
-          have hq'q : q < q' := by
-            simp only [Finset.mem_Ico] at hq'
-            omega
-          change T i (i + (↑q' - ↑q)) = T i (i + ↑(q' - q))
-          rw [Nat.cast_sub hq'q.le]
-      rw [hFirst, hThird, sub_self, add_zero]
-      ac_rfl
-    rw [Finset.sum_congr rfl hPer, Finset.sum_add_distrib, Finset.sum_add_distrib]
-  -- Assemble: diagonal, then the two weighted triangles.
-  rw [hFlat, Finset.sum_congr rfl fun i _ => hSplit i, Finset.sum_add_distrib,
-    Finset.sum_add_distrib]
-  have hDiag : (∑ i : ZMod N, ∑ q ∈ Finset.range m, T i i) = m • ∑ i : ZMod N, T i i := by
-    rw [Finset.sum_comm]
-    simp
-  rw [hDiag]
-  have hUpper : (∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q),
-      T i (i + e)) = ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i + e) := by
-    rw [Finset.sum_congr rfl fun i _ => sum_range_Ico_triangular (fun e => T i (i + e)) m,
-      Finset.sum_comm]
-    exact Finset.sum_congr rfl fun e _ => (Finset.smul_sum).symm
-  have hLower : (∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1),
-      T i (i - e)) = ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i - e) := by
-    rw [Finset.sum_congr rfl fun i _ =>
-      sum_range_Ico_triangular_lower (fun e => T i (i - e)) m, Finset.sum_comm]
-    exact Finset.sum_congr rfl fun e _ => (Finset.smul_sum).symm
-  have hComb : (∑ e ∈ Finset.Ico 1 m, (m - e) •
-        ∑ i : ZMod N, (T i (i + e) + T i (i - e))) =
-      (∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i + e)) +
-        (∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i - e)) := by
-    rw [← Finset.sum_add_distrib]
-    exact Finset.sum_congr rfl fun e _ => by rw [Finset.sum_add_distrib, smul_add]
-  rw [hUpper, hLower, ← hComb]
-
-/-- Partition of the nonzero cyclic offsets into short offsets `1 ≤ e < m`,
-the reflection `N - e` of each short offset, and middle offsets
-`m ≤ k ≤ N - m`.  The partition requires `1 ≤ m ≤ N / 2`, so that the middle
-interval is well placed and short offsets and their reflections are distinct. -/
-theorem sum_offset_partition (F : ZMod N → M) {m : ℕ} (hm1 : 1 ≤ m) (hm : 2 * m ≤ N) :
-    (∑ u ∈ (Finset.univ.erase 0 : Finset (ZMod N)), F u) =
-      (∑ e ∈ Finset.Ico 1 m, (F e + F ((N - e : ℕ) : ZMod N))) +
-        ∑ k ∈ Finset.Ico m (N - m + 1), F k := by
-  classical
-  -- Index the nonzero cyclic offsets by the integer interval `1 ≤ k < N`.
-  have hBij : (∑ u ∈ Finset.univ.erase (0 : ZMod N), F u) =
-      ∑ k ∈ Finset.Ico 1 N, F k := by
-    refine Finset.sum_nbij' (fun u => u.val) (fun k => (k : ZMod N)) ?_ ?_ ?_ ?_ ?_
-    · intro u hu
-      have hu0 : u ≠ 0 := by simpa using hu
-      have hlt : u.val < N := ZMod.val_lt u
-      have hne : u.val ≠ 0 := fun h0 => hu0 (by
-        rw [← ZMod.natCast_zmod_val u, h0]
-        simp)
-      simp only [Finset.mem_Ico]
-      omega
-    · intro k hk
-      simp only [Finset.mem_Ico] at hk
-      have hkne : (k : ZMod N) ≠ 0 := by
-        intro h0
-        have hkmod : k % N = 0 := by
-          rw [← ZMod.val_natCast N k, h0]
-          simp
-        rw [Nat.mod_eq_of_lt (by omega)] at hkmod
-        omega
-      exact Finset.mem_erase.2 ⟨hkne, Finset.mem_univ _⟩
-    · intro u _
-      exact ZMod.natCast_zmod_val u
-    · intro k hk
-      simp only [Finset.mem_Ico] at hk
-      have hkN : ((k : ZMod N)).val = k % N := ZMod.val_natCast N k
-      rw [hkN, Nat.mod_eq_of_lt (by omega)]
-    · intro u _
-      rw [ZMod.natCast_zmod_val]
-  rw [hBij]
-  -- Split the interval `1 ≤ k < N` into short, middle, and long offsets.
-  have hUnion : (Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1)) ∪ Finset.Ico (N - m + 1) N =
-      Finset.Ico 1 N := by
-    have hU1 : Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1) = Finset.Ico 1 (N - m + 1) :=
-      Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)
-    have hU2 : Finset.Ico 1 (N - m + 1) ∪ Finset.Ico (N - m + 1) N = Finset.Ico 1 N :=
-      Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)
-    rw [hU1, hU2]
-  have hDisj1 : Disjoint (Finset.Ico 1 m) (Finset.Ico m (N - m + 1)) := by
-    rw [Finset.disjoint_iff_inter_eq_empty]
-    refine Finset.eq_empty_iff_forall_notMem.mpr fun x hx => ?_
-    simp only [Finset.mem_inter, Finset.mem_Ico] at hx
-    omega
-  have hDisj2 : Disjoint (Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1))
-      (Finset.Ico (N - m + 1) N) := by
-    rw [Finset.disjoint_iff_inter_eq_empty]
-    refine Finset.eq_empty_iff_forall_notMem.mpr fun x hx => ?_
-    simp only [Finset.mem_inter, Finset.mem_union, Finset.mem_Ico] at hx
-    omega
-  -- Reflect the long offsets `N - m + 1 ≤ k < N` back to short offsets.
-  have hLong : (∑ k ∈ Finset.Ico (N - m + 1) N, F k) =
-      ∑ e ∈ Finset.Ico 1 m, F ((N - e : ℕ) : ZMod N) := by
-    refine Finset.sum_nbij' (fun k => N - k) (fun e => N - e) ?_ ?_ ?_ ?_ ?_
-    · intro k hk
-      simp only [Finset.mem_Ico] at hk ⊢
-      omega
-    · intro e he
-      simp only [Finset.mem_Ico] at he ⊢
-      omega
-    · intro k hk
-      simp only [Finset.mem_Ico] at hk
-      omega
-    · intro e he
-      simp only [Finset.mem_Ico] at he
-      omega
-    · intro k hk
-      simp only [Finset.mem_Ico] at hk
-      have hkN : N - (N - k) = k := by omega
-      simp only [hkN]
-  rw [← hUnion, Finset.sum_union hDisj2, Finset.sum_union hDisj1, hLong,
-    Finset.sum_add_distrib]
-  ac_rfl
-
-end CyclicSums
 
 
 
@@ -476,7 +137,7 @@ theorem cyclicWindowSum_sq_sum_eq (h : ZMod N → E →ₗ[𝕜] E)
 /-- The ordered real cross terms of a cyclic family at offset `e`: the sum over
 all sites of the two ordered quadratic forms of the pairs at cyclic offsets
 `e` and `-e`. -/
-def re_inner_cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] E) (e : ℕ) (v : E) : ℝ :=
+def reInnerCyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] E) (e : ℕ) (v : E) : ℝ :=
   ∑ i : ZMod N, (RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 + RCLike.re ⟪h i v, h (i - e) v⟫_𝕜)
 
 /-- The cyclic double-counting identity for a family of symmetric projections:
@@ -487,7 +148,7 @@ theorem re_inner_cyclicWindowSum_sum_eq (h : ZMod N → E →ₗ[𝕜] E)
     (hh : ∀ i, (h i).IsSymmetricProjection) (m : ℕ) (v : E) :
     (∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜) =
       m * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
-        ∑ e ∈ Finset.Ico 1 m, (m - e) * re_inner_cyclicCrossTerms h e v := by
+        ∑ e ∈ Finset.Ico 1 m, (m - e) * reInnerCyclicCrossTerms h e v := by
   classical
   have hExpand : ∀ s : ZMod N,
       RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜 =
@@ -504,7 +165,6 @@ theorem re_inner_cyclicWindowSum_sum_eq (h : ZMod N → E →ₗ[𝕜] E)
   set T : ZMod N → ZMod N → ℝ := fun i j => RCLike.re ⟪h i v, h j v⟫_𝕜 with hT
   have hDiag : (∑ i : ZMod N, T i i) = RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
     rw [hT]
-    simp only []
     rw [re_inner_sum_apply_left h v]
     exact Finset.sum_congr rfl fun i _ => (hh i).re_inner_apply_apply_self v
   calc (∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜)
@@ -515,11 +175,11 @@ theorem re_inner_cyclicWindowSum_sum_eq (h : ZMod N → E →ₗ[𝕜] E)
         ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, (T i (i + e) + T i (i - e)) :=
         sum_cyclic_window_eq T m
     _ = m * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
-        ∑ e ∈ Finset.Ico 1 m, (m - e) * re_inner_cyclicCrossTerms h e v := by
+        ∑ e ∈ Finset.Ico 1 m, (m - e) * reInnerCyclicCrossTerms h e v := by
         rw [hDiag, nsmul_eq_mul]
         have hsmulB : ∀ e ∈ Finset.Ico 1 m,
             ((m - e : ℕ) • (∑ i : ZMod N, (T i (i + e) + T i (i - e)))) =
-              ((m : ℝ) - (e : ℝ)) * re_inner_cyclicCrossTerms h e v := by
+              ((m : ℝ) - (e : ℝ)) * reInnerCyclicCrossTerms h e v := by
           intro e he
           simp only [Finset.mem_Ico] at he
           rw [nsmul_eq_mul, Nat.cast_sub (by omega)]
@@ -557,7 +217,7 @@ theorem re_inner_cyclicWindowSum_sum_apply (h : ZMod N → E →ₗ[𝕜] E) (m 
 any offset are bounded by twice the total quadratic form. -/
 theorem re_inner_cyclicCrossTerms_le_two (h : ZMod N → E →ₗ[𝕜] E)
     (hh : ∀ i, (h i).IsSymmetricProjection) (e : ℕ) (v : E) :
-    re_inner_cyclicCrossTerms h e v ≤ 2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+    reInnerCyclicCrossTerms h e v ≤ 2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
   classical
   have hPair : ∀ i : ZMod N,
       RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 + RCLike.re ⟪h (i + e) v, h i v⟫_𝕜 ≤
@@ -573,12 +233,12 @@ theorem re_inner_cyclicCrossTerms_le_two (h : ZMod N → E →ₗ[𝕜] E)
   have hDiag : (∑ i : ZMod N, RCLike.re ⟪h (i + e) v, v⟫_𝕜) =
       ∑ i : ZMod N, RCLike.re ⟪h i v, v⟫_𝕜 :=
     sum_comp_addRight (fun u : ZMod N => RCLike.re ⟪h u v, v⟫_𝕜) _
-  have hSplit : re_inner_cyclicCrossTerms h e v =
+  have hSplit : reInnerCyclicCrossTerms h e v =
       (∑ i : ZMod N, (RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 +
         RCLike.re ⟪h (i + e) v, h i v⟫_𝕜)) := by
-    unfold re_inner_cyclicCrossTerms
+    unfold reInnerCyclicCrossTerms
     rw [Finset.sum_add_distrib, Finset.sum_add_distrib, hTrans]
-  calc re_inner_cyclicCrossTerms h e v
+  calc reInnerCyclicCrossTerms h e v
       = (∑ i : ZMod N, (RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 +
         RCLike.re ⟪h (i + e) v, h i v⟫_𝕜)) := hSplit
     _ ≤ (∑ i : ZMod N, (RCLike.re ⟪h i v, v⟫_𝕜 +
@@ -599,7 +259,7 @@ theorem re_inner_cyclicCrossTerms_nonneg (h : ZMod N → E →ₗ[𝕜] E)
     (hcomm : ∀ d : ℕ, R ≤ d → d + R ≤ N → ∀ i : ZMod N, ∀ v : E,
       h i (h ((i + (d : ZMod N))) v) = h ((i + (d : ZMod N))) (h i v))
     {e : ℕ} (he1 : R ≤ e) (he2 : e + R ≤ N) (v : E) :
-    0 ≤ re_inner_cyclicCrossTerms h e v := by
+    0 ≤ reInnerCyclicCrossTerms h e v := by
   have h1 : ∀ i : ZMod N, 0 ≤ RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 :=
     fun i => LinearMap.IsSymmetricProjection.re_inner_apply_apply_nonneg_of_commute
       (hh i) (hh (i + e)) (hcomm e he1 he2 i) v
@@ -628,7 +288,7 @@ theorem re_inner_sum_two_ge_sum_cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] 
     (hcomm : ∀ d : ℕ, R ≤ d → d + R ≤ N → ∀ i : ZMod N, ∀ v : E,
       h i (h ((i + (d : ZMod N))) v) = h ((i + (d : ZMod N))) (h i v))
     (v : E) :
-    RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 + ∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v ≤
+    RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 + ∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v ≤
       RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 := by
   classical
   set T : ZMod N → ZMod N → ℝ := fun i j => RCLike.re ⟪h i v, h j v⟫_𝕜 with hT
@@ -663,7 +323,7 @@ theorem re_inner_sum_two_ge_sum_cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] 
   -- The reflected short offsets reproduce the second leg of the cross terms.
   have hCross : ∀ e ∈ Finset.Ico 1 m,
       F ((e : ZMod N)) + F ((N - e : ℕ) : ZMod N) =
-        re_inner_cyclicCrossTerms h e v := by
+        reInnerCyclicCrossTerms h e v := by
     intro e he
     simp only [Finset.mem_Ico] at he
     have hshift : (∑ i : ZMod N, T i (i + ((N - e : ℕ) : ZMod N))) =
@@ -679,18 +339,18 @@ theorem re_inner_sum_two_ge_sum_cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] 
         (∑ i : ZMod N, T i (i + ((N - e : ℕ) : ZMod N))) = _
     rw [hshift, ← Finset.sum_add_distrib]
     rfl
-  calc RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 + ∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v
-      = (∑ i : ZMod N, T i i) + (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) := by
+  calc RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 + ∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v
+      = (∑ i : ZMod N, T i i) + (∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v) := by
         rw [re_inner_sum_apply_left h v]
         congr 1
         exact Finset.sum_congr rfl fun i _ => ((hh i).re_inner_apply_apply_self v).symm
     _ ≤ (∑ i : ZMod N, T i i) +
-        (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v +
+        (∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v +
           ∑ k ∈ Finset.Ico m (N - m + 1), F k) := by
         have hle := hMidNonneg
         linarith
     _ = RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 := by
-        have hCrossSum : (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) =
+        have hCrossSum : (∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v) =
             (∑ e ∈ Finset.Ico 1 m, (F ((e : ZMod N)) + F ((N - e : ℕ) : ZMod N))) :=
           Finset.sum_congr rfl fun e he => (hCross e he).symm
         have hswap2 : (∑ u ∈ (Finset.univ.erase 0 : Finset (ZMod N)),
@@ -756,11 +416,11 @@ theorem quadraticForm_sum_projections_of_cyclic_knabe
   -- The cyclic expansion.
   have hii := re_inner_cyclicWindowSum_sum_eq h hh m v
   -- The pairwise bound, summed over the ring.
-  have hiii : ∀ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v ≤
+  have hiii : ∀ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v ≤
       2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 :=
     fun e _ => re_inner_cyclicCrossTerms_le_two h hh e v
   -- Nonnegative cross terms at separated offsets.
-  have hiv : ∀ e ∈ Finset.Ico R m, 0 ≤ re_inner_cyclicCrossTerms h e v := by
+  have hiv : ∀ e ∈ Finset.Ico R m, 0 ≤ reInnerCyclicCrossTerms h e v := by
     intro e he
     simp only [Finset.mem_Ico] at he
     have he2 : e + R ≤ N := by omega
@@ -807,13 +467,13 @@ theorem quadraticForm_sum_projections_of_cyclic_knabe
   have hc : (0 : ℝ) < ((m - R + 1 : ℕ) : ℝ) := by
     have h1 : 0 < m - R + 1 := by omega
     exact_mod_cast h1
-  have hSplit : (∑ e ∈ Finset.Ico 1 m, ((m : ℝ) - e) * re_inner_cyclicCrossTerms h e v) =
-      (((m - R + 1 : ℕ) : ℝ) * (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) +
-        ∑ e ∈ Finset.Ico 1 m, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) := by
+  have hSplit : (∑ e ∈ Finset.Ico 1 m, ((m : ℝ) - e) * reInnerCyclicCrossTerms h e v) =
+      (((m - R + 1 : ℕ) : ℝ) * (∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v) +
+        ∑ e ∈ Finset.Ico 1 m, (((R : ℝ) - 1 - e) * reInnerCyclicCrossTerms h e v)) := by
     have hCoeff : ∀ e ∈ Finset.Ico 1 m,
-        (((m : ℝ) - e) * re_inner_cyclicCrossTerms h e v) =
-          (((m - R + 1 : ℕ) : ℝ) * re_inner_cyclicCrossTerms h e v +
-            (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) := by
+        (((m : ℝ) - e) * reInnerCyclicCrossTerms h e v) =
+          (((m - R + 1 : ℕ) : ℝ) * reInnerCyclicCrossTerms h e v +
+            (((R : ℝ) - 1 - e) * reInnerCyclicCrossTerms h e v)) := by
       intro e he
       simp only [Finset.mem_Ico] at he
       have hc2 : ((m - R + 1 : ℕ) : ℝ) = (m : ℝ) - (R : ℝ) + 1 := by
@@ -828,7 +488,7 @@ theorem quadraticForm_sum_projections_of_cyclic_knabe
       rw [hEq]
       ring
     rw [Finset.sum_congr rfl hCoeff, Finset.sum_add_distrib, Finset.mul_sum]
-  have hDrop : (∑ e ∈ Finset.Ico 1 m, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) ≤
+  have hDrop : (∑ e ∈ Finset.Ico 1 m, (((R : ℝ) - 1 - e) * reInnerCyclicCrossTerms h e v)) ≤
       ((R : ℝ) - 1) * ((R : ℝ) - 2) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
     have hUnion : Finset.Ico 1 m = Finset.Ico 1 R ∪ Finset.Ico R m :=
       (Finset.Ico_union_Ico_eq_Ico (a := 1) (b := R) (c := m) (by omega) (by omega)).symm
@@ -838,9 +498,9 @@ theorem quadraticForm_sum_projections_of_cyclic_knabe
       simp only [Finset.mem_inter, Finset.mem_Ico] at hx
       omega
     rw [hUnion, Finset.sum_union hDisj]
-    have hShort : (∑ e ∈ Finset.Ico 1 R, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) ≤
+    have hShort : (∑ e ∈ Finset.Ico 1 R, (((R : ℝ) - 1 - e) * reInnerCyclicCrossTerms h e v)) ≤
         ((R : ℝ) - 1) * ((R : ℝ) - 2) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
-      calc (∑ e ∈ Finset.Ico 1 R, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v))
+      calc (∑ e ∈ Finset.Ico 1 R, (((R : ℝ) - 1 - e) * reInnerCyclicCrossTerms h e v))
           ≤ (∑ e ∈ Finset.Ico 1 R, (((R : ℝ) - 1 - e) *
               (2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜))) := by
             refine Finset.sum_le_sum fun e he => ?_
@@ -858,7 +518,7 @@ theorem quadraticForm_sum_projections_of_cyclic_knabe
                   (2 * ∑ e ∈ Finset.Ico 1 R, (R - 1 - (e : ℝ))) *
                     RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by ring
               _ = _ := by rw [hvi]
-    have hLong : (∑ e ∈ Finset.Ico R m, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) ≤
+    have hLong : (∑ e ∈ Finset.Ico R m, (((R : ℝ) - 1 - e) * reInnerCyclicCrossTerms h e v)) ≤
         0 := by
       refine Finset.sum_nonpos fun e he => ?_
       have he' := Finset.mem_Ico.mp he
@@ -870,13 +530,13 @@ theorem quadraticForm_sum_projections_of_cyclic_knabe
       RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜) ≤
       (((m - R + 1 : ℕ) : ℝ) * RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 +
         ((R : ℝ) - 1) ^ 2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜) := by
-    have hCrossSumLe : (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) ≤
+    have hCrossSumLe : (∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v) ≤
         RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 - RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
       have h1 := hv
       linarith
     rw [hii, hSplit]
     have hMidLe : (((m - R + 1 : ℕ) : ℝ) *
-        (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v)) ≤
+        (∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v)) ≤
         (((m - R + 1 : ℕ) : ℝ) *
           (RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 -
             RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜)) :=
@@ -888,9 +548,9 @@ theorem quadraticForm_sum_projections_of_cyclic_knabe
     calc
       (m : ℝ) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
           (((m - R + 1 : ℕ) : ℝ) *
-            (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) +
+            (∑ e ∈ Finset.Ico 1 m, reInnerCyclicCrossTerms h e v) +
           ∑ e ∈ Finset.Ico 1 m,
-            ((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)
+            ((R : ℝ) - 1 - e) * reInnerCyclicCrossTerms h e v)
         ≤ (m : ℝ) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
             ((m - R + 1 : ℕ) : ℝ) *
               (RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 -

--- a/TNLean/Analysis/FiniteRangeKnabe.lean
+++ b/TNLean/Analysis/FiniteRangeKnabe.lean
@@ -14,19 +14,20 @@ one-dimensional cyclic family of symmetric projections with a finite
 interaction range `R`.
 
 Let `h i` be symmetric projections indexed by the cyclic group `ZMod N`, and
-write `H = ∑ i, h i` for the total term.  For `m ≥ R`, let
-`cyclicWindowSum h m s = ∑ q : Fin m, h (s + q)` be the sum of `m` consecutive
-terms starting at `s`, and suppose every window satisfies the quadratic-form
-gap `γ • Re ⟪A s v, v⟫ ≤ Re ⟪A s v, A s v⟫` uniformly in `s` and `v`.  If terms
-at cyclic separation at least `R` commute pointwise, then for `N ≥ 2 * m` the
-total term satisfies, as a quadratic form,
+write \(H=\sum_i h_i\). For \(m\geq R\), define the window sum
+\(A_s=\sum_{q=0}^{m-1}h_{s+q}\), represented by `cyclicWindowSum h m s`.
+Suppose every window satisfies
+\(\gamma\,\operatorname{Re}\langle A_s v,v\rangle\leq
+\operatorname{Re}\langle A_s v,A_s v\rangle\), uniformly in \(s\) and \(v\).
+If terms at cyclic separation at least \(R\) commute pointwise and \(N\geq2m\),
+then
+\(\delta\,\operatorname{Re}\langle Hv,v\rangle\leq
+\operatorname{Re}\langle Hv,Hv\rangle\), where
+\(\delta=(m\gamma-(R-1)^2)/(m-R+1)\), whenever
+\((R-1)^2<m\gamma\).
 
-`δ * Re ⟪H v, v⟫ ≤ Re ⟪H v, H v⟫,  δ = (m * γ - (R - 1) ^ 2) / (m - R + 1),`
-
-whenever the numerator `(R - 1) ^ 2 < m * γ` is positive.
-
-For `R = 2` this recovers Knabe's nearest-neighbor coefficient
-`(m * γ - 1) / (m - 1)`.
+For \(R=2\), this recovers Knabe's nearest-neighbor coefficient
+\((m\gamma-1)/(m-1)\).
 
 ## Sources
 
@@ -42,8 +43,6 @@ the cited sources, and is not attributed to any of them.
 
 ## Main results
 
-* `LinearMap.IsSymmetricProjection.re_inner_anticommutator_le`: the pairwise
-  bound `P Q + Q P ≤ P + Q` for symmetric projections.
 * `ProjectionGeometry.cyclicWindowSum_sq_sum_eq`: the cyclic double-counting
   identity `∑ s A s ^ 2 = m • H + ∑ e (m - e) • Q e`.
 * `ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe`: the
@@ -53,33 +52,6 @@ the cited sources, and is not attributed to any of them.
 -/
 
 open scoped InnerProductSpace
-
-namespace LinearMap.IsSymmetricProjection
-
-variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
-
-/-- Pairwise anticommutator upper bound for two symmetric projections.
-
-For symmetric projections `P` and `Q`, the positivity of `‖(P - Q) v‖²`
-(equivalently, of the operator `(P - Q) ^ 2`) expands, using idempotence of
-`P` and `Q`, into the anticommutator estimate `P Q + Q P ≤ P + Q` in
-quadratic-form terms:
-
-`Re ⟪P v, Q v⟫ + Re ⟪Q v, P v⟫ ≤ Re ⟪P v, v⟫ + Re ⟪Q v, v⟫.` -/
-theorem re_inner_anticommutator_le {P Q : E →ₗ[𝕜] E} (hP : P.IsSymmetricProjection)
-    (hQ : Q.IsSymmetricProjection) (v : E) :
-    RCLike.re ⟪P v, Q v⟫_𝕜 + RCLike.re ⟪Q v, P v⟫_𝕜 ≤
-      RCLike.re ⟪P v, v⟫_𝕜 + RCLike.re ⟪Q v, v⟫_𝕜 := by
-  have h0 : (0 : ℝ) ≤ RCLike.re ⟪P v - Q v, P v - Q v⟫_𝕜 :=
-    inner_self_nonneg (x := P v - Q v)
-  rw [inner_sub_sub_self] at h0
-  have h0' : (0 : ℝ) ≤ RCLike.re ⟪P v, P v⟫_𝕜 - RCLike.re ⟪P v, Q v⟫_𝕜 -
-      RCLike.re ⟪Q v, P v⟫_𝕜 + RCLike.re ⟪Q v, Q v⟫_𝕜 := by
-    simpa only [map_add, map_sub] using h0
-  rw [hP.re_inner_apply_apply_self, hQ.re_inner_apply_apply_self] at h0'
-  linarith
-
-end LinearMap.IsSymmetricProjection
 
 namespace ProjectionGeometry
 
@@ -139,6 +111,23 @@ all sites of the two ordered quadratic forms of the pairs at cyclic offsets
 `e` and `-e`. -/
 def reInnerCyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] E) (e : ℕ) (v : E) : ℝ :=
   ∑ i : ZMod N, (RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 + RCLike.re ⟪h i v, h (i - e) v⟫_𝕜)
+
+/-- For a cyclic family of symmetric projections, the real cross-term sum is
+the quadratic form of the corresponding cross-term operator. -/
+theorem reInnerCyclicCrossTerms_eq_re_inner_cyclicCrossTerms
+    (h : ZMod N → E →ₗ[𝕜] E) (hh : ∀ i, (h i).IsSymmetricProjection)
+    (e : ℕ) (v : E) :
+    reInnerCyclicCrossTerms h e v = RCLike.re ⟪cyclicCrossTerms h e v, v⟫_𝕜 := by
+  classical
+  unfold reInnerCyclicCrossTerms cyclicCrossTerms
+  simp only [LinearMap.sum_apply, LinearMap.add_apply, sum_inner, map_sum]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  change RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 + RCLike.re ⟪h i v, h (i - e) v⟫_𝕜 =
+    RCLike.re ⟪h i (h (i + e) v) + h i (h (i - e) v), v⟫_𝕜
+  rw [inner_add_left, map_add, (hh i).isSymmetric (h (i + e) v) v,
+    (hh i).isSymmetric (h (i - e) v) v,
+    ← inner_conj_symm (h i v) (h (i + e) v),
+    ← inner_conj_symm (h i v) (h (i - e) v), RCLike.conj_re, RCLike.conj_re]
 
 /-- The cyclic double-counting identity for a family of symmetric projections:
 summing the quadratic form of every window of `m` consecutive terms produces
@@ -429,39 +418,29 @@ theorem quadraticForm_sum_projections_of_cyclic_knabe
   have hv := re_inner_sum_two_ge_sum_cyclicCrossTerms h hh hm1 hN hmR hcomm v
   -- The sum of the short-offset weights.
   have hvi : 2 * (∑ e ∈ Finset.Ico 1 R, ((R : ℝ) - 1 - e)) = ((R : ℝ) - 1) * ((R : ℝ) - 2) := by
-    have hnbij : (∑ e ∈ Finset.Ico 1 R, ((R : ℝ) - 1 - e)) =
-        ∑ d ∈ Finset.range (R - 1), ((d : ℕ) : ℝ) := by
-      refine Finset.sum_nbij' (fun e => R - 1 - e) (fun d => R - 1 - d) ?_ ?_ ?_ ?_ ?_
-      · intro e he
-        simp only [Finset.mem_Ico, Finset.mem_range] at he ⊢
-        omega
-      · intro d hd
-        simp only [Finset.mem_Ico, Finset.mem_range] at hd ⊢
-        omega
-      · intro e he
-        simp only [Finset.mem_Ico] at he
-        omega
-      · intro d hd
-        simp only [Finset.mem_range] at hd
-        omega
-      · intro e he
-        have heR : e ≤ R - 1 := by
-          simp only [Finset.mem_Ico] at he
-          omega
-        change ((R : ℝ) - 1 - e) = ((R - 1 - e : ℕ) : ℝ)
-        rw [Nat.cast_sub heR, Nat.cast_sub (by omega : 1 ≤ R)]
-        norm_num
+    have hCast : ∀ e ∈ Finset.Ico 1 R,
+        ((R : ℝ) - 1 - e) = ((R - 1 - e : ℕ) : ℝ) := by
+      intro e he
+      simp only [Finset.mem_Ico] at he
+      rw [Nat.cast_sub (by omega : e ≤ R - 1), Nat.cast_sub hR]
+      norm_num
+    rw [Finset.sum_congr rfl hCast,
+      Finset.sum_Ico_reflect (fun d : ℕ => (d : ℝ)) 1 (n := R - 1) (by omega)]
+    simp only [Nat.sub_add_cancel hR, Nat.sub_self, Nat.Ico_zero_eq_range]
     have hTwo : ∀ n : ℕ, 2 * (∑ d ∈ Finset.range n, ((d : ℕ) : ℝ)) =
-        ((n : ℝ) * (((n : ℝ) - 1))) := by
+        (n : ℝ) * ((n : ℝ) - 1) := by
       intro n
-      induction n with
-      | zero => norm_num
-      | succ n ih =>
-          rw [Finset.sum_range_succ]
-          push_cast
-          nlinarith
-    rw [hnbij, hTwo (R - 1), Nat.cast_sub hR]
-    push_cast
+      by_cases hn : n = 0
+      · simp [hn]
+      · have hn1 : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr hn
+        have hcast : ((n - 1 : ℕ) : ℝ) = (n : ℝ) - 1 := by
+          rw [Nat.cast_sub hn1]
+          norm_num
+        have hnat := congrArg (fun x : ℕ => (x : ℝ)) (Finset.sum_range_id_mul_two n)
+        push_cast at hnat
+        rw [← hcast, mul_comm]
+        exact hnat
+    rw [hTwo (R - 1), Nat.cast_sub hR]
     ring
   -- Assemble the upper bound on the summed window squares.
   have hc : (0 : ℝ) < ((m - R + 1 : ℕ) : ℝ) := by

--- a/TNLean/Analysis/FiniteRangeKnabe.lean
+++ b/TNLean/Analysis/FiniteRangeKnabe.lean
@@ -1,0 +1,955 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Order.Interval.Finset.Nat
+import TNLean.Analysis.ProjectionGeometry
+
+/-!
+# Finite-range Knabe inequality for cyclic families of projections
+
+This file develops the Knabe open-to-periodic gap transfer for an abstract
+one-dimensional cyclic family of symmetric projections with a finite
+interaction range `R`.
+
+Let `h i` be symmetric projections indexed by the cyclic group `ZMod N`, and
+write `H = ∑ i, h i` for the total term.  For `m ≥ R`, let
+`cyclicWindowSum h m s = ∑ q : Fin m, h (s + q)` be the sum of `m` consecutive
+terms starting at `s`, and suppose every window satisfies the quadratic-form
+gap `γ • Re ⟪A s v, v⟫ ≤ Re ⟪A s v, A s v⟫` uniformly in `s` and `v`.  If terms
+at cyclic separation at least `R` commute pointwise, then for `N ≥ 2 * m` the
+total term satisfies, as a quadratic form,
+
+`δ * Re ⟪H v, v⟫ ≤ Re ⟪H v, H v⟫,  δ = (m * γ - (R - 1) ^ 2) / (m - R + 1),`
+
+whenever the numerator `(R - 1) ^ 2 < m * γ` is positive.
+
+For `R = 2` this recovers Knabe's nearest-neighbor coefficient
+`(m * γ - 1) / (m - 1)`.
+
+## Sources
+
+The nearest-neighbor threshold `γ > 1 / m` goes back to Knabe, J. Stat. Phys.
+52, 627 (1988) (`Knabe1988Energy`); the same criterion is stated in
+Pérez-García et al., arXiv:quant-ph/0608197, lines 1483-1489, and in
+Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:2011.12127, lines 2194-2197
+(paragraph "The Knabe bound").  The finite-range coefficient above is a
+TNLean derivation obtained by running Knabe's window argument with a general
+range; it is recorded in the note
+`docs/paper-gaps/knabe_finite_range_coefficient.tex`, is not stated in any of
+the cited sources, and is not attributed to any of them.
+
+## Main results
+
+* `LinearMap.IsSymmetricProjection.re_inner_anticommutator_le`: the pairwise
+  bound `P Q + Q P ≤ P + Q` for symmetric projections.
+* `ProjectionGeometry.cyclicWindowSum_sq_sum_eq`: the cyclic double-counting
+  identity `∑ s A s ^ 2 = m • H + ∑ e (m - e) • Q e`.
+* `ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe`: the
+  finite-range Knabe inequality.
+* `ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe_nearest_neighbor`:
+  the nearest-neighbor specialization `R = 2`.
+-/
+
+open scoped InnerProductSpace
+
+namespace LinearMap.IsSymmetricProjection
+
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-- Pairwise anticommutator upper bound for two symmetric projections.
+
+For symmetric projections `P` and `Q`, the positivity of `‖(P - Q) v‖²`
+(equivalently, of the operator `(P - Q) ^ 2`) expands, using idempotence of
+`P` and `Q`, into the anticommutator estimate `P Q + Q P ≤ P + Q` in
+quadratic-form terms:
+
+`Re ⟪P v, Q v⟫ + Re ⟪Q v, P v⟫ ≤ Re ⟪P v, v⟫ + Re ⟪Q v, v⟫.` -/
+theorem re_inner_anticommutator_le {P Q : E →ₗ[𝕜] E} (hP : P.IsSymmetricProjection)
+    (hQ : Q.IsSymmetricProjection) (v : E) :
+    RCLike.re ⟪P v, Q v⟫_𝕜 + RCLike.re ⟪Q v, P v⟫_𝕜 ≤
+      RCLike.re ⟪P v, v⟫_𝕜 + RCLike.re ⟪Q v, v⟫_𝕜 := by
+  have h0 : (0 : ℝ) ≤ RCLike.re ⟪P v - Q v, P v - Q v⟫_𝕜 :=
+    inner_self_nonneg (x := P v - Q v)
+  rw [inner_sub_sub_self] at h0
+  simp only [map_add, map_sub] at h0
+  rw [hP.re_inner_apply_apply_self, hQ.re_inner_apply_apply_self] at h0
+  linarith
+
+end LinearMap.IsSymmetricProjection
+
+namespace ProjectionGeometry
+
+section CyclicSums
+
+variable {M : Type*} [AddCommMonoid M] {N : ℕ} [NeZero N]
+
+/-- Cyclic translation invariance: summing over the cyclic group `ZMod N`
+commutes with right translation of the index. -/
+theorem sum_comp_addRight (F : ZMod N → M) (d : ZMod N) :
+    ∑ i, F (i + d) = ∑ i, F i := by
+  simpa using Equiv.sum_comp (Equiv.addRight d) F
+
+/-- Cyclic translation invariance: summing over the cyclic group `ZMod N`
+commutes with left translation of the index. -/
+theorem sum_comp_addLeft (F : ZMod N → M) (d : ZMod N) :
+    ∑ i, F (d + i) = ∑ i, F i := by
+  simpa using Equiv.sum_comp (Equiv.addLeft d) F
+
+/-- Weighted triangular count, upper form.  Summing the offsets `e` with
+`1 ≤ e < m - q` over all `q < m` counts each `e` with `1 ≤ e < m` exactly
+`m - e` times. -/
+theorem sum_range_Ico_triangular (F : ℕ → M) (m : ℕ) :
+    (∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q), F e) =
+      ∑ e ∈ Finset.Ico 1 m, (m - e) • F e := by
+  classical
+  have hExtend : ∀ q ∈ Finset.range m,
+      (∑ e ∈ Finset.Ico 1 (m - q), F e) =
+        ∑ e ∈ Finset.Ico 1 m, (if e ∈ Finset.Ico 1 (m - q) then F e else 0) := by
+    intro q _
+    have hfil : (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (m - q)) =
+        Finset.Ico 1 (m - q) := by
+      refine Finset.ext fun x => ?_
+      simp only [Finset.mem_filter, Finset.mem_Ico]
+      omega
+    have h1 : (∑ e ∈ Finset.Ico 1 (m - q), F e) =
+        ∑ e ∈ (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (m - q)), F e := by
+      rw [hfil]
+    rw [h1, Finset.sum_filter]
+  rw [Finset.sum_congr rfl (fun q hq => hExtend q hq), Finset.sum_comm]
+  refine Finset.sum_congr rfl fun e he => ?_
+  have hem : 1 ≤ e ∧ e < m := Finset.mem_Ico.mp he
+  have hCard : ∑ q ∈ Finset.range m, (if q ∈ Finset.range (m - e) then F e else 0) =
+      (m - e) • F e := by
+    have hfil : (Finset.range m).filter (fun q => q ∈ Finset.range (m - e)) =
+        Finset.range (m - e) := by
+      refine Finset.ext fun x => ?_
+      simp only [Finset.mem_filter, Finset.mem_range]
+      omega
+    rw [← Finset.sum_filter (s := Finset.range m), hfil, Finset.sum_const]
+    congr 1
+    simp
+  rw [← hCard]
+  refine Finset.sum_congr rfl fun q hq => ?_
+  have hqm : q < m := Finset.mem_range.mp hq
+  by_cases h1 : e ∈ Finset.Ico 1 (m - q)
+  · by_cases h2 : q ∈ Finset.range (m - e)
+    · simp [h1, h2]
+    · exfalso
+      simp only [Finset.mem_Ico, Finset.mem_range] at h1 h2
+      omega
+  · by_cases h2 : q ∈ Finset.range (m - e)
+    · exfalso
+      simp only [Finset.mem_Ico, Finset.mem_range] at h1 h2
+      omega
+    · simp [h1, h2]
+
+/-- Weighted triangular count, lower form.  Summing the offsets `e` with
+`1 ≤ e ≤ q` over all `q < m` counts each `e` with `1 ≤ e < m` exactly
+`m - e` times. -/
+theorem sum_range_Ico_triangular_lower (F : ℕ → M) (m : ℕ) :
+    (∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1), F e) =
+      ∑ e ∈ Finset.Ico 1 m, (m - e) • F e := by
+  classical
+  have hExtend : ∀ q ∈ Finset.range m,
+      (∑ e ∈ Finset.Ico 1 (q + 1), F e) =
+        ∑ e ∈ Finset.Ico 1 m, (if e ∈ Finset.Ico 1 (q + 1) then F e else 0) := by
+    intro q hq
+    have hqm : q < m := Finset.mem_range.mp hq
+    have hfil : (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (q + 1)) =
+        Finset.Ico 1 (q + 1) := by
+      refine Finset.ext fun x => ?_
+      simp only [Finset.mem_filter, Finset.mem_Ico]
+      omega
+    have h1 : (∑ e ∈ Finset.Ico 1 (q + 1), F e) =
+        ∑ e ∈ (Finset.Ico 1 m).filter (fun e => e ∈ Finset.Ico 1 (q + 1)), F e := by
+      rw [hfil]
+    rw [h1, Finset.sum_filter]
+  rw [Finset.sum_congr rfl (fun q hq => hExtend q hq), Finset.sum_comm]
+  refine Finset.sum_congr rfl fun e he => ?_
+  have hem : 1 ≤ e ∧ e < m := Finset.mem_Ico.mp he
+  have hCard : ∑ q ∈ Finset.range m, (if q ∈ Finset.Ico e m then F e else 0) =
+      (m - e) • F e := by
+    have hfil : (Finset.range m).filter (fun q => q ∈ Finset.Ico e m) =
+        Finset.Ico e m := by
+      refine Finset.ext fun x => ?_
+      simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]
+      omega
+    rw [← Finset.sum_filter (s := Finset.range m), hfil, Finset.sum_const]
+    congr 1
+    simp
+  rw [← hCard]
+  refine Finset.sum_congr rfl fun q hq => ?_
+  have hqm : q < m := Finset.mem_range.mp hq
+  by_cases h1 : e ∈ Finset.Ico 1 (q + 1)
+  · by_cases h2 : q ∈ Finset.Ico e m
+    · simp [h1, h2]
+    · exfalso
+      simp only [Finset.mem_Ico] at h1 h2
+      omega
+  · by_cases h2 : q ∈ Finset.Ico e m
+    · exfalso
+      simp only [Finset.mem_Ico] at h1 h2
+      omega
+    · simp [h1, h2]
+
+/-- Cyclic double counting for a square window of offsets.  For any function
+`T` on pairs of cyclic sites, summing `T (s + q) (s + q')` over all starting
+points `s` and all pairs of offsets `q, q' < m` produces the diagonal `T i i`
+with multiplicity `m`, and each ordered pair `(i, i + e)` and `(i, i - e)` with
+`1 ≤ e < m` with multiplicity `m - e`. -/
+theorem sum_cyclic_window_eq (T : ZMod N → ZMod N → M) (m : ℕ) :
+    (∑ s : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+        T (s + q) (s + q')) =
+      m • ∑ i : ZMod N, T i i +
+        ∑ e ∈ Finset.Ico 1 m, (m - e) •
+          ∑ i : ZMod N, (T i (i + e) + T i (i - e)) := by
+  classical
+  -- Translate the sum over starting points for each fixed pair of offsets.
+  have hStep1 : ∀ q ∈ Finset.range m, ∀ q' ∈ Finset.range m,
+      (∑ s : ZMod N, T (s + q) (s + q')) = ∑ i : ZMod N, T i (i + (q' - q)) := by
+    intro q _ q' _
+    have harg : ∀ s : ZMod N, (s + q) + (q' - q) = s + q' := by
+      intro s
+      abel
+    calc (∑ s : ZMod N, T (s + q) (s + q'))
+        = ∑ s : ZMod N, T (s + q) ((s + q) + (q' - q)) :=
+          Finset.sum_congr rfl fun s _ => by rw [harg s]
+      _ = ∑ i : ZMod N, T i (i + (q' - q)) :=
+          sum_comp_addRight (fun u => T u (u + (q' - q))) q
+  -- Flatten the sum over starting points to the inside.
+  have hFlat : (∑ s : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+      T (s + q) (s + q')) =
+      ∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+        T i (i + (q' - q)) := by
+    conv_rhs => rw [Finset.sum_comm]
+    conv_lhs => rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun q hq => ?_
+    conv_rhs => rw [Finset.sum_comm]
+    conv_lhs => rw [Finset.sum_comm]
+    exact Finset.sum_congr rfl fun q' hq' => hStep1 q hq q' hq'
+  -- Split each offset square into the diagonal and the two triangles.
+  have hSplit : ∀ i : ZMod N,
+      (∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m, T i (i + (q' - q))) =
+        (∑ q ∈ Finset.range m, T i i) +
+          ((∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q), T i (i + e)) +
+            ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e)) := by
+    intro i
+    have hPer : ∀ q ∈ Finset.range m,
+        (∑ q' ∈ Finset.range m, T i (i + (q' - q))) =
+          T i i + ((∑ e ∈ Finset.Ico 1 (m - q), T i (i + e)) +
+            ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e)) := by
+      intro q hq
+      have hqm : q < m := Finset.mem_range.mp hq
+      have hRange : Finset.range m =
+          Finset.Ico 0 q ∪ insert q (Finset.Ico (q + 1) m) := by
+        have h1 : Finset.range m = Finset.Ico 0 m := Finset.range_eq_Ico m
+        have h2 : Finset.Ico 0 m = Finset.Ico 0 q ∪ Finset.Ico q m :=
+          (Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)).symm
+        have h3 : Finset.Ico q m = insert q (Finset.Ico (q + 1) m) := by
+          rw [← Finset.insert_erase (Finset.mem_Ico.mpr ⟨le_refl q, by omega⟩),
+            ← Nat.Ico_succ_left_eq_erase_Ico]
+        rw [h1, h2, h3]
+      rw [hRange, Finset.sum_union (Finset.disjoint_iff_inter_eq_empty.mpr
+        (Finset.eq_empty_iff_forall_notMem.mpr fun x hx => by
+          simp only [Finset.mem_inter, Finset.mem_Ico, Finset.mem_insert] at hx
+          omega)), Finset.sum_insert (by
+        intro hxs
+        simp only [Finset.mem_Ico] at hxs
+        omega)]
+      -- The strict lower triangle reindexes by the positive offset difference.
+      have hFirst : (∑ q' ∈ Finset.Ico 0 q, T i (i + (q' - q))) =
+          ∑ e ∈ Finset.Ico 1 (q + 1), T i (i - e) := by
+        refine Finset.sum_nbij' (fun q' => q - q') (fun e => q - e) ?_ ?_ ?_ ?_ ?_
+        · intro q' hq'
+          simp only [Finset.mem_Ico] at hq' ⊢
+          omega
+        · intro e he
+          simp only [Finset.mem_Ico] at he ⊢
+          omega
+        · intro q' hq'
+          simp only [Finset.mem_Ico] at hq'
+          omega
+        · intro e he
+          simp only [Finset.mem_Ico] at he
+          omega
+        · intro q' hq'
+          have hq'q : q' ≤ q := by
+            simp only [Finset.mem_Ico] at hq'
+            omega
+          have hcast : ((q' : ZMod N) - q) = -((q - q' : ℕ) : ZMod N) := by
+            have hsub : (((q - q' : ℕ) : ZMod N)) + (q' : ZMod N) = (q : ZMod N) := by
+              rw [← Nat.cast_add, Nat.sub_add_cancel hq'q]
+            linear_combination (norm := module) hsub
+          change T i (i + (↑q' - ↑q)) = T i (i - ↑(q - q'))
+          congr 1
+          rw [hcast]
+          abel
+      -- The strict upper triangle reindexes by the positive offset difference.
+      have hThird : (∑ q' ∈ Finset.Ico (q + 1) m, T i (i + (q' - q))) =
+          ∑ e ∈ Finset.Ico 1 (m - q), T i (i + e) := by
+        refine Finset.sum_nbij' (fun q' => q' - q) (fun e => q + e) ?_ ?_ ?_ ?_ ?_
+        · intro q' hq'
+          simp only [Finset.mem_Ico] at hq' ⊢
+          omega
+        · intro e he
+          simp only [Finset.mem_Ico] at he ⊢
+          omega
+        · intro q' hq'
+          simp only [Finset.mem_Ico] at hq'
+          omega
+        · intro e he
+          simp only [Finset.mem_Ico] at he
+          omega
+        · intro q' hq'
+          have hq'q : q < q' := by
+            simp only [Finset.mem_Ico] at hq'
+            omega
+          change T i (i + (↑q' - ↑q)) = T i (i + ↑(q' - q))
+          rw [Nat.cast_sub hq'q.le]
+      rw [hFirst, hThird, sub_self, add_zero]
+      ac_rfl
+    rw [Finset.sum_congr rfl hPer, Finset.sum_add_distrib, Finset.sum_add_distrib]
+  -- Assemble: diagonal, then the two weighted triangles.
+  rw [hFlat, Finset.sum_congr rfl fun i _ => hSplit i, Finset.sum_add_distrib,
+    Finset.sum_add_distrib]
+  have hDiag : (∑ i : ZMod N, ∑ q ∈ Finset.range m, T i i) = m • ∑ i : ZMod N, T i i := by
+    rw [Finset.sum_comm]
+    simp
+  rw [hDiag]
+  have hUpper : (∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (m - q),
+      T i (i + e)) = ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i + e) := by
+    rw [Finset.sum_congr rfl fun i _ => sum_range_Ico_triangular (fun e => T i (i + e)) m,
+      Finset.sum_comm]
+    exact Finset.sum_congr rfl fun e _ => (Finset.smul_sum).symm
+  have hLower : (∑ i : ZMod N, ∑ q ∈ Finset.range m, ∑ e ∈ Finset.Ico 1 (q + 1),
+      T i (i - e)) = ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i - e) := by
+    rw [Finset.sum_congr rfl fun i _ =>
+      sum_range_Ico_triangular_lower (fun e => T i (i - e)) m, Finset.sum_comm]
+    exact Finset.sum_congr rfl fun e _ => (Finset.smul_sum).symm
+  have hComb : (∑ e ∈ Finset.Ico 1 m, (m - e) •
+        ∑ i : ZMod N, (T i (i + e) + T i (i - e))) =
+      (∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i + e)) +
+        (∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, T i (i - e)) := by
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun e _ => by rw [Finset.sum_add_distrib, smul_add]
+  rw [hUpper, hLower, ← hComb]
+
+/-- Partition of the nonzero cyclic offsets into short offsets `1 ≤ e < m`,
+the reflection `N - e` of each short offset, and middle offsets
+`m ≤ k ≤ N - m`.  The partition requires `1 ≤ m ≤ N / 2`, so that the middle
+interval is well placed and short offsets and their reflections are distinct. -/
+theorem sum_offset_partition (F : ZMod N → M) {m : ℕ} (hm1 : 1 ≤ m) (hm : 2 * m ≤ N) :
+    (∑ u ∈ (Finset.univ.erase 0 : Finset (ZMod N)), F u) =
+      (∑ e ∈ Finset.Ico 1 m, (F e + F ((N - e : ℕ) : ZMod N))) +
+        ∑ k ∈ Finset.Ico m (N - m + 1), F k := by
+  classical
+  -- Index the nonzero cyclic offsets by the integer interval `1 ≤ k < N`.
+  have hBij : (∑ u ∈ Finset.univ.erase (0 : ZMod N), F u) =
+      ∑ k ∈ Finset.Ico 1 N, F k := by
+    refine Finset.sum_nbij' (fun u => u.val) (fun k => (k : ZMod N)) ?_ ?_ ?_ ?_ ?_
+    · intro u hu
+      have hu0 : u ≠ 0 := by simpa using hu
+      have hlt : u.val < N := ZMod.val_lt u
+      have hne : u.val ≠ 0 := fun h0 => hu0 (by
+        rw [← ZMod.natCast_zmod_val u, h0]
+        simp)
+      simp only [Finset.mem_Ico]
+      omega
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk
+      have hkne : (k : ZMod N) ≠ 0 := by
+        intro h0
+        have hkmod : k % N = 0 := by
+          rw [← ZMod.val_natCast N k, h0]
+          simp
+        rw [Nat.mod_eq_of_lt (by omega)] at hkmod
+        omega
+      exact Finset.mem_erase.2 ⟨hkne, Finset.mem_univ _⟩
+    · intro u _
+      exact ZMod.natCast_zmod_val u
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk
+      have hkN : ((k : ZMod N)).val = k % N := ZMod.val_natCast N k
+      rw [hkN, Nat.mod_eq_of_lt (by omega)]
+    · intro u _
+      rw [ZMod.natCast_zmod_val]
+  rw [hBij]
+  -- Split the interval `1 ≤ k < N` into short, middle, and long offsets.
+  have hUnion : (Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1)) ∪ Finset.Ico (N - m + 1) N =
+      Finset.Ico 1 N := by
+    have hU1 : Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1) = Finset.Ico 1 (N - m + 1) :=
+      Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)
+    have hU2 : Finset.Ico 1 (N - m + 1) ∪ Finset.Ico (N - m + 1) N = Finset.Ico 1 N :=
+      Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)
+    rw [hU1, hU2]
+  have hDisj1 : Disjoint (Finset.Ico 1 m) (Finset.Ico m (N - m + 1)) := by
+    rw [Finset.disjoint_iff_inter_eq_empty]
+    refine Finset.eq_empty_iff_forall_notMem.mpr fun x hx => ?_
+    simp only [Finset.mem_inter, Finset.mem_Ico] at hx
+    omega
+  have hDisj2 : Disjoint (Finset.Ico 1 m ∪ Finset.Ico m (N - m + 1))
+      (Finset.Ico (N - m + 1) N) := by
+    rw [Finset.disjoint_iff_inter_eq_empty]
+    refine Finset.eq_empty_iff_forall_notMem.mpr fun x hx => ?_
+    simp only [Finset.mem_inter, Finset.mem_union, Finset.mem_Ico] at hx
+    omega
+  -- Reflect the long offsets `N - m + 1 ≤ k < N` back to short offsets.
+  have hLong : (∑ k ∈ Finset.Ico (N - m + 1) N, F k) =
+      ∑ e ∈ Finset.Ico 1 m, F ((N - e : ℕ) : ZMod N) := by
+    refine Finset.sum_nbij' (fun k => N - k) (fun e => N - e) ?_ ?_ ?_ ?_ ?_
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk ⊢
+      omega
+    · intro e he
+      simp only [Finset.mem_Ico] at he ⊢
+      omega
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk
+      omega
+    · intro e he
+      simp only [Finset.mem_Ico] at he
+      omega
+    · intro k hk
+      simp only [Finset.mem_Ico] at hk
+      have hkN : N - (N - k) = k := by omega
+      simp only [hkN]
+  rw [← hUnion, Finset.sum_union hDisj2, Finset.sum_union hDisj1, hLong,
+    Finset.sum_add_distrib]
+  ac_rfl
+
+end CyclicSums
+
+
+
+section CyclicFamily
+
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+variable {N : ℕ} [NeZero N]
+
+/-- The sum of `m` consecutive terms of a cyclic family, starting at `s`. -/
+def cyclicWindowSum (h : ZMod N → E →ₗ[𝕜] E) (m : ℕ) (s : ZMod N) : E →ₗ[𝕜] E :=
+  ∑ q : Fin m, h (s + (q : ℕ))
+
+/-- The operator cross terms of a cyclic family at offset `e`. -/
+def cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] E) (e : ℕ) : E →ₗ[𝕜] E :=
+  ∑ i : ZMod N, (h i * h (i + e) + h i * h (i - e))
+
+/-- Cyclic expansion of the sum of squared windows. If `H = ∑ i, h i` and
+`Q e = cyclicCrossTerms h e`, then
+`∑ s, (cyclicWindowSum h m s) ^ 2 = m • H + ∑ e, (m - e) • Q e`. -/
+theorem cyclicWindowSum_sq_sum_eq (h : ZMod N → E →ₗ[𝕜] E)
+    (hh : ∀ i, (h i).IsSymmetricProjection) (m : ℕ) :
+    (∑ s : ZMod N, cyclicWindowSum h m s * cyclicWindowSum h m s) =
+      m • ∑ i : ZMod N, h i +
+        ∑ e ∈ Finset.Ico 1 m, (m - e) • cyclicCrossTerms h e := by
+  classical
+  have hWindow : ∀ s : ZMod N, cyclicWindowSum h m s =
+      ∑ q ∈ Finset.range m, h (s + q) := by
+    intro s
+    rw [cyclicWindowSum]
+    exact Fin.sum_univ_eq_sum_range (fun q : ℕ => h (s + (q : ZMod N))) m
+  have hDiag : ∀ i : ZMod N, h i * h i = h i := by
+    intro i
+    ext v
+    exact LinearMap.IsIdempotentElem.apply_apply (hh i).isIdempotentElem v
+  calc
+    (∑ s : ZMod N, cyclicWindowSum h m s * cyclicWindowSum h m s) =
+        ∑ s : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+          h (s + q) * h (s + q') := by
+      refine Finset.sum_congr rfl fun s _ => ?_
+      rw [hWindow s, Finset.sum_mul]
+      refine Finset.sum_congr rfl fun q _ => ?_
+      rw [Finset.mul_sum]
+    _ = m • ∑ i : ZMod N, h i * h i +
+        ∑ e ∈ Finset.Ico 1 m, (m - e) •
+          ∑ i : ZMod N, (h i * h (i + e) + h i * h (i - e)) :=
+      sum_cyclic_window_eq (fun i j => h i * h j) m
+    _ = m • ∑ i : ZMod N, h i +
+        ∑ e ∈ Finset.Ico 1 m, (m - e) • cyclicCrossTerms h e := by
+      rw [Finset.sum_congr rfl fun i _ => hDiag i]
+      rfl
+
+/-- The ordered real cross terms of a cyclic family at offset `e`: the sum over
+all sites of the two ordered quadratic forms of the pairs at cyclic offsets
+`e` and `-e`. -/
+def re_inner_cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] E) (e : ℕ) (v : E) : ℝ :=
+  ∑ i : ZMod N, (RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 + RCLike.re ⟪h i v, h (i - e) v⟫_𝕜)
+
+/-- The cyclic double-counting identity for a family of symmetric projections:
+summing the quadratic form of every window of `m` consecutive terms produces
+the diagonal with multiplicity `m` and each offset pair of cross terms with
+multiplicity `m - e`. -/
+theorem re_inner_cyclicWindowSum_sum_eq (h : ZMod N → E →ₗ[𝕜] E)
+    (hh : ∀ i, (h i).IsSymmetricProjection) (m : ℕ) (v : E) :
+    (∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜) =
+      m * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
+        ∑ e ∈ Finset.Ico 1 m, (m - e) * re_inner_cyclicCrossTerms h e v := by
+  classical
+  have hExpand : ∀ s : ZMod N,
+      RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜 =
+        ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+          RCLike.re ⟪h (s + q) v, h (s + q') v⟫_𝕜 := by
+    intro s
+    rw [cyclicWindowSum, re_inner_sum_apply_apply,
+      Fin.sum_univ_eq_sum_range
+        (fun k : ℕ => ∑ q' : Fin m,
+          RCLike.re ⟪h (s + (k : ZMod N)) v, h (s + ((q' : ℕ) : ZMod N)) v⟫_𝕜) m]
+    refine Finset.sum_congr rfl fun q _ => ?_
+    exact Fin.sum_univ_eq_sum_range
+      (fun k' : ℕ => RCLike.re ⟪h (s + (q : ZMod N)) v, h (s + (k' : ZMod N)) v⟫_𝕜) m
+  set T : ZMod N → ZMod N → ℝ := fun i j => RCLike.re ⟪h i v, h j v⟫_𝕜 with hT
+  have hDiag : (∑ i : ZMod N, T i i) = RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+    rw [hT]
+    simp only []
+    rw [re_inner_sum_apply_left h v]
+    exact Finset.sum_congr rfl fun i _ => (hh i).re_inner_apply_apply_self v
+  calc (∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜)
+      = ∑ s : ZMod N, ∑ q ∈ Finset.range m, ∑ q' ∈ Finset.range m,
+          T (s + q) (s + q') :=
+        Finset.sum_congr rfl fun s _ => hExpand s
+    _ = m • ∑ i : ZMod N, T i i +
+        ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, (T i (i + e) + T i (i - e)) :=
+        sum_cyclic_window_eq T m
+    _ = m * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
+        ∑ e ∈ Finset.Ico 1 m, (m - e) * re_inner_cyclicCrossTerms h e v := by
+        rw [hDiag, nsmul_eq_mul]
+        have hsmulB : ∀ e ∈ Finset.Ico 1 m,
+            ((m - e : ℕ) • (∑ i : ZMod N, (T i (i + e) + T i (i - e)))) =
+              ((m : ℝ) - (e : ℝ)) * re_inner_cyclicCrossTerms h e v := by
+          intro e he
+          simp only [Finset.mem_Ico] at he
+          rw [nsmul_eq_mul, Nat.cast_sub (by omega)]
+          rfl
+        refine congrArg _ ?_
+        exact Finset.sum_congr rfl hsmulB
+
+/-- Summing the quadratic forms of all windows counts every site `m` times. -/
+theorem re_inner_cyclicWindowSum_sum_apply (h : ZMod N → E →ₗ[𝕜] E) (m : ℕ) (v : E) :
+    (∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, v⟫_𝕜) =
+      m * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+  classical
+  have hExpand : ∀ s : ZMod N,
+      RCLike.re ⟪cyclicWindowSum h m s v, v⟫_𝕜 =
+        ∑ q : Fin m, RCLike.re ⟪h (s + (q : ℕ)) v, v⟫_𝕜 := by
+    intro s
+    simp only [cyclicWindowSum, re_inner_sum_apply_left]
+  have h1 : (∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, v⟫_𝕜) =
+      ∑ s : ZMod N, ∑ q : Fin m, RCLike.re ⟪h (s + (q : ℕ)) v, v⟫_𝕜 :=
+    Finset.sum_congr rfl fun s _ => hExpand s
+  have hswap : (∑ s : ZMod N, ∑ q : Fin m, RCLike.re ⟪h (s + (q : ℕ)) v, v⟫_𝕜) =
+      ∑ q : Fin m, ∑ s : ZMod N, RCLike.re ⟪h (s + (q : ℕ)) v, v⟫_𝕜 := Finset.sum_comm
+  rw [h1, hswap]
+  have hTrans : ∀ q : Fin m, (∑ s : ZMod N, RCLike.re ⟪h (s + (q : ℕ)) v, v⟫_𝕜) =
+      RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+    intro q
+    have hTra := sum_comp_addRight (M := ℝ)
+      (fun u : ZMod N => RCLike.re ⟪h u v, v⟫_𝕜) ((q : ℕ) : ZMod N)
+    rw [hTra]
+    exact (re_inner_sum_apply_left h v).symm
+  rw [Finset.sum_congr rfl fun q _ => hTrans q]
+  simp
+
+/-- The pairwise anticommutator bound, summed over the ring: the cross terms at
+any offset are bounded by twice the total quadratic form. -/
+theorem re_inner_cyclicCrossTerms_le_two (h : ZMod N → E →ₗ[𝕜] E)
+    (hh : ∀ i, (h i).IsSymmetricProjection) (e : ℕ) (v : E) :
+    re_inner_cyclicCrossTerms h e v ≤ 2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+  classical
+  have hPair : ∀ i : ZMod N,
+      RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 + RCLike.re ⟪h (i + e) v, h i v⟫_𝕜 ≤
+        RCLike.re ⟪h i v, v⟫_𝕜 + RCLike.re ⟪h (i + e) v, v⟫_𝕜 :=
+    fun i => LinearMap.IsSymmetricProjection.re_inner_anticommutator_le (hh i)
+      (hh (i + e)) v
+  -- The reversed ordered pair is a translate of the pair at offset `-e`.
+  have hTrans : (∑ i : ZMod N, RCLike.re ⟪h (i + e) v, h i v⟫_𝕜) =
+      ∑ i : ZMod N, RCLike.re ⟪h i v, h (i - e) v⟫_𝕜 := by
+    refine Fintype.sum_equiv (Equiv.addRight ((e : ZMod N))) _ _ fun i => ?_
+    change RCLike.re ⟪h (i + e) v, h i v⟫_𝕜 = RCLike.re ⟪h (i + e) v, h ((i + e) - e) v⟫_𝕜
+    abel_nf
+  have hDiag : (∑ i : ZMod N, RCLike.re ⟪h (i + e) v, v⟫_𝕜) =
+      ∑ i : ZMod N, RCLike.re ⟪h i v, v⟫_𝕜 :=
+    sum_comp_addRight (fun u : ZMod N => RCLike.re ⟪h u v, v⟫_𝕜) _
+  have hSplit : re_inner_cyclicCrossTerms h e v =
+      (∑ i : ZMod N, (RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 +
+        RCLike.re ⟪h (i + e) v, h i v⟫_𝕜)) := by
+    unfold re_inner_cyclicCrossTerms
+    rw [Finset.sum_add_distrib, Finset.sum_add_distrib, hTrans]
+  calc re_inner_cyclicCrossTerms h e v
+      = (∑ i : ZMod N, (RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 +
+        RCLike.re ⟪h (i + e) v, h i v⟫_𝕜)) := hSplit
+    _ ≤ (∑ i : ZMod N, (RCLike.re ⟪h i v, v⟫_𝕜 +
+        RCLike.re ⟪h (i + e) v, v⟫_𝕜)) :=
+        Finset.sum_le_sum fun i _ => hPair i
+    _ = (∑ i : ZMod N, RCLike.re ⟪h i v, v⟫_𝕜) +
+        ∑ i : ZMod N, RCLike.re ⟪h (i + e) v, v⟫_𝕜 :=
+        Finset.sum_add_distrib
+    _ = 2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+        rw [hDiag, ← Finset.sum_add_distrib, re_inner_sum_apply_left h v, two_mul,
+          ← Finset.sum_add_distrib]
+
+/-- Terms at cyclic separation at least `R` commute pointwise; commuting
+symmetric projections have nonnegative ordered cross terms, so both legs of the
+cross terms at an offset between `R` and `N - R` are nonnegative. -/
+theorem re_inner_cyclicCrossTerms_nonneg (h : ZMod N → E →ₗ[𝕜] E)
+    (hh : ∀ i, (h i).IsSymmetricProjection) {R : ℕ}
+    (hcomm : ∀ d : ℕ, R ≤ d → d + R ≤ N → ∀ i : ZMod N, ∀ v : E,
+      h i (h ((i + (d : ZMod N))) v) = h ((i + (d : ZMod N))) (h i v))
+    {e : ℕ} (he1 : R ≤ e) (he2 : e + R ≤ N) (v : E) :
+    0 ≤ re_inner_cyclicCrossTerms h e v := by
+  have h1 : ∀ i : ZMod N, 0 ≤ RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 :=
+    fun i => LinearMap.IsSymmetricProjection.re_inner_apply_apply_nonneg_of_commute
+      (hh i) (hh (i + e)) (hcomm e he1 he2 i) v
+  have h2 : ∀ i : ZMod N, 0 ≤ RCLike.re ⟪h i v, h (i - e) v⟫_𝕜 := by
+    intro i
+    have hshift : (i - (e : ZMod N)) = (i + ((N - e : ℕ) : ZMod N)) := by
+      have hzero : (((e : ZMod N)) + ((N - e : ℕ) : ZMod N)) = 0 := by
+        have hsum : e + (N - e) = N := by omega
+        rw [← Nat.cast_add, hsum, ZMod.natCast_self]
+      have hneg : ((N - e : ℕ) : ZMod N) = -((e : ZMod N)) :=
+        eq_neg_of_add_eq_zero_right hzero
+      rw [sub_eq_add_neg, hneg]
+    rw [hshift]
+    exact LinearMap.IsSymmetricProjection.re_inner_apply_apply_nonneg_of_commute
+      (hh i) (hh (i + ((N - e : ℕ) : ZMod N))) (hcomm (N - e) (by omega) (by omega) i) v
+  exact Finset.sum_nonneg fun i _ => add_nonneg (h1 i) (h2 i)
+
+/-- The diagonal-plus-cross-terms lower bound on the total square.  Expanding
+`Re ⟪H v, H v⟫` over ordered pairs and grouping by cyclic offset, the offsets
+between `m` and `N - m` carry nonnegative cross terms (they are at separation
+at least `R`), so the total square dominates the diagonal plus the short cross
+terms. -/
+theorem re_inner_sum_two_ge_sum_cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] E)
+    (hh : ∀ i, (h i).IsSymmetricProjection) {R m : ℕ}
+    (hm1 : 1 ≤ m) (hN : 2 * m ≤ N) (hRm : R ≤ m)
+    (hcomm : ∀ d : ℕ, R ≤ d → d + R ≤ N → ∀ i : ZMod N, ∀ v : E,
+      h i (h ((i + (d : ZMod N))) v) = h ((i + (d : ZMod N))) (h i v))
+    (v : E) :
+    RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 + ∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v ≤
+      RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 := by
+  classical
+  set T : ZMod N → ZMod N → ℝ := fun i j => RCLike.re ⟪h i v, h j v⟫_𝕜 with hT
+  -- Expand over ordered pairs and translate the second site.
+  have hInner : ∀ i : ZMod N, (∑ j : ZMod N, T i j) = ∑ u : ZMod N, T i (i + u) := by
+    intro i
+    exact (Equiv.sum_comp (Equiv.addLeft i) (T i)).symm
+  -- Split off the zero offset.
+  have hSplit0 : ∀ i : ZMod N, (∑ u : ZMod N, T i (i + u)) = T i i +
+      ∑ u ∈ (Finset.univ.erase 0 : Finset (ZMod N)), T i (i + u) := by
+    intro i
+    have hEq : (∑ u : ZMod N, T i (i + u)) =
+        T i (i + 0) + ∑ u ∈ (Finset.univ.erase 0 : Finset (ZMod N)), T i (i + u) := by
+      have hU : (Finset.univ : Finset (ZMod N)) =
+          insert (0 : ZMod N) (Finset.univ.erase (0 : ZMod N)) :=
+        (Finset.insert_erase (Finset.mem_univ 0)).symm
+      calc (∑ u : ZMod N, T i (i + u))
+          = (∑ u ∈ insert (0 : ZMod N) (Finset.univ.erase (0 : ZMod N)), T i (i + u)) := by
+            rw [← hU]
+        _ = T i (i + 0) + ∑ u ∈ Finset.univ.erase (0 : ZMod N), T i (i + u) :=
+            Finset.sum_insert (by simp)
+    rw [hEq, add_zero]
+  -- Partition the nonzero offsets.
+  set F : ZMod N → ℝ := fun u => ∑ i : ZMod N, T i (i + u) with hF
+  have hPart := sum_offset_partition F hm1 hN
+  -- The middle offsets carry nonnegative cross terms.
+  have hMidNonneg : 0 ≤ ∑ k ∈ Finset.Ico m (N - m + 1), F k := by
+    refine Finset.sum_nonneg fun k hk => Finset.sum_nonneg fun i _ => ?_
+    simp only [Finset.mem_Ico] at hk
+    exact LinearMap.IsSymmetricProjection.re_inner_apply_apply_nonneg_of_commute
+      (hh i) (hh (i + k)) (hcomm k (by omega) (by omega) i) v
+  -- The reflected short offsets reproduce the second leg of the cross terms.
+  have hCross : ∀ e ∈ Finset.Ico 1 m,
+      F ((e : ZMod N)) + F ((N - e : ℕ) : ZMod N) =
+        re_inner_cyclicCrossTerms h e v := by
+    intro e he
+    simp only [Finset.mem_Ico] at he
+    have hshift : (∑ i : ZMod N, T i (i + ((N - e : ℕ) : ZMod N))) =
+        ∑ i : ZMod N, T i (i - e) := by
+      have hneg : ((N - e : ℕ) : ZMod N) = -((e : ZMod N)) := by
+        have hzero : (((e : ZMod N)) + ((N - e : ℕ) : ZMod N)) = 0 := by
+          have hsum : e + (N - e) = N := by omega
+          rw [← Nat.cast_add, hsum, ZMod.natCast_self]
+        exact eq_neg_of_add_eq_zero_right hzero
+      refine Finset.sum_congr rfl fun i _ => ?_
+      rw [hneg, sub_eq_add_neg]
+    change (∑ i : ZMod N, T i (i + ((e : ZMod N)))) +
+        (∑ i : ZMod N, T i (i + ((N - e : ℕ) : ZMod N))) = _
+    rw [hshift, ← Finset.sum_add_distrib]
+    rfl
+  calc RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 + ∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v
+      = (∑ i : ZMod N, T i i) + (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) := by
+        rw [re_inner_sum_apply_left h v]
+        congr 1
+        exact Finset.sum_congr rfl fun i _ => ((hh i).re_inner_apply_apply_self v).symm
+    _ ≤ (∑ i : ZMod N, T i i) +
+        (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v +
+          ∑ k ∈ Finset.Ico m (N - m + 1), F k) := by
+        have hle := hMidNonneg
+        linarith
+    _ = RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 := by
+        have hCrossSum : (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) =
+            (∑ e ∈ Finset.Ico 1 m, (F ((e : ZMod N)) + F ((N - e : ℕ) : ZMod N))) :=
+          Finset.sum_congr rfl fun e he => (hCross e he).symm
+        have hswap2 : (∑ u ∈ (Finset.univ.erase 0 : Finset (ZMod N)),
+            ∑ i : ZMod N, T i (i + u)) =
+            (∑ i : ZMod N, ∑ u ∈ (Finset.univ.erase 0 : Finset (ZMod N)), T i (i + u)) :=
+          Finset.sum_comm
+        rw [re_inner_sum_apply_apply h v,
+          Finset.sum_congr rfl fun i _ => hInner i,
+          Finset.sum_congr rfl fun i _ => hSplit0 i, Finset.sum_add_distrib, hCrossSum,
+          ← hPart, hswap2]
+
+
+/-- **Finite-range cyclic Knabe inequality.**
+
+Let `h i` be symmetric projections on a Hilbert space, indexed by the cyclic
+group `ZMod N`, such that terms at cyclic separation at least `R` commute
+pointwise (cyclic separation at least `R` means the offset `d` satisfies
+`R ≤ d ≤ N - R`).  Let `A s = cyclicWindowSum h m s` be the sums of `m`
+consecutive terms with `R ≤ m` and `2 * m ≤ N`, and suppose every window has
+the quadratic-form gap `γ * Re ⟪A s v, v⟫ ≤ Re ⟪A s v, A s v⟫` uniformly.
+Writing `H = ∑ i, h i`, the total term satisfies the quadratic-form gap
+
+`δ * Re ⟪H v, v⟫ ≤ Re ⟪H v, H v⟫,  δ = (m * γ - (R - 1) ^ 2) / (m - R + 1),`
+
+whenever the numerator is positive, `(R - 1) ^ 2 < m * γ`.  For `R = 2` this
+is Knabe's nearest-neighbor coefficient `(m * γ - 1) / (m - 1)`.
+
+The nearest-neighbor threshold `γ > 1 / m` goes back to Knabe, J. Stat. Phys.
+52, 627 (1988); it is stated in this form in Pérez-García et al.,
+arXiv:quant-ph/0608197, lines 1483-1489, and Cirac--Perez-Garcia--Schuch--
+Verstraete, arXiv:2011.12127, lines 2194-2197.  The finite-range coefficient
+is a TNLean derivation obtained by running Knabe's window argument with a
+general range; see the paper-gap note
+`docs/paper-gaps/knabe_finite_range_coefficient.tex`. -/
+theorem quadraticForm_sum_projections_of_cyclic_knabe
+    {N R m : ℕ} [NeZero N]
+    (h : ZMod N → E →ₗ[𝕜] E) (hh : ∀ i, (h i).IsSymmetricProjection)
+    (hN : 2 * m ≤ N) (hR : 1 ≤ R) (hmR : R ≤ m)
+    (hcomm : ∀ d : ℕ, R ≤ d → d + R ≤ N → ∀ i : ZMod N, ∀ v : E,
+      h i (h ((i + (d : ZMod N))) v) = h ((i + (d : ZMod N))) (h i v))
+    {γ δ : ℝ} (hδ : δ = (m * γ - (R - 1) ^ 2) / (m - R + 1))
+    (hnum : (R - 1) ^ 2 < m * γ)
+    (hgap : ∀ s : ZMod N, ∀ v : E,
+      γ * RCLike.re ⟪cyclicWindowSum h m s v, v⟫_𝕜 ≤
+        RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜)
+    (v : E) :
+    δ * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 ≤
+      RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 := by
+  classical
+  have hm1 : 1 ≤ m := le_trans hR hmR
+  -- The summed window gap.
+  have hi : m * γ * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 ≤
+      ∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜 := by
+    have hSumForm : (∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, v⟫_𝕜) =
+        m * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := re_inner_cyclicWindowSum_sum_apply h m v
+    calc m * γ * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜
+        = γ * (∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, v⟫_𝕜) := by
+          rw [hSumForm]
+          ring
+      _ ≤ ∑ s : ZMod N, RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜 := by
+          rw [Finset.mul_sum]
+          exact Finset.sum_le_sum fun s _ => hgap s v
+  -- The cyclic expansion.
+  have hii := re_inner_cyclicWindowSum_sum_eq h hh m v
+  -- The pairwise bound, summed over the ring.
+  have hiii : ∀ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v ≤
+      2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 :=
+    fun e _ => re_inner_cyclicCrossTerms_le_two h hh e v
+  -- Nonnegative cross terms at separated offsets.
+  have hiv : ∀ e ∈ Finset.Ico R m, 0 ≤ re_inner_cyclicCrossTerms h e v := by
+    intro e he
+    simp only [Finset.mem_Ico] at he
+    have he2 : e + R ≤ N := by omega
+    exact re_inner_cyclicCrossTerms_nonneg h hh hcomm he.1 he2 v
+  -- The diagonal-plus-cross lower bound on the total square.
+  have hv := re_inner_sum_two_ge_sum_cyclicCrossTerms h hh hm1 hN hmR hcomm v
+  -- The sum of the short-offset weights.
+  have hvi : 2 * (∑ e ∈ Finset.Ico 1 R, ((R : ℝ) - 1 - e)) = ((R : ℝ) - 1) * ((R : ℝ) - 2) := by
+    have hnbij : (∑ e ∈ Finset.Ico 1 R, ((R : ℝ) - 1 - e)) =
+        ∑ d ∈ Finset.range (R - 1), ((d : ℕ) : ℝ) := by
+      refine Finset.sum_nbij' (fun e => R - 1 - e) (fun d => R - 1 - d) ?_ ?_ ?_ ?_ ?_
+      · intro e he
+        simp only [Finset.mem_Ico, Finset.mem_range] at he ⊢
+        omega
+      · intro d hd
+        simp only [Finset.mem_Ico, Finset.mem_range] at hd ⊢
+        omega
+      · intro e he
+        simp only [Finset.mem_Ico] at he
+        omega
+      · intro d hd
+        simp only [Finset.mem_range] at hd
+        omega
+      · intro e he
+        have heR : e ≤ R - 1 := by
+          simp only [Finset.mem_Ico] at he
+          omega
+        change ((R : ℝ) - 1 - e) = ((R - 1 - e : ℕ) : ℝ)
+        rw [Nat.cast_sub heR, Nat.cast_sub (by omega : 1 ≤ R)]
+        norm_num
+    have hTwo : ∀ n : ℕ, 2 * (∑ d ∈ Finset.range n, ((d : ℕ) : ℝ)) =
+        ((n : ℝ) * (((n : ℝ) - 1))) := by
+      intro n
+      induction n with
+      | zero => norm_num
+      | succ n ih =>
+          rw [Finset.sum_range_succ]
+          push_cast
+          nlinarith
+    rw [hnbij, hTwo (R - 1), Nat.cast_sub hR]
+    push_cast
+    ring
+  -- Assemble the upper bound on the summed window squares.
+  have hc : (0 : ℝ) < ((m - R + 1 : ℕ) : ℝ) := by
+    have h1 : 0 < m - R + 1 := by omega
+    exact_mod_cast h1
+  have hSplit : (∑ e ∈ Finset.Ico 1 m, ((m : ℝ) - e) * re_inner_cyclicCrossTerms h e v) =
+      (((m - R + 1 : ℕ) : ℝ) * (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) +
+        ∑ e ∈ Finset.Ico 1 m, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) := by
+    have hCoeff : ∀ e ∈ Finset.Ico 1 m,
+        (((m : ℝ) - e) * re_inner_cyclicCrossTerms h e v) =
+          (((m - R + 1 : ℕ) : ℝ) * re_inner_cyclicCrossTerms h e v +
+            (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) := by
+      intro e he
+      simp only [Finset.mem_Ico] at he
+      have hc2 : ((m - R + 1 : ℕ) : ℝ) = (m : ℝ) - (R : ℝ) + 1 := by
+        have h1 : (m - R + 1 : ℕ) = (m - R : ℕ) + 1 := by omega
+        rw [h1, Nat.cast_add, Nat.cast_sub hmR]
+        push_cast
+        ring
+      have hEq : ((m : ℝ) - e) =
+          ((m - R + 1 : ℕ) : ℝ) + (((R : ℝ) - 1) - (e : ℝ)) := by
+        rw [hc2]
+        ring
+      rw [hEq]
+      ring
+    rw [Finset.sum_congr rfl hCoeff, Finset.sum_add_distrib, Finset.mul_sum]
+  have hDrop : (∑ e ∈ Finset.Ico 1 m, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) ≤
+      ((R : ℝ) - 1) * ((R : ℝ) - 2) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+    have hUnion : Finset.Ico 1 m = Finset.Ico 1 R ∪ Finset.Ico R m :=
+      (Finset.Ico_union_Ico_eq_Ico (a := 1) (b := R) (c := m) (by omega) (by omega)).symm
+    have hDisj : Disjoint (Finset.Ico 1 R) (Finset.Ico R m) := by
+      rw [Finset.disjoint_iff_inter_eq_empty]
+      refine Finset.eq_empty_iff_forall_notMem.mpr fun x hx => ?_
+      simp only [Finset.mem_inter, Finset.mem_Ico] at hx
+      omega
+    rw [hUnion, Finset.sum_union hDisj]
+    have hShort : (∑ e ∈ Finset.Ico 1 R, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) ≤
+        ((R : ℝ) - 1) * ((R : ℝ) - 2) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+      calc (∑ e ∈ Finset.Ico 1 R, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v))
+          ≤ (∑ e ∈ Finset.Ico 1 R, (((R : ℝ) - 1 - e) *
+              (2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜))) := by
+            refine Finset.sum_le_sum fun e he => ?_
+            simp only [Finset.mem_Ico] at he
+            have heR : (e : ℝ) + 1 ≤ (R : ℝ) := by
+              exact_mod_cast (show e + 1 ≤ R by omega)
+            have hCoeffNonneg : (0 : ℝ) ≤ (R : ℝ) - 1 - e := by linarith
+            exact mul_le_mul_of_nonneg_left
+              (hiii e (by simp only [Finset.mem_Ico]; omega)) hCoeffNonneg
+        _ = ((R : ℝ) - 1) * ((R : ℝ) - 2) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+            rw [← Finset.sum_mul]
+            calc
+              (∑ e ∈ Finset.Ico 1 R, (R - 1 - (e : ℝ))) *
+                  (2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜) =
+                  (2 * ∑ e ∈ Finset.Ico 1 R, (R - 1 - (e : ℝ))) *
+                    RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by ring
+              _ = _ := by rw [hvi]
+    have hLong : (∑ e ∈ Finset.Ico R m, (((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)) ≤
+        0 := by
+      refine Finset.sum_nonpos fun e he => ?_
+      have he' := Finset.mem_Ico.mp he
+      have heR : (R : ℝ) ≤ (e : ℝ) := by exact_mod_cast he'.1
+      exact mul_nonpos_of_nonpos_of_nonneg (by linarith) (hiv e he)
+    linarith
+  -- Combine.
+  have hUpper : (∑ s : ZMod N,
+      RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜) ≤
+      (((m - R + 1 : ℕ) : ℝ) * RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 +
+        ((R : ℝ) - 1) ^ 2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜) := by
+    have hCrossSumLe : (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) ≤
+        RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 - RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+      have h1 := hv
+      linarith
+    rw [hii, hSplit]
+    have hMidLe : (((m - R + 1 : ℕ) : ℝ) *
+        (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v)) ≤
+        (((m - R + 1 : ℕ) : ℝ) *
+          (RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 -
+            RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜)) :=
+      mul_le_mul_of_nonneg_left hCrossSumLe (le_of_lt hc)
+    have hCast : ((m - R + 1 : ℕ) : ℝ) = (m : ℝ) - (R : ℝ) + 1 := by
+      rw [Nat.cast_add, Nat.cast_sub hmR]
+      push_cast
+      ring
+    calc
+      (m : ℝ) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
+          (((m - R + 1 : ℕ) : ℝ) *
+            (∑ e ∈ Finset.Ico 1 m, re_inner_cyclicCrossTerms h e v) +
+          ∑ e ∈ Finset.Ico 1 m,
+            ((R : ℝ) - 1 - e) * re_inner_cyclicCrossTerms h e v)
+        ≤ (m : ℝ) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
+            ((m - R + 1 : ℕ) : ℝ) *
+              (RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 -
+                RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜) +
+            ((R : ℝ) - 1) * ((R : ℝ) - 2) *
+              RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by linarith
+      _ = ((m - R + 1 : ℕ) : ℝ) *
+            RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 +
+          ((R : ℝ) - 1) ^ 2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
+            rw [hCast]
+            ring
+  have hKey : m * γ * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 ≤
+      (((m - R + 1 : ℕ) : ℝ) * RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 +
+        ((R : ℝ) - 1) ^ 2 * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜) := hi.trans hUpper
+  have hCastC : ((m - R + 1 : ℕ) : ℝ) = (m : ℝ) - (R : ℝ) + 1 := by
+    rw [Nat.cast_add, Nat.cast_sub hmR]
+    push_cast
+    ring
+  have hDiv : (m * γ - ((R : ℝ) - 1) ^ 2) *
+      RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 / ((m : ℝ) - R + 1) ≤
+      RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 := by
+    rw [← hCastC]
+    refine (div_le_iff₀' hc).2 ?_
+    linarith
+  have _hδpos : 0 < δ := by
+    rw [hδ]
+    exact div_pos (sub_pos.mpr hnum) (by rw [← hCastC]; exact hc)
+  rw [hδ, div_mul_eq_mul_div]
+  exact hDiv
+
+/-- **Nearest-neighbor cyclic Knabe inequality.**
+
+For interaction range `R = 2`, the finite-range coefficient becomes
+`(m * γ - 1) / (m - 1)`. Thus a window gap above `1 / m` gives a positive
+periodic gap on every ring with `2 * m ≤ N`.
+
+This is the threshold of Knabe, J. Stat. Phys. 52, 627 (1988), and the form
+quoted in Pérez-García et al., arXiv:quant-ph/0608197, lines 1483-1489, and
+Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:2011.12127, lines 2194-2197. -/
+theorem quadraticForm_sum_projections_of_cyclic_knabe_nearest_neighbor
+    {N m : ℕ} [NeZero N]
+    (h : ZMod N → E →ₗ[𝕜] E) (hh : ∀ i, (h i).IsSymmetricProjection)
+    (hN : 2 * m ≤ N) (hm : 2 ≤ m)
+    (hcomm : ∀ d : ℕ, 2 ≤ d → d + 2 ≤ N → ∀ i : ZMod N, ∀ v : E,
+      h i (h ((i + (d : ZMod N))) v) = h ((i + (d : ZMod N))) (h i v))
+    {γ : ℝ} (hnum : 1 < m * γ)
+    (hgap : ∀ s : ZMod N, ∀ v : E,
+      γ * RCLike.re ⟪cyclicWindowSum h m s v, v⟫_𝕜 ≤
+        RCLike.re ⟪cyclicWindowSum h m s v, cyclicWindowSum h m s v⟫_𝕜)
+    (v : E) :
+    ((m * γ - 1) / (m - 1)) * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 ≤
+      RCLike.re ⟪(∑ i, h i) v, (∑ i, h i) v⟫_𝕜 := by
+  apply quadraticForm_sum_projections_of_cyclic_knabe h hh hN (R := 2)
+    (by norm_num) hm hcomm (γ := γ) (δ := (m * γ - 1) / (m - 1))
+  · ring
+  · norm_num
+    exact hnum
+  · exact hgap
+
+end CyclicFamily
+
+end ProjectionGeometry

--- a/TNLean/Analysis/FiniteRangeKnabe.lean
+++ b/TNLean/Analysis/FiniteRangeKnabe.lean
@@ -55,7 +55,6 @@ open scoped InnerProductSpace
 
 namespace ProjectionGeometry
 
-
 section CyclicFamily
 
 variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
@@ -348,7 +347,6 @@ theorem re_inner_sum_two_ge_sum_cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] 
           Finset.sum_congr rfl fun i _ => hInner i,
           Finset.sum_congr rfl fun i _ => hSplit0 i, Finset.sum_add_distrib, hCrossSum,
           ← hPart, hswap2]
-
 
 /-- **Finite-range cyclic Knabe inequality.**
 

--- a/TNLean/Analysis/FiniteRangeKnabe.lean
+++ b/TNLean/Analysis/FiniteRangeKnabe.lean
@@ -56,8 +56,6 @@ open scoped InnerProductSpace
 namespace ProjectionGeometry
 
 
-
-
 section CyclicFamily
 
 variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]

--- a/TNLean/Analysis/FiniteRangeKnabe.lean
+++ b/TNLean/Analysis/FiniteRangeKnabe.lean
@@ -128,7 +128,7 @@ theorem cyclicWindowSum_sq_sum_eq (h : ZMod N → E →ₗ[𝕜] E)
     _ = m • ∑ i : ZMod N, h i * h i +
         ∑ e ∈ Finset.Ico 1 m, (m - e) •
           ∑ i : ZMod N, (h i * h (i + e) + h i * h (i - e)) :=
-      sum_cyclic_window_eq (fun i j => h i * h j) m
+      ZModCyclicSums.sum_cyclic_window_eq (fun i j => h i * h j) m
     _ = m • ∑ i : ZMod N, h i +
         ∑ e ∈ Finset.Ico 1 m, (m - e) • cyclicCrossTerms h e := by
       rw [Finset.sum_congr rfl fun i _ => hDiag i]
@@ -173,7 +173,7 @@ theorem re_inner_cyclicWindowSum_sum_eq (h : ZMod N → E →ₗ[𝕜] E)
         Finset.sum_congr rfl fun s _ => hExpand s
     _ = m • ∑ i : ZMod N, T i i +
         ∑ e ∈ Finset.Ico 1 m, (m - e) • ∑ i : ZMod N, (T i (i + e) + T i (i - e)) :=
-        sum_cyclic_window_eq T m
+        ZModCyclicSums.sum_cyclic_window_eq T m
     _ = m * RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 +
         ∑ e ∈ Finset.Ico 1 m, (m - e) * reInnerCyclicCrossTerms h e v := by
         rw [hDiag, nsmul_eq_mul]
@@ -206,7 +206,7 @@ theorem re_inner_cyclicWindowSum_sum_apply (h : ZMod N → E →ₗ[𝕜] E) (m 
   have hTrans : ∀ q : Fin m, (∑ s : ZMod N, RCLike.re ⟪h (s + (q : ℕ)) v, v⟫_𝕜) =
       RCLike.re ⟪(∑ i, h i) v, v⟫_𝕜 := by
     intro q
-    have hTra := sum_comp_addRight (M := ℝ)
+    have hTra := ZModCyclicSums.sum_comp_addRight (M := ℝ)
       (fun u : ZMod N => RCLike.re ⟪h u v, v⟫_𝕜) ((q : ℕ) : ZMod N)
     rw [hTra]
     exact (re_inner_sum_apply_left h v).symm
@@ -232,7 +232,7 @@ theorem re_inner_cyclicCrossTerms_le_two (h : ZMod N → E →ₗ[𝕜] E)
     abel_nf
   have hDiag : (∑ i : ZMod N, RCLike.re ⟪h (i + e) v, v⟫_𝕜) =
       ∑ i : ZMod N, RCLike.re ⟪h i v, v⟫_𝕜 :=
-    sum_comp_addRight (fun u : ZMod N => RCLike.re ⟪h u v, v⟫_𝕜) _
+    ZModCyclicSums.sum_comp_addRight (fun u : ZMod N => RCLike.re ⟪h u v, v⟫_𝕜) _
   have hSplit : reInnerCyclicCrossTerms h e v =
       (∑ i : ZMod N, (RCLike.re ⟪h i v, h (i + e) v⟫_𝕜 +
         RCLike.re ⟪h (i + e) v, h i v⟫_𝕜)) := by
@@ -313,7 +313,7 @@ theorem re_inner_sum_two_ge_sum_cyclicCrossTerms (h : ZMod N → E →ₗ[𝕜] 
     rw [hEq, add_zero]
   -- Partition the nonzero offsets.
   set F : ZMod N → ℝ := fun u => ∑ i : ZMod N, T i (i + u) with hF
-  have hPart := sum_offset_partition F hm1 hN
+  have hPart := ZModCyclicSums.sum_offset_partition F hm1 hN
   -- The middle offsets carry nonnegative cross terms.
   have hMidNonneg : 0 ≤ ∑ k ∈ Finset.Ico m (N - m + 1), F k := by
     refine Finset.sum_nonneg fun k hk => Finset.sum_nonneg fun i _ => ?_

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -139,6 +139,27 @@ theorem re_inner_anticommutator_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
   nlinarith [hcross_lb, hamgm, hc,
     mul_nonneg (norm_nonneg (P v)) (norm_nonneg (Q v))]
 
+/-- Pairwise anticommutator upper bound for two symmetric projections.
+
+For symmetric projections `P` and `Q`, the positivity of `‖(P - Q) v‖²`
+(equivalently, of the operator `(P - Q) ^ 2`) expands, using idempotence of
+`P` and `Q`, into the anticommutator estimate `P Q + Q P ≤ P + Q` in
+quadratic-form terms:
+
+`Re ⟪P v, Q v⟫ + Re ⟪Q v, P v⟫ ≤ Re ⟪P v, v⟫ + Re ⟪Q v, v⟫.` -/
+theorem re_inner_anticommutator_le {P Q : E →ₗ[𝕜] E} (hP : P.IsSymmetricProjection)
+    (hQ : Q.IsSymmetricProjection) (v : E) :
+    RCLike.re ⟪P v, Q v⟫_𝕜 + RCLike.re ⟪Q v, P v⟫_𝕜 ≤
+      RCLike.re ⟪P v, v⟫_𝕜 + RCLike.re ⟪Q v, v⟫_𝕜 := by
+  have h0 : (0 : ℝ) ≤ RCLike.re ⟪P v - Q v, P v - Q v⟫_𝕜 :=
+    inner_self_nonneg (x := P v - Q v)
+  rw [inner_sub_sub_self] at h0
+  have h0' : (0 : ℝ) ≤ RCLike.re ⟪P v, P v⟫_𝕜 - RCLike.re ⟪P v, Q v⟫_𝕜 -
+      RCLike.re ⟪Q v, P v⟫_𝕜 + RCLike.re ⟪Q v, Q v⟫_𝕜 := by
+    simpa only [map_add, map_sub] using h0
+  rw [hP.re_inner_apply_apply_self, hQ.re_inner_apply_apply_self] at h0'
+  linarith
+
 /-- Commuting symmetric projections have nonnegative ordered cross terms.
 
 If `P` and `Q` are symmetric projections that commute pointwise, then

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2644,10 +2644,13 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
             +\operatorname{Re}\langle h_i v,h_{i-q}v\rangle\bigr)
             =\operatorname{Re}\langle Q_qv,v\rangle.
     \end{align}
-    Then
+    Then, for every vector $v$,
     \begin{align}
         \sum_s A_s^2
         &=mH+\sum_{q=1}^{m-1}(m-q)Q_q,\label{eq:cyclic_knabe_window_square}\\
+        \sum_s\operatorname{Re}\langle A_sv,A_sv\rangle
+        &=m\operatorname{Re}\langle Hv,v\rangle
+        +\sum_{q=1}^{m-1}(m-q)C_q(v),\label{eq:cyclic_knabe_window_square_form}\\
         \sum_s\operatorname{Re}\langle A_s v,v\rangle
         &=m\operatorname{Re}\langle Hv,v\rangle.
     \end{align}
@@ -2678,6 +2681,7 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
         ProjectionGeometry.re_inner_cyclicCrossTerms_nonneg,
         ProjectionGeometry.re_inner_sum_two_ge_sum_cyclicCrossTerms}
     \leanok
+    \uses{thm:cyclic_knabe_double_counting}
     For $Q_q$ as in Theorem~\ref{thm:cyclic_knabe_double_counting},
     \begin{align}
         \operatorname{Re}\langle Q_qv,v\rangle
@@ -2762,13 +2766,33 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
         m\gamma\operatorname{Re}\langle Hv,v\rangle
         &\leq\sum_s\operatorname{Re}\langle A_sv,A_sv\rangle.
     \end{align}
-    Decompose $m-q=c+(R-1-q)$. For $q<R$, the anticommutator bound and
+    Decompose $m-q=c+(R-1-q)$ and expand
+    (\ref{eq:cyclic_knabe_window_square_form}): the weights $q\leq R-2$
+    carry the coefficient $c$ plus the positive part $R-1-q$, while for
+    $q\geq R$ the coefficient $R-1-q$ is nonpositive and the cross term is
+    nonnegative, so those summands are bounded by $c\,C_q(v)$. For the
+    positive parts, the anticommutator bound and the triangular identity
     \begin{align}
         2\sum_{q=1}^{R-1}(R-1-q)&=(R-1)(R-2)
     \end{align}
-    control the positive coefficients. For $q\geq R$, the coefficient
-    $R-1-q$ is nonpositive and the cross term is nonnegative. The cyclic
-    cross-term estimate therefore gives
+    combine with the decomposition
+    \begin{align}
+        m-c+(R-1)(R-2)&=(R-1)^2,
+        \qquad c=m-R+1,
+        \label{eq:cyclic_knabe_coefficient}
+    \end{align}
+    so that
+    \begin{align}
+        \sum_s\operatorname{Re}\langle A_sv,A_sv\rangle
+        &\leq\bigl(m+(R-1)(R-2)\bigr)\operatorname{Re}\langle Hv,v\rangle
+        +c\sum_{q=1}^{m-1}C_q(v)
+        \notag\\
+        &\leq\bigl(m+(R-1)(R-2)\bigr)\operatorname{Re}\langle Hv,v\rangle
+        +c\bigl(\operatorname{Re}\langle Hv,Hv\rangle
+        -\operatorname{Re}\langle Hv,v\rangle\bigr).
+        \notag
+    \end{align}
+    The cyclic cross-term estimate therefore gives
     \begin{align}
         \sum_s\operatorname{Re}\langle A_sv,A_sv\rangle
         &\leq c\operatorname{Re}\langle Hv,Hv\rangle

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2614,18 +2614,26 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{theorem}[Cyclic window double counting]
     \label{thm:cyclic_knabe_double_counting}
-    \lean{ProjectionGeometry.sum_offset_partition,
+    \lean{ProjectionGeometry.cyclicWindowSum,
+        ProjectionGeometry.cyclicCrossTerms,
+        ProjectionGeometry.reInnerCyclicCrossTerms,
+        ProjectionGeometry.sum_comp_addRight,
+        ProjectionGeometry.sum_comp_addLeft,
+        ProjectionGeometry.sum_range_Ico_triangular,
+        ProjectionGeometry.sum_range_Ico_triangular_lower,
         ProjectionGeometry.sum_cyclic_window_eq,
         ProjectionGeometry.cyclicWindowSum_sq_sum_eq,
         ProjectionGeometry.re_inner_cyclicWindowSum_sum_eq,
         ProjectionGeometry.re_inner_cyclicWindowSum_sum_apply}
     \leanok
-    Let $h_i$, with $i\in\mathbb Z/N\mathbb Z$, be orthogonal projections.
-    Define
+    Let $h_i$, with $i\in\mathbb Z/N\mathbb Z$, be orthogonal projections. Define
     \begin{align}
-        H&=\sum_i h_i,
-        &A_s&=\sum_{a=0}^{m-1}h_{s+a},
-        &Q_q&=\sum_i\bigl(h_i h_{i+q}+h_i h_{i-q}\bigr).
+        H&=\sum_i h_i,\\
+        A_s&=\sum_{a=0}^{m-1}h_{s+a},\\
+        Q_q&=\sum_i\bigl(h_i h_{i+q}+h_i h_{i-q}\bigr),\\
+        C_q(v)&=\sum_i\bigl(\operatorname{Re}\langle h_i v,h_{i+q}v\rangle
+            +\operatorname{Re}\langle h_i v,h_{i-q}v\rangle\bigr)
+            =\operatorname{Re}\langle Q_qv,v\rangle.
     \end{align}
     Then
     \begin{align}
@@ -2638,16 +2646,26 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{proof}
     \leanok
-    For fixed offsets $a,b\in\{0,\ldots,m-1\}$, translation by $a$ sends
-    $(s+a,s+b)$ to $(i,i+b-a)$. The diagonal $a=b$ occurs $m$ times. For
-    $1\leq q<m$, each of the differences $q$ and $-q$ occurs $m-q$ times,
-    which gives~(\ref{eq:cyclic_knabe_window_square}). The second identity
-    follows by counting each $h_i$ in exactly $m$ windows.
+    For fixed offsets $a,b\in\{0,\ldots,m-1\}$, translation by $a$ gives
+    \begin{align}
+        \sum_s h_{s+a}h_{s+b}
+        &=\sum_i h_i h_{i+b-a}.\label{eq:cyclic_knabe_reindex}
+    \end{align}
+    The case $a=b$ contributes $mH$, while each of the differences
+    $b-a=q$ and $b-a=-q$ contributes $(m-q)Q_q$. Summing
+    (\ref{eq:cyclic_knabe_reindex}) over $a$ and $b$ gives
+    (\ref{eq:cyclic_knabe_window_square}). Translation invariance also gives
+    \begin{align}
+        \sum_s \operatorname{Re}\langle A_s v,v\rangle
+        &=m\operatorname{Re}\langle Hv,v\rangle.
+        \label{eq:cyclic_knabe_window_linear}
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Cyclic cross-term estimates]
     \label{thm:cyclic_knabe_cross_estimates}
-    \lean{ProjectionGeometry.re_inner_cyclicCrossTerms_le_two,
+    \lean{ProjectionGeometry.sum_offset_partition,
+        ProjectionGeometry.re_inner_cyclicCrossTerms_le_two,
         ProjectionGeometry.re_inner_cyclicCrossTerms_nonneg,
         ProjectionGeometry.re_inner_sum_two_ge_sum_cyclicCrossTerms}
     \leanok
@@ -2658,7 +2676,7 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     \end{align}
     Suppose that $h_i$ and $h_{i+d}$ commute whenever
     $R\leq d\leq N-R$. Then the cross term is nonnegative for these offsets.
-    If $R\leq m$ and $2m\leq N$, it follows that
+    If $1\leq m$, $R\leq m$, and $2m\leq N$, it follows that
     \begin{align}
         \operatorname{Re}\langle Hv,v\rangle
         +\sum_{q=1}^{m-1}\operatorname{Re}\langle Q_qv,v\rangle
@@ -2670,18 +2688,38 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     \leanok
     \uses{thm:projection_anticommutator_upper_bound,
         thm:cyclic_knabe_double_counting}
+    Translation of the reversed leg gives
+    \begin{align}
+        \sum_i\operatorname{Re}\langle h_{i+q}v,h_i v\rangle
+        &=\sum_i\operatorname{Re}\langle h_i v,h_{i-q}v\rangle.
+        \label{eq:cyclic_knabe_reversed_leg}
+    \end{align}
     Summing Theorem~\ref{thm:projection_anticommutator_upper_bound} over $i$
-    proves the upper bound. Commuting projections have nonnegative products.
-    Partition the nonzero cyclic offsets into $1\leq q<m$, their reflections
-    $N-q$, and $m\leq q\leq N-m$; the last group is nonnegative.
+    and using (\ref{eq:cyclic_knabe_reversed_leg}) proves the upper bound.
+    If $h_i$ and $h_{i+d}$ commute, their symmetry and idempotence give
+    \begin{align}
+        0&\leq\operatorname{Re}\langle h_i v,h_{i+d}v\rangle.
+        \label{eq:cyclic_knabe_commuting_nonnegative}
+    \end{align}
+    Partitioning the nonzero cyclic offsets into $1\leq q<m$, their
+    reflections $N-q$, and $m\leq k\leq N-m$ gives
+    \begin{align}
+        \operatorname{Re}\langle Hv,Hv\rangle
+        &=\operatorname{Re}\langle Hv,v\rangle
+          +\sum_{q=1}^{m-1}\operatorname{Re}\langle Q_qv,v\rangle
+          +\sum_{k=m}^{N-m}\sum_i
+            \operatorname{Re}\langle h_i v,h_{i+k}v\rangle.
+        \label{eq:cyclic_knabe_offset_partition}
+    \end{align}
+    The last sum in (\ref{eq:cyclic_knabe_offset_partition}) is nonnegative by
+    (\ref{eq:cyclic_knabe_commuting_nonnegative}), which proves the lower bound.
 \end{proof}
 
 \begin{theorem}[Finite-range cyclic Knabe inequality]
     \label{thm:finite_range_cyclic_knabe}
     \lean{ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe}
     \leanok
-    \uses{thm:cyclic_knabe_double_counting,
-        thm:cyclic_knabe_cross_estimates}
+    \uses{thm:cyclic_knabe_double_counting}
     Let $1\leq R\leq m$, $2m\leq N$, and let $h_i$ be cyclically indexed
     orthogonal projections such that $h_i$ commutes with $h_{i+d}$ whenever
     $R\leq d\leq N-R$. Suppose that, for every $s$ and $v$,
@@ -2699,8 +2737,9 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
         &\leq\operatorname{Re}\langle Hv,Hv\rangle.
     \end{align}
     The coefficient for general $R$ is derived here and is not attributed to
-    the cited papers. Its source comparison is recorded in
-    \path{docs/paper-gaps/knabe_finite_range_coefficient.tex}.
+    the cited papers.
+    % Its source comparison is recorded in
+    % docs/paper-gaps/knabe_finite_range_coefficient.tex.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2617,11 +2617,11 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     \lean{ProjectionGeometry.cyclicWindowSum,
         ProjectionGeometry.cyclicCrossTerms,
         ProjectionGeometry.reInnerCyclicCrossTerms,
-        ProjectionGeometry.sum_comp_addRight,
-        ProjectionGeometry.sum_comp_addLeft,
-        ProjectionGeometry.sum_range_Ico_triangular,
-        ProjectionGeometry.sum_range_Ico_triangular_lower,
-        ProjectionGeometry.sum_cyclic_window_eq,
+        ZModCyclicSums.sum_comp_addRight,
+        ZModCyclicSums.sum_comp_addLeft,
+        ZModCyclicSums.sum_range_Ico_triangular,
+        ZModCyclicSums.sum_range_Ico_triangular_lower,
+        ZModCyclicSums.sum_cyclic_window_eq,
         ProjectionGeometry.cyclicWindowSum_sq_sum_eq,
         ProjectionGeometry.re_inner_cyclicWindowSum_sum_eq,
         ProjectionGeometry.re_inner_cyclicWindowSum_sum_apply}
@@ -2664,7 +2664,7 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{theorem}[Cyclic cross-term estimates]
     \label{thm:cyclic_knabe_cross_estimates}
-    \lean{ProjectionGeometry.sum_offset_partition,
+    \lean{ZModCyclicSums.sum_offset_partition,
         ProjectionGeometry.re_inner_cyclicCrossTerms_le_two,
         ProjectionGeometry.re_inner_cyclicCrossTerms_nonneg,
         ProjectionGeometry.re_inner_sum_two_ge_sum_cyclicCrossTerms}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2666,7 +2666,10 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     The case $a=b$ contributes $mH$, while each of the differences
     $b-a=q$ and $b-a=-q$ contributes $(m-q)Q_q$. Summing
     (\ref{eq:cyclic_knabe_reindex}) over $a$ and $b$ gives
-    (\ref{eq:cyclic_knabe_window_square}). Translation invariance also gives
+    (\ref{eq:cyclic_knabe_window_square}). Taking the quadratic form of
+    that operator identity at $v$ turns each product $h_ih_{i\pm q}$ into
+    the pair $\operatorname{Re}\langle h_iv,h_{i\pm q}v\rangle$, giving
+    (\ref{eq:cyclic_knabe_window_square_form}). Translation invariance also gives
     \begin{align}
         \sum_s \operatorname{Re}\langle A_s v,v\rangle
         &=m\operatorname{Re}\langle Hv,v\rangle.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2607,7 +2607,7 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{proof}
     \leanok
-    Symmetry and idempotence give
+    Positivity of the inner product gives
     \begin{align}
         0
         &\leq \operatorname{Re}\langle(P-Q)v,(P-Q)v\rangle,\\
@@ -2617,7 +2617,8 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
           -\operatorname{Re}\langle Qv,Pv\rangle
           +\operatorname{Re}\langle Qv,v\rangle.
     \end{align}
-    Rearranging the second line proves the claim.
+    Symmetry and idempotence expand the left-hand side into the second line;
+    rearranging it proves the claim.
 \end{proof}
 
 \begin{theorem}[Cyclic window double counting]
@@ -2627,7 +2628,6 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
         ProjectionGeometry.reInnerCyclicCrossTerms,
         ProjectionGeometry.reInnerCyclicCrossTerms_eq_re_inner_cyclicCrossTerms,
         ZModCyclicSums.sum_comp_addRight,
-        ZModCyclicSums.sum_comp_addLeft,
         ZModCyclicSums.sum_range_Ico_triangular,
         ZModCyclicSums.sum_range_Ico_triangular_lower,
         ZModCyclicSums.sum_cyclic_window_eq,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2607,9 +2607,17 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 
 \begin{proof}
     \leanok
-    Expanding the nonnegative quantity
-    $\operatorname{Re}\langle(P-Q)v,(P-Q)v\rangle$ and using
-    $P^2=P$ and $Q^2=Q$ gives the inequality.
+    Symmetry and idempotence give
+    \begin{align}
+        0
+        &\leq \operatorname{Re}\langle(P-Q)v,(P-Q)v\rangle,\\
+        \operatorname{Re}\langle(P-Q)v,(P-Q)v\rangle
+        &=\operatorname{Re}\langle Pv,v\rangle
+          -\operatorname{Re}\langle Pv,Qv\rangle
+          -\operatorname{Re}\langle Qv,Pv\rangle
+          +\operatorname{Re}\langle Qv,v\rangle.
+    \end{align}
+    Rearranging the second line proves the claim.
 \end{proof}
 
 \begin{theorem}[Cyclic window double counting]
@@ -2617,6 +2625,7 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     \lean{ProjectionGeometry.cyclicWindowSum,
         ProjectionGeometry.cyclicCrossTerms,
         ProjectionGeometry.reInnerCyclicCrossTerms,
+        ProjectionGeometry.reInnerCyclicCrossTerms_eq_re_inner_cyclicCrossTerms,
         ZModCyclicSums.sum_comp_addRight,
         ZModCyclicSums.sum_comp_addLeft,
         ZModCyclicSums.sum_range_Ico_triangular,
@@ -2687,7 +2696,8 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
 \begin{proof}
     \leanok
     \uses{thm:projection_anticommutator_upper_bound,
-        thm:cyclic_knabe_double_counting}
+        thm:cyclic_knabe_double_counting,
+        rem:projection_geometry_rowsum_identities}
     Translation of the reversed leg gives
     \begin{align}
         \sum_i\operatorname{Re}\langle h_{i+q}v,h_i v\rangle

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -2591,6 +2591,167 @@ $N=L$. They give no gap estimate for $N>L$ and no periodic coercivity.
     $1-2(7/16)=1/8$.
 \end{proof}
 
+\begin{theorem}[Anticommutator bound for two projections]
+    \label{thm:projection_anticommutator_upper_bound}
+    \lean{LinearMap.IsSymmetricProjection.re_inner_anticommutator_le}
+    \leanok
+    Let $P$ and $Q$ be orthogonal projections on a real or complex Hilbert
+    space. For every vector $v$,
+    \begin{align}
+        \operatorname{Re}\langle Pv,Qv\rangle
+        +\operatorname{Re}\langle Qv,Pv\rangle
+        &\leq \operatorname{Re}\langle Pv,v\rangle
+        +\operatorname{Re}\langle Qv,v\rangle.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Expanding the nonnegative quantity
+    $\operatorname{Re}\langle(P-Q)v,(P-Q)v\rangle$ and using
+    $P^2=P$ and $Q^2=Q$ gives the inequality.
+\end{proof}
+
+\begin{theorem}[Cyclic window double counting]
+    \label{thm:cyclic_knabe_double_counting}
+    \lean{ProjectionGeometry.sum_offset_partition,
+        ProjectionGeometry.sum_cyclic_window_eq,
+        ProjectionGeometry.cyclicWindowSum_sq_sum_eq,
+        ProjectionGeometry.re_inner_cyclicWindowSum_sum_eq,
+        ProjectionGeometry.re_inner_cyclicWindowSum_sum_apply}
+    \leanok
+    Let $h_i$, with $i\in\mathbb Z/N\mathbb Z$, be orthogonal projections.
+    Define
+    \begin{align}
+        H&=\sum_i h_i,
+        &A_s&=\sum_{a=0}^{m-1}h_{s+a},
+        &Q_q&=\sum_i\bigl(h_i h_{i+q}+h_i h_{i-q}\bigr).
+    \end{align}
+    Then
+    \begin{align}
+        \sum_s A_s^2
+        &=mH+\sum_{q=1}^{m-1}(m-q)Q_q,\label{eq:cyclic_knabe_window_square}\\
+        \sum_s\operatorname{Re}\langle A_s v,v\rangle
+        &=m\operatorname{Re}\langle Hv,v\rangle.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For fixed offsets $a,b\in\{0,\ldots,m-1\}$, translation by $a$ sends
+    $(s+a,s+b)$ to $(i,i+b-a)$. The diagonal $a=b$ occurs $m$ times. For
+    $1\leq q<m$, each of the differences $q$ and $-q$ occurs $m-q$ times,
+    which gives~(\ref{eq:cyclic_knabe_window_square}). The second identity
+    follows by counting each $h_i$ in exactly $m$ windows.
+\end{proof}
+
+\begin{theorem}[Cyclic cross-term estimates]
+    \label{thm:cyclic_knabe_cross_estimates}
+    \lean{ProjectionGeometry.re_inner_cyclicCrossTerms_le_two,
+        ProjectionGeometry.re_inner_cyclicCrossTerms_nonneg,
+        ProjectionGeometry.re_inner_sum_two_ge_sum_cyclicCrossTerms}
+    \leanok
+    For $Q_q$ as in Theorem~\ref{thm:cyclic_knabe_double_counting},
+    \begin{align}
+        \operatorname{Re}\langle Q_qv,v\rangle
+        &\leq2\operatorname{Re}\langle Hv,v\rangle.
+    \end{align}
+    Suppose that $h_i$ and $h_{i+d}$ commute whenever
+    $R\leq d\leq N-R$. Then the cross term is nonnegative for these offsets.
+    If $R\leq m$ and $2m\leq N$, it follows that
+    \begin{align}
+        \operatorname{Re}\langle Hv,v\rangle
+        +\sum_{q=1}^{m-1}\operatorname{Re}\langle Q_qv,v\rangle
+        &\leq\operatorname{Re}\langle Hv,Hv\rangle.
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:projection_anticommutator_upper_bound,
+        thm:cyclic_knabe_double_counting}
+    Summing Theorem~\ref{thm:projection_anticommutator_upper_bound} over $i$
+    proves the upper bound. Commuting projections have nonnegative products.
+    Partition the nonzero cyclic offsets into $1\leq q<m$, their reflections
+    $N-q$, and $m\leq q\leq N-m$; the last group is nonnegative.
+\end{proof}
+
+\begin{theorem}[Finite-range cyclic Knabe inequality]
+    \label{thm:finite_range_cyclic_knabe}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe}
+    \leanok
+    \uses{thm:cyclic_knabe_double_counting,
+        thm:cyclic_knabe_cross_estimates}
+    Let $1\leq R\leq m$, $2m\leq N$, and let $h_i$ be cyclically indexed
+    orthogonal projections such that $h_i$ commutes with $h_{i+d}$ whenever
+    $R\leq d\leq N-R$. Suppose that, for every $s$ and $v$,
+    \begin{align}
+        \gamma\operatorname{Re}\langle A_sv,v\rangle
+        &\leq\operatorname{Re}\langle A_sv,A_sv\rangle.
+    \end{align}
+    If $(R-1)^2<m\gamma$, then, with
+    \begin{align}
+        \delta&=\frac{m\gamma-(R-1)^2}{m-R+1}>0,
+    \end{align}
+    one has
+    \begin{align}
+        \delta\operatorname{Re}\langle Hv,v\rangle
+        &\leq\operatorname{Re}\langle Hv,Hv\rangle.
+    \end{align}
+    The coefficient for general $R$ is derived here and is not attributed to
+    the cited papers. Its source comparison is recorded in
+    \path{docs/paper-gaps/knabe_finite_range_coefficient.tex}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cyclic_knabe_double_counting,
+        thm:cyclic_knabe_cross_estimates}
+    Put $c=m-R+1$. Summing the window gaps and applying
+    Theorem~\ref{thm:cyclic_knabe_double_counting} gives
+    \begin{align}
+        m\gamma\operatorname{Re}\langle Hv,v\rangle
+        &\leq\sum_s\operatorname{Re}\langle A_sv,A_sv\rangle.
+    \end{align}
+    Decompose $m-q=c+(R-1-q)$. For $q<R$, the anticommutator bound and
+    \begin{align}
+        2\sum_{q=1}^{R-1}(R-1-q)&=(R-1)(R-2)
+    \end{align}
+    control the positive coefficients. For $q\geq R$, the coefficient
+    $R-1-q$ is nonpositive and the cross term is nonnegative. The cyclic
+    cross-term estimate therefore gives
+    \begin{align}
+        \sum_s\operatorname{Re}\langle A_sv,A_sv\rangle
+        &\leq c\operatorname{Re}\langle Hv,Hv\rangle
+          +(R-1)^2\operatorname{Re}\langle Hv,v\rangle.
+    \end{align}
+    Rearranging and dividing by $c>0$ proves the claim.
+\end{proof}
+
+\begin{theorem}[Nearest-neighbor cyclic Knabe inequality]
+    \label{thm:nearest_neighbor_cyclic_knabe}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe_nearest_neighbor}
+    \leanok
+    \uses{thm:finite_range_cyclic_knabe}
+    Under the hypotheses of Theorem~\ref{thm:finite_range_cyclic_knabe} with
+    $R=2$, if $1<m\gamma$, then
+    \begin{align}
+        \frac{m\gamma-1}{m-1}\operatorname{Re}\langle Hv,v\rangle
+        &\leq\operatorname{Re}\langle Hv,Hv\rangle.
+    \end{align}
+    Equivalently, the open-window threshold is $\gamma>1/m$. This is Knabe's
+    nearest-neighbor threshold~\cite{Knabe1988Energy}, quoted in
+    \cite[lines~1483--1489]{PerezGarcia2007Matrix} and
+    \cite[lines~2194--2197]{Cirac2021Matrix}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:finite_range_cyclic_knabe}
+    Substitute $R=2$ into the coefficient of
+    Theorem~\ref{thm:finite_range_cyclic_knabe}.
+\end{proof}
+
 \begin{lemma}[Positive gap transfer under Loewner domination]
     \label{lem:positive_gap_transfer_loewner}
     \lean{LinearMap.IsPositive.re_inner_ge_of_norm_gap,

--- a/docs/paper-gaps/knabe_finite_range_coefficient.tex
+++ b/docs/paper-gaps/knabe_finite_range_coefficient.tex
@@ -32,7 +32,7 @@ below.
 
 \section{Finite-range derivation}
 
-Let $h_i$ be cyclically indexed orthogonal projections, let
+Let $h_i$, $i\in\mathbb Z/N\mathbb Z$, be orthogonal projections, let
 $H=\sum_i h_i$, and define
 \begin{align}
     A_s&=\sum_{a=0}^{m-1}h_{s+a},

--- a/docs/paper-gaps/knabe_finite_range_coefficient.tex
+++ b/docs/paper-gaps/knabe_finite_range_coefficient.tex
@@ -1,0 +1,73 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Finite-Range Cyclic Knabe Coefficient}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\section{Source statements}
+
+Knabe's finite-size criterion gives the nearest-neighbor threshold
+$\gamma>1/m$ and periodic coefficient
+\begin{align}
+    \delta&=\frac{m\gamma-1}{m-1}.
+\end{align}
+This criterion originates in \cite{Knabe1988Energy}. It is quoted for MPS
+parent Hamiltonians in lines~1483--1489 of the local source for
+\cite{PerezGarcia2007Matrix} and in lines~2194--2197 of the local source for
+\cite{Cirac2021Matrix}. These passages do not state the general finite-range
+coefficient below.
+
+\section{Finite-range derivation}
+
+Let $h_i$ be cyclically indexed orthogonal projections, let
+$H=\sum_i h_i$, and define
+\begin{align}
+    A_s&=\sum_{a=0}^{m-1}h_{s+a},
+    &Q_q&=\sum_i\bigl(h_i h_{i+q}+h_i h_{i-q}\bigr).
+\end{align}
+Assume $1\leq R\leq m$, $N\geq2m$, and that terms at cyclic separation at
+least $R$ commute. Cyclic double counting gives
+\begin{align}
+    \sum_s A_s^2&=mH+\sum_{q=1}^{m-1}(m-q)Q_q.
+\end{align}
+The projection inequality $h_i h_j+h_j h_i\leq h_i+h_j$ gives $Q_q\leq2H$.
+The separated terms satisfy $Q_q\geq0$ for $q\geq R$, and expansion of $H^2$
+gives
+\begin{align}
+    H+\sum_{q=1}^{m-1}Q_q&\leq H^2.
+\end{align}
+Writing $c=m-R+1$ and $m-q=c+(R-1-q)$ yields
+\begin{align}
+    \sum_s A_s^2
+    &\leq cH^2+(R-1)^2H.
+\end{align}
+Consequently, the local inequalities $A_s^2\geq\gamma A_s$ imply
+\begin{align}
+    H^2&\geq\frac{m\gamma-(R-1)^2}{m-R+1}H.
+\end{align}
+The condition $(R-1)^2<m\gamma$ makes this coefficient positive. At $R=2$
+it reduces to Knabe's nearest-neighbor coefficient.
+
+\section{Verdict}
+
+The nearest-neighbor threshold is source-attributed as above. The coefficient
+for arbitrary finite range is a TNLean derivation, not a statement attributed
+to Knabe, Nachtergaele, or the two MPS reviews. The abstract result concerns a
+cyclic family of projections. Applying it to every sufficiently large MPS
+parent Hamiltonian still requires a uniform gap for the corresponding
+nonwrapping open interaction.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/knabe_finite_range_coefficient.tex
+++ b/docs/paper-gaps/knabe_finite_range_coefficient.tex
@@ -65,9 +65,9 @@ it reduces to Knabe's nearest-neighbor coefficient.
 
 The nearest-neighbor threshold is source-attributed as above. The coefficient
 for arbitrary finite range is a TNLean derivation, not a statement attributed
-to Knabe, to Nachtergaele's martingale finite-size criterion
-\cite[Equations~(2.4)--(2.5) and Theorem~3]{Nachtergaele1996Spectral}, or to
-the two MPS reviews. The abstract result concerns a cyclic family of
+to Knabe, to the gap-from-hypotheses criterion
+\cite[Theorem~2.1(i)]{Nachtergaele1996Spectral} of Nachtergaele's martingale
+argument, or to the two MPS reviews. The abstract result concerns a cyclic family of
 projections. Applying it to every sufficiently large MPS parent Hamiltonian
 still requires a uniform gap for the corresponding nonwrapping open
 interaction.

--- a/docs/paper-gaps/knabe_finite_range_coefficient.tex
+++ b/docs/paper-gaps/knabe_finite_range_coefficient.tex
@@ -49,8 +49,29 @@ gives
 \begin{align}
     H+\sum_{q=1}^{m-1}Q_q&\leq H^2.
 \end{align}
-Writing $c=m-R+1$ and $m-q=c+(R-1-q)$ yields
+Set $c=m-R+1$, so that $m-q=c+(R-1-q)$. The correction term splits as
 \begin{align}
+    \sum_{q=1}^{m-1}(R-1-q)Q_q
+    &=\sum_{q=1}^{R-2}(R-1-q)Q_q
+      +\sum_{q=R}^{m-1}(R-1-q)Q_q,\\
+    \sum_{q=1}^{R-2}(R-1-q)Q_q
+    &\leq 2H\sum_{q=1}^{R-2}(R-1-q),\\
+    \sum_{q=R}^{m-1}(R-1-q)Q_q
+    &\leq0.
+\end{align}
+Indeed, the first sum has positive weights and $Q_q\leq2H$ termwise. In the
+second sum, $R-1-q\leq0$ and $Q_q\geq0$: the latter estimate applies because
+$R\leq q\leq m-1\leq N-R$. The triangular sum is
+\begin{align}
+    \sum_{q=1}^{R-2}(R-1-q)
+    &=\frac{(R-1)(R-2)}{2}.
+\end{align}
+Therefore
+\begin{align}
+    \sum_s A_s^2
+    &\leq cH^2+\bigl(m-c+(R-1)(R-2)\bigr)H,\\
+    m-c+(R-1)(R-2)
+    &=(R-1)^2,\\
     \sum_s A_s^2
     &\leq cH^2+(R-1)^2H.
 \end{align}
@@ -64,7 +85,10 @@ it reduces to Knabe's nearest-neighbor coefficient.
 \section{Verdict}
 
 The nearest-neighbor threshold is source-attributed as above. The coefficient
-for arbitrary finite range is a TNLean derivation, not a statement attributed
+for arbitrary finite range is a TNLean derivation, formalized by the cyclic
+projection theorem.\footnote{Formal declaration:
+\leanid{ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe}.}
+It is not a statement attributed
 to Knabe, to the gap-from-hypotheses criterion
 \cite[Theorem~2.1(i)]{Nachtergaele1996Spectral} of Nachtergaele's martingale
 argument, or to the two MPS reviews. The abstract result concerns a cyclic family of

--- a/docs/paper-gaps/knabe_finite_range_coefficient.tex
+++ b/docs/paper-gaps/knabe_finite_range_coefficient.tex
@@ -16,16 +16,19 @@
 
 \section{Source statements}
 
-Knabe's finite-size criterion gives the nearest-neighbor threshold
-$\gamma>1/m$ and periodic coefficient
-\begin{align}
-    \delta&=\frac{m\gamma-1}{m-1}.
-\end{align}
-This criterion originates in \cite{Knabe1988Energy}. It is quoted for MPS
-parent Hamiltonians in lines~1483--1489 of the local source for
+For a nearest-neighbor chain, let $m$ be the number of local interaction
+terms in each window and let $\gamma$ be the gap of the corresponding open
+window Hamiltonian. Knabe's finite-size criterion gives the threshold
+$\gamma>1/m$. This threshold originates in \cite{Knabe1988Energy}. It is
+quoted for MPS parent Hamiltonians in lines~1483--1489 of the local source for
 \cite{PerezGarcia2007Matrix} and in lines~2194--2197 of the local source for
-\cite{Cirac2021Matrix}. These passages do not state the general finite-range
-coefficient below.
+\cite{Cirac2021Matrix}. The quoted passages state only the threshold. The
+closed-form periodic coefficient
+\begin{align}
+    \delta&=\frac{m\gamma-1}{m-1}
+\end{align}
+is obtained by the present derivation, as the range-two case of the coefficient
+below.
 
 \section{Finite-range derivation}
 
@@ -62,10 +65,12 @@ it reduces to Knabe's nearest-neighbor coefficient.
 
 The nearest-neighbor threshold is source-attributed as above. The coefficient
 for arbitrary finite range is a TNLean derivation, not a statement attributed
-to Knabe, Nachtergaele, or the two MPS reviews. The abstract result concerns a
-cyclic family of projections. Applying it to every sufficiently large MPS
-parent Hamiltonian still requires a uniform gap for the corresponding
-nonwrapping open interaction.
+to Knabe, to Nachtergaele's martingale finite-size criterion
+\cite[Equations~(2.4)--(2.5) and Theorem~3]{Nachtergaele1996Spectral}, or to
+the two MPS reviews. The abstract result concerns a cyclic family of
+projections. Applying it to every sufficiently large MPS parent Hamiltonian
+still requires a uniform gap for the corresponding nonwrapping open
+interaction.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/references.bib
+++ b/docs/paper-gaps/references.bib
@@ -283,3 +283,26 @@
   eprint       = {1703.09188},
   eprinttype   = {arxiv},
 }
+
+@article{PerezGarcia2007Matrix,
+  author       = {P{\'e}rez-Garc{\'i}a, D. and Verstraete, F. and Wolf, M. M. and Cirac, J. I.},
+  title        = {Matrix Product State Representations},
+  journal      = {Quantum Information \& Computation},
+  volume       = {7},
+  number       = {5},
+  pages        = {401--430},
+  year         = {2007},
+  eprint       = {quant-ph/0608197},
+  eprinttype   = {arxiv},
+}
+
+@article{Knabe1988Energy,
+  author       = {Knabe, Stefan},
+  title        = {Energy gaps and elementary excitations for certain {VBS}-quantum antiferromagnets},
+  journal      = {Journal of Statistical Physics},
+  volume       = {52},
+  number       = {3--4},
+  pages        = {627--638},
+  year         = {1988},
+  doi          = {10.1007/BF01019721},
+}


### PR DESCRIPTION
## What changed

Abstract one-dimensional finite-range Knabe inequality for a cyclic family of symmetric projections (generic infrastructure, no MPS content in the abstract statements), in new module `TNLean/Analysis/FiniteRangeKnabe.lean`:

- `LinearMap.IsSymmetricProjection.re_inner_anticommutator_le`: the pairwise projection inequality $P Q + Q P \le P + Q$ in quadratic-form shape (from $(P-Q)^2 \ge 0$ and idempotence).
- `ProjectionGeometry.sum_cyclic_window_eq` / `cyclicWindowSum_sq_sum_eq`: the cyclic double-counting identity and the operator expansion $\sum_s A_s^2 = m\bullet H + \sum_{e=1}^{m-1}(m-e)\bullet Q_e$ with $Q_e = \sum_i (h_i h_{i+e} + h_i h_{i-e})$.
- `ProjectionGeometry.quadraticForm_sum_projections_of_cyclic_knabe`: under $1 \le R \le m$, $N \ge 2m$, cyclic commutation at separation $\ge R$, uniform window gap $A_s^2 \ge \gamma A_s$, and $(R-1)^2 < m\gamma$, the total satisfies $\delta\,\operatorname{Re}\langle Hv,v\rangle \le \operatorname{Re}\langle Hv,Hv\rangle$ with $\delta = (m\gamma-(R-1)^2)/(m-R+1) > 0$.
- Nearest-neighbor corollary $R = 2$: $\delta = (m\gamma-1)/(m-1)$.

Blueprint: formula-first ch13 entries with matching theorem environments and dependency-linked proofs; new paper-gap note `docs/paper-gaps/knabe_finite_range_coefficient.tex` records the finite-range coefficient as a TNLean derivation (nearest-neighbor threshold attributed to Knabe 1988 / quant-ph/0608197 / 2011.12127; no Nachtergaele attribution). One intermediate arithmetic identity in the earlier draft was corrected ($m - c + (R-1)(R-2) = (R-1)^2$ with $c = m-R+1$); the issue's final coefficient stands.

## Validation

- `lake build TNLean.Analysis.FiniteRangeKnabe TNLean.Analysis`: green, no new warnings; axioms only propext/Classical.choice/Quot.sound.
- Double `lualatex print.tex`: zero undefined References.
- Blueprint sync 7862/7862; `leanblueprint checkdecls`: zero missing.

Closes #6430 (advances #6412, #6374)