### PR TITLE
feat(QCA): equate forward and two-sided finite propagation

### DIFF
--- a/TNLean/QCA.lean
+++ b/TNLean/QCA.lean
@@ -23,3 +23,4 @@ import TNLean.QCA.RegionSumset
 import TNLean.QCA.RelativeCommutant
 import TNLean.QCA.Translation
 import TNLean.QCA.TranslationCovariance
+import TNLean.QCA.TwoSidedPropagation

--- a/TNLean/QCA/TwoSidedPropagation.lean
+++ b/TNLean/QCA/TwoSidedPropagation.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.QCA.InversePropagation
+
+/-!
+# Two-sided finite propagation of quasi-local automorphisms
+
+For a quasi-local star-automorphism, finite forward propagation already implies finite propagation
+of the inverse. Consequently, the forward-only finite-propagation predicate is equivalent to the
+two-sided convenience predicate. A forward neighborhood and its reflection can be enlarged to one
+common neighborhood, and then to a symmetric integer interval.
+
+The QCA definitions in the cited sources remain forward-only. The results here are derived
+convenience statements using inverse propagation.
+
+## Main results
+
+* `SpinChain.PropagatesWithinTwoSided.of_forward` — a forward bound gives a common enlarged
+  two-sided bound.
+* `SpinChain.hasFinitePropagation_iff_hasTwoSidedFinitePropagation` — forward and two-sided finite
+  propagation are equivalent for star-automorphisms.
+* `SpinChain.HasFinitePropagation.exists_common_twoSided_neighborhood` — finite forward
+  propagation admits a common neighborhood for the automorphism and its inverse.
+* `SpinChain.HasFinitePropagation.exists_twoSided_symmetric_Icc` — the common neighborhood can be
+  chosen to be a symmetric integer interval.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1703.09188, Appendix, line 2298.
+* Schumacher--Werner, quant-ph/0405174, Lemma 5, Theorem 6, and Corollary 7.
+-/
+
+open scoped Pointwise
+
+namespace SpinChain
+
+variable {d : ℕ} [NeZero d]
+  {ω : QuasiLocalAlgebra d ≃⋆ₐ[ℂ] QuasiLocalAlgebra d} {𝓝 : Finset ℤ}
+
+namespace PropagatesWithinTwoSided
+
+/-- A forward propagation bound by \(\mathcal N\) gives a common two-sided bound after enlarging
+to \(\mathcal N\cup(-\mathcal N)\).
+
+The inverse bound is first derived on the reflected neighborhood. This avoids asserting a generally
+unavailable common bound on the original, possibly nonsymmetric, neighborhood. -/
+theorem of_forward (hω : PropagatesWithin ω 𝓝) :
+    PropagatesWithinTwoSided ω (𝓝 ∪ (-𝓝)) :=
+  of_reflected hω hω.symm
+
+end PropagatesWithinTwoSided
+
+/-- Finite forward propagation is equivalent to two-sided finite propagation for quasi-local
+star-automorphisms.
+
+The forward condition is the locality condition in arXiv:1703.09188, Appendix, line 2298, and
+Schumacher--Werner, Definition 1. The reverse implication uses the first projection; the forward
+implication uses derived inverse locality. -/
+theorem hasFinitePropagation_iff_hasTwoSidedFinitePropagation :
+    HasFinitePropagation ω ↔ HasTwoSidedFinitePropagation ω :=
+  ⟨fun hω ↦ ⟨hω, hω.symm⟩, And.left⟩
+
+namespace HasFinitePropagation
+
+/-- Finite forward propagation admits one common finite neighborhood for an automorphism and its
+inverse.
+
+This combines derived inverse finite propagation with the common-neighborhood enlargement for
+separately supplied bounds. -/
+theorem exists_common_twoSided_neighborhood (hω : HasFinitePropagation ω) :
+    ∃ 𝓝 : Finset ℤ, PropagatesWithinTwoSided ω 𝓝 :=
+  (hasFinitePropagation_iff_hasTwoSidedFinitePropagation.mp hω).exists_common_neighborhood
+
+/-- Finite forward propagation admits a common symmetric-interval neighborhood for an
+automorphism and its inverse. -/
+theorem exists_twoSided_symmetric_Icc (hω : HasFinitePropagation ω) :
+    ∃ R : ℕ, PropagatesWithinTwoSided ω (Finset.Icc (-(R : ℤ)) (R : ℤ)) :=
+  (hasFinitePropagation_iff_hasTwoSidedFinitePropagation.mp hω).exists_symmetric_Icc
+
+end HasFinitePropagation
+
+end SpinChain

