### PR TITLE
feat(QCA): identify finite and algebraic relative commutants

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -18,5 +18,6 @@ import TNLean.QCA.LocalNorm
 import TNLean.QCA.QuasiLocal
 import TNLean.QCA.QuasiLocalTranslation
 import TNLean.QCA.RegionSumset
+import TNLean.QCA.RelativeCommutant
 import TNLean.QCA.Translation
 import TNLean.QCA.TranslationCovariance

--- a/TNLean/QCA/RelativeCommutant.lean
+++ b/TNLean/QCA/RelativeCommutant.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.ScalarCommutant
+import TNLean.QCA.DisjointSupport
+
+/-!
+# Relative commutants of finite-region observable algebras
+
+Inside the observable algebra of a finite region, the commutant of the full matrix algebra on a
+complementary subregion is exactly the matrix algebra on the retained subregion. The corresponding
+statement in the algebraic local algebra characterizes finite support by commutation with every
+observable supported in a disjoint finite region.
+
+These are source-independent finite-dimensional and algebraic-local facts. They do not assert the
+norm-completed support characterization of Schumacher--Werner.
+
+## Main results
+
+* `SpinChain.mem_range_localInclusion_iff_commute_complement` identifies the finite relative
+  commutant.
+* `SpinChain.supportedIn_iff_commute_disjoint` characterizes algebraic-local support by
+  commutation with all observables having disjoint finite support.
+-/
+
+open scoped Kronecker
+
+namespace SpinChain
+
+namespace Config
+
+private lemma splitComplement_snd_eq_iff {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
+    (x y : Config d Γ) :
+    (splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) x).2 =
+        (splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) y).2 ↔
+      restrict h x = restrict h y := by
+  constructor
+  · intro hxy
+    funext i
+    exact congrFun hxy ⟨i, Finset.mem_sdiff.mpr ⟨h i.2, by simp [i.2]⟩⟩
+  · intro hxy
+    funext i
+    have hiΛ : (i : ℤ) ∈ Λ := by
+      by_contra hi
+      exact (Finset.mem_sdiff.mp i.2).2
+        (Finset.mem_sdiff.mpr ⟨(Finset.mem_sdiff.mp i.2).1, hi⟩)
+    exact congrFun hxy ⟨i, hiΛ⟩
+
+private lemma restrict_sdiff_splitEquiv_symm {d : ℕ} {Λ Γ : Finset ℤ} (h : Λ ⊆ Γ)
+    (p : Config d Λ × Config d (Γ \ Λ)) :
+    restrict (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) ((splitEquiv h).symm p) = p.2 := by
+  have hp := congrArg Prod.snd ((splitEquiv h).apply_symm_apply p)
+  exact hp
+
+end Config
+
+section Finite
+
+variable {d : ℕ} {Λ Γ : Finset ℤ}
+
+private lemma reindex_localInclusion (h : Λ ⊆ Γ) (A : LocalAlgebra d Λ) :
+    CStarMatrix.reindexₐ ℂ ℂ (Config.splitEquiv h) (localInclusion h A) =
+      CStarMatrix.leftKroneckerEmbed (n := Config d (Γ \ Λ)) A := by
+  rw [localInclusion]
+  simp
+
+private lemma reindex_localInclusion_sdiff (h : Λ ⊆ Γ)
+    (B : LocalAlgebra d (Γ \ Λ)) :
+    CStarMatrix.reindexₐ ℂ ℂ (Config.splitEquiv h)
+        (localInclusion (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) B) =
+      CStarMatrix.ofMatrix
+        (Matrix.rightKroneckerEmbed (m := Config d Λ) (CStarMatrix.ofMatrix.symm B)) := by
+  ext p q
+  rw [CStarMatrix.reindexₐ_apply, Matrix.reindex_apply]
+  change localInclusion (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) B
+      ((Config.splitEquiv h).symm p) ((Config.splitEquiv h).symm q) = _
+  rw [localInclusion_apply]
+  rw [Config.restrict_sdiff_splitEquiv_symm h,
+    Config.restrict_sdiff_splitEquiv_symm h]
+  simp only [CStarMatrix.ofMatrix_apply, Matrix.rightKroneckerEmbed_apply,
+    Matrix.kroneckerMap_apply, Matrix.one_apply]
+  have hp : Config.restrict h ((Config.splitEquiv h).symm p) = p.1 :=
+    congrArg Prod.fst ((Config.splitEquiv h).apply_symm_apply p)
+  have hq : Config.restrict h ((Config.splitEquiv h).symm q) = q.1 :=
+    congrArg Prod.fst ((Config.splitEquiv h).apply_symm_apply q)
+  have heq :
+      (Config.splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ)
+          ((Config.splitEquiv h).symm p)).2 =
+        (Config.splitEquiv (Finset.sdiff_subset : Γ \ Λ ⊆ Γ)
+          ((Config.splitEquiv h).symm q)).2 ↔ p.1 = q.1 := by
+    rw [Config.splitComplement_snd_eq_iff h, hp, hq]
+  by_cases hpq : p.1 = q.1
+  · have hsnd := heq.mpr hpq
+    simp [hpq, hsnd]
+  · have hsnd := mt heq.mp hpq
+    simp [hpq, hsnd]
+
+/-- In a finite-region observable algebra, the commutant of the full algebra on the complement
+of a retained region is exactly the image of the retained-region inclusion.
+
+This is elementary finite tensor-factor infrastructure and is not a separately named theorem of
+arXiv:1703.09188 or Schumacher--Werner. -/
+theorem mem_range_localInclusion_iff_commute_complement (h : Λ ⊆ Γ)
+    (A : LocalAlgebra d Γ) :
+    A ∈ Set.range (localInclusion (d := d) h) ↔
+      ∀ B : LocalAlgebra d (Γ \ Λ),
+        Commute A (localInclusion (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) B) := by
+  constructor
+  · rintro ⟨AΛ, rfl⟩ B
+    rw [commute_iff_eq]
+    let e := CStarMatrix.reindexₐ ℂ ℂ (Config.splitEquiv (d := d) h)
+    apply e.injective
+    rw [map_mul, map_mul]
+    have hleft : e.toRingEquiv (localInclusion h AΛ) =
+        CStarMatrix.leftKroneckerEmbed (n := Config d (Γ \ Λ)) AΛ :=
+      reindex_localInclusion h AΛ
+    have hright : e.toRingEquiv
+        (localInclusion (Finset.sdiff_subset : Γ \ Λ ⊆ Γ) B) =
+        CStarMatrix.ofMatrix
+          (Matrix.rightKroneckerEmbed (m := Config d Λ) (CStarMatrix.ofMatrix.symm B)) :=
+      reindex_localInclusion_sdiff h B
+    rw [hleft, hright]
+    apply CStarMatrix.ext
+    intro p q
+    change ((CStarMatrix.ofMatrix.symm AΛ ⊗ₖ
+        (1 : Matrix (Config d (Γ \ Λ)) (Config d (Γ \ Λ)) ℂ)) *
+      ((1 : Matrix (Config d Λ) (Config d Λ) ℂ) ⊗ₖ
+        CStarMatrix.ofMatrix.symm B)) p q =
+      (((1 : Matrix (Config d Λ) (Config d Λ) ℂ) ⊗ₖ
+        CStarMatrix.ofMatrix.symm B) *
+      (CStarMatrix.ofMatrix.symm AΛ ⊗ₖ
+        (1 : Matrix (Config d (Γ \ Λ)) (Config d (Γ \ Λ)) ℂ))) p q
+    rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+    simp
+  · intro hcomm
+    let e := CStarMatrix.reindexₐ ℂ ℂ (Config.splitEquiv (d := d) h)
+    let C : Matrix (Config d Λ × Config d (Γ \ Λ))
+        (Config d Λ × Config d (Γ \ Λ)) ℂ := CStarMatrix.ofMatrix.symm (e A)
+    have hC (B : Matrix (Config d (Γ \ Λ)) (Config d (Γ \ Λ)) ℂ) :
+        ((1 : Matrix (Config d Λ) (Config d Λ) ℂ) ⊗ₖ B) * C =
+          C * ((1 : Matrix (Config d Λ) (Config d Λ) ℂ) ⊗ₖ B) := by
+      let B' : LocalAlgebra d (Γ \ Λ) := CStarMatrix.ofMatrix B
+      have hmapped := (hcomm B').map e
+      rw [reindex_localInclusion_sdiff] at hmapped
+      exact hmapped.eq.symm
+    obtain ⟨AΛ, hAΛ⟩ :=
+      Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top
+        (A := fun B : Matrix (Config d (Γ \ Λ)) (Config d (Γ \ Λ)) ℂ => B)
+        (C := C)
+        (by rw [Set.range_id', Submodule.span_univ])
+        hC
+    refine ⟨CStarMatrix.ofMatrix AΛ, ?_⟩
+    apply e.injective
+    change CStarMatrix.reindexₐ ℂ ℂ (Config.splitEquiv h)
+        (localInclusion h (CStarMatrix.ofMatrix AΛ)) = e A
+    rw [reindex_localInclusion]
+    exact congrArg CStarMatrix.ofMatrix hAΛ.symm
+
+end Finite
+
+section Algebraic
+
+variable {d : ℕ} [NeZero d] {x : AlgebraicLocalAlgebra d} {Λ : Finset ℤ}
+
+/-- An algebraic-local observable is supported in a finite region exactly when it commutes with
+every algebraic-local observable supported in a disjoint finite region.
+
+This is an algebraic-local consequence of the finite relative-commutant theorem. It is not the
+norm-completed support characterization in Schumacher--Werner, Theorem 6 and Corollary 7. -/
+theorem supportedIn_iff_commute_disjoint :
+    SupportedIn x Λ ↔
+      ∀ Γ, Disjoint Γ Λ →
+        ∀ y, SupportedIn y Γ → Commute x y := by
+  constructor
+  · intro hx Γ hΓΛ y hy
+    exact hx.commute_of_disjoint hy hΓΛ.symm
+  · intro hcomm
+    obtain ⟨Δ, AΔ, rfl⟩ := exists_supportedIn x
+    let A := localInclusion (d := d) (Finset.subset_union_right : Δ ⊆ Λ ∪ Δ) AΔ
+    have hA : localObservable d (Λ ∪ Δ) A = localObservable d Δ AΔ :=
+      localObservable_localInclusion d Finset.subset_union_right AΔ
+    rw [← hA] at hcomm ⊢
+    let hΛ : Λ ⊆ Λ ∪ Δ := Finset.subset_union_left
+    rw [show SupportedIn (localObservable d (Λ ∪ Δ) A) Λ ↔
+        A ∈ Set.range (localInclusion (d := d) hΛ) by
+      constructor
+      · rintro ⟨AΛ, hAΛ⟩
+        refine ⟨AΛ, (localObservable_injective d (Λ ∪ Δ)) ?_⟩
+        rw [localObservable_localInclusion]
+        exact hAΛ
+      · rintro ⟨AΛ, hAΛ⟩
+        refine ⟨AΛ, ?_⟩
+        rw [← hAΛ, localObservable_localInclusion]]
+    rw [mem_range_localInclusion_iff_commute_complement]
+    intro B
+    rw [commute_iff_eq]
+    apply localObservable_injective d (Λ ∪ Δ)
+    rw [map_mul, map_mul]
+    have hB := localObservable_localInclusion d
+      (Finset.sdiff_subset : (Λ ∪ Δ) \ Λ ⊆ Λ ∪ Δ) B
+    rw [hB]
+    exact (hcomm ((Λ ∪ Δ) \ Λ) Finset.sdiff_disjoint
+      (localObservable d ((Λ ∪ Δ) \ Λ) B) ⟨B, rfl⟩).eq
+
+end Algebraic
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7870,6 +7870,7 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
 \end{theorem}
 
 \begin{proof}\leanok
+  \uses{lem:amplified_center_scalar}
   Splitting configurations gives
   $\mathcal A_\Gamma\cong
   \mathcal A_\Lambda\otimes\mathcal A_{\Gamma\setminus\Lambda}$. Under this

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -7850,6 +7850,43 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
   Reversing the two factors gives the same scalar product.
 \end{proof}
 
+\begin{theorem}[Finite relative commutant]
+  \label{thm:qca_finite_relative_commutant}
+  \lean{SpinChain.mem_range_localInclusion_iff_commute_complement}
+  \leanok
+  \uses{def:qca_local_inclusion}
+  Let $\Lambda\subseteq\Gamma$ be finite regions and
+  $A\in\mathcal A_\Gamma$. Then $A$ acts trivially outside $\Lambda$ if
+  and only if it commutes with the full observable algebra on the complement:
+  \begin{align}
+    A\in\iota_{\Lambda,\Gamma}(\mathcal A_\Lambda)
+      &\iff
+      \forall B\in\mathcal A_{\Gamma\setminus\Lambda},\quad
+      A\iota_{\Gamma\setminus\Lambda,\Gamma}(B)
+        =\iota_{\Gamma\setminus\Lambda,\Gamma}(B)A.
+  \end{align}
+  This is a finite-dimensional tensor-factor identity. It is not a statement
+  of Schumacher--Werner or the QCA appendix of \cite{Cirac2017MPU}.
+\end{theorem}
+
+\begin{proof}\leanok
+  Splitting configurations gives
+  $\mathcal A_\Gamma\cong
+  \mathcal A_\Lambda\otimes\mathcal A_{\Gamma\setminus\Lambda}$. Under this
+  identification, the two inclusions are $C\mapsto C\otimes\mathbf 1$ and
+  $B\mapsto\mathbf 1\otimes B$. Write an arbitrary matrix in blocks indexed
+  by configurations on $\Lambda$. If it commutes with every
+  $\mathbf 1\otimes B$, each block commutes with the full matrix algebra on
+  $\Gamma\setminus\Lambda$ and is therefore scalar. Thus the matrix is
+  $C\otimes\mathbf 1$ for some $C\in\mathcal A_\Lambda$. The converse follows
+  from
+  \begin{align}
+    (C\otimes\mathbf 1)(\mathbf 1\otimes B)
+      &=C\otimes B
+       =(\mathbf 1\otimes B)(C\otimes\mathbf 1).
+  \end{align}
+\end{proof}
+
 \begin{definition}[Translation of a finite region]
   \label{def:qca_translate_region}
   \lean{SpinChain.translateRegion,SpinChain.mem_translateRegion,
@@ -8292,6 +8329,42 @@ coefficient of its length-$N$ periodic vector at the configuration $\sigma$.
         \iota_{\Lambda,\Lambda\cup\Gamma}(A)\bigr)
        =YX.
   \end{align}
+\end{proof}
+
+\begin{theorem}[Algebraic-local relative commutant]
+  \label{thm:qca_algebraic_local_relative_commutant}
+  \lean{SpinChain.supportedIn_iff_commute_disjoint}
+  \leanok
+  \uses{def:qca_supported_in}
+  Assume $d>0$. A local observable $X\in\mathcal A_{\mathrm{loc}}$ is
+  supported in a finite region $\Lambda$ if and only if it commutes with every
+  local observable having a finite support disjoint from $\Lambda$:
+  \begin{align}
+    X\in\iota_\Lambda(\mathcal A_\Lambda)
+      &\iff
+      \forall \Gamma,\ \forall Y,\quad
+      \bigl(\Gamma\cap\Lambda=\varnothing\ \land\
+        Y\in\iota_\Gamma(\mathcal A_\Gamma)\bigr)\Longrightarrow XY=YX.
+  \end{align}
+  This is an algebraic-local statement. It does not assert the corresponding
+  characterization in the norm completion and is not Schumacher--Werner
+  Theorem~6 or Corollary~7.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:qca_finite_relative_commutant,
+    thm:qca_disjoint_supported_local_commute,
+    thm:qca_local_observable_finite_support}
+  The forward implication is commutation of disjointly supported observables.
+  Conversely, choose a finite support $\Delta$ of $X$ and represent $X$ by
+  $A\in\mathcal A_{\Lambda\cup\Delta}$. The hypothesis says that $A$ commutes
+  with every observable on $(\Lambda\cup\Delta)\setminus\Lambda$. Since
+  $d>0$, the canonical map from $\mathcal A_{\Lambda\cup\Delta}$ into
+  $\mathcal A_{\mathrm{loc}}$ is injective, so this commutation already holds
+  in the finite-region algebra. The finite relative-commutant theorem gives
+  $A=\iota_{\Lambda,\Lambda\cup\Delta}(A_\Lambda)$ for some
+  $A_\Lambda\in\mathcal A_\Lambda$. Hence
+  $X=\iota_\Lambda(A_\Lambda)$.
 \end{proof}
 
 \begin{definition}[Algebraic-local translation homomorphism]


### PR DESCRIPTION
## What changed

- characterize the range of a finite-region local inclusion as the commutant of the complementary matrix factor
- lift the characterization to algebraic-local observables supported in a finite region
- add Chapter 28 coverage that keeps this infrastructure distinct from the norm-completed theorem and Schumacher--Werner

## Validation

- targeted `TNLean.QCA.RelativeCommutant` and `TNLean.QCA` builds green from exact warmed main
- explicit elaboration checks for `d = 1`, empty retained region, and empty complement
- import aggregators current for 1427 production modules
- proof-integrity, style, prose, and whitespace checks green
- blueprint source synchronization and compiled declaration resolution green
- two LuaLaTeX passes with zero undefined cross-references

Closes #6528.