### PR TITLE
feat(QCA): derive inverse finite propagation

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.QCA.AlgebraicTranslation
 import TNLean.QCA.DisjointSupport
 import TNLean.QCA.FinitePropagation
+import TNLean.QCA.InversePropagation
 import TNLean.QCA.IsQCA
 import TNLean.QCA.LocalAlgebra
 import TNLean.QCA.LocalLimit

--- a/TNLean/QCA/InversePropagation.lean
+++ b/TNLean/QCA/InversePropagation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.QCA.FinitePropagation
 import TNLean.QCA.QuasiLocalCommutant
 import TNLean.QCA.TranslationCovariance
 
@@ -50,7 +51,8 @@ lemma disjoint_regionSumset_of_disjoint_regionSumset_neg
   rw [mem_regionSumset]
   refine ⟨z, hzΛ, -n, ?_, ?_⟩
   · exact Finset.neg_mem_neg hn
-  · omega
+  · rw [← hgn]
+    simp
 
 variable {d : ℕ} [NeZero d]
   {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}

--- a/TNLean/QCA/InversePropagation.lean
+++ b/TNLean/QCA/InversePropagation.lean
@@ -20,8 +20,6 @@ characterization of finite support by commutation with all observables outside t
 
 ## Main results
 
-* `SpinChain.disjoint_regionSumset_of_disjoint_regionSumset_neg` — reflected-neighborhood region
-  arithmetic.
 * `SpinChain.PropagatesWithin.symm` — a forward propagation bound gives the reflected bound for
   the inverse.
 * `SpinChain.HasFinitePropagation.symm` — finite propagation is preserved by inversion.
@@ -36,23 +34,6 @@ characterization of finite support by commutation with all observables outside t
 open scoped Pointwise
 
 namespace SpinChain