--- a/blueprint/src/chapter/ch28_mpu.tex
+++ b/blueprint/src/chapter/ch28_mpu.tex
@@ -9407,6 +9407,50 @@ $\omega^{-1}$.
   \end{align}
 \end{proof}
 
+\begin{theorem}[Forward and two-sided finite propagation]
+  \label{thm:qca_forward_iff_two_sided_propagation}
+  \lean{SpinChain.PropagatesWithinTwoSided.of_forward,
+    SpinChain.hasFinitePropagation_iff_hasTwoSidedFinitePropagation,
+    SpinChain.HasFinitePropagation.exists_common_twoSided_neighborhood,
+    SpinChain.HasFinitePropagation.exists_twoSided_symmetric_Icc}
+  \leanok
+  \uses{def:qca_finite_propagation,
+    def:qca_two_sided_finite_propagation}
+  Let $d>0$ and let $\omega$ be a star-algebra automorphism of $\mathcal A$.
+  Then
+  \begin{align}
+    \omega\text{ has finite forward propagation}
+      &\iff
+    \omega\text{ has two-sided finite propagation}.
+  \end{align}
+  More precisely, a forward bound by a finite set $\mathcal N$ gives an inverse
+  bound by $-\mathcal N$, so both maps propagate within the enlarged common
+  neighborhood
+  \begin{align}
+    \mathcal N\cup(-\mathcal N).
+  \end{align}
+  This statement remains valid when $\mathcal N=\varnothing$.  For an arbitrary
+  finite forward-propagation witness, there is therefore a common finite
+  neighborhood for $\omega$ and $\omega^{-1}$, and it may be enlarged to a
+  symmetric interval $[-R,R]\cap\mathbb Z$.
+
+  This equivalence is a derived convenience theorem.  It does not change the
+  forward-only locality definition at line~2298 of \cite{Cirac2017MPU} or in
+  Schumacher--Werner, Definition~1.
+\end{theorem}
+
+\begin{proof}\leanok
+  \uses{lem:qca_two_sided_common_neighborhood,
+    thm:qca_inverse_propagation}
+  Derived inverse locality sends a forward bound by $\mathcal N$ to an inverse
+  bound by $-\mathcal N$.  Enlarging both bounds to
+  $\mathcal N\cup(-\mathcal N)$ gives the fixed-neighborhood statement.  At the
+  existential level, forward finite propagation gives finite propagation of
+  the inverse, hence the two-sided predicate.  The converse is its first
+  conjunct.  Finally, apply the common-neighborhood and symmetric-interval
+  enlargement results to the resulting two-sided pair.
+\end{proof}
+
 \begin{definition}[One-dimensional quantum cellular automaton]
   \label{def:qca}
   \lean{SpinChain.IsQCA}


### PR DESCRIPTION
## What changed

- enlarge a forward neighborhood and its reflection to a common two-sided neighborhood
- prove forward finite propagation is equivalent to the existing two-sided predicate for quasi-local star automorphisms
- package common-neighborhood and symmetric-interval witnesses by reusing the established two-sided APIs
- document the equivalence as derived convenience API while leaving `SpinChain.IsQCA` forward-only

## Validation

- targeted `TNLean.QCA` build green before the dependency rebase: 3067 jobs
- explicit `d = 1` and empty-neighborhood elaboration checks green
- independent mathematical/API review approved with no findings
- generated import aggregators current for 1432 production modules
- blueprint synchronization: 7930/7930; strict declaration check green
- two LuaLaTeX passes with no non-citation undefined cross-references
- style, proof-integrity, and whitespace checks green

The final rebase onto merged #6536 was patch-equivalent; clean-environment CI provides the post-rebase Lean gate because the shared local package checkout is temporarily owned by a concurrent Mathlib-upgrade build.

Closes #6517.