-
-/-- If \(\Gamma\) is disjoint from \(\Lambda+(-\mathcal N)\), then
-\(\Gamma+\mathcal N\) is disjoint from \(\Lambda\).
-
-This is elementary finite-region arithmetic underlying the reflected inverse-propagation bound. -/
-lemma disjoint_regionSumset_of_disjoint_regionSumset_neg
-    {Γ Λ 𝓝 : Finset ℤ} (h : Disjoint Γ (regionSumset Λ (-𝓝))) :
-    Disjoint (regionSumset Γ 𝓝) Λ := by
-  rw [Finset.disjoint_left] at h ⊢
-  intro z hz hzΛ
-  obtain ⟨g, hg, n, hn, hgn⟩ := (mem_regionSumset z Γ 𝓝).mp hz
-  apply h hg
-  rw [mem_regionSumset]
-  refine ⟨z, hzΛ, -n, ?_, ?_⟩
-  · exact Finset.neg_mem_neg hn
-  · rw [← hgn]
-    simp
 
 variable {d : ℕ} [NeZero d]
   {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
@@ -70,7 +51,7 @@ theorem symm (hω : PropagatesWithin ω 𝓝) : PropagatesWithin ω.symm (-𝓝)
   rw [quasiLocalSupportedIn_iff_commute_disjoint]
   intro Γ hΓ y hy
   have hωy := hω Γ y hy
-  have hregions := disjoint_regionSumset_of_disjoint_regionSumset_neg hΓ
+  have hregions := disjoint_regionSumset_neg_iff.mp hΓ
   have hcomm : Commute x (ω y) :=
     (quasiLocalSupportedIn_iff_commute_disjoint x Λ).mp hx
       (regionSumset Γ 𝓝) hregions (ω y) hωy

--- a/TNLean/QCA/InversePropagation.lean
+++ b/TNLean/QCA/InversePropagation.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.QuasiLocalCommutant
+import TNLean.QCA.TranslationCovariance
+
+/-!
+# Inverse propagation of quasi-local automorphisms
+
+Finite forward propagation of a quasi-local star-automorphism implies finite forward propagation
+of its inverse. At the neighborhood level, a bound by \(\mathcal N\) for the automorphism gives a
+bound by the reflected neighborhood \(-\mathcal N\) for its inverse.
+
+The QCA definitions in both cited sources are forward-only. Schumacher--Werner derive inverse
+locality through Lemma 5, Theorem 6, and Corollary 7. Here the proof instead uses the exact
+characterization of finite support by commutation with all observables outside the region.
+
+## Main results
+
+* `SpinChain.disjoint_regionSumset_of_disjoint_regionSumset_neg` — reflected-neighborhood region
+  arithmetic.
+* `SpinChain.PropagatesWithin.symm` — a forward propagation bound gives the reflected bound for
+  the inverse.
+* `SpinChain.HasFinitePropagation.symm` — finite propagation is preserved by inversion.
+* `SpinChain.TranslationCovariant.symm` — translation covariance is preserved by inversion.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, line 2298.
+* Schumacher--Werner, quant-ph/0405174, Lemma 5, Theorem 6, and Corollary 7.
+-/
+
+open scoped Pointwise
+
+namespace SpinChain
+
+/-- If \(\Gamma\) is disjoint from \(\Lambda+(-\mathcal N)\), then
+\(\Gamma+\mathcal N\) is disjoint from \(\Lambda\).
+
+This is elementary finite-region arithmetic underlying the reflected inverse-propagation bound. -/
+lemma disjoint_regionSumset_of_disjoint_regionSumset_neg
+    {Γ Λ 𝓝 : Finset ℤ} (h : Disjoint Γ (regionSumset Λ (-𝓝))) :
+    Disjoint (regionSumset Γ 𝓝) Λ := by
+  rw [Finset.disjoint_left] at h ⊢
+  intro z hz hzΛ
+  obtain ⟨g, hg, n, hn, hgn⟩ := (mem_regionSumset z Γ 𝓝).mp hz
+  apply h hg
+  rw [mem_regionSumset]
+  refine ⟨z, hzΛ, -n, ?_, ?_⟩
+  · exact Finset.neg_mem_neg hn
+  · omega
+
+variable {d : ℕ} [NeZero d]
+  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
+
+namespace PropagatesWithin
+
+/-- If an automorphism propagates within \(\mathcal N\), then its inverse propagates within the
+reflected neighborhood \(-\mathcal N\).
+
+The source definitions are forward-only. Schumacher--Werner derive inverse locality from their
+Lemma 5, Theorem 6, and Corollary 7. This proof uses the exact outside-commutant characterization
+of finite support. -/
+theorem symm (hω : PropagatesWithin ω 𝓝) : PropagatesWithin ω.symm (-𝓝) := by
+  intro Λ x hx
+  rw [quasiLocalSupportedIn_iff_commute_disjoint]
+  intro Γ hΓ y hy
+  have hωy := hω Γ y hy
+  have hregions := disjoint_regionSumset_of_disjoint_regionSumset_neg hΓ
+  have hcomm : Commute x (ω y) :=
+    (quasiLocalSupportedIn_iff_commute_disjoint x Λ).mp hx
+      (regionSumset Γ 𝓝) hregions (ω y) hωy
+  simpa only [StarAlgEquiv.symm_apply_apply] using hcomm.map ω.symm
+
+end PropagatesWithin
+
+namespace HasFinitePropagation
+
+/-- Finite forward propagation is preserved by inversion.
+
+This is derived from the forward-only locality condition. Source route: Schumacher--Werner,
+Lemma 5, Theorem 6, and Corollary 7. -/
+theorem symm (hω : HasFinitePropagation ω) : HasFinitePropagation ω.symm := by
+  obtain ⟨𝓝, h𝓝⟩ := hω
+  exact ⟨-𝓝, h𝓝.symm⟩
+
+end HasFinitePropagation
+
+namespace TranslationCovariant
+
+/-- The inverse of a translation-covariant automorphism is translation covariant.
+
+Source context: arXiv:1703.09188, Appendix, line 2298. -/
+theorem symm (hω : TranslationCovariant ω) : TranslationCovariant ω.symm := by
+  intro a
+  rw [← StarAlgEquiv.aut_inv]
+  exact (hω a).inv_left
+
+end TranslationCovariant
+
+end SpinChain

--- a/TNLean/QCA/IsQCA.lean
+++ b/TNLean/QCA/IsQCA.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.QCA.FinitePropagation
 import TNLean.QCA.InversePropagation
+import TNLean.QCA.TranslationCovariance
 
 /-!
 # One-dimensional quantum cellular automata

--- a/TNLean/QCA/IsQCA.lean
+++ b/TNLean/QCA/IsQCA.lean
@@ -3,16 +3,15 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.QCA.FinitePropagation
-import TNLean.QCA.TranslationCovariance
+import TNLean.QCA.InversePropagation
 
 /-!
 # One-dimensional quantum cellular automata
 
 A one-dimensional quantum cellular automaton (QCA) is a translation-covariant star-automorphism
 of the quasi-local observable algebra with finite forward propagation. This file packages those two
-conditions and records its basic interface, the identity example, and closure under forward
-composition.
+conditions and records its basic interface, the identity example, and closure under composition
+and inversion.
 
 ## Main definitions
 
@@ -22,6 +21,7 @@ composition.
 
 * `SpinChain.isQCA_iff` — the exact unfolding of the QCA predicate.
 * `SpinChain.IsQCA.trans` — forward composition of QCAs is a QCA.
+* `SpinChain.IsQCA.symm` — the inverse of a QCA is a QCA.
 * `SpinChain.isQCA_refl` — the identity star-automorphism is a QCA.
 
 ## References
@@ -79,6 +79,13 @@ separately there. -/
 theorem trans (hω : IsQCA ω) (hη : IsQCA η) : IsQCA (ω.trans η) :=
   ⟨TranslationCovariant.trans hω.translationCovariant hη.translationCovariant,
     HasFinitePropagation.trans hω.hasFinitePropagation hη.hasFinitePropagation⟩
+
+/-- The inverse of a quantum cellular automaton is a quantum cellular automaton.
+
+The QCA definition is forward-only. Inverse locality is a derived consequence, corresponding to
+Schumacher--Werner, Lemma 5, Theorem 6, and Corollary 7. -/
+theorem symm (hω : IsQCA ω) : IsQCA ω.symm :=
+  ⟨hω.translationCovariant.symm, hω.hasFinitePropagation.symm⟩
 
 end IsQCA
 

--- a/TNLean/QCA/RegionSumset.lean
+++ b/TNLean/QCA/RegionSumset.lean
@@ -22,6 +22,7 @@ observable algebras, or quantum cellular automata.
 ## Main results
 
 * `SpinChain.mem_regionSumset` — membership in a finite-region sumset.
+* `SpinChain.disjoint_regionSumset_neg_iff` — reflected sumsets exchange disjointness.
 * `SpinChain.regionSumset_singleton_right` — addition by a singleton is `translateRegion`.
 * `SpinChain.regionSumset_mono` — the sumset is monotone in both regions.
 * `SpinChain.regionSumset_assoc` — finite-region sumsets are associative.
@@ -52,6 +53,31 @@ Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
 lemma mem_regionSumset (i : ℤ) (Λ 𝓝 : Finset ℤ) :
     i ∈ regionSumset Λ 𝓝 ↔ ∃ j ∈ Λ, ∃ a ∈ 𝓝, j + a = i :=
   Finset.mem_add
+
+/-- A region \(\Gamma\) is disjoint from \(\Lambda+(-\mathcal N)\) if and only if
+\(\Gamma+\mathcal N\) is disjoint from \(\Lambda\).
+
+This is elementary finite-region arithmetic for reflected neighborhoods. -/
+lemma disjoint_regionSumset_neg_iff {Γ Λ 𝓝 : Finset ℤ} :
+    Disjoint Γ (regionSumset Λ (-𝓝)) ↔ Disjoint (regionSumset Γ 𝓝) Λ := by
+  constructor
+  · intro h
+    rw [Finset.disjoint_left] at h ⊢
+    intro z hz hzΛ
+    obtain ⟨g, hg, n, hn, hgn⟩ := (mem_regionSumset z Γ 𝓝).mp hz
+    apply h hg
+    rw [mem_regionSumset]
+    refine ⟨z, hzΛ, -n, Finset.neg_mem_neg hn, ?_⟩
+    rw [← hgn]
+    simp
+  · intro h
+    rw [Finset.disjoint_left] at h ⊢
+    intro g hg hgsum
+    obtain ⟨z, hz, n, hn, hzng⟩ := (mem_regionSumset g Λ (-𝓝)).mp hgsum
+    obtain ⟨m, hm, rfl⟩ := Finset.mem_neg.mp hn
+    apply h ((mem_regionSumset z Γ 𝓝).mpr ⟨g, hg, m, hm, ?_⟩) hz
+    rw [← hzng]
+    simp
 
 /-- Adding the singleton displacement region \(\{a\}\) agrees with translation by \(a\).
 

--- a/TNLean/QCA/RegionSumset.lean
+++ b/TNLean/QCA/RegionSumset.lean
@@ -57,7 +57,8 @@ lemma mem_regionSumset (i : ℤ) (Λ 𝓝 : Finset ℤ) :
 /-- A region \(\Gamma\) is disjoint from \(\Lambda+(-\mathcal N)\) if and only if
 \(\Gamma+\mathcal N\) is disjoint from \(\Lambda\).
 
-This is elementary finite-region arithmetic for reflected neighborhoods. -/
+This is elementary finite-region arithmetic for reflected neighborhoods.
+Source: arXiv:1703.09188, Appendix, lines 2292--2298. -/
 lemma disjoint_regionSumset_neg_iff {Γ Λ 𝓝 : Finset ℤ} :
     Disjoint Γ (regionSumset Λ (-𝓝)) ↔ Disjoint (regionSumset Γ 𝓝) Λ := by
   constructor

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9341,25 +9341,25 @@ $\omega^{-1}$.
 \end{proof}
 
 \begin{lemma}[Disjointness for reflected neighborhoods]
-  \label{lem:qca_reflected_region_disjoint}
-  \lean{SpinChain.disjoint_regionSumset_of_disjoint_regionSumset_neg}
+  \label{lem:qca_disjoint_region_sumset_neg_iff}
+  \lean{SpinChain.disjoint_regionSumset_neg_iff}
   \leanok
   \uses{def:qca_region_sumset}
-  Let $\Gamma,\Lambda,\mathcal N\subset\mathbb Z$ be finite.  If
+  Let $\Gamma,\Lambda,\mathcal N\subset\mathbb Z$ be finite.  Then
   \begin{align}
-    \Gamma\cap(\Lambda+(-\mathcal N))&=\varnothing,
-  \end{align}
-  then
-  \begin{align}
-    (\Gamma+\mathcal N)\cap\Lambda&=\varnothing.
+    \Gamma\cap(\Lambda+(-\mathcal N))=\varnothing
+      \quad\Longleftrightarrow\quad
+    (\Gamma+\mathcal N)\cap\Lambda=\varnothing.
   \end{align}
 \end{lemma}
 
 \begin{proof}\leanok
   If $g+n=\lambda$ for $g\in\Gamma$, $n\in\mathcal N$, and
   $\lambda\in\Lambda$, then
-  $g=\lambda+(-n)\in\Lambda+(-\mathcal N)$, contradicting the assumed
-  disjointness.
+  $g=\lambda+(-n)\in\Lambda+(-\mathcal N)$, proving the forward implication.
+  Conversely, if $g\in\Gamma$ and $g=\lambda+(-n)$ with
+  $\lambda\in\Lambda$ and $n\in\mathcal N$, then
+  $\lambda=g+n\in\Gamma+\mathcal N$.
 \end{proof}
 
 \begin{theorem}[Inverse propagation and inverse covariance]
@@ -9378,13 +9378,14 @@ $\omega^{-1}$.
   $\omega^{-1}$.
 
   This is a consequence of the forward-only locality definition, not part of
-  that definition.  Schumacher--Werner obtain inverse locality through their
-  Lemma~5, Theorem~6, and Corollary~7.  The proof here uses exact outside
-  commutants instead.
+  that definition.  Schumacher--Werner, quant-ph/0405174, derive inverse
+  locality through Lemma~5, Theorem~6, and Corollary~7 using the generalized
+  Margolus structure.  The proof here instead uses TNLean's exact
+  outside-commutant infrastructure.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{lem:qca_reflected_region_disjoint,
+  \uses{lem:qca_disjoint_region_sumset_neg_iff,
     thm:qca_quasi_local_supported_iff_commute_disjoint}
   Let $x\in\mathcal A_\Lambda$ and let
   $y\in\mathcal A_\Gamma$, where

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9340,6 +9340,53 @@ $\omega^{-1}$.
   interval.
 \end{proof}
 
+\begin{theorem}[Inverse propagation and inverse covariance]
+  \label{thm:qca_inverse_propagation}
+  \lean{SpinChain.disjoint_regionSumset_of_disjoint_regionSumset_neg,
+    SpinChain.PropagatesWithin.symm,
+    SpinChain.HasFinitePropagation.symm,
+    SpinChain.TranslationCovariant.symm}
+  \leanok
+  \uses{def:qca_region_sumset,def:qca_propagates_within,
+    def:qca_finite_propagation,def:qca_translation_covariant}
+  Let $d>0$, let $\omega$ be a star-algebra automorphism of $\mathcal A$, and
+  let $\mathcal N\subset\mathbb Z$ be finite.  If $\omega$ propagates within
+  $\mathcal N$, then $\omega^{-1}$ propagates within $-\mathcal N$.  Therefore
+  finite forward propagation of $\omega$ implies finite forward propagation of
+  $\omega^{-1}$.  Moreover, if $\omega$ is translation covariant, then so is
+  $\omega^{-1}$.
+
+  This is a consequence of the forward-only locality definition, not part of
+  that definition.  Schumacher--Werner obtain inverse locality through their
+  Lemma~5, Theorem~6, and Corollary~7.  The proof here uses exact outside
+  commutants instead.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:qca_quasi_local_supported_iff_commute_disjoint}
+  First observe that
+  \begin{align}
+    \Gamma\cap(\Lambda+(-\mathcal N))=\varnothing
+      &\implies (\Gamma+\mathcal N)\cap\Lambda=\varnothing.
+  \end{align}
+  Indeed, $g+n=\lambda$ would imply
+  $g=\lambda+(-n)\in\Lambda+(-\mathcal N)$.
+
+  Let $x\in\mathcal A_\Lambda$ and let
+  $y\in\mathcal A_\Gamma$, where
+  $\Gamma\cap(\Lambda+(-\mathcal N))=\varnothing$.  Forward locality gives
+  $\omega(y)\in\mathcal A_{\Gamma+\mathcal N}$.  The regions
+  $\Gamma+\mathcal N$ and $\Lambda$ are disjoint, so $x$ commutes with
+  $\omega(y)$.  Applying $\omega^{-1}$ shows that $\omega^{-1}(x)$ commutes
+  with $y$.  The exact outside-commutant characterization now gives
+  \begin{align}
+    \omega^{-1}(x)&\in\mathcal A_{\Lambda+(-\mathcal N)}.
+  \end{align}
+  Choosing the reflected finite neighborhood proves the existential statement.
+  Finally, an inverse commutes with every translation whenever the original
+  automorphism does.
+\end{proof}
+
 \begin{definition}[One-dimensional quantum cellular automaton]
   \label{def:qca}
   \lean{SpinChain.IsQCA}
@@ -9418,4 +9465,20 @@ $\omega^{-1}$.
   propagation neighborhoods for $\omega$ and $\eta$, respectively, then
   $\mathcal N+\mathcal M$ is a forward propagation neighborhood for
   $\eta\circ\omega$.  Hence the composite is a quantum cellular automaton.
+\end{proof}
+
+\begin{theorem}[Inverse quantum cellular automaton]
+  \label{thm:qca_inverse}
+  \lean{SpinChain.IsQCA.symm}
+  \leanok
+  \uses{def:qca}
+  Let $d>0$.  If $\omega$ is a quantum cellular automaton on $\mathcal A$, then
+  $\omega^{-1}$ is also a quantum cellular automaton.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{thm:qca_iff_mk_projections,thm:qca_inverse_propagation}
+  Translation covariance and finite forward propagation are both preserved by
+  inversion.  These are the two defining properties of a quantum cellular
+  automaton.
 \end{proof}

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9340,14 +9340,35 @@ $\omega^{-1}$.
   interval.
 \end{proof}
 
+\begin{lemma}[Disjointness for reflected neighborhoods]
+  \label{lem:qca_reflected_region_disjoint}
+  \lean{SpinChain.disjoint_regionSumset_of_disjoint_regionSumset_neg}
+  \leanok
+  \uses{def:qca_region_sumset}
+  Let $\Gamma,\Lambda,\mathcal N\subset\mathbb Z$ be finite.  If
+  \begin{align}
+    \Gamma\cap(\Lambda+(-\mathcal N))&=\varnothing,
+  \end{align}
+  then
+  \begin{align}
+    (\Gamma+\mathcal N)\cap\Lambda&=\varnothing.
+  \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+  If $g+n=\lambda$ for $g\in\Gamma$, $n\in\mathcal N$, and
+  $\lambda\in\Lambda$, then
+  $g=\lambda+(-n)\in\Lambda+(-\mathcal N)$, contradicting the assumed
+  disjointness.
+\end{proof}
+
 \begin{theorem}[Inverse propagation and inverse covariance]
   \label{thm:qca_inverse_propagation}
-  \lean{SpinChain.disjoint_regionSumset_of_disjoint_regionSumset_neg,
-    SpinChain.PropagatesWithin.symm,
+  \lean{SpinChain.PropagatesWithin.symm,
     SpinChain.HasFinitePropagation.symm,
     SpinChain.TranslationCovariant.symm}
   \leanok
-  \uses{def:qca_region_sumset,def:qca_propagates_within,
+  \uses{def:qca_propagates_within,
     def:qca_finite_propagation,def:qca_translation_covariant}
   Let $d>0$, let $\omega$ be a star-algebra automorphism of $\mathcal A$, and
   let $\mathcal N\subset\mathbb Z$ be finite.  If $\omega$ propagates within
@@ -9363,15 +9384,8 @@ $\omega^{-1}$.
 \end{theorem}
 
 \begin{proof}\leanok
-  \uses{thm:qca_quasi_local_supported_iff_commute_disjoint}
-  First observe that
-  \begin{align}
-    \Gamma\cap(\Lambda+(-\mathcal N))=\varnothing
-      &\implies (\Gamma+\mathcal N)\cap\Lambda=\varnothing.
-  \end{align}
-  Indeed, $g+n=\lambda$ would imply
-  $g=\lambda+(-n)\in\Lambda+(-\mathcal N)$.
-
+  \uses{lem:qca_reflected_region_disjoint,
+    thm:qca_quasi_local_supported_iff_commute_disjoint}
   Let $x\in\mathcal A_\Lambda$ and let
   $y\in\mathcal A_\Gamma$, where
   $\Gamma\cap(\Lambda+(-\mathcal N))=\varnothing$.  Forward locality gives

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9398,8 +9398,13 @@ $\omega^{-1}$.
     \omega^{-1}(x)&\in\mathcal A_{\Lambda+(-\mathcal N)}.
   \end{align}
   Choosing the reflected finite neighborhood proves the existential statement.
-  Finally, an inverse commutes with every translation whenever the original
-  automorphism does.
+  For each lattice translation $\tau_a$, multiplying the covariance identity
+  on the left and right by $\omega^{-1}$ gives
+  \begin{align}
+    \omega\circ\tau_a=\tau_a\circ\omega
+      &\implies
+    \omega^{-1}\circ\tau_a=\tau_a\circ\omega^{-1}.
+  \end{align}
 \end{proof}
 
 \begin{definition}[One-dimensional quantum cellular automaton]


### PR DESCRIPTION
## What changed

- prove the reflected-region disjointness lemma needed for inverse locality
- derive `PropagatesWithin ω.symm (-𝓝)` from forward propagation of `ω` using exact outside commutants
- package inverse finite propagation, inverse translation covariance, and `IsQCA.symm`
- document the result in Chapter 28 as a derived theorem, keeping the MPU and Schumacher--Werner definitions forward-only

## Validation

- targeted QCA and full Lean builds green: 10143 jobs from exact warmed main
- generated import aggregators current for 1431 production modules
- proof-integrity and style checks green
- blueprint synchronization: 7926/7926; declaration resolution green
- two LuaLaTeX passes with zero undefined cross-references

Closes #6516